### PR TITLE
[ci] support rerun failed ci command

### DIFF
--- a/.github/workflows/rerun-ci.yaml
+++ b/.github/workflows/rerun-ci.yaml
@@ -1,0 +1,64 @@
+name: Rerun CI
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  actions: write
+  pull-requests: read
+  contents: read
+
+jobs:
+  rerun-failed:
+    # Only run on PR comments that say /rerun-failed-ci
+    if: >
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/rerun-failed-ci')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rerun failed jobs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Get the PR head SHA
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const headSha = pr.head.sha;
+
+            // List workflow runs for this commit
+            const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: headSha,
+            });
+
+            let reranCount = 0;
+            for (const run of runs.workflow_runs) {
+              if (run.conclusion === 'failure' || run.conclusion === 'cancelled') {
+                await github.rest.actions.reRunWorkflowFailedJobs({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run.id,
+                });
+                console.log(`Re-ran failed jobs for: ${run.name} (${run.id})`);
+                reranCount++;
+              }
+            }
+
+            if (reranCount === 0) {
+              console.log('No failed or cancelled workflow runs found to rerun.');
+            } else {
+              console.log(`Reran ${reranCount} workflow(s).`);
+            }
+
+            // React to the comment to acknowledge
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            });


### PR DESCRIPTION
This PR adds a workflow to support rerun failed test via a slash command.