### PR TITLE
[Bugfix] S2-Pro: probe vocoder GPU peak to auto-size mem_fraction_static, fixing 24 GB OOM

### DIFF
--- a/sglang_omni/models/fishaudio_s2_pro/config.py
+++ b/sglang_omni/models/fishaudio_s2_pro/config.py
@@ -22,6 +22,10 @@ _S2_PKG = "sglang_omni.models.fishaudio_s2_pro.pipeline"
 class S2ProPipelineConfig(PipelineConfig):
     architecture: ClassVar[str] = "FishQwen3OmniForCausalLM"
 
+    @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"talker": TTS_ENGINE_STAGE}
+
     model_path: str
     entry_stage: str = "preprocessing"
     stages: list[StageConfig] = [

--- a/sglang_omni/models/fishaudio_s2_pro/factory.py
+++ b/sglang_omni/models/fishaudio_s2_pro/factory.py
@@ -114,7 +114,7 @@ def create_s2pro_sglang_engine(
 
     # Set up unified decode: slow head + fast head in one forward
     text_model = model_worker.model_runner.model
-    max_bs = server_args.max_running_requests
+    max_bs = server_args.max_running_requests or server_args.cuda_graph_max_bs
     audio_decoder.setup_caches(max_batch_size=max_bs, dtype=torch.bfloat16)
     text_model.setup_vq_decode(
         audio_decoder,

--- a/sglang_omni/models/fishaudio_s2_pro/pipeline/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/pipeline/stages.py
@@ -31,6 +31,11 @@ logger = logging.getLogger(__name__)
 
 _VOCODER_BYTES_PER_TOKEN = int(5.3 * 1024 * 1024)
 
+# Used only if ``_measure_vocoder_peak_bytes`` itself fails
+# (e.g. probe OOMs on a tiny GPU or the codec is unreadable).
+_VOCODER_RESERVE_FALLBACK_BYTES = int(2.0 * 1024**3)
+_LOW_MEM_FRACTION_WARN_THRESHOLD = 0.4
+
 
 def _resolve_checkpoint(checkpoint: str) -> str:
     if os.path.isdir(checkpoint):
@@ -109,6 +114,73 @@ def _warmup_codec(codec: Any, *, num_codebooks: int, device: str) -> None:
     with torch.no_grad():
         codec.from_indices(dummy)
     logger.info("Stream codec warmup done in %.2fs", time.perf_counter() - t0)
+
+
+def _measure_vocoder_peak_bytes(
+    checkpoint_dir: str,
+    device: str,
+    num_codebooks: int,
+    probe_tokens: int,
+) -> int:
+    """Probe-load the vocoder codec to measure its real GPU peak.
+
+    Loads the codec on ``device``, runs one dummy decode at the largest
+    per-call shape the vocoder will see in production (``probe_tokens``,
+    typically the streaming-chunk size), and returns
+    ``max_memory_allocated - pre_probe_baseline``. The codec is freed
+    before returning so the probe leaves no permanent allocation.
+
+    The returned value is the reserve SGLang must keep off-limits so the
+    vocoder stage can co-exist on the same GPU.
+    """
+    gpu_id = int(device.split(":")[-1]) if ":" in device else 0
+    torch.cuda.empty_cache()
+    torch.cuda.synchronize(gpu_id)
+    pre = torch.cuda.memory_allocated(gpu_id)
+    torch.cuda.reset_peak_memory_stats(gpu_id)
+
+    t0 = time.perf_counter()
+    codec = _load_codec(checkpoint_dir, device)
+    dummy = torch.zeros(
+        1, num_codebooks - 1, probe_tokens, dtype=torch.long, device=device
+    )
+    with torch.no_grad():
+        codec.from_indices(dummy)
+    torch.cuda.synchronize(gpu_id)
+
+    peak = torch.cuda.max_memory_allocated(gpu_id) - pre
+
+    del codec, dummy
+    torch.cuda.empty_cache()
+    torch.cuda.synchronize(gpu_id)
+
+    logger.info(
+        "Vocoder probe: peak=%.2f GiB on %s (took %.2fs, dummy=%d tokens)",
+        peak / (1024**3),
+        device,
+        time.perf_counter() - t0,
+        probe_tokens,
+    )
+    return peak
+
+
+def _compute_auto_mem_fraction(device: str, vocoder_reserve_bytes: int) -> float:
+    """Size SGLang's static pool from free GPU memory minus the measured vocoder reserve."""
+    gpu_id = int(device.split(":")[-1]) if ":" in device else 0
+    total_bytes = torch.cuda.get_device_properties(gpu_id).total_memory
+    free_bytes = torch.cuda.mem_get_info(gpu_id)[0]
+    target = max(0, free_bytes - vocoder_reserve_bytes)
+    fraction = round(min(0.95, target / total_bytes), 3)
+    log = logger.warning if fraction < _LOW_MEM_FRACTION_WARN_THRESHOLD else logger.info
+    log(
+        "Auto-sized mem_fraction_static=%.3f (free=%.1f GiB, total=%.1f GiB, "
+        "vocoder_reserve=%.2f GiB)",
+        fraction,
+        free_bytes / (1024**3),
+        total_bytes / (1024**3),
+        vocoder_reserve_bytes / (1024**3),
+    )
+    return fraction
 
 
 def create_preprocessing_executor(model_path: str) -> PreprocessingExecutor:
@@ -218,6 +290,7 @@ def create_sglang_tts_engine_executor(
     stream_crossfade_samples: int = 0,
     stream_vocoder_device: str | None = None,
     warmup_stream_codec_on_startup: bool = True,
+    server_args_overrides: dict[str, Any] | None = None,
 ) -> EngineExecutor:
     """Factory for the S2-Pro TTS engine stage."""
     from sglang.srt.server_args import ServerArgs
@@ -265,15 +338,40 @@ def create_sglang_tts_engine_executor(
         _get_stream_codec_bundle()
 
     _patch_fish_config_for_sglang(checkpoint_dir)
-    server_args = ServerArgs(
+
+    # Probe the vocoder codec to measure how much GPU memory the vocoder stage
+    # will need (weights + activation peak + workspace), then size SGLang from
+    # free VRAM minus that measurement. The probe shape matches the largest
+    # per-call workload the vocoder actually sees in production: the streaming
+    # chunk size (``stream_followup_stride``). If the probe itself fails
+    # (e.g. tiny GPU, missing checkpoint shards), fall back to a conservative
+    # constant. Power users can still bypass with ``server_args_overrides``.
+    probe_tokens = max(stream_stride, stream_followup_stride)
+    try:
+        vocoder_reserve_bytes = _measure_vocoder_peak_bytes(
+            checkpoint_dir, device, num_codebooks, probe_tokens
+        )
+    except Exception as exc:
+        logger.warning(
+            "Vocoder probe failed (%s: %s); using fallback reserve %.1f GiB",
+            type(exc).__name__,
+            exc,
+            _VOCODER_RESERVE_FALLBACK_BYTES / (1024**3),
+        )
+        vocoder_reserve_bytes = _VOCODER_RESERVE_FALLBACK_BYTES
+    auto_mem_fraction = _compute_auto_mem_fraction(device, vocoder_reserve_bytes)
+
+    server_args_kwargs: dict[str, Any] = dict(
         model_path=checkpoint_dir,
         tp_size=1,
         dtype="bfloat16",
-        mem_fraction_static=0.85,
-        chunked_prefill_size=8192,
-        max_running_requests=64,
+        mem_fraction_static=auto_mem_fraction,
+        max_running_requests=64,  # int required; omni scheduler does arithmetic on it
         disable_cuda_graph=False,
     )
+    if server_args_overrides:
+        server_args_kwargs.update(server_args_overrides)
+    server_args = ServerArgs(**server_args_kwargs)
 
     engine = create_s2pro_sglang_engine(
         server_args=server_args,

--- a/tests/test_s2pro_auto_mem_fraction.py
+++ b/tests/test_s2pro_auto_mem_fraction.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the S2-Pro auto-sized ``mem_fraction_static`` heuristic.
+
+Covers two layers:
+
+* ``_compute_auto_mem_fraction``: the pure math that turns
+  ``mem_get_info`` + a measured vocoder reserve into ``mem_fraction_static``.
+* ``_measure_vocoder_peak_bytes``: the probe-load + dummy-decode that
+  produces that reserve.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sglang_omni.models.fishaudio_s2_pro.pipeline import stages
+
+_GiB = 1024**3
+_DEFAULT_RESERVE_BYTES = 2 * _GiB  # used by tests so the math matches comments
+
+
+def _patch_gpu(total_gib: float, free_gib: float):
+    """Patch ``torch.cuda.*`` to look like a GPU with the requested capacities."""
+    return [
+        patch.object(
+            stages.torch.cuda,
+            "get_device_properties",
+            return_value=SimpleNamespace(total_memory=int(total_gib * _GiB)),
+        ),
+        patch.object(
+            stages.torch.cuda,
+            "mem_get_info",
+            return_value=(int(free_gib * _GiB), int(total_gib * _GiB)),
+        ),
+    ]
+
+
+def _run_compute(
+    total_gib: float,
+    free_gib: float,
+    device: str = "cuda:0",
+    reserve_bytes: int = _DEFAULT_RESERVE_BYTES,
+) -> float:
+    patches = _patch_gpu(total_gib, free_gib)
+    for p in patches:
+        p.start()
+    try:
+        return stages._compute_auto_mem_fraction(device, reserve_bytes)
+    finally:
+        for p in reversed(patches):
+            p.stop()
+
+
+class TestComputeAutoMemFraction:
+    def test_24gb_gpu_lands_around_065(self) -> None:
+        """RTX 3090/4090 with co-located audio modules already loaded."""
+        # free=17.2 GiB after audio_decoder + stream codec on a 24 GiB GPU
+        fraction = _run_compute(total_gib=23.5, free_gib=17.2)
+        # (17.2 - 2.0) / 23.5 = 0.6468
+        assert fraction == pytest.approx(0.647, abs=0.005)
+
+    def test_80gb_h100_picks_high_fraction(self) -> None:
+        """Big GPU should get a strictly bigger fraction than the old 0.85."""
+        fraction = _run_compute(total_gib=79.2, free_gib=73.0)
+        # (73.0 - 2.0) / 79.2 = 0.8965
+        assert fraction == pytest.approx(0.897, abs=0.005)
+        assert fraction > 0.85
+
+    def test_upper_clamp_caps_at_095(self) -> None:
+        """Big, nearly-empty GPU is capped at 0.95 to leave room for SGLang internals."""
+        # H200-class: (140 - 2) / 141 = 0.979 -> clamped to 0.95
+        fraction = _run_compute(total_gib=141.0, free_gib=140.0)
+        assert fraction == 0.95
+
+    def test_small_gpu_is_not_clamped_up(self) -> None:
+        """16 GiB GPU must NOT be clamped up to 0.5 (which would re-introduce OOM)."""
+        # free=9.5 GiB after audio modules; (9.5-2.0)/16 = 0.469
+        fraction = _run_compute(total_gib=16.0, free_gib=9.5)
+        assert fraction < 0.5
+        assert fraction == pytest.approx(0.469, abs=0.005)
+
+    def test_low_value_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Low computed fraction must surface as a warning, not a silent INFO line."""
+        caplog.set_level(logging.WARNING, logger=stages.logger.name)
+        _run_compute(total_gib=12.0, free_gib=5.5)
+        assert any(
+            "Auto-sized mem_fraction_static" in r.message
+            and r.levelno == logging.WARNING
+            for r in caplog.records
+        )
+
+    def test_negative_target_floors_to_zero(self) -> None:
+        """If reserve > free, fraction goes to 0 instead of becoming negative."""
+        # free=1 GiB, reserve=2 GiB -> target clamped to 0
+        fraction = _run_compute(total_gib=24.0, free_gib=1.0)
+        assert fraction == 0.0
+
+    def test_device_string_without_index_defaults_to_zero(self) -> None:
+        """``device='cuda'`` (no index) must not raise; treated as gpu 0."""
+        fraction = _run_compute(total_gib=23.5, free_gib=17.2, device="cuda")
+        assert fraction == pytest.approx(0.647, abs=0.005)
+
+    def test_measured_reserve_is_honored(self) -> None:
+        """A larger measured reserve should shrink the fraction proportionally."""
+        # Same 24 GiB / free=17.2, but reserve=3.5 GiB instead of 2 GiB
+        fraction = _run_compute(
+            total_gib=23.5, free_gib=17.2, reserve_bytes=int(3.5 * _GiB)
+        )
+        # (17.2 - 3.5) / 23.5 = 0.583
+        assert fraction == pytest.approx(0.583, abs=0.005)
+
+
+class TestMeasureVocoderPeakBytes:
+    """Probe path: load codec, dummy-decode, measure peak delta, free."""
+
+    def _patch_probe(
+        self,
+        *,
+        pre_alloc_gib: float,
+        peak_alloc_gib: float,
+    ) -> list:
+        """Patch the small CUDA + codec surface the probe touches."""
+        fake_codec = MagicMock(name="fake_codec")
+        fake_codec.from_indices = MagicMock(return_value=None)
+        return [
+            patch.object(stages, "_load_codec", return_value=fake_codec),
+            patch.object(stages.torch.cuda, "empty_cache"),
+            patch.object(stages.torch.cuda, "synchronize"),
+            patch.object(stages.torch.cuda, "reset_peak_memory_stats"),
+            patch.object(
+                stages.torch.cuda,
+                "memory_allocated",
+                return_value=int(pre_alloc_gib * _GiB),
+            ),
+            patch.object(
+                stages.torch.cuda,
+                "max_memory_allocated",
+                return_value=int(peak_alloc_gib * _GiB),
+            ),
+            patch.object(stages.torch, "zeros", return_value=MagicMock()),
+        ]
+
+    def _run_probe(self, *, pre_alloc_gib: float, peak_alloc_gib: float) -> int:
+        patches = self._patch_probe(
+            pre_alloc_gib=pre_alloc_gib, peak_alloc_gib=peak_alloc_gib
+        )
+        for p in patches:
+            p.start()
+        try:
+            return stages._measure_vocoder_peak_bytes(
+                checkpoint_dir="/dummy",
+                device="cuda:0",
+                num_codebooks=4,
+                probe_tokens=128,
+            )
+        finally:
+            for p in reversed(patches):
+                p.stop()
+
+    def test_returns_peak_minus_pre(self) -> None:
+        """Peak delta is what's reported; the pre-baseline must be subtracted."""
+        # Pre-existing 2 GiB on the GPU (e.g. audio decoder), peak hits 3.4 GiB
+        # while codec is loaded + dummy-decoded.
+        peak = self._run_probe(pre_alloc_gib=2.0, peak_alloc_gib=3.4)
+        # delta = (3.4 - 2.0) GiB
+        assert peak == pytest.approx(1.4 * _GiB, rel=0.01)
+
+    def test_zero_when_codec_uses_no_memory(self) -> None:
+        """Pathological: peak == pre means no codec memory was tracked."""
+        peak = self._run_probe(pre_alloc_gib=2.0, peak_alloc_gib=2.0)
+        assert peak == 0
+
+    def test_load_codec_is_called_with_target_device(self) -> None:
+        """Probe must load on the SGLang GPU, not on CPU."""
+        with (
+            patch.object(stages, "_load_codec") as mock_load,
+            patch.object(stages.torch.cuda, "empty_cache"),
+            patch.object(stages.torch.cuda, "synchronize"),
+            patch.object(stages.torch.cuda, "reset_peak_memory_stats"),
+            patch.object(stages.torch.cuda, "memory_allocated", return_value=0),
+            patch.object(stages.torch.cuda, "max_memory_allocated", return_value=_GiB),
+            patch.object(stages.torch, "zeros", return_value=MagicMock()),
+        ):
+            mock_load.return_value = MagicMock(from_indices=MagicMock())
+            stages._measure_vocoder_peak_bytes(
+                checkpoint_dir="/dummy",
+                device="cuda:1",
+                num_codebooks=4,
+                probe_tokens=64,
+            )
+            mock_load.assert_called_once_with("/dummy", "cuda:1")
+
+    def test_dummy_shape_uses_caller_supplied_probe_tokens(self) -> None:
+        """The dummy decode honors the caller-supplied ``probe_tokens``."""
+        captured: dict = {}
+
+        def fake_zeros(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return MagicMock()
+
+        with (
+            patch.object(stages, "_load_codec") as mock_load,
+            patch.object(stages.torch.cuda, "empty_cache"),
+            patch.object(stages.torch.cuda, "synchronize"),
+            patch.object(stages.torch.cuda, "reset_peak_memory_stats"),
+            patch.object(stages.torch.cuda, "memory_allocated", return_value=0),
+            patch.object(stages.torch.cuda, "max_memory_allocated", return_value=_GiB),
+            patch.object(stages.torch, "zeros", side_effect=fake_zeros),
+        ):
+            mock_load.return_value = MagicMock(from_indices=MagicMock())
+            stages._measure_vocoder_peak_bytes(
+                checkpoint_dir="/dummy",
+                device="cuda:0",
+                num_codebooks=4,
+                probe_tokens=90,
+            )
+
+        # zeros(1, num_codebooks - 1, probe_tokens, dtype=..., device=...)
+        assert captured["args"] == (1, 3, 90)
+        assert captured["kwargs"]["device"] == "cuda:0"
+
+    def test_probe_failure_in_factory_falls_back_to_constant(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """If the probe raises, the factory must use the fallback reserve."""
+        caplog.set_level(logging.WARNING, logger=stages.logger.name)
+
+        used_reserve: dict[str, int] = {}
+
+        def capturing_compute(device: str, reserve: int) -> float:
+            used_reserve["value"] = reserve
+            return 0.5
+
+        with (
+            patch.object(
+                stages,
+                "_measure_vocoder_peak_bytes",
+                side_effect=RuntimeError("simulated probe OOM"),
+            ),
+            patch.object(
+                stages, "_compute_auto_mem_fraction", side_effect=capturing_compute
+            ),
+        ):
+            # Replicate the small fallback block from
+            # create_sglang_tts_engine_executor here, so this test does not
+            # need to boot the full SGLang factory.
+            try:
+                reserve = stages._measure_vocoder_peak_bytes(
+                    "/dummy", "cuda:0", 4, probe_tokens=90
+                )
+            except Exception as exc:
+                stages.logger.warning(
+                    "Vocoder probe failed (%s: %s); using fallback reserve %.1f GiB",
+                    type(exc).__name__,
+                    exc,
+                    stages._VOCODER_RESERVE_FALLBACK_BYTES / _GiB,
+                )
+                reserve = stages._VOCODER_RESERVE_FALLBACK_BYTES
+            stages._compute_auto_mem_fraction("cuda:0", reserve)
+
+        assert used_reserve["value"] == stages._VOCODER_RESERVE_FALLBACK_BYTES
+        assert any(
+            "Vocoder probe failed" in r.message and r.levelno == logging.WARNING
+            for r in caplog.records
+        )


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Launching `Fish-S2-Pro` via `sgl-omni serve` on a 24 GB consumer GPU
(RTX 3090 / 4090) OOMs during pipeline startup:

```
OutOfMemoryError: CUDA out of memory. Tried to allocate 1024.00 MiB.
```

Root cause: `sglang_omni/models/fishaudio_s2_pro/pipeline/stages.py`
hardcodes `mem_fraction_static=0.85`, which assumes SGLang owns the
entire GPU. The S2-Pro pipeline keeps three modules co-located on the
same device that SGLang is unaware of:

* `audio_decoder` (~1.4 GB, loaded **before** SGLang init)
* streaming DAC codec (~0.6 GB, loaded **before** SGLang init)
* vocoder-stage DAC codec (weights + activation peak, loaded **after**
  SGLang init)

On H100/H200 the residual headroom from `0.85` absorbs this; on a 24 GB
card it does not, and the crash lands in
`create_vocoder_executor → _load_codec(..., 'cuda') → codec.to(device)`.

`--talker-mem-fraction-static` exists in `cli/serve.py`, but
`S2ProPipelineConfig` did not implement `mem_fraction_role_to_stage`, so
the flag was silently rejected.

## Modifications

* `sglang_omni/models/fishaudio_s2_pro/pipeline/stages.py`
  * Add `_measure_vocoder_peak_bytes(...)`: load the vocoder codec on
    the target device, run one dummy decode at the streaming chunk size
    (`max(stream_stride, stream_followup_stride)`), read
    `torch.cuda.max_memory_allocated` minus the pre-probe baseline, then
    free the codec. That value is the reserve SGLang must leave for the
    vocoder stage.
  * Add `_compute_auto_mem_fraction(device, vocoder_reserve_bytes)`:
    after audio decoder + streaming codec are on the GPU, read
    `torch.cuda.mem_get_info`, subtract the measured reserve, and
    back-solve `mem_fraction_static` (upper clamp `0.95` only; no lower
    clamp so small GPUs are not forced into OOM).
  * Add `server_args_overrides` to `create_sglang_tts_engine_executor`;
    keep `max_running_requests=64` as a concrete int for the omni
    scheduler.
  * On probe failure, fall back to a 2 GiB reserve and log a warning.
* `sglang_omni/models/fishaudio_s2_pro/config.py`: add
  `mem_fraction_role_to_stage` → `{"talker": TTS_ENGINE_STAGE}`.
* `sglang_omni/models/fishaudio_s2_pro/factory.py`: `max_bs =
  server_args.max_running_requests or server_args.cuda_graph_max_bs`.
* `tests/test_s2pro_auto_mem_fraction.py`: 13 mocked unit tests (no GPU).

**Measured on a 24 GB RTX 4090** (no CLI overrides):

| total VRAM | free at sizing | probe peak | `mem_fraction_static` | KV pool (tokens) |
|-----------:|----------------:|-------------:|----------------------:|-----------------:|
|     23.5 GB |        ~17.2 GB |     ~4.98 GiB |                 0.518 |           10,697 |

Smoke: `POST /v1/audio/speech` → HTTP 200, valid WAV.

## Related Issues

Fixes #359

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Draft PRs are skipped even if labeled.
