### PR TITLE
[V1] Mount profiler routes on multi-process launcher path

### DIFF
--- a/sglang_omni_v1/pipeline/mp_runner.py
+++ b/sglang_omni_v1/pipeline/mp_runner.py
@@ -279,6 +279,21 @@ class MultiProcessPipelineRunner:
             raise RuntimeError("Runner not started")
         return self._coordinator
 
+    @property
+    def stage_control_endpoints(self) -> dict[str, str]:
+        """Return leader control-plane endpoints for externally addressable stages."""
+        if not self._started:
+            raise RuntimeError("Runner not started")
+        endpoints: dict[str, str] = {}
+        for group in self._groups:
+            endpoint = group.leader_endpoint
+            if not endpoint:
+                raise RuntimeError(
+                    f"Cannot resolve control endpoint for stage={group.stage_name}"
+                )
+            endpoints[group.stage_name] = endpoint
+        return endpoints
+
     async def start(self, timeout: float = 120.0) -> None:
         if self._started:
             raise RuntimeError("Already started")

--- a/sglang_omni_v1/serve/launcher.py
+++ b/sglang_omni_v1/serve/launcher.py
@@ -28,6 +28,7 @@ import asyncio
 import logging
 import os
 import socket
+import tempfile
 import time
 from contextlib import suppress
 from typing import Any
@@ -68,8 +69,9 @@ def _default_run_id() -> str:
     return time.strftime("run_%Y%m%d_%H%M%S")
 
 
-def _default_template(profiler_dir: str, run_id: str) -> str:
-    return os.path.join(profiler_dir, run_id, "trace")
+def _default_template(profiler_dir: str | None, run_id: str) -> str:
+    base_dir = profiler_dir or os.path.join(tempfile.gettempdir(), "sglang_omni_v1")
+    return os.path.join(base_dir, run_id, "trace")
 
 
 # ---------------------------------------------------------------------------
@@ -99,12 +101,14 @@ class StopReq(BaseModel):
 
 
 def _mount_profiler_routes(
-    app, profiler_ctl: ProfilerControlClient, profiler_dir: str
+    app, profiler_ctl: ProfilerControlClient, profiler_dir: str | None
 ) -> None:
     router = APIRouter()
+    active_run_id: str | None = None
 
     @router.post("/start_profile")
     async def start(req: StartReq):
+        nonlocal active_run_id
         run_id = req.run_id or _default_run_id()
         tpl = req.trace_path_template or _default_template(profiler_dir, run_id)
         await profiler_ctl.broadcast_start(
@@ -112,12 +116,16 @@ def _mount_profiler_routes(
             trace_path_template=tpl,
             config=req.config,
         )
+        active_run_id = run_id
         return {"run_id": run_id, "trace_path_template": tpl}
 
     @router.post("/stop_profile")
     async def stop(req: StopReq):
-        run_id = req.run_id or "default"
+        nonlocal active_run_id
+        run_id = req.run_id or active_run_id or "default"
         await profiler_ctl.broadcast_stop(run_id=run_id)
+        if active_run_id == run_id:
+            active_run_id = None
         return {"run_id": run_id}
 
     app.include_router(router)
@@ -168,6 +176,7 @@ async def _run_server(
             len(gpu_ids),
         )
 
+        profiler_ctl: ProfilerControlClient | None = None
         try:
             cl_kwargs = client_kwargs or {}
             client = Client(coordinator, **cl_kwargs)
@@ -175,6 +184,10 @@ async def _run_server(
                 client,
                 model_name=model_name or pipeline_config.name,
             )
+
+            profiler_dir = os.environ.get("SGLANG_TORCH_PROFILER_DIR")
+            profiler_ctl = ProfilerControlClient(mp_runner.stage_control_endpoints)
+            _mount_profiler_routes(app, profiler_ctl, profiler_dir)
 
             config = uvicorn.Config(
                 app,
@@ -186,6 +199,8 @@ async def _run_server(
             server = uvicorn.Server(config)
             await server.serve()
         finally:
+            if profiler_ctl is not None:
+                await profiler_ctl.close()
             logger.info("Shutting down pipeline …")
             await mp_runner.stop()
             logger.info("Pipeline stopped.")
@@ -198,6 +213,7 @@ async def _run_server(
         stage_tasks = []
         coordinator_started = False
 
+        profiler_ctl: ProfilerControlClient | None = None
         try:
             stage_endpoints = _collect_stage_control_endpoints(stages)
             await coordinator.start()
@@ -231,6 +247,8 @@ async def _run_server(
             server = uvicorn.Server(config)
             await server.serve()
         finally:
+            if profiler_ctl is not None:
+                await profiler_ctl.close()
             logger.info("Shutting down pipeline …")
             for t in stage_tasks:
                 t.cancel()

--- a/tests/test_v1_ipc_runtime_dir.py
+++ b/tests/test_v1_ipc_runtime_dir.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Omni V1 IPC runtime directory lifecycle tests."""
+"""Omni V1 IPC runtime directory and launcher profiler lifecycle tests."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 pytest.importorskip("torch")
 
@@ -69,6 +70,31 @@ def _make_config(base_path: str, *, scheme: str = "ipc") -> PipelineConfig:
                 factory="tests.test_v1_ipc_runtime_dir.noop_factory",
                 terminal=True,
             )
+        ],
+        endpoints=EndpointsConfig(
+            scheme=scheme,
+            base_path=base_path,
+        ),
+    )
+
+
+def _make_mp_config(base_path: str, *, scheme: str = "ipc") -> PipelineConfig:
+    return PipelineConfig(
+        model_path="Qwen/Qwen3-Omni-30B-A3B-Instruct",
+        entry_stage="preprocessing",
+        stages=[
+            StageConfig(
+                name="preprocessing",
+                factory="tests.test_v1_ipc_runtime_dir.noop_factory",
+                next="decode",
+                gpu=0,
+            ),
+            StageConfig(
+                name="decode",
+                factory="tests.test_v1_ipc_runtime_dir.noop_factory",
+                terminal=True,
+                gpu=1,
+            ),
         ],
         endpoints=EndpointsConfig(
             scheme=scheme,
@@ -275,6 +301,28 @@ class TestV1MultiProcessRunnerIpcCleanup(unittest.IsolatedAsyncioTestCase):
 
             self.assertEqual(list(Path(tmp_dir).iterdir()), [])
 
+    async def test_mp_runner_exposes_stage_control_endpoints(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = _make_config(tmp_dir)
+            from sglang_omni_v1.pipeline.mp_runner import MultiProcessPipelineRunner
+
+            runner = MultiProcessPipelineRunner(config)
+
+            with self.assertRaisesRegex(RuntimeError, "Runner not started"):
+                _ = runner.stage_control_endpoints
+
+            try:
+                await runner.start(timeout=30.0)
+
+                endpoints = runner.stage_control_endpoints
+                self.assertEqual(set(endpoints), {"preprocessing"})
+                self.assertEqual(
+                    endpoints["preprocessing"],
+                    runner._groups[0].leader_endpoint,
+                )
+            finally:
+                await runner.stop()
+
 
 class TestV1LauncherIpcCleanup(unittest.IsolatedAsyncioTestCase):
     async def _run_single_process_launcher_with_mocked_server(
@@ -408,3 +456,158 @@ class TestV1LauncherIpcCleanup(unittest.IsolatedAsyncioTestCase):
             self.assertFalse(coordinator.started)
             coordinator.stop.assert_awaited_once()
             self.assertFalse(runtime_path.exists())
+
+    async def test_multi_process_launcher_mounts_profiler_routes(
+        self,
+    ) -> None:
+        class _FakeMpRunner:
+            instances: list["_FakeMpRunner"] = []
+
+            def __init__(self, config: PipelineConfig):
+                self.config = config
+                self.coordinator = _FakeCoordinator()
+                self.stage_control_endpoints = {
+                    "preprocessing": "ipc://runtime/stage_preprocessing.sock",
+                    "decode": "ipc://runtime/stage_decode.sock",
+                }
+                self.started = False
+                self.stopped = False
+                _FakeMpRunner.instances.append(self)
+
+            async def start(self, timeout: float) -> None:
+                self.started = True
+                self.startup_timeout = timeout
+
+            async def stop(self) -> None:
+                self.stopped = True
+
+        class _FakeProfilerControlClient:
+            instances: list["_FakeProfilerControlClient"] = []
+
+            def __init__(self, stage_endpoints: dict[str, str]):
+                self.stage_endpoints = dict(stage_endpoints)
+                self.start_calls: list[dict] = []
+                self.stop_calls: list[str] = []
+                self.closed = False
+                _FakeProfilerControlClient.instances.append(self)
+
+            async def broadcast_start(
+                self,
+                run_id: str,
+                trace_path_template: str,
+                config: dict | None = None,
+            ) -> None:
+                self.start_calls.append(
+                    {
+                        "run_id": run_id,
+                        "trace_path_template": trace_path_template,
+                        "config": config,
+                    }
+                )
+
+            async def broadcast_stop(self, run_id: str) -> None:
+                self.stop_calls.append(run_id)
+
+            async def close(self) -> None:
+                self.closed = True
+
+        async def _serve_once(server) -> None:
+            app = server.config.app
+            mounted_paths = {route.path for route in app.routes}
+            self.assertIn("/start_profile", mounted_paths)
+            self.assertIn("/stop_profile", mounted_paths)
+
+            with TestClient(app) as client:
+                start_response = client.post(
+                    "/start_profile",
+                    json={
+                        "run_id": "profile-1",
+                        "trace_path_template": "/tmp/{run_id}/{stage}/trace",
+                        "config": {"wait": 1},
+                    },
+                )
+                self.assertEqual(start_response.status_code, 200)
+
+                stop_response = client.post(
+                    "/stop_profile",
+                    json={"run_id": "profile-1"},
+                )
+                self.assertEqual(stop_response.status_code, 200)
+
+                default_start_response = client.post(
+                    "/start_profile",
+                    json={},
+                )
+                self.assertEqual(default_start_response.status_code, 200)
+                default_run_id = default_start_response.json()["run_id"]
+
+                default_stop_response = client.post(
+                    "/stop_profile",
+                    json={},
+                )
+                self.assertEqual(default_stop_response.status_code, 200)
+                self.assertEqual(
+                    default_stop_response.json()["run_id"],
+                    default_run_id,
+                )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config = _make_mp_config(tmp_dir)
+
+            from sglang_omni_v1.serve.launcher import _run_server
+
+            with (
+                patch(
+                    "sglang_omni_v1.serve.launcher._find_available_port",
+                    return_value=8000,
+                ),
+                patch(
+                    "sglang_omni_v1.pipeline.mp_runner.MultiProcessPipelineRunner",
+                    _FakeMpRunner,
+                ),
+                patch(
+                    "sglang_omni_v1.serve.launcher.ProfilerControlClient",
+                    _FakeProfilerControlClient,
+                ),
+                patch(
+                    "sglang_omni_v1.serve.launcher.uvicorn.Server.serve",
+                    new=_serve_once,
+                ),
+            ):
+                await _run_server(config, port=8000)
+
+        runner = _FakeMpRunner.instances[0]
+        profiler_ctl = _FakeProfilerControlClient.instances[0]
+
+        self.assertTrue(runner.started)
+        self.assertTrue(runner.stopped)
+        self.assertEqual(profiler_ctl.stage_endpoints, runner.stage_control_endpoints)
+        self.assertEqual(
+            profiler_ctl.start_calls,
+            [
+                {
+                    "run_id": "profile-1",
+                    "trace_path_template": "/tmp/{run_id}/{stage}/trace",
+                    "config": {"wait": 1},
+                },
+                {
+                    "run_id": profiler_ctl.start_calls[1]["run_id"],
+                    "trace_path_template": (
+                        f"{tempfile.gettempdir()}/sglang_omni_v1/"
+                        f"{profiler_ctl.start_calls[1]['run_id']}/trace"
+                    ),
+                    "config": None,
+                },
+            ],
+        )
+        self.assertTrue(profiler_ctl.start_calls[1]["run_id"].startswith("run_"))
+        self.assertTrue(
+            profiler_ctl.start_calls[1]["trace_path_template"].endswith(
+                f"{profiler_ctl.start_calls[1]['run_id']}/trace"
+            )
+        )
+        self.assertEqual(
+            profiler_ctl.stop_calls,
+            ["profile-1", profiler_ctl.start_calls[1]["run_id"]],
+        )
+        self.assertTrue(profiler_ctl.closed)


### PR DESCRIPTION
## Motivation

V1 profiler routes are only mounted in `_run_server`'s single-process branch. Multi-GPU Qwen3-Omni goes through `MultiProcessPipelineRunner`, so `/start_profile` and `/stop_profile` are unreachable.

`stop_profile` sends `"default"` when `run_id` is omitted instead of stopping the active run. The launcher also never closes `ProfilerControlClient`.

## Modifications

- Expose `stage_control_endpoints` on `MultiProcessPipelineRunner`.
- Mount profiler routes in `_run_server`'s multi-process branch.
- Default `stop_profile` to the tracked active `run_id` instead of `"default"`.
- Close `ProfilerControlClient` in each `finally` block.
- Fall back `_default_template` to `tempfile.gettempdir()` when `SGLANG_TORCH_PROFILER_DIR` is unset.
- Add regression tests in `tests/test_v1_ipc_runtime_dir.py`.

## Accuracy Tests

Existing IPC tests pass. New tests cover explicit and default `run_id` flows, and `close` on shutdown.


