### PR TITLE
[V1]: Isolate IPC endpoints per server run

### DIFF
--- a/sglang_omni_v1/config/__init__.py
+++ b/sglang_omni_v1/config/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from sglang_omni_v1.config.compiler import (
     IpcRuntimeDir,
+    PipelineRuntimePrep,
     compile_pipeline,
     compile_pipeline_core,
     create_ipc_runtime_dir,
@@ -15,6 +16,7 @@ from sglang_omni_v1.config.schema import (
 
 __all__ = [
     "IpcRuntimeDir",
+    "PipelineRuntimePrep",
     "compile_pipeline",
     "compile_pipeline_core",
     "create_ipc_runtime_dir",

--- a/sglang_omni_v1/config/__init__.py
+++ b/sglang_omni_v1/config/__init__.py
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-from sglang_omni_v1.config.compiler import compile_pipeline
+from sglang_omni_v1.config.compiler import (
+    IpcRuntimeDir,
+    compile_pipeline,
+    compile_pipeline_core,
+    create_ipc_runtime_dir,
+    prepare_pipeline_runtime,
+)
 from sglang_omni_v1.config.schema import (
     EndpointsConfig,
     PipelineConfig,
@@ -8,7 +14,11 @@ from sglang_omni_v1.config.schema import (
 )
 
 __all__ = [
+    "IpcRuntimeDir",
     "compile_pipeline",
+    "compile_pipeline_core",
+    "create_ipc_runtime_dir",
+    "prepare_pipeline_runtime",
     "PipelineConfig",
     "StageConfig",
     "RelayConfig",

--- a/sglang_omni_v1/config/__init__.py
+++ b/sglang_omni_v1/config/__init__.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from sglang_omni_v1.config.compiler import (
+    CompiledPipeline,
     IpcRuntimeDir,
     PipelineRuntimePrep,
     compile_pipeline,
@@ -15,6 +16,7 @@ from sglang_omni_v1.config.schema import (
 )
 
 __all__ = [
+    "CompiledPipeline",
     "IpcRuntimeDir",
     "PipelineRuntimePrep",
     "compile_pipeline",

--- a/sglang_omni_v1/config/compiler.py
+++ b/sglang_omni_v1/config/compiler.py
@@ -4,7 +4,11 @@
 from __future__ import annotations
 
 import inspect
+import logging
+import re
+import shutil
 import socket
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -14,35 +18,116 @@ from sglang_omni_v1.pipeline.control_plane import StageControlPlane
 from sglang_omni_v1.pipeline.stage.input import InputHandler
 from sglang_omni_v1.utils import import_string
 
+logger = logging.getLogger(__name__)
 
-def compile_pipeline(config: PipelineConfig) -> tuple[Coordinator, list[Stage]]:
+
+class IpcRuntimeDir:
+    """Runtime-owned IPC directory for one pipeline instance."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self._closed = False
+
+    def __enter__(self) -> IpcRuntimeDir:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            shutil.rmtree(self.path)
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            logger.warning("Failed to remove IPC runtime dir %s: %s", self.path, exc)
+
+
+def create_ipc_runtime_dir(config: PipelineConfig) -> IpcRuntimeDir | None:
+    """Create a per-run IPC namespace for one pipeline instance."""
+    if config.endpoints.scheme != "ipc":
+        return None
+
+    base_root = Path(config.endpoints.base_path)
+    base_root.mkdir(parents=True, exist_ok=True)
+
+    namespace_prefix = re.sub(r"[^0-9a-z]+", "-", config.name.lower()).strip("-")
+    if not namespace_prefix:
+        namespace_prefix = "pipeline"
+    path = Path(tempfile.mkdtemp(prefix=f"{namespace_prefix}-", dir=base_root))
+    return IpcRuntimeDir(path)
+
+
+def prepare_pipeline_runtime(
+    config: PipelineConfig,
+    *,
+    ipc_runtime_dir: IpcRuntimeDir | None = None,
+) -> tuple[
+    list[StageConfig], dict[str, str], str, dict[str, str], IpcRuntimeDir | None, bool
+]:
+    """Prepare fused stages and endpoint allocation for one runtime."""
+    runtime_dir = ipc_runtime_dir
+    created_runtime_dir = None
+    if runtime_dir is None:
+        runtime_dir = create_ipc_runtime_dir(config)
+        created_runtime_dir = runtime_dir
+    owns_runtime_dir = created_runtime_dir is not None
+
+    try:
+        stages_cfg, name_map, entry_stage = config.apply_fusion()
+        endpoints = _allocate_endpoints(
+            config,
+            stages=stages_cfg,
+            ipc_base_dir=runtime_dir.path if runtime_dir else None,
+        )
+    except Exception:
+        if created_runtime_dir is not None:
+            created_runtime_dir.close()
+        raise
+
+    return stages_cfg, name_map, entry_stage, endpoints, runtime_dir, owns_runtime_dir
+
+
+def compile_pipeline_core(
+    config: PipelineConfig,
+    *,
+    ipc_runtime_dir: IpcRuntimeDir | None = None,
+) -> tuple[Coordinator, list[Stage], IpcRuntimeDir | None]:
     """Build the coordinator and stage objects from the pipeline configuration."""
-    stages_cfg, name_map, entry_stage = config.apply_fusion()
-    endpoints = _allocate_endpoints(config, stages=stages_cfg)
-
-    coordinator = Coordinator(
-        completion_endpoint=endpoints["completion"],
-        abort_endpoint=endpoints["abort"],
-        entry_stage=entry_stage,
-        terminal_stages=config.terminal_stages or None,
+    stages_cfg, name_map, entry_stage, endpoints, runtime_dir, owns_runtime_dir = (
+        prepare_pipeline_runtime(
+            config,
+            ipc_runtime_dir=ipc_runtime_dir,
+        )
     )
 
-    stage_endpoints = {s.name: endpoints[f"stage_{s.name}"] for s in stages_cfg}
-
-    stages: list[Stage] = []
-    for stage_cfg in stages_cfg:
-        stage = _compile_stage(
-            stage_cfg, config, stage_endpoints, endpoints, name_map=name_map
+    try:
+        coordinator = Coordinator(
+            completion_endpoint=endpoints["completion"],
+            abort_endpoint=endpoints["abort"],
+            entry_stage=entry_stage,
+            terminal_stages=config.terminal_stages or None,
         )
-        coordinator.register_stage(stage.name, stage.control_plane.recv_endpoint)
-        stages.append(stage)
 
-    # Wire streaming targets
-    stage_map = {stage.name: stage for stage in stages}
-    cfg_map = {s.name: s for s in stages_cfg}
-    for stage_cfg in stages_cfg:
-        stage = stage_map.get(stage_cfg.name)
-        if stage is not None:
+        stage_endpoints = {s.name: endpoints[f"stage_{s.name}"] for s in stages_cfg}
+
+        stages: list[Stage] = []
+        for stage_cfg in stages_cfg:
+            stage = _compile_stage(
+                stage_cfg, config, stage_endpoints, endpoints, name_map=name_map
+            )
+            coordinator.register_stage(stage.name, stage.control_plane.recv_endpoint)
+            stages.append(stage)
+
+        stage_map = {stage.name: stage for stage in stages}
+        cfg_map = {s.name: s for s in stages_cfg}
+        for stage_cfg in stages_cfg:
+            stage = stage_map.get(stage_cfg.name)
+            if stage is None:
+                continue
             _wire_stream_targets(
                 stage,
                 stage_cfg,
@@ -50,7 +135,27 @@ def compile_pipeline(config: PipelineConfig) -> tuple[Coordinator, list[Stage]]:
                 gpu_placement=config.gpu_placement,
                 cfg_map=cfg_map,
             )
+    except Exception:
+        if owns_runtime_dir and runtime_dir is not None:
+            runtime_dir.close()
+        raise
 
+    return coordinator, stages, runtime_dir
+
+
+def compile_pipeline(config: PipelineConfig) -> tuple[Coordinator, list[Stage]]:
+    """Build coordinator and stages directly from a pipeline config.
+
+    IPC pipelines need explicit runtime-directory ownership so multiple
+    replicas cannot bind the same local sockets.
+    """
+    if config.endpoints.scheme == "ipc":
+        raise ValueError(
+            "compile_pipeline() does not manage IPC runtime-dir ownership. "
+            "Use compile_pipeline_core(...) or MultiProcessPipelineRunner."
+        )
+
+    coordinator, stages, _ = compile_pipeline_core(config)
     return coordinator, stages
 
 
@@ -252,6 +357,7 @@ def _allocate_endpoints(
     config: PipelineConfig,
     *,
     stages: list[StageConfig],
+    ipc_base_dir: Path | None = None,
 ) -> dict[str, str]:
     endpoints: dict[str, str] = {}
 
@@ -261,8 +367,9 @@ def _allocate_endpoints(
         endpoints["abort"] = config.abort_endpoint
 
     if config.endpoints.scheme == "ipc":
-        base_dir = Path(config.endpoints.base_path) / config.name
-        base_dir.mkdir(parents=True, exist_ok=True)
+        if ipc_base_dir is None:
+            raise ValueError("IPC endpoint allocation requires an IPC runtime dir")
+        base_dir = ipc_base_dir
         endpoints.setdefault("completion", f"ipc://{base_dir}/completion.sock")
         endpoints.setdefault("abort", f"ipc://{base_dir}/abort.sock")
         for s in stages:

--- a/sglang_omni_v1/config/compiler.py
+++ b/sglang_omni_v1/config/compiler.py
@@ -9,6 +9,7 @@ import re
 import shutil
 import socket
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -46,6 +47,18 @@ class IpcRuntimeDir:
             logger.warning("Failed to remove IPC runtime dir %s: %s", self.path, exc)
 
 
+@dataclass(frozen=True)
+class PipelineRuntimePrep:
+    """Prepared stage and endpoint state for one pipeline runtime."""
+
+    stages_cfg: list[StageConfig]
+    name_map: dict[str, str]
+    entry_stage: str
+    endpoints: dict[str, str]
+    runtime_dir: IpcRuntimeDir | None
+    runtime_dir_created_here: bool
+
+
 def create_ipc_runtime_dir(config: PipelineConfig) -> IpcRuntimeDir | None:
     """Create a per-run IPC namespace for one pipeline instance."""
     if config.endpoints.scheme != "ipc":
@@ -65,16 +78,18 @@ def prepare_pipeline_runtime(
     config: PipelineConfig,
     *,
     ipc_runtime_dir: IpcRuntimeDir | None = None,
-) -> tuple[
-    list[StageConfig], dict[str, str], str, dict[str, str], IpcRuntimeDir | None, bool
-]:
-    """Prepare fused stages and endpoint allocation for one runtime."""
+) -> PipelineRuntimePrep:
+    """Prepare fused stages and endpoint allocation for one runtime.
+
+    Caller-provided IPC runtime dirs stay caller-owned. This helper only
+    closes runtime dirs it creates internally.
+    """
     runtime_dir = ipc_runtime_dir
     created_runtime_dir = None
     if runtime_dir is None:
         runtime_dir = create_ipc_runtime_dir(config)
         created_runtime_dir = runtime_dir
-    owns_runtime_dir = created_runtime_dir is not None
+    runtime_dir_created_here = created_runtime_dir is not None
 
     try:
         stages_cfg, name_map, entry_stage = config.apply_fusion()
@@ -88,7 +103,14 @@ def prepare_pipeline_runtime(
             created_runtime_dir.close()
         raise
 
-    return stages_cfg, name_map, entry_stage, endpoints, runtime_dir, owns_runtime_dir
+    return PipelineRuntimePrep(
+        stages_cfg=stages_cfg,
+        name_map=name_map,
+        entry_stage=entry_stage,
+        endpoints=endpoints,
+        runtime_dir=runtime_dir,
+        runtime_dir_created_here=runtime_dir_created_here,
+    )
 
 
 def compile_pipeline_core(
@@ -96,35 +118,43 @@ def compile_pipeline_core(
     *,
     ipc_runtime_dir: IpcRuntimeDir | None = None,
 ) -> tuple[Coordinator, list[Stage], IpcRuntimeDir | None]:
-    """Build the coordinator and stage objects from the pipeline configuration."""
-    stages_cfg, name_map, entry_stage, endpoints, runtime_dir, owns_runtime_dir = (
-        prepare_pipeline_runtime(
-            config,
-            ipc_runtime_dir=ipc_runtime_dir,
-        )
+    """Build coordinator and stages, returning any managed runtime dir.
+
+    Caller-provided IPC runtime dirs stay caller-owned. The returned runtime
+    dir must be closed by the caller after successful compilation.
+    """
+    prep = prepare_pipeline_runtime(
+        config,
+        ipc_runtime_dir=ipc_runtime_dir,
     )
 
     try:
         coordinator = Coordinator(
-            completion_endpoint=endpoints["completion"],
-            abort_endpoint=endpoints["abort"],
-            entry_stage=entry_stage,
+            completion_endpoint=prep.endpoints["completion"],
+            abort_endpoint=prep.endpoints["abort"],
+            entry_stage=prep.entry_stage,
             terminal_stages=config.terminal_stages or None,
         )
 
-        stage_endpoints = {s.name: endpoints[f"stage_{s.name}"] for s in stages_cfg}
+        stage_endpoints = {
+            s.name: prep.endpoints[f"stage_{s.name}"] for s in prep.stages_cfg
+        }
 
         stages: list[Stage] = []
-        for stage_cfg in stages_cfg:
+        for stage_cfg in prep.stages_cfg:
             stage = _compile_stage(
-                stage_cfg, config, stage_endpoints, endpoints, name_map=name_map
+                stage_cfg,
+                config,
+                stage_endpoints,
+                prep.endpoints,
+                name_map=prep.name_map,
             )
             coordinator.register_stage(stage.name, stage.control_plane.recv_endpoint)
             stages.append(stage)
 
         stage_map = {stage.name: stage for stage in stages}
-        cfg_map = {s.name: s for s in stages_cfg}
-        for stage_cfg in stages_cfg:
+        cfg_map = {s.name: s for s in prep.stages_cfg}
+        for stage_cfg in prep.stages_cfg:
             stage = stage_map.get(stage_cfg.name)
             if stage is None:
                 continue
@@ -136,18 +166,18 @@ def compile_pipeline_core(
                 cfg_map=cfg_map,
             )
     except Exception:
-        if owns_runtime_dir and runtime_dir is not None:
-            runtime_dir.close()
+        if prep.runtime_dir_created_here and prep.runtime_dir is not None:
+            prep.runtime_dir.close()
         raise
 
-    return coordinator, stages, runtime_dir
+    return coordinator, stages, prep.runtime_dir
 
 
 def compile_pipeline(config: PipelineConfig) -> tuple[Coordinator, list[Stage]]:
     """Build coordinator and stages directly from a pipeline config.
 
-    IPC pipelines need explicit runtime-directory ownership so multiple
-    replicas cannot bind the same local sockets.
+    This thin helper is TCP-only. For IPC, use compile_pipeline_core(...)
+    with explicit runtime-dir cleanup, or MultiProcessPipelineRunner.
     """
     if config.endpoints.scheme == "ipc":
         raise ValueError(

--- a/sglang_omni_v1/config/compiler.py
+++ b/sglang_omni_v1/config/compiler.py
@@ -120,8 +120,13 @@ def compile_pipeline_core(
 ) -> tuple[Coordinator, list[Stage], IpcRuntimeDir | None]:
     """Build coordinator and stages, returning any managed runtime dir.
 
-    Caller-provided IPC runtime dirs stay caller-owned. The returned runtime
-    dir must be closed by the caller after successful compilation.
+    Note (Chenyang, Ratish):
+        1. If the caller passes ipc_runtime_dir, that dir is caller-owned for
+           the full lifetime — this function never closes it, on success or on
+           failure. The same dir is returned back so callers can keep using it.
+        2. If the caller does not pass one, this function may create a new
+           runtime dir internally; that dir is closed automatically on failure
+           and returned to the caller on success. The caller MUST close it.
     """
     prep = prepare_pipeline_runtime(
         config,

--- a/sglang_omni_v1/config/compiler.py
+++ b/sglang_omni_v1/config/compiler.py
@@ -35,6 +35,9 @@ class IpcRuntimeDir:
     def __exit__(self, exc_type, exc, tb) -> None:
         self.close()
 
+    def __repr__(self) -> str:
+        return f"IpcRuntimeDir(path={self.path!s}, closed={self._closed})"
+
     def close(self) -> None:
         if self._closed:
             return
@@ -57,6 +60,15 @@ class PipelineRuntimePrep:
     endpoints: dict[str, str]
     runtime_dir: IpcRuntimeDir | None
     runtime_dir_created_here: bool
+
+
+@dataclass(frozen=True)
+class CompiledPipeline:
+    """Compiled coordinator, stages, and optional managed IPC runtime dir."""
+
+    coordinator: Coordinator
+    stages: list[Stage]
+    runtime_dir: IpcRuntimeDir | None
 
 
 def create_ipc_runtime_dir(config: PipelineConfig) -> IpcRuntimeDir | None:
@@ -117,7 +129,7 @@ def compile_pipeline_core(
     config: PipelineConfig,
     *,
     ipc_runtime_dir: IpcRuntimeDir | None = None,
-) -> tuple[Coordinator, list[Stage], IpcRuntimeDir | None]:
+) -> CompiledPipeline:
     """Build coordinator and stages, returning any managed runtime dir.
 
     Note (Chenyang, Ratish):
@@ -175,7 +187,11 @@ def compile_pipeline_core(
             prep.runtime_dir.close()
         raise
 
-    return coordinator, stages, prep.runtime_dir
+    return CompiledPipeline(
+        coordinator=coordinator,
+        stages=stages,
+        runtime_dir=prep.runtime_dir,
+    )
 
 
 def compile_pipeline(config: PipelineConfig) -> tuple[Coordinator, list[Stage]]:
@@ -187,11 +203,13 @@ def compile_pipeline(config: PipelineConfig) -> tuple[Coordinator, list[Stage]]:
     if config.endpoints.scheme == "ipc":
         raise ValueError(
             "compile_pipeline() does not manage IPC runtime-dir ownership. "
-            "Use compile_pipeline_core(...) or MultiProcessPipelineRunner."
+            "Use MultiProcessPipelineRunner, or compile_pipeline_core(...) "
+            "directly: either let it self-manage the runtime dir, or pair it "
+            "with create_ipc_runtime_dir(...) for caller-managed ownership."
         )
 
-    coordinator, stages, _ = compile_pipeline_core(config)
-    return coordinator, stages
+    compiled = compile_pipeline_core(config)
+    return compiled.coordinator, compiled.stages
 
 
 def _compile_stage(

--- a/sglang_omni_v1/config/compiler.py
+++ b/sglang_omni_v1/config/compiler.py
@@ -36,7 +36,7 @@ class IpcRuntimeDir:
         self.close()
 
     def __repr__(self) -> str:
-        return f"IpcRuntimeDir(path={self.path!s}, closed={self._closed})"
+        return f"IpcRuntimeDir(path={self.path!r}, closed={self._closed})"
 
     def close(self) -> None:
         if self._closed:

--- a/sglang_omni_v1/pipeline/mp_runner.py
+++ b/sglang_omni_v1/pipeline/mp_runner.py
@@ -34,22 +34,18 @@ def _build_stage_groups(
     config: PipelineConfig,
     ctx: multiprocessing.context.BaseContext | None = None,
     *,
-    stages_cfg: list[StageConfig] | None = None,
-    name_map: dict[str, str] | None = None,
-    endpoints: dict[str, str] | None = None,
+    stages_cfg: list[StageConfig],
+    name_map: dict[str, str],
+    endpoints: dict[str, str],
 ) -> list[StageGroup]:
-    """Compile *config* into one :class:`StageGroup` per logical stage.
+    """Build one :class:`StageGroup` per logical stage from prepared endpoints.
 
-    This runs in the **main process** so that subprocesses never need to
-    re-compile the pipeline configuration.
+    The caller owns endpoint allocation and IPC runtime-dir lifecycle. This
+    helper only converts prepared runtime state into subprocess specs.
     """
     if ctx is None:
         ctx = multiprocessing.get_context("spawn")
 
-    if stages_cfg is None or name_map is None or endpoints is None:
-        if config.endpoints.scheme == "ipc":
-            raise ValueError("_build_stage_groups requires prepared IPC endpoints")
-        stages_cfg, name_map, _, endpoints, _, _ = prepare_pipeline_runtime(config)
     stage_endpoints = {s.name: endpoints[f"stage_{s.name}"] for s in stages_cfg}
     cfg_map = {s.name: s for s in stages_cfg}
 
@@ -289,29 +285,23 @@ class MultiProcessPipelineRunner:
 
         try:
             ctx = multiprocessing.get_context("spawn")
-            (
-                stages_cfg,
-                name_map,
-                entry_stage,
-                endpoints,
-                self._ipc_runtime_dir,
-                _,
-            ) = prepare_pipeline_runtime(
+            prep = prepare_pipeline_runtime(
                 self._config,
                 ipc_runtime_dir=self._ipc_runtime_dir,
             )
+            self._ipc_runtime_dir = prep.runtime_dir
             groups = _build_stage_groups(
                 self._config,
                 ctx,
-                stages_cfg=stages_cfg,
-                name_map=name_map,
-                endpoints=endpoints,
+                stages_cfg=prep.stages_cfg,
+                name_map=prep.name_map,
+                endpoints=prep.endpoints,
             )
 
             self._coordinator = Coordinator(
-                completion_endpoint=endpoints["completion"],
-                abort_endpoint=endpoints["abort"],
-                entry_stage=entry_stage,
+                completion_endpoint=prep.endpoints["completion"],
+                abort_endpoint=prep.endpoints["abort"],
+                entry_stage=prep.entry_stage,
                 terminal_stages=self._config.terminal_stages or None,
             )
             await self._coordinator.start()

--- a/sglang_omni_v1/pipeline/mp_runner.py
+++ b/sglang_omni_v1/pipeline/mp_runner.py
@@ -16,10 +16,11 @@ import socket
 from typing import Any
 
 from sglang_omni_v1.config.compiler import (
-    _allocate_endpoints,
+    IpcRuntimeDir,
     _build_relay_config,
     _detect_same_gpu_targets,
     _resolve_factory_args,
+    prepare_pipeline_runtime,
 )
 from sglang_omni_v1.config.schema import PipelineConfig, StageConfig
 from sglang_omni_v1.pipeline import Coordinator
@@ -32,6 +33,10 @@ logger = logging.getLogger(__name__)
 def _build_stage_groups(
     config: PipelineConfig,
     ctx: multiprocessing.context.BaseContext | None = None,
+    *,
+    stages_cfg: list[StageConfig] | None = None,
+    name_map: dict[str, str] | None = None,
+    endpoints: dict[str, str] | None = None,
 ) -> list[StageGroup]:
     """Compile *config* into one :class:`StageGroup` per logical stage.
 
@@ -41,8 +46,10 @@ def _build_stage_groups(
     if ctx is None:
         ctx = multiprocessing.get_context("spawn")
 
-    stages_cfg, name_map, _ = config.apply_fusion()
-    endpoints = _allocate_endpoints(config, stages=stages_cfg)
+    if stages_cfg is None or name_map is None or endpoints is None:
+        if config.endpoints.scheme == "ipc":
+            raise ValueError("_build_stage_groups requires prepared IPC endpoints")
+        stages_cfg, name_map, _, endpoints, _, _ = prepare_pipeline_runtime(config)
     stage_endpoints = {s.name: endpoints[f"stage_{s.name}"] for s in stages_cfg}
     cfg_map = {s.name: s for s in stages_cfg}
 
@@ -264,6 +271,7 @@ class MultiProcessPipelineRunner:
     def __init__(self, config: PipelineConfig):
         self._config = config
         self._coordinator: Coordinator | None = None
+        self._ipc_runtime_dir: IpcRuntimeDir | None = None
         self._groups: list[StageGroup] = []
         self._completion_task: asyncio.Task | None = None
         self._monitor_task: asyncio.Task | None = None
@@ -281,10 +289,24 @@ class MultiProcessPipelineRunner:
 
         try:
             ctx = multiprocessing.get_context("spawn")
-            groups = _build_stage_groups(self._config, ctx)
-
-            stages_cfg, _, entry_stage = self._config.apply_fusion()
-            endpoints = _allocate_endpoints(self._config, stages=stages_cfg)
+            (
+                stages_cfg,
+                name_map,
+                entry_stage,
+                endpoints,
+                self._ipc_runtime_dir,
+                _,
+            ) = prepare_pipeline_runtime(
+                self._config,
+                ipc_runtime_dir=self._ipc_runtime_dir,
+            )
+            groups = _build_stage_groups(
+                self._config,
+                ctx,
+                stages_cfg=stages_cfg,
+                name_map=name_map,
+                endpoints=endpoints,
+            )
 
             self._coordinator = Coordinator(
                 completion_endpoint=endpoints["completion"],
@@ -373,6 +395,11 @@ class MultiProcessPipelineRunner:
 
         await self._coordinator.stop()
         self._groups.clear()
+        self._coordinator = None
+
+        if self._ipc_runtime_dir is not None:
+            self._ipc_runtime_dir.close()
+            self._ipc_runtime_dir = None
 
     async def _cleanup_on_failure(self) -> None:
         """Best-effort cleanup after a failed start()."""
@@ -401,3 +428,7 @@ class MultiProcessPipelineRunner:
             except Exception:
                 pass
             self._coordinator = None
+
+        if self._ipc_runtime_dir is not None:
+            self._ipc_runtime_dir.close()
+            self._ipc_runtime_dir = None

--- a/sglang_omni_v1/pipeline/mp_runner.py
+++ b/sglang_omni_v1/pipeline/mp_runner.py
@@ -353,6 +353,22 @@ class MultiProcessPipelineRunner:
                     return
             await asyncio.sleep(5.0)
 
+    async def _cancel_completion_task(self) -> None:
+        if self._completion_task is None:
+            return
+        self._completion_task.cancel()
+        try:
+            await self._completion_task
+        except asyncio.CancelledError:
+            pass
+        self._completion_task = None
+
+    def _close_runtime_dir(self) -> None:
+        if self._ipc_runtime_dir is None:
+            return
+        self._ipc_runtime_dir.close()
+        self._ipc_runtime_dir = None
+
     async def stop(self) -> None:
         if not self._started:
             return
@@ -376,20 +392,13 @@ class MultiProcessPipelineRunner:
             return_exceptions=True,
         )
 
-        if self._completion_task is not None:
-            self._completion_task.cancel()
-            try:
-                await self._completion_task
-            except asyncio.CancelledError:
-                pass
+        await self._cancel_completion_task()
 
         await self._coordinator.stop()
         self._groups.clear()
         self._coordinator = None
 
-        if self._ipc_runtime_dir is not None:
-            self._ipc_runtime_dir.close()
-            self._ipc_runtime_dir = None
+        self._close_runtime_dir()
 
     async def _cleanup_on_failure(self) -> None:
         """Best-effort cleanup after a failed start()."""
@@ -404,13 +413,7 @@ class MultiProcessPipelineRunner:
                     p.join(timeout=2)
         self._groups.clear()
 
-        if self._completion_task is not None:
-            self._completion_task.cancel()
-            try:
-                await self._completion_task
-            except asyncio.CancelledError:
-                pass
-            self._completion_task = None
+        await self._cancel_completion_task()
 
         if self._coordinator is not None:
             try:
@@ -419,6 +422,4 @@ class MultiProcessPipelineRunner:
                 pass
             self._coordinator = None
 
-        if self._ipc_runtime_dir is not None:
-            self._ipc_runtime_dir.close()
-            self._ipc_runtime_dir = None
+        self._close_runtime_dir()

--- a/sglang_omni_v1/serve/launcher.py
+++ b/sglang_omni_v1/serve/launcher.py
@@ -191,11 +191,11 @@ async def _run_server(
             logger.info("Pipeline stopped.")
     else:
         coordinator, stages, runtime_dir = compile_pipeline_core(pipeline_config)
-        stage_endpoints = _collect_stage_control_endpoints(stages)
         completion_task = None
         stage_tasks = []
 
         try:
+            stage_endpoints = _collect_stage_control_endpoints(stages)
             await coordinator.start()
             completion_task = asyncio.create_task(coordinator.run_completion_loop())
             stage_tasks = [asyncio.create_task(s.run()) for s in stages]

--- a/sglang_omni_v1/serve/launcher.py
+++ b/sglang_omni_v1/serve/launcher.py
@@ -29,6 +29,7 @@ import logging
 import os
 import socket
 import time
+from contextlib import suppress
 from typing import Any
 
 import uvicorn
@@ -36,7 +37,7 @@ from fastapi import APIRouter
 from pydantic import BaseModel
 
 from sglang_omni_v1.client import Client
-from sglang_omni_v1.config import PipelineConfig, compile_pipeline
+from sglang_omni_v1.config import PipelineConfig, compile_pipeline_core
 from sglang_omni_v1.profiler.profiler_control import ProfilerControlClient
 from sglang_omni_v1.serve.openai_api import create_app
 
@@ -189,20 +190,21 @@ async def _run_server(
             await mp_runner.stop()
             logger.info("Pipeline stopped.")
     else:
-        coordinator, stages = compile_pipeline(pipeline_config)
+        coordinator, stages, runtime_dir = compile_pipeline_core(pipeline_config)
         stage_endpoints = _collect_stage_control_endpoints(stages)
-
-        # Start coordinator + all stages as async tasks
-        await coordinator.start()
-        completion_task = asyncio.create_task(coordinator.run_completion_loop())
-        stage_tasks = [asyncio.create_task(s.run()) for s in stages]
-        logger.info(
-            "Pipeline '%s' started (%d stages)",
-            pipeline_config.name,
-            len(stages),
-        )
+        completion_task = None
+        stage_tasks = []
 
         try:
+            await coordinator.start()
+            completion_task = asyncio.create_task(coordinator.run_completion_loop())
+            stage_tasks = [asyncio.create_task(s.run()) for s in stages]
+            logger.info(
+                "Pipeline '%s' started (%d stages)",
+                pipeline_config.name,
+                len(stages),
+            )
+
             cl_kwargs = client_kwargs or {}
             client = Client(coordinator, **cl_kwargs)
             app = create_app(
@@ -227,8 +229,17 @@ async def _run_server(
             logger.info("Shutting down pipeline …")
             for t in stage_tasks:
                 t.cancel()
-            completion_task.cancel()
-            await coordinator.stop()
+            if completion_task is not None:
+                completion_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await completion_task
+            if stage_tasks:
+                await asyncio.gather(*stage_tasks, return_exceptions=True)
+            try:
+                await coordinator.stop()
+            finally:
+                if runtime_dir is not None:
+                    runtime_dir.close()
             logger.info("Pipeline stopped.")
 
 

--- a/sglang_omni_v1/serve/launcher.py
+++ b/sglang_omni_v1/serve/launcher.py
@@ -190,13 +190,18 @@ async def _run_server(
             await mp_runner.stop()
             logger.info("Pipeline stopped.")
     else:
-        coordinator, stages, runtime_dir = compile_pipeline_core(pipeline_config)
+        compiled = compile_pipeline_core(pipeline_config)
+        coordinator = compiled.coordinator
+        stages = compiled.stages
+        runtime_dir = compiled.runtime_dir
         completion_task = None
         stage_tasks = []
+        coordinator_started = False
 
         try:
             stage_endpoints = _collect_stage_control_endpoints(stages)
             await coordinator.start()
+            coordinator_started = True
             completion_task = asyncio.create_task(coordinator.run_completion_loop())
             stage_tasks = [asyncio.create_task(s.run()) for s in stages]
             logger.info(
@@ -236,7 +241,11 @@ async def _run_server(
             if stage_tasks:
                 await asyncio.gather(*stage_tasks, return_exceptions=True)
             try:
-                await coordinator.stop()
+                if coordinator_started:
+                    await coordinator.stop()
+                else:
+                    with suppress(Exception):
+                        await coordinator.stop()
             finally:
                 if runtime_dir is not None:
                     runtime_dir.close()

--- a/tests/test_v1_ipc_runtime_dir.py
+++ b/tests/test_v1_ipc_runtime_dir.py
@@ -15,6 +15,7 @@ from fastapi import FastAPI
 pytest.importorskip("torch")
 
 from sglang_omni_v1.config.compiler import (
+    IpcRuntimeDir,
     compile_pipeline,
     compile_pipeline_core,
     create_ipc_runtime_dir,
@@ -223,6 +224,44 @@ class TestV1MultiProcessRunnerIpcCleanup(unittest.IsolatedAsyncioTestCase):
 
 
 class TestV1LauncherIpcCleanup(unittest.IsolatedAsyncioTestCase):
+    async def _run_single_process_launcher_with_mocked_server(
+        self,
+        *,
+        config: PipelineConfig,
+        runtime_dir: IpcRuntimeDir,
+        serve_mock: AsyncMock,
+    ) -> tuple[_FakeCoordinator, FastAPI]:
+        stage = _FakeStage(f"ipc://{runtime_dir.path}/stage_preprocessing.sock")
+        coordinator = _FakeCoordinator()
+        app = FastAPI()
+
+        from sglang_omni_v1.serve.launcher import _run_server
+
+        with (
+            patch(
+                "sglang_omni_v1.serve.launcher._find_available_port",
+                return_value=8000,
+            ),
+            patch(
+                "sglang_omni_v1.serve.launcher.compile_pipeline_core",
+                return_value=(coordinator, [stage], runtime_dir),
+            ) as compile_pipeline_core,
+            patch(
+                "sglang_omni_v1.serve.launcher.create_app",
+                return_value=app,
+            ) as create_app,
+            patch(
+                "sglang_omni_v1.serve.launcher.uvicorn.Server.serve",
+                new=serve_mock,
+            ),
+        ):
+            await _run_server(config, port=8000)
+
+        compile_pipeline_core.assert_called_once_with(config)
+        create_app.assert_called_once()
+
+        return coordinator, app
+
     async def test_single_process_launcher_cleans_runtime_dir_on_server_exit(
         self,
     ) -> None:
@@ -231,39 +270,40 @@ class TestV1LauncherIpcCleanup(unittest.IsolatedAsyncioTestCase):
             runtime_dir = create_ipc_runtime_dir(config)
             self.assertIsNotNone(runtime_dir)
             runtime_path = runtime_dir.path
-            stage = _FakeStage(f"ipc://{runtime_path}/stage_preprocessing.sock")
-            coordinator = _FakeCoordinator()
-            app = FastAPI()
             server_serve = AsyncMock(return_value=None)
 
-            from sglang_omni_v1.serve.launcher import _run_server
-
-            with (
-                patch(
-                    "sglang_omni_v1.serve.launcher._find_available_port",
-                    return_value=8000,
-                ),
-                patch(
-                    "sglang_omni_v1.serve.launcher.compile_pipeline_core",
-                    return_value=(coordinator, [stage], runtime_dir),
-                ) as compile_pipeline_core,
-                patch(
-                    "sglang_omni_v1.serve.launcher.create_app",
-                    return_value=app,
-                ) as create_app,
-                patch(
-                    "sglang_omni_v1.serve.launcher.uvicorn.Server.serve",
-                    new=server_serve,
-                ),
-            ):
-                await _run_server(config, port=8000)
+            coordinator, app = (
+                await self._run_single_process_launcher_with_mocked_server(
+                    config=config,
+                    runtime_dir=runtime_dir,
+                    serve_mock=server_serve,
+                )
+            )
 
             self.assertTrue(coordinator.started)
             self.assertTrue(coordinator.stopped)
-            compile_pipeline_core.assert_called_once_with(config)
-            create_app.assert_called_once()
             server_serve.assert_awaited_once()
             mounted_paths = {route.path for route in app.routes}
             self.assertIn("/start_profile", mounted_paths)
             self.assertIn("/stop_profile", mounted_paths)
+            self.assertFalse(runtime_path.exists())
+
+    async def test_single_process_launcher_cleans_runtime_dir_on_server_error(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = _make_config(tmp_dir)
+            runtime_dir = create_ipc_runtime_dir(config)
+            self.assertIsNotNone(runtime_dir)
+            runtime_path = runtime_dir.path
+            server_serve = AsyncMock(side_effect=RuntimeError("server failed"))
+
+            with self.assertRaisesRegex(RuntimeError, "server failed"):
+                await self._run_single_process_launcher_with_mocked_server(
+                    config=config,
+                    runtime_dir=runtime_dir,
+                    serve_mock=server_serve,
+                )
+
+            server_serve.assert_awaited_once()
             self.assertFalse(runtime_path.exists())

--- a/tests/test_v1_ipc_runtime_dir.py
+++ b/tests/test_v1_ipc_runtime_dir.py
@@ -3,12 +3,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from fastapi import FastAPI
 
 pytest.importorskip("torch")
 
@@ -24,7 +26,37 @@ def noop_factory():
     return None
 
 
-def _make_config(base_path: str) -> PipelineConfig:
+class _FakeControlPlane:
+    def __init__(self, recv_endpoint: str):
+        self.recv_endpoint = recv_endpoint
+
+
+class _FakeStage:
+    name = "preprocessing"
+
+    def __init__(self, recv_endpoint: str):
+        self.control_plane = _FakeControlPlane(recv_endpoint)
+
+    async def run(self) -> None:
+        await asyncio.Event().wait()
+
+
+class _FakeCoordinator:
+    def __init__(self):
+        self.started = False
+        self.stopped = False
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def run_completion_loop(self) -> None:
+        await asyncio.Event().wait()
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+def _make_config(base_path: str, *, scheme: str = "ipc") -> PipelineConfig:
     return PipelineConfig(
         model_path="Qwen/Qwen3-Omni-30B-A3B-Instruct",
         entry_stage="preprocessing",
@@ -36,13 +68,31 @@ def _make_config(base_path: str) -> PipelineConfig:
             )
         ],
         endpoints=EndpointsConfig(
-            scheme="ipc",
+            scheme=scheme,
             base_path=base_path,
         ),
     )
 
 
 class TestV1IpcRuntimeDir(unittest.TestCase):
+    def test_ipc_runtime_dir_close_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = _make_config(tmp_dir)
+            runtime_dir = create_ipc_runtime_dir(config)
+            self.assertIsNotNone(runtime_dir)
+            runtime_path = runtime_dir.path
+
+            runtime_dir.close()
+            runtime_dir.close()
+
+            self.assertFalse(runtime_path.exists())
+
+    def test_create_ipc_runtime_dir_returns_none_for_tcp(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = _make_config(tmp_dir, scheme="tcp")
+
+            self.assertIsNone(create_ipc_runtime_dir(config))
+
     def test_ipc_runtime_dirs_are_unique_for_same_model_name(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = _make_config(tmp_dir)
@@ -110,6 +160,27 @@ class TestV1IpcRuntimeDir(unittest.TestCase):
             runtime_dir.close()
             self.assertFalse(runtime_path.exists())
 
+    def test_compile_core_returns_owned_runtime_dir_for_successful_ipc_compile(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = _make_config(tmp_dir)
+
+            _coordinator, stages, runtime_dir = compile_pipeline_core(config)
+            self.assertIsNotNone(runtime_dir)
+            runtime_path = runtime_dir.path
+
+            try:
+                self.assertTrue(runtime_path.exists())
+                self.assertIn(
+                    str(runtime_path),
+                    stages[0].control_plane.recv_endpoint,
+                )
+            finally:
+                runtime_dir.close()
+
+            self.assertFalse(runtime_path.exists())
+
 
 class TestV1MultiProcessRunnerIpcCleanup(unittest.IsolatedAsyncioTestCase):
     async def test_mp_runner_cleans_runtime_dir_on_start_failure(self) -> None:
@@ -127,3 +198,72 @@ class TestV1MultiProcessRunnerIpcCleanup(unittest.IsolatedAsyncioTestCase):
                     await runner.start()
 
             self.assertEqual(list(Path(tmp_dir).iterdir()), [])
+
+    async def test_mp_runner_cleans_runtime_dir_on_stop(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = _make_config(tmp_dir)
+            from sglang_omni_v1.pipeline.mp_runner import MultiProcessPipelineRunner
+
+            runner = MultiProcessPipelineRunner(config)
+            await runner.start(timeout=30.0)
+
+            runtime_path = None
+            try:
+                runtime_dirs = [
+                    path for path in Path(tmp_dir).iterdir() if path.is_dir()
+                ]
+                self.assertEqual(len(runtime_dirs), 1)
+                runtime_path = runtime_dirs[0]
+                self.assertTrue(runtime_path.exists())
+            finally:
+                await runner.stop()
+
+            self.assertIsNotNone(runtime_path)
+            self.assertFalse(runtime_path.exists())
+
+
+class TestV1LauncherIpcCleanup(unittest.IsolatedAsyncioTestCase):
+    async def test_single_process_launcher_cleans_runtime_dir_on_server_exit(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = _make_config(tmp_dir)
+            runtime_dir = create_ipc_runtime_dir(config)
+            self.assertIsNotNone(runtime_dir)
+            runtime_path = runtime_dir.path
+            stage = _FakeStage(f"ipc://{runtime_path}/stage_preprocessing.sock")
+            coordinator = _FakeCoordinator()
+            app = FastAPI()
+            server_serve = AsyncMock(return_value=None)
+
+            from sglang_omni_v1.serve.launcher import _run_server
+
+            with (
+                patch(
+                    "sglang_omni_v1.serve.launcher._find_available_port",
+                    return_value=8000,
+                ),
+                patch(
+                    "sglang_omni_v1.serve.launcher.compile_pipeline_core",
+                    return_value=(coordinator, [stage], runtime_dir),
+                ) as compile_pipeline_core,
+                patch(
+                    "sglang_omni_v1.serve.launcher.create_app",
+                    return_value=app,
+                ) as create_app,
+                patch(
+                    "sglang_omni_v1.serve.launcher.uvicorn.Server.serve",
+                    new=server_serve,
+                ),
+            ):
+                await _run_server(config, port=8000)
+
+            self.assertTrue(coordinator.started)
+            self.assertTrue(coordinator.stopped)
+            compile_pipeline_core.assert_called_once_with(config)
+            create_app.assert_called_once()
+            server_serve.assert_awaited_once()
+            mounted_paths = {route.path for route in app.routes}
+            self.assertIn("/start_profile", mounted_paths)
+            self.assertIn("/stop_profile", mounted_paths)
+            self.assertFalse(runtime_path.exists())

--- a/tests/test_v1_ipc_runtime_dir.py
+++ b/tests/test_v1_ipc_runtime_dir.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Omni V1 IPC runtime directory lifecycle tests."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("torch")
+
+from sglang_omni_v1.config.compiler import (
+    compile_pipeline,
+    compile_pipeline_core,
+    create_ipc_runtime_dir,
+)
+from sglang_omni_v1.config.schema import EndpointsConfig, PipelineConfig, StageConfig
+
+
+def noop_factory():
+    return None
+
+
+def _make_config(base_path: str) -> PipelineConfig:
+    return PipelineConfig(
+        model_path="Qwen/Qwen3-Omni-30B-A3B-Instruct",
+        entry_stage="preprocessing",
+        stages=[
+            StageConfig(
+                name="preprocessing",
+                factory="tests.test_v1_ipc_runtime_dir.noop_factory",
+                terminal=True,
+            )
+        ],
+        endpoints=EndpointsConfig(
+            scheme="ipc",
+            base_path=base_path,
+        ),
+    )
+
+
+class TestV1IpcRuntimeDir(unittest.TestCase):
+    def test_ipc_runtime_dirs_are_unique_for_same_model_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = _make_config(tmp_dir)
+
+            runtime_a = create_ipc_runtime_dir(config)
+            runtime_b = create_ipc_runtime_dir(config)
+            self.assertIsNotNone(runtime_a)
+            self.assertIsNotNone(runtime_b)
+
+            try:
+                self.assertNotEqual(runtime_a.path, runtime_b.path)
+
+                _coordinator_a, stages_a, _ = compile_pipeline_core(
+                    config,
+                    ipc_runtime_dir=runtime_a,
+                )
+                _coordinator_b, stages_b, _ = compile_pipeline_core(
+                    config,
+                    ipc_runtime_dir=runtime_b,
+                )
+
+                self.assertNotEqual(
+                    stages_a[0].control_plane.recv_endpoint,
+                    stages_b[0].control_plane.recv_endpoint,
+                )
+            finally:
+                runtime_a.close()
+                runtime_b.close()
+
+    def test_compile_pipeline_rejects_unmanaged_ipc(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = _make_config(tmp_dir)
+
+            with self.assertRaisesRegex(ValueError, "does not manage IPC"):
+                compile_pipeline(config)
+
+    def test_compile_core_cleans_owned_ipc_dir_on_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = _make_config(tmp_dir)
+
+            with patch(
+                "sglang_omni_v1.config.compiler._compile_stage",
+                side_effect=RuntimeError("boom"),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "boom"):
+                    compile_pipeline_core(config)
+
+            self.assertEqual(list(Path(tmp_dir).iterdir()), [])
+
+    def test_caller_owned_ipc_dir_is_not_removed_on_compile_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = _make_config(tmp_dir)
+            runtime_dir = create_ipc_runtime_dir(config)
+            self.assertIsNotNone(runtime_dir)
+            runtime_path = runtime_dir.path
+
+            with patch(
+                "sglang_omni_v1.config.compiler._compile_stage",
+                side_effect=RuntimeError("boom"),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "boom"):
+                    compile_pipeline_core(config, ipc_runtime_dir=runtime_dir)
+
+            self.assertTrue(runtime_path.exists())
+            runtime_dir.close()
+            self.assertFalse(runtime_path.exists())
+
+
+class TestV1MultiProcessRunnerIpcCleanup(unittest.IsolatedAsyncioTestCase):
+    async def test_mp_runner_cleans_runtime_dir_on_start_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = _make_config(tmp_dir)
+            from sglang_omni_v1.pipeline.mp_runner import MultiProcessPipelineRunner
+
+            runner = MultiProcessPipelineRunner(config)
+
+            with patch(
+                "sglang_omni_v1.pipeline.mp_runner.Coordinator.start",
+                new=AsyncMock(side_effect=RuntimeError("boom")),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "boom"):
+                    await runner.start()
+
+            self.assertEqual(list(Path(tmp_dir).iterdir()), [])

--- a/tests/test_v1_ipc_runtime_dir.py
+++ b/tests/test_v1_ipc_runtime_dir.py
@@ -243,27 +243,37 @@ class TestV1MultiProcessRunnerIpcCleanup(unittest.IsolatedAsyncioTestCase):
 
             self.assertEqual(list(Path(tmp_dir).iterdir()), [])
 
-    async def test_mp_runner_cleans_runtime_dir_on_stop(self) -> None:
+    async def test_mp_runner_starts_two_same_model_instances_and_cleans_on_stop(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = _make_config(tmp_dir)
             from sglang_omni_v1.pipeline.mp_runner import MultiProcessPipelineRunner
 
-            runner = MultiProcessPipelineRunner(config)
-            await runner.start(timeout=30.0)
+            runner_a = MultiProcessPipelineRunner(config)
+            runner_b = MultiProcessPipelineRunner(config)
 
-            runtime_path = None
             try:
+                await runner_a.start(timeout=30.0)
+                await runner_b.start(timeout=30.0)
+
                 runtime_dirs = [
                     path for path in Path(tmp_dir).iterdir() if path.is_dir()
                 ]
-                self.assertEqual(len(runtime_dirs), 1)
-                runtime_path = runtime_dirs[0]
-                self.assertTrue(runtime_path.exists())
+                self.assertEqual(len(runtime_dirs), 2)
+                self.assertNotEqual(
+                    runner_a.coordinator.control_plane.completion_endpoint,
+                    runner_b.coordinator.control_plane.completion_endpoint,
+                )
+                self.assertNotEqual(
+                    runner_a._groups[0].leader_endpoint,
+                    runner_b._groups[0].leader_endpoint,
+                )
             finally:
-                await runner.stop()
+                await runner_b.stop()
+                await runner_a.stop()
 
-            self.assertIsNotNone(runtime_path)
-            self.assertFalse(runtime_path.exists())
+            self.assertEqual(list(Path(tmp_dir).iterdir()), [])
 
 
 class TestV1LauncherIpcCleanup(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_v1_ipc_runtime_dir.py
+++ b/tests/test_v1_ipc_runtime_dir.py
@@ -15,10 +15,12 @@ from fastapi import FastAPI
 pytest.importorskip("torch")
 
 from sglang_omni_v1.config.compiler import (
+    CompiledPipeline,
     IpcRuntimeDir,
     compile_pipeline,
     compile_pipeline_core,
     create_ipc_runtime_dir,
+    prepare_pipeline_runtime,
 )
 from sglang_omni_v1.config.schema import EndpointsConfig, PipelineConfig, StageConfig
 
@@ -106,18 +108,18 @@ class TestV1IpcRuntimeDir(unittest.TestCase):
             try:
                 self.assertNotEqual(runtime_a.path, runtime_b.path)
 
-                _coordinator_a, stages_a, _ = compile_pipeline_core(
+                compiled_a = compile_pipeline_core(
                     config,
                     ipc_runtime_dir=runtime_a,
                 )
-                _coordinator_b, stages_b, _ = compile_pipeline_core(
+                compiled_b = compile_pipeline_core(
                     config,
                     ipc_runtime_dir=runtime_b,
                 )
 
                 self.assertNotEqual(
-                    stages_a[0].control_plane.recv_endpoint,
-                    stages_b[0].control_plane.recv_endpoint,
+                    compiled_a.stages[0].control_plane.recv_endpoint,
+                    compiled_b.stages[0].control_plane.recv_endpoint,
                 )
             finally:
                 runtime_a.close()
@@ -167,7 +169,8 @@ class TestV1IpcRuntimeDir(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = _make_config(tmp_dir)
 
-            _coordinator, stages, runtime_dir = compile_pipeline_core(config)
+            compiled = compile_pipeline_core(config)
+            runtime_dir = compiled.runtime_dir
             self.assertIsNotNone(runtime_dir)
             runtime_path = runtime_dir.path
 
@@ -175,7 +178,7 @@ class TestV1IpcRuntimeDir(unittest.TestCase):
                 self.assertTrue(runtime_path.exists())
                 self.assertIn(
                     str(runtime_path),
-                    stages[0].control_plane.recv_endpoint,
+                    compiled.stages[0].control_plane.recv_endpoint,
                 )
             finally:
                 runtime_dir.close()
@@ -184,6 +187,46 @@ class TestV1IpcRuntimeDir(unittest.TestCase):
 
 
 class TestV1MultiProcessRunnerIpcCleanup(unittest.IsolatedAsyncioTestCase):
+    def test_mp_runner_uses_unique_ipc_endpoints_for_same_model_name(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = _make_config(tmp_dir)
+            from sglang_omni_v1.pipeline.mp_runner import _build_stage_groups
+
+            prep_a = prepare_pipeline_runtime(config)
+            prep_b = prepare_pipeline_runtime(config)
+            self.assertIsNotNone(prep_a.runtime_dir)
+            self.assertIsNotNone(prep_b.runtime_dir)
+
+            try:
+                groups_a = _build_stage_groups(
+                    config,
+                    stages_cfg=prep_a.stages_cfg,
+                    name_map=prep_a.name_map,
+                    endpoints=prep_a.endpoints,
+                )
+                groups_b = _build_stage_groups(
+                    config,
+                    stages_cfg=prep_b.stages_cfg,
+                    name_map=prep_b.name_map,
+                    endpoints=prep_b.endpoints,
+                )
+
+                self.assertNotEqual(
+                    prep_a.endpoints["completion"],
+                    prep_b.endpoints["completion"],
+                )
+                self.assertNotEqual(
+                    groups_a[0].leader_endpoint,
+                    groups_b[0].leader_endpoint,
+                )
+            finally:
+                prep_a.runtime_dir.close()
+                prep_b.runtime_dir.close()
+
+            self.assertEqual(list(Path(tmp_dir).iterdir()), [])
+
     async def test_mp_runner_cleans_runtime_dir_on_start_failure(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             config = _make_config(tmp_dir)
@@ -244,7 +287,11 @@ class TestV1LauncherIpcCleanup(unittest.IsolatedAsyncioTestCase):
             ),
             patch(
                 "sglang_omni_v1.serve.launcher.compile_pipeline_core",
-                return_value=(coordinator, [stage], runtime_dir),
+                return_value=CompiledPipeline(
+                    coordinator=coordinator,
+                    stages=[stage],
+                    runtime_dir=runtime_dir,
+                ),
             ) as compile_pipeline_core,
             patch(
                 "sglang_omni_v1.serve.launcher.create_app",
@@ -257,7 +304,12 @@ class TestV1LauncherIpcCleanup(unittest.IsolatedAsyncioTestCase):
         ):
             await _run_server(config, port=8000)
 
-        compile_pipeline_core.assert_called_once_with(config)
+        compile_pipeline_core.assert_called_once()
+        call_args = compile_pipeline_core.call_args
+        called_config = (
+            call_args.args[0] if call_args.args else call_args.kwargs.get("config")
+        )
+        self.assertIs(called_config, config)
         create_app.assert_called_once()
 
         return coordinator, app
@@ -306,4 +358,43 @@ class TestV1LauncherIpcCleanup(unittest.IsolatedAsyncioTestCase):
                 )
 
             server_serve.assert_awaited_once()
+            self.assertFalse(runtime_path.exists())
+
+    async def test_single_process_launcher_preserves_pre_start_error(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = _make_config(tmp_dir)
+            runtime_dir = create_ipc_runtime_dir(config)
+            self.assertIsNotNone(runtime_dir)
+            runtime_path = runtime_dir.path
+            coordinator = _FakeCoordinator()
+            coordinator.stop = AsyncMock(side_effect=RuntimeError("stop failed"))
+            stage = _FakeStage(f"ipc://{runtime_dir.path}/stage_preprocessing.sock")
+
+            from sglang_omni_v1.serve.launcher import _run_server
+
+            with (
+                patch(
+                    "sglang_omni_v1.serve.launcher._find_available_port",
+                    return_value=8000,
+                ),
+                patch(
+                    "sglang_omni_v1.serve.launcher.compile_pipeline_core",
+                    return_value=CompiledPipeline(
+                        coordinator=coordinator,
+                        stages=[stage],
+                        runtime_dir=runtime_dir,
+                    ),
+                ),
+                patch(
+                    "sglang_omni_v1.serve.launcher._collect_stage_control_endpoints",
+                    side_effect=RuntimeError("bad endpoints"),
+                ),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "bad endpoints"):
+                    await _run_server(config, port=8000)
+
+            self.assertFalse(coordinator.started)
+            coordinator.stop.assert_awaited_once()
             self.assertFalse(runtime_path.exists())


### PR DESCRIPTION
## Motivation

Omni V1 currently derives default IPC endpoints from `endpoints.base_path / config.name`. When two V1 servers are launched with the same model name and default IPC settings, they can bind/connect to the same ZMQ socket paths and leak control-plane messages across server instances.

This applies the same per-server IPC namespace invariant used for the V0 runtime isolation fix in #263, adapted to the V1 compiler and `StageProcessSpec` startup path.

## Root Cause

`PipelineConfig.name` defaults to the model path. Two Qwen3-Omni V1 servers launched with the same model therefore allocate identical stable endpoints under the same model-name directory.

Because V1 uses ZMQ for Coordinator-to-Stage control-plane traffic, sharing these paths can let one server receive another server's stage messages or completions.

## Modifications

- Add a managed `IpcRuntimeDir` lifecycle in `sglang_omni_v1.config.compiler`, matching the V0 per-run IPC directory ownership model from #263.
- Allocate IPC endpoints under a unique runtime directory created with `tempfile.mkdtemp(...)` instead of the stable `base_path / config.name` path.
- Split V1 compilation into `prepare_pipeline_runtime(...)` and `compile_pipeline_core(...)` so callers that own server lifecycle also own IPC cleanup.
- Keep V1 multi-process startup V1-native: `MultiProcessPipelineRunner` prepares one endpoint map in the main process and passes it into `StageProcessSpec` construction, so subprocesses still do not recompile endpoint state.
- Use the managed compile path in the V1 single-process server launcher and close the runtime directory during shutdown/failure cleanup.
- Add V1 IPC regression coverage for same-model namespace uniqueness, non-IPC no-op behavior, unmanaged IPC rejection, compile failure cleanup, caller-owned cleanup, successful compile ownership, multi-process cleanup, and single-process launcher cleanup.

## Accuracy Tests

- Unit tests: PASS
- V1 runtime endpoint preflight: PASS
  - observed `ipc:///tmp/sglang_omni_v1/qwen-qwen3-omni-30b-a3b-instruct-9ta1b5i2/stage_preprocessing.sock`
  - observed `ipc:///tmp/sglang_omni_v1/qwen-qwen3-omni-30b-a3b-instruct-9ta1b5i2/stage_thinker.sock`
  - observed `ipc:///tmp/sglang_omni_v1/qwen-qwen3-omni-30b-a3b-instruct-9ta1b5i2/completion.sock`
- Two Qwen3-Omni V1 text servers launched side by side with default IPC settings: PASS
  - server on port 8101 submitted to `ipc:///tmp/sglang_omni_v1/qwen-qwen3-omni-30b-a3b-instruct-y3dtxwhb/stage_preprocessing.sock`
  - server on port 8102 submitted to `ipc:///tmp/sglang_omni_v1/qwen-qwen3-omni-30b-a3b-instruct-1w6lk5as/stage_preprocessing.sock`
- Sent concurrent simple curl chat-completion requests to both servers and received HTTP 200 responses from both: PASS

## Speed Tests and Profiling

Not run. This changes server startup endpoint allocation and shutdown cleanup only; it does not touch request scheduling, model execution, relay tensor transfer, or decode hot paths.
