### PR TITLE
Add fish audio s2-pro benchmarks

### DIFF
--- a/benchmarks/benchmark_relay.py
+++ b/benchmarks/benchmark_relay.py
@@ -1,0 +1,404 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Relay benchmark helper.
+
+Usage:
+
+```bash
+# benchmark nccl
+python benchmark_relay.py --backend-type nccl --start-size 16 --end-size 1024 --factor 2 --warmup-iters 10 --num-iters 20 --pool-credits 4 --verbose --output-dir ./results
+```
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import multiprocessing
+import os
+import socket
+import time
+import traceback
+
+import numpy as np
+import pandas as pd
+import torch
+from tabulate import tabulate
+from tqdm import tqdm
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Relay Benchmark")
+    parser.add_argument(
+        "-b",
+        "--backend-type",
+        type=str,
+        default="all",
+        choices=["nixl", "shm", "nccl", "mooncake", "all"],
+        help="The type of communication backend for benchmarking",
+    )
+    parser.add_argument(
+        "-s", "--start-size", type=int, default=16, help="Starting data size in MB"
+    )
+    parser.add_argument(
+        "-e", "--end-size", type=int, default=1024, help="Ending data size in MB"
+    )
+    parser.add_argument(
+        "-f", "--factor", type=int, default=2, help="Factor to multiply the data size"
+    )
+    parser.add_argument(
+        "-w", "--warmup-iters", type=int, default=10, help="Warm-up iterations"
+    )
+    parser.add_argument(
+        "-i", "--num-iters", type=int, default=20, help="Measurement iterations"
+    )
+    parser.add_argument(
+        "-c", "--pool-credits", type=int, default=4, help="Number of concurrent slots"
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        type=str,
+        default="./results",
+        help="Output directory for benchmarking results",
+    )
+    return parser.parse_args()
+
+
+# ================= Configuration =================
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def find_free_port() -> str:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return str(s.getsockname()[1])
+
+
+def sender_process(
+    args,
+    meta_queue,
+    barrier,
+    relay_type: str,
+    data_size_mb: int,
+    master_addr: str,
+    master_port: str,
+):
+    """Sender Process: Rank 0 for NCCL."""
+    try:
+        if relay_type.lower() == "nccl":
+            os.environ["MASTER_ADDR"] = master_addr
+            os.environ["MASTER_PORT"] = master_port
+            barrier.wait()
+
+        relay_kwargs = {
+            "engine_id": "sender_engine",
+            "slot_size_mb": data_size_mb,
+            "credits": args.pool_credits,
+            "device": (
+                "cuda:0" if relay_type.lower() in ["nccl", "mooncake"] else DEVICE
+            ),
+        }
+
+        # NCCL-specific parameters (ignored by Shm/Nixl)
+        relay_kwargs.update(
+            {"rank": 0, "world_size": 2, "send_to_ranks": [1], "recv_from_ranks": []}
+        )
+
+        if relay_type.lower() == "nixl":
+            from sglang_omni.relay.nixl import NixlRelay as RelayCls
+        elif relay_type.lower() == "shm":
+            from sglang_omni.relay.shm import ShmRelay as RelayCls
+        elif relay_type.lower() == "nccl":
+            from sglang_omni.relay.nccl import NcclRelay as RelayCls
+        elif relay_type.lower() == "mooncake":
+            from sglang_omni.relay.mooncake import MooncakeRelay as RelayCls
+        else:
+            raise ValueError(f"Unknown relay type: {relay_type}")
+
+        if relay_type.lower() != "nccl":
+            for k in ["rank", "world_size", "send_to_ranks", "recv_from_ranks"]:
+                relay_kwargs.pop(k, None)
+
+        relay = RelayCls(**relay_kwargs)
+        print("[Sender] Relay initialized.")
+
+        element_size = 2 if "cuda" in str(relay_kwargs["device"]) else 4
+        num_elements = (data_size_mb * 1024 * 1024) // element_size
+        dtype = (
+            torch.float16 if "cuda" in str(relay_kwargs["device"]) else torch.float32
+        )
+
+        async def _sender_loop():
+            print(f"[Sender] Warm-up {args.warmup_iters} iters...")
+            for i in range(args.warmup_iters):
+                src_tensor = torch.zeros(
+                    num_elements, dtype=dtype, device=relay_kwargs["device"]
+                )
+                src_tensor[0] = i + 0.5
+                if "cuda" in str(relay_kwargs["device"]):
+                    torch.cuda.synchronize()
+
+                # NCCL requires dst_rank; other relays ignore it.
+                op = await relay.put_async(src_tensor, dst_rank=1)
+                meta_queue.put(op.metadata)
+                await op.wait_for_completion()
+
+            print(f"[Sender] Measuring {args.num_iters} iters...")
+            for i in range(args.num_iters):
+                src_tensor = torch.zeros(
+                    num_elements, dtype=dtype, device=relay_kwargs["device"]
+                )
+                src_tensor[0] = i + 1.0
+                if "cuda" in str(relay_kwargs["device"]):
+                    torch.cuda.synchronize()
+
+                op = await relay.put_async(src_tensor, dst_rank=1)
+                meta_queue.put(op.metadata)
+                await op.wait_for_completion()
+
+            print("[Sender] Done.")
+            meta_queue.put(None)  # EOS
+            await asyncio.sleep(0.5)
+
+        asyncio.run(_sender_loop())
+
+    except Exception:
+        traceback.print_exc()
+    finally:
+        if "relay" in locals() and hasattr(relay, "close"):
+            relay.close()
+
+
+def receiver_process(
+    args,
+    meta_queue,
+    barrier,
+    relay_type: str,
+    data_size_mb: int,
+    master_addr: str,
+    master_port: str,
+    results_pipe: multiprocessing.Pipe,
+):
+    """Receiver Process: Rank 1 for NCCL."""
+    try:
+        if relay_type.lower() == "nccl":
+            os.environ["MASTER_ADDR"] = master_addr
+            os.environ["MASTER_PORT"] = master_port
+            barrier.wait()
+
+        relay_kwargs = {
+            "engine_id": "receiver_engine",
+            "slot_size_mb": data_size_mb,
+            "credits": args.pool_credits,
+            "device": (
+                "cuda:1" if relay_type.lower() in ["nccl", "mooncake"] else DEVICE
+            ),
+        }
+
+        relay_kwargs.update(
+            {"rank": 1, "world_size": 2, "send_to_ranks": [], "recv_from_ranks": [0]}
+        )
+
+        if relay_type.lower() == "nixl":
+            from sglang_omni.relay.nixl import NixlRelay as RelayCls
+        elif relay_type.lower() == "shm":
+            from sglang_omni.relay.shm import ShmRelay as RelayCls
+        elif relay_type.lower() == "nccl":
+            from sglang_omni.relay.nccl import NcclRelay as RelayCls
+        elif relay_type.lower() == "mooncake":
+            from sglang_omni.relay.mooncake import MooncakeRelay as RelayCls
+        else:
+            raise ValueError(f"Unknown relay type: {relay_type}")
+
+        if relay_type.lower() != "nccl":
+            for k in ["rank", "world_size", "send_to_ranks", "recv_from_ranks"]:
+                relay_kwargs.pop(k, None)
+
+        relay = RelayCls(**relay_kwargs)
+
+        element_size = 2 if "cuda" in str(relay_kwargs["device"]) else 4
+        num_elements = (data_size_mb * 1024 * 1024) // element_size
+        dtype = (
+            torch.float16 if "cuda" in str(relay_kwargs["device"]) else torch.float32
+        )
+
+        latencies_ms: list[float] = []
+        throughputs_gbs: list[float] = []
+
+        async def _receiver_loop():
+            if args.verbose:
+                print("[Receiver] Ready.")
+
+            for _ in range(args.warmup_iters):
+                remote_meta = meta_queue.get()
+                if remote_meta is None:
+                    return
+                dest_tensor = torch.zeros(
+                    num_elements, dtype=dtype, device=relay_kwargs["device"]
+                )
+                op = await relay.get_async(remote_meta, dest_tensor)
+                await op.wait_for_completion()
+                if "cuda" in str(relay_kwargs["device"]):
+                    torch.cuda.synchronize()
+
+            if args.verbose:
+                print("[Receiver] Measuring...")
+            dest_tensor = torch.zeros(
+                num_elements, dtype=dtype, device=relay_kwargs["device"]
+            )
+            for i in range(args.num_iters):
+                remote_meta = meta_queue.get()
+                if remote_meta is None:
+                    break
+
+                if "cuda" in str(relay_kwargs["device"]):
+                    torch.cuda.synchronize()
+                t0 = time.perf_counter()
+
+                op = await relay.get_async(remote_meta, dest_tensor)
+                await op.wait_for_completion()
+
+                if "cuda" in str(relay_kwargs["device"]):
+                    torch.cuda.synchronize()
+                t1 = time.perf_counter()
+
+                lat_ms = (t1 - t0) * 1000
+                bw_gbs = (data_size_mb / 1024) / (t1 - t0)
+
+                latencies_ms.append(lat_ms)
+                throughputs_gbs.append(bw_gbs)
+
+                val = float(dest_tensor[0].item())
+                expected = i + 1.0
+
+                if abs(val - expected) < 0.1:
+                    if args.verbose:
+                        print(f"[Iter {i}] {lat_ms:.2f} ms | {bw_gbs:.2f} GB/s")
+                else:
+                    raise ValueError(
+                        f"[Iter {i}] Mismatch! Exp: {expected}, Got: {val}"
+                    )
+
+            if latencies_ms:
+                results_pipe.send((latencies_ms, throughputs_gbs))
+                results_pipe.close()
+
+        asyncio.run(_receiver_loop())
+
+    except Exception:
+        traceback.print_exc()
+    finally:
+        if "relay" in locals() and hasattr(relay, "close"):
+            relay.close()
+
+
+def benchmark_relay(args, backend_type: str):
+    # the benchmark sizes should be a multiple of the factor and the start size
+    benchmark_sizes = []
+    start_size = args.start_size
+    benchmark_sizes.append(start_size)
+    while start_size < args.end_size:
+        start_size *= args.factor
+        benchmark_sizes.append(start_size)
+    if benchmark_sizes[-1] != args.end_size:
+        benchmark_sizes.append(args.end_size)
+
+    latency_list = []
+    throughput_list = []
+
+    for size in tqdm(
+        benchmark_sizes, desc=f"Benchmarking {backend_type.upper()} Relay"
+    ):
+        meta_queue = multiprocessing.Queue()
+        init_barrier = multiprocessing.Barrier(2)
+        receiver, sender = multiprocessing.Pipe()
+
+        master_addr = "127.0.0.1"
+        master_port = find_free_port()
+
+        p_sender = multiprocessing.Process(
+            target=sender_process,
+            args=(
+                args,
+                meta_queue,
+                init_barrier,
+                backend_type,
+                size,
+                master_addr,
+                master_port,
+            ),
+        )
+        p_receiver = multiprocessing.Process(
+            target=receiver_process,
+            args=(
+                args,
+                meta_queue,
+                init_barrier,
+                backend_type,
+                size,
+                master_addr,
+                master_port,
+                sender,
+            ),
+        )
+        p_sender.start()
+        p_receiver.start()
+
+        p_sender.join()
+        p_receiver.join()
+        latencies_ms, throughputs_gbs = receiver.recv()
+
+        if args.verbose:
+            print(
+                f"--- Benchmarking {backend_type.upper()} Relay with {size} MB data ---"
+            )
+            print(f"Avg Latency:    {np.mean(latencies_ms):.2f} ms")
+            print(f"Avg Throughput: {np.mean(throughputs_gbs):.2f} GB/s")
+            print("=" * 50)
+
+        latency_list.append(np.mean(latencies_ms))
+        throughput_list.append(np.mean(throughputs_gbs))
+
+    return benchmark_sizes, latency_list, throughput_list
+
+
+def tabulate_and_save(
+    backend_type, output_dir, benchmark_sizes, latency_list, throughput_list
+):
+    results = pd.DataFrame(
+        {
+            "Size (MB)": benchmark_sizes,
+            "Latency (ms)": latency_list,
+            "Throughput (GB/s)": throughput_list,
+        }
+    )
+    table = tabulate(results, headers="keys", tablefmt="grid")
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    os.makedirs(output_dir, exist_ok=True)
+    with open(
+        os.path.join(output_dir, f"benchmark_relay_{backend_type}_{timestamp}.txt"), "w"
+    ) as f:
+        f.write(table)
+
+
+if __name__ == "__main__":
+    multiprocessing.set_start_method("spawn", force=True)
+    args = parse_args()
+    if args.backend_type == "all":
+        backend_types = ["nixl", "shm", "nccl", "mooncake"]
+    else:
+        backend_types = [args.backend_type]
+
+    for backend_type in backend_types:
+        benchmark_sizes, latency_list, throughput_list = benchmark_relay(
+            args, backend_type
+        )
+        tabulate_and_save(
+            backend_type,
+            args.output_dir,
+            benchmark_sizes,
+            latency_list,
+            throughput_list,
+        )

--- a/benchmarks/eval_wer.py
+++ b/benchmarks/eval_wer.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""WER evaluation for seed-tts-eval generated audio.
+
+Supports both English (Whisper-large-v3) and Chinese (FunASR paraformer-zh).
+
+Usage:
+    # English
+    CUDA_VISIBLE_DEVICES=7 python benchmarks/eval_wer.py \
+        --meta /tmp/seed-tts-eval/seedtts_testset/en/meta.lst \
+        --audio-dir results/s2pro_compile_eager/audio \
+        --lang en
+
+    # Chinese
+    CUDA_VISIBLE_DEVICES=7 python benchmarks/eval_wer.py \
+        --meta /tmp/seed-tts-eval/seedtts_testset/zh/meta.lst \
+        --audio-dir results/s2pro_zh/audio \
+        --lang zh
+
+    # Chinese hard cases
+    CUDA_VISIBLE_DEVICES=7 python benchmarks/eval_wer.py \
+        --meta /tmp/seed-tts-eval/seedtts_testset/zh/hardcase.lst \
+        --audio-dir results/s2pro_zh_hard/audio \
+        --lang zh
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import string
+import time
+
+import numpy as np
+import scipy.signal
+import soundfile as sf
+import torch
+from jiwer import process_words
+from tqdm import tqdm
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def parse_meta_lst(path: str) -> list[dict]:
+    base_dir = os.path.dirname(path)
+    samples = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split("|")
+            if len(parts) < 4:
+                continue
+            samples.append(
+                {
+                    "id": parts[0],
+                    "ref_text": parts[1],
+                    "ref_audio": os.path.join(base_dir, parts[2]),
+                    "text": parts[3],
+                }
+            )
+    return samples
+
+
+def normalize_text(text: str, lang: str) -> str:
+    if lang == "zh":
+        from zhon.hanzi import punctuation as zh_punct
+
+        all_punct = zh_punct + string.punctuation
+    else:
+        all_punct = string.punctuation
+
+    for ch in all_punct:
+        if ch == "'":
+            continue
+        text = text.replace(ch, "")
+
+    text = text.replace("  ", " ").strip()
+
+    if lang == "zh":
+        # Character-level: space between each character
+        text = " ".join(list(text))
+    else:
+        text = text.lower()
+
+    return text
+
+
+def load_asr_model(lang: str, device: str):
+    if lang == "en":
+        from transformers import WhisperForConditionalGeneration, WhisperProcessor
+
+        logger.info("Loading Whisper-large-v3...")
+        t0 = time.perf_counter()
+        processor = WhisperProcessor.from_pretrained("openai/whisper-large-v3")
+        model = WhisperForConditionalGeneration.from_pretrained(
+            "openai/whisper-large-v3"
+        ).to(device)
+        logger.info("Whisper loaded in %.1fs", time.perf_counter() - t0)
+        return {"type": "whisper", "processor": processor, "model": model}
+    elif lang == "zh":
+        from funasr import AutoModel
+
+        logger.info("Loading FunASR paraformer-zh...")
+        t0 = time.perf_counter()
+        model = AutoModel(model="paraformer-zh")
+        logger.info("FunASR loaded in %.1fs", time.perf_counter() - t0)
+        return {"type": "funasr", "model": model}
+    else:
+        raise ValueError(f"Unsupported language: {lang}")
+
+
+def transcribe(asr, wav_path: str, lang: str, device: str) -> str:
+    if asr["type"] == "whisper":
+        processor = asr["processor"]
+        model = asr["model"]
+        wav, sr = sf.read(wav_path)
+        if sr != 16000:
+            wav = scipy.signal.resample(wav, int(len(wav) * 16000 / sr))
+        input_features = processor(
+            wav, sampling_rate=16000, return_tensors="pt"
+        ).input_features.to(device)
+        forced_decoder_ids = processor.get_decoder_prompt_ids(
+            language="english", task="transcribe"
+        )
+        with torch.no_grad():
+            predicted_ids = model.generate(
+                input_features, forced_decoder_ids=forced_decoder_ids
+            )
+        return processor.batch_decode(predicted_ids, skip_special_tokens=True)[0]
+    elif asr["type"] == "funasr":
+        import zhconv
+
+        res = asr["model"].generate(input=wav_path, batch_size_s=300)
+        transcription = res[0]["text"]
+        return zhconv.convert(transcription, "zh-cn")
+
+
+def main(args):
+    lang = args.lang
+    device = args.device
+
+    # Load ASR
+    asr = load_asr_model(lang, device)
+
+    # Parse samples
+    samples = parse_meta_lst(args.meta)
+    logger.info("Loaded %d samples from %s", len(samples), args.meta)
+
+    if args.max_samples and args.max_samples < len(samples):
+        samples = samples[: args.max_samples]
+
+    results = []
+    skipped = 0
+
+    for sample in tqdm(samples, desc=f"Evaluating WER ({lang})"):
+        wav_path = os.path.join(args.audio_dir, f"{sample['id']}.wav")
+        if not os.path.exists(wav_path):
+            skipped += 1
+            continue
+
+        # Transcribe
+        transcription = transcribe(asr, wav_path, lang, device)
+
+        # Compute WER
+        ref = normalize_text(sample["text"], lang)
+        hyp = normalize_text(transcription, lang)
+
+        if not ref:
+            skipped += 1
+            continue
+
+        measures = process_words(ref, hyp)
+        wer = measures.wer
+
+        results.append(
+            {
+                "id": sample["id"],
+                "ref_text": sample["text"],
+                "hyp_text": transcription,
+                "ref_norm": ref,
+                "hyp_norm": hyp,
+                "wer": wer,
+                "substitutions": measures.substitutions,
+                "deletions": measures.deletions,
+                "insertions": measures.insertions,
+            }
+        )
+
+    # Aggregate
+    wers = [r["wer"] for r in results]
+    wer_arr = np.array(wers)
+
+    n_above_50 = int(np.sum(wer_arr > 0.5))
+    wers_below_50 = wer_arr[wer_arr <= 0.5]
+
+    summary = {
+        "lang": lang,
+        "total_samples": len(samples),
+        "evaluated": len(results),
+        "skipped": skipped,
+        "wer_mean": float(np.mean(wer_arr)) if len(wer_arr) else 0,
+        "wer_median": float(np.median(wer_arr)) if len(wer_arr) else 0,
+        "wer_std": float(np.std(wer_arr)) if len(wer_arr) else 0,
+        "wer_p95": float(np.percentile(wer_arr, 95)) if len(wer_arr) else 0,
+        "wer_below_50_mean": float(np.mean(wers_below_50)) if len(wers_below_50) else 0,
+        "n_above_50_pct_wer": n_above_50,
+        "pct_above_50_pct_wer": n_above_50 / len(results) * 100 if results else 0,
+    }
+
+    output = {"summary": summary, "per_sample": results}
+
+    # Save
+    os.makedirs(
+        os.path.dirname(args.output) if os.path.dirname(args.output) else ".",
+        exist_ok=True,
+    )
+    with open(args.output, "w") as f:
+        json.dump(output, f, indent=2, ensure_ascii=False)
+
+    # Print
+    print("\n" + "=" * 52)
+    print(f"  WER Evaluation Results ({lang.upper()})")
+    print("=" * 52)
+    print(f"  Evaluated:           {len(results)}/{len(samples)}")
+    print(
+        f"  WER mean:            {summary['wer_mean']:.4f} ({summary['wer_mean']*100:.2f}%)"
+    )
+    print(f"  WER median:          {summary['wer_median']:.4f}")
+    print(
+        f"  WER (excl >50%):     {summary['wer_below_50_mean']:.4f} ({summary['wer_below_50_mean']*100:.2f}%)"
+    )
+    print(
+        f"  Samples >50% WER:    {n_above_50} ({summary['pct_above_50_pct_wer']:.1f}%)"
+    )
+    print(f"\n  Output: {args.output}")
+    print("=" * 52 + "\n")
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser(
+        description="WER evaluation (Whisper for EN, FunASR for ZH)"
+    )
+    p.add_argument("--meta", default="/tmp/seed-tts-eval/seedtts_testset/en/meta.lst")
+    p.add_argument(
+        "--audio-dir", required=True, help="Directory with generated {id}.wav files"
+    )
+    p.add_argument(
+        "--output", default=None, help="Output JSON (default: {audio-dir}/../wer.json)"
+    )
+    p.add_argument(
+        "--lang", choices=["en", "zh"], default="en", help="Language for ASR model"
+    )
+    p.add_argument("--device", default="cuda:0")
+    p.add_argument("--max-samples", type=int, default=None)
+    args = p.parse_args()
+    if args.output is None:
+        args.output = os.path.join(os.path.dirname(args.audio_dir), "wer.json")
+    main(args)

--- a/benchmarks/profile_s2pro_sglang.py
+++ b/benchmarks/profile_s2pro_sglang.py
@@ -1,0 +1,721 @@
+#!/usr/bin/env python3
+"""Performance profiling for S2-Pro SGLang paged-attention engine.
+
+Measures:
+  - TTFT (time to first token): from add_request to first stream output
+  - tok/s: semantic tokens per second (generation throughput)
+  - Total latency, RTF
+
+Tests single-request and batched-request scenarios.
+
+Usage:
+    CUDA_VISIBLE_DEVICES=0 python benchmarks/profile_s2pro_sglang.py \
+        --checkpoint fishaudio/s2-pro \
+        --testset /tmp/seed-tts-eval/seedtts_testset/en/meta.lst \
+        --max-samples 10 --batch-sizes 1,2,4
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import torch
+import torchaudio
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+CHECKPOINT = "fishaudio/s2-pro"
+TESTSET = "/tmp/seed-tts-eval/seedtts_testset/en/meta.lst"
+
+
+# ---------------------------------------------------------------------------
+# Shared setup
+# ---------------------------------------------------------------------------
+
+
+def parse_meta_lst(path: str, max_samples: int | None = None) -> list[dict]:
+    base_dir = os.path.dirname(path)
+    samples = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split("|")
+            if len(parts) < 4:
+                continue
+            samples.append(
+                {
+                    "id": parts[0],
+                    "ref_text": parts[1],
+                    "ref_audio": os.path.join(base_dir, parts[2]),
+                    "text": parts[3],
+                }
+            )
+            if max_samples and len(samples) >= max_samples:
+                break
+    return samples
+
+
+def load_audio_decoder(checkpoint: str, device: str):
+    from sglang_omni.models.fishaudio_s2_pro.fish_speech.models.text2semantic.configuration import (
+        FishQwen3OmniConfig,
+    )
+    from sglang_omni.models.fishaudio_s2_pro.fish_speech.models.text2semantic.modeling import (
+        FishQwen3OmniForCausalLM,
+    )
+
+    config = FishQwen3OmniConfig.from_pretrained(checkpoint)
+    full_model = FishQwen3OmniForCausalLM.from_pretrained(checkpoint, config=config)
+    full_model = full_model.to(device=device, dtype=torch.bfloat16).eval()
+
+    audio_decoder = full_model.audio_decoder
+    audio_decoder.setup_caches(max_batch_size=1, dtype=torch.bfloat16)
+    audio_decoder._parent_ref = full_model
+    return audio_decoder, config
+
+
+def create_sglang_engine(
+    checkpoint,
+    audio_decoder,
+    tokenizer,
+    num_codebooks,
+    codebook_size,
+    max_new_tokens,
+    top_k,
+    use_torch_compile=False,
+):
+    from sglang.srt.server_args import ServerArgs
+
+    from sglang_omni.models.fishaudio_s2_pro.factory import (
+        _patch_fish_config_for_sglang,
+        create_s2pro_sglang_engine,
+    )
+
+    _patch_fish_config_for_sglang(checkpoint)
+    server_args = ServerArgs(
+        model_path=checkpoint,
+        tp_size=1,
+        dtype="bfloat16",
+        mem_fraction_static=0.85,
+        chunked_prefill_size=8192,
+        max_running_requests=64,
+        disable_cuda_graph=True,
+    )
+    return create_s2pro_sglang_engine(
+        server_args=server_args,
+        audio_decoder=audio_decoder,
+        tokenizer=tokenizer,
+        gpu_id=0,
+        num_codebooks=num_codebooks,
+        codebook_size=codebook_size,
+        max_new_tokens=max_new_tokens,
+        top_k=top_k,
+        use_torch_compile=use_torch_compile,
+    )
+
+
+def build_request_data(
+    sample,
+    adapter,
+    codec,
+    tokenizer,
+    num_codebooks,
+    codebook_size,
+    max_new_tokens,
+    device,
+):
+    from sglang.srt.managers.schedule_batch import Req
+    from sglang.srt.sampling.sampling_params import SamplingParams
+
+    from sglang_omni.models.fishaudio_s2_pro.runtime.s2pro_sglang_ar import (
+        S2ProSGLangRequestData,
+    )
+    from sglang_omni.models.fishaudio_s2_pro.tokenizer import Reference
+
+    # Encode reference audio
+    audio, sr = torchaudio.load(sample["ref_audio"])
+    if audio.shape[0] > 1:
+        audio = audio.mean(0, keepdim=True)
+    audio = torchaudio.functional.resample(audio, sr, codec.sample_rate)
+    audios = audio.squeeze(0).unsqueeze(0).to(device)
+    audio_lengths = torch.tensor([audios.shape[1]], device=device, dtype=torch.long)
+    with torch.no_grad():
+        indices, _ = codec.encode(audios, audio_lengths)
+        if indices.ndim == 3:
+            indices = indices[0]
+    ref_codes = indices.cpu()
+
+    refs = [Reference(audio_bytes=b"", text=sample["ref_text"], vq_codes=ref_codes)]
+    prompt = adapter.build_prompt(
+        sample["text"], references=refs, num_codebooks=num_codebooks
+    )
+    input_ids = prompt["input_ids"]
+
+    sampling_params = SamplingParams(max_new_tokens=max_new_tokens, temperature=0.8)
+    sampling_params.normalize(tokenizer)
+    sampling_params.verify(adapter._tok.vocab_size)
+
+    input_ids_list = (
+        input_ids.tolist() if isinstance(input_ids, torch.Tensor) else input_ids
+    )
+    req = Req(
+        rid=sample["id"],
+        origin_input_text="",
+        origin_input_ids=input_ids_list,
+        sampling_params=sampling_params,
+        vocab_size=adapter._tok.vocab_size,
+    )
+
+    return S2ProSGLangRequestData(
+        input_ids=(
+            torch.tensor(input_ids_list, dtype=torch.long)
+            if not isinstance(input_ids, torch.Tensor)
+            else input_ids
+        ),
+        req=req,
+        vq_mask_tokens=prompt["vq_mask_tokens"],
+        vq_parts=prompt["vq_parts"],
+        num_codebooks=num_codebooks,
+        codebook_size=codebook_size,
+        max_new_tokens=max_new_tokens,
+        temperature=0.8,
+        top_p=0.8,
+        top_k=30,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Profiling
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RequestMetrics:
+    request_id: str
+    text: str
+    prompt_tokens: int
+    gen_tokens: int
+    ttft_s: float  # time to first token
+    ttfb_s: float  # time to first audio block (TTFT + 10 tokens + vocoder)
+    total_s: float  # total generation time
+    tok_per_s: float
+    audio_duration_s: float = 0.0
+    rtf: float = 0.0
+    ref_audio: str = ""
+    output_audio: str = ""
+
+
+async def profile_single_request(
+    engine,
+    sample,
+    adapter,
+    codec,
+    tokenizer,
+    num_codebooks,
+    codebook_size,
+    max_new_tokens,
+    device,
+    audio_dir=None,
+) -> RequestMetrics:
+    data = build_request_data(
+        sample,
+        adapter,
+        codec,
+        tokenizer,
+        num_codebooks,
+        codebook_size,
+        max_new_tokens,
+        device,
+    )
+    rid = f"prof-{sample['id']}"
+    data.req.rid = rid
+    prompt_len = len(data.input_ids)
+
+    t_start = time.perf_counter()
+    await engine.add_request(rid, data)
+
+    # Stream to measure TTFT and TTFB (TTFT + 10 tokens + vocoder for first block)
+    ttft = None
+    t_10th_token = None
+    token_count = 0
+    async for codes in engine.stream(rid):
+        if ttft is None:
+            ttft = time.perf_counter() - t_start
+        token_count += 1
+        if token_count == 10 and t_10th_token is None:
+            t_10th_token = time.perf_counter() - t_start
+
+    total = time.perf_counter() - t_start
+
+    result = data
+    n_codes = len(result.output_codes)
+    tok_per_s = n_codes / total if total > 0 else 0
+
+    # Vocode for audio duration + measure vocoder time for TTFB
+    audio_dur = 0.0
+    vocoder_time = 0.0
+    output_audio_path = ""
+    if n_codes > 0:
+        all_codes = torch.cat(result.output_codes, dim=-1)
+        codebook_codes = all_codes[1:].to(device)
+        # Time the vocoder for first 10 tokens
+        if n_codes >= 10:
+            first_10_codes = torch.cat(result.output_codes[:10], dim=-1)
+            first_10_cb = first_10_codes[1:].to(device)
+            torch.cuda.synchronize()
+            t_voc = time.perf_counter()
+            with torch.no_grad():
+                codec.from_indices(first_10_cb[None])
+            torch.cuda.synchronize()
+            vocoder_time = time.perf_counter() - t_voc
+
+        with torch.no_grad():
+            audio_out = codec.from_indices(codebook_codes[None])
+        audio_dur = audio_out.shape[-1] / codec.sample_rate
+
+        # Save audio if requested
+        if audio_dir is not None:
+            output_audio_path = str(Path(audio_dir) / f"{sample['id']}.wav")
+            torchaudio.save(
+                output_audio_path, audio_out.squeeze(0).cpu(), codec.sample_rate
+            )
+
+    # TTFB = time to 10th token + vocoder decode time for those 10 tokens
+    if t_10th_token is not None:
+        ttfb = t_10th_token + vocoder_time
+    else:
+        ttfb = (ttft or total) + vocoder_time
+
+    return RequestMetrics(
+        request_id=rid,
+        text=sample["text"][:60],
+        prompt_tokens=prompt_len,
+        gen_tokens=n_codes,
+        ttft_s=ttft if ttft is not None else total,
+        ttfb_s=ttfb,
+        total_s=total,
+        tok_per_s=tok_per_s,
+        audio_duration_s=audio_dur,
+        rtf=total / audio_dur if audio_dur > 0 else float("inf"),
+        ref_audio=sample.get("ref_audio", ""),
+        output_audio=output_audio_path,
+    )
+
+
+async def profile_batch(
+    engine,
+    samples,
+    adapter,
+    codec,
+    tokenizer,
+    num_codebooks,
+    codebook_size,
+    max_new_tokens,
+    device,
+) -> list[RequestMetrics]:
+    batch_size = len(samples)
+
+    # Pre-build all request data
+    requests = []
+    for i, sample in enumerate(samples):
+        data = build_request_data(
+            sample,
+            adapter,
+            codec,
+            tokenizer,
+            num_codebooks,
+            codebook_size,
+            max_new_tokens,
+            device,
+        )
+        rid = f"batch-{i}-{sample['id']}"
+        data.req.rid = rid
+        requests.append((rid, data, sample))
+
+    t_batch_start = time.perf_counter()
+
+    # Add all requests
+    for rid, data, _ in requests:
+        await engine.add_request(rid, data)
+
+    # Collect results concurrently
+    async def collect_one(rid, data, sample):
+        t_start = time.perf_counter()
+        ttft = None
+        t_10th_token = None
+        token_count = 0
+        async for codes in engine.stream(rid):
+            if ttft is None:
+                ttft = time.perf_counter() - t_start
+            token_count += 1
+            if token_count == 10 and t_10th_token is None:
+                t_10th_token = time.perf_counter() - t_start
+
+        total = time.perf_counter() - t_start
+        n_codes = len(data.output_codes)
+        tok_per_s = n_codes / total if total > 0 else 0
+
+        audio_dur = 0.0
+        vocoder_time = 0.0
+        if n_codes > 0:
+            all_codes = torch.cat(data.output_codes, dim=-1)
+            codebook_codes = all_codes[1:].to(device)
+            if n_codes >= 10:
+                first_10_codes = torch.cat(data.output_codes[:10], dim=-1)
+                first_10_cb = first_10_codes[1:].to(device)
+                torch.cuda.synchronize()
+                t_voc = time.perf_counter()
+                with torch.no_grad():
+                    codec.from_indices(first_10_cb[None])
+                torch.cuda.synchronize()
+                vocoder_time = time.perf_counter() - t_voc
+            with torch.no_grad():
+                audio_out = codec.from_indices(codebook_codes[None])
+            audio_dur = audio_out.shape[-1] / codec.sample_rate
+
+        ttfb = (t_10th_token or ttft or total) + vocoder_time
+
+        return RequestMetrics(
+            request_id=rid,
+            text=sample["text"][:60],
+            prompt_tokens=len(data.input_ids),
+            gen_tokens=n_codes,
+            ttft_s=ttft if ttft is not None else total,
+            ttfb_s=ttfb,
+            total_s=total,
+            tok_per_s=tok_per_s,
+            audio_duration_s=audio_dur,
+            rtf=total / audio_dur if audio_dur > 0 else float("inf"),
+        )
+
+    results = await asyncio.gather(
+        *[collect_one(rid, data, sample) for rid, data, sample in requests]
+    )
+    return list(results)
+
+
+def print_metrics(label: str, metrics: list[RequestMetrics]):
+    if not metrics:
+        print(f"\n{label}: No results")
+        return
+
+    ttfts = [m.ttft_s for m in metrics]
+    ttfbs = [m.ttfb_s for m in metrics]
+    toks = [m.tok_per_s for m in metrics]
+    totals = [m.total_s for m in metrics]
+    rtfs = [m.rtf for m in metrics if m.rtf < float("inf")]
+    gen_tokens = [m.gen_tokens for m in metrics]
+
+    total_tokens = sum(gen_tokens)
+    total_wall = sum(totals)
+    agg_tok_per_s = total_tokens / total_wall if total_wall > 0 else 0
+
+    print(f"\n{'='*64}")
+    print(f"  {label}")
+    print(f"{'='*64}")
+    print(f"  Requests:        {len(metrics)}")
+    print(
+        f"  TTFT mean:       {np.mean(ttfts)*1000:.1f}ms (median {np.median(ttfts)*1000:.1f}ms)"
+    )
+    print(
+        f"  TTFB mean:       {np.mean(ttfbs)*1000:.1f}ms (median {np.median(ttfbs)*1000:.1f}ms)"
+    )
+    print(f"  TTFB p95:        {np.percentile(ttfbs, 95)*1000:.1f}ms")
+    print(f"  Tok/s (per-req): {np.mean(toks):.1f} mean, {np.median(toks):.1f} median")
+    print(f"  Tok/s (agg):     {agg_tok_per_s:.1f}")
+    print(f"  Gen tokens:      {np.mean(gen_tokens):.0f} mean, {sum(gen_tokens)} total")
+    print(f"  Latency mean:    {np.mean(totals):.3f}s")
+    if rtfs:
+        print(f"  RTF mean:        {np.mean(rtfs):.4f}")
+    print(f"{'='*64}")
+
+    return {
+        "label": label,
+        "n_requests": len(metrics),
+        "ttft_mean_ms": float(np.mean(ttfts)) * 1000,
+        "ttft_median_ms": float(np.median(ttfts)) * 1000,
+        "ttfb_mean_ms": float(np.mean(ttfbs)) * 1000,
+        "ttfb_median_ms": float(np.median(ttfbs)) * 1000,
+        "ttfb_p95_ms": float(np.percentile(ttfbs, 95)) * 1000,
+        "tok_per_s_mean": float(np.mean(toks)),
+        "tok_per_s_agg": agg_tok_per_s,
+        "gen_tokens_mean": float(np.mean(gen_tokens)),
+        "latency_mean": float(np.mean(totals)),
+        "rtf_mean": float(np.mean(rtfs)) if rtfs else None,
+    }
+
+
+async def run_profiling(args):
+    device = "cuda"
+
+    # Load model components
+    logger.info("Loading audio decoder...")
+    audio_decoder, config = load_audio_decoder(args.checkpoint, device)
+    num_codebooks = config.audio_decoder_config.num_codebooks
+    codebook_size = config.audio_decoder_config.vocab_size
+
+    from transformers import PreTrainedTokenizerFast
+
+    tokenizer = PreTrainedTokenizerFast.from_pretrained(args.checkpoint)
+
+    from sglang_omni.models.fishaudio_s2_pro.pipeline.stages import _load_codec
+
+    codec = _load_codec(args.checkpoint, device)
+
+    from sglang_omni.models.fishaudio_s2_pro.tokenizer import S2ProTokenizerAdapter
+
+    adapter = S2ProTokenizerAdapter(tokenizer)
+
+    # Create engine
+    use_compile = not args.no_compile
+    logger.info("Creating SGLang engine (compile=%s)...", use_compile)
+    engine = create_sglang_engine(
+        args.checkpoint,
+        audio_decoder,
+        tokenizer,
+        num_codebooks,
+        codebook_size,
+        args.max_new_tokens,
+        args.top_k,
+        use_torch_compile=use_compile,
+    )
+    await engine.start()
+
+    # Load test samples
+    samples = parse_meta_lst(args.testset, args.max_samples)
+    logger.info("Loaded %d test samples", len(samples))
+
+    batch_sizes = [int(x) for x in args.batch_sizes.split(",")]
+    all_results = {}
+
+    # Warmup
+    logger.info("Warmup...")
+    try:
+        warmup_data = build_request_data(
+            samples[0],
+            adapter,
+            codec,
+            tokenizer,
+            num_codebooks,
+            codebook_size,
+            args.max_new_tokens,
+            device,
+        )
+        warmup_data.req.rid = "warmup-0"
+        await engine.add_request("warmup-0", warmup_data)
+        await asyncio.wait_for(engine.get_result("warmup-0"), timeout=120)
+        logger.info("Warmup done")
+    except Exception as e:
+        logger.warning("Warmup failed: %s", e)
+
+    # Set up audio output dir
+    audio_dir = None
+    if args.save_audio:
+        audio_dir = str(Path(args.output_dir) / "audio")
+        Path(audio_dir).mkdir(parents=True, exist_ok=True)
+
+    # Single-request profiling
+    if 1 in batch_sizes:
+        logger.info("Profiling single requests...")
+        single_metrics = []
+        for i, sample in enumerate(samples):
+            try:
+                m = await profile_single_request(
+                    engine,
+                    sample,
+                    adapter,
+                    codec,
+                    tokenizer,
+                    num_codebooks,
+                    codebook_size,
+                    args.max_new_tokens,
+                    device,
+                    audio_dir=audio_dir,
+                )
+                single_metrics.append(m)
+                logger.info(
+                    "[%d/%d] %s: TTFT=%.1fms TTFB=%.1fms %d tok %.1f tok/s %.3fs",
+                    i + 1,
+                    len(samples),
+                    m.request_id,
+                    m.ttft_s * 1000,
+                    m.ttfb_s * 1000,
+                    m.gen_tokens,
+                    m.tok_per_s,
+                    m.total_s,
+                )
+            except Exception as e:
+                logger.error(
+                    "[%d/%d] %s FAILED: %s", i + 1, len(samples), sample["id"], e
+                )
+
+        all_results["single"] = print_metrics("Single Request", single_metrics)
+
+        # Radix cache hit test: re-run same samples (prefix should be cached)
+        if args.test_cache_hit:
+            logger.info("Testing radix cache hit (re-running same ref audio)...")
+            cache_metrics = []
+            for i, sample in enumerate(samples[: min(5, len(samples))]):
+                try:
+                    m = await profile_single_request(
+                        engine,
+                        sample,
+                        adapter,
+                        codec,
+                        tokenizer,
+                        num_codebooks,
+                        codebook_size,
+                        args.max_new_tokens,
+                        device,
+                        audio_dir=None,  # don't save audio for cache hit test
+                    )
+                    cache_metrics.append(m)
+                    logger.info(
+                        "[cache %d] %s: TTFT=%.1fms TTFB=%.1fms %d tok %.1f tok/s",
+                        i + 1,
+                        m.request_id,
+                        m.ttft_s * 1000,
+                        m.ttfb_s * 1000,
+                        m.gen_tokens,
+                        m.tok_per_s,
+                    )
+                except Exception as e:
+                    logger.error("[cache %d] FAILED: %s", i + 1, e)
+            all_results["cache_hit"] = print_metrics("Radix Cache Hit", cache_metrics)
+
+        batch_sizes = [b for b in batch_sizes if b != 1]
+
+    # Batched-request profiling
+    for bs in batch_sizes:
+        if bs <= 1:
+            continue
+        logger.info("Profiling batch_size=%d...", bs)
+        batch_metrics = []
+
+        # Run batches of `bs` samples
+        for start in range(0, len(samples), bs):
+            batch_samples = samples[start : start + bs]
+            if len(batch_samples) < bs:
+                break
+            try:
+                metrics = await profile_batch(
+                    engine,
+                    batch_samples,
+                    adapter,
+                    codec,
+                    tokenizer,
+                    num_codebooks,
+                    codebook_size,
+                    args.max_new_tokens,
+                    device,
+                )
+                batch_metrics.extend(metrics)
+                for m in metrics:
+                    logger.info(
+                        "  %s: TTFT=%.4fs, %d tok, %.1f tok/s",
+                        m.request_id,
+                        m.ttft_s,
+                        m.gen_tokens,
+                        m.tok_per_s,
+                    )
+            except Exception as e:
+                logger.error("Batch starting at %d FAILED: %s", start, e)
+
+        all_results[f"batch_{bs}"] = print_metrics(f"Batch Size {bs}", batch_metrics)
+
+    await engine.stop()
+
+    # Save results
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with open(out_dir / "profile_results.json", "w") as f:
+        json.dump(all_results, f, indent=2)
+
+    # Save per-sample CSV (for WER eval compatibility)
+    if "single" in all_results and single_metrics:
+        import csv
+
+        csv_path = out_dir / "results.csv"
+        with open(csv_path, "w", newline="") as f:
+            w = csv.writer(f)
+            w.writerow(
+                [
+                    "id",
+                    "text",
+                    "ref_audio",
+                    "output_audio",
+                    "latency_s",
+                    "audio_duration_s",
+                    "rtf",
+                    "gen_tokens",
+                    "tok_per_s",
+                    "ttft_ms",
+                    "ttfb_ms",
+                    "error",
+                ]
+            )
+            for m in single_metrics:
+                w.writerow(
+                    [
+                        m.request_id.replace("prof-", ""),
+                        m.text,
+                        m.ref_audio,
+                        m.output_audio,
+                        f"{m.total_s:.4f}",
+                        f"{m.audio_duration_s:.4f}",
+                        f"{m.rtf:.4f}",
+                        m.gen_tokens,
+                        f"{m.tok_per_s:.2f}",
+                        f"{m.ttft_s*1000:.1f}",
+                        f"{m.ttfb_s*1000:.1f}",
+                        "",
+                    ]
+                )
+        logger.info("CSV saved to %s", csv_path)
+
+    logger.info("Results saved to %s", out_dir / "profile_results.json")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="S2-Pro SGLang performance profiling")
+    p.add_argument("--checkpoint", default=CHECKPOINT)
+    p.add_argument("--testset", default=TESTSET)
+    p.add_argument("--output-dir", default="results/s2pro_sglang_profile")
+    p.add_argument("--max-samples", type=int, default=0)
+    p.add_argument("--max-new-tokens", type=int, default=2048)
+    p.add_argument("--top-k", type=int, default=30)
+    p.add_argument(
+        "--batch-sizes", default="1,2,4", help="Comma-separated batch sizes to test"
+    )
+    p.add_argument(
+        "--no-compile",
+        action="store_true",
+        help="Disable torch.compile on codebook loop (enabled by default)",
+    )
+    p.add_argument(
+        "--test-cache-hit", action="store_true", help="Test radix cache hit TTFB"
+    )
+    p.add_argument(
+        "--save-audio",
+        action="store_true",
+        help="Save generated WAV files for WER eval",
+    )
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    asyncio.run(run_profiling(args))


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The benchmark files of Audio S2-Pro in branch s2-integration-Jing written by @JingwenGu0829 was not checked-in. 
Refer to https://github.com/sgl-project/sglang-omni/pull/142

This PR is to help checkin these missing benchmarks.

```
git clone git@github.com:sgl-project-dev/sglang-omni.git
cd sglang-omni

deactivate
rm -rf .venv
uv venv .venv -p 3.12
source .venv/bin/activate
uv pip install msgpack
uv pip install -e ".[s2pro]"

uv pip install https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu12torch2.9cxx11abiTRUE-cp312-cp312-linux_x86_64.whl
    
export S2PRO_CKPT=/root/.cache/huggingface/hub/models--fishaudio--s2-pro/blobs/
tar xzf /root/.cache/huggingface/seed_tts_eval_testset.tar.gz -C /tmp
export SEED_TTS=/tmp
source .venv/bin/activate
uv pip install torchaudio jiwer scipy tqdm

python benchmarks/profile_s2pro_sglang.py \
    --checkpoint $S2PRO_CKPT \
    --testset $SEED_TTS/seedtts_testset/en/meta.lst \
    --output-dir results/s2pro_sglang \
    --max-samples 50 --batch-sizes 1 --save-audio

python benchmarks/profile_s2pro_sglang.py \
    --checkpoint $S2PRO_CKPT \
    --testset $SEED_TTS/seedtts_testset/en/meta.lst \
    --output-dir results/s2pro_sglang_batched \
    --max-samples 50 --batch-sizes 1,2,4,8 --save-audio
```

```
(sglang-omni-dev) ➜  sglang-omni-dev git:(s2-integration-Jing) python benchmarks/profile_s2pro_sglang.py \
    --checkpoint $S2PRO_CKPT \
    --testset $SEED_TTS/seedtts_testset/en/meta.lst \
    --output-dir results/s2pro_sglang \
    --max-samples 50 --batch-sizes 1 --save-audio
2026-03-10 08:05:45,330 __main__ INFO Loading audio decoder...
Loading checkpoint shards: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:01<00:00,  1.62it/s]
2026-03-10 08:05:59,975 sglang_omni.models.fishaudio_s2_pro.pipeline.stages INFO Loading DAC codec from /root/.cache/huggingface/s2-pro/s2-pro/codec.pth …
/sgl-workspace/sglang-omni-dev/.venv/lib/python3.12/site-packages/torch/nn/utils/weight_norm.py:144: FutureWarning: `torch.nn.utils.weight_norm` is deprecated in favor of `torch.nn.utils.parametrizations.weight_norm`.
  WeightNorm.apply(module, name, dim)
^[[O2026-03-10 08:06:05,811 sglang_omni.models.fishaudio_s2_pro.pipeline.stages INFO DAC codec loaded in 5.83s
2026-03-10 08:06:05,812 __main__ INFO Creating SGLang engine (compile=True)...
`torch_dtype` is deprecated! Use `dtype` instead!
2026-03-10 08:06:06,112 sglang.srt.server_args INFO Attention backend not specified. Use fa3 backend by default.
2026-03-10 08:06:06,128 sglang.srt.model_executor.model_runner INFO Init torch distributed begin.
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
2026-03-10 08:06:06,680 sglang.srt.model_executor.model_runner INFO Init torch distributed ends. mem usage=0.00 GB
2026-03-10 08:06:06,711 sglang.srt.layers.moe.utils INFO MOE_RUNNER_BACKEND is not initialized, the backend will be automatically selected
2026-03-10 08:06:07,057 sglang.srt.models.registry WARNING Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/sgl-workspace/sglang-omni-dev/.venv/lib/python3.12/site-packages/transformers/__init__.py)
2026-03-10 08:06:07,229 qwen_vl_utils.vision_process INFO set VIDEO_TOTAL_PIXELS: 90316800
{'FishQwen3OmniForCausalLM': <class 'sglang_omni.models.fishaudio_s2_pro.config.S2ProPipelineConfig'>, 'Qwen3OmniMoeForConditionalGeneration': <class 'sglang_omni.models.qwen3_omni.config.Qwen3OmniPipelineConfig'>}
2026-03-10 08:06:07,243 sglang.srt.model_executor.model_runner INFO Load weight begin. avail mem=126.04 GB
Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  50% Completed | 1/2 [00:00<00:00,  1.06it/s]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:01<00:00,  1.23it/s]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:01<00:00,  1.20it/s]

2026-03-10 08:06:09,096 sglang.srt.model_executor.model_runner INFO Load weight end. type=S2ProSGLangTextModel, dtype=torch.bfloat16, avail mem=118.46 GB, mem usage=7.58 GB.
2026-03-10 08:06:09,098 sglang.srt.model_executor.model_runner INFO Using KV cache dtype: torch.bfloat16
2026-03-10 08:06:09,136 sglang.srt.mem_cache.memory_pool INFO KV Cache is allocated. #tokens: 724929, K size: 49.78 GB, V size: 49.78 GB
2026-03-10 08:06:09,136 sglang.srt.model_executor.model_runner_kv_cache_mixin INFO Memory pool end. avail mem=18.81 GB
/sgl-workspace/sglang-omni-dev/.venv/lib/python3.12/site-packages/sglang/srt/utils/common.py:1232: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:206.)
  tensor_data = torch.ByteTensor(
2026-03-10 08:06:09,281 sglang_omni.engines.omni.engine INFO OmniEngine started
2026-03-10 08:06:09,281 __main__ INFO Loaded 50 test samples
2026-03-10 08:06:09,281 __main__ INFO Warmup...
^[[O2026-03-10 08:06:19,000 __main__ INFO Warmup done
2026-03-10 08:06:19,001 __main__ INFO Profiling single requests...
2026-03-10 08:06:20,104 __main__ INFO [1/50] prof-common_voice_en_10119832-common_voice_en_10119840: TTFT=17.7ms TTFB=391.6ms 47 tok 61.1 tok/s 0.769s
2026-03-10 08:06:21,462 __main__ INFO [2/50] prof-common_voice_en_10119832-common_voice_en_10119847: TTFT=32.6ms TTFB=191.4ms 73 tok 60.8 tok/s 1.201s
2026-03-10 08:06:23,837 __main__ INFO [3/50] prof-common_voice_en_103675-common_voice_en_103676: TTFT=29.4ms TTFB=188.6ms 127 tok 61.5 tok/s 2.065s
2026-03-10 08:06:24,997 __main__ INFO [4/50] prof-common_voice_en_103675-common_voice_en_103677: TTFT=18.0ms TTFB=174.4ms 60 tok 61.7 tok/s 0.973s
2026-03-10 08:06:26,470 __main__ INFO [5/50] prof-common_voice_en_10933823-common_voice_en_10933822: TTFT=31.6ms TTFB=190.2ms 82 tok 61.2 tok/s 1.341s
2026-03-10 08:06:27,560 __main__ INFO [6/50] prof-common_voice_en_10933823-common_voice_en_10933825: TTFT=23.5ms TTFB=180.4ms 61 tok 61.4 tok/s 0.993s
2026-03-10 08:06:30,705 __main__ INFO [7/50] prof-common_voice_en_120405-common_voice_en_120402: TTFT=28.8ms TTFB=187.5ms 185 tok 61.5 tok/s 3.009s
2026-03-10 08:06:32,351 __main__ INFO [8/50] prof-common_voice_en_120405-common_voice_en_120406: TTFT=28.9ms TTFB=186.2ms 95 tok 61.3 tok/s 1.551s
2026-03-10 08:06:33,628 __main__ INFO [9/50] prof-common_voice_en_1205005-common_voice_en_1205007: TTFT=34.0ms TTFB=191.3ms 70 tok 60.8 tok/s 1.152s
2026-03-10 08:06:34,758 __main__ INFO [10/50] prof-common_voice_en_1205005-common_voice_en_1205008: TTFT=24.0ms TTFB=180.6ms 64 tok 61.4 tok/s 1.042s
2026-03-10 08:06:36,544 __main__ INFO [11/50] prof-common_voice_en_123125-common_voice_en_123126: TTFT=25.4ms TTFB=182.0ms 102 tok 61.7 tok/s 1.652s
2026-03-10 08:06:38,450 __main__ INFO [12/50] prof-common_voice_en_123125-common_voice_en_123127: TTFT=22.3ms TTFB=181.9ms 112 tok 61.7 tok/s 1.814s
2026-03-10 08:06:40,140 __main__ INFO [13/50] prof-common_voice_en_125386-common_voice_en_125388: TTFT=33.0ms TTFB=189.3ms 96 tok 61.5 tok/s 1.561s
2026-03-10 08:06:41,480 __main__ INFO [14/50] prof-common_voice_en_125386-common_voice_en_125389: TTFT=21.8ms TTFB=180.0ms 77 tok 61.6 tok/s 1.250s
2026-03-10 08:06:42,875 __main__ INFO [15/50] prof-common_voice_en_137148-common_voice_en_137152: TTFT=25.0ms TTFB=181.2ms 78 tok 61.5 tok/s 1.269s
2026-03-10 08:06:44,382 __main__ INFO [16/50] prof-common_voice_en_13900-common_voice_en_13901: TTFT=28.7ms TTFB=186.5ms 85 tok 61.5 tok/s 1.383s
2026-03-10 08:06:45,745 __main__ INFO [17/50] prof-common_voice_en_1416089-common_voice_en_1416090: TTFT=24.2ms TTFB=181.0ms 78 tok 61.9 tok/s 1.259s
2026-03-10 08:06:47,246 __main__ INFO [18/50] prof-common_voice_en_1416089-common_voice_en_1416093: TTFT=21.7ms TTFB=176.6ms 88 tok 62.3 tok/s 1.412s
2026-03-10 08:06:48,671 __main__ INFO [19/50] prof-common_voice_en_15265-common_voice_en_15266: TTFT=23.1ms TTFB=177.4ms 82 tok 62.0 tok/s 1.323s
2026-03-10 08:06:50,048 __main__ INFO [20/50] prof-common_voice_en_15265-common_voice_en_15268: TTFT=17.3ms TTFB=173.9ms 80 tok 62.1 tok/s 1.288s
2026-03-10 08:06:51,101 __main__ INFO [21/50] prof-common_voice_en_153872-common_voice_en_153873: TTFT=28.4ms TTFB=184.1ms 57 tok 61.5 tok/s 0.927s
2026-03-10 08:06:52,568 __main__ INFO [22/50] prof-common_voice_en_153872-common_voice_en_153874: TTFT=21.8ms TTFB=177.2ms 86 tok 62.2 tok/s 1.382s
2026-03-10 08:06:54,796 __main__ INFO [23/50] prof-common_voice_en_155313-common_voice_en_155315: TTFT=18.1ms TTFB=176.5ms 128 tok 60.9 tok/s 2.100s
2026-03-10 08:06:56,306 __main__ INFO [24/50] prof-common_voice_en_15734837-common_voice_en_15734838: TTFT=24.8ms TTFB=189.7ms 85 tok 60.4 tok/s 1.407s
2026-03-10 08:06:56,855 __main__ INFO [25/50] prof-common_voice_en_15735839-common_voice_en_15735837: TTFT=35.4ms TTFB=195.7ms 27 tok 58.5 tok/s 0.462s
2026-03-10 08:06:58,178 __main__ INFO [26/50] prof-common_voice_en_15903802-common_voice_en_15903807: TTFT=31.2ms TTFB=189.7ms 72 tok 60.4 tok/s 1.191s
2026-03-10 08:06:59,430 __main__ INFO [27/50] prof-common_voice_en_15903802-common_voice_en_15903815: TTFT=17.7ms TTFB=177.2ms 71 tok 61.2 tok/s 1.160s
2026-03-10 08:07:00,813 __main__ INFO [28/50] prof-common_voice_en_16666041-common_voice_en_16666040: TTFT=22.4ms TTFB=181.5ms 78 tok 61.0 tok/s 1.279s
2026-03-10 08:07:02,053 __main__ INFO [29/50] prof-common_voice_en_167249-common_voice_en_167246: TTFT=18.2ms TTFB=176.8ms 68 tok 61.3 tok/s 1.110s
2026-03-10 08:07:03,214 __main__ INFO [30/50] prof-common_voice_en_167249-common_voice_en_167247: TTFT=17.7ms TTFB=176.2ms 66 tok 61.6 tok/s 1.071s
2026-03-10 08:07:05,195 __main__ INFO [31/50] prof-common_voice_en_17147545-common_voice_en_17147546: TTFT=18.1ms TTFB=175.4ms 113 tok 61.0 tok/s 1.851s
2026-03-10 08:07:06,492 __main__ INFO [32/50] prof-common_voice_en_17161-common_voice_en_17159: TTFT=24.5ms TTFB=185.1ms 72 tok 60.3 tok/s 1.193s
2026-03-10 08:07:08,400 __main__ INFO [33/50] prof-common_voice_en_17161-common_voice_en_17160: TTFT=22.0ms TTFB=181.1ms 112 tok 60.9 tok/s 1.838s
2026-03-10 08:07:10,428 __main__ INFO [34/50] prof-common_voice_en_17249419-common_voice_en_17249428: TTFT=25.8ms TTFB=181.7ms 117 tok 61.7 tok/s 1.897s
2026-03-10 08:07:11,885 __main__ INFO [35/50] prof-common_voice_en_17255102-common_voice_en_17255101: TTFT=23.0ms TTFB=181.2ms 79 tok 59.4 tok/s 1.329s
2026-03-10 08:07:13,426 __main__ INFO [36/50] prof-common_voice_en_17256676-common_voice_en_17256678: TTFT=25.6ms TTFB=183.1ms 88 tok 61.0 tok/s 1.443s
2026-03-10 08:07:14,533 __main__ INFO [37/50] prof-common_voice_en_17259121-common_voice_en_17259122: TTFT=24.8ms TTFB=182.4ms 62 tok 61.1 tok/s 1.015s
2026-03-10 08:07:16,482 __main__ INFO [38/50] prof-common_voice_en_17263752-common_voice_en_17263750: TTFT=24.6ms TTFB=184.3ms 113 tok 61.3 tok/s 1.845s
2026-03-10 08:07:17,829 __main__ INFO [39/50] prof-common_voice_en_17263752-common_voice_en_17263755: TTFT=17.5ms TTFB=174.2ms 78 tok 60.9 tok/s 1.281s
2026-03-10 08:07:18,930 __main__ INFO [40/50] prof-common_voice_en_17263780-common_voice_en_17263781: TTFT=23.6ms TTFB=179.7ms 64 tok 61.7 tok/s 1.038s
2026-03-10 08:07:20,558 __main__ INFO [41/50] prof-common_voice_en_17263780-common_voice_en_17263782: TTFT=18.0ms TTFB=174.8ms 92 tok 59.8 tok/s 1.538s
2026-03-10 08:07:21,208 __main__ INFO [42/50] prof-common_voice_en_17267923-common_voice_en_17267922: TTFT=33.0ms TTFB=188.2ms 34 tok 60.2 tok/s 0.565s
2026-03-10 08:07:23,719 __main__ INFO [43/50] prof-common_voice_en_17268075-common_voice_en_17268076: TTFT=17.6ms TTFB=174.1ms 150 tok 62.0 tok/s 2.421s
2026-03-10 08:07:24,982 __main__ INFO [44/50] prof-common_voice_en_17271507-common_voice_en_17271509: TTFT=17.9ms TTFB=174.1ms 72 tok 61.9 tok/s 1.162s
2026-03-10 08:07:26,388 __main__ INFO [45/50] prof-common_voice_en_17271507-common_voice_en_17271510: TTFT=21.9ms TTFB=179.5ms 81 tok 61.7 tok/s 1.313s
2026-03-10 08:07:27,648 __main__ INFO [46/50] prof-common_voice_en_17274522-common_voice_en_17274523: TTFT=28.7ms TTFB=184.7ms 71 tok 61.3 tok/s 1.158s
2026-03-10 08:07:28,612 __main__ INFO [47/50] prof-common_voice_en_17274522-common_voice_en_17274525: TTFT=17.7ms TTFB=172.6ms 54 tok 61.8 tok/s 0.873s
2026-03-10 08:07:30,609 __main__ INFO [48/50] prof-common_voice_en_17274533-common_voice_en_17274531: TTFT=18.8ms TTFB=175.5ms 116 tok 61.9 tok/s 1.873s
2026-03-10 08:07:31,986 __main__ INFO [49/50] prof-common_voice_en_17275818-common_voice_en_17275816: TTFT=28.3ms TTFB=182.8ms 79 tok 61.8 tok/s 1.279s
2026-03-10 08:07:33,080 __main__ INFO [50/50] prof-common_voice_en_17275818-common_voice_en_17275817: TTFT=21.8ms TTFB=177.9ms 64 tok 62.0 tok/s 1.032s

================================================================
  Single Request
================================================================
  Requests:        50
  TTFT mean:       24.0ms (median 23.6ms)
  TTFB mean:       185.8ms (median 181.2ms)
  TTFB p95:        191.3ms
  Tok/s (per-req): 61.3 mean, 61.5 median
  Tok/s (agg):     61.3
  Gen tokens:      84 mean, 4191 total
  Latency mean:    1.367s
  RTF mean:        0.3515
================================================================
2026-03-10 08:07:33,081 sglang_omni.engines.omni.engine INFO OmniEngine stopped
2026-03-10 08:07:33,082 __main__ INFO CSV saved to results/s2pro_sglang/results.csv
2026-03-10 08:07:33,083 __main__ INFO Results saved to results/s2pro_sglang/profile_results.json
[rank0]:[W310 08:07:34.820054219 ProcessGroupNCCL.cpp:1524] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
```

## Modifications

<!-- Describe the changes made in this PR. -->

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
