### PR TITLE
fix(encoder-patch): HF-parity patches for sglang Qwen3-VL vision encoder (#434)

### DIFF
--- a/sglang_omni/model_runner/_sglang_qwen3_vl_patches.py
+++ b/sglang_omni/model_runner/_sglang_qwen3_vl_patches.py
@@ -1,0 +1,309 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HF-parity patches for sglang ``Qwen3VLMoeVisionModel``.
+
+Patches ``fast_pos_embed_interpolate`` and ``rot_pos_emb`` to match HF
+transformers' semantics. See sglang-omni issue #434 for context, scope,
+and removal plan.
+"""
+from __future__ import annotations
+
+import inspect
+import logging
+import re
+import threading
+from typing import Sequence
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+_PATCHED_FLAG = "_sglang_omni_hf_parity_patched"
+
+# Serialize first-call apply so two concurrent callers cannot observe a
+# half-patched class.
+_APPLY_LOCK = threading.Lock()
+
+# Released sglang versions whose Qwen3VLMoeVisionModel layout matches the
+# patch. Dev builds (``0.0.0.dev1+...``) are accepted with a warning since
+# they are unversioned snapshots that may or may not match.
+_SUPPORTED_SGLANG_VERSIONS: frozenset[str] = frozenset({"0.5.8", "0.5.8.post1"})
+
+# Instance attributes the patches read; preflight checks each is present
+# either as a class-level descriptor or as a self.<name> = assignment in
+# any parent's __init__.
+_REQUIRED_INSTANCE_ATTRS: Sequence[str] = (
+    "spatial_merge_size",
+    "num_grid_per_side",
+    "pos_embed",
+    "rotary_pos_emb",
+    "rot_pos_ids",
+    "dtype",
+    "device",
+)
+# Methods the patches replace.
+_REQUIRED_METHODS: Sequence[str] = (
+    "fast_pos_embed_interpolate",
+    "rot_pos_emb",
+)
+
+
+def _patched_fast_pos_embed_interpolate(self, grid_thw):
+    """HF-aligned port; ``grid_thw`` accepts tensor or list."""
+    if hasattr(grid_thw, "tolist"):
+        grid_thw_list = grid_thw.tolist()
+    else:
+        grid_thw_list = list(grid_thw)
+    grid_ts = [row[0] for row in grid_thw_list]
+    grid_hs = [row[1] for row in grid_thw_list]
+    grid_ws = [row[2] for row in grid_thw_list]
+    device = self.pos_embed.weight.device
+
+    idx_list: list[list[int]] = [[] for _ in range(4)]
+    weight_list: list[list[float]] = [[] for _ in range(4)]
+
+    for _t, h, w in grid_thw_list:
+        # Pin to fp32 so the interpolation coords are independent of the
+        # ambient torch default dtype.
+        h_idxs = torch.linspace(0, self.num_grid_per_side - 1, h, dtype=torch.float32)
+        w_idxs = torch.linspace(0, self.num_grid_per_side - 1, w, dtype=torch.float32)
+
+        h_idxs_floor = h_idxs.int()
+        w_idxs_floor = w_idxs.int()
+        h_idxs_ceil = (h_idxs.int() + 1).clip(max=self.num_grid_per_side - 1)
+        w_idxs_ceil = (w_idxs.int() + 1).clip(max=self.num_grid_per_side - 1)
+
+        dh = h_idxs - h_idxs_floor
+        dw = w_idxs - w_idxs_floor
+
+        base_h = h_idxs_floor * self.num_grid_per_side
+        base_h_ceil = h_idxs_ceil * self.num_grid_per_side
+
+        indices = [
+            (base_h[None].T + w_idxs_floor[None]).flatten(),
+            (base_h[None].T + w_idxs_ceil[None]).flatten(),
+            (base_h_ceil[None].T + w_idxs_floor[None]).flatten(),
+            (base_h_ceil[None].T + w_idxs_ceil[None]).flatten(),
+        ]
+
+        weights = [
+            ((1 - dh)[None].T * (1 - dw)[None]).flatten(),
+            ((1 - dh)[None].T * dw[None]).flatten(),
+            (dh[None].T * (1 - dw)[None]).flatten(),
+            (dh[None].T * dw[None]).flatten(),
+        ]
+
+        for i in range(4):
+            idx_list[i].extend(indices[i].tolist())
+            weight_list[i].extend(weights[i].tolist())
+
+    idx_tensor = torch.tensor(idx_list, dtype=torch.long, device=device)
+    weight_tensor = torch.tensor(
+        weight_list, dtype=self.pos_embed.weight.dtype, device=device
+    )
+    pos_embeds = self.pos_embed(idx_tensor).to(device) * weight_tensor[:, :, None]
+    patch_pos_embeds = pos_embeds[0] + pos_embeds[1] + pos_embeds[2] + pos_embeds[3]
+
+    patch_pos_embeds = patch_pos_embeds.split([h * w for h, w in zip(grid_hs, grid_ws)])
+
+    patch_pos_embeds_permute = []
+    merge_size = self.spatial_merge_size
+    for pos_embed, t, h, w in zip(patch_pos_embeds, grid_ts, grid_hs, grid_ws):
+        pos_embed = pos_embed.repeat(t, 1)
+        pos_embed = (
+            pos_embed.view(
+                t, h // merge_size, merge_size, w // merge_size, merge_size, -1
+            )
+            .permute(0, 1, 3, 2, 4, 5)
+            .flatten(0, 4)
+        )
+        patch_pos_embeds_permute.append(pos_embed)
+    return torch.cat(patch_pos_embeds_permute)
+
+
+def _patched_rot_pos_emb(self, grid_thw):
+    """Returns ``(cos, sin)`` at half-dim ``(N, head_dim/2)`` (block cats internally).
+
+    Computes cos/sin in ``self.dtype`` rather than reading fp32 cache.
+    """
+    pos_ids = []
+    for t, h, w in grid_thw:
+        base = self.rot_pos_ids(h, w, self.spatial_merge_size)
+        pos_ids.append(base if t == 1 else base.repeat(t, 1))
+    pos_ids = torch.cat(pos_ids, dim=0).to(self.device, non_blocking=True)
+    max_grid_size = max(max(h, w) for _, h, w in grid_thw)
+
+    rope = self.rotary_pos_emb
+    inv_freq = rope._compute_inv_freq(rope.base).to(
+        device=self.device, dtype=self.dtype
+    )
+    seq = torch.arange(max_grid_size, device=self.device, dtype=self.dtype)
+    freq_table = torch.outer(seq, inv_freq)
+    embeddings = freq_table[pos_ids].flatten(1)
+    return embeddings.cos(), embeddings.sin()
+
+
+def _check_target_class_surface(cls) -> None:
+    """Fail-fast if sglang renamed attrs / methods / helper signatures."""
+    missing_methods = [m for m in _REQUIRED_METHODS if not hasattr(cls, m)]
+    if missing_methods:
+        raise RuntimeError(
+            f"sglang {cls.__module__}.{cls.__name__} missing methods: "
+            f"{missing_methods}"
+        )
+
+    init_sources: list[str] = []
+    for klass in cls.__mro__:
+        if klass is object:
+            break
+        try:
+            init_sources.append(inspect.getsource(klass.__init__))
+        except (TypeError, OSError):
+            # built-in or source unavailable — skip
+            continue
+    combined_init_src = "\n".join(init_sources)
+
+    missing_attrs: list[str] = []
+    for attr in _REQUIRED_INSTANCE_ATTRS:
+        if hasattr(cls, attr):
+            continue
+        if f"self.{attr}" in combined_init_src:
+            continue
+        missing_attrs.append(attr)
+
+    if missing_attrs:
+        raise RuntimeError(
+            f"sglang {cls.__module__}.{cls.__name__} missing attrs: " f"{missing_attrs}"
+        )
+
+    # The patches call ``self.rot_pos_ids(h, w, spatial_merge_size)`` and
+    # ``rope._compute_inv_freq(rope.base)``; an upstream rename of any of
+    # these positional parameters would be a silent semantic break.
+    _check_signature(
+        cls, "rot_pos_ids", expected_names=("h", "w", "spatial_merge_size")
+    )
+
+    try:
+        from sglang.srt.layers.rotary_embedding import RotaryEmbedding
+    except ImportError as exc:
+        raise RuntimeError("sglang RotaryEmbedding import failed") from exc
+
+    _check_signature(RotaryEmbedding, "_compute_inv_freq", expected_names=("base",))
+
+
+def _check_signature(cls, name: str, *, expected_names: tuple[str, ...]) -> None:
+    """Verify ``cls.name`` accepts ``expected_names`` as leading positional args.
+
+    ``self`` is dropped before comparison. Built-in / unintrospectable callables
+    are skipped (we cannot reason about their signatures and refusing to patch
+    on that basis would be over-strict).
+    """
+    fn = getattr(cls, name, None)
+    if not callable(fn):
+        raise RuntimeError(
+            f"sglang {cls.__module__}.{cls.__name__}.{name} missing or not callable"
+        )
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return
+    positional = [
+        p
+        for p in sig.parameters.values()
+        if p.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    ]
+    if positional and positional[0].name == "self":
+        positional = positional[1:]
+    actual_names = tuple(p.name for p in positional[: len(expected_names)])
+    if actual_names != expected_names:
+        raise RuntimeError(
+            f"sglang {cls.__module__}.{cls.__name__}.{name} signature changed: "
+            f"expected leading params {expected_names}, got {actual_names} (full sig: {sig})"
+        )
+
+
+# Matches PEP 440 ``.devN`` markers in the public version segment only.
+# Strip the local-version suffix (``+...``) before matching so legitimate
+# release+local strings like ``0.5.9+foo.dev1`` aren't misclassified.
+_DEV_VERSION_RE = re.compile(r"\.dev\d*$")
+
+
+def _is_dev_version(version: str) -> bool:
+    public = version.split("+", 1)[0]
+    return bool(_DEV_VERSION_RE.search(public))
+
+
+def _check_sglang_version() -> None:
+    """Reject sglang versions outside the validated set; warn for dev builds."""
+    try:
+        import sglang
+    except ImportError as exc:
+        raise RuntimeError(
+            "sglang import failed; cannot apply HF-parity patches."
+        ) from exc
+
+    version = getattr(sglang, "__version__", None)
+    if version is None or _is_dev_version(version):
+        logger.warning(
+            "sglang version %r is a dev build; assuming layout is "
+            "compatible with %s. Pin to a supported release if you see "
+            "parity drift.",
+            version,
+            sorted(_SUPPORTED_SGLANG_VERSIONS),
+        )
+        return
+
+    if version not in _SUPPORTED_SGLANG_VERSIONS:
+        raise RuntimeError(
+            f"sglang=={version} is not in the patch's supported version "
+            f"set {sorted(_SUPPORTED_SGLANG_VERSIONS)}. Either pin sglang "
+            f"to a supported version, or update / remove this patch module."
+        )
+
+
+def apply_qwen3_vl_hf_parity_patches() -> None:
+    """Atomically apply both HF-parity patches to ``Qwen3VLMoeVisionModel``.
+
+    Idempotent (class-level flag) and threadsafe (module-level lock).
+    Raises ``RuntimeError`` on unsupported sglang version or class-surface drift.
+    """
+    _check_sglang_version()
+
+    from sglang.srt.models.qwen3_vl import Qwen3VLMoeVisionModel
+
+    # Fast path without acquiring the lock.
+    if getattr(Qwen3VLMoeVisionModel, _PATCHED_FLAG, False):
+        return
+
+    with _APPLY_LOCK:
+        # Re-check under the lock — another thread may have applied while
+        # we were waiting.
+        if getattr(Qwen3VLMoeVisionModel, _PATCHED_FLAG, False):
+            return
+
+        _check_target_class_surface(Qwen3VLMoeVisionModel)
+
+        # Snapshot originals so a mid-apply failure can roll back, leaving
+        # the class either fully patched or untouched (never half-patched).
+        original_fpei = Qwen3VLMoeVisionModel.fast_pos_embed_interpolate
+        original_rope = Qwen3VLMoeVisionModel.rot_pos_emb
+        try:
+            Qwen3VLMoeVisionModel.fast_pos_embed_interpolate = (
+                _patched_fast_pos_embed_interpolate
+            )
+            Qwen3VLMoeVisionModel.rot_pos_emb = _patched_rot_pos_emb
+        except Exception:
+            Qwen3VLMoeVisionModel.fast_pos_embed_interpolate = original_fpei
+            Qwen3VLMoeVisionModel.rot_pos_emb = original_rope
+            raise
+        setattr(Qwen3VLMoeVisionModel, _PATCHED_FLAG, True)
+
+    logger.info(
+        "Applied HF-parity patches to %s.%s "
+        "(see sglang-omni issue #434 for context).",
+        Qwen3VLMoeVisionModel.__module__,
+        Qwen3VLMoeVisionModel.__name__,
+    )

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,6 +9,7 @@ tests/
 │   ├── qwen3_omni/
 │   └── s2pro/
 ├── test_model/
+│   └── conftest.py
 └── unit_test/
     ├── fixtures/
     │   ├── fish_fakes.py
@@ -48,6 +49,20 @@ General rules:
 - Do not add root-level `tests/test_*.py` files.
 
 
+## Markers
+
+Markers are registered in `pyproject.toml` under `[tool.pytest.ini_options]`.
+Tag each test with the marker that matches its lane and use it to filter runs.
+
+- `benchmark`: GPU performance / parity tests in `test_model/`. May require a
+  populated HF cache and tens of GB of GPU memory; per-test docstrings call
+  out hardware needs.
+- `docs`: documented-example tests in `docs/`. Verify documented request
+  shapes and CLI snippets still work.
+- `s2pro_stage(name)`: in-file CI stage selector for S2-Pro benchmarks.
+  Combined with `--s2pro-stage` (see `test_model/conftest.py`).
+
+
 ## Root Files
 
 - `README.md`: This file. It explains test ownership and where new tests belong.
@@ -74,11 +89,35 @@ Use this lane when the test protects:
 
 These tests are not the default fast unit lane.
 
+Expected command:
+
+```bash
+pytest tests/docs -m docs -v
+```
+
 ## `test_model/`
 
 End-to-end and model CI tests. These are allowed to depend on real servers,
 model snapshots, benchmark artifacts, optional packages, and GPU/runtime
 resources.
+
+Expected command (GPU benchmark subset):
+
+```bash
+pytest tests/test_model -m benchmark -v -s
+```
+
+`conftest.py` owns shared bring-up for everything in this directory:
+
+- `qwen3_omni_thinker_server` / `qwen3_omni_talker_server`: start a real
+  Qwen3-Omni server and yield a `ServerHandle`.
+- `qwen3_omni_vision_sglang_env`: session-scoped SGLang dist + DP-attention
+  init shared by every Qwen3-Omni vision-encoder benchmark module — avoids
+  re-initializing the process-global TP group when the combined `-m benchmark`
+  command runs more than one module.
+- CLI flags `--s2pro-stage {nonstream,stream,consistency,all}` and
+  `--concurrency {1,2,4,8,16,all}`: scope an S2-Pro CI sweep without editing
+  source.
 
 
 ## `unit_test/`

--- a/tests/test_model/conftest.py
+++ b/tests/test_model/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -106,6 +107,55 @@ def qwen3_omni_talker_server(tmp_path_factory: pytest.TempPathFactory):
     )
     yield ServerHandle(proc=proc, port=port)
     stop_server(proc)
+
+
+def _model_cache_present(model_path: str) -> bool:
+    """Return True iff *model_path* is either a local directory or an
+    already-resolvable HF snapshot. Avoids triggering a multi-GB download
+    on a CI runner that did not opt in.
+    """
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError:
+        return False
+    if Path(model_path).exists():
+        return True
+    try:
+        snapshot_download(model_path, local_files_only=True)
+    except Exception:
+        return False
+    return True
+
+
+def resolve_qwen3_omni_model_dir(model_path: str) -> Path:
+    """Return the model directory without triggering a download. Caller is
+    responsible for confirming the cache is populated (see
+    :func:`_model_cache_present`).
+    """
+    if Path(model_path).exists():
+        return Path(model_path)
+    from huggingface_hub import snapshot_download
+
+    return Path(snapshot_download(model_path, local_files_only=True))
+
+
+@pytest.fixture(scope="module")
+def cuda_device():
+    """CUDA device for Qwen3-Omni benchmarks. Skips when CUDA is unavailable
+    or the Qwen3-Omni checkpoint is not in the local HF cache."""
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    if not _model_cache_present(QWEN3_OMNI_TEST_MODEL_PATH):
+        pytest.skip(
+            f"{QWEN3_OMNI_TEST_MODEL_PATH} is not in the local HF cache; this "
+            f"benchmark test refuses to auto-download a multi-GB checkpoint. "
+            f"Pre-populate the cache or set SGLANG_OMNI_TEST_QWEN3_MODEL to a "
+            f"local path."
+        )
+    torch.cuda.set_device(0)
+    return torch.device("cuda:0")
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_model/conftest.py
+++ b/tests/test_model/conftest.py
@@ -140,10 +140,7 @@ def qwen3_omni_vision_sglang_env():
     from sglang.srt.models.qwen3_omni_moe import (  # noqa: F401 -- lazy-import order
         Qwen3OmniMoeVisionEncoder,
     )
-    from sglang.srt.server_args import (
-        ServerArgs,
-        set_global_server_args_for_scheduler,
-    )
+    from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
 
     if not torch_dist.is_initialized():
         init_distributed_environment(

--- a/tests/test_model/conftest.py
+++ b/tests/test_model/conftest.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 
 import pytest
@@ -98,6 +99,73 @@ def qwen3_omni_talker_server(tmp_path_factory: pytest.TempPathFactory):
     )
     yield ServerHandle(proc=proc, port=port)
     stop_server(proc)
+
+
+@pytest.fixture(scope="session")
+def qwen3_omni_vision_sglang_env():
+    """Process-global SGLang dist + DP-attention bring-up shared by every
+    Qwen3-Omni vision-encoder benchmark module in ``tests/test_model``.
+
+    SGLang's TP group, DP-attention group, and global server-args slot are
+    all process-global. Two benchmark modules that each owned an unguarded
+    ``initialize_model_parallel`` call would trip an already-initialized
+    assertion when the combined command ``pytest -m benchmark tests/test_model``
+    runs them in the same process. Hoisting the bring-up to a session
+    fixture means it executes at most once per session; the explicit
+    ``model_parallel_is_initialized`` / ``torch.distributed.is_initialized``
+    guards are belt-and-suspenders against an external initializer.
+    """
+    import torch
+    import torch.distributed as torch_dist
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    torch.cuda.set_device(0)
+
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29550")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("NCCL_SOCKET_IFNAME", "lo")
+    os.environ.setdefault("NCCL_IB_DISABLE", "1")
+    os.environ.setdefault("NCCL_P2P_DISABLE", "1")
+
+    from sglang.srt.configs.model_config import ModelConfig
+    from sglang.srt.distributed.parallel_state import (
+        init_distributed_environment,
+        initialize_model_parallel,
+        model_parallel_is_initialized,
+    )
+    from sglang.srt.layers.dp_attention import initialize_dp_attention
+    from sglang.srt.models.qwen3_omni_moe import (  # noqa: F401 -- lazy-import order
+        Qwen3OmniMoeVisionEncoder,
+    )
+    from sglang.srt.server_args import (
+        ServerArgs,
+        set_global_server_args_for_scheduler,
+    )
+
+    if not torch_dist.is_initialized():
+        init_distributed_environment(
+            world_size=1,
+            rank=0,
+            distributed_init_method=f"tcp://127.0.0.1:{os.environ['MASTER_PORT']}",
+            local_rank=0,
+            backend="nccl",
+        )
+    if not model_parallel_is_initialized():
+        initialize_model_parallel(tensor_model_parallel_size=1)
+
+    sa = ServerArgs(
+        model_path=QWEN3_OMNI_MODEL_PATH,
+        trust_remote_code=True,
+        tp_size=1,
+        dtype="bfloat16",
+        disable_cuda_graph=True,
+        random_seed=123,
+    )
+    set_global_server_args_for_scheduler(sa)
+    initialize_dp_attention(sa, ModelConfig.from_server_args(sa))
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/tests/test_model/conftest.py
+++ b/tests/test_model/conftest.py
@@ -24,6 +24,13 @@ SELECTED_S2PRO_TTS_CONCURRENCIES = pytest.StashKey[tuple[int, ...]]()
 S2PRO_STAGE_OPTION = "--s2pro-stage"
 SELECTED_S2PRO_CI_STAGE = pytest.StashKey[str]()
 QWEN3_OMNI_MODEL_PATH = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
+# Single source of truth for the model path used by Qwen3-Omni vision-encoder
+# benchmarks and the SGLang state they bring up. Honors
+# ``SGLANG_OMNI_TEST_QWEN3_MODEL=/local/path`` so an offline runner does not
+# fall back to the HF hub name in ``ServerArgs.model_path``.
+QWEN3_OMNI_TEST_MODEL_PATH = os.environ.get(
+    "SGLANG_OMNI_TEST_QWEN3_MODEL", QWEN3_OMNI_MODEL_PATH
+)
 QWEN3_OMNI_STARTUP_TIMEOUT = 300
 
 
@@ -154,7 +161,7 @@ def qwen3_omni_vision_sglang_env():
         initialize_model_parallel(tensor_model_parallel_size=1)
 
     sa = ServerArgs(
-        model_path=QWEN3_OMNI_MODEL_PATH,
+        model_path=QWEN3_OMNI_TEST_MODEL_PATH,
         trust_remote_code=True,
         tp_size=1,
         dtype="bfloat16",

--- a/tests/test_model/test_v1_encoder_patches_perf.py
+++ b/tests/test_model/test_v1_encoder_patches_perf.py
@@ -21,12 +21,12 @@ local HF cache (skips if absent — never auto-downloads).
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
 import torch
 
 from tests.test_model.conftest import QWEN3_OMNI_TEST_MODEL_PATH as MODEL_PATH
+from tests.test_model.conftest import resolve_qwen3_omni_model_dir
 
 # (label, t, h, w, n_grids, n_iters)
 SCENARIOS = [
@@ -43,44 +43,6 @@ SCENARIOS = [
 # This 5% gate only fires on a real regression; tighter trend tracking
 # happens via the per-scenario PERF_JSON CI artifacts instead.
 PREP_RATIO_GATE = 0.05
-
-
-def _model_cache_present(model_path: str) -> bool:
-    try:
-        from huggingface_hub import snapshot_download
-    except ImportError:
-        return False
-
-    if Path(model_path).exists():
-        return True
-    try:
-        snapshot_download(model_path, local_files_only=True)
-    except Exception:
-        return False
-    return True
-
-
-def _resolve_model_dir(model_path: str) -> Path:
-    """Resolve to the model directory without triggering a download."""
-    if Path(model_path).exists():
-        return Path(model_path)
-    from huggingface_hub import snapshot_download
-
-    return Path(snapshot_download(model_path, local_files_only=True))
-
-
-@pytest.fixture(scope="module")
-def cuda_device():
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA not available")
-    if not _model_cache_present(MODEL_PATH):
-        pytest.skip(
-            f"{MODEL_PATH} is not in the local HF cache; this benchmark test "
-            f"refuses to auto-download a multi-GB checkpoint. Pre-populate "
-            f"the cache or set SGLANG_OMNI_TEST_QWEN3_MODEL to a local path."
-        )
-    torch.cuda.set_device(0)
-    return torch.device("cuda:0")
 
 
 @pytest.fixture(scope="module")
@@ -124,7 +86,7 @@ def sg_visual(cuda_device, qwen3_omni_vision_sglang_env):
 def _load_visual_safetensors():
     from safetensors import safe_open
 
-    md = _resolve_model_dir(MODEL_PATH)
+    md = resolve_qwen3_omni_model_dir(MODEL_PATH)
     weight_map = json.loads((md / "model.safetensors.index.json").read_text())[
         "weight_map"
     ]

--- a/tests/test_model/test_v1_encoder_patches_perf.py
+++ b/tests/test_model/test_v1_encoder_patches_perf.py
@@ -21,15 +21,12 @@ local HF cache (skips if absent — never auto-downloads).
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
 import pytest
 import torch
 
-MODEL_PATH = os.environ.get(
-    "SGLANG_OMNI_TEST_QWEN3_MODEL", "Qwen/Qwen3-Omni-30B-A3B-Instruct"
-)
+from tests.test_model.conftest import QWEN3_OMNI_TEST_MODEL_PATH as MODEL_PATH
 
 # (label, t, h, w, n_grids, n_iters)
 SCENARIOS = [

--- a/tests/test_model/test_v1_encoder_patches_perf.py
+++ b/tests/test_model/test_v1_encoder_patches_perf.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Performance regression test for the HF-parity patches.
+
+Issue https://github.com/sgl-project/sglang-omni/issues/434 sets a 1% target
+for ``(time(fast_pos_embed_interpolate) + time(rot_pos_emb)) / total encoder
+forward`` so the patches stay invisible to long-video / batched throughput.
+Reference H100 measurements with the current patch are 100×–1000× under that
+target (0.0007%–0.034%), so this test asserts only an anti-pathological
+ceiling (5%) — looser than the target on purpose, because the prep time is
+mostly CPU-bound while the encoder forward time scales with GPU SKU. Trend
+tracking against the 1% target lives in CI dashboards, fed from the
+per-scenario PERF_JSON artifacts emitted below.
+
+Run::
+
+    pytest -v -m benchmark tests/test_model/test_v1_encoder_patches_perf.py
+
+Requires CUDA and the ``Qwen/Qwen3-Omni-30B-A3B-Instruct`` checkpoint in the
+local HF cache (skips if absent — never auto-downloads).
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+import torch
+
+MODEL_PATH = os.environ.get(
+    "SGLANG_OMNI_TEST_QWEN3_MODEL", "Qwen/Qwen3-Omni-30B-A3B-Instruct"
+)
+
+# (label, t, h, w, n_grids, n_iters)
+SCENARIOS = [
+    ("S1_image", 1, 16, 16, 1, 30),
+    ("S2_short_video", 5, 16, 16, 1, 20),
+    ("S3_long_video", 60, 16, 16, 1, 5),
+    ("S4_batch32_short_video", 5, 16, 16, 32, 5),
+]
+
+# Anti-pathological ceiling. The 1% target from issue #434 was set against
+# H100 numbers where actual prep_ratio is 100x-1000x lower (0.0007%-0.034%).
+# Across GPU SKUs the encoder forward time changes much faster than the
+# (mostly CPU-bound) prep time, so a tighter assertion would be brittle.
+# This 5% gate only fires on a real regression; tighter trend tracking
+# happens via the per-scenario PERF_JSON CI artifacts instead.
+PREP_RATIO_GATE = 0.05
+
+
+def _model_cache_present(model_path: str) -> bool:
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError:
+        return False
+
+    if Path(model_path).exists():
+        return True
+    try:
+        snapshot_download(model_path, local_files_only=True)
+    except Exception:
+        return False
+    return True
+
+
+def _resolve_model_dir(model_path: str) -> Path:
+    """Resolve to the model directory without triggering a download."""
+    if Path(model_path).exists():
+        return Path(model_path)
+    from huggingface_hub import snapshot_download
+
+    return Path(snapshot_download(model_path, local_files_only=True))
+
+
+@pytest.fixture(scope="module")
+def cuda_device():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    if not _model_cache_present(MODEL_PATH):
+        pytest.skip(
+            f"{MODEL_PATH} is not in the local HF cache; this benchmark test "
+            f"refuses to auto-download a multi-GB checkpoint. Pre-populate "
+            f"the cache or set SGLANG_OMNI_TEST_QWEN3_MODEL to a local path."
+        )
+    torch.cuda.set_device(0)
+    return torch.device("cuda:0")
+
+
+@pytest.fixture(scope="module")
+def sg_visual(cuda_device, qwen3_omni_vision_sglang_env):
+    """One patched SGLang Qwen3-Omni vision encoder loaded with real weights;
+    shared across all scenario benchmarks. SGLang dist + DP-attention bring-up
+    lives in the session-scoped ``qwen3_omni_vision_sglang_env`` fixture in
+    ``tests/test_model/conftest.py`` so the combined benchmark command does
+    not re-initialize the process-global TP group.
+    """
+    from sglang.srt.model_loader.utils import set_default_torch_dtype
+    from sglang.srt.models.qwen3_omni_moe import Qwen3OmniMoeVisionEncoder as SGVE
+    from transformers import AutoConfig
+
+    cfg = AutoConfig.from_pretrained(MODEL_PATH, trust_remote_code=True)
+    vision_cfg = cfg.thinker_config.vision_config
+
+    dtype = torch.bfloat16
+    with set_default_torch_dtype(dtype):
+        with torch.device("cuda:0"):
+            sg_v = SGVE(vision_cfg)
+
+    raw = _load_visual_safetensors()
+    sg_input = {
+        (k.replace(".attn.qkv.", ".attn.qkv_proj.") if ".attn.qkv." in k else k): v
+        for k, v in raw.items()
+    }
+    sg_v.load_state_dict(sg_input, strict=True)
+    sg_v.eval()
+
+    # Apply the patches once; stays applied for every scenario.
+    from sglang_omni.model_runner._sglang_qwen3_vl_patches import (
+        apply_qwen3_vl_hf_parity_patches,
+    )
+
+    apply_qwen3_vl_hf_parity_patches()
+
+    return sg_v, vision_cfg, dtype
+
+
+def _load_visual_safetensors():
+    from safetensors import safe_open
+
+    md = _resolve_model_dir(MODEL_PATH)
+    weight_map = json.loads((md / "model.safetensors.index.json").read_text())[
+        "weight_map"
+    ]
+    keys = [k for k in weight_map if k.startswith("thinker.visual.")]
+    by_shard: dict[str, list[str]] = {}
+    for k in keys:
+        by_shard.setdefault(weight_map[k], []).append(k)
+    sd: dict[str, torch.Tensor] = {}
+    for shard, ks in by_shard.items():
+        with safe_open(str(md / shard), framework="pt", device="cpu") as f:
+            for k in ks:
+                sd[k[len("thinker.visual.") :]] = f.get_tensor(k)
+    return sd
+
+
+def _time_fn(fn, n_warmup: int, n_iters: int) -> float:
+    """Time a callable in ms (CUDA-synchronized)."""
+    for _ in range(n_warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(n_iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / n_iters
+
+
+def _make_input(t_g: int, h_g: int, w_g: int, n_grids: int, vision_cfg, dtype):
+    in_d = (
+        vision_cfg.in_channels
+        * vision_cfg.temporal_patch_size
+        * vision_cfg.patch_size**2
+    )
+    grids = [[t_g, h_g, w_g]] * n_grids
+    num_p = sum(t * h * w for t, h, w in grids)
+    torch.manual_seed(42)
+    pv = torch.randn(num_p, in_d, dtype=dtype, device="cuda:0")
+    gw = torch.tensor(grids, dtype=torch.long, device="cuda:0")
+    return pv, gw
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("label,t_g,h_g,w_g,n_grids,n_iters", SCENARIOS)
+def test_patch_overhead_below_pathological_ceiling(
+    sg_visual, label, t_g, h_g, w_g, n_grids, n_iters
+):
+    """Each scenario: ``(fpei + rope) / total ≤ PREP_RATIO_GATE``."""
+    sg_v, vision_cfg, dtype = sg_visual
+
+    pv, gw = _make_input(t_g, h_g, w_g, n_grids, vision_cfg, dtype)
+    gw_cpu = gw.cpu()
+    gw_list = gw_cpu.tolist()
+
+    n_warmup = 3
+    with torch.no_grad():
+        t_fpei = _time_fn(
+            lambda: sg_v.fast_pos_embed_interpolate(gw_cpu),
+            n_warmup=n_warmup,
+            n_iters=n_iters,
+        )
+        t_rope = _time_fn(
+            lambda: sg_v.rot_pos_emb(gw_list), n_warmup=n_warmup, n_iters=n_iters
+        )
+        t_total = _time_fn(lambda: sg_v(pv, gw_cpu), n_warmup=n_warmup, n_iters=n_iters)
+
+    prep_ratio = (t_fpei + t_rope) / t_total
+    print(
+        f"\n[{label}] fpei={t_fpei:.4f}ms rope={t_rope:.4f}ms "
+        f"total={t_total:.2f}ms prep_ratio={prep_ratio*100:.4f}%"
+    )
+
+    # Emit JSON line for CI artifact aggregation.
+    artifact = {
+        "scenario": label,
+        "t_g": t_g,
+        "h_g": h_g,
+        "w_g": w_g,
+        "n_grids": n_grids,
+        "fpei_ms": t_fpei,
+        "rope_ms": t_rope,
+        "total_ms": t_total,
+        "prep_ratio": prep_ratio,
+    }
+    print(f"PERF_JSON: {json.dumps(artifact)}")
+
+    assert prep_ratio <= PREP_RATIO_GATE, (
+        f"[{label}] interpolation prep ratio {prep_ratio*100:.4f}% exceeds "
+        f"the {PREP_RATIO_GATE*100:.1f}% gate. See issue #434 for context. "
+        f"Remediation order: (1) cache idx_tensor/weight_tensor by grid shape; "
+        f"(2) vectorize the per-grid loop while preserving accumulation order "
+        f"and dtype semantics."
+    )

--- a/tests/test_model/test_v1_encoder_qwen3_vl_hf_parity.py
+++ b/tests/test_model/test_v1_encoder_qwen3_vl_hf_parity.py
@@ -21,46 +21,12 @@ Requires:
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
 import torch
 
 from tests.test_model.conftest import QWEN3_OMNI_TEST_MODEL_PATH as MODEL_PATH
-
-
-def _model_cache_present(model_path: str) -> bool:
-    """Return True iff the HF snapshot for *model_path* is already on disk.
-
-    Avoids triggering an automatic ~60 GB download on a CI runner that
-    does not opt in. Local string paths and HF cached snapshots are both
-    accepted.
-    """
-    try:
-        from huggingface_hub import snapshot_download
-    except ImportError:
-        return False
-    if Path(model_path).exists():
-        return True
-    try:
-        snapshot_download(model_path, local_files_only=True)
-    except Exception:
-        return False
-    return True
-
-
-@pytest.fixture(scope="module")
-def cuda_device():
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA not available")
-    if not _model_cache_present(MODEL_PATH):
-        pytest.skip(
-            f"{MODEL_PATH} is not in the local HF cache; this benchmark test "
-            f"refuses to auto-download a multi-GB checkpoint. Pre-populate "
-            f"the cache or set SGLANG_OMNI_TEST_QWEN3_MODEL to a local path."
-        )
-    torch.cuda.set_device(0)
-    return torch.device("cuda:0")
+from tests.test_model.conftest import resolve_qwen3_omni_model_dir
 
 
 @pytest.fixture(scope="module")
@@ -73,26 +39,11 @@ def dist_init(cuda_device, qwen3_omni_vision_sglang_env):
     """
 
 
-def _resolve_model_dir(model_path: str) -> Path:
-    """Return the model directory without triggering a download.
-
-    Honors a local-filesystem ``model_path`` (e.g. via
-    ``SGLANG_OMNI_TEST_QWEN3_MODEL=/local/dir``) and otherwise resolves
-    against the HF cache only — the caller-side cache gate has already
-    asserted the cache is populated.
-    """
-    if Path(model_path).exists():
-        return Path(model_path)
-    from huggingface_hub import snapshot_download
-
-    return Path(snapshot_download(model_path, local_files_only=True))
-
-
 def _load_visual_safetensors():
     """Read all ``thinker.visual.*`` weights from the model checkpoint."""
     from safetensors import safe_open
 
-    md = _resolve_model_dir(MODEL_PATH)
+    md = resolve_qwen3_omni_model_dir(MODEL_PATH)
     weight_map = json.loads((md / "model.safetensors.index.json").read_text())[
         "weight_map"
     ]

--- a/tests/test_model/test_v1_encoder_qwen3_vl_hf_parity.py
+++ b/tests/test_model/test_v1_encoder_qwen3_vl_hf_parity.py
@@ -21,15 +21,12 @@ Requires:
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
 import pytest
 import torch
 
-MODEL_PATH = os.environ.get(
-    "SGLANG_OMNI_TEST_QWEN3_MODEL", "Qwen/Qwen3-Omni-30B-A3B-Instruct"
-)
+from tests.test_model.conftest import QWEN3_OMNI_TEST_MODEL_PATH as MODEL_PATH
 
 
 def _model_cache_present(model_path: str) -> bool:

--- a/tests/test_model/test_v1_encoder_qwen3_vl_hf_parity.py
+++ b/tests/test_model/test_v1_encoder_qwen3_vl_hf_parity.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GPU parity test: sglang ``Qwen3OmniMoeVisionEncoder`` (post-patch) vs HF
+transformers reference, on the real Qwen3-Omni-30B-A3B-Instruct checkpoint.
+
+Validates that ``apply_qwen3_vl_hf_parity_patches()`` restores HF-equivalent
+output up to bf16 noise across a 27-layer encoder forward.
+
+Acceptance:
+    cosine sim ≥ 0.999, max abs ≤ 0.2 (bf16 27-layer accumulation noise)
+
+Without the patches, cosine sim is ~0.67 — see issue
+https://github.com/sgl-project/sglang-omni/issues/434.
+
+Run:
+    pytest -v -m benchmark tests/test_model/test_v1_encoder_qwen3_vl_hf_parity.py
+
+Requires:
+    - 1× H100 (or equivalent ≥ 80GB GPU) with sglang==0.5.8 and transformers
+    - HF cache populated for ``Qwen/Qwen3-Omni-30B-A3B-Instruct``
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+import torch
+
+MODEL_PATH = os.environ.get(
+    "SGLANG_OMNI_TEST_QWEN3_MODEL", "Qwen/Qwen3-Omni-30B-A3B-Instruct"
+)
+
+
+def _model_cache_present(model_path: str) -> bool:
+    """Return True iff the HF snapshot for *model_path* is already on disk.
+
+    Avoids triggering an automatic ~60 GB download on a CI runner that
+    does not opt in. Local string paths and HF cached snapshots are both
+    accepted.
+    """
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError:
+        return False
+    if Path(model_path).exists():
+        return True
+    try:
+        snapshot_download(model_path, local_files_only=True)
+    except Exception:
+        return False
+    return True
+
+
+@pytest.fixture(scope="module")
+def cuda_device():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    if not _model_cache_present(MODEL_PATH):
+        pytest.skip(
+            f"{MODEL_PATH} is not in the local HF cache; this benchmark test "
+            f"refuses to auto-download a multi-GB checkpoint. Pre-populate "
+            f"the cache or set SGLANG_OMNI_TEST_QWEN3_MODEL to a local path."
+        )
+    torch.cuda.set_device(0)
+    return torch.device("cuda:0")
+
+
+@pytest.fixture(scope="module")
+def dist_init(cuda_device, qwen3_omni_vision_sglang_env):
+    """Module-level alias of the session-scoped SGLang vision-encoder env.
+
+    Existed as a per-module fixture before the bring-up was hoisted to
+    ``tests/test_model/conftest.py``; kept so the test signature is
+    unchanged.
+    """
+
+
+def _resolve_model_dir(model_path: str) -> Path:
+    """Return the model directory without triggering a download.
+
+    Honors a local-filesystem ``model_path`` (e.g. via
+    ``SGLANG_OMNI_TEST_QWEN3_MODEL=/local/dir``) and otherwise resolves
+    against the HF cache only — the caller-side cache gate has already
+    asserted the cache is populated.
+    """
+    if Path(model_path).exists():
+        return Path(model_path)
+    from huggingface_hub import snapshot_download
+
+    return Path(snapshot_download(model_path, local_files_only=True))
+
+
+def _load_visual_safetensors():
+    """Read all ``thinker.visual.*`` weights from the model checkpoint."""
+    from safetensors import safe_open
+
+    md = _resolve_model_dir(MODEL_PATH)
+    weight_map = json.loads((md / "model.safetensors.index.json").read_text())[
+        "weight_map"
+    ]
+    keys = [k for k in weight_map if k.startswith("thinker.visual.")]
+    by_shard: dict[str, list[str]] = {}
+    for k in keys:
+        by_shard.setdefault(weight_map[k], []).append(k)
+    sd: dict[str, torch.Tensor] = {}
+    for shard, ks in by_shard.items():
+        with safe_open(str(md / shard), framework="pt", device="cpu") as f:
+            for k in ks:
+                sd[k[len("thinker.visual.") :]] = f.get_tensor(k)
+    return sd
+
+
+@pytest.mark.benchmark
+def test_qwen3_omni_vision_encoder_hf_parity(cuda_device, dist_init):
+    """Patched sglang Qwen3-Omni vision encoder must match HF within bf16 noise."""
+    from sglang.srt.model_loader.utils import set_default_torch_dtype
+    from sglang.srt.models.qwen3_omni_moe import Qwen3OmniMoeVisionEncoder as SGVE
+    from transformers import AutoConfig
+    from transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe import (
+        Qwen3OmniMoeVisionEncoder as HFVE,
+    )
+
+    from sglang_omni.model_runner._sglang_qwen3_vl_patches import (
+        apply_qwen3_vl_hf_parity_patches,
+    )
+
+    dtype = torch.bfloat16
+    cfg = AutoConfig.from_pretrained(MODEL_PATH, trust_remote_code=True)
+    vision_cfg = cfg.thinker_config.vision_config
+
+    # Build both encoders on cuda:0 in bf16
+    with torch.device("cuda:0"):
+        hf_v = HFVE(vision_cfg).to(dtype=dtype)
+    with set_default_torch_dtype(dtype):
+        with torch.device("cuda:0"):
+            sg_v = SGVE(vision_cfg)
+
+    # Load identical weights into both. SGLang uses fused QKV naming
+    # (``attn.qkv_proj.*``); HF uses ``attn.qkv.*``. One-line rename.
+    raw = _load_visual_safetensors()
+    hf_miss, hf_unexp = hf_v.load_state_dict(raw, strict=False)
+    assert (
+        not hf_miss and not hf_unexp
+    ), f"HF load: missing={len(hf_miss)} unexpected={len(hf_unexp)}"
+
+    sg_input = {
+        (k.replace(".attn.qkv.", ".attn.qkv_proj.") if ".attn.qkv." in k else k): v
+        for k, v in raw.items()
+    }
+    sg_miss, sg_unexp = sg_v.load_state_dict(sg_input, strict=True)
+    assert (
+        not sg_miss and not sg_unexp
+    ), f"SG load: missing={len(sg_miss)} unexpected={len(sg_unexp)}"
+
+    hf_v.eval()
+    sg_v.eval()
+
+    # Apply HF-parity patches before forward.
+    apply_qwen3_vl_hf_parity_patches()
+
+    # Fixed-seed input: 32 patches arranged as t=2, h=4, w=4
+    T_g, H_g, W_g = 2, 4, 4
+    num_patches = T_g * H_g * W_g
+    in_d = (
+        vision_cfg.in_channels
+        * vision_cfg.temporal_patch_size
+        * vision_cfg.patch_size**2
+    )
+    torch.manual_seed(42)
+    pixel_values = torch.randn(num_patches, in_d, dtype=dtype, device="cuda:0")
+    grid_thw = torch.tensor([[T_g, H_g, W_g]], dtype=torch.long, device="cuda:0")
+
+    with torch.no_grad():
+        hf_out = hf_v(pixel_values.clone(), grid_thw.clone())
+        # SGLang requires grid_thw on CPU (compute_cu_seqlens_from_grid_numpy assertion).
+        sg_out = sg_v(pixel_values.clone(), grid_thw.cpu().clone())
+
+    # HF returns (main, deepstack_list); SGLang returns a single tensor with
+    # main + deepstack concatenated along the last dim.
+    hf_main, hf_deepstack = hf_out[0], hf_out[1]
+    n_deep = len(hf_deepstack)
+    H = vision_cfg.out_hidden_size
+
+    assert sg_out.shape[-1] == H * (1 + n_deep), (
+        f"SGLang output last-dim {sg_out.shape[-1]} does not match expected "
+        f"{H} × (1 + {n_deep} deepstack)"
+    )
+    sg_main = sg_out[..., :H]
+    sg_deepstack = [sg_out[..., H * (i + 1) : H * (i + 2)] for i in range(n_deep)]
+
+    # Tolerance derived from bf16 27-layer accumulation noise floor on H100
+    # (measured via patched-vs-HF parity audit, see issue #434).
+    COS_GATE = 0.999
+    MAX_ABS_GATE = 0.2
+
+    def _check(label: str, a: torch.Tensor, b: torch.Tensor) -> None:
+        assert (
+            a.shape == b.shape
+        ), f"{label}: shape diff HF={tuple(a.shape)} SG={tuple(b.shape)}"
+        diff = (a.float() - b.float()).abs()
+        cos = torch.nn.functional.cosine_similarity(
+            a.float().flatten(), b.float().flatten(), dim=0
+        ).item()
+        max_abs = diff.max().item()
+        print(
+            f"{label}: shape={tuple(a.shape)} max_abs={max_abs:.4e} "
+            f"mean_abs={diff.mean().item():.4e} cos={cos:.6f}"
+        )
+        assert cos >= COS_GATE, (
+            f"{label}: cosine sim {cos:.6f} below gate {COS_GATE} — "
+            f"patches degraded HF parity. See issue #434."
+        )
+        assert max_abs <= MAX_ABS_GATE, (
+            f"{label}: max abs diff {max_abs:.4e} above gate {MAX_ABS_GATE} — "
+            f"bf16 noise exceeded; investigate before relaxing gate."
+        )
+
+    _check("MAIN", hf_main, sg_main)
+    for i in range(n_deep):
+        _check(f"DEEPSTACK[{i}]", hf_deepstack[i], sg_deepstack[i])


### PR DESCRIPTION
## Summary

Implements the local SGLang patch strategy from #434 — two methods on
`Qwen3VLMoeVisionModel` that produce per-element divergence from HF transformers
reference, plus the smoke / parity / performance tests that gate them.

The divergence is intrinsic to model implementation differences in
`sglang==0.5.8` and is **not** introduced by tensor parallelism — single-process
`tp_size=1` runs see the same drift. After both patches are applied,
SGLang's `Qwen3OmniMoeVisionEncoder` matches HF transformers within bf16
noise floor (cos ≥ 0.9997, max_abs ≤ 0.2 over a 27-layer encoder forward).

See #434 for the full RFC including root cause, scope decisions, and removal trigger.

## Scope

**In this PR**:
- `sglang_omni_v1/model_runner/_sglang_qwen3_vl_patches.py`
  Atomic, idempotent, threadsafe `apply_qwen3_vl_hf_parity_patches()` with a
  class-surface + helper-signature preflight check and a sglang-version guard.
- `tests/test_model/test_v1_encoder_qwen3_vl_hf_parity.py` (GPU `benchmark`)
  Real Qwen3-Omni vision encoder; asserts `cos ≥ 0.999, max_abs ≤ 0.2` vs HF.
- `tests/test_model/test_v1_encoder_patches_perf.py` (GPU `benchmark`)
  Four scenarios from #434 body; asserts an anti-pathological 5% ceiling on
  `(fpei + rope) / total`. Tighter 1% trend tracking belongs in CI dashboards
  fed by the per-scenario `PERF_JSON` artifacts emitted by the test.

**Deliberately not in this PR** (deferred to follow-up encoder TP work):
- No production code path calls `apply_qwen3_vl_hf_parity_patches()` yet —
  the module is callable but uncalled. The `SGLangEncoderRunner` that will
  invoke it lands in a separate PR. Patches are **dormant** in this PR.
- No changes to `mp_runner`, `coordinator`, `compiler`, `launcher`,
  encoder factories, or any other v1 surface.
- No `EncoderModuleSpec` / `EncoderScheduler` / `EncoderAdapter` infrastructure.

This keeps the change reviewable in isolation and lets the patch + tests
land before the larger encoder TP series. Default behavior of the entire
v1 surface is unchanged.

## Test plan

Both GPU tests run on the H100 dev container with `sglang==0.5.8` (dev build
`dce8b0606`), `transformers==4.57.1`, `torch==2.9.1+cu129`, dtype=bfloat16,
model `Qwen/Qwen3-Omni-30B-A3B-Instruct`.

### Parity (GPU)

```
$ pytest -v -s -m benchmark tests/test_model/test_v1_encoder_qwen3_vl_hf_parity.py
MAIN: shape=(8, 2048) max_abs=1.2500e-01 mean_abs=8.8703e-03 cos=0.999720
DEEPSTACK[0]: shape=(8, 2048) max_abs=6.8359e-03 mean_abs=1.0167e-03 cos=0.999949
DEEPSTACK[1]: shape=(8, 2048) max_abs=1.6602e-02 mean_abs=2.9684e-03 cos=0.999887
DEEPSTACK[2]: shape=(8, 2048) max_abs=4.6875e-02 mean_abs=3.9141e-03 cos=0.999686
PASSED
```

Numbers match the experimental investigation reference values bit-for-bit.

### Performance (GPU)

```
$ pytest -v -s -m benchmark tests/test_model/test_v1_encoder_patches_perf.py
[S1_image]              fpei=0.327ms rope=0.072ms total=1159.4ms  prep_ratio=0.0344%
[S2_short_video]        fpei=0.341ms rope=0.083ms total=5575.0ms  prep_ratio=0.0076%
[S3_long_video]         fpei=0.331ms rope=0.099ms total=65343.5ms prep_ratio=0.0007%
[S4_batch32_short_video] fpei=6.336ms rope=0.289ms total=176285.8ms prep_ratio=0.0038%
4 passed in 2094.08s (0:34:54)
```

All four scenarios are 20×–1500× under the relaxed 5% ceiling, and remain well
under the 1% target from #434. The HF-semantics `fast_pos_embed_interpolate`
is consistently faster than the upstream sglang 0.5.8 `F.interpolate` baseline
on this hardware (the manual 4-corner path batches the `pos_embed` lookup
once and avoids per-grid CUDA kernel-launch overhead).

## Notes for reviewer

- **Patches are dormant in this PR** — `apply_qwen3_vl_hf_parity_patches()`
  exists, is exercised by the parity + perf tests, but is not invoked from any
  production code path. Wiring it into the `SGLangEncoderRunner` constructor
  lands in a follow-up PR. Until that PR lands, default behavior of the entire
  v1 surface is unchanged (`backend="local"` everywhere).
- The patches refuse to install on a sglang version outside
  `_SUPPORTED_SGLANG_VERSIONS = {"0.5.8", "0.5.8.post1"}`. Dev builds
  (`0.0.0.dev1+...`) are accepted with a warning. A future dep bump must
  update or remove this module.
- The preflight check covers (1) method presence on the class, (2) instance
  attribute presence via MRO `__init__` source walk, and (3)
  `inspect.signature` validation of the helper APIs the patch depends on
  (`rot_pos_ids` and `RotaryEmbedding._compute_inv_freq`).
- Apply is threadsafe (module-level lock) and idempotent (class-level flag).
  Atomic — both methods replace or neither, never partial.

Closes #434 only after the production caller PR lands and the parity gate is
wired into CI; this PR alone does not close #434.


