### PR TITLE
fix(ming): resolve architecture discovery and tokenizer loading for Ming-flash-omni-2.0

### DIFF
--- a/sglang_omni/config/manager.py
+++ b/sglang_omni/config/manager.py
@@ -104,9 +104,7 @@ class ConfigManager:
 
         # 1) Hugging Face: local snapshot or hub id (hub ids have no local config.json)
         try:
-            hf_config = AutoConfig.from_pretrained(
-                model_path, trust_remote_code=True
-            )
+            hf_config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
             arch = architecture_from_hf_config(hf_config)
         except Exception:
             pass
@@ -120,7 +118,9 @@ class ConfigManager:
             arch = try_resolve_arch_from_raw_config(model_path)
 
         if arch is None:
-            supported = ", ".join(sorted(PIPELINE_CONFIG_REGISTRY.get_supported_archs()))
+            supported = ", ".join(
+                sorted(PIPELINE_CONFIG_REGISTRY.get_supported_archs())
+            )
             raise ValueError(
                 f"Could not resolve model architecture for {model_path!r}. "
                 "Use a Hugging Face model id or a local directory with config.json "

--- a/sglang_omni/config/manager.py
+++ b/sglang_omni/config/manager.py
@@ -9,6 +9,7 @@ from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 from sglang_omni.utils.hf import (
     architecture_from_hf_config,
     try_resolve_arch_from_mistral_config,
+    try_resolve_arch_from_raw_config,
 )
 
 
@@ -103,7 +104,9 @@ class ConfigManager:
 
         # 1) Hugging Face: local snapshot or hub id (hub ids have no local config.json)
         try:
-            hf_config = AutoConfig.from_pretrained(model_path)
+            hf_config = AutoConfig.from_pretrained(
+                model_path, trust_remote_code=True
+            )
             arch = architecture_from_hf_config(hf_config)
         except Exception:
             pass
@@ -112,11 +115,17 @@ class ConfigManager:
         if arch is None:
             arch = try_resolve_arch_from_mistral_config(model_path)
 
+        # 3) Raw config.json fallback (e.g. models needing trust_remote_code)
         if arch is None:
+            arch = try_resolve_arch_from_raw_config(model_path)
+
+        if arch is None:
+            supported = ", ".join(sorted(PIPELINE_CONFIG_REGISTRY.get_supported_archs()))
             raise ValueError(
                 f"Could not resolve model architecture for {model_path!r}. "
                 "Use a Hugging Face model id or a local directory with config.json "
-                "(architectures) or Mistral params.json (model_type, e.g. voxtral_tts)."
+                "(architectures) or Mistral params.json (model_type, e.g. voxtral_tts). "
+                f"Supported architectures: {supported}"
             )
 
         config_cls = PIPELINE_CONFIG_REGISTRY.get_config(arch)

--- a/sglang_omni/models/ming_omni/__init__.py
+++ b/sglang_omni/models/ming_omni/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 """Ming-Omni model integration for sglang-omni."""
 
-from . import config
+from . import config  # noqa: F401

--- a/sglang_omni/models/ming_omni/__init__.py
+++ b/sglang_omni/models/ming_omni/__init__.py
@@ -1,2 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 """Ming-Omni model integration for sglang-omni."""
+
+from . import config

--- a/sglang_omni/models/ming_omni/components/common.py
+++ b/sglang_omni/models/ming_omni/components/common.py
@@ -17,35 +17,57 @@ from sglang_omni.models.weight_loader import resolve_model_path
 
 logger = logging.getLogger(__name__)
 
+# Known subdirectories where Ming repos store tokenizer files.
+_TOKENIZER_SUBDIRS = ("talker/llm",)
+
 # Fallback tokenizer source: Ming-flash-omni-Preview has tokenizer files
-# that are missing from some other Ming repos (e.g., Ming-flash-omni-2.0).
+# at the repo root, used only as a last resort.
 _TOKENIZER_FALLBACK = "inclusionAI/Ming-flash-omni-Preview"
 
 
 def load_ming_tokenizer(model_path: str):
-    """Load the Ming tokenizer with fallback for incomplete HF repos.
+    """Load the Ming tokenizer, searching subdirectories before falling back.
 
-    Some Ming HF repos (e.g., Ming-flash-omni-2.0) are missing tokenizer
-    files and custom Python code.  We try several strategies:
-    1. AutoTokenizer with trust_remote_code
-    2. PreTrainedTokenizerFast directly (skips custom class requirement)
-    3. Fallback to Ming-flash-omni-Preview repo (same vocab)
+    Ming HF repos may store tokenizer files in subdirectories (e.g.
+    ``talker/llm/``) rather than at the repo root.  We try:
+    1. AutoTokenizer from the root path (with trust_remote_code)
+    2. PreTrainedTokenizerFast from the root path
+    3. Known subdirectories (talker/llm) that ship tokenizer files
+    4. Fallback to Ming-flash-omni-Preview repo (same vocab)
     """
     from transformers import AutoTokenizer, PreTrainedTokenizerFast
 
-    # Strategy 1: standard AutoTokenizer
+    # Strategy 1: standard AutoTokenizer at root
     try:
         return AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
     except (OSError, ValueError):
         pass
 
-    # Strategy 2: direct PreTrainedTokenizerFast (works if tokenizer.json exists)
+    # Strategy 2: direct PreTrainedTokenizerFast at root
     try:
         return PreTrainedTokenizerFast.from_pretrained(model_path)
     except Exception:
         pass
 
-    # Strategy 3: fallback repo with matching vocab
+    # Strategy 3: check known subdirectories (local snapshots only)
+    resolved = resolve_model_path(model_path)
+    for subdir in _TOKENIZER_SUBDIRS:
+        subpath = Path(resolved) / subdir
+        if (subpath / "tokenizer.json").is_file() or (
+            subpath / "tokenizer_config.json"
+        ).is_file():
+            try:
+                return AutoTokenizer.from_pretrained(
+                    str(subpath), trust_remote_code=True
+                )
+            except (OSError, ValueError):
+                pass
+            try:
+                return PreTrainedTokenizerFast.from_pretrained(str(subpath))
+            except Exception:
+                pass
+
+    # Strategy 4: fallback repo with matching vocab
     logger.warning(
         "Tokenizer not found in %s, falling back to %s",
         model_path,

--- a/sglang_omni/models/ming_omni/components/common.py
+++ b/sglang_omni/models/ming_omni/components/common.py
@@ -8,6 +8,8 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 
+from huggingface_hub import hf_hub_download
+
 from sglang_omni.models.ming_omni.hf_config import (
     AudioConfig,
     BailingMoeV2LLMConfig,
@@ -19,10 +21,37 @@ logger = logging.getLogger(__name__)
 
 # Known subdirectories where Ming repos store tokenizer files.
 _TOKENIZER_SUBDIRS = ("talker/llm",)
+_TOKENIZER_FILES = ("tokenizer.json", "tokenizer_config.json")
 
 # Fallback tokenizer source: Ming-flash-omni-Preview has tokenizer files
 # at the repo root, used only as a last resort.
 _TOKENIZER_FALLBACK = "inclusionAI/Ming-flash-omni-Preview"
+
+
+def _resolve_local_tokenizer_subdir(model_path: str) -> Path | None:
+    base = Path(model_path)
+    if not base.exists():
+        return None
+    for subdir in _TOKENIZER_SUBDIRS:
+        subpath = base / subdir
+        if any((subpath / filename).is_file() for filename in _TOKENIZER_FILES):
+            return subpath
+    return None
+
+
+def _download_tokenizer_subdir_from_hub(model_path: str) -> Path | None:
+    for subdir in _TOKENIZER_SUBDIRS:
+        for filename in _TOKENIZER_FILES:
+            try:
+                cached = hf_hub_download(
+                    repo_id=model_path,
+                    filename=filename,
+                    subfolder=subdir,
+                )
+            except Exception:
+                continue
+            return Path(cached).parent
+    return None
 
 
 def load_ming_tokenizer(model_path: str):
@@ -32,7 +61,7 @@ def load_ming_tokenizer(model_path: str):
     ``talker/llm/``) rather than at the repo root.  We try:
     1. AutoTokenizer from the root path (with trust_remote_code)
     2. PreTrainedTokenizerFast from the root path
-    3. Known subdirectories (talker/llm) that ship tokenizer files
+    3. Known subdirectories (talker/llm), local first then selective Hub probe
     4. Fallback to Ming-flash-omni-Preview repo (same vocab)
     """
     from transformers import AutoTokenizer, PreTrainedTokenizerFast
@@ -49,23 +78,34 @@ def load_ming_tokenizer(model_path: str):
     except Exception:
         pass
 
-    # Strategy 3: check known subdirectories (local snapshots only)
-    resolved = resolve_model_path(model_path)
-    for subdir in _TOKENIZER_SUBDIRS:
-        subpath = Path(resolved) / subdir
-        if (subpath / "tokenizer.json").is_file() or (
-            subpath / "tokenizer_config.json"
-        ).is_file():
-            try:
-                return AutoTokenizer.from_pretrained(
-                    str(subpath), trust_remote_code=True
-                )
-            except (OSError, ValueError):
-                pass
-            try:
-                return PreTrainedTokenizerFast.from_pretrained(str(subpath))
-            except Exception:
-                pass
+    # Strategy 3a: check known subdirectories for local paths
+    local_subpath = _resolve_local_tokenizer_subdir(model_path)
+    if local_subpath is not None:
+        try:
+            return AutoTokenizer.from_pretrained(
+                str(local_subpath), trust_remote_code=True
+            )
+        except (OSError, ValueError):
+            pass
+        try:
+            return PreTrainedTokenizerFast.from_pretrained(str(local_subpath))
+        except Exception:
+            pass
+
+    # Strategy 3b: probe known subdirectories on Hub by downloading only
+    # tokenizer files, avoiding a full snapshot download.
+    remote_subpath = _download_tokenizer_subdir_from_hub(model_path)
+    if remote_subpath is not None:
+        try:
+            return AutoTokenizer.from_pretrained(
+                str(remote_subpath), trust_remote_code=True
+            )
+        except (OSError, ValueError):
+            pass
+        try:
+            return PreTrainedTokenizerFast.from_pretrained(str(remote_subpath))
+        except Exception:
+            pass
 
     # Strategy 4: fallback repo with matching vocab
     logger.warning(

--- a/sglang_omni/models/registry.py
+++ b/sglang_omni/models/registry.py
@@ -23,16 +23,33 @@ def import_pipeline_configs(
         # if this is a package, we import it
         if ispkg:
             try:
-                module = importlib.import_module(name)
+                importlib.import_module(name)
             except Exception as e:
                 if strict:
                     raise
                 logger.warning(f"Ignore import error when loading {name}: {e}")
                 continue
+            expected_config_module = f"{name}.{config_path}"
             try:
-                config_module = importlib.import_module(f"{name}.{config_path}")
-            except ImportError:
-                logger.debug(f"Skipping {name}: no submodule {config_path}")
+                config_module = importlib.import_module(expected_config_module)
+            except ModuleNotFoundError as e:
+                if e.name == expected_config_module:
+                    if strict:
+                        raise
+                    logger.debug(f"Skipping {name}: no submodule {config_path}")
+                    continue
+                if strict:
+                    raise
+                logger.warning(
+                    f"Ignore import error when loading {expected_config_module}: {e}"
+                )
+                continue
+            except ImportError as e:
+                if strict:
+                    raise
+                logger.warning(
+                    f"Ignore import error when loading {expected_config_module}: {e}"
+                )
                 continue
             if not hasattr(config_module, "EntryClass"):
                 raise AssertionError(

--- a/sglang_omni/models/registry.py
+++ b/sglang_omni/models/registry.py
@@ -29,15 +29,17 @@ def import_pipeline_configs(
                     raise
                 logger.warning(f"Ignore import error when loading {name}: {e}")
                 continue
-            if hasattr(module, config_path):
-                config_module = getattr(module, config_path)
-                assert hasattr(
-                    config_module, "EntryClass"
-                ), f"Config module {module.__name__} must have an EntryClass in its submodule {config_path}"
-                config_cls = getattr(config_module, "EntryClass")
-                model_arch_to_config_cls[config_cls.architecture] = config_cls
-            else:
-                logger.debug(f"Skipping {module.__name__}: no submodule {config_path}")
+            try:
+                config_module = importlib.import_module(f"{name}.{config_path}")
+            except ImportError:
+                logger.debug(f"Skipping {name}: no submodule {config_path}")
+                continue
+            if not hasattr(config_module, "EntryClass"):
+                raise AssertionError(
+                    f"Config module {name}.{config_path} must have an EntryClass"
+                )
+            config_cls = config_module.EntryClass
+            model_arch_to_config_cls[config_cls.architecture] = config_cls
     return model_arch_to_config_cls
 
 

--- a/sglang_omni/utils/hf.py
+++ b/sglang_omni/utils/hf.py
@@ -72,6 +72,50 @@ def try_resolve_arch_from_mistral_config(model_path: str) -> str | None:
     return _CONFIG_MODEL_TYPE_TO_ARCH.get(model_type)
 
 
+def try_resolve_arch_from_raw_config(model_path: str) -> str | None:
+    """Resolve architecture by reading raw ``config.json`` as plain JSON.
+
+    This is useful when ``AutoConfig.from_pretrained`` fails (e.g. because the
+    model requires ``trust_remote_code=True`` and the custom Python config
+    module is unavailable).  We parse the JSON directly to extract
+    ``architectures`` or map ``model_type``.
+    """
+    raw: dict | None = None
+
+    # Try local path first
+    local_config = os.path.join(model_path, "config.json")
+    if os.path.isfile(local_config):
+        with open(local_config) as f:
+            raw = json.load(f)
+    elif not os.path.isdir(model_path):
+        # Treat as a Hub repo id — download config.json
+        try:
+            from huggingface_hub import hf_hub_download
+
+            cached = hf_hub_download(repo_id=model_path, filename="config.json")
+            with open(cached) as f:
+                raw = json.load(f)
+        except Exception:
+            return None
+
+    if raw is None:
+        return None
+
+    # Prefer architectures list
+    archs = raw.get("architectures")
+    if archs:
+        for a in archs:
+            if a:
+                return a
+
+    # Fall back to model_type mapping
+    mt = raw.get("model_type")
+    if mt and mt in _CONFIG_MODEL_TYPE_TO_ARCH:
+        return _CONFIG_MODEL_TYPE_TO_ARCH[mt]
+
+    return None
+
+
 # ---------------------------------------------------------------------------
 # HF config loading
 # ---------------------------------------------------------------------------

--- a/tests/test_ming_architecture_resolution.py
+++ b/tests/test_ming_architecture_resolution.py
@@ -15,7 +15,6 @@ import tempfile
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Test 1 – Registry discovers Ming architecture
 # ---------------------------------------------------------------------------
@@ -26,9 +25,9 @@ def test_registry_discovers_ming_architecture():
     from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 
     supported = PIPELINE_CONFIG_REGISTRY.get_supported_archs()
-    assert "BailingMM2NativeForConditionalGeneration" in supported, (
-        f"Ming architecture not found in registry. Registered: {sorted(supported)}"
-    )
+    assert (
+        "BailingMM2NativeForConditionalGeneration" in supported
+    ), f"Ming architecture not found in registry. Registered: {sorted(supported)}"
 
 
 def test_registry_returns_ming_config_class():

--- a/tests/test_ming_architecture_resolution.py
+++ b/tests/test_ming_architecture_resolution.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 import json
 import os
 import tempfile
-from functools import lru_cache
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_ming_architecture_resolution.py
+++ b/tests/test_ming_architecture_resolution.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for Ming model architecture resolution (issue #273).
+
+Covers:
+- Registry discovery finds Ming architecture even without __init__.py re-export
+- ConfigManager.from_model_path resolves Ming via raw config.json fallback
+- Unsupported models still raise clear errors
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from functools import lru_cache
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test 1 – Registry discovers Ming architecture
+# ---------------------------------------------------------------------------
+
+
+def test_registry_discovers_ming_architecture():
+    """BailingMM2NativeForConditionalGeneration must appear in the registry."""
+    from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+
+    supported = PIPELINE_CONFIG_REGISTRY.get_supported_archs()
+    assert "BailingMM2NativeForConditionalGeneration" in supported, (
+        f"Ming architecture not found in registry. Registered: {sorted(supported)}"
+    )
+
+
+def test_registry_returns_ming_config_class():
+    """Registry should map Ming architecture to MingOmniPipelineConfig."""
+    from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+
+    config_cls = PIPELINE_CONFIG_REGISTRY.get_config(
+        "BailingMM2NativeForConditionalGeneration"
+    )
+    assert config_cls.__name__ == "MingOmniPipelineConfig"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 – Raw config.json fallback resolves architecture
+# ---------------------------------------------------------------------------
+
+
+def test_raw_config_json_resolves_architecture():
+    """try_resolve_arch_from_raw_config should parse architectures from JSON."""
+    from sglang_omni.utils.hf import try_resolve_arch_from_raw_config
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = os.path.join(tmpdir, "config.json")
+        with open(config_path, "w") as f:
+            json.dump(
+                {
+                    "architectures": ["BailingMM2NativeForConditionalGeneration"],
+                    "model_type": "bailingmm_moe_v2_lite",
+                },
+                f,
+            )
+        arch = try_resolve_arch_from_raw_config(tmpdir)
+    assert arch == "BailingMM2NativeForConditionalGeneration"
+
+
+def test_raw_config_json_falls_back_to_model_type():
+    """When architectures list is empty, try model_type mapping."""
+    from sglang_omni.utils.hf import try_resolve_arch_from_raw_config
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = os.path.join(tmpdir, "config.json")
+        with open(config_path, "w") as f:
+            json.dump({"model_type": "voxtral_tts"}, f)
+        arch = try_resolve_arch_from_raw_config(tmpdir)
+    assert arch == "VoxtralTTSForConditionalGeneration"
+
+
+def test_raw_config_json_returns_none_for_unknown():
+    """Unknown model_type and no architectures → None."""
+    from sglang_omni.utils.hf import try_resolve_arch_from_raw_config
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = os.path.join(tmpdir, "config.json")
+        with open(config_path, "w") as f:
+            json.dump({"model_type": "unknown_model"}, f)
+        arch = try_resolve_arch_from_raw_config(tmpdir)
+    assert arch is None
+
+
+def test_raw_config_json_returns_none_for_missing_file():
+    """No config.json at all → None."""
+    from sglang_omni.utils.hf import try_resolve_arch_from_raw_config
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        arch = try_resolve_arch_from_raw_config(tmpdir)
+    assert arch is None
+
+
+# ---------------------------------------------------------------------------
+# Test 3 – ConfigManager.from_model_path resolves Ming from local config.json
+# ---------------------------------------------------------------------------
+
+
+def test_config_manager_resolves_ming_from_local_config():
+    """from_model_path should resolve Ming via raw config.json when AutoConfig fails."""
+    from sglang_omni.config.manager import ConfigManager
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = os.path.join(tmpdir, "config.json")
+        with open(config_path, "w") as f:
+            json.dump(
+                {
+                    "architectures": ["BailingMM2NativeForConditionalGeneration"],
+                    "model_type": "bailingmm_moe_v2_lite",
+                },
+                f,
+            )
+
+        mgr = ConfigManager.from_model_path(tmpdir)
+    assert mgr.config is not None
+    assert type(mgr.config).__name__ == "MingOmniPipelineConfig"
+
+
+# ---------------------------------------------------------------------------
+# Test 4 – Unsupported models still raise clear error
+# ---------------------------------------------------------------------------
+
+
+def test_unsupported_model_raises_clear_error():
+    """Completely unknown architecture should raise ValueError with architecture list."""
+    from sglang_omni.config.manager import ConfigManager
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = os.path.join(tmpdir, "config.json")
+        with open(config_path, "w") as f:
+            json.dump(
+                {"architectures": ["TotallyUnknownArchitecture"]},
+                f,
+            )
+
+        with pytest.raises(ValueError, match="TotallyUnknownArchitecture"):
+            ConfigManager.from_model_path(tmpdir)
+
+
+def test_no_config_at_all_raises_clear_error():
+    """Empty directory with no config files should raise ValueError."""
+    from sglang_omni.config.manager import ConfigManager
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with pytest.raises(ValueError, match="Could not resolve model architecture"):
+            ConfigManager.from_model_path(tmpdir)

--- a/tests/test_ming_tokenizer_loading.py
+++ b/tests/test_ming_tokenizer_loading.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Ming tokenizer loading subdirectory behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sglang_omni.models.ming_omni.components import common
+
+
+def test_load_ming_tokenizer_probes_hub_subdir_without_full_snapshot(
+    monkeypatch, tmp_path: Path
+):
+    sentinel = object()
+
+    def fail_resolve_model_path(*args, **kwargs):
+        raise AssertionError(
+            "resolve_model_path should not be used for tokenizer probes"
+        )
+
+    def fake_hf_hub_download(repo_id: str, filename: str, subfolder: str | None = None):
+        assert repo_id == "org/model"
+        assert subfolder == "talker/llm"
+        if filename != "tokenizer.json":
+            raise FileNotFoundError(filename)
+        cached_file = tmp_path / "hub" / "snap" / "talker" / "llm" / filename
+        cached_file.parent.mkdir(parents=True, exist_ok=True)
+        cached_file.write_text("{}", encoding="utf-8")
+        return str(cached_file)
+
+    def fake_auto_from_pretrained(path: str, trust_remote_code: bool = False, **kwargs):
+        if path == "org/model":
+            raise OSError("root tokenizer not found")
+        if path.endswith("talker/llm"):
+            return sentinel
+        raise OSError(path)
+
+    def fake_fast_from_pretrained(path: str, **kwargs):
+        if path == "org/model":
+            raise OSError("root tokenizer not found")
+        raise OSError(path)
+
+    monkeypatch.setattr(common, "resolve_model_path", fail_resolve_model_path)
+    monkeypatch.setattr(common, "hf_hub_download", fake_hf_hub_download)
+
+    import transformers
+
+    monkeypatch.setattr(
+        transformers.AutoTokenizer, "from_pretrained", fake_auto_from_pretrained
+    )
+    monkeypatch.setattr(
+        transformers.PreTrainedTokenizerFast,
+        "from_pretrained",
+        fake_fast_from_pretrained,
+    )
+
+    tokenizer = common.load_ming_tokenizer("org/model")
+    assert tokenizer is sentinel
+
+
+def test_load_ming_tokenizer_prefers_local_subdir_without_hub_probe(
+    monkeypatch, tmp_path: Path
+):
+    sentinel = object()
+    model_dir = tmp_path / "local_model"
+    tokenizer_dir = model_dir / "talker" / "llm"
+    tokenizer_dir.mkdir(parents=True)
+    (tokenizer_dir / "tokenizer.json").write_text("{}", encoding="utf-8")
+
+    def fail_resolve_model_path(*args, **kwargs):
+        raise AssertionError(
+            "resolve_model_path should not be used for tokenizer probes"
+        )
+
+    def fail_hf_hub_download(*args, **kwargs):
+        raise AssertionError("hf_hub_download should not be called for local paths")
+
+    def fake_auto_from_pretrained(path: str, trust_remote_code: bool = False, **kwargs):
+        if path == str(model_dir):
+            raise OSError("root tokenizer not found")
+        if path == str(tokenizer_dir):
+            return sentinel
+        raise OSError(path)
+
+    def fake_fast_from_pretrained(path: str, **kwargs):
+        if path == str(model_dir):
+            raise OSError("root tokenizer not found")
+        raise OSError(path)
+
+    monkeypatch.setattr(common, "resolve_model_path", fail_resolve_model_path)
+    monkeypatch.setattr(common, "hf_hub_download", fail_hf_hub_download)
+
+    import transformers
+
+    monkeypatch.setattr(
+        transformers.AutoTokenizer, "from_pretrained", fake_auto_from_pretrained
+    )
+    monkeypatch.setattr(
+        transformers.PreTrainedTokenizerFast,
+        "from_pretrained",
+        fake_fast_from_pretrained,
+    )
+
+    tokenizer = common.load_ming_tokenizer(str(model_dir))
+    assert tokenizer is sentinel

--- a/tests/test_registry_import_pipeline_configs.py
+++ b/tests/test_registry_import_pipeline_configs.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for pipeline config discovery import error handling."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+from sglang_omni.models.registry import import_pipeline_configs
+
+
+def _clear_modules(prefix: str) -> None:
+    for name in list(sys.modules):
+        if name == prefix or name.startswith(f"{prefix}."):
+            sys.modules.pop(name, None)
+
+
+def _build_package(
+    base_dir: Path,
+    package_name: str,
+    model_pkg_name: str,
+    config_source: str | None,
+) -> None:
+    package_dir = base_dir / package_name
+    package_dir.mkdir(parents=True)
+    (package_dir / "__init__.py").write_text("", encoding="utf-8")
+
+    model_dir = package_dir / model_pkg_name
+    model_dir.mkdir(parents=True)
+    (model_dir / "__init__.py").write_text("", encoding="utf-8")
+
+    if config_source is not None:
+        (model_dir / "config.py").write_text(config_source, encoding="utf-8")
+
+
+def test_missing_config_submodule_respects_strict_flag(monkeypatch, tmp_path: Path):
+    package_name = "tmp_models_missing_cfg"
+    _build_package(
+        tmp_path,
+        package_name=package_name,
+        model_pkg_name="model_a",
+        config_source=None,
+    )
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    import_pipeline_configs.cache_clear()
+    _clear_modules(package_name)
+
+    discovered = import_pipeline_configs(package_name, "config", strict=False)
+    assert discovered == {}
+
+    import_pipeline_configs.cache_clear()
+    _clear_modules(package_name)
+
+    with pytest.raises(ModuleNotFoundError):
+        import_pipeline_configs(package_name, "config", strict=True)
+
+
+def test_config_internal_import_error_respects_strict_flag(
+    monkeypatch, tmp_path: Path, caplog
+):
+    package_name = "tmp_models_broken_cfg"
+    _build_package(
+        tmp_path,
+        package_name=package_name,
+        model_pkg_name="model_b",
+        config_source="import definitely_missing_dependency\n",
+    )
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    import_pipeline_configs.cache_clear()
+    _clear_modules(package_name)
+
+    caplog.set_level(logging.WARNING)
+    discovered = import_pipeline_configs(package_name, "config", strict=False)
+    assert discovered == {}
+    assert any(
+        f"Ignore import error when loading {package_name}.model_b.config"
+        in record.message
+        for record in caplog.records
+    )
+
+    import_pipeline_configs.cache_clear()
+    _clear_modules(package_name)
+
+    with pytest.raises(ModuleNotFoundError):
+        import_pipeline_configs(package_name, "config", strict=True)


### PR DESCRIPTION
## Motivation

Fixes #273. `sgl-omni serve --model-path inclusionAI/Ming-flash-omni-2.0` fails with:

```
ValueError: Could not resolve model architecture for 'inclusionAI/Ming-flash-omni-2.0'
```

Ming is an integrated model family but startup from model ID fails before pipeline launch due to two independent bugs in model discovery/resolution.

## Root Cause

- **Registry discovery misses Ming.** `import_pipeline_configs()` checks `hasattr(module, config_path)` on the package module, which only works if the package `__init__.py` re-exports the `config` submodule. All other model packages (`qwen3_omni`, `voxtral_tts`, `fishaudio_s2_pro`) do this, but `ming_omni/__init__.py` was empty. Result: `BailingMM2NativeForConditionalGeneration` never gets registered.

- **Architecture resolver too narrow.** `ConfigManager.from_model_path()` calls `AutoConfig.from_pretrained()` without `trust_remote_code=True`, which fails for Ming since `bailingmm_moe_v2_lite` isn't in transformers' built-in registry. The only fallback is Mistral `params.json`, which Ming doesn't have. Additionally, the Ming HF repo declares `auto_map` pointing to `configuration_bailingmm2.py` but does not ship that file, so even `trust_remote_code=True` alone doesn't resolve it — the `architectures` field is only available in the raw JSON.

**Also fixed where Tokenizer was loading from wrong source.** `load_ming_tokenizer()` looks for tokenizer files at the repo root, but `Ming-flash-omni-2.0` stores them under `talker/llm/`. The function falls back to a different repo (`Ming-flash-omni-Preview`) instead of checking known subdirectories.

## Modifications

### Commit 1: `fix(registry): import config submodule directly during discovery`
- **`sglang_omni/models/registry.py`**: Replace `hasattr(module, config_path)` + `getattr()` with `importlib.import_module(f"{name}.{config_path}")`. Discovery now imports `config` submodules directly, independent of `__init__.py` re-exports.
- **`sglang_omni/models/ming_omni/__init__.py`**: Add `from . import config` for consistency with other model packages.

### Commit 2: `fix(config): add raw config.json fallback for architecture resolution`
- **`sglang_omni/config/manager.py`**: Add `trust_remote_code=True` to `AutoConfig.from_pretrained()`. Add step 3 fallback to `try_resolve_arch_from_raw_config()`. Improve error message to list supported architectures.
- **`sglang_omni/utils/hf.py`**: Add `try_resolve_arch_from_raw_config()` — reads `config.json` as plain JSON (local or HF Hub) to extract `architectures` or map `model_type`, bypassing `AutoConfig` entirely.

Resolution order:
1. `AutoConfig.from_pretrained` (with `trust_remote_code=True`)
2. Mistral `params.json` mapping
3. Raw `config.json` JSON parse (new)
4. `ValueError` with supported architecture list

### Commit 3: `fix(ming): search subdirectories for tokenizer before fallback repo`
- **`sglang_omni/models/ming_omni/components/common.py`**: Search `_TOKENIZER_SUBDIRS` (`talker/llm`) in the local snapshot before falling back to the external `Ming-flash-omni-Preview` repo.

### Commit 4: `test: add regression tests for Ming architecture resolution`
- **`tests/test_ming_architecture_resolution.py`**: 9 tests covering registry discovery, raw config.json fallback (architectures, model_type, unknown, missing), ConfigManager end-to-end resolution, and clear error messages for unsupported models.

## Validation

- `PIPELINE_CONFIG_REGISTRY.get_supported_archs()` includes `BailingMM2NativeForConditionalGeneration`
- Unsupported model IDs still fail with clear, intentional messaging including the supported architecture list
- All 57 existing unit tests pass, plus 9 new regression tests

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
