### PR TITLE
[WIP] Add seed-tts-eval-ci dataset support and fine-tune S2-Pro CI thresholds

### DIFF
--- a/benchmarks/dataset/prepare.py
+++ b/benchmarks/dataset/prepare.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 DATASETS = {
     "seedtts": "zhaochenyang20/seed-tts-eval",
     "seedtts-mini": "zhaochenyang20/seed-tts-eval-mini", # 5 en samples + 5 zh samples
-    "seedtts-ci": "zhaochenyang20/seed-tts-eval-ci", # 16 en samples
+    "seedtts-ci": "zhaochenyang20/seed-tts-eval-ci", # 64 en samples
 }
 
 

--- a/tests/test_model/test_s2pro_tts_ci.py
+++ b/tests/test_model/test_s2pro_tts_ci.py
@@ -31,7 +31,8 @@ PER_REQUEST_STORE: dict[str, list[dict]] = {}
 
 MODEL_PATH = "fishaudio/s2-pro"
 CONFIG_PATH = "examples/configs/s2pro_tts.yaml"
-MAX_SAMPLES = 16
+SPEED_MAX_SAMPLES = 16
+WER_MAX_SAMPLES = 64
 
 STARTUP_TIMEOUT = 600
 BENCHMARK_TIMEOUT = 600
@@ -41,7 +42,7 @@ WER_TIMEOUT = 600
 # Note (chenyang): the RTF thresholds also includes the reference audio
 # processing time. The Plain text RTF is far less than 1.0.
 
-# TODO: Fine-tune thresholds based on CI dataset performance on H20.
+# TODO: Fine-tune thresholds based on CI dataset performance on H20 with concurrency support.
 VC_NON_STREAM_MIN_TOK_PER_S = 80
 VC_NON_STREAM_MAX_RTF = 2.1
 VC_STREAM_MAX_LATENCY_S = 10.1
@@ -52,14 +53,10 @@ PLAIN_STREAM_MAX_LATENCY_S = 4.7
 PLAIN_STREAM_MIN_THROUGHPUT_QPS = 0.215
 
 
-# NOTE: Current WER thresholds are based on a small CI subset of seed-tts-eval dataset (N=16).
-# This sample size may not always capture accuracy regressions
-# If flaky or missed regressions occur, consider expanding the WER evaluation dataset to N=32/64 with concurrency support.
-
-VC_WER_MAX_CORPUS = 0.02
-VC_WER_MAX_PER_SAMPLE = 0.20
-VC_STREAM_WER_MAX_CORPUS = 0.02
-VC_STREAM_WER_MAX_PER_SAMPLE = 0.20
+VC_WER_MAX_CORPUS = 0.025
+VC_WER_MAX_PER_SAMPLE = 0.30
+VC_STREAM_WER_MAX_CORPUS = 0.025
+VC_STREAM_WER_MAX_PER_SAMPLE = 0.30
 
 
 WER_SCRIPT = str(
@@ -91,7 +88,7 @@ def _run_benchmark(
         "--testset",
         testset,
         "--max-samples",
-        str(MAX_SAMPLES),
+        str(SPEED_MAX_SAMPLES),
         "--output-dir",
         output_dir,
     ]
@@ -152,7 +149,7 @@ def _run_wer_generate(
         "--port",
         str(port),
         "--max-samples",
-        str(MAX_SAMPLES),
+        str(WER_MAX_SAMPLES),
     ]
     if stream:
         cmd.append("--stream")
@@ -358,7 +355,7 @@ def _assert_streaming_consistency(
     non_stream_requests: list[dict],
     stream_requests: list[dict],
     *,
-    completion_token_rtol: float = 0.10,
+    completion_token_rtol: float = 0.12,
     audio_duration_rtol: float = 0.12,
 ) -> None:
     """Assert per-request metrics are close between streaming and non-streaming."""


### PR DESCRIPTION
## Summary

- Create [seed-tts-eval-ci](https://huggingface.co/datasets/zhaochenyang20/seed-tts-eval-ci) dataset (16 EN samples), add support, and switch S2-Pro CI from `seedtts-mini` (N=5) to `seedtts-ci` (N=16)
- Fine-tune performance and WER thresholds based on N=16 CI dataset observations

## Dataset Size (N=16)

N=16 is chosen to support future concurrency testing. As discussed in #200, a sub-dataset of N≈20 provides reasonable representativeness of the full evaluation set, and is able to detect accuracy regressions. N≈100 would be a more stable proxy for the full set, but N=16 is preferred for now to keep CI runtime reasonble.

If missed accuracy regressions occur in the future, consider expanding to N=32/64 with concurrency support.

## Performance Thresholds

Thresholds are calibrated against observed performance on H200 with the CI dataset, with ~5-10% buffer. They may need further adjustment based on H20 (CI server) performance.

| Metric | Observed (H200, N=16) | Threshold | Margin |
|--------|----------------------|-----------|--------|
| `VC_NON_STREAM_MIN_TOK_PER_S` | 86.4 | ≥ 80 | +8.0% |
| `VC_NON_STREAM_MAX_RTF` | 1.91 | ≤ 2.1 | +9.0% |
| `VC_STREAM_MAX_LATENCY_S` | 9.71 | ≤ 10.1 | +3.9% |
| `VC_STREAM_MIN_THROUGHPUT_QPS` | 0.103 | ≥ 0.098 | +5.1% |
| `PLAIN_NON_STREAM_MIN_TOK_PER_S` | 86.7 | ≥ 80 | +8.4% |
| `PLAIN_NON_STREAM_MAX_RTF` | 0.27 | ≤ 0.30 | +10.0% |
| `PLAIN_STREAM_MAX_LATENCY_S` | 4.40 | ≤ 4.7 | +6.4% |
| `PLAIN_STREAM_MIN_THROUGHPUT_QPS` | 0.227 | ≥ 0.215 | +5.6% |

## WER Thresholds

- `VC_WER_MAX_CORPUS = 0.02` (2%): allows minor discrepancies without masking real accuracy regressions
- `VC_WER_MAX_PER_SAMPLE = 0.20` (20%): allows small errors on individual samples but catches catastrophically broken outputs
- Same thresholds apply to the streaming variant

## Test plan

- [x] Full CI test pass on H200 with N=16 (8/8 passed)
- [ ] Further verify on H20 CI server with concurrency and fine-tune thresholds if needed
