### PR TITLE
[Bugfix] fix NameError in _apply_repetition_penalty

### DIFF
--- a/sglang_omni/engines/omni/runtime/sglang_ar.py
+++ b/sglang_omni/engines/omni/runtime/sglang_ar.py
@@ -904,19 +904,6 @@ class SGLangModelRunner:
             scores = torch.where(scores > 0, scores / penalty, scores * penalty)
             logits[row_idx, idx] = scores
 
-        model = model_worker.model_runner.model
-        self._embed_tokens, self._inner_model = self._get_inner_model_components(model)
-
-        hf_config = model_worker.model_runner.model_config.hf_config
-        thinker_cfg = (
-            hf_config.thinker_config
-            if hasattr(hf_config, "thinker_config")
-            else hf_config
-        )
-        self._image_token_id = thinker_cfg.image_token_id
-        self._video_token_id = thinker_cfg.video_token_id
-        self._audio_token_id = thinker_cfg.audio_token_id
-
     @staticmethod
     def _get_inner_model_components(model):
         outer = model.thinker if hasattr(model, "thinker") else model


### PR DESCRIPTION
## Motivation

`_apply_repetition_penalty` in `SGLangModelRunner` contains duplicated init code (lines 907-918) left over from PR #169 merge. 

This duplicated code also can be reliably triggered when running the server and issuing a request:

```
SGLANG_DISABLE_OVERLAP=1 sgl-omni serve \
  --model-path /workspace/models/qwen3_omni_30b \
  --port 8000 \
  --relay-backend shm
```

Then sending a request:

```
curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "default",
    "messages": [{"role": "user", "content": "hello"}],
    "max_tokens": 10
  }'
```

The request fails because _apply_repetition_penalty executes the duplicated init block, which references model_worker and raises a NameError. This causes the entire inference request to crash.

## Modifications

Remove duplicated init block from `_apply_repetition_penalty`. The same initialization already exists in `__init__` (lines 516-528).

## Checklist

- [x] Format your code according with pre-commit.