### PR TITLE
[CI] Lower s2pro streaming tok_per_s_agg threshold 6.7 -> 6.4

### DIFF
--- a/tests/test_model/test_s2pro_tts_ci.py
+++ b/tests/test_model/test_s2pro_tts_ci.py
@@ -152,7 +152,7 @@ _VC_STREAM_P95 = {
     },
     8: {
         "throughput_qps": 0.31,
-        "tok_per_s_agg": 8.4,
+        "tok_per_s_agg": 8.5,
         "latency_mean_s": 22.7,
         "rtf_mean": 5.89,
     },

--- a/tests/test_model/test_s2pro_tts_ci.py
+++ b/tests/test_model/test_s2pro_tts_ci.py
@@ -152,7 +152,7 @@ _VC_STREAM_P95 = {
     },
     8: {
         "throughput_qps": 0.31,
-        "tok_per_s_agg": 8.9,
+        "tok_per_s_agg": 8.4,
         "latency_mean_s": 22.7,
         "rtf_mean": 5.89,
     },


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Lower s2pro streaming tok_per_s_agg threshold 6.7 -> 6.4 to avoid flaky ci failure

## Modifications

<!-- Describe the changes made in this PR. -->

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
