### PR TITLE
[Bugfix] Fix V1 abort cleanup and Qwen AR request data

### DIFF
--- a/sglang_omni_v1/models/qwen3_omni/request_builders.py
+++ b/sglang_omni_v1/models/qwen3_omni/request_builders.py
@@ -18,6 +18,7 @@ from sglang_omni_v1.models.qwen3_omni.payload_types import PipelineState, Thinke
 from sglang_omni_v1.proto import StagePayload
 from sglang_omni_v1.scheduling.messages import OutgoingMessage
 from sglang_omni_v1.scheduling.sglang_backend import SGLangARRequestData
+from sglang_omni_v1.scheduling.types import ARRequestData
 
 IMAGE_STAGE = "image_encoder"
 AUDIO_STAGE = "audio_encoder"
@@ -30,18 +31,6 @@ class EncoderRequestData:
     model_inputs: dict[str, Any]
     cache_key: str | None = None
     skip_result: dict[str, Any] | None = None
-
-
-@dataclass(slots=True)
-class ARRequestData:
-    """AR request data — base for SGLangARRequestData."""
-
-    input_ids: torch.Tensor
-    attention_mask: torch.Tensor | None = None
-    model_inputs: dict[str, Any] | None = None
-    capture_model_output_keys: tuple = ()
-    max_new_tokens: int | None = None
-    temperature: float = 0.0
 
 
 def build_encoder_request(

--- a/sglang_omni_v1/models/qwen3_omni/request_builders.py
+++ b/sglang_omni_v1/models/qwen3_omni/request_builders.py
@@ -32,8 +32,16 @@ class EncoderRequestData:
     skip_result: dict[str, Any] | None = None
 
 
+@dataclass(slots=True)
 class ARRequestData:
     """AR request data — base for SGLangARRequestData."""
+
+    input_ids: torch.Tensor
+    attention_mask: torch.Tensor | None = None
+    model_inputs: dict[str, Any] | None = None
+    capture_model_output_keys: tuple = ()
+    max_new_tokens: int | None = None
+    temperature: float = 0.0
 
 
 def build_encoder_request(

--- a/sglang_omni_v1/pipeline/stage/runtime.py
+++ b/sglang_omni_v1/pipeline/stage/runtime.py
@@ -682,12 +682,8 @@ class Stage:
             it = iter(self._aborted)
             to_remove = [next(it) for _ in range(excess)]
             self._aborted -= set(to_remove)
-        self._active_requests.discard(request_id)
-        self.input_handler.cancel(request_id)
         self.relay.cleanup(request_id)
-        if self._stream_queue is not None:
-            self._stream_queue.close(request_id)
-        self._pending_stream_data.pop(request_id, None)
+        self._clear_request_state(request_id)
         self.scheduler.abort(request_id)
 
     # ------------------------------------------------------------------

--- a/sglang_omni_v1/pipeline/stage/runtime.py
+++ b/sglang_omni_v1/pipeline/stage/runtime.py
@@ -120,7 +120,6 @@ class Stage:
         self._scheduler_crash_error: BaseException | None = None
         self._background_task_error: BaseException | None = None
 
-
     async def start(self) -> None:
         if self._running:
             return
@@ -214,7 +213,6 @@ class Stage:
                 await outbox_task
             if self._background_task_error is not None:
                 raise self._background_task_error
-
 
     async def _handle_message(self, msg: Any) -> None:
         if isinstance(msg, SubmitMessage):
@@ -508,7 +506,6 @@ class Stage:
                 raise RuntimeError(
                     f"TP follower stage {self.name} received scheduler error: {out.data}"
                 )
-
 
     async def _route_result(self, request_id: str, result: Any) -> None:
         """Route a completed result to next stage(s) or complete at coordinator."""

--- a/sglang_omni_v1/pipeline/stage/runtime.py
+++ b/sglang_omni_v1/pipeline/stage/runtime.py
@@ -120,9 +120,6 @@ class Stage:
         self._scheduler_crash_error: BaseException | None = None
         self._background_task_error: BaseException | None = None
 
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
 
     async def start(self) -> None:
         if self._running:
@@ -218,9 +215,6 @@ class Stage:
             if self._background_task_error is not None:
                 raise self._background_task_error
 
-    # ------------------------------------------------------------------
-    # Message handling
-    # ------------------------------------------------------------------
 
     async def _handle_message(self, msg: Any) -> None:
         if isinstance(msg, SubmitMessage):
@@ -444,10 +438,6 @@ class Stage:
             IncomingMessage(request_id=request_id, type="stream_chunk", data=item)
         )
 
-    # ------------------------------------------------------------------
-    # Dispatch: always through scheduler
-    # ------------------------------------------------------------------
-
     async def _execute(self, payload: Any) -> None:
         request_id = payload.request_id
         self.scheduler.inbox.put(
@@ -519,9 +509,6 @@ class Stage:
                     f"TP follower stage {self.name} received scheduler error: {out.data}"
                 )
 
-    # ------------------------------------------------------------------
-    # Routing: send results to next stage(s) or coordinator
-    # ------------------------------------------------------------------
 
     async def _route_result(self, request_id: str, result: Any) -> None:
         """Route a completed result to next stage(s) or complete at coordinator."""
@@ -658,10 +645,6 @@ class Stage:
                 self.relay.cleanup(request_id)
         self.control_plane.close()
 
-    # ------------------------------------------------------------------
-    # Abort
-    # ------------------------------------------------------------------
-
     async def _abort_listener(self) -> None:
         try:
             while self._running:
@@ -686,10 +669,6 @@ class Stage:
         self._clear_request_state(request_id)
         self.scheduler.abort(request_id)
 
-    # ------------------------------------------------------------------
-    # Profiler (kept from original)
-    # ------------------------------------------------------------------
-
     def _on_profiler_start(self, msg: ProfilerStartMessage) -> None:
         if TorchProfiler.is_active():
             return
@@ -707,10 +686,6 @@ class Stage:
             and TorchProfiler.get_active_run_id() == msg.run_id
         ):
             TorchProfiler.stop(run_id=msg.run_id)
-
-    # ------------------------------------------------------------------
-    # Info
-    # ------------------------------------------------------------------
 
     def _on_background_task_done(self, task: asyncio.Task, label: str) -> None:
         if task.cancelled():

--- a/sglang_omni_v1/scheduling/sglang_backend/request_data.py
+++ b/sglang_omni_v1/scheduling/sglang_backend/request_data.py
@@ -7,24 +7,17 @@ import collections
 from dataclasses import dataclass, field
 from typing import Any
 
+from sglang_omni_v1.scheduling.types import ARRequestData
+
 
 @dataclass
-class SGLangARRequestData:
+class SGLangARRequestData(ARRequestData):
     """Per-request state for SGLang-backed AR stages."""
 
-    input_ids: Any = None
-    attention_mask: Any = None
-    model_inputs: dict[str, Any] = field(default_factory=dict)
-    output_ids: list[int] = field(default_factory=list)
-    extra_model_outputs: dict[str, Any] = field(default_factory=dict)
-    finish_reason: str | None = None
     req: Any = None
     synced: bool = False
     generation_steps: int = 0
     suppress_tokens: list[int] | None = None
-    capture_model_output_keys: tuple = ()
-    max_new_tokens: int | None = None
-    temperature: float = 0.0
     top_p: float = 1.0
     top_k: int = -1
     repetition_penalty: float = 1.0

--- a/sglang_omni_v1/scheduling/types.py
+++ b/sglang_omni_v1/scheduling/types.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import torch
 
 
 class SchedulerStatus(Enum):
@@ -49,3 +52,18 @@ class ModelRunnerOutput:
     outputs: dict[str, RequestOutput]
     req_ids: list[str] = field(default_factory=list)
     req_id_to_index: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class ARRequestData:
+    """Backend-neutral autoregressive request state."""
+
+    input_ids: "torch.Tensor | None" = None
+    attention_mask: "torch.Tensor | None" = None
+    model_inputs: dict[str, Any] = field(default_factory=dict)
+    output_ids: list[int] = field(default_factory=list)
+    extra_model_outputs: dict[str, Any] = field(default_factory=dict)
+    finish_reason: str | None = None
+    capture_model_output_keys: tuple[str, ...] = ()
+    max_new_tokens: int | None = None
+    temperature: float = 0.0


### PR DESCRIPTION
Below is a patch for two potential logical issue found when implementing the unit test CI, with the first being an essential logic fix, and the second being a fix for code readability and unit test.

## 1. Abort Clears All Per-Request Stage State

Patch: `Stage._on_abort()` calls `_clear_request_state(request_id)`.

Why it is essential:
- Abort should remove every local trace of a request from a stage.
- `_clear_request_state()` already defines the complete cleanup contract:
  active request set, input aggregation, stream queue, pending stream data, and
  stream chunk counters.
- Calling the shared cleanup path keeps abort behavior consistent with normal
  completion and failure cleanup.

Bug if missing:
- A request is aborted while stream chunks are in flight.
- The stream chunk counter keeps stale `(request_id, source_stage)` state.
- A later request can inherit wrong stream ordering or leak stale memory/state.

## 2. Qwen `ARRequestData` Is a Real Data Object

Patch: `ARRequestData` is a dataclass with explicit fields.

Why it is essential:
- `build_thinker_request()` constructs `ARRequestData(...)` directly.
- Without dataclass fields, this helper is not constructible as written.
- The fields document the minimal AR request contract used before converting to
  SGLang-backed request data.

Bug if missing:
- Unit tests or lightweight pipeline paths that call `build_thinker_request()`
  fail immediately with a constructor error.
- The code path cannot validate tensor contracts such as `input_ids`,
  `attention_mask`, captured model outputs, or generation params.

Pipeline symptom:
- Non-SGLang or pre-SGLang request-builder logic is broken even though the
  heavier `SGLangARRequestData` path may still work.