### PR TITLE
[Refactor] Unify pip install: merge optional deps into base dependencies

### DIFF
--- a/.github/actions/omni-setup/action.yaml
+++ b/.github/actions/omni-setup/action.yaml
@@ -5,10 +5,6 @@ inputs:
   venv-name:
     description: Name of the virtualenv to restore and activate.
     required: true
-  pip-extras:
-    description: Optional dependency extras to install, for example `dev` or `s2pro,dev`.
-    required: false
-    default: ""
   install-deps:
     description: Prepare or refresh the requested virtualenv before running tests.
     required: false
@@ -31,7 +27,6 @@ runs:
       shell: bash
       env:
         VENV_NAME: ${{ inputs.venv-name }}
-        PIP_EXTRAS: ${{ inputs.pip-extras }}
       run: |
         if [ -d "${VENV_NAME}" ] && ! "${VENV_NAME}/bin/python" -c "import torch" 2>/dev/null; then
           echo "Cached venv is corrupted, removing..."
@@ -41,12 +36,7 @@ runs:
           uv venv "${VENV_NAME}" -p 3.11
         fi
         source "${VENV_NAME}/bin/activate"
-        if [ -n "${PIP_EXTRAS}" ]; then
-          uv pip install -v -e ".[${PIP_EXTRAS}]"
-        else
-          echo "::warning::pip-extras is empty; installing bare package without extras"
-          uv pip install -v -e .
-        fi
+        uv pip install -v -e .
         # Repair PyAV if its bundled shared libs got corrupted in the cached
         # venv (e.g. "libx265-...so.215: file too short"). The editable install
         # above does not reinstall an already-present package, so force it.

--- a/.github/workflows/test-examples.yaml
+++ b/.github/workflows/test-examples.yaml
@@ -43,7 +43,7 @@ jobs:
             uv venv omni -p 3.11
           fi
           source omni/bin/activate
-          uv pip install -v -e ".[dev]"
+          uv pip install -v -e .
 
       - name: Kill GPU processes
         shell: bash

--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -27,7 +27,6 @@ jobs:
       - uses: ./.github/actions/omni-setup
         with:
           venv-name: omni-qwen3
-          pip-extras: dev
           install-deps: "true"
 
       - name: Run docs tests

--- a/.github/workflows/test-s2pro-ci.yaml
+++ b/.github/workflows/test-s2pro-ci.yaml
@@ -27,7 +27,6 @@ jobs:
       - uses: ./.github/actions/omni-setup
         with:
           venv-name: omni-s2pro
-          pip-extras: s2pro,dev
           install-deps: "true"
 
       - name: Run docs tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,7 +43,7 @@ jobs:
             uv venv omni -p 3.11
           fi
           source omni/bin/activate
-          uv pip install -v -e ".[dev]"
+          uv pip install -v -e .
           # Repair PyAV if its bundled shared libs got corrupted in the cached
           # venv (e.g. "libx265-...so.215: file too short"). The editable install
           # above does not reinstall an already-present package, so force it.

--- a/docs/basic_usage/qwen3_omni.md
+++ b/docs/basic_usage/qwen3_omni.md
@@ -13,7 +13,7 @@ docker run -it --shm-size 32g --gpus all frankleeeee/sglang-omni:dev /bin/zsh
 git clone https://github.com/sgl-project/sglang-omni.git
 cd sglang-omni
 uv venv .venv -p 3.12 && source .venv/bin/activate
-uv pip install -e "."
+uv pip install -v .
 ```
 
 ## Text-Only Mode

--- a/docs/basic_usage/tts_s2pro.md
+++ b/docs/basic_usage/tts_s2pro.md
@@ -13,7 +13,7 @@ docker run -it --shm-size 32g --gpus all frankleeeee/sglang-omni:dev /bin/zsh
 git clone https://github.com/sgl-project/sglang-omni.git
 cd sglang-omni
 uv venv .venv -p 3.12 && source .venv/bin/activate
-uv pip install -e .
+uv pip install -v .
 hf download fishaudio/s2-pro
 ```
 

--- a/docs/basic_usage/tts_s2pro.md
+++ b/docs/basic_usage/tts_s2pro.md
@@ -13,7 +13,7 @@ docker run -it --shm-size 32g --gpus all frankleeeee/sglang-omni:dev /bin/zsh
 git clone https://github.com/sgl-project/sglang-omni.git
 cd sglang-omni
 uv venv .venv -p 3.12 && source .venv/bin/activate
-uv pip install -e ".[s2pro]"
+uv pip install -e .
 hf download fishaudio/s2-pro
 ```
 

--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -14,6 +14,9 @@ uv venv .venv -p 3.11
 source .venv/bin/activate
 
 # install
+uv pip install -v .
+
+# install for development
 uv pip install -v -e .
 ```
 

--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -14,10 +14,7 @@ uv venv .venv -p 3.11
 source .venv/bin/activate
 
 # install
-uv pip install -v .
-
-# install for development
-uv pip install -v -e ".[dev]"
+uv pip install -v -e .
 ```
 
 

--- a/playground/README.md
+++ b/playground/README.md
@@ -12,7 +12,7 @@ This directory contains two playground interfaces for SGLang-Omni.
 The web playground is embedded in the backend — a single process serves both the API and the UI.
 
 ```bash
-uv pip install -v -e ".[dev]"
+uv pip install -v -e .
 ./playground/web/start.sh \
   --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct
 ```
@@ -32,8 +32,7 @@ Then open `http://localhost:8000` in your browser.
 ### Install
 
 ```bash
-pip install "sglang-omni[gradio]"
-# or just: pip install gradio httpx
+pip install sglang-omni
 ```
 
 ### Launch (one command)

--- a/playground/gradio/start.sh
+++ b/playground/gradio/start.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # become healthy, then starts the Gradio UI.  One command, one terminal.
 #
 # Prerequisites:
-#   pip install "sglang-omni[gradio]"   # or: pip install gradio httpx
+#   pip install sglang-omni
 #
 # Usage:
 #   ./playground/gradio/start.sh --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,30 +39,24 @@ dependencies = [
     "typer>=0.9.0",
     "openai==2.6.1",
     "openai-harmony==0.0.4",
-    "soundfile>=0.12.0"
-]
-
-[project.optional-dependencies]
-dev = [
-    # Testing dependencies
+    "soundfile>=0.12.0",
+    # Testing
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
-    # WER benchmark dependencies (Whisper ASR + text normalization)
     "jiwer",
     "scipy>=1.10.0",
     "openai-whisper",
-]
-s2pro = [
+    # S2-Pro
     "tiktoken",
     "hydra-core",
     "omegaconf",
     "descript-audiotools",
     "descript-audio-codec",
     "torchaudio",
+    # Gradio playground
     "gradio>=4.0.0",
     # flash-attn: install separately via prebuilt wheel (see install instructions below)
 ]
-gradio = ["gradio>=4.0.0"]
 
 [project.scripts]
 sgl-omni = "sglang_omni.cli.cli:app"


### PR DESCRIPTION
## Motivation
Per @zhaochenyang20 request:
The project had 3 optional dependency groups (`dev`, `s2pro`, `gradio`) requiring different install suffixes (`".[dev]"`, `".[s2pro,dev]"`, `"sglang-omni[gradio]"`) across CI, docs, and scripts. This was inconsistent and error-prone. Simplify to a single `pip install .` everywhere.

## Modifications

- **`pyproject.toml`**: Merged all optional dependencies (`dev`, `s2pro`, `gradio`) into base `dependencies`; removed `[project.optional-dependencies]` section.
- **CI/Actions** (4 files): Replaced `".[dev]"` / `".[s2pro,dev]"` with `.` in pip install commands.
- **Docs** (3 files): Updated install instructions to use `pip install .` / `pip install sglang-omni`.
- **`playground/gradio/start.sh`**: Updated prerequisite comment.

9 files changed, no functional/behavioral changes.

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.