### PR TITLE
[Doc] Unify Python version to 3.13 across install guides

### DIFF
--- a/docs/basic_usage/qwen3_omni.md
+++ b/docs/basic_usage/qwen3_omni.md
@@ -12,7 +12,7 @@ docker run -it --shm-size 32g --gpus all frankleeeee/sglang-omni:dev /bin/zsh
 ```bash
 git clone https://github.com/sgl-project/sglang-omni.git
 cd sglang-omni
-uv venv .venv -p 3.12 && source .venv/bin/activate
+uv venv .venv -p 3.13 && source .venv/bin/activate
 uv pip install -v .
 ```
 

--- a/docs/basic_usage/tts_s2pro.md
+++ b/docs/basic_usage/tts_s2pro.md
@@ -12,7 +12,7 @@ docker run -it --shm-size 32g --gpus all frankleeeee/sglang-omni:dev /bin/zsh
 ```bash
 git clone https://github.com/sgl-project/sglang-omni.git
 cd sglang-omni
-uv venv .venv -p 3.12 && source .venv/bin/activate
+uv venv .venv -p 3.13 && source .venv/bin/activate
 uv pip install -v .
 hf download fishaudio/s2-pro
 ```

--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -10,7 +10,7 @@ git clone git@github.com:sgl-project/sglang-omni.git
 cd sglang-omni
 
 # create a virtual environment in docker
-uv venv .venv -p 3.11
+uv venv .venv -p 3.13
 source .venv/bin/activate
 
 # install


### PR DESCRIPTION
## Motivation

Following up on #369: the `uv venv -p` Python version pinned in the installation instructions was inconsistent across three docs pages (`3.11` vs `3.12`), which could confuse new users during setup.

Per maintainer guidance on the issue, unify all three to `3.13` to match the docs CI (`docs-check.yaml`, `publish-docs.yaml`).

## Modifications

Align `uv venv -p` to Python `3.13` in three install guides:

- `docs/get_started/installation.md`: `3.11` → `3.13`
- `docs/basic_usage/qwen3_omni.md`: `3.12` → `3.13`
- `docs/basic_usage/tts_s2pro.md`: `3.12` → `3.13`

## Related Issues

Closes #369

## Accuracy Test

N/A (docs-only change)

## Benchmark & Profiling

N/A (docs-only change)

## Checklist

- [x] Format your code according with pre-commit. (pre-commit not installed locally; `git diff --check` passed, CI will validate.)
- [x] Add unit tests. (N/A, docs-only change.)
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed. (N/A, docs-only change.)
