### PR TITLE
[CI] Add RUN CI Trigger Rules

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,3 +27,9 @@
 - [ ] Update documentation / docstrings / example tutorials as needed.
 - [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
 - [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
+
+## CI
+
+CI runs on self-hosted GPU runners and requires a maintainer to add the
+`run-ci` label. Once labeled, every subsequent push re-triggers CI as
+long as the label remains. Draft PRs are skipped even if labeled.

--- a/.github/workflows/cancel-pr-workflow-on-merge.yaml
+++ b/.github/workflows/cancel-pr-workflow-on-merge.yaml
@@ -1,0 +1,42 @@
+name: Cancel PR Workflow On Merge
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  actions: write
+  pull-requests: read
+
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel in-flight workflow runs for the closed PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const headSha = context.payload.pull_request.head.sha;
+            const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: headSha,
+              per_page: 100,
+            });
+            let cancelled = 0;
+            for (const run of runs.workflow_runs) {
+              if (['queued', 'in_progress', 'waiting', 'pending', 'requested'].includes(run.status)) {
+                console.log(`Cancelling ${run.name} (run_id=${run.id}, status=${run.status})`);
+                try {
+                  await github.rest.actions.cancelWorkflowRun({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: run.id,
+                  });
+                  cancelled++;
+                } catch (e) {
+                  console.log(`  failed to cancel: ${e.message}`);
+                }
+              }
+            }
+            console.log(`Cancelled ${cancelled} in-flight run(s) for PR #${context.payload.pull_request.number}`);

--- a/.github/workflows/test-examples.yaml
+++ b/.github/workflows/test-examples.yaml
@@ -3,6 +3,7 @@ name: PR Test (Examples)
 on:
   pull_request:
     branches: [ main ]
+    types: [labeled, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:
@@ -14,6 +15,10 @@ permissions:
 
 jobs:
   unit-test:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft &&
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     runs-on: [self-hosted]
     container:
       image: frankleeeee/sglang-omni:dev # we lock to this version to avoid repeated docker pull

--- a/.github/workflows/test-examples.yaml
+++ b/.github/workflows/test-examples.yaml
@@ -15,6 +15,8 @@ permissions:
 
 jobs:
   unit-test:
+    # CI gate — runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
+    # Keep in sync with the same gate in test.yaml / test-qwen3-omni-ci.yaml / test-s2pro-ci.yaml.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (!github.event.pull_request.draft &&

--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -3,6 +3,7 @@ name: Qwen3-Omni CI
 on:
   pull_request:
     branches: [main]
+    types: [labeled, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:
@@ -26,6 +27,10 @@ permissions:
 jobs:
   docs:
     name: docs
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft &&
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     runs-on: [self-hosted]
     timeout-minutes: 15
     container:

--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -27,6 +27,8 @@ permissions:
 jobs:
   docs:
     name: docs
+    # CI gate — runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
+    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (!github.event.pull_request.draft &&

--- a/.github/workflows/test-s2pro-ci.yaml
+++ b/.github/workflows/test-s2pro-ci.yaml
@@ -21,6 +21,8 @@ permissions:
 jobs:
   docs:
     name: docs
+    # CI gate — runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
+    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-qwen3-omni-ci.yaml.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (!github.event.pull_request.draft &&

--- a/.github/workflows/test-s2pro-ci.yaml
+++ b/.github/workflows/test-s2pro-ci.yaml
@@ -3,6 +3,7 @@ name: S2-Pro CI
 on:
   pull_request:
     branches: [main]
+    types: [labeled, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:
@@ -20,6 +21,10 @@ permissions:
 jobs:
   docs:
     name: docs
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft &&
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     runs-on: [self-hosted]
     timeout-minutes: 10
     container:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,7 @@ name: PR Test
 on:
   pull_request:
     branches: [ main ]
+    types: [labeled, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:
@@ -14,6 +15,10 @@ permissions:
 
 jobs:
   unit-test:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft &&
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     runs-on: [self-hosted]
     container:
       image: frankleeeee/sglang-omni:dev # we lock to this version to avoid repeated docker pull

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,8 @@ permissions:
 
 jobs:
   unit-test:
+    # CI gate — runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
+    # Keep in sync with the same gate in test-examples.yaml / test-qwen3-omni-ci.yaml / test-s2pro-ci.yaml.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (!github.event.pull_request.draft &&

--- a/tests/test_model/test_qwen3_omni_videoamme_ci.py
+++ b/tests/test_model/test_qwen3_omni_videoamme_ci.py
@@ -26,7 +26,7 @@ from tests.utils import ServerHandle, apply_slack, assert_speed_thresholds
 CONCURRENCY = 16
 MAX_SAMPLES = 30
 
-# threshold reference: https://github.com/sgl-project/sglang-omni/pull/363#issuecomment-4323126404
+# threshold reference: https://github.com/sgl-project/sglang-omni/pull/367#issue-4333687689
 VIDEOAMME_MIN_ACCURACY = 0.60
 
 _VIDEOAMME_P95 = {

--- a/tests/test_model/test_qwen3_omni_videoamme_ci.py
+++ b/tests/test_model/test_qwen3_omni_videoamme_ci.py
@@ -24,15 +24,16 @@ from benchmarks.tasks.video_understanding import print_videomme_accuracy_summary
 from tests.utils import ServerHandle, apply_slack, assert_speed_thresholds
 
 CONCURRENCY = 16
+MAX_SAMPLES = 30
 
 # threshold reference: https://github.com/sgl-project/sglang-omni/pull/363#issuecomment-4323126404
-VIDEOAMME_MIN_ACCURACY = 0.68
+VIDEOAMME_MIN_ACCURACY = 0.60
 
 _VIDEOAMME_P95 = {
     16: {
-        "throughput_qps": 0.132,
+        "throughput_qps": 0.128,
         "tok_per_s_agg": 0.4,
-        "latency_mean_s": 119.004,
+        "latency_mean_s": 118.437,
     },
 }
 VIDEOAMME_THRESHOLDS = apply_slack(_VIDEOAMME_P95)
@@ -43,10 +44,11 @@ def test_videoamme_accuracy_and_speed(
     qwen3_omni_thinker_server: ServerHandle,
     tmp_path: Path,
 ) -> None:
-    """Run videoamme-ci-50 at concurrency=8 and report accuracy + speed."""
+    """Run first 30 of videoamme-ci-50 at concurrency=16 and report accuracy + speed."""
     config = VideoEvalConfig(
         model="qwen3-omni",
         port=qwen3_omni_thinker_server.port,
+        max_samples=MAX_SAMPLES,
         max_concurrency=CONCURRENCY,
         output_dir=str(tmp_path / "videoamme"),
         repo_id=DATASETS["videoamme-ci-50"],

--- a/tests/test_model/test_qwen3_omni_videomme_ci.py
+++ b/tests/test_model/test_qwen3_omni_videomme_ci.py
@@ -27,7 +27,7 @@ from tests.utils import ServerHandle, apply_slack, assert_speed_thresholds
 CONCURRENCY = 16
 MAX_SAMPLES = 30
 
-# threshold reference: https://github.com/sgl-project/sglang-omni/pull/337#issuecomment-4321084941
+# threshold reference: https://github.com/sgl-project/sglang-omni/pull/367#issue-4333687689
 VIDEOMME_MIN_ACCURACY = 0.53
 
 _VIDEOMME_P95 = {

--- a/tests/test_model/test_qwen3_omni_videomme_ci.py
+++ b/tests/test_model/test_qwen3_omni_videomme_ci.py
@@ -25,15 +25,16 @@ from benchmarks.tasks.video_understanding import print_videomme_accuracy_summary
 from tests.utils import ServerHandle, apply_slack, assert_speed_thresholds
 
 CONCURRENCY = 16
+MAX_SAMPLES = 30
 
 # threshold reference: https://github.com/sgl-project/sglang-omni/pull/337#issuecomment-4321084941
-VIDEOMME_MIN_ACCURACY = 0.56
+VIDEOMME_MIN_ACCURACY = 0.53
 
 _VIDEOMME_P95 = {
     16: {
-        "throughput_qps": 0.145,
-        "tok_per_s_agg": 1.10,
-        "latency_mean_s": 105.247,
+        "throughput_qps": 0.127,
+        "tok_per_s_agg": 0.90,
+        "latency_mean_s": 121.264,
     },
 }
 VIDEOMME_THRESHOLDS = apply_slack(_VIDEOMME_P95)
@@ -44,10 +45,11 @@ def test_videomme_accuracy_and_speed(
     qwen3_omni_thinker_server: ServerHandle,
     tmp_path: Path,
 ) -> None:
-    """Run videomme-ci-50 at concurrency=16 and report accuracy + speed."""
+    """Run first 30 of videomme-ci-50 at concurrency=16 and report accuracy + speed."""
     config = VideoEvalConfig(
         model="qwen3-omni",
         port=qwen3_omni_thinker_server.port,
+        max_samples=MAX_SAMPLES,
         max_concurrency=CONCURRENCY,
         output_dir=str(tmp_path / "videomme"),
         repo_id=DATASETS["videomme-ci-50"],


### PR DESCRIPTION
## Summary                                                                                                                  
                                                                                                                            
  This PR makes two CI-related changes:                                                                                       
                                                                                                                              
  ### 1. Reduce VideoMME / Video-AMME CI sample size: 50 → 30
                                                                                                                              
  To speed up the GPU CI pipeline, the thinker-only Video-MME and Video-AMME tests now run on the first 30 samples (down from 50). Thresholds re-calibrated against worst-of-5 on H20 at 30 samples, c=16:                                                
                                                                                   
  - `VIDEOMME_MIN_ACCURACY`: 0.56 → **0.53**; `_VIDEOMME_P95`: qps 0.145→**0.127**, tok/s 1.10→**0.90**, latency              
  105.247→**121.264**                  
  - `VIDEOAMME_MIN_ACCURACY`: 0.68 → **0.60**; `_VIDEOAMME_P95`: qps 0.132→**0.128**, latency 119.004→**118.437**             
                                                                                   
  ### 2. Reduce redundant CI triggers                                                                                         
                                                                                                                              
  Three rules added to the GPU CI workflows (`test-qwen3-omni-ci.yaml`, `test-s2pro-ci.yaml`, `test-examples.yaml`,
  `test.yaml`):                                                                                                               
                                                                                                                              
  1. **Auto-cancel in-flight runs on PR merge/close** — new `cancel-pr-workflow-on-merge.yaml` listens to                     
  `pull_request_target: closed` and cancels any queued / in-progress runs for that PR.                                        
  2. **`run-ci` label gate** — workflows only fire when the PR carries the `run-ci` label. Once labeled, every subsequent push
   triggers CI as long as the label remains. Maintainers add the label via PR sidebar or `gh pr edit <PR#> --add-label
  run-ci`.                                                                                                                    
  3. **Block draft PRs** — `if: !github.event.pull_request.draft` skips CI while the PR is in draft, even if labeled.         
                                         
  `workflow_dispatch` (manual trigger via Actions UI / `gh workflow run`) remains available and bypasses the gate.            
                                                                                                                              
  ### Required one-time setup before merging
                                                                                                                              
  Create the `run-ci` label in the repo (Settings → Labels → New label).