### PR TITLE
[bug fix] Deepstack shape mismatch in chunked prefill and qwen-vl-utils AP…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "httpx",
     "xxhash>=3.0.0",
     "av>=16.1.0",
-    "qwen-vl-utils==0.0.11",
+    "qwen-vl-utils>=0.0.14",
     "numba==0.63.1",
     "librosa>=0.11.0",
     "pandas",

--- a/sglang_omni/engines/omni/runtime/sglang_ar.py
+++ b/sglang_omni/engines/omni/runtime/sglang_ar.py
@@ -482,7 +482,9 @@ class SGLangModelRunner:
                 device=device,
                 dtype=dtype,
             )
-            full_ds[visual_pos_masks] = ds_input
+            n_positions = visual_pos_masks.sum().item()
+            if n_positions > 0:
+                full_ds[visual_pos_masks] = ds_input[:n_positions]
             ds_input = full_ds
 
         hidden_states = outer.model(

--- a/sglang_omni/preprocessing/video.py
+++ b/sglang_omni/preprocessing/video.py
@@ -14,8 +14,6 @@ import av
 import librosa
 import torch
 from qwen_vl_utils import vision_process as qwen_vision
-from torchvision.transforms import InterpolationMode
-from torchvision.transforms import functional as tv_f
 
 from .base import MediaIO, _is_url
 from .cache_key import compute_media_cache_key
@@ -252,48 +250,21 @@ def load_video_path(
     path: str | Path,
     fps: float | None = None,
 ) -> tuple[torch.Tensor, float]:
-    """Load a local video into a torch tensor (T, C, H, W) on CPU."""
+    """Load a local video into a torch tensor (T, C, H, W) on CPU.
+
+    Uses ``qwen_vl_utils.vision_process.fetch_video`` which handles frame
+    sampling, smart resize and pixel budget internally.
+
+    Requires qwen-vl-utils >= 0.0.14 (fetch_video API).
+    """
     ele: dict[str, Any] = {"video": str(path)}
     if fps is not None:
         ele["fps"] = float(fps)
-    backend = qwen_vision.get_video_reader_backend()
-    try:
-        video, sample_fps = qwen_vision.VIDEO_READER_BACKENDS[backend](ele)
-    except Exception:
-        logger.warning("Video reader %s failed, falling back to torchvision", backend)
-        video, sample_fps = qwen_vision.VIDEO_READER_BACKENDS["torchvision"](ele)
-    nframes, _, height, width = video.shape
-    min_pixels = ele.get("min_pixels", qwen_vision.VIDEO_MIN_PIXELS)
-    total_pixels = ele.get("total_pixels", qwen_vision.VIDEO_TOTAL_PIXELS)
-    max_pixels = max(
-        min(
-            qwen_vision.VIDEO_MAX_PIXELS,
-            total_pixels / nframes * qwen_vision.FRAME_FACTOR,
-        ),
-        int(min_pixels * 1.05),
-    )
-    max_pixels_supposed = ele.get("max_pixels", max_pixels)
-    max_pixels = min(max_pixels_supposed, max_pixels)
-    if "resized_height" in ele and "resized_width" in ele:
-        resized_height, resized_width = qwen_vision.smart_resize(
-            ele["resized_height"],
-            ele["resized_width"],
-            factor=qwen_vision.IMAGE_FACTOR,
-        )
-    else:
-        resized_height, resized_width = qwen_vision.smart_resize(
-            height,
-            width,
-            factor=qwen_vision.IMAGE_FACTOR,
-            min_pixels=min_pixels,
-            max_pixels=max_pixels,
-        )
-    video = tv_f.resize(
-        video,
-        [resized_height, resized_width],
-        interpolation=InterpolationMode.BICUBIC,
-        antialias=True,
-    ).float()
+    video, sample_fps = qwen_vision.fetch_video(ele, return_video_sample_fps=True)
+    if not isinstance(video, torch.Tensor):
+        import numpy as np
+
+        video = torch.from_numpy(np.stack(video))
     return video, sample_fps
 
 


### PR DESCRIPTION
## fix: deepstack shape mismatch and qwen-vl-utils API compatibility

### Bug 1: Deepstack visual embeds shape mismatch in decode / chunked prefill

**Problem:** `_forward_with_omni_embeds` crashes with `RuntimeError: shape mismatch` when `visual_pos_masks` selects fewer positions than `ds_input` has rows. This happens because:
- During **decode**: the current batch only contains newly generated tokens (no visual tokens), so `visual_pos_masks.sum() == 0`, but deepstack embeds from prefill are still passed in.
- During **chunked prefill**: the current chunk may only cover a subset of visual token positions.

Both are normal operating modes in SGLang's continuous batching scheduler.

**Fix:** Handle size mismatch in `sglang_ar.py` by checking `n_positions` before scatter assignment:
- `n_positions == ds_input.shape[0]`: full match (normal prefill)
- `0 < n_positions < ds_input.shape[0]`: partial match (chunked prefill), fill available positions
- `n_positions == 0`: no visual tokens in current batch (decode), `full_ds` stays zero — semantically correct since KV cache already captured visual info during prefill

### Bug 2: qwen-vl-utils >= 0.0.14 API breaking change

**Problem:** `_read_video_torchvision` now returns 3 values `(video, video_metadata, sample_fps)` instead of 2, and constants like `VIDEO_MIN_PIXELS`, `VIDEO_TOTAL_PIXELS`, `IMAGE_FACTOR` were removed.

**Fix:** Replace manual video loading logic in `load_video_path` with the stable public API `qwen_vl_utils.vision_process.fetch_video`, which handles frame sampling, smart resize, and pixel budget internally. Updated version constraint in `pyproject.toml` from `==0.0.11` to `>=0.0.14`.

### Files changed

- `sglang_omni/engines/omni/runtime/sglang_ar.py` — deepstack shape mismatch fix
- `sglang_omni/preprocessing/video.py` — use `fetch_video` API
- `pyproject.toml` — `qwen-vl-utils>=0.0.14`


### Test after fix
CUDA_VISIBLE_DEVICES=1 python benchmarks/bench_qwen3_omni/bench_sglang_omni.py \
  --video-path tests/data/draw.mp4 \
  --prompt "What is happening in this video? Describe in detail." \
  --max-new-tokens 256 \
  --temperature 0.3

```
{'events': [{'type': 'text_final', 'modality': 'text', 'payload': {'text': "The video captures a close-up, top-down view of a person using a tablet and a stylus to draw a guitar on a digital canvas. The person's left hand is holding the tablet steady on a wooden surface, while the right hand, clad in a white long-sleeved shirt, operates the stylus. The tablet screen displays a drawing application with a simple, cartoon-style guitar already partially drawn. The guitar features a light brown body, a black neck, and six tuning pegs at the top.\n\nAs the video progresses, the person uses the stylus to add details to the guitar, focusing on the neck and headstock. The stylus moves smoothly across the screen, indicating precise control and attention to detail. The person's fingers adjust their grip slightly as they draw, showcasing the fluidity of their movements. The background remains consistent, with the wooden surface providing a warm, natural contrast to the sleek, modern tablet.\n\nThroughout the video, the focus remains on the drawing process, highlighting the artist's skill and the capabilities of the digital drawing tool. The video effectively demonstrates the ease and precision of creating digital art using a tablet and stylus, emphasizing the creative potential of modern technology."}, 'is_final': True}], 'text': "The video captures a close-up, top-down view of a person using a tablet and a stylus to draw a guitar on a digital canvas. The person's left hand is holding the tablet steady on a wooden surface, while the right hand, clad in a white long-sleeved shirt, operates the stylus. The tablet screen displays a drawing application with a simple, cartoon-style guitar already partially drawn. The guitar features a light brown body, a black neck, and six tuning pegs at the top.\n\nAs the video progresses, the person uses the stylus to add details to the guitar, focusing on the neck and headstock. The stylus moves smoothly across the screen, indicating precise control and attention to detail. The person's fingers adjust their grip slightly as they draw, showcasing the fluidity of their movements. The background remains consistent, with the wooden surface providing a warm, natural contrast to the sleek, modern tablet.\n\nThroughout the video, the focus remains on the drawing process, highlighting the artist's skill and the capabilities of the digital drawing tool. The video effectively demonstrates the ease and precision of creating digital art using a tablet and stylus, emphasizing the creative potential of modern technology.", 'modality': 'text'}
============================================================
Warmup:  22.650s
Real:    18.124s
```