### PR TITLE
fix: propagate real error message instead of request UUID in worker f…

### DIFF
--- a/sglang_omni/pipeline/worker/runtime.py
+++ b/sglang_omni/pipeline/worker/runtime.py
@@ -169,9 +169,9 @@ class Worker:
 
         except asyncio.CancelledError:
             logger.debug("Worker: request %s cancelled", request_id)
-        except Exception:
+        except Exception as e:
             logger.exception("Worker: request %s failed", request_id)
-            await self._send_failure(request_id, str(request_id))
+            await self._send_failure(request_id, str(e))
         finally:
             self._result_waiters.pop(request_id, None)
             if self.stage is not None:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

When a worker executor throws an exception, the error message returned to the client is the **request UUID** instead of the actual exception message. This makes debugging impossible from the client side — users see a meaningless UUID like `RuntimeError: 9d464fba-694d-47f9-b451-bf31c3631620` instead of the real error (e.g. OOM, shape mismatch, etc.).

The root cause is in `sglang_omni/pipeline/worker/runtime.py` line 172-174:

```python
except Exception:  # exception not captured
    logger.exception("Worker: request %s failed", request_id)
    await self._send_failure(request_id, str(request_id))  # sends UUID, not error
```

The exception is never bound (`except Exception` without `as e`), and `str(request_id)` is passed as the error string instead of the exception message.

**Traceback:**
```
sglang_omni/serve/openai_api.py:263      → client.completion_stream()
sglang_omni/client/client.py:143         → self.generate()
sglang_omni/client/client.py:58          → self._coordinator.stream()
sglang_omni/pipeline/coordinator.py:128  → raise RuntimeError(msg.error or "Unknown error")
RuntimeError: 9d464fba-694d-47f9-b451-bf31c3631620   ← UUID instead of real error
```

**Example error**
<img width="858" height="733" alt="Screenshot 2026-02-24 at 4 17 27 PM" src="https://github.com/user-attachments/assets/02a28efe-63d1-4149-bb88-586d5138f690" />


## Modifications

<!-- Describe the changes made in this PR. -->

One-line fix in `sglang_omni/pipeline/worker/runtime.py`:

```python
except Exception as e:
    logger.exception("Worker: request %s failed", request_id)
    await self._send_failure(request_id, str(e))
```

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

N/A — error handling only, no model logic changes.

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

N/A — no performance impact; only changes the error path.

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
