### PR TITLE
[CI]: Separated qwen3-omni CI stage

### DIFF
--- a/.github/actions/qwen3-omni-setup/action.yaml
+++ b/.github/actions/qwen3-omni-setup/action.yaml
@@ -39,6 +39,10 @@ runs:
           echo "Prepared omni-qwen3 environment is missing. Run the docs stage first."
           exit 1
         }
+        omni-qwen3/bin/python -c "import torch" 2>/dev/null || {
+          echo "Cached venv is corrupted (torch not importable). Re-run the docs stage."
+          exit 1
+        }
 
     - name: Remove flashinfer
       shell: bash

--- a/.github/actions/qwen3-omni-setup/action.yaml
+++ b/.github/actions/qwen3-omni-setup/action.yaml
@@ -1,0 +1,51 @@
+name: Qwen3-Omni CI Setup
+description: Restore the prepared Qwen3-Omni environment and run common pre-test setup.
+
+inputs:
+  install-deps:
+    description: Prepare the shared omni-qwen3 virtualenv.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Restore cache
+      shell: bash
+      run: |
+        if [ -d /github/home/omni-qwen3 ] && [ ! -z "$(ls -A /github/home/omni-qwen3/)" ]; then
+          cp -p -r /github/home/omni-qwen3 ./omni-qwen3
+        fi
+
+    - name: Install dependencies
+      if: ${{ inputs.install-deps == 'true' }}
+      shell: bash
+      run: |
+        if [ -d omni-qwen3 ] && ! omni-qwen3/bin/python -c "import torch" 2>/dev/null; then
+          echo "Cached venv is corrupted, removing..."
+          rm -rf omni-qwen3
+        fi
+        if [ ! -d omni-qwen3 ]; then
+          uv venv omni-qwen3 -p 3.11
+        fi
+        source omni-qwen3/bin/activate
+        uv pip install -v -e ".[dev]"
+
+    - name: Validate prepared environment
+      if: ${{ inputs.install-deps != 'true' }}
+      shell: bash
+      run: |
+        test -x omni-qwen3/bin/python || {
+          echo "Prepared omni-qwen3 environment is missing. Run the docs stage first."
+          exit 1
+        }
+
+    - name: Remove flashinfer
+      shell: bash
+      run: |
+        rm -rf /github/home/.cache/flashinfer
+
+    - name: Kill GPU processes
+      shell: bash
+      run: |
+        bash .github/scripts/delete_gpu_process.sh

--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -16,7 +16,7 @@ jobs:
   docs:
     name: docs
     runs-on: [self-hosted]
-    timeout-minutes: 30
+    timeout-minutes: 15
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -54,7 +54,7 @@ jobs:
     name: stage 1 - TTS speed + WER
     needs: docs
     runs-on: [self-hosted]
-    timeout-minutes: 90
+    timeout-minutes: 15
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -95,7 +95,7 @@ jobs:
     name: stage 2 - MMMU accuracy + speed
     needs: stage-1-tts
     runs-on: [self-hosted]
-    timeout-minutes: 90
+    timeout-minutes: 20
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -135,7 +135,7 @@ jobs:
     name: stage 3 - MMMU TTS consistency
     needs: stage-2-mmmu
     runs-on: [self-hosted]
-    timeout-minutes: 90
+    timeout-minutes: 15
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm

--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -13,8 +13,10 @@ permissions:
   contents: read
 
 jobs:
-  qwen3-omni-ci:
+  docs:
+    name: docs
     runs-on: [self-hosted]
+    timeout-minutes: 30
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -22,36 +24,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Restore cache
-        run: |
-          if [ -d /github/home/omni-qwen3 ] && [ ! -z "$(ls -A /github/home/omni-qwen3/)" ]; then
-            cp -p -r /github/home/omni-qwen3 ./omni-qwen3
-          fi
-
-      - name: Remove flashinfer
-        run: |
-          rm -rf /github/home/.cache/flashinfer
-
-      - name: Install dependencies
-        shell: bash
-        run: |
-          if [ -d omni-qwen3 ] && ! omni-qwen3/bin/python -c "import torch" 2>/dev/null; then
-            echo "Cached venv is corrupted, removing..."
-            rm -rf omni-qwen3
-          fi
-          if [ ! -d omni-qwen3 ]; then
-            uv venv omni-qwen3 -p 3.11
-          fi
-          source omni-qwen3/bin/activate
-          uv pip install -v -e ".[dev]"
-
-      - name: Kill GPU processes
-        shell: bash
-        run: |
-          bash .github/scripts/delete_gpu_process.sh
+      - uses: ./.github/actions/qwen3-omni-setup
+        with:
+          install-deps: "true"
 
       - name: Run docs tests
-        timeout-minutes: 60
         shell: bash
         run: |
           source omni-qwen3/bin/activate
@@ -66,8 +43,28 @@ jobs:
         run: |
           bash .github/scripts/delete_gpu_process.sh
 
+      - name: Save cache
+        if: always()
+        shell: bash
+        run: |
+          rm -rf /github/home/omni-qwen3
+          cp -p -r omni-qwen3 /github/home/
+
+  stage-1-tts:
+    name: stage 1 - TTS speed + WER
+    needs: docs
+    runs-on: [self-hosted]
+    timeout-minutes: 90
+    container:
+      image: frankleeeee/sglang-omni:dev
+      options: --gpus all --rm -v /dev/shm:/dev/shm
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/qwen3-omni-setup
+
       - name: Run TTS CI (speed + WER)
-        timeout-minutes: 60
         shell: bash
         run: |
           source omni-qwen3/bin/activate
@@ -93,8 +90,21 @@ jobs:
         run: |
           bash .github/scripts/delete_gpu_process.sh
 
+  stage-2-mmmu:
+    name: stage 2 - MMMU accuracy + speed
+    needs: stage-1-tts
+    runs-on: [self-hosted]
+    timeout-minutes: 90
+    container:
+      image: frankleeeee/sglang-omni:dev
+      options: --gpus all --rm -v /dev/shm:/dev/shm
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/qwen3-omni-setup
+
       - name: Run MMMU CI (accuracy + speed)
-        timeout-minutes: 60
         shell: bash
         run: |
           source omni-qwen3/bin/activate
@@ -120,8 +130,21 @@ jobs:
         run: |
           bash .github/scripts/delete_gpu_process.sh
 
+  stage-3-mmmu-tts-consistency:
+    name: stage 3 - MMMU TTS consistency
+    needs: stage-2-mmmu
+    runs-on: [self-hosted]
+    timeout-minutes: 90
+    container:
+      image: frankleeeee/sglang-omni:dev
+      options: --gpus all --rm -v /dev/shm:/dev/shm
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/qwen3-omni-setup
+
       - name: Run MMMU TTS Consistency CI (WER + speed)
-        timeout-minutes: 60
         shell: bash
         run: |
           source omni-qwen3/bin/activate
@@ -141,6 +164,8 @@ jobs:
             echo ""
           done
 
-      - name: Save cache
+      - name: Kill GPU processes
+        if: always()
+        shell: bash
         run: |
-          cp -p -r omni-qwen3 /github/home/
+          bash .github/scripts/delete_gpu_process.sh

--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -170,4 +170,3 @@ jobs:
         shell: bash
         run: |
           bash .github/scripts/delete_gpu_process.sh
-ma

--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -72,6 +72,7 @@ jobs:
           pytest tests/test_model/test_qwen3_omni_tts_ci.py -v -s -x
         env:
           HF_ENDPOINT: https://hf-mirror.com
+          SGLANG_SEEDTTS_MINI_DIR: /github/home/seedtts-mini
 
       - name: Print TTS CI artifacts (speed + WER)
         if: always()
@@ -169,3 +170,4 @@ jobs:
         shell: bash
         run: |
           bash .github/scripts/delete_gpu_process.sh
+ma

--- a/tests/test_model/test_qwen3_omni_tts_ci.py
+++ b/tests/test_model/test_qwen3_omni_tts_ci.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -43,6 +44,8 @@ MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
 
 CONCURRENCY = 1
 MAX_SAMPLES = 10
+# Also used in .github/workflows/test-qwen3-omni-ci.yaml — keep in sync.
+DATASET_CACHE_ENV = "SGLANG_SEEDTTS_MINI_DIR"
 
 STARTUP_TIMEOUT = 900
 WER_TIMEOUT = 600
@@ -204,7 +207,11 @@ def _run_wer_transcribe(
 
 @pytest.fixture(scope="module")
 def dataset_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    root = tmp_path_factory.mktemp("seed_tts_eval") / "data"
+    override_dir = os.environ.get(DATASET_CACHE_ENV)
+    if override_dir:
+        root = Path(override_dir).expanduser()
+    else:
+        root = tmp_path_factory.mktemp("seed_tts_eval") / "data"
     download_dataset(DATASETS["seedtts-mini"], str(root))
     return root
 


### PR DESCRIPTION
## Motivation
Follow up discussion: https://github.com/sgl-project/sglang-omni/issues/274#issuecomment-4232850253
Split the Qwen3-Omni CI into separate GitHub jobs so failed stages can be retried
with GitHub's built-in "Re-run failed jobs" flow instead of rerunning the full
test suite.

This follows the same pattern established for S2-Pro in #278.

## Root Cause

The previous Qwen3-Omni workflow ran all test stages (docs, TTS, MMMU, MMMU-TTS
consistency) inside one CI job. A failure in any stage required rerunning the
entire job from scratch, wasting CI time on stages that had already passed.

## Modifications

**`.github/actions/qwen3-omni-setup/action.yaml`** (new)
- Extracted shared setup logic (restore cached venv, dependency install,
  environment validation, cleanup logic).

**`.github/workflows/test-qwen3-omni-ci.yaml`**
- Replaced monolithic `qwen3-omni-ci` job with four chained jobs:
  - `docs` (installs deps, saves venv cache)
  - `stage-1-tts` (TTS speed + WER)
  - `stage-2-mmmu` (MMMU accuracy + speed)
  - `stage-3-mmmu-tts-consistency` (MMMU TTS consistency)
- Added strict `needs` dependency chain: `docs → stage-1 → stage-2 → stage-3`.
- Preserved exact pytest commands, env settings, and runtime semantics.

**Note:** Job-level `timeout-minutes` values (docs: 30, stages: 90) are conservative
initial estimates, yet to be discussed.

## Accuracy Tests

NA

## Speed Tests and Profiling

NA