### PR TITLE
[WIP]feat: support flexible inference path for omni model

### DIFF
--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -165,7 +165,7 @@ class Qwen3OmniSpeechPipelineConfig(PipelineConfig):
                 factory="sglang_omni.models.qwen3_omni.pipeline.stages.create_sglang_thinker_executor_from_config",
                 args={"thinker_max_seq_len": 8192, "speech_enabled": True},
             ),
-            get_next="sglang_omni.models.qwen3_omni.pipeline.next_stage.thinker_next_speech",
+            get_next="sglang_omni.models.qwen3_omni.pipeline.next_stage.thinker_next_flexible",
             relay=RelayConfig(device="cuda"),
             stream_to=[StreamTargetConfig(to_stage=TALKER_AR_STAGE)],
         ),

--- a/sglang_omni/models/qwen3_omni/pipeline/next_stage.py
+++ b/sglang_omni/models/qwen3_omni/pipeline/next_stage.py
@@ -72,6 +72,26 @@ def thinker_next_speech(request_id: str, output: Any) -> list[str]:
     return [DECODE_STAGE, TALKER_AR_STAGE]
 
 
+def thinker_next_flexible(request_id: str, output: Any) -> str | list[str]:
+    """Modality-aware thinker routing for the speech pipeline.
+
+    Checks ``output.request.metadata["output_modalities"]`` to decide
+    whether to fan out to the audio path.  When the caller only requests
+    text (i.e. ``"audio"`` is **not** in the modalities list), the audio
+    stages are skipped entirely and only DECODE_STAGE is returned.
+
+    If ``output_modalities`` is *unset* or ``None`` the default behaviour
+    is to produce **both** text and audio (full speech pipeline).
+    """
+    del request_id
+    modalities = None
+    if isinstance(output, StagePayload):
+        modalities = output.request.metadata.get("output_modalities")
+    if modalities is not None and "audio" not in modalities:
+        return DECODE_STAGE
+    return [DECODE_STAGE, TALKER_AR_STAGE]
+
+
 def talker_ar_next(request_id: str, output: Any) -> str:
     del request_id, output
     return CODE_PREDICTOR_STAGE

--- a/sglang_omni/pipeline/coordinator.py
+++ b/sglang_omni/pipeline/coordinator.py
@@ -54,6 +54,11 @@ class Coordinator:
         )
         self._partial_results: dict[str, dict[str, Any]] = {}
 
+        # Per-request terminal stage overrides.  When a request's
+        # output_modalities skip audio, only a subset of the global
+        # terminal_stages is expected to complete.
+        self._request_terminals: dict[str, set[str]] = {}
+
         # Control plane
         self.control_plane = CoordinatorControlPlane(
             completion_endpoint=completion_endpoint,
@@ -136,16 +141,24 @@ class Coordinator:
                         raise RuntimeError(msg.error or "Unknown error")
                     yield msg
                     completed_stages.add(msg.from_stage)
-                    if (
-                        not self._terminal_stages
-                        or completed_stages >= self._terminal_stages
-                    ):
+                    effective = self._effective_terminals(request_id)
+                    if not effective or completed_stages >= effective:
                         return
                 else:
                     yield msg
         finally:
             self._stream_queues.pop(request_id, None)
             self._completion_futures.pop(request_id, None)
+            self._request_terminals.pop(request_id, None)
+
+    def _effective_terminals(self, request_id: str) -> set[str]:
+        """Return the terminal stage set for *request_id*.
+
+        If a per-request override was stored (e.g. text-only request in a
+        multi-terminal speech pipeline), return that; otherwise fall back to
+        the global ``_terminal_stages``.
+        """
+        return self._request_terminals.get(request_id, self._terminal_stages)
 
     async def _submit_request(
         self, request_id: str, request: OmniRequest | Any
@@ -171,6 +184,18 @@ class Coordinator:
 
         if not isinstance(request, OmniRequest):
             request = OmniRequest(inputs=request)
+
+        # Compute per-request terminal stages when the multi-terminal speech
+        # pipeline is active but this particular request only needs text.
+        if len(self._terminal_stages) > 1:
+            modalities = request.metadata.get("output_modalities")
+            if modalities is not None and "audio" not in modalities:
+                # Only the text decode terminal is expected.
+                text_terminals = {
+                    s for s in self._terminal_stages if s == "decode"
+                }
+                if text_terminals:
+                    self._request_terminals[request_id] = text_terminals
 
         payload = StagePayload(
             request_id=request_id,
@@ -240,6 +265,7 @@ class Coordinator:
         # Cleanup request tracking
         self._requests.pop(request_id, None)
         self._partial_results.pop(request_id, None)
+        self._request_terminals.pop(request_id, None)
 
         logger.info("Coordinator aborted req=%s", request_id)
         return True
@@ -285,6 +311,7 @@ class Coordinator:
             info.state = RequestState.FAILED
             info.error = msg.error
             self._partial_results.pop(request_id, None)
+            self._request_terminals.pop(request_id, None)
             if request_id in self._completion_futures:
                 future = self._completion_futures[request_id]
                 if not future.done():
@@ -294,8 +321,10 @@ class Coordinator:
             self._requests.pop(request_id, None)
             return
 
+        effective = self._effective_terminals(request_id)
+
         # Single terminal (original behavior) or no terminal_stages configured
-        if len(self._terminal_stages) <= 1:
+        if len(effective) <= 1:
             info.state = RequestState.COMPLETED
             info.result = msg.result
             if request_id in self._completion_futures:
@@ -305,6 +334,7 @@ class Coordinator:
             if request_id in self._stream_queues:
                 await self._stream_queues[request_id].put(msg)
             self._requests.pop(request_id, None)
+            self._request_terminals.pop(request_id, None)
             return
 
         # Multi-terminal: collect partial results
@@ -315,12 +345,13 @@ class Coordinator:
         if request_id in self._stream_queues:
             await self._stream_queues[request_id].put(msg)
 
-        if len(partials) < len(self._terminal_stages):
+        if len(partials) < len(effective):
             return  # still waiting
 
         # All terminal stages done -> merge and resolve
         merged = dict(partials)
         self._partial_results.pop(request_id)
+        self._request_terminals.pop(request_id, None)
         info.state = RequestState.COMPLETED
         info.result = merged
 

--- a/sglang_omni/pipeline/worker/runtime.py
+++ b/sglang_omni/pipeline/worker/runtime.py
@@ -72,6 +72,9 @@ class Worker:
             set()
         )  # Set by compiler for CUDA IPC zero-copy
         self._stream_running: bool = False
+        # Per-request set of stream targets to suppress (for text-only
+        # requests in the speech pipeline).
+        self._suppressed_stream_targets: dict[str, set[str]] = {}
 
     def bind(self, stage: Stage, queue: asyncio.Queue[WorkDescriptor | None]) -> None:
         """Bind this worker to a stage."""
@@ -174,7 +177,23 @@ class Worker:
                     f"(expected={request_id} got={merged.request_id})"
                 )
 
+            # Determine whether audio stream targets should be suppressed
+            # for this request (e.g. text-only in speech pipeline).
             bootstrap_targets = self._get_stream_bootstrap_targets()
+            if bootstrap_targets or self._stream_targets:
+                modalities = None
+                if hasattr(merged, "request") and merged.request is not None:
+                    modalities = merged.request.metadata.get("output_modalities")
+                if modalities is not None and "audio" not in modalities:
+                    self._suppressed_stream_targets[request_id] = set(
+                        self._stream_targets
+                    )
+                    bootstrap_targets = [
+                        t
+                        for t in bootstrap_targets
+                        if t not in self._suppressed_stream_targets[request_id]
+                    ]
+
             for stage_name in bootstrap_targets:
                 sent = await self._send_to_next(request_id, stage_name, merged)
                 if not sent:
@@ -209,7 +228,11 @@ class Worker:
             logger.debug("Worker %s: got result for %s", self.stage.name, request_id)
 
             # Signal stream done to all downstream streaming targets
+            # (skip targets suppressed for this request).
+            suppressed = self._suppressed_stream_targets.get(request_id, set())
             for target in self._stream_targets:
+                if target in suppressed:
+                    continue
                 try:
                     self._enqueue_stream_done(request_id, target)
                 except Exception:
@@ -271,6 +294,7 @@ class Worker:
             await self._send_failure(request_id, str(e))
         finally:
             self._result_waiters.pop(request_id, None)
+            self._suppressed_stream_targets.pop(request_id, None)
             if self.stage is not None:
                 self.stage.router.clear_request(request_id)
                 # Close the stream queue entry to prevent per-request leaks
@@ -420,6 +444,11 @@ class Worker:
         metadata: dict | None = None,
     ) -> None:
         """Non-blocking enqueue. Must not block — may be called from the event loop."""
+        # Skip streaming to targets suppressed for this request (e.g.
+        # text-only request skipping audio stages in the speech pipeline).
+        suppressed = self._suppressed_stream_targets.get(request_id)
+        if suppressed and target_stage in suppressed:
+            return
         try:
             self._stream_send_queue.put_nowait(
                 _PendingStreamItem(

--- a/tests/test_flexible_inference.py
+++ b/tests/test_flexible_inference.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for flexible inference path (per-request modality routing)."""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from sglang_omni.models.qwen3_omni.pipeline.next_stage import (
+    DECODE_STAGE,
+    TALKER_AR_STAGE,
+    thinker_next_flexible,
+    thinker_next_speech,
+)
+from sglang_omni.proto import OmniRequest, StagePayload
+
+
+def _make_payload(output_modalities: list[str] | None = None) -> StagePayload:
+    metadata: dict = {}
+    if output_modalities is not None:
+        metadata["output_modalities"] = output_modalities
+    return StagePayload(
+        request_id="test-req",
+        request=OmniRequest(inputs={}, metadata=metadata),
+        data={},
+    )
+
+
+# ------------------------------------------------------------------
+# thinker_next_flexible routing tests
+# ------------------------------------------------------------------
+
+
+class TestThinkerNextFlexible(unittest.TestCase):
+    def test_text_only_returns_decode_only(self):
+        payload = _make_payload(["text"])
+        result = thinker_next_flexible("req-1", payload)
+        self.assertEqual(result, DECODE_STAGE)
+
+    def test_text_audio_returns_fanout(self):
+        payload = _make_payload(["text", "audio"])
+        result = thinker_next_flexible("req-1", payload)
+        self.assertEqual(result, [DECODE_STAGE, TALKER_AR_STAGE])
+
+    def test_audio_only_returns_fanout(self):
+        payload = _make_payload(["audio"])
+        result = thinker_next_flexible("req-1", payload)
+        self.assertEqual(result, [DECODE_STAGE, TALKER_AR_STAGE])
+
+    def test_none_modalities_returns_fanout(self):
+        """When output_modalities is unset, default to full speech path."""
+        payload = _make_payload(None)
+        result = thinker_next_flexible("req-1", payload)
+        self.assertEqual(result, [DECODE_STAGE, TALKER_AR_STAGE])
+
+    def test_non_stage_payload_returns_fanout(self):
+        """Defensive: if output is not a StagePayload, default to full path."""
+        result = thinker_next_flexible("req-1", {"some": "dict"})
+        self.assertEqual(result, [DECODE_STAGE, TALKER_AR_STAGE])
+
+    def test_original_thinker_next_speech_unchanged(self):
+        """Backward compat: the old function still returns full fanout."""
+        result = thinker_next_speech("req-1", _make_payload(["text"]))
+        self.assertEqual(result, [DECODE_STAGE, TALKER_AR_STAGE])
+
+
+# ------------------------------------------------------------------
+# Coordinator per-request terminal tests
+# ------------------------------------------------------------------
+
+
+class TestCoordinatorPerRequestTerminals(unittest.TestCase):
+    """Test the coordinator's per-request terminal stage tracking."""
+
+    def _make_coordinator(self, terminal_stages=None):
+        from sglang_omni.pipeline.coordinator import Coordinator
+
+        coord = Coordinator(
+            completion_endpoint="inproc://test-comp",
+            abort_endpoint="inproc://test-abort",
+            entry_stage="preprocessing",
+            terminal_stages=terminal_stages,
+        )
+        # Mock the control plane so we don't need real ZMQ
+        coord.control_plane = MagicMock()
+        coord.control_plane.submit_to_stage = AsyncMock()
+        coord.control_plane.recv_event = AsyncMock()
+        coord.control_plane.broadcast_abort = AsyncMock()
+        return coord
+
+    def test_effective_terminals_default(self):
+        coord = self._make_coordinator(["decode", "code2wav"])
+        self.assertEqual(
+            coord._effective_terminals("req-1"), {"decode", "code2wav"}
+        )
+
+    def test_effective_terminals_with_override(self):
+        coord = self._make_coordinator(["decode", "code2wav"])
+        coord._request_terminals["req-1"] = {"decode"}
+        self.assertEqual(coord._effective_terminals("req-1"), {"decode"})
+
+    def test_submit_text_only_sets_override(self):
+        coord = self._make_coordinator(["decode", "code2wav"])
+        # Register a dummy entry stage
+        coord._stages["preprocessing"] = MagicMock()
+        coord._stages["preprocessing"].control_endpoint = "inproc://dummy"
+
+        request = OmniRequest(
+            inputs={}, metadata={"output_modalities": ["text"]}
+        )
+        asyncio.get_event_loop().run_until_complete(
+            coord._submit_request("req-text", request)
+        )
+        self.assertIn("req-text", coord._request_terminals)
+        self.assertEqual(coord._request_terminals["req-text"], {"decode"})
+
+    def test_submit_audio_no_override(self):
+        coord = self._make_coordinator(["decode", "code2wav"])
+        coord._stages["preprocessing"] = MagicMock()
+        coord._stages["preprocessing"].control_endpoint = "inproc://dummy"
+
+        request = OmniRequest(
+            inputs={}, metadata={"output_modalities": ["text", "audio"]}
+        )
+        asyncio.get_event_loop().run_until_complete(
+            coord._submit_request("req-audio", request)
+        )
+        self.assertNotIn("req-audio", coord._request_terminals)
+
+    def test_submit_no_modalities_no_override(self):
+        coord = self._make_coordinator(["decode", "code2wav"])
+        coord._stages["preprocessing"] = MagicMock()
+        coord._stages["preprocessing"].control_endpoint = "inproc://dummy"
+
+        request = OmniRequest(inputs={}, metadata={})
+        asyncio.get_event_loop().run_until_complete(
+            coord._submit_request("req-default", request)
+        )
+        self.assertNotIn("req-default", coord._request_terminals)
+
+    def test_completion_text_only_resolves_on_decode(self):
+        """Text-only request resolves after decode completes, not waiting for code2wav."""
+        from sglang_omni.proto import CompleteMessage, RequestInfo, RequestState
+
+        coord = self._make_coordinator(["decode", "code2wav"])
+        # Simulate a submitted text-only request
+        coord._requests["req-text"] = RequestInfo(
+            request_id="req-text", state=RequestState.RUNNING
+        )
+        coord._request_terminals["req-text"] = {"decode"}
+        loop = asyncio.get_event_loop()
+        future = loop.create_future()
+        coord._completion_futures["req-text"] = future
+
+        loop.run_until_complete(
+            coord._handle_completion(
+                CompleteMessage(
+                    request_id="req-text",
+                    from_stage="decode",
+                    success=True,
+                    result={"text": "hello"},
+                )
+            )
+        )
+        # Should be resolved immediately
+        self.assertTrue(future.done())
+        self.assertEqual(future.result(), {"text": "hello"})
+        # Cleanup
+        self.assertNotIn("req-text", coord._request_terminals)
+
+    def test_completion_audio_waits_for_both(self):
+        """Audio request waits for both decode and code2wav."""
+        from sglang_omni.proto import CompleteMessage, RequestInfo, RequestState
+
+        coord = self._make_coordinator(["decode", "code2wav"])
+        coord._requests["req-audio"] = RequestInfo(
+            request_id="req-audio", state=RequestState.RUNNING
+        )
+        # No override — uses global terminal_stages
+        loop = asyncio.get_event_loop()
+        future = loop.create_future()
+        coord._completion_futures["req-audio"] = future
+
+        # First terminal completes
+        loop.run_until_complete(
+            coord._handle_completion(
+                CompleteMessage(
+                    request_id="req-audio",
+                    from_stage="decode",
+                    success=True,
+                    result={"text": "hello"},
+                )
+            )
+        )
+        self.assertFalse(future.done())
+
+        # Second terminal completes
+        loop.run_until_complete(
+            coord._handle_completion(
+                CompleteMessage(
+                    request_id="req-audio",
+                    from_stage="code2wav",
+                    success=True,
+                    result={"audio": b"wav-data"},
+                )
+            )
+        )
+        self.assertTrue(future.done())
+        self.assertEqual(
+            future.result(),
+            {"decode": {"text": "hello"}, "code2wav": {"audio": b"wav-data"}},
+        )
+
+    def test_abort_cleans_up_request_terminals(self):
+        from sglang_omni.proto import RequestInfo, RequestState
+
+        coord = self._make_coordinator(["decode", "code2wav"])
+        coord._requests["req-abort"] = RequestInfo(
+            request_id="req-abort", state=RequestState.RUNNING
+        )
+        coord._request_terminals["req-abort"] = {"decode"}
+        loop = asyncio.get_event_loop()
+        future = loop.create_future()
+        coord._completion_futures["req-abort"] = future
+
+        loop.run_until_complete(coord.abort("req-abort"))
+        self.assertNotIn("req-abort", coord._request_terminals)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #61.

- When the speech pipeline is deployed, requests with `modalities=["text"]` now skip audio stages entirely (talker_ar, code_predictor, code2wav) instead of running them and filtering at the API layer
- Requests with `modalities=["text", "audio"]` or no modalities specified behave exactly as before
- No configuration changes needed — the same pipeline serves both text-only and speech requests dynamically

## Changes

- **Modality-aware routing** (`next_stage.py`): New `thinker_next_flexible` checks request metadata to decide whether to fan out to audio stages
- **Per-request terminal tracking** (`coordinator.py`): Coordinator now tracks expected terminal stages per request so text-only requests resolve after decode without waiting for code2wav
- **Stream suppression** (`runtime.py`): Bootstrap, inter-stage streaming, and stream-done signals are suppressed for audio targets on text-only requests to avoid memory leaks
- **Pipeline config** (`config.py`): Speech pipeline now uses the flexible routing function

## Test plan

- [x] Unit tests for `thinker_next_flexible` with all modality combinations
- [x] Unit tests for coordinator per-request terminal resolution
- [x] All 33 existing + new tests pass