### PR TITLE
[CI] Add MMSU CI for qwen3-omni

### DIFF
--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -181,3 +181,88 @@ jobs:
         shell: bash
         run: |
           bash .github/scripts/delete_gpu_process.sh
+
+  stage-4-mmsu:
+    name: stage 4 - MMSU accuracy + speed
+    needs: stage-3-mmmu-tts-consistency
+    runs-on: [self-hosted]
+    timeout-minutes: 20
+    container:
+      image: frankleeeee/sglang-omni:dev
+      options: --gpus all --rm -v /dev/shm:/dev/shm
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/omni-setup
+        with:
+          venv-name: omni-qwen3
+
+      - name: Run MMSU CI (accuracy + speed)
+        shell: bash
+        run: |
+          source omni-qwen3/bin/activate
+          export PYTHONPATH=$PWD
+          pytest tests/test_model/test_qwen3_omni_mmsu_ci.py -v -s -x
+        env:
+          HF_ENDPOINT: https://hf-mirror.com
+
+      - name: Print MMSU CI artifacts (accuracy + speed)
+        if: always()
+        shell: bash
+        run: |
+          source omni-qwen3/bin/activate
+          echo "=== Qwen3-Omni MMSU CI results (summary only) ==="
+          for f in $(find /tmp -path '*/mmsu/mmsu_results.json' 2>/dev/null); do
+            echo "--- $f ---"
+            python -c "import json,sys; d=json.load(open(sys.argv[1])); d.pop('per_sample',None); print(json.dumps(d, indent=2, ensure_ascii=False))" "$f"
+            echo ""
+          done
+
+      - name: Kill GPU processes
+        if: always()
+        shell: bash
+        run: |
+          bash .github/scripts/delete_gpu_process.sh
+
+  stage-5-mmsu-tts-consistency:
+    name: stage 5 - MMSU TTS consistency
+    needs: stage-4-mmsu
+    runs-on: [self-hosted]
+    timeout-minutes: 15
+    container:
+      image: frankleeeee/sglang-omni:dev
+      options: --gpus all --rm -v /dev/shm:/dev/shm
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/omni-setup
+        with:
+          venv-name: omni-qwen3
+
+      - name: Run MMSU TTS Consistency CI (WER + speed)
+        shell: bash
+        run: |
+          source omni-qwen3/bin/activate
+          export PYTHONPATH=$PWD
+          pytest tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py -v -s -x
+        env:
+          HF_ENDPOINT: https://hf-mirror.com
+
+      - name: Print MMSU TTS Consistency CI artifacts (WER + speed)
+        if: always()
+        shell: bash
+        run: |
+          echo "=== Qwen3-Omni MMSU TTS Consistency CI results ==="
+          for f in $(find /tmp -path '*/mmsu_audio/mmsu_results.json' 2>/dev/null); do
+            echo "--- $f ---"
+            cat "$f"
+            echo ""
+          done
+
+      - name: Kill GPU processes
+        if: always()
+        shell: bash
+        run: |
+          bash .github/scripts/delete_gpu_process.sh

--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -198,6 +198,14 @@ jobs:
         with:
           venv-name: omni-qwen3
 
+      - name: Dump pip freeze for CI-vs-local diff
+        shell: bash
+        run: |
+          source omni-qwen3/bin/activate
+          echo "=== CI pip freeze ==="
+          pip freeze | sort
+          echo "=== end CI pip freeze ==="
+
       - name: Run MMSU CI (accuracy + speed)
         shell: bash
         run: |

--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -198,14 +198,6 @@ jobs:
         with:
           venv-name: omni-qwen3
 
-      - name: Dump pip freeze for CI-vs-local diff
-        shell: bash
-        run: |
-          source omni-qwen3/bin/activate
-          echo "=== CI pip freeze ==="
-          pip freeze | sort
-          echo "=== end CI pip freeze ==="
-
       - name: Run MMSU CI (accuracy + speed)
         shell: bash
         run: |

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -7,7 +7,7 @@ and accuracy (WER, MMSU, MMMU) across supported modality combinations.
 
 ```
 benchmarks/
-├── tasks/          # Per-task logic (tts, mmsu, visual_understand)
+├── tasks/          # Per-task logic (tts, audio_understanding, visual_understand)
 ├── metrics/        # Metric computation (performance, accuracy)
 ├── dataset/        # Dataset loaders + download helpers
 ├── benchmarker/    # Framework: runner, data structures, utilities

--- a/benchmarks/dataset/mmsu.py
+++ b/benchmarks/dataset/mmsu.py
@@ -61,6 +61,10 @@ def load_mmsu_samples(
     (train split, ~5000 samples).  zhaochenyang20/mmsu-ci-2000 to
     load our pre-built subset for CI.
     """
+    import tempfile
+
+    from datasets import Audio, load_dataset
+
     ds = load_dataset(repo_id or "ddwang2000/MMSU")
     assert list(ds.keys()) == [
         "train"

--- a/benchmarks/dataset/mmsu.py
+++ b/benchmarks/dataset/mmsu.py
@@ -55,20 +55,12 @@ def load_mmsu_samples(
 ) -> list[MmsuSample]:
     """Load MMSU samples.
 
-    Args:
-        max_samples: Cap on how many samples to return.  None = all.
-        task_names: Optional task_name filter.
-        categories: Optional category filter.
-        seed: If set, shuffle with ``random.Random(seed)`` before slicing.
-        repo_id: HuggingFace dataset repo to load from.  Defaults to
-            None which loads the full ddwang2000/MMSU (train split,
-            ~5000 samples).  Pass a repo id like
-            "zhaochenyang20/mmsu-ci-2000" to load a pre-built subset.
+
+    Note (Yifei, Chenyang):
+    repo_id defaults to None which loads the full ddwang2000/MMSU
+    (train split, ~5000 samples).  zhaochenyang20/mmsu-ci-2000 to
+    load our pre-built subset for CI.
     """
-    import tempfile
-
-    from datasets import Audio, load_dataset
-
     ds = load_dataset(repo_id or "ddwang2000/MMSU")
     assert list(ds.keys()) == [
         "train"

--- a/benchmarks/dataset/mmsu.py
+++ b/benchmarks/dataset/mmsu.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 
 import random
 import re
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+
+from datasets import Audio, load_dataset
 
 
 @dataclass
@@ -61,9 +64,6 @@ def load_mmsu_samples(
     (train split, ~5000 samples).  zhaochenyang20/mmsu-ci-2000 to
     load our pre-built subset for CI.
     """
-    import tempfile
-
-    from datasets import Audio, load_dataset
 
     ds = load_dataset(repo_id or "ddwang2000/MMSU")
     assert list(ds.keys()) == [

--- a/benchmarks/dataset/mmsu.py
+++ b/benchmarks/dataset/mmsu.py
@@ -50,13 +50,26 @@ def load_mmsu_samples(
     task_names: list[str] | None = None,
     categories: list[str] | None = None,
     seed: int | None = None,
+    *,
+    repo_id: str | None = None,
 ) -> list[MmsuSample]:
-    """Load MMSU samples from HuggingFace dataset ``ddwang2000/MMSU``."""
+    """Load MMSU samples.
+
+    Args:
+        max_samples: Cap on how many samples to return.  None = all.
+        task_names: Optional task_name filter.
+        categories: Optional category filter.
+        seed: If set, shuffle with ``random.Random(seed)`` before slicing.
+        repo_id: HuggingFace dataset repo to load from.  Defaults to
+            None which loads the full ddwang2000/MMSU (train split,
+            ~5000 samples).  Pass a repo id like
+            "zhaochenyang20/mmsu-ci-2000" to load a pre-built subset.
+    """
     import tempfile
 
     from datasets import Audio, load_dataset
 
-    ds = load_dataset("ddwang2000/MMSU")
+    ds = load_dataset(repo_id or "ddwang2000/MMSU")
     assert list(ds.keys()) == [
         "train"
     ], f"Expected only 'train' split, got {list(ds.keys())}"

--- a/benchmarks/dataset/prepare.py
+++ b/benchmarks/dataset/prepare.py
@@ -29,6 +29,7 @@ DATASETS: dict[str, str] = {
     "mmmu": "MMMU/MMMU",
     "mmmu-ci-50": "zhaochenyang20/mmmu-ci-50",
     "mmsu": "ddwang2000/MMSU",
+    "mmsu-ci-2000": "zhaochenyang20/mmsu-ci-2000",
 }
 
 _CLI_LOCAL_DIRS: dict[str, str] = {

--- a/benchmarks/eval/benchmark_omni_mmmu.py
+++ b/benchmarks/eval/benchmark_omni_mmmu.py
@@ -66,12 +66,9 @@ from benchmarks.benchmarker.utils import save_json_results, wait_for_service
 from benchmarks.dataset.mmmu import load_mmmu_samples
 from benchmarks.metrics.performance import compute_speed_metrics
 from benchmarks.tasks.tts import (
-    SampleOutput,
-    calculate_wer_metrics,
-    load_asr_model,
+    compute_text_audio_consistency,
     print_speed_summary,
     print_wer_summary,
-    transcribe_and_compute_wer,
 )
 from benchmarks.tasks.visual_understand import (
     compute_mmmu_metrics,
@@ -170,68 +167,14 @@ async def run_mmmu_eval(config: MMMUEvalConfig) -> dict:
     }
 
     if config.enable_audio:
-        wer_results = _compute_audio_wer(
+        results["wer"] = compute_text_audio_consistency(
             request_results, config.lang, config.asr_device
         )
-        results["wer"] = wer_results
 
     if config.output_dir:
         save_json_results(results, config.output_dir, "mmmu_results.json")
 
     return results
-
-
-def _compute_audio_wer(
-    request_results: list,
-    lang: str,
-    asr_device: str,
-) -> dict:
-    """Transcribe audio outputs with ASR and compute WER against text outputs.
-
-    Text output is the reference; ASR transcription of the audio is the
-    hypothesis.  Returns a dict with summary and per_sample keys.
-    """
-    asr = load_asr_model(lang, asr_device)
-
-    outputs: list[SampleOutput] = []
-    for result in request_results:
-
-        ref_text = " ".join(result.text.split())
-        output = SampleOutput(
-            sample_id=result.request_id,
-            target_text=ref_text,
-            latency_s=result.latency_s,
-            audio_duration_s=result.audio_duration_s,
-        )
-
-        if not result.is_success or not result.wav_path:
-            output.error = result.error or "No audio in response"
-            outputs.append(output)
-            continue
-
-        output = transcribe_and_compute_wer(
-            output, result.wav_path, asr, lang, asr_device
-        )
-        outputs.append(output)
-
-    wer_summary = calculate_wer_metrics(outputs, lang)
-
-    per_sample = [
-        {
-            "id": o.sample_id,
-            "is_success": o.is_success,
-            "wer": o.wer if o.is_success else None,
-            "ref_text": o.target_text[:100],
-            "hyp_text": o.whisper_text[:100],
-            "ref_norm": o.ref_norm,
-            "hyp_norm": o.hyp_norm,
-            "audio_duration_s": o.audio_duration_s,
-            "error": o.error,
-        }
-        for o in outputs
-    ]
-
-    return {"summary": wer_summary, "per_sample": per_sample}
 
 
 def _config_from_args(args: argparse.Namespace) -> MMMUEvalConfig:

--- a/benchmarks/eval/benchmark_omni_mmsu.py
+++ b/benchmarks/eval/benchmark_omni_mmsu.py
@@ -86,7 +86,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from benchmarks.benchmarker.runner import BenchmarkRunner, RunConfig
 from benchmarks.benchmarker.utils import wait_for_service
-from benchmarks.dataset.mmsu import load_mmsu_samples
+from benchmarks.dataset.mmsu import MmsuSample, load_mmsu_samples
 from benchmarks.metrics.performance import compute_speed_metrics
 from benchmarks.tasks.audio_understanding import (
     build_mmsu_results,
@@ -103,17 +103,22 @@ logging.basicConfig(
 )
 
 
-async def run(args: argparse.Namespace) -> dict:
+async def run(
+    args: argparse.Namespace,
+    *,
+    samples: list[MmsuSample] | None = None,
+) -> dict:
     base_url = args.base_url or f"http://{args.host}:{args.port}"
     api_url = f"{base_url}/v1/chat/completions"
     modalities = ["text", "audio"] if args.modalities == "text+audio" else ["text"]
 
-    samples = load_mmsu_samples(
-        max_samples=args.max_samples,
-        task_names=args.task_names.split(",") if args.task_names else None,
-        categories=args.categories.split(",") if args.categories else None,
-        seed=args.seed,
-    )
+    if samples is None:
+        samples = load_mmsu_samples(
+            max_samples=args.max_samples,
+            task_names=args.task_names.split(",") if args.task_names else None,
+            categories=args.categories.split(",") if args.categories else None,
+            seed=args.seed,
+        )
 
     save_audio_dir = None
     if args.save_audio and args.output_dir:

--- a/benchmarks/eval/benchmark_omni_mmsu.py
+++ b/benchmarks/eval/benchmark_omni_mmsu.py
@@ -88,12 +88,18 @@ from benchmarks.benchmarker.runner import BenchmarkRunner, RunConfig
 from benchmarks.benchmarker.utils import wait_for_service
 from benchmarks.dataset.mmsu import load_mmsu_samples
 from benchmarks.metrics.performance import compute_speed_metrics
-from benchmarks.tasks.mmsu import (
+from benchmarks.tasks.audio_understanding import (
     build_mmsu_results,
     compute_mmsu_metrics,
     make_mmsu_send_fn,
     print_mmsu_summary,
     save_mmsu_results,
+)
+from benchmarks.tasks.tts import (
+    SampleOutput,
+    calculate_wer_metrics,
+    load_asr_model,
+    transcribe_and_compute_wer,
 )
 
 logging.basicConfig(
@@ -167,7 +173,52 @@ async def run(args: argparse.Namespace) -> dict:
             speed_metrics=speed,
         )
 
-    return {"accuracy": metrics, "speed": speed}
+    output: dict = {"accuracy": metrics, "speed": speed}
+    if audio_mode:
+        output["wer"] = _compute_audio_wer(
+            request_results,
+            getattr(args, "lang", "en"),
+            getattr(args, "asr_device", "cuda:0"),
+        )
+    return output
+
+
+def _compute_audio_wer(request_results, lang: str, asr_device: str) -> dict:
+    """Transcribe audio outputs and compute WER against text outputs."""
+    asr = load_asr_model(lang, asr_device)
+
+    outputs: list[SampleOutput] = []
+    for result in request_results:
+        ref_text = " ".join(result.text.split())
+        out = SampleOutput(
+            sample_id=result.request_id,
+            target_text=ref_text,
+            latency_s=result.latency_s,
+            audio_duration_s=result.audio_duration_s,
+        )
+        if not result.is_success or not result.wav_path:
+            out.error = result.error or "No audio in response"
+            outputs.append(out)
+            continue
+        out = transcribe_and_compute_wer(out, result.wav_path, asr, lang, asr_device)
+        outputs.append(out)
+
+    wer_summary = calculate_wer_metrics(outputs, lang)
+    per_sample = [
+        {
+            "id": o.sample_id,
+            "is_success": o.is_success,
+            "wer": o.wer if o.is_success else None,
+            "ref_text": o.target_text[:100],
+            "hyp_text": o.whisper_text[:100],
+            "ref_norm": o.ref_norm,
+            "hyp_norm": o.hyp_norm,
+            "audio_duration_s": o.audio_duration_s,
+            "error": o.error,
+        }
+        for o in outputs
+    ]
+    return {"summary": wer_summary, "per_sample": per_sample}
 
 
 def main() -> None:

--- a/benchmarks/eval/benchmark_omni_mmsu.py
+++ b/benchmarks/eval/benchmark_omni_mmsu.py
@@ -95,7 +95,7 @@ from benchmarks.tasks.audio_understanding import (
     print_mmsu_summary,
     save_mmsu_results,
 )
-from benchmarks.tasks.tts import compute_text_audio_consistency
+from benchmarks.tasks.tts import compute_text_audio_consistency, print_wer_summary
 
 logging.basicConfig(
     level=logging.INFO,
@@ -151,6 +151,17 @@ async def run(args: argparse.Namespace) -> dict:
 
     print_mmsu_summary(metrics, args.model, speed_metrics=speed)
 
+    output: dict = {"accuracy": metrics, "speed": speed}
+    wer_results = None
+    if audio_mode:
+        wer_results = compute_text_audio_consistency(
+            request_results,
+            getattr(args, "lang", "en"),
+            getattr(args, "asr_device", "cuda:0"),
+        )
+        output["wer"] = wer_results
+        print_wer_summary(wer_results["summary"], args.model)
+
     if args.output_dir:
         save_mmsu_results(
             results,
@@ -165,16 +176,10 @@ async def run(args: argparse.Namespace) -> dict:
                 "seed": args.seed,
             },
             args.output_dir,
-            speed_metrics=speed,
+            speed_metrics=speed if audio_mode else None,
+            wer_metrics=wer_results,
         )
 
-    output: dict = {"accuracy": metrics, "speed": speed}
-    if audio_mode:
-        output["wer"] = compute_text_audio_consistency(
-            request_results,
-            getattr(args, "lang", "en"),
-            getattr(args, "asr_device", "cuda:0"),
-        )
     return output
 
 
@@ -198,6 +203,8 @@ def main() -> None:
     p.add_argument("--save-audio", action="store_true")
     p.add_argument("--disable-tqdm", action="store_true")
     p.add_argument("--seed", type=int, default=None)
+    p.add_argument("--lang", type=str, default="en", help="Language for ASR WER evaluation")
+    p.add_argument("--asr-device", type=str, default="cuda:0", help="Device for ASR model")
 
     args = p.parse_args()
     wait_for_service(args.base_url or f"http://{args.host}:{args.port}")

--- a/benchmarks/eval/benchmark_omni_mmsu.py
+++ b/benchmarks/eval/benchmark_omni_mmsu.py
@@ -95,12 +95,7 @@ from benchmarks.tasks.audio_understanding import (
     print_mmsu_summary,
     save_mmsu_results,
 )
-from benchmarks.tasks.tts import (
-    SampleOutput,
-    calculate_wer_metrics,
-    load_asr_model,
-    transcribe_and_compute_wer,
-)
+from benchmarks.tasks.tts import compute_text_audio_consistency
 
 logging.basicConfig(
     level=logging.INFO,
@@ -175,50 +170,12 @@ async def run(args: argparse.Namespace) -> dict:
 
     output: dict = {"accuracy": metrics, "speed": speed}
     if audio_mode:
-        output["wer"] = _compute_audio_wer(
+        output["wer"] = compute_text_audio_consistency(
             request_results,
             getattr(args, "lang", "en"),
             getattr(args, "asr_device", "cuda:0"),
         )
     return output
-
-
-def _compute_audio_wer(request_results, lang: str, asr_device: str) -> dict:
-    """Transcribe audio outputs and compute WER against text outputs."""
-    asr = load_asr_model(lang, asr_device)
-
-    outputs: list[SampleOutput] = []
-    for result in request_results:
-        ref_text = " ".join(result.text.split())
-        out = SampleOutput(
-            sample_id=result.request_id,
-            target_text=ref_text,
-            latency_s=result.latency_s,
-            audio_duration_s=result.audio_duration_s,
-        )
-        if not result.is_success or not result.wav_path:
-            out.error = result.error or "No audio in response"
-            outputs.append(out)
-            continue
-        out = transcribe_and_compute_wer(out, result.wav_path, asr, lang, asr_device)
-        outputs.append(out)
-
-    wer_summary = calculate_wer_metrics(outputs, lang)
-    per_sample = [
-        {
-            "id": o.sample_id,
-            "is_success": o.is_success,
-            "wer": o.wer if o.is_success else None,
-            "ref_text": o.target_text[:100],
-            "hyp_text": o.whisper_text[:100],
-            "ref_norm": o.ref_norm,
-            "hyp_norm": o.hyp_norm,
-            "audio_duration_s": o.audio_duration_s,
-            "error": o.error,
-        }
-        for o in outputs
-    ]
-    return {"summary": wer_summary, "per_sample": per_sample}
 
 
 def main() -> None:

--- a/benchmarks/eval/benchmark_omni_mmsu.py
+++ b/benchmarks/eval/benchmark_omni_mmsu.py
@@ -182,7 +182,7 @@ async def run(
                 "seed": args.seed,
             },
             args.output_dir,
-            speed_metrics=speed if audio_mode else None,
+            speed_metrics=speed,
             wer_metrics=wer_results,
         )
 
@@ -216,8 +216,12 @@ def main() -> None:
         help="HuggingFace dataset repo (e.g. 'zhaochenyang20/mmsu-ci-2000'). "
         "Defaults to loading the full ddwang2000/MMSU (train split).",
     )
-    p.add_argument("--lang", type=str, default="en", help="Language for ASR WER evaluation")
-    p.add_argument("--asr-device", type=str, default="cuda:0", help="Device for ASR model")
+    p.add_argument(
+        "--lang", type=str, default="en", help="Language for ASR WER evaluation"
+    )
+    p.add_argument(
+        "--asr-device", type=str, default="cuda:0", help="Device for ASR model"
+    )
 
     args = p.parse_args()
     wait_for_service(args.base_url or f"http://{args.host}:{args.port}")

--- a/benchmarks/eval/benchmark_omni_mmsu.py
+++ b/benchmarks/eval/benchmark_omni_mmsu.py
@@ -118,7 +118,7 @@ async def run(
             task_names=args.task_names.split(",") if args.task_names else None,
             categories=args.categories.split(",") if args.categories else None,
             seed=args.seed,
-            repo_id=getattr(args, "repo_id", None),
+            repo_id=args.repo_id,
         )
 
     save_audio_dir = None
@@ -162,8 +162,8 @@ async def run(
     if audio_mode:
         wer_results = compute_text_audio_consistency(
             request_results,
-            getattr(args, "lang", "en"),
-            getattr(args, "asr_device", "cuda:0"),
+            args.lang,
+            args.asr_device,
         )
         output["wer"] = wer_results
         print_wer_summary(wer_results["summary"], args.model)

--- a/benchmarks/eval/benchmark_omni_mmsu.py
+++ b/benchmarks/eval/benchmark_omni_mmsu.py
@@ -118,6 +118,7 @@ async def run(
             task_names=args.task_names.split(",") if args.task_names else None,
             categories=args.categories.split(",") if args.categories else None,
             seed=args.seed,
+            repo_id=getattr(args, "repo_id", None),
         )
 
     save_audio_dir = None
@@ -208,6 +209,13 @@ def main() -> None:
     p.add_argument("--save-audio", action="store_true")
     p.add_argument("--disable-tqdm", action="store_true")
     p.add_argument("--seed", type=int, default=None)
+    p.add_argument(
+        "--repo-id",
+        type=str,
+        default=None,
+        help="HuggingFace dataset repo (e.g. 'zhaochenyang20/mmsu-ci-2000'). "
+        "Defaults to loading the full ddwang2000/MMSU (train split).",
+    )
     p.add_argument("--lang", type=str, default="en", help="Language for ASR WER evaluation")
     p.add_argument("--asr-device", type=str, default="cuda:0", help="Device for ASR model")
 

--- a/benchmarks/tasks/audio_understanding.py
+++ b/benchmarks/tasks/audio_understanding.py
@@ -182,6 +182,7 @@ class MmsuResult:
     raw_response: str = ""
     is_correct: bool = False
     is_parseable: bool = False
+    is_success: bool = False
     latency_s: float = 0.0
     has_audio: bool = False
     audio_duration_s: float = 0.0
@@ -294,6 +295,7 @@ def build_mmsu_results(
             raw_response=request_result.text,
             is_correct=index_match or text_match,
             is_parseable=predicted_index is not None or bool(predicted_answer),
+            is_success=bool(request_result.is_success),
             latency_s=request_result.latency_s,
             error=request_result.error,
         )
@@ -310,12 +312,15 @@ def build_mmsu_results(
 def compute_mmsu_metrics(results: list[MmsuResult]) -> dict[str, Any]:
     total = len(results)
     parseable = sum(1 for result in results if result.is_parseable)
+    successful = sum(1 for result in results if result.is_success)
     correct = sum(1 for result in results if result.is_correct)
 
     return {
         "total_samples": total,
         "parseable_samples": parseable,
         "unparseable_samples": total - parseable,
+        "successful_samples": successful,
+        "failed_samples": total - successful,
         "correct": correct,
         "incorrect": total - correct,
         "overall_accuracy": round(correct / total, 4) if total else 0.0,
@@ -340,6 +345,9 @@ def print_mmsu_summary(
     print(f"  MMSU Results - {model_name}")
     print("=" * 60)
     print(f"  Total samples:    {metrics['total_samples']}")
+    print(
+        f"  Successful:       {metrics.get('successful_samples', metrics['total_samples'])}"
+    )
     print(f"  Parseable:        {metrics['parseable_samples']}")
     print(f"  Correct:          {metrics['correct']}")
     print(f"  Overall accuracy: {metrics['overall_accuracy']:.2%}")

--- a/benchmarks/tasks/audio_understanding.py
+++ b/benchmarks/tasks/audio_understanding.py
@@ -374,6 +374,7 @@ def save_mmsu_results(
     output_dir: str,
     *,
     speed_metrics: dict[str, Any] | None = None,
+    wer_metrics: dict[str, Any] | None = None,
 ) -> None:
     summary_output = {
         "summary": metrics,
@@ -382,6 +383,8 @@ def save_mmsu_results(
     }
     if speed_metrics:
         summary_output["speed_metrics"] = speed_metrics
+    if wer_metrics:
+        summary_output["wer"] = wer_metrics
 
     save_json_results(summary_output, output_dir, "mmsu_results.json")
 

--- a/benchmarks/tasks/audio_understanding.py
+++ b/benchmarks/tasks/audio_understanding.py
@@ -359,6 +359,7 @@ def print_mmsu_summary(
         if speed_metrics.get("rtf_mean") is not None:
             print(f"  RTF mean:         {speed_metrics.get('rtf_mean', 0):.4f}")
         print(f"  Throughput:       {speed_metrics.get('throughput_qps', 0):.2f} req/s")
+        print(f"  Tok/s agg:        {speed_metrics.get('tok_per_s_agg', 0):.2f}")
         audio_returned = speed_metrics.get("audio_returned")
         audio_expected = speed_metrics.get("audio_expected")
         if audio_expected:

--- a/benchmarks/tasks/tts.py
+++ b/benchmarks/tasks/tts.py
@@ -303,6 +303,48 @@ def calculate_wer_metrics(outputs: list[SampleOutput], lang: str) -> dict:
     }
 
 
+def compute_text_audio_consistency(
+    request_results: list[RequestResult],
+    lang: str,
+    asr_device: str,
+) -> dict:
+    """WER between each request's text output (ref) and ASR-transcribed audio (hyp)."""
+    asr = load_asr_model(lang, asr_device)
+
+    outputs: list[SampleOutput] = []
+    for result in request_results:
+        ref_text = " ".join(result.text.split())
+        out = SampleOutput(
+            sample_id=result.request_id,
+            target_text=ref_text,
+            latency_s=result.latency_s,
+            audio_duration_s=result.audio_duration_s,
+        )
+        if not result.is_success or not result.wav_path:
+            out.error = result.error or "No audio in response"
+            outputs.append(out)
+            continue
+        outputs.append(
+            transcribe_and_compute_wer(out, result.wav_path, asr, lang, asr_device)
+        )
+
+    per_sample = [
+        {
+            "id": o.sample_id,
+            "is_success": o.is_success,
+            "wer": o.wer if o.is_success else None,
+            "ref_text": o.target_text[:100],
+            "hyp_text": o.whisper_text[:100],
+            "ref_norm": o.ref_norm,
+            "hyp_norm": o.hyp_norm,
+            "audio_duration_s": o.audio_duration_s,
+            "error": o.error,
+        }
+        for o in outputs
+    ]
+    return {"summary": calculate_wer_metrics(outputs, lang), "per_sample": per_sample}
+
+
 def print_wer_summary(
     metrics: dict, model_name: str, generation_mode: str | None = None
 ) -> None:

--- a/tests/test_model/test_qwen3_omni_mmsu_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_ci.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MMSU accuracy and speed CI for Qwen3-Omni (Text + Audio → Text, Talker OFF).
+
+Usage:
+    pytest tests/test_model/test_qwen3_omni_mmsu_ci.py -s -x
+
+Author:
+    Yifei Gao https://github.com/PasserBy4
+    Huapeng Zhou https://github.com/PopSoda2002
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from benchmarks.eval.benchmark_omni_mmsu import run as run_mmsu
+from sglang_omni.utils import find_available_port
+from tests.utils import (
+    apply_slack,
+    assert_speed_thresholds,
+    start_server_from_cmd,
+    stop_server,
+)
+
+MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
+
+CONCURRENCY = 8
+MAX_SAMPLES = 1000
+SEED = 42
+STARTUP_TIMEOUT = 900
+
+MMSU_MIN_ACCURACY = 0.52
+
+_MMSU_P95 = {
+    8: {
+        "throughput_qps": 0.001,
+        "tok_per_s_agg": 1.0,
+        "latency_mean_s": 1000.0,
+    },
+}
+MMSU_THRESHOLDS = apply_slack(_MMSU_P95)
+
+
+@pytest.fixture(scope="module")
+def server_process(tmp_path_factory: pytest.TempPathFactory):
+    port = find_available_port()
+    log_file = tmp_path_factory.mktemp("server_logs") / "server.log"
+    cmd = [
+        sys.executable,
+        "examples/run_qwen3_omni_server.py",
+        "--model-path",
+        MODEL_PATH,
+        "--port",
+        str(port),
+        "--model-name",
+        "qwen3-omni",
+    ]
+    proc = start_server_from_cmd(cmd, log_file, port, timeout=STARTUP_TIMEOUT)
+    proc.port = port
+    yield proc
+    stop_server(proc)
+
+
+def _build_args(port: int, output_dir: str) -> argparse.Namespace:
+    return argparse.Namespace(
+        base_url=None,
+        host="localhost",
+        port=port,
+        model="qwen3-omni",
+        modalities="text",
+        output_dir=output_dir,
+        max_samples=MAX_SAMPLES,
+        task_names=None,
+        categories=None,
+        prompt=None,
+        max_tokens=32,
+        temperature=0.0,
+        warmup=1,
+        max_concurrency=CONCURRENCY,
+        request_rate=float("inf"),
+        save_audio=False,
+        disable_tqdm=True,
+        seed=SEED,
+    )
+
+
+@pytest.mark.benchmark
+def test_mmsu_accuracy_and_speed(
+    server_process: subprocess.Popen,
+    tmp_path: Path,
+) -> None:
+    """Run MMSU eval and assert accuracy and speed meet thresholds."""
+    args = _build_args(server_process.port, str(tmp_path / "mmsu"))
+    results = asyncio.run(run_mmsu(args))
+
+    accuracy = results["accuracy"]["overall_accuracy"]
+    assert accuracy >= MMSU_MIN_ACCURACY, (
+        f"MMSU accuracy {accuracy:.4f} ({accuracy * 100:.1f}%) < "
+        f"threshold {MMSU_MIN_ACCURACY} ({MMSU_MIN_ACCURACY * 100:.0f}%)"
+    )
+
+    assert_speed_thresholds(results["speed"], MMSU_THRESHOLDS, CONCURRENCY)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-s", "-x", "-v"]))

--- a/tests/test_model/test_qwen3_omni_mmsu_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_ci.py
@@ -7,6 +7,7 @@ Usage:
 Author:
     Yifei Gao https://github.com/PasserBy4
     Huapeng Zhou https://github.com/PopSoda2002
+    Chenyang Zhao https://github.com/zhaochenyang20
 """
 
 from __future__ import annotations
@@ -31,8 +32,7 @@ from tests.utils import (
 MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
 
 CONCURRENCY = 8
-MAX_SAMPLES = 1000
-SEED = 42
+MAX_SAMPLES = 500
 STARTUP_TIMEOUT = 900
 
 MMSU_MIN_ACCURACY = 0.52
@@ -85,8 +85,7 @@ def _build_args(port: int, output_dir: str) -> argparse.Namespace:
         max_concurrency=CONCURRENCY,
         request_rate=float("inf"),
         save_audio=False,
-        disable_tqdm=True,
-        seed=SEED,
+        disable_tqdm=True
     )
 
 

--- a/tests/test_model/test_qwen3_omni_mmsu_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_ci.py
@@ -35,13 +35,13 @@ MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
 CONCURRENCY = 8
 STARTUP_TIMEOUT = 900
 
-MMSU_MIN_ACCURACY = 0.52
+MMSU_MIN_ACCURACY = 0.67
 
 _MMSU_P95 = {
     8: {
-        "throughput_qps": 0.001,
-        "tok_per_s_agg": 1.0,
-        "latency_mean_s": 1000.0,
+        "throughput_qps": 8.24,
+        "tok_per_s_agg": 3.9,
+        "latency_mean_s": 0.969,
     },
 }
 MMSU_THRESHOLDS = apply_slack(_MMSU_P95)

--- a/tests/test_model/test_qwen3_omni_mmsu_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_ci.py
@@ -35,13 +35,13 @@ MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
 CONCURRENCY = 8
 STARTUP_TIMEOUT = 900
 
-MMSU_MIN_ACCURACY = 0.67
+MMSU_MIN_ACCURACY = 0.69
 
 _MMSU_P95 = {
     8: {
-        "throughput_qps": 8.24,
-        "tok_per_s_agg": 3.9,
-        "latency_mean_s": 0.969,
+        "throughput_qps": 9.94,
+        "tok_per_s_agg": 2.60,
+        "latency_mean_s": 0.804,
     },
 }
 MMSU_THRESHOLDS = apply_slack(_MMSU_P95)

--- a/tests/test_model/test_qwen3_omni_mmsu_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_ci.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import pytest
 
+from benchmarks.dataset.prepare import DATASETS
 from benchmarks.eval.benchmark_omni_mmsu import run as run_mmsu
 from sglang_omni.utils import find_available_port
 from tests.utils import (
@@ -32,7 +33,6 @@ from tests.utils import (
 MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
 
 CONCURRENCY = 8
-MAX_SAMPLES = 500
 STARTUP_TIMEOUT = 900
 
 MMSU_MIN_ACCURACY = 0.52
@@ -75,17 +75,19 @@ def _build_args(port: int, output_dir: str) -> argparse.Namespace:
         model="qwen3-omni",
         modalities="text",
         output_dir=output_dir,
-        max_samples=MAX_SAMPLES,
+        max_samples=None,
         task_names=None,
         categories=None,
         prompt=None,
         max_tokens=32,
         temperature=0.0,
-        warmup=1,
+        warmup=0,
         max_concurrency=CONCURRENCY,
         request_rate=float("inf"),
         save_audio=False,
-        disable_tqdm=True
+        disable_tqdm=True,
+        seed=None,
+        repo_id=DATASETS["mmsu-ci-2000"],
     )
 
 

--- a/tests/test_model/test_qwen3_omni_mmsu_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_ci.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import subprocess
 import sys
 from pathlib import Path
 
@@ -24,6 +23,7 @@ from benchmarks.dataset.prepare import DATASETS
 from benchmarks.eval.benchmark_omni_mmsu import run as run_mmsu
 from sglang_omni.utils import find_available_port
 from tests.utils import (
+    ServerHandle,
     apply_slack,
     assert_speed_thresholds,
     start_server_from_cmd,
@@ -62,8 +62,7 @@ def server_process(tmp_path_factory: pytest.TempPathFactory):
         "qwen3-omni",
     ]
     proc = start_server_from_cmd(cmd, log_file, port, timeout=STARTUP_TIMEOUT)
-    proc.port = port
-    yield proc
+    yield ServerHandle(proc=proc, port=port)
     stop_server(proc)
 
 
@@ -88,12 +87,15 @@ def _build_args(port: int, output_dir: str) -> argparse.Namespace:
         disable_tqdm=True,
         seed=None,
         repo_id=DATASETS["mmsu-ci-2000"],
+        # Unused in text-only mode but kept for API consistency with run().
+        lang="en",
+        asr_device="cuda:0",
     )
 
 
 @pytest.mark.benchmark
 def test_mmsu_accuracy_and_speed(
-    server_process: subprocess.Popen,
+    server_process: ServerHandle,
     tmp_path: Path,
 ) -> None:
     """Run MMSU eval and assert accuracy and speed meet thresholds."""

--- a/tests/test_model/test_qwen3_omni_mmsu_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_ci.py
@@ -81,7 +81,7 @@ def _build_args(port: int, output_dir: str) -> argparse.Namespace:
         prompt=None,
         max_tokens=32,
         temperature=0.0,
-        warmup=0,
+        warmup=1,
         max_concurrency=CONCURRENCY,
         request_rate=float("inf"),
         save_audio=False,
@@ -99,6 +99,13 @@ def test_mmsu_accuracy_and_speed(
     """Run MMSU eval and assert accuracy and speed meet thresholds."""
     args = _build_args(server_process.port, str(tmp_path / "mmsu"))
     results = asyncio.run(run_mmsu(args))
+
+    failed = results["accuracy"].get("failed_samples", 0)
+    total = results["accuracy"].get("total_samples", 0)
+    assert failed == 0, (
+        f"MMSU had {failed}/{total} failed requests (timeouts or empty responses); "
+        f"any failure fails the test"
+    )
 
     accuracy = results["accuracy"]["overall_accuracy"]
     assert accuracy >= MMSU_MIN_ACCURACY, (

--- a/tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py
@@ -50,7 +50,7 @@ STARTUP_TIMEOUT = 900
 # modules serialize GPU access, so they run serially even when concurrency > 1.
 CONCURRENCY = 1
 
-# Use chain-of-thought prompt (mirroring MMMU style) instead of the default
+# Note (Yifei): Use chain-of-thought prompt (mirroring MMMU style) instead of the default
 # "Reply with only A, B, C, or D." to elicit longer responses for WER.
 MMSU_TTS_PROMPT = (
     "Listen to the audio and answer the multiple-choice question. "
@@ -61,8 +61,8 @@ MMSU_TTS_PROMPT = (
 
 # TODO (Yifei): update thresholds when concurrency > 1 is supported.
 
-MMMU_AUDIO_WER_MAX_CORPUS = 0.12
-MMMU_AUDIO_WER_MAX_PER_SAMPLE = 0.20
+MMSU_AUDIO_WER_MAX_CORPUS = 0.12
+MMSU_AUDIO_WER_MAX_PER_SAMPLE = 0.20
 
 _MMSU_AUDIO_P95 = {
     1: {

--- a/tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py
@@ -20,9 +20,8 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import subprocess
 import sys
-from copy import copy
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -32,6 +31,7 @@ from benchmarks.dataset.prepare import DATASETS
 from benchmarks.eval.benchmark_omni_mmsu import run as run_mmsu
 from sglang_omni.utils import find_available_port
 from tests.utils import (
+    ServerHandle,
     apply_slack,
     assert_speed_thresholds,
     assert_wer_results,
@@ -98,8 +98,7 @@ def server_process(tmp_path_factory: pytest.TempPathFactory):
         "qwen3-omni",
     ]
     proc = start_server_from_cmd(cmd, log_file, port, timeout=STARTUP_TIMEOUT)
-    proc.port = port
-    yield proc
+    yield ServerHandle(proc=proc, port=port)
     stop_server(proc)
 
 
@@ -130,7 +129,7 @@ def _build_args(port: int, output_dir: str) -> argparse.Namespace:
 
 @pytest.mark.benchmark
 def test_mmsu_audio_wer_and_speed(
-    server_process: subprocess.Popen,
+    server_process: ServerHandle,
     tmp_path: Path,
 ) -> None:
     """Run MMSU eval with audio and assert WER and speed meet thresholds."""
@@ -141,7 +140,7 @@ def test_mmsu_audio_wer_and_speed(
     # audio encoder sees a cached+non-cached mixed batch. Inert at
     # concurrency=1; starts to take effect once concurrency is raised.
     base = load_mmsu_samples(max_samples=MAX_SAMPLES, repo_id=DATASETS["mmsu-ci-2000"])
-    dup = copy(base[0])
+    dup = deepcopy(base[0])
     dup.sample_id = f"{base[0].sample_id}__dup"
     samples = [*base, dup]
 

--- a/tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py
@@ -62,14 +62,14 @@ MMSU_TTS_PROMPT = (
 # TODO (Yifei): update thresholds when concurrency > 1 is supported.
 
 MMSU_AUDIO_WER_MAX_CORPUS = 0.12
-MMSU_AUDIO_WER_MAX_PER_SAMPLE = 0.20
+MMSU_AUDIO_WER_MAX_PER_SAMPLE = 0.36
 
 _MMSU_AUDIO_P95 = {
     1: {
-        "throughput_qps": 0.03,
-        "tok_per_s_agg": 1.70,
-        "latency_mean_s": 29.090,
-        "rtf_mean": 1.5625,
+        "throughput_qps": 0.04,
+        "tok_per_s_agg": 1.80,
+        "latency_mean_s": 27.376,
+        "rtf_mean": 1.5734,
     },
 }
 MMSU_AUDIO_THRESHOLDS = apply_slack(_MMSU_AUDIO_P95)

--- a/tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py
@@ -58,8 +58,10 @@ MMSU_TTS_PROMPT = (
     "where LETTER is one of the options."
 )
 
-MMSU_AUDIO_WER_MAX_CORPUS = 0.10
-MMSU_AUDIO_WER_MAX_PER_SAMPLE = 0.18
+# TODO: Update thresholds after testing on H20 CI machines.
+
+MMSU_AUDIO_WER_MAX_CORPUS = 0.30
+MMSU_AUDIO_WER_MAX_PER_SAMPLE = 0.50
 
 _MMSU_AUDIO_P95 = {
     1: {

--- a/tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MMSU TTS consistency CI for Qwen3-Omni (Text + Audio → Text+Audio, Talker ON).
+
+Evaluates text-audio consistency by comparing the model's text output with
+ASR transcription of its audio output on MMSU audio-QA tasks. The default
+"Reply with only A, B, C, or D." instruction is stripped so the model
+produces a full-sentence response suitable for WER evaluation.
+
+Usage:
+    pytest tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py -v -s -x
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from benchmarks.eval.benchmark_omni_mmsu import run as run_mmsu
+from sglang_omni.utils import find_available_port
+from tests.utils import (
+    apply_slack,
+    assert_speed_thresholds,
+    assert_wer_results,
+    start_server_from_cmd,
+    stop_server,
+)
+
+MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
+
+MAX_SAMPLES = 5
+MAX_TOKENS = 50
+SEED = 42
+STARTUP_TIMEOUT = 900
+
+# Note (Yifei): Concurrency=1 only for now — code_predictor and code2wav
+# modules serialize GPU access, so they run serially even when concurrency > 1.
+CONCURRENCY = 1
+
+# Strip the "Reply with only A, B, C, or D." constraint so the model emits
+# a natural-language response that can be transcribed for WER comparison.
+MMSU_TTS_PROMPT = "Listen to the audio and answer the multiple-choice question."
+
+MMSU_AUDIO_WER_MAX_CORPUS = 0.10
+MMSU_AUDIO_WER_MAX_PER_SAMPLE = 0.18
+
+_MMSU_AUDIO_P95 = {
+    1: {
+        "throughput_qps": 0.001,
+        "tok_per_s_agg": 1.0,
+        "latency_mean_s": 1000.0,
+        "rtf_mean": 1000.0,
+    },
+}
+MMSU_AUDIO_THRESHOLDS = apply_slack(_MMSU_AUDIO_P95)
+
+
+@pytest.fixture(scope="module")
+def server_process(tmp_path_factory: pytest.TempPathFactory):
+    port = find_available_port()
+    log_file = tmp_path_factory.mktemp("server_logs") / "server.log"
+    cmd = [
+        sys.executable,
+        "examples/run_qwen3_omni_speech_server.py",
+        "--model-path",
+        MODEL_PATH,
+        "--gpu-thinker",
+        "0",
+        "--gpu-talker",
+        "1",
+        "--gpu-code-predictor",
+        "1",
+        "--gpu-code2wav",
+        "1",
+        "--port",
+        str(port),
+        "--model-name",
+        "qwen3-omni",
+    ]
+    proc = start_server_from_cmd(cmd, log_file, port, timeout=STARTUP_TIMEOUT)
+    proc.port = port
+    yield proc
+    stop_server(proc)
+
+
+def _build_args(port: int, output_dir: str) -> argparse.Namespace:
+    return argparse.Namespace(
+        base_url=None,
+        host="localhost",
+        port=port,
+        model="qwen3-omni",
+        modalities="text+audio",
+        output_dir=output_dir,
+        max_samples=MAX_SAMPLES,
+        task_names=None,
+        categories=None,
+        prompt=MMSU_TTS_PROMPT,
+        max_tokens=MAX_TOKENS,
+        temperature=0.0,
+        warmup=0,
+        max_concurrency=CONCURRENCY,
+        request_rate=float("inf"),
+        save_audio=True,
+        disable_tqdm=True,
+        seed=SEED,
+        lang="en",
+        asr_device="cuda:0",
+    )
+
+
+@pytest.mark.benchmark
+def test_mmsu_audio_wer_and_speed(
+    server_process: subprocess.Popen,
+    tmp_path: Path,
+) -> None:
+    """Run MMSU eval with audio and assert WER and speed meet thresholds."""
+    args = _build_args(server_process.port, str(tmp_path / "mmsu_audio"))
+    results = asyncio.run(run_mmsu(args))
+
+    assert "wer" in results, "Audio WER results missing from eval output"
+    assert_wer_results(
+        results["wer"], MMSU_AUDIO_WER_MAX_CORPUS, MMSU_AUDIO_WER_MAX_PER_SAMPLE
+    )
+
+    assert_speed_thresholds(results["speed"], MMSU_AUDIO_THRESHOLDS, CONCURRENCY)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-s", "-x", "-v"]))

--- a/tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py
@@ -41,6 +41,7 @@ from tests.utils import (
 
 MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
 
+# TODO (Yifei): enable larger subset/max_tokens when concurrency > 1 is supported.
 MAX_SAMPLES = 5
 MAX_TOKENS = 50
 STARTUP_TIMEOUT = 900
@@ -58,17 +59,17 @@ MMSU_TTS_PROMPT = (
     "where LETTER is one of the options."
 )
 
-# TODO: Update thresholds after testing on H20 CI machines.
+# TODO (Yifei): update thresholds when concurrency > 1 is supported.
 
-MMSU_AUDIO_WER_MAX_CORPUS = 0.30
-MMSU_AUDIO_WER_MAX_PER_SAMPLE = 0.50
+MMMU_AUDIO_WER_MAX_CORPUS = 0.12
+MMMU_AUDIO_WER_MAX_PER_SAMPLE = 0.20
 
 _MMSU_AUDIO_P95 = {
     1: {
-        "throughput_qps": 0.001,
-        "tok_per_s_agg": 1.0,
-        "latency_mean_s": 1000.0,
-        "rtf_mean": 1000.0,
+        "throughput_qps": 0.03,
+        "tok_per_s_agg": 1.70,
+        "latency_mean_s": 29.090,
+        "rtf_mean": 1.5625,
     },
 }
 MMSU_AUDIO_THRESHOLDS = apply_slack(_MMSU_AUDIO_P95)
@@ -116,7 +117,7 @@ def _build_args(port: int, output_dir: str) -> argparse.Namespace:
         prompt=MMSU_TTS_PROMPT,
         max_tokens=MAX_TOKENS,
         temperature=0.0,
-        warmup=0,
+        warmup=1,
         max_concurrency=CONCURRENCY,
         request_rate=float("inf"),
         save_audio=True,
@@ -145,6 +146,13 @@ def test_mmsu_audio_wer_and_speed(
     samples = [*base, dup]
 
     results = asyncio.run(run_mmsu(args, samples=samples))
+
+    failed = results["accuracy"].get("failed_samples", 0)
+    total = results["accuracy"].get("total_samples", 0)
+    assert failed == 0, (
+        f"MMSU TTS consistency had {failed}/{total} failed requests "
+        f"(timeouts or empty responses); any failure fails the test"
+    )
 
     assert "wer" in results, "Audio WER results missing from eval output"
     assert_wer_results(

--- a/tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py
@@ -22,10 +22,12 @@ import argparse
 import asyncio
 import subprocess
 import sys
+from copy import copy
 from pathlib import Path
 
 import pytest
 
+from benchmarks.dataset.mmsu import load_mmsu_samples
 from benchmarks.eval.benchmark_omni_mmsu import run as run_mmsu
 from sglang_omni.utils import find_available_port
 from tests.utils import (
@@ -129,7 +131,17 @@ def test_mmsu_audio_wer_and_speed(
 ) -> None:
     """Run MMSU eval with audio and assert WER and speed meet thresholds."""
     args = _build_args(server_process.port, str(tmp_path / "mmsu_audio"))
-    results = asyncio.run(run_mmsu(args))
+
+    # NOTE (Yifei):
+    # Regression guard for issue #299: append a dup of sample[0] so the
+    # audio encoder sees a cached+non-cached mixed batch. Inert at
+    # concurrency=1; starts to take effect once concurrency is raised.
+    base = load_mmsu_samples(max_samples=MAX_SAMPLES)
+    dup = copy(base[0])
+    dup.sample_id = f"{base[0].sample_id}__dup"
+    samples = [*base, dup]
+
+    results = asyncio.run(run_mmsu(args, samples=samples))
 
     assert "wer" in results, "Audio WER results missing from eval output"
     assert_wer_results(

--- a/tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py
@@ -28,6 +28,7 @@ from pathlib import Path
 import pytest
 
 from benchmarks.dataset.mmsu import load_mmsu_samples
+from benchmarks.dataset.prepare import DATASETS
 from benchmarks.eval.benchmark_omni_mmsu import run as run_mmsu
 from sglang_omni.utils import find_available_port
 from tests.utils import (
@@ -136,7 +137,9 @@ def test_mmsu_audio_wer_and_speed(
     # Regression guard for issue #299: append a dup of sample[0] so the
     # audio encoder sees a cached+non-cached mixed batch. Inert at
     # concurrency=1; starts to take effect once concurrency is raised.
-    base = load_mmsu_samples(max_samples=MAX_SAMPLES)
+    base = load_mmsu_samples(
+        max_samples=MAX_SAMPLES, repo_id=DATASETS["mmsu-ci-2000"]
+    )
     dup = copy(base[0])
     dup.sample_id = f"{base[0].sample_id}__dup"
     samples = [*base, dup]

--- a/tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py
@@ -2,12 +2,18 @@
 """MMSU TTS consistency CI for Qwen3-Omni (Text + Audio → Text+Audio, Talker ON).
 
 Evaluates text-audio consistency by comparing the model's text output with
-ASR transcription of its audio output on MMSU audio-QA tasks. The default
-"Reply with only A, B, C, or D." instruction is stripped so the model
-produces a full-sentence response suitable for WER evaluation.
+ASR transcription of its audio output on MMSU audio-QA tasks. Uses a
+chain-of-thought prompt (mirroring MMMU style) so the model reasons step
+by step before giving the final answer letter, producing longer responses
+more suitable for WER evaluation.
 
 Usage:
     pytest tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py -v -s -x
+
+Author:
+    Yifei Gao https://github.com/PasserBy4
+    Huapeng Zhou https://github.com/PopSoda2002
+    Chenyang Zhao https://github.com/zhaochenyang20
 """
 
 from __future__ import annotations
@@ -33,17 +39,21 @@ from tests.utils import (
 MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
 
 MAX_SAMPLES = 5
-MAX_TOKENS = 50
-SEED = 42
+MAX_TOKENS = 100
 STARTUP_TIMEOUT = 900
 
 # Note (Yifei): Concurrency=1 only for now — code_predictor and code2wav
 # modules serialize GPU access, so they run serially even when concurrency > 1.
 CONCURRENCY = 1
 
-# Strip the "Reply with only A, B, C, or D." constraint so the model emits
-# a natural-language response that can be transcribed for WER comparison.
-MMSU_TTS_PROMPT = "Listen to the audio and answer the multiple-choice question."
+# Use chain-of-thought prompt (mirroring MMMU style) instead of the default
+# "Reply with only A, B, C, or D." to elicit longer responses for WER.
+MMSU_TTS_PROMPT = (
+    "Listen to the audio and answer the multiple-choice question. "
+    "Think step by step before answering. The last line of your response "
+    "should be of the following format: 'Answer: $LETTER' (without quotes) "
+    "where LETTER is one of the options."
+)
 
 MMSU_AUDIO_WER_MAX_CORPUS = 0.10
 MMSU_AUDIO_WER_MAX_PER_SAMPLE = 0.18
@@ -106,7 +116,7 @@ def _build_args(port: int, output_dir: str) -> argparse.Namespace:
         request_rate=float("inf"),
         save_audio=True,
         disable_tqdm=True,
-        seed=SEED,
+        seed=None,
         lang="en",
         asr_device="cuda:0",
     )

--- a/tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_tts_consistency_ci.py
@@ -42,7 +42,7 @@ from tests.utils import (
 MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
 
 MAX_SAMPLES = 5
-MAX_TOKENS = 100
+MAX_TOKENS = 50
 STARTUP_TIMEOUT = 900
 
 # Note (Yifei): Concurrency=1 only for now — code_predictor and code2wav
@@ -137,9 +137,7 @@ def test_mmsu_audio_wer_and_speed(
     # Regression guard for issue #299: append a dup of sample[0] so the
     # audio encoder sees a cached+non-cached mixed batch. Inert at
     # concurrency=1; starts to take effect once concurrency is raised.
-    base = load_mmsu_samples(
-        max_samples=MAX_SAMPLES, repo_id=DATASETS["mmsu-ci-2000"]
-    )
+    base = load_mmsu_samples(max_samples=MAX_SAMPLES, repo_id=DATASETS["mmsu-ci-2000"])
     dup = copy(base[0])
     dup.sample_id = f"{base[0].sample_id}__dup"
     samples = [*base, dup]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,12 +8,21 @@ import signal
 import statistics
 import subprocess
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Generator
 
 from benchmarks.benchmarker.utils import wait_for_service
 
 STARTUP_TIMEOUT = 600
+
+
+@dataclass
+class ServerHandle:
+    """Typed bundle of a running server's process and its port."""
+
+    proc: subprocess.Popen
+    port: int
 
 
 @contextmanager


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Adds MMSU-dimension CI coverage for Qwen3-Omni: thinker-only accuracy/speed plus full-pipeline text-audio consistency (WER), and locks down the #305 regression as a guard.

## Modifications

### New CI stages
- **Stage 4 — MMSU accuracy + speed** (`test_qwen3_omni_mmsu_ci.py`): `modalities="text"`, thinker-only, concurrency=8, runs all 2000 samples from `mmsu-ci-2000`.
- **Stage 5 — MMSU TTS consistency** (`test_qwen3_omni_mmsu_tts_consistency_ci.py`): full 9-stage pipeline (talker + code2wav), `modalities="text+audio"`, concurrency=1, 5 samples + **1 explicitly appended duplicate sample**, each capped at 50 generated tokens.

> ⚠️ **About whether Stage 5 should go into main CI**: because the code_predictor / code2wav path does not yet support concurrency > 1 (blocked by #276 among others), this stage can only run at c=1 with 6 samples × 50 tokens — the sample size and threshold confidence are both low. **Consider holding Stage 5 out of main CI for now**, and revisit once concurrency support lands so we can scale up sample size and re-calibrate thresholds.

### Monitored metrics and thresholds (calibrated on H20 runner)

Stage 4 (concurrency=8):
| Metric | Threshold |
|---|---|
| `MMSU_MIN_ACCURACY` | 0.69 |
| `throughput_qps` | 9.94 |
| `tok_per_s_agg` | 2.60 |
| `latency_mean_s` | 0.804 |
| `failed_samples` | == 0 |

Stage 5 (concurrency=1):
| Metric | Threshold |
|---|---|
| `MMSU_AUDIO_WER_MAX_CORPUS` | 0.12 |
| `MMSU_AUDIO_WER_MAX_PER_SAMPLE` | 0.36 |
| `throughput_qps` | 0.04 |
| `tok_per_s_agg` | 1.80 |
| `latency_mean_s` | 27.376 |
| `rtf_mean` | 1.5734 |
| `failed_samples` | == 0 |

All speed thresholds will be further loosened via `apply_slack` on top of observed thresholds to absorb transient jitter.

### Duplicate audio requests (#305 regression guard)
Both stages exercise the `cached + non-cached` mixed-batch path:
- **Stage 4**: `mmsu-ci-2000` natively contains **32 pairs of sha1-identical audio** (64 requests sharing 32 audio contents); running the full 2000 samples covers this path organically.
- **Stage 5**: explicitly `append`s a dup of `base[0]` (too few samples to reliably hit the native dups, so manual injection is needed).

### Dataset
Adds support for[`zhaochenyang20/mmsu-ci-2000`](https://huggingface.co/datasets/zhaochenyang20/mmsu-ci-2000) — 2000 samples randomly drawn from MMSU full (5000) with `seed=42`. All 47 task sub-types and the full category / sub-category / sub-sub-category distribution are preserved and closely match the full set.

### Metrics & failure detection
- `MmsuResult` / summary JSON adds `is_success` plus `successful_samples` / `failed_samples` counters, fully decoupling "request succeeded" from "answer parseable".
- Both stages hard-assert `failed_samples == 0`: any timeout / empty response / network error fails the test.
- `save_mmsu_results` now also writes WER into `mmsu_results.json` for a unified output schema.

### Code structure
- `benchmarks/tasks/mmsu.py` → `benchmarks/tasks/audio_understanding.py`
- `compute_text_audio_consistency` moved into `benchmarks/tasks/tts.py`, replacing the inline `_compute_audio_wer` in `benchmark_omni_mmmu.py`; MMMU and MMSU now share one WER implementation.
- `load_mmsu_samples` gains a `repo_id` kwarg, letting CI point at a custom HF dataset.
- `run()` gains a `samples` kwarg so tests can inject externally-built sample lists (e.g. with a dup appended).

## Related PR/Issues
- Part of [#253 Comprehensive CI Coverage for Qwen3 Omni: All Modality Combinations](https://github.com/sgl-project/sglang-omni/issues/253)
- Regression guard for [#305 Fix cached requests dropped in mixed batches causing pipeline hang](https://github.com/sgl-project/sglang-omni/pull/305)
- Related to [#285 Fix Qwen3-Omni variable-length audio batching in encoder runtime](https://github.com/sgl-project/sglang-omni/pull/285)

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
