### PR TITLE
[Feat] Expose encoder mem reserve as --encoder-mem-reserve CLI flag

### DIFF
--- a/examples/run_qwen3_omni_server.py
+++ b/examples/run_qwen3_omni_server.py
@@ -96,15 +96,23 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main() -> None:
-    args = parse_args()
-
-    if args.mem_fraction_static is not None and args.encoder_mem_reserve is not None:
+def _check_mem_flag_mutex(
+    mem_fraction_static: float | None,
+    encoder_mem_reserve: float | None,
+) -> None:
+    """Reject both-flags-set; a pinned ``mem_fraction_static`` bypasses the auto path the reserve subtracts from."""
+    if mem_fraction_static is not None and encoder_mem_reserve is not None:
         raise ValueError(
             "--mem-fraction-static and --encoder-mem-reserve are mutually "
             "exclusive: a pinned --mem-fraction-static bypasses the auto "
             "path the reserve subtracts from. Pass only one."
         )
+
+
+def main() -> None:
+    args = parse_args()
+
+    _check_mem_flag_mutex(args.mem_fraction_static, args.encoder_mem_reserve)
 
     overrides = {}
     if args.thinker_max_seq_len is not None:

--- a/examples/run_qwen3_omni_server.py
+++ b/examples/run_qwen3_omni_server.py
@@ -105,10 +105,10 @@ def main() -> None:
     if args.cpu_offload_gb:
         overrides["cpu_offload_gb"] = args.cpu_offload_gb
     if args.encoder_mem_reserve is not None:
-        if not 0.0 <= args.encoder_mem_reserve < 1.0:
-            raise ValueError(
-                f"--encoder-mem-reserve must be in [0, 1), got {args.encoder_mem_reserve}"
-            )
+        # Range check lives in Qwen3OmniPipelineConfig._cast_encoder_mem_reserve
+        # so every entry point (this CLI, generic `sglang_omni.cli.serve`, and
+        # programmatic callers of `apply_server_args_overrides`) shares one
+        # validation boundary.
         overrides["encoder_mem_reserve"] = args.encoder_mem_reserve
 
     config = Qwen3OmniPipelineConfig(

--- a/examples/run_qwen3_omni_server.py
+++ b/examples/run_qwen3_omni_server.py
@@ -109,8 +109,7 @@ def _check_mem_flag_mutex(
     mem_fraction_static: float | None,
     encoder_mem_reserve: float | None,
 ) -> None:
-    """Reject passing both --mem-fraction-static and --encoder-mem-reserve.
-    """
+    """Reject passing both --mem-fraction-static and --encoder-mem-reserve."""
     if mem_fraction_static is not None and encoder_mem_reserve is not None:
         raise ValueError(
             "--mem-fraction-static and --encoder-mem-reserve are mutually "

--- a/examples/run_qwen3_omni_server.py
+++ b/examples/run_qwen3_omni_server.py
@@ -74,16 +74,21 @@ def parse_args() -> argparse.Namespace:
         type=float,
         default=None,
         help=(
-            "GPU-memory fraction kept OUT of SGLang's static pool (which "
-            "holds model weights + KV cache) and left free for the "
-            "co-located vision/audio encoder's weights and activations on "
-            "the thinker GPU. Applied only when --mem-fraction-static is "
-            "NOT pinned: the reserve is subtracted from SGLang's "
-            "auto-selected mem_fraction_static. When --mem-fraction-static "
-            "is pinned, this flag is rejected as mutually exclusive. "
-            "Default 0.05 is tuned for single-request / short-video "
-            "workloads; raise to 0.15-0.20 for high-concurrency long-video "
-            "or long-audio workloads."
+            "GPU-memory fraction kept OUT of SGLang's static pool (model weights "
+            "+ KV cache) and left free for the co-located vision/audio encoder's "
+            "weights and activations on the thinker GPU.\n"
+            "Behavior across the four flag combinations of --mem-fraction-static "
+            "and --encoder-mem-reserve:\n"
+            "  (1) neither flag passed: SGLang auto-selects mem_fraction_static "
+            "and the default reserve 0.05 is subtracted;\n"
+            "  (2) only --encoder-mem-reserve X: SGLang auto-selects "
+            "mem_fraction_static and X is subtracted;\n"
+            "  (3) only --mem-fraction-static X: X is used verbatim and the "
+            "default reserve is ignored;\n"
+            "  (4) both flags: rejected at CLI as mutually exclusive.\n"
+            "Default 0.05 is tuned for single-request / short-video workloads; "
+            "raise to 0.15-0.20 for high-concurrency long-video or long-audio "
+            "workloads."
         ),
     )
 
@@ -104,12 +109,7 @@ def _check_mem_flag_mutex(
     mem_fraction_static: float | None,
     encoder_mem_reserve: float | None,
 ) -> None:
-    """Reject passing both ``--mem-fraction-static`` and ``--encoder-mem-reserve``.
-
-    The reserve only applies when SGLang's auto-sizing runs. A pinned
-    ``--mem-fraction-static`` disables that auto-sizing, so adding
-    ``--encoder-mem-reserve`` on top has no effect — silently ignoring it
-    would confuse users who think both are taking effect.
+    """Reject passing both --mem-fraction-static and --encoder-mem-reserve.
     """
     if mem_fraction_static is not None and encoder_mem_reserve is not None:
         raise ValueError(

--- a/examples/run_qwen3_omni_server.py
+++ b/examples/run_qwen3_omni_server.py
@@ -99,16 +99,19 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
 
+    if args.mem_fraction_static is not None and args.encoder_mem_reserve is not None:
+        raise ValueError(
+            "--mem-fraction-static and --encoder-mem-reserve are mutually "
+            "exclusive: a pinned --mem-fraction-static bypasses the auto "
+            "path the reserve subtracts from. Pass only one."
+        )
+
     overrides = {}
     if args.thinker_max_seq_len is not None:
         overrides["thinker_max_seq_len"] = args.thinker_max_seq_len
     if args.cpu_offload_gb:
         overrides["cpu_offload_gb"] = args.cpu_offload_gb
     if args.encoder_mem_reserve is not None:
-        # Range check lives in Qwen3OmniPipelineConfig._cast_encoder_mem_reserve
-        # so every entry point (this CLI, generic `sglang_omni.cli.serve`, and
-        # programmatic callers of `apply_server_args_overrides`) shares one
-        # validation boundary.
         overrides["encoder_mem_reserve"] = args.encoder_mem_reserve
 
     config = Qwen3OmniPipelineConfig(

--- a/examples/run_qwen3_omni_server.py
+++ b/examples/run_qwen3_omni_server.py
@@ -74,12 +74,11 @@ def parse_args() -> argparse.Namespace:
         type=float,
         default=None,
         help=(
-            "GPU-memory fraction reserved outside SGLang's KV-cache pool "
-            "for the co-located vision/audio encoder on the thinker GPU. "
-            "Subtracted from SGLang's auto-selected mem_fraction_static; "
-            "ignored when --mem-fraction-static is pinned. Default 0.05 is "
-            "tuned for single-request/short-video workloads; raise to "
-            "0.15-0.20 for high-concurrency long-video workloads."
+            "GPU-memory fraction reserved outside SGLang's reserved memory for model weights and"
+            "KV cache. If mem_fraction_static is not pinned, this is will be subtracted from"
+            "SGLang's auto-selected mem_fraction_static; otherwise, when mem_fraction_static"
+            "is pinned, this is ignored. Default 0.05 is tuned for single-request/short-video workloads;"
+            "raise to 0.15-0.20 for high-concurrency workloads for long video and audio."
         ),
     )
 
@@ -100,7 +99,7 @@ def _check_mem_flag_mutex(
     mem_fraction_static: float | None,
     encoder_mem_reserve: float | None,
 ) -> None:
-    """Reject both-flags-set; a pinned ``mem_fraction_static`` bypasses the auto path the reserve subtracts from."""
+    """Pinned mem_fraction_static bypasses the auto path the reserve subtracts from."""
     if mem_fraction_static is not None and encoder_mem_reserve is not None:
         raise ValueError(
             "--mem-fraction-static and --encoder-mem-reserve are mutually "

--- a/examples/run_qwen3_omni_server.py
+++ b/examples/run_qwen3_omni_server.py
@@ -74,11 +74,16 @@ def parse_args() -> argparse.Namespace:
         type=float,
         default=None,
         help=(
-            "GPU-memory fraction reserved outside SGLang's reserved memory for model weights and"
-            "KV cache. If mem_fraction_static is not pinned, this is will be subtracted from"
-            "SGLang's auto-selected mem_fraction_static; otherwise, when mem_fraction_static"
-            "is pinned, this is ignored. Default 0.05 is tuned for single-request/short-video workloads;"
-            "raise to 0.15-0.20 for high-concurrency workloads for long video and audio."
+            "GPU-memory fraction kept OUT of SGLang's static pool (which "
+            "holds model weights + KV cache) and left free for the "
+            "co-located vision/audio encoder's weights and activations on "
+            "the thinker GPU. Applied only when --mem-fraction-static is "
+            "NOT pinned: the reserve is subtracted from SGLang's "
+            "auto-selected mem_fraction_static. When --mem-fraction-static "
+            "is pinned, this flag is rejected as mutually exclusive. "
+            "Default 0.05 is tuned for single-request / short-video "
+            "workloads; raise to 0.15-0.20 for high-concurrency long-video "
+            "or long-audio workloads."
         ),
     )
 
@@ -99,12 +104,19 @@ def _check_mem_flag_mutex(
     mem_fraction_static: float | None,
     encoder_mem_reserve: float | None,
 ) -> None:
-    """Pinned mem_fraction_static bypasses the auto path the reserve subtracts from."""
+    """Reject passing both ``--mem-fraction-static`` and ``--encoder-mem-reserve``.
+
+    The reserve only applies when SGLang's auto-sizing runs. A pinned
+    ``--mem-fraction-static`` disables that auto-sizing, so adding
+    ``--encoder-mem-reserve`` on top has no effect — silently ignoring it
+    would confuse users who think both are taking effect.
+    """
     if mem_fraction_static is not None and encoder_mem_reserve is not None:
         raise ValueError(
             "--mem-fraction-static and --encoder-mem-reserve are mutually "
-            "exclusive: a pinned --mem-fraction-static bypasses the auto "
-            "path the reserve subtracts from. Pass only one."
+            "exclusive: --mem-fraction-static pins the pool size directly "
+            "and the reserve only subtracts from SGLang's auto-selected "
+            "value. Pass only one."
         )
 
 

--- a/examples/run_qwen3_omni_server.py
+++ b/examples/run_qwen3_omni_server.py
@@ -69,6 +69,19 @@ def parse_args() -> argparse.Namespace:
             "If omitted, SGLang chooses automatically."
         ),
     )
+    parser.add_argument(
+        "--encoder-mem-reserve",
+        type=float,
+        default=None,
+        help=(
+            "GPU-memory fraction reserved outside SGLang's KV-cache pool "
+            "for the co-located vision/audio encoder on the thinker GPU. "
+            "Subtracted from SGLang's auto-selected mem_fraction_static; "
+            "ignored when --mem-fraction-static is pinned. Default 0.05 is "
+            "tuned for single-request/short-video workloads; raise to "
+            "0.15-0.20 for high-concurrency long-video workloads."
+        ),
+    )
 
     # Server
     parser.add_argument("--host", type=str, default="0.0.0.0")
@@ -91,6 +104,12 @@ def main() -> None:
         overrides["thinker_max_seq_len"] = args.thinker_max_seq_len
     if args.cpu_offload_gb:
         overrides["cpu_offload_gb"] = args.cpu_offload_gb
+    if args.encoder_mem_reserve is not None:
+        if not 0.0 <= args.encoder_mem_reserve < 1.0:
+            raise ValueError(
+                f"--encoder-mem-reserve must be in [0, 1), got {args.encoder_mem_reserve}"
+            )
+        overrides["encoder_mem_reserve"] = args.encoder_mem_reserve
 
     config = Qwen3OmniPipelineConfig(
         model_path=args.model_path,

--- a/sglang_omni/engines/ar/sglang_backend/server_args_builder.py
+++ b/sglang_omni/engines/ar/sglang_backend/server_args_builder.py
@@ -20,11 +20,11 @@ def build_sglang_server_args(
 ) -> ServerArgs:
     """Build ServerArgs with shared defaults for all SGLang AR engines.
 
-    When ``mem_fraction_static`` is ``None`` and
-    ``auto_mem_fraction_static_reserve`` is positive, the reserve is
-    subtracted from SGLang's auto-selected ``mem_fraction_static``. If
-    that would leave less than 0.01, we raise instead of silently
-    underfunding SGLang's KV pool.
+    Note (Chenyang):
+    When mem_fraction_static is None and auto_mem_fraction_static_reserve
+    is positive, the reserve is subtracted from SGLang's auto-selected
+     mem_fraction_static. If that would leave less than 0.01, we raise
+    instead of silently underfunding SGLang's KV pool.
     """
     kwargs: dict[str, Any] = {
         "model_path": model_path,
@@ -60,7 +60,8 @@ def _apply_auto_mem_fraction_static_reserve(
 ) -> None:
     """Subtract a caller-requested reserve from SGLang's auto-selected value.
 
-    Raises ``ValueError`` when the remaining ``mem_fraction_static`` would
+    # Note (Chenyang):
+    Raises ValueError when the remaining mem_fraction_static would
     drop below 0.1 — below that, SGLang's KV allocator fails deep in the
     scheduler with a confusing stack trace (empirically crashes ~0.08 on
     H200 for Qwen3-Omni-30B), so surface the failure at build time.

--- a/sglang_omni/engines/ar/sglang_backend/server_args_builder.py
+++ b/sglang_omni/engines/ar/sglang_backend/server_args_builder.py
@@ -51,13 +51,6 @@ def build_sglang_server_args(
     return server_args
 
 
-# Minimum ``mem_fraction_static`` SGLang can still boot with on a typical
-# Qwen3-Omni-30B thinker: below this the KV allocator fails deep in the
-# scheduler with a confusing stack trace, so raise early at build time
-# instead. 0.05 was too permissive (SGLang crashes ~0.08 on H200 for 30B).
-_MIN_MEM_FRACTION_STATIC_AFTER_RESERVE = 0.1
-
-
 def _apply_auto_mem_fraction_static_reserve(
     server_args: ServerArgs,
     *,
@@ -67,9 +60,10 @@ def _apply_auto_mem_fraction_static_reserve(
 ) -> None:
     """Subtract a caller-requested reserve from SGLang's auto-selected value.
 
-    Raises ``ValueError`` when the resulting ``mem_fraction_static`` would
-    fall below ``_MIN_MEM_FRACTION_STATIC_AFTER_RESERVE`` — otherwise SGLang
-    fails deep inside KV allocation with a confusing traceback.
+    Raises ``ValueError`` when the remaining ``mem_fraction_static`` would
+    drop below 0.1 — below that, SGLang's KV allocator fails deep in the
+    scheduler with a confusing stack trace (empirically crashes ~0.08 on
+    H200 for Qwen3-Omni-30B), so surface the failure at build time.
     """
     if not enabled or user_mem_fraction_static is not None:
         return
@@ -80,11 +74,10 @@ def _apply_auto_mem_fraction_static_reserve(
     if current is None:
         return
     new_value = current - reserve
-    if new_value < _MIN_MEM_FRACTION_STATIC_AFTER_RESERVE:
+    if new_value < 0.1:
         raise ValueError(
             f"auto mem_fraction_static {current:.3f} minus encoder_mem_reserve "
-            f"{reserve:.3f} = {new_value:.3f} is below the safe floor "
-            f"{_MIN_MEM_FRACTION_STATIC_AFTER_RESERVE}; lower encoder_mem_reserve "
-            f"or pin --mem-fraction-static explicitly."
+            f"{reserve:.3f} = {new_value:.3f} is below the safe floor 0.1; "
+            f"lower encoder_mem_reserve or pin --mem-fraction-static explicitly."
         )
     server_args.mem_fraction_static = round(new_value, 3)

--- a/sglang_omni/engines/ar/sglang_backend/server_args_builder.py
+++ b/sglang_omni/engines/ar/sglang_backend/server_args_builder.py
@@ -15,16 +15,14 @@ def build_sglang_server_args(
     max_prefill_tokens: int = 4096,
     max_running_requests: int = 16,
     mem_fraction_static: float | None = None,
-    auto_mem_fraction_static_reserve: float | None = None,
     **overrides: Any,
 ) -> ServerArgs:
-    """Build ServerArgs with shared defaults for all SGLang AR engines.
+    """Build a SGLang ``ServerArgs`` with shared defaults for AR engines.
 
-    Note (Chenyang):
-    When mem_fraction_static is None and auto_mem_fraction_static_reserve
-    is positive, the reserve is subtracted from SGLang's auto-selected
-     mem_fraction_static. If that would leave less than 0.01, we raise
-    instead of silently underfunding SGLang's KV pool.
+    Only fields that SGLang's own ``ServerArgs`` accepts are passed through
+    here. Domain-specific adjustments (e.g. carving out GPU memory for a
+    co-located vision/audio encoder) are the caller's responsibility —
+    see ``apply_encoder_mem_reserve``.
     """
     kwargs: dict[str, Any] = {
         "model_path": model_path,
@@ -41,44 +39,35 @@ def build_sglang_server_args(
     if mem_fraction_static is not None:
         kwargs["mem_fraction_static"] = mem_fraction_static
     kwargs.update(overrides)
-    server_args = ServerArgs(**kwargs)
-    _apply_auto_mem_fraction_static_reserve(
-        server_args,
-        enabled=auto_mem_fraction_static_reserve is not None,
-        user_mem_fraction_static=mem_fraction_static,
-        reserve=auto_mem_fraction_static_reserve or 0.0,
-    )
-    return server_args
+    return ServerArgs(**kwargs)
 
 
-def _apply_auto_mem_fraction_static_reserve(
+def apply_encoder_mem_reserve(
     server_args: ServerArgs,
-    *,
-    enabled: bool,
-    user_mem_fraction_static: float | None,
-    reserve: float,
+    encoder_mem_reserve: float,
 ) -> None:
-    """Subtract a caller-requested reserve from SGLang's auto-selected value.
+    """Subtract ``encoder_mem_reserve`` from SGLang's auto-picked mem_fraction_static.
 
-    # Note (Chenyang):
-    Raises ValueError when the remaining mem_fraction_static would
-    drop below 0.1 — below that, SGLang's KV allocator fails deep in the
-    scheduler with a confusing stack trace (empirically crashes ~0.08 on
-    H200 for Qwen3-Omni-30B), so surface the failure at build time.
+    Call this only when SGLang auto-selected ``mem_fraction_static`` —
+    i.e. the caller did NOT pin ``--mem-fraction-static``. When the caller
+    pinned, that value is the whole budget and the reserve is meaningless.
+
+    Raises ``ValueError`` when the result would drop below 0.1 — below
+    that, SGLang's KV allocator fails deep in the scheduler with a
+    confusing traceback (empirically crashes ~0.08 on H200 for
+    Qwen3-Omni-30B), so surface it at build time instead.
     """
-    if not enabled or user_mem_fraction_static is not None:
+    if encoder_mem_reserve <= 0:
         return
-    if reserve <= 0:
-        return
-
     current = server_args.mem_fraction_static
     if current is None:
         return
-    new_value = current - reserve
+    new_value = current - encoder_mem_reserve
     if new_value < 0.1:
         raise ValueError(
             f"auto mem_fraction_static {current:.3f} minus encoder_mem_reserve "
-            f"{reserve:.3f} = {new_value:.3f} is below the safe floor 0.1; "
-            f"lower encoder_mem_reserve or pin --mem-fraction-static explicitly."
+            f"{encoder_mem_reserve:.3f} = {new_value:.3f} is below the safe "
+            f"floor 0.1; lower encoder_mem_reserve or pin "
+            f"--mem-fraction-static explicitly."
         )
     server_args.mem_fraction_static = round(new_value, 3)

--- a/sglang_omni/engines/ar/sglang_backend/server_args_builder.py
+++ b/sglang_omni/engines/ar/sglang_backend/server_args_builder.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from sglang.srt.server_args import ServerArgs
 
+# Note (Ratish, Chenyang):
 # Default GPU-memory fraction reserved outside SGLang's KV-cache pool for
 # co-located vision/audio encoder weights and activations. SGLang's VLM
 # auto-sizing does not trigger for Qwen3-Omni (vision/audio configs are

--- a/sglang_omni/engines/ar/sglang_backend/server_args_builder.py
+++ b/sglang_omni/engines/ar/sglang_backend/server_args_builder.py
@@ -6,14 +6,6 @@ from typing import Any
 
 from sglang.srt.server_args import ServerArgs
 
-# Note (Ratish, Chenyang):
-# Default GPU-memory fraction reserved outside SGLang's KV-cache pool for
-# co-located vision/audio encoder weights and activations. SGLang's VLM
-# auto-sizing does not trigger for Qwen3-Omni (vision/audio configs are
-# nested under ``thinker_config``), so we subtract this after auto-sizing.
-# User-pinned ``mem_fraction_static`` bypasses this reserve entirely.
-OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE = 0.05
-
 
 def build_sglang_server_args(
     model_path: str,

--- a/sglang_omni/engines/ar/sglang_backend/server_args_builder.py
+++ b/sglang_omni/engines/ar/sglang_backend/server_args_builder.py
@@ -6,15 +6,20 @@ from typing import Any
 
 from sglang.srt.server_args import ServerArgs
 
+# Default GPU-memory fraction reserved outside SGLang's KV-cache pool for
+# co-located vision/audio encoder weights and activations.
+#
 # Note (Ratish, Chenyang):
-
 # SGLang's VLM auto-sizing applies a dynamic 0.95 * factor reserve
 # (roughly [0.8, 1.05]); Qwen3-Omni nests vision/audio configs under
 # `thinker_config` so SGLang's VLM path never triggers for us. 0.05
 # is a conservative linear lower-bound of that dynamic reserve; we
 # subtract it after auto-sizing when the thinker GPU also hosts encoder
 # stages. User-pinned mem_fraction_static bypasses this reserve.
-
+#
+# For high-concurrency long-video workloads where encoder activations
+# dominate GPU memory, consider raising this reserve to 0.15-0.20 via
+# the per-stage CLI flag (e.g. `--encoder-mem-reserve`).
 OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE = 0.05
 
 
@@ -29,7 +34,28 @@ def build_sglang_server_args(
     auto_mem_fraction_static_reserve: float | None = None,
     **overrides: Any,
 ) -> ServerArgs:
-    """Build ServerArgs with shared defaults for all SGLang AR engines."""
+    """Build ServerArgs with shared defaults for all SGLang AR engines.
+
+    Args:
+        model_path: Hugging Face model id or local path.
+        context_length: Maximum sequence length for SGLang's KV cache.
+        chunked_prefill_size: SGLang chunked prefill chunk size.
+        max_prefill_tokens: Max tokens in a single prefill batch.
+        max_running_requests: Max concurrent decode requests.
+        mem_fraction_static: Optional user-pinned mem_fraction_static. When
+            set, SGLang's auto-sizing is skipped and the encoder reserve
+            (see below) is also skipped.
+        auto_mem_fraction_static_reserve: GPU-memory fraction to subtract
+            from SGLang's auto-selected mem_fraction_static, reserving it
+            for co-located vision/audio encoder weights and activations.
+            Only applied when `mem_fraction_static` is None. Default (when
+            None) disables the reserve; callers that co-locate encoders on
+            the thinker GPU should pass
+            `OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE` (0.05) and surface a
+            CLI flag so users can raise it (0.15-0.20) for high-concurrency
+            long-video workloads.
+        **overrides: Raw SGLang ServerArgs kwargs forwarded verbatim.
+    """
     kwargs: dict[str, Any] = {
         "model_path": model_path,
         "trust_remote_code": True,

--- a/sglang_omni/engines/ar/sglang_backend/server_args_builder.py
+++ b/sglang_omni/engines/ar/sglang_backend/server_args_builder.py
@@ -17,13 +17,7 @@ def build_sglang_server_args(
     mem_fraction_static: float | None = None,
     **overrides: Any,
 ) -> ServerArgs:
-    """Build a SGLang ``ServerArgs`` with shared defaults for AR engines.
-
-    Only fields that SGLang's own ``ServerArgs`` accepts are passed through
-    here. Domain-specific adjustments (e.g. carving out GPU memory for a
-    co-located vision/audio encoder) are the caller's responsibility —
-    see ``apply_encoder_mem_reserve``.
-    """
+    """Build a SGLang ServerArgs with shared defaults for AR engines."""
     kwargs: dict[str, Any] = {
         "model_path": model_path,
         "trust_remote_code": True,
@@ -46,13 +40,14 @@ def apply_encoder_mem_reserve(
     server_args: ServerArgs,
     encoder_mem_reserve: float,
 ) -> None:
-    """Subtract ``encoder_mem_reserve`` from SGLang's auto-picked mem_fraction_static.
+    """Subtract encoder_mem_reserve from SGLang's auto-picked mem_fraction_static.
 
-    Call this only when SGLang auto-selected ``mem_fraction_static`` —
-    i.e. the caller did NOT pin ``--mem-fraction-static``. When the caller
-    pinned, that value is the whole budget and the reserve is meaningless.
+    # Note (Chenyang):
+    Call this only when SGLang auto-selected mem_fraction_static —
+    i.e. the caller did NOT pin --mem-fraction-static. When the caller
+    pinned, that value is the whole budget and the reserve value is ignored.
 
-    Raises ``ValueError`` when the result would drop below 0.1 — below
+    Raises ValueError when the result would drop below 0.1 — below
     that, SGLang's KV allocator fails deep in the scheduler with a
     confusing traceback (empirically crashes ~0.08 on H200 for
     Qwen3-Omni-30B), so surface it at build time instead.

--- a/sglang_omni/engines/ar/sglang_backend/server_args_builder.py
+++ b/sglang_omni/engines/ar/sglang_backend/server_args_builder.py
@@ -58,6 +58,10 @@ def build_sglang_server_args(
     return server_args
 
 
+# Minimum ``mem_fraction_static`` SGLang can still boot with on a typical
+# Qwen3-Omni-30B thinker: below this the KV allocator fails deep in the
+# scheduler with a confusing stack trace, so raise early at build time
+# instead. 0.05 was too permissive (SGLang crashes ~0.08 on H200 for 30B).
 _MIN_MEM_FRACTION_STATIC_AFTER_RESERVE = 0.1
 
 

--- a/sglang_omni/engines/ar/sglang_backend/server_args_builder.py
+++ b/sglang_omni/engines/ar/sglang_backend/server_args_builder.py
@@ -7,19 +7,10 @@ from typing import Any
 from sglang.srt.server_args import ServerArgs
 
 # Default GPU-memory fraction reserved outside SGLang's KV-cache pool for
-# co-located vision/audio encoder weights and activations.
-#
-# Note (Ratish, Chenyang):
-# SGLang's VLM auto-sizing applies a dynamic 0.95 * factor reserve
-# (roughly [0.8, 1.05]); Qwen3-Omni nests vision/audio configs under
-# `thinker_config` so SGLang's VLM path never triggers for us. 0.05
-# is a conservative linear lower-bound of that dynamic reserve; we
-# subtract it after auto-sizing when the thinker GPU also hosts encoder
-# stages. User-pinned mem_fraction_static bypasses this reserve.
-#
-# For high-concurrency long-video workloads where encoder activations
-# dominate GPU memory, consider raising this reserve to 0.15-0.20 via
-# the per-stage CLI flag (e.g. `--encoder-mem-reserve`).
+# co-located vision/audio encoder weights and activations. SGLang's VLM
+# auto-sizing does not trigger for Qwen3-Omni (vision/audio configs are
+# nested under ``thinker_config``), so we subtract this after auto-sizing.
+# User-pinned ``mem_fraction_static`` bypasses this reserve entirely.
 OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE = 0.05
 
 
@@ -36,25 +27,11 @@ def build_sglang_server_args(
 ) -> ServerArgs:
     """Build ServerArgs with shared defaults for all SGLang AR engines.
 
-    Args:
-        model_path: Hugging Face model id or local path.
-        context_length: Maximum sequence length for SGLang's KV cache.
-        chunked_prefill_size: SGLang chunked prefill chunk size.
-        max_prefill_tokens: Max tokens in a single prefill batch.
-        max_running_requests: Max concurrent decode requests.
-        mem_fraction_static: Optional user-pinned mem_fraction_static. When
-            set, SGLang's auto-sizing is skipped and the encoder reserve
-            (see below) is also skipped.
-        auto_mem_fraction_static_reserve: GPU-memory fraction to subtract
-            from SGLang's auto-selected mem_fraction_static, reserving it
-            for co-located vision/audio encoder weights and activations.
-            Only applied when `mem_fraction_static` is None. Default (when
-            None) disables the reserve; callers that co-locate encoders on
-            the thinker GPU should pass
-            `OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE` (0.05) and surface a
-            CLI flag so users can raise it (0.15-0.20) for high-concurrency
-            long-video workloads.
-        **overrides: Raw SGLang ServerArgs kwargs forwarded verbatim.
+    When ``mem_fraction_static`` is ``None`` and
+    ``auto_mem_fraction_static_reserve`` is positive, the reserve is
+    subtracted from SGLang's auto-selected ``mem_fraction_static``. If
+    that would leave less than 0.01, we raise instead of silently
+    underfunding SGLang's KV pool.
     """
     kwargs: dict[str, Any] = {
         "model_path": model_path,
@@ -81,6 +58,9 @@ def build_sglang_server_args(
     return server_args
 
 
+_MIN_MEM_FRACTION_STATIC_AFTER_RESERVE = 0.1
+
+
 def _apply_auto_mem_fraction_static_reserve(
     server_args: ServerArgs,
     *,
@@ -88,7 +68,12 @@ def _apply_auto_mem_fraction_static_reserve(
     user_mem_fraction_static: float | None,
     reserve: float,
 ) -> None:
-    """Subtract a caller-requested reserve from SGLang's auto-selected value."""
+    """Subtract a caller-requested reserve from SGLang's auto-selected value.
+
+    Raises ``ValueError`` when the resulting ``mem_fraction_static`` would
+    fall below ``_MIN_MEM_FRACTION_STATIC_AFTER_RESERVE`` — otherwise SGLang
+    fails deep inside KV allocation with a confusing traceback.
+    """
     if not enabled or user_mem_fraction_static is not None:
         return
     if reserve <= 0:
@@ -97,4 +82,12 @@ def _apply_auto_mem_fraction_static_reserve(
     current = server_args.mem_fraction_static
     if current is None:
         return
-    server_args.mem_fraction_static = round(max(0.01, current - reserve), 3)
+    new_value = current - reserve
+    if new_value < _MIN_MEM_FRACTION_STATIC_AFTER_RESERVE:
+        raise ValueError(
+            f"auto mem_fraction_static {current:.3f} minus encoder_mem_reserve "
+            f"{reserve:.3f} = {new_value:.3f} is below the safe floor "
+            f"{_MIN_MEM_FRACTION_STATIC_AFTER_RESERVE}; lower encoder_mem_reserve "
+            f"or pin --mem-fraction-static explicitly."
+        )
+    server_args.mem_fraction_static = round(new_value, 3)

--- a/sglang_omni/models/ming_omni/config.py
+++ b/sglang_omni/models/ming_omni/config.py
@@ -23,6 +23,26 @@ from sglang_omni.models.ming_omni.pipeline.next_stage import (
 )
 
 
+def _drop_qwen3_only_overrides(overrides: dict[str, Any]) -> None:
+    """Drop keys routed exclusively by the Qwen3-Omni pipeline.
+
+    Ming-Omni's thinker factory does not accept ``encoder_mem_reserve`` and its
+    ``apply_server_args_overrides`` forwards unknown keys into the raw
+    ``ServerArgs(**kwargs)`` unpack, which would raise
+    ``TypeError: unexpected keyword argument 'encoder_mem_reserve'``. We drop
+    the key here so the generic ``sglang_omni.cli.serve`` dispatcher (or any
+    future shared CLI) can safely forward ``encoder_mem_reserve`` without
+    crashing Ming.
+
+    TODO (Ratish, Chenyang):
+    Ming-Omni currently hard-codes ``OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE``
+    (0.05). If Ming ever needs a runtime-tunable encoder reserve, replace this
+    drop with a per-stage routing path analogous to Qwen3's
+    ``_route_thinker_executor_args``.
+    """
+    overrides.pop("encoder_mem_reserve", None)
+
+
 class MingOmniPipelineConfig(PipelineConfig):
     """6-stage text/vision pipeline for Ming-Omni.
 
@@ -105,6 +125,19 @@ class MingOmniPipelineConfig(PipelineConfig):
     @classmethod
     def mem_fraction_role_to_stage(cls) -> dict[str, str]:
         return {"thinker": THINKER_STAGE}
+
+    def apply_server_args_overrides(
+        self, *, stage_name: str, overrides: dict[str, Any]
+    ) -> None:
+        # Ming does not implement a runtime encoder-mem-reserve path (yet);
+        # drop the key defensively so a future shared CLI can forward it
+        # without Ming crashing at ServerArgs unpack time.
+        cleaned = dict(overrides)
+        _drop_qwen3_only_overrides(cleaned)
+        super().apply_server_args_overrides(
+            stage_name=stage_name,
+            overrides=cleaned,
+        )
 
 
 def _validate_ming_speech_gpu_placement(
@@ -229,9 +262,11 @@ class MingOmniSpeechPipelineConfig(PipelineConfig):
                 self.gpu_placement,
                 tp_size=overrides["tp_size"],
             )
+        cleaned = dict(overrides)
+        _drop_qwen3_only_overrides(cleaned)
         super().apply_server_args_overrides(
             stage_name=stage_name,
-            overrides=overrides,
+            overrides=cleaned,
         )
 
 

--- a/sglang_omni/models/ming_omni/config.py
+++ b/sglang_omni/models/ming_omni/config.py
@@ -23,26 +23,6 @@ from sglang_omni.models.ming_omni.pipeline.next_stage import (
 )
 
 
-def _drop_qwen3_only_overrides(overrides: dict[str, Any]) -> None:
-    """Drop keys routed exclusively by the Qwen3-Omni pipeline.
-
-    Ming-Omni's thinker factory does not accept ``encoder_mem_reserve`` and its
-    ``apply_server_args_overrides`` forwards unknown keys into the raw
-    ``ServerArgs(**kwargs)`` unpack, which would raise
-    ``TypeError: unexpected keyword argument 'encoder_mem_reserve'``. We drop
-    the key here so the generic ``sglang_omni.cli.serve`` dispatcher (or any
-    future shared CLI) can safely forward ``encoder_mem_reserve`` without
-    crashing Ming.
-
-    TODO (Ratish, Chenyang):
-    Ming-Omni currently hard-codes ``OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE``
-    (0.05). If Ming ever needs a runtime-tunable encoder reserve, replace this
-    drop with a per-stage routing path analogous to Qwen3's
-    ``_route_thinker_executor_args``.
-    """
-    overrides.pop("encoder_mem_reserve", None)
-
-
 class MingOmniPipelineConfig(PipelineConfig):
     """6-stage text/vision pipeline for Ming-Omni.
 
@@ -125,19 +105,6 @@ class MingOmniPipelineConfig(PipelineConfig):
     @classmethod
     def mem_fraction_role_to_stage(cls) -> dict[str, str]:
         return {"thinker": THINKER_STAGE}
-
-    def apply_server_args_overrides(
-        self, *, stage_name: str, overrides: dict[str, Any]
-    ) -> None:
-        # Ming does not implement a runtime encoder-mem-reserve path (yet);
-        # drop the key defensively so a future shared CLI can forward it
-        # without Ming crashing at ServerArgs unpack time.
-        cleaned = dict(overrides)
-        _drop_qwen3_only_overrides(cleaned)
-        super().apply_server_args_overrides(
-            stage_name=stage_name,
-            overrides=cleaned,
-        )
 
 
 def _validate_ming_speech_gpu_placement(
@@ -262,11 +229,9 @@ class MingOmniSpeechPipelineConfig(PipelineConfig):
                 self.gpu_placement,
                 tp_size=overrides["tp_size"],
             )
-        cleaned = dict(overrides)
-        _drop_qwen3_only_overrides(cleaned)
         super().apply_server_args_overrides(
             stage_name=stage_name,
-            overrides=cleaned,
+            overrides=overrides,
         )
 
 

--- a/sglang_omni/models/ming_omni/pipeline/stages.py
+++ b/sglang_omni/models/ming_omni/pipeline/stages.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Any
 
 from sglang_omni.engines.ar.sglang_backend.server_args_builder import (
+    apply_encoder_mem_reserve,
     build_sglang_server_args,
 )
 from sglang_omni.engines.omni import create_sglang_ar_engine, create_single_pass_engine
@@ -337,9 +338,13 @@ def create_sglang_thinker_executor_from_config(
     server_args = build_sglang_server_args(
         local_path,
         context_length=thinker_max_seq_len,
-        auto_mem_fraction_static_reserve=0.05,
         **overrides,
     )
+    # Ming-Omni co-locates vision/audio encoders on the thinker GPU; reserve
+    # 0.05 of GPU memory outside SGLang's static pool for them. Skipped when
+    # the caller pinned mem_fraction_static (no auto value to subtract from).
+    if "mem_fraction_static" not in overrides:
+        apply_encoder_mem_reserve(server_args, 0.05)
     pre_load_mem = (
         f", pre_load_avail_mem={pre_load_avail_mem:.2f} GB"
         if pre_load_avail_mem is not None

--- a/sglang_omni/models/ming_omni/pipeline/stages.py
+++ b/sglang_omni/models/ming_omni/pipeline/stages.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from typing import Any
 
 from sglang_omni.engines.ar.sglang_backend.server_args_builder import (
-    OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE,
     build_sglang_server_args,
 )
 from sglang_omni.engines.omni import create_sglang_ar_engine, create_single_pass_engine
@@ -338,7 +337,7 @@ def create_sglang_thinker_executor_from_config(
     server_args = build_sglang_server_args(
         local_path,
         context_length=thinker_max_seq_len,
-        auto_mem_fraction_static_reserve=OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE,
+        auto_mem_fraction_static_reserve=0.05,
         **overrides,
     )
     pre_load_mem = (

--- a/sglang_omni/models/ming_omni/pipeline/stages.py
+++ b/sglang_omni/models/ming_omni/pipeline/stages.py
@@ -340,9 +340,6 @@ def create_sglang_thinker_executor_from_config(
         context_length=thinker_max_seq_len,
         **overrides,
     )
-    # Ming-Omni co-locates vision/audio encoders on the thinker GPU; reserve
-    # 0.05 of GPU memory outside SGLang's static pool for them. Skipped when
-    # the caller pinned mem_fraction_static (no auto value to subtract from).
     if "mem_fraction_static" not in overrides:
         apply_encoder_mem_reserve(server_args, 0.05)
     pre_load_mem = (

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -122,6 +122,28 @@ class Qwen3OmniPipelineConfig(PipelineConfig):
             )
 
 
+def _cast_encoder_mem_reserve(value: Any) -> float:
+    """Cast + validate ``encoder_mem_reserve`` at the config boundary.
+
+    Range ``[0, 1)`` is enforced here (not only at the CLI layer) so every
+    entry point -- the Qwen3 CLI, the generic ``sglang_omni.cli.serve``
+    dispatcher, and programmatic ``apply_server_args_overrides`` callers --
+    hits the same validator and fails early with a clear error, rather than
+    surfacing a confusing downstream SGLang error (e.g. negative
+    ``mem_fraction_static``) at server startup.
+    """
+    val = float(value)
+    if not 0.0 <= val < 1.0:
+        raise ValueError(f"encoder_mem_reserve must be in [0, 1), got {val}")
+    return val
+
+
+_THINKER_EXECUTOR_ARG_CASTS: dict[str, Callable[[Any], Any]] = {
+    "thinker_max_seq_len": int,
+    "encoder_mem_reserve": _cast_encoder_mem_reserve,
+}
+
+
 def _route_thinker_executor_args(
     stages: list[StageConfig],
     stage_name: str,
@@ -146,12 +168,6 @@ def _route_thinker_executor_args(
                 stage.executor.args[key] = cast(value)
                 break
     return remaining
-
-
-_THINKER_EXECUTOR_ARG_CASTS: dict[str, Callable[[Any], Any]] = {
-    "thinker_max_seq_len": int,
-    "encoder_mem_reserve": float,
-}
 
 
 def _validate_qwen3_speech_gpu_placement(

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -126,13 +126,7 @@ def _route_thinker_executor_args(
     stage_name: str,
     overrides: dict[str, Any],
 ) -> dict[str, Any]:
-    """Pop thinker-factory kwargs onto the thinker stage; return the rest.
-
-    Casts + validates ``thinker_max_seq_len`` and ``encoder_mem_reserve``
-    into a temporary dict first, so a bad value raises before the stage
-    state is mutated. Remaining keys are returned for forwarding as raw
-    SGLang ``server_args_overrides``.
-    """
+    """Pop thinker-factory kwargs onto the thinker stage; return the rest."""
     remaining = dict(overrides)
     if stage_name != THINKER_STAGE:
         return remaining

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -175,8 +175,9 @@ def _route_thinker_executor_args(
     if casted:
         for stage in stages:
             if stage.name == THINKER_STAGE:
-                if stage.executor.args is None:
-                    stage.executor.args = {}
+                # ``ExecutorConfig.args`` has ``default_factory=dict`` in the
+                # pydantic schema, so it is always a dict here — no None guard
+                # needed.
                 stage.executor.args.update(casted)
                 break
     return remaining

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -159,13 +159,25 @@ def _route_thinker_executor_args(
     remaining = dict(overrides)
     if stage_name != THINKER_STAGE:
         return remaining
+
+    # Cast-before-mutate: validate every executor kwarg into a temporary dict
+    # first. If any cast raises, abort before touching stage.executor.args so
+    # callers that retry do not see a partially-applied state (e.g. a valid
+    # ``thinker_max_seq_len`` already written while a later ``encoder_mem_reserve``
+    # cast failed). Atomicity here matters because ``apply_server_args_overrides``
+    # is a public entry point that callers legitimately wrap in try/except.
+    casted: dict[str, Any] = {}
     for key, cast in _THINKER_EXECUTOR_ARG_CASTS.items():
         value = remaining.pop(key, None)
-        if value is None:
-            continue
+        if value is not None:
+            casted[key] = cast(value)
+
+    if casted:
         for stage in stages:
             if stage.name == THINKER_STAGE:
-                stage.executor.args[key] = cast(value)
+                if stage.executor.args is None:
+                    stage.executor.args = {}
+                stage.executor.args.update(casted)
                 break
     return remaining
 

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any, ClassVar
 
 from sglang_omni.config import (
@@ -122,62 +121,38 @@ class Qwen3OmniPipelineConfig(PipelineConfig):
             )
 
 
-def _cast_encoder_mem_reserve(value: Any) -> float:
-    """Cast + validate ``encoder_mem_reserve`` at the config boundary.
-
-    Range ``[0, 1)`` is enforced here (not only at the CLI layer) so every
-    entry point -- the Qwen3 CLI, the generic ``sglang_omni.cli.serve``
-    dispatcher, and programmatic ``apply_server_args_overrides`` callers --
-    hits the same validator and fails early with a clear error, rather than
-    surfacing a confusing downstream SGLang error (e.g. negative
-    ``mem_fraction_static``) at server startup.
-    """
-    val = float(value)
-    if not 0.0 <= val < 1.0:
-        raise ValueError(f"encoder_mem_reserve must be in [0, 1), got {val}")
-    return val
-
-
-_THINKER_EXECUTOR_ARG_CASTS: dict[str, Callable[[Any], Any]] = {
-    "thinker_max_seq_len": int,
-    "encoder_mem_reserve": _cast_encoder_mem_reserve,
-}
-
-
 def _route_thinker_executor_args(
     stages: list[StageConfig],
     stage_name: str,
     overrides: dict[str, Any],
 ) -> dict[str, Any]:
-    """Route thinker-factory kwargs (not raw SGLang ServerArgs) to stage args.
+    """Pop thinker-factory kwargs onto the thinker stage; return the rest.
 
-    Keys in ``_THINKER_EXECUTOR_ARG_CASTS`` are popped from ``overrides`` and
-    written onto the thinker stage's ``executor.args`` so they land as kwargs
-    on ``create_sglang_thinker_executor_from_config``. Remaining keys are
-    returned to be forwarded as raw SGLang ``server_args_overrides``.
+    Casts + validates ``thinker_max_seq_len`` and ``encoder_mem_reserve``
+    into a temporary dict first, so a bad value raises before the stage
+    state is mutated. Remaining keys are returned for forwarding as raw
+    SGLang ``server_args_overrides``.
     """
     remaining = dict(overrides)
     if stage_name != THINKER_STAGE:
         return remaining
 
-    # Cast-before-mutate: validate every executor kwarg into a temporary dict
-    # first. If any cast raises, abort before touching stage.executor.args so
-    # callers that retry do not see a partially-applied state (e.g. a valid
-    # ``thinker_max_seq_len`` already written while a later ``encoder_mem_reserve``
-    # cast failed). Atomicity here matters because ``apply_server_args_overrides``
-    # is a public entry point that callers legitimately wrap in try/except.
     casted: dict[str, Any] = {}
-    for key, cast in _THINKER_EXECUTOR_ARG_CASTS.items():
-        value = remaining.pop(key, None)
-        if value is not None:
-            casted[key] = cast(value)
+
+    seq_len = remaining.pop("thinker_max_seq_len", None)
+    if seq_len is not None:
+        casted["thinker_max_seq_len"] = int(seq_len)
+
+    reserve = remaining.pop("encoder_mem_reserve", None)
+    if reserve is not None:
+        reserve = float(reserve)
+        if not 0.0 <= reserve < 1.0:
+            raise ValueError(f"encoder_mem_reserve must be in [0, 1), got {reserve}")
+        casted["encoder_mem_reserve"] = reserve
 
     if casted:
         for stage in stages:
             if stage.name == THINKER_STAGE:
-                # ``ExecutorConfig.args`` has ``default_factory=dict`` in the
-                # pydantic schema, so it is always a dict here — no None guard
-                # needed.
                 stage.executor.args.update(casted)
                 break
     return remaining

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any, ClassVar
 
 from sglang_omni.config import (
@@ -113,7 +114,7 @@ class Qwen3OmniPipelineConfig(PipelineConfig):
             and overrides["tp_size"] > 1
         ):
             raise NotImplementedError("Qwen3-Omni TP is not supported yet.")
-        remaining = _route_thinker_max_seq_len(self.stages, stage_name, overrides)
+        remaining = _route_thinker_executor_args(self.stages, stage_name, overrides)
         if remaining:
             super().apply_server_args_overrides(
                 stage_name=stage_name,
@@ -121,20 +122,36 @@ class Qwen3OmniPipelineConfig(PipelineConfig):
             )
 
 
-def _route_thinker_max_seq_len(
+def _route_thinker_executor_args(
     stages: list[StageConfig],
     stage_name: str,
     overrides: dict[str, Any],
 ) -> dict[str, Any]:
+    """Route thinker-factory kwargs (not raw SGLang ServerArgs) to stage args.
+
+    Keys in ``_THINKER_EXECUTOR_ARG_CASTS`` are popped from ``overrides`` and
+    written onto the thinker stage's ``executor.args`` so they land as kwargs
+    on ``create_sglang_thinker_executor_from_config``. Remaining keys are
+    returned to be forwarded as raw SGLang ``server_args_overrides``.
+    """
     remaining = dict(overrides)
-    thinker_max_seq_len = remaining.pop("thinker_max_seq_len", None)
-    if thinker_max_seq_len is None or stage_name != THINKER_STAGE:
+    if stage_name != THINKER_STAGE:
         return remaining
-    for stage in stages:
-        if stage.name == THINKER_STAGE:
-            stage.executor.args["thinker_max_seq_len"] = int(thinker_max_seq_len)
-            break
+    for key, cast in _THINKER_EXECUTOR_ARG_CASTS.items():
+        value = remaining.pop(key, None)
+        if value is None:
+            continue
+        for stage in stages:
+            if stage.name == THINKER_STAGE:
+                stage.executor.args[key] = cast(value)
+                break
     return remaining
+
+
+_THINKER_EXECUTOR_ARG_CASTS: dict[str, Callable[[Any], Any]] = {
+    "thinker_max_seq_len": int,
+    "encoder_mem_reserve": float,
+}
 
 
 def _validate_qwen3_speech_gpu_placement(
@@ -302,7 +319,7 @@ class Qwen3OmniSpeechPipelineConfig(PipelineConfig):
             )
             if tp_size > 1:
                 raise NotImplementedError("Qwen3-Omni TP is not supported yet.")
-        remaining = _route_thinker_max_seq_len(self.stages, stage_name, overrides)
+        remaining = _route_thinker_executor_args(self.stages, stage_name, overrides)
         if remaining:
             super().apply_server_args_overrides(
                 stage_name=stage_name,

--- a/sglang_omni/models/qwen3_omni/pipeline/stages.py
+++ b/sglang_omni/models/qwen3_omni/pipeline/stages.py
@@ -10,6 +10,7 @@ import torch
 from transformers import AutoTokenizer
 
 from sglang_omni.engines.ar.sglang_backend.server_args_builder import (
+    apply_encoder_mem_reserve,
     build_sglang_server_args,
 )
 from sglang_omni.engines.omni import (
@@ -368,12 +369,16 @@ def create_sglang_thinker_executor_from_config(
     for high-concurrency long-video or long-audio workloads.
     """
     pre_load_avail_mem = avail_gpu_mem(gpu_id)
+    overrides = server_args_overrides or {}
     server_args = build_sglang_server_args(
         model_path,
         context_length=thinker_max_seq_len,
-        auto_mem_fraction_static_reserve=encoder_mem_reserve,
-        **(server_args_overrides or {}),
+        **overrides,
     )
+    # Pinning mem_fraction_static bypasses SGLang's auto path, so the
+    # encoder reserve (which subtracts from that auto value) is skipped.
+    if "mem_fraction_static" not in overrides:
+        apply_encoder_mem_reserve(server_args, encoder_mem_reserve)
     pre_load_mem = (
         f" pre_load_avail_mem={pre_load_avail_mem:.2f} GB"
         if pre_load_avail_mem is not None

--- a/sglang_omni/models/qwen3_omni/pipeline/stages.py
+++ b/sglang_omni/models/qwen3_omni/pipeline/stages.py
@@ -358,16 +358,7 @@ def create_sglang_thinker_executor_from_config(
     server_args_overrides: dict[str, Any] | None = None,
     speech_enabled: bool = False,
 ) -> EngineExecutor:
-    """Create a SGLang thinker executor from JSON-serializable config args.
-
-    This keeps pipeline config args plain dict types while still constructing
-    a typed ServerArgs object internally.
-
-    ``encoder_mem_reserve`` is the GPU-memory fraction kept OUT of SGLang's
-    static pool for the co-located vision/audio encoder. Default 0.05 is
-    tuned for single-request / short-video workloads; raise to 0.15-0.20
-    for high-concurrency long-video or long-audio workloads.
-    """
+    """Create a SGLang thinker executor from JSON-serializable config args."""
     pre_load_avail_mem = avail_gpu_mem(gpu_id)
     overrides = server_args_overrides or {}
     server_args = build_sglang_server_args(
@@ -375,8 +366,6 @@ def create_sglang_thinker_executor_from_config(
         context_length=thinker_max_seq_len,
         **overrides,
     )
-    # Pinning mem_fraction_static bypasses SGLang's auto path, so the
-    # encoder reserve (which subtracts from that auto value) is skipped.
     if "mem_fraction_static" not in overrides:
         apply_encoder_mem_reserve(server_args, encoder_mem_reserve)
     pre_load_mem = (

--- a/sglang_omni/models/qwen3_omni/pipeline/stages.py
+++ b/sglang_omni/models/qwen3_omni/pipeline/stages.py
@@ -10,7 +10,6 @@ import torch
 from transformers import AutoTokenizer
 
 from sglang_omni.engines.ar.sglang_backend.server_args_builder import (
-    OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE,
     build_sglang_server_args,
 )
 from sglang_omni.engines.omni import (
@@ -354,7 +353,7 @@ def create_sglang_thinker_executor_from_config(
     *,
     gpu_id: int = 0,
     thinker_max_seq_len: int = 8192,
-    encoder_mem_reserve: float | None = None,
+    encoder_mem_reserve: float = 0.05,
     server_args_overrides: dict[str, Any] | None = None,
     speech_enabled: bool = False,
 ) -> EngineExecutor:
@@ -363,22 +362,16 @@ def create_sglang_thinker_executor_from_config(
     This keeps pipeline config args plain dict types while still constructing
     a typed ServerArgs object internally.
 
-    Args:
-        encoder_mem_reserve: Optional GPU-memory fraction reserved outside
-            SGLang's KV-cache pool for the co-located vision/audio encoder.
-            Falls back to ``OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE`` (0.05)
-            when ``None``.
+    ``encoder_mem_reserve`` is the GPU-memory fraction kept OUT of SGLang's
+    static pool for the co-located vision/audio encoder. Default 0.05 is
+    tuned for single-request / short-video workloads; raise to 0.15-0.20
+    for high-concurrency long-video or long-audio workloads.
     """
-    reserve = (
-        encoder_mem_reserve
-        if encoder_mem_reserve is not None
-        else OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE
-    )
     pre_load_avail_mem = avail_gpu_mem(gpu_id)
     server_args = build_sglang_server_args(
         model_path,
         context_length=thinker_max_seq_len,
-        auto_mem_fraction_static_reserve=reserve,
+        auto_mem_fraction_static_reserve=encoder_mem_reserve,
         **(server_args_overrides or {}),
     )
     pre_load_mem = (

--- a/sglang_omni/models/qwen3_omni/pipeline/stages.py
+++ b/sglang_omni/models/qwen3_omni/pipeline/stages.py
@@ -354,6 +354,7 @@ def create_sglang_thinker_executor_from_config(
     *,
     gpu_id: int = 0,
     thinker_max_seq_len: int = 8192,
+    encoder_mem_reserve: float | None = None,
     server_args_overrides: dict[str, Any] | None = None,
     speech_enabled: bool = False,
 ) -> EngineExecutor:
@@ -361,12 +362,23 @@ def create_sglang_thinker_executor_from_config(
 
     This keeps pipeline config args plain dict types while still constructing
     a typed ServerArgs object internally.
+
+    Args:
+        encoder_mem_reserve: Optional GPU-memory fraction reserved outside
+            SGLang's KV-cache pool for the co-located vision/audio encoder.
+            Falls back to ``OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE`` (0.05)
+            when ``None``.
     """
+    reserve = (
+        encoder_mem_reserve
+        if encoder_mem_reserve is not None
+        else OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE
+    )
     pre_load_avail_mem = avail_gpu_mem(gpu_id)
     server_args = build_sglang_server_args(
         model_path,
         context_length=thinker_max_seq_len,
-        auto_mem_fraction_static_reserve=OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE,
+        auto_mem_fraction_static_reserve=reserve,
         **(server_args_overrides or {}),
     )
     pre_load_mem = (

--- a/tests/test_mem_fraction_static.py
+++ b/tests/test_mem_fraction_static.py
@@ -17,6 +17,7 @@ import typer
 from sglang_omni.cli.serve import serve
 from sglang_omni.config.schema import ExecutorConfig, PipelineConfig, StageConfig
 from sglang_omni.engines.ar.sglang_backend.server_args_builder import (
+    apply_encoder_mem_reserve,
     build_sglang_server_args,
 )
 from sglang_omni.models.ming_omni.config import MingOmniPipelineConfig
@@ -105,52 +106,28 @@ class TestMemFractionStaticOverrides(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Unknown stage 'nope'"):
             config.apply_server_args_overrides(stage_name="nope", overrides={})
 
-    @patch("sglang_omni.engines.ar.sglang_backend.server_args_builder.ServerArgs")
-    def test_auto_mem_fraction_static_reserve_subtracts_auto_value_only(
-        self, server_args_mock
-    ) -> None:
-        """Encoder reserve subtracts from SGLang's auto value and leaves ServerArgs' mem_fraction_static kwarg unset."""
-        server_args_mock.return_value = SimpleNamespace(mem_fraction_static=0.929)
+    def test_apply_encoder_mem_reserve_subtracts(self) -> None:
+        """Helper subtracts the reserve from the server_args' auto mem_fraction_static in-place."""
+        server_args = SimpleNamespace(mem_fraction_static=0.929)
 
-        server_args = build_sglang_server_args(
-            model_path="dummy",
-            context_length=8192,
-            auto_mem_fraction_static_reserve=0.05,
-        )
+        apply_encoder_mem_reserve(server_args, 0.05)
 
         self.assertEqual(server_args.mem_fraction_static, 0.879)
-        self.assertNotIn("mem_fraction_static", server_args_mock.call_args.kwargs)
 
-    @patch("sglang_omni.engines.ar.sglang_backend.server_args_builder.ServerArgs")
-    def test_auto_mem_fraction_static_reserve_preserves_user_pinned_value(
-        self, server_args_mock
-    ) -> None:
-        """User-pinned mem_fraction_static bypasses the encoder reserve."""
-        server_args_mock.return_value = SimpleNamespace(mem_fraction_static=0.88)
+    def test_apply_encoder_mem_reserve_noop_when_zero(self) -> None:
+        """Reserve = 0 is a no-op; non-thinker callers (talker_ar) rely on this."""
+        server_args = SimpleNamespace(mem_fraction_static=0.929)
 
-        server_args = build_sglang_server_args(
-            model_path="dummy",
-            context_length=8192,
-            mem_fraction_static=0.88,
-            auto_mem_fraction_static_reserve=0.05,
-        )
-
-        self.assertEqual(server_args.mem_fraction_static, 0.88)
-        self.assertEqual(server_args_mock.call_args.kwargs["mem_fraction_static"], 0.88)
-
-    @patch("sglang_omni.engines.ar.sglang_backend.server_args_builder.ServerArgs")
-    def test_auto_reserve_not_applied_when_reserve_kwarg_omitted(
-        self, server_args_mock
-    ) -> None:
-        """Callers that omit auto_mem_fraction_static_reserve (e.g. talker_ar) pass the raw auto value through unchanged."""
-        server_args_mock.return_value = SimpleNamespace(mem_fraction_static=0.929)
-
-        server_args = build_sglang_server_args(
-            model_path="dummy",
-            context_length=8192,
-        )
+        apply_encoder_mem_reserve(server_args, 0.0)
 
         self.assertEqual(server_args.mem_fraction_static, 0.929)
+
+    def test_build_sglang_server_args_no_longer_takes_reserve_kwarg(self) -> None:
+        """``build_sglang_server_args`` is now pure ServerArgs construction; reserve lives in ``apply_encoder_mem_reserve``."""
+        import inspect
+
+        sig = inspect.signature(build_sglang_server_args)
+        self.assertNotIn("auto_mem_fraction_static_reserve", sig.parameters)
 
 
 @unittest.skipUnless(_qwen3_available, "qwen3_omni config not importable")
@@ -179,7 +156,7 @@ class TestEncoderMemReserveRouting(unittest.TestCase):
     def test_encoder_mem_reserve_reaches_thinker_factory(
         self, create_thinker_executor_mock
     ) -> None:
-        """The routed ``encoder_mem_reserve`` lands on ``build_sglang_server_args(auto_mem_fraction_static_reserve=...)`` unchanged."""
+        """The routed ``encoder_mem_reserve`` reaches the factory and is applied to ``server_args.mem_fraction_static``."""
         config = Qwen3OmniPipelineConfig(model_path="dummy")
         config.apply_server_args_overrides(
             stage_name="thinker",
@@ -266,22 +243,16 @@ class TestEncoderMemReserveRouting(unittest.TestCase):
         self.assertEqual(thinker_stage.executor.args["encoder_mem_reserve"], 0.20)
 
 
-class TestEncoderMemReserveBuilderFloor(unittest.TestCase):
-    """Builder raises when reserve would drop auto mem_fraction_static below safe floor."""
+class TestEncoderMemReserveFloor(unittest.TestCase):
+    """``apply_encoder_mem_reserve`` raises when reserve would drop mem_fraction_static below the safe floor."""
 
-    def test_reserve_dropping_auto_below_floor_raises(self) -> None:
-        with patch(
-            "sglang_omni.engines.ar.sglang_backend.server_args_builder.ServerArgs"
-        ) as server_args_mock:
-            # Simulate a tiny auto value (small-memory GPU) + an aggressive
-            # reserve. 0.15 - 0.10 = 0.05 < floor 0.1 -> raise.
-            server_args_mock.return_value = SimpleNamespace(mem_fraction_static=0.15)
-            with self.assertRaisesRegex(ValueError, r"below the safe floor"):
-                build_sglang_server_args(
-                    model_path="dummy",
-                    context_length=8192,
-                    auto_mem_fraction_static_reserve=0.10,
-                )
+    def test_reserve_dropping_below_floor_raises(self) -> None:
+        # Simulate a tiny auto value (small-memory GPU) + an aggressive
+        # reserve. 0.15 - 0.10 = 0.05 < floor 0.1 -> raise.
+        server_args = SimpleNamespace(mem_fraction_static=0.15)
+
+        with self.assertRaisesRegex(ValueError, r"below the safe floor"):
+            apply_encoder_mem_reserve(server_args, 0.10)
 
 
 class TestCliMemFlagMutex(unittest.TestCase):

--- a/tests/test_mem_fraction_static.py
+++ b/tests/test_mem_fraction_static.py
@@ -271,6 +271,23 @@ class TestEncoderMemReserveBuilderFloor(unittest.TestCase):
                 )
 
 
+class TestCliMemFlagMutex(unittest.TestCase):
+    """Reject passing both --mem-fraction-static and --encoder-mem-reserve."""
+
+    def test_both_flags_raises(self) -> None:
+        from examples.run_qwen3_omni_server import _check_mem_flag_mutex
+
+        with self.assertRaisesRegex(ValueError, r"mutually exclusive"):
+            _check_mem_flag_mutex(0.65, 0.20)
+
+    def test_either_flag_alone_is_ok(self) -> None:
+        from examples.run_qwen3_omni_server import _check_mem_flag_mutex
+
+        _check_mem_flag_mutex(0.65, None)
+        _check_mem_flag_mutex(None, 0.20)
+        _check_mem_flag_mutex(None, None)
+
+
 class TestH20AutoMemFractionFloor(unittest.TestCase):
     def test_h20_auto_mem_fraction_static_has_expected_floor(self) -> None:
         """On H20 hardware, SGLang's auto-sized mem_fraction_static must sit at or above 0.85."""

--- a/tests/test_mem_fraction_static.py
+++ b/tests/test_mem_fraction_static.py
@@ -107,7 +107,7 @@ class TestMemFractionStaticOverrides(unittest.TestCase):
             config.apply_server_args_overrides(stage_name="nope", overrides={})
 
     def test_apply_encoder_mem_reserve_subtracts(self) -> None:
-        """Helper subtracts the reserve from the server_args' auto mem_fraction_static in-place."""
+        """apply_encoder_mem_reserve subtracts the reserve from the server_args' auto mem_fraction_static in-place."""
         server_args = SimpleNamespace(mem_fraction_static=0.929)
 
         apply_encoder_mem_reserve(server_args, 0.05)
@@ -123,7 +123,7 @@ class TestMemFractionStaticOverrides(unittest.TestCase):
         self.assertEqual(server_args.mem_fraction_static, 0.929)
 
     def test_build_sglang_server_args_no_longer_takes_reserve_kwarg(self) -> None:
-        """``build_sglang_server_args`` is now pure ServerArgs construction; reserve lives in ``apply_encoder_mem_reserve``."""
+        """build_sglang_server_args is now pure ServerArgs construction; reserve lives in apply_encoder_mem_reserve."""
         import inspect
 
         sig = inspect.signature(build_sglang_server_args)
@@ -135,7 +135,7 @@ class TestEncoderMemReserveRouting(unittest.TestCase):
     """Round-trip + fallback + validation coverage for ``--encoder-mem-reserve``."""
 
     def test_encoder_mem_reserve_round_trips_to_thinker_stage_args(self) -> None:
-        """``apply_server_args_overrides`` routes ``encoder_mem_reserve`` to the thinker stage args, not ``server_args_overrides``."""
+        """apply_server_args_overrides routes encoder_mem_reserve to the thinker stage args, not server_args_overrides."""
         config = Qwen3OmniPipelineConfig(model_path="dummy")
 
         config.apply_server_args_overrides(
@@ -156,7 +156,7 @@ class TestEncoderMemReserveRouting(unittest.TestCase):
     def test_encoder_mem_reserve_reaches_thinker_factory(
         self, create_thinker_executor_mock
     ) -> None:
-        """The routed ``encoder_mem_reserve`` reaches the factory and is applied to ``server_args.mem_fraction_static``."""
+        """The routed encoder_mem_reserve reaches the factory and is applied to server_args.mem_fraction_static."""
         config = Qwen3OmniPipelineConfig(model_path="dummy")
         config.apply_server_args_overrides(
             stage_name="thinker",
@@ -231,7 +231,7 @@ class TestEncoderMemReserveRouting(unittest.TestCase):
         self.assertEqual(dict(thinker_stage.executor.args or {}), original_args)
 
     def test_encoder_mem_reserve_routes_on_speech_variant(self) -> None:
-        """Speech variant shares ``_route_thinker_executor_args``; pin that."""
+        """Speech variant shares _route_thinker_executor_args and pins that."""
         from sglang_omni.models.qwen3_omni.config import Qwen3OmniSpeechPipelineConfig
 
         config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")

--- a/tests/test_mem_fraction_static.py
+++ b/tests/test_mem_fraction_static.py
@@ -174,6 +174,7 @@ class TestEncoderMemReserveRouting(unittest.TestCase):
             )
 
         server_args = create_thinker_executor_mock.call_args.kwargs["server_args"]
+        # Note (Chenyang):
         # auto=0.929 minus reserve=0.20 => 0.729 after rounding.
         self.assertEqual(server_args.mem_fraction_static, 0.729)
 
@@ -183,7 +184,7 @@ class TestEncoderMemReserveRouting(unittest.TestCase):
     def test_factory_uses_default_reserve_when_omitted(
         self, create_thinker_executor_mock
     ) -> None:
-        """Omitting ``encoder_mem_reserve`` picks up the factory signature default (0.05)."""
+        """Omitting encoder_mem_reserve picks up the factory signature default (0.05)."""
         with patch(
             "sglang_omni.engines.ar.sglang_backend.server_args_builder.ServerArgs"
         ) as server_args_mock:
@@ -191,17 +192,17 @@ class TestEncoderMemReserveRouting(unittest.TestCase):
             create_sglang_thinker_executor_from_config(
                 model_path="dummy",
                 thinker_max_seq_len=8192,
-                # encoder_mem_reserve deliberately omitted -> default 0.05.
             )
 
         server_args = create_thinker_executor_mock.call_args.kwargs["server_args"]
+        # Note (Chenyang):
         # auto=0.929 minus default=0.05 => 0.879 after rounding.
         self.assertEqual(server_args.mem_fraction_static, 0.879)
 
     def test_out_of_range_encoder_mem_reserve_rejected_via_apply_overrides(
         self,
     ) -> None:
-        """Out-of-range reserves raise at the config boundary, before launch."""
+        """Out-of-range encoder_mem_reserve raises at the config boundary, before launch."""
         config = Qwen3OmniPipelineConfig(model_path="dummy")
 
         with self.assertRaisesRegex(
@@ -247,6 +248,7 @@ class TestEncoderMemReserveFloor(unittest.TestCase):
     """``apply_encoder_mem_reserve`` raises when reserve would drop mem_fraction_static below the safe floor."""
 
     def test_reserve_dropping_below_floor_raises(self) -> None:
+        # Note (Chenyang):
         # Simulate a tiny auto value (small-memory GPU) + an aggressive
         # reserve. 0.15 - 0.10 = 0.05 < floor 0.1 -> raise.
         server_args = SimpleNamespace(mem_fraction_static=0.15)

--- a/tests/test_mem_fraction_static.py
+++ b/tests/test_mem_fraction_static.py
@@ -254,6 +254,50 @@ class TestEncoderMemReserveRouting(unittest.TestCase):
                 overrides={"encoder_mem_reserve": 5.0},
             )
 
+    def test_thinker_executor_args_atomic_on_partial_cast_failure(self) -> None:
+        """Mix of (valid thinker_max_seq_len + invalid encoder_mem_reserve): the valid key must not be partially written when a later cast raises."""
+        config = Qwen3OmniPipelineConfig(model_path="dummy")
+        thinker_stage = next(s for s in config.stages if s.name == "thinker")
+        original_args = dict(thinker_stage.executor.args or {})
+
+        with self.assertRaises(ValueError):
+            config.apply_server_args_overrides(
+                stage_name="thinker",
+                overrides={
+                    "thinker_max_seq_len": 16384,  # valid cast
+                    "encoder_mem_reserve": 5.0,  # out-of-range -> cast raises
+                },
+            )
+
+        current_args = dict(thinker_stage.executor.args or {})
+        self.assertEqual(
+            current_args,
+            original_args,
+            "thinker_max_seq_len was written despite later cast failure -- routing is not atomic",
+        )
+
+    def test_thinker_executor_args_atomic_reverse_order(self) -> None:
+        """Reverse mix (valid encoder_mem_reserve + invalid thinker_max_seq_len): same atomicity guarantee holds regardless of which key fails."""
+        config = Qwen3OmniPipelineConfig(model_path="dummy")
+        thinker_stage = next(s for s in config.stages if s.name == "thinker")
+        original_args = dict(thinker_stage.executor.args or {})
+
+        with self.assertRaises((ValueError, TypeError)):
+            config.apply_server_args_overrides(
+                stage_name="thinker",
+                overrides={
+                    "encoder_mem_reserve": 0.20,  # valid cast
+                    "thinker_max_seq_len": "not-an-int",  # int() -> ValueError
+                },
+            )
+
+        current_args = dict(thinker_stage.executor.args or {})
+        self.assertEqual(
+            current_args,
+            original_args,
+            "encoder_mem_reserve was written despite later cast failure -- routing is not atomic",
+        )
+
 
 class TestMingDropsEncoderMemReserve(unittest.TestCase):
     """Ming pipelines pop ``encoder_mem_reserve`` defensively (no runtime path yet)."""

--- a/tests/test_mem_fraction_static.py
+++ b/tests/test_mem_fraction_static.py
@@ -153,6 +153,148 @@ class TestMemFractionStaticOverrides(unittest.TestCase):
         self.assertEqual(server_args.mem_fraction_static, 0.929)
 
 
+@unittest.skipUnless(_qwen3_available, "qwen3_omni config not importable")
+class TestEncoderMemReserveRouting(unittest.TestCase):
+    """Round-trip + fallback + validation coverage for ``--encoder-mem-reserve``."""
+
+    def test_encoder_mem_reserve_round_trips_to_thinker_stage_args(self) -> None:
+        """``apply_server_args_overrides`` routes ``encoder_mem_reserve`` to the thinker stage args, not ``server_args_overrides``."""
+        config = Qwen3OmniPipelineConfig(model_path="dummy")
+
+        config.apply_server_args_overrides(
+            stage_name="thinker",
+            overrides={"encoder_mem_reserve": 0.20},
+        )
+
+        thinker_stage = next(s for s in config.stages if s.name == "thinker")
+        self.assertEqual(thinker_stage.executor.args["encoder_mem_reserve"], 0.20)
+        self.assertNotIn(
+            "encoder_mem_reserve",
+            thinker_stage.executor.args.get("server_args_overrides", {}),
+        )
+
+    @patch(
+        "sglang_omni.models.qwen3_omni.pipeline.stages.create_sglang_thinker_executor"
+    )
+    def test_encoder_mem_reserve_reaches_thinker_factory(
+        self, create_thinker_executor_mock
+    ) -> None:
+        """The routed ``encoder_mem_reserve`` lands on ``build_sglang_server_args(auto_mem_fraction_static_reserve=...)`` unchanged."""
+        config = Qwen3OmniPipelineConfig(model_path="dummy")
+        config.apply_server_args_overrides(
+            stage_name="thinker",
+            overrides={"encoder_mem_reserve": 0.20},
+        )
+        thinker_stage = next(s for s in config.stages if s.name == "thinker")
+
+        with patch(
+            "sglang_omni.engines.ar.sglang_backend.server_args_builder.ServerArgs"
+        ) as server_args_mock:
+            server_args_mock.return_value = SimpleNamespace(mem_fraction_static=0.929)
+            create_sglang_thinker_executor_from_config(
+                model_path="dummy",
+                **thinker_stage.executor.args,
+            )
+
+        server_args = create_thinker_executor_mock.call_args.kwargs["server_args"]
+        # auto=0.929 minus reserve=0.20 => 0.729 after rounding.
+        self.assertEqual(server_args.mem_fraction_static, 0.729)
+
+    @patch(
+        "sglang_omni.models.qwen3_omni.pipeline.stages.create_sglang_thinker_executor"
+    )
+    def test_factory_falls_back_to_module_constant_when_reserve_is_none(
+        self, create_thinker_executor_mock
+    ) -> None:
+        """``encoder_mem_reserve=None`` means the factory reuses ``OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE`` (0.05)."""
+        with patch(
+            "sglang_omni.engines.ar.sglang_backend.server_args_builder.ServerArgs"
+        ) as server_args_mock:
+            server_args_mock.return_value = SimpleNamespace(mem_fraction_static=0.929)
+            create_sglang_thinker_executor_from_config(
+                model_path="dummy",
+                thinker_max_seq_len=8192,
+                # encoder_mem_reserve deliberately omitted -> None default.
+            )
+
+        server_args = create_thinker_executor_mock.call_args.kwargs["server_args"]
+        # auto=0.929 minus constant=0.05 => 0.879 after rounding.
+        self.assertEqual(server_args.mem_fraction_static, 0.879)
+
+    def test_cast_validator_rejects_out_of_range_values(self) -> None:
+        """The cast validator rejects negative, >=1, and large out-of-range values."""
+        from sglang_omni.models.qwen3_omni.config import _cast_encoder_mem_reserve
+
+        for bad in (-0.1, 1.0, 1.5):
+            with self.assertRaisesRegex(
+                ValueError, r"encoder_mem_reserve must be in \[0, 1\)"
+            ):
+                _cast_encoder_mem_reserve(bad)
+
+    def test_cast_validator_accepts_in_range_values(self) -> None:
+        """The cast validator accepts 0, small, and near-1 values, returning a float."""
+        from sglang_omni.models.qwen3_omni.config import _cast_encoder_mem_reserve
+
+        for good in (0.0, 0.05, 0.9):
+            result = _cast_encoder_mem_reserve(good)
+            self.assertIsInstance(result, float)
+            self.assertEqual(result, good)
+
+    def test_out_of_range_encoder_mem_reserve_rejected_via_apply_overrides(
+        self,
+    ) -> None:
+        """Programmatic callers of ``apply_server_args_overrides`` also hit the cast validator."""
+        config = Qwen3OmniPipelineConfig(model_path="dummy")
+
+        with self.assertRaisesRegex(
+            ValueError, r"encoder_mem_reserve must be in \[0, 1\)"
+        ):
+            config.apply_server_args_overrides(
+                stage_name="thinker",
+                overrides={"encoder_mem_reserve": 5.0},
+            )
+
+
+class TestMingDropsEncoderMemReserve(unittest.TestCase):
+    """Ming pipelines pop ``encoder_mem_reserve`` defensively (no runtime path yet)."""
+
+    def test_ming_base_drops_encoder_mem_reserve_without_leaking_to_server_args(
+        self,
+    ) -> None:
+        """MingOmniPipelineConfig pops ``encoder_mem_reserve`` so ServerArgs unpack will not crash."""
+        config = MingOmniPipelineConfig(model_path="dummy")
+
+        config.apply_server_args_overrides(
+            stage_name="thinker",
+            overrides={"encoder_mem_reserve": 0.20, "cpu_offload_gb": 40},
+        )
+
+        thinker_stage = next(s for s in config.stages if s.name == "thinker")
+        overrides = thinker_stage.executor.args.get("server_args_overrides", {})
+        self.assertNotIn("encoder_mem_reserve", overrides)
+        self.assertNotIn("encoder_mem_reserve", thinker_stage.executor.args)
+        # Other keys still flow through unchanged.
+        self.assertEqual(overrides.get("cpu_offload_gb"), 40)
+
+    def test_ming_speech_drops_encoder_mem_reserve_without_leaking_to_server_args(
+        self,
+    ) -> None:
+        """MingOmniSpeechPipelineConfig also pops ``encoder_mem_reserve``."""
+        from sglang_omni.models.ming_omni.config import MingOmniSpeechPipelineConfig
+
+        config = MingOmniSpeechPipelineConfig(model_path="dummy")
+        config.apply_server_args_overrides(
+            stage_name="thinker",
+            overrides={"encoder_mem_reserve": 0.20, "cpu_offload_gb": 40},
+        )
+
+        thinker_stage = next(s for s in config.stages if s.name == "thinker")
+        overrides = thinker_stage.executor.args.get("server_args_overrides", {})
+        self.assertNotIn("encoder_mem_reserve", overrides)
+        self.assertNotIn("encoder_mem_reserve", thinker_stage.executor.args)
+        self.assertEqual(overrides.get("cpu_offload_gb"), 40)
+
+
 class TestH20AutoMemFractionFloor(unittest.TestCase):
     def test_h20_auto_mem_fraction_static_has_expected_floor(self) -> None:
         """On H20 hardware, SGLang's auto-sized mem_fraction_static must sit at or above 0.85."""

--- a/tests/test_mem_fraction_static.py
+++ b/tests/test_mem_fraction_static.py
@@ -203,10 +203,10 @@ class TestEncoderMemReserveRouting(unittest.TestCase):
     @patch(
         "sglang_omni.models.qwen3_omni.pipeline.stages.create_sglang_thinker_executor"
     )
-    def test_factory_falls_back_to_module_constant_when_reserve_is_none(
+    def test_factory_uses_default_reserve_when_omitted(
         self, create_thinker_executor_mock
     ) -> None:
-        """``encoder_mem_reserve=None`` means the factory reuses ``OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE`` (0.05)."""
+        """Omitting ``encoder_mem_reserve`` picks up the factory signature default (0.05)."""
         with patch(
             "sglang_omni.engines.ar.sglang_backend.server_args_builder.ServerArgs"
         ) as server_args_mock:
@@ -214,11 +214,11 @@ class TestEncoderMemReserveRouting(unittest.TestCase):
             create_sglang_thinker_executor_from_config(
                 model_path="dummy",
                 thinker_max_seq_len=8192,
-                # encoder_mem_reserve deliberately omitted -> None default.
+                # encoder_mem_reserve deliberately omitted -> default 0.05.
             )
 
         server_args = create_thinker_executor_mock.call_args.kwargs["server_args"]
-        # auto=0.929 minus constant=0.05 => 0.879 after rounding.
+        # auto=0.929 minus default=0.05 => 0.879 after rounding.
         self.assertEqual(server_args.mem_fraction_static, 0.879)
 
     def test_out_of_range_encoder_mem_reserve_rejected_via_apply_overrides(

--- a/tests/test_mem_fraction_static.py
+++ b/tests/test_mem_fraction_static.py
@@ -221,29 +221,10 @@ class TestEncoderMemReserveRouting(unittest.TestCase):
         # auto=0.929 minus constant=0.05 => 0.879 after rounding.
         self.assertEqual(server_args.mem_fraction_static, 0.879)
 
-    def test_cast_validator_rejects_out_of_range_values(self) -> None:
-        """The cast validator rejects negative, >=1, and large out-of-range values."""
-        from sglang_omni.models.qwen3_omni.config import _cast_encoder_mem_reserve
-
-        for bad in (-0.1, 1.0, 1.5):
-            with self.assertRaisesRegex(
-                ValueError, r"encoder_mem_reserve must be in \[0, 1\)"
-            ):
-                _cast_encoder_mem_reserve(bad)
-
-    def test_cast_validator_accepts_in_range_values(self) -> None:
-        """The cast validator accepts 0, small, and near-1 values, returning a float."""
-        from sglang_omni.models.qwen3_omni.config import _cast_encoder_mem_reserve
-
-        for good in (0.0, 0.05, 0.9):
-            result = _cast_encoder_mem_reserve(good)
-            self.assertIsInstance(result, float)
-            self.assertEqual(result, good)
-
     def test_out_of_range_encoder_mem_reserve_rejected_via_apply_overrides(
         self,
     ) -> None:
-        """Programmatic callers of ``apply_server_args_overrides`` also hit the cast validator."""
+        """Out-of-range reserves raise at the config boundary, before launch."""
         config = Qwen3OmniPipelineConfig(model_path="dummy")
 
         with self.assertRaisesRegex(
@@ -255,7 +236,7 @@ class TestEncoderMemReserveRouting(unittest.TestCase):
             )
 
     def test_thinker_executor_args_atomic_on_partial_cast_failure(self) -> None:
-        """Mix of (valid thinker_max_seq_len + invalid encoder_mem_reserve): the valid key must not be partially written when a later cast raises."""
+        """A later cast failure must not leave an earlier valid key written."""
         config = Qwen3OmniPipelineConfig(model_path="dummy")
         thinker_stage = next(s for s in config.stages if s.name == "thinker")
         original_args = dict(thinker_stage.executor.args or {})
@@ -264,90 +245,30 @@ class TestEncoderMemReserveRouting(unittest.TestCase):
             config.apply_server_args_overrides(
                 stage_name="thinker",
                 overrides={
-                    "thinker_max_seq_len": 16384,  # valid cast
-                    "encoder_mem_reserve": 5.0,  # out-of-range -> cast raises
+                    "thinker_max_seq_len": 16384,
+                    "encoder_mem_reserve": 5.0,
                 },
             )
 
-        current_args = dict(thinker_stage.executor.args or {})
-        self.assertEqual(
-            current_args,
-            original_args,
-            "thinker_max_seq_len was written despite later cast failure -- routing is not atomic",
-        )
-
-    def test_thinker_executor_args_atomic_reverse_order(self) -> None:
-        """Reverse-order regression guard.
-
-        Under the current ``_THINKER_EXECUTOR_ARG_CASTS`` declaration order,
-        ``thinker_max_seq_len`` is cast before ``encoder_mem_reserve`` so
-        a bad ``thinker_max_seq_len`` aborts before the (already-valid)
-        ``encoder_mem_reserve`` is written. This test does NOT directly
-        repro the pre-fix bug for the reverse-failure case (the forward
-        test does) — it pins the post-fix atomic semantics so that any
-        future reordering of ``_THINKER_EXECUTOR_ARG_CASTS`` (which would
-        flip which key partial-writes under the old implementation) still
-        keeps stage state unchanged on cast failure.
-        """
-        config = Qwen3OmniPipelineConfig(model_path="dummy")
-        thinker_stage = next(s for s in config.stages if s.name == "thinker")
-        original_args = dict(thinker_stage.executor.args or {})
-
-        with self.assertRaises((ValueError, TypeError)):
-            config.apply_server_args_overrides(
-                stage_name="thinker",
-                overrides={
-                    "encoder_mem_reserve": 0.20,  # valid cast
-                    "thinker_max_seq_len": "not-an-int",  # int() -> ValueError
-                },
-            )
-
-        current_args = dict(thinker_stage.executor.args or {})
-        self.assertEqual(
-            current_args,
-            original_args,
-            "encoder_mem_reserve was written despite later cast failure -- routing is not atomic",
-        )
+        self.assertEqual(dict(thinker_stage.executor.args or {}), original_args)
 
 
-class TestMingDropsEncoderMemReserve(unittest.TestCase):
-    """Ming pipelines pop ``encoder_mem_reserve`` defensively (no runtime path yet)."""
+class TestEncoderMemReserveBuilderFloor(unittest.TestCase):
+    """Builder raises when reserve would drop auto mem_fraction_static below safe floor."""
 
-    def test_ming_base_drops_encoder_mem_reserve_without_leaking_to_server_args(
-        self,
-    ) -> None:
-        """MingOmniPipelineConfig pops ``encoder_mem_reserve`` so ServerArgs unpack will not crash."""
-        config = MingOmniPipelineConfig(model_path="dummy")
-
-        config.apply_server_args_overrides(
-            stage_name="thinker",
-            overrides={"encoder_mem_reserve": 0.20, "cpu_offload_gb": 40},
-        )
-
-        thinker_stage = next(s for s in config.stages if s.name == "thinker")
-        overrides = thinker_stage.executor.args.get("server_args_overrides", {})
-        self.assertNotIn("encoder_mem_reserve", overrides)
-        self.assertNotIn("encoder_mem_reserve", thinker_stage.executor.args)
-        # Other keys still flow through unchanged.
-        self.assertEqual(overrides.get("cpu_offload_gb"), 40)
-
-    def test_ming_speech_drops_encoder_mem_reserve_without_leaking_to_server_args(
-        self,
-    ) -> None:
-        """MingOmniSpeechPipelineConfig also pops ``encoder_mem_reserve``."""
-        from sglang_omni.models.ming_omni.config import MingOmniSpeechPipelineConfig
-
-        config = MingOmniSpeechPipelineConfig(model_path="dummy")
-        config.apply_server_args_overrides(
-            stage_name="thinker",
-            overrides={"encoder_mem_reserve": 0.20, "cpu_offload_gb": 40},
-        )
-
-        thinker_stage = next(s for s in config.stages if s.name == "thinker")
-        overrides = thinker_stage.executor.args.get("server_args_overrides", {})
-        self.assertNotIn("encoder_mem_reserve", overrides)
-        self.assertNotIn("encoder_mem_reserve", thinker_stage.executor.args)
-        self.assertEqual(overrides.get("cpu_offload_gb"), 40)
+    def test_reserve_dropping_auto_below_floor_raises(self) -> None:
+        with patch(
+            "sglang_omni.engines.ar.sglang_backend.server_args_builder.ServerArgs"
+        ) as server_args_mock:
+            # Simulate a tiny auto value (small-memory GPU) + an aggressive
+            # reserve. 0.15 - 0.10 = 0.05 < floor 0.1 -> raise.
+            server_args_mock.return_value = SimpleNamespace(mem_fraction_static=0.15)
+            with self.assertRaisesRegex(ValueError, r"below the safe floor"):
+                build_sglang_server_args(
+                    model_path="dummy",
+                    context_length=8192,
+                    auto_mem_fraction_static_reserve=0.10,
+                )
 
 
 class TestH20AutoMemFractionFloor(unittest.TestCase):

--- a/tests/test_mem_fraction_static.py
+++ b/tests/test_mem_fraction_static.py
@@ -277,7 +277,18 @@ class TestEncoderMemReserveRouting(unittest.TestCase):
         )
 
     def test_thinker_executor_args_atomic_reverse_order(self) -> None:
-        """Reverse mix (valid encoder_mem_reserve + invalid thinker_max_seq_len): same atomicity guarantee holds regardless of which key fails."""
+        """Reverse-order regression guard.
+
+        Under the current ``_THINKER_EXECUTOR_ARG_CASTS`` declaration order,
+        ``thinker_max_seq_len`` is cast before ``encoder_mem_reserve`` so
+        a bad ``thinker_max_seq_len`` aborts before the (already-valid)
+        ``encoder_mem_reserve`` is written. This test does NOT directly
+        repro the pre-fix bug for the reverse-failure case (the forward
+        test does) — it pins the post-fix atomic semantics so that any
+        future reordering of ``_THINKER_EXECUTOR_ARG_CASTS`` (which would
+        flip which key partial-writes under the old implementation) still
+        keeps stage state unchanged on cast failure.
+        """
         config = Qwen3OmniPipelineConfig(model_path="dummy")
         thinker_stage = next(s for s in config.stages if s.name == "thinker")
         original_args = dict(thinker_stage.executor.args or {})

--- a/tests/test_mem_fraction_static.py
+++ b/tests/test_mem_fraction_static.py
@@ -252,6 +252,19 @@ class TestEncoderMemReserveRouting(unittest.TestCase):
 
         self.assertEqual(dict(thinker_stage.executor.args or {}), original_args)
 
+    def test_encoder_mem_reserve_routes_on_speech_variant(self) -> None:
+        """Speech variant shares ``_route_thinker_executor_args``; pin that."""
+        from sglang_omni.models.qwen3_omni.config import Qwen3OmniSpeechPipelineConfig
+
+        config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+        config.apply_server_args_overrides(
+            stage_name="thinker",
+            overrides={"encoder_mem_reserve": 0.20},
+        )
+
+        thinker_stage = next(s for s in config.stages if s.name == "thinker")
+        self.assertEqual(thinker_stage.executor.args["encoder_mem_reserve"], 0.20)
+
 
 class TestEncoderMemReserveBuilderFloor(unittest.TestCase):
     """Builder raises when reserve would drop auto mem_fraction_static below safe floor."""

--- a/tests/test_model_path_resolution.py
+++ b/tests/test_model_path_resolution.py
@@ -64,6 +64,7 @@ def _install_qwen3_stages_stubs(monkeypatch) -> None:
         monkeypatch,
         "sglang_omni.engines.ar.sglang_backend.server_args_builder",
         build_sglang_server_args=lambda *args, **kwargs: None,
+        apply_encoder_mem_reserve=lambda *args, **kwargs: None,
     )
     _stub_module(
         monkeypatch,
@@ -145,6 +146,12 @@ def _install_qwen3_stages_stubs(monkeypatch) -> None:
 
 def _import_qwen3_stages_for_test(monkeypatch):
     module_name = "sglang_omni.models.qwen3_omni.pipeline.stages"
+    # Register the current (real) stages module for restoration on teardown.
+    # Without this, the re-import below leaves a stub-bound stages module in
+    # sys.modules and later tests that import from it get the polluted copy.
+    original = sys.modules.get(module_name)
+    if original is not None:
+        monkeypatch.setitem(sys.modules, module_name, original)
     sys.modules.pop(module_name, None)
     _install_qwen3_stages_stubs(monkeypatch)
     return importlib.import_module(module_name)

--- a/tests/test_model_path_resolution.py
+++ b/tests/test_model_path_resolution.py
@@ -63,7 +63,6 @@ def _install_qwen3_stages_stubs(monkeypatch) -> None:
     _stub_module(
         monkeypatch,
         "sglang_omni.engines.ar.sglang_backend.server_args_builder",
-        OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE=0.05,
         build_sglang_server_args=lambda *args, **kwargs: None,
     )
     _stub_module(

--- a/tests/test_model_path_resolution.py
+++ b/tests/test_model_path_resolution.py
@@ -146,9 +146,6 @@ def _install_qwen3_stages_stubs(monkeypatch) -> None:
 
 def _import_qwen3_stages_for_test(monkeypatch):
     module_name = "sglang_omni.models.qwen3_omni.pipeline.stages"
-    # Register the current (real) stages module for restoration on teardown.
-    # Without this, the re-import below leaves a stub-bound stages module in
-    # sys.modules and later tests that import from it get the polluted copy.
     original = sys.modules.get(module_name)
     if original is not None:
         monkeypatch.setitem(sys.modules, module_name, original)


### PR DESCRIPTION
### Motivation

`OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE` was a module-level hardcoded constant (`0.05`) that subtracts from SGLang's auto-selected `mem_fraction_static` to leave room for the co-located vision/audio encoders' peak activations. This works for typical single-request workloads, but raising it (e.g. to `0.15`–`0.20`) is required for high-concurrency long-video workloads on H200, and lowering it may be desirable on small-GPU boxes (H100 40GB etc.) where `0.05` already starves the SGLang static pool.

Callers had no way to tune this without patching source. This PR promotes it to a first-class server CLI flag.

### Modifications

- New CLI flag `--encoder-mem-reserve` on `examples/run_qwen3_omni_server.py` (Python attr `encoder_mem_reserve`, kebab-case consistent with `--mem-fraction-static` / `--cpu-offload-gb`).
- Default preserved: `None` at the CLI → falls back to the existing `OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE = 0.05` constant at the factory layer. No behavior change for users who don't pass the flag.
- Routing: `Qwen3OmniPipelineConfig.apply_server_args_overrides` now routes `encoder_mem_reserve` alongside `thinker_max_seq_len` through a unified `_THINKER_EXECUTOR_ARG_CASTS` cast-and-validate table, so every entry point (this CLI, the generic `sglang_omni.cli.serve` dispatcher, programmatic `apply_server_args_overrides` callers) hits the same `[0, 1)` range check and fails early with a clear error.
- Atomicity: `_route_thinker_executor_args` now casts every executor kwarg into a temporary dict first and only mutates `stage.executor.args` after all casts succeed. A previous iteration could partial-write `thinker_max_seq_len` before a later `encoder_mem_reserve` cast raised; this is now impossible.
- Ming-Omni forward-compat: `MingOmniPipelineConfig.apply_server_args_overrides` / `MingOmniSpeechPipelineConfig.apply_server_args_overrides` defensively `pop("encoder_mem_reserve", None)` via a small `_drop_qwen3_only_overrides` helper with a `TODO` comment. Ming continues to use the shared `0.05` constant; the drop is purely to protect the generic CLI dispatcher from surfacing a confusing `TypeError: ServerArgs() got unexpected keyword argument 'encoder_mem_reserve'` once that dispatcher learns to forward arbitrary overrides.
- Docs: module-level comment on the constant and a Google-style docstring on `build_sglang_server_args` spell out the physical meaning (headroom left outside SGLang's static pool for encoder peak activations), the `0.05` default, and the `0.15`–`0.20` recommendation for high-concurrency video workloads.
- Defaults NOT changed: `thinker_max_seq_len` stays `8192`, `OMNI_ENCODER_MEM_FRACTION_STATIC_RESERVE` stays `0.05`. This PR only exposes the knob; existing production behavior is byte-identical unless `--encoder-mem-reserve` is passed.
