### PR TITLE
[Benchmark] Add colocated SeedTTS benchmark path

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -91,6 +91,14 @@ python -m benchmarks.eval.benchmark_omni_seedtts \
     --output-dir results/qwen3_omni_en \
     --model qwen3-omni --lang en --device cuda:0
 
+# 3d. Qwen3-Omni — colocated multi-server latency benchmark
+python -m benchmarks.eval.benchmark_omni_seedtts_colocated \
+    --base-url http://localhost:8000 \
+    --base-url http://localhost:8001 \
+    --meta seedtts_testset/en/meta.lst \
+    --output-dir results/qwen3_omni_colocated \
+    --model qwen3-omni --max-samples 50 --max-concurrency 16 --rounds 2
+
 # 4. Qwen3-Omni — MMSU (audio comprehension)
 python -m benchmarks.eval.benchmark_omni_mmsu \
     --model qwen3-omni --port 8000 \
@@ -126,6 +134,7 @@ python -m benchmarks.eval.benchmark_omni_videoamme \
 |--------|------|-------|-----|
 | `eval/benchmark_tts_seedtts.py` | TTS speed + WER (unified) | e.g. S2-Pro, Voxtral | `/v1/audio/speech` |
 | `eval/benchmark_omni_seedtts.py` | TTS speed + WER (unified) | Qwen3-Omni | `/v1/chat/completions` |
+| `eval/benchmark_omni_seedtts_colocated.py` | Colocated per-server latency benchmark | Qwen3-Omni | `/v1/chat/completions` |
 | `eval/benchmark_omni_mmsu.py` | MMSU (audio comprehension) | Qwen3-Omni | `/v1/chat/completions` |
 | `eval/benchmark_omni_mmmu.py` | MMMU (VLM accuracy + speed) | Qwen3-Omni | `/v1/chat/completions` |
 | `eval/benchmark_omni_videomme.py` | Video-MME (video understanding) | Qwen3-Omni | `/v1/chat/completions` |

--- a/benchmarks/eval/benchmark_omni_seedtts_colocated.py
+++ b/benchmarks/eval/benchmark_omni_seedtts_colocated.py
@@ -1,0 +1,364 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Colocated SeedTTS benchmark for per-server latency under shared-pod runs.
+
+Usage:
+
+    # Start multiple Qwen3-Omni servers on the same host first, each on its
+    # own port / GPU placement. Then point this harness at all of them:
+    python -m benchmarks.eval.benchmark_omni_seedtts_colocated \
+        --base-url http://localhost:8000 \
+        --base-url http://localhost:8001 \
+        --meta seedtts_testset/en/meta.lst \
+        --model qwen3-omni \
+        --max-samples 50 \
+        --max-concurrency 16 \
+        --rounds 2
+
+The harness runs one SeedTTS generation-speed benchmark against each server in
+parallel and reports both per-run and aggregate per-server metrics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+from dataclasses import asdict, dataclass
+from statistics import mean
+from typing import Any
+
+from benchmarks.benchmarker.utils import save_json_results, wait_for_service
+from benchmarks.eval.benchmark_omni_seedtts import (
+    OmniSeedttsBenchmarkConfig,
+    run_omni_seedtts_benchmark,
+)
+
+
+@dataclass
+class ColocatedSeedttsConfig:
+    base_urls: list[str]
+    model: str
+    meta: str
+    output_dir: str
+    lang: str = "en"
+    speaker: str = "Ethan"
+    voice_clone: bool = False
+    max_samples: int | None = None
+    max_new_tokens: int = 256
+    temperature: float = 0.7
+    warmup: int = 1
+    max_concurrency: int = 1
+    request_rate: float = float("inf")
+    disable_tqdm: bool = False
+    rounds: int = 1
+    server_timeout: int = 1200
+
+
+def _validate_config(config: ColocatedSeedttsConfig) -> None:
+    if not os.path.isfile(config.meta):
+        raise FileNotFoundError(f"Meta file not found: {config.meta}")
+    if not config.base_urls:
+        raise ValueError("At least one --base-url is required")
+    if len(set(config.base_urls)) != len(config.base_urls):
+        raise ValueError("Duplicate --base-url values are not allowed")
+    if config.rounds < 1:
+        raise ValueError("--rounds must be >= 1")
+
+
+def _make_server_config(
+    config: ColocatedSeedttsConfig,
+    *,
+    base_url: str,
+    server_index: int,
+    round_index: int,
+) -> OmniSeedttsBenchmarkConfig:
+    output_dir = os.path.join(
+        config.output_dir,
+        f"n{len(config.base_urls)}",
+        f"round_{round_index + 1}",
+        f"server_{server_index + 1}",
+    )
+    return OmniSeedttsBenchmarkConfig(
+        model=config.model,
+        meta=config.meta,
+        base_url=base_url,
+        lang=config.lang,
+        speaker=config.speaker,
+        voice_clone=config.voice_clone,
+        output_dir=output_dir,
+        max_samples=config.max_samples,
+        max_new_tokens=config.max_new_tokens,
+        temperature=config.temperature,
+        warmup=config.warmup,
+        max_concurrency=config.max_concurrency,
+        request_rate=config.request_rate,
+        disable_tqdm=config.disable_tqdm,
+    )
+
+
+def _mean_metric(summaries: list[dict[str, Any]], key: str) -> float | None:
+    values = [summary.get(key) for summary in summaries if summary.get(key) is not None]
+    if not values:
+        return None
+    return round(float(mean(values)), 4)
+
+
+def _summarize_runs(
+    summaries: list[dict[str, Any]],
+    *,
+    extra_fields: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        **extra_fields,
+        "completed_requests_total": sum(
+            int(summary.get("completed_requests", 0)) for summary in summaries
+        ),
+        "failed_requests_total": sum(
+            int(summary.get("failed_requests", 0)) for summary in summaries
+        ),
+        "throughput_qps_mean": _mean_metric(summaries, "throughput_qps"),
+        "latency_mean_s_mean": _mean_metric(summaries, "latency_mean_s"),
+        "latency_p95_s_mean": _mean_metric(summaries, "latency_p95_s"),
+        "tok_per_s_agg_mean": _mean_metric(summaries, "tok_per_s_agg"),
+        "rtf_mean_mean": _mean_metric(summaries, "rtf_mean"),
+    }
+
+
+def _build_per_server_summaries(runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[tuple[int, str], list[dict[str, Any]]] = {}
+    for run in runs:
+        key = (int(run["server_index"]), str(run["base_url"]))
+        grouped.setdefault(key, []).append(run["summary"])
+
+    per_server: list[dict[str, Any]] = []
+    for (server_index, base_url), summaries in sorted(grouped.items()):
+        per_server.append(
+            _summarize_runs(
+                summaries,
+                extra_fields={
+                    "server_index": server_index,
+                    "base_url": base_url,
+                    "rounds": len(summaries),
+                },
+            )
+        )
+    return per_server
+
+
+def _build_aggregate_summary(
+    runs: list[dict[str, Any]],
+    *,
+    per_server: list[dict[str, Any]],
+) -> dict[str, Any]:
+    summaries = [run["summary"] for run in runs]
+    return _summarize_runs(
+        summaries,
+        extra_fields={
+            "num_servers": len(per_server),
+            "total_runs": len(runs),
+        },
+    )
+
+
+def _print_per_server_summaries(per_server: list[dict[str, Any]]) -> None:
+    for server in per_server:
+        print(
+            "  "
+            f"server_{server['server_index']} "
+            f"lat_mean={server.get('latency_mean_s_mean', 'N/A')}s "
+            f"p95={server.get('latency_p95_s_mean', 'N/A')}s "
+            f"qps={server.get('throughput_qps_mean', 'N/A')}"
+        )
+
+
+def _print_group_summary(
+    aggregate: dict[str, Any],
+    *,
+    per_server: list[dict[str, Any]],
+) -> None:
+    print("\n============================================================")
+    print("              Colocated SeedTTS Benchmark Result            ")
+    print("============================================================")
+    print(f"  Servers:                      {aggregate['num_servers']}")
+    print(f"  Runs:                         {aggregate['total_runs']}")
+    print(
+        f"  Completed requests (total):   {aggregate['completed_requests_total']}"
+    )
+    print(f"  Failed requests (total):      {aggregate['failed_requests_total']}")
+    print("------------------------------------------------------------")
+    print(
+        f"  Throughput qps (mean):        {aggregate.get('throughput_qps_mean', 'N/A')}"
+    )
+    print(
+        f"  Latency mean (s, mean):       {aggregate.get('latency_mean_s_mean', 'N/A')}"
+    )
+    print(
+        f"  Latency p95 (s, mean):        {aggregate.get('latency_p95_s_mean', 'N/A')}"
+    )
+    print(
+        f"  Tok/s agg (mean):             {aggregate.get('tok_per_s_agg_mean', 'N/A')}"
+    )
+    print(
+        f"  RTF mean (mean):              {aggregate.get('rtf_mean_mean', 'N/A')}"
+    )
+    print("------------------------------------------------------------")
+    _print_per_server_summaries(per_server)
+    print("============================================================")
+
+
+async def run_colocated_seedtts_benchmark(
+    config: ColocatedSeedttsConfig,
+) -> dict[str, Any]:
+    _validate_config(config)
+
+    for base_url in config.base_urls:
+        wait_for_service(base_url, timeout=config.server_timeout)
+
+    runs: list[dict[str, Any]] = []
+
+    for round_index in range(config.rounds):
+        tasks = []
+        for server_index, base_url in enumerate(config.base_urls, start=1):
+            server_config = _make_server_config(
+                config,
+                base_url=base_url,
+                server_index=server_index,
+                round_index=round_index,
+            )
+            tasks.append(run_omni_seedtts_benchmark(server_config))
+
+        round_results = await asyncio.gather(*tasks)
+        for server_index, (base_url, result) in enumerate(
+            zip(config.base_urls, round_results, strict=True),
+            start=1,
+        ):
+            runs.append(
+                {
+                    "round": round_index + 1,
+                    "server_index": server_index,
+                    "base_url": base_url,
+                    "summary": result["summary"],
+                    "config": result["config"],
+                }
+            )
+
+    per_server = _build_per_server_summaries(runs)
+    aggregate = _build_aggregate_summary(runs, per_server=per_server)
+    _print_group_summary(aggregate, per_server=per_server)
+
+    return {
+        "config": asdict(config),
+        "aggregate": aggregate,
+        "per_server": per_server,
+        "runs": runs,
+    }
+
+
+def _config_from_args(args: argparse.Namespace) -> ColocatedSeedttsConfig:
+    voice_clone = args.voice_clone and not args.no_ref_audio
+    return ColocatedSeedttsConfig(
+        base_urls=args.base_url,
+        model=args.model,
+        meta=args.meta,
+        output_dir=args.output_dir,
+        lang=args.lang,
+        speaker=args.speaker,
+        voice_clone=voice_clone,
+        max_samples=args.max_samples,
+        max_new_tokens=args.max_new_tokens,
+        temperature=args.temperature,
+        warmup=args.warmup,
+        max_concurrency=args.max_concurrency,
+        request_rate=args.request_rate,
+        disable_tqdm=args.disable_tqdm,
+        rounds=args.rounds,
+        server_timeout=args.server_timeout,
+    )
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run SeedTTS generation-speed benchmarks against multiple colocated "
+            "Qwen3-Omni servers in parallel and report per-server latency drift."
+        )
+    )
+    parser.add_argument(
+        "--base-url",
+        action="append",
+        required=True,
+        help=(
+            "Server base URL. Repeat once per colocated server, e.g. "
+            "--base-url http://localhost:8000 "
+            "--base-url http://localhost:8001."
+        ),
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="qwen3-omni",
+        help="Model name for the API request.",
+    )
+    parser.add_argument(
+        "--meta",
+        "--testset",
+        dest="meta",
+        type=str,
+        default="seedtts_testset/en/meta.lst",
+        help="Path to a meta.lst file (seed-tts-eval format).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="results/omni_seedtts_colocated",
+    )
+    parser.add_argument(
+        "--lang",
+        type=str,
+        choices=["en", "zh"],
+        default="en",
+        help="Language for prompt construction.",
+    )
+    parser.add_argument(
+        "--speaker",
+        type=str,
+        default="Ethan",
+        choices=["Ethan", "Chelsie", "Aiden"],
+        help="Speaker voice for TTS.",
+    )
+    voice_clone_group = parser.add_mutually_exclusive_group()
+    voice_clone_group.add_argument(
+        "--voice-clone",
+        dest="voice_clone",
+        action="store_true",
+        help="Pass ref_audio via 'audios' field for voice cloning.",
+    )
+    voice_clone_group.add_argument(
+        "--no-ref-audio",
+        dest="no_ref_audio",
+        action="store_true",
+        help="Disable voice cloning.",
+    )
+    parser.set_defaults(voice_clone=False, no_ref_audio=False)
+    parser.add_argument("--max-samples", type=int, default=None)
+    parser.add_argument("--max-new-tokens", type=int, default=256)
+    parser.add_argument("--temperature", type=float, default=0.7)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--max-concurrency", type=int, default=16)
+    parser.add_argument("--request-rate", type=float, default=float("inf"))
+    parser.add_argument("--disable-tqdm", action="store_true")
+    parser.add_argument("--rounds", type=int, default=1)
+    parser.add_argument("--server-timeout", type=int, default=1200)
+    return parser
+
+
+def main() -> None:
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+    config = _config_from_args(args)
+    results = asyncio.run(run_colocated_seedtts_benchmark(config))
+    save_json_results(results, config.output_dir, "colocated_eval_results.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_colocated_seedtts_benchmark.py
+++ b/tests/test_colocated_seedtts_benchmark.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for colocated SeedTTS benchmark harness."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from benchmarks.eval.benchmark_omni_seedtts_colocated import (
+    ColocatedSeedttsConfig,
+    _build_aggregate_summary,
+    _build_per_server_summaries,
+    _config_from_args,
+    _make_server_config,
+    _validate_config,
+    run_colocated_seedtts_benchmark,
+)
+
+
+def test_make_server_config_sets_unique_output_dir() -> None:
+    config = ColocatedSeedttsConfig(
+        base_urls=["http://localhost:8000", "http://localhost:8001"],
+        model="qwen3-omni",
+        meta="seedtts_testset/en/meta.lst",
+        output_dir="results/out",
+    )
+
+    server_config = _make_server_config(
+        config,
+        base_url="http://localhost:8001",
+        server_index=1,
+        round_index=2,
+    )
+
+    assert server_config.base_url == "http://localhost:8001"
+    assert server_config.output_dir.endswith("n2/round_3/server_2")
+
+
+def test_build_per_server_summaries_groups_by_server() -> None:
+    runs = [
+        {
+            "server_index": 1,
+            "base_url": "http://localhost:8000",
+            "summary": {
+                "completed_requests": 10,
+                "failed_requests": 0,
+                "throughput_qps": 2.0,
+                "latency_mean_s": 5.0,
+                "latency_p95_s": 8.0,
+                "tok_per_s_agg": 1.5,
+                "rtf_mean": 1.2,
+            },
+        },
+        {
+            "server_index": 1,
+            "base_url": "http://localhost:8000",
+            "summary": {
+                "completed_requests": 8,
+                "failed_requests": 1,
+                "throughput_qps": 4.0,
+                "latency_mean_s": 7.0,
+                "latency_p95_s": 10.0,
+                "tok_per_s_agg": 2.5,
+                "rtf_mean": 1.4,
+            },
+        },
+    ]
+
+    per_server = _build_per_server_summaries(runs)
+
+    assert len(per_server) == 1
+    assert per_server[0]["server_index"] == 1
+    assert per_server[0]["rounds"] == 2
+    assert per_server[0]["completed_requests_total"] == 18
+    assert per_server[0]["failed_requests_total"] == 1
+    assert per_server[0]["throughput_qps_mean"] == 3.0
+    assert per_server[0]["latency_mean_s_mean"] == 6.0
+
+
+def test_build_aggregate_summary_averages_metrics() -> None:
+    runs = [
+        {
+            "server_index": 1,
+            "base_url": "http://localhost:8000",
+            "summary": {
+                "completed_requests": 10,
+                "failed_requests": 0,
+                "throughput_qps": 2.0,
+                "latency_mean_s": 5.0,
+                "latency_p95_s": 8.0,
+                "tok_per_s_agg": 1.5,
+                "rtf_mean": 1.2,
+            },
+        },
+        {
+            "server_index": 2,
+            "base_url": "http://localhost:8001",
+            "summary": {
+                "completed_requests": 10,
+                "failed_requests": 1,
+                "throughput_qps": 4.0,
+                "latency_mean_s": 7.0,
+                "latency_p95_s": 10.0,
+                "tok_per_s_agg": 2.5,
+                "rtf_mean": 1.4,
+            },
+        },
+    ]
+    per_server = _build_per_server_summaries(runs)
+    aggregate = _build_aggregate_summary(runs, per_server=per_server)
+
+    assert aggregate["num_servers"] == 2
+    assert aggregate["total_runs"] == 2
+    assert aggregate["completed_requests_total"] == 20
+    assert aggregate["failed_requests_total"] == 1
+    assert aggregate["throughput_qps_mean"] == 3.0
+    assert aggregate["latency_mean_s_mean"] == 6.0
+    assert aggregate["latency_p95_s_mean"] == 9.0
+    assert aggregate["tok_per_s_agg_mean"] == 2.0
+    assert aggregate["rtf_mean_mean"] == 1.3
+
+
+def test_config_from_args_parses_repeated_base_urls() -> None:
+    args = argparse.Namespace(
+        base_url=["http://localhost:8000", "http://localhost:8001"],
+        model="qwen3-omni",
+        meta="seedtts_testset/en/meta.lst",
+        output_dir="results/out",
+        lang="en",
+        speaker="Ethan",
+        voice_clone=True,
+        no_ref_audio=False,
+        max_samples=50,
+        max_new_tokens=256,
+        temperature=0.7,
+        warmup=1,
+        max_concurrency=16,
+        request_rate=float("inf"),
+        disable_tqdm=False,
+        rounds=2,
+        server_timeout=1200,
+    )
+
+    config = _config_from_args(args)
+
+    assert config.base_urls == ["http://localhost:8000", "http://localhost:8001"]
+    assert config.voice_clone is True
+    assert config.rounds == 2
+
+
+def test_validate_config_rejects_duplicate_base_urls(tmp_path: Path) -> None:
+    meta = tmp_path / "meta.lst"
+    meta.write_text("sample|ref text|ref.wav|target text\n")
+
+    config = ColocatedSeedttsConfig(
+        base_urls=["http://localhost:8000", "http://localhost:8000"],
+        model="qwen3-omni",
+        meta=str(meta),
+        output_dir=str(tmp_path / "results"),
+    )
+
+    with pytest.raises(ValueError, match="Duplicate --base-url"):
+        _validate_config(config)
+
+
+def test_validate_config_rejects_rounds_below_one(tmp_path: Path) -> None:
+    meta = tmp_path / "meta.lst"
+    meta.write_text("sample|ref text|ref.wav|target text\n")
+
+    config = ColocatedSeedttsConfig(
+        base_urls=["http://localhost:8000"],
+        model="qwen3-omni",
+        meta=str(meta),
+        output_dir=str(tmp_path / "results"),
+        rounds=0,
+    )
+
+    with pytest.raises(ValueError, match="--rounds must be >= 1"):
+        _validate_config(config)
+
+
+def test_run_colocated_seedtts_benchmark_runs_all_servers_and_rounds(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    meta = tmp_path / "meta.lst"
+    meta.write_text("sample|ref text|ref.wav|target text\n")
+
+    waited = []
+    invoked = []
+
+    def _fake_wait_for_service(base_url: str, timeout: int = 1200, **kwargs) -> None:
+        del kwargs
+        waited.append((base_url, timeout))
+
+    async def _fake_run_omni_seedtts_benchmark(config):
+        invoked.append((config.base_url, config.output_dir))
+        return {
+            "summary": {
+                "completed_requests": 1,
+                "failed_requests": 0,
+                "throughput_qps": 2.0,
+                "latency_mean_s": 5.0,
+                "latency_p95_s": 8.0,
+                "tok_per_s_agg": 1.5,
+                "rtf_mean": 1.2,
+            },
+            "config": {"base_url": config.base_url},
+        }
+
+    monkeypatch.setattr(
+        "benchmarks.eval.benchmark_omni_seedtts_colocated.wait_for_service",
+        _fake_wait_for_service,
+    )
+    monkeypatch.setattr(
+        "benchmarks.eval.benchmark_omni_seedtts_colocated.run_omni_seedtts_benchmark",
+        _fake_run_omni_seedtts_benchmark,
+    )
+
+    config = ColocatedSeedttsConfig(
+        base_urls=["http://localhost:8000", "http://localhost:8001"],
+        model="qwen3-omni",
+        meta=str(meta),
+        output_dir=str(tmp_path / "results"),
+        rounds=2,
+    )
+
+    results = asyncio.run(run_colocated_seedtts_benchmark(config))
+
+    assert waited == [
+        ("http://localhost:8000", 1200),
+        ("http://localhost:8001", 1200),
+    ]
+    assert len(invoked) == 4
+    assert results["aggregate"]["num_servers"] == 2
+    assert results["aggregate"]["total_runs"] == 4
+    assert len(results["per_server"]) == 2
+    assert len(results["runs"]) == 4


### PR DESCRIPTION
### Motivation

Related to #372.

We do not currently have a dedicated harness for measuring per-server latency
under colocated Qwen3-Omni SeedTTS runs on a shared host. That makes shared-host
behavior harder to reproduce and compare consistently.

This PR adds the benchmark path first.

### Modifications

- Add `benchmarks/eval/benchmark_omni_seedtts_colocated.py`.
- Reuse the existing SeedTTS generation-speed benchmark path instead of adding
  a separate request/task stack.
- Support repeated `--base-url` inputs so multiple colocated servers can be
  benchmarked through one entrypoint.
- Report:
  - aggregate summary
  - per-server summary
  - per-run records
- Add basic config validation for:
  - missing `--base-url`
  - duplicate `--base-url`
  - invalid `--rounds`
- Add unit tests in `tests/test_colocated_seedtts_benchmark.py`.
- Update `benchmarks/README.md`.

### Accuracy Test

N/A.

### Benchmark & Profiling

Validated on a 48 GB RTX 4090 environment.

Unit tests:
- `tests/test_colocated_seedtts_benchmark.py`: `7 passed`

Real smoke runs used 10 SeedTTS samples with `max_concurrency=4`.

N=1:
- `throughput_qps = 0.293`
- `latency_mean_s = 12.311`
- `latency_p95_s = 20.475`
- `tok_per_s_agg = 1.3`
- `rtf_mean = 3.3575`

N=2:
- aggregate:
  - `throughput_qps = 0.386`
  - `latency_mean_s = 9.815`
  - `latency_p95_s = 16.149`
  - `tok_per_s_agg = 1.7`
  - `rtf_mean = 2.8034`
- per-server:
  - `server_1: latency_mean_s = 9.052, latency_p95_s = 13.744, throughput_qps = 0.411`
  - `server_2: latency_mean_s = 10.578, latency_p95_s = 18.554, throughput_qps = 0.361`

These are smoke numbers on a 48 GB RTX 4090 host, not H200 shared-pod reference
numbers. The purpose here is to land the colocated measurement plumbing and a
first reproducible shared-host benchmark path.
