### PR TITLE
[Fix][Qwen3-Omni] Plumb per-request sampler seed for talker layer-0

### DIFF
--- a/sglang_omni_v1/models/qwen3_omni/components/talker.py
+++ b/sglang_omni_v1/models/qwen3_omni/components/talker.py
@@ -848,6 +848,11 @@ class Qwen3OmniTalker(nn.Module):
             dtype=self.model.codec_embedding.weight.dtype,
             device=device,
         )
+        self._sampling_seeds = torch.zeros(
+            max_batch_size,
+            dtype=torch.int64,
+            device=device,
+        )
         self._output_codes = torch.zeros(
             max_batch_size,
             config.num_code_groups,
@@ -885,6 +890,7 @@ class Qwen3OmniTalker(nn.Module):
         self._sampling_top_ps[:batch_size].fill_(1.0)
         self._sampling_top_ks[:batch_size].fill_(1)
         self._sampling_min_ps[:batch_size].zero_()
+        self._sampling_seeds[:batch_size].zero_()
 
         for row_idx, sched_req in enumerate(requests):
             data = sched_req.data
@@ -897,6 +903,9 @@ class Qwen3OmniTalker(nn.Module):
             self._sampling_top_ps[row_idx] = float(sampling_params.top_p)
             self._sampling_top_ks[row_idx] = int(sampling_params.top_k)
             self._sampling_min_ps[row_idx] = float(sampling_params.min_p)
+            req_seed = sampling_params.sampling_seed
+            if req_seed is not None:
+                self._sampling_seeds[row_idx] = int(req_seed)
             if penalty != 1.0 and req.output_ids:
                 token_ids = torch.as_tensor(
                     list({int(token_id) for token_id in req.output_ids}),
@@ -1109,7 +1118,7 @@ class Qwen3OmniTalker(nn.Module):
             has_custom_logit_processor=False,
             custom_params=None,
             custom_logit_processor=None,
-            sampling_seed=None,
+            sampling_seed=self._sampling_seeds[:batch_size],
             device="cuda",
             logit_bias=None,
         )

--- a/sglang_omni_v1/models/qwen3_omni/request_builders.py
+++ b/sglang_omni_v1/models/qwen3_omni/request_builders.py
@@ -435,6 +435,7 @@ def build_sglang_talker_request(
     thinker_chunks_done: bool = True,
     thinker_config: Any = None,
     talker_model_inputs: dict[str, Any] | None = None,
+    sampling_seed: int | None = None,
 ) -> "SGLangARRequestData":
     """Build SGLang AR request for the Talker from thinker hidden states.
 
@@ -477,6 +478,7 @@ def build_sglang_talker_request(
         repetition_penalty=repetition_penalty,
         stop_token_ids=[int(codec_eos_id)] if codec_eos_id is not None else None,
         logit_bias=None,
+        sampling_seed=sampling_seed,
     )
     sampling_params.normalize(tokenizer)
     sampling_params.verify(codec_vocab_size)
@@ -770,6 +772,7 @@ def make_talker_scheduler_adapters(
             "repetition_penalty": float(params.get("talker_repetition_penalty", 1.05)),
             "codec_eos_id": codec_eos_id if codec_eos_id >= 0 else None,
             "suppress_tokens": suppress_tokens,
+            "seed": params.get("seed"),
         }
 
     def request_builder(payload: StagePayload) -> SGLangARRequestData:
@@ -818,6 +821,7 @@ def make_talker_scheduler_adapters(
             thinker_chunks_done=True,
             thinker_config=thinker_config,
             talker_model_inputs=prompt_prefill["prompt_model_inputs"],
+            sampling_seed=sampling_cfg.get("seed"),
         )
         req_data.tts_eos_embed = prompt_prefill["tts_eos_embed"]
         req_data.stage_payload = payload


### PR DESCRIPTION
### Problem

related: https://github.com/sgl-project/sglang-omni/pull/387

Under CUDA graph mode, the V1 talker layer-0 sampler produces **run-to-run non-deterministic** outputs that surface as catastrophic per-sample WER   outliers (degenerate audio loops, sample WER >50%, audio duration 5+   minutes).

Two consecutive pushes on PR #387's branch — diff is comments-only, no functional change — give different CI results:

| Run | wer_per_sample_max | n_above_50 |
|-----|-------------------:|-----------:|
| 7f258ed PASS | 21.05% | 0 |
| 75ed2016 FAIL | **70.58%** | **1** |

This breaks `assert n_above_50 == 0` in three Qwen3-Omni talker CI stages:
Stage 6 (MMSU Talker), Stage 8 (Video-MME Talker), Stage 10 (Video-AMME Talker).

### Root cause

`talker.py` hard-codes `sampling_seed=None` when constructing   `SamplingBatchInfo`, so the layer-0 sampler draws from the global   CUDA RNG. Under graph capture the RNG offset advancement is   recorded into the graph; at replay the captured offset interacts   non-deterministically with batch composition (which varies   run-to-run with scheduling order), producing different draws.   About one in ten samples lands in a degenerate AR loop (   `"bf watch tv 2021 bf watch tv 2021 ..."`, audio 5+ minutes, sample   WER >50%).

### Fix

Plumb the OpenAI API `seed` from `_resolve_talker_sampling_config`   → `build_sglang_talker_request` → `SamplingParams.sampling_seed`.   Add a per-row CUDA-graph-friendly   `_sampling_seeds: int64[max_batch_size]` buffer in the talker,   populated each step in `prepare_decode_buffers`. Requests without   a seed default to row value 0 (deterministic seed for   `multinomial_with_seed`); requests with `seed=N` now get   reproducible audio per (prompt, seed) — previously the talker   silently ignored client `seed`.

- Catastrophic outliers eliminated under graph mode (`n_above_50: 1+ → 0`).
- Graph-mode WER std tightened (0.23-0.25pp → ~0.18pp on the 5-round set).
- The OpenAI API `seed` parameter now reaches the talker — clients passing `seed=N` get reproducible audio per (prompt, seed). The talker previously ignored `seed` silently.
- Zero RTF or accuracy regression: per-row int64 buffer is allocated once at init and reused every step; no extra GPU compute. 

### Validation

Baseline: all 10 samples in Round 1 hit the   500-second `timeout_s` and are Skipped (audio duration 0.0s) — every   request enters the degenerate AR loop without seed plumb. The test   fails on `evaluated == total` before reaching the WER threshold.

After fix

Stage 8 (Video-MME Talker, N=10/round, c=8) re-run **5 rounds back-to-back** on H200 with `disable_cuda_graph: False`:

| Round | WER corpus | wer_per_sample_max | **n_above_50** | Accuracy |
|------:|-----------:|-------------------:|---------------:|---------:|
| 1     | 0.52%      | 3.85%              | **0**          | 50.0%    |
| 2     | 0.52%      | 3.70%              | **0**          | 50.0%    |
| 3     | 0.52%      | 3.70%              | **0**          | 50.0%    |
| 4     | 0.26%      | 3.70%              | **0**          | 50.0%    |
| 5     | 0.78%      | 5.00%              | **0**          | 50.0%    |

Stages 6 and 10 also re-tested with the fix + graph=on; both clear `n_above_50 == 0`