### PR TITLE
refactored relay benchmark for better data tabulation and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ htmlcov/
 Thumbs.db
 .ruff_cache/
 uv.lock
+results/

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,16 @@
+# 📊 Benchmarks
+
+## 💬 Benchmark Relay
+
+This benchmark measures the latency and throughput of the various backends for relay. You can use the sample command below to benchmark all the backends. If you want to benchmark a specific backend, you can use the `--backend-type` argument (check `python benchmark_relay.py --help` for more details).
+
+```bash
+python benchmark_relay.py \
+    --backend-type all \
+    --start-size 16 \
+    --end-size 1024 \
+    --factor 2 \
+    --output-dir ./results
+```
+
+You can check the benchmark results in the `results` directory.

--- a/benchmarks/benchmark_relay.py
+++ b/benchmarks/benchmark_relay.py
@@ -5,10 +5,8 @@ Relay benchmark helper.
 Usage:
 
 ```bash
-python benchmarks/benchmark_relay.py --type nixl --size 10
-python benchmarks/benchmark_relay.py --type shm --size 10
-python benchmarks/benchmark_relay.py --type nccl --size 10
-python benchmarks/benchmark_relay.py --type mooncake --size 10
+# benchmark nccl
+python benchmark_relay.py --backend-type nccl --start-size 16 --end-size 1024 --factor 2 --warmup-iters 10 --num-iters 20 --pool-credits 4 --verbose --output-dir ./results
 ```
 """
 
@@ -23,13 +21,52 @@ import time
 import traceback
 
 import numpy as np
+import pandas as pd
 import torch
+from tabulate import tabulate
+from tqdm import tqdm
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Relay Benchmark")
+    parser.add_argument(
+        "-b",
+        "--backend-type",
+        type=str,
+        default="all",
+        choices=["nixl", "shm", "nccl", "mooncake", "all"],
+        help="The type of communication backend for benchmarking",
+    )
+    parser.add_argument(
+        "-s", "--start-size", type=int, default=16, help="Starting data size in MB"
+    )
+    parser.add_argument(
+        "-e", "--end-size", type=int, default=1024, help="Ending data size in MB"
+    )
+    parser.add_argument(
+        "-f", "--factor", type=int, default=2, help="Factor to multiply the data size"
+    )
+    parser.add_argument(
+        "-w", "--warmup-iters", type=int, default=10, help="Warm-up iterations"
+    )
+    parser.add_argument(
+        "-i", "--num-iters", type=int, default=20, help="Measurement iterations"
+    )
+    parser.add_argument(
+        "-c", "--pool-credits", type=int, default=4, help="Number of concurrent slots"
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        type=str,
+        default="./results",
+        help="Output directory for benchmarking results",
+    )
+    return parser.parse_args()
+
 
 # ================= Configuration =================
-POOL_CREDITS = 4  # Number of concurrent slots
-NUM_ITERS = 20  # Measurement iterations
-WARMUP_ITERS = 10  # Warm-up iterations
-
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
 
@@ -40,6 +77,7 @@ def find_free_port() -> str:
 
 
 def sender_process(
+    args,
     meta_queue,
     barrier,
     relay_type: str,
@@ -57,7 +95,7 @@ def sender_process(
         relay_kwargs = {
             "engine_id": "sender_engine",
             "slot_size_mb": data_size_mb,
-            "credits": POOL_CREDITS,
+            "credits": args.pool_credits,
             "device": (
                 "cuda:0" if relay_type.lower() in ["nccl", "mooncake"] else DEVICE
             ),
@@ -93,8 +131,8 @@ def sender_process(
         )
 
         async def _sender_loop():
-            print(f"[Sender] Warm-up {WARMUP_ITERS} iters...")
-            for i in range(WARMUP_ITERS):
+            print(f"[Sender] Warm-up {args.warmup_iters} iters...")
+            for i in range(args.warmup_iters):
                 src_tensor = torch.zeros(
                     num_elements, dtype=dtype, device=relay_kwargs["device"]
                 )
@@ -107,8 +145,8 @@ def sender_process(
                 meta_queue.put(op.metadata)
                 await op.wait_for_completion()
 
-            print(f"[Sender] Measuring {NUM_ITERS} iters...")
-            for i in range(NUM_ITERS):
+            print(f"[Sender] Measuring {args.num_iters} iters...")
+            for i in range(args.num_iters):
                 src_tensor = torch.zeros(
                     num_elements, dtype=dtype, device=relay_kwargs["device"]
                 )
@@ -134,12 +172,14 @@ def sender_process(
 
 
 def receiver_process(
+    args,
     meta_queue,
     barrier,
     relay_type: str,
     data_size_mb: int,
     master_addr: str,
     master_port: str,
+    results_pipe: multiprocessing.Pipe,
 ):
     """Receiver Process: Rank 1 for NCCL."""
     try:
@@ -151,7 +191,7 @@ def receiver_process(
         relay_kwargs = {
             "engine_id": "receiver_engine",
             "slot_size_mb": data_size_mb,
-            "credits": POOL_CREDITS,
+            "credits": args.pool_credits,
             "device": (
                 "cuda:1" if relay_type.lower() in ["nccl", "mooncake"] else DEVICE
             ),
@@ -188,9 +228,10 @@ def receiver_process(
         throughputs_gbs: list[float] = []
 
         async def _receiver_loop():
-            print("[Receiver] Ready.")
+            if args.verbose:
+                print("[Receiver] Ready.")
 
-            for _ in range(WARMUP_ITERS):
+            for _ in range(args.warmup_iters):
                 remote_meta = meta_queue.get()
                 if remote_meta is None:
                     return
@@ -202,11 +243,12 @@ def receiver_process(
                 if "cuda" in str(relay_kwargs["device"]):
                     torch.cuda.synchronize()
 
-            print("[Receiver] Measuring...")
+            if args.verbose:
+                print("[Receiver] Measuring...")
             dest_tensor = torch.zeros(
                 num_elements, dtype=dtype, device=relay_kwargs["device"]
             )
-            for i in range(NUM_ITERS):
+            for i in range(args.num_iters):
                 remote_meta = meta_queue.get()
                 if remote_meta is None:
                     break
@@ -230,17 +272,18 @@ def receiver_process(
 
                 val = float(dest_tensor[0].item())
                 expected = i + 1.0
+
                 if abs(val - expected) < 0.1:
-                    print(f"[Iter {i}] {lat_ms:.2f} ms | {bw_gbs:.2f} GB/s")
+                    if args.verbose:
+                        print(f"[Iter {i}] {lat_ms:.2f} ms | {bw_gbs:.2f} GB/s")
                 else:
-                    print(f"[Iter {i}] Mismatch! Exp: {expected}, Got: {val}")
+                    raise ValueError(
+                        f"[Iter {i}] Mismatch! Exp: {expected}, Got: {val}"
+                    )
 
             if latencies_ms:
-                print("\n" + "=" * 50)
-                print(f"Result for {relay_type.upper()} Relay ({data_size_mb} MB)")
-                print(f"Avg Latency:    {np.mean(latencies_ms):.2f} ms")
-                print(f"Avg Throughput: {np.mean(throughputs_gbs):.2f} GB/s")
-                print("=" * 50)
+                results_pipe.send((latencies_ms, throughputs_gbs))
+                results_pipe.close()
 
         asyncio.run(_receiver_loop())
 
@@ -251,38 +294,111 @@ def receiver_process(
             relay.close()
 
 
+def benchmark_relay(args, backend_type: str):
+    # the benchmark sizes should be a multiple of the factor and the start size
+    benchmark_sizes = []
+    start_size = args.start_size
+    benchmark_sizes.append(start_size)
+    while start_size < args.end_size:
+        start_size *= args.factor
+        benchmark_sizes.append(start_size)
+    if benchmark_sizes[-1] != args.end_size:
+        benchmark_sizes.append(args.end_size)
+
+    latency_list = []
+    throughput_list = []
+
+    for size in tqdm(
+        benchmark_sizes, desc=f"Benchmarking {backend_type.upper()} Relay"
+    ):
+        meta_queue = multiprocessing.Queue()
+        init_barrier = multiprocessing.Barrier(2)
+        receiver, sender = multiprocessing.Pipe()
+
+        master_addr = "127.0.0.1"
+        master_port = find_free_port()
+
+        p_sender = multiprocessing.Process(
+            target=sender_process,
+            args=(
+                args,
+                meta_queue,
+                init_barrier,
+                backend_type,
+                size,
+                master_addr,
+                master_port,
+            ),
+        )
+        p_receiver = multiprocessing.Process(
+            target=receiver_process,
+            args=(
+                args,
+                meta_queue,
+                init_barrier,
+                backend_type,
+                size,
+                master_addr,
+                master_port,
+                sender,
+            ),
+        )
+        p_sender.start()
+        p_receiver.start()
+
+        p_sender.join()
+        p_receiver.join()
+        latencies_ms, throughputs_gbs = receiver.recv()
+
+        if args.verbose:
+            print(
+                f"--- Benchmarking {backend_type.upper()} Relay with {size} MB data ---"
+            )
+            print(f"Avg Latency:    {np.mean(latencies_ms):.2f} ms")
+            print(f"Avg Throughput: {np.mean(throughputs_gbs):.2f} GB/s")
+            print("=" * 50)
+
+        latency_list.append(np.mean(latencies_ms))
+        throughput_list.append(np.mean(throughputs_gbs))
+
+    return benchmark_sizes, latency_list, throughput_list
+
+
+def tabulate_and_save(
+    backend_type, output_dir, benchmark_sizes, latency_list, throughput_list
+):
+    results = pd.DataFrame(
+        {
+            "Size (MB)": benchmark_sizes,
+            "Latency (ms)": latency_list,
+            "Throughput (GB/s)": throughput_list,
+        }
+    )
+    table = tabulate(results, headers="keys", tablefmt="grid")
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    os.makedirs(output_dir, exist_ok=True)
+    with open(
+        os.path.join(output_dir, f"benchmark_relay_{backend_type}_{timestamp}.txt"), "w"
+    ) as f:
+        f.write(table)
+
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Relay Benchmark")
-    parser.add_argument(
-        "--type", type=str, default="nccl", choices=["nixl", "shm", "nccl", "mooncake"]
-    )
-    parser.add_argument("--size", type=int, default=10, help="Data size in MB")
-    args = parser.parse_args()
+    multiprocessing.set_start_method("spawn", force=True)
+    args = parse_args()
+    if args.backend_type == "all":
+        backend_types = ["nixl", "shm", "nccl", "mooncake"]
+    else:
+        backend_types = [args.backend_type]
 
-    try:
-        multiprocessing.set_start_method("spawn", force=True)
-    except RuntimeError:
-        pass
-
-    print(f"--- Benchmarking {args.type.upper()} Relay with {args.size} MB data ---")
-
-    meta_queue = multiprocessing.Queue()
-    init_barrier = multiprocessing.Barrier(2)
-
-    master_addr = "127.0.0.1"
-    master_port = find_free_port()
-
-    p_sender = multiprocessing.Process(
-        target=sender_process,
-        args=(meta_queue, init_barrier, args.type, args.size, master_addr, master_port),
-    )
-    p_receiver = multiprocessing.Process(
-        target=receiver_process,
-        args=(meta_queue, init_barrier, args.type, args.size, master_addr, master_port),
-    )
-
-    p_sender.start()
-    p_receiver.start()
-
-    p_sender.join()
-    p_receiver.join()
+    for backend_type in backend_types:
+        benchmark_sizes, latency_list, throughput_list = benchmark_relay(
+            args, backend_type
+        )
+        tabulate_and_save(
+            backend_type,
+            args.output_dir,
+            benchmark_sizes,
+            latency_list,
+            throughput_list,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,9 @@ dependencies = [
     "av>=16.1.0",
     "qwen-vl-utils==0.0.11",
     "numba==0.63.1",
-    "librosa>=0.11.0"
+    "librosa>=0.11.0",
+    "pandas",
+    "tabulate"
 ]
 
 [project.scripts]


### PR DESCRIPTION
I noticed that the relay benchmark script currently only benchmark for one backend and one data size at a time, I have refactored the code to run range test and present the data with tabulation.