### PR TITLE
[Refactor] Remove unused ModelWorker.get_worker_info

### DIFF
--- a/sglang_omni_v1/model_runner/model_worker.py
+++ b/sglang_omni_v1/model_runner/model_worker.py
@@ -88,26 +88,6 @@ class ModelWorker:
             self.model_runner.token_to_kv_pool_allocator,
         )
 
-    def get_worker_info(self):
-        max_total_num_tokens = self.model_runner.max_total_num_tokens
-        max_req_len = min(self.server_args.context_length - 1, max_total_num_tokens - 1)
-        max_req_input_len = max_req_len - 1
-        req_pool = self.model_runner.req_to_token_pool
-        kv_pool = self.model_runner.token_to_kv_pool_allocator
-        return (
-            max_total_num_tokens,
-            self.server_args.max_prefill_tokens,
-            self.server_args.max_running_requests,
-            self.server_args.max_queued_requests,
-            max_req_len,
-            max_req_input_len,
-            self.random_seed,
-            self.device,
-            req_pool.size,
-            req_pool.max_context_len,
-            kv_pool.size,
-        )
-
     def get_tp_group(self):
         return self.model_runner.tp_group
 

--- a/sglang_omni_v1/scheduling/omni_scheduler.py
+++ b/sglang_omni_v1/scheduling/omni_scheduler.py
@@ -128,7 +128,7 @@ class OmniScheduler:
         self.page_size = server_args.page_size
         self.enable_overlap = enable_overlap
 
-        # Token / memory info (upstream reads from tp_worker.get_worker_info)
+        # Token / memory limits
         mr = tp_worker.model_runner
         self.max_total_num_tokens = mr.max_total_num_tokens
         self.max_prefill_tokens = server_args.max_prefill_tokens


### PR DESCRIPTION
OmniScheduler reads these fields directly from tp_worker.model_runner / server_args, so the method is dead code. Update the now-stale comment in omni_scheduler.py that referenced it.

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Draft PRs are skipped even if labeled.
