### PR TITLE
refactor(benchmarks): introduce model-agnostic benchmark framework

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,9 +1,28 @@
 # SGLang Omni Benchmarks
 
-Comprehensive benchmark suite for SGLang Omni, covering both performance (latency, throughput, RTF etc.) and accuracy (quality metrics) across all supported modality combinations. Omni models operate on a `{video, audio, text} x {video, audio, text}` input-output matrix. The table below tracks benchmark coverage.
+Model-agnostic benchmark framework for SGLang Omni. V1 focuses on performance
+benchmarking for the models and HTTP APIs that already exist in this repo.
+The public entrypoint is model-first via explicit benchmark profiles.
 
 ## Performance Benchmarks
 
-### TTS Voice Cloning
+### Generic Runner
 
-[`performance/tts/benchmark_tts_speed.py`](performance/tts/benchmark_tts_speed.py): Benchmarks online serving latency and throughput for TTS models via the `/v1/audio/speech` HTTP API.
+Run the new framework via:
+
+```bash
+python3 -m benchmarks.run \
+  --base-url http://localhost:8000 \
+  --model fishaudio/s2-pro \
+  --model-profile s2_tts \
+  --case voice-cloning \
+  --dataset seedtts_testset/en/meta.lst
+```
+
+Built-in profiles:
+
+- `s2_tts`
+
+The legacy [`performance/tts/benchmark_tts_speed.py`](performance/tts/benchmark_tts_speed.py)
+script is kept temporarily, but the supported entrypoint for the new framework
+is [`benchmarks.run`](run.py).

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,2 @@
+"""Benchmark framework for sglang-omni."""
+

--- a/benchmarks/adapters/__init__.py
+++ b/benchmarks/adapters/__init__.py
@@ -1,0 +1,2 @@
+"""Model and request-family adapters."""
+

--- a/benchmarks/adapters/model/__init__.py
+++ b/benchmarks/adapters/model/__init__.py
@@ -1,0 +1,2 @@
+"""Model adapters for benchmark profiles."""
+

--- a/benchmarks/adapters/model/base.py
+++ b/benchmarks/adapters/model/base.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from benchmarks.core.types import BenchmarkCaseSpec, BenchmarkRunConfig, NormalizedSample, PreparedRequest
+
+
+class ModelAdapter(ABC):
+    name: str
+
+    @abstractmethod
+    def build_request(
+        self,
+        *,
+        sample: NormalizedSample,
+        case_spec: BenchmarkCaseSpec,
+        run_config: BenchmarkRunConfig,
+        served_model_name: str,
+    ) -> PreparedRequest:
+        raise NotImplementedError
+

--- a/benchmarks/adapters/model/s2_tts.py
+++ b/benchmarks/adapters/model/s2_tts.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from benchmarks.core.types import BenchmarkCaseSpec, BenchmarkRunConfig, NormalizedSample, PreparedRequest
+
+from .base import ModelAdapter
+
+
+class S2TTSModelAdapter(ModelAdapter):
+    name = "s2_tts_adapter"
+
+    def build_request(
+        self,
+        *,
+        sample: NormalizedSample,
+        case_spec: BenchmarkCaseSpec,
+        run_config: BenchmarkRunConfig,
+        served_model_name: str,
+    ) -> PreparedRequest:
+        references = sample.payload.get("references") or []
+        payload: dict[str, object] = {
+            "model": served_model_name,
+            "input": sample.payload["text"],
+            "response_format": "wav",
+            "stream": run_config.stream,
+        }
+        max_output_tokens = (
+            run_config.max_output_tokens or case_spec.default_max_output_tokens
+        )
+        if max_output_tokens is not None:
+            payload["max_new_tokens"] = max_output_tokens
+        if run_config.temperature is not None:
+            payload["temperature"] = run_config.temperature
+        if run_config.top_p is not None:
+            payload["top_p"] = run_config.top_p
+        if run_config.top_k is not None:
+            payload["top_k"] = run_config.top_k
+        if run_config.repetition_penalty is not None:
+            payload["repetition_penalty"] = run_config.repetition_penalty
+
+        if case_spec.case_id == "voice-cloning" and references:
+            payload["references"] = references
+
+        return PreparedRequest(
+            request_id=sample.sample_id,
+            input_preview=sample.input_preview,
+            payload=payload,
+        )
+

--- a/benchmarks/adapters/request_family/__init__.py
+++ b/benchmarks/adapters/request_family/__init__.py
@@ -1,0 +1,6 @@
+"""HTTP request-family adapters."""
+
+from .base import get_request_family_adapter
+
+__all__ = ["get_request_family_adapter"]
+

--- a/benchmarks/adapters/request_family/base.py
+++ b/benchmarks/adapters/request_family/base.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import struct
+import time
+from abc import ABC, abstractmethod
+from typing import Any
+
+import aiohttp
+
+from benchmarks.core.types import PerRequestResult, PreparedRequest
+
+WAV_HEADER_SIZE = 44
+SSE_DATA_PREFIX = "data: "
+SSE_DONE_MARKER = "data: [DONE]"
+
+
+class RequestFamilyAdapter(ABC):
+    family_name: str
+    endpoint_path: str
+
+    async def execute(
+        self,
+        *,
+        session: aiohttp.ClientSession,
+        base_url: str,
+        request: PreparedRequest,
+    ) -> PerRequestResult:
+        result = PerRequestResult(
+            request_id=request.request_id,
+            input_preview=request.input_preview,
+        )
+        start_time = time.perf_counter()
+        url = f"{base_url}{self.endpoint_path}"
+
+        try:
+            async with session.post(url, json=request.payload) as response:
+                if response.status != 200:
+                    body_text = await response.text()
+                    result.error = f"HTTP {response.status}: {body_text}"
+                elif request.payload.get("stream"):
+                    await self._handle_stream_response(response, result)
+                else:
+                    await self._handle_non_stream_response(response, result)
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            result.error = str(exc)
+        finally:
+            result.latency_s = time.perf_counter() - start_time
+
+        if result.audio_duration_s and result.audio_duration_s > 0:
+            result.rtf = result.latency_s / result.audio_duration_s
+        return result
+
+    @abstractmethod
+    async def _handle_stream_response(
+        self,
+        response: aiohttp.ClientResponse,
+        result: PerRequestResult,
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def _handle_non_stream_response(
+        self,
+        response: aiohttp.ClientResponse,
+        result: PerRequestResult,
+    ) -> None:
+        raise NotImplementedError
+
+
+def get_request_family_adapter(name: str) -> RequestFamilyAdapter:
+    from .speech_http import SpeechHTTPAdapter
+
+    adapters: dict[str, RequestFamilyAdapter] = {
+        "speech_http": SpeechHTTPAdapter(),
+    }
+    if name not in adapters:
+        raise ValueError(f"Unknown request family: {name}")
+    return adapters[name]
+
+
+def wav_duration(wav_bytes: bytes) -> float:
+    if len(wav_bytes) <= WAV_HEADER_SIZE:
+        return 0.0
+    sample_rate = struct.unpack_from("<I", wav_bytes, 24)[0]
+    num_channels = struct.unpack_from("<H", wav_bytes, 22)[0]
+    bits_per_sample = struct.unpack_from("<H", wav_bytes, 34)[0]
+    if sample_rate == 0 or num_channels == 0 or bits_per_sample == 0:
+        return 0.0
+    bytes_per_sample = num_channels * bits_per_sample // 8
+    pcm_size = len(wav_bytes) - WAV_HEADER_SIZE
+    return pcm_size / (sample_rate * bytes_per_sample)
+
+
+def decode_wav_audio(audio_b64: str) -> bytes:
+    return base64.b64decode(audio_b64)
+
+
+def parse_sse_event(line: str) -> dict[str, Any] | None:
+    if not line.startswith(SSE_DATA_PREFIX) or line == SSE_DONE_MARKER:
+        return None
+    return json.loads(line[len(SSE_DATA_PREFIX):])
+
+
+def apply_usage(
+    result: PerRequestResult,
+    usage: dict[str, Any] | None,
+) -> None:
+    if not usage:
+        return
+    prompt_tokens = usage.get("prompt_tokens")
+    completion_tokens = usage.get("completion_tokens")
+    engine_time_s = usage.get("engine_time_s")
+    if prompt_tokens is not None:
+        result.prompt_tokens = int(prompt_tokens)
+    if completion_tokens is not None:
+        result.completion_tokens = int(completion_tokens)
+    if engine_time_s is not None:
+        result.engine_time_s = float(engine_time_s)
+    if result.completion_tokens and result.engine_time_s and result.engine_time_s > 0:
+        result.tok_per_s = result.completion_tokens / result.engine_time_s

--- a/benchmarks/adapters/request_family/speech_http.py
+++ b/benchmarks/adapters/request_family/speech_http.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import base64
+
+import aiohttp
+
+from benchmarks.core.types import PerRequestResult
+
+from .base import RequestFamilyAdapter, apply_usage, parse_sse_event, wav_duration
+
+
+class SpeechHTTPAdapter(RequestFamilyAdapter):
+    family_name = "speech_http"
+    endpoint_path = "/v1/audio/speech"
+
+    async def _handle_non_stream_response(
+        self,
+        response: aiohttp.ClientResponse,
+        result: PerRequestResult,
+    ) -> None:
+        audio_bytes = await response.read()
+        result.audio_duration_s = wav_duration(audio_bytes)
+        result.success = result.audio_duration_s > 0
+        if not result.success:
+            result.error = (
+                f"Empty or invalid audio response ({len(audio_bytes)} bytes)"
+            )
+            return
+
+        result.audio_bytes = audio_bytes
+
+        usage = {
+            "prompt_tokens": response.headers.get("X-Prompt-Tokens"),
+            "completion_tokens": response.headers.get("X-Completion-Tokens"),
+            "engine_time_s": response.headers.get("X-Engine-Time"),
+        }
+        apply_usage(result, usage)
+
+    async def _handle_stream_response(
+        self,
+        response: aiohttp.ClientResponse,
+        result: PerRequestResult,
+    ) -> None:
+        total_audio_duration = 0.0
+        usage: dict | None = None
+        buffer = bytearray()
+
+        async for chunk in response.content.iter_any():
+            buffer.extend(chunk)
+            while b"\n" in buffer:
+                idx = buffer.index(b"\n")
+                raw_line = bytes(buffer[:idx])
+                del buffer[:idx + 1]
+                line = raw_line.decode("utf-8", errors="replace").strip()
+                total_audio_duration, usage = _process_sse_line(
+                    line, total_audio_duration, usage
+                )
+        if buffer.strip():
+            line = bytes(buffer).decode("utf-8", errors="replace").strip()
+            total_audio_duration, usage = _process_sse_line(
+                line, total_audio_duration, usage
+            )
+
+        result.audio_duration_s = total_audio_duration
+        result.success = total_audio_duration > 0
+        if not result.success:
+            result.error = "No audio chunks received from streaming speech response"
+            return
+        apply_usage(result, usage)
+
+
+def _process_sse_line(
+    line: str,
+    total_duration: float,
+    usage: dict | None,
+) -> tuple[float, dict | None]:
+    event = parse_sse_event(line)
+    if event is None:
+        return total_duration, usage
+    audio = event.get("audio")
+    if isinstance(audio, dict) and audio.get("data"):
+        total_duration += wav_duration(base64.b64decode(audio["data"]))
+    event_usage = event.get("usage")
+    if isinstance(event_usage, dict):
+        usage = event_usage
+    return total_duration, usage

--- a/benchmarks/core/__init__.py
+++ b/benchmarks/core/__init__.py
@@ -1,0 +1,2 @@
+"""Core types and helpers for the benchmark framework."""
+

--- a/benchmarks/core/http.py
+++ b/benchmarks/core/http.py
@@ -1,0 +1,1 @@
+"""HTTP utilities for the benchmark framework."""

--- a/benchmarks/core/metrics.py
+++ b/benchmarks/core/metrics.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import statistics
+
+from .types import PerRequestResult, RunSummary
+
+
+def compute_run_summary(
+    *,
+    results: list[PerRequestResult],
+    run_wall_time_s: float,
+    model_profile: str,
+    case_id: str,
+    scenario_id: str,
+    request_family: str,
+) -> RunSummary:
+    successes = [result for result in results if result.success]
+    failures = len(results) - len(successes)
+
+    summary = RunSummary(
+        model_profile=model_profile,
+        case=case_id,
+        scenario=scenario_id,
+        request_family=request_family,
+        completed_requests=len(successes),
+        failed_requests=failures,
+        run_wall_time_s=run_wall_time_s,
+    )
+
+    if not successes:
+        return summary
+
+    latencies = [result.latency_s for result in successes]
+    audio_durations = _non_null(result.audio_duration_s for result in successes)
+    rtfs = _positive(result.rtf for result in successes)
+    tok_rates = _positive(result.tok_per_s for result in successes)
+    prompt_tokens = _positive_int(result.prompt_tokens for result in successes)
+    completion_tokens = _positive_int(
+        result.completion_tokens for result in successes
+    )
+    engine_times = _positive(result.engine_time_s for result in successes)
+
+    summary.latency_mean_s = statistics.fmean(latencies)
+    summary.latency_median_s = statistics.median(latencies)
+    summary.latency_p95_s = _percentile(latencies, 95)
+    summary.latency_p99_s = _percentile(latencies, 99)
+    if run_wall_time_s > 0:
+        summary.throughput_qps = len(successes) / run_wall_time_s
+    if audio_durations:
+        summary.audio_duration_mean_s = statistics.fmean(audio_durations)
+    if rtfs:
+        summary.rtf_mean = statistics.fmean(rtfs)
+        summary.rtf_median = statistics.median(rtfs)
+    if tok_rates:
+        summary.tok_per_s_mean = statistics.fmean(tok_rates)
+        summary.tok_per_s_median = statistics.median(tok_rates)
+    if prompt_tokens:
+        summary.prompt_tokens_mean = statistics.fmean(prompt_tokens)
+        summary.prompt_tokens_total = sum(prompt_tokens)
+    if completion_tokens:
+        summary.completion_tokens_mean = statistics.fmean(completion_tokens)
+        summary.completion_tokens_total = sum(completion_tokens)
+    if completion_tokens and engine_times and sum(engine_times) > 0:
+        summary.tok_per_s_agg = sum(completion_tokens) / sum(engine_times)
+
+    return summary
+
+
+def _percentile(values: list[float], percentile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (len(ordered) - 1) * (percentile / 100.0)
+    lower = int(rank)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = rank - lower
+    return ordered[lower] * (1 - weight) + ordered[upper] * weight
+
+
+def _non_null(values) -> list[float]:
+    return [value for value in values if value is not None]
+
+
+def _positive(values) -> list[float]:
+    return [value for value in values if value is not None and value > 0]
+
+
+def _positive_int(values) -> list[int]:
+    return [value for value in values if value is not None and value > 0]
+

--- a/benchmarks/core/reporters.py
+++ b/benchmarks/core/reporters.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import csv
+import json
+import os
+
+from .types import BenchmarkResults
+
+
+def print_summary(results: BenchmarkResults) -> None:
+    summary = results.summary
+    line_width = 68
+    print(f"\n{'=' * line_width}")
+    print(f"{'Benchmark Result':^{line_width}}")
+    print(f"{'=' * line_width}")
+    print(f"  {'Model profile:':<28} {summary.model_profile}")
+    print(f"  {'Case:':<28} {summary.case}")
+    print(f"  {'Scenario:':<28} {summary.scenario}")
+    print(f"  {'Request family:':<28} {summary.request_family}")
+    print(f"  {'Completed requests:':<28} {summary.completed_requests}")
+    print(f"  {'Failed requests:':<28} {summary.failed_requests}")
+    print(f"  {'Run wall time (s):':<28} {summary.to_dict()['run_wall_time_s']}")
+    print("-" * line_width)
+    if summary.latency_mean_s is not None:
+        print(f"  {'Latency mean (s):':<28} {summary.to_dict()['latency_mean_s']}")
+        print(
+            f"  {'Latency median (s):':<28} {summary.to_dict()['latency_median_s']}"
+        )
+        print(f"  {'Latency p95 (s):':<28} {summary.to_dict()['latency_p95_s']}")
+        print(f"  {'Latency p99 (s):':<28} {summary.to_dict()['latency_p99_s']}")
+    if summary.throughput_qps is not None:
+        print(f"  {'Throughput (req/s):':<28} {summary.to_dict()['throughput_qps']}")
+    if summary.audio_duration_mean_s is not None:
+        print(
+            f"  {'Audio duration mean (s):':<28} "
+            f"{summary.to_dict()['audio_duration_mean_s']}"
+        )
+    if summary.rtf_mean is not None:
+        print(f"  {'RTF mean:':<28} {summary.to_dict()['rtf_mean']}")
+        print(f"  {'RTF median:':<28} {summary.to_dict()['rtf_median']}")
+    if summary.tok_per_s_mean is not None:
+        print(
+            f"  {'Tok/s (per-request mean):':<28} "
+            f"{summary.to_dict()['tok_per_s_mean']}"
+        )
+    if summary.tok_per_s_agg is not None:
+        print(
+            f"  {'Tok/s (aggregate):':<28} {summary.to_dict()['tok_per_s_agg']}"
+        )
+    print(f"{'=' * line_width}")
+
+
+def save_results(results: BenchmarkResults, output_dir: str) -> None:
+    os.makedirs(output_dir, exist_ok=True)
+    json_path = os.path.join(output_dir, "benchmark_results.json")
+    csv_path = os.path.join(output_dir, "per_request.csv")
+
+    with open(json_path, "w", encoding="utf-8") as handle:
+        json.dump(results.to_dict(), handle, indent=2, ensure_ascii=False)
+
+    with open(csv_path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "id",
+                "input_preview",
+                "success",
+                "latency_s",
+                "first_audio_latency_s",
+                "audio_duration_s",
+                "rtf",
+                "prompt_tokens",
+                "completion_tokens",
+                "engine_time_s",
+                "tok_per_s",
+                "error",
+            ],
+        )
+        writer.writeheader()
+        for result in results.per_request:
+            writer.writerow(result.to_dict())
+

--- a/benchmarks/core/runner.py
+++ b/benchmarks/core/runner.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import os
+import random
+import time
+
+import aiohttp
+from tqdm.asyncio import tqdm
+
+from benchmarks.adapters.request_family import get_request_family_adapter
+from benchmarks.core.metrics import compute_run_summary
+from benchmarks.core.reporters import print_summary, save_results
+from benchmarks.core.types import BenchmarkResults, BenchmarkRunConfig, PreparedRequest
+from benchmarks.profiles.registry import PROFILE_REGISTRY
+from benchmarks.profiles.resolver import resolve_profile_selection
+
+logger = logging.getLogger(__name__)
+
+
+async def run_from_config(
+    run_config: BenchmarkRunConfig,
+) -> BenchmarkResults:
+    _validate_run_config(run_config)
+    await wait_for_service(run_config.base_url)
+    selection = resolve_profile_selection(
+        run_config=run_config,
+        registry=PROFILE_REGISTRY,
+    )
+    profile = selection.model_profile
+    case_spec = selection.case_spec
+
+    if case_spec.requires_dataset_path and run_config.dataset_path is None:
+        raise ValueError(
+            f"Case '{case_spec.case_id}' for profile '{selection.model_profile_name}' "
+            "requires --dataset"
+        )
+    if run_config.stream and not case_spec.supports_stream:
+        raise ValueError(
+            f"Case '{case_spec.case_id}' for profile '{selection.model_profile_name}' "
+            "does not support streaming"
+        )
+
+    samples = profile.dataset_loader.load(
+        dataset_path=run_config.dataset_path,
+        max_samples=run_config.max_samples,
+    )
+    if not samples:
+        raise ValueError(
+            f"Dataset loader '{profile.dataset_loader.name}' returned no samples"
+        )
+    requests = [
+        profile.model_adapter.build_request(
+            sample=sample,
+            case_spec=case_spec,
+            run_config=run_config,
+            served_model_name=selection.served_model_name,
+        )
+        for sample in samples
+    ]
+    logger.info(
+        "Prepared %d requests for profile=%s case=%s",
+        len(requests),
+        selection.model_profile_name,
+        case_spec.case_id,
+    )
+
+    request_family = get_request_family_adapter(selection.request_family)
+
+    async with aiohttp.ClientSession() as session:
+        if run_config.warmup > 0 and requests:
+            await _run_warmup(
+                requests=requests,
+                warmup_count=run_config.warmup,
+                base_url=run_config.base_url,
+                request_family=request_family,
+                session=session,
+            )
+
+        started_at = time.perf_counter()
+        per_request = await _run_requests(
+            requests=requests,
+            base_url=run_config.base_url,
+            request_family=request_family,
+            session=session,
+            max_concurrency=run_config.max_concurrency,
+            request_rate=run_config.request_rate,
+            disable_tqdm=run_config.disable_tqdm,
+        )
+        run_wall_time_s = time.perf_counter() - started_at
+
+    if run_config.save_audio and run_config.output_dir:
+        _save_audio_files(per_request, run_config.output_dir)
+
+    summary = compute_run_summary(
+        results=per_request,
+        run_wall_time_s=run_wall_time_s,
+        model_profile=selection.model_profile_name,
+        case_id=case_spec.case_id,
+        scenario_id=case_spec.scenario_id,
+        request_family=request_family.family_name,
+    )
+    results = BenchmarkResults(
+        summary=summary,
+        config={
+            "model_profile": selection.model_profile_name,
+            "served_model_name": selection.served_model_name,
+            "case": case_spec.case_id,
+            "scenario": case_spec.scenario_id,
+            "request_family": request_family.family_name,
+            "dataset_loader": selection.dataset_loader_name,
+            "model_adapter": selection.model_adapter_name,
+            "base_url": run_config.base_url,
+            "model": run_config.model,
+            "dataset": run_config.dataset_path,
+            "stream": run_config.stream,
+            "max_samples": run_config.max_samples,
+            "max_output_tokens": run_config.max_output_tokens
+            or case_spec.default_max_output_tokens,
+            "temperature": run_config.temperature,
+            "top_p": run_config.top_p,
+            "top_k": run_config.top_k,
+            "repetition_penalty": run_config.repetition_penalty,
+            "warmup": run_config.warmup,
+            "max_concurrency": run_config.max_concurrency,
+            "request_rate": (
+                "inf" if math.isinf(run_config.request_rate) else run_config.request_rate
+            ),
+            "save_audio": run_config.save_audio,
+        },
+        per_request=per_request,
+    )
+    print_summary(results)
+    save_results(results, run_config.output_dir)
+    return results
+
+
+def _validate_run_config(run_config: BenchmarkRunConfig) -> None:
+    if not run_config.model_profile:
+        raise ValueError("--model-profile is required")
+    if run_config.max_samples is not None and run_config.max_samples <= 0:
+        raise ValueError("--max-samples must be greater than 0 when provided")
+    if run_config.warmup < 0:
+        raise ValueError("--warmup must be greater than or equal to 0")
+    if run_config.max_concurrency <= 0:
+        raise ValueError("--max-concurrency must be greater than 0")
+    if not math.isinf(run_config.request_rate) and run_config.request_rate <= 0:
+        raise ValueError("--request-rate must be positive or inf")
+
+
+async def wait_for_service(
+    base_url: str,
+    timeout_s: int = 1200,
+) -> None:
+    logger.info("Waiting for service at %s ...", base_url)
+    started_at = time.perf_counter()
+    while True:
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"{base_url}/health", timeout=aiohttp.ClientTimeout(total=5)
+                ) as resp:
+                    if resp.status == 200:
+                        body = await resp.json()
+                        if body.get("status") == "healthy":
+                            logger.info("Service is ready.")
+                            return
+        except (aiohttp.ClientError, Exception):
+            pass
+        if time.perf_counter() - started_at > timeout_s:
+            raise TimeoutError(f"Service at {base_url} not ready within {timeout_s}s")
+        await asyncio.sleep(1)
+
+
+async def _run_warmup(
+    *,
+    requests: list[PreparedRequest],
+    warmup_count: int,
+    base_url: str,
+    request_family,
+    session: aiohttp.ClientSession,
+) -> None:
+    logger.info("Warmup (%d requests)...", warmup_count)
+    for index, request in enumerate(requests[:warmup_count], start=1):
+        result = await request_family.execute(
+            session=session,
+            base_url=base_url,
+            request=request,
+        )
+        status = "ok" if result.success else result.error
+        logger.info("  warmup %d/%d: %s", index, warmup_count, status)
+
+
+async def _run_requests(
+    *,
+    requests: list[PreparedRequest],
+    base_url: str,
+    request_family,
+    session: aiohttp.ClientSession,
+    max_concurrency: int,
+    request_rate: float,
+    disable_tqdm: bool = False,
+) -> list:
+    semaphore = asyncio.Semaphore(max_concurrency) if max_concurrency else None
+    pbar = tqdm(total=len(requests), disable=disable_tqdm)
+
+    async def _execute(request: PreparedRequest):
+        if semaphore is not None:
+            async with semaphore:
+                result = await request_family.execute(
+                    session=session,
+                    base_url=base_url,
+                    request=request,
+                )
+        else:
+            result = await request_family.execute(
+                session=session,
+                base_url=base_url,
+                request=request,
+            )
+        pbar.update(1)
+        return result
+
+    tasks = []
+    for request in requests:
+        if not math.isinf(request_rate):
+            await asyncio.sleep(random.expovariate(request_rate))
+        tasks.append(asyncio.create_task(_execute(request)))
+    results = await asyncio.gather(*tasks)
+    pbar.close()
+    return results
+
+
+def _save_audio_files(per_request: list, output_dir: str) -> None:
+    audio_dir = os.path.join(output_dir, "audio")
+    os.makedirs(audio_dir, exist_ok=True)
+    for result in per_request:
+        if result.audio_bytes:
+            audio_path = os.path.join(audio_dir, f"{result.request_id}.wav")
+            with open(audio_path, "wb") as f:
+                f.write(result.audio_bytes)
+    logger.info("Audio files saved to %s", audio_dir)

--- a/benchmarks/core/types.py
+++ b/benchmarks/core/types.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+INPUT_PREVIEW_LENGTH = 60
+
+
+@dataclass(frozen=True)
+class NormalizedSample:
+    sample_id: str
+    input_preview: str
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class BenchmarkCaseSpec:
+    case_id: str
+    scenario_id: str
+    description: str
+    requires_dataset_path: bool
+    supports_stream: bool = True
+    default_max_output_tokens: int | None = None
+
+
+@dataclass(frozen=True)
+class BenchmarkRunConfig:
+    base_url: str
+    model: str
+    model_profile: str
+    case_id: str | None = None
+    dataset_path: str | None = None
+    output_dir: str = "results/benchmark"
+    stream: bool = False
+    max_samples: int | None = None
+    max_output_tokens: int | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    top_k: int | None = None
+    repetition_penalty: float | None = None
+    warmup: int = 1
+    max_concurrency: int = 1
+    request_rate: float = float("inf")
+    save_audio: bool = False
+    disable_tqdm: bool = False
+
+
+@dataclass(frozen=True)
+class PreparedRequest:
+    request_id: str
+    input_preview: str
+    payload: dict[str, Any]
+
+
+@dataclass
+class PerRequestResult:
+    request_id: str
+    input_preview: str
+    success: bool = False
+    latency_s: float = 0.0
+    first_audio_latency_s: float | None = None
+    audio_duration_s: float | None = None
+    rtf: float | None = None
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    engine_time_s: float | None = None
+    tok_per_s: float | None = None
+    error: str | None = None
+    # Transient field for save-audio support; not serialized.
+    audio_bytes: bytes | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.request_id,
+            "input_preview": self.input_preview,
+            "success": self.success,
+            "latency_s": _round_or_none(self.latency_s, 4),
+            "first_audio_latency_s": _round_or_none(self.first_audio_latency_s, 4),
+            "audio_duration_s": _round_or_none(self.audio_duration_s, 4),
+            "rtf": _round_or_none(self.rtf, 4),
+            "prompt_tokens": self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "engine_time_s": _round_or_none(self.engine_time_s, 4),
+            "tok_per_s": _round_or_none(self.tok_per_s, 1),
+            "error": self.error,
+        }
+
+
+@dataclass
+class RunSummary:
+    model_profile: str
+    case: str
+    scenario: str
+    request_family: str
+    completed_requests: int
+    failed_requests: int
+    run_wall_time_s: float
+    latency_mean_s: float | None = None
+    latency_median_s: float | None = None
+    latency_p95_s: float | None = None
+    latency_p99_s: float | None = None
+    throughput_qps: float | None = None
+    audio_duration_mean_s: float | None = None
+    rtf_mean: float | None = None
+    rtf_median: float | None = None
+    tok_per_s_mean: float | None = None
+    tok_per_s_median: float | None = None
+    tok_per_s_agg: float | None = None
+    prompt_tokens_mean: float | None = None
+    prompt_tokens_total: int | None = None
+    completion_tokens_mean: float | None = None
+    completion_tokens_total: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "model_profile": self.model_profile,
+            "case": self.case,
+            "scenario": self.scenario,
+            "request_family": self.request_family,
+            "completed_requests": self.completed_requests,
+            "failed_requests": self.failed_requests,
+            "run_wall_time_s": round(self.run_wall_time_s, 4),
+            "latency_mean_s": _round_or_none(self.latency_mean_s, 4),
+            "latency_median_s": _round_or_none(self.latency_median_s, 4),
+            "latency_p95_s": _round_or_none(self.latency_p95_s, 4),
+            "latency_p99_s": _round_or_none(self.latency_p99_s, 4),
+            "throughput_qps": _round_or_none(self.throughput_qps, 4),
+            "audio_duration_mean_s": _round_or_none(self.audio_duration_mean_s, 4),
+            "rtf_mean": _round_or_none(self.rtf_mean, 4),
+            "rtf_median": _round_or_none(self.rtf_median, 4),
+            "tok_per_s_mean": _round_or_none(self.tok_per_s_mean, 1),
+            "tok_per_s_median": _round_or_none(self.tok_per_s_median, 1),
+            "tok_per_s_agg": _round_or_none(self.tok_per_s_agg, 1),
+            "prompt_tokens_mean": _round_or_none(self.prompt_tokens_mean, 1),
+            "prompt_tokens_total": self.prompt_tokens_total,
+            "completion_tokens_mean": _round_or_none(self.completion_tokens_mean, 1),
+            "completion_tokens_total": self.completion_tokens_total,
+        }
+
+
+@dataclass(frozen=True)
+class ResolvedProfileSelection:
+    model_profile_name: str
+    case_spec: BenchmarkCaseSpec
+    request_family: str
+    served_model_name: str
+    dataset_loader_name: str
+    model_adapter_name: str
+    model_profile: Any
+
+
+@dataclass
+class BenchmarkResults:
+    summary: RunSummary
+    config: dict[str, Any]
+    per_request: list[PerRequestResult]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "summary": self.summary.to_dict(),
+            "config": dict(self.config),
+            "per_request": [result.to_dict() for result in self.per_request],
+        }
+
+
+def _round_or_none(value: float | None, digits: int) -> float | None:
+    if value is None:
+        return None
+    return round(value, digits)

--- a/benchmarks/datasets/__init__.py
+++ b/benchmarks/datasets/__init__.py
@@ -1,0 +1,2 @@
+"""Dataset loaders for benchmark cases."""
+

--- a/benchmarks/datasets/base.py
+++ b/benchmarks/datasets/base.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from benchmarks.core.types import NormalizedSample
+
+
+class DatasetLoader(ABC):
+    name: str
+
+    @abstractmethod
+    def load(
+        self,
+        *,
+        dataset_path: str | None,
+        max_samples: int | None,
+    ) -> list[NormalizedSample]:
+        raise NotImplementedError

--- a/benchmarks/datasets/seed_tts_eval.py
+++ b/benchmarks/datasets/seed_tts_eval.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+
+from benchmarks.core.types import INPUT_PREVIEW_LENGTH, NormalizedSample
+
+from .base import DatasetLoader
+
+META_FIELD_COUNT = 4
+
+
+class SeedTTSEvalLoader(DatasetLoader):
+    name = "seed_tts_eval"
+
+    def load(
+        self,
+        *,
+        dataset_path: str | None,
+        max_samples: int | None,
+    ) -> list[NormalizedSample]:
+        if dataset_path is None:
+            raise ValueError("seed_tts_eval requires --dataset")
+        if not os.path.isfile(dataset_path):
+            raise FileNotFoundError(f"Dataset not found: {dataset_path}")
+
+        base_dir = os.path.dirname(dataset_path)
+        samples: list[NormalizedSample] = []
+        with open(dataset_path, encoding="utf-8") as handle:
+            for raw_line in handle:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                fields = line.split("|")
+                if len(fields) < META_FIELD_COUNT:
+                    continue
+                ref_audio = os.path.join(base_dir, fields[2])
+                text = fields[3]
+                samples.append(
+                    NormalizedSample(
+                        sample_id=fields[0],
+                        input_preview=text[:INPUT_PREVIEW_LENGTH],
+                        payload={
+                            "text": text,
+                            "references": [
+                                {
+                                    "audio_path": ref_audio,
+                                    "text": fields[1],
+                                }
+                            ],
+                        },
+                    )
+                )
+                if max_samples is not None and len(samples) >= max_samples:
+                    break
+        return samples

--- a/benchmarks/profiles/__init__.py
+++ b/benchmarks/profiles/__init__.py
@@ -1,0 +1,2 @@
+"""Benchmark profile registry and built-in profiles."""
+

--- a/benchmarks/profiles/base.py
+++ b/benchmarks/profiles/base.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import ClassVar
+
+from benchmarks.adapters.model.base import ModelAdapter
+from benchmarks.core.types import BenchmarkCaseSpec
+from benchmarks.datasets.base import DatasetLoader
+
+
+class BenchmarkProfile(ABC):
+    profile_name: ClassVar[str]
+    aliases: ClassVar[tuple[str, ...]] = ()
+    request_family: ClassVar[str]
+    default_case: ClassVar[str]
+
+    def __init__(self) -> None:
+        self.model_adapter = self.build_model_adapter()
+
+    @property
+    @abstractmethod
+    def cases(self) -> dict[str, BenchmarkCaseSpec]:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def dataset_loader(self) -> DatasetLoader:
+        raise NotImplementedError
+
+    @abstractmethod
+    def build_model_adapter(self) -> ModelAdapter:
+        raise NotImplementedError
+
+    def get_case(self, case_id: str | None) -> BenchmarkCaseSpec:
+        if case_id is None and len(self.cases) > 1:
+            raise ValueError(
+                f"Profile '{self.profile_name}' supports multiple cases "
+                f"{sorted(self.cases)}; --case is required"
+            )
+        resolved_case_id = case_id or self.default_case
+        if resolved_case_id not in self.cases:
+            raise ValueError(
+                f"Unsupported case '{resolved_case_id}' for profile '{self.profile_name}'. "
+                f"Supported cases: {sorted(self.cases)}"
+            )
+        return self.cases[resolved_case_id]
+
+    @classmethod
+    def matches_alias(cls, value: str) -> bool:
+        if value == cls.profile_name:
+            return True
+        return value in cls.aliases

--- a/benchmarks/profiles/registry.py
+++ b/benchmarks/profiles/registry.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import importlib
+import logging
+import pkgutil
+from dataclasses import dataclass, field
+from typing import Type
+
+from .base import BenchmarkProfile
+
+logger = logging.getLogger(__name__)
+
+_PROFILE_CLASSES: dict[str, Type[BenchmarkProfile]] = {}
+
+
+def register_profile(cls: Type[BenchmarkProfile]) -> Type[BenchmarkProfile]:
+    """Decorator that registers a BenchmarkProfile subclass by its profile_name."""
+    if cls.profile_name in _PROFILE_CLASSES:
+        raise ValueError(f"Duplicate profile registration: '{cls.profile_name}'")
+    _PROFILE_CLASSES[cls.profile_name] = cls
+    return cls
+
+
+def _import_profile_subpackages(
+    package_name: str,
+    strict: bool = False,
+) -> None:
+    """Import all subpackages under *package_name*, triggering @register_profile decorators."""
+    package = importlib.import_module(package_name)
+
+    for _, name, ispkg in pkgutil.iter_modules(package.__path__, package_name + "."):
+        if not ispkg:
+            continue
+        try:
+            importlib.import_module(name)
+        except Exception as exc:
+            if strict:
+                raise
+            logger.warning("Ignore import error when loading %s: %s", name, exc)
+
+
+@dataclass
+class BenchmarkProfileRegistry:
+    profiles: dict[str, Type[BenchmarkProfile]] = field(default_factory=dict)
+
+    def register_profiles(
+        self,
+        package_name: str,
+        strict: bool = False,
+    ) -> None:
+        _import_profile_subpackages(package_name, strict=strict)
+        for profile_name, profile_cls in _PROFILE_CLASSES.items():
+            if profile_name in self.profiles:
+                raise ValueError(f"Benchmark profile '{profile_name}' already registered")
+            self.profiles[profile_name] = profile_cls
+
+    def get_by_name_or_alias(self, value: str) -> BenchmarkProfile:
+        matches = [
+            profile_cls
+            for profile_cls in self.profiles.values()
+            if profile_cls.matches_alias(value)
+        ]
+        if not matches:
+            raise ValueError(
+                f"Unknown benchmark profile '{value}'. Supported profiles: {sorted(self.profiles)}"
+            )
+        if len(matches) > 1:
+            raise ValueError(
+                f"Ambiguous benchmark profile '{value}'. Matches: "
+                f"{[profile_cls.profile_name for profile_cls in matches]}"
+            )
+        return matches[0]()
+
+    def list_profiles(self) -> list[str]:
+        return sorted(self.profiles)
+
+
+PROFILE_REGISTRY = BenchmarkProfileRegistry()
+PROFILE_REGISTRY.register_profiles("benchmarks.profiles")

--- a/benchmarks/profiles/resolver.py
+++ b/benchmarks/profiles/resolver.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from benchmarks.core.types import BenchmarkRunConfig, ResolvedProfileSelection
+
+from .registry import BenchmarkProfileRegistry
+
+
+def resolve_profile_selection(
+    *,
+    run_config: BenchmarkRunConfig,
+    registry: BenchmarkProfileRegistry,
+) -> ResolvedProfileSelection:
+    profile = registry.get_by_name_or_alias(run_config.model_profile)
+
+    case_spec = profile.get_case(run_config.case_id)
+    return ResolvedProfileSelection(
+        model_profile_name=profile.profile_name,
+        case_spec=case_spec,
+        request_family=profile.request_family,
+        served_model_name=run_config.model,
+        dataset_loader_name=profile.dataset_loader.name,
+        model_adapter_name=profile.model_adapter.name,
+        model_profile=profile,
+    )

--- a/benchmarks/profiles/s2_tts/__init__.py
+++ b/benchmarks/profiles/s2_tts/__init__.py
@@ -1,0 +1,4 @@
+from . import profile
+
+__all__ = ["profile"]
+

--- a/benchmarks/profiles/s2_tts/profile.py
+++ b/benchmarks/profiles/s2_tts/profile.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from benchmarks.adapters.model.s2_tts import S2TTSModelAdapter
+from benchmarks.core.types import BenchmarkCaseSpec
+from benchmarks.datasets.seed_tts_eval import SeedTTSEvalLoader
+from benchmarks.profiles.base import BenchmarkProfile
+from benchmarks.profiles.registry import register_profile
+
+
+@register_profile
+class S2TTSBenchmarkProfile(BenchmarkProfile):
+    profile_name = "s2_tts"
+    aliases = ("s2-pro", "fishaudio/s2-pro")
+    request_family = "speech_http"
+    default_case = "voice-cloning"
+
+    @property
+    def cases(self) -> dict[str, BenchmarkCaseSpec]:
+        return {
+            "voice-cloning": BenchmarkCaseSpec(
+                case_id="voice-cloning",
+                scenario_id="text_to_speech",
+                description="TTS voice cloning with reference audio",
+                requires_dataset_path=True,
+                default_max_output_tokens=2048,
+            ),
+            "plain-tts": BenchmarkCaseSpec(
+                case_id="plain-tts",
+                scenario_id="text_to_speech",
+                description="Plain TTS without reference audio",
+                requires_dataset_path=True,
+                default_max_output_tokens=2048,
+            ),
+        }
+
+    @property
+    def dataset_loader(self) -> SeedTTSEvalLoader:
+        return SeedTTSEvalLoader()
+
+    def build_model_adapter(self) -> S2TTSModelAdapter:
+        return S2TTSModelAdapter()

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+
+from benchmarks.core.runner import run_from_config
+from benchmarks.core.types import BenchmarkRunConfig
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Model-agnostic performance benchmark runner for sglang-omni."
+    )
+    parser.add_argument("--base-url", type=str, required=True)
+    parser.add_argument(
+        "--model",
+        type=str,
+        required=True,
+        help="Model name for the API request.",
+    )
+    parser.add_argument(
+        "--model-profile",
+        type=str,
+        required=True,
+        help="Registered benchmark profile name or alias.",
+    )
+    parser.add_argument("--case", type=str, default=None)
+    parser.add_argument("--dataset", type=str, default=None)
+    parser.add_argument("--output-dir", type=str, default="results/benchmark")
+    parser.add_argument("--stream", action="store_true")
+    parser.add_argument("--max-samples", type=int, default=None)
+    parser.add_argument("--max-output-tokens", type=int, default=None)
+    parser.add_argument("--temperature", type=float, default=None)
+    parser.add_argument("--top-p", type=float, default=None)
+    parser.add_argument("--top-k", type=int, default=None)
+    parser.add_argument("--repetition-penalty", type=float, default=None)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--max-concurrency", type=int, default=1)
+    parser.add_argument(
+        "--request-rate",
+        type=float,
+        default=float("inf"),
+        help="Requests per second (inf = fire all immediately).",
+    )
+    parser.add_argument(
+        "--save-audio", action="store_true", help="Save generated WAV files."
+    )
+    parser.add_argument("--disable-tqdm", action="store_true")
+    return parser
+
+
+def main() -> None:
+    parser = build_arg_parser()
+    args = parser.parse_args()
+
+    run_config = BenchmarkRunConfig(
+        base_url=args.base_url,
+        model=args.model,
+        model_profile=args.model_profile,
+        case_id=args.case,
+        dataset_path=args.dataset,
+        output_dir=args.output_dir,
+        stream=args.stream,
+        max_samples=args.max_samples,
+        max_output_tokens=args.max_output_tokens,
+        temperature=args.temperature,
+        top_p=args.top_p,
+        top_k=args.top_k,
+        repetition_penalty=args.repetition_penalty,
+        warmup=args.warmup,
+        max_concurrency=args.max_concurrency,
+        request_rate=args.request_rate,
+        save_audio=args.save_audio,
+        disable_tqdm=args.disable_tqdm,
+    )
+    asyncio.run(run_from_config(run_config))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ s2pro = [
     "gradio>=4.0.0",
     # flash-attn: install separately via prebuilt wheel (see install instructions below)
 ]
+benchmark = ["aiohttp", "tqdm"]
 gradio = ["gradio>=4.0.0"]
 
 [project.scripts]
@@ -76,7 +77,7 @@ markers = [
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["sglang_omni*"]
+include = ["sglang_omni*", "benchmarks*"]
 
 # Fish Speech S2-Pro DAC: OmegaConf YAML must ship with the wheel (not only .py).
 [tool.setuptools.package-data]

--- a/tests/test_benchmark_framework.py
+++ b/tests/test_benchmark_framework.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the model-agnostic benchmark framework."""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import threading
+import wave
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import aiohttp
+import pytest
+
+from benchmarks.adapters.request_family.speech_http import SpeechHTTPAdapter
+from benchmarks.core.runner import run_from_config
+from benchmarks.core.types import BenchmarkRunConfig, PreparedRequest
+from benchmarks.profiles.registry import PROFILE_REGISTRY
+from benchmarks.profiles.resolver import resolve_profile_selection
+
+
+def _make_wav_bytes(num_frames: int = 1600, sample_rate: int = 16000) -> bytes:
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(b"\x00\x00" * num_frames)
+    return buffer.getvalue()
+
+
+@contextmanager
+def _serve(routes):
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self._dispatch()
+
+        def do_POST(self):
+            self._dispatch()
+
+        def log_message(self, format, *args):
+            del format, args
+
+        def _dispatch(self):
+            key = (self.command, self.path)
+            if key not in routes:
+                self.send_response(404)
+                self.end_headers()
+                return
+
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length) if length else b""
+            status_code, headers, response_body = routes[key](self, body)
+            self.send_response(status_code)
+            for header_name, header_value in headers.items():
+                self.send_header(header_name, header_value)
+            self.end_headers()
+            self.wfile.write(response_body)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_profile_registry_discovers_builtin_profiles() -> None:
+    assert "s2_tts" in PROFILE_REGISTRY.list_profiles()
+
+
+def test_resolver_uses_explicit_model_profile() -> None:
+    selection = resolve_profile_selection(
+        run_config=BenchmarkRunConfig(
+            base_url="http://localhost:8000",
+            model="s2-pro",
+            model_profile="s2_tts",
+            case_id="voice-cloning",
+        ),
+        registry=PROFILE_REGISTRY,
+    )
+
+    assert selection.model_profile_name == "s2_tts"
+    assert selection.case_spec.case_id == "voice-cloning"
+    assert selection.served_model_name == "s2-pro"
+
+
+@pytest.mark.asyncio
+async def test_speech_http_stream_adapter_parses_stream_response() -> None:
+    audio_b64 = base64.b64encode(_make_wav_bytes()).decode("ascii")
+    stream_payload = (
+        f'data: {json.dumps({"audio": {"data": audio_b64}, "finish_reason": None})}\n\n'
+        f'data: {json.dumps({"audio": None, "finish_reason": "stop", "usage": {"prompt_tokens": 3, "completion_tokens": 5, "engine_time_s": 0.5}})}\n\n'
+        "data: [DONE]\n\n"
+    ).encode("utf-8")
+
+    with _serve(
+        {
+            ("POST", "/v1/audio/speech"): lambda _handler, body: (
+                200,
+                {"Content-Type": "text/event-stream"},
+                stream_payload,
+            )
+        }
+    ) as base_url:
+        adapter = SpeechHTTPAdapter()
+        async with aiohttp.ClientSession() as session:
+            result = await adapter.execute(
+                session=session,
+                base_url=base_url,
+                request=PreparedRequest(
+                    request_id="speech-1",
+                    input_preview="hello",
+                    payload={
+                        "model": "s2-pro",
+                        "input": "hello",
+                        "response_format": "wav",
+                        "stream": True,
+                    },
+                ),
+            )
+
+    assert result.success is True
+    assert result.audio_duration_s is not None and result.audio_duration_s > 0
+    assert result.prompt_tokens == 3
+    assert result.completion_tokens == 5
+    assert result.tok_per_s == 10.0
+
+
+@pytest.mark.asyncio
+async def test_run_from_config_supports_s2_profile(tmp_path) -> None:
+    dataset_root = tmp_path / "seedtts"
+    dataset_root.mkdir()
+    meta_path = dataset_root / "meta.lst"
+    ref_audio = dataset_root / "ref.wav"
+    ref_audio.write_bytes(_make_wav_bytes())
+    meta_path.write_text("utt-1|reference transcript|ref.wav|hello world\n")
+
+    wav_bytes = _make_wav_bytes()
+
+    def _speech_response(_handler, body: bytes):
+        payload = json.loads(body.decode("utf-8"))
+        assert payload["model"] == "custom-s2"
+        assert payload["references"][0]["text"] == "reference transcript"
+        return (
+            200,
+            {
+                "Content-Type": "audio/wav",
+                "X-Prompt-Tokens": "10",
+                "X-Completion-Tokens": "20",
+                "X-Engine-Time": "1.0",
+            },
+            wav_bytes,
+        )
+
+    with _serve(
+        {
+            ("GET", "/health"): lambda _handler, _body: (
+                200,
+                {"Content-Type": "application/json"},
+                json.dumps({"status": "healthy", "running": True}).encode("utf-8"),
+            ),
+            ("POST", "/v1/audio/speech"): _speech_response,
+        }
+    ) as base_url:
+        results = await run_from_config(
+            BenchmarkRunConfig(
+                base_url=base_url,
+                model="custom-s2",
+                model_profile="s2_tts",
+                case_id="voice-cloning",
+                dataset_path=str(meta_path),
+                output_dir=str(tmp_path / "out-s2"),
+                max_samples=1,
+                warmup=0,
+            )
+        )
+
+    assert results.summary.model_profile == "s2_tts"
+    assert results.summary.completed_requests == 1
+    assert results.summary.failed_requests == 0
+    assert results.summary.prompt_tokens_total == 10
+    assert results.summary.completion_tokens_total == 20
+    assert results.per_request[0].success is True
+    assert (tmp_path / "out-s2" / "benchmark_results.json").exists()
+    assert (tmp_path / "out-s2" / "per_request.csv").exists()
+
+
+def test_multi_case_profile_requires_explicit_case() -> None:
+    profile = PROFILE_REGISTRY.get_by_name_or_alias("s2_tts")
+    with pytest.raises(ValueError, match="--case is required"):
+        profile.get_case(None)
+
+
+@pytest.mark.asyncio
+async def test_run_from_config_requires_model_profile(tmp_path) -> None:
+    with pytest.raises(ValueError, match="--model-profile is required"):
+        await run_from_config(
+            BenchmarkRunConfig(
+                base_url="http://localhost:8000",
+                model="test",
+                model_profile="",
+                output_dir=str(tmp_path / "out"),
+            )
+        )

--- a/tests/test_model/test_s2pro_benchmark.py
+++ b/tests/test_model/test_s2pro_benchmark.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""S2-Pro TTS benchmark CI: starts server, runs benchmarks, asserts thresholds.
+"""S2-Pro benchmark CI: starts server, runs the generic benchmark framework, asserts thresholds.
 
 Usage:
     pytest tests/test_model/test_s2pro_benchmark.py -s -x
@@ -48,9 +48,10 @@ def _run_benchmark(
     port: int,
     testset: str,
     output_dir: str,
+    case_id: str,
     extra_args: list[str] | None = None,
 ) -> dict:
-    """Run benchmark_tts_speed as subprocess and return the full results dict.
+    """Run the generic benchmark runner as subprocess and return the full results dict.
 
     Returns the complete JSON results containing both ``summary`` and
     ``per_request`` entries.
@@ -58,12 +59,16 @@ def _run_benchmark(
     cmd = [
         sys.executable,
         "-m",
-        "benchmarks.performance.tts.benchmark_tts_speed",
+        "benchmarks.run",
+        "--base-url",
+        f"http://localhost:{port}",
         "--model",
         MODEL_PATH,
-        "--port",
-        str(port),
-        "--testset",
+        "--model-profile",
+        "s2_tts",
+        "--case",
+        case_id,
+        "--dataset",
         testset,
         "--max-samples",
         str(MAX_SAMPLES),
@@ -91,7 +96,7 @@ def _run_benchmark(
         f"stdout:\n{proc_result.stdout}\nstderr:\n{proc_result.stderr}"
     )
 
-    results_path = Path(output_dir) / "speed_results.json"
+    results_path = Path(output_dir) / "benchmark_results.json"
     assert results_path.exists(), f"Results file not found: {results_path}"
 
     with open(results_path) as f:
@@ -195,8 +200,11 @@ def _assert_summary_metrics(summary: dict) -> None:
         summary["audio_duration_mean_s"] > 0
     ), f"Expected positive audio duration, got {summary['audio_duration_mean_s']}"
     assert (
-        summary.get("gen_tokens_mean", 0) > 0
-    ), f"Expected positive gen_tokens_mean, got {summary.get('gen_tokens_mean', 0)}"
+        summary.get("completion_tokens_mean", 0) > 0
+    ), (
+        "Expected positive completion_tokens_mean, got "
+        f"{summary.get('completion_tokens_mean', 0)}"
+    )
     assert (
         summary.get("prompt_tokens_mean", 0) > 0
     ), f"Expected positive prompt_tokens_mean, got {summary.get('prompt_tokens_mean', 0)}"
@@ -206,7 +214,7 @@ def _assert_per_request_fields(per_request: list[dict]) -> None:
     """Verify every request has valid audio, prompt_tokens, and completion_tokens."""
     for req in per_request:
         rid = req["id"]
-        assert req["is_success"], f"Request {rid} failed: {req.get('error')}"
+        assert req["success"], f"Request {rid} failed: {req.get('error')}"
         assert (
             req["audio_duration_s"] is not None and req["audio_duration_s"] > 0
         ), f"Request {rid}: audio_duration_s={req['audio_duration_s']}, expected > 0"
@@ -281,6 +289,7 @@ def test_voice_cloning_non_streaming(
         server_port,
         str(dataset_dir / "en" / "meta.lst"),
         str(tmp_path / "vc_nonstream"),
+        "voice-cloning",
     )
     summary, per_request = results["summary"], results["per_request"]
     _assert_summary_metrics(summary)
@@ -306,6 +315,7 @@ def test_voice_cloning_streaming(
         server_port,
         str(dataset_dir / "en" / "meta.lst"),
         str(tmp_path / "vc_stream"),
+        "voice-cloning",
         ["--stream"],
     )
     summary, per_request = results["summary"], results["per_request"]
@@ -332,7 +342,7 @@ def test_plain_tts_non_streaming(
         server_port,
         str(dataset_dir / "en" / "meta.lst"),
         str(tmp_path / "plain_nonstream"),
-        ["--no-ref-audio"],
+        "plain-tts",
     )
     summary, per_request = results["summary"], results["per_request"]
     _assert_summary_metrics(summary)
@@ -358,7 +368,8 @@ def test_plain_tts_streaming(
         server_port,
         str(dataset_dir / "en" / "meta.lst"),
         str(tmp_path / "plain_stream"),
-        ["--no-ref-audio", "--stream"],
+        "plain-tts",
+        ["--stream"],
     )
     summary, per_request = results["summary"], results["per_request"]
     _assert_summary_metrics(summary)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

Seeing another PR with similar work is currently in-flight. Although my PR takes a different approach, it serves the same purpose, **feel free to review it for reference, but you can hold off on merging until the other PR is merged into main**.

## Motivation

Refactors the benchmarks/ module into a model-agnostic benchmark framework. Previously, benchmark logic was more tightly coupled to the S2 TTS use case. This change introduces a reusable runner architecture that separates profile selection, dataset loading, model-specific request construction, transport-specific execution, metrics aggregation, and result reporting. The initial built-in profile is s2_tts, and existing S2 benchmark CI is migrated to the new framework.

## Modifications

- Introduce a unified benchmark runner and execution flow, a generic `benchmarks.run` entrypoint and a shared runner pipeline for multiple stages, making benchmark execution configuration-driven instead of relying on model-specific scripts.
- Decouple benchmark extension points into reusable abstractions, split the framework into explicit layers: benchmark profile selection, dataset loading, model-specific request construction, and request-family execution. 
- Migrate S2 TTS into the new framework as the first built-in profile with explicit voice-cloning and plain-tts cases. 
- Standardize outputs, documentation, and CI integration , unifying benchmark outputs into structured summary + per-request artifacts, updated the README to make `python -m benchmarks.run` the supported entrypoint, and migrated the existing S2 benchmark CI test to call the new framework directly. 


## Related Issues

#200 

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
