### PR TITLE
[CLI]: Collapse duplicate CLI module path

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -25,20 +25,20 @@ python -m benchmarks.dataset.prepare --dataset seedtts
 # 1. Start a server on port 8000 (pick one matching the benchmark below)
 
 # S2-Pro — for sections 2a/2b/2c
-python -m sglang_omni.cli.cli serve \
+python -m sglang_omni.cli serve \
     --model-path fishaudio/s2-pro \
     --config examples/configs/s2pro_tts.yaml --port 8000
 
 # Voxtral-4B-TTS — for section 2d (plain TTS, no voice cloning)
-python -m sglang_omni.cli.cli serve \
+python -m sglang_omni.cli serve \
     --model-path mistralai/Voxtral-4B-TTS-2603 --port 8000
 
 # Qwen3-Omni, speech mode — for section 3 (SeedTTS; multi-GPU)
-python -m sglang_omni.cli.cli serve \
+python -m sglang_omni.cli serve \
     --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct --port 8000
 
 # Qwen3-Omni, text-only mode — for sections 4 (MMSU) and 5 (MMMU)
-python -m sglang_omni.cli.cli serve \
+python -m sglang_omni.cli serve \
     --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct --text-only --port 8000
 
 # 2a. S2-Pro — full pipeline: generate + WER (server needed for phase 1 only)

--- a/benchmarks/eval/benchmark_omni_mmsu.py
+++ b/benchmarks/eval/benchmark_omni_mmsu.py
@@ -7,13 +7,13 @@ Evaluates Qwen3-Omni accuracy and performance on the MMSU eval set via
 Usage:
 
     # Launch the server:
-    python -m sglang_omni.cli.cli serve \
+    python -m sglang_omni.cli serve \
         --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
         --port 8000
 
     # If only text is needed:
 
-    python -m sglang_omni.cli.cli serve \
+    python -m sglang_omni.cli serve \
         --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
         --text-only --port 8000
 

--- a/benchmarks/eval/benchmark_omni_seedtts.py
+++ b/benchmarks/eval/benchmark_omni_seedtts.py
@@ -13,7 +13,7 @@ Note (chenyang):
 Usage:
 
     # Launch the server:
-    python -m sglang_omni.cli.cli serve \
+    python -m sglang_omni.cli serve \
         --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
         --port 8000
 

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -15,12 +15,12 @@ Usage:
 
     # Launch the server:
     1. For S2-Pro:
-    python -m sglang_omni.cli.cli serve \
+    python -m sglang_omni.cli serve \
         --model-path fishaudio/s2-pro \
         --port 8000
 
     2. For Voxtral-4B-TTS-2603:
-    python -m sglang_omni.cli.cli serve \
+    python -m sglang_omni.cli serve \
         --model-path mistralai/Voxtral-4B-TTS-2603 \
         --port 8000
 

--- a/benchmarks/performance/tts/benchmark_tts_stream.py
+++ b/benchmarks/performance/tts/benchmark_tts_stream.py
@@ -7,7 +7,7 @@ benchmark_tts_speed.py which measures overall latency and throughput.
 
 Usage:
     # Launch a server first:
-    python -m sglang_omni.cli.cli serve \\
+    python -m sglang_omni.cli serve \\
         --model-path fishaudio/s2-pro \\
         --config examples/configs/s2pro_tts.yaml \\
         --port 8000

--- a/playground/gradio/start.sh
+++ b/playground/gradio/start.sh
@@ -71,7 +71,7 @@ echo ""
 
 # 1. Start the backend server in the background
 echo "[1/2] Starting backend server with arguments: ${BACKEND_ARGS[@]}"
-"${PYTHON_BIN}" -m sglang_omni.cli.cli serve \
+"${PYTHON_BIN}" -m sglang_omni.cli serve \
   "${BACKEND_ARGS[@]}" \
   --port "${BACKEND_PORT}" &
 SERVER_PID=$!

--- a/playground/tts/start.sh
+++ b/playground/tts/start.sh
@@ -61,7 +61,7 @@ echo "============================================================"
 
 # 1. Start backend
 echo "[1/2] Starting S2-Pro server..."
-"${PYTHON_BIN}" -m sglang_omni.cli.cli serve \
+"${PYTHON_BIN}" -m sglang_omni.cli serve \
   --model-path "${MODEL_PATH}" \
   --config "${CONFIG_PATH}" \
   --port "${BACKEND_PORT}" &

--- a/playground/web/start.sh
+++ b/playground/web/start.sh
@@ -58,7 +58,7 @@ echo ""
 
 # 1. Start the backend server in the background
 echo "[1/2] Starting backend server with arguments: ${BACKEND_ARGS[@]}"
-"${PYTHON_BIN}" -m sglang_omni.cli.cli serve \
+"${PYTHON_BIN}" -m sglang_omni.cli serve \
   "${BACKEND_ARGS[@]}" \
   --port "${PORT}" &
 SERVER_PID=$!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
 ]
 
 [project.scripts]
-sgl-omni = "sglang_omni.cli.cli:app"
+sgl-omni = "sglang_omni.cli:app"
 
 [tool.uv]
 override-dependencies = [

--- a/sglang_omni/cli/__init__.py
+++ b/sglang_omni/cli/__init__.py
@@ -1,0 +1,14 @@
+from typer import Typer
+
+from .config import config_app
+from .serve import serve as _serve
+
+app = Typer()
+
+# Register the subcommands.
+app.add_typer(config_app, name="config")
+app.command(
+    "serve", context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
+)(_serve)
+
+__all__ = ["app"]

--- a/sglang_omni/cli/__main__.py
+++ b/sglang_omni/cli/__main__.py
@@ -1,0 +1,4 @@
+from . import app
+
+if __name__ == "__main__":
+    app()

--- a/sglang_omni/cli/cli.py
+++ b/sglang_omni/cli/cli.py
@@ -1,15 +1,16 @@
-from typer import Typer
+from __future__ import annotations
 
-from .config import config_app
-from .serve import serve
+import warnings
 
-app = Typer()
+from . import app
 
-# register the subcommands
-app.add_typer(config_app, name="config")
-app.command(
-    "serve", context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
-)(serve)
+warnings.warn(
+    "`sglang_omni.cli.cli` is deprecated and will be removed after the "
+    "SGLang Omni V1 release. "
+    "Use `sglang_omni.cli` instead.",
+    DeprecationWarning,
+    stacklevel=1 if __name__ == "__main__" else 2,
+)
 
 
 if __name__ == "__main__":

--- a/tests/docs/qwen3_omni/test_docs_qwen3_omni.py
+++ b/tests/docs/qwen3_omni/test_docs_qwen3_omni.py
@@ -114,7 +114,7 @@ class TestTextOnlyMode:
         cmd = [
             sys.executable,
             "-m",
-            "sglang_omni.cli.cli",
+            "sglang_omni.cli",
             "serve",
             "--model-path",
             MODEL_PATH,

--- a/tests/docs/s2pro/test_docs_tts_s2pro.py
+++ b/tests/docs/s2pro/test_docs_tts_s2pro.py
@@ -40,7 +40,7 @@ def server_process(tmp_path_factory: pytest.TempPathFactory):
     cmd = [
         sys.executable,
         "-m",
-        "sglang_omni.cli.cli",
+        "sglang_omni.cli",
         "serve",
         "--model-path",
         S2PRO_MODEL_PATH,

--- a/tests/test_model/test_s2pro_tts_ci.py
+++ b/tests/test_model/test_s2pro_tts_ci.py
@@ -440,7 +440,7 @@ def server_process(tmp_path_factory: pytest.TempPathFactory):
     cmd = [
         sys.executable,
         "-m",
-        "sglang_omni.cli.cli",
+        "sglang_omni.cli",
         "serve",
         "--model-path",
         S2PRO_MODEL_PATH,

--- a/tests/test_model/test_video_integration.py
+++ b/tests/test_model/test_video_integration.py
@@ -53,7 +53,7 @@ def server_process(tmp_path_factory: pytest.TempPathFactory):
     cmd = [
         sys.executable,
         "-m",
-        "sglang_omni.cli.cli",
+        "sglang_omni.cli",
         "serve",
         "--model-path",
         MODEL_PATH,


### PR DESCRIPTION
## Summary

Fixes #349 

- make `sglang_omni.cli` the canonical module entry point
- keep `sglang_omni.cli.cli` as a deprecated compatibility shim until after the SGLang Omni V1 release
- update console script target, docs, benchmark snippets, playground scripts, and server-starting tests to use the canonical path

## Testing
- `python -m sglang_omni.cli --help`
- `python -W default -m sglang_omni.cli.cli --help`
  - verified the deprecated path still works and emits the expected `DeprecationWarning`. ```DeprecationWarning: `sglang_omni.cli.cli` is deprecated and will be removed after the SGLang Omni V1 release. Use `sglang_omni.cli` instead.```
- `sgl-omni --help`
- Started the server with:

```bash
python -m sglang_omni.cli serve \
  --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
  --text-only \
  --port 8000 \
  --thinker-max-seq-len 32768 \
  --encoder-mem-reserve 0.40
```

- Verified the running server with a simple health check:

```bash
curl -fsS http://127.0.0.1:8000/health
```
