### PR TITLE
propagate model_path without invididual stage configuration

### DIFF
--- a/sglang_omni/config/compiler.py
+++ b/sglang_omni/config/compiler.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import inspect
 from pathlib import Path
 from typing import Any
 
@@ -83,6 +84,14 @@ def _compile_stage(
         input_handler=input_handler,
         relay_config=_build_relay_config(stage_cfg, global_cfg),
     )
+
+    # check if factory has the signature of model_path and the user does not provide the model path
+    # if yes, use the one in global config
+    if (
+        "model_path" in inspect.signature(factory).parameters
+        and "model_path" not in stage_cfg.executor.args
+    ):
+        stage_cfg.executor.args["model_path"] = global_cfg.model_path
 
     for _ in range(stage_cfg.num_workers):
         executor = factory(**stage_cfg.executor.args)

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -98,13 +98,5 @@ class Qwen3OmniPipelineConfig(PipelineConfig):
         ),
     ]
 
-    def model_post_init(self, __context: Any = None) -> None:
-        super().model_post_init(__context)
-
-        # TODO: we need to refactor this factory pattern to avoid
-        for stage in self.stages:
-            if stage.name != AGGREGATE_STAGE:
-                stage.executor.args["model_path"] = self.model_path
-
 
 EntryClass = Qwen3OmniPipelineConfig


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Part of the efforts for issue #107 

## Modifications

<!-- Describe the changes made in this PR. -->

If the factory function does not require `model_path`, then just ignore it. If yes and `model_path` is not given in the config, we will propagate the global `model_path` to it.

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

Fixed #107 

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
