### PR TITLE
[Benchmark]: Consolidate benchmark metric ownership

### DIFF
--- a/benchmarks/benchmarker/utils.py
+++ b/benchmarks/benchmarker/utils.py
@@ -10,7 +10,6 @@ import os
 import struct
 import subprocess
 import time
-from typing import Any
 
 import requests as requests_lib
 
@@ -19,7 +18,6 @@ logger = logging.getLogger(__name__)
 WAV_HEADER_SIZE = 44
 SSE_DATA_PREFIX = "data: "
 SSE_DONE_MARKER = "data: [DONE]"
-DEFAULT_BREAKDOWN_KEY_WIDTH = 14
 
 
 def get_wav_duration(wav_bytes: bytes) -> float:
@@ -107,20 +105,3 @@ def save_json_results(results: dict, output_dir: str, filename: str) -> str:
         json.dump(results, f, indent=2, ensure_ascii=False)
     logger.info(f"Results saved to {path}")
     return path
-
-
-def print_accuracy_breakdown(
-    title: str,
-    breakdown: dict[str, dict[str, Any]],
-    *,
-    key_width: int = DEFAULT_BREAKDOWN_KEY_WIDTH,
-) -> None:
-    """Print a correct/total (accuracy%) table for a per-bucket breakdown."""
-    if not breakdown:
-        return
-    print(f"  {title}:")
-    for key, stat in breakdown.items():
-        print(
-            f"    {key:<{key_width}} {stat['correct']}/{stat['total']} "
-            f"({stat['accuracy'] * 100:.1f}%)"
-        )

--- a/benchmarks/eval/benchmark_omni_mmmu.py
+++ b/benchmarks/eval/benchmark_omni_mmmu.py
@@ -151,8 +151,8 @@ async def run_mmmu_eval(config: MMMUEvalConfig) -> dict:
     )
     request_results = await runner.run(samples, send_fn)
 
-    per_sample, mc_fallback = build_mmmu_result_records(samples, request_results)
-    summary, per_sample = compute_mmmu_metrics(per_sample, mc_fallback)
+    per_sample = build_mmmu_result_records(samples, request_results)
+    summary = compute_mmmu_metrics(per_sample)
     speed_metrics = compute_speed_metrics(
         request_results, wall_clock_s=runner.wall_clock_s
     )

--- a/benchmarks/eval/benchmark_omni_mmmu.py
+++ b/benchmarks/eval/benchmark_omni_mmmu.py
@@ -68,16 +68,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from benchmarks.benchmarker.runner import BenchmarkRunner, RunConfig
 from benchmarks.benchmarker.utils import save_json_results, wait_for_service
 from benchmarks.dataset.mmmu import load_mmmu_samples
-from benchmarks.metrics.performance import compute_speed_metrics
-from benchmarks.tasks.tts import (
-    compute_text_audio_consistency,
-    print_speed_summary,
-    print_wer_summary,
-)
+from benchmarks.metrics.mmmu import compute_mmmu_metrics, print_mmmu_accuracy_summary
+from benchmarks.metrics.performance import compute_speed_metrics, print_speed_summary
+from benchmarks.metrics.wer import print_wer_summary
+from benchmarks.tasks.tts import compute_text_audio_consistency
 from benchmarks.tasks.visual_understand import (
-    compute_mmmu_metrics,
+    build_mmmu_result_records,
     make_mmmu_send_fn,
-    print_mmmu_accuracy_summary,
 )
 
 logging.basicConfig(
@@ -154,7 +151,8 @@ async def run_mmmu_eval(config: MMMUEvalConfig) -> dict:
     )
     request_results = await runner.run(samples, send_fn)
 
-    summary, per_sample = compute_mmmu_metrics(samples, request_results)
+    per_sample, mc_fallback = build_mmmu_result_records(samples, request_results)
+    summary, per_sample = compute_mmmu_metrics(per_sample, mc_fallback)
     speed_metrics = compute_speed_metrics(
         request_results, wall_clock_s=runner.wall_clock_s
     )

--- a/benchmarks/eval/benchmark_omni_mmsu.py
+++ b/benchmarks/eval/benchmark_omni_mmsu.py
@@ -93,15 +93,15 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from benchmarks.benchmarker.runner import BenchmarkRunner, RunConfig
 from benchmarks.benchmarker.utils import wait_for_service
 from benchmarks.dataset.mmsu import MmsuSample, load_mmsu_samples
+from benchmarks.metrics.mmsu import compute_mmsu_metrics, print_mmsu_summary
 from benchmarks.metrics.performance import compute_speed_metrics
+from benchmarks.metrics.wer import print_wer_summary
 from benchmarks.tasks.audio_understanding import (
     build_mmsu_results,
-    compute_mmsu_metrics,
     make_mmsu_send_fn,
-    print_mmsu_summary,
     save_mmsu_results,
 )
-from benchmarks.tasks.tts import compute_text_audio_consistency, print_wer_summary
+from benchmarks.tasks.tts import compute_text_audio_consistency
 
 logging.basicConfig(
     level=logging.INFO,

--- a/benchmarks/eval/benchmark_omni_seedtts.py
+++ b/benchmarks/eval/benchmark_omni_seedtts.py
@@ -116,12 +116,14 @@ from benchmarks.benchmarker.utils import (
     wait_for_service,
 )
 from benchmarks.dataset.seedtts import SampleInput, load_seedtts_samples
-from benchmarks.metrics.performance import compute_speed_metrics
+from benchmarks.metrics.performance import (
+    build_speed_results,
+    compute_speed_metrics,
+    print_speed_summary,
+)
 from benchmarks.tasks.tts import (
     VoiceCloneOmni,
     build_base_url,
-    build_speed_results,
-    print_speed_summary,
     run_seedtts_transcribe,
     save_generated_audio_metadata,
     save_speed_results,

--- a/benchmarks/eval/benchmark_omni_videoamme.py
+++ b/benchmarks/eval/benchmark_omni_videoamme.py
@@ -69,11 +69,10 @@ from benchmarks.eval.benchmark_omni_videomme import (
     run_video_eval,
     video_eval_config_from_args,
 )
-from benchmarks.tasks.tts import print_speed_summary, print_wer_summary
-from benchmarks.tasks.video_understanding import (
-    VIDEOAMME_REQUEST_TEXT,
-    print_videomme_accuracy_summary,
-)
+from benchmarks.metrics.performance import print_speed_summary
+from benchmarks.metrics.video import print_videomme_accuracy_summary
+from benchmarks.metrics.wer import print_wer_summary
+from benchmarks.tasks.video_understanding import VIDEOAMME_REQUEST_TEXT
 
 logging.basicConfig(
     level=logging.INFO,

--- a/benchmarks/eval/benchmark_omni_videomme.py
+++ b/benchmarks/eval/benchmark_omni_videomme.py
@@ -178,8 +178,8 @@ async def run_video_eval(
     )
     request_results = await runner.run(samples, send_fn)
 
-    per_sample, mc_fallback = build_videomme_result_records(samples, request_results)
-    summary, per_sample = compute_videomme_metrics(per_sample, mc_fallback)
+    per_sample = build_videomme_result_records(samples, request_results)
+    summary = compute_videomme_metrics(per_sample)
     speed = compute_speed_metrics(request_results, wall_clock_s=runner.wall_clock_s)
     results = {
         "summary": summary,

--- a/benchmarks/eval/benchmark_omni_videomme.py
+++ b/benchmarks/eval/benchmark_omni_videomme.py
@@ -77,16 +77,16 @@ from benchmarks.benchmarker.runner import BenchmarkRunner, RunConfig
 from benchmarks.benchmarker.utils import save_json_results, wait_for_service
 from benchmarks.dataset.videomme import DEFAULT_REPO_ID as _VIDEOMME_DEFAULT_REPO
 from benchmarks.dataset.videomme import VideoMMESample, load_videomme_samples
-from benchmarks.metrics.performance import compute_speed_metrics
-from benchmarks.tasks.tts import (
-    compute_text_audio_consistency,
-    print_speed_summary,
-    print_wer_summary,
-)
-from benchmarks.tasks.video_understanding import (
+from benchmarks.metrics.performance import compute_speed_metrics, print_speed_summary
+from benchmarks.metrics.video import (
     compute_videomme_metrics,
-    make_video_send_fn,
     print_videomme_accuracy_summary,
+)
+from benchmarks.metrics.wer import print_wer_summary
+from benchmarks.tasks.tts import compute_text_audio_consistency
+from benchmarks.tasks.video_understanding import (
+    build_videomme_result_records,
+    make_video_send_fn,
 )
 
 logging.basicConfig(
@@ -178,7 +178,8 @@ async def run_video_eval(
     )
     request_results = await runner.run(samples, send_fn)
 
-    summary, per_sample = compute_videomme_metrics(samples, request_results)
+    per_sample, mc_fallback = build_videomme_result_records(samples, request_results)
+    summary, per_sample = compute_videomme_metrics(per_sample, mc_fallback)
     speed = compute_speed_metrics(request_results, wall_clock_s=runner.wall_clock_s)
     results = {
         "summary": summary,

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -119,12 +119,14 @@ from dataclasses import dataclass
 from benchmarks.benchmarker.runner import BenchmarkRunner, RunConfig
 from benchmarks.benchmarker.utils import wait_for_service
 from benchmarks.dataset.seedtts import load_seedtts_samples
-from benchmarks.metrics.performance import compute_speed_metrics
+from benchmarks.metrics.performance import (
+    build_speed_results,
+    compute_speed_metrics,
+    print_speed_summary,
+)
 from benchmarks.tasks.tts import (
     build_base_url,
-    build_speed_results,
     make_tts_send_fn,
-    print_speed_summary,
     run_seedtts_transcribe,
     save_generated_audio_metadata,
     save_speed_results,

--- a/benchmarks/metrics/_format.py
+++ b/benchmarks/metrics/_format.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared metric presentation formatting."""
+
+from __future__ import annotations
+
+from typing import Any
+
+ACCURACY_LABEL_WIDTH = 28
+ACCURACY_LINE_WIDTH = 50
+SPEED_LABEL_WIDTH = 30
+SPEED_LINE_WIDTH = 60
+BREAKDOWN_KEY_WIDTH = 14
+MMSU_CATEGORY_WIDTH = 18
+
+
+def print_accuracy_breakdown(
+    title: str,
+    breakdown: dict[str, dict[str, Any]],
+    *,
+    key_width: int = BREAKDOWN_KEY_WIDTH,
+) -> None:
+    """Print a correct/total (accuracy%) table for a per-bucket breakdown."""
+    if not breakdown:
+        return
+    print(f"  {title}:")
+    for key, stat in breakdown.items():
+        print(
+            f"    {key:<{key_width}} {stat['correct']}/{stat['total']} "
+            f"({stat['accuracy'] * 100:.1f}%)"
+        )

--- a/benchmarks/metrics/mmmu.py
+++ b/benchmarks/metrics/mmmu.py
@@ -3,18 +3,16 @@
 
 from __future__ import annotations
 
-SUMMARY_LABEL_WIDTH = 28
-SUMMARY_LINE_WIDTH = 50
+from typing import TYPE_CHECKING
+
+from benchmarks.metrics._format import ACCURACY_LABEL_WIDTH, ACCURACY_LINE_WIDTH
+
+if TYPE_CHECKING:
+    from benchmarks.tasks.visual_understand import MMMURecord
 
 
-def compute_mmmu_metrics(
-    per_sample: list[dict],
-    mc_fallback: int,
-) -> tuple[dict, list[dict]]:
-    """Aggregate already-decided MMMU per-sample result records.
-
-    Returns ``(summary_dict, per_sample_list)``.
-    """
+def compute_mmmu_metrics(per_sample: list["MMMURecord"]) -> dict:
+    """Aggregate already-decided MMMU per-sample result records."""
     correct = sum(1 for record in per_sample if record["is_correct"])
     failed = sum(1 for record in per_sample if not record["is_success"])
     total = len(per_sample)
@@ -25,17 +23,17 @@ def compute_mmmu_metrics(
         "correct": correct,
         "accuracy": round(accuracy, 4),
         "failed": failed,
-        "mc_fallback": mc_fallback,
+        "mc_fallback": sum(record["is_mc_fallback"] for record in per_sample),
     }
-    return summary, per_sample
+    return summary
 
 
 def print_mmmu_accuracy_summary(metrics: dict, model_name: str) -> None:
     """Print formatted MMMU accuracy summary to stdout."""
-    lw = SUMMARY_LABEL_WIDTH
-    print(f"\n{'=' * SUMMARY_LINE_WIDTH}")
+    lw = ACCURACY_LABEL_WIDTH
+    print(f"\n{'=' * ACCURACY_LINE_WIDTH}")
     print(f"  MMMU Accuracy — {model_name}")
-    print(f"{'=' * SUMMARY_LINE_WIDTH}")
+    print(f"{'=' * ACCURACY_LINE_WIDTH}")
     print(f"  {'Total samples:':<{lw}} {metrics['total_samples']}")
     print(f"  {'Correct:':<{lw}} {metrics['correct']}")
     print(
@@ -44,4 +42,4 @@ def print_mmmu_accuracy_summary(metrics: dict, model_name: str) -> None:
     )
     print(f"  {'Failed requests:':<{lw}} {metrics['failed']}")
     print(f"  {'MC parse fallback:':<{lw}} {metrics['mc_fallback']}")
-    print(f"{'=' * SUMMARY_LINE_WIDTH}\n")
+    print(f"{'=' * ACCURACY_LINE_WIDTH}\n")

--- a/benchmarks/metrics/mmmu.py
+++ b/benchmarks/metrics/mmmu.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MMMU accuracy metrics and presentation."""
+
+from __future__ import annotations
+
+SUMMARY_LABEL_WIDTH = 28
+SUMMARY_LINE_WIDTH = 50
+
+
+def compute_mmmu_metrics(
+    per_sample: list[dict],
+    mc_fallback: int,
+) -> tuple[dict, list[dict]]:
+    """Aggregate already-decided MMMU per-sample result records.
+
+    Returns ``(summary_dict, per_sample_list)``.
+    """
+    correct = sum(1 for record in per_sample if record["is_correct"])
+    failed = sum(1 for record in per_sample if not record["is_success"])
+    total = len(per_sample)
+    accuracy = correct / total if total > 0 else 0.0
+
+    summary = {
+        "total_samples": total,
+        "correct": correct,
+        "accuracy": round(accuracy, 4),
+        "failed": failed,
+        "mc_fallback": mc_fallback,
+    }
+    return summary, per_sample
+
+
+def print_mmmu_accuracy_summary(metrics: dict, model_name: str) -> None:
+    """Print formatted MMMU accuracy summary to stdout."""
+    lw = SUMMARY_LABEL_WIDTH
+    print(f"\n{'=' * SUMMARY_LINE_WIDTH}")
+    print(f"  MMMU Accuracy — {model_name}")
+    print(f"{'=' * SUMMARY_LINE_WIDTH}")
+    print(f"  {'Total samples:':<{lw}} {metrics['total_samples']}")
+    print(f"  {'Correct:':<{lw}} {metrics['correct']}")
+    print(
+        f"  {'Accuracy:':<{lw}} {metrics['accuracy']:.4f} "
+        f"({metrics['accuracy'] * 100:.1f}%)"
+    )
+    print(f"  {'Failed requests:':<{lw}} {metrics['failed']}")
+    print(f"  {'MC parse fallback:':<{lw}} {metrics['mc_fallback']}")
+    print(f"{'=' * SUMMARY_LINE_WIDTH}\n")

--- a/benchmarks/metrics/mmsu.py
+++ b/benchmarks/metrics/mmsu.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
+from benchmarks.metrics._format import MMSU_CATEGORY_WIDTH, SPEED_LINE_WIDTH
+
 if TYPE_CHECKING:
     from benchmarks.tasks.audio_understanding import MmsuResult
 
@@ -68,9 +70,9 @@ def print_mmsu_summary(
     *,
     speed_metrics: dict[str, Any] | None = None,
 ) -> None:
-    print("\n" + "=" * 60)
+    print("\n" + "=" * SPEED_LINE_WIDTH)
     print(f"  MMSU Results - {model_name}")
-    print("=" * 60)
+    print("=" * SPEED_LINE_WIDTH)
     print(f"  Total samples:    {metrics['total_samples']}")
     print(
         f"  Successful:       {metrics.get('successful_samples', metrics['total_samples'])}"
@@ -78,13 +80,16 @@ def print_mmsu_summary(
     print(f"  Parseable:        {metrics['parseable_samples']}")
     print(f"  Correct:          {metrics['correct']}")
     print(f"  Overall accuracy: {metrics['overall_accuracy']:.2%}")
-    print("-" * 60)
-    print(f"  {'Category':<18} {'Acc':>8} {'N':>6}")
-    print("-" * 60)
+    print("-" * SPEED_LINE_WIDTH)
+    print(f"  {'Category':<{MMSU_CATEGORY_WIDTH}} {'Acc':>8} {'N':>6}")
+    print("-" * SPEED_LINE_WIDTH)
     for name, info in metrics["per_category"].items():
-        print(f"  {name:<18} {info['accuracy']:>8.2%} {info['total']:>6}")
+        print(
+            f"  {name:<{MMSU_CATEGORY_WIDTH}} "
+            f"{info['accuracy']:>8.2%} {info['total']:>6}"
+        )
     if speed_metrics:
-        print("-" * 60)
+        print("-" * SPEED_LINE_WIDTH)
         print(f"  Latency mean:     {speed_metrics.get('latency_mean_s', 0):.3f}s")
         print(f"  Latency p95:      {speed_metrics.get('latency_p95_s', 0):.3f}s")
         if speed_metrics.get("audio_duration_mean_s", 0) > 0:
@@ -99,4 +104,4 @@ def print_mmsu_summary(
         audio_expected = speed_metrics.get("audio_expected")
         if audio_expected:
             print(f"  Audio returned:   {audio_returned}/{audio_expected}")
-    print("=" * 60)
+    print("=" * SPEED_LINE_WIDTH)

--- a/benchmarks/metrics/mmsu.py
+++ b/benchmarks/metrics/mmsu.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MMSU accuracy metrics and presentation."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from benchmarks.tasks.audio_understanding import MmsuResult
+
+
+def _build_group_metrics(
+    results: list["MmsuResult"],
+    key: str,
+) -> dict[str, dict[str, Any]]:
+    grouped: dict[str, dict[str, int]] = defaultdict(
+        lambda: {"total": 0, "correct": 0, "parseable": 0}
+    )
+    for result in results:
+        value = getattr(result, key)
+        grouped[value]["total"] += 1
+        if result.is_parseable:
+            grouped[value]["parseable"] += 1
+        if result.is_correct:
+            grouped[value]["correct"] += 1
+
+    metrics: dict[str, dict[str, Any]] = {}
+    for name, counts in sorted(grouped.items()):
+        metrics[name] = {
+            "total": counts["total"],
+            "correct": counts["correct"],
+            "parseable": counts["parseable"],
+            "accuracy": round(counts["correct"] / counts["total"], 4),
+        }
+    return metrics
+
+
+def compute_mmsu_metrics(results: list["MmsuResult"]) -> dict[str, Any]:
+    total = len(results)
+    parseable = sum(1 for result in results if result.is_parseable)
+    successful = sum(1 for result in results if result.is_success)
+    correct = sum(1 for result in results if result.is_correct)
+
+    return {
+        "total_samples": total,
+        "parseable_samples": parseable,
+        "unparseable_samples": total - parseable,
+        "successful_samples": successful,
+        "failed_samples": total - successful,
+        "correct": correct,
+        "incorrect": total - correct,
+        "overall_accuracy": round(correct / total, 4) if total else 0.0,
+        "per_task": _build_group_metrics(results, "task_name"),
+        "per_category": _build_group_metrics(results, "category"),
+        "per_sub_category": _build_group_metrics(results, "sub_category"),
+        "per_sub_sub_category": _build_group_metrics(results, "sub_sub_category"),
+        "per_linguistics_sub_discipline": _build_group_metrics(
+            results,
+            "linguistics_sub_discipline",
+        ),
+    }
+
+
+def print_mmsu_summary(
+    metrics: dict[str, Any],
+    model_name: str,
+    *,
+    speed_metrics: dict[str, Any] | None = None,
+) -> None:
+    print("\n" + "=" * 60)
+    print(f"  MMSU Results - {model_name}")
+    print("=" * 60)
+    print(f"  Total samples:    {metrics['total_samples']}")
+    print(
+        f"  Successful:       {metrics.get('successful_samples', metrics['total_samples'])}"
+    )
+    print(f"  Parseable:        {metrics['parseable_samples']}")
+    print(f"  Correct:          {metrics['correct']}")
+    print(f"  Overall accuracy: {metrics['overall_accuracy']:.2%}")
+    print("-" * 60)
+    print(f"  {'Category':<18} {'Acc':>8} {'N':>6}")
+    print("-" * 60)
+    for name, info in metrics["per_category"].items():
+        print(f"  {name:<18} {info['accuracy']:>8.2%} {info['total']:>6}")
+    if speed_metrics:
+        print("-" * 60)
+        print(f"  Latency mean:     {speed_metrics.get('latency_mean_s', 0):.3f}s")
+        print(f"  Latency p95:      {speed_metrics.get('latency_p95_s', 0):.3f}s")
+        if speed_metrics.get("audio_duration_mean_s", 0) > 0:
+            print(
+                f"  Audio mean:       {speed_metrics.get('audio_duration_mean_s', 0):.3f}s"
+            )
+        if speed_metrics.get("rtf_mean") is not None:
+            print(f"  RTF mean:         {speed_metrics.get('rtf_mean', 0):.4f}")
+        print(f"  Throughput:       {speed_metrics.get('throughput_qps', 0):.2f} req/s")
+        print(f"  Tok/s agg:        {speed_metrics.get('tok_per_s_agg', 0):.2f}")
+        audio_returned = speed_metrics.get("audio_returned")
+        audio_expected = speed_metrics.get("audio_expected")
+        if audio_expected:
+            print(f"  Audio returned:   {audio_returned}/{audio_expected}")
+    print("=" * 60)

--- a/benchmarks/metrics/performance.py
+++ b/benchmarks/metrics/performance.py
@@ -6,9 +6,7 @@ from __future__ import annotations
 import numpy as np
 
 from benchmarks.benchmarker.data import RequestResult
-
-SUMMARY_LABEL_WIDTH = 30
-SUMMARY_LINE_WIDTH = 60
+from benchmarks.metrics._format import SPEED_LABEL_WIDTH, SPEED_LINE_WIDTH
 
 
 def _compute_token_metrics(successes: list[RequestResult]) -> dict:
@@ -80,10 +78,10 @@ def print_speed_summary(
     metrics: dict,
     model_name: str,
     concurrency: int | None = None,
-    title: str = "TTS Benchmark Result",
+    title: str = "Speed Benchmark Result",
 ) -> None:
-    lw = SUMMARY_LABEL_WIDTH
-    w = SUMMARY_LINE_WIDTH
+    lw = SPEED_LABEL_WIDTH
+    w = SPEED_LINE_WIDTH
     print(f"\n{'=' * w}")
     print(f"{title:^{w}}")
     print(f"{'=' * w}")

--- a/benchmarks/metrics/performance.py
+++ b/benchmarks/metrics/performance.py
@@ -7,6 +7,9 @@ import numpy as np
 
 from benchmarks.benchmarker.data import RequestResult
 
+SUMMARY_LABEL_WIDTH = 30
+SUMMARY_LINE_WIDTH = 60
+
 
 def _compute_token_metrics(successes: list[RequestResult]) -> dict:
     tokens_per_sec = [o.tok_per_s for o in successes if o.tok_per_s > 0]
@@ -71,3 +74,74 @@ def compute_speed_metrics(
         **_compute_token_metrics(successes),
     }
     return metrics_summary
+
+
+def print_speed_summary(
+    metrics: dict,
+    model_name: str,
+    concurrency: int | None = None,
+    title: str = "TTS Benchmark Result",
+) -> None:
+    lw = SUMMARY_LABEL_WIDTH
+    w = SUMMARY_LINE_WIDTH
+    print(f"\n{'=' * w}")
+    print(f"{title:^{w}}")
+    print(f"{'=' * w}")
+    print(f"  {'Model:':<{lw}} {model_name}")
+    if concurrency is not None:
+        print(f"  {'Concurrency:':<{lw}} {concurrency}")
+    print(f"  {'Completed requests:':<{lw}} {metrics['completed_requests']}")
+    print(f"  {'Failed requests:':<{lw}} {metrics['failed_requests']}")
+    print(f"{'-' * w}")
+    print(f"  {'Latency mean (s):':<{lw}} {metrics.get('latency_mean_s', 'N/A')}")
+    print(f"  {'Latency median (s):':<{lw}} {metrics.get('latency_median_s', 'N/A')}")
+    print(f"  {'Latency p95 (s):':<{lw}} {metrics.get('latency_p95_s', 'N/A')}")
+    print(f"  {'Latency p99 (s):':<{lw}} {metrics.get('latency_p99_s', 'N/A')}")
+    if metrics.get("rtf_mean") is not None:
+        print(f"  {'RTF mean:':<{lw}} {metrics['rtf_mean']}")
+        print(f"  {'RTF median:':<{lw}} {metrics['rtf_median']}")
+    if metrics.get("audio_duration_mean_s"):
+        print(
+            f"  {'Audio duration mean (s):':<{lw}} {metrics['audio_duration_mean_s']}"
+        )
+    if metrics.get("tok_per_s_mean") is not None:
+        print(f"  {'Tok/s (per-req mean):':<{lw}} {metrics['tok_per_s_mean']}")
+        print(f"  {'Tok/s (per-req median):':<{lw}} {metrics['tok_per_s_median']}")
+    if metrics.get("tok_per_s_agg") is not None:
+        print(f"  {'Tok/s (aggregate):':<{lw}} {metrics['tok_per_s_agg']}")
+    if metrics.get("gen_tokens_mean") is not None:
+        print(f"  {'Gen tokens (mean):':<{lw}} {metrics['gen_tokens_mean']:.0f}")
+        print(f"  {'Gen tokens (total):':<{lw}} {metrics['gen_tokens_total']}")
+    if metrics.get("prompt_tokens_mean") is not None:
+        print(f"  {'Prompt tokens (mean):':<{lw}} {metrics['prompt_tokens_mean']:.0f}")
+        print(f"  {'Prompt tokens (total):':<{lw}} {metrics['prompt_tokens_total']}")
+    print(f"  {'Throughput (req/s):':<{lw}} {metrics.get('throughput_qps', 'N/A')}")
+    print(f"{'=' * w}")
+
+
+def build_speed_results(
+    outputs: list[RequestResult],
+    metrics: dict,
+    config: dict,
+) -> dict:
+    return {
+        "summary": metrics,
+        "config": config,
+        "per_request": [_request_result_to_dict(output) for output in outputs],
+    }
+
+
+def _request_result_to_dict(output: RequestResult) -> dict:
+    return {
+        "id": output.request_id,
+        "text": output.text,
+        "is_success": output.is_success,
+        "latency_s": round(output.latency_s, 4),
+        "audio_duration_s": round(output.audio_duration_s, 4),
+        "rtf": round(output.rtf, 4) if output.rtf < float("inf") else None,
+        "prompt_tokens": output.prompt_tokens or None,
+        "completion_tokens": output.completion_tokens or None,
+        "tok_per_s": round(output.tok_per_s, 1) if output.tok_per_s > 0 else None,
+        "wav_path": output.wav_path or None,
+        "error": output.error or None,
+    }

--- a/benchmarks/metrics/video.py
+++ b/benchmarks/metrics/video.py
@@ -4,12 +4,16 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from benchmarks.benchmarker.utils import print_accuracy_breakdown
+from benchmarks.metrics._format import (
+    ACCURACY_LABEL_WIDTH,
+    ACCURACY_LINE_WIDTH,
+    print_accuracy_breakdown,
+)
 
-SUMMARY_LABEL_WIDTH = 28
-SUMMARY_LINE_WIDTH = 50
+if TYPE_CHECKING:
+    from benchmarks.tasks.video_understanding import VideoMMERecord
 
 
 def _finalize_breakdown(
@@ -30,9 +34,8 @@ def _finalize_breakdown(
 
 
 def compute_videomme_metrics(
-    per_sample: list[dict[str, Any]],
-    mc_fallback: int,
-) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    per_sample: list["VideoMMERecord"],
+) -> dict[str, Any]:
     correct = 0
     failed = 0
     per_duration: dict[str, dict[str, int]] = defaultdict(
@@ -66,12 +69,12 @@ def compute_videomme_metrics(
         "correct": correct,
         "accuracy": round(correct / total, 4) if total > 0 else 0.0,
         "failed": failed,
-        "mc_fallback": mc_fallback,
+        "mc_fallback": sum(record["is_mc_fallback"] for record in per_sample),
         "per_duration": _finalize_breakdown(per_duration),
         "per_domain": _finalize_breakdown(per_domain),
         "per_task_type": _finalize_breakdown(per_task_type),
     }
-    return summary, per_sample
+    return summary
 
 
 def print_videomme_accuracy_summary(
@@ -80,10 +83,10 @@ def print_videomme_accuracy_summary(
     *,
     title: str = "Video-MME Accuracy",
 ) -> None:
-    lw = SUMMARY_LABEL_WIDTH
-    print(f"\n{'=' * SUMMARY_LINE_WIDTH}")
+    lw = ACCURACY_LABEL_WIDTH
+    print(f"\n{'=' * ACCURACY_LINE_WIDTH}")
     print(f"  {title} — {model_name}")
-    print(f"{'=' * SUMMARY_LINE_WIDTH}")
+    print(f"{'=' * ACCURACY_LINE_WIDTH}")
     print(f"  {'Total samples:':<{lw}} {metrics['total_samples']}")
     print(f"  {'Correct:':<{lw}} {metrics['correct']}")
     print(
@@ -95,4 +98,4 @@ def print_videomme_accuracy_summary(
     print_accuracy_breakdown("By duration", metrics.get("per_duration", {}))
     print_accuracy_breakdown("By domain", metrics.get("per_domain", {}))
     print_accuracy_breakdown("By task type", metrics.get("per_task_type", {}))
-    print(f"{'=' * SUMMARY_LINE_WIDTH}\n")
+    print(f"{'=' * ACCURACY_LINE_WIDTH}\n")

--- a/benchmarks/metrics/video.py
+++ b/benchmarks/metrics/video.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Video understanding accuracy metrics and presentation."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from benchmarks.benchmarker.utils import print_accuracy_breakdown
+
+SUMMARY_LABEL_WIDTH = 28
+SUMMARY_LINE_WIDTH = 50
+
+
+def _finalize_breakdown(
+    buckets: dict[str, dict[str, int]]
+) -> dict[str, dict[str, Any]]:
+    return {
+        key: {
+            "total": value["total"],
+            "correct": value["correct"],
+            "accuracy": (
+                round(value["correct"] / value["total"], 4)
+                if value["total"] > 0
+                else 0.0
+            ),
+        }
+        for key, value in sorted(buckets.items())
+    }
+
+
+def compute_videomme_metrics(
+    per_sample: list[dict[str, Any]],
+    mc_fallback: int,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    correct = 0
+    failed = 0
+    per_duration: dict[str, dict[str, int]] = defaultdict(
+        lambda: {"total": 0, "correct": 0}
+    )
+    per_domain: dict[str, dict[str, int]] = defaultdict(
+        lambda: {"total": 0, "correct": 0}
+    )
+    per_task_type: dict[str, dict[str, int]] = defaultdict(
+        lambda: {"total": 0, "correct": 0}
+    )
+
+    for record in per_sample:
+        per_duration[record["duration"]]["total"] += 1
+        per_domain[record["domain"]]["total"] += 1
+        per_task_type[record["task_type"]]["total"] += 1
+
+        if not record["is_success"]:
+            failed += 1
+            continue
+
+        if record["is_correct"]:
+            correct += 1
+            per_duration[record["duration"]]["correct"] += 1
+            per_domain[record["domain"]]["correct"] += 1
+            per_task_type[record["task_type"]]["correct"] += 1
+
+    total = len(per_sample)
+    summary = {
+        "total_samples": total,
+        "correct": correct,
+        "accuracy": round(correct / total, 4) if total > 0 else 0.0,
+        "failed": failed,
+        "mc_fallback": mc_fallback,
+        "per_duration": _finalize_breakdown(per_duration),
+        "per_domain": _finalize_breakdown(per_domain),
+        "per_task_type": _finalize_breakdown(per_task_type),
+    }
+    return summary, per_sample
+
+
+def print_videomme_accuracy_summary(
+    metrics: dict[str, Any],
+    model_name: str,
+    *,
+    title: str = "Video-MME Accuracy",
+) -> None:
+    lw = SUMMARY_LABEL_WIDTH
+    print(f"\n{'=' * SUMMARY_LINE_WIDTH}")
+    print(f"  {title} — {model_name}")
+    print(f"{'=' * SUMMARY_LINE_WIDTH}")
+    print(f"  {'Total samples:':<{lw}} {metrics['total_samples']}")
+    print(f"  {'Correct:':<{lw}} {metrics['correct']}")
+    print(
+        f"  {'Accuracy:':<{lw}} {metrics['accuracy']:.4f} "
+        f"({metrics['accuracy'] * 100:.1f}%)"
+    )
+    print(f"  {'Failed requests:':<{lw}} {metrics['failed']}")
+    print(f"  {'MC parse fallback:':<{lw}} {metrics['mc_fallback']}")
+    print_accuracy_breakdown("By duration", metrics.get("per_duration", {}))
+    print_accuracy_breakdown("By domain", metrics.get("per_domain", {}))
+    print_accuracy_breakdown("By task type", metrics.get("per_task_type", {}))
+    print(f"{'=' * SUMMARY_LINE_WIDTH}\n")

--- a/benchmarks/metrics/wer.py
+++ b/benchmarks/metrics/wer.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+"""WER and ASR-speed metric computation and presentation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from benchmarks.tasks.tts import SampleOutput
+
+SUMMARY_LABEL_WIDTH = 30
+SUMMARY_LINE_WIDTH = 60
+
+
+def calculate_wer_metrics(outputs: list["SampleOutput"], lang: str) -> dict:
+    """Compute corpus-level WER metrics from per-sample outputs."""
+    successes = [o for o in outputs if o.is_success]
+    if not successes:
+        return {
+            "lang": lang,
+            "total_samples": len(outputs),
+            "evaluated": 0,
+            "skipped": len(outputs),
+            "wer_corpus": 0.0,
+            "wer_per_sample_mean": 0.0,
+            "wer_per_sample_median": 0.0,
+            "wer_per_sample_std": 0.0,
+            "wer_per_sample_p95": 0.0,
+            "wer_per_sample_max": 0.0,
+            "wer_below_50_corpus": 0.0,
+            "n_above_50_pct_wer": 0,
+            "pct_above_50_pct_wer": 0.0,
+            "latency_mean_s": 0.0,
+            "audio_duration_mean_s": 0.0,
+        }
+
+    total_errors = sum(o.substitutions + o.deletions + o.insertions for o in successes)
+    total_ref_words = sum(o.substitutions + o.deletions + o.hits for o in successes)
+    corpus_wer = total_errors / total_ref_words if total_ref_words > 0 else 0.0
+
+    wer_arr = np.array([o.wer for o in successes])
+    latencies = [o.latency_s for o in successes]
+    audio_durations = [o.audio_duration_s for o in successes if o.audio_duration_s > 0]
+
+    n_above_50 = int(np.sum(wer_arr > 0.5))
+    ok_samples = [o for o in successes if o.wer <= 0.5]
+    if ok_samples:
+        ok_errors = sum(
+            o.substitutions + o.deletions + o.insertions for o in ok_samples
+        )
+        ok_ref = sum(o.substitutions + o.deletions + o.hits for o in ok_samples)
+        wer_below_50_micro = ok_errors / ok_ref if ok_ref > 0 else 0.0
+    else:
+        wer_below_50_micro = 0.0
+
+    return {
+        "lang": lang,
+        "total_samples": len(outputs),
+        "evaluated": len(successes),
+        "skipped": len(outputs) - len(successes),
+        "wer_corpus": float(corpus_wer),
+        "wer_per_sample_mean": float(np.mean(wer_arr)),
+        "wer_per_sample_median": float(np.median(wer_arr)),
+        "wer_per_sample_std": float(np.std(wer_arr)),
+        "wer_per_sample_p95": float(np.percentile(wer_arr, 95)),
+        "wer_per_sample_max": float(np.max(wer_arr)),
+        "wer_below_50_corpus": float(wer_below_50_micro),
+        "n_above_50_pct_wer": n_above_50,
+        "pct_above_50_pct_wer": (n_above_50 / len(successes) * 100 if successes else 0),
+        "latency_mean_s": float(np.mean(latencies)),
+        "audio_duration_mean_s": (
+            float(np.mean(audio_durations)) if audio_durations else 0
+        ),
+    }
+
+
+def print_wer_summary(
+    metrics: dict, model_name: str, generation_mode: str | None = None
+) -> None:
+    lw = SUMMARY_LABEL_WIDTH
+    w = SUMMARY_LINE_WIDTH
+    title = "TTS WER Benchmark Result"
+    if generation_mode:
+        title = f"TTS WER Benchmark Result ({generation_mode})"
+    print(f"\n{'=' * w}")
+    print(f"{title:^{w}}")
+    print(f"{'=' * w}")
+    print(f"  {'Model:':<{lw}} {model_name}")
+    if generation_mode:
+        print(f"  {'Generation mode:':<{lw}} {generation_mode}")
+    print(f"  {'Language:':<{lw}} {metrics.get('lang', 'N/A')}")
+    print(
+        f"  {'Evaluated / Total:':<{lw}} "
+        f"{metrics.get('evaluated', 0)}/{metrics.get('total_samples', 0)}"
+    )
+    print(f"  {'Skipped:':<{lw}} {metrics.get('skipped', 0)}")
+    print(f"{'-' * w}")
+    print(
+        f"  {'WER (corpus, micro-avg):':<{lw}} "
+        f"{metrics.get('wer_corpus', 0):.4f} "
+        f"({metrics.get('wer_corpus', 0) * 100:.2f}%)"
+    )
+    print(f"{'-' * w}")
+    print(
+        f"  {'WER per-sample mean:':<{lw}} "
+        f"{metrics.get('wer_per_sample_mean', 0):.4f} "
+        f"({metrics.get('wer_per_sample_mean', 0) * 100:.2f}%)"
+    )
+    print(
+        f"  {'WER per-sample median:':<{lw}} "
+        f"{metrics.get('wer_per_sample_median', 0):.4f}"
+    )
+    print(
+        f"  {'WER per-sample std:':<{lw}} "
+        f"{metrics.get('wer_per_sample_std', 0):.4f}"
+    )
+    print(
+        f"  {'WER per-sample p95:':<{lw}} "
+        f"{metrics.get('wer_per_sample_p95', 0):.4f}"
+    )
+    print(
+        f"  {'WER per-sample max:':<{lw}} "
+        f"{metrics.get('wer_per_sample_max', 0):.4f} "
+        f"({metrics.get('wer_per_sample_max', 0) * 100:.2f}%)"
+    )
+    print(
+        f"  {'WER corpus (excl >50%):':<{lw}} "
+        f"{metrics.get('wer_below_50_corpus', 0):.4f} "
+        f"({metrics.get('wer_below_50_corpus', 0) * 100:.2f}%)"
+    )
+    print(
+        f"  {'>50% WER samples:':<{lw}} "
+        f"{metrics.get('n_above_50_pct_wer', 0)} "
+        f"({metrics.get('pct_above_50_pct_wer', 0):.1f}%)"
+    )
+    print(f"{'-' * w}")
+    print(f"  {'Latency mean (s):':<{lw}} {metrics.get('latency_mean_s', 'N/A')}")
+    print(
+        f"  {'Audio duration mean (s):':<{lw}} "
+        f"{metrics.get('audio_duration_mean_s', 'N/A')}"
+    )
+    print(f"{'=' * w}\n")
+
+
+def calculate_asr_speed_metrics(outputs: list["SampleOutput"]) -> dict:
+    """Compute speed metrics for the ASR transcription phase."""
+    successes = [o for o in outputs if o.is_success and o.asr_latency_s > 0]
+    if not successes:
+        return {
+            "total_samples": len(outputs),
+            "evaluated": 0,
+            "skipped": len(outputs),
+            "asr_latency_mean_s": 0.0,
+            "asr_latency_median_s": 0.0,
+            "asr_latency_p95_s": 0.0,
+            "asr_latency_p99_s": 0.0,
+            "asr_total_time_s": 0.0,
+            "asr_throughput_samples_per_s": 0.0,
+            "asr_rtf_mean": 0.0,
+            "asr_rtf_median": 0.0,
+            "asr_audio_processed_s": 0.0,
+        }
+
+    latencies = np.array([o.asr_latency_s for o in successes])
+    total_asr_time = float(np.sum(latencies))
+
+    audio_durations = [o.audio_duration_s for o in successes if o.audio_duration_s > 0]
+    rtfs = np.array(
+        [
+            o.asr_latency_s / o.audio_duration_s
+            for o in successes
+            if o.audio_duration_s > 0
+        ]
+    )
+
+    return {
+        "total_samples": len(outputs),
+        "evaluated": len(successes),
+        "skipped": len(outputs) - len(successes),
+        "asr_latency_mean_s": float(np.mean(latencies)),
+        "asr_latency_median_s": float(np.median(latencies)),
+        "asr_latency_p95_s": float(np.percentile(latencies, 95)),
+        "asr_latency_p99_s": float(np.percentile(latencies, 99)),
+        "asr_total_time_s": total_asr_time,
+        "asr_throughput_samples_per_s": (
+            float(len(successes) / total_asr_time) if total_asr_time > 0 else 0.0
+        ),
+        "asr_rtf_mean": float(np.mean(rtfs)) if len(rtfs) > 0 else 0.0,
+        "asr_rtf_median": float(np.median(rtfs)) if len(rtfs) > 0 else 0.0,
+        "asr_audio_processed_s": (
+            float(sum(audio_durations)) if audio_durations else 0.0
+        ),
+    }
+
+
+def print_asr_speed_summary(metrics: dict, model_name: str) -> None:
+    """Print ASR speed metrics summary table."""
+    lw = SUMMARY_LABEL_WIDTH
+    w = SUMMARY_LINE_WIDTH
+    print(f"\n{'=' * w}")
+    print(f"{'ASR Speed Benchmark Result':^{w}}")
+    print(f"{'=' * w}")
+    print(f"  {'Model:':<{lw}} {model_name}")
+    print(
+        f"  {'Evaluated / Total:':<{lw}} "
+        f"{metrics.get('evaluated', 0)}/{metrics.get('total_samples', 0)}"
+    )
+    print(f"  {'Skipped:':<{lw}} {metrics.get('skipped', 0)}")
+    print(f"{'-' * w}")
+    print(
+        f"  {'ASR latency mean (s):':<{lw}} "
+        f"{metrics.get('asr_latency_mean_s', 'N/A')}"
+    )
+    print(
+        f"  {'ASR latency median (s):':<{lw}} "
+        f"{metrics.get('asr_latency_median_s', 'N/A')}"
+    )
+    print(
+        f"  {'ASR latency p95 (s):':<{lw}} "
+        f"{metrics.get('asr_latency_p95_s', 'N/A')}"
+    )
+    print(
+        f"  {'ASR latency p99 (s):':<{lw}} "
+        f"{metrics.get('asr_latency_p99_s', 'N/A')}"
+    )
+    print(f"  {'ASR RTF mean:':<{lw}} {metrics.get('asr_rtf_mean', 'N/A')}")
+    print(f"  {'ASR RTF median:':<{lw}} {metrics.get('asr_rtf_median', 'N/A')}")
+    print(
+        f"  {'ASR total time (s):':<{lw}} " f"{metrics.get('asr_total_time_s', 'N/A')}"
+    )
+    print(
+        f"  {'ASR throughput (samples/s):':<{lw}} "
+        f"{metrics.get('asr_throughput_samples_per_s', 'N/A')}"
+    )
+    if metrics.get("asr_audio_processed_s"):
+        print(
+            f"  {'Audio processed (s):':<{lw}} " f"{metrics['asr_audio_processed_s']}"
+        )
+    print(f"{'=' * w}")

--- a/benchmarks/metrics/wer.py
+++ b/benchmarks/metrics/wer.py
@@ -7,11 +7,10 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from benchmarks.metrics._format import SPEED_LABEL_WIDTH, SPEED_LINE_WIDTH
+
 if TYPE_CHECKING:
     from benchmarks.tasks.tts import SampleOutput
-
-SUMMARY_LABEL_WIDTH = 30
-SUMMARY_LINE_WIDTH = 60
 
 
 def calculate_wer_metrics(outputs: list["SampleOutput"], lang: str) -> dict:
@@ -79,8 +78,8 @@ def calculate_wer_metrics(outputs: list["SampleOutput"], lang: str) -> dict:
 def print_wer_summary(
     metrics: dict, model_name: str, generation_mode: str | None = None
 ) -> None:
-    lw = SUMMARY_LABEL_WIDTH
-    w = SUMMARY_LINE_WIDTH
+    lw = SPEED_LABEL_WIDTH
+    w = SPEED_LINE_WIDTH
     title = "TTS WER Benchmark Result"
     if generation_mode:
         title = f"TTS WER Benchmark Result ({generation_mode})"
@@ -197,8 +196,8 @@ def calculate_asr_speed_metrics(outputs: list["SampleOutput"]) -> dict:
 
 def print_asr_speed_summary(metrics: dict, model_name: str) -> None:
     """Print ASR speed metrics summary table."""
-    lw = SUMMARY_LABEL_WIDTH
-    w = SUMMARY_LINE_WIDTH
+    lw = SPEED_LABEL_WIDTH
+    w = SPEED_LINE_WIDTH
     print(f"\n{'=' * w}")
     print(f"{'ASR Speed Benchmark Result':^{w}}")
     print(f"{'=' * w}")

--- a/benchmarks/tasks/audio_understanding.py
+++ b/benchmarks/tasks/audio_understanding.py
@@ -9,7 +9,6 @@ import csv
 import json
 import os
 import time
-from collections import defaultdict
 from dataclasses import asdict, dataclass
 from typing import Any
 
@@ -139,32 +138,6 @@ def _build_result_from_response(
     else:
         result.error = "Empty response"
     return result
-
-
-def _build_group_metrics(
-    results: list["MmsuResult"],
-    key: str,
-) -> dict[str, dict[str, Any]]:
-    grouped: dict[str, dict[str, int]] = defaultdict(
-        lambda: {"total": 0, "correct": 0, "parseable": 0}
-    )
-    for result in results:
-        value = getattr(result, key)
-        grouped[value]["total"] += 1
-        if result.is_parseable:
-            grouped[value]["parseable"] += 1
-        if result.is_correct:
-            grouped[value]["correct"] += 1
-
-    metrics: dict[str, dict[str, Any]] = {}
-    for name, counts in sorted(grouped.items()):
-        metrics[name] = {
-            "total": counts["total"],
-            "correct": counts["correct"],
-            "parseable": counts["parseable"],
-            "accuracy": round(counts["correct"] / counts["total"], 4),
-        }
-    return metrics
 
 
 @dataclass
@@ -307,72 +280,6 @@ def build_mmsu_results(
         results.append(result)
 
     return results
-
-
-def compute_mmsu_metrics(results: list[MmsuResult]) -> dict[str, Any]:
-    total = len(results)
-    parseable = sum(1 for result in results if result.is_parseable)
-    successful = sum(1 for result in results if result.is_success)
-    correct = sum(1 for result in results if result.is_correct)
-
-    return {
-        "total_samples": total,
-        "parseable_samples": parseable,
-        "unparseable_samples": total - parseable,
-        "successful_samples": successful,
-        "failed_samples": total - successful,
-        "correct": correct,
-        "incorrect": total - correct,
-        "overall_accuracy": round(correct / total, 4) if total else 0.0,
-        "per_task": _build_group_metrics(results, "task_name"),
-        "per_category": _build_group_metrics(results, "category"),
-        "per_sub_category": _build_group_metrics(results, "sub_category"),
-        "per_sub_sub_category": _build_group_metrics(results, "sub_sub_category"),
-        "per_linguistics_sub_discipline": _build_group_metrics(
-            results,
-            "linguistics_sub_discipline",
-        ),
-    }
-
-
-def print_mmsu_summary(
-    metrics: dict[str, Any],
-    model_name: str,
-    *,
-    speed_metrics: dict[str, Any] | None = None,
-) -> None:
-    print("\n" + "=" * 60)
-    print(f"  MMSU Results - {model_name}")
-    print("=" * 60)
-    print(f"  Total samples:    {metrics['total_samples']}")
-    print(
-        f"  Successful:       {metrics.get('successful_samples', metrics['total_samples'])}"
-    )
-    print(f"  Parseable:        {metrics['parseable_samples']}")
-    print(f"  Correct:          {metrics['correct']}")
-    print(f"  Overall accuracy: {metrics['overall_accuracy']:.2%}")
-    print("-" * 60)
-    print(f"  {'Category':<18} {'Acc':>8} {'N':>6}")
-    print("-" * 60)
-    for name, info in metrics["per_category"].items():
-        print(f"  {name:<18} {info['accuracy']:>8.2%} {info['total']:>6}")
-    if speed_metrics:
-        print("-" * 60)
-        print(f"  Latency mean:     {speed_metrics.get('latency_mean_s', 0):.3f}s")
-        print(f"  Latency p95:      {speed_metrics.get('latency_p95_s', 0):.3f}s")
-        if speed_metrics.get("audio_duration_mean_s", 0) > 0:
-            print(
-                f"  Audio mean:       {speed_metrics.get('audio_duration_mean_s', 0):.3f}s"
-            )
-        if speed_metrics.get("rtf_mean") is not None:
-            print(f"  RTF mean:         {speed_metrics.get('rtf_mean', 0):.4f}")
-        print(f"  Throughput:       {speed_metrics.get('throughput_qps', 0):.2f} req/s")
-        print(f"  Tok/s agg:        {speed_metrics.get('tok_per_s_agg', 0):.2f}")
-        audio_returned = speed_metrics.get("audio_returned")
-        audio_expected = speed_metrics.get("audio_expected")
-        if audio_expected:
-            print(f"  Audio returned:   {audio_returned}/{audio_expected}")
-    print("=" * 60)
 
 
 def save_mmsu_results(

--- a/benchmarks/tasks/tts.py
+++ b/benchmarks/tasks/tts.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""TTS task utilities: voice-clone API clients, WER/ASR evaluation,
-HTTP send functions, and speed/WER result builders.
+"""TTS task utilities: voice-clone API clients, ASR evaluation, and HTTP send functions.
 
 Replaces tasks/tts_speed.py and tasks/voice_clone.py.
 """
@@ -24,7 +23,6 @@ from pathlib import Path
 from typing import Protocol
 
 import aiohttp
-import numpy as np
 import soundfile as sf
 import torch
 import transformers
@@ -43,12 +41,17 @@ from benchmarks.benchmarker.utils import (
     save_json_results,
 )
 from benchmarks.dataset.seedtts import SampleInput
+from benchmarks.metrics.performance import build_speed_results
+from benchmarks.metrics.wer import (
+    calculate_asr_speed_metrics,
+    calculate_wer_metrics,
+    print_asr_speed_summary,
+    print_wer_summary,
+)
 
 logger = logging.getLogger(__name__)
 
 TEXT_PREVIEW_LENGTH = 60
-SUMMARY_LABEL_WIDTH = 30
-SUMMARY_LINE_WIDTH = 60
 
 
 # ---------------------------------------------------------------------------
@@ -239,68 +242,6 @@ def transcribe_and_compute_wer(
     return output
 
 
-def calculate_wer_metrics(outputs: list[SampleOutput], lang: str) -> dict:
-    """Compute corpus-level WER metrics from per-sample outputs."""
-    successes = [o for o in outputs if o.is_success]
-    if not successes:
-        return {
-            "lang": lang,
-            "total_samples": len(outputs),
-            "evaluated": 0,
-            "skipped": len(outputs),
-            "wer_corpus": 0.0,
-            "wer_per_sample_mean": 0.0,
-            "wer_per_sample_median": 0.0,
-            "wer_per_sample_std": 0.0,
-            "wer_per_sample_p95": 0.0,
-            "wer_per_sample_max": 0.0,
-            "wer_below_50_corpus": 0.0,
-            "n_above_50_pct_wer": 0,
-            "pct_above_50_pct_wer": 0.0,
-            "latency_mean_s": 0.0,
-            "audio_duration_mean_s": 0.0,
-        }
-
-    total_errors = sum(o.substitutions + o.deletions + o.insertions for o in successes)
-    total_ref_words = sum(o.substitutions + o.deletions + o.hits for o in successes)
-    corpus_wer = total_errors / total_ref_words if total_ref_words > 0 else 0.0
-
-    wer_arr = np.array([o.wer for o in successes])
-    latencies = [o.latency_s for o in successes]
-    audio_durations = [o.audio_duration_s for o in successes if o.audio_duration_s > 0]
-
-    n_above_50 = int(np.sum(wer_arr > 0.5))
-    ok_samples = [o for o in successes if o.wer <= 0.5]
-    if ok_samples:
-        ok_errors = sum(
-            o.substitutions + o.deletions + o.insertions for o in ok_samples
-        )
-        ok_ref = sum(o.substitutions + o.deletions + o.hits for o in ok_samples)
-        wer_below_50_micro = ok_errors / ok_ref if ok_ref > 0 else 0.0
-    else:
-        wer_below_50_micro = 0.0
-
-    return {
-        "lang": lang,
-        "total_samples": len(outputs),
-        "evaluated": len(successes),
-        "skipped": len(outputs) - len(successes),
-        "wer_corpus": float(corpus_wer),
-        "wer_per_sample_mean": float(np.mean(wer_arr)),
-        "wer_per_sample_median": float(np.median(wer_arr)),
-        "wer_per_sample_std": float(np.std(wer_arr)),
-        "wer_per_sample_p95": float(np.percentile(wer_arr, 95)),
-        "wer_per_sample_max": float(np.max(wer_arr)),
-        "wer_below_50_corpus": float(wer_below_50_micro),
-        "n_above_50_pct_wer": n_above_50,
-        "pct_above_50_pct_wer": (n_above_50 / len(successes) * 100 if successes else 0),
-        "latency_mean_s": float(np.mean(latencies)),
-        "audio_duration_mean_s": (
-            float(np.mean(audio_durations)) if audio_durations else 0
-        ),
-    }
-
-
 def compute_text_audio_consistency(
     request_results: list[RequestResult],
     lang: str,
@@ -341,171 +282,6 @@ def compute_text_audio_consistency(
         for o in outputs
     ]
     return {"summary": calculate_wer_metrics(outputs, lang), "per_sample": per_sample}
-
-
-def print_wer_summary(
-    metrics: dict, model_name: str, generation_mode: str | None = None
-) -> None:
-    lw = SUMMARY_LABEL_WIDTH
-    w = SUMMARY_LINE_WIDTH
-    title = "TTS WER Benchmark Result"
-    if generation_mode:
-        title = f"TTS WER Benchmark Result ({generation_mode})"
-    print(f"\n{'=' * w}")
-    print(f"{title:^{w}}")
-    print(f"{'=' * w}")
-    print(f"  {'Model:':<{lw}} {model_name}")
-    if generation_mode:
-        print(f"  {'Generation mode:':<{lw}} {generation_mode}")
-    print(f"  {'Language:':<{lw}} {metrics.get('lang', 'N/A')}")
-    print(
-        f"  {'Evaluated / Total:':<{lw}} "
-        f"{metrics.get('evaluated', 0)}/{metrics.get('total_samples', 0)}"
-    )
-    print(f"  {'Skipped:':<{lw}} {metrics.get('skipped', 0)}")
-    print(f"{'-' * w}")
-    print(
-        f"  {'WER (corpus, micro-avg):':<{lw}} "
-        f"{metrics.get('wer_corpus', 0):.4f} "
-        f"({metrics.get('wer_corpus', 0) * 100:.2f}%)"
-    )
-    print(f"{'-' * w}")
-    print(
-        f"  {'WER per-sample mean:':<{lw}} "
-        f"{metrics.get('wer_per_sample_mean', 0):.4f} "
-        f"({metrics.get('wer_per_sample_mean', 0) * 100:.2f}%)"
-    )
-    print(
-        f"  {'WER per-sample median:':<{lw}} "
-        f"{metrics.get('wer_per_sample_median', 0):.4f}"
-    )
-    print(
-        f"  {'WER per-sample std:':<{lw}} "
-        f"{metrics.get('wer_per_sample_std', 0):.4f}"
-    )
-    print(
-        f"  {'WER per-sample p95:':<{lw}} "
-        f"{metrics.get('wer_per_sample_p95', 0):.4f}"
-    )
-    print(
-        f"  {'WER per-sample max:':<{lw}} "
-        f"{metrics.get('wer_per_sample_max', 0):.4f} "
-        f"({metrics.get('wer_per_sample_max', 0) * 100:.2f}%)"
-    )
-    print(
-        f"  {'WER corpus (excl >50%):':<{lw}} "
-        f"{metrics.get('wer_below_50_corpus', 0):.4f} "
-        f"({metrics.get('wer_below_50_corpus', 0) * 100:.2f}%)"
-    )
-    print(
-        f"  {'>50% WER samples:':<{lw}} "
-        f"{metrics.get('n_above_50_pct_wer', 0)} "
-        f"({metrics.get('pct_above_50_pct_wer', 0):.1f}%)"
-    )
-    print(f"{'-' * w}")
-    print(f"  {'Latency mean (s):':<{lw}} {metrics.get('latency_mean_s', 'N/A')}")
-    print(
-        f"  {'Audio duration mean (s):':<{lw}} "
-        f"{metrics.get('audio_duration_mean_s', 'N/A')}"
-    )
-    print(f"{'=' * w}\n")
-
-
-def calculate_asr_speed_metrics(outputs: list[SampleOutput]) -> dict:
-    """Compute speed metrics for the ASR transcription phase."""
-    successes = [o for o in outputs if o.is_success and o.asr_latency_s > 0]
-    if not successes:
-        return {
-            "total_samples": len(outputs),
-            "evaluated": 0,
-            "skipped": len(outputs),
-            "asr_latency_mean_s": 0.0,
-            "asr_latency_median_s": 0.0,
-            "asr_latency_p95_s": 0.0,
-            "asr_latency_p99_s": 0.0,
-            "asr_total_time_s": 0.0,
-            "asr_throughput_samples_per_s": 0.0,
-            "asr_rtf_mean": 0.0,
-            "asr_rtf_median": 0.0,
-            "asr_audio_processed_s": 0.0,
-        }
-
-    latencies = np.array([o.asr_latency_s for o in successes])
-    total_asr_time = float(np.sum(latencies))
-
-    audio_durations = [o.audio_duration_s for o in successes if o.audio_duration_s > 0]
-    rtfs = np.array(
-        [
-            o.asr_latency_s / o.audio_duration_s
-            for o in successes
-            if o.audio_duration_s > 0
-        ]
-    )
-
-    return {
-        "total_samples": len(outputs),
-        "evaluated": len(successes),
-        "skipped": len(outputs) - len(successes),
-        "asr_latency_mean_s": float(np.mean(latencies)),
-        "asr_latency_median_s": float(np.median(latencies)),
-        "asr_latency_p95_s": float(np.percentile(latencies, 95)),
-        "asr_latency_p99_s": float(np.percentile(latencies, 99)),
-        "asr_total_time_s": total_asr_time,
-        "asr_throughput_samples_per_s": (
-            float(len(successes) / total_asr_time) if total_asr_time > 0 else 0.0
-        ),
-        "asr_rtf_mean": float(np.mean(rtfs)) if len(rtfs) > 0 else 0.0,
-        "asr_rtf_median": float(np.median(rtfs)) if len(rtfs) > 0 else 0.0,
-        "asr_audio_processed_s": (
-            float(sum(audio_durations)) if audio_durations else 0.0
-        ),
-    }
-
-
-def print_asr_speed_summary(metrics: dict, model_name: str) -> None:
-    """Print ASR speed metrics summary table."""
-    lw = SUMMARY_LABEL_WIDTH
-    w = SUMMARY_LINE_WIDTH
-    print(f"\n{'=' * w}")
-    print(f"{'ASR Speed Benchmark Result':^{w}}")
-    print(f"{'=' * w}")
-    print(f"  {'Model:':<{lw}} {model_name}")
-    print(
-        f"  {'Evaluated / Total:':<{lw}} "
-        f"{metrics.get('evaluated', 0)}/{metrics.get('total_samples', 0)}"
-    )
-    print(f"  {'Skipped:':<{lw}} {metrics.get('skipped', 0)}")
-    print(f"{'-' * w}")
-    print(
-        f"  {'ASR latency mean (s):':<{lw}} "
-        f"{metrics.get('asr_latency_mean_s', 'N/A')}"
-    )
-    print(
-        f"  {'ASR latency median (s):':<{lw}} "
-        f"{metrics.get('asr_latency_median_s', 'N/A')}"
-    )
-    print(
-        f"  {'ASR latency p95 (s):':<{lw}} "
-        f"{metrics.get('asr_latency_p95_s', 'N/A')}"
-    )
-    print(
-        f"  {'ASR latency p99 (s):':<{lw}} "
-        f"{metrics.get('asr_latency_p99_s', 'N/A')}"
-    )
-    print(f"  {'ASR RTF mean:':<{lw}} {metrics.get('asr_rtf_mean', 'N/A')}")
-    print(f"  {'ASR RTF median:':<{lw}} {metrics.get('asr_rtf_median', 'N/A')}")
-    print(
-        f"  {'ASR total time (s):':<{lw}} " f"{metrics.get('asr_total_time_s', 'N/A')}"
-    )
-    print(
-        f"  {'ASR throughput (samples/s):':<{lw}} "
-        f"{metrics.get('asr_throughput_samples_per_s', 'N/A')}"
-    )
-    if metrics.get("asr_audio_processed_s"):
-        print(
-            f"  {'Audio processed (s):':<{lw}} " f"{metrics['asr_audio_processed_s']}"
-        )
-    print(f"{'=' * w}")
 
 
 def save_wer_results(
@@ -1239,82 +1015,6 @@ def make_tts_send_fn(
         return result
 
     return send_fn
-
-
-# ---------------------------------------------------------------------------
-# Speed results builders
-# ---------------------------------------------------------------------------
-
-
-def print_speed_summary(
-    metrics: dict,
-    model_name: str,
-    concurrency: int | None = None,
-    title: str = "TTS Benchmark Result",
-) -> None:
-    lw = SUMMARY_LABEL_WIDTH
-    w = SUMMARY_LINE_WIDTH
-    print(f"\n{'=' * w}")
-    print(f"{title:^{w}}")
-    print(f"{'=' * w}")
-    print(f"  {'Model:':<{lw}} {model_name}")
-    if concurrency is not None:
-        print(f"  {'Concurrency:':<{lw}} {concurrency}")
-    print(f"  {'Completed requests:':<{lw}} {metrics['completed_requests']}")
-    print(f"  {'Failed requests:':<{lw}} {metrics['failed_requests']}")
-    print(f"{'-' * w}")
-    print(f"  {'Latency mean (s):':<{lw}} {metrics.get('latency_mean_s', 'N/A')}")
-    print(f"  {'Latency median (s):':<{lw}} {metrics.get('latency_median_s', 'N/A')}")
-    print(f"  {'Latency p95 (s):':<{lw}} {metrics.get('latency_p95_s', 'N/A')}")
-    print(f"  {'Latency p99 (s):':<{lw}} {metrics.get('latency_p99_s', 'N/A')}")
-    if metrics.get("rtf_mean") is not None:
-        print(f"  {'RTF mean:':<{lw}} {metrics['rtf_mean']}")
-        print(f"  {'RTF median:':<{lw}} {metrics['rtf_median']}")
-    if metrics.get("audio_duration_mean_s"):
-        print(
-            f"  {'Audio duration mean (s):':<{lw}} {metrics['audio_duration_mean_s']}"
-        )
-    if metrics.get("tok_per_s_mean") is not None:
-        print(f"  {'Tok/s (per-req mean):':<{lw}} {metrics['tok_per_s_mean']}")
-        print(f"  {'Tok/s (per-req median):':<{lw}} {metrics['tok_per_s_median']}")
-    if metrics.get("tok_per_s_agg") is not None:
-        print(f"  {'Tok/s (aggregate):':<{lw}} {metrics['tok_per_s_agg']}")
-    if metrics.get("gen_tokens_mean") is not None:
-        print(f"  {'Gen tokens (mean):':<{lw}} {metrics['gen_tokens_mean']:.0f}")
-        print(f"  {'Gen tokens (total):':<{lw}} {metrics['gen_tokens_total']}")
-    if metrics.get("prompt_tokens_mean") is not None:
-        print(f"  {'Prompt tokens (mean):':<{lw}} {metrics['prompt_tokens_mean']:.0f}")
-        print(f"  {'Prompt tokens (total):':<{lw}} {metrics['prompt_tokens_total']}")
-    print(f"  {'Throughput (req/s):':<{lw}} {metrics.get('throughput_qps', 'N/A')}")
-    print(f"{'=' * w}")
-
-
-def build_speed_results(
-    outputs: list[RequestResult],
-    metrics: dict,
-    config: dict,
-) -> dict:
-    return {
-        "summary": metrics,
-        "config": config,
-        "per_request": [_request_result_to_dict(output) for output in outputs],
-    }
-
-
-def _request_result_to_dict(output: RequestResult) -> dict:
-    return {
-        "id": output.request_id,
-        "text": output.text,
-        "is_success": output.is_success,
-        "latency_s": round(output.latency_s, 4),
-        "audio_duration_s": round(output.audio_duration_s, 4),
-        "rtf": round(output.rtf, 4) if output.rtf < float("inf") else None,
-        "prompt_tokens": output.prompt_tokens or None,
-        "completion_tokens": output.completion_tokens or None,
-        "tok_per_s": round(output.tok_per_s, 1) if output.tok_per_s > 0 else None,
-        "wav_path": output.wav_path or None,
-        "error": output.error or None,
-    }
 
 
 def save_generated_audio_metadata(

--- a/benchmarks/tasks/video_understanding.py
+++ b/benchmarks/tasks/video_understanding.py
@@ -48,11 +48,11 @@ class VideoMMERecord(TypedDict):
     rtf: float | None
     wav_path: str
     predicted: str
-    raw_response: str | None
+    raw_response: str
     is_correct: bool
     is_success: bool
     is_mc_fallback: bool
-    error: str | None
+    error: str
 
 
 def _apply_chat_completion_response(

--- a/benchmarks/tasks/video_understanding.py
+++ b/benchmarks/tasks/video_understanding.py
@@ -11,21 +11,18 @@ import os
 import random
 import struct
 import time
-from collections import defaultdict
 from typing import Any
 
 import aiohttp
 
 from benchmarks.benchmarker.data import RequestResult
 from benchmarks.benchmarker.runner import SendFn
-from benchmarks.benchmarker.utils import get_wav_duration, print_accuracy_breakdown
+from benchmarks.benchmarker.utils import get_wav_duration
 from benchmarks.dataset.videomme import VideoAMMESample, VideoMMESample
 from benchmarks.tasks.visual_understand import parse_multi_choice_response
 
 logger = logging.getLogger(__name__)
 
-SUMMARY_LABEL_WIDTH = 28
-SUMMARY_LINE_WIDTH = 50
 VIDEOAMME_REQUEST_TEXT = (
     "Use the video and the audio question to answer. "
     "Return the final answer as Answer: $LETTER."
@@ -161,44 +158,17 @@ def make_video_send_fn(
     return send_fn
 
 
-def _finalize_breakdown(
-    buckets: dict[str, dict[str, int]]
-) -> dict[str, dict[str, Any]]:
-    return {
-        key: {
-            "total": value["total"],
-            "correct": value["correct"],
-            "accuracy": (
-                round(value["correct"] / value["total"], 4)
-                if value["total"] > 0
-                else 0.0
-            ),
-        }
-        for key, value in sorted(buckets.items())
-    }
-
-
-def compute_videomme_metrics(
+def build_videomme_result_records(
     samples: list[VideoMMESample],
     results: list[RequestResult],
-) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+) -> tuple[list[dict[str, Any]], int]:
+    """Parse responses into persisted per-sample records plus fallback count."""
     assert len(samples) == len(
         results
     ), f"Sample/result count mismatch: {len(samples)} samples vs {len(results)} results"
     random.seed(42)
 
-    correct = 0
-    failed = 0
     mc_fallback = 0
-    per_duration: dict[str, dict[str, int]] = defaultdict(
-        lambda: {"total": 0, "correct": 0}
-    )
-    per_domain: dict[str, dict[str, int]] = defaultdict(
-        lambda: {"total": 0, "correct": 0}
-    )
-    per_task_type: dict[str, dict[str, int]] = defaultdict(
-        lambda: {"total": 0, "correct": 0}
-    )
     per_sample: list[dict[str, Any]] = []
 
     for sample, result in zip(samples, results):
@@ -226,10 +196,6 @@ def compute_videomme_metrics(
             "wav_path": result.wav_path or "",
         }
 
-        per_duration[sample.duration]["total"] += 1
-        per_domain[sample.domain]["total"] += 1
-        per_task_type[sample.task_type]["total"] += 1
-
         if not result.is_success:
             record.update(
                 predicted="",
@@ -238,7 +204,6 @@ def compute_videomme_metrics(
                 is_success=False,
                 error=result.error,
             )
-            failed += 1
             per_sample.append(record)
             continue
 
@@ -251,11 +216,6 @@ def compute_videomme_metrics(
         if is_fallback:
             mc_fallback += 1
             logger.debug("Video-MME parse fallback for sample %s", sample.sample_id)
-        if is_correct:
-            correct += 1
-            per_duration[sample.duration]["correct"] += 1
-            per_domain[sample.domain]["correct"] += 1
-            per_task_type[sample.task_type]["correct"] += 1
 
         record.update(
             predicted=predicted,
@@ -266,39 +226,4 @@ def compute_videomme_metrics(
         )
         per_sample.append(record)
 
-    total = len(samples)
-    summary = {
-        "total_samples": total,
-        "correct": correct,
-        "accuracy": round(correct / total, 4) if total > 0 else 0.0,
-        "failed": failed,
-        "mc_fallback": mc_fallback,
-        "per_duration": _finalize_breakdown(per_duration),
-        "per_domain": _finalize_breakdown(per_domain),
-        "per_task_type": _finalize_breakdown(per_task_type),
-    }
-    return summary, per_sample
-
-
-def print_videomme_accuracy_summary(
-    metrics: dict[str, Any],
-    model_name: str,
-    *,
-    title: str = "Video-MME Accuracy",
-) -> None:
-    lw = SUMMARY_LABEL_WIDTH
-    print(f"\n{'=' * SUMMARY_LINE_WIDTH}")
-    print(f"  {title} — {model_name}")
-    print(f"{'=' * SUMMARY_LINE_WIDTH}")
-    print(f"  {'Total samples:':<{lw}} {metrics['total_samples']}")
-    print(f"  {'Correct:':<{lw}} {metrics['correct']}")
-    print(
-        f"  {'Accuracy:':<{lw}} {metrics['accuracy']:.4f} "
-        f"({metrics['accuracy'] * 100:.1f}%)"
-    )
-    print(f"  {'Failed requests:':<{lw}} {metrics['failed']}")
-    print(f"  {'MC parse fallback:':<{lw}} {metrics['mc_fallback']}")
-    print_accuracy_breakdown("By duration", metrics.get("per_duration", {}))
-    print_accuracy_breakdown("By domain", metrics.get("per_domain", {}))
-    print_accuracy_breakdown("By task type", metrics.get("per_task_type", {}))
-    print(f"{'=' * SUMMARY_LINE_WIDTH}\n")
+    return per_sample, mc_fallback

--- a/benchmarks/tasks/video_understanding.py
+++ b/benchmarks/tasks/video_understanding.py
@@ -11,7 +11,7 @@ import os
 import random
 import struct
 import time
-from typing import Any
+from typing import Any, TypedDict
 
 import aiohttp
 
@@ -27,6 +27,32 @@ VIDEOAMME_REQUEST_TEXT = (
     "Use the video and the audio question to answer. "
     "Return the final answer as Answer: $LETTER."
 )
+
+
+class VideoMMERecord(TypedDict):
+    sample_id: str
+    video_path: str
+    url: str
+    video_id: str
+    question_id: str
+    duration: str
+    domain: str
+    sub_category: str
+    task_type: str
+    expected: str
+    latency_s: float
+    prompt_tokens: int
+    completion_tokens: int
+    tok_per_s: float | None
+    audio_duration_s: float | None
+    rtf: float | None
+    wav_path: str
+    predicted: str
+    raw_response: str | None
+    is_correct: bool
+    is_success: bool
+    is_mc_fallback: bool
+    error: str | None
 
 
 def _apply_chat_completion_response(
@@ -161,18 +187,17 @@ def make_video_send_fn(
 def build_videomme_result_records(
     samples: list[VideoMMESample],
     results: list[RequestResult],
-) -> tuple[list[dict[str, Any]], int]:
-    """Parse responses into persisted per-sample records plus fallback count."""
+) -> list[VideoMMERecord]:
+    """Parse responses into persisted per-sample records."""
     assert len(samples) == len(
         results
     ), f"Sample/result count mismatch: {len(samples)} samples vs {len(results)} results"
     random.seed(42)
 
-    mc_fallback = 0
-    per_sample: list[dict[str, Any]] = []
+    per_sample: list[VideoMMERecord] = []
 
     for sample, result in zip(samples, results):
-        record = {
+        record: VideoMMERecord = {
             "sample_id": sample.sample_id,
             "video_path": sample.video_path,
             "url": sample.url,
@@ -194,16 +219,15 @@ def build_videomme_result_records(
             ),
             "rtf": (round(result.rtf, 4) if result.rtf > 0 else None),
             "wav_path": result.wav_path or "",
+            "predicted": "",
+            "raw_response": result.error,
+            "is_correct": False,
+            "is_success": False,
+            "is_mc_fallback": False,
+            "error": result.error,
         }
 
         if not result.is_success:
-            record.update(
-                predicted="",
-                raw_response=result.error,
-                is_correct=False,
-                is_success=False,
-                error=result.error,
-            )
             per_sample.append(record)
             continue
 
@@ -214,7 +238,6 @@ def build_videomme_result_records(
         )
         is_correct = predicted == sample.answer
         if is_fallback:
-            mc_fallback += 1
             logger.debug("Video-MME parse fallback for sample %s", sample.sample_id)
 
         record.update(
@@ -222,8 +245,9 @@ def build_videomme_result_records(
             raw_response=result.text,
             is_correct=is_correct,
             is_success=True,
+            is_mc_fallback=is_fallback,
             error="",
         )
         per_sample.append(record)
 
-    return per_sample, mc_fallback
+    return per_sample

--- a/benchmarks/tasks/visual_understand.py
+++ b/benchmarks/tasks/visual_understand.py
@@ -33,17 +33,17 @@ class MMMURecord(TypedDict):
     sample_id: str
     subject: str
     question_type: str
-    expected: str | list[str] | None
+    expected: str
     latency_s: float
     prompt_tokens: int
     completion_tokens: int
     tok_per_s: float | None
     predicted: str
-    raw_response: str | None
+    raw_response: str
     is_correct: bool
     is_success: bool
     is_mc_fallback: bool
-    error: str | None
+    error: str
 
 
 def _check_is_number(s: str) -> bool:

--- a/benchmarks/tasks/visual_understand.py
+++ b/benchmarks/tasks/visual_understand.py
@@ -10,6 +10,7 @@ import os
 import random
 import re
 import time
+from typing import TypedDict
 
 import aiohttp
 
@@ -26,6 +27,23 @@ MULTI_CHOICE_INSTRUCTION = (
     "where LETTER is one of the options. "
     "Think step by step before answering."
 )
+
+
+class MMMURecord(TypedDict):
+    sample_id: str
+    subject: str
+    question_type: str
+    expected: str | list[str] | None
+    latency_s: float
+    prompt_tokens: int
+    completion_tokens: int
+    tok_per_s: float | None
+    predicted: str
+    raw_response: str | None
+    is_correct: bool
+    is_success: bool
+    is_mc_fallback: bool
+    error: str | None
 
 
 def _check_is_number(s: str) -> bool:
@@ -296,19 +314,18 @@ def make_mmmu_send_fn(
 def build_mmmu_result_records(
     samples: list[MMMUSample],
     results: list[RequestResult],
-) -> tuple[list[dict], int]:
-    """Parse responses into persisted per-sample records plus fallback count."""
+) -> list[MMMURecord]:
+    """Parse responses into persisted per-sample records."""
     assert len(samples) == len(
         results
     ), f"Sample/result count mismatch: {len(samples)} samples vs {len(results)} results"
     # Fix the random seed so MC fallback choices stay deterministic across CI runs.
     random.seed(42)
 
-    mc_fallback = 0
-    per_sample: list[dict] = []
+    per_sample: list[MMMURecord] = []
 
     for sample, result in zip(samples, results):
-        record = {
+        record: MMMURecord = {
             "sample_id": sample.sample_id,
             "subject": sample.subject,
             "question_type": sample.question_type,
@@ -317,18 +334,17 @@ def build_mmmu_result_records(
             "prompt_tokens": result.prompt_tokens,
             "completion_tokens": result.completion_tokens,
             "tok_per_s": (round(result.tok_per_s, 1) if result.tok_per_s > 0 else None),
+            "predicted": "",
+            "raw_response": result.error,
+            "is_correct": False,
+            "is_success": False,
+            "is_mc_fallback": False,
+            "error": result.error,
         }
 
-        if not result.is_success:
-            record.update(
-                predicted="",
-                raw_response=result.error,
-                is_correct=False,
-                is_success=False,
-                error=result.error,
-            )
-        else:
+        if result.is_success:
             gold = sample.answer
+            is_fallback = False
             if (
                 sample.question_type == "multiple-choice"
                 and sample.all_choices
@@ -340,7 +356,6 @@ def build_mmmu_result_records(
                     sample.index2ans,
                 )
                 if is_fallback:
-                    mc_fallback += 1
                     logger.debug(
                         f"MMMU multi-choice parse fallback for sample "
                         f"{sample.sample_id}"
@@ -356,9 +371,10 @@ def build_mmmu_result_records(
                 raw_response=result.text,
                 is_correct=is_correct,
                 is_success=True,
+                is_mc_fallback=is_fallback,
                 error="",
             )
 
         per_sample.append(record)
 
-    return per_sample, mc_fallback
+    return per_sample

--- a/benchmarks/tasks/visual_understand.py
+++ b/benchmarks/tasks/visual_understand.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""MMMU benchmark case -- answer parsing, send_fn, metrics, and persistence."""
+"""MMMU benchmark case: answer parsing and request execution."""
 
 from __future__ import annotations
 
@@ -18,9 +18,6 @@ from benchmarks.benchmarker.runner import SendFn
 from benchmarks.dataset.mmmu import MMMUSample, image_to_data_uri
 
 logger = logging.getLogger(__name__)
-
-SUMMARY_LABEL_WIDTH = 28
-SUMMARY_LINE_WIDTH = 50
 
 MULTI_CHOICE_INSTRUCTION = (
     "\nAnswer the following multiple-choice question. "
@@ -296,24 +293,17 @@ def make_mmmu_send_fn(
     return send_fn
 
 
-def compute_mmmu_metrics(
+def build_mmmu_result_records(
     samples: list[MMMUSample],
     results: list[RequestResult],
-) -> tuple[dict, list[dict]]:
-    """Parse answers, compute accuracy, and build per-sample detail list.
-
-    Returns ``(summary_dict, per_sample_list)``.
-    """
+) -> tuple[list[dict], int]:
+    """Parse responses into persisted per-sample records plus fallback count."""
     assert len(samples) == len(
         results
     ), f"Sample/result count mismatch: {len(samples)} samples vs {len(results)} results"
-    # Fix the random seed so that MC fallback choices are deterministic across
-    # CI runs.  The MMMU reference eval also uses random fallback, so this
-    # does not change the evaluation methodology.
+    # Fix the random seed so MC fallback choices stay deterministic across CI runs.
     random.seed(42)
 
-    correct = 0
-    failed = 0
     mc_fallback = 0
     per_sample: list[dict] = []
 
@@ -337,7 +327,6 @@ def compute_mmmu_metrics(
                 is_success=False,
                 error=result.error,
             )
-            failed += 1
         else:
             gold = sample.answer
             if (
@@ -362,9 +351,6 @@ def compute_mmmu_metrics(
                 is_correct = gold is not None and eval_open(gold, parsed_list)
                 predicted = ", ".join(map(str, parsed_list))
 
-            if is_correct:
-                correct += 1
-
             record.update(
                 predicted=predicted,
                 raw_response=result.text,
@@ -375,31 +361,4 @@ def compute_mmmu_metrics(
 
         per_sample.append(record)
 
-    total = len(samples)
-    accuracy = correct / total if total > 0 else 0.0
-
-    summary = {
-        "total_samples": total,
-        "correct": correct,
-        "accuracy": round(accuracy, 4),
-        "failed": failed,
-        "mc_fallback": mc_fallback,
-    }
-    return summary, per_sample
-
-
-def print_mmmu_accuracy_summary(metrics: dict, model_name: str) -> None:
-    """Print formatted MMMU accuracy summary to stdout."""
-    lw = SUMMARY_LABEL_WIDTH
-    print(f"\n{'=' * SUMMARY_LINE_WIDTH}")
-    print(f"  MMMU Accuracy — {model_name}")
-    print(f"{'=' * SUMMARY_LINE_WIDTH}")
-    print(f"  {'Total samples:':<{lw}} {metrics['total_samples']}")
-    print(f"  {'Correct:':<{lw}} {metrics['correct']}")
-    print(
-        f"  {'Accuracy:':<{lw}} {metrics['accuracy']:.4f} "
-        f"({metrics['accuracy'] * 100:.1f}%)"
-    )
-    print(f"  {'Failed requests:':<{lw}} {metrics['failed']}")
-    print(f"  {'MC parse fallback:':<{lw}} {metrics['mc_fallback']}")
-    print(f"{'=' * SUMMARY_LINE_WIDTH}\n")
+    return per_sample, mc_fallback

--- a/tests/test_model/test_qwen3_omni_videoamme_ci.py
+++ b/tests/test_model/test_qwen3_omni_videoamme_ci.py
@@ -19,8 +19,8 @@ import pytest
 from benchmarks.dataset.prepare import DATASETS
 from benchmarks.eval.benchmark_omni_videoamme import run_videoamme_eval
 from benchmarks.eval.benchmark_omni_videomme import VideoEvalConfig
-from benchmarks.tasks.tts import print_speed_summary
-from benchmarks.tasks.video_understanding import print_videomme_accuracy_summary
+from benchmarks.metrics.performance import print_speed_summary
+from benchmarks.metrics.video import print_videomme_accuracy_summary
 from tests.utils import ServerHandle, apply_slack, assert_speed_thresholds
 
 CONCURRENCY = 16

--- a/tests/test_model/test_qwen3_omni_videoamme_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_videoamme_talker_ci.py
@@ -22,8 +22,9 @@ import pytest
 from benchmarks.dataset.prepare import DATASETS
 from benchmarks.eval.benchmark_omni_videoamme import run_videoamme_eval
 from benchmarks.eval.benchmark_omni_videomme import VideoEvalConfig
-from benchmarks.tasks.tts import print_speed_summary, print_wer_summary
-from benchmarks.tasks.video_understanding import print_videomme_accuracy_summary
+from benchmarks.metrics.performance import print_speed_summary
+from benchmarks.metrics.video import print_videomme_accuracy_summary
+from benchmarks.metrics.wer import print_wer_summary
 from tests.utils import (
     ServerHandle,
     apply_slack,

--- a/tests/test_model/test_qwen3_omni_videomme_ci.py
+++ b/tests/test_model/test_qwen3_omni_videomme_ci.py
@@ -20,8 +20,8 @@ import pytest
 
 from benchmarks.dataset.prepare import DATASETS
 from benchmarks.eval.benchmark_omni_videomme import VideoEvalConfig, run_video_eval
-from benchmarks.tasks.tts import print_speed_summary
-from benchmarks.tasks.video_understanding import print_videomme_accuracy_summary
+from benchmarks.metrics.performance import print_speed_summary
+from benchmarks.metrics.video import print_videomme_accuracy_summary
 from tests.utils import ServerHandle, apply_slack, assert_speed_thresholds
 
 CONCURRENCY = 16

--- a/tests/test_model/test_qwen3_omni_videomme_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_videomme_talker_ci.py
@@ -31,8 +31,9 @@ import pytest
 from benchmarks.dataset.prepare import DATASETS
 from benchmarks.dataset.videomme import VideoMMESample, load_videomme_samples
 from benchmarks.eval.benchmark_omni_videomme import VideoEvalConfig, run_video_eval
-from benchmarks.tasks.tts import print_speed_summary, print_wer_summary
-from benchmarks.tasks.video_understanding import print_videomme_accuracy_summary
+from benchmarks.metrics.performance import print_speed_summary
+from benchmarks.metrics.video import print_videomme_accuracy_summary
+from benchmarks.metrics.wer import print_wer_summary
 from tests.utils import (
     ServerHandle,
     apply_slack,


### PR DESCRIPTION
## Motivation

Fixes #360.

Benchmark metric logic has drifted across task modules: speed/WER printers, Video-MME/MMMU accuracy summaries, and MMSU aggregation were exported from `benchmarks/tasks/*` even though the benchmark framework already has `benchmarks/metrics/` as the natural ownership layer.

This PR consolidates metric computation and presentation under `benchmarks/metrics/` while preserving benchmark behavior. Task modules still own request execution, response parsing, and per-sample correctness decisions; eval modules remain thin orchestration and persistence layers.

## Modifications

| Area | Change |
| --- | --- |
| Shared performance metrics | Moved speed summary printing and request-result serialization into `benchmarks/metrics/performance.py`, next to the existing speed aggregation helper. The shared speed title now defaults to `Speed Benchmark Result`. |
| Shared metric formatting | Added `benchmarks/metrics/_format.py` for shared accuracy/speed layout constants and accuracy breakdown presentation. This keeps metric presentation helpers inside `benchmarks/metrics/`. |
| WER / ASR metrics | Moved WER summary, WER printer, ASR speed summary, and ASR speed printer into `benchmarks/metrics/wer.py`. TTS task code now calls into metrics instead of exporting metric helpers itself. |
| Video-MME / Video-AMME metrics | Added `benchmarks/metrics/video.py` for Video-MME-style accuracy aggregation and presentation. `benchmarks/tasks/video_understanding.py` now builds typed per-sample records, including `is_mc_fallback`, and metrics derive aggregate fallback counts from those records. |
| MMMU metrics | Added `benchmarks/metrics/mmmu.py` for MMMU summary aggregation and presentation. MMMU parsing/correctness stays in `benchmarks/tasks/visual_understand.py`, which now builds typed per-sample records. |
| MMSU metrics | Added `benchmarks/metrics/mmsu.py` for MMSU group aggregation and summary printing. `benchmarks/tasks/audio_understanding.py` keeps request/result construction and persistence. |
| Eval and CI imports | Updated benchmark eval scripts and model CI tests to import metric helpers from `benchmarks.metrics.*` instead of `benchmarks.tasks.*`. |