### PR TITLE
misc: simplify fixed v1 attribute access

### DIFF
--- a/sglang_omni_v1/relay/mooncake.py
+++ b/sglang_omni_v1/relay/mooncake.py
@@ -764,9 +764,8 @@ class MooncakeRelay(Relay):
             logger.info(f"[{self.engine_id}] Notification listener task cancelled")
 
         # Deregister memory pool
-        if hasattr(self, "pool_handle"):
-            self.connection.deregister_memory(self.pool_handle)
-            logger.info(f"[{self.engine_id}] Memory pool deregistered")
+        self.connection.deregister_memory(self.pool_handle)
+        logger.info(f"[{self.engine_id}] Memory pool deregistered")
 
         # Close Mooncake connection
         self.connection.close()

--- a/sglang_omni_v1/relay/nixl.py
+++ b/sglang_omni_v1/relay/nixl.py
@@ -343,7 +343,7 @@ class NixlRelay(Relay):
         pass
 
     def close(self):
-        if NIXL_AVAILABLE and hasattr(self, "pool_handle"):
+        if NIXL_AVAILABLE:
             try:
                 self.connection._nixl.deregister_memory(self.pool_handle)
             except:

--- a/sglang_omni_v1/serve/openai_api.py
+++ b/sglang_omni_v1/serve/openai_api.py
@@ -426,14 +426,13 @@ def _build_chat_generate_request(req: ChatCompletionRequest) -> GenerateRequest:
         metadata["video_total_pixels"] = req.video_total_pixels
 
     extra_params: dict[str, Any] = {}
-    for field_name in (
-        "talker_temperature",
-        "talker_top_p",
-        "talker_top_k",
-        "talker_repetition_penalty",
-        "talker_max_new_tokens",
+    for field_name, value in (
+        ("talker_temperature", req.talker_temperature),
+        ("talker_top_p", req.talker_top_p),
+        ("talker_top_k", req.talker_top_k),
+        ("talker_repetition_penalty", req.talker_repetition_penalty),
+        ("talker_max_new_tokens", req.talker_max_new_tokens),
     ):
-        value = getattr(req, field_name)
         if value is not None:
             extra_params[field_name] = value
 


### PR DESCRIPTION
## Motivation

This PR removes a few redundant dynamic attribute checks in `sglang_omni_v1` where the attributes are fixed by the local request schema or by successful relay construction.

The scope is intentionally small: it does not touch dynamic accesses for Hugging Face configs, optional model APIs, upstream SGLang compatibility, or runtime-attached request data.

## Modifications

- Read Qwen talker override fields directly from `ChatCompletionRequest` instead of looking them up by string. These fields are declared on the Pydantic request model, and the previous `getattr(req, field_name)` had no default fallback.
- Remove the `pool_handle` existence guard from `MooncakeRelay.close()`. `pool_handle` is assigned in both constructor branches after the memory pool is created.
- Remove the `pool_handle` existence guard from `NixlRelay.close()` while preserving the `NIXL_AVAILABLE` deregistration gate. `pool_handle` is assigned in both constructor branches before a relay instance can be returned.

## Validation

N/A

## Checklist

- [x] Format your code according to the contribution guide.
- [x] Add or update tests as needed.
- [x] Update documentation as needed.
- [x] Provide accuracy and speed results when the change affects them.
