### PR TITLE
[S2Pro]: preserve sglang request ids for concurrent tts

### DIFF
--- a/sglang_omni/models/fishaudio_s2_pro/pipeline/engine_io.py
+++ b/sglang_omni/models/fishaudio_s2_pro/pipeline/engine_io.py
@@ -14,7 +14,7 @@ from sglang_omni.models.fishaudio_s2_pro.runtime.s2pro_sglang_ar import (
 
 
 def build_sglang_tts_request(
-    state: S2ProState, tokenizer: Any
+    state: S2ProState, tokenizer: Any, request_id: str
 ) -> S2ProSGLangRequestData:
     from sglang.srt.managers.schedule_batch import Req
     from sglang.srt.sampling.sampling_params import SamplingParams
@@ -35,7 +35,7 @@ def build_sglang_tts_request(
     )
 
     req = Req(
-        rid="",
+        rid=request_id,
         origin_input_text="",
         origin_input_ids=input_ids_list,
         sampling_params=sampling_params,

--- a/sglang_omni/models/fishaudio_s2_pro/pipeline/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/pipeline/stages.py
@@ -328,7 +328,7 @@ def create_sglang_tts_engine_executor(
 
     def _request_builder(payload: StagePayload):
         state = load_state(payload)
-        return build_sglang_tts_request(state, tokenizer)
+        return build_sglang_tts_request(state, tokenizer, request_id=payload.request_id)
 
     def _result_builder(payload: StagePayload, result: Any) -> StagePayload:
         state = load_state(payload)

--- a/tests/test_model/test_s2pro_benchmark.py
+++ b/tests/test_model/test_s2pro_benchmark.py
@@ -42,6 +42,7 @@ PLAIN_NON_STREAM_MIN_TOK_PER_S = 80
 PLAIN_NON_STREAM_MAX_RTF = 0.35
 PLAIN_STREAM_MAX_LATENCY_S = 4.0
 PLAIN_STREAM_MIN_THROUGHPUT_QPS = 0.25
+VC_CONCURRENT_MAX_CONCURRENCY = 16
 
 
 def _run_benchmark(
@@ -318,6 +319,28 @@ def test_voice_cloning_streaming(
     assert (
         summary["throughput_qps"] >= VC_STREAM_MIN_THROUGHPUT_QPS
     ), f"throughput_qps {summary['throughput_qps']} < {VC_STREAM_MIN_THROUGHPUT_QPS}"
+
+
+@pytest.mark.benchmark
+def test_voice_cloning_concurrent_non_streaming(
+    server_process: subprocess.Popen,
+    server_port: int,
+    dataset_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """Voice cloning (non-streaming, concurrent): all requests must succeed."""
+    results = _run_benchmark(
+        server_port,
+        str(dataset_dir / "en" / "meta.lst"),
+        str(tmp_path / "vc_concurrent_nonstream"),
+        ["--max-concurrency", str(VC_CONCURRENT_MAX_CONCURRENCY)],
+    )
+    summary, per_request = results["summary"], results["per_request"]
+    _assert_summary_metrics(summary)
+    _assert_per_request_fields(per_request)
+    assert (
+        summary["throughput_qps"] > 0
+    ), f"Expected positive throughput, got {summary['throughput_qps']}"
 
 
 @pytest.mark.benchmark


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. --> Fix S2 Pro concurrent `/v1/audio/speech` failures by preserving the pipeline request ID when constructing the SGLang `Req`.

Before this change, S2 Pro built every request with `Req(rid="")`. The SGLang planner keys live requests by `req.rid`, so concurrent requests could overwrite each other in planner state. Under concurrency, that corrupted prefill batches and later surfaced as tensor-shape errors in the S2 Pro prefill path.

## Modifications

<!-- Describe the changes made in this PR. -->
  - pass `payload.request_id` into S2 Pro request construction
  - build `Req(rid=request_id)` instead of `Req(rid="")`
  - add a concurrent S2 Pro benchmark regression in CI (`max_concurrency=16` on the mini dataset)
## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" --> Fixes #228. 

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html --> 
- `voice_clone_s2pro.py` WER unchanged after
- corpus WER remained `1.09%`

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

Before Fix:
<img width="620" height="335" alt="image" src="https://github.com/user-attachments/assets/e40b7f6c-bdb6-42f3-b337-0f327df1ad90" />

After Fix:
<img width="708" height="325" alt="image" src="https://github.com/user-attachments/assets/ff8a4f02-52b1-4c21-8eec-d1d94e12783e" />


## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
