### PR TITLE
Refactor: removed redundant find_free_port util

### DIFF
--- a/examples/run_two_stage_demo.py
+++ b/examples/run_two_stage_demo.py
@@ -11,11 +11,11 @@ import asyncio
 import logging
 import multiprocessing as mp
 import os
-import socket
 import time
 from typing import Any, List
 
 from sglang_omni import Coordinator
+from sglang_omni.utils import find_available_port
 
 # Configure logging
 logging.basicConfig(
@@ -40,14 +40,6 @@ ENDPOINTS = {
 WORLD_SIZE = 2
 RANK_STAGE1 = 0
 RANK_STAGE2 = 1
-
-
-def find_free_port():
-    """Find a free port on localhost to avoid collisions."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        return s.getsockname()[1]
 
 
 def stage1_get_next(request_id: str, output: Any) -> str | None:
@@ -313,7 +305,7 @@ def main():
 
     # Configure NCCL environment dynamically to avoid port conflicts
     if relay_type == "nccl":
-        free_port = str(find_free_port())
+        free_port = str(find_available_port())
         os.environ["MASTER_ADDR"] = "127.0.0.1"
         os.environ["MASTER_PORT"] = free_port
         logger.info(f"Using NCCL Master Port: {free_port}")

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -38,6 +38,7 @@ from sglang_omni.client import Client
 from sglang_omni.config import PipelineConfig, build_pipeline_runner
 from sglang_omni.profiler.profiler_control import ProfilerControlClient
 from sglang_omni.serve.openai_api import create_app
+from sglang_omni.utils import find_available_port
 
 logger = logging.getLogger(__name__)
 

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import socket
 import time
 from typing import Any
 
@@ -45,22 +44,6 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Built-in pipeline registry
 # ---------------------------------------------------------------------------
-
-
-def _find_available_port(host: str, port: int) -> int:
-    """Return *port* if available, otherwise find a free port and warn."""
-    try:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind((host, port))
-            return port
-    except OSError:
-        pass
-    logger.warning(f"Port {port} is already in use on {host}.")
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind((host, 0))
-        free_port = s.getsockname()[1]
-    logger.warning(f"Using port {free_port} instead.")
-    return free_port
 
 
 def _default_run_id() -> str:

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -151,7 +151,7 @@ async def _run_server(
     This is the async entry point.  For a blocking call use :func:`launch_server`.
     """
     # 0. Check port availability before loading models
-    port = _find_available_port(host, port)
+    port = find_available_port(host, port)
 
     gpu_ids = set(pipeline_config.gpu_placement.values())
     need_multi_process = len(gpu_ids) > 1

--- a/sglang_omni/utils/__init__.py
+++ b/sglang_omni/utils/__init__.py
@@ -15,6 +15,7 @@ from .misc import (
 )
 
 __all__ = [
+    "find_available_port",
     "load_hf_config",
     "instantiate_module",
     "architecture_from_hf_config",
@@ -25,5 +26,4 @@ __all__ = [
     "add_prefix",
     "set_random_seed",
     "broadcast_pyobj",
-    "find_available_port",
 ]

--- a/sglang_omni/utils/__init__.py
+++ b/sglang_omni/utils/__init__.py
@@ -1,3 +1,4 @@
+from .connection import find_available_port
 from .hf import (
     architecture_from_hf_config,
     instantiate_module,
@@ -24,4 +25,5 @@ __all__ = [
     "add_prefix",
     "set_random_seed",
     "broadcast_pyobj",
+    "find_available_port",
 ]

--- a/sglang_omni/utils/connection.py
+++ b/sglang_omni/utils/connection.py
@@ -15,13 +15,16 @@ def find_available_port(host: str = "127.0.0.1", port: int = None) -> int:
     Returns:
         The available port.
     """
-    try:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind((host, port))
-            return port
-    except OSError:
-        pass
-    logger.warning(f"Port {port} is already in use on {host}.")
+    if port is not None:
+        # check if the given port can be used
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind((host, port))
+                return port
+        except OSError:
+            logger.warning(f"Port {port} is already in use on {host}.")
+
+    # find the available port
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind((host, 0))
         free_port = s.getsockname()[1]

--- a/sglang_omni/utils/connection.py
+++ b/sglang_omni/utils/connection.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Network connection utilities."""
+
 from __future__ import annotations
 
 import logging
@@ -30,5 +33,9 @@ def find_available_port(host: str = "0.0.0.0", port: int | None = None) -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind((host, 0))
         free_port = s.getsockname()[1]
-    logger.warning(f"Using port {free_port} instead.")
+
+    if port is not None:
+        logger.warning(f"Using port {free_port} instead.")
+    else:
+        logger.info(f"Found available port {free_port}.")
     return free_port

--- a/sglang_omni/utils/connection.py
+++ b/sglang_omni/utils/connection.py
@@ -1,15 +1,17 @@
+from __future__ import annotations
+
 import logging
 import socket
 
 logger = logging.getLogger(__name__)
 
 
-def find_available_port(host: str = "127.0.0.1", port: int = None) -> int:
+def find_available_port(host: str = "0.0.0.0", port: int | None = None) -> int:
     """
     Find a free port on the host if the port is not provided. If the port is provided, check if it is available.
 
     Args:
-        host: The host to bind to. Default is "127.0.0.1".
+        host: The host to bind to. Default is "0.0.0.0".
         port: The port to bind to. Default is None, which means a free port will be found.
 
     Returns:

--- a/sglang_omni/utils/connection.py
+++ b/sglang_omni/utils/connection.py
@@ -1,0 +1,29 @@
+import logging
+import socket
+
+logger = logging.getLogger(__name__)
+
+
+def find_available_port(host: str = "127.0.0.1", port: int = None) -> int:
+    """
+    Find a free port on the host if the port is not provided. If the port is provided, check if it is available.
+
+    Args:
+        host: The host to bind to. Default is "127.0.0.1".
+        port: The port to bind to. Default is None, which means a free port will be found.
+
+    Returns:
+        The available port.
+    """
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind((host, port))
+            return port
+    except OSError:
+        pass
+    logger.warning(f"Port {port} is already in use on {host}.")
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind((host, 0))
+        free_port = s.getsockname()[1]
+    logger.warning(f"Using port {free_port} instead.")
+    return free_port

--- a/tests/docs/qwen3_omni/test_docs_qwen3_omni.py
+++ b/tests/docs/qwen3_omni/test_docs_qwen3_omni.py
@@ -26,12 +26,7 @@ from jiwer import process_words
 
 from benchmarks.tasks.voice_clone import load_asr_model, normalize_text, transcribe
 from sglang_omni.utils import find_available_port
-from tests.utils import (
-    disable_proxy,
-    no_proxy_env,
-    start_server_from_cmd,
-    stop_server,
-)
+from tests.utils import disable_proxy, no_proxy_env, start_server_from_cmd, stop_server
 
 MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
 MODEL_NAME = "qwen3-omni"

--- a/tests/docs/qwen3_omni/test_docs_qwen3_omni.py
+++ b/tests/docs/qwen3_omni/test_docs_qwen3_omni.py
@@ -25,9 +25,9 @@ import torch
 from jiwer import process_words
 
 from benchmarks.tasks.voice_clone import load_asr_model, normalize_text, transcribe
+from sglang_omni.utils import find_available_port
 from tests.utils import (
     disable_proxy,
-    find_free_port,
     no_proxy_env,
     start_server_from_cmd,
     stop_server,
@@ -114,7 +114,7 @@ class TestTextOnlyMode:
 
     @pytest.fixture(scope="class")
     def server(self, tmp_path_factory: pytest.TempPathFactory):
-        port = find_free_port()
+        port = find_available_port()
         log_file = tmp_path_factory.mktemp("text_only_logs") / "server.log"
         cmd = [
             sys.executable,
@@ -182,7 +182,7 @@ class TestSpeechMode:
 
     @pytest.fixture(scope="class")
     def server(self, tmp_path_factory: pytest.TempPathFactory):
-        port = find_free_port()
+        port = find_available_port()
         log_file = tmp_path_factory.mktemp("speech_logs") / "server.log"
         cmd = [
             sys.executable,

--- a/tests/docs/s2pro/test_docs_tts_s2pro.py
+++ b/tests/docs/s2pro/test_docs_tts_s2pro.py
@@ -21,12 +21,8 @@ from pathlib import Path
 import pytest
 import requests
 
-from tests.utils import (
-    disable_proxy,
-    find_free_port,
-    start_server_from_cmd,
-    stop_server,
-)
+from sglang_omni.utils import find_available_port
+from tests.utils import disable_proxy, start_server_from_cmd, stop_server
 
 S2PRO_MODEL_PATH = "fishaudio/s2-pro"
 S2PRO_CONFIG_PATH = "examples/configs/s2pro_tts.yaml"
@@ -39,7 +35,7 @@ REFERENCE_AUDIO = "https://huggingface.co/datasets/zhaochenyang20/seed-tts-eval-
 @pytest.fixture(scope="module")
 def server_process(tmp_path_factory: pytest.TempPathFactory):
     """Start the S2-Pro server, wait until healthy, and yield `(proc, port)`."""
-    port = find_free_port()
+    port = find_available_port()
     log_file = tmp_path_factory.mktemp("server_logs") / "server.log"
     cmd = [
         sys.executable,

--- a/tests/test_model/test_qwen3_omni_mmmu_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmmu_ci.py
@@ -20,10 +20,10 @@ import pytest
 
 from benchmarks.dataset.prepare import DATASETS
 from benchmarks.eval.benchmark_omni_mmmu import MMMUEvalConfig, run_mmmu_eval
+from sglang_omni.utils import find_available_port
 from tests.utils import (
     apply_slack,
     assert_speed_thresholds,
-    find_free_port,
     start_server_from_cmd,
     stop_server,
 )
@@ -51,7 +51,7 @@ MMMU_THRESHOLDS = apply_slack(_MMMU_P95)
 @pytest.fixture(scope="module")
 def server_process(tmp_path_factory: pytest.TempPathFactory):
     """Start the text-only Qwen3-Omni server and wait until healthy."""
-    port = find_free_port()
+    port = find_available_port()
     log_file = tmp_path_factory.mktemp("server_logs") / "server.log"
     cmd = [
         sys.executable,

--- a/tests/test_model/test_qwen3_omni_mmmu_tts_consistency_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmmu_tts_consistency_ci.py
@@ -28,11 +28,11 @@ import pytest
 
 from benchmarks.dataset.prepare import DATASETS
 from benchmarks.eval.benchmark_omni_mmmu import MMMUEvalConfig, run_mmmu_eval
+from sglang_omni.utils import find_available_port
 from tests.utils import (
     apply_slack,
     assert_speed_thresholds,
     assert_wer_results,
-    find_free_port,
     start_server_from_cmd,
     stop_server,
 )
@@ -69,7 +69,7 @@ MMMU_AUDIO_THRESHOLDS = apply_slack(_MMMU_AUDIO_P95)
 @pytest.fixture(scope="module")
 def server_process(tmp_path_factory: pytest.TempPathFactory):
     """Start the Qwen3-Omni speech server (talker ON) and wait until healthy."""
-    port = find_free_port()
+    port = find_available_port()
     log_file = tmp_path_factory.mktemp("server_logs") / "server.log"
     cmd = [
         sys.executable,

--- a/tests/test_model/test_qwen3_omni_tts_ci.py
+++ b/tests/test_model/test_qwen3_omni_tts_ci.py
@@ -24,13 +24,13 @@ from benchmarks.eval.benchmark_omni_tts_speed import (
     OmniTtsSpeedBenchmarkConfig,
     run_omni_tts_speed_benchmark,
 )
+from sglang_omni.utils import find_available_port
 from tests.utils import (
     apply_slack,
     assert_per_request_fields,
     assert_speed_thresholds,
     assert_summary_metrics,
     assert_wer_results,
-    find_free_port,
     no_proxy_env,
     start_server_from_cmd,
     stop_server,
@@ -219,7 +219,7 @@ def dataset_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
 @pytest.fixture(scope="module")
 def server_process(tmp_path_factory: pytest.TempPathFactory):
     """Start the Qwen3-Omni speech server and wait until healthy."""
-    port = find_free_port()
+    port = find_available_port()
     log_file = tmp_path_factory.mktemp("server_logs") / "server.log"
     cmd = [
         sys.executable,

--- a/tests/test_model/test_s2pro_tts_ci.py
+++ b/tests/test_model/test_s2pro_tts_ci.py
@@ -39,6 +39,7 @@ from benchmarks.eval.benchmark_tts_speed import (
     TtsSpeedBenchmarkConfig,
     run_tts_speed_benchmark,
 )
+from sglang_omni.utils import find_available_port
 from tests.test_model.conftest import (
     S2PRO_STAGE_CONSISTENCY,
     S2PRO_STAGE_NONSTREAM,
@@ -51,7 +52,6 @@ from tests.utils import (
     assert_streaming_consistency,
     assert_summary_metrics,
     assert_wer_results,
-    find_free_port,
     no_proxy_env,
     start_server_from_cmd,
     stop_server,
@@ -432,7 +432,7 @@ def cleanup_generated_audio_fixture():
 @pytest.fixture(scope="module")
 def server_process(tmp_path_factory: pytest.TempPathFactory):
     """Start the s2-pro server and wait until healthy."""
-    port = find_free_port()
+    port = find_available_port()
     log_file = tmp_path_factory.mktemp("server_logs") / "server.log"
     cmd = [
         sys.executable,

--- a/tests/test_relay_unified_multiprocess.py
+++ b/tests/test_relay_unified_multiprocess.py
@@ -30,7 +30,7 @@ import sglang_omni.relay.nccl  # noqa: F401
 import sglang_omni.relay.nixl  # noqa: F401 (Trigger @register_relay)
 import sglang_omni.relay.shm  # noqa: F401
 from sglang_omni.relay.base import create_relay
-from tests.utils import find_free_port
+from sglang_omni.utils import find_available_port
 
 
 def sender_process(
@@ -291,7 +291,7 @@ def test_multiprocess_transfer(relay_type):
             pytest.skip(f"{relay_type.upper()} requires at least 2 GPUs")
 
     # [Modification 4] Dynamic Port Generation
-    master_port = str(find_free_port())
+    master_port = str(find_available_port())
     master_addr = "127.0.0.1"
 
     # Base configuration

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import os
 import signal
-import socket
 import statistics
 import subprocess
 from contextlib import contextmanager
@@ -39,13 +38,6 @@ def disable_proxy() -> Generator[None, None, None]:
         for k in proxy_vars:
             os.environ.pop(k, None)
         os.environ.update(saved_env)
-
-
-def find_free_port() -> int:
-    """Find and return an available TCP port."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as socket_handle:
-        socket_handle.bind(("", 0))
-        return socket_handle.getsockname()[1]
 
 
 def no_proxy_env() -> dict[str, str]:


### PR DESCRIPTION
## Motivation

There are duplicated function called `_find_available_port` and `find_free_port` scattered across the codebase (`tests/utils.py`, `sglang_omni/serve/launcher.py`, `examples/run_two_stage_demo.py`), each with slightly different implementations. This caused duplication and inconsistency.

## Modifications

- Added a unified `find_available_port(host, port)` function in `sglang_omni/utils/connection.py`
- Exported `find_available_port` from `sglang_omni/utils/__init__.py`
- Removed all local `find_free_port` / `_find_available_port` implementations from:
  - `tests/utils.py`
  - `sglang_omni/serve/launcher.py`
  - `examples/run_two_stage_demo.py`
- Updated all callers (tests and examples) to import and use the centralized utility

## Related Issues

N/A

## Accuracy Test

N/A

## Benchmark & Profiling

N/A

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.