### PR TITLE
[FIX] [Logging] fix flooding log issue DataReadyMessage

### DIFF
--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -261,7 +261,7 @@ class Stage:
             while self._running:
                 # Receive work
                 msg = await self.control_plane.recv()
-                logger.debug("Stage %s received msg: %s", self.name, type(msg).__name__)
+                logger.debug(f"Stage {self.name} received msg: {type(msg).__name__}")
 
                 if isinstance(msg, ShutdownMessage):
                     logger.info("Stage %s received shutdown", self.name)

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -261,7 +261,7 @@ class Stage:
             while self._running:
                 # Receive work
                 msg = await self.control_plane.recv()
-                logger.info("Stage %s received msg: %s", self.name, type(msg).__name__)
+                logger.debug("Stage %s received msg: %s", self.name, type(msg).__name__)
 
                 if isinstance(msg, ShutdownMessage):
                     logger.info("Stage %s received shutdown", self.name)


### PR DESCRIPTION
 ## Motivation

Pipeline stage runtime logs every `DataReadyMessage` receipt at INFO level, flooding the terminal with 10+ identical lines per second during normal inference. Real INFO-level signal (request lifecycle, errors, stage transitions) gets buried.
                                                                                                                                                                         
Fix : https://github.com/sgl-project/sglang-omni/issues/315                                                                                                           

  ## Modifications

  - `sglang_omni/pipeline/stage/runtime.py`: Demote per-message receipt log from `logger.info` to `logger.debug` (line 264). All other INFO logs in the pipeline are lifecycle events (start/stop/shutdown) and remain unchanged.

**before**
<img width="1341" height="121" alt="Screenshot 2026-04-17 at 6 20 36 PM" src="https://github.com/user-attachments/assets/ce017b58-bbdd-4991-8d46-6b577b479450" />

**after**        
<img width="1354" height="111" alt="Screenshot 2026-04-17 at 6 11 00 PM" src="https://github.com/user-attachments/assets/cc2d0c83-97df-473c-8044-cda9cf6ff2fc" />

Audit note: checked other logger.info calls in pipeline/ were audited. No other high-frequency logging was found. Looks like all other logger.info are lifecycle events.                                                                                                                                                              

## Related Issues

  Fixes #315

  ## Accuracy Test

  N/A                                                                                                                          
  
  ## Benchmark & Profiling                                                                                                                                               
                  
  N/A 

  ## Checklist

  - [x] Format your code according with pre-commit.                                                                                                                      
  - [ ] Add unit tests.
  - [ ] Update documentation / docstrings / example tutorials as needed.                                                                                                 
  - [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
  - [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when
  merging the PR.          