### PR TITLE
feat: token-level streaming between pipeline stages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ Thumbs.db
 .ruff_cache/
 uv.lock
 results/
+.humanize/
+.humanize/

--- a/sglang_omni/config/compiler.py
+++ b/sglang_omni/config/compiler.py
@@ -35,6 +35,7 @@ def compile_pipeline(config: PipelineConfig) -> tuple[Coordinator, list[Stage]]:
         completion_endpoint=endpoints["completion"],
         abort_endpoint=endpoints["abort"],
         entry_stage=entry_stage,
+        terminal_stages=config.terminal_stages or None,
     )
 
     # 5. create each stage in order
@@ -49,6 +50,21 @@ def compile_pipeline(config: PipelineConfig) -> tuple[Coordinator, list[Stage]]:
         )
         coordinator.register_stage(stage.name, stage.control_plane.recv_endpoint)
         stages.append(stage)
+
+    # 6. wire stream targets
+    stage_map = {stage.name: stage for stage in stages}
+    cfg_map = {s.name: s for s in stages_cfg}
+    for stage_cfg in stages_cfg:
+        stage = stage_map.get(stage_cfg.name)
+        if stage is None:
+            continue
+        _wire_stream_targets(
+            stage,
+            stage_cfg,
+            stage_map,
+            gpu_placement=config.gpu_placement,
+            cfg_map=cfg_map,
+        )
 
     return coordinator, stages
 
@@ -92,6 +108,14 @@ def _compile_stage(
         and "model_path" not in stage_cfg.executor.args
     ):
         stage_cfg.executor.args["model_path"] = global_cfg.model_path
+
+    # Inject gpu_id from gpu_placement map
+    if (
+        "gpu_id" in inspect.signature(factory).parameters
+        and "gpu_id" not in stage_cfg.executor.args
+    ):
+        gpu_id = global_cfg.gpu_placement.get(stage_cfg.name, 0)
+        stage_cfg.executor.args["gpu_id"] = gpu_id
 
     for _ in range(stage_cfg.num_workers):
         executor = factory(**stage_cfg.executor.args)
@@ -224,3 +248,111 @@ def _dedupe_list(items: list[str]) -> list[str]:
         seen.add(item)
         result.append(item)
     return result
+
+
+def _wire_stream_targets(
+    sender_stage: Stage,
+    sender_cfg: StageConfig,
+    stage_map: dict[str, Stage],
+    *,
+    gpu_placement: dict[str, int] | None = None,
+    cfg_map: dict[str, StageConfig] | None = None,
+) -> None:
+    """Wire stream_to targets between stages.
+
+    For each stream_to entry on the sender:
+    1. Set worker._stream_targets and worker._bootstrap_targets
+    2. Detect same-GPU targets and set worker._same_gpu_targets (CUDA IPC)
+    3. Create StreamQueue on receiver stages
+    4. Set executor._stream_queue on receiver executors
+    5. Wire set_stream_fn on sender executors
+    """
+    from sglang_omni.pipeline.stage.stream_queue import StreamQueue
+
+    targets = sender_cfg.stream_to
+    if not targets:
+        return
+
+    # Collect target stage names and bootstrap targets
+    all_targets = [t.to_stage for t in targets]
+    bootstrap_targets = {t.to_stage for t in targets if t.bootstrap}
+
+    # Detect same-GPU targets for CUDA IPC zero-copy
+    same_gpu_targets = _detect_same_gpu_targets(
+        sender_cfg,
+        targets,
+        gpu_placement=gpu_placement,
+        cfg_map=cfg_map,
+    )
+
+    # Set stream targets on sender workers and wire stream_fn.
+    for worker in sender_stage.workers:
+        worker._stream_targets = all_targets
+        worker._bootstrap_targets = bootstrap_targets
+        worker._same_gpu_targets = same_gpu_targets
+        # Wire stream_fn: executor calls worker._enqueue_stream
+        set_fn = getattr(worker.executor, "set_stream_fn", None)
+        if callable(set_fn):
+            set_fn(worker._enqueue_stream)
+
+    # Set up receiver side: create StreamQueue on receiver stages
+    for target_cfg in targets:
+        receiver_stage = stage_map.get(target_cfg.to_stage)
+        if receiver_stage is None:
+            continue
+
+        # Create a shared StreamQueue for the receiver stage if not already present
+        if receiver_stage._stream_queue is None:
+            queue = StreamQueue(max_pending=4096)
+            receiver_stage._stream_queue = queue
+        else:
+            queue = receiver_stage._stream_queue
+
+        # Wire stream queue to receiver executors
+        for worker in receiver_stage.workers:
+            worker.executor._stream_queue = queue
+            # Wire feedback mailbox for executors that support it
+            set_feedback_mailbox = getattr(
+                worker.executor, "set_feedback_mailbox", None
+            )
+            if callable(set_feedback_mailbox):
+                set_feedback_mailbox(queue)
+
+
+def _detect_same_gpu_targets(
+    sender_cfg: StageConfig,
+    targets: list,
+    *,
+    gpu_placement: dict[str, int] | None = None,
+    cfg_map: dict[str, StageConfig] | None = None,
+) -> set[str]:
+    """Return the set of target stage names that share a GPU with the sender.
+
+    Same-GPU streaming uses CUDA IPC (zero data copy) instead of the relay.
+    Both the sender and receiver must use CUDA relays and be placed on the
+    same GPU (per ``gpu_placement``) for this to activate.
+    """
+    if not gpu_placement or not cfg_map:
+        return set()
+
+    sender_gpu = gpu_placement.get(sender_cfg.name)
+    if sender_gpu is None:
+        return set()
+
+    # Sender must have a CUDA relay
+    if sender_cfg.relay.device == "cpu":
+        return set()
+
+    same: set[str] = set()
+    for target in targets:
+        receiver_cfg = cfg_map.get(target.to_stage)
+        if receiver_cfg is None:
+            continue
+        # Receiver must also have a CUDA relay
+        if receiver_cfg.relay.device == "cpu":
+            continue
+        receiver_gpu = gpu_placement.get(target.to_stage)
+        if receiver_gpu is not None and receiver_gpu == sender_gpu:
+            same.add(target.to_stage)
+
+    return same

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -39,6 +39,14 @@ class RelayConfig(BaseModel):
     device: str = "cpu"
 
 
+class StreamTargetConfig(BaseModel):
+    """Streaming target for inter-stage streaming data transfer."""
+
+    model_config = ConfigDict(extra="forbid")
+    to_stage: str
+    bootstrap: bool = True
+
+
 class StageConfig(BaseModel):
     """Single pipeline stage configuration."""
 
@@ -49,6 +57,7 @@ class StageConfig(BaseModel):
     input_handler: InputHandlerConfig = Field(default_factory=InputHandlerConfig)
     relay: RelayConfig = Field(default_factory=RelayConfig)
     num_workers: int = 1
+    stream_to: list[StreamTargetConfig] = Field(default_factory=list)
 
 
 class EndpointsConfig(BaseModel):
@@ -70,9 +79,11 @@ class PipelineConfig(BaseModel):
     entry_stage: str
     stages: list[StageConfig]
     name: str = "model"  # default for all
+    terminal_stages: list[str] = Field(default_factory=list)
     relay_backend: Literal["shm", "nccl", "nixl", "mooncake"] = "shm"
     fused_stages: list[list[str]] = Field(default_factory=list)
     endpoints: EndpointsConfig = Field(default_factory=EndpointsConfig)
+    gpu_placement: dict[str, int] = Field(default_factory=dict)
     completion_endpoint: str | None = None
     abort_endpoint: str | None = None
     config_cls: str | None = None
@@ -120,6 +131,15 @@ class PipelineConfig(BaseModel):
                 if unknown:
                     raise ValueError(
                         f"Stage {stage_cfg.name!r} has unknown sources: {sorted(unknown)}"
+                    )
+
+        # Validate stream_to targets
+        for stage_cfg in self.stages:
+            for st in stage_cfg.stream_to:
+                if st.to_stage not in stage_names:
+                    raise ValueError(
+                        f"Stage {stage_cfg.name!r} stream_to references "
+                        f"unknown stage {st.to_stage!r}"
                     )
 
     def _validate_fusion(self) -> None:
@@ -192,6 +212,7 @@ class PipelineConfig(BaseModel):
                     input_handler=first.input_handler,
                     relay=first.relay,
                     num_workers=first.num_workers,
+                    stream_to=first.stream_to,
                 )
                 stages_out.append(fused_stage)
             else:

--- a/sglang_omni/executors/__init__.py
+++ b/sglang_omni/executors/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Executors adapt preprocessing and engines to the pipeline worker interface."""
 
+from sglang_omni.executors.direct_model_executor import DirectModelExecutor
 from sglang_omni.executors.engine_executor import EngineExecutor
 from sglang_omni.executors.interface import Executor
 from sglang_omni.executors.preprocessing_executor import PreprocessingExecutor
@@ -9,4 +10,5 @@ __all__ = [
     "Executor",
     "PreprocessingExecutor",
     "EngineExecutor",
+    "DirectModelExecutor",
 ]

--- a/sglang_omni/executors/engine_executor.py
+++ b/sglang_omni/executors/engine_executor.py
@@ -30,6 +30,12 @@ class EngineExecutor(Executor):
         self._request_builder = request_builder
         self._result_builder = result_builder or self._default_result_builder
         self._stream_builder = stream_builder or self._default_stream_builder
+        self._stream_queue: Any | None = (
+            None  # Set by compiler for stream-receiving stages
+        )
+        self._stream_fn: Callable | None = (
+            None  # Set by compiler for stream-sending stages
+        )
         self._done: asyncio.Queue[str] = asyncio.Queue()
         self._tasks: dict[str, asyncio.Task[StagePayload]] = {}
         self._payloads: dict[str, StagePayload] = {}
@@ -39,6 +45,18 @@ class EngineExecutor(Executor):
         request_id = payload.request_id
         if request_id in self._aborted:
             return
+
+        # Pre-fetch chunks from stream queue (async) before calling sync request_builder
+        if self._stream_queue is not None:
+            chunks = []
+            while True:
+                item = await self._stream_queue.get(request_id)
+                if item is None:  # EOS
+                    break
+                chunks.append(item)
+            payload.prefetched_chunks = chunks
+        else:
+            payload.prefetched_chunks = None
 
         self._payloads[request_id] = payload
         engine_input = self._request_builder(payload)
@@ -57,6 +75,15 @@ class EngineExecutor(Executor):
         stop = getattr(self._engine, "stop", None)
         if callable(stop):
             await stop()
+
+    def set_stream_fn(self, fn) -> None:
+        """Set the streaming output callback."""
+        self._stream_fn = fn
+
+    def set_feedback_mailbox(self, mailbox: Any) -> None:
+        """Attach a feedback mailbox to engines that support WAITING_FEEDBACK."""
+        if hasattr(self._engine, "_feedback_mailbox"):
+            self._engine._feedback_mailbox = mailbox
 
     async def get_result(self) -> StagePayload:
         while True:
@@ -96,6 +123,7 @@ class EngineExecutor(Executor):
     async def _await_result(self, payload: StagePayload) -> StagePayload:
         request_id = payload.request_id
         result = await self._engine.get_result(request_id)
+
         output = self._result_builder(payload, result)
         if not isinstance(output, StagePayload):
             output = StagePayload(

--- a/sglang_omni/executors/interface.py
+++ b/sglang_omni/executors/interface.py
@@ -36,3 +36,7 @@ class Executor(ABC):
     async def abort(self, request_id: str) -> None:
         """Abort a request if possible."""
         ...
+
+    def set_stream_fn(self, fn) -> None:
+        """Set the streaming output callback. Sync, non-blocking."""
+        pass  # Default no-op; streaming executors override

--- a/sglang_omni/pipeline/coordinator.py
+++ b/sglang_omni/pipeline/coordinator.py
@@ -37,6 +37,7 @@ class Coordinator:
         completion_endpoint: str,
         abort_endpoint: str,
         entry_stage: str,
+        terminal_stages: list[str] | None = None,
     ):
         """Initialize coordinator.
 
@@ -44,8 +45,14 @@ class Coordinator:
             completion_endpoint: ZMQ endpoint to receive completions
             abort_endpoint: ZMQ endpoint for abort broadcasts
             entry_stage: Name of the entry stage for new requests
+            terminal_stages: Terminal stage names. When multiple are given,
+                the coordinator waits for all to complete before resolving.
         """
         self.entry_stage = entry_stage
+        self._terminal_stages: set[str] = (
+            set(terminal_stages) if terminal_stages else set()
+        )
+        self._partial_results: dict[str, dict[str, Any]] = {}
 
         # Control plane
         self.control_plane = CoordinatorControlPlane(
@@ -118,15 +125,22 @@ class Coordinator:
 
         await self._submit_request(request_id, request)
 
+        completed_stages: set[str] = set()
         try:
             while True:
                 msg = await queue.get()
                 if isinstance(msg, CompleteMessage):
-                    if msg.success:
-                        yield msg
+                    if not msg.success:
+                        raise RuntimeError(msg.error or "Unknown error")
+                    yield msg
+                    completed_stages.add(msg.from_stage)
+                    if (
+                        not self._terminal_stages
+                        or completed_stages >= self._terminal_stages
+                    ):
                         return
-                    raise RuntimeError(msg.error or "Unknown error")
-                yield msg
+                else:
+                    yield msg
         finally:
             self._stream_queues.pop(request_id, None)
             self._completion_futures.pop(request_id, None)
@@ -173,7 +187,12 @@ class Coordinator:
         # Update state
         self._requests[request_id].state = RequestState.RUNNING
 
-        logger.debug("Coordinator submitted req=%s to %s", request_id, self.entry_stage)
+        logger.info(
+            "Coordinator submitted req=%s to %s at %s",
+            request_id,
+            self.entry_stage,
+            entry_info.control_endpoint,
+        )
 
     async def abort(self, request_id: str) -> bool:
         """Abort a request.
@@ -255,24 +274,52 @@ class Coordinator:
 
         info = self._requests[request_id]
 
-        if msg.success:
-            info.state = RequestState.COMPLETED
-            info.result = msg.result
-        else:
+        # Fail-fast: any terminal failure -> fail entire request
+        if not msg.success:
             info.state = RequestState.FAILED
             info.error = msg.error
+            self._partial_results.pop(request_id, None)
+            if request_id in self._completion_futures:
+                future = self._completion_futures[request_id]
+                if not future.done():
+                    future.set_exception(RuntimeError(msg.error or "Unknown error"))
+            if request_id in self._stream_queues:
+                await self._stream_queues[request_id].put(msg)
+            return
 
-        # Resolve future (if not already done, e.g., by abort)
+        # Single terminal (original behavior) or no terminal_stages configured
+        if len(self._terminal_stages) <= 1:
+            info.state = RequestState.COMPLETED
+            info.result = msg.result
+            if request_id in self._completion_futures:
+                future = self._completion_futures[request_id]
+                if not future.done():
+                    future.set_result(msg.result)
+            if request_id in self._stream_queues:
+                await self._stream_queues[request_id].put(msg)
+            return
+
+        # Multi-terminal: collect partial results
+        partials = self._partial_results.setdefault(request_id, {})
+        partials[msg.from_stage] = msg.result
+
+        # Forward stream completion per-stage
+        if request_id in self._stream_queues:
+            await self._stream_queues[request_id].put(msg)
+
+        if len(partials) < len(self._terminal_stages):
+            return  # still waiting
+
+        # All terminal stages done -> merge and resolve
+        merged = dict(partials)
+        self._partial_results.pop(request_id)
+        info.state = RequestState.COMPLETED
+        info.result = merged
+
         if request_id in self._completion_futures:
             future = self._completion_futures[request_id]
             if not future.done():
-                if msg.success:
-                    future.set_result(msg.result)
-                else:
-                    future.set_exception(RuntimeError(msg.error or "Unknown error"))
-
-        if request_id in self._stream_queues:
-            await self._stream_queues[request_id].put(msg)
+                future.set_result(merged)
 
     async def _handle_stream(self, msg: StreamMessage) -> None:
         """Handle a stream chunk from a stage."""
@@ -307,6 +354,7 @@ async def run_coordinator(
     abort_endpoint: str,
     entry_stage: str,
     stages: dict[str, str],  # name -> endpoint
+    terminal_stages: list[str] | None = None,
 ) -> Coordinator:
     """Create and start a coordinator.
 
@@ -315,6 +363,7 @@ async def run_coordinator(
         abort_endpoint: ZMQ endpoint for abort broadcasts
         entry_stage: Name of the entry stage
         stages: Dict of stage_name -> stage_endpoint
+        terminal_stages: Optional list of terminal stage names for multi-terminal merge
 
     Returns:
         Started Coordinator instance
@@ -323,6 +372,7 @@ async def run_coordinator(
         completion_endpoint=completion_endpoint,
         abort_endpoint=abort_endpoint,
         entry_stage=entry_stage,
+        terminal_stages=terminal_stages,
     )
 
     # Register stages

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -1,0 +1,467 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Multi-process pipeline runner.
+
+Spawns each pipeline stage in its own OS process. Main process runs only
+the Coordinator. Stages communicate via ZMQ (control plane) and relay
+(data plane) — same protocols as single-process, now cross-process.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import multiprocessing
+from typing import Any
+
+from sglang_omni.config.compiler import (
+    _allocate_endpoints,
+    _build_relay_config,
+    _create_input_handler,
+    _wrap_get_next,
+)
+from sglang_omni.config.schema import PipelineConfig, StageConfig
+from sglang_omni.pipeline import Coordinator, Stage, Worker
+from sglang_omni.utils import import_string
+
+logger = logging.getLogger(__name__)
+
+
+def _noop_executor_factory(model_path: str = "", **kwargs):
+    """No-op executor factory for testing."""
+    from sglang_omni.executors import PreprocessingExecutor
+
+    return PreprocessingExecutor(lambda payload: payload)
+
+
+def _noop_get_next(request_id: str, output: Any) -> None:
+    """No-op get_next for testing — terminal stage."""
+    return None
+
+
+def _build_stage_process_config(
+    *,
+    pipeline_config: PipelineConfig,
+    stage_name: str,
+    stage_endpoints: dict[str, str],
+    all_endpoints: dict[str, str],
+    name_map: dict[str, str],
+) -> dict[str, Any]:
+    """Build a picklable config dict for a stage subprocess."""
+    return {
+        "pipeline_config": pipeline_config.model_dump(),
+        "stage_name": stage_name,
+        "stage_endpoints": stage_endpoints,
+        "all_endpoints": all_endpoints,
+        "name_map": name_map,
+    }
+
+
+def _resolve_relay_config(
+    stage_cfg: StageConfig, global_cfg: PipelineConfig
+) -> dict[str, Any]:
+    """Build relay config with gpu_id from gpu_placement (not relay.device).
+
+    The base _build_relay_config uses relay.device to determine gpu_id,
+    which defaults to 0 for "cuda". For multi-process deployment, we
+    override with the actual gpu_placement value.
+    """
+    relay_config = _build_relay_config(stage_cfg, global_cfg)
+
+    # Override gpu_id from gpu_placement when relay is on CUDA
+    if stage_cfg.relay.device != "cpu":
+        placement_gpu = global_cfg.gpu_placement.get(stage_cfg.name)
+        if placement_gpu is not None:
+            relay_config["gpu_id"] = placement_gpu
+
+    return relay_config
+
+
+def _compile_stage_local(
+    stage_cfg: StageConfig,
+    global_cfg: PipelineConfig,
+    stage_endpoints: dict[str, str],
+    all_endpoints: dict[str, str],
+    name_map: dict[str, str],
+) -> Stage:
+    """Compile a single stage in the current process.
+
+    Same logic as compiler._compile_stage but uses _resolve_relay_config
+    for correct GPU placement in multi-process mode.
+    """
+    factory = import_string(stage_cfg.executor.factory)
+    if not callable(factory):
+        raise TypeError(f"Executor factory not callable: {stage_cfg.executor.factory}")
+
+    get_next = import_string(stage_cfg.get_next)
+    if not callable(get_next):
+        raise TypeError(f"get_next not callable: {stage_cfg.get_next}")
+    get_next = _wrap_get_next(get_next, name_map)
+
+    input_handler = _create_input_handler(stage_cfg.input_handler, name_map=name_map)
+
+    stage = Stage(
+        name=stage_cfg.name,
+        get_next=get_next,
+        recv_endpoint=stage_endpoints[stage_cfg.name],
+        coordinator_endpoint=all_endpoints["completion"],
+        abort_endpoint=all_endpoints["abort"],
+        endpoints=stage_endpoints,
+        input_handler=input_handler,
+        relay_config=_resolve_relay_config(stage_cfg, global_cfg),
+    )
+
+    # Inject model_path and gpu_id into executor args (same as compiler)
+    if (
+        "model_path" in inspect.signature(factory).parameters
+        and "model_path" not in stage_cfg.executor.args
+    ):
+        stage_cfg.executor.args["model_path"] = global_cfg.model_path
+
+    if (
+        "gpu_id" in inspect.signature(factory).parameters
+        and "gpu_id" not in stage_cfg.executor.args
+    ):
+        gpu_id = global_cfg.gpu_placement.get(stage_cfg.name, 0)
+        stage_cfg.executor.args["gpu_id"] = gpu_id
+
+    for _ in range(stage_cfg.num_workers):
+        executor = factory(**stage_cfg.executor.args)
+        stage.add_worker(Worker(executor=executor))
+
+    return stage
+
+
+def _wire_stream_targets_local(
+    stage: Stage,
+    stage_cfg: StageConfig,
+    all_stages_cfg: list[StageConfig],
+    stage_endpoints: dict[str, str],
+    *,
+    gpu_placement: dict[str, int] | None = None,
+) -> None:
+    """Wire stream_to targets for a single stage (sender + receiver sides).
+
+    Uses the same StreamQueue-based pattern as compiler._wire_stream_targets
+    but works with only the local Stage and config for all stages.
+    """
+    from sglang_omni.config.compiler import _detect_same_gpu_targets
+    from sglang_omni.pipeline.stage.stream_queue import StreamQueue
+
+    # --- Sender side: set stream targets and wire stream_fn ---
+    targets = stage_cfg.stream_to
+    if targets:
+        all_targets = [t.to_stage for t in targets]
+        bootstrap_targets = {t.to_stage for t in targets if t.bootstrap}
+
+        cfg_map = {s.name: s for s in all_stages_cfg}
+        same_gpu_targets = _detect_same_gpu_targets(
+            stage_cfg,
+            targets,
+            gpu_placement=gpu_placement,
+            cfg_map=cfg_map,
+        )
+
+        for worker in stage.workers:
+            worker._stream_targets = all_targets
+            worker._bootstrap_targets = bootstrap_targets
+            worker._same_gpu_targets = same_gpu_targets
+            # Wire stream_fn: executor calls worker._enqueue_stream
+            set_fn = getattr(worker.executor, "set_stream_fn", None)
+            if callable(set_fn):
+                set_fn(worker._enqueue_stream)
+
+    # --- Receiver side: other stages stream to this stage ---
+    is_receiver = any(
+        any(t.to_stage == stage.name for t in other_cfg.stream_to)
+        for other_cfg in all_stages_cfg
+    )
+
+    if is_receiver:
+        if stage._stream_queue is None:
+            queue = StreamQueue(max_pending=4096)
+            stage._stream_queue = queue
+        else:
+            queue = stage._stream_queue
+
+        for worker in stage.workers:
+            worker.executor._stream_queue = queue
+            set_feedback_mailbox = getattr(
+                worker.executor, "set_feedback_mailbox", None
+            )
+            if callable(set_feedback_mailbox):
+                set_feedback_mailbox(queue)
+
+
+def _stage_process_entry(
+    config_dict: dict[str, Any],
+    ready_event: multiprocessing.Event,
+) -> None:
+    """Subprocess entrypoint: reconstruct and run a single Stage.
+
+    1. Deserialize PipelineConfig from dict
+    2. Find this stage's StageConfig
+    3. Create Stage (relay, executor, workers)
+    4. Wire chunk transfers (sender + receiver)
+    5. Signal ready
+    6. Run stage.run() until shutdown
+    """
+    import logging
+    import sys
+
+    logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+    log = logging.getLogger(f"stage.{config_dict['stage_name']}")
+
+    try:
+        stage_name = config_dict["stage_name"]
+        stage_endpoints = config_dict["stage_endpoints"]
+        all_endpoints = config_dict["all_endpoints"]
+        name_map = config_dict["name_map"]
+
+        # Reconstruct PipelineConfig from serialized dict
+        pipeline_config = PipelineConfig(**config_dict["pipeline_config"])
+
+        # Apply fusion to get actual stage configs
+        stages_cfg, fused_name_map, _ = pipeline_config.apply_fusion()
+        name_map.update(fused_name_map)
+
+        # Find this stage's config
+        stage_cfg = next((s for s in stages_cfg if s.name == stage_name), None)
+        if stage_cfg is None:
+            log.error("Stage %s not found in config", stage_name)
+            return
+
+        log.info("Compiling stage %s...", stage_name)
+
+        # Compile stage (creates relay, loads executor/model, adds workers)
+        stage = _compile_stage_local(
+            stage_cfg, pipeline_config, stage_endpoints, all_endpoints, name_map
+        )
+
+        # Wire stream targets
+        _wire_stream_targets_local(
+            stage,
+            stage_cfg,
+            stages_cfg,
+            stage_endpoints,
+            gpu_placement=pipeline_config.gpu_placement,
+        )
+
+        # Start the stage (opens connections, binds ZMQ sockets) before
+        # signalling ready.  stage.run() calls start() internally but it
+        # is idempotent, so this is safe.
+        async def _start_and_run() -> None:
+            await stage.start()
+            log.info("Stage %s ready", stage_name)
+            ready_event.set()
+            await stage.run()
+
+        asyncio.run(_start_and_run())
+
+    except Exception:
+        import traceback
+
+        log.error("Stage process failed:\n%s", traceback.format_exc())
+        # Exit with non-zero code so the parent monitor can detect the failure.
+        sys.exit(1)
+
+
+class MultiProcessPipelineRunner:
+    """Run each pipeline stage in its own OS process.
+
+    Main process runs only the Coordinator. Each stage is spawned as a
+    separate multiprocessing.Process that reconstructs its Stage from
+    serialized PipelineConfig.
+    """
+
+    def __init__(self, config: PipelineConfig):
+        self._config = config
+        self._coordinator: Coordinator | None = None
+        self._processes: list[multiprocessing.Process] = []
+        self._completion_task: asyncio.Task | None = None
+        self._monitor_task: asyncio.Task | None = None
+        self._started = False
+
+    @property
+    def coordinator(self) -> Coordinator:
+        if self._coordinator is None:
+            raise RuntimeError("Runner not started")
+        return self._coordinator
+
+    async def start(self, timeout: float = 120.0) -> None:
+        """Start coordinator and spawn stage subprocesses.
+
+        Args:
+            timeout: Max seconds to wait for all stages to be ready.
+        """
+        if self._started:
+            raise RuntimeError("Already started")
+
+        try:
+            # 1. Apply fusion, allocate endpoints
+            stages_cfg, name_map, entry_stage = self._config.apply_fusion()
+            endpoints = _allocate_endpoints(self._config, stages=stages_cfg)
+
+            stage_endpoints = {s.name: endpoints[f"stage_{s.name}"] for s in stages_cfg}
+
+            # 2. Create Coordinator in main process (binds ZMQ first)
+            self._coordinator = Coordinator(
+                completion_endpoint=endpoints["completion"],
+                abort_endpoint=endpoints["abort"],
+                entry_stage=entry_stage,
+                terminal_stages=self._config.terminal_stages or None,
+            )
+            await self._coordinator.start()
+            self._completion_task = asyncio.create_task(
+                self._coordinator.run_completion_loop()
+            )
+
+            # 3. Spawn one subprocess per stage
+            ready_events: list[multiprocessing.Event] = []
+
+            for stage_cfg in stages_cfg:
+                ready = multiprocessing.Event()
+                config_dict = _build_stage_process_config(
+                    pipeline_config=self._config,
+                    stage_name=stage_cfg.name,
+                    stage_endpoints=stage_endpoints,
+                    all_endpoints=endpoints,
+                    name_map=name_map,
+                )
+                p = multiprocessing.Process(
+                    target=_stage_process_entry,
+                    args=(config_dict, ready),
+                    name=f"stage-{stage_cfg.name}",
+                    daemon=True,
+                )
+                p.start()
+                self._processes.append(p)
+                ready_events.append(ready)
+
+            # 4. Wait for all stages to be ready
+            import time as _time
+
+            for i, event in enumerate(ready_events):
+                stage_name = stages_cfg[i].name
+                p = self._processes[i]
+                deadline = _time.monotonic() + timeout
+                while not event.is_set():
+                    remaining = deadline - _time.monotonic()
+                    if remaining <= 0:
+                        raise TimeoutError(
+                            f"Stage {stage_name} did not become ready within {timeout}s"
+                        )
+                    # Check if process died before signalling ready
+                    if not p.is_alive():
+                        raise RuntimeError(
+                            f"Stage {stage_name} process died during startup "
+                            f"(exit code {p.exitcode})"
+                        )
+                    event.wait(timeout=min(remaining, 1.0))
+                logger.info("Stage %s ready", stage_name)
+
+            # 5. Check for early process failures
+            for i, p in enumerate(self._processes):
+                if not p.is_alive() and p.exitcode != 0:
+                    raise RuntimeError(
+                        f"Stage {stages_cfg[i].name} exited with code {p.exitcode}"
+                    )
+
+            # 6. Register stages with coordinator
+            for stage_cfg in stages_cfg:
+                self._coordinator.register_stage(
+                    stage_cfg.name, stage_endpoints[stage_cfg.name]
+                )
+
+            self._started = True
+            self._monitor_task = asyncio.create_task(self._monitor_children())
+            logger.info(
+                "MultiProcessPipelineRunner started: %d stages", len(self._processes)
+            )
+
+        except Exception:
+            # Rollback: kill any spawned processes to avoid leaks
+            for p in self._processes:
+                if p.is_alive():
+                    p.terminate()
+            for p in self._processes:
+                p.join(timeout=5)
+                if p.is_alive():
+                    p.kill()
+                    p.join(timeout=2)
+            self._processes.clear()
+
+            # Cancel completion loop if started
+            if self._completion_task is not None:
+                self._completion_task.cancel()
+                try:
+                    await self._completion_task
+                except asyncio.CancelledError:
+                    pass
+                self._completion_task = None
+
+            # Stop coordinator if started
+            if self._coordinator is not None:
+                try:
+                    await self._coordinator.stop()
+                except Exception:
+                    pass
+                self._coordinator = None
+
+            raise
+
+    async def _monitor_children(self) -> None:
+        """Periodically check that all stage processes are alive."""
+        while self._started:
+            for i, p in enumerate(self._processes):
+                if not p.is_alive():
+                    logger.error(
+                        "Stage process %d (pid=%d) died with exitcode=%s",
+                        i,
+                        p.pid,
+                        p.exitcode,
+                    )
+                    # Trigger shutdown
+                    await self.stop()
+                    return
+            await asyncio.sleep(5.0)
+
+    async def stop(self) -> None:
+        """Gracefully stop all stage processes and coordinator."""
+        if not self._started:
+            return
+        self._started = False
+
+        # Cancel the monitor task only if we are not being called from it
+        if self._monitor_task is not None:
+            current_task = asyncio.current_task()
+            if current_task != self._monitor_task:
+                self._monitor_task.cancel()
+            self._monitor_task = None
+
+        # 1. Send shutdown to all stages via coordinator
+        try:
+            await self._coordinator.shutdown_stages()
+        except Exception as e:
+            logger.warning("shutdown_stages error: %s", e)
+
+        # 2. Wait for processes to exit
+        for p in self._processes:
+            p.join(timeout=30)
+            if p.is_alive():
+                logger.warning("Terminating stuck process %s", p.name)
+                p.terminate()
+                p.join(timeout=5)
+                if p.is_alive():
+                    p.kill()
+                    p.join(timeout=2)
+
+        # 3. Cancel completion loop and stop coordinator
+        if self._completion_task is not None:
+            self._completion_task.cancel()
+            try:
+                await self._completion_task
+            except asyncio.CancelledError:
+                pass
+
+        await self._coordinator.stop()
+        self._processes.clear()

--- a/sglang_omni/pipeline/stage/router.py
+++ b/sglang_omni/pipeline/stage/router.py
@@ -33,6 +33,10 @@ class WorkerRouter:
 
         self._queues[idx].put_nowait(work)
 
+    def get_worker_index(self, request_id: str) -> int | None:
+        """Return the worker index for a request, or None if not assigned."""
+        return self._affinity.get(request_id)
+
     def clear_request(self, request_id: str) -> None:
         self._affinity.pop(request_id, None)
 

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -13,8 +13,13 @@ from typing import Any, Callable
 from sglang_omni.pipeline.control_plane import StageControlPlane
 from sglang_omni.pipeline.stage.input import DirectInput, InputHandler
 from sglang_omni.pipeline.stage.router import WorkerRouter
+from sglang_omni.pipeline.stage.stream_queue import (
+    StreamItem,
+    StreamQueue,
+    StreamSignal,
+)
 from sglang_omni.pipeline.stage.work import InputRef
-from sglang_omni.pipeline.worker.data_plane import DataPlaneAdapter
+from sglang_omni.pipeline.worker.data_plane import DataPlaneAdapter, _restore_tensors
 from sglang_omni.pipeline.worker.runtime import Worker
 from sglang_omni.profiler.torch_profiler import TorchProfiler
 from sglang_omni.proto import (
@@ -127,6 +132,10 @@ class Stage:
         # State
         self._running = False
         self._aborted_requests: set[str] = set()
+        self._stream_queue: StreamQueue | None = (
+            None  # Set by compiler for streaming-receiving stages
+        )
+        self._pending_stream_data: dict[str, list[StreamItem | StreamSignal]] = {}
 
         # Profiler
         self._profiler_run_id: str | None = None
@@ -216,7 +225,9 @@ class Stage:
         self.workers.append(worker)
 
     async def start(self) -> None:
-        """Start the stage."""
+        """Start the stage (idempotent — safe to call more than once)."""
+        if self._running:
+            return
         await self.control_plane.start()
         self._running = True
         logger.info("Stage %s started", self.name)
@@ -250,6 +261,7 @@ class Stage:
             while self._running:
                 # Receive work
                 msg = await self.control_plane.recv()
+                logger.info("Stage %s received msg: %s", self.name, type(msg).__name__)
 
                 if isinstance(msg, ShutdownMessage):
                     logger.info("Stage %s received shutdown", self.name)
@@ -302,7 +314,12 @@ class Stage:
         if isinstance(msg, SubmitMessage):
             await self._process_submit(msg)
         elif isinstance(msg, DataReadyMessage):
-            await self._process_data_ready(msg)
+            if msg.is_done or msg.error:
+                self._handle_stream_signal(msg)
+            elif msg.chunk_id is not None:
+                await self._handle_stream_chunk(msg)
+            else:
+                await self._process_data_ready(msg)
         elif isinstance(msg, ProfilerStartMessage):
             await self._on_profiler_start(msg)
         elif isinstance(msg, ProfilerStopMessage):
@@ -320,6 +337,10 @@ class Stage:
         if request_id in self._aborted_requests:
             logger.debug("Stage %s skipping aborted req=%s", self.name, request_id)
             return
+
+        # Open stream queue for this request if stage has one
+        if self._stream_queue is not None and not self._stream_queue.has(request_id):
+            self._stream_queue.open(request_id)
 
         input_ref = InputRef.from_payload("coordinator", msg.data)
         work = self.input_handler.receive(request_id, "coordinator", input_ref)
@@ -346,6 +367,10 @@ class Stage:
             self.relay.cleanup(request_id)
             return
 
+        # Open stream queue for this request if stage has one
+        if self._stream_queue is not None and not self._stream_queue.has(request_id):
+            self._stream_queue.open(request_id)
+
         # Eagerly read from relay to release sender's credit/notification.
         if msg.shm_metadata:
             try:
@@ -367,6 +392,164 @@ class Stage:
         work = self.input_handler.receive(request_id, msg.from_stage, input_ref)
         if work is not None:
             self.router.enqueue(work)
+            # Flush pending stream data that arrived before this request was assigned
+            pending_stream = self._pending_stream_data.pop(request_id, [])
+            for pending in pending_stream:
+                if self._stream_queue is not None:
+                    if isinstance(pending, StreamItem):
+                        self._stream_queue.put(request_id, pending)
+                    elif isinstance(pending, StreamSignal):
+                        if pending.error:
+                            self._stream_queue.put_error(request_id, pending.error)
+                        elif pending.is_done:
+                            self._stream_queue.put_done(
+                                request_id, from_stage=pending.from_stage
+                            )
+
+    async def _handle_stream_chunk(self, msg: DataReadyMessage) -> None:
+        """Handle a streaming data chunk from an upstream stage."""
+        request_id = msg.request_id
+        if request_id in self._aborted_requests:
+            return
+
+        # ── Same-GPU CUDA IPC path: deserialize tensor directly (zero copy) ──
+        if isinstance(msg.shm_metadata, dict) and msg.shm_metadata.get("_ipc"):
+            try:
+                item = self._deserialize_ipc_chunk(msg)
+            except Exception as exc:
+                logger.error(
+                    "Stage %s: IPC stream chunk deserialize failed for %s: %s",
+                    self.name,
+                    request_id,
+                    exc,
+                )
+                if self._stream_queue is not None and self._stream_queue.has(
+                    request_id
+                ):
+                    self._stream_queue.put_error(request_id, exc)
+                return
+            self._route_stream_item(request_id, item)
+            return
+
+        # ── Cross-GPU: read from relay (existing path) ──
+        # blob_key must match the sender format in worker/runtime.py _do_stream_send
+        blob_key = f"{request_id}:stream:{msg.from_stage}:{msg.to_stage}:{msg.chunk_id}"
+        try:
+            data = await self._data_plane.read_blob(blob_key, msg.shm_metadata)
+
+            # Restore metadata tensors from relay
+            metadata: dict[str, Any] = {}
+            chunk_metadata = (
+                msg.shm_metadata.get("chunk_metadata")
+                if isinstance(msg.shm_metadata, dict)
+                else None
+            )
+            if isinstance(chunk_metadata, dict):
+                metadata.update(chunk_metadata)
+            metadata_tensor_blobs = (
+                msg.shm_metadata.get("chunk_metadata_tensors", {})
+                if isinstance(msg.shm_metadata, dict)
+                else {}
+            )
+            if isinstance(metadata_tensor_blobs, dict):
+                tensor_dict: dict[str, Any] = {}
+                for path, info in metadata_tensor_blobs.items():
+                    if not isinstance(path, str) or not isinstance(info, dict):
+                        continue
+                    meta_blob_key = info.get("blob_key")
+                    meta_metadata = info.get("relay_metadata")
+                    if not isinstance(meta_blob_key, str) or not isinstance(
+                        meta_metadata, dict
+                    ):
+                        continue
+                    tensor_dict[path] = await self._data_plane.read_blob(
+                        meta_blob_key, meta_metadata
+                    )
+                if tensor_dict:
+                    metadata = _restore_tensors(metadata, tensor_dict)
+        except Exception as exc:
+            logger.error(
+                "Stage %s: stream chunk read failed for %s: %s",
+                self.name,
+                request_id,
+                exc,
+            )
+            if self._stream_queue is not None and self._stream_queue.has(request_id):
+                self._stream_queue.put_error(request_id, exc)
+            return
+
+        item = StreamItem(
+            chunk_id=msg.chunk_id,
+            data=data,
+            from_stage=msg.from_stage,
+            metadata=metadata or None,
+        )
+        self._route_stream_item(request_id, item)
+
+    @staticmethod
+    def _deserialize_ipc_chunk(msg: DataReadyMessage) -> StreamItem:
+        """Deserialize a same-GPU CUDA IPC stream chunk from control-plane metadata.
+
+        Uses ``pickle.loads`` which reconstructs CUDA tensors via
+        ``cudaIpcOpenMemHandle`` — zero data copy, the returned tensor
+        points directly to the sender's GPU memory.
+        """
+        import pickle as _pickle
+
+        ipc_meta = msg.shm_metadata
+        data = _pickle.loads(ipc_meta["tensor_bytes"])
+
+        metadata: dict[str, Any] = {}
+        raw_meta = ipc_meta.get("metadata", {})
+        if isinstance(raw_meta, dict):
+            for key, value in raw_meta.items():
+                if isinstance(value, dict) and "_ipc_tensor" in value:
+                    metadata[key] = _pickle.loads(value["_ipc_tensor"])
+                else:
+                    metadata[key] = value
+
+        return StreamItem(
+            chunk_id=msg.chunk_id,
+            data=data,
+            from_stage=msg.from_stage,
+            metadata=metadata or None,
+        )
+
+    def _route_stream_item(self, request_id: str, item: StreamItem) -> None:
+        """Route a stream item to the queue or buffer it if the worker is not assigned yet."""
+        worker_idx = self.router.get_worker_index(request_id)
+        if worker_idx is None:
+            self._pending_stream_data.setdefault(request_id, []).append(item)
+            logger.debug(
+                "Stage %s: buffered early stream chunk for %s", self.name, request_id
+            )
+            return
+
+        if self._stream_queue is not None:
+            self._stream_queue.put(request_id, item)
+
+    def _handle_stream_signal(self, msg: DataReadyMessage) -> None:
+        """Handle a streaming EOS or error signal."""
+        request_id = msg.request_id
+        if request_id in self._aborted_requests:
+            return
+        if self._stream_queue is None or not self._stream_queue.has(request_id):
+            # Buffer signal if queue not open yet
+            if msg.error:
+                self._pending_stream_data.setdefault(request_id, []).append(
+                    StreamSignal(
+                        from_stage=msg.from_stage, error=RuntimeError(msg.error)
+                    )
+                )
+            elif msg.is_done:
+                self._pending_stream_data.setdefault(request_id, []).append(
+                    StreamSignal(from_stage=msg.from_stage, is_done=True)
+                )
+            return
+        if msg.error:
+            self._stream_queue.put_error(request_id, RuntimeError(msg.error))
+        elif msg.is_done:
+            self._stream_queue.put_done(request_id, from_stage=msg.from_stage)
 
     def _on_abort(self, request_id: str) -> None:
         """Handle abort for a request."""
@@ -375,6 +558,11 @@ class Stage:
         self.router.clear_request(request_id)
         self.input_handler.cancel(request_id)
         self.relay.cleanup(request_id)
+
+        # Close stream queue and discard buffered stream data
+        if self._stream_queue is not None:
+            self._stream_queue.close(request_id)
+        self._pending_stream_data.pop(request_id, None)
 
         # Notify workers' engines
         for worker in self.workers:

--- a/sglang_omni/pipeline/stage/stream_queue.py
+++ b/sglang_omni/pipeline/stage/stream_queue.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-request bounded queue for streaming between pipeline stages."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StreamItem:
+    """A single item of streaming data between stages."""
+
+    chunk_id: int
+    data: Any
+    from_stage: str
+    metadata: dict[str, Any] | None = None
+
+
+@dataclass
+class StreamSignal:
+    """Non-data queue event such as per-source EOS or error."""
+
+    from_stage: str | None = None
+    is_done: bool = False
+    error: BaseException | None = None
+
+
+class StreamQueue:
+    """Manages per-request unbounded async queues for streaming between stages.
+
+    Backpressure is applied at the sender side (Worker's ``_stream_send_queue``
+    with maxsize=4096 and blocking put).  The per-request queues here are
+    unbounded so that ordered chunks are never dropped.
+
+    Usage:
+        sq.open("req-1")              # create queue for request
+        sq.put("req-1", item)         # sender puts items
+        item = await sq.get(...)      # consumer awaits next item (returns None on EOS)
+        sq.close("req-1")             # cleanup
+    """
+
+    def __init__(self, max_pending: int = 16):
+        self._max_pending = max_pending
+        self._queues: dict[str, asyncio.Queue] = {}
+        self._signals: dict[str, StreamSignal] = {}  # guaranteed delivery
+
+    def open(self, request_id: str) -> None:
+        if request_id not in self._queues:
+            self._queues[request_id] = (
+                asyncio.Queue()
+            )  # unbounded; backpressure at sender
+
+    def has(self, request_id: str) -> bool:
+        return request_id in self._queues
+
+    def put(self, request_id: str, item: StreamItem) -> None:
+        queue = self._queues.get(request_id)
+        if queue is None:
+            raise KeyError(f"No queue for {request_id}")
+        queue.put_nowait(item)
+
+    def put_done(self, request_id: str, from_stage: str | None = None) -> None:
+        queue = self._queues.get(request_id)
+        if queue is None:
+            return
+        queue.put_nowait(StreamSignal(from_stage=from_stage, is_done=True))
+
+    def put_error(
+        self, request_id: str, error: BaseException, from_stage: str | None = None
+    ) -> None:
+        queue = self._queues.get(request_id)
+        if queue is None:
+            return
+        queue.put_nowait(StreamSignal(from_stage=from_stage, error=error))
+
+    async def get(self, request_id: str) -> StreamItem | None:
+        """Get next item. Returns None when done, raises on error."""
+        queue = self._queues.get(request_id)
+        if queue is None:
+            # Check deferred signals
+            sig = self._signals.pop(request_id, None)
+            if sig is not None:
+                if sig.error:
+                    raise sig.error
+                return None  # done
+            raise RuntimeError(f"No queue for {request_id}")
+
+        try:
+            item = queue.get_nowait()
+        except asyncio.QueueEmpty:
+            # Check deferred signals before waiting
+            sig = self._signals.pop(request_id, None)
+            if sig is not None:
+                if sig.error:
+                    raise sig.error
+                return None
+            item = await queue.get()
+
+        if isinstance(item, StreamSignal):
+            if item.error:
+                raise item.error
+            return None
+        return item
+
+    async def get_with_source(self, request_id: str) -> StreamItem | StreamSignal:
+        """Get next item or signal while preserving the upstream stage info."""
+        queue = self._queues.get(request_id)
+        if queue is None:
+            sig = self._signals.pop(request_id, None)
+            if sig is not None:
+                return sig
+            raise RuntimeError(f"No queue for {request_id}")
+
+        try:
+            item = queue.get_nowait()
+        except asyncio.QueueEmpty:
+            sig = self._signals.pop(request_id, None)
+            if sig is not None:
+                return sig
+            item = await queue.get()
+        return item
+
+    def close(self, request_id: str) -> None:
+        q = self._queues.pop(request_id, None)
+        self._signals.pop(request_id, None)
+        if q is not None:
+            # Wake any blocked get() calls with a proper sentinel
+            q.put_nowait(StreamSignal(is_done=True))

--- a/sglang_omni/pipeline/worker/data_plane.py
+++ b/sglang_omni/pipeline/worker/data_plane.py
@@ -89,6 +89,7 @@ class DataPlaneAdapter:
         payload: StagePayload,
     ) -> tuple[dict[str, Any], Any]:
         device = self._relay.device if hasattr(self._relay, "device") else "cpu"
+        transport_device = torch.device(device)
 
         # Extract tensors from payload.data
         modified_data, tensor_dict = _extract_tensors(payload.data)
@@ -112,6 +113,8 @@ class DataPlaneAdapter:
             for path, tensor in tensor_dict.items():
                 # Flatten tensor to bytes
                 flat = tensor.contiguous().view(torch.uint8).reshape(-1)
+                if flat.device != transport_device:
+                    flat = flat.to(device=transport_device)
                 tensor_buffers.append(flat)
                 tensor_info.append(
                     {
@@ -125,10 +128,7 @@ class DataPlaneAdapter:
                 offset += flat.numel()
 
             # Concatenate all tensors
-            if tensor_buffers[0].is_cuda:
-                all_tensors = torch.cat(tensor_buffers)
-            else:
-                all_tensors = torch.cat(tensor_buffers)
+            all_tensors = torch.cat(tensor_buffers)
         else:
             # Relay still expects a payload to transfer; use a 1-byte placeholder.
             all_tensors = torch.zeros(1, dtype=torch.uint8, device=device)
@@ -198,6 +198,47 @@ class DataPlaneAdapter:
         if not isinstance(payload, StagePayload):
             raise TypeError(f"Expected StagePayload, got {type(payload)}")
         return payload
+
+    async def write_blob(
+        self,
+        key: str,
+        tensor: torch.Tensor,
+    ) -> tuple[dict[str, Any], Any]:
+        """Write a raw tensor via relay (no StagePayload wrapping).
+
+        Returns (metadata_dict, relay_operation).
+        metadata_dict is sent via control plane; receiver uses it in read_blob.
+        """
+        flat = tensor.contiguous().view(torch.uint8).reshape(-1)
+        op = await self._relay.put_async(flat, request_id=key)
+        metadata = {
+            "relay_info": op.metadata,
+            "tensor_shape": list(tensor.shape),
+            "tensor_dtype": str(tensor.dtype),
+        }
+        return metadata, op
+
+    async def read_blob(
+        self,
+        key: str,
+        metadata: dict[str, Any],
+    ) -> torch.Tensor:
+        """Read a raw tensor from relay using metadata from write_blob."""
+        device = self._relay.device if hasattr(self._relay, "device") else "cpu"
+        relay_info = metadata["relay_info"]
+        shape = metadata["tensor_shape"]
+        dtype_str = metadata["tensor_dtype"]
+
+        data_size = relay_info["transfer_info"]["size"]
+        recv_buf = torch.zeros(data_size, dtype=torch.uint8, device=device)
+        op = await self._relay.get_async(
+            metadata=relay_info, dest_tensor=recv_buf, request_id=key
+        )
+        await op.wait_for_completion()
+
+        dtype = getattr(torch, dtype_str.replace("torch.", ""))
+        tensor = recv_buf.view(dtype).reshape(shape)
+        return tensor
 
     def cleanup(self, request_id: str) -> None:
         self._relay.cleanup(request_id)

--- a/sglang_omni/pipeline/worker/runtime.py
+++ b/sglang_omni/pipeline/worker/runtime.py
@@ -4,8 +4,14 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import logging
+import queue as _queue_mod
+from dataclasses import dataclass
+from multiprocessing.reduction import ForkingPickler
 from typing import TYPE_CHECKING, Any
+
+import torch
 
 from sglang_omni.executors.interface import Executor
 from sglang_omni.pipeline.stage.work import WorkDescriptor
@@ -21,6 +27,16 @@ if TYPE_CHECKING:
     from sglang_omni.pipeline.stage.runtime import Stage
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _PendingStreamItem:
+    request_id: str
+    data: Any
+    target_stage: str
+    metadata: dict | None = None
+    is_done: bool = False
+    error: str | None = None
 
 
 class Worker:
@@ -44,6 +60,18 @@ class Worker:
         self.queue: asyncio.Queue[WorkDescriptor | None] | None = None
         self._running = False
         self._result_waiters: dict[str, asyncio.Future[StagePayload]] = {}
+        # Streaming send state (thread-safe queue for cross-thread enqueue)
+        self._stream_send_queue: _queue_mod.Queue[_PendingStreamItem] = (
+            _queue_mod.Queue()
+        )
+        self._stream_send_task: asyncio.Task | None = None
+        self._stream_chunk_counters: dict[tuple[str, str], int] = {}
+        self._stream_targets: list[str] = []  # Set by compiler
+        self._bootstrap_targets: set[str] = set()  # Set by compiler
+        self._same_gpu_targets: set[str] = (
+            set()
+        )  # Set by compiler for CUDA IPC zero-copy
+        self._stream_running: bool = False
 
     def bind(self, stage: Stage, queue: asyncio.Queue[WorkDescriptor | None]) -> None:
         """Bind this worker to a stage."""
@@ -59,6 +87,11 @@ class Worker:
         try:
             await self.executor.start()
             self._running = True
+
+            # Start streaming send loop
+            self._stream_running = True
+            self._stream_send_task = asyncio.create_task(self._stream_send_loop())
+
             logger.info("Worker started for stage %s", self.stage.name)
 
             inflight: set[asyncio.Task[None]] = set()
@@ -87,6 +120,14 @@ class Worker:
             logger.info("Worker cancelled for stage %s", self.stage.name)
         finally:
             self._running = False
+            # Stop streaming send loop
+            self._stream_running = False
+            if self._stream_send_task is not None:
+                try:
+                    await self._stream_send_task
+                except asyncio.CancelledError:
+                    pass
+                self._stream_send_task = None
             await self.executor.stop()
 
     async def _dispatch_results(self) -> None:
@@ -118,10 +159,12 @@ class Worker:
     async def _process_request(self, work: WorkDescriptor) -> None:
         """Process a single request."""
         request_id = work.request_id
+        logger.debug("Worker %s: processing request %s", self.stage.name, request_id)
         try:
             if self.data_plane is None:
                 raise RuntimeError("Worker not bound to a data plane")
             payloads = await self._load_inputs(work)
+            logger.debug("Worker %s: loaded inputs for %s", self.stage.name, request_id)
             merged = self._merge_payloads(work, payloads)
             if not isinstance(merged, StagePayload):
                 raise TypeError(f"Expected StagePayload, got {type(merged)}")
@@ -131,13 +174,27 @@ class Worker:
                     f"(expected={request_id} got={merged.request_id})"
                 )
 
+            bootstrap_targets = self._get_stream_bootstrap_targets()
+            for stage_name in bootstrap_targets:
+                sent = await self._send_to_next(request_id, stage_name, merged)
+                if not sent:
+                    return
+
             # Register future BEFORE add_request so the dispatcher can
             # route the result even if the executor completes synchronously.
             loop = asyncio.get_running_loop()
             fut: asyncio.Future[StagePayload] = loop.create_future()
             self._result_waiters[request_id] = fut
 
+            logger.debug(
+                "Worker %s: adding request %s to executor", self.stage.name, request_id
+            )
             await self.executor.add_request(merged)
+            logger.debug(
+                "Worker %s: request %s added, waiting for result",
+                self.stage.name,
+                request_id,
+            )
 
             stream_task: asyncio.Task[None] | None = None
             stream_fn = getattr(self.executor, "stream", None)
@@ -149,6 +206,18 @@ class Worker:
                     )
 
             output_payload = await fut
+            logger.debug("Worker %s: got result for %s", self.stage.name, request_id)
+
+            # Signal stream done to all downstream streaming targets
+            for target in self._stream_targets:
+                try:
+                    self._enqueue_stream_done(request_id, target)
+                except Exception:
+                    logger.debug(
+                        "Worker: failed to send stream done for %s to %s",
+                        request_id,
+                        target,
+                    )
 
             if not isinstance(output_payload, StagePayload):
                 raise TypeError(
@@ -163,25 +232,51 @@ class Worker:
             # Route
             next_stage = self.stage.get_next(request_id, output_payload)
 
+            logger.debug(
+                "Worker %s: next_stage=%s for %s",
+                self.stage.name,
+                next_stage,
+                request_id,
+            )
             if next_stage is None:
                 if stream_task is not None:
                     await self._finish_stream_task(stream_task)
                 await self._send_complete(request_id, output_payload.data)
+                logger.debug(
+                    "Worker %s: sent complete for %s", self.stage.name, request_id
+                )
             else:
                 if stream_task is not None:
                     await self._finish_stream_task(stream_task)
                 for stage_name in self._normalize_next_stages(next_stage):
-                    await self._send_to_next(request_id, stage_name, output_payload)
+                    if stage_name in bootstrap_targets:
+                        continue
+                    sent = await self._send_to_next(
+                        request_id, stage_name, output_payload
+                    )
+                    if not sent:
+                        return
+                    logger.debug(
+                        "Worker %s: routed %s to %s",
+                        self.stage.name,
+                        request_id,
+                        stage_name,
+                    )
 
         except asyncio.CancelledError:
             logger.debug("Worker: request %s cancelled", request_id)
         except Exception as e:
             logger.exception("Worker: request %s failed", request_id)
+            self._notify_stream_error(request_id, str(e))
             await self._send_failure(request_id, str(e))
         finally:
             self._result_waiters.pop(request_id, None)
             if self.stage is not None:
                 self.stage.router.clear_request(request_id)
+                # Close the stream queue entry to prevent per-request leaks
+                if self.stage._stream_queue is not None:
+                    self.stage._stream_queue.close(request_id)
+                self.stage._pending_stream_data.pop(request_id, None)
 
     # ------------------------------------------------------------------
     # Helpers
@@ -239,7 +334,7 @@ class Worker:
 
     async def _send_to_next(
         self, request_id: str, next_stage: str, payload: StagePayload
-    ) -> None:
+    ) -> bool:
         """Send data to next stage."""
         logger.debug("Worker: routing %s to %s", request_id, next_stage)
 
@@ -247,7 +342,7 @@ class Worker:
             endpoint = self.stage.endpoints.get(next_stage)
             if endpoint is None:
                 await self._send_failure(request_id, f"Unknown stage: {next_stage}")
-                return
+                return False
             metadata, op = await self.data_plane.write_payload(request_id, payload)
 
             await self.stage.control_plane.send_to_stage(
@@ -263,11 +358,12 @@ class Worker:
 
             await op.wait_for_completion()
             self.data_plane.cleanup(request_id)
+            return True
 
         except Exception as e:
             logger.exception("Worker: failed to write data for req=%s", request_id)
             await self._send_failure(request_id, f"Failed to write data: {e}")
-            return
+            return False
 
     async def _send_failure(self, request_id: str, error: str) -> None:
         """Send failure to coordinator."""
@@ -311,6 +407,266 @@ class Worker:
                 await task
             except asyncio.CancelledError:
                 pass
+
+    # ------------------------------------------------------------------
+    # Streaming send
+    # ------------------------------------------------------------------
+
+    def _enqueue_stream(
+        self,
+        request_id: str,
+        data: Any,
+        target_stage: str,
+        metadata: dict | None = None,
+    ) -> None:
+        """Non-blocking enqueue. Must not block — may be called from the event loop."""
+        try:
+            self._stream_send_queue.put_nowait(
+                _PendingStreamItem(
+                    request_id=request_id,
+                    data=data,
+                    target_stage=target_stage,
+                    metadata=metadata,
+                ),
+            )
+        except _queue_mod.Full:
+            logger.error(
+                "Stream send queue full for %s → %s, dropping chunk",
+                request_id,
+                target_stage,
+            )
+
+    def _enqueue_stream_done(self, request_id: str, target_stage: str) -> None:
+        """Non-blocking end-of-stream signal."""
+        try:
+            self._stream_send_queue.put_nowait(
+                _PendingStreamItem(
+                    request_id=request_id,
+                    data=None,
+                    target_stage=target_stage,
+                    is_done=True,
+                ),
+            )
+        except _queue_mod.Full:
+            logger.error(
+                "Stream send queue full, dropping done signal for %s", request_id
+            )
+
+    def _enqueue_stream_error(
+        self, request_id: str, target_stage: str, error: str
+    ) -> None:
+        """Non-blocking error signal."""
+        try:
+            self._stream_send_queue.put_nowait(
+                _PendingStreamItem(
+                    request_id=request_id,
+                    data=None,
+                    target_stage=target_stage,
+                    error=error,
+                ),
+            )
+        except _queue_mod.Full:
+            logger.error(
+                "Stream send queue full, dropping error signal for %s", request_id
+            )
+
+    async def _stream_send_loop(self) -> None:
+        """Background async task: drain thread-safe queue, write relay, send messages."""
+        loop = asyncio.get_running_loop()
+        while self._stream_running or not self._stream_send_queue.empty():
+            try:
+                item = await loop.run_in_executor(
+                    None, lambda: self._stream_send_queue.get(timeout=0.1)
+                )
+            except _queue_mod.Empty:
+                continue
+            try:
+                await self._do_stream_send(item)
+            except Exception as e:
+                logger.exception(
+                    "Worker: failed to send stream item for %s", item.request_id
+                )
+                # Propagate failure to downstream stage via error signal
+                try:
+                    target_endpoint = (
+                        self.stage.endpoints.get(item.target_stage)
+                        if self.stage
+                        else None
+                    )
+                    error_msg = DataReadyMessage(
+                        request_id=item.request_id,
+                        from_stage=self.stage.name if self.stage else "",
+                        to_stage=item.target_stage,
+                        shm_metadata={},
+                        error=str(e),
+                    )
+                    await self._send_stream_control_message(
+                        error_msg, item.target_stage, target_endpoint
+                    )
+                except Exception:
+                    logger.debug(
+                        "Failed to propagate stream error for %s", item.request_id
+                    )
+
+    async def _do_stream_send(self, item: _PendingStreamItem) -> None:
+        """Write data to relay and send DataReadyMessage with streaming fields."""
+        target_endpoint = (
+            self.stage.endpoints.get(item.target_stage) if self.stage else None
+        )
+
+        # Handle done/error signals
+        if item.is_done or item.error:
+            msg = DataReadyMessage(
+                request_id=item.request_id,
+                from_stage=self.stage.name,
+                to_stage=item.target_stage,
+                shm_metadata={},
+                is_done=item.is_done,
+                error=item.error,
+            )
+            await self._send_stream_control_message(
+                msg, item.target_stage, target_endpoint
+            )
+            key = (item.request_id, item.target_stage)
+            self._stream_chunk_counters.pop(key, None)
+            return
+
+        # Normal chunk
+        key = (item.request_id, item.target_stage)
+        chunk_id = self._stream_chunk_counters.get(key, 0)
+        self._stream_chunk_counters[key] = chunk_id + 1
+
+        # ── Same-GPU CUDA IPC path: skip relay entirely ──
+        if item.target_stage in self._same_gpu_targets:
+            ipc_metadata = self._serialize_ipc_chunk(item)
+            ipc_metadata["chunk_id"] = chunk_id
+            msg = DataReadyMessage(
+                request_id=item.request_id,
+                from_stage=self.stage.name,
+                to_stage=item.target_stage,
+                shm_metadata=ipc_metadata,
+                chunk_id=chunk_id,
+            )
+            await self._send_stream_control_message(
+                msg, item.target_stage, target_endpoint
+            )
+            return
+
+        # ── Cross-GPU: use relay ──
+        blob_key = (
+            f"{item.request_id}:stream:{self.stage.name}:{item.target_stage}:{chunk_id}"
+        )
+
+        # Write tensors to relay, then notify receiver BEFORE waiting for completion.
+        # NIXL relay has limited credits (default 2). If we wait_for_completion before
+        # notifying the receiver, the receiver never starts reading, never sends the
+        # notification, and we deadlock. The fix: send the control message first so the
+        # receiver starts read_blob (which triggers the RDMA notification), then wait.
+        pending_ops: list = []
+        relay_metadata, op = await self.data_plane.write_blob(blob_key, item.data)
+        pending_ops.append(op)
+
+        # Handle metadata tensors
+        if item.metadata:
+            from .data_plane import _extract_tensors
+
+            cleaned_meta, tensor_dict = _extract_tensors(item.metadata)
+            relay_metadata["chunk_metadata"] = cleaned_meta
+            if tensor_dict:
+                metadata_refs: dict[str, Any] = {}
+                for meta_idx, (tkey, tensor) in enumerate(tensor_dict.items()):
+                    meta_blob_key = f"{blob_key}:meta:{meta_idx}"
+                    meta_relay_info, meta_op = await self.data_plane.write_blob(
+                        meta_blob_key, tensor
+                    )
+                    pending_ops.append(meta_op)
+                    metadata_refs[tkey] = {
+                        "blob_key": meta_blob_key,
+                        "relay_metadata": meta_relay_info,
+                    }
+                relay_metadata["chunk_metadata_tensors"] = metadata_refs
+
+        # Send control message FIRST — receiver starts reading immediately
+        msg = DataReadyMessage(
+            request_id=item.request_id,
+            from_stage=self.stage.name,
+            to_stage=item.target_stage,
+            shm_metadata=relay_metadata,
+            chunk_id=chunk_id,
+        )
+        await self._send_stream_control_message(msg, item.target_stage, target_endpoint)
+
+        # Wait for all writes to complete after notifying receiver.
+        # The receiver starts reading (triggering RDMA notification) upon receiving
+        # the DataReadyMessage, which helps avoid credit deadlock when credits > 1.
+        for pending_op in pending_ops:
+            await pending_op.wait_for_completion()
+
+    @staticmethod
+    def _ipc_pickle(obj: Any) -> bytes:
+        """Serialize an object using ForkingPickler (CUDA IPC for GPU tensors)."""
+        buf = io.BytesIO()
+        ForkingPickler(buf, 2).dump(obj)
+        return buf.getvalue()
+
+    def _serialize_ipc_chunk(self, item: _PendingStreamItem) -> dict[str, Any]:
+        """Build IPC metadata dict for a same-GPU stream chunk.
+
+        Uses ``ForkingPickler`` which serialises CUDA tensors via
+        ``cudaIpcGetMemHandle`` (~200 bytes per handle, zero data copy).
+        The receiver deserialises with plain ``pickle.loads``, getting a tensor
+        that points directly to the sender's GPU memory.
+
+        PyTorch's CUDA IPC mechanism uses built-in reference counting: the
+        receiver's reconstructed tensor holds a reference to the shared CUDA
+        storage, keeping it alive until the receiver is done.
+        """
+        ipc_metadata: dict[str, Any] = {"_ipc": True}
+
+        # Serialize main tensor / data
+        ipc_metadata["tensor_bytes"] = self._ipc_pickle(item.data)
+
+        # Serialize metadata tensors
+        if item.metadata:
+            serialized_meta: dict[str, Any] = {}
+            for mkey, value in item.metadata.items():
+                if isinstance(value, torch.Tensor):
+                    serialized_meta[mkey] = {
+                        "_ipc_tensor": self._ipc_pickle(value),
+                    }
+                else:
+                    serialized_meta[mkey] = value
+            ipc_metadata["metadata"] = serialized_meta
+
+        return ipc_metadata
+
+    async def _send_stream_control_message(
+        self, msg, target_stage: str, endpoint: str | None
+    ) -> None:
+        """Send a control message to a specific downstream stage."""
+        if self.stage is None:
+            logger.warning("Worker: cannot send stream message, stage is None")
+            return
+        if endpoint is None:
+            logger.warning(
+                "Worker: no endpoint for stage %s, dropping message", target_stage
+            )
+            return
+        await self.stage.control_plane.send_to_stage(target_stage, endpoint, msg)
+
+    def _get_stream_bootstrap_targets(self) -> list[str]:
+        """Return streaming downstream stages that should receive bootstrap data."""
+        return list(self._bootstrap_targets)
+
+    def _notify_stream_error(self, request_id: str, error: str) -> None:
+        """Propagate error to all downstream streaming targets."""
+        for target in self._stream_targets:
+            try:
+                self._enqueue_stream_error(request_id, target, error)
+            except Exception:
+                logger.debug(
+                    "Worker: failed to propagate stream error for %s", request_id
+                )
 
     def stop(self) -> None:
         """Stop the worker."""

--- a/sglang_omni/proto/__init__.py
+++ b/sglang_omni/proto/__init__.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-# Import SHMMetadata from relay.nixl (kept for backward compatibility)
 from .messages import (
     AbortMessage,
     CompleteMessage,

--- a/sglang_omni/proto/messages.py
+++ b/sglang_omni/proto/messages.py
@@ -21,6 +21,9 @@ class DataReadyMessage:
     from_stage: str
     to_stage: str
     shm_metadata: Any  # Can be dict, SHMMetadata, or RdmaMetadata
+    chunk_id: int | None = None
+    is_done: bool = False
+    error: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         # Handle different metadata types
@@ -43,13 +46,20 @@ class DataReadyMessage:
                 else {}
             )
 
-        return {
+        d = {
             "type": "data_ready",
             "request_id": self.request_id,
             "from_stage": self.from_stage,
             "to_stage": self.to_stage,
             "shm_metadata": metadata_dict,
         }
+        if self.chunk_id is not None:
+            d["chunk_id"] = self.chunk_id
+        if self.is_done:
+            d["is_done"] = True
+        if self.error is not None:
+            d["error"] = self.error
+        return d
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "DataReadyMessage":
@@ -108,6 +118,9 @@ class DataReadyMessage:
             from_stage=d["from_stage"],
             to_stage=d["to_stage"],
             shm_metadata=metadata,
+            chunk_id=d.get("chunk_id"),
+            is_done=d.get("is_done", False),
+            error=d.get("error"),
         )
 
 

--- a/tests/test_stream_queue.py
+++ b/tests/test_stream_queue.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for StreamQueue."""
+from __future__ import annotations
+
+import pytest
+
+from sglang_omni.pipeline.stage.stream_queue import (
+    StreamItem,
+    StreamQueue,
+    StreamSignal,
+)
+
+REQ = "req-1"
+
+
+def _make_item(
+    chunk_id: int = 0, data: str = "hello", stage: str = "enc"
+) -> StreamItem:
+    return StreamItem(chunk_id=chunk_id, data=data, from_stage=stage)
+
+
+# ------------------------------------------------------------------
+# Tests
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_open_put_get():
+    sq = StreamQueue()
+    sq.open(REQ)
+    item = _make_item(chunk_id=0)
+    sq.put(REQ, item)
+    result = await sq.get(REQ)
+    assert result is item
+    assert result.chunk_id == 0
+    assert result.data == "hello"
+    sq.close(REQ)
+
+
+@pytest.mark.asyncio
+async def test_put_done_returns_none():
+    sq = StreamQueue()
+    sq.open(REQ)
+    sq.put_done(REQ, from_stage="enc")
+    result = await sq.get(REQ)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_put_error_raises():
+    sq = StreamQueue()
+    sq.open(REQ)
+    sq.put_error(REQ, ValueError("boom"), from_stage="enc")
+    with pytest.raises(ValueError, match="boom"):
+        await sq.get(REQ)
+
+
+@pytest.mark.asyncio
+async def test_get_with_source_returns_signal():
+    sq = StreamQueue()
+    sq.open(REQ)
+
+    # done signal
+    sq.put_done(REQ, from_stage="enc")
+    sig = await sq.get_with_source(REQ)
+    assert isinstance(sig, StreamSignal)
+    assert sig.is_done is True
+    assert sig.from_stage == "enc"
+
+    # error signal
+    err = RuntimeError("fail")
+    sq.put_error(REQ, err, from_stage="dec")
+    sig = await sq.get_with_source(REQ)
+    assert isinstance(sig, StreamSignal)
+    assert sig.error is err
+    assert sig.from_stage == "dec"
+
+    sq.close(REQ)
+
+
+@pytest.mark.asyncio
+async def test_close_cleans_up():
+    sq = StreamQueue()
+    sq.open(REQ)
+    assert sq.has(REQ)
+    sq.close(REQ)
+    assert not sq.has(REQ)
+
+
+@pytest.mark.asyncio
+async def test_put_to_closed_queue_raises():
+    sq = StreamQueue()
+    # never opened
+    with pytest.raises(KeyError):
+        sq.put(REQ, _make_item())
+
+    # opened then closed
+    sq.open(REQ)
+    sq.close(REQ)
+    with pytest.raises(KeyError):
+        sq.put(REQ, _make_item())
+
+
+@pytest.mark.asyncio
+async def test_has():
+    sq = StreamQueue()
+    assert not sq.has(REQ)
+    sq.open(REQ)
+    assert sq.has(REQ)
+    sq.close(REQ)
+    assert not sq.has(REQ)
+
+
+@pytest.mark.asyncio
+async def test_done_after_many_items():
+    """Done signal enqueued after many items, delivered in order."""
+    sq = StreamQueue()
+    sq.open(REQ)
+    sq.put(REQ, _make_item(chunk_id=0))
+    sq.put(REQ, _make_item(chunk_id=1))
+    sq.put_done(REQ, from_stage="enc")
+
+    item0 = await sq.get(REQ)
+    assert item0.chunk_id == 0
+    item1 = await sq.get(REQ)
+    assert item1.chunk_id == 1
+    result = await sq.get(REQ)
+    assert result is None  # done
+    sq.close(REQ)
+
+
+@pytest.mark.asyncio
+async def test_error_after_items():
+    """Error signal enqueued after items, raised in order."""
+    sq = StreamQueue()
+    sq.open(REQ)
+    sq.put(REQ, _make_item(chunk_id=0))
+    sq.put_error(REQ, ValueError("boom"), from_stage="enc")
+
+    item0 = await sq.get(REQ)
+    assert item0.chunk_id == 0
+    with pytest.raises(ValueError, match="boom"):
+        await sq.get(REQ)
+    sq.close(REQ)
+
+
+@pytest.mark.asyncio
+async def test_get_with_source_signal_after_items():
+    """get_with_source() delivers signals in order after data items."""
+    sq = StreamQueue()
+    sq.open(REQ)
+    sq.put(REQ, _make_item(chunk_id=0))
+    sq.put_done(REQ, from_stage="enc")
+
+    # Drain data
+    item0 = await sq.get_with_source(REQ)
+    assert isinstance(item0, StreamItem)
+    # Done signal
+    sig = await sq.get_with_source(REQ)
+    assert isinstance(sig, StreamSignal)
+    assert sig.is_done is True
+    sq.close(REQ)
+
+
+@pytest.mark.asyncio
+async def test_unbounded_put_preserves_all_chunks():
+    """Unbounded queue preserves all chunks (no drop-oldest)."""
+    sq = StreamQueue()
+    sq.open(REQ)
+    for i in range(100):
+        sq.put(REQ, _make_item(chunk_id=i))
+
+    for i in range(100):
+        item = await sq.get(REQ)
+        assert item.chunk_id == i
+    sq.close(REQ)


### PR DESCRIPTION
  ## Summary

Let pipeline stages stream partial results to downstream stages during generation, instead of waiting for the full result. This enables pipelining: upstream and downstream stages run simultaneously, reducing end-to-end latency. 

  - `DataReadyMessage`: `chunk_id` distinguishes streaming chunks from batch results
  - `StreamQueue`: per-request async queue for consuming streamed chunks
  - `stream_to` on StageConfig: declare streaming targets at compile time
  - Non-blocking worker send loop with CUDA IPC for same-GPU transfers
  - MultiProcessPipelineRunner: added startup rollback and child monitoring
  - Coordinator: multi-terminal merge (collect results from multiple terminal stages)