### PR TITLE
added missing param in qwen3-omni

### DIFF
--- a/sglang_omni/models/qwen3_omni/components/preprocessor.py
+++ b/sglang_omni/models/qwen3_omni/components/preprocessor.py
@@ -192,6 +192,7 @@ class Qwen3OmniPreprocessor:
             images = []
             videos = []
             audios = []
+            audio_target_sr = None
             image_cache_key = None
             raw_audio_cache_key = None
             video_cache_key = None


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

When running qwen3-omni with the following command,

```bash
sgl-omni serve --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct --port 8000 --relay_backend nixl
```

and curl it with the command:

```bash
curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "qwen3-omni",
    "messages": [
      {
        "role": "user",
        "content": "Who are you?"
      }
    ],
    "max_tokens": 2048,
    "temperature": 0.7
  }'
```

the server raises 500 internal error:

```text
RuntimeError: cannot access local variable 'audio_target_sr' where it is not associated with a value
INFO:     127.0.0.1:51720 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
```

## Modifications

We just need to add back the missing param.

<!-- Describe the changes made in this PR. -->

The results are correct now:

<img width="1494" height="216" alt="Screenshot 2026-03-26 at 2 38 10 PM" src="https://github.com/user-attachments/assets/64cb013c-eeac-4264-a3b2-d15b206b1ad3" />


## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
