### PR TITLE
[CLI] Expose --cpu-offload-gb, --tp-size, and --mem-fraction-static on sgl-omni

### DIFF
--- a/docs/basic_usage/qwen3_omni.md
+++ b/docs/basic_usage/qwen3_omni.md
@@ -174,6 +174,11 @@ python examples/run_qwen3_omni_speech_server.py \
 the global value for that stage. Values must be greater than `0` and less than
 `1`.
 
+Additional thinker-stage engine tuning is available via `--cpu-offload-gb`,
+`--tp-size`, and `--disable-cuda-graph`. These all target the pipeline's
+thinker AR stage. Qwen3-Omni rejects `--tp-size > 1` (not yet supported);
+Ming-Omni auto-injects `disable_custom_all_reduce=True` under TP.
+
 ### Image and Text Input
 
 Send an image with a text question to get both text and audio responses. Set `"modalities": ["text", "audio"]` to enable audio output.

--- a/docs/get_started/apiserver_quickstart.md
+++ b/docs/get_started/apiserver_quickstart.md
@@ -41,6 +41,15 @@ The most useful flags are:
 - `--model-name`: override the model name returned by `/v1/models`
 - `--log-level`: logging level for the server process
 
+Thinker-stage engine tuning (applies to the pipeline's SGLang thinker AR stage):
+
+- `--cpu-offload-gb N`: offload `N` GB of thinker weights to CPU (`0` disables)
+- `--tp-size N`: tensor parallel size for the thinker
+- `--disable-cuda-graph`: disable CUDA graph on the thinker
+- `--mem-fraction-static`, `--thinker-mem-fraction-static`, `--talker-mem-fraction-static`: pin SGLang KV/weights budget; omit to let SGLang auto-size
+
+For Ming-Omni with `--tp-size > 1`, `disable_custom_all_reduce=True` is injected automatically (the custom all-reduce kernel hangs the Ming thinker under TP).
+
 If you already have a pipeline config file, you can also pass `--config path/to/config.yaml`. In the current CLI, `--model-path` is still required even when `--config` is provided.
 
 ## Check That It Works

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -66,6 +66,36 @@ def serve(
             )
         ),
     ] = None,
+    cpu_offload_gb: Annotated[
+        int | None,
+        typer.Option(
+            help=(
+                "GB of model weights to offload to CPU for the pipeline's "
+                "thinker AR stage. Some pipelines do not expose a thinker AR "
+                "stage."
+            )
+        ),
+    ] = None,
+    tp_size: Annotated[
+        int | None,
+        typer.Option(
+            help=(
+                "Tensor parallel size for the pipeline's thinker AR stage. "
+                "Some pipelines do not expose a thinker AR stage or reject "
+                "tp_size > 1."
+            )
+        ),
+    ] = None,
+    disable_cuda_graph: Annotated[
+        bool,
+        typer.Option(
+            "--disable-cuda-graph",
+            help=(
+                "Disable CUDA graph on the pipeline's thinker AR stage. "
+                "Some pipelines do not expose a thinker AR stage."
+            ),
+        ),
+    ] = False,
     log_level: Annotated[
         Literal["debug", "info", "warning", "error", "critical"],
         typer.Option(help="Log level (default: info)."),
@@ -129,6 +159,44 @@ def serve(
                 stage_name=stage_name,
                 overrides={"mem_fraction_static": final_mem_fraction_static},
             )
+
+    thinker_stage = role_to_stage.get("thinker")
+    if cpu_offload_gb is not None:
+        if cpu_offload_gb < 0:
+            raise typer.BadParameter(
+                f"--cpu-offload-gb must be >= 0, got {cpu_offload_gb}"
+            )
+        if thinker_stage is None:
+            raise typer.BadParameter(
+                "--cpu-offload-gb is not supported by pipeline "
+                f"{type(merged_config).__name__}."
+            )
+    if tp_size is not None:
+        if tp_size < 1:
+            raise typer.BadParameter(f"--tp-size must be >= 1, got {tp_size}")
+        if thinker_stage is None:
+            raise typer.BadParameter(
+                "--tp-size is not supported by pipeline "
+                f"{type(merged_config).__name__}."
+            )
+    if disable_cuda_graph and thinker_stage is None:
+        raise typer.BadParameter(
+            "--disable-cuda-graph is not supported by pipeline "
+            f"{type(merged_config).__name__}."
+        )
+
+    thinker_overrides: dict[str, object] = {}
+    if cpu_offload_gb is not None:
+        thinker_overrides["cpu_offload_gb"] = cpu_offload_gb
+    if tp_size is not None:
+        thinker_overrides["tp_size"] = tp_size
+    if disable_cuda_graph:
+        thinker_overrides["disable_cuda_graph"] = True
+    if thinker_overrides:
+        merged_config.apply_server_args_overrides(
+            stage_name=thinker_stage,
+            overrides=thinker_overrides,
+        )
 
     # print merged configuration
     print("=" * 20, "Merged Configuration", "=" * 20)

--- a/sglang_omni/models/ming_omni/config.py
+++ b/sglang_omni/models/ming_omni/config.py
@@ -23,6 +23,12 @@ from sglang_omni.models.ming_omni.pipeline.next_stage import (
 )
 
 
+def _inject_ming_tp_all_reduce_workaround(overrides: dict[str, Any]) -> None:
+    # Ming thinker hangs with the custom all-reduce kernel under TP>1.
+    if overrides.get("tp_size", 1) > 1:
+        overrides.setdefault("disable_custom_all_reduce", True)
+
+
 class MingOmniPipelineConfig(PipelineConfig):
     """6-stage text/vision pipeline for Ming-Omni.
 
@@ -105,6 +111,16 @@ class MingOmniPipelineConfig(PipelineConfig):
     @classmethod
     def mem_fraction_role_to_stage(cls) -> dict[str, str]:
         return {"thinker": THINKER_STAGE}
+
+    def apply_server_args_overrides(
+        self, *, stage_name: str, overrides: dict[str, Any]
+    ) -> None:
+        if stage_name == THINKER_STAGE:
+            _inject_ming_tp_all_reduce_workaround(overrides)
+        super().apply_server_args_overrides(
+            stage_name=stage_name,
+            overrides=overrides,
+        )
 
 
 def _validate_ming_speech_gpu_placement(
@@ -224,11 +240,13 @@ class MingOmniSpeechPipelineConfig(PipelineConfig):
     def apply_server_args_overrides(
         self, *, stage_name: str, overrides: dict[str, Any]
     ) -> None:
-        if stage_name == THINKER_STAGE and "tp_size" in overrides:
-            _validate_ming_speech_gpu_placement(
-                self.gpu_placement,
-                tp_size=overrides["tp_size"],
-            )
+        if stage_name == THINKER_STAGE:
+            if "tp_size" in overrides:
+                _validate_ming_speech_gpu_placement(
+                    self.gpu_placement,
+                    tp_size=overrides["tp_size"],
+                )
+            _inject_ming_tp_all_reduce_workaround(overrides)
         super().apply_server_args_overrides(
             stage_name=stage_name,
             overrides=overrides,


### PR DESCRIPTION
## Motivation

`sgl-omni serve` only exposed high-level options; common SGLang runtime settings like `cpu_offload_gb`, `mem_fraction_static`, and `tp_size` required editing pipeline config YAML by hand. This blocks Ming-flash-omni-2.0 launches, where the generated defaults (`cpu_offload_gb=0`, `mem_fraction_static=0.7`) are often too tight, and blocks multi-GPU runs that need `tp_size>1`.

4.22 put this PR on hold since we are facing major codebase refactor, will apply changes after refactored code pushed to main branch

## Modifications

- **sglang_omni/cli/serve.py**: Add `--cpu-offload-gb`, `--mem-fraction-static`, and `--tp-size`; pass as `server_args_overrides` via `ConfigManager.from_model_path` or `--config`.
- **sglang_omni/config/schema.py**: Add `server_args_overrides` and `_apply_server_args_overrides` to `PipelineConfig`; route via `primary_sglang_stage`.
- **sglang_omni/config/manager.py**: Plumb `server_args_overrides` through `ConfigManager.from_model_path`.
- **sglang_omni/models/ming_omni/config.py**: Set `primary_sglang_stage = THINKER_STAGE`; auto-inject `disable_custom_all_reduce=True` when `tp_size>1` (Ming custom all-reduce kernel hangs under TP); remove legacy local override logic.


## Example

TP=1:
```bash
CUDA_VISIBLE_DEVICES=0 \
sgl-omni serve \
  --model-path inclusionAI/Ming-flash-omni-2.0 \
  --port 8000 \
  --model-name ming-omni \
  --cpu-offload-gb 80 \
  --mem-fraction-static 0.92
```

TP=2 (Ming-Omni):
```bash
CUDA_VISIBLE_DEVICES=0,1 \
sgl-omni serve \
  --model-path inclusionAI/Ming-flash-omni-2.0 \
  --port 8000 \
  --model-name ming-omni \
  --tp-size 2 \
  --cpu-offload-gb 0 \
  --mem-fraction-static 0.80
```

## Related Issues

Closes #296

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.