### PR TITLE
[Docs] Add H100 full-set reference results to benchmark entry scripts

### DIFF
--- a/benchmarks/eval/benchmark_omni_mmmu.py
+++ b/benchmarks/eval/benchmark_omni_mmmu.py
@@ -37,8 +37,8 @@ Accuracy (summary)
 | ---------- | ------------------ | -------- | ------- | ------ | ----------- | ------------------------------------------------------ |
 | Qwen3-Omni | enable_audio=False | 67.22%   | 605/900 | 0      | 21          | PR #316 [H200, full-set, c=8, max_tokens=2048]         |
 | Qwen3-Omni | enable_audio=True  | 46.00%   | 23/50   | 15     | 0           | PR #316 [H200, 50-sample subset, c=1, max_tokens=2048] |
-| Qwen3-Omni | enable_audio=False | TBD      | TBD     | TBD    | TBD         | PR #351 [H100, deferred — c=8 OOM on 80GB HBM] |
-| Qwen3-Omni | enable_audio=True  | TBD      | TBD     | TBD    | TBD         | PR #351 [H100, deferred — talker bottleneck (#276) timeouts on H100] |
+| Qwen3-Omni | enable_audio=False | 66.11%   | 595/900 | 0      | 28          | PR #351 [H100, full-set, c=8, max_tokens=2048, text-only server] |
+| Qwen3-Omni | enable_audio=True  | 18.00%   | 9/50    | 21     | 20          | PR #351 [H100, 50-sample subset, c=1, max_tokens=64, timeout=120s] |
 
 Note (Xuesong): full 900 not runfor enable_audio = True — Issue #276 talker is c=1 only and ~2 min/sample (~30 h for full set). 15/50 requests failed
  in audio generation (Issue #276); on the 35 completed requests accuracy = 65.7%.
@@ -49,8 +49,8 @@ Speed (speed)
 | ---------- | ------------------ | -------------- | ------------- | -------------- | -------------- | ------------- | ---------------------------------------------------------- |
 | Qwen3-Omni | enable_audio=False | 25.70          | 96.38         | 0.308          | 19.6           | 19.9          | PR #316 [H200, full-set, c=8, max_tokens=2048]             |
 | Qwen3-Omni | enable_audio=True  | 123.13         | 221.52        | 0.004          | 2.2            | 2.1           | PR #316 [H200, **50-sample subset**, c=1, max_tokens=2048] |
-| Qwen3-Omni | enable_audio=False | TBD            | TBD           | TBD            | TBD            | TBD           | PR #351 [H100, deferred — c=8 OOM on 80GB HBM] |
-| Qwen3-Omni | enable_audio=True  | TBD            | TBD           | TBD            | TBD            | TBD           | PR #351 [H100, deferred — talker bottleneck (#276) timeouts on H100] |
+| Qwen3-Omni | enable_audio=False | 20.297         | 74.122        | 0.392          | 24.9           | 25.4          | PR #351 [H100, full-set, c=8, max_tokens=2048, text-only server] |
+| Qwen3-Omni | enable_audio=True  | 19.579         | 23.147        | 0.009          | 3.3            | 3.3           | PR #351 [H100, 50-sample subset, c=1, max_tokens=64, timeout=120s] |
 """
 
 

--- a/benchmarks/eval/benchmark_omni_mmmu.py
+++ b/benchmarks/eval/benchmark_omni_mmmu.py
@@ -37,6 +37,8 @@ Accuracy (summary)
 | ---------- | ------------------ | -------- | ------- | ------ | ----------- | ------------------------------------------------------ |
 | Qwen3-Omni | enable_audio=False | 67.22%   | 605/900 | 0      | 21          | PR #316 [H200, full-set, c=8, max_tokens=2048]         |
 | Qwen3-Omni | enable_audio=True  | 46.00%   | 23/50   | 15     | 0           | PR #316 [H200, 50-sample subset, c=1, max_tokens=2048] |
+| Qwen3-Omni | enable_audio=False | TBD      | TBD     | TBD    | TBD         | PR #??? [H100, deferred — c=8 OOM on 80GB HBM] |
+| Qwen3-Omni | enable_audio=True  | TBD      | TBD     | TBD    | TBD         | PR #??? [H100, deferred — talker bottleneck (#276) timeouts on H100] |
 
 Note (Xuesong): full 900 not runfor enable_audio = True — Issue #276 talker is c=1 only and ~2 min/sample (~30 h for full set). 15/50 requests failed
  in audio generation (Issue #276); on the 35 completed requests accuracy = 65.7%.
@@ -47,6 +49,8 @@ Speed (speed)
 | ---------- | ------------------ | -------------- | ------------- | -------------- | -------------- | ------------- | ---------------------------------------------------------- |
 | Qwen3-Omni | enable_audio=False | 25.70          | 96.38         | 0.308          | 19.6           | 19.9          | PR #316 [H200, full-set, c=8, max_tokens=2048]             |
 | Qwen3-Omni | enable_audio=True  | 123.13         | 221.52        | 0.004          | 2.2            | 2.1           | PR #316 [H200, **50-sample subset**, c=1, max_tokens=2048] |
+| Qwen3-Omni | enable_audio=False | TBD            | TBD           | TBD            | TBD            | TBD           | PR #??? [H100, deferred — c=8 OOM on 80GB HBM] |
+| Qwen3-Omni | enable_audio=True  | TBD            | TBD           | TBD            | TBD            | TBD           | PR #??? [H100, deferred — talker bottleneck (#276) timeouts on H100] |
 """
 
 

--- a/benchmarks/eval/benchmark_omni_mmmu.py
+++ b/benchmarks/eval/benchmark_omni_mmmu.py
@@ -29,7 +29,7 @@ CI runs on a subset and has its own thresholds elsewhere (see tasks/*.py).
 
 Benchmark: MMMU     |  Dataset: MMMU_val (900 samples, all 30 subjects)
 Hardware:  1 x H200 (default; non-H200 sources are tagged in Source column)
-Last verified: 2026-04-18
+Last verified: 2026-04-25
 
 Accuracy (summary)
 
@@ -37,8 +37,8 @@ Accuracy (summary)
 | ---------- | ------------------ | -------- | ------- | ------ | ----------- | ------------------------------------------------------ |
 | Qwen3-Omni | enable_audio=False | 67.22%   | 605/900 | 0      | 21          | PR #316 [H200, full-set, c=8, max_tokens=2048]         |
 | Qwen3-Omni | enable_audio=True  | 46.00%   | 23/50   | 15     | 0           | PR #316 [H200, 50-sample subset, c=1, max_tokens=2048] |
-| Qwen3-Omni | enable_audio=False | TBD      | TBD     | TBD    | TBD         | PR #??? [H100, deferred — c=8 OOM on 80GB HBM] |
-| Qwen3-Omni | enable_audio=True  | TBD      | TBD     | TBD    | TBD         | PR #??? [H100, deferred — talker bottleneck (#276) timeouts on H100] |
+| Qwen3-Omni | enable_audio=False | TBD      | TBD     | TBD    | TBD         | PR #351 [H100, deferred — c=8 OOM on 80GB HBM] |
+| Qwen3-Omni | enable_audio=True  | TBD      | TBD     | TBD    | TBD         | PR #351 [H100, deferred — talker bottleneck (#276) timeouts on H100] |
 
 Note (Xuesong): full 900 not runfor enable_audio = True — Issue #276 talker is c=1 only and ~2 min/sample (~30 h for full set). 15/50 requests failed
  in audio generation (Issue #276); on the 35 completed requests accuracy = 65.7%.
@@ -49,8 +49,8 @@ Speed (speed)
 | ---------- | ------------------ | -------------- | ------------- | -------------- | -------------- | ------------- | ---------------------------------------------------------- |
 | Qwen3-Omni | enable_audio=False | 25.70          | 96.38         | 0.308          | 19.6           | 19.9          | PR #316 [H200, full-set, c=8, max_tokens=2048]             |
 | Qwen3-Omni | enable_audio=True  | 123.13         | 221.52        | 0.004          | 2.2            | 2.1           | PR #316 [H200, **50-sample subset**, c=1, max_tokens=2048] |
-| Qwen3-Omni | enable_audio=False | TBD            | TBD           | TBD            | TBD            | TBD           | PR #??? [H100, deferred — c=8 OOM on 80GB HBM] |
-| Qwen3-Omni | enable_audio=True  | TBD            | TBD           | TBD            | TBD            | TBD           | PR #??? [H100, deferred — talker bottleneck (#276) timeouts on H100] |
+| Qwen3-Omni | enable_audio=False | TBD            | TBD           | TBD            | TBD            | TBD           | PR #351 [H100, deferred — c=8 OOM on 80GB HBM] |
+| Qwen3-Omni | enable_audio=True  | TBD            | TBD           | TBD            | TBD            | TBD           | PR #351 [H100, deferred — talker bottleneck (#276) timeouts on H100] |
 """
 
 

--- a/benchmarks/eval/benchmark_omni_mmsu.py
+++ b/benchmarks/eval/benchmark_omni_mmsu.py
@@ -42,7 +42,7 @@ CI runs on a subset and has its own thresholds elsewhere (see tasks/*.py).
 
 Benchmark: MMSU     |  Dataset: MMSU full (5000 samples)
 Hardware:  1 x H200 (default; non-H200 sources are tagged in Source column)
-Last verified: 2026-04-18
+Last verified: 2026-04-25
 
 Accuracy (accuracy)
 
@@ -50,8 +50,8 @@ Accuracy (accuracy)
 | ---------- | --------------------- | ---------------- | ----------------- | ------------------- | ----------------------------- |
 | Qwen3-Omni | modalities=text       | 70.88%           | 5000/5000         | 0                   | PR #316 [H200, full-set, c=8] |
 | Qwen3-Omni | modalities=text+audio | 71.22%           | 5000/5000         | 0                   | PR #316 [H200, full-set, c=8] |
-| Qwen3-Omni | modalities=text       | 71.10%           | 4999/5000         | 1                   | PR #??? [H100, full-set, c=8] |
-| Qwen3-Omni | modalities=text+audio | 71.14%           | 5000/5000         | 0                   | PR #??? [H100, full-set, c=8] |
+| Qwen3-Omni | modalities=text       | 71.10%           | 4999/5000         | 1                   | PR #351 [H100, full-set, c=8] |
+| Qwen3-Omni | modalities=text+audio | 71.14%           | 5000/5000         | 0                   | PR #351 [H100, full-set, c=8] |
 
 Per-task accuracy (accuracy.per_task; top-level task names only — full sub/sub-sub trees stay in JSON output)
 
@@ -59,8 +59,8 @@ Per-task accuracy (accuracy.per_task; top-level task names only — full sub/sub
 | ---------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
 | Qwen3-Omni | modalities=text       | strong: casual_reasoning / continuation_writing / long_speech_summarization / polysemy_reasoning = 100%; weak: dialogue_turn_counting 10.10%, pitch_comparison 22.22%, speed_comparison 22.94% | PR #316 [H200, full-set] |
 | Qwen3-Omni | modalities=text+audio | strong: casual_reasoning / continuation_writing / long_speech_summarization / polysemy_reasoning = 100%; weak: dialogue_turn_counting 12.12%, speed_comparison 21.10%, pitch_comparison 24.07% | PR #316 [H200, full-set] |
-| Qwen3-Omni | modalities=text       | strong: casual_reasoning / continuation_writing / long_speech_summarization / polysemy_reasoning = 100%; weak: dialogue_turn_counting 12.12%, speed_comparison 22.94%, pitch_comparison 23.15%   | PR #??? [H100, full-set] |
-| Qwen3-Omni | modalities=text+audio | strong: casual_reasoning / continuation_writing / long_speech_summarization / polysemy_reasoning = 100%; weak: dialogue_turn_counting 13.13%, speed_comparison 22.02%, pitch_comparison 24.07%   | PR #??? [H100, full-set] |
+| Qwen3-Omni | modalities=text       | strong: casual_reasoning / continuation_writing / long_speech_summarization / polysemy_reasoning = 100%; weak: dialogue_turn_counting 12.12%, speed_comparison 22.94%, pitch_comparison 23.15%   | PR #351 [H100, full-set] |
+| Qwen3-Omni | modalities=text+audio | strong: casual_reasoning / continuation_writing / long_speech_summarization / polysemy_reasoning = 100%; weak: dialogue_turn_counting 13.13%, speed_comparison 22.02%, pitch_comparison 24.07%   | PR #351 [H100, full-set] |
 
 Speed (speed)
 
@@ -68,8 +68,8 @@ Speed (speed)
 | ---------- | --------------------- | -------------- | ------------- | -------------- | -------------- | ------------- | ----------------------------------------------- |
 | Qwen3-Omni | modalities=text       | 0.349          | 0.484         | 22.91          | 6.1            | 5.9           | PR #316 [H200, full-set, c=8]                   |
 | Qwen3-Omni | modalities=text+audio | 0.330          | 0.444         | 24.23          | 6.4            | 6.3           | PR #316 [H200, full-set, c=8, text-only server] |
-| Qwen3-Omni | modalities=text       | 0.512          | 0.864         | 15.598         | 4.5            | 4.0           | PR #??? [H100, full-set, c=8]                   |
-| Qwen3-Omni | modalities=text+audio | 0.515          | 0.884         | 15.521         | 4.4            | 4.0           | PR #??? [H100, full-set, c=8] (text-only server) |
+| Qwen3-Omni | modalities=text       | 0.512          | 0.864         | 15.598         | 4.5            | 4.0           | PR #351 [H100, full-set, c=8]                   |
+| Qwen3-Omni | modalities=text+audio | 0.515          | 0.884         | 15.521         | 4.4            | 4.0           | PR #351 [H100, full-set, c=8] (text-only server) |
 
 Note (Xuesong): text + audio numbers above were measured against a text-only
 Qwen3-Omni server (talker disabled) because a full-pipeline run is blocked on

--- a/benchmarks/eval/benchmark_omni_mmsu.py
+++ b/benchmarks/eval/benchmark_omni_mmsu.py
@@ -50,6 +50,8 @@ Accuracy (accuracy)
 | ---------- | --------------------- | ---------------- | ----------------- | ------------------- | ----------------------------- |
 | Qwen3-Omni | modalities=text       | 70.88%           | 5000/5000         | 0                   | PR #316 [H200, full-set, c=8] |
 | Qwen3-Omni | modalities=text+audio | 71.22%           | 5000/5000         | 0                   | PR #316 [H200, full-set, c=8] |
+| Qwen3-Omni | modalities=text       | 71.10%           | 4999/5000         | 1                   | PR #??? [H100, full-set, c=8] |
+| Qwen3-Omni | modalities=text+audio | 71.14%           | 5000/5000         | 0                   | PR #??? [H100, full-set, c=8] |
 
 Per-task accuracy (accuracy.per_task; top-level task names only — full sub/sub-sub trees stay in JSON output)
 
@@ -57,6 +59,8 @@ Per-task accuracy (accuracy.per_task; top-level task names only — full sub/sub
 | ---------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
 | Qwen3-Omni | modalities=text       | strong: casual_reasoning / continuation_writing / long_speech_summarization / polysemy_reasoning = 100%; weak: dialogue_turn_counting 10.10%, pitch_comparison 22.22%, speed_comparison 22.94% | PR #316 [H200, full-set] |
 | Qwen3-Omni | modalities=text+audio | strong: casual_reasoning / continuation_writing / long_speech_summarization / polysemy_reasoning = 100%; weak: dialogue_turn_counting 12.12%, speed_comparison 21.10%, pitch_comparison 24.07% | PR #316 [H200, full-set] |
+| Qwen3-Omni | modalities=text       | strong: casual_reasoning / continuation_writing / long_speech_summarization / polysemy_reasoning = 100%; weak: dialogue_turn_counting 12.12%, speed_comparison 22.94%, pitch_comparison 23.15%   | PR #??? [H100, full-set] |
+| Qwen3-Omni | modalities=text+audio | strong: casual_reasoning / continuation_writing / long_speech_summarization / polysemy_reasoning = 100%; weak: dialogue_turn_counting 13.13%, speed_comparison 22.02%, pitch_comparison 24.07%   | PR #??? [H100, full-set] |
 
 Speed (speed)
 
@@ -64,6 +68,8 @@ Speed (speed)
 | ---------- | --------------------- | -------------- | ------------- | -------------- | -------------- | ------------- | ----------------------------------------------- |
 | Qwen3-Omni | modalities=text       | 0.349          | 0.484         | 22.91          | 6.1            | 5.9           | PR #316 [H200, full-set, c=8]                   |
 | Qwen3-Omni | modalities=text+audio | 0.330          | 0.444         | 24.23          | 6.4            | 6.3           | PR #316 [H200, full-set, c=8, text-only server] |
+| Qwen3-Omni | modalities=text       | 0.512          | 0.864         | 15.598         | 4.5            | 4.0           | PR #??? [H100, full-set, c=8]                   |
+| Qwen3-Omni | modalities=text+audio | 0.515          | 0.884         | 15.521         | 4.4            | 4.0           | PR #??? [H100, full-set, c=8] (text-only server) |
 
 Note (Xuesong): text + audio numbers above were measured against a text-only
 Qwen3-Omni server (talker disabled) because a full-pipeline run is blocked on

--- a/benchmarks/eval/benchmark_omni_seedtts.py
+++ b/benchmarks/eval/benchmark_omni_seedtts.py
@@ -62,6 +62,10 @@ Accuracy (accuracy.wer)
 | Qwen3-Omni | EN, voice_clone=F | 2.39%      | 2.34%               | 0.00%                 | 8.6%               | 1088/1088 | 0       | PR #316 [H200, full-set, c=16] |
 | Qwen3-Omni | ZH, voice_clone=T | 1.66%      | 1.63%               | 0.00%                 | 8.1%               | 2020/2020 | 0       | PR #316 [H200, full-set, c=16] |
 | Qwen3-Omni | ZH, voice_clone=F | 1.79%      | 1.72%               | 0.00%                 | 6.8%               | 2020/2020 | 0       | PR #316 [H200, full-set, c=16] |
+| Qwen3-Omni | EN, voice_clone=T | 1.86%      | 1.94%               | 0.00%                 | 5.9%               | 1088/1088 | 0       | PR #??? [H100, full-set, c=16] |
+| Qwen3-Omni | EN, voice_clone=F | 2.40%      | 2.44%               | 0.00%                 | 7.3%               | 1088/1088 | 0       | PR #??? [H100, full-set, c=16] |
+| Qwen3-Omni | ZH, voice_clone=T | 1.49%      | 1.45%               | 0.00%                 | 3.7%               | 2020/2020 | 0       | PR #??? [H100, full-set, c=16] |
+| Qwen3-Omni | ZH, voice_clone=F | 1.76%      | 1.62%               | 0.00%                 | 8.6%               | 2018/2020 | 2       | PR #??? [H100, full-set, c=16] |
 
 
 Generation speed (generation.speed)
@@ -72,6 +76,10 @@ Generation speed (generation.speed)
 | Qwen3-Omni | EN, voice_clone=F | 62.31          | 93.69         | 17.38    | 0.256          | 0.2            | 0.2           | PR #316 [H200, full-set, c=16] |
 | Qwen3-Omni | ZH, voice_clone=T | 73.31          | 98.57         | 17.61    | 0.218          | 0.2            | 0.2           | PR #316 [H200, full-set, c=16] |
 | Qwen3-Omni | ZH, voice_clone=F | 70.75          | 94.03         | 16.99    | 0.226          | 0.2            | 0.2           | PR #316 [H200, full-set, c=16] |
+| Qwen3-Omni | EN, voice_clone=T | 44.94          | 67.44         | 12.43    | 0.355          | 0.3            | 0.3           | PR #??? [H100, full-set, c=16] |
+| Qwen3-Omni | EN, voice_clone=F | 45.73          | 68.10         | 12.69    | 0.349          | 0.3            | 0.3           | PR #??? [H100, full-set, c=16] |
+| Qwen3-Omni | ZH, voice_clone=T | 55.88          | 74.93         | 13.44    | 0.286          | 0.3            | 0.3           | PR #??? [H100, full-set, c=16] |
+| Qwen3-Omni | ZH, voice_clone=F | 55.09          | 73.68         | 13.19    | 0.288          | 0.3            | 0.3           | PR #??? [H100, full-set, c=16] |
 
 Note (Chenyang): tok_per_s_{mean,agg} here counts Qwen3-Omni's discrete talker LM
 tokens (code tokens driving code2wav) and therefore runs at audio frame rate, thus
@@ -85,6 +93,8 @@ ASR speed (accuracy.asr_speed) — Whisper-large-v3 for EN, FunASR paraformer-zh
 | ---- | ------------------ | ------------ | ---------------------------- | ------------------------------------------- |
 | EN   | 0.354              | 0.1039       | 2.83                         | PR #316 [H200, from VC=F run]               |
 | ZH   | 0.344              | 0.0861       | 2.90                         | PR #316 [H200, from Qwen3-Omni ZH VC=T run] |
+| EN   | 0.224              | 0.0660       | 4.46                         | PR #??? [H100, from Qwen3-Omni EN VC=F run] |
+| ZH   | 0.261              | 0.0652       | 3.83                         | PR #??? [H100, from Qwen3-Omni ZH VC=T run] |
 """
 
 from __future__ import annotations

--- a/benchmarks/eval/benchmark_omni_seedtts.py
+++ b/benchmarks/eval/benchmark_omni_seedtts.py
@@ -52,7 +52,7 @@ CI runs on a subset and has its own thresholds elsewhere (see tasks/*.py).
 
 Benchmark: SeedTTS  |  Dataset: seed-tts-eval, full set
 Hardware:  1 x H200 (default; non-H200 sources are tagged in Source column)
-Last verified: 2026-04-18
+Last verified: 2026-04-25
 
 Accuracy (accuracy.wer)
 
@@ -62,10 +62,10 @@ Accuracy (accuracy.wer)
 | Qwen3-Omni | EN, voice_clone=F | 2.39%      | 2.34%               | 0.00%                 | 8.6%               | 1088/1088 | 0       | PR #316 [H200, full-set, c=16] |
 | Qwen3-Omni | ZH, voice_clone=T | 1.66%      | 1.63%               | 0.00%                 | 8.1%               | 2020/2020 | 0       | PR #316 [H200, full-set, c=16] |
 | Qwen3-Omni | ZH, voice_clone=F | 1.79%      | 1.72%               | 0.00%                 | 6.8%               | 2020/2020 | 0       | PR #316 [H200, full-set, c=16] |
-| Qwen3-Omni | EN, voice_clone=T | 1.86%      | 1.94%               | 0.00%                 | 5.9%               | 1088/1088 | 0       | PR #??? [H100, full-set, c=16] |
-| Qwen3-Omni | EN, voice_clone=F | 2.40%      | 2.44%               | 0.00%                 | 7.3%               | 1088/1088 | 0       | PR #??? [H100, full-set, c=16] |
-| Qwen3-Omni | ZH, voice_clone=T | 1.49%      | 1.45%               | 0.00%                 | 3.7%               | 2020/2020 | 0       | PR #??? [H100, full-set, c=16] |
-| Qwen3-Omni | ZH, voice_clone=F | 1.76%      | 1.62%               | 0.00%                 | 8.6%               | 2018/2020 | 2       | PR #??? [H100, full-set, c=16] |
+| Qwen3-Omni | EN, voice_clone=T | 1.86%      | 1.94%               | 0.00%                 | 5.9%               | 1088/1088 | 0       | PR #351 [H100, full-set, c=16] |
+| Qwen3-Omni | EN, voice_clone=F | 2.40%      | 2.44%               | 0.00%                 | 7.3%               | 1088/1088 | 0       | PR #351 [H100, full-set, c=16] |
+| Qwen3-Omni | ZH, voice_clone=T | 1.49%      | 1.45%               | 0.00%                 | 3.7%               | 2020/2020 | 0       | PR #351 [H100, full-set, c=16] |
+| Qwen3-Omni | ZH, voice_clone=F | 1.76%      | 1.62%               | 0.00%                 | 8.6%               | 2018/2020 | 2       | PR #351 [H100, full-set, c=16] |
 
 
 Generation speed (generation.speed)
@@ -76,10 +76,10 @@ Generation speed (generation.speed)
 | Qwen3-Omni | EN, voice_clone=F | 62.31          | 93.69         | 17.38    | 0.256          | 0.2            | 0.2           | PR #316 [H200, full-set, c=16] |
 | Qwen3-Omni | ZH, voice_clone=T | 73.31          | 98.57         | 17.61    | 0.218          | 0.2            | 0.2           | PR #316 [H200, full-set, c=16] |
 | Qwen3-Omni | ZH, voice_clone=F | 70.75          | 94.03         | 16.99    | 0.226          | 0.2            | 0.2           | PR #316 [H200, full-set, c=16] |
-| Qwen3-Omni | EN, voice_clone=T | 44.94          | 67.44         | 12.43    | 0.355          | 0.3            | 0.3           | PR #??? [H100, full-set, c=16] |
-| Qwen3-Omni | EN, voice_clone=F | 45.73          | 68.10         | 12.69    | 0.349          | 0.3            | 0.3           | PR #??? [H100, full-set, c=16] |
-| Qwen3-Omni | ZH, voice_clone=T | 55.88          | 74.93         | 13.44    | 0.286          | 0.3            | 0.3           | PR #??? [H100, full-set, c=16] |
-| Qwen3-Omni | ZH, voice_clone=F | 55.09          | 73.68         | 13.19    | 0.288          | 0.3            | 0.3           | PR #??? [H100, full-set, c=16] |
+| Qwen3-Omni | EN, voice_clone=T | 44.94          | 67.44         | 12.43    | 0.355          | 0.3            | 0.3           | PR #351 [H100, full-set, c=16] |
+| Qwen3-Omni | EN, voice_clone=F | 45.73          | 68.10         | 12.69    | 0.349          | 0.3            | 0.3           | PR #351 [H100, full-set, c=16] |
+| Qwen3-Omni | ZH, voice_clone=T | 55.88          | 74.93         | 13.44    | 0.286          | 0.3            | 0.3           | PR #351 [H100, full-set, c=16] |
+| Qwen3-Omni | ZH, voice_clone=F | 55.09          | 73.68         | 13.19    | 0.288          | 0.3            | 0.3           | PR #351 [H100, full-set, c=16] |
 
 Note (Chenyang): tok_per_s_{mean,agg} here counts Qwen3-Omni's discrete talker LM
 tokens (code tokens driving code2wav) and therefore runs at audio frame rate, thus
@@ -93,8 +93,8 @@ ASR speed (accuracy.asr_speed) — Whisper-large-v3 for EN, FunASR paraformer-zh
 | ---- | ------------------ | ------------ | ---------------------------- | ------------------------------------------- |
 | EN   | 0.354              | 0.1039       | 2.83                         | PR #316 [H200, from VC=F run]               |
 | ZH   | 0.344              | 0.0861       | 2.90                         | PR #316 [H200, from Qwen3-Omni ZH VC=T run] |
-| EN   | 0.224              | 0.0660       | 4.46                         | PR #??? [H100, from Qwen3-Omni EN VC=F run] |
-| ZH   | 0.261              | 0.0652       | 3.83                         | PR #??? [H100, from Qwen3-Omni ZH VC=T run] |
+| EN   | 0.224              | 0.0660       | 4.46                         | PR #351 [H100, from Qwen3-Omni EN VC=F run] |
+| ZH   | 0.261              | 0.0652       | 3.83                         | PR #351 [H100, from Qwen3-Omni ZH VC=T run] |
 """
 
 from __future__ import annotations

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -75,6 +75,10 @@ Accuracy (accuracy.wer)
 | S2-Pro | EN, stream=True  | 0.97%      | 0.93%               | 0.00%                 | 3.3%               | 1088/1088 | 0       | PR #316 [H200, full-set, c=16] |
 | S2-Pro | ZH, stream=False | 1.15%      | 1.09%               | 0.00%                 | 2.7%               | 2020/2020 | 0       | PR #316 [H200, full-set, c=16] |
 | S2-Pro | ZH, stream=True  | 1.10%      | 1.05%               | 0.00%                 | 2.7%               | 2020/2020 | 0       | PR #316 [H200, full-set, c=16] |
+| S2-Pro | EN, stream=False | 1.03%      | 0.98%               | 0.00%                 | 3.4%               | 1088/1088 | 0       | PR #??? [H100, full-set, c=16] |
+| S2-Pro | EN, stream=True  | 0.98%      | 0.94%               | 0.00%                 | 3.3%               | 1088/1088 | 0       | PR #??? [H100, full-set, c=16] |
+| S2-Pro | ZH, stream=False | 0.93%      | 0.89%               | 0.00%                 | 2.2%               | 2020/2020 | 0       | PR #??? [H100, full-set, c=16] |
+| S2-Pro | ZH, stream=True  | 0.98%      | 0.94%               | 0.00%                 | 2.4%               | 2020/2020 | 0       | PR #??? [H100, full-set, c=16] |
 
 
 Generation speed (generation.speed)
@@ -85,6 +89,10 @@ Generation speed (generation.speed)
 | S2-Pro | EN, stream=True  | 15.172         | 24.686        | 4.047    | 1.051          | 50.1           | 43.8          | PR #316 [H200, full-set, c=16] |
 | S2-Pro | ZH, stream=False | 15.934         | 24.903        | 2.986    | 1.001          | 45.9           | 40.8          | PR #316 [H200, full-set, c=16] |
 | S2-Pro | ZH, stream=True  | 13.913         | 22.303        | 2.608    | 1.146          | 48.2           | 44.0          | PR #316 [H200, full-set, c=16] |
+| S2-Pro | EN, stream=False | 9.38           | 14.65         | 2.48     | 1.700          | 56.6           | 56.0          | PR #??? [H100, full-set, c=16] |
+| S2-Pro | EN, stream=True  | 9.92           | 15.49         | 2.62     | 1.607          | 53.9           | 53.2          | PR #??? [H100, full-set, c=16] |
+| S2-Pro | ZH, stream=False | 9.64           | 13.61         | 1.80     | 1.655          | 55.7           | 55.2          | PR #??? [H100, full-set, c=16] |
+| S2-Pro | ZH, stream=True  | 9.27           | 13.11         | 1.74     | 1.722          | 51.7           | 51.1          | PR #??? [H100, full-set, c=16] |
 
 Note (Chenyang): tok_per_s_{mean,agg} here counts S2-Pro's codec tokens.  It is NOT
 comparable to the tok_per_s column reported for Qwen3-Omni in benchmark_omni_seedtts.py,

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -65,7 +65,7 @@ CI runs on a subset and has its own thresholds elsewhere (see tasks/*.py).
 
 Benchmark: SeedTTS  |  Dataset: seed-tts-eval, full set (EN=1088, ZH=2020)
 Hardware:  1 x H200 (default; non-H200 sources are tagged in Source column)
-Last verified: 2026-04-18
+Last verified: 2026-04-25
 
 Accuracy (accuracy.wer)
 
@@ -75,10 +75,10 @@ Accuracy (accuracy.wer)
 | S2-Pro | EN, stream=True  | 0.97%      | 0.93%               | 0.00%                 | 3.3%               | 1088/1088 | 0       | PR #316 [H200, full-set, c=16] |
 | S2-Pro | ZH, stream=False | 1.15%      | 1.09%               | 0.00%                 | 2.7%               | 2020/2020 | 0       | PR #316 [H200, full-set, c=16] |
 | S2-Pro | ZH, stream=True  | 1.10%      | 1.05%               | 0.00%                 | 2.7%               | 2020/2020 | 0       | PR #316 [H200, full-set, c=16] |
-| S2-Pro | EN, stream=False | 1.03%      | 0.98%               | 0.00%                 | 3.4%               | 1088/1088 | 0       | PR #??? [H100, full-set, c=16] |
-| S2-Pro | EN, stream=True  | 0.98%      | 0.94%               | 0.00%                 | 3.3%               | 1088/1088 | 0       | PR #??? [H100, full-set, c=16] |
-| S2-Pro | ZH, stream=False | 0.93%      | 0.89%               | 0.00%                 | 2.2%               | 2020/2020 | 0       | PR #??? [H100, full-set, c=16] |
-| S2-Pro | ZH, stream=True  | 0.98%      | 0.94%               | 0.00%                 | 2.4%               | 2020/2020 | 0       | PR #??? [H100, full-set, c=16] |
+| S2-Pro | EN, stream=False | 1.03%      | 0.98%               | 0.00%                 | 3.4%               | 1088/1088 | 0       | PR #351 [H100, full-set, c=16] |
+| S2-Pro | EN, stream=True  | 0.98%      | 0.94%               | 0.00%                 | 3.3%               | 1088/1088 | 0       | PR #351 [H100, full-set, c=16] |
+| S2-Pro | ZH, stream=False | 0.93%      | 0.89%               | 0.00%                 | 2.2%               | 2020/2020 | 0       | PR #351 [H100, full-set, c=16] |
+| S2-Pro | ZH, stream=True  | 0.98%      | 0.94%               | 0.00%                 | 2.4%               | 2020/2020 | 0       | PR #351 [H100, full-set, c=16] |
 
 
 Generation speed (generation.speed)
@@ -89,10 +89,10 @@ Generation speed (generation.speed)
 | S2-Pro | EN, stream=True  | 15.172         | 24.686        | 4.047    | 1.051          | 50.1           | 43.8          | PR #316 [H200, full-set, c=16] |
 | S2-Pro | ZH, stream=False | 15.934         | 24.903        | 2.986    | 1.001          | 45.9           | 40.8          | PR #316 [H200, full-set, c=16] |
 | S2-Pro | ZH, stream=True  | 13.913         | 22.303        | 2.608    | 1.146          | 48.2           | 44.0          | PR #316 [H200, full-set, c=16] |
-| S2-Pro | EN, stream=False | 9.38           | 14.65         | 2.48     | 1.700          | 56.6           | 56.0          | PR #??? [H100, full-set, c=16] |
-| S2-Pro | EN, stream=True  | 9.92           | 15.49         | 2.62     | 1.607          | 53.9           | 53.2          | PR #??? [H100, full-set, c=16] |
-| S2-Pro | ZH, stream=False | 9.64           | 13.61         | 1.80     | 1.655          | 55.7           | 55.2          | PR #??? [H100, full-set, c=16] |
-| S2-Pro | ZH, stream=True  | 9.27           | 13.11         | 1.74     | 1.722          | 51.7           | 51.1          | PR #??? [H100, full-set, c=16] |
+| S2-Pro | EN, stream=False | 9.38           | 14.65         | 2.48     | 1.700          | 56.6           | 56.0          | PR #351 [H100, full-set, c=16] |
+| S2-Pro | EN, stream=True  | 9.92           | 15.49         | 2.62     | 1.607          | 53.9           | 53.2          | PR #351 [H100, full-set, c=16] |
+| S2-Pro | ZH, stream=False | 9.64           | 13.61         | 1.80     | 1.655          | 55.7           | 55.2          | PR #351 [H100, full-set, c=16] |
+| S2-Pro | ZH, stream=True  | 9.27           | 13.11         | 1.74     | 1.722          | 51.7           | 51.1          | PR #351 [H100, full-set, c=16] |
 
 Note (Chenyang): tok_per_s_{mean,agg} here counts S2-Pro's codec tokens.  It is NOT
 comparable to the tok_per_s column reported for Qwen3-Omni in benchmark_omni_seedtts.py,


### PR DESCRIPTION
Per #316, append H100 reference rows to the H200 reference tables at the top of each benchmark entry script.

- benchmark_omni_seedtts.py: 4 Qwen3-Omni × SeedTTS configs
  (EN/ZH × VC=T/F) + EN/ZH ASR speed
- benchmark_tts_seedtts.py:  4 S2-Pro × SeedTTS configs
  (EN/ZH × stream=F/T)
- benchmark_omni_mmsu.py:    2 Qwen3-Omni × MMSU configs
  (text, text+audio) — accuracy + per-task + speed
- benchmark_omni_mmmu.py:    2 rows TBD (deferred)

10/12 cells filled. MMMU two cells (enable_audio=False, enable_audio=True) deferred: H100 80GB HBM cannot accommodate the c=8 vision-encoder + thinker activation budget that H200 141GB supports; c=4/c=8 OOM, c=1 fallback hits Issue #276 talker-bottleneck timeouts.