### PR TITLE
[Doc] improve qwen omni doc to keep two section aligned

### DIFF
--- a/docs/basic_usage/qwen3_omni.md
+++ b/docs/basic_usage/qwen3_omni.md
@@ -109,6 +109,46 @@ result = resp.json()
 print(result["choices"][0]["message"]["content"])
 ```
 
+### Video and Audio Input
+
+Send a video with a spoken audio question. The model watches the video, hears the question, and responds with text.
+
+**cURL**
+
+```bash
+curl -X POST http://localhost:8008/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen3-omni",
+    "messages": [{"role": "user", "content": ""}],
+    "videos": ["tests/data/draw.mp4"],
+    "audios": ["tests/data/query_to_draw.wav"],
+    "modalities": ["text"],
+    "max_tokens": 16
+  }'
+```
+
+**Python**
+
+```python
+import requests
+
+resp = requests.post(
+    "http://localhost:8008/v1/chat/completions",
+    json={
+        "model": "qwen3-omni",
+        "messages": [{"role": "user", "content": ""}],
+        "videos": ["tests/data/draw.mp4"],
+        "audios": ["tests/data/query_to_draw.wav"],
+        "modalities": ["text"],
+        "max_tokens": 16,
+    },
+)
+resp.raise_for_status()
+result = resp.json()
+print(result["choices"][0]["message"]["content"])
+```
+
 ## Speech Mode
 
 Speech mode runs the full 9-stage pipeline across multiple GPUs. It produces both text (from the thinker) and audio (from the talker) output.

--- a/tests/docs/qwen3_omni/test_docs_qwen3_omni.py
+++ b/tests/docs/qwen3_omni/test_docs_qwen3_omni.py
@@ -171,7 +171,6 @@ class TestTextOnlyMode:
         assert isinstance(content, str)
         assert len(content) > 0
 
-
     @pytest.mark.docs
     @pytest.mark.parametrize("client", ["python", "curl"])
     def test_video_audio(self, server: int, client: str) -> None:

--- a/tests/docs/qwen3_omni/test_docs_qwen3_omni.py
+++ b/tests/docs/qwen3_omni/test_docs_qwen3_omni.py
@@ -172,6 +172,31 @@ class TestTextOnlyMode:
         assert len(content) > 0
 
 
+    @pytest.mark.docs
+    @pytest.mark.parametrize("client", ["python", "curl"])
+    def test_video_audio(self, server: int, client: str) -> None:
+        """Docs section: Text-Only Mode — Video and Audio Input."""
+        assert VIDEO_PATH.exists(), f"Test video not found: {VIDEO_PATH}"
+        assert VIDEO_AUDIO_PATH.exists(), f"Test audio not found: {VIDEO_AUDIO_PATH}"
+        payload = {
+            "model": MODEL_NAME,
+            "messages": [{"role": "user", "content": ""}],
+            "videos": [str(VIDEO_PATH)],
+            "audios": [str(VIDEO_AUDIO_PATH)],
+            "modalities": ["text"],
+            "max_tokens": 16,
+        }
+        result = _send_chat(server, payload, client)
+        assert "choices" in result
+        content = result["choices"][0]["message"]["content"]
+        assert isinstance(content, str)
+        assert len(content) > 0
+        content_lower = content.lower()
+        assert any(
+            kw in content_lower for kw in EXPECTED_VIDEO_KEYWORDS
+        ), f"Text output missing expected keywords about the video. Got: {content}"
+
+
 class TestSpeechMode:
     """Speech server (multi-GPU, text + audio output)."""
 


### PR DESCRIPTION
## Motivation                                                                                                                                                       
                                            
The Text-Only mode section in docs/basic_usage/qwen3_omni.md was missing the "Video and Audio Input" example, while Speech mode had all three input combinations    
  (Image+Text, Audio+Image, Video+Audio). This asymmetry could confuse users who expect both modes to document the same input types.          
                                                                                                                                                                      
  ## Modifications                                                                                                                                                    

  - Added "Video and Audio Input" subsection to the Text-Only mode section in docs/basic_usage/qwen3_omni.md, with both cURL and Python examples using "modalities":  
  ["text"].
  - Added corresponding test_video_audio integration test in TestTextOnlyMode (tests/docs/qwen3_omni/test_docs_qwen3_omni.py) to mirror the existing Speech mode test.
                                                                                                                                                                      
  ## Related Issues

  N/A

  ## Accuracy Test                                                                                                                                                    
   
  Added doc integration test TestTextOnlyMode.test_video_audio in test_docs_qwen3_omni.py.                                                                                                                                                        
                  
  ## Benchmark & Profiling

  N/A (docs-only change)                                                                                                                                              
   
  ## Checklist                                                                                                                                                        
                  
  - [x] Format your code according with pre-commit.
  - [x] Add unit tests.
  - [x] Update documentation / docstrings / example tutorials as needed.
  - [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
  - [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author    
  when merging the PR.
                                                                                            