### PR TITLE
[Feature] Framework-level torch.compile for S2-Pro codebook decoder Phase 1

### DIFF
--- a/examples/configs/s2pro_tts_compile.yaml
+++ b/examples/configs/s2pro_tts_compile.yaml
@@ -1,0 +1,28 @@
+config_cls: S2ProPipelineConfig
+model_path: fishaudio/s2-pro
+relay_backend: shm
+stages:
+  - name: preprocessing
+    executor:
+      factory: sglang_omni.models.fishaudio_s2_pro.pipeline.stages.create_preprocessing_executor
+      args: {}
+    get_next: sglang_omni.models.fishaudio_s2_pro.pipeline.next_stage.preprocessing_next
+    relay:
+      device: cpu
+  - name: tts_engine
+    executor:
+      factory: sglang_omni.models.fishaudio_s2_pro.pipeline.stages.create_sglang_tts_engine_executor
+      args:
+        device: "cuda:0"
+        max_new_tokens: 2048
+        compile_level: partial
+    get_next: sglang_omni.models.fishaudio_s2_pro.pipeline.next_stage.tts_engine_next
+    relay:
+      device: cuda
+  - name: vocoder
+    executor:
+      factory: sglang_omni.models.fishaudio_s2_pro.pipeline.stages.create_vocoder_executor
+      args: {}
+    get_next: sglang_omni.models.fishaudio_s2_pro.pipeline.next_stage.vocoder_next
+    relay:
+      device: cpu

--- a/sglang_omni/engines/omni/compile.py
+++ b/sglang_omni/engines/omni/compile.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Framework-level torch.compile support for omni models.
+
+See: https://github.com/sgl-project/sglang-omni/issues/172
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Protocol, runtime_checkable
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_COMPILE_MODE = "max-autotune-no-cudagraphs"
+FALLBACK_COMPILE_MODE = "max-autotune"
+
+
+@runtime_checkable
+class CompilableModel(Protocol):
+    def get_compile_targets(self) -> dict[str, Callable]: ...
+
+
+def _set_inductor_config() -> None:
+    """Match SGLang's CudaGraphRunner compile settings."""
+    import torch._dynamo.config
+    import torch._inductor.config
+
+    torch._inductor.config.coordinate_descent_tuning = True
+    torch._inductor.config.triton.unique_kernel_names = True
+    torch._inductor.config.fx_graph_cache = True
+    torch._dynamo.config.accumulated_cache_size_limit = 1024
+
+
+def apply_compile_targets(
+    *models: Any,
+    compile_mode: str = DEFAULT_COMPILE_MODE,
+) -> list[str]:
+    """Compile all registered targets on one or more models.
+
+    For targets named "X", calls set_compiled_X_fn() if available,
+    otherwise stores as _compiled_X on the model.
+    """
+    _set_inductor_config()
+    all_compiled = []
+
+    for model in models:
+        if not isinstance(model, CompilableModel):
+            continue
+
+        targets = model.get_compile_targets()
+        if not targets:
+            continue
+
+        for name, fn in targets.items():
+            compiled_fn = _compile_function(fn, name, compile_mode)
+            if compiled_fn is None:
+                continue
+
+            setter_name = f"set_compiled_{name}_fn"
+            if hasattr(model, setter_name):
+                getattr(model, setter_name)(compiled_fn)
+            else:
+                setattr(model, f"_compiled_{name}", compiled_fn)
+            all_compiled.append(name)
+
+    if all_compiled:
+        logger.info(
+            "Compiled %d target(s) with mode '%s': %s",
+            len(all_compiled),
+            compile_mode,
+            ", ".join(all_compiled),
+        )
+
+    return all_compiled
+
+
+def _compile_function(
+    fn: Callable,
+    name: str,
+    compile_mode: str,
+) -> Callable | None:
+    """Compile a single function with fullgraph=True, with fallback."""
+    try:
+        return torch.compile(fn, mode=compile_mode, fullgraph=True)
+    except Exception:
+        logger.warning(
+            "torch.compile mode '%s' failed for '%s'; trying '%s'.",
+            compile_mode,
+            name,
+            FALLBACK_COMPILE_MODE,
+        )
+    try:
+        return torch.compile(fn, mode=FALLBACK_COMPILE_MODE, fullgraph=True)
+    except Exception:
+        logger.error(
+            "torch.compile failed for '%s' with all modes. Running eager.",
+            name,
+        )
+        return None

--- a/sglang_omni/models/fishaudio_s2_pro/factory.py
+++ b/sglang_omni/models/fishaudio_s2_pro/factory.py
@@ -3,9 +3,12 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import torch
+
+logger = logging.getLogger(__name__)
 
 from sglang_omni.engines.omni.engine import OmniEngine
 from sglang_omni.engines.omni.scheduler import Scheduler
@@ -75,8 +78,9 @@ def create_s2pro_sglang_engine(
     ras_window: int = 16,
     ras_temperature: float = 1.5,
     ras_top_p: float = 0.95,
+    compile_level: str = "none",
 ) -> OmniEngine:
-    """Create a unified S2-Pro engine (slow+fast head in one CUDA graph)."""
+    """Create an S2-Pro engine."""
     from sglang_omni.engines.ar.sglang_backend.model_worker import (
         ModelWorker,
         ModelWorkerConfig,
@@ -91,9 +95,11 @@ def create_s2pro_sglang_engine(
     if server_args.attention_backend is None:
         server_args.attention_backend = "fa3"
 
-    # Enable hidden state capture for unified decode
+    use_partial_compile = compile_level == "partial"
+
+    # Enable hidden state capture for unified decode or partial compile
     want_cuda_graph = not server_args.disable_cuda_graph
-    if want_cuda_graph:
+    if want_cuda_graph or use_partial_compile:
         server_args.enable_return_hidden_states = True
 
     adapter = S2ProTokenizerAdapter(tokenizer)
@@ -128,7 +134,12 @@ def create_s2pro_sglang_engine(
         max_batch_size=max_bs,
     )
 
-    # Now capture CUDA graphs with _decode_codebooks in the graph
+    if use_partial_compile:
+        from sglang_omni.engines.omni.compile import apply_compile_targets
+
+        compiled = apply_compile_targets(text_model)
+        logger.info("Partial compile targets: %s", compiled)
+
     if want_cuda_graph:
         model_worker.model_runner.init_device_graphs()
 

--- a/sglang_omni/models/fishaudio_s2_pro/pipeline/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/pipeline/stages.py
@@ -271,6 +271,7 @@ def create_sglang_tts_engine_executor(
     stream_stride: int = 5,
     stream_followup_stride: int = 100,
     stream_vocoder_device: str | None = None,
+    compile_level: str = "none",
 ) -> EngineExecutor:
     """Factory for the S2-Pro TTS engine stage."""
     from sglang.srt.server_args import ServerArgs
@@ -324,6 +325,7 @@ def create_sglang_tts_engine_executor(
         codebook_size=codebook_size,
         max_new_tokens=max_new_tokens,
         top_k=top_k,
+        compile_level=compile_level,
     )
 
     def _request_builder(payload: StagePayload):

--- a/sglang_omni/models/fishaudio_s2_pro/runtime/s2pro_sglang_ar.py
+++ b/sglang_omni/models/fishaudio_s2_pro/runtime/s2pro_sglang_ar.py
@@ -15,9 +15,10 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 import torch
+from torch import Tensor
 from sglang.srt.mem_cache.common import release_kv_cache
 
 from sglang_omni.engines.omni.runtime.sglang_ar import (
@@ -32,7 +33,7 @@ from sglang_omni.engines.omni.types import (
     SchedulerRequest,
 )
 
-from .s2pro_ar import S2ProStepOutput
+from .s2pro_ar import S2ProStepOutput, _sample_with_topk
 
 if TYPE_CHECKING:
     from sglang_omni.engines.ar.sglang_backend.model_worker import ModelWorker
@@ -114,12 +115,7 @@ def _codebook_loop_impl(
 
 
 class S2ProSGLangOutputProcessor:
-    """Two-stage output processor for S2-Pro on SGLang backend.
-
-    After the text model produces logits + hidden states via ForwardBatch,
-    applies constrained decoding + RAS + codebook generation using the
-    audio decoder's static KVCache.
-    """
+    """Two-stage output processor: constrained decoding + codebook generation."""
 
     def __init__(
         self,
@@ -134,7 +130,6 @@ class S2ProSGLangOutputProcessor:
         ras_window: int = 16,
         ras_temperature: float = 1.5,
         ras_top_p: float = 0.95,
-        use_torch_compile: bool = False,
         align_logits_to_bf16: bool = True,
     ) -> None:
         self._audio_decoder = audio_decoder
@@ -152,30 +147,19 @@ class S2ProSGLangOutputProcessor:
 
         import functools
 
-        _cb_fn = functools.partial(
+        self._codebook_fn = functools.partial(
             _codebook_loop_impl,
             audio_decoder,
             num_codebooks=num_codebooks,
             codebook_size=codebook_size,
             semantic_begin_id=semantic_begin_id,
         )
-        if use_torch_compile:
-            # Avoid CUDA-graph capture inside inductor for sampling stability.
-            compile_mode = "max-autotune-no-cudagraphs"
-            try:
-                self._codebook_fn = torch.compile(
-                    _cb_fn, mode=compile_mode, fullgraph=True
-                )
-            except Exception:
-                logger.warning(
-                    "torch.compile mode '%s' unavailable; fallback to max-autotune.",
-                    compile_mode,
-                )
-                self._codebook_fn = torch.compile(
-                    _cb_fn, mode="max-autotune", fullgraph=True
-                )
-        else:
-            self._codebook_fn = _cb_fn
+
+    def get_compile_targets(self) -> dict[str, Callable]:
+        return {"codebook_loop": self._codebook_fn}
+
+    def set_compiled_codebook_loop_fn(self, compiled_fn: Callable) -> None:
+        self._codebook_fn = compiled_fn
 
     @staticmethod
     def _truncate_to_bf16(logits: Tensor) -> Tensor:

--- a/sglang_omni/models/fishaudio_s2_pro/sglang_model.py
+++ b/sglang_omni/models/fishaudio_s2_pro/sglang_model.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import Any, Iterable, Optional, Tuple
+from typing import Any, Callable, Iterable, Optional, Tuple
 
 import torch
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
@@ -26,6 +26,46 @@ from sglang_omni.vendor.sglang.models import apply_qk_norm
 from sglang_omni.vendor.sglang.utils import make_layers
 
 logger = logging.getLogger(__name__)
+
+
+def _decode_codebooks_impl(
+    logits: Tensor,
+    hidden_states: Tensor,
+    semantic_bias: Tensor,
+    audio_decoder: nn.Module,
+    codebook_size: int,
+    num_codebooks: int,
+    semantic_begin_id: int,
+) -> tuple[Tensor, Tensor]:
+    """Constrained semantic argmax + codebook generation.
+
+    Standalone function so torch.compile can trace it with fullgraph=True.
+    Returns (output_codes [bs, num_codebooks+1], semantic_ids [bs]).
+    """
+    # Constrained semantic decode
+    biased_logits = logits + semantic_bias
+    semantic_token = torch.argmax(biased_logits, dim=-1)  # [bs]
+
+    # Codebook generation
+    audio_decoder.reset_caches()
+    fast_input = audio_decoder.project_in(hidden_states)
+    fast_input = fast_input.unsqueeze(1)  # [bs, 1, fast_dim]
+    audio_decoder.forward_kvcached(fast_input, codebook_idx=0)
+
+    sem_id = (semantic_token - semantic_begin_id).clamp(min=0)
+    cb_hidden = audio_decoder.embeddings(sem_id).unsqueeze(1)
+
+    codes = [semantic_token, sem_id]
+    for cb_idx in range(1, num_codebooks):
+        cb_logits = audio_decoder.forward_kvcached(cb_hidden, codebook_idx=cb_idx)
+        cb_logits = cb_logits[:, 0, :codebook_size]
+        cb_token = torch.argmax(cb_logits, dim=-1)  # [bs]
+        cb_hidden = audio_decoder.embeddings(cb_token).unsqueeze(1)
+        codes.append(cb_token)
+
+    # [bs, num_codebooks+1]
+    output_codes = torch.stack(codes, dim=1)
+    return output_codes, semantic_token
 
 
 class S2ProAttention(nn.Module):
@@ -281,6 +321,8 @@ class S2ProSGLangTextModel(nn.Module):
             max_batch_size, dtype=torch.long, device=device
         )
 
+        self._decode_codebooks_fn = _decode_codebooks_impl
+
         self._vq_ready = True
 
     # ------------------------------------------------------------------
@@ -344,37 +386,29 @@ class S2ProSGLangTextModel(nn.Module):
             hidden_states=hidden_states,
         )
 
+    def get_compile_targets(self) -> dict[str, "Callable"]:
+        if not self._vq_ready:
+            return {}
+        return {"decode_codebooks": self._decode_codebooks_fn}
+
+    def set_compiled_decode_codebooks_fn(self, compiled_fn: "Callable") -> None:
+        self._decode_codebooks_fn = compiled_fn
+
     @torch.no_grad()
     def _decode_codebooks(self, logits: Tensor, hidden_states: Tensor) -> None:
-        """Constrained semantic sampling + batched codebook generation."""
         bs = logits.shape[0]
+        output_codes, semantic_ids = self._decode_codebooks_fn(
+            logits,
+            hidden_states,
+            self._semantic_bias,
+            self._audio_decoder,
+            self._codebook_size,
+            self._num_codebooks,
+            self._semantic_begin_id,
+        )
 
-        # Constrained decode: mask non-semantic tokens
-        biased_logits = logits + self._semantic_bias
-        semantic_token = torch.argmax(biased_logits, dim=-1)  # [bs]
-
-        # Batched codebook loop
-        self._audio_decoder.reset_caches()
-        fast_input = self._audio_decoder.project_in(hidden_states)
-        fast_input = fast_input.unsqueeze(1)  # [bs, 1, fast_dim]
-        self._audio_decoder.forward_kvcached(fast_input, codebook_idx=0)
-
-        sem_id = (semantic_token - self._semantic_begin_id).clamp(min=0)
-        cb_hidden = self._audio_decoder.embeddings(sem_id).unsqueeze(1)
-
-        self._output_codes[:bs, 0] = semantic_token
-        self._output_codes[:bs, 1] = sem_id
-
-        for cb_idx in range(1, self._num_codebooks):
-            cb_logits = self._audio_decoder.forward_kvcached(
-                cb_hidden, codebook_idx=cb_idx
-            )
-            cb_logits = cb_logits[:, 0, : self._codebook_size]
-            cb_token = torch.argmax(cb_logits, dim=-1)  # [bs]
-            cb_hidden = self._audio_decoder.embeddings(cb_token).unsqueeze(1)
-            self._output_codes[:bs, cb_idx + 1] = cb_token
-
-        self._output_semantic_ids[:bs] = semantic_token
+        self._output_codes[:bs] = output_codes
+        self._output_semantic_ids[:bs] = semantic_ids
 
     # ------------------------------------------------------------------
     # Helpers


### PR DESCRIPTION
## Modifications

Framework-level torch.compile support (Phase 1 of #172)

## Benchmark & Profiling

```
PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True python -m sglang_omni.cli.cli serve --model-path /home/jobuser/models/s2-pro --port 8000 --config examples/configs/s2pro_tts.yaml

python -m benchmarks.performance.tts.benchmark_tts_speed --model fishaudio/s2-pro --port 8000 --testset /home/jobuser/data/seedtts_testset/en/meta.lst --no-ref-audio --output-dir results/exp_baseline_1088

============================================================
                    TTS Benchmark Result                    
============================================================
  Model:                         fishaudio/s2-pro
  Completed requests:            1079
  Failed requests:               9
------------------------------------------------------------
  Latency mean (s):              1.319
  Latency median (s):            1.247
  Latency p95 (s):               1.951
  Latency p99 (s):               3.841
  RTF mean:                      0.2833
  RTF median:                    0.2837
  Audio duration mean (s):       4.689
  Tok/s (per-req mean):          82.2
  Tok/s (per-req median):        81.3
  Tok/s (aggregate):             82.3
  Gen tokens (mean):             101
  Gen tokens (total):            108952
  Prompt tokens (mean):          29
  Prompt tokens (total):         31550
  Throughput (req/s):            0.758
============================================================
```

```
PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True python -m sglang_omni.cli.cli serve --model-path /home/jobuser/models/s2-pro --port 8000 --config examples/configs/s2pro_tts_compile.yaml

python -m benchmarks.performance.tts.benchmark_tts_speed --model fishaudio/s2-pro --port 8000 --testset /home/jobuser/data/seedtts_testset/en/meta.lst --no-ref-audio --output-dir results/exp_compile_1088

============================================================
                    TTS Benchmark Result                    
============================================================
  Model:                         fishaudio/s2-pro
  Completed requests:            1074
  Failed requests:               14
------------------------------------------------------------
  Latency mean (s):              0.984
  Latency median (s):            0.941
  Latency p95 (s):               1.418
  Latency p99 (s):               2.594
  RTF mean:                      0.2141
  RTF median:                    0.2128
  Audio duration mean (s):       4.633
  Tok/s (per-req mean):          111.6
  Tok/s (per-req median):        112.5
  Tok/s (aggregate):             111.8
  Gen tokens (mean):             100
  Gen tokens (total):            107152
  Prompt tokens (mean):          29
  Prompt tokens (total):         31420
  Throughput (req/s):            1.016
============================================================
```

  | Config | Tok/s (mean) | Tok/s (aggregate) | Failed |
  |--------|-------------|-------------------|--------|
  | Baseline | 82.2 | 82.3 | 9 |
  | Partial compile | 111.6 | 111.8 | 14 |
  | Delta | +36% | +36% | |


  - fullgraph=True verified: zero graph breaks (TORCH_LOGS=graph_breaks)
  - 9 baseline failures are a pre-existing OOM issue (#235), unrelated to compile
  - 5 additional compile failures due to torch.compile workspace memory overhead