### PR TITLE
[Feat] add streaming TTS and test to Ming Omni

### DIFF
--- a/examples/run_ming_omni_server.py
+++ b/examples/run_ming_omni_server.py
@@ -26,8 +26,15 @@ import logging
 import multiprocessing as mp
 import os
 
-from sglang_omni.models.ming_omni.config import MingOmniPipelineConfig
-from sglang_omni.serve import launch_server
+from sglang_omni.models.ming_omni.config import (
+    MingOmniPipelineConfig,
+    MingOmniSpeechPipelineConfig,
+    MingOmniStreamingSpeechPipelineConfig,
+)
+from sglang_omni.models.ming_omni.pipeline.next_stage import (
+    TALKER_STAGE,
+    TALKER_STREAM_STAGE,
+)
 
 logging.basicConfig(
     level=os.environ.get("LOGLEVEL", "INFO").upper(),
@@ -35,7 +42,34 @@ logging.basicConfig(
 )
 
 
-def parse_args() -> argparse.Namespace:
+def resolve_ming_pipeline_config(
+    *, enable_speech: bool, enable_streaming_tts: bool
+) -> type[
+    MingOmniPipelineConfig
+    | MingOmniSpeechPipelineConfig
+    | MingOmniStreamingSpeechPipelineConfig
+]:
+    if enable_speech and enable_streaming_tts:
+        return MingOmniStreamingSpeechPipelineConfig
+    if enable_speech:
+        return MingOmniSpeechPipelineConfig
+    return MingOmniPipelineConfig
+
+
+def resolve_ming_gpu_placement(
+    *,
+    enable_speech: bool,
+    enable_streaming_tts: bool,
+    gpu_thinker: int,
+    gpu_talker: int,
+) -> dict[str, int] | None:
+    if not enable_speech:
+        return None
+    talker_stage = TALKER_STREAM_STAGE if enable_streaming_tts else TALKER_STAGE
+    return {"thinker": gpu_thinker, talker_stage: gpu_talker}
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
@@ -55,6 +89,22 @@ def parse_args() -> argparse.Namespace:
         type=int,
         default=1,
         help="Tensor parallel size for thinker",
+    )
+    parser.add_argument(
+        "--gpu-thinker",
+        type=int,
+        default=0,
+        help="GPU index for the thinker stage",
+    )
+    parser.add_argument(
+        "--gpu-talker",
+        type=int,
+        default=1,
+        help=(
+            "GPU index for the speech talker stage. "
+            "When using --tp-size 2, set --gpu-talker 2 to avoid "
+            "the thinker TP range."
+        ),
     )
     parser.add_argument(
         "--quantization",
@@ -84,6 +134,16 @@ def parse_args() -> argparse.Namespace:
         choices=["shm", "nixl"],
         help="Relay backend for inter-stage data transfer",
     )
+    parser.add_argument(
+        "--enable-speech",
+        action="store_true",
+        help="Enable non-streaming speech output pipeline",
+    )
+    parser.add_argument(
+        "--enable-streaming-tts",
+        action="store_true",
+        help="Enable streaming TTS speech pipeline; requires --enable-speech",
+    )
 
     # Server
     parser.add_argument("--host", type=str, default="0.0.0.0")
@@ -95,11 +155,15 @@ def parse_args() -> argparse.Namespace:
         help="Model name for /v1/models (default: ming-omni)",
     )
 
-    return parser.parse_args()
+    args = parser.parse_args(argv)
+    if args.enable_streaming_tts and not args.enable_speech:
+        parser.error("--enable-streaming-tts requires --enable-speech")
+    return args
 
 
 def main() -> None:
     args = parse_args()
+    from sglang_omni.serve import launch_server
 
     overrides = {}
     if args.tp_size and args.tp_size > 1:
@@ -110,9 +174,24 @@ def main() -> None:
     if args.cpu_offload_gb:
         overrides["cpu_offload_gb"] = args.cpu_offload_gb
 
-    config = MingOmniPipelineConfig(
-        model_path=args.model_path,
-        relay_backend=args.relay_backend,
+    config_cls = resolve_ming_pipeline_config(
+        enable_speech=args.enable_speech,
+        enable_streaming_tts=args.enable_streaming_tts,
+    )
+    config_kwargs = {
+        "model_path": args.model_path,
+        "relay_backend": args.relay_backend,
+    }
+    gpu_placement = resolve_ming_gpu_placement(
+        enable_speech=args.enable_speech,
+        enable_streaming_tts=args.enable_streaming_tts,
+        gpu_thinker=args.gpu_thinker,
+        gpu_talker=args.gpu_talker,
+    )
+    if gpu_placement is not None:
+        config_kwargs["gpu_placement"] = gpu_placement
+    config = config_cls(
+        **config_kwargs,
     )
     if overrides:
         config.apply_server_args_overrides(stage_name="thinker", overrides=overrides)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "torchvision==0.24.1",    # torchvision for vision processor
     "accelerate>=0.27.0",     # init_empty_weights for meta initialization
     "transformers<5.0",   # HF models/tokenizers
+    "diffusers>=0.35.0",      # Ming AudioVAE autoencoder implementation
     "safetensors>=0.4.3",     # Direct weight loading
     "pillow>=10.0.0",         # Required by AutoImageProcessor
     "huggingface-hub>=0.36.0",# HF model downloads

--- a/sglang_omni/client/client.py
+++ b/sglang_omni/client/client.py
@@ -9,6 +9,7 @@ from typing import Any, AsyncIterator, Callable
 import numpy as np
 
 from sglang_omni.client.audio import (
+    DEFAULT_SAMPLE_RATE,
     FORMAT_MIME_TYPES,
     audio_to_base64,
     encode_audio,
@@ -28,6 +29,9 @@ from sglang_omni.client.types import (
 )
 from sglang_omni.pipeline.coordinator import Coordinator
 from sglang_omni.proto import OmniRequest, RequestState, StreamMessage
+
+
+_MERGED_AUDIO_RESULT_STAGES = ("code2wav", "talker")
 
 
 class Client:
@@ -86,6 +90,7 @@ class Client:
         """
         text_parts: list[str] = []
         audio_chunks: list[Any] = []
+        sample_rate: int | None = None
         last_chunk: GenerateChunk | None = None
         finish_reason: str | None = None
 
@@ -95,6 +100,8 @@ class Client:
                 text_parts.append(chunk.text)
             if chunk.audio_data is not None:
                 audio_chunks.append(chunk.audio_data)
+            if chunk.sample_rate is not None:
+                sample_rate = chunk.sample_rate
             if chunk.finish_reason is not None:
                 finish_reason = chunk.finish_reason
 
@@ -109,7 +116,11 @@ class Client:
                 combined = audio_chunks[0]
             else:
                 combined = np.concatenate([to_numpy(c) for c in audio_chunks])
-            audio_b64 = audio_to_base64(combined, output_format=audio_format)
+            audio_b64 = audio_to_base64(
+                combined,
+                sample_rate=sample_rate or DEFAULT_SAMPLE_RATE,
+                output_format=audio_format,
+            )
             audio = CompletionAudio(
                 id=f"audio-{request_id}",
                 data=audio_b64,
@@ -143,15 +154,29 @@ class Client:
         async for chunk in self.generate(request, request_id=request_id):
             audio_b64: str | None = None
             if chunk.modality == "audio" and chunk.audio_data is not None:
-                audio_b64 = audio_to_base64(
-                    chunk.audio_data, output_format=audio_format
-                )
+                audio_data = to_numpy(chunk.audio_data)
+                if audio_data.size == 0:
+                    if (
+                        chunk.finish_reason is None
+                        and not chunk.text
+                        and not chunk.token_ids
+                    ):
+                        continue
+                else:
+                    audio_b64 = audio_to_base64(
+                        audio_data,
+                        sample_rate=chunk.sample_rate or DEFAULT_SAMPLE_RATE,
+                        output_format=audio_format,
+                    )
 
             yield CompletionStreamChunk(
                 request_id=request_id,
                 text=chunk.text,
                 modality=chunk.modality,
                 audio_b64=audio_b64,
+                sample_rate=chunk.sample_rate,
+                talker_queue_depth=chunk.talker_queue_depth,
+                segmenter_first_emit_ms=chunk.segmenter_first_emit_ms,
                 finish_reason=chunk.finish_reason,
                 usage=chunk.usage,
                 stage_name=chunk.stage_name,
@@ -244,7 +269,9 @@ class Client:
 
     @staticmethod
     def _set_audio_data(chunk: GenerateChunk, data: dict[str, Any]) -> None:
-        audio_data = data.get("audio_data") or data.get("audio")
+        audio_data = data.get("audio_data")
+        if audio_data is None:
+            audio_data = data.get("audio")
         if audio_data is None and data.get("audio_waveform") is not None:
             raw = data.get("audio_waveform")
             if isinstance(raw, memoryview):
@@ -280,14 +307,23 @@ class Client:
             result.request_id = request_id
             return result
         if isinstance(result, dict):
-            # Multi-terminal merged result: {"decode": {...}, "code2wav": {...}}
-            if "decode" in result and "code2wav" in result:
+            # Multi-terminal merged result, e.g.
+            # {"decode": {...}, "code2wav": {...}} for Qwen or
+            # {"decode": {...}, "talker": {...}} for Ming non-streaming TTS.
+            audio_result = None
+            if "decode" in result:
+                for audio_stage in _MERGED_AUDIO_RESULT_STAGES:
+                    if audio_stage in result:
+                        candidate = result[audio_stage] or {}
+                        if isinstance(candidate, dict):
+                            audio_result = candidate
+                            break
+            if audio_result is not None:
                 decode_result = result["decode"] or {}
-                c2w_result = result["code2wav"] or {}
                 text = decode_result.get("text")
                 if isinstance(text, str):
                     chunk.text = text
-                Client._set_audio_data(chunk, c2w_result)
+                Client._set_audio_data(chunk, audio_result)
                 chunk.usage = UsageInfo.from_dict(decode_result.get("usage"))
                 return chunk
             text = result.get("text")
@@ -380,6 +416,12 @@ class Client:
             modality = data.get("modality")
             if modality is not None:
                 chunk.modality = modality
+            talker_queue_depth = data.get("talker_queue_depth")
+            if isinstance(talker_queue_depth, int):
+                chunk.talker_queue_depth = talker_queue_depth
+            segmenter_first_emit_ms = data.get("segmenter_first_emit_ms")
+            if isinstance(segmenter_first_emit_ms, (int, float)):
+                chunk.segmenter_first_emit_ms = float(segmenter_first_emit_ms)
             Client._set_audio_data(chunk, data)
             return chunk
         if isinstance(data, str):

--- a/sglang_omni/client/client.py
+++ b/sglang_omni/client/client.py
@@ -30,7 +30,6 @@ from sglang_omni.client.types import (
 from sglang_omni.pipeline.coordinator import Coordinator
 from sglang_omni.proto import OmniRequest, RequestState, StreamMessage
 
-
 _MERGED_AUDIO_RESULT_STAGES = ("code2wav", "talker")
 
 

--- a/sglang_omni/client/types.py
+++ b/sglang_omni/client/types.py
@@ -136,6 +136,8 @@ class GenerateChunk:
     # Multi-modal output data (e.g. audio waveform bytes, image bytes)
     audio_data: Any = None
     sample_rate: int | None = None
+    talker_queue_depth: int | None = None
+    segmenter_first_emit_ms: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -151,6 +153,8 @@ class GenerateChunk:
             "modality": self.modality,
             "audio_data": self.audio_data,
             "sample_rate": self.sample_rate,
+            "talker_queue_depth": self.talker_queue_depth,
+            "segmenter_first_emit_ms": self.segmenter_first_emit_ms,
         }
 
 
@@ -206,6 +210,9 @@ class CompletionStreamChunk:
     finish_reason: str | None = None
     usage: UsageInfo | None = None
     stage_name: str | None = None
+    sample_rate: int | None = None
+    talker_queue_depth: int | None = None
+    segmenter_first_emit_ms: float | None = None
 
 
 @dataclass

--- a/sglang_omni/models/ming_omni/components/streaming_segmenter_executor.py
+++ b/sglang_omni/models/ming_omni/components/streaming_segmenter_executor.py
@@ -21,7 +21,11 @@ from sglang_omni.models.ming_omni.components.streaming_text import (
     uint8_tensor_to_text,
 )
 from sglang_omni.models.ming_omni.pipeline.next_stage import TALKER_STREAM_STAGE
-from sglang_omni.pipeline.stage.stream_queue import StreamItem, StreamQueue, StreamSignal
+from sglang_omni.pipeline.stage.stream_queue import (
+    StreamItem,
+    StreamQueue,
+    StreamSignal,
+)
 from sglang_omni.proto import StagePayload
 
 

--- a/sglang_omni/models/ming_omni/components/streaming_segmenter_executor.py
+++ b/sglang_omni/models/ming_omni/components/streaming_segmenter_executor.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Streaming text segmenter executor for Ming-Omni TTS."""
+
+from __future__ import annotations
+
+import asyncio
+import collections
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from sglang_omni.executors.interface import Executor
+from sglang_omni.models.ming_omni.components.streaming_text import (
+    CompletedResult,
+    SegmenterConfig,
+    SegmenterState,
+    TextSegment,
+    TokenCountFn,
+    is_done_signal,
+    text_to_uint8_tensor,
+    uint8_tensor_to_text,
+)
+from sglang_omni.models.ming_omni.pipeline.next_stage import TALKER_STREAM_STAGE
+from sglang_omni.pipeline.stage.stream_queue import StreamItem, StreamQueue, StreamSignal
+from sglang_omni.proto import StagePayload
+
+
+@dataclass
+class _RequestState:
+    payload: StagePayload
+    segmenter: SegmenterState
+    segment_count: int = 0
+    first_text_ms: int | None = None
+
+
+def _fallback_token_count(text: str) -> int:
+    return len(text.split()) or len(text)
+
+
+_FIRST_SEGMENT_TIMEOUT = object()
+
+
+class MingStreamingSegmenterExecutor(Executor):
+    """Consume streamed thinker text and fan out speakable text segments."""
+
+    def __init__(
+        self,
+        *,
+        config: SegmenterConfig | None = None,
+        token_count_fn: TokenCountFn | None = None,
+    ) -> None:
+        self._config = config or SegmenterConfig()
+        self._token_count_fn = token_count_fn or _fallback_token_count
+        self._stream_queue: StreamQueue | None = None
+        self._stream_fn: Any | None = None
+        self._results: asyncio.Queue[CompletedResult] = asyncio.Queue()
+        self._tasks: dict[str, asyncio.Task[None]] = {}
+        self._states: dict[str, _RequestState] = {}
+        self._aborted: set[str] = set()
+        self._pre_aborted: collections.OrderedDict[str, None] = (
+            collections.OrderedDict()
+        )
+        self._max_pre_aborted = 4096
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        for request_id, task in list(self._tasks.items()):
+            self._aborted.add(request_id)
+            if not task.done():
+                task.cancel()
+            self._close_stream_queue(request_id)
+        self._tasks.clear()
+        self._states.clear()
+
+    def set_stream_fn(self, fn) -> None:
+        self._stream_fn = fn
+
+    def set_feedback_mailbox(self, mailbox: Any) -> None:
+        del mailbox
+
+    async def add_request(self, payload: StagePayload) -> None:
+        request_id = payload.request_id
+        if request_id in self._pre_aborted:
+            self._pre_aborted.pop(request_id, None)
+            self._set_payload_result(payload, segment_count=0, aborted=True)
+            self._results.put_nowait(
+                CompletedResult(request_id=request_id, payload=payload)
+            )
+            self._close_stream_queue(request_id)
+            return
+        if self._stream_queue is None:
+            raise RuntimeError("Ming streaming segmenter requires a stream queue")
+        if request_id in self._tasks:
+            raise RuntimeError(f"Request {request_id} is already running")
+
+        state = _RequestState(
+            payload=payload,
+            segmenter=SegmenterState(self._config, self._token_count_fn),
+        )
+        self._states[request_id] = state
+        task = asyncio.create_task(self._run_request(request_id))
+        self._tasks[request_id] = task
+
+    async def get_result(self) -> StagePayload:
+        completed = await self._results.get()
+        self._aborted.discard(completed.request_id)
+        if completed.error is not None:
+            completed.error.request_id = completed.request_id
+            raise completed.error
+        if completed.payload is None:
+            raise RuntimeError(f"Missing result payload for {completed.request_id}")
+        return completed.payload
+
+    async def abort(self, request_id: str) -> None:
+        state = self._states.pop(request_id, None)
+        task = self._tasks.pop(request_id, None)
+        if state is None and task is None:
+            self._remember_pre_aborted(request_id)
+            self._close_stream_queue(request_id)
+            return
+
+        self._aborted.add(request_id)
+        if task is not None and not task.done():
+            task.cancel()
+        self._close_stream_queue(request_id)
+        if state is not None:
+            self._set_payload_result(
+                state.payload,
+                segment_count=state.segment_count,
+                aborted=True,
+            )
+            self._results.put_nowait(
+                CompletedResult(request_id=request_id, payload=state.payload)
+            )
+
+    async def _run_request(self, request_id: str) -> None:
+        state = self._states[request_id]
+        try:
+            while request_id not in self._aborted:
+                item = await self._get_inbound_with_timeout(request_id, state)
+                if item is _FIRST_SEGMENT_TIMEOUT:
+                    for segment in state.segmenter.push("", now_ms=self._now_ms()):
+                        self._emit_segment(request_id, segment)
+                        state.segment_count += 1
+                        state.first_text_ms = None
+                    continue
+                if is_done_signal(item):
+                    break
+                if isinstance(item, StreamSignal):
+                    if item.error is not None:
+                        raise item.error
+                    continue
+                if not isinstance(item, StreamItem):
+                    raise TypeError(f"Unexpected stream item type: {type(item)!r}")
+
+                text = uint8_tensor_to_text(item.data)
+                now_ms = self._now_ms()
+                if text and state.segment_count == 0 and state.first_text_ms is None:
+                    state.first_text_ms = now_ms
+                for segment in state.segmenter.push(text, now_ms=now_ms):
+                    self._emit_segment(request_id, segment)
+                    state.segment_count += 1
+                    state.first_text_ms = None
+
+            if request_id in self._aborted:
+                return
+
+            final_segments = state.segmenter.flush()
+            if not final_segments:
+                final_segments = [self._empty_final_segment(state.segment_count)]
+            for segment in final_segments:
+                self._emit_segment(request_id, segment)
+                state.segment_count += 1
+
+            self._set_payload_result(
+                state.payload,
+                segment_count=state.segment_count,
+                aborted=False,
+            )
+            await self._results.put(
+                CompletedResult(request_id=request_id, payload=state.payload)
+            )
+        except asyncio.CancelledError:
+            raise
+        except BaseException as exc:
+            exc.request_id = request_id
+            await self._results.put(CompletedResult(request_id=request_id, error=exc))
+        finally:
+            self._tasks.pop(request_id, None)
+            self._states.pop(request_id, None)
+            self._close_stream_queue(request_id)
+
+    async def _get_inbound_with_timeout(
+        self, request_id: str, state: _RequestState
+    ) -> StreamItem | StreamSignal | None | object:
+        timeout = self._first_segment_timeout_seconds(state)
+        if timeout is None:
+            return await self._get_inbound(request_id)
+        if timeout <= 0:
+            return _FIRST_SEGMENT_TIMEOUT
+        try:
+            return await asyncio.wait_for(
+                self._get_inbound(request_id), timeout=timeout
+            )
+        except asyncio.TimeoutError:
+            return _FIRST_SEGMENT_TIMEOUT
+
+    async def _get_inbound(self, request_id: str) -> StreamItem | StreamSignal | None:
+        if self._stream_queue is None:
+            raise RuntimeError("Ming streaming segmenter requires a stream queue")
+        return await self._stream_queue.get_with_source(request_id)
+
+    def _emit_segment(self, request_id: str, segment: TextSegment) -> None:
+        if self._stream_fn is None:
+            return
+        data = text_to_uint8_tensor(segment.text)
+        self._stream_fn(
+            request_id,
+            data,
+            TALKER_STREAM_STAGE,
+            metadata={
+                "segment_id": segment.segment_id,
+                "is_final_segment": bool(segment.is_final_segment),
+                "text_len": int(data.numel()),
+            },
+        )
+
+    def _first_segment_timeout_seconds(self, state: _RequestState) -> float | None:
+        if state.segment_count != 0 or state.first_text_ms is None:
+            return None
+        if state.segmenter.buffer_token_count() < self._config.first_segment_min_tokens:
+            return None
+        elapsed_ms = self._now_ms() - state.first_text_ms
+        remaining_ms = self._config.first_segment_max_wait_ms - elapsed_ms
+        return max(remaining_ms, 0) / 1000
+
+    def _close_stream_queue(self, request_id: str) -> None:
+        if self._stream_queue is not None:
+            self._stream_queue.close(request_id)
+
+    def _empty_final_segment(self, segment_id: int) -> TextSegment:
+        return TextSegment(segment_id=segment_id, text="", is_final_segment=True)
+
+    def _now_ms(self) -> int:
+        return int(time.monotonic() * 1000)
+
+    def _set_payload_result(
+        self,
+        payload: StagePayload,
+        *,
+        segment_count: int,
+        aborted: bool,
+    ) -> None:
+        result = {
+            "segment_count": segment_count,
+            "aborted": aborted,
+        }
+        if isinstance(payload.data, dict):
+            payload.data = {**payload.data, **result}
+        else:
+            payload.data = result
+
+    def _remember_pre_aborted(self, request_id: str) -> None:
+        self._pre_aborted[request_id] = None
+        self._pre_aborted.move_to_end(request_id)
+        while len(self._pre_aborted) > self._max_pre_aborted:
+            self._pre_aborted.popitem(last=False)

--- a/sglang_omni/models/ming_omni/components/streaming_talker_executor.py
+++ b/sglang_omni/models/ming_omni/components/streaming_talker_executor.py
@@ -1,0 +1,599 @@
+"""Streaming Ming-Omni talker executor."""
+
+from __future__ import annotations
+
+import asyncio
+import collections
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import numpy as np
+import torch
+
+from sglang_omni.executors.interface import Executor
+from sglang_omni.models.ming_omni.components.streaming_text import (
+    CompletedResult,
+    is_done_signal,
+    uint8_tensor_to_text,
+)
+from sglang_omni.models.ming_omni.pipeline.next_stage import TALKER_STREAM_STAGE
+from sglang_omni.pipeline.stage.stream_queue import StreamItem, StreamQueue, StreamSignal
+from sglang_omni.proto import StagePayload
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_VOICE = "DB30"
+DEFAULT_SAMPLE_RATE = 44100
+
+
+@dataclass
+class _RequestState:
+    payload: StagePayload
+    output_queue: asyncio.Queue[dict[str, Any] | None]
+    abort_event: threading.Event
+    request_t_start_s: float = 0.0
+    segmenter_first_emit_ms: float | None = None
+    talker_first_audio_ms: float | None = None
+    task: asyncio.Task[None] | None = None
+    segment_count: int = 0
+    result_enqueued: bool = False
+
+
+class MingTalkerStreamExecutor(Executor):
+    """Consume text segments and stream audio chunks from MingOmniTalker."""
+
+    def __init__(
+        self,
+        model_path: str | None = None,
+        *,
+        device: str = "cuda",
+        voice: str = DEFAULT_VOICE,
+        talker: Any | None = None,
+        audio_detokenizer: Any | None = None,
+        sample_rate: int | None = None,
+        loader: Callable[[], Any] | None = None,
+    ) -> None:
+        self._model_path = model_path
+        self._device = device
+        self._voice = voice
+        self._loader = loader
+
+        self._talker = talker
+        self._audio_detokenizer = audio_detokenizer
+        self._sample_rate = sample_rate
+        self._started = talker is not None
+
+        self._stream_queue: StreamQueue | None = None
+        self._results: asyncio.Queue[CompletedResult] = asyncio.Queue()
+        self._states: dict[str, _RequestState] = {}
+        self._tasks: dict[str, asyncio.Task[None]] = {}
+        self._output_queues: dict[
+            str, asyncio.Queue[dict[str, Any] | None]
+        ] = {}
+        self._pre_aborted: collections.OrderedDict[str, None] = (
+            collections.OrderedDict()
+        )
+        self._max_pre_aborted = 4096
+
+    async def start(self) -> None:
+        t_start = time.perf_counter()
+        logger.info(
+            "[TALKER_STREAM] start begin device=%s model_path=%s",
+            self._device,
+            self._model_path,
+        )
+        if self._talker is not None:
+            self._sample_rate = self._resolve_sample_rate()
+            self._started = True
+        elif self._loader is not None:
+            loaded = await asyncio.to_thread(self._loader)
+            self._apply_loaded_models(loaded)
+            if self._talker is None:
+                raise RuntimeError(
+                    "MingTalkerStreamExecutor loader did not provide a talker"
+                )
+            self._sample_rate = self._resolve_sample_rate()
+            self._started = True
+        else:
+            if not self._model_path:
+                raise RuntimeError(
+                    "MingTalkerStreamExecutor requires model_path to start"
+                )
+            await asyncio.to_thread(self._load_production_models)
+            if self._talker is None:
+                raise RuntimeError("MingTalkerStreamExecutor did not load a talker")
+            self._sample_rate = self._resolve_sample_rate()
+            self._started = True
+
+        logger.info(
+            "[TALKER_STREAM] start complete sample_rate=%s elapsed=%.2fs",
+            self._sample_rate,
+            time.perf_counter() - t_start,
+        )
+
+    async def stop(self) -> None:
+        for request_id in list(self._states):
+            await self.abort(request_id)
+
+    async def add_request(self, payload: StagePayload) -> None:
+        request_id = payload.request_id
+        if request_id in self._pre_aborted:
+            self._pre_aborted.pop(request_id, None)
+            self._set_payload_result(payload, aborted=True)
+            self._results.put_nowait(
+                CompletedResult(request_id=request_id, payload=payload)
+            )
+            self._close_stream_queue(request_id)
+            return
+        if self._talker is None:
+            raise RuntimeError(
+                "MingTalkerStreamExecutor.add_request() called before start(); "
+                "call start() or inject a talker for tests"
+            )
+        if self._stream_queue is None:
+            raise RuntimeError("Ming streaming talker requires a stream queue")
+        if request_id in self._states or request_id in self._tasks:
+            raise RuntimeError(f"Request {request_id} is already running")
+
+        output_queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
+        state = _RequestState(
+            payload=payload,
+            output_queue=output_queue,
+            abort_event=threading.Event(),
+            request_t_start_s=time.perf_counter(),
+        )
+        self._states[request_id] = state
+        self._output_queues[request_id] = output_queue
+        task = asyncio.create_task(self._run_request(request_id, state))
+        state.task = task
+        self._tasks[request_id] = task
+
+    async def get_result(self) -> StagePayload:
+        completed = await self._results.get()
+        if completed.error is not None:
+            completed.error.request_id = completed.request_id
+            raise completed.error
+        if completed.payload is None:
+            raise RuntimeError(f"Missing result payload for {completed.request_id}")
+        return completed.payload
+
+    async def abort(self, request_id: str) -> None:
+        state = self._states.get(request_id)
+        task = self._tasks.get(request_id)
+        queue = self._output_queues.get(request_id)
+
+        if state is None and task is None:
+            self._remember_pre_aborted(request_id)
+            self._close_stream_queue(request_id)
+            return
+
+        if state is not None:
+            state.abort_event.set()
+            self._set_payload_result(state.payload, aborted=True)
+            self._enqueue_result_once(
+                state,
+                CompletedResult(request_id=request_id, payload=state.payload),
+            )
+        if queue is not None:
+            self._close_output_queue(queue)
+        if task is not None and not task.done():
+            task.cancel()
+        self._close_stream_queue(request_id)
+
+    def stream(self, request_id: str):
+        queue = self._output_queues.get(request_id)
+
+        async def generator():
+            if queue is None:
+                return
+            while True:
+                item = await queue.get()
+                if item is None:
+                    return
+                yield item
+
+        return generator()
+
+    async def _run_request(self, request_id: str, state: _RequestState) -> None:
+        loop = asyncio.get_running_loop()
+        try:
+            while not state.abort_event.is_set():
+                item = await self._get_inbound(request_id)
+                if is_done_signal(item):
+                    break
+                if isinstance(item, StreamSignal):
+                    if item.error is not None:
+                        raise item.error
+                    continue
+                assert isinstance(item, StreamItem)
+
+                metadata = dict(item.metadata or {})
+                segment_id = int(metadata.get("segment_id", item.chunk_id))
+                is_final_segment = bool(metadata.get("is_final_segment", False))
+                text = uint8_tensor_to_text(item.data)
+                if text:
+                    if state.segmenter_first_emit_ms is None:
+                        state.segmenter_first_emit_ms = (
+                            time.perf_counter() - state.request_t_start_s
+                        ) * 1000.0
+                    await self._run_generation_thread(
+                        loop,
+                        request_id,
+                        text,
+                        segment_id,
+                        state.abort_event,
+                        state,
+                    )
+                    state.segment_count += 1
+                if is_final_segment:
+                    break
+
+            if state.abort_event.is_set():
+                return
+            self._set_payload_result(state.payload, aborted=False)
+            self._enqueue_result_once(
+                state,
+                CompletedResult(request_id=request_id, payload=state.payload),
+            )
+        except asyncio.CancelledError:
+            raise
+        except BaseException as exc:
+            exc.request_id = request_id
+            self._enqueue_result_once(
+                state,
+                CompletedResult(request_id=request_id, error=exc),
+            )
+        finally:
+            if self._states.get(request_id) is state:
+                self._put_sentinel(state.output_queue)
+                self._close_stream_queue(request_id)
+            self._cleanup_request(request_id, state)
+
+    async def _get_inbound(self, request_id: str) -> StreamItem | StreamSignal | None:
+        if self._stream_queue is None:
+            raise RuntimeError("Ming streaming talker requires a stream queue")
+        return await self._stream_queue.get_with_source(request_id)
+
+    def _drain_generation_sync(
+        self,
+        request_id: str,
+        text: str,
+        segment_id: int,
+        abort_event: threading.Event,
+        loop: asyncio.AbstractEventLoop,
+        state: _RequestState,
+    ) -> None:
+        generator = self._build_generation_iterator(text, abort_event)
+        for item in generator:
+            if abort_event.is_set():
+                break
+            waveform = self._extract_waveform(item)
+            if waveform is None or self._waveform_numel(waveform) == 0:
+                continue
+            payload = self._build_audio_payload(waveform, segment_id=segment_id)
+            payload["talker_queue_depth"] = state.output_queue.qsize()
+            if state.talker_first_audio_ms is None:
+                state.talker_first_audio_ms = (
+                    time.perf_counter() - state.request_t_start_s
+                ) * 1000.0
+            payload.setdefault("stage_times_ms", {})
+            payload["stage_times_ms"]["talker_first_audio"] = (
+                state.talker_first_audio_ms
+            )
+            if state.segmenter_first_emit_ms is not None:
+                payload["stage_times_ms"]["segmenter_first_emit"] = (
+                    state.segmenter_first_emit_ms
+                )
+                payload["segmenter_first_emit_ms"] = state.segmenter_first_emit_ms
+            loop.call_soon_threadsafe(
+                self._put_output_if_active,
+                request_id,
+                state,
+                payload,
+            )
+
+    async def _run_generation_thread(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        request_id: str,
+        text: str,
+        segment_id: int,
+        abort_event: threading.Event,
+        state: _RequestState,
+    ) -> None:
+        """ (wenyao) Run the sync generator on a daemon thread; await its completion.
+                                                                                                
+        Generator must honor ``abort_event`` within ~50 ms. If it hangs       
+        (CUDA, 3rd-party code that ignores the event), the daemon thread                       
+        leaks until process exit — daemon=True so shutdown isn't blocked.
+        """
+        future: asyncio.Future[None] = loop.create_future()
+
+        def runner() -> None:
+            try:
+                self._drain_generation_sync(
+                    request_id,
+                    text,
+                    segment_id,
+                    abort_event,
+                    loop,
+                    state,
+                )
+            except BaseException as exc:
+                self._complete_thread_future(loop, future, exc)
+            else:
+                self._complete_thread_future(loop, future, None)
+
+        thread = threading.Thread(
+            target=runner,
+            name=f"ming-talker-stream-{request_id}",
+            daemon=True,
+        )
+        thread.start()
+        await future
+
+    def _complete_thread_future(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        future: asyncio.Future[None],
+        exc: BaseException | None,
+    ) -> None:
+        def complete() -> None:
+            if future.cancelled() or future.done():
+                return
+            if exc is None:
+                future.set_result(None)
+            else:
+                future.set_exception(exc)
+
+        try:
+            loop.call_soon_threadsafe(complete)
+        except RuntimeError:
+            pass
+
+    def _build_generation_iterator(
+        self, text: str, abort_event: threading.Event
+    ) -> Any:
+        if self._talker is None:
+            raise RuntimeError("Talker model not loaded")
+        if hasattr(self._talker, "omni_audio_generation"):
+            return self._talker.omni_audio_generation(
+                tts_text=text,
+                voice_name=self._voice,
+                audio_detokenizer=self._audio_detokenizer,
+                stream=True,
+                abort_event=abort_event,
+            )
+        if hasattr(self._talker, "instruct_audio_generation"):
+            return self._talker.instruct_audio_generation(
+                prompt="Please generate speech based on the following description.\n",
+                text=text,
+                audio_detokenizer=self._audio_detokenizer,
+                stream=True,
+                abort_event=abort_event,
+            )
+        raise RuntimeError("Talker has no supported streaming generation method")
+
+    def _put_output_if_active(
+        self,
+        request_id: str,
+        state: _RequestState,
+        payload: dict[str, Any],
+    ) -> None:
+        if self._states.get(request_id) is not state:
+            return
+        if self._output_queues.get(request_id) is not state.output_queue:
+            return
+        if state.abort_event.is_set():
+            return
+        state.output_queue.put_nowait(payload)
+
+    def _enqueue_result_once(
+        self,
+        state: _RequestState,
+        completed: CompletedResult,
+    ) -> None:
+        if state.result_enqueued:
+            return
+        state.result_enqueued = True
+        self._results.put_nowait(completed)
+
+    def _put_sentinel(
+        self, queue: asyncio.Queue[dict[str, Any] | None]
+    ) -> None:
+        queue.put_nowait(None)
+
+    def _close_output_queue(
+        self, queue: asyncio.Queue[dict[str, Any] | None]
+    ) -> None:
+        while True:
+            try:
+                queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+        queue.put_nowait(None)
+
+    def _cleanup_request(self, request_id: str, state: _RequestState) -> None:
+        # Ownership invariant: only the task that still owns the current
+        # state may remove per-request dictionaries for this request_id.
+        if self._states.get(request_id) is not state:
+            return
+        self._states.pop(request_id, None)
+        task = state.task
+        if task is not None and self._tasks.get(request_id) is task:
+            self._tasks.pop(request_id, None)
+        if self._output_queues.get(request_id) is state.output_queue:
+            self._output_queues.pop(request_id, None)
+
+    def _close_stream_queue(self, request_id: str) -> None:
+        if self._stream_queue is not None:
+            self._stream_queue.close(request_id)
+
+    def _remember_pre_aborted(self, request_id: str) -> None:
+        self._pre_aborted[request_id] = None
+        self._pre_aborted.move_to_end(request_id)
+        while len(self._pre_aborted) > self._max_pre_aborted:
+            self._pre_aborted.popitem(last=False)
+
+    def _extract_waveform(self, item: Any) -> Any | None:
+        if isinstance(item, tuple):
+            return item[0] if item else None
+        return item
+
+    def _waveform_numel(self, waveform: Any) -> int:
+        if isinstance(waveform, torch.Tensor):
+            return int(waveform.numel())
+        if isinstance(waveform, np.ndarray):
+            return int(waveform.size)
+        if isinstance(waveform, (bytes, bytearray, memoryview)):
+            return len(waveform)
+        return int(np.asarray(waveform).size)
+
+    def _build_audio_payload(self, waveform: Any, *, segment_id: int) -> dict[str, Any]:
+        audio_bytes, shape, dtype = self._serialize_waveform(waveform)
+        return {
+            "modality": "audio",
+            "audio_waveform": audio_bytes,
+            "audio_waveform_shape": shape,
+            "audio_waveform_dtype": dtype,
+            "sample_rate": self._resolve_sample_rate(),
+            "stage_name": TALKER_STREAM_STAGE,
+            "segment_id": segment_id,
+        }
+
+    def _serialize_waveform(self, waveform: Any) -> tuple[bytes, list[int], str]:
+        if isinstance(waveform, torch.Tensor):
+            array = waveform.detach().cpu().float().numpy()
+        elif isinstance(waveform, np.ndarray):
+            array = waveform.astype(np.float32, copy=False)
+        elif isinstance(waveform, (bytes, bytearray, memoryview)):
+            raw = bytes(waveform)
+            return raw, [len(raw)], "uint8"
+        else:
+            array = np.asarray(waveform, dtype=np.float32)
+        array = np.asarray(array, dtype=np.float32)
+        return array.tobytes(), list(array.shape), str(array.dtype)
+
+    def _set_payload_result(self, payload: StagePayload, *, aborted: bool) -> None:
+        result = {"aborted": aborted}
+        payload.data = result
+
+    def _resolve_sample_rate(self) -> int:
+        if self._sample_rate is not None:
+            return int(self._sample_rate)
+        for owner in (self._audio_detokenizer, self._talker):
+            sample_rate = self._sample_rate_from(owner)
+            if sample_rate is not None:
+                self._sample_rate = sample_rate
+                return sample_rate
+        self._sample_rate = DEFAULT_SAMPLE_RATE
+        return self._sample_rate
+
+    def _sample_rate_from(self, owner: Any) -> int | None:
+        if owner is None:
+            return None
+        config = getattr(owner, "config", None)
+        sample_rate = getattr(config, "sample_rate", None)
+        if sample_rate is None:
+            sample_rate = getattr(owner, "sample_rate", None)
+        return int(sample_rate) if sample_rate is not None else None
+
+    def _apply_loaded_models(self, loaded: Any) -> None:
+        if not isinstance(loaded, dict):
+            raise RuntimeError(
+                "MingTalkerStreamExecutor loader must return a dict with 'talker'"
+            )
+        self._talker = loaded.get("talker")
+        self._audio_detokenizer = loaded.get(
+            "audio_detokenizer", loaded.get("vae")
+        )
+        if loaded.get("sample_rate") is not None:
+            self._sample_rate = int(loaded["sample_rate"])
+
+    def _load_production_models(self) -> None:
+        from transformers import AutoTokenizer
+
+        from sglang_omni.models.ming_omni.talker import (
+            MingOmniTalker,
+            MingOmniTalkerConfig,
+            SpkembExtractor,
+        )
+        from sglang_omni.models.ming_omni.talker.audio_vae.modeling_audio_vae import (
+            AudioVAE,
+        )
+        from sglang_omni.models.weight_loader import load_weights_by_prefix
+
+        import json
+        import os
+
+        if self._model_path is None:
+            raise RuntimeError("MingTalkerStreamExecutor requires model_path to start")
+
+        t_start = time.perf_counter()
+        talker_model_path = str(Path(self._model_path) / "talker")
+        logger.info(
+            "[TALKER_STREAM] load begin talker_model_path=%s device=%s",
+            talker_model_path,
+            self._device,
+        )
+        config = MingOmniTalkerConfig.from_pretrained_dir(talker_model_path)
+        talker = MingOmniTalker(config)
+        talker.eval()
+        weights = load_weights_by_prefix(talker_model_path, prefix="")
+        talker.load_weights(weights.items())
+        talker.to(device=self._device, dtype=torch.bfloat16)
+        talker.set_tokenizer(
+            AutoTokenizer.from_pretrained(str(Path(talker_model_path) / "llm"))
+        )
+
+        voice_json_path = os.path.join(talker_model_path, "data", "voice_name.json")
+        if os.path.exists(voice_json_path):
+            with open(voice_json_path) as voice_file:
+                voice_dict = json.load(voice_file)
+            for value in voice_dict.values():
+                value["prompt_wav_path"] = os.path.join(
+                    talker_model_path,
+                    value["prompt_wav_path"],
+                )
+            talker.set_voice_presets(voice_dict)
+        else:
+            logger.warning(
+                "[TALKER_STREAM] voice_name.json not found at %s",
+                voice_json_path,
+            )
+
+        campplus_path = os.path.join(talker_model_path, "campplus.onnx")
+        try:
+            talker.set_spkemb_extractor(SpkembExtractor(campplus_path))
+        except (ImportError, Exception) as exc:
+            logger.warning("[TALKER_STREAM] SpkembExtractor not available: %s", exc)
+
+        try:
+            from talker_tn.talker_tn import TalkerTN
+
+            talker.set_normalizer(TalkerTN())
+        except ImportError:
+            logger.warning(
+                "[TALKER_STREAM] TalkerTN unavailable; using identity normalizer"
+            )
+
+        vae_path = str(Path(talker_model_path) / "vae")
+        vae = None
+        if Path(vae_path).exists():
+            vae = AudioVAE.from_pretrained(vae_path, dtype=torch.bfloat16)
+            vae.to(self._device)
+            vae.eval()
+        else:
+            logger.warning("[TALKER_STREAM] AudioVAE not found at %s", vae_path)
+
+        talker.initial_graph()
+        self._talker = talker
+        self._audio_detokenizer = vae
+        logger.info(
+            "[TALKER_STREAM] load complete elapsed=%.2fs",
+            time.perf_counter() - t_start,
+        )

--- a/sglang_omni/models/ming_omni/components/streaming_talker_executor.py
+++ b/sglang_omni/models/ming_omni/components/streaming_talker_executor.py
@@ -21,7 +21,11 @@ from sglang_omni.models.ming_omni.components.streaming_text import (
     uint8_tensor_to_text,
 )
 from sglang_omni.models.ming_omni.pipeline.next_stage import TALKER_STREAM_STAGE
-from sglang_omni.pipeline.stage.stream_queue import StreamItem, StreamQueue, StreamSignal
+from sglang_omni.pipeline.stage.stream_queue import (
+    StreamItem,
+    StreamQueue,
+    StreamSignal,
+)
 from sglang_omni.proto import StagePayload
 
 logger = logging.getLogger(__name__)
@@ -71,9 +75,7 @@ class MingTalkerStreamExecutor(Executor):
         self._results: asyncio.Queue[CompletedResult] = asyncio.Queue()
         self._states: dict[str, _RequestState] = {}
         self._tasks: dict[str, asyncio.Task[None]] = {}
-        self._output_queues: dict[
-            str, asyncio.Queue[dict[str, Any] | None]
-        ] = {}
+        self._output_queues: dict[str, asyncio.Queue[dict[str, Any] | None]] = {}
         self._pre_aborted: collections.OrderedDict[str, None] = (
             collections.OrderedDict()
         )
@@ -281,13 +283,13 @@ class MingTalkerStreamExecutor(Executor):
                     time.perf_counter() - state.request_t_start_s
                 ) * 1000.0
             payload.setdefault("stage_times_ms", {})
-            payload["stage_times_ms"]["talker_first_audio"] = (
-                state.talker_first_audio_ms
-            )
+            payload["stage_times_ms"][
+                "talker_first_audio"
+            ] = state.talker_first_audio_ms
             if state.segmenter_first_emit_ms is not None:
-                payload["stage_times_ms"]["segmenter_first_emit"] = (
-                    state.segmenter_first_emit_ms
-                )
+                payload["stage_times_ms"][
+                    "segmenter_first_emit"
+                ] = state.segmenter_first_emit_ms
                 payload["segmenter_first_emit_ms"] = state.segmenter_first_emit_ms
             loop.call_soon_threadsafe(
                 self._put_output_if_active,
@@ -305,10 +307,10 @@ class MingTalkerStreamExecutor(Executor):
         abort_event: threading.Event,
         state: _RequestState,
     ) -> None:
-        """ (wenyao) Run the sync generator on a daemon thread; await its completion.
-                                                                                                
-        Generator must honor ``abort_event`` within ~50 ms. If it hangs       
-        (CUDA, 3rd-party code that ignores the event), the daemon thread                       
+        """(wenyao) Run the sync generator on a daemon thread; await its completion.
+
+        Generator must honor ``abort_event`` within ~50 ms. If it hangs
+        (CUDA, 3rd-party code that ignores the event), the daemon thread
         leaks until process exit — daemon=True so shutdown isn't blocked.
         """
         future: asyncio.Future[None] = loop.create_future()
@@ -402,14 +404,10 @@ class MingTalkerStreamExecutor(Executor):
         state.result_enqueued = True
         self._results.put_nowait(completed)
 
-    def _put_sentinel(
-        self, queue: asyncio.Queue[dict[str, Any] | None]
-    ) -> None:
+    def _put_sentinel(self, queue: asyncio.Queue[dict[str, Any] | None]) -> None:
         queue.put_nowait(None)
 
-    def _close_output_queue(
-        self, queue: asyncio.Queue[dict[str, Any] | None]
-    ) -> None:
+    def _close_output_queue(self, queue: asyncio.Queue[dict[str, Any] | None]) -> None:
         while True:
             try:
                 queue.get_nowait()
@@ -508,13 +506,14 @@ class MingTalkerStreamExecutor(Executor):
                 "MingTalkerStreamExecutor loader must return a dict with 'talker'"
             )
         self._talker = loaded.get("talker")
-        self._audio_detokenizer = loaded.get(
-            "audio_detokenizer", loaded.get("vae")
-        )
+        self._audio_detokenizer = loaded.get("audio_detokenizer", loaded.get("vae"))
         if loaded.get("sample_rate") is not None:
             self._sample_rate = int(loaded["sample_rate"])
 
     def _load_production_models(self) -> None:
+        import json
+        import os
+
         from transformers import AutoTokenizer
 
         from sglang_omni.models.ming_omni.talker import (
@@ -526,9 +525,6 @@ class MingTalkerStreamExecutor(Executor):
             AudioVAE,
         )
         from sglang_omni.models.weight_loader import load_weights_by_prefix
-
-        import json
-        import os
 
         if self._model_path is None:
             raise RuntimeError("MingTalkerStreamExecutor requires model_path to start")

--- a/sglang_omni/models/ming_omni/components/streaming_text.py
+++ b/sglang_omni/models/ming_omni/components/streaming_text.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import torch
+
+from sglang_omni.pipeline.stage.stream_queue import StreamSignal
+from sglang_omni.proto import StagePayload
+
+
+TokenCountFn = Callable[[str], int]
+
+
+_SEGMENT_END_PUNCTUATION = (".", "!", "?", "。", "！", "？", "；", ";")
+
+
+@dataclass
+class CompletedResult:
+    request_id: str
+    payload: StagePayload | None = None
+    error: BaseException | None = None
+
+
+def is_done_signal(item: Any) -> bool:
+    if item is None:
+        return True
+    return isinstance(item, StreamSignal) and item.is_done and item.error is None
+
+
+def text_to_uint8_tensor(text: str) -> torch.Tensor:
+    return torch.tensor(list(text.encode("utf-8")), dtype=torch.uint8)
+
+
+def uint8_tensor_to_text(tensor: torch.Tensor) -> str:
+    if tensor.dtype != torch.uint8:
+        raise TypeError("uint8_tensor_to_text expects a torch.uint8 tensor")
+    values = tensor.detach().cpu().flatten().tolist()
+    return bytes(values).decode("utf-8", errors="ignore")
+
+
+def split_whitespace_tokens(text: str, max_tokens: int) -> tuple[str, str]:
+    parts = text.split()
+    if len(parts) <= max_tokens:
+        return text, ""
+    return " ".join(parts[:max_tokens]), " ".join(parts[max_tokens:])
+
+
+@dataclass(frozen=True)
+class SegmenterConfig:
+    segment_min_tokens: int = 8
+    segment_max_tokens: int = 40
+    first_segment_min_tokens: int = 4
+    first_segment_max_wait_ms: int = 450
+
+    def __post_init__(self) -> None:
+        if self.segment_min_tokens <= 0:
+            raise ValueError("segment_min_tokens must be positive")
+        if self.segment_max_tokens <= 0:
+            raise ValueError("segment_max_tokens must be positive")
+        if self.first_segment_min_tokens <= 0:
+            raise ValueError("first_segment_min_tokens must be positive")
+        if self.segment_min_tokens > self.segment_max_tokens:
+            raise ValueError("segment_min_tokens must be <= segment_max_tokens")
+        if self.first_segment_min_tokens > self.segment_max_tokens:
+            raise ValueError("first_segment_min_tokens must be <= segment_max_tokens")
+        if self.first_segment_max_wait_ms < 0:
+            raise ValueError("first_segment_max_wait_ms must be non-negative")
+
+
+@dataclass(frozen=True)
+class TextSegment:
+    segment_id: int
+    text: str
+    is_final_segment: bool = False
+
+
+class SegmenterState:
+    def __init__(
+        self,
+        config: SegmenterConfig,
+        token_count_fn: TokenCountFn,
+    ) -> None:
+        self.config = config
+        self.token_count_fn = token_count_fn
+        self._buffer = ""
+        self._segment_id = 0
+        self._first_text_ms: int | None = None
+
+    def push(self, text: str, *, now_ms: int) -> list[TextSegment]:
+        if text and self._first_text_ms is None:
+            self._first_text_ms = now_ms
+        self._buffer += text
+        if not self._buffer:
+            return []
+
+        tokens = self.token_count_fn(self._buffer)
+        if tokens >= self.config.segment_max_tokens:
+            return [self._emit_max_window(now_ms=now_ms)]
+
+        first_timeout_ready = (
+            self._segment_id == 0
+            and self._first_text_ms is not None
+            and tokens >= self.config.first_segment_min_tokens
+            and now_ms - self._first_text_ms
+            >= self.config.first_segment_max_wait_ms
+        )
+        should_emit = (
+            (
+                tokens >= self.config.segment_min_tokens
+                and self._has_segment_end_punctuation()
+            )
+            or first_timeout_ready
+        )
+        if not should_emit:
+            return []
+
+        return [self._emit(is_final_segment=False)]
+
+    def buffer_token_count(self) -> int:
+        return self.token_count_fn(self._buffer) if self._buffer else 0
+
+    def flush(self) -> list[TextSegment]:
+        if not self._buffer:
+            return []
+        return [self._emit(is_final_segment=True)]
+
+    def _has_segment_end_punctuation(self) -> bool:
+        return self._buffer.rstrip().endswith(_SEGMENT_END_PUNCTUATION)
+
+    def _emit_max_window(self, *, now_ms: int) -> TextSegment:
+        text, remainder = split_whitespace_tokens(
+            self._buffer, self.config.segment_max_tokens
+        )
+        return self._emit_text(
+            text=text,
+            remainder=remainder,
+            is_final_segment=False,
+            remainder_start_ms=now_ms if remainder else None,
+        )
+
+    def _emit(self, *, is_final_segment: bool) -> TextSegment:
+        return self._emit_text(
+            text=self._buffer,
+            remainder="",
+            is_final_segment=is_final_segment,
+            remainder_start_ms=None,
+        )
+
+    def _emit_text(
+        self,
+        *,
+        text: str,
+        remainder: str,
+        is_final_segment: bool,
+        remainder_start_ms: int | None,
+    ) -> TextSegment:
+        segment = TextSegment(
+            segment_id=self._segment_id,
+            text=text,
+            is_final_segment=is_final_segment,
+        )
+        self._segment_id += 1
+        self._buffer = remainder
+        self._first_text_ms = remainder_start_ms
+        return segment

--- a/sglang_omni/models/ming_omni/components/streaming_text.py
+++ b/sglang_omni/models/ming_omni/components/streaming_text.py
@@ -8,7 +8,6 @@ import torch
 from sglang_omni.pipeline.stage.stream_queue import StreamSignal
 from sglang_omni.proto import StagePayload
 
-
 TokenCountFn = Callable[[str], int]
 
 
@@ -102,16 +101,12 @@ class SegmenterState:
             self._segment_id == 0
             and self._first_text_ms is not None
             and tokens >= self.config.first_segment_min_tokens
-            and now_ms - self._first_text_ms
-            >= self.config.first_segment_max_wait_ms
+            and now_ms - self._first_text_ms >= self.config.first_segment_max_wait_ms
         )
         should_emit = (
-            (
-                tokens >= self.config.segment_min_tokens
-                and self._has_segment_end_punctuation()
-            )
-            or first_timeout_ready
-        )
+            tokens >= self.config.segment_min_tokens
+            and self._has_segment_end_punctuation()
+        ) or first_timeout_ready
         if not should_emit:
             return []
 

--- a/sglang_omni/models/ming_omni/config.py
+++ b/sglang_omni/models/ming_omni/config.py
@@ -12,13 +12,16 @@ from sglang_omni.config import (
     RelayConfig,
     StageConfig,
 )
+from sglang_omni.config.schema import StreamTargetConfig
 from sglang_omni.models.ming_omni.pipeline.next_stage import (
     AGGREGATE_STAGE,
     AUDIO_STAGE,
     DECODE_STAGE,
     IMAGE_STAGE,
     PREPROCESSING_STAGE,
+    SEGMENTER_STAGE,
     TALKER_STAGE,
+    TALKER_STREAM_STAGE,
     THINKER_STAGE,
 )
 
@@ -111,15 +114,19 @@ def _validate_ming_speech_gpu_placement(
     gpu_placement: dict[str, int],
     *,
     tp_size: int,
+    talker_stage: str = TALKER_STAGE,
 ) -> None:
     thinker_gpu = gpu_placement.get("thinker", 0)
-    talker_gpu = gpu_placement.get("talker", 1)
+    talker_gpu = gpu_placement.get(
+        talker_stage,
+        gpu_placement.get(TALKER_STAGE, 1),
+    )
     thinker_range = range(thinker_gpu, thinker_gpu + tp_size)
     if talker_gpu in thinker_range:
         raise ValueError(
-            f"Talker GPU {talker_gpu} collides with thinker TP range "
+            f"{talker_stage} GPU {talker_gpu} collides with thinker TP range "
             f"[{thinker_gpu}, {thinker_gpu + tp_size}). "
-            f"Set --gpu-talker >= {thinker_gpu + tp_size}."
+            f"Set {talker_stage!r} GPU >= {thinker_gpu + tp_size}."
         )
 
 
@@ -228,6 +235,134 @@ class MingOmniSpeechPipelineConfig(PipelineConfig):
             _validate_ming_speech_gpu_placement(
                 self.gpu_placement,
                 tp_size=overrides["tp_size"],
+            )
+        super().apply_server_args_overrides(
+            stage_name=stage_name,
+            overrides=overrides,
+        )
+
+
+class MingOmniStreamingSpeechPipelineConfig(PipelineConfig):
+    """Streaming speech pipeline for Ming-Omni with thinker text side channel.
+
+    Routes thinker text chunks through a segmenter before the streaming talker.
+    """
+
+    architecture: ClassVar[str] = "BailingMM2NativeForConditionalGeneration"
+
+    model_path: str
+    entry_stage: str = "preprocessing"
+    terminal_stages: list[str] = [DECODE_STAGE, TALKER_STREAM_STAGE]
+    gpu_placement: dict[str, int] = {
+        "thinker": 0,
+        TALKER_STREAM_STAGE: 1,
+    }
+
+    stages: list[StageConfig] = [
+        StageConfig(
+            name=PREPROCESSING_STAGE,
+            executor=ExecutorConfig(
+                factory="sglang_omni.models.ming_omni.pipeline.stages.create_preprocessing_executor",
+            ),
+            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.preprocessing_next",
+            relay=RelayConfig(device="cpu"),
+        ),
+        StageConfig(
+            name=AUDIO_STAGE,
+            executor=ExecutorConfig(
+                factory="sglang_omni.models.ming_omni.pipeline.stages.create_audio_encoder_executor",
+                args={"device": "cuda", "dtype": None},
+            ),
+            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.encoder_next",
+            relay=RelayConfig(device="cuda"),
+        ),
+        StageConfig(
+            name=IMAGE_STAGE,
+            executor=ExecutorConfig(
+                factory="sglang_omni.models.ming_omni.pipeline.stages.create_image_encoder_executor",
+                args={"device": "cuda", "dtype": None},
+            ),
+            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.encoder_next",
+            relay=RelayConfig(device="cuda"),
+        ),
+        StageConfig(
+            name=AGGREGATE_STAGE,
+            executor=ExecutorConfig(
+                factory="sglang_omni.models.ming_omni.pipeline.stages.create_aggregate_executor",
+                args={},
+            ),
+            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.aggregate_next",
+            input_handler=InputHandlerConfig(
+                type="aggregated",
+                sources=[PREPROCESSING_STAGE, AUDIO_STAGE, IMAGE_STAGE],
+                merge_fn="sglang_omni.models.ming_omni.pipeline.merge.merge_for_thinker",
+            ),
+            relay=RelayConfig(device="cpu"),
+        ),
+        StageConfig(
+            name=THINKER_STAGE,
+            executor=ExecutorConfig(
+                factory="sglang_omni.models.ming_omni.pipeline.stages.create_sglang_thinker_executor_from_config",
+                args={
+                    "thinker_max_seq_len": 8192,
+                    "stream_text_to_segmenter": True,
+                    "stream_text_target_stage": SEGMENTER_STAGE,
+                },
+            ),
+            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.thinker_next_streaming_speech",
+            relay=RelayConfig(device="cuda"),
+            stream_to=[StreamTargetConfig(to_stage=SEGMENTER_STAGE)],
+        ),
+        StageConfig(
+            name=DECODE_STAGE,
+            executor=ExecutorConfig(
+                factory="sglang_omni.models.ming_omni.pipeline.stages.create_decode_executor",
+                args={},
+            ),
+            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.decode_next",
+            relay=RelayConfig(device="cpu"),
+        ),
+        StageConfig(
+            name=SEGMENTER_STAGE,
+            executor=ExecutorConfig(
+                factory="sglang_omni.models.ming_omni.pipeline.stages.create_streaming_segmenter_executor",
+                args={},
+            ),
+            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.segmenter_next",
+            relay=RelayConfig(device="cpu"),
+            stream_to=[StreamTargetConfig(to_stage=TALKER_STREAM_STAGE)],
+        ),
+        StageConfig(
+            name=TALKER_STREAM_STAGE,
+            executor=ExecutorConfig(
+                factory="sglang_omni.models.ming_omni.pipeline.stages.create_talker_stream_executor",
+                args={"device": "cuda"},
+            ),
+            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.talker_stream_next",
+            relay=RelayConfig(device="cuda"),
+        ),
+    ]
+
+    @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"thinker": THINKER_STAGE}
+
+    def model_post_init(self, __context: Any) -> None:
+        super().model_post_init(__context)
+        _validate_ming_speech_gpu_placement(
+            self.gpu_placement,
+            tp_size=1,
+            talker_stage=TALKER_STREAM_STAGE,
+        )
+
+    def apply_server_args_overrides(
+        self, *, stage_name: str, overrides: dict[str, Any]
+    ) -> None:
+        if stage_name == THINKER_STAGE and "tp_size" in overrides:
+            _validate_ming_speech_gpu_placement(
+                self.gpu_placement,
+                tp_size=overrides["tp_size"],
+                talker_stage=TALKER_STREAM_STAGE,
             )
         super().apply_server_args_overrides(
             stage_name=stage_name,

--- a/sglang_omni/models/ming_omni/pipeline/next_stage.py
+++ b/sglang_omni/models/ming_omni/pipeline/next_stage.py
@@ -15,6 +15,8 @@ AGGREGATE_STAGE = "mm_aggregate"
 THINKER_STAGE = "thinker"
 DECODE_STAGE = "decode"
 TALKER_STAGE = "talker"
+SEGMENTER_STAGE = "segmenter"
+TALKER_STREAM_STAGE = "talker_stream"
 
 
 def preprocessing_next(request_id: str, output: Any) -> list[str]:
@@ -56,13 +58,31 @@ def thinker_next_speech(request_id: str, output: Any) -> list[str]:
     return [DECODE_STAGE, TALKER_STAGE]
 
 
+def thinker_next_streaming_speech(request_id: str, output: Any) -> list[str]:
+    """Streaming speech pipeline: thinker decodes text and streams text through the segmenter."""
+    del request_id, output
+    return [DECODE_STAGE, SEGMENTER_STAGE]
+
+
 def decode_next(request_id: str, output: Any) -> None:
     """Decode is terminal."""
     del request_id, output
     return None
 
 
+def segmenter_next(request_id: str, output: Any) -> str:
+    """Segmenter routes to streaming talker."""
+    del request_id, output
+    return TALKER_STREAM_STAGE
+
+
 def talker_next(request_id: str, output: Any) -> None:
     """Talker is terminal."""
+    del request_id, output
+    return None
+
+
+def talker_stream_next(request_id: str, output: Any) -> None:
+    """Streaming talker is terminal."""
     del request_id, output
     return None

--- a/sglang_omni/models/ming_omni/pipeline/stages.py
+++ b/sglang_omni/models/ming_omni/pipeline/stages.py
@@ -5,19 +5,16 @@ from __future__ import annotations
 
 from typing import Any
 
-from sglang_omni.engines.ar.sglang_backend.server_args_builder import (
-    apply_encoder_mem_reserve,
-    build_sglang_server_args,
-)
 from sglang_omni.engines.omni import create_sglang_ar_engine, create_single_pass_engine
 from sglang_omni.executors import EngineExecutor, PreprocessingExecutor
-from sglang_omni.models.ming_omni.components.audio_encoder import MingAudioEncoder
 from sglang_omni.models.ming_omni.components.common import (
     load_ming_config,
     load_ming_tokenizer,
 )
-from sglang_omni.models.ming_omni.components.preprocessor import MingPreprocessor
-from sglang_omni.models.ming_omni.components.talker_executor import MingTalkerExecutor
+from sglang_omni.models.ming_omni.components.streaming_text import (
+    SegmenterConfig,
+    text_to_uint8_tensor,
+)
 from sglang_omni.models.ming_omni.io import OmniEvent, ThinkerOutput
 from sglang_omni.models.ming_omni.pipeline.engine_io import (
     apply_encoder_result,
@@ -29,6 +26,7 @@ from sglang_omni.models.ming_omni.pipeline.merge import decode_events
 from sglang_omni.models.ming_omni.pipeline.next_stage import (
     AUDIO_STAGE,
     IMAGE_STAGE,
+    SEGMENTER_STAGE,
     THINKER_STAGE,
 )
 from sglang_omni.models.ming_omni.pipeline.state_io import load_state, store_state
@@ -46,6 +44,8 @@ def _event_to_dict(event: OmniEvent) -> dict[str, Any]:
 
 
 def create_preprocessing_executor(model_path: str) -> PreprocessingExecutor:
+    from sglang_omni.models.ming_omni.components.preprocessor import MingPreprocessor
+
     preprocessor = MingPreprocessor(model_path=model_path)
 
     async def _preprocess(payload: StagePayload) -> StagePayload:
@@ -67,6 +67,8 @@ def create_audio_encoder_executor(
     device: str = "cuda",
     dtype: str | None = None,
 ) -> EngineExecutor:
+    from sglang_omni.models.ming_omni.components.audio_encoder import MingAudioEncoder
+
     model = MingAudioEncoder(model_path=model_path, device=device, dtype=dtype)
 
     def _request_builder(payload: StagePayload):
@@ -125,6 +127,8 @@ def create_sglang_thinker_executor(
     model_path: str,
     *,
     gpu_id: int = 0,
+    stream_text_to_segmenter: bool = False,
+    stream_text_target_stage: str = SEGMENTER_STAGE,
 ) -> EngineExecutor:
     """Create a thinker executor backed by SGLang's ModelWorker."""
     tokenizer = load_ming_tokenizer(model_path)
@@ -138,6 +142,7 @@ def create_sglang_thinker_executor(
     )
 
     step_counters: dict[str, int] = {}
+    stream_fn_holder: dict[str, Any] = {"fn": None}
 
     def _request_builder(payload: StagePayload):
         state = load_state(payload)
@@ -191,13 +196,24 @@ def create_sglang_thinker_executor(
             ]
 
         text_to_add = ""
+        side_channel_text = ""
         for event in events:
             if event.modality == "text" and "text" in event.payload:
                 if event.is_final:
-                    text_to_add = event.payload["text"]
+                    final_text = str(event.payload["text"])
+                    emitted_text = str(state.stream_state.get("emitted_text", ""))
+                    if final_text.startswith(emitted_text):
+                        final_delta = final_text[len(emitted_text) :]
+                    else:
+                        final_delta = final_text
+                    text_to_add += final_delta
+                    side_channel_text += final_delta
+                    state.stream_state["emitted_text"] = final_text
                     break
                 else:
-                    text_to_add += event.payload["text"]
+                    delta_text = event.payload["text"]
+                    text_to_add += delta_text
+                    side_channel_text += delta_text
 
         result: dict[str, Any] = {
             "events": [_event_to_dict(event) for event in events],
@@ -207,6 +223,21 @@ def create_sglang_thinker_executor(
         }
         if text_to_add:
             result["text"] = text_to_add
+            stream_fn = stream_fn_holder.get("fn")
+            if stream_text_to_segmenter and callable(stream_fn) and side_channel_text:
+                text_tensor = text_to_uint8_tensor(side_channel_text)
+                stream_fn(
+                    request_id,
+                    text_tensor,
+                    stream_text_target_stage,
+                    metadata={
+                        "token_id": token_id,
+                        "step": step,
+                        "text_len": int(text_tensor.numel()),
+                        "source_stage": THINKER_STAGE,
+                        "target_stage": stream_text_target_stage,
+                    },
+                )
         return result
 
     engine = create_sglang_ar_engine(
@@ -215,12 +246,20 @@ def create_sglang_thinker_executor(
         model_arch_override="BailingMoeV2ForCausalLM",
     )
 
-    return EngineExecutor(
+    executor = EngineExecutor(
         engine=engine,
         request_builder=_request_builder,
         result_builder=_result_builder,
         stream_builder=_stream_builder,
     )
+    original_set_stream_fn = executor.set_stream_fn
+
+    def _set_stream_fn(fn) -> None:
+        stream_fn_holder["fn"] = fn
+        original_set_stream_fn(fn)
+
+    executor.set_stream_fn = _set_stream_fn  # type: ignore[method-assign]
+    return executor
 
 
 _ming_config_registered = False
@@ -301,8 +340,15 @@ def create_sglang_thinker_executor_from_config(
     gpu_id: int = 0,
     thinker_max_seq_len: int = 8192,
     server_args_overrides: dict[str, Any] | None = None,
+    stream_text_to_segmenter: bool = False,
+    stream_text_target_stage: str = SEGMENTER_STAGE,
 ) -> EngineExecutor:
     """Create a SGLang thinker executor from JSON-serializable config args."""
+    from sglang_omni.engines.ar.sglang_backend.server_args_builder import (
+        apply_encoder_mem_reserve,
+        build_sglang_server_args,
+    )
+
     import logging as _log
 
     _log.getLogger(__name__).info(
@@ -356,6 +402,8 @@ def create_sglang_thinker_executor_from_config(
         server_args=server_args,
         model_path=local_path,
         gpu_id=gpu_id,
+        stream_text_to_segmenter=stream_text_to_segmenter,
+        stream_text_target_stage=stream_text_target_stage,
     )
     post_load_avail_mem = avail_gpu_mem(gpu_id)
     post_load_mem = (
@@ -381,6 +429,10 @@ def create_talker_executor(
     The talker is a self-contained MingOmniTalker with its own LLM + CFM + AudioVAE,
     wrapped as an Executor for the pipeline.
     """
+    from sglang_omni.models.ming_omni.components.talker_executor import (
+        MingTalkerExecutor,
+    )
+
     # Resolve HF repo ID to local snapshot path so that
     # Path(model_path) / "talker" yields a real filesystem path.
     local_path = _resolve_local_model_path(model_path)
@@ -390,6 +442,51 @@ def create_talker_executor(
         device=device,
         voice=voice,
     )
+
+
+def create_streaming_segmenter_executor(model_path: str, **kwargs: Any) -> Any:
+    """Create the streaming text segmenter executor."""
+    from sglang_omni.models.ming_omni.components.streaming_segmenter_executor import (
+        MingStreamingSegmenterExecutor,
+    )
+
+    tokenizer = load_ming_tokenizer(model_path)
+
+    def _token_count(text: str) -> int:
+        encode = getattr(tokenizer, "encode", None)
+        if callable(encode):
+            try:
+                return len(encode(text, add_special_tokens=False))
+            except TypeError:
+                return len(encode(text))
+            except Exception:
+                pass
+        return len(text.split()) or len(text)
+
+    config = SegmenterConfig(
+        segment_min_tokens=int(kwargs.pop("segment_min_tokens", 8)),
+        segment_max_tokens=int(kwargs.pop("segment_max_tokens", 40)),
+        first_segment_min_tokens=int(kwargs.pop("first_segment_min_tokens", 4)),
+        first_segment_max_wait_ms=int(kwargs.pop("first_segment_max_wait_ms", 450)),
+    )
+    return MingStreamingSegmenterExecutor(
+        config=config,
+        token_count_fn=_token_count,
+        **kwargs,
+    )
+
+
+def create_talker_stream_executor(
+    model_path: str,
+    *,
+    device: str = "cuda",
+    **kwargs: Any,
+) -> Any:
+    from sglang_omni.models.ming_omni.components.streaming_talker_executor import (
+        MingTalkerStreamExecutor,
+    )
+    local_path = _resolve_local_model_path(model_path)
+    return MingTalkerStreamExecutor(model_path=local_path, device=device, **kwargs)
 
 
 def create_decode_executor(model_path: str) -> PreprocessingExecutor:

--- a/sglang_omni/models/ming_omni/pipeline/stages.py
+++ b/sglang_omni/models/ming_omni/pipeline/stages.py
@@ -344,12 +344,12 @@ def create_sglang_thinker_executor_from_config(
     stream_text_target_stage: str = SEGMENTER_STAGE,
 ) -> EngineExecutor:
     """Create a SGLang thinker executor from JSON-serializable config args."""
+    import logging as _log
+
     from sglang_omni.engines.ar.sglang_backend.server_args_builder import (
         apply_encoder_mem_reserve,
         build_sglang_server_args,
     )
-
-    import logging as _log
 
     _log.getLogger(__name__).info(
         f"create_sglang_thinker_executor_from_config: "
@@ -485,6 +485,7 @@ def create_talker_stream_executor(
     from sglang_omni.models.ming_omni.components.streaming_talker_executor import (
         MingTalkerStreamExecutor,
     )
+
     local_path = _resolve_local_model_path(model_path)
     return MingTalkerStreamExecutor(model_path=local_path, device=device, **kwargs)
 

--- a/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
+++ b/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
@@ -7,12 +7,12 @@ infrastructure, CFM/DiT/Aggregator modules and generation.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import math
 import queue
 import re
 import threading
-import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from queue import Queue
@@ -34,6 +34,8 @@ from .talker_module.cfm import CFM, get_epss_timesteps
 from .talker_module.dit import DiT
 
 logger = logging.getLogger(__name__)
+
+_TOKEN_DONE = object()
 
 # ---------- Optional: onnxruntime for speaker embedding ----------
 try:
@@ -109,8 +111,16 @@ class CFMGraphExecutor:
         self.graph = None
 
     def execute(
-        self, input_tensor, his_lat, cfg_strength=2.0, sigma=0.25, temperature=0.0
+        self,
+        input_tensor,
+        his_lat,
+        cfg_strength=2.0,
+        sigma=0.25,
+        temperature=0.0,
+        abort_event: threading.Event | None = None,
     ):
+        if abort_event is not None and abort_event.is_set():
+            raise asyncio.CancelledError()
         bat_size, his_patch_size, z_dim = his_lat.shape
         randn_tensor = torch.randn(
             (bat_size, self.config.patch_size, z_dim),
@@ -127,7 +137,11 @@ class CFMGraphExecutor:
         )
 
         if not self.initialized:
-            self._initialize_graph(input_tensor, his_lat, randn_tensor, sde_rnd)
+            if abort_event is not None and abort_event.is_set():
+                raise asyncio.CancelledError()
+            self._initialize_graph(
+                input_tensor, his_lat, randn_tensor, sde_rnd, abort_event
+            )
 
         self.last_hidden_state_placeholder.copy_(input_tensor)
         self.his_lat_placeholder.copy_(his_lat)
@@ -138,7 +152,13 @@ class CFMGraphExecutor:
         self.sde_args_placeholder[2] = temperature
         self.sde_rnd_placeholder.copy_(sde_rnd)
 
+        if abort_event is not None and abort_event.is_set():
+            raise asyncio.CancelledError()
+        # Python abort checks inside CFM.sample run during capture; replay is
+        # bounded by explicit checks before and after the CUDA graph replay.
         self.graph.replay()
+        if abort_event is not None and abort_event.is_set():
+            raise asyncio.CancelledError()
 
         gen_lat = torch.empty_like(self.gen_lat_placeholder)
         gen_lat.copy_(self.gen_lat_placeholder)
@@ -149,7 +169,9 @@ class CFMGraphExecutor:
 
         return gen_lat, inputs_embeds, stop_out
 
-    def _initialize_graph(self, input_tensor, his_lat, randn_tensor, sde_rnd):
+    def _initialize_graph(
+        self, input_tensor, his_lat, randn_tensor, sde_rnd, abort_event=None
+    ):
         self.last_hidden_state_placeholder = torch.empty_like(input_tensor)
         self.his_lat_placeholder = torch.empty_like(his_lat)
         self.randn_like_placeholder = torch.empty_like(randn_tensor)
@@ -163,20 +185,31 @@ class CFMGraphExecutor:
         )
         self.sde_rnd_placeholder = torch.empty_like(sde_rnd)
 
+        # (wenyao) Aborting CFM.sample during torch.cuda.graph capture corrupts the
+        # partial graph. Pass abort_event=None during capture; the caller
+        # (execute) checks abort before _initialize_graph and on every replay.
         self.graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(self.graph):
-            self.gen_lat_placeholder = self.cfm.sample(
-                self.last_hidden_state_placeholder,
-                self.his_lat_placeholder,
-                self.randn_like_placeholder,
-                self.t_placeholder,
-                self.sde_args_placeholder,
-                self.sde_rnd_placeholder,
-            )
-            self.inputs_embeds_placeholder = self.aggregator(self.gen_lat_placeholder)
-            self.stop_out_placeholder = self.stop_head(
-                self.last_hidden_state_placeholder[:, -1, :]
-            ).softmax(dim=-1)
+        try:
+            with torch.cuda.graph(self.graph):
+                self.gen_lat_placeholder = self.cfm.sample(
+                    self.last_hidden_state_placeholder,
+                    self.his_lat_placeholder,
+                    self.randn_like_placeholder,
+                    self.t_placeholder,
+                    self.sde_args_placeholder,
+                    self.sde_rnd_placeholder,
+                    abort_event=None,
+                )
+                self.inputs_embeds_placeholder = self.aggregator(self.gen_lat_placeholder)
+                self.stop_out_placeholder = self.stop_head(
+                    self.last_hidden_state_placeholder[:, -1, :]
+                ).softmax(dim=-1)
+        except BaseException:
+            self.graph = None
+            self.gen_lat_placeholder = None
+            self.inputs_embeds_placeholder = None
+            self.stop_out_placeholder = None
+            raise
 
         self.initialized = True
 
@@ -206,12 +239,18 @@ class CFMGraphExecutorPool:
             self.pool.put(executor)
 
     def execute(
-        self, input_tensor, his_lat, cfg_strength=2.0, sigma=0.25, temperature=0.0
+        self,
+        input_tensor,
+        his_lat,
+        cfg_strength=2.0,
+        sigma=0.25,
+        temperature=0.0,
+        abort_event: threading.Event | None = None,
     ):
         executor = self.acquire()
         try:
             return executor.execute(
-                input_tensor, his_lat, cfg_strength, sigma, temperature
+                input_tensor, his_lat, cfg_strength, sigma, temperature, abort_event
             )
         finally:
             self.release(executor)
@@ -373,24 +412,25 @@ class MingOmniTalker(nn.Module):
                         "Please generate speech based on the following description.\n"
                     )
                     text = "Initialize compilation graph"
-                    future = self.executor.submit(
-                        self.llm_job,
-                        prompt,
-                        text,
-                        None,
-                        None,
-                        "",
-                        None,
-                        None,
-                        this_uuid,
-                    )
-                    future.result()
-
-                    with self.lock:
-                        self.tts_speech_token_dict.pop(this_uuid)
-                        self.llm_end_dict.pop(this_uuid)
-                        self.vae_cache.pop(this_uuid)
-                        self.sil_holder_cache.pop(this_uuid)
+                    try:
+                        future = self.executor.submit(
+                            self.llm_job,
+                            prompt,
+                            text,
+                            None,
+                            None,
+                            "",
+                            None,
+                            None,
+                            this_uuid,
+                        )
+                        future.result()
+                    finally:
+                        with self.lock:
+                            self.tts_speech_token_dict.pop(this_uuid, None)
+                            self.llm_end_dict.pop(this_uuid, None)
+                            self.vae_cache.pop(this_uuid, None)
+                            self.sil_holder_cache.pop(this_uuid, None)
 
                 self.initialized = True
 
@@ -414,6 +454,7 @@ class MingOmniTalker(nn.Module):
         cfg=2.0,
         sigma=0.25,
         temperature=0,
+        abort_event: threading.Event | None = None,
     ):
         step = 0
         target_dtype = torch.bfloat16
@@ -446,121 +487,128 @@ class MingOmniTalker(nn.Module):
             model_graph,
         ) = self.model_graph_pool.get()
 
-        if past_key_values is None:
-            past_key_values = StaticCache(
-                config=self.model.config,
-                max_batch_size=1,
-                max_cache_len=max_cache_len,
-                device=self.model.device,
-                dtype=target_dtype,
-            )
-        else:
-            if hasattr(past_key_values, "reset"):
-                past_key_values.reset()
-            elif hasattr(past_key_values, "key_cache"):
-                for layer_idx in range(len(past_key_values.key_cache)):
-                    past_key_values.key_cache[layer_idx].zero_()
-                    past_key_values.value_cache[layer_idx].zero_()
-            else:
-                for layer in past_key_values.layers:
-                    layer.keys.zero_()
-                    layer.values.zero_()
-
-        prefill_len = inputs_embeds.shape[1]
-        attention_mask = torch.ones(input_ids.shape).to(input_ids.device)
-        position_ids = (attention_mask.cumsum(-1) - 1).masked_fill_(
-            (attention_mask == 0), 1
-        )
-
-        max_decode_steps = (max_cache_len - prefill_len) // self.patch_size
-
-        while step < 1000 and step < max_decode_steps:
-            if step == 0:
-                prefill_cache_position = torch.arange(
-                    0, prefill_len, device=inputs_embeds.device
-                )
-                outputs = self.model(
-                    position_ids=position_ids,
-                    cache_position=prefill_cache_position,
-                    past_key_values=past_key_values,
-                    inputs_embeds=inputs_embeds,
-                    use_cache=True,
-                    output_hidden_states=True,
+        try:
+            if past_key_values is None:
+                past_key_values = StaticCache(
+                    config=self.model.config,
+                    max_batch_size=1,
+                    max_cache_len=max_cache_len,
+                    device=self.model.device,
+                    dtype=target_dtype,
                 )
             else:
-                past_seen_tokens = past_key_values.get_seq_length()
-                cache_position = torch.arange(
-                    past_seen_tokens,
-                    past_seen_tokens + inputs_embeds.shape[1],
-                    device=inputs_embeds.device,
-                )
-
-                if model_graph is None:
-                    model_graph = torch.cuda.CUDAGraph()
-                    inputs_embeds_placeholder = torch.empty_like(inputs_embeds)
-                    position_ids_placeholder = None
-                    attention_mask_placeholder = None
-                    cache_position_placeholder = torch.empty_like(cache_position)
-
-                    inputs_embeds_placeholder.copy_(inputs_embeds)
-                    cache_position_placeholder.copy_(cache_position)
-
-                    with torch.cuda.graph(model_graph):
-                        outputs_placeholder = self.model(
-                            position_ids=position_ids_placeholder,
-                            cache_position=cache_position_placeholder,
-                            attention_mask=attention_mask_placeholder,
-                            past_key_values=past_key_values,
-                            inputs_embeds=inputs_embeds_placeholder,
-                            use_cache=True,
-                            output_hidden_states=True,
-                        )
+                if hasattr(past_key_values, "reset"):
+                    past_key_values.reset()
+                elif hasattr(past_key_values, "key_cache"):
+                    for layer_idx in range(len(past_key_values.key_cache)):
+                        past_key_values.key_cache[layer_idx].zero_()
+                        past_key_values.value_cache[layer_idx].zero_()
                 else:
-                    inputs_embeds_placeholder.copy_(inputs_embeds)
-                    if cache_position_placeholder is not None:
+                    for layer in past_key_values.layers:
+                        layer.keys.zero_()
+                        layer.values.zero_()
+
+            prefill_len = inputs_embeds.shape[1]
+            attention_mask = torch.ones(input_ids.shape).to(input_ids.device)
+            position_ids = (attention_mask.cumsum(-1) - 1).masked_fill_(
+                (attention_mask == 0), 1
+            )
+
+            max_decode_steps = (max_cache_len - prefill_len) // self.patch_size
+
+            while step < 1000 and step < max_decode_steps:
+                if abort_event is not None and abort_event.is_set():
+                    raise asyncio.CancelledError()
+                if step == 0:
+                    prefill_cache_position = torch.arange(
+                        0, prefill_len, device=inputs_embeds.device
+                    )
+                    outputs = self.model(
+                        position_ids=position_ids,
+                        cache_position=prefill_cache_position,
+                        past_key_values=past_key_values,
+                        inputs_embeds=inputs_embeds,
+                        use_cache=True,
+                        output_hidden_states=True,
+                    )
+                else:
+                    past_seen_tokens = past_key_values.get_seq_length()
+                    cache_position = torch.arange(
+                        past_seen_tokens,
+                        past_seen_tokens + inputs_embeds.shape[1],
+                        device=inputs_embeds.device,
+                    )
+
+                    if model_graph is None:
+                        model_graph = torch.cuda.CUDAGraph()
+                        inputs_embeds_placeholder = torch.empty_like(inputs_embeds)
+                        position_ids_placeholder = None
+                        attention_mask_placeholder = None
+                        cache_position_placeholder = torch.empty_like(cache_position)
+
+                        inputs_embeds_placeholder.copy_(inputs_embeds)
                         cache_position_placeholder.copy_(cache_position)
-                    model_graph.replay()
 
-                outputs = outputs_placeholder
+                        with torch.cuda.graph(model_graph):
+                            outputs_placeholder = self.model(
+                                position_ids=position_ids_placeholder,
+                                cache_position=cache_position_placeholder,
+                                attention_mask=attention_mask_placeholder,
+                                past_key_values=past_key_values,
+                                inputs_embeds=inputs_embeds_placeholder,
+                                use_cache=True,
+                                output_hidden_states=True,
+                            )
+                    else:
+                        inputs_embeds_placeholder.copy_(inputs_embeds)
+                        if cache_position_placeholder is not None:
+                            cache_position_placeholder.copy_(cache_position)
+                        model_graph.replay()
 
-            hidden_out = outputs.hidden_states[-1][:, -1:, :]
+                    outputs = outputs_placeholder
 
-            gen_lat, inputs_embeds, stop_out = self.sampler_pool.execute(
-                hidden_out,
-                his_lat,
-                cfg,
-                sigma,
-                temperature,
-            )
+                hidden_out = outputs.hidden_states[-1][:, -1:, :]
 
-            if self.his_patch_size == self.patch_size:
-                his_lat = gen_lat
-            elif self.his_patch_size > self.patch_size:
-                his_lat = torch.cat(
-                    [his_lat[:, self.patch_size - self.his_patch_size :], gen_lat],
-                    dim=1,
+                gen_lat, inputs_embeds, stop_out = self.sampler_pool.execute(
+                    hidden_out,
+                    his_lat,
+                    cfg,
+                    sigma,
+                    temperature,
+                    abort_event,
                 )
-            else:
-                raise NotImplementedError
 
-            if step > min_new_token and stop_out.cpu()[0, 1] > 0.5:
-                yield gen_lat, True
-                break
+                if self.his_patch_size == self.patch_size:
+                    his_lat = gen_lat
+                elif self.his_patch_size > self.patch_size:
+                    his_lat = torch.cat(
+                        [his_lat[:, self.patch_size - self.his_patch_size :], gen_lat],
+                        dim=1,
+                    )
+                else:
+                    raise NotImplementedError
 
-            yield gen_lat, False
-            step += 1
+                if abort_event is not None and abort_event.is_set():
+                    raise asyncio.CancelledError()
 
-        self.model_graph_pool.put(
-            (
-                past_key_values,
-                inputs_embeds_placeholder,
-                cache_position_placeholder,
-                position_ids_placeholder,
-                attention_mask_placeholder,
-                outputs_placeholder,
-                model_graph,
+                if step > min_new_token and stop_out.cpu()[0, 1] > 0.5:
+                    yield gen_lat, True
+                    break
+
+                yield gen_lat, False
+                step += 1
+        finally:
+            self.model_graph_pool.put(
+                (
+                    past_key_values,
+                    inputs_embeds_placeholder,
+                    cache_position_placeholder,
+                    position_ids_placeholder,
+                    attention_mask_placeholder,
+                    outputs_placeholder,
+                    model_graph,
+                )
             )
-        )
 
     def omni_audio_generation_func(
         self,
@@ -574,6 +622,7 @@ class MingOmniTalker(nn.Module):
         cfg=2.0,
         sigma=0.25,
         temperature=0,
+        abort_event: threading.Event | None = None,
     ):
         assert (
             self.tokenizer is not None
@@ -668,6 +717,7 @@ class MingOmniTalker(nn.Module):
                 cfg=cfg,
                 sigma=sigma,
                 temperature=temperature,
+                abort_event=abort_event,
             ):
                 yield audio_token
 
@@ -755,23 +805,37 @@ class MingOmniTalker(nn.Module):
         cfg=2.0,
         sigma=0.25,
         temperature=0,
+        token_queue: queue.Queue | None = None,
+        abort_event: threading.Event | None = None,
     ):
-        with torch.cuda.stream(torch.cuda.Stream(self.device)):
-            for audio_token in self.omni_audio_generation_func(
-                prompt=prompt,
-                text=text,
-                spk_emb=spk_emb,
-                instruction=instruction,
-                prompt_text=prompt_text,
-                prompt_wav_lat=prompt_wav_lat,
-                prompt_wav_emb=prompt_wav_emb,
-                cfg=cfg,
-                sigma=sigma,
-                temperature=temperature,
-            ):
-                torch.cuda.current_stream().synchronize()
-                self.tts_speech_token_dict[this_uuid].append(audio_token)
-        self.llm_end_dict[this_uuid] = True
+        try:
+            with torch.cuda.stream(torch.cuda.Stream(self.device)):
+                for audio_token in self.omni_audio_generation_func(
+                    prompt=prompt,
+                    text=text,
+                    spk_emb=spk_emb,
+                    instruction=instruction,
+                    prompt_text=prompt_text,
+                    prompt_wav_lat=prompt_wav_lat,
+                    prompt_wav_emb=prompt_wav_emb,
+                    cfg=cfg,
+                    sigma=sigma,
+                    temperature=temperature,
+                    abort_event=abort_event,
+                ):
+                    if abort_event is not None and abort_event.is_set():
+                        raise asyncio.CancelledError()
+                    torch.cuda.current_stream().synchronize()
+                    if token_queue is not None:
+                        token_queue.put(audio_token)
+                    else:
+                        self.tts_speech_token_dict[this_uuid].append(audio_token)
+        finally:
+            with self.lock:
+                if this_uuid in self.llm_end_dict:
+                    self.llm_end_dict[this_uuid] = True
+            if token_queue is not None:
+                token_queue.put(_TOKEN_DONE)
 
     def tts_job(
         self,
@@ -787,9 +851,16 @@ class MingOmniTalker(nn.Module):
         cfg=2.0,
         sigma=0.25,
         temperature=0,
+        abort_event: threading.Event | None = None,
     ):
         with torch.cuda.stream(torch.cuda.Stream(self.device)):
             this_uuid = str(uuid.uuid1())
+            token_queue = queue.Queue() if stream else None
+            effective_abort_event = abort_event
+            if stream and effective_abort_event is None:
+                effective_abort_event = threading.Event()
+            completed = False
+            future = None
             with self.lock:
                 self.tts_speech_token_dict[this_uuid] = []
                 self.llm_end_dict[this_uuid] = False
@@ -799,36 +870,50 @@ class MingOmniTalker(nn.Module):
                 }
                 self.sil_holder_cache[this_uuid] = None
 
-            future = self.executor.submit(
-                self.llm_job,
-                prompt,
-                text,
-                spk_emb,
-                instruction,
-                prompt_text,
-                prompt_wav_lat,
-                prompt_wav_emb,
-                this_uuid,
-                cfg,
-                sigma,
-                temperature,
-            )
+            try:
+                future = self.executor.submit(
+                    self.llm_job,
+                    prompt,
+                    text,
+                    spk_emb,
+                    instruction,
+                    prompt_text,
+                    prompt_wav_lat,
+                    prompt_wav_emb,
+                    this_uuid,
+                    cfg,
+                    sigma,
+                    temperature,
+                    token_queue=token_queue,
+                    abort_event=effective_abort_event,
+                )
 
-            if stream:
-                token_offset = 0
-                while True:
-                    if future.done():
-                        exc = future.exception()
-                        if exc:
-                            raise exc
-                    time.sleep(0.1)
-                    nxt = len(self.tts_speech_token_dict[this_uuid])
-                    if nxt > token_offset:
-                        this_tts_speech_token = self.tts_speech_token_dict[this_uuid][
-                            token_offset:nxt
-                        ]
-                        last_chunk = this_tts_speech_token[-1][-1]
-                        this_tts_speech_token = [ii[0] for ii in this_tts_speech_token]
+                if stream:
+                    assert token_queue is not None
+                    # 25ms wakeup keeps the abort_event check responsive when
+                    # llm_job has not yet pushed a token or _TOKEN_DONE.
+                    # Worst-case external abort latency is bounded by this poll
+                    # interval plus one inner generator step.
+                    while True:
+                        if (
+                            effective_abort_event is not None
+                            and effective_abort_event.is_set()
+                        ):
+                            raise asyncio.CancelledError()
+                        if future.done():
+                            exc = future.exception()
+                            if exc:
+                                raise exc
+                        try:
+                            queue_item = token_queue.get(timeout=0.025)
+                        except queue.Empty:
+                            continue
+                        if queue_item is _TOKEN_DONE:
+                            future.result()
+                            completed = True
+                            break
+                        last_chunk = queue_item[-1]
+                        this_tts_speech_token = [queue_item[0]]
                         this_tts_speech, self.vae_cache[this_uuid] = self.token2wav(
                             audio_detokenizer=audio_detokenizer,
                             token=this_tts_speech_token,
@@ -836,41 +921,43 @@ class MingOmniTalker(nn.Module):
                             stream=True,
                             last_chunk=last_chunk,
                         )
-                        token_offset = nxt
                         yield {"tts_speech": this_tts_speech.cpu()}
+                else:
+                    future.result()
+                    this_tts_speech_token = self.tts_speech_token_dict[this_uuid]
+                    this_tts_speech_token = [ii[0] for ii in this_tts_speech_token]
+                    this_tts_speech, self.vae_cache[this_uuid] = self.token2wav(
+                        audio_detokenizer=audio_detokenizer,
+                        token=this_tts_speech_token,
+                        cache=self.vae_cache[this_uuid],
+                        stream=False,
+                        last_chunk=True,
+                    )
+                    (
+                        this_tts_speech,
+                        self.sil_holder_cache[this_uuid],
+                    ) = self.silence_holder(
+                        this_tts_speech,
+                        audio_detokenizer.config.sample_rate,
+                        self.sil_holder_cache[this_uuid],
+                        True,
+                    )
+                    yield {"tts_speech": this_tts_speech.cpu()}
+                    completed = True
 
-                    if self.llm_end_dict[this_uuid] and token_offset == len(
-                        self.tts_speech_token_dict[this_uuid]
-                    ):
-                        break
-                future.result()
-            else:
-                future.result()
-                this_tts_speech_token = self.tts_speech_token_dict[this_uuid]
-                this_tts_speech_token = [ii[0] for ii in this_tts_speech_token]
-                this_tts_speech, self.vae_cache[this_uuid] = self.token2wav(
-                    audio_detokenizer=audio_detokenizer,
-                    token=this_tts_speech_token,
-                    cache=self.vae_cache[this_uuid],
-                    stream=False,
-                    last_chunk=True,
-                )
-                this_tts_speech, self.sil_holder_cache[this_uuid] = self.silence_holder(
-                    this_tts_speech,
-                    audio_detokenizer.config.sample_rate,
-                    self.sil_holder_cache[this_uuid],
-                    True,
-                )
-                yield {"tts_speech": this_tts_speech.cpu()}
-
-            if torch.cuda.is_available():
-                torch.cuda.current_stream().synchronize()
-
-            with self.lock:
-                self.tts_speech_token_dict.pop(this_uuid)
-                self.llm_end_dict.pop(this_uuid)
-                self.vae_cache.pop(this_uuid)
-                self.sil_holder_cache.pop(this_uuid)
+                if torch.cuda.is_available():
+                    torch.cuda.current_stream().synchronize()
+            finally:
+                if stream and not completed:
+                    if effective_abort_event is not None:
+                        effective_abort_event.set()
+                    if future is not None:
+                        future.cancel()
+                with self.lock:
+                    self.tts_speech_token_dict.pop(this_uuid, None)
+                    self.llm_end_dict.pop(this_uuid, None)
+                    self.vae_cache.pop(this_uuid, None)
+                    self.sil_holder_cache.pop(this_uuid, None)
 
     def register_prompt_wav(self, prompt_wav_path, audio_detokenizer):
         if isinstance(prompt_wav_path, str):
@@ -976,6 +1063,7 @@ class MingOmniTalker(nn.Module):
         prompt_wav_emb,
         stream,
         max_length=50,
+        abort_event: threading.Event | None = None,
     ):
         count = 0
         cache_position: dict = {}
@@ -1045,6 +1133,7 @@ class MingOmniTalker(nn.Module):
                     max_length,
                     wds_lg_zh,
                     wds_lg_en,
+                    abort_event,
                 )
                 count += 1
                 streaming_text = []
@@ -1067,6 +1156,7 @@ class MingOmniTalker(nn.Module):
                 max_length,
                 wds_lg_zh,
                 wds_lg_en,
+                abort_event,
             )
 
     def _process_segment(
@@ -1085,6 +1175,7 @@ class MingOmniTalker(nn.Module):
         max_length,
         wds_lg_zh,
         wds_lg_en,
+        abort_event: threading.Event | None = None,
     ):
         sub_output_dict = cut_text_by_semantic_length(streaming_text, max_length)
         text_list = sub_output_dict["fragments"]
@@ -1124,6 +1215,7 @@ class MingOmniTalker(nn.Module):
                     prompt_wav_lat=prompt_wav_lat,
                     prompt_wav_emb=prompt_wav_emb,
                     stream=use_stream,
+                    abort_event=abort_event,
                 )
             ):
                 tts_speech = this_tts_speech_dict["tts_speech"]
@@ -1186,6 +1278,7 @@ class MingOmniTalker(nn.Module):
         text = tts_text
         prompt = "Please generate speech based on the following description.\n"
         instruction = None
+        abort_event = kwargs.get("abort_event")
 
         with torch.cuda.stream(torch.cuda.Stream(self.device)):
             self.initial_graph()
@@ -1211,8 +1304,9 @@ class MingOmniTalker(nn.Module):
                 prompt_text,
                 prompt_wav_lat,
                 prompt_wav_emb,
-                stream,
-                max_length,
+                stream=stream,
+                max_length=max_length,
+                abort_event=abort_event if stream else None,
             )
 
     def instruct_audio_generation(
@@ -1234,6 +1328,7 @@ class MingOmniTalker(nn.Module):
         taskname="TTS",
         **kwargs,
     ):
+        abort_event = kwargs.get("abort_event")
         with torch.cuda.stream(torch.cuda.Stream(self.device)):
             self.initial_graph()
 
@@ -1265,6 +1360,7 @@ class MingOmniTalker(nn.Module):
                     cfg=cfg,
                     sigma=sigma,
                     temperature=temperature,
+                    abort_event=abort_event if stream else None,
                 ):
                     yield this_tts_speech_dict["tts_speech"], None, None, None
             else:
@@ -1277,6 +1373,7 @@ class MingOmniTalker(nn.Module):
                     prompt_text,
                     prompt_wav_lat,
                     prompt_wav_emb,
-                    stream,
-                    max_length,
+                    stream=stream,
+                    max_length=max_length,
+                    abort_event=abort_event if stream else None,
                 )

--- a/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
+++ b/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
@@ -200,7 +200,9 @@ class CFMGraphExecutor:
                     self.sde_rnd_placeholder,
                     abort_event=None,
                 )
-                self.inputs_embeds_placeholder = self.aggregator(self.gen_lat_placeholder)
+                self.inputs_embeds_placeholder = self.aggregator(
+                    self.gen_lat_placeholder
+                )
                 self.stop_out_placeholder = self.stop_head(
                     self.last_hidden_state_placeholder[:, -1, :]
                 ).softmax(dim=-1)

--- a/sglang_omni/models/ming_omni/talker/talker_module/cfm.py
+++ b/sglang_omni/models/ming_omni/talker/talker_module/cfm.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 import torch
 import torch.nn.functional as F
 from torch import nn
@@ -31,8 +33,12 @@ class CFM(nn.Module):
         self.sway_sampling_coef = sway_sampling_coef
 
     @torch.no_grad()
-    def sample(self, llm_cond, lat_cond, y0, t, sde_args, sde_rnd):
+    def sample(self, llm_cond, lat_cond, y0, t, sde_args, sde_rnd, abort_event=None):
         # cfg_strength=2, sigma=0, temperature=0
+        def check_abort():
+            if abort_event is not None and abort_event.is_set():
+                raise asyncio.CancelledError()
+
         def fn(fn_t, x):
             pred_cfg = self.model.forward_with_cfg(x, fn_t, llm_cond, lat_cond, None)
             pred, null_pred = torch.chunk(pred_cfg, 2, dim=0)
@@ -43,6 +49,7 @@ class CFM(nn.Module):
 
         trajectory = [y0]
         for step in range(self.steps):
+            check_abort()
             dt = t[step + 1] - t[step]
             y0 = y0 + fn(t[step], y0) * dt
             y0 = (

--- a/sglang_omni/pipeline/worker/data_plane.py
+++ b/sglang_omni/pipeline/worker/data_plane.py
@@ -137,9 +137,7 @@ class DataPlaneAdapter:
             # Concatenate all tensors
             all_tensors = torch.cat(tensor_buffers)
             if all_tensors.numel() == 0:
-                all_tensors = torch.zeros(
-                    1, dtype=torch.uint8, device=transport_device
-                )
+                all_tensors = torch.zeros(1, dtype=torch.uint8, device=transport_device)
         else:
             # Relay still expects a payload to transfer; use a 1-byte placeholder.
             all_tensors = torch.zeros(1, dtype=torch.uint8, device=device)
@@ -231,9 +229,7 @@ class DataPlaneAdapter:
         is_empty_tensor = flat.numel() == 0
         relay_tensor = flat
         if is_empty_tensor:
-            relay_tensor = torch.zeros(
-                1, dtype=torch.uint8, device=transport_device
-            )
+            relay_tensor = torch.zeros(1, dtype=torch.uint8, device=transport_device)
 
         op = await self._relay.put_async(relay_tensor, request_id=key)
         metadata = {

--- a/sglang_omni/pipeline/worker/data_plane.py
+++ b/sglang_omni/pipeline/worker/data_plane.py
@@ -136,6 +136,10 @@ class DataPlaneAdapter:
 
             # Concatenate all tensors
             all_tensors = torch.cat(tensor_buffers)
+            if all_tensors.numel() == 0:
+                all_tensors = torch.zeros(
+                    1, dtype=torch.uint8, device=transport_device
+                )
         else:
             # Relay still expects a payload to transfer; use a 1-byte placeholder.
             all_tensors = torch.zeros(1, dtype=torch.uint8, device=device)
@@ -183,15 +187,15 @@ class DataPlaneAdapter:
                 offset = info["offset"]
                 size = info["size"]
 
-                # Extract tensor bytes
-                tensor_bytes = recv_tensor[offset : offset + size]
-
                 # Parse dtype
                 dtype = getattr(torch, dtype_str.replace("torch.", ""))
 
-                # Keep a view into the relay receive buffer instead of cloning;
-                # write_payload pads offsets so dtype views are aligned.
-                tensor = tensor_bytes.view(dtype).reshape(shape)
+                if size == 0:
+                    tensor = torch.empty(shape, dtype=dtype, device=device)
+                else:
+                    # Extract tensor bytes
+                    tensor_bytes = recv_tensor[offset : offset + size]
+                    tensor = tensor_bytes.view(dtype).reshape(shape)
                 tensor_dict[path] = tensor
 
         # Restore tensors into payload
@@ -218,12 +222,25 @@ class DataPlaneAdapter:
         Returns (metadata_dict, relay_operation).
         metadata_dict is sent via control plane; receiver uses it in read_blob.
         """
+        device = self._relay.device if hasattr(self._relay, "device") else "cpu"
+        transport_device = torch.device(device)
         flat = tensor.contiguous().view(torch.uint8).reshape(-1)
-        op = await self._relay.put_async(flat, request_id=key)
+        if flat.device != transport_device:
+            flat = flat.to(device=transport_device)
+
+        is_empty_tensor = flat.numel() == 0
+        relay_tensor = flat
+        if is_empty_tensor:
+            relay_tensor = torch.zeros(
+                1, dtype=torch.uint8, device=transport_device
+            )
+
+        op = await self._relay.put_async(relay_tensor, request_id=key)
         metadata = {
             "relay_info": op.metadata,
             "tensor_shape": list(tensor.shape),
             "tensor_dtype": str(tensor.dtype),
+            "empty_tensor": is_empty_tensor,
         }
         return metadata, op
 
@@ -246,6 +263,9 @@ class DataPlaneAdapter:
         await op.wait_for_completion()
 
         dtype = getattr(torch, dtype_str.replace("torch.", ""))
+        if metadata.get("empty_tensor"):
+            return torch.empty(shape, dtype=dtype, device=device)
+
         tensor = recv_buf.view(dtype).reshape(shape)
         return tensor
 

--- a/sglang_omni/pipeline/worker/runtime.py
+++ b/sglang_omni/pipeline/worker/runtime.py
@@ -85,6 +85,11 @@ class Worker:
             raise RuntimeError("Worker not bound to a stage")
 
         try:
+            logger.info(
+                "Worker starting executor for stage %s (%s)",
+                self.stage.name,
+                type(self.executor).__name__,
+            )
             await self.executor.start()
             self._running = True
 
@@ -118,6 +123,9 @@ class Worker:
 
         except asyncio.CancelledError:
             logger.info("Worker cancelled for stage %s", self.stage.name)
+        except Exception:
+            logger.exception("Worker failed for stage %s", self.stage.name)
+            raise
         finally:
             self._running = False
             # Stop streaming send loop
@@ -207,6 +215,10 @@ class Worker:
 
             output_payload = await fut
             logger.debug("Worker %s: got result for %s", self.stage.name, request_id)
+
+            if stream_task is not None:
+                await self._finish_stream_task(stream_task)
+                stream_task = None
 
             # Signal stream done to all downstream streaming targets
             for target in self._stream_targets:

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -12,6 +12,7 @@ Provides the following endpoints:
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import logging
@@ -275,69 +276,103 @@ async def _chat_stream(
     requested_modalities = req.modalities or ["text"]
     finish_reason: str | None = None
     final_usage: UsageResponse | None = None
+    stream_start_s = time.perf_counter()
+    stage_times_ms: dict[str, float] = {}
 
-    async for chunk in client.completion_stream(
-        gen_req,
-        request_id=request_id,
-        audio_format=audio_format,
-    ):
-        # Capture finish info for the dedicated finish chunk after the loop.
-        if chunk.finish_reason is not None:
-            finish_reason = chunk.finish_reason
-            if chunk.usage is not None:
-                final_usage = UsageResponse(
-                    prompt_tokens=chunk.usage.prompt_tokens or 0,
-                    completion_tokens=chunk.usage.completion_tokens or 0,
-                    total_tokens=chunk.usage.total_tokens or 0,
-                )
-            continue
-
-        delta = ChatCompletionStreamDelta()
-        emit = False
-
-        # Send role on first chunk
-        if not role_sent:
-            delta.role = "assistant"
-            role_sent = True
-            emit = True
-
-        # Text chunk
-        if chunk.modality == "text" and chunk.text and "text" in requested_modalities:
-            delta.content = chunk.text
-            emit = True
-
-        # Audio chunk
-        if (
-            chunk.modality == "audio"
-            and chunk.audio_b64 is not None
-            and "audio" in requested_modalities
+    try:
+        async for chunk in client.completion_stream(
+            gen_req,
+            request_id=request_id,
+            audio_format=audio_format,
         ):
-            delta.audio = ChatCompletionAudio(
-                id=f"audio-{request_id}",
-                data=chunk.audio_b64,
-            )
-            emit = True
+            # Capture finish info for the dedicated finish chunk after the loop.
+            if chunk.finish_reason is not None:
+                finish_reason = chunk.finish_reason
+                if chunk.usage is not None:
+                    final_usage = UsageResponse(
+                        prompt_tokens=chunk.usage.prompt_tokens or 0,
+                        completion_tokens=chunk.usage.completion_tokens or 0,
+                        total_tokens=chunk.usage.total_tokens or 0,
+                    )
+                continue
 
-        if not emit:
-            continue
+            delta = ChatCompletionStreamDelta()
+            emit = False
 
-        stream_resp = ChatCompletionStreamResponse(
-            id=response_id,
-            created=created,
-            model=model,
-            choices=[
-                ChatCompletionStreamChoice(
-                    index=0,
-                    delta=delta,
-                    finish_reason=None,
+            # Send role on first chunk
+            if not role_sent:
+                delta.role = "assistant"
+                role_sent = True
+                emit = True
+
+            # Text chunk
+            if (
+                chunk.modality == "text"
+                and chunk.text
+                and "text" in requested_modalities
+            ):
+                delta.content = chunk.text
+                emit = True
+                stage_times_ms.setdefault(
+                    "thinker_first_text",
+                    (time.perf_counter() - stream_start_s) * 1000.0,
                 )
-            ],
-        )
 
-        data = stream_resp.model_dump(exclude_none=True)
-        for choice in data.get("choices", []):
-            choice.setdefault("finish_reason", None)
-        yield f"data: {json.dumps(data)}\n\n"
+            # Audio chunk
+            if (
+                chunk.modality == "audio"
+                and chunk.audio_b64 is not None
+                and "audio" in requested_modalities
+            ):
+                delta.audio = ChatCompletionAudio(
+                    id=f"audio-{request_id}",
+                    data=chunk.audio_b64,
+                )
+                emit = True
+                first_audio_ms = (time.perf_counter() - stream_start_s) * 1000.0
+                stage_times_ms.setdefault("talker_first_audio", first_audio_ms)
+                segmenter_first_emit_ms = getattr(
+                    chunk, "segmenter_first_emit_ms", None
+                )
+                if segmenter_first_emit_ms is not None:
+                    stage_times_ms.setdefault(
+                        "segmenter_first_emit", float(segmenter_first_emit_ms)
+                    )
+
+            if not emit:
+                continue
+
+            stream_resp = ChatCompletionStreamResponse(
+                id=response_id,
+                created=created,
+                model=model,
+                choices=[
+                    ChatCompletionStreamChoice(
+                        index=0,
+                        delta=delta,
+                        finish_reason=None,
+                    )
+                ],
+            )
+
+            data = stream_resp.model_dump(exclude_none=True)
+            for choice in data.get("choices", []):
+                choice.setdefault("finish_reason", None)
+            stage_name = getattr(chunk, "stage_name", None)
+            sample_rate = getattr(chunk, "sample_rate", None)
+            talker_queue_depth = getattr(chunk, "talker_queue_depth", None)
+            if stage_name is not None:
+                data["stage_name"] = stage_name
+            if sample_rate is not None:
+                data["sample_rate"] = sample_rate
+            if talker_queue_depth is not None:
+                data["talker_queue_depth"] = talker_queue_depth
+            if stage_times_ms:
+                data["stage_times_ms"] = dict(stage_times_ms)
+            yield f"data: {json.dumps(data)}\n\n"
+    except (asyncio.CancelledError, GeneratorExit):
+        await client.abort(request_id)
+        raise
 
     # Finish chunk: empty delta + finish_reason.
     finish_resp = ChatCompletionStreamResponse(

--- a/tests/test_ming_streaming_client.py
+++ b/tests/test_ming_streaming_client.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Ming streaming TTS client behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import struct
+from typing import Any
+
+import numpy as np
+
+from sglang_omni.client.client import Client
+from sglang_omni.client.types import GenerateChunk, GenerateRequest
+from sglang_omni.proto import StreamMessage
+from sglang_omni.serve.openai_api import _chat_stream
+
+
+class _FakeStreamingCoordinator:
+    def __init__(self, *, segmenter_first_emit_ms: float | None = 42.0):
+        self._segmenter_first_emit_ms = segmenter_first_emit_ms
+        self.aborted_request_ids: list[str] = []
+
+    async def abort(self, request_id: str) -> bool:
+        self.aborted_request_ids.append(request_id)
+        return True
+
+    async def stream(self, request_id: str, request: Any):
+        yield StreamMessage(
+            request_id=request_id,
+            from_stage="talker",
+            chunk=GenerateChunk(
+                request_id=request_id,
+                modality="audio",
+                audio_data=np.zeros(4410, dtype=np.float32),
+                sample_rate=44100,
+                stage_name="talker_stream",
+                talker_queue_depth=2,
+                segmenter_first_emit_ms=self._segmenter_first_emit_ms,
+            ),
+        )
+        yield StreamMessage(
+            request_id=request_id,
+            from_stage="talker",
+            chunk=GenerateChunk(request_id=request_id, finish_reason="stop"),
+        )
+
+
+class _FakeStreamingCoordinatorWithEmptyAudio:
+    def __init__(self) -> None:
+        self.aborted_request_ids: list[str] = []
+
+    async def abort(self, request_id: str) -> bool:
+        self.aborted_request_ids.append(request_id)
+        return True
+
+    async def stream(self, request_id: str, request: Any):
+        yield StreamMessage(
+            request_id=request_id,
+            from_stage="thinker",
+            chunk=GenerateChunk(request_id=request_id, modality="text", text="hi"),
+        )
+        yield StreamMessage(
+            request_id=request_id,
+            from_stage="talker",
+            chunk=GenerateChunk(
+                request_id=request_id,
+                modality="audio",
+                audio_data=np.zeros(0, dtype=np.float32),
+                sample_rate=44100,
+                stage_name="talker_stream",
+            ),
+        )
+        yield StreamMessage(
+            request_id=request_id,
+            from_stage="talker",
+            chunk=GenerateChunk(
+                request_id=request_id,
+                modality="audio",
+                audio_data=np.zeros(4410, dtype=np.float32),
+                sample_rate=44100,
+                stage_name="talker_stream",
+            ),
+        )
+        yield StreamMessage(
+            request_id=request_id,
+            from_stage="decode",
+            chunk=GenerateChunk(request_id=request_id, finish_reason="stop"),
+        )
+
+
+class _FakeMingTalkerMergedCoordinator:
+    async def submit(self, request_id: str, request: Any):
+        waveform = np.zeros(2205, dtype=np.float32)
+        return {
+            "decode": {
+                "text": "The sun rises in the east.",
+                "usage": {
+                    "prompt_tokens": 3,
+                    "completion_tokens": 7,
+                    "total_tokens": 10,
+                },
+            },
+            "talker": {
+                "audio_waveform": waveform.tobytes(),
+                "audio_waveform_dtype": str(waveform.dtype),
+                "audio_waveform_shape": list(waveform.shape),
+                "sample_rate": 44100,
+            },
+        }
+
+
+async def _collect_stream_chunks():
+    client = Client(_FakeStreamingCoordinator())
+    chunks = []
+    async for chunk in client.completion_stream(
+        GenerateRequest(prompt="hello", stream=True),
+        request_id="req-sr",
+    ):
+        chunks.append(chunk)
+    return chunks
+
+
+def _wav_sample_rate(audio_b64: str) -> int:
+    wav = base64.b64decode(audio_b64)
+    return struct.unpack("<I", wav[24:28])[0]
+
+
+def _wav_frame_count(audio_b64: str) -> int:
+    wav = base64.b64decode(audio_b64)
+    data_size = struct.unpack("<I", wav[40:44])[0]
+    return data_size // 2
+
+
+def test_completion_stream_uses_chunk_sample_rate_for_wav_header():
+    chunks = asyncio.run(_collect_stream_chunks())
+
+    audio_chunk = next(chunk for chunk in chunks if chunk.audio_b64)
+
+    assert _wav_sample_rate(audio_chunk.audio_b64) == 44100
+    assert audio_chunk.sample_rate == 44100
+    assert audio_chunk.talker_queue_depth == 2
+
+
+def test_completion_builds_audio_from_ming_talker_merged_result():
+    client = Client(_FakeMingTalkerMergedCoordinator())
+
+    result = asyncio.run(
+        client.completion(
+            GenerateRequest(prompt="hello", stream=False),
+            request_id="req-ming-nonstream-audio",
+        )
+    )
+
+    assert result.audio is not None
+    assert result.audio.transcript == "The sun rises in the east."
+    assert _wav_sample_rate(result.audio.data) == 44100
+    assert _wav_frame_count(result.audio.data) == 2205
+    assert result.usage is not None
+    assert result.usage.total_tokens == 10
+
+
+def test_chat_stream_emits_audio_observability_extensions():
+    coordinator = _FakeStreamingCoordinator()
+    client = Client(coordinator)
+    request = type("Req", (), {"modalities": ["text", "audio"]})()
+    gen = _chat_stream(
+        client,
+        GenerateRequest(prompt="hello", stream=True),
+        "req-observe",
+        "chatcmpl",
+        0,
+        "ming",
+        request,
+        "wav",
+    )
+
+    async def run():
+        first = await gen.__anext__()
+        await gen.aclose()
+        return json.loads(first[len("data: ") :])
+
+    payload = asyncio.run(run())
+
+    assert payload["stage_name"] == "talker_stream"
+    assert payload["sample_rate"] == 44100
+    assert payload["talker_queue_depth"] == 2
+    assert payload["stage_times_ms"]["talker_first_audio"] >= 0
+    assert payload["stage_times_ms"]["segmenter_first_emit"] == 42.0
+    assert coordinator.aborted_request_ids == ["req-observe"]
+
+
+def test_chat_stream_suppresses_empty_audio_chunks():
+    client = Client(_FakeStreamingCoordinatorWithEmptyAudio())
+    request = type("Req", (), {"modalities": ["text", "audio"]})()
+    gen = _chat_stream(
+        client,
+        GenerateRequest(prompt="hello", stream=True),
+        "req-empty-audio",
+        "chatcmpl",
+        0,
+        "ming",
+        request,
+        "wav",
+    )
+
+    async def run():
+        events = []
+        async for raw in gen:
+            payload = raw[len("data: ") :].strip()
+            events.append(payload)
+            if payload == "[DONE]":
+                break
+        return events
+
+    events = asyncio.run(run())
+    payloads = [json.loads(event) for event in events if event != "[DONE]"]
+    audio_chunks = [
+        choice["delta"]["audio"]["data"]
+        for payload in payloads
+        for choice in payload["choices"]
+        if "audio" in choice["delta"]
+    ]
+
+    assert [_wav_frame_count(audio) for audio in audio_chunks] == [4410]
+    assert events[-1] == "[DONE]"

--- a/tests/test_ming_streaming_pipeline_config.py
+++ b/tests/test_ming_streaming_pipeline_config.py
@@ -32,7 +32,9 @@ def test_launcher_selects_streaming_speech_config_and_talker_stream_gpu() -> Non
 
 
 def test_streaming_speech_topology_routes_text_segments_to_talker_stream() -> None:
-    from sglang_omni.models.ming_omni.config import MingOmniStreamingSpeechPipelineConfig
+    from sglang_omni.models.ming_omni.config import (
+        MingOmniStreamingSpeechPipelineConfig,
+    )
     from sglang_omni.models.ming_omni.pipeline.next_stage import (
         DECODE_STAGE,
         SEGMENTER_STAGE,
@@ -52,11 +54,18 @@ def test_streaming_speech_topology_routes_text_segments_to_talker_stream() -> No
     assert config.terminal_stages == [DECODE_STAGE, TALKER_STREAM_STAGE]
     assert thinker_next_streaming_speech("req-1", {}) == [DECODE_STAGE, SEGMENTER_STAGE]
     assert segmenter_next("req-1", {}) == TALKER_STREAM_STAGE
-    assert _stage_by_name(config, THINKER_STAGE).stream_to[0].to_stage == SEGMENTER_STAGE
-    assert _stage_by_name(config, SEGMENTER_STAGE).stream_to[0].to_stage == TALKER_STREAM_STAGE
+    assert (
+        _stage_by_name(config, THINKER_STAGE).stream_to[0].to_stage == SEGMENTER_STAGE
+    )
+    assert (
+        _stage_by_name(config, SEGMENTER_STAGE).stream_to[0].to_stage
+        == TALKER_STREAM_STAGE
+    )
 
 
-def test_streaming_speech_config_validates_talker_stream_outside_thinker_tp_range() -> None:
+def test_streaming_speech_config_validates_talker_stream_outside_thinker_tp_range() -> (
+    None
+):
     from sglang_omni.models.ming_omni.config import (
         MingOmniStreamingSpeechPipelineConfig,
     )

--- a/tests/test_ming_streaming_pipeline_config.py
+++ b/tests/test_ming_streaming_pipeline_config.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+
+def _stage_by_name(config, name: str):
+    return next(stage for stage in config.stages if stage.name == name)
+
+
+def test_launcher_selects_streaming_speech_config_and_talker_stream_gpu() -> None:
+    from examples.run_ming_omni_server import (
+        resolve_ming_gpu_placement,
+        resolve_ming_pipeline_config,
+    )
+    from sglang_omni.models.ming_omni.config import (
+        MingOmniStreamingSpeechPipelineConfig,
+    )
+    from sglang_omni.models.ming_omni.pipeline.next_stage import TALKER_STREAM_STAGE
+
+    assert (
+        resolve_ming_pipeline_config(
+            enable_speech=True,
+            enable_streaming_tts=True,
+        )
+        is MingOmniStreamingSpeechPipelineConfig
+    )
+    assert resolve_ming_gpu_placement(
+        enable_speech=True,
+        enable_streaming_tts=True,
+        gpu_thinker=0,
+        gpu_talker=2,
+    ) == {"thinker": 0, TALKER_STREAM_STAGE: 2}
+
+
+def test_streaming_speech_topology_routes_text_segments_to_talker_stream() -> None:
+    from sglang_omni.models.ming_omni.config import MingOmniStreamingSpeechPipelineConfig
+    from sglang_omni.models.ming_omni.pipeline.next_stage import (
+        DECODE_STAGE,
+        SEGMENTER_STAGE,
+        TALKER_STREAM_STAGE,
+        THINKER_STAGE,
+        segmenter_next,
+        thinker_next_streaming_speech,
+    )
+
+    config = MingOmniStreamingSpeechPipelineConfig(model_path="/tmp/model")
+    stage_names = {stage.name for stage in config.stages}
+
+    assert TALKER_STREAM_STAGE in stage_names
+    assert SEGMENTER_STAGE in stage_names
+    assert "code_predictor" not in stage_names
+    assert "code2wav" not in stage_names
+    assert config.terminal_stages == [DECODE_STAGE, TALKER_STREAM_STAGE]
+    assert thinker_next_streaming_speech("req-1", {}) == [DECODE_STAGE, SEGMENTER_STAGE]
+    assert segmenter_next("req-1", {}) == TALKER_STREAM_STAGE
+    assert _stage_by_name(config, THINKER_STAGE).stream_to[0].to_stage == SEGMENTER_STAGE
+    assert _stage_by_name(config, SEGMENTER_STAGE).stream_to[0].to_stage == TALKER_STREAM_STAGE
+
+
+def test_streaming_speech_config_validates_talker_stream_outside_thinker_tp_range() -> None:
+    from sglang_omni.models.ming_omni.config import (
+        MingOmniStreamingSpeechPipelineConfig,
+    )
+    from sglang_omni.models.ming_omni.pipeline.next_stage import (
+        TALKER_STREAM_STAGE,
+        THINKER_STAGE,
+    )
+
+    config = MingOmniStreamingSpeechPipelineConfig(
+        model_path="/tmp/model",
+        gpu_placement={"thinker": 0, TALKER_STREAM_STAGE: 2},
+    )
+    config.apply_server_args_overrides(
+        stage_name=THINKER_STAGE,
+        overrides={"tp_size": 2},
+    )
+
+    bad_config = MingOmniStreamingSpeechPipelineConfig(
+        model_path="/tmp/model",
+        gpu_placement={"thinker": 0, TALKER_STREAM_STAGE: 1},
+    )
+    try:
+        bad_config.apply_server_args_overrides(
+            stage_name=THINKER_STAGE,
+            overrides={"tp_size": 2},
+        )
+    except ValueError as exc:
+        assert "collides" in str(exc).lower()
+    else:
+        raise AssertionError("tp_size=2 should reject talker_stream on GPU 1")

--- a/tests/test_ming_streaming_segmenter_executor.py
+++ b/tests/test_ming_streaming_segmenter_executor.py
@@ -32,9 +32,7 @@ def _executor(**config_kwargs):
         segment_min_tokens=config_kwargs.pop("segment_min_tokens", 2),
         segment_max_tokens=config_kwargs.pop("segment_max_tokens", 10),
         first_segment_min_tokens=config_kwargs.pop("first_segment_min_tokens", 4),
-        first_segment_max_wait_ms=config_kwargs.pop(
-            "first_segment_max_wait_ms", 9999
-        ),
+        first_segment_max_wait_ms=config_kwargs.pop("first_segment_max_wait_ms", 9999),
     )
     return MingStreamingSegmenterExecutor(
         config=config,

--- a/tests/test_ming_streaming_segmenter_executor.py
+++ b/tests/test_ming_streaming_segmenter_executor.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import asyncio
+
+import torch
+
+from sglang_omni.models.ming_omni.components.streaming_text import (
+    SegmenterConfig,
+    text_to_uint8_tensor,
+    uint8_tensor_to_text,
+)
+from sglang_omni.models.ming_omni.pipeline.next_stage import TALKER_STREAM_STAGE
+from sglang_omni.pipeline.stage.stream_queue import StreamItem, StreamQueue
+from sglang_omni.proto import OmniRequest, StagePayload
+
+
+def _payload(request_id: str) -> StagePayload:
+    return StagePayload(
+        request_id=request_id,
+        request=OmniRequest(inputs={}, params={}),
+        data={},
+    )
+
+
+def _executor(**config_kwargs):
+    from sglang_omni.models.ming_omni.components.streaming_segmenter_executor import (
+        MingStreamingSegmenterExecutor,
+    )
+
+    config = SegmenterConfig(
+        segment_min_tokens=config_kwargs.pop("segment_min_tokens", 2),
+        segment_max_tokens=config_kwargs.pop("segment_max_tokens", 10),
+        first_segment_min_tokens=config_kwargs.pop("first_segment_min_tokens", 4),
+        first_segment_max_wait_ms=config_kwargs.pop(
+            "first_segment_max_wait_ms", 9999
+        ),
+    )
+    return MingStreamingSegmenterExecutor(
+        config=config,
+        token_count_fn=lambda text: len(text.split()),
+        **config_kwargs,
+    )
+
+
+def _open_queue(executor, request_id: str) -> StreamQueue:
+    queue = StreamQueue()
+    queue.open(request_id)
+    executor._stream_queue = queue
+    return queue
+
+
+def _stream_item(text: str, chunk_id: int = 0) -> StreamItem:
+    return StreamItem(
+        chunk_id=chunk_id,
+        data=text_to_uint8_tensor(text),
+        from_stage="thinker",
+    )
+
+
+def test_segmenter_emits_uint8_segment_to_talker_stream_with_metadata() -> None:
+    async def run() -> None:
+        executor = _executor(segment_min_tokens=10)
+        queue = _open_queue(executor, "req-1")
+        captured = []
+
+        def capture(request_id, data, target_stage, metadata=None):
+            captured.append((request_id, data, target_stage, metadata))
+
+        executor.set_stream_fn(capture)
+        await executor.add_request(_payload("req-1"))
+
+        queue.put("req-1", _stream_item("partial text"))
+        queue.put_done("req-1", from_stage="thinker")
+
+        await asyncio.wait_for(executor.get_result(), timeout=0.5)
+
+        assert len(captured) == 1
+        request_id, data, target_stage, metadata = captured[0]
+        assert request_id == "req-1"
+        assert target_stage == TALKER_STREAM_STAGE
+        assert isinstance(data, torch.Tensor)
+        assert data.dtype == torch.uint8
+        assert uint8_tensor_to_text(data) == "partial text"
+        assert metadata == {
+            "segment_id": 0,
+            "is_final_segment": True,
+            "text_len": len("partial text".encode("utf-8")),
+        }
+
+    asyncio.run(run())
+
+
+def test_segmenter_sends_empty_final_marker_after_pre_eos_segment() -> None:
+    async def run() -> None:
+        executor = _executor()
+        queue = _open_queue(executor, "req-1")
+        captured = []
+        executor.set_stream_fn(
+            lambda request_id, data, target_stage, metadata=None: captured.append(
+                (request_id, data, target_stage, metadata)
+            )
+        )
+
+        await executor.add_request(_payload("req-1"))
+        queue.put("req-1", _stream_item("hello world."))
+        queue.put_done("req-1", from_stage="thinker")
+
+        await asyncio.wait_for(executor.get_result(), timeout=0.5)
+
+        assert len(captured) == 2
+        assert uint8_tensor_to_text(captured[0][1]) == "hello world."
+        assert captured[0][3]["is_final_segment"] is False
+        assert captured[1][1].dtype == torch.uint8
+        assert captured[1][1].numel() == 0
+        assert captured[1][3] == {
+            "segment_id": 1,
+            "is_final_segment": True,
+            "text_len": 0,
+        }
+
+    asyncio.run(run())
+
+
+def test_segmenter_first_segment_timeout_emits_without_more_input() -> None:
+    async def run() -> None:
+        executor = _executor(
+            segment_min_tokens=10,
+            segment_max_tokens=40,
+            first_segment_min_tokens=3,
+            first_segment_max_wait_ms=20,
+        )
+        queue = _open_queue(executor, "req-1")
+        captured = []
+        executor.set_stream_fn(
+            lambda request_id, data, target_stage, metadata=None: captured.append(
+                (request_id, uint8_tensor_to_text(data), target_stage, metadata)
+            )
+        )
+
+        await executor.add_request(_payload("req-1"))
+        queue.put("req-1", _stream_item("passive first segment"))
+
+        await asyncio.sleep(0.08)
+        assert captured == [
+            (
+                "req-1",
+                "passive first segment",
+                TALKER_STREAM_STAGE,
+                {
+                    "segment_id": 0,
+                    "is_final_segment": False,
+                    "text_len": len("passive first segment".encode("utf-8")),
+                },
+            )
+        ]
+
+        queue.put_done("req-1", from_stage="thinker")
+        result = await asyncio.wait_for(executor.get_result(), timeout=0.5)
+        assert result.data["segment_count"] == 2
+
+    asyncio.run(run())
+
+
+def test_segmenter_abort_before_add_request_emits_aborted_payload() -> None:
+    """Regression: pipeline broadcasts abort to executors before add_request
+    is dispatched. The late add_request must complete with aborted=True,
+    not flush an empty final segment as a success."""
+
+    async def run() -> None:
+        executor = _executor()
+        await executor.abort("req-pre")
+        await executor.add_request(_payload("req-pre"))
+        result = await asyncio.wait_for(executor.get_result(), timeout=1.0)
+        assert result.request_id == "req-pre"
+        assert result.data["aborted"] is True
+        assert result.data["segment_count"] == 0
+
+    asyncio.run(run())

--- a/tests/test_ming_streaming_talker_executor.py
+++ b/tests/test_ming_streaming_talker_executor.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any
+
+import numpy as np
+import torch
+
+from sglang_omni.models.ming_omni.components.streaming_text import text_to_uint8_tensor
+from sglang_omni.models.ming_omni.pipeline.next_stage import TALKER_STREAM_STAGE
+from sglang_omni.pipeline.stage.stream_queue import StreamItem, StreamQueue
+from sglang_omni.proto import OmniRequest, StagePayload
+
+
+def _payload(request_id: str) -> StagePayload:
+    return StagePayload(
+        request_id=request_id,
+        request=OmniRequest(inputs={}, params={}),
+        data={},
+    )
+
+
+def _stream_item(
+    text: str,
+    *,
+    segment_id: int = 0,
+    is_final_segment: bool = False,
+) -> StreamItem:
+    return StreamItem(
+        chunk_id=segment_id,
+        data=text_to_uint8_tensor(text),
+        from_stage="segmenter",
+        metadata={
+            "segment_id": segment_id,
+            "is_final_segment": is_final_segment,
+        },
+    )
+
+
+def _open_queue(executor: Any, request_id: str) -> StreamQueue:
+    queue = StreamQueue()
+    queue.open(request_id)
+    executor._stream_queue = queue
+    return queue
+
+
+class FakeTalker:
+    def __init__(
+        self,
+        *,
+        waveforms: list[torch.Tensor] | None = None,
+        started: threading.Event | None = None,
+        release: threading.Event | None = None,
+        sample_rate: int = 44_100,
+    ) -> None:
+        self.waveforms = waveforms or [torch.tensor([1.0, 2.0], dtype=torch.float32)]
+        self.started = started
+        self.release = release
+        self.calls: list[dict[str, Any]] = []
+        self.config = type("Config", (), {"sample_rate": sample_rate})()
+
+    def omni_audio_generation(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.started is not None:
+            self.started.set()
+        if self.release is not None:
+            self.release.wait()
+        for waveform in self.waveforms:
+            yield waveform, None, None, None
+
+
+def _executor(talker: Any, *, sample_rate: int | None = None):
+    from sglang_omni.models.ming_omni.components.streaming_talker_executor import (
+        MingTalkerStreamExecutor,
+    )
+
+    return MingTalkerStreamExecutor(
+        model_path="/fake/model",
+        talker=talker,
+        audio_detokenizer=object(),
+        sample_rate=sample_rate,
+    )
+
+
+async def _assert_stream_ends(stream_iter: Any) -> None:
+    try:
+        await asyncio.wait_for(stream_iter.__anext__(), timeout=0.5)
+    except StopAsyncIteration:
+        return
+    raise AssertionError("Expected stream to end without yielding audio")
+
+
+def test_talker_stream_yields_audio_chunk_before_completion() -> None:
+    async def run() -> None:
+        started = threading.Event()
+        release = threading.Event()
+        executor = _executor(FakeTalker(started=started, release=release))
+        queue = _open_queue(executor, "req-1")
+
+        await executor.add_request(_payload("req-1"))
+        stream_iter = executor.stream("req-1")
+        next_chunk = asyncio.create_task(stream_iter.__anext__())
+        result_task = asyncio.create_task(executor.get_result())
+
+        queue.put("req-1", _stream_item("hello", is_final_segment=True))
+        await asyncio.to_thread(started.wait, 0.5)
+        assert not result_task.done()
+
+        release.set()
+        chunk = await asyncio.wait_for(next_chunk, timeout=0.5)
+
+        assert chunk["modality"] == "audio"
+        assert chunk["stage_name"] == TALKER_STREAM_STAGE
+        assert chunk["segment_id"] == 0
+        assert chunk["sample_rate"] == 44_100
+        result = await asyncio.wait_for(result_task, timeout=0.5)
+        assert result.request_id == "req-1"
+
+    asyncio.run(run())
+
+
+def test_talker_stream_skips_empty_waveform_chunks() -> None:
+    async def run() -> None:
+        executor = _executor(
+            FakeTalker(
+                waveforms=[
+                    torch.empty((0,), dtype=torch.float32),
+                    torch.tensor([3.0, 4.0], dtype=torch.float32),
+                ],
+            )
+        )
+        queue = _open_queue(executor, "req-1")
+
+        await executor.add_request(_payload("req-1"))
+        stream_iter = executor.stream("req-1")
+        queue.put("req-1", _stream_item("hello", is_final_segment=True))
+
+        chunk = await asyncio.wait_for(stream_iter.__anext__(), timeout=0.5)
+        audio = np.frombuffer(chunk["audio_waveform"], dtype=np.float32)
+
+        assert audio.tolist() == [3.0, 4.0]
+        assert chunk["audio_waveform_shape"] == [2]
+        assert chunk["audio_waveform_dtype"] == "float32"
+
+    asyncio.run(run())
+
+
+def test_talker_stream_audio_chunk_carries_stage_timing_metadata() -> None:
+    async def run() -> None:
+        executor = _executor(FakeTalker())
+        queue = _open_queue(executor, "req-emit")
+
+        await executor.add_request(_payload("req-emit"))
+        await asyncio.sleep(0.05)
+        queue.put("req-emit", _stream_item("hi", is_final_segment=True))
+        stream_iter = executor.stream("req-emit")
+
+        chunk = await asyncio.wait_for(stream_iter.__anext__(), timeout=0.5)
+
+        emit_ms = chunk.get("segmenter_first_emit_ms")
+        assert isinstance(emit_ms, float)
+        assert emit_ms >= 40.0
+        stage_times = chunk["stage_times_ms"]
+        assert stage_times["segmenter_first_emit"] == emit_ms
+        assert isinstance(stage_times["talker_first_audio"], float)
+        assert stage_times["talker_first_audio"] >= emit_ms
+
+    asyncio.run(run())
+
+
+def test_talker_abort_before_add_request_emits_aborted_payload_and_no_stream() -> None:
+    async def run() -> None:
+        executor = _executor(FakeTalker())
+        _open_queue(executor, "req-pre")
+
+        await executor.abort("req-pre")
+        await executor.add_request(_payload("req-pre"))
+
+        result = await asyncio.wait_for(executor.get_result(), timeout=1.0)
+        assert result.request_id == "req-pre"
+        assert result.data["aborted"] is True
+
+        stream_iter = executor.stream("req-pre")
+        await _assert_stream_ends(stream_iter)
+
+    asyncio.run(run())
+
+
+def test_talker_abort_running_generation_finishes_aborted_and_closes_stream() -> None:
+    async def run() -> None:
+        started = threading.Event()
+        release = threading.Event()
+        executor = _executor(FakeTalker(started=started, release=release))
+        queue = _open_queue(executor, "req-running")
+
+        await executor.add_request(_payload("req-running"))
+        stream_iter = executor.stream("req-running")
+        result_task = asyncio.create_task(executor.get_result())
+
+        try:
+            queue.put("req-running", _stream_item("hello", is_final_segment=True))
+            assert await asyncio.to_thread(started.wait, 0.5)
+
+            await executor.abort("req-running")
+
+            result = await asyncio.wait_for(result_task, timeout=0.5)
+            assert result.request_id == "req-running"
+            assert result.data["aborted"] is True
+
+            await _assert_stream_ends(stream_iter)
+        finally:
+            release.set()
+
+    asyncio.run(run())
+
+
+def test_talker_preserves_segment_id_order_across_multiple_segments() -> None:
+    async def run() -> None:
+        executor = _executor(
+            FakeTalker(waveforms=[torch.tensor([1.0], dtype=torch.float32)])
+        )
+        queue = _open_queue(executor, "req-order")
+
+        await executor.add_request(_payload("req-order"))
+        stream_iter = executor.stream("req-order")
+        result_task = asyncio.create_task(executor.get_result())
+
+        queue.put(
+            "req-order",
+            _stream_item("first segment", segment_id=0, is_final_segment=False),
+        )
+        first = await asyncio.wait_for(stream_iter.__anext__(), timeout=0.5)
+
+        queue.put(
+            "req-order",
+            _stream_item("second segment", segment_id=1, is_final_segment=True),
+        )
+        second = await asyncio.wait_for(stream_iter.__anext__(), timeout=0.5)
+
+        result = await asyncio.wait_for(result_task, timeout=0.5)
+
+        assert [first["segment_id"], second["segment_id"]] == [0, 1]
+        assert first["stage_name"] == TALKER_STREAM_STAGE
+        assert second["stage_name"] == TALKER_STREAM_STAGE
+        assert result.data["aborted"] is False
+
+        await _assert_stream_ends(stream_iter)
+
+    asyncio.run(run())

--- a/tests/test_ming_streaming_text.py
+++ b/tests/test_ming_streaming_text.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from sglang_omni.models.ming_omni.components.streaming_text import (
+    SegmenterConfig,
+    SegmenterState,
+    text_to_uint8_tensor,
+    uint8_tensor_to_text,
+)
+
+
+def _token_count(text: str) -> int:
+    return len(text.split())
+
+
+def test_utf8_tensor_round_trip_chinese_and_english():
+    text = "world，streaming TTS!"
+
+    assert uint8_tensor_to_text(text_to_uint8_tensor(text)) == text
+
+
+def test_segmenter_flushes_on_punctuation_after_min_tokens():
+    state = SegmenterState(
+        SegmenterConfig(
+            segment_min_tokens=2,
+            segment_max_tokens=10,
+            first_segment_max_wait_ms=500,
+        ),
+        token_count_fn=_token_count,
+    )
+
+    assert state.push("hello", now_ms=0) == []
+    out = state.push(" world.", now_ms=10)
+
+    assert [segment.text for segment in out] == ["hello world."]
+    assert out[0].is_final_segment is False
+
+
+def test_first_segment_max_wait_flushes_before_punctuation():
+    state = SegmenterState(
+        SegmenterConfig(
+            segment_min_tokens=10,
+            segment_max_tokens=40,
+            first_segment_min_tokens=3,
+            first_segment_max_wait_ms=400,
+        ),
+        token_count_fn=_token_count,
+    )
+
+    assert state.push("one two three", now_ms=0) == []
+    out = state.push("", now_ms=401)
+
+    assert [segment.text for segment in out] == ["one two three"]
+    assert out[0].is_final_segment is False
+
+
+def test_segmenter_caps_max_tokens_and_retains_overflow():
+    state = SegmenterState(
+        SegmenterConfig(
+            segment_min_tokens=1,
+            segment_max_tokens=3,
+            first_segment_min_tokens=3,
+            first_segment_max_wait_ms=9999,
+        ),
+        token_count_fn=_token_count,
+    )
+
+    out = state.push("one two three four five", now_ms=0)
+    tail = state.flush()
+
+    assert [segment.text for segment in out] == ["one two three"]
+    assert [segment.text for segment in tail] == ["four five"]


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Ming-Omni speech currently runs `Thinker_full → Talker_full`, so TTFA ≈ Thinker latency + Talker latency. Add an opt-in streaming pipeline so audio starts emitting before Thinker finishes, without changing the default non-streaming path.       

Assuming the prompt/model/server setup is otherwise identical, streaming TTS keeps throughput essentially unchanged while reducing first-audio latency by more than 6x.                           
## Modifications

Adds a sibling streaming speech pipeline `thinker → segmenter → talker_stream` selected by a new CLI flag. Non-streaming `MingOmniSpeechPipelineConfig` behavior is unchanged.
                                                                                                                                                                                                                                                                                          
  - `sglang_omni/models/ming_omni/config.py`: add `MingOmniStreamingSpeechPipelineConfig`; add `SEGMENTER_STAGE` / `TALKER_STREAM_STAGE` and reuse GPU-placement validator for the streaming talker stage.
  - `sglang_omni/models/ming_omni/components/streaming_text.py`: UTF-8 tensor conversion and punctuation/length segmenter state with first-segment wall-clock flush.                                                                                                                      
  - `sglang_omni/models/ming_omni/components/streaming_segmenter_executor.py`: streaming `Executor` that turns Thinker text deltas into Talker text segments.       
  - `sglang_omni/models/ming_omni/components/streaming_talker_executor.py`: streaming `Executor` that runs Ming Talker generation off the asyncio loop and emits audio chunks; abort-aware cleanup of VAE cache and graph pool.                                                           
  - `sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py`: replace `time.sleep(0.1)` polling with condition wakeup; abort checks; graph-pool `try/finally`; remove `(count == 0)` gate; keep `vae_cache[uuid]` for the lifetime of a streaming session.                      
  - `sglang_omni/models/ming_omni/pipeline/{next_stage.py,stages.py}`: thinker text side channel and segmenter / talker-stream factories.                                                                                                                                                 
  - `sglang_omni/serve/openai_api.py`: propagate SSE generator cancellation to `client.abort(request_id)` and record per-stage timing.                                                                                                                                                    
  - `sglang_omni/client/{client.py,types.py}`: carry `sample_rate` on `CompletionStreamChunk` and pass it to `audio_to_base64()` in both streaming and non-streaming chat paths.                                                                                                          
  - `examples/run_ming_omni_server.py`: add `--enable-streaming-tts` (requires `--enable-speech`) plus `--gpu-thinker` / `--gpu-talker` and `resolve_ming_pipeline_config` / `resolve_ming_gpu_placement` helpers.                                                                        
                                                                                                                                                                                                                                                                                          
  Tests added: `test_ming_streaming_text.py`, `test_ming_streaming_segmenter_executor.py`, `test_ming_streaming_talker_executor.py`, `test_ming_streaming_pipeline_config.py`, `test_ming_streaming_client.py`.      
## Related Issues

closes #341 
## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling
### Prompt
```
LONG_TEXT="Respond with exactly this paragraph and no extra words: This is an alternate long prompt for benchmarking streaming TTS. It is intentionally long and includes multiple clauses so that time-to-first-audio and chunk cadence are easy to observe. The benchmark should measure how quickly the first playable audio arrives, how steadily subsequent chunks are delivered, and whether the final waveform quality is consistent. Keep the wording exactly as written, with no extra sentences or formatting."
```
### Summary Comparison

Metric | Non-streaming | Streaming
-- | -- | --
Run count | 5 | 5
TTFA p50 | 3,756.2 ms | 586.7 ms
TTFA p95 | 3,838.5 ms | 623.5 ms
Mean RTF | 0.1639 | 0.1602
averaged audio chunks | 1 | 70.6
Mean chunk jitter | n/a | 95.8 ms
Sample rate | 44100 Hz | 44100 Hz
Max talker queue depth | 0 | 0

### Run by Run Metrics
<h4><strong>Non-streaming</strong></h4>

Run | TTFA | Total Time | Audio Duration | RTF | Chunks | Jitter | Queue Depth | Thinker First Text | Segmenter First Emit | Talker First Audio
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | 3,838.5 ms | 3,843.0 ms | 23,400.0 ms | 0.1642 | 1 | n/a | 0 | n/a | n/a | 3,838.5 ms
2 | 3,741.5 ms | 3,745.7 ms | 22,100.0 ms | 0.1695 | 1 | n/a | 0 | n/a | n/a | 3,741.5 ms
3 | 3,756.2 ms | 3,760.7 ms | 23,100.0 ms | 0.1628 | 1 | n/a | 0 | n/a | n/a | 3,756.2 ms
4 | 3,754.4 ms | 3,758.4 ms | 22,900.0 ms | 0.1641 | 1 | n/a | 0 | n/a | n/a | 3,754.4 ms
5 | 3,820.9 ms | 3,824.8 ms | 24,100.0 ms | 0.1587 | 1 | n/a | 0 | n/a | n/a | 3,820.9 ms


<h4><strong>Streaming</strong></h4>

Run | TTFA | Total Time | Audio Duration | RTF | Chunks | Jitter | Queue Depth | Thinker First Text | Segmenter First Emit | Talker First Audio
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | 623.5 ms | 3,775.0 ms | 24,000.0 ms | 0.1573 | 72 | 93.7 ms | 0 | 53.6 ms | 497.5 ms | 572.8 ms
2 | 586.7 ms | 3,710.6 ms | 23,680.0 ms | 0.1567 | 71 | 89.6 ms | 0 | 54.3 ms | 499.8 ms | 570.1 ms
3 | 588.7 ms | 3,838.6 ms | 23,040.0 ms | 0.1666 | 69 | 99.0 ms | 0 | 51.2 ms | 497.8 ms | 572.3 ms
4 | 585.5 ms | 3,756.3 ms | 24,000.0 ms | 0.1565 | 72 | 95.4 ms | 0 | 54.6 ms | 498.7 ms | 568.8 ms
5 | 584.9 ms | 3,781.0 ms | 23,040.0 ms | 0.1641 | 69 | 101.1 ms | 0 | 53.3 ms | 497.3 ms | 568.4 ms


<!-- notionvc: 81d9acd0-2d3f-4984-9515-a86dae96f09d -->
## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Draft PRs are skipped even if labeled.
