### PR TITLE
[CI] Reduce the Qwen3-Omni MMMU_Talker CI sample size and adjust the thresholds

### DIFF
--- a/tests/test_model/test_qwen3_omni_mmmu_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmmu_ci.py
@@ -31,7 +31,7 @@ from tests.utils import (
 MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
 
 CONCURRENCY = 8
-STARTUP_TIMEOUT = 900
+STARTUP_TIMEOUT = 300
 
 MMMU_MIN_ACCURACY = 0.60
 

--- a/tests/test_model/test_qwen3_omni_mmmu_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmmu_talker_ci.py
@@ -39,9 +39,9 @@ from tests.utils import (
 
 MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
 
-MAX_SAMPLES = 20
+MAX_SAMPLES = 10
 MAX_TOKENS = 256
-STARTUP_TIMEOUT = 900
+STARTUP_TIMEOUT = 300
 
 CONCURRENCY = 8
 
@@ -59,20 +59,20 @@ MMMU_TTS_PROMPT = (
 # Threshold reference: https://github.com/sgl-project/sglang-omni/pull/337#issuecomment-4314808991
 
 # Accuracy floor — audio-mode MMMU.
-MMMU_AUDIO_MIN_ACCURACY = 0.60
+MMMU_AUDIO_MIN_ACCURACY = 0.50
 
 # WER thresholds use a partitioned view of the per-sample distribution:
 #  - corpus WER over the "sane" subset (per-sample WER <= 50%)
 #  - count of catastrophic failures (per-sample WER > 50%)
 MMMU_AUDIO_WER_BELOW_50_CORPUS_MAX = 0.20
-MMMU_AUDIO_N_ABOVE_50_MAX = 6
+MMMU_AUDIO_N_ABOVE_50_MAX = 3
 
 _MMMU_AUDIO_P95 = {
     8: {
-        "throughput_qps": 0.042,
-        "tok_per_s_agg": 0.80,
-        "latency_mean_s": 179.428,
-        "rtf_mean": 3.9102,
+        "throughput_qps": 0.035,
+        "tok_per_s_agg": 0.90,
+        "latency_mean_s": 151.500,
+        "rtf_mean": 3.6109,
     },
 }
 MMMU_AUDIO_THRESHOLDS = apply_slack(_MMMU_AUDIO_P95)
@@ -122,7 +122,6 @@ def test_mmmu_audio_wer_and_speed(
         output_dir=str(tmp_path / "mmmu_audio"),
         enable_audio=True,
         repo_id=DATASETS["mmmu-ci-50"],
-        warmup=1,
         prompt_override=MMMU_TTS_PROMPT,
         timeout_s=500,
     )

--- a/tests/test_model/test_qwen3_omni_mmsu_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_ci.py
@@ -33,7 +33,7 @@ from tests.utils import (
 MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
 
 CONCURRENCY = 8
-STARTUP_TIMEOUT = 900
+STARTUP_TIMEOUT = 300
 
 MMSU_MIN_ACCURACY = 0.69
 
@@ -81,7 +81,6 @@ def _build_args(port: int, output_dir: str) -> argparse.Namespace:
         prompt=None,
         max_tokens=32,
         temperature=0.0,
-        warmup=1,
         max_concurrency=CONCURRENCY,
         request_rate=float("inf"),
         timeout_s=300,

--- a/tests/test_model/test_qwen3_omni_mmsu_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_ci.py
@@ -81,6 +81,7 @@ def _build_args(port: int, output_dir: str) -> argparse.Namespace:
         prompt=None,
         max_tokens=32,
         temperature=0.0,
+        warmup=0,
         max_concurrency=CONCURRENCY,
         request_rate=float("inf"),
         timeout_s=300,

--- a/tests/test_model/test_qwen3_omni_mmsu_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_talker_ci.py
@@ -120,6 +120,7 @@ def _build_args(port: int, output_dir: str) -> argparse.Namespace:
         prompt=MMSU_TTS_PROMPT,
         max_tokens=MAX_TOKENS,
         temperature=0.0,
+        warmup=0,
         max_concurrency=CONCURRENCY,
         request_rate=float("inf"),
         save_audio=True,

--- a/tests/test_model/test_qwen3_omni_mmsu_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_talker_ci.py
@@ -42,7 +42,7 @@ MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
 
 MAX_SAMPLES = 20
 MAX_TOKENS = 256
-STARTUP_TIMEOUT = 900
+STARTUP_TIMEOUT = 300
 
 CONCURRENCY = 8
 
@@ -120,7 +120,6 @@ def _build_args(port: int, output_dir: str) -> argparse.Namespace:
         prompt=MMSU_TTS_PROMPT,
         max_tokens=MAX_TOKENS,
         temperature=0.0,
-        warmup=1,
         max_concurrency=CONCURRENCY,
         request_rate=float("inf"),
         save_audio=True,

--- a/tests/test_model/test_qwen3_omni_thinker_length.py
+++ b/tests/test_model/test_qwen3_omni_thinker_length.py
@@ -21,7 +21,7 @@ from tests.utils import disable_proxy, start_server_from_cmd, stop_server
 MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
 MODEL_NAME = "qwen3-omni"
 THINKER_MAX_SEQ_LEN = 128
-STARTUP_TIMEOUT = 900
+STARTUP_TIMEOUT = 300
 REQUEST_TIMEOUT = 120
 
 

--- a/tests/test_model/test_qwen3_omni_tts_ci.py
+++ b/tests/test_model/test_qwen3_omni_tts_ci.py
@@ -42,7 +42,7 @@ CONCURRENCY = 8
 MAX_SAMPLES = 50
 DATASET_CACHE_ENV = "SGLANG_SEEDTTS50_DIR"
 
-STARTUP_TIMEOUT = 900
+STARTUP_TIMEOUT = 300
 WER_TIMEOUT = 600
 
 # Threshold reference: https://github.com/sgl-project/sglang-omni/pull/337#issuecomment-4321089804

--- a/tests/test_model/test_qwen3_omni_videomme_ci.py
+++ b/tests/test_model/test_qwen3_omni_videomme_ci.py
@@ -36,7 +36,7 @@ from tests.utils import (
 MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
 
 CONCURRENCY = 16
-STARTUP_TIMEOUT = 900
+STARTUP_TIMEOUT = 300
 
 # threshold reference: https://github.com/sgl-project/sglang-omni/pull/337#issuecomment-4321084941
 VIDEOMME_MIN_ACCURACY = 0.56

--- a/tests/test_model/test_qwen3_omni_videomme_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_videomme_talker_ci.py
@@ -52,7 +52,7 @@ MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
 CONCURRENCY = 8
 MAX_SAMPLES = 10
 MAX_TOKENS = 256
-STARTUP_TIMEOUT = 900
+STARTUP_TIMEOUT = 300
 SHORT_ANSWER_PROMPT = (
     "For the audio response, answer briefly in one sentence and end with "
     "'Answer: $LETTER'. Do not include step-by-step reasoning."


### PR DESCRIPTION
Make the Qwen3-omni CI faster:

- Reduce the MMMU_Talker CI sample size  from 20 to 10 and adjust the thresholds; 
- Skip the warmup for MMSU, MMMU_Talker, MMSU_Talker CI;
- Reduce `STARTUP_TIMEOUT` from 900 to 300.


