### PR TITLE
qwen3 omni: switch talker moe backend to fused native

### DIFF
--- a/sglang_omni/models/qwen3_omni/talker.py
+++ b/sglang_omni/models/qwen3_omni/talker.py
@@ -12,7 +12,8 @@ from typing import Iterable, Optional, Tuple
 
 import torch
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
-from sglang.srt.layers.moe.fused_moe_native import moe_forward_native
+from sglang.srt.layers.moe.fused_moe_native import fused_moe_forward_native
+from sglang.srt.layers.moe.token_dispatcher import StandardDispatchOutput
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix
 from torch import nn
@@ -237,14 +238,15 @@ class Qwen3OmniMoeTalkerSparseMoeBlock(Qwen3OmniMoeThinkerTextSparseMoeBlock):
         # --- Routed experts (no all-reduce yet) ---
         router_logits, _ = self.gate(linear_hidden_states)
         topk_output = self.topk(linear_hidden_states, router_logits)
-        # Talker parity depends on the native MoE path here. The fused routed-expert
-        # path diverges from HF on exact layer inputs, while the native path matches.
-        routed_output = moe_forward_native(
-            self.experts,
-            linear_hidden_states,
-            topk_output,
-            self.experts.moe_runner_config,
+        dispatch_output = StandardDispatchOutput(
+            hidden_states=linear_hidden_states,
+            hidden_states_scale=None,
+            topk_output=topk_output,
         )
+        routed_output = fused_moe_forward_native(
+            self.experts,
+            dispatch_output,
+        ).hidden_states
 
         # --- Combine then unified all-reduce ---
         final_hidden_states = routed_output + shared_output


### PR DESCRIPTION
## Motivation

This PR switches the Qwen3-Omni talker MoE backend from the current unfused/native path to the fused native path.

The motivation:

- better precision alignment based on our existing three-way MoE studies
- better throughput / lower latency in end-to-end talker evaluation
- better CUDA-graph compatibility for future talker refactors and kernel work

## WER Benchmark

We ran the same Qwen3-Omni WER benchmark on the same 50-sample English SeedTTS split, comparing:

- `origin/main` with the original talker backend (`moe_forward_native`)
- the same branch with a minimal switch to `fused_moe_forward_native`

| Metric | Original backend (`moe_forward_native`) | Fused backend (`fused_moe_forward_native`) |
| --- | ---: | ---: |
| Total samples | 50 | 50 |
| Evaluated | 50 | 50 |
| Skipped | 0 | 0 |
| Corpus WER | 0.014492753623188406 (1.45%) | 0.014492753623188406 (1.45%) |
| Mean per-sample WER | 0.0153815987933635 (1.54%) | 0.01571493212669683 (1.57%) |
| Median per-sample WER | 0.0 | 0.0 |
| Mean latency (s) | 6.73298 | 5.479964 |
| Mean audio duration (s) | 3.4542539999999997 | 3.4617579999999997 |

On this 50-sample run, the fused backend keeps corpus WER unchanged while reducing mean latency from `6.73298s` to `5.479964s` (about `18.6%` faster).

## Layer-Wise Precision Experiment Result

Did a three-way MoE precision study  comparing:

- `moe_native`
- `fused_native`
- `experts`

against a local `hf_eager` reference reconstructed from the same loaded SGLang weights.

The conclusions include:

- the three MoE implementations are numerically different
- `fused_native` is consistently the closest mode to the local `hf_eager` reference in our replay experiments
- this is true both on random layer replay inputs and on captured real talker runtime inputs
- real runtime traces also diverge across the three backends, confirming that the backend choice affects the actual decode path rather than only isolated offline tensor tests

### Selected Precision Numbers

Synthetic control between `moe_native` and `fused_native` already shows a large mismatch:

| Shape | `allclose_all_trials` | `max_abs_overall` | `mean_abs_overall` |
| --- | --- | ---: | ---: |
| Talker-like (`hidden=1024`, `intermediate=384`, `top_k=6`) | `false` | `192.0` | `8.6449` |
| Thinker-like (`hidden=2048`, `intermediate=768`, `top_k=8`) | `false` | `512.0` | `20.7994` |

Random-input replay on talker layers, measured against `hf_eager`:

| Layer | `fused_native` mean abs | `moe_native` mean abs | `experts` mean abs |
| --- | ---: | ---: | ---: |
| 0 | `1.157e-4` | `1.899e-4` | `1.920e-4` |
| 9 | `1.000e-4` | `1.674e-4` | `1.695e-4` |
| 19 | `1.430e-4` | `2.415e-4` | `2.447e-4` |

Replay on one real talker decode trajectory, again measured against `hf_eager`:

| Layer | `fused_native` mean abs | `moe_native` mean abs | `experts` mean abs |
| --- | ---: | ---: | ---: |
| 0 | `3.974e-5` | `5.674e-5` | `6.058e-5` |
| 9 | `3.097e-5` | `4.955e-5` | `4.990e-5` |
| 19 | `1.788e-4` | `2.842e-4` | `2.912e-4` |

In the runtime A/B/C experiment, the three backends also diverged immediately in real pipeline traces, including:

- first talker AR-step trace
- decode-step talker inputs
- code predictor outputs
- code2wav emitted chunk payloads

This means the backend swap produces real runtime differences, and the current replay evidence consistently places `fused_native` closest to the local eager-style reference.

### Conclusion

Comparing the three kernels, fused_native's numerical value staye closest to the HF baseline and stays CUDA_graph friendly. So this pr propose switching talker MOE kernel to fused_native to improve accuracy, improve throughput and make future CUDA-graph refractor friendly.


