### PR TITLE
qwen3 omni: switch talker moe backend to sglang fused native

### DIFF
--- a/sglang_omni/models/qwen3_omni/talker.py
+++ b/sglang_omni/models/qwen3_omni/talker.py
@@ -12,7 +12,8 @@ from typing import Iterable, Optional, Tuple
 
 import torch
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
-from sglang.srt.layers.moe.fused_moe_native import moe_forward_native
+from sglang.srt.layers.moe.fused_moe_native import fused_moe_forward_native
+from sglang.srt.layers.moe.token_dispatcher import StandardDispatchOutput
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix
 from torch import nn
@@ -237,14 +238,15 @@ class Qwen3OmniMoeTalkerSparseMoeBlock(Qwen3OmniMoeThinkerTextSparseMoeBlock):
         # --- Routed experts (no all-reduce yet) ---
         router_logits, _ = self.gate(linear_hidden_states)
         topk_output = self.topk(linear_hidden_states, router_logits)
-        # Talker parity depends on the native MoE path here. The fused routed-expert
-        # path diverges from HF on exact layer inputs, while the native path matches.
-        routed_output = moe_forward_native(
-            self.experts,
-            linear_hidden_states,
-            topk_output,
-            self.experts.moe_runner_config,
+        dispatch_output = StandardDispatchOutput(
+            hidden_states=linear_hidden_states,
+            hidden_states_scale=None,
+            topk_output=topk_output,
         )
+        routed_output = fused_moe_forward_native(
+            self.experts,
+            dispatch_output,
+        ).hidden_states
 
         # --- Combine then unified all-reduce ---
         final_hidden_states = routed_output + shared_output

--- a/sglang_omni/models/qwen3_omni/talker.py
+++ b/sglang_omni/models/qwen3_omni/talker.py
@@ -12,8 +12,6 @@ from typing import Iterable, Optional, Tuple
 
 import torch
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
-from sglang.srt.layers.moe.fused_moe_native import fused_moe_forward_native
-from sglang.srt.layers.moe.token_dispatcher import StandardDispatchOutput
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix
 from torch import nn
@@ -230,7 +228,6 @@ class Qwen3OmniMoeTalkerSparseMoeBlock(Qwen3OmniMoeThinkerTextSparseMoeBlock):
             linear_hidden_states = linear_hidden_states.to(dtype=linear_dtype)
 
         # Shared branch must consume the original MLP input before routed experts.
-        # The fused MoE implementation mutates `hidden_states` in-place.
         shared_output = self.shared_expert(linear_hidden_states)
         shared_gate, _ = self.shared_expert_gate(linear_hidden_states)
         shared_output = shared_output * torch.sigmoid(shared_gate)
@@ -238,15 +235,7 @@ class Qwen3OmniMoeTalkerSparseMoeBlock(Qwen3OmniMoeThinkerTextSparseMoeBlock):
         # --- Routed experts (no all-reduce yet) ---
         router_logits, _ = self.gate(linear_hidden_states)
         topk_output = self.topk(linear_hidden_states, router_logits)
-        dispatch_output = StandardDispatchOutput(
-            hidden_states=linear_hidden_states,
-            hidden_states_scale=None,
-            topk_output=topk_output,
-        )
-        routed_output = fused_moe_forward_native(
-            self.experts,
-            dispatch_output,
-        ).hidden_states
+        routed_output = self.experts(linear_hidden_states, topk_output)
 
         # --- Combine then unified all-reduce ---
         final_hidden_states = routed_output + shared_output


### PR DESCRIPTION
This PR switches the Qwen3-Omni talker MoE backend on `main` from the current native / unfused path to the standard SGLang `.experts()` path.

The motivation is straightforward:

- use the official SGLang MoE surface already used by the thinker path
- improve end-to-end talker throughput in our WER evaluation
- keep the talker backend aligned with upstream MoE kernel work instead of maintaining a separate custom path

## Pros and Cons

We have three kernels to choose from: 
- `moe_native`
- `fused_native`
- `experts`

#### experts:
         Pros: official sglang moe backend. CUDA_graph friendly. Simpliest code. Most likely to be maintained by sglang for longer time. Align with the thinker backend. 
         Cons: Bad precision on both benchmark and layer-wise precision test (performance downgrade)

### fused-native:
         Pros: Also CUDA_graph friendly, faster, best precision in layer-wise test.
         Cons:heavy memory operation w13_weights = layer.w13_weight[topk_ids] which can cause OOM if large input. Not recommended

#### moe_native
        Pros: Current implementation. No need to change. Best benchmark WER score.
        Cons: Not sglang-official implementation. Can't enable CUDA graph causing ~2x speed downgrade.

## WER Benchmark

We ran the same Qwen3-Omni WER benchmark on the same 50-sample English SeedTTS split, comparing:

- `origin/main` with the original talker backend (`moe_forward_native`)
- the same branch with a minimal switch to `self.experts(...)`

.experts() full benchmark:

<img width="455" height="290" alt="fcdd168453d264e048827a29ed5d7898" src="https://github.com/user-attachments/assets/935d5103-7c67-4911-b868-fc8e6bf3bb55" />


fused_native full benchmark:

<img width="436" height="293" alt="Screenshot 2026-04-17 at 1 17 43 PM" src="https://github.com/user-attachments/assets/09b74197-9bc6-4e9b-ae6e-be0364c8cab4" />

On this 50-sample run, the `.experts()` backend improved corpus WER from `1.45%` to `1.27%` and reduced mean latency from `6.73298s` to `5.91012s`.

## Layer-Wise Precision Experiment Result

We already have a three-way MoE precision study in `sglang-omni-refractor` comparing:

- `moe_native`
- `fused_native`
- `experts`

against a local `hf_eager` reference reconstructed from the same loaded SGLang weights.

The main conclusions from the existing logs are:


- the three MoE implementations are numerically different
- `fused_native` is consistently the closest mode to the local `hf_eager` reference in our replay experiments
- this is true both on random layer replay inputs and on captured real talker runtime inputs
- local eager-alignment does not cleanly predict end-to-end WER by itself

### Selected Precision Numbers

Synthetic control between `moe_native` and `fused_native` already shows a large mismatch:

| Shape | `allclose_all_trials` | `max_abs_overall` | `mean_abs_overall` |
| --- | --- | ---: | ---: |
| Talker-like (`hidden=1024`, `intermediate=384`, `top_k=6`) | `false` | `192.0` | `8.6449` |
| Thinker-like (`hidden=2048`, `intermediate=768`, `top_k=8`) | `false` | `512.0` | `20.7994` |

Random-input replay on talker layers, measured against `hf_eager`:

| Layer | `fused_native` mean abs | `moe_native` mean abs | `experts` mean abs |
| --- | ---: | ---: | ---: |
| 0 | `1.157e-4` | `1.899e-4` | `1.920e-4` |
| 9 | `1.000e-4` | `1.674e-4` | `1.695e-4` |
| 19 | `1.430e-4` | `2.415e-4` | `2.447e-4` |

Replay on one real talker decode trajectory, again measured against `hf_eager`:

| Layer | `fused_native` mean abs | `moe_native` mean abs | `experts` mean abs |
| --- | ---: | ---: | ---: |
| 0 | `3.974e-5` | `5.674e-5` | `6.058e-5` |
| 9 | `3.097e-5` | `4.955e-5` | `4.990e-5` |
| 19 | `1.788e-4` | `2.842e-4` | `2.912e-4` |

In other words, `fused_native` remains closest to the local eager-style reference in our replay harness, but the official `.experts()` backend performed well in the end-to-end WER benchmark used for this PR.
