### PR TITLE
[Fix] Wire legacy S2-Pro into generic --mem-fraction-static plumbing

### DIFF
--- a/docs/basic_usage/tts_s2pro.md
+++ b/docs/basic_usage/tts_s2pro.md
@@ -26,6 +26,17 @@ sgl-omni serve \
   --port 8000
 ```
 
+If startup OOMs on consumer GPUs, try lowering SGLang's KV-cache reservation.
+For example, start around `0.70` and tune from there:
+
+```bash
+sgl-omni serve \
+  --model-path fishaudio/s2-pro \
+  --config examples/configs/s2pro_tts.yaml \
+  --mem-fraction-static 0.70 \
+  --port 8000
+```
+
 ## Use Curl
 
 Generate speech from text without any reference audio:

--- a/sglang_omni/models/fishaudio_s2_pro/config.py
+++ b/sglang_omni/models/fishaudio_s2_pro/config.py
@@ -38,6 +38,7 @@ class S2ProPipelineConfig(PipelineConfig):
             executor=ExecutorConfig(
                 factory=f"{_S2_PKG}.stages.create_sglang_tts_engine_executor",
                 args={
+                    "server_args_overrides": {},
                     "device": "cuda:0",
                     "max_new_tokens": 2048,
                     "stream_stride": 10,
@@ -60,6 +61,13 @@ class S2ProPipelineConfig(PipelineConfig):
             relay=RelayConfig(device="cpu"),
         ),
     ]
+
+    @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        # Legacy S2-Pro has a single GPU-heavy SGLang stage. Reuse the generic
+        # thinker/global mem_fraction_static CLI plumbing so consumer GPUs can
+        # lower KV-cache preallocation without introducing S2-Pro-only flags.
+        return {"thinker": TTS_ENGINE_STAGE}
 
 
 EntryClass = S2ProPipelineConfig

--- a/sglang_omni/models/fishaudio_s2_pro/pipeline/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/pipeline/stages.py
@@ -209,6 +209,7 @@ def create_preprocessing_executor(model_path: str) -> PreprocessingExecutor:
 def create_sglang_tts_engine_executor(
     model_path: str,
     *,
+    server_args_overrides: dict[str, Any] | None = None,
     device: str = "cuda",
     max_new_tokens: int = 2048,
     top_k: int = 30,
@@ -265,14 +266,26 @@ def create_sglang_tts_engine_executor(
         _get_stream_codec_bundle()
 
     _patch_fish_config_for_sglang(checkpoint_dir)
+    overrides = dict(server_args_overrides or {})
+    server_args_kwargs = {
+        "model_path": checkpoint_dir,
+        "tp_size": 1,
+        "dtype": "bfloat16",
+        "mem_fraction_static": 0.85,
+        "chunked_prefill_size": 8192,
+        "max_running_requests": 64,
+        "disable_cuda_graph": False,
+    }
+    server_args_kwargs.update(overrides)
     server_args = ServerArgs(
-        model_path=checkpoint_dir,
-        tp_size=1,
-        dtype="bfloat16",
-        mem_fraction_static=0.85,
-        chunked_prefill_size=8192,
-        max_running_requests=64,
-        disable_cuda_graph=False,
+        **server_args_kwargs,
+    )
+    logger.info(
+        "Creating S2-Pro TTS executor: gpu=%s mem_fraction_static=%s "
+        "stream_vocoder_device=%s",
+        device,
+        getattr(server_args, "mem_fraction_static", None),
+        stream_vocoder_device,
     )
 
     engine = create_s2pro_sglang_engine(

--- a/tests/test_mem_fraction_static.py
+++ b/tests/test_mem_fraction_static.py
@@ -20,6 +20,7 @@ from sglang_omni.engines.ar.sglang_backend.server_args_builder import (
     apply_encoder_mem_reserve,
     build_sglang_server_args,
 )
+from sglang_omni.models.fishaudio_s2_pro.config import S2ProPipelineConfig
 from sglang_omni.models.ming_omni.config import MingOmniPipelineConfig
 
 try:
@@ -329,6 +330,41 @@ class _FakeConfigManager:
 class TestServeMemFractionStatic(unittest.TestCase):
     @patch("sglang_omni.cli.serve.launch_server")
     @patch("sglang_omni.cli.serve.ConfigManager.from_model_path")
+    def test_serve_routes_global_mem_fraction_to_s2pro_tts_engine(
+        self,
+        from_model_path,
+        launch_server_mock,
+    ) -> None:
+        """Legacy S2-Pro accepts the global mem_fraction flag on its only AR stage."""
+        from_model_path.return_value = _FakeConfigManager(
+            S2ProPipelineConfig(model_path="dummy")
+        )
+
+        serve(
+            ctx=SimpleNamespace(args=[]),
+            model_path="dummy",
+            config=None,
+            text_only=False,
+            host="0.0.0.0",
+            port=8000,
+            model_name=None,
+            mem_fraction_static=0.70,
+            thinker_mem_fraction_static=None,
+            talker_mem_fraction_static=None,
+            log_level="info",
+        )
+
+        passed_config = launch_server_mock.call_args.args[0]
+        tts_stage = next(
+            stage for stage in passed_config.stages if stage.name == "tts_engine"
+        )
+        self.assertEqual(
+            tts_stage.executor.args["server_args_overrides"]["mem_fraction_static"],
+            0.70,
+        )
+
+    @patch("sglang_omni.cli.serve.launch_server")
+    @patch("sglang_omni.cli.serve.ConfigManager.from_model_path")
     def test_serve_rejects_unsupported_talker_flag_before_launch(
         self,
         from_model_path,
@@ -607,3 +643,64 @@ class TestSpeechMemFractionFactoryWiring(unittest.TestCase):
         talker_server_args = create_talker_executor_mock.call_args.kwargs["server_args"]
         self.assertEqual(thinker_server_args.mem_fraction_static, 0.70)
         self.assertEqual(talker_server_args.mem_fraction_static, 0.65)
+
+
+class TestS2ProMemFractionFactoryWiring(unittest.TestCase):
+    @patch(
+        "sglang_omni.models.fishaudio_s2_pro.factory.create_s2pro_sglang_engine"
+    )
+    def test_s2pro_executor_applies_server_args_overrides(
+        self,
+        create_engine_mock,
+    ) -> None:
+        """Legacy S2-Pro executor honors config/CLI server_args overrides."""
+        from sglang_omni.models.fishaudio_s2_pro import factory as factory_module
+        from sglang_omni.models.fishaudio_s2_pro.pipeline import stages as stage_module
+        import sglang.srt.server_args as server_args_module
+
+        class _FakeServerArgs:
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+
+        class _FakeAudioDecoder:
+            pass
+
+        def _fake_load_audio_decoder(model_path: str, device: str):
+            del model_path, device
+            return _FakeAudioDecoder(), 10, 4096, object(), "/tmp/fake-model"
+
+        def _fake_patch_config(model_path: str) -> None:
+            del model_path
+
+        with (
+            patch.object(
+                stage_module,
+                "_load_audio_decoder",
+                _fake_load_audio_decoder,
+            ),
+            patch.object(
+                stage_module.torch.cuda,
+                "mem_get_info",
+                lambda gpu_id: (8 * 1024**3, 0),
+            ),
+            patch.object(server_args_module, "ServerArgs", _FakeServerArgs),
+            patch.object(
+                factory_module,
+                "_patch_fish_config_for_sglang",
+                _fake_patch_config,
+            ),
+        ):
+            create_engine_mock.return_value = object()
+            stage_module.create_sglang_tts_engine_executor(
+                model_path="unused",
+                device="cuda:0",
+                server_args_overrides={
+                    "mem_fraction_static": 0.70,
+                    "max_running_requests": 8,
+                },
+                warmup_stream_codec_on_startup=False,
+            )
+
+        server_args = create_engine_mock.call_args.kwargs["server_args"]
+        self.assertEqual(server_args.mem_fraction_static, 0.70)
+        self.assertEqual(server_args.max_running_requests, 8)


### PR DESCRIPTION
### Motivation

Fixes #359.

Legacy S2-Pro hardcodes `mem_fraction_static=0.85` inside
`create_sglang_tts_engine_executor()`. This is fine on larger GPUs, but on
consumer-GPU boxes it leaves users with no supported way to lower SGLang's
static KV reservation when startup OOMs.

Other pipelines already expose this through the generic
`sglang_omni.cli.serve` override path. Legacy S2-Pro simply was not wired into
that path. This PR fixes that without introducing an S2-Pro-specific CLI flag.

### Modifications

- Add `server_args_overrides: {}` to the legacy `S2ProPipelineConfig`
  `tts_engine` stage so the stage can receive generic SGLang server-arg
  overrides.
- Route legacy S2-Pro's only GPU-heavy SGLang stage through
  `mem_fraction_role_to_stage() -> {"thinker": "tts_engine"}` so the existing
  generic `--mem-fraction-static` plumbing reaches it.
- Extend `create_sglang_tts_engine_executor()` to accept
  `server_args_overrides` and merge them into the final `ServerArgs`
  construction.
- Update `docs/basic_usage/tts_s2pro.md` to document the supported
  consumer-GPU mitigation path.

Defaults NOT changed:
- no new S2-Pro-specific CLI surface
- `mem_fraction_static` stays `0.85` when no override is passed
- `max_running_requests` stays `64`
- CUDA graph behavior stays unchanged

### Accuracy Test

N/A. This PR only changes startup-time `ServerArgs` wiring for legacy S2-Pro.

### Benchmark & Profiling

N/A.

Validated on a 4090 environment:

- `tests/test_mem_fraction_static.py::TestServeMemFractionStatic::test_serve_routes_global_mem_fraction_to_s2pro_tts_engine`
- `tests/test_mem_fraction_static.py::TestS2ProMemFractionFactoryWiring::test_s2pro_executor_applies_server_args_overrides`

Also validated that the real legacy launch path accepts both:
- default launch
- `--mem-fraction-static 0.70`

I did not include throughput / latency numbers because this PR does not change  model-side execution, only config routing.