### PR TITLE
Add a PR-ready SocialOmni benchmark path for sglang-omni

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -98,6 +98,15 @@ python -m benchmarks.eval.benchmark_omni_mmsu \
 # 5. Qwen3-Omni — MMMU (VLM accuracy, image input)
 python -m benchmarks.eval.benchmark_omni_mmmu \
     --model qwen3-omni --port 8000 --max-samples 50 --max-concurrency 16
+
+# 6. Qwen3-Omni — SocialOmni level1
+python -m benchmarks.eval.benchmark_omni_socialomni \
+    --model qwen3-omni --port 8000 --level level1 --max-samples 10
+
+# 7. Qwen3-Omni — SocialOmni level2 with one judge
+python -m benchmarks.eval.benchmark_omni_socialomni \
+    --model qwen3-omni --port 8000 --level level2 --judges 1 --max-samples 1 \
+    --judge-base-url http://localhost:8001 --judge-model qwen3-omni-judge
 ```
 
 ## Eval Scripts
@@ -108,6 +117,7 @@ python -m benchmarks.eval.benchmark_omni_mmmu \
 | `eval/benchmark_omni_seedtts.py` | TTS speed + WER (unified) | Qwen3-Omni | `/v1/chat/completions` |
 | `eval/benchmark_omni_mmsu.py` | MMSU (audio comprehension) | Qwen3-Omni | `/v1/chat/completions` |
 | `eval/benchmark_omni_mmmu.py` | MMMU (VLM accuracy + speed) | Qwen3-Omni | `/v1/chat/completions` |
+| `eval/benchmark_omni_socialomni.py` | SocialOmni level1/level2 | Qwen3-Omni + optional judges | `/v1/chat/completions` |
 
 The two `*_seedtts.py` scripts merge the previous `benchmark_*_tts_speed.py`
 and `voice_clone_*_wer.py` pairs into a single two-phase pipeline: phase 1
@@ -138,9 +148,13 @@ python -m benchmarks.dataset.prepare --dataset seedtts-50    # 50-sample subset
 python -m benchmarks.dataset.prepare --dataset mmmu          # full MMMU (30 subjects)
 python -m benchmarks.dataset.prepare --dataset mmmu-ci-50    # MMMU CI subset
 python -m benchmarks.dataset.prepare --dataset mmsu          # full MMSU (ddwang2000/MMSU)
+python -m benchmarks.dataset.prepare --dataset socialomni    # full SocialOmni into ./socialomni
+python -m benchmarks.dataset.prepare --dataset socialomni-mini  # deterministic smoke subset into ./socialomni-mini
 ```
 
 SeedTTS datasets are materialized into `./seedtts_testset/` (override with
-`--local-dir`).  MMMU/MMSU datasets are pre-warmed into the default
+`--local-dir`). MMMU/MMSU datasets are pre-warmed into the default
 HuggingFace cache and consumed via `datasets.load_dataset(repo_id)`, so
-`--local-dir` is a no-op for them.
+`--local-dir` is a no-op for them. SocialOmni datasets are materialized into
+`./socialomni/` or `./socialomni-mini/` with `level_1/`, `level_2/`, and a
+reviewable `mini_manifest.json` for the frozen mini subset.

--- a/benchmarks/dataset/prepare.py
+++ b/benchmarks/dataset/prepare.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Dataset download helpers.
+"""Dataset download and materialization helpers.
 
 Usage:
     # SeedTTS family (downloads into ./seedtts_testset by default)
@@ -11,6 +11,10 @@ Usage:
     python -m benchmarks.dataset.prepare --dataset mmmu
     python -m benchmarks.dataset.prepare --dataset mmmu-ci-50
     python -m benchmarks.dataset.prepare --dataset mmsu
+
+    # SocialOmni (full + deterministic mini subset)
+    python -m benchmarks.dataset.prepare --dataset socialomni
+    python -m benchmarks.dataset.prepare --dataset socialomni-mini
 """
 
 from __future__ import annotations
@@ -19,6 +23,11 @@ import argparse
 import logging
 import os
 import subprocess
+from collections.abc import Callable
+from functools import partial
+from pathlib import Path
+
+from benchmarks.dataset.socialomni import prepare_socialomni_dataset
 
 logger = logging.getLogger(__name__)
 
@@ -29,12 +38,16 @@ DATASETS: dict[str, str] = {
     "mmmu": "MMMU/MMMU",
     "mmmu-ci-50": "zhaochenyang20/mmmu-ci-50",
     "mmsu": "ddwang2000/MMSU",
+    "socialomni": "alexisty/SocialOmni",
+    "socialomni-mini": "alexisty/SocialOmni",
 }
 
 _CLI_LOCAL_DIRS: dict[str, str] = {
     "seedtts": "seedtts_testset",
     "seedtts-mini": "seedtts_testset",
     "seedtts-50": "seedtts_testset",
+    "socialomni": "socialomni",
+    "socialomni-mini": "socialomni-mini",
 }
 
 _SEEDTTS_EXISTENCE_MARKER = "en/meta.lst"
@@ -53,13 +66,14 @@ def download_dataset(
         if os.path.exists(marker_path):
             if not quiet:
                 logger.info(
-                    f"Dataset already exists at {local_dir}, skipping download."
+                    "Dataset already exists at %s, skipping download.",
+                    local_dir,
                 )
             return
 
     if not quiet:
         where = local_dir if local_dir is not None else "HuggingFace cache"
-        logger.info(f"Downloading {repo_id} to {where} ...")
+        logger.info("Downloading %s to %s ...", repo_id, where)
 
     cmd = [
         "huggingface-cli",
@@ -80,7 +94,60 @@ def download_dataset(
             f"stderr:\n{exc.stderr}"
         ) from exc
     if not quiet:
-        logger.info(f"Dataset {repo_id} ready.")
+        logger.info("Dataset %s ready.", repo_id)
+
+
+DatasetHandler = Callable[[str, str | None, bool], None]
+
+
+def _prepare_hf_dataset(
+    dataset_name: str,
+    local_dir: str | None,
+    quiet: bool,
+    *,
+    repo_id: str,
+) -> None:
+    existence_marker = (
+        _SEEDTTS_EXISTENCE_MARKER
+        if dataset_name in {"seedtts", "seedtts-mini", "seedtts-50"}
+        else None
+    )
+    download_dataset(
+        repo_id,
+        local_dir,
+        existence_marker=existence_marker,
+        quiet=quiet,
+    )
+
+
+def _prepare_socialomni(dataset_name: str, local_dir: str | None, quiet: bool) -> None:
+    prepare_socialomni_dataset(dataset_name, local_dir, quiet=quiet)
+
+
+_DATASET_HANDLERS: dict[str, DatasetHandler] = {
+    "seedtts": partial(_prepare_hf_dataset, repo_id=DATASETS["seedtts"]),
+    "seedtts-mini": partial(_prepare_hf_dataset, repo_id=DATASETS["seedtts-mini"]),
+    "seedtts-50": partial(_prepare_hf_dataset, repo_id=DATASETS["seedtts-50"]),
+    "mmmu": partial(_prepare_hf_dataset, repo_id=DATASETS["mmmu"]),
+    "mmmu-ci-50": partial(_prepare_hf_dataset, repo_id=DATASETS["mmmu-ci-50"]),
+    "mmsu": partial(_prepare_hf_dataset, repo_id=DATASETS["mmsu"]),
+    "socialomni": _prepare_socialomni,
+    "socialomni-mini": _prepare_socialomni,
+}
+
+
+def prepare_dataset(
+    dataset_name: str,
+    local_dir: str | None = None,
+    *,
+    quiet: bool = False,
+) -> Path | None:
+    """Prepare a dataset by name using the appropriate handler."""
+    if dataset_name not in DATASETS:
+        raise ValueError(f"Unsupported dataset: {dataset_name}")
+    handler = _DATASET_HANDLERS[dataset_name]
+    handler(dataset_name, local_dir, quiet)
+    return Path(local_dir) if local_dir is not None else None
 
 
 def main() -> None:
@@ -94,24 +161,15 @@ def main() -> None:
     parser.add_argument(
         "--local-dir",
         default=None,
-        help="Override local directory for seedtts-family datasets. "
-        "Ignored for datasets that are pulled into the HuggingFace cache.",
+        help="Override local directory for datasets that materialize locally. "
+        "Ignored for datasets that are pulled only into the HuggingFace cache.",
     )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)
 
-    repo_id = DATASETS[args.dataset]
-    default_local_dir = _CLI_LOCAL_DIRS.get(args.dataset)
-    local_dir = args.local_dir or default_local_dir
-    existence_marker = (
-        _SEEDTTS_EXISTENCE_MARKER if args.dataset in _CLI_LOCAL_DIRS else None
-    )
-    download_dataset(
-        repo_id,
-        local_dir,
-        existence_marker=existence_marker,
-    )
+    local_dir = args.local_dir or _CLI_LOCAL_DIRS.get(args.dataset)
+    prepare_dataset(args.dataset, local_dir)
 
 
 if __name__ == "__main__":

--- a/benchmarks/dataset/socialomni.py
+++ b/benchmarks/dataset/socialomni.py
@@ -1,0 +1,440 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SocialOmni dataset helpers.
+
+Single-file layout aligned with the existing benchmark modules in this repo.
+Sections below cover:
+- frozen mini manifest
+- dataset dataclasses
+- full + mini materialization
+- level1 loader
+- level2 loader
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SOCIALOMNI_REPO_ID = "alexisty/SocialOmni"
+SOCIALOMNI_DATASET_NAMES = ("socialomni", "socialomni-mini")
+DEFAULT_SOCIALOMNI_DIRS = {
+    "socialomni": "socialomni",
+    "socialomni-mini": "socialomni-mini",
+}
+
+SOCIALOMNI_MINI_LEVEL1 = (1, 2, 3, 4)
+SOCIALOMNI_MINI_LEVEL2 = (
+    "video_0001",  # Q1 gold YES path
+    "video_0002",  # Q1 gold YES path
+    "video_0005",  # Q1 gold NO path
+    "video_0007",  # Q1 gold NO path
+)
+SOCIALOMNI_MINI_MANIFEST: dict[str, Any] = {
+    "dataset_name": "socialomni-mini",
+    "source_dataset": "socialomni",
+    "description": (
+        "Deterministic SocialOmni smoke-test subset with both level1 coverage "
+        "and level2 YES/NO branch coverage."
+    ),
+    "level1": {
+        "sample_ids": list(SOCIALOMNI_MINI_LEVEL1),
+        "coverage": ["multiple level1 MCQ samples"],
+    },
+    "level2": {
+        "video_ids": list(SOCIALOMNI_MINI_LEVEL2),
+        "coverage": [
+            "at least one Q1 gold YES sample",
+            "at least one Q1 gold NO sample",
+        ],
+    },
+}
+
+LEVEL1_DATASET_PATH = Path("level_1") / "dataset.json"
+LEVEL1_VIDEOS_DIR = Path("level_1") / "videos"
+LEVEL2_DATASET_PATH = Path("level_2") / "annotations.json"
+LEVEL2_VIDEOS_DIR = Path("level_2") / "videos"
+
+
+@dataclass(frozen=True)
+class SocialOmniLevel1Sample:
+    sample_id: str
+    video_path: str
+    question: str
+    options: list[str]
+    correct_answer: str
+    asr_content: str
+    metadata: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class SocialOmniLevel2Question1:
+    question: str
+    timestamp: str
+    option_a: str
+    option_b: str
+    correct_answer: str
+
+
+@dataclass(frozen=True)
+class SocialOmniLevel2Question2:
+    question: str
+    answer: str
+
+
+@dataclass(frozen=True)
+class SocialOmniLevel2Sample:
+    sample_id: str
+    video_path: str
+    original_video_id: str
+    source_dir: str
+    question_1: SocialOmniLevel2Question1
+    question_2: SocialOmniLevel2Question2
+    metadata: dict[str, Any]
+    full_asr: str
+
+
+def get_socialomni_local_dir(
+    dataset_name: str,
+    local_dir: str | None = None,
+) -> Path:
+    """Resolve the local root for a SocialOmni dataset variant."""
+    if dataset_name not in SOCIALOMNI_DATASET_NAMES:
+        raise ValueError(f"Unsupported SocialOmni dataset: {dataset_name}")
+    return Path(local_dir or DEFAULT_SOCIALOMNI_DIRS[dataset_name])
+
+
+def write_socialomni_mini_manifest(root_dir: str | Path) -> Path:
+    """Write the frozen mini manifest to *root_dir* and return the path."""
+    path = Path(root_dir) / "mini_manifest.json"
+    path.write_text(
+        json.dumps(SOCIALOMNI_MINI_MANIFEST, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+def get_level1_dataset_path(root_dir: str | Path) -> Path:
+    return Path(root_dir) / LEVEL1_DATASET_PATH
+
+
+def get_level1_videos_dir(root_dir: str | Path) -> Path:
+    return Path(root_dir) / LEVEL1_VIDEOS_DIR
+
+
+def get_level2_dataset_path(root_dir: str | Path) -> Path:
+    return Path(root_dir) / LEVEL2_DATASET_PATH
+
+
+def get_level2_videos_dir(root_dir: str | Path) -> Path:
+    return Path(root_dir) / LEVEL2_VIDEOS_DIR
+
+
+def _normalize_source_root(source_root: str | Path) -> Path:
+    root = Path(source_root)
+    if (root / "level_1").is_dir() and (root / "level_2").is_dir():
+        return root
+    if (root / "data" / "level_1").is_dir() and (root / "data" / "level_2").is_dir():
+        return root / "data"
+    raise FileNotFoundError(
+        f"SocialOmni source root must contain level_1/ and level_2/ directories: {root}"
+    )
+
+
+def _download_socialomni_source(tmpdir: str | Path) -> Path:
+    try:
+        from huggingface_hub import snapshot_download
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(
+            "SocialOmni dataset preparation requires huggingface_hub in the project environment."
+        ) from exc
+
+    snapshot_download(
+        repo_id=SOCIALOMNI_REPO_ID,
+        repo_type="dataset",
+        local_dir=str(tmpdir),
+        allow_patterns=["data/level_1/**", "data/level_2/**"],
+    )
+    return _normalize_source_root(tmpdir)
+
+
+def _copy_file(src: Path, dst: Path) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+
+
+def _dataset_ready(root_dir: Path, *, mini: bool) -> bool:
+    level1_dataset = root_dir / LEVEL1_DATASET_PATH
+    level2_dataset = root_dir / LEVEL2_DATASET_PATH
+    level1_videos = root_dir / LEVEL1_VIDEOS_DIR
+    level2_videos = root_dir / LEVEL2_VIDEOS_DIR
+    if not all(
+        [
+            level1_dataset.is_file(),
+            level2_dataset.is_file(),
+            level1_videos.is_dir(),
+            level2_videos.is_dir(),
+        ]
+    ):
+        return False
+    if mini and not (root_dir / "mini_manifest.json").is_file():
+        return False
+    return True
+
+
+def _materialize_full_dataset(source_root: Path, target_root: Path) -> None:
+    for relative in (LEVEL1_DATASET_PATH, LEVEL2_DATASET_PATH):
+        _copy_file(source_root / relative, target_root / relative)
+
+    for level_dir in ("level_1", "level_2"):
+        src_dir = source_root / level_dir / "videos"
+        dst_dir = target_root / level_dir / "videos"
+        if dst_dir.exists():
+            shutil.rmtree(dst_dir)
+        shutil.copytree(src_dir, dst_dir)
+
+
+def _load_level1_rows(source_root: Path) -> list[dict[str, Any]]:
+    return json.loads((source_root / LEVEL1_DATASET_PATH).read_text(encoding="utf-8"))
+
+
+def _load_level2_payload(source_root: Path) -> dict[str, Any] | list[dict[str, Any]]:
+    return json.loads((source_root / LEVEL2_DATASET_PATH).read_text(encoding="utf-8"))
+
+
+def _materialize_mini_dataset(source_root: Path, target_root: Path) -> None:
+    target_root.mkdir(parents=True, exist_ok=True)
+
+    level1_rows = [
+        row
+        for row in _load_level1_rows(source_root)
+        if int(row.get("id", -1)) in SOCIALOMNI_MINI_LEVEL1
+    ]
+    level1_rows.sort(key=lambda row: SOCIALOMNI_MINI_LEVEL1.index(int(row["id"])))
+    level1_dataset_path = target_root / LEVEL1_DATASET_PATH
+    level1_dataset_path.parent.mkdir(parents=True, exist_ok=True)
+    level1_dataset_path.write_text(
+        json.dumps(level1_rows, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    level1_videos_dir = target_root / LEVEL1_VIDEOS_DIR
+    level1_videos_dir.mkdir(parents=True, exist_ok=True)
+    for row in level1_rows:
+        rel_name = Path(str(row["video_path"]).strip()).name
+        _copy_file(
+            source_root / LEVEL1_VIDEOS_DIR / rel_name, level1_videos_dir / rel_name
+        )
+
+    level2_payload = _load_level2_payload(source_root)
+    level2_rows = (
+        level2_payload.get("data", level2_payload)
+        if isinstance(level2_payload, dict)
+        else level2_payload
+    )
+    if not isinstance(level2_rows, list):
+        raise ValueError("SocialOmni level2 annotations must contain a list of samples")
+    filtered_level2_rows = [
+        row
+        for row in level2_rows
+        if str(row.get("video_id", "")).strip() in SOCIALOMNI_MINI_LEVEL2
+    ]
+    filtered_level2_rows.sort(
+        key=lambda row: SOCIALOMNI_MINI_LEVEL2.index(str(row["video_id"]).strip())
+    )
+    if isinstance(level2_payload, dict):
+        mini_level2_payload = dict(level2_payload)
+        mini_level2_payload["dataset_name"] = "socialomni-mini"
+        mini_level2_payload["total_samples"] = len(filtered_level2_rows)
+        mini_level2_payload["data"] = filtered_level2_rows
+    else:
+        mini_level2_payload = filtered_level2_rows
+    level2_dataset_path = target_root / LEVEL2_DATASET_PATH
+    level2_dataset_path.parent.mkdir(parents=True, exist_ok=True)
+    level2_dataset_path.write_text(
+        json.dumps(mini_level2_payload, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    level2_videos_dir = target_root / LEVEL2_VIDEOS_DIR
+    level2_videos_dir.mkdir(parents=True, exist_ok=True)
+    for row in filtered_level2_rows:
+        rel_name = Path(str(row["video_file"]).strip()).name
+        _copy_file(
+            source_root / LEVEL2_VIDEOS_DIR / rel_name, level2_videos_dir / rel_name
+        )
+
+    write_socialomni_mini_manifest(target_root)
+
+
+def prepare_socialomni_dataset(
+    dataset_name: str,
+    local_dir: str | None = None,
+    *,
+    quiet: bool = False,
+    source_root: str | Path | None = None,
+) -> Path:
+    """Materialize the full or frozen mini SocialOmni dataset locally."""
+    target_root = get_socialomni_local_dir(dataset_name, local_dir)
+    is_mini = dataset_name == "socialomni-mini"
+    if _dataset_ready(target_root, mini=is_mini):
+        if not quiet:
+            logger.info("SocialOmni dataset already exists at %s", target_root)
+        return target_root
+
+    if not quiet:
+        logger.info("Preparing %s under %s", dataset_name, target_root)
+
+    normalized_source = (
+        _normalize_source_root(source_root) if source_root is not None else None
+    )
+    if normalized_source is None:
+        with tempfile.TemporaryDirectory(prefix="socialomni_prepare_") as tmpdir:
+            normalized_source = _download_socialomni_source(tmpdir)
+            if is_mini:
+                _materialize_mini_dataset(normalized_source, target_root)
+            else:
+                _materialize_full_dataset(normalized_source, target_root)
+        return target_root
+
+    if is_mini:
+        _materialize_mini_dataset(normalized_source, target_root)
+    else:
+        _materialize_full_dataset(normalized_source, target_root)
+    return target_root
+
+
+def load_socialomni_level1_samples(
+    root_dir: str | Path,
+    max_samples: int | None = None,
+) -> list[SocialOmniLevel1Sample]:
+    """Load SocialOmni level1 samples from a prepared local dataset root."""
+    dataset_path = get_level1_dataset_path(root_dir)
+    videos_dir = get_level1_videos_dir(root_dir)
+    if not dataset_path.is_file():
+        raise FileNotFoundError(
+            f"SocialOmni level1 dataset not found: {dataset_path}. "
+            "Run `python -m benchmarks.dataset.prepare --dataset socialomni`."
+        )
+    if not videos_dir.is_dir():
+        raise FileNotFoundError(
+            f"SocialOmni level1 videos directory missing: {videos_dir}"
+        )
+
+    rows = json.loads(dataset_path.read_text(encoding="utf-8"))
+    if not isinstance(rows, list):
+        raise ValueError(
+            f"Expected a list in {dataset_path}, got {type(rows).__name__}"
+        )
+
+    samples: list[SocialOmniLevel1Sample] = []
+    for row in rows:
+        rel_video_path = str(row.get("video_path", "")).strip()
+        if not rel_video_path:
+            continue
+        resolved_video = videos_dir / rel_video_path
+        if not resolved_video.is_file():
+            raise FileNotFoundError(
+                f"SocialOmni level1 video missing for sample {row.get('id')}: {resolved_video}"
+            )
+        samples.append(
+            SocialOmniLevel1Sample(
+                sample_id=str(row.get("id", "")),
+                video_path=str(resolved_video),
+                question=str(row.get("question", "")).strip(),
+                options=[str(option).strip() for option in row.get("options", [])],
+                correct_answer=str(row.get("correct_answer", "")).strip().upper(),
+                asr_content=str(row.get("asr_content", "")).strip(),
+                metadata=dict(row.get("metadata", {})),
+            )
+        )
+        if max_samples is not None and len(samples) >= max_samples:
+            break
+    return samples
+
+
+def load_socialomni_level2_samples(
+    root_dir: str | Path,
+    max_samples: int | None = None,
+) -> list[SocialOmniLevel2Sample]:
+    """Load SocialOmni level2 samples from a prepared local dataset root."""
+    dataset_path = get_level2_dataset_path(root_dir)
+    videos_dir = get_level2_videos_dir(root_dir)
+    if not dataset_path.is_file():
+        raise FileNotFoundError(
+            f"SocialOmni level2 dataset not found: {dataset_path}. "
+            "Run `python -m benchmarks.dataset.prepare --dataset socialomni`."
+        )
+    if not videos_dir.is_dir():
+        raise FileNotFoundError(
+            f"SocialOmni level2 videos directory missing: {videos_dir}"
+        )
+
+    payload = json.loads(dataset_path.read_text(encoding="utf-8"))
+    rows = payload.get("data", payload) if isinstance(payload, dict) else payload
+    if not isinstance(rows, list):
+        raise ValueError(
+            f"Expected a list in {dataset_path}, got {type(rows).__name__}"
+        )
+
+    samples: list[SocialOmniLevel2Sample] = []
+    for row in rows:
+        rel_video_path = str(row.get("video_file", "")).strip()
+        if not rel_video_path:
+            continue
+        resolved_video = videos_dir / rel_video_path
+        if not resolved_video.is_file():
+            raise FileNotFoundError(
+                f"SocialOmni level2 video missing for sample {row.get('video_id')}: {resolved_video}"
+            )
+        q1 = row.get("question_1", {})
+        q2 = row.get("question_2", {})
+        samples.append(
+            SocialOmniLevel2Sample(
+                sample_id=str(row.get("video_id", "")).strip(),
+                video_path=str(resolved_video),
+                original_video_id=str(row.get("original_video_id", "")).strip(),
+                source_dir=str(row.get("source_dir", "")).strip(),
+                question_1=SocialOmniLevel2Question1(
+                    question=str(q1.get("question", "")).strip(),
+                    timestamp=str(q1.get("timestamp", "")).strip(),
+                    option_a=str(q1.get("option_A", "YES")).strip(),
+                    option_b=str(q1.get("option_B", "NO")).strip(),
+                    correct_answer=str(q1.get("correct_answer", "")).strip().upper(),
+                ),
+                question_2=SocialOmniLevel2Question2(
+                    question=str(q2.get("question", "")).strip(),
+                    answer=str(q2.get("answer", "")).strip(),
+                ),
+                metadata=dict(row.get("metadata", {})),
+                full_asr=str(row.get("full_asr", "")).strip(),
+            )
+        )
+        if max_samples is not None and len(samples) >= max_samples:
+            break
+    return samples
+
+
+__all__ = [
+    "DEFAULT_SOCIALOMNI_DIRS",
+    "SOCIALOMNI_DATASET_NAMES",
+    "SOCIALOMNI_MINI_LEVEL1",
+    "SOCIALOMNI_MINI_LEVEL2",
+    "SOCIALOMNI_MINI_MANIFEST",
+    "SOCIALOMNI_REPO_ID",
+    "SocialOmniLevel1Sample",
+    "SocialOmniLevel2Question1",
+    "SocialOmniLevel2Question2",
+    "SocialOmniLevel2Sample",
+    "get_socialomni_local_dir",
+    "load_socialomni_level1_samples",
+    "load_socialomni_level2_samples",
+    "prepare_socialomni_dataset",
+    "write_socialomni_mini_manifest",
+]

--- a/benchmarks/eval/benchmark_omni_socialomni.py
+++ b/benchmarks/eval/benchmark_omni_socialomni.py
@@ -1,0 +1,306 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SocialOmni benchmark entrypoint for sglang-omni.
+
+Usage:
+    python -m benchmarks.dataset.prepare --dataset socialomni
+    python -m benchmarks.eval.benchmark_omni_socialomni \
+        --model qwen3-omni --port 8000 --level level1
+
+    python -m benchmarks.eval.benchmark_omni_socialomni \
+        --model qwen3-omni --port 8000 --level level2 --judges 1 \
+        --judge-base-url http://localhost:8001 --judge-model qwen3-omni-judge
+
+    python -m benchmarks.eval.benchmark_omni_socialomni \
+        --model qwen3-omni --port 8000 --level level2 --judges 3 \
+        --judge-base-url http://localhost:8001 --judge-model judge-a \
+        --judge-base-url http://localhost:8002 --judge-model judge-b \
+        --judge-base-url https://openai-compatible.example/v1 --judge-model judge-c
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+
+from benchmarks.benchmarker.runner import BenchmarkRunner, RunConfig
+from benchmarks.benchmarker.utils import save_json_results, wait_for_service
+from benchmarks.dataset.socialomni import (
+    DEFAULT_SOCIALOMNI_DIRS,
+    load_socialomni_level1_samples,
+    load_socialomni_level2_samples,
+)
+from benchmarks.metrics.performance import compute_speed_metrics
+from benchmarks.tasks.socialomni import (
+    build_base_url,
+    build_chat_api_url,
+    build_socialomni_level2_metrics,
+    build_socialomni_level2_summary,
+    compute_socialomni_level1_results,
+    make_socialomni_level1_send_fn,
+    preflight_chat_completion_endpoint,
+    print_socialomni_level1_summary,
+    print_socialomni_level2_summary,
+    run_socialomni_level2_benchmark,
+    validate_judge_specs,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+)
+
+
+@dataclass(frozen=True)
+class SocialOmniEvalConfig:
+    model: str
+    level: str
+    dataset_name: str = "socialomni"
+    dataset_dir: str | None = None
+    base_url: str | None = None
+    host: str = "localhost"
+    port: int = 8000
+    output_dir: str = "results/socialomni"
+    max_samples: int | None = None
+    max_tokens: int = 64
+    temperature: float = 0.0
+    warmup: int = 0
+    max_concurrency: int = 1
+    request_rate: float = float("inf")
+    disable_tqdm: bool = False
+    timeout_s: int = 300
+    judges: int = 1
+    judge_base_urls: tuple[str, ...] = ()
+    judge_models: tuple[str, ...] = ()
+
+
+def _resolve_dataset_root(config: SocialOmniEvalConfig) -> Path:
+    if config.dataset_dir:
+        return Path(config.dataset_dir)
+    return Path(DEFAULT_SOCIALOMNI_DIRS[config.dataset_name])
+
+
+def _result_filename(dataset_name: str, level: str) -> str:
+    return f"{dataset_name.replace('-', '_')}_{level}_results.json"
+
+
+async def run_socialomni_level1_eval(config: SocialOmniEvalConfig) -> dict[str, Any]:
+    """Run the SocialOmni level1 benchmark."""
+    dataset_root = _resolve_dataset_root(config)
+    samples = load_socialomni_level1_samples(dataset_root, config.max_samples)
+    base_url = build_base_url(
+        base_url=config.base_url, host=config.host, port=config.port
+    )
+    api_url = build_chat_api_url(base_url)
+
+    timeout = aiohttp.ClientTimeout(total=config.timeout_s)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        await preflight_chat_completion_endpoint(
+            session,
+            api_url=api_url,
+            model_name=config.model,
+            endpoint_name="main endpoint",
+        )
+
+    send_fn = make_socialomni_level1_send_fn(
+        config.model,
+        api_url,
+        max_tokens=config.max_tokens,
+        temperature=config.temperature,
+    )
+    runner = BenchmarkRunner(
+        RunConfig(
+            max_concurrency=config.max_concurrency,
+            request_rate=config.request_rate,
+            warmup=config.warmup,
+            disable_tqdm=config.disable_tqdm,
+            timeout_s=config.timeout_s,
+        )
+    )
+    request_results = await runner.run(samples, send_fn)
+    summary, per_sample = compute_socialomni_level1_results(samples, request_results)
+    speed = compute_speed_metrics(request_results, wall_clock_s=runner.wall_clock_s)
+
+    results = {
+        "benchmark": "socialomni",
+        "level": "level1",
+        "config": {
+            "model": config.model,
+            "base_url": base_url,
+            "dataset_name": config.dataset_name,
+            "dataset_root": str(dataset_root),
+            "max_samples": config.max_samples,
+            "max_tokens": config.max_tokens,
+            "temperature": config.temperature,
+            "max_concurrency": config.max_concurrency,
+            "warmup": config.warmup,
+        },
+        "summary": summary,
+        "speed": speed,
+        "per_sample": per_sample,
+    }
+    save_json_results(
+        results, config.output_dir, _result_filename(config.dataset_name, config.level)
+    )
+    print_socialomni_level1_summary(summary)
+    return results
+
+
+async def run_socialomni_level2_eval(config: SocialOmniEvalConfig) -> dict[str, Any]:
+    """Run the SocialOmni level2 benchmark."""
+    dataset_root = _resolve_dataset_root(config)
+    samples = load_socialomni_level2_samples(dataset_root, config.max_samples)
+    base_url = build_base_url(
+        base_url=config.base_url, host=config.host, port=config.port
+    )
+    api_url = build_chat_api_url(base_url)
+    judge_specs = validate_judge_specs(
+        config.judges,
+        list(config.judge_base_urls),
+        list(config.judge_models),
+    )
+
+    timeout = aiohttp.ClientTimeout(total=config.timeout_s)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        await preflight_chat_completion_endpoint(
+            session,
+            api_url=api_url,
+            model_name=config.model,
+            endpoint_name="main endpoint",
+        )
+        for judge in judge_specs:
+            await preflight_chat_completion_endpoint(
+                session,
+                api_url=judge.api_url,
+                model_name=judge.model,
+                endpoint_name=f"judge endpoint ({judge.model})",
+            )
+
+    per_sample, primary_requests, judge_requests, wall_clock_s = (
+        await run_socialomni_level2_benchmark(
+            samples,
+            api_url=api_url,
+            model_name=config.model,
+            judge_specs=judge_specs,
+            max_tokens=config.max_tokens,
+            temperature=config.temperature,
+            max_concurrency=config.max_concurrency,
+            timeout_s=config.timeout_s,
+        )
+    )
+    summary = build_socialomni_level2_summary(per_sample)
+    metrics = build_socialomni_level2_metrics(
+        per_sample,
+        primary_requests,
+        judge_requests,
+        wall_clock_s=wall_clock_s,
+    )
+
+    results = {
+        "benchmark": "socialomni",
+        "level": "level2",
+        "config": {
+            "model": config.model,
+            "base_url": base_url,
+            "dataset_name": config.dataset_name,
+            "dataset_root": str(dataset_root),
+            "max_samples": config.max_samples,
+            "max_tokens": config.max_tokens,
+            "temperature": config.temperature,
+            "max_concurrency": config.max_concurrency,
+            "judges": config.judges,
+            "judge_specs": [
+                {"base_url": judge.base_url, "model": judge.model}
+                for judge in judge_specs
+            ],
+        },
+        "summary": summary,
+        "per_sample": per_sample,
+        **metrics,
+    }
+    save_json_results(
+        results, config.output_dir, _result_filename(config.dataset_name, config.level)
+    )
+    print_socialomni_level2_summary(summary)
+    return results
+
+
+async def run_socialomni_eval(config: SocialOmniEvalConfig) -> dict[str, Any]:
+    """Run the requested SocialOmni benchmark level."""
+    if config.level == "level1":
+        return await run_socialomni_level1_eval(config)
+    return await run_socialomni_level2_eval(config)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="SocialOmni benchmark for sglang-omni."
+    )
+    parser.add_argument("--base-url", type=str, default=None)
+    parser.add_argument("--host", type=str, default="localhost")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--model", type=str, required=True)
+    parser.add_argument("--level", choices=["level1", "level2"], required=True)
+    parser.add_argument(
+        "--dataset-name",
+        choices=["socialomni", "socialomni-mini"],
+        default="socialomni",
+    )
+    parser.add_argument(
+        "--dataset-dir",
+        type=str,
+        default=None,
+        help="Override the prepared dataset root (defaults to ./socialomni or ./socialomni-mini).",
+    )
+    parser.add_argument("--output-dir", type=str, default="results/socialomni")
+    parser.add_argument("--max-samples", type=int, default=None)
+    parser.add_argument("--max-tokens", type=int, default=64)
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--warmup", type=int, default=0)
+    parser.add_argument("--max-concurrency", type=int, default=1)
+    parser.add_argument("--request-rate", type=float, default=float("inf"))
+    parser.add_argument("--disable-tqdm", action="store_true")
+    parser.add_argument("--timeout-s", type=int, default=300)
+    parser.add_argument("--judges", choices=[1, 3], type=int, default=1)
+    parser.add_argument("--judge-base-url", action="append", default=[])
+    parser.add_argument("--judge-model", action="append", default=[])
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    config = SocialOmniEvalConfig(
+        model=args.model,
+        level=args.level,
+        dataset_name=args.dataset_name,
+        dataset_dir=args.dataset_dir,
+        base_url=args.base_url,
+        host=args.host,
+        port=args.port,
+        output_dir=args.output_dir,
+        max_samples=args.max_samples,
+        max_tokens=args.max_tokens,
+        temperature=args.temperature,
+        warmup=args.warmup,
+        max_concurrency=args.max_concurrency,
+        request_rate=args.request_rate,
+        disable_tqdm=args.disable_tqdm,
+        timeout_s=args.timeout_s,
+        judges=args.judges,
+        judge_base_urls=tuple(args.judge_base_url),
+        judge_models=tuple(args.judge_model),
+    )
+
+    wait_for_service(
+        build_base_url(base_url=config.base_url, host=config.host, port=config.port)
+    )
+    asyncio.run(run_socialomni_eval(config))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/tasks/socialomni.py
+++ b/benchmarks/tasks/socialomni.py
@@ -1,0 +1,905 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SocialOmni benchmark task helpers.
+
+Single-file layout aligned with existing benchmark modules. Sections below cover:
+- common request helpers
+- level1 prompt / parsing / scoring
+- judge orchestration helpers
+- level2 workflow helpers
+- level2 metrics and endpoint preflight
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+import numpy as np
+
+from benchmarks.benchmarker.data import RequestResult
+from benchmarks.benchmarker.runner import SendFn
+from benchmarks.dataset.socialomni import SocialOmniLevel1Sample, SocialOmniLevel2Sample
+from benchmarks.metrics.performance import compute_speed_metrics
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SYSTEM_PROMPT = "You are a careful multimodal reasoning assistant."
+LEVEL1_INSTRUCTION = (
+    "Answer ONLY with the option letter (A, B, C, or D). Do not include any other text."
+)
+LEVEL2_Q1_INSTRUCTION = "Answer ONLY with the option letter (A or B)."
+LEVEL2_Q2_INSTRUCTION = (
+    "Provide only the natural interruption utterance with no explanation."
+)
+LEVEL1_USER_PROMPT = "Watch the video and answer the multiple-choice question about what happens in the relevant segment."
+LEVEL2_Q1_USER_PROMPT = "Decide whether the named speaker should interrupt immediately after the timestamped prefix."
+LEVEL2_Q2_USER_PROMPT = (
+    "Generate the natural interruption utterance for that exact moment."
+)
+JUDGE_BUCKETS = (0, 25, 50, 75, 100)
+
+
+@dataclass(frozen=True)
+class JudgeSpec:
+    base_url: str
+    api_url: str
+    model: str
+
+
+@dataclass(frozen=True)
+class JudgeOutcome:
+    judge: JudgeSpec
+    raw_response: str
+    score: int | None
+    request_result: RequestResult
+    error: str = ""
+
+
+def build_base_url(
+    *,
+    base_url: str | None = None,
+    host: str = "localhost",
+    port: int = 8000,
+) -> str:
+    """Return a normalized base URL for an OpenAI-compatible endpoint."""
+    return (base_url or f"http://{host}:{port}").rstrip("/")
+
+
+def build_chat_api_url(base_url: str) -> str:
+    """Normalize a base URL to a /v1/chat/completions endpoint."""
+    normalized = base_url.rstrip("/")
+    if normalized.endswith("/chat/completions"):
+        return normalized
+    if normalized.endswith("/v1"):
+        return f"{normalized}/chat/completions"
+    return f"{normalized}/v1/chat/completions"
+
+
+def maybe_openai_headers() -> dict[str, str]:
+    """Return optional auth headers when OPENAI_API_KEY is available."""
+    api_key = os.getenv("OPENAI_API_KEY", "").strip()
+    if not api_key:
+        return {"Content-Type": "application/json"}
+    return {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    }
+
+
+def strip_option_prefix(option: str) -> str:
+    """Strip a leading option prefix like 'A. ' from an option string."""
+    return re.sub(r"^[A-D]\.\s*", "", option.strip(), flags=re.IGNORECASE)
+
+
+def join_prompt_sections(*sections: str) -> str:
+    """Join non-empty prompt sections with blank lines."""
+    return "\n\n".join(
+        section.strip() for section in sections if section and section.strip()
+    )
+
+
+def normalize_multiple_choice_prediction(
+    text: str,
+    *,
+    letters: tuple[str, ...],
+) -> str:
+    """Extract the first usable option letter from a model response."""
+    content = (text or "").strip()
+    if not content:
+        return ""
+    upper = content.upper()
+    tagged = re.search(
+        r"(?:ANSWER|CHOICE)\s*(?:IS|:)\s*([%s])\b" % "".join(letters),
+        upper,
+    )
+    if tagged:
+        return tagged.group(1)
+    if upper[0] in letters:
+        return upper[0]
+    match = re.search(r"\b([%s])\b" % "".join(letters), upper)
+    if match:
+        return match.group(1)
+    return ""
+
+
+def normalize_level2_yes_no_prediction(text: str) -> str:
+    """Mirror the reference Level2 Q1 normalization semantics."""
+    parsed = normalize_multiple_choice_prediction(text, letters=("A", "B"))
+    if parsed:
+        return parsed
+    lowered = (text or "").lower()
+    if "yes" in lowered:
+        return "A"
+    if "no" in lowered:
+        return "B"
+    return ""
+
+
+def extract_message_text(message: dict[str, Any]) -> str:
+    """Extract plain text content from a chat completion message."""
+    content = message.get("content")
+    if isinstance(content, str) and content.strip():
+        return content.strip()
+    if isinstance(content, list):
+        text_parts = [
+            part.get("text", "")
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        ]
+        merged = "\n".join(part for part in text_parts if part.strip()).strip()
+        if merged:
+            return merged
+    return ""
+
+
+async def send_chat_completion(
+    session: aiohttp.ClientSession,
+    *,
+    api_url: str,
+    payload: dict[str, Any],
+    request_id: str,
+    headers: dict[str, str] | None = None,
+) -> RequestResult:
+    """Send an OpenAI-compatible chat completion request."""
+    result = RequestResult(request_id=request_id)
+    start_time = time.perf_counter()
+    try:
+        async with session.post(
+            api_url,
+            json=payload,
+            headers=headers or maybe_openai_headers(),
+        ) as response:
+            response.raise_for_status()
+            body = await response.json()
+
+        message = body.get("choices", [{}])[0].get("message", {})
+        result.text = extract_message_text(message)
+        usage = body.get("usage", {})
+        result.prompt_tokens = usage.get("prompt_tokens", 0)
+        result.completion_tokens = usage.get("completion_tokens", 0)
+        result.is_success = bool(result.text)
+        if not result.is_success:
+            result.error = "Empty response"
+    except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as exc:
+        result.error = str(exc)
+    finally:
+        elapsed = time.perf_counter() - start_time
+        result.latency_s = elapsed
+        result.engine_time_s = elapsed
+        if result.completion_tokens > 0 and elapsed > 0:
+            result.tok_per_s = result.completion_tokens / elapsed
+    return result
+
+
+async def preflight_chat_completion_endpoint(
+    session: aiohttp.ClientSession,
+    *,
+    api_url: str,
+    model_name: str,
+    endpoint_name: str,
+) -> None:
+    """Fail fast if an OpenAI-compatible endpoint is unreachable or unusable."""
+    payload: dict[str, Any] = {
+        "model": model_name,
+        "messages": [{"role": "user", "content": "Reply with OK."}],
+        "modalities": ["text"],
+        "max_tokens": 4,
+        "temperature": 0.0,
+        "stream": False,
+    }
+    result = await send_chat_completion(
+        session,
+        api_url=api_url,
+        payload=payload,
+        request_id=f"preflight:{endpoint_name}",
+    )
+    if not result.is_success:
+        raise RuntimeError(
+            f"{endpoint_name} preflight failed for {api_url}: {result.error or 'empty response'}"
+        )
+
+
+def build_socialomni_level1_prompt(sample: SocialOmniLevel1Sample) -> str:
+    """Build a level1 prompt from the dataset sample."""
+    options_block = "\n".join(
+        f"{chr(ord('A') + index)}. {strip_option_prefix(option)}"
+        for index, option in enumerate(sample.options)
+    )
+    asr_block = f"ASR transcript:\n{sample.asr_content}" if sample.asr_content else ""
+    question_block = f"Question: {sample.question}\n\nOptions:\n{options_block}"
+    return join_prompt_sections(
+        DEFAULT_SYSTEM_PROMPT,
+        LEVEL1_USER_PROMPT,
+        asr_block,
+        question_block,
+        LEVEL1_INSTRUCTION,
+    )
+
+
+def extract_level1_prediction(raw_response: str) -> str:
+    """Extract the Level1 choice letter from raw model output."""
+    return normalize_multiple_choice_prediction(
+        raw_response, letters=("A", "B", "C", "D")
+    )
+
+
+def make_socialomni_level1_send_fn(
+    model_name: str,
+    api_url: str,
+    *,
+    max_tokens: int = 32,
+    temperature: float = 0.0,
+) -> SendFn:
+    """Return a send_fn for SocialOmni level1 over /v1/chat/completions."""
+
+    async def send_fn(session, sample: SocialOmniLevel1Sample):
+        payload: dict[str, Any] = {
+            "model": model_name,
+            "messages": [
+                {"role": "user", "content": build_socialomni_level1_prompt(sample)}
+            ],
+            "videos": [sample.video_path],
+            "modalities": ["text"],
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "stream": False,
+        }
+        return await send_chat_completion(
+            session,
+            api_url=api_url,
+            payload=payload,
+            request_id=sample.sample_id,
+        )
+
+    return send_fn
+
+
+def compute_socialomni_level1_results(
+    samples: list[SocialOmniLevel1Sample],
+    request_results: list[RequestResult],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Build summary + per-sample rows for SocialOmni level1."""
+    if len(samples) != len(request_results):
+        raise ValueError(
+            "samples and request_results must have the same length "
+            f"({len(samples)} != {len(request_results)})"
+        )
+
+    per_sample: list[dict[str, Any]] = []
+    correct = 0
+    parsed = 0
+    failed = 0
+    by_consistency: dict[str, dict[str, int]] = {}
+
+    for sample, result in zip(samples, request_results, strict=True):
+        prediction = extract_level1_prediction(result.text) if result.is_success else ""
+        is_correct = bool(prediction and prediction == sample.correct_answer)
+        if prediction:
+            parsed += 1
+        if is_correct:
+            correct += 1
+        if not result.is_success:
+            failed += 1
+
+        consistency = (
+            str(sample.metadata.get("consistency", "unknown")).strip() or "unknown"
+        )
+        bucket = by_consistency.setdefault(consistency, {"total": 0, "correct": 0})
+        bucket["total"] += 1
+        bucket["correct"] += int(is_correct)
+
+        per_sample.append(
+            {
+                "sample_id": sample.sample_id,
+                "video_path": sample.video_path,
+                "prediction": prediction,
+                "correct_answer": sample.correct_answer,
+                "is_correct": is_correct,
+                "raw_response": result.text,
+                "latency_s": round(result.latency_s, 3),
+                "error": result.error,
+                "metadata": sample.metadata,
+            }
+        )
+
+    total = len(samples)
+    summary = {
+        "total_samples": total,
+        "parsed_predictions": parsed,
+        "correct": correct,
+        "failed_requests": failed,
+        "accuracy": round(correct / total, 4) if total else 0.0,
+        "accuracy_by_consistency": {
+            key: {
+                "total": value["total"],
+                "correct": value["correct"],
+                "accuracy": round(value["correct"] / value["total"], 4),
+            }
+            for key, value in sorted(by_consistency.items())
+            if value["total"] > 0
+        },
+    }
+    return summary, per_sample
+
+
+def print_socialomni_level1_summary(summary: dict[str, Any]) -> None:
+    """Print a compact level1 summary."""
+    logger.info(
+        "SocialOmni level1 accuracy: %.2f%% (%s/%s)",
+        summary.get("accuracy", 0.0) * 100.0,
+        summary.get("correct", 0),
+        summary.get("total_samples", 0),
+    )
+
+
+def validate_judge_specs(
+    judges: int,
+    judge_base_urls: list[str] | None,
+    judge_models: list[str] | None,
+) -> list[JudgeSpec]:
+    """Validate and normalize repeated judge CLI args."""
+    base_urls = judge_base_urls or []
+    models = judge_models or []
+    if len(base_urls) != len(models):
+        raise ValueError(
+            "Judge configuration is incomplete: provide the same number of "
+            "--judge-base-url and --judge-model arguments."
+        )
+    if len(base_urls) != judges:
+        raise ValueError(
+            f"--judges {judges} requires exactly {judges} judge endpoint/model pairs; "
+            f"received {len(base_urls)}."
+        )
+
+    return [
+        JudgeSpec(
+            base_url=base_url.rstrip("/"),
+            api_url=build_chat_api_url(base_url.rstrip("/")),
+            model=model,
+        )
+        for base_url, model in zip(base_urls, models, strict=True)
+    ]
+
+
+def parse_judge_score(text: str) -> int:
+    """Parse a judge score and snap it to {0,25,50,75,100}."""
+    match = re.search(r"-?\d+(?:\.\d+)?", str(text or ""))
+    if not match:
+        return 0
+    score = max(0.0, min(100.0, float(match.group(0))))
+    return min(JUDGE_BUCKETS, key=lambda bucket: abs(bucket - score))
+
+
+def aggregate_judge_scores(scores: list[int]) -> float:
+    """Aggregate multiple judge scores as an arithmetic mean."""
+    if not scores:
+        return 0.0
+    return round(sum(scores) / len(scores), 2)
+
+
+async def run_socialomni_judge(
+    session: aiohttp.ClientSession,
+    *,
+    judge: JudgeSpec,
+    sample_id: str,
+    video_path: str,
+    reference_answer: str,
+    candidate_answer: str,
+) -> JudgeOutcome:
+    """Execute a single OpenAI-compatible Q2 judge request."""
+    if not candidate_answer.strip():
+        empty_result = RequestResult(request_id=f"{sample_id}:{judge.model}")
+        empty_result.error = "Empty candidate answer"
+        return JudgeOutcome(
+            judge=judge,
+            raw_response="",
+            score=0,
+            request_result=empty_result,
+            error=empty_result.error,
+        )
+
+    payload: dict[str, Any] = {
+        "model": judge.model,
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "You are a strict evaluator for dialog continuation.\n"
+                    "Score the candidate interruption against the reference on the "
+                    "exact scale {0, 25, 50, 75, 100}.\n"
+                    "Consider semantic match, intent correctness, and key information completeness.\n"
+                    "Output ONLY one number.\n\n"
+                    f"[Reference]\n{reference_answer}\n\n"
+                    f"[Candidate]\n{candidate_answer}\n"
+                ),
+            }
+        ],
+        "videos": [video_path],
+        "modalities": ["text"],
+        "max_tokens": 8,
+        "temperature": 0.0,
+        "stream": False,
+    }
+    request_result = await send_chat_completion(
+        session,
+        api_url=judge.api_url,
+        payload=payload,
+        request_id=f"{sample_id}:{judge.model}",
+    )
+    if not request_result.is_success:
+        return JudgeOutcome(
+            judge=judge,
+            raw_response=request_result.text,
+            score=None,
+            request_result=request_result,
+            error=request_result.error or "Judge request failed",
+        )
+
+    return JudgeOutcome(
+        judge=judge,
+        raw_response=request_result.text,
+        score=parse_judge_score(request_result.text),
+        request_result=request_result,
+    )
+
+
+def ensure_ffmpeg_available() -> None:
+    """Fail fast when ffmpeg is unavailable for prefix cutting."""
+    if shutil.which("ffmpeg") is None:
+        raise RuntimeError(
+            "SocialOmni level2 requires ffmpeg to cut the video prefix, but ffmpeg was not found in PATH."
+        )
+
+
+def parse_level2_timestamp_to_seconds(timestamp: str) -> float:
+    """Mirror the reference SocialOmni timestamp parsing semantics."""
+    text = str(timestamp or "").strip()
+    if not text:
+        return 0.0
+    if text.isdigit():
+        return float(text)
+    if ":" in text:
+        parts = text.split(":")
+        if len(parts) == 3:
+            try:
+                return float(parts[1])
+            except Exception:  # noqa: BLE001
+                pass
+        if len(parts) == 2:
+            try:
+                minutes = int(parts[0])
+                seconds = float(parts[1])
+                return minutes * 60 + seconds
+            except Exception:  # noqa: BLE001
+                pass
+    return float(text)
+
+
+def cut_video_prefix(input_video: str, timestamp_s: float, output_video: str) -> None:
+    """Cut *input_video* from t=0 to *timestamp_s* into *output_video*."""
+    cmd = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        input_video,
+        "-t",
+        str(max(0.0, timestamp_s)),
+        "-c",
+        "copy",
+        "-y",
+        output_video,
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if completed.returncode != 0 or not Path(output_video).is_file():
+        raise RuntimeError(
+            f"ffmpeg failed to cut video prefix at {timestamp_s}s for {input_video}: {completed.stderr.strip()}"
+        )
+
+
+def build_socialomni_level2_q1_prompt(sample: SocialOmniLevel2Sample) -> str:
+    """Build the Q1 prompt for a level2 sample."""
+    options_block = f"A. {sample.question_1.option_a}\nB. {sample.question_1.option_b}"
+    asr_block = f"ASR transcript:\n{sample.full_asr}" if sample.full_asr else ""
+    question_block = (
+        f"Question: {sample.question_1.question}\n\nOptions:\n{options_block}"
+    )
+    return join_prompt_sections(
+        DEFAULT_SYSTEM_PROMPT,
+        LEVEL2_Q1_USER_PROMPT,
+        asr_block,
+        question_block,
+        LEVEL2_Q1_INSTRUCTION,
+    )
+
+
+def build_socialomni_level2_q2_prompt(sample: SocialOmniLevel2Sample) -> str:
+    """Build the Q2 prompt for a level2 sample."""
+    asr_block = f"ASR transcript:\n{sample.full_asr}" if sample.full_asr else ""
+    question_block = f"Question: {sample.question_2.question}"
+    return join_prompt_sections(
+        DEFAULT_SYSTEM_PROMPT,
+        LEVEL2_Q2_USER_PROMPT,
+        asr_block,
+        question_block,
+        LEVEL2_Q2_INSTRUCTION,
+    )
+
+
+def resolve_level2_outcome(
+    *,
+    q1_answer: str,
+    q1_prediction: str,
+    judge_scores: list[int],
+    judge_errors: list[str],
+) -> tuple[bool, str, float | None]:
+    """Apply the reference gating semantics and return (q1_correct, branch, q2_score)."""
+    q1_correct = bool(q1_prediction and q1_answer and q1_prediction == q1_answer)
+    if q1_answer == "A":
+        if not q1_correct:
+            return q1_correct, "zeroed_wrong_q1", 0.0
+        if judge_errors:
+            return q1_correct, "judge_failed", None
+        return q1_correct, "yes_judged", aggregate_judge_scores(judge_scores)
+    if q1_correct:
+        return q1_correct, "no_skipped", None
+    return q1_correct, "zeroed_wrong_q1", 0.0
+
+
+async def _run_level2_primary_request(
+    session: aiohttp.ClientSession,
+    *,
+    api_url: str,
+    model_name: str,
+    sample_id: str,
+    video_path: str,
+    prompt: str,
+    max_tokens: int,
+    temperature: float,
+) -> RequestResult:
+    payload: dict[str, Any] = {
+        "model": model_name,
+        "messages": [{"role": "user", "content": prompt}],
+        "videos": [video_path],
+        "modalities": ["text"],
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "stream": False,
+    }
+    return await send_chat_completion(
+        session,
+        api_url=api_url,
+        payload=payload,
+        request_id=sample_id,
+    )
+
+
+async def run_socialomni_level2_sample(
+    session: aiohttp.ClientSession,
+    *,
+    sample: SocialOmniLevel2Sample,
+    api_url: str,
+    model_name: str,
+    judge_specs: list[JudgeSpec],
+    max_tokens: int,
+    temperature: float,
+) -> tuple[dict[str, Any], list[RequestResult], list[RequestResult]]:
+    """Run the full level2 workflow for one sample."""
+    workflow_start = time.perf_counter()
+    primary_requests: list[RequestResult] = []
+    judge_requests: list[RequestResult] = []
+    judge_scores: list[dict[str, Any]] = []
+    row: dict[str, Any] = {
+        "sample_id": sample.sample_id,
+        "video_path": sample.video_path,
+        "timestamp": sample.question_1.timestamp,
+        "q1_prediction": "",
+        "q1_correct": False,
+        "q2_response": "",
+        "judge_scores": judge_scores,
+        "q2_score": None,
+        "branch_status": "not_started",
+        "error": "",
+    }
+
+    try:
+        with tempfile.TemporaryDirectory(
+            prefix=f"socialomni_{sample.sample_id}_"
+        ) as tmpdir:
+            cut_path = str(Path(tmpdir) / Path(sample.video_path).name)
+            cut_video_prefix(
+                sample.video_path,
+                parse_level2_timestamp_to_seconds(sample.question_1.timestamp),
+                cut_path,
+            )
+            q1_result = await _run_level2_primary_request(
+                session,
+                api_url=api_url,
+                model_name=model_name,
+                sample_id=f"{sample.sample_id}:q1",
+                video_path=cut_path,
+                prompt=build_socialomni_level2_q1_prompt(sample),
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
+            primary_requests.append(q1_result)
+            row["q1_response"] = q1_result.text
+            row["q1_prediction"] = normalize_level2_yes_no_prediction(q1_result.text)
+
+            if not q1_result.is_success or not row["q1_prediction"]:
+                row["branch_status"] = "q1_failed"
+                row["q2_score"] = 0.0
+                row["error"] = (
+                    q1_result.error or "Failed to obtain a parseable Q1 answer"
+                )
+                return row, primary_requests, judge_requests
+
+            if sample.question_1.correct_answer == "A" and row["q1_prediction"] == "A":
+                q2_result = await _run_level2_primary_request(
+                    session,
+                    api_url=api_url,
+                    model_name=model_name,
+                    sample_id=f"{sample.sample_id}:q2",
+                    video_path=cut_path,
+                    prompt=build_socialomni_level2_q2_prompt(sample),
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                )
+                primary_requests.append(q2_result)
+                row["q2_response"] = q2_result.text
+                if not q2_result.is_success:
+                    row["branch_status"] = "q2_failed"
+                    row["q2_score"] = 0.0
+                    row["error"] = q2_result.error or "Q2 generation failed"
+                    return row, primary_requests, judge_requests
+
+                outcomes = await asyncio.gather(
+                    *[
+                        run_socialomni_judge(
+                            session,
+                            judge=judge,
+                            sample_id=sample.sample_id,
+                            video_path=sample.video_path,
+                            reference_answer=sample.question_2.answer,
+                            candidate_answer=q2_result.text,
+                        )
+                        for judge in judge_specs
+                    ]
+                )
+                judge_errors: list[str] = []
+                numeric_scores: list[int] = []
+                for outcome in outcomes:
+                    judge_requests.append(outcome.request_result)
+                    judge_scores.append(
+                        {
+                            "judge_model": outcome.judge.model,
+                            "judge_base_url": outcome.judge.base_url,
+                            "score": outcome.score,
+                            "raw_response": outcome.raw_response,
+                            "error": outcome.error,
+                        }
+                    )
+                    if outcome.error:
+                        judge_errors.append(f"{outcome.judge.model}: {outcome.error}")
+                    elif outcome.score is not None:
+                        numeric_scores.append(outcome.score)
+                q1_correct, branch_status, q2_score = resolve_level2_outcome(
+                    q1_answer=sample.question_1.correct_answer,
+                    q1_prediction=row["q1_prediction"],
+                    judge_scores=numeric_scores,
+                    judge_errors=judge_errors,
+                )
+                row["q1_correct"] = q1_correct
+                row["branch_status"] = branch_status
+                row["q2_score"] = q2_score
+                if judge_errors:
+                    row["error"] = "; ".join(judge_errors)
+            else:
+                q1_correct, branch_status, q2_score = resolve_level2_outcome(
+                    q1_answer=sample.question_1.correct_answer,
+                    q1_prediction=row["q1_prediction"],
+                    judge_scores=[],
+                    judge_errors=[],
+                )
+                row["q1_correct"] = q1_correct
+                row["branch_status"] = branch_status
+                row["q2_score"] = q2_score
+    except Exception as exc:  # noqa: BLE001
+        row["branch_status"] = "workflow_failed"
+        row["q2_score"] = 0.0
+        row["error"] = str(exc)
+
+    if not row["q1_correct"] and row["q1_prediction"]:
+        row["q1_correct"] = row["q1_prediction"] == sample.question_1.correct_answer
+    row["workflow_latency_s"] = round(time.perf_counter() - workflow_start, 3)
+    row["primary_latency_s"] = round(sum(req.latency_s for req in primary_requests), 3)
+    row["judge_latency_s"] = round(sum(req.latency_s for req in judge_requests), 3)
+    return row, primary_requests, judge_requests
+
+
+async def run_socialomni_level2_benchmark(
+    samples: list[SocialOmniLevel2Sample],
+    *,
+    api_url: str,
+    model_name: str,
+    judge_specs: list[JudgeSpec],
+    max_tokens: int,
+    temperature: float,
+    max_concurrency: int,
+    timeout_s: int,
+) -> tuple[list[dict[str, Any]], list[RequestResult], list[RequestResult], float]:
+    """Run the level2 workflow benchmark across all samples."""
+    ensure_ffmpeg_available()
+    semaphore = asyncio.Semaphore(max(1, max_concurrency))
+    timeout = aiohttp.ClientTimeout(total=timeout_s)
+    wall_clock_start = time.perf_counter()
+
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+
+        async def _limited(sample: SocialOmniLevel2Sample):
+            async with semaphore:
+                return await run_socialomni_level2_sample(
+                    session,
+                    sample=sample,
+                    api_url=api_url,
+                    model_name=model_name,
+                    judge_specs=judge_specs,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                )
+
+        completed = await asyncio.gather(*[_limited(sample) for sample in samples])
+
+    per_sample = [item[0] for item in completed]
+    primary_requests = [request for _, requests, _ in completed for request in requests]
+    judge_requests = [request for _, _, requests in completed for request in requests]
+    return (
+        per_sample,
+        primary_requests,
+        judge_requests,
+        time.perf_counter() - wall_clock_start,
+    )
+
+
+def build_socialomni_level2_summary(per_sample: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build the level2 accuracy summary from per-sample rows."""
+    q1_total = len(per_sample)
+    q1_correct = sum(1 for row in per_sample if row.get("q1_correct"))
+    q2_scores = [
+        float(row["q2_score"])
+        for row in per_sample
+        if isinstance(row.get("q2_score"), (int, float))
+    ]
+    branch_counts: dict[str, int] = {}
+    failed_samples = 0
+    for row in per_sample:
+        branch = str(row.get("branch_status", "unknown") or "unknown")
+        branch_counts[branch] = branch_counts.get(branch, 0) + 1
+        if row.get("error"):
+            failed_samples += 1
+
+    return {
+        "q1_total": q1_total,
+        "q1_correct": q1_correct,
+        "q1_accuracy": round(q1_correct / q1_total, 4) if q1_total else 0.0,
+        "q2_count": len(q2_scores),
+        "q2_avg_score": round(sum(q2_scores) / len(q2_scores), 2) if q2_scores else 0.0,
+        "failed_samples": failed_samples,
+        "branch_counts": branch_counts,
+    }
+
+
+def build_socialomni_level2_metrics(
+    per_sample: list[dict[str, Any]],
+    primary_requests: list[RequestResult],
+    judge_requests: list[RequestResult],
+    *,
+    wall_clock_s: float,
+) -> dict[str, Any]:
+    """Build separated metrics for primary model, judges, and overall workflow."""
+    primary_metrics = compute_speed_metrics(primary_requests)
+    primary_metrics["q1_requests"] = sum(
+        1 for request in primary_requests if request.request_id.endswith(":q1")
+    )
+    primary_metrics["q2_requests"] = sum(
+        1 for request in primary_requests if request.request_id.endswith(":q2")
+    )
+
+    judge_metrics = compute_speed_metrics(judge_requests)
+    judge_metrics["requested_judges"] = len(judge_requests)
+
+    workflow_latencies = [row.get("workflow_latency_s", 0.0) for row in per_sample]
+    overall_metrics: dict[str, Any] = {
+        "workflow_wall_clock_s": round(wall_clock_s, 3),
+        "samples": len(per_sample),
+        "successful_samples": sum(1 for row in per_sample if not row.get("error")),
+        "failed_samples": sum(1 for row in per_sample if row.get("error")),
+    }
+    if workflow_latencies:
+        overall_metrics.update(
+            {
+                "workflow_latency_mean_s": round(float(np.mean(workflow_latencies)), 3),
+                "workflow_latency_p95_s": round(
+                    float(np.percentile(workflow_latencies, 95)), 3
+                ),
+            }
+        )
+
+    return {
+        "primary_model_metrics": primary_metrics,
+        "judge_metrics": judge_metrics,
+        "overall_metrics": overall_metrics,
+    }
+
+
+def print_socialomni_level2_summary(summary: dict[str, Any]) -> None:
+    """Print a compact level2 summary."""
+    logger.info(
+        "SocialOmni level2 Q1 accuracy: %.2f%% (%s/%s), Q2 average: %.2f over %s scored samples",
+        summary.get("q1_accuracy", 0.0) * 100.0,
+        summary.get("q1_correct", 0),
+        summary.get("q1_total", 0),
+        summary.get("q2_avg_score", 0.0),
+        summary.get("q2_count", 0),
+    )
+
+
+__all__ = [
+    "JudgeOutcome",
+    "JudgeSpec",
+    "aggregate_judge_scores",
+    "build_base_url",
+    "build_chat_api_url",
+    "build_socialomni_level1_prompt",
+    "build_socialomni_level2_metrics",
+    "build_socialomni_level2_q1_prompt",
+    "build_socialomni_level2_q2_prompt",
+    "build_socialomni_level2_summary",
+    "compute_socialomni_level1_results",
+    "cut_video_prefix",
+    "ensure_ffmpeg_available",
+    "extract_level1_prediction",
+    "make_socialomni_level1_send_fn",
+    "parse_judge_score",
+    "parse_level2_timestamp_to_seconds",
+    "preflight_chat_completion_endpoint",
+    "print_socialomni_level1_summary",
+    "print_socialomni_level2_summary",
+    "resolve_level2_outcome",
+    "run_socialomni_judge",
+    "run_socialomni_level2_benchmark",
+    "run_socialomni_level2_sample",
+    "send_chat_completion",
+    "validate_judge_specs",
+]

--- a/tests/test_socialomni_benchmark.py
+++ b/tests/test_socialomni_benchmark.py
@@ -1,0 +1,486 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the SocialOmni benchmark integration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from benchmarks.benchmarker.data import RequestResult
+from benchmarks.dataset.socialomni import (
+    SOCIALOMNI_MINI_LEVEL1,
+    SOCIALOMNI_MINI_LEVEL2,
+    SocialOmniLevel1Sample,
+    prepare_socialomni_dataset,
+)
+from benchmarks.tasks.socialomni import (
+    build_socialomni_level2_summary,
+    compute_socialomni_level1_results,
+    ensure_ffmpeg_available,
+    parse_level2_timestamp_to_seconds,
+    resolve_level2_outcome,
+    validate_judge_specs,
+)
+
+
+def _write_fake_socialomni_source(root: Path) -> None:
+    (root / "level_1" / "videos").mkdir(parents=True)
+    (root / "level_2" / "videos").mkdir(parents=True)
+
+    level1_rows = []
+    for sample_id in list(SOCIALOMNI_MINI_LEVEL1) + [9999]:
+        video_name = f"video_{sample_id}.mp4"
+        (root / "level_1" / "videos" / video_name).write_bytes(b"level1")
+        level1_rows.append(
+            {
+                "id": sample_id,
+                "video_path": video_name,
+                "question": f"Question {sample_id}?",
+                "options": [
+                    "A. option a",
+                    "B. option b",
+                    "C. option c",
+                    "D. option d",
+                ],
+                "correct_answer": "A",
+                "asr_content": "transcript",
+                "metadata": {"consistency": "consistent"},
+            }
+        )
+    (root / "level_1" / "dataset.json").write_text(
+        json.dumps(level1_rows),
+        encoding="utf-8",
+    )
+
+    level2_rows = []
+    for video_id in list(SOCIALOMNI_MINI_LEVEL2) + ["video_0999"]:
+        video_name = f"{video_id}.mp4"
+        (root / "level_2" / "videos" / video_name).write_bytes(b"level2")
+        is_yes = video_id in {SOCIALOMNI_MINI_LEVEL2[0], SOCIALOMNI_MINI_LEVEL2[1]}
+        level2_rows.append(
+            {
+                "video_id": video_id,
+                "video_file": video_name,
+                "original_video_id": video_id,
+                "source_dir": "source",
+                "question_1": {
+                    "question": "Should they speak?",
+                    "timestamp": "00:17:00",
+                    "option_A": "YES",
+                    "option_B": "NO",
+                    "correct_answer": "A" if is_yes else "B",
+                },
+                "question_2": {
+                    "question": "What should they say?",
+                    "answer": "hello there",
+                },
+                "metadata": {"consistency": "consistent"},
+                "full_asr": "full transcript",
+            }
+        )
+    (root / "level_2" / "annotations.json").write_text(
+        json.dumps({"dataset_name": "socialomni", "data": level2_rows}),
+        encoding="utf-8",
+    )
+
+
+def test_prepare_socialomni_mini_materializes_frozen_manifest(tmp_path: Path) -> None:
+    source_root = tmp_path / "source"
+    target_root = tmp_path / "socialomni-mini"
+    _write_fake_socialomni_source(source_root)
+
+    prepare_socialomni_dataset(
+        "socialomni-mini",
+        local_dir=str(target_root),
+        source_root=source_root,
+    )
+
+    level1_rows = json.loads((target_root / "level_1" / "dataset.json").read_text())
+    assert [row["id"] for row in level1_rows] == list(SOCIALOMNI_MINI_LEVEL1)
+    level2_payload = json.loads(
+        (target_root / "level_2" / "annotations.json").read_text()
+    )
+    assert [row["video_id"] for row in level2_payload["data"]] == list(
+        SOCIALOMNI_MINI_LEVEL2
+    )
+    assert (target_root / "mini_manifest.json").is_file()
+    assert (target_root / "level_2" / "videos" / "video_0005.mp4").is_file()
+
+
+def test_validate_judge_specs_requires_exact_count() -> None:
+    with pytest.raises(ValueError, match="requires exactly 3"):
+        validate_judge_specs(
+            3, ["http://localhost:8001", "http://localhost:8002"], ["a", "b"]
+        )
+
+    specs = validate_judge_specs(1, ["http://localhost:8001/v1"], ["judge-a"])
+    assert specs[0].api_url == "http://localhost:8001/v1/chat/completions"
+
+
+@pytest.mark.parametrize(
+    (
+        "q1_answer",
+        "q1_prediction",
+        "judge_scores",
+        "judge_errors",
+        "expected_branch",
+        "expected_score",
+    ),
+    [
+        ("A", "A", [50, 75, 100], [], "yes_judged", 75.0),
+        ("B", "B", [], [], "no_skipped", None),
+        ("A", "B", [], [], "zeroed_wrong_q1", 0.0),
+        ("A", "A", [75], ["judge failed"], "judge_failed", None),
+    ],
+)
+def test_level2_protocol_branches(
+    q1_answer: str,
+    q1_prediction: str,
+    judge_scores: list[int],
+    judge_errors: list[str],
+    expected_branch: str,
+    expected_score: float | None,
+) -> None:
+    q1_correct, branch, q2_score = resolve_level2_outcome(
+        q1_answer=q1_answer,
+        q1_prediction=q1_prediction,
+        judge_scores=judge_scores,
+        judge_errors=judge_errors,
+    )
+    assert q1_correct is (q1_answer == q1_prediction)
+    assert branch == expected_branch
+    assert q2_score == expected_score
+
+
+def test_parse_level2_timestamp_reference_semantics() -> None:
+    assert parse_level2_timestamp_to_seconds("00:17:00") == 17.0
+    assert parse_level2_timestamp_to_seconds("27") == 27.0
+
+
+def test_level2_summary_includes_zero_scores_in_average() -> None:
+    summary = build_socialomni_level2_summary(
+        [
+            {
+                "q1_correct": True,
+                "q2_score": 75.0,
+                "branch_status": "yes_judged",
+                "error": "",
+            },
+            {
+                "q1_correct": False,
+                "q2_score": 0.0,
+                "branch_status": "zeroed_wrong_q1",
+                "error": "",
+            },
+            {
+                "q1_correct": True,
+                "q2_score": None,
+                "branch_status": "no_skipped",
+                "error": "",
+            },
+        ]
+    )
+    assert summary["q2_count"] == 2
+    assert summary["q2_avg_score"] == 37.5
+
+
+def test_level1_results_include_required_fields() -> None:
+    sample = SocialOmniLevel1Sample(
+        sample_id="1",
+        video_path="/tmp/video_1.mp4",
+        question="What happened?",
+        options=["A. alpha", "B. beta", "C. gamma", "D. delta"],
+        correct_answer="D",
+        asr_content="transcript",
+        metadata={"consistency": "consistent"},
+    )
+    result = RequestResult(
+        request_id="1", text="Answer: D", is_success=True, latency_s=1.25
+    )
+
+    summary, per_sample = compute_socialomni_level1_results([sample], [result])
+
+    assert summary["accuracy"] == 1.0
+    assert per_sample[0]["prediction"] == "D"
+    assert per_sample[0]["correct_answer"] == "D"
+    assert per_sample[0]["is_correct"] is True
+    assert per_sample[0]["raw_response"] == "Answer: D"
+
+
+import asyncio
+import shutil
+
+from aiohttp import web
+
+from benchmarks.eval.benchmark_omni_socialomni import (
+    SocialOmniEvalConfig,
+    run_socialomni_level1_eval,
+    run_socialomni_level2_eval,
+)
+
+
+def _write_level1_dataset_root(root: Path) -> Path:
+    (root / "level_1" / "videos").mkdir(parents=True)
+    (root / "level_1" / "videos" / "video_1.mp4").write_bytes(b"fake")
+    (root / "level_1" / "dataset.json").write_text(
+        json.dumps(
+            [
+                {
+                    "id": 1,
+                    "video_path": "video_1.mp4",
+                    "question": "What happened?",
+                    "options": [
+                        "A. alpha",
+                        "B. beta",
+                        "C. gamma",
+                        "D. delta",
+                    ],
+                    "correct_answer": "D",
+                    "asr_content": "transcript",
+                    "metadata": {"consistency": "consistent"},
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return root
+
+
+def _write_level2_dataset_root(root: Path) -> Path:
+    (root / "level_2" / "videos").mkdir(parents=True)
+    for name in ("video_yes.mp4", "video_no.mp4"):
+        (root / "level_2" / "videos" / name).write_bytes(b"fake")
+    (root / "level_2" / "annotations.json").write_text(
+        json.dumps(
+            {
+                "dataset_name": "socialomni-mini",
+                "data": [
+                    {
+                        "video_id": "video_yes",
+                        "video_file": "video_yes.mp4",
+                        "original_video_id": "video_yes",
+                        "source_dir": "src",
+                        "question_1": {
+                            "question": "Should the speaker talk now?",
+                            "timestamp": "00:17:00",
+                            "option_A": "YES",
+                            "option_B": "NO",
+                            "correct_answer": "A",
+                        },
+                        "question_2": {
+                            "question": "What should the speaker say?",
+                            "answer": "reference answer",
+                        },
+                        "metadata": {"consistency": "consistent"},
+                        "full_asr": "transcript",
+                    },
+                    {
+                        "video_id": "video_no",
+                        "video_file": "video_no.mp4",
+                        "original_video_id": "video_no",
+                        "source_dir": "src",
+                        "question_1": {
+                            "question": "Should the speaker talk now?",
+                            "timestamp": "12",
+                            "option_A": "YES",
+                            "option_B": "NO",
+                            "correct_answer": "B",
+                        },
+                        "question_2": {
+                            "question": "What should the speaker say?",
+                            "answer": "unused",
+                        },
+                        "metadata": {"consistency": "consistent"},
+                        "full_asr": "transcript",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return root
+
+
+async def _start_json_server(handler):
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    sockets = site._server.sockets
+    port = sockets[0].getsockname()[1]
+    return runner, f"http://127.0.0.1:{port}"
+
+
+def test_run_socialomni_level1_eval_end_to_end(tmp_path: Path) -> None:
+    dataset_root = _write_level1_dataset_root(tmp_path / "dataset")
+
+    async def handler(request):
+        return web.json_response(
+            {
+                "choices": [{"message": {"content": "Answer: D"}}],
+                "usage": {"prompt_tokens": 12, "completion_tokens": 2},
+            }
+        )
+
+    async def _run() -> None:
+        runner, base_url = await _start_json_server(handler)
+        try:
+            results = await run_socialomni_level1_eval(
+                SocialOmniEvalConfig(
+                    model="test-model",
+                    level="level1",
+                    dataset_name="socialomni-mini",
+                    dataset_dir=str(dataset_root),
+                    base_url=base_url,
+                    output_dir=str(tmp_path / "out-level1"),
+                    max_concurrency=1,
+                )
+            )
+            assert results["summary"]["accuracy"] == 1.0
+            assert results["per_sample"][0]["prediction"] == "D"
+            assert (
+                tmp_path / "out-level1" / "socialomni_mini_level1_results.json"
+            ).is_file()
+        finally:
+            await runner.cleanup()
+
+    asyncio.run(_run())
+
+
+def test_run_socialomni_level2_eval_end_to_end(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dataset_root = _write_level2_dataset_root(tmp_path / "dataset")
+
+    def _fake_cut_video_prefix(
+        input_video: str, timestamp_s: float, output_video: str
+    ) -> None:
+        Path(output_video).write_bytes(Path(input_video).read_bytes())
+
+    monkeypatch.setattr(
+        "benchmarks.tasks.socialomni.ensure_ffmpeg_available",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "benchmarks.tasks.socialomni.cut_video_prefix",
+        _fake_cut_video_prefix,
+    )
+
+    async def primary_handler(request):
+        payload = await request.json()
+        prompt = payload["messages"][0]["content"]
+        videos = payload.get("videos") or []
+        if not videos:
+            return web.json_response(
+                {
+                    "choices": [{"message": {"content": "OK"}}],
+                    "usage": {"prompt_tokens": 2, "completion_tokens": 1},
+                }
+            )
+        video_name = Path(videos[0]).name
+        if "Should the speaker talk now?" in prompt:
+            content = "Answer: A" if video_name == "video_yes.mp4" else "Answer: B"
+        else:
+            content = "generated interruption"
+        return web.json_response(
+            {
+                "choices": [{"message": {"content": content}}],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 3},
+            }
+        )
+
+    async def judge_handler(request):
+        return web.json_response(
+            {
+                "choices": [{"message": {"content": "75"}}],
+                "usage": {"prompt_tokens": 8, "completion_tokens": 1},
+            }
+        )
+
+    async def _run() -> None:
+        primary_runner, primary_url = await _start_json_server(primary_handler)
+        judge_runner, judge_url = await _start_json_server(judge_handler)
+        try:
+            results = await run_socialomni_level2_eval(
+                SocialOmniEvalConfig(
+                    model="test-model",
+                    level="level2",
+                    dataset_name="socialomni-mini",
+                    dataset_dir=str(dataset_root),
+                    base_url=primary_url,
+                    output_dir=str(tmp_path / "out-level2"),
+                    max_concurrency=1,
+                    judges=1,
+                    judge_base_urls=(judge_url,),
+                    judge_models=("judge-model",),
+                )
+            )
+            assert results["summary"]["q1_accuracy"] == 1.0
+            assert results["summary"]["q2_avg_score"] == 75.0
+            assert results["summary"]["branch_counts"]["yes_judged"] == 1
+            assert results["summary"]["branch_counts"]["no_skipped"] == 1
+            assert results["judge_metrics"]["requested_judges"] == 1
+            assert results["per_sample"][0]["judge_scores"][0]["score"] == 75
+            assert (
+                tmp_path / "out-level2" / "socialomni_mini_level2_results.json"
+            ).is_file()
+        finally:
+            await primary_runner.cleanup()
+            await judge_runner.cleanup()
+
+    asyncio.run(_run())
+
+
+def test_level2_ffmpeg_missing_fails_fast(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(shutil, "which", lambda _: None)
+    with pytest.raises(RuntimeError, match="ffmpeg"):
+        ensure_ffmpeg_available()
+
+
+def test_level2_judge_preflight_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dataset_root = _write_level2_dataset_root(tmp_path / "dataset-preflight")
+
+    async def primary_handler(request):
+        return web.json_response(
+            {
+                "choices": [{"message": {"content": "OK"}}],
+                "usage": {"prompt_tokens": 4, "completion_tokens": 1},
+            }
+        )
+
+    async def bad_judge_handler(request):
+        return web.Response(status=500, text="judge down")
+
+    async def _run() -> None:
+        primary_runner, primary_url = await _start_json_server(primary_handler)
+        judge_runner, judge_url = await _start_json_server(bad_judge_handler)
+        try:
+            with pytest.raises(RuntimeError, match="judge endpoint"):
+                await run_socialomni_level2_eval(
+                    SocialOmniEvalConfig(
+                        model="test-model",
+                        level="level2",
+                        dataset_name="socialomni-mini",
+                        dataset_dir=str(dataset_root),
+                        base_url=primary_url,
+                        output_dir=str(tmp_path / "out-preflight"),
+                        max_concurrency=1,
+                        judges=1,
+                        judge_base_urls=(judge_url,),
+                        judge_models=("judge-model",),
+                    )
+                )
+        finally:
+            await primary_runner.cleanup()
+            await judge_runner.cleanup()
+
+    monkeypatch.setattr(
+        "benchmarks.tasks.socialomni.ensure_ffmpeg_available", lambda: None
+    )
+    asyncio.run(_run())


### PR DESCRIPTION
 ## Motivation

  Add a PR-ready SocialOmni benchmark path for sglang-omni so users can evaluate omni models through the existing OpenAI-compatible serving API.

  The benchmark follows the existing repository pattern: users start the target model service separately, then point the benchmark entrypoint to that endpoint with `--base-url` / `--model`.

  ## Modifications

  - Add SocialOmni dataset preparation and loading support, including `socialomni` and deterministic `socialomni-mini` preparation.
  - Add a single-file SocialOmni dataset module at `benchmarks/dataset/socialomni.py`.
  - Add a single-file SocialOmni task module at `benchmarks/tasks/socialomni.py` for:
    - level1 prompt construction, request sending, answer parsing, and accuracy summary;
    - level2 Q1/Q2 workflow, video prefix cutting, judge requests, and result aggregation;
    - main endpoint and judge endpoint preflight checks.
  - Add the user-facing entrypoint `benchmarks/eval/benchmark_omni_socialomni.py`.
  - Document SocialOmni usage in `benchmarks/README.md`.
  - Add unit tests covering dataset materialization, endpoint normalization/preflight, level1 scoring, level2 branching, judge parsing/aggregation, and entrypoint behavior.

  ## Related Issues

  N/A

  ## Accuracy Test

  N/A. This PR adds benchmark plumbing and does not modify model architecture, kernels, or inference numerics.

  ## Benchmark & Profiling

  N/A. This PR adds a benchmark entrypoint and is not expected to change model serving throughput or latency.

  Local API-flow smoke was validated with OpenAI-compatible mock main and judge endpoints for both SocialOmni level1 and level2. The benchmark relies on the existing sglang-omni serving stack for real model startup.

  ## Checklist

  - [x] Format your code according with pre-commit.
  - [x] Add unit tests.
  - [x] Update documentation / docstrings / example tutorials as needed.
  - [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.

  Verification:

  ```bash
  uv run --with pre-commit pre-commit run --files \
    benchmarks/README.md \
    benchmarks/dataset/prepare.py \
    benchmarks/dataset/socialomni.py \
    benchmarks/eval/benchmark_omni_socialomni.py \
    benchmarks/tasks/socialomni.py \
    tests/test_socialomni_benchmark.py

  ./.venv/bin/pytest tests/test_socialomni_benchmark.py -q

  ./.venv/bin/python -m py_compile \
    benchmarks/dataset/prepare.py \
    benchmarks/dataset/socialomni.py \
    benchmarks/tasks/socialomni.py \
    benchmarks/eval/benchmark_omni_socialomni.py \
    tests/test_socialomni_benchmark.py

  git diff --check

  Results:

  - pre-commit run --files ...: passed
  - pytest tests/test_socialomni_benchmark.py -q: 13 passed
  - py_compile: passed
  - git diff --check: passed