### PR TITLE
[Ming-Omni] Support Vision Encoder

### DIFF
--- a/scripts/test_ming_omni_vision_e2e.py
+++ b/scripts/test_ming_omni_vision_e2e.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""E2E test for Ming-flash-omni-2.0 image understanding.
+
+Tests the complete vision pipeline with a real image:
+  1. Image preprocessing (Qwen2VLImageProcessor)
+  2. Vision encoding (MingOmniVisionEncoder)
+  3. Feature projection + L2 normalization (VisionProjector)
+  4. Token expansion & embedding injection
+  5. Validate combined input_embeds
+
+Usage (on remote server):
+    cd /sgl-workspace/sglang-omni-dev2
+    CUDA_VISIBLE_DEVICES=0 python scripts/test_vision_e2e.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from io import BytesIO
+from pathlib import Path
+
+import requests
+import torch
+import torch.nn.functional as F
+from PIL import Image
+
+MODEL = os.environ.get("MODEL_PATH", "inclusionAI/Ming-flash-omni-2.0")
+DEVICE = os.environ.get("DEVICE", "cuda:0")
+
+# A simple test image
+TEST_IMAGE_URL = "https://farm4.staticflickr.com/3175/2653711032_804ff86d81_z.jpg"
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def resolve_model_dir(model_path: str) -> Path:
+    p = Path(model_path)
+    if p.exists():
+        return p
+    from huggingface_hub import snapshot_download
+
+    return Path(snapshot_download(model_path))
+
+
+def load_config(model_dir: Path):
+    with open(model_dir / "config.json") as f:
+        raw = json.load(f)
+    thinker = raw.get("thinker_config", raw)
+    vision_raw = thinker.get("vision_config", {})
+    mlp_depth = thinker.get("mlp_depth", 2)
+    llm_cfg = thinker.get("llm_config", {})
+    llm_hidden_size = llm_cfg.get("hidden_size", 4096)
+    vocab_size = llm_cfg.get("vocab_size", 157184)
+    return vision_raw, mlp_depth, llm_hidden_size, vocab_size, llm_cfg
+
+
+def init_sglang_tp():
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29500")
+
+    from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+
+    set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+
+    from sglang.srt.distributed import parallel_state
+
+    parallel_state.init_distributed_environment(
+        backend="nccl",
+        world_size=1,
+        rank=0,
+        local_rank=0,
+    )
+    parallel_state.initialize_model_parallel()
+
+    import sglang.srt.layers.dp_attention as dp
+
+    dp._ATTN_TP_SIZE = 1
+    dp._ATTN_TP_RANK = 0
+    print("[OK] sglang TP=1 context initialized")
+
+
+def iter_weights_by_prefix(model_dir: Path, prefix: str):
+    """Iterate checkpoint weights with given prefix, stripping it."""
+    from safetensors import safe_open
+
+    with open(model_dir / "model.safetensors.index.json") as f:
+        weight_map = json.load(f)["weight_map"]
+
+    shards: dict[str, list[str]] = {}
+    for key, shard in weight_map.items():
+        if key.startswith(prefix):
+            shards.setdefault(shard, []).append(key)
+
+    for shard, keys in sorted(shards.items()):
+        with safe_open(str(model_dir / shard), framework="pt", device="cpu") as f:
+            for key in keys:
+                yield key[len(prefix) :], f.get_tensor(key)
+
+
+def download_image(url: str) -> Image.Image:
+    """Download a test image, with fallback to a generated dummy."""
+    try:
+        resp = requests.get(url, timeout=15)
+        resp.raise_for_status()
+        return Image.open(BytesIO(resp.content)).convert("RGB")
+    except Exception as e:
+        print(f"  [WARN] Failed to download image ({e}), using dummy 224x224")
+        import numpy as np
+
+        arr = np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8)
+        return Image.fromarray(arr)
+
+
+# ============================================================================
+# Step 1: Image Preprocessing
+# ============================================================================
+
+
+def preprocess_image(image: Image.Image, spatial_merge_size: int = 2):
+    """Preprocess image using Qwen2VLImageProcessor (same as Ming)."""
+    from transformers import Qwen2VLImageProcessor
+
+    processor = Qwen2VLImageProcessor(
+        min_pixels=256 * 28 * 28,
+        max_pixels=1280 * 28 * 28,
+        patch_size=16,
+        temporal_patch_size=2,
+        merge_size=spatial_merge_size,
+    )
+    result = processor(images=[image], return_tensors="pt")
+    pixel_values = result["pixel_values"]
+    grid_thw = result["image_grid_thw"]
+
+    print(f"  Image size: {image.size}")
+    print(f"  pixel_values: {pixel_values.shape}, dtype={pixel_values.dtype}")
+    print(f"  grid_thw: {grid_thw.tolist()}")
+    return pixel_values, grid_thw
+
+
+# ============================================================================
+# Step 2: Vision Encoding
+# ============================================================================
+
+
+def load_vision_encoder(model_dir: Path, vision_raw: dict, device: str):
+    """Load MingOmniVisionEncoder with weights."""
+    from transformers import PretrainedConfig
+
+    from sglang_omni.models.ming_omni.components.vision_encoder import (
+        MingOmniVisionEncoder,
+    )
+
+    vision_config = PretrainedConfig(**vision_raw)
+    encoder = MingOmniVisionEncoder(vision_config, quant_config=None, prefix="visual")
+
+    t0 = time.time()
+    loaded = encoder.load_weights(iter_weights_by_prefix(model_dir, "vision."))
+    print(f"  Vision encoder: {len(loaded)} weights loaded in {time.time()-t0:.1f}s")
+
+    encoder = encoder.to(device=device, dtype=torch.bfloat16).eval()
+    return encoder
+
+
+def load_projector(
+    model_dir: Path, vision_dim: int, llm_dim: int, mlp_depth: int, device: str
+):
+    """Load VisionProjector with weights."""
+    from sglang_omni.models.ming_omni.components.projectors import VisionProjector
+
+    proj = VisionProjector(vision_dim=vision_dim, llm_dim=llm_dim, mlp_depth=mlp_depth)
+    loaded = proj.load_weights(iter_weights_by_prefix(model_dir, "linear_proj."))
+    print(f"  Projector: {len(loaded)} weights loaded")
+
+    proj = proj.to(device=device, dtype=torch.bfloat16).eval()
+    return proj
+
+
+def run_vision_pipeline(encoder, projector, pixel_values, grid_thw, device):
+    """Run: pixel_values -> vision encoder -> projector -> L2 normalize."""
+    pixel_values = pixel_values.to(device=device, dtype=torch.bfloat16)
+    grid_thw = grid_thw.to(device=device)
+
+    with torch.no_grad():
+        # Vision encoder
+        image_embeds = encoder(pixel_values, grid_thw)
+        print(f"  Vision encoder output: {image_embeds.shape}")
+
+        # Use only base merger output (not deepstack) for projection
+        if encoder.use_deepstack:
+            image_embeds_for_proj = image_embeds[:, : encoder.image_emb_dim]
+            print(f"  After deepstack slice: {image_embeds_for_proj.shape}")
+        else:
+            image_embeds_for_proj = image_embeds
+
+        # Project to LLM dimension
+        image_embeds_proj = projector(image_embeds_for_proj)
+        print(f"  After projector: {image_embeds_proj.shape}")
+
+        # L2 normalize
+        image_features = F.normalize(image_embeds_proj, dim=-1)
+
+    return image_features
+
+
+# ============================================================================
+# Step 3: Embedding Injection
+# ============================================================================
+
+
+def load_embedding_table(
+    model_dir: Path, vocab_size: int, hidden_size: int, device: str
+):
+    """Load just the LLM embedding table from checkpoint."""
+    from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
+
+    embed = VocabParallelEmbedding(vocab_size, hidden_size)
+
+    # Load embedding weights
+    for name, tensor in iter_weights_by_prefix(model_dir, "model.model."):
+        if name == "word_embeddings.weight":
+            embed.weight.data.copy_(tensor)
+            print(f"  Embedding table loaded: {tensor.shape}")
+            break
+
+    embed = embed.to(device=device, dtype=torch.bfloat16).eval()
+    return embed
+
+
+def build_input_embeds(
+    embed_table,
+    image_features: torch.Tensor,
+    tokenizer,
+    llm_cfg: dict,
+    device: str,
+):
+    """Build input_embeds with image features injected at image token positions.
+
+    Prompt: "<role>HUMAN</role><image>..patches..</image>\\nDescribe this image.</s><role>ASSISTANT</role>"
+    """
+    spatial_merge_size = 2
+    num_image_tokens = image_features.shape[0]
+
+    # Build prompt with image patch tokens
+    image_patch_token = "<imagePatch>"
+    prompt = (
+        "<role>SYSTEM</role>你是一个友好的AI助手。\n\ndetailed thinking off</s>"
+        "<role>HUMAN</role>"
+        "<image>" + (image_patch_token * num_image_tokens) + "</image>\n"
+        "Describe this image in English.</s>"
+        "<role>ASSISTANT</role>"
+    )
+
+    input_ids = tokenizer.encode(prompt, add_special_tokens=False)
+    input_ids = torch.tensor([input_ids], dtype=torch.long, device=device)
+    print(f"  Prompt tokens: {input_ids.shape[1]}")
+
+    # Get the image patch token ID
+    patch_token_id = tokenizer.convert_tokens_to_ids(image_patch_token)
+    print(f"  Image patch token ID: {patch_token_id}")
+
+    # Get text embeddings
+    with torch.no_grad():
+        text_embeds = embed_table(input_ids[0])  # [seq_len, hidden]
+
+    # Find image token positions and replace with image features
+    mask = input_ids[0] == patch_token_id
+    num_found = mask.sum().item()
+    print(f"  Image token positions found: {num_found} (expected: {num_image_tokens})")
+
+    if num_found == num_image_tokens:
+        text_embeds[mask] = image_features.to(text_embeds.dtype)
+        print(f"  [OK] Image features injected into embeddings")
+    elif num_found > 0:
+        # Truncate or pad as needed
+        print(
+            f"  [WARN] Token count mismatch, injecting min({num_found}, {num_image_tokens})"
+        )
+        n = min(num_found, num_image_tokens)
+        positions = mask.nonzero(as_tuple=True)[0][:n]
+        text_embeds[positions] = image_features[:n].to(text_embeds.dtype)
+    else:
+        print(f"  [FAIL] No image tokens found in prompt")
+        return None
+
+    return text_embeds
+
+
+# ============================================================================
+# Step 4: Validation
+# ============================================================================
+
+
+def validate_features(image_features: torch.Tensor) -> bool:
+    """Validate image features are well-formed."""
+    ok = True
+
+    # Shape check
+    seq_len, dim = image_features.shape
+    print(f"\n  Image features: shape=({seq_len}, {dim})")
+
+    # NaN/Inf check
+    has_nan = torch.isnan(image_features).any().item()
+    has_inf = torch.isinf(image_features).any().item()
+    if has_nan or has_inf:
+        print(f"  [FAIL] has_nan={has_nan}, has_inf={has_inf}")
+        ok = False
+
+    # L2 norm check (should be ~1.0 after normalize)
+    norms = image_features.float().norm(dim=-1)
+    mean_norm = norms.mean().item()
+    print(
+        f"  L2 norms: mean={mean_norm:.4f}, min={norms.min():.4f}, max={norms.max():.4f}"
+    )
+    if abs(mean_norm - 1.0) > 0.01:
+        print(f"  [FAIL] Expected mean L2 norm ~1.0, got {mean_norm:.4f}")
+        ok = False
+
+    # Diversity check (features should not be all the same)
+    feat_std = image_features.float().std(dim=0).mean().item()
+    print(f"  Feature diversity (mean std across tokens): {feat_std:.6f}")
+    if feat_std < 1e-6:
+        print(f"  [FAIL] Features are degenerate (all same)")
+        ok = False
+
+    # Stats
+    vals = image_features.float()
+    print(
+        f"  Stats: mean={vals.mean():.4f}, std={vals.std():.4f}, "
+        f"min={vals.min():.4f}, max={vals.max():.4f}"
+    )
+
+    return ok
+
+
+def validate_input_embeds(input_embeds: torch.Tensor) -> bool:
+    """Validate combined input embeddings."""
+    ok = True
+    print(f"\n  Combined input_embeds: shape={input_embeds.shape}")
+
+    has_nan = torch.isnan(input_embeds).any().item()
+    has_inf = torch.isinf(input_embeds).any().item()
+    if has_nan or has_inf:
+        print(f"  [FAIL] has_nan={has_nan}, has_inf={has_inf}")
+        ok = False
+    else:
+        print(f"  [OK] No NaN/Inf")
+
+    vals = input_embeds.float()
+    print(f"  Stats: mean={vals.mean():.4f}, std={vals.std():.4f}")
+    return ok
+
+
+# ============================================================================
+# Main
+# ============================================================================
+
+
+def main():
+    print("=" * 60)
+    print("Ming-flash-omni-2.0 Image Understanding E2E Test")
+    print("=" * 60)
+    print(f"Model: {MODEL}")
+    print(f"Device: {DEVICE}\n")
+
+    # Resolve model
+    model_dir = resolve_model_dir(MODEL)
+    vision_raw, mlp_depth, llm_hidden_size, vocab_size, llm_cfg = load_config(model_dir)
+    print(
+        f"Vision: depth={vision_raw.get('depth')}, out={vision_raw.get('out_hidden_size')}"
+    )
+    print(f"LLM: hidden={llm_hidden_size}, vocab={vocab_size}\n")
+
+    # Init sglang
+    init_sglang_tp()
+
+    results = []
+
+    # --- Step 1: Download & preprocess image ---
+    print("\n--- Step 1: Image Preprocessing ---")
+    image = download_image(TEST_IMAGE_URL)
+    pixel_values, grid_thw = preprocess_image(
+        image, spatial_merge_size=vision_raw.get("spatial_merge_size", 2)
+    )
+    results.append(("Image Preprocessing", True))
+
+    # --- Step 2: Load vision encoder + projector ---
+    print("\n--- Step 2: Load Vision Components ---")
+    encoder = load_vision_encoder(model_dir, vision_raw, DEVICE)
+    vision_dim = vision_raw.get("out_hidden_size", 4096)
+    projector = load_projector(
+        model_dir, vision_dim, llm_hidden_size, mlp_depth, DEVICE
+    )
+
+    # --- Step 3: Run vision pipeline ---
+    print("\n--- Step 3: Vision Pipeline ---")
+    t0 = time.time()
+    image_features = run_vision_pipeline(
+        encoder, projector, pixel_values, grid_thw, DEVICE
+    )
+    elapsed = time.time() - t0
+    print(f"  Pipeline time: {elapsed:.2f}s")
+
+    # --- Step 4: Validate features ---
+    print("\n--- Step 4: Feature Validation ---")
+    feat_ok = validate_features(image_features)
+    results.append(("Feature Validation", feat_ok))
+
+    # --- Step 5: Embedding injection ---
+    print("\n--- Step 5: Embedding Injection ---")
+    # Load tokenizer
+    from sglang_omni.models.ming_omni.components.common import load_ming_tokenizer
+
+    tokenizer = load_ming_tokenizer(str(model_dir))
+    print(f"  Tokenizer loaded: vocab_size={tokenizer.vocab_size}")
+
+    # Load embedding table
+    embed_table = load_embedding_table(model_dir, vocab_size, llm_hidden_size, DEVICE)
+
+    # Build input_embeds
+    input_embeds = build_input_embeds(
+        embed_table, image_features, tokenizer, llm_cfg, DEVICE
+    )
+
+    if input_embeds is not None:
+        embed_ok = validate_input_embeds(input_embeds)
+        results.append(("Embedding Injection", embed_ok))
+    else:
+        results.append(("Embedding Injection", False))
+
+    # --- Step 6: Free vision components, attempt LLM forward ---
+    print("\n--- Step 6: LLM Logits Check (first token prediction) ---")
+    # Free vision encoder to make room for LLM head
+    del encoder, projector
+    torch.cuda.empty_cache()
+
+    try:
+        # Load LM head only (small: vocab_size * hidden_size * 2 bytes ≈ 1.2GB)
+        lm_head = torch.nn.Linear(llm_hidden_size, vocab_size, bias=False)
+        for name, tensor in iter_weights_by_prefix(model_dir, ""):
+            if name in ("lm_head.weight", "model.lm_head.weight"):
+                lm_head.weight.data.copy_(tensor)
+                print(f"  LM head loaded: {tensor.shape}")
+                break
+        lm_head = lm_head.to(device=DEVICE, dtype=torch.bfloat16).eval()
+
+        # Get logits for the last token (prediction for first generated token)
+        with torch.no_grad():
+            # Use just the image features + a few text tokens around them
+            # We can't run through the full LLM (needs ForwardBatch), but we can
+            # check what the LM head predicts from raw embeddings as a sanity check
+            last_embed = input_embeds[-1:].to(torch.bfloat16)  # last token embedding
+            logits = lm_head(last_embed)
+            top5_vals, top5_ids = logits[0].topk(5)
+
+            print(f"  Top-5 predicted tokens after prompt:")
+            for i, (val, tid) in enumerate(zip(top5_vals, top5_ids)):
+                token_text = tokenizer.decode([tid.item()])
+                print(
+                    f"    {i+1}. '{token_text}' (id={tid.item()}, logit={val.item():.2f})"
+                )
+
+        # Basic sanity: logits should not be NaN
+        logits_ok = not torch.isnan(logits).any().item()
+        results.append(("LLM Logits Check", logits_ok))
+        del lm_head
+    except Exception as e:
+        print(f"  [WARN] LLM logits check skipped: {e}")
+        results.append(("LLM Logits Check", "SKIP"))
+
+    # --- Summary ---
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    all_pass = True
+    for name, ok in results:
+        if ok == "SKIP":
+            status = "SKIP"
+        elif ok:
+            status = "PASS"
+        else:
+            status = "FAIL"
+            all_pass = False
+        print(f"  {status}  {name}")
+
+    print(f"\n{'ALL TESTS PASSED' if all_pass else 'SOME TESTS FAILED'}")
+    sys.exit(0 if all_pass else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_vision_encoder.py
+++ b/scripts/test_vision_encoder.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""Test MingOmniVisionEncoder correctness.
+
+Tests:
+  1. Model instantiation from checkpoint config
+  2. Weight loading completeness (no missing weights)
+  3. Weight spot-check against raw checkpoint
+  4. Forward pass shape correctness
+  5. Output sanity (no NaN, reasonable values)
+
+Usage (on remote server):
+    cd /sgl-workspace/sglang-omni-dev2
+    CUDA_VISIBLE_DEVICES=0 python scripts/test_vision_encoder.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import torch
+
+MODEL = os.environ.get("MODEL_PATH", "inclusionAI/Ming-flash-omni-2.0")
+DEVICE = os.environ.get("DEVICE", "cuda:0")
+
+
+def resolve_model_dir(model_path: str) -> Path:
+    p = Path(model_path)
+    if p.exists():
+        return p
+    from huggingface_hub import snapshot_download
+
+    return Path(snapshot_download(model_path))
+
+
+def load_config(model_dir: Path):
+    """Load vision config from checkpoint config.json."""
+    config_path = model_dir / "config.json"
+    with open(config_path) as f:
+        raw = json.load(f)
+
+    # Ming-flash-omni-2.0 has thinker_config.vision_config
+    thinker = raw.get("thinker_config", raw)
+    vision_raw = thinker.get("vision_config", {})
+    mlp_depth = thinker.get("mlp_depth", 2)
+    llm_hidden_size = thinker.get("llm_config", {}).get("hidden_size", 4096)
+    return vision_raw, mlp_depth, llm_hidden_size
+
+
+def init_sglang_tp():
+    """Initialize sglang distributed context for TP=1 standalone testing.
+
+    Sets up: global server args, distributed process group, model parallel,
+    and dp_attention module-level variables.
+    """
+    import os
+
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29500")
+
+    # 1. Global server args (needed by get_rope -> get_global_server_args)
+    from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+
+    dummy_args = ServerArgs(model_path="dummy")
+    set_global_server_args_for_scheduler(dummy_args)
+
+    # 2. Distributed process group
+    from sglang.srt.distributed import parallel_state
+
+    parallel_state.init_distributed_environment(
+        backend="nccl",
+        world_size=1,
+        rank=0,
+        local_rank=0,
+    )
+    parallel_state.initialize_model_parallel()
+
+    # 3. dp_attention variables (needed by VisionAttention -> get_attention_tp_size)
+    import sglang.srt.layers.dp_attention as dp
+
+    dp._ATTN_TP_SIZE = 1
+    dp._ATTN_TP_RANK = 0
+
+    print("[OK] sglang TP=1 context initialized")
+
+
+def get_vision_weight_keys(model_dir: Path) -> dict[str, str]:
+    """Get mapping of vision weight keys to their shard files."""
+    index_file = model_dir / "model.safetensors.index.json"
+    if not index_file.exists():
+        return {}
+    with open(index_file) as f:
+        weight_map = json.load(f)["weight_map"]
+
+    # Collect keys with "vision." or "linear_proj." prefix
+    # Checkpoint uses "model.vision.*" and "model.linear_proj.*"
+    result = {}
+    for key, shard in weight_map.items():
+        if key.startswith("vision.") or key.startswith("linear_proj."):
+            result[key] = shard
+    return result
+
+
+def load_checkpoint_weights(
+    model_dir: Path, keys: list[str]
+) -> dict[str, torch.Tensor]:
+    """Load specific weights from safetensors checkpoint."""
+    from safetensors import safe_open
+
+    index_file = model_dir / "model.safetensors.index.json"
+    with open(index_file) as f:
+        weight_map = json.load(f)["weight_map"]
+
+    # Group keys by shard file
+    shards: dict[str, list[str]] = {}
+    for key in keys:
+        shard = weight_map.get(key)
+        if shard:
+            shards.setdefault(shard, []).append(key)
+
+    result = {}
+    for shard, shard_keys in shards.items():
+        shard_path = model_dir / shard
+        with safe_open(str(shard_path), framework="pt", device="cpu") as f:
+            for key in shard_keys:
+                result[key] = f.get_tensor(key)
+    return result
+
+
+def iter_vision_weights(model_dir: Path):
+    """Iterate over vision encoder weights from checkpoint, with prefix stripped."""
+    from safetensors import safe_open
+
+    index_file = model_dir / "model.safetensors.index.json"
+    with open(index_file) as f:
+        weight_map = json.load(f)["weight_map"]
+
+    prefix = "vision."
+    shards: dict[str, list[str]] = {}
+    for key, shard in weight_map.items():
+        if key.startswith(prefix):
+            shards.setdefault(shard, []).append(key)
+
+    for shard, keys in sorted(shards.items()):
+        shard_path = model_dir / shard
+        with safe_open(str(shard_path), framework="pt", device="cpu") as f:
+            for key in keys:
+                stripped = key[len(prefix) :]
+                yield stripped, f.get_tensor(key)
+
+
+def iter_proj_weights(model_dir: Path):
+    """Iterate over vision projector weights from checkpoint, with prefix stripped."""
+    from safetensors import safe_open
+
+    index_file = model_dir / "model.safetensors.index.json"
+    with open(index_file) as f:
+        weight_map = json.load(f)["weight_map"]
+
+    prefix = "linear_proj."
+    shards: dict[str, list[str]] = {}
+    for key, shard in weight_map.items():
+        if key.startswith(prefix):
+            shards.setdefault(shard, []).append(key)
+
+    for shard, keys in sorted(shards.items()):
+        shard_path = model_dir / shard
+        with safe_open(str(shard_path), framework="pt", device="cpu") as f:
+            for key in keys:
+                stripped = key[len(prefix) :]
+                yield stripped, f.get_tensor(key)
+
+
+# ============================================================================
+# Test 1: Instantiation
+# ============================================================================
+
+
+def test_instantiation(vision_raw: dict):
+    """Test that MingOmniVisionEncoder can be created from config."""
+    from transformers import PretrainedConfig
+
+    from sglang_omni.models.ming_omni.components.vision_encoder import (
+        MingOmniVisionEncoder,
+    )
+
+    vision_config = PretrainedConfig(**vision_raw)
+    encoder = MingOmniVisionEncoder(vision_config, quant_config=None, prefix="visual")
+
+    # Verify key attributes
+    assert encoder.hidden_size == vision_raw.get("hidden_size", 1152)
+    assert encoder.num_heads == vision_raw.get("num_heads", 16)
+    assert len(encoder.blocks) == vision_raw.get("depth", 27)
+    assert encoder.use_deepstack is True
+    assert len(encoder.merger_list) == len(
+        vision_raw.get("deepstack_visual_indexes", [8, 16, 24])
+    )
+
+    num_params = sum(p.numel() for p in encoder.parameters())
+    print(f"[OK] MingOmniVisionEncoder instantiated: {num_params / 1e6:.1f}M params")
+    print(
+        f"     hidden_size={encoder.hidden_size}, num_heads={encoder.num_heads}, "
+        f"depth={len(encoder.blocks)}, out_hidden_size={encoder.image_emb_dim}"
+    )
+    print(f"     deepstack_indexes={encoder.deepstack_visual_indexes}")
+    return encoder
+
+
+# ============================================================================
+# Test 2: Weight Loading Completeness
+# ============================================================================
+
+
+def test_weight_loading(encoder, model_dir: Path):
+    """Test that all weights load without missing or unexpected keys."""
+    # Collect all model parameter names (before loading)
+    all_params = set(dict(encoder.named_parameters()).keys())
+    print(f"\n     Model has {len(all_params)} parameters")
+
+    # Load weights
+    t0 = time.time()
+    loaded = encoder.load_weights(iter_vision_weights(model_dir))
+    elapsed = time.time() - t0
+
+    missing = all_params - loaded
+    # Some params might be handled by TP sharding or have special loaders
+    # Filter out rotary_pos_emb (not in checkpoint — computed at init)
+    missing = {k for k in missing if "rotary_pos_emb" not in k}
+
+    print(
+        f"[{'OK' if not missing else 'FAIL'}] Weight loading: "
+        f"{len(loaded)}/{len(all_params)} loaded in {elapsed:.1f}s"
+    )
+
+    if missing:
+        print(f"     MISSING weights ({len(missing)}):")
+        for m in sorted(missing):
+            print(f"       - {m}")
+        return False
+    return True
+
+
+# ============================================================================
+# Test 3: Weight Spot-Check
+# ============================================================================
+
+
+def test_weight_spotcheck(encoder, model_dir: Path):
+    """Spot-check a few loaded weights against checkpoint values."""
+    model_params = dict(encoder.named_parameters())
+
+    # Define checkpoint -> model weight name mappings to check.
+    # The encoder's load_weights applies _remap_ming_vision_weight internally.
+    # So we check the final model param name vs the raw checkpoint value.
+    spot_checks = [
+        # (checkpoint_key_with_prefix, model_param_name, description)
+        (
+            "vision.patch_embed.proj.weight",
+            "patch_embed.proj.weight",
+            "patch_embed Conv3d",
+        ),
+        ("vision.blocks.0.norm1.weight", "blocks.0.norm1.weight", "block0 norm1"),
+        ("vision.blocks.26.norm2.weight", "blocks.26.norm2.weight", "block26 norm2"),
+        ("vision.merger.norm.weight", "merger.ln_q.weight", "merger ln_q (remapped)"),
+    ]
+
+    ckpt_keys = [s[0] for s in spot_checks]
+    ckpt_data = load_checkpoint_weights(model_dir, ckpt_keys)
+
+    passed = 0
+    for ckpt_key, model_key, desc in spot_checks:
+        if ckpt_key not in ckpt_data:
+            print(f"  SKIP {desc}: {ckpt_key} not in checkpoint")
+            continue
+        if model_key not in model_params:
+            print(f"  FAIL {desc}: {model_key} not in model")
+            continue
+
+        ckpt_w = ckpt_data[ckpt_key].to("cpu").float()
+        model_w = model_params[model_key].data.to("cpu").float()
+
+        if ckpt_w.shape != model_w.shape:
+            print(
+                f"  FAIL {desc}: shape mismatch ckpt={ckpt_w.shape} model={model_w.shape}"
+            )
+            continue
+
+        max_diff = (ckpt_w - model_w).abs().max().item()
+        status = "OK  " if max_diff < 1e-5 else "FAIL"
+        print(f"  {status} {desc}: max_diff={max_diff:.2e}")
+        if max_diff < 1e-5:
+            passed += 1
+
+    total = len([s for s in spot_checks if s[0] in ckpt_data])
+    print(
+        f"[{'OK' if passed == total else 'FAIL'}] Spot-check: {passed}/{total} passed"
+    )
+    return passed == total
+
+
+# ============================================================================
+# Test 4: Forward Pass
+# ============================================================================
+
+
+def test_forward_pass(encoder, device: str):
+    """Test forward pass with dummy input."""
+    encoder = encoder.to(device=device, dtype=torch.bfloat16)
+    encoder.eval()
+
+    # Simulate a single 224x224 image
+    # grid_thw: [1, 14, 14] — 1 temporal frame, 14x14 spatial grid
+    # total_patches = 1 * 14 * 14 = 196
+    # Each patch: C * temporal_patch_size * patch_size * patch_size = 3*2*16*16 = 1536
+    t, h, w = 1, 14, 14
+    total_patches = t * h * w
+    in_channels = 3
+    temporal_patch_size = encoder.temporal_patch_size
+    patch_size = encoder.patch_size
+    patch_dim = in_channels * temporal_patch_size * patch_size * patch_size
+
+    pixel_values = torch.randn(
+        total_patches, patch_dim, dtype=torch.bfloat16, device=device
+    )
+    grid_thw = torch.tensor([[t, h, w]], dtype=torch.int64, device=device)
+
+    with torch.no_grad():
+        output = encoder(pixel_values, grid_thw)
+
+    # Expected output shape after spatial merge:
+    # seq_len = total_patches / (spatial_merge_size^2) = 196 / 4 = 49
+    merge_size = encoder.spatial_merge_size
+    expected_seq_len = total_patches // (merge_size**2)
+
+    # With deepstack: output dim = out_hidden_size * (1 + num_deepstack)
+    if encoder.use_deepstack:
+        expected_dim = encoder.out_hidden_size
+    else:
+        expected_dim = encoder.image_emb_dim
+
+    has_nan = torch.isnan(output).any().item()
+    has_inf = torch.isinf(output).any().item()
+    all_zero = (output == 0).all().item()
+
+    shape_ok = output.shape == (expected_seq_len, expected_dim)
+    sanity_ok = not has_nan and not has_inf and not all_zero
+
+    print(
+        f"\n  output shape: {output.shape} (expected: ({expected_seq_len}, {expected_dim}))"
+    )
+    print(f"  has_nan={has_nan}, has_inf={has_inf}, all_zero={all_zero}")
+    print(
+        f"  output stats: mean={output.float().mean():.4f}, std={output.float().std():.4f}, "
+        f"min={output.float().min():.4f}, max={output.float().max():.4f}"
+    )
+    print(f"[{'OK' if shape_ok else 'FAIL'}] Forward pass shape")
+    print(f"[{'OK' if sanity_ok else 'FAIL'}] Forward pass sanity")
+    return shape_ok and sanity_ok
+
+
+# ============================================================================
+# Test 5: Vision Projector
+# ============================================================================
+
+
+def test_projector(
+    model_dir: Path, vision_raw: dict, mlp_depth: int, llm_hidden_size: int, device: str
+):
+    """Test VisionProjector instantiation, weight loading, and forward pass."""
+    from sglang_omni.models.ming_omni.components.projectors import VisionProjector
+
+    vision_dim = vision_raw.get("out_hidden_size", 3584)
+    proj = VisionProjector(
+        vision_dim=vision_dim, llm_dim=llm_hidden_size, mlp_depth=mlp_depth
+    )
+
+    num_params = sum(p.numel() for p in proj.parameters())
+    print(
+        f"\n  VisionProjector: {num_params / 1e6:.1f}M params "
+        f"({vision_dim} -> {llm_hidden_size}, depth={mlp_depth})"
+    )
+
+    # Load weights
+    loaded = proj.load_weights(iter_proj_weights(model_dir))
+    all_params = set(dict(proj.named_parameters()).keys())
+    missing = all_params - loaded
+
+    print(f"  Loaded {len(loaded)}/{len(all_params)} projector weights")
+    if missing:
+        print(f"  MISSING: {missing}")
+
+    # Forward pass
+    proj = proj.to(device=device, dtype=torch.bfloat16)
+    proj.eval()
+    dummy = torch.randn(49, vision_dim, dtype=torch.bfloat16, device=device)
+    with torch.no_grad():
+        out = proj(dummy)
+
+    shape_ok = out.shape == (49, llm_hidden_size)
+    sanity_ok = not torch.isnan(out).any().item()
+
+    print(f"  output shape: {out.shape} (expected: (49, {llm_hidden_size}))")
+    print(
+        f"[{'OK' if shape_ok and sanity_ok and not missing else 'FAIL'}] VisionProjector"
+    )
+    return shape_ok and sanity_ok and not missing
+
+
+# ============================================================================
+# Main
+# ============================================================================
+
+
+def main():
+    print(f"=== MingOmniVisionEncoder Test ===")
+    print(f"Model: {MODEL}")
+    print(f"Device: {DEVICE}\n")
+
+    # Resolve model directory
+    print("Resolving model directory...")
+    model_dir = resolve_model_dir(MODEL)
+    print(f"  {model_dir}\n")
+
+    # Load config
+    vision_raw, mlp_depth, llm_hidden_size = load_config(model_dir)
+    print(
+        f"Vision config: depth={vision_raw.get('depth')}, "
+        f"hidden={vision_raw.get('hidden_size')}, "
+        f"out={vision_raw.get('out_hidden_size')}"
+    )
+    print(f"Projector: mlp_depth={mlp_depth}, llm_hidden={llm_hidden_size}\n")
+
+    # Init sglang TP
+    init_sglang_tp()
+
+    results = []
+
+    # Test 1: Instantiation
+    print("\n--- Test 1: Instantiation ---")
+    encoder = test_instantiation(vision_raw)
+    results.append(("Instantiation", True))
+
+    # Test 2: Weight Loading
+    print("\n--- Test 2: Weight Loading ---")
+    ok = test_weight_loading(encoder, model_dir)
+    results.append(("Weight Loading", ok))
+
+    # Test 3: Spot-Check
+    print("\n--- Test 3: Weight Spot-Check ---")
+    ok = test_weight_spotcheck(encoder, model_dir)
+    results.append(("Weight Spot-Check", ok))
+
+    # Test 4: Forward Pass
+    print("\n--- Test 4: Forward Pass ---")
+    ok = test_forward_pass(encoder, DEVICE)
+    results.append(("Forward Pass", ok))
+
+    # Test 5: Projector
+    print("\n--- Test 5: Vision Projector ---")
+    ok = test_projector(model_dir, vision_raw, mlp_depth, llm_hidden_size, DEVICE)
+    results.append(("Vision Projector", ok))
+
+    # Summary
+    print("\n" + "=" * 50)
+    print("SUMMARY")
+    print("=" * 50)
+    all_pass = True
+    for name, ok in results:
+        status = "PASS" if ok else "FAIL"
+        print(f"  {status}  {name}")
+        if not ok:
+            all_pass = False
+
+    print(f"\n{'ALL TESTS PASSED' if all_pass else 'SOME TESTS FAILED'}")
+    sys.exit(0 if all_pass else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sglang_omni/models/ming_omni/components/image_encoder.py
+++ b/sglang_omni/models/ming_omni/components/image_encoder.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standalone image encoder for Ming-Omni pipeline.
+
+Loads the vision encoder + projector from checkpoint and runs:
+  pixel_values → MingOmniVisionEncoder → VisionProjector → L2 normalize
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from sglang_omni.models.ming_omni.components.common import load_ming_config
+from sglang_omni.models.ming_omni.components.projectors import VisionProjector
+from sglang_omni.models.ming_omni.components.vision_encoder import MingOmniVisionEncoder
+from sglang_omni.models.weight_loader import resolve_model_path
+
+logger = logging.getLogger(__name__)
+
+
+def _iter_weights_by_prefix(model_dir: Path, prefix: str):
+    """Iterate checkpoint weights with given prefix, stripping it."""
+    from safetensors import safe_open
+
+    index_file = model_dir / "model.safetensors.index.json"
+    with open(index_file) as f:
+        weight_map = json.load(f)["weight_map"]
+
+    shards: dict[str, list[str]] = {}
+    for key, shard in weight_map.items():
+        if key.startswith(prefix):
+            shards.setdefault(shard, []).append(key)
+
+    for shard, keys in sorted(shards.items()):
+        with safe_open(str(model_dir / shard), framework="pt", device="cpu") as f:
+            for key in keys:
+                yield key[len(prefix) :], f.get_tensor(key)
+
+
+class MingImageEncoder(nn.Module):
+    """Image encoder for Ming-Omni pipeline.
+
+    Loads vision encoder + projector from checkpoint and produces
+    L2-normalized image embeddings ready for injection into the thinker.
+    """
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        device: str = "cuda",
+        dtype: str | None = None,
+    ) -> None:
+        super().__init__()
+
+        resolved_path = resolve_model_path(model_path)
+        model_dir = Path(resolved_path)
+        config = load_ming_config(model_path)
+
+        vision_cfg = config.vision_config
+        mlp_depth = config.mlp_depth
+
+        # Need sglang TP context for VisionAttention
+        self._init_sglang_tp()
+
+        # Build vision encoder
+        from transformers import PretrainedConfig
+
+        vision_config_obj = PretrainedConfig(**self._vision_dict(vision_cfg))
+        self.visual = MingOmniVisionEncoder(
+            vision_config_obj, quant_config=None, prefix="visual"
+        )
+
+        # Build projector
+        vision_dim = vision_cfg.out_hidden_size
+        llm_dim = config.llm_config.hidden_size
+        self.linear_proj = VisionProjector(
+            vision_dim=vision_dim, llm_dim=llm_dim, mlp_depth=mlp_depth
+        )
+
+        # Load weights
+        loaded_vis = self.visual.load_weights(
+            _iter_weights_by_prefix(model_dir, "vision.")
+        )
+        loaded_proj = self.linear_proj.load_weights(
+            _iter_weights_by_prefix(model_dir, "linear_proj.")
+        )
+        logger.info(
+            "MingImageEncoder loaded: %d vision + %d projector weights",
+            len(loaded_vis),
+            len(loaded_proj),
+        )
+
+        # Move to device
+        torch_dtype = _resolve_dtype(dtype)
+        self.to(device=device, dtype=torch_dtype)
+        self.eval()
+
+        # Release model parallel state so the thinker (loaded later) can
+        # reinitialize it.  At runtime, the thinker's TP context will be
+        # active and this encoder can use it transparently (TP=1).
+        self._cleanup_sglang_tp()
+
+    @staticmethod
+    def _vision_dict(vision_cfg: Any) -> dict:
+        """Convert VisionConfig dataclass to plain dict for PretrainedConfig."""
+        if hasattr(vision_cfg, "__dataclass_fields__"):
+            from dataclasses import asdict
+
+            return asdict(vision_cfg)
+        return {k: v for k, v in vars(vision_cfg).items() if not k.startswith("_")}
+
+    _did_init_tp = False  # Track whether we initialized TP ourselves
+
+    @classmethod
+    def _init_sglang_tp(cls):
+        """Initialize minimal sglang TP=1 context if not already done."""
+        import os
+
+        import sglang.srt.layers.dp_attention as dp
+
+        if getattr(dp, "_ATTN_TP_SIZE", None) is not None and dp._ATTN_TP_SIZE > 0:
+            return  # Already initialized
+
+        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+        os.environ.setdefault("MASTER_PORT", "29500")
+
+        from sglang.srt.server_args import (
+            ServerArgs,
+            set_global_server_args_for_scheduler,
+        )
+
+        try:
+            set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+        except Exception:
+            pass  # Already set
+
+        from sglang.srt.distributed import parallel_state
+
+        if not parallel_state.model_parallel_is_initialized():
+            parallel_state.init_distributed_environment(
+                backend="nccl", world_size=1, rank=0, local_rank=0
+            )
+            parallel_state.initialize_model_parallel()
+            cls._did_init_tp = True
+
+        dp._ATTN_TP_SIZE = 1
+        dp._ATTN_TP_RANK = 0
+
+    @classmethod
+    def _cleanup_sglang_tp(cls):
+        """Destroy model parallel state so a later component (thinker) can reinit.
+
+        Only cleans up if we were the ones who initialized it.
+        torch.distributed stays alive — only the TP/PP groups are removed.
+        """
+        if not cls._did_init_tp:
+            return
+        cls._did_init_tp = False
+
+        from sglang.srt.distributed import parallel_state
+
+        if parallel_state.model_parallel_is_initialized():
+            parallel_state.destroy_model_parallel()
+            logger.info("Cleaned up model parallel state for thinker reuse")
+
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        image_grid_thw: torch.Tensor,
+        **kwargs: Any,
+    ) -> dict[str, torch.Tensor]:
+        """Encode images and return embeddings.
+
+        Args:
+            pixel_values: Flattened pixel values [total_patches, patch_dim].
+            image_grid_thw: [num_images, 3] tensor of (t, h, w).
+
+        Returns:
+            Dict with ``image_embeds`` [seq_len, llm_hidden_size] (L2-normalized).
+        """
+        pixel_values = pixel_values.to(
+            device=self.visual.device, dtype=self.visual.dtype
+        )
+        image_grid_thw = image_grid_thw.to(device=self.visual.device)
+
+        with torch.no_grad():
+            image_embeds = self.visual(pixel_values, image_grid_thw)
+
+            # Deepstack: use only base merger output for projection
+            if self.visual.use_deepstack:
+                image_embeds = image_embeds[:, : self.visual.image_emb_dim]
+
+            image_embeds = self.linear_proj(image_embeds)
+            image_embeds = F.normalize(image_embeds, dim=-1)
+
+        return {
+            "image_embeds": image_embeds,
+            "image_grid_thw": image_grid_thw,
+        }
+
+
+def _resolve_dtype(dtype: str | None) -> torch.dtype:
+    if dtype is None or dtype == "bfloat16":
+        return torch.bfloat16
+    if dtype == "float16":
+        return torch.float16
+    if dtype == "float32":
+        return torch.float32
+    return torch.bfloat16

--- a/sglang_omni/models/ming_omni/components/image_encoder.py
+++ b/sglang_omni/models/ming_omni/components/image_encoder.py
@@ -97,6 +97,9 @@ class MingImageEncoder(nn.Module):
             len(loaded_proj),
         )
 
+        # Store spatial merge size for token count computation
+        self._spatial_merge_size = vision_cfg.spatial_merge_size
+
         # Move to device
         torch_dtype = _resolve_dtype(dtype)
         self.to(device=device, dtype=torch_dtype)
@@ -129,7 +132,12 @@ class MingImageEncoder(nn.Module):
             return  # Already initialized
 
         os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
-        os.environ.setdefault("MASTER_PORT", "29500")
+        if "MASTER_PORT" not in os.environ:
+            import socket
+
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(("", 0))
+                os.environ["MASTER_PORT"] = str(s.getsockname()[1])
 
         from sglang.srt.server_args import (
             ServerArgs,
@@ -183,7 +191,10 @@ class MingImageEncoder(nn.Module):
             image_grid_thw: [num_images, 3] tensor of (t, h, w).
 
         Returns:
-            Dict with ``image_embeds`` [seq_len, llm_hidden_size] (L2-normalized).
+            Dict with:
+            - ``image_embeds`` [seq_len, llm_hidden_size] (L2-normalized)
+            - ``image_grid_thw`` [num_images, 3]
+            - ``image_token_counts`` [num_images] per-image token counts
         """
         pixel_values = pixel_values.to(
             device=self.visual.device, dtype=self.visual.dtype
@@ -200,9 +211,16 @@ class MingImageEncoder(nn.Module):
             image_embeds = self.linear_proj(image_embeds)
             image_embeds = F.normalize(image_embeds, dim=-1)
 
+        # Per-image token counts after spatial merge: t * h * w / merge^2
+        merge_sq = self._spatial_merge_size**2
+        image_token_counts = (
+            image_grid_thw[:, 0] * image_grid_thw[:, 1] * image_grid_thw[:, 2]
+        ) // merge_sq
+
         return {
             "image_embeds": image_embeds,
             "image_grid_thw": image_grid_thw,
+            "image_token_counts": image_token_counts,
         }
 
 

--- a/sglang_omni/models/ming_omni/components/preprocessor.py
+++ b/sglang_omni/models/ming_omni/components/preprocessor.py
@@ -108,6 +108,36 @@ def _estimate_image_tokens(
     return counts
 
 
+def _inject_top_level_images(
+    messages: list[dict[str, Any]],
+    images: list[str],
+) -> list[dict[str, Any]]:
+    """Convert top-level ``images`` into inline content items.
+
+    When the request uses ``{"images": ["url1"], "messages": [...]}`` instead of
+    inline ``image_url`` content items, we prepend the images to the first user
+    message so that the rest of the preprocessor handles both formats uniformly.
+
+    Returns a shallow copy of messages with the first user message modified;
+    the original list is not mutated.
+    """
+    messages = list(messages)  # shallow copy
+    for idx, msg in enumerate(messages):
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content", "")
+        new_content: list[dict[str, Any]] = [
+            {"type": "image_url", "image_url": {"url": url}} for url in images
+        ]
+        if isinstance(content, str):
+            new_content.append({"type": "text", "text": content})
+        elif isinstance(content, list):
+            new_content.extend(content)
+        messages[idx] = {**msg, "content": new_content}
+        break
+    return messages
+
+
 class MingPreprocessor:
     """Preprocessor for Ming-Omni model.
 
@@ -177,9 +207,17 @@ class MingPreprocessor:
             # OpenAI API passes messages list directly as inputs
             messages = raw_inputs
             audio_urls = []
+            top_level_images: list[str] = []
         else:
             messages = raw_inputs.get("messages", [])
             audio_urls = raw_inputs.get("audios", [])
+            top_level_images = raw_inputs.get("images") or []
+
+        # If top-level images are provided (e.g. {"images": ["url1", ...]}),
+        # inject them as inline content items in the first user message so that
+        # placeholder insertion and image extraction use a single code path.
+        if top_level_images:
+            messages = _inject_top_level_images(messages, top_level_images)
 
         # --- Extract image URLs/data from messages ---
         raw_images: list[Any] = []

--- a/sglang_omni/models/ming_omni/components/preprocessor.py
+++ b/sglang_omni/models/ming_omni/components/preprocessor.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Preprocessor for Ming-Omni: tokenize text, extract audio mel features."""
+"""Preprocessor for Ming-Omni: tokenize text, extract audio mel features, prepare images."""
 
 from __future__ import annotations
 
@@ -15,8 +15,9 @@ from sglang_omni.models.ming_omni.components.common import (
     load_ming_tokenizer,
 )
 from sglang_omni.models.ming_omni.io import PipelineState, PromptInputs
-from sglang_omni.models.ming_omni.pipeline.next_stage import AUDIO_STAGE
+from sglang_omni.models.ming_omni.pipeline.next_stage import AUDIO_STAGE, IMAGE_STAGE
 from sglang_omni.preprocessing.audio import load_audio_path
+from sglang_omni.preprocessing.image import ensure_image_list_async
 from sglang_omni.proto import StagePayload
 
 logger = logging.getLogger(__name__)
@@ -33,6 +34,10 @@ AUDIO_START = "<audio>"
 AUDIO_END = "</audio>"
 AUDIO_PATCH = "<audioPatch>"
 END_OF_AUDIO = "<end_of_audio>"
+
+IMAGE_START = "<image>"
+IMAGE_END = "</image>"
+IMAGE_PATCH = "<imagePatch>"
 
 # Whisper mel spectrogram parameters
 WHISPER_N_MELS = 128
@@ -91,13 +96,26 @@ def estimate_audio_feature_length(
     return proj_out_len
 
 
+def _estimate_image_tokens(
+    grid_thw: list[list[int]],
+    spatial_merge_size: int = 2,
+) -> list[int]:
+    """Estimate the number of image patch tokens per image after spatial merge."""
+    counts = []
+    for t, h, w in grid_thw:
+        n_tokens = t * h * w // (spatial_merge_size**2)
+        counts.append(n_tokens)
+    return counts
+
+
 class MingPreprocessor:
     """Preprocessor for Ming-Omni model.
 
     Handles:
     - Chat template formatting with <role>HUMAN</role> / <role>ASSISTANT</role>
     - Audio input loading and mel-spectrogram extraction
-    - Placeholder token insertion for audio segments
+    - Image input loading and Qwen2VL-style preprocessing
+    - Placeholder token insertion for audio/image segments
     """
 
     def __init__(self, model_path: str):
@@ -105,11 +123,51 @@ class MingPreprocessor:
         self._config = load_ming_config(model_path)
         self._tokenizer = load_ming_tokenizer(model_path)
         self._audio_config = self._config.audio_config
+        self._vision_config = self._config.vision_config
 
         # Resolve special token IDs
         self._audio_patch_id = self._tokenizer.convert_tokens_to_ids(AUDIO_PATCH)
         self._audio_start_id = self._tokenizer.convert_tokens_to_ids(AUDIO_START)
         self._audio_end_id = self._tokenizer.convert_tokens_to_ids(AUDIO_END)
+        self._image_patch_id = self._tokenizer.convert_tokens_to_ids(IMAGE_PATCH)
+
+        # Lazy-init image processor
+        self._image_processor = None
+
+    def _get_image_processor(self):
+        """Lazy-init Qwen2VLImageProcessor (same processor as Ming-Omni uses)."""
+        if self._image_processor is None:
+            from transformers import Qwen2VLImageProcessor
+
+            vc = self._vision_config
+            self._image_processor = Qwen2VLImageProcessor(
+                min_pixels=256 * 28 * 28,
+                max_pixels=1280 * 28 * 28,
+                patch_size=vc.patch_size,
+                temporal_patch_size=vc.temporal_patch_size,
+                merge_size=vc.spatial_merge_size,
+            )
+        return self._image_processor
+
+    def _process_images(
+        self, images: list[Any]
+    ) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
+        """Process PIL images into pixel_values, grid_thw, and token counts.
+
+        Returns:
+            pixel_values: [total_patches, patch_dim]
+            image_grid_thw: [num_images, 3]
+            image_token_counts: number of patch tokens per image
+        """
+        processor = self._get_image_processor()
+        result = processor(images=images, return_tensors="pt")
+        pixel_values = result["pixel_values"]
+        image_grid_thw = result["image_grid_thw"]
+        token_counts = _estimate_image_tokens(
+            image_grid_thw.tolist(),
+            self._vision_config.spatial_merge_size,
+        )
+        return pixel_values, image_grid_thw, token_counts
 
     async def __call__(self, payload: StagePayload) -> StagePayload:
         """Process a chat completion request into pipeline state."""
@@ -123,18 +181,75 @@ class MingPreprocessor:
             messages = raw_inputs.get("messages", [])
             audio_urls = raw_inputs.get("audios", [])
 
-        # Load audio files concurrently (load_audio_path returns 16kHz np.ndarray)
-        waveforms: list[np.ndarray] = []
-        if audio_urls:
-            tasks = [
+        # --- Extract image URLs/data from messages ---
+        raw_images: list[Any] = []
+        for msg in messages:
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                for item in content:
+                    if isinstance(item, dict):
+                        item_type = item.get("type", "")
+                        if item_type == "image_url":
+                            url_data = item.get("image_url", {})
+                            url = (
+                                url_data.get("url", "")
+                                if isinstance(url_data, dict)
+                                else str(url_data)
+                            )
+                            if url:
+                                raw_images.append(url)
+                        elif item_type == "image":
+                            img = item.get("image", "")
+                            if img:
+                                raw_images.append(img)
+
+        # --- Load images and audio concurrently ---
+        image_coro = ensure_image_list_async(raw_images) if raw_images else None
+        audio_coros = (
+            [
                 asyncio.to_thread(load_audio_path, url, target_sr=WHISPER_SAMPLE_RATE)
                 for url in audio_urls
             ]
-            waveforms = [
-                a
-                for a in await asyncio.gather(*tasks, return_exceptions=True)
-                if isinstance(a, np.ndarray)
-            ]
+            if audio_urls
+            else []
+        )
+
+        # Gather all loads concurrently
+        all_tasks: list[Any] = []
+        if image_coro is not None:
+            all_tasks.append(image_coro)
+        all_tasks.extend(audio_coros)
+
+        if all_tasks:
+            results = await asyncio.gather(*all_tasks, return_exceptions=True)
+        else:
+            results = []
+
+        # Unpack results
+        images: list[Any] = []
+        if image_coro is not None:
+            img_result = results[0]
+            if isinstance(img_result, list):
+                images = img_result
+            elif isinstance(img_result, BaseException):
+                logger.error("Failed to load images: %s", img_result)
+            audio_results = results[1:]
+        else:
+            audio_results = results
+
+        waveforms: list[np.ndarray] = [
+            a for a in audio_results if isinstance(a, np.ndarray)
+        ]
+
+        # --- Process images ---
+        image_token_counts: list[int] = []
+        pixel_values: torch.Tensor | None = None
+        image_grid_thw: torch.Tensor | None = None
+
+        if images:
+            pixel_values, image_grid_thw, image_token_counts = await asyncio.to_thread(
+                self._process_images, images
+            )
 
         # --- Compute mel features FIRST so we know exact placeholder counts ---
         mel_features_list: list[torch.Tensor] = []
@@ -155,7 +270,9 @@ class MingPreprocessor:
 
         # --- Build prompt with correct placeholder counts, then tokenize ---
         prompt_text, audio_positions = self._build_prompt(
-            messages, audio_token_counts=audio_token_counts
+            messages,
+            audio_token_counts=audio_token_counts,
+            image_token_counts=image_token_counts,
         )
         input_ids = self._tokenizer.encode(prompt_text, add_special_tokens=False)
         input_ids_tensor = torch.tensor([input_ids], dtype=torch.long)
@@ -167,12 +284,14 @@ class MingPreprocessor:
             "prompt_text": prompt_text,
         }
 
-        # --- Prepare audio encoder inputs ---
-        # Always include audio_encoder key so that the aggregated input handler
+        # --- Prepare encoder inputs ---
+        # Always include keys so that the aggregated input handler
         # (which waits for ALL configured sources) receives data from every source.
         encoder_inputs: dict[str, dict[str, Any]] = {
             AUDIO_STAGE: {"_skip": True, "_result": {}},
+            IMAGE_STAGE: {"_skip": True, "_result": {}},
         }
+
         if mel_features_list:
             placeholder_loc_lens_list = []
             for i, num_tokens in enumerate(audio_token_counts):
@@ -189,6 +308,12 @@ class MingPreprocessor:
                 "audio_feats": concat_mel,
                 "audio_feats_lengths": mel_lens,
                 "audio_placeholder_loc_lens": placeholder_locs,
+            }
+
+        if pixel_values is not None and image_grid_thw is not None:
+            encoder_inputs[IMAGE_STAGE] = {
+                "pixel_values": pixel_values,
+                "image_grid_thw": image_grid_thw,
             }
 
         state = PipelineState(
@@ -208,22 +333,27 @@ class MingPreprocessor:
         messages: list[dict[str, Any]],
         *,
         audio_token_counts: list[int] | None = None,
+        image_token_counts: list[int] | None = None,
     ) -> tuple[str, list[int]]:
-        """Build Ming-Omni chat format prompt with audio placeholders.
+        """Build Ming-Omni chat format prompt with audio/image placeholders.
 
         Args:
             messages: Chat messages.
             audio_token_counts: Exact number of <audioPatch> tokens to insert
                 per audio segment (computed from mel features). If None or
                 shorter than the number of audio items, a fallback of 1 is used.
+            image_token_counts: Exact number of <imagePatch> tokens to insert
+                per image (computed from grid_thw). If None or shorter, fallback of 1.
 
         Returns:
             prompt_text: The formatted prompt string.
             audio_positions: Token positions where <audioPatch> placeholders start.
         """
-        counts = audio_token_counts or []
+        a_counts = audio_token_counts or []
+        i_counts = image_token_counts or []
         parts: list[str] = []
         audio_idx = 0
+        image_idx = 0
 
         # System message: match the Jinja template behavior exactly.
         # Always include system prompt + "\n\ndetailed thinking off".
@@ -260,7 +390,7 @@ class MingPreprocessor:
                             text_parts.append(item.get("text", ""))
                         elif item_type in ("audio_url", "input_audio"):
                             n_tokens = (
-                                counts[audio_idx] if audio_idx < len(counts) else 1
+                                a_counts[audio_idx] if audio_idx < len(a_counts) else 1
                             )
                             placeholder = (
                                 f"{AUDIO_START}"
@@ -269,6 +399,17 @@ class MingPreprocessor:
                             )
                             text_parts.append(placeholder)
                             audio_idx += 1
+                        elif item_type in ("image_url", "image"):
+                            n_tokens = (
+                                i_counts[image_idx] if image_idx < len(i_counts) else 1
+                            )
+                            placeholder = (
+                                f"{IMAGE_START}"
+                                + IMAGE_PATCH * n_tokens
+                                + f"{IMAGE_END}"
+                            )
+                            text_parts.append(placeholder)
+                            image_idx += 1
                     elif isinstance(item, str):
                         text_parts.append(item)
                 parts.append(f"{role_tag}{''.join(text_parts)}{ROLE_END}")

--- a/sglang_omni/models/ming_omni/components/projectors.py
+++ b/sglang_omni/models/ming_omni/components/projectors.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Vision projector for Ming-Omni: maps vision encoder output to LLM hidden space.
+
+Architecture (mlp_depth=2, default for Ming-flash-omni-2.0):
+  Linear(3584, 4096) → GELU → Linear(4096, 4096)
+
+Weight checkpoint mapping (direct, no remapping needed):
+  linear_proj.0.weight → proj.0.weight
+  linear_proj.0.bias   → proj.0.bias
+  linear_proj.2.weight → proj.2.weight
+  linear_proj.2.bias   → proj.2.bias
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, Tuple
+
+import torch
+import torch.nn as nn
+
+from sglang_omni.models.weight_loader import default_weight_loader
+
+logger = logging.getLogger(__name__)
+
+
+class VisionProjector(nn.Module):
+    """MLP projector from vision encoder output to LLM hidden space.
+
+    Args:
+        vision_dim: Vision encoder output dimension (out_hidden_size, e.g. 3584).
+        llm_dim: LLM hidden dimension (e.g. 4096).
+        mlp_depth: Number of linear layers. 1 = single linear, 2 = linear+GELU+linear.
+    """
+
+    def __init__(self, vision_dim: int, llm_dim: int, mlp_depth: int = 1) -> None:
+        super().__init__()
+        layers: list[nn.Module] = [nn.Linear(vision_dim, llm_dim)]
+        for _ in range(1, mlp_depth):
+            layers.append(nn.GELU())
+            layers.append(nn.Linear(llm_dim, llm_dim))
+        self.proj = nn.Sequential(*layers)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.proj(x)
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        """Load weights with prefix normalization.
+
+        Checkpoint keys like ``0.weight`` get prepended with ``proj.``
+        to match the internal Sequential structure.
+        """
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+
+        for name, loaded_weight in weights:
+            if not name.startswith("proj."):
+                name = f"proj.{name}"
+
+            if name not in params_dict:
+                logger.debug("Skipping unknown projector weight: %s", name)
+                continue
+
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+
+        return loaded_params

--- a/sglang_omni/models/ming_omni/components/vision_encoder.py
+++ b/sglang_omni/models/ming_omni/components/vision_encoder.py
@@ -112,8 +112,6 @@ class MingOmniVisionEncoder(nn.Module):
     ) -> None:
         super().__init__()
 
-        # --- imports from sglang (sub-modules only, no top-level model) ---
-        from sglang.srt.layers.attention.vision import VisionAttention  # noqa: F401
         from sglang.srt.layers.rotary_embedding import get_rope
         from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
         from sglang.srt.models.qwen3_omni_moe import Qwen3OmniMoeVisionPatchMerger

--- a/sglang_omni/models/ming_omni/components/vision_encoder.py
+++ b/sglang_omni/models/ming_omni/components/vision_encoder.py
@@ -1,0 +1,391 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ming-Omni vision encoder composing sglang's native ViT sub-modules.
+
+Builds the same ViT architecture as sglang's ``Qwen3OmniMoeVisionEncoder``
+(Qwen3-style ViT with deepstack mergers) but without the top-level
+``Qwen3VLMoeVisionModel`` runtime dependencies (PP group, server_args,
+CUDA graph runners).
+
+Keeps:
+- TP via ``ColumnParallelLinear`` / ``RowParallelLinear`` / ``VocabParallelEmbedding``
+- Flash attention via ``VisionAttention``
+- Deepstack multi-scale feature support
+
+Skips (can be added later):
+- Pipeline parallelism (always single PP rank)
+- CUDA graph capture for vision forward
+- flashinfer_cudnn attention backend
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from functools import partial
+from typing import Iterable, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from sglang_omni.models.weight_loader import default_weight_loader
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_vision_dict(vision_config) -> dict:
+    """Extract a plain dict from a vision config object."""
+    if hasattr(vision_config, "to_dict"):
+        d = vision_config.to_dict()
+    elif hasattr(vision_config, "__dataclass_fields__"):
+        from dataclasses import asdict
+
+        d = asdict(vision_config)
+    else:
+        d = {k: v for k, v in vars(vision_config).items() if not k.startswith("_")}
+    # Remove keys that Qwen3OmniMoeVisionEncoderConfig doesn't accept
+    for key in ("model_type", "transformers_version", "torch_dtype"):
+        d.pop(key, None)
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Weight name remapping: Ming checkpoint -> sglang model
+# ---------------------------------------------------------------------------
+
+_WEIGHT_SUBSTR_MAPPINGS = {
+    "deepstack_merger_list.": "merger_list.",
+    "merger.norm.": "merger.ln_q.",
+    "merger.linear_fc1.": "merger.mlp.0.",
+    "merger.linear_fc2.": "merger.mlp.2.",
+}
+
+
+def _remap_ming_vision_weight(name: str) -> str:
+    """Remap Ming checkpoint vision weight name to sglang model name."""
+    # 1. Merger / deepstack naming
+    for old, new in _WEIGHT_SUBSTR_MAPPINGS.items():
+        name = name.replace(old, new)
+    # Also handle merger_list inner layers (after deepstack rename)
+    name = re.sub(r"(merger_list\.\d+)\.norm\.", r"\1.ln_q.", name)
+    name = re.sub(r"(merger_list\.\d+)\.linear_fc1\.", r"\1.mlp.0.", name)
+    name = re.sub(r"(merger_list\.\d+)\.linear_fc2\.", r"\1.mlp.2.", name)
+
+    # 2. VisionAttention naming
+    name = name.replace("attn.qkv.", "attn.qkv_proj.")
+    name = name.replace("attn.out_proj.", "attn.proj.")
+
+    return name
+
+
+# ---------------------------------------------------------------------------
+# MingOmniVisionEncoder
+# ---------------------------------------------------------------------------
+
+
+class MingOmniVisionEncoder(nn.Module):
+    """ViT for Ming-Omni, composed from sglang sub-modules.
+
+    Architecture:
+      PatchEmbed(Conv3d) -> pos_embed -> 27x VisionBlock -> merger
+                                          + deepstack mergers at [8,16,24]
+
+    Weight checkpoint mapping (Ming -> this model):
+      deepstack_merger_list.N.* -> merger_list.N.*
+      merger.norm.*             -> merger.ln_q.*
+      merger.linear_fc1.*       -> merger.mlp.0.*
+      merger.linear_fc2.*       -> merger.mlp.2.*
+      attn.qkv.*               -> attn.qkv_proj.*
+      attn.out_proj.*           -> attn.proj.*
+    """
+
+    def __init__(
+        self,
+        vision_config,
+        quant_config: Optional[object] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+
+        # --- imports from sglang (sub-modules only, no top-level model) ---
+        from sglang.srt.layers.attention.vision import VisionAttention  # noqa: F401
+        from sglang.srt.layers.rotary_embedding import get_rope
+        from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
+        from sglang.srt.models.qwen3_omni_moe import Qwen3OmniMoeVisionPatchMerger
+        from sglang.srt.models.qwen3_vl import (
+            Qwen3_VisionBlock,
+            Qwen3VLVisionPatchEmbed,
+        )
+        from sglang.srt.models.utils import RotaryPosMixin
+        from sglang.srt.utils import add_prefix
+
+        # Store mixin method as a static helper
+        self._rot_pos_ids = RotaryPosMixin.rot_pos_ids
+
+        # --- config ---
+        self.hidden_size = vision_config.hidden_size
+        self.num_heads = vision_config.num_heads
+        self.num_position_embeddings = vision_config.num_position_embeddings
+        self.num_grid_per_side = int(self.num_position_embeddings**0.5)
+        self.patch_size = vision_config.patch_size
+        self.spatial_merge_size = vision_config.spatial_merge_size
+        self.temporal_patch_size = vision_config.temporal_patch_size
+        self.deepstack_visual_indexes = vision_config.deepstack_visual_indexes or []
+
+        self.image_emb_dim = vision_config.out_hidden_size
+        self.use_deepstack = bool(self.deepstack_visual_indexes)
+        self.out_hidden_size = vision_config.out_hidden_size * (
+            1 + len(self.deepstack_visual_indexes)
+        )
+
+        # --- patch embedding (Conv3d, no deps) ---
+        self.patch_embed = Qwen3VLVisionPatchEmbed(config=vision_config)
+
+        # --- position embedding (TP-sharded) ---
+        self.pos_embed = VocabParallelEmbedding(
+            self.num_position_embeddings,
+            self.hidden_size,
+            quant_config=quant_config,
+            prefix=add_prefix("pos_embed", prefix),
+        )
+
+        # --- rotary pos embedding for vision blocks ---
+        head_dim = self.hidden_size // self.num_heads
+        self.rotary_pos_emb = get_rope(
+            head_size=head_dim,
+            rotary_dim=head_dim // 2,
+            max_position=8192,
+            base=10000.0,
+            is_neox_style=True,
+        )
+
+        # --- vision transformer blocks ---
+        norm_layer = partial(nn.LayerNorm, eps=1e-6)
+        self.blocks = nn.ModuleList(
+            [
+                Qwen3_VisionBlock(
+                    dim=self.hidden_size,
+                    num_heads=self.num_heads,
+                    intermediate_dim=vision_config.intermediate_size,
+                    hidden_act=vision_config.hidden_act,
+                    norm_layer=norm_layer,
+                    quant_config=quant_config,
+                    prefix=add_prefix(f"blocks.{layer_idx}", prefix),
+                )
+                for layer_idx in range(vision_config.depth)
+            ]
+        )
+
+        # --- merger (final spatial merge, uses Qwen3-Omni style with ln_q) ---
+        self.merger = Qwen3OmniMoeVisionPatchMerger(
+            dim=vision_config.out_hidden_size,
+            context_dim=self.hidden_size,
+            spatial_merge_size=self.spatial_merge_size,
+            quant_config=quant_config,
+            use_postshuffle_norm=False,
+            prefix=add_prefix("merger", prefix),
+        )
+
+        # --- deepstack mergers ---
+        self.merger_list = nn.ModuleList(
+            [
+                Qwen3OmniMoeVisionPatchMerger(
+                    dim=vision_config.out_hidden_size,
+                    context_dim=self.hidden_size,
+                    spatial_merge_size=self.spatial_merge_size,
+                    use_postshuffle_norm=True,
+                    quant_config=quant_config,
+                    prefix=add_prefix(f"merger_list.{i}", prefix),
+                )
+                for i in range(len(self.deepstack_visual_indexes))
+            ]
+        )
+
+    # --- properties ---
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.patch_embed.proj.weight.dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self.patch_embed.proj.weight.device
+
+    # --- position embedding helpers (adapted from Qwen3VLMoeVisionModel) ---
+
+    def _rot_pos_emb(
+        self, grid_thw: list[list[int]]
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Compute rotary position embeddings for vision blocks."""
+        pos_ids = []
+        for t, h, w in grid_thw:
+            base = self._rot_pos_ids(h, w, self.spatial_merge_size)
+            pos_ids.append(base if t == 1 else base.repeat(t, 1))
+
+        pos_ids = torch.cat(pos_ids, dim=0).to(self.device, non_blocking=True)
+        max_grid_size = max(max(h, w) for _, h, w in grid_thw)
+
+        cos, sin = self.rotary_pos_emb.get_cos_sin(max_grid_size)
+        cos_combined = cos[pos_ids].flatten(1)
+        sin_combined = sin[pos_ids].flatten(1)
+        return cos_combined, sin_combined
+
+    def _interpolate_pos_embed(self, grid_thw: list[list[int]]) -> torch.Tensor:
+        """Bilinear interpolation of position embeddings.
+
+        Adapted from ``Qwen3VLMoeVisionModel.fast_pos_embed_interpolate_from_list``.
+        Uses ``align_corners=True`` (linspace from 0 to N-1).
+        """
+        num_grid_per_side = self.num_grid_per_side
+        m_size = self.spatial_merge_size
+        hidden_dim = self.pos_embed.embedding_dim
+
+        outputs = []
+        for t, h, w in grid_thw:
+            h_idxs = torch.linspace(
+                0, num_grid_per_side - 1, h, dtype=torch.float32, device=self.device
+            )
+            w_idxs = torch.linspace(
+                0, num_grid_per_side - 1, w, dtype=torch.float32, device=self.device
+            )
+
+            h_floor = h_idxs.to(torch.long)
+            w_floor = w_idxs.to(torch.long)
+            h_ceil = torch.clamp(h_floor + 1, max=num_grid_per_side - 1)
+            w_ceil = torch.clamp(w_floor + 1, max=num_grid_per_side - 1)
+
+            dh = h_idxs - h_floor
+            dw = w_idxs - w_floor
+
+            dh_grid, dw_grid = torch.meshgrid(dh, dw, indexing="ij")
+            h_floor_grid, w_floor_grid = torch.meshgrid(h_floor, w_floor, indexing="ij")
+            h_ceil_grid, w_ceil_grid = torch.meshgrid(h_ceil, w_ceil, indexing="ij")
+
+            w11 = dh_grid * dw_grid
+            w10 = dh_grid - w11
+            w01 = dw_grid - w11
+            w00 = 1 - dh_grid - w01
+
+            h_grid = torch.stack([h_floor_grid, h_floor_grid, h_ceil_grid, h_ceil_grid])
+            w_grid = torch.stack([w_floor_grid, w_ceil_grid, w_floor_grid, w_ceil_grid])
+            indices = (h_grid * num_grid_per_side + w_grid).reshape(4, -1)
+            weights = torch.stack([w00, w01, w10, w11], dim=0).reshape(4, -1, 1)
+            weights = weights.to(dtype=self.dtype)
+
+            embeds = self.pos_embed(indices)
+            embeds *= weights
+            combined = embeds.sum(dim=0)
+
+            combined = combined.reshape(
+                h // m_size, m_size, w // m_size, m_size, hidden_dim
+            )
+            combined = combined.permute(0, 2, 1, 3, 4).reshape(1, -1, hidden_dim)
+            repeated = combined.expand(t, -1, -1).reshape(-1, hidden_dim)
+            outputs.append(repeated)
+
+        return torch.cat(outputs, dim=0)
+
+    # --- forward ---
+
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        grid_thw: torch.Tensor,
+    ) -> torch.Tensor:
+        """Forward pass through the vision encoder.
+
+        Adapted from ``Qwen3VLMoeVisionModel.forward()`` without CUDA graph
+        and flashinfer_cudnn paths.
+
+        Args:
+            pixel_values: Flattened pixel values, shape [total_patches, C*Tp*Pp*Pp].
+            grid_thw: [num_images, 3] tensor of (t, h, w) grid dimensions.
+
+        Returns:
+            If deepstack: [seq_len, out_hidden_size * (1 + num_deepstack)].
+            Otherwise: [seq_len, out_hidden_size].
+        """
+        x = pixel_values.to(device=self.device, dtype=self.dtype)
+        x = self.patch_embed(x)
+
+        # Convert grid_thw to list for iteration
+        if isinstance(grid_thw, torch.Tensor):
+            grid_thw_list = grid_thw.tolist()
+            grid_thw_np = grid_thw.cpu().numpy()
+        else:
+            grid_thw_list = grid_thw
+            grid_thw_np = np.array(grid_thw, dtype=np.int32)
+
+        # Position embeddings (bilinear interpolation)
+        pos_embeds = self._interpolate_pos_embed(grid_thw_list)
+        x += pos_embeds
+
+        # Rotary position embeddings for attention
+        rotary_pos_emb_cos, rotary_pos_emb_sin = self._rot_pos_emb(grid_thw_list)
+
+        # Build cu_seqlens for variable-length flash attention
+        token_cu_seqlens = np.repeat(
+            grid_thw_np[:, 1] * grid_thw_np[:, 2], grid_thw_np[:, 0]
+        ).cumsum(axis=0, dtype=np.int32)
+        token_cu_seqlens = np.concatenate(
+            [np.zeros(1, dtype=np.int32), token_cu_seqlens]
+        )
+        cu_seqlens = torch.from_numpy(token_cu_seqlens).to(
+            self.device, non_blocking=True
+        )
+
+        # VisionBlock expects shape [seq_len, 1, hidden_size]
+        x = x.unsqueeze(1)
+
+        # Run vision transformer blocks
+        deepstack_feature_lists = []
+        num_deepstack_captured = 0
+
+        for layer_num, blk in enumerate(self.blocks):
+            x = blk(
+                x,
+                cu_seqlens=cu_seqlens,
+                rotary_pos_emb_cos=rotary_pos_emb_cos,
+                rotary_pos_emb_sin=rotary_pos_emb_sin,
+            )
+
+            if layer_num in self.deepstack_visual_indexes:
+                deepstack_feature = self.merger_list[num_deepstack_captured](x)
+                deepstack_feature_lists.append(deepstack_feature)
+                num_deepstack_captured += 1
+
+        # Final merger
+        x = self.merger(x)
+
+        # Concat deepstack features
+        hidden_states = torch.cat(
+            [x] + deepstack_feature_lists, dim=1
+        )  # [seq_len, out_hidden_size * (1 + num_deepstack)]
+
+        return hidden_states
+
+    # --- weight loading ---
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        """Load weights with Ming -> sglang name remapping."""
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+
+        for name, loaded_weight in weights:
+            name = _remap_ming_vision_weight(name)
+
+            if name not in params_dict:
+                logger.debug("Skipping unknown vision weight: %s", name)
+                continue
+
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+
+        return loaded_params

--- a/sglang_omni/models/ming_omni/components/vision_encoder.py
+++ b/sglang_omni/models/ming_omni/components/vision_encoder.py
@@ -33,11 +33,6 @@ from sglang_omni.models.weight_loader import default_weight_loader
 logger = logging.getLogger(__name__)
 
 
-# ---------------------------------------------------------------------------
-# Config helpers
-# ---------------------------------------------------------------------------
-
-
 def _extract_vision_dict(vision_config) -> dict:
     """Extract a plain dict from a vision config object."""
     if hasattr(vision_config, "to_dict"):
@@ -53,10 +48,6 @@ def _extract_vision_dict(vision_config) -> dict:
         d.pop(key, None)
     return d
 
-
-# ---------------------------------------------------------------------------
-# Weight name remapping: Ming checkpoint -> sglang model
-# ---------------------------------------------------------------------------
 
 _WEIGHT_SUBSTR_MAPPINGS = {
     "deepstack_merger_list.": "merger_list.",
@@ -81,11 +72,6 @@ def _remap_ming_vision_weight(name: str) -> str:
     name = name.replace("attn.out_proj.", "attn.proj.")
 
     return name
-
-
-# ---------------------------------------------------------------------------
-# MingOmniVisionEncoder
-# ---------------------------------------------------------------------------
 
 
 class MingOmniVisionEncoder(nn.Module):

--- a/sglang_omni/models/ming_omni/config.py
+++ b/sglang_omni/models/ming_omni/config.py
@@ -16,6 +16,7 @@ from sglang_omni.models.ming_omni.pipeline.next_stage import (
     AGGREGATE_STAGE,
     AUDIO_STAGE,
     DECODE_STAGE,
+    IMAGE_STAGE,
     PREPROCESSING_STAGE,
     TALKER_STAGE,
     THINKER_STAGE,
@@ -23,9 +24,9 @@ from sglang_omni.models.ming_omni.pipeline.next_stage import (
 
 
 class MingOmniPipelineConfig(PipelineConfig):
-    """6-stage text-only pipeline for Ming-Omni.
+    """6-stage text/vision pipeline for Ming-Omni.
 
-    preprocessing → audio_encoder → mm_aggregate → thinker → decode
+    preprocessing → audio_encoder + image_encoder → mm_aggregate → thinker → decode
     """
 
     architecture: ClassVar[str] = "BailingMM2NativeForConditionalGeneration"
@@ -54,6 +55,18 @@ class MingOmniPipelineConfig(PipelineConfig):
             relay=RelayConfig(device="cuda"),
         ),
         StageConfig(
+            name=IMAGE_STAGE,
+            executor=ExecutorConfig(
+                factory="sglang_omni.models.ming_omni.pipeline.stages.create_image_encoder_executor",
+                args={
+                    "device": "cuda",
+                    "dtype": None,
+                },
+            ),
+            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.encoder_next",
+            relay=RelayConfig(device="cuda"),
+        ),
+        StageConfig(
             name=AGGREGATE_STAGE,
             executor=ExecutorConfig(
                 factory="sglang_omni.models.ming_omni.pipeline.stages.create_aggregate_executor",
@@ -62,7 +75,7 @@ class MingOmniPipelineConfig(PipelineConfig):
             get_next="sglang_omni.models.ming_omni.pipeline.next_stage.aggregate_next",
             input_handler=InputHandlerConfig(
                 type="aggregated",
-                sources=[PREPROCESSING_STAGE, AUDIO_STAGE],
+                sources=[PREPROCESSING_STAGE, AUDIO_STAGE, IMAGE_STAGE],
                 merge_fn="sglang_omni.models.ming_omni.pipeline.merge.merge_for_thinker",
             ),
             relay=RelayConfig(device="cpu"),
@@ -153,6 +166,15 @@ class MingOmniSpeechPipelineConfig(PipelineConfig):
             relay=RelayConfig(device="cuda"),
         ),
         StageConfig(
+            name=IMAGE_STAGE,
+            executor=ExecutorConfig(
+                factory="sglang_omni.models.ming_omni.pipeline.stages.create_image_encoder_executor",
+                args={"device": "cuda", "dtype": None},
+            ),
+            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.encoder_next",
+            relay=RelayConfig(device="cuda"),
+        ),
+        StageConfig(
             name=AGGREGATE_STAGE,
             executor=ExecutorConfig(
                 factory="sglang_omni.models.ming_omni.pipeline.stages.create_aggregate_executor",
@@ -161,7 +183,7 @@ class MingOmniSpeechPipelineConfig(PipelineConfig):
             get_next="sglang_omni.models.ming_omni.pipeline.next_stage.aggregate_next",
             input_handler=InputHandlerConfig(
                 type="aggregated",
-                sources=[PREPROCESSING_STAGE, AUDIO_STAGE],
+                sources=[PREPROCESSING_STAGE, AUDIO_STAGE, IMAGE_STAGE],
                 merge_fn="sglang_omni.models.ming_omni.pipeline.merge.merge_for_thinker",
             ),
             relay=RelayConfig(device="cpu"),

--- a/sglang_omni/models/ming_omni/hf_config.py
+++ b/sglang_omni/models/ming_omni/hf_config.py
@@ -46,14 +46,35 @@ class VisionConfig:
 
     depth: int = 27
     hidden_size: int = 1152
-    num_heads: int = 16
-    patch_size: int = 16
+    hidden_act: str = "gelu_pytorch_tanh"
     intermediate_size: int = 4304
-    out_hidden_size: int = 4096
+    num_heads: int = 16
+    in_channels: int = 3
+    patch_size: int = 16
     spatial_merge_size: int = 2
     temporal_patch_size: int = 2
+    out_hidden_size: int = 4096
     num_position_embeddings: int = 2304
     deepstack_visual_indexes: list[int] = field(default_factory=lambda: [8, 16, 24])
+    initializer_range: float = 0.02
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "VisionConfig":
+        return cls(
+            depth=d.get("depth", 27),
+            hidden_size=d.get("hidden_size", 1152),
+            hidden_act=d.get("hidden_act", "gelu_pytorch_tanh"),
+            intermediate_size=d.get("intermediate_size", 4304),
+            num_heads=d.get("num_heads", 16),
+            in_channels=d.get("in_channels", 3),
+            patch_size=d.get("patch_size", 16),
+            spatial_merge_size=d.get("spatial_merge_size", 2),
+            temporal_patch_size=d.get("temporal_patch_size", 2),
+            out_hidden_size=d.get("out_hidden_size", 4096),
+            num_position_embeddings=d.get("num_position_embeddings", 2304),
+            deepstack_visual_indexes=d.get("deepstack_visual_indexes", [8, 16, 24]),
+            initializer_range=d.get("initializer_range", 0.02),
+        )
 
 
 @dataclass(frozen=True)
@@ -156,8 +177,13 @@ class MingOmniConfig:
     def from_dict(cls, d: dict[str, Any]) -> "MingOmniConfig":
         llm_config = BailingMoeV2LLMConfig.from_dict(d.get("llm_config", {}))
         audio_config = AudioConfig.from_dict(d.get("audio_config", {}))
+        vision_raw = d.get("vision_config", {})
+        vision_config = (
+            VisionConfig.from_dict(vision_raw) if vision_raw else VisionConfig()
+        )
         return cls(
             llm_config=llm_config,
             audio_config=audio_config,
+            vision_config=vision_config,
             mlp_depth=d.get("mlp_depth", 2),
         )

--- a/sglang_omni/models/ming_omni/pipeline/merge.py
+++ b/sglang_omni/models/ming_omni/pipeline/merge.py
@@ -8,7 +8,7 @@ from typing import Any, Iterable
 import torch
 
 from sglang_omni.models.ming_omni.io import OmniEvent, PipelineState, ThinkerOutput
-from sglang_omni.models.ming_omni.pipeline.next_stage import AUDIO_STAGE
+from sglang_omni.models.ming_omni.pipeline.next_stage import AUDIO_STAGE, IMAGE_STAGE
 from sglang_omni.proto import StagePayload
 
 
@@ -63,20 +63,28 @@ def build_thinker_inputs(
 ) -> dict[str, Any]:
     """Build model_inputs dict for the Ming thinker from encoder outputs.
 
-    The SGLang runtime's _inject_multimodal_embeds() handles audio embedding
-    injection automatically: it finds positions where input_ids == audio_token_id
-    and patches audio_embeds from req.omni_model_inputs into those positions.
+    The SGLang runtime's _inject_multimodal_embeds() handles embedding
+    injection automatically: it finds positions where input_ids == token_id
+    and patches embeddings from req.omni_model_inputs into those positions.
 
-    We just need to pass audio_embeds as a flat [T', hidden_size] tensor —
+    We pass each modality as a flat [T', hidden_size] tensor —
     the runtime handles the rest via token ID matching.
     """
     audio_out = (
         encoder_outs.get(AUDIO_STAGE, {}) if isinstance(encoder_outs, dict) else {}
     )
+    image_out = (
+        encoder_outs.get(IMAGE_STAGE, {}) if isinstance(encoder_outs, dict) else {}
+    )
 
     audio_embeds = (
         _as_tensor(audio_out.get("audio_embeds"))
         if isinstance(audio_out, dict)
+        else None
+    )
+    image_embeds = (
+        _as_tensor(image_out.get("image_embeds"))
+        if isinstance(image_out, dict)
         else None
     )
 
@@ -87,6 +95,12 @@ def build_thinker_inputs(
         if audio_embeds.dim() == 3:
             audio_embeds = audio_embeds.squeeze(0)
         thinker_model_inputs["audio_embeds"] = audio_embeds
+
+    if _non_empty(image_embeds):
+        # Flatten: [B, T', H] -> [T', H] if needed
+        if image_embeds.dim() == 3:
+            image_embeds = image_embeds.squeeze(0)
+        thinker_model_inputs["image_embeds"] = image_embeds
 
     if not thinker_model_inputs:
         return {}

--- a/sglang_omni/models/ming_omni/pipeline/next_stage.py
+++ b/sglang_omni/models/ming_omni/pipeline/next_stage.py
@@ -10,6 +10,7 @@ from sglang_omni.proto import StagePayload
 
 PREPROCESSING_STAGE = "preprocessing"
 AUDIO_STAGE = "audio_encoder"
+IMAGE_STAGE = "image_encoder"
 AGGREGATE_STAGE = "mm_aggregate"
 THINKER_STAGE = "thinker"
 DECODE_STAGE = "decode"

--- a/sglang_omni/models/ming_omni/pipeline/stages.py
+++ b/sglang_omni/models/ming_omni/pipeline/stages.py
@@ -25,7 +25,11 @@ from sglang_omni.models.ming_omni.pipeline.engine_io import (
     build_sglang_thinker_request,
 )
 from sglang_omni.models.ming_omni.pipeline.merge import decode_events
-from sglang_omni.models.ming_omni.pipeline.next_stage import AUDIO_STAGE, THINKER_STAGE
+from sglang_omni.models.ming_omni.pipeline.next_stage import (
+    AUDIO_STAGE,
+    IMAGE_STAGE,
+    THINKER_STAGE,
+)
 from sglang_omni.models.ming_omni.pipeline.state_io import load_state, store_state
 from sglang_omni.proto import StagePayload
 
@@ -70,6 +74,37 @@ def create_audio_encoder_executor(
     def _result_builder(payload: StagePayload, result: Any) -> StagePayload:
         state = load_state(payload)
         apply_encoder_result(state, stage_name=AUDIO_STAGE, result=result)
+        return store_state(payload, state)
+
+    engine = create_single_pass_engine(
+        model,
+        device=device,
+        use_cache=True,
+        cache_size=64,
+    )
+    return EngineExecutor(
+        engine=engine, request_builder=_request_builder, result_builder=_result_builder
+    )
+
+
+def create_image_encoder_executor(
+    model_path: str,
+    *,
+    device: str = "cuda",
+    dtype: str | None = None,
+) -> EngineExecutor:
+    """Create an image encoder executor for the Ming-Omni vision pipeline."""
+    from sglang_omni.models.ming_omni.components.image_encoder import MingImageEncoder
+
+    model = MingImageEncoder(model_path=model_path, device=device, dtype=dtype)
+
+    def _request_builder(payload: StagePayload):
+        state = load_state(payload)
+        return build_encoder_request(state, stage_name=IMAGE_STAGE)
+
+    def _result_builder(payload: StagePayload, result: Any) -> StagePayload:
+        state = load_state(payload)
+        apply_encoder_result(state, stage_name=IMAGE_STAGE, result=result)
         return store_state(payload, state)
 
     engine = create_single_pass_engine(

--- a/sglang_omni/models/ming_omni/thinker.py
+++ b/sglang_omni/models/ming_omni/thinker.py
@@ -731,6 +731,31 @@ class BailingMoeV2ForCausalLM(nn.Module):
         self.logits_processor = LogitsProcessor(adapted)
 
         # ------------------------------------------------------------------
+        # Vision encoder + projector
+        # ------------------------------------------------------------------
+        vision_cfg = getattr(config, "vision_config", None)
+        if vision_cfg is not None:
+            from sglang_omni.models.ming_omni.components.projectors import (
+                VisionProjector,
+            )
+            from sglang_omni.models.ming_omni.components.vision_encoder import (
+                MingOmniVisionEncoder,
+            )
+
+            self.visual = MingOmniVisionEncoder(
+                vision_cfg, quant_config=quant_config, prefix="visual"
+            )
+            mlp_depth = getattr(config, "mlp_depth", 2)
+            self.linear_proj = VisionProjector(
+                vision_dim=self.visual.image_emb_dim,
+                llm_dim=adapted.hidden_size,
+                mlp_depth=mlp_depth,
+            )
+        else:
+            self.visual = None
+            self.linear_proj = None
+
+        # ------------------------------------------------------------------
         # Patch token IDs on the HF config for SGLang runtime's
         # _inject_multimodal_embeds() which reads config.audio_token_id etc.
         # This runs during model loading, BEFORE SGLangModelScheduler reads
@@ -774,6 +799,33 @@ class BailingMoeV2ForCausalLM(nn.Module):
             else:
                 config.audio_token_id = None
 
+    def get_image_feature(
+        self,
+        pixel_values: torch.Tensor,
+        grid_thw: torch.Tensor,
+    ) -> torch.Tensor:
+        """Extract image features: vision encode → project → L2 normalize.
+
+        Args:
+            pixel_values: Flattened pixel values from image processor.
+            grid_thw: [num_images, 3] tensor of (t, h, w) grid dimensions.
+
+        Returns:
+            Image embeddings of shape [seq_len, llm_hidden_size].
+        """
+        assert self.visual is not None, "Vision encoder not initialized"
+        assert self.linear_proj is not None, "Vision projector not initialized"
+
+        image_embeds = self.visual(pixel_values, grid_thw=grid_thw)
+
+        # If deepstack is enabled, only use the base merger output for projection
+        if self.visual.use_deepstack:
+            image_embeds = image_embeds[:, : self.visual.image_emb_dim]
+
+        image_embeds = self.linear_proj(image_embeds)
+        image_embeds = torch.nn.functional.normalize(image_embeds, dim=-1)
+        return image_embeds
+
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -790,15 +842,30 @@ class BailingMoeV2ForCausalLM(nn.Module):
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         """Load weights from Ming-Omni checkpoint.
 
-        Routes lm_head weights to self.lm_head and text model weights
-        to self.model. Skips non-LLM weights (audio encoder, vision, etc.).
+        Routes weights to sub-modules:
+        - lm_head.*       → self.lm_head
+        - vision.*        → self.visual (MingOmniVisionEncoder)
+        - linear_proj.*   → self.linear_proj (VisionProjector)
+        - audio.*, linear_proj_audio.* → skipped (audio encoder handled separately)
+        - everything else → self.model (BailingMoeV2TextModel)
         """
         model_weights = []
+        vision_weights = []
+        proj_weights = []
         lm_head_params = dict(self.lm_head.named_parameters())
 
         for name, tensor in weights:
+            # Strip top-level "model." prefix from checkpoint names.
+            # Checkpoint uses "model.vision.*", "model.linear_proj.*", etc.
+            # but NOT "model.model.*" (that stripping is in TextModel).
+            stripped = name
+            if stripped.startswith("model.") and not stripped.startswith(
+                "model.model."
+            ):
+                stripped = stripped[len("model.") :]
+
             # Route lm_head weights
-            if name in ("lm_head.weight", "model.lm_head.weight"):
+            if stripped in ("lm_head.weight",) or name in ("model.lm_head.weight",):
                 param = lm_head_params.get("weight")
                 if param is not None:
                     weight_loader = getattr(
@@ -807,16 +874,41 @@ class BailingMoeV2ForCausalLM(nn.Module):
                     weight_loader(param, tensor)
                 continue
 
-            # Skip non-LLM weights that may be in the checkpoint
-            if any(
-                name.startswith(p)
-                for p in ("audio.", "linear_proj_audio.", "vision.", "linear_proj.")
+            # Route vision encoder weights
+            if stripped.startswith("vision."):
+                if self.visual is not None:
+                    vision_weights.append((stripped[len("vision.") :], tensor))
+                continue
+
+            # Route vision projector weights
+            if stripped.startswith("linear_proj.") and not stripped.startswith(
+                "linear_proj_audio."
+            ):
+                if self.linear_proj is not None:
+                    proj_weights.append((stripped[len("linear_proj.") :], tensor))
+                continue
+
+            # Skip audio weights (handled by audio encoder separately)
+            if stripped.startswith("audio.") or stripped.startswith(
+                "linear_proj_audio."
             ):
                 continue
 
+            # Pass original name to text model (it does its own prefix stripping)
             model_weights.append((name, tensor))
 
+        # Load text model weights
         self.model.load_weights(iter(model_weights))
+
+        # Load vision encoder weights
+        if self.visual is not None and vision_weights:
+            loaded = self.visual.load_weights(iter(vision_weights))
+            logger.info("Loaded %d vision encoder weights", len(loaded))
+
+        # Load vision projector weights
+        if self.linear_proj is not None and proj_weights:
+            loaded = self.linear_proj.load_weights(iter(proj_weights))
+            logger.info("Loaded %d vision projector weights", len(loaded))
 
         # Handle weight tying
         llm_cfg = getattr(self.config, "llm_config", self.config)

--- a/sglang_omni/models/ming_omni/thinker.py
+++ b/sglang_omni/models/ming_omni/thinker.py
@@ -731,29 +731,15 @@ class BailingMoeV2ForCausalLM(nn.Module):
         self.logits_processor = LogitsProcessor(adapted)
 
         # ------------------------------------------------------------------
-        # Vision encoder + projector
+        # Vision encoder + projector — NOT loaded here.
+        # The pipeline's IMAGE_STAGE (MingImageEncoder) handles vision
+        # encoding independently and injects pre-computed image_embeds
+        # via SGLang's _inject_multimodal_embeds().  Loading a duplicate
+        # copy here would waste ~1.2 GB of GPU memory.
+        # Vision/projector weights are silently skipped in load_weights().
         # ------------------------------------------------------------------
-        vision_cfg = getattr(config, "vision_config", None)
-        if vision_cfg is not None:
-            from sglang_omni.models.ming_omni.components.projectors import (
-                VisionProjector,
-            )
-            from sglang_omni.models.ming_omni.components.vision_encoder import (
-                MingOmniVisionEncoder,
-            )
-
-            self.visual = MingOmniVisionEncoder(
-                vision_cfg, quant_config=quant_config, prefix="visual"
-            )
-            mlp_depth = getattr(config, "mlp_depth", 2)
-            self.linear_proj = VisionProjector(
-                vision_dim=self.visual.image_emb_dim,
-                llm_dim=adapted.hidden_size,
-                mlp_depth=mlp_depth,
-            )
-        else:
-            self.visual = None
-            self.linear_proj = None
+        self.visual = None
+        self.linear_proj = None
 
         # ------------------------------------------------------------------
         # Patch token IDs on the HF config for SGLang runtime's
@@ -799,33 +785,6 @@ class BailingMoeV2ForCausalLM(nn.Module):
             else:
                 config.audio_token_id = None
 
-    def get_image_feature(
-        self,
-        pixel_values: torch.Tensor,
-        grid_thw: torch.Tensor,
-    ) -> torch.Tensor:
-        """Extract image features: vision encode → project → L2 normalize.
-
-        Args:
-            pixel_values: Flattened pixel values from image processor.
-            grid_thw: [num_images, 3] tensor of (t, h, w) grid dimensions.
-
-        Returns:
-            Image embeddings of shape [seq_len, llm_hidden_size].
-        """
-        assert self.visual is not None, "Vision encoder not initialized"
-        assert self.linear_proj is not None, "Vision projector not initialized"
-
-        image_embeds = self.visual(pixel_values, grid_thw=grid_thw)
-
-        # If deepstack is enabled, only use the base merger output for projection
-        if self.visual.use_deepstack:
-            image_embeds = image_embeds[:, : self.visual.image_emb_dim]
-
-        image_embeds = self.linear_proj(image_embeds)
-        image_embeds = torch.nn.functional.normalize(image_embeds, dim=-1)
-        return image_embeds
-
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -844,14 +803,11 @@ class BailingMoeV2ForCausalLM(nn.Module):
 
         Routes weights to sub-modules:
         - lm_head.*       → self.lm_head
-        - vision.*        → self.visual (MingOmniVisionEncoder)
-        - linear_proj.*   → self.linear_proj (VisionProjector)
-        - audio.*, linear_proj_audio.* → skipped (audio encoder handled separately)
+        - vision.*, linear_proj.* → skipped (vision handled by IMAGE_STAGE)
+        - audio.*, linear_proj_audio.* → skipped (audio handled by AUDIO_STAGE)
         - everything else → self.model (BailingMoeV2TextModel)
         """
         model_weights = []
-        vision_weights = []
-        proj_weights = []
         lm_head_params = dict(self.lm_head.named_parameters())
 
         for name, tensor in weights:
@@ -874,21 +830,15 @@ class BailingMoeV2ForCausalLM(nn.Module):
                     weight_loader(param, tensor)
                 continue
 
-            # Route vision encoder weights
+            # Skip vision encoder + projector weights (handled by IMAGE_STAGE)
             if stripped.startswith("vision."):
-                if self.visual is not None:
-                    vision_weights.append((stripped[len("vision.") :], tensor))
                 continue
-
-            # Route vision projector weights
             if stripped.startswith("linear_proj.") and not stripped.startswith(
                 "linear_proj_audio."
             ):
-                if self.linear_proj is not None:
-                    proj_weights.append((stripped[len("linear_proj.") :], tensor))
                 continue
 
-            # Skip audio weights (handled by audio encoder separately)
+            # Skip audio weights (handled by AUDIO_STAGE)
             if stripped.startswith("audio.") or stripped.startswith(
                 "linear_proj_audio."
             ):
@@ -899,16 +849,6 @@ class BailingMoeV2ForCausalLM(nn.Module):
 
         # Load text model weights
         self.model.load_weights(iter(model_weights))
-
-        # Load vision encoder weights
-        if self.visual is not None and vision_weights:
-            loaded = self.visual.load_weights(iter(vision_weights))
-            logger.info("Loaded %d vision encoder weights", len(loaded))
-
-        # Load vision projector weights
-        if self.linear_proj is not None and proj_weights:
-            loaded = self.linear_proj.load_weights(iter(proj_weights))
-            logger.info("Loaded %d vision projector weights", len(loaded))
 
         # Handle weight tying
         llm_cfg = getattr(self.config, "llm_config", self.config)

--- a/tests/test_ming_omni_vision_e2e.py
+++ b/tests/test_ming_omni_vision_e2e.py
@@ -10,7 +10,7 @@ Tests the complete vision pipeline with a real image:
 
 Usage (on remote server):
     cd /sgl-workspace/sglang-omni-dev2
-    CUDA_VISIBLE_DEVICES=0 python scripts/test_vision_e2e.py
+    CUDA_VISIBLE_DEVICES=0 python scripts/test_ming_omni_vision_e2e.py
 """
 
 from __future__ import annotations


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR is to support vision encoder for Ming-flash-omni-2.0 to support image recognition.

VisionEncoder test passed. Unit test passed.

Integrate it into pipeline and make whole E2E work, passed.


### E2E Result
```
 Server:

  # Single GPU, Ming-Omni with vision support (text output)
  CUDA_VISIBLE_DEVICES=0 python examples/run_ming_omni_server.py \
      --model-path inclusionAI/Ming-flash-omni-2.0 \
      --port 8000 \
      --cpu-offload-gb 80 \
      --mem-fraction-static 0.92

  Client ：

  # Text-only request
  curl http://localhost:8000/v1/chat/completions \
      -H "Content-Type: application/json" \
      -d '{
          "model": "ming-omni",
          "messages": [{"role": "user", "content": "What is 2+3?"}],
          "max_tokens": 64
      }'

  # Image + text request
  curl http://localhost:8000/v1/chat/completions \
      -H "Content-Type: application/json" \
      -d '{
          "model": "ming-omni",
          "messages": [{
              "role": "user",
              "content": [
                  {"type": "image_url", "image_url": {"url": "https://picsum.photos/id/237/300/200"}},
                  {"type": "text", "text": "Describe what you see in this image."}
              ]
          }],
          "max_tokens": 256
      }'

  Client Output Result:
  {
       "id": "chatcmpl-0329e56c-06d2-4556-ae33-aedb191de1f2",
       "object": "chat.completion",
       "created": 1775658945,
       "model": "ming-omni",
       "choices": [
         {
           "index": 0,
           "message": {
             "role": "assistant",
             "content": "The image shows a black puppy lying on a wooden floor. The puppy has a shiny black coat, and its eyes are wide open, giving it a curious and attentive expression. The floor consists of several wooden planks, and
     each plank has a weathered look with a natural wood grain pattern. The lighting is soft, highlighting the texture of the floor and the smoothness of the puppy's fur. The puppy's paws are visible, showing its front legs stretched
     forward. There is a calm and relaxed atmosphere conveyed by the serene setting."
           },
           "finish_reason": "stop"
         }
       ],
       "usage": null
     }
```

### Unit Test Result
```
============================================================
Ming-flash-omni-2.0 Image Understanding E2E Test
============================================================
Model: inclusionAI/Ming-flash-omni-2.0
Device: cuda:0


Fetching 98 files:   0%|          | 0/98 [00:00<?, ?it/s]
Fetching 98 files: 100%|██████████| 98/98 [00:00<00:00, 11386.20it/s]
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[2026-04-08 12:32:29] INFO common.py:2924: MOE_RUNNER_BACKEND is not initialized, the backend will be automatically selected
[2026-04-08 12:32:29] INFO common.py:1889: Multimodal attention backend not set. Use fa3.
[2026-04-08 12:32:29] INFO common.py:1889: Using fa3 as multimodal attention backend.
[2026-04-08 12:32:37] WARNING common.py:49: Tokenizer not found in /root/.cache/huggingface/hub/models--inclusionAI--Ming-flash-omni-2.0/snapshots/6a2e1dec07066d20f62a743ac7c34284e4a3932d, falling back to
inclusionAI/Ming-flash-omni-Preview
The tokenizer class you load from this checkpoint is not the same type as the class this function is called from. It may result in unexpected tokenization.
The tokenizer class you load from this checkpoint is 'BailingTokenizer'.
The class this function is called from is 'PreTrainedTokenizerFast'.
Vision: depth=27, out=4096
LLM: hidden=4096, vocab=157184

[OK] sglang TP=1 context initialized

--- Step 1: Image Preprocessing ---
 Image size: (384, 639)
 pixel_values: torch.Size([960, 1536]), dtype=torch.float32
 grid_thw: [[1, 40, 24]]

--- Step 2: Load Vision Components ---
 Vision encoder: 351 weights loaded in 0.2s
 Projector: 4 weights loaded

--- Step 3: Vision Pipeline ---
 Vision encoder output: torch.Size([240, 16384])
 After deepstack slice: torch.Size([240, 4096])
 After projector: torch.Size([240, 4096])
 Pipeline time: 6.53s

--- Step 4: Feature Validation ---

 Image features: shape=(240, 4096)
 L2 norms: mean=1.0000, min=0.9967, max=1.0037
 Feature diversity (mean std across tokens): 0.013620
 Stats: mean=-0.0001, std=0.0156, min=-0.1357, max=0.2734

--- Step 5: Embedding Injection ---
 Tokenizer loaded: vocab_size=156891
 Embedding table loaded: torch.Size([157184, 4096])
 Prompt tokens: 278
 Image patch token ID: 157157
 Image token positions found: 240 (expected: 240)
 [OK] Image features injected into embeddings

 Combined input_embeds: shape=torch.Size([278, 4096])
 [OK] No NaN/Inf
 Stats: mean=-0.0001, std=0.0160

--- Step 6: LLM Logits Check (first token prediction) ---
 LM head loaded: torch.Size([157184, 4096])
 Top-5 predicted tokens after prompt:
   1. ' Cr' (id=8344, logit=0.07)
   2. 'cr' (id=11387, logit=0.07)
   3. 'CX' (id=66838, logit=0.06)
   4. '不全' (id=61718, logit=0.06)
   5. ' bic' (id=71932, logit=0.06)

============================================================
SUMMARY
============================================================
 PASS  Image Preprocessing
 PASS  Feature Validation
 PASS  Embedding Injection
 PASS  LLM Logits Check

ALL TESTS PASSED
[rank0]:[W408 12:32:44.376623869 ProcessGroupNCCL.cpp:1524] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see
https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
```

```
=== MingOmniVisionEncoder Test ===
Model: inclusionAI/Ming-flash-omni-2.0
Device: cuda:0

Resolving model directory...

Fetching 98 files:   0%|          | 0/98 [00:00<?, ?it/s]
Fetching 98 files: 100%|██████████| 98/98 [00:00<00:00, 9427.56it/s]
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
[2026-04-08 12:01:07] INFO common.py:2924: MOE_RUNNER_BACKEND is not initialized, the backend will be automatically selected
[2026-04-08 12:01:07] INFO common.py:1889: Multimodal attention backend not set. Use fa3.
[2026-04-08 12:01:07] INFO common.py:1889: Using fa3 as multimodal attention backend.
 /root/.cache/huggingface/hub/models--inclusionAI--Ming-flash-omni-2.0/snapshots/6a2e1dec07066d20f62a743ac7c34284e4a3932d

Vision config: depth=27, hidden=1152, out=4096
Projector: mlp_depth=2, llm_hidden=4096

[OK] sglang TP=1 context initialized

--- Test 1: Instantiation ---
[OK] MingOmniVisionEncoder instantiated: 576.4M params
    hidden_size=1152, num_heads=16, depth=27, out_hidden_size=4096
    deepstack_indexes=[8, 16, 24]

--- Test 2: Weight Loading ---

    Model has 351 parameters
[OK] Weight loading: 351/351 loaded in 0.2s

--- Test 3: Weight Spot-Check ---
 OK   patch_embed Conv3d: max_diff=0.00e+00
 OK   block0 norm1: max_diff=0.00e+00
 OK   block26 norm2: max_diff=0.00e+00
 OK   merger ln_q (remapped): max_diff=0.00e+00
[OK] Spot-check: 4/4 passed

--- Test 4: Forward Pass ---

 output shape: torch.Size([49, 16384]) (expected: (49, 16384))
 has_nan=False, has_inf=False, all_zero=False
 output stats: mean=0.0003, std=0.2858, min=-27.7500, max=18.7500
[OK] Forward pass shape
[OK] Forward pass sanity

--- Test 5: Vision Projector ---

 VisionProjector: 33.6M params (4096 -> 4096, depth=2)
 Loaded 4/4 projector weights
 output shape: torch.Size([49, 4096]) (expected: (49, 4096))
[OK] VisionProjector

==================================================
SUMMARY
==================================================
 PASS  Instantiation
 PASS  Weight Loading
 PASS  Weight Spot-Check
 PASS  Forward Pass
 PASS  Vision Projector

ALL TESTS PASSED
[rank0]:[W408 12:01:15.613039759 ProcessGroupNCCL.cpp:1524] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
```

## Modifications

<!-- Describe the changes made in this PR. -->

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
