### PR TITLE
Fix Qwen3-Omni variable-length audio batching in encoder runtime

### DIFF
--- a/.github/actions/s2pro-setup/action.yaml
+++ b/.github/actions/s2pro-setup/action.yaml
@@ -30,6 +30,13 @@ runs:
         fi
         source omni-s2pro/bin/activate
         uv pip install -v -e ".[s2pro,dev]"
+        # Repair PyAV if its bundled shared libs got corrupted in the cached
+        # venv (e.g. "libx265-...so.215: file too short"). The editable install
+        # above does not reinstall an already-present package, so force it.
+        if ! python -c "import av" 2>/dev/null; then
+          echo "PyAV native libraries corrupted in cached venv, force-reinstalling..."
+          uv pip install --force-reinstall --no-deps --no-cache av
+        fi
 
     - name: Validate prepared environment
       if: ${{ inputs.install-deps != 'true' }}

--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -44,6 +44,13 @@ jobs:
           fi
           source omni-qwen3/bin/activate
           uv pip install -v -e ".[dev]"
+          # Repair PyAV if its bundled shared libs got corrupted in the cached
+          # venv (e.g. "libx265-...so.215: file too short"). The editable install
+          # above does not reinstall an already-present package, so force it.
+          if ! python -c "import av" 2>/dev/null; then
+            echo "PyAV native libraries corrupted in cached venv, force-reinstalling..."
+            uv pip install --force-reinstall --no-deps --no-cache av
+          fi
 
       - name: Kill GPU processes
         shell: bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,6 +44,13 @@ jobs:
           fi
           source omni/bin/activate
           uv pip install -v -e ".[dev]"
+          # Repair PyAV if its bundled shared libs got corrupted in the cached
+          # venv (e.g. "libx265-...so.215: file too short"). The editable install
+          # above does not reinstall an already-present package, so force it.
+          if ! python -c "import av" 2>/dev/null; then
+            echo "PyAV native libraries corrupted in cached venv, force-reinstalling..."
+            uv pip install --force-reinstall --no-deps --no-cache av
+          fi
 
       - name: Kill GPU processes
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,7 @@ Thumbs.db
 uv.lock
 results/
 .humanize/
-.humanize/
 .benchmark-data/
+
+# AI
+.claude/

--- a/sglang_omni/engines/omni/runtime/encoder.py
+++ b/sglang_omni/engines/omni/runtime/encoder.py
@@ -19,7 +19,7 @@ _AUDIO_MASK_NDIM = 2
 def _right_pad_last_dim(
     tensor: torch.Tensor, target_len: int, pad_value: float | int = 0.0
 ) -> torch.Tensor:
-    """Right-pad only the last dimension of tensor`` to target_len.
+    """Right-pad only the last dimension of tensor to target_len.
 
     Note (Chenyang):
     Returns the tensor unchanged if its last dimension already meets or

--- a/sglang_omni/engines/omni/runtime/encoder.py
+++ b/sglang_omni/engines/omni/runtime/encoder.py
@@ -20,6 +20,11 @@ def _right_pad_last_dim(tensor: torch.Tensor, target_len: int) -> torch.Tensor:
     return F.pad(tensor, (0, target_len - current_len))
 
 
+QWEN3_AUDIO_TIME_PAD_KEYS = {"input_features", "feature_attention_mask"}
+QWEN3_AUDIO_FEATURES_RANK = 3
+QWEN3_AUDIO_MASK_RANK = 2
+
+
 # -----------------------------------------------------------------------------
 # Data Structures
 # -----------------------------------------------------------------------------
@@ -132,9 +137,6 @@ class EncoderInputPreparer:
     """Converts EncoderBatchData to model inputs."""
 
     EXCLUDED_KEYS = {"cache_key", "_skip", "_result"}
-    QWEN3_AUDIO_TIME_PAD_KEYS = {"input_features", "feature_attention_mask"}
-    QWEN3_AUDIO_FEATURES_RANK = 3
-    QWEN3_AUDIO_MASK_RANK = 2
 
     def __init__(self, pad_token_id: int = 0):
         self.pad_token_id = pad_token_id
@@ -146,7 +148,7 @@ class EncoderInputPreparer:
         tensors: list[torch.Tensor],
         device: torch.device,
     ) -> torch.Tensor:
-        if key not in self.QWEN3_AUDIO_TIME_PAD_KEYS:
+        if key not in QWEN3_AUDIO_TIME_PAD_KEYS:
             return torch.cat(tensors, dim=0).to(device)
 
         # Qwen3-Omni pads within each request but can still produce different
@@ -154,9 +156,9 @@ class EncoderInputPreparer:
         # the audio tower receives one padded batch plus the original feature
         # masks / lengths.
         expected_dim = (
-            self.QWEN3_AUDIO_FEATURES_RANK
+            QWEN3_AUDIO_FEATURES_RANK
             if key == "input_features"
-            else self.QWEN3_AUDIO_MASK_RANK
+            else QWEN3_AUDIO_MASK_RANK
         )
         if any(tensor.dim() != expected_dim for tensor in tensors):
             raise ValueError(

--- a/sglang_omni/engines/omni/runtime/encoder.py
+++ b/sglang_omni/engines/omni/runtime/encoder.py
@@ -160,6 +160,7 @@ class EncoderInputPreparer:
                 f"tensor_shapes={[tuple(tensor.shape) for tensor in tensors]}"
             )
 
+        # Note (Chenyang, Ratish):
         # Only the last (time) dim is padded; all non-time dims must match
         # across requests. Catching the mismatch here surfaces a clear error
         # instead of a silent shape bug downstream.

--- a/sglang_omni/engines/omni/runtime/encoder.py
+++ b/sglang_omni/engines/omni/runtime/encoder.py
@@ -12,17 +12,16 @@ import torch.nn.functional as F
 from ..types import RequestOutput, SchedulerOutput, SchedulerRequest
 from .interfaces import ResourceManager
 
+QWEN3_AUDIO_TIME_PAD_KEYS = {"input_features", "feature_attention_mask"}
+QWEN3_AUDIO_FEATURES_RANK = 3
+QWEN3_AUDIO_MASK_RANK = 2
+
 
 def _right_pad_last_dim(tensor: torch.Tensor, target_len: int) -> torch.Tensor:
     current_len = int(tensor.shape[-1])
     if current_len >= target_len:
         return tensor
     return F.pad(tensor, (0, target_len - current_len))
-
-
-QWEN3_AUDIO_TIME_PAD_KEYS = {"input_features", "feature_attention_mask"}
-QWEN3_AUDIO_FEATURES_RANK = 3
-QWEN3_AUDIO_MASK_RANK = 2
 
 
 # -----------------------------------------------------------------------------

--- a/sglang_omni/engines/omni/runtime/encoder.py
+++ b/sglang_omni/engines/omni/runtime/encoder.py
@@ -164,9 +164,9 @@ class EncoderInputPreparer:
         tensors: list[torch.Tensor],
         device: torch.device,
     ) -> torch.Tensor:
-        assert tensors, (
-            f"_pad_and_cat_tensors called with empty tensor list for key={key}"
-        )
+        assert (
+            tensors
+        ), f"_pad_and_cat_tensors called with empty tensor list for key={key}"
         expected_dim, pad_value = self.TIME_PAD_SPECS[key]
         if any(tensor.dim() != expected_dim for tensor in tensors):
             raise ValueError(

--- a/sglang_omni/engines/omni/runtime/encoder.py
+++ b/sglang_omni/engines/omni/runtime/encoder.py
@@ -12,16 +12,17 @@ import torch.nn.functional as F
 from ..types import RequestOutput, SchedulerOutput, SchedulerRequest
 from .interfaces import ResourceManager
 
-QWEN3_AUDIO_TIME_PAD_KEYS = {"input_features", "feature_attention_mask"}
-QWEN3_AUDIO_FEATURES_RANK = 3
-QWEN3_AUDIO_MASK_RANK = 2
+_AUDIO_FEATURES_NDIM = 3
+_AUDIO_MASK_NDIM = 2
 
 
-def _right_pad_last_dim(tensor: torch.Tensor, target_len: int) -> torch.Tensor:
-    current_len = int(tensor.shape[-1])
+def _right_pad_last_dim(
+    tensor: torch.Tensor, target_len: int, pad_value: float = 0.0
+) -> torch.Tensor:
+    current_len = tensor.shape[-1]
     if current_len >= target_len:
         return tensor
-    return F.pad(tensor, (0, target_len - current_len))
+    return F.pad(tensor, (0, target_len - current_len), value=pad_value)
 
 
 # -----------------------------------------------------------------------------
@@ -136,36 +137,32 @@ class EncoderInputPreparer:
     """Converts EncoderBatchData to model inputs."""
 
     EXCLUDED_KEYS = {"cache_key", "_skip", "_result"}
+    # Note (Ratish): Qwen3-Omni pads within each request but can still produce
+    # different time lengths across requests.
+    TIME_PAD_KEYS = {"input_features", "feature_attention_mask"}
+    TIME_PAD_NDIMS = {
+        "input_features": _AUDIO_FEATURES_NDIM,
+        "feature_attention_mask": _AUDIO_MASK_NDIM,
+    }
 
     def __init__(self, pad_token_id: int = 0):
         self.pad_token_id = pad_token_id
 
-    def _prepare_qwen3_audio_batch_tensor(
+    def _pad_and_cat_tensors(
         self,
         *,
         key: str,
         tensors: list[torch.Tensor],
         device: torch.device,
     ) -> torch.Tensor:
-        if key not in QWEN3_AUDIO_TIME_PAD_KEYS:
-            return torch.cat(tensors, dim=0).to(device)
-
-        # Note (Ratish): Qwen3-Omni pads within each request but can still produce different
-        # time lengths across requests. Right-pad the shared time axis here so
-        # the audio tower receives one padded batch plus the original feature
-        # masks / lengths.
-        expected_dim = (
-            QWEN3_AUDIO_FEATURES_RANK
-            if key == "input_features"
-            else QWEN3_AUDIO_MASK_RANK
-        )
+        expected_dim = self.TIME_PAD_NDIMS[key]
         if any(tensor.dim() != expected_dim for tensor in tensors):
             raise ValueError(
-                f"Unsupported Qwen3 audio tensor layout: key={key}, "
+                f"Unsupported tensor layout for time padding: key={key}, "
                 f"tensor_shapes={[tuple(tensor.shape) for tensor in tensors]}"
             )
 
-        max_time_dim = max(int(tensor.shape[-1]) for tensor in tensors)
+        max_time_dim = max(tensor.shape[-1] for tensor in tensors)
         padded = [_right_pad_last_dim(tensor, max_time_dim) for tensor in tensors]
         return torch.cat(padded, dim=0).to(device)
 
@@ -199,12 +196,14 @@ class EncoderInputPreparer:
                     tensors = [inp[key] for inp in active_inputs]
                     if value.dim() == 0:
                         batched[key] = torch.stack(tensors).to(device)
-                    elif key in cat_keys:
-                        batched[key] = self._prepare_qwen3_audio_batch_tensor(
+                    elif key in self.TIME_PAD_KEYS:
+                        batched[key] = self._pad_and_cat_tensors(
                             key=key,
                             tensors=tensors,
                             device=device,
                         )
+                    elif key in cat_keys:
+                        batched[key] = torch.cat(tensors, dim=0).to(device)
                     else:
                         batched[key] = torch.stack(tensors).to(device)
                 else:

--- a/sglang_omni/engines/omni/runtime/encoder.py
+++ b/sglang_omni/engines/omni/runtime/encoder.py
@@ -150,7 +150,7 @@ class EncoderInputPreparer:
         if key not in QWEN3_AUDIO_TIME_PAD_KEYS:
             return torch.cat(tensors, dim=0).to(device)
 
-        # Qwen3-Omni pads within each request but can still produce different
+        # Note (Ratish): Qwen3-Omni pads within each request but can still produce different
         # time lengths across requests. Right-pad the shared time axis here so
         # the audio tower receives one padded batch plus the original feature
         # masks / lengths.

--- a/sglang_omni/engines/omni/runtime/encoder.py
+++ b/sglang_omni/engines/omni/runtime/encoder.py
@@ -193,12 +193,12 @@ class EncoderInputPreparer:
             active_inputs = [batch_data.input_dicts[i] for i in active_indices]
             first = active_inputs[0]
             batched: dict[str, Any] = {}
-            
+
             # Note (Ratish, Chenyang):
             # Keys routed through plain torch.cat on dim=0. Entries in
             # TIME_PAD_SPECS are intercepted earlier and handled via the
             # right-pad-and-cat path, so they do not appear here.
-            
+
             cat_keys = {
                 "pixel_values",
                 "pixel_values_videos",

--- a/sglang_omni/engines/omni/runtime/encoder.py
+++ b/sglang_omni/engines/omni/runtime/encoder.py
@@ -19,22 +19,17 @@ _AUDIO_MASK_NDIM = 2
 def _right_pad_last_dim(
     tensor: torch.Tensor, target_len: int, pad_value: float | int = 0.0
 ) -> torch.Tensor:
-    """Right-pad only the last dimension of ``tensor`` to ``target_len``.
+    """Right-pad only the last dimension of tensor`` to target_len.
 
-    Returns the tensor unchanged if its last dimension already meets or exceeds
-    ``target_len``. ``pad_value`` is cast by ``F.pad`` to the tensor's dtype,
+    Note (Chenyang):
+    Returns the tensor unchanged if its last dimension already meets or
+    exceeds target_len. pad_value is cast by F.pad to the tensor's dtype,
     so both float and int are accepted for use with feature/mask tensors.
     """
     current_len = tensor.shape[-1]
     if current_len >= target_len:
         return tensor
     return F.pad(tensor, (0, target_len - current_len), value=pad_value)
-
-
-# -----------------------------------------------------------------------------
-# Data Structures
-# -----------------------------------------------------------------------------
-
 
 @dataclass
 class EncoderRequestData:
@@ -56,11 +51,6 @@ class EncoderBatchData:
     input_dicts: list[dict[str, Any]] | None = None
     active_indices: list[int] | None = None
     skip_results: list[dict[str, Any] | None] | None = None
-
-
-# -----------------------------------------------------------------------------
-# BatchPlanner
-# -----------------------------------------------------------------------------
 
 
 class EncoderBatchPlanner:
@@ -132,11 +122,6 @@ class EncoderBatchPlanner:
 
     def is_finished(self, request: SchedulerRequest, output: RequestOutput) -> bool:
         return True  # Encoder always done in one pass
-
-
-# -----------------------------------------------------------------------------
-# InputPreparer
-# -----------------------------------------------------------------------------
 
 
 class EncoderInputPreparer:
@@ -380,9 +365,6 @@ class EncoderOutputProcessor:
         else:
             return self._process_text_embedding(model_output, scheduler_output)
 
-    # -------------------------------------------------------------------------
-    # Multimodal Processing
-    # -------------------------------------------------------------------------
 
     def _process_multimodal(
         self,

--- a/sglang_omni/engines/omni/runtime/encoder.py
+++ b/sglang_omni/engines/omni/runtime/encoder.py
@@ -193,9 +193,12 @@ class EncoderInputPreparer:
             active_inputs = [batch_data.input_dicts[i] for i in active_indices]
             first = active_inputs[0]
             batched: dict[str, Any] = {}
+            
+            # Note (Ratish, Chenyang):
             # Keys routed through plain torch.cat on dim=0. Entries in
             # TIME_PAD_SPECS are intercepted earlier and handled via the
             # right-pad-and-cat path, so they do not appear here.
+            
             cat_keys = {
                 "pixel_values",
                 "pixel_values_videos",

--- a/sglang_omni/engines/omni/runtime/encoder.py
+++ b/sglang_omni/engines/omni/runtime/encoder.py
@@ -31,6 +31,7 @@ def _right_pad_last_dim(
         return tensor
     return F.pad(tensor, (0, target_len - current_len), value=pad_value)
 
+
 @dataclass
 class EncoderRequestData:
     """Encoder-specific request data (stored in SchedulerRequest.data)."""
@@ -364,7 +365,6 @@ class EncoderOutputProcessor:
             return self._process_multimodal(model_output, scheduler_output)
         else:
             return self._process_text_embedding(model_output, scheduler_output)
-
 
     def _process_multimodal(
         self,

--- a/sglang_omni/engines/omni/runtime/encoder.py
+++ b/sglang_omni/engines/omni/runtime/encoder.py
@@ -17,8 +17,14 @@ _AUDIO_MASK_NDIM = 2
 
 
 def _right_pad_last_dim(
-    tensor: torch.Tensor, target_len: int, pad_value: float = 0.0
+    tensor: torch.Tensor, target_len: int, pad_value: float | int = 0.0
 ) -> torch.Tensor:
+    """Right-pad only the last dimension of ``tensor`` to ``target_len``.
+
+    Returns the tensor unchanged if its last dimension already meets or exceeds
+    ``target_len``. ``pad_value`` is cast by ``F.pad`` to the tensor's dtype,
+    so both float and int are accepted for use with feature/mask tensors.
+    """
     current_len = tensor.shape[-1]
     if current_len >= target_len:
         return tensor
@@ -138,11 +144,14 @@ class EncoderInputPreparer:
 
     EXCLUDED_KEYS = {"cache_key", "_skip", "_result"}
     # Note (Ratish): Qwen3-Omni pads within each request but can still produce
-    # different time lengths across requests.
-    TIME_PAD_KEYS = {"input_features", "feature_attention_mask"}
-    TIME_PAD_NDIMS = {
-        "input_features": _AUDIO_FEATURES_NDIM,
-        "feature_attention_mask": _AUDIO_MASK_NDIM,
+    # different time lengths across requests. Keys listed here are right-padded
+    # on their last (time) dimension before being concatenated on the batch
+    # dimension. Each entry maps to (expected_ndim, pad_value_for_last_dim) so
+    # the dispatch key set and per-key invariants stay in a single source of
+    # truth.
+    TIME_PAD_SPECS: dict[str, tuple[int, float]] = {
+        "input_features": (_AUDIO_FEATURES_NDIM, 0.0),
+        "feature_attention_mask": (_AUDIO_MASK_NDIM, 0.0),
     }
 
     def __init__(self, pad_token_id: int = 0):
@@ -155,15 +164,33 @@ class EncoderInputPreparer:
         tensors: list[torch.Tensor],
         device: torch.device,
     ) -> torch.Tensor:
-        expected_dim = self.TIME_PAD_NDIMS[key]
+        assert tensors, (
+            f"_pad_and_cat_tensors called with empty tensor list for key={key}"
+        )
+        expected_dim, pad_value = self.TIME_PAD_SPECS[key]
         if any(tensor.dim() != expected_dim for tensor in tensors):
             raise ValueError(
                 f"Unsupported tensor layout for time padding: key={key}, "
                 f"tensor_shapes={[tuple(tensor.shape) for tensor in tensors]}"
             )
 
+        # Only the last (time) dim is padded; all non-time dims must match
+        # across requests. Catching the mismatch here surfaces a clear error
+        # instead of a silent shape bug downstream.
+        ref_shape = tensors[0].shape[:-1]
+        for i, tensor in enumerate(tensors[1:], 1):
+            if tensor.shape[:-1] != ref_shape:
+                raise ValueError(
+                    f"Non-time dimensions mismatch for key={key}: "
+                    f"tensor[0].shape={tuple(tensors[0].shape)}, "
+                    f"tensor[{i}].shape={tuple(tensor.shape)}"
+                )
+
         max_time_dim = max(tensor.shape[-1] for tensor in tensors)
-        padded = [_right_pad_last_dim(tensor, max_time_dim) for tensor in tensors]
+        padded = [
+            _right_pad_last_dim(tensor, max_time_dim, pad_value=pad_value)
+            for tensor in tensors
+        ]
         return torch.cat(padded, dim=0).to(device)
 
     def prepare(
@@ -179,13 +206,14 @@ class EncoderInputPreparer:
             active_inputs = [batch_data.input_dicts[i] for i in active_indices]
             first = active_inputs[0]
             batched: dict[str, Any] = {}
+            # Keys routed through plain torch.cat on dim=0. Entries in
+            # TIME_PAD_SPECS are intercepted earlier and handled via the
+            # right-pad-and-cat path, so they do not appear here.
             cat_keys = {
                 "pixel_values",
                 "pixel_values_videos",
                 "image_grid_thw",
                 "video_grid_thw",
-                "input_features",
-                "feature_attention_mask",
                 "audio_feature_lengths",
             }
             for key, value in first.items():
@@ -196,7 +224,7 @@ class EncoderInputPreparer:
                     tensors = [inp[key] for inp in active_inputs]
                     if value.dim() == 0:
                         batched[key] = torch.stack(tensors).to(device)
-                    elif key in self.TIME_PAD_KEYS:
+                    elif key in self.TIME_PAD_SPECS:
                         batched[key] = self._pad_and_cat_tensors(
                             key=key,
                             tensors=tensors,

--- a/sglang_omni/engines/omni/runtime/encoder.py
+++ b/sglang_omni/engines/omni/runtime/encoder.py
@@ -7,9 +7,18 @@ from dataclasses import dataclass
 from typing import Any, Callable
 
 import torch
+import torch.nn.functional as F
 
 from ..types import RequestOutput, SchedulerOutput, SchedulerRequest
 from .interfaces import ResourceManager
+
+
+def _right_pad_last_dim(tensor: torch.Tensor, target_len: int) -> torch.Tensor:
+    current_len = int(tensor.shape[-1])
+    if current_len >= target_len:
+        return tensor
+    return F.pad(tensor, (0, target_len - current_len))
+
 
 # -----------------------------------------------------------------------------
 # Data Structures
@@ -123,9 +132,41 @@ class EncoderInputPreparer:
     """Converts EncoderBatchData to model inputs."""
 
     EXCLUDED_KEYS = {"cache_key", "_skip", "_result"}
+    QWEN3_AUDIO_TIME_PAD_KEYS = {"input_features", "feature_attention_mask"}
+    QWEN3_AUDIO_FEATURES_RANK = 3
+    QWEN3_AUDIO_MASK_RANK = 2
 
     def __init__(self, pad_token_id: int = 0):
         self.pad_token_id = pad_token_id
+
+    def _prepare_qwen3_audio_batch_tensor(
+        self,
+        *,
+        key: str,
+        tensors: list[torch.Tensor],
+        device: torch.device,
+    ) -> torch.Tensor:
+        if key not in self.QWEN3_AUDIO_TIME_PAD_KEYS:
+            return torch.cat(tensors, dim=0).to(device)
+
+        # Qwen3-Omni pads within each request but can still produce different
+        # time lengths across requests. Right-pad the shared time axis here so
+        # the audio tower receives one padded batch plus the original feature
+        # masks / lengths.
+        expected_dim = (
+            self.QWEN3_AUDIO_FEATURES_RANK
+            if key == "input_features"
+            else self.QWEN3_AUDIO_MASK_RANK
+        )
+        if any(tensor.dim() != expected_dim for tensor in tensors):
+            raise ValueError(
+                f"Unsupported Qwen3 audio tensor layout: key={key}, "
+                f"tensor_shapes={[tuple(tensor.shape) for tensor in tensors]}"
+            )
+
+        max_time_dim = max(int(tensor.shape[-1]) for tensor in tensors)
+        padded = [_right_pad_last_dim(tensor, max_time_dim) for tensor in tensors]
+        return torch.cat(padded, dim=0).to(device)
 
     def prepare(
         self,
@@ -158,7 +199,11 @@ class EncoderInputPreparer:
                     if value.dim() == 0:
                         batched[key] = torch.stack(tensors).to(device)
                     elif key in cat_keys:
-                        batched[key] = torch.cat(tensors, dim=0).to(device)
+                        batched[key] = self._prepare_qwen3_audio_batch_tensor(
+                            key=key,
+                            tensors=tensors,
+                            device=device,
+                        )
                     else:
                         batched[key] = torch.stack(tensors).to(device)
                 else:


### PR DESCRIPTION
## Motivation

Qwen3-Omni audio requests with different feature lengths could be batched together in the shared encoder runtime and crash before reaching the audio tower. This change fixes that batching boundary without changing the Qwen3 model path itself. Fixes #284 

## Modifications
- Add right-padding for `input_features` and `feature_attention_mask` in `EncoderInputPreparer` before cross-request concatenation.
- Restrict the padding path to the Qwen3 audio keys used by this runtime and validate their expected tensor ranks. Why: the failure was caused by batching heterogeneous audio time dimensions, not by a generic multimodal collation bug.
- Leave `audio_feature_lengths` unchanged so downstream Qwen3 code still receives the original per-request lengths.

## Root Cause
- `EncoderInputPreparer.prepare()` concatenated Qwen3 audio tensors from different requests with `torch.cat(..., dim=0)`.
- When concurrent requests carried different audio time lengths, `input_features` and `feature_attention_mask` had incompatible non-batch dimensions and batching failed with a tensor size mismatch.
- Qwen3-Omni expects padded batched audio features plus masks/lengths; the old runtime code skipped the cross-request padding step.

## Accuracy Tests

- Manual concurrent-audio validation was run in the user's H200 container against four simultaneous Qwen3-Omni requests mixing `tests/data/query_to_cars.wav` and `tests/data/cough.wav`. The exact command is not captured in this workspace. Observed result: before the fix all four requests failed with HTTP 500 and `Sizes of tensors must match`; after the fix all four requests returned HTTP 200 and the batch reached the Qwen3 audio tower.


## Checklist

- [ ] Format your code according to the contribution guide.
- [ ] Add or update tests as needed.
- [ ] Update documentation as needed.
- [ ] Provide accuracy and speed results when the change affects them.
