### PR TITLE
[Perf] replace Conv3d with Linear in VisionPatchEmbed

### DIFF
--- a/sglang_omni/models/qwen3_omni/components/image_encoder.py
+++ b/sglang_omni/models/qwen3_omni/components/image_encoder.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import logging
+import types
+
 import torch
 import torch.nn as nn
 from transformers.models.qwen3_omni_moe import modeling_qwen3_omni_moe as hf_modeling
@@ -11,8 +14,76 @@ from sglang_omni.models.qwen3_omni.components.common import load_thinker_config
 from sglang_omni.models.weight_loader import load_module, resolve_dtype
 from sglang_omni.utils import instantiate_module
 
+logger = logging.getLogger(__name__)
+
 VISUAL_PREFIX = ("thinker.visual.", "visual.")
 VISUAL_CLASS = hf_modeling.Qwen3OmniMoeVisionEncoder
+
+
+def _patch_embed_forward(self: nn.Module, hidden_states: torch.Tensor) -> torch.Tensor:
+    """Optimized PatchEmbed forward using Linear instead of Conv3d."""
+    return self.linear(hidden_states.to(dtype=self.linear.weight.dtype))
+
+
+def _optimize_patch_embed(visual: nn.Module) -> None:
+    """Replace Conv3d with Linear in PatchEmbed for ~7-15× speedup.
+
+    The Conv3d kernel does not slide (kernel_size == stride), so it is
+    equivalent to a reshape + linear. We load weights via Conv3d for
+    checkpoint compatibility, then copy them to a Linear layer.
+
+    Reference: https://github.com/sgl-project/sglang/pull/19788
+    """
+    patch_embed = getattr(visual, "patch_embed", None)
+    if patch_embed is None:
+        return
+    conv = getattr(patch_embed, "proj", None)
+    if conv is None or not isinstance(conv, nn.Conv3d):
+        return
+
+    if list(conv.kernel_size) != list(conv.stride):
+        logger.debug(
+            "PatchEmbed Conv3d kernel_size=%s != stride=%s, skipping optimization",
+            conv.kernel_size,
+            conv.stride,
+        )
+        return
+
+    if conv.padding != (0, 0, 0) or conv.dilation != (1, 1, 1) or conv.groups != 1:
+        logger.debug(
+            "PatchEmbed Conv3d has non-trivial padding/dilation/groups, skipping"
+        )
+        return
+
+    embed_dim = conv.out_channels
+    in_features = (
+        conv.in_channels
+        * conv.kernel_size[0]
+        * conv.kernel_size[1]
+        * conv.kernel_size[2]
+    )
+
+    linear = nn.Linear(
+        in_features,
+        embed_dim,
+        bias=True,
+        dtype=conv.weight.dtype,
+        device=conv.weight.device,
+    )
+    with torch.no_grad():
+        linear.weight.copy_(conv.weight.view(embed_dim, -1))
+        linear.bias.copy_(conv.bias)
+
+    del patch_embed.proj
+    patch_embed.linear = linear
+    patch_embed.forward = types.MethodType(_patch_embed_forward, patch_embed)
+    logger.info(
+        "PatchEmbed optimized: Conv3d(%d→%d) replaced with Linear(%d→%d)",
+        conv.in_channels,
+        embed_dim,
+        in_features,
+        embed_dim,
+    )
 
 
 def _build_visual(
@@ -24,7 +95,7 @@ def _build_visual(
 ) -> nn.Module:
     vision_cfg = thinker_cfg.vision_config
     visual = instantiate_module(VISUAL_CLASS, vision_cfg)
-    return load_module(
+    visual = load_module(
         visual,
         model_path,
         prefix=VISUAL_PREFIX,
@@ -32,6 +103,8 @@ def _build_visual(
         device=device,
         strict=True,
     )
+    _optimize_patch_embed(visual)
+    return visual
 
 
 class Qwen3OmniImageEncoder(nn.Module):


### PR DESCRIPTION
Conv3d with kernel_size == stride does not slide over the input, making it equivalent to a reshape + linear projection. Replace it with nn.Linear after loading HF checkpoint weights for significantly faster patch embedding, especially on older cuDNN versions where Conv3d with large non-sliding kernels is extremely slow.

Safety checks ensure the optimization only applies when kernel_size == stride, padding == 0, dilation == 1, and groups == 1.

Reference: https://github.com/sgl-project/sglang/pull/19788

Benchmark in H20, `linear` vs `conv3d`:

  ```
    size   patches   Conv3d/ms   Linear/ms   Speedup
------------------------------------------------------
   32x32           4       0.211       0.019     11.3x
   64x64          16       0.216       0.020     10.9x
   96x96          36       0.231       0.018     12.5x
  128x128         64       0.253       0.019     13.4x
  160x160        100       0.253       0.019     13.5x
  192x192        144       0.254       0.019     13.6x
  224x224        196       0.254       0.019     13.7x
  256x256        256       0.254       0.019     13.7x
  288x288        324       0.254       0.019     13.5x
  320x320        400       0.255       0.019     13.8x
  352x352        484       0.256       0.019     13.8x
  384x384        576       0.362       0.020     18.2x
  416x416        676       0.365       0.023     15.9x
  448x448        784       0.368       0.025     15.0x
  480x480        900       0.368       0.027     13.5x
  512x512       1024       0.368       0.031     11.7x
  544x544       1156       0.490       0.037     13.2x
  576x576       1296       0.492       0.040     12.2x
  608x608       1444       0.492       0.040     12.2x
  640x640       1600       0.493       0.046     10.8x
  672x672       1764       0.625       0.051     12.3x
  704x704       1936       0.628       0.056     11.2x
  736x736       2116       0.628       0.061     10.2x
  768x768       2304       0.860       0.067     12.9x
  800x800       2500       1.146       0.072     15.9x
  832x832       2704       1.186       0.072     16.5x
  864x864       2916       1.106       0.081     13.7x
  896x896       3136       1.101       0.088     12.5x
  928x928       3364       1.103       0.091     12.1x
  960x960       3600       1.210       0.099     12.2x
  992x992       3844       1.213       0.106     11.5x
 1024x1024      4096       1.248       0.110     11.4x
```

Accuracy: 

Test with uniform distribution:
```
device  dtype       patches     max_abs    mean_abs
----------------------------------------------------
cuda    bfloat16          1    1.56e-02    6.68e-04
cuda    bfloat16         10    1.56e-02    6.29e-04
cuda    bfloat16         50    1.56e-02    6.52e-04
cuda    bfloat16        100    1.56e-02    6.48e-04
cuda    bfloat16        500    1.56e-02    6.48e-04
cuda    bfloat16       1000    1.56e-02    6.48e-04
cuda    bfloat16       2000    1.56e-02    6.48e-04
cuda    bfloat16       4000    1.56e-02    6.48e-04
cuda    bfloat16       6000    1.56e-02    6.48e-04
cuda    bfloat16       8000    1.56e-02    6.52e-04
cuda    bfloat16      12000    1.56e-02    6.48e-04
cuda    bfloat16      16000    1.56e-02    6.52e-04
cuda    bfloat16      20000    1.56e-02    6.48e-04
cuda    bfloat16      24168    1.56e-02    6.52e-04
cuda    float16           1    1.95e-03    7.70e-05
cuda    float16          10    1.95e-03    7.74e-05
cuda    float16          50    1.95e-03    7.99e-05
cuda    float16         100    1.95e-03    7.95e-05
cuda    float16         500    1.95e-03    7.96e-05
cuda    float16        1000    1.95e-03    7.98e-05
cuda    float16        2000    1.95e-03    7.97e-05
cuda    float16        4000    1.95e-03    7.97e-05
cuda    float16        6000    1.95e-03    7.96e-05
cuda    float16        8000    1.95e-03    7.95e-05
cuda    float16       12000    1.95e-03    7.96e-05
cuda    float16       16000    1.95e-03    7.96e-05
cuda    float16       20000    1.95e-03    7.96e-05
cuda    float16       24168    1.95e-03    7.96e-05
```

Test with 24168 real image patches from image processor
```
dtype          max_abs    mean_abs    match%
--------------------------------------------
float32       7.73e-04    8.28e-05    100.0%
bfloat16      1.56e-02    4.46e-04    100.0%
float16       1.95e-03    5.48e-05    100.0%
```
