### PR TITLE
[Docs] Refresh H200 reference results to V1 pipeline

### DIFF
--- a/benchmarks/eval/benchmark_omni_mmmu.py
+++ b/benchmarks/eval/benchmark_omni_mmmu.py
@@ -35,8 +35,8 @@ Accuracy (summary)
 
 | Model      | Config             | accuracy | correct | failed | mc_fallback | Source                                                 |
 | ---------- | ------------------ | -------- | ------- | ------ | ----------- | ------------------------------------------------------ |
-| Qwen3-Omni | enable_audio=False | 66.33%   | 597/900 | 0      | 22          | this PR [H200, V1-pipeline, full-set, c=8, max_tokens=2048]         |
-| Qwen3-Omni | enable_audio=True  | 60.00%   | 30/50   | 0      | 2           | this PR [H200, V1-pipeline, 50-sample subset, c=1, max_tokens=2048] |
+| Qwen3-Omni | enable_audio=False | 66.33%   | 597/900 | 0      | 22          | PR #393 [H200, V1-pipeline, full-set, c=8, max_tokens=2048]         |
+| Qwen3-Omni | enable_audio=True  | 60.00%   | 30/50   | 0      | 2           | PR #393 [H200, V1-pipeline, 50-sample subset, c=1, max_tokens=2048] |
 | Qwen3-Omni | enable_audio=False | 66.11%   | 595/900 | 0      | 28          | PR #351 [H100, full-set, c=8, max_tokens=2048, text-only server] |
 | Qwen3-Omni | enable_audio=True  | 18.00%   | 9/50    | 21     | 20          | PR #351 [H100, 50-sample subset, c=1, max_tokens=64, timeout=120s] |
 
@@ -47,8 +47,8 @@ Speed (speed)
 
 | Model      | Config             | latency_mean_s | latency_p95_s | throughput_qps | tok_per_s_mean | tok_per_s_agg | Source                                                     |
 | ---------- | ------------------ | -------------- | ------------- | -------------- | -------------- | ------------- | ---------------------------------------------------------- |
-| Qwen3-Omni | enable_audio=False | 5.724          | 20.134        | 1.377          | 83.5           | 88.4          | this PR [H200, V1-pipeline, full-set, c=8, max_tokens=2048]             |
-| Qwen3-Omni | enable_audio=True  | 70.927         | 197.541       | 0.014          | 10.2           | 8.2           | this PR [H200, V1-pipeline, **50-sample subset**, c=1, max_tokens=2048] |
+| Qwen3-Omni | enable_audio=False | 5.724          | 20.134        | 1.377          | 83.5           | 88.4          | PR #393 [H200, V1-pipeline, full-set, c=8, max_tokens=2048]             |
+| Qwen3-Omni | enable_audio=True  | 70.927         | 197.541       | 0.014          | 10.2           | 8.2           | PR #393 [H200, V1-pipeline, **50-sample subset**, c=1, max_tokens=2048] |
 | Qwen3-Omni | enable_audio=False | 20.297         | 74.122        | 0.392          | 24.9           | 25.4          | PR #351 [H100, full-set, c=8, max_tokens=2048, text-only server] |
 | Qwen3-Omni | enable_audio=True  | 19.579         | 23.147        | 0.009          | 3.3            | 3.3           | PR #351 [H100, 50-sample subset, c=1, max_tokens=64, timeout=120s] |
 

--- a/benchmarks/eval/benchmark_omni_mmmu.py
+++ b/benchmarks/eval/benchmark_omni_mmmu.py
@@ -29,14 +29,14 @@ CI runs on a subset and has its own thresholds elsewhere (see tasks/*.py).
 
 Benchmark: MMMU     |  Dataset: MMMU_val (900 samples, all 30 subjects)
 Hardware:  1 x H200 (default; non-H200 sources are tagged in Source column)
-Last verified: 2026-04-25
+Last verified: 2026-05-04
 
 Accuracy (summary)
 
 | Model      | Config             | accuracy | correct | failed | mc_fallback | Source                                                 |
 | ---------- | ------------------ | -------- | ------- | ------ | ----------- | ------------------------------------------------------ |
-| Qwen3-Omni | enable_audio=False | 67.22%   | 605/900 | 0      | 21          | PR #316 [H200, full-set, c=8, max_tokens=2048]         |
-| Qwen3-Omni | enable_audio=True  | 46.00%   | 23/50   | 15     | 0           | PR #316 [H200, 50-sample subset, c=1, max_tokens=2048] |
+| Qwen3-Omni | enable_audio=False | 66.33%   | 597/900 | 0      | 22          | this PR [H200, V1-pipeline, full-set, c=8, max_tokens=2048]         |
+| Qwen3-Omni | enable_audio=True  | 60.00%   | 30/50   | 0      | 2           | this PR [H200, V1-pipeline, 50-sample subset, c=1, max_tokens=2048] |
 | Qwen3-Omni | enable_audio=False | 66.11%   | 595/900 | 0      | 28          | PR #351 [H100, full-set, c=8, max_tokens=2048, text-only server] |
 | Qwen3-Omni | enable_audio=True  | 18.00%   | 9/50    | 21     | 20          | PR #351 [H100, 50-sample subset, c=1, max_tokens=64, timeout=120s] |
 
@@ -47,8 +47,8 @@ Speed (speed)
 
 | Model      | Config             | latency_mean_s | latency_p95_s | throughput_qps | tok_per_s_mean | tok_per_s_agg | Source                                                     |
 | ---------- | ------------------ | -------------- | ------------- | -------------- | -------------- | ------------- | ---------------------------------------------------------- |
-| Qwen3-Omni | enable_audio=False | 25.70          | 96.38         | 0.308          | 19.6           | 19.9          | PR #316 [H200, full-set, c=8, max_tokens=2048]             |
-| Qwen3-Omni | enable_audio=True  | 123.13         | 221.52        | 0.004          | 2.2            | 2.1           | PR #316 [H200, **50-sample subset**, c=1, max_tokens=2048] |
+| Qwen3-Omni | enable_audio=False | 5.724          | 20.134        | 1.377          | 83.5           | 88.4          | this PR [H200, V1-pipeline, full-set, c=8, max_tokens=2048]             |
+| Qwen3-Omni | enable_audio=True  | 70.927         | 197.541       | 0.014          | 10.2           | 8.2           | this PR [H200, V1-pipeline, **50-sample subset**, c=1, max_tokens=2048] |
 | Qwen3-Omni | enable_audio=False | 20.297         | 74.122        | 0.392          | 24.9           | 25.4          | PR #351 [H100, full-set, c=8, max_tokens=2048, text-only server] |
 | Qwen3-Omni | enable_audio=True  | 19.579         | 23.147        | 0.009          | 3.3            | 3.3           | PR #351 [H100, 50-sample subset, c=1, max_tokens=64, timeout=120s] |
 

--- a/benchmarks/eval/benchmark_omni_mmsu.py
+++ b/benchmarks/eval/benchmark_omni_mmsu.py
@@ -48,8 +48,8 @@ Accuracy (accuracy)
 
 | Model      | Config                | overall_accuracy | parseable_samples | unparseable_samples | Source                        |
 | ---------- | --------------------- | ---------------- | ----------------- | ------------------- | ----------------------------- |
-| Qwen3-Omni | modalities=text       | 70.96%           | 5000/5000         | 0                   | this PR [H200, V1-pipeline, full-set, c=8] |
-| Qwen3-Omni | modalities=text+audio | 71.06%           | 5000/5000         | 0                   | this PR [H200, V1-pipeline, full-set, c=8] |
+| Qwen3-Omni | modalities=text       | 70.96%           | 5000/5000         | 0                   | PR #393 [H200, V1-pipeline, full-set, c=8] |
+| Qwen3-Omni | modalities=text+audio | 71.06%           | 5000/5000         | 0                   | PR #393 [H200, V1-pipeline, full-set, c=8] |
 | Qwen3-Omni | modalities=text       | 71.10%           | 4999/5000         | 1                   | PR #351 [H100, full-set, c=8] |
 | Qwen3-Omni | modalities=text+audio | 71.14%           | 5000/5000         | 0                   | PR #351 [H100, full-set, c=8] |
 
@@ -66,8 +66,8 @@ Speed (speed)
 
 | Model      | Config                | latency_mean_s | latency_p95_s | throughput_qps | tok_per_s_mean | tok_per_s_agg | Source                                          |
 | ---------- | --------------------- | -------------- | ------------- | -------------- | -------------- | ------------- | ----------------------------------------------- |
-| Qwen3-Omni | modalities=text       | 0.226          | 0.335         | 35.33          | 9.1            | 9.1           | this PR [H200, V1-pipeline, full-set, c=8]                   |
-| Qwen3-Omni | modalities=text+audio | 0.243          | 0.340         | 32.89          | 8.5            | 8.5           | this PR [H200, V1-pipeline, full-set, c=8, text-only server] |
+| Qwen3-Omni | modalities=text       | 0.226          | 0.335         | 35.33          | 9.1            | 9.1           | PR #393 [H200, V1-pipeline, full-set, c=8]                   |
+| Qwen3-Omni | modalities=text+audio | 0.243          | 0.340         | 32.89          | 8.5            | 8.5           | PR #393 [H200, V1-pipeline, full-set, c=8, text-only server] |
 | Qwen3-Omni | modalities=text       | 0.512          | 0.864         | 15.598         | 4.5            | 4.0           | PR #351 [H100, full-set, c=8]                   |
 | Qwen3-Omni | modalities=text+audio | 0.515          | 0.884         | 15.521         | 4.4            | 4.0           | PR #351 [H100, full-set, c=8] (text-only server) |
 

--- a/benchmarks/eval/benchmark_omni_mmsu.py
+++ b/benchmarks/eval/benchmark_omni_mmsu.py
@@ -42,14 +42,14 @@ CI runs on a subset and has its own thresholds elsewhere (see tasks/*.py).
 
 Benchmark: MMSU     |  Dataset: MMSU full (5000 samples)
 Hardware:  1 x H200 (default; non-H200 sources are tagged in Source column)
-Last verified: 2026-04-25
+Last verified: 2026-05-04
 
 Accuracy (accuracy)
 
 | Model      | Config                | overall_accuracy | parseable_samples | unparseable_samples | Source                        |
 | ---------- | --------------------- | ---------------- | ----------------- | ------------------- | ----------------------------- |
-| Qwen3-Omni | modalities=text       | 70.88%           | 5000/5000         | 0                   | PR #316 [H200, full-set, c=8] |
-| Qwen3-Omni | modalities=text+audio | 71.22%           | 5000/5000         | 0                   | PR #316 [H200, full-set, c=8] |
+| Qwen3-Omni | modalities=text       | 70.96%           | 5000/5000         | 0                   | this PR [H200, V1-pipeline, full-set, c=8] |
+| Qwen3-Omni | modalities=text+audio | 71.06%           | 5000/5000         | 0                   | this PR [H200, V1-pipeline, full-set, c=8] |
 | Qwen3-Omni | modalities=text       | 71.10%           | 4999/5000         | 1                   | PR #351 [H100, full-set, c=8] |
 | Qwen3-Omni | modalities=text+audio | 71.14%           | 5000/5000         | 0                   | PR #351 [H100, full-set, c=8] |
 
@@ -66,8 +66,8 @@ Speed (speed)
 
 | Model      | Config                | latency_mean_s | latency_p95_s | throughput_qps | tok_per_s_mean | tok_per_s_agg | Source                                          |
 | ---------- | --------------------- | -------------- | ------------- | -------------- | -------------- | ------------- | ----------------------------------------------- |
-| Qwen3-Omni | modalities=text       | 0.349          | 0.484         | 22.91          | 6.1            | 5.9           | PR #316 [H200, full-set, c=8]                   |
-| Qwen3-Omni | modalities=text+audio | 0.330          | 0.444         | 24.23          | 6.4            | 6.3           | PR #316 [H200, full-set, c=8, text-only server] |
+| Qwen3-Omni | modalities=text       | 0.226          | 0.335         | 35.33          | 9.1            | 9.1           | this PR [H200, V1-pipeline, full-set, c=8]                   |
+| Qwen3-Omni | modalities=text+audio | 0.243          | 0.340         | 32.89          | 8.5            | 8.5           | this PR [H200, V1-pipeline, full-set, c=8, text-only server] |
 | Qwen3-Omni | modalities=text       | 0.512          | 0.864         | 15.598         | 4.5            | 4.0           | PR #351 [H100, full-set, c=8]                   |
 | Qwen3-Omni | modalities=text+audio | 0.515          | 0.884         | 15.521         | 4.4            | 4.0           | PR #351 [H100, full-set, c=8] (text-only server) |
 

--- a/benchmarks/eval/benchmark_omni_mmsu.py
+++ b/benchmarks/eval/benchmark_omni_mmsu.py
@@ -9,13 +9,13 @@ Usage:
     # Launch the server:
     python -m sglang_omni.cli serve \
         --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
-        --port 8000
+        --version v1 --port 8000
 
     # If only text is needed:
 
     python -m sglang_omni.cli serve \
         --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
-        --text-only --port 8000
+        --version v1 --text-only --port 8000
 
     # Prepare the dataset:
     python -m benchmarks.dataset.prepare --dataset mmsu

--- a/benchmarks/eval/benchmark_omni_seedtts.py
+++ b/benchmarks/eval/benchmark_omni_seedtts.py
@@ -15,7 +15,7 @@ Usage:
     # Launch the server:
     python -m sglang_omni.cli serve \
         --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
-        --port 8000
+        --version v1 --port 8000
 
     # Download the test set:
     python -m benchmarks.dataset.prepare --dataset seedtts
@@ -58,7 +58,7 @@ Accuracy (accuracy.wer)
 
 | Model      | Config            | wer_corpus | wer_per_sample_mean | wer_per_sample_median | wer_per_sample_std | evaluated | skipped | Source                         |
 | ---------- | ----------------- | ---------- | ------------------- | --------------------- | ------------------ | --------- | ------- | ------------------------------ |
-| Qwen3-Omni | EN, voice_clone=T | 2.61%      | 2.60%               | 0.00%                 | 10.2%              | 1088/1088 | 0       | PR #393 [H200, V1-pipeline, full-set, c=16] |
+| Qwen3-Omni | EN, voice_clone=T | 2.18%      | 2.28%               | 0.00%                 | 7.8%               | 1088/1088 | 0       | PR #393 [H200, V1-pipeline, full-set, c=16, n=3 mean] |
 | Qwen3-Omni | EN, voice_clone=F | 2.06%      | 2.19%               | 0.00%                 | 6.8%               | 1088/1088 | 0       | PR #393 [H200, V1-pipeline, full-set, c=16] |
 | Qwen3-Omni | ZH, voice_clone=T | 1.88%      | 1.80%               | 0.00%                 | 12.0%              | 2020/2020 | 0       | PR #393 [H200, V1-pipeline, full-set, c=16] |
 | Qwen3-Omni | ZH, voice_clone=F | 1.80%      | 1.70%               | 0.00%                 | 8.0%               | 2020/2020 | 0       | PR #393 [H200, V1-pipeline, full-set, c=16] |

--- a/benchmarks/eval/benchmark_omni_seedtts.py
+++ b/benchmarks/eval/benchmark_omni_seedtts.py
@@ -58,10 +58,10 @@ Accuracy (accuracy.wer)
 
 | Model      | Config            | wer_corpus | wer_per_sample_mean | wer_per_sample_median | wer_per_sample_std | evaluated | skipped | Source                         |
 | ---------- | ----------------- | ---------- | ------------------- | --------------------- | ------------------ | --------- | ------- | ------------------------------ |
-| Qwen3-Omni | EN, voice_clone=T | 2.61%      | 2.60%               | 0.00%                 | 10.2%              | 1088/1088 | 0       | this PR [H200, V1-pipeline, full-set, c=16] |
-| Qwen3-Omni | EN, voice_clone=F | 2.06%      | 2.19%               | 0.00%                 | 6.8%               | 1088/1088 | 0       | this PR [H200, V1-pipeline, full-set, c=16] |
-| Qwen3-Omni | ZH, voice_clone=T | 1.88%      | 1.80%               | 0.00%                 | 12.0%              | 2020/2020 | 0       | this PR [H200, V1-pipeline, full-set, c=16] |
-| Qwen3-Omni | ZH, voice_clone=F | 1.80%      | 1.70%               | 0.00%                 | 8.0%               | 2020/2020 | 0       | this PR [H200, V1-pipeline, full-set, c=16] |
+| Qwen3-Omni | EN, voice_clone=T | 2.61%      | 2.60%               | 0.00%                 | 10.2%              | 1088/1088 | 0       | PR #393 [H200, V1-pipeline, full-set, c=16] |
+| Qwen3-Omni | EN, voice_clone=F | 2.06%      | 2.19%               | 0.00%                 | 6.8%               | 1088/1088 | 0       | PR #393 [H200, V1-pipeline, full-set, c=16] |
+| Qwen3-Omni | ZH, voice_clone=T | 1.88%      | 1.80%               | 0.00%                 | 12.0%              | 2020/2020 | 0       | PR #393 [H200, V1-pipeline, full-set, c=16] |
+| Qwen3-Omni | ZH, voice_clone=F | 1.80%      | 1.70%               | 0.00%                 | 8.0%               | 2020/2020 | 0       | PR #393 [H200, V1-pipeline, full-set, c=16] |
 | Qwen3-Omni | EN, voice_clone=T | 1.86%      | 1.94%               | 0.00%                 | 5.9%               | 1088/1088 | 0       | PR #351 [H100, full-set, c=16] |
 | Qwen3-Omni | EN, voice_clone=F | 2.40%      | 2.44%               | 0.00%                 | 7.3%               | 1088/1088 | 0       | PR #351 [H100, full-set, c=16] |
 | Qwen3-Omni | ZH, voice_clone=T | 1.49%      | 1.45%               | 0.00%                 | 3.7%               | 2020/2020 | 0       | PR #351 [H100, full-set, c=16] |
@@ -72,10 +72,10 @@ Generation speed (generation.speed)
 
 | Model      | Config            | latency_mean_s | latency_p95_s | rtf_mean | throughput_qps | tok_per_s_mean | tok_per_s_agg | Source                         |
 | ---------- | ----------------- | -------------- | ------------- | -------- | -------------- | -------------- | ------------- | ------------------------------ |
-| Qwen3-Omni | EN, voice_clone=T | 6.84           | 11.22         | 1.91     | 2.327          | 2.2            | 2.1           | this PR [H200, V1-pipeline, full-set, c=16] |
-| Qwen3-Omni | EN, voice_clone=F | 5.60           | 8.25          | 1.56     | 2.847          | 2.6            | 2.5           | this PR [H200, V1-pipeline, full-set, c=16] |
-| Qwen3-Omni | ZH, voice_clone=T | 6.94           | 9.36          | 1.67     | 2.301          | 2.5            | 2.4           | this PR [H200, V1-pipeline, full-set, c=16] |
-| Qwen3-Omni | ZH, voice_clone=F | 6.51           | 8.77          | 1.57     | 2.450          | 2.6            | 2.6           | this PR [H200, V1-pipeline, full-set, c=16] |
+| Qwen3-Omni | EN, voice_clone=T | 6.84           | 11.22         | 1.91     | 2.327          | 2.2            | 2.1           | PR #393 [H200, V1-pipeline, full-set, c=16] |
+| Qwen3-Omni | EN, voice_clone=F | 5.60           | 8.25          | 1.56     | 2.847          | 2.6            | 2.5           | PR #393 [H200, V1-pipeline, full-set, c=16] |
+| Qwen3-Omni | ZH, voice_clone=T | 6.94           | 9.36          | 1.67     | 2.301          | 2.5            | 2.4           | PR #393 [H200, V1-pipeline, full-set, c=16] |
+| Qwen3-Omni | ZH, voice_clone=F | 6.51           | 8.77          | 1.57     | 2.450          | 2.6            | 2.6           | PR #393 [H200, V1-pipeline, full-set, c=16] |
 | Qwen3-Omni | EN, voice_clone=T | 44.94          | 67.44         | 12.43    | 0.355          | 0.3            | 0.3           | PR #351 [H100, full-set, c=16] |
 | Qwen3-Omni | EN, voice_clone=F | 45.73          | 68.10         | 12.69    | 0.349          | 0.3            | 0.3           | PR #351 [H100, full-set, c=16] |
 | Qwen3-Omni | ZH, voice_clone=T | 55.88          | 74.93         | 13.44    | 0.286          | 0.3            | 0.3           | PR #351 [H100, full-set, c=16] |

--- a/benchmarks/eval/benchmark_omni_seedtts.py
+++ b/benchmarks/eval/benchmark_omni_seedtts.py
@@ -52,16 +52,16 @@ CI runs on a subset and has its own thresholds elsewhere (see tasks/*.py).
 
 Benchmark: SeedTTS  |  Dataset: seed-tts-eval, full set
 Hardware:  1 x H200 (default; non-H200 sources are tagged in Source column)
-Last verified: 2026-04-25
+Last verified: 2026-05-04
 
 Accuracy (accuracy.wer)
 
 | Model      | Config            | wer_corpus | wer_per_sample_mean | wer_per_sample_median | wer_per_sample_std | evaluated | skipped | Source                         |
 | ---------- | ----------------- | ---------- | ------------------- | --------------------- | ------------------ | --------- | ------- | ------------------------------ |
-| Qwen3-Omni | EN, voice_clone=T | 2.10%      | 2.20%               | 0.00%                 | 7.0%               | 1088/1088 | 0       | PR #316 [H200, full-set, c=16] |
-| Qwen3-Omni | EN, voice_clone=F | 2.39%      | 2.34%               | 0.00%                 | 8.6%               | 1088/1088 | 0       | PR #316 [H200, full-set, c=16] |
-| Qwen3-Omni | ZH, voice_clone=T | 1.66%      | 1.63%               | 0.00%                 | 8.1%               | 2020/2020 | 0       | PR #316 [H200, full-set, c=16] |
-| Qwen3-Omni | ZH, voice_clone=F | 1.79%      | 1.72%               | 0.00%                 | 6.8%               | 2020/2020 | 0       | PR #316 [H200, full-set, c=16] |
+| Qwen3-Omni | EN, voice_clone=T | 2.61%      | 2.60%               | 0.00%                 | 10.2%              | 1088/1088 | 0       | this PR [H200, V1-pipeline, full-set, c=16] |
+| Qwen3-Omni | EN, voice_clone=F | 2.06%      | 2.19%               | 0.00%                 | 6.8%               | 1088/1088 | 0       | this PR [H200, V1-pipeline, full-set, c=16] |
+| Qwen3-Omni | ZH, voice_clone=T | 1.88%      | 1.80%               | 0.00%                 | 12.0%              | 2020/2020 | 0       | this PR [H200, V1-pipeline, full-set, c=16] |
+| Qwen3-Omni | ZH, voice_clone=F | 1.80%      | 1.70%               | 0.00%                 | 8.0%               | 2020/2020 | 0       | this PR [H200, V1-pipeline, full-set, c=16] |
 | Qwen3-Omni | EN, voice_clone=T | 1.86%      | 1.94%               | 0.00%                 | 5.9%               | 1088/1088 | 0       | PR #351 [H100, full-set, c=16] |
 | Qwen3-Omni | EN, voice_clone=F | 2.40%      | 2.44%               | 0.00%                 | 7.3%               | 1088/1088 | 0       | PR #351 [H100, full-set, c=16] |
 | Qwen3-Omni | ZH, voice_clone=T | 1.49%      | 1.45%               | 0.00%                 | 3.7%               | 2020/2020 | 0       | PR #351 [H100, full-set, c=16] |
@@ -72,10 +72,10 @@ Generation speed (generation.speed)
 
 | Model      | Config            | latency_mean_s | latency_p95_s | rtf_mean | throughput_qps | tok_per_s_mean | tok_per_s_agg | Source                         |
 | ---------- | ----------------- | -------------- | ------------- | -------- | -------------- | -------------- | ------------- | ------------------------------ |
-| Qwen3-Omni | EN, voice_clone=T | 62.70          | 95.72         | 17.49    | 0.254          | 0.2            | 0.2           | PR #316 [H200, full-set, c=16] |
-| Qwen3-Omni | EN, voice_clone=F | 62.31          | 93.69         | 17.38    | 0.256          | 0.2            | 0.2           | PR #316 [H200, full-set, c=16] |
-| Qwen3-Omni | ZH, voice_clone=T | 73.31          | 98.57         | 17.61    | 0.218          | 0.2            | 0.2           | PR #316 [H200, full-set, c=16] |
-| Qwen3-Omni | ZH, voice_clone=F | 70.75          | 94.03         | 16.99    | 0.226          | 0.2            | 0.2           | PR #316 [H200, full-set, c=16] |
+| Qwen3-Omni | EN, voice_clone=T | 6.84           | 11.22         | 1.91     | 2.327          | 2.2            | 2.1           | this PR [H200, V1-pipeline, full-set, c=16] |
+| Qwen3-Omni | EN, voice_clone=F | 5.60           | 8.25          | 1.56     | 2.847          | 2.6            | 2.5           | this PR [H200, V1-pipeline, full-set, c=16] |
+| Qwen3-Omni | ZH, voice_clone=T | 6.94           | 9.36          | 1.67     | 2.301          | 2.5            | 2.4           | this PR [H200, V1-pipeline, full-set, c=16] |
+| Qwen3-Omni | ZH, voice_clone=F | 6.51           | 8.77          | 1.57     | 2.450          | 2.6            | 2.6           | this PR [H200, V1-pipeline, full-set, c=16] |
 | Qwen3-Omni | EN, voice_clone=T | 44.94          | 67.44         | 12.43    | 0.355          | 0.3            | 0.3           | PR #351 [H100, full-set, c=16] |
 | Qwen3-Omni | EN, voice_clone=F | 45.73          | 68.10         | 12.69    | 0.349          | 0.3            | 0.3           | PR #351 [H100, full-set, c=16] |
 | Qwen3-Omni | ZH, voice_clone=T | 55.88          | 74.93         | 13.44    | 0.286          | 0.3            | 0.3           | PR #351 [H100, full-set, c=16] |

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -65,16 +65,16 @@ CI runs on a subset and has its own thresholds elsewhere (see tasks/*.py).
 
 Benchmark: SeedTTS  |  Dataset: seed-tts-eval, full set (EN=1088, ZH=2020)
 Hardware:  1 x H200 (default; non-H200 sources are tagged in Source column)
-Last verified: 2026-04-25
+Last verified: 2026-05-04
 
 Accuracy (accuracy.wer)
 
 | Model  | Config           | wer_corpus | wer_per_sample_mean | wer_per_sample_median | wer_per_sample_std | evaluated | skipped | Source                         |
 | ------ | ---------------- | ---------- | ------------------- | --------------------- | ------------------ | --------- | ------- | ------------------------------ |
-| S2-Pro | EN, stream=False | 1.02%      | 0.99%               | 0.00%                 | 3.4%               | 1088/1088 | 0       | PR #316 [H200, full-set, c=16] |
-| S2-Pro | EN, stream=True  | 0.97%      | 0.93%               | 0.00%                 | 3.3%               | 1088/1088 | 0       | PR #316 [H200, full-set, c=16] |
-| S2-Pro | ZH, stream=False | 1.15%      | 1.09%               | 0.00%                 | 2.7%               | 2020/2020 | 0       | PR #316 [H200, full-set, c=16] |
-| S2-Pro | ZH, stream=True  | 1.10%      | 1.05%               | 0.00%                 | 2.7%               | 2020/2020 | 0       | PR #316 [H200, full-set, c=16] |
+| S2-Pro | EN, stream=False | 1.16%      | 1.11%               | 0.00%                 | 3.7%               | 1088/1088 | 0       | this PR [H200, V1-pipeline, full-set, c=16] |
+| S2-Pro | EN, stream=True  | 1.06%      | 1.00%               | 0.00%                 | 3.4%               | 1088/1088 | 0       | this PR [H200, V1-pipeline, full-set, c=16] |
+| S2-Pro | ZH, stream=False | 0.93%      | 0.89%               | 0.00%                 | 2.2%               | 2020/2020 | 0       | this PR [H200, V1-pipeline, full-set, c=16] |
+| S2-Pro | ZH, stream=True  | 0.94%      | 0.89%               | 0.00%                 | 2.2%               | 2020/2020 | 0       | this PR [H200, V1-pipeline, full-set, c=16] |
 | S2-Pro | EN, stream=False | 1.03%      | 0.98%               | 0.00%                 | 3.4%               | 1088/1088 | 0       | PR #351 [H100, full-set, c=16] |
 | S2-Pro | EN, stream=True  | 0.98%      | 0.94%               | 0.00%                 | 3.3%               | 1088/1088 | 0       | PR #351 [H100, full-set, c=16] |
 | S2-Pro | ZH, stream=False | 0.93%      | 0.89%               | 0.00%                 | 2.2%               | 2020/2020 | 0       | PR #351 [H100, full-set, c=16] |
@@ -85,10 +85,10 @@ Generation speed (generation.speed)
 
 | Model  | Config           | latency_mean_s | latency_p95_s | rtf_mean | throughput_qps | tok_per_s_mean | tok_per_s_agg | Source                         |
 | ------ | ---------------- | -------------- | ------------- | -------- | -------------- | -------------- | ------------- | ------------------------------ |
-| S2-Pro | EN, stream=False | 13.724         | 21.163        | 3.604    | 1.161          | 45.5           | 25.7          | PR #316 [H200, full-set, c=16] |
-| S2-Pro | EN, stream=True  | 15.172         | 24.686        | 4.047    | 1.051          | 50.1           | 43.8          | PR #316 [H200, full-set, c=16] |
-| S2-Pro | ZH, stream=False | 15.934         | 24.903        | 2.986    | 1.001          | 45.9           | 40.8          | PR #316 [H200, full-set, c=16] |
-| S2-Pro | ZH, stream=True  | 13.913         | 22.303        | 2.608    | 1.146          | 48.2           | 44.0          | PR #316 [H200, full-set, c=16] |
+| S2-Pro | EN, stream=False | 17.016         | 28.582        | 4.501    | 0.937          | 45.3           | 42.7          | this PR [H200, V1-pipeline, full-set, c=16] |
+| S2-Pro | EN, stream=True  | 16.189         | 27.789        | 4.297    | 0.984          | 46.7           | 44.8          | this PR [H200, V1-pipeline, full-set, c=16] |
+| S2-Pro | ZH, stream=False | 12.428         | 21.057        | 2.318    | 1.282          | 51.7           | 50.4          | this PR [H200, V1-pipeline, full-set, c=16] |
+| S2-Pro | ZH, stream=True  | 9.384          | 13.631        | 1.762    | 1.700          | 57.0           | 56.4          | this PR [H200, V1-pipeline, full-set, c=16] |
 | S2-Pro | EN, stream=False | 9.38           | 14.65         | 2.48     | 1.700          | 56.6           | 56.0          | PR #351 [H100, full-set, c=16] |
 | S2-Pro | EN, stream=True  | 9.92           | 15.49         | 2.62     | 1.607          | 53.9           | 53.2          | PR #351 [H100, full-set, c=16] |
 | S2-Pro | ZH, stream=False | 9.64           | 13.61         | 1.80     | 1.655          | 55.7           | 55.2          | PR #351 [H100, full-set, c=16] |
@@ -104,8 +104,8 @@ ASR speed (accuracy.asr_speed) — Whisper-large-v3 for EN, FunASR paraformer-zh
 
 | Lang | asr_latency_mean_s | asr_rtf_mean | asr_throughput_samples_per_s | Source                                          |
 | ---- | ------------------ | ------------ | ---------------------------- | ----------------------------------------------- |
-| EN   | 0.274              | 0.0713       | 3.65                         | PR #316 [H200, from S2-Pro EN stream=False run] |
-| ZH   | 0.357              | 0.0676       | 2.80                         | PR #316 [H200, from S2-Pro ZH stream=False run] |
+| EN   | 0.297              | 0.0772       | 3.36                         | this PR [H200, from S2-Pro EN stream=False run] |
+| ZH   | 0.294              | 0.0556       | 3.40                         | this PR [H200, from S2-Pro ZH stream=False run] |
 """
 
 from __future__ import annotations

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -71,10 +71,10 @@ Accuracy (accuracy.wer)
 
 | Model  | Config           | wer_corpus | wer_per_sample_mean | wer_per_sample_median | wer_per_sample_std | evaluated | skipped | Source                         |
 | ------ | ---------------- | ---------- | ------------------- | --------------------- | ------------------ | --------- | ------- | ------------------------------ |
-| S2-Pro | EN, stream=False | 1.16%      | 1.11%               | 0.00%                 | 3.7%               | 1088/1088 | 0       | PR #393 [H200, V1-pipeline, full-set, c=16] |
-| S2-Pro | EN, stream=True  | 1.06%      | 1.00%               | 0.00%                 | 3.4%               | 1088/1088 | 0       | PR #393 [H200, V1-pipeline, full-set, c=16] |
-| S2-Pro | ZH, stream=False | 0.93%      | 0.89%               | 0.00%                 | 2.2%               | 2020/2020 | 0       | PR #393 [H200, V1-pipeline, full-set, c=16] |
-| S2-Pro | ZH, stream=True  | 0.94%      | 0.89%               | 0.00%                 | 2.2%               | 2020/2020 | 0       | PR #393 [H200, V1-pipeline, full-set, c=16] |
+| S2-Pro | EN, stream=False | 1.16%      | 1.11%               | 0.00%                 | 3.7%               | 1088/1088 | 0       | PR #393 [H200, full-set, c=16] |
+| S2-Pro | EN, stream=True  | 1.06%      | 1.00%               | 0.00%                 | 3.4%               | 1088/1088 | 0       | PR #393 [H200, full-set, c=16] |
+| S2-Pro | ZH, stream=False | 0.93%      | 0.89%               | 0.00%                 | 2.2%               | 2020/2020 | 0       | PR #393 [H200, full-set, c=16] |
+| S2-Pro | ZH, stream=True  | 0.94%      | 0.89%               | 0.00%                 | 2.2%               | 2020/2020 | 0       | PR #393 [H200, full-set, c=16] |
 | S2-Pro | EN, stream=False | 1.03%      | 0.98%               | 0.00%                 | 3.4%               | 1088/1088 | 0       | PR #351 [H100, full-set, c=16] |
 | S2-Pro | EN, stream=True  | 0.98%      | 0.94%               | 0.00%                 | 3.3%               | 1088/1088 | 0       | PR #351 [H100, full-set, c=16] |
 | S2-Pro | ZH, stream=False | 0.93%      | 0.89%               | 0.00%                 | 2.2%               | 2020/2020 | 0       | PR #351 [H100, full-set, c=16] |
@@ -85,10 +85,10 @@ Generation speed (generation.speed)
 
 | Model  | Config           | latency_mean_s | latency_p95_s | rtf_mean | throughput_qps | tok_per_s_mean | tok_per_s_agg | Source                         |
 | ------ | ---------------- | -------------- | ------------- | -------- | -------------- | -------------- | ------------- | ------------------------------ |
-| S2-Pro | EN, stream=False | 17.016         | 28.582        | 4.501    | 0.937          | 45.3           | 42.7          | PR #393 [H200, V1-pipeline, full-set, c=16] |
-| S2-Pro | EN, stream=True  | 16.189         | 27.789        | 4.297    | 0.984          | 46.7           | 44.8          | PR #393 [H200, V1-pipeline, full-set, c=16] |
-| S2-Pro | ZH, stream=False | 12.428         | 21.057        | 2.318    | 1.282          | 51.7           | 50.4          | PR #393 [H200, V1-pipeline, full-set, c=16] |
-| S2-Pro | ZH, stream=True  | 9.384          | 13.631        | 1.762    | 1.700          | 57.0           | 56.4          | PR #393 [H200, V1-pipeline, full-set, c=16] |
+| S2-Pro | EN, stream=False | 17.016         | 28.582        | 4.501    | 0.937          | 45.3           | 42.7          | PR #393 [H200, full-set, c=16] |
+| S2-Pro | EN, stream=True  | 16.189         | 27.789        | 4.297    | 0.984          | 46.7           | 44.8          | PR #393 [H200, full-set, c=16] |
+| S2-Pro | ZH, stream=False | 12.428         | 21.057        | 2.318    | 1.282          | 51.7           | 50.4          | PR #393 [H200, full-set, c=16] |
+| S2-Pro | ZH, stream=True  | 9.384          | 13.631        | 1.762    | 1.700          | 57.0           | 56.4          | PR #393 [H200, full-set, c=16] |
 | S2-Pro | EN, stream=False | 9.38           | 14.65         | 2.48     | 1.700          | 56.6           | 56.0          | PR #351 [H100, full-set, c=16] |
 | S2-Pro | EN, stream=True  | 9.92           | 15.49         | 2.62     | 1.607          | 53.9           | 53.2          | PR #351 [H100, full-set, c=16] |
 | S2-Pro | ZH, stream=False | 9.64           | 13.61         | 1.80     | 1.655          | 55.7           | 55.2          | PR #351 [H100, full-set, c=16] |

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -71,10 +71,10 @@ Accuracy (accuracy.wer)
 
 | Model  | Config           | wer_corpus | wer_per_sample_mean | wer_per_sample_median | wer_per_sample_std | evaluated | skipped | Source                         |
 | ------ | ---------------- | ---------- | ------------------- | --------------------- | ------------------ | --------- | ------- | ------------------------------ |
-| S2-Pro | EN, stream=False | 1.16%      | 1.11%               | 0.00%                 | 3.7%               | 1088/1088 | 0       | this PR [H200, V1-pipeline, full-set, c=16] |
-| S2-Pro | EN, stream=True  | 1.06%      | 1.00%               | 0.00%                 | 3.4%               | 1088/1088 | 0       | this PR [H200, V1-pipeline, full-set, c=16] |
-| S2-Pro | ZH, stream=False | 0.93%      | 0.89%               | 0.00%                 | 2.2%               | 2020/2020 | 0       | this PR [H200, V1-pipeline, full-set, c=16] |
-| S2-Pro | ZH, stream=True  | 0.94%      | 0.89%               | 0.00%                 | 2.2%               | 2020/2020 | 0       | this PR [H200, V1-pipeline, full-set, c=16] |
+| S2-Pro | EN, stream=False | 1.16%      | 1.11%               | 0.00%                 | 3.7%               | 1088/1088 | 0       | PR #393 [H200, V1-pipeline, full-set, c=16] |
+| S2-Pro | EN, stream=True  | 1.06%      | 1.00%               | 0.00%                 | 3.4%               | 1088/1088 | 0       | PR #393 [H200, V1-pipeline, full-set, c=16] |
+| S2-Pro | ZH, stream=False | 0.93%      | 0.89%               | 0.00%                 | 2.2%               | 2020/2020 | 0       | PR #393 [H200, V1-pipeline, full-set, c=16] |
+| S2-Pro | ZH, stream=True  | 0.94%      | 0.89%               | 0.00%                 | 2.2%               | 2020/2020 | 0       | PR #393 [H200, V1-pipeline, full-set, c=16] |
 | S2-Pro | EN, stream=False | 1.03%      | 0.98%               | 0.00%                 | 3.4%               | 1088/1088 | 0       | PR #351 [H100, full-set, c=16] |
 | S2-Pro | EN, stream=True  | 0.98%      | 0.94%               | 0.00%                 | 3.3%               | 1088/1088 | 0       | PR #351 [H100, full-set, c=16] |
 | S2-Pro | ZH, stream=False | 0.93%      | 0.89%               | 0.00%                 | 2.2%               | 2020/2020 | 0       | PR #351 [H100, full-set, c=16] |
@@ -85,10 +85,10 @@ Generation speed (generation.speed)
 
 | Model  | Config           | latency_mean_s | latency_p95_s | rtf_mean | throughput_qps | tok_per_s_mean | tok_per_s_agg | Source                         |
 | ------ | ---------------- | -------------- | ------------- | -------- | -------------- | -------------- | ------------- | ------------------------------ |
-| S2-Pro | EN, stream=False | 17.016         | 28.582        | 4.501    | 0.937          | 45.3           | 42.7          | this PR [H200, V1-pipeline, full-set, c=16] |
-| S2-Pro | EN, stream=True  | 16.189         | 27.789        | 4.297    | 0.984          | 46.7           | 44.8          | this PR [H200, V1-pipeline, full-set, c=16] |
-| S2-Pro | ZH, stream=False | 12.428         | 21.057        | 2.318    | 1.282          | 51.7           | 50.4          | this PR [H200, V1-pipeline, full-set, c=16] |
-| S2-Pro | ZH, stream=True  | 9.384          | 13.631        | 1.762    | 1.700          | 57.0           | 56.4          | this PR [H200, V1-pipeline, full-set, c=16] |
+| S2-Pro | EN, stream=False | 17.016         | 28.582        | 4.501    | 0.937          | 45.3           | 42.7          | PR #393 [H200, V1-pipeline, full-set, c=16] |
+| S2-Pro | EN, stream=True  | 16.189         | 27.789        | 4.297    | 0.984          | 46.7           | 44.8          | PR #393 [H200, V1-pipeline, full-set, c=16] |
+| S2-Pro | ZH, stream=False | 12.428         | 21.057        | 2.318    | 1.282          | 51.7           | 50.4          | PR #393 [H200, V1-pipeline, full-set, c=16] |
+| S2-Pro | ZH, stream=True  | 9.384          | 13.631        | 1.762    | 1.700          | 57.0           | 56.4          | PR #393 [H200, V1-pipeline, full-set, c=16] |
 | S2-Pro | EN, stream=False | 9.38           | 14.65         | 2.48     | 1.700          | 56.6           | 56.0          | PR #351 [H100, full-set, c=16] |
 | S2-Pro | EN, stream=True  | 9.92           | 15.49         | 2.62     | 1.607          | 53.9           | 53.2          | PR #351 [H100, full-set, c=16] |
 | S2-Pro | ZH, stream=False | 9.64           | 13.61         | 1.80     | 1.655          | 55.7           | 55.2          | PR #351 [H100, full-set, c=16] |
@@ -104,8 +104,8 @@ ASR speed (accuracy.asr_speed) — Whisper-large-v3 for EN, FunASR paraformer-zh
 
 | Lang | asr_latency_mean_s | asr_rtf_mean | asr_throughput_samples_per_s | Source                                          |
 | ---- | ------------------ | ------------ | ---------------------------- | ----------------------------------------------- |
-| EN   | 0.297              | 0.0772       | 3.36                         | this PR [H200, from S2-Pro EN stream=False run] |
-| ZH   | 0.294              | 0.0556       | 3.40                         | this PR [H200, from S2-Pro ZH stream=False run] |
+| EN   | 0.297              | 0.0772       | 3.36                         | PR #393 [H200, from S2-Pro EN stream=False run] |
+| ZH   | 0.294              | 0.0556       | 3.40                         | PR #393 [H200, from S2-Pro ZH stream=False run] |
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Re-run all 12 H200 reference cells on commit 406e1c5 (V1 pipeline).

Accuracy preserved within noise across all benchmarks.

- Qwen3-Omni SeedTTS speed: RTF 17.x → 1.6~1.9: 10×
- MMSU throughput: 22→35 req/s（text）: +54% 
- MMMU audio=False latency: 25.7s → 5.7s: 4.5× 
- MMMU audio=True: 60% 0 failures vs 46% 15 failures 
- S2-Pro ZH speed: RTF 2.6→1.76 

regression:
S2-Pro EN speed：RTF 3.6→4.5, +25%