### PR TITLE
[devcontainer] Add devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,63 @@
+FROM frankleeeee/sglang-omni:dev AS base
+
+ENV PYTHONUNBUFFERED=1
+
+# Default to non 1000 uid to avoid default 1000 uid collsion
+ARG HOST_UID=1003
+ARG HOST_GID=1003
+# fallback uid to swap if HOST_UID is taken
+ARG DEV_UID_FALLBACK=1100
+ARG DEV_GID_FALLBACK=1100
+
+RUN set -eux; \
+    conflict_group="$(getent group "${HOST_GID}" | cut -d: -f1 || true)"; \
+    if [ -n "${conflict_group}" ] && [ "${conflict_group}" != "devuser" ]; then \
+        groupmod -g "${DEV_GID_FALLBACK}" "${conflict_group}"; \
+    fi; \
+    if ! getent group devuser >/dev/null; then \
+        groupadd -g "${HOST_GID}" devuser; \
+    else \
+        groupmod -g "${HOST_GID}" devuser; \
+    fi; \
+    conflict_user="$(getent passwd "${HOST_UID}" | cut -d: -f1 || true)"; \
+    if [ -n "${conflict_user}" ] && [ "${conflict_user}" != "devuser" ]; then \
+        old_group="$(id -gn "${conflict_user}")"; \
+        usermod -u "${DEV_UID_FALLBACK}" -g "${DEV_GID_FALLBACK}" "${conflict_user}"; \
+        if [ -d "/home/${conflict_user}" ]; then \
+            chown -R "${DEV_UID_FALLBACK}:${DEV_GID_FALLBACK}" "/home/${conflict_user}"; \
+        fi; \
+    fi; \
+    if id -u devuser >/dev/null 2>&1; then \
+        usermod -u "${HOST_UID}" -g "${HOST_GID}" -s /bin/zsh devuser; \
+    else \
+        useradd -m -u "${HOST_UID}" -g "${HOST_GID}" -s /bin/zsh devuser; \
+    fi; \
+    if [ -d /home/devuser ]; then \
+        chown -R "${HOST_UID}:${HOST_GID}" /home/devuser; \
+    fi
+
+RUN apt-get update \
+    && apt-get install -y sudo \
+    && echo "devuser ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/devuser \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# copy host shell configs
+RUN if [ -d /root/.oh-my-zsh ]; then cp -r /root/.oh-my-zsh /home/devuser/.oh-my-zsh; fi \
+    && if [ -f /root/.zshrc ]; then cp /root/.zshrc /home/devuser/.zshrc; fi \
+    && if [ -f /root/.vimrc ]; then cp /root/.vimrc /home/devuser/.vimrc; fi \
+    && if [ -f /root/.tmux.conf ]; then cp /root/.tmux.conf /home/devuser/.tmux.conf; fi \
+    && if [ -f /home/devuser/.zshrc ]; then sed -i 's|/root/.oh-my-zsh|/home/devuser/.oh-my-zsh|g' /home/devuser/.zshrc; fi \
+    && chown -R devuser:devuser /home/devuser
+
+WORKDIR /sgl-workspace/sglang-omni
+RUN install -d -o devuser -g devuser /sgl-workspace
+
+USER devuser
+
+# install uv
+RUN if ! command -v uv >/dev/null 2>&1; then curl -LsSf https://astral.sh/uv/install.sh | sh; fi
+
+ENV PATH="/home/devuser/.local/bin:${PATH}"
+
+FROM base AS dev

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+{
+  "name": "sglang-omni",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "..",
+    "target": "dev",
+    "args": {
+      // Change to your host uid/gid to preserve workspace folder write permission in container  
+      // "HOST_UID": "1000",
+      // "HOST_GID": "1000"
+    }
+  },
+  "remoteUser": "devuser",
+  "updateRemoteUserUID": true,
+  "runArgs": [
+    "--gpus",
+    "all",
+    "--shm-size",
+    "32g"
+  ],
+  "workspaceFolder": "/sgl-workspace/sglang-omni",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/sgl-workspace/sglang-omni,type=bind",
+  "containerEnv": {
+    "PYTHON_BIN": "python3"
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "python.terminal.activateEnvironment": true
+      },
+      "extensions": [
+        "ms-python.python"
+      ]
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
     "context": "..",
     "target": "dev",
     "args": {
-      // Change to your host uid/gid to preserve workspace folder write permission in container  
+      // Change to your host uid/gid to preserve workspace folder write permission in container
       // "HOST_UID": "1000",
       // "HOST_GID": "1000"
     }

--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -23,6 +23,100 @@ uv pip install -v -e ".[dev]"
 
 ## 🐳 Use Docker
 
+
+### Option 1 Use Devcontainer (VSCode as an example)
+
+[Devcontainer](https://containers.dev/) can auto spin up a development environment on top of docker image and handles host-container folder binding.
+
+We will use VS Code as example here, but devbocontainer [supports](https://containers.dev/supporting) multiple ide and tools
+
+See also: [sglang dev container guide](https://github.com/sgl-project/sglang/blob/main/docs/developer_guide/development_guide_using_docker.md#option-1-use-the-default-dev-container-automatically-from-vscode)
+
+### Prerequisites
+
+- VS Code installation on development host machine
+  - You can find VS Code installation guide at https://code.visualstudio.com/download
+
+
+### Use The Default Dev Container Automatically From VS Code
+
+```bash
+# clone this repository
+git clone git@github.com:sgl-project/sglang-omni.git
+cd sglang-omni
+
+# open the repository in VS Code locally
+code .
+# if you are opening a folder in remote host, use ssh:
+code --remote ssh-remote+[YOUR_HOST] [PROJECT_PATH]
+```
+
+Then in VS Code:
+
+1. Install the VS Code `Dev Containers` extension.
+2. Press `F1` and run `Dev Containers: Reopen in Container`.
+3. Wait for the initial pull and build to complete.
+4. Open a new terminal inside the container.
+
+The devcontainer will:
+
+- build from `.devcontainer/Dockerfile`
+- reuse `frankleeeee/sglang-omni:dev` as the base image
+- mount the repository at `/sgl-workspace/sglang-omni`
+- create a `devuser` user and align container UID/GID with the host when possible
+
+The first time you open the repository in the devcontainer may take longer because Docker needs to pull the base image and build the container image. Once startup is successful, the VS Code status bar should show that you are connected to a dev container.
+
+### Install Python Dependencies Inside The Container
+
+After VS Code finishes attaching to the container, install the project dependencies in the container terminal:
+
+#### install for runtime
+```bash
+uv pip install -v .
+```
+
+#### install for development
+```bash
+uv pip install -v -e ".[dev]"
+```
+
+#### Optional UID/GID Override
+
+If the mounted workspace is not writable inside the container, set the host UID (`id -u`) and GID (`id -u`) in `.devcontainer/devcontainer.json` before rebuilding:
+
+```jsonc
+"args": {
+  "HOST_UID": "1000",
+  "HOST_GID": "1000"
+}
+```
+
+Then run `Dev Containers: Rebuild Container`.
+
+#### Optional docker args override
+
+You can change Docker runArgs in devcontainer.json
+
+```jsonc
+  "runArgs": [
+    "--gpus",
+    "all",
+    "--shm-size",
+    "32g"
+  ],
+```
+
+and devcontainer will run it as
+
+```shell
+docker run -it \
+    --shm-size 32g \
+    --gpus all \
+...
+```
+
+### Option 2 Start up containers manually
 We have build all necessary dependencies into our Docker Image, so you can simply pull and run it.
 
 ```bash


### PR DESCRIPTION
## Motivation

Add a VS Code devcontainer configuration so the repository can be opened directly in a preconfigured development environment with GPU support and a writable mounted workspace.

## Test

Test env: WSL2 Ubuntu 22.04 with RTX 4090

I followed S2-Pro example to test https://cookbook.sglang.io/omni/S2-Pro#22-install-sglang-omni-inside-docker

1. Opened project in vscode devcontainer
2. `uv pip install -v ".[s2pro,dev]"` 
3. `./playground/tts/start.sh --model-path /models/s2-pro`
4. Demo returns audio as expected

<img width="1523" height="347" alt="image" src="https://github.com/user-attachments/assets/578eac27-bff7-447f-836d-68bf6edca822" />


## Modifications

- add `.devcontainer/Dockerfile` based on the existing `frankleeeee/sglang-omni:dev` image
- create a `devuser` that can adapt to host UID/GID collisions and preserve write access on the bind-mounted workspace
- install `sudo`, copy shell configuration, and expose `uv` on the user PATH
- add `.devcontainer/devcontainer.json` to build the `dev` target, mount the repo into `/sgl-workspace/sglang-omni`, enable `--gpus all`, set `--shm-size 32g`, and configure the Python VS Code extension


## Related Issues

N/A

## Accuracy Test

N/A. This change only adds development-container configuration and does not modify model-side code.

## Benchmark & Profiling

N/A. This change is not expected to affect runtime performance.

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed. 
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
