### PR TITLE
[WIP][Benchmark] Move MMMU answer parsers to metrics/accuracy.

### DIFF
--- a/benchmarks/metrics/accuracy.py
+++ b/benchmarks/metrics/accuracy.py
@@ -1,8 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Accuracy metrics for multiple-choice evaluation (e.g. MMSU)."""
+"""Accuracy parsing and answer extraction for benchmark evaluation.
+
+Houses the pure functions that turn free-form model responses into a
+predicted answer (or correctness signal). No IO, no async, no task glue —
+inputs are strings and option lists; outputs are letters / indices /
+booleans / lists of normalised candidates.
+
+Public API:
+
+* ``extract_answer_letter`` — bare-letter A-D extraction (MMSU).
+* ``parse_multi_choice_response`` — variable-choice MCQ extraction
+  with bracket/space/option-text fallbacks (MMMU, Video-MME).
+* ``parse_open_response`` + ``eval_open`` — open-ended answer
+  extraction and fuzzy match (MMMU open split).
+"""
 
 from __future__ import annotations
 
+import random
 import re
 
 ANSWER_LETTERS = {"A": 0, "B": 1, "C": 2, "D": 3}
@@ -36,3 +51,177 @@ def extract_answer_letter(text: str) -> int | None:
             return ANSWER_LETTERS[letter]
 
     return None
+
+
+def _check_is_number(s: str) -> bool:
+    try:
+        float(s.replace(",", ""))
+        return True
+    except ValueError:
+        return False
+
+
+def _normalize_str(s: str) -> list[float | str]:
+    """Normalize a string for open-ended answer comparison."""
+    s = s.strip()
+    if _check_is_number(s):
+        return [round(float(s.replace(",", "")), 2)]
+    return [s.lower()] if len(s) > 1 else [" " + s, s + " "]
+
+
+def _extract_numbers(s: str) -> list[str]:
+    """Extract all numbers (with commas, scientific notation, etc.) from *s*."""
+    pattern_commas = r"-?\b\d{1,3}(?:,\d{3})+\b"
+    pattern_scientific = r"-?\d+(?:\.\d+)?[eE][+-]?\d+"
+    pattern_simple = r"-?(?:\d+\.\d+|\.\d+|\d+\b)(?![eE][+-]?\d+)(?![,\d])"
+    return (
+        re.findall(pattern_commas, s)
+        + re.findall(pattern_scientific, s)
+        + re.findall(pattern_simple, s)
+    )
+
+
+def _parse_open_answer_tag(response: str) -> str | None:
+    """Try to extract the answer from an explicit 'Answer: ...' line.
+
+    Supports formats like ``Answer: 42``, ``Answer: MgS``,
+    ``Answer: \\boxed{13.0}``.  Returns ``None`` when no match is found.
+    """
+    matches = re.findall(
+        r"[Aa]nswer\s*:\s*\*?\*?\s*(.+)",
+        response,
+    )
+    if not matches:
+        return None
+    raw = matches[-1].strip().rstrip(".")
+    # Unwrap \boxed{...} if present
+    boxed = re.search(r"\\boxed\{(.+?)\}", raw)
+    if boxed:
+        raw = boxed.group(1)
+    # Strip surrounding ** (bold markdown)
+    raw = raw.strip("*").strip()
+    return raw if raw else None
+
+
+def parse_open_response(response: str) -> list[float | str]:
+    """Extract answer candidates from an open-ended model response.
+
+    First tries to extract from an explicit ``Answer: ...`` line.
+    Falls back to heuristic key-subresponse extraction.
+    """
+    # Fast path: explicit "Answer: ..."
+    tag_answer = _parse_open_answer_tag(response)
+    if tag_answer is not None:
+        out: list = []
+        out.extend(_normalize_str(tag_answer))
+        for num in _extract_numbers(tag_answer):
+            out.extend(_normalize_str(num))
+        return list(dict.fromkeys(out))
+
+    # Fallback: heuristic extraction
+    def _get_key_subresponses(resp: str) -> list[str]:
+        resp = resp.strip().strip(".").lower()
+        subs = re.split(r"\.\s(?=[A-Z])|\n", resp)
+        indicators = [
+            "could be ",
+            "so ",
+            "is ",
+            "thus ",
+            "therefore ",
+            "final ",
+            "answer ",
+            "result ",
+        ]
+        keys: list[str] = []
+        for i, s in enumerate(subs):
+            cands = indicators + ["="] if i == len(subs) - 1 else indicators
+            shortest = None
+            for ind in cands:
+                if ind in s:
+                    part = s.split(ind)[-1].strip()
+                    if not shortest or len(part) < len(shortest):
+                        shortest = part
+            if shortest and shortest not in (":", ",", ".", "!", "?", ";", "'"):
+                keys.append(shortest)
+        return keys or [resp]
+
+    key_resps = _get_key_subresponses(response)
+    pred_list = key_resps.copy()
+    for r in key_resps:
+        pred_list.extend(_extract_numbers(r))
+    out = []
+    for x in pred_list:
+        out.extend(_normalize_str(x))
+    return list(dict.fromkeys(out))
+
+
+def eval_open(gold: str | list[str], preds: list[float | str]) -> bool:
+    """Check if any prediction matches the gold answer (fuzzy)."""
+    if isinstance(gold, list):
+        norm_answers: list = []
+        for ans in gold:
+            norm_answers.extend(_normalize_str(ans))
+    else:
+        norm_answers = _normalize_str(gold)
+    for p in preds:
+        if isinstance(p, str):
+            for na in norm_answers:
+                if isinstance(na, str) and na in p:
+                    return True
+        else:
+            if p in norm_answers:
+                return True
+    return False
+
+
+def parse_multi_choice_response(
+    response: str,
+    all_choices: list[str],
+    index2ans: dict[str, str],
+) -> tuple[str, bool]:
+    """Extract a single answer letter from the model response.
+
+    Priority: ``Answer: X`` → ``(A)`` bracket → ``·A·`` space-padded →
+    option-text match → last-occurrence tie-break → random fallback.
+
+    Returns ``(choice, is_fallback)``. ``is_fallback`` is ``True`` iff
+    nothing could be parsed out of *response* and a random choice was
+    returned — this counter is observational and doesn't change scoring
+    behavior vs. the MMMU reference eval.
+    """
+    answer_matches = re.findall(r"[Aa]nswer\s*:\s*\*?\*?\s*\(?([A-Z])\)?", response)
+    if answer_matches:
+        candidate = answer_matches[-1]
+        if candidate in all_choices:
+            return candidate, False
+
+    for char in (",", ".", "!", "?", ";", ":", "'"):
+        response = response.strip(char)
+    response = " " + response + " "
+
+    candidates: list[str] = []
+    for choice in all_choices:
+        if f"({choice})" in response:
+            candidates.append(choice)
+    if not candidates:
+        for choice in all_choices:
+            if f" {choice} " in response:
+                candidates.append(choice)
+    if not candidates and len(response.split()) > 5:
+        for idx, ans in index2ans.items():
+            if ans and ans.lower() in response.lower():
+                candidates.append(idx)
+    if not candidates:
+        return random.choice(all_choices), True
+    if len(candidates) == 1:
+        return candidates[0], False
+
+    starts: list[int] = []
+    for can in candidates:
+        pos = response.rfind(f"({can})")
+        if pos == -1:
+            pos = response.rfind(f" {can} ")
+        if pos == -1 and index2ans.get(can):
+            pos = response.lower().rfind(index2ans[can].lower())
+        starts.append(pos)
+    return candidates[max(range(len(candidates)), key=starts.__getitem__)], False

--- a/benchmarks/tasks/video_understanding.py
+++ b/benchmarks/tasks/video_understanding.py
@@ -20,7 +20,7 @@ from benchmarks.benchmarker.data import RequestResult
 from benchmarks.benchmarker.runner import SendFn
 from benchmarks.benchmarker.utils import get_wav_duration, print_accuracy_breakdown
 from benchmarks.dataset.videomme import VideoAMMESample, VideoMMESample
-from benchmarks.tasks.visual_understand import parse_multi_choice_response
+from benchmarks.metrics.accuracy import parse_multi_choice_response
 
 logger = logging.getLogger(__name__)
 

--- a/benchmarks/tasks/visual_understand.py
+++ b/benchmarks/tasks/visual_understand.py
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-"""MMMU benchmark case -- answer parsing, send_fn, metrics, and persistence."""
+"""MMMU benchmark case -- send_fn, metrics, and persistence.
+
+Answer-parsing helpers (``parse_multi_choice_response``,
+``parse_open_response``, ``eval_open``) live in
+``benchmarks.metrics.accuracy``. They are re-exported from this module
+for backwards compatibility with existing call sites.
+"""
 
 from __future__ import annotations
 
@@ -8,7 +14,6 @@ import base64
 import logging
 import os
 import random
-import re
 import time
 
 import aiohttp
@@ -16,6 +21,21 @@ import aiohttp
 from benchmarks.benchmarker.data import RequestResult
 from benchmarks.benchmarker.runner import SendFn
 from benchmarks.dataset.mmmu import MMMUSample, image_to_data_uri
+from benchmarks.metrics.accuracy import (
+    eval_open,
+    parse_multi_choice_response,
+    parse_open_response,
+)
+
+__all__ = [
+    "MULTI_CHOICE_INSTRUCTION",
+    "compute_mmmu_metrics",
+    "eval_open",
+    "make_mmmu_send_fn",
+    "parse_multi_choice_response",
+    "parse_open_response",
+    "print_mmmu_accuracy_summary",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -29,180 +49,6 @@ MULTI_CHOICE_INSTRUCTION = (
     "where LETTER is one of the options. "
     "Think step by step before answering."
 )
-
-
-def _check_is_number(s: str) -> bool:
-    try:
-        float(s.replace(",", ""))
-        return True
-    except ValueError:
-        return False
-
-
-def _normalize_str(s: str) -> list[float | str]:
-    """Normalize a string for open-ended answer comparison."""
-    s = s.strip()
-    if _check_is_number(s):
-        return [round(float(s.replace(",", "")), 2)]
-    return [s.lower()] if len(s) > 1 else [" " + s, s + " "]
-
-
-def _extract_numbers(s: str) -> list[str]:
-    """Extract all numbers (with commas, scientific notation, etc.) from *s*."""
-    pattern_commas = r"-?\b\d{1,3}(?:,\d{3})+\b"
-    pattern_scientific = r"-?\d+(?:\.\d+)?[eE][+-]?\d+"
-    pattern_simple = r"-?(?:\d+\.\d+|\.\d+|\d+\b)(?![eE][+-]?\d+)(?![,\d])"
-    return (
-        re.findall(pattern_commas, s)
-        + re.findall(pattern_scientific, s)
-        + re.findall(pattern_simple, s)
-    )
-
-
-def _parse_open_answer_tag(response: str) -> str | None:
-    """Try to extract the answer from an explicit 'Answer: ...' line.
-
-    Supports formats like ``Answer: 42``, ``Answer: MgS``,
-    ``Answer: \\boxed{13.0}``.  Returns ``None`` when no match is found.
-    """
-    matches = re.findall(
-        r"[Aa]nswer\s*:\s*\*?\*?\s*(.+)",
-        response,
-    )
-    if not matches:
-        return None
-    raw = matches[-1].strip().rstrip(".")
-    # Unwrap \boxed{...} if present
-    boxed = re.search(r"\\boxed\{(.+?)\}", raw)
-    if boxed:
-        raw = boxed.group(1)
-    # Strip surrounding ** (bold markdown)
-    raw = raw.strip("*").strip()
-    return raw if raw else None
-
-
-def parse_open_response(response: str) -> list[float | str]:
-    """Extract answer candidates from an open-ended model response.
-
-    First tries to extract from an explicit ``Answer: ...`` line.
-    Falls back to heuristic key-subresponse extraction.
-    """
-    # Fast path: explicit "Answer: ..."
-    tag_answer = _parse_open_answer_tag(response)
-    if tag_answer is not None:
-        out: list = []
-        out.extend(_normalize_str(tag_answer))
-        for num in _extract_numbers(tag_answer):
-            out.extend(_normalize_str(num))
-        return list(dict.fromkeys(out))
-
-    # Fallback: heuristic extraction
-    def _get_key_subresponses(resp: str) -> list[str]:
-        resp = resp.strip().strip(".").lower()
-        subs = re.split(r"\.\s(?=[A-Z])|\n", resp)
-        indicators = [
-            "could be ",
-            "so ",
-            "is ",
-            "thus ",
-            "therefore ",
-            "final ",
-            "answer ",
-            "result ",
-        ]
-        keys: list[str] = []
-        for i, s in enumerate(subs):
-            cands = indicators + ["="] if i == len(subs) - 1 else indicators
-            shortest = None
-            for ind in cands:
-                if ind in s:
-                    part = s.split(ind)[-1].strip()
-                    if not shortest or len(part) < len(shortest):
-                        shortest = part
-            if shortest and shortest not in (":", ",", ".", "!", "?", ";", "'"):
-                keys.append(shortest)
-        return keys or [resp]
-
-    key_resps = _get_key_subresponses(response)
-    pred_list = key_resps.copy()
-    for r in key_resps:
-        pred_list.extend(_extract_numbers(r))
-    out = []
-    for x in pred_list:
-        out.extend(_normalize_str(x))
-    return list(dict.fromkeys(out))
-
-
-def eval_open(gold: str | list[str], preds: list[float | str]) -> bool:
-    """Check if any prediction matches the gold answer (fuzzy)."""
-    if isinstance(gold, list):
-        norm_answers: list = []
-        for ans in gold:
-            norm_answers.extend(_normalize_str(ans))
-    else:
-        norm_answers = _normalize_str(gold)
-    for p in preds:
-        if isinstance(p, str):
-            for na in norm_answers:
-                if isinstance(na, str) and na in p:
-                    return True
-        else:
-            if p in norm_answers:
-                return True
-    return False
-
-
-def parse_multi_choice_response(
-    response: str,
-    all_choices: list[str],
-    index2ans: dict[str, str],
-) -> tuple[str, bool]:
-    """Extract a single answer letter from the model response.
-
-    Priority: ``Answer: X`` → ``(A)`` bracket → ``·A·`` space-padded →
-    option-text match → last-occurrence tie-break → random fallback.
-
-    Returns ``(choice, is_fallback)``. ``is_fallback`` is ``True`` iff
-    nothing could be parsed out of *response* and a random choice was
-    returned — this counter is observational and doesn't change scoring
-    behavior vs. the MMMU reference eval.
-    """
-    answer_matches = re.findall(r"[Aa]nswer\s*:\s*\*?\*?\s*\(?([A-Z])\)?", response)
-    if answer_matches:
-        candidate = answer_matches[-1]
-        if candidate in all_choices:
-            return candidate, False
-
-    for char in (",", ".", "!", "?", ";", ":", "'"):
-        response = response.strip(char)
-    response = " " + response + " "
-
-    candidates: list[str] = []
-    for choice in all_choices:
-        if f"({choice})" in response:
-            candidates.append(choice)
-    if not candidates:
-        for choice in all_choices:
-            if f" {choice} " in response:
-                candidates.append(choice)
-    if not candidates and len(response.split()) > 5:
-        for idx, ans in index2ans.items():
-            if ans and ans.lower() in response.lower():
-                candidates.append(idx)
-    if not candidates:
-        return random.choice(all_choices), True
-    if len(candidates) == 1:
-        return candidates[0], False
-
-    starts: list[int] = []
-    for can in candidates:
-        pos = response.rfind(f"({can})")
-        if pos == -1:
-            pos = response.rfind(f" {can} ")
-        if pos == -1 and index2ans.get(can):
-            pos = response.lower().rfind(index2ans[can].lower())
-        starts.append(pos)
-    return candidates[max(range(len(candidates)), key=starts.__getitem__)], False
 
 
 def make_mmmu_send_fn(

--- a/tests/test_metrics_accuracy.py
+++ b/tests/test_metrics_accuracy.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for benchmarks.metrics.accuracy.
+
+These tests pin behaviour of the answer-parsing helpers that previously
+lived in ``benchmarks.tasks.visual_understand``. They serve as a guard
+against accidental drift while metric logic is being consolidated under
+``benchmarks/metrics/`` (RFC: sgl-project/sglang-omni#360).
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from benchmarks.metrics.accuracy import (
+    INDEX_TO_LETTER,
+    eval_open,
+    extract_answer_letter,
+    parse_multi_choice_response,
+    parse_open_response,
+)
+
+
+class TestExtractAnswerLetter:
+    def test_bare_letter(self) -> None:
+        assert extract_answer_letter("B") == 1
+        assert extract_answer_letter("b.") == 1
+        assert extract_answer_letter("C) something") == 2
+
+    def test_phrase_forms(self) -> None:
+        assert extract_answer_letter("The answer is A") == 0
+        assert extract_answer_letter("answer: D") == 3
+        assert extract_answer_letter("Option C") == 2
+
+    def test_does_not_match_word_boundary(self) -> None:
+        # "Because..." should not match "B"
+        assert extract_answer_letter("Because the option is wrong") is None
+
+    def test_empty_or_whitespace(self) -> None:
+        assert extract_answer_letter("") is None
+        assert extract_answer_letter("   ") is None
+
+    def test_index_letter_roundtrip(self) -> None:
+        for letter, idx in (("A", 0), ("B", 1), ("C", 2), ("D", 3)):
+            assert INDEX_TO_LETTER[idx] == letter
+
+
+class TestParseMultiChoiceResponse:
+    def _index2ans(self, choices: list[str]) -> dict[str, str]:
+        return {c: f"option-text-{c}" for c in choices}
+
+    def test_explicit_answer_line(self) -> None:
+        choices = ["A", "B", "C", "D"]
+        choice, fallback = parse_multi_choice_response(
+            "Reasoning here. Answer: B",
+            choices,
+            self._index2ans(choices),
+        )
+        assert choice == "B"
+        assert fallback is False
+
+    def test_bracketed_letter(self) -> None:
+        choices = ["A", "B", "C", "D"]
+        choice, fallback = parse_multi_choice_response(
+            "I think it is (C) for the reason that...",
+            choices,
+            self._index2ans(choices),
+        )
+        assert choice == "C"
+        assert fallback is False
+
+    def test_space_padded_letter(self) -> None:
+        choices = ["A", "B", "C", "D"]
+        choice, fallback = parse_multi_choice_response(
+            "the choice should be A here",
+            choices,
+            self._index2ans(choices),
+        )
+        assert choice == "A"
+        assert fallback is False
+
+    def test_option_text_match_with_long_response(self) -> None:
+        choices = ["A", "B", "C", "D"]
+        index2ans = {
+            "A": "alpha",
+            "B": "bravo signal",
+            "C": "charlie",
+            "D": "delta",
+        }
+        choice, fallback = parse_multi_choice_response(
+            "After careful reasoning the bravo signal is correct here",
+            choices,
+            index2ans,
+        )
+        assert choice == "B"
+        assert fallback is False
+
+    def test_random_fallback_signalled(self) -> None:
+        # Stable seed → deterministic fallback choice
+        random.seed(0)
+        choices = ["A", "B", "C", "D"]
+        choice, fallback = parse_multi_choice_response(
+            "asdf",
+            choices,
+            {c: "" for c in choices},
+        )
+        assert choice in choices
+        assert fallback is True
+
+    def test_last_occurrence_tie_break(self) -> None:
+        # Two bracketed letters; later position wins
+        choices = ["A", "B", "C", "D"]
+        choice, fallback = parse_multi_choice_response(
+            "First (A), but actually (C) is correct.",
+            choices,
+            self._index2ans(choices),
+        )
+        assert choice == "C"
+        assert fallback is False
+
+
+class TestParseOpenResponse:
+    def test_explicit_answer_tag(self) -> None:
+        out = parse_open_response("Reasoning. Answer: 42")
+        assert 42.0 in out
+
+    def test_answer_tag_with_boxed(self) -> None:
+        out = parse_open_response(r"Steps... Answer: \boxed{13.0}")
+        assert 13.0 in out
+
+    def test_answer_tag_text(self) -> None:
+        out = parse_open_response("Answer: MgS")
+        assert "mgs" in out
+
+    def test_extracts_number_with_commas(self) -> None:
+        out = parse_open_response("Answer: 1,234")
+        assert 1234.0 in out
+
+    def test_falls_back_to_heuristic_when_no_tag(self) -> None:
+        # No "Answer:" line; heuristic should still surface candidates
+        out = parse_open_response("So the result is 7.")
+        assert out  # non-empty
+        assert any(p == 7.0 or (isinstance(p, str) and "7" in p) for p in out)
+
+
+class TestEvalOpen:
+    def test_string_match(self) -> None:
+        assert eval_open("hello", ["this contains hello somewhere"]) is True
+
+    def test_number_exact_match(self) -> None:
+        assert eval_open("42", [42.0]) is True
+
+    def test_no_match(self) -> None:
+        assert eval_open("dog", ["cat", "fish"]) is False
+
+    def test_list_of_acceptable_answers(self) -> None:
+        assert eval_open(["foo", "bar"], ["the bar is set high"]) is True
+
+
+@pytest.mark.parametrize(
+    "response,expected_idx",
+    [
+        ("A", 0),
+        ("B.", 1),
+        ("C)", 2),
+        ("D ", 3),
+        ("The answer is A", 0),
+        ("answer: D", 3),
+        ("Option C", 2),
+    ],
+)
+def test_extract_answer_letter_table(response: str, expected_idx: int) -> None:
+    assert extract_answer_letter(response) == expected_idx


### PR DESCRIPTION
## Motivation

This is the first exploratory slice of the metric-consolidation refactor proposed in #360.

That RFC argues `benchmarks/metrics/` should own metric **computation** and **presentation**, while `benchmarks/tasks/` should own per-sample **execution**. Today most metric helpers live inside `tasks/*.py`, and new benchmarks naturally inherit that pattern, which entrenches the layout further.

This PR ships the smallest demonstrable migration: the MMMU answer-parsing helpers move from `benchmarks/tasks/visual_understand.py` into `benchmarks/metrics/accuracy.py`. The intent is to land a concrete example that the per-task migration plan in #360 can follow, and to surface any layout / API / shim-policy concerns on a small diff before larger moves (`tasks/tts.py` WER + speed summaries are next).

Marked **WIP** because the broader audit (file-by-file, metric-vs-glue) and the migration shape are still under discussion on the issue.

## Modifications

- `benchmarks/metrics/accuracy.py`
  - Adds `parse_multi_choice_response`, `parse_open_response`, `eval_open` as public API.
  - Adds private helpers `_check_is_number`, `_normalize_str`, `_extract_numbers`, `_parse_open_answer_tag`.
  - Function bodies are copied verbatim from `tasks/visual_understand.py` — no behavioural change.
- `benchmarks/tasks/visual_understand.py`
  - Drops the moved helpers.
  - Re-exports the three public parsers from `benchmarks.metrics.accuracy` as a one-release backwards-compat shim, with `__all__` declared.
  - Stops importing `re` (now unused locally); keeps `random` (still used in `compute_mmmu_metrics`).
- `benchmarks/tasks/video_understanding.py`
  - Switches `from benchmarks.tasks.visual_understand import parse_multi_choice_response` to import from `benchmarks.metrics.accuracy` directly.
- `tests/test_metrics_accuracy.py` (new, 27 unit tests)
  - Pins the parsing behaviour: `extract_answer_letter` table; multi-choice bracket / space-padded / option-text / random-fallback paths and last-occurrence tie-break; open-answer tag / `\boxed{…}` / number-with-commas extraction; `eval_open` string and numeric matching.
  - Pure-Python, no GPU, runs under the existing default `pytest -m "not benchmark and not docs"` filter.

Net diff: +387 / −178 across 3 modified files + 1 new test file.

## Related Issues

Refs #360 (RFC: Consolidate metric computation under `benchmarks/metrics/`).

This PR addresses the "PR1 / foundation slice" from the migration plan discussed there. Subsequent PRs are expected to migrate WER + speed summaries from `tasks/tts.py`, and accuracy summaries from `tasks/{video,audio,visual}_understanding.py`, one task per PR.

## Accuracy Test

N/A — pure code reorganisation. The MMMU and Video-MME accuracy paths call the same function bodies as before; only the import paths change. Behavioural equivalence is asserted at unit-test granularity (27 tests, all green locally).

## Benchmark & Profiling

N/A — same caveat. No model-side or hot-path changes.

## Verification (local)

- `python -m py_compile` on all 4 touched files: pass
- `PYTHONPATH=$PWD pytest tests/test_metrics_accuracy.py -v`: 27/27 passed
- `pytest --collect-only` across `tests/`: collects cleanly (no conftest breakage)
- `grep` for stale references to the removed private helpers in `tasks/`: none
- `pre-commit run --files <touched files>`: all hooks pass (autoflake / isort / ruff / black / AST checks)
- Codex adversarial review on the working-tree diff: **approve**, no material findings.

GPU-backed end-to-end accuracy parity is left to the project's `pytest -m benchmark` CI runners after merge — function bodies are byte-identical to pre-refactor, so no numerical drift is expected.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed. *(N/A — pure refactor, no measurable impact.)*
