### PR TITLE
Fix S2-Pro concurrent decode isolation

### DIFF
--- a/sglang_omni/models/fishaudio_s2_pro/runtime/s2pro_sglang_ar.py
+++ b/sglang_omni/models/fishaudio_s2_pro/runtime/s2pro_sglang_ar.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 import torch
+from sglang.srt.managers.schedule_batch import FINISH_LENGTH, FINISH_MATCHED_TOKEN
 from sglang.srt.mem_cache.common import release_kv_cache
 
 from sglang_omni.engines.omni.runtime.sglang_ar import (
@@ -97,7 +98,7 @@ class S2ProSGLangIterationController:
         codes = output.data.codes.clone()
         data.output_codes.append(codes)
 
-        semantic_token = codes[0, -1].item()
+        semantic_token = int(codes[0, -1].item())
         data._previous_semantic_tokens.append(semantic_token)
 
         # Codebook values for next step's VQ embedding (clone is redundant
@@ -105,6 +106,14 @@ class S2ProSGLangIterationController:
         data._last_codebook_values = codes[1:, 0].clone()
 
         req.output_ids.append(semantic_token)
+
+        max_tok = data.max_new_tokens or self._max_new_tokens
+        if semantic_token == self._im_end_id:
+            req.finished_reason = FINISH_MATCHED_TOKEN(matched=semantic_token)
+            req.finished_len = len(req.output_ids)
+        elif len(data.output_codes) >= max_tok:
+            req.finished_reason = FINISH_LENGTH(length=max_tok)
+            req.finished_len = max_tok
 
         if not req.finished() and req.decode_batch_idx == 0:
             self.tree_cache.cache_unfinished_req(req)
@@ -115,15 +124,7 @@ class S2ProSGLangIterationController:
         if data.req.is_chunked > 0:
             return False
 
-        semantic_token = output.data.codes[0, -1].item()
-        if semantic_token == self._im_end_id:
-            return True
-
-        max_tok = data.max_new_tokens or self._max_new_tokens
-        if len(data.output_codes) >= max_tok:
-            return True
-
-        return False
+        return data.req.finished()
 
 
 # ---------------------------------------------------------------------------
@@ -242,7 +243,7 @@ class S2ProSGLangModelRunner:
                 continue
 
             # [num_codebooks+1] → [num_codebooks+1, 1] for existing format
-            codes = text_model._output_codes[i].unsqueeze(-1)
+            codes = text_model._output_codes[i].unsqueeze(-1).clone()
             outputs[sched_req.request_id] = RequestOutput(
                 request_id=sched_req.request_id,
                 data=S2ProStepOutput(codes=codes),

--- a/tests/test_s2pro_runtime.py
+++ b/tests/test_s2pro_runtime.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from sglang_omni.engines.omni.types import RequestOutput, SchedulerRequest
+from sglang_omni.models.fishaudio_s2_pro.runtime.s2pro_ar import S2ProStepOutput
+from sglang_omni.models.fishaudio_s2_pro.runtime.s2pro_sglang_ar import (
+    S2ProSGLangIterationController,
+    S2ProSGLangModelRunner,
+    S2ProSGLangRequestData,
+    S2ProSGLangResourceManager,
+)
+
+
+class _FakeReq:
+    def __init__(self) -> None:
+        self.output_ids: list[int] = []
+        self.decode_batch_idx = 0
+        self.is_chunked = 0
+        self.finished_reason = None
+        self.finished_len = None
+        self.prefix_indices = []
+        self.req_pool_idx = 0
+        self.origin_input_ids = [1, 2, 3]
+        self.fill_ids = [1, 2, 3]
+        self.cache_protected_len = 0
+
+    def finished(self) -> bool:
+        return self.finished_reason is not None
+
+
+class _FakeTreeCache:
+    def __init__(self) -> None:
+        self.calls: list[_FakeReq] = []
+
+    def cache_unfinished_req(self, req: _FakeReq) -> None:
+        self.calls.append(req)
+
+
+def _make_request_data(req: _FakeReq, *, max_new_tokens: int = 4) -> S2ProSGLangRequestData:
+    return S2ProSGLangRequestData(
+        input_ids=torch.tensor([1, 2, 3], dtype=torch.long),
+        req=req,
+        max_new_tokens=max_new_tokens,
+    )
+
+
+def _make_step_output(semantic_token: int, codebooks: list[int] | None = None) -> RequestOutput:
+    if codebooks is None:
+        codebooks = [101, 202]
+    codes = torch.tensor(
+        [[semantic_token], *[[value] for value in codebooks]],
+        dtype=torch.long,
+    )
+    return RequestOutput(
+        request_id="req-1",
+        data=S2ProStepOutput(codes=codes),
+        finished=False,
+    )
+
+
+def test_iteration_controller_marks_eos_finished_without_unfinished_cache() -> None:
+    tree_cache = _FakeTreeCache()
+    controller = S2ProSGLangIterationController(tree_cache=tree_cache, im_end_token_id=999)
+    req = _FakeReq()
+    data = _make_request_data(req, max_new_tokens=8)
+    request = SchedulerRequest(request_id="req-1", data=data)
+
+    controller.update_request(request, _make_step_output(999))
+
+    assert req.output_ids == [999]
+    assert req.finished() is True
+    assert req.finished_len == 1
+    assert tree_cache.calls == []
+
+
+def test_iteration_controller_marks_length_finished_on_limit() -> None:
+    tree_cache = _FakeTreeCache()
+    controller = S2ProSGLangIterationController(tree_cache=tree_cache, im_end_token_id=999)
+    req = _FakeReq()
+    data = _make_request_data(req, max_new_tokens=2)
+    request = SchedulerRequest(request_id="req-1", data=data)
+
+    controller.update_request(request, _make_step_output(111))
+    assert req.finished() is False
+    assert len(tree_cache.calls) == 1
+
+    controller.update_request(request, _make_step_output(222))
+    assert req.finished() is True
+    assert req.finished_len == 2
+    assert req.output_ids == [111, 222]
+    assert len(tree_cache.calls) == 1
+
+
+def test_build_outputs_clones_model_buffers() -> None:
+    text_model = SimpleNamespace(
+        _output_codes=torch.tensor([[11, 12, 13], [21, 22, 23]], dtype=torch.long),
+        _output_semantic_ids=torch.tensor([11, 21], dtype=torch.long),
+    )
+    model_worker = SimpleNamespace(model_runner=SimpleNamespace(model=text_model))
+    runner = S2ProSGLangModelRunner(
+        model_worker=model_worker,
+        batch_planner=SimpleNamespace(),
+        semantic_begin_id=0,
+        semantic_end_id=1000,
+    )
+
+    req = _FakeReq()
+    data = _make_request_data(req)
+    scheduler_output = SimpleNamespace(
+        requests=[SchedulerRequest(request_id="req-1", data=data)]
+    )
+
+    outputs = runner._build_outputs(scheduler_output)
+    text_model._output_codes[0, 0] = 999
+
+    assert outputs["req-1"].data.codes[0, 0].item() == 11
+
+
+def test_resource_manager_free_clears_request_state(monkeypatch) -> None:
+    released: list[_FakeReq] = []
+
+    def _fake_release(req: _FakeReq, tree_cache: object) -> None:
+        released.append(req)
+
+    monkeypatch.setattr(
+        "sglang_omni.models.fishaudio_s2_pro.runtime.s2pro_sglang_ar.release_kv_cache",
+        _fake_release,
+    )
+
+    req = _FakeReq()
+    data = _make_request_data(req)
+    data._previous_semantic_tokens = [1, 2]
+    data._last_codebook_values = torch.tensor([7, 8], dtype=torch.long)
+    request = SchedulerRequest(request_id="req-1", data=data)
+
+    mgr = S2ProSGLangResourceManager(
+        token_to_kv_pool_allocator=None,
+        req_to_token_pool=None,
+        tree_cache=object(),
+    )
+    mgr.free(request)
+
+    assert released == [req]
+    assert data._previous_semantic_tokens == []
+    assert data._last_codebook_values is None


### PR DESCRIPTION
## Summary
This fixes a concurrency correctness issue in the S2-Pro unified decode path and adds regression coverage.

The patch does three things:
- clones per-request `codes` tensors when building outputs from the model-owned output buffers
- synchronizes Fish-specific finish state onto `req.finished_reason` / `req.finished_len` before unfinished-prefix caching decisions
- adds focused runtime tests for finish-state behavior, output isolation, and cleanup

## Reproduction
This issue shows up under concurrent S2-Pro unified decode when multiple requests are in flight at the same time.

A reliable way to reproduce it is to send several overlapping TTS requests that:
- use the same `reference_id`
- use different, easily distinguishable texts
- are launched with small offsets so they overlap during decode

### Example request set
Use five requests with marker phrases that are easy to identify by ear:
- A: `Alpha alpha alpha. This is diagnostic request A. Keep hearing alpha and only alpha all the way through this sample.`
- B: `Bravo bravo bravo. This is diagnostic request B. Keep hearing bravo and only bravo all the way through this sample.`
- C: `Charlie charlie charlie. This is diagnostic request C. Keep hearing charlie and only charlie all the way through this sample.`
- D: `Delta delta delta. This is diagnostic request D. Keep hearing delta and only delta all the way through this sample.`
- E: `Echo echo echo. This is diagnostic request E. Keep hearing echo and only echo all the way through this sample.`

All requests should:
- use the same reference voice
- use non-streaming generation
- launch with offsets like `0 ms`, `250 ms`, `500 ms`, `750 ms`, and `1000 ms`

### Expected behavior
Each WAV should contain only its own marker phrase and request text.

### Broken behavior before this fix
Before this patch, concurrent outputs can cross-contaminate.
Examples observed locally:
- request A started with its own text and then switched into request B's text
- request C returned request D's text
- HTTP responses still succeeded, but the audio content was wrong

This points to per-request outputs being read from shared model-owned buffers without isolating each row's result.

### Why this reproduces the bug well
This reproduction is intentionally simple:
- all requests share the same decode path
- all requests overlap in time
- each request is trivially identifiable by ear
- failures are easy to verify without inspecting tokens or logs

## Root cause
The unified S2-Pro decode path builds request outputs from model-owned output buffers. Without cloning the per-request slice, a later row can overwrite data that an earlier request still references.

There is also a finish-state mismatch in the Fish runtime:
- `update_request()` decides Fish stop conditions
- `is_finished()` separately recomputes them
- unfinished-prefix caching decisions can happen before the request's canonical finished state is reflected on `req`

## Fix
### 1. Isolate request outputs
`_build_outputs()` now clones each request's `codes` tensor before returning it.

### 2. Sync finish state onto `req`
`update_request()` now sets:
- `req.finished_reason`
- `req.finished_len`

for both:
- matched end token
- max length termination

`is_finished()` then relies on `data.req.finished()` instead of recomputing Fish-specific stop conditions separately.

### 3. Add regression tests
The new runtime tests cover:
- EOS marks the request finished and avoids unfinished-cache publication
- length limit marks the request finished on the correct step
- per-request output buffers are cloned
- resource cleanup clears request-local runtime state

## Testing
Added `tests/test_s2pro_runtime.py`.