### PR TITLE
Support overlap scheduler for sglang ar

### DIFF
--- a/sglang_omni/engines/omni/engine.py
+++ b/sglang_omni/engines/omni/engine.py
@@ -247,14 +247,22 @@ class OmniEngine(Engine):
                 )
 
                 # While GPU is busy, process previous step's result on CPU
-                if self._last_scheduler_output is not None and self._result_queue:
+                if self._result_queue:
                     self._process_pending_result()
 
                 # Now wait for GPU to finish
                 model_output = await execute_future
             else:
                 # ═══ SYNCHRONOUS PATH ═══
-                # Either CPU device or overlap disabled
+                # Either CPU device or overlap disabled for this step.
+                # Process pending results BEFORE execution to minimize latency.
+                if (
+                    not disable_overlap
+                    and self._last_scheduler_output is not None
+                    and self._result_queue
+                ):
+                    self._process_pending_result()
+
                 if execute_in_thread:
                     loop = asyncio.get_running_loop()
                     model_output = await loop.run_in_executor(
@@ -265,19 +273,9 @@ class OmniEngine(Engine):
                 else:
                     model_output = self.model_runner.execute(scheduler_output)
 
-                # Process previous result after execution (no overlap)
-                if (
-                    not disable_overlap
-                    and self._last_scheduler_output is not None
-                    and self._result_queue
-                ):
-                    self._process_pending_result()
-
-            # 6. Update cache
-            if self.cache_manager is not None:
-                self._update_cache_sync(scheduler_output, model_output)
-
-            # 7. Buffer current result for next step
+            # 6. Buffer current result for next step's CPU processing
+            #    (cache update is deferred to _process_pending_result to keep
+            #     it co-located with scheduler.update for consistency)
             self._result_queue.append(
                 _PendingResult(
                     scheduler_output=scheduler_output,
@@ -285,7 +283,7 @@ class OmniEngine(Engine):
                 )
             )
 
-            # 8. Track last output
+            # 7. Track last output for prefill-detection heuristic
             self._last_scheduler_output = scheduler_output
 
         except Exception as e:

--- a/sglang_omni/engines/omni/factory.py
+++ b/sglang_omni/engines/omni/factory.py
@@ -172,7 +172,11 @@ def create_ar_engine(
         device=device,
     )
 
-    return OmniEngine(scheduler=scheduler, model_runner=model_runner)
+    return OmniEngine(
+        scheduler=scheduler,
+        model_runner=model_runner,
+        enable_overlap=enable_overlap,
+    )
 
 
 def create_sglang_ar_engine(

--- a/sglang_omni/engines/omni/scheduler.py
+++ b/sglang_omni/engines/omni/scheduler.py
@@ -58,7 +58,11 @@ class Scheduler:
         # Result futures (created lazily in get_result)
         self._futures: dict[str, asyncio.Future[SchedulerRequest]] = {}
         self._step_id = 0
-        self._aborted_this_step: set[str] = set()
+
+        # Track aborted request IDs persistently so that overlap-deferred
+        # update() calls still see the abort.  Entries are cleaned up when
+        # the request is fully removed from self.requests.
+        self._aborted_ids: set[str] = set()
         self._stream_queues: dict[str, asyncio.Queue[Any]] = {}
         self._stream_done = object()
 
@@ -82,7 +86,7 @@ class Scheduler:
         request = self.requests.get(request_id)
         if request is None:
             return
-        self._aborted_this_step.add(request_id)
+        self._aborted_ids.add(request_id)
         self._finish_request(request, status=SchedulerStatus.ABORTED)
 
     def fail_request(self, request_id: str, error: Exception) -> None:
@@ -90,7 +94,7 @@ class Scheduler:
         request = self.requests.get(request_id)
         if request is None:
             return
-        self._aborted_this_step.add(request_id)
+        self._aborted_ids.add(request_id)
         self._finish_request(request, status=SchedulerStatus.ABORTED, error=error)
 
     def has_requests(self) -> bool:
@@ -153,7 +157,6 @@ class Scheduler:
             return None
 
         self._step_id += 1
-        self._aborted_this_step.clear()
 
         waiting_reqs = [self.requests[req_id] for req_id in self.waiting]
         running_reqs = [self.requests[req_id] for req_id in self.running]
@@ -189,11 +192,24 @@ class Scheduler:
         """Update state from model output.
 
         Returns list of finished requests.
+
+        Note: In overlap mode, update() for step N-1 may be called after
+        schedule() for step N. Therefore we must guard against requests
+        that have been finished, aborted, or re-scheduled since this
+        SchedulerOutput was created.
         """
         finished: list[SchedulerRequest] = []
 
         for request in scheduler_output.requests:
-            if request.request_id in self._aborted_this_step:
+            # ── overlap-safety: skip requests that are no longer RUNNING ──
+            # In overlap mode, between when this batch was scheduled and now,
+            # the request may have been:
+            #   - aborted by the user  (status == ABORTED)
+            #   - finished by a prior overlapped update  (status == FINISHED)
+            #   - failed by error handling  (status == ABORTED)
+            if request.request_id in self._aborted_ids:
+                continue
+            if request.status != SchedulerStatus.RUNNING:
                 continue
 
             output = model_output.outputs.get(request.request_id)
@@ -243,6 +259,9 @@ class Scheduler:
             self.running.remove(request.request_id)
         if request.request_id in self.waiting:
             self.waiting.remove(request.request_id)
+
+        # Clean up abort tracking (request is fully done now)
+        self._aborted_ids.discard(request.request_id)
 
         # Resolve future if someone is waiting
         if request.request_id in self._futures:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Introduced event_loop_overlap in scheduler.
In this overlapped mode, the asynchrony between GPU computation and CPU processing is leveraged to achieve pipeline parallelism: run_batch() returns immediately after launching the GPU computation (which executes asynchronously), and the CPU then processes the results of the previous batch concurrently while the GPU is still computing. In this way, the CPU processing time is "hidden" (overlapped) by the GPU computation time.

```
Time line:  ─────────────────────────────────────────────────►

normal mode (event_loop_normal):
  [schedule] [GPU: run_batch_N] [process_result_N] [schedule] [GPU: run_batch_N+1] [process_result_N+1]

overlap mode (event_loop_overlap):
  [schedule] [GPU: run_batch_N]                    [GPU: run_batch_N+1]
                                [process_result_N]                      [process_result_N+1]
                                [schedule]                              [schedule]
```

Per testing, the result was correct and the performance improved a lot.

```
(sglang-omni-dev) ➜  sglang-omni-dev git:(support_overlap_scheduler) sgl-omni serve --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct --port 8000 --relay-backend shm
2026-03-14 12:11:53,656 [INFO] qwen_vl_utils.vision_process: set VIDEO_TOTAL_PIXELS: 90316800
{'FishQwen3OmniForCausalLM': <class 'sglang_omni.models.fishaudio_s2_pro.config.S2ProPipelineConfig'>, 'Qwen3OmniMoeForConditionalGeneration': <class 'sglang_omni.models.qwen3_omni.config.Qwen3OmniPipelineConfig'>}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'interleaved', 'mrope_section', 'mrope_interleaved'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'interleaved', 'mrope_section'}
==================== Merged Configuration ====================
model_path: Qwen/Qwen3-Omni-30B-A3B-Instruct
entry_stage: preprocessing
stages:
- name: preprocessing
  executor:
    factory: sglang_omni.models.qwen3_omni.pipeline.stages.create_preprocessing_executor
    args: {}
  get_next: sglang_omni.models.qwen3_omni.pipeline.next_stage.preprocessing_next
  input_handler:
    type: direct
    sources: null
    merge_fn: null
  relay:
    slot_size_mb: 512
    credits: 2
    rank: null
    world_size: null
    device: cpu
  num_workers: 1
- name: image_encoder
  executor:
    factory: sglang_omni.models.qwen3_omni.pipeline.stages.create_image_encoder_executor
    args:
      device: cuda
      dtype: null
  get_next: sglang_omni.models.qwen3_omni.pipeline.next_stage.encoder_next
  input_handler:
    type: direct
    sources: null
    merge_fn: null
  relay:
    slot_size_mb: 512
    credits: 2
    rank: null
    world_size: null
    device: cuda
  num_workers: 1
- name: audio_encoder
  executor:
    factory: sglang_omni.models.qwen3_omni.pipeline.stages.create_audio_encoder_executor
    args:
      device: cuda
      dtype: null
  get_next: sglang_omni.models.qwen3_omni.pipeline.next_stage.encoder_next
  input_handler:
    type: direct
    sources: null
    merge_fn: null
  relay:
    slot_size_mb: 512
    credits: 2
    rank: null
    world_size: null
    device: cuda
  num_workers: 1
- name: mm_aggregate
  executor:
    factory: sglang_omni.models.qwen3_omni.pipeline.stages.create_aggregate_executor
    args: {}
  get_next: sglang_omni.models.qwen3_omni.pipeline.next_stage.aggregate_next
  input_handler:
    type: aggregated
    sources:
    - preprocessing
    - image_encoder
    - audio_encoder
    merge_fn: sglang_omni.models.qwen3_omni.pipeline.merge.merge_for_thinker
  relay:
    slot_size_mb: 512
    credits: 2
    rank: null
    world_size: null
    device: cpu
  num_workers: 1
- name: thinker
  executor:
    factory: sglang_omni.models.qwen3_omni.pipeline.stages.create_sglang_thinker_executor_from_config
    args:
      thinker_max_seq_len: 8192
  get_next: sglang_omni.models.qwen3_omni.pipeline.next_stage.thinker_next
  input_handler:
    type: direct
    sources: null
    merge_fn: null
  relay:
    slot_size_mb: 512
    credits: 2
    rank: null
    world_size: null
    device: cuda
  num_workers: 1
- name: decode
  executor:
    factory: sglang_omni.models.qwen3_omni.pipeline.stages.create_decode_executor
    args: {}
  get_next: sglang_omni.models.qwen3_omni.pipeline.next_stage.decode_next
  input_handler:
    type: direct
    sources: null
    merge_fn: null
  relay:
    slot_size_mb: 512
    credits: 2
    rank: null
    world_size: null
    device: cpu
  num_workers: 1
name: model
relay_backend: shm
fused_stages: []
endpoints:
  scheme: ipc
  base_path: /tmp/sglang_omni
  base_port: 16000
completion_endpoint: null
abort_endpoint: null
config_cls: Qwen3OmniPipelineConfig

==================================================
2026-03-14 12:11:53,892 [INFO] sglang_omni.pipeline.stage.runtime: Initializing shm for stage preprocessing (device=cpu)
The image processor of type `Qwen2VLImageProcessor` is now loaded as a fast processor by default, even if the model checkpoint was saved with a slow processor. This is a breaking change and may produce slightly different outputs. To continue using the slow processor, instantiate this class with `use_fast=False`. Note that this behavior will be extended to all models in a future release.
2026-03-14 12:11:54,545 [INFO] sglang_omni.pipeline.coordinator: Coordinator registered stage: preprocessing at ipc:///tmp/sglang_omni/model/stage_preprocessing.sock
2026-03-14 12:11:54,546 [INFO] sglang_omni.pipeline.stage.runtime: Initializing shm for stage image_encoder (device=cuda:0)
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'interleaved', 'mrope_section', 'mrope_interleaved'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'interleaved', 'mrope_section'}
2026-03-14 12:11:55,950 [INFO] sglang_omni.models.qwen3_omni.components.image_encoder: PatchEmbed optimized: Conv3d(3→1152) replaced with Linear(1536→1152)
2026-03-14 12:11:55,953 [INFO] sglang_omni.pipeline.coordinator: Coordinator registered stage: image_encoder at ipc:///tmp/sglang_omni/model/stage_image_encoder.sock
2026-03-14 12:11:55,953 [INFO] sglang_omni.pipeline.stage.runtime: Initializing shm for stage audio_encoder (device=cuda:0)
2026-03-14 12:11:56,287 [INFO] sglang_omni.pipeline.coordinator: Coordinator registered stage: audio_encoder at ipc:///tmp/sglang_omni/model/stage_audio_encoder.sock
2026-03-14 12:11:56,287 [INFO] sglang_omni.pipeline.stage.runtime: Initializing shm for stage mm_aggregate (device=cpu)
2026-03-14 12:11:56,287 [INFO] sglang_omni.pipeline.coordinator: Coordinator registered stage: mm_aggregate at ipc:///tmp/sglang_omni/model/stage_mm_aggregate.sock
2026-03-14 12:11:56,287 [INFO] sglang_omni.pipeline.stage.runtime: Initializing shm for stage thinker (device=cuda:0)
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'interleaved', 'mrope_section', 'mrope_interleaved'}
Unrecognized keys in `rope_scaling` for 'rope_type'='default': {'interleaved', 'mrope_section'}
`torch_dtype` is deprecated! Use `dtype` instead!
2026-03-14 12:11:56,597 [INFO] sglang.srt.server_args: Attention backend not specified. Use fa3 backend by default.
2026-03-14 12:11:57,065 [INFO] sglang.srt.model_executor.model_runner: Init torch distributed begin.
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
2026-03-14 12:11:57,123 [INFO] sglang.srt.model_executor.model_runner: Init torch distributed ends. mem usage=0.09 GB
2026-03-14 12:11:57,155 [INFO] sglang.srt.layers.moe.utils: MOE_RUNNER_BACKEND is not initialized, the backend will be automatically selected
2026-03-14 12:11:57,721 [WARNING] sglang.srt.models.registry: Ignore import error when loading sglang.srt.models.glmasr: cannot import name 'GlmAsrConfig' from 'transformers' (/sgl-workspace/sglang-omni-dev/.venv/lib/python3.12/site-packages/transformers/__init__.py)
2026-03-14 12:11:57,900 [INFO] sglang.srt.model_executor.model_runner: Load weight begin. avail mem=136.82 GB
2026-03-14 12:11:57,957 [INFO] sglang.srt.utils.common: Multimodal attention backend not set. Use fa3.
2026-03-14 12:11:57,957 [INFO] sglang.srt.utils.common: Using fa3 as multimodal attention backend.
2026-03-14 12:11:58,148 [INFO] sglang.srt.model_loader.weight_utils: Found local HF snapshot for Qwen/Qwen3-Omni-30B-A3B-Instruct at /root/.cache/huggingface/hub/models--Qwen--Qwen3-Omni-30B-A3B-Instruct/snapshots/26291f793822fb6be9555850f06dfe95f2d7e695; skipping download.
Loading safetensors checkpoint shards:   0% Completed | 0/15 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:   7% Completed | 1/15 [00:00<00:13,  1.06it/s]
Loading safetensors checkpoint shards:  13% Completed | 2/15 [00:02<00:13,  1.04s/it]
Loading safetensors checkpoint shards:  20% Completed | 3/15 [00:03<00:13,  1.13s/it]
Loading safetensors checkpoint shards:  27% Completed | 4/15 [00:04<00:12,  1.10s/it]
Loading safetensors checkpoint shards:  33% Completed | 5/15 [00:05<00:10,  1.04s/it]
Loading safetensors checkpoint shards:  40% Completed | 6/15 [00:06<00:09,  1.01s/it]
Loading safetensors checkpoint shards:  47% Completed | 7/15 [00:07<00:07,  1.01it/s]
Loading safetensors checkpoint shards:  53% Completed | 8/15 [00:08<00:06,  1.03it/s]
Loading safetensors checkpoint shards:  67% Completed | 10/15 [00:09<00:03,  1.29it/s]
Loading safetensors checkpoint shards:  73% Completed | 11/15 [00:10<00:03,  1.09it/s]
Loading safetensors checkpoint shards:  80% Completed | 12/15 [00:11<00:02,  1.01it/s]
Loading safetensors checkpoint shards:  87% Completed | 13/15 [00:12<00:01,  1.09it/s]
Loading safetensors checkpoint shards:  93% Completed | 14/15 [00:13<00:00,  1.09it/s]
Loading safetensors checkpoint shards: 100% Completed | 15/15 [00:13<00:00,  1.43it/s]
Loading safetensors checkpoint shards: 100% Completed | 15/15 [00:13<00:00,  1.11it/s]

2026-03-14 12:12:11,798 [INFO] sglang.srt.model_executor.model_runner: Load weight end. type=Qwen3OmniMoeForConditionalGeneration, dtype=torch.bfloat16, avail mem=76.22 GB, mem usage=60.61 GB.
2026-03-14 12:12:11,801 [INFO] sglang.srt.model_executor.model_runner: Using KV cache dtype: torch.bfloat16
2026-03-14 12:12:11,817 [INFO] sglang.srt.mem_cache.memory_pool: KV Cache is allocated. #tokens: 384140, K size: 17.58 GB, V size: 17.58 GB
2026-03-14 12:12:11,817 [INFO] sglang.srt.model_executor.model_runner_kv_cache_mixin: Memory pool end. avail mem=40.97 GB
/sgl-workspace/sglang-omni-dev/.venv/lib/python3.12/site-packages/sglang/srt/utils/common.py:1232: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:206.)
  tensor_data = torch.ByteTensor(
2026-03-14 12:12:11,935 [INFO] sglang_omni.pipeline.coordinator: Coordinator registered stage: thinker at ipc:///tmp/sglang_omni/model/stage_thinker.sock
2026-03-14 12:12:11,936 [INFO] sglang_omni.pipeline.stage.runtime: Initializing shm for stage decode (device=cpu)
2026-03-14 12:12:12,354 [INFO] sglang_omni.pipeline.coordinator: Coordinator registered stage: decode at ipc:///tmp/sglang_omni/model/stage_decode.sock
2026-03-14 12:12:12,456 [INFO] sglang_omni.pipeline.control_plane: Coordinator control plane started
2026-03-14 12:12:12,456 [INFO] sglang_omni.pipeline.coordinator: Coordinator started
2026-03-14 12:12:12,456 [INFO] sglang_omni.serve.launcher: Pipeline 'model' started (6 stages)
INFO:     Started server process [39108]
INFO:     Waiting for application startup.
2026-03-14 12:12:12,492 [INFO] sglang_omni.pipeline.control_plane: Stage preprocessing control plane started
2026-03-14 12:12:12,493 [INFO] sglang_omni.pipeline.stage.runtime: Stage preprocessing started
2026-03-14 12:12:12,493 [INFO] sglang_omni.pipeline.control_plane: Stage image_encoder control plane started
2026-03-14 12:12:12,493 [INFO] sglang_omni.pipeline.stage.runtime: Stage image_encoder started
2026-03-14 12:12:12,494 [INFO] sglang_omni.pipeline.control_plane: Stage audio_encoder control plane started
2026-03-14 12:12:12,494 [INFO] sglang_omni.pipeline.stage.runtime: Stage audio_encoder started
2026-03-14 12:12:12,494 [INFO] sglang_omni.pipeline.control_plane: Stage mm_aggregate control plane started
2026-03-14 12:12:12,494 [INFO] sglang_omni.pipeline.stage.runtime: Stage mm_aggregate started
2026-03-14 12:12:12,494 [INFO] sglang_omni.pipeline.control_plane: Stage thinker control plane started
2026-03-14 12:12:12,494 [INFO] sglang_omni.pipeline.stage.runtime: Stage thinker started
2026-03-14 12:12:12,494 [INFO] sglang_omni.pipeline.control_plane: Stage decode control plane started
2026-03-14 12:12:12,494 [INFO] sglang_omni.pipeline.stage.runtime: Stage decode started
2026-03-14 12:12:12,495 [INFO] sglang_omni.pipeline.worker.runtime: Worker started for stage preprocessing
2026-03-14 12:12:12,495 [INFO] sglang_omni.engines.omni.engine: OmniEngine started (overlap=False)
2026-03-14 12:12:12,495 [INFO] sglang_omni.pipeline.worker.runtime: Worker started for stage image_encoder
2026-03-14 12:12:12,495 [INFO] sglang_omni.engines.omni.engine: OmniEngine started (overlap=False)
2026-03-14 12:12:12,495 [INFO] sglang_omni.pipeline.worker.runtime: Worker started for stage audio_encoder
2026-03-14 12:12:12,495 [INFO] sglang_omni.pipeline.worker.runtime: Worker started for stage mm_aggregate
2026-03-14 12:12:12,495 [INFO] sglang_omni.engines.omni.engine: OmniEngine started (overlap=True)
2026-03-14 12:12:12,495 [INFO] sglang_omni.pipeline.worker.runtime: Worker started for stage thinker
2026-03-14 12:12:12,495 [INFO] sglang_omni.pipeline.worker.runtime: Worker started for stage decode
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
2026-03-14 12:12:54,542 [WARNING] sglang.srt.layers.moe.fused_moe_triton.fused_moe_triton_config: Config file not found at /sgl-workspace/sglang-omni-dev/.venv/lib/python3.12/site-packages/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=128,N=768,device_name=NVIDIA_H200.json. Fallback to triton version 3.2.0 and use MoE kernel config from /sgl-workspace/sglang-omni-dev/.venv/lib/python3.12/site-packages/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_2_0/E=128,N=768,device_name=NVIDIA_H200.json. Performance might be sub-optimal!
2026-03-14 12:12:54,543 [WARNING] sglang.srt.layers.moe.fused_moe_triton.fused_moe_triton_config: Using MoE kernel config with down_moe=False. Performance might be sub-optimal! Config file not found at /sgl-workspace/sglang-omni-dev/.venv/lib/python3.12/site-packages/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_5_1/E=128,N=768,device_name=NVIDIA_H200_down.json, you can create them with https://github.com/sgl-project/sglang/tree/main/benchmark/kernels/fused_moe_triton
INFO:     127.0.0.1:33362 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:55796 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:     127.0.0.1:39146 - "POST /v1/chat/completions HTTP/1.1" 200 OK
^CINFO:     Shutting down
INFO:     Waiting for application shutdown.
INFO:     Application shutdown complete.
INFO:     Finished server process [39108]
```

```
(sglang-omni-dev) ➜  sglang-omni-dev git:(support_overlap_scheduler) curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
  "model": "qwen3-omni",
  "messages": [{"role": "user", "content": "Hello, how are you?"}],
  "max_tokens": 64,
  "temperature": 0.0,
  "modalities": ["text", "audio"],
  "stream": false
}'
{"id":"chatcmpl-d888c623-317c-453f-ae6c-01780e903c7b","object":"chat.completion","created":1773490404,"model":"qwen3-omni","choices":[{"index":0,"message":{"role":"assistant","content":"Hello! I'm doing well, thank you. How can I assist you today?"},"finish_reason":"stop"}],"usage":null}#
```

## Modifications

<!-- Describe the changes made in this PR. -->

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
