### PR TITLE
[Fix] S2-Pro argmax decoding degeneration causing vocoder OOM (#235)

### DIFF
--- a/benchmarks/dataset/prepare.py
+++ b/benchmarks/dataset/prepare.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 DATASETS = {
     "seedtts": "zhaochenyang20/seed-tts-eval",
     "seedtts-mini": "zhaochenyang20/seed-tts-eval-mini",
-    "seedtts-50": "Ratish21/seed-tts-eval-50",
+    "seedtts-50": "xuesongye/seed-tts-eval-50",
 }
 
 

--- a/sglang_omni/models/fishaudio_s2_pro/pipeline/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/pipeline/stages.py
@@ -334,12 +334,28 @@ def create_sglang_tts_engine_executor(
         top_k=top_k,
     )
 
-    # Note (Xuesong): Compute the max sequence length the vocoder can handle
-    # given available GPU memory after model + KV cache are loaded.
-    # DAC decoder peak memory ≈ 5.3 MB/token (float32, measured empirically).
-    # This guards against user-supplied max_new_tokens that would OOM the
-    # vocoder, but does not account for PyTorch caching allocator fragmentation
-    # after many requests. reference: #267
+      # Note (Xuesong, Chenyang): 
+      # SGLang engine pre-allocates ~85% of total VRAM for model weights
+      # and KV cache. The remaining ~15% is shared by runtime activations
+      # and the vocoder (DAC decoder).
+
+      # Unlike the KV cache, the vocoder has no pre-allocated memory pool —
+      # it allocates dynamically during codec.from_indices() on each request.
+      # If the AR model produces an oversized codebook sequence, DAC conv1d
+      # layers need ~5.3 MB per token (float32, measured empirically on H100),
+      # easily exceeding the remaining free VRAM.
+
+      # To prevent this, we snapshot free GPU memory at engine startup and
+      # compute the maximum token count the vocoder can safely handle.
+      # Requests whose max_new_tokens exceed this limit are clamped and raise
+      # warnings.
+
+      # Caveat: PyTorch's caching allocator gradually consumes free memory
+      # over time, so actual headroom at runtime is lower than at startup.
+      # This guard is conservative but not airtight.
+
+      # reference: https://github.com/sgl-project/sglang-omni/pull/267
+
     _VOCODER_BYTES_PER_TOKEN = int(5.3 * 1024 * 1024)
     gpu_id_int = int(device.split(":")[-1]) if ":" in device else 0
     free_mem = torch.cuda.mem_get_info(gpu_id_int)[0]

--- a/sglang_omni/models/fishaudio_s2_pro/pipeline/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/pipeline/stages.py
@@ -352,9 +352,11 @@ def create_sglang_tts_engine_executor(
     # Requests whose max_new_tokens exceed this limit are clamped and raise
     # warnings.
 
-    # Caveat: PyTorch's caching allocator gradually consumes free memory
-    # over time, so actual headroom at runtime is lower than at startup.
-    # This guard is conservative but not airtight.
+    # Caveat: PyTorch's caching allocator reserves memory for intermediate
+    # tensors across requests (~5.5 GB over ~100 diverse requests on H100).
+    # This memory is NOT lost — the vocoder allocates through the same
+    # allocator and reuses cached blocks. The allocator also evicts old
+    # blocks when large contiguous allocations are needed.
 
     # reference: https://github.com/sgl-project/sglang-omni/pull/267
 

--- a/sglang_omni/models/fishaudio_s2_pro/pipeline/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/pipeline/stages.py
@@ -334,8 +334,32 @@ def create_sglang_tts_engine_executor(
         top_k=top_k,
     )
 
+    # Note (Xuesong): Compute the max sequence length the vocoder can handle
+    # given available GPU memory after model + KV cache are loaded.
+    # DAC decoder peak memory ≈ 5.3 MB/token (float32, measured empirically).
+    # This guards against user-supplied max_new_tokens that would OOM the
+    # vocoder, but does not account for PyTorch caching allocator fragmentation
+    # after many requests. reference: #267
+    _VOCODER_BYTES_PER_TOKEN = int(5.3 * 1024 * 1024)
+    gpu_id_int = int(device.split(":")[-1]) if ":" in device else 0
+    free_mem = torch.cuda.mem_get_info(gpu_id_int)[0]
+    max_vocoder_tokens = int(free_mem / _VOCODER_BYTES_PER_TOKEN)
+    logger.info(
+        "Vocoder memory guard: GPU free %.1f GB, max_vocoder_tokens=%d",
+        free_mem / 1e9,
+        max_vocoder_tokens,
+    )
+
     def _request_builder(payload: StagePayload):
         state = load_state(payload)
+        if state.max_new_tokens > max_vocoder_tokens:
+            logger.warning(
+                "Request %s: max_new_tokens=%d exceeds vocoder limit %d, clamping.",
+                payload.request_id,
+                state.max_new_tokens,
+                max_vocoder_tokens,
+            )
+            state.max_new_tokens = max_vocoder_tokens
         return build_sglang_tts_request(state, tokenizer, request_id=payload.request_id)
 
     def _result_builder(payload: StagePayload, result: Any) -> StagePayload:

--- a/sglang_omni/models/fishaudio_s2_pro/pipeline/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/pipeline/stages.py
@@ -334,27 +334,27 @@ def create_sglang_tts_engine_executor(
         top_k=top_k,
     )
 
-      # Note (Xuesong, Chenyang): 
-      # SGLang engine pre-allocates ~85% of total VRAM for model weights
-      # and KV cache. The remaining ~15% is shared by runtime activations
-      # and the vocoder (DAC decoder).
+    # Note (Xuesong, Chenyang):
+    # SGLang engine pre-allocates ~85% of total VRAM for model weights
+    # and KV cache. The remaining ~15% is shared by runtime activations
+    # and the vocoder (DAC decoder).
 
-      # Unlike the KV cache, the vocoder has no pre-allocated memory pool —
-      # it allocates dynamically during codec.from_indices() on each request.
-      # If the AR model produces an oversized codebook sequence, DAC conv1d
-      # layers need ~5.3 MB per token (float32, measured empirically on H100),
-      # easily exceeding the remaining free VRAM.
+    # Unlike the KV cache, the vocoder has no pre-allocated memory pool —
+    # it allocates dynamically during codec.from_indices() on each request.
+    # If the AR model produces an oversized codebook sequence, DAC conv1d
+    # layers need ~5.3 MB per token (float32, measured empirically on H100),
+    # easily exceeding the remaining free VRAM.
 
-      # To prevent this, we snapshot free GPU memory at engine startup and
-      # compute the maximum token count the vocoder can safely handle.
-      # Requests whose max_new_tokens exceed this limit are clamped and raise
-      # warnings.
+    # To prevent this, we snapshot free GPU memory at engine startup and
+    # compute the maximum token count the vocoder can safely handle.
+    # Requests whose max_new_tokens exceed this limit are clamped and raise
+    # warnings.
 
-      # Caveat: PyTorch's caching allocator gradually consumes free memory
-      # over time, so actual headroom at runtime is lower than at startup.
-      # This guard is conservative but not airtight.
+    # Caveat: PyTorch's caching allocator gradually consumes free memory
+    # over time, so actual headroom at runtime is lower than at startup.
+    # This guard is conservative but not airtight.
 
-      # reference: https://github.com/sgl-project/sglang-omni/pull/267
+    # reference: https://github.com/sgl-project/sglang-omni/pull/267
 
     _VOCODER_BYTES_PER_TOKEN = int(5.3 * 1024 * 1024)
     gpu_id_int = int(device.split(":")[-1]) if ":" in device else 0

--- a/sglang_omni/models/fishaudio_s2_pro/pipeline/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/pipeline/stages.py
@@ -24,6 +24,8 @@ from sglang_omni.proto import StagePayload
 
 logger = logging.getLogger(__name__)
 
+_VOCODER_BYTES_PER_TOKEN = int(5.3 * 1024 * 1024)
+
 _STREAM_CODES_KEY = "_stream_output_codes"
 _STREAM_EMITTED_SAMPLES_KEY = "_stream_emitted_samples"
 _STREAM_LAST_VOCODE_TOKENS_KEY = "_stream_last_vocode_tokens"
@@ -356,24 +358,18 @@ def create_sglang_tts_engine_executor(
 
     # reference: https://github.com/sgl-project/sglang-omni/pull/267
 
-    _VOCODER_BYTES_PER_TOKEN = int(5.3 * 1024 * 1024)
     gpu_id_int = int(device.split(":")[-1]) if ":" in device else 0
     free_mem = torch.cuda.mem_get_info(gpu_id_int)[0]
     max_vocoder_tokens = int(free_mem / _VOCODER_BYTES_PER_TOKEN)
     logger.info(
-        "Vocoder memory guard: GPU free %.1f GB, max_vocoder_tokens=%d",
-        free_mem / 1e9,
-        max_vocoder_tokens,
+        f"Vocoder memory guard: GPU free {free_mem / 1e9:.1f} GB, max_vocoder_tokens={max_vocoder_tokens}"
     )
 
     def _request_builder(payload: StagePayload):
         state = load_state(payload)
         if state.max_new_tokens > max_vocoder_tokens:
             logger.warning(
-                "Request %s: max_new_tokens=%d exceeds vocoder limit %d, clamping.",
-                payload.request_id,
-                state.max_new_tokens,
-                max_vocoder_tokens,
+                f"Request {payload.request_id}: max_new_tokens={state.max_new_tokens} exceeds vocoder limit {max_vocoder_tokens}, clamping."
             )
             state.max_new_tokens = max_vocoder_tokens
         return build_sglang_tts_request(state, tokenizer, request_id=payload.request_id)

--- a/sglang_omni/models/fishaudio_s2_pro/sglang_model.py
+++ b/sglang_omni/models/fishaudio_s2_pro/sglang_model.py
@@ -349,9 +349,12 @@ class S2ProSGLangTextModel(nn.Module):
         """Constrained semantic sampling + batched codebook generation."""
         bs = logits.shape[0]
 
-        # Constrained decode: mask non-semantic tokens
+        # Constrained decode: mask non-semantic tokens, then sample
         biased_logits = logits + self._semantic_bias
-        semantic_token = torch.argmax(biased_logits, dim=-1)  # [bs]
+        # Note (Xuesong): Following Non-CUDA Graph path with temperature=0.7 (fish-speech upstream default).
+        # reference: https://github.com/sgl-project/sglang-omni/pull/267
+        probs = torch.softmax(biased_logits / 0.7, dim=-1)
+        semantic_token = torch.multinomial(probs, num_samples=1).squeeze(-1)  # [bs]
 
         # Batched codebook loop
         self._audio_decoder.reset_caches()

--- a/tests/test_model/test_s2pro_tts_ci.py
+++ b/tests/test_model/test_s2pro_tts_ci.py
@@ -12,6 +12,7 @@ Author:
     Jingwen Guo https://github.com/JingwenGu0829
     Yuan Luo https://github.com/yuan-luo
     Yitong Guan https://github.com/minleminzui
+    Xuesong Ye https://github.com/yxs
 
 The benchmark supports one selected concurrency per test run. Use --concurrency 8
 in CI, run without the flag to use concurrency 1, or pass --concurrency all
@@ -77,9 +78,9 @@ STREAMING_BENCHMARK_MAX_SAMPLES = 16
 THRESHOLD_SLACK_HIGHER = 0.75
 THRESHOLD_SLACK_LOWER = 1.25
 
-VC_WER_MAX_CORPUS = 0.025
+VC_WER_MAX_CORPUS = 0.015
 VC_WER_MAX_PER_SAMPLE = 0.5
-VC_STREAM_WER_MAX_CORPUS = 0.025
+VC_STREAM_WER_MAX_CORPUS = 0.015
 VC_STREAM_WER_MAX_PER_SAMPLE = 0.5
 
 # Note (Chenyang): Only thresholds for concurrency 8 are dedicatedly tuned, others


### PR DESCRIPTION
  **Root cause**: The CUDA-graphed inference path uses `torch.argmax` for semantic token selection, while fish-speech upstream uses `torch.multinomial` sampling. With argmax, if `im_end` never becomes the highest-logit token for a given input, the model never stops, it runs to `max_new_tokens` every time. The oversized codebook sequence then OOMs the vocoder.

  **Fix**: Replace `torch.argmax` with `torch.multinomial` sampling (temperature=0.7, matching fish-speech upstream default). `torch.multinomial` is CUDA-graph compatible.

  Tested on H100 80GB, SeedTTS EN 1088 (`--no-ref-audio`, concurrency=1):

  |  | Before | After |
  |---|---|---|
  | Pass | 1079/1088 | 1088/1088 |
  | Fail | 9 (same 9 every run) | 0 |
  | Latency mean | 1.293s | 1.26s |
  | WER (seedtts-50, whisper-large-v3) | 1.45% | 0.91% |