### PR TITLE
[Docs] Update benchmarks README for unified TTS/WER pipeline and MMSU

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -22,10 +22,20 @@ benchmarks/
 # 0. Prepare dataset (once)
 python -m benchmarks.dataset.prepare --dataset seedtts
 
-# 1. Start the server
+# 1. Start a server on port 8000 (pick one matching the benchmark below)
+
+# S2-Pro — for sections 2a/2b/2c
 python -m sglang_omni.cli.cli serve \
     --model-path fishaudio/s2-pro \
     --config examples/configs/s2pro_tts.yaml --port 8000
+
+# Qwen3-Omni, speech mode — for section 3 (SeedTTS; multi-GPU)
+python -m sglang_omni.cli.cli serve \
+    --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct --port 8000
+
+# Qwen3-Omni, text-only mode — for sections 4 (MMSU) and 5 (MMMU)
+python -m sglang_omni.cli.cli serve \
+    --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct --text-only --port 8000
 
 # 2a. S2-Pro — full pipeline: generate + WER (server needed for phase 1 only)
 python -m benchmarks.eval.benchmark_tts_seedtts \

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,17 +1,17 @@
 # SGLang Omni Benchmarks
 
 Benchmark suite for SGLang Omni, covering performance (latency, throughput, RTF)
-and accuracy (WER) across supported modality combinations.
+and accuracy (WER, MMSU, MMMU) across supported modality combinations.
 
 ## Directory Structure
 
 ```
 benchmarks/
-├── tasks/          # Task definitions (voice_clone, tts_speed)
-├── metrics/        # Atomic evaluation tools (wer, performance)
+├── tasks/          # Per-task logic (tts, mmsu, visual_understand)
+├── metrics/        # Metric computation (performance, accuracy)
 ├── dataset/        # Dataset loaders + download helpers
 ├── benchmarker/    # Framework: runner, data structures, utilities
-├── eval/           # Entry-point scripts (one per task x model)
+├── eval/           # Entry-point scripts (one per task × model)
 ├── cache/          # (gitignored) dataset caches
 └── results/        # (gitignored) evaluation outputs
 ```
@@ -19,52 +19,80 @@ benchmarks/
 ## Quick Start
 
 ```bash
+# 0. Prepare dataset (once)
+python -m benchmarks.dataset.prepare --dataset seedtts
+
 # 1. Start the server
 python -m sglang_omni.cli.cli serve \
     --model-path fishaudio/s2-pro \
     --config examples/configs/s2pro_tts.yaml --port 8000
 
-# 2a. Speed benchmark (voice cloning, non-streaming)
-python benchmarks/eval/benchmark_tts_speed.py \
-    --model fishaudio/s2-pro --port 8000 \
-    --testset seedtts_testset/en/meta.lst --max-samples 10
-
-# 2b. Speed benchmark (voice cloning, non-streaming, concurrency 20)
-python benchmarks/eval/benchmark_tts_speed.py \
-    --model fishaudio/s2-pro --port 8000 \
-    --testset seedtts_testset/en/meta.lst --max-samples 50 \
-    --concurrency 20
-
-# 2c. Speed benchmark (streaming)
-python benchmarks/eval/benchmark_tts_speed.py \
-    --model fishaudio/s2-pro --port 8000 \
-    --testset seedtts_testset/en/meta.lst --max-samples 10 --stream
-
-# 2d. WER evaluation (voice cloning)
-python benchmarks/eval/voice_clone_tts_wer.py \
+# 2a. S2-Pro — full pipeline: generate + WER (server needed for phase 1 only)
+python -m benchmarks.eval.benchmark_tts_seedtts \
     --meta seedtts_testset/en/meta.lst \
-    --output-dir results/s2pro_en --lang en --max-samples 50
+    --model fishaudio/s2-pro --port 8000 \
+    --output-dir results/s2pro_en --lang en --max-samples 50 --concurrency 8
 
-# 2e. WER evaluation (voice cloning, higher-concurrency generation)
-python benchmarks/eval/voice_clone_tts_wer.py \
+# 2b. S2-Pro — generate only (speed metrics, no transcription)
+python -m benchmarks.eval.benchmark_tts_seedtts \
+    --generate-only --stream \
     --meta seedtts_testset/en/meta.lst \
-    --output-dir results/s2pro_en_c20 --lang en --max-samples 50 \
-    --generation-concurrency 20
+    --model fishaudio/s2-pro --port 8000 --max-samples 50 --concurrency 8
+
+# 2c. S2-Pro — transcribe only (reuses audio from a prior generate run; no server)
+python -m benchmarks.eval.benchmark_tts_seedtts \
+    --transcribe-only \
+    --meta seedtts_testset/en/meta.lst \
+    --model fishaudio/s2-pro \
+    --output-dir results/s2pro_en --lang en --device cuda:0
+
+# 3. Qwen3-Omni — same two-phase pipeline
+python -m benchmarks.eval.benchmark_omni_seedtts \
+    --meta seedtts_testset/en/meta.lst \
+    --model qwen3-omni --port 8000 \
+    --output-dir results/qwen3_omni_en --max-samples 50
+
+# 4. Qwen3-Omni — MMSU (audio comprehension)
+python -m benchmarks.eval.benchmark_omni_mmsu \
+    --model qwen3-omni --port 8000 \
+    --modalities text+audio --max-samples 50
+
+# 5. Qwen3-Omni — MMMU (VLM accuracy, image input)
+python -m benchmarks.eval.benchmark_omni_mmmu \
+    --model qwen3-omni --port 8000 --max-samples 50 --max-concurrency 16
 ```
 
 ## Eval Scripts
 
 | Script | Task | Model | API |
 |--------|------|-------|-----|
-| `eval/benchmark_tts_speed.py` | TTS speed | S2 Pro | `/v1/audio/speech` |
-| `eval/benchmark_omni_tts_speed.py` | TTS speed | Qwen3 Omni | `/v1/chat/completions` |
-| `eval/voice_clone_tts_wer.py` | Voice clone WER | S2 Pro | `/v1/audio/speech` |
-| `eval/voice_clone_omni_wer.py` | Voice clone WER | Qwen3 Omni | `/v1/chat/completions` |
-| `eval/benchmark_omni_mmsu.py` | MMSU accuracy | Qwen3 Omni | `/v1/chat/completions` |
+| `eval/benchmark_tts_seedtts.py` | TTS speed + WER (unified) | S2-Pro | `/v1/audio/speech` |
+| `eval/benchmark_omni_seedtts.py` | TTS speed + WER (unified) | Qwen3-Omni | `/v1/chat/completions` |
+| `eval/benchmark_omni_mmsu.py` | MMSU (audio comprehension) | Qwen3-Omni | `/v1/chat/completions` |
+| `eval/benchmark_omni_mmmu.py` | MMMU (VLM accuracy + speed) | Qwen3-Omni | `/v1/chat/completions` |
+
+The two `*_seedtts.py` scripts merge the previous `benchmark_*_tts_speed.py`
+and `voice_clone_*_wer.py` pairs into a single two-phase pipeline: phase 1
+generates + persists WAVs while the server runs, phase 2 transcribes offline
+to avoid GPU contention with the server. Use `--generate-only` or
+`--transcribe-only` to run a single phase.
 
 ## Adding a New Model
 
-For a model using the same API type (e.g., another OAI TTS API model):
-1. Add eval script in `eval/voice_clone_your_model_wer.py` using existing task class
+- **Same API type** (e.g. another OAI-compatible TTS model): add an eval
+  script under `eval/` that reuses the existing task helpers in
+  `tasks/tts.py` (`make_tts_send_fn`, `run_seedtts_transcribe`, …).
+- **New API type**: add a task class in the relevant `tasks/*.py` file
+  (mirroring `VoiceCloneOmni` in `tasks/tts.py`) and wire it into a new
+  eval script.
 
-For a new API type: add a new class in the relevant `tasks/` file.
+## Datasets
+
+Download helpers live in `benchmarks/dataset/prepare.py`:
+
+```bash
+python -m benchmarks.dataset.prepare --dataset seedtts       # full SeedTTS
+python -m benchmarks.dataset.prepare --dataset seedtts-mini  # smoke-test subset
+python -m benchmarks.dataset.prepare --dataset seedtts-50    # 50-sample subset
+python -m benchmarks.dataset.prepare --dataset mmmu-ci-50    # MMMU CI subset
+```

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -77,14 +77,14 @@ generates + persists WAVs while the server runs, phase 2 transcribes offline
 to avoid GPU contention with the server. Use `--generate-only` or
 `--transcribe-only` to run a single phase.
 
-## Adding a New Model
+## Adding a New Model or Task
 
-- **Same API type** (e.g. another OAI-compatible TTS model): add an eval
-  script under `eval/` that reuses the existing task helpers in
-  `tasks/tts.py` (`make_tts_send_fn`, `run_seedtts_transcribe`, …).
-- **New API type**: add a task class in the relevant `tasks/*.py` file
-  (mirroring `VoiceCloneOmni` in `tasks/tts.py`) and wire it into a new
-  eval script.
+- **New model, same task/API type** (e.g. another OAI-compatible TTS model):
+  add an eval script under `eval/` that reuses the existing task helpers
+  in `tasks/tts.py` (`make_tts_send_fn`, `run_seedtts_transcribe`, …).
+- **New task or API type**: add a task class in the relevant `tasks/*.py`
+  file (mirroring `VoiceCloneOmni` in `tasks/tts.py`), expose metric
+  helpers, and wire it into a new eval script.
 
 ## Datasets
 


### PR DESCRIPTION
Reflects the merged `benchmark_tts_seedtts.py` / `benchmark_omni_seedtts.py` two-phase pipeline (#280) and the newer MMSU (#261) and MMMU (#265) eval scripts. Also adds dataset prep commands and refreshes directory layout.

