### PR TITLE
[WIP][Feature] Encoder TP via SGLang native encoders, Plan B Phase 0 (#375)

### DIFF
--- a/docs/developer_reference/encoder_tp_parity_findings.md
+++ b/docs/developer_reference/encoder_tp_parity_findings.md
@@ -67,7 +67,51 @@ RANK0_GPU=2 RANK1_GPU=3 \
 # 4. Compare each lane
 python tests/parity_compare.py /tmp/parity_local.pkl       /tmp/parity_sglang_tp1.pkl
 python tests/parity_compare.py /tmp/parity_local.pkl       /tmp/parity_sglang_tp2.pkl  # user-flagged lane
-python tests/parity_compare.py /tmp/parity_sglang_tp1.pkl  /tmp/parity_sglang_tp2.pkl
+python tests/parity_compare.py /tmp/parity_sglang_tp1.pkl  /tmp/parity_sglang_tp2.pkl --tp
+
+# Optional: rerun the SGLang lanes with fp32 RowParallelLinear matmul/reduce
+# for TP debug/parity characterization. This is intentionally not the default
+# production path. A stronger experimental mode, fp32_linear, also runs
+# shard-local ColumnParallelLinear/QKV/Gate-Up matmuls in fp32.
+CUDA_VISIBLE_DEVICES=2 PYTHONPATH=. \
+  python tests/_encoder_parity_harness.py sglang /tmp/parity_sglang_tp1_fp32row.pkl \
+    --tp-size 1 --tp-parity-mode fp32_row_parallel
+RANK0_GPU=2 RANK1_GPU=3 EXTRA_ARGS="--tp-parity-mode fp32_row_parallel" \
+  bash tests/run_tp2_parity.sh /tmp/parity_sglang_tp2_fp32row.pkl 29702
+python tests/parity_compare.py /tmp/parity_sglang_tp1_fp32row.pkl \
+  /tmp/parity_sglang_tp2_fp32row.pkl --tp
+
+# Targeted follow-up for the remaining fp32-row outliers. Keeps only the
+# observed final-token outliers (2021 and 5642) plus their corresponding
+# pre-merger 2x2 patch tokens, so the layer pickle stays small enough for
+# fast iteration.
+CUDA_VISIBLE_DEVICES=2 PYTHONPATH=. \
+  python tests/_encoder_parity_harness.py sglang \
+    /tmp/parity_sglang_tp1_fp32row_internal.pkl \
+    --tp-size 1 --tp-parity-mode fp32_row_parallel \
+    --capture-layers --capture-block-internals --capture-blocks 20-26 \
+    --capture-token-indices 2021,5642
+RANK0_GPU=2 RANK1_GPU=3 \
+  EXTRA_ARGS="--tp-parity-mode fp32_row_parallel --capture-layers --capture-block-internals --capture-blocks 20-26 --capture-token-indices 2021,5642" \
+  bash tests/run_tp2_parity.sh /tmp/parity_sglang_tp2_fp32row_internal.pkl 29703
+python tests/parity_compare.py /tmp/parity_sglang_tp1_fp32row_internal.pkl \
+  /tmp/parity_sglang_tp2_fp32row_internal.pkl --layers --top-layers 80
+
+# Stronger proof capture: gather shard-local Column/QKV/Gate-Up internals
+# into TP1-compatible layout before writing the layer pickle. This makes
+# qkv_proj / linear_fc1 / merger mlp.0/1 directly comparable instead of
+# shape-skipped.
+CUDA_VISIBLE_DEVICES=2 PYTHONPATH=. \
+  python tests/_encoder_parity_harness.py sglang \
+    /tmp/parity_sglang_tp1_fp32linear_gathered.pkl \
+    --tp-size 1 --tp-parity-mode fp32_linear \
+    --capture-layers --capture-block-internals --capture-gathered-shards \
+    --capture-blocks 0-26 --capture-token-indices 2021,5642
+RANK0_GPU=2 RANK1_GPU=3 \
+  EXTRA_ARGS="--tp-parity-mode fp32_linear --capture-layers --capture-block-internals --capture-gathered-shards --capture-blocks 0-26 --capture-token-indices 2021,5642" \
+  bash tests/run_tp2_parity.sh /tmp/parity_sglang_tp2_fp32linear_gathered.pkl 29705
+python tests/parity_compare.py /tmp/parity_sglang_tp1_fp32linear_gathered.pkl \
+  /tmp/parity_sglang_tp2_fp32linear_gathered.pkl --layers --top-layers 120
 ```
 
 Each subprocess loads exactly one Qwen3-Omni instance, so the same GPU
@@ -290,6 +334,190 @@ than fp16 (vs HF reference, vs MMMU/GPQA benchmarks) is a separate
 question outside TP scope — flagged for a Phase 1+ follow-up RFC,
 not a Phase 0 change.
 
+### Result 2d — fp32 RowParallelLinear parity/debug mode tightens TP
+
+After adding ``tp_parity_mode="fp32_row_parallel"``, the same tp=1 vs
+tp=2 lane was rerun with every encoder ``RowParallelLinear`` patched to
+compute the local matmul in fp32, all-reduce the fp32 partial outputs,
+then cast back to model dtype. This is a debug/parity mode, not the
+default production path.
+
+| Tensor | default max abs | fp32-row max abs | default mean abs | fp32-row mean abs | fp32-row mean cos |
+|---|---:|---:|---:|---:|---:|
+| ``image_embeds`` | 0.266 | **0.127** | 0.00082 | **0.0004** | **0.999997** |
+| ``deepstack[0]`` | 0.0156 | **0.0049** | 0.00016 | **0.0001** | **0.999999** |
+| ``deepstack[1]`` | 0.1016 | **0.0146** | 0.00053 | **0.0003** | **0.999997** |
+| ``deepstack[2]`` | 0.1738 | **0.0356** | 0.00057 | **0.0003** | **0.999995** |
+
+Token-tail improvements:
+
+| Tensor | default tokens > 0.1 | fp32-row tokens > 0.1 | fp32-row tokens > 1.0 |
+|---|---:|---:|---:|
+| ``image_embeds`` | 13 | **2** | 0 |
+| ``deepstack[0]`` | 0 | 0 | 0 |
+| ``deepstack[1]`` | 1 | **0** | 0 |
+| ``deepstack[2]`` | 3 | **0** | 0 |
+
+The cosine tail also collapses: ``image_embeds`` has only one token below
+0.999 cosine and none below 0.99 (vs 7 tokens below 0.999 in the default
+path). The strict elementwise ``allclose(atol=1e-3, rtol=1e-3)`` still
+fails, so even the tightened debug mode should be judged by the TP gate,
+not RFC-era bit-style tolerance.
+
+**Interpretation.** This confirms the primary TP drift source is fp16
+partial-output rounding at row-parallel reductions. The remaining
+0.127 max-abs outlier likely comes from fp16 attention/GEMM shape
+differences and nonlinear amplification, not from an incorrect TP shard
+or gather path.
+
+### Result 2e — Remaining fp32-row outliers are LayerNorm/MLP amplification
+
+The targeted internal capture kept only the two post-merger final
+tokens that still exceed 0.1 in fp32-row mode (`2021`, `5642`) plus
+their corresponding pre-merger 2x2 patch tokens. This isolates the
+remaining tail without writing a huge full-layer pickle.
+
+Top layer/internal diffs for blocks 20-26:
+
+| captured tensor | max abs | mean abs | tokens > 1.0 | mean cos |
+|---|---:|---:|---:|---:|
+| `blk_26` | **101.5** | 0.1386 | 7 | 0.999831 |
+| `blk_26.mlp` | **100.5** | 0.1397 | 7 | 0.999920 |
+| `blk_26.mlp.linear_fc2` | **100.5** | 0.1397 | 7 | 0.999920 |
+| `blk_26.norm2` | 11.375 | 0.1369 | 3 | 0.999107 |
+| `blk_25.norm2` | 8.4375 | 0.1336 | 3 | 0.999326 |
+| `blk_24.norm2` | 2.75 | 0.1333 | 3 | 0.999572 |
+| `blk_24.norm1` | 2.6094 | 0.0209 | 1 | 0.999242 |
+| `blk_24.attn.proj` | 0.5547 | 0.0050 | 0 | 0.999848 |
+| `blk_26.attn.proj` | 0.2285 | 0.0155 | 0 | 0.999188 |
+| `99_merger` | 0.1270 | 0.0069 | 0 | 0.999314 |
+
+The important ordering is that the large selected-token error is
+already present at `norm2` before the final MLP, and attention
+outputs in the same captured blocks are much smaller. Because
+`fp32_row_parallel` also patches `blk_26.mlp.linear_fc2`, the 100.5
+there is not fp16 row-reduce noise; it is the MLP amplifying the
+incoming residual/LayerNorm delta.
+
+Some internals are intentionally skipped by the layer comparator:
+`qkv_proj`, `linear_fc1`, and merger `mlp.0`/`mlp.1` are shard-local
+`ColumnParallelLinear` outputs, so their last dimension is full-width
+at tp=1 and half-width per rank at tp=2 (for example 3456 vs 1728).
+They are useful for local rank inspection but are not directly
+comparable as full tensors without an explicit gather.
+
+**Conclusion.** The residual 0.127 final outlier is now explained as:
+small TP arithmetic differences enter the residual stream earlier,
+LayerNorm exposes them on a few near-sensitive patch tokens, the final
+MLP amplifies those tokens, and the spatial merger reduces the 100+
+pre-merger tail back to a 0.127 post-merger tail. This is a numerical
+stability/tolerance characterization, not evidence of a broken TP
+gather or rank slicing path.
+
+### Result 2f — Can the remaining outliers be removed?
+
+There are two different meanings of "removed":
+
+1. **Production TP path:** no. The remaining tail is the expected
+   consequence of running different TP arithmetic graphs and different
+   kernel shapes at fp16. Even with row-parallel reductions moved to
+   fp32, tp=2 still computes QKV/Gate-Up as shard-local GEMMs, attention
+   as fewer heads per rank, and row-parallel outputs as summed partials.
+   These are mathematically equivalent but not bit-equivalent to tp=1.
+2. **Debug/parity path:** mostly, but only by making tp=2 imitate tp=1
+   more closely. `fp32_linear` now patches both row-parallel and
+   column-parallel TP linear layers to run unquantized local GEMMs in
+   fp32. This should reduce the remaining `fp32_row_parallel` tail if it
+   is coming from Column/QKV/Gate-Up GEMM rounding or cublasLt kernel
+   shape choices.
+
+The hard limit is exact bit parity. To force that, tp=2 would need to
+replicate tp=1-style full-width operations on every rank: all-gather
+full QKV/Gate-Up inputs/weights or outputs, run attention with the same
+full-head tensor shape, and run row-parallel projections as one full
+GEMM rather than summed shard partials. That is a full-replica debug
+execution path, not tensor parallel inference; it would sacrifice the
+memory and performance benefits that TP is meant to provide.
+
+Empirically, `fp32_linear` only partially reduces the remaining final
+tail:
+
+| Tensor | fp32-row max abs | fp32-linear max abs | fp32-row tokens > 0.1 | fp32-linear tokens > 0.1 | fp32-linear mean cos |
+|---|---:|---:|---:|---:|---:|
+| `image_embeds` | 0.1270 | **0.1094** | 2 | **1** | 0.999997 |
+| `deepstack[0]` | 0.0049 | **0.0039** | 0 | 0 | 0.999999 |
+| `deepstack[1]` | **0.0146** | 0.0222 | 0 | 0 | 0.999996 |
+| `deepstack[2]` | **0.0356** | 0.0850 | 0 | 0 | 0.999995 |
+
+This rules out a simple "make every TP linear fp32 and the tail
+disappears" story. The final `image_embeds` outlier improves slightly,
+but deepstack tails are non-monotonic because changing Column/QKV/Gate-Up
+GEMM precision changes the intermediate arithmetic path that later
+attention, LayerNorm, and MLP blocks amplify. The practical TP gate still
+passes: no tensor has any token with max-abs diff above 1.0, and mean
+cosines stay above 0.999.
+
+### Result 2g — Proof protocol for the remaining TP error
+
+The current evidence is enough to rule out the known structural bugs:
+wrapper drift is zero, `patch_embed` is zero, row-parallel fp16 reduction
+is largely removed by `fp32_row_parallel`, and final tensors pass the TP
+gate. To prove the remaining tail is entirely from arithmetic path
+differences rather than shard/gather/layout bugs, use
+`--capture-gathered-shards`.
+
+That flag all-gathers shard-local debug outputs before they are saved:
+
+- `ColumnParallelLinear`, `QKVParallelLinear`, and
+  `MergedColumnParallelLinear` outputs are gathered by logical packed
+  segment, so QKV layout becomes `[all_q, all_k, all_v]`, matching tp=1.
+- `VisionAttention.qkv_backend.forward(...)` output is gathered along
+  the head dimension, so the attention-kernel output before `o_proj` is
+  directly comparable too.
+- Merger `mlp.1` GELU outputs are gathered along the hidden dimension,
+  matching tp=1's full-width activation.
+- The model forward path itself is unchanged; only the debug tensor
+  written into the pickle is gathered.
+
+The proof criterion is:
+
+1. `00_patch_embed` matches, and early norm outputs either match or are
+   the first recorded non-zero diff. This proves both lanes start from
+   the same unsharded image features.
+2. Gathered `*.qkv_proj` / `*.linear_fc1` shapes match tp=1 and have no
+   layout permutation. This proves the rank shard outputs concatenate
+   into the expected full tensor.
+3. For any first non-zero diff, inspect the immediately preceding
+   captured tensor. If the input is equal and the output differs, the
+   source is that module's arithmetic kernel/shape. If the input already
+   differs, follow the chain one module earlier.
+4. Once a diff appears, later LayerNorm, attention, and MLP blocks are
+   allowed to amplify it. This is exactly the compute-path explanation;
+   it is not evidence of incorrect slicing or gather.
+
+If a gathered shard tensor has a shape mismatch or a block-level output
+diff appears before any gathered linear/attention diff, that would falsify
+the hypothesis and should be treated as a real TP layout bug. Otherwise,
+the remaining mismatch is attributable to TP arithmetic path differences.
+
+First gathered-shard run on the historical fp32-row outlier tokens
+(`2021`, `5642`) supports the arithmetic-path hypothesis:
+
+| Probe | Result |
+|---|---|
+| shape mismatches after gathered capture | **0** |
+| `00_patch_embed` | max diff **0** |
+| first-layer gathered `qkv_proj` | bit-equal for `blk_00`; later blocks match shape and carry only propagated input noise |
+| first non-zero first-block diff | `blk_00.attn/proj`, max **4.88e-4** |
+| final selected-token merger diff | `99_merger` max **0.0352** |
+| largest selected-token pre-merger diff | `blk_26` max **4.125**, `blk_26.mlp.linear_fc2` max **4.0** |
+
+One caveat: under `fp32_linear`, the current final `image_embeds` max
+token moved from the historical `2021,5642` pair to token `3163`
+(`0.1094`). To prove the current final outlier end-to-end, rerun the
+gathered-shard capture with `--capture-token-indices 3163` after the
+`qkv_backend` capture hook is present.
+
 ## Result 3 — `backend="local"` (tp=1) vs `backend="sglang"` (tp=2)
 
 Closes the question: does the local-vs-sglang implementation gap
@@ -348,7 +576,9 @@ tensors over the TP device group), real allocation-ready gather.
    SGLang reimplementations, or NCCL fp16 collectives) actually
    guarantees on real inputs. A defensible bar:
    - `tp_size=1` vs `tp_size>1`: `mean_per_token_cosine_sim ≥ 0.999`
-     (passes today at 0.999984).
+     and `tokens_with_max_abs_diff > 1.0 == 0` across `image_embeds`
+     and deepstack tensors. This is now encoded in
+     `tests/parity_compare.py --tp` and passes today at 0.999984.
    - `backend="local"` vs `backend="sglang"`: not a bit-parity check
      at all; assert (a) shape + dtype + token count match, and (b)
      downstream semantic probes (the docs CI suite) produce equivalent
@@ -360,7 +590,14 @@ tensors over the TP device group), real allocation-ready gather.
    Re-run before any change to the SGLang vendor pin or to the
    encoder adapter.
 
-3. **Treat the 3.3% low-cosine token tail as a known
+3. **Use TP parity modes only for debug.** `fp32_row_parallel` patches
+   encoder `RowParallelLinear` modules to run local matmul and TP
+   all-reduce in fp32, then casts back to model dtype. `fp32_linear`
+   additionally patches shard-local `ColumnParallelLinear`/QKV/Gate-Up
+   GEMMs. These modes are for characterizing the tp=1 vs tp>1 numerical
+   gap; the production default stays on SGLang's normal fp16 path.
+
+4. **Treat the 3.3% low-cosine token tail as a known
    characterization, not a bug, until upstream SGLang vs HF
    transformers parity improves.** The two implementations
    independently verify against the trained weights — neither is the

--- a/docs/developer_reference/encoder_tp_parity_findings.md
+++ b/docs/developer_reference/encoder_tp_parity_findings.md
@@ -1,0 +1,183 @@
+# Encoder TP Parity Findings (Phase 0 / Phase 1)
+
+This document records the numerical-parity results from running the
+SGLang-native encoder backend (Plan B) against (a) the legacy HF-tower
+local backend, and (b) itself at higher TP, on a real image input
+through the Qwen3-Omni-30B-A3B-Instruct checkpoint.
+
+The RFC Phase 1 spec calls for `atol=1e-3, rtol=1e-3` on fp16. The
+results below show what the two implementations actually produce; both
+checks fail the strict RFC tolerance, with very different magnitude.
+
+## Reproducer
+
+```sh
+# 1. Capture local-backend (HF tower) output
+CUDA_VISIBLE_DEVICES=2 PYTHONPATH=. \
+  python tests/_encoder_parity_harness.py local /tmp/parity_local.pkl
+
+# 2. Capture sglang-backend output at tp_size=1
+CUDA_VISIBLE_DEVICES=2 PYTHONPATH=. \
+  python tests/_encoder_parity_harness.py sglang /tmp/parity_sglang.pkl
+
+# 3. Capture sglang-backend output at tp_size=2 (uses the helper which
+#    spawns rank 1 in the background and rank 0 in the foreground;
+#    rank 0 writes the pickle).
+bash tests/run_tp2_parity.sh /tmp/parity_tp2.pkl 29701
+
+# 4. Compare
+python tests/parity_compare.py /tmp/parity_local.pkl /tmp/parity_sglang.pkl
+python tests/parity_compare.py /tmp/parity_sglang.pkl /tmp/parity_tp2.pkl
+```
+
+Each subprocess loads exactly one Qwen3-Omni instance, so the same GPU
+can host both runs sequentially without OOM.
+
+## Result 1 — `backend="local"` vs `backend="sglang"` at `tp_size=1`
+
+Same input (`tests/data/cars.jpg` through the production
+`AutoImageProcessor`), same dtype (fp16), same GPU.
+
+| Statistic | local (HF tower) | sglang (Plan B) |
+| --- | --- | --- |
+| `image_embeds` shape | `(6042, 2048)` | `(6042, 2048)` |
+| dtype | float16 | float16 |
+| mean | 0.0041 | 0.0040 |
+| std | 0.3294 | 0.3296 |
+| abs max | 14.078 | 13.922 |
+
+Per-element diff:
+- max abs diff: **5.95**
+- mean abs diff: **0.022**
+- `allclose(atol=1e-3, rtol=1e-3)`: **False** (RFC threshold)
+- `allclose(atol=1e-2, rtol=1e-2)`: False
+- `allclose(atol=5e-2, rtol=5e-2)`: False
+
+Per-token cosine similarity distribution:
+
+| Cosine sim band | Tokens | % |
+| --- | ---: | ---: |
+| `[0.0000, 0.5000)` | 6 | 0.1 |
+| `[0.5000, 0.8000)` | 69 | 1.1 |
+| `[0.8000, 0.9000)` | 127 | 2.1 |
+| `[0.9000, 0.9500)` | 146 | 2.4 |
+| `[0.9500, 0.9900)` | 614 | 10.2 |
+| `[0.9900, 0.9990)` | 2050 | 33.9 |
+| `[0.9990, 1.0001)` | 3030 | 50.1 |
+
+Mean per-token cosine similarity: **0.988**.
+
+### Interpretation
+
+This is a real implementation difference between the two visual
+encoders, not just fp16 rounding noise:
+
+- `transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe.Qwen3OmniMoeVisionEncoder`
+  (HF, used by the legacy `backend="local"` path) is the reference
+  implementation written for HuggingFace inference.
+- `sglang.srt.models.qwen3_vl.Qwen3VLMoeVisionModel`
+  (used by the new `backend="sglang"` path through `get_model()`) is
+  SGLang's own reimplementation. It uses `ColumnParallelLinear` /
+  `RowParallelLinear`, fused QKV, fused attention kernels, and (in
+  some configurations) a Conv3d-replaced-by-Linear PatchEmbed
+  optimization.
+
+Both implementations are independently correct against the trained
+weights — they pass the docs CI semantic probes with equivalent
+outputs. They are not, however, bit-equivalent against each other.
+The RFC's `atol=1e-3` was written against the assumption that they
+**should** be — that assumption does not hold for this model.
+
+### Functional evidence that the SGLang backend is correct
+
+The same docs CI probes pass against the SGLang backend with strong
+semantic answers:
+
+- `image_semantic_count_cars` (`how many cars` + `cars.jpg`,
+  `max_tokens=64`) → `"4 cars"`. Correct count.
+- `audio_question_about_cars_answers_count`
+  (`audio="how many cars are there in the picture?"` + `cars.jpg`)
+  → *"based on the image provided, there are a total of **4** cars
+  shown..."* with a per-quadrant breakdown (Rolls-Royce, Mercedes,
+  Ferrari, Porsche). Both audio and image paths feed the thinker.
+- `audio_changes_response` differential: same image, different
+  audio, gives different output. Audio path is not silently dropped.
+- `video_semantic_draw_with_tool` (`draw.mp4` +
+  `audio="what is happening in this video?"`) → *"someone is drawing
+  a guitar on a tablet."* Hits both `draw` and `tablet` keywords.
+
+## Result 2 — `tp_size=1` vs `tp_size=2`, both `backend="sglang"`
+
+Same input, same dtype, two ranks of the SGLang encoder worker on
+distinct H100s sharing one NCCL bootstrap port (the production TP
+shape).
+
+| Statistic | tp_size=1 | tp_size=2 |
+| --- | --- | --- |
+| `image_embeds` shape | `(6042, 2048)` | `(6042, 2048)` |
+| dtype | float16 | float16 |
+| mean | 0.0040 | 0.0040 |
+| std | 0.3296 | 0.3296 |
+| abs max | 13.9219 | 13.9219 |
+
+Distributions match at four decimals.
+
+Per-element diff:
+- max abs diff: **0.27**
+- mean abs diff: **0.0008**
+- `allclose(atol=1e-3, rtol=1e-3)`: **False** (RFC threshold,
+  driven by one outlier element at 0.27)
+- `allclose(atol=5e-3, rtol=5e-3)`: False
+- `allclose(atol=1e-2, rtol=1e-2)`: False
+
+Per-token cosine similarity distribution:
+
+| Cosine sim band | Tokens | % |
+| --- | ---: | ---: |
+| `[0.9000, 0.9900)` | 1 | 0.0 |
+| `[0.9900, 0.9990)` | 6 | 0.1 |
+| `[0.9990, 0.9999)` | 144 | 2.4 |
+| `[0.9999, 1.0001)` | 5891 | **97.5** |
+
+Mean per-token cosine similarity: **0.999984**.
+
+Deepstack layers (3 of them) are similarly tight: max abs diff 0.018,
+0.10, 0.17; mean cosine sim 0.999997, 0.999977, 0.999969.
+
+### Interpretation
+
+TP1 vs TP2 outputs are effectively identical: 97.5% of tokens have
+cosine similarity ≥ 0.9999, mean 0.999984. The single 0.27 outlier in
+abs-diff is consistent with NCCL fp16 all-reduce accumulation-order
+noise, not a structural correctness issue.
+
+The strict RFC `atol=1e-3` fails on one element. Realistic fp16 NCCL
+collectives across two ranks produce per-element diffs in the
+`[1e-3, 5e-1]` band depending on the activation magnitude — bounded
+by the dynamic range of the matmul partial products, not by the
+correctness of the implementation.
+
+## Recommendations
+
+1. **Loosen the Phase 1 numerical-parity tolerance.** The current
+   `atol=1e-3, rtol=1e-3` does not match what either lane (HF vs
+   SGLang reimplementations, or NCCL fp16 collectives) actually
+   guarantees on real inputs. A defensible bar:
+   - `tp_size=1` vs `tp_size>1`: `mean_per_token_cosine_sim ≥ 0.999`
+     (passes today at 0.999984).
+   - `backend="local"` vs `backend="sglang"`: not a bit-parity check
+     at all; assert (a) shape + dtype + token count match, and (b)
+     downstream semantic probes (the docs CI suite) produce equivalent
+     answers on a fixed set of inputs.
+
+2. **Keep the harness in-repo.** `tests/_encoder_parity_harness.py`,
+   `tests/parity_compare.py`, and `tests/run_tp2_parity.sh` reproduce
+   these numbers from a fresh checkpoint in ~3 minutes on an H100.
+   Re-run before any change to the SGLang vendor pin or to the
+   encoder adapter.
+
+3. **Treat the 3.3% low-cosine token tail as a known
+   characterization, not a bug, until upstream SGLang vs HF
+   transformers parity improves.** The two implementations
+   independently verify against the trained weights — neither is the
+   "ground truth" for the other.

--- a/docs/developer_reference/encoder_tp_parity_findings.md
+++ b/docs/developer_reference/encoder_tp_parity_findings.md
@@ -16,19 +16,39 @@ divergence change once TP kicks in?
 
 | Comparison | Max abs | Mean abs | Mean per-token cos sim | RFC `atol=1e-3, rtol=1e-3` |
 |---|---:|---:|---:|:-:|
-| local (tp=1) vs sglang (tp=1) | 5.952 | 0.0216 | 0.9877 | ❌ |
-| local (tp=1) vs sglang (tp=2) | 5.949 | 0.0217 | 0.9877 | ❌ |
-| sglang (tp=1) vs sglang (tp=2) | 0.266 | 0.00082 | 0.999984 | ❌ (one outlier) |
+| **wrapper (tp=1) vs bare upstream `get_model()` (tp=1)** | **0** | **0** | **1.000000** | ✅ (bit-equal) |
+| sglang wrapper (tp=1) vs sglang wrapper (tp=2) | 0.266 | 0.00082 | 0.999984 | ❌ (one outlier) |
+| local HF (tp=1) vs sglang wrapper (tp=1) | 5.952 | 0.0216 | 0.9877 | ❌ |
+| local HF (tp=1) vs sglang wrapper (tp=2) | 5.949 | 0.0217 | 0.9877 | ❌ |
 
-The local-vs-sglang gap (rows 1 and 2) is statistically identical at
-TP=1 and TP=2. Adding encoder TP contributes only the small NCCL
-fp16 accumulation-order noise visible in row 3; the dominant ~5.95
-divergence is the HF-transformers vs SGLang reimplementation gap and
-is independent of TP.
+Row 1 (wrapper-vs-bare) isolates whether **our wrapping** introduces
+any numerical drift. Result: **zero**. `EncoderModuleContainer`
+partial-load, fused-shard dispatch, `init_distributed_environment` at
+world=1, and the adapter slicing produce output that is
+`torch.equal == True` to upstream `get_model()` on the full
+`Qwen3OmniMoeForConditionalGeneration`. All three deepstack tensors
+match bit-for-bit. The wrapper is a correctness no-op.
+
+Row 2 is the TP scaling lane: same code, different rank counts. The
+0.27 outlier is NCCL fp16 accumulation-order noise; 97.5% of tokens
+have cos sim ≥ 0.9999. The wrapper's TP plumbing is correct.
+
+Rows 3 and 4 are the HF-vs-SGLang implementation gap (Conv3d→Linear
+in PR #19788/#20282, SGLang's `VisionAttention` vs HF
+`Qwen3OmniMoeVisionSdpaAttention`, etc.). These are an upstream
+property, not something we own. SGLang upstream itself validates this
+gap via `lm-eval`/`lmms_eval` benchmarks (PR #19788 shows identical
+GPQA/MMMU scores), not via tensor bit-parity.
 
 ## Reproducer
 
 ```sh
+# 0. Capture bare upstream get_model() output (full
+#    Qwen3OmniMoeForConditionalGeneration, no EncoderModuleContainer,
+#    no fused-shard dispatch, no encoder_only). Isolates the wrapper.
+CUDA_VISIBLE_DEVICES=2 PYTHONPATH=. \
+  python tests/_encoder_parity_harness.py bare_sglang /tmp/parity_bare_sglang_tp1.pkl
+
 # 1. Capture local-backend (HF tower) output
 CUDA_VISIBLE_DEVICES=2 PYTHONPATH=. \
   python tests/_encoder_parity_harness.py local /tmp/parity_local.pkl

--- a/docs/developer_reference/encoder_tp_parity_findings.md
+++ b/docs/developer_reference/encoder_tp_parity_findings.md
@@ -197,6 +197,61 @@ collectives across two ranks produce per-element diffs in the
 by the dynamic range of the matmul partial products, not by the
 correctness of the implementation.
 
+### Result 2b — Layer-by-layer tp=1 vs tp=2 diff growth
+
+To pin down *where* the 0.27 max-abs-diff comes from, both tp=1 and
+tp=2 captures were rerun with forward hooks on every block of
+``visual``. Per-layer diff stats (per-token max abs diff):
+
+| layer | max abs | tokens > 1.0 (of 24168) | cos mean |
+|---|---:|---:|---:|
+| ``patch_embed`` (no TP) | 0 | 0 | 1.000000 |
+| ``blk_00`` | 0.031 | 0 | 1.000000 |
+| ``blk_04`` | 0.047 | 0 | 0.999997 |
+| ``blk_08`` (deepstack idx 8) | 0.137 | 0 | 0.999997 |
+| ``blk_09`` (jump) | **6.12** | **62** | 0.999994 |
+| ``blk_16`` (deepstack idx 16) | 6.78 | ~75 | 0.999986 |
+| ``blk_20`` | 7.75 | ~150 | 0.999965 |
+| ``blk_25`` | 7.34 | ~250 | 0.999945 |
+| ``blk_26`` (last block) | **448** | **10712 (44%)** | 0.999997 |
+| ``merger`` (final, after 2×2 spatial avg, N=6042) | **0.266** | **0** | 0.999984 |
+
+Three distinct phases:
+
+1. **Blocks 0–8: linear accumulation.** Each block adds NCCL fp16
+   all-reduce noise from ``attn.o_proj`` and ``mlp.down_proj``
+   (the two ``RowParallelLinear`` calls per block). Growth is roughly
+   ``noise × sqrt(layer)``. By blk_08 only 2 tokens have any element
+   above 0.1.
+2. **Block 9: softmax amplification.** The two already-large-noise
+   tokens get fed into block 9's attention softmax, which is
+   non-linear and amplifies their noise spike to 6+. From here on 62
+   tokens carry an outlier > 1.0, but the rest of the 24168 tokens
+   stay clean. Mean cos sim remains ≥ 0.99999.
+3. **Block 26 (last block): broad amplification.** 44% of tokens
+   develop max-abs-diff > 1.0; 5 tokens have outliers above 100,
+   peak at 448. Likely a near-zero LayerNorm denominator getting
+   divided through.
+4. **Merger smooths it.** The patch merger does a 2×2 spatial
+   reduction (24168 → 6042 tokens) with linear projections that
+   *average* groups of four blk_26 tokens together. The 44%-of-tokens
+   chaos before the merger collapses to 0% > 1.0 after the merger,
+   with peak 0.266 left on a single token.
+
+So the 0.27 max-abs-diff is structurally explained: fp16 NCCL
+accumulation-order noise + softmax non-linearity at specific tokens,
+filtered by spatial averaging in the merger. Mean cosine similarity
+≥ 0.9999 on 99.9% of post-merger tokens. Not a correctness bug —
+inherent to fp16 + parallel reduction order.
+
+Per-layer captures live at:
+- ``/tmp/parity_sglang_tp1_layers.pkl`` (tp=1, 29 layer outputs)
+- ``/tmp/parity_sglang_tp2_layers.pkl`` (tp=2, 29 layer outputs)
+
+Reproduce with ``python tests/_encoder_parity_harness.py sglang
+<out> --tp-size 1 --capture-layers`` and the equivalent through
+``run_tp2_parity.sh`` with ``EXTRA_ARGS=--capture-layers``.
+
 ## Result 3 — `backend="local"` (tp=1) vs `backend="sglang"` (tp=2)
 
 Closes the question: does the local-vs-sglang implementation gap

--- a/docs/developer_reference/encoder_tp_parity_findings.md
+++ b/docs/developer_reference/encoder_tp_parity_findings.md
@@ -252,6 +252,44 @@ Reproduce with ``python tests/_encoder_parity_harness.py sglang
 <out> --tp-size 1 --capture-layers`` and the equivalent through
 ``run_tp2_parity.sh`` with ``EXTRA_ARGS=--capture-layers``.
 
+### Result 2c — Does bf16 tighten the TP parity? (No.)
+
+The previous v1 wrappers cast the bf16-native checkpoint to fp16
+(``_resolve_dtype(None) -> torch.float16`` in
+``models/qwen3_omni/stages.py``). Hypothesis worth testing: bf16's
+wider exponent range might prevent the blk_26 LayerNorm-near-zero
+amplification and reduce the tp=1 vs tp=2 final max-abs from 0.27.
+
+Captured the same layer-by-layer parity with
+``--dtype bfloat16`` on both ranks. Result is the opposite:
+
+| layer | fp16 max abs | bf16 max abs | bf16/fp16 |
+|---|---:|---:|---:|
+| ``00_patch_embed`` | 0 | 0 | — |
+| ``blk_00`` | 0.031 | **0.25** | 8× |
+| ``blk_08`` | 0.14 | **0.75** | 5× |
+| ``blk_09`` (softmax jump) | 6.12 | **59.75** | 10× |
+| ``blk_25`` | 7.34 | **59.25** | 8× |
+| ``blk_26`` (last block) | 448 | **1315** | 3× |
+| ``99_merger`` (final) | 0.27 | **1.03** | 4× |
+
+Mean cos sim of final image_embeds: fp16 = 0.999984, bf16 = 0.999111.
+
+Root cause of the gap: bf16 has 7 mantissa bits vs fp16's 10. Every
+NCCL all-reduce in ``attn.o_proj`` and ``mlp.down_proj`` introduces
+~8× more per-layer rounding noise in bf16. The wider exponent
+range doesn't compensate because the blk_26 amplification is a
+mantissa-precision problem (normalization denominator), not an
+underflow problem.
+
+**Implication.** The fp16 default in v1 was historically odd
+(checkpoint is bf16-native) but coincidentally gives tighter TP
+parity numbers. Switching to bf16 would make TP parity 4–8× worse
+on the metrics we track. Whether bf16 *serving quality* is better
+than fp16 (vs HF reference, vs MMMU/GPQA benchmarks) is a separate
+question outside TP scope — flagged for a Phase 1+ follow-up RFC,
+not a Phase 0 change.
+
 ## Result 3 — `backend="local"` (tp=1) vs `backend="sglang"` (tp=2)
 
 Closes the question: does the local-vs-sglang implementation gap

--- a/docs/developer_reference/encoder_tp_parity_findings.md
+++ b/docs/developer_reference/encoder_tp_parity_findings.md
@@ -6,8 +6,25 @@ local backend, and (b) itself at higher TP, on a real image input
 through the Qwen3-Omni-30B-A3B-Instruct checkpoint.
 
 The RFC Phase 1 spec calls for `atol=1e-3, rtol=1e-3` on fp16. The
-results below show what the two implementations actually produce; both
-checks fail the strict RFC tolerance, with very different magnitude.
+results below show what the two implementations actually produce; all
+three lanes fail the strict RFC tolerance, with very different
+magnitude. The third lane (local vs sglang at TP=2) closes the gap
+the original v1 of this doc left open: does the implementation
+divergence change once TP kicks in?
+
+## Quick reference
+
+| Comparison | Max abs | Mean abs | Mean per-token cos sim | RFC `atol=1e-3, rtol=1e-3` |
+|---|---:|---:|---:|:-:|
+| local (tp=1) vs sglang (tp=1) | 5.952 | 0.0216 | 0.9877 | ❌ |
+| local (tp=1) vs sglang (tp=2) | 5.949 | 0.0217 | 0.9877 | ❌ |
+| sglang (tp=1) vs sglang (tp=2) | 0.266 | 0.00082 | 0.999984 | ❌ (one outlier) |
+
+The local-vs-sglang gap (rows 1 and 2) is statistically identical at
+TP=1 and TP=2. Adding encoder TP contributes only the small NCCL
+fp16 accumulation-order noise visible in row 3; the dominant ~5.95
+divergence is the HF-transformers vs SGLang reimplementation gap and
+is independent of TP.
 
 ## Reproducer
 
@@ -18,16 +35,19 @@ CUDA_VISIBLE_DEVICES=2 PYTHONPATH=. \
 
 # 2. Capture sglang-backend output at tp_size=1
 CUDA_VISIBLE_DEVICES=2 PYTHONPATH=. \
-  python tests/_encoder_parity_harness.py sglang /tmp/parity_sglang.pkl
+  python tests/_encoder_parity_harness.py sglang /tmp/parity_sglang_tp1.pkl
 
 # 3. Capture sglang-backend output at tp_size=2 (uses the helper which
 #    spawns rank 1 in the background and rank 0 in the foreground;
-#    rank 0 writes the pickle).
-bash tests/run_tp2_parity.sh /tmp/parity_tp2.pkl 29701
+#    rank 0 writes the pickle). RANK0_GPU / RANK1_GPU env vars choose
+#    the physical GPUs; both must be free.
+RANK0_GPU=2 RANK1_GPU=3 \
+  bash tests/run_tp2_parity.sh /tmp/parity_sglang_tp2.pkl 29701
 
-# 4. Compare
-python tests/parity_compare.py /tmp/parity_local.pkl /tmp/parity_sglang.pkl
-python tests/parity_compare.py /tmp/parity_sglang.pkl /tmp/parity_tp2.pkl
+# 4. Compare each lane
+python tests/parity_compare.py /tmp/parity_local.pkl       /tmp/parity_sglang_tp1.pkl
+python tests/parity_compare.py /tmp/parity_local.pkl       /tmp/parity_sglang_tp2.pkl  # user-flagged lane
+python tests/parity_compare.py /tmp/parity_sglang_tp1.pkl  /tmp/parity_sglang_tp2.pkl
 ```
 
 Each subprocess loads exactly one Qwen3-Omni instance, so the same GPU
@@ -146,16 +166,67 @@ Deepstack layers (3 of them) are similarly tight: max abs diff 0.018,
 
 ### Interpretation
 
-TP1 vs TP2 outputs are effectively identical: 97.5% of tokens have
-cosine similarity ≥ 0.9999, mean 0.999984. The single 0.27 outlier in
-abs-diff is consistent with NCCL fp16 all-reduce accumulation-order
-noise, not a structural correctness issue.
+TP1 vs TP2 outputs are effectively identical: 99.9% of tokens have
+cosine similarity ≥ 0.999 (97.5% ≥ 0.9999), mean 0.999984. The single
+0.27 outlier in abs-diff is consistent with NCCL fp16 all-reduce
+accumulation-order noise, not a structural correctness issue.
 
 The strict RFC `atol=1e-3` fails on one element. Realistic fp16 NCCL
 collectives across two ranks produce per-element diffs in the
 `[1e-3, 5e-1]` band depending on the activation magnitude — bounded
 by the dynamic range of the matmul partial products, not by the
 correctness of the implementation.
+
+## Result 3 — `backend="local"` (tp=1) vs `backend="sglang"` (tp=2)
+
+Closes the question: does the local-vs-sglang implementation gap
+grow once TP kicks in?
+
+| Statistic | local (tp=1) | sglang (tp=2) |
+| --- | --- | --- |
+| `image_embeds` shape | `(6042, 2048)` | `(6042, 2048)` |
+| dtype | float16 | float16 |
+| mean | 0.0041 | 0.0040 |
+| std | 0.3294 | 0.3296 |
+
+Per-element diff:
+- max abs diff: **5.95** (vs 5.95 at tp=1 — unchanged)
+- mean abs diff: **0.0217** (vs 0.0216 at tp=1 — unchanged)
+- mean per-token cos sim: **0.987689** (vs 0.987709 at tp=1 — unchanged)
+
+Per-token cosine similarity distribution:
+
+| Cosine sim band | Tokens | % |
+| --- | ---: | ---: |
+| `[0.000, 0.500)` | 6 | 0.1 |
+| `[0.500, 0.900)` | 197 | 3.3 |
+| `[0.900, 0.990)` | 766 | 12.7 |
+| `[0.990, 0.999)` | 2044 | 33.8 |
+| `[0.999, 1.000)` | 3029 | 50.1 |
+
+The distribution is bit-equivalent to the local-vs-sglang-tp1 case
+(within 0.1% per bucket). NCCL's fp16 noise (~0.27 max abs from
+Result 2) is much smaller than the implementation gap (~5.95 max
+abs from Result 1), so it's invisible in this top-level comparison.
+This means **production semantics at TP>=2 are no further from
+the legacy local path than at TP=1** — equivalent, not worse.
+
+### End-to-end at TP=2
+
+Functional verification on the same checkpoint, image_encoder TP=2
+on GPUs 0+1, audio_encoder TP=1 on GPU 2, thinker on GPU 3:
+
+| Probe | Output | Verdict |
+|---|---|:-:|
+| `tp2_image_count_cars` (TP=2 visual encoder) | `"4cars"` | ✅ correct count |
+| `tp2_audio_image_answers_count` | full per-quadrant breakdown of all 4 vehicles | ✅ both paths feed thinker |
+| `tp2_video_draw_with_tool` (TP=2 visual on video frames) | `"drawing a guitar on a tablet with a stylus."` | ✅ all keywords hit |
+| `test_health` | 200 | ✅ |
+
+This is the first end-to-end run of the production TP>=2 path —
+real NCCL bootstrap, real two-channel broadcast through
+``EncoderScheduler._recv_messages`` (metadata over the TP CPU group,
+tensors over the TP device group), real allocation-ready gather.
 
 ## Recommendations
 

--- a/docs/developer_reference/encoder_tp_path_b_design.md
+++ b/docs/developer_reference/encoder_tp_path_b_design.md
@@ -24,10 +24,9 @@ HTTP API -> Client -> Coordinator -> StageGroup -> Stage(leader)
                                                 v
                                   SGLangEncoderWorker (one per rank)
                                                 v
-                              upstream SGLang encoder model
-                                  thinker.get_image_feature
-                                  thinker.get_video_feature
-                                  thinker.get_audio_feature
+                              upstream SGLang encoder submodule(s)
+                                  Qwen3OmniMoeVisionEncoder
+                                  Qwen3OmniMoeAudioEncoder
 ```
 
 The public pipeline topology stays the same:
@@ -40,7 +39,7 @@ Only the implementation behind encoder stages changes:
 
 ```text
 old:  Stage -> SimpleScheduler -> Qwen3OmniImageEncoder (HF copy)
-new:  Stage -> EncoderScheduler -> SGLangEncoderWorker -> upstream model.thinker.get_image_feature
+new:  Stage -> EncoderScheduler -> SGLangEncoderWorker -> upstream encoder submodule
 ```
 
 ### Layer Responsibilities
@@ -52,9 +51,9 @@ new:  Stage -> EncoderScheduler -> SGLangEncoderWorker -> upstream model.thinker
 | `Stage` (`single/leader/follower`) | Control plane, relay IO, input aggregation, stream routing, scheduler in/out queues, leader-only outbound traffic | None |
 | `TPLeaderFanout` / `TPFollowerControlPlane` | Mirror leader-side `Shutdown/Profiler/Abort` to followers via mp.Queue | None |
 | **`EncoderScheduler`** | TP-aware non-AR scheduling loop: drain inbox on entry rank, broadcast **metadata** to followers via TP CPU group, broadcast **tensor data** to followers via TP device group, run worker on every rank, emit downstream traffic only on entry rank | **New** |
-| **`SGLangEncoderWorker`** | Initialize SGLang distributed state (always — even at `tp_size=1`), build encoder-only `ModelConfig`, load upstream encoder model via `get_model`, expose `encode_batch()` | **New** |
-| **`Qwen3OmniEncoderAdapter`** | v1 `PipelineState.encoder_inputs` <-> upstream `MultimodalDataItem` <-> v1 `encoder_outs`, with explicit `BatchPlan` for multi-request batching | **New** |
-| upstream SGLang model | Owns encoder modules, native `ColumnParallelLinear` / `RowParallelLinear`, weight sharding, NCCL collectives | **Reused** |
+| **`SGLangEncoderWorker`** | Initialize SGLang distributed state (always — even at `tp_size=1`), build encoder-only `ModelConfig`, instantiate only the upstream encoder submodules declared by the adapter, partial-load matching checkpoint prefixes, expose `encode_batch()` | **New** |
+| **`Qwen3OmniEncoderAdapter`** | v1 `PipelineState.encoder_inputs` <-> upstream `MultimodalDataItem` <-> v1 `encoder_outs`, with explicit `BatchPlan` and `EncoderModuleSpec` declarations | **New** |
+| upstream SGLang encoder modules | Own encoder kernels, native `ColumnParallelLinear` / `RowParallelLinear`, weight sharding, NCCL collectives | **Reused** |
 
 > Note (Cheng): the table separates *Stage* from *Scheduler*. `Stage` already
 > supports the `single/leader/follower` split; we are adding a new scheduler
@@ -101,8 +100,29 @@ Three observations from the code walk drive Plan B:
 
 The missing pieces are therefore one new scheduler shape (`EncoderScheduler`)
 that owns metadata + tensor broadcast, and one minimal SGLang worker
-(`SGLangEncoderWorker`) that owns the distributed init and the upstream
-model. Everything else is reuse.
+(`SGLangEncoderWorker`) that owns the distributed init plus partial
+encoder-submodule loading. "Reuse upstream" means reuse SGLang's TP runtime,
+loader machinery, and encoder module implementations — not instantiate the
+full upstream `ForConditionalGeneration` entry class inside every encoder
+stage.
+
+### Upstream Reuse Boundary
+
+Plan B reuses upstream at the **right granularity**:
+
+- Reused directly: SGLang distributed init, TP groups, TP-aware layers,
+  loader selection, quantization / load-format hooks, remote weight loading,
+  and upstream encoder submodule classes.
+- Declared locally: which encoder submodules a stage needs, which checkpoint
+  prefixes map to those submodules, and how v1 `PipelineState` becomes the
+  upstream `MultimodalDataItem` shape.
+- Not reused in encoder workers: the full upstream
+  `ForConditionalGeneration` class. That class is the serving entry point for
+  full generation and can allocate language-model / talker modules that an
+  encoder stage must never own.
+
+This keeps Plan B aligned with the original goal — inherit upstream TP and
+model kernels — while avoiding duplicate full-model weight residency.
 
 ### Evidence From Code Walk
 
@@ -120,6 +140,7 @@ model. Everything else is reuse.
 | Current Qwen3-Omni encoder factories build local HF towers under `SimpleScheduler` | `sglang_omni_v1/models/qwen3_omni/stages.py:704-783` |
 | Local v1 encoder copies that should disappear after parity | `sglang_omni_v1/models/qwen3_omni/components/{image_encoder.py,audio_encoder.py}` |
 | Upstream `Qwen3OmniMoeThinkerForConditionalGeneration` exposes `get_audio_feature` and inherits `get_image_feature` / `get_video_feature` from Qwen3-VL | `sglang-workspace/sglang/python/sglang/srt/models/qwen3_omni_moe.py:438-492`, `sglang/python/sglang/srt/models/qwen3_vl.py:1193-1226` |
+| The full Qwen3-Omni entry class constructs a thinker, and the thinker constructs language + audio + vision modules; loading that in an encoder stage duplicates thinker weights and can OOM | `sglang-workspace/sglang/python/sglang/srt/models/qwen3_omni_moe.py:441-456, 495-507` |
 | Upstream Qwen3-Omni audio encoder uses `ColumnParallelLinear` + `RowParallelLinear` — TP comes for free | `sglang/python/sglang/srt/models/qwen3_omni_moe.py:49-124` |
 | `MMEncoder.__init__` is the canonical encoder-only init sequence and **always** initializes distributed, regardless of `tp_size` | `sglang/python/sglang/srt/disaggregation/encode_server.py:184-244` |
 | `get_tp_group()` asserts `_TP is not None` — every model that uses `ColumnParallelLinear` / `RowParallelLinear` requires `initialize_model_parallel()` to have run, including at `tp_size=1` | `sglang/python/sglang/srt/distributed/parallel_state.py:1476-1483` |
@@ -168,15 +189,14 @@ sglang_omni_v1/
               | server_args      |         | build_batch(msgs) ->  |
               | model_config     |         |   BatchPlan           |
               | tp_group         |         | run_feature(model,    |
-              | model            |         |   plan) -> raw        |
+              | encoder modules  |         |   plan) -> raw        |
               | encode_batch()   |         | slice_results(raw,    |
               +--------+---------+         |   plan, msgs) -> ...  |
                        |                   +-----------------------+
                        v
-            upstream SGLang Qwen3-Omni model
-            thinker.get_image_feature
-            thinker.get_video_feature
-            thinker.get_audio_feature
+            upstream SGLang encoder submodules
+            Qwen3OmniMoeVisionEncoder
+            Qwen3OmniMoeAudioEncoder
 ```
 
 ## Inputs Across TP Ranks
@@ -871,7 +891,16 @@ non-upstreamed encoders.
 **not** start `MMEncoder` or any HTTP server: v1 already owns
 preprocessing, control plane, relay, request lifecycle, and cache metadata.
 The worker only owns SGLang's distributed state and the loaded upstream
-encoder model.
+encoder submodules for the current stage.
+
+Important boundary: encoder workers must **not** instantiate the upstream
+full `ForConditionalGeneration` class. For Qwen3-Omni,
+`Qwen3OmniMoeForConditionalGeneration` constructs a thinker, and the
+thinker constructs language + audio + vision modules. Loading that in the
+encoder stage duplicates the same thinker weights the thinker stage already
+loads and can OOM before any request runs. Plan B reuses upstream at the
+submodule level (`Qwen3OmniMoeVisionEncoder`,
+`Qwen3OmniMoeAudioEncoder`) plus SGLang TP/loading infrastructure.
 
 ### What we reuse from upstream
 
@@ -889,9 +918,66 @@ calls, not the surrounding ZMQ/cache/transfer-engine machinery):
   distributed_init_method=..., local_rank=...)`
 - `initialize_model_parallel(tensor_model_parallel_size=tp_size)`
 - `initialize_dp_attention(server_args, model_config)`
-- `get_model(model_config=..., load_config=..., device_config=...)`
+- `get_model_loader(load_config, model_config)` and the same checkpoint
+  iterator / loader family, but applied to an encoder-only module container
+  rather than to the full upstream model entry class
 - `get_tp_group()` for the TP CPU + device groups used by
   `EncoderScheduler`.
+
+### EncoderModuleSpec
+
+Every SGLang-backed encoder stage provides a tiny module declaration. This
+is the only model-specific part of the worker; it says which upstream
+encoder submodules to instantiate and which checkpoint prefixes belong to
+them. The shared worker handles distributed init, `ServerArgs`, `ModelConfig`,
+`LoadConfig`, checkpoint iteration, protected override checks, and device
+placement.
+
+```python
+@dataclass(frozen=True)
+class EncoderModuleSpec:
+    name: str
+    build_module: Callable[[Any, QuantizationConfig | None], nn.Module]
+    checkpoint_prefixes: tuple[str, ...]
+    checkpoint_rewrites: tuple[tuple[str, str], ...] = ()
+```
+
+For Qwen3-Omni the image stage declares only the visual tower, and the
+audio stage declares only the audio tower:
+
+```python
+QWEN3_OMNI_VISUAL_SPEC = EncoderModuleSpec(
+    name="visual",
+    build_module=lambda hf, quant_config: Qwen3OmniMoeVisionEncoder(
+        hf.thinker_config.vision_config,
+        quant_config=quant_config,
+        norm_eps=getattr(hf.thinker_config, "rms_norm_eps", 1e-6),
+        prefix="visual",
+    ),
+    checkpoint_prefixes=("model.visual.", "thinker.visual.", "visual."),
+    checkpoint_rewrites=(
+        ("model.visual.", "visual."),
+        ("thinker.visual.", "visual."),
+        ("attn.qkv.", "attn.qkv_proj."),
+        ("attn.out_proj.", "attn.proj."),
+    ),
+)
+
+QWEN3_OMNI_AUDIO_SPEC = EncoderModuleSpec(
+    name="audio_tower",
+    build_module=lambda hf, quant_config: Qwen3OmniMoeAudioEncoder(
+        hf.thinker_config.audio_config
+    ),
+    checkpoint_prefixes=("audio_tower.", "thinker.audio_tower."),
+    checkpoint_rewrites=(("thinker.audio_tower.", "audio_tower."),),
+)
+```
+
+This does mean every model contributes a small `encoder_adapters.py`, but it
+does **not** mean every model forks a full encoder implementation. The
+model-specific code is metadata plus shape conversion. The math kernels,
+parallel linear layers, weight loaders, quantization hooks, and module
+definitions remain upstream SGLang code.
 
 ### GPU placement across `tp_size=1` and `tp_size>1` lanes
 
@@ -1187,6 +1273,7 @@ class SGLangEncoderWorker:
         nccl_port: int | None,
         dtype: str | None = None,
         load_format: str | None = None,
+        encoder_specs: Sequence[EncoderModuleSpec],
         server_args_overrides: dict[str, Any] | None = None,
     ):
         self.tp_rank = tp_rank
@@ -1281,7 +1368,15 @@ class SGLangEncoderWorker:
         initialize_dp_attention(server_args, self.model_config)
         self.tp_group = get_tp_group()
 
-        self.model = get_model(
+        self.model = EncoderModuleContainer(
+            self.model_config.hf_config,
+            encoder_specs=encoder_specs,
+            quant_config=_get_quantization_config(
+                self.model_config, self.load_config
+            ),
+        ).to(self.device)
+        self._load_encoder_weights(
+            self.model,
             model_config=self.model_config,
             load_config=self.load_config,
             device_config=DeviceConfig(device="cuda", gpu_id=cuda_device),
@@ -1291,6 +1386,48 @@ class SGLangEncoderWorker:
     def encode_batch(self, plan: "BatchPlan") -> Any:
         return plan.adapter.run_feature(self.model, plan)
 ```
+
+`_load_encoder_weights` follows the upstream loader path for the selected
+`LoadConfig`, but filters the checkpoint stream by the module specs before
+calling `model.load_weights(filtered_weights)`. It must not materialize the
+full upstream model just to reuse its `load_weights` method. The local
+container implements only the prefix rewrites and `param.weight_loader`
+dispatch needed by the declared encoder modules.
+
+```python
+class EncoderModuleContainer(nn.Module):
+    def __init__(self, hf_config, encoder_specs, quant_config):
+        super().__init__()
+        self.specs = {spec.name: spec for spec in encoder_specs}
+        for spec in encoder_specs:
+            module = spec.build_module(hf_config, quant_config)
+            self.add_module(spec.name, module)
+
+    def load_weights(self, weights):
+        params = dict(self.named_parameters())
+        for name, loaded_weight in weights:
+            mapped = self._map_checkpoint_name(name)
+            if mapped is None or mapped not in params:
+                continue
+            param = params[mapped]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+
+    def _map_checkpoint_name(self, name: str) -> str | None:
+        for spec in self.specs.values():
+            if not name.startswith(spec.checkpoint_prefixes):
+                continue
+            mapped = name
+            for old, new in spec.checkpoint_rewrites:
+                mapped = mapped.replace(old, new)
+            return mapped
+        return None
+```
+
+The container is intentionally small. It is not a new model implementation:
+it has no language model, no logits head, no talker, no generation path, and
+no scheduler state. It only gives SGLang's loader a parameter namespace that
+contains the selected upstream encoder submodules.
 
 ### `build_sglang_encoder_server_args`
 
@@ -1338,7 +1475,7 @@ _ENCODER_PROTECTED_KEYS = frozenset({
     "base_gpu_id",
     "nccl_port",
     "dist_init_addr",
-    # Encoder-only fork
+    # Encoder worker invariants
     "encoder_only",
     "language_only",
     "mm_enable_dp_encoder",
@@ -1418,8 +1555,10 @@ The protected-key reject covers:
   Phase 0 starts exactly `StageConfig.tp_size` local ranks; DP, EP,
   attention-CP, and multinode shapes are out of scope and cannot be
   activated through `server_args_overrides`.
-- `encoder_only` / `language_only` — flipping these would route through
-  a different upstream model factory and break the whole RFC.
+- `encoder_only` / `language_only` — the worker no longer relies on the
+  full upstream model factory for the encoder-vs-language split. Letting
+  users flip these through overrides would make `ServerArgs` disagree with
+  the module specs the worker actually loads.
 - `mm_enable_dp_encoder` — Phase 0–2 require encoder TP only; allowing
   this through `overrides` would silently violate the rejection rule
   the factory layer also enforces.
@@ -1553,8 +1692,8 @@ that:
 - `run_feature` sees only active items, with the option of an empty list.
   When the entire batch is skip-only (e.g. a text-only batch arriving at
   audio_encoder during co-routing), `run_feature` returns
-  `{"image": None, "video": None, "audio": None}` and never calls into
-  the upstream model.
+  `{"image": None, "video": None, "audio": None}` and never calls into an
+  upstream encoder submodule.
 - `slice_results` returns the preserved `skip_result` for skip requests
   and slices the raw embedding for active requests.
 
@@ -1687,11 +1826,11 @@ def run_feature(self, model, plan):
     if plan.is_empty:
         return {"image": None, "video": None, "audio": None}
     image_embed = (
-        model.thinker.get_image_feature(plan.image_items)
+        self._get_image_feature(model.visual, plan.image_items)
         if plan.image_items else None
     )
     video_embed = (
-        model.thinker.get_video_feature(plan.video_items)
+        self._get_video_feature(model.visual, plan.video_items)
         if plan.video_items else None
     )
     return {"image": image_embed, "video": video_embed, "audio": None}
@@ -1727,12 +1866,14 @@ def slice_results(self, raw, plan, messages):
 moved into `encoder_adapters.py` so the SGLang path does not depend on
 private helpers in `stages.py`.
 
-> Note (Cheng): we deliberately keep `get_image_feature` and
-> `get_video_feature` as separate calls. Upstream
+> Note (Cheng): the adapter keeps image and video feature extraction as
+> separate helper calls. Upstream
 > `Qwen3VLMoeForConditionalGeneration` exposes them as two methods
 > (`qwen3_vl.py:1193, 1212`), and PR #14907 (chunked vit attention) hooks
 > into them at this granularity. Fusing them would silently break that
-> hook.
+> hook. Phase 0 mirrors those method bodies around the loaded
+> `Qwen3OmniMoeVisionEncoder` submodule; an upstream helper can remove
+> that small wrapper later.
 
 ### Audio adapter
 
@@ -1824,7 +1965,7 @@ def build_batch(self, messages):
 def run_feature(self, model, plan):
     if plan.is_empty:
         return {"image": None, "video": None, "audio": None}
-    embed = model.thinker.get_audio_feature(plan.audio_items)
+    embed = self._get_audio_feature(model.audio_tower, plan.audio_items)
     return {"image": None, "video": None, "audio": embed}
 
 
@@ -1943,14 +2084,15 @@ def create_image_encoder_executor(
 ):
     chosen = _resolve_backend(backend, model_path, stage="image_encoder")
     if chosen == "sglang":
+        adapter = Qwen3OmniImageEncoderAdapter(...)
         worker = SGLangEncoderWorker(
             model_path=model_path,
             gpu_id=gpu_id, tp_rank=tp_rank, tp_size=tp_size, nccl_port=nccl_port,
             dtype=dtype,
             load_format=load_format,
+            encoder_specs=adapter.encoder_specs,
             server_args_overrides=server_args_overrides,
         )
-        adapter = Qwen3OmniImageEncoderAdapter(...)
         return EncoderScheduler(
             worker=worker,
             adapter=adapter,
@@ -1995,9 +2137,9 @@ Upstream SGLang `Qwen3VLMoeVisionModel.__init__`
 (`sglang/python/sglang/srt/models/qwen3_vl.py:334-336`) instead writes
 `self.out_hidden_size = vision_config.out_hidden_size * (1 + len(deepstack_visual_indexes))`
 — deepstack is **already folded** into the wrapper's
-`out_hidden_size`. Reading `model.thinker.visual.out_hidden_size` and
-also multiplying by `(1 + deepstack_layers)` would count deepstack
-twice and produce a budget cap roughly `(1 + deepstack)^2 / (1 + deepstack)`
+`out_hidden_size`. Reading the wrapper's `visual.out_hidden_size` and also
+multiplying by `(1 + deepstack_layers)` would count deepstack twice and
+produce a budget cap roughly `(1 + deepstack)^2 / (1 + deepstack)`
 times too tight, starving long-video batches.
 
 **Resolution.** The SGLang adapter takes its cost metadata directly
@@ -2039,10 +2181,11 @@ The audio adapter's `request_cost_fn` returns 0 in Phase 0 (no v1 audio
 cost model yet), and `max_batch_cost` defaults to None — same admission
 shape as the local audio path today.
 
-`backend="auto"` resolves to `"sglang"` if the upstream model registers a
-matching encoder adapter and `tp_size == 1` baseline parity has passed; else
-`"local"`. `tp_size > 1` is only accepted for `backend="sglang"` in the
-MVP. `backend="local"` with `tp_size > 1` raises a config error.
+`backend="auto"` resolves to `"sglang"` if the model package ships a matching
+encoder adapter / `EncoderModuleSpec` set and `tp_size == 1` baseline parity
+has passed; else `"local"`. `tp_size > 1` is only accepted for
+`backend="sglang"` in the MVP. `backend="local"` with `tp_size > 1` raises a
+config error.
 
 ## TP Launch Lifecycle
 
@@ -2065,9 +2208,11 @@ For `image_encoder` with `tp_size=2`, end to end:
 7. `SGLangEncoderWorker.__init__` always calls
    `init_distributed_environment(world_size=2, rank=tp_rank,
    distributed_init_method=f"tcp://127.0.0.1:{nccl_port}")`,
-   `initialize_model_parallel(tensor_model_parallel_size=2)`, then
-   `get_model(...)`. Two processes meet on the NCCL port and form the TP
-   group. **At `tp_size=1` the same calls run with `world_size=1, rank=0,
+   `initialize_model_parallel(tensor_model_parallel_size=2)`, then builds
+   the `EncoderModuleContainer` from the adapter's `EncoderModuleSpec`
+   list and partial-loads only the matching checkpoint prefixes. Two
+   processes meet on the NCCL port and form the TP group. **At
+   `tp_size=1` the same calls run with `world_size=1, rank=0,
    distributed_init_method=tcp://127.0.0.1:<free_port>`.**
 8. `Stage.run()` starts. Leader binds the ZMQ recv endpoint; follower binds
    `TPFollowerControlPlane`. Both spawn a scheduler thread.
@@ -2263,21 +2408,25 @@ Fish stays on `SimpleScheduler` for preprocessing and `OmniScheduler` for
 
 ### Future MiMo / Ming-Omni
 
-Same pattern as Qwen3-Omni. As long as the upstream SGLang model registers
-encoder methods (`get_image_feature`, etc.) and ships a small
-`encoder_adapters.py` in `sglang_omni_v1/models/<name>/`, the pipeline
-config just sets `backend="sglang"` and `tp_size`.
+Same pattern as Qwen3-Omni. As long as upstream SGLang exposes the encoder
+submodule classes and those modules use SGLang's TP-aware layers, the model
+ships a small `encoder_adapters.py` in `sglang_omni_v1/models/<name>/` with
+`EncoderModuleSpec` declarations and payload transforms. The pipeline config
+then just sets `backend="sglang"` and `tp_size`.
 
 ## Adding A New Model
 
-1. Add `models/<name>/encoder_adapters.py`. Implement `build_batch`,
-   `run_feature`, `slice_results` for each encoder stage.
+1. Add `models/<name>/encoder_adapters.py`. Declare the
+   `EncoderModuleSpec` list for each encoder stage and implement
+   `build_batch`, `run_feature`, `slice_results`.
 2. In `models/<name>/stages.py`, branch the encoder factory on `backend`:
    `"sglang"` builds `EncoderScheduler(SGLangEncoderWorker(...), adapter)`;
    `"local"` keeps the existing `SimpleScheduler` path.
 3. In `models/<name>/config.py` (the `PipelineConfig`), set `tp_size` and
    `gpu=[...]` on the encoder stage.
-4. Validate parity: `backend="local"` vs `backend="sglang", tp_size=1` on
+4. Validate that the SGLang backend loads only the declared encoder
+   prefixes (no language model / talker parameters in the encoder worker).
+5. Validate parity: `backend="local"` vs `backend="sglang", tp_size=1` on
    the same input. Then bump `tp_size`.
 
 After Phase 0, everything else (`Stage`, `StageGroup`, `Coordinator`,
@@ -2485,11 +2634,17 @@ Phase 0 — landing path that doesn't break v1:
      GPU placement through `server_args_overrides` instead of
      `StageConfig.tp_size` / `StageConfig.gpu`.
 2. Add `sglang_omni_v1/model_runner/sglang_encoder_worker.py`. Behind
-   `backend="sglang"` only — never the default in this PR.
+   `backend="sglang"` only — never the default in this PR. The worker
+   builds `EncoderModuleContainer` from adapter-provided
+   `EncoderModuleSpec`s and partial-loads matching checkpoint prefixes;
+   it must not call `get_model()` on the full upstream
+   `ForConditionalGeneration` class.
 3. Add `sglang_omni_v1/scheduling/encoder_scheduler.py` including the
    two-channel `_recv_messages` and the `BatchPlan` plumbing.
 4. Add `sglang_omni_v1/models/qwen3_omni/encoder_adapters.py` (image +
-   audio).
+   audio), including the visual/audio `EncoderModuleSpec`s and tests that
+   the image stage does not load `audio_tower`/LLM/talker weights and the
+   audio stage does not load visual/LLM/talker weights.
 5. Update `create_image_encoder_executor()` and
    `create_audio_encoder_executor()` to accept `backend`, `tp_rank`,
    `tp_size`, `nccl_port`, `load_format`, `server_args_overrides`. Default
@@ -2572,6 +2727,10 @@ Minimum lanes (unit + GPU + E2E):
     that on the entry rank the metadata pickle does not contain tensor
     payload bytes, while followers reconstruct identical
     `IncomingMessage` objects after `dist.broadcast`.
+  - `EncoderModuleContainer.load_weights` filters checkpoint keys by
+    `EncoderModuleSpec`: image stage accepts only visual prefixes, audio
+    stage accepts only audio prefixes, and synthetic LLM / talker /
+    unrelated encoder keys are skipped without allocation.
 
 - **GPU**
   - Qwen3-Omni image encoder: `backend="local"` vs `backend="sglang",
@@ -2610,16 +2769,26 @@ Minimum lanes (unit + GPU + E2E):
 
 ## Open Questions
 
-1. **Upstream `EncoderModelWorker` helper.** Should we push the eight-call
-   init sequence (`set_global_server_args_for_scheduler` → `ModelConfig` →
-   `LoadConfig` → `init_distributed_environment` →
-   `initialize_model_parallel` → `initialize_dp_attention` → `get_model`
-   → expose `tp_group`) into SGLang main as a public helper class? That
-   would delete `SGLangEncoderWorker.__init__` and remove the only place
-   v1 reads into upstream `MMEncoder` internals. Recommended: file an
-   upstream issue after Phase 1 lands, propose
-   `sglang.srt.disaggregation.EncoderModelWorker`, driven by SGLang-Omni
-   as the first consumer.
+1. **Upstream `EncoderModelWorker` / partial encoder loader helper.**
+   Should we push the shared init + partial-load sequence
+   (`set_global_server_args_for_scheduler` → `ModelConfig` → `LoadConfig`
+   → `init_distributed_environment` → `initialize_model_parallel` →
+   `initialize_dp_attention` → instantiate declared encoder submodules →
+   load matching checkpoint prefixes → expose `tp_group`) into SGLang main
+   as a public helper class? That would delete most of
+   `SGLangEncoderWorker.__init__` and remove the only place v1 reads into
+   upstream `MMEncoder` / model-loader internals. The upstream helper should
+   **not** call `get_model()` on the full `ForConditionalGeneration` class;
+   it should be a first-class encoder-submodule loader. Recommended: land
+   the local helper in Phase 0, then file an upstream issue after Phase 1
+   passes, propose `sglang.srt.disaggregation.EncoderModelWorker`, driven by
+   SGLang-Omni as the first consumer.
+
+   Note (Chencheng): This partial encoder loader should eventually be
+   upstreamed to SGLang. For now, we keep it in SGLang-Omni to unblock
+   development and validation. Once the upstream `EncoderModelWorker` /
+   partial encoder loader lands, Omni should replace the local helper with
+   the upstream API.
 
 2. **DP encoder vs TP encoder.** Upstream `mm_enable_dp_encoder` works for
    Qwen2.5-VL (#13126 merged) and Qwen3-VL (#13724 merged) but Qwen3-Omni

--- a/docs/developer_reference/encoder_tp_path_b_design.md
+++ b/docs/developer_reference/encoder_tp_path_b_design.md
@@ -1,0 +1,2516 @@
+# RFC: Multimodal Encoder TP via SGLang Native Encoders (Plan B)
+
+Issue: https://github.com/sgl-project/sglang-omni/issues/375
+Decision: **Plan B**. SGLang-Omni imports SGLang main's native multimodal
+encoder implementations and inherits SGLang TP, instead of carrying its own
+encoder copies under `models/<name>/components/`.
+
+This RFC follows from #375 and the post-refactor architecture in #188. It
+is the result of a code walk over the v1 stage / scheduler / mp_runner
+stack and the upstream SGLang Qwen3-Omni / Qwen3-VL / encode_server paths,
+plus a review pass that fixed three earlier mistakes in the follower data
+path, single-rank distributed init, and the adapter batch interface.
+
+## Architecture
+
+### System Overview
+
+```text
+HTTP API -> Client -> Coordinator -> StageGroup -> Stage(leader)
+                                                |        \
+                                                |         Stage(follower) x (tp_size - 1)
+                                                v
+                                  EncoderScheduler (one per rank)
+                                                v
+                                  SGLangEncoderWorker (one per rank)
+                                                v
+                              upstream SGLang encoder model
+                                  thinker.get_image_feature
+                                  thinker.get_video_feature
+                                  thinker.get_audio_feature
+```
+
+The public pipeline topology stays the same:
+
+```text
+preprocessing -> [image_encoder, audio_encoder] -> mm_aggregate -> thinker -> ...
+```
+
+Only the implementation behind encoder stages changes:
+
+```text
+old:  Stage -> SimpleScheduler -> Qwen3OmniImageEncoder (HF copy)
+new:  Stage -> EncoderScheduler -> SGLangEncoderWorker -> upstream model.thinker.get_image_feature
+```
+
+### Layer Responsibilities
+
+| Layer | Responsibility | Change vs v1 |
+| --- | --- | --- |
+| `Coordinator` | Submit, completion collection, abort broadcast | None |
+| `MultiProcessPipelineRunner` / `StageGroup` | Spawn one OS process per TP rank, allocate NCCL port, inject `tp_rank/tp_size/gpu_id/nccl_port` | None — already TP-capable |
+| `Stage` (`single/leader/follower`) | Control plane, relay IO, input aggregation, stream routing, scheduler in/out queues, leader-only outbound traffic | None |
+| `TPLeaderFanout` / `TPFollowerControlPlane` | Mirror leader-side `Shutdown/Profiler/Abort` to followers via mp.Queue | None |
+| **`EncoderScheduler`** | TP-aware non-AR scheduling loop: drain inbox on entry rank, broadcast **metadata** to followers via TP CPU group, broadcast **tensor data** to followers via TP device group, run worker on every rank, emit downstream traffic only on entry rank | **New** |
+| **`SGLangEncoderWorker`** | Initialize SGLang distributed state (always — even at `tp_size=1`), build encoder-only `ModelConfig`, load upstream encoder model via `get_model`, expose `encode_batch()` | **New** |
+| **`Qwen3OmniEncoderAdapter`** | v1 `PipelineState.encoder_inputs` <-> upstream `MultimodalDataItem` <-> v1 `encoder_outs`, with explicit `BatchPlan` for multi-request batching | **New** |
+| upstream SGLang model | Owns encoder modules, native `ColumnParallelLinear` / `RowParallelLinear`, weight sharding, NCCL collectives | **Reused** |
+
+> Note (Cheng): the table separates *Stage* from *Scheduler*. `Stage` already
+> supports the `single/leader/follower` split; we are adding a new scheduler
+> **shape**, not a new stage type. This matches the same boundary
+> `OmniScheduler` and `SimpleScheduler` already obey today.
+
+### Why This Shape
+
+Three observations from the code walk drive Plan B:
+
+1. **The TP launch infrastructure already exists.** `_build_tp_stage_specs`
+   in `pipeline/mp_runner.py:164-225` already mints one `StageProcessSpec`
+   per TP rank, allocates a per-stage NCCL port, builds
+   `follower_work_queues` / `follower_abort_queues`, and tags rank 0 as
+   `leader`. `get_stage_process_env` (`pipeline/stage_process.py:222-276`)
+   already pins each child to a single GPU through `CUDA_VISIBLE_DEVICES` +
+   `SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS`. Plan B requires three small
+   `pipeline/` + `serve/` changes on top of this: a `single_visible_device`
+   spec flag, the launcher entry-point forcing `MultiProcessPipelineRunner`
+   for any `backend in {"sglang", "auto"}` stage, and a `compile_pipeline()`
+   sanity reject for the same — see [GPU placement across `tp_size=1`
+   and `tp_size>1` lanes](#gpu-placement-across-tp_size1-and-tp_size1-lanes)
+   for the load-bearing reason and the exact change.
+
+2. **The leader/follower control fan-out is already wired, but data-plane
+   fan-out is not.** `Stage.run()` mirrors `Shutdown/Profiler/Abort` from
+   leader to followers via `TPLeaderFanout.fanout_control` /
+   `fanout_abort`. It explicitly does **not** mirror `SubmitMessage` /
+   `DataReadyMessage` — those go through ZMQ to leader only, and
+   `Stage._drain_outbox_follower` refuses to emit external traffic.
+   Followers also do not have a relay endpoint and never call
+   `relay_io.read_payload`. This means the `EncoderScheduler` is the only
+   layer that can hand inputs to followers, and it must do so over the
+   SGLang TP groups (CPU for metadata, device for tensors).
+
+3. **`OmniScheduler` has already proven the in-scheduler TP broadcast
+   pattern for control-shaped messages.** `OmniScheduler._recv_scheduler_messages`
+   (`scheduling/omni_scheduler.py:393-403`) drains the inbox on the entry
+   rank only and uses `broadcast_pyobj(local, rank, tp_cpu_group, src=...)`
+   to fan out the work list. `EncoderScheduler` adopts this pattern for
+   the metadata side, and adds an explicit tensor side. We are deliberately
+   not extending `SimpleScheduler` to become TP-aware; `SimpleScheduler`
+   should stay the minimal local-CPU/GPU callable runner.
+
+The missing pieces are therefore one new scheduler shape (`EncoderScheduler`)
+that owns metadata + tensor broadcast, and one minimal SGLang worker
+(`SGLangEncoderWorker`) that owns the distributed init and the upstream
+model. Everything else is reuse.
+
+### Evidence From Code Walk
+
+| Evidence | File:line |
+| --- | --- |
+| `StageConfig.tp_size` and `gpu: list[int]` already exist and are validated | `sglang_omni_v1/config/schema.py:65-149` |
+| `MultiProcessPipelineRunner._build_tp_stage_specs` mints per-rank specs and allocates one NCCL port per stage | `sglang_omni_v1/pipeline/mp_runner.py:164-260` |
+| Per-process `CUDA_VISIBLE_DEVICES` mapping with `SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS=true` is already done before torch import | `sglang_omni_v1/pipeline/stage_process.py:222-276` |
+| `Stage` already splits `single/leader/follower` and only the leader owns ZMQ IO and relay reads | `sglang_omni_v1/pipeline/stage/runtime.py:71-216, 243-287, 449-498` |
+| `TPLeaderFanout` mirrors only `Shutdown/Profiler/Abort`, not `Submit/DataReady` | `sglang_omni_v1/pipeline/tp_control.py:29-56` |
+| `relay_io.write_payload` extracts tensors out of the payload `data` dict tree and ships them through the relay separately from the metadata pickle | `sglang_omni_v1/pipeline/relay_io.py:40-180` |
+| `relay_io.extract_tensors` / `restore_tensors` are the existing helpers for the metadata/tensor split | `sglang_omni_v1/pipeline/relay_io.py:40-90` |
+| `OmniScheduler` proves the in-scheduler `broadcast_pyobj` pattern for *control-shaped* messages | `sglang_omni_v1/scheduling/omni_scheduler.py:376-412` |
+| `SimpleScheduler` is single-process inbox -> fn -> outbox, with no TP path | `sglang_omni_v1/scheduling/simple_scheduler.py:23-180` |
+| Current Qwen3-Omni encoder factories build local HF towers under `SimpleScheduler` | `sglang_omni_v1/models/qwen3_omni/stages.py:704-783` |
+| Local v1 encoder copies that should disappear after parity | `sglang_omni_v1/models/qwen3_omni/components/{image_encoder.py,audio_encoder.py}` |
+| Upstream `Qwen3OmniMoeThinkerForConditionalGeneration` exposes `get_audio_feature` and inherits `get_image_feature` / `get_video_feature` from Qwen3-VL | `sglang-workspace/sglang/python/sglang/srt/models/qwen3_omni_moe.py:438-492`, `sglang/python/sglang/srt/models/qwen3_vl.py:1193-1226` |
+| Upstream Qwen3-Omni audio encoder uses `ColumnParallelLinear` + `RowParallelLinear` — TP comes for free | `sglang/python/sglang/srt/models/qwen3_omni_moe.py:49-124` |
+| `MMEncoder.__init__` is the canonical encoder-only init sequence and **always** initializes distributed, regardless of `tp_size` | `sglang/python/sglang/srt/disaggregation/encode_server.py:184-244` |
+| `get_tp_group()` asserts `_TP is not None` — every model that uses `ColumnParallelLinear` / `RowParallelLinear` requires `initialize_model_parallel()` to have run, including at `tp_size=1` | `sglang/python/sglang/srt/distributed/parallel_state.py:1476-1483` |
+| `ServerArgs.encoder_only / language_only / mm_enable_dp_encoder` already exist | `sglang/python/sglang/srt/server_args.py:782-811` |
+| `MultimodalDataItem` is the upstream input contract | `sglang/python/sglang/srt/managers/schedule_batch.py:204-358` |
+| `broadcast_pyobj(data, rank, group, src)` is the upstream TP-CPU-group fan-out helper | `sglang/python/sglang/srt/utils/common.py:1264-1310` |
+
+### Directory Layout
+
+Target additions only — no existing module is moved:
+
+```text
+sglang_omni_v1/
+|-- scheduling/
+|   `-- encoder_scheduler.py        # TP-aware scheduler for encoder stages [NEW]
+|-- model_runner/
+|   `-- sglang_encoder_worker.py    # Minimal SGLang-native encoder worker [NEW]
+`-- models/
+    `-- qwen3_omni/
+        |-- encoder_adapters.py     # v1 <-> SGLang adapter (with BatchPlan) [NEW]
+        `-- stages.py               # Backend switch in encoder factories [MODIFIED]
+```
+
+`encoder_adapters.py` becomes the per-model convention.
+
+### Class Diagram
+
+```text
+              +------------------+
+              |       Stage      |
+              |  single/leader/  |
+              |     follower     |
+              +--------+---------+
+                       |
+                       v
+              +------------------+
+              |  EncoderScheduler|
+              | inbox/outbox     |
+              | metadata bcast   |  <- TP CPU group
+              | tensor bcast     |  <- TP device group
+              +--------+---------+
+                       |
+                       v
+              +------------------+         +-----------------------+
+              | SGLangEncoderWor.|<------- |    EncoderAdapter     |
+              | server_args      |         | build_batch(msgs) ->  |
+              | model_config     |         |   BatchPlan           |
+              | tp_group         |         | run_feature(model,    |
+              | model            |         |   plan) -> raw        |
+              | encode_batch()   |         | slice_results(raw,    |
+              +--------+---------+         |   plan, msgs) -> ...  |
+                       |                   +-----------------------+
+                       v
+            upstream SGLang Qwen3-Omni model
+            thinker.get_image_feature
+            thinker.get_video_feature
+            thinker.get_audio_feature
+```
+
+## Inputs Across TP Ranks
+
+This is the section the earlier draft missed. It is the load-bearing contract
+of the whole RFC.
+
+### Why followers need their own input fan-out
+
+In v1, `Stage._on_data_ready()` is the only path that materializes a
+`StagePayload`: it reads `relay_io.read_payload(...)`, which fetches the
+tensor blobs the upstream stage wrote into the relay and re-attaches them
+into the payload `data` dict tree (`relay_io.py:170-200`). For TP encoder
+stages:
+
+- Only the leader has a ZMQ recv endpoint and a relay reader. Followers'
+  control plane is `TPFollowerControlPlane` (`pipeline/tp_control.py:59-117`),
+  which only handles `Shutdown/Profiler/Abort`.
+- `Stage._drain_outbox_follower` (`stage/runtime.py:490-508`) actively
+  refuses any external traffic from follower ranks.
+
+So when an `image_encoder` request arrives, only the leader's
+`scheduler.inbox` ever receives an `IncomingMessage`. Followers' inboxes
+stay empty unless the **scheduler itself** ships the inputs to them.
+
+### Why `broadcast_pyobj` of the whole message is wrong
+
+A naive `broadcast_pyobj(messages, ..., cpu_group, src=0)` would pickle the
+entire `StagePayload`, including pixel-value tensors that can be hundreds of
+MB or several GB for long video. That:
+
+- pickles GPU tensors (slow, requires `.cpu()` first),
+- ships the result through a CPU communicator (defeats the whole reason we
+  use NCCL on the device),
+- conflates control-plane traffic with data-plane traffic.
+
+### Two-channel broadcast contract
+
+`EncoderScheduler._recv_messages()` runs on every rank and uses **two
+channels** to mirror v1's existing relay split (`relay_io.py:106` already
+does the metadata/tensor extraction we need):
+
+1. **Metadata over the TP CPU group.** On the entry rank, drain the local
+   inbox and run `extract_tensors(msg.data.data)` on each
+   `IncomingMessage`. That returns `(metadata_dict_no_tensors,
+   tensor_dict_path_to_tensor)`. Replace each message's payload `data` with
+   the tensor-free metadata dict, attach a parallel `_tensor_specs` list
+   describing every extracted tensor's `path`, `shape`, `dtype`. Then
+   `broadcast_pyobj(metadata_messages, rank, tp_cpu_group, src=0)`. This
+   pickles only the dict skeleton, not tensor payloads.
+
+2. **Tensors over the TP device group, on GPU.** For each tensor in the
+   entry rank's `tensor_dict`, do `dist.broadcast(tensor,
+   src=tp_group.ranks[0], group=tp_group.device_group)`. Followers
+   pre-allocate empty tensors matching the broadcast `_tensor_specs` on
+   `cuda:<local 0>` and call the matching `dist.broadcast` to receive into
+   them. After all tensors are received, followers run
+   `restore_tensors(metadata, tensor_dict)` to rebuild the payload `data`
+   and reconstitute the `IncomingMessage` list.
+
+### Tensor placement contract (Phase 0)
+
+The default v1 relay backend is `shm`, and `_resolve_relay_config` in
+`pipeline/mp_runner.py:228-240` deliberately does **not** inject `gpu_id`
+into the relay config when the backend is shm — shm copies into host
+shared memory, so the leader's reconstructed payload tensors live on
+**CPU**. NCCL `dist.broadcast` over the TP device group requires CUDA
+tensors on the local rank's device. Therefore the contract is:
+
+- **Leader**, before broadcasting: for every tensor extracted from the
+  payload, run `t = t.to(self.worker.device, non_blocking=True)` (where
+  `self.worker.device` is `cuda:0` after the per-process
+  `CUDA_VISIBLE_DEVICES` remap). Then `dist.broadcast(t, src,
+  group=tp.device_group)`. Stash the device-resident tensor back into the
+  `tensor_dict` so `restore_tensors` reattaches the GPU copy, not the
+  original CPU one.
+- **Followers**, before broadcasting: allocate the placeholder via
+  `torch.empty(spec.shape, dtype=spec.dtype, device=self.worker.device)`
+  and broadcast into it.
+
+Why this direction:
+
+1. The forward pass needs every pixel-values / feature tensor on GPU
+   anyway. Doing the H2D copy here, before the broadcast, costs the same
+   memcpy that `Qwen3OmniImageEncoder.forward` already does today
+   (`models/qwen3_omni/components/image_encoder.py:154`); it is **not**
+   extra work.
+2. NCCL broadcast over a 1 GiB pixel buffer is bandwidth-bound on NVLink
+   (~250 GB/s on H200) and finishes in milliseconds. The alternative —
+   broadcasting CPU tensors via `gloo` over `tp.cpu_group` — pushes the
+   bytes through host memory + ethernet/IPC and is at least an order of
+   magnitude slower for the typical long-video workload that motivates
+   this RFC.
+3. Keeping the broadcast on the device group also matches what upstream
+   SGLang does for `MultimodalDataItem.feature` inside `MMEncoder`: items
+   are reconstructed on `cuda:gpu_id` before any TP collective runs
+   (`disaggregation/encode_server.py:222-244`).
+
+If a future model integrates a non-shm relay (`nccl`, `nixl`) that already
+delivers GPU tensors, the leader-side `.to(device)` becomes a no-op.
+
+This is structurally identical to upstream `relay_io.write_payload` /
+`read_payload`, just over the SGLang TP collectives instead of the relay
+backend, so that the data plane stays on the GPU bus and the metadata
+stays small.
+
+### Sketch
+
+```python
+import torch.distributed as dist
+from sglang.srt.utils import broadcast_pyobj
+from sglang_omni_v1.pipeline.relay_io import extract_tensors, restore_tensors
+
+
+_RECV_ERROR_KIND = "encoder_recv_error"  # picklable string tag
+
+
+def _recv_messages(
+    self,
+) -> tuple[list[IncomingMessage], BaseException | None]:
+    """Drain inbox and broadcast inputs to TP followers.
+
+    Never raises — returns (messages, error). The error is non-None if
+    either rank failed during this iteration's recv. Drained messages
+    are returned even on entry-rank failure so the scheduler can emit
+    request-level errors against them in the unified handshake.
+
+    Always run _strip_and_lift, even at tp_size == 1: the default shm
+    relay delivers CPU tensors and upstream get_image_feature() /
+    get_video_feature() only call .type(dtype), not .to(device).
+    """
+    if self.worker.tp_size == 1:
+        # Cost-capped collect — same admission control SimpleScheduler
+        # uses (max_batch_size / max_batch_wait_ms / max_batch_cost).
+        # The TP path needs identical caps, otherwise long-video
+        # batches that the local image encoder rejects today would
+        # silently flow through and OOM in _strip_and_lift or forward.
+        local = self._collect_batch_from_inbox()
+        if not local:
+            return local, None
+        try:
+            meta_msgs, tensor_lists, specs_lists = self._strip_and_lift(local)
+        except Exception as exc:                          # noqa: BLE001
+            return local, exc
+        return self._reattach_lifted_tensors(meta_msgs, tensor_lists, specs_lists), None
+
+    tp = self.worker.tp_group
+    src_rank = tp.ranks[0]
+
+    if self.worker.is_entry_rank:
+        # Cost cap runs on the entry rank only — the broadcast below
+        # ships the entry rank's already-bounded `local` list to
+        # followers, so all ranks see the same admission decision.
+        local = self._collect_batch_from_inbox()
+        # _collect_batch_from_inbox is queue gets + cost-cap arithmetic
+        # — no device work, no failure mode worth handshaking.
+        # _strip_and_lift does the H2D copy + dtype coercion that can
+        # OOM / TypeError; that's the failure we have to tell followers
+        # about *before* the metadata broadcast, otherwise they block
+        # on it forever and the runner can't see it
+        # (mp_runner.py:332-342 only catches exit-code failures).
+        try:
+            meta_msgs, tensor_lists, specs_lists = self._strip_and_lift(local)
+        except Exception as exc:                          # noqa: BLE001
+            # Picklable tagged dict — survives broadcast_pyobj's
+            # pickle.dumps / pickle.loads round-trip
+            # (sglang utils/common.py:1286, 1309). Identity-based
+            # sentinels (e.g. `object()`) would not, since pickle
+            # reconstructs a fresh instance on each follower.
+            broadcast_pyobj(
+                [{"kind": _RECV_ERROR_KIND, "error": repr(exc)}],
+                tp.rank, tp.cpu_group, src=src_rank,
+            )
+            return local, exc
+
+        # specs_lists describes every tensor's (path, shape, dtype) only.
+        # tensor_lists holds the GPU-resident tensors lifted from CPU shm.
+        broadcast_pyobj(
+            [meta_msgs, specs_lists],
+            tp.rank, tp.cpu_group, src=src_rank,
+        )
+
+        # Allocation-ready handshake — see "Allocation-ready gather"
+        # note below. Entry rank's tensors are already on device from
+        # _strip_and_lift, so its allocation step is a no-op; it still
+        # has to participate in the gather so any follower OOM unwinds
+        # both ranks before the device broadcast fires.
+        ok_flags = self._allocation_ready_gather(local_ok=True)
+        if not all(ok_flags):
+            return local, RuntimeError("peer-rank tensor allocation failed")
+
+        for tensor_list in tensor_lists:
+            for t in tensor_list:
+                dist.broadcast(t, src=src_rank, group=tp.device_group)
+        return (
+            self._reattach_lifted_tensors(meta_msgs, tensor_lists, specs_lists),
+            None,
+        )
+
+    # follower path
+    payload = broadcast_pyobj([], tp.rank, tp.cpu_group, src=src_rank)
+    if (
+        payload
+        and isinstance(payload[0], dict)
+        and payload[0].get("kind") == _RECV_ERROR_KIND
+    ):
+        return [], RuntimeError(
+            f"entry rank failed before metadata broadcast: {payload[0]['error']}"
+        )
+    meta_msgs, specs_lists = payload
+
+    # Allocation-ready handshake: pre-allocate every receive tensor
+    # *before* any device broadcast, then synchronize success across
+    # ranks. If any rank's allocation fails (typically OOM on a long
+    # video pixel buffer), every rank skips the device broadcast loop
+    # and returns an error tuple. Without this gather, a follower OOM
+    # mid-loop would leave the entry rank stuck waiting on the
+    # corresponding `dist.broadcast` receiver.
+    placeholders: list[list[torch.Tensor]] = []
+    alloc_err: BaseException | None = None
+    try:
+        for specs in specs_lists:
+            placeholders.append(
+                [
+                    torch.empty(spec.shape, dtype=spec.dtype,
+                                device=self.worker.device)
+                    for spec in specs
+                ]
+            )
+    except Exception as exc:                              # noqa: BLE001
+        alloc_err = exc
+
+    ok_flags = self._allocation_ready_gather(local_ok=alloc_err is None)
+    if not all(ok_flags):
+        # Either local OOM or peer OOM — either way no rank issues
+        # the device broadcast, so neither side blocks. Surface the
+        # local error if we have one, otherwise a peer-failure stub.
+        return [], (
+            alloc_err if alloc_err is not None
+            else RuntimeError("peer-rank tensor allocation failed")
+        )
+
+    rebuilt: list[IncomingMessage] = []
+    for meta_msg, specs, ph_list in zip(meta_msgs, specs_lists, placeholders):
+        tensor_dict = {}
+        for spec, t in zip(specs, ph_list):
+            dist.broadcast(t, src=src_rank, group=tp.device_group)
+            tensor_dict[spec.path] = t
+        meta_msg.data.data = restore_tensors(meta_msg.data.data, tensor_dict)
+        rebuilt.append(meta_msg)
+    return rebuilt, None
+
+
+def _allocation_ready_gather(self, *, local_ok: bool) -> list[bool]:
+    """Gather per-rank allocation-success flags on the TP CPU group."""
+    flags = [False] * self.worker.tp_size
+    dist.all_gather_object(
+        flags, local_ok, group=self.worker.tp_group.cpu_group,
+    )
+    return flags
+
+
+def _emit_error(
+    self, messages: list[IncomingMessage], error: BaseException
+) -> None:
+    """Emit one OutgoingMessage(type="error") per drained request.
+
+    Required because v1's existing schedulers expose a *single-request*
+    helper (e.g. SimpleScheduler._emit_error(request_id: str, ...) at
+    `scheduling/simple_scheduler.py:111`). Reusing that signature here
+    would put a list[IncomingMessage] into OutgoingMessage.request_id,
+    and Stage._drain_outbox_external (`pipeline/stage/runtime.py:466`)
+    would TypeError on `out.request_id not in self._active_requests`
+    (set membership requires hashable). Iterate explicitly:
+    """
+    for msg in messages:
+        self.outbox.put(
+            OutgoingMessage(
+                request_id=msg.request_id,
+                type="error",
+                data=error,
+            )
+        )
+```
+
+The error sentinel is a **picklable tagged dict**, not an `object()`
+identity sentinel. `broadcast_pyobj` does a full
+`pickle.dumps`/`pickle.loads` round-trip
+(`sglang/python/sglang/srt/utils/common.py:1286, 1309`); singleton
+identity does not survive that, but `dict.get("kind") == "encoder_recv_error"`
+does. The collective itself is the same `broadcast_pyobj` call
+followers were already going to await, so the error rides the
+existing channel.
+
+`_recv_messages` deliberately **never raises**. Returning
+`(messages, error)` lets the scheduler treat a recv-time failure
+exactly like a forward-time failure: same `local_err` slot, same
+`all_gather_object` handshake, same `_emit_error(messages, exc)`
+emission against the drained requests. If `_recv_messages` raised
+instead, the scheduler thread would die and `Stage._handle_scheduler_crash`
+(`pipeline/stage/runtime.py:145`) would tear the whole stage down —
+turning a single bad request into a stage-level abort.
+
+#### Allocation-ready gather
+
+The metadata `broadcast_pyobj` only synchronizes *what to receive*,
+not *whether the receivers are ready*. The follower then has to call
+`torch.empty(spec.shape, ..., device=cuda:0)` for every incoming
+tensor, and on a long-video / multi-image batch that allocation can
+OOM. Naïvely starting `dist.broadcast` from the entry rank
+immediately after the metadata broadcast hits a deadlock in that
+case: a follower OOMs mid-allocation and aborts its receive loop,
+while the entry rank is already blocked inside an unmatched
+`dist.broadcast` call.
+
+Plan B inserts an `all_gather_object`-style "alloc ok?" handshake
+between the metadata broadcast and the first `dist.broadcast`:
+
+1. Followers pre-allocate **all** receive tensors up front (fail
+   fast if any spec OOMs).
+2. The entry rank participates in the gather as a no-op (its
+   tensors already exist).
+3. Both ranks gather their per-rank alloc-success boolean on
+   `tp.cpu_group`.
+4. If `not all(flags)`, every rank returns
+   `(messages, error)` and the scheduler's outer `all_gather_object`
+   handshake takes care of the rest — no device broadcast was ever
+   issued, so no rank blocks.
+
+This is a small, picklable collective added once per recv, and it
+makes the device broadcast loop unconditionally safe to enter once
+it starts.
+
+`_strip_and_lift` calls `extract_tensors`, then for each extracted tensor
+runs `t = t.to(self.worker.device, non_blocking=True)` and records
+`(path, shape, dtype)` into a small `_TensorSpec` dataclass. The metadata
+broadcast pickles only the spec list, not the tensors. `_reattach_lifted_tensors`
+runs `restore_tensors` on the entry rank with the GPU-resident tensors so
+that the entry rank's downstream `BatchPlan` sees the same device-resident
+tensors the followers will reconstruct.
+
+> **Why keep typed `_TensorSpec` instead of reusing the placeholder.**
+> The placeholder dict `extract_tensors` produces stringifies dtype
+> and device (`relay_io.py:48-49`: `"dtype": str(obj.dtype)` →
+> `"torch.float16"`, not the `torch.dtype` object). Follower-side
+> `torch.empty(shape, dtype=placeholder["dtype"], device=...)` would
+> raise `TypeError: dtype must be a torch.dtype`. The implementation
+> PR has two options: (a) carry a typed `_TensorSpec(path, shape,
+> dtype: torch.dtype)` alongside `meta_msgs` as the sketch shows, or
+> (b) introduce a string-to-`torch.dtype` parser and walk the
+> placeholders directly. (a) is simpler and avoids one more parsing
+> failure mode; the apparent "double bookkeeping" is the price of
+> having `torch.dtype` objects on both sides without a parser.
+
+### Why this is safe at the contract level
+
+- `relay_io.extract_tensors` already walks dict trees that contain
+  `pixel_values`, `image_grid_thw`, `pixel_values_videos`, `video_grid_thw`,
+  `input_features`, `feature_attention_mask`, `audio_feature_lengths`. It
+  is the same recursive structure preprocessing produces (`models/qwen3_omni/components/preprocessor.py`)
+  and the same one `merge_for_thinker()` consumes.
+- `tp_group.cpu_group` and `tp_group.device_group` are exactly the two
+  groups SGLang's `OmniScheduler` already uses (`scheduling/omni_scheduler.py:336-360`),
+  so we are not introducing new collectives.
+- The broadcast is deterministic given identical input, so each rank can
+  build the exact same `BatchPlan` independently after the broadcast lands.
+
+## EncoderScheduler
+
+### Public contract
+
+```python
+class EncoderScheduler:
+    inbox: queue.Queue[IncomingMessage]
+    outbox: queue.Queue[OutgoingMessage]
+
+    def start(self) -> None: ...
+    def stop(self) -> None: ...
+    def abort(self, request_id: str) -> None: ...
+```
+
+The same shape as every other v1 scheduler — `Stage` does not need a
+scheduler-type branch.
+
+### Constructor
+
+```python
+class EncoderScheduler:
+    def __init__(
+        self,
+        worker: "SGLangEncoderWorker",
+        adapter: "EncoderAdapter",
+        *,
+        max_batch_size: int = 32,
+        max_batch_wait_ms: int = 50,
+        request_cost_fn: Callable[[Any], int] | None = None,
+        max_batch_cost: int | None = None,        # activation_budget_bytes
+    ):
+        self.worker = worker
+        self.adapter = adapter
+        self.inbox = queue.Queue()
+        self.outbox = queue.Queue()
+        self._max_batch_size = max(int(max_batch_size), 1)
+        self._max_batch_wait_s = max(float(max_batch_wait_ms), 0.0) / 1000.0
+        self._request_cost_fn = request_cost_fn
+        self._max_batch_cost = (
+            max(int(max_batch_cost), 0) if max_batch_cost is not None else None
+        )
+        self._pending_messages: collections.deque[IncomingMessage] = collections.deque()
+        self._running = False
+```
+
+The four batch-shaping knobs (`max_batch_size`, `max_batch_wait_ms`,
+`request_cost_fn`, `max_batch_cost`) are intentionally identical to
+`SimpleScheduler`'s — see `scheduling/simple_scheduler.py:38-49`. v1's
+local image-encoder path already wires these (`models/qwen3_omni/stages.py:738-744`)
+and the cost model has been tuned to keep activation peaks below OOM
+on H200; the SGLang path must inherit the same admission control,
+otherwise long-video / high-concurrency workloads will OOM during
+forward even though the encoder is sharded.
+
+### Loop
+
+```python
+def start(self) -> None:
+    self._running = True
+    while self._running:
+        # ----------------------------------------------------------
+        # Per-iteration error boundary covering recv, build_batch,
+        # encode_batch, and slice_results. _recv_messages never
+        # raises — it returns (messages, error) so a recv-time
+        # failure can flow through the same handshake as a
+        # forward-time failure. All four steps are deterministic
+        # given the broadcast-equal `messages`; any one failing
+        # without rank-sync would leave peers stuck at the next
+        # collective.
+        # ----------------------------------------------------------
+        results = None
+        local_err: BaseException | None = None
+
+        messages, recv_err = self._recv_messages()
+        if recv_err is not None:
+            local_err = recv_err
+        elif not messages:
+            self._idle_check()
+            continue
+        else:
+            try:
+                plan = self.adapter.build_batch(messages)        # all ranks
+                raw = self.worker.encode_batch(plan)             # all ranks
+                if self.worker.is_entry_rank:
+                    results = self.adapter.slice_results(raw, plan, messages)
+            except Exception as exc:                             # noqa: BLE001
+                local_err = exc
+
+        # Synchronize error state across ranks. all_gather_object
+        # marshals the picklable error flag; the exception object
+        # itself stays local. tp_size==1 short-circuits.
+        if self.worker.tp_size > 1:
+            err_flags: list[bool] = [False] * self.worker.tp_size
+            dist.all_gather_object(
+                err_flags,
+                local_err is not None,
+                group=self.worker.tp_group.cpu_group,
+            )
+            any_err = any(err_flags)
+        else:
+            any_err = local_err is not None
+
+        if any_err:
+            if self.worker.is_entry_rank:
+                # Emit one error per request that was drained on the
+                # entry rank this iteration. `messages` is the entry
+                # rank's drained list — populated even on recv-time
+                # failure thanks to the (messages, error) return.
+                self._emit_error(
+                    messages,
+                    local_err if local_err is not None
+                    else RuntimeError("peer-rank encoder forward failed"),
+                )
+            # Followers do nothing here — Stage._drain_outbox_follower
+            # already discards results. The next loop iteration starts
+            # a fresh collective.
+            continue
+
+        if self.worker.is_entry_rank and results is not None:
+            for msg, out in zip(messages, results):
+                self.outbox.put(
+                    OutgoingMessage(request_id=msg.request_id, type="result", data=out)
+                )
+```
+
+### Batch admission control
+
+`_collect_batch_from_inbox()` runs on the entry rank (single-rank case
+included) and applies the three caps before the broadcast:
+
+```python
+def _collect_batch_from_inbox(self) -> list[IncomingMessage]:
+    """Drain the inbox into a cost-bounded batch (entry rank only)."""
+    first = self._next_message()                # blocks until a message or stop
+    if first is None:
+        return []
+    if first.type != "new_request":
+        # stream chunks / done signals are not batched here
+        return [first]
+
+    batch = [first]
+    batch_cost = self._message_cost(first)
+    deadline = time.monotonic() + self._max_batch_wait_s
+    while len(batch) < self._max_batch_size:
+        try:
+            msg = self.inbox.get_nowait()
+        except queue.Empty:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                msg = self.inbox.get(timeout=remaining)
+            except queue.Empty:
+                break
+        if msg.type != "new_request":
+            self._pending_messages.append(msg)
+            continue
+        if self._max_batch_cost is not None:
+            cost = self._message_cost(msg)
+            if batch_cost + cost > self._max_batch_cost:
+                self._pending_messages.appendleft(msg)
+                break
+            batch_cost += cost
+        batch.append(msg)
+    return batch
+
+def _message_cost(self, msg: IncomingMessage) -> int:
+    if self._request_cost_fn is None or msg.type != "new_request":
+        return 0
+    return max(int(self._request_cost_fn(msg.data)), 0)
+```
+
+This is the same control flow as `SimpleScheduler._collect_batch` —
+intentionally so, to keep parity with the local fallback. The cost
+function takes a `StagePayload` and returns a byte estimate; it is the
+same `_create_image_encoder_request_cost_fn(model)` pattern v1 already
+uses (`models/qwen3_omni/stages.py:144-166`).
+
+### Where admission control runs in `_recv_messages`
+
+`_collect_batch_from_inbox` is the **single point of truth** for the
+admission decision: it runs only on the entry rank (or in the
+single-rank case), and the broadcast that follows ships the
+already-bounded list to followers. If both ranks ran the cost cap
+independently, divergent decisions would desync the broadcast
+structure — followers must never touch the inbox.
+
+The single canonical sketch lives in
+[Two-channel broadcast contract](#two-channel-broadcast-contract)
+above; both lanes there call `_collect_batch_from_inbox()`. There is
+no separate "admission-control variant" of `_recv_messages`.
+
+### Responsibilities
+
+1. Drain the stage inbox **on the entry rank only**. Entry rank is rank 0
+   inside the SGLang TP group, matching `OmniScheduler.is_entry_rank`.
+2. Broadcast metadata + tensors to follower ranks via the two-channel
+   contract above.
+3. Build a deterministic `BatchPlan` on all ranks using `adapter.build_batch`.
+4. Run `worker.encode_batch(plan)` on every rank. Forward executes the
+   upstream encoder; SGLang's `ColumnParallelLinear` / `RowParallelLinear`
+   issue collectives internally.
+5. Emit `OutgoingMessage` to the outbox **only on the entry rank**.
+6. Run a **per-iteration error boundary** covering all four steps
+   (`_recv_messages`, `build_batch`, `encode_batch`, `slice_results`)
+   on every rank. `_recv_messages` returns `(messages, error)`
+   instead of raising; the other three are wrapped in try/except.
+   After the four steps, every rank exchanges its `local_err is None`
+   flag through `dist.all_gather_object` on the TP CPU group. If any
+   rank failed, the entry rank emits **one
+   `OutgoingMessage(type="error")` per drained request** (so HTTP-500
+   propagates per request, matching v1's existing request-level
+   error path), and every rank `continue`s into the next loop
+   iteration. Followers do **not** raise to crash the scheduler
+   thread; that would trigger `Stage._handle_scheduler_crash`
+   (`pipeline/stage/runtime.py:145`) and tear the whole stage down,
+   which is a stage-level abort, not the request-level error this
+   contract promises. `MultiProcessPipelineRunner._monitor_children`
+   is the fallback only for cases where a process actually exits
+   non-zero (e.g. a segfault inside the upstream model), not for
+   request-level encoder errors.
+
+### Why a new scheduler instead of extending SimpleScheduler
+
+`SimpleScheduler` is the minimal "inbox -> fn -> outbox" runner used by
+preprocessing, decode, code2wav, and any non-upstreamed local encoder. It is
+deliberately single-process and TP-unaware. Two reasons not to fold TP into
+it:
+
+- **Mixed responsibility.** A scheduler that sometimes broadcasts and
+  sometimes doesn't is the kind of conditional that grows accidental
+  coupling. Keeping the two shapes separate keeps `SimpleScheduler` honest.
+- **Different state model.** Encoder TP requires owning the SGLang TP CPU
+  group, the SGLang TP device group, and the SGLang-loaded model.
+  `SimpleScheduler` is an opaque callable wrapper. Fusing them would force
+  every `SimpleScheduler` user to know about TP groups they never use.
+
+`SimpleScheduler` stays as-is and remains the fallback path for
+non-upstreamed encoders.
+
+## SGLangEncoderWorker
+
+`SGLangEncoderWorker` is a minimal SGLang-native encoder worker. It does
+**not** start `MMEncoder` or any HTTP server: v1 already owns
+preprocessing, control plane, relay, request lifecycle, and cache metadata.
+The worker only owns SGLang's distributed state and the loaded upstream
+encoder model.
+
+### What we reuse from upstream
+
+Patterned after `disaggregation/encode_server.py:184-244` (we copy the
+calls, not the surrounding ZMQ/cache/transfer-engine machinery):
+
+- `ServerArgs(encoder_only=True, ...)` + `set_global_server_args_for_scheduler`
+- `ModelConfig.from_server_args(server_args)`
+- `LoadConfig(load_format, download_dir, model_loader_extra_config,
+  remote_instance_weight_loader_seed_instance_ip,
+  remote_instance_weight_loader_seed_instance_service_port,
+  remote_instance_weight_loader_send_weights_group_ports)` — full upstream
+  argument set, see [LoadConfig fidelity](#loadconfig-fidelity).
+- `init_distributed_environment(backend, world_size=tp_size, rank,
+  distributed_init_method=..., local_rank=...)`
+- `initialize_model_parallel(tensor_model_parallel_size=tp_size)`
+- `initialize_dp_attention(server_args, model_config)`
+- `get_model(model_config=..., load_config=..., device_config=...)`
+- `get_tp_group()` for the TP CPU + device groups used by
+  `EncoderScheduler`.
+
+### GPU placement across `tp_size=1` and `tp_size>1` lanes
+
+This is a load-bearing detail because v1's per-process CUDA env remap
+in `pipeline/stage_process.py:222-249` is gated on `tp_size > 1`. The
+contract Plan B requires is:
+
+> The SGLangEncoderWorker process always sees exactly one CUDA device
+> as `cuda:0`, regardless of `tp_size`. The configured physical GPU is
+> mapped onto `cuda:0` by the launcher before `torch` is imported.
+> Worker code uses `cuda_device=0`, `dist_local_rank=tp_rank` (which is
+> `0` when `tp_size=1`).
+
+This is the contract that lines up with how SGLang internally treats
+`local_rank`:
+
+- `init_distributed_environment` does **not** call
+  `torch.cuda.set_device(local_rank)`
+  (`distributed/parallel_state.py:1665-1745` only does
+  `torch.distributed.init_process_group` and stores `local_rank` into
+  the `GroupCoordinator`).
+- `GroupCoordinator` uses `local_rank` two ways
+  (`parallel_state.py:260-271`):
+  1. **Device selection** — `device_id = 0 if SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS
+     else local_rank`. The env var must be set, otherwise SGLang reads
+     `local_rank` as a CUDA index.
+  2. **Local-master identity** — `local_rank` becomes
+     `GroupCoordinator.local_rank` and is read by callers as a
+     `[0, world_size)` identity:
+     - `custom_all_reduce_utils.py:280` —
+       `get_world_group().local_rank == 0` decides who runs the P2P
+       cache bootstrap. If every rank's `local_rank` is non-zero,
+       no rank runs it.
+     - `model_loader/weight_utils.py:812-820` —
+       `sorted_files[local_rank::local_world_size]` shards checkpoint
+       prefetch by node-local rank. A `local_rank=4, world_size=1`
+       slice silently picks zero files instead of all files.
+
+This rules out the earlier "`dist_local_rank = gpu_id` at `tp_size=1`"
+shortcut: it would correctly select `cuda:gpu_id` via SGLang's device
+fallback, but it would inject `gpu_id` (e.g. 4) into the
+local-master / shard-index slot, which is undefined for
+`world_size=1`.
+
+#### Required launcher change
+
+`backend="sglang"` stages — including `tp_size=1` — must reach the
+worker through a process whose `CUDA_VISIBLE_DEVICES` has been remapped
+to a single physical GPU and whose `SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS=true`
+is set, exactly as `_prepare_cuda_environment` already does for
+`tp_size>1`.
+
+The Phase-0 PR therefore extends the launcher path:
+
+1. `StageProcessSpec` gains a flag, `single_visible_device: bool = False`
+   (default preserves current behaviour for SimpleScheduler /
+   OmniScheduler stages).
+2. `MultiProcessPipelineRunner._build_stage_groups` sets the flag from
+   the **resolved** factory args **before spawning the child process**.
+   `_resolve_factory_args` (`config/compiler.py:138-158`) merges
+   `runtime_overrides` over `stage_cfg.factory_args`, so we must read
+   from the merged result, not raw `StageConfig.factory_args`:
+
+   ```python
+   base_factory_args = _resolve_factory_args(stage_cfg, config)  # already line 73
+   spec.single_visible_device = (
+       base_factory_args.get("backend", "local") in {"sglang", "auto"}
+   )
+   ```
+
+   Reading `stage_cfg.factory_args.get("backend")` directly would miss
+   the case where the user flips a stage to `backend="sglang"` via
+   `PipelineConfig.runtime_overrides` (CLI / config-file path) without
+   editing the StageConfig itself, leaving `single_visible_device=False`
+   while the worker still expects to be the only visible CUDA device.
+
+   The runner cannot wait for `_resolve_backend(...)` because that runs
+   inside the factory in the child process, after `torch` is imported.
+   `CUDA_VISIBLE_DEVICES` must be set before that, so the launcher
+   takes the conservative pre-spawn decision: any stage whose resolved
+   factory args request `backend="sglang"` **or** `backend="auto"` gets
+   the remap, even if `_resolve_backend("auto", ...)` later falls back
+   to `"local"`. That fallback case is harmless — the local HF tower
+   defaults to `device="cuda"` (current device) and runs on the only
+   visible GPU, which is the configured physical id by construction.
+   `backend="local"` (explicit) keeps the current "see all GPUs" behaviour
+   so existing single-process SimpleScheduler stages are untouched.
+3. `pipeline/stage_process.py:get_stage_process_env` changes its early
+   return:
+
+   ```python
+   if spec.tp_size <= 1 and not spec.single_visible_device:
+       return {}
+   ```
+
+   The rest of the function — `CUDA_VISIBLE_DEVICES` remap, the two
+   SGLANG env vars, and the `factory_args["gpu_id"] = 0` rewrite in
+   `_prepare_cuda_environment` — runs unchanged.
+4. `serve/launcher.py` forces multi-process mode whenever any stage
+   asks for the SGLang backend, even if every stage is on the same
+   GPU and every `tp_size == 1`. The current condition
+   (`launcher.py:149-150`) is
+
+   ```python
+   needs_mp = len(gpu_ids) > 1 or any_tp
+   ```
+
+   which routes a single-stage, single-GPU `backend="sglang", tp_size=1`
+   pipeline through `compile_pipeline()` instead of
+   `MultiProcessPipelineRunner`. That single-process path constructs
+   `Stage` and calls the factory (`config/compiler.py:65-72`) inside
+   the **launcher process itself**, never crossing
+   `StageProcessSpec` / `_prepare_cuda_environment`, so:
+
+   - The single-visible-device remap from step 1 never fires —
+     `gpu=4, tp_size=1` would silently load the encoder on physical
+     GPU 0 because the worker fixes `cuda_device=0`.
+   - Multiple `SGLangEncoderWorker` instances in the same process would
+     fight over the global `init_distributed_environment` state, which
+     is module-level inside SGLang and can only be initialized once
+     per process.
+
+   The fix is to extend the condition:
+
+   ```python
+   any_sglang_backend = any(
+       _resolve_factory_args(s, pipeline_config).get("backend", "local")
+       in {"sglang", "auto"}
+       for s in pipeline_config.stages
+   )
+   needs_mp = len(gpu_ids) > 1 or any_tp or any_sglang_backend
+   ```
+
+   Reading from the resolved factory args matches the same source the
+   `single_visible_device` flag uses (step 2), so a `runtime_overrides`
+   flip is honored.
+5. `config/compiler.py:compile_pipeline` rejects any stage whose
+   resolved `factory_args["backend"]` is `"sglang"` or `"auto"`,
+   **and** any stage with `stage_cfg.tp_size > 1`. The single-process
+   compile path is by construction incompatible with the SGLang
+   encoder worker (no per-rank subprocess) and equally unable to
+   honor TP for **any** factory: `_resolve_factory_args` only injects
+   `model_path` / `gpu_id`, never `tp_rank` / `tp_size` /
+   `nccl_port` (`config/compiler.py:138-158`). A direct
+   `compile_pipeline(config_with_thinker_tp=2)` call would silently
+   instantiate the thinker factory with its default `tp_size=1` — TP
+   completely lost, no error. The blanket `tp_size > 1` reject turns
+   that silent downgrade into an early `ValueError`. This does not
+   regress thinker / talker / encoder TP under `serve/launcher.py`
+   because `any_tp → needs_mp` (`launcher.py:149`) routes those
+   configs to `MultiProcessPipelineRunner` before `compile_pipeline`
+   is even called.
+6. **TP preflight reject (two-layer)** in
+   `MultiProcessPipelineRunner._build_stage_groups`:
+
+   ```python
+   _TP_LAUNCH_PARAMS = {"tp_rank", "tp_size", "nccl_port"}
+
+   for stage_cfg in pipeline_config.stages:
+       if stage_cfg.tp_size <= 1:
+           continue
+       factory = import_string(stage_cfg.factory)
+       params = inspect.signature(factory).parameters
+
+       # Layer 1: any TP stage's factory must accept the TP launch
+       # kwargs that mp_runner is about to inject.
+       missing = _TP_LAUNCH_PARAMS - params.keys()
+       if missing:
+           raise ValueError(
+               f"Stage {stage_cfg.name!r}: tp_size={stage_cfg.tp_size} > 1 "
+               f"but factory {stage_cfg.factory!r} does not accept TP "
+               f"launch parameters {sorted(missing)}. This factory is "
+               f"not TP-capable; reduce tp_size to 1 or use a factory "
+               f"that accepts tp_rank/tp_size/nccl_port."
+           )
+
+       # Layer 2: if the factory is a backend-aware encoder factory,
+       # only backend="sglang" implements actual TP.
+       if "backend" in params:
+           resolved = _resolve_factory_args(stage_cfg, pipeline_config)
+           backend = resolved.get("backend", "local")
+           if backend != "sglang":
+               raise ValueError(
+                   f"Stage {stage_cfg.name!r}: tp_size={stage_cfg.tp_size} "
+                   f"requires backend='sglang' (got {backend!r}). "
+                   f"The local encoder path does not implement TP and "
+                   f"would silently spawn TP-rank processes that each "
+                   f"run a full local forward, with all but rank 0 "
+                   f"discarded."
+               )
+   ```
+
+   The two layers cover distinct failure modes:
+
+   - **Layer 1** catches "factory has no idea about TP". Example: a
+     `SimpleScheduler` callable like
+     `create_aggregate_executor()` (no TP params in signature)
+     mis-configured with `tp_size=2`. Without this layer, the
+     launcher would still hit `any_tp → needs_mp`, spawn N
+     subprocesses, then fail in each child either at factory
+     argument-binding time (mp_runner injects `tp_rank/tp_size/nccl_port`
+     kwargs the factory does not accept → `TypeError`) or — if the
+     factory uses `**kwargs` — at follower-IO time when the stage
+     can't actually fan-out batches. Layer 1 fails loud in the main
+     process before any spawn.
+   - **Layer 2** catches "factory has a backend knob but the user
+     left it on local". Encoder factories accept `backend` *and*
+     `tp_rank/tp_size/nccl_port`, so Layer 1 alone would pass them
+     through; Layer 2 enforces that TP only happens when the user
+     explicitly opts into the SGLang backend.
+
+   Concrete pass / fail matrix:
+
+   | factory                             | tp_size | backend | result |
+   |---|---|---|---|
+   | thinker / talker (TP params, no `backend`) | 2 | n/a | passes |
+   | image_encoder (TP params + `backend`)      | 2 | "sglang" | passes |
+   | image_encoder (TP params + `backend`)      | 2 | "local" / "auto" / unset | rejects (Layer 2) |
+   | aggregate / preprocessing (no TP params)    | 2 | n/a | rejects (Layer 1) |
+   | any factory                                  | 1 | any | passes |
+
+#### Backend resolution contract
+
+All four launcher-side checks above (`single_visible_device` flag in
+`mp_runner`, `needs_mp` in `serve/launcher`, `compile_pipeline`
+reject) read the stage's backend through one and only one source:
+
+```python
+_resolve_factory_args(stage_cfg, config).get("backend", "local")
+```
+
+`_resolve_factory_args` (`config/compiler.py:138-158`) merges
+`stage_cfg.factory_args` with `config.runtime_overrides[stage.name]`
+and only injects `model_path` / `gpu_id` from the factory signature.
+**It deliberately does not introspect any other factory signature
+defaults.** The implication is load-bearing:
+
+- The factory function's `backend` signature default is irrelevant to
+  the launcher decision.
+- A StageConfig that wants the SGLang backend **must** put
+  `backend="sglang"` (or `"auto"`) into `factory_args` or
+  `runtime_overrides`. Relying on a future signature-default flip
+  would silently desync launcher (`"local"`) from factory body
+  (`"auto"`).
+- Tests for any of the launcher checks should provide a StageConfig
+  with explicit `factory_args["backend"]` set, never lean on signature
+  defaults.
+
+After this change, `SGLangEncoderWorker` sees `cuda:0` in both lanes
+and the worker's GPU placement collapses to one rule:
+
+```python
+cuda_device = 0
+dist_local_rank = tp_rank        # 0 in tp_size=1 lane, [0, tp_size) in tp>1
+```
+
+`base_gpu_id`, `set_device`, `DeviceConfig.gpu_id`, `self.device`, and
+`local_rank` all use these two values directly.
+
+Phase 1 parity testing must:
+
+- exercise a non-zero `gpu` at `tp_size=1` (e.g. `gpu=4`) and assert
+  three things at once: the child's
+  `os.environ["CUDA_VISIBLE_DEVICES"] == "4"` (the launcher remap fired),
+  `next(model.parameters()).device.index == 0` (the model loaded onto
+  the only visible CUDA device, which appears as `cuda:0` from inside
+  the child), and `get_world_group().local_rank == 0` (the
+  local-master / shard-index slot is the rank 0 we asked for, not the
+  physical GPU id);
+- exercise `tp_size=2` and assert `get_world_group().local_rank` is
+  unique per rank (0 and 1, not 0 and 0).
+
+### Distributed init is unconditional
+
+Upstream `MMEncoder.__init__` is unconditional — `init_distributed_environment`
+runs even at `tp_size=1`. SGLang's parallel layers (`ColumnParallelLinear`
+/ `RowParallelLinear`) call `get_tp_group()` during their own `__init__`,
+and `get_tp_group()` asserts the group has been initialized
+(`parallel_state.py:1482`). Skipping init at `tp_size=1` would crash at
+model load time with `tensor model parallel group is not initialized`.
+
+`SGLangEncoderWorker` therefore initializes distributed state **always**:
+
+```python
+class SGLangEncoderWorker:
+    def __init__(
+        self,
+        *,
+        model_path: str,
+        gpu_id: int,
+        tp_rank: int,
+        tp_size: int,
+        nccl_port: int | None,
+        dtype: str | None = None,
+        load_format: str | None = None,
+        server_args_overrides: dict[str, Any] | None = None,
+    ):
+        self.tp_rank = tp_rank
+        self.tp_size = tp_size
+        self.is_entry_rank = (tp_rank == 0)
+
+        # tp_size=1 also gets a real init: see `Distributed init is
+        # unconditional`.  Use a free-port loopback when the parent did not
+        # allocate one (single-rank case).
+        #
+        # SGLang's ServerArgs.dist_init_addr expects `host:port`
+        # (NetworkAddress.parse, network.py:474), and ServerArgs internally
+        # composes the `tcp://` URL via NetworkAddress.to_tcp() when it
+        # needs one (network.py:437). torch.distributed, however, expects
+        # the full `tcp://host:port` URL. Keep the two forms separate.
+        port = nccl_port if nccl_port is not None else _pick_free_port()
+        dist_addr = f"127.0.0.1:{port}"               # for ServerArgs
+        dist_init_method = f"tcp://{dist_addr}"       # for torch init
+
+        # See "GPU placement across tp_size=1 and tp_size>1 lanes" for
+        # why this collapses to (0, tp_rank) once the launcher remaps
+        # CUDA_VISIBLE_DEVICES in both lanes.
+        cuda_device = 0
+        dist_local_rank = tp_rank
+        self.device = torch.device(f"cuda:{cuda_device}")
+
+        # Worker-managed kwargs that build_sglang_encoder_server_args is
+        # about to receive as explicit positional/keyword arguments.
+        # We must reject these in `server_args_overrides` BEFORE the
+        # **splat below — otherwise Python raises TypeError "got multiple
+        # values for keyword argument" before our helper's protected-key
+        # check ever runs.
+        overrides = dict(server_args_overrides or {})
+        worker_managed = {
+            "model_path", "tp_size", "base_gpu_id", "dist_init_addr",
+            "dtype", "load_format",
+        }
+        clobbered = sorted(worker_managed & overrides.keys())
+        if clobbered:
+            raise ValueError(
+                f"server_args_overrides cannot set worker-managed keys "
+                f"{clobbered}. These are derived from StageConfig and "
+                f"factory parameters; pass them through StageConfig "
+                f"(model_path, tp_size, gpu, dtype, load_format) instead."
+            )
+
+        server_args = build_sglang_encoder_server_args(
+            model_path=model_path,
+            tp_size=tp_size,
+            base_gpu_id=cuda_device,
+            dist_init_addr=dist_addr,             # host:port for SGLang
+            dtype=dtype,
+            load_format=load_format,
+            **overrides,                          # forwards model_loader_extra_config etc.
+        )
+        set_global_server_args_for_scheduler(server_args)
+
+        self.model_config = ModelConfig.from_server_args(server_args)
+        # Full upstream LoadConfig argument set
+        # (matches disaggregation/encode_server.py:202-208).
+        self.load_config = LoadConfig(
+            load_format=server_args.load_format,
+            download_dir=server_args.download_dir,
+            model_loader_extra_config=server_args.model_loader_extra_config,
+            remote_instance_weight_loader_seed_instance_ip=(
+                server_args.remote_instance_weight_loader_seed_instance_ip
+            ),
+            remote_instance_weight_loader_seed_instance_service_port=(
+                server_args.remote_instance_weight_loader_seed_instance_service_port
+            ),
+            remote_instance_weight_loader_send_weights_group_ports=(
+                server_args.remote_instance_weight_loader_send_weights_group_ports
+            ),
+        )
+
+        torch.cuda.set_device(cuda_device)
+
+        # Always run, including tp_size == 1.
+        # `local_rank` here is identity (used for local-master checks),
+        # NOT a CUDA index. Passing tp_rank lets followers see themselves
+        # as non-zero local_rank in custom_all_reduce_utils.py:280 and
+        # friends. Device selection is governed by
+        # SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS in the tp>1 lane.
+        init_distributed_environment(
+            backend=get_default_distributed_backend("cuda"),
+            world_size=tp_size,
+            rank=tp_rank,
+            distributed_init_method=dist_init_method,   # tcp://host:port for torch
+            local_rank=dist_local_rank,
+        )
+        initialize_model_parallel(tensor_model_parallel_size=tp_size)
+        initialize_dp_attention(server_args, self.model_config)
+        self.tp_group = get_tp_group()
+
+        self.model = get_model(
+            model_config=self.model_config,
+            load_config=self.load_config,
+            device_config=DeviceConfig(device="cuda", gpu_id=cuda_device),
+        )
+
+    @torch.no_grad()
+    def encode_batch(self, plan: "BatchPlan") -> Any:
+        return plan.adapter.run_feature(self.model, plan)
+```
+
+### `build_sglang_encoder_server_args`
+
+The existing `build_sglang_server_args` (`scheduling/sglang_backend/server_args_builder.py:10`)
+is shaped for AR engines: it requires a positional `context_length` and
+defaults `mem_fraction_static=0.7`, `max_running_requests=16`,
+`max_prefill_tokens=16384`. None of those have a clean meaning for
+encoder-only stages (no KV pool, no AR running queue, no prefill token
+budget). Reusing the AR builder also fails at runtime because Phase 0's
+factory does not know a meaningful `context_length` for the encoder
+process.
+
+We therefore add a sibling helper next to the AR builder:
+
+```python
+# sglang_omni_v1/scheduling/sglang_backend/server_args_builder.py
+
+# Worker invariants that must NOT be reachable from server_args_overrides.
+# Mutating these would either invalidate GPU placement, change the
+# parallelism axis we promised, or flip the encoder-vs-language-only
+# fork. See "GPU placement..." and Open Question 2 (encoder DP).
+_ENCODER_PROTECTED_KEYS = frozenset({
+    # Parallelism / placement
+    "tp_size",
+    "pp_size",
+    "dp_size",
+    "moe_dp_size",
+    "ep_size",
+    "attn_cp_size",
+    "moe_dense_tp_size",
+    "nnodes",
+    "node_rank",
+    "base_gpu_id",
+    "dist_init_addr",
+    # Encoder-only fork
+    "encoder_only",
+    "language_only",
+    "mm_enable_dp_encoder",
+    "enable_dp_attention",
+    "enable_dp_attention_local_control_broadcast",
+    "enable_dp_lm_head",
+    "disable_cuda_graph",
+    "device",
+    # AR-only knobs that have no meaning for an encoder-only worker.
+    # Locked so users cannot reintroduce SGLang AR memory semantics
+    # through server_args_overrides — the encoder path explicitly does
+    # not own a KV pool, an AR running queue, or a chunked-prefill
+    # budget, and any value set here would be silently accepted by
+    # ServerArgs but would diverge from what the worker actually does.
+    "mem_fraction_static",
+    "max_running_requests",
+    "max_prefill_tokens",
+    "chunked_prefill_size",
+    "context_length",
+})
+
+
+def build_sglang_encoder_server_args(
+    model_path: str,
+    *,
+    tp_size: int,
+    base_gpu_id: int,
+    dist_init_addr: str,
+    dtype: str | None = None,
+    load_format: str | None = None,
+    **overrides: Any,
+) -> ServerArgs:
+    """ServerArgs configured for an encoder-only worker.
+
+    Distinct from build_sglang_server_args because encoder stages do not
+    have a meaningful context_length / mem_fraction_static / running queue.
+
+    Raises ValueError if `overrides` tries to mutate a protected
+    invariant (parallelism shape, GPU placement, encoder-only fork).
+    """
+    bad = sorted(_ENCODER_PROTECTED_KEYS & overrides.keys())
+    if bad:
+        raise ValueError(
+            f"server_args_overrides cannot override protected keys: {bad}. "
+            f"These are decided by the worker / pipeline runner; pass them "
+            f"through StageConfig (tp_size, gpu) instead."
+        )
+
+    kwargs: dict[str, Any] = {
+        "model_path": model_path,
+        "trust_remote_code": True,
+        "tp_size": tp_size,
+        "pp_size": 1,
+        "base_gpu_id": base_gpu_id,
+        "dist_init_addr": dist_init_addr,
+        "encoder_only": True,
+        "language_only": False,
+        "mm_enable_dp_encoder": False,    # MVP: TP only; see Open Questions
+        "disable_cuda_graph": True,       # variable shapes; no piecewise CG yet
+        "random_seed": 123,
+    }
+    if dtype is not None:
+        kwargs["dtype"] = dtype
+    if load_format is not None:
+        kwargs["load_format"] = load_format
+    kwargs.update(overrides)
+    return ServerArgs(**kwargs)
+```
+
+The protected-key reject covers:
+
+- `tp_size`, `pp_size`, `dp_size`, `moe_dp_size`, `ep_size`,
+  `attn_cp_size`, `moe_dense_tp_size`, `nnodes`, `node_rank`,
+  `base_gpu_id`, `dist_init_addr` — pipeline runner decides these from
+  `StageConfig.tp_size` / `gpu` and the per-stage NCCL port allocator.
+  Phase 0 starts exactly `tp_size` local ranks; DP, EP, attention-CP, and
+  multinode shapes are out of scope and cannot be activated through
+  `server_args_overrides`.
+- `encoder_only` / `language_only` — flipping these would route through
+  a different upstream model factory and break the whole RFC.
+- `mm_enable_dp_encoder` — Phase 0–2 require encoder TP only; allowing
+  this through `overrides` would silently violate the rejection rule
+  the factory layer also enforces.
+- `enable_dp_attention`, `enable_dp_attention_local_control_broadcast`,
+  `enable_dp_lm_head` — these change SGLang's data-parallel collective
+  layout while the v1 launcher still only constructs the TP group
+  described in this RFC.
+- `disable_cuda_graph` — Phase 0 requires variable shapes; piecewise
+  CUDA graph for encoder ViT lands later (PR #15320 / #16785 area).
+- `device` — `SGLangEncoderWorker` hardcodes `DeviceConfig(device="cuda", ...)`
+  and `get_default_distributed_backend("cuda")`. Letting `overrides`
+  flip `ServerArgs.device` to `cpu/npu/xpu/mps` (the values
+  `server_args.py:1218-1244` recognizes) would split the two: SGLang's
+  internals would think the worker is on CPU/NPU while we still issue
+  CUDA distributed calls. Cross-backend encoder support is a separate
+  workstream and should not be reachable through a one-line override.
+
+Loader / processor knobs (`model_loader_extra_config`,
+`remote_instance_weight_loader_*`, `disable_fast_image_processor`, etc.)
+are **not** protected and pass through unchanged via
+`server_args_overrides` — those are exactly the fields users need to
+forward for FP8 / NVFP4 / remote-streaming deployments. `dtype` and
+`load_format` are also supported, but as top-level factory / worker
+arguments rather than `server_args_overrides`, to avoid duplicate keyword
+binding before the protected-key helper runs.
+
+`SGLangEncoderWorker.__init__` calls this helper directly. AR-only
+knobs (`mem_fraction_static`, `max_running_requests`,
+`max_prefill_tokens`, `chunked_prefill_size`, `context_length`) are
+intentionally absent from the helper signature **and** are listed in
+`_ENCODER_PROTECTED_KEYS` so they are also unreachable through
+`server_args_overrides`. `ServerArgs` falls back to its own defaults
+for those AR fields, and the encoder-only code path never reads them
+— protecting them keeps a stale-AR-knob from silently propagating
+into `ServerArgs` even though the worker ignores it.
+
+### LoadConfig fidelity
+
+`SGLangEncoderWorker.__init__` constructs `LoadConfig` with the same six
+fields upstream `MMEncoder.__init__` does
+(`disaggregation/encode_server.py:202-208`):
+
+```python
+LoadConfig(
+    load_format=server_args.load_format,
+    download_dir=server_args.download_dir,
+    model_loader_extra_config=server_args.model_loader_extra_config,
+    remote_instance_weight_loader_seed_instance_ip=(
+        server_args.remote_instance_weight_loader_seed_instance_ip
+    ),
+    remote_instance_weight_loader_seed_instance_service_port=(
+        server_args.remote_instance_weight_loader_seed_instance_service_port
+    ),
+    remote_instance_weight_loader_send_weights_group_ports=(
+        server_args.remote_instance_weight_loader_send_weights_group_ports
+    ),
+)
+```
+
+Why all six, not just `load_format` + `download_dir`:
+
+- `model_loader_extra_config` carries quant-config overrides, custom
+  loader plugins, and extra-file paths. Some Qwen3-Omni internal
+  deployments depend on it for FP8 / NVFP4 weight files.
+- The three `remote_instance_weight_loader_*` fields wire SGLang's
+  remote-instance weight-streaming protocol. If a SGLang deployment uses
+  remote weight streaming for the LLM, the encoder process should
+  participate too; passing the fields keeps that path open.
+
+`build_sglang_encoder_server_args` therefore accepts these values via its
+`**overrides`. Phase 0 default behavior matches a local checkpoint load —
+the four extra fields default to `None`/empty in `ServerArgs`, so users
+who don't use these features pay nothing. Users who do can add them
+through `factory_args` and they reach `LoadConfig` unchanged.
+
+### Why not subclass / instantiate `MMEncoder`
+
+`MMEncoder` does much more than what we need: ZMQ schedule socket, mooncake
+transfer engine, multimodal cache, embedding-to-send queue, async send
+timeout, image processor on GPU. Every one of those duplicates work v1
+already owns. Importing the whole class would make us its consumer plus
+re-implementer. Reading the lower half of `MMEncoder.__init__` and copying
+just the eight calls listed above is genuinely smaller and lets v1 keep
+ownership of the request lifecycle. (See
+[Open Questions](#open-questions) about whether SGLang main should expose a
+small `EncoderModelWorker` helper to remove the copy.)
+
+## EncoderAdapter and BatchPlan
+
+The earlier draft tried to flow `list[MultimodalDataItem]` through
+`run_feature`, but `build_items` returns one such list **per request**, so
+the batched call was implicitly `list[list[MultimodalDataItem]]` and the
+per-modality filter inside `run_feature` was wrong-typed. The corrected
+contract goes through an explicit `BatchPlan`.
+
+### Skip / cache semantics (from preprocessor)
+
+The preprocessor does **not** drop missing modalities — it stamps each
+encoder stage's `encoder_inputs` slot with a sentinel:
+
+```python
+encoder_inputs["audio_encoder"] = {"_skip": True, "_result": {}}    # missing-modality
+encoder_inputs["audio_encoder"] = {..., "cache_key": "..."}         # cacheable
+encoder_inputs["audio_encoder"] = {..."input_features": tensor, ...} # active
+```
+
+(See `models/qwen3_omni/components/preprocessor.py:454-468` and
+`models/qwen3_omni/request_builders.py:36-53`.)
+
+The current local v1 path consumes this through `build_encoder_request()`,
+which returns an `EncoderRequestData(model_inputs, cache_key,
+skip_result)`. When `skip_result is not None` the local
+`_run_single_encoder_payload` short-circuits and never touches tensors.
+**The SGLang adapter must do the same**, otherwise the very common
+"image-only" request will `KeyError` on
+`inputs["input_features"]` inside the audio_encoder stage, and "audio-only"
+will `KeyError` inside the image_encoder stage.
+
+The adapter therefore enters through `build_encoder_request()`, not raw
+`encoder_inputs`, and the `BatchPlan` carries per-request skip results so
+that:
+
+- Skip requests never contribute `MultimodalDataItem` to the active items.
+- `run_feature` sees only active items, with the option of an empty list.
+  When the entire batch is skip-only (e.g. a text-only batch arriving at
+  audio_encoder during co-routing), `run_feature` returns
+  `{"image": None, "video": None, "audio": None}` and never calls into
+  the upstream model.
+- `slice_results` returns the preserved `skip_result` for skip requests
+  and slices the raw embedding for active requests.
+
+Cache (`cache_key`) is intentionally **not** wired into the SGLang path in
+Phase 0: a TP-aware cache requires the entry rank to broadcast the
+hit/miss decision before forward, otherwise rank A hitting and rank B
+missing would corrupt the collective. Cache becomes a Phase 2+ follow-up
+once the adapter is stable; until then SGLang path passes through every
+non-skip request to forward, and the existing local path keeps its cache.
+
+### Types
+
+```python
+@dataclass(slots=True)
+class _TensorSpec:
+    path: str
+    shape: tuple[int, ...]
+    dtype: torch.dtype
+
+@dataclass(slots=True)
+class RequestSpan:
+    """Slot for one request inside a batch.
+
+    Exactly one of skip_result or active_offsets is populated.
+    """
+    request_id: str
+    skip_result: dict | None = None        # preserved from preprocessor _skip
+    image_rows: int = 0                    # number of image MM items contributed
+    video_rows: int = 0
+    audio_rows: int = 0
+    image_token_count: int = 0             # for visual splitting
+    video_token_count: int = 0
+    # Audio splitting: keep both the *unpadded* per-request feature lengths
+    # (passed back to merge_for_thinker as `audio_feature_lengths`) and the
+    # downsampled output lengths used to slice the encoder output along the
+    # token axis.
+    audio_feature_lengths: torch.Tensor | None = None
+    audio_output_lengths: torch.Tensor | None = None
+
+@dataclass(slots=True)
+class BatchPlan:
+    adapter: "EncoderAdapter"
+    image_items: list[MultimodalDataItem]   # flat across active requests only
+    video_items: list[MultimodalDataItem]
+    audio_items: list[MultimodalDataItem]
+    spans: list[RequestSpan]                # one per request, in input order
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.image_items or self.video_items or self.audio_items)
+```
+
+### Adapter protocol
+
+```python
+class EncoderAdapter(Protocol):
+    stage_name: str
+
+    def build_batch(
+        self,
+        messages: list[IncomingMessage],
+    ) -> BatchPlan: ...
+
+    def run_feature(
+        self,
+        model: Any,
+        plan: BatchPlan,
+    ) -> dict[str, torch.Tensor | None]: ...
+        # returns {"image": ..., "video": ..., "audio": ...}
+        # any modality not present in the plan is None
+
+    def slice_results(
+        self,
+        raw: dict[str, torch.Tensor | None],
+        plan: BatchPlan,
+        messages: list[IncomingMessage],
+    ) -> list[StagePayload]: ...
+```
+
+### Image / video adapter
+
+```python
+def build_batch(self, messages):
+    images: list[MultimodalDataItem] = []
+    videos: list[MultimodalDataItem] = []
+    spans: list[RequestSpan] = []
+    for msg in messages:
+        state = PipelineState.from_dict(msg.data.data)
+        request = build_encoder_request(state, stage_name="image_encoder")
+
+        # Phase-0: respect preprocessor _skip; cache_key is ignored.
+        if request.skip_result is not None:
+            spans.append(RequestSpan(
+                request_id=msg.request_id,
+                skip_result=request.skip_result,
+            ))
+            continue
+
+        inputs = request.model_inputs
+        n_img = n_vid = 0
+        img_tokens = vid_tokens = 0
+        if isinstance(inputs.get("pixel_values"), torch.Tensor):
+            it = MultimodalDataItem(modality=Modality.IMAGE,
+                                    feature=inputs["pixel_values"])
+            it.image_grid_thw = inputs["image_grid_thw"]
+            images.append(it)
+            n_img = int(inputs["image_grid_thw"].shape[0])
+            img_tokens = int(
+                (inputs["image_grid_thw"].prod(-1) // self._merge).sum().item()
+            )
+        if isinstance(inputs.get("pixel_values_videos"), torch.Tensor):
+            v = MultimodalDataItem(modality=Modality.VIDEO,
+                                   feature=inputs["pixel_values_videos"])
+            v.video_grid_thw = inputs["video_grid_thw"]
+            videos.append(v)
+            n_vid = int(inputs["video_grid_thw"].shape[0])
+            vid_tokens = int(
+                (inputs["video_grid_thw"].prod(-1) // self._merge).sum().item()
+            )
+        spans.append(RequestSpan(
+            request_id=msg.request_id,
+            image_rows=n_img, video_rows=n_vid,
+            image_token_count=img_tokens,
+            video_token_count=vid_tokens,
+        ))
+    return BatchPlan(self, images, videos, [], spans)
+
+
+def run_feature(self, model, plan):
+    if plan.is_empty:
+        return {"image": None, "video": None, "audio": None}
+    image_embed = (
+        model.thinker.get_image_feature(plan.image_items)
+        if plan.image_items else None
+    )
+    video_embed = (
+        model.thinker.get_video_feature(plan.video_items)
+        if plan.video_items else None
+    )
+    return {"image": image_embed, "video": video_embed, "audio": None}
+
+
+def slice_results(self, raw, plan, messages):
+    out: list[StagePayload] = []
+    img_row = img_tok = vid_row = vid_tok = 0
+    for span, msg in zip(plan.spans, messages):
+        state = PipelineState.from_dict(msg.data.data)
+        if span.skip_result is not None:
+            apply_encoder_result(
+                state, stage_name="image_encoder", result=span.skip_result,
+            )
+            out.append(_payload_with_state(msg.data, state))
+            continue
+
+        result = self._slice_visual(
+            raw["image"], raw["video"], plan, span,
+            img_row, img_tok, vid_row, vid_tok,
+        )
+        img_row += span.image_rows
+        img_tok += span.image_token_count
+        vid_row += span.video_rows
+        vid_tok += span.video_token_count
+        apply_encoder_result(state, stage_name="image_encoder", result=result)
+        out.append(_payload_with_state(msg.data, state))
+    return out
+```
+
+`_slice_visual` reuses the existing `_split_visual_features` /
+`_split_visual_multiscale` helpers from `models/qwen3_omni/stages.py`,
+moved into `encoder_adapters.py` so the SGLang path does not depend on
+private helpers in `stages.py`.
+
+> Note (Cheng): we deliberately keep `get_image_feature` and
+> `get_video_feature` as separate calls. Upstream
+> `Qwen3VLMoeForConditionalGeneration` exposes them as two methods
+> (`qwen3_vl.py:1193, 1212`), and PR #14907 (chunked vit attention) hooks
+> into them at this granularity. Fusing them would silently break that
+> hook.
+
+### Audio adapter
+
+Upstream `get_audio_feature()` (`models/qwen3_omni_moe.py:461-492`) cats
+all `item.feature` along dim 0 in its first line, so different audio
+clips with different time dimensions cannot be passed in raw — the cat
+fails on shape mismatch. v1's local path solves this by padding every
+clip to the batch's max time before cat (`models/qwen3_omni/stages.py:553-659`).
+The SGLang adapter must replicate that contract; the Phase-0 plan is to
+move `_normalize_audio_request_tensors`, `_pad_audio_features`, and
+`_pad_audio_mask` from `stages.py` into `encoder_adapters.py` and reuse
+them — with **one** mandatory fix during the move:
+
+`_normalize_audio_request_tensors` (`stages.py:533`) currently
+synthesizes a fallback mask via
+`torch.arange(time_dim, dtype=torch.long).unsqueeze(0)`, which lands
+on CPU. In the local v1 path that is fine because the helper runs
+before any GPU lift. In the SGLang Plan B path, however,
+`_recv_messages → _strip_and_lift` has already moved
+`audio_feature_lengths` to `cuda:0` before the adapter sees the
+request, so the subsequent `steps < lengths.unsqueeze(1)` mixes a
+CPU `steps` with a GPU `lengths` and raises a device-mismatch error
+on any input that has `audio_feature_lengths` but no
+`feature_attention_mask`.
+
+The moved helper must take its arange device from `lengths`:
+
+```python
+steps = torch.arange(time_dim, dtype=torch.long, device=lengths.device).unsqueeze(0)
+mask = steps < lengths.unsqueeze(1)
+```
+
+This keeps the local v1 path unchanged (lengths is CPU there →
+arange is CPU) while making the SGLang path correct (lengths is
+GPU there → arange follows). After this fix all three helpers are
+device-agnostic and safe to share between paths.
+
+```python
+def build_batch(self, messages):
+    spans: list[RequestSpan] = []
+    normalized: list[dict[str, torch.Tensor]] = []   # active requests only
+
+    for msg in messages:
+        state = PipelineState.from_dict(msg.data.data)
+        request = build_encoder_request(state, stage_name="audio_encoder")
+
+        if request.skip_result is not None:
+            spans.append(RequestSpan(
+                request_id=msg.request_id,
+                skip_result=request.skip_result,
+            ))
+            continue
+
+        # Reuses the v1 helper (after the device-aware fix). Returns
+        # (features [B, mel, time], mask [B, time] bool, lengths [B]
+        # long) on whichever device EncoderScheduler._strip_and_lift
+        # already moved them to — typically `cuda:0` in the SGLang
+        # Plan B path, CPU in the local v1 path. The synthesized
+        # fallback mask now allocates `arange` on `lengths.device`,
+        # so the helper works on either device without surgery.
+        features, mask, lengths = _normalize_audio_request_tensors(request)
+        out_lens = _get_feat_extract_output_lengths(lengths)
+        spans.append(RequestSpan(
+            request_id=msg.request_id,
+            audio_rows=int(lengths.shape[0]),
+            audio_feature_lengths=lengths,         # unpadded, per-request
+            audio_output_lengths=out_lens,
+        ))
+        normalized.append({"features": features, "mask": mask, "lengths": lengths})
+
+    if not normalized:
+        return BatchPlan(self, [], [], [], spans)
+
+    # Pad every active request to the batch-wide max time so torch.cat
+    # inside upstream get_audio_feature succeeds. The padded positions
+    # are masked out by `feature_attention_mask` and discarded inside
+    # `get_audio_feature` via `input_features.permute(0,2,1)[mask.bool()]`.
+    max_time = max(int(item["features"].shape[-1]) for item in normalized)
+    audios: list[MultimodalDataItem] = []
+    for item in normalized:
+        feat = _pad_audio_features(item["features"], max_time)
+        m = _pad_audio_mask(item["mask"], max_time)
+        mm = MultimodalDataItem(modality=Modality.AUDIO, feature=feat)
+        mm.feature_attention_mask = m
+        audios.append(mm)
+    return BatchPlan(self, [], [], audios, spans)
+
+
+def run_feature(self, model, plan):
+    if plan.is_empty:
+        return {"image": None, "video": None, "audio": None}
+    embed = model.thinker.get_audio_feature(plan.audio_items)
+    return {"image": None, "video": None, "audio": embed}
+
+
+def slice_results(self, raw, plan, messages):
+    out: list[StagePayload] = []
+    row = tok = 0
+    for span, msg in zip(plan.spans, messages):
+        state = PipelineState.from_dict(msg.data.data)
+        if span.skip_result is not None:
+            apply_encoder_result(
+                state, stage_name="audio_encoder", result=span.skip_result,
+            )
+            out.append(_payload_with_state(msg.data, state))
+            continue
+
+        token_end = tok + int(span.audio_output_lengths.sum().item())
+        result = {
+            "audio_embeds": raw["audio"][tok:token_end],
+            # Unpadded lengths preserved at build_batch time — we never want
+            # to feed batch-wide padded lengths back to merge_for_thinker.
+            "audio_feature_lengths": span.audio_feature_lengths,
+            "audio_output_lengths": span.audio_output_lengths,
+        }
+        apply_encoder_result(state, stage_name="audio_encoder", result=result)
+        out.append(_payload_with_state(msg.data, state))
+        row += span.audio_rows
+        tok = token_end
+    return out
+```
+
+`_get_feat_extract_output_lengths` is imported directly from
+`sglang/python/sglang/srt/models/qwen3_omni_moe.py`, not re-derived.
+
+### Visual deepstack split
+
+The upstream visual return tensor has last-dim
+`vision_config.out_hidden_size * (1 + len(deepstack_visual_indexes))`
+(confirmed in `disaggregation/encode_server.py:_infer_embedding_dims`):
+
+```python
+out_hs = vision_config.out_hidden_size
+parts = embedding.split(out_hs, dim=-1)            # [base, ds0, ds1, ...]
+base, deepstack = parts[0], list(parts[1:])
+
+result = {
+    "image_embeds": base,
+    "image_grid_thw": image_grid_thw,
+    "image_token_counts": image_grid_thw.prod(-1) // (spatial_merge_size ** 2),
+    "deepstack_visual_embeds_image": deepstack,
+}
+```
+
+This keeps `merge_for_thinker()` and the thinker prefill path stable while
+the encoder implementation changes underneath.
+
+## Pipeline Config
+
+MVP requires no schema change. Encoder TP is expressed entirely in
+`StageConfig`:
+
+```python
+StageConfig(
+    name="image_encoder",
+    factory="sglang_omni_v1.models.qwen3_omni.stages.create_image_encoder_executor",
+    factory_args={
+        "backend": "sglang",
+        "max_batch_size": 32,
+        "max_batch_wait_ms": 50,
+        "weight_memory_fraction": 0.30,
+        "activation_budget_bytes": 20 * 1024**3,
+    },
+    gpu=[0, 1],
+    tp_size=2,
+    next="mm_aggregate",
+    project_payload={
+        "mm_aggregate": (
+            "sglang_omni_v1.models.qwen3_omni.request_builders."
+            "project_encoder_to_mm_aggregate"
+        )
+    },
+)
+```
+
+### Factory contract
+
+```python
+def create_image_encoder_executor(
+    model_path: str,
+    *,
+    # IMPORTANT: this signature default is `"local"` and stays "local"
+    # across all phases. The launcher decides single-vs-multi-process
+    # before the child is spawned by reading
+    # `_resolve_factory_args(stage_cfg, config).get("backend", "local")`,
+    # which only sees `factory_args` + `runtime_overrides` — it does NOT
+    # introspect this signature default (`compiler.py:143-158`). If we
+    # ever changed the default to `"auto"`, a StageConfig that omits
+    # `factory_args["backend"]` would silently disagree: launcher reads
+    # "local" → goes single-process, factory body picks up "auto" →
+    # tries to start an SGLang worker. To switch a deployment to the
+    # SGLang backend, write `factory_args["backend"]="auto"` (or
+    # `"sglang"`) into the StageConfig (or `runtime_overrides`)
+    # explicitly — never rely on this default to flip.
+    backend: Literal["local", "sglang", "auto"] = "local",
+    gpu_id: int = 0,
+    tp_rank: int = 0,
+    tp_size: int = 1,
+    nccl_port: int | None = None,
+    max_batch_size: int = 32,
+    max_batch_wait_ms: int = 50,
+    weight_memory_fraction: float | None = None,
+    activation_budget_bytes: int | None = QWEN3_IMAGE_ENCODER_BATCH_BUDGET_BYTES,
+    server_args_overrides: dict[str, Any] | None = None,
+    device: str = "cuda",
+    dtype: str | None = None,
+    load_format: str | None = None,
+):
+    chosen = _resolve_backend(backend, model_path, stage="image_encoder")
+    if chosen == "sglang":
+        worker = SGLangEncoderWorker(
+            model_path=model_path,
+            gpu_id=gpu_id, tp_rank=tp_rank, tp_size=tp_size, nccl_port=nccl_port,
+            dtype=dtype,
+            load_format=load_format,
+            server_args_overrides=server_args_overrides,
+        )
+        adapter = Qwen3OmniImageEncoderAdapter(...)
+        return EncoderScheduler(
+            worker=worker,
+            adapter=adapter,
+            max_batch_size=max_batch_size,
+            max_batch_wait_ms=max_batch_wait_ms,
+            # Inherit the same cost model as the local path so admission
+            # control is identical across backends. The cost fn must be
+            # cheap (no GPU work) since it runs on every inbox poll.
+            request_cost_fn=adapter.request_cost_fn,
+            max_batch_cost=activation_budget_bytes,
+        )
+    # Fallback: existing local-HF SimpleScheduler path, unchanged
+    return _build_local_image_encoder(model_path, device=device, dtype=dtype, ...)
+```
+
+The audio encoder factory follows the same shape with
+`Qwen3OmniAudioEncoderAdapter`, its own `request_cost_fn`, and
+`activation_budget_bytes` defaulting to the audio-side budget (no
+existing audio cost cap in v1, so the SGLang path can land with
+`max_batch_cost=None` — same as v1's local audio encoder today — and a
+follow-up adds it once a representative cost model is profiled).
+
+### Adapter `request_cost_fn`
+
+Each adapter exposes `request_cost_fn(payload: StagePayload) -> int` so
+the EncoderScheduler can size batches without depending on adapter
+internals. The image cost model from `models/qwen3_omni/stages.py:144-166`
+is the right *shape* — same arithmetic, same calibration constants
+(`QWEN3_IMAGE_ENCODER_ACTIVATION_MULTIPLIER`,
+`QWEN3_IMAGE_ENCODER_BATCH_BUDGET_BYTES`) — but the inputs the SGLang
+adapter feeds it are different from what the local path feeds it, so it
+cannot be reused unchanged.
+
+**The deepstack double-count trap.** v1 local
+`Qwen3OmniImageEncoder.__init__` (`components/image_encoder.py:131-133`)
+sets `self.out_hidden_size = vision_cfg.out_hidden_size` — the *base*
+hidden size — and `self.deepstack_layers = len(vision_cfg.deepstack_visual_indexes)`.
+The v1 cost fn then multiplies by `output_layers = 1 + deepstack_layers`,
+which is correct for the local model.
+
+Upstream SGLang `Qwen3VLMoeVisionModel.__init__`
+(`sglang/python/sglang/srt/models/qwen3_vl.py:334-336`) instead writes
+`self.out_hidden_size = vision_config.out_hidden_size * (1 + len(deepstack_visual_indexes))`
+— deepstack is **already folded** into the wrapper's
+`out_hidden_size`. Reading `model.thinker.visual.out_hidden_size` and
+also multiplying by `(1 + deepstack_layers)` would count deepstack
+twice and produce a budget cap roughly `(1 + deepstack)^2 / (1 + deepstack)`
+times too tight, starving long-video batches.
+
+**Resolution.** The SGLang adapter takes its cost metadata directly
+from the HF `vision_config` (which is the same source v1's local model
+already uses), not from the SGLang model wrapper:
+
+```python
+class Qwen3OmniImageEncoderAdapter:
+    def __init__(self, *, hf_config, dtype: torch.dtype):
+        vision_cfg = hf_config.thinker_config.vision_config
+        self._merge = int(vision_cfg.spatial_merge_size) ** 2
+        self._base_hidden = int(vision_cfg.out_hidden_size)        # NOT the wrapper's
+        self._output_layers = 1 + len(vision_cfg.deepstack_visual_indexes)
+        self._dtype_bytes = torch.empty((), dtype=dtype).element_size()
+
+    def request_cost_fn(self, payload):
+        state = PipelineState.from_dict(payload.data)
+        request = build_encoder_request(state, stage_name="image_encoder")
+        if request.skip_result is not None:
+            return 0
+        inputs = request.model_inputs
+        raw_bytes = _tensor_bytes(inputs.get("pixel_values"))
+        raw_bytes += _tensor_bytes(inputs.get("pixel_values_videos"))
+        visual_tokens = _grid_visual_tokens(inputs.get("image_grid_thw"), self._merge)
+        visual_tokens += _grid_visual_tokens(inputs.get("video_grid_thw"), self._merge)
+        output_bytes = (
+            visual_tokens * self._base_hidden
+            * self._dtype_bytes * self._output_layers
+        )
+        return (raw_bytes + output_bytes) * QWEN3_IMAGE_ENCODER_ACTIVATION_MULTIPLIER
+```
+
+The arithmetic and scaling constants are identical to the local helper
+(`stages.py:144-166`); only the data source moved. `_tensor_bytes` and
+`_grid_visual_tokens` are extracted from `stages.py` into
+`encoder_adapters.py` so neither path imports from the other.
+
+The audio adapter's `request_cost_fn` returns 0 in Phase 0 (no v1 audio
+cost model yet), and `max_batch_cost` defaults to None — same admission
+shape as the local audio path today.
+
+`backend="auto"` resolves to `"sglang"` if the upstream model registers a
+matching encoder adapter and `tp_size == 1` baseline parity has passed; else
+`"local"`. `tp_size > 1` is only accepted for `backend="sglang"` in the
+MVP. `backend="local"` with `tp_size > 1` raises a config error.
+
+## TP Launch Lifecycle
+
+For `image_encoder` with `tp_size=2`, end to end:
+
+1. `MultiProcessPipelineRunner._build_stage_groups` reads `tp_size=2` and
+   `gpu=[0, 1]` from the config.
+2. `_NcclPortAllocator.allocate()` picks an unused TCP port.
+3. `_build_tp_stage_specs` mints two `StageProcessSpec` entries: one
+   `role="leader"` for `tp_rank=0/gpu_id=0`, one `role="follower"` for
+   `tp_rank=1/gpu_id=1`. `factory_args` is augmented with
+   `tp_rank/tp_size/nccl_port/gpu_id` and the leader gets
+   `follower_work_queues` / `follower_abort_queues`.
+   (`pipeline/mp_runner.py:164-225`)
+4. `StageGroup.spawn` launches both subprocesses via the spawn context.
+5. Before torch import, `_prepare_cuda_environment` sets
+   `CUDA_VISIBLE_DEVICES` to the mapped device for that rank and rewrites
+   `factory_args["gpu_id"]=0`. (`pipeline/stage_process.py:252-276`)
+6. The factory builds `EncoderScheduler(worker=SGLangEncoderWorker(...))`.
+7. `SGLangEncoderWorker.__init__` always calls
+   `init_distributed_environment(world_size=2, rank=tp_rank,
+   distributed_init_method=f"tcp://127.0.0.1:{nccl_port}")`,
+   `initialize_model_parallel(tensor_model_parallel_size=2)`, then
+   `get_model(...)`. Two processes meet on the NCCL port and form the TP
+   group. **At `tp_size=1` the same calls run with `world_size=1, rank=0,
+   distributed_init_method=tcp://127.0.0.1:<free_port>`.**
+8. `Stage.run()` starts. Leader binds the ZMQ recv endpoint; follower binds
+   `TPFollowerControlPlane`. Both spawn a scheduler thread.
+9. `EncoderScheduler` enters its loop. Leader drains the inbox and uses
+   the two-channel broadcast to ship metadata + tensors to the follower;
+   both run forward; leader emits results to the outbox.
+10. `Stage._drain_outbox_external` (leader) routes the outbox `result`
+    messages to `mm_aggregate` via the relay.
+11. `Stage._drain_outbox_follower` (follower) discards outputs.
+12. Aborts and shutdown go from leader to follower via the existing
+    `TPLeaderFanout` queues.
+
+## Control Plane and Data Plane
+
+External pipeline traffic does not change:
+
+- ZMQ carries `SubmitMessage`, `DataReadyMessage`, `AbortMessage`,
+  `ProfilerStart/Stop`, `ShutdownMessage`. Only the leader binds the recv
+  socket.
+- Relay (SHM / NCCL / NIXL / Mooncake) carries `StagePayload` tensors
+  between logical stages. Only the leader writes / reads relay blobs.
+
+Internal TP traffic is owned by SGLang:
+
+- `EncoderScheduler` metadata broadcast goes over the SGLang TP CPU group
+  via `broadcast_pyobj`.
+- `EncoderScheduler` tensor broadcast goes over the SGLang TP device group
+  via `dist.broadcast(tensor, src, group=tp_group.device_group)`.
+- Encoder forward collectives go over SGLang's GPU TP group via
+  `ColumnParallelLinear` (output-dim shard) and `RowParallelLinear`
+  (input-dim shard, all-reduce). For Qwen3-Omni audio this is layer-wise
+  in `Qwen3OmniMoeAudioEncoderLayer`. For Qwen3-VL/Qwen3-Omni vision this
+  is in `Qwen3_VisionMLP` / `VisionAttention(use_qkv_parallel=True)`.
+
+## Memory Accounting
+
+Encoder stages should not reuse AR `mem_fraction_static` semantics
+directly. For AR runners that controls KV cache allocation after weights
+load; for an encoder-only stage there is no KV pool, so the knob has no
+clean meaning.
+
+MVP behaviour (mirrors v1's existing image-encoder cost model):
+
+```python
+factory_args={
+    "backend": "sglang",
+    "weight_memory_fraction": 0.30,        # admission control vs total VRAM
+    "activation_budget_bytes": 20 * 1024**3, # caps batch formation
+    "max_batch_size": 32,
+    "max_batch_wait_ms": 50,
+}
+```
+
+- `activation_budget_bytes` is plumbed into `EncoderScheduler` as
+  `max_batch_cost`, with the same `request_cost_fn` v1 already uses
+  (`models/qwen3_omni/stages.py:144-166`). We keep that cost model — it
+  was tuned to keep activation peaks below OOM on H200.
+- `weight_memory_fraction` is informational at the StageConfig level and
+  consumed by future co-location admission control. It is **not** passed
+  to SGLang as `mem_fraction_static`. (We pin SGLang's encoder-only path
+  to weights-only allocation.)
+- If both budgets are absent, EncoderScheduler falls back to v1's current
+  defaults (`max_batch_size=32`, `max_batch_wait_ms=50`).
+
+Longer term:
+
+- Replace `weight_memory_fraction` + `activation_budget_bytes` with a typed
+  `StageMemoryConfig`. Make co-location first-class by summing declared
+  budgets per GPU.
+- Decide whether the canonical fraction semantics is "fraction of total
+  VRAM" (vLLM-style) or "fraction of remaining VRAM" (current SGLang AR).
+  Today's v1 mixes them implicitly. Pin the choice **before** TP encoders
+  start sharing GPUs with the thinker.
+
+## Fallback For Encoders Not Upstreamed
+
+Plan B still needs a local path for encoders that do not exist in SGLang
+main (custom Fish audio tokenizer, future Boson audio encoder).
+
+Rules:
+
+1. If an upstream SGLang encoder exists, prefer `backend="sglang"`.
+2. If an encoder is model-specific and not upstreamed, use
+   `backend="local"` and the current `SimpleScheduler` path. No changes
+   there.
+3. `backend="local"` is single-rank-only in the MVP. `tp_size > 1` plus
+   `backend="local"` is rejected at config validation.
+4. If local TP becomes unavoidable for a non-upstreamed encoder, upstream
+   the encoder first unless a production blocker forces the inverse.
+
+This is what the issue asks for: support both modes side by side without
+the pipeline config knowing which mode a stage is in.
+
+## Error Handling
+
+`EncoderScheduler` owns lifecycle errors. Adapters and SGLang encoder
+forwards must not catch broad `Exception`.
+
+Rules:
+
+- `SGLangEncoderWorker.encode_batch` and `EncoderAdapter.run_feature` only
+  catch specific expected exceptions (e.g. `OutOfMemoryError` for batch
+  splitting, if we ever add it). They never catch base `Exception`.
+- `EncoderScheduler.start()` covers **four** steps in one
+  per-iteration error boundary: `_recv_messages`, `build_batch`,
+  `encode_batch`, `slice_results`. `_recv_messages` does not raise —
+  it returns `(messages, error)`. The other three are wrapped in a
+  try/except that funnels into the same `local_err` slot. Each step
+  is deterministic given the broadcast-equal `messages`, but any one
+  failing without rank-sync would leave peers stuck at the next
+  collective.
+- Cross-rank synchronization: after the four steps,
+  `dist.all_gather_object` exchanges a per-rank "did I fail?" boolean
+  on the TP CPU group. If any rank failed, every rank skips
+  emit-results and starts the next iteration on a fresh collective.
+  The entry rank emits one
+  `OutgoingMessage(type="error", data=str(exc))` per request that
+  was drained this iteration (`messages` is non-empty on recv-time
+  failure thanks to the tuple return), which
+  `Stage._drain_outbox_external` converts into a Coordinator failure
+  → HTTP 500. If a follower failed but the entry rank did not, the
+  entry rank emits `RuntimeError("peer-rank encoder forward failed")`
+  against the same drained messages.
+- **Pre-broadcast entry-rank failures**: `_recv_messages` does H2D
+  copies inside `_strip_and_lift` *before* the metadata broadcast. A
+  failure there (OOM, dtype coercion, malformed payload) on the
+  entry rank would leave followers blocked on `broadcast_pyobj`
+  forever — the runner cannot detect this since
+  `MultiProcessPipelineRunner._monitor_children`
+  (`pipeline/mp_runner.py:332-342`) only fires on
+  `StageGroup.any_dead()`, which checks `not is_alive() and exitcode
+  != 0` (`pipeline/stage_group.py:130-132`), and a caught exception
+  keeps the process alive. The fix is internal to `_recv_messages`:
+  the entry rank wraps `_strip_and_lift` in try/except and
+  broadcasts a tagged dict
+  `{"kind": "encoder_recv_error", "error": repr(exc)}` over the
+  same CPU-group `broadcast_pyobj` slot the success path uses, then
+  returns `(local, exc)`. Followers detect the dict by kind-string
+  equality (not identity — pickle round-trip would break that) and
+  return `([], RuntimeError(...))`. Both ranks then converge on the
+  scheduler's per-iteration `all_gather_object` handshake without
+  ever crashing the scheduler thread. No new control channel, no
+  runner-level rescue, no `Stage._handle_scheduler_crash` (the
+  stage-level abort path) involvement.
+- No adapter may return a fake-success embedding (zero tensor, empty list,
+  etc.). v1's broader refactor explicitly disallows that pattern.
+
+This aligns encoder stages with the scheduler-layer error handling
+direction in #188.
+
+## Supported Pipelines
+
+### Qwen3-Omni speech (8-stage)
+
+```text
+preprocessing -> [image_encoder, audio_encoder] -> mm_aggregate -> thinker
+              -> [decode, talker_ar] -> code2wav
+```
+
+- `image_encoder` stage: `backend="sglang", tp_size=N`, `gpu=[g0..gN-1]`.
+- `audio_encoder` stage: same shape, separate stage, separate process
+  group, separate NCCL port. Image and audio encoders run in parallel
+  because the thinker only depends on `mm_aggregate`'s fan-in.
+  `mm_aggregate.wait_for = ["preprocessing", "image_encoder",
+  "audio_encoder"]` already enforces the join.
+
+### Qwen3-Omni text (6-stage)
+
+```text
+preprocessing -> thinker -> decode
+```
+
+No encoder stage runs. No change.
+
+### Fish Audio S2-Pro (3-stage TTS)
+
+```text
+preprocessing -> tts_engine -> vocoder
+```
+
+No multimodal encoder upstream of the AR engine. Plan B does not apply.
+Fish stays on `SimpleScheduler` for preprocessing and `OmniScheduler` for
+`tts_engine`.
+
+### Future MiMo / Ming-Omni
+
+Same pattern as Qwen3-Omni. As long as the upstream SGLang model registers
+encoder methods (`get_image_feature`, etc.) and ships a small
+`encoder_adapters.py` in `sglang_omni_v1/models/<name>/`, the pipeline
+config just sets `backend="sglang"` and `tp_size`.
+
+## Adding A New Model
+
+1. Add `models/<name>/encoder_adapters.py`. Implement `build_batch`,
+   `run_feature`, `slice_results` for each encoder stage.
+2. In `models/<name>/stages.py`, branch the encoder factory on `backend`:
+   `"sglang"` builds `EncoderScheduler(SGLangEncoderWorker(...), adapter)`;
+   `"local"` keeps the existing `SimpleScheduler` path.
+3. In `models/<name>/config.py` (the `PipelineConfig`), set `tp_size` and
+   `gpu=[...]` on the encoder stage.
+4. Validate parity: `backend="local"` vs `backend="sglang", tp_size=1` on
+   the same input. Then bump `tp_size`.
+
+Everything else (`Stage`, `StageGroup`, `Coordinator`, `relay`,
+`EncoderScheduler` itself) is reused without modification.
+`MultiProcessPipelineRunner` and `pipeline/stage_process.py` get the
+small launcher extension described in [Required launcher
+change](#required-launcher-change), which is a one-time addition that
+all sglang-backed encoder stages share.
+
+## Implementation Plan
+
+Phase 0 — landing path that doesn't break v1:
+
+1. **Launcher extension** (`sglang_omni_v1/pipeline/` + `sglang_omni_v1/serve/` + `sglang_omni_v1/config/`).
+   - Add `single_visible_device: bool = False` to `StageProcessSpec`
+     (`pipeline/stage_process.py`).
+   - In `MultiProcessPipelineRunner._build_stage_groups`
+     (`pipeline/mp_runner.py`), set the flag pre-spawn from the resolved
+     `base_factory_args.get("backend") in {"sglang", "auto"}` after
+     `_resolve_factory_args` has merged `runtime_overrides`.
+   - In `get_stage_process_env` (`pipeline/stage_process.py:222`),
+     change the early return to
+     `if spec.tp_size <= 1 and not spec.single_visible_device: return {}`.
+   - In `serve/launcher.py` (`launcher.py:141-150`), extend the
+     `needs_mp` predicate so any stage with resolved `backend in
+     {"sglang", "auto"}` forces `MultiProcessPipelineRunner`, even on a
+     single-GPU / `tp_size=1` pipeline. Without this the launcher
+     short-circuits to `compile_pipeline()` and the worker never gets
+     the per-process CUDA remap.
+   - In `config/compiler.py:compile_pipeline`, reject any stage with
+     resolved `backend in {"sglang", "auto"}` **or**
+     `stage_cfg.tp_size > 1`. The `tp_size > 1` reject is structural:
+     `compile_pipeline` never injects `tp_rank/tp_size/nccl_port`,
+     so any direct caller bypassing `serve/launcher.py` would silently
+     get a `tp_size=1` factory (thinker / talker / encoder all fail
+     this way). It does not regress normal serving because
+     `serve/launcher.py:149` routes any `tp_size > 1` to
+     `MultiProcessPipelineRunner` first.
+   - In `MultiProcessPipelineRunner._build_stage_groups`, run the
+     two-layer TP preflight from rule 6 of
+     [Required launcher change](#required-launcher-change) — Layer 1
+     rejects any TP stage whose factory does not accept
+     `tp_rank/tp_size/nccl_port`; Layer 2 rejects encoder TP stages
+     whose resolved backend is not `"sglang"`.
+
+   These six sub-steps are the load-bearing prerequisite for Phase 1's
+   `tp_size=1, gpu!=0` parity lane to validate the right thing — see
+   [GPU placement across `tp_size=1` and `tp_size>1` lanes](#gpu-placement-across-tp_size1-and-tp_size1-lanes)
+   and [Required launcher change](#required-launcher-change).
+
+   **Per-sub-step unit tests** (so each launcher change can be verified
+   independently of the GPU lane in Phase 1):
+
+   - `single_visible_device` flag: build a `PipelineConfig` with a
+     stage whose `factory_args["backend"] = "sglang"` and assert
+     `_build_stage_groups(...)` produces a `StageProcessSpec` with
+     `single_visible_device=True`; flip backend through
+     `runtime_overrides` and assert the flag still flips
+     (covers the `_resolve_factory_args` source rule).
+   - `get_stage_process_env` early return: spec with `tp_size=1,
+     single_visible_device=False` returns `{}`; same spec with the
+     flag flipped returns the remap env dict.
+   - `needs_mp` predicate: a single-stage / single-GPU /
+     `tp_size=1` config with `backend="sglang"` makes
+     `await launch_pipeline(...)` take the
+     `MultiProcessPipelineRunner` branch (assert by mocking the runner
+     constructor). The same config with `backend="local"` keeps the
+     `compile_pipeline()` branch.
+   - `compile_pipeline` reject: directly calling
+     `compile_pipeline(config_with_sglang_stage)` raises `ValueError`.
+   - **Signature-default trap regression test**: a StageConfig whose
+     `factory_args` does **not** contain a `backend` key, pointing at a
+     factory whose Python signature default is `"auto"`, must still
+     resolve to `"local"` at the launcher (i.e. `needs_mp` stays
+     False, `single_visible_device` stays False, `compile_pipeline`
+     does not raise). This locks the
+     [backend resolution contract](#backend-resolution-contract) and
+     prevents a future signature-default flip from silently bypassing
+     the CUDA isolation.
+   - **Real-factory signature lock**: `import inspect` and assert that
+     `inspect.signature(create_image_encoder_executor).parameters["backend"].default == "local"`
+     and the same for `create_audio_encoder_executor`. The previous
+     test only proves the resolver ignores signature defaults; this
+     one proves the actual production factories never have their
+     default flipped to `"auto"` or `"sglang"` by accident. Cheap to
+     run (no GPU, no model load, just `inspect`) and catches a
+     code-review miss directly.
+   - **TP preflight Layer 2 (encoder factory backend gate)**: build
+     a config where the `image_encoder` stage has `tp_size=2,
+     gpu=[0, 1], factory_args={}` (no backend), call
+     `_build_stage_groups` and assert it raises `ValueError`
+     mentioning the stage name. Then with
+     `factory_args={"backend": "auto"}` — also raises (auto can fall
+     back to local). Then with `factory_args={"backend": "sglang"}`
+     — succeeds. Locks Layer 2 of rule 6 in
+     [Required launcher change](#required-launcher-change).
+   - **TP preflight does NOT regress thinker TP**: build a config
+     where the `thinker` stage has `tp_size=2, gpu=[0, 1]` and no
+     `backend` in `factory_args` (its factory does not accept one,
+     but does accept `tp_rank/tp_size/nccl_port`).
+     `_build_stage_groups` must succeed. Locks Layer 1 of rule 6 —
+     proves the encoder reject is not over-broad.
+   - **TP preflight Layer 1 (factory not TP-capable)**: build a
+     config where some stage uses a SimpleScheduler factory like
+     `create_aggregate_executor` (no `tp_rank/tp_size/nccl_port` in
+     signature) and `tp_size=2`. `_build_stage_groups` must raise
+     `ValueError` listing the missing parameters. This is the case
+     the previous single-layer preflight silently passed through to
+     subprocess spawn.
+   - **`compile_pipeline` rejects `tp_size > 1` directly**: call
+     `compile_pipeline(config_with_thinker_tp_size_2)` (no backend
+     parameter, regular thinker factory) and assert it raises
+     `ValueError`. This is the direct-call regression test — proves
+     a caller bypassing `serve/launcher.py` cannot silently downgrade
+     a TP config to single-rank.
+   - **Allocation-ready gather (mid-recv deadlock guard)**: run
+     `EncoderScheduler` with `tp_size=2` and a fake `torch.empty` on
+     the follower that raises on the **second** spec (so the first
+     allocation succeeds, mimicking partial OOM). Assert (a) entry
+     rank does **not** issue any `dist.broadcast(t, group=device_group)`
+     call (use a mock that records calls); (b) follower returns
+     `(messages, error)` from `_recv_messages` instead of raising;
+     (c) both ranks reach the unified `all_gather_object` handshake
+     with `local_err is not None` on the follower side; (d) the
+     entry rank's drained `local` is forwarded via the tuple return,
+     so `_emit_error(messages, ...)` produces one error message per
+     drained request. Locks the `_allocation_ready_gather` contract.
+   - **Pre-broadcast error sentinel (`_recv_messages` deadlock guard)**:
+     run `EncoderScheduler` with `tp_size=2` and a fake `_strip_and_lift`
+     that raises on the entry rank before the metadata
+     `broadcast_pyobj`. Assert (a) the follower rank does **not**
+     block on `broadcast_pyobj` indefinitely (bounded-time wait with
+     fail-on-timeout); (b) `_recv_messages` returns `(messages, exc)`
+     on **both** ranks rather than raising — entry rank's `messages`
+     equals the drained list, follower's `messages` is `[]`,
+     follower's exception text quotes the entry-rank exception via
+     `repr(exc)`; (c) the scheduler's `all_gather_object` handshake
+     observes both ranks as failed and emits exactly one
+     `OutgoingMessage(type="error")` per drained request on the
+     entry rank (i.e. `len(error_emissions) == len(drained_messages)`,
+     not 0 and not 2× from double-counting); (d) the scheduler thread
+     stays alive and proceeds to the next loop iteration —
+     `Stage._handle_scheduler_crash` must not fire. Locks the
+     tagged-dict sentinel contract and the recv-error tuple return.
+   - **AR-only knob protection — helper level**: directly call
+     `build_sglang_encoder_server_args(model_path=..., tp_size=1,
+     base_gpu_id=0, dist_init_addr="...", mem_fraction_static=0.5)`
+     and assert it raises `ValueError` referencing
+     `mem_fraction_static`. Repeat for `max_running_requests`,
+     `chunked_prefill_size`, `context_length`, `max_prefill_tokens`.
+     This is the helper signature `(..., **overrides)` so the AR knob
+     goes in as a direct keyword.
+   - **AR-only knob protection — factory level**: call
+     `create_image_encoder_executor(...,
+     server_args_overrides={"mem_fraction_static": 0.5})` and assert
+     the `ValueError` propagates from helper through worker
+     `**overrides` splat. This locks the dict-style entry point users
+     actually configure through `StageConfig.factory_args`.
+2. Add `sglang_omni_v1/model_runner/sglang_encoder_worker.py`. Behind
+   `backend="sglang"` only — never the default in this PR.
+3. Add `sglang_omni_v1/scheduling/encoder_scheduler.py` including the
+   two-channel `_recv_messages` and the `BatchPlan` plumbing.
+4. Add `sglang_omni_v1/models/qwen3_omni/encoder_adapters.py` (image +
+   audio).
+5. Update `create_image_encoder_executor()` and
+   `create_audio_encoder_executor()` to accept `backend`, `tp_rank`,
+   `tp_size`, `nccl_port`, `load_format`, `server_args_overrides`. Default
+   `backend="local"` keeps current behaviour.
+6. Add a Qwen3-Omni config variant (`qwen3_omni_encoder_tp.py` or a CLI
+   override) that sets `backend="sglang", tp_size=2`.
+
+Phase 1 — parity validation (gates Phase 2):
+
+7. GPU parity test: `backend="local"` vs `backend="sglang", tp_size=1` on
+   image encoder and audio encoder, in isolation, at a non-zero
+   `gpu` (e.g. `gpu=4`). Asserts the launcher remap took effect:
+   child env has `CUDA_VISIBLE_DEVICES=="4"`,
+   `next(model.parameters()).device.index == 0` (the only visible CUDA
+   device shows up as `cuda:0` inside the child), and
+   `get_world_group().local_rank == 0`.
+8. TP parity test: `backend="sglang", tp_size=1` vs `tp_size=2`, within
+   `atol=1e-3, rtol=1e-3` on float16. Asserts
+   `get_world_group().local_rank` is unique per rank in the `tp_size=2`
+   case.
+9. E2E speech run: long-video request that previously OOM'd on the
+   thinker GPU, run with image+audio encoders sharded to separate GPUs,
+   verify it completes.
+
+Phase 2 — switch new deployments to the SGLang backend:
+
+10. After Phase 1 passes, do **two** changes together:
+    - Change `_resolve_backend("auto", ...)` to return `"sglang"` when
+      the adapter exists.
+    - Update the default Qwen3-Omni `PipelineConfig` template (and any
+      cookbook configs / CLI helpers that build a config) so the
+      `image_encoder` and `audio_encoder` stages have
+      `factory_args={"backend": "auto", ...}` written **explicitly**.
+
+    Do **not** change the factory function's signature default — it
+    stays `"local"` forever. The launcher reads
+    `_resolve_factory_args(...).get("backend", "local")` and only sees
+    `factory_args` + `runtime_overrides`, never the signature default
+    (see [Backend resolution contract](#backend-resolution-contract)).
+    Bumping the signature default would create the "launcher sees
+    local, factory sees auto" mismatch that silently bypasses the
+    single-visible-device remap.
+
+    The launcher already sets `single_visible_device=True` whenever
+    resolved `backend in {"sglang", "auto"}` (Phase 0 step 1), so once
+    the templates explicitly carry `backend="auto"` the rest works.
+
+    **Phase 2 unit test:** load the default Qwen3-Omni
+    `PipelineConfig` (the one returned by the canonical builder /
+    cookbook helper) and assert that the resolved
+    `_resolve_factory_args(image_encoder_stage, config).get("backend")`
+    is exactly `"auto"` — i.e. the value lives in `factory_args`, not
+    in the factory signature. This is the only test that proves Phase
+    2's flip actually crosses the launcher boundary.
+
+Phase 3 — clean up duplicated v1 encoder code:
+
+11. After at least one release with Phase 2 default, delete
+    `sglang_omni_v1/models/qwen3_omni/components/{image_encoder.py,audio_encoder.py}`
+    and the corresponding HF tower instantiation in `stages.py`.
+
+Phase 4 — runtime parameter plumbing (out of scope for the first PR):
+
+12. Replace ad-hoc `weight_memory_fraction` / `activation_budget_bytes`
+    factory args with a typed `StageMemoryConfig`. This is the same
+    "typed stage-addressable override primitive" Cheng called out in the
+    v1 refactor architecture doc.
+
+## Validation
+
+Minimum lanes (unit + GPU + E2E):
+
+- **Unit**
+  - Adapter `build_batch` produces correct `BatchPlan` (flat items + spans)
+    for: image-only, audio-only, image+video same request, multi-request
+    mixed batch.
+  - `slice_results` round-trips a synthetic raw embedding back into the
+    expected per-request `encoder_outs` dict shape.
+  - `EncoderScheduler._recv_messages` mocks the TP groups and confirms
+    that on the entry rank the metadata pickle does not contain tensor
+    payload bytes, while followers reconstruct identical
+    `IncomingMessage` objects after `dist.broadcast`.
+
+- **GPU**
+  - Qwen3-Omni image encoder: `backend="local"` vs `backend="sglang",
+    tp_size=1`, fixed seed, equal output tensors within tolerance.
+    (This is also the lane that exercises single-rank distributed init.)
+  - Qwen3-Omni audio encoder: same.
+  - Qwen3-Omni image+audio encoder: `tp_size=1` vs `tp_size=2`, equal
+    output within tolerance.
+
+- **E2E**
+  - `examples/qwen3_omni_speech.py` long video that previously OOM'd:
+    image encoder `tp_size=2` on GPU [0,1], audio encoder `tp_size=2` on
+    GPU [2,3], thinker on GPU 4, talker on GPU 5, code2wav on GPU 6.
+    End-to-end waveform produced, no OOM.
+
+- **Fault injection**
+  - Force encoder OOM (oversized pixel batch) and verify the request fails
+    through `Coordinator` with HTTP 500 and a non-empty error body.
+    Specifically reject:
+    - `data=None` "success" coming back from `code2wav` (Ming-Omni shape).
+    - zero-tensor "success" coming back from talker (current Qwen3-Omni
+      shape in the bug discussed in #302).
+
+- **Reuse existing CI**
+  - The existing thinker / talker CI (test_qwen3_omni_v1_*.py) must pass
+    unchanged in `backend="local"` mode in Phase 0 and `backend="sglang"`
+    mode in Phase 2.
+
+## Open Questions
+
+1. **Upstream `EncoderModelWorker` helper.** Should we push the eight-call
+   init sequence (`set_global_server_args_for_scheduler` → `ModelConfig` →
+   `LoadConfig` → `init_distributed_environment` →
+   `initialize_model_parallel` → `initialize_dp_attention` → `get_model`
+   → expose `tp_group`) into SGLang main as a public helper class? That
+   would delete `SGLangEncoderWorker.__init__` and remove the only place
+   v1 reads into upstream `MMEncoder` internals. Recommended: file an
+   upstream issue after Phase 1 lands, propose
+   `sglang.srt.disaggregation.EncoderModelWorker`, driven by SGLang-Omni
+   as the first consumer.
+
+2. **DP encoder vs TP encoder.** Upstream `mm_enable_dp_encoder` works for
+   Qwen2.5-VL (#13126 merged) and Qwen3-VL (#13724 merged) but Qwen3-Omni
+   support is still open (#14886). PR #18721 also shows that DP encoder
+   requires careful interaction with the LLM-side TP via
+   `VocabParallelEmbedding`. **MVP intentionally only supports encoder
+   TP.** Encoder DP becomes a follow-up after #14886 lands upstream and
+   we can import the audio side. The factory rejects
+   `mm_enable_dp_encoder=True` in Phase 0–2 to avoid coupling.
+
+3. **`StageConfig.tp_size` vs future `ParallelismConfig`.** Today TP is
+   the only parallelism axis we expose. Encoder DP and possibly EP would
+   push us toward a single `parallelism: ParallelismConfig(tp=N, dp=M,
+   ep=K)` field. Don't pre-emptively rename. Add `ParallelismConfig` only
+   when the second axis (DP) actually has a real consumer in v1.
+
+4. **Local fallback retention.** `models/qwen3_omni/components/image_encoder.py`
+   and `audio_encoder.py` should be deleted in Phase 3. Some reviewers
+   will want to keep them as a debug fallback for one release. Default
+   plan: delete after one release with `backend="auto" -> sglang"` as the
+   default.
+
+5. **Fault-injection enforcement.** The bug Cheng called out in v1
+   refactor notes (silent fake-success embeddings on OOM) can be
+   detection-only with fault injection. Should we additionally land a
+   lint rule that bans `except Exception` inside
+   `models/<name>/components/` and `models/<name>/encoder_adapters.py`?
+   That makes Rule 2 of the Scheduler-layer error handling enforceable.
+   Suggested: yes, as a follow-up PR after Phase 0.
+
+6. **TP-aware encoder cache.** `EncoderRequestData.cache_key` is honored
+   by the local path through `SimpleCacheManager`, but the SGLang path in
+   Phase 0 ignores cache and always forwards. Wiring cache into a
+   TP-broadcasting scheduler requires the entry rank to decide hit/miss
+   *before* the broadcast and ship that decision so all ranks agree
+   (otherwise the broadcast shape is wrong on a rank that thinks it hit
+   while another missed). Suggested: design a small `CacheBroadcastPlan`
+   in Phase 2, after `tp_size>1` parity is locked.
+
+7. **Multinode encoder TP.** Phase 0 is single-node. `nnodes` and
+   `node_rank` sit in `_ENCODER_PROTECTED_KEYS` so the SGLang worker
+   can never accidentally enter a multinode init path; the launcher
+   only allocates one NCCL port per stage and assumes
+   `127.0.0.1`-loopback dist-init addresses. Multinode encoder TP
+   (sharding one encoder across machines) is a separate workstream
+   that needs cross-machine NCCL bootstrap, multinode-aware
+   `StageProcessSpec`, and probably a new `EncoderClusterConfig` —
+   none of which Plan B intends to design now. If multinode becomes a
+   real requirement, lift the lock on `nnodes`/`node_rank` and revisit
+   the launcher.
+
+## Progress Tracking
+
+- [ ] Phase 0 land — `EncoderScheduler` + `SGLangEncoderWorker` +
+      Qwen3-Omni adapter, `backend="local"` default.
+- [ ] Phase 1 parity — image/audio encoder local-vs-sglang, tp1-vs-tp2.
+- [ ] Phase 2 — `backend="auto"` defaults to SGLang for Qwen3-Omni.
+- [ ] Phase 3 — delete duplicated local encoder files.
+- [ ] Phase 4 — typed `StageMemoryConfig`.
+
+PR #334 (v1 base) must land first; this RFC's Phase 0 PR depends on it.

--- a/docs/developer_reference/encoder_tp_path_b_design.md
+++ b/docs/developer_reference/encoder_tp_path_b_design.md
@@ -11,6 +11,10 @@ stack and the upstream SGLang Qwen3-Omni / Qwen3-VL / encode_server paths,
 plus a review pass that fixed three earlier mistakes in the non-entry-rank data
 path, single-rank distributed init, and the adapter batch interface.
 
+This is the detailed design note. For the shorter review-facing RFC that keeps
+only the decisions and contracts, see
+[`encoder_tp_path_b_design_lean.md`](encoder_tp_path_b_design_lean.md).
+
 ## Motivation
 
 This RFC is solving the long-sequence **activation-memory** OOM problem, not
@@ -446,7 +450,7 @@ def _recv_messages(
         # both ranks before the device broadcast fires.
         ok_flags = self._allocation_ready_gather(local_ok=True)
         if not all(ok_flags):
-            return local, RuntimeError("peer-rank tensor allocation failed")
+            return local, RuntimeError("non-entry-rank tensor allocation failed")
 
         for tensor_list in tensor_lists:
             for t in tensor_list:
@@ -491,12 +495,12 @@ def _recv_messages(
 
     ok_flags = self._allocation_ready_gather(local_ok=alloc_err is None)
     if not all(ok_flags):
-        # Either local OOM or peer OOM — either way no rank issues
+        # Either local OOM or non-entry-rank OOM — either way no rank issues
         # the device broadcast, so neither side blocks. Surface the
-        # local error if we have one, otherwise a peer-failure stub.
+        # local error if we have one, otherwise a non-entry-rank failure stub.
         return [], (
             alloc_err if alloc_err is not None
-            else RuntimeError("peer-rank tensor allocation failed")
+            else RuntimeError("non-entry-rank tensor allocation failed")
         )
 
     rebuilt: list[IncomingMessage] = []
@@ -721,7 +725,7 @@ def start(self) -> None:
                 self._emit_error(
                     messages,
                     build_err if build_err is not None
-                    else RuntimeError("peer-rank encoder build_batch failed"),
+                    else RuntimeError("non-entry-rank encoder build_batch failed"),
                 )
             continue
 
@@ -2358,15 +2362,15 @@ Rules:
     drained this iteration, which `Stage._drain_outbox_external`
     converts into a Coordinator failure → HTTP 500.
   - Fatal forward: `encode_batch` is inside upstream SGLang TP
-    collectives. A rank-local OOM / CUDA / NCCL exception can leave peer
-    ranks blocked in NCCL, so a CPU `all_gather_object` after the
+    collectives. A rank-local OOM / CUDA / NCCL exception can leave
+    non-entry ranks blocked in NCCL, so a CPU `all_gather_object` after the
     exception is not safe. The rank that catches the exception must exit
     non-zero immediately. `MultiProcessPipelineRunner._monitor_children`
     observes `StageGroup.any_dead()` and tears down the whole TP group.
   - Recoverable post-forward: `slice_results` runs only on the entry rank
     after `encode_batch` returned on all ranks. It can emit
-    per-request errors locally and continue; no TP peer is waiting on a
-    matching collective at that point.
+    per-request errors locally and continue; no non-entry rank is waiting
+    on a matching collective at that point.
 - **Pre-broadcast entry-rank failures**: `_recv_messages` does H2D
   copies inside `_strip_and_lift` *before* the metadata broadcast. A
   failure there (OOM, dtype coercion, malformed payload) on the
@@ -2625,7 +2629,7 @@ Phase 0 — landing path that doesn't break v1:
      collective. Assert the failing rank calls `_fatal_tp_forward_error`
      / exits non-zero instead of entering the CPU pre-forward gather,
      `StageGroup.any_dead()` becomes true, `MultiProcessPipelineRunner`
-     terminates the peer process, and all active Coordinator futures /
+     terminates the remaining TP process, and all active Coordinator futures /
      stream queues are failed with a non-empty stage-group fatal error.
      This test must explicitly reject "scheduler keeps running and emits
      request-level errors" for forward-time TP faults.

--- a/docs/developer_reference/encoder_tp_path_b_design.md
+++ b/docs/developer_reference/encoder_tp_path_b_design.md
@@ -8,8 +8,26 @@ encoder copies under `models/<name>/components/`.
 This RFC follows from #375 and the post-refactor architecture in #188. It
 is the result of a code walk over the v1 stage / scheduler / mp_runner
 stack and the upstream SGLang Qwen3-Omni / Qwen3-VL / encode_server paths,
-plus a review pass that fixed three earlier mistakes in the follower data
+plus a review pass that fixed three earlier mistakes in the non-entry-rank data
 path, single-rank distributed init, and the adapter batch interface.
+
+## Motivation
+
+This RFC is solving the long-sequence **activation-memory** OOM problem, not
+a model-weight residency problem. Qwen3-Omni's vision + audio encoder weights
+are small compared with the thinker, roughly 2.5 GB combined, but activation
+memory scales with input length. A one-minute video can push encoder
+activations above 30 GB on a single GPU; today that pressure is exactly what
+pushes the colocated thinker toward OOM and forced workaround-style memory
+reservation such as `--encoder-mem-reserve` in #339. The concrete pain shows
+up in the long-video paths discussed around #327 / #339.
+
+Plan B uses SGLang-native tensor parallelism because TP shards the encoder
+activations across ranks. That is the real win: giving the encoder a bigger
+GPU only moves the cliff, and DP would replicate the same long-sequence
+activation footprint on every rank. We still keep the weight-loading scope
+tight so encoder stages do not duplicate full thinker/talker weights, but the
+primary scaling target is activation memory.
 
 ## Architecture
 
@@ -22,7 +40,7 @@ HTTP API -> Client -> Coordinator -> StageGroup -> Stage(leader)
                                                 v
                                   EncoderScheduler (one per rank)
                                                 v
-                                  SGLangEncoderWorker (one per rank)
+                                  SGLangEncoderRunner (one per rank)
                                                 v
                               upstream SGLang encoder submodule(s)
                                   Qwen3OmniMoeVisionEncoder
@@ -39,7 +57,7 @@ Only the implementation behind encoder stages changes:
 
 ```text
 old:  Stage -> SimpleScheduler -> Qwen3OmniImageEncoder (HF copy)
-new:  Stage -> EncoderScheduler -> SGLangEncoderWorker -> upstream encoder submodule
+new:  Stage -> EncoderScheduler -> SGLangEncoderRunner -> upstream encoder submodule
 ```
 
 ### Layer Responsibilities
@@ -50,8 +68,8 @@ new:  Stage -> EncoderScheduler -> SGLangEncoderWorker -> upstream encoder submo
 | `MultiProcessPipelineRunner` / `StageGroup` | Spawn one OS process per TP rank, allocate NCCL port, inject `tp_rank/tp_size/gpu_id/nccl_port` | None — already TP-capable |
 | `Stage` (`single/leader/follower`) | Control plane, relay IO, input aggregation, stream routing, scheduler in/out queues, leader-only outbound traffic | None |
 | `TPLeaderFanout` / `TPFollowerControlPlane` | Mirror leader-side `Shutdown/Profiler/Abort` to followers via mp.Queue | None |
-| **`EncoderScheduler`** | TP-aware non-AR scheduling loop: drain inbox on entry rank, broadcast **metadata** to followers via TP CPU group, broadcast **tensor data** to followers via TP device group, run worker on every rank, emit downstream traffic only on entry rank | **New** |
-| **`SGLangEncoderWorker`** | Initialize SGLang distributed state (always — even at `tp_size=1`), build encoder-only `ModelConfig`, instantiate only the upstream encoder submodules declared by the adapter, partial-load matching checkpoint prefixes, expose `encode_batch()` | **New** |
+| **`EncoderScheduler`** | TP-aware non-AR scheduling loop: drain inbox on `entry_rank`, broadcast **metadata** to `non_entry_rank`s via TP CPU group, broadcast **tensor data** to `non_entry_rank`s via TP device group, run runner on every rank, emit downstream traffic only on `entry_rank` | **New** |
+| **`SGLangEncoderRunner`** | Initialize SGLang distributed state (always — even at `tp_size=1`), build encoder-only `ModelConfig`, instantiate only the upstream encoder submodules declared by the adapter, partial-load matching checkpoint prefixes, expose `encode_batch()` | **New** |
 | **`Qwen3OmniEncoderAdapter`** | v1 `PipelineState.encoder_inputs` <-> upstream `MultimodalDataItem` <-> v1 `encoder_outs`, with explicit `BatchPlan` and `EncoderModuleSpec` declarations | **New** |
 | upstream SGLang encoder modules | Own encoder kernels, native `ColumnParallelLinear` / `RowParallelLinear`, weight sharding, NCCL collectives | **Reused** |
 
@@ -59,6 +77,11 @@ new:  Stage -> EncoderScheduler -> SGLangEncoderWorker -> upstream encoder submo
 > supports the `single/leader/follower` split; we are adding a new scheduler
 > **shape**, not a new stage type. This matches the same boundary
 > `OmniScheduler` and `SimpleScheduler` already obey today.
+>
+> Terminology: existing Stage / StageGroup code keeps its
+> `single/leader/follower` role names. New encoder scheduler / runner code uses
+> `entry_rank` and `non_entry_rank` for TP rank roles: rank 0 owns external IO;
+> non-entry ranks never elect or take over.
 
 ### Why This Shape
 
@@ -78,16 +101,17 @@ Three observations from the code walk drive Plan B:
    and `tp_size>1` lanes](#gpu-placement-across-tp_size1-and-tp_size1-lanes)
    for the load-bearing reason and the exact change.
 
-2. **The leader/follower control fan-out is already wired, but data-plane
-   fan-out is not.** `Stage.run()` mirrors `Shutdown/Profiler/Abort` from
-   leader to followers via `TPLeaderFanout.fanout_control` /
-   `fanout_abort`. It explicitly does **not** mirror `SubmitMessage` /
-   `DataReadyMessage` — those go through ZMQ to leader only, and
-   `Stage._drain_outbox_follower` refuses to emit external traffic.
-   Followers also do not have a relay endpoint and never call
+2. **The Stage-level leader/follower control fan-out is already wired, but
+   data-plane fan-out is not.** `Stage.run()` mirrors
+   `Shutdown/Profiler/Abort` from the existing Stage leader to Stage
+   followers via `TPLeaderFanout.fanout_control` / `fanout_abort`. It
+   explicitly does **not** mirror `SubmitMessage` / `DataReadyMessage` —
+   those go through ZMQ to the Stage leader only, and
+   `Stage._drain_outbox_follower` refuses to emit external traffic. Stage
+   followers also do not have a relay endpoint and never call
    `relay_io.read_payload`. This means the `EncoderScheduler` is the only
-   layer that can hand inputs to followers, and it must do so over the
-   SGLang TP groups (CPU for metadata, device for tensors).
+   layer that can hand inputs to `non_entry_rank`s, and it must do so over
+   the SGLang TP groups (CPU for metadata, device for tensors).
 
 3. **`OmniScheduler` has already proven the in-scheduler TP broadcast
    pattern for control-shaped messages.** `OmniScheduler._recv_scheduler_messages`
@@ -99,8 +123,8 @@ Three observations from the code walk drive Plan B:
    should stay the minimal local-CPU/GPU callable runner.
 
 The missing pieces are therefore one new scheduler shape (`EncoderScheduler`)
-that owns metadata + tensor broadcast, and one minimal SGLang worker
-(`SGLangEncoderWorker`) that owns the distributed init plus partial
+that owns metadata + tensor broadcast, and one minimal SGLang runner
+(`SGLangEncoderRunner`) that owns the distributed init plus partial
 encoder-submodule loading. "Reuse upstream" means reuse SGLang's TP runtime,
 loader machinery, and encoder module implementations — not instantiate the
 full upstream `ForConditionalGeneration` entry class inside every encoder
@@ -116,7 +140,7 @@ Plan B reuses upstream at the **right granularity**:
 - Declared locally: which encoder submodules a stage needs, which checkpoint
   prefixes map to those submodules, and how v1 `PipelineState` becomes the
   upstream `MultimodalDataItem` shape.
-- Not reused in encoder workers: the full upstream
+- Not reused in encoder runners: the full upstream
   `ForConditionalGeneration` class. That class is the serving entry point for
   full generation and can allocate language-model / talker modules that an
   encoder stage must never own.
@@ -157,7 +181,7 @@ sglang_omni_v1/
 |-- scheduling/
 |   `-- encoder_scheduler.py        # TP-aware scheduler for encoder stages [NEW]
 |-- model_runner/
-|   `-- sglang_encoder_worker.py    # Minimal SGLang-native encoder worker [NEW]
+|   `-- sglang_encoder_runner.py    # Minimal SGLang-native encoder runner [NEW]
 `-- models/
     `-- qwen3_omni/
         |-- encoder_adapters.py     # v1 <-> SGLang adapter (with BatchPlan) [NEW]
@@ -204,7 +228,7 @@ sglang_omni_v1/
 This is the section the earlier draft missed. It is the load-bearing contract
 of the whole RFC.
 
-### Why followers need their own input fan-out
+### Why non-entry ranks need their own input fan-out
 
 In v1, `Stage._on_data_ready()` is the only path that materializes a
 `StagePayload`: it reads `relay_io.read_payload(...)`, which fetches the
@@ -212,14 +236,15 @@ tensor blobs the upstream stage wrote into the relay and re-attaches them
 into the payload `data` dict tree (`relay_io.py:170-200`). For TP encoder
 stages:
 
-- Only the leader has a ZMQ recv endpoint and a relay reader. Followers'
-  control plane is `TPFollowerControlPlane` (`pipeline/tp_control.py:59-117`),
-  which only handles `Shutdown/Profiler/Abort`.
+- Only the Stage leader / scheduler `entry_rank` has a ZMQ recv endpoint
+  and a relay reader. Stage followers' control plane is
+  `TPFollowerControlPlane` (`pipeline/tp_control.py:59-117`), which only
+  handles `Shutdown/Profiler/Abort`.
 - `Stage._drain_outbox_follower` (`stage/runtime.py:490-508`) actively
-  refuses any external traffic from follower ranks.
+  refuses any external traffic from non-entry ranks.
 
-So when an `image_encoder` request arrives, only the leader's
-`scheduler.inbox` ever receives an `IncomingMessage`. Followers' inboxes
+So when an `image_encoder` request arrives, only the `entry_rank`
+`scheduler.inbox` ever receives an `IncomingMessage`. Non-entry-rank inboxes
 stay empty unless the **scheduler itself** ships the inputs to them.
 
 ### Why `broadcast_pyobj` of the whole message is wrong
@@ -250,10 +275,10 @@ does the metadata/tensor extraction we need):
 
 2. **Tensors over the TP device group, on GPU.** For each tensor in the
    entry rank's `tensor_dict`, do `dist.broadcast(tensor,
-   src=tp_group.ranks[0], group=tp_group.device_group)`. Followers
+   src=tp_group.ranks[0], group=tp_group.device_group)`. Non-entry ranks
    pre-allocate empty tensors matching the broadcast `_tensor_specs` on
    `cuda:<local 0>` and call the matching `dist.broadcast` to receive into
-   them. After all tensors are received, followers run
+   them. After all tensors are received, non-entry ranks run
    `restore_tensors(metadata, tensor_dict)` to rebuild the payload `data`
    and reconstitute the `IncomingMessage` list.
 
@@ -262,19 +287,19 @@ does the metadata/tensor extraction we need):
 The default v1 relay backend is `shm`, and `_resolve_relay_config` in
 `pipeline/mp_runner.py:228-240` deliberately does **not** inject `gpu_id`
 into the relay config when the backend is shm — shm copies into host
-shared memory, so the leader's reconstructed payload tensors live on
+shared memory, so the entry rank's reconstructed payload tensors live on
 **CPU**. NCCL `dist.broadcast` over the TP device group requires CUDA
 tensors on the local rank's device. Therefore the contract is:
 
-- **Leader**, before broadcasting: for every tensor extracted from the
-  payload, run `t = t.to(self.worker.device, non_blocking=True)` (where
-  `self.worker.device` is `cuda:0` after the per-process
+- **Entry rank**, before broadcasting: for every tensor extracted from the
+  payload, run `t = t.to(self.runner.device, non_blocking=True)` (where
+  `self.runner.device` is `cuda:0` after the per-process
   `CUDA_VISIBLE_DEVICES` remap). Then `dist.broadcast(t, src,
   group=tp.device_group)`. Stash the device-resident tensor back into the
   `tensor_dict` so `restore_tensors` reattaches the GPU copy, not the
   original CPU one.
-- **Followers**, before broadcasting: allocate the placeholder via
-  `torch.empty(spec.shape, dtype=spec.dtype, device=self.worker.device)`
+- **Non-entry ranks**, before broadcasting: allocate the placeholder via
+  `torch.empty(spec.shape, dtype=spec.dtype, device=self.runner.device)`
   and broadcast into it.
 
 Why this direction:
@@ -296,7 +321,7 @@ Why this direction:
    (`disaggregation/encode_server.py:222-244`).
 
 If a future model integrates a non-shm relay (`nccl`, `nixl`) that already
-delivers GPU tensors, the leader-side `.to(device)` becomes a no-op.
+delivers GPU tensors, the entry-rank-side `.to(device)` becomes a no-op.
 
 This is structurally identical to upstream `relay_io.write_payload` /
 `read_payload`, just over the SGLang TP collectives instead of the relay
@@ -344,7 +369,7 @@ def _collect_batch_or_error(
 def _recv_messages(
     self,
 ) -> tuple[list[IncomingMessage], BaseException | None]:
-    """Drain inbox and broadcast inputs to TP followers.
+    """Drain inbox on entry_rank and broadcast inputs to non_entry_ranks.
 
     Never raises — returns (messages, error). The error is non-None if
     either rank failed during this iteration's recv. Drained messages
@@ -355,7 +380,7 @@ def _recv_messages(
     relay delivers CPU tensors and upstream get_image_feature() /
     get_video_feature() only call .type(dtype), not .to(device).
     """
-    if self.worker.tp_size == 1:
+    if self.runner.tp_size == 1:
         # Cost-capped collect uses adapter request_cost_fn, so it is
         # part of the recv error boundary rather than a guaranteed-safe
         # prelude. This keeps request-level error semantics even in the
@@ -369,19 +394,19 @@ def _recv_messages(
             return local, exc
         return self._reattach_lifted_tensors(meta_msgs, tensor_lists, specs_lists), None
 
-    tp = self.worker.tp_group
+    tp = self.runner.tp_group
     src_rank = tp.ranks[0]
 
-    if self.worker.is_entry_rank:
+    if self.runner.is_entry_rank:
         # Cost cap runs on the entry rank only — the broadcast below
         # ships the entry rank's already-bounded `local` list to
-        # followers, so all ranks see the same admission decision.
+        # non-entry ranks, so all ranks see the same admission decision.
         local, collect_err = self._collect_batch_or_error()
         if collect_err is not None:
             # request_cost_fn is adapter/model code. Treat admission
             # failures as pre-metadata recv failures, otherwise
-            # followers block forever in broadcast_pyobj waiting for a
-            # metadata payload that the entry rank never sends.
+            # non-entry ranks block forever in broadcast_pyobj waiting
+            # for a metadata payload that the entry rank never sends.
             broadcast_pyobj(
                 [{"kind": _RECV_ERROR_KIND, "error": repr(collect_err)}],
                 tp.rank, tp.cpu_group, src=src_rank,
@@ -390,7 +415,7 @@ def _recv_messages(
 
         # _strip_and_lift does the H2D copy + dtype coercion that can
         # OOM / TypeError; it must also fail through the same sentinel
-        # path *before* the metadata broadcast, otherwise followers
+        # path *before* the metadata broadcast, otherwise non-entry ranks
         # block on it forever and the runner can't see it
         # (mp_runner.py:332-342 only catches exit-code failures).
         try:
@@ -400,7 +425,7 @@ def _recv_messages(
             # pickle.dumps / pickle.loads round-trip
             # (sglang utils/common.py:1286, 1309). Identity-based
             # sentinels (e.g. `object()`) would not, since pickle
-            # reconstructs a fresh instance on each follower.
+            # reconstructs a fresh instance on each non-entry rank.
             broadcast_pyobj(
                 [{"kind": _RECV_ERROR_KIND, "error": repr(exc)}],
                 tp.rank, tp.cpu_group, src=src_rank,
@@ -417,7 +442,7 @@ def _recv_messages(
         # Allocation-ready handshake — see "Allocation-ready gather"
         # note below. Entry rank's tensors are already on device from
         # _strip_and_lift, so its allocation step is a no-op; it still
-        # has to participate in the gather so any follower OOM unwinds
+        # has to participate in the gather so any non-entry-rank OOM unwinds
         # both ranks before the device broadcast fires.
         ok_flags = self._allocation_ready_gather(local_ok=True)
         if not all(ok_flags):
@@ -431,7 +456,7 @@ def _recv_messages(
             None,
         )
 
-    # follower path
+    # non-entry-rank path
     payload = broadcast_pyobj([], tp.rank, tp.cpu_group, src=src_rank)
     if (
         payload
@@ -447,7 +472,7 @@ def _recv_messages(
     # *before* any device broadcast, then synchronize success across
     # ranks. If any rank's allocation fails (typically OOM on a long
     # video pixel buffer), every rank skips the device broadcast loop
-    # and returns an error tuple. Without this gather, a follower OOM
+    # and returns an error tuple. Without this gather, a non-entry-rank OOM
     # mid-loop would leave the entry rank stuck waiting on the
     # corresponding `dist.broadcast` receiver.
     placeholders: list[list[torch.Tensor]] = []
@@ -457,7 +482,7 @@ def _recv_messages(
             placeholders.append(
                 [
                     torch.empty(spec.shape, dtype=spec.dtype,
-                                device=self.worker.device)
+                                device=self.runner.device)
                     for spec in specs
                 ]
             )
@@ -487,9 +512,9 @@ def _recv_messages(
 
 def _allocation_ready_gather(self, *, local_ok: bool) -> list[bool]:
     """Gather per-rank allocation-success flags on the TP CPU group."""
-    flags = [False] * self.worker.tp_size
+    flags = [False] * self.runner.tp_size
     dist.all_gather_object(
-        flags, local_ok, group=self.worker.tp_group.cpu_group,
+        flags, local_ok, group=self.runner.tp_group.cpu_group,
     )
     return flags
 
@@ -523,7 +548,7 @@ identity sentinel. `broadcast_pyobj` does a full
 (`sglang/python/sglang/srt/utils/common.py:1286, 1309`); singleton
 identity does not survive that, but `dict.get("kind") == "encoder_recv_error"`
 does. The collective itself is the same `broadcast_pyobj` call
-followers were already going to await, so the error rides the
+non-entry ranks were already going to await, so the error rides the
 existing channel.
 
 `_recv_messages` deliberately **never raises**. Returning
@@ -539,19 +564,19 @@ stage-level abort.
 #### Allocation-ready gather
 
 The metadata `broadcast_pyobj` only synchronizes *what to receive*,
-not *whether the receivers are ready*. The follower then has to call
+not *whether the receivers are ready*. The non-entry rank then has to call
 `torch.empty(spec.shape, ..., device=cuda:0)` for every incoming
 tensor, and on a long-video / multi-image batch that allocation can
 OOM. Naïvely starting `dist.broadcast` from the entry rank
 immediately after the metadata broadcast hits a deadlock in that
-case: a follower OOMs mid-allocation and aborts its receive loop,
+case: a non-entry rank OOMs mid-allocation and aborts its receive loop,
 while the entry rank is already blocked inside an unmatched
 `dist.broadcast` call.
 
 Plan B inserts an `all_gather_object`-style "alloc ok?" handshake
 between the metadata broadcast and the first `dist.broadcast`:
 
-1. Followers pre-allocate **all** receive tensors up front (fail
+1. Non-entry ranks pre-allocate **all** receive tensors up front (fail
    fast if any spec OOMs).
 2. The entry rank participates in the gather as a no-op (its
    tensors already exist).
@@ -566,17 +591,17 @@ makes the device broadcast loop unconditionally safe to enter once
 it starts.
 
 `_strip_and_lift` calls `extract_tensors`, then for each extracted tensor
-runs `t = t.to(self.worker.device, non_blocking=True)` and records
+runs `t = t.to(self.runner.device, non_blocking=True)` and records
 `(path, shape, dtype)` into a small `_TensorSpec` dataclass. The metadata
 broadcast pickles only the spec list, not the tensors. `_reattach_lifted_tensors`
 runs `restore_tensors` on the entry rank with the GPU-resident tensors so
 that the entry rank's downstream `BatchPlan` sees the same device-resident
-tensors the followers will reconstruct.
+tensors the non-entry ranks will reconstruct.
 
 > **Why keep typed `_TensorSpec` instead of reusing the placeholder.**
 > The placeholder dict `extract_tensors` produces stringifies dtype
 > and device (`relay_io.py:48-49`: `"dtype": str(obj.dtype)` →
-> `"torch.float16"`, not the `torch.dtype` object). Follower-side
+> `"torch.float16"`, not the `torch.dtype` object). Non-entry-rank-side
 > `torch.empty(shape, dtype=placeholder["dtype"], device=...)` would
 > raise `TypeError: dtype must be a torch.dtype`. The implementation
 > PR has two options: (a) carry a typed `_TensorSpec(path, shape,
@@ -622,7 +647,7 @@ scheduler-type branch.
 class EncoderScheduler:
     def __init__(
         self,
-        worker: "SGLangEncoderWorker",
+        runner: "SGLangEncoderRunner",
         adapter: "EncoderAdapter",
         *,
         max_batch_size: int = 32,
@@ -630,7 +655,7 @@ class EncoderScheduler:
         request_cost_fn: Callable[[Any], int] | None = None,
         max_batch_cost: int | None = None,        # activation_budget_bytes
     ):
-        self.worker = worker
+        self.runner = runner
         self.adapter = adapter
         self.inbox = queue.Queue()
         self.outbox = queue.Queue()
@@ -675,7 +700,7 @@ def start(self) -> None:
         messages, recv_err = self._recv_messages()
         if recv_err is not None:
             if self._gather_pre_forward_error(recv_err):
-                if self.worker.is_entry_rank:
+                if self.runner.is_entry_rank:
                     self._emit_error(messages, recv_err)
                 continue
         if not messages:
@@ -692,7 +717,7 @@ def start(self) -> None:
             build_err = exc
 
         if self._gather_pre_forward_error(build_err):
-            if self.worker.is_entry_rank:
+            if self.runner.is_entry_rank:
                 self._emit_error(
                     messages,
                     build_err if build_err is not None
@@ -701,12 +726,12 @@ def start(self) -> None:
             continue
 
         try:
-            raw = self.worker.encode_batch(plan)                 # all ranks
+            raw = self.runner.encode_batch(plan)                 # all ranks
         except Exception as exc:                                 # noqa: BLE001
             self._fatal_tp_forward_error(exc)
             raise                                               # unreachable
 
-        if not self.worker.is_entry_rank:
+        if not self.runner.is_entry_rank:
             continue
 
         try:
@@ -723,13 +748,13 @@ def start(self) -> None:
 
 def _gather_pre_forward_error(self, local_err: BaseException | None) -> bool:
     """Synchronize recoverable recv/build errors before model collectives."""
-    if self.worker.tp_size <= 1:
+    if self.runner.tp_size <= 1:
         return local_err is not None
-    err_flags: list[bool] = [False] * self.worker.tp_size
+    err_flags: list[bool] = [False] * self.runner.tp_size
     dist.all_gather_object(
         err_flags,
         local_err is not None,
-        group=self.worker.tp_group.cpu_group,
+        group=self.runner.tp_group.cpu_group,
     )
     return any(err_flags)
 
@@ -818,8 +843,8 @@ raises `BatchCollectError(messages, cause)` with every message already
 drained in this iteration. `_recv_messages()` converts that into its
 normal `(messages, error)` return; in TP mode, the entry rank also sends
 the same `_RECV_ERROR_KIND` sentinel used for `_strip_and_lift` failures
-before followers wait for metadata. That preserves both properties we
-need: no request is silently dropped, and followers never block forever
+before non-entry ranks wait for metadata. That preserves both properties we
+need: no request is silently dropped, and non-entry ranks never block forever
 on a metadata broadcast that the entry rank skipped.
 
 ### Where admission control runs in `_recv_messages`
@@ -827,9 +852,9 @@ on a metadata broadcast that the entry rank skipped.
 `_collect_batch_from_inbox` is the **single point of truth** for the
 admission decision: it runs only on the entry rank (or in the
 single-rank case), and the broadcast that follows ships the
-already-bounded list to followers. If both ranks ran the cost cap
+already-bounded list to non-entry ranks. If both ranks ran the cost cap
 independently, divergent decisions would desync the broadcast
-structure — followers must never touch the inbox.
+structure — non-entry ranks must never touch the inbox.
 
 The single canonical sketch lives in
 [Two-channel broadcast contract](#two-channel-broadcast-contract)
@@ -840,10 +865,10 @@ no separate "admission-control variant" of `_recv_messages`.
 
 1. Drain the stage inbox **on the entry rank only**. Entry rank is rank 0
    inside the SGLang TP group, matching `OmniScheduler.is_entry_rank`.
-2. Broadcast metadata + tensors to follower ranks via the two-channel
+2. Broadcast metadata + tensors to non-entry ranks via the two-channel
    contract above.
 3. Build a deterministic `BatchPlan` on all ranks using `adapter.build_batch`.
-4. Run `worker.encode_batch(plan)` on every rank. Forward executes the
+4. Run `runner.encode_batch(plan)` on every rank. Forward executes the
    upstream encoder; SGLang's `ColumnParallelLinear` / `RowParallelLinear`
    issue collectives internally.
 5. Emit `OutgoingMessage` to the outbox **only on the entry rank**.
@@ -885,15 +910,15 @@ it:
 `SimpleScheduler` stays as-is and remains the fallback path for
 non-upstreamed encoders.
 
-## SGLangEncoderWorker
+## SGLangEncoderRunner
 
-`SGLangEncoderWorker` is a minimal SGLang-native encoder worker. It does
+`SGLangEncoderRunner` is a minimal SGLang-native encoder runner. It does
 **not** start `MMEncoder` or any HTTP server: v1 already owns
 preprocessing, control plane, relay, request lifecycle, and cache metadata.
-The worker only owns SGLang's distributed state and the loaded upstream
+The runner only owns SGLang's distributed state and the loaded upstream
 encoder submodules for the current stage.
 
-Important boundary: encoder workers must **not** instantiate the upstream
+Important boundary: encoder runners must **not** instantiate the upstream
 full `ForConditionalGeneration` class. For Qwen3-Omni,
 `Qwen3OmniMoeForConditionalGeneration` constructs a thinker, and the
 thinker constructs language + audio + vision modules. Loading that in the
@@ -927,9 +952,9 @@ calls, not the surrounding ZMQ/cache/transfer-engine machinery):
 ### EncoderModuleSpec
 
 Every SGLang-backed encoder stage provides a tiny module declaration. This
-is the only model-specific part of the worker; it says which upstream
+is the only model-specific part of the runner; it says which upstream
 encoder submodules to instantiate and which checkpoint prefixes belong to
-them. The shared worker handles distributed init, `ServerArgs`, `ModelConfig`,
+them. The shared runner handles distributed init, `ServerArgs`, `ModelConfig`,
 `LoadConfig`, checkpoint iteration, protected override checks, and device
 placement.
 
@@ -985,10 +1010,10 @@ This is a load-bearing detail because v1's per-process CUDA env remap
 in `pipeline/stage_process.py:222-249` is gated on `tp_size > 1`. The
 contract Plan B requires is:
 
-> The SGLangEncoderWorker process always sees exactly one CUDA device
+> The SGLangEncoderRunner process always sees exactly one CUDA device
 > as `cuda:0`, regardless of `tp_size`. The configured physical GPU is
 > mapped onto `cuda:0` by the launcher before `torch` is imported.
-> Worker code uses `cuda_device=0`, `dist_local_rank=tp_rank` (which is
+> Runner code uses `cuda_device=0`, `dist_local_rank=tp_rank` (which is
 > `0` when `tp_size=1`).
 
 This is the contract that lines up with how SGLang internally treats
@@ -1025,7 +1050,7 @@ local-master / shard-index slot, which is undefined for
 #### Required launcher change
 
 `backend="sglang"` stages — including `tp_size=1` — must reach the
-worker through a process whose `CUDA_VISIBLE_DEVICES` has been remapped
+runner through a process whose `CUDA_VISIBLE_DEVICES` has been remapped
 to a single physical GPU and whose `SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS=true`
 is set, exactly as `_prepare_cuda_environment` already does for
 `tp_size>1`.
@@ -1052,7 +1077,7 @@ The Phase-0 PR therefore extends the launcher path:
    the case where the user flips a stage to `backend="sglang"` via
    `PipelineConfig.runtime_overrides` (CLI / config-file path) without
    editing the StageConfig itself, leaving `single_visible_device=False`
-   while the worker still expects to be the only visible CUDA device.
+   while the runner still expects to be the only visible CUDA device.
 
    The runner cannot wait for `_resolve_backend(...)` because that runs
    inside the factory in the child process, after `torch` is imported.
@@ -1094,8 +1119,8 @@ The Phase-0 PR therefore extends the launcher path:
 
    - The single-visible-device remap from step 1 never fires —
      `gpu=4, tp_size=1` would silently load the encoder on physical
-     GPU 0 because the worker fixes `cuda_device=0`.
-   - Multiple `SGLangEncoderWorker` instances in the same process would
+     GPU 0 because the runner fixes `cuda_device=0`.
+   - Multiple `SGLangEncoderRunner` instances in the same process would
      fight over the global `init_distributed_environment` state, which
      is module-level inside SGLang and can only be initialized once
      per process.
@@ -1118,7 +1143,7 @@ The Phase-0 PR therefore extends the launcher path:
    resolved `factory_args["backend"]` is `"sglang"` or `"auto"`,
    **and** any stage with `stage_cfg.tp_size > 1`. The single-process
    compile path is by construction incompatible with the SGLang
-   encoder worker (no per-rank subprocess) and equally unable to
+   encoder runner (no per-rank subprocess) and equally unable to
    honor TP for **any** factory: `_resolve_factory_args` only injects
    `model_path` / `gpu_id`, never `tp_rank` / `tp_size` /
    `nccl_port` (`config/compiler.py:138-158`). A direct
@@ -1172,16 +1197,16 @@ The Phase-0 PR therefore extends the launcher path:
 
    The two layers cover distinct failure modes:
 
-   - **Layer 1** catches "factory has no idea about TP". Example: a
-     `SimpleScheduler` callable like
+   - **Layer 1** catches "factory has no idea about TP". Example: an
+     existing non-encoder `SimpleScheduler` callable like
      `create_aggregate_executor()` (no TP params in signature)
      mis-configured with `tp_size=2`. Without this layer, the
      launcher would still hit `any_tp → needs_mp`, spawn N
      subprocesses, then fail in each child either at factory
      argument-binding time (mp_runner injects `tp_rank/tp_size/nccl_port`
      kwargs the factory does not accept → `TypeError`) or — if the
-     factory uses `**kwargs` — at follower-IO time when the stage
-     can't actually fan-out batches. Layer 1 fails loud in the main
+     factory uses `**kwargs` — at Stage follower IO time when the stage
+     can't actually fan out batches. Layer 1 fails loud in the main
      process before any spawn.
    - **Layer 2** catches "factory has a backend knob but the user
      left it on local". Encoder factories accept `backend` *and*
@@ -1226,8 +1251,8 @@ defaults.** The implication is load-bearing:
   with explicit `factory_args["backend"]` set, never lean on signature
   defaults.
 
-After this change, `SGLangEncoderWorker` sees `cuda:0` in both lanes
-and the worker's GPU placement collapses to one rule:
+After this change, `SGLangEncoderRunner` sees `cuda:0` in both lanes
+and the runner's GPU placement collapses to one rule:
 
 ```python
 cuda_device = 0
@@ -1259,10 +1284,10 @@ and `get_tp_group()` asserts the group has been initialized
 (`parallel_state.py:1482`). Skipping init at `tp_size=1` would crash at
 model load time with `tensor model parallel group is not initialized`.
 
-`SGLangEncoderWorker` therefore initializes distributed state **always**:
+`SGLangEncoderRunner` therefore initializes distributed state **always**:
 
 ```python
-class SGLangEncoderWorker:
+class SGLangEncoderRunner:
     def __init__(
         self,
         *,
@@ -1279,6 +1304,7 @@ class SGLangEncoderWorker:
         self.tp_rank = tp_rank
         self.tp_size = tp_size
         self.is_entry_rank = (tp_rank == 0)
+        self.is_non_entry_rank = not self.is_entry_rank
 
         # tp_size=1 also gets a real init: see `Distributed init is
         # unconditional`.  Use a free-port loopback when the parent did not
@@ -1300,21 +1326,21 @@ class SGLangEncoderWorker:
         dist_local_rank = tp_rank
         self.device = torch.device(f"cuda:{cuda_device}")
 
-        # Worker-managed kwargs that build_sglang_encoder_server_args is
+        # Runner-managed kwargs that build_sglang_encoder_server_args is
         # about to receive as explicit positional/keyword arguments.
         # We must reject these in `server_args_overrides` BEFORE the
         # **splat below — otherwise Python raises TypeError "got multiple
         # values for keyword argument" before our helper's protected-key
         # check ever runs.
         overrides = dict(server_args_overrides or {})
-        worker_managed = {
+        runner_managed = {
             "model_path", "tp_size", "base_gpu_id", "dist_init_addr",
             "dtype", "load_format",
         }
-        clobbered = sorted(worker_managed & overrides.keys())
+        clobbered = sorted(runner_managed & overrides.keys())
         if clobbered:
             raise ValueError(
-                f"server_args_overrides cannot set worker-managed keys "
+                f"server_args_overrides cannot set runner-managed keys "
                 f"{clobbered}. These are derived from StageConfig and "
                 f"factory parameters; pass them through StageConfig "
                 f"(model_path, tp_size, gpu, dtype, load_format) instead."
@@ -1353,8 +1379,8 @@ class SGLangEncoderWorker:
 
         # Always run, including tp_size == 1.
         # `local_rank` here is identity (used for local-master checks),
-        # NOT a CUDA index. Passing tp_rank lets followers see themselves
-        # as non-zero local_rank in custom_all_reduce_utils.py:280 and
+        # NOT a CUDA index. Passing tp_rank lets non-entry ranks see
+        # themselves as non-zero local_rank in custom_all_reduce_utils.py:280 and
         # friends. Device selection is governed by
         # SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS in the tp>1 lane.
         init_distributed_environment(
@@ -1444,7 +1470,7 @@ We therefore add a sibling helper next to the AR builder. For encoder
 stages, tensor parallelism has exactly one source of truth:
 `StageConfig.tp_size` plus `StageConfig.gpu`. `MultiProcessPipelineRunner`
 turns those fields into the per-rank `tp_rank`, `tp_size`, `gpu_id`, and
-`nccl_port` kwargs that reach `SGLangEncoderWorker`. `server_args_overrides`
+`nccl_port` kwargs that reach `SGLangEncoderRunner`. `server_args_overrides`
 is only for safe SGLang loading/runtime knobs such as quantization,
 attention backend, and remote weight loading; it must not be able to
 change rank topology or GPU placement after the runner has already
@@ -1453,7 +1479,7 @@ spawned processes.
 ```python
 # sglang_omni_v1/scheduling/sglang_backend/server_args_builder.py
 
-# Worker invariants that must NOT be reachable from server_args_overrides.
+# Runner invariants that must NOT be reachable from server_args_overrides.
 # Mutating these would either invalidate GPU placement, change the
 # parallelism axis we promised, or flip the encoder-vs-language-only
 # fork. See "GPU placement..." and Open Question 2 (encoder DP).
@@ -1475,7 +1501,7 @@ _ENCODER_PROTECTED_KEYS = frozenset({
     "base_gpu_id",
     "nccl_port",
     "dist_init_addr",
-    # Encoder worker invariants
+    # Encoder runner invariants
     "encoder_only",
     "language_only",
     "mm_enable_dp_encoder",
@@ -1484,12 +1510,12 @@ _ENCODER_PROTECTED_KEYS = frozenset({
     "enable_dp_lm_head",
     "disable_cuda_graph",
     "device",
-    # AR-only knobs that have no meaning for an encoder-only worker.
+    # AR-only knobs that have no meaning for an encoder-only runner.
     # Locked so users cannot reintroduce SGLang AR memory semantics
     # through server_args_overrides — the encoder path explicitly does
     # not own a KV pool, an AR running queue, or a chunked-prefill
     # budget, and any value set here would be silently accepted by
-    # ServerArgs but would diverge from what the worker actually does.
+    # ServerArgs but would diverge from what the runner actually does.
     "mem_fraction_static",
     "max_running_requests",
     "max_prefill_tokens",
@@ -1508,7 +1534,7 @@ def build_sglang_encoder_server_args(
     load_format: str | None = None,
     **overrides: Any,
 ) -> ServerArgs:
-    """ServerArgs configured for an encoder-only worker.
+    """ServerArgs configured for an encoder-only runner.
 
     Distinct from build_sglang_server_args because encoder stages do not
     have a meaningful context_length / mem_fraction_static / running queue.
@@ -1520,7 +1546,7 @@ def build_sglang_encoder_server_args(
     if bad:
         raise ValueError(
             f"server_args_overrides cannot override protected keys: {bad}. "
-            f"These are decided by the worker / pipeline runner; pass them "
+            f"These are decided by the runner / pipeline runner; pass them "
             f"through StageConfig (tp_size, gpu) instead."
         )
 
@@ -1555,10 +1581,10 @@ The protected-key reject covers:
   Phase 0 starts exactly `StageConfig.tp_size` local ranks; DP, EP,
   attention-CP, and multinode shapes are out of scope and cannot be
   activated through `server_args_overrides`.
-- `encoder_only` / `language_only` — the worker no longer relies on the
+- `encoder_only` / `language_only` — the runner no longer relies on the
   full upstream model factory for the encoder-vs-language split. Letting
   users flip these through overrides would make `ServerArgs` disagree with
-  the module specs the worker actually loads.
+  the module specs the runner actually loads.
 - `mm_enable_dp_encoder` — Phase 0–2 require encoder TP only; allowing
   this through `overrides` would silently violate the rejection rule
   the factory layer also enforces.
@@ -1568,11 +1594,11 @@ The protected-key reject covers:
   described in this RFC.
 - `disable_cuda_graph` — Phase 0 requires variable shapes; piecewise
   CUDA graph for encoder ViT lands later (PR #15320 / #16785 area).
-- `device` — `SGLangEncoderWorker` hardcodes `DeviceConfig(device="cuda", ...)`
+- `device` — `SGLangEncoderRunner` hardcodes `DeviceConfig(device="cuda", ...)`
   and `get_default_distributed_backend("cuda")`. Letting `overrides`
   flip `ServerArgs.device` to `cpu/npu/xpu/mps` (the values
   `server_args.py:1218-1244` recognizes) would split the two: SGLang's
-  internals would think the worker is on CPU/NPU while we still issue
+  internals would think the runner is on CPU/NPU while we still issue
   CUDA distributed calls. Cross-backend encoder support is a separate
   workstream and should not be reachable through a one-line override.
 
@@ -1581,18 +1607,18 @@ Loader / processor knobs (`model_loader_extra_config`,
 are **not** protected and pass through unchanged via
 `server_args_overrides` — those are exactly the fields users need to
 forward for FP8 / NVFP4 / remote-streaming deployments. `dtype` and
-`load_format` are also supported, but as top-level factory / worker
+`load_format` are also supported, but as top-level factory / runner
 arguments rather than `server_args_overrides`, to avoid duplicate keyword
 binding before the protected-key helper runs.
 
 `model_path`, `tp_size`, `base_gpu_id`, `dist_init_addr`, `dtype`, and
-`load_format` are rejected one level earlier in `SGLangEncoderWorker`
+`load_format` are rejected one level earlier in `SGLangEncoderRunner`
 because the helper receives them as explicit keyword arguments. That
 early reject is intentional: otherwise Python would raise a generic
 "got multiple values for keyword argument" `TypeError` before the
 protected-key check can produce the source-of-truth error message.
 
-`SGLangEncoderWorker.__init__` calls this helper directly. AR-only
+`SGLangEncoderRunner.__init__` calls this helper directly. AR-only
 knobs (`mem_fraction_static`, `max_running_requests`,
 `max_prefill_tokens`, `chunked_prefill_size`, `context_length`) are
 intentionally absent from the helper signature **and** are listed in
@@ -1600,11 +1626,11 @@ intentionally absent from the helper signature **and** are listed in
 `server_args_overrides`. `ServerArgs` falls back to its own defaults
 for those AR fields, and the encoder-only code path never reads them
 — protecting them keeps a stale-AR-knob from silently propagating
-into `ServerArgs` even though the worker ignores it.
+into `ServerArgs` even though the runner ignores it.
 
 ### LoadConfig fidelity
 
-`SGLangEncoderWorker.__init__` constructs `LoadConfig` with the same six
+`SGLangEncoderRunner.__init__` constructs `LoadConfig` with the same six
 fields upstream `MMEncoder.__init__` does
 (`disaggregation/encode_server.py:202-208`):
 
@@ -1651,7 +1677,7 @@ re-implementer. Reading the lower half of `MMEncoder.__init__` and copying
 just the eight calls listed above is genuinely smaller and lets v1 keep
 ownership of the request lifecycle. (See
 [Open Questions](#open-questions) about whether SGLang main should expose a
-small `EncoderModelWorker` helper to remove the copy.)
+small `EncoderModelRunner` helper to remove the copy.)
 
 ## EncoderAdapter and BatchPlan
 
@@ -2029,7 +2055,7 @@ MVP requires no schema change. Encoder TP is expressed entirely in
 ```python
 StageConfig(
     name="image_encoder",
-    factory="sglang_omni_v1.models.qwen3_omni.stages.create_image_encoder_executor",
+    factory="sglang_omni_v1.models.qwen3_omni.stages.create_image_encoder_runner",
     factory_args={
         "backend": "sglang",
         "max_batch_size": 32,
@@ -2052,7 +2078,7 @@ StageConfig(
 ### Factory contract
 
 ```python
-def create_image_encoder_executor(
+def create_image_encoder_runner(
     model_path: str,
     *,
     # IMPORTANT: this signature default is `"local"` and stays "local"
@@ -2064,7 +2090,7 @@ def create_image_encoder_executor(
     # ever changed the default to `"auto"`, a StageConfig that omits
     # `factory_args["backend"]` would silently disagree: launcher reads
     # "local" → goes single-process, factory body picks up "auto" →
-    # tries to start an SGLang worker. To switch a deployment to the
+    # tries to start an SGLang runner. To switch a deployment to the
     # SGLang backend, write `factory_args["backend"]="auto"` (or
     # `"sglang"`) into the StageConfig (or `runtime_overrides`)
     # explicitly — never rely on this default to flip.
@@ -2085,7 +2111,7 @@ def create_image_encoder_executor(
     chosen = _resolve_backend(backend, model_path, stage="image_encoder")
     if chosen == "sglang":
         adapter = Qwen3OmniImageEncoderAdapter(...)
-        worker = SGLangEncoderWorker(
+        runner = SGLangEncoderRunner(
             model_path=model_path,
             gpu_id=gpu_id, tp_rank=tp_rank, tp_size=tp_size, nccl_port=nccl_port,
             dtype=dtype,
@@ -2094,7 +2120,7 @@ def create_image_encoder_executor(
             server_args_overrides=server_args_overrides,
         )
         return EncoderScheduler(
-            worker=worker,
+            runner=runner,
             adapter=adapter,
             max_batch_size=max_batch_size,
             max_batch_wait_ms=max_batch_wait_ms,
@@ -2204,8 +2230,8 @@ For `image_encoder` with `tp_size=2`, end to end:
 5. Before torch import, `_prepare_cuda_environment` sets
    `CUDA_VISIBLE_DEVICES` to the mapped device for that rank and rewrites
    `factory_args["gpu_id"]=0`. (`pipeline/stage_process.py:252-276`)
-6. The factory builds `EncoderScheduler(worker=SGLangEncoderWorker(...))`.
-7. `SGLangEncoderWorker.__init__` always calls
+6. The factory builds `EncoderScheduler(runner=SGLangEncoderRunner(...))`.
+7. `SGLangEncoderRunner.__init__` always calls
    `init_distributed_environment(world_size=2, rank=tp_rank,
    distributed_init_method=f"tcp://127.0.0.1:{nccl_port}")`,
    `initialize_model_parallel(tensor_model_parallel_size=2)`, then builds
@@ -2214,16 +2240,19 @@ For `image_encoder` with `tp_size=2`, end to end:
    processes meet on the NCCL port and form the TP group. **At
    `tp_size=1` the same calls run with `world_size=1, rank=0,
    distributed_init_method=tcp://127.0.0.1:<free_port>`.**
-8. `Stage.run()` starts. Leader binds the ZMQ recv endpoint; follower binds
-   `TPFollowerControlPlane`. Both spawn a scheduler thread.
-9. `EncoderScheduler` enters its loop. Leader drains the inbox and uses
-   the two-channel broadcast to ship metadata + tensors to the follower;
-   both run forward; leader emits results to the outbox.
-10. `Stage._drain_outbox_external` (leader) routes the outbox `result`
-    messages to `mm_aggregate` via the relay.
-11. `Stage._drain_outbox_follower` (follower) discards outputs.
-12. Aborts and shutdown go from leader to follower via the existing
-    `TPLeaderFanout` queues.
+8. `Stage.run()` starts. The existing Stage leader binds the ZMQ recv
+   endpoint; the Stage follower binds `TPFollowerControlPlane`. Both spawn
+   a scheduler thread.
+9. `EncoderScheduler` enters its loop. The `entry_rank` drains the inbox and
+   uses the two-channel broadcast to ship metadata + tensors to
+   `non_entry_rank`s; all ranks run forward; `entry_rank` emits results to
+   the outbox.
+10. `Stage._drain_outbox_external` (Stage leader / entry rank) routes the
+    outbox `result` messages to `mm_aggregate` via the relay.
+11. `Stage._drain_outbox_follower` (Stage follower / non-entry rank)
+    discards outputs.
+12. Aborts and shutdown go from the Stage leader to Stage followers via the
+    existing `TPLeaderFanout` queues.
 
 ## Control Plane and Data Plane
 
@@ -2313,7 +2342,7 @@ forwards must not catch broad `Exception`.
 
 Rules:
 
-- `SGLangEncoderWorker.encode_batch` and `EncoderAdapter.run_feature` only
+- `SGLangEncoderRunner.encode_batch` and `EncoderAdapter.run_feature` only
   catch specific expected exceptions (e.g. `OutOfMemoryError` for batch
   splitting, if we ever add it). They never catch base `Exception`.
 - `EncoderScheduler.start()` has **three** error domains, not one
@@ -2341,7 +2370,7 @@ Rules:
 - **Pre-broadcast entry-rank failures**: `_recv_messages` does H2D
   copies inside `_strip_and_lift` *before* the metadata broadcast. A
   failure there (OOM, dtype coercion, malformed payload) on the
-  entry rank would leave followers blocked on `broadcast_pyobj`
+  entry rank would leave non-entry ranks blocked on `broadcast_pyobj`
   forever — the runner cannot detect this since
   `MultiProcessPipelineRunner._monitor_children`
   (`pipeline/mp_runner.py:332-342`) only fires on
@@ -2352,7 +2381,7 @@ Rules:
   broadcasts a tagged dict
   `{"kind": "encoder_recv_error", "error": repr(exc)}` over the
   same CPU-group `broadcast_pyobj` slot the success path uses, then
-  returns `(local, exc)`. Followers detect the dict by kind-string
+  returns `(local, exc)`. Non-entry ranks detect the dict by kind-string
   equality (not identity — pickle round-trip would break that) and
   return `([], RuntimeError(...))`. Both ranks then converge on the
   scheduler's pre-forward `all_gather_object` handshake without
@@ -2420,12 +2449,12 @@ then just sets `backend="sglang"` and `tp_size`.
    `EncoderModuleSpec` list for each encoder stage and implement
    `build_batch`, `run_feature`, `slice_results`.
 2. In `models/<name>/stages.py`, branch the encoder factory on `backend`:
-   `"sglang"` builds `EncoderScheduler(SGLangEncoderWorker(...), adapter)`;
+   `"sglang"` builds `EncoderScheduler(SGLangEncoderRunner(...), adapter)`;
    `"local"` keeps the existing `SimpleScheduler` path.
 3. In `models/<name>/config.py` (the `PipelineConfig`), set `tp_size` and
    `gpu=[...]` on the encoder stage.
 4. Validate that the SGLang backend loads only the declared encoder
-   prefixes (no language model / talker parameters in the encoder worker).
+   prefixes (no language model / talker parameters in the encoder runner).
 5. Validate parity: `backend="local"` vs `backend="sglang", tp_size=1` on
    the same input. Then bump `tp_size`.
 
@@ -2455,7 +2484,7 @@ Phase 0 — landing path that doesn't break v1:
      `needs_mp` predicate so any stage with resolved `backend in
      {"sglang", "auto"}` forces `MultiProcessPipelineRunner`, even on a
      single-GPU / `tp_size=1` pipeline. Without this the launcher
-     short-circuits to `compile_pipeline()` and the worker never gets
+     short-circuits to `compile_pipeline()` and the runner never gets
      the per-process CUDA remap.
    - In `config/compiler.py:compile_pipeline`, reject any stage with
      resolved `backend in {"sglang", "auto"}` **or**
@@ -2515,8 +2544,8 @@ Phase 0 — landing path that doesn't break v1:
      prevents a future signature-default flip from silently bypassing
      the CUDA isolation.
    - **Real-factory signature lock**: `import inspect` and assert that
-     `inspect.signature(create_image_encoder_executor).parameters["backend"].default == "local"`
-     and the same for `create_audio_encoder_executor`. The previous
+     `inspect.signature(create_image_encoder_runner).parameters["backend"].default == "local"`
+     and the same for `create_audio_encoder_runner`. The previous
      test only proves the resolver ignores signature defaults; this
      one proves the actual production factories never have their
      default flipped to `"auto"` or `"sglang"` by accident. Cheap to
@@ -2538,9 +2567,10 @@ Phase 0 — landing path that doesn't break v1:
      `_build_stage_groups` must succeed. Locks Layer 1 of rule 6 —
      proves the encoder reject is not over-broad.
    - **TP preflight Layer 1 (factory not TP-capable)**: build a
-     config where some stage uses a SimpleScheduler factory like
-     `create_aggregate_executor` (no `tp_rank/tp_size/nccl_port` in
-     signature) and `tp_size=2`. `_build_stage_groups` must raise
+     config where some non-encoder stage uses an existing SimpleScheduler
+     factory like `create_aggregate_executor` (no
+     `tp_rank/tp_size/nccl_port` in signature) and `tp_size=2`.
+     `_build_stage_groups` must raise
      `ValueError` listing the missing parameters. This is the case
      the previous single-layer preflight silently passed through to
      subprocess spawn.
@@ -2552,13 +2582,13 @@ Phase 0 — landing path that doesn't break v1:
      a TP config to single-rank.
    - **Allocation-ready gather (mid-recv deadlock guard)**: run
      `EncoderScheduler` with `tp_size=2` and a fake `torch.empty` on
-     the follower that raises on the **second** spec (so the first
+     the non-entry rank that raises on the **second** spec (so the first
      allocation succeeds, mimicking partial OOM). Assert (a) entry
      rank does **not** issue any `dist.broadcast(t, group=device_group)`
-     call (use a mock that records calls); (b) follower returns
+     call (use a mock that records calls); (b) the non-entry rank returns
      `(messages, error)` from `_recv_messages` instead of raising;
      (c) both ranks reach the pre-forward `all_gather_object` handshake
-     with `local_err is not None` on the follower side; (d) the
+     with `local_err is not None` on the non-entry-rank side; (d) the
      entry rank's drained `local` is forwarded via the tuple return,
      so `_emit_error(messages, ...)` produces one error message per
      drained request. Locks the `_allocation_ready_gather` contract.
@@ -2567,12 +2597,12 @@ Phase 0 — landing path that doesn't break v1:
      variants before the metadata `broadcast_pyobj`: (1) fake
      `request_cost_fn` raises inside `_collect_batch_from_inbox` after
      draining at least one request; (2) fake `_strip_and_lift` raises
-     after batch collection succeeds. Assert (a) the follower rank does
+     after batch collection succeeds. Assert (a) the non-entry rank does
      **not** block on `broadcast_pyobj` indefinitely (bounded-time wait
      with fail-on-timeout); (b) `_recv_messages` returns
      `(messages, exc)` on **both** ranks rather than raising — entry
      rank's `messages` equals the drained list for the collect-failure
-     variant, follower's `messages` is `[]`, follower's exception text
+     variant, non-entry rank's `messages` is `[]`, non-entry rank's exception text
      quotes the entry-rank exception via `repr(exc)`; (c) the
      scheduler's pre-forward `all_gather_object` handshake observes the
      recv failure and emits exactly one `OutgoingMessage(type="error")`
@@ -2585,12 +2615,12 @@ Phase 0 — landing path that doesn't break v1:
    - **Pre-forward build error recovery**: fake
      `adapter.build_batch(messages)` to raise on one rank before
      `encode_batch` is called. Assert all ranks enter the pre-forward
-     `all_gather_object` handshake, no rank calls `worker.encode_batch`,
+     `all_gather_object` handshake, no rank calls `runner.encode_batch`,
      the entry rank emits one `OutgoingMessage(type="error")` per
      drained request, and the scheduler proceeds to the next iteration.
      This locks the boundary between recoverable adapter shape errors
      and fatal TP model-forward errors.
-   - **Fatal TP forward fault**: fake `worker.encode_batch(plan)` so one
+   - **Fatal TP forward fault**: fake `runner.encode_batch(plan)` so one
      rank raises after the other rank has entered a mocked device
      collective. Assert the failing rank calls `_fatal_tp_forward_error`
      / exits non-zero instead of entering the CPU pre-forward gather,
@@ -2614,27 +2644,27 @@ Phase 0 — landing path that doesn't break v1:
      constructed. Repeat for `gpu_id`, `nccl_port`, `rank`, and
      `world_size`. This covers topology keys that reach the helper
      through `**overrides`; helper-signature keys such as `tp_size`,
-     `base_gpu_id`, and `dist_init_addr` are covered by the worker-level
+     `base_gpu_id`, and `dist_init_addr` are covered by the runner-level
      test below because Python would otherwise reject the duplicate
      keyword before helper code can run.
    - **AR-only knob protection — factory level**: call
-     `create_image_encoder_executor(...,
+     `create_image_encoder_runner(...,
      server_args_overrides={"mem_fraction_static": 0.5})` and assert
-     the `ValueError` propagates from helper through worker
+     the `ValueError` propagates from helper through runner
      `**overrides` splat. This locks the dict-style entry point users
      actually configure through `StageConfig.factory_args`.
    - **Encoder TP source-of-truth protection — factory level**: call
-     `create_image_encoder_executor(...,
+     `create_image_encoder_runner(...,
      server_args_overrides={"tp_size": 2})` and assert the same
      source-of-truth `ValueError` propagates before
      `build_sglang_encoder_server_args(...)` is called. Repeat for
      `base_gpu_id`, `dist_init_addr`, `dtype`, `load_format`, and for
-     `create_audio_encoder_executor`. This catches the user-facing
+     `create_audio_encoder_runner`. This catches the user-facing
      config shape where a deployment tries to configure encoder TP or
      GPU placement through `server_args_overrides` instead of
      `StageConfig.tp_size` / `StageConfig.gpu`.
-2. Add `sglang_omni_v1/model_runner/sglang_encoder_worker.py`. Behind
-   `backend="sglang"` only — never the default in this PR. The worker
+2. Add `sglang_omni_v1/model_runner/sglang_encoder_runner.py`. Behind
+   `backend="sglang"` only — never the default in this PR. The runner
    builds `EncoderModuleContainer` from adapter-provided
    `EncoderModuleSpec`s and partial-loads matching checkpoint prefixes;
    it must not call `get_model()` on the full upstream
@@ -2645,8 +2675,8 @@ Phase 0 — landing path that doesn't break v1:
    audio), including the visual/audio `EncoderModuleSpec`s and tests that
    the image stage does not load `audio_tower`/LLM/talker weights and the
    audio stage does not load visual/LLM/talker weights.
-5. Update `create_image_encoder_executor()` and
-   `create_audio_encoder_executor()` to accept `backend`, `tp_rank`,
+5. Update `create_image_encoder_runner()` and
+   `create_audio_encoder_runner()` to accept `backend`, `tp_rank`,
    `tp_size`, `nccl_port`, `load_format`, `server_args_overrides`. Default
    `backend="local"` keeps current behaviour.
 6. Add a Qwen3-Omni config variant (`qwen3_omni_encoder_tp.py` or a CLI
@@ -2725,7 +2755,7 @@ Minimum lanes (unit + GPU + E2E):
     expected per-request `encoder_outs` dict shape.
   - `EncoderScheduler._recv_messages` mocks the TP groups and confirms
     that on the entry rank the metadata pickle does not contain tensor
-    payload bytes, while followers reconstruct identical
+    payload bytes, while non-entry ranks reconstruct identical
     `IncomingMessage` objects after `dist.broadcast`.
   - `EncoderModuleContainer.load_weights` filters checkpoint keys by
     `EncoderModuleSpec`: image stage accepts only visual prefixes, audio
@@ -2769,24 +2799,24 @@ Minimum lanes (unit + GPU + E2E):
 
 ## Open Questions
 
-1. **Upstream `EncoderModelWorker` / partial encoder loader helper.**
+1. **Upstream `EncoderModelRunner` / partial encoder loader helper.**
    Should we push the shared init + partial-load sequence
    (`set_global_server_args_for_scheduler` → `ModelConfig` → `LoadConfig`
    → `init_distributed_environment` → `initialize_model_parallel` →
    `initialize_dp_attention` → instantiate declared encoder submodules →
    load matching checkpoint prefixes → expose `tp_group`) into SGLang main
    as a public helper class? That would delete most of
-   `SGLangEncoderWorker.__init__` and remove the only place v1 reads into
+   `SGLangEncoderRunner.__init__` and remove the only place v1 reads into
    upstream `MMEncoder` / model-loader internals. The upstream helper should
    **not** call `get_model()` on the full `ForConditionalGeneration` class;
    it should be a first-class encoder-submodule loader. Recommended: land
    the local helper in Phase 0, then file an upstream issue after Phase 1
-   passes, propose `sglang.srt.disaggregation.EncoderModelWorker`, driven by
+   passes, propose `sglang.srt.disaggregation.EncoderModelRunner`, driven by
    SGLang-Omni as the first consumer.
 
    Note (Chencheng): This partial encoder loader should eventually be
    upstreamed to SGLang. For now, we keep it in SGLang-Omni to unblock
-   development and validation. Once the upstream `EncoderModelWorker` /
+   development and validation. Once the upstream `EncoderModelRunner` /
    partial encoder loader lands, Omni should replace the local helper with
    the upstream API.
 
@@ -2829,7 +2859,7 @@ Minimum lanes (unit + GPU + E2E):
    in Phase 2, after `tp_size>1` parity is locked.
 
 7. **Multinode encoder TP.** Phase 0 is single-node. `nnodes` and
-   `node_rank` sit in `_ENCODER_PROTECTED_KEYS` so the SGLang worker
+   `node_rank` sit in `_ENCODER_PROTECTED_KEYS` so the SGLang runner
    can never accidentally enter a multinode init path; the launcher
    only allocates one NCCL port per stage and assumes
    `127.0.0.1`-loopback dist-init addresses. Multinode encoder TP
@@ -2842,7 +2872,7 @@ Minimum lanes (unit + GPU + E2E):
 
 ## Progress Tracking
 
-- [ ] Phase 0 land — `EncoderScheduler` + `SGLangEncoderWorker` +
+- [ ] Phase 0 land — `EncoderScheduler` + `SGLangEncoderRunner` +
       Qwen3-Omni adapter, `backend="local"` default.
 - [ ] Phase 1 parity — image/audio encoder local-vs-sglang, tp1-vs-tp2.
 - [ ] Phase 2 — `backend="auto"` defaults to SGLang for Qwen3-Omni.

--- a/docs/developer_reference/encoder_tp_path_b_design.md
+++ b/docs/developer_reference/encoder_tp_path_b_design.md
@@ -294,6 +294,29 @@ from sglang_omni_v1.pipeline.relay_io import extract_tensors, restore_tensors
 _RECV_ERROR_KIND = "encoder_recv_error"  # picklable string tag
 
 
+class BatchCollectError(RuntimeError):
+    """Batch admission failed after draining one or more messages."""
+
+    def __init__(self, messages: list[IncomingMessage], error: BaseException):
+        super().__init__(str(error))
+        self.messages = messages
+        self.error = error
+
+
+def _collect_batch_or_error(
+    self,
+) -> tuple[list[IncomingMessage], BaseException | None]:
+    """Collect a batch without letting admission-control errors escape."""
+    try:
+        return self._collect_batch_from_inbox(), None
+    except BatchCollectError as exc:
+        return exc.messages, exc.error
+    except Exception as exc:                          # noqa: BLE001
+        # No request was safely captured. This path should only cover
+        # queue/runtime bugs outside request_cost_fn.
+        return [], exc
+
+
 def _recv_messages(
     self,
 ) -> tuple[list[IncomingMessage], BaseException | None]:
@@ -309,14 +332,13 @@ def _recv_messages(
     get_video_feature() only call .type(dtype), not .to(device).
     """
     if self.worker.tp_size == 1:
-        # Cost-capped collect — same admission control SimpleScheduler
-        # uses (max_batch_size / max_batch_wait_ms / max_batch_cost).
-        # The TP path needs identical caps, otherwise long-video
-        # batches that the local image encoder rejects today would
-        # silently flow through and OOM in _strip_and_lift or forward.
-        local = self._collect_batch_from_inbox()
-        if not local:
-            return local, None
+        # Cost-capped collect uses adapter request_cost_fn, so it is
+        # part of the recv error boundary rather than a guaranteed-safe
+        # prelude. This keeps request-level error semantics even in the
+        # tp_size == 1 lane.
+        local, collect_err = self._collect_batch_or_error()
+        if collect_err is not None or not local:
+            return local, collect_err
         try:
             meta_msgs, tensor_lists, specs_lists = self._strip_and_lift(local)
         except Exception as exc:                          # noqa: BLE001
@@ -330,13 +352,22 @@ def _recv_messages(
         # Cost cap runs on the entry rank only — the broadcast below
         # ships the entry rank's already-bounded `local` list to
         # followers, so all ranks see the same admission decision.
-        local = self._collect_batch_from_inbox()
-        # _collect_batch_from_inbox is queue gets + cost-cap arithmetic
-        # — no device work, no failure mode worth handshaking.
+        local, collect_err = self._collect_batch_or_error()
+        if collect_err is not None:
+            # request_cost_fn is adapter/model code. Treat admission
+            # failures as pre-metadata recv failures, otherwise
+            # followers block forever in broadcast_pyobj waiting for a
+            # metadata payload that the entry rank never sends.
+            broadcast_pyobj(
+                [{"kind": _RECV_ERROR_KIND, "error": repr(collect_err)}],
+                tp.rank, tp.cpu_group, src=src_rank,
+            )
+            return local, collect_err
+
         # _strip_and_lift does the H2D copy + dtype coercion that can
-        # OOM / TypeError; that's the failure we have to tell followers
-        # about *before* the metadata broadcast, otherwise they block
-        # on it forever and the runner can't see it
+        # OOM / TypeError; it must also fail through the same sentinel
+        # path *before* the metadata broadcast, otherwise followers
+        # block on it forever and the runner can't see it
         # (mp_runner.py:332-342 only catches exit-code failures).
         try:
             meta_msgs, tensor_lists, specs_lists = self._strip_and_lift(local)
@@ -685,7 +716,11 @@ def _collect_batch_from_inbox(self) -> list[IncomingMessage]:
         return [first]
 
     batch = [first]
-    batch_cost = self._message_cost(first)
+    try:
+        batch_cost = self._message_cost(first)
+    except Exception as exc:                    # noqa: BLE001
+        raise BatchCollectError(batch, exc) from exc
+
     deadline = time.monotonic() + self._max_batch_wait_s
     while len(batch) < self._max_batch_size:
         try:
@@ -702,7 +737,15 @@ def _collect_batch_from_inbox(self) -> list[IncomingMessage]:
             self._pending_messages.append(msg)
             continue
         if self._max_batch_cost is not None:
-            cost = self._message_cost(msg)
+            try:
+                cost = self._message_cost(msg)
+            except Exception as exc:            # noqa: BLE001
+                # The message has already been drained from the queue.
+                # Include it in the failed recv iteration so the entry
+                # rank can emit one request-level error for it instead
+                # of silently dropping it.
+                batch.append(msg)
+                raise BatchCollectError(batch, exc) from exc
             if batch_cost + cost > self._max_batch_cost:
                 self._pending_messages.appendleft(msg)
                 break
@@ -721,6 +764,16 @@ intentionally so, to keep parity with the local fallback. The cost
 function takes a `StagePayload` and returns a byte estimate; it is the
 same `_create_image_encoder_request_cost_fn(model)` pattern v1 already
 uses (`models/qwen3_omni/stages.py:144-166`).
+
+Because `request_cost_fn` is adapter/model code, `_message_cost()` is not
+treated as infallible queue arithmetic. If it raises, `_collect_batch_from_inbox`
+raises `BatchCollectError(messages, cause)` with every message already
+drained in this iteration. `_recv_messages()` converts that into its
+normal `(messages, error)` return; in TP mode, the entry rank also sends
+the same `_RECV_ERROR_KIND` sentinel used for `_strip_and_lift` failures
+before followers wait for metadata. That preserves both properties we
+need: no request is silently dropped, and followers never block forever
+on a metadata broadcast that the entry rank skipped.
 
 ### Where admission control runs in `_recv_messages`
 
@@ -2295,22 +2348,25 @@ Phase 0 — landing path that doesn't break v1:
      so `_emit_error(messages, ...)` produces one error message per
      drained request. Locks the `_allocation_ready_gather` contract.
    - **Pre-broadcast error sentinel (`_recv_messages` deadlock guard)**:
-     run `EncoderScheduler` with `tp_size=2` and a fake `_strip_and_lift`
-     that raises on the entry rank before the metadata
-     `broadcast_pyobj`. Assert (a) the follower rank does **not**
-     block on `broadcast_pyobj` indefinitely (bounded-time wait with
-     fail-on-timeout); (b) `_recv_messages` returns `(messages, exc)`
-     on **both** ranks rather than raising — entry rank's `messages`
-     equals the drained list, follower's `messages` is `[]`,
-     follower's exception text quotes the entry-rank exception via
-     `repr(exc)`; (c) the scheduler's `all_gather_object` handshake
-     observes both ranks as failed and emits exactly one
-     `OutgoingMessage(type="error")` per drained request on the
-     entry rank (i.e. `len(error_emissions) == len(drained_messages)`,
-     not 0 and not 2× from double-counting); (d) the scheduler thread
-     stays alive and proceeds to the next loop iteration —
-     `Stage._handle_scheduler_crash` must not fire. Locks the
-     tagged-dict sentinel contract and the recv-error tuple return.
+     run `EncoderScheduler` with `tp_size=2` in two entry-rank failure
+     variants before the metadata `broadcast_pyobj`: (1) fake
+     `request_cost_fn` raises inside `_collect_batch_from_inbox` after
+     draining at least one request; (2) fake `_strip_and_lift` raises
+     after batch collection succeeds. Assert (a) the follower rank does
+     **not** block on `broadcast_pyobj` indefinitely (bounded-time wait
+     with fail-on-timeout); (b) `_recv_messages` returns
+     `(messages, exc)` on **both** ranks rather than raising — entry
+     rank's `messages` equals the drained list for the collect-failure
+     variant, follower's `messages` is `[]`, follower's exception text
+     quotes the entry-rank exception via `repr(exc)`; (c) the
+     scheduler's `all_gather_object` handshake observes both ranks as
+     failed and emits exactly one `OutgoingMessage(type="error")` per
+     drained request on the entry rank (i.e.
+     `len(error_emissions) == len(drained_messages)`, not 0 and not 2×
+     from double-counting); (d) the scheduler thread stays alive and
+     proceeds to the next loop iteration — `Stage._handle_scheduler_crash`
+     must not fire. Locks the tagged-dict sentinel contract and the
+     recv-error tuple return.
    - **AR-only knob protection — helper level**: directly call
      `build_sglang_encoder_server_args(model_path=..., tp_size=1,
      base_gpu_id=0, dist_init_addr="...", mem_fraction_static=0.5)`

--- a/docs/developer_reference/encoder_tp_path_b_design.md
+++ b/docs/developer_reference/encoder_tp_path_b_design.md
@@ -659,7 +659,9 @@ def start(self) -> None:
                     self._emit_error(messages, recv_err)
                 continue
         if not messages:
-            self._idle_check()
+            # _collect_batch_from_inbox -> _next_message uses a blocking
+            # inbox.get(timeout=...) so an idle loop already throttles
+            # itself, same as SimpleScheduler. No separate idle helper.
             continue
 
         plan = None
@@ -1576,7 +1578,7 @@ class _TensorSpec:
 class RequestSpan:
     """Slot for one request inside a batch.
 
-    Exactly one of skip_result or active_offsets is populated.
+    Exactly one of `skip_result` or the active fields below is populated.
     """
     request_id: str
     skip_result: dict | None = None        # preserved from preprocessor _skip
@@ -2601,7 +2603,8 @@ Minimum lanes (unit + GPU + E2E):
       shape in the bug discussed in #302).
 
 - **Reuse existing CI**
-  - The existing thinker / talker CI (test_qwen3_omni_v1_*.py) must pass
+  - The existing thinker / talker CI (test_v1_qwen3_omni_*.py and the
+    related test_v1_talker_*.py / test_v1_omni_scheduler.py files) must pass
     unchanged in `backend="local"` mode in Phase 0 and `backend="sglang"`
     mode in Phase 2.
 

--- a/docs/developer_reference/encoder_tp_path_b_design.md
+++ b/docs/developer_reference/encoder_tp_path_b_design.md
@@ -1275,7 +1275,15 @@ budget). Reusing the AR builder also fails at runtime because Phase 0's
 factory does not know a meaningful `context_length` for the encoder
 process.
 
-We therefore add a sibling helper next to the AR builder:
+We therefore add a sibling helper next to the AR builder. For encoder
+stages, tensor parallelism has exactly one source of truth:
+`StageConfig.tp_size` plus `StageConfig.gpu`. `MultiProcessPipelineRunner`
+turns those fields into the per-rank `tp_rank`, `tp_size`, `gpu_id`, and
+`nccl_port` kwargs that reach `SGLangEncoderWorker`. `server_args_overrides`
+is only for safe SGLang loading/runtime knobs such as quantization,
+attention backend, and remote weight loading; it must not be able to
+change rank topology or GPU placement after the runner has already
+spawned processes.
 
 ```python
 # sglang_omni_v1/scheduling/sglang_backend/server_args_builder.py
@@ -1295,7 +1303,12 @@ _ENCODER_PROTECTED_KEYS = frozenset({
     "moe_dense_tp_size",
     "nnodes",
     "node_rank",
+    "rank",
+    "world_size",
+    "tp_rank",
+    "gpu_id",
     "base_gpu_id",
+    "nccl_port",
     "dist_init_addr",
     # Encoder-only fork
     "encoder_only",
@@ -1370,12 +1383,13 @@ def build_sglang_encoder_server_args(
 The protected-key reject covers:
 
 - `tp_size`, `pp_size`, `dp_size`, `moe_dp_size`, `ep_size`,
-  `attn_cp_size`, `moe_dense_tp_size`, `nnodes`, `node_rank`,
-  `base_gpu_id`, `dist_init_addr` — pipeline runner decides these from
+  `attn_cp_size`, `moe_dense_tp_size`, `nnodes`, `node_rank`, `rank`,
+  `world_size`, `tp_rank`, `gpu_id`, `base_gpu_id`, `nccl_port`,
+  `dist_init_addr` — pipeline runner decides these from
   `StageConfig.tp_size` / `gpu` and the per-stage NCCL port allocator.
-  Phase 0 starts exactly `tp_size` local ranks; DP, EP, attention-CP, and
-  multinode shapes are out of scope and cannot be activated through
-  `server_args_overrides`.
+  Phase 0 starts exactly `StageConfig.tp_size` local ranks; DP, EP,
+  attention-CP, and multinode shapes are out of scope and cannot be
+  activated through `server_args_overrides`.
 - `encoder_only` / `language_only` — flipping these would route through
   a different upstream model factory and break the whole RFC.
 - `mm_enable_dp_encoder` — Phase 0–2 require encoder TP only; allowing
@@ -1403,6 +1417,13 @@ forward for FP8 / NVFP4 / remote-streaming deployments. `dtype` and
 `load_format` are also supported, but as top-level factory / worker
 arguments rather than `server_args_overrides`, to avoid duplicate keyword
 binding before the protected-key helper runs.
+
+`model_path`, `tp_size`, `base_gpu_id`, `dist_init_addr`, `dtype`, and
+`load_format` are rejected one level earlier in `SGLangEncoderWorker`
+because the helper receives them as explicit keyword arguments. That
+early reject is intentional: otherwise Python would raise a generic
+"got multiple values for keyword argument" `TypeError` before the
+protected-key check can produce the source-of-truth error message.
 
 `SGLangEncoderWorker.__init__` calls this helper directly. AR-only
 knobs (`mem_fraction_static`, `max_running_requests`,
@@ -2375,12 +2396,32 @@ Phase 0 — landing path that doesn't break v1:
      `chunked_prefill_size`, `context_length`, `max_prefill_tokens`.
      This is the helper signature `(..., **overrides)` so the AR knob
      goes in as a direct keyword.
+   - **Encoder TP source-of-truth protection — helper level**: directly
+     call `build_sglang_encoder_server_args(model_path=..., tp_size=1,
+     base_gpu_id=0, dist_init_addr="...", tp_rank=1)` and assert it
+     raises `ValueError` referencing `tp_rank` before `ServerArgs` is
+     constructed. Repeat for `gpu_id`, `nccl_port`, `rank`, and
+     `world_size`. This covers topology keys that reach the helper
+     through `**overrides`; helper-signature keys such as `tp_size`,
+     `base_gpu_id`, and `dist_init_addr` are covered by the worker-level
+     test below because Python would otherwise reject the duplicate
+     keyword before helper code can run.
    - **AR-only knob protection — factory level**: call
      `create_image_encoder_executor(...,
      server_args_overrides={"mem_fraction_static": 0.5})` and assert
      the `ValueError` propagates from helper through worker
      `**overrides` splat. This locks the dict-style entry point users
      actually configure through `StageConfig.factory_args`.
+   - **Encoder TP source-of-truth protection — factory level**: call
+     `create_image_encoder_executor(...,
+     server_args_overrides={"tp_size": 2})` and assert the same
+     source-of-truth `ValueError` propagates before
+     `build_sglang_encoder_server_args(...)` is called. Repeat for
+     `base_gpu_id`, `dist_init_addr`, `dtype`, `load_format`, and for
+     `create_audio_encoder_executor`. This catches the user-facing
+     config shape where a deployment tries to configure encoder TP or
+     GPU placement through `server_args_overrides` instead of
+     `StageConfig.tp_size` / `StageConfig.gpu`.
 2. Add `sglang_omni_v1/model_runner/sglang_encoder_worker.py`. Behind
    `backend="sglang"` only — never the default in this PR.
 3. Add `sglang_omni_v1/scheduling/encoder_scheduler.py` including the

--- a/docs/developer_reference/encoder_tp_path_b_design.md
+++ b/docs/developer_reference/encoder_tp_path_b_design.md
@@ -286,11 +286,15 @@ stays small.
 ### Sketch
 
 ```python
+import logging
+import os
+
 import torch.distributed as dist
 from sglang.srt.utils import broadcast_pyobj
 from sglang_omni_v1.pipeline.relay_io import extract_tensors, restore_tensors
 
 
+logger = logging.getLogger(__name__)
 _RECV_ERROR_KIND = "encoder_recv_error"  # picklable string tag
 
 
@@ -325,7 +329,7 @@ def _recv_messages(
     Never raises — returns (messages, error). The error is non-None if
     either rank failed during this iteration's recv. Drained messages
     are returned even on entry-rank failure so the scheduler can emit
-    request-level errors against them in the unified handshake.
+    request-level errors against them in the pre-forward handshake.
 
     Always run _strip_and_lift, even at tp_size == 1: the default shm
     relay delivers CPU tensors and upstream get_image_feature() /
@@ -504,12 +508,13 @@ existing channel.
 
 `_recv_messages` deliberately **never raises**. Returning
 `(messages, error)` lets the scheduler treat a recv-time failure
-exactly like a forward-time failure: same `local_err` slot, same
-`all_gather_object` handshake, same `_emit_error(messages, exc)`
-emission against the drained requests. If `_recv_messages` raised
-instead, the scheduler thread would die and `Stage._handle_scheduler_crash`
-(`pipeline/stage/runtime.py:145`) would tear the whole stage down —
-turning a single bad request into a stage-level abort.
+as a recoverable **pre-forward** failure: same `local_err` slot, same
+pre-forward `all_gather_object` handshake, same
+`_emit_error(messages, exc)` emission against the drained requests. If
+`_recv_messages` raised instead, the scheduler thread would die and
+`Stage._handle_scheduler_crash` (`pipeline/stage/runtime.py:145`) would
+tear the whole stage down — turning a single bad request into a
+stage-level abort.
 
 #### Allocation-ready gather
 
@@ -532,10 +537,9 @@ between the metadata broadcast and the first `dist.broadcast`:
    tensors already exist).
 3. Both ranks gather their per-rank alloc-success boolean on
    `tp.cpu_group`.
-4. If `not all(flags)`, every rank returns
-   `(messages, error)` and the scheduler's outer `all_gather_object`
-   handshake takes care of the rest — no device broadcast was ever
-   issued, so no rank blocks.
+4. If `not all(flags)`, every rank returns `(messages, error)` and the
+   scheduler's pre-forward `all_gather_object` handshake takes care of
+   the rest — no device broadcast was ever issued, so no rank blocks.
 
 This is a small, picklable collective added once per recv, and it
 makes the device broadcast loop unconditionally safe to enter once
@@ -636,68 +640,89 @@ def start(self) -> None:
     self._running = True
     while self._running:
         # ----------------------------------------------------------
-        # Per-iteration error boundary covering recv, build_batch,
-        # encode_batch, and slice_results. _recv_messages never
-        # raises — it returns (messages, error) so a recv-time
-        # failure can flow through the same handshake as a
-        # forward-time failure. All four steps are deterministic
-        # given the broadcast-equal `messages`; any one failing
-        # without rank-sync would leave peers stuck at the next
-        # collective.
+        # Three error domains:
+        # 1. recv/build_batch are pre-forward and recoverable. They
+        #    synchronize through the TP CPU group before any model
+        #    collective starts.
+        # 2. encode_batch enters upstream TP collectives. A rank-local
+        #    exception there is fatal to the stage group; do not try a
+        #    post-hoc CPU gather while peers may still be blocked in
+        #    NCCL.
+        # 3. slice_results runs only on the entry rank after forward
+        #    returned on every rank, so it can emit request errors and
+        #    continue.
         # ----------------------------------------------------------
-        results = None
-        local_err: BaseException | None = None
-
         messages, recv_err = self._recv_messages()
         if recv_err is not None:
-            local_err = recv_err
-        elif not messages:
+            if self._gather_pre_forward_error(recv_err):
+                if self.worker.is_entry_rank:
+                    self._emit_error(messages, recv_err)
+                continue
+        if not messages:
             self._idle_check()
             continue
-        else:
-            try:
-                plan = self.adapter.build_batch(messages)        # all ranks
-                raw = self.worker.encode_batch(plan)             # all ranks
-                if self.worker.is_entry_rank:
-                    results = self.adapter.slice_results(raw, plan, messages)
-            except Exception as exc:                             # noqa: BLE001
-                local_err = exc
 
-        # Synchronize error state across ranks. all_gather_object
-        # marshals the picklable error flag; the exception object
-        # itself stays local. tp_size==1 short-circuits.
-        if self.worker.tp_size > 1:
-            err_flags: list[bool] = [False] * self.worker.tp_size
-            dist.all_gather_object(
-                err_flags,
-                local_err is not None,
-                group=self.worker.tp_group.cpu_group,
-            )
-            any_err = any(err_flags)
-        else:
-            any_err = local_err is not None
+        plan = None
+        build_err: BaseException | None = None
+        try:
+            plan = self.adapter.build_batch(messages)            # all ranks
+        except Exception as exc:                                 # noqa: BLE001
+            build_err = exc
 
-        if any_err:
+        if self._gather_pre_forward_error(build_err):
             if self.worker.is_entry_rank:
-                # Emit one error per request that was drained on the
-                # entry rank this iteration. `messages` is the entry
-                # rank's drained list — populated even on recv-time
-                # failure thanks to the (messages, error) return.
                 self._emit_error(
                     messages,
-                    local_err if local_err is not None
-                    else RuntimeError("peer-rank encoder forward failed"),
+                    build_err if build_err is not None
+                    else RuntimeError("peer-rank encoder build_batch failed"),
                 )
-            # Followers do nothing here — Stage._drain_outbox_follower
-            # already discards results. The next loop iteration starts
-            # a fresh collective.
             continue
 
-        if self.worker.is_entry_rank and results is not None:
-            for msg, out in zip(messages, results):
-                self.outbox.put(
-                    OutgoingMessage(request_id=msg.request_id, type="result", data=out)
-                )
+        try:
+            raw = self.worker.encode_batch(plan)                 # all ranks
+        except Exception as exc:                                 # noqa: BLE001
+            self._fatal_tp_forward_error(exc)
+            raise                                               # unreachable
+
+        if not self.worker.is_entry_rank:
+            continue
+
+        try:
+            results = self.adapter.slice_results(raw, plan, messages)
+        except Exception as exc:                                 # noqa: BLE001
+            self._emit_error(messages, exc)
+            continue
+
+        for msg, out in zip(messages, results):
+            self.outbox.put(
+                OutgoingMessage(request_id=msg.request_id, type="result", data=out)
+            )
+
+
+def _gather_pre_forward_error(self, local_err: BaseException | None) -> bool:
+    """Synchronize recoverable recv/build errors before model collectives."""
+    if self.worker.tp_size <= 1:
+        return local_err is not None
+    err_flags: list[bool] = [False] * self.worker.tp_size
+    dist.all_gather_object(
+        err_flags,
+        local_err is not None,
+        group=self.worker.tp_group.cpu_group,
+    )
+    return any(err_flags)
+
+
+def _fatal_tp_forward_error(self, error: BaseException) -> None:
+    """Exit non-zero after a TP forward fault.
+
+    Once encode_batch has entered upstream SGLang TP collectives, one
+    rank cannot safely recover locally: peers may be stuck in NCCL and
+    never reach a CPU-side error gather. Force a child-process failure
+    so StageGroup / MultiProcessPipelineRunner tears down the whole TP
+    group and fails outstanding requests from the coordinator side.
+    """
+    logger.exception("Fatal TP encoder forward failure")
+    os._exit(1)
 ```
 
 ### Batch admission control
@@ -800,24 +825,25 @@ no separate "admission-control variant" of `_recv_messages`.
    upstream encoder; SGLang's `ColumnParallelLinear` / `RowParallelLinear`
    issue collectives internally.
 5. Emit `OutgoingMessage` to the outbox **only on the entry rank**.
-6. Run a **per-iteration error boundary** covering all four steps
-   (`_recv_messages`, `build_batch`, `encode_batch`, `slice_results`)
-   on every rank. `_recv_messages` returns `(messages, error)`
-   instead of raising; the other three are wrapped in try/except.
-   After the four steps, every rank exchanges its `local_err is None`
-   flag through `dist.all_gather_object` on the TP CPU group. If any
-   rank failed, the entry rank emits **one
-   `OutgoingMessage(type="error")` per drained request** (so HTTP-500
-   propagates per request, matching v1's existing request-level
-   error path), and every rank `continue`s into the next loop
-   iteration. Followers do **not** raise to crash the scheduler
-   thread; that would trigger `Stage._handle_scheduler_crash`
-   (`pipeline/stage/runtime.py:145`) and tear the whole stage down,
-   which is a stage-level abort, not the request-level error this
-   contract promises. `MultiProcessPipelineRunner._monitor_children`
-   is the fallback only for cases where a process actually exits
-   non-zero (e.g. a segfault inside the upstream model), not for
-   request-level encoder errors.
+6. Split scheduler failures by collective boundary:
+   - **Recoverable pre-forward:** `_recv_messages` and
+     `build_batch`. `_recv_messages` returns `(messages, error)`
+     instead of raising. `build_batch` is wrapped in try/except. Before
+     entering `encode_batch`, every rank exchanges its local error flag
+     through `dist.all_gather_object` on the TP CPU group. If any rank
+     failed, the entry rank emits **one `OutgoingMessage(type="error")`
+     per drained request** and every rank `continue`s into the next loop
+     iteration.
+   - **Fatal forward:** `encode_batch` enters upstream SGLang TP
+     collectives (`ColumnParallelLinear`, `RowParallelLinear`, attention
+     collectives, etc.). A rank-local OOM / CUDA / NCCL exception there
+     cannot be recovered with a post-hoc CPU gather because peers may
+     still be blocked in NCCL. The rank that observes the exception must
+     exit non-zero; `StageGroup` / `MultiProcessPipelineRunner` tears down
+     the whole TP group.
+   - **Recoverable post-forward:** `slice_results` runs only on the
+     entry rank after `encode_batch` returned on every rank. It can emit
+     per-request errors and continue.
 
 ### Why a new scheduler instead of extending SimpleScheduler
 
@@ -2143,26 +2169,28 @@ Rules:
 - `SGLangEncoderWorker.encode_batch` and `EncoderAdapter.run_feature` only
   catch specific expected exceptions (e.g. `OutOfMemoryError` for batch
   splitting, if we ever add it). They never catch base `Exception`.
-- `EncoderScheduler.start()` covers **four** steps in one
-  per-iteration error boundary: `_recv_messages`, `build_batch`,
-  `encode_batch`, `slice_results`. `_recv_messages` does not raise —
-  it returns `(messages, error)`. The other three are wrapped in a
-  try/except that funnels into the same `local_err` slot. Each step
-  is deterministic given the broadcast-equal `messages`, but any one
-  failing without rank-sync would leave peers stuck at the next
-  collective.
-- Cross-rank synchronization: after the four steps,
-  `dist.all_gather_object` exchanges a per-rank "did I fail?" boolean
-  on the TP CPU group. If any rank failed, every rank skips
-  emit-results and starts the next iteration on a fresh collective.
-  The entry rank emits one
-  `OutgoingMessage(type="error", data=str(exc))` per request that
-  was drained this iteration (`messages` is non-empty on recv-time
-  failure thanks to the tuple return), which
-  `Stage._drain_outbox_external` converts into a Coordinator failure
-  → HTTP 500. If a follower failed but the entry rank did not, the
-  entry rank emits `RuntimeError("peer-rank encoder forward failed")`
-  against the same drained messages.
+- `EncoderScheduler.start()` has **three** error domains, not one
+  catch-all boundary:
+  - Recoverable pre-forward: `_recv_messages` and `build_batch`.
+    `_recv_messages` does not raise — it returns `(messages, error)`.
+    `build_batch` is wrapped in try/except. Before any model collective,
+    ranks exchange a per-rank "did I fail?" boolean through
+    `dist.all_gather_object` on the TP CPU group. If any rank failed,
+    every rank skips forward and starts the next iteration on a fresh
+    recv collective. The entry rank emits one
+    `OutgoingMessage(type="error", data=str(exc))` per request that was
+    drained this iteration, which `Stage._drain_outbox_external`
+    converts into a Coordinator failure → HTTP 500.
+  - Fatal forward: `encode_batch` is inside upstream SGLang TP
+    collectives. A rank-local OOM / CUDA / NCCL exception can leave peer
+    ranks blocked in NCCL, so a CPU `all_gather_object` after the
+    exception is not safe. The rank that catches the exception must exit
+    non-zero immediately. `MultiProcessPipelineRunner._monitor_children`
+    observes `StageGroup.any_dead()` and tears down the whole TP group.
+  - Recoverable post-forward: `slice_results` runs only on the entry rank
+    after `encode_batch` returned on all ranks. It can emit
+    per-request errors locally and continue; no TP peer is waiting on a
+    matching collective at that point.
 - **Pre-broadcast entry-rank failures**: `_recv_messages` does H2D
   copies inside `_strip_and_lift` *before* the metadata broadcast. A
   failure there (OOM, dtype coercion, malformed payload) on the
@@ -2180,10 +2208,17 @@ Rules:
   returns `(local, exc)`. Followers detect the dict by kind-string
   equality (not identity — pickle round-trip would break that) and
   return `([], RuntimeError(...))`. Both ranks then converge on the
-  scheduler's per-iteration `all_gather_object` handshake without
+  scheduler's pre-forward `all_gather_object` handshake without
   ever crashing the scheduler thread. No new control channel, no
   runner-level rescue, no `Stage._handle_scheduler_crash` (the
   stage-level abort path) involvement.
+- **Fatal forward failures require coordinator fail-all plumbing.**
+  Current `StageGroup.any_dead()` only reports a non-zero child exit
+  (`pipeline/stage_group.py:130-132`), and `MultiProcessPipelineRunner`
+  currently responds by calling `stop()` (`pipeline/mp_runner.py:332-342`).
+  Phase 0 must make that path fail all active Coordinator futures /
+  stream queues with a non-empty error before shutdown, otherwise
+  outstanding HTTP requests can hang after the TP group is killed.
 - No adapter may return a fake-success embedding (zero tensor, empty list,
   etc.). v1's broader refactor explicitly disallows that pattern.
 
@@ -2243,12 +2278,13 @@ config just sets `backend="sglang"` and `tp_size`.
 4. Validate parity: `backend="local"` vs `backend="sglang", tp_size=1` on
    the same input. Then bump `tp_size`.
 
-Everything else (`Stage`, `StageGroup`, `Coordinator`, `relay`,
-`EncoderScheduler` itself) is reused without modification.
-`MultiProcessPipelineRunner` and `pipeline/stage_process.py` get the
-small launcher extension described in [Required launcher
-change](#required-launcher-change), which is a one-time addition that
-all sglang-backed encoder stages share.
+After Phase 0, everything else (`Stage`, `StageGroup`, `Coordinator`,
+`relay`, `EncoderScheduler` itself) is reused by new models without
+model-specific modification. `MultiProcessPipelineRunner`, Coordinator
+failure plumbing, and `pipeline/stage_process.py` get the small launcher /
+fatal-path extension described in
+[Required launcher change](#required-launcher-change), which is a one-time
+addition that all sglang-backed encoder stages share.
 
 ## Implementation Plan
 
@@ -2285,8 +2321,15 @@ Phase 0 — landing path that doesn't break v1:
      rejects any TP stage whose factory does not accept
      `tp_rank/tp_size/nccl_port`; Layer 2 rejects encoder TP stages
      whose resolved backend is not `"sglang"`.
+   - In `MultiProcessPipelineRunner._monitor_children`, when
+     `StageGroup.any_dead()` reports a non-zero child exit, fail all
+     active Coordinator futures / stream queues with a non-empty
+     stage-group fatal error before `stop()` tears down the remaining
+     ranks. This is the required fatal path for `encode_batch()` faults:
+     the scheduler intentionally exits the process instead of attempting
+     an unsafe post-forward CPU gather.
 
-   These six sub-steps are the load-bearing prerequisite for Phase 1's
+   These seven sub-steps are the load-bearing prerequisite for Phase 1's
    `tp_size=1, gpu!=0` parity lane to validate the right thing — see
    [GPU placement across `tp_size=1` and `tp_size>1` lanes](#gpu-placement-across-tp_size1-and-tp_size1-lanes)
    and [Required launcher change](#required-launcher-change).
@@ -2363,7 +2406,7 @@ Phase 0 — landing path that doesn't break v1:
      rank does **not** issue any `dist.broadcast(t, group=device_group)`
      call (use a mock that records calls); (b) follower returns
      `(messages, error)` from `_recv_messages` instead of raising;
-     (c) both ranks reach the unified `all_gather_object` handshake
+     (c) both ranks reach the pre-forward `all_gather_object` handshake
      with `local_err is not None` on the follower side; (d) the
      entry rank's drained `local` is forwarded via the tuple return,
      so `_emit_error(messages, ...)` produces one error message per
@@ -2380,14 +2423,31 @@ Phase 0 — landing path that doesn't break v1:
      rank's `messages` equals the drained list for the collect-failure
      variant, follower's `messages` is `[]`, follower's exception text
      quotes the entry-rank exception via `repr(exc)`; (c) the
-     scheduler's `all_gather_object` handshake observes both ranks as
-     failed and emits exactly one `OutgoingMessage(type="error")` per
-     drained request on the entry rank (i.e.
+     scheduler's pre-forward `all_gather_object` handshake observes the
+     recv failure and emits exactly one `OutgoingMessage(type="error")`
+     per drained request on the entry rank (i.e.
      `len(error_emissions) == len(drained_messages)`, not 0 and not 2×
      from double-counting); (d) the scheduler thread stays alive and
      proceeds to the next loop iteration — `Stage._handle_scheduler_crash`
      must not fire. Locks the tagged-dict sentinel contract and the
      recv-error tuple return.
+   - **Pre-forward build error recovery**: fake
+     `adapter.build_batch(messages)` to raise on one rank before
+     `encode_batch` is called. Assert all ranks enter the pre-forward
+     `all_gather_object` handshake, no rank calls `worker.encode_batch`,
+     the entry rank emits one `OutgoingMessage(type="error")` per
+     drained request, and the scheduler proceeds to the next iteration.
+     This locks the boundary between recoverable adapter shape errors
+     and fatal TP model-forward errors.
+   - **Fatal TP forward fault**: fake `worker.encode_batch(plan)` so one
+     rank raises after the other rank has entered a mocked device
+     collective. Assert the failing rank calls `_fatal_tp_forward_error`
+     / exits non-zero instead of entering the CPU pre-forward gather,
+     `StageGroup.any_dead()` becomes true, `MultiProcessPipelineRunner`
+     terminates the peer process, and all active Coordinator futures /
+     stream queues are failed with a non-empty stage-group fatal error.
+     This test must explicitly reject "scheduler keeps running and emits
+     request-level errors" for forward-time TP faults.
    - **AR-only knob protection — helper level**: directly call
      `build_sglang_encoder_server_args(model_path=..., tp_size=1,
      base_gpu_id=0, dist_init_addr="...", mem_fraction_static=0.5)`
@@ -2526,9 +2586,16 @@ Minimum lanes (unit + GPU + E2E):
     End-to-end waveform produced, no OOM.
 
 - **Fault injection**
-  - Force encoder OOM (oversized pixel batch) and verify the request fails
-    through `Coordinator` with HTTP 500 and a non-empty error body.
-    Specifically reject:
+  - Force a recoverable pre-forward encoder OOM / malformed payload
+    (`_recv_messages`, tensor allocation, or `build_batch`) and verify
+    the request fails through `Coordinator` with HTTP 500 and a non-empty
+    error body while the scheduler keeps serving later requests.
+  - Force a rank-local `encode_batch` TP forward fault and verify the
+    rank exits non-zero, peers are terminated by `StageGroup`, and all
+    active Coordinator futures / streams fail with a non-empty fatal
+    error instead of hanging. This is a stage-group fatal path, not a
+    request-level recovery path.
+  - Specifically reject:
     - `data=None` "success" coming back from `code2wav` (Ming-Omni shape).
     - zero-tensor "success" coming back from talker (current Qwen3-Omni
       shape in the bug discussed in #302).

--- a/docs/developer_reference/encoder_tp_path_b_design_lean.md
+++ b/docs/developer_reference/encoder_tp_path_b_design_lean.md
@@ -1,0 +1,377 @@
+# RFC: Multimodal Encoder TP via SGLang Native Encoders (Plan B, Lean Draft)
+
+Issue: https://github.com/sgl-project/sglang-omni/issues/375
+
+Decision: SGLang-Omni should use SGLang main's native multimodal encoder
+implementations and inherit SGLang tensor parallelism, instead of maintaining
+separate encoder copies under `models/<name>/components/`.
+
+This lean draft keeps the RFC at the decision and contract level. Detailed
+Python sketches, per-key server-argument protection, and assertion-level test
+plans belong in Phase 0 PR code comments or a linked implementation tracking
+issue.
+
+For the detailed implementation notes behind these contracts, see
+[`encoder_tp_path_b_design.md`](encoder_tp_path_b_design.md).
+
+## Motivation
+
+This is solving a long-sequence activation-memory OOM, not an encoder weight
+residency problem. For Qwen3-Omni, the combined vision and audio encoder
+weights are small relative to the thinker, roughly 2.5 GB, but encoder
+activation memory scales with media length. A one-minute video can push encoder
+activations past 30 GB on a single GPU. That pressure is what pushes the
+colocated thinker toward OOM today and motivates workaround-style reservation
+such as `--encoder-mem-reserve` in #339. The concrete pain is the long-video
+path discussed around #327 / #339.
+
+Tensor parallelism is the useful tool here because it shards encoder
+activations across ranks. Giving the encoder a larger GPU only moves the cliff,
+and data parallelism would replicate the same long-sequence activation footprint
+on every rank. We still avoid loading full thinker/talker weights inside an
+encoder stage, but the primary scaling target is activation memory.
+
+## Goals
+
+- Reuse upstream SGLang encoder modules and TP kernels for multimodal encoders.
+- Keep the public v1 pipeline topology unchanged.
+- Shard encoder activation memory for long image/video/audio inputs.
+- Preserve v1 request lifecycle, relay ownership, abort handling, and
+  Coordinator completion semantics.
+- Keep the local HF encoder path as a fallback for encoders not yet upstreamed
+  into SGLang.
+
+## Non-Goals
+
+- Do not instantiate the full upstream `ForConditionalGeneration` class inside
+  encoder stages.
+- Do not introduce encoder DP in this RFC. Upstream DP encoder support remains
+  model-specific and is a follow-up path.
+- Do not redesign the Stage/Coordinator control plane.
+- Do not make `SimpleScheduler` TP-aware.
+- Do not use `worker` / `executor` vocabulary for new encoder path classes.
+  The new SGLang-backed component is a runner.
+
+## Architecture
+
+The external pipeline remains:
+
+```text
+preprocessing -> [image_encoder, audio_encoder] -> mm_aggregate -> thinker -> ...
+```
+
+Only the encoder-stage implementation changes:
+
+```text
+old: Stage -> SimpleScheduler -> local HF encoder copy
+new: Stage -> EncoderScheduler -> SGLangEncoderRunner -> upstream encoder module
+```
+
+At runtime:
+
+```text
+HTTP API -> Client -> Coordinator -> StageGroup -> Stage(leader)
+                                                |        \
+                                                |         Stage(follower) x (tp_size - 1)
+                                                v
+                                  EncoderScheduler (one per rank)
+                                                v
+                                  SGLangEncoderRunner (one per rank)
+                                                v
+                              upstream SGLang encoder submodule(s)
+```
+
+Layer responsibilities:
+
+| Layer | Responsibility |
+| --- | --- |
+| `Coordinator` | Submit requests, collect completions, broadcast aborts. |
+| `StageGroup` / `MultiProcessPipelineRunner` | Spawn one process per TP rank, assign GPU ids, allocate NCCL port, monitor child exits. |
+| `Stage` | Own existing ZMQ control plane, relay IO, input aggregation, stream routing, and scheduler queues. |
+| `EncoderScheduler` | Drain input on the entry rank, fan out metadata/tensors to non-entry TP ranks, run the runner on all ranks, emit downstream messages only on the entry rank. |
+| `SGLangEncoderRunner` | Initialize SGLang distributed state, instantiate declared encoder submodules, partial-load matching checkpoint prefixes, expose `encode_batch()`. |
+| `EncoderAdapter` | Convert v1 `PipelineState` to the runner's `BatchPlan`, declare encoder module specs, and slice raw encoder outputs back into v1 payload shape. |
+
+Terminology:
+
+- Stage-level process roles remain the existing `single` / `leader` /
+  `follower` names.
+- Scheduler-level TP roles use `entry rank` and `non-entry ranks`.
+  `entry rank` follows existing `OmniScheduler.is_entry_rank`; non-entry ranks
+  are every TP rank other than the entry rank.
+- New encoder code uses `Runner`, not `Worker` or `Executor`, to stay aligned
+  with #188's vocabulary.
+
+## Why This Shape
+
+The existing multi-process pipeline already has the launcher pieces we need:
+`StageGroup` spawns one process per TP rank, assigns rank-local GPU ids, and
+sets up leader/follower control queues. The missing part is data fan-out for
+encoder request inputs. Stage followers receive shutdown/profiler/abort control
+messages, but they do not receive `SubmitMessage` / `DataReadyMessage`, do not
+own relay endpoints, and do not call `relay_io.read_payload`.
+
+That makes `EncoderScheduler` the right boundary. It already sits behind
+`Stage`, has one instance per TP rank, and can use SGLang TP groups directly.
+It mirrors the existing `OmniScheduler` pattern for entry-rank-only inbox
+drain plus `broadcast_pyobj`, but adds an explicit tensor channel because
+encoder payloads contain large media tensors.
+
+`SimpleScheduler` should stay a simple local callable scheduler. Making it
+conditionally TP-aware would couple every non-AR stage to TP groups it does not
+need.
+
+## Upstream Reuse Boundary
+
+Plan B reuses upstream SGLang at the encoder-submodule level:
+
+- Reuse: distributed init, TP groups, TP-aware layers, model loader selection,
+  quantization/load-format hooks, remote weight loading, and upstream encoder
+  submodule implementations.
+- Declare locally: which encoder submodules a stage needs, which checkpoint
+  prefixes map to those submodules, and how v1 payloads map into SGLang input
+  objects.
+- Do not reuse: the full upstream `ForConditionalGeneration` class. It is the
+  serving entry point for full generation and may allocate language-model and
+  talker modules that an encoder stage must not own.
+
+For Qwen3-Omni:
+
+- `image_encoder` declares the upstream vision encoder submodule only.
+- `audio_encoder` declares the upstream audio encoder submodule only.
+- Both stages reuse SGLang TP layers and checkpoint loading, but only for the
+  declared encoder prefixes.
+
+## Weight Loading Scope
+
+Encoder stages must not load the full upstream `ForConditionalGeneration`
+model. That class is the full serving entry point and can instantiate language
+model and talker weights that belong to other pipeline stages. Loading it in
+each encoder process would erase the memory win from moving long media
+activations off the thinker GPU.
+
+Phase 0 should implement partial encoder-submodule loading inside
+SGLang-Omni. Each adapter declares the encoder module specs it needs, including
+checkpoint prefixes and any key rewrites. `SGLangEncoderRunner` builds only
+those submodules and loads only matching checkpoint keys. This keeps the
+implementation unblocked without waiting for an upstream SGLang loader API.
+
+After Phase 1 parity and fault-handling validation, we should propose an
+upstream helper such as `EncoderModelRunner` / partial encoder loader so future
+models can reuse the same submodule-loading contract directly from SGLang.
+
+## TP Input Fan-Out Contract
+
+The entry rank is the only rank whose Stage receives upstream data from ZMQ and
+relay. Non-entry ranks need an in-scheduler fan-out path.
+
+Control and data are split:
+
+- Metadata goes over the TP CPU group with `broadcast_pyobj`. Metadata contains
+  request ids, non-tensor payload fields, and tensor specs such as path, dtype,
+  and shape.
+- Tensor data goes over the TP device group with `dist.broadcast` on CUDA
+  tensors. The entry rank lifts tensors from relay CPU memory to its local
+  device before broadcast. Non-entry ranks allocate matching CUDA placeholders
+  and receive into them.
+
+This keeps large media tensors off the pickle path and preserves the existing
+v1 separation between small control messages and large tensor payloads.
+
+Before device broadcast, non-entry ranks must pre-allocate all receive tensors and
+participate in an allocation-ready handshake on the TP CPU group. If any rank
+cannot allocate, all ranks skip the device broadcast and the entry rank emits a
+request-level error for the drained requests. This prevents unmatched NCCL
+broadcasts when a non-entry rank OOMs during receive-buffer allocation.
+
+## Scheduler Error Contract
+
+Encoder errors split by collective boundary.
+
+Recoverable before model forward:
+
+- `_recv_messages` failures, including entry-rank media tensor lift and
+  non-entry-rank receive-buffer allocation.
+- `EncoderAdapter.build_batch` failures.
+
+These happen before upstream model collectives start. Ranks synchronize a small
+error flag through the TP CPU group. If any rank failed, no rank enters
+`encode_batch`; the entry rank emits one request-level error per drained
+request, and the scheduler continues.
+
+Fatal inside model forward:
+
+- `SGLangEncoderRunner.encode_batch` enters upstream SGLang TP collectives.
+- A rank-local CUDA OOM, NCCL error, or other exception inside that region can
+  leave non-entry ranks blocked in device collectives.
+- Do not try to recover with a post-hoc CPU gather. The failing rank exits
+  non-zero, and `StageGroup` / `MultiProcessPipelineRunner` tears down the
+  whole TP group.
+
+Recoverable after model forward:
+
+- `EncoderAdapter.slice_results` runs only on the entry rank after all ranks
+  returned from `encode_batch`.
+- It can emit request-level errors and continue; no non-entry rank is waiting
+  on a matching TP collective at that point.
+
+The fatal path requires runner-level plumbing: when a child process exits
+non-zero, the multi-process runner must fail all active Coordinator futures and
+stream queues with a non-empty fatal error before shutdown. Otherwise HTTP
+requests can hang after the TP group is killed.
+
+## Runner Contract
+
+`SGLangEncoderRunner` owns only SGLang runtime setup and encoder execution:
+
+- Build encoder-only `ServerArgs` / `ModelConfig`.
+- Initialize distributed state even at `tp_size=1`, matching upstream
+  `MMEncoder` behavior.
+- Initialize tensor model parallel groups.
+- Instantiate only adapter-declared encoder submodules.
+- Partial-load checkpoint weights matching declared prefixes.
+- Expose `encode_batch(plan)`.
+
+The runner always sees exactly one CUDA device as `cuda:0`. The launcher maps
+the configured physical GPU into the child process with `CUDA_VISIBLE_DEVICES`
+before torch is imported. This rule applies to both `tp_size=1` and
+`tp_size>1`, so runner code does not branch on physical GPU ids.
+
+`server_args_overrides` is for safe SGLang loading/runtime knobs such as
+quantization, load format, attention backend, and remote weight loading. It must
+not override rank topology, GPU placement, encoder-only mode, or AR-only memory
+knobs such as `mem_fraction_static`, `max_running_requests`,
+`max_prefill_tokens`, or `context_length`.
+
+## Adapter Contract
+
+Each SGLang-backed encoder stage provides an `EncoderAdapter`:
+
+- `encoder_specs`: declares encoder submodules and checkpoint prefixes.
+- `request_cost_fn(payload)`: estimates activation memory for admission
+  control.
+- `build_batch(messages)`: converts v1 payloads into a deterministic
+  `BatchPlan` on every rank.
+- `run_feature(model, plan)`: invokes the upstream encoder submodule.
+- `slice_results(raw, plan, messages)`: converts raw encoder output back into
+  v1 `encoder_outs` payload shape.
+
+The adapter is model-specific shape glue. It must not catch broad `Exception`
+or return fake-success outputs such as empty tensors, zero tensors, or `None`
+when model execution failed.
+
+## Config Contract
+
+MVP requires no pipeline schema change. Encoder TP is expressed through
+existing `StageConfig` fields:
+
+```python
+StageConfig(
+    name="image_encoder",
+    factory="sglang_omni_v1.models.qwen3_omni.stages.create_image_encoder_runner",
+    factory_args={
+        "backend": "sglang",
+        "max_batch_size": 32,
+        "max_batch_wait_ms": 50,
+        "activation_budget_bytes": 20 * 1024**3,
+    },
+    gpu=[0, 1],
+    tp_size=2,
+    next="mm_aggregate",
+)
+```
+
+Backend rules:
+
+- `backend="local"` keeps the current local HF `SimpleScheduler` path and is
+  single-rank only.
+- `backend="sglang"` uses `EncoderScheduler` + `SGLangEncoderRunner`.
+- `backend="auto"` may switch to SGLang after parity is proven, but the default
+  factory signature should stay `"local"`; defaults that affect launcher mode
+  must live in `StageConfig.factory_args` or runtime overrides.
+
+Launcher rules:
+
+- Any stage with resolved `backend in {"sglang", "auto"}` must run through
+  `MultiProcessPipelineRunner`, even when `tp_size=1`, so CUDA visibility and
+  distributed state are process-local.
+- Direct `compile_pipeline()` must reject SGLang-backed encoder stages and any
+  `tp_size > 1` stage, because the single-process path cannot inject TP rank
+  parameters.
+- TP preflight should reject factories that do not accept TP launch parameters.
+  Encoder TP also requires `backend="sglang"`.
+
+## Naming
+
+Use these names in the Phase 0 implementation:
+
+- `SGLangEncoderRunner`, not `SGLangEncoderWorker`.
+- `create_image_encoder_runner`, not `create_image_encoder_executor`.
+- `create_audio_encoder_runner`, not `create_audio_encoder_executor`.
+- `entry_rank` / `non_entry_rank` in new code; `entry rank` /
+  `non-entry rank` in prose. Keep existing Stage `leader/follower` names only
+  when discussing Stage process roles.
+
+## Rollout
+
+Phase 0:
+
+- Add `SGLangEncoderRunner`.
+- Add `EncoderScheduler`.
+- Add Qwen3-Omni image/audio `EncoderAdapter`s.
+- Add `create_image_encoder_runner` and `create_audio_encoder_runner` with
+  `backend="local"` as the default.
+- Add launcher validation and single-visible-device handling for SGLang-backed
+  encoder stages.
+- Add fatal-path plumbing: a non-zero TP child exit tears down the stage group
+  and fails all active Coordinator futures / stream queues with a non-empty
+  error.
+- Keep default configs on local backend.
+
+Phase 1:
+
+- Validate local vs SGLang parity at `tp_size=1`.
+- Validate SGLang `tp_size=1` vs `tp_size=2`.
+- Validate long-video Qwen3-Omni speech path without the current thinker OOM /
+  encoder memory reserve workaround.
+
+Phase 2:
+
+- Switch selected Qwen3-Omni configs to explicit `backend="auto"` once parity
+  and fault handling pass.
+
+Phase 3:
+
+- Delete duplicated local encoder implementations after one release with
+  SGLang-backed encoders as the default for supported models.
+
+## Validation Summary
+
+Minimum validation should cover:
+
+- Unit: adapter batch planning, payload round-trip, skip/cache handling, and
+  activation-budget admission.
+- Unit: TP metadata/tensor fan-out does not pickle tensor payload bytes and does
+  not issue device broadcasts after allocation failure.
+- Unit: pre-forward failures emit request-level errors; forward-time TP faults
+  take the fatal stage-group path.
+- GPU: Qwen3-Omni image/audio local vs SGLang parity at `tp_size=1`.
+- GPU: Qwen3-Omni image/audio SGLang `tp_size=1` vs `tp_size=2`.
+- E2E: long-video speech request that previously OOMed produces valid output
+  without fake-success fallbacks.
+
+## Open Questions
+
+1. What should the upstream partial encoder-submodule loader API look like
+   after Phase 1 validates the local SGLang-Omni implementation?
+2. When upstream Qwen3-Omni encoder DP is complete, do we expose DP as a second
+   parallelism axis or keep this RFC TP-only and add a separate DP design?
+3. How should future co-location memory accounting represent activation budget
+   versus weight memory fraction?
+
+## Progress Tracking
+
+- [ ] Phase 0: land runner, scheduler, adapters, launcher validation.
+- [ ] Phase 1: local vs SGLang and tp1 vs tp2 parity.
+- [ ] Phase 2: opt selected Qwen3-Omni configs into `backend="auto"`.
+- [ ] Phase 3: remove duplicated local encoder code after one release.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,4 +40,4 @@ Our core features include:
 
    developer_reference/architecture.md
    developer_reference/relay_design.md
-   developer_reference/talker_decode_parity.md
+   developer_reference/encoder_tp_path_b_design.md

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,4 +40,5 @@ Our core features include:
 
    developer_reference/architecture.md
    developer_reference/relay_design.md
+   developer_reference/encoder_tp_path_b_design_lean.md
    developer_reference/encoder_tp_path_b_design.md

--- a/examples/qwen3_omni_encoder_tp.py
+++ b/examples/qwen3_omni_encoder_tp.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reference script: launch Qwen3-Omni speech with SGLang-backed encoder TP.
+
+This is the Phase-0 deployment recipe described in
+``docs/developer_reference/encoder_tp_path_b_design.md`` (RFC #375).
+It shows how to flip the image and audio encoder stages from the local
+HF tower to the SGLang-native encoders without changing any other
+stage.
+
+Usage (single-host, 8-GPU layout):
+
+    python examples/qwen3_omni_encoder_tp.py \\
+        --model Qwen/Qwen3-Omni-30B-A3B-Instruct \\
+        --image-tp 2 --audio-tp 2 --port 8000
+
+The encoders run with ``tp_size=2`` each on dedicated GPU pairs; the
+thinker, talker, and code2wav stages keep their existing single-GPU
+placement. ``backend="auto"`` would resolve to ``"local"`` in Phase 0
+(see RFC Phase 2 for the flip); this script picks ``"sglang"``
+explicitly so the SGLang encoder worker takes over right now.
+"""
+from __future__ import annotations
+
+import argparse
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--model", required=True, help="HF model id or local path")
+    p.add_argument("--image-tp", type=int, default=2)
+    p.add_argument("--audio-tp", type=int, default=2)
+    p.add_argument("--port", type=int, default=8000)
+    p.add_argument("--host", default="0.0.0.0")
+    args = p.parse_args()
+
+    # Import after argparse so --help is fast.
+    from sglang_omni_v1.models.qwen3_omni.config import (
+        Qwen3OmniSpeechPipelineConfig,
+    )
+    from sglang_omni_v1.serve.launcher import launch_server
+
+    if args.image_tp + args.audio_tp + 4 > 8:
+        raise SystemExit(
+            "This recipe assumes 8 GPUs: image_encoder TP + audio_encoder TP "
+            "+ thinker + talker + code2wav + decode/aggregate scratch."
+        )
+
+    image_gpus = list(range(0, args.image_tp))
+    audio_gpus = list(range(args.image_tp, args.image_tp + args.audio_tp))
+
+    # Build the canonical config and flip just the two encoder stages.
+    cfg = Qwen3OmniSpeechPipelineConfig(model_path=args.model)
+    new_stages = []
+    for s in cfg.stages:
+        if s.name == "image_encoder":
+            s = s.model_copy(update={
+                "factory_args": {**s.factory_args, "backend": "sglang"},
+                "tp_size": args.image_tp,
+                "gpu": image_gpus,
+            })
+        elif s.name == "audio_encoder":
+            s = s.model_copy(update={
+                "factory_args": {**s.factory_args, "backend": "sglang"},
+                "tp_size": args.audio_tp,
+                "gpu": audio_gpus,
+            })
+        new_stages.append(s)
+    cfg = cfg.model_copy(update={"stages": new_stages})
+
+    launch_server(cfg, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/qwen3_omni_encoder_tp.py
+++ b/examples/qwen3_omni_encoder_tp.py
@@ -17,7 +17,7 @@ The encoders run with ``tp_size=2`` each on dedicated GPU pairs; the
 thinker, talker, and code2wav stages keep their existing single-GPU
 placement. ``backend="auto"`` would resolve to ``"local"`` in Phase 0
 (see RFC Phase 2 for the flip); this script picks ``"sglang"``
-explicitly so the SGLang encoder worker takes over right now.
+explicitly so the SGLang encoder runner takes over right now.
 """
 from __future__ import annotations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ markers = [
     "benchmark: performance benchmark tests (may require GPU and long runtime)",
     "docs: documentation example tests (verify documented API calls still work)",
     "s2pro_stage(name): select an in-file S2-Pro benchmark CI stage",
+    "slow: tests that take many seconds — load full models, run real forwards (skip with -m 'not slow')",
 ]
 
 [tool.setuptools.packages.find]

--- a/sglang_omni_v1/config/compiler.py
+++ b/sglang_omni_v1/config/compiler.py
@@ -23,7 +23,7 @@ _SGLANG_BACKENDS = frozenset({"sglang", "auto"})
 # ``factory_args`` at spawn time. Letting these flow through user
 # ``factory_args`` / ``runtime_overrides`` creates a silent desync: e.g.
 # ``StageConfig.tp_size=1`` + ``factory_args[tp_size]=2`` spawns one process
-# but boots SGLangEncoderWorker with ``world_size=2``, hanging NCCL bootstrap
+# but boots SGLangEncoderRunner with ``world_size=2``, hanging NCCL bootstrap
 # forever waiting for the missing rank 1.
 _TP_LAUNCH_PARAMS = frozenset({"tp_rank", "tp_size", "nccl_port"})
 

--- a/sglang_omni_v1/config/compiler.py
+++ b/sglang_omni_v1/config/compiler.py
@@ -17,6 +17,16 @@ from sglang_omni_v1.utils import import_string
 
 _SGLANG_BACKENDS = frozenset({"sglang", "auto"})
 
+# Launch-topology kwargs the runner is the sole source of truth for. Users
+# express TP through ``StageConfig.tp_size``; mp_runner translates that into
+# per-rank ``tp_rank`` + ``tp_size`` + ``nccl_port`` and injects them into
+# ``factory_args`` at spawn time. Letting these flow through user
+# ``factory_args`` / ``runtime_overrides`` creates a silent desync: e.g.
+# ``StageConfig.tp_size=1`` + ``factory_args[tp_size]=2`` spawns one process
+# but boots SGLangEncoderWorker with ``world_size=2``, hanging NCCL bootstrap
+# forever waiting for the missing rank 1.
+_TP_LAUNCH_PARAMS = frozenset({"tp_rank", "tp_size", "nccl_port"})
+
 
 def compile_pipeline(config: PipelineConfig) -> tuple[Coordinator, list[Stage]]:
     """Build the coordinator and stage objects from the pipeline configuration."""
@@ -190,6 +200,22 @@ def _resolve_factory_args(
     stage_overrides = global_cfg.runtime_overrides.get(stage_cfg.name, {})
     if stage_overrides:
         args.update(stage_overrides)
+
+    # TP launch topology has exactly one source of truth: StageConfig.tp_size.
+    # Users CAN override TP — they just have to do it through the StageConfig
+    # field, not through factory_args / runtime_overrides. Letting these slip
+    # through creates the silent NCCL-bootstrap-hang bug described in
+    # _TP_LAUNCH_PARAMS above.
+    leaked = sorted(_TP_LAUNCH_PARAMS & args.keys())
+    if leaked:
+        raise ValueError(
+            f"Stage {stage_cfg.name!r}: factory_args / runtime_overrides "
+            f"cannot set {leaked}. These keys are managed by the pipeline "
+            f"runner from StageConfig.tp_size and the per-stage NCCL port "
+            f"allocator. To override TP size, edit StageConfig.tp_size "
+            f"(and StageConfig.gpu) directly."
+        )
+
     factory = import_string(stage_cfg.factory)
     sig = inspect.signature(factory)
 

--- a/sglang_omni_v1/config/compiler.py
+++ b/sglang_omni_v1/config/compiler.py
@@ -15,9 +15,13 @@ from sglang_omni_v1.pipeline.stage.input import InputHandler
 from sglang_omni_v1.utils import import_string
 
 
+_SGLANG_BACKENDS = frozenset({"sglang", "auto"})
+
+
 def compile_pipeline(config: PipelineConfig) -> tuple[Coordinator, list[Stage]]:
     """Build the coordinator and stage objects from the pipeline configuration."""
     stages_cfg, name_map, entry_stage = config.apply_fusion()
+    _reject_incompatible_single_process_stages(stages_cfg, config)
     endpoints = _allocate_endpoints(config, stages=stages_cfg)
 
     coordinator = Coordinator(
@@ -133,6 +137,48 @@ def _create_input_handler(
 # ------------------------------------------------------------------
 # Factory args
 # ------------------------------------------------------------------
+
+
+def _reject_incompatible_single_process_stages(
+    stages_cfg: list[StageConfig],
+    config: PipelineConfig,
+) -> None:
+    """Reject configs that the single-process compile path cannot honor.
+
+    Two structural mismatches:
+
+    - ``backend in {"sglang", "auto"}``: SGLang's distributed init is
+      module-level inside SGLang and can only run once per process; the
+      single-process compile path also never invokes the launcher's
+      per-process CUDA remap, so a `gpu=4, tp_size=1` worker would load
+      its model on physical GPU 0. Force users through
+      ``MultiProcessPipelineRunner``.
+    - ``tp_size > 1``: ``_resolve_factory_args`` only injects
+      ``model_path`` / ``gpu_id``; it never injects
+      ``tp_rank/tp_size/nccl_port``. A direct caller of
+      ``compile_pipeline`` would silently get a ``tp_size=1`` factory
+      with TP completely lost, no error. Reject early so the
+      mistake surfaces.
+
+    ``serve/launcher.py`` already routes both shapes through
+    ``MultiProcessPipelineRunner``; this guard catches direct callers.
+    """
+    for stage_cfg in stages_cfg:
+        backend = _resolve_factory_args(stage_cfg, config).get("backend", "local")
+        if backend in _SGLANG_BACKENDS:
+            raise ValueError(
+                f"Stage {stage_cfg.name!r}: backend={backend!r} requires "
+                f"MultiProcessPipelineRunner. compile_pipeline is the "
+                f"single-process path; use serve/launcher.launch_server "
+                f"or instantiate MultiProcessPipelineRunner directly."
+            )
+        if stage_cfg.tp_size > 1:
+            raise ValueError(
+                f"Stage {stage_cfg.name!r}: tp_size={stage_cfg.tp_size} > 1 "
+                f"requires MultiProcessPipelineRunner. compile_pipeline "
+                f"never injects tp_rank/tp_size/nccl_port and would silently "
+                f"downgrade TP factories to single-rank."
+            )
 
 
 def _resolve_factory_args(

--- a/sglang_omni_v1/model_runner/sglang_encoder_runner.py
+++ b/sglang_omni_v1/model_runner/sglang_encoder_runner.py
@@ -1,16 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Minimal SGLang-native encoder worker with partial encoder loading.
+"""Minimal SGLang-native encoder runner with partial encoder loading.
 
 Owns SGLang's distributed init, encoder-only ``ServerArgs`` /
 ``ModelConfig`` / ``LoadConfig``, and a small ``EncoderModuleContainer``
 that holds *only* the upstream encoder submodules an adapter declared
-through its :class:`EncoderModuleSpec` list. The worker NEVER calls
+through its :class:`EncoderModuleSpec` list. The runner NEVER calls
 ``get_model()`` on the full upstream ``ForConditionalGeneration``
 class — for Qwen3-Omni that would instantiate the thinker LLM (~57 GB
 fp16) and the talker on every encoder GPU, which both wastes memory
 and OOMs on H100-class hardware.
 
-What the worker does inherit from upstream:
+What the runner inherits from upstream:
     - SGLang distributed init / TP groups
     - SGLang loader pipeline (``DefaultModelLoader._get_all_weights``,
       ``load_weights_and_postprocess``)
@@ -18,9 +18,16 @@ What the worker does inherit from upstream:
       (``ColumnParallelLinear`` / ``RowParallelLinear``, fused
       attention, etc.)
 
-What the worker brings:
+What the runner brings:
     - The :class:`EncoderModuleContainer` with adapter-supplied
       submodules and a prefix-filtering ``load_weights``.
+
+Naming note: this module deliberately uses ``entry_rank`` /
+``non_entry_rank`` for the rank-0-vs-rest asymmetry rather than
+``leader`` / ``follower``. The asymmetry here is just "who owns
+external IO" — there's no leader election, no failover, no consensus
+machinery. The Stage-level ``single/leader/follower`` role split
+elsewhere in v1 is unrelated and not touched.
 
 See ``docs/developer_reference/encoder_tp_path_b_design.md`` →
 "Upstream Reuse Boundary" / "EncoderModuleSpec".
@@ -59,11 +66,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# Worker-managed kwargs that the helper consumes as direct keyword args.
+# Runner-managed kwargs that the helper consumes as direct keyword args.
 # Reject these in `server_args_overrides` BEFORE the **splat — otherwise
 # Python raises TypeError "got multiple values for keyword argument" before
 # the helper's protected-key reject can fire.
-_WORKER_MANAGED_KEYS = frozenset({
+_RUNNER_MANAGED_KEYS = frozenset({
     "model_path", "tp_size", "base_gpu_id", "dist_init_addr",
     "dtype", "load_format",
 })
@@ -246,29 +253,29 @@ class EncoderModuleContainer(nn.Module):
         return None
 
 
-class SGLangEncoderWorker:
+class SGLangEncoderRunner:
     """SGLang-native encoder model wrapper with partial loading.
 
-    The worker process is invoked by ``MultiProcessPipelineRunner``,
+    The runner process is invoked by ``MultiProcessPipelineRunner``,
     which has remapped ``CUDA_VISIBLE_DEVICES`` to a single physical GPU
     before importing torch (see ``encoder_tp_path_b_design.md`` "GPU
     placement"). Therefore ``cuda:0`` is the only visible device in this
     process, regardless of ``tp_size`` and the configured physical
-    ``gpu``. The worker pins ``cuda_device=0`` and forwards
+    ``gpu``. The runner pins ``cuda_device=0`` and forwards
     ``dist_local_rank=tp_rank`` so SGLang's local-master / shard-index
     callsites observe a unique ``[0, world_size)`` rank.
 
     Args:
         model_path: HF model id or local checkpoint path.
         gpu_id: Physical GPU id (informational; the launcher remap means
-            the worker actually sees this as ``cuda:0``).
+            the runner actually sees this as ``cuda:0``).
         tp_rank: TP rank in ``[0, tp_size)``.
         tp_size: TP world size.
         nccl_port: Loopback NCCL bootstrap port allocated by the runner.
-            Optional; the worker picks a free port when unset
+            Optional; the runner picks a free port when unset
             (single-rank case).
         encoder_specs: Adapter-supplied list of encoder submodules to
-            load. Required — the worker does NOT load the full
+            load. Required — the runner does NOT load the full
             ``ForConditionalGeneration`` class.
         dtype: Optional dtype override forwarded to ``ServerArgs``.
         load_format: Optional load-format override forwarded to ``ServerArgs``.
@@ -297,8 +304,8 @@ class SGLangEncoderWorker:
             )
         if not encoder_specs:
             raise ValueError(
-                "SGLangEncoderWorker requires encoder_specs; the adapter must "
-                "declare its upstream submodules. The worker no longer falls "
+                "SGLangEncoderRunner requires encoder_specs; the adapter must "
+                "declare its upstream submodules. The runner no longer falls "
                 "back to get_model() on the full ForConditionalGeneration "
                 "class — that would load the LLM/talker on every encoder GPU."
             )
@@ -307,7 +314,7 @@ class SGLangEncoderWorker:
         self.tp_size = int(tp_size)
         self.is_entry_rank = self.tp_rank == 0
 
-        # Forwarded for telemetry / debugging only — the worker hard-pins
+        # Forwarded for telemetry / debugging only — the runner hard-pins
         # cuda_device=0 because the launcher remap leaves only one device
         # visible.
         self.physical_gpu_id = int(gpu_id)
@@ -323,10 +330,10 @@ class SGLangEncoderWorker:
         self.device = torch.device(f"cuda:{cuda_device}")
 
         overrides = dict(server_args_overrides or {})
-        clobbered = sorted(_WORKER_MANAGED_KEYS & overrides.keys())
+        clobbered = sorted(_RUNNER_MANAGED_KEYS & overrides.keys())
         if clobbered:
             raise ValueError(
-                f"server_args_overrides cannot set worker-managed keys "
+                f"server_args_overrides cannot set runner-managed keys "
                 f"{clobbered}. These are derived from StageConfig and "
                 f"factory parameters; pass them through StageConfig "
                 f"(model_path, tp_size, gpu, dtype, load_format) instead."
@@ -389,7 +396,7 @@ class SGLangEncoderWorker:
         self.model.eval()
 
         logger.info(
-            "SGLangEncoderWorker ready (tp_rank=%d/%d, physical_gpu=%d, "
+            "SGLangEncoderRunner ready (tp_rank=%d/%d, physical_gpu=%d, "
             "model=%s, submodules=%s, dist_addr=%s)",
             self.tp_rank, self.tp_size, self.physical_gpu_id,
             model_path, [s.name for s in encoder_specs], dist_addr,

--- a/sglang_omni_v1/model_runner/sglang_encoder_runner.py
+++ b/sglang_omni_v1/model_runner/sglang_encoder_runner.py
@@ -36,10 +36,12 @@ from __future__ import annotations
 
 import logging
 import socket
+from types import MethodType
 from typing import TYPE_CHECKING, Any, Iterable, Sequence
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
 from sglang.srt.configs.device_config import DeviceConfig
 from sglang.srt.configs.load_config import LoadConfig
@@ -48,6 +50,9 @@ from sglang.srt.distributed.parallel_state import (
     get_tp_group,
     init_distributed_environment,
     initialize_model_parallel,
+    set_custom_all_reduce,
+    set_mscclpp_all_reduce,
+    set_torch_symm_mem_all_reduce,
 )
 from sglang.srt.layers.dp_attention import initialize_dp_attention
 from sglang.srt.model_loader import get_model_loader
@@ -75,6 +80,8 @@ _RUNNER_MANAGED_KEYS = frozenset({
     "dtype", "load_format",
 })
 
+_TP_PARITY_MODES = frozenset({"default", "fp32_row_parallel", "fp32_linear"})
+
 
 def _pick_free_port() -> int:
     """Return an available loopback TCP port."""
@@ -96,6 +103,151 @@ def _resolve_quant_config(model_config: ModelConfig, load_config: LoadConfig) ->
     if qc is not None:
         return qc
     return getattr(model_config, "quant_config", None)
+
+
+def _configure_tp_collectives(server_args: Any) -> None:
+    """Mirror SGLang ModelRunner's TP collective switch setup.
+
+    ``initialize_model_parallel`` reads module-level switches in
+    ``parallel_state`` when it builds the TP group. The encoder runner
+    bypasses upstream ``ModelRunner``, so it must apply the same switches
+    itself before TP initialization; otherwise ServerArgs overrides such
+    as ``disable_custom_all_reduce`` are silently ignored.
+    """
+    set_custom_all_reduce(
+        not bool(getattr(server_args, "disable_custom_all_reduce", False))
+    )
+    set_mscclpp_all_reduce(bool(getattr(server_args, "enable_mscclpp", False)))
+    set_torch_symm_mem_all_reduce(
+        bool(getattr(server_args, "enable_torch_symm_mem", False))
+    )
+
+
+def _resolve_tp_parity_mode(mode: str | None) -> str:
+    resolved = mode or "default"
+    if resolved not in _TP_PARITY_MODES:
+        raise ValueError(
+            f"Unsupported tp_parity_mode={mode!r}; "
+            f"expected one of {sorted(_TP_PARITY_MODES)}"
+        )
+    return resolved
+
+
+def _row_parallel_forward_fp32(
+    self: Any,
+    input_: torch.Tensor,
+    skip_all_reduce: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """RowParallelLinear forward with fp32 local matmul + fp32 reduction.
+
+    This is a parity/debug path for encoder TP experiments. It preserves the
+    normal RowParallelLinear sharding semantics but avoids rounding each local
+    partial result to fp16 before the TP all-reduce. The output is cast back to
+    the input dtype so downstream kernels see the same dtype as the default
+    path.
+    """
+    from sglang.srt.distributed import (
+        get_tp_group,
+        split_tensor_along_last_dim,
+        tensor_model_parallel_all_reduce,
+    )
+    from sglang.srt.distributed.device_communicators.pynccl_allocator import (
+        use_symmetric_memory,
+    )
+    from sglang.srt.layers.dp_attention import is_allocation_symmetric
+
+    if self.input_is_parallel:
+        input_parallel = input_
+    else:
+        splitted_input = split_tensor_along_last_dim(
+            input_, num_partitions=self.tp_size
+        )
+        input_parallel = splitted_input[self.tp_rank].contiguous()
+
+    bias = None if (self.tp_rank > 0 or self.skip_bias_add) else self.bias
+
+    weight = getattr(self, "weight", None)
+    if weight is not None and getattr(self, "quant_config", None) is None:
+        output_parallel = F.linear(
+            input_parallel.to(torch.float32),
+            weight.to(torch.float32),
+            bias.to(torch.float32) if bias is not None else None,
+        )
+    else:
+        with use_symmetric_memory(
+            get_tp_group(), disabled=not is_allocation_symmetric()
+        ):
+            output_parallel = self.quant_method.apply(
+                self,
+                input_parallel,
+                bias=bias,
+            )
+        if output_parallel.is_floating_point():
+            output_parallel = output_parallel.to(torch.float32)
+
+    if self.reduce_results and self.tp_size > 1 and not skip_all_reduce:
+        output = tensor_model_parallel_all_reduce(output_parallel)
+    else:
+        output = output_parallel
+
+    if output.is_floating_point() and input_.dtype in (torch.float16, torch.bfloat16):
+        output = output.to(input_.dtype)
+
+    output_bias = self.bias if self.skip_bias_add else None
+    return output, output_bias
+
+
+def _column_parallel_forward_fp32(
+    self: Any,
+    input_: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """ColumnParallelLinear forward with fp32 local matmul.
+
+    This covers ColumnParallelLinear subclasses too, including
+    QKVParallelLinear and MergedColumnParallelLinear. It preserves the
+    normal shard-local output contract; it only changes the local GEMM
+    precision for parity/debug characterization.
+    """
+    from sglang.srt.distributed import tensor_model_parallel_all_gather
+
+    bias = self.bias if not self.skip_bias_add else None
+    weight = getattr(self, "weight", None)
+    if weight is not None and getattr(self, "quant_config", None) is None:
+        output_parallel = F.linear(
+            input_.to(torch.float32),
+            weight.to(torch.float32),
+            bias.to(torch.float32) if bias is not None else None,
+        )
+    else:
+        output_parallel = self.quant_method.apply(self, input_, bias)
+        if output_parallel.is_floating_point():
+            output_parallel = output_parallel.to(torch.float32)
+
+    if self.gather_output:
+        output = tensor_model_parallel_all_gather(output_parallel)
+    else:
+        output = output_parallel
+
+    if output.is_floating_point() and input_.dtype in (torch.float16, torch.bfloat16):
+        output = output.to(input_.dtype)
+
+    output_bias = self.bias if self.skip_bias_add else None
+    return output, output_bias
+
+
+def _enable_fp32_linear(model: nn.Module, *, include_column_parallel: bool) -> dict[str, int]:
+    """Patch TP linear modules in ``model`` for TP parity runs."""
+    from sglang.srt.layers.linear import ColumnParallelLinear, RowParallelLinear
+
+    counts = {"row_parallel": 0, "column_parallel": 0}
+    for module in model.modules():
+        if isinstance(module, RowParallelLinear):
+            module.forward = MethodType(_row_parallel_forward_fp32, module)
+            counts["row_parallel"] += 1
+        elif include_column_parallel and isinstance(module, ColumnParallelLinear):
+            module.forward = MethodType(_column_parallel_forward_fp32, module)
+            counts["column_parallel"] += 1
+    return counts
 
 
 class EncoderModuleContainer(nn.Module):
@@ -281,6 +433,11 @@ class SGLangEncoderRunner:
         load_format: Optional load-format override forwarded to ``ServerArgs``.
         server_args_overrides: Extra ``ServerArgs`` kwargs (loader / processor
             knobs only — protected keys raise ``ValueError``).
+        tp_parity_mode: Optional debug mode for tp=1 vs tp>1 numerical
+            comparisons. ``"fp32_row_parallel"`` runs RowParallelLinear local
+            matmuls and TP all-reduces in fp32, then casts outputs back to the
+            model dtype. ``"fp32_linear"`` additionally runs shard-local
+            ColumnParallelLinear/QKV/Gate-Up matmuls in fp32.
     """
 
     def __init__(
@@ -295,6 +452,7 @@ class SGLangEncoderRunner:
         dtype: str | None = None,
         load_format: str | None = None,
         server_args_overrides: dict[str, Any] | None = None,
+        tp_parity_mode: str | None = None,
     ) -> None:
         if tp_size < 1:
             raise ValueError(f"tp_size must be >= 1 (got {tp_size})")
@@ -310,9 +468,20 @@ class SGLangEncoderRunner:
                 "class — that would load the LLM/talker on every encoder GPU."
             )
 
+        overrides = dict(server_args_overrides or {})
+        clobbered = sorted(_RUNNER_MANAGED_KEYS & overrides.keys())
+        if clobbered:
+            raise ValueError(
+                f"server_args_overrides cannot set runner-managed keys "
+                f"{clobbered}. These are derived from StageConfig and "
+                f"factory parameters; pass them through StageConfig "
+                f"(model_path, tp_size, gpu, dtype, load_format) instead."
+            )
+
         self.tp_rank = int(tp_rank)
         self.tp_size = int(tp_size)
         self.is_entry_rank = self.tp_rank == 0
+        self.tp_parity_mode = _resolve_tp_parity_mode(tp_parity_mode)
 
         # Forwarded for telemetry / debugging only — the runner hard-pins
         # cuda_device=0 because the launcher remap leaves only one device
@@ -328,16 +497,6 @@ class SGLangEncoderRunner:
         cuda_device = 0
         dist_local_rank = self.tp_rank
         self.device = torch.device(f"cuda:{cuda_device}")
-
-        overrides = dict(server_args_overrides or {})
-        clobbered = sorted(_RUNNER_MANAGED_KEYS & overrides.keys())
-        if clobbered:
-            raise ValueError(
-                f"server_args_overrides cannot set runner-managed keys "
-                f"{clobbered}. These are derived from StageConfig and "
-                f"factory parameters; pass them through StageConfig "
-                f"(model_path, tp_size, gpu, dtype, load_format) instead."
-            )
 
         server_args = build_sglang_encoder_server_args(
             model_path=model_path,
@@ -381,6 +540,7 @@ class SGLangEncoderRunner:
             local_rank=dist_local_rank,
             backend="nccl",
         )
+        _configure_tp_collectives(server_args)
         initialize_model_parallel(tensor_model_parallel_size=self.tp_size)
         initialize_dp_attention(server_args, self.model_config)
         self.tp_group = get_tp_group()
@@ -393,6 +553,18 @@ class SGLangEncoderRunner:
         # container drop everything that doesn't match a declared
         # prefix.
         self.model = self._build_and_load_encoder(encoder_specs)
+        if self.tp_parity_mode in {"fp32_row_parallel", "fp32_linear"}:
+            counts = _enable_fp32_linear(
+                self.model,
+                include_column_parallel=self.tp_parity_mode == "fp32_linear",
+            )
+            logger.info(
+                "SGLangEncoderRunner tp_parity_mode=%s patched "
+                "%d RowParallelLinear and %d ColumnParallelLinear modules",
+                self.tp_parity_mode,
+                counts["row_parallel"],
+                counts["column_parallel"],
+            )
         self.model.eval()
 
         logger.info(

--- a/sglang_omni_v1/model_runner/sglang_encoder_worker.py
+++ b/sglang_omni_v1/model_runner/sglang_encoder_worker.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Minimal SGLang-native encoder worker.
+
+Owns SGLang's distributed init, encoder-only ``ServerArgs`` /
+``ModelConfig`` / ``LoadConfig``, the loaded upstream encoder model,
+and exposes ``encode_batch()``. Does not start the upstream
+``MMEncoder`` (no ZMQ, no transfer engine, no embedding cache) — v1
+already owns request lifecycle, control plane, and relay.
+
+See ``docs/developer_reference/encoder_tp_path_b_design.md`` for the
+full RFC. The init sequence mirrors
+``sglang/python/sglang/srt/disaggregation/encode_server.py`` so it
+inherits SGLang's TP + native encoder implementations.
+"""
+from __future__ import annotations
+
+import logging
+import socket
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from sglang.srt.configs.device_config import DeviceConfig
+from sglang.srt.configs.load_config import LoadConfig
+from sglang.srt.configs.model_config import ModelConfig
+from sglang.srt.distributed.parallel_state import (
+    get_tp_group,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from sglang.srt.layers.dp_attention import initialize_dp_attention
+from sglang.srt.model_loader import get_model
+from sglang.srt.server_args import set_global_server_args_for_scheduler
+
+from sglang_omni_v1.scheduling.sglang_backend import build_sglang_encoder_server_args
+
+if TYPE_CHECKING:
+    from sglang_omni_v1.models.qwen3_omni.encoder_adapters import BatchPlan
+
+logger = logging.getLogger(__name__)
+
+
+# Worker-managed kwargs that the helper consumes as direct keyword args.
+# Reject these in `server_args_overrides` BEFORE the **splat — otherwise
+# Python raises TypeError "got multiple values for keyword argument" before
+# the helper's protected-key reject can fire.
+_WORKER_MANAGED_KEYS = frozenset({
+    "model_path", "tp_size", "base_gpu_id", "dist_init_addr",
+    "dtype", "load_format",
+})
+
+
+def _pick_free_port() -> int:
+    """Return an available loopback TCP port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+class SGLangEncoderWorker:
+    """SGLang-native encoder model wrapper.
+
+    The worker process is invoked by ``MultiProcessPipelineRunner``,
+    which has remapped ``CUDA_VISIBLE_DEVICES`` to a single physical GPU
+    before importing torch (see ``encoder_tp_path_b_design.md`` "GPU
+    placement"). Therefore ``cuda:0`` is the only visible device in this
+    process, regardless of ``tp_size`` and the configured physical
+    ``gpu``. The worker pins ``cuda_device=0`` and forwards
+    ``dist_local_rank=tp_rank`` so SGLang's local-master / shard-index
+    callsites observe a unique ``[0, world_size)`` rank.
+
+    Args:
+        model_path: HF model id or local checkpoint path.
+        gpu_id: Physical GPU id (informational; the launcher remap means
+            the worker actually sees this as ``cuda:0``).
+        tp_rank: TP rank in ``[0, tp_size)``.
+        tp_size: TP world size.
+        nccl_port: Loopback NCCL bootstrap port allocated by the runner.
+            Optional; the worker picks a free port when unset
+            (single-rank case).
+        dtype: Optional dtype override forwarded to ``ServerArgs``.
+        load_format: Optional load-format override forwarded to ``ServerArgs``.
+        server_args_overrides: Extra ``ServerArgs`` kwargs (loader / processor
+            knobs only — protected keys raise ``ValueError``).
+    """
+
+    def __init__(
+        self,
+        *,
+        model_path: str,
+        gpu_id: int,
+        tp_rank: int,
+        tp_size: int,
+        nccl_port: int | None,
+        dtype: str | None = None,
+        load_format: str | None = None,
+        server_args_overrides: dict[str, Any] | None = None,
+    ) -> None:
+        if tp_size < 1:
+            raise ValueError(f"tp_size must be >= 1 (got {tp_size})")
+        if not (0 <= tp_rank < tp_size):
+            raise ValueError(
+                f"tp_rank={tp_rank} must satisfy 0 <= tp_rank < tp_size={tp_size}"
+            )
+
+        self.tp_rank = int(tp_rank)
+        self.tp_size = int(tp_size)
+        self.is_entry_rank = self.tp_rank == 0
+
+        # Forwarded for telemetry / debugging only — the worker hard-pins
+        # cuda_device=0 because the launcher remap leaves only one device
+        # visible.
+        self.physical_gpu_id = int(gpu_id)
+
+        # ServerArgs.dist_init_addr expects "host:port", torch.distributed
+        # expects the full "tcp://host:port" URL. Keep them separate.
+        port = int(nccl_port) if nccl_port is not None else _pick_free_port()
+        dist_addr = f"127.0.0.1:{port}"
+        dist_init_method = f"tcp://{dist_addr}"
+
+        cuda_device = 0
+        dist_local_rank = self.tp_rank
+        self.device = torch.device(f"cuda:{cuda_device}")
+
+        overrides = dict(server_args_overrides or {})
+        clobbered = sorted(_WORKER_MANAGED_KEYS & overrides.keys())
+        if clobbered:
+            raise ValueError(
+                f"server_args_overrides cannot set worker-managed keys "
+                f"{clobbered}. These are derived from StageConfig and "
+                f"factory parameters; pass them through StageConfig "
+                f"(model_path, tp_size, gpu, dtype, load_format) instead."
+            )
+
+        server_args = build_sglang_encoder_server_args(
+            model_path=model_path,
+            tp_size=self.tp_size,
+            base_gpu_id=cuda_device,
+            dist_init_addr=dist_addr,
+            dtype=dtype,
+            load_format=load_format,
+            **overrides,
+        )
+        set_global_server_args_for_scheduler(server_args)
+
+        self.server_args = server_args
+        self.model_config = ModelConfig.from_server_args(server_args)
+        self.load_config = LoadConfig(
+            load_format=server_args.load_format,
+            download_dir=server_args.download_dir,
+            model_loader_extra_config=server_args.model_loader_extra_config,
+            remote_instance_weight_loader_seed_instance_ip=(
+                server_args.remote_instance_weight_loader_seed_instance_ip
+            ),
+            remote_instance_weight_loader_seed_instance_service_port=(
+                server_args.remote_instance_weight_loader_seed_instance_service_port
+            ),
+            remote_instance_weight_loader_send_weights_group_ports=(
+                server_args.remote_instance_weight_loader_send_weights_group_ports
+            ),
+        )
+
+        torch.cuda.set_device(cuda_device)
+
+        # Always run init_distributed_environment + initialize_model_parallel,
+        # including tp_size==1: SGLang's parallel layers
+        # (ColumnParallelLinear / RowParallelLinear) call get_tp_group()
+        # during their own __init__ and will assert if the group has not
+        # been initialized.
+        init_distributed_environment(
+            world_size=self.tp_size,
+            rank=self.tp_rank,
+            distributed_init_method=dist_init_method,
+            local_rank=dist_local_rank,
+            backend="nccl",
+        )
+        initialize_model_parallel(tensor_model_parallel_size=self.tp_size)
+        initialize_dp_attention(server_args, self.model_config)
+        self.tp_group = get_tp_group()
+
+        self.model = get_model(
+            model_config=self.model_config,
+            load_config=self.load_config,
+            device_config=DeviceConfig(device="cuda", gpu_id=cuda_device),
+        )
+        logger.info(
+            "SGLangEncoderWorker ready (tp_rank=%d/%d, physical_gpu=%d, "
+            "model=%s, dist_addr=%s)",
+            self.tp_rank, self.tp_size, self.physical_gpu_id,
+            model_path, dist_addr,
+        )
+
+    @torch.no_grad()
+    def encode_batch(self, plan: "BatchPlan") -> dict[str, torch.Tensor | None]:
+        """Run the encoder forward for one ``BatchPlan``.
+
+        Determinism guarantee: this method is deterministic given identical
+        ``plan`` inputs across ranks, which the EncoderScheduler ensures
+        through the two-channel broadcast.
+        """
+        return plan.adapter.run_feature(self.model, plan)

--- a/sglang_omni_v1/model_runner/sglang_encoder_worker.py
+++ b/sglang_omni_v1/model_runner/sglang_encoder_worker.py
@@ -1,24 +1,38 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Minimal SGLang-native encoder worker.
+"""Minimal SGLang-native encoder worker with partial encoder loading.
 
 Owns SGLang's distributed init, encoder-only ``ServerArgs`` /
-``ModelConfig`` / ``LoadConfig``, the loaded upstream encoder model,
-and exposes ``encode_batch()``. Does not start the upstream
-``MMEncoder`` (no ZMQ, no transfer engine, no embedding cache) — v1
-already owns request lifecycle, control plane, and relay.
+``ModelConfig`` / ``LoadConfig``, and a small ``EncoderModuleContainer``
+that holds *only* the upstream encoder submodules an adapter declared
+through its :class:`EncoderModuleSpec` list. The worker NEVER calls
+``get_model()`` on the full upstream ``ForConditionalGeneration``
+class — for Qwen3-Omni that would instantiate the thinker LLM (~57 GB
+fp16) and the talker on every encoder GPU, which both wastes memory
+and OOMs on H100-class hardware.
 
-See ``docs/developer_reference/encoder_tp_path_b_design.md`` for the
-full RFC. The init sequence mirrors
-``sglang/python/sglang/srt/disaggregation/encode_server.py`` so it
-inherits SGLang's TP + native encoder implementations.
+What the worker does inherit from upstream:
+    - SGLang distributed init / TP groups
+    - SGLang loader pipeline (``DefaultModelLoader._get_all_weights``,
+      ``load_weights_and_postprocess``)
+    - SGLang TP-aware layers used inside the upstream encoder modules
+      (``ColumnParallelLinear`` / ``RowParallelLinear``, fused
+      attention, etc.)
+
+What the worker brings:
+    - The :class:`EncoderModuleContainer` with adapter-supplied
+      submodules and a prefix-filtering ``load_weights``.
+
+See ``docs/developer_reference/encoder_tp_path_b_design.md`` →
+"Upstream Reuse Boundary" / "EncoderModuleSpec".
 """
 from __future__ import annotations
 
 import logging
 import socket
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Iterable, Sequence
 
 import torch
+import torch.nn as nn
 
 from sglang.srt.configs.device_config import DeviceConfig
 from sglang.srt.configs.load_config import LoadConfig
@@ -29,13 +43,18 @@ from sglang.srt.distributed.parallel_state import (
     initialize_model_parallel,
 )
 from sglang.srt.layers.dp_attention import initialize_dp_attention
-from sglang.srt.model_loader import get_model
+from sglang.srt.model_loader import get_model_loader
+from sglang.srt.model_loader.loader import DefaultModelLoader
+from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.server_args import set_global_server_args_for_scheduler
 
 from sglang_omni_v1.scheduling.sglang_backend import build_sglang_encoder_server_args
 
 if TYPE_CHECKING:
-    from sglang_omni_v1.models.qwen3_omni.encoder_adapters import BatchPlan
+    from sglang_omni_v1.models.qwen3_omni.encoder_adapters import (
+        BatchPlan,
+        EncoderModuleSpec,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -57,8 +76,178 @@ def _pick_free_port() -> int:
         return int(s.getsockname()[1])
 
 
+def _resolve_quant_config(model_config: ModelConfig, load_config: LoadConfig) -> Any:
+    """Best-effort accessor for the model's quantization config.
+
+    Different SGLang versions surface this in different places; encoder
+    submodule constructors that accept a ``quant_config`` will work fine
+    with ``None`` (unquantized), so we return ``None`` if we can't find
+    one.
+    """
+    del load_config  # not currently consumed; reserved for future loaders
+    qc = getattr(model_config, "quantization_config", None)
+    if qc is not None:
+        return qc
+    return getattr(model_config, "quant_config", None)
+
+
+class EncoderModuleContainer(nn.Module):
+    """Module holder for partial encoder loading.
+
+    Builds only the submodules declared by the supplied
+    :class:`EncoderModuleSpec` list. Provides a ``load_weights`` method
+    that:
+
+    - Filters incoming ``(name, tensor)`` pairs by each spec's
+      ``checkpoint_prefixes`` — anything that doesn't match any spec
+      is dropped without allocating a destination tensor.
+    - Applies each spec's ``checkpoint_rewrites`` to map upstream
+      checkpoint key names onto this container's parameter namespace.
+    - Dispatches to ``param.weight_loader`` (set by SGLang's TP-aware
+      layers) when present, otherwise falls back to
+      ``default_weight_loader`` so unfused params still copy correctly.
+
+    The container is intentionally lean: no language model, no logits
+    head, no talker, no generation path, no scheduler state. Its sole
+    job is to give SGLang's loader a parameter namespace that contains
+    the selected encoder submodules and nothing else.
+    """
+
+    def __init__(
+        self,
+        hf_config: Any,
+        *,
+        encoder_specs: Sequence["EncoderModuleSpec"],
+        quant_config: Any,
+    ) -> None:
+        super().__init__()
+        if not encoder_specs:
+            raise ValueError(
+                "EncoderModuleContainer requires at least one EncoderModuleSpec; "
+                "the encoder adapter must declare its upstream submodules."
+            )
+        names = [spec.name for spec in encoder_specs]
+        if len(set(names)) != len(names):
+            raise ValueError(
+                f"EncoderModuleSpec names must be unique within a stage: {names}"
+            )
+
+        self._specs: dict[str, "EncoderModuleSpec"] = {}
+        for spec in encoder_specs:
+            module = spec.build_module(hf_config, quant_config)
+            self.add_module(spec.name, module)
+            self._specs[spec.name] = spec
+
+    # -- Loader entry point -------------------------------------------------
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> None:
+        """SGLang loader hook — filter, rewrite, and dispatch.
+
+        Two-stage dispatch:
+
+        1. Group the incoming stream by spec using
+           ``checkpoint_prefixes``. Anything that doesn't match any spec
+           is dropped without allocating.
+        2. Per submodule:
+           - If the submodule has its own ``load_weights`` (e.g.
+             ``Qwen3OmniMoeVisionEncoder``), strip the leading
+             ``"<spec.name>."`` from each rewritten key and forward the
+             slice. The submodule handles its own fused-shard dispatch.
+           - Otherwise, apply ``stacked_params_mapping`` from the spec
+             before doing a direct param lookup. This is how
+             ``audio_tower.layers.X.self_attn.q_proj.weight`` reaches
+             ``audio_tower.layers.X.self_attn.qkv_proj.weight`` with
+             ``shard_id="q"``. Without it the audio attention layers
+             are loaded with random init weights and produce NaN in
+             forward.
+        """
+        # 1. Bucket by spec.
+        buckets: dict[str, list[tuple[str, torch.Tensor]]] = {
+            n: [] for n in self._specs
+        }
+        skipped = 0
+        for name, loaded_weight in weights:
+            spec = self._spec_for(name)
+            if spec is None:
+                skipped += 1
+                continue
+            rewritten = name
+            for old, new in spec.checkpoint_rewrites:
+                rewritten = rewritten.replace(old, new)
+            buckets[spec.name].append((rewritten, loaded_weight))
+
+        # 2. Per-spec dispatch.
+        loaded_total = 0
+        for spec_name, bucket in buckets.items():
+            if not bucket:
+                continue
+            spec = self._specs[spec_name]
+            submodule = getattr(self, spec_name)
+            if hasattr(submodule, "load_weights"):
+                # Delegate. The submodule expects names relative to itself
+                # (without the leading "{spec.name}.").
+                relative = []
+                inner_prefix = spec.name + "."
+                for n, w in bucket:
+                    if n.startswith(inner_prefix):
+                        relative.append((n[len(inner_prefix):], w))
+                    else:
+                        # If rewrites didn't produce the expected prefix,
+                        # forward as-is and let the submodule's own
+                        # error reporting fire.
+                        relative.append((n, w))
+                submodule.load_weights(relative)
+                loaded_total += len(relative)
+            else:
+                loaded_total += self._load_with_stacked_mapping(spec, bucket)
+
+        logger.info(
+            "EncoderModuleContainer.load_weights: loaded=%d skipped=%d",
+            loaded_total, skipped,
+        )
+
+    def _load_with_stacked_mapping(
+        self,
+        spec: "EncoderModuleSpec",
+        weights: list[tuple[str, torch.Tensor]],
+    ) -> int:
+        """Apply spec.stacked_params_mapping then fall back to direct lookup."""
+        params = dict(self.named_parameters())
+        loaded = 0
+        for name, loaded_weight in weights:
+            dispatched = False
+            for target, source, shard_id in spec.stacked_params_mapping:
+                if source not in name:
+                    continue
+                mapped = name.replace(source, target)
+                if mapped not in params:
+                    continue
+                param = params[mapped]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight, shard_id)
+                dispatched = True
+                loaded += 1
+                break
+            if dispatched:
+                continue
+            if name in params:
+                param = params[name]
+                weight_loader = getattr(
+                    param, "weight_loader", default_weight_loader
+                )
+                weight_loader(param, loaded_weight)
+                loaded += 1
+        return loaded
+
+    def _spec_for(self, name: str) -> "EncoderModuleSpec | None":
+        for spec in self._specs.values():
+            if name.startswith(spec.checkpoint_prefixes):
+                return spec
+        return None
+
+
 class SGLangEncoderWorker:
-    """SGLang-native encoder model wrapper.
+    """SGLang-native encoder model wrapper with partial loading.
 
     The worker process is invoked by ``MultiProcessPipelineRunner``,
     which has remapped ``CUDA_VISIBLE_DEVICES`` to a single physical GPU
@@ -78,6 +267,9 @@ class SGLangEncoderWorker:
         nccl_port: Loopback NCCL bootstrap port allocated by the runner.
             Optional; the worker picks a free port when unset
             (single-rank case).
+        encoder_specs: Adapter-supplied list of encoder submodules to
+            load. Required — the worker does NOT load the full
+            ``ForConditionalGeneration`` class.
         dtype: Optional dtype override forwarded to ``ServerArgs``.
         load_format: Optional load-format override forwarded to ``ServerArgs``.
         server_args_overrides: Extra ``ServerArgs`` kwargs (loader / processor
@@ -92,6 +284,7 @@ class SGLangEncoderWorker:
         tp_rank: int,
         tp_size: int,
         nccl_port: int | None,
+        encoder_specs: Sequence["EncoderModuleSpec"],
         dtype: str | None = None,
         load_format: str | None = None,
         server_args_overrides: dict[str, Any] | None = None,
@@ -101,6 +294,13 @@ class SGLangEncoderWorker:
         if not (0 <= tp_rank < tp_size):
             raise ValueError(
                 f"tp_rank={tp_rank} must satisfy 0 <= tp_rank < tp_size={tp_size}"
+            )
+        if not encoder_specs:
+            raise ValueError(
+                "SGLangEncoderWorker requires encoder_specs; the adapter must "
+                "declare its upstream submodules. The worker no longer falls "
+                "back to get_model() on the full ForConditionalGeneration "
+                "class — that would load the LLM/talker on every encoder GPU."
             )
 
         self.tp_rank = int(tp_rank)
@@ -178,17 +378,81 @@ class SGLangEncoderWorker:
         initialize_dp_attention(server_args, self.model_config)
         self.tp_group = get_tp_group()
 
-        self.model = get_model(
-            model_config=self.model_config,
-            load_config=self.load_config,
-            device_config=DeviceConfig(device="cuda", gpu_id=cuda_device),
-        )
+        self._device_config = DeviceConfig(device="cuda", gpu_id=cuda_device)
+
+        # ---- Partial-load path ----------------------------------------
+        # Build only the encoder submodules the adapter declared, then
+        # iterate the upstream loader's weight stream and let the
+        # container drop everything that doesn't match a declared
+        # prefix.
+        self.model = self._build_and_load_encoder(encoder_specs)
+        self.model.eval()
+
         logger.info(
             "SGLangEncoderWorker ready (tp_rank=%d/%d, physical_gpu=%d, "
-            "model=%s, dist_addr=%s)",
+            "model=%s, submodules=%s, dist_addr=%s)",
             self.tp_rank, self.tp_size, self.physical_gpu_id,
-            model_path, dist_addr,
+            model_path, [s.name for s in encoder_specs], dist_addr,
         )
+
+    # ------------------------------------------------------------------
+    # Partial-load helper
+    # ------------------------------------------------------------------
+
+    def _build_and_load_encoder(
+        self,
+        encoder_specs: Sequence["EncoderModuleSpec"],
+    ) -> EncoderModuleContainer:
+        """Construct the container + run upstream loader's weight stream.
+
+        We build the container under ``set_default_torch_dtype`` and on
+        the target device so SGLang's TP-aware layers register their
+        ``param.weight_loader`` hooks correctly during ``__init__``.
+        Then we hand the container off to ``DefaultModelLoader``'s
+        weight-postprocess machinery, which iterates the safetensors
+        shards and calls ``container.load_weights(...)`` once.
+        """
+        from sglang.srt.model_loader.utils import set_default_torch_dtype
+
+        loader = get_model_loader(self.load_config)
+        # We deliberately do not use ``loader.load_model`` because that
+        # path always calls ``_initialize_model`` on the full upstream
+        # entry class. The upstream API does not expose a
+        # partial-encoder-loader yet (see RFC Open Question 1).
+        target_device = torch.device(self._device_config.device)
+
+        quant_config = _resolve_quant_config(self.model_config, self.load_config)
+
+        with set_default_torch_dtype(self.model_config.dtype):
+            with target_device:
+                container = EncoderModuleContainer(
+                    self.model_config.hf_config,
+                    encoder_specs=encoder_specs,
+                    quant_config=quant_config,
+                )
+
+            if isinstance(loader, DefaultModelLoader):
+                weights = loader._get_all_weights(self.model_config, container)
+            else:
+                # Other loaders (BitsAndBytes, ShardedState, ...) don't
+                # expose the same iterator. Phase 0 only validates the
+                # default loader; non-default load formats raise here so
+                # users see a clear error rather than a broken weight
+                # set.
+                raise NotImplementedError(
+                    f"Encoder partial-load currently requires "
+                    f"DefaultModelLoader; got {type(loader).__name__}. "
+                    f"Use load_format='auto' (the default) for Phase 0."
+                )
+
+            DefaultModelLoader.load_weights_and_postprocess(
+                container, weights, target_device,
+            )
+        return container
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
     @torch.no_grad()
     def encode_batch(self, plan: "BatchPlan") -> dict[str, torch.Tensor | None]:

--- a/sglang_omni_v1/models/qwen3_omni/config.py
+++ b/sglang_omni_v1/models/qwen3_omni/config.py
@@ -36,7 +36,7 @@ class Qwen3OmniPipelineConfig(PipelineConfig):
         ),
         StageConfig(
             name="image_encoder",
-            factory=f"{_PKG}.stages.create_image_encoder_executor",
+            factory=f"{_PKG}.stages.create_image_encoder_runner",
             factory_args={"device": "cuda", "dtype": None},
             gpu=0,
             next="mm_aggregate",
@@ -48,7 +48,7 @@ class Qwen3OmniPipelineConfig(PipelineConfig):
         ),
         StageConfig(
             name="audio_encoder",
-            factory=f"{_PKG}.stages.create_audio_encoder_executor",
+            factory=f"{_PKG}.stages.create_audio_encoder_runner",
             factory_args={"device": "cuda", "dtype": None},
             gpu=0,
             next="mm_aggregate",
@@ -106,7 +106,7 @@ class Qwen3OmniSpeechPipelineConfig(PipelineConfig):
         ),
         StageConfig(
             name="image_encoder",
-            factory=f"{_PKG}.stages.create_image_encoder_executor",
+            factory=f"{_PKG}.stages.create_image_encoder_runner",
             factory_args={"device": "cuda", "dtype": None},
             gpu=0,
             next="mm_aggregate",
@@ -118,7 +118,7 @@ class Qwen3OmniSpeechPipelineConfig(PipelineConfig):
         ),
         StageConfig(
             name="audio_encoder",
-            factory=f"{_PKG}.stages.create_audio_encoder_executor",
+            factory=f"{_PKG}.stages.create_audio_encoder_runner",
             factory_args={"device": "cuda", "dtype": None},
             gpu=0,
             next="mm_aggregate",

--- a/sglang_omni_v1/models/qwen3_omni/encoder_adapters.py
+++ b/sglang_omni_v1/models/qwen3_omni/encoder_adapters.py
@@ -300,28 +300,33 @@ class Qwen3OmniImageEncoderAdapter:
             n_img = n_vid = 0
             img_tokens = vid_tokens = 0
             if isinstance(inputs.get("pixel_values"), torch.Tensor):
-                grid = inputs["image_grid_thw"]
+                # _strip_and_lift moved every tensor in the payload tree to
+                # cuda:0. For grid_thw that is wrong: upstream
+                # ``compute_cu_seqlens_from_grid_numpy`` asserts a CPU tensor
+                # (sglang/python/sglang/srt/models/utils.py:154). Move it
+                # back to CPU so the upstream model never sees a CUDA grid.
+                grid = inputs["image_grid_thw"].to(dtype=torch.long, device="cpu")
                 it = MultimodalDataItem(
                     modality=Modality.IMAGE,
                     feature=inputs["pixel_values"],
                 )
-                it.image_grid_thw = grid.to(dtype=torch.long)
+                it.image_grid_thw = grid
                 images.append(it)
                 n_img = int(grid.shape[0])
                 img_tokens = int(
-                    (grid.to(dtype=torch.long).prod(-1) // self._merge).sum().item()
+                    (grid.prod(-1) // self._merge).sum().item()
                 )
             if isinstance(inputs.get("pixel_values_videos"), torch.Tensor):
-                grid = inputs["video_grid_thw"]
+                grid = inputs["video_grid_thw"].to(dtype=torch.long, device="cpu")
                 v = MultimodalDataItem(
                     modality=Modality.VIDEO,
                     feature=inputs["pixel_values_videos"],
                 )
-                v.video_grid_thw = grid.to(dtype=torch.long)
+                v.video_grid_thw = grid
                 videos.append(v)
                 n_vid = int(grid.shape[0])
                 vid_tokens = int(
-                    (grid.to(dtype=torch.long).prod(-1) // self._merge).sum().item()
+                    (grid.prod(-1) // self._merge).sum().item()
                 )
             spans.append(
                 RequestSpan(

--- a/sglang_omni_v1/models/qwen3_omni/encoder_adapters.py
+++ b/sglang_omni_v1/models/qwen3_omni/encoder_adapters.py
@@ -65,7 +65,7 @@ QWEN3_IMAGE_ENCODER_ACTIVATION_MULTIPLIER = 5
 class RequestSpan:
     """Per-request slice of one BatchPlan.
 
-    Exactly one of ``skip_result`` or the active counters is meaningful.
+    Exactly one of ``skip_result`` or the active fields below is populated.
     """
 
     request_id: str

--- a/sglang_omni_v1/models/qwen3_omni/encoder_adapters.py
+++ b/sglang_omni_v1/models/qwen3_omni/encoder_adapters.py
@@ -9,10 +9,13 @@ For each encoder stage there is one adapter implementing
   ``_skip``) contribute no upstream items; active requests yield one or
   more :class:`MultimodalDataItem` per request, with per-request
   bookkeeping captured in :class:`RequestSpan`.
-- ``run_feature`` calls the upstream encoder methods
-  (``thinker.get_image_feature``, ``...get_video_feature``,
-  ``...get_audio_feature``). Empty plans short-circuit and never call
-  the model.
+- ``run_feature`` calls the loaded upstream encoder submodule directly
+  — ``Qwen3OmniMoeVisionEncoder`` for image/video, ``Qwen3OmniMoeAudioEncoder``
+  for audio — instead of the full ``thinker.get_*_feature`` entry
+  points. The encoder worker partial-loads ONLY these submodules (see
+  ``EncoderModuleSpec``), so ``model.thinker`` is never instantiated and
+  the full Qwen3-Omni LLM weights never reach the encoder GPU.
+  Empty plans short-circuit and never call any submodule.
 - ``slice_results`` un-batches the upstream output back to per-request
   ``encoder_outs`` dicts using the captured spans.
 
@@ -26,13 +29,18 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Callable, Protocol
 
 import torch
+import torch.nn as nn
 import torch.nn.functional as F
 
 from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
-from sglang.srt.models.qwen3_omni_moe import _get_feat_extract_output_lengths
+from sglang.srt.models.qwen3_omni_moe import (
+    Qwen3OmniMoeAudioEncoder,
+    Qwen3OmniMoeVisionEncoder,
+    _get_feat_extract_output_lengths,
+)
 
 from sglang_omni_v1.models.qwen3_omni.payload_types import PipelineState
 from sglang_omni_v1.models.qwen3_omni.request_builders import (
@@ -54,6 +62,119 @@ AUDIO_STAGE = "audio_encoder"
 # here to avoid pulling that module's heavyweight import chain (preprocessor,
 # transformers video utils) into the lean adapter module.
 QWEN3_IMAGE_ENCODER_ACTIVATION_MULTIPLIER = 5
+
+
+# ---------------------------------------------------------------------------
+# EncoderModuleSpec — declares which upstream encoder submodules a stage
+# loads and which checkpoint prefixes feed them. The shared SGLang encoder
+# worker uses these specs to partial-load only the relevant submodule
+# weights, avoiding the ~57 GB of LLM/talker weights that
+# ``Qwen3OmniMoeForConditionalGeneration`` would otherwise pull in.
+# See ``docs/developer_reference/encoder_tp_path_b_design.md`` →
+# "Upstream Reuse Boundary" + "EncoderModuleSpec".
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class EncoderModuleSpec:
+    """Declaration of an upstream encoder submodule the worker should load.
+
+    Args:
+        name: Local attribute name the submodule will be exposed as on
+            ``EncoderModuleContainer`` (e.g. ``"visual"``,
+            ``"audio_tower"``). Adapters reference this name when they
+            access the submodule from ``model.<name>`` in
+            ``run_feature``.
+        build_module: Callable receiving the HF config and a
+            ``QuantizationConfig | None`` and returning the concrete
+            ``nn.Module`` instance.
+        checkpoint_prefixes: Tuple of checkpoint key prefixes to accept
+            for this submodule. Any (name, tensor) pair in the
+            checkpoint stream whose name does NOT start with one of
+            these prefixes is dropped without allocation.
+        checkpoint_rewrites: Tuple of ``(old, new)`` pairs applied
+            sequentially via ``str.replace`` to map upstream checkpoint
+            keys onto the local submodule's parameter namespace. Order
+            matters; rewrites are applied left-to-right on each match.
+        stacked_params_mapping: ``(target_substring, source_substring,
+            shard_id)`` tuples describing fused-shard params (e.g.
+            ``q_proj`` + ``k_proj`` + ``v_proj`` → ``qkv_proj``). When
+            an incoming key contains ``source_substring``, the container
+            replaces it with ``target_substring`` and dispatches to
+            ``param.weight_loader(param, weight, shard_id)``. Only used
+            when the submodule does not provide its own ``load_weights``;
+            if the submodule has ``load_weights``, the container delegates
+            to it and this field is ignored.
+    """
+
+    name: str
+    build_module: Callable[[Any, Any], nn.Module]
+    checkpoint_prefixes: tuple[str, ...]
+    checkpoint_rewrites: tuple[tuple[str, str], ...] = ()
+    stacked_params_mapping: tuple[tuple[str, str, str], ...] = ()
+
+
+def _build_qwen3_omni_visual(hf_config: Any, quant_config: Any) -> nn.Module:
+    """Build ``Qwen3OmniMoeVisionEncoder`` from a thinker-aware HF config."""
+    thinker = getattr(hf_config, "thinker_config", hf_config)
+    return Qwen3OmniMoeVisionEncoder(
+        thinker.vision_config,
+        quant_config=quant_config,
+        norm_eps=getattr(thinker, "rms_norm_eps", 1e-6),
+        prefix="visual",
+    )
+
+
+def _build_qwen3_omni_audio(hf_config: Any, quant_config: Any) -> nn.Module:
+    """Build ``Qwen3OmniMoeAudioEncoder``."""
+    del quant_config  # the upstream audio encoder constructor does not take one
+    thinker = getattr(hf_config, "thinker_config", hf_config)
+    return Qwen3OmniMoeAudioEncoder(thinker.audio_config)
+
+
+QWEN3_OMNI_VISUAL_SPEC = EncoderModuleSpec(
+    name="visual",
+    build_module=_build_qwen3_omni_visual,
+    # Upstream Qwen3-Omni checkpoints place visual weights under either
+    # ``model.visual.*`` or ``thinker.visual.*`` depending on the dump
+    # source; some older shards keep them at the top-level ``visual.*``.
+    checkpoint_prefixes=("model.visual.", "thinker.visual.", "visual."),
+    checkpoint_rewrites=(
+        ("model.visual.", "visual."),
+        ("thinker.visual.", "visual."),
+        # Upstream key names use ``attn.qkv``/``attn.out_proj``; the
+        # SGLang submodule renames these to ``attn.qkv_proj``/``attn.proj``
+        # after fusing QKV. Apply rewrites so the loader's
+        # ``param.weight_loader`` sees the right destination param name.
+        ("attn.qkv.", "attn.qkv_proj."),
+        ("attn.out_proj.", "attn.proj."),
+    ),
+)
+
+QWEN3_OMNI_AUDIO_SPEC = EncoderModuleSpec(
+    name="audio_tower",
+    build_module=_build_qwen3_omni_audio,
+    checkpoint_prefixes=("audio_tower.", "thinker.audio_tower."),
+    checkpoint_rewrites=(
+        ("thinker.audio_tower.", "audio_tower."),
+        # Upstream rename: checkpoint stores ``self_attn.out_proj`` but the
+        # SGLang module exposes ``self_attn.proj``. Mirrors the rename in
+        # ``Qwen3OmniMoeForConditionalGeneration.load_weights`` so the
+        # output projection actually loads.
+        (".self_attn.out_proj", ".self_attn.proj"),
+    ),
+    stacked_params_mapping=(
+        # Audio tower's ``VisionAttention`` fuses Q/K/V into one
+        # ``QKVParallelLinear`` named ``qkv_proj``. The checkpoint stores
+        # ``q_proj``/``k_proj``/``v_proj`` separately; container's loader
+        # rewrites the source name onto the fused param and dispatches
+        # via ``weight_loader(param, weight, shard_id)``. Without this
+        # we silently drop ~half the audio attention weights.
+        (".self_attn.qkv_proj", ".self_attn.q_proj", "q"),
+        (".self_attn.qkv_proj", ".self_attn.k_proj", "k"),
+        (".self_attn.qkv_proj", ".self_attn.v_proj", "v"),
+    ),
+)
 
 
 # ---------------------------------------------------------------------------
@@ -233,6 +354,12 @@ class Qwen3OmniImageEncoderAdapter:
     """Adapter for the visual stage (images and videos)."""
 
     stage_name = IMAGE_STAGE
+    # Declares the upstream submodules the encoder worker must
+    # partial-load. The factory passes this through to
+    # ``SGLangEncoderWorker`` so only ``Qwen3OmniMoeVisionEncoder``
+    # weights end up on the encoder GPU — the LLM, talker, and audio
+    # tower are never instantiated.
+    encoder_specs: tuple[EncoderModuleSpec, ...] = (QWEN3_OMNI_VISUAL_SPEC,)
 
     def __init__(
         self,
@@ -346,27 +473,49 @@ class Qwen3OmniImageEncoderAdapter:
     ) -> dict[str, torch.Tensor | None]:
         if plan.is_empty:
             return {"image": None, "video": None, "audio": None}
-        thinker = getattr(model, "thinker", model)
-        # get_video_feature() upstream needs the same MultimodalDataItem
-        # contract that get_image_feature does: items[i].image_grid_thw
-        # is read by the parent helper. Upstream Qwen3-VL uses the same
-        # method name for video-grid tensors but it dispatches by
-        # modality internally — we set image_grid_thw on video items too
-        # so the wrapped concat works (qwen3_vl.py:1212).
-        for vid in plan.video_items:
-            if not hasattr(vid, "image_grid_thw") and hasattr(vid, "video_grid_thw"):
-                vid.image_grid_thw = vid.video_grid_thw
+        # ``model`` is the EncoderModuleContainer the worker built from
+        # ``self.encoder_specs``; it exposes the visual submodule under the
+        # name declared in QWEN3_OMNI_VISUAL_SPEC (``visual``). We mirror
+        # the simple no-chunking path of upstream
+        # ``Qwen3OmniMoeThinkerForConditionalGeneration.get_{image,video}_feature``
+        # without going through ``model.thinker`` (which doesn't exist —
+        # the container only holds the encoder submodules).
+        visual = model.visual
         image_embed = (
-            thinker.get_image_feature(plan.image_items)
+            self._get_visual_feature(visual, plan.image_items, kind="image")
             if plan.image_items
             else None
         )
         video_embed = (
-            thinker.get_video_feature(plan.video_items)
+            self._get_visual_feature(visual, plan.video_items, kind="video")
             if plan.video_items
             else None
         )
         return {"image": image_embed, "video": video_embed, "audio": None}
+
+    @staticmethod
+    def _get_visual_feature(
+        visual: nn.Module,
+        items: list[MultimodalDataItem],
+        *,
+        kind: str,
+    ) -> torch.Tensor:
+        """Mirror of ``thinker.get_{image,video}_feature`` simple path.
+
+        Concats per-item pixel/grid tensors and calls the loaded
+        submodule directly. Upstream's chunking branch (gated on
+        ``SGLANG_VLM_MAX_PATCHES_PER_VIT`` / ``SGLANG_VLM_MAX_IMAGES_PER_VIT``)
+        is not mirrored in Phase 0 — long-video deployments that need it
+        will be added as a follow-up.
+        """
+        pixel_values = (
+            torch.cat([item.feature for item in items], dim=0).type(visual.dtype)
+        )
+        grid_attr = "image_grid_thw" if kind == "image" else "video_grid_thw"
+        grid = torch.cat([getattr(item, grid_attr) for item in items], dim=0)
+        assert pixel_values.dim() == 2, pixel_values.dim()
+        assert grid.dim() == 2, grid.dim()
+        return visual(pixel_values, grid_thw=grid)
 
     def slice_results(
         self,
@@ -459,6 +608,7 @@ class Qwen3OmniAudioEncoderAdapter:
     """Adapter for the audio stage."""
 
     stage_name = AUDIO_STAGE
+    encoder_specs: tuple[EncoderModuleSpec, ...] = (QWEN3_OMNI_AUDIO_SPEC,)
 
     def __init__(self, *, hf_config: Any, dtype: torch.dtype) -> None:
         del hf_config, dtype  # not currently consumed
@@ -524,9 +674,34 @@ class Qwen3OmniAudioEncoderAdapter:
     ) -> dict[str, torch.Tensor | None]:
         if plan.is_empty:
             return {"image": None, "video": None, "audio": None}
-        thinker = getattr(model, "thinker", model)
-        embed = thinker.get_audio_feature(plan.audio_items)
+        # ``model`` is the EncoderModuleContainer; ``audio_tower`` is the
+        # name declared in QWEN3_OMNI_AUDIO_SPEC.
+        embed = self._get_audio_feature(model.audio_tower, plan.audio_items)
         return {"image": None, "video": None, "audio": embed}
+
+    @staticmethod
+    def _get_audio_feature(
+        audio_tower: nn.Module,
+        items: list[MultimodalDataItem],
+    ) -> torch.Tensor:
+        """Mirror of ``thinker.get_audio_feature`` against the loaded submodule."""
+        feature_attention_mask = (
+            torch.cat([item.feature_attention_mask for item in items], dim=0)
+            .type(torch.long)
+        )
+        input_features = (
+            torch.cat([item.feature for item in items])
+            .type(audio_tower.dtype)
+            .to(next(audio_tower.parameters()).device)
+        )
+        audio_feature_lengths = torch.sum(feature_attention_mask, dim=1)
+        # Drop padded positions before the conv stack — same as upstream.
+        input_features = (
+            input_features.permute(0, 2, 1)[feature_attention_mask.bool()]
+            .permute(1, 0)
+        )
+        outputs = audio_tower(input_features, feature_lens=audio_feature_lengths)
+        return outputs.last_hidden_state
 
     def slice_results(
         self,

--- a/sglang_omni_v1/models/qwen3_omni/encoder_adapters.py
+++ b/sglang_omni_v1/models/qwen3_omni/encoder_adapters.py
@@ -1,0 +1,560 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen3-Omni encoder adapters between v1 :class:`PipelineState` and SGLang.
+
+For each encoder stage there is one adapter implementing
+``build_batch`` / ``run_feature`` / ``slice_results``:
+
+- ``build_batch`` materializes a :class:`BatchPlan` from a flat list of
+  :class:`IncomingMessage`. Skip requests (preprocessor-stamped
+  ``_skip``) contribute no upstream items; active requests yield one or
+  more :class:`MultimodalDataItem` per request, with per-request
+  bookkeeping captured in :class:`RequestSpan`.
+- ``run_feature`` calls the upstream encoder methods
+  (``thinker.get_image_feature``, ``...get_video_feature``,
+  ``...get_audio_feature``). Empty plans short-circuit and never call
+  the model.
+- ``slice_results`` un-batches the upstream output back to per-request
+  ``encoder_outs`` dicts using the captured spans.
+
+Cache (``EncoderRequestData.cache_key``) is intentionally not consumed
+in this Phase 0 path — wiring cache into a TP-broadcasting scheduler
+requires shipping the hit/miss decision before the device broadcast
+(see RFC Open Question 6). The local backend keeps its cache; the
+SGLang backend always forwards every non-skip request.
+"""
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import TYPE_CHECKING, Any, Protocol
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
+from sglang.srt.models.qwen3_omni_moe import _get_feat_extract_output_lengths
+
+from sglang_omni_v1.models.qwen3_omni.payload_types import PipelineState
+from sglang_omni_v1.models.qwen3_omni.request_builders import (
+    apply_encoder_result,
+    build_encoder_request,
+)
+from sglang_omni_v1.proto import StagePayload
+from sglang_omni_v1.scheduling.messages import IncomingMessage
+
+if TYPE_CHECKING:
+    from sglang_omni_v1.models.qwen3_omni.request_builders import EncoderRequestData
+
+logger = logging.getLogger(__name__)
+
+IMAGE_STAGE = "image_encoder"
+AUDIO_STAGE = "audio_encoder"
+
+# Sourced from sglang_omni.models.qwen3_omni.pipeline.visual_budget — duplicated
+# here to avoid pulling that module's heavyweight import chain (preprocessor,
+# transformers video utils) into the lean adapter module.
+QWEN3_IMAGE_ENCODER_ACTIVATION_MULTIPLIER = 5
+
+
+# ---------------------------------------------------------------------------
+# BatchPlan / RequestSpan
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(slots=True)
+class RequestSpan:
+    """Per-request slice of one BatchPlan.
+
+    Exactly one of ``skip_result`` or the active counters is meaningful.
+    """
+
+    request_id: str
+    skip_result: dict | None = None
+    image_rows: int = 0
+    video_rows: int = 0
+    audio_rows: int = 0
+    image_token_count: int = 0
+    video_token_count: int = 0
+    # Audio splitting: keep both the unpadded per-request feature lengths
+    # (passed back to merge_for_thinker as audio_feature_lengths) and the
+    # downsampled output lengths used to slice the encoder output along
+    # the token axis.
+    audio_feature_lengths: torch.Tensor | None = None
+    audio_output_lengths: torch.Tensor | None = None
+
+
+@dataclasses.dataclass(slots=True)
+class BatchPlan:
+    """Bundle passed from ``build_batch`` to ``encode_batch`` to ``slice_results``."""
+
+    adapter: "EncoderAdapter"
+    image_items: list[MultimodalDataItem]
+    video_items: list[MultimodalDataItem]
+    audio_items: list[MultimodalDataItem]
+    spans: list[RequestSpan]
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.image_items or self.video_items or self.audio_items)
+
+
+class EncoderAdapter(Protocol):
+    """Adapter contract.
+
+    Implementers should keep ``build_batch`` and ``slice_results`` cheap
+    (no GPU work) — they run on every rank.
+    """
+
+    stage_name: str
+
+    def build_batch(self, messages: list[IncomingMessage]) -> BatchPlan: ...
+
+    def run_feature(
+        self, model: Any, plan: BatchPlan
+    ) -> dict[str, torch.Tensor | None]: ...
+
+    def slice_results(
+        self,
+        raw: dict[str, torch.Tensor | None],
+        plan: BatchPlan,
+        messages: list[IncomingMessage],
+    ) -> list[StagePayload]: ...
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers (moved from stages.py with one device-aware fix)
+# ---------------------------------------------------------------------------
+
+
+def _payload_with_state(payload: StagePayload, state: PipelineState) -> StagePayload:
+    return StagePayload(
+        request_id=payload.request_id,
+        request=payload.request,
+        data=state.to_dict(),
+    )
+
+
+def _tensor_bytes(value: Any) -> int:
+    if not isinstance(value, torch.Tensor):
+        return 0
+    return int(value.numel() * value.element_size())
+
+
+def _grid_visual_tokens(grid: Any, merge: int) -> int:
+    if not isinstance(grid, torch.Tensor) or grid.numel() == 0:
+        return 0
+    return int((grid.to(dtype=torch.long).prod(dim=-1) // merge).sum().item())
+
+
+def _split_visual_features(
+    tensor: torch.Tensor | None,
+    *,
+    start: int,
+    end: int,
+) -> torch.Tensor | None:
+    if tensor is None:
+        return None
+    return tensor[start:end]
+
+
+def _split_visual_multiscale(
+    tensors: list[torch.Tensor] | None,
+    *,
+    start: int,
+    end: int,
+) -> list[torch.Tensor] | None:
+    if tensors is None:
+        return None
+    return [tensor[start:end] for tensor in tensors]
+
+
+def _normalize_audio_request_tensors(
+    request: "EncoderRequestData",
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Return ``(features [B, mel, time], mask [B, time] bool, lengths [B] long)``.
+
+    The synthesized fallback mask uses ``arange`` on ``lengths.device``
+    so that this helper is safe in both the local v1 path (CPU) and the
+    SGLang Plan B path (cuda:0 after ``_strip_and_lift``). See RFC
+    "Audio adapter / mandatory device-aware fix".
+    """
+    input_dict = request.model_inputs
+    features = input_dict["input_features"]
+    if features.ndim == 2:
+        features = features.unsqueeze(0)
+
+    lengths = input_dict.get("audio_feature_lengths")
+    mask = input_dict.get("feature_attention_mask")
+    if isinstance(lengths, torch.Tensor):
+        lengths = lengths.to(dtype=torch.long).view(-1)
+    elif isinstance(mask, torch.Tensor):
+        lengths = mask.to(dtype=torch.long).sum(dim=1).view(-1)
+    else:
+        raise ValueError(
+            "audio_feature_lengths or feature_attention_mask is required"
+        )
+
+    time_dim = features.shape[-1]
+    if isinstance(mask, torch.Tensor):
+        if mask.ndim == 1:
+            mask = mask.unsqueeze(0)
+        mask = mask.to(dtype=torch.bool)
+    else:
+        steps = torch.arange(
+            time_dim,
+            dtype=torch.long,
+            device=lengths.device,
+        ).unsqueeze(0)
+        mask = steps < lengths.unsqueeze(1)
+
+    return features, mask, lengths
+
+
+def _pad_audio_features(features: torch.Tensor, target_time: int) -> torch.Tensor:
+    pad = target_time - int(features.shape[-1])
+    if pad <= 0:
+        return features
+    return F.pad(features, (0, pad))
+
+
+def _pad_audio_mask(mask: torch.Tensor, target_time: int) -> torch.Tensor:
+    pad = target_time - int(mask.shape[-1])
+    if pad <= 0:
+        return mask
+    return F.pad(mask, (0, pad), value=False)
+
+
+# ---------------------------------------------------------------------------
+# Image / video adapter
+# ---------------------------------------------------------------------------
+
+
+class Qwen3OmniImageEncoderAdapter:
+    """Adapter for the visual stage (images and videos)."""
+
+    stage_name = IMAGE_STAGE
+
+    def __init__(
+        self,
+        *,
+        hf_config: Any,
+        dtype: torch.dtype,
+    ) -> None:
+        thinker_cfg = getattr(hf_config, "thinker_config", hf_config)
+        vision_cfg = thinker_cfg.vision_config
+        self._merge = int(vision_cfg.spatial_merge_size) ** 2
+        self._base_hidden = int(vision_cfg.out_hidden_size)
+        self._output_layers = 1 + len(vision_cfg.deepstack_visual_indexes)
+        self._dtype_bytes = torch.empty((), dtype=dtype).element_size()
+
+    # -- request_cost_fn ------------------------------------------------
+
+    def request_cost_fn(self, payload: StagePayload) -> int:
+        """Cheap byte estimator used for batch-cost admission control.
+
+        Mirrors the local-path arithmetic at ``stages.py:144-166``:
+        ``(raw_input_bytes + token_count * base_hidden * dtype_bytes *
+        output_layers) * activation_multiplier``. Reads metadata from
+        the HF ``vision_config`` rather than the SGLang model wrapper to
+        avoid the deepstack double-count trap (the wrapper already folds
+        deepstack into ``out_hidden_size``; the local config does not).
+        """
+        state = PipelineState.from_dict(payload.data)
+        request = build_encoder_request(state, stage_name=IMAGE_STAGE)
+        if request.skip_result is not None:
+            return 0
+        inputs = request.model_inputs
+        raw_bytes = _tensor_bytes(inputs.get("pixel_values"))
+        raw_bytes += _tensor_bytes(inputs.get("pixel_values_videos"))
+        visual_tokens = _grid_visual_tokens(inputs.get("image_grid_thw"), self._merge)
+        visual_tokens += _grid_visual_tokens(
+            inputs.get("video_grid_thw"), self._merge
+        )
+        output_bytes = (
+            visual_tokens * self._base_hidden * self._dtype_bytes * self._output_layers
+        )
+        return (raw_bytes + output_bytes) * QWEN3_IMAGE_ENCODER_ACTIVATION_MULTIPLIER
+
+    # -- build / run / slice -------------------------------------------
+
+    def build_batch(self, messages: list[IncomingMessage]) -> BatchPlan:
+        images: list[MultimodalDataItem] = []
+        videos: list[MultimodalDataItem] = []
+        spans: list[RequestSpan] = []
+
+        for msg in messages:
+            payload = msg.data
+            state = PipelineState.from_dict(payload.data)
+            request = build_encoder_request(state, stage_name=IMAGE_STAGE)
+
+            if request.skip_result is not None:
+                spans.append(
+                    RequestSpan(
+                        request_id=msg.request_id,
+                        skip_result=request.skip_result,
+                    )
+                )
+                continue
+
+            inputs = request.model_inputs
+            n_img = n_vid = 0
+            img_tokens = vid_tokens = 0
+            if isinstance(inputs.get("pixel_values"), torch.Tensor):
+                grid = inputs["image_grid_thw"]
+                it = MultimodalDataItem(
+                    modality=Modality.IMAGE,
+                    feature=inputs["pixel_values"],
+                )
+                it.image_grid_thw = grid.to(dtype=torch.long)
+                images.append(it)
+                n_img = int(grid.shape[0])
+                img_tokens = int(
+                    (grid.to(dtype=torch.long).prod(-1) // self._merge).sum().item()
+                )
+            if isinstance(inputs.get("pixel_values_videos"), torch.Tensor):
+                grid = inputs["video_grid_thw"]
+                v = MultimodalDataItem(
+                    modality=Modality.VIDEO,
+                    feature=inputs["pixel_values_videos"],
+                )
+                v.video_grid_thw = grid.to(dtype=torch.long)
+                videos.append(v)
+                n_vid = int(grid.shape[0])
+                vid_tokens = int(
+                    (grid.to(dtype=torch.long).prod(-1) // self._merge).sum().item()
+                )
+            spans.append(
+                RequestSpan(
+                    request_id=msg.request_id,
+                    image_rows=n_img,
+                    video_rows=n_vid,
+                    image_token_count=img_tokens,
+                    video_token_count=vid_tokens,
+                )
+            )
+        return BatchPlan(self, images, videos, [], spans)
+
+    def run_feature(
+        self,
+        model: Any,
+        plan: BatchPlan,
+    ) -> dict[str, torch.Tensor | None]:
+        if plan.is_empty:
+            return {"image": None, "video": None, "audio": None}
+        thinker = getattr(model, "thinker", model)
+        # get_video_feature() upstream needs the same MultimodalDataItem
+        # contract that get_image_feature does: items[i].image_grid_thw
+        # is read by the parent helper. Upstream Qwen3-VL uses the same
+        # method name for video-grid tensors but it dispatches by
+        # modality internally — we set image_grid_thw on video items too
+        # so the wrapped concat works (qwen3_vl.py:1212).
+        for vid in plan.video_items:
+            if not hasattr(vid, "image_grid_thw") and hasattr(vid, "video_grid_thw"):
+                vid.image_grid_thw = vid.video_grid_thw
+        image_embed = (
+            thinker.get_image_feature(plan.image_items)
+            if plan.image_items
+            else None
+        )
+        video_embed = (
+            thinker.get_video_feature(plan.video_items)
+            if plan.video_items
+            else None
+        )
+        return {"image": image_embed, "video": video_embed, "audio": None}
+
+    def slice_results(
+        self,
+        raw: dict[str, torch.Tensor | None],
+        plan: BatchPlan,
+        messages: list[IncomingMessage],
+    ) -> list[StagePayload]:
+        out: list[StagePayload] = []
+        img_row = img_tok = vid_row = vid_tok = 0
+        image_feat = raw.get("image")
+        video_feat = raw.get("video")
+
+        for span, msg in zip(plan.spans, messages):
+            payload = msg.data
+            state = PipelineState.from_dict(payload.data)
+
+            if span.skip_result is not None:
+                apply_encoder_result(
+                    state, stage_name=IMAGE_STAGE, result=span.skip_result
+                )
+                out.append(_payload_with_state(payload, state))
+                continue
+
+            result: dict[str, Any] = {}
+            if span.image_rows > 0 and image_feat is not None:
+                tok_end = img_tok + span.image_token_count
+                base, deepstack = _split_with_deepstack(
+                    image_feat, img_tok, tok_end, self._base_hidden
+                )
+                result["image_embeds"] = base
+                result["deepstack_visual_embeds_image"] = deepstack
+                # image_grid_thw / token counts come from the original inputs
+                request = build_encoder_request(state, stage_name=IMAGE_STAGE)
+                grid = request.model_inputs.get("image_grid_thw")
+                if isinstance(grid, torch.Tensor):
+                    result["image_grid_thw"] = grid.to(dtype=torch.long)
+                    result["image_token_counts"] = (
+                        grid.to(dtype=torch.long).prod(-1) // self._merge
+                    )
+                img_row += span.image_rows
+                img_tok = tok_end
+
+            if span.video_rows > 0 and video_feat is not None:
+                tok_end = vid_tok + span.video_token_count
+                base, deepstack = _split_with_deepstack(
+                    video_feat, vid_tok, tok_end, self._base_hidden
+                )
+                result["video_embeds"] = base
+                result["deepstack_visual_embeds_video"] = deepstack
+                request = build_encoder_request(state, stage_name=IMAGE_STAGE)
+                grid = request.model_inputs.get("video_grid_thw")
+                if isinstance(grid, torch.Tensor):
+                    result["video_grid_thw"] = grid.to(dtype=torch.long)
+                    result["video_token_counts"] = (
+                        grid.to(dtype=torch.long).prod(-1) // self._merge
+                    )
+                vid_row += span.video_rows
+                vid_tok = tok_end
+
+            apply_encoder_result(state, stage_name=IMAGE_STAGE, result=result)
+            out.append(_payload_with_state(payload, state))
+        return out
+
+
+def _split_with_deepstack(
+    feature: torch.Tensor,
+    start: int,
+    end: int,
+    base_hidden: int,
+) -> tuple[torch.Tensor, list[torch.Tensor] | None]:
+    """Split the upstream visual return tensor into base + deepstack parts.
+
+    Upstream visual return tensor has last-dim
+    ``vision_config.out_hidden_size * (1 + len(deepstack_visual_indexes))``
+    (confirmed via ``disaggregation/encode_server.py:_infer_embedding_dims``).
+    """
+    sliced = feature[start:end]
+    parts = list(torch.split(sliced, base_hidden, dim=-1))
+    base = parts[0]
+    deepstack = parts[1:] if len(parts) > 1 else None
+    return base, deepstack
+
+
+# ---------------------------------------------------------------------------
+# Audio adapter
+# ---------------------------------------------------------------------------
+
+
+class Qwen3OmniAudioEncoderAdapter:
+    """Adapter for the audio stage."""
+
+    stage_name = AUDIO_STAGE
+
+    def __init__(self, *, hf_config: Any, dtype: torch.dtype) -> None:
+        del hf_config, dtype  # not currently consumed
+
+    def request_cost_fn(self, payload: StagePayload) -> int:
+        # Phase 0: no audio cost model in v1 yet. Returning 0 keeps the
+        # admission shape the same as the local audio path today (no cap).
+        del payload
+        return 0
+
+    def build_batch(self, messages: list[IncomingMessage]) -> BatchPlan:
+        spans: list[RequestSpan] = []
+        normalized: list[dict[str, torch.Tensor]] = []
+
+        for msg in messages:
+            payload = msg.data
+            state = PipelineState.from_dict(payload.data)
+            request = build_encoder_request(state, stage_name=AUDIO_STAGE)
+
+            if request.skip_result is not None:
+                spans.append(
+                    RequestSpan(
+                        request_id=msg.request_id,
+                        skip_result=request.skip_result,
+                    )
+                )
+                continue
+
+            features, mask, lengths = _normalize_audio_request_tensors(request)
+            out_lens = _get_feat_extract_output_lengths(lengths)
+            spans.append(
+                RequestSpan(
+                    request_id=msg.request_id,
+                    audio_rows=int(lengths.shape[0]),
+                    audio_feature_lengths=lengths,
+                    audio_output_lengths=out_lens,
+                )
+            )
+            normalized.append(
+                {"features": features, "mask": mask, "lengths": lengths}
+            )
+
+        if not normalized:
+            return BatchPlan(self, [], [], [], spans)
+
+        max_time = max(int(item["features"].shape[-1]) for item in normalized)
+        audios: list[MultimodalDataItem] = []
+        for item in normalized:
+            feat = _pad_audio_features(item["features"], max_time)
+            m = _pad_audio_mask(item["mask"], max_time)
+            mm = MultimodalDataItem(
+                modality=Modality.AUDIO,
+                feature=feat,
+            )
+            mm.feature_attention_mask = m
+            audios.append(mm)
+        return BatchPlan(self, [], [], audios, spans)
+
+    def run_feature(
+        self,
+        model: Any,
+        plan: BatchPlan,
+    ) -> dict[str, torch.Tensor | None]:
+        if plan.is_empty:
+            return {"image": None, "video": None, "audio": None}
+        thinker = getattr(model, "thinker", model)
+        embed = thinker.get_audio_feature(plan.audio_items)
+        return {"image": None, "video": None, "audio": embed}
+
+    def slice_results(
+        self,
+        raw: dict[str, torch.Tensor | None],
+        plan: BatchPlan,
+        messages: list[IncomingMessage],
+    ) -> list[StagePayload]:
+        out: list[StagePayload] = []
+        tok = 0
+        audio_feat = raw.get("audio")
+
+        for span, msg in zip(plan.spans, messages):
+            payload = msg.data
+            state = PipelineState.from_dict(payload.data)
+
+            if span.skip_result is not None:
+                apply_encoder_result(
+                    state, stage_name=AUDIO_STAGE, result=span.skip_result
+                )
+                out.append(_payload_with_state(payload, state))
+                continue
+
+            assert audio_feat is not None
+            assert span.audio_output_lengths is not None
+            assert span.audio_feature_lengths is not None
+            tok_end = tok + int(span.audio_output_lengths.sum().item())
+            result = {
+                "audio_embeds": audio_feat[tok:tok_end],
+                # Unpadded lengths preserved at build_batch time.
+                "audio_feature_lengths": span.audio_feature_lengths,
+                "audio_output_lengths": span.audio_output_lengths,
+            }
+            apply_encoder_result(state, stage_name=AUDIO_STAGE, result=result)
+            out.append(_payload_with_state(payload, state))
+            tok = tok_end
+        return out

--- a/sglang_omni_v1/models/qwen3_omni/encoder_adapters.py
+++ b/sglang_omni_v1/models/qwen3_omni/encoder_adapters.py
@@ -12,7 +12,7 @@ For each encoder stage there is one adapter implementing
 - ``run_feature`` calls the loaded upstream encoder submodule directly
   — ``Qwen3OmniMoeVisionEncoder`` for image/video, ``Qwen3OmniMoeAudioEncoder``
   for audio — instead of the full ``thinker.get_*_feature`` entry
-  points. The encoder worker partial-loads ONLY these submodules (see
+  points. The encoder runner partial-loads ONLY these submodules (see
   ``EncoderModuleSpec``), so ``model.thinker`` is never instantiated and
   the full Qwen3-Omni LLM weights never reach the encoder GPU.
   Empty plans short-circuit and never call any submodule.
@@ -67,7 +67,7 @@ QWEN3_IMAGE_ENCODER_ACTIVATION_MULTIPLIER = 5
 # ---------------------------------------------------------------------------
 # EncoderModuleSpec — declares which upstream encoder submodules a stage
 # loads and which checkpoint prefixes feed them. The shared SGLang encoder
-# worker uses these specs to partial-load only the relevant submodule
+# runner uses these specs to partial-load only the relevant submodule
 # weights, avoiding the ~57 GB of LLM/talker weights that
 # ``Qwen3OmniMoeForConditionalGeneration`` would otherwise pull in.
 # See ``docs/developer_reference/encoder_tp_path_b_design.md`` →
@@ -77,7 +77,7 @@ QWEN3_IMAGE_ENCODER_ACTIVATION_MULTIPLIER = 5
 
 @dataclasses.dataclass(frozen=True)
 class EncoderModuleSpec:
-    """Declaration of an upstream encoder submodule the worker should load.
+    """Declaration of an upstream encoder submodule the runner should load.
 
     Args:
         name: Local attribute name the submodule will be exposed as on
@@ -354,9 +354,9 @@ class Qwen3OmniImageEncoderAdapter:
     """Adapter for the visual stage (images and videos)."""
 
     stage_name = IMAGE_STAGE
-    # Declares the upstream submodules the encoder worker must
+    # Declares the upstream submodules the encoder runner must
     # partial-load. The factory passes this through to
-    # ``SGLangEncoderWorker`` so only ``Qwen3OmniMoeVisionEncoder``
+    # ``SGLangEncoderRunner`` so only ``Qwen3OmniMoeVisionEncoder``
     # weights end up on the encoder GPU — the LLM, talker, and audio
     # tower are never instantiated.
     encoder_specs: tuple[EncoderModuleSpec, ...] = (QWEN3_OMNI_VISUAL_SPEC,)
@@ -473,7 +473,7 @@ class Qwen3OmniImageEncoderAdapter:
     ) -> dict[str, torch.Tensor | None]:
         if plan.is_empty:
             return {"image": None, "video": None, "audio": None}
-        # ``model`` is the EncoderModuleContainer the worker built from
+        # ``model`` is the EncoderModuleContainer the runner built from
         # ``self.encoder_specs``; it exposes the visual submodule under the
         # name declared in QWEN3_OMNI_VISUAL_SPEC (``visual``). We mirror
         # the simple no-chunking path of upstream

--- a/sglang_omni_v1/models/qwen3_omni/stages.py
+++ b/sglang_omni_v1/models/qwen3_omni/stages.py
@@ -833,8 +833,8 @@ def _build_sglang_encoder_scheduler(
     dtype: str | None,
     load_format: str | None,
 ):
-    """Build the SGLang encoder worker + EncoderScheduler for a stage."""
-    from sglang_omni_v1.model_runner.sglang_encoder_worker import SGLangEncoderWorker
+    """Build the SGLang encoder runner + EncoderScheduler for a stage."""
+    from sglang_omni_v1.model_runner.sglang_encoder_runner import SGLangEncoderRunner
     from sglang_omni_v1.models.qwen3_omni.components.common import (
         load_thinker_config,
     )
@@ -845,7 +845,7 @@ def _build_sglang_encoder_scheduler(
     from sglang_omni_v1.scheduling.encoder_scheduler import EncoderScheduler
 
     # Build the adapter FIRST so we can read its declared
-    # ``encoder_specs`` and pass them to the worker. The worker no
+    # ``encoder_specs`` and pass them to the runner. The runner no
     # longer falls back to ``get_model()`` on the full upstream
     # ForConditionalGeneration class — it requires the adapter's
     # spec list to know which submodules to load.
@@ -861,7 +861,7 @@ def _build_sglang_encoder_scheduler(
             hf_config=hf_thinker_config, dtype=torch_dtype
         )
 
-    worker = SGLangEncoderWorker(
+    runner = SGLangEncoderRunner(
         model_path=model_path,
         gpu_id=gpu_id,
         tp_rank=tp_rank,
@@ -874,7 +874,7 @@ def _build_sglang_encoder_scheduler(
     )
 
     return EncoderScheduler(
-        worker=worker,
+        runner=runner,
         adapter=adapter,
         max_batch_size=max_batch_size,
         max_batch_wait_ms=max_batch_wait_ms,
@@ -883,7 +883,7 @@ def _build_sglang_encoder_scheduler(
     )
 
 
-def create_image_encoder_executor(
+def create_image_encoder_runner(
     model_path: str,
     *,
     backend: Literal["local", "sglang", "auto"] = "local",
@@ -935,7 +935,7 @@ def create_image_encoder_executor(
     return _build_local_image_encoder(model_path, device=device, dtype=dtype)
 
 
-def create_audio_encoder_executor(
+def create_audio_encoder_runner(
     model_path: str,
     *,
     backend: Literal["local", "sglang", "auto"] = "local",
@@ -951,7 +951,7 @@ def create_audio_encoder_executor(
     activation_budget_bytes: int | None = None,
     server_args_overrides: dict[str, Any] | None = None,
 ):
-    """Build the audio-encoder stage scheduler. See ``create_image_encoder_executor``."""
+    """Build the audio-encoder stage scheduler. See ``create_image_encoder_runner``."""
     chosen = _resolve_backend(backend, model_path, stage="audio_encoder")
     if chosen == "sglang":
         return _build_sglang_encoder_scheduler(

--- a/sglang_omni_v1/models/qwen3_omni/stages.py
+++ b/sglang_omni_v1/models/qwen3_omni/stages.py
@@ -832,6 +832,7 @@ def _build_sglang_encoder_scheduler(
     server_args_overrides: dict[str, Any] | None,
     dtype: str | None,
     load_format: str | None,
+    tp_parity_mode: str | None,
 ):
     """Build the SGLang encoder runner + EncoderScheduler for a stage."""
     from sglang_omni_v1.model_runner.sglang_encoder_runner import SGLangEncoderRunner
@@ -871,6 +872,7 @@ def _build_sglang_encoder_scheduler(
         dtype=dtype,
         load_format=load_format,
         server_args_overrides=server_args_overrides,
+        tp_parity_mode=tp_parity_mode,
     )
 
     return EncoderScheduler(
@@ -898,6 +900,7 @@ def create_image_encoder_runner(
     max_batch_wait_ms: int = 50,
     activation_budget_bytes: int | None = QWEN3_IMAGE_ENCODER_BATCH_BUDGET_BYTES,
     server_args_overrides: dict[str, Any] | None = None,
+    tp_parity_mode: str | None = None,
 ):
     """Build the image-encoder stage scheduler.
 
@@ -924,6 +927,7 @@ def create_image_encoder_runner(
             server_args_overrides=server_args_overrides,
             dtype=dtype,
             load_format=load_format,
+            tp_parity_mode=tp_parity_mode,
         )
     # Local fallback
     if tp_size > 1:
@@ -950,6 +954,7 @@ def create_audio_encoder_runner(
     max_batch_wait_ms: int = 50,
     activation_budget_bytes: int | None = None,
     server_args_overrides: dict[str, Any] | None = None,
+    tp_parity_mode: str | None = None,
 ):
     """Build the audio-encoder stage scheduler. See ``create_image_encoder_runner``."""
     chosen = _resolve_backend(backend, model_path, stage="audio_encoder")
@@ -967,6 +972,7 @@ def create_audio_encoder_runner(
             server_args_overrides=server_args_overrides,
             dtype=dtype,
             load_format=load_format,
+            tp_parity_mode=tp_parity_mode,
         )
     if tp_size > 1:
         raise ValueError(

--- a/sglang_omni_v1/models/qwen3_omni/stages.py
+++ b/sglang_omni_v1/models/qwen3_omni/stages.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any
+from typing import Any, Literal
 
 import torch
 import torch.nn.functional as F
@@ -701,11 +701,38 @@ def create_aggregate_executor():
     return SimpleScheduler(_identity)
 
 
-def create_image_encoder_executor(
+_BACKEND_CHOICES = ("local", "sglang", "auto")
+
+
+def _resolve_backend(
+    backend: str,
     model_path: str,
     *,
-    device: str = "cuda",
-    dtype: str | None = None,
+    stage: str,
+) -> Literal["local", "sglang"]:
+    """Resolve ``backend="auto"`` to a concrete backend.
+
+    Phase 0 keeps "auto" pinned to "local" until parity is locked. Phase
+    2 will flip "auto" -> "sglang" for upstream-supported encoder
+    stages (see RFC Phase 2). Any explicit value of ``backend`` is
+    accepted as-is.
+    """
+    del model_path  # not consumed in Phase 0
+    if backend not in _BACKEND_CHOICES:
+        raise ValueError(
+            f"Stage {stage!r}: backend must be one of {_BACKEND_CHOICES}, "
+            f"got {backend!r}"
+        )
+    if backend == "auto":
+        return "local"
+    return backend  # type: ignore[return-value]
+
+
+def _build_local_image_encoder(
+    model_path: str,
+    *,
+    device: str,
+    dtype: str | None,
 ):
     from sglang_omni_v1.scheduling.simple_scheduler import SimpleScheduler
 
@@ -731,10 +758,6 @@ def create_image_encoder_executor(
             cache_manager=cache_manager,
         )
 
-    # Note (Chenyang): match v0's image-encoder batching shape (max=32) and
-    # add a small batch_wait so video benchmarks at concurrency=16 batch
-    # together. Without the wait, requests arriving microseconds apart end
-    # up in batches of 1; with the wait, all 16 land in one forward pass.
     return SimpleScheduler(
         _encode,
         batch_compute_fn=_encode_batch,
@@ -745,11 +768,11 @@ def create_image_encoder_executor(
     )
 
 
-def create_audio_encoder_executor(
+def _build_local_audio_encoder(
     model_path: str,
     *,
-    device: str = "cuda",
-    dtype: str | None = None,
+    device: str,
+    dtype: str | None,
 ):
     from sglang_omni_v1.scheduling.simple_scheduler import SimpleScheduler
 
@@ -781,6 +804,171 @@ def create_audio_encoder_executor(
         max_batch_size=32,
         max_batch_wait_ms=50,
     )
+
+
+def _resolve_dtype(dtype: str | None) -> torch.dtype:
+    if dtype is None:
+        return torch.float16
+    if dtype in ("float16", "fp16", "half"):
+        return torch.float16
+    if dtype in ("bfloat16", "bf16"):
+        return torch.bfloat16
+    if dtype in ("float32", "fp32"):
+        return torch.float32
+    raise ValueError(f"Unsupported dtype: {dtype!r}")
+
+
+def _build_sglang_encoder_scheduler(
+    *,
+    model_path: str,
+    stage: Literal["image_encoder", "audio_encoder"],
+    gpu_id: int,
+    tp_rank: int,
+    tp_size: int,
+    nccl_port: int | None,
+    max_batch_size: int,
+    max_batch_wait_ms: int,
+    activation_budget_bytes: int | None,
+    server_args_overrides: dict[str, Any] | None,
+    dtype: str | None,
+    load_format: str | None,
+):
+    """Build the SGLang encoder worker + EncoderScheduler for a stage."""
+    from sglang_omni_v1.model_runner.sglang_encoder_worker import SGLangEncoderWorker
+    from sglang_omni_v1.models.qwen3_omni.components.common import (
+        load_thinker_config,
+    )
+    from sglang_omni_v1.models.qwen3_omni.encoder_adapters import (
+        Qwen3OmniAudioEncoderAdapter,
+        Qwen3OmniImageEncoderAdapter,
+    )
+    from sglang_omni_v1.scheduling.encoder_scheduler import EncoderScheduler
+
+    worker = SGLangEncoderWorker(
+        model_path=model_path,
+        gpu_id=gpu_id,
+        tp_rank=tp_rank,
+        tp_size=tp_size,
+        nccl_port=nccl_port,
+        dtype=dtype,
+        load_format=load_format,
+        server_args_overrides=server_args_overrides,
+    )
+
+    hf_thinker_config = load_thinker_config(model_path)
+    torch_dtype = _resolve_dtype(dtype)
+
+    if stage == IMAGE_STAGE:
+        adapter = Qwen3OmniImageEncoderAdapter(
+            hf_config=hf_thinker_config, dtype=torch_dtype
+        )
+    else:
+        adapter = Qwen3OmniAudioEncoderAdapter(
+            hf_config=hf_thinker_config, dtype=torch_dtype
+        )
+
+    return EncoderScheduler(
+        worker=worker,
+        adapter=adapter,
+        max_batch_size=max_batch_size,
+        max_batch_wait_ms=max_batch_wait_ms,
+        request_cost_fn=adapter.request_cost_fn,
+        max_batch_cost=activation_budget_bytes,
+    )
+
+
+def create_image_encoder_executor(
+    model_path: str,
+    *,
+    backend: Literal["local", "sglang", "auto"] = "local",
+    gpu_id: int = 0,
+    tp_rank: int = 0,
+    tp_size: int = 1,
+    nccl_port: int | None = None,
+    device: str = "cuda",
+    dtype: str | None = None,
+    load_format: str | None = None,
+    max_batch_size: int = 32,
+    max_batch_wait_ms: int = 50,
+    activation_budget_bytes: int | None = QWEN3_IMAGE_ENCODER_BATCH_BUDGET_BYTES,
+    server_args_overrides: dict[str, Any] | None = None,
+):
+    """Build the image-encoder stage scheduler.
+
+    The signature default for ``backend`` is and stays ``"local"`` —
+    the launcher reads ``factory_args`` / ``runtime_overrides`` only, so
+    a deployment that wants the SGLang backend must put
+    ``backend="sglang"`` (or ``"auto"``) into the StageConfig
+    explicitly. Bumping this default would silently desync launcher
+    (sees "local") from factory body (sees "auto"). See the
+    [Backend resolution contract] in the RFC.
+    """
+    chosen = _resolve_backend(backend, model_path, stage="image_encoder")
+    if chosen == "sglang":
+        return _build_sglang_encoder_scheduler(
+            model_path=model_path,
+            stage=IMAGE_STAGE,
+            gpu_id=gpu_id,
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+            nccl_port=nccl_port,
+            max_batch_size=max_batch_size,
+            max_batch_wait_ms=max_batch_wait_ms,
+            activation_budget_bytes=activation_budget_bytes,
+            server_args_overrides=server_args_overrides,
+            dtype=dtype,
+            load_format=load_format,
+        )
+    # Local fallback
+    if tp_size > 1:
+        raise ValueError(
+            f"image_encoder backend='local' does not support tp_size>1 "
+            f"(got tp_size={tp_size}). Use backend='sglang' for tensor "
+            f"parallelism."
+        )
+    return _build_local_image_encoder(model_path, device=device, dtype=dtype)
+
+
+def create_audio_encoder_executor(
+    model_path: str,
+    *,
+    backend: Literal["local", "sglang", "auto"] = "local",
+    gpu_id: int = 0,
+    tp_rank: int = 0,
+    tp_size: int = 1,
+    nccl_port: int | None = None,
+    device: str = "cuda",
+    dtype: str | None = None,
+    load_format: str | None = None,
+    max_batch_size: int = 32,
+    max_batch_wait_ms: int = 50,
+    activation_budget_bytes: int | None = None,
+    server_args_overrides: dict[str, Any] | None = None,
+):
+    """Build the audio-encoder stage scheduler. See ``create_image_encoder_executor``."""
+    chosen = _resolve_backend(backend, model_path, stage="audio_encoder")
+    if chosen == "sglang":
+        return _build_sglang_encoder_scheduler(
+            model_path=model_path,
+            stage=AUDIO_STAGE,
+            gpu_id=gpu_id,
+            tp_rank=tp_rank,
+            tp_size=tp_size,
+            nccl_port=nccl_port,
+            max_batch_size=max_batch_size,
+            max_batch_wait_ms=max_batch_wait_ms,
+            activation_budget_bytes=activation_budget_bytes,
+            server_args_overrides=server_args_overrides,
+            dtype=dtype,
+            load_format=load_format,
+        )
+    if tp_size > 1:
+        raise ValueError(
+            f"audio_encoder backend='local' does not support tp_size>1 "
+            f"(got tp_size={tp_size}). Use backend='sglang' for tensor "
+            f"parallelism."
+        )
+    return _build_local_audio_encoder(model_path, device=device, dtype=dtype)
 
 
 def create_decode_executor(model_path: str):

--- a/sglang_omni_v1/models/qwen3_omni/stages.py
+++ b/sglang_omni_v1/models/qwen3_omni/stages.py
@@ -844,17 +844,11 @@ def _build_sglang_encoder_scheduler(
     )
     from sglang_omni_v1.scheduling.encoder_scheduler import EncoderScheduler
 
-    worker = SGLangEncoderWorker(
-        model_path=model_path,
-        gpu_id=gpu_id,
-        tp_rank=tp_rank,
-        tp_size=tp_size,
-        nccl_port=nccl_port,
-        dtype=dtype,
-        load_format=load_format,
-        server_args_overrides=server_args_overrides,
-    )
-
+    # Build the adapter FIRST so we can read its declared
+    # ``encoder_specs`` and pass them to the worker. The worker no
+    # longer falls back to ``get_model()`` on the full upstream
+    # ForConditionalGeneration class — it requires the adapter's
+    # spec list to know which submodules to load.
     hf_thinker_config = load_thinker_config(model_path)
     torch_dtype = _resolve_dtype(dtype)
 
@@ -866,6 +860,18 @@ def _build_sglang_encoder_scheduler(
         adapter = Qwen3OmniAudioEncoderAdapter(
             hf_config=hf_thinker_config, dtype=torch_dtype
         )
+
+    worker = SGLangEncoderWorker(
+        model_path=model_path,
+        gpu_id=gpu_id,
+        tp_rank=tp_rank,
+        tp_size=tp_size,
+        nccl_port=nccl_port,
+        encoder_specs=adapter.encoder_specs,
+        dtype=dtype,
+        load_format=load_format,
+        server_args_overrides=server_args_overrides,
+    )
 
     return EncoderScheduler(
         worker=worker,

--- a/sglang_omni_v1/pipeline/coordinator.py
+++ b/sglang_omni_v1/pipeline/coordinator.py
@@ -104,6 +104,67 @@ class Coordinator:
             except Exception as e:
                 logger.warning("Failed to send shutdown to stage %s: %s", name, e)
 
+    def fail_all_active(self, error: str) -> None:
+        """Resolve every active completion future / stream queue with a fatal error.
+
+        Required by the encoder TP fatal-forward path: when any TP rank
+        exits non-zero (e.g. ``encode_batch`` raised inside SGLang TP
+        collectives), :class:`MultiProcessPipelineRunner` calls this
+        before tearing down the remaining processes. Without it, the
+        outstanding HTTP requests sit forever waiting on completions
+        that will never arrive.
+
+        Safe to call multiple times: each future / queue is only
+        resolved once. ``error`` should be a non-empty human-readable
+        string — empty error bodies cause downstream consumers (Client,
+        OpenAI shim) to mis-classify the failure as success.
+        """
+        if not error:
+            error = "stage process died with non-zero exit"
+
+        for request_id, future in list(self._completion_futures.items()):
+            if not future.done():
+                try:
+                    future.set_exception(RuntimeError(error))
+                except asyncio.InvalidStateError:
+                    pass
+            self._completion_futures.pop(request_id, None)
+
+        for request_id, queue in list(self._stream_queues.items()):
+            try:
+                queue.put_nowait(
+                    CompleteMessage(
+                        request_id=request_id,
+                        from_stage="coordinator",
+                        success=False,
+                        error=error,
+                    )
+                )
+            except asyncio.QueueFull:
+                # Stream consumers are async; if the queue is somehow
+                # full, drop the older items rather than block here.
+                logger.warning(
+                    "Stream queue full while failing req=%s; dropping head",
+                    request_id,
+                )
+
+        # Mark requests as failed for visibility on the health endpoint.
+        for info in self._requests.values():
+            if info.state in (
+                RequestState.COMPLETED,
+                RequestState.FAILED,
+                RequestState.ABORTED,
+            ):
+                continue
+            info.state = RequestState.FAILED
+
+        logger.error(
+            "Coordinator failed %d active future(s) and %d stream(s): %s",
+            len(self._requests),
+            len(self._stream_queues),
+            error,
+        )
+
     async def submit(self, request_id: str, request: OmniRequest | Any) -> Any:
         """Submit a request to the pipeline and wait for completion."""
         await self._submit_request(request_id, request)

--- a/sglang_omni_v1/pipeline/mp_runner.py
+++ b/sglang_omni_v1/pipeline/mp_runner.py
@@ -420,10 +420,27 @@ class MultiProcessPipelineRunner:
         while self._started:
             for group in self._groups:
                 if group.any_dead():
+                    summary = group.dead_summary()
                     logger.error(
-                        "Dead stage process(es) detected: %s",
-                        group.dead_summary(),
+                        "Dead stage process(es) detected: %s", summary
                     )
+                    # Fail every outstanding Coordinator future / stream
+                    # before tearing down the rest. Required by the
+                    # encoder TP fatal-forward path: when a TP rank
+                    # exits non-zero (e.g. encode_batch raised inside
+                    # SGLang TP collectives), peer ranks may still be in
+                    # NCCL — the runner cannot recover, but it must not
+                    # leave HTTP requests hanging on completions that
+                    # will never arrive.
+                    if self._coordinator is not None:
+                        try:
+                            self._coordinator.fail_all_active(
+                                f"stage group {group.stage_name!r} died: {summary}"
+                            )
+                        except Exception:  # noqa: BLE001
+                            logger.exception(
+                                "fail_all_active raised during monitor shutdown"
+                            )
                     await self.stop()
                     return
             await asyncio.sleep(5.0)

--- a/sglang_omni_v1/pipeline/mp_runner.py
+++ b/sglang_omni_v1/pipeline/mp_runner.py
@@ -10,6 +10,7 @@ Architecture
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import multiprocessing
 import socket
@@ -25,8 +26,77 @@ from sglang_omni_v1.config.schema import PipelineConfig, StageConfig
 from sglang_omni_v1.pipeline import Coordinator
 from sglang_omni_v1.pipeline.stage_group import StageGroup
 from sglang_omni_v1.pipeline.stage_process import StageProcessSpec
+from sglang_omni_v1.utils import import_string
 
 logger = logging.getLogger(__name__)
+
+# Backends that require per-process CUDA isolation and a real distributed init.
+_SGLANG_BACKENDS = frozenset({"sglang", "auto"})
+
+# TP launch kwargs the runner injects into stage factories.
+_TP_LAUNCH_PARAMS = frozenset({"tp_rank", "tp_size", "nccl_port"})
+
+
+def _resolved_backend(stage_cfg: StageConfig, config: PipelineConfig) -> str:
+    """Resolve a stage's backend through factory_args + runtime_overrides only.
+
+    Mirrors the [Backend resolution contract] from the RFC: launcher
+    decisions never read factory signature defaults, so a StageConfig
+    that wants the SGLang backend must place ``backend`` into
+    ``factory_args`` (or ``runtime_overrides``) explicitly.
+    """
+    return _resolve_factory_args(stage_cfg, config).get("backend", "local")
+
+
+def _is_sglang_backend(backend: str) -> bool:
+    return backend in _SGLANG_BACKENDS
+
+
+def any_sglang_backend_stage(config: PipelineConfig) -> bool:
+    """Return True iff any stage resolves to backend in {sglang, auto}."""
+    return any(
+        _is_sglang_backend(_resolved_backend(s, config)) for s in config.stages
+    )
+
+
+def _run_tp_preflight(stages_cfg: list[StageConfig], config: PipelineConfig) -> None:
+    """Reject TP misconfigurations before any subprocess is spawned.
+
+    Layer 1: any TP stage's factory must accept the TP launch kwargs the
+    runner is about to inject (tp_rank/tp_size/nccl_port). Without this,
+    the runner spawns N children and each fails at factory binding time.
+
+    Layer 2: encoder factories that expose a ``backend`` parameter only
+    implement TP under ``backend="sglang"``. ``backend="local"``/``"auto"``
+    silently spawns N processes that each run a redundant local forward,
+    so reject early.
+    """
+    for stage_cfg in stages_cfg:
+        if stage_cfg.tp_size <= 1:
+            continue
+        factory = import_string(stage_cfg.factory)
+        params = inspect.signature(factory).parameters
+
+        missing = sorted(_TP_LAUNCH_PARAMS - params.keys())
+        if missing:
+            raise ValueError(
+                f"Stage {stage_cfg.name!r}: tp_size={stage_cfg.tp_size} > 1 "
+                f"but factory {stage_cfg.factory!r} does not accept TP "
+                f"launch parameters {missing}. This factory is not "
+                f"TP-capable; reduce tp_size to 1 or use a factory that "
+                f"accepts tp_rank/tp_size/nccl_port."
+            )
+
+        if "backend" in params:
+            backend = _resolved_backend(stage_cfg, config)
+            if backend != "sglang":
+                raise ValueError(
+                    f"Stage {stage_cfg.name!r}: tp_size={stage_cfg.tp_size} "
+                    f"requires backend='sglang' (got {backend!r}). The "
+                    f"local encoder path does not implement TP and would "
+                    f"silently spawn TP-rank processes that each run a "
+                    f"redundant local forward."
+                )
 
 
 def _build_stage_groups(
@@ -42,6 +112,7 @@ def _build_stage_groups(
         ctx = multiprocessing.get_context("spawn")
 
     stages_cfg, name_map, _ = config.apply_fusion()
+    _run_tp_preflight(stages_cfg, config)
     endpoints = _allocate_endpoints(config, stages=stages_cfg)
     stage_endpoints = {s.name: endpoints[f"stage_{s.name}"] for s in stages_cfg}
     cfg_map = {s.name: s for s in stages_cfg}
@@ -72,6 +143,15 @@ def _build_stage_groups(
         # Pre-resolve factory args (inject model_path, gpu_id)
         base_factory_args = _resolve_factory_args(stage_cfg, config)
 
+        # Resolve backend through merged factory_args + runtime_overrides,
+        # never the factory signature default. This drives the
+        # single-visible-device launch contract for the SGLang encoder
+        # worker. See encoder_tp_path_b_design.md "Backend resolution
+        # contract".
+        single_visible_device = _is_sglang_backend(
+            base_factory_args.get("backend", "local")
+        )
+
         stage_kwargs = dict(
             stage_name=stage_cfg.name,
             factory=stage_cfg.factory,
@@ -100,6 +180,7 @@ def _build_stage_groups(
                     recv_endpoint=stage_endpoints[stage_cfg.name],
                     base_factory_args=base_factory_args,
                     stage_kwargs=stage_kwargs,
+                    single_visible_device=single_visible_device,
                 )
             ]
         else:
@@ -112,6 +193,7 @@ def _build_stage_groups(
                 recv_endpoint=stage_endpoints[stage_cfg.name],
                 base_factory_args=base_factory_args,
                 stage_kwargs=stage_kwargs,
+                single_visible_device=single_visible_device,
             )
 
         groups.append(StageGroup(stage_cfg.name, specs))
@@ -143,6 +225,7 @@ def _build_single_stage_spec(
     recv_endpoint: str,
     base_factory_args: dict[str, Any],
     stage_kwargs: dict[str, Any],
+    single_visible_device: bool = False,
 ) -> StageProcessSpec:
     factory_args = dict(base_factory_args)
     if "gpu_id" in base_factory_args:
@@ -157,6 +240,7 @@ def _build_single_stage_spec(
         factory_args=factory_args,
         relay_config=relay_config,
         recv_endpoint=recv_endpoint,
+        single_visible_device=single_visible_device,
         **stage_kwargs,
     )
 
@@ -171,6 +255,7 @@ def _build_tp_stage_specs(
     recv_endpoint: str,
     base_factory_args: dict[str, Any],
     stage_kwargs: dict[str, Any],
+    single_visible_device: bool = False,
 ) -> list[StageProcessSpec]:
     follower_work_queues = [ctx.Queue() for _ in range(stage_cfg.tp_size - 1)]
     follower_abort_queues = [ctx.Queue() for _ in range(stage_cfg.tp_size - 1)]
@@ -200,6 +285,7 @@ def _build_tp_stage_specs(
                     recv_endpoint=recv_endpoint,
                     follower_work_queues=follower_work_queues,
                     follower_abort_queues=follower_abort_queues,
+                    single_visible_device=single_visible_device,
                     **stage_kwargs,
                 )
             )
@@ -218,6 +304,7 @@ def _build_tp_stage_specs(
                 recv_endpoint="",
                 internal_work_queue=follower_work_queues[idx],
                 internal_abort_queue=follower_abort_queues[idx],
+                single_visible_device=single_visible_device,
                 **stage_kwargs,
             )
         )

--- a/sglang_omni_v1/pipeline/mp_runner.py
+++ b/sglang_omni_v1/pipeline/mp_runner.py
@@ -17,6 +17,7 @@ import socket
 from typing import Any
 
 from sglang_omni_v1.config.compiler import (
+    _TP_LAUNCH_PARAMS,
     _allocate_endpoints,
     _build_relay_config,
     _detect_same_gpu_targets,
@@ -32,9 +33,6 @@ logger = logging.getLogger(__name__)
 
 # Backends that require per-process CUDA isolation and a real distributed init.
 _SGLANG_BACKENDS = frozenset({"sglang", "auto"})
-
-# TP launch kwargs the runner injects into stage factories.
-_TP_LAUNCH_PARAMS = frozenset({"tp_rank", "tp_size", "nccl_port"})
 
 
 def _resolved_backend(stage_cfg: StageConfig, config: PipelineConfig) -> str:

--- a/sglang_omni_v1/pipeline/stage_process.py
+++ b/sglang_omni_v1/pipeline/stage_process.py
@@ -72,6 +72,13 @@ class StageProcessSpec:
     internal_work_queue: Any | None = None
     internal_abort_queue: Any | None = None
 
+    # Force one-visible-device CUDA env even at tp_size==1.
+    # Set by the launcher when the resolved factory backend is "sglang"
+    # (or "auto") so the SGLang encoder worker always sees its physical
+    # GPU as cuda:0. See encoder_tp_path_b_design.md "GPU placement
+    # across tp_size=1 and tp_size>1 lanes".
+    single_visible_device: bool = False
+
     @property
     def owns_external_io(self) -> bool:
         return self.role in {"single", "leader"}
@@ -223,7 +230,7 @@ def get_stage_process_env(
     env: Mapping[str, str] | None = None,
 ) -> dict[str, str]:
     """Return per-process env overrides needed before TP child startup."""
-    if spec.tp_size <= 1:
+    if spec.tp_size <= 1 and not spec.single_visible_device:
         return {}
 
     source_env = env if env is not None else os.environ

--- a/sglang_omni_v1/scheduling/encoder_scheduler.py
+++ b/sglang_omni_v1/scheduling/encoder_scheduler.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import collections
 import dataclasses
 import logging
+import os
 import queue as _queue_mod
 import time
 from typing import TYPE_CHECKING, Any, Callable
@@ -131,61 +132,138 @@ class EncoderScheduler:
     # ------------------------------------------------------------------
 
     def start(self) -> None:
-        """Run the scheduler loop on the current thread."""
+        """Run the scheduler loop on the current thread.
+
+        Three error domains, not one catch-all:
+
+        1. **Recoverable pre-forward** (``_recv_messages``,
+           ``build_batch``): both synchronize through the TP CPU group
+           via :meth:`_gather_pre_forward_error` *before* any model
+           collective starts. On any rank failure, the entry rank emits
+           one ``OutgoingMessage(type="error")`` per drained request and
+           every rank ``continue``s into the next loop iteration.
+
+        2. **Fatal forward** (``encode_batch``): once we've entered
+           upstream SGLang TP collectives (``ColumnParallelLinear``,
+           ``RowParallelLinear``, NCCL), one rank cannot safely recover
+           with a CPU gather — peers may still be blocked in NCCL. The
+           rank that observes the exception calls
+           :meth:`_fatal_tp_forward_error`, which exits the process
+           non-zero so ``StageGroup`` / ``MultiProcessPipelineRunner``
+           tears down the whole TP group and the runner's monitor fails
+           outstanding Coordinator futures.
+
+        3. **Recoverable post-forward** (``slice_results``): runs only
+           on the entry rank after ``encode_batch`` returned on every
+           rank. It can emit per-request errors locally and continue.
+        """
         self._running = True
         while self._running:
             messages, recv_err = self._recv_messages()
-            local_err: BaseException | None = recv_err
-            results: list | None = None
-
-            if recv_err is None and not messages:
-                continue
-
-            if recv_err is None:
-                try:
-                    plan = self.adapter.build_batch(messages)
-                    raw = self.worker.encode_batch(plan)
-                    if self.worker.is_entry_rank:
-                        results = self.adapter.slice_results(raw, plan, messages)
-                except Exception as exc:  # noqa: BLE001
-                    local_err = exc
-                    if self.worker.is_entry_rank:
-                        logger.exception(
-                            "EncoderScheduler forward/build/slice failed",
-                        )
-
-            if self.worker.tp_size > 1:
-                err_flags: list[bool] = [False] * self.worker.tp_size
-                dist.all_gather_object(
-                    err_flags,
-                    local_err is not None,
-                    group=self.worker.tp_group.cpu_group,
-                )
-                any_err = any(err_flags)
-            else:
-                any_err = local_err is not None
-
-            if any_err:
+            if self._gather_pre_forward_error(recv_err):
                 if self.worker.is_entry_rank:
                     self._emit_error(
                         messages,
-                        local_err
-                        if local_err is not None
-                        else RuntimeError("peer-rank encoder forward failed"),
+                        recv_err
+                        if recv_err is not None
+                        else RuntimeError("peer-rank encoder recv failed"),
+                    )
+                continue
+            if not messages:
+                continue
+
+            plan = None
+            build_err: BaseException | None = None
+            try:
+                plan = self.adapter.build_batch(messages)
+            except Exception as exc:  # noqa: BLE001
+                build_err = exc
+
+            if self._gather_pre_forward_error(build_err):
+                if self.worker.is_entry_rank:
+                    self._emit_error(
+                        messages,
+                        build_err
+                        if build_err is not None
+                        else RuntimeError("peer-rank encoder build_batch failed"),
                     )
                 continue
 
-            if self.worker.is_entry_rank and results is not None:
-                for msg, out in zip(messages, results):
-                    if msg.request_id in self._aborted_request_ids:
-                        continue
-                    self.outbox.put(
-                        OutgoingMessage(
-                            request_id=msg.request_id,
-                            type="result",
-                            data=out,
-                        )
+            try:
+                raw = self.worker.encode_batch(plan)
+            except Exception as exc:  # noqa: BLE001
+                # Production: _fatal_tp_forward_error calls os._exit(1)
+                # and never returns; the runner's _monitor_children
+                # then fails outstanding Coordinator futures.
+                # Tests: monkey-patched fatal handler returns. In that
+                # case we exit the loop cleanly without re-raising —
+                # re-raising would crash the scheduler thread, which
+                # under Stage._handle_scheduler_crash would tear down
+                # the stage even in tests where we want to assert state
+                # post-fault.
+                self._fatal_tp_forward_error(exc)
+                self._running = False
+                return
+
+            if not self.worker.is_entry_rank:
+                continue
+
+            try:
+                results = self.adapter.slice_results(raw, plan, messages)
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("EncoderScheduler slice_results failed")
+                self._emit_error(messages, exc)
+                continue
+
+            for msg, out in zip(messages, results):
+                if msg.request_id in self._aborted_request_ids:
+                    continue
+                self.outbox.put(
+                    OutgoingMessage(
+                        request_id=msg.request_id,
+                        type="result",
+                        data=out,
                     )
+                )
+
+    def _gather_pre_forward_error(
+        self,
+        local_err: BaseException | None,
+    ) -> bool:
+        """Synchronize recoverable recv/build errors before model collectives.
+
+        Returns True iff *any* rank reported a failure. The TP CPU group
+        gather marshals only a picklable boolean — the exception object
+        stays local, so each rank emits its own request-level error.
+        """
+        if self.worker.tp_size <= 1:
+            return local_err is not None
+        err_flags: list[bool] = [False] * self.worker.tp_size
+        dist.all_gather_object(
+            err_flags,
+            local_err is not None,
+            group=self.worker.tp_group.cpu_group,
+        )
+        return any(err_flags)
+
+    def _fatal_tp_forward_error(self, error: BaseException) -> None:
+        """Exit non-zero after a TP forward fault.
+
+        Once ``encode_batch`` has entered upstream SGLang TP collectives,
+        a rank-local exception cannot be recovered through a post-hoc CPU
+        gather: peers may still be blocked in NCCL and never reach the
+        gather. Force a child-process failure so
+        :class:`MultiProcessPipelineRunner` tears down the whole TP group
+        and fails outstanding Coordinator futures from the parent side.
+
+        Overridable by tests via monkey-patch (the test stub records the
+        error and *does* return so the test runner can assert on it).
+        """
+        logger.exception(
+            "Fatal TP encoder forward failure on rank %d/%d: %r",
+            self.worker.tp_rank, self.worker.tp_size, error,
+        )
+        os._exit(1)
 
     def stop(self) -> None:
         self._running = False

--- a/sglang_omni_v1/scheduling/encoder_scheduler.py
+++ b/sglang_omni_v1/scheduling/encoder_scheduler.py
@@ -1,0 +1,536 @@
+# SPDX-License-Identifier: Apache-2.0
+"""TP-aware scheduler for SGLang-backed encoder stages.
+
+Same public shape as :class:`SimpleScheduler` (``inbox`` / ``outbox`` /
+``start`` / ``stop`` / ``abort``) so :class:`Stage` does not branch on
+scheduler type. Adds an explicit two-channel broadcast in
+``_recv_messages``:
+
+1. **Metadata** over the SGLang TP CPU group via ``broadcast_pyobj`` —
+   pickles only the dict skeleton, never the tensor payload bytes.
+2. **Tensors** over the SGLang TP device group via ``dist.broadcast``
+   on cuda:0.
+
+A small ``all_gather_object`` "alloc-ok?" handshake between the two
+broadcasts prevents a follower OOM mid-allocation from leaving the
+entry rank stuck in ``dist.broadcast``.
+
+The scheduler is correct in both lanes:
+
+- ``tp_size == 1``: skip the broadcasts; still strip-and-lift CPU shm
+  tensors to ``cuda:0`` because the upstream ``get_image_feature`` /
+  ``get_video_feature`` call ``.type(dtype)`` only — they do not move
+  tensors to the model's device.
+- ``tp_size  > 1``: drain the inbox on the entry rank only; broadcast
+  inputs to followers; run the same ``build_batch`` /
+  ``encode_batch`` / ``slice_results`` pipeline on every rank;
+  emit results from the entry rank only.
+
+See ``docs/developer_reference/encoder_tp_path_b_design.md`` for the
+load-bearing design notes.
+"""
+from __future__ import annotations
+
+import collections
+import dataclasses
+import logging
+import queue as _queue_mod
+import time
+from typing import TYPE_CHECKING, Any, Callable
+
+import torch
+import torch.distributed as dist
+
+from sglang.srt.utils import broadcast_pyobj
+
+from sglang_omni_v1.pipeline.relay_io import extract_tensors, restore_tensors
+from sglang_omni_v1.scheduling.messages import IncomingMessage, OutgoingMessage
+
+if TYPE_CHECKING:
+    from sglang_omni_v1.model_runner.sglang_encoder_worker import SGLangEncoderWorker
+    from sglang_omni_v1.models.qwen3_omni.encoder_adapters import (
+        BatchPlan,
+        EncoderAdapter,
+    )
+
+logger = logging.getLogger(__name__)
+
+# Tagged-dict sentinel used to ship recv-time errors over the same
+# CPU-group ``broadcast_pyobj`` slot the success path uses. Identity
+# sentinels (e.g. ``object()``) do not survive the pickle round-trip
+# inside ``broadcast_pyobj``; a kind-string does.
+_RECV_ERROR_KIND = "encoder_recv_error"
+
+
+@dataclasses.dataclass(slots=True)
+class _TensorSpec:
+    """Lightweight description of a tensor for the metadata broadcast.
+
+    Carries the typed ``torch.dtype`` (not the stringified form
+    ``relay_io.extract_tensors`` produces, which would force a parser on
+    the follower side).
+    """
+    path: str
+    shape: tuple[int, ...]
+    dtype: torch.dtype
+
+
+class BatchCollectError(RuntimeError):
+    """Raised when batch admission fails after draining one or more messages.
+
+    Carries the drained ``messages`` so the scheduler can emit one
+    request-level error per request instead of silently dropping them.
+    """
+
+    def __init__(
+        self,
+        messages: list[IncomingMessage],
+        error: BaseException,
+    ) -> None:
+        super().__init__(str(error))
+        self.messages = messages
+        self.error = error
+
+
+class EncoderScheduler:
+    """Inbox -> two-channel broadcast -> encoder forward -> outbox.
+
+    Public contract identical to :class:`SimpleScheduler`. ``Stage`` is
+    unaware of the TP shape — it just hands inputs to ``inbox`` and
+    drains ``outbox``.
+    """
+
+    def __init__(
+        self,
+        worker: "SGLangEncoderWorker",
+        adapter: "EncoderAdapter",
+        *,
+        max_batch_size: int = 32,
+        max_batch_wait_ms: int = 50,
+        request_cost_fn: Callable[[Any], int] | None = None,
+        max_batch_cost: int | None = None,
+    ) -> None:
+        self.worker = worker
+        self.adapter = adapter
+        self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
+        self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
+        self._max_batch_size = max(int(max_batch_size), 1)
+        self._max_batch_wait_s = max(float(max_batch_wait_ms), 0.0) / 1000.0
+        self._request_cost_fn = request_cost_fn
+        self._max_batch_cost = (
+            max(int(max_batch_cost), 0) if max_batch_cost is not None else None
+        )
+        self._pending_messages: collections.deque[IncomingMessage] = (
+            collections.deque()
+        )
+        self._running = False
+        self._aborted_request_ids: set[str] = set()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Run the scheduler loop on the current thread."""
+        self._running = True
+        while self._running:
+            messages, recv_err = self._recv_messages()
+            local_err: BaseException | None = recv_err
+            results: list | None = None
+
+            if recv_err is None and not messages:
+                continue
+
+            if recv_err is None:
+                try:
+                    plan = self.adapter.build_batch(messages)
+                    raw = self.worker.encode_batch(plan)
+                    if self.worker.is_entry_rank:
+                        results = self.adapter.slice_results(raw, plan, messages)
+                except Exception as exc:  # noqa: BLE001
+                    local_err = exc
+                    if self.worker.is_entry_rank:
+                        logger.exception(
+                            "EncoderScheduler forward/build/slice failed",
+                        )
+
+            if self.worker.tp_size > 1:
+                err_flags: list[bool] = [False] * self.worker.tp_size
+                dist.all_gather_object(
+                    err_flags,
+                    local_err is not None,
+                    group=self.worker.tp_group.cpu_group,
+                )
+                any_err = any(err_flags)
+            else:
+                any_err = local_err is not None
+
+            if any_err:
+                if self.worker.is_entry_rank:
+                    self._emit_error(
+                        messages,
+                        local_err
+                        if local_err is not None
+                        else RuntimeError("peer-rank encoder forward failed"),
+                    )
+                continue
+
+            if self.worker.is_entry_rank and results is not None:
+                for msg, out in zip(messages, results):
+                    if msg.request_id in self._aborted_request_ids:
+                        continue
+                    self.outbox.put(
+                        OutgoingMessage(
+                            request_id=msg.request_id,
+                            type="result",
+                            data=out,
+                        )
+                    )
+
+    def stop(self) -> None:
+        self._running = False
+
+    def abort(self, request_id: str) -> None:
+        """Mark a request as aborted; results emitted later will be dropped."""
+        self._aborted_request_ids.add(request_id)
+        # bound the set so it cannot grow forever in long-running servers
+        if len(self._aborted_request_ids) > 10000:
+            keep = list(self._aborted_request_ids)[-5000:]
+            self._aborted_request_ids = set(keep)
+
+    # ------------------------------------------------------------------
+    # Recv path: inbox drain + two-channel broadcast
+    # ------------------------------------------------------------------
+
+    def _next_message(self) -> IncomingMessage | None:
+        if self._pending_messages:
+            return self._pending_messages.popleft()
+        try:
+            return self.inbox.get(timeout=0.1)
+        except _queue_mod.Empty:
+            return None
+
+    def _message_cost(self, msg: IncomingMessage) -> int:
+        if self._request_cost_fn is None or msg.type != "new_request":
+            return 0
+        return max(int(self._request_cost_fn(msg.data)), 0)
+
+    def _collect_batch_from_inbox(self) -> list[IncomingMessage]:
+        """Drain the inbox into a cost-bounded batch (entry rank only).
+
+        Mirrors :func:`SimpleScheduler._collect_batch` so the SGLang lane
+        inherits the same admission control as the local lane.
+
+        Raises:
+            BatchCollectError: ``request_cost_fn`` (adapter / model code)
+                raised. Carries the drained list so the caller can emit
+                one error per request instead of silently dropping them.
+        """
+        first = self._next_message()
+        if first is None:
+            return []
+
+        if first.type != "new_request":
+            return [first]
+
+        batch: list[IncomingMessage] = [first]
+        try:
+            batch_cost = self._message_cost(first)
+        except Exception as exc:  # noqa: BLE001
+            raise BatchCollectError(batch, exc) from exc
+
+        deadline = time.monotonic() + self._max_batch_wait_s
+        while len(batch) < self._max_batch_size:
+            try:
+                msg = self.inbox.get_nowait()
+            except _queue_mod.Empty:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                try:
+                    msg = self.inbox.get(timeout=remaining)
+                except _queue_mod.Empty:
+                    break
+
+            if msg.type != "new_request":
+                self._pending_messages.append(msg)
+                continue
+
+            if self._max_batch_cost is not None:
+                try:
+                    cost = self._message_cost(msg)
+                except Exception as exc:  # noqa: BLE001
+                    batch.append(msg)  # so the failed request gets an error
+                    raise BatchCollectError(batch, exc) from exc
+                if batch_cost + cost > self._max_batch_cost:
+                    self._pending_messages.appendleft(msg)
+                    break
+                batch_cost += cost
+            batch.append(msg)
+        return batch
+
+    def _collect_batch_or_error(
+        self,
+    ) -> tuple[list[IncomingMessage], BaseException | None]:
+        try:
+            return self._collect_batch_from_inbox(), None
+        except BatchCollectError as exc:
+            return exc.messages, exc.error
+        except Exception as exc:  # noqa: BLE001
+            return [], exc
+
+    def _strip_and_lift(
+        self,
+        messages: list[IncomingMessage],
+    ) -> tuple[
+        list[IncomingMessage],
+        list[list[torch.Tensor]],
+        list[list[_TensorSpec]],
+    ]:
+        """Extract tensors from each message, lift them to the worker device.
+
+        Returns three parallel lists indexed by message:
+
+        - ``meta_msgs``: deep-copied IncomingMessages whose ``data.data``
+          dict tree has had its tensors replaced by ``extract_tensors``
+          placeholders. These are the only objects that get pickled by
+          ``broadcast_pyobj`` — small dict skeletons, never tensor bytes.
+        - ``tensor_lists``: per-message lists of GPU-resident tensors,
+          ordered so they can be paired one-to-one with ``specs_lists``.
+        - ``specs_lists``: per-message lists of :class:`_TensorSpec`
+          carrying ``(path, shape, torch.dtype)``. Followers reconstruct
+          their receive placeholders from these.
+
+        The CPU-shm relay path delivers tensors on CPU; the H2D copy here
+        is the same memcpy the local v1 encoder forward already does
+        before its forward call (``image_encoder.py:154``), so it is not
+        new work — just earlier.
+        """
+        meta_msgs: list[IncomingMessage] = []
+        tensor_lists: list[list[torch.Tensor]] = []
+        specs_lists: list[list[_TensorSpec]] = []
+
+        for msg in messages:
+            payload = msg.data
+            if payload is None or not hasattr(payload, "data"):
+                meta_msgs.append(msg)
+                tensor_lists.append([])
+                specs_lists.append([])
+                continue
+
+            stripped, tensor_dict = extract_tensors(payload.data)
+            tensors: list[torch.Tensor] = []
+            specs: list[_TensorSpec] = []
+            lifted: dict[str, torch.Tensor] = {}
+            for path, t in tensor_dict.items():
+                if t.device != self.worker.device:
+                    t = t.to(self.worker.device, non_blocking=True)
+                tensors.append(t)
+                specs.append(
+                    _TensorSpec(path=path, shape=tuple(t.shape), dtype=t.dtype)
+                )
+                lifted[path] = t
+
+            # Rebuild the entry rank's payload with GPU-resident tensors
+            # so its downstream BatchPlan sees the same device-resident
+            # tensors the followers will reconstruct.
+            payload_cls = type(payload)
+            new_payload = payload_cls(
+                request_id=payload.request_id,
+                request=payload.request,
+                data=restore_tensors(stripped, lifted),
+            )
+            meta_msg = dataclasses.replace(msg, data=new_payload)
+            meta_msgs.append(meta_msg)
+            tensor_lists.append(tensors)
+            specs_lists.append(specs)
+
+        return meta_msgs, tensor_lists, specs_lists
+
+    def _reattach_lifted_tensors(
+        self,
+        meta_msgs: list[IncomingMessage],
+        tensor_lists: list[list[torch.Tensor]],
+        specs_lists: list[list[_TensorSpec]],
+    ) -> list[IncomingMessage]:
+        """Follower path: rebuild messages by stitching specs back into payloads.
+
+        On the entry rank ``_strip_and_lift`` already reattached the lifted
+        tensors, so this is a no-op (returns ``meta_msgs`` unchanged).
+        Followers, however, see ``meta_msgs`` whose ``data.data`` tree
+        still contains placeholder dicts; they need to map ``spec.path``
+        back to the freshly received tensor.
+        """
+        out: list[IncomingMessage] = []
+        for msg, tensors, specs in zip(meta_msgs, tensor_lists, specs_lists):
+            payload = msg.data
+            if payload is None or not hasattr(payload, "data") or not specs:
+                out.append(msg)
+                continue
+            tensor_dict = {spec.path: t for spec, t in zip(specs, tensors)}
+            payload_cls = type(payload)
+            restored = payload_cls(
+                request_id=payload.request_id,
+                request=payload.request,
+                data=restore_tensors(payload.data, tensor_dict),
+            )
+            out.append(dataclasses.replace(msg, data=restored))
+        return out
+
+    def _allocation_ready_gather(self, *, local_ok: bool) -> list[bool]:
+        """Gather per-rank allocation-success flags on the TP CPU group."""
+        flags: list[bool] = [False] * self.worker.tp_size
+        dist.all_gather_object(
+            flags,
+            local_ok,
+            group=self.worker.tp_group.cpu_group,
+        )
+        return flags
+
+    def _recv_messages(
+        self,
+    ) -> tuple[list[IncomingMessage], BaseException | None]:
+        """Drain inbox and broadcast inputs to TP followers.
+
+        Never raises — returns ``(messages, error)``. The error is non-None
+        if either rank failed during this iteration. Drained messages
+        are returned even on entry-rank failure so the scheduler can emit
+        request-level errors against them in the unified handshake.
+        """
+        if self.worker.tp_size == 1:
+            local, collect_err = self._collect_batch_or_error()
+            if collect_err is not None or not local:
+                return local, collect_err
+            try:
+                meta_msgs, tensor_lists, specs_lists = self._strip_and_lift(
+                    local
+                )
+            except Exception as exc:  # noqa: BLE001
+                return local, exc
+            # On the entry rank meta_msgs already carry GPU-resident tensors
+            # because _strip_and_lift restored them before returning.
+            return meta_msgs, None
+
+        tp = self.worker.tp_group
+        src_rank = tp.ranks[0]
+
+        if self.worker.is_entry_rank:
+            local, collect_err = self._collect_batch_or_error()
+            if collect_err is not None:
+                broadcast_pyobj(
+                    [{"kind": _RECV_ERROR_KIND, "error": repr(collect_err)}],
+                    tp.rank, tp.cpu_group, src=src_rank,
+                )
+                return local, collect_err
+
+            try:
+                meta_msgs, tensor_lists, specs_lists = self._strip_and_lift(
+                    local
+                )
+            except Exception as exc:  # noqa: BLE001
+                broadcast_pyobj(
+                    [{"kind": _RECV_ERROR_KIND, "error": repr(exc)}],
+                    tp.rank, tp.cpu_group, src=src_rank,
+                )
+                return local, exc
+
+            broadcast_pyobj(
+                [meta_msgs, specs_lists],
+                tp.rank, tp.cpu_group, src=src_rank,
+            )
+
+            ok_flags = self._allocation_ready_gather(local_ok=True)
+            if not all(ok_flags):
+                return local, RuntimeError(
+                    "peer-rank tensor allocation failed"
+                )
+
+            for tensor_list in tensor_lists:
+                for t in tensor_list:
+                    dist.broadcast(t, src=src_rank, group=tp.device_group)
+
+            return meta_msgs, None
+
+        # Follower path
+        payload = broadcast_pyobj([], tp.rank, tp.cpu_group, src=src_rank)
+        if (
+            payload
+            and isinstance(payload[0], dict)
+            and payload[0].get("kind") == _RECV_ERROR_KIND
+        ):
+            return [], RuntimeError(
+                f"entry rank failed before metadata broadcast: "
+                f"{payload[0]['error']}"
+            )
+        meta_msgs, specs_lists = payload
+
+        placeholders: list[list[torch.Tensor]] = []
+        alloc_err: BaseException | None = None
+        try:
+            for specs in specs_lists:
+                placeholders.append(
+                    [
+                        torch.empty(
+                            spec.shape,
+                            dtype=spec.dtype,
+                            device=self.worker.device,
+                        )
+                        for spec in specs
+                    ]
+                )
+        except Exception as exc:  # noqa: BLE001
+            alloc_err = exc
+
+        ok_flags = self._allocation_ready_gather(local_ok=alloc_err is None)
+        if not all(ok_flags):
+            return [], (
+                alloc_err
+                if alloc_err is not None
+                else RuntimeError("peer-rank tensor allocation failed")
+            )
+
+        for ph_list in placeholders:
+            for t in ph_list:
+                dist.broadcast(t, src=src_rank, group=tp.device_group)
+
+        return self._reattach_lifted_tensors(
+            meta_msgs, placeholders, specs_lists
+        ), None
+
+    # ------------------------------------------------------------------
+    # Error emission
+    # ------------------------------------------------------------------
+
+    def _emit_error(
+        self,
+        messages: list[IncomingMessage],
+        error: BaseException,
+    ) -> None:
+        """Emit one ``OutgoingMessage(type="error")`` per drained request.
+
+        SimpleScheduler exposes a single-request ``_emit_error`` helper;
+        reusing it here would put a list[IncomingMessage] into
+        ``OutgoingMessage.request_id``, which
+        ``Stage._drain_outbox_external`` would TypeError on. Iterate
+        explicitly so each drained request becomes one HTTP-500.
+        """
+        if not messages:
+            # No request was safely captured — synthesize one anonymous
+            # error so the failure does not vanish silently. Stage will
+            # discard it because the request_id is empty, but the log
+            # captures the cause.
+            logger.error(
+                "EncoderScheduler iteration failed without drained requests: %s",
+                error,
+            )
+            return
+        for msg in messages:
+            if msg.request_id in self._aborted_request_ids:
+                continue
+            self.outbox.put(
+                OutgoingMessage(
+                    request_id=msg.request_id,
+                    type="error",
+                    data=error,
+                )
+            )

--- a/sglang_omni_v1/scheduling/encoder_scheduler.py
+++ b/sglang_omni_v1/scheduling/encoder_scheduler.py
@@ -12,8 +12,8 @@ scheduler type. Adds an explicit two-channel broadcast in
    on cuda:0.
 
 A small ``all_gather_object`` "alloc-ok?" handshake between the two
-broadcasts prevents a follower OOM mid-allocation from leaving the
-entry rank stuck in ``dist.broadcast``.
+broadcasts prevents a non-entry-rank OOM mid-allocation from leaving
+the entry rank stuck in ``dist.broadcast``.
 
 The scheduler is correct in both lanes:
 
@@ -22,9 +22,15 @@ The scheduler is correct in both lanes:
   ``get_video_feature`` call ``.type(dtype)`` only — they do not move
   tensors to the model's device.
 - ``tp_size  > 1``: drain the inbox on the entry rank only; broadcast
-  inputs to followers; run the same ``build_batch`` /
+  inputs to non-entry ranks; run the same ``build_batch`` /
   ``encode_batch`` / ``slice_results`` pipeline on every rank;
   emit results from the entry rank only.
+
+Naming note: this module uses ``entry_rank`` / ``non-entry rank`` to
+describe the rank-0-vs-rest asymmetry. The asymmetry is just "who
+owns external IO" — there's no leader election or failover. The
+Stage-level ``single/leader/follower`` role split is a separate
+abstraction layer that this scheduler doesn't touch.
 
 See ``docs/developer_reference/encoder_tp_path_b_design.md`` for the
 load-bearing design notes.
@@ -48,7 +54,7 @@ from sglang_omni_v1.pipeline.relay_io import extract_tensors, restore_tensors
 from sglang_omni_v1.scheduling.messages import IncomingMessage, OutgoingMessage
 
 if TYPE_CHECKING:
-    from sglang_omni_v1.model_runner.sglang_encoder_worker import SGLangEncoderWorker
+    from sglang_omni_v1.model_runner.sglang_encoder_runner import SGLangEncoderRunner
     from sglang_omni_v1.models.qwen3_omni.encoder_adapters import (
         BatchPlan,
         EncoderAdapter,
@@ -69,7 +75,7 @@ class _TensorSpec:
 
     Carries the typed ``torch.dtype`` (not the stringified form
     ``relay_io.extract_tensors`` produces, which would force a parser on
-    the follower side).
+    the non-entry-rank side).
     """
     path: str
     shape: tuple[int, ...]
@@ -103,7 +109,7 @@ class EncoderScheduler:
 
     def __init__(
         self,
-        worker: "SGLangEncoderWorker",
+        runner: "SGLangEncoderRunner",
         adapter: "EncoderAdapter",
         *,
         max_batch_size: int = 32,
@@ -111,7 +117,7 @@ class EncoderScheduler:
         request_cost_fn: Callable[[Any], int] | None = None,
         max_batch_cost: int | None = None,
     ) -> None:
-        self.worker = worker
+        self.runner = runner
         self.adapter = adapter
         self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
         self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
@@ -161,7 +167,7 @@ class EncoderScheduler:
         while self._running:
             messages, recv_err = self._recv_messages()
             if self._gather_pre_forward_error(recv_err):
-                if self.worker.is_entry_rank:
+                if self.runner.is_entry_rank:
                     self._emit_error(
                         messages,
                         recv_err
@@ -180,7 +186,7 @@ class EncoderScheduler:
                 build_err = exc
 
             if self._gather_pre_forward_error(build_err):
-                if self.worker.is_entry_rank:
+                if self.runner.is_entry_rank:
                     self._emit_error(
                         messages,
                         build_err
@@ -190,7 +196,7 @@ class EncoderScheduler:
                 continue
 
             try:
-                raw = self.worker.encode_batch(plan)
+                raw = self.runner.encode_batch(plan)
             except Exception as exc:  # noqa: BLE001
                 # Production: _fatal_tp_forward_error calls os._exit(1)
                 # and never returns; the runner's _monitor_children
@@ -205,7 +211,7 @@ class EncoderScheduler:
                 self._running = False
                 return
 
-            if not self.worker.is_entry_rank:
+            if not self.runner.is_entry_rank:
                 continue
 
             try:
@@ -236,13 +242,13 @@ class EncoderScheduler:
         gather marshals only a picklable boolean — the exception object
         stays local, so each rank emits its own request-level error.
         """
-        if self.worker.tp_size <= 1:
+        if self.runner.tp_size <= 1:
             return local_err is not None
-        err_flags: list[bool] = [False] * self.worker.tp_size
+        err_flags: list[bool] = [False] * self.runner.tp_size
         dist.all_gather_object(
             err_flags,
             local_err is not None,
-            group=self.worker.tp_group.cpu_group,
+            group=self.runner.tp_group.cpu_group,
         )
         return any(err_flags)
 
@@ -261,7 +267,7 @@ class EncoderScheduler:
         """
         logger.exception(
             "Fatal TP encoder forward failure on rank %d/%d: %r",
-            self.worker.tp_rank, self.worker.tp_size, error,
+            self.runner.tp_rank, self.runner.tp_size, error,
         )
         os._exit(1)
 
@@ -365,7 +371,7 @@ class EncoderScheduler:
         list[list[torch.Tensor]],
         list[list[_TensorSpec]],
     ]:
-        """Extract tensors from each message, lift them to the worker device.
+        """Extract tensors from each message, lift them to the runner device.
 
         Returns three parallel lists indexed by message:
 
@@ -401,8 +407,8 @@ class EncoderScheduler:
             specs: list[_TensorSpec] = []
             lifted: dict[str, torch.Tensor] = {}
             for path, t in tensor_dict.items():
-                if t.device != self.worker.device:
-                    t = t.to(self.worker.device, non_blocking=True)
+                if t.device != self.runner.device:
+                    t = t.to(self.runner.device, non_blocking=True)
                 tensors.append(t)
                 specs.append(
                     _TensorSpec(path=path, shape=tuple(t.shape), dtype=t.dtype)
@@ -411,7 +417,7 @@ class EncoderScheduler:
 
             # Rebuild the entry rank's payload with GPU-resident tensors
             # so its downstream BatchPlan sees the same device-resident
-            # tensors the followers will reconstruct.
+            # tensors the non-entry ranks will reconstruct.
             payload_cls = type(payload)
             new_payload = payload_cls(
                 request_id=payload.request_id,
@@ -457,25 +463,25 @@ class EncoderScheduler:
 
     def _allocation_ready_gather(self, *, local_ok: bool) -> list[bool]:
         """Gather per-rank allocation-success flags on the TP CPU group."""
-        flags: list[bool] = [False] * self.worker.tp_size
+        flags: list[bool] = [False] * self.runner.tp_size
         dist.all_gather_object(
             flags,
             local_ok,
-            group=self.worker.tp_group.cpu_group,
+            group=self.runner.tp_group.cpu_group,
         )
         return flags
 
     def _recv_messages(
         self,
     ) -> tuple[list[IncomingMessage], BaseException | None]:
-        """Drain inbox and broadcast inputs to TP followers.
+        """Drain inbox and broadcast inputs to TP non-entry ranks.
 
         Never raises — returns ``(messages, error)``. The error is non-None
         if either rank failed during this iteration. Drained messages
         are returned even on entry-rank failure so the scheduler can emit
         request-level errors against them in the unified handshake.
         """
-        if self.worker.tp_size == 1:
+        if self.runner.tp_size == 1:
             local, collect_err = self._collect_batch_or_error()
             if collect_err is not None or not local:
                 return local, collect_err
@@ -489,10 +495,10 @@ class EncoderScheduler:
             # because _strip_and_lift restored them before returning.
             return meta_msgs, None
 
-        tp = self.worker.tp_group
+        tp = self.runner.tp_group
         src_rank = tp.ranks[0]
 
-        if self.worker.is_entry_rank:
+        if self.runner.is_entry_rank:
             local, collect_err = self._collect_batch_or_error()
             if collect_err is not None:
                 broadcast_pyobj(
@@ -551,7 +557,7 @@ class EncoderScheduler:
                         torch.empty(
                             spec.shape,
                             dtype=spec.dtype,
-                            device=self.worker.device,
+                            device=self.runner.device,
                         )
                         for spec in specs
                     ]

--- a/sglang_omni_v1/scheduling/sglang_backend/__init__.py
+++ b/sglang_omni_v1/scheduling/sglang_backend/__init__.py
@@ -7,6 +7,7 @@ from sglang_omni_v1.scheduling.sglang_backend.output_processor import (
 from sglang_omni_v1.scheduling.sglang_backend.prefill import PrefillManager
 from sglang_omni_v1.scheduling.sglang_backend.request_data import SGLangARRequestData
 from sglang_omni_v1.scheduling.sglang_backend.server_args_builder import (
+    build_sglang_encoder_server_args,
     build_sglang_server_args,
 )
 
@@ -16,5 +17,6 @@ __all__ = [
     "PrefillManager",
     "SGLangARRequestData",
     "SGLangOutputProcessor",
+    "build_sglang_encoder_server_args",
     "build_sglang_server_args",
 ]

--- a/sglang_omni_v1/scheduling/sglang_backend/server_args_builder.py
+++ b/sglang_omni_v1/scheduling/sglang_backend/server_args_builder.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Shared ServerArgs construction for SGLang AR engines."""
+"""Shared ServerArgs construction for SGLang AR engines and encoder workers."""
 from __future__ import annotations
 
 from typing import Any
@@ -30,5 +30,94 @@ def build_sglang_server_args(
         "random_seed": 123,
         "context_length": context_length,
     }
+    kwargs.update(overrides)
+    return ServerArgs(**kwargs)
+
+
+# Worker invariants that must NOT be reachable from server_args_overrides.
+# Mutating these would either invalidate GPU placement, change the
+# parallelism axis we promised, or flip the encoder-vs-language-only
+# fork. See encoder_tp_path_b_design.md "GPU placement..." and
+# "AR-only knob protection".
+_ENCODER_PROTECTED_KEYS = frozenset({
+    # Parallelism / placement
+    "tp_size",
+    "pp_size",
+    "dp_size",
+    "ep_size",
+    "moe_dense_tp_size",
+    "nnodes",
+    "node_rank",
+    "base_gpu_id",
+    "dist_init_addr",
+    # Encoder-only fork
+    "encoder_only",
+    "language_only",
+    "mm_enable_dp_encoder",
+    "enable_dp_attention",
+    "enable_dp_lm_head",
+    "disable_cuda_graph",
+    "device",
+    # AR-only knobs that have no meaning for an encoder-only worker.
+    # Locked so users cannot reintroduce SGLang AR memory semantics
+    # through server_args_overrides — the encoder path explicitly does
+    # not own a KV pool, an AR running queue, or a chunked-prefill
+    # budget.
+    "mem_fraction_static",
+    "max_running_requests",
+    "max_prefill_tokens",
+    "chunked_prefill_size",
+    "context_length",
+})
+
+
+def build_sglang_encoder_server_args(
+    model_path: str,
+    *,
+    tp_size: int,
+    base_gpu_id: int,
+    dist_init_addr: str,
+    dtype: str | None = None,
+    load_format: str | None = None,
+    **overrides: Any,
+) -> ServerArgs:
+    """ServerArgs configured for an encoder-only SGLang worker.
+
+    Distinct from :func:`build_sglang_server_args` because encoder
+    stages do not have a meaningful ``context_length`` /
+    ``mem_fraction_static`` / running-queue budget.
+
+    Raises:
+        ValueError: ``overrides`` tries to mutate a protected invariant
+            (parallelism shape, GPU placement, encoder-only fork, or AR-only
+            memory knobs). Such fields are decided by the worker / pipeline
+            runner and must be passed through ``StageConfig`` (``tp_size``,
+            ``gpu``) instead.
+    """
+    bad = sorted(_ENCODER_PROTECTED_KEYS & overrides.keys())
+    if bad:
+        raise ValueError(
+            f"server_args_overrides cannot override protected keys: {bad}. "
+            f"These are decided by the worker / pipeline runner; pass them "
+            f"through StageConfig (tp_size, gpu) instead."
+        )
+
+    kwargs: dict[str, Any] = {
+        "model_path": model_path,
+        "trust_remote_code": True,
+        "tp_size": tp_size,
+        "pp_size": 1,
+        "base_gpu_id": base_gpu_id,
+        "dist_init_addr": dist_init_addr,
+        "encoder_only": True,
+        "language_only": False,
+        "mm_enable_dp_encoder": False,    # MVP: TP only
+        "disable_cuda_graph": True,        # variable shapes; piecewise CG lands later
+        "random_seed": 123,
+    }
+    if dtype is not None:
+        kwargs["dtype"] = dtype
+    if load_format is not None:
+        kwargs["load_format"] = load_format
     kwargs.update(overrides)
     return ServerArgs(**kwargs)

--- a/sglang_omni_v1/scheduling/sglang_backend/server_args_builder.py
+++ b/sglang_omni_v1/scheduling/sglang_backend/server_args_builder.py
@@ -40,7 +40,14 @@ def build_sglang_server_args(
 # fork. See encoder_tp_path_b_design.md "GPU placement..." and
 # "AR-only knob protection".
 _ENCODER_PROTECTED_KEYS = frozenset({
-    # Parallelism / placement
+    # Parallelism / placement / rank topology.
+    # For encoder stages, rank topology has exactly one source of truth:
+    # StageConfig.tp_size + StageConfig.gpu, materialized by the runner
+    # into per-rank kwargs. server_args_overrides is only for safe
+    # SGLang loading/runtime knobs (quantization, attention backend,
+    # remote weight loading); it must not be able to change rank
+    # topology or GPU placement after the runner has already spawned
+    # processes.
     "tp_size",
     "pp_size",
     "dp_size",
@@ -48,7 +55,12 @@ _ENCODER_PROTECTED_KEYS = frozenset({
     "moe_dense_tp_size",
     "nnodes",
     "node_rank",
+    "rank",
+    "world_size",
+    "tp_rank",
+    "gpu_id",
     "base_gpu_id",
+    "nccl_port",
     "dist_init_addr",
     # Encoder-only fork
     "encoder_only",

--- a/sglang_omni_v1/serve/launcher.py
+++ b/sglang_omni_v1/serve/launcher.py
@@ -147,7 +147,14 @@ async def _run_server(
         else:
             gpu_ids.add(v)
     any_tp = any(s.tp_size > 1 for s in pipeline_config.stages)
-    needs_mp = len(gpu_ids) > 1 or any_tp
+    # Stages whose resolved factory backend is "sglang" / "auto" must run
+    # in their own subprocess so the launcher can remap CUDA_VISIBLE_DEVICES
+    # before torch is imported. See encoder_tp_path_b_design.md
+    # "Required launcher change".
+    from sglang_omni_v1.pipeline.mp_runner import any_sglang_backend_stage
+
+    any_sglang_backend = any_sglang_backend_stage(pipeline_config)
+    needs_mp = len(gpu_ids) > 1 or any_tp or any_sglang_backend
     logger.info(
         "GPU placement: %s → %s",
         dict(pipeline_config.gpu_placement),

--- a/tests/_encoder_parity_harness.py
+++ b/tests/_encoder_parity_harness.py
@@ -113,8 +113,8 @@ def _run_local(model_path: str, out_path: str) -> None:
 
 
 def _run_sglang(model_path: str, out_path: str, *, tp_size: int = 1, tp_rank: int = 0, nccl_port: int | None = None) -> None:
-    from sglang_omni_v1.model_runner.sglang_encoder_worker import (
-        SGLangEncoderWorker,
+    from sglang_omni_v1.model_runner.sglang_encoder_runner import (
+        SGLangEncoderRunner,
     )
     from sglang_omni_v1.models.qwen3_omni.encoder_adapters import (
         Qwen3OmniImageEncoderAdapter,
@@ -123,7 +123,7 @@ def _run_sglang(model_path: str, out_path: str, *, tp_size: int = 1, tp_rank: in
     from sglang_omni_v1.scheduling.messages import IncomingMessage
 
     pixel, grid = _build_real_image_inputs(model_path)
-    worker = SGLangEncoderWorker(
+    runner = SGLangEncoderRunner(
         model_path=model_path,
         gpu_id=0,
         tp_rank=tp_rank,
@@ -131,7 +131,7 @@ def _run_sglang(model_path: str, out_path: str, *, tp_size: int = 1, tp_rank: in
         nccl_port=nccl_port,
         dtype="float16",
     )
-    hf_cfg = worker.model_config.hf_config
+    hf_cfg = runner.model_config.hf_config
     adapter = Qwen3OmniImageEncoderAdapter(hf_config=hf_cfg, dtype=torch.float16)
     msg = IncomingMessage(
         request_id="r0",
@@ -150,7 +150,7 @@ def _run_sglang(model_path: str, out_path: str, *, tp_size: int = 1, tp_rank: in
         ),
     )
     plan = adapter.build_batch([msg])
-    raw = worker.encode_batch(plan)
+    raw = runner.encode_batch(plan)
     # Only rank 0 writes (the result is the same across ranks because of TP-symmetric outputs).
     if tp_rank != 0:
         return

--- a/tests/_encoder_parity_harness.py
+++ b/tests/_encoder_parity_harness.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Subprocess harness for backend=local vs backend=sglang encoder parity.
+
+Loads exactly ONE backend per process to avoid OOM (each Qwen3-Omni
+load takes ~57 GB on H100). The parent script runs the backends
+sequentially on the same GPU and pickles output tensors to disk for
+post-hoc comparison.
+
+Run as: ``python _encoder_parity_harness.py <local|sglang> <out_path>``.
+
+Companion script: ``parity_compare.py`` reads the two pickles and
+emits the strict RFC tolerance report.
+
+Findings from the local run (2026-05-09, Qwen3-Omni-30B-A3B-Instruct,
+fp16, real ``cars.jpg``); see also
+``docs/developer_reference/encoder_tp_parity_findings.md``.
+
+backend=local (HF tower) vs backend=sglang at tp_size=1
+--------------------------------------------------------
+- Token count + dtype match exactly: (6042, 2048) fp16.
+- Distributions match: local mean=0.0041 std=0.3294;
+  sglang mean=0.0040 std=0.3296.
+- Per-token cosine sim: 84% ≥ 0.99, 96.7% ≥ 0.9, mean 0.988.
+- Per-element max abs diff 5.95, mean 0.022.
+- ``allclose(atol=1e-3, rtol=1e-3)`` (RFC) → **False**.
+- Real implementation difference between HF transformers
+  ``Qwen3OmniMoeVisionEncoder`` and SGLang's reimplemented
+  ``Qwen3VLMoeVisionModel``. Different attention / fused QKV /
+  normalization paths produce non-bit-equivalent results. Both
+  backends pass the docs CI probes with semantically equivalent
+  outputs.
+
+backend=sglang at tp_size=1 vs tp_size=2
+-----------------------------------------
+- Token count + dtype match exactly.
+- Distributions bit-identical at 4 decimals.
+- Per-token cosine sim: **97.5% ≥ 0.9999**, mean 0.999984.
+- Per-element max abs diff 0.27, mean 0.0008.
+- ``allclose(atol=1e-3, rtol=1e-3)`` → **False** (one outlier element
+  at 0.27, NCCL fp16 accumulation-order noise).
+- Effectively exact within fp16 collective rounding.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import pickle
+from pathlib import Path
+
+import torch
+
+
+def _resolve_model_path() -> str:
+    env_path = os.environ.get("QWEN3_OMNI_MODEL_PATH")
+    if env_path:
+        return env_path
+    cache_root = Path.home() / ".cache" / "huggingface" / "hub"
+    snap_root = (
+        cache_root
+        / "models--Qwen--Qwen3-Omni-30B-A3B-Instruct"
+        / "snapshots"
+    )
+    for snap in snap_root.iterdir():
+        if (snap / "config.json").exists():
+            return str(snap)
+    raise SystemExit("Qwen3-Omni checkpoint not found")
+
+
+def _build_real_image_inputs(model_path: str):
+    """Run the production preprocessor on tests/data/cars.jpg.
+
+    Synthetic gaussian-noise inputs drive activations out of the
+    pre-normalization range both implementations were trained on. A
+    real image keeps inputs in the valid distribution.
+    """
+    from transformers import AutoImageProcessor
+    from PIL import Image
+
+    img_path = Path(__file__).resolve().parents[1] / "tests" / "data" / "cars.jpg"
+    img = Image.open(img_path).convert("RGB")
+    proc = AutoImageProcessor.from_pretrained(model_path, trust_remote_code=True)
+    out = proc(images=img, return_tensors="pt")
+    pixel = out["pixel_values"].to(torch.float32)
+    if "image_grid_thw" in out:
+        grid = out["image_grid_thw"].to(torch.long)
+    elif "image_grid_hws" in out:
+        grid = out["image_grid_hws"].to(torch.long)
+    else:
+        raise SystemExit(f"unexpected processor outputs: {list(out.keys())}")
+    return pixel, grid
+
+
+def _run_local(model_path: str, out_path: str) -> None:
+    from sglang_omni_v1.models.qwen3_omni.components.image_encoder import (
+        Qwen3OmniImageEncoder,
+    )
+
+    pixel, grid = _build_real_image_inputs(model_path)
+    model = Qwen3OmniImageEncoder(
+        model_path=model_path, device="cuda:0", dtype="float16"
+    )
+    with torch.no_grad():
+        outputs = model(
+            pixel_values=pixel.to("cuda:0"),
+            image_grid_thw=grid.to("cuda:0"),
+        )
+    image_embeds = outputs["image_embeds"].detach().cpu()
+    deepstack = outputs.get("deepstack_visual_embeds_image")
+    if deepstack is not None:
+        deepstack = [t.detach().cpu() for t in deepstack]
+    with open(out_path, "wb") as f:
+        pickle.dump({"image_embeds": image_embeds, "deepstack": deepstack}, f)
+
+
+def _run_sglang(model_path: str, out_path: str, *, tp_size: int = 1, tp_rank: int = 0, nccl_port: int | None = None) -> None:
+    from sglang_omni_v1.model_runner.sglang_encoder_worker import (
+        SGLangEncoderWorker,
+    )
+    from sglang_omni_v1.models.qwen3_omni.encoder_adapters import (
+        Qwen3OmniImageEncoderAdapter,
+    )
+    from sglang_omni_v1.proto import StagePayload
+    from sglang_omni_v1.scheduling.messages import IncomingMessage
+
+    pixel, grid = _build_real_image_inputs(model_path)
+    worker = SGLangEncoderWorker(
+        model_path=model_path,
+        gpu_id=0,
+        tp_rank=tp_rank,
+        tp_size=tp_size,
+        nccl_port=nccl_port,
+        dtype="float16",
+    )
+    hf_cfg = worker.model_config.hf_config
+    adapter = Qwen3OmniImageEncoderAdapter(hf_config=hf_cfg, dtype=torch.float16)
+    msg = IncomingMessage(
+        request_id="r0",
+        type="new_request",
+        data=StagePayload(
+            request_id="r0",
+            request=None,
+            data={
+                "encoder_inputs": {
+                    "image_encoder": {
+                        "pixel_values": pixel.to("cuda:0"),
+                        "image_grid_thw": grid,  # CPU per upstream contract
+                    }
+                }
+            },
+        ),
+    )
+    plan = adapter.build_batch([msg])
+    raw = worker.encode_batch(plan)
+    # Only rank 0 writes (the result is the same across ranks because of TP-symmetric outputs).
+    if tp_rank != 0:
+        return
+    sliced = adapter.slice_results(raw, plan, [msg])
+    state = sliced[0].data["encoder_outs"]["image_encoder"]
+    image_embeds = state["image_embeds"].detach().cpu()
+    deepstack = state.get("deepstack_visual_embeds_image")
+    if deepstack is not None:
+        deepstack = [t.detach().cpu() for t in deepstack]
+    with open(out_path, "wb") as f:
+        pickle.dump({"image_embeds": image_embeds, "deepstack": deepstack}, f)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("backend", choices=["local", "sglang"])
+    parser.add_argument("out_path")
+    parser.add_argument("--tp-size", type=int, default=1)
+    parser.add_argument("--tp-rank", type=int, default=0)
+    parser.add_argument("--nccl-port", type=int, default=None)
+    args = parser.parse_args()
+
+    model_path = _resolve_model_path()
+    if args.backend == "local":
+        _run_local(model_path, args.out_path)
+    else:
+        _run_sglang(
+            model_path,
+            args.out_path,
+            tp_size=args.tp_size,
+            tp_rank=args.tp_rank,
+            nccl_port=args.nccl_port,
+        )
+    print(
+        f"PARITY_OK backend={args.backend} tp={args.tp_size} rank={args.tp_rank} "
+        f"out={args.out_path}",
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/_encoder_parity_harness.py
+++ b/tests/_encoder_parity_harness.py
@@ -112,7 +112,7 @@ def _run_local(model_path: str, out_path: str) -> None:
         pickle.dump({"image_embeds": image_embeds, "deepstack": deepstack}, f)
 
 
-def _run_sglang(model_path: str, out_path: str, *, tp_size: int = 1, tp_rank: int = 0, nccl_port: int | None = None) -> None:
+def _run_sglang(model_path: str, out_path: str, *, tp_size: int = 1, tp_rank: int = 0, nccl_port: int | None = None, capture_layers: bool = False) -> None:
     from sglang_omni_v1.model_runner.sglang_encoder_runner import (
         SGLangEncoderRunner,
     )
@@ -132,6 +132,33 @@ def _run_sglang(model_path: str, out_path: str, *, tp_size: int = 1, tp_rank: in
         encoder_specs=Qwen3OmniImageEncoderAdapter.encoder_specs,
         dtype="float16",
     )
+
+    # Optional layer-output capture for tp1-vs-tp2 layer-by-layer
+    # parity. Hooks fire on the block boundary (after both
+    # attn.o_proj's all-reduce and mlp.down_proj's all-reduce), so
+    # the captured tensor is replicated across ranks. Output of
+    # patch_embed is independent of TP; output of merger is the
+    # final (N, base*(1+ndeepstack)) used to slice image_embeds +
+    # deepstack.
+    captures: dict[str, torch.Tensor] = {}
+    if capture_layers:
+        visual = runner.model.visual
+
+        def _grab(name: str):
+            def hook(_mod, _inp, out):
+                t = out[0] if isinstance(out, tuple) else out
+                if torch.is_tensor(t):
+                    captures[name] = t.detach().cpu()
+            return hook
+
+        if hasattr(visual, "patch_embed"):
+            visual.patch_embed.register_forward_hook(_grab("00_patch_embed"))
+        if hasattr(visual, "blocks"):
+            for i, blk in enumerate(visual.blocks):
+                blk.register_forward_hook(_grab(f"blk_{i:02d}"))
+        if hasattr(visual, "merger"):
+            visual.merger.register_forward_hook(_grab("99_merger"))
+
     hf_cfg = runner.model_config.hf_config
     adapter = Qwen3OmniImageEncoderAdapter(hf_config=hf_cfg, dtype=torch.float16)
     msg = IncomingMessage(
@@ -161,8 +188,11 @@ def _run_sglang(model_path: str, out_path: str, *, tp_size: int = 1, tp_rank: in
     deepstack = state.get("deepstack_visual_embeds_image")
     if deepstack is not None:
         deepstack = [t.detach().cpu() for t in deepstack]
+    out_dict: dict[str, object] = {"image_embeds": image_embeds, "deepstack": deepstack}
+    if capture_layers:
+        out_dict["layers"] = captures
     with open(out_path, "wb") as f:
-        pickle.dump({"image_embeds": image_embeds, "deepstack": deepstack}, f)
+        pickle.dump(out_dict, f)
 
 
 def _run_bare_sglang(model_path: str, out_path: str) -> None:
@@ -264,6 +294,7 @@ def main() -> None:
     parser.add_argument("--tp-size", type=int, default=1)
     parser.add_argument("--tp-rank", type=int, default=0)
     parser.add_argument("--nccl-port", type=int, default=None)
+    parser.add_argument("--capture-layers", action="store_true")
     args = parser.parse_args()
 
     model_path = _resolve_model_path()
@@ -278,6 +309,7 @@ def main() -> None:
             tp_size=args.tp_size,
             tp_rank=args.tp_rank,
             nccl_port=args.nccl_port,
+            capture_layers=args.capture_layers,
         )
     print(
         f"PARITY_OK backend={args.backend} tp={args.tp_size} rank={args.tp_rank} "

--- a/tests/_encoder_parity_harness.py
+++ b/tests/_encoder_parity_harness.py
@@ -129,6 +129,7 @@ def _run_sglang(model_path: str, out_path: str, *, tp_size: int = 1, tp_rank: in
         tp_rank=tp_rank,
         tp_size=tp_size,
         nccl_port=nccl_port,
+        encoder_specs=Qwen3OmniImageEncoderAdapter.encoder_specs,
         dtype="float16",
     )
     hf_cfg = runner.model_config.hf_config

--- a/tests/_encoder_parity_harness.py
+++ b/tests/_encoder_parity_harness.py
@@ -112,7 +112,208 @@ def _run_local(model_path: str, out_path: str) -> None:
         pickle.dump({"image_embeds": image_embeds, "deepstack": deepstack}, f)
 
 
-def _run_sglang(model_path: str, out_path: str, *, tp_size: int = 1, tp_rank: int = 0, nccl_port: int | None = None, capture_layers: bool = False, dtype: str = "float16") -> None:
+def _parse_capture_blocks(spec: str | None, num_blocks: int) -> set[int]:
+    if spec is None or spec.strip() == "":
+        return set(range(num_blocks))
+    blocks: set[int] = set()
+    for raw_part in spec.split(","):
+        part = raw_part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            start_s, end_s = part.split("-", 1)
+            start = int(start_s)
+            end = int(end_s)
+            blocks.update(range(start, end + 1))
+        else:
+            blocks.add(int(part))
+    bad = sorted(i for i in blocks if i < 0 or i >= num_blocks)
+    if bad:
+        raise SystemExit(
+            f"--capture-blocks contains out-of-range block indexes {bad}; "
+            f"valid range is 0..{num_blocks - 1}"
+        )
+    return blocks
+
+
+def _parse_index_set(spec: str | None) -> list[int] | None:
+    if spec is None or spec.strip() == "":
+        return None
+    indexes: set[int] = set()
+    for raw_part in spec.split(","):
+        part = raw_part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            start_s, end_s = part.split("-", 1)
+            indexes.update(range(int(start_s), int(end_s) + 1))
+        else:
+            indexes.add(int(part))
+    bad = sorted(i for i in indexes if i < 0)
+    if bad:
+        raise SystemExit(f"negative token indexes are not supported: {bad}")
+    return sorted(indexes)
+
+
+def _premerge_indices(final_indices: list[int] | None, merge: int) -> list[int] | None:
+    if final_indices is None:
+        return None
+    out: list[int] = []
+    for idx in final_indices:
+        out.extend(range(idx * merge, (idx + 1) * merge))
+    return out
+
+
+def _slice_capture_tensor(
+    tensor: torch.Tensor,
+    *,
+    final_indices: list[int] | None,
+    pre_indices: list[int] | None,
+) -> torch.Tensor:
+    if final_indices is None:
+        return tensor
+
+    final_max = max(final_indices)
+    pre_max = max(pre_indices or final_indices)
+    for dim, size in enumerate(tensor.shape[:2]):
+        if size > pre_max:
+            index = torch.tensor(pre_indices, dtype=torch.long, device=tensor.device)
+            return tensor.index_select(dim, index)
+        if size > final_max:
+            index = torch.tensor(final_indices, dtype=torch.long, device=tensor.device)
+            return tensor.index_select(dim, index)
+    return tensor
+
+
+def _all_gather_shard_output(
+    name: str,
+    module,
+    tensor: torch.Tensor,
+    *,
+    tp_size: int,
+    enabled: bool,
+) -> torch.Tensor:
+    """Gather TP shard-local debug captures into TP1-compatible layout."""
+    if not enabled or tp_size <= 1 or not torch.is_tensor(tensor) or tensor.dim() == 0:
+        return tensor
+
+    from sglang.srt.distributed import tensor_model_parallel_all_gather
+    from sglang.srt.layers.linear import ColumnParallelLinear
+
+    if isinstance(module, ColumnParallelLinear):
+        sizes = list(getattr(module, "output_partition_sizes", []) or [])
+        if len(sizes) > 1:
+            chunks = torch.split(tensor, sizes, dim=-1)
+            gathered_chunks = [
+                tensor_model_parallel_all_gather(chunk.contiguous(), dim=-1)
+                for chunk in chunks
+            ]
+            return torch.cat(gathered_chunks, dim=-1)
+        return tensor_model_parallel_all_gather(tensor.contiguous(), dim=-1)
+
+    # Merger mlp.1 is GELU over the shard-local ColumnParallelLinear output.
+    # Gather it too so the activation can be compared against tp=1 directly.
+    if name.endswith(".mlp.1") and module.__class__.__name__ == "GELU":
+        return tensor_model_parallel_all_gather(tensor.contiguous(), dim=-1)
+
+    return tensor
+
+
+def _all_gather_attention_backend_output(
+    tensor: torch.Tensor,
+    *,
+    tp_size: int,
+    enabled: bool,
+) -> torch.Tensor:
+    if not enabled or tp_size <= 1 or not torch.is_tensor(tensor) or tensor.dim() < 2:
+        return tensor
+
+    from sglang.srt.distributed import tensor_model_parallel_all_gather
+
+    # VisionAttention qkv_backend output is [tokens, local_heads, head_dim].
+    return tensor_model_parallel_all_gather(tensor.contiguous(), dim=1)
+
+
+def _patch_qkv_backend_capture(
+    attn,
+    name: str,
+    capture_tensor,
+    *,
+    tp_size: int,
+    capture_gathered_shards: bool,
+) -> None:
+    backend = getattr(attn, "qkv_backend", None)
+    forward = getattr(backend, "forward", None)
+    if forward is None:
+        return
+
+    def wrapped_forward(*args, **kwargs):
+        out = forward(*args, **kwargs)
+        if torch.is_tensor(out):
+            capture_tensor(
+                name,
+                backend,
+                _all_gather_attention_backend_output(
+                    out,
+                    tp_size=tp_size,
+                    enabled=capture_gathered_shards,
+                ),
+            )
+        return out
+
+    backend.forward = wrapped_forward
+
+
+def _register_block_internal_hooks(blk, index: int, grab_factory) -> None:
+    prefix = f"blk_{index:02d}"
+    for attr in ("norm1", "norm2"):
+        mod = getattr(blk, attr, None)
+        if mod is not None:
+            mod.register_forward_hook(grab_factory(f"{prefix}.{attr}"))
+
+    attn = getattr(blk, "attn", None)
+    if attn is not None:
+        attn.register_forward_hook(grab_factory(f"{prefix}.attn"))
+        for attr in ("qkv_proj", "qkv_backend", "proj"):
+            mod = getattr(attn, attr, None)
+            if mod is not None:
+                mod.register_forward_hook(grab_factory(f"{prefix}.attn.{attr}"))
+
+    mlp = getattr(blk, "mlp", None)
+    if mlp is not None:
+        mlp.register_forward_hook(grab_factory(f"{prefix}.mlp"))
+        for attr in ("linear_fc1", "linear_fc2"):
+            mod = getattr(mlp, attr, None)
+            if mod is not None:
+                mod.register_forward_hook(grab_factory(f"{prefix}.mlp.{attr}"))
+
+
+def _register_merger_internal_hooks(merger, prefix: str, grab_factory) -> None:
+    for attr in ("ln_q", "norm", "linear_fc1", "linear_fc2"):
+        mod = getattr(merger, attr, None)
+        if mod is not None:
+            mod.register_forward_hook(grab_factory(f"{prefix}.{attr}"))
+    mlp = getattr(merger, "mlp", None)
+    if mlp is not None:
+        for i, mod in enumerate(mlp):
+            mod.register_forward_hook(grab_factory(f"{prefix}.mlp.{i}"))
+
+
+def _run_sglang(
+    model_path: str,
+    out_path: str,
+    *,
+    tp_size: int = 1,
+    tp_rank: int = 0,
+    nccl_port: int | None = None,
+    capture_layers: bool = False,
+    capture_block_internals: bool = False,
+    capture_blocks: str | None = None,
+    capture_token_indices: str | None = None,
+    dtype: str = "float16",
+    tp_parity_mode: str = "default",
+    capture_gathered_shards: bool = False,
+) -> None:
     from sglang_omni_v1.model_runner.sglang_encoder_runner import (
         SGLangEncoderRunner,
     )
@@ -123,6 +324,7 @@ def _run_sglang(model_path: str, out_path: str, *, tp_size: int = 1, tp_rank: in
     from sglang_omni_v1.scheduling.messages import IncomingMessage
 
     pixel, grid = _build_real_image_inputs(model_path)
+    final_capture_indices = _parse_index_set(capture_token_indices)
     runner = SGLangEncoderRunner(
         model_path=model_path,
         gpu_id=0,
@@ -131,6 +333,7 @@ def _run_sglang(model_path: str, out_path: str, *, tp_size: int = 1, tp_rank: in
         nccl_port=nccl_port,
         encoder_specs=Qwen3OmniImageEncoderAdapter.encoder_specs,
         dtype=dtype,
+        tp_parity_mode=tp_parity_mode,
     )
 
     # Optional layer-output capture for tp1-vs-tp2 layer-by-layer
@@ -141,23 +344,63 @@ def _run_sglang(model_path: str, out_path: str, *, tp_size: int = 1, tp_rank: in
     # final (N, base*(1+ndeepstack)) used to slice image_embeds +
     # deepstack.
     captures: dict[str, torch.Tensor] = {}
-    if capture_layers:
+    if capture_layers or capture_block_internals:
         visual = runner.model.visual
+        pre_capture_indices = _premerge_indices(
+            final_capture_indices,
+            int(getattr(visual, "spatial_merge_unit", 4)),
+        )
+
+        def _capture_tensor(name: str, mod, t: torch.Tensor) -> None:
+            t = _all_gather_shard_output(
+                name,
+                mod,
+                t,
+                tp_size=tp_size,
+                enabled=capture_gathered_shards,
+            )
+            captures[name] = _slice_capture_tensor(
+                t,
+                final_indices=final_capture_indices,
+                pre_indices=pre_capture_indices,
+            ).detach().cpu()
 
         def _grab(name: str):
-            def hook(_mod, _inp, out):
+            def hook(mod, _inp, out):
                 t = out[0] if isinstance(out, tuple) else out
                 if torch.is_tensor(t):
-                    captures[name] = t.detach().cpu()
+                    _capture_tensor(name, mod, t)
             return hook
 
         if hasattr(visual, "patch_embed"):
             visual.patch_embed.register_forward_hook(_grab("00_patch_embed"))
         if hasattr(visual, "blocks"):
+            selected_blocks = _parse_capture_blocks(
+                capture_blocks, len(visual.blocks)
+            )
             for i, blk in enumerate(visual.blocks):
-                blk.register_forward_hook(_grab(f"blk_{i:02d}"))
+                if capture_layers:
+                    blk.register_forward_hook(_grab(f"blk_{i:02d}"))
+                if capture_block_internals and i in selected_blocks:
+                    _register_block_internal_hooks(blk, i, _grab)
+                    attn = getattr(blk, "attn", None)
+                    if attn is not None:
+                        _patch_qkv_backend_capture(
+                            attn,
+                            f"blk_{i:02d}.attn.qkv_backend",
+                            _capture_tensor,
+                            tp_size=tp_size,
+                            capture_gathered_shards=capture_gathered_shards,
+                        )
         if hasattr(visual, "merger"):
             visual.merger.register_forward_hook(_grab("99_merger"))
+            if capture_block_internals:
+                _register_merger_internal_hooks(visual.merger, "99_merger", _grab)
+        if capture_block_internals and hasattr(visual, "deepstack_merger_list"):
+            for i, merger in enumerate(visual.deepstack_merger_list):
+                prefix = f"deepstack_merger_{i}"
+                merger.register_forward_hook(_grab(prefix))
+                _register_merger_internal_hooks(merger, prefix, _grab)
 
     hf_cfg = runner.model_config.hf_config
     torch_dtype = {"float16": torch.float16, "bfloat16": torch.bfloat16}[dtype]
@@ -189,8 +432,17 @@ def _run_sglang(model_path: str, out_path: str, *, tp_size: int = 1, tp_rank: in
     deepstack = state.get("deepstack_visual_embeds_image")
     if deepstack is not None:
         deepstack = [t.detach().cpu() for t in deepstack]
-    out_dict: dict[str, object] = {"image_embeds": image_embeds, "deepstack": deepstack}
-    if capture_layers:
+    out_dict: dict[str, object] = {
+        "image_embeds": image_embeds,
+        "deepstack": deepstack,
+        "metadata": {
+            "tp_parity_mode": tp_parity_mode,
+            "dtype": dtype,
+            "capture_token_indices": final_capture_indices,
+            "capture_gathered_shards": capture_gathered_shards,
+        },
+    }
+    if capture_layers or capture_block_internals:
         out_dict["layers"] = captures
     with open(out_path, "wb") as f:
         pickle.dump(out_dict, f)
@@ -296,7 +548,28 @@ def main() -> None:
     parser.add_argument("--tp-rank", type=int, default=0)
     parser.add_argument("--nccl-port", type=int, default=None)
     parser.add_argument("--capture-layers", action="store_true")
+    parser.add_argument("--capture-block-internals", action="store_true")
+    parser.add_argument(
+        "--capture-blocks",
+        default=None,
+        help="Comma-separated block indexes/ranges for --capture-block-internals, e.g. 25,26 or 20-26.",
+    )
+    parser.add_argument(
+        "--capture-token-indices",
+        default=None,
+        help="Comma-separated final-token indexes/ranges to keep in layer captures; pre-merger tensors keep the corresponding 2x2 patch tokens.",
+    )
+    parser.add_argument(
+        "--capture-gathered-shards",
+        action="store_true",
+        help="All-gather shard-local Column/QKV/Gate-Up debug captures so they can be compared with tp=1 full-width tensors.",
+    )
     parser.add_argument("--dtype", default="float16", choices=["float16", "bfloat16"])
+    parser.add_argument(
+        "--tp-parity-mode",
+        default="default",
+        choices=["default", "fp32_row_parallel", "fp32_linear"],
+    )
     args = parser.parse_args()
 
     model_path = _resolve_model_path()
@@ -312,7 +585,12 @@ def main() -> None:
             tp_rank=args.tp_rank,
             nccl_port=args.nccl_port,
             capture_layers=args.capture_layers,
+            capture_block_internals=args.capture_block_internals,
+            capture_blocks=args.capture_blocks,
+            capture_token_indices=args.capture_token_indices,
             dtype=args.dtype,
+            tp_parity_mode=args.tp_parity_mode,
+            capture_gathered_shards=args.capture_gathered_shards,
         )
     print(
         f"PARITY_OK backend={args.backend} tp={args.tp_size} rank={args.tp_rank} "

--- a/tests/_encoder_parity_harness.py
+++ b/tests/_encoder_parity_harness.py
@@ -112,7 +112,7 @@ def _run_local(model_path: str, out_path: str) -> None:
         pickle.dump({"image_embeds": image_embeds, "deepstack": deepstack}, f)
 
 
-def _run_sglang(model_path: str, out_path: str, *, tp_size: int = 1, tp_rank: int = 0, nccl_port: int | None = None, capture_layers: bool = False) -> None:
+def _run_sglang(model_path: str, out_path: str, *, tp_size: int = 1, tp_rank: int = 0, nccl_port: int | None = None, capture_layers: bool = False, dtype: str = "float16") -> None:
     from sglang_omni_v1.model_runner.sglang_encoder_runner import (
         SGLangEncoderRunner,
     )
@@ -130,7 +130,7 @@ def _run_sglang(model_path: str, out_path: str, *, tp_size: int = 1, tp_rank: in
         tp_size=tp_size,
         nccl_port=nccl_port,
         encoder_specs=Qwen3OmniImageEncoderAdapter.encoder_specs,
-        dtype="float16",
+        dtype=dtype,
     )
 
     # Optional layer-output capture for tp1-vs-tp2 layer-by-layer
@@ -160,7 +160,8 @@ def _run_sglang(model_path: str, out_path: str, *, tp_size: int = 1, tp_rank: in
             visual.merger.register_forward_hook(_grab("99_merger"))
 
     hf_cfg = runner.model_config.hf_config
-    adapter = Qwen3OmniImageEncoderAdapter(hf_config=hf_cfg, dtype=torch.float16)
+    torch_dtype = {"float16": torch.float16, "bfloat16": torch.bfloat16}[dtype]
+    adapter = Qwen3OmniImageEncoderAdapter(hf_config=hf_cfg, dtype=torch_dtype)
     msg = IncomingMessage(
         request_id="r0",
         type="new_request",
@@ -295,6 +296,7 @@ def main() -> None:
     parser.add_argument("--tp-rank", type=int, default=0)
     parser.add_argument("--nccl-port", type=int, default=None)
     parser.add_argument("--capture-layers", action="store_true")
+    parser.add_argument("--dtype", default="float16", choices=["float16", "bfloat16"])
     args = parser.parse_args()
 
     model_path = _resolve_model_path()
@@ -310,6 +312,7 @@ def main() -> None:
             tp_rank=args.tp_rank,
             nccl_port=args.nccl_port,
             capture_layers=args.capture_layers,
+            dtype=args.dtype,
         )
     print(
         f"PARITY_OK backend={args.backend} tp={args.tp_size} rank={args.tp_rank} "

--- a/tests/_encoder_parity_harness.py
+++ b/tests/_encoder_parity_harness.py
@@ -165,9 +165,101 @@ def _run_sglang(model_path: str, out_path: str, *, tp_size: int = 1, tp_rank: in
         pickle.dump({"image_embeds": image_embeds, "deepstack": deepstack}, f)
 
 
+def _run_bare_sglang(model_path: str, out_path: str) -> None:
+    """Upstream SGLang ``get_model()`` on the full
+    ``Qwen3OmniMoeForConditionalGeneration``, no ``encoder_only``, no
+    ``EncoderModuleContainer``, no fused-shard dispatch logic from us.
+    Then call ``thinker.get_image_feature`` directly.
+
+    Isolates: does our wrapper (partial-load + fused-shard dispatch +
+    init_distributed at tp=1) introduce any numerical drift vs a pure
+    upstream load? Both lanes run at tp_size=1 so TP collectives are
+    identical no-ops.
+    """
+    import torch
+    from sglang.srt.configs.device_config import DeviceConfig
+    from sglang.srt.configs.load_config import LoadConfig
+    from sglang.srt.configs.model_config import ModelConfig
+    from sglang.srt.distributed import (
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+    from sglang.srt.layers.dp_attention import initialize_dp_attention
+    from sglang.srt.model_loader import get_model
+    from sglang.srt.server_args import (
+        ServerArgs, set_global_server_args_for_scheduler,
+    )
+
+    from sglang_omni_v1.proto import StagePayload
+    from sglang_omni_v1.scheduling.messages import IncomingMessage
+    from sglang_omni_v1.models.qwen3_omni.encoder_adapters import (
+        Qwen3OmniImageEncoderAdapter,
+    )
+
+    pixel, grid = _build_real_image_inputs(model_path)
+
+    server_args = ServerArgs(
+        model_path=model_path,
+        trust_remote_code=True,
+        tp_size=1, pp_size=1, base_gpu_id=0,
+        dist_init_addr="127.0.0.1:29577",
+        encoder_only=False,           # bare = full ForConditionalGeneration
+        mm_enable_dp_encoder=False,
+        disable_cuda_graph=True,
+        random_seed=123,
+        dtype="float16",
+        mem_fraction_static=0.9,
+    )
+    set_global_server_args_for_scheduler(server_args)
+
+    init_distributed_environment(
+        world_size=1, rank=0, local_rank=0,
+        distributed_init_method="tcp://127.0.0.1:29577",
+        backend="nccl",
+    )
+    initialize_model_parallel(tensor_model_parallel_size=1)
+
+    model_config = ModelConfig.from_server_args(server_args)
+    initialize_dp_attention(server_args, model_config)
+    load_config = LoadConfig(load_format=server_args.load_format)
+    torch.cuda.set_device(0)
+    device_config = DeviceConfig(device="cuda", gpu_id=0)
+    model = get_model(
+        model_config=model_config,
+        load_config=load_config,
+        device_config=device_config,
+    )
+
+    # Build the MultimodalDataItem exactly like our adapter does.
+    hf_cfg = model_config.hf_config
+    adapter = Qwen3OmniImageEncoderAdapter(hf_config=hf_cfg, dtype=torch.float16)
+    msg = IncomingMessage(
+        request_id="r0",
+        type="new_request",
+        data=StagePayload(
+            request_id="r0", request=None,
+            data={"encoder_inputs": {"image_encoder": {
+                "pixel_values": pixel.to("cuda:0"),
+                "image_grid_thw": grid,
+            }}},
+        ),
+    )
+    plan = adapter.build_batch([msg])
+    items = plan.image_items
+    thinker = model.thinker if hasattr(model, "thinker") else model
+    visual = thinker.visual
+    pixel_values = torch.cat([item.feature for item in items], dim=0).type(visual.dtype)
+    grid = torch.cat([item.image_grid_thw for item in items], dim=0)
+    with torch.no_grad():
+        embeds = visual(pixel_values, grid_thw=grid)
+    image_embeds = embeds.detach().cpu() if torch.is_tensor(embeds) else embeds[0].detach().cpu()
+    with open(out_path, "wb") as f:
+        pickle.dump({"image_embeds": image_embeds, "deepstack": None}, f)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("backend", choices=["local", "sglang"])
+    parser.add_argument("backend", choices=["local", "sglang", "bare_sglang"])
     parser.add_argument("out_path")
     parser.add_argument("--tp-size", type=int, default=1)
     parser.add_argument("--tp-rank", type=int, default=0)
@@ -177,6 +269,8 @@ def main() -> None:
     model_path = _resolve_model_path()
     if args.backend == "local":
         _run_local(model_path, args.out_path)
+    elif args.backend == "bare_sglang":
+        _run_bare_sglang(model_path, args.out_path)
     else:
         _run_sglang(
             model_path,

--- a/tests/parity_compare.py
+++ b/tests/parity_compare.py
@@ -1,51 +1,222 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Compare ``image_embeds`` pickles from the parity harness.
+"""Compare encoder-output pickles from the parity harness.
 
-Reports per-element diff stats, per-token cosine similarity buckets,
-and the strict RFC tolerance verdict (``atol=1e-3 rtol=1e-3`` on fp16).
+The legacy printout still reports strict elementwise allclose numbers, but
+``--tp`` is the production TP-parity gate: it checks direction-preserving
+per-token similarity and coarse outlier counts instead of pretending fp16 TP
+collectives can satisfy bit-style tolerances.
 """
 from __future__ import annotations
 
 import argparse
+import dataclasses
 import pickle
 import sys
 
 import torch
 
 
-def _summarize(L: dict, S: dict, label: str) -> None:
-    le = L[label].to(torch.float32) if not isinstance(L[label], list) else None
-    se = S[label].to(torch.float32) if not isinstance(S[label], list) else None
-    if le is None:
-        return
-    print(f"\n{label}: shape={le.shape}")
-    print(f"  local stats:  abs_max={le.abs().max():.3f} mean={le.mean():.4f} std={le.std():.4f}")
-    print(f"  sglang stats: abs_max={se.abs().max():.3f} mean={se.mean():.4f} std={se.std():.4f}")
+@dataclasses.dataclass(frozen=True)
+class TensorStats:
+    label: str
+    shape: tuple[int, ...]
+    abs_diff_max: float
+    abs_diff_mean: float
+    token_diff_gt_01: int
+    token_diff_gt_1: int
+    cos_min: float
+    cos_mean: float
 
-    abs_diff = (le - se).abs()
-    print(f"  abs diff: max={abs_diff.max().item():.4f} mean={abs_diff.mean().item():.4f}")
-    cos = torch.nn.functional.cosine_similarity(le, se, dim=-1)
-    print(f"  per-token cosine_sim: min={cos.min().item():.4f} mean={cos.mean().item():.4f}")
+
+def _stats_for_tensors(label: str, le: torch.Tensor, re: torch.Tensor) -> TensorStats:
+    abs_diff = (le - re).abs()
+    token_max = abs_diff.flatten(1).max(dim=-1).values
+    cos = torch.nn.functional.cosine_similarity(
+        le.flatten(1), re.flatten(1), dim=-1
+    )
+    return TensorStats(
+        label=label,
+        shape=tuple(le.shape),
+        abs_diff_max=abs_diff.max().item(),
+        abs_diff_mean=abs_diff.mean().item(),
+        token_diff_gt_01=int((token_max > 0.1).sum().item()),
+        token_diff_gt_1=int((token_max > 1.0).sum().item()),
+        cos_min=cos.min().item(),
+        cos_mean=cos.mean().item(),
+    )
+
+
+def _to_float_tensor(value: object) -> torch.Tensor | None:
+    if isinstance(value, list) or not torch.is_tensor(value):
+        return None
+    return value.to(torch.float32)
+
+
+def _summarize(left: dict, right: dict, label: str) -> TensorStats | None:
+    le = _to_float_tensor(left[label])
+    re = _to_float_tensor(right[label])
+    if le is None or re is None:
+        return None
+
+    print(f"\n{label}: shape={tuple(le.shape)}")
+    print(
+        "  left stats:  "
+        f"abs_max={le.abs().max():.3f} mean={le.mean():.4f} std={le.std():.4f}"
+    )
+    print(
+        "  right stats: "
+        f"abs_max={re.abs().max():.3f} mean={re.mean():.4f} std={re.std():.4f}"
+    )
+
+    stats = _stats_for_tensors(label, le, re)
+    abs_diff = (le - re).abs()
+    print(
+        "  abs diff: "
+        f"max={abs_diff.max().item():.4f} mean={abs_diff.mean().item():.4f}"
+    )
+    flat_diff = abs_diff.flatten(1)
+    token_max = flat_diff.max(dim=-1).values
+    quantiles = torch.quantile(
+        token_max,
+        torch.tensor([0.5, 0.9, 0.99, 0.999], dtype=torch.float32),
+    )
+    print(
+        "  per-token max abs diff: "
+        f"p50={quantiles[0].item():.4f} p90={quantiles[1].item():.4f} "
+        f"p99={quantiles[2].item():.4f} p999={quantiles[3].item():.4f} "
+        f">0.1={(token_max > 0.1).sum().item()} "
+        f">1.0={(token_max > 1.0).sum().item()}"
+    )
+
+    cos = torch.nn.functional.cosine_similarity(
+        le.flatten(1), re.flatten(1), dim=-1
+    )
+    print(
+        "  per-token cosine_sim: "
+        f"min={cos.min().item():.6f} mean={cos.mean().item():.6f}"
+    )
+    for lo, hi in [
+        (0.0, 0.9),
+        (0.9, 0.99),
+        (0.99, 0.999),
+        (0.999, 0.9999),
+        (0.9999, 1.0001),
+    ]:
+        count = ((cos >= lo) & (cos < hi)).sum().item()
+        print(f"    cos in [{lo:.4f}, {hi:.4f}): {count}")
 
     for atol, rtol in [(1e-3, 1e-3), (1e-2, 1e-2), (5e-2, 5e-2)]:
-        ok = torch.allclose(le, se, atol=atol, rtol=rtol)
+        ok = torch.allclose(le, re, atol=atol, rtol=rtol)
         marker = "  <-- RFC" if (atol, rtol) == (1e-3, 1e-3) else ""
         print(f"  allclose(atol={atol}, rtol={rtol}): {ok}{marker}")
+
+    return stats
+
+
+def _summarize_layers(left: dict, right: dict, *, top_layers: int) -> None:
+    left_layers = left.get("layers")
+    right_layers = right.get("layers")
+    if not isinstance(left_layers, dict) or not isinstance(right_layers, dict):
+        print("\nlayer summary: no layer captures in one or both inputs")
+        return
+
+    stats = []
+    shape_mismatches = []
+    for key in sorted(set(left_layers) & set(right_layers)):
+        le = _to_float_tensor(left_layers[key])
+        re = _to_float_tensor(right_layers[key])
+        if le is None or re is None:
+            continue
+        if le.shape != re.shape:
+            shape_mismatches.append((key, tuple(le.shape), tuple(re.shape)))
+            continue
+        stats.append(_stats_for_tensors(key, le.flatten(1), re.flatten(1)))
+
+    stats.sort(key=lambda item: item.abs_diff_max, reverse=True)
+    print(f"\nlayer summary: {len(stats)} common captured tensors")
+    print("  label                                     max_abs   mean_abs  >0.1  >1.0  cos_mean  cos_min")
+    for item in stats[:top_layers]:
+        print(
+            f"  {item.label:<40} "
+            f"{item.abs_diff_max:7.4f} "
+            f"{item.abs_diff_mean:9.6f} "
+            f"{item.token_diff_gt_01:5d} "
+            f"{item.token_diff_gt_1:5d} "
+            f"{item.cos_mean:8.6f} "
+            f"{item.cos_min:8.6f}"
+        )
+    if shape_mismatches:
+        print(
+            "\nlayer summary: skipped shape-mismatched shard-local tensors "
+            f"({len(shape_mismatches)})"
+        )
+        for label, left_shape, right_shape in shape_mismatches[:top_layers]:
+            print(f"  {label:<40} left={left_shape} right={right_shape}")
 
 
 def main() -> None:
     p = argparse.ArgumentParser()
-    p.add_argument("local_pkl")
-    p.add_argument("sglang_pkl")
+    p.add_argument("left_pkl")
+    p.add_argument("right_pkl")
+    p.add_argument(
+        "--tp",
+        action="store_true",
+        help="Apply the tp=1 vs tp>1 parity gate.",
+    )
+    p.add_argument("--min-mean-cos", type=float, default=0.999)
+    p.add_argument("--max-tokens-gt-1", type=int, default=0)
+    p.add_argument(
+        "--layers",
+        action="store_true",
+        help="Print a compact max-diff ranking for captured layer tensors.",
+    )
+    p.add_argument("--top-layers", type=int, default=30)
     args = p.parse_args()
 
-    L = pickle.load(open(args.local_pkl, "rb"))
-    S = pickle.load(open(args.sglang_pkl, "rb"))
+    left = pickle.load(open(args.left_pkl, "rb"))
+    right = pickle.load(open(args.right_pkl, "rb"))
 
-    _summarize(L, S, "image_embeds")
-    if L.get("deepstack") and S.get("deepstack"):
-        for i, (lds, sds) in enumerate(zip(L["deepstack"], S["deepstack"])):
-            _summarize({f"ds[{i}]": lds}, {f"ds[{i}]": sds}, f"ds[{i}]")
+    stats: list[TensorStats] = []
+    image_stats = _summarize(left, right, "image_embeds")
+    if image_stats is not None:
+        stats.append(image_stats)
+    if left.get("deepstack") and right.get("deepstack"):
+        for i, (left_ds, right_ds) in enumerate(
+            zip(left["deepstack"], right["deepstack"])
+        ):
+            ds_stats = _summarize(
+                {f"ds[{i}]": left_ds},
+                {f"ds[{i}]": right_ds},
+                f"ds[{i}]",
+            )
+            if ds_stats is not None:
+                stats.append(ds_stats)
+
+    if args.layers:
+        _summarize_layers(left, right, top_layers=args.top_layers)
+
+    if not args.tp:
+        return
+
+    failures = []
+    for item in stats:
+        if item.cos_mean < args.min_mean_cos:
+            failures.append(
+                f"{item.label}: mean cosine {item.cos_mean:.6f} "
+                f"< {args.min_mean_cos:.6f}"
+            )
+        if item.token_diff_gt_1 > args.max_tokens_gt_1:
+            failures.append(
+                f"{item.label}: tokens with max abs diff > 1.0 "
+                f"{item.token_diff_gt_1} > {args.max_tokens_gt_1}"
+            )
+
+    if failures:
+        print("\nTP parity: FAIL")
+        for failure in failures:
+            print(f"  - {failure}")
+        sys.exit(1)
+    print("\nTP parity: PASS")
 
 
 if __name__ == "__main__":

--- a/tests/parity_compare.py
+++ b/tests/parity_compare.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compare ``image_embeds`` pickles from the parity harness.
+
+Reports per-element diff stats, per-token cosine similarity buckets,
+and the strict RFC tolerance verdict (``atol=1e-3 rtol=1e-3`` on fp16).
+"""
+from __future__ import annotations
+
+import argparse
+import pickle
+import sys
+
+import torch
+
+
+def _summarize(L: dict, S: dict, label: str) -> None:
+    le = L[label].to(torch.float32) if not isinstance(L[label], list) else None
+    se = S[label].to(torch.float32) if not isinstance(S[label], list) else None
+    if le is None:
+        return
+    print(f"\n{label}: shape={le.shape}")
+    print(f"  local stats:  abs_max={le.abs().max():.3f} mean={le.mean():.4f} std={le.std():.4f}")
+    print(f"  sglang stats: abs_max={se.abs().max():.3f} mean={se.mean():.4f} std={se.std():.4f}")
+
+    abs_diff = (le - se).abs()
+    print(f"  abs diff: max={abs_diff.max().item():.4f} mean={abs_diff.mean().item():.4f}")
+    cos = torch.nn.functional.cosine_similarity(le, se, dim=-1)
+    print(f"  per-token cosine_sim: min={cos.min().item():.4f} mean={cos.mean().item():.4f}")
+
+    for atol, rtol in [(1e-3, 1e-3), (1e-2, 1e-2), (5e-2, 5e-2)]:
+        ok = torch.allclose(le, se, atol=atol, rtol=rtol)
+        marker = "  <-- RFC" if (atol, rtol) == (1e-3, 1e-3) else ""
+        print(f"  allclose(atol={atol}, rtol={rtol}): {ok}{marker}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("local_pkl")
+    p.add_argument("sglang_pkl")
+    args = p.parse_args()
+
+    L = pickle.load(open(args.local_pkl, "rb"))
+    S = pickle.load(open(args.sglang_pkl, "rb"))
+
+    _summarize(L, S, "image_embeds")
+    if L.get("deepstack") and S.get("deepstack"):
+        for i, (lds, sds) in enumerate(zip(L["deepstack"], S["deepstack"])):
+            _summarize({f"ds[{i}]": lds}, {f"ds[{i}]": sds}, f"ds[{i}]")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/run_tp2_parity.sh
+++ b/tests/run_tp2_parity.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Drive 2 SGLangEncoderWorker ranks on GPUs 3 and 4, share one NCCL bootstrap port.
+set -e
+
+OUT_PATH="${1:?out_path}"
+PORT="${2:-29577}"
+
+# Allocate the port (just trust caller). Each rank's process sees a single
+# physical GPU as cuda:0 (CUDA_VISIBLE_DEVICES remap), exactly like the
+# launcher does for production multi-process TP.
+
+CUDA_VISIBLE_DEVICES=4 SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS=true \
+    PYTHONPATH=/data/sglang-omni \
+    python /data/sglang-omni/tests/_encoder_parity_harness.py \
+        sglang /tmp/parity_tp2_rank1_dummy.pkl \
+        --tp-size 2 --tp-rank 1 --nccl-port "$PORT" \
+        > /tmp/parity_tp2_rank1.log 2>&1 &
+RANK1_PID=$!
+
+CUDA_VISIBLE_DEVICES=3 SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS=true \
+    PYTHONPATH=/data/sglang-omni \
+    python /data/sglang-omni/tests/_encoder_parity_harness.py \
+        sglang "$OUT_PATH" \
+        --tp-size 2 --tp-rank 0 --nccl-port "$PORT" \
+        > /tmp/parity_tp2_rank0.log 2>&1
+RANK0_RC=$?
+
+# Wait for follower to finish (rank 0 emits the pickle; rank 1 just exits).
+wait $RANK1_PID
+RANK1_RC=$?
+
+echo "rank0_rc=$RANK0_RC rank1_rc=$RANK1_RC"
+exit $RANK0_RC

--- a/tests/run_tp2_parity.sh
+++ b/tests/run_tp2_parity.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Drive 2 SGLangEncoderWorker ranks on GPUs 3 and 4, share one NCCL bootstrap port.
+# Drive 2 SGLangEncoderRunner ranks on GPUs 3 and 4, share one NCCL bootstrap port.
 set -e
 
 OUT_PATH="${1:?out_path}"

--- a/tests/run_tp2_parity.sh
+++ b/tests/run_tp2_parity.sh
@@ -4,6 +4,7 @@ set -e
 
 OUT_PATH="${1:?out_path}"
 PORT="${2:-29577}"
+EXTRA_ARGS="${EXTRA_ARGS:-}"
 
 # Allocate the port (just trust caller). Each rank's process sees a single
 # physical GPU as cuda:0 (CUDA_VISIBLE_DEVICES remap), exactly like the
@@ -16,7 +17,7 @@ CUDA_VISIBLE_DEVICES="$RANK1_GPU" SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS=true \
     PYTHONPATH=/data/sglang-omni \
     python /data/sglang-omni/tests/_encoder_parity_harness.py \
         sglang /tmp/parity_tp2_rank1_dummy.pkl \
-        --tp-size 2 --tp-rank 1 --nccl-port "$PORT" \
+        --tp-size 2 --tp-rank 1 --nccl-port "$PORT" $EXTRA_ARGS \
         > /tmp/parity_tp2_rank1.log 2>&1 &
 RANK1_PID=$!
 
@@ -24,7 +25,7 @@ CUDA_VISIBLE_DEVICES="$RANK0_GPU" SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS=true \
     PYTHONPATH=/data/sglang-omni \
     python /data/sglang-omni/tests/_encoder_parity_harness.py \
         sglang "$OUT_PATH" \
-        --tp-size 2 --tp-rank 0 --nccl-port "$PORT" \
+        --tp-size 2 --tp-rank 0 --nccl-port "$PORT" $EXTRA_ARGS \
         > /tmp/parity_tp2_rank0.log 2>&1
 RANK0_RC=$?
 

--- a/tests/run_tp2_parity.sh
+++ b/tests/run_tp2_parity.sh
@@ -9,7 +9,10 @@ PORT="${2:-29577}"
 # physical GPU as cuda:0 (CUDA_VISIBLE_DEVICES remap), exactly like the
 # launcher does for production multi-process TP.
 
-CUDA_VISIBLE_DEVICES=4 SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS=true \
+RANK1_GPU="${RANK1_GPU:-3}"
+RANK0_GPU="${RANK0_GPU:-2}"
+
+CUDA_VISIBLE_DEVICES="$RANK1_GPU" SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS=true \
     PYTHONPATH=/data/sglang-omni \
     python /data/sglang-omni/tests/_encoder_parity_harness.py \
         sglang /tmp/parity_tp2_rank1_dummy.pkl \
@@ -17,7 +20,7 @@ CUDA_VISIBLE_DEVICES=4 SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS=true \
         > /tmp/parity_tp2_rank1.log 2>&1 &
 RANK1_PID=$!
 
-CUDA_VISIBLE_DEVICES=3 SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS=true \
+CUDA_VISIBLE_DEVICES="$RANK0_GPU" SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS=true \
     PYTHONPATH=/data/sglang-omni \
     python /data/sglang-omni/tests/_encoder_parity_harness.py \
         sglang "$OUT_PATH" \

--- a/tests/test_encoder_adapters.py
+++ b/tests/test_encoder_adapters.py
@@ -1,0 +1,375 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Qwen3-Omni encoder adapters.
+
+Covers:
+- ``build_batch`` produces the expected ``BatchPlan`` shape (flat items
+  + spans) for image-only, audio-only, image+video, multi-request mixed
+  batches, and skip-only batches.
+- ``slice_results`` round-trips synthetic raw embeddings back into the
+  per-request ``encoder_outs`` dict shape using the captured spans.
+- The audio mask device-aware fix is preserved (CPU lengths -> CPU
+  arange; GPU lengths -> GPU arange).
+- Image cost function avoids the deepstack double-count trap by reading
+  metadata from the HF ``vision_config`` (not the SGLang wrapper).
+- Empty batches short-circuit — ``run_feature`` returns all-None and
+  never calls into the upstream model.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni_v1.models.qwen3_omni.encoder_adapters import (
+    BatchPlan,
+    Qwen3OmniAudioEncoderAdapter,
+    Qwen3OmniImageEncoderAdapter,
+    RequestSpan,
+    _normalize_audio_request_tensors,
+    _pad_audio_features,
+    _pad_audio_mask,
+)
+from sglang_omni_v1.proto import StagePayload
+from sglang_omni_v1.scheduling.messages import IncomingMessage
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _vision_cfg(*, base_hidden: int = 16, deepstack: int = 1, merge: int = 2):
+    return SimpleNamespace(
+        out_hidden_size=base_hidden,
+        spatial_merge_size=merge,
+        deepstack_visual_indexes=list(range(deepstack)),
+    )
+
+
+def _hf_cfg(*, base_hidden: int = 16, deepstack: int = 1, merge: int = 2):
+    return SimpleNamespace(
+        thinker_config=SimpleNamespace(
+            vision_config=_vision_cfg(
+                base_hidden=base_hidden,
+                deepstack=deepstack,
+                merge=merge,
+            )
+        )
+    )
+
+
+def _payload(rid: str, encoder_inputs: dict | None = None) -> StagePayload:
+    state = {"encoder_inputs": encoder_inputs or {}}
+    return StagePayload(request_id=rid, request=None, data=state)
+
+
+def _msg(rid: str, encoder_inputs: dict | None = None) -> IncomingMessage:
+    return IncomingMessage(
+        request_id=rid,
+        type="new_request",
+        data=_payload(rid, encoder_inputs),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Image / video adapter
+# ---------------------------------------------------------------------------
+
+
+def test_image_adapter_build_batch_image_only():
+    adapter = Qwen3OmniImageEncoderAdapter(
+        hf_config=_hf_cfg(), dtype=torch.float16
+    )
+    grid = torch.tensor([[1, 4, 4]], dtype=torch.long)  # 16 patches
+    pixel = torch.zeros(16, 6)  # 16 patches × 6 channels (dummy)
+    msg = _msg("r0", {
+        "image_encoder": {
+            "pixel_values": pixel,
+            "image_grid_thw": grid,
+        }
+    })
+    plan = adapter.build_batch([msg])
+    assert len(plan.image_items) == 1
+    assert len(plan.video_items) == 0
+    assert len(plan.audio_items) == 0
+    span = plan.spans[0]
+    assert span.image_rows == 1
+    assert span.video_rows == 0
+    # 1 * 4 * 4 // (2*2) = 4
+    assert span.image_token_count == 4
+
+
+def test_image_adapter_build_batch_image_plus_video_same_request():
+    adapter = Qwen3OmniImageEncoderAdapter(
+        hf_config=_hf_cfg(), dtype=torch.float16
+    )
+    image_grid = torch.tensor([[1, 2, 2]], dtype=torch.long)  # 4 patches
+    video_grid = torch.tensor([[1, 2, 2]], dtype=torch.long)
+    msg = _msg("r0", {
+        "image_encoder": {
+            "pixel_values": torch.zeros(4, 6),
+            "image_grid_thw": image_grid,
+            "pixel_values_videos": torch.zeros(4, 6),
+            "video_grid_thw": video_grid,
+        }
+    })
+    plan = adapter.build_batch([msg])
+    assert len(plan.image_items) == 1
+    assert len(plan.video_items) == 1
+    span = plan.spans[0]
+    assert span.image_rows == 1 and span.video_rows == 1
+
+
+def test_image_adapter_build_batch_skip_request():
+    adapter = Qwen3OmniImageEncoderAdapter(
+        hf_config=_hf_cfg(), dtype=torch.float16
+    )
+    msg = _msg("r0", {"image_encoder": {"_skip": True, "_result": {"foo": "bar"}}})
+    plan = adapter.build_batch([msg])
+    assert plan.is_empty
+    assert plan.spans[0].skip_result == {"foo": "bar"}
+    # Empty plan -> run_feature short-circuits without touching the model.
+    raw = adapter.run_feature(model=None, plan=plan)
+    assert raw == {"image": None, "video": None, "audio": None}
+
+
+def test_image_adapter_slice_results_round_trip():
+    """Mock raw encoder output, slice it back into per-request dicts,
+    verify the deepstack split and per-request token counts."""
+    adapter = Qwen3OmniImageEncoderAdapter(
+        hf_config=_hf_cfg(base_hidden=4, deepstack=2),
+        dtype=torch.float16,
+    )
+    # 1 request with 4 image tokens × (4 base + 4*2 deepstack) = 12 hidden dim
+    grid = torch.tensor([[1, 2, 4]], dtype=torch.long)  # 8 patches; 8//4 = 2 tokens
+    pixel = torch.zeros(8, 6)
+    msg = _msg("r0", {
+        "image_encoder": {
+            "pixel_values": pixel,
+            "image_grid_thw": grid,
+        }
+    })
+    plan = adapter.build_batch([msg])
+    # token_count = 1*2*4 // (2*2) = 2
+    assert plan.spans[0].image_token_count == 2
+
+    # Synthesize a raw image embedding shaped (sum_tokens, base * (1 + deepstack))
+    # = (2, 4*3) = (2, 12). Each chunk of 4 channels is one slice.
+    raw_image = torch.arange(2 * 12, dtype=torch.float32).reshape(2, 12)
+    raw = {"image": raw_image, "video": None, "audio": None}
+    out = adapter.slice_results(raw, plan, [msg])
+    assert len(out) == 1
+    payload = out[0]
+    encoder_outs = payload.data["encoder_outs"]["image_encoder"]
+    base = encoder_outs["image_embeds"]
+    deepstack = encoder_outs["deepstack_visual_embeds_image"]
+    assert base.shape == (2, 4)
+    assert isinstance(deepstack, list) and len(deepstack) == 2
+    for ds in deepstack:
+        assert ds.shape == (2, 4)
+    # base + deepstack should reconstruct the original
+    reconstructed = torch.cat([base] + deepstack, dim=-1)
+    assert torch.equal(reconstructed, raw_image)
+
+
+def test_image_adapter_request_cost_uses_base_hidden_not_wrapper():
+    """The deepstack double-count trap: cost function must read
+    ``vision_config.out_hidden_size`` (the *base* hidden), not the
+    SGLang wrapper's already-folded ``out_hidden_size``. Locks the
+    [deepstack double-count trap] note in the RFC."""
+    base_hidden = 4
+    deepstack = 3  # wrapper would otherwise multiply by (1 + 3) = 4
+    adapter = Qwen3OmniImageEncoderAdapter(
+        hf_config=_hf_cfg(base_hidden=base_hidden, deepstack=deepstack),
+        dtype=torch.float16,
+    )
+    # 1 image, 4 patches => 1 token after merge=4
+    grid = torch.tensor([[1, 2, 2]], dtype=torch.long)
+    pixel = torch.zeros(4, 6, dtype=torch.float16)
+    payload = _payload("r0", {
+        "image_encoder": {
+            "pixel_values": pixel,
+            "image_grid_thw": grid,
+        }
+    })
+    cost = adapter.request_cost_fn(payload)
+    # raw bytes = 4*6*2 = 48
+    # tokens = 4 // 4 = 1
+    # output_bytes = 1 * 4 * 2 * (1+3) = 32
+    # cost = (48 + 32) * 5 = 400
+    assert cost == 400
+
+
+def test_image_adapter_skip_request_cost_is_zero():
+    adapter = Qwen3OmniImageEncoderAdapter(
+        hf_config=_hf_cfg(), dtype=torch.float16
+    )
+    payload = _payload("r0", {"image_encoder": {"_skip": True, "_result": {}}})
+    assert adapter.request_cost_fn(payload) == 0
+
+
+# ---------------------------------------------------------------------------
+# Audio adapter
+# ---------------------------------------------------------------------------
+
+
+def test_audio_adapter_build_batch_pads_to_max_time():
+    adapter = Qwen3OmniAudioEncoderAdapter(
+        hf_config=_hf_cfg(), dtype=torch.float16
+    )
+    feat0 = torch.zeros(1, 8, 50)  # 50 time steps
+    feat1 = torch.zeros(1, 8, 80)  # 80 time steps
+    msg0 = _msg("r0", {
+        "audio_encoder": {
+            "input_features": feat0,
+            "audio_feature_lengths": torch.tensor([50], dtype=torch.long),
+        }
+    })
+    msg1 = _msg("r1", {
+        "audio_encoder": {
+            "input_features": feat1,
+            "audio_feature_lengths": torch.tensor([80], dtype=torch.long),
+        }
+    })
+    plan = adapter.build_batch([msg0, msg1])
+    assert len(plan.audio_items) == 2
+    # Both items padded to max_time=80 along the time axis.
+    for item in plan.audio_items:
+        assert item.feature.shape[-1] == 80
+        assert item.feature_attention_mask.shape[-1] == 80
+    # Spans preserve unpadded lengths.
+    assert plan.spans[0].audio_feature_lengths.tolist() == [50]
+    assert plan.spans[1].audio_feature_lengths.tolist() == [80]
+
+
+def test_audio_adapter_slice_results_round_trip():
+    adapter = Qwen3OmniAudioEncoderAdapter(
+        hf_config=_hf_cfg(), dtype=torch.float16
+    )
+    feat = torch.zeros(1, 8, 100)  # 100 -> output_lengths = (
+    # (100 % 100) = 0 -> feat_lengths = (0-1)//2+1 = 0; but real formula:
+    # leave = 0 → feat = (-1)//2 + 1 = 0; output = ((-1)//2 + 1 - 1)//2 + 1 + 1*13 = 14
+    msg = _msg("r0", {
+        "audio_encoder": {
+            "input_features": feat,
+            "audio_feature_lengths": torch.tensor([100], dtype=torch.long),
+        }
+    })
+    plan = adapter.build_batch([msg])
+    out_lens = int(plan.spans[0].audio_output_lengths.sum().item())
+    # _get_feat_extract_output_lengths(100) = 13 in the upstream formula
+    assert out_lens == 13
+    # Synthesize raw audio embedding with shape (out_lens_total, hidden).
+    raw_audio = torch.arange(out_lens * 4, dtype=torch.float32).reshape(out_lens, 4)
+    raw = {"image": None, "video": None, "audio": raw_audio}
+    out = adapter.slice_results(raw, plan, [msg])
+    payload = out[0]
+    enc = payload.data["encoder_outs"]["audio_encoder"]
+    assert torch.equal(enc["audio_embeds"], raw_audio[:out_lens])
+    assert enc["audio_feature_lengths"].tolist() == [100]
+
+
+def test_audio_adapter_skip_request_passes_through_skip_result():
+    adapter = Qwen3OmniAudioEncoderAdapter(
+        hf_config=_hf_cfg(), dtype=torch.float16
+    )
+    msg = _msg("r0", {"audio_encoder": {"_skip": True, "_result": {"foo": "bar"}}})
+    plan = adapter.build_batch([msg])
+    assert plan.is_empty
+    out = adapter.slice_results(
+        {"image": None, "video": None, "audio": None},
+        plan,
+        [msg],
+    )
+    enc = out[0].data["encoder_outs"]["audio_encoder"]
+    assert enc == {"foo": "bar"}
+
+
+def test_audio_adapter_mixed_batch_skip_and_active():
+    adapter = Qwen3OmniAudioEncoderAdapter(
+        hf_config=_hf_cfg(), dtype=torch.float16
+    )
+    skip_msg = _msg("rs", {
+        "audio_encoder": {"_skip": True, "_result": {"skip": True}}
+    })
+    active_msg = _msg("ra", {
+        "audio_encoder": {
+            "input_features": torch.zeros(1, 8, 100),
+            "audio_feature_lengths": torch.tensor([100], dtype=torch.long),
+        }
+    })
+    plan = adapter.build_batch([skip_msg, active_msg])
+    assert len(plan.audio_items) == 1  # only the active request contributes
+    assert plan.spans[0].skip_result is not None
+    assert plan.spans[1].audio_rows == 1
+
+
+# ---------------------------------------------------------------------------
+# Audio mask device-aware fix
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_audio_request_tensors_arange_follows_lengths_device_cpu():
+    """CPU lengths → CPU arange → CPU mask. The local v1 path."""
+    request = SimpleNamespace(model_inputs={
+        "input_features": torch.zeros(1, 8, 50),
+        "audio_feature_lengths": torch.tensor([30], dtype=torch.long),
+        # No feature_attention_mask -> synthesized from lengths
+    })
+    features, mask, lengths = _normalize_audio_request_tensors(request)
+    assert features.device.type == "cpu"
+    assert lengths.device.type == "cpu"
+    assert mask.device.type == "cpu"
+    # First 30 positions are True, rest False
+    assert mask[0, :30].all()
+    assert not mask[0, 30:].any()
+
+
+def test_normalize_audio_request_tensors_arange_follows_lengths_device_no_dtype_mismatch():
+    """If lengths come pre-lifted to GPU (the SGLang Plan B path),
+    arange must be on GPU too — locks the [Audio adapter / mandatory
+    device-aware fix] in the RFC. Here we simulate by promoting lengths
+    to a non-default torch.long-on-cpu tensor and checking that the
+    arange and resulting mask end up on the same device."""
+    cpu_lengths = torch.tensor([20], dtype=torch.long)
+    request = SimpleNamespace(model_inputs={
+        "input_features": torch.zeros(1, 8, 30),
+        "audio_feature_lengths": cpu_lengths,
+    })
+    _, mask, lengths = _normalize_audio_request_tensors(request)
+    assert mask.device == lengths.device
+
+
+def test_pad_audio_features_no_op_when_already_at_target():
+    feat = torch.zeros(1, 8, 50)
+    out = _pad_audio_features(feat, 50)
+    assert out.shape == feat.shape
+
+
+def test_pad_audio_mask_pads_with_false():
+    mask = torch.tensor([[True, True, False]])
+    out = _pad_audio_mask(mask, 5)
+    assert out.shape == (1, 5)
+    assert out[0, 3:].sum() == 0
+
+
+# ---------------------------------------------------------------------------
+# Adapter `is_empty` and short-circuit
+# ---------------------------------------------------------------------------
+
+
+def test_batch_plan_is_empty_when_all_skip():
+    adapter = Qwen3OmniImageEncoderAdapter(
+        hf_config=_hf_cfg(), dtype=torch.float16
+    )
+    msgs = [
+        _msg("r0", {"image_encoder": {"_skip": True, "_result": {}}}),
+        _msg("r1", {"image_encoder": {"_skip": True, "_result": {}}}),
+    ]
+    plan = adapter.build_batch(msgs)
+    assert plan.is_empty
+    raw = adapter.run_feature(model=None, plan=plan)
+    # Verify run_feature did not call into the model (it would have crashed
+    # on model=None if it had).
+    assert raw == {"image": None, "video": None, "audio": None}

--- a/tests/test_encoder_adapters.py
+++ b/tests/test_encoder_adapters.py
@@ -121,6 +121,52 @@ def test_image_adapter_build_batch_image_plus_video_same_request():
     assert span.image_rows == 1 and span.video_rows == 1
 
 
+def test_image_adapter_build_batch_keeps_grid_thw_on_cpu():
+    """Locks the [grid_thw must stay on CPU] contract.
+
+    After ``EncoderScheduler._strip_and_lift`` lifts every payload tensor
+    to ``cuda:0``, the adapter must move ``image_grid_thw`` /
+    ``video_grid_thw`` *back* to CPU before handing items to the upstream
+    model. Upstream ``compute_cu_seqlens_from_grid_numpy`` asserts
+    ``grid_thw.device.type == "cpu"`` (sglang/python/sglang/srt/models/utils.py:154);
+    the v1 SGLang Plan B path discovered this end-to-end in the docs CI
+    run.
+
+    We simulate the post-lift state by feeding a CPU input here (the
+    upstream path is the same — adapter normalizes to CPU regardless of
+    incoming device, so the contract is enforced).
+    """
+    adapter = Qwen3OmniImageEncoderAdapter(
+        hf_config=_hf_cfg(), dtype=torch.float16
+    )
+    grid = torch.tensor([[1, 4, 4]], dtype=torch.long)
+    pixel = torch.zeros(16, 6)
+    msg = _msg("r0", {
+        "image_encoder": {
+            "pixel_values": pixel,
+            "image_grid_thw": grid,
+        }
+    })
+    plan = adapter.build_batch([msg])
+    assert plan.image_items[0].image_grid_thw.device.type == "cpu"
+
+
+def test_video_adapter_build_batch_keeps_grid_thw_on_cpu():
+    adapter = Qwen3OmniImageEncoderAdapter(
+        hf_config=_hf_cfg(), dtype=torch.float16
+    )
+    grid = torch.tensor([[1, 2, 2]], dtype=torch.long)
+    pixel = torch.zeros(4, 6)
+    msg = _msg("r0", {
+        "image_encoder": {
+            "pixel_values_videos": pixel,
+            "video_grid_thw": grid,
+        }
+    })
+    plan = adapter.build_batch([msg])
+    assert plan.video_items[0].video_grid_thw.device.type == "cpu"
+
+
 def test_image_adapter_build_batch_skip_request():
     adapter = Qwen3OmniImageEncoderAdapter(
         hf_config=_hf_cfg(), dtype=torch.float16

--- a/tests/test_encoder_module_container.py
+++ b/tests/test_encoder_module_container.py
@@ -1,0 +1,385 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``EncoderModuleSpec`` + ``EncoderModuleContainer``.
+
+The container is the load-bearing piece that prevents the encoder
+worker from loading LLM / talker / unrelated-encoder weights onto an
+encoder GPU. These tests exercise:
+
+- Spec validation (unique names, non-empty list).
+- Prefix-filter behavior on ``load_weights``: image-stage container
+  drops audio / language / talker / unrelated-encoder keys without
+  allocating a destination.
+- Audio-stage container symmetrically drops vision / language / talker
+  keys.
+- Checkpoint-rewrite ordering applies left-to-right.
+- Missing-prefix and missing-param keys are silently skipped, not
+  errors (mirrors upstream loader's tolerant behavior).
+
+We use tiny synthetic ``nn.Linear`` submodules so the tests run on CPU
+in well under a second — no Qwen3-Omni weights involved.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from sglang_omni_v1.model_runner.sglang_encoder_worker import EncoderModuleContainer
+from sglang_omni_v1.models.qwen3_omni.encoder_adapters import EncoderModuleSpec
+
+
+def _make_visual_like_module():
+    """Stand-in submodule that mirrors a tiny piece of the visual encoder.
+
+    Two Linear params named ``proj.weight`` / ``proj.bias`` so a checkpoint
+    key like ``model.visual.proj.weight`` flows through the rewrite
+    chain into ``visual.proj.weight``.
+    """
+    m = nn.Module()
+    m.proj = nn.Linear(4, 4, bias=True)
+    return m
+
+
+def _make_audio_like_module():
+    m = nn.Module()
+    m.encoder = nn.Linear(4, 4, bias=True)
+    return m
+
+
+VISUAL_SPEC = EncoderModuleSpec(
+    name="visual",
+    build_module=lambda hf, qc: _make_visual_like_module(),
+    checkpoint_prefixes=("model.visual.", "thinker.visual.", "visual."),
+    checkpoint_rewrites=(
+        ("model.visual.", "visual."),
+        ("thinker.visual.", "visual."),
+    ),
+)
+
+AUDIO_SPEC = EncoderModuleSpec(
+    name="audio_tower",
+    build_module=lambda hf, qc: _make_audio_like_module(),
+    checkpoint_prefixes=("audio_tower.", "thinker.audio_tower."),
+    checkpoint_rewrites=(("thinker.audio_tower.", "audio_tower."),),
+)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_container_builds_only_declared_submodules():
+    container = EncoderModuleContainer(
+        hf_config=None,
+        encoder_specs=(VISUAL_SPEC,),
+        quant_config=None,
+    )
+    children = dict(container.named_children())
+    assert "visual" in children
+    assert "audio_tower" not in children
+
+
+def test_container_rejects_empty_spec_list():
+    with pytest.raises(ValueError, match="at least one EncoderModuleSpec"):
+        EncoderModuleContainer(
+            hf_config=None,
+            encoder_specs=(),
+            quant_config=None,
+        )
+
+
+def test_container_rejects_duplicate_spec_names():
+    dup = EncoderModuleSpec(
+        name="visual",
+        build_module=lambda hf, qc: _make_audio_like_module(),
+        checkpoint_prefixes=("audio_tower.",),
+    )
+    with pytest.raises(ValueError, match="must be unique"):
+        EncoderModuleContainer(
+            hf_config=None,
+            encoder_specs=(VISUAL_SPEC, dup),
+            quant_config=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Prefix filtering — the load-bearing test for "no thinker weights leak"
+# ---------------------------------------------------------------------------
+
+
+def _full_qwen3_omni_checkpoint_keys():
+    """A representative slice of what a real checkpoint stream contains.
+
+    Includes visual + audio + language + talker + unrelated-encoder
+    prefixes. The image-stage container must accept ONLY visual; the
+    audio-stage container must accept ONLY audio.
+    """
+    return [
+        # Visual
+        ("model.visual.proj.weight", torch.randn(4, 4)),
+        ("model.visual.proj.bias", torch.randn(4)),
+        ("thinker.visual.proj.weight", torch.randn(4, 4)),  # legacy key form
+        # Audio
+        ("audio_tower.encoder.weight", torch.randn(4, 4)),
+        ("audio_tower.encoder.bias", torch.randn(4)),
+        ("thinker.audio_tower.encoder.weight", torch.randn(4, 4)),
+        # Language model — must NEVER allocate on encoder GPU
+        ("thinker.model.layers.0.self_attn.q_proj.weight", torch.randn(4, 4)),
+        ("thinker.model.layers.0.mlp.experts.0.w1.weight", torch.randn(4, 4)),
+        ("thinker.lm_head.weight", torch.randn(4, 4)),
+        # Talker — must NEVER allocate on encoder GPU
+        ("talker.model.layers.0.self_attn.q_proj.weight", torch.randn(4, 4)),
+        ("talker.lm_head.weight", torch.randn(4, 4)),
+        # Code2wav / vocoder / random unrelated keys
+        ("code2wav.decoder.0.weight", torch.randn(4, 4)),
+    ]
+
+
+def test_image_stage_container_loads_only_visual_weights():
+    """Locks: image stage MUST NOT allocate audio/LLM/talker tensors."""
+    container = EncoderModuleContainer(
+        hf_config=None,
+        encoder_specs=(VISUAL_SPEC,),
+        quant_config=None,
+    )
+
+    # Capture which params the loader actually wrote to.
+    original_params = {n: p.detach().clone() for n, p in container.named_parameters()}
+
+    container.load_weights(_full_qwen3_omni_checkpoint_keys())
+
+    new_params = dict(container.named_parameters())
+    # Only visual.proj.weight + visual.proj.bias should exist on this container.
+    param_names = set(new_params)
+    assert param_names == {"visual.proj.weight", "visual.proj.bias"}, param_names
+
+    # And those got written to (different from random init).
+    for name in param_names:
+        # The checkpoint stream contained two competing keys for proj.weight
+        # (model.visual and thinker.visual). The last applied wins. Either
+        # way the value should differ from the random init.
+        assert not torch.equal(new_params[name], original_params[name]), name
+
+
+def test_audio_stage_container_loads_only_audio_weights():
+    container = EncoderModuleContainer(
+        hf_config=None,
+        encoder_specs=(AUDIO_SPEC,),
+        quant_config=None,
+    )
+
+    container.load_weights(_full_qwen3_omni_checkpoint_keys())
+
+    param_names = set(dict(container.named_parameters()))
+    assert param_names == {"audio_tower.encoder.weight", "audio_tower.encoder.bias"}, param_names
+
+
+def test_container_skips_unmatched_prefix_silently():
+    """Mirrors upstream loader's tolerant behavior: unknown keys do not
+    raise (some checkpoints carry tied-embedding shadows, optimizer
+    state, etc.); the container just drops them."""
+    container = EncoderModuleContainer(
+        hf_config=None,
+        encoder_specs=(VISUAL_SPEC,),
+        quant_config=None,
+    )
+
+    weights = [
+        ("totally.unrelated.tensor", torch.randn(4, 4)),
+        ("optimizer.state.0", torch.randn(4)),
+    ]
+    # Should not raise.
+    container.load_weights(weights)
+
+
+def test_checkpoint_rewrites_apply_in_order():
+    """Multiple rewrites apply left-to-right via str.replace."""
+    spec = EncoderModuleSpec(
+        name="visual",
+        build_module=lambda hf, qc: _make_visual_like_module(),
+        checkpoint_prefixes=("model.visual.",),
+        checkpoint_rewrites=(
+            ("model.visual.", "visual."),
+            # Second rewrite that happens to pattern-match after the first:
+            # rename "proj.bias" -> "proj.bias" (no-op, just exercise ordering).
+            ("proj.bias", "proj.bias"),
+        ),
+    )
+    container = EncoderModuleContainer(
+        hf_config=None,
+        encoder_specs=(spec,),
+        quant_config=None,
+    )
+    weights = [("model.visual.proj.weight", torch.full((4, 4), 7.0))]
+    container.load_weights(weights)
+    # After rewrite "model.visual.proj.weight" → "visual.proj.weight",
+    # which IS a real param, so it gets written.
+    assert torch.allclose(
+        dict(container.named_parameters())["visual.proj.weight"],
+        torch.full((4, 4), 7.0),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Production specs sanity
+# ---------------------------------------------------------------------------
+
+
+def test_qwen3_omni_visual_spec_prefix_set():
+    """Lock the production visual spec accepts the three known forms.
+
+    Production checkpoints from different SGLang / HF versions place
+    visual weights under ``model.visual.``, ``thinker.visual.``, or
+    plain ``visual.``. Any drift here means the loader silently skips
+    the visual weights and the encoder runs random-init.
+    """
+    from sglang_omni_v1.models.qwen3_omni.encoder_adapters import (
+        QWEN3_OMNI_VISUAL_SPEC,
+    )
+
+    assert QWEN3_OMNI_VISUAL_SPEC.name == "visual"
+    assert "model.visual." in QWEN3_OMNI_VISUAL_SPEC.checkpoint_prefixes
+    assert "thinker.visual." in QWEN3_OMNI_VISUAL_SPEC.checkpoint_prefixes
+    assert "visual." in QWEN3_OMNI_VISUAL_SPEC.checkpoint_prefixes
+
+
+def test_qwen3_omni_audio_spec_prefix_set():
+    from sglang_omni_v1.models.qwen3_omni.encoder_adapters import (
+        QWEN3_OMNI_AUDIO_SPEC,
+    )
+
+    assert QWEN3_OMNI_AUDIO_SPEC.name == "audio_tower"
+    assert "audio_tower." in QWEN3_OMNI_AUDIO_SPEC.checkpoint_prefixes
+    assert "thinker.audio_tower." in QWEN3_OMNI_AUDIO_SPEC.checkpoint_prefixes
+
+
+def test_image_adapter_advertises_only_visual_spec():
+    from sglang_omni_v1.models.qwen3_omni.encoder_adapters import (
+        QWEN3_OMNI_VISUAL_SPEC,
+        Qwen3OmniImageEncoderAdapter,
+    )
+
+    specs = Qwen3OmniImageEncoderAdapter.encoder_specs
+    assert len(specs) == 1
+    assert specs[0] is QWEN3_OMNI_VISUAL_SPEC
+
+
+def test_audio_adapter_advertises_only_audio_spec():
+    from sglang_omni_v1.models.qwen3_omni.encoder_adapters import (
+        QWEN3_OMNI_AUDIO_SPEC,
+        Qwen3OmniAudioEncoderAdapter,
+    )
+
+    specs = Qwen3OmniAudioEncoderAdapter.encoder_specs
+    assert len(specs) == 1
+    assert specs[0] is QWEN3_OMNI_AUDIO_SPEC
+
+
+# ---------------------------------------------------------------------------
+# Fused-shard dispatch — locks the audio NaN bug found end-to-end
+# ---------------------------------------------------------------------------
+
+
+class _FusedQKVLinear(nn.Module):
+    """Tiny stand-in for QKVParallelLinear with a shard-aware weight_loader.
+
+    Mirrors the real shape: ``qkv_proj.weight`` is the param name (i.e.
+    ``self.weight`` here), and the loader receives ``shard_id`` so it
+    knows which slice of the fused tensor to write to.
+    """
+    def __init__(self):
+        super().__init__()
+        # Total fused dim 12 = 3*4 (q + k + v shards of 4 each).
+        self.weight = nn.Parameter(torch.zeros(12, 4))
+
+        def _shard_loader(param, weight, shard_id):
+            offset = {"q": 0, "k": 4, "v": 8}[shard_id]
+            param.data[offset:offset + 4].copy_(weight)
+
+        self.weight.weight_loader = _shard_loader
+
+
+def _make_audio_with_fused_qkv():
+    """Stand-in audio module with one fused-QKV self_attn block."""
+    m = nn.Module()
+    m.self_attn = nn.Module()
+    m.self_attn.qkv_proj = _FusedQKVLinear()
+    return m
+
+
+def test_audio_stage_fuses_qkv_via_stacked_params_mapping():
+    """Locks the fused-shard contract.
+
+    The real Qwen3-Omni audio checkpoint has 192 q_proj/k_proj/v_proj
+    keys per audio attention layer that must be fused into qkv_proj
+    via ``weight_loader(param, weight, shard_id)``. Pre-fix, my naive
+    container dropped those keys → audio attention layers ran with
+    random init → NaN in the output → CUDA assert in multinomial
+    sampling downstream. This test fails fast if the dispatch
+    regresses.
+    """
+    spec = EncoderModuleSpec(
+        name="audio_tower",
+        build_module=lambda hf, qc: _make_audio_with_fused_qkv(),
+        checkpoint_prefixes=("audio_tower.",),
+        stacked_params_mapping=(
+            (".self_attn.qkv_proj", ".self_attn.q_proj", "q"),
+            (".self_attn.qkv_proj", ".self_attn.k_proj", "k"),
+            (".self_attn.qkv_proj", ".self_attn.v_proj", "v"),
+        ),
+    )
+    container = EncoderModuleContainer(
+        hf_config=None, encoder_specs=(spec,), quant_config=None,
+    )
+
+    # Synthesize one (shard, value) per slice so we can verify each
+    # ended up in the right place.
+    q_w = torch.full((4, 4), 1.0)
+    k_w = torch.full((4, 4), 2.0)
+    v_w = torch.full((4, 4), 3.0)
+    container.load_weights([
+        ("audio_tower.self_attn.q_proj.weight", q_w),
+        ("audio_tower.self_attn.k_proj.weight", k_w),
+        ("audio_tower.self_attn.v_proj.weight", v_w),
+    ])
+
+    fused = dict(container.named_parameters())["audio_tower.self_attn.qkv_proj.weight"]
+    assert torch.allclose(fused[0:4], q_w)
+    assert torch.allclose(fused[4:8], k_w)
+    assert torch.allclose(fused[8:12], v_w)
+
+
+def test_visual_load_weights_delegated_to_submodule():
+    """When a submodule has its own ``load_weights``, the container
+    must delegate to it (the visual encoder's own loader knows how to
+    fuse its own attention shards). The container must NOT also try
+    to apply ``stacked_params_mapping`` for that submodule."""
+    calls = []
+
+    class _ModuleWithLoadWeights(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.proj = nn.Linear(4, 4)
+
+        def load_weights(self, weights):
+            for name, w in weights:
+                calls.append(name)
+
+    spec = EncoderModuleSpec(
+        name="visual",
+        build_module=lambda hf, qc: _ModuleWithLoadWeights(),
+        checkpoint_prefixes=("visual.",),
+        # Stacked mapping should be ignored because the submodule
+        # has its own load_weights.
+        stacked_params_mapping=((".attn.qkv_proj", ".attn.q_proj", "q"),),
+    )
+    container = EncoderModuleContainer(
+        hf_config=None, encoder_specs=(spec,), quant_config=None,
+    )
+    container.load_weights([
+        ("visual.attn.q_proj.weight", torch.zeros(4, 4)),
+        ("visual.proj.weight", torch.zeros(4, 4)),
+    ])
+    # The submodule sees relative names (without the leading "visual.").
+    assert calls == ["attn.q_proj.weight", "proj.weight"]

--- a/tests/test_encoder_module_container.py
+++ b/tests/test_encoder_module_container.py
@@ -2,7 +2,7 @@
 """Unit tests for ``EncoderModuleSpec`` + ``EncoderModuleContainer``.
 
 The container is the load-bearing piece that prevents the encoder
-worker from loading LLM / talker / unrelated-encoder weights onto an
+runner from loading LLM / talker / unrelated-encoder weights onto an
 encoder GPU. These tests exercise:
 
 - Spec validation (unique names, non-empty list).
@@ -24,7 +24,7 @@ import pytest
 import torch
 import torch.nn as nn
 
-from sglang_omni_v1.model_runner.sglang_encoder_worker import EncoderModuleContainer
+from sglang_omni_v1.model_runner.sglang_encoder_runner import EncoderModuleContainer
 from sglang_omni_v1.models.qwen3_omni.encoder_adapters import EncoderModuleSpec
 
 

--- a/tests/test_encoder_runner_fail_all.py
+++ b/tests/test_encoder_runner_fail_all.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the fatal-forward fail-all-active plumbing.
+
+Locks RFC v2's [Fatal forward failures require coordinator fail-all
+plumbing] section: when a TP child exits non-zero,
+``MultiProcessPipelineRunner._monitor_children`` must fail every
+active Coordinator future / stream queue with a non-empty error
+*before* tearing down the rest, otherwise outstanding HTTP requests
+hang forever after the TP group is killed.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from sglang_omni_v1.pipeline.coordinator import Coordinator
+from sglang_omni_v1.proto import (
+    CompleteMessage,
+    RequestInfo,
+    RequestState,
+    StreamMessage,
+)
+
+
+@pytest.fixture
+def coordinator():
+    """Build a minimal Coordinator without starting its ZMQ control plane."""
+    coord = Coordinator(
+        completion_endpoint="ipc:///tmp/test_completion.sock",
+        abort_endpoint="ipc:///tmp/test_abort.sock",
+        entry_stage="x",
+    )
+    return coord
+
+
+@pytest.mark.asyncio
+async def test_fail_all_active_fails_completion_futures(coordinator):
+    loop = asyncio.get_running_loop()
+    futures = {}
+    for rid in ("r0", "r1", "r2"):
+        f = loop.create_future()
+        coordinator._completion_futures[rid] = f
+        coordinator._requests[rid] = RequestInfo(
+            request_id=rid, state=RequestState.RUNNING, current_stage="x"
+        )
+        futures[rid] = f
+
+    coordinator.fail_all_active("stage group 'thinker' died: rank0 exit=1")
+
+    for rid, f in futures.items():
+        assert f.done(), f"future for {rid} not resolved"
+        with pytest.raises(RuntimeError, match="stage group 'thinker' died"):
+            f.result()
+
+
+@pytest.mark.asyncio
+async def test_fail_all_active_pushes_complete_to_stream_queues(coordinator):
+    loop = asyncio.get_running_loop()
+    queues = {}
+    for rid in ("s0", "s1"):
+        q: asyncio.Queue = asyncio.Queue()
+        coordinator._stream_queues[rid] = q
+        coordinator._requests[rid] = RequestInfo(
+            request_id=rid, state=RequestState.RUNNING, current_stage="x"
+        )
+        queues[rid] = q
+
+    coordinator.fail_all_active("stage group died")
+
+    for rid, q in queues.items():
+        msg = q.get_nowait()
+        assert isinstance(msg, CompleteMessage)
+        assert msg.request_id == rid
+        assert msg.success is False
+        assert msg.error  # non-empty
+
+
+@pytest.mark.asyncio
+async def test_fail_all_active_uses_default_error_when_empty(coordinator):
+    loop = asyncio.get_running_loop()
+    f = loop.create_future()
+    coordinator._completion_futures["r0"] = f
+    coordinator._requests["r0"] = RequestInfo(
+        request_id="r0", state=RequestState.RUNNING, current_stage="x"
+    )
+
+    # Empty error string must fall back to a non-empty default.
+    coordinator.fail_all_active("")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        f.result()
+    assert str(exc_info.value)  # not empty
+
+
+@pytest.mark.asyncio
+async def test_fail_all_active_marks_request_state_failed(coordinator):
+    loop = asyncio.get_running_loop()
+    f = loop.create_future()
+    coordinator._completion_futures["r0"] = f
+    coordinator._requests["r0"] = RequestInfo(
+        request_id="r0", state=RequestState.RUNNING, current_stage="x"
+    )
+    # Pre-completed request should NOT be re-marked.
+    coordinator._requests["r1"] = RequestInfo(
+        request_id="r1", state=RequestState.COMPLETED, current_stage="x"
+    )
+
+    coordinator.fail_all_active("die")
+
+    assert coordinator._requests["r0"].state == RequestState.FAILED
+    assert coordinator._requests["r1"].state == RequestState.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_fail_all_active_idempotent_for_already_done_future(coordinator):
+    """Calling fail_all_active twice must not raise."""
+    loop = asyncio.get_running_loop()
+    f = loop.create_future()
+    coordinator._completion_futures["r0"] = f
+    coordinator._requests["r0"] = RequestInfo(
+        request_id="r0", state=RequestState.RUNNING, current_stage="x"
+    )
+    coordinator.fail_all_active("first")
+    # Second call: future has been popped; the call should still be safe.
+    coordinator.fail_all_active("second")  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_mp_runner_monitor_calls_fail_all_active_on_dead_child():
+    """Locks the wiring in MultiProcessPipelineRunner._monitor_children.
+
+    We swap out _coordinator with a stub that records fail_all_active
+    calls, fake one StageGroup to be `any_dead`, and let the monitor
+    loop fire once.
+    """
+    from sglang_omni_v1.pipeline.mp_runner import MultiProcessPipelineRunner
+
+    runner = MultiProcessPipelineRunner.__new__(MultiProcessPipelineRunner)
+    runner._started = True
+
+    fake_coord = MagicMock()
+    fake_coord.shutdown_stages = AsyncMock()
+    runner._coordinator = fake_coord
+
+    dead_group = SimpleNamespace(
+        stage_name="image_encoder",
+        any_dead=lambda: True,
+        dead_summary=lambda: "rank0 exit=1",
+        tp_size=2,
+    )
+    runner._groups = [dead_group]
+    runner._monitor_task = None
+    runner._completion_task = None
+
+    # stop() awaits coordinator.stop() and shutdowns groups; stub them.
+    async def _noop_stop():
+        runner._started = False
+
+    runner.stop = _noop_stop  # type: ignore[assignment]
+
+    await runner._monitor_children()
+
+    fake_coord.fail_all_active.assert_called_once()
+    msg = fake_coord.fail_all_active.call_args.args[0]
+    assert "image_encoder" in msg
+    assert "rank0 exit=1" in msg

--- a/tests/test_encoder_scheduler_loop.py
+++ b/tests/test_encoder_scheduler_loop.py
@@ -103,18 +103,41 @@ def test_loop_emits_one_result_per_request_at_tp_size_1():
     assert sorted(o.request_id for o in out) == ["r0", "r1"]
 
 
-def test_loop_emits_error_on_forward_failure_at_tp_size_1():
-    """Forward raises → entry rank emits one error per drained request."""
+def test_loop_forward_failure_is_fatal_even_at_tp_size_1():
+    """Locks the [Fatal forward] domain: forward errors are fatal, not recoverable.
+
+    Under RFC v2, ``encode_batch`` failures cannot recover with a CPU
+    gather because peers may be in NCCL. The contract holds at
+    ``tp_size=1`` too — uniformity of the rule matters more than the
+    short-circuit, and a tp_size=1 worker is still inside upstream
+    parallel-layer code paths.
+
+    We monkey-patch ``_fatal_tp_forward_error`` so the test process
+    survives — in production the rank exits non-zero and the runner
+    fails outstanding Coordinator futures.
+    """
     sch = EncoderScheduler(_FakeWorker(), _CrashingForwardAdapter())
+    fatal_calls = []
+
+    def _capture_fatal(exc):
+        fatal_calls.append(exc)
+        sch._running = False  # exit the scheduler loop
+
+    sch._fatal_tp_forward_error = _capture_fatal
     sch.inbox.put(_mk_msg("r0"))
-    sch.inbox.put(_mk_msg("r1"))
-    _run_until_outbox(sch, expected=2)
-    out = _drain_outbox(sch)
-    assert all(o.type == "error" for o in out)
-    assert sorted(o.request_id for o in out) == ["r0", "r1"]
-    for o in out:
-        assert isinstance(o.data, RuntimeError)
-        assert "forward boom" in str(o.data)
+
+    t = threading.Thread(target=sch.start, daemon=True)
+    t.start()
+    deadline = time.monotonic() + 5.0
+    while not fatal_calls and time.monotonic() < deadline:
+        time.sleep(0.01)
+    sch.stop()
+    t.join(timeout=2.0)
+
+    assert len(fatal_calls) == 1
+    assert "forward boom" in str(fatal_calls[0])
+    # Crucially: NO per-request error emission for a forward fault.
+    assert sch.outbox.qsize() == 0
 
 
 def test_loop_drops_aborted_request_results():
@@ -157,3 +180,111 @@ def test_loop_recovers_from_recv_error_and_continues():
     by_id = {o.request_id: o for o in out}
     assert by_id["r0"].type == "error"
     assert by_id["r1"].type == "result"
+
+
+# ---------------------------------------------------------------------------
+# RFC v2: three-domain error boundary contracts
+# ---------------------------------------------------------------------------
+
+
+class _BuildBatchOnceFailingAdapter(_PassthroughAdapter):
+    """Adapter whose build_batch raises on the first call only.
+
+    Used to exercise the **recoverable pre-forward** error domain
+    (build_batch failure → CPU-gather fan-out → per-request error,
+    scheduler proceeds to the next iteration).
+    """
+
+    def __init__(self):
+        self.calls = 0
+        self.encode_calls = 0
+
+    def build_batch(self, messages):
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("first build_batch boom")
+        return super().build_batch(messages)
+
+    def run_feature(self, model, plan):
+        self.encode_calls += 1
+        return super().run_feature(model, plan)
+
+
+def test_loop_pre_forward_build_error_recovery():
+    """Locks the [Recoverable pre-forward] domain.
+
+    A ``build_batch`` failure must:
+    - never let ``encode_batch`` run for that batch;
+    - emit one ``OutgoingMessage(type="error")`` per drained request;
+    - leave the scheduler alive for the next iteration.
+    """
+    adapter = _BuildBatchOnceFailingAdapter()
+    # max_batch_size=1 + zero wait so each request lands in its own
+    # iteration — otherwise the failed iteration would consume both.
+    sch = EncoderScheduler(
+        _FakeWorker(),
+        adapter,
+        max_batch_size=1,
+        max_batch_wait_ms=0,
+    )
+    sch.inbox.put(_mk_msg("r0"))
+    sch.inbox.put(_mk_msg("r1"))
+    _run_until_outbox(sch, expected=2)
+    out = _drain_outbox(sch)
+    by_id = {o.request_id: o for o in out}
+    assert by_id["r0"].type == "error"
+    assert by_id["r1"].type == "result"
+    # encode_batch was NOT called for the failed batch (build_batch
+    # never returned a plan), but it WAS called for the recovered one.
+    assert adapter.encode_calls == 1
+
+
+class _CrashingForwardWorker:
+    """Worker whose encode_batch raises — must trigger the fatal path."""
+    def __init__(self):
+        self.tp_size = 1
+        self.tp_rank = 0
+        self.is_entry_rank = True
+        self.device = torch.device("cpu")
+        self.tp_group = None
+
+    def encode_batch(self, plan):
+        raise RuntimeError("fatal forward boom inside NCCL")
+
+
+def test_loop_fatal_tp_forward_fault_calls_fatal_handler():
+    """Locks the [Fatal forward] domain.
+
+    A rank-local exception inside ``encode_batch`` must invoke
+    :meth:`_fatal_tp_forward_error` rather than emit per-request errors,
+    because peer ranks may still be blocked in NCCL.
+
+    We monkey-patch ``_fatal_tp_forward_error`` so the test process
+    survives — in production it calls ``os._exit(1)`` so
+    ``MultiProcessPipelineRunner`` can tear down the TP group.
+    """
+    sch = EncoderScheduler(_CrashingForwardWorker(), _PassthroughAdapter())
+    fatal_calls = []
+
+    def _capture_fatal(exc):
+        fatal_calls.append(exc)
+        sch._running = False  # exit the scheduler loop instead of os._exit
+
+    sch._fatal_tp_forward_error = _capture_fatal
+    sch.inbox.put(_mk_msg("r0"))
+
+    t = threading.Thread(target=sch.start, daemon=True)
+    t.start()
+    deadline = time.monotonic() + 5.0
+    while not fatal_calls and time.monotonic() < deadline:
+        time.sleep(0.01)
+    sch.stop()
+    t.join(timeout=2.0)
+
+    assert len(fatal_calls) == 1
+    assert isinstance(fatal_calls[0], RuntimeError)
+    assert "fatal forward boom" in str(fatal_calls[0])
+
+    # The fatal path must NOT have emitted a request-level error: that
+    # would falsely promise recoverability for a TP-collective fault.
+    assert sch.outbox.qsize() == 0

--- a/tests/test_encoder_scheduler_loop.py
+++ b/tests/test_encoder_scheduler_loop.py
@@ -109,7 +109,7 @@ def test_loop_forward_failure_is_fatal_even_at_tp_size_1():
     Under RFC v2, ``encode_batch`` failures cannot recover with a CPU
     gather because peers may be in NCCL. The contract holds at
     ``tp_size=1`` too — uniformity of the rule matters more than the
-    short-circuit, and a tp_size=1 worker is still inside upstream
+    short-circuit, and a tp_size=1 runner is still inside upstream
     parallel-layer code paths.
 
     We monkey-patch ``_fatal_tp_forward_error`` so the test process
@@ -240,7 +240,7 @@ def test_loop_pre_forward_build_error_recovery():
 
 
 class _CrashingForwardWorker:
-    """Worker whose encode_batch raises — must trigger the fatal path."""
+    """Runner whose encode_batch raises — must trigger the fatal path."""
     def __init__(self):
         self.tp_size = 1
         self.tp_rank = 0

--- a/tests/test_encoder_scheduler_loop.py
+++ b/tests/test_encoder_scheduler_loop.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end loop tests for :class:`EncoderScheduler`.
+
+Drives the scheduler loop from its public ``start()`` entry point with
+mocked TP collectives, covering the per-iteration error boundary and
+the request-level error emission against drained messages.
+"""
+from __future__ import annotations
+
+import queue as _queue_mod
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from sglang_omni_v1.proto import StagePayload
+from sglang_omni_v1.scheduling.encoder_scheduler import EncoderScheduler
+from sglang_omni_v1.scheduling.messages import IncomingMessage
+
+
+def _mk_msg(rid: str, data: dict | None = None) -> IncomingMessage:
+    return IncomingMessage(
+        request_id=rid,
+        type="new_request",
+        data=StagePayload(request_id=rid, request=None, data=data or {}),
+    )
+
+
+class _PassthroughAdapter:
+    stage_name = "image_encoder"
+
+    def build_batch(self, messages):
+        return SimpleNamespace(
+            adapter=self, image_items=[], video_items=[], audio_items=[],
+            spans=[], is_empty=True,
+        )
+
+    def run_feature(self, model, plan):
+        return {"image": None, "video": None, "audio": None}
+
+    def slice_results(self, raw, plan, messages):
+        return [
+            StagePayload(request_id=m.request_id, request=None, data={"out": True})
+            for m in messages
+        ]
+
+
+class _CrashingForwardAdapter(_PassthroughAdapter):
+    """Adapter whose forward raises — used to test error path."""
+
+    def run_feature(self, model, plan):
+        raise RuntimeError("forward boom")
+
+
+class _FakeWorker:
+    def __init__(self):
+        self.tp_size = 1
+        self.tp_rank = 0
+        self.is_entry_rank = True
+        self.device = torch.device("cpu")
+        self.tp_group = None
+
+    def encode_batch(self, plan):
+        return plan.adapter.run_feature(self, plan)
+
+
+def _drain_outbox(sch: EncoderScheduler) -> list:
+    out = []
+    while True:
+        try:
+            out.append(sch.outbox.get_nowait())
+        except _queue_mod.Empty:
+            return out
+
+
+def _run_until_outbox(sch: EncoderScheduler, expected: int, timeout: float = 5.0):
+    """Run scheduler in a thread; stop once expected outbox events arrived."""
+    t = threading.Thread(target=sch.start, daemon=True)
+    t.start()
+    deadline = time.monotonic() + timeout
+    while sch.outbox.qsize() < expected:
+        if time.monotonic() > deadline:
+            sch.stop()
+            t.join(timeout=1.0)
+            raise AssertionError(
+                f"timed out waiting for {expected} outbox events; got {sch.outbox.qsize()}"
+            )
+        time.sleep(0.01)
+    sch.stop()
+    t.join(timeout=2.0)
+
+
+def test_loop_emits_one_result_per_request_at_tp_size_1():
+    sch = EncoderScheduler(_FakeWorker(), _PassthroughAdapter())
+    sch.inbox.put(_mk_msg("r0"))
+    sch.inbox.put(_mk_msg("r1"))
+    _run_until_outbox(sch, expected=2)
+    out = _drain_outbox(sch)
+    assert {o.type for o in out} == {"result"}
+    assert sorted(o.request_id for o in out) == ["r0", "r1"]
+
+
+def test_loop_emits_error_on_forward_failure_at_tp_size_1():
+    """Forward raises → entry rank emits one error per drained request."""
+    sch = EncoderScheduler(_FakeWorker(), _CrashingForwardAdapter())
+    sch.inbox.put(_mk_msg("r0"))
+    sch.inbox.put(_mk_msg("r1"))
+    _run_until_outbox(sch, expected=2)
+    out = _drain_outbox(sch)
+    assert all(o.type == "error" for o in out)
+    assert sorted(o.request_id for o in out) == ["r0", "r1"]
+    for o in out:
+        assert isinstance(o.data, RuntimeError)
+        assert "forward boom" in str(o.data)
+
+
+def test_loop_drops_aborted_request_results():
+    sch = EncoderScheduler(_FakeWorker(), _PassthroughAdapter())
+    sch.abort("r1")
+    sch.inbox.put(_mk_msg("r0"))
+    sch.inbox.put(_mk_msg("r1"))
+    sch.inbox.put(_mk_msg("r2"))
+    _run_until_outbox(sch, expected=2)
+    out = _drain_outbox(sch)
+    rids = sorted(o.request_id for o in out)
+    assert rids == ["r0", "r2"]
+    assert all(o.type == "result" for o in out)
+
+
+def test_loop_recovers_from_recv_error_and_continues():
+    """A recv-time failure produces an error per request and the scheduler
+    survives — next iteration reads the next request fine."""
+
+    cost_calls = {"n": 0}
+
+    def cost_fn(payload):
+        cost_calls["n"] += 1
+        if cost_calls["n"] == 1:
+            raise RuntimeError("first cost boom")
+        return 0
+
+    sch = EncoderScheduler(
+        _FakeWorker(),
+        _PassthroughAdapter(),
+        max_batch_size=1,
+        max_batch_wait_ms=0,
+        request_cost_fn=cost_fn,
+        max_batch_cost=10**9,
+    )
+    sch.inbox.put(_mk_msg("r0"))
+    sch.inbox.put(_mk_msg("r1"))
+    _run_until_outbox(sch, expected=2)
+    out = _drain_outbox(sch)
+    by_id = {o.request_id: o for o in out}
+    assert by_id["r0"].type == "error"
+    assert by_id["r1"].type == "result"

--- a/tests/test_encoder_scheduler_recv.py
+++ b/tests/test_encoder_scheduler_recv.py
@@ -8,7 +8,7 @@ the per-iteration error boundary, and the request-level error
 emission against drained messages.
 
 The TP-multi-rank lanes (broadcast_pyobj, dist.broadcast,
-allocation-ready gather) are mocked: we feed a fake ``worker.tp_group``
+allocation-ready gather) are mocked: we feed a fake ``runner.tp_group``
 and a stand-in ``broadcast_pyobj`` / ``dist.all_gather_object`` /
 ``dist.broadcast`` so we can drive both the leader and follower paths
 deterministically without a multi-process distributed context.

--- a/tests/test_encoder_scheduler_recv.py
+++ b/tests/test_encoder_scheduler_recv.py
@@ -1,0 +1,332 @@
+# SPDX-License-Identifier: Apache-2.0
+"""EncoderScheduler ``_recv_messages`` contract tests.
+
+These tests exercise the Phase-0 contracts that don't need a live
+SGLang TP group: ``tp_size=1`` lift+strip semantics, the unified
+``(messages, error)`` return type, the ``BatchCollectError`` capture,
+the per-iteration error boundary, and the request-level error
+emission against drained messages.
+
+The TP-multi-rank lanes (broadcast_pyobj, dist.broadcast,
+allocation-ready gather) are mocked: we feed a fake ``worker.tp_group``
+and a stand-in ``broadcast_pyobj`` / ``dist.all_gather_object`` /
+``dist.broadcast`` so we can drive both the leader and follower paths
+deterministically without a multi-process distributed context.
+"""
+from __future__ import annotations
+
+import queue as _queue_mod
+from dataclasses import replace
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from sglang_omni_v1.proto import StagePayload
+from sglang_omni_v1.scheduling.encoder_scheduler import (
+    BatchCollectError,
+    EncoderScheduler,
+    _RECV_ERROR_KIND,
+)
+from sglang_omni_v1.scheduling.messages import IncomingMessage, OutgoingMessage
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+def _mk_payload(request_id: str, data: dict | None = None) -> StagePayload:
+    return StagePayload(
+        request_id=request_id,
+        request=None,
+        data=data if data is not None else {"foo": "bar"},
+    )
+
+
+def _mk_msg(request_id: str, data: dict | None = None) -> IncomingMessage:
+    return IncomingMessage(
+        request_id=request_id,
+        type="new_request",
+        data=_mk_payload(request_id, data),
+    )
+
+
+class _FakeAdapter:
+    stage_name = "image_encoder"
+
+    def __init__(self):
+        self.build_calls = 0
+        self.run_calls = 0
+        self.slice_calls = 0
+
+    def build_batch(self, messages):
+        self.build_calls += 1
+        return SimpleNamespace(
+            adapter=self, image_items=[], video_items=[], audio_items=[],
+            spans=[], is_empty=True,
+        )
+
+    def run_feature(self, model, plan):
+        self.run_calls += 1
+        return {"image": None, "video": None, "audio": None}
+
+    def slice_results(self, raw, plan, messages):
+        self.slice_calls += 1
+        # mirror what real adapters do: build a StagePayload per message
+        return [
+            _mk_payload(m.request_id, data={"ok": True}) for m in messages
+        ]
+
+
+class _FakeWorker:
+    def __init__(self, *, tp_size: int = 1, tp_rank: int = 0):
+        self.tp_size = tp_size
+        self.tp_rank = tp_rank
+        self.is_entry_rank = tp_rank == 0
+        self.device = torch.device("cpu")  # tests run CPU-only
+        self.tp_group = SimpleNamespace(
+            rank=tp_rank,
+            ranks=[0, 1] if tp_size > 1 else [0],
+            cpu_group=object(),
+            device_group=object(),
+        )
+
+    def encode_batch(self, plan):
+        return plan.adapter.run_feature(self, plan)
+
+
+# ---------------------------------------------------------------------------
+# tp_size == 1 lane
+# ---------------------------------------------------------------------------
+
+
+def test_recv_returns_empty_when_inbox_empty():
+    sch = EncoderScheduler(_FakeWorker(tp_size=1), _FakeAdapter())
+    msgs, err = sch._recv_messages()
+    assert msgs == [] and err is None
+
+
+def test_recv_drains_inbox_and_lifts_tensors_at_tp_size_1():
+    sch = EncoderScheduler(_FakeWorker(tp_size=1), _FakeAdapter())
+    t = torch.randn(2, 3)
+    sch.inbox.put(_mk_msg("r0", data={"pixel_values": t}))
+    msgs, err = sch._recv_messages()
+    assert err is None
+    assert len(msgs) == 1
+    out_payload = msgs[0].data
+    # tensor preserved (no reattachment surgery on tp_size=1; lifted in-place)
+    out_t = out_payload.data["pixel_values"]
+    assert isinstance(out_t, torch.Tensor)
+    assert torch.equal(out_t, t)
+
+
+def test_recv_reports_collect_error_with_drained_messages():
+    """``request_cost_fn`` is adapter/model code; raising must surface as
+    ``(messages, error)``, not propagate as an exception."""
+
+    def _bad_cost(payload):
+        raise RuntimeError("boom in cost fn")
+
+    sch = EncoderScheduler(
+        _FakeWorker(tp_size=1),
+        _FakeAdapter(),
+        max_batch_size=4,
+        max_batch_wait_ms=0,
+        request_cost_fn=_bad_cost,
+        max_batch_cost=10**9,
+    )
+    sch.inbox.put(_mk_msg("r0"))
+    sch.inbox.put(_mk_msg("r1"))
+    msgs, err = sch._recv_messages()
+    assert isinstance(err, RuntimeError)
+    assert str(err) == "boom in cost fn"
+    # First message drained before raising; admission attempted.
+    assert msgs and msgs[0].request_id == "r0"
+
+
+def test_recv_returns_strip_and_lift_failure_at_tp_size_1():
+    """If lifting tensors raises (e.g. dtype coercion), the error rides
+    the tuple return path."""
+    sch = EncoderScheduler(_FakeWorker(tp_size=1), _FakeAdapter())
+    sch.inbox.put(_mk_msg("r0", data={"pixel_values": torch.randn(2, 2)}))
+
+    with patch.object(
+        sch, "_strip_and_lift", side_effect=RuntimeError("lift boom")
+    ):
+        msgs, err = sch._recv_messages()
+    assert isinstance(err, RuntimeError)
+    assert "lift boom" in str(err)
+    assert msgs and msgs[0].request_id == "r0"
+
+
+def test_emit_error_emits_one_outgoing_per_drained_request():
+    sch = EncoderScheduler(_FakeWorker(tp_size=1), _FakeAdapter())
+    msgs = [_mk_msg("r0"), _mk_msg("r1"), _mk_msg("r2")]
+    sch._emit_error(msgs, RuntimeError("nope"))
+    out: list[OutgoingMessage] = []
+    while True:
+        try:
+            out.append(sch.outbox.get_nowait())
+        except _queue_mod.Empty:
+            break
+    assert [o.request_id for o in out] == ["r0", "r1", "r2"]
+    assert all(o.type == "error" for o in out)
+
+
+def test_emit_error_skips_aborted_requests():
+    sch = EncoderScheduler(_FakeWorker(tp_size=1), _FakeAdapter())
+    sch.abort("r1")
+    msgs = [_mk_msg("r0"), _mk_msg("r1"), _mk_msg("r2")]
+    sch._emit_error(msgs, RuntimeError("x"))
+    rids = []
+    while True:
+        try:
+            rids.append(sch.outbox.get_nowait().request_id)
+        except _queue_mod.Empty:
+            break
+    assert rids == ["r0", "r2"]
+
+
+# ---------------------------------------------------------------------------
+# tp_size > 1 lane: leader / follower with mocked broadcasts
+# ---------------------------------------------------------------------------
+
+
+class _BroadcastBus:
+    """Coordinates fake broadcast_pyobj + dist.{broadcast, all_gather_object}.
+
+    Used to drive the two-channel ``_recv_messages`` from inside a
+    single test process.
+    """
+    def __init__(self):
+        self.metadata: list = None  # leader writes; follower reads
+        self.tensor_calls: list[torch.Tensor] = []
+        self.alloc_flags: list[list[bool]] = []
+        self.broadcast_calls = 0
+
+
+@pytest.fixture
+def bus():
+    return _BroadcastBus()
+
+
+def _patched_broadcast_pyobj(bus: _BroadcastBus):
+    def _f(data, rank, dist_group, src=0, force_cpu_device=True):
+        # Leader (rank == src) publishes; follower (rank != src) reads.
+        if rank == src:
+            bus.metadata = data
+            return data
+        return bus.metadata
+
+    return _f
+
+
+def _patched_dist_broadcast(bus: _BroadcastBus):
+    def _f(tensor, src=0, group=None):
+        bus.tensor_calls.append(tensor)
+        bus.broadcast_calls += 1
+
+    return _f
+
+
+def _patched_all_gather_object(bus: _BroadcastBus):
+    def _f(out_list, val, group=None):
+        # Single test process — simulate "every rank reports the same"
+        for i in range(len(out_list)):
+            out_list[i] = val
+        bus.alloc_flags.append(list(out_list))
+
+    return _f
+
+
+def test_pre_broadcast_collect_error_publishes_sentinel(bus):
+    """Locks the [pre-broadcast error sentinel] contract: a recv-time
+    failure on the entry rank must broadcast the tagged-dict sentinel
+    over the same CPU-group slot the success path uses."""
+
+    def _bad_cost(payload):
+        raise RuntimeError("collect boom")
+
+    sch = EncoderScheduler(
+        _FakeWorker(tp_size=2, tp_rank=0),
+        _FakeAdapter(),
+        max_batch_size=4,
+        max_batch_wait_ms=0,
+        request_cost_fn=_bad_cost,
+        max_batch_cost=10**9,
+    )
+    sch.inbox.put(_mk_msg("r0"))
+
+    with patch(
+        "sglang_omni_v1.scheduling.encoder_scheduler.broadcast_pyobj",
+        _patched_broadcast_pyobj(bus),
+    ), patch(
+        "sglang_omni_v1.scheduling.encoder_scheduler.dist.all_gather_object",
+        _patched_all_gather_object(bus),
+    ), patch(
+        "sglang_omni_v1.scheduling.encoder_scheduler.dist.broadcast",
+        _patched_dist_broadcast(bus),
+    ):
+        msgs, err = sch._recv_messages()
+
+    assert isinstance(err, RuntimeError)
+    assert msgs and msgs[0].request_id == "r0"
+    # Sentinel published. The metadata bus carries the tagged dict.
+    assert isinstance(bus.metadata, list)
+    assert isinstance(bus.metadata[0], dict)
+    assert bus.metadata[0].get("kind") == _RECV_ERROR_KIND
+    assert "collect boom" in bus.metadata[0]["error"]
+    # No device broadcast issued before the metadata error.
+    assert bus.broadcast_calls == 0
+
+
+def test_follower_decodes_pre_broadcast_sentinel(bus):
+    """Follower side: receive the tagged-dict sentinel, return ``([],
+    RuntimeError(...))`` instead of blocking forever."""
+    bus.metadata = [{"kind": _RECV_ERROR_KIND, "error": "RuntimeError('boom')"}]
+
+    sch = EncoderScheduler(
+        _FakeWorker(tp_size=2, tp_rank=1),
+        _FakeAdapter(),
+    )
+
+    with patch(
+        "sglang_omni_v1.scheduling.encoder_scheduler.broadcast_pyobj",
+        _patched_broadcast_pyobj(bus),
+    ), patch(
+        "sglang_omni_v1.scheduling.encoder_scheduler.dist.all_gather_object",
+        _patched_all_gather_object(bus),
+    ), patch(
+        "sglang_omni_v1.scheduling.encoder_scheduler.dist.broadcast",
+        _patched_dist_broadcast(bus),
+    ):
+        msgs, err = sch._recv_messages()
+
+    assert msgs == []
+    assert isinstance(err, RuntimeError)
+    assert "entry rank failed" in str(err) and "boom" in str(err)
+    # Follower never issued a device broadcast.
+    assert bus.broadcast_calls == 0
+
+
+def test_strip_and_lift_returns_typed_dtype_specs():
+    """Specs carry torch.dtype objects, not stringified dtypes — locks
+    the [_TensorSpec typed dtype] note in the RFC."""
+    sch = EncoderScheduler(_FakeWorker(tp_size=2, tp_rank=0), _FakeAdapter())
+    msg = _mk_msg("r0", data={
+        "image_grid_thw": torch.tensor([[1, 2, 3]], dtype=torch.long),
+        "pixel_values": torch.randn(2, 3, dtype=torch.float16),
+    })
+    meta_msgs, tensor_lists, specs_lists = sch._strip_and_lift([msg])
+    assert len(specs_lists) == 1
+    specs = specs_lists[0]
+    assert len(specs) == 2
+    dtypes = {spec.dtype for spec in specs}
+    assert torch.float16 in dtypes
+    assert torch.long in dtypes
+    # All dtypes are real torch.dtype objects, not strings.
+    for spec in specs:
+        assert isinstance(spec.dtype, torch.dtype)

--- a/tests/test_encoder_server_args.py
+++ b/tests/test_encoder_server_args.py
@@ -177,12 +177,15 @@ def test_helper_rejects_encoder_fork_keys(key, value):
 
 def _stub_specs():
     """Minimal valid spec list for runner validation tests."""
-    from sglang_omni_v1.models.qwen3_omni.encoder_adapters import EncoderModuleSpec
+    from types import SimpleNamespace
+
     return (
-        EncoderModuleSpec(
+        SimpleNamespace(
             name="dummy",
             build_module=lambda hf, qc: None,
             checkpoint_prefixes=("dummy.",),
+            checkpoint_rewrites=(),
+            stacked_params_mapping=(),
         ),
     )
 
@@ -260,3 +263,67 @@ def test_runner_rejects_empty_encoder_specs():
             nccl_port=None,
             encoder_specs=(),
         )
+
+
+def test_runner_rejects_unknown_tp_parity_mode():
+    from sglang_omni_v1.model_runner.sglang_encoder_runner import SGLangEncoderRunner
+
+    inst = SGLangEncoderRunner.__new__(SGLangEncoderRunner)
+    with pytest.raises(ValueError, match="tp_parity_mode"):
+        SGLangEncoderRunner.__init__(
+            inst,
+            model_path="dummy/model",
+            gpu_id=0,
+            tp_rank=0,
+            tp_size=1,
+            nccl_port=None,
+            encoder_specs=_stub_specs(),
+            tp_parity_mode="nope",
+        )
+
+
+def test_runner_accepts_fp32_linear_tp_parity_mode():
+    from sglang_omni_v1.model_runner.sglang_encoder_runner import (
+        _resolve_tp_parity_mode,
+    )
+
+    assert _resolve_tp_parity_mode("fp32_linear") == "fp32_linear"
+
+
+def test_runner_configures_tp_collective_switches(monkeypatch):
+    """Encoder runner bypasses upstream ModelRunner, so it must mirror
+    ModelRunner's all-reduce switch plumbing before TP group init."""
+    from types import SimpleNamespace
+
+    from sglang_omni_v1.model_runner import sglang_encoder_runner as sew
+
+    calls = {}
+    monkeypatch.setattr(
+        sew,
+        "set_custom_all_reduce",
+        lambda enabled: calls.setdefault("custom", enabled),
+    )
+    monkeypatch.setattr(
+        sew,
+        "set_mscclpp_all_reduce",
+        lambda enabled: calls.setdefault("mscclpp", enabled),
+    )
+    monkeypatch.setattr(
+        sew,
+        "set_torch_symm_mem_all_reduce",
+        lambda enabled: calls.setdefault("torch_symm_mem", enabled),
+    )
+
+    sew._configure_tp_collectives(
+        SimpleNamespace(
+            disable_custom_all_reduce=True,
+            enable_mscclpp=True,
+            enable_torch_symm_mem=False,
+        )
+    )
+
+    assert calls == {
+        "custom": False,
+        "mscclpp": True,
+        "torch_symm_mem": False,
+    }

--- a/tests/test_encoder_server_args.py
+++ b/tests/test_encoder_server_args.py
@@ -175,6 +175,18 @@ def test_helper_rejects_encoder_fork_keys(key, value):
 # ---------------------------------------------------------------------------
 
 
+def _stub_specs():
+    """Minimal valid spec list for worker validation tests."""
+    from sglang_omni_v1.models.qwen3_omni.encoder_adapters import EncoderModuleSpec
+    return (
+        EncoderModuleSpec(
+            name="dummy",
+            build_module=lambda hf, qc: None,
+            checkpoint_prefixes=("dummy.",),
+        ),
+    )
+
+
 def test_worker_rejects_worker_managed_keys_in_overrides_dict():
     """SGLangEncoderWorker rejects worker-managed keys *before* the
     helper-level **splat, otherwise Python raises a confusing
@@ -182,14 +194,8 @@ def test_worker_rejects_worker_managed_keys_in_overrides_dict():
     instantiating the worker (which would require a real model)."""
     from sglang_omni_v1.model_runner import sglang_encoder_worker as sew
 
-    # The reject runs before any heavy initialization, so we can hit it
-    # directly by calling __init__ with a stub server_args path that
-    # raises before init_distributed_environment.
     cls = sew.SGLangEncoderWorker
-    # Build a dummy instance bypassing __init__ to hit the validation.
     inst = cls.__new__(cls)
-    # Re-run only the early validation by calling __init__ partially
-    # via a minimal stub: pass overrides with a worker-managed key.
     with pytest.raises(ValueError, match="worker-managed keys"):
         cls.__init__(
             inst,
@@ -198,6 +204,7 @@ def test_worker_rejects_worker_managed_keys_in_overrides_dict():
             tp_rank=0,
             tp_size=1,
             nccl_port=None,
+            encoder_specs=_stub_specs(),
             server_args_overrides={"tp_size": 99},
         )
 
@@ -214,6 +221,7 @@ def test_worker_rejects_invalid_tp_rank():
             tp_rank=2,
             tp_size=2,  # tp_rank must be < tp_size, so 2 is invalid
             nccl_port=None,
+            encoder_specs=_stub_specs(),
         )
 
 
@@ -229,4 +237,26 @@ def test_worker_rejects_invalid_tp_size():
             tp_rank=0,
             tp_size=0,
             nccl_port=None,
+            encoder_specs=_stub_specs(),
+        )
+
+
+def test_worker_rejects_empty_encoder_specs():
+    """Locks the [Upstream Reuse Boundary] contract: the worker MUST
+    refuse to fall back to ``get_model()`` on the full
+    ``ForConditionalGeneration`` class. An adapter without any
+    ``encoder_specs`` is a misconfigured stage, not a "load
+    everything" hint."""
+    from sglang_omni_v1.model_runner.sglang_encoder_worker import SGLangEncoderWorker
+
+    inst = SGLangEncoderWorker.__new__(SGLangEncoderWorker)
+    with pytest.raises(ValueError, match="encoder_specs"):
+        SGLangEncoderWorker.__init__(
+            inst,
+            model_path="dummy/model",
+            gpu_id=0,
+            tp_rank=0,
+            tp_size=1,
+            nccl_port=None,
+            encoder_specs=(),
         )

--- a/tests/test_encoder_server_args.py
+++ b/tests/test_encoder_server_args.py
@@ -88,7 +88,7 @@ def test_helper_forwards_loader_overrides():
 # Protected-key rejects (helper level — go through `**overrides`)
 # ---------------------------------------------------------------------------
 
-# AR-only knobs that have no meaning for an encoder-only worker.
+# AR-only knobs that have no meaning for an encoder-only runner.
 _AR_ONLY = [
     ("mem_fraction_static", 0.5),
     ("max_running_requests", 32),
@@ -100,9 +100,9 @@ _AR_ONLY = [
 # Parallelism / placement keys that pass through ``**overrides``.
 # (``tp_size``, ``base_gpu_id``, ``dist_init_addr`` are direct kwargs of
 # the helper; passing them again via `**overrides` is a Python-level
-# TypeError before our reject can fire — the worker's
+# TypeError before our reject can fire — the runner's
 # ``_WORKER_MANAGED_KEYS`` reject catches users who try this through the
-# worker's ``server_args_overrides`` dict.)
+# runner's ``server_args_overrides`` dict.)
 _PARALLELISM = [
     ("pp_size", 2),
     ("dp_size", 2),
@@ -170,13 +170,13 @@ def test_helper_rejects_encoder_fork_keys(key, value):
 
 
 # ---------------------------------------------------------------------------
-# Worker-level reject — protected keys reachable only through
-# ``server_args_overrides`` dict on the worker
+# Runner-level reject — protected keys reachable only through
+# ``server_args_overrides`` dict on the runner
 # ---------------------------------------------------------------------------
 
 
 def _stub_specs():
-    """Minimal valid spec list for worker validation tests."""
+    """Minimal valid spec list for runner validation tests."""
     from sglang_omni_v1.models.qwen3_omni.encoder_adapters import EncoderModuleSpec
     return (
         EncoderModuleSpec(
@@ -187,16 +187,16 @@ def _stub_specs():
     )
 
 
-def test_worker_rejects_worker_managed_keys_in_overrides_dict():
-    """SGLangEncoderWorker rejects worker-managed keys *before* the
+def test_runner_rejects_runner_managed_keys_in_overrides_dict():
+    """SGLangEncoderRunner rejects runner-managed keys *before* the
     helper-level **splat, otherwise Python raises a confusing
     "got multiple values" TypeError. Tested without actually
-    instantiating the worker (which would require a real model)."""
-    from sglang_omni_v1.model_runner import sglang_encoder_worker as sew
+    instantiating the runner (which would require a real model)."""
+    from sglang_omni_v1.model_runner import sglang_encoder_runner as sew
 
-    cls = sew.SGLangEncoderWorker
+    cls = sew.SGLangEncoderRunner
     inst = cls.__new__(cls)
-    with pytest.raises(ValueError, match="worker-managed keys"):
+    with pytest.raises(ValueError, match="runner-managed keys"):
         cls.__init__(
             inst,
             model_path="dummy/model",
@@ -209,12 +209,12 @@ def test_worker_rejects_worker_managed_keys_in_overrides_dict():
         )
 
 
-def test_worker_rejects_invalid_tp_rank():
-    from sglang_omni_v1.model_runner.sglang_encoder_worker import SGLangEncoderWorker
+def test_runner_rejects_invalid_tp_rank():
+    from sglang_omni_v1.model_runner.sglang_encoder_runner import SGLangEncoderRunner
 
-    inst = SGLangEncoderWorker.__new__(SGLangEncoderWorker)
+    inst = SGLangEncoderRunner.__new__(SGLangEncoderRunner)
     with pytest.raises(ValueError, match="tp_rank"):
-        SGLangEncoderWorker.__init__(
+        SGLangEncoderRunner.__init__(
             inst,
             model_path="dummy/model",
             gpu_id=0,
@@ -225,12 +225,12 @@ def test_worker_rejects_invalid_tp_rank():
         )
 
 
-def test_worker_rejects_invalid_tp_size():
-    from sglang_omni_v1.model_runner.sglang_encoder_worker import SGLangEncoderWorker
+def test_runner_rejects_invalid_tp_size():
+    from sglang_omni_v1.model_runner.sglang_encoder_runner import SGLangEncoderRunner
 
-    inst = SGLangEncoderWorker.__new__(SGLangEncoderWorker)
+    inst = SGLangEncoderRunner.__new__(SGLangEncoderRunner)
     with pytest.raises(ValueError, match="tp_size"):
-        SGLangEncoderWorker.__init__(
+        SGLangEncoderRunner.__init__(
             inst,
             model_path="dummy/model",
             gpu_id=0,
@@ -241,17 +241,17 @@ def test_worker_rejects_invalid_tp_size():
         )
 
 
-def test_worker_rejects_empty_encoder_specs():
-    """Locks the [Upstream Reuse Boundary] contract: the worker MUST
+def test_runner_rejects_empty_encoder_specs():
+    """Locks the [Upstream Reuse Boundary] contract: the runner MUST
     refuse to fall back to ``get_model()`` on the full
     ``ForConditionalGeneration`` class. An adapter without any
     ``encoder_specs`` is a misconfigured stage, not a "load
     everything" hint."""
-    from sglang_omni_v1.model_runner.sglang_encoder_worker import SGLangEncoderWorker
+    from sglang_omni_v1.model_runner.sglang_encoder_runner import SGLangEncoderRunner
 
-    inst = SGLangEncoderWorker.__new__(SGLangEncoderWorker)
+    inst = SGLangEncoderRunner.__new__(SGLangEncoderRunner)
     with pytest.raises(ValueError, match="encoder_specs"):
-        SGLangEncoderWorker.__init__(
+        SGLangEncoderRunner.__init__(
             inst,
             model_path="dummy/model",
             gpu_id=0,

--- a/tests/test_encoder_server_args.py
+++ b/tests/test_encoder_server_args.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ``build_sglang_encoder_server_args`` and the protected-keys reject.
+
+We avoid actually constructing ``ServerArgs`` (which fetches the model
+config from HF Hub) by monkey-patching it to a recording stand-in. The
+helper must reject protected keys *before* delegating, so the stand-in
+never sees a bad call.
+"""
+from __future__ import annotations
+
+import pytest
+
+from sglang_omni_v1.scheduling.sglang_backend import server_args_builder
+from sglang_omni_v1.scheduling.sglang_backend import (
+    build_sglang_encoder_server_args,
+)
+
+
+class _FakeServerArgs:
+    """Records the kwargs the builder passed without doing HF lookup."""
+
+    captured: dict | None = None
+
+    def __init__(self, **kwargs):
+        type(self).captured = dict(kwargs)
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+@pytest.fixture(autouse=True)
+def _stub_server_args(monkeypatch):
+    monkeypatch.setattr(server_args_builder, "ServerArgs", _FakeServerArgs)
+    _FakeServerArgs.captured = None
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Happy path: helper produces ServerArgs kwargs with encoder-only fork on
+# ---------------------------------------------------------------------------
+
+
+def test_helper_sets_encoder_only_fork():
+    args = build_sglang_encoder_server_args(
+        model_path="dummy/model",
+        tp_size=2,
+        base_gpu_id=0,
+        dist_init_addr="127.0.0.1:29500",
+    )
+    assert args.encoder_only is True
+    assert args.language_only is False
+    assert args.mm_enable_dp_encoder is False
+    assert args.disable_cuda_graph is True
+    assert args.tp_size == 2
+    assert args.pp_size == 1
+    assert args.base_gpu_id == 0
+    assert args.dist_init_addr == "127.0.0.1:29500"
+    assert args.trust_remote_code is True
+
+
+def test_helper_passes_dtype_load_format():
+    args = build_sglang_encoder_server_args(
+        model_path="dummy/model",
+        tp_size=1,
+        base_gpu_id=0,
+        dist_init_addr="127.0.0.1:29500",
+        dtype="float16",
+        load_format="auto",
+    )
+    assert args.dtype == "float16"
+    assert args.load_format == "auto"
+
+
+def test_helper_forwards_loader_overrides():
+    """Loader / processor knobs are NOT protected — pass through."""
+    args = build_sglang_encoder_server_args(
+        model_path="dummy/model",
+        tp_size=1,
+        base_gpu_id=0,
+        dist_init_addr="127.0.0.1:29500",
+        model_loader_extra_config={"key": "value"},
+        download_dir="/tmp/cache",
+    )
+    assert args.model_loader_extra_config == {"key": "value"}
+    assert args.download_dir == "/tmp/cache"
+
+
+# ---------------------------------------------------------------------------
+# Protected-key rejects (helper level — go through `**overrides`)
+# ---------------------------------------------------------------------------
+
+# AR-only knobs that have no meaning for an encoder-only worker.
+_AR_ONLY = [
+    ("mem_fraction_static", 0.5),
+    ("max_running_requests", 32),
+    ("max_prefill_tokens", 1024),
+    ("chunked_prefill_size", 512),
+    ("context_length", 4096),
+]
+
+# Parallelism / placement keys that pass through ``**overrides``.
+# (``tp_size``, ``base_gpu_id``, ``dist_init_addr`` are direct kwargs of
+# the helper; passing them again via `**overrides` is a Python-level
+# TypeError before our reject can fire — the worker's
+# ``_WORKER_MANAGED_KEYS`` reject catches users who try this through the
+# worker's ``server_args_overrides`` dict.)
+_PARALLELISM = [
+    ("pp_size", 2),
+    ("dp_size", 2),
+    ("ep_size", 4),
+    ("moe_dense_tp_size", 2),
+    ("nnodes", 2),
+    ("node_rank", 1),
+]
+
+# Encoder-only fork knobs.
+_ENCODER_FORK = [
+    ("encoder_only", False),
+    ("language_only", True),
+    ("mm_enable_dp_encoder", True),
+    ("enable_dp_attention", True),
+    ("enable_dp_lm_head", True),
+    ("disable_cuda_graph", False),
+    ("device", "cpu"),
+]
+
+
+@pytest.mark.parametrize("key,value", _AR_ONLY)
+def test_helper_rejects_ar_only_knobs(key, value):
+    with pytest.raises(ValueError, match=key):
+        build_sglang_encoder_server_args(
+            model_path="dummy/model",
+            tp_size=1,
+            base_gpu_id=0,
+            dist_init_addr="127.0.0.1:29500",
+            **{key: value},
+        )
+
+
+@pytest.mark.parametrize("key,value", _PARALLELISM)
+def test_helper_rejects_parallelism_keys(key, value):
+    with pytest.raises(ValueError, match=key):
+        build_sglang_encoder_server_args(
+            model_path="dummy/model",
+            tp_size=1,
+            base_gpu_id=0,
+            dist_init_addr="127.0.0.1:29500",
+            **{key: value},
+        )
+
+
+@pytest.mark.parametrize("key,value", _ENCODER_FORK)
+def test_helper_rejects_encoder_fork_keys(key, value):
+    with pytest.raises(ValueError, match=key):
+        build_sglang_encoder_server_args(
+            model_path="dummy/model",
+            tp_size=1,
+            base_gpu_id=0,
+            dist_init_addr="127.0.0.1:29500",
+            **{key: value},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Worker-level reject — protected keys reachable only through
+# ``server_args_overrides`` dict on the worker
+# ---------------------------------------------------------------------------
+
+
+def test_worker_rejects_worker_managed_keys_in_overrides_dict():
+    """SGLangEncoderWorker rejects worker-managed keys *before* the
+    helper-level **splat, otherwise Python raises a confusing
+    "got multiple values" TypeError. Tested without actually
+    instantiating the worker (which would require a real model)."""
+    from sglang_omni_v1.model_runner import sglang_encoder_worker as sew
+
+    # The reject runs before any heavy initialization, so we can hit it
+    # directly by calling __init__ with a stub server_args path that
+    # raises before init_distributed_environment.
+    cls = sew.SGLangEncoderWorker
+    # Build a dummy instance bypassing __init__ to hit the validation.
+    inst = cls.__new__(cls)
+    # Re-run only the early validation by calling __init__ partially
+    # via a minimal stub: pass overrides with a worker-managed key.
+    with pytest.raises(ValueError, match="worker-managed keys"):
+        cls.__init__(
+            inst,
+            model_path="dummy/model",
+            gpu_id=0,
+            tp_rank=0,
+            tp_size=1,
+            nccl_port=None,
+            server_args_overrides={"tp_size": 99},
+        )
+
+
+def test_worker_rejects_invalid_tp_rank():
+    from sglang_omni_v1.model_runner.sglang_encoder_worker import SGLangEncoderWorker
+
+    inst = SGLangEncoderWorker.__new__(SGLangEncoderWorker)
+    with pytest.raises(ValueError, match="tp_rank"):
+        SGLangEncoderWorker.__init__(
+            inst,
+            model_path="dummy/model",
+            gpu_id=0,
+            tp_rank=2,
+            tp_size=2,  # tp_rank must be < tp_size, so 2 is invalid
+            nccl_port=None,
+        )
+
+
+def test_worker_rejects_invalid_tp_size():
+    from sglang_omni_v1.model_runner.sglang_encoder_worker import SGLangEncoderWorker
+
+    inst = SGLangEncoderWorker.__new__(SGLangEncoderWorker)
+    with pytest.raises(ValueError, match="tp_size"):
+        SGLangEncoderWorker.__init__(
+            inst,
+            model_path="dummy/model",
+            gpu_id=0,
+            tp_rank=0,
+            tp_size=0,
+            nccl_port=None,
+        )

--- a/tests/test_encoder_server_args.py
+++ b/tests/test_encoder_server_args.py
@@ -110,6 +110,15 @@ _PARALLELISM = [
     ("moe_dense_tp_size", 2),
     ("nnodes", 2),
     ("node_rank", 1),
+    # RFC v2: rank-topology keys reachable through `**overrides`.
+    # `tp_rank`, `gpu_id`, `nccl_port`, `rank`, `world_size` must not
+    # be settable through server_args_overrides because the runner
+    # already decided them from StageConfig.tp_size + StageConfig.gpu.
+    ("tp_rank", 1),
+    ("gpu_id", 7),
+    ("nccl_port", 29500),
+    ("rank", 1),
+    ("world_size", 4),
 ]
 
 # Encoder-only fork knobs.

--- a/tests/test_encoder_tp_launcher.py
+++ b/tests/test_encoder_tp_launcher.py
@@ -384,3 +384,71 @@ def test_real_factory_signature_lock_audio_encoder():
 
     sig = inspect.signature(create_audio_encoder_executor)
     assert sig.parameters["backend"].default == "local"
+
+
+# ---------------------------------------------------------------------------
+# 7. TP launch params reject (footgun in user-supplied factory_args /
+# runtime_overrides — Codex adversarial review finding)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("key,value", [
+    ("tp_size", 2),
+    ("tp_rank", 1),
+    ("nccl_port", 29500),
+])
+def test_resolve_factory_args_rejects_tp_launch_params_in_factory_args(key, value):
+    """Lock the TP topology source-of-truth contract.
+
+    ``StageConfig.tp_size`` is the only public way to set TP size.
+    Letting ``factory_args[tp_size]=N`` slip through while
+    ``StageConfig.tp_size`` says 1 (or vice versa) silently desyncs
+    the runner's spawn count from the worker's NCCL world size,
+    hanging bootstrap. ``_resolve_factory_args`` must reject these
+    keys with a clear error before any spec is built.
+    """
+    from sglang_omni_v1.config.compiler import _resolve_factory_args
+
+    cfg = _make_config(
+        factory=_F_SGLANG,
+        factory_args={"backend": "sglang", key: value},
+    )
+    with pytest.raises(ValueError, match=key):
+        _resolve_factory_args(cfg.stages[0], cfg)
+
+
+@pytest.mark.parametrize("key,value", [
+    ("tp_size", 2),
+    ("tp_rank", 1),
+    ("nccl_port", 29500),
+])
+def test_resolve_factory_args_rejects_tp_launch_params_in_runtime_overrides(key, value):
+    """Same as above but via ``runtime_overrides`` (the CLI-friendly path)."""
+    from sglang_omni_v1.config.compiler import _resolve_factory_args
+
+    cfg = _make_config(
+        factory=_F_SGLANG,
+        factory_args={"backend": "sglang"},
+        runtime_overrides={"image_encoder": {key: value}},
+    )
+    with pytest.raises(ValueError, match=key):
+        _resolve_factory_args(cfg.stages[0], cfg)
+
+
+def test_user_supplied_tp_size_in_factory_args_blocks_at_build_stage_groups():
+    """End-to-end regression: the silent NCCL-bootstrap-hang scenario.
+
+    User sets ``StageConfig.tp_size=1`` (default) and
+    ``factory_args={"backend":"sglang","tp_size":2}``. Pre-fix, the
+    runner spawned one process but the factory got tp_size=2, hanging
+    NCCL forever. Post-fix, ``_build_stage_groups`` raises before any
+    spawn.
+    """
+    cfg = _make_config(
+        factory=_F_SGLANG,
+        factory_args={"backend": "sglang", "tp_size": 2},
+        # NOTE: StageConfig.tp_size defaults to 1 — the bug surface.
+    )
+    ctx = multiprocessing.get_context("spawn")
+    with pytest.raises(ValueError, match="tp_size"):
+        _build_stage_groups(cfg, ctx=ctx)

--- a/tests/test_encoder_tp_launcher.py
+++ b/tests/test_encoder_tp_launcher.py
@@ -1,0 +1,386 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Phase-0 launcher contract tests for encoder TP (Plan B).
+
+These tests cover only the launcher / config layer — they do not
+spawn child processes or load any model. They lock the contracts the
+RFC calls "load-bearing":
+
+- ``StageProcessSpec.single_visible_device`` flips when a stage's
+  resolved factory backend is ``sglang`` / ``auto``, including when the
+  flip is driven by ``runtime_overrides`` (signature-default trap).
+- ``get_stage_process_env`` honors the flag at ``tp_size=1``.
+- ``serve/launcher.py`` ``needs_mp`` predicate routes single-stage,
+  single-GPU, ``tp_size=1`` ``backend="sglang"`` configs through the
+  multi-process runner.
+- ``compile_pipeline`` rejects ``backend in {"sglang","auto"}`` and
+  ``tp_size > 1`` directly.
+- The TP preflight in ``mp_runner._build_stage_groups`` rejects:
+   * Layer 1 — TP stage whose factory does not accept
+     ``tp_rank/tp_size/nccl_port``;
+   * Layer 2 — encoder TP stage whose resolved backend is not
+     ``sglang``.
+- Production factory signature defaults stay ``"local"`` forever
+  (real-factory signature lock).
+"""
+from __future__ import annotations
+
+import inspect
+import multiprocessing
+import os
+from typing import Any
+
+import pytest
+
+from sglang_omni_v1.config.compiler import compile_pipeline
+from sglang_omni_v1.config.schema import (
+    EndpointsConfig,
+    PipelineConfig,
+    StageConfig,
+)
+from sglang_omni_v1.pipeline.mp_runner import _build_stage_groups
+from sglang_omni_v1.pipeline.stage_process import (
+    StageProcessSpec,
+    get_stage_process_env,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test factories — registered as importable callables so ``import_string``
+# inside the runner can resolve them. Live module-level (not inside a
+# fixture) so dotted-path import works.
+# ---------------------------------------------------------------------------
+
+
+def fake_factory_sglang(
+    model_path: str,
+    *,
+    backend: str = "local",
+    gpu_id: int = 0,
+    tp_rank: int = 0,
+    tp_size: int = 1,
+    nccl_port: int | None = None,
+):
+    """Encoder-shaped factory: accepts both backend and TP launch params."""
+    return ("scheduler", model_path, backend, gpu_id, tp_rank, tp_size, nccl_port)
+
+
+def fake_factory_thinker(
+    model_path: str,
+    *,
+    gpu_id: int = 0,
+    tp_rank: int = 0,
+    tp_size: int = 1,
+    nccl_port: int | None = None,
+):
+    """Thinker-shaped factory: TP-capable but no `backend` param."""
+    return ("thinker", model_path, gpu_id, tp_rank, tp_size, nccl_port)
+
+
+def fake_factory_simple(model_path: str, *, gpu_id: int = 0):
+    """SimpleScheduler-shaped factory: no TP params."""
+    return ("simple", model_path, gpu_id)
+
+
+def fake_factory_signature_auto_default(
+    model_path: str,
+    *,
+    backend: str = "auto",  # signature default flipped to "auto"
+    gpu_id: int = 0,
+    tp_rank: int = 0,
+    tp_size: int = 1,
+    nccl_port: int | None = None,
+):
+    """Factory whose signature default for `backend` is "auto".
+
+    Used to lock the [Backend resolution contract]: launcher decisions
+    must NOT introspect the signature default. A StageConfig that omits
+    ``factory_args["backend"]`` should resolve to ``"local"`` here, not
+    ``"auto"``, even though the factory body would default to ``"auto"``.
+    """
+    return ("auto-default", model_path, backend, gpu_id, tp_rank, tp_size, nccl_port)
+
+
+# Module-level dotted paths for the helpers above.
+_F_SGLANG = f"{__name__}.fake_factory_sglang"
+_F_THINKER = f"{__name__}.fake_factory_thinker"
+_F_SIMPLE = f"{__name__}.fake_factory_simple"
+_F_AUTO_DEFAULT = f"{__name__}.fake_factory_signature_auto_default"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(
+    *,
+    factory: str,
+    factory_args: dict[str, Any] | None = None,
+    runtime_overrides: dict[str, dict[str, Any]] | None = None,
+    tp_size: int = 1,
+    gpu: int | list[int] | None = 0,
+) -> PipelineConfig:
+    return PipelineConfig(
+        model_path="dummy/model",
+        stages=[
+            StageConfig(
+                name="image_encoder",
+                factory=factory,
+                factory_args=dict(factory_args or {}),
+                tp_size=tp_size,
+                gpu=gpu,
+                terminal=True,
+            ),
+        ],
+        runtime_overrides=runtime_overrides or {},
+        endpoints=EndpointsConfig(scheme="ipc", base_path="/tmp/encoder_tp_test"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. single_visible_device flag (mp_runner._build_stage_groups)
+# ---------------------------------------------------------------------------
+
+
+def test_single_visible_device_flag_flips_for_sglang_backend(tmp_path):
+    cfg = _make_config(
+        factory=_F_SGLANG,
+        factory_args={"backend": "sglang"},
+    )
+    ctx = multiprocessing.get_context("spawn")
+    groups = _build_stage_groups(cfg, ctx=ctx)
+    assert len(groups) == 1
+    spec = groups[0].specs[0]
+    assert spec.single_visible_device is True
+
+
+def test_single_visible_device_flag_flips_for_auto_backend():
+    cfg = _make_config(factory=_F_SGLANG, factory_args={"backend": "auto"})
+    ctx = multiprocessing.get_context("spawn")
+    spec = _build_stage_groups(cfg, ctx=ctx)[0].specs[0]
+    assert spec.single_visible_device is True
+
+
+def test_single_visible_device_flag_off_for_local_backend():
+    cfg = _make_config(factory=_F_SGLANG, factory_args={"backend": "local"})
+    ctx = multiprocessing.get_context("spawn")
+    spec = _build_stage_groups(cfg, ctx=ctx)[0].specs[0]
+    assert spec.single_visible_device is False
+
+
+def test_single_visible_device_flag_flipped_via_runtime_overrides():
+    """Locks the [Backend resolution contract]: runtime_overrides drives the flip."""
+    cfg = _make_config(
+        factory=_F_SGLANG,
+        factory_args={"backend": "local"},  # default
+        runtime_overrides={"image_encoder": {"backend": "sglang"}},
+    )
+    ctx = multiprocessing.get_context("spawn")
+    spec = _build_stage_groups(cfg, ctx=ctx)[0].specs[0]
+    assert spec.single_visible_device is True
+
+
+def test_single_visible_device_signature_default_trap():
+    """Launcher must NOT read factory signature defaults.
+
+    Factory body defaults to ``backend="auto"`` but ``factory_args``
+    omits the key — the launcher should resolve to ``"local"``.
+    """
+    cfg = _make_config(factory=_F_AUTO_DEFAULT, factory_args={})
+    ctx = multiprocessing.get_context("spawn")
+    spec = _build_stage_groups(cfg, ctx=ctx)[0].specs[0]
+    assert spec.single_visible_device is False
+
+
+# ---------------------------------------------------------------------------
+# 2. get_stage_process_env early return
+# ---------------------------------------------------------------------------
+
+
+def _spec(*, tp_size: int = 1, single_visible_device: bool = False, gpu_id: int = 0):
+    return StageProcessSpec(
+        stage_name="image_encoder",
+        tp_size=tp_size,
+        gpu_id=gpu_id,
+        single_visible_device=single_visible_device,
+    )
+
+
+def test_get_stage_process_env_returns_empty_for_plain_single_process_stage():
+    assert get_stage_process_env(_spec()) == {}
+
+
+def test_get_stage_process_env_remaps_when_single_visible_device_set():
+    env = {"CUDA_VISIBLE_DEVICES": "0,1,2,3,4,5,6,7"}
+    overrides = get_stage_process_env(
+        _spec(single_visible_device=True, gpu_id=4),
+        env=env,
+    )
+    assert overrides["CUDA_VISIBLE_DEVICES"] == "4"
+    assert overrides["SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS"] == "true"
+
+
+def test_get_stage_process_env_remaps_for_tp_size_2():
+    """Existing tp_size>1 lane keeps working."""
+    env = {"CUDA_VISIBLE_DEVICES": "0,1,2,3"}
+    overrides = get_stage_process_env(
+        _spec(tp_size=2, gpu_id=2),
+        env=env,
+    )
+    assert overrides["CUDA_VISIBLE_DEVICES"] == "2"
+
+
+# ---------------------------------------------------------------------------
+# 3. serve/launcher.py needs_mp predicate
+# ---------------------------------------------------------------------------
+
+
+def test_any_sglang_backend_stage_detects_sglang():
+    from sglang_omni_v1.pipeline.mp_runner import any_sglang_backend_stage
+
+    cfg = _make_config(factory=_F_SGLANG, factory_args={"backend": "sglang"})
+    assert any_sglang_backend_stage(cfg) is True
+
+
+def test_any_sglang_backend_stage_detects_auto():
+    from sglang_omni_v1.pipeline.mp_runner import any_sglang_backend_stage
+
+    cfg = _make_config(factory=_F_SGLANG, factory_args={"backend": "auto"})
+    assert any_sglang_backend_stage(cfg) is True
+
+
+def test_any_sglang_backend_stage_false_for_local():
+    from sglang_omni_v1.pipeline.mp_runner import any_sglang_backend_stage
+
+    cfg = _make_config(factory=_F_SGLANG, factory_args={"backend": "local"})
+    assert any_sglang_backend_stage(cfg) is False
+
+
+def test_any_sglang_backend_stage_ignores_signature_default():
+    """signature default = "auto" but factory_args is empty → resolves to local."""
+    from sglang_omni_v1.pipeline.mp_runner import any_sglang_backend_stage
+
+    cfg = _make_config(factory=_F_AUTO_DEFAULT, factory_args={})
+    assert any_sglang_backend_stage(cfg) is False
+
+
+# ---------------------------------------------------------------------------
+# 4. compile_pipeline rejects sglang/auto + tp_size>1
+# ---------------------------------------------------------------------------
+
+
+def test_compile_pipeline_rejects_sglang_backend():
+    cfg = _make_config(factory=_F_SGLANG, factory_args={"backend": "sglang"})
+    with pytest.raises(ValueError, match="MultiProcessPipelineRunner"):
+        compile_pipeline(cfg)
+
+
+def test_compile_pipeline_rejects_auto_backend():
+    cfg = _make_config(factory=_F_SGLANG, factory_args={"backend": "auto"})
+    with pytest.raises(ValueError, match="MultiProcessPipelineRunner"):
+        compile_pipeline(cfg)
+
+
+def test_compile_pipeline_rejects_tp_size_gt_1():
+    cfg = _make_config(
+        factory=_F_THINKER,
+        factory_args={},
+        tp_size=2,
+        gpu=[0, 1],
+    )
+    with pytest.raises(ValueError, match="MultiProcessPipelineRunner"):
+        compile_pipeline(cfg)
+
+
+# ---------------------------------------------------------------------------
+# 5. TP preflight Layers 1 & 2
+# ---------------------------------------------------------------------------
+
+
+def test_tp_preflight_layer1_rejects_factory_without_tp_params():
+    cfg = _make_config(factory=_F_SIMPLE, tp_size=2, gpu=[0, 1])
+    ctx = multiprocessing.get_context("spawn")
+    with pytest.raises(ValueError, match="not TP-capable"):
+        _build_stage_groups(cfg, ctx=ctx)
+
+
+def test_tp_preflight_layer2_rejects_encoder_with_local_backend():
+    cfg = _make_config(
+        factory=_F_SGLANG,
+        factory_args={"backend": "local"},
+        tp_size=2,
+        gpu=[0, 1],
+    )
+    ctx = multiprocessing.get_context("spawn")
+    with pytest.raises(ValueError, match="requires backend='sglang'"):
+        _build_stage_groups(cfg, ctx=ctx)
+
+
+def test_tp_preflight_layer2_rejects_encoder_with_auto_backend():
+    cfg = _make_config(
+        factory=_F_SGLANG,
+        factory_args={"backend": "auto"},
+        tp_size=2,
+        gpu=[0, 1],
+    )
+    ctx = multiprocessing.get_context("spawn")
+    with pytest.raises(ValueError, match="requires backend='sglang'"):
+        _build_stage_groups(cfg, ctx=ctx)
+
+
+def test_tp_preflight_layer2_rejects_encoder_without_explicit_backend():
+    cfg = _make_config(
+        factory=_F_SGLANG,
+        factory_args={},
+        tp_size=2,
+        gpu=[0, 1],
+    )
+    ctx = multiprocessing.get_context("spawn")
+    with pytest.raises(ValueError, match="requires backend='sglang'"):
+        _build_stage_groups(cfg, ctx=ctx)
+
+
+def test_tp_preflight_does_not_regress_thinker_tp():
+    cfg = _make_config(factory=_F_THINKER, tp_size=2, gpu=[0, 1])
+    ctx = multiprocessing.get_context("spawn")
+    # Should succeed.
+    groups = _build_stage_groups(cfg, ctx=ctx)
+    assert len(groups[0].specs) == 2
+
+
+def test_tp_preflight_passes_encoder_with_sglang_backend():
+    cfg = _make_config(
+        factory=_F_SGLANG,
+        factory_args={"backend": "sglang"},
+        tp_size=2,
+        gpu=[0, 1],
+    )
+    ctx = multiprocessing.get_context("spawn")
+    groups = _build_stage_groups(cfg, ctx=ctx)
+    assert len(groups[0].specs) == 2
+    for spec in groups[0].specs:
+        assert spec.single_visible_device is True
+
+
+# ---------------------------------------------------------------------------
+# 6. Real-factory signature lock
+# ---------------------------------------------------------------------------
+
+
+def test_real_factory_signature_lock_image_encoder():
+    """The production image-encoder factory's signature default must stay "local".
+
+    Bumping it to "auto" / "sglang" would silently desync launcher
+    (sees "local") from factory body. See [Backend resolution contract].
+    """
+    from sglang_omni_v1.models.qwen3_omni.stages import create_image_encoder_executor
+
+    sig = inspect.signature(create_image_encoder_executor)
+    assert sig.parameters["backend"].default == "local"
+
+
+def test_real_factory_signature_lock_audio_encoder():
+    from sglang_omni_v1.models.qwen3_omni.stages import create_audio_encoder_executor
+
+    sig = inspect.signature(create_audio_encoder_executor)
+    assert sig.parameters["backend"].default == "local"

--- a/tests/test_encoder_tp_launcher.py
+++ b/tests/test_encoder_tp_launcher.py
@@ -373,16 +373,16 @@ def test_real_factory_signature_lock_image_encoder():
     Bumping it to "auto" / "sglang" would silently desync launcher
     (sees "local") from factory body. See [Backend resolution contract].
     """
-    from sglang_omni_v1.models.qwen3_omni.stages import create_image_encoder_executor
+    from sglang_omni_v1.models.qwen3_omni.stages import create_image_encoder_runner
 
-    sig = inspect.signature(create_image_encoder_executor)
+    sig = inspect.signature(create_image_encoder_runner)
     assert sig.parameters["backend"].default == "local"
 
 
 def test_real_factory_signature_lock_audio_encoder():
-    from sglang_omni_v1.models.qwen3_omni.stages import create_audio_encoder_executor
+    from sglang_omni_v1.models.qwen3_omni.stages import create_audio_encoder_runner
 
-    sig = inspect.signature(create_audio_encoder_executor)
+    sig = inspect.signature(create_audio_encoder_runner)
     assert sig.parameters["backend"].default == "local"
 
 
@@ -403,7 +403,7 @@ def test_resolve_factory_args_rejects_tp_launch_params_in_factory_args(key, valu
     ``StageConfig.tp_size`` is the only public way to set TP size.
     Letting ``factory_args[tp_size]=N`` slip through while
     ``StageConfig.tp_size`` says 1 (or vice versa) silently desyncs
-    the runner's spawn count from the worker's NCCL world size,
+    the runner's spawn count from the runner's NCCL world size,
     hanging bootstrap. ``_resolve_factory_args`` must reject these
     keys with a clear error before any spec is built.
     """

--- a/tests/test_encoder_tp_parity_gpu.py
+++ b/tests/test_encoder_tp_parity_gpu.py
@@ -33,6 +33,12 @@ from pathlib import Path
 
 import pytest
 
+# All tests in this module load the full Qwen3-Omni model — mark them
+# slow so the local CPU-only CI gate (``pytest -m "not slow"``) skips
+# the whole file. CI runners that don't have the checkpoint cached fall
+# through to the module-level ``pytest.skip`` below.
+pytestmark = pytest.mark.slow
+
 torch = pytest.importorskip("torch")
 
 if not torch.cuda.is_available():

--- a/tests/test_encoder_tp_parity_gpu.py
+++ b/tests/test_encoder_tp_parity_gpu.py
@@ -80,9 +80,17 @@ if _MODEL_PATH is None:
 
 @pytest.fixture(scope="module")
 def sglang_image_worker_tp1():
-    """Build a single-rank SGLang encoder worker on cuda:0."""
+    """Build a single-rank SGLang encoder worker on cuda:0.
+
+    Loads ONLY the visual encoder submodule (not the full thinker /
+    talker), per the partial-load contract. Footprint should be ~1-2
+    GB instead of ~57 GB for the full Qwen3-Omni-30B model.
+    """
     from sglang_omni_v1.model_runner.sglang_encoder_worker import (
         SGLangEncoderWorker,
+    )
+    from sglang_omni_v1.models.qwen3_omni.encoder_adapters import (
+        Qwen3OmniImageEncoderAdapter,
     )
 
     worker = SGLangEncoderWorker(
@@ -91,6 +99,7 @@ def sglang_image_worker_tp1():
         tp_rank=0,
         tp_size=1,
         nccl_port=None,
+        encoder_specs=Qwen3OmniImageEncoderAdapter.encoder_specs,
         dtype="float16",
     )
     yield worker
@@ -100,9 +109,52 @@ def test_sglang_worker_pin_cuda_zero_at_tp_size_1(sglang_image_worker_tp1):
     worker = sglang_image_worker_tp1
     # The launcher remap pins us to one visible GPU as cuda:0.
     assert worker.device == torch.device("cuda:0")
-    # The model lives on cuda:0 from get_model(...).
+    # The visual submodule (and its params) lives on cuda:0.
     p = next(worker.model.parameters())
     assert p.device.index == 0
+
+
+def test_partial_load_visual_only_no_thinker_no_talker(sglang_image_worker_tp1):
+    """Locks the partial-load contract.
+
+    The container must hold ONLY the visual submodule. Any
+    LLM/talker/audio module on an image-stage worker means we
+    silently re-introduced the full-model load that the partial loader
+    was built to avoid.
+    """
+    worker = sglang_image_worker_tp1
+    children = dict(worker.model.named_children())
+    assert set(children) == {"visual"}, (
+        f"image-stage container should hold only 'visual', got {sorted(children)}"
+    )
+
+    # The visual submodule itself should not contain any sub-attribute
+    # that looks like a language-model layer or talker block.
+    forbidden = {"thinker", "talker", "audio_tower", "lm_head", "embed_tokens"}
+    for name, _ in worker.model.named_modules():
+        for f in forbidden:
+            assert f not in name.split("."), (
+                f"image-stage container leaked module {name!r}, "
+                f"forbidden component {f!r} should not be present"
+            )
+
+
+def test_partial_load_visual_footprint_under_5gb(sglang_image_worker_tp1):
+    """The visual encoder alone should fit comfortably in <5 GB on
+    fp16. Pre-partial-load we'd see ~57 GB here from the full
+    Qwen3-Omni-30B thinker. Use a generous bound so the test isn't
+    flaky on minor revisions; the regression we care about (loading
+    the full thinker) blows past 5 GB by an order of magnitude.
+    """
+    worker = sglang_image_worker_tp1
+    total_bytes = sum(
+        p.numel() * p.element_size() for p in worker.model.parameters()
+    )
+    total_gb = total_bytes / (1024 ** 3)
+    assert total_gb < 5.0, (
+        f"visual-only encoder is using {total_gb:.2f} GB; the full thinker "
+        f"would land ~57 GB here. Did the partial-load contract regress?"
+    )
 
 
 def test_sglang_worker_world_group_local_rank_zero(sglang_image_worker_tp1):

--- a/tests/test_encoder_tp_parity_gpu.py
+++ b/tests/test_encoder_tp_parity_gpu.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""GPU parity tests for SGLang encoder worker (Phase 1).
+"""GPU parity tests for SGLang encoder runner (Phase 1).
 
 These tests are gated on:
 
@@ -74,26 +74,26 @@ if _MODEL_PATH is None:
 
 
 # ---------------------------------------------------------------------------
-# Worker init lane (tp_size=1)
+# Runner init lane (tp_size=1)
 # ---------------------------------------------------------------------------
 
 
 @pytest.fixture(scope="module")
-def sglang_image_worker_tp1():
-    """Build a single-rank SGLang encoder worker on cuda:0.
+def sglang_image_runner_tp1():
+    """Build a single-rank SGLang encoder runner on cuda:0.
 
     Loads ONLY the visual encoder submodule (not the full thinker /
     talker), per the partial-load contract. Footprint should be ~1-2
     GB instead of ~57 GB for the full Qwen3-Omni-30B model.
     """
-    from sglang_omni_v1.model_runner.sglang_encoder_worker import (
-        SGLangEncoderWorker,
+    from sglang_omni_v1.model_runner.sglang_encoder_runner import (
+        SGLangEncoderRunner,
     )
     from sglang_omni_v1.models.qwen3_omni.encoder_adapters import (
         Qwen3OmniImageEncoderAdapter,
     )
 
-    worker = SGLangEncoderWorker(
+    runner = SGLangEncoderRunner(
         model_path=_MODEL_PATH,
         gpu_id=0,
         tp_rank=0,
@@ -102,28 +102,28 @@ def sglang_image_worker_tp1():
         encoder_specs=Qwen3OmniImageEncoderAdapter.encoder_specs,
         dtype="float16",
     )
-    yield worker
+    yield runner
 
 
-def test_sglang_worker_pin_cuda_zero_at_tp_size_1(sglang_image_worker_tp1):
-    worker = sglang_image_worker_tp1
+def test_sglang_runner_pin_cuda_zero_at_tp_size_1(sglang_image_runner_tp1):
+    runner = sglang_image_runner_tp1
     # The launcher remap pins us to one visible GPU as cuda:0.
-    assert worker.device == torch.device("cuda:0")
+    assert runner.device == torch.device("cuda:0")
     # The visual submodule (and its params) lives on cuda:0.
-    p = next(worker.model.parameters())
+    p = next(runner.model.parameters())
     assert p.device.index == 0
 
 
-def test_partial_load_visual_only_no_thinker_no_talker(sglang_image_worker_tp1):
+def test_partial_load_visual_only_no_thinker_no_talker(sglang_image_runner_tp1):
     """Locks the partial-load contract.
 
     The container must hold ONLY the visual submodule. Any
-    LLM/talker/audio module on an image-stage worker means we
+    LLM/talker/audio module on an image-stage runner means we
     silently re-introduced the full-model load that the partial loader
     was built to avoid.
     """
-    worker = sglang_image_worker_tp1
-    children = dict(worker.model.named_children())
+    runner = sglang_image_runner_tp1
+    children = dict(runner.model.named_children())
     assert set(children) == {"visual"}, (
         f"image-stage container should hold only 'visual', got {sorted(children)}"
     )
@@ -131,7 +131,7 @@ def test_partial_load_visual_only_no_thinker_no_talker(sglang_image_worker_tp1):
     # The visual submodule itself should not contain any sub-attribute
     # that looks like a language-model layer or talker block.
     forbidden = {"thinker", "talker", "audio_tower", "lm_head", "embed_tokens"}
-    for name, _ in worker.model.named_modules():
+    for name, _ in runner.model.named_modules():
         for f in forbidden:
             assert f not in name.split("."), (
                 f"image-stage container leaked module {name!r}, "
@@ -139,16 +139,16 @@ def test_partial_load_visual_only_no_thinker_no_talker(sglang_image_worker_tp1):
             )
 
 
-def test_partial_load_visual_footprint_under_5gb(sglang_image_worker_tp1):
+def test_partial_load_visual_footprint_under_5gb(sglang_image_runner_tp1):
     """The visual encoder alone should fit comfortably in <5 GB on
     fp16. Pre-partial-load we'd see ~57 GB here from the full
     Qwen3-Omni-30B thinker. Use a generous bound so the test isn't
     flaky on minor revisions; the regression we care about (loading
     the full thinker) blows past 5 GB by an order of magnitude.
     """
-    worker = sglang_image_worker_tp1
+    runner = sglang_image_runner_tp1
     total_bytes = sum(
-        p.numel() * p.element_size() for p in worker.model.parameters()
+        p.numel() * p.element_size() for p in runner.model.parameters()
     )
     total_gb = total_bytes / (1024 ** 3)
     assert total_gb < 5.0, (
@@ -157,7 +157,7 @@ def test_partial_load_visual_footprint_under_5gb(sglang_image_worker_tp1):
     )
 
 
-def test_sglang_worker_world_group_local_rank_zero(sglang_image_worker_tp1):
+def test_sglang_runner_world_group_local_rank_zero(sglang_image_runner_tp1):
     """Locks "GPU placement across tp_size=1 and tp_size>1 lanes".
 
     At ``tp_size=1`` the local-master / shard-index slot must be 0, not
@@ -168,7 +168,7 @@ def test_sglang_worker_world_group_local_rank_zero(sglang_image_worker_tp1):
     assert get_world_group().local_rank == 0
 
 
-def test_sglang_worker_tp_size_one_initializes_distributed(sglang_image_worker_tp1):
+def test_sglang_runner_tp_size_one_initializes_distributed(sglang_image_runner_tp1):
     """``init_distributed_environment`` runs even at tp_size=1 — locks
     the [Distributed init is unconditional] section of the RFC."""
     import torch.distributed as dist
@@ -178,7 +178,7 @@ def test_sglang_worker_tp_size_one_initializes_distributed(sglang_image_worker_t
     assert dist.get_world_size() == 1
 
 
-def test_sglang_worker_tp_group_is_resolvable(sglang_image_worker_tp1):
+def test_sglang_runner_tp_group_is_resolvable(sglang_image_runner_tp1):
     """``get_tp_group()`` must resolve, otherwise ColumnParallelLinear /
     RowParallelLinear in the upstream encoder modules would have crashed
     at __init__ time."""
@@ -196,14 +196,14 @@ def test_sglang_worker_tp_group_is_resolvable(sglang_image_worker_tp1):
 
 
 @pytest.fixture(scope="module")
-def synthetic_image_inputs(sglang_image_worker_tp1):
+def synthetic_image_inputs(sglang_image_runner_tp1):
     """A tiny synthetic image in the format the preprocessor would emit.
 
     Patches: 1×4×4 = 16 patches; each patch dim is read from the
     model's vision config (``in_channels × temporal_patch_size ×
     patch_size × patch_size``).
     """
-    vc = sglang_image_worker_tp1.model_config.hf_config.thinker_config.vision_config
+    vc = sglang_image_runner_tp1.model_config.hf_config.thinker_config.vision_config
     in_ch = int(vc.in_channels)
     tps = int(vc.temporal_patch_size)
     ps = int(vc.patch_size)
@@ -217,7 +217,7 @@ def synthetic_image_inputs(sglang_image_worker_tp1):
 
 @pytest.mark.slow
 def test_image_encoder_local_vs_sglang_tp1_parity(
-    sglang_image_worker_tp1, synthetic_image_inputs
+    sglang_image_runner_tp1, synthetic_image_inputs
 ):
     """Verify backend=local and backend=sglang produce equivalent embeddings.
 
@@ -234,8 +234,8 @@ def test_image_encoder_local_vs_sglang_tp1_parity(
     from sglang_omni_v1.proto import StagePayload
     from sglang_omni_v1.scheduling.messages import IncomingMessage
 
-    worker = sglang_image_worker_tp1
-    hf_cfg = worker.model_config.hf_config
+    runner = sglang_image_runner_tp1
+    hf_cfg = runner.model_config.hf_config
     adapter = Qwen3OmniImageEncoderAdapter(
         hf_config=hf_cfg, dtype=torch.float16
     )
@@ -259,7 +259,7 @@ def test_image_encoder_local_vs_sglang_tp1_parity(
         ),
     )
     plan = adapter.build_batch([msg])
-    raw = worker.encode_batch(plan)
+    raw = runner.encode_batch(plan)
 
     sglang_image = raw["image"]
     assert sglang_image is not None

--- a/tests/test_encoder_tp_parity_gpu.py
+++ b/tests/test_encoder_tp_parity_gpu.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GPU parity tests for SGLang encoder worker (Phase 1).
+
+These tests are gated on:
+
+- A CUDA device being available, and
+- A locally cached Qwen3-Omni-30B-A3B-Instruct checkpoint (either via
+  the standard HF cache layout or the ``QWEN3_OMNI_MODEL_PATH`` env
+  override).
+
+When either prerequisite is missing, every test in this module is
+skipped — keeping the unit-test pipeline green on CPU-only CI runners.
+
+Lanes covered (mirrors RFC Phase 1):
+
+1. ``backend="local"`` vs ``backend="sglang", tp_size=1`` parity for the
+   image encoder. Verifies the launcher remap of
+   ``CUDA_VISIBLE_DEVICES`` and that the upstream model loads onto the
+   only visible CUDA device as ``cuda:0``.
+
+2. ``get_world_group().local_rank == 0`` at ``tp_size=1`` (locks the
+   "non-zero gpu_id at tp_size=1" expectation in the RFC).
+
+The full ``tp_size=2`` lane requires multi-process orchestration; that
+shape is exercised by the launcher contract suite at the unit level
+(see ``test_encoder_tp_launcher.py::test_tp_preflight_*``) and by the
+end-to-end speech run.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA unavailable", allow_module_level=True)
+
+
+def _resolve_model_path() -> str | None:
+    """Look up the Qwen3-Omni model path from env or the HF cache."""
+    env_path = os.environ.get("QWEN3_OMNI_MODEL_PATH")
+    if env_path:
+        return env_path
+    cache_root = Path.home() / ".cache" / "huggingface" / "hub"
+    snapshots_root = (
+        cache_root
+        / "models--Qwen--Qwen3-Omni-30B-A3B-Instruct"
+        / "snapshots"
+    )
+    if not snapshots_root.exists():
+        return None
+    for snap in snapshots_root.iterdir():
+        if (snap / "config.json").exists():
+            return str(snap)
+    return None
+
+
+_MODEL_PATH = _resolve_model_path()
+if _MODEL_PATH is None:
+    pytest.skip(
+        "Qwen3-Omni checkpoint not found locally; set QWEN3_OMNI_MODEL_PATH "
+        "or populate ~/.cache/huggingface/hub",
+        allow_module_level=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Worker init lane (tp_size=1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def sglang_image_worker_tp1():
+    """Build a single-rank SGLang encoder worker on cuda:0."""
+    from sglang_omni_v1.model_runner.sglang_encoder_worker import (
+        SGLangEncoderWorker,
+    )
+
+    worker = SGLangEncoderWorker(
+        model_path=_MODEL_PATH,
+        gpu_id=0,
+        tp_rank=0,
+        tp_size=1,
+        nccl_port=None,
+        dtype="float16",
+    )
+    yield worker
+
+
+def test_sglang_worker_pin_cuda_zero_at_tp_size_1(sglang_image_worker_tp1):
+    worker = sglang_image_worker_tp1
+    # The launcher remap pins us to one visible GPU as cuda:0.
+    assert worker.device == torch.device("cuda:0")
+    # The model lives on cuda:0 from get_model(...).
+    p = next(worker.model.parameters())
+    assert p.device.index == 0
+
+
+def test_sglang_worker_world_group_local_rank_zero(sglang_image_worker_tp1):
+    """Locks "GPU placement across tp_size=1 and tp_size>1 lanes".
+
+    At ``tp_size=1`` the local-master / shard-index slot must be 0, not
+    the physical GPU id.
+    """
+    from sglang.srt.distributed.parallel_state import get_world_group
+
+    assert get_world_group().local_rank == 0
+
+
+def test_sglang_worker_tp_size_one_initializes_distributed(sglang_image_worker_tp1):
+    """``init_distributed_environment`` runs even at tp_size=1 — locks
+    the [Distributed init is unconditional] section of the RFC."""
+    import torch.distributed as dist
+
+    # Initialized, single-rank world.
+    assert dist.is_initialized()
+    assert dist.get_world_size() == 1
+
+
+def test_sglang_worker_tp_group_is_resolvable(sglang_image_worker_tp1):
+    """``get_tp_group()`` must resolve, otherwise ColumnParallelLinear /
+    RowParallelLinear in the upstream encoder modules would have crashed
+    at __init__ time."""
+    from sglang.srt.distributed.parallel_state import get_tp_group
+
+    tp = get_tp_group()
+    assert tp is not None
+    # World coords match.
+    assert tp.world_size == 1
+
+
+# ---------------------------------------------------------------------------
+# End-to-end image encode parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def synthetic_image_inputs(sglang_image_worker_tp1):
+    """A tiny synthetic image in the format the preprocessor would emit.
+
+    Patches: 1×4×4 = 16 patches; each patch dim is read from the
+    model's vision config (``in_channels × temporal_patch_size ×
+    patch_size × patch_size``).
+    """
+    vc = sglang_image_worker_tp1.model_config.hf_config.thinker_config.vision_config
+    in_ch = int(vc.in_channels)
+    tps = int(vc.temporal_patch_size)
+    ps = int(vc.patch_size)
+    patch_dim = in_ch * tps * ps * ps
+
+    rng = torch.Generator(device="cpu").manual_seed(0)
+    grid = torch.tensor([[1, 4, 4]], dtype=torch.long)
+    pixel = torch.randn(16, patch_dim, generator=rng, dtype=torch.float32)
+    return pixel, grid
+
+
+@pytest.mark.slow
+def test_image_encoder_local_vs_sglang_tp1_parity(
+    sglang_image_worker_tp1, synthetic_image_inputs
+):
+    """Verify backend=local and backend=sglang produce equivalent embeddings.
+
+    Tolerance is float16-loose because both encoders run in fp16 and
+    accumulator order can differ slightly between the HF reference path
+    and the SGLang ``ColumnParallelLinear``/``RowParallelLinear`` path.
+    """
+    pixel, grid = synthetic_image_inputs
+
+    # SGLang side via the adapter
+    from sglang_omni_v1.models.qwen3_omni.encoder_adapters import (
+        Qwen3OmniImageEncoderAdapter,
+    )
+    from sglang_omni_v1.proto import StagePayload
+    from sglang_omni_v1.scheduling.messages import IncomingMessage
+
+    worker = sglang_image_worker_tp1
+    hf_cfg = worker.model_config.hf_config
+    adapter = Qwen3OmniImageEncoderAdapter(
+        hf_config=hf_cfg, dtype=torch.float16
+    )
+    msg = IncomingMessage(
+        request_id="r0",
+        type="new_request",
+        data=StagePayload(
+            request_id="r0",
+            request=None,
+            data={
+                "encoder_inputs": {
+                    "image_encoder": {
+                        "pixel_values": pixel.to("cuda:0"),
+                        # Upstream get_image_feature dispatches grid_thw
+                        # through compute_cu_seqlens_from_grid_numpy,
+                        # which asserts a CPU tensor.
+                        "image_grid_thw": grid,
+                    }
+                }
+            },
+        ),
+    )
+    plan = adapter.build_batch([msg])
+    raw = worker.encode_batch(plan)
+
+    sglang_image = raw["image"]
+    assert sglang_image is not None
+    assert sglang_image.is_cuda
+
+    # The local fallback path goes through the HF tower wrapper. We only
+    # need to assert that the SGLang output has the expected shape and
+    # is finite — the strict numerical comparison vs the local HF tower
+    # is done in the broader Phase-1 suite (``examples/qwen3_omni_speech.py``
+    # E2E run). Loading both tower variants in the same process at the
+    # same time blows up OOM, so we keep this test SGLang-only here and
+    # rely on the launcher-process E2E run for the head-to-head compare.
+    assert torch.isfinite(sglang_image).all()
+    # token count = 1 * 4 * 4 // (spatial_merge_size**2)
+    spatial_merge = hf_cfg.thinker_config.vision_config.spatial_merge_size
+    expected_tokens = (1 * 4 * 4) // (spatial_merge ** 2)
+    assert sglang_image.shape[0] == expected_tokens

--- a/tests/test_parity_compare.py
+++ b/tests/test_parity_compare.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import pickle
+import subprocess
+import sys
+from pathlib import Path
+
+import torch
+
+
+SCRIPT = Path(__file__).with_name("parity_compare.py")
+
+
+def _dump(
+    path: Path, image_embeds: torch.Tensor, layers: dict[str, torch.Tensor] | None = None
+) -> None:
+    with open(path, "wb") as f:
+        payload = {"image_embeds": image_embeds, "deepstack": None}
+        if layers is not None:
+            payload["layers"] = layers
+        pickle.dump(payload, f)
+
+
+def test_tp_gate_passes_directional_match(tmp_path: Path) -> None:
+    left = torch.eye(4, dtype=torch.float16)
+    right = left.clone()
+    right[0, 0] += 1e-4
+    left_path = tmp_path / "left.pkl"
+    right_path = tmp_path / "right.pkl"
+    _dump(left_path, left)
+    _dump(right_path, right)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(left_path), str(right_path), "--tp"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "TP parity: PASS" in result.stdout
+
+
+def test_tp_gate_fails_low_cosine(tmp_path: Path) -> None:
+    left_path = tmp_path / "left.pkl"
+    right_path = tmp_path / "right.pkl"
+    _dump(left_path, torch.eye(4, dtype=torch.float16))
+    _dump(right_path, -torch.eye(4, dtype=torch.float16))
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(left_path), str(right_path), "--tp"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "TP parity: FAIL" in result.stdout
+
+
+def test_layer_compare_skips_shard_local_shape_mismatch(tmp_path: Path) -> None:
+    left_path = tmp_path / "left.pkl"
+    right_path = tmp_path / "right.pkl"
+    _dump(
+        left_path,
+        torch.eye(4, dtype=torch.float16),
+        layers={
+            "blk_00": torch.zeros((2, 4), dtype=torch.float16),
+            "blk_00.attn.qkv_proj": torch.zeros((2, 8), dtype=torch.float16),
+        },
+    )
+    _dump(
+        right_path,
+        torch.eye(4, dtype=torch.float16),
+        layers={
+            "blk_00": torch.zeros((2, 4), dtype=torch.float16),
+            "blk_00.attn.qkv_proj": torch.zeros((2, 4), dtype=torch.float16),
+        },
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            str(left_path),
+            str(right_path),
+            "--layers",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "skipped shape-mismatched shard-local tensors" in result.stdout
+    assert "blk_00.attn.qkv_proj" in result.stdout


### PR DESCRIPTION
## Motivation

Closes the encoder-OOM problem from #375 for long-video / high-resolution multi-image
Qwen3-Omni inputs by reusing SGLang's native encoder implementations and inheriting
SGLang TP, instead of carrying parallel HF encoder copies under
`sglang_omni_v1/models/<name>/components/`. Implements **Plan B**, Phase 0.

This branch is **stacked**: 8 design-doc commits from the RFC author followed by
7 implementation commits. The RFC remains the source of truth for what the
implementation is meant to do; the impl commits map directly onto its sections.

This PR is **WIP / Draft**. Phase 1 long-video E2E and Phase 2 default flip
are tracked separately; everything in this PR is opt-in (default
`backend="local"` preserved).

## Modifications

### Design RFC (8 commits, vendored at `docs/developer_reference/encoder_tp_path_b_design.md`)

- `3811e5c docs: add Plan B RFC for multimodal encoder TP (issue #375)`
- `82716b0 docs: harden encoder TP recv error handling`
- `b1f3daa docs: clarify encoder TP source of truth`
- `faa9499 docs: make encoder TP forward faults fatal`
- `a2b15c0 docs: address ultrareview nits in encoder TP RFC`
- `041f6bb docs: clarify encoder partial loader plan`
- `857e23e docs: clarify encoder TP motivation and naming`
- `0a3d9a1 docs: add lean encoder TP RFC`

### Implementation (7 commits on top of the RFC)

- `3a4555b [Feature] Encoder TP via SGLang native encoders, Phase 0 (#375)` — new runtime pieces (`scheduling/encoder_scheduler.py`, `model_runner/sglang_encoder_worker.py`, `models/qwen3_omni/encoder_adapters.py`) plus launcher / config plumbing (`pipeline/stage_process.py`, `pipeline/mp_runner.py`, `pipeline/coordinator.py`, `config/compiler.py`, `serve/launcher.py`), `build_sglang_encoder_server_args` with `_ENCODER_PROTECTED_KEYS`, factory backend switch in `models/qwen3_omni/stages.py`, reference deployment script `examples/qwen3_omni_encoder_tp.py`, 75 new unit tests + 5 GPU smoke tests (gated `slow`).
- `1b92f14 [Feature] Encoder TP three-domain error boundary + fail-all plumbing (#375)` — `EncoderScheduler` splits into recoverable pre-forward / fatal forward / recoverable post-forward; `Coordinator.fail_all_active(error)` resolves outstanding completion futures and stream queues so HTTP requests can't hang after a TP rank exits; `_monitor_children` calls it on `StageGroup.any_dead()`.
- `d2862b3 [Bugfix] Encoder adapter must keep grid_thw on CPU after _strip_and_lift (#375)` — found end-to-end on H100: upstream `compute_cu_seqlens_from_grid_numpy` asserts CPU; locked with two unit tests.
- `fe72e64 [Feature] Encoder TP RFC v3 align: grid_thw on CPU + slow-mark GPU parity (#375)` — RFC v3 alignment; module-level `pytest.mark.slow` on the GPU parity file so the CPU-only CI gate skips it cleanly.
- `f326575 [Validation] Encoder TP numerical + semantic parity harness (#375)` — `tests/_encoder_parity_harness.py` + `tests/parity_compare.py` + `tests/run_tp2_parity.sh` plus `docs/developer_reference/encoder_tp_parity_findings.md`.
- `afd72ee [Bugfix] Reject tp_rank/tp_size/nccl_port from user factory_args (#375)` — Codex adversarial-review finding: silent NCCL-bootstrap-hang scenario when `factory_args["tp_size"]=2` desyncs from `StageConfig.tp_size=1`. `_resolve_factory_args` now rejects topology kwargs from `factory_args`/`runtime_overrides`.
- `e85bf0e [Feature] Encoder partial-load: only encoder submodules on encoder GPUs (#375)` — `EncoderModuleSpec` + `EncoderModuleContainer`; worker partial-loads only the upstream encoder submodules an adapter declared (visual: 351 weights; audio: 525 weights), drops ~27 700 LLM/talker weights without allocation. Audio path's fused-shard `q_proj`/`k_proj`/`v_proj` → `qkv_proj` dispatch via spec `stacked_params_mapping` (caught a real audio-NaN bug end-to-end). Visual delegates to its submodule's own `load_weights`.

## Related Issues

Closes #375.

## Accuracy Test

### Numerical parity (Phase 1, RFC step 7-8) — `tests/_encoder_parity_harness.py`

| Lane | Tokens match | dtype match | Distribution | RFC `atol=1e-3, rtol=1e-3` | Mean per-token cosine sim |
|---|:-:|:-:|---|:-:|---|
| `backend="local"` vs `backend="sglang"` (tp=1, real `cars.jpg`) | ✅ (6042, 2048) | ✅ fp16 | local mean=0.0041 std=0.3294; sglang mean=0.0040 std=0.3296 | ❌ (84% tokens ≥ 0.99) | **0.988** |
| `tp_size=1` vs `tp_size=2` (both sglang) | ✅ | ✅ fp16 | identical at 4 decimals | ❌ (one outlier at 0.27) | **0.999984** |

The strict RFC tolerance fails on **both** lanes — local-vs-sglang because
the two implementations (HF transformers `Qwen3OmniMoeVisionEncoder` vs
SGLang's reimplemented `Qwen3VLMoeVisionModel`) are not bit-equivalent;
tp1-vs-tp2 because of NCCL fp16 accumulation-order noise. The findings
doc (`docs/developer_reference/encoder_tp_parity_findings.md`) recommends
relaxing the Phase 1 bar to `mean_per_token_cosine_sim ≥ 0.999` (passes
today at 0.999984 for tp parity).

### Semantic parity (replaces "non-empty string" assertions)

Run against the SGLang backend with image+audio encoders flipped via
`runtime_overrides`, on real Qwen3-Omni-30B-A3B-Instruct on 3 H100s
(image_encoder GPU 0, audio_encoder GPU 1, thinker GPU 2):

| Probe | Output | Verdict |
|---|---|:-:|
| `image_semantic_count_cars` | `"4cars"` | ✅ correct count |
| `docs_image_text` | `"Based on the image provided, we can analyze the content to determine the number of"` | ✅ |
| `docs_audio_image` | `"Based on the original image provided, we can count the number of distinct cars shown"` | ✅ |
| `audio_changes_response` | cars-question vs draw-question diverge | ✅ audio path active |
| `audio_question_about_cars_answers_count` | full per-quadrant breakdown of all 4 vehicles (Rolls-Royce, Mercedes, Ferrari, Porsche) | ✅ both paths fed |
| `video_semantic_draw_with_tool` | `"someone uses a stylus to draw an acoustic guitar"` | ✅ hits both required keywords |
| `test_health` | 200 | ✅ |

### Partial-load footprint validation

`EncoderModuleContainer.load_weights` logs from the production run:
```
loaded=525 skipped=27485   <-- audio  (525/525 audio_tower keys load; ~98% of stream dropped)
loaded=351 skipped=27659   <-- visual (delegated to submodule's own load_weights)
```
Visual-only encoder fits in **<5 GB** vs ~57 GB for the full thinker
(`test_partial_load_visual_footprint_under_5gb` enforces).

## Benchmark & Profiling

Long-video E2E benchmark (RFC Phase 1 step 9) is the next item on the
plan and **not in this PR** — gating on Phase 1 sign-off so we land the
Phase 0 surface first.

## Checklist

- [x] Format your code according with pre-commit. _(no formatter changes
      detected by `git diff`; matches surrounding style)_
- [x] Add unit tests. **111 new encoder TP unit tests** + **5 GPU-gated
      partial-load tests** (`tests/test_encoder_*.py`,
      `tests/test_encoder_module_container.py`,
      `tests/test_encoder_runner_fail_all.py`,
      `tests/test_encoder_tp_parity_gpu.py`).
- [x] Update documentation / docstrings / example tutorials as needed.
      RFC vendored at
      `docs/developer_reference/encoder_tp_path_b_design.md` (RFC author's
      8 commits); parity findings at
      `docs/developer_reference/encoder_tp_parity_findings.md`;
      reference launcher at `examples/qwen3_omni_encoder_tp.py`.
- [x] Provide throughput / latency benchmark results and accuracy
      evaluation results as needed. _(accuracy table above; long-video
      throughput in follow-up PR.)_

## CI

- All Phase 0 unit tests pass locally: 111/111 in the encoder TP suite,
  212/212 in the broader `pytest tests/ -m "not benchmark and not docs and
  not slow"` gate.
- Defaults are unchanged (`backend="local"` everywhere). The pre-existing
  qwen3-omni-v1 / s2-pro-v1 CI lanes should be unaffected; please apply
  `run-ci` to verify.

## Out of scope (follow-up PRs)

- Phase 1 long-video E2E (RFC step 9).
- Phase 2 flip `_resolve_backend("auto", ...)` to `"sglang"` + update
  default `PipelineConfig` template to carry `backend="auto"` explicitly.
- Phase 3 delete `models/qwen3_omni/components/{image_encoder,audio_encoder}.py`.
- Phase 4 typed `StageMemoryConfig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)