### PR TITLE
[Benchmark] Update Video_MME results

### DIFF
--- a/benchmarks/eval/benchmark_omni_videomme.py
+++ b/benchmarks/eval/benchmark_omni_videomme.py
@@ -66,6 +66,45 @@ Speed (speed)
 | Model      | Config                             | latency_mean_s | latency_p95_s | throughput_qps | tok_per_s_mean | tok_per_s_agg | Source                                                |
 | ---------- | ---------------------------------- | -------------- | ------------- | -------------- | -------------- | ------------- | ----------------------------------------------------- |
 | Qwen3-Omni | thinker-only, encoder-reserve=0.40 | 42.53          | 67.62         | 0.094          | 2.70           | 2.60          | PR #327 [H200, first-100 prefix, c=4, max_tokens=256] |
+
+Full-set command
+
+    python -m sglang_omni.cli.cli serve \
+        --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
+        --port 30000 \
+        --model-name qwen3-omni \
+        --thinker-max-seq-len 32768 \
+        --text-only \
+        --encoder-mem-reserve 0.20
+
+    python -m benchmarks.eval.benchmark_omni_videomme \
+        --model qwen3-omni \
+        --port 30000 \
+        --max-concurrency 4 \
+        --max-tokens 256 \
+        --temperature 0.0 \
+        --video-fps 2 \
+        --video-max-frames 128 \
+        --video-max-pixels 401408 \
+        --output-dir /tmp/videomme-full
+
+H200 Reference Results
+
+Benchmark: Video-MME | Dataset: zhaochenyang20/Video_MME test split (2520 questions full)
+Hardware:  1 x H200
+Last verified: 2026-04-26
+
+Accuracy (full set)
+
+| Model      | Config                       | accuracy | correct   | failed | mc_fallback | Source                                            |
+| ---------- | ---------------------------- | -------- | --------- | ------ | ----------- | ------------------------------------------------- |
+| Qwen3-Omni | thinker-only, full-set, c=4 | 64.52%   | 1626/2520 | 24     | 67          | main 0d1a46d18369cb24185340ff7e82c1064c771fe6 [H200, c=4, max_tokens=256] |
+
+Speed (full set)
+
+| Model      | Config                       | completed | failed | latency_mean_s | latency_median_s | latency_p95_s | latency_p99_s | tok_per_s_mean | tok_per_s_agg | gen_tokens_mean | gen_tokens_total | prompt_tokens_mean | prompt_tokens_total | throughput_qps | Source                                            |
+| ---------- | ---------------------------- | --------- | ------ | -------------- | ---------------- | ------------- | ------------- | -------------- | ------------- | --------------- | ---------------- | ------------------ | ------------------- | -------------- | ------------------------------------------------- |
+| Qwen3-Omni | thinker-only, full-set, c=4 | 2496      | 24     | 30.251         | 28.896           | 48.294        | 58.313        | 3.9            | 3.8           | 116             | 289152           | 13769              | 34366523            | 0.132          | main 0d1a46d18369cb24185340ff7e82c1064c771fe6 [H200, c=4, max_tokens=256] |
 """
 
 

--- a/benchmarks/eval/benchmark_omni_videomme.py
+++ b/benchmarks/eval/benchmark_omni_videomme.py
@@ -13,18 +13,6 @@ thinker context. We set --thinker-max-seq-len 32768 to accommodate the longest
 ones, and --encoder-mem-reserve 0.40 to hold back ~56 GB of GPU memory for the
 co-located video encoder at peak activation.
 
-TODO (Qiujiang, Chenyang):
-
-We are facing extremely fragmented memory allocation when processing long videos.
-
-In CI of test_qwen3_omni_videomme_ci.py, we use --encoder-mem-reserve 0.20
-on the 50-sample videomme-ci-50 subset. The smaller reserve is sufficient
-there because the per-server request budget never crosses the threshold where
-encoder-activation fragmentation starts dropping requests. At 100 samples on
-the test-split prefix,0.40 is the smallest reserve that empirically completes
-100 sequential requests without dropped responses; going above 0.40 leaves
- SGLang with too little KV pool to boot.
-
 
 Detailed usage of the serving args can be found in https://github.com/sgl-project/sglang-omni/pull/339
 
@@ -41,54 +29,20 @@ Usage:
         --port 8000 \
         --thinker-max-seq-len 32768 \
         --text-only \
-        --encoder-mem-reserve 0.40
+        --encoder-mem-reserve 0.2
 
     3. Run the benchmark (--max-samples matches the reference table below)
 
-    python benchmarks/eval/benchmark_omni_videomme.py \
-        --model qwen3-omni --port 8000 \
-        --max-concurrency 4 --max-tokens 256 --max-samples 100
-
-H200 Reference Results
-
-Benchmark: Video-MME | Dataset: lmms-lab/Video-MME test split (2520 questions full; first N samples used here)
-Hardware:  1 x H200
-Last verified: 2026-04-24
-
-Accuracy (summary)
-
-| Model      | Config                          | accuracy | correct | failed | mc_fallback | Source                                                              |
-| ---------- | ------------------------------- | -------- | ------- | ------ | ----------- | ------------------------------------------------------------------- |
-| Qwen3-Omni | thinker-only, encoder-reserve=0.40 | 77.00% | 77/100  | 0      | 1           | PR #327 [H200, first-100 prefix, c=4, max_tokens=256] |
-
-Speed (speed)
-
-| Model      | Config                             | latency_mean_s | latency_p95_s | throughput_qps | tok_per_s_mean | tok_per_s_agg | Source                                                |
-| ---------- | ---------------------------------- | -------------- | ------------- | -------------- | -------------- | ------------- | ----------------------------------------------------- |
-| Qwen3-Omni | thinker-only, encoder-reserve=0.40 | 42.53          | 67.62         | 0.094          | 2.70           | 2.60          | PR #327 [H200, first-100 prefix, c=4, max_tokens=256] |
-
-Full-set command
-
-    python -m sglang_omni.cli.cli serve \
-        --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
-        --port 30000 \
-        --model-name qwen3-omni \
-        --thinker-max-seq-len 32768 \
-        --text-only \
-        --encoder-mem-reserve 0.20
-
-    python -m benchmarks.eval.benchmark_omni_videomme \
+python -m benchmarks.eval.benchmark_omni_videomme \
         --model qwen3-omni \
-        --port 30000 \
+        --port 8000 \
         --max-concurrency 4 \
         --max-tokens 256 \
         --temperature 0.0 \
         --video-fps 2 \
         --video-max-frames 128 \
-        --video-max-pixels 401408 \
-        --output-dir /tmp/videomme-full
+        --video-max-pixels 401408
 
-H200 Reference Results
 
 Benchmark: Video-MME | Dataset: zhaochenyang20/Video_MME test split (2520 questions full)
 Hardware:  1 x H200
@@ -96,15 +50,15 @@ Last verified: 2026-04-26
 
 Accuracy (full set)
 
-| Model      | Config                       | accuracy | correct   | failed | mc_fallback | Source                                            |
-| ---------- | ---------------------------- | -------- | --------- | ------ | ----------- | ------------------------------------------------- |
-| Qwen3-Omni | thinker-only, full-set, c=4 | 64.52%   | 1626/2520 | 24     | 67          | main 0d1a46d18369cb24185340ff7e82c1064c771fe6 [H200, c=4, max_tokens=256] |
+| Model      | Config                      | accuracy | correct   | failed | mc_fallback | Source                                                                    |
+| ---------- | --------------------------- | -------- | --------- | ------ | ----------- | ------------------------------------------------------------------------- |
+| Qwen3-Omni | thinker-only, full-set, c=4 | 63.97%   | 1612/2520 | 24     | 64          | main 0298e70b59d941e894283dd6a7aeb83bfc71c602 [H200, c=4, max_tokens=256] |
 
 Speed (full set)
 
-| Model      | Config                       | completed | failed | latency_mean_s | latency_median_s | latency_p95_s | latency_p99_s | tok_per_s_mean | tok_per_s_agg | gen_tokens_mean | gen_tokens_total | prompt_tokens_mean | prompt_tokens_total | throughput_qps | Source                                            |
-| ---------- | ---------------------------- | --------- | ------ | -------------- | ---------------- | ------------- | ------------- | -------------- | ------------- | --------------- | ---------------- | ------------------ | ------------------- | -------------- | ------------------------------------------------- |
-| Qwen3-Omni | thinker-only, full-set, c=4 | 2496      | 24     | 30.251         | 28.896           | 48.294        | 58.313        | 3.9            | 3.8           | 116             | 289152           | 13769              | 34366523            | 0.132          | main 0d1a46d18369cb24185340ff7e82c1064c771fe6 [H200, c=4, max_tokens=256] |
+| Model      | Config                      | completed | failed | latency_mean_s | latency_median_s | latency_p95_s | latency_p99_s | tok_per_s_mean | tok_per_s_agg | gen_tokens_mean | gen_tokens_total | prompt_tokens_mean | prompt_tokens_total | throughput_qps | Source                                                                    |
+| ---------- | --------------------------- | --------- | ------ | -------------- | ---------------- | ------------- | ------------- | -------------- | ------------- | --------------- | ---------------- | ------------------ | ------------------- | -------------- | ------------------------------------------------------------------------- |
+| Qwen3-Omni | thinker-only, full-set, c=4 | 2496      | 24     | 30.172         | 28.859           | 48.639        | 59.039        | 3.8            | 3.8           | 115             | 286801           | 13769              | 34366523            | 0.133          | main 0298e70b59d941e894283dd6a7aeb83bfc71c602 [H200, c=4, max_tokens=256] |
 """
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Record the Video-MME full-set results on the latest codebase.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

```bash
    python -m sglang_omni.cli.cli serve \
        --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
        --port 30000 \
        --model-name qwen3-omni \
        --thinker-max-seq-len 32768 \
        --text-only \
        --encoder-mem-reserve 0.20

    python -m benchmarks.eval.benchmark_omni_videomme \
        --model qwen3-omni \
        --port 30000 \
        --max-concurrency 4 \
        --max-tokens 256 \
        --temperature 0.0 \
        --video-fps 2 \
        --video-max-frames 128 \
        --video-max-pixels 401408 \
        --output-dir /tmp/videomme-full
```

```
==================================================
  Video-MME Accuracy — qwen3-omni
==================================================
  Total samples:               2520
  Correct:                     1626
  Accuracy:                    0.6452 (64.5%)
  Failed requests:             24
  MC parse fallback:           67
  By duration:
    long           431/837 (51.5%)
    medium         556/855 (65.0%)
    short          639/828 (77.2%)
  By domain:
    Artistic Performance 212/327 (64.8%)
    Film & Television 215/324 (66.4%)
    Knowledge      524/759 (69.0%)
    Life Record    365/594 (61.5%)
    Multilingual   45/87 (51.7%)
    Sports Competition 265/429 (61.8%)
  By task type:
    Action Reasoning 148/258 (57.4%)
    Action Recognition 180/284 (63.4%)
    Attribute Perception 160/203 (78.8%)
    Counting Problem 118/249 (47.4%)
    Information Synopsis 228/306 (74.5%)
    OCR Problems   103/136 (75.7%)
    Object Reasoning 254/428 (59.4%)
    Object Recognition 233/333 (70.0%)
    Spatial Perception 34/51 (66.7%)
    Spatial Reasoning 37/49 (75.5%)
    Temporal Perception 36/51 (70.6%)
    Temporal Reasoning 95/172 (55.2%)
==================================================


============================================================
                      Video-MME Speed                       
============================================================
  Model:                         qwen3-omni
  Concurrency:                   4
  Completed requests:            2496
  Failed requests:               24
------------------------------------------------------------
  Latency mean (s):              30.251
  Latency median (s):            28.896
  Latency p95 (s):               48.294
  Latency p99 (s):               58.313
  Tok/s (per-req mean):          3.9
  Tok/s (per-req median):        3.7
  Tok/s (aggregate):             3.8
  Gen tokens (mean):             116
  Gen tokens (total):            289152
  Prompt tokens (mean):          13769
  Prompt tokens (total):         34366523
  Throughput (req/s):            0.132
============================================================
```
<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->
## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
