### PR TITLE
[Refactor] Add error_code to CompleteMessage for HTTP status classification

### DIFF
--- a/sglang_omni/pipeline/coordinator.py
+++ b/sglang_omni/pipeline/coordinator.py
@@ -21,6 +21,11 @@ from sglang_omni.proto import (
 logger = logging.getLogger(__name__)
 
 
+def _attach_error_code(exc: RuntimeError, error_code: str | None) -> None:
+    if error_code is not None:
+        exc.error_code = error_code  # type: ignore[attr-defined]
+
+
 class Coordinator:
     """Central coordinator for the multi-stage pipeline.
 
@@ -133,7 +138,9 @@ class Coordinator:
                 msg = await queue.get()
                 if isinstance(msg, CompleteMessage):
                     if not msg.success:
-                        raise RuntimeError(msg.error or "Unknown error")
+                        exc = RuntimeError(msg.error or "Unknown error")
+                        _attach_error_code(exc, msg.error_code)
+                        raise exc
                     yield msg
                     completed_stages.add(msg.from_stage)
                     if (
@@ -288,7 +295,9 @@ class Coordinator:
             if request_id in self._completion_futures:
                 future = self._completion_futures[request_id]
                 if not future.done():
-                    future.set_exception(RuntimeError(msg.error or "Unknown error"))
+                    exc = RuntimeError(msg.error or "Unknown error")
+                    _attach_error_code(exc, msg.error_code)
+                    future.set_exception(exc)
             if request_id in self._stream_queues:
                 await self._stream_queues[request_id].put(msg)
             self._requests.pop(request_id, None)

--- a/sglang_omni/pipeline/worker/runtime.py
+++ b/sglang_omni/pipeline/worker/runtime.py
@@ -21,6 +21,7 @@ from sglang_omni.proto import (
     DataReadyMessage,
     StagePayload,
     StreamMessage,
+    classify_error_code,
 )
 
 if TYPE_CHECKING:
@@ -380,12 +381,14 @@ class Worker:
 
     async def _send_failure(self, request_id: str, error: str) -> None:
         """Send failure to coordinator."""
+        error_code = classify_error_code(error)
         await self.stage.control_plane.send_complete(
             CompleteMessage(
                 request_id=request_id,
                 from_stage=self.stage.name,
                 success=False,
                 error=error,
+                error_code=error_code,
             )
         )
 

--- a/sglang_omni/proto/__init__.py
+++ b/sglang_omni/proto/__init__.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from .messages import (
+    CLIENT_ERROR_CODES,
     AbortMessage,
     CompleteMessage,
     DataReadyMessage,
@@ -8,12 +9,14 @@ from .messages import (
     ShutdownMessage,
     StreamMessage,
     SubmitMessage,
+    classify_error_code,
     parse_message,
 )
 from .request import OmniRequest, RequestInfo, RequestState, StagePayload
 from .stage import StageInfo
 
 __all__ = [
+    "CLIENT_ERROR_CODES",
     "DataReadyMessage",
     "AbortMessage",
     "CompleteMessage",
@@ -22,6 +25,7 @@ __all__ = [
     "ShutdownMessage",
     "ProfilerStartMessage",
     "ProfilerStopMessage",
+    "classify_error_code",
     "parse_message",
     "RequestState",
     "RequestInfo",

--- a/sglang_omni/proto/messages.py
+++ b/sglang_omni/proto/messages.py
@@ -6,6 +6,24 @@ from typing import Any
 
 from sglang_omni.proto.request import StagePayload
 
+_ERROR_PATTERNS: dict[str, tuple[str, ...]] = {
+    "PROMPT_TOO_LONG": (
+        "longer than the model's context length",
+        "Requested token count exceeds the model's maximum context length",
+    ),
+}
+
+CLIENT_ERROR_CODES: set[str] = set(_ERROR_PATTERNS.keys())
+
+
+def classify_error_code(message: str) -> str | None:
+    """Classify an error message into a structured error code."""
+    for code, patterns in _ERROR_PATTERNS.items():
+        for pattern in patterns:
+            if pattern in message:
+                return code
+    return None
+
 
 @dataclass
 class DataReadyMessage:
@@ -147,9 +165,10 @@ class CompleteMessage:
     success: bool
     result: Any = None
     error: str | None = None
+    error_code: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d = {
             "type": "complete",
             "request_id": self.request_id,
             "from_stage": self.from_stage,
@@ -157,6 +176,9 @@ class CompleteMessage:
             "result": self.result,
             "error": self.error,
         }
+        if self.error_code is not None:
+            d["error_code"] = self.error_code
+        return d
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "CompleteMessage":
@@ -166,6 +188,7 @@ class CompleteMessage:
             success=d["success"],
             result=d.get("result"),
             error=d.get("error"),
+            error_code=d.get("error_code"),
         )
 
 

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -36,6 +36,7 @@ from sglang_omni.client.audio import (
     encode_audio,
     to_numpy,
 )
+from sglang_omni.proto.messages import CLIENT_ERROR_CODES
 from sglang_omni.serve.protocol import (
     ChatCompletionAudio,
     ChatCompletionChoice,
@@ -52,6 +53,7 @@ from sglang_omni.serve.protocol import (
 
 logger = logging.getLogger(__name__)
 MIME_TO_FORMAT = {mime: fmt for fmt, mime in FORMAT_MIME_TYPES.items()}
+
 _BAD_REQUEST_MARKERS = (
     "longer than the model's context length",
     "Requested token count exceeds the model's maximum context length",
@@ -59,12 +61,9 @@ _BAD_REQUEST_MARKERS = (
 
 
 def _is_bad_request_error(exc: Exception) -> bool:
-    # TODO (Qiujiang): replace with structured error code.
-    # Worker → coordinator currently serializes exceptions to str, so
-    # 400 vs 500 must be recovered via phrase match. See Ccyest's proposal
-    # on #330 for the end-to-end design (CompleteMessage.error_code).
-    # These markers must stay in sync with SGLang's ValueError wording:
-    #   - managers/tokenizer_manager.py:761, 791
+    error_code = getattr(exc, "error_code", None)
+    if error_code is not None:
+        return error_code in CLIENT_ERROR_CODES
     message = str(exc)
     return any(marker in message for marker in _BAD_REQUEST_MARKERS)
 

--- a/sglang_omni_v1/pipeline/coordinator.py
+++ b/sglang_omni_v1/pipeline/coordinator.py
@@ -21,6 +21,11 @@ from sglang_omni_v1.proto import (
 logger = logging.getLogger(__name__)
 
 
+def _attach_error_code(exc: RuntimeError, error_code: str | None) -> None:
+    if error_code is not None:
+        exc.error_code = error_code  # type: ignore[attr-defined]
+
+
 class Coordinator:
     """Central coordinator for the multi-stage pipeline.
 
@@ -133,7 +138,9 @@ class Coordinator:
                 msg = await queue.get()
                 if isinstance(msg, CompleteMessage):
                     if not msg.success:
-                        raise RuntimeError(msg.error or "Unknown error")
+                        exc = RuntimeError(msg.error or "Unknown error")
+                        _attach_error_code(exc, msg.error_code)
+                        raise exc
                     yield msg
                     completed_stages.add(msg.from_stage)
                     if (
@@ -288,7 +295,9 @@ class Coordinator:
             if request_id in self._completion_futures:
                 future = self._completion_futures[request_id]
                 if not future.done():
-                    future.set_exception(RuntimeError(msg.error or "Unknown error"))
+                    exc = RuntimeError(msg.error or "Unknown error")
+                    _attach_error_code(exc, msg.error_code)
+                    future.set_exception(exc)
             if request_id in self._stream_queues:
                 await self._stream_queues[request_id].put(msg)
             self._requests.pop(request_id, None)

--- a/sglang_omni_v1/pipeline/stage/runtime.py
+++ b/sglang_omni_v1/pipeline/stage/runtime.py
@@ -33,6 +33,7 @@ from sglang_omni_v1.proto import (
     ShutdownMessage,
     StageInfo,
     SubmitMessage,
+    classify_error_code,
 )
 from sglang_omni_v1.relay.base import Relay, create_relay
 from sglang_omni_v1.scheduling.messages import IncomingMessage
@@ -596,6 +597,7 @@ class Stage:
         )
 
     async def _send_failure(self, request_id: str, error: str) -> None:
+        error_code = classify_error_code(error)
         if not self._owns_external_io:
             self._clear_request_state(request_id)
             raise RuntimeError(f"Follower stage {self.name} failed: {error}")
@@ -605,6 +607,7 @@ class Stage:
                 from_stage=self.name,
                 success=False,
                 error=error,
+                error_code=error_code,
             )
         )
         self._clear_request_state(request_id)

--- a/sglang_omni_v1/proto/__init__.py
+++ b/sglang_omni_v1/proto/__init__.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from .messages import (
+    CLIENT_ERROR_CODES,
     AbortMessage,
     CompleteMessage,
     DataReadyMessage,
@@ -8,12 +9,14 @@ from .messages import (
     ShutdownMessage,
     StreamMessage,
     SubmitMessage,
+    classify_error_code,
     parse_message,
 )
 from .request import OmniRequest, RequestInfo, RequestState, StagePayload
 from .stage import StageInfo
 
 __all__ = [
+    "CLIENT_ERROR_CODES",
     "DataReadyMessage",
     "AbortMessage",
     "CompleteMessage",
@@ -22,6 +25,7 @@ __all__ = [
     "ShutdownMessage",
     "ProfilerStartMessage",
     "ProfilerStopMessage",
+    "classify_error_code",
     "parse_message",
     "RequestState",
     "RequestInfo",

--- a/sglang_omni_v1/proto/messages.py
+++ b/sglang_omni_v1/proto/messages.py
@@ -6,6 +6,24 @@ from typing import Any
 
 from sglang_omni_v1.proto.request import StagePayload
 
+_ERROR_PATTERNS: dict[str, tuple[str, ...]] = {
+    "PROMPT_TOO_LONG": (
+        "longer than the model's context length",
+        "Requested token count exceeds the model's maximum context length",
+    ),
+}
+
+CLIENT_ERROR_CODES: set[str] = set(_ERROR_PATTERNS.keys())
+
+
+def classify_error_code(message: str) -> str | None:
+    """Classify an error message into a structured error code."""
+    for code, patterns in _ERROR_PATTERNS.items():
+        for pattern in patterns:
+            if pattern in message:
+                return code
+    return None
+
 
 @dataclass
 class DataReadyMessage:
@@ -147,9 +165,10 @@ class CompleteMessage:
     success: bool
     result: Any = None
     error: str | None = None
+    error_code: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d = {
             "type": "complete",
             "request_id": self.request_id,
             "from_stage": self.from_stage,
@@ -157,6 +176,9 @@ class CompleteMessage:
             "result": self.result,
             "error": self.error,
         }
+        if self.error_code is not None:
+            d["error_code"] = self.error_code
+        return d
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "CompleteMessage":
@@ -166,6 +188,7 @@ class CompleteMessage:
             success=d["success"],
             result=d.get("result"),
             error=d.get("error"),
+            error_code=d.get("error_code"),
         )
 
 

--- a/sglang_omni_v1/serve/openai_api.py
+++ b/sglang_omni_v1/serve/openai_api.py
@@ -36,6 +36,7 @@ from sglang_omni_v1.client.audio import (
     encode_audio,
     to_numpy,
 )
+from sglang_omni_v1.proto.messages import CLIENT_ERROR_CODES
 from sglang_omni_v1.serve.protocol import (
     ChatCompletionAudio,
     ChatCompletionChoice,
@@ -60,6 +61,9 @@ _BAD_REQUEST_MARKERS = (
 
 
 def _is_bad_request_error(exc: Exception) -> bool:
+    error_code = getattr(exc, "error_code", None)
+    if error_code is not None:
+        return error_code in CLIENT_ERROR_CODES
     message = str(exc)
     return any(marker in message for marker in _BAD_REQUEST_MARKERS)
 

--- a/tests/test_error_code.py
+++ b/tests/test_error_code.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for structured error code classification and propagation."""
+
+from __future__ import annotations
+
+from sglang_omni.proto.messages import (
+    CLIENT_ERROR_CODES,
+    CompleteMessage,
+    classify_error_code,
+)
+from sglang_omni.serve.openai_api import _is_bad_request_error
+
+
+def _make_error(message: str, error_code: str | None = None) -> RuntimeError:
+    exc = RuntimeError(message)
+    if error_code is not None:
+        exc.error_code = error_code  # type: ignore[attr-defined]
+    return exc
+
+
+class TestClassifyErrorCode:
+    def test_prompt_too_long_matches_context_length(self) -> None:
+        code = classify_error_code(
+            "The input is longer than the model's context length of 8192 tokens"
+        )
+        assert code == "PROMPT_TOO_LONG", f"Expected PROMPT_TOO_LONG, got {code}"
+
+    def test_prompt_too_long_matches_token_count(self) -> None:
+        code = classify_error_code(
+            "Requested token count exceeds the model's maximum context length"
+        )
+        assert code == "PROMPT_TOO_LONG", f"Expected PROMPT_TOO_LONG, got {code}"
+
+    def test_unrecognized_error_returns_none(self) -> None:
+        result = classify_error_code("Some random CUDA OOM error")
+        assert result is None, f"Expected None for unrecognized error, got {result}"
+
+    def test_empty_message_returns_none(self) -> None:
+        result = classify_error_code("")
+        assert result is None, f"Expected None for empty message, got {result}"
+
+
+class TestCompleteMessageErrorCode:
+    def test_roundtrip_with_error_code(self) -> None:
+        msg = CompleteMessage(
+            request_id="req-1",
+            from_stage="thinker",
+            success=False,
+            error="prompt too long",
+            error_code="PROMPT_TOO_LONG",
+        )
+        serialized = msg.to_dict()
+        assert serialized["error_code"] == "PROMPT_TOO_LONG", (
+            f"error_code must be present in serialized dict, got {serialized}"
+        )
+        restored = CompleteMessage.from_dict(serialized)
+        assert restored.error_code == "PROMPT_TOO_LONG", (
+            f"error_code must survive round-trip, got {restored.error_code}"
+        )
+
+    def test_roundtrip_without_error_code(self) -> None:
+        msg = CompleteMessage(
+            request_id="req-1",
+            from_stage="thinker",
+            success=False,
+            error="relay read failed",
+        )
+        serialized = msg.to_dict()
+        assert "error_code" not in serialized, (
+            f"error_code key must be absent when None, got {serialized}"
+        )
+        restored = CompleteMessage.from_dict(serialized)
+        assert restored.error_code is None, (
+            f"error_code must be None when absent from dict, got {restored.error_code}"
+        )
+
+    def test_success_message_omits_error_code(self) -> None:
+        msg = CompleteMessage(
+            request_id="req-1",
+            from_stage="decode",
+            success=True,
+            result={"text": "ok"},
+        )
+        serialized = msg.to_dict()
+        assert "error_code" not in serialized, (
+            f"error_code key must be absent for successful messages, got {serialized}"
+        )
+
+
+class TestIsBadRequestError:
+    def test_error_code_takes_priority(self) -> None:
+        exc = _make_error("something went wrong", error_code="PROMPT_TOO_LONG")
+        assert _is_bad_request_error(exc) is True, (
+            "PROMPT_TOO_LONG error_code must be classified as 400, even with "
+            "a message that would not match legacy markers"
+        )
+
+    def test_unknown_error_code_not_bad_request(self) -> None:
+        exc = _make_error("something went wrong", error_code="SOME_OTHER_CODE")
+        assert _is_bad_request_error(exc) is False, (
+            "Unknown error_code must not be classified as a 400"
+        )
+
+    def test_fallback_to_string_matching(self) -> None:
+        exc = RuntimeError(
+            "The input is longer than the model's context length"
+        )
+        assert _is_bad_request_error(exc) is True, (
+            "Legacy phrase matching must still work when error_code is absent"
+        )
+
+    def test_fallback_no_match_returns_false(self) -> None:
+        exc = RuntimeError("Internal server error")
+        assert _is_bad_request_error(exc) is False, (
+            "Unrecognized message without error_code must not be classified as 400"
+        )
+
+    def test_cl_error_codes_is_derived_from_patterns(self) -> None:
+        assert "PROMPT_TOO_LONG" in CLIENT_ERROR_CODES, (
+            f"PROMPT_TOO_LONG must be in CLIENT_ERROR_CODES, got {CLIENT_ERROR_CODES}"
+        )
+        assert "NONEXISTENT" not in CLIENT_ERROR_CODES, (
+            f"NONEXISTENT must not appear in CLIENT_ERROR_CODES, got {CLIENT_ERROR_CODES}"
+        )


### PR DESCRIPTION
As titled. The current _is_bad_request_error recovers HTTP status codes from substring matches against SGLang's internal error phrasing — this propagates a structured error_code through CompleteMessage instead.