### PR TITLE
[Benchmark] Add Chinese text normalization for WER benchmark

### DIFF
--- a/benchmarks/performance/tts/benchmark_tts_wer.py
+++ b/benchmarks/performance/tts/benchmark_tts_wer.py
@@ -175,11 +175,9 @@ def _get_en_normalizer():
 
 def normalize_text(text: str, lang: str) -> str:
     if lang == "zh":
-        # Chinese numeral normalization (e.g., 四百六十五 → 465, 二零零二年 → 2002年)
-        # so that ASR hypothesis and reference text align on number format.
-        text = text.replace("\u3007", "\u96f6")  # 〇 (circle zero) → 零
-        text = text.replace("\u4e24", "\u4e8c")  # 两 → 二 (cn2an handles 二 better)
-        text = cn2an.transform(text, "cn2an")
+        # Normalize Arabic numerals to spoken-form Chinese (e.g., 2002年 → 二零零二年)
+        # so that reference text aligns with ASR output, which is always spoken-form.
+        text = cn2an.transform(text, "an2cn")
 
         from zhon.hanzi import punctuation as zh_punct
 

--- a/tests/test_wer_normalize.py
+++ b/tests/test_wer_normalize.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for Chinese inverse text normalization in WER benchmark.
+"""Tests for Chinese text normalization in WER benchmark.
 
-Verifies that normalize_text correctly converts Chinese numerals to Arabic
-numerals before character-level WER comparison, so that spoken-form ASR output
-(e.g., 四百六十五) matches written-form reference text (e.g., 465).
+Verifies that normalize_text converts Arabic numerals to spoken-form Chinese
+so that reference text aligns with ASR output (which is always spoken-form).
 """
 
 import sys
@@ -29,45 +28,60 @@ def _suppress_cn2an_warnings():
         yield
 
 
-# --- Group 1: Chinese ITN (new behavior) ---
+# --- Group 1: Arabic → spoken-form normalization ---
+# Reference text with Arabic numerals should normalize to the same result
+# as spoken-form Chinese (what ASR outputs).
 
 
 @pytest.mark.parametrize(
-    "spoken, written, expected",
+    "written, spoken, expected",
     [
-        ("四百六十五", "465", "4 6 5"),
-        ("二零零二年一月二十八日", "2002年1月28日", "2 0 0 2 年 1 月 2 8 日"),
-        ("一二三四五", "12345", "1 2 3 4 5"),
-        ("十三点五", "13.5", "1 3 5"),
-        ("百分之六点三", "6.3%", "6 3"),
-        ("共四百六十五篇", "共465篇", "共 4 6 5 篇"),
-        ("2002年", "2002年", "2 0 0 2 年"),
-        ("你好世界", "你好世界", "你 好 世 界"),
-        ("二〇二二年", "2022年", "2 0 2 2 年"),
-        ("两百五十", "250", "2 5 0"),
-        ("三分之一", "1/3", "1 3"),
+        ("465", "四百六十五", "四 百 六 十 五"),
+        ("2002年1月28日", "二零零二年一月二十八日", "二 零 零 二 年 一 月 二 十 八 日"),
+        ("13.5", "十三点五", "十 三 点 五"),
+        ("6.3%", "百分之六点三", "百 分 之 六 点 三"),
+        ("共465篇", "共四百六十五篇", "共 四 百 六 十 五 篇"),
+        ("2022年", "二零二二年", "二 零 二 二 年"),
+        ("250", "二百五十", "二 百 五 十"),
+        ("25公里", "二十五公里", "二 十 五 公 里"),
+        ("1/3", "三分之一", "三 分 之 一"),
     ],
     ids=[
         "cardinal",
         "date",
-        "sequential_digits",
         "decimal",
         "percentage",
         "mixed_text",
-        "already_arabic",
-        "no_numbers",
-        "circle_zero",
-        "liang_variant",
+        "year",
+        "round_number",
+        "with_unit",
         "fraction",
     ],
 )
-def test_zh_itn_spoken_matches_written(spoken, written, expected):
-    """Spoken-form and written-form should normalize to the same output."""
-    assert normalize_text(spoken, "zh") == expected
+def test_zh_arabic_matches_spoken(written, spoken, expected):
+    """Arabic-numeral reference and spoken-form ASR should normalize identically."""
     assert normalize_text(written, "zh") == expected
+    assert normalize_text(spoken, "zh") == expected
 
 
-# --- Group 2: Chinese regression tests (existing behavior preserved) ---
+# --- Group 2: Spoken-form passthrough (seed-tts-eval zh dataset uses this) ---
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("导航开始，全程二十五公里，预计需要十二分钟。", "导 航 开 始 全 程 二 十 五 公 里 预 计 需 要 十 二 分 钟"),
+        ("一点五公里后，右转驶入京藏高速辅路。", "一 点 五 公 里 后 右 转 驶 入 京 藏 高 速 辅 路"),
+        ("你好世界", "你 好 世 界"),
+    ],
+    ids=["navigation_distance", "navigation_decimal", "no_numbers"],
+)
+def test_zh_spoken_form_passthrough(text, expected):
+    """Spoken-form text (no Arabic digits) passes through unchanged."""
+    assert normalize_text(text, "zh") == expected
+
+
+# --- Group 3: Existing behavior preserved ---
 
 
 @pytest.mark.parametrize(
@@ -83,7 +97,7 @@ def test_zh_existing_behavior(text, expected):
     assert normalize_text(text, "zh") == expected
 
 
-# --- Group 3: English path not broken ---
+# --- Group 4: English path not broken ---
 
 
 def test_en_unchanged():


### PR DESCRIPTION
## Motivation

FunASR paraformer-zh always outputs spoken-form Chinese (`二十五公里`), so strategy here is to convert reference text to spoken-form also.

Note: the seed-tts-eval Chinese dataset already uses spoken-form numerals, so this is a no-op on that dataset. But it makes the benchmark robust to any dataset that uses Arabic numerals in reference text.

Flagged by @zhaochenyang20 in #200.

## Modifications

- Use `cn2an` (`an2cn` mode) to convert Arabic numerals → spoken-form Chinese in `normalize_text`, matching what ASR outputs
- Spoken-form text passes through unchanged — no-op on current seed-tts-eval zh dataset
- 16 unit tests: Arabic→spoken conversion, spoken-form passthrough with real seed-tts-eval samples, regression, English path

## Note

`normalize_text` is a pure string function but lives in `benchmark_tts_wer.py` which has heavy top-level imports (torch, scipy, etc.). Tests mock those unrelated imports. A future refactor could extract `normalize_text` into its own module.

## Related

- #200 — Benchmark refactor tracking issue
- #216 — S2 Pro WER benchmark by @yuan-luo

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.