### PR TITLE
[fix] Fix ineffective per-sample max WER threshold in S2-Pro CI

### DIFF
--- a/tests/test_model/test_s2pro_tts_ci.py
+++ b/tests/test_model/test_s2pro_tts_ci.py
@@ -68,9 +68,9 @@ THRESHOLD_SLACK_HIGHER = 0.75
 THRESHOLD_SLACK_LOWER = 1.25
 
 VC_WER_MAX_CORPUS = 0.025
-VC_WER_MAX_PER_SAMPLE = 0.6
+VC_WER_MAX_PER_SAMPLE = 0.5
 VC_STREAM_WER_MAX_CORPUS = 0.025
-VC_STREAM_WER_MAX_PER_SAMPLE = 0.6
+VC_STREAM_WER_MAX_PER_SAMPLE = 0.5
 
 # Note (Chenyang): Only thresholds for concurrency 8 are dedicatedly tuned, others
 # may not pass the CI.


### PR DESCRIPTION
## Summary
- `VC_WER_MAX_PER_SAMPLE` / `VC_STREAM_WER_MAX_PER_SAMPLE`: 0.6 -> 0.5 in `test_s2pro_tts_ci`
- The previous value (0.6) was strictly weaker than the existing `n_above_50_pct_wer == 0` check, making the per-sample threshold dead code
- Aligning to 0.5 ensures the threshold is actually enforceable and avoids confusion in future development

## Note
These two parameters only take effect when set to **≤ 0.5**, since `_assert_wer_results` already rejects any sample with WER > 50% via the `n_above_50_pct_wer == 0` assertion.