### PR TITLE
[Bugfix] Add v1 stage output cache without legacy dependency

### DIFF
--- a/sglang_omni_v1/models/qwen3_omni/stages.py
+++ b/sglang_omni_v1/models/qwen3_omni/stages.py
@@ -46,14 +46,11 @@ from sglang_omni_v1.proto import StagePayload
 
 logger = logging.getLogger(__name__)
 
-# V0 guardrail for image-encoder admission. This is deliberately explicit,
-# not derived from transient free GPU memory during multiprocess startup.
+# Image-encoder batching budget; the multiplier accounts for transient activations.
 QWEN3_IMAGE_ENCODER_BATCH_BUDGET_BYTES = 10 * 1024**3
-# Covers temporary visual-forward activations beyond input/output tensors.
 QWEN3_IMAGE_ENCODER_ACTIVATION_MULTIPLIER = 5
 
-# Keep repeated-media encoder cache useful without retaining unbounded host
-# tensors. 4096 MiB matches SGLang's disaggregated VLM encode cache default.
+# CPU LRU cap for repeated-media encoder outputs.
 QWEN3_ENCODER_CACHE_MAX_BYTES = 4 * 1024**3
 QWEN3_ENCODER_CACHE_MAX_ENTRIES = 64
 

--- a/sglang_omni_v1/models/qwen3_omni/stages.py
+++ b/sglang_omni_v1/models/qwen3_omni/stages.py
@@ -15,12 +15,6 @@ import torch
 import torch.nn.functional as F
 from transformers import AutoTokenizer
 
-from sglang_omni.engines.omni.runtime.cache import SimpleCacheManager
-from sglang_omni.engines.omni.types import RequestOutput, SchedulerRequest
-from sglang_omni.models.qwen3_omni.pipeline.visual_budget import (
-    QWEN3_IMAGE_ENCODER_ACTIVATION_MULTIPLIER,
-    QWEN3_IMAGE_ENCODER_BATCH_BUDGET_BYTES,
-)
 from sglang_omni_v1.models.qwen3_omni.bootstrap import create_thinker_scheduler
 from sglang_omni_v1.models.qwen3_omni.components.audio_encoder import (
     Qwen3OmniAudioEncoder,
@@ -41,6 +35,7 @@ from sglang_omni_v1.scheduling.sglang_backend import (
     apply_encoder_mem_reserve,
     build_sglang_server_args,
 )
+from sglang_omni_v1.scheduling.stage_cache import StageOutputCache
 from sglang_omni_v1.utils.misc import avail_gpu_mem
 
 IMAGE_STAGE = "image_encoder"
@@ -50,6 +45,12 @@ from sglang_omni_v1.models.qwen3_omni.payload_types import PipelineState
 from sglang_omni_v1.proto import StagePayload
 
 logger = logging.getLogger(__name__)
+
+# V0 guardrail for image-encoder admission. This is deliberately explicit,
+# not derived from transient free GPU memory during multiprocess startup.
+QWEN3_IMAGE_ENCODER_BATCH_BUDGET_BYTES = 10 * 1024**3
+# Covers temporary visual-forward activations beyond input/output tensors.
+QWEN3_IMAGE_ENCODER_ACTIVATION_MULTIPLIER = 5
 
 # Keep repeated-media encoder cache useful without retaining unbounded host
 # tensors. 4096 MiB matches SGLang's disaggregated VLM encode cache default.
@@ -92,7 +93,7 @@ def _run_single_encoder_payload(
     *,
     stage_name: str,
     model: Any,
-    cache_manager: SimpleCacheManager | None = None,
+    cache: StageOutputCache | None = None,
 ) -> StagePayload:
     state = load_state(payload)
     request = build_encoder_request(state, stage_name=stage_name)
@@ -103,7 +104,7 @@ def _run_single_encoder_payload(
             request=request,
             request_id=payload.request_id,
             stage_name=stage_name,
-            cache_manager=cache_manager,
+            cache=cache,
         )
         if result is None:
             with torch.no_grad():
@@ -112,7 +113,7 @@ def _run_single_encoder_payload(
                 request=request,
                 request_id=payload.request_id,
                 stage_name=stage_name,
-                cache_manager=cache_manager,
+                cache=cache,
                 result=result,
             )
     apply_encoder_result(state, stage_name=stage_name, result=result)
@@ -243,11 +244,11 @@ def _lookup_cached_encoder_output(
     request: Any,
     request_id: str,
     stage_name: str,
-    cache_manager: SimpleCacheManager | None,
+    cache: StageOutputCache | None,
 ) -> Any | None:
-    if cache_manager is None or request.cache_key is None:
+    if cache is None or request.cache_key is None:
         return None
-    cached = cache_manager.get(SchedulerRequest(request_id=request_id, data=request))
+    cached = cache.get(request.cache_key)
     if cached is None:
         _trace_encoder_cache(
             stage_name,
@@ -263,9 +264,9 @@ def _lookup_cached_encoder_output(
         request_id=request_id,
         cache_key=request.cache_key,
         input_bytes=_nested_tensor_bytes(request.model_inputs),
-        output_bytes=_nested_tensor_bytes(cached.data),
+        output_bytes=_nested_tensor_bytes(cached),
     )
-    return cached.data
+    return cached
 
 
 def _store_cached_encoder_output(
@@ -273,20 +274,12 @@ def _store_cached_encoder_output(
     request: Any,
     request_id: str,
     stage_name: str,
-    cache_manager: SimpleCacheManager | None,
+    cache: StageOutputCache | None,
     result: Any,
 ) -> None:
-    if cache_manager is None or request.cache_key is None:
+    if cache is None or request.cache_key is None:
         return
-    cache_manager.put(
-        SchedulerRequest(request_id=request_id, data=request),
-        RequestOutput(
-            request_id=request_id,
-            data=result,
-            finished=True,
-            finish_reason="stop",
-        ),
-    )
+    cache.put(request.cache_key, result)
     _trace_encoder_cache(
         stage_name,
         "store",
@@ -307,7 +300,7 @@ def _batch_image_encoder_payloads(
     payloads: list[StagePayload],
     *,
     model: Any,
-    cache_manager: SimpleCacheManager | None = None,
+    cache: StageOutputCache | None = None,
 ) -> list[StagePayload]:
     results: list[StagePayload | None] = [None] * len(payloads)
     active: list[tuple[int, StagePayload, Any, Any]] = []
@@ -323,7 +316,7 @@ def _batch_image_encoder_payloads(
                 payload,
                 stage_name=IMAGE_STAGE,
                 model=model,
-                cache_manager=cache_manager,
+                cache=cache,
             )
             continue
 
@@ -331,7 +324,7 @@ def _batch_image_encoder_payloads(
             request=request,
             request_id=payload.request_id,
             stage_name=IMAGE_STAGE,
-            cache_manager=cache_manager,
+            cache=cache,
         )
         if cached is not None:
             apply_encoder_result(state, stage_name=IMAGE_STAGE, result=cached)
@@ -343,7 +336,7 @@ def _batch_image_encoder_payloads(
                 payload,
                 stage_name=IMAGE_STAGE,
                 model=model,
-                cache_manager=cache_manager,
+                cache=cache,
             )
             continue
 
@@ -490,7 +483,7 @@ def _batch_image_encoder_payloads(
             request=request,
             request_id=meta["payload"].request_id,
             stage_name=IMAGE_STAGE,
-            cache_manager=cache_manager,
+            cache=cache,
             result=stage_result,
         )
         if request.cache_key is not None:
@@ -570,7 +563,7 @@ def _batch_audio_encoder_payloads(
     payloads: list[StagePayload],
     *,
     model: Any,
-    cache_manager: SimpleCacheManager | None = None,
+    cache: StageOutputCache | None = None,
 ) -> list[StagePayload]:
     results: list[StagePayload | None] = [None] * len(payloads)
     active: list[tuple[int, StagePayload, Any, Any]] = []
@@ -583,7 +576,7 @@ def _batch_audio_encoder_payloads(
                 payload,
                 stage_name=AUDIO_STAGE,
                 model=model,
-                cache_manager=cache_manager,
+                cache=cache,
             )
             continue
 
@@ -591,7 +584,7 @@ def _batch_audio_encoder_payloads(
             request=request,
             request_id=payload.request_id,
             stage_name=AUDIO_STAGE,
-            cache_manager=cache_manager,
+            cache=cache,
         )
         if cached is not None:
             apply_encoder_result(state, stage_name=AUDIO_STAGE, result=cached)
@@ -603,7 +596,7 @@ def _batch_audio_encoder_payloads(
                 payload,
                 stage_name=AUDIO_STAGE,
                 model=model,
-                cache_manager=cache_manager,
+                cache=cache,
             )
             continue
 
@@ -664,7 +657,7 @@ def _batch_audio_encoder_payloads(
             request=item["request"],
             request_id=item["payload"].request_id,
             stage_name=AUDIO_STAGE,
-            cache_manager=cache_manager,
+            cache=cache,
             result=stage_result,
         )
         apply_encoder_result(item["state"], stage_name=AUDIO_STAGE, result=stage_result)
@@ -726,7 +719,7 @@ def create_image_encoder_executor(
     from sglang_omni_v1.scheduling.simple_scheduler import SimpleScheduler
 
     model = Qwen3OmniImageEncoder(model_path=model_path, device=device, dtype=dtype)
-    cache_manager = SimpleCacheManager(
+    cache = StageOutputCache(
         max_size=QWEN3_ENCODER_CACHE_MAX_ENTRIES,
         max_bytes=QWEN3_ENCODER_CACHE_MAX_BYTES,
         cache_device="cpu",
@@ -737,14 +730,14 @@ def create_image_encoder_executor(
             payload,
             stage_name=IMAGE_STAGE,
             model=model,
-            cache_manager=cache_manager,
+            cache=cache,
         )
 
     def _encode_batch(payloads: list[StagePayload]) -> list[StagePayload]:
         return _batch_image_encoder_payloads(
             payloads,
             model=model,
-            cache_manager=cache_manager,
+            cache=cache,
         )
 
     # Note (Chenyang): match v0's image-encoder batching shape (max=32) and
@@ -770,7 +763,7 @@ def create_audio_encoder_executor(
     from sglang_omni_v1.scheduling.simple_scheduler import SimpleScheduler
 
     model = Qwen3OmniAudioEncoder(model_path=model_path, device=device, dtype=dtype)
-    cache_manager = SimpleCacheManager(
+    cache = StageOutputCache(
         max_size=QWEN3_ENCODER_CACHE_MAX_ENTRIES,
         max_bytes=QWEN3_ENCODER_CACHE_MAX_BYTES,
         cache_device="cpu",
@@ -781,14 +774,14 @@ def create_audio_encoder_executor(
             payload,
             stage_name=AUDIO_STAGE,
             model=model,
-            cache_manager=cache_manager,
+            cache=cache,
         )
 
     def _encode_batch(payloads: list[StagePayload]) -> list[StagePayload]:
         return _batch_audio_encoder_payloads(
             payloads,
             model=model,
-            cache_manager=cache_manager,
+            cache=cache,
         )
 
     return SimpleScheduler(

--- a/sglang_omni_v1/scheduling/stage_cache.py
+++ b/sglang_omni_v1/scheduling/stage_cache.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+
+@dataclass
+class _CacheEntry:
+    data: Any
+    size_bytes: int
+
+
+def _detach_value(value: Any, *, device: torch.device | None) -> Any:
+    if isinstance(value, torch.Tensor):
+        value = value.detach()
+        if device is not None:
+            value = value.to(device=device)
+        return value
+    if isinstance(value, dict):
+        return {key: _detach_value(item, device=device) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return type(value)(_detach_value(item, device=device) for item in value)
+    return value
+
+
+def _value_size_bytes(value: Any) -> int:
+    if isinstance(value, torch.Tensor):
+        return int(value.numel() * value.element_size())
+    if isinstance(value, dict):
+        return sum(_value_size_bytes(item) for item in value.values())
+    if isinstance(value, (list, tuple)):
+        return sum(_value_size_bytes(item) for item in value)
+    return 0
+
+
+class StageOutputCache:
+    """Small in-memory LRU cache for non-AR stage outputs."""
+
+    def __init__(
+        self,
+        max_size: int | None = None,
+        max_bytes: int | None = None,
+        cache_device: torch.device | str | None = None,
+    ) -> None:
+        if isinstance(cache_device, str):
+            cache_device = torch.device(cache_device)
+        self._cache: OrderedDict[str, _CacheEntry] = OrderedDict()
+        self.max_size = max_size
+        self.max_bytes = max_bytes
+        self.cache_device = cache_device
+        self.current_bytes = 0
+
+    def get(self, key: str | None) -> Any | None:
+        if key is None:
+            return None
+        key = str(key)
+        entry = self._cache.get(key)
+        if entry is None:
+            return None
+        self._cache.move_to_end(key)
+        return entry.data
+
+    def put(self, key: str | None, data: Any) -> None:
+        if key is None:
+            return
+        key = str(key)
+        size_bytes = _value_size_bytes(data)
+        old_entry = self._cache.pop(key, None)
+        if old_entry is not None:
+            self.current_bytes -= old_entry.size_bytes
+        if self.max_bytes is not None and size_bytes > self.max_bytes:
+            return
+        self._cache[key] = _CacheEntry(
+            data=_detach_value(data, device=self.cache_device),
+            size_bytes=size_bytes,
+        )
+        self.current_bytes += size_bytes
+        self._cache.move_to_end(key)
+        self._evict_over_budget()
+
+    def clear(self) -> None:
+        self._cache.clear()
+        self.current_bytes = 0
+
+    def _evict_over_budget(self) -> None:
+        while self.max_size is not None and len(self._cache) > self.max_size:
+            _, entry = self._cache.popitem(last=False)
+            self.current_bytes -= entry.size_bytes
+        while self.max_bytes is not None and self.current_bytes > self.max_bytes:
+            if not self._cache:
+                self.current_bytes = 0
+                return
+            _, entry = self._cache.popitem(last=False)
+            self.current_bytes -= entry.size_bytes

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import threading
 from types import SimpleNamespace
 
+import torch
+
 from sglang_omni_v1.scheduling.messages import IncomingMessage
 from sglang_omni_v1.scheduling.omni_scheduler import OmniScheduler
 from sglang_omni_v1.scheduling.simple_scheduler import SimpleScheduler
+from sglang_omni_v1.scheduling.stage_cache import StageOutputCache
 from sglang_omni_v1.scheduling.threaded_simple_scheduler import ThreadedSimpleScheduler
 from tests.unit_test.pipeline.helpers import run_scheduler
 
@@ -121,3 +124,33 @@ def test_omni_scheduler_default_stream_done_sets_generic_flag() -> None:
     scheduler._mark_stream_done(req_data)
 
     assert req_data.stream_done is True
+
+
+def test_stage_output_cache_eviction_uses_lru_order() -> None:
+    cache = StageOutputCache(max_size=2)
+
+    cache.put("a", torch.tensor([1]))
+    cache.put("b", torch.tensor([2]))
+    assert torch.equal(cache.get("a"), torch.tensor([1]))
+
+    cache.put("c", torch.tensor([3]))
+
+    assert cache.get("b") is None
+    assert torch.equal(cache.get("a"), torch.tensor([1]))
+    assert torch.equal(cache.get("c"), torch.tensor([3]))
+
+
+def test_stage_output_cache_tracks_bytes_and_detaches() -> None:
+    cache = StageOutputCache(max_bytes=8, cache_device="cpu")
+
+    cache.put("fit", {"x": torch.ones(2, dtype=torch.float32, requires_grad=True)})
+    cached = cache.get("fit")
+
+    assert cache.current_bytes == 8
+    assert cached["x"].device.type == "cpu"
+    assert cached["x"].requires_grad is False
+
+    cache.put("too-large", torch.ones(3, dtype=torch.float32))
+
+    assert cache.get("too-large") is None
+    assert cache.current_bytes == 8


### PR DESCRIPTION
## Summary
- add a small v1-native `StageOutputCache` for non-AR stage outputs
- switch Qwen3-Omni encoder caching off legacy scheduler/cache types
- remove remaining `sglang_omni.*` imports from `sglang_omni_v1`
