### PR TITLE
[V1] Ming omni v1 migration

### DIFF
--- a/benchmarks/eval/benchmark_omni_seedtts.py
+++ b/benchmarks/eval/benchmark_omni_seedtts.py
@@ -192,6 +192,12 @@ class OmniSeedttsBenchmarkConfig:
     disable_tqdm: bool = False
     # Transcribe phase
     device: str = "cuda:0"
+    # Optional system prompt prepended to chat messages. Default ``None``
+    # preserves the legacy Qwen3-Omni behavior (no system role). Pass a
+    # strict TTS-only prompt to suppress chat-mode leakage on models that
+    # were not fine-tuned to robustly interpret "please read aloud" as a
+    # verbatim-TTS command (e.g. Ming-Omni).
+    system_prompt: str | None = None
 
 
 def _build_results_config(
@@ -226,6 +232,7 @@ def make_send_fn(
     temperature: float,
     stream: bool,
     save_audio_dir: str,
+    system_prompt: str | None = None,
 ) -> SendFn:
     """Return a SendFn that calls Qwen3-Omni via VoiceCloneOmni and saves WAV."""
     task = VoiceCloneOmni()
@@ -250,6 +257,7 @@ def make_send_fn(
                 temperature=temperature,
                 voice_clone=voice_clone,
                 stream=stream,
+                system_prompt=system_prompt,
             )
             result.audio_duration_s = get_wav_duration(wav_bytes)
             elapsed = time.perf_counter() - start_time
@@ -315,6 +323,7 @@ async def run_omni_seedtts_benchmark(
         temperature=config.temperature,
         stream=config.stream,
         save_audio_dir=save_audio_dir,
+        system_prompt=config.system_prompt,
     )
 
     runner = BenchmarkRunner(
@@ -382,6 +391,7 @@ def _config_from_args(args: argparse.Namespace) -> OmniSeedttsBenchmarkConfig:
         request_rate=args.request_rate,
         disable_tqdm=args.disable_tqdm,
         device=device,
+        system_prompt=args.system_prompt,
     )
 
 
@@ -499,6 +509,15 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         type=int,
         default=1200,
         help="Timeout in seconds to wait for server readiness.",
+    )
+    parser.add_argument(
+        "--system-prompt",
+        type=str,
+        default=None,
+        help="Optional system role content prepended to every chat request. "
+        "Default omits the system message (Qwen3-Omni-tuned legacy behavior). "
+        "Pass a strict TTS-only prompt for models that leak chat-style "
+        "preambles or refusals (e.g. Ming-Omni).",
     )
 
     mode = parser.add_mutually_exclusive_group()

--- a/benchmarks/tasks/tts.py
+++ b/benchmarks/tasks/tts.py
@@ -648,6 +648,7 @@ class VoiceCloneOmni:
         temperature: float = 0.7,
         voice_clone: bool = False,
         stream: bool = False,
+        system_prompt: str | None = None,
     ) -> tuple[bytes, float, dict]:
         if max_tokens is None:
             max_tokens = self.THINKER_MAX_NEW_TOKENS
@@ -673,9 +674,14 @@ class VoiceCloneOmni:
             else:
                 prompt_text = f"请用中文朗读以下文本: {sample.target_text}"
 
+        messages: list[dict] = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": prompt_text})
+
         payload = {
             "model": model_name,
-            "messages": [{"role": "user", "content": prompt_text}],
+            "messages": messages,
             "modalities": ["text", "audio"],
             "audio": {"format": "wav"},
             "max_tokens": max_tokens,
@@ -766,6 +772,7 @@ class VoiceCloneOmni:
         max_tokens: int | None = None,
         voice_clone: bool = False,
         stream: bool = False,
+        system_prompt: str | None = None,
     ) -> SampleOutput:
         output = SampleOutput(
             sample_id=sample.sample_id,
@@ -784,6 +791,7 @@ class VoiceCloneOmni:
                 max_tokens,
                 voice_clone=voice_clone,
                 stream=stream,
+                system_prompt=system_prompt,
             )
             with open(wav_path, "wb") as f:
                 f.write(wav_bytes)

--- a/examples/run_ming_omni_server.py
+++ b/examples/run_ming_omni_server.py
@@ -25,9 +25,7 @@ import argparse
 import logging
 import multiprocessing as mp
 import os
-
-from sglang_omni.models.ming_omni.config import MingOmniPipelineConfig
-from sglang_omni.serve import launch_server
+from typing import Any
 
 logging.basicConfig(
     level=os.environ.get("LOGLEVEL", "INFO").upper(),
@@ -57,6 +55,26 @@ def parse_args() -> argparse.Namespace:
         help="Tensor parallel size for thinker",
     )
     parser.add_argument(
+        "--gpu-audio-encoder",
+        type=int,
+        default=None,
+        help="GPU id for the V1 audio encoder stage.",
+    )
+    parser.add_argument(
+        "--gpu-image-encoder",
+        type=int,
+        default=None,
+        help="GPU id for the V1 image encoder stage.",
+    )
+    parser.add_argument(
+        "--thinker-only",
+        action="store_true",
+        help=(
+            "Launch a V1 pure-text smoke pipeline without audio/image encoders. "
+            "Default keeps the full v0-parity multimodal pipeline."
+        ),
+    )
+    parser.add_argument(
         "--quantization",
         type=str,
         default=None,
@@ -81,8 +99,15 @@ def parse_args() -> argparse.Namespace:
         "--relay-backend",
         type=str,
         default="shm",
-        choices=["shm", "nixl"],
+        choices=["shm", "nccl", "nixl"],
         help="Relay backend for inter-stage data transfer",
+    )
+    parser.add_argument(
+        "--version",
+        type=str,
+        default=os.environ.get("SGLANG_OMNI_SERVER_VERSION", "legacy"),
+        choices=["legacy", "v1"],
+        help="Select the legacy or v1 Ming-Omni launcher implementation.",
     )
 
     # Server
@@ -98,8 +123,120 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main() -> None:
-    args = parse_args()
+def _validate_fraction(flag_name: str, value: float | None) -> None:
+    if value is not None and not 0.0 < value < 1.0:
+        raise ValueError(f"{flag_name} must be > 0 and < 1, got {value}")
+
+
+def _apply_stage_factory_updates(
+    config: Any,
+    *,
+    stage_name: str,
+    updates: dict[str, object] | None = None,
+    server_arg_updates: dict[str, object] | None = None,
+) -> None:
+    for stage in config.stages:
+        if stage.name != stage_name:
+            continue
+        factory_args = dict(stage.factory_args or {})
+        if updates:
+            factory_args.update(updates)
+        if server_arg_updates:
+            overrides = dict(factory_args.get("server_args_overrides") or {})
+            overrides.update(server_arg_updates)
+            factory_args["server_args_overrides"] = overrides
+        stage.factory_args = factory_args
+        return
+    raise ValueError(
+        f"Stage {stage_name!r} not found in config {type(config).__name__}"
+    )
+
+
+def _set_stage_gpu(config: Any, stage_name: str, gpu_id: int) -> None:
+    for stage in config.stages:
+        if stage.name == stage_name:
+            stage.gpu = int(gpu_id)
+            return
+    raise ValueError(
+        f"Stage {stage_name!r} not found in config {type(config).__name__}"
+    )
+
+
+def _configure_thinker_only_pipeline(config: Any) -> None:
+    stages = {stage.name: stage for stage in config.stages}
+    preprocessing = stages["preprocessing"]
+    aggregate = stages["mm_aggregate"]
+
+    preprocessing.next = "mm_aggregate"
+    preprocessing.project_payload = {
+        "mm_aggregate": (
+            "sglang_omni_v1.models.ming_omni.stages."
+            "project_preprocessing_to_mm_aggregate"
+        )
+    }
+    aggregate.wait_for = ["preprocessing"]
+    config.stages = [
+        stage
+        for stage in config.stages
+        if stage.name not in {"audio_encoder", "image_encoder"}
+    ]
+
+
+def _launch_v1_text_server(args: argparse.Namespace) -> None:
+    from sglang_omni_v1.models.ming_omni.config import MingOmniPipelineConfig
+    from sglang_omni_v1.serve import launch_server as launch_v1_server
+
+    _validate_fraction("--mem-fraction-static", args.mem_fraction_static)
+
+    config = MingOmniPipelineConfig(
+        model_path=args.model_path,
+        relay_backend=args.relay_backend,
+    )
+
+    if getattr(args, "thinker_only", False):
+        if args.gpu_audio_encoder is not None or args.gpu_image_encoder is not None:
+            raise ValueError(
+                "--gpu-audio-encoder/--gpu-image-encoder cannot be used "
+                "with --thinker-only"
+            )
+        _configure_thinker_only_pipeline(config)
+
+    server_arg_updates: dict[str, object] = {}
+    if args.tp_size and args.tp_size > 1:
+        thinker = next(stage for stage in config.stages if stage.name == "thinker")
+        tp_size = int(args.tp_size)
+        thinker.tp_size = tp_size
+        thinker.gpu = list(range(tp_size))
+        server_arg_updates["disable_custom_all_reduce"] = True
+    if args.gpu_audio_encoder is not None:
+        _set_stage_gpu(config, "audio_encoder", args.gpu_audio_encoder)
+    if args.gpu_image_encoder is not None:
+        _set_stage_gpu(config, "image_encoder", args.gpu_image_encoder)
+    if args.quantization:
+        server_arg_updates["quantization"] = args.quantization
+    if args.cpu_offload_gb:
+        server_arg_updates["cpu_offload_gb"] = int(args.cpu_offload_gb)
+    if args.mem_fraction_static is not None:
+        server_arg_updates["mem_fraction_static"] = args.mem_fraction_static
+
+    _apply_stage_factory_updates(
+        config,
+        stage_name="thinker",
+        updates={"thinker_max_seq_len": int(args.thinker_max_seq_len)},
+        server_arg_updates=server_arg_updates or None,
+    )
+
+    launch_v1_server(
+        config,
+        host=args.host,
+        port=args.port,
+        model_name=args.model_name,
+    )
+
+
+def _launch_legacy_text_server(args: argparse.Namespace) -> None:
+    from sglang_omni.models.ming_omni.config import MingOmniPipelineConfig
+    from sglang_omni.serve import launch_server
 
     overrides = {}
     if args.tp_size and args.tp_size > 1:
@@ -132,6 +269,24 @@ def main() -> None:
         port=args.port,
         model_name=args.model_name,
     )
+
+
+def _print_version_banner(version: str) -> None:
+    try:
+        from sglang_omni.utils import print_server_version_banner
+    except Exception:
+        print(f"SGLANG-OMNI SERVER VERSION = {version.upper()}", flush=True)
+        return
+    print_server_version_banner(version, entry="examples/run_ming_omni_server.py")
+
+
+def main() -> None:
+    args = parse_args()
+    _print_version_banner(args.version)
+    if args.version == "v1":
+        _launch_v1_text_server(args)
+        return
+    _launch_legacy_text_server(args)
 
 
 if __name__ == "__main__":

--- a/examples/run_ming_omni_server.py
+++ b/examples/run_ming_omni_server.py
@@ -170,7 +170,7 @@ def _configure_thinker_only_pipeline(config: Any) -> None:
     preprocessing.next = "mm_aggregate"
     preprocessing.project_payload = {
         "mm_aggregate": (
-            "sglang_omni_v1.models.ming_omni.stages."
+            "sglang_omni.models.ming_omni.stages."
             "project_preprocessing_to_mm_aggregate"
         )
     }
@@ -183,8 +183,8 @@ def _configure_thinker_only_pipeline(config: Any) -> None:
 
 
 def _launch_v1_text_server(args: argparse.Namespace) -> None:
-    from sglang_omni_v1.models.ming_omni.config import MingOmniPipelineConfig
-    from sglang_omni_v1.serve import launch_server as launch_v1_server
+    from sglang_omni.models.ming_omni.config import MingOmniPipelineConfig
+    from sglang_omni.serve import launch_server as launch_v1_server
 
     _validate_fraction("--mem-fraction-static", args.mem_fraction_static)
 

--- a/examples/run_ming_omni_server.py
+++ b/examples/run_ming_omni_server.py
@@ -58,19 +58,19 @@ def parse_args() -> argparse.Namespace:
         "--gpu-audio-encoder",
         type=int,
         default=None,
-        help="GPU id for the V1 audio encoder stage.",
+        help="GPU id for the audio encoder stage.",
     )
     parser.add_argument(
         "--gpu-image-encoder",
         type=int,
         default=None,
-        help="GPU id for the V1 image encoder stage.",
+        help="GPU id for the image encoder stage.",
     )
     parser.add_argument(
         "--thinker-only",
         action="store_true",
         help=(
-            "Launch a V1 pure-text smoke pipeline without audio/image encoders. "
+            "Launch a pure-text smoke pipeline without audio/image encoders. "
             "Default keeps the full v0-parity multimodal pipeline."
         ),
     )
@@ -102,14 +102,6 @@ def parse_args() -> argparse.Namespace:
         choices=["shm", "nccl", "nixl"],
         help="Relay backend for inter-stage data transfer",
     )
-    parser.add_argument(
-        "--version",
-        type=str,
-        default=os.environ.get("SGLANG_OMNI_SERVER_VERSION", "legacy"),
-        choices=["legacy", "v1"],
-        help="Select the legacy or v1 Ming-Omni launcher implementation.",
-    )
-
     # Server
     parser.add_argument("--host", type=str, default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8000)
@@ -182,9 +174,9 @@ def _configure_thinker_only_pipeline(config: Any) -> None:
     ]
 
 
-def _launch_v1_text_server(args: argparse.Namespace) -> None:
+def _launch_text_server(args: argparse.Namespace) -> None:
     from sglang_omni.models.ming_omni.config import MingOmniPipelineConfig
-    from sglang_omni.serve import launch_server as launch_v1_server
+    from sglang_omni.serve import launch_server
 
     _validate_fraction("--mem-fraction-static", args.mem_fraction_static)
 
@@ -206,6 +198,7 @@ def _launch_v1_text_server(args: argparse.Namespace) -> None:
         thinker = next(stage for stage in config.stages if stage.name == "thinker")
         tp_size = int(args.tp_size)
         thinker.tp_size = tp_size
+        thinker.parallelism = thinker.parallelism.model_copy(update={"tp": tp_size})
         thinker.gpu = list(range(tp_size))
         server_arg_updates["disable_custom_all_reduce"] = True
     if args.gpu_audio_encoder is not None:
@@ -226,43 +219,6 @@ def _launch_v1_text_server(args: argparse.Namespace) -> None:
         server_arg_updates=server_arg_updates or None,
     )
 
-    launch_v1_server(
-        config,
-        host=args.host,
-        port=args.port,
-        model_name=args.model_name,
-    )
-
-
-def _launch_legacy_text_server(args: argparse.Namespace) -> None:
-    from sglang_omni.models.ming_omni.config import MingOmniPipelineConfig
-    from sglang_omni.serve import launch_server
-
-    overrides = {}
-    if args.tp_size and args.tp_size > 1:
-        overrides["tp_size"] = args.tp_size
-        overrides["disable_custom_all_reduce"] = True
-    if args.quantization:
-        overrides["quantization"] = args.quantization
-    if args.cpu_offload_gb:
-        overrides["cpu_offload_gb"] = args.cpu_offload_gb
-
-    config = MingOmniPipelineConfig(
-        model_path=args.model_path,
-        relay_backend=args.relay_backend,
-    )
-    if overrides:
-        config.apply_server_args_overrides(stage_name="thinker", overrides=overrides)
-    if args.mem_fraction_static is not None:
-        if not 0.0 < args.mem_fraction_static < 1.0:
-            raise ValueError(
-                f"--mem-fraction-static must be > 0 and < 1, got {args.mem_fraction_static}"
-            )
-        config.apply_server_args_overrides(
-            stage_name="thinker",
-            overrides={"mem_fraction_static": args.mem_fraction_static},
-        )
-
     launch_server(
         config,
         host=args.host,
@@ -271,22 +227,9 @@ def _launch_legacy_text_server(args: argparse.Namespace) -> None:
     )
 
 
-def _print_version_banner(version: str) -> None:
-    try:
-        from sglang_omni.utils import print_server_version_banner
-    except Exception:
-        print(f"SGLANG-OMNI SERVER VERSION = {version.upper()}", flush=True)
-        return
-    print_server_version_banner(version, entry="examples/run_ming_omni_server.py")
-
-
 def main() -> None:
     args = parse_args()
-    _print_version_banner(args.version)
-    if args.version == "v1":
-        _launch_v1_text_server(args)
-        return
-    _launch_legacy_text_server(args)
+    _launch_text_server(args)
 
 
 if __name__ == "__main__":

--- a/examples/run_ming_omni_speech_server.py
+++ b/examples/run_ming_omni_speech_server.py
@@ -33,6 +33,7 @@ import asyncio
 import logging
 import multiprocessing as mp
 import os
+from typing import Any
 
 logging.basicConfig(
     level=os.environ.get("LOGLEVEL", "INFO").upper(),
@@ -56,6 +57,15 @@ def parse_args() -> argparse.Namespace:
     # GPU placement
     parser.add_argument("--gpu-thinker", type=int, default=0)
     parser.add_argument("--gpu-talker", type=int, default=1)
+    parser.add_argument(
+        "--tp-size",
+        type=int,
+        default=1,
+        help=(
+            "Tensor parallel size for the thinker stage. "
+            "--gpu-thinker is interpreted as the first visible GPU rank."
+        ),
+    )
 
     # Pipeline
     parser.add_argument(
@@ -73,6 +83,13 @@ def parse_args() -> argparse.Namespace:
             "If omitted, SGLang chooses automatically."
         ),
     )
+    parser.add_argument(
+        "--version",
+        type=str,
+        default=os.environ.get("SGLANG_OMNI_SERVER_VERSION", "legacy"),
+        choices=["legacy", "v1"],
+        help="Select the legacy or v1 Ming-Omni speech launcher implementation.",
+    )
 
     # Server
     parser.add_argument("--host", type=str, default="0.0.0.0")
@@ -80,6 +97,102 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--model-name", type=str, default="ming-omni")
 
     return parser.parse_args()
+
+
+def _validate_fraction(flag_name: str, value: float | None) -> None:
+    if value is not None and not 0.0 < value < 1.0:
+        raise ValueError(f"{flag_name} must be > 0 and < 1, got {value}")
+
+
+def _apply_stage_factory_updates(
+    config: Any,
+    *,
+    stage_name: str,
+    updates: dict[str, object] | None = None,
+    server_arg_updates: dict[str, object] | None = None,
+) -> None:
+    for stage in config.stages:
+        if stage.name != stage_name:
+            continue
+        factory_args = dict(stage.factory_args or {})
+        if updates:
+            factory_args.update(updates)
+        if server_arg_updates:
+            overrides = dict(factory_args.get("server_args_overrides") or {})
+            overrides.update(server_arg_updates)
+            factory_args["server_args_overrides"] = overrides
+        stage.factory_args = factory_args
+        return
+    raise ValueError(
+        f"Stage {stage_name!r} not found in config {type(config).__name__}"
+    )
+
+
+def _set_stage_gpu(config: Any, stage_name: str, gpu_id: int) -> None:
+    for stage in config.stages:
+        if stage.name == stage_name:
+            stage.gpu = int(gpu_id)
+            return
+    raise ValueError(
+        f"Stage {stage_name!r} not found in config {type(config).__name__}"
+    )
+
+
+def _set_thinker_tp(config: Any, *, start_gpu: int, tp_size: int) -> None:
+    if tp_size < 1:
+        raise ValueError(f"--tp-size must be >= 1, got {tp_size}")
+    for stage in config.stages:
+        if stage.name == "thinker":
+            stage.tp_size = int(tp_size)
+            if tp_size == 1:
+                stage.gpu = int(start_gpu)
+            else:
+                stage.gpu = list(range(int(start_gpu), int(start_gpu) + int(tp_size)))
+            return
+    raise ValueError("Stage 'thinker' not found in config")
+
+
+def _launch_v1_speech_server(args: argparse.Namespace) -> None:
+    from sglang_omni_v1.models.ming_omni.config import MingOmniSpeechPipelineConfig
+    from sglang_omni_v1.serve import launch_server as launch_v1_server
+
+    _validate_fraction("--mem-fraction-static", args.mem_fraction_static)
+
+    config = MingOmniSpeechPipelineConfig(
+        model_path=args.model_path,
+        relay_backend=args.relay_backend,
+    )
+    _set_thinker_tp(
+        config,
+        start_gpu=args.gpu_thinker,
+        tp_size=int(args.tp_size),
+    )
+    _set_stage_gpu(config, "talker", args.gpu_talker)
+    config._validate_talker_gpu_not_in_thinker_tp_range()
+
+    server_arg_updates: dict[str, object] = {}
+    if args.tp_size and args.tp_size > 1:
+        server_arg_updates["disable_custom_all_reduce"] = True
+    if args.mem_fraction_static is not None:
+        server_arg_updates["mem_fraction_static"] = args.mem_fraction_static
+    if server_arg_updates:
+        _apply_stage_factory_updates(
+            config,
+            stage_name="thinker",
+            server_arg_updates=server_arg_updates,
+        )
+    _apply_stage_factory_updates(
+        config,
+        stage_name="talker",
+        updates={"voice": args.voice},
+    )
+
+    launch_v1_server(
+        config,
+        host=args.host,
+        port=args.port,
+        model_name=args.model_name,
+    )
 
 
 async def main_async(args: argparse.Namespace) -> None:
@@ -136,7 +249,22 @@ async def main_async(args: argparse.Namespace) -> None:
 def main() -> None:
     mp.set_start_method("spawn", force=True)
     args = parse_args()
+    _print_version_banner(args.version)
+    if args.version == "v1":
+        _launch_v1_speech_server(args)
+        return
     asyncio.run(main_async(args))
+
+
+def _print_version_banner(version: str) -> None:
+    try:
+        from sglang_omni.utils import print_server_version_banner
+    except Exception:
+        print(f"SGLANG-OMNI SERVER VERSION = {version.upper()}", flush=True)
+        return
+    print_server_version_banner(
+        version, entry="examples/run_ming_omni_speech_server.py"
+    )
 
 
 if __name__ == "__main__":

--- a/examples/run_ming_omni_speech_server.py
+++ b/examples/run_ming_omni_speech_server.py
@@ -153,8 +153,8 @@ def _set_thinker_tp(config: Any, *, start_gpu: int, tp_size: int) -> None:
 
 
 def _launch_v1_speech_server(args: argparse.Namespace) -> None:
-    from sglang_omni_v1.models.ming_omni.config import MingOmniSpeechPipelineConfig
-    from sglang_omni_v1.serve import launch_server as launch_v1_server
+    from sglang_omni.models.ming_omni.config import MingOmniSpeechPipelineConfig
+    from sglang_omni.serve import launch_server as launch_v1_server
 
     _validate_fraction("--mem-fraction-static", args.mem_fraction_static)
 

--- a/examples/run_ming_omni_speech_server.py
+++ b/examples/run_ming_omni_speech_server.py
@@ -29,7 +29,6 @@ Usage::
 from __future__ import annotations
 
 import argparse
-import asyncio
 import logging
 import multiprocessing as mp
 import os
@@ -83,14 +82,6 @@ def parse_args() -> argparse.Namespace:
             "If omitted, SGLang chooses automatically."
         ),
     )
-    parser.add_argument(
-        "--version",
-        type=str,
-        default=os.environ.get("SGLANG_OMNI_SERVER_VERSION", "legacy"),
-        choices=["legacy", "v1"],
-        help="Select the legacy or v1 Ming-Omni speech launcher implementation.",
-    )
-
     # Server
     parser.add_argument("--host", type=str, default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8000)
@@ -144,6 +135,9 @@ def _set_thinker_tp(config: Any, *, start_gpu: int, tp_size: int) -> None:
     for stage in config.stages:
         if stage.name == "thinker":
             stage.tp_size = int(tp_size)
+            stage.parallelism = stage.parallelism.model_copy(
+                update={"tp": int(tp_size)}
+            )
             if tp_size == 1:
                 stage.gpu = int(start_gpu)
             else:
@@ -152,9 +146,9 @@ def _set_thinker_tp(config: Any, *, start_gpu: int, tp_size: int) -> None:
     raise ValueError("Stage 'thinker' not found in config")
 
 
-def _launch_v1_speech_server(args: argparse.Namespace) -> None:
+def _launch_speech_server(args: argparse.Namespace) -> None:
     from sglang_omni.models.ming_omni.config import MingOmniSpeechPipelineConfig
-    from sglang_omni.serve import launch_server as launch_v1_server
+    from sglang_omni.serve import launch_server
 
     _validate_fraction("--mem-fraction-static", args.mem_fraction_static)
 
@@ -187,7 +181,7 @@ def _launch_v1_speech_server(args: argparse.Namespace) -> None:
         updates={"voice": args.voice},
     )
 
-    launch_v1_server(
+    launch_server(
         config,
         host=args.host,
         port=args.port,
@@ -195,76 +189,10 @@ def _launch_v1_speech_server(args: argparse.Namespace) -> None:
     )
 
 
-async def main_async(args: argparse.Namespace) -> None:
-    import uvicorn
-
-    from sglang_omni.client import Client
-    from sglang_omni.models.ming_omni.config import MingOmniSpeechPipelineConfig
-    from sglang_omni.pipeline.mp_runner import MultiProcessPipelineRunner
-    from sglang_omni.serve.openai_api import create_app
-
-    gpu_placement = {
-        "thinker": args.gpu_thinker,
-        "talker": args.gpu_talker,
-    }
-
-    config = MingOmniSpeechPipelineConfig(
-        model_path=args.model_path,
-        relay_backend=args.relay_backend,
-        gpu_placement=gpu_placement,
-    )
-    if args.mem_fraction_static is not None:
-        if not 0.0 < args.mem_fraction_static < 1.0:
-            raise ValueError(
-                f"--mem-fraction-static must be > 0 and < 1, got {args.mem_fraction_static}"
-            )
-        config.apply_server_args_overrides(
-            stage_name="thinker",
-            overrides={"mem_fraction_static": args.mem_fraction_static},
-        )
-
-    runner = MultiProcessPipelineRunner(config)
-    logger.info("Starting Ming-Omni speech pipeline (multiprocess)...")
-    await runner.start(timeout=600)
-    logger.info("Pipeline ready.")
-
-    try:
-        client = Client(runner.coordinator)
-        app = create_app(client, model_name=args.model_name)
-
-        server_config = uvicorn.Config(
-            app,
-            host=args.host,
-            port=args.port,
-            log_level="info",
-        )
-        server = uvicorn.Server(server_config)
-        await server.serve()
-    finally:
-        logger.info("Shutting down pipeline...")
-        await runner.stop()
-        logger.info("Pipeline stopped.")
-
-
 def main() -> None:
     mp.set_start_method("spawn", force=True)
     args = parse_args()
-    _print_version_banner(args.version)
-    if args.version == "v1":
-        _launch_v1_speech_server(args)
-        return
-    asyncio.run(main_async(args))
-
-
-def _print_version_banner(version: str) -> None:
-    try:
-        from sglang_omni.utils import print_server_version_banner
-    except Exception:
-        print(f"SGLANG-OMNI SERVER VERSION = {version.upper()}", flush=True)
-        return
-    print_server_version_banner(
-        version, entry="examples/run_ming_omni_speech_server.py"
-    )
+    _launch_speech_server(args)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dependencies = [
     "gradio>=4.0.0",
     # Ming-Omni
     "diffusers==0.37.1",
+    "x-transformers",          # Ming talker rotary embeddings
     # flash-attn: install separately via prebuilt wheel (see install instructions below)
 ]
 

--- a/sglang_omni/client/client.py
+++ b/sglang_omni/client/client.py
@@ -303,17 +303,22 @@ class Client:
             result.request_id = request_id
             return result
         if isinstance(result, dict):
-            # Multi-terminal merged result: {"decode": {...}, "code2wav": {...}}
-            if "decode" in result and "code2wav" in result:
+            # Multi-terminal merged result, e.g. decode + code2wav/talker.
+            audio_result = None
+            if "decode" in result:
+                for audio_stage in ("code2wav", "talker"):
+                    if audio_stage in result:
+                        audio_result = result[audio_stage] or {}
+                        break
+            if audio_result is not None:
                 decode_result = result["decode"] or {}
-                c2w_result = result["code2wav"] or {}
                 text = decode_result.get("text")
                 if isinstance(text, str):
                     chunk.text = text
-                Client._set_audio_data(chunk, c2w_result)
+                Client._set_audio_data(chunk, audio_result)
                 chunk.usage = Client._build_usage_info(
                     decode_result
-                ) or Client._build_usage_info(c2w_result)
+                ) or Client._build_usage_info(audio_result)
                 return chunk
             text = result.get("text")
             if isinstance(text, str):

--- a/sglang_omni/config/__init__.py
+++ b/sglang_omni/config/__init__.py
@@ -52,3 +52,11 @@ __all__ = [
     "RelayConfig",
     "EndpointsConfig",
 ]
+
+
+def __getattr__(name: str):
+    if name == "compile_pipeline":
+        from sglang_omni_v1.config.compiler import compile_pipeline
+
+        return compile_pipeline
+    raise AttributeError(name)

--- a/sglang_omni/config/__init__.py
+++ b/sglang_omni/config/__init__.py
@@ -52,11 +52,3 @@ __all__ = [
     "RelayConfig",
     "EndpointsConfig",
 ]
-
-
-def __getattr__(name: str):
-    if name == "compile_pipeline":
-        from sglang_omni_v1.config.compiler import compile_pipeline
-
-        return compile_pipeline
-    raise AttributeError(name)

--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -250,7 +250,7 @@ class ModelRunner:
             suppress_tokens = data.suppress_tokens
             if not suppress_tokens:
                 req = data.req
-                suppress_tokens = req._codec_suppress_tokens
+                suppress_tokens = getattr(req, "_codec_suppress_tokens", None)
             if not suppress_tokens:
                 continue
             for token_id in suppress_tokens:

--- a/sglang_omni/model_runner/ming_thinker_model_runner.py
+++ b/sglang_omni/model_runner/ming_thinker_model_runner.py
@@ -118,10 +118,9 @@ class MingThinkerModelRunner(ModelRunner):
 
                 mask = req_input_ids == match_id
                 if not mask.any():
-                    if is_final_chunk and offset < total_rows:
-                        raise self._missing_placeholder_error(
-                            modality, req_id, remaining=total_rows - offset
-                        )
+                    # Cache hit may have absorbed all placeholder positions for
+                    # this modality; aligning with qwen3 thinker_model_runner
+                    # which silently continues here.
                     continue
 
                 n_tokens = int(mask.sum().item())
@@ -142,7 +141,8 @@ class MingThinkerModelRunner(ModelRunner):
             req._omni_consumed = consumed
 
             if is_final_chunk:
-                self._validate_final_consumption(req, omni_inputs, consumed)
+                # Skip strict consumed==total validation: radix prefix cache may
+                # have absorbed placeholder positions. Mirrors qwen3 path.
                 req.omni_model_inputs = None
                 req._omni_consumed = None
 

--- a/sglang_omni/model_runner/ming_thinker_model_runner.py
+++ b/sglang_omni/model_runner/ming_thinker_model_runner.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+"""V1 multimodal prefill injection."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from sglang.srt.managers.scheduler import GenerationBatchResult
+
+from sglang_omni_v1.model_runner.base import ModelRunner
+
+
+class MingThinkerModelRunner(ModelRunner):
+    """Inject Ming image/audio embeddings into thinker prefill requests."""
+
+    def __init__(self, tp_worker: Any, output_processor: Any):
+        super().__init__(tp_worker, output_processor)
+
+        self._outer_model = self.model
+        self._text_model = getattr(self._outer_model, "model", self._outer_model)
+        self._embed_tokens = self._get_embed_tokens(self._text_model)
+
+        hf_config = tp_worker.model_runner.model_config.hf_config
+        llm_config = getattr(hf_config, "llm_config", hf_config)
+        self._image_token_id = self._token_id(
+            hf_config,
+            "image_token_id",
+            fallback=getattr(llm_config, "image_patch_token", None),
+        )
+        self._video_token_id = self._token_id(
+            hf_config,
+            "video_token_id",
+            fallback=getattr(llm_config, "video_patch_token", None),
+        )
+        self._audio_token_id = self._token_id(hf_config, "audio_token_id")
+
+    @staticmethod
+    def _get_embed_tokens(text_model: Any) -> Any:
+        embed_tokens = getattr(text_model, "embed_tokens", None)
+        if embed_tokens is not None:
+            return embed_tokens
+        get_input_embeddings = getattr(text_model, "get_input_embeddings", None)
+        if callable(get_input_embeddings):
+            embed_tokens = get_input_embeddings()
+        if embed_tokens is None:
+            raise AttributeError("Ming thinker model does not expose embed_tokens")
+        return embed_tokens
+
+    @staticmethod
+    def _token_id(config: Any, name: str, *, fallback: Any = None) -> int | None:
+        value = getattr(config, name, None)
+        if value is None:
+            value = fallback
+        return int(value) if value is not None else None
+
+    def prepare_prefill(self, forward_batch: Any, schedule_batch: Any, requests: list):
+        """Custom prefill for multimodal inputs."""
+        del requests
+        if not schedule_batch.forward_mode.is_extend():
+            return None
+
+        input_embeds = self._inject_multimodal_embeds(forward_batch, schedule_batch)
+        if input_embeds is None:
+            return None
+        return self._forward_with_omni_embeds(forward_batch, input_embeds)
+
+    def _inject_multimodal_embeds(
+        self, forward_batch: Any, schedule_batch: Any
+    ) -> torch.Tensor | None:
+        if not any(req.omni_model_inputs is not None for req in schedule_batch.reqs):
+            return None
+
+        device = forward_batch.input_ids.device
+        embed_input_ids = forward_batch.input_ids.clamp(
+            0, self._embed_tokens.num_embeddings - 1
+        )
+        input_embeds = self._embed_tokens(embed_input_ids)
+
+        extend_lens = forward_batch.extend_seq_lens_cpu
+        offsets = []
+        pos = 0
+        for length in extend_lens:
+            offsets.append(pos)
+            pos += length
+
+        for i, req in enumerate(schedule_batch.reqs):
+            omni_inputs = req.omni_model_inputs
+            if omni_inputs is None:
+                continue
+
+            start = offsets[i]
+            end = start + extend_lens[i]
+            req_input_ids = forward_batch.input_ids[start:end]
+            consumed = getattr(req, "_omni_consumed", None) or {}
+            pad_values = omni_inputs.get("pad_values", {})
+            is_final_chunk = getattr(req, "is_chunked", 0) == 0
+            req_id = self._request_id(req)
+
+            for modality, embed_key, token_id in [
+                ("image", "image_embeds", self._image_token_id),
+                ("video", "video_embeds", self._video_token_id),
+                ("audio", "audio_embeds", self._audio_token_id),
+            ]:
+                embeds = omni_inputs.get(embed_key)
+                if embeds is None:
+                    continue
+
+                total_rows = self._num_embed_rows(embeds)
+                offset = int(consumed.get(modality, 0))
+                match_id = self._resolve_match_id(pad_values, modality, token_id)
+                if match_id is None:
+                    if is_final_chunk and offset < total_rows:
+                        raise self._missing_match_id_error(
+                            modality, req_id, remaining=total_rows - offset
+                        )
+                    continue
+
+                mask = req_input_ids == match_id
+                if not mask.any():
+                    if is_final_chunk and offset < total_rows:
+                        raise self._missing_placeholder_error(
+                            modality, req_id, remaining=total_rows - offset
+                        )
+                    continue
+
+                n_tokens = int(mask.sum().item())
+                available = total_rows - offset
+                if available < n_tokens:
+                    raise self._short_embeds_error(
+                        modality,
+                        req_id,
+                        needed=n_tokens,
+                        available=available,
+                    )
+                chunk_embeds = embeds[offset : offset + n_tokens].to(
+                    device=device, dtype=input_embeds.dtype
+                )
+                input_embeds[torch.where(mask)[0] + start] = chunk_embeds
+                consumed[modality] = offset + n_tokens
+
+            req._omni_consumed = consumed
+
+            if is_final_chunk:
+                self._validate_final_consumption(req, omni_inputs, consumed)
+                req.omni_model_inputs = None
+                req._omni_consumed = None
+
+        return input_embeds
+
+    @staticmethod
+    def _resolve_match_id(
+        pad_values: dict[str, Any], modality: str, token_id: int | None
+    ) -> int | None:
+        if modality in pad_values:
+            return int(pad_values[modality])
+        return token_id
+
+    @staticmethod
+    def _num_embed_rows(embeds: Any) -> int:
+        shape = getattr(embeds, "shape", None)
+        if shape is not None and len(shape) > 0:
+            return int(shape[0])
+        return len(embeds)
+
+    @staticmethod
+    def _request_id(req: Any) -> str:
+        return str(getattr(req, "rid", getattr(req, "request_id", "<unknown>")))
+
+    def _validate_final_consumption(
+        self, req: Any, omni_inputs: dict[str, Any], consumed: dict[str, int]
+    ) -> None:
+        req_id = self._request_id(req)
+        for modality, embed_key in [
+            ("image", "image_embeds"),
+            ("video", "video_embeds"),
+            ("audio", "audio_embeds"),
+        ]:
+            embeds = omni_inputs.get(embed_key)
+            if embeds is None:
+                continue
+            total_rows = self._num_embed_rows(embeds)
+            consumed_rows = int(consumed.get(modality, 0))
+            if consumed_rows != total_rows:
+                raise ValueError(
+                    "Ming thinker multimodal embed count mismatch for "
+                    f"{modality} request_id={req_id}: "
+                    f"consumed={consumed_rows}, total={total_rows}"
+                )
+
+    @staticmethod
+    def _missing_match_id_error(
+        modality: str, req_id: str, *, remaining: int
+    ) -> ValueError:
+        return ValueError(
+            "Ming thinker multimodal embeds could not be injected for "
+            f"{modality} request_id={req_id}: no usable match id "
+            f"for remaining={remaining} embed rows"
+        )
+
+    @staticmethod
+    def _missing_placeholder_error(
+        modality: str, req_id: str, *, remaining: int
+    ) -> ValueError:
+        return ValueError(
+            "Ming thinker multimodal embeds could not be injected for "
+            f"{modality} request_id={req_id}: no placeholders found "
+            f"for remaining={remaining} embed rows"
+        )
+
+    @staticmethod
+    def _short_embeds_error(
+        modality: str, req_id: str, *, needed: int, available: int
+    ) -> ValueError:
+        return ValueError(
+            "Ming thinker multimodal embeds are shorter than placeholders for "
+            f"{modality} request_id={req_id}: "
+            f"needed={needed}, available={available}"
+        )
+
+    def _forward_with_omni_embeds(
+        self, forward_batch: Any, input_embeds: torch.Tensor
+    ) -> Any:
+        model_runner = self.tp_worker.model_runner
+        outer = self._outer_model
+
+        model_runner.attn_backend.init_forward_metadata(forward_batch)
+
+        positions = forward_batch.positions
+        if forward_batch.mrope_positions is not None:
+            positions = forward_batch.mrope_positions
+
+        hidden_states = outer.model(
+            input_ids=None,
+            positions=positions,
+            forward_batch=forward_batch,
+            input_embeds=input_embeds,
+        )
+
+        logits_output = outer.logits_processor(
+            forward_batch.input_ids,
+            hidden_states,
+            outer.lm_head,
+            forward_batch,
+        )
+
+        return GenerationBatchResult(
+            logits_output=logits_output,
+            can_run_cuda_graph=False,
+        )

--- a/sglang_omni/model_runner/ming_thinker_model_runner.py
+++ b/sglang_omni/model_runner/ming_thinker_model_runner.py
@@ -8,7 +8,7 @@ from typing import Any
 import torch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 
-from sglang_omni_v1.model_runner.base import ModelRunner
+from sglang_omni.model_runner.base import ModelRunner
 
 
 class MingThinkerModelRunner(ModelRunner):

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -56,7 +56,7 @@ class ModelWorker:
 
     def _init_model_config(self):
         if self.model_arch_override == "BailingMoeV2ForCausalLM":
-            from sglang_omni_v1.models.ming_omni.registration import (
+            from sglang_omni.models.ming_omni.registration import (
                 register_ming_hf_config,
             )
 

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -19,6 +19,7 @@ class ModelWorkerConfig:
 
 
 _ARCH_CONFIG_MAP: dict[str, tuple[str, str | None]] = {
+    "BailingMoeV2ForCausalLM": ("llm_config", None),
     "Qwen3OmniTalker": ("talker_config", "text_config"),
     "Qwen3OmniThinkerForCausalLM": ("thinker_config", "text_config"),
 }
@@ -54,6 +55,13 @@ class ModelWorker:
         set_random_seed(self.random_seed)
 
     def _init_model_config(self):
+        if self.model_arch_override == "BailingMoeV2ForCausalLM":
+            from sglang_omni_v1.models.ming_omni.registration import (
+                register_ming_hf_config,
+            )
+
+            register_ming_hf_config()
+
         from sglang.srt.configs.model_config import ModelConfig
 
         self.model_config = ModelConfig.from_server_args(

--- a/sglang_omni/model_runner/sglang_model_runner.py
+++ b/sglang_omni/model_runner/sglang_model_runner.py
@@ -86,10 +86,17 @@ class SGLModelRunner(ModelRunner):
             S2ProSGLangTextModel,
         )
         from sglang_omni.models.higgs_tts.model import HiggsTTSModel
+        from sglang_omni.models.ming_omni.registration import (
+            register_ming_hf_config,
+            register_ming_model_registry,
+        )
         from sglang_omni.models.qwen3_omni.components.sglang_thinker import (
             Qwen3OmniThinkerForCausalLM,
         )
         from sglang_omni.models.qwen3_omni.components.talker import Qwen3OmniTalker
+
+        register_ming_hf_config()
+        register_ming_model_registry()
 
         ModelRegistry.models["S2ProSGLangTextModel"] = S2ProSGLangTextModel
         ModelRegistry.models["Qwen3OmniTalker"] = Qwen3OmniTalker

--- a/sglang_omni/models/ming_omni/bootstrap.py
+++ b/sglang_omni/models/ming_omni/bootstrap.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def create_thinker_scheduler(
+    server_args: Any,
+    *,
+    model_path: str,
+    gpu_id: int = 0,
+    tp_rank: int = 0,
+    tp_size: int = 1,
+    nccl_port: int | None = None,
+):
+    if tp_size < 1:
+        raise ValueError(f"tp_size must be >= 1, got {tp_size}")
+    if getattr(server_args, "tp_size", None) != tp_size:
+        server_args.tp_size = tp_size
+
+    from sglang_omni_v1.model_runner.ming_thinker_model_runner import (
+        MingThinkerModelRunner,
+    )
+    from sglang_omni_v1.models.ming_omni.components.common import (
+        load_ming_config,
+        load_ming_tokenizer,
+    )
+    from sglang_omni_v1.scheduling.bootstrap import create_sglang_infrastructure
+    from sglang_omni_v1.scheduling.omni_scheduler import OmniScheduler
+    from sglang_omni_v1.scheduling.sglang_backend import SGLangOutputProcessor
+
+    tokenizer = load_ming_tokenizer(model_path)
+    config = load_ming_config(model_path)
+    llm_cfg = getattr(config, "llm_config", config)
+    vocab_size = getattr(llm_cfg, "vocab_size", None) or getattr(
+        tokenizer, "vocab_size", 32000
+    )
+
+    (
+        model_worker,
+        tree_cache,
+        req_to_token_pool,
+        token_to_kv_pool_allocator,
+        prefill_mgr,
+        decode_mgr,
+        model_config,
+    ) = create_sglang_infrastructure(
+        server_args,
+        gpu_id,
+        tp_rank=tp_rank,
+        nccl_port=nccl_port,
+        model_arch_override="BailingMoeV2ForCausalLM",
+    )
+
+    output_proc = SGLangOutputProcessor(
+        capture_hidden=False,
+        capture_hidden_layers=None,
+        model=model_worker.model_runner.model,
+    )
+    model_runner = MingThinkerModelRunner(model_worker, output_proc)
+
+    request_builder, result_adapter = make_thinker_scheduler_adapters(
+        tokenizer=tokenizer,
+        vocab_size=vocab_size,
+    )
+
+    return OmniScheduler(
+        tp_worker=model_worker,
+        tree_cache=tree_cache,
+        req_to_token_pool=req_to_token_pool,
+        token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+        server_args=server_args,
+        model_config=model_config,
+        prefill_manager=prefill_mgr,
+        decode_manager=decode_mgr,
+        model_runner=model_runner,
+        request_builder=request_builder,
+        result_adapter=result_adapter,
+    )
+
+
+def make_thinker_scheduler_adapters(
+    *,
+    tokenizer: Any,
+    vocab_size: int,
+    stage_name: str = "thinker",
+):
+    """Build StagePayload <-> SGLang request adapters."""
+
+    def request_builder(payload):
+        from sglang.srt.managers.schedule_batch import Req
+        from sglang.srt.sampling.sampling_params import SamplingParams
+
+        from sglang_omni_v1.models.ming_omni.io import PipelineState
+        from sglang_omni_v1.scheduling.sglang_backend import SGLangARRequestData
+
+        state = PipelineState.from_dict(payload.data)
+        prompt = state.prompt
+        if not isinstance(prompt, dict):
+            raise TypeError("prompt missing for thinker request")
+
+        input_ids = prompt.get("input_ids")
+        if not hasattr(input_ids, "to"):
+            raise TypeError("prompt.input_ids must be a torch.Tensor")
+        input_ids_list = input_ids.to(dtype=_torch_long()).flatten().tolist()
+
+        params = payload.request.params or {}
+        max_new_tokens = params.get("max_new_tokens", 2048)
+        temperature = params.get("temperature", 0.0)
+        sampling_params = SamplingParams(
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+        )
+        sampling_params.normalize(tokenizer)
+        sampling_params.verify(vocab_size)
+
+        eos_token_ids = _collect_eos_token_ids(tokenizer)
+        req = Req(
+            rid=payload.request_id,
+            origin_input_text="",
+            origin_input_ids=input_ids_list,
+            sampling_params=sampling_params,
+            vocab_size=vocab_size,
+            eos_token_ids=eos_token_ids,
+        )
+        req.tokenizer = tokenizer
+
+        thinker_inputs = state.thinker_inputs or {}
+        model_inputs = dict(thinker_inputs.get("model_inputs", {}))
+        if not model_inputs:
+            model_inputs = {
+                key: value
+                for key, value in thinker_inputs.items()
+                if key != "capture_model_output_keys"
+            }
+        model_inputs.pop("attention_mask", None)
+        capture_keys = thinker_inputs.get("capture_model_output_keys", ())
+
+        req.omni_model_inputs = model_inputs if model_inputs else None
+        req._omni_consumed = None
+        req._codec_suppress_tokens = None
+
+        attention_mask = prompt.get("attention_mask")
+        req_data = SGLangARRequestData(
+            input_ids=input_ids.to(dtype=_torch_long()).flatten(),
+            attention_mask=attention_mask if hasattr(attention_mask, "to") else None,
+            model_inputs=model_inputs,
+            capture_model_output_keys=tuple(capture_keys) if capture_keys else (),
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+            output_ids=req.output_ids,
+            req=req,
+        )
+        req_data.stage_payload = payload
+        return req_data
+
+    def result_adapter(data):
+        from sglang_omni_v1.models.ming_omni.io import PipelineState
+        from sglang_omni_v1.proto import StagePayload
+
+        payload = data.stage_payload
+        state = PipelineState.from_dict(payload.data)
+        output_ids = list(data.output_ids)
+        if data.finish_reason is not None or not output_ids:
+            logger.info(
+                "Ming thinker result request_id=%s finish=%s output_len=%d "
+                "output_tail=%s stop_hits=%s",
+                payload.request_id,
+                data.finish_reason,
+                len(output_ids),
+                output_ids[-8:],
+                _stop_hits(output_ids, tokenizer),
+            )
+        thinker_out: dict[str, Any] = {
+            "output_ids": output_ids,
+            "step": len(output_ids),
+            "is_final": True,
+            "extra_model_outputs": dict(data.extra_model_outputs),
+        }
+        if data.finish_reason is not None:
+            thinker_out["finish_reason"] = data.finish_reason
+        state.thinker_out = thinker_out
+        state.engine_outputs[stage_name] = thinker_out
+        return StagePayload(
+            request_id=payload.request_id,
+            request=payload.request,
+            data=state.to_dict(),
+        )
+
+    return request_builder, result_adapter
+
+
+def _torch_long():
+    import torch
+
+    return torch.long
+
+
+def _collect_eos_token_ids(tokenizer: Any) -> set[int] | None:
+    """Match Ming V0: let the SGLang request stop only on tokenizer EOS."""
+    eid = getattr(tokenizer, "eos_token_id", None)
+    return {int(eid)} if isinstance(eid, int) and eid >= 0 else None
+
+
+def _stop_hits(output_ids: list[int], tokenizer: Any) -> list[int]:
+    stop_ids = _collect_eos_token_ids(tokenizer) or set()
+    return [int(token_id) for token_id in output_ids[-8:] if int(token_id) in stop_ids]

--- a/sglang_omni/models/ming_omni/bootstrap.py
+++ b/sglang_omni/models/ming_omni/bootstrap.py
@@ -22,16 +22,16 @@ def create_thinker_scheduler(
     if getattr(server_args, "tp_size", None) != tp_size:
         server_args.tp_size = tp_size
 
-    from sglang_omni_v1.model_runner.ming_thinker_model_runner import (
+    from sglang_omni.model_runner.ming_thinker_model_runner import (
         MingThinkerModelRunner,
     )
-    from sglang_omni_v1.models.ming_omni.components.common import (
+    from sglang_omni.models.ming_omni.components.common import (
         load_ming_config,
         load_ming_tokenizer,
     )
-    from sglang_omni_v1.scheduling.bootstrap import create_sglang_infrastructure
-    from sglang_omni_v1.scheduling.omni_scheduler import OmniScheduler
-    from sglang_omni_v1.scheduling.sglang_backend import SGLangOutputProcessor
+    from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
+    from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+    from sglang_omni.scheduling.sglang_backend import SGLangOutputProcessor
 
     tokenizer = load_ming_tokenizer(model_path)
     config = load_ming_config(model_path)
@@ -109,8 +109,8 @@ def make_thinker_scheduler_adapters(
         from sglang.srt.managers.schedule_batch import Req
         from sglang.srt.sampling.sampling_params import SamplingParams
 
-        from sglang_omni_v1.models.ming_omni.io import PipelineState
-        from sglang_omni_v1.scheduling.sglang_backend import SGLangARRequestData
+        from sglang_omni.models.ming_omni.io import PipelineState
+        from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
 
         state = PipelineState.from_dict(payload.data)
         prompt = state.prompt
@@ -205,8 +205,8 @@ def make_thinker_scheduler_adapters(
         return req_data
 
     def result_adapter(data):
-        from sglang_omni_v1.models.ming_omni.io import PipelineState
-        from sglang_omni_v1.proto import StagePayload
+        from sglang_omni.models.ming_omni.io import PipelineState
+        from sglang_omni.proto import StagePayload
 
         payload = data.stage_payload
         state = PipelineState.from_dict(payload.data)

--- a/sglang_omni/models/ming_omni/bootstrap.py
+++ b/sglang_omni/models/ming_omni/bootstrap.py
@@ -63,9 +63,20 @@ def create_thinker_scheduler(
     )
     model_runner = MingThinkerModelRunner(model_worker, output_proc)
 
+    image_token_id = getattr(llm_cfg, "image_patch_token", None)
+    video_token_id = getattr(llm_cfg, "video_patch_token", None)
+    _audio_tok = tokenizer.convert_tokens_to_ids("<audioPatch>")
+    _unk = getattr(tokenizer, "unk_token_id", None)
+    audio_token_id = (
+        _audio_tok if isinstance(_audio_tok, int) and _audio_tok != _unk else None
+    )
+
     request_builder, result_adapter = make_thinker_scheduler_adapters(
         tokenizer=tokenizer,
         vocab_size=vocab_size,
+        image_token_id=image_token_id,
+        audio_token_id=audio_token_id,
+        video_token_id=video_token_id,
     )
 
     return OmniScheduler(
@@ -87,6 +98,9 @@ def make_thinker_scheduler_adapters(
     *,
     tokenizer: Any,
     vocab_size: int,
+    image_token_id: int | None = None,
+    audio_token_id: int | None = None,
+    video_token_id: int | None = None,
     stage_name: str = "thinker",
 ):
     """Build StagePayload <-> SGLang request adapters."""
@@ -106,6 +120,36 @@ def make_thinker_scheduler_adapters(
         input_ids = prompt.get("input_ids")
         if not hasattr(input_ids, "to"):
             raise TypeError("prompt.input_ids must be a torch.Tensor")
+
+        # Per-content pad_value substitution to defeat SGLang radix prefix-cache
+        # aliasing across multimodal requests that share the same generic
+        # image/audio/video patch token id.
+        thinker_inputs_early = state.thinker_inputs or {}
+        media_cache_keys = thinker_inputs_early.get("media_cache_keys") or {}
+        pad_values: dict[str, int] = {}
+        if media_cache_keys:
+            import xxhash
+
+            token_id_map: dict[int, int] = {}
+            for _modality, _orig in [
+                ("image", image_token_id),
+                ("audio", audio_token_id),
+                ("video", video_token_id),
+            ]:
+                if _orig is None:
+                    continue
+                _ck = media_cache_keys.get(_modality)
+                if _ck is None:
+                    continue
+                _h = xxhash.xxh3_64(_ck.encode()).intdigest()
+                _pad = vocab_size + _h % (1 << 30)
+                pad_values[_modality] = _pad
+                token_id_map[int(_orig)] = _pad
+            if token_id_map:
+                input_ids = input_ids.clone()
+                for _orig_id, _pad in token_id_map.items():
+                    input_ids[input_ids == _orig_id] = _pad
+
         input_ids_list = input_ids.to(dtype=_torch_long()).flatten().tolist()
 
         params = payload.request.params or {}
@@ -129,15 +173,17 @@ def make_thinker_scheduler_adapters(
         )
         req.tokenizer = tokenizer
 
-        thinker_inputs = state.thinker_inputs or {}
+        thinker_inputs = thinker_inputs_early
         model_inputs = dict(thinker_inputs.get("model_inputs", {}))
         if not model_inputs:
             model_inputs = {
                 key: value
                 for key, value in thinker_inputs.items()
-                if key != "capture_model_output_keys"
+                if key not in ("capture_model_output_keys", "media_cache_keys")
             }
         model_inputs.pop("attention_mask", None)
+        if pad_values:
+            model_inputs["pad_values"] = pad_values
         capture_keys = thinker_inputs.get("capture_model_output_keys", ())
 
         req.omni_model_inputs = model_inputs if model_inputs else None

--- a/sglang_omni/models/ming_omni/bootstrap.py
+++ b/sglang_omni/models/ming_omni/bootstrap.py
@@ -142,7 +142,7 @@ def make_thinker_scheduler_adapters(
                 if _ck is None:
                     continue
                 _h = xxhash.xxh3_64(_ck.encode()).intdigest()
-                _pad = vocab_size + _h % (1 << 30)
+                _pad = vocab_size + _h % (1 << 62)
                 pad_values[_modality] = _pad
                 token_id_map[int(_orig)] = _pad
             if token_id_map:

--- a/sglang_omni/models/ming_omni/components/audio_encoder.py
+++ b/sglang_omni/models/ming_omni/components/audio_encoder.py
@@ -86,7 +86,19 @@ class MingAudioEncoder(nn.Module):
 
         # Move to target device/dtype
         self.to(device=self._device, dtype=self._dtype)
+        self._patch_whisper_layernorms()
         self.eval()
+
+    def _patch_whisper_layernorms(self) -> None:
+        # whisper.model.LayerNorm.forward does x.float() which breaks bf16 weights.
+        import types
+
+        def _plain_ln_forward(ln_self: nn.LayerNorm, x: torch.Tensor) -> torch.Tensor:
+            return nn.LayerNorm.forward(ln_self, x)
+
+        for m in self.audio_tower.modules():
+            if isinstance(m, nn.LayerNorm):
+                m.forward = types.MethodType(_plain_ln_forward, m)
 
     def _build_whisper_encoder(self, whisper_cfg: Any) -> nn.Module:
         """Build a WhisperAudioEncoder from config."""

--- a/sglang_omni/models/ming_omni/components/audio_encoder.py
+++ b/sglang_omni/models/ming_omni/components/audio_encoder.py
@@ -141,6 +141,10 @@ class MingAudioEncoder(nn.Module):
                 audio_embeds: Projected embeddings [B, T', hidden_size]
                 audio_embed_lengths: Output lengths [B, N]
         """
+        audio_feats = audio_feats.to(device=self._device, dtype=self._dtype)
+        if audio_feats_lengths is not None:
+            audio_feats_lengths = audio_feats_lengths.to(device=self._device)
+
         # Whisper encoder expects [B, T, n_mels] and we process segments independently
         # Unwrap segments for per-segment encoding
         if audio_feats_lengths is not None and audio_feats_lengths.dim() == 2:

--- a/sglang_omni/models/ming_omni/components/audio_encoder.py
+++ b/sglang_omni/models/ming_omni/components/audio_encoder.py
@@ -86,19 +86,7 @@ class MingAudioEncoder(nn.Module):
 
         # Move to target device/dtype
         self.to(device=self._device, dtype=self._dtype)
-        self._patch_whisper_layernorms()
         self.eval()
-
-    def _patch_whisper_layernorms(self) -> None:
-        # whisper.model.LayerNorm.forward does x.float() which breaks bf16 weights.
-        import types
-
-        def _plain_ln_forward(ln_self: nn.LayerNorm, x: torch.Tensor) -> torch.Tensor:
-            return nn.LayerNorm.forward(ln_self, x)
-
-        for m in self.audio_tower.modules():
-            if isinstance(m, nn.LayerNorm):
-                m.forward = types.MethodType(_plain_ln_forward, m)
 
     def _build_whisper_encoder(self, whisper_cfg: Any) -> nn.Module:
         """Build a WhisperAudioEncoder from config."""
@@ -153,7 +141,7 @@ class MingAudioEncoder(nn.Module):
                 audio_embeds: Projected embeddings [B, T', hidden_size]
                 audio_embed_lengths: Output lengths [B, N]
         """
-        audio_feats = audio_feats.to(device=self._device, dtype=self._dtype)
+        audio_feats = audio_feats.to(device=self._device)
         if audio_feats_lengths is not None:
             audio_feats_lengths = audio_feats_lengths.to(device=self._device)
 
@@ -168,7 +156,14 @@ class MingAudioEncoder(nn.Module):
                 [audio_feats.shape[1]], device=audio_feats.device, dtype=torch.long
             )
 
-        with torch.no_grad():
+        with (
+            torch.no_grad(),
+            torch.autocast(
+                device_type="cuda", dtype=torch.bfloat16, enabled=segments.is_cuda
+            ),
+        ):
+            # Cast input to float32 for Whisper conv layers, autocast handles the rest
+            segments = segments.float()
             # Whisper encoder forward: [B, T, n_mels] -> [B, T, n_state]
             # The whisper encoder expects [B, T, n_mels], transposes internally
             encoded = self._whisper_forward(segments)

--- a/sglang_omni/models/ming_omni/components/common.py
+++ b/sglang_omni/models/ming_omni/components/common.py
@@ -19,101 +19,68 @@ from sglang_omni.models.weight_loader import resolve_model_path
 
 logger = logging.getLogger(__name__)
 
-# Known subdirectories where Ming repos store tokenizer files.
-_TOKENIZER_SUBDIRS = ("talker/llm",)
-_TOKENIZER_FILES = ("tokenizer.json", "tokenizer_config.json")
-
+_TOKENIZER_LOAD_ERRORS = (OSError, ValueError, KeyError)
 # Fallback tokenizer source: Ming-flash-omni-Preview has tokenizer files
-# at the repo root, used only as a last resort.
+# at the repo root.  Ming-flash-omni-2.0 also ships a talker/llm tokenizer, but
+# that is Qwen2-format and does not match the Bailing thinker vocabulary.
 _TOKENIZER_FALLBACK = "inclusionAI/Ming-flash-omni-Preview"
 
 
-def _resolve_local_tokenizer_subdir(model_path: str) -> Path | None:
-    base = Path(model_path)
-    if not base.exists():
-        return None
-    for subdir in _TOKENIZER_SUBDIRS:
-        subpath = base / subdir
-        if any((subpath / filename).is_file() for filename in _TOKENIZER_FILES):
-            return subpath
-    return None
-
-
-def _download_tokenizer_subdir_from_hub(model_path: str) -> Path | None:
-    for subdir in _TOKENIZER_SUBDIRS:
-        for filename in _TOKENIZER_FILES:
-            try:
-                cached = hf_hub_download(
-                    repo_id=model_path,
-                    filename=filename,
-                    subfolder=subdir,
-                )
-            except Exception:
-                continue
-            return Path(cached).parent
-    return None
-
-
 def load_ming_tokenizer(model_path: str):
-    """Load the Ming tokenizer, searching subdirectories before falling back.
+    """（wenyao）Load the Ming thinker tokenizer with a same-vocab fallback.
 
-    Ming HF repos may store tokenizer files in subdirectories (e.g.
-    ``talker/llm/``) rather than at the repo root.  We try:
+    Ming-flash-omni thinker uses the Bailing tokenizer.  Some Ming HF repos
+    (e.g. Ming-flash-omni-2.0) omit thinker tokenizer files at the root, so we
+    try:
     1. AutoTokenizer from the root path (with trust_remote_code)
     2. PreTrainedTokenizerFast from the root path
-    3. Known subdirectories (talker/llm), local first then selective Hub probe
-    4. Fallback to Ming-flash-omni-Preview repo (same vocab)
+    3. Fallback to Ming-flash-omni-Preview repo (same thinker vocab)
     """
     from transformers import AutoTokenizer, PreTrainedTokenizerFast
 
     # Strategy 1: standard AutoTokenizer at root
     try:
-        return AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
-    except (OSError, ValueError):
+        tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+        return _attach_ming_tokenizer_compat(tokenizer)
+    except _TOKENIZER_LOAD_ERRORS:
         pass
 
     # Strategy 2: direct PreTrainedTokenizerFast at root
     try:
-        return PreTrainedTokenizerFast.from_pretrained(model_path)
+        tokenizer = PreTrainedTokenizerFast.from_pretrained(model_path)
+        return _attach_ming_tokenizer_compat(tokenizer)
     except Exception:
         pass
 
-    # Strategy 3a: check known subdirectories for local paths
-    local_subpath = _resolve_local_tokenizer_subdir(model_path)
-    if local_subpath is not None:
-        try:
-            return AutoTokenizer.from_pretrained(
-                str(local_subpath), trust_remote_code=True
-            )
-        except (OSError, ValueError):
-            pass
-        try:
-            return PreTrainedTokenizerFast.from_pretrained(str(local_subpath))
-        except Exception:
-            pass
-
-    # Strategy 3b: probe known subdirectories on Hub by downloading only
-    # tokenizer files, avoiding a full snapshot download.
-    remote_subpath = _download_tokenizer_subdir_from_hub(model_path)
-    if remote_subpath is not None:
-        try:
-            return AutoTokenizer.from_pretrained(
-                str(remote_subpath), trust_remote_code=True
-            )
-        except (OSError, ValueError):
-            pass
-        try:
-            return PreTrainedTokenizerFast.from_pretrained(str(remote_subpath))
-        except Exception:
-            pass
-
-    # Strategy 4: fallback repo with matching vocab
+    # Strategy 3: fallback repo with matching thinker vocab
     logger.warning(
         "Tokenizer not found in %s, falling back to %s",
         model_path,
         _TOKENIZER_FALLBACK,
     )
-    return PreTrainedTokenizerFast.from_pretrained(_TOKENIZER_FALLBACK)
+    try:
+        tokenizer = AutoTokenizer.from_pretrained(
+            _TOKENIZER_FALLBACK, trust_remote_code=True
+        )
+        return _attach_ming_tokenizer_compat(tokenizer)
+    except _TOKENIZER_LOAD_ERRORS:
+        tokenizer = PreTrainedTokenizerFast.from_pretrained(_TOKENIZER_FALLBACK)
+        return _attach_ming_tokenizer_compat(tokenizer)
+
+
+def _attach_ming_tokenizer_compat(tokenizer):
+    """（wenyao）Patch tokenizer fields assumed by SGLang's scheduler.
+
+    Ming V0 relies on ``Req.eos_token_ids`` only.  Newer upstream SGLang also
+    probes ``tokenizer.additional_stop_token_ids`` during finish checks, so keep
+    the attribute present without adding extra stop ids that would change Ming's
+    known-good stop behavior.
+    """
+    try:
+        tokenizer.additional_stop_token_ids = None
+    except Exception:
+        pass
+    return tokenizer
 
 
 def load_ming_config(model_path: str) -> MingOmniConfig:

--- a/sglang_omni/models/ming_omni/components/common.py
+++ b/sglang_omni/models/ming_omni/components/common.py
@@ -8,8 +8,6 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 
-from huggingface_hub import hf_hub_download
-
 from sglang_omni.models.ming_omni.hf_config import (
     AudioConfig,
     BailingMoeV2LLMConfig,

--- a/sglang_omni/models/ming_omni/components/image_encoder.py
+++ b/sglang_omni/models/ming_omni/components/image_encoder.py
@@ -105,10 +105,10 @@ class MingImageEncoder(nn.Module):
         self.to(device=device, dtype=torch_dtype)
         self.eval()
 
-        # Release model parallel state so the thinker (loaded later) can
-        # reinitialize it.  At runtime, the thinker's TP context will be
-        # active and this encoder can use it transparently (TP=1).
-        self._cleanup_sglang_tp()
+        # Keep this stage's TP=1 context alive. In V1 multiprocess mode the
+        # image encoder and thinker run in separate processes, so the image
+        # encoder cannot rely on the thinker's tensor-parallel state at
+        # request time.
 
     @staticmethod
     def _vision_dict(vision_cfg: Any) -> dict:
@@ -127,8 +127,12 @@ class MingImageEncoder(nn.Module):
         import os
 
         import sglang.srt.layers.dp_attention as dp
+        from sglang.srt.distributed import parallel_state
 
-        if getattr(dp, "_ATTN_TP_SIZE", None) is not None and dp._ATTN_TP_SIZE > 0:
+        dp_tp_ready = (
+            getattr(dp, "_ATTN_TP_SIZE", None) is not None and dp._ATTN_TP_SIZE > 0
+        )
+        if dp_tp_ready and parallel_state.model_parallel_is_initialized():
             return  # Already initialized
 
         os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
@@ -148,8 +152,6 @@ class MingImageEncoder(nn.Module):
             set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
         except Exception:
             pass  # Already set
-
-        from sglang.srt.distributed import parallel_state
 
         if not parallel_state.model_parallel_is_initialized():
             parallel_state.init_distributed_environment(

--- a/sglang_omni/models/ming_omni/components/image_encoder.py
+++ b/sglang_omni/models/ming_omni/components/image_encoder.py
@@ -105,7 +105,7 @@ class MingImageEncoder(nn.Module):
         self.to(device=device, dtype=torch_dtype)
         self.eval()
 
-        # Keep this stage's TP=1 context alive. In V1 multiprocess mode the
+        # Keep this stage's TP=1 context alive. In multiprocess mode the
         # image encoder and thinker run in separate processes, so the image
         # encoder cannot rely on the thinker's tensor-parallel state at
         # request time.

--- a/sglang_omni/models/ming_omni/components/preprocessor.py
+++ b/sglang_omni/models/ming_omni/components/preprocessor.py
@@ -28,6 +28,7 @@ ROLE_ASSISTANT = "<role>ASSISTANT</role>"
 ROLE_SYSTEM = "<role>SYSTEM</role>"
 ROLE_END = "<|role_end|>"
 DEFAULT_SYSTEM_PROMPT = "你是一个友好的AI助手。"
+THINKING_SUFFIX = "\n\ndetailed thinking off"
 
 # Modality tokens
 AUDIO_START = "<audio>"
@@ -159,7 +160,10 @@ class MingPreprocessor:
         self._audio_patch_id = self._tokenizer.convert_tokens_to_ids(AUDIO_PATCH)
         self._audio_start_id = self._tokenizer.convert_tokens_to_ids(AUDIO_START)
         self._audio_end_id = self._tokenizer.convert_tokens_to_ids(AUDIO_END)
-        self._image_patch_id = self._tokenizer.convert_tokens_to_ids(IMAGE_PATCH)
+        llm_config = getattr(self._config, "llm_config", None)
+        self._image_patch_id = getattr(llm_config, "image_patch_token", None)
+        if self._image_patch_id is None:
+            self._image_patch_id = self._tokenizer.convert_tokens_to_ids(IMAGE_PATCH)
 
         # Lazy-init image processor
         self._image_processor = None
@@ -306,13 +310,12 @@ class MingPreprocessor:
                 )
             )
 
-        # --- Build prompt with correct placeholder counts, then tokenize ---
-        prompt_text, audio_positions = self._build_prompt(
+        # Build prompt with placeholder counts and token IDs
+        prompt_text, input_ids, audio_positions = self._build_prompt(
             messages,
             audio_token_counts=audio_token_counts,
             image_token_counts=image_token_counts,
         )
-        input_ids = self._tokenizer.encode(prompt_text, add_special_tokens=False)
         input_ids_tensor = torch.tensor([input_ids], dtype=torch.long)
         attention_mask = torch.ones_like(input_ids_tensor)
 
@@ -372,8 +375,8 @@ class MingPreprocessor:
         *,
         audio_token_counts: list[int] | None = None,
         image_token_counts: list[int] | None = None,
-    ) -> tuple[str, list[int]]:
-        """Build Ming-Omni chat format prompt with audio/image placeholders.
+    ) -> tuple[str, list[int], list[int]]:
+        """Build Ming-Omni chat prompt and token IDs with modality placeholders.
 
         Args:
             messages: Chat messages.
@@ -385,29 +388,67 @@ class MingPreprocessor:
 
         Returns:
             prompt_text: The formatted prompt string.
+            input_ids: Token IDs with modality patch IDs inserted directly.
             audio_positions: Token positions where <audioPatch> placeholders start.
         """
         a_counts = audio_token_counts or []
         i_counts = image_token_counts or []
         parts: list[str] = []
+        input_ids: list[int] = []
+        text_buffer: list[str] = []
         audio_idx = 0
         image_idx = 0
 
-        # System message: match the Jinja template behavior exactly.
-        # Always include system prompt + "\n\ndetailed thinking off".
-        # If no explicit system message, use the default system prompt.
+        def flush_text() -> None:
+            if not text_buffer:
+                return
+            input_ids.extend(
+                self._tokenizer.encode("".join(text_buffer), add_special_tokens=False)
+            )
+            text_buffer.clear()
+
+        def append_text(text: Any) -> None:
+            value = str(text)
+            if not value:
+                return
+            parts.append(value)
+            text_buffer.append(value)
+
+        def append_placeholder(
+            start_token: str,
+            patch_token: str,
+            end_token: str,
+            patch_id: int,
+            n_tokens: int,
+        ) -> int:
+            n_tokens = int(n_tokens)
+            parts.append(start_token + patch_token * n_tokens + end_token)
+            flush_text()
+
+            input_ids.extend(
+                self._tokenizer.encode(start_token, add_special_tokens=False)
+            )
+            patch_start = len(input_ids)
+            input_ids.extend([int(patch_id)] * n_tokens)
+            input_ids.extend(
+                self._tokenizer.encode(end_token, add_special_tokens=False)
+            )
+            return patch_start
+
+        # Keep the Ming V1 prompt text aligned with the known-good Ming V0 path.
+        role_end = ROLE_END
+
+        # Match Ming V0's system template.
         has_system = messages and messages[0].get("role") == "system"
         if has_system:
             system_content = messages[0].get("content", DEFAULT_SYSTEM_PROMPT)
-            parts.append(
-                f"{ROLE_SYSTEM}{system_content}\n\ndetailed thinking off{ROLE_END}"
-            )
+            append_text(f"{ROLE_SYSTEM}{system_content}{THINKING_SUFFIX}{role_end}")
         else:
-            # Official Jinja template always includes the default system prompt
-            parts.append(
-                f"{ROLE_SYSTEM}{DEFAULT_SYSTEM_PROMPT}\n\ndetailed thinking off{ROLE_END}"
+            append_text(
+                f"{ROLE_SYSTEM}{DEFAULT_SYSTEM_PROMPT}{THINKING_SUFFIX}{role_end}"
             )
 
+        audio_positions: list[int] = []
         for msg in messages:
             role = msg.get("role", "user")
             content = msg.get("content", "")
@@ -418,53 +459,50 @@ class MingPreprocessor:
             role_tag = ROLE_HUMAN if role == "user" else ROLE_ASSISTANT
 
             if isinstance(content, str):
-                parts.append(f"{role_tag}{content}{ROLE_END}")
+                append_text(f"{role_tag}{content}{role_end}")
             elif isinstance(content, list):
-                text_parts: list[str] = []
+                append_text(role_tag)
                 for item in content:
                     if isinstance(item, dict):
                         item_type = item.get("type", "text")
                         if item_type == "text":
-                            text_parts.append(item.get("text", ""))
+                            append_text(item.get("text", ""))
                         elif item_type in ("audio_url", "input_audio"):
                             n_tokens = (
                                 a_counts[audio_idx] if audio_idx < len(a_counts) else 1
                             )
-                            placeholder = (
-                                f"{AUDIO_START}"
-                                + AUDIO_PATCH * n_tokens
-                                + f"{AUDIO_END}"
+                            audio_positions.append(
+                                append_placeholder(
+                                    AUDIO_START,
+                                    AUDIO_PATCH,
+                                    AUDIO_END,
+                                    self._audio_patch_id,
+                                    n_tokens,
+                                )
                             )
-                            text_parts.append(placeholder)
                             audio_idx += 1
                         elif item_type in ("image_url", "image"):
                             n_tokens = (
                                 i_counts[image_idx] if image_idx < len(i_counts) else 1
                             )
-                            placeholder = (
-                                f"{IMAGE_START}"
-                                + IMAGE_PATCH * n_tokens
-                                + f"{IMAGE_END}"
+                            append_placeholder(
+                                IMAGE_START,
+                                IMAGE_PATCH,
+                                IMAGE_END,
+                                self._image_patch_id,
+                                n_tokens,
                             )
-                            text_parts.append(placeholder)
                             image_idx += 1
                     elif isinstance(item, str):
-                        text_parts.append(item)
-                parts.append(f"{role_tag}{''.join(text_parts)}{ROLE_END}")
+                        append_text(item)
+                append_text(role_end)
             else:
-                parts.append(f"{role_tag}{content}{ROLE_END}")
+                append_text(f"{role_tag}{content}{role_end}")
 
         # Add assistant prefix for generation
-        parts.append(ROLE_ASSISTANT)
+        append_text(ROLE_ASSISTANT)
+        flush_text()
 
         prompt_text = "".join(parts)
 
-        # Find audio placeholder positions in tokenized prompt
-        audio_positions: list[int] = []
-        tokens = self._tokenizer.encode(prompt_text, add_special_tokens=False)
-        for i, tok in enumerate(tokens):
-            if tok == self._audio_start_id:
-                # The audio patch tokens start after <audio>
-                audio_positions.append(i + 1)
-
-        return prompt_text, audio_positions
+        return prompt_text, input_ids, audio_positions

--- a/sglang_omni/models/ming_omni/components/preprocessor.py
+++ b/sglang_omni/models/ming_omni/components/preprocessor.py
@@ -16,8 +16,11 @@ from sglang_omni.models.ming_omni.components.common import (
 )
 from sglang_omni.models.ming_omni.io import PipelineState, PromptInputs
 from sglang_omni.models.ming_omni.pipeline.next_stage import AUDIO_STAGE, IMAGE_STAGE
-from sglang_omni.preprocessing.audio import load_audio_path
-from sglang_omni.preprocessing.image import ensure_image_list_async
+from sglang_omni.preprocessing.audio import compute_audio_cache_key, load_audio_path
+from sglang_omni.preprocessing.image import (
+    compute_image_cache_key,
+    ensure_image_list_async,
+)
 from sglang_omni.proto import StagePayload
 
 logger = logging.getLogger(__name__)
@@ -139,6 +142,34 @@ def _inject_top_level_images(
     return messages
 
 
+def _inject_top_level_audios(
+    messages: list[dict[str, Any]],
+    audios: list[str],
+) -> list[dict[str, Any]]:
+    """Convert top-level ``audios`` into inline content items.
+
+    Symmetric to _inject_top_level_images: when the request uses
+    ``{"audios": ["url"], "messages": [...]}`` instead of inline
+    ``audio_url`` items, prepend the audios to the first user message
+    so _build_prompt emits ``<audioPatch>`` placeholders.
+    """
+    messages = list(messages)
+    for idx, msg in enumerate(messages):
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content", "")
+        new_content: list[dict[str, Any]] = [
+            {"type": "audio_url", "audio_url": {"url": url}} for url in audios
+        ]
+        if isinstance(content, str):
+            new_content.append({"type": "text", "text": content})
+        elif isinstance(content, list):
+            new_content.extend(content)
+        messages[idx] = {**msg, "content": new_content}
+        break
+    return messages
+
+
 class MingPreprocessor:
     """Preprocessor for Ming-Omni model.
 
@@ -222,6 +253,8 @@ class MingPreprocessor:
         # placeholder insertion and image extraction use a single code path.
         if top_level_images:
             messages = _inject_top_level_images(messages, top_level_images)
+        if audio_urls:
+            messages = _inject_top_level_audios(messages, audio_urls)
 
         # --- Extract image URLs/data from messages ---
         raw_images: list[Any] = []
@@ -244,6 +277,13 @@ class MingPreprocessor:
                             img = item.get("image", "")
                             if img:
                                 raw_images.append(img)
+
+        # Compute cache keys BEFORE async loading; same content -> same key so
+        # SGLang's radix prefix cache can correctly reuse KVs across requests, and
+        # different content -> different key so it never falsely aliases image
+        # placeholder positions (which share the same generic image_patch_token).
+        image_cache_key = compute_image_cache_key(raw_images) if raw_images else None
+        audio_cache_key = compute_audio_cache_key(audio_urls) if audio_urls else None
 
         # --- Load images and audio concurrently ---
         image_coro = ensure_image_list_async(raw_images) if raw_images else None
@@ -350,12 +390,16 @@ class MingPreprocessor:
                 "audio_feats_lengths": mel_lens,
                 "audio_placeholder_loc_lens": placeholder_locs,
             }
+            if audio_cache_key:
+                encoder_inputs[AUDIO_STAGE]["cache_key"] = audio_cache_key
 
         if pixel_values is not None and image_grid_thw is not None:
             encoder_inputs[IMAGE_STAGE] = {
                 "pixel_values": pixel_values,
                 "image_grid_thw": image_grid_thw,
             }
+            if image_cache_key:
+                encoder_inputs[IMAGE_STAGE]["cache_key"] = image_cache_key
 
         state = PipelineState(
             raw_inputs=raw_inputs,

--- a/sglang_omni/models/ming_omni/components/preprocessor.py
+++ b/sglang_omni/models/ming_omni/components/preprocessor.py
@@ -148,23 +148,26 @@ def _inject_top_level_audios(
 ) -> list[dict[str, Any]]:
     """Convert top-level ``audios`` into inline content items.
 
-    Symmetric to _inject_top_level_images: when the request uses
-    ``{"audios": ["url"], "messages": [...]}`` instead of inline
-    ``audio_url`` items, prepend the audios to the first user message
-    so _build_prompt emits ``<audioPatch>`` placeholders.
+    Ming-Omni was trained with text BEFORE audio in user turns
+    (see /tmp/Ming-src/test_audio_tasks.py and processing_bailingmm2.py
+    apply_chat_template, which renders content list in order). The
+    instruction must precede the audio so attention can condition the
+    audio interpretation on the task description.
     """
     messages = list(messages)
+    audio_items: list[dict[str, Any]] = [
+        {"type": "audio_url", "audio_url": {"url": url}} for url in audios
+    ]
     for idx, msg in enumerate(messages):
         if msg.get("role") != "user":
             continue
         content = msg.get("content", "")
-        new_content: list[dict[str, Any]] = [
-            {"type": "audio_url", "audio_url": {"url": url}} for url in audios
-        ]
+        new_content: list[dict[str, Any]] = []
         if isinstance(content, str):
             new_content.append({"type": "text", "text": content})
         elif isinstance(content, list):
             new_content.extend(content)
+        new_content.extend(audio_items)
         messages[idx] = {**msg, "content": new_content}
         break
     return messages

--- a/sglang_omni/models/ming_omni/components/preprocessor.py
+++ b/sglang_omni/models/ming_omni/components/preprocessor.py
@@ -482,7 +482,7 @@ class MingPreprocessor:
             )
             return patch_start
 
-        # Keep the Ming V1 prompt text aligned with the known-good Ming V0 path.
+        # Keep the Ming prompt text aligned with the known-good Ming reference path.
         role_end = ROLE_END
 
         # Match Ming V0's system template.

--- a/sglang_omni/models/ming_omni/components/talker_executor.py
+++ b/sglang_omni/models/ming_omni/components/talker_executor.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Talker executor for Ming-Omni.
 
-Wraps MingOmniTalker as a pipeline Executor stage. The talker
+Wraps MingOmniTalker as a pipeline stage. The talker
 receives decoded text from the thinker and independently generates speech audio
 using its own internal LLM + CFM + DiT + AudioVAE pipeline.
 
@@ -23,7 +23,6 @@ from pathlib import Path
 
 import torch
 
-from sglang_omni.executors.interface import Executor
 from sglang_omni.proto import StagePayload
 
 logger = logging.getLogger(__name__)
@@ -31,7 +30,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_VOICE = "DB30"
 
 
-class MingTalkerExecutor(Executor):
+class MingTalkerExecutor:
     """Executor that wraps MingOmniTalker for speech generation."""
 
     def __init__(
@@ -168,6 +167,14 @@ class MingTalkerExecutor(Executor):
         request_id = payload.request_id
         if request_id in self._aborted:
             return
+        if not self.should_generate_audio(payload):
+            logger.info(
+                "[TALKER] Skipping TTS for request %s; output_modalities=%s",
+                request_id,
+                self._output_modalities(payload),
+            )
+            await self._results.put(self.build_empty_audio_result(payload))
+            return
 
         text = self._extract_text(payload)
         logger.info(
@@ -186,20 +193,12 @@ class MingTalkerExecutor(Executor):
 
         t0 = time.time()
         logger.info("[TALKER] Starting TTS generation for %d chars...", len(text))
-        try:
-            waveform, sample_rate, duration = await asyncio.to_thread(
-                self._generate_speech, text
-            )
-            logger.info(
-                "[TALKER] TTS done in %.1fs, audio=%.2fs", time.time() - t0, duration
-            )
-        except Exception as e:
-            logger.error(
-                "[TALKER] ERROR after %.1fs: %s", time.time() - t0, e, exc_info=True
-            )
-            waveform = None
-            sample_rate = 44100
-            duration = 0.0
+        waveform, sample_rate, duration = await asyncio.to_thread(
+            self._generate_speech, text
+        )
+        logger.info(
+            "[TALKER] TTS done in %.1fs, audio=%.2fs", time.time() - t0, duration
+        )
 
         # Serialize tensor to bytes for cross-process msgpack transport
         if waveform is not None:
@@ -234,6 +233,37 @@ class MingTalkerExecutor(Executor):
 
     async def abort(self, request_id: str) -> None:
         self._aborted.add(request_id)
+
+    def should_generate_audio(self, payload: StagePayload) -> bool:
+        modalities = self._output_modalities(payload)
+        return modalities is None or "audio" in modalities
+
+    @staticmethod
+    def _output_modalities(payload: StagePayload) -> set[str] | None:
+        metadata = getattr(payload.request, "metadata", None)
+        if not isinstance(metadata, dict):
+            return None
+        modalities = metadata.get("output_modalities")
+        if modalities is None:
+            return None
+        if isinstance(modalities, str):
+            return {modalities}
+        if isinstance(modalities, (list, tuple, set)):
+            return {str(modality) for modality in modalities}
+        return None
+
+    @staticmethod
+    def build_empty_audio_result(payload: StagePayload) -> StagePayload:
+        return StagePayload(
+            request_id=payload.request_id,
+            request=payload.request,
+            data={
+                "audio_waveform": None,
+                "sample_rate": 44100,
+                "duration": 0.0,
+                "skipped": True,
+            },
+        )
 
     def _extract_text(self, payload: StagePayload) -> str:
         """Extract generated text from the thinker output in the payload."""

--- a/sglang_omni/models/ming_omni/components/vision_encoder.py
+++ b/sglang_omni/models/ming_omni/components/vision_encoder.py
@@ -19,6 +19,7 @@ Skips (can be added later):
 
 from __future__ import annotations
 
+import inspect
 import logging
 import re
 from functools import partial
@@ -72,6 +73,32 @@ def _remap_ming_vision_weight(name: str) -> str:
     name = name.replace("attn.out_proj.", "attn.proj.")
 
     return name
+
+
+def _build_qwen3_vision_block_kwargs(
+    block_cls,
+    *,
+    dim: int,
+    num_heads: int,
+    head_size: int,
+    intermediate_dim: int,
+    hidden_act: str,
+    norm_layer,
+    quant_config: Optional[object],
+    prefix: str,
+) -> dict:
+    kwargs = {
+        "dim": dim,
+        "num_heads": num_heads,
+        "intermediate_dim": intermediate_dim,
+        "hidden_act": hidden_act,
+        "norm_layer": norm_layer,
+        "quant_config": quant_config,
+        "prefix": prefix,
+    }
+    if "head_size" in inspect.signature(block_cls.__init__).parameters:
+        kwargs["head_size"] = head_size
+    return kwargs
 
 
 class MingOmniVisionEncoder(nn.Module):
@@ -153,13 +180,17 @@ class MingOmniVisionEncoder(nn.Module):
         self.blocks = nn.ModuleList(
             [
                 Qwen3_VisionBlock(
-                    dim=self.hidden_size,
-                    num_heads=self.num_heads,
-                    intermediate_dim=vision_config.intermediate_size,
-                    hidden_act=vision_config.hidden_act,
-                    norm_layer=norm_layer,
-                    quant_config=quant_config,
-                    prefix=add_prefix(f"blocks.{layer_idx}", prefix),
+                    **_build_qwen3_vision_block_kwargs(
+                        Qwen3_VisionBlock,
+                        dim=self.hidden_size,
+                        num_heads=self.num_heads,
+                        head_size=head_dim,
+                        intermediate_dim=vision_config.intermediate_size,
+                        hidden_act=vision_config.hidden_act,
+                        norm_layer=norm_layer,
+                        quant_config=quant_config,
+                        prefix=add_prefix(f"blocks.{layer_idx}", prefix),
+                    )
                 )
                 for layer_idx in range(vision_config.depth)
             ]

--- a/sglang_omni/models/ming_omni/config.py
+++ b/sglang_omni/models/ming_omni/config.py
@@ -1,17 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Pipeline configuration for Ming-Omni."""
+"""Pipeline configuration for Ming-Omni V1."""
 
 from __future__ import annotations
 
-from typing import ClassVar
+from typing import Any, ClassVar
 
-from sglang_omni.config import (
-    ExecutorConfig,
-    InputHandlerConfig,
-    PipelineConfig,
-    RelayConfig,
-    StageConfig,
-)
+from sglang_omni.config.schema import PipelineConfig, StageConfig
 from sglang_omni.models.ming_omni.pipeline.next_stage import (
     AGGREGATE_STAGE,
     AUDIO_STAGE,
@@ -22,203 +16,146 @@ from sglang_omni.models.ming_omni.pipeline.next_stage import (
     THINKER_STAGE,
 )
 
+_PKG = "sglang_omni.models.ming_omni"
 
-class MingOmniPipelineConfig(PipelineConfig):
-    """6-stage text/vision pipeline for Ming-Omni.
 
-    preprocessing → audio_encoder + image_encoder → mm_aggregate → thinker → decode
+def _stage_by_name(stages: list[StageConfig], name: str) -> StageConfig | None:
+    return next((stage for stage in stages if stage.name == name), None)
+
+
+def _stage_gpu_set(gpu: int | list[int] | None, tp_size: int) -> set[int]:
+    """Return GPUs occupied by a stage.
+
+    Explicit list placement is authoritative; scalar placement preserves the
+    legacy contiguous TP range interpretation.
     """
+    if isinstance(gpu, list):
+        return {int(gpu_id) for gpu_id in gpu}
+    if gpu is None:
+        return set()
+    return set(range(int(gpu), int(gpu) + tp_size))
 
-    architecture: ClassVar[str] = "BailingMM2NativeForConditionalGeneration"
 
-    model_path: str
-    entry_stage: str = "preprocessing"
-    stages: list[StageConfig] = [
+def _ming_text_stages() -> list[StageConfig]:
+    return [
         StageConfig(
             name=PREPROCESSING_STAGE,
-            executor=ExecutorConfig(
-                factory="sglang_omni.models.ming_omni.pipeline.stages.create_preprocessing_executor",
-            ),
-            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.preprocessing_next",
-            relay=RelayConfig(device="cpu"),
+            factory=f"{_PKG}.stages.create_preprocessing_executor",
+            next=[AUDIO_STAGE, IMAGE_STAGE, AGGREGATE_STAGE],
+            project_payload={
+                AUDIO_STAGE: f"{_PKG}.stages.project_preprocessing_to_audio_encoder",
+                IMAGE_STAGE: f"{_PKG}.stages.project_preprocessing_to_image_encoder",
+                AGGREGATE_STAGE: (
+                    f"{_PKG}.stages.project_preprocessing_to_mm_aggregate"
+                ),
+            },
         ),
         StageConfig(
             name=AUDIO_STAGE,
-            executor=ExecutorConfig(
-                factory="sglang_omni.models.ming_omni.pipeline.stages.create_audio_encoder_executor",
-                args={
-                    "device": "cuda",
-                    "dtype": None,
-                },
-            ),
-            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.encoder_next",
-            relay=RelayConfig(device="cuda"),
+            factory=f"{_PKG}.stages.create_audio_encoder_executor",
+            factory_args={"device": "cuda", "dtype": None},
+            gpu=0,
+            next=AGGREGATE_STAGE,
+            project_payload={
+                AGGREGATE_STAGE: f"{_PKG}.stages.project_encoder_to_mm_aggregate"
+            },
         ),
         StageConfig(
             name=IMAGE_STAGE,
-            executor=ExecutorConfig(
-                factory="sglang_omni.models.ming_omni.pipeline.stages.create_image_encoder_executor",
-                args={
-                    "device": "cuda",
-                    "dtype": None,
-                },
-            ),
-            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.encoder_next",
-            relay=RelayConfig(device="cuda"),
+            factory=f"{_PKG}.stages.create_image_encoder_executor",
+            factory_args={"device": "cuda", "dtype": None},
+            gpu=0,
+            next=AGGREGATE_STAGE,
+            project_payload={
+                AGGREGATE_STAGE: f"{_PKG}.stages.project_encoder_to_mm_aggregate"
+            },
         ),
         StageConfig(
             name=AGGREGATE_STAGE,
-            executor=ExecutorConfig(
-                factory="sglang_omni.models.ming_omni.pipeline.stages.create_aggregate_executor",
-                args={},
-            ),
-            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.aggregate_next",
-            input_handler=InputHandlerConfig(
-                type="aggregated",
-                sources=[PREPROCESSING_STAGE, AUDIO_STAGE, IMAGE_STAGE],
-                merge_fn="sglang_omni.models.ming_omni.pipeline.merge.merge_for_thinker",
-            ),
-            relay=RelayConfig(device="cpu"),
+            factory=f"{_PKG}.stages.create_aggregate_executor",
+            wait_for=[PREPROCESSING_STAGE, AUDIO_STAGE, IMAGE_STAGE],
+            merge_fn=f"{_PKG}.pipeline.merge.merge_for_thinker",
+            next=THINKER_STAGE,
         ),
         StageConfig(
             name=THINKER_STAGE,
-            executor=ExecutorConfig(
-                factory="sglang_omni.models.ming_omni.pipeline.stages.create_sglang_thinker_executor_from_config",
-                args={
-                    "thinker_max_seq_len": 8192,
-                },
-            ),
-            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.thinker_next",
-            relay=RelayConfig(device="cuda"),
+            factory=f"{_PKG}.stages.create_sglang_thinker_executor_from_config",
+            factory_args={"thinker_max_seq_len": 8192},
+            gpu=0,
+            next=DECODE_STAGE,
         ),
         StageConfig(
             name=DECODE_STAGE,
-            executor=ExecutorConfig(
-                factory="sglang_omni.models.ming_omni.pipeline.stages.create_decode_executor",
-                args={},
-            ),
-            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.decode_next",
-            relay=RelayConfig(device="cpu"),
+            factory=f"{_PKG}.stages.create_decode_executor",
+            terminal=True,
         ),
     ]
 
-    def __init__(self, **kwargs):
-        # Extract server_args_overrides and inject into thinker stage
-        server_args_overrides = kwargs.pop("server_args_overrides", None)
-        super().__init__(**kwargs)
-        if server_args_overrides:
-            for stage in self.stages:
-                if stage.name == THINKER_STAGE:
-                    if stage.executor.args is None:
-                        stage.executor.args = {}
-                    existing = stage.executor.args.setdefault(
-                        "server_args_overrides", {}
-                    )
-                    existing.update(server_args_overrides)
+
+def _ming_speech_stages() -> list[StageConfig]:
+    stages = _ming_text_stages()
+    thinker = _stage_by_name(stages, THINKER_STAGE)
+    if thinker is not None:
+        thinker.next = [DECODE_STAGE, TALKER_STAGE]
+
+    stages.append(
+        StageConfig(
+            name=TALKER_STAGE,
+            factory=f"{_PKG}.stages.create_talker_executor",
+            factory_args={"device": "cuda", "voice": "DB30"},
+            gpu=1,
+            terminal=True,
+        )
+    )
+    return stages
+
+
+class MingOmniPipelineConfig(PipelineConfig):
+    """6-stage text pipeline."""
+
+    architecture: ClassVar[str] = "BailingMoeV2ForCausalLM"
+
+    model_path: str
+    entry_stage: str = PREPROCESSING_STAGE
+    stages: list[StageConfig] = _ming_text_stages()
 
 
 class MingOmniSpeechPipelineConfig(PipelineConfig):
-    """7-stage pipeline for Ming-Omni with text + speech output.
+    """7-stage speech pipeline."""
 
-    Adds a talker stage that generates audio from thinker's decoded text.
-    The talker is a self-contained MingOmniTalker (own LLM + CFM + AudioVAE).
-    """
-
-    architecture: ClassVar[str] = "BailingMM2NativeForConditionalGeneration"
+    architecture: ClassVar[str] = "BailingMoeV2ForCausalLM"
 
     model_path: str
-    entry_stage: str = "preprocessing"
-    terminal_stages: list[str] = [DECODE_STAGE, TALKER_STAGE]
-    gpu_placement: dict[str, int] = {
-        "thinker": 0,
-        "talker": 1,
-    }
+    entry_stage: str = PREPROCESSING_STAGE
+    stages: list[StageConfig] = _ming_speech_stages()
 
-    def __init__(self, **kwargs):
-        server_args_overrides = kwargs.pop("server_args_overrides", None)
-        super().__init__(**kwargs)
-        if server_args_overrides:
-            for stage in self.stages:
-                if stage.name == THINKER_STAGE:
-                    if stage.executor.args is None:
-                        stage.executor.args = {}
-                    existing = stage.executor.args.setdefault(
-                        "server_args_overrides", {}
-                    )
-                    existing.update(server_args_overrides)
+    def model_post_init(self, __context: Any = None) -> None:
+        super().model_post_init(__context)
+        self._validate_talker_gpu_not_in_thinker_tp_range()
 
-    stages: list[StageConfig] = [
-        StageConfig(
-            name=PREPROCESSING_STAGE,
-            executor=ExecutorConfig(
-                factory="sglang_omni.models.ming_omni.pipeline.stages.create_preprocessing_executor",
-            ),
-            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.preprocessing_next",
-            relay=RelayConfig(device="cpu"),
-        ),
-        StageConfig(
-            name=AUDIO_STAGE,
-            executor=ExecutorConfig(
-                factory="sglang_omni.models.ming_omni.pipeline.stages.create_audio_encoder_executor",
-                args={"device": "cuda", "dtype": None},
-            ),
-            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.encoder_next",
-            relay=RelayConfig(device="cuda"),
-        ),
-        StageConfig(
-            name=IMAGE_STAGE,
-            executor=ExecutorConfig(
-                factory="sglang_omni.models.ming_omni.pipeline.stages.create_image_encoder_executor",
-                args={"device": "cuda", "dtype": None},
-            ),
-            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.encoder_next",
-            relay=RelayConfig(device="cuda"),
-        ),
-        StageConfig(
-            name=AGGREGATE_STAGE,
-            executor=ExecutorConfig(
-                factory="sglang_omni.models.ming_omni.pipeline.stages.create_aggregate_executor",
-                args={},
-            ),
-            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.aggregate_next",
-            input_handler=InputHandlerConfig(
-                type="aggregated",
-                sources=[PREPROCESSING_STAGE, AUDIO_STAGE, IMAGE_STAGE],
-                merge_fn="sglang_omni.models.ming_omni.pipeline.merge.merge_for_thinker",
-            ),
-            relay=RelayConfig(device="cpu"),
-        ),
-        StageConfig(
-            name=THINKER_STAGE,
-            executor=ExecutorConfig(
-                factory="sglang_omni.models.ming_omni.pipeline.stages.create_sglang_thinker_executor_from_config",
-                args={"thinker_max_seq_len": 8192},
-            ),
-            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.thinker_next_speech",
-            relay=RelayConfig(device="cuda"),
-        ),
-        StageConfig(
-            name=DECODE_STAGE,
-            executor=ExecutorConfig(
-                factory="sglang_omni.models.ming_omni.pipeline.stages.create_decode_executor",
-                args={},
-            ),
-            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.decode_next",
-            relay=RelayConfig(device="cpu"),
-        ),
-        StageConfig(
-            name=TALKER_STAGE,
-            executor=ExecutorConfig(
-                factory="sglang_omni.models.ming_omni.pipeline.stages.create_talker_executor",
-                args={
-                    "device": "cuda",
-                    "voice": "DB30",
-                },
-            ),
-            get_next="sglang_omni.models.ming_omni.pipeline.next_stage.talker_next",
-            relay=RelayConfig(device="cuda"),
-        ),
-    ]
+    def _validate_talker_gpu_not_in_thinker_tp_range(self) -> None:
+        thinker = _stage_by_name(self.stages, THINKER_STAGE)
+        talker = _stage_by_name(self.stages, TALKER_STAGE)
+        if thinker is None or talker is None:
+            return
+
+        thinker_gpus = _stage_gpu_set(thinker.gpu, thinker.tp_size)
+        talker_gpus = _stage_gpu_set(talker.gpu, talker.tp_size)
+        collisions = thinker_gpus & talker_gpus
+        if not collisions:
+            return
+
+        raise ValueError(
+            "Ming-Omni speech talker GPU collides with thinker TP range: "
+            f"talker gpus={sorted(talker_gpus)}, "
+            f"thinker gpus={sorted(thinker_gpus)}, "
+            f"collisions={sorted(collisions)}"
+        )
 
 
 EntryClass = MingOmniPipelineConfig
+
+Variants = {
+    "text": MingOmniPipelineConfig,
+    "speech": MingOmniSpeechPipelineConfig,
+}

--- a/sglang_omni/models/ming_omni/config.py
+++ b/sglang_omni/models/ming_omni/config.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
-from sglang_omni.config.schema import PipelineConfig, StageConfig
+from pydantic import Field
+
+from sglang_omni.config.schema import PipelineConfig, PlacementConfig, StageConfig
 from sglang_omni.models.ming_omni.pipeline.next_stage import (
     AGGREGATE_STAGE,
     AUDIO_STAGE,
@@ -36,78 +38,113 @@ def _stage_gpu_set(gpu: int | list[int] | None, tp_size: int) -> set[int]:
     return set(range(int(gpu), int(gpu) + tp_size))
 
 
+def _preprocessing_stage(*, process: str) -> StageConfig:
+    return StageConfig(
+        name=PREPROCESSING_STAGE,
+        process=process,
+        factory=f"{_PKG}.stages.create_preprocessing_executor",
+        next=[AUDIO_STAGE, IMAGE_STAGE, AGGREGATE_STAGE],
+        project_payload={
+            AUDIO_STAGE: f"{_PKG}.stages.project_preprocessing_to_audio_encoder",
+            IMAGE_STAGE: f"{_PKG}.stages.project_preprocessing_to_image_encoder",
+            AGGREGATE_STAGE: (
+                f"{_PKG}.stages.project_preprocessing_to_mm_aggregate"
+            ),
+        },
+    )
+
+
+def _audio_encoder_stage(*, gpu: int, process: str) -> StageConfig:
+    return StageConfig(
+        name=AUDIO_STAGE,
+        process=process,
+        factory=f"{_PKG}.stages.create_audio_encoder_executor",
+        factory_args={"device": "cuda", "dtype": None},
+        gpu=gpu,
+        next=AGGREGATE_STAGE,
+        project_payload={
+            AGGREGATE_STAGE: f"{_PKG}.stages.project_encoder_to_mm_aggregate"
+        },
+    )
+
+
+def _image_encoder_stage(*, gpu: int, process: str) -> StageConfig:
+    return StageConfig(
+        name=IMAGE_STAGE,
+        process=process,
+        factory=f"{_PKG}.stages.create_image_encoder_executor",
+        factory_args={"device": "cuda", "dtype": None},
+        gpu=gpu,
+        next=AGGREGATE_STAGE,
+        project_payload={
+            AGGREGATE_STAGE: f"{_PKG}.stages.project_encoder_to_mm_aggregate"
+        },
+    )
+
+
+def _aggregate_stage(*, process: str) -> StageConfig:
+    return StageConfig(
+        name=AGGREGATE_STAGE,
+        process=process,
+        factory=f"{_PKG}.stages.create_aggregate_executor",
+        wait_for=[PREPROCESSING_STAGE, AUDIO_STAGE, IMAGE_STAGE],
+        merge_fn=f"{_PKG}.pipeline.merge.merge_for_thinker",
+        next=THINKER_STAGE,
+    )
+
+
+def _thinker_stage(*, gpu: int, speech_enabled: bool, process: str) -> StageConfig:
+    return StageConfig(
+        name=THINKER_STAGE,
+        process=process,
+        factory=f"{_PKG}.stages.create_sglang_thinker_executor_from_config",
+        factory_args={"thinker_max_seq_len": 8192},
+        gpu=gpu,
+        next=[DECODE_STAGE, TALKER_STAGE] if speech_enabled else DECODE_STAGE,
+    )
+
+
+def _decode_stage(*, process: str) -> StageConfig:
+    return StageConfig(
+        name=DECODE_STAGE,
+        process=process,
+        factory=f"{_PKG}.stages.create_decode_executor",
+        terminal=True,
+    )
+
+
+def _talker_stage(*, gpu: int, process: str) -> StageConfig:
+    return StageConfig(
+        name=TALKER_STAGE,
+        process=process,
+        factory=f"{_PKG}.stages.create_talker_executor",
+        factory_args={"device": "cuda", "voice": "DB30"},
+        gpu=gpu,
+        terminal=True,
+    )
+
+
 def _ming_text_stages() -> list[StageConfig]:
     return [
-        StageConfig(
-            name=PREPROCESSING_STAGE,
-            factory=f"{_PKG}.stages.create_preprocessing_executor",
-            next=[AUDIO_STAGE, IMAGE_STAGE, AGGREGATE_STAGE],
-            project_payload={
-                AUDIO_STAGE: f"{_PKG}.stages.project_preprocessing_to_audio_encoder",
-                IMAGE_STAGE: f"{_PKG}.stages.project_preprocessing_to_image_encoder",
-                AGGREGATE_STAGE: (
-                    f"{_PKG}.stages.project_preprocessing_to_mm_aggregate"
-                ),
-            },
-        ),
-        StageConfig(
-            name=AUDIO_STAGE,
-            factory=f"{_PKG}.stages.create_audio_encoder_executor",
-            factory_args={"device": "cuda", "dtype": None},
-            gpu=0,
-            next=AGGREGATE_STAGE,
-            project_payload={
-                AGGREGATE_STAGE: f"{_PKG}.stages.project_encoder_to_mm_aggregate"
-            },
-        ),
-        StageConfig(
-            name=IMAGE_STAGE,
-            factory=f"{_PKG}.stages.create_image_encoder_executor",
-            factory_args={"device": "cuda", "dtype": None},
-            gpu=0,
-            next=AGGREGATE_STAGE,
-            project_payload={
-                AGGREGATE_STAGE: f"{_PKG}.stages.project_encoder_to_mm_aggregate"
-            },
-        ),
-        StageConfig(
-            name=AGGREGATE_STAGE,
-            factory=f"{_PKG}.stages.create_aggregate_executor",
-            wait_for=[PREPROCESSING_STAGE, AUDIO_STAGE, IMAGE_STAGE],
-            merge_fn=f"{_PKG}.pipeline.merge.merge_for_thinker",
-            next=THINKER_STAGE,
-        ),
-        StageConfig(
-            name=THINKER_STAGE,
-            factory=f"{_PKG}.stages.create_sglang_thinker_executor_from_config",
-            factory_args={"thinker_max_seq_len": 8192},
-            gpu=0,
-            next=DECODE_STAGE,
-        ),
-        StageConfig(
-            name=DECODE_STAGE,
-            factory=f"{_PKG}.stages.create_decode_executor",
-            terminal=True,
-        ),
+        _preprocessing_stage(process="preprocessing"),
+        _audio_encoder_stage(gpu=0, process="audio_encoder"),
+        _image_encoder_stage(gpu=0, process="image_encoder"),
+        _aggregate_stage(process="mm_aggregate"),
+        _thinker_stage(gpu=0, speech_enabled=False, process="thinker"),
+        _decode_stage(process="decode"),
     ]
 
 
 def _ming_speech_stages() -> list[StageConfig]:
-    stages = _ming_text_stages()
-    thinker = _stage_by_name(stages, THINKER_STAGE)
-    if thinker is not None:
-        thinker.next = [DECODE_STAGE, TALKER_STAGE]
-
-    stages.append(
-        StageConfig(
-            name=TALKER_STAGE,
-            factory=f"{_PKG}.stages.create_talker_executor",
-            factory_args={"device": "cuda", "voice": "DB30"},
-            gpu=1,
-            terminal=True,
-        )
-    )
-    return stages
+    return [
+        _preprocessing_stage(process="preprocessing"),
+        _audio_encoder_stage(gpu=0, process="audio_encoder"),
+        _image_encoder_stage(gpu=0, process="image_encoder"),
+        _aggregate_stage(process="mm_aggregate"),
+        _thinker_stage(gpu=0, speech_enabled=True, process="thinker"),
+        _decode_stage(process="decode"),
+        _talker_stage(gpu=1, process="talker"),
+    ]
 
 
 class MingOmniPipelineConfig(PipelineConfig):
@@ -117,7 +154,12 @@ class MingOmniPipelineConfig(PipelineConfig):
 
     model_path: str
     entry_stage: str = PREPROCESSING_STAGE
-    stages: list[StageConfig] = _ming_text_stages()
+    placement: PlacementConfig = Field(
+        default_factory=lambda: PlacementConfig(
+            require_memory_fraction_for_colocation=False
+        )
+    )
+    stages: list[StageConfig] = Field(default_factory=_ming_text_stages)
 
 
 class MingOmniSpeechPipelineConfig(PipelineConfig):
@@ -127,7 +169,12 @@ class MingOmniSpeechPipelineConfig(PipelineConfig):
 
     model_path: str
     entry_stage: str = PREPROCESSING_STAGE
-    stages: list[StageConfig] = _ming_speech_stages()
+    placement: PlacementConfig = Field(
+        default_factory=lambda: PlacementConfig(
+            require_memory_fraction_for_colocation=False
+        )
+    )
+    stages: list[StageConfig] = Field(default_factory=_ming_speech_stages)
 
     def model_post_init(self, __context: Any = None) -> None:
         super().model_post_init(__context)

--- a/sglang_omni/models/ming_omni/config.py
+++ b/sglang_omni/models/ming_omni/config.py
@@ -47,9 +47,7 @@ def _preprocessing_stage(*, process: str) -> StageConfig:
         project_payload={
             AUDIO_STAGE: f"{_PKG}.stages.project_preprocessing_to_audio_encoder",
             IMAGE_STAGE: f"{_PKG}.stages.project_preprocessing_to_image_encoder",
-            AGGREGATE_STAGE: (
-                f"{_PKG}.stages.project_preprocessing_to_mm_aggregate"
-            ),
+            AGGREGATE_STAGE: (f"{_PKG}.stages.project_preprocessing_to_mm_aggregate"),
         },
     )
 

--- a/sglang_omni/models/ming_omni/config.py
+++ b/sglang_omni/models/ming_omni/config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Pipeline configuration for Ming-Omni V1."""
+"""Pipeline configuration for Ming-Omni."""
 
 from __future__ import annotations
 

--- a/sglang_omni/models/ming_omni/pipeline/merge.py
+++ b/sglang_omni/models/ming_omni/pipeline/merge.py
@@ -102,9 +102,23 @@ def build_thinker_inputs(
             image_embeds = image_embeds.squeeze(0)
         thinker_model_inputs["image_embeds"] = image_embeds
 
+    media_cache_keys: dict[str, str] = {}
+    encoder_inputs = state.encoder_inputs or {}
+    image_ck = (encoder_inputs.get(IMAGE_STAGE) or {}).get("cache_key")
+    audio_ck = (encoder_inputs.get(AUDIO_STAGE) or {}).get("cache_key")
+    if image_ck:
+        media_cache_keys["image"] = f"image:{image_ck}"
+    if audio_ck:
+        media_cache_keys["audio"] = f"audio:{audio_ck}"
+
     if not thinker_model_inputs:
+        if media_cache_keys:
+            return {"media_cache_keys": media_cache_keys}
         return {}
-    return {"model_inputs": thinker_model_inputs}
+    result: dict[str, Any] = {"model_inputs": thinker_model_inputs}
+    if media_cache_keys:
+        result["media_cache_keys"] = media_cache_keys
+    return result
 
 
 def decode_events(

--- a/sglang_omni/models/ming_omni/pipeline/stages.py
+++ b/sglang_omni/models/ming_omni/pipeline/stages.py
@@ -241,10 +241,7 @@ def _ensure_ming_config_registered(model_path: str = "inclusionAI/Ming-flash-omn
 
     from sglang_omni.models.ming_omni.thinker import BailingMM2Config
 
-    try:
-        AutoConfig.register("bailingmm_moe_v2_lite", BailingMM2Config)
-    except ValueError:
-        pass
+    AutoConfig.register("bailingmm_moe_v2_lite", BailingMM2Config, exist_ok=True)
 
     # Patch HF cache with missing files
     try:

--- a/sglang_omni/models/ming_omni/registration.py
+++ b/sglang_omni/models/ming_omni/registration.py
@@ -14,7 +14,7 @@ def register_ming_hf_config() -> None:
 
     from transformers import AutoConfig
 
-    from sglang_omni_v1.models.ming_omni.thinker import BailingMM2Config
+    from sglang_omni.models.ming_omni.thinker import BailingMM2Config
 
     try:
         AutoConfig.register("bailingmm_moe_v2_lite", BailingMM2Config)
@@ -26,6 +26,6 @@ def register_ming_hf_config() -> None:
 def register_ming_model_registry() -> None:
     from sglang.srt.models.registry import ModelRegistry
 
-    from sglang_omni_v1.models.ming_omni.thinker import BailingMoeV2ForCausalLM
+    from sglang_omni.models.ming_omni.thinker import BailingMoeV2ForCausalLM
 
     ModelRegistry.models["BailingMoeV2ForCausalLM"] = BailingMoeV2ForCausalLM

--- a/sglang_omni/models/ming_omni/registration.py
+++ b/sglang_omni/models/ming_omni/registration.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lazy registration helpers."""
+
+from __future__ import annotations
+
+_ming_hf_config_registered = False
+
+
+def register_ming_hf_config() -> None:
+    """Register Ming's composite HF config before SGLang loads ModelConfig."""
+    global _ming_hf_config_registered
+    if _ming_hf_config_registered:
+        return
+
+    from transformers import AutoConfig
+
+    from sglang_omni_v1.models.ming_omni.thinker import BailingMM2Config
+
+    try:
+        AutoConfig.register("bailingmm_moe_v2_lite", BailingMM2Config)
+    except ValueError:
+        pass
+    _ming_hf_config_registered = True
+
+
+def register_ming_model_registry() -> None:
+    from sglang.srt.models.registry import ModelRegistry
+
+    from sglang_omni_v1.models.ming_omni.thinker import BailingMoeV2ForCausalLM
+
+    ModelRegistry.models["BailingMoeV2ForCausalLM"] = BailingMoeV2ForCausalLM

--- a/sglang_omni/models/ming_omni/registration.py
+++ b/sglang_omni/models/ming_omni/registration.py
@@ -16,10 +16,7 @@ def register_ming_hf_config() -> None:
 
     from sglang_omni.models.ming_omni.thinker import BailingMM2Config
 
-    try:
-        AutoConfig.register("bailingmm_moe_v2_lite", BailingMM2Config)
-    except ValueError:
-        pass
+    AutoConfig.register("bailingmm_moe_v2_lite", BailingMM2Config, exist_ok=True)
     _ming_hf_config_registered = True
 
 

--- a/sglang_omni/models/ming_omni/stages.py
+++ b/sglang_omni/models/ming_omni/stages.py
@@ -1,0 +1,312 @@
+# SPDX-License-Identifier: Apache-2.0
+"""（wenyao）V1-facing stage factories for Ming-Omni.
+
+Heavy runtime imports are intentionally local to factory calls so importing
+Ming's V1 config remains usable in lightweight environments.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sglang_omni_v1.models.ming_omni.io import PipelineState
+from sglang_omni_v1.models.ming_omni.pipeline.next_stage import AUDIO_STAGE, IMAGE_STAGE
+from sglang_omni_v1.proto import StagePayload
+
+
+def project_preprocessing_to_audio_encoder(payload: StagePayload) -> StagePayload:
+    return _project_preprocessing_to_encoder(payload, stage_name=AUDIO_STAGE)
+
+
+def project_preprocessing_to_image_encoder(payload: StagePayload) -> StagePayload:
+    return _project_preprocessing_to_encoder(payload, stage_name=IMAGE_STAGE)
+
+
+def project_preprocessing_to_mm_aggregate(payload: StagePayload) -> StagePayload:
+    state = PipelineState.from_dict(payload.data)
+    projected = PipelineState(
+        prompt=dict(state.prompt) if isinstance(state.prompt, dict) else None,
+        mm_inputs=dict(state.mm_inputs),
+        encoder_inputs=_project_encoder_input_metadata(state.encoder_inputs),
+        stream_state=dict(state.stream_state),
+    )
+    return _payload_with_state(payload, projected)
+
+
+def project_encoder_to_mm_aggregate(payload: StagePayload) -> StagePayload:
+    state = PipelineState.from_dict(payload.data)
+    stage_name = _single_encoder_stage_name(state)
+    projected = PipelineState(
+        encoder_outs={stage_name: state.encoder_outs.get(stage_name, {})}
+    )
+    return _payload_with_state(payload, projected)
+
+
+def _project_preprocessing_to_encoder(
+    payload: StagePayload,
+    *,
+    stage_name: str,
+) -> StagePayload:
+    state = PipelineState.from_dict(payload.data)
+    stage_inputs = state.encoder_inputs.get(stage_name)
+    projected_inputs = (
+        {stage_name: dict(stage_inputs)} if isinstance(stage_inputs, dict) else {}
+    )
+    return _payload_with_state(payload, PipelineState(encoder_inputs=projected_inputs))
+
+
+def _payload_with_state(payload: StagePayload, state: PipelineState) -> StagePayload:
+    return StagePayload(
+        request_id=payload.request_id,
+        request=payload.request,
+        data=state.to_dict(),
+    )
+
+
+def _project_encoder_input_metadata(
+    encoder_inputs: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    projected: dict[str, dict[str, Any]] = {}
+    for stage_name, stage_inputs in encoder_inputs.items():
+        if not isinstance(stage_inputs, dict):
+            continue
+        metadata: dict[str, Any] = {}
+        cache_key = stage_inputs.get("cache_key")
+        if cache_key is not None:
+            metadata["cache_key"] = cache_key
+        if stage_inputs.get("_skip"):
+            metadata["_skip"] = True
+        if metadata:
+            projected[stage_name] = metadata
+    return projected
+
+
+def _single_encoder_stage_name(state: PipelineState) -> str:
+    if len(state.encoder_outs) != 1:
+        raise ValueError(
+            f"Expected exactly one encoder output in payload, got {sorted(state.encoder_outs)}"
+        )
+    return next(iter(state.encoder_outs))
+
+
+def create_preprocessing_executor(model_path: str):
+    from sglang_omni_v1.models.ming_omni.components.preprocessor import MingPreprocessor
+    from sglang_omni_v1.scheduling.simple_scheduler import SimpleScheduler
+
+    preprocessor = MingPreprocessor(model_path=model_path)
+
+    async def _preprocess(payload: StagePayload) -> StagePayload:
+        return await preprocessor(payload)
+
+    return SimpleScheduler(_preprocess)
+
+
+def create_aggregate_executor():
+    from sglang_omni_v1.scheduling.simple_scheduler import SimpleScheduler
+
+    def _identity(payload: StagePayload) -> StagePayload:
+        return payload
+
+    return SimpleScheduler(_identity)
+
+
+def create_audio_encoder_executor(
+    model_path: str,
+    *,
+    device: str = "cuda",
+    dtype: str | None = None,
+):
+    from sglang_omni_v1.models.ming_omni.components.audio_encoder import (
+        MingAudioEncoder,
+    )
+    from sglang_omni_v1.scheduling.simple_scheduler import SimpleScheduler
+
+    model = MingAudioEncoder(model_path=model_path, device=device, dtype=dtype)
+
+    def _encode(payload: StagePayload) -> StagePayload:
+        state = PipelineState.from_dict(payload.data)
+        inputs = state.encoder_inputs.get(AUDIO_STAGE)
+        if not isinstance(inputs, dict) or not inputs:
+            result = {}
+        elif inputs.get("_skip"):
+            skip_result = inputs.get("_result")
+            result = skip_result if isinstance(skip_result, dict) else {}
+        else:
+            model_inputs = {k: v for k, v in inputs.items() if k != "cache_key"}
+            result = model(**model_inputs)
+        state.encoder_outs[AUDIO_STAGE] = result if isinstance(result, dict) else {}
+        state.engine_outputs[AUDIO_STAGE] = state.encoder_outs[AUDIO_STAGE]
+        payload.data = state.to_dict()
+        return payload
+
+    return SimpleScheduler(_encode)
+
+
+def create_image_encoder_executor(
+    model_path: str,
+    *,
+    device: str = "cuda",
+    dtype: str | None = None,
+):
+    from sglang_omni_v1.models.ming_omni.components.image_encoder import (
+        MingImageEncoder,
+    )
+    from sglang_omni_v1.scheduling.simple_scheduler import SimpleScheduler
+
+    model = MingImageEncoder(model_path=model_path, device=device, dtype=dtype)
+
+    def _encode(payload: StagePayload) -> StagePayload:
+        state = PipelineState.from_dict(payload.data)
+        inputs = state.encoder_inputs.get(IMAGE_STAGE)
+        if not isinstance(inputs, dict) or not inputs:
+            result = {}
+        elif inputs.get("_skip"):
+            skip_result = inputs.get("_result")
+            result = skip_result if isinstance(skip_result, dict) else {}
+        else:
+            model_inputs = {k: v for k, v in inputs.items() if k != "cache_key"}
+            result = model(**model_inputs)
+        state.encoder_outs[IMAGE_STAGE] = result if isinstance(result, dict) else {}
+        state.engine_outputs[IMAGE_STAGE] = state.encoder_outs[IMAGE_STAGE]
+        payload.data = state.to_dict()
+        return payload
+
+    return SimpleScheduler(_encode)
+
+
+def create_sglang_thinker_executor_from_config(
+    model_path: str,
+    *,
+    gpu_id: int = 0,
+    tp_rank: int = 0,
+    tp_size: int = 1,
+    nccl_port: int | None = None,
+    thinker_max_seq_len: int = 8192,
+    server_args_overrides: dict[str, Any] | None = None,
+):
+    from sglang_omni_v1.models.ming_omni.bootstrap import create_thinker_scheduler
+    from sglang_omni_v1.models.ming_omni.registration import register_ming_hf_config
+    from sglang_omni_v1.scheduling.sglang_backend import build_sglang_server_args
+
+    register_ming_hf_config()
+
+    overrides = dict(server_args_overrides or {})
+    overrides.setdefault("trust_remote_code", False)
+    overrides["tp_size"] = tp_size
+    server_args = build_sglang_server_args(
+        model_path,
+        context_length=thinker_max_seq_len,
+        **overrides,
+    )
+    return create_thinker_scheduler(
+        server_args,
+        model_path=model_path,
+        gpu_id=gpu_id,
+        tp_rank=tp_rank,
+        tp_size=tp_size,
+        nccl_port=nccl_port,
+    )
+
+
+def create_talker_executor(
+    model_path: str,
+    *,
+    talker_model_path: str | None = None,
+    device: str = "cuda",
+    voice: str = "DB30",
+):
+    from sglang_omni_v1.models.ming_omni.components.talker_executor import (
+        MingTalkerExecutor,
+    )
+    from sglang_omni_v1.models.weight_loader import resolve_model_path
+    from sglang_omni_v1.scheduling.simple_scheduler import SimpleScheduler
+
+    local_path = resolve_model_path(model_path)
+    executor = MingTalkerExecutor(
+        model_path=local_path,
+        talker_model_path=talker_model_path,
+        device=device,
+        voice=voice,
+    )
+    started = False
+
+    async def _talk(payload: StagePayload) -> StagePayload:
+        nonlocal started
+        if not executor.should_generate_audio(payload):
+            return executor.build_empty_audio_result(payload)
+        if not started:
+            await executor.start()
+            started = True
+        await executor.add_request(payload)
+        return await executor.get_result()
+
+    return SimpleScheduler(_talk)
+
+
+def create_decode_executor(model_path: str):
+    from sglang_omni_v1.models.ming_omni.components.common import load_ming_tokenizer
+    from sglang_omni_v1.models.ming_omni.io import OmniEvent
+    from sglang_omni_v1.models.ming_omni.pipeline.merge import decode_events
+    from sglang_omni_v1.models.ming_omni.pipeline.next_stage import THINKER_STAGE
+    from sglang_omni_v1.models.ming_omni.pipeline.state_io import load_state
+    from sglang_omni_v1.scheduling.simple_scheduler import SimpleScheduler
+
+    tokenizer = load_ming_tokenizer(model_path)
+    eos_token_id = getattr(tokenizer, "eos_token_id", None)
+
+    def _event_to_dict(event: OmniEvent) -> dict[str, Any]:
+        return {
+            "type": event.type,
+            "modality": event.modality,
+            "payload": dict(event.payload),
+            "is_final": bool(event.is_final),
+        }
+
+    def _decode(payload: StagePayload) -> StagePayload:
+        state = load_state(payload)
+        thinker_out = state.thinker_out or state.engine_outputs.get(THINKER_STAGE)
+        if not isinstance(thinker_out, dict):
+            thinker_out = {
+                "output_ids": [],
+                "step": 0,
+                "is_final": True,
+                "extra_model_outputs": {},
+            }
+
+        step = int(thinker_out.get("step") or len(thinker_out.get("output_ids", [])))
+        events = list(
+            decode_events(
+                thinker_out=thinker_out,  # type: ignore[arg-type]
+                state=state,
+                tokenizer=tokenizer,
+                eos_token_id=eos_token_id,
+                step=step,
+            )
+        )
+        result: dict[str, Any] = {"events": [_event_to_dict(event) for event in events]}
+        final_event = next(
+            (
+                event
+                for event in reversed(events)
+                if event.is_final or event.type in {"text_final", "final"}
+            ),
+            None,
+        )
+        if final_event is not None:
+            result.update(final_event.payload)
+            result.setdefault("modality", final_event.modality)
+
+        if "text" not in result:
+            output_ids = thinker_out.get("output_ids")
+            if (
+                callable(getattr(tokenizer, "decode", None))
+                and isinstance(output_ids, list)
+                and output_ids
+            ):
+                result["text"] = tokenizer.decode(output_ids, skip_special_tokens=True)
+                result.setdefault("modality", "text")
+
+        payload.data = result
+        return payload
+
+    return SimpleScheduler(_decode)

--- a/sglang_omni/models/ming_omni/stages.py
+++ b/sglang_omni/models/ming_omni/stages.py
@@ -132,7 +132,8 @@ def create_audio_encoder_executor(
             skip_result = inputs.get("_result")
             result = skip_result if isinstance(skip_result, dict) else {}
         else:
-            model_inputs = {k: v for k, v in inputs.items() if k != "cache_key"}
+            _meta = {"cache_key", "audio_placeholder_loc_lens"}
+            model_inputs = {k: v for k, v in inputs.items() if k not in _meta}
             result = model(**model_inputs)
         state.encoder_outs[AUDIO_STAGE] = result if isinstance(result, dict) else {}
         state.engine_outputs[AUDIO_STAGE] = state.encoder_outs[AUDIO_STAGE]

--- a/sglang_omni/models/ming_omni/stages.py
+++ b/sglang_omni/models/ming_omni/stages.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from sglang_omni_v1.models.ming_omni.io import PipelineState
-from sglang_omni_v1.models.ming_omni.pipeline.next_stage import AUDIO_STAGE, IMAGE_STAGE
-from sglang_omni_v1.proto import StagePayload
+from sglang_omni.models.ming_omni.io import PipelineState
+from sglang_omni.models.ming_omni.pipeline.next_stage import AUDIO_STAGE, IMAGE_STAGE
+from sglang_omni.proto import StagePayload
 
 
 def project_preprocessing_to_audio_encoder(payload: StagePayload) -> StagePayload:
@@ -90,8 +90,8 @@ def _single_encoder_stage_name(state: PipelineState) -> str:
 
 
 def create_preprocessing_executor(model_path: str):
-    from sglang_omni_v1.models.ming_omni.components.preprocessor import MingPreprocessor
-    from sglang_omni_v1.scheduling.simple_scheduler import SimpleScheduler
+    from sglang_omni.models.ming_omni.components.preprocessor import MingPreprocessor
+    from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
     preprocessor = MingPreprocessor(model_path=model_path)
 
@@ -102,7 +102,7 @@ def create_preprocessing_executor(model_path: str):
 
 
 def create_aggregate_executor():
-    from sglang_omni_v1.scheduling.simple_scheduler import SimpleScheduler
+    from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
     def _identity(payload: StagePayload) -> StagePayload:
         return payload
@@ -116,10 +116,10 @@ def create_audio_encoder_executor(
     device: str = "cuda",
     dtype: str | None = None,
 ):
-    from sglang_omni_v1.models.ming_omni.components.audio_encoder import (
+    from sglang_omni.models.ming_omni.components.audio_encoder import (
         MingAudioEncoder,
     )
-    from sglang_omni_v1.scheduling.simple_scheduler import SimpleScheduler
+    from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
     model = MingAudioEncoder(model_path=model_path, device=device, dtype=dtype)
 
@@ -149,10 +149,10 @@ def create_image_encoder_executor(
     device: str = "cuda",
     dtype: str | None = None,
 ):
-    from sglang_omni_v1.models.ming_omni.components.image_encoder import (
+    from sglang_omni.models.ming_omni.components.image_encoder import (
         MingImageEncoder,
     )
-    from sglang_omni_v1.scheduling.simple_scheduler import SimpleScheduler
+    from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
     model = MingImageEncoder(model_path=model_path, device=device, dtype=dtype)
 
@@ -185,9 +185,9 @@ def create_sglang_thinker_executor_from_config(
     thinker_max_seq_len: int = 8192,
     server_args_overrides: dict[str, Any] | None = None,
 ):
-    from sglang_omni_v1.models.ming_omni.bootstrap import create_thinker_scheduler
-    from sglang_omni_v1.models.ming_omni.registration import register_ming_hf_config
-    from sglang_omni_v1.scheduling.sglang_backend import build_sglang_server_args
+    from sglang_omni.models.ming_omni.bootstrap import create_thinker_scheduler
+    from sglang_omni.models.ming_omni.registration import register_ming_hf_config
+    from sglang_omni.scheduling.sglang_backend import build_sglang_server_args
 
     register_ming_hf_config()
 
@@ -216,11 +216,11 @@ def create_talker_executor(
     device: str = "cuda",
     voice: str = "DB30",
 ):
-    from sglang_omni_v1.models.ming_omni.components.talker_executor import (
+    from sglang_omni.models.ming_omni.components.talker_executor import (
         MingTalkerExecutor,
     )
-    from sglang_omni_v1.models.weight_loader import resolve_model_path
-    from sglang_omni_v1.scheduling.simple_scheduler import SimpleScheduler
+    from sglang_omni.models.weight_loader import resolve_model_path
+    from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
     local_path = resolve_model_path(model_path)
     executor = MingTalkerExecutor(
@@ -245,12 +245,12 @@ def create_talker_executor(
 
 
 def create_decode_executor(model_path: str):
-    from sglang_omni_v1.models.ming_omni.components.common import load_ming_tokenizer
-    from sglang_omni_v1.models.ming_omni.io import OmniEvent
-    from sglang_omni_v1.models.ming_omni.pipeline.merge import decode_events
-    from sglang_omni_v1.models.ming_omni.pipeline.next_stage import THINKER_STAGE
-    from sglang_omni_v1.models.ming_omni.pipeline.state_io import load_state
-    from sglang_omni_v1.scheduling.simple_scheduler import SimpleScheduler
+    from sglang_omni.models.ming_omni.components.common import load_ming_tokenizer
+    from sglang_omni.models.ming_omni.io import OmniEvent
+    from sglang_omni.models.ming_omni.pipeline.merge import decode_events
+    from sglang_omni.models.ming_omni.pipeline.next_stage import THINKER_STAGE
+    from sglang_omni.models.ming_omni.pipeline.state_io import load_state
+    from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
     tokenizer = load_ming_tokenizer(model_path)
     eos_token_id = getattr(tokenizer, "eos_token_id", None)

--- a/sglang_omni/models/ming_omni/stages.py
+++ b/sglang_omni/models/ming_omni/stages.py
@@ -116,9 +116,7 @@ def create_audio_encoder_executor(
     device: str = "cuda",
     dtype: str | None = None,
 ):
-    from sglang_omni.models.ming_omni.components.audio_encoder import (
-        MingAudioEncoder,
-    )
+    from sglang_omni.models.ming_omni.components.audio_encoder import MingAudioEncoder
     from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
     model = MingAudioEncoder(model_path=model_path, device=device, dtype=dtype)
@@ -149,9 +147,7 @@ def create_image_encoder_executor(
     device: str = "cuda",
     dtype: str | None = None,
 ):
-    from sglang_omni.models.ming_omni.components.image_encoder import (
-        MingImageEncoder,
-    )
+    from sglang_omni.models.ming_omni.components.image_encoder import MingImageEncoder
     from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
     model = MingImageEncoder(model_path=model_path, device=device, dtype=dtype)

--- a/sglang_omni/models/ming_omni/stages.py
+++ b/sglang_omni/models/ming_omni/stages.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-"""（wenyao）V1-facing stage factories for Ming-Omni.
+"""（wenyao）Stage factories for Ming-Omni.
 
 Heavy runtime imports are intentionally local to factory calls so importing
-Ming's V1 config remains usable in lightweight environments.
+Ming's config remains usable in lightweight environments.
 """
 
 from __future__ import annotations

--- a/sglang_omni/models/ming_omni/thinker.py
+++ b/sglang_omni/models/ming_omni/thinker.py
@@ -344,7 +344,13 @@ class BailingMoeV2SparseMoeBlock(nn.Module):
         else:
             self.expert_bias = None
 
-        # FusedMoE implementation
+        # （wenyao）reduce_results=True so the expert output is all_reduced across TP
+        # ranks before it is combined with the replicated shared-expert output.
+        # Upstream sglang bailing_moe.py uses reduce_results=False + a manual
+        # all_reduce after adding a parallel shared_experts; since our
+        # shared_experts is ReplicatedLinear (full value on every rank), we
+        # must reduce the experts output before the add to avoid double
+        # counting the shared expert contribution.
         FusedMoE = get_moe_impl_class(quant_config)
         self.experts = FusedMoE(
             num_experts=config.num_experts,
@@ -353,7 +359,7 @@ class BailingMoeV2SparseMoeBlock(nn.Module):
             intermediate_size=config.moe_intermediate_size,
             layer_id=layer_id,
             quant_config=quant_config,
-            reduce_results=False,
+            reduce_results=True,
         )
 
         # Shared expert
@@ -557,7 +563,9 @@ class BailingMoeV2TextModel(nn.Module):
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         """Load weights with prefix-based selection and MoE mapping."""
 
-        from sglang_omni.models.qwen3_omni.thinker import extract_fused_experts
+        from sglang_omni.models.qwen3_omni.components.thinker_model import (
+            extract_fused_experts,
+        )
 
         # Fused QKV: attention q/k/v -> qkv_proj
         _attn_fused_map = {

--- a/sglang_omni/models/qwen3_omni/request_builders.py
+++ b/sglang_omni/models/qwen3_omni/request_builders.py
@@ -320,7 +320,7 @@ def build_sglang_thinker_request(
             if cache_key is None:
                 continue
             h = xxhash.xxh3_64(cache_key.encode()).intdigest()
-            pad_val = vocab_size + h % (1 << 30)
+            pad_val = vocab_size + h % (1 << 62)
             pad_values[modality] = pad_val
             token_id_map[orig_token_id] = pad_val
         if token_id_map:

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -259,6 +259,7 @@ class OmniScheduler:
         self.soft_watchdog = None
         self.recv_skipper = None
         self.idle_sleeper = None
+        self._init_upstream_compat_flags(server_args)
         self.grammar_manager = _NoOpGrammarManager()
         self.grammar_queue = []
         self.grammar_backend = None
@@ -302,6 +303,27 @@ class OmniScheduler:
         self._pending_stream_chunks: dict[str, list[Any]] = {}
         self._pending_stream_done: set[str] = set()
         self._deferred_request_payloads: dict[str, Any] = {}
+
+    def _init_upstream_compat_flags(self, server_args: Any) -> None:
+        self.enable_hisparse = bool(getattr(server_args, "enable_hisparse", False))
+        self.hisparse_coordinator = None
+        self.enable_priority_preemption = bool(
+            getattr(server_args, "enable_priority_scheduling", False)
+            and not getattr(server_args, "disable_priority_preemption", False)
+        )
+        self.max_prefill_bs = 0
+        self.use_ngram_embedding = False
+        self.return_health_check_ipcs = []
+        self.enable_overlap_mlx = False
+
+    def self_check_during_idle(self) -> None:
+        self.new_token_ratio = self.init_new_token_ratio
+        idle_sleeper = self.__dict__.get("idle_sleeper")
+        if idle_sleeper is not None:
+            idle_sleeper.maybe_sleep()
+
+    def self_check_during_busy(self) -> None:
+        return None
 
     # ------------------------------------------------------------------
     # Composition: delegate missing attributes to the upstream class

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -311,6 +311,7 @@ class OmniScheduler:
             getattr(server_args, "enable_priority_scheduling", False)
             and not getattr(server_args, "disable_priority_preemption", False)
         )
+        # High-water mark, not a cap. Mirrors upstream Scheduler.__init__ (sglang/srt/managers/scheduler.py).
         self.max_prefill_bs = 0
         self.use_ngram_embedding = False
         self.return_health_check_ipcs = []

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -280,6 +280,8 @@ async def _chat_stream(
         audio_format=audio_format,
     ):
         # Capture finish info for the dedicated finish chunk after the loop.
+        # Some pipelines only emit a final aggregate chunk; do not drop its
+        # text/audio just because it already carries a finish reason.
         if chunk.finish_reason is not None:
             finish_reason = chunk.finish_reason
             if chunk.usage is not None:
@@ -288,7 +290,17 @@ async def _chat_stream(
                     completion_tokens=chunk.usage.completion_tokens or 0,
                     total_tokens=chunk.usage.total_tokens or 0,
                 )
-            continue
+            has_payload = (
+                chunk.modality == "text"
+                and bool(chunk.text)
+                and "text" in requested_modalities
+            ) or (
+                chunk.modality == "audio"
+                and chunk.audio_b64 is not None
+                and "audio" in requested_modalities
+            )
+            if not has_payload:
+                continue
 
         delta = ChatCompletionStreamDelta()
         emit = False
@@ -386,7 +398,7 @@ def _build_chat_generate_request(req: ChatCompletionRequest) -> GenerateRequest:
     messages = [Message(role=m.role, content=m.content) for m in req.messages]
 
     # Determine output modalities
-    output_modalities = req.modalities  # e.g. ["text", "audio"]
+    output_modalities = req.modalities or ["text"]  # e.g. ["text", "audio"]
 
     # Build per-stage sampling overrides
     stage_sampling: dict[str, SamplingParams] | None = None

--- a/sglang_omni/vendor/sglang/layers.py
+++ b/sglang_omni/vendor/sglang/layers.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 from typing import Optional, Tuple, Union
 
 import torch
-from sgl_kernel import top_k_top_p_sampling_from_probs
 from sglang.srt.layers.activation import SiluAndMul
 from sglang.srt.layers.communicator import LayerCommunicator, LayerScatterModes
 from sglang.srt.layers.dp_attention import get_attention_tp_rank, get_attention_tp_size
@@ -159,5 +158,4 @@ __all__ = [
     "LayerCommunicator",
     "LayerScatterModes",
     "FusedMoE",
-    "top_k_top_p_sampling_from_probs",
 ]

--- a/tests/README.md
+++ b/tests/README.md
@@ -40,6 +40,12 @@ tests/
     │   ├── test_sglang_ar_budget.py
     │   ├── test_streaming.py
     │   └── test_talker.py
+    ├── ming_omni/
+    │   ├── test_pipeline.py
+    │   ├── test_talker.py
+    │   ├── test_thinker.py
+    │   ├── test_tokenizer.py
+    │   └── test_tp.py
     ├── router/
     │   ├── test_app.py
     │   └── test_core.py
@@ -182,6 +188,19 @@ that happened to contain an older version of the test.
   - `PipelineState` request builders
   - talker behavior
   - Code2Wav streaming/cleanup behavior.
+
+- `unit_test/ming_omni/` Ming-Omni unit tests:
+
+  - text + speech pipeline config and stage schema
+  - launcher argparse, GPU placement, and TP wiring
+  - stage factory and scheduler contracts (preprocessing, encoders, thinker, talker, decode)
+  - thinker bootstrap registration and Ming model runner wiring
+  - multimodal embed injection (per-modality consumed state, pad-value fallback, short-embeds detection)
+  - image/vision encoder TP context preservation
+  - audio/image preprocessor placeholder construction and cache-key plumbing
+  - talker executor request gating and result-builder modality merging
+  - Bailing tokenizer loader fallback for vocab compatibility
+  - TP topology validation (rank-specific stage specs, talker/thinker GPU collision detection, server_args alignment before infra init).
 
 - `unit_test/router/`: SGLang-Omni Router unit tests:
   - router CLI/config behavior

--- a/tests/test_model/run_ming_tp4.py
+++ b/tests/test_model/run_ming_tp4.py
@@ -79,6 +79,57 @@ def parse_args() -> argparse.Namespace:
         help="Output directory for MMMU results. Defaults under --output-dir.",
     )
     parser.add_argument(
+        "--run-mmsu",
+        action="store_true",
+        help="Run the MMSU audio-text benchmark after smoke tests.",
+    )
+    parser.add_argument("--mmsu-max-samples", type=int, default=50)
+    parser.add_argument("--mmsu-max-tokens", type=int, default=32)
+    parser.add_argument("--mmsu-temperature", type=float, default=0.0)
+    parser.add_argument("--mmsu-warmup", type=int, default=1)
+    parser.add_argument("--mmsu-max-concurrency", type=int, default=1)
+    parser.add_argument(
+        "--mmsu-modalities",
+        choices=["text", "text+audio"],
+        default="text+audio",
+    )
+    parser.add_argument(
+        "--mmsu-output-dir",
+        default=None,
+        help="Output directory for MMSU results. Defaults under --output-dir.",
+    )
+    parser.add_argument(
+        "--run-tts",
+        action="store_true",
+        help="Run the SeedTTS benchmark after smoke tests.",
+    )
+    parser.add_argument("--tts-max-samples", type=int, default=20)
+    parser.add_argument("--tts-max-new-tokens", type=int, default=256)
+    parser.add_argument("--tts-temperature", type=float, default=0.7)
+    parser.add_argument("--tts-warmup", type=int, default=1)
+    parser.add_argument("--tts-max-concurrency", type=int, default=1)
+    parser.add_argument(
+        "--tts-meta",
+        default="seedtts_testset/en/meta.lst",
+        help="Path to a seed-tts-eval meta.lst file.",
+    )
+    parser.add_argument("--tts-lang", choices=["en", "zh"], default="en")
+    parser.add_argument(
+        "--tts-speaker",
+        default="Ethan",
+        choices=["Ethan", "Chelsie", "Aiden"],
+    )
+    parser.add_argument(
+        "--tts-generate-only",
+        action="store_true",
+        help="Skip WER transcription phase (generate audio + measure speed only).",
+    )
+    parser.add_argument(
+        "--tts-output-dir",
+        default=None,
+        help="Output directory for TTS results. Defaults under --output-dir.",
+    )
+    parser.add_argument(
         "--quiet-server-log",
         action="store_true",
         help="Do not mirror the server log to stdout while tests are running.",
@@ -405,6 +456,90 @@ def _run_mmmu_benchmark(args: argparse.Namespace) -> None:
     subprocess.run(command, cwd=os.getcwd(), env=env, check=True)
 
 
+def _run_mmsu_benchmark(args: argparse.Namespace) -> None:
+    output_dir = (
+        Path(args.mmsu_output_dir)
+        if args.mmsu_output_dir
+        else Path(args.output_dir) / "mmsu_ming"
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    command = [
+        sys.executable,
+        "-m",
+        "benchmarks.eval.benchmark_omni_mmsu",
+        "--model",
+        "ming-omni",
+        "--host",
+        args.host,
+        "--port",
+        str(args.port),
+        "--modalities",
+        args.mmsu_modalities,
+        "--max-samples",
+        str(args.mmsu_max_samples),
+        "--max-concurrency",
+        str(args.mmsu_max_concurrency),
+        "--warmup",
+        str(args.mmsu_warmup),
+        "--max-tokens",
+        str(args.mmsu_max_tokens),
+        "--temperature",
+        str(args.mmsu_temperature),
+        "--output-dir",
+        str(output_dir),
+    ]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"{os.getcwd()}:{env.get('PYTHONPATH', '')}"
+    print("\n[test] mmsu", flush=True)
+    print("[mmsu] " + " ".join(command), flush=True)
+    subprocess.run(command, cwd=os.getcwd(), env=env, check=True)
+
+
+def _run_tts_benchmark(args: argparse.Namespace) -> None:
+    output_dir = (
+        Path(args.tts_output_dir)
+        if args.tts_output_dir
+        else Path(args.output_dir) / "tts_ming"
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    command = [
+        sys.executable,
+        "-m",
+        "benchmarks.eval.benchmark_omni_seedtts",
+        "--model",
+        "ming-omni",
+        "--host",
+        args.host,
+        "--port",
+        str(args.port),
+        "--meta",
+        args.tts_meta,
+        "--lang",
+        args.tts_lang,
+        "--speaker",
+        args.tts_speaker,
+        "--max-samples",
+        str(args.tts_max_samples),
+        "--max-new-tokens",
+        str(args.tts_max_new_tokens),
+        "--temperature",
+        str(args.tts_temperature),
+        "--warmup",
+        str(args.tts_warmup),
+        "--max-concurrency",
+        str(args.tts_max_concurrency),
+        "--output-dir",
+        str(output_dir),
+    ]
+    if args.tts_generate_only:
+        command.append("--generate-only")
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"{os.getcwd()}:{env.get('PYTHONPATH', '')}"
+    print("\n[test] tts", flush=True)
+    print("[tts] " + " ".join(command), flush=True)
+    subprocess.run(command, cwd=os.getcwd(), env=env, check=True)
+
+
 def _stop_server(process: subprocess.Popen | None) -> None:
     if process is None or process.poll() is not None:
         return
@@ -461,6 +596,10 @@ def main() -> None:
         _run_smoke_tests(args)
         if args.run_mmmu:
             _run_mmmu_benchmark(args)
+        if args.run_mmsu:
+            _run_mmsu_benchmark(args)
+        if args.run_tts:
+            _run_tts_benchmark(args)
         if args.keep_server:
             print(f"[server] keeping server alive; log={log_path}", flush=True)
             process = None

--- a/tests/test_model/run_ming_tp4.py
+++ b/tests/test_model/run_ming_tp4.py
@@ -495,6 +495,21 @@ def _run_mmsu_benchmark(args: argparse.Namespace) -> None:
     subprocess.run(command, cwd=os.getcwd(), env=env, check=True)
 
 
+_MING_TTS_SYSTEM_PROMPT_EN = (
+    "You are a text-to-speech engine. Read aloud only the exact text the user "
+    "asks you to speak. Do not add greetings, preambles, suffixes, "
+    "explanations, apologies, or refusals. Do not say phrases like \"Sure\", "
+    "\"Here is\", \"In English\", or \"I am an AI\". Output the spoken text "
+    "verbatim and nothing else."
+)
+_MING_TTS_SYSTEM_PROMPT_ZH = (
+    "你是一个文本转语音引擎。只朗读用户给出的原文，逐字朗读。"
+    "不要添加任何开场白、前缀、后缀、解释、道歉或拒绝。"
+    "不要说\"好的\"、\"以下是\"、\"用中文\"或\"我是 AI\"之类的话。"
+    "只输出原文对应的语音，不要任何额外内容。"
+)
+
+
 def _run_tts_benchmark(args: argparse.Namespace) -> None:
     output_dir = (
         Path(args.tts_output_dir)
@@ -502,6 +517,11 @@ def _run_tts_benchmark(args: argparse.Namespace) -> None:
         else Path(args.output_dir) / "tts_ming"
     )
     output_dir.mkdir(parents=True, exist_ok=True)
+    system_prompt = (
+        _MING_TTS_SYSTEM_PROMPT_ZH
+        if args.tts_lang == "zh"
+        else _MING_TTS_SYSTEM_PROMPT_EN
+    )
     command = [
         sys.executable,
         "-m",
@@ -530,6 +550,8 @@ def _run_tts_benchmark(args: argparse.Namespace) -> None:
         str(args.tts_max_concurrency),
         "--output-dir",
         str(output_dir),
+        "--system-prompt",
+        system_prompt,
     ]
     if args.tts_generate_only:
         command.append("--generate-only")

--- a/tests/test_model/run_ming_tp4.py
+++ b/tests/test_model/run_ming_tp4.py
@@ -498,14 +498,14 @@ def _run_mmsu_benchmark(args: argparse.Namespace) -> None:
 _MING_TTS_SYSTEM_PROMPT_EN = (
     "You are a text-to-speech engine. Read aloud only the exact text the user "
     "asks you to speak. Do not add greetings, preambles, suffixes, "
-    "explanations, apologies, or refusals. Do not say phrases like \"Sure\", "
-    "\"Here is\", \"In English\", or \"I am an AI\". Output the spoken text "
+    'explanations, apologies, or refusals. Do not say phrases like "Sure", '
+    '"Here is", "In English", or "I am an AI". Output the spoken text '
     "verbatim and nothing else."
 )
 _MING_TTS_SYSTEM_PROMPT_ZH = (
     "你是一个文本转语音引擎。只朗读用户给出的原文，逐字朗读。"
     "不要添加任何开场白、前缀、后缀、解释、道歉或拒绝。"
-    "不要说\"好的\"、\"以下是\"、\"用中文\"或\"我是 AI\"之类的话。"
+    '不要说"好的"、"以下是"、"用中文"或"我是 AI"之类的话。'
     "只输出原文对应的语音，不要任何额外内容。"
 )
 

--- a/tests/test_model/run_ming_tp4.py
+++ b/tests/test_model/run_ming_tp4.py
@@ -1,0 +1,480 @@
+# SPDX-License-Identifier: Apache-2.0
+"""（wenyao）Launch Ming V1 speech server and run TP4 smoke tests from one terminal.
+
+The script starts ``examples/run_ming_omni_speech_server.py`` in a subprocess,
+waits for ``/health``, then exercises the OpenAI-compatible endpoints.
+
+Example::
+
+    CUDA_VISIBLE_DEVICES=3,4,5,6,7 python -u run_ming_tp4.py
+
+Use ``--skip-server`` if a server is already running on the target port.
+Use ``--run-mmmu`` to run the MMMU CI subset after the smoke tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--model-path", default="inclusionAI/Ming-flash-omni-2.0")
+    parser.add_argument(
+        "--launcher",
+        default=str(
+            Path(__file__).resolve().parents[2]
+            / "examples"
+            / "run_ming_omni_speech_server.py"
+        ),
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument(
+        "--cuda-visible-devices",
+        default=os.environ.get("CUDA_VISIBLE_DEVICES", "3,4,5,6,7"),
+    )
+    parser.add_argument("--gpu-thinker", type=int, default=0)
+    parser.add_argument("--gpu-talker", type=int, default=4)
+    parser.add_argument("--tp-size", type=int, default=4)
+    parser.add_argument("--mem-fraction-static", type=float, default=0.80)
+    parser.add_argument("--startup-timeout", type=float, default=900)
+    parser.add_argument("--request-timeout", type=float, default=300)
+    parser.add_argument("--output-dir", default="/data/repo/logs")
+    parser.add_argument("--run-log", default=None)
+    parser.add_argument("--no-run-log", action="store_true")
+    parser.add_argument("--keep-server", action="store_true")
+    parser.add_argument("--skip-server", action="store_true")
+    parser.add_argument(
+        "--run-mmmu",
+        action="store_true",
+        help="Run the MMMU image-text benchmark after smoke tests.",
+    )
+    parser.add_argument(
+        "--mmmu-repo-id",
+        default="zhaochenyang20/mmmu-ci-50",
+        help="HuggingFace dataset repo for MMMU. Defaults to the CI-50 subset.",
+    )
+    parser.add_argument("--mmmu-max-samples", type=int, default=50)
+    parser.add_argument("--mmmu-max-tokens", type=int, default=512)
+    parser.add_argument("--mmmu-temperature", type=float, default=0.0)
+    parser.add_argument("--mmmu-warmup", type=int, default=2)
+    parser.add_argument("--mmmu-max-concurrency", type=int, default=1)
+    parser.add_argument(
+        "--mmmu-output-dir",
+        default=None,
+        help="Output directory for MMMU results. Defaults under --output-dir.",
+    )
+    parser.add_argument(
+        "--quiet-server-log",
+        action="store_true",
+        help="Do not mirror the server log to stdout while tests are running.",
+    )
+    return parser.parse_args()
+
+
+class _TeeStream:
+    def __init__(self, *streams):
+        self._streams = streams
+
+    def write(self, data: str) -> int:
+        for stream in self._streams:
+            stream.write(data)
+            stream.flush()
+        return len(data)
+
+    def flush(self) -> None:
+        for stream in self._streams:
+            stream.flush()
+
+
+def _url(args: argparse.Namespace, path: str) -> str:
+    return f"http://{args.host}:{args.port}{path}"
+
+
+def _get_json(args: argparse.Namespace, path: str, timeout: float = 10) -> dict:
+    request = urllib.request.Request(_url(args, path), method="GET")
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _post_json(
+    args: argparse.Namespace,
+    path: str,
+    payload: dict,
+    timeout: float,
+) -> dict:
+    request = urllib.request.Request(
+        _url(args, path),
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")
+        raise RuntimeError(f"HTTP {exc.code}: {detail[:1000]}") from exc
+
+
+def _stream_sse(
+    args: argparse.Namespace,
+    payload: dict,
+    timeout: float,
+) -> list[dict]:
+    request = urllib.request.Request(
+        _url(args, "/v1/chat/completions"),
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    events: list[dict] = []
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        while True:
+            line = response.readline()
+            if not line:
+                break
+            line_text = line.decode("utf-8", "replace").strip()
+            if not line_text.startswith("data: "):
+                continue
+            data = line_text[len("data: ") :]
+            if data == "[DONE]":
+                break
+            events.append(json.loads(data))
+    return events
+
+
+def _start_server(args: argparse.Namespace, log_path: Path) -> subprocess.Popen:
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = args.cuda_visible_devices
+    env["PYTHONPATH"] = f"{os.getcwd()}:{env.get('PYTHONPATH', '')}"
+    command = [
+        sys.executable,
+        "-u",
+        args.launcher,
+        "--version",
+        "v1",
+        "--model-path",
+        args.model_path,
+        "--tp-size",
+        str(args.tp_size),
+        "--gpu-thinker",
+        str(args.gpu_thinker),
+        "--gpu-talker",
+        str(args.gpu_talker),
+        "--mem-fraction-static",
+        str(args.mem_fraction_static),
+        "--host",
+        args.host,
+        "--port",
+        str(args.port),
+    ]
+
+    print("[server] " + " ".join(command), flush=True)
+    print(f"[server] CUDA_VISIBLE_DEVICES={args.cuda_visible_devices}", flush=True)
+    print(f"[server] log: {log_path}", flush=True)
+    log_file = open(log_path, "w", buffering=1)
+    process = subprocess.Popen(
+        command,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        env=env,
+        cwd=os.getcwd(),
+        start_new_session=True,
+        text=True,
+    )
+    process._log_file = log_file  # type: ignore[attr-defined]
+    if not args.quiet_server_log:
+        thread = threading.Thread(
+            target=_mirror_server_log,
+            args=(log_path, process),
+            name="server-log-mirror",
+            daemon=True,
+        )
+        thread.start()
+        process._log_thread = thread  # type: ignore[attr-defined]
+    return process
+
+
+def _mirror_server_log(log_path: Path, process: subprocess.Popen) -> None:
+    """Mirror the server log file to stdout for one-terminal smoke runs."""
+    try:
+        with open(log_path, "r", encoding="utf-8", errors="replace") as reader:
+            while process.poll() is None:
+                line = reader.readline()
+                if line:
+                    print(f"[server-log] {line}", end="", flush=True)
+                else:
+                    time.sleep(0.2)
+            for line in reader:
+                print(f"[server-log] {line}", end="", flush=True)
+    except Exception as exc:
+        print(f"[server-log] mirror stopped: {exc}", flush=True)
+
+
+def _wait_ready(args: argparse.Namespace, process: subprocess.Popen | None) -> None:
+    deadline = time.time() + args.startup_timeout
+    last_error = ""
+    while time.time() < deadline:
+        if process is not None and process.poll() is not None:
+            raise RuntimeError(f"server exited early with code {process.returncode}")
+        try:
+            health = _get_json(args, "/health", timeout=5)
+            if health.get("status") == "healthy" or health.get("running") is True:
+                print("[ready] /health OK", flush=True)
+                return
+            last_error = str(health)
+        except Exception as exc:
+            last_error = str(exc)
+        time.sleep(2)
+    raise TimeoutError(f"server did not become healthy: {last_error}")
+
+
+def _show_text_response(name: str, body: dict) -> str:
+    choices = body.get("choices") or []
+    if not choices:
+        raise AssertionError(f"{name}: missing choices: {body}")
+    message = choices[0].get("message") or {}
+    text = message.get("content") or ""
+    if not isinstance(text, str):
+        raise AssertionError(f"{name}: missing text content: {body}")
+    print(f"\n=== {name} OUTPUT ===\n{text}\n=== END {name} OUTPUT ===", flush=True)
+    return text
+
+
+def _show_stream_response(name: str, events: list[dict]) -> None:
+    text_parts: list[str] = []
+    for event in events:
+        choices = event.get("choices") or []
+        for choice in choices:
+            delta = choice.get("delta") or {}
+            content = delta.get("content")
+            if isinstance(content, str):
+                text_parts.append(content)
+    text = "".join(text_parts)
+    print(
+        f"\n=== {name} STREAM OUTPUT ===\n{text}\n=== END {name} STREAM OUTPUT ===",
+        flush=True,
+    )
+
+
+def _run_smoke_tests(args: argparse.Namespace) -> None:
+    results: list[tuple[str, bool, float, str]] = []
+
+    def run(name: str, fn) -> None:
+        print(f"[test] {name}", flush=True)
+        started = time.time()
+        try:
+            fn()
+            results.append((name, True, time.time() - started, ""))
+        except Exception as exc:
+            results.append((name, False, time.time() - started, str(exc)))
+            print(f"[fail] {name}: {exc}", flush=True)
+            raise
+
+    run("health", lambda: _get_json(args, "/health", timeout=10))
+    run("models", lambda: _get_json(args, "/v1/models", timeout=10))
+
+    def text_chat() -> None:
+        body = _post_json(
+            args,
+            "/v1/chat/completions",
+            {
+                "model": "ming-omni",
+                "messages": [{"role": "user", "content": "What is capital of japan?"}],
+                "max_tokens": 256,
+                "temperature": 0,
+                "top_p": 1,
+            },
+            args.request_timeout,
+        )
+        _show_text_response("text_chat", body)
+
+    run("text_chat", text_chat)
+
+    def image_text_chat() -> None:
+        body = _post_json(
+            args,
+            "/v1/chat/completions",
+            {
+                "model": "ming-omni",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": "https://picsum.photos/id/237/300/200"
+                                },
+                            },
+                            {
+                                "type": "text",
+                                "text": "Describe what you see in this image.",
+                            },
+                        ],
+                    }
+                ],
+                "max_tokens": 256,
+            },
+            args.request_timeout,
+        )
+        _show_text_response("image_text_chat", body)
+
+    run("image_text_chat", image_text_chat)
+
+    def stream_text_chat() -> None:
+        events = _stream_sse(
+            args,
+            {
+                "model": "ming-omni",
+                "messages": [{"role": "user", "content": "Say: stream ok"}],
+                "modalities": ["text"],
+                "stream": True,
+                "max_tokens": 256,
+                "temperature": 0.2,
+            },
+            args.request_timeout,
+        )
+        if not events:
+            raise AssertionError("no SSE events")
+        print(f"[ok] stream_text_chat: events={len(events)}", flush=True)
+        _show_stream_response("stream_text_chat", events)
+
+    run("stream_text_chat", stream_text_chat)
+
+    failed = [item for item in results if not item[1]]
+    print("\n=== SUMMARY ===", flush=True)
+    for name, ok, seconds, error in results:
+        status = "PASS" if ok else "FAIL"
+        print(f"{status} {name:18s} {seconds:8.2f}s {error[:180]}", flush=True)
+    if failed:
+        raise SystemExit(1)
+
+
+def _run_mmmu_benchmark(args: argparse.Namespace) -> None:
+    output_dir = (
+        Path(args.mmmu_output_dir)
+        if args.mmmu_output_dir
+        else Path(args.output_dir) / "mmmu_ming_ci50"
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    command = [
+        sys.executable,
+        "-m",
+        "benchmarks.eval.benchmark_omni_mmmu",
+        "--model",
+        "ming-omni",
+        "--host",
+        args.host,
+        "--port",
+        str(args.port),
+        "--repo-id",
+        args.mmmu_repo_id,
+        "--max-samples",
+        str(args.mmmu_max_samples),
+        "--max-concurrency",
+        str(args.mmmu_max_concurrency),
+        "--warmup",
+        str(args.mmmu_warmup),
+        "--max-tokens",
+        str(args.mmmu_max_tokens),
+        "--temperature",
+        str(args.mmmu_temperature),
+        "--output-dir",
+        str(output_dir),
+    ]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"{os.getcwd()}:{env.get('PYTHONPATH', '')}"
+    print("\n[test] mmmu", flush=True)
+    print("[mmmu] " + " ".join(command), flush=True)
+    subprocess.run(command, cwd=os.getcwd(), env=env, check=True)
+
+
+def _stop_server(process: subprocess.Popen | None) -> None:
+    if process is None or process.poll() is not None:
+        return
+    print("[server] stopping...", flush=True)
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except Exception:
+        process.terminate()
+    try:
+        process.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except Exception:
+            process.kill()
+    log_thread = getattr(process, "_log_thread", None)
+    if log_thread is not None:
+        log_thread.join(timeout=2)
+    log_file = getattr(process, "_log_file", None)
+    if log_file is not None:
+        log_file.close()
+
+
+def _tail(path: Path, n: int = 160) -> None:
+    if not path.exists():
+        return
+    lines = path.read_text(errors="replace").splitlines()
+    print(f"\n=== SERVER LOG TAIL: {path} ===", flush=True)
+    for line in lines[-n:]:
+        print(line, flush=True)
+
+
+def main() -> None:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    log_path = output_dir / "server.log"
+    run_log_file = None
+    original_stdout = sys.stdout
+    original_stderr = sys.stderr
+    if not args.no_run_log:
+        run_log_path = Path(args.run_log) if args.run_log else output_dir / "run.log"
+        run_log_path.parent.mkdir(parents=True, exist_ok=True)
+        run_log_file = open(run_log_path, "w", buffering=1)
+        sys.stdout = _TeeStream(original_stdout, run_log_file)  # type: ignore[assignment]
+        sys.stderr = _TeeStream(original_stderr, run_log_file)  # type: ignore[assignment]
+        print(f"[runner] log: {run_log_path}", flush=True)
+
+    process: subprocess.Popen | None = None
+    try:
+        if not args.skip_server:
+            process = _start_server(args, log_path)
+        _wait_ready(args, process)
+        _run_smoke_tests(args)
+        if args.run_mmmu:
+            _run_mmmu_benchmark(args)
+        if args.keep_server:
+            print(f"[server] keeping server alive; log={log_path}", flush=True)
+            process = None
+    except Exception:
+        _tail(log_path)
+        raise
+    finally:
+        if not args.keep_server:
+            _stop_server(process)
+        if run_log_file is not None:
+            sys.stdout = original_stdout
+            sys.stderr = original_stderr
+            run_log_file.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_test/ming_omni/test_pipeline.py
+++ b/tests/unit_test/ming_omni/test_pipeline.py
@@ -11,7 +11,7 @@ from types import ModuleType, SimpleNamespace
 
 
 def test_ming_v1_text_config_imports_and_uses_current_stage_schema() -> None:
-    from sglang_omni_v1.models.ming_omni.config import MingOmniPipelineConfig
+    from sglang_omni.models.ming_omni.config import MingOmniPipelineConfig
 
     config = MingOmniPipelineConfig(model_path="dummy")
 
@@ -25,7 +25,7 @@ def test_ming_v1_text_config_imports_and_uses_current_stage_schema() -> None:
     ]
     assert config.terminal_stages == ["decode"]
     assert all(
-        stage.factory.startswith("sglang_omni_v1.models.ming_omni.stages.create_")
+        stage.factory.startswith("sglang_omni.models.ming_omni.stages.create_")
         for stage in config.stages
     )
     assert all("executor" not in stage.model_dump() for stage in config.stages)
@@ -34,7 +34,7 @@ def test_ming_v1_text_config_imports_and_uses_current_stage_schema() -> None:
 
 
 def test_ming_v1_speech_config_routes_decode_and_talker() -> None:
-    from sglang_omni_v1.models.ming_omni.config import MingOmniSpeechPipelineConfig
+    from sglang_omni.models.ming_omni.config import MingOmniSpeechPipelineConfig
 
     config = MingOmniSpeechPipelineConfig(model_path="dummy")
     stages = {stage.name: stage for stage in config.stages}
@@ -65,7 +65,7 @@ def test_ming_v1_speech_config_routes_decode_and_talker() -> None:
     ]
     assert (
         stages["mm_aggregate"].merge_fn
-        == "sglang_omni_v1.models.ming_omni.pipeline.merge.merge_for_thinker"
+        == "sglang_omni.models.ming_omni.pipeline.merge.merge_for_thinker"
     )
     assert stages["thinker"].next == ["decode", "talker"]
     assert stages["decode"].terminal is True
@@ -97,14 +97,14 @@ def test_ming_v1_speech_launcher_places_thinker_tp_and_talker(monkeypatch) -> No
     from examples.run_ming_omni_speech_server import _launch_v1_speech_server
 
     captured: dict[str, object] = {}
-    serve_module = ModuleType("sglang_omni_v1.serve")
+    serve_module = ModuleType("sglang_omni.serve")
 
     def fake_launch_server(config, **kwargs):
         captured["config"] = config
         captured["kwargs"] = kwargs
 
     serve_module.launch_server = fake_launch_server
-    monkeypatch.setitem(sys.modules, "sglang_omni_v1.serve", serve_module)
+    monkeypatch.setitem(sys.modules, "sglang_omni.serve", serve_module)
 
     args = SimpleNamespace(
         model_path="dummy",
@@ -135,7 +135,7 @@ def test_ming_v1_speech_launcher_places_thinker_tp_and_talker(monkeypatch) -> No
 
 
 def test_ming_v1_stages_import_light_and_accept_mp_injection_args() -> None:
-    stages = importlib.import_module("sglang_omni_v1.models.ming_omni.stages")
+    stages = importlib.import_module("sglang_omni.models.ming_omni.stages")
 
     sig = inspect.signature(stages.create_sglang_thinker_executor_from_config)
 
@@ -146,7 +146,7 @@ def test_ming_v1_stages_import_light_and_accept_mp_injection_args() -> None:
 
 def test_ming_talker_factory_returns_v1_scheduler_contract(monkeypatch) -> None:
     talker_module = ModuleType(
-        "sglang_omni_v1.models.ming_omni.components.talker_executor"
+        "sglang_omni.models.ming_omni.components.talker_executor"
     )
 
     class FakeMingTalkerExecutor:
@@ -165,21 +165,21 @@ def test_ming_talker_factory_returns_v1_scheduler_contract(monkeypatch) -> None:
     talker_module.MingTalkerExecutor = FakeMingTalkerExecutor
     monkeypatch.setitem(
         sys.modules,
-        "sglang_omni_v1.models.ming_omni.components.talker_executor",
+        "sglang_omni.models.ming_omni.components.talker_executor",
         talker_module,
     )
 
-    weight_loader_module = ModuleType("sglang_omni_v1.models.weight_loader")
+    weight_loader_module = ModuleType("sglang_omni.models.weight_loader")
     weight_loader_module.resolve_model_path = (
         lambda model_path: f"/resolved/{model_path}"
     )
     monkeypatch.setitem(
         sys.modules,
-        "sglang_omni_v1.models.weight_loader",
+        "sglang_omni.models.weight_loader",
         weight_loader_module,
     )
 
-    from sglang_omni_v1.models.ming_omni.stages import create_talker_executor
+    from sglang_omni.models.ming_omni.stages import create_talker_executor
 
     scheduler = create_talker_executor(
         model_path="dummy",
@@ -198,7 +198,7 @@ def test_ming_talker_factory_returns_v1_scheduler_contract(monkeypatch) -> None:
 
 def test_ming_audio_encoder_moves_inputs_to_component_device() -> None:
     source = Path(
-        "sglang_omni_v1/models/ming_omni/components/audio_encoder.py"
+        "sglang_omni/models/ming_omni/components/audio_encoder.py"
     ).read_text(encoding="utf-8")
 
     assert (
@@ -211,14 +211,14 @@ def test_ming_v1_text_launcher_places_tp_ranks_on_distinct_gpus(monkeypatch) -> 
     from examples.run_ming_omni_server import _launch_v1_text_server
 
     captured: dict[str, object] = {}
-    serve_module = ModuleType("sglang_omni_v1.serve")
+    serve_module = ModuleType("sglang_omni.serve")
 
     def fake_launch_server(config, **kwargs):
         captured["config"] = config
         captured["kwargs"] = kwargs
 
     serve_module.launch_server = fake_launch_server
-    monkeypatch.setitem(sys.modules, "sglang_omni_v1.serve", serve_module)
+    monkeypatch.setitem(sys.modules, "sglang_omni.serve", serve_module)
 
     args = SimpleNamespace(
         model_path="dummy",
@@ -248,14 +248,14 @@ def test_ming_v1_text_launcher_allows_encoder_gpu_overrides(monkeypatch) -> None
     from examples.run_ming_omni_server import _launch_v1_text_server
 
     captured: dict[str, object] = {}
-    serve_module = ModuleType("sglang_omni_v1.serve")
+    serve_module = ModuleType("sglang_omni.serve")
 
     def fake_launch_server(config, **kwargs):
         del kwargs
         captured["config"] = config
 
     serve_module.launch_server = fake_launch_server
-    monkeypatch.setitem(sys.modules, "sglang_omni_v1.serve", serve_module)
+    monkeypatch.setitem(sys.modules, "sglang_omni.serve", serve_module)
 
     args = SimpleNamespace(
         model_path="dummy",
@@ -288,14 +288,14 @@ def test_ming_v1_text_launcher_can_build_thinker_only_smoke_pipeline(
     from examples.run_ming_omni_server import _launch_v1_text_server
 
     captured: dict[str, object] = {}
-    serve_module = ModuleType("sglang_omni_v1.serve")
+    serve_module = ModuleType("sglang_omni.serve")
 
     def fake_launch_server(config, **kwargs):
         del kwargs
         captured["config"] = config
 
     serve_module.launch_server = fake_launch_server
-    monkeypatch.setitem(sys.modules, "sglang_omni_v1.serve", serve_module)
+    monkeypatch.setitem(sys.modules, "sglang_omni.serve", serve_module)
 
     args = SimpleNamespace(
         model_path="dummy",
@@ -325,50 +325,15 @@ def test_ming_v1_text_launcher_can_build_thinker_only_smoke_pipeline(
     assert stages["thinker"].tp_size == 4
 
 
-def test_ming_test_utils_inject_version_for_ming_launchers(monkeypatch) -> None:
-    from tests.utils import _inject_server_version
-
-    monkeypatch.setenv("SGLANG_OMNI_SERVER_VERSION", "v1")
-
-    assert _inject_server_version(
-        ["python", "examples/run_qwen3_omni_server.py", "--port", "8000"]
-    ) == [
-        "python",
-        "examples/run_qwen3_omni_server.py",
-        "--port",
-        "8000",
-        "--version",
-        "v1",
-    ]
-    assert _inject_server_version(
-        ["python", "examples/run_ming_omni_server.py", "--port", "8000"]
-    ) == [
-        "python",
-        "examples/run_ming_omni_server.py",
-        "--port",
-        "8000",
-        "--version",
-        "v1",
-    ]
-    assert _inject_server_version(
-        ["python", "examples/run_ming_omni_speech_server.py"]
-    ) == [
-        "python",
-        "examples/run_ming_omni_speech_server.py",
-        "--version",
-        "v1",
-    ]
-
-
 def test_ming_thinker_factory_registers_hf_config_before_server_args(
     monkeypatch,
 ) -> None:
-    from sglang_omni_v1.models.ming_omni import stages
+    from sglang_omni.models.ming_omni import stages
 
     call_order: list[str] = []
     captured_server_args_kwargs: dict[str, object] = {}
 
-    registration_module = ModuleType("sglang_omni_v1.models.ming_omni.registration")
+    registration_module = ModuleType("sglang_omni.models.ming_omni.registration")
 
     def register_ming_hf_config() -> None:
         call_order.append("register")
@@ -376,11 +341,11 @@ def test_ming_thinker_factory_registers_hf_config_before_server_args(
     registration_module.register_ming_hf_config = register_ming_hf_config
     monkeypatch.setitem(
         sys.modules,
-        "sglang_omni_v1.models.ming_omni.registration",
+        "sglang_omni.models.ming_omni.registration",
         registration_module,
     )
 
-    backend_module = ModuleType("sglang_omni_v1.scheduling.sglang_backend")
+    backend_module = ModuleType("sglang_omni.scheduling.sglang_backend")
 
     def build_sglang_server_args(*args, **kwargs):
         del args
@@ -392,11 +357,11 @@ def test_ming_thinker_factory_registers_hf_config_before_server_args(
     backend_module.build_sglang_server_args = build_sglang_server_args
     monkeypatch.setitem(
         sys.modules,
-        "sglang_omni_v1.scheduling.sglang_backend",
+        "sglang_omni.scheduling.sglang_backend",
         backend_module,
     )
 
-    bootstrap_module = ModuleType("sglang_omni_v1.models.ming_omni.bootstrap")
+    bootstrap_module = ModuleType("sglang_omni.models.ming_omni.bootstrap")
 
     def create_thinker_scheduler(*args, **kwargs):
         del args, kwargs
@@ -406,7 +371,7 @@ def test_ming_thinker_factory_registers_hf_config_before_server_args(
     bootstrap_module.create_thinker_scheduler = create_thinker_scheduler
     monkeypatch.setitem(
         sys.modules,
-        "sglang_omni_v1.models.ming_omni.bootstrap",
+        "sglang_omni.models.ming_omni.bootstrap",
         bootstrap_module,
     )
 
@@ -417,7 +382,7 @@ def test_ming_thinker_factory_registers_hf_config_before_server_args(
 
 
 def test_ming_arch_override_uses_composite_llm_config() -> None:
-    from sglang_omni_v1.model_runner.model_worker import ModelWorker
+    from sglang_omni.model_runner.model_worker import ModelWorker
 
     llm_config = SimpleNamespace(
         num_attention_heads=32,
@@ -447,11 +412,11 @@ def test_ming_arch_override_uses_composite_llm_config() -> None:
 def test_ming_init_model_config_registers_auto_config_before_loading(
     monkeypatch,
 ) -> None:
-    from sglang_omni_v1.model_runner.model_worker import ModelWorker
+    from sglang_omni.model_runner.model_worker import ModelWorker
 
     call_order: list[str] = []
 
-    registration_module = ModuleType("sglang_omni_v1.models.ming_omni.registration")
+    registration_module = ModuleType("sglang_omni.models.ming_omni.registration")
 
     def register_ming_hf_config() -> None:
         call_order.append("register")
@@ -459,7 +424,7 @@ def test_ming_init_model_config_registers_auto_config_before_loading(
     registration_module.register_ming_hf_config = register_ming_hf_config
     monkeypatch.setitem(
         sys.modules,
-        "sglang_omni_v1.models.ming_omni.registration",
+        "sglang_omni.models.ming_omni.registration",
         registration_module,
     )
 

--- a/tests/unit_test/ming_omni/test_pipeline.py
+++ b/tests/unit_test/ming_omni/test_pipeline.py
@@ -9,8 +9,6 @@ import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
-import pytest
-
 
 def test_ming_v1_text_config_imports_and_uses_current_stage_schema() -> None:
     from sglang_omni_v1.models.ming_omni.config import MingOmniPipelineConfig
@@ -73,39 +71,6 @@ def test_ming_v1_speech_config_routes_decode_and_talker() -> None:
     assert stages["decode"].terminal is True
     assert stages["talker"].terminal is True
     assert config.terminal_stages == ["decode", "talker"]
-
-
-def test_ming_v1_speech_rejects_talker_inside_thinker_tp_range() -> None:
-    from sglang_omni_v1.models.ming_omni.config import MingOmniSpeechPipelineConfig
-
-    base = MingOmniSpeechPipelineConfig(model_path="dummy")
-    stages = [stage.model_copy(deep=True) for stage in base.stages]
-    for stage in stages:
-        if stage.name == "thinker":
-            stage.gpu = 0
-            stage.tp_size = 2
-        if stage.name == "talker":
-            stage.gpu = 1
-
-    with pytest.raises(ValueError, match="collides"):
-        MingOmniSpeechPipelineConfig(model_path="dummy", stages=stages)
-
-
-def test_ming_v1_speech_allows_talker_outside_thinker_tp_range() -> None:
-    from sglang_omni_v1.models.ming_omni.config import MingOmniSpeechPipelineConfig
-
-    base = MingOmniSpeechPipelineConfig(model_path="dummy")
-    stages = [stage.model_copy(deep=True) for stage in base.stages]
-    for stage in stages:
-        if stage.name == "thinker":
-            stage.gpu = 0
-            stage.tp_size = 2
-        if stage.name == "talker":
-            stage.gpu = 2
-
-    config = MingOmniSpeechPipelineConfig(model_path="dummy", stages=stages)
-
-    assert config.gpu_placement["talker"] == 2
 
 
 def test_ming_v1_speech_launcher_exposes_tp_size_arg(monkeypatch) -> None:
@@ -393,34 +358,6 @@ def test_ming_test_utils_inject_version_for_ming_launchers(monkeypatch) -> None:
         "--version",
         "v1",
     ]
-
-
-def test_ming_examples_expose_v1_version_dispatch() -> None:
-    for path in (
-        Path("examples/run_ming_omni_server.py"),
-        Path("examples/run_ming_omni_speech_server.py"),
-    ):
-        source = path.read_text(encoding="utf-8")
-        assert "--version" in source
-        assert "SGLANG_OMNI_SERVER_VERSION" in source
-        assert 'args.version == "v1"' in source
-        assert "sglang_omni_v1.models.ming_omni.config" in source
-
-
-def test_ming_model_registration_is_owned_by_v1_model_runner() -> None:
-    runner_source = Path(
-        "sglang_omni_v1/model_runner/sglang_model_runner.py"
-    ).read_text(encoding="utf-8")
-    registration_source = Path(
-        "sglang_omni_v1/models/ming_omni/registration.py"
-    ).read_text(encoding="utf-8")
-
-    assert "register_ming_hf_config()" in runner_source
-    assert "register_ming_model_registry()" in runner_source
-    assert 'AutoConfig.register("bailingmm_moe_v2_lite", BailingMM2Config)' in (
-        registration_source
-    )
-    assert 'ModelRegistry.models["BailingMoeV2ForCausalLM"]' in registration_source
 
 
 def test_ming_thinker_factory_registers_hf_config_before_server_args(

--- a/tests/unit_test/ming_omni/test_pipeline.py
+++ b/tests/unit_test/ming_omni/test_pipeline.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
 
-def test_ming_v1_text_config_imports_and_uses_current_stage_schema() -> None:
+def test_ming_text_config_imports_and_uses_current_stage_schema() -> None:
     from sglang_omni.models.ming_omni.config import MingOmniPipelineConfig
 
     config = MingOmniPipelineConfig(model_path="dummy")
@@ -33,7 +33,7 @@ def test_ming_v1_text_config_imports_and_uses_current_stage_schema() -> None:
     assert all("get_next" not in stage.model_dump() for stage in config.stages)
 
 
-def test_ming_v1_speech_config_routes_decode_and_talker() -> None:
+def test_ming_speech_config_routes_decode_and_talker() -> None:
     from sglang_omni.models.ming_omni.config import MingOmniSpeechPipelineConfig
 
     config = MingOmniSpeechPipelineConfig(model_path="dummy")
@@ -73,7 +73,7 @@ def test_ming_v1_speech_config_routes_decode_and_talker() -> None:
     assert config.terminal_stages == ["decode", "talker"]
 
 
-def test_ming_v1_speech_launcher_exposes_tp_size_arg(monkeypatch) -> None:
+def test_ming_speech_launcher_exposes_tp_size_arg(monkeypatch) -> None:
     from examples.run_ming_omni_speech_server import parse_args
 
     monkeypatch.setattr(
@@ -81,8 +81,6 @@ def test_ming_v1_speech_launcher_exposes_tp_size_arg(monkeypatch) -> None:
         "argv",
         [
             "run_ming_omni_speech_server.py",
-            "--version",
-            "v1",
             "--tp-size",
             "4",
         ],
@@ -93,8 +91,8 @@ def test_ming_v1_speech_launcher_exposes_tp_size_arg(monkeypatch) -> None:
     assert args.tp_size == 4
 
 
-def test_ming_v1_speech_launcher_places_thinker_tp_and_talker(monkeypatch) -> None:
-    from examples.run_ming_omni_speech_server import _launch_v1_speech_server
+def test_ming_speech_launcher_places_thinker_tp_and_talker(monkeypatch) -> None:
+    from examples.run_ming_omni_speech_server import _launch_speech_server
 
     captured: dict[str, object] = {}
     serve_module = ModuleType("sglang_omni.serve")
@@ -119,7 +117,7 @@ def test_ming_v1_speech_launcher_places_thinker_tp_and_talker(monkeypatch) -> No
         model_name="ming-omni",
     )
 
-    _launch_v1_speech_server(args)
+    _launch_speech_server(args)
 
     config = captured["config"]
     stages = {stage.name: stage for stage in config.stages}
@@ -134,7 +132,7 @@ def test_ming_v1_speech_launcher_places_thinker_tp_and_talker(monkeypatch) -> No
     assert overrides["mem_fraction_static"] == 0.8
 
 
-def test_ming_v1_stages_import_light_and_accept_mp_injection_args() -> None:
+def test_ming_stages_import_light_and_accept_mp_injection_args() -> None:
     stages = importlib.import_module("sglang_omni.models.ming_omni.stages")
 
     sig = inspect.signature(stages.create_sglang_thinker_executor_from_config)
@@ -144,7 +142,7 @@ def test_ming_v1_stages_import_light_and_accept_mp_injection_args() -> None:
     assert "nccl_port" in sig.parameters
 
 
-def test_ming_talker_factory_returns_v1_scheduler_contract(monkeypatch) -> None:
+def test_ming_talker_factory_returns_scheduler_contract(monkeypatch) -> None:
     talker_module = ModuleType(
         "sglang_omni.models.ming_omni.components.talker_executor"
     )
@@ -207,8 +205,8 @@ def test_ming_audio_encoder_moves_inputs_to_component_device() -> None:
     assert "audio_feats_lengths = audio_feats_lengths.to(device=self._device)" in source
 
 
-def test_ming_v1_text_launcher_places_tp_ranks_on_distinct_gpus(monkeypatch) -> None:
-    from examples.run_ming_omni_server import _launch_v1_text_server
+def test_ming_text_launcher_places_tp_ranks_on_distinct_gpus(monkeypatch) -> None:
+    from examples.run_ming_omni_server import _launch_text_server
 
     captured: dict[str, object] = {}
     serve_module = ModuleType("sglang_omni.serve")
@@ -236,7 +234,7 @@ def test_ming_v1_text_launcher_places_tp_ranks_on_distinct_gpus(monkeypatch) -> 
         model_name="ming-omni",
     )
 
-    _launch_v1_text_server(args)
+    _launch_text_server(args)
 
     config = captured["config"]
     thinker = next(stage for stage in config.stages if stage.name == "thinker")
@@ -244,8 +242,8 @@ def test_ming_v1_text_launcher_places_tp_ranks_on_distinct_gpus(monkeypatch) -> 
     assert thinker.gpu == [0, 1, 2]
 
 
-def test_ming_v1_text_launcher_allows_encoder_gpu_overrides(monkeypatch) -> None:
-    from examples.run_ming_omni_server import _launch_v1_text_server
+def test_ming_text_launcher_allows_encoder_gpu_overrides(monkeypatch) -> None:
+    from examples.run_ming_omni_server import _launch_text_server
 
     captured: dict[str, object] = {}
     serve_module = ModuleType("sglang_omni.serve")
@@ -273,7 +271,7 @@ def test_ming_v1_text_launcher_allows_encoder_gpu_overrides(monkeypatch) -> None
         model_name="ming-omni",
     )
 
-    _launch_v1_text_server(args)
+    _launch_text_server(args)
 
     config = captured["config"]
     stages = {stage.name: stage for stage in config.stages}
@@ -282,10 +280,10 @@ def test_ming_v1_text_launcher_allows_encoder_gpu_overrides(monkeypatch) -> None
     assert stages["image_encoder"].gpu == 4
 
 
-def test_ming_v1_text_launcher_can_build_thinker_only_smoke_pipeline(
+def test_ming_text_launcher_can_build_thinker_only_smoke_pipeline(
     monkeypatch,
 ) -> None:
-    from examples.run_ming_omni_server import _launch_v1_text_server
+    from examples.run_ming_omni_server import _launch_text_server
 
     captured: dict[str, object] = {}
     serve_module = ModuleType("sglang_omni.serve")
@@ -313,7 +311,7 @@ def test_ming_v1_text_launcher_can_build_thinker_only_smoke_pipeline(
         model_name="ming-omni",
     )
 
-    _launch_v1_text_server(args)
+    _launch_text_server(args)
 
     config = captured["config"]
     stages = {stage.name: stage for stage in config.stages}

--- a/tests/unit_test/ming_omni/test_pipeline.py
+++ b/tests/unit_test/ming_omni/test_pipeline.py
@@ -1,0 +1,564 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Import/config/version-dispatch tests."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+def test_ming_v1_text_config_imports_and_uses_current_stage_schema() -> None:
+    from sglang_omni_v1.models.ming_omni.config import MingOmniPipelineConfig
+
+    config = MingOmniPipelineConfig(model_path="dummy")
+
+    assert [stage.name for stage in config.stages] == [
+        "preprocessing",
+        "audio_encoder",
+        "image_encoder",
+        "mm_aggregate",
+        "thinker",
+        "decode",
+    ]
+    assert config.terminal_stages == ["decode"]
+    assert all(
+        stage.factory.startswith("sglang_omni_v1.models.ming_omni.stages.create_")
+        for stage in config.stages
+    )
+    assert all("executor" not in stage.model_dump() for stage in config.stages)
+    assert all("input_handler" not in stage.model_dump() for stage in config.stages)
+    assert all("get_next" not in stage.model_dump() for stage in config.stages)
+
+
+def test_ming_v1_speech_config_routes_decode_and_talker() -> None:
+    from sglang_omni_v1.models.ming_omni.config import MingOmniSpeechPipelineConfig
+
+    config = MingOmniSpeechPipelineConfig(model_path="dummy")
+    stages = {stage.name: stage for stage in config.stages}
+
+    assert list(stages) == [
+        "preprocessing",
+        "audio_encoder",
+        "image_encoder",
+        "mm_aggregate",
+        "thinker",
+        "decode",
+        "talker",
+    ]
+    assert stages["preprocessing"].next == [
+        "audio_encoder",
+        "image_encoder",
+        "mm_aggregate",
+    ]
+    assert set(stages["preprocessing"].project_payload) == {
+        "audio_encoder",
+        "image_encoder",
+        "mm_aggregate",
+    }
+    assert stages["mm_aggregate"].wait_for == [
+        "preprocessing",
+        "audio_encoder",
+        "image_encoder",
+    ]
+    assert (
+        stages["mm_aggregate"].merge_fn
+        == "sglang_omni_v1.models.ming_omni.pipeline.merge.merge_for_thinker"
+    )
+    assert stages["thinker"].next == ["decode", "talker"]
+    assert stages["decode"].terminal is True
+    assert stages["talker"].terminal is True
+    assert config.terminal_stages == ["decode", "talker"]
+
+
+def test_ming_v1_speech_rejects_talker_inside_thinker_tp_range() -> None:
+    from sglang_omni_v1.models.ming_omni.config import MingOmniSpeechPipelineConfig
+
+    base = MingOmniSpeechPipelineConfig(model_path="dummy")
+    stages = [stage.model_copy(deep=True) for stage in base.stages]
+    for stage in stages:
+        if stage.name == "thinker":
+            stage.gpu = 0
+            stage.tp_size = 2
+        if stage.name == "talker":
+            stage.gpu = 1
+
+    with pytest.raises(ValueError, match="collides"):
+        MingOmniSpeechPipelineConfig(model_path="dummy", stages=stages)
+
+
+def test_ming_v1_speech_allows_talker_outside_thinker_tp_range() -> None:
+    from sglang_omni_v1.models.ming_omni.config import MingOmniSpeechPipelineConfig
+
+    base = MingOmniSpeechPipelineConfig(model_path="dummy")
+    stages = [stage.model_copy(deep=True) for stage in base.stages]
+    for stage in stages:
+        if stage.name == "thinker":
+            stage.gpu = 0
+            stage.tp_size = 2
+        if stage.name == "talker":
+            stage.gpu = 2
+
+    config = MingOmniSpeechPipelineConfig(model_path="dummy", stages=stages)
+
+    assert config.gpu_placement["talker"] == 2
+
+
+def test_ming_v1_speech_launcher_exposes_tp_size_arg(monkeypatch) -> None:
+    from examples.run_ming_omni_speech_server import parse_args
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_ming_omni_speech_server.py",
+            "--version",
+            "v1",
+            "--tp-size",
+            "4",
+        ],
+    )
+
+    args = parse_args()
+
+    assert args.tp_size == 4
+
+
+def test_ming_v1_speech_launcher_places_thinker_tp_and_talker(monkeypatch) -> None:
+    from examples.run_ming_omni_speech_server import _launch_v1_speech_server
+
+    captured: dict[str, object] = {}
+    serve_module = ModuleType("sglang_omni_v1.serve")
+
+    def fake_launch_server(config, **kwargs):
+        captured["config"] = config
+        captured["kwargs"] = kwargs
+
+    serve_module.launch_server = fake_launch_server
+    monkeypatch.setitem(sys.modules, "sglang_omni_v1.serve", serve_module)
+
+    args = SimpleNamespace(
+        model_path="dummy",
+        relay_backend="shm",
+        tp_size=4,
+        gpu_thinker=0,
+        gpu_talker=4,
+        voice="DB30",
+        mem_fraction_static=0.8,
+        host="127.0.0.1",
+        port=8000,
+        model_name="ming-omni",
+    )
+
+    _launch_v1_speech_server(args)
+
+    config = captured["config"]
+    stages = {stage.name: stage for stage in config.stages}
+    thinker = stages["thinker"]
+    talker = stages["talker"]
+    overrides = thinker.factory_args["server_args_overrides"]
+
+    assert thinker.tp_size == 4
+    assert thinker.gpu == [0, 1, 2, 3]
+    assert talker.gpu == 4
+    assert overrides["disable_custom_all_reduce"] is True
+    assert overrides["mem_fraction_static"] == 0.8
+
+
+def test_ming_v1_stages_import_light_and_accept_mp_injection_args() -> None:
+    stages = importlib.import_module("sglang_omni_v1.models.ming_omni.stages")
+
+    sig = inspect.signature(stages.create_sglang_thinker_executor_from_config)
+
+    assert "tp_rank" in sig.parameters
+    assert "tp_size" in sig.parameters
+    assert "nccl_port" in sig.parameters
+
+
+def test_ming_talker_factory_returns_v1_scheduler_contract(monkeypatch) -> None:
+    talker_module = ModuleType(
+        "sglang_omni_v1.models.ming_omni.components.talker_executor"
+    )
+
+    class FakeMingTalkerExecutor:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def start(self):
+            pass
+
+        async def add_request(self, payload):
+            self.payload = payload
+
+        async def get_result(self):
+            return getattr(self, "payload", None)
+
+    talker_module.MingTalkerExecutor = FakeMingTalkerExecutor
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni_v1.models.ming_omni.components.talker_executor",
+        talker_module,
+    )
+
+    weight_loader_module = ModuleType("sglang_omni_v1.models.weight_loader")
+    weight_loader_module.resolve_model_path = (
+        lambda model_path: f"/resolved/{model_path}"
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni_v1.models.weight_loader",
+        weight_loader_module,
+    )
+
+    from sglang_omni_v1.models.ming_omni.stages import create_talker_executor
+
+    scheduler = create_talker_executor(
+        model_path="dummy",
+        talker_model_path="talker",
+        device="cuda:1",
+        voice="DB30",
+    )
+
+    assert hasattr(scheduler, "inbox")
+    assert hasattr(scheduler, "outbox")
+    assert callable(scheduler.start)
+    assert callable(scheduler.stop)
+    assert callable(scheduler.abort)
+    assert not isinstance(scheduler, FakeMingTalkerExecutor)
+
+
+def test_ming_audio_encoder_moves_inputs_to_component_device() -> None:
+    source = Path(
+        "sglang_omni_v1/models/ming_omni/components/audio_encoder.py"
+    ).read_text(encoding="utf-8")
+
+    assert (
+        "audio_feats = audio_feats.to(device=self._device, dtype=self._dtype)" in source
+    )
+    assert "audio_feats_lengths = audio_feats_lengths.to(device=self._device)" in source
+
+
+def test_ming_v1_text_launcher_places_tp_ranks_on_distinct_gpus(monkeypatch) -> None:
+    from examples.run_ming_omni_server import _launch_v1_text_server
+
+    captured: dict[str, object] = {}
+    serve_module = ModuleType("sglang_omni_v1.serve")
+
+    def fake_launch_server(config, **kwargs):
+        captured["config"] = config
+        captured["kwargs"] = kwargs
+
+    serve_module.launch_server = fake_launch_server
+    monkeypatch.setitem(sys.modules, "sglang_omni_v1.serve", serve_module)
+
+    args = SimpleNamespace(
+        model_path="dummy",
+        relay_backend="shm",
+        tp_size=3,
+        quantization=None,
+        cpu_offload_gb=0,
+        gpu_audio_encoder=None,
+        gpu_image_encoder=None,
+        thinker_only=False,
+        mem_fraction_static=None,
+        thinker_max_seq_len=8192,
+        host="127.0.0.1",
+        port=8000,
+        model_name="ming-omni",
+    )
+
+    _launch_v1_text_server(args)
+
+    config = captured["config"]
+    thinker = next(stage for stage in config.stages if stage.name == "thinker")
+    assert thinker.tp_size == 3
+    assert thinker.gpu == [0, 1, 2]
+
+
+def test_ming_v1_text_launcher_allows_encoder_gpu_overrides(monkeypatch) -> None:
+    from examples.run_ming_omni_server import _launch_v1_text_server
+
+    captured: dict[str, object] = {}
+    serve_module = ModuleType("sglang_omni_v1.serve")
+
+    def fake_launch_server(config, **kwargs):
+        del kwargs
+        captured["config"] = config
+
+    serve_module.launch_server = fake_launch_server
+    monkeypatch.setitem(sys.modules, "sglang_omni_v1.serve", serve_module)
+
+    args = SimpleNamespace(
+        model_path="dummy",
+        relay_backend="shm",
+        tp_size=4,
+        quantization=None,
+        cpu_offload_gb=0,
+        gpu_audio_encoder=4,
+        gpu_image_encoder=4,
+        thinker_only=False,
+        mem_fraction_static=None,
+        thinker_max_seq_len=8192,
+        host="127.0.0.1",
+        port=8000,
+        model_name="ming-omni",
+    )
+
+    _launch_v1_text_server(args)
+
+    config = captured["config"]
+    stages = {stage.name: stage for stage in config.stages}
+    assert stages["thinker"].gpu == [0, 1, 2, 3]
+    assert stages["audio_encoder"].gpu == 4
+    assert stages["image_encoder"].gpu == 4
+
+
+def test_ming_v1_text_launcher_can_build_thinker_only_smoke_pipeline(
+    monkeypatch,
+) -> None:
+    from examples.run_ming_omni_server import _launch_v1_text_server
+
+    captured: dict[str, object] = {}
+    serve_module = ModuleType("sglang_omni_v1.serve")
+
+    def fake_launch_server(config, **kwargs):
+        del kwargs
+        captured["config"] = config
+
+    serve_module.launch_server = fake_launch_server
+    monkeypatch.setitem(sys.modules, "sglang_omni_v1.serve", serve_module)
+
+    args = SimpleNamespace(
+        model_path="dummy",
+        relay_backend="shm",
+        tp_size=4,
+        quantization=None,
+        cpu_offload_gb=0,
+        gpu_audio_encoder=None,
+        gpu_image_encoder=None,
+        thinker_only=True,
+        mem_fraction_static=None,
+        thinker_max_seq_len=8192,
+        host="127.0.0.1",
+        port=8000,
+        model_name="ming-omni",
+    )
+
+    _launch_v1_text_server(args)
+
+    config = captured["config"]
+    stages = {stage.name: stage for stage in config.stages}
+    assert list(stages) == ["preprocessing", "mm_aggregate", "thinker", "decode"]
+    assert stages["preprocessing"].next == "mm_aggregate"
+    assert set(stages["preprocessing"].project_payload) == {"mm_aggregate"}
+    assert stages["mm_aggregate"].wait_for == ["preprocessing"]
+    assert stages["thinker"].gpu == [0, 1, 2, 3]
+    assert stages["thinker"].tp_size == 4
+
+
+def test_ming_test_utils_inject_version_for_ming_launchers(monkeypatch) -> None:
+    from tests.utils import _inject_server_version
+
+    monkeypatch.setenv("SGLANG_OMNI_SERVER_VERSION", "v1")
+
+    assert _inject_server_version(
+        ["python", "examples/run_qwen3_omni_server.py", "--port", "8000"]
+    ) == [
+        "python",
+        "examples/run_qwen3_omni_server.py",
+        "--port",
+        "8000",
+        "--version",
+        "v1",
+    ]
+    assert _inject_server_version(
+        ["python", "examples/run_ming_omni_server.py", "--port", "8000"]
+    ) == [
+        "python",
+        "examples/run_ming_omni_server.py",
+        "--port",
+        "8000",
+        "--version",
+        "v1",
+    ]
+    assert _inject_server_version(
+        ["python", "examples/run_ming_omni_speech_server.py"]
+    ) == [
+        "python",
+        "examples/run_ming_omni_speech_server.py",
+        "--version",
+        "v1",
+    ]
+
+
+def test_ming_examples_expose_v1_version_dispatch() -> None:
+    for path in (
+        Path("examples/run_ming_omni_server.py"),
+        Path("examples/run_ming_omni_speech_server.py"),
+    ):
+        source = path.read_text(encoding="utf-8")
+        assert "--version" in source
+        assert "SGLANG_OMNI_SERVER_VERSION" in source
+        assert 'args.version == "v1"' in source
+        assert "sglang_omni_v1.models.ming_omni.config" in source
+
+
+def test_ming_model_registration_is_owned_by_v1_model_runner() -> None:
+    runner_source = Path(
+        "sglang_omni_v1/model_runner/sglang_model_runner.py"
+    ).read_text(encoding="utf-8")
+    registration_source = Path(
+        "sglang_omni_v1/models/ming_omni/registration.py"
+    ).read_text(encoding="utf-8")
+
+    assert "register_ming_hf_config()" in runner_source
+    assert "register_ming_model_registry()" in runner_source
+    assert 'AutoConfig.register("bailingmm_moe_v2_lite", BailingMM2Config)' in (
+        registration_source
+    )
+    assert 'ModelRegistry.models["BailingMoeV2ForCausalLM"]' in registration_source
+
+
+def test_ming_thinker_factory_registers_hf_config_before_server_args(
+    monkeypatch,
+) -> None:
+    from sglang_omni_v1.models.ming_omni import stages
+
+    call_order: list[str] = []
+    captured_server_args_kwargs: dict[str, object] = {}
+
+    registration_module = ModuleType("sglang_omni_v1.models.ming_omni.registration")
+
+    def register_ming_hf_config() -> None:
+        call_order.append("register")
+
+    registration_module.register_ming_hf_config = register_ming_hf_config
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni_v1.models.ming_omni.registration",
+        registration_module,
+    )
+
+    backend_module = ModuleType("sglang_omni_v1.scheduling.sglang_backend")
+
+    def build_sglang_server_args(*args, **kwargs):
+        del args
+        assert call_order == ["register"]
+        call_order.append("build_server_args")
+        captured_server_args_kwargs.update(kwargs)
+        return SimpleNamespace(tp_size=1)
+
+    backend_module.build_sglang_server_args = build_sglang_server_args
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni_v1.scheduling.sglang_backend",
+        backend_module,
+    )
+
+    bootstrap_module = ModuleType("sglang_omni_v1.models.ming_omni.bootstrap")
+
+    def create_thinker_scheduler(*args, **kwargs):
+        del args, kwargs
+        call_order.append("create_scheduler")
+        return object()
+
+    bootstrap_module.create_thinker_scheduler = create_thinker_scheduler
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni_v1.models.ming_omni.bootstrap",
+        bootstrap_module,
+    )
+
+    stages.create_sglang_thinker_executor_from_config(model_path="dummy")
+
+    assert call_order == ["register", "build_server_args", "create_scheduler"]
+    assert captured_server_args_kwargs["trust_remote_code"] is False
+
+
+def test_ming_arch_override_uses_composite_llm_config() -> None:
+    from sglang_omni_v1.model_runner.model_worker import ModelWorker
+
+    llm_config = SimpleNamespace(
+        num_attention_heads=32,
+        num_key_value_heads=4,
+        hidden_size=4096,
+        num_hidden_layers=32,
+    )
+    model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(architectures=[], llm_config=llm_config),
+        hf_text_config=None,
+        num_attention_heads=None,
+        num_key_value_heads=None,
+        hidden_size=None,
+        num_hidden_layers=None,
+    )
+
+    ModelWorker._apply_arch_override(model_config, "BailingMoeV2ForCausalLM")
+
+    assert model_config.hf_config.architectures == ["BailingMoeV2ForCausalLM"]
+    assert model_config.hf_text_config is llm_config
+    assert model_config.num_attention_heads == 32
+    assert model_config.num_key_value_heads == 4
+    assert model_config.hidden_size == 4096
+    assert model_config.num_hidden_layers == 32
+
+
+def test_ming_init_model_config_registers_auto_config_before_loading(
+    monkeypatch,
+) -> None:
+    from sglang_omni_v1.model_runner.model_worker import ModelWorker
+
+    call_order: list[str] = []
+
+    registration_module = ModuleType("sglang_omni_v1.models.ming_omni.registration")
+
+    def register_ming_hf_config() -> None:
+        call_order.append("register")
+
+    registration_module.register_ming_hf_config = register_ming_hf_config
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni_v1.models.ming_omni.registration",
+        registration_module,
+    )
+
+    model_config_module = ModuleType("sglang.srt.configs.model_config")
+
+    class FakeModelConfig:
+        @classmethod
+        def from_server_args(cls, **kwargs):
+            del kwargs
+            call_order.append("from_server_args")
+            return SimpleNamespace(
+                hf_config=SimpleNamespace(
+                    architectures=[],
+                    llm_config=SimpleNamespace(
+                        num_attention_heads=32,
+                        num_key_value_heads=4,
+                        hidden_size=4096,
+                        num_hidden_layers=32,
+                    ),
+                )
+            )
+
+    model_config_module.ModelConfig = FakeModelConfig
+    monkeypatch.setitem(sys.modules, "sglang", ModuleType("sglang"))
+    monkeypatch.setitem(sys.modules, "sglang.srt", ModuleType("sglang.srt"))
+    monkeypatch.setitem(
+        sys.modules, "sglang.srt.configs", ModuleType("sglang.srt.configs")
+    )
+    monkeypatch.setitem(
+        sys.modules, "sglang.srt.configs.model_config", model_config_module
+    )
+
+    worker = object.__new__(ModelWorker)
+    worker.server_args = SimpleNamespace(model_path="dummy", revision=None)
+    worker.model_arch_override = "BailingMoeV2ForCausalLM"
+
+    worker._init_model_config()
+
+    assert call_order == ["register", "from_server_args"]

--- a/tests/unit_test/ming_omni/test_pipeline.py
+++ b/tests/unit_test/ming_omni/test_pipeline.py
@@ -195,13 +195,11 @@ def test_ming_talker_factory_returns_scheduler_contract(monkeypatch) -> None:
 
 
 def test_ming_audio_encoder_moves_inputs_to_component_device() -> None:
-    source = Path(
-        "sglang_omni/models/ming_omni/components/audio_encoder.py"
-    ).read_text(encoding="utf-8")
-
-    assert (
-        "audio_feats = audio_feats.to(device=self._device, dtype=self._dtype)" in source
+    source = Path("sglang_omni/models/ming_omni/components/audio_encoder.py").read_text(
+        encoding="utf-8"
     )
+
+    assert "audio_feats = audio_feats.to(device=self._device)" in source
     assert "audio_feats_lengths = audio_feats_lengths.to(device=self._device)" in source
 
 

--- a/tests/unit_test/ming_omni/test_talker.py
+++ b/tests/unit_test/ming_omni/test_talker.py
@@ -15,8 +15,8 @@ import pytest
 def test_ming_v1_talker_add_request_propagates_generation_errors(
     monkeypatch,
 ) -> None:
-    module_name = "sglang_omni_v1.models.ming_omni.components.talker_executor"
-    parent_name = "sglang_omni_v1.models.ming_omni.components"
+    module_name = "sglang_omni.models.ming_omni.components.talker_executor"
+    parent_name = "sglang_omni.models.ming_omni.components"
     sys.modules.pop(module_name, None)
 
     fake_torch = ModuleType("torch")
@@ -34,7 +34,7 @@ def test_ming_v1_talker_add_request_propagates_generation_errors(
 
     try:
         module = importlib.import_module(module_name)
-        from sglang_omni_v1.proto import OmniRequest, StagePayload
+        from sglang_omni.proto import OmniRequest, StagePayload
 
         executor = module.MingTalkerExecutor(model_path="/fake/model/path")
         payload = StagePayload(
@@ -61,8 +61,8 @@ def test_ming_v1_talker_add_request_propagates_generation_errors(
 
 
 def test_ming_v1_talker_skips_text_only_requests(monkeypatch) -> None:
-    module_name = "sglang_omni_v1.models.ming_omni.components.talker_executor"
-    parent_name = "sglang_omni_v1.models.ming_omni.components"
+    module_name = "sglang_omni.models.ming_omni.components.talker_executor"
+    parent_name = "sglang_omni.models.ming_omni.components"
     sys.modules.pop(module_name, None)
 
     fake_torch = ModuleType("torch")
@@ -80,7 +80,7 @@ def test_ming_v1_talker_skips_text_only_requests(monkeypatch) -> None:
 
     try:
         module = importlib.import_module(module_name)
-        from sglang_omni_v1.proto import OmniRequest, StagePayload
+        from sglang_omni.proto import OmniRequest, StagePayload
 
         executor = module.MingTalkerExecutor(model_path="/fake/model/path")
         payload = StagePayload(
@@ -128,7 +128,7 @@ def _waveform_payload(values: np.ndarray) -> dict:
 
 
 def test_default_result_builder_merges_decode_and_talker_audio() -> None:
-    from sglang_omni_v1.client.client import Client
+    from sglang_omni.client.client import Client
 
     waveform = np.array([0.1, -0.2, 0.3], dtype=np.float32)
 
@@ -154,7 +154,7 @@ def test_default_result_builder_merges_decode_and_talker_audio() -> None:
 
 
 def test_default_result_builder_keeps_text_modality_for_skipped_talker() -> None:
-    from sglang_omni_v1.client.client import Client
+    from sglang_omni.client.client import Client
 
     chunk = Client._default_result_builder(
         "req-text",
@@ -175,7 +175,7 @@ def test_default_result_builder_keeps_text_modality_for_skipped_talker() -> None
 
 
 def test_default_result_builder_still_merges_decode_and_code2wav_audio() -> None:
-    from sglang_omni_v1.client.client import Client
+    from sglang_omni.client.client import Client
 
     waveform = np.array([1.0, 0.5], dtype=np.float32)
 

--- a/tests/unit_test/ming_omni/test_talker.py
+++ b/tests/unit_test/ming_omni/test_talker.py
@@ -6,22 +6,10 @@ from __future__ import annotations
 import asyncio
 import importlib
 import sys
-from pathlib import Path
 from types import ModuleType
 
 import numpy as np
 import pytest
-
-TALKER_EXECUTOR_PATH = Path(
-    "sglang_omni_v1/models/ming_omni/components/talker_executor.py"
-)
-
-
-def test_ming_v1_talker_executor_does_not_import_nonexistent_executor() -> None:
-    source = TALKER_EXECUTOR_PATH.read_text(encoding="utf-8")
-
-    assert "sglang_omni_v1.executors" not in source
-    assert "class MingTalkerExecutor:" in source
 
 
 def test_ming_v1_talker_add_request_propagates_generation_errors(

--- a/tests/unit_test/ming_omni/test_talker.py
+++ b/tests/unit_test/ming_omni/test_talker.py
@@ -12,7 +12,7 @@ import numpy as np
 import pytest
 
 
-def test_ming_v1_talker_add_request_propagates_generation_errors(
+def test_ming_talker_add_request_propagates_generation_errors(
     monkeypatch,
 ) -> None:
     module_name = "sglang_omni.models.ming_omni.components.talker_executor"
@@ -60,7 +60,7 @@ def test_ming_v1_talker_add_request_propagates_generation_errors(
             delattr(parent, "talker_executor")
 
 
-def test_ming_v1_talker_skips_text_only_requests(monkeypatch) -> None:
+def test_ming_talker_skips_text_only_requests(monkeypatch) -> None:
     module_name = "sglang_omni.models.ming_omni.components.talker_executor"
     parent_name = "sglang_omni.models.ming_omni.components"
     sys.modules.pop(module_name, None)

--- a/tests/unit_test/ming_omni/test_talker.py
+++ b/tests/unit_test/ming_omni/test_talker.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Speech/talker terminal tests."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import numpy as np
+import pytest
+
+TALKER_EXECUTOR_PATH = Path(
+    "sglang_omni_v1/models/ming_omni/components/talker_executor.py"
+)
+
+
+def test_ming_v1_talker_executor_does_not_import_nonexistent_executor() -> None:
+    source = TALKER_EXECUTOR_PATH.read_text(encoding="utf-8")
+
+    assert "sglang_omni_v1.executors" not in source
+    assert "class MingTalkerExecutor:" in source
+
+
+def test_ming_v1_talker_add_request_propagates_generation_errors(
+    monkeypatch,
+) -> None:
+    module_name = "sglang_omni_v1.models.ming_omni.components.talker_executor"
+    parent_name = "sglang_omni_v1.models.ming_omni.components"
+    sys.modules.pop(module_name, None)
+
+    fake_torch = ModuleType("torch")
+    fake_torch.bfloat16 = "bfloat16"
+    fake_torch.Tensor = object
+
+    def no_grad():
+        def decorator(fn):
+            return fn
+
+        return decorator
+
+    fake_torch.no_grad = no_grad
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    try:
+        module = importlib.import_module(module_name)
+        from sglang_omni_v1.proto import OmniRequest, StagePayload
+
+        executor = module.MingTalkerExecutor(model_path="/fake/model/path")
+        payload = StagePayload(
+            request_id="req-1",
+            request=OmniRequest(inputs="hello"),
+            data={},
+        )
+        injected = RuntimeError("talker failed")
+
+        monkeypatch.setattr(executor, "_extract_text", lambda _payload: "hello")
+
+        def raise_error(_text):
+            raise injected
+
+        monkeypatch.setattr(executor, "_generate_speech", raise_error)
+
+        with pytest.raises(RuntimeError, match="talker failed"):
+            asyncio.run(executor.add_request(payload))
+    finally:
+        sys.modules.pop(module_name, None)
+        parent = sys.modules.get(parent_name)
+        if parent is not None and hasattr(parent, "talker_executor"):
+            delattr(parent, "talker_executor")
+
+
+def test_ming_v1_talker_skips_text_only_requests(monkeypatch) -> None:
+    module_name = "sglang_omni_v1.models.ming_omni.components.talker_executor"
+    parent_name = "sglang_omni_v1.models.ming_omni.components"
+    sys.modules.pop(module_name, None)
+
+    fake_torch = ModuleType("torch")
+    fake_torch.bfloat16 = "bfloat16"
+    fake_torch.Tensor = object
+
+    def no_grad():
+        def decorator(fn):
+            return fn
+
+        return decorator
+
+    fake_torch.no_grad = no_grad
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    try:
+        module = importlib.import_module(module_name)
+        from sglang_omni_v1.proto import OmniRequest, StagePayload
+
+        executor = module.MingTalkerExecutor(model_path="/fake/model/path")
+        payload = StagePayload(
+            request_id="req-text",
+            request=OmniRequest(
+                inputs="hello",
+                metadata={"output_modalities": ["text"]},
+            ),
+            data={"thinker_out": {"output_ids": [1, 2, 3]}},
+        )
+        monkeypatch.setattr(
+            executor,
+            "_extract_text",
+            lambda _payload: pytest.fail("text-only request should not decode text"),
+        )
+        monkeypatch.setattr(
+            executor,
+            "_generate_speech",
+            lambda _text: pytest.fail("text-only request should not generate speech"),
+        )
+
+        async def run_request():
+            await executor.add_request(payload)
+            return await executor.get_result()
+
+        result = asyncio.run(run_request())
+
+        assert result.request_id == "req-text"
+        assert result.data["audio_waveform"] is None
+        assert result.data["skipped"] is True
+    finally:
+        sys.modules.pop(module_name, None)
+        parent = sys.modules.get(parent_name)
+        if parent is not None and hasattr(parent, "talker_executor"):
+            delattr(parent, "talker_executor")
+
+
+def _waveform_payload(values: np.ndarray) -> dict:
+    return {
+        "audio_waveform": values.tobytes(),
+        "audio_waveform_dtype": str(values.dtype),
+        "audio_waveform_shape": list(values.shape),
+        "sample_rate": 44100,
+    }
+
+
+def test_default_result_builder_merges_decode_and_talker_audio() -> None:
+    from sglang_omni_v1.client.client import Client
+
+    waveform = np.array([0.1, -0.2, 0.3], dtype=np.float32)
+
+    chunk = Client._default_result_builder(
+        "req-1",
+        {
+            "decode": {
+                "text": "hi",
+                "usage": {"prompt_tokens": 2, "completion_tokens": 1},
+            },
+            "talker": _waveform_payload(waveform),
+        },
+    )
+
+    assert chunk.text == "hi"
+    assert chunk.modality == "audio"
+    assert chunk.sample_rate == 44100
+    np.testing.assert_array_equal(chunk.audio_data, waveform)
+    assert chunk.usage is not None
+    assert chunk.usage.prompt_tokens == 2
+    assert chunk.usage.completion_tokens == 1
+    assert chunk.usage.total_tokens == 3
+
+
+def test_default_result_builder_keeps_text_modality_for_skipped_talker() -> None:
+    from sglang_omni_v1.client.client import Client
+
+    chunk = Client._default_result_builder(
+        "req-text",
+        {
+            "decode": {"text": "hello"},
+            "talker": {
+                "audio_waveform": None,
+                "sample_rate": 44100,
+                "duration": 0.0,
+                "skipped": True,
+            },
+        },
+    )
+
+    assert chunk.text == "hello"
+    assert chunk.modality == "text"
+    assert chunk.audio_data is None
+
+
+def test_default_result_builder_still_merges_decode_and_code2wav_audio() -> None:
+    from sglang_omni_v1.client.client import Client
+
+    waveform = np.array([1.0, 0.5], dtype=np.float32)
+
+    chunk = Client._default_result_builder(
+        "req-2",
+        {
+            "decode": {"text": "hello"},
+            "code2wav": {
+                **_waveform_payload(waveform),
+                "usage": {"prompt_tokens": 5, "completion_tokens": 7},
+            },
+        },
+    )
+
+    assert chunk.text == "hello"
+    assert chunk.modality == "audio"
+    np.testing.assert_array_equal(chunk.audio_data, waveform)
+    assert chunk.usage is not None
+    assert chunk.usage.prompt_tokens == 5
+    assert chunk.usage.completion_tokens == 7
+    assert chunk.usage.total_tokens == 12

--- a/tests/unit_test/ming_omni/test_thinker.py
+++ b/tests/unit_test/ming_omni/test_thinker.py
@@ -11,16 +11,16 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 
-BOOTSTRAP_PATH = Path("sglang_omni_v1/models/ming_omni/bootstrap.py")
-RUNNER_PATH = Path("sglang_omni_v1/model_runner/ming_thinker_model_runner.py")
-MING_THINKER_PATH = Path("sglang_omni_v1/models/ming_omni/thinker.py")
+BOOTSTRAP_PATH = Path("sglang_omni/models/ming_omni/bootstrap.py")
+RUNNER_PATH = Path("sglang_omni/model_runner/ming_thinker_model_runner.py")
+MING_THINKER_PATH = Path("sglang_omni/models/ming_omni/thinker.py")
 MING_IMAGE_ENCODER_PATH = Path(
-    "sglang_omni_v1/models/ming_omni/components/image_encoder.py"
+    "sglang_omni/models/ming_omni/components/image_encoder.py"
 )
 MING_PREPROCESSOR_PATH = Path(
-    "sglang_omni_v1/models/ming_omni/components/preprocessor.py"
+    "sglang_omni/models/ming_omni/components/preprocessor.py"
 )
-VENDOR_SGLANG_LAYERS_PATH = Path("sglang_omni_v1/vendor/sglang/layers.py")
+VENDOR_SGLANG_LAYERS_PATH = Path("sglang_omni/vendor/sglang/layers.py")
 
 
 def _read(path: Path) -> str:
@@ -75,8 +75,8 @@ def test_ming_thinker_runner_uses_ming_token_id_contract() -> None:
 def test_ming_thinker_weight_loader_uses_v1_qwen3_helper_path() -> None:
     source = _read(MING_THINKER_PATH)
 
-    assert "sglang_omni_v1.models.qwen3_omni.thinker" not in source
-    assert "sglang_omni_v1.models.qwen3_omni.components.thinker_model" in source
+    assert "sglang_omni.models.qwen3_omni.thinker" not in source
+    assert "sglang_omni.models.qwen3_omni.components.thinker_model" in source
     assert "extract_fused_experts" in source
 
 
@@ -107,15 +107,15 @@ def test_vendored_sglang_layers_do_not_import_removed_sampling_symbol() -> None:
 def test_ming_vision_block_kwargs_pass_head_size_only_when_supported(
     monkeypatch,
 ) -> None:
-    weight_loader_module = ModuleType("sglang_omni_v1.models.weight_loader")
+    weight_loader_module = ModuleType("sglang_omni.models.weight_loader")
     weight_loader_module.default_weight_loader = lambda *args, **kwargs: None
     monkeypatch.setitem(
         sys.modules,
-        "sglang_omni_v1.models.weight_loader",
+        "sglang_omni.models.weight_loader",
         weight_loader_module,
     )
 
-    from sglang_omni_v1.models.ming_omni.components.vision_encoder import (
+    from sglang_omni.models.ming_omni.components.vision_encoder import (
         _build_qwen3_vision_block_kwargs,
     )
 
@@ -149,42 +149,42 @@ def test_ming_vision_block_kwargs_pass_head_size_only_when_supported(
 
 
 def _load_preprocessor_with_fake_deps(monkeypatch, *, config=None, tokenizer=None):
-    common_module = ModuleType("sglang_omni_v1.models.ming_omni.components.common")
+    common_module = ModuleType("sglang_omni.models.ming_omni.components.common")
     common_module.load_ming_config = lambda model_path: config
     common_module.load_ming_tokenizer = lambda model_path: tokenizer
     monkeypatch.setitem(
         sys.modules,
-        "sglang_omni_v1.models.ming_omni.components.common",
+        "sglang_omni.models.ming_omni.components.common",
         common_module,
     )
 
-    io_module = ModuleType("sglang_omni_v1.models.ming_omni.io")
+    io_module = ModuleType("sglang_omni.models.ming_omni.io")
     io_module.PipelineState = object
     io_module.PromptInputs = dict
-    monkeypatch.setitem(sys.modules, "sglang_omni_v1.models.ming_omni.io", io_module)
+    monkeypatch.setitem(sys.modules, "sglang_omni.models.ming_omni.io", io_module)
 
     next_stage_module = ModuleType(
-        "sglang_omni_v1.models.ming_omni.pipeline.next_stage"
+        "sglang_omni.models.ming_omni.pipeline.next_stage"
     )
     next_stage_module.AUDIO_STAGE = "audio_encoder"
     next_stage_module.IMAGE_STAGE = "image_encoder"
     monkeypatch.setitem(
         sys.modules,
-        "sglang_omni_v1.models.ming_omni.pipeline.next_stage",
+        "sglang_omni.models.ming_omni.pipeline.next_stage",
         next_stage_module,
     )
 
-    audio_module = ModuleType("sglang_omni_v1.preprocessing.audio")
+    audio_module = ModuleType("sglang_omni.preprocessing.audio")
     audio_module.load_audio_path = lambda *args, **kwargs: None
-    monkeypatch.setitem(sys.modules, "sglang_omni_v1.preprocessing.audio", audio_module)
+    monkeypatch.setitem(sys.modules, "sglang_omni.preprocessing.audio", audio_module)
 
-    image_module = ModuleType("sglang_omni_v1.preprocessing.image")
+    image_module = ModuleType("sglang_omni.preprocessing.image")
     image_module.ensure_image_list_async = lambda images: images
-    monkeypatch.setitem(sys.modules, "sglang_omni_v1.preprocessing.image", image_module)
+    monkeypatch.setitem(sys.modules, "sglang_omni.preprocessing.image", image_module)
 
-    proto_module = ModuleType("sglang_omni_v1.proto")
+    proto_module = ModuleType("sglang_omni.proto")
     proto_module.StagePayload = object
-    monkeypatch.setitem(sys.modules, "sglang_omni_v1.proto", proto_module)
+    monkeypatch.setitem(sys.modules, "sglang_omni.proto", proto_module)
 
     module_name = "_ming_preprocessor_under_test"
     spec = importlib.util.spec_from_file_location(module_name, MING_PREPROCESSOR_PATH)
@@ -276,11 +276,11 @@ def test_ming_preprocessor_uses_config_image_patch_token_id(monkeypatch) -> None
 
 
 def test_ming_config_and_stages_do_not_import_ming_runner() -> None:
-    runner_module = "sglang_omni_v1.model_runner.ming_thinker_model_runner"
+    runner_module = "sglang_omni.model_runner.ming_thinker_model_runner"
     sys.modules.pop(runner_module, None)
 
-    importlib.import_module("sglang_omni_v1.models.ming_omni.config")
-    importlib.import_module("sglang_omni_v1.models.ming_omni.stages")
+    importlib.import_module("sglang_omni.models.ming_omni.config")
+    importlib.import_module("sglang_omni.models.ming_omni.stages")
 
     assert runner_module not in sys.modules
 
@@ -306,7 +306,7 @@ def _load_runner_with_fake_sglang(monkeypatch):
         scheduler_module,
     )
 
-    module_name = "sglang_omni_v1.model_runner.ming_thinker_model_runner"
+    module_name = "sglang_omni.model_runner.ming_thinker_model_runner"
     sys.modules.pop(module_name, None)
     module = importlib.import_module(module_name)
     runner_cls = module.MingThinkerModelRunner

--- a/tests/unit_test/ming_omni/test_thinker.py
+++ b/tests/unit_test/ming_omni/test_thinker.py
@@ -323,23 +323,6 @@ def _purge_cached_module(module_name: str, module: ModuleType) -> None:
         delattr(parent, child_name)
 
 
-def test_ming_fake_sglang_runner_loader_cleanup_removes_parent_attr(
-    monkeypatch,
-) -> None:
-    module_name = "sglang_omni_v1.model_runner.ming_thinker_model_runner"
-    parent_name = "sglang_omni_v1.model_runner"
-    fake_parent = ModuleType(parent_name)
-    fake_module = ModuleType(module_name)
-    fake_parent.ming_thinker_model_runner = fake_module
-    monkeypatch.setitem(sys.modules, parent_name, fake_parent)
-    monkeypatch.setitem(sys.modules, module_name, fake_module)
-
-    _purge_cached_module(module_name, fake_module)
-
-    assert module_name not in sys.modules
-    assert not hasattr(fake_parent, "ming_thinker_model_runner")
-
-
 class _FakeEmbedTokens:
     num_embeddings = 16
 
@@ -452,3 +435,28 @@ def test_ming_runner_successful_final_injection_consumes_and_clears(
     assert torch.equal(input_embeds[1], audio_embeds[0])
     assert req.omni_model_inputs is None
     assert req._omni_consumed is None
+
+
+def test_ming_runner_keeps_chunk_state_until_final_chunk(monkeypatch) -> None:
+    torch, runner_cls = _load_runner_with_fake_sglang(monkeypatch)
+    runner = _fake_runner(torch, runner_cls, image=3)
+    image_embeds = torch.tensor([[20.0, 21.0], [22.0, 23.0]])
+    model_inputs = {"image_embeds": image_embeds}
+    req = _fake_req(model_inputs, is_chunked=1, rid="chunked-image")
+    forward_batch, schedule_batch = _fake_batch(torch, [3, 1], req)
+
+    input_embeds = runner._inject_multimodal_embeds(forward_batch, schedule_batch)
+
+    assert torch.equal(input_embeds[0], image_embeds[0])
+    assert req.omni_model_inputs is model_inputs
+    assert req._omni_consumed == {"image": 1}
+
+    req.is_chunked = 0
+    forward_batch, schedule_batch = _fake_batch(torch, [3, 2], req)
+
+    input_embeds = runner._inject_multimodal_embeds(forward_batch, schedule_batch)
+
+    assert torch.equal(input_embeds[0], image_embeds[1])
+    assert req.omni_model_inputs is None
+    assert req._omni_consumed is None
+    assert model_inputs == {"image_embeds": image_embeds}

--- a/tests/unit_test/ming_omni/test_thinker.py
+++ b/tests/unit_test/ming_omni/test_thinker.py
@@ -72,7 +72,7 @@ def test_ming_thinker_runner_uses_ming_token_id_contract() -> None:
     assert "thinker_config" not in source
 
 
-def test_ming_thinker_weight_loader_uses_v1_qwen3_helper_path() -> None:
+def test_ming_thinker_weight_loader_uses_qwen3_helper_path() -> None:
     source = _read(MING_THINKER_PATH)
 
     assert "sglang_omni.models.qwen3_omni.thinker" not in source
@@ -80,7 +80,7 @@ def test_ming_thinker_weight_loader_uses_v1_qwen3_helper_path() -> None:
     assert "extract_fused_experts" in source
 
 
-def test_ming_v1_image_encoder_keeps_its_tp_context_for_runtime_forward() -> None:
+def test_ming_image_encoder_keeps_its_tp_context_for_runtime_forward() -> None:
     source = _read(MING_IMAGE_ENCODER_PATH)
     init_body = source.split("    @staticmethod", 1)[0]
 
@@ -88,7 +88,7 @@ def test_ming_v1_image_encoder_keeps_its_tp_context_for_runtime_forward() -> Non
     assert "self._cleanup_sglang_tp()" not in init_body
 
 
-def test_ming_v1_image_encoder_tp_init_requires_parallel_state() -> None:
+def test_ming_image_encoder_tp_init_requires_parallel_state() -> None:
     source = _read(MING_IMAGE_ENCODER_PATH)
     init_fn = source.split("def _init_sglang_tp", 1)[1].split(
         "    @classmethod\n    def _cleanup_sglang_tp", 1

--- a/tests/unit_test/ming_omni/test_thinker.py
+++ b/tests/unit_test/ming_omni/test_thinker.py
@@ -1,0 +1,454 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Multimodal thinker wiring tests."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+BOOTSTRAP_PATH = Path("sglang_omni_v1/models/ming_omni/bootstrap.py")
+RUNNER_PATH = Path("sglang_omni_v1/model_runner/ming_thinker_model_runner.py")
+MING_THINKER_PATH = Path("sglang_omni_v1/models/ming_omni/thinker.py")
+MING_IMAGE_ENCODER_PATH = Path(
+    "sglang_omni_v1/models/ming_omni/components/image_encoder.py"
+)
+MING_PREPROCESSOR_PATH = Path(
+    "sglang_omni_v1/models/ming_omni/components/preprocessor.py"
+)
+VENDOR_SGLANG_LAYERS_PATH = Path("sglang_omni_v1/vendor/sglang/layers.py")
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_ming_bootstrap_wires_ming_thinker_model_runner() -> None:
+    source = _read(BOOTSTRAP_PATH)
+
+    assert "MingThinkerModelRunner" in source
+    assert "SGLangOutputProcessor" in source
+    assert "model=model_worker.model_runner.model" in source
+    assert "model_runner = MingThinkerModelRunner(model_worker, output_proc)" in source
+    assert "model_runner=model_runner" in source
+    assert 'model_arch_override="BailingMoeV2ForCausalLM"' in source
+
+
+def test_ming_thinker_runner_source_injects_multimodal_embeds() -> None:
+    source = _read(RUNNER_PATH)
+
+    assert "class MingThinkerModelRunner(ModelRunner)" in source
+    assert "audio_embeds" in source
+    assert "image_embeds" in source
+    assert "_resolve_match_id" in source
+    assert "_validate_final_consumption" in source
+    assert "continue" in source
+    assert ".clamp(" in source
+    assert "self._embed_tokens.num_embeddings - 1" in source
+    assert "outer.model(" in source
+    assert "input_ids=None" in source
+    assert "input_embeds=input_embeds" in source
+    assert "outer.logits_processor(" in source
+    assert "GenerationBatchResult(" in source
+    assert "can_run_cuda_graph=False" in source
+    assert "req.omni_model_inputs = None" in source
+    assert "req._omni_consumed = None" in source
+
+
+def test_ming_thinker_runner_uses_ming_token_id_contract() -> None:
+    source = _read(RUNNER_PATH)
+
+    assert "hf_config" in source
+    assert "llm_config" in source
+    assert "image_token_id" in source
+    assert "video_token_id" in source
+    assert "audio_token_id" in source
+    assert "image_patch_token" in source
+    assert "video_patch_token" in source
+    assert "thinker_config" not in source
+
+
+def test_ming_thinker_weight_loader_uses_v1_qwen3_helper_path() -> None:
+    source = _read(MING_THINKER_PATH)
+
+    assert "sglang_omni_v1.models.qwen3_omni.thinker" not in source
+    assert "sglang_omni_v1.models.qwen3_omni.components.thinker_model" in source
+    assert "extract_fused_experts" in source
+
+
+def test_ming_v1_image_encoder_keeps_its_tp_context_for_runtime_forward() -> None:
+    source = _read(MING_IMAGE_ENCODER_PATH)
+    init_body = source.split("    @staticmethod", 1)[0]
+
+    assert "self._init_sglang_tp()" in init_body
+    assert "self._cleanup_sglang_tp()" not in init_body
+
+
+def test_ming_v1_image_encoder_tp_init_requires_parallel_state() -> None:
+    source = _read(MING_IMAGE_ENCODER_PATH)
+    init_fn = source.split("def _init_sglang_tp", 1)[1].split(
+        "    @classmethod\n    def _cleanup_sglang_tp", 1
+    )[0]
+
+    assert "parallel_state.model_parallel_is_initialized()" in init_fn
+    assert 'if getattr(dp, "_ATTN_TP_SIZE", None) is not None' not in init_fn
+
+
+def test_vendored_sglang_layers_do_not_import_removed_sampling_symbol() -> None:
+    source = _read(VENDOR_SGLANG_LAYERS_PATH)
+
+    assert "top_k_top_p_sampling_from_probs" not in source
+
+
+def test_ming_vision_block_kwargs_pass_head_size_only_when_supported(
+    monkeypatch,
+) -> None:
+    weight_loader_module = ModuleType("sglang_omni_v1.models.weight_loader")
+    weight_loader_module.default_weight_loader = lambda *args, **kwargs: None
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni_v1.models.weight_loader",
+        weight_loader_module,
+    )
+
+    from sglang_omni_v1.models.ming_omni.components.vision_encoder import (
+        _build_qwen3_vision_block_kwargs,
+    )
+
+    class LegacyVisionBlock:
+        def __init__(self, dim, num_heads, intermediate_dim, prefix=""):
+            pass
+
+    class NewVisionBlock:
+        def __init__(self, dim, num_heads, head_size, intermediate_dim, prefix=""):
+            pass
+
+    common = {
+        "dim": 1152,
+        "num_heads": 16,
+        "head_size": 72,
+        "intermediate_dim": 4304,
+        "hidden_act": "gelu_pytorch_tanh",
+        "norm_layer": None,
+        "quant_config": None,
+        "prefix": "visual.blocks.0",
+    }
+
+    legacy_kwargs = _build_qwen3_vision_block_kwargs(
+        LegacyVisionBlock,
+        **common,
+    )
+    new_kwargs = _build_qwen3_vision_block_kwargs(NewVisionBlock, **common)
+
+    assert "head_size" not in legacy_kwargs
+    assert new_kwargs["head_size"] == 72
+
+
+def _load_preprocessor_with_fake_deps(monkeypatch, *, config=None, tokenizer=None):
+    common_module = ModuleType("sglang_omni_v1.models.ming_omni.components.common")
+    common_module.load_ming_config = lambda model_path: config
+    common_module.load_ming_tokenizer = lambda model_path: tokenizer
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni_v1.models.ming_omni.components.common",
+        common_module,
+    )
+
+    io_module = ModuleType("sglang_omni_v1.models.ming_omni.io")
+    io_module.PipelineState = object
+    io_module.PromptInputs = dict
+    monkeypatch.setitem(sys.modules, "sglang_omni_v1.models.ming_omni.io", io_module)
+
+    next_stage_module = ModuleType(
+        "sglang_omni_v1.models.ming_omni.pipeline.next_stage"
+    )
+    next_stage_module.AUDIO_STAGE = "audio_encoder"
+    next_stage_module.IMAGE_STAGE = "image_encoder"
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni_v1.models.ming_omni.pipeline.next_stage",
+        next_stage_module,
+    )
+
+    audio_module = ModuleType("sglang_omni_v1.preprocessing.audio")
+    audio_module.load_audio_path = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "sglang_omni_v1.preprocessing.audio", audio_module)
+
+    image_module = ModuleType("sglang_omni_v1.preprocessing.image")
+    image_module.ensure_image_list_async = lambda images: images
+    monkeypatch.setitem(sys.modules, "sglang_omni_v1.preprocessing.image", image_module)
+
+    proto_module = ModuleType("sglang_omni_v1.proto")
+    proto_module.StagePayload = object
+    monkeypatch.setitem(sys.modules, "sglang_omni_v1.proto", proto_module)
+
+    module_name = "_ming_preprocessor_under_test"
+    spec = importlib.util.spec_from_file_location(module_name, MING_PREPROCESSOR_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    sys.modules.pop(module_name, None)
+    return module
+
+
+class _FakeMingTokenizer:
+    unk_token_id = -1
+    _ids = {
+        "<audio>": 10,
+        "</audio>": 11,
+        "<audioPatch>": 12,
+        "<image>": 20,
+        "</image>": 21,
+        "<imagePatch>": 22,
+    }
+
+    def convert_tokens_to_ids(self, token):
+        return self._ids.get(token, self.unk_token_id)
+
+    def encode(self, text, add_special_tokens=False):
+        del add_special_tokens
+        if text in self._ids and "Patch" not in text:
+            return [self._ids[text]]
+        return [1000 + (ord(ch) % 127) for ch in text]
+
+
+def test_ming_preprocessor_builds_placeholder_input_ids_directly(monkeypatch) -> None:
+    module = _load_preprocessor_with_fake_deps(monkeypatch)
+    processor = module.MingPreprocessor.__new__(module.MingPreprocessor)
+    processor._tokenizer = _FakeMingTokenizer()
+    processor._audio_patch_id = processor._tokenizer.convert_tokens_to_ids(
+        module.AUDIO_PATCH
+    )
+    processor._audio_start_id = processor._tokenizer.convert_tokens_to_ids(
+        module.AUDIO_START
+    )
+    processor._audio_end_id = processor._tokenizer.convert_tokens_to_ids(
+        module.AUDIO_END
+    )
+    processor._image_patch_id = processor._tokenizer.convert_tokens_to_ids(
+        module.IMAGE_PATCH
+    )
+
+    prompt_text, input_ids, audio_positions = processor._build_prompt(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "image://1"}},
+                    {"type": "text", "text": " describe "},
+                    {"type": "audio_url", "audio_url": {"url": "audio://1"}},
+                ],
+            }
+        ],
+        image_token_counts=[3],
+        audio_token_counts=[2],
+    )
+
+    assert "<image><imagePatch><imagePatch><imagePatch></image>" in prompt_text
+    assert input_ids.count(22) == 3
+    assert input_ids.count(12) == 2
+    assert audio_positions == [input_ids.index(12)]
+
+
+def test_ming_preprocessor_uses_config_image_patch_token_id(monkeypatch) -> None:
+    config = SimpleNamespace(
+        llm_config=SimpleNamespace(image_patch_token=222),
+        audio_config=SimpleNamespace(),
+        vision_config=SimpleNamespace(),
+    )
+    tokenizer = _FakeMingTokenizer()
+    tokenizer._ids = {**tokenizer._ids, "<imagePatch>": 999}
+    module = _load_preprocessor_with_fake_deps(
+        monkeypatch,
+        config=config,
+        tokenizer=tokenizer,
+    )
+
+    processor = module.MingPreprocessor("fake-model")
+
+    assert processor._image_patch_id == 222
+
+
+def test_ming_config_and_stages_do_not_import_ming_runner() -> None:
+    runner_module = "sglang_omni_v1.model_runner.ming_thinker_model_runner"
+    sys.modules.pop(runner_module, None)
+
+    importlib.import_module("sglang_omni_v1.models.ming_omni.config")
+    importlib.import_module("sglang_omni_v1.models.ming_omni.stages")
+
+    assert runner_module not in sys.modules
+
+
+def _load_runner_with_fake_sglang(monkeypatch):
+    torch = pytest.importorskip("torch")
+
+    scheduler_module = ModuleType("sglang.srt.managers.scheduler")
+
+    class GenerationBatchResult:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    scheduler_module.GenerationBatchResult = GenerationBatchResult
+    monkeypatch.setitem(sys.modules, "sglang", ModuleType("sglang"))
+    monkeypatch.setitem(sys.modules, "sglang.srt", ModuleType("sglang.srt"))
+    monkeypatch.setitem(
+        sys.modules, "sglang.srt.managers", ModuleType("sglang.srt.managers")
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang.srt.managers.scheduler",
+        scheduler_module,
+    )
+
+    module_name = "sglang_omni_v1.model_runner.ming_thinker_model_runner"
+    sys.modules.pop(module_name, None)
+    module = importlib.import_module(module_name)
+    runner_cls = module.MingThinkerModelRunner
+    _purge_cached_module(module_name, module)
+    assert module_name not in sys.modules
+    return torch, runner_cls
+
+
+def _purge_cached_module(module_name: str, module: ModuleType) -> None:
+    sys.modules.pop(module_name, None)
+    parent_name, _, child_name = module_name.rpartition(".")
+    parent = sys.modules.get(parent_name)
+    if isinstance(parent, ModuleType) and getattr(parent, child_name, None) is module:
+        delattr(parent, child_name)
+
+
+def test_ming_fake_sglang_runner_loader_cleanup_removes_parent_attr(
+    monkeypatch,
+) -> None:
+    module_name = "sglang_omni_v1.model_runner.ming_thinker_model_runner"
+    parent_name = "sglang_omni_v1.model_runner"
+    fake_parent = ModuleType(parent_name)
+    fake_module = ModuleType(module_name)
+    fake_parent.ming_thinker_model_runner = fake_module
+    monkeypatch.setitem(sys.modules, parent_name, fake_parent)
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    _purge_cached_module(module_name, fake_module)
+
+    assert module_name not in sys.modules
+    assert not hasattr(fake_parent, "ming_thinker_model_runner")
+
+
+class _FakeEmbedTokens:
+    num_embeddings = 16
+
+    def __init__(self, torch_module):
+        self._torch = torch_module
+
+    def __call__(self, input_ids):
+        values = input_ids.to(dtype=self._torch.float32)
+        return self._torch.stack((values, values + 100), dim=-1)
+
+
+def _fake_runner(torch_module, runner_cls, **token_ids):
+    runner = runner_cls.__new__(runner_cls)
+    runner._embed_tokens = _FakeEmbedTokens(torch_module)
+    runner._image_token_id = token_ids.get("image", 3)
+    runner._video_token_id = token_ids.get("video", 4)
+    runner._audio_token_id = token_ids.get("audio", 5)
+    return runner
+
+
+def _fake_batch(torch_module, input_ids, req):
+    forward_batch = SimpleNamespace(
+        input_ids=torch_module.tensor(input_ids, dtype=torch_module.long),
+        extend_seq_lens_cpu=[len(input_ids)],
+    )
+    schedule_batch = SimpleNamespace(reqs=[req])
+    return forward_batch, schedule_batch
+
+
+def _fake_req(model_inputs, *, is_chunked=0, rid="req-1"):
+    return SimpleNamespace(
+        rid=rid,
+        omni_model_inputs=model_inputs,
+        _omni_consumed=None,
+        is_chunked=is_chunked,
+    )
+
+
+def test_ming_runner_uses_pad_value_when_token_id_is_none(monkeypatch) -> None:
+    torch, runner_cls = _load_runner_with_fake_sglang(monkeypatch)
+    runner = _fake_runner(torch, runner_cls, audio=None)
+    audio_embeds = torch.tensor([[30.0, 31.0]])
+    req = _fake_req(
+        {"audio_embeds": audio_embeds, "pad_values": {"audio": 12}},
+        rid="pad-audio",
+    )
+    forward_batch, schedule_batch = _fake_batch(torch, [12, 1], req)
+
+    input_embeds = runner._inject_multimodal_embeds(forward_batch, schedule_batch)
+
+    assert torch.equal(input_embeds[0], audio_embeds[0])
+    assert req.omni_model_inputs is None
+    assert req._omni_consumed is None
+
+
+def test_ming_runner_raises_when_final_request_has_missing_placeholder(
+    monkeypatch,
+) -> None:
+    torch, runner_cls = _load_runner_with_fake_sglang(monkeypatch)
+    runner = _fake_runner(torch, runner_cls, audio=5)
+    req = _fake_req({"audio_embeds": torch.ones(1, 2)}, rid="missing-audio")
+    forward_batch, schedule_batch = _fake_batch(torch, [1, 2], req)
+
+    with pytest.raises(ValueError, match="audio.*missing-audio.*no placeholders"):
+        runner._inject_multimodal_embeds(forward_batch, schedule_batch)
+
+    assert req.omni_model_inputs is not None
+
+
+def test_ming_runner_raises_when_embeds_are_short(monkeypatch) -> None:
+    torch, runner_cls = _load_runner_with_fake_sglang(monkeypatch)
+    runner = _fake_runner(torch, runner_cls, image=3)
+    req = _fake_req({"image_embeds": torch.ones(1, 2)}, rid="short-image")
+    forward_batch, schedule_batch = _fake_batch(torch, [3, 3], req)
+
+    with pytest.raises(ValueError, match="image.*short-image.*needed=2.*available=1"):
+        runner._inject_multimodal_embeds(forward_batch, schedule_batch)
+
+    assert req.omni_model_inputs is not None
+
+
+def test_ming_runner_raises_when_final_request_has_extra_embeds(monkeypatch) -> None:
+    torch, runner_cls = _load_runner_with_fake_sglang(monkeypatch)
+    runner = _fake_runner(torch, runner_cls, image=3)
+    req = _fake_req({"image_embeds": torch.ones(2, 2)}, rid="extra-image")
+    forward_batch, schedule_batch = _fake_batch(torch, [3], req)
+
+    with pytest.raises(ValueError, match="image.*extra-image.*consumed=1.*total=2"):
+        runner._inject_multimodal_embeds(forward_batch, schedule_batch)
+
+    assert req.omni_model_inputs is not None
+
+
+def test_ming_runner_successful_final_injection_consumes_and_clears(
+    monkeypatch,
+) -> None:
+    torch, runner_cls = _load_runner_with_fake_sglang(monkeypatch)
+    runner = _fake_runner(torch, runner_cls, image=3, audio=5)
+    image_embeds = torch.tensor([[20.0, 21.0]])
+    audio_embeds = torch.tensor([[30.0, 31.0]])
+    req = _fake_req(
+        {"image_embeds": image_embeds, "audio_embeds": audio_embeds},
+        rid="ok-mm",
+    )
+    forward_batch, schedule_batch = _fake_batch(torch, [3, 5, 1], req)
+
+    input_embeds = runner._inject_multimodal_embeds(forward_batch, schedule_batch)
+
+    assert torch.equal(input_embeds[0], image_embeds[0])
+    assert torch.equal(input_embeds[1], audio_embeds[0])
+    assert req.omni_model_inputs is None
+    assert req._omni_consumed is None

--- a/tests/unit_test/ming_omni/test_thinker.py
+++ b/tests/unit_test/ming_omni/test_thinker.py
@@ -17,9 +17,7 @@ MING_THINKER_PATH = Path("sglang_omni/models/ming_omni/thinker.py")
 MING_IMAGE_ENCODER_PATH = Path(
     "sglang_omni/models/ming_omni/components/image_encoder.py"
 )
-MING_PREPROCESSOR_PATH = Path(
-    "sglang_omni/models/ming_omni/components/preprocessor.py"
-)
+MING_PREPROCESSOR_PATH = Path("sglang_omni/models/ming_omni/components/preprocessor.py")
 VENDOR_SGLANG_LAYERS_PATH = Path("sglang_omni/vendor/sglang/layers.py")
 
 
@@ -163,9 +161,7 @@ def _load_preprocessor_with_fake_deps(monkeypatch, *, config=None, tokenizer=Non
     io_module.PromptInputs = dict
     monkeypatch.setitem(sys.modules, "sglang_omni.models.ming_omni.io", io_module)
 
-    next_stage_module = ModuleType(
-        "sglang_omni.models.ming_omni.pipeline.next_stage"
-    )
+    next_stage_module = ModuleType("sglang_omni.models.ming_omni.pipeline.next_stage")
     next_stage_module.AUDIO_STAGE = "audio_encoder"
     next_stage_module.IMAGE_STAGE = "image_encoder"
     monkeypatch.setitem(
@@ -176,10 +172,12 @@ def _load_preprocessor_with_fake_deps(monkeypatch, *, config=None, tokenizer=Non
 
     audio_module = ModuleType("sglang_omni.preprocessing.audio")
     audio_module.load_audio_path = lambda *args, **kwargs: None
+    audio_module.compute_audio_cache_key = lambda audios: None
     monkeypatch.setitem(sys.modules, "sglang_omni.preprocessing.audio", audio_module)
 
     image_module = ModuleType("sglang_omni.preprocessing.image")
     image_module.ensure_image_list_async = lambda images: images
+    image_module.compute_image_cache_key = lambda images: None
     monkeypatch.setitem(sys.modules, "sglang_omni.preprocessing.image", image_module)
 
     proto_module = ModuleType("sglang_omni.proto")
@@ -378,20 +376,6 @@ def test_ming_runner_uses_pad_value_when_token_id_is_none(monkeypatch) -> None:
     assert req._omni_consumed is None
 
 
-def test_ming_runner_raises_when_final_request_has_missing_placeholder(
-    monkeypatch,
-) -> None:
-    torch, runner_cls = _load_runner_with_fake_sglang(monkeypatch)
-    runner = _fake_runner(torch, runner_cls, audio=5)
-    req = _fake_req({"audio_embeds": torch.ones(1, 2)}, rid="missing-audio")
-    forward_batch, schedule_batch = _fake_batch(torch, [1, 2], req)
-
-    with pytest.raises(ValueError, match="audio.*missing-audio.*no placeholders"):
-        runner._inject_multimodal_embeds(forward_batch, schedule_batch)
-
-    assert req.omni_model_inputs is not None
-
-
 def test_ming_runner_raises_when_embeds_are_short(monkeypatch) -> None:
     torch, runner_cls = _load_runner_with_fake_sglang(monkeypatch)
     runner = _fake_runner(torch, runner_cls, image=3)
@@ -399,18 +383,6 @@ def test_ming_runner_raises_when_embeds_are_short(monkeypatch) -> None:
     forward_batch, schedule_batch = _fake_batch(torch, [3, 3], req)
 
     with pytest.raises(ValueError, match="image.*short-image.*needed=2.*available=1"):
-        runner._inject_multimodal_embeds(forward_batch, schedule_batch)
-
-    assert req.omni_model_inputs is not None
-
-
-def test_ming_runner_raises_when_final_request_has_extra_embeds(monkeypatch) -> None:
-    torch, runner_cls = _load_runner_with_fake_sglang(monkeypatch)
-    runner = _fake_runner(torch, runner_cls, image=3)
-    req = _fake_req({"image_embeds": torch.ones(2, 2)}, rid="extra-image")
-    forward_batch, schedule_batch = _fake_batch(torch, [3], req)
-
-    with pytest.raises(ValueError, match="image.*extra-image.*consumed=1.*total=2"):
         runner._inject_multimodal_embeds(forward_batch, schedule_batch)
 
     assert req.omni_model_inputs is not None

--- a/tests/unit_test/ming_omni/test_tokenizer.py
+++ b/tests/unit_test/ming_omni/test_tokenizer.py
@@ -36,13 +36,13 @@ def test_load_ming_tokenizer_handles_custom_config_mapping_keyerror(monkeypatch)
     )
     monkeypatch.setitem(sys.modules, "transformers", transformers_module)
 
-    weight_loader_module = ModuleType("sglang_omni_v1.models.weight_loader")
+    weight_loader_module = ModuleType("sglang_omni.models.weight_loader")
     weight_loader_module.resolve_model_path = lambda model_path: model_path
     monkeypatch.setitem(
-        sys.modules, "sglang_omni_v1.models.weight_loader", weight_loader_module
+        sys.modules, "sglang_omni.models.weight_loader", weight_loader_module
     )
 
-    from sglang_omni_v1.models.ming_omni.components import common
+    from sglang_omni.models.ming_omni.components import common
 
     common = importlib.reload(common)
 

--- a/tests/unit_test/ming_omni/test_tokenizer.py
+++ b/tests/unit_test/ming_omni/test_tokenizer.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Thinker tokenizer loading tests."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+
+
+def test_load_ming_tokenizer_handles_custom_config_mapping_keyerror(monkeypatch):
+    hub_module = ModuleType("huggingface_hub")
+    hub_module.hf_hub_download = lambda *args, **kwargs: None
+    hub_module.snapshot_download = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub_module)
+
+    sentinel = object()
+    calls: list[str] = []
+
+    def fake_auto_from_pretrained(path: str, trust_remote_code: bool = False, **kwargs):
+        calls.append(f"auto:{path}")
+        raise KeyError("BailingMM2Config")
+
+    def fake_fast_from_pretrained(path: str, **kwargs):
+        calls.append(f"fast:{path}")
+        if path == "org/model":
+            return sentinel
+        raise OSError("tokenizer not found")
+
+    transformers_module = ModuleType("transformers")
+    transformers_module.AutoTokenizer = SimpleNamespace(
+        from_pretrained=fake_auto_from_pretrained
+    )
+    transformers_module.PreTrainedTokenizerFast = SimpleNamespace(
+        from_pretrained=fake_fast_from_pretrained
+    )
+    monkeypatch.setitem(sys.modules, "transformers", transformers_module)
+
+    weight_loader_module = ModuleType("sglang_omni_v1.models.weight_loader")
+    weight_loader_module.resolve_model_path = lambda model_path: model_path
+    monkeypatch.setitem(
+        sys.modules, "sglang_omni_v1.models.weight_loader", weight_loader_module
+    )
+
+    from sglang_omni_v1.models.ming_omni.components import common
+
+    common = importlib.reload(common)
+
+    tokenizer = common.load_ming_tokenizer("org/model")
+
+    assert tokenizer is sentinel
+    assert calls == ["auto:org/model", "fast:org/model"]

--- a/tests/unit_test/ming_omni/test_tp.py
+++ b/tests/unit_test/ming_omni/test_tp.py
@@ -10,7 +10,7 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 
-_PROJECT_PREFIX = "sglang_omni_v1."
+_PROJECT_PREFIX = "sglang_omni."
 
 
 def _ming_config_with_thinker_tp2(config_cls):
@@ -19,6 +19,7 @@ def _ming_config_with_thinker_tp2(config_cls):
     for stage in stages:
         if stage.name == "thinker":
             stage.tp_size = 2
+            stage.parallelism = stage.parallelism.model_copy(update={"tp": 2})
             stage.gpu = [0, 1]
     return stages
 
@@ -31,6 +32,8 @@ def _build_groups(config, build_stage_groups, prepare_pipeline_runtime):
             stages_cfg=prep.stages_cfg,
             name_map=prep.name_map,
             endpoints=prep.endpoints,
+            placement_plan=prep.placement_plan,
+            process_plan=prep.process_plan,
         )
     finally:
         if prep.runtime_dir is not None:
@@ -39,8 +42,7 @@ def _build_groups(config, build_stage_groups, prepare_pipeline_runtime):
 
 def _thinker_specs(config, build_stage_groups, prepare_pipeline_runtime):
     groups = _build_groups(config, build_stage_groups, prepare_pipeline_runtime)
-    thinker_group = next(group for group in groups if group.stage_name == "thinker")
-    return thinker_group.specs
+    return [s for g in groups for s in g.specs if s.stage_name == "thinker"]
 
 
 def _module_refs_any(module: ModuleType, refs: Iterable[object]) -> bool:
@@ -119,7 +121,7 @@ def _cached_attrs_from_missing_project_modules() -> list[str]:
 
 
 def test_ming_thinker_tp2_builds_rank_specific_stage_specs(monkeypatch) -> None:
-    importlib.import_module("sglang_omni_v1.pipeline")
+    importlib.import_module("sglang_omni.pipeline")
     before_import = set(sys.modules)
     fake_torch = ModuleType("torch")
     fake_torch.Tensor = object
@@ -170,9 +172,9 @@ def test_ming_thinker_tp2_builds_rank_specific_stage_specs(monkeypatch) -> None:
             mp.setitem(sys.modules, "transformers.utils", fake_transformers_utils)
             mp.setitem(sys.modules, "transformers.utils.hub", fake_transformers_hub)
 
-            from sglang_omni_v1.config.compiler import prepare_pipeline_runtime
-            from sglang_omni_v1.models.ming_omni.config import MingOmniPipelineConfig
-            from sglang_omni_v1.pipeline.mp_runner import _build_stage_groups
+            from sglang_omni.pipeline.runtime_config import prepare_pipeline_runtime
+            from sglang_omni.models.ming_omni.config import MingOmniPipelineConfig
+            from sglang_omni.pipeline.mp_runner import _build_stage_groups
 
             config = MingOmniPipelineConfig(
                 model_path="dummy",
@@ -182,14 +184,12 @@ def test_ming_thinker_tp2_builds_rank_specific_stage_specs(monkeypatch) -> None:
             groups = _build_groups(
                 config, _build_stage_groups, prepare_pipeline_runtime
             )
-            thinker_group = next(
-                group for group in groups if group.stage_name == "thinker"
-            )
-            specs = thinker_group.specs
+            all_specs = [s for g in groups for s in g.specs]
+            specs = [s for s in all_specs if s.stage_name == "thinker"]
             cpu_stage_specs = {
-                group.stage_name: group.specs[0]
-                for group in groups
-                if group.stage_name in {"preprocessing", "mm_aggregate", "decode"}
+                s.stage_name: s
+                for s in all_specs
+                if s.stage_name in {"preprocessing", "mm_aggregate", "decode"}
             }
             assert {name: spec.gpu_id for name, spec in cpu_stage_specs.items()} == {
                 "preprocessing": None,
@@ -207,19 +207,6 @@ def test_ming_thinker_tp2_builds_rank_specific_stage_specs(monkeypatch) -> None:
             assert {spec.factory_args["tp_size"] for spec in specs} == {2}
             assert specs[0].factory_args["nccl_port"] == specs[0].nccl_port
             assert specs[1].factory_args["nccl_port"] == specs[0].nccl_port
-
-            scalar_stages = _ming_config_with_thinker_tp2(MingOmniPipelineConfig)
-            for stage in scalar_stages:
-                if stage.name == "thinker":
-                    stage.gpu = 2
-            scalar_config = MingOmniPipelineConfig(
-                model_path="dummy",
-                stages=scalar_stages,
-            )
-            scalar_specs = _thinker_specs(
-                scalar_config, _build_stage_groups, prepare_pipeline_runtime
-            )
-            assert [spec.gpu_id for spec in scalar_specs] == [2, 3]
 
             explicit_stages = _ming_config_with_thinker_tp2(MingOmniPipelineConfig)
             for stage in explicit_stages:
@@ -241,7 +228,7 @@ def test_ming_thinker_tp2_builds_rank_specific_stage_specs(monkeypatch) -> None:
 
 
 def test_ming_speech_rejects_talker_inside_explicit_thinker_tp_gpus() -> None:
-    from sglang_omni_v1.models.ming_omni.config import MingOmniSpeechPipelineConfig
+    from sglang_omni.models.ming_omni.config import MingOmniSpeechPipelineConfig
 
     stages = _ming_config_with_thinker_tp2(MingOmniSpeechPipelineConfig)
     for stage in stages:
@@ -253,7 +240,7 @@ def test_ming_speech_rejects_talker_inside_explicit_thinker_tp_gpus() -> None:
 
 
 def test_ming_speech_rejects_talker_on_non_contiguous_thinker_tp_gpu() -> None:
-    from sglang_omni_v1.models.ming_omni.config import MingOmniSpeechPipelineConfig
+    from sglang_omni.models.ming_omni.config import MingOmniSpeechPipelineConfig
 
     stages = _ming_config_with_thinker_tp2(MingOmniSpeechPipelineConfig)
     for stage in stages:
@@ -267,7 +254,7 @@ def test_ming_speech_rejects_talker_on_non_contiguous_thinker_tp_gpu() -> None:
 
 
 def test_ming_speech_rejects_any_talker_gpu_list_overlap_with_thinker_tp() -> None:
-    from sglang_omni_v1.models.ming_omni.config import MingOmniSpeechPipelineConfig
+    from sglang_omni.models.ming_omni.config import MingOmniSpeechPipelineConfig
 
     stages = _ming_config_with_thinker_tp2(MingOmniSpeechPipelineConfig)
     for stage in stages:
@@ -275,6 +262,7 @@ def test_ming_speech_rejects_any_talker_gpu_list_overlap_with_thinker_tp() -> No
             stage.gpu = [0, 2]
         if stage.name == "talker":
             stage.tp_size = 2
+            stage.parallelism = stage.parallelism.model_copy(update={"tp": 2})
             stage.gpu = [3, 2]
 
     with pytest.raises(ValueError, match="collides"):
@@ -282,7 +270,7 @@ def test_ming_speech_rejects_any_talker_gpu_list_overlap_with_thinker_tp() -> No
 
 
 def test_ming_speech_allows_talker_outside_explicit_thinker_tp_gpus() -> None:
-    from sglang_omni_v1.models.ming_omni.config import MingOmniSpeechPipelineConfig
+    from sglang_omni.models.ming_omni.config import MingOmniSpeechPipelineConfig
 
     stages = _ming_config_with_thinker_tp2(MingOmniSpeechPipelineConfig)
     for stage in stages:
@@ -300,7 +288,7 @@ def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
 ) -> None:
     captured: dict[str, object] = {}
 
-    common_module = ModuleType("sglang_omni_v1.models.ming_omni.components.common")
+    common_module = ModuleType("sglang_omni.models.ming_omni.components.common")
     common_module.load_ming_tokenizer = lambda _model_path: SimpleNamespace(
         vocab_size=32000,
         eos_token_id=2,
@@ -310,11 +298,11 @@ def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
     )
     monkeypatch.setitem(
         sys.modules,
-        "sglang_omni_v1.models.ming_omni.components.common",
+        "sglang_omni.models.ming_omni.components.common",
         common_module,
     )
 
-    runner_module = ModuleType("sglang_omni_v1.model_runner.ming_thinker_model_runner")
+    runner_module = ModuleType("sglang_omni.model_runner.ming_thinker_model_runner")
 
     class FakeMingThinkerModelRunner:
         def __init__(self, model_worker, output_proc):
@@ -324,11 +312,11 @@ def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
     runner_module.MingThinkerModelRunner = FakeMingThinkerModelRunner
     monkeypatch.setitem(
         sys.modules,
-        "sglang_omni_v1.model_runner.ming_thinker_model_runner",
+        "sglang_omni.model_runner.ming_thinker_model_runner",
         runner_module,
     )
 
-    scheduling_bootstrap_module = ModuleType("sglang_omni_v1.scheduling.bootstrap")
+    scheduling_bootstrap_module = ModuleType("sglang_omni.scheduling.bootstrap")
 
     def fake_create_sglang_infrastructure(
         server_args,
@@ -362,11 +350,11 @@ def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
     )
     monkeypatch.setitem(
         sys.modules,
-        "sglang_omni_v1.scheduling.bootstrap",
+        "sglang_omni.scheduling.bootstrap",
         scheduling_bootstrap_module,
     )
 
-    omni_scheduler_module = ModuleType("sglang_omni_v1.scheduling.omni_scheduler")
+    omni_scheduler_module = ModuleType("sglang_omni.scheduling.omni_scheduler")
 
     class FakeOmniScheduler:
         def __init__(self, **kwargs):
@@ -375,11 +363,11 @@ def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
     omni_scheduler_module.OmniScheduler = FakeOmniScheduler
     monkeypatch.setitem(
         sys.modules,
-        "sglang_omni_v1.scheduling.omni_scheduler",
+        "sglang_omni.scheduling.omni_scheduler",
         omni_scheduler_module,
     )
 
-    sglang_backend_module = ModuleType("sglang_omni_v1.scheduling.sglang_backend")
+    sglang_backend_module = ModuleType("sglang_omni.scheduling.sglang_backend")
 
     class FakeSGLangOutputProcessor:
         def __init__(self, **kwargs):
@@ -388,11 +376,11 @@ def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
     sglang_backend_module.SGLangOutputProcessor = FakeSGLangOutputProcessor
     monkeypatch.setitem(
         sys.modules,
-        "sglang_omni_v1.scheduling.sglang_backend",
+        "sglang_omni.scheduling.sglang_backend",
         sglang_backend_module,
     )
 
-    bootstrap = importlib.import_module("sglang_omni_v1.models.ming_omni.bootstrap")
+    bootstrap = importlib.import_module("sglang_omni.models.ming_omni.bootstrap")
     server_args = SimpleNamespace(tp_size=1)
 
     scheduler = bootstrap.create_thinker_scheduler(

--- a/tests/unit_test/ming_omni/test_tp.py
+++ b/tests/unit_test/ming_omni/test_tp.py
@@ -23,8 +23,22 @@ def _ming_config_with_thinker_tp2(config_cls):
     return stages
 
 
-def _thinker_specs(config, build_stage_groups):
-    groups = build_stage_groups(config)
+def _build_groups(config, build_stage_groups, prepare_pipeline_runtime):
+    prep = prepare_pipeline_runtime(config)
+    try:
+        return build_stage_groups(
+            config,
+            stages_cfg=prep.stages_cfg,
+            name_map=prep.name_map,
+            endpoints=prep.endpoints,
+        )
+    finally:
+        if prep.runtime_dir is not None:
+            prep.runtime_dir.close()
+
+
+def _thinker_specs(config, build_stage_groups, prepare_pipeline_runtime):
+    groups = _build_groups(config, build_stage_groups, prepare_pipeline_runtime)
     thinker_group = next(group for group in groups if group.stage_name == "thinker")
     return thinker_group.specs
 
@@ -156,6 +170,7 @@ def test_ming_thinker_tp2_builds_rank_specific_stage_specs(monkeypatch) -> None:
             mp.setitem(sys.modules, "transformers.utils", fake_transformers_utils)
             mp.setitem(sys.modules, "transformers.utils.hub", fake_transformers_hub)
 
+            from sglang_omni_v1.config.compiler import prepare_pipeline_runtime
             from sglang_omni_v1.models.ming_omni.config import MingOmniPipelineConfig
             from sglang_omni_v1.pipeline.mp_runner import _build_stage_groups
 
@@ -164,7 +179,9 @@ def test_ming_thinker_tp2_builds_rank_specific_stage_specs(monkeypatch) -> None:
                 stages=_ming_config_with_thinker_tp2(MingOmniPipelineConfig),
             )
 
-            groups = _build_stage_groups(config)
+            groups = _build_groups(
+                config, _build_stage_groups, prepare_pipeline_runtime
+            )
             thinker_group = next(
                 group for group in groups if group.stage_name == "thinker"
             )
@@ -199,7 +216,9 @@ def test_ming_thinker_tp2_builds_rank_specific_stage_specs(monkeypatch) -> None:
                 model_path="dummy",
                 stages=scalar_stages,
             )
-            scalar_specs = _thinker_specs(scalar_config, _build_stage_groups)
+            scalar_specs = _thinker_specs(
+                scalar_config, _build_stage_groups, prepare_pipeline_runtime
+            )
             assert [spec.gpu_id for spec in scalar_specs] == [2, 3]
 
             explicit_stages = _ming_config_with_thinker_tp2(MingOmniPipelineConfig)
@@ -210,7 +229,9 @@ def test_ming_thinker_tp2_builds_rank_specific_stage_specs(monkeypatch) -> None:
                 model_path="dummy",
                 stages=explicit_stages,
             )
-            explicit_specs = _thinker_specs(explicit_config, _build_stage_groups)
+            explicit_specs = _thinker_specs(
+                explicit_config, _build_stage_groups, prepare_pipeline_runtime
+            )
             assert [spec.gpu_id for spec in explicit_specs] == [2, 4]
     finally:
         _purge_project_modules_with_fake_refs(before_import, fake_refs)
@@ -390,35 +411,3 @@ def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
     assert captured["nccl_port"] == 29500
     assert captured["model_arch_override"] == "BailingMoeV2ForCausalLM"
     assert scheduler.kwargs["server_args"] is server_args
-
-
-def test_ming_runner_keeps_chunk_state_until_final_chunk(monkeypatch) -> None:
-    from tests.test_ming_v1_phase4b import (
-        _fake_batch,
-        _fake_req,
-        _fake_runner,
-        _load_runner_with_fake_sglang,
-    )
-
-    torch, runner_cls = _load_runner_with_fake_sglang(monkeypatch)
-    runner = _fake_runner(torch, runner_cls, image=3)
-    image_embeds = torch.tensor([[20.0, 21.0], [22.0, 23.0]])
-    model_inputs = {"image_embeds": image_embeds}
-    req = _fake_req(model_inputs, is_chunked=1, rid="chunked-image")
-    forward_batch, schedule_batch = _fake_batch(torch, [3, 1], req)
-
-    input_embeds = runner._inject_multimodal_embeds(forward_batch, schedule_batch)
-
-    assert torch.equal(input_embeds[0], image_embeds[0])
-    assert req.omni_model_inputs is model_inputs
-    assert req._omni_consumed == {"image": 1}
-
-    req.is_chunked = 0
-    forward_batch, schedule_batch = _fake_batch(torch, [3, 2], req)
-
-    input_embeds = runner._inject_multimodal_embeds(forward_batch, schedule_batch)
-
-    assert torch.equal(input_embeds[0], image_embeds[1])
-    assert req.omni_model_inputs is None
-    assert req._omni_consumed is None
-    assert model_inputs == {"image_embeds": image_embeds}

--- a/tests/unit_test/ming_omni/test_tp.py
+++ b/tests/unit_test/ming_omni/test_tp.py
@@ -1,0 +1,424 @@
+# SPDX-License-Identifier: Apache-2.0
+"""TP=2 support tests."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from collections.abc import Iterable
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+_PROJECT_PREFIX = "sglang_omni_v1."
+
+
+def _ming_config_with_thinker_tp2(config_cls):
+    config = config_cls(model_path="dummy")
+    stages = [stage.model_copy(deep=True) for stage in config.stages]
+    for stage in stages:
+        if stage.name == "thinker":
+            stage.tp_size = 2
+            stage.gpu = [0, 1]
+    return stages
+
+
+def _thinker_specs(config, build_stage_groups):
+    groups = build_stage_groups(config)
+    thinker_group = next(group for group in groups if group.stage_name == "thinker")
+    return thinker_group.specs
+
+
+def _module_refs_any(module: ModuleType, refs: Iterable[object]) -> bool:
+    ref_ids = {id(ref) for ref in refs}
+    return any(id(value) in ref_ids for value in vars(module).values())
+
+
+def _purge_project_modules_with_fake_refs(
+    snapshot: set[str],
+    refs: Iterable[object],
+) -> set[str]:
+    purged: set[str] = set()
+    for name, module in list(sys.modules.items()):
+        if not name.startswith(_PROJECT_PREFIX) or not isinstance(module, ModuleType):
+            continue
+        if name not in snapshot or _module_refs_any(module, refs):
+            _remove_module(name, module)
+            purged.add(name)
+    _remove_cached_attrs_from_purged_modules(purged)
+    return purged
+
+
+def _remove_module(name: str, module: ModuleType) -> None:
+    sys.modules.pop(name, None)
+    parent_name, _, child_name = name.rpartition(".")
+    parent = sys.modules.get(parent_name)
+    if isinstance(parent, ModuleType) and getattr(parent, child_name, None) is module:
+        delattr(parent, child_name)
+
+
+def _remove_cached_attrs_from_purged_modules(purged: set[str]) -> None:
+    if not purged:
+        return
+    for module in list(sys.modules.values()):
+        if not isinstance(module, ModuleType) or not module.__name__.startswith(
+            _PROJECT_PREFIX
+        ):
+            continue
+        for attr_name, value in list(vars(module).items()):
+            value_module = getattr(value, "__module__", "")
+            if _module_name_matches_any(value_module, purged):
+                delattr(module, attr_name)
+
+
+def _module_name_matches_any(module_name: str, candidates: set[str]) -> bool:
+    return any(
+        module_name == candidate or module_name.startswith(f"{candidate}.")
+        for candidate in candidates
+    )
+
+
+def _project_modules_with_ref(ref: object) -> list[str]:
+    return [
+        name
+        for name, module in sys.modules.items()
+        if name.startswith(_PROJECT_PREFIX)
+        and isinstance(module, ModuleType)
+        and _module_refs_any(module, (ref,))
+    ]
+
+
+def _cached_attrs_from_missing_project_modules() -> list[str]:
+    stale_attrs: list[str] = []
+    for module_name, module in sys.modules.items():
+        if not module_name.startswith(_PROJECT_PREFIX) or not isinstance(
+            module, ModuleType
+        ):
+            continue
+        for attr_name, value in vars(module).items():
+            value_module = getattr(value, "__module__", "")
+            if not value_module.startswith(_PROJECT_PREFIX):
+                continue
+            if value_module not in sys.modules:
+                stale_attrs.append(f"{module_name}.{attr_name}->{value_module}")
+    return stale_attrs
+
+
+def test_ming_thinker_tp2_builds_rank_specific_stage_specs(monkeypatch) -> None:
+    importlib.import_module("sglang_omni_v1.pipeline")
+    before_import = set(sys.modules)
+    fake_torch = ModuleType("torch")
+    fake_torch.Tensor = object
+    fake_torch_nn = ModuleType("torch.nn")
+    fake_torch_nn.Module = object
+    fake_torch_distributed = ModuleType("torch.distributed")
+    fake_torch_distributed.ProcessGroup = object
+    fake_torch.distributed = fake_torch_distributed
+    fake_profiler = ModuleType("torch.profiler")
+    fake_profiler.ProfilerActivity = SimpleNamespace(CPU="cpu", CUDA="cuda")
+
+    class FakeProfile:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    fake_profiler.profile = FakeProfile
+    fake_transformers = ModuleType("transformers")
+    fake_transformers.AutoConfig = SimpleNamespace(from_pretrained=lambda *a, **k: None)
+    fake_transformers_init = ModuleType("transformers.initialization")
+    fake_transformers_init.no_init_weights = lambda: SimpleNamespace(
+        __enter__=lambda self: None,
+        __exit__=lambda self, exc_type, exc, tb: None,
+    )
+    fake_transformers_utils = ModuleType("transformers.utils")
+    fake_transformers_hub = ModuleType("transformers.utils.hub")
+    fake_transformers_hub.cached_file = lambda *a, **k: ""
+    fake_refs = (
+        fake_torch,
+        fake_torch_nn,
+        fake_torch_distributed,
+        fake_profiler,
+        fake_transformers,
+        fake_transformers_init,
+        fake_transformers_utils,
+        fake_transformers_hub,
+    )
+
+    try:
+        with monkeypatch.context() as mp:
+            mp.setitem(sys.modules, "torch", fake_torch)
+            mp.setitem(sys.modules, "torch.nn", fake_torch_nn)
+            mp.setitem(sys.modules, "torch.distributed", fake_torch_distributed)
+            mp.setitem(sys.modules, "torch.profiler", fake_profiler)
+            mp.setitem(sys.modules, "transformers", fake_transformers)
+            mp.setitem(
+                sys.modules, "transformers.initialization", fake_transformers_init
+            )
+            mp.setitem(sys.modules, "transformers.utils", fake_transformers_utils)
+            mp.setitem(sys.modules, "transformers.utils.hub", fake_transformers_hub)
+
+            from sglang_omni_v1.models.ming_omni.config import MingOmniPipelineConfig
+            from sglang_omni_v1.pipeline.mp_runner import _build_stage_groups
+
+            config = MingOmniPipelineConfig(
+                model_path="dummy",
+                stages=_ming_config_with_thinker_tp2(MingOmniPipelineConfig),
+            )
+
+            groups = _build_stage_groups(config)
+            thinker_group = next(
+                group for group in groups if group.stage_name == "thinker"
+            )
+            specs = thinker_group.specs
+            cpu_stage_specs = {
+                group.stage_name: group.specs[0]
+                for group in groups
+                if group.stage_name in {"preprocessing", "mm_aggregate", "decode"}
+            }
+            assert {name: spec.gpu_id for name, spec in cpu_stage_specs.items()} == {
+                "preprocessing": None,
+                "mm_aggregate": None,
+                "decode": None,
+            }
+            assert [spec.role for spec in specs] == ["leader", "follower"]
+            assert [spec.gpu_id for spec in specs] == [0, 1]
+            assert [spec.tp_rank for spec in specs] == [0, 1]
+            assert {spec.tp_size for spec in specs} == {2}
+            assert specs[0].nccl_port is not None
+            assert specs[0].nccl_port == specs[1].nccl_port
+            assert [spec.factory_args["gpu_id"] for spec in specs] == [0, 1]
+            assert [spec.factory_args["tp_rank"] for spec in specs] == [0, 1]
+            assert {spec.factory_args["tp_size"] for spec in specs} == {2}
+            assert specs[0].factory_args["nccl_port"] == specs[0].nccl_port
+            assert specs[1].factory_args["nccl_port"] == specs[0].nccl_port
+
+            scalar_stages = _ming_config_with_thinker_tp2(MingOmniPipelineConfig)
+            for stage in scalar_stages:
+                if stage.name == "thinker":
+                    stage.gpu = 2
+            scalar_config = MingOmniPipelineConfig(
+                model_path="dummy",
+                stages=scalar_stages,
+            )
+            scalar_specs = _thinker_specs(scalar_config, _build_stage_groups)
+            assert [spec.gpu_id for spec in scalar_specs] == [2, 3]
+
+            explicit_stages = _ming_config_with_thinker_tp2(MingOmniPipelineConfig)
+            for stage in explicit_stages:
+                if stage.name == "thinker":
+                    stage.gpu = [2, 4]
+            explicit_config = MingOmniPipelineConfig(
+                model_path="dummy",
+                stages=explicit_stages,
+            )
+            explicit_specs = _thinker_specs(explicit_config, _build_stage_groups)
+            assert [spec.gpu_id for spec in explicit_specs] == [2, 4]
+    finally:
+        _purge_project_modules_with_fake_refs(before_import, fake_refs)
+
+    assert _project_modules_with_ref(fake_torch) == []
+    assert _cached_attrs_from_missing_project_modules() == []
+
+
+def test_ming_speech_rejects_talker_inside_explicit_thinker_tp_gpus() -> None:
+    from sglang_omni_v1.models.ming_omni.config import MingOmniSpeechPipelineConfig
+
+    stages = _ming_config_with_thinker_tp2(MingOmniSpeechPipelineConfig)
+    for stage in stages:
+        if stage.name == "talker":
+            stage.gpu = 1
+
+    with pytest.raises(ValueError, match="collides"):
+        MingOmniSpeechPipelineConfig(model_path="dummy", stages=stages)
+
+
+def test_ming_speech_rejects_talker_on_non_contiguous_thinker_tp_gpu() -> None:
+    from sglang_omni_v1.models.ming_omni.config import MingOmniSpeechPipelineConfig
+
+    stages = _ming_config_with_thinker_tp2(MingOmniSpeechPipelineConfig)
+    for stage in stages:
+        if stage.name == "thinker":
+            stage.gpu = [0, 2]
+        if stage.name == "talker":
+            stage.gpu = 2
+
+    with pytest.raises(ValueError, match="collides"):
+        MingOmniSpeechPipelineConfig(model_path="dummy", stages=stages)
+
+
+def test_ming_speech_rejects_any_talker_gpu_list_overlap_with_thinker_tp() -> None:
+    from sglang_omni_v1.models.ming_omni.config import MingOmniSpeechPipelineConfig
+
+    stages = _ming_config_with_thinker_tp2(MingOmniSpeechPipelineConfig)
+    for stage in stages:
+        if stage.name == "thinker":
+            stage.gpu = [0, 2]
+        if stage.name == "talker":
+            stage.tp_size = 2
+            stage.gpu = [3, 2]
+
+    with pytest.raises(ValueError, match="collides"):
+        MingOmniSpeechPipelineConfig(model_path="dummy", stages=stages)
+
+
+def test_ming_speech_allows_talker_outside_explicit_thinker_tp_gpus() -> None:
+    from sglang_omni_v1.models.ming_omni.config import MingOmniSpeechPipelineConfig
+
+    stages = _ming_config_with_thinker_tp2(MingOmniSpeechPipelineConfig)
+    for stage in stages:
+        if stage.name == "talker":
+            stage.gpu = 2
+
+    config = MingOmniSpeechPipelineConfig(model_path="dummy", stages=stages)
+
+    assert config.gpu_placement["thinker"] == [0, 1]
+    assert config.gpu_placement["talker"] == 2
+
+
+def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    common_module = ModuleType("sglang_omni_v1.models.ming_omni.components.common")
+    common_module.load_ming_tokenizer = lambda _model_path: SimpleNamespace(
+        vocab_size=32000,
+        eos_token_id=2,
+    )
+    common_module.load_ming_config = lambda _model_path: SimpleNamespace(
+        llm_config=SimpleNamespace(vocab_size=32000)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni_v1.models.ming_omni.components.common",
+        common_module,
+    )
+
+    runner_module = ModuleType("sglang_omni_v1.model_runner.ming_thinker_model_runner")
+
+    class FakeMingThinkerModelRunner:
+        def __init__(self, model_worker, output_proc):
+            self.model_worker = model_worker
+            self.output_proc = output_proc
+
+    runner_module.MingThinkerModelRunner = FakeMingThinkerModelRunner
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni_v1.model_runner.ming_thinker_model_runner",
+        runner_module,
+    )
+
+    scheduling_bootstrap_module = ModuleType("sglang_omni_v1.scheduling.bootstrap")
+
+    def fake_create_sglang_infrastructure(
+        server_args,
+        gpu_id,
+        *,
+        tp_rank,
+        nccl_port,
+        model_arch_override,
+    ):
+        captured["server_args_tp_size"] = server_args.tp_size
+        captured["gpu_id"] = gpu_id
+        captured["tp_rank"] = tp_rank
+        captured["nccl_port"] = nccl_port
+        captured["model_arch_override"] = model_arch_override
+        model = object()
+        model_worker = SimpleNamespace(
+            model_runner=SimpleNamespace(model=model),
+        )
+        return (
+            model_worker,
+            "tree_cache",
+            "req_to_token_pool",
+            "token_to_kv_pool_allocator",
+            "prefill_mgr",
+            "decode_mgr",
+            "model_config",
+        )
+
+    scheduling_bootstrap_module.create_sglang_infrastructure = (
+        fake_create_sglang_infrastructure
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni_v1.scheduling.bootstrap",
+        scheduling_bootstrap_module,
+    )
+
+    omni_scheduler_module = ModuleType("sglang_omni_v1.scheduling.omni_scheduler")
+
+    class FakeOmniScheduler:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    omni_scheduler_module.OmniScheduler = FakeOmniScheduler
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni_v1.scheduling.omni_scheduler",
+        omni_scheduler_module,
+    )
+
+    sglang_backend_module = ModuleType("sglang_omni_v1.scheduling.sglang_backend")
+
+    class FakeSGLangOutputProcessor:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    sglang_backend_module.SGLangOutputProcessor = FakeSGLangOutputProcessor
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni_v1.scheduling.sglang_backend",
+        sglang_backend_module,
+    )
+
+    bootstrap = importlib.import_module("sglang_omni_v1.models.ming_omni.bootstrap")
+    server_args = SimpleNamespace(tp_size=1)
+
+    scheduler = bootstrap.create_thinker_scheduler(
+        server_args,
+        model_path="dummy",
+        gpu_id=1,
+        tp_rank=1,
+        tp_size=2,
+        nccl_port=29500,
+    )
+
+    assert captured["server_args_tp_size"] == 2
+    assert server_args.tp_size == 2
+    assert captured["gpu_id"] == 1
+    assert captured["tp_rank"] == 1
+    assert captured["nccl_port"] == 29500
+    assert captured["model_arch_override"] == "BailingMoeV2ForCausalLM"
+    assert scheduler.kwargs["server_args"] is server_args
+
+
+def test_ming_runner_keeps_chunk_state_until_final_chunk(monkeypatch) -> None:
+    from tests.test_ming_v1_phase4b import (
+        _fake_batch,
+        _fake_req,
+        _fake_runner,
+        _load_runner_with_fake_sglang,
+    )
+
+    torch, runner_cls = _load_runner_with_fake_sglang(monkeypatch)
+    runner = _fake_runner(torch, runner_cls, image=3)
+    image_embeds = torch.tensor([[20.0, 21.0], [22.0, 23.0]])
+    model_inputs = {"image_embeds": image_embeds}
+    req = _fake_req(model_inputs, is_chunked=1, rid="chunked-image")
+    forward_batch, schedule_batch = _fake_batch(torch, [3, 1], req)
+
+    input_embeds = runner._inject_multimodal_embeds(forward_batch, schedule_batch)
+
+    assert torch.equal(input_embeds[0], image_embeds[0])
+    assert req.omni_model_inputs is model_inputs
+    assert req._omni_consumed == {"image": 1}
+
+    req.is_chunked = 0
+    forward_batch, schedule_batch = _fake_batch(torch, [3, 2], req)
+
+    input_embeds = runner._inject_multimodal_embeds(forward_batch, schedule_batch)
+
+    assert torch.equal(input_embeds[0], image_embeds[1])
+    assert req.omni_model_inputs is None
+    assert req._omni_consumed is None
+    assert model_inputs == {"image_embeds": image_embeds}

--- a/tests/unit_test/ming_omni/test_tp.py
+++ b/tests/unit_test/ming_omni/test_tp.py
@@ -172,9 +172,9 @@ def test_ming_thinker_tp2_builds_rank_specific_stage_specs(monkeypatch) -> None:
             mp.setitem(sys.modules, "transformers.utils", fake_transformers_utils)
             mp.setitem(sys.modules, "transformers.utils.hub", fake_transformers_hub)
 
-            from sglang_omni.pipeline.runtime_config import prepare_pipeline_runtime
             from sglang_omni.models.ming_omni.config import MingOmniPipelineConfig
             from sglang_omni.pipeline.mp_runner import _build_stage_groups
+            from sglang_omni.pipeline.runtime_config import prepare_pipeline_runtime
 
             config = MingOmniPipelineConfig(
                 model_path="dummy",
@@ -292,6 +292,8 @@ def test_ming_bootstrap_aligns_server_args_tp_size_before_infra(
     common_module.load_ming_tokenizer = lambda _model_path: SimpleNamespace(
         vocab_size=32000,
         eos_token_id=2,
+        unk_token_id=0,
+        convert_tokens_to_ids=lambda token: 0,
     )
     common_module.load_ming_config = lambda _model_path: SimpleNamespace(
         llm_config=SimpleNamespace(vocab_size=32000)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Based on RFC https://github.com/sgl-project/sglang-omni/issues/429
Port Ming-Omni from the legacy runner to `sglang_omni_v1`, the staged pipeline (preprocess → thinker → talker) used by Qwen3-Omni and S2-Pro. Without this, Ming cannot run under the V1 scheduler, share its multiprocess stage runner, or benefit from the V1 OpenAI-compatible server.

## Modifications

- `models/ming_omni/`: add `bootstrap.py`, `stages.py`, `registration.py`; rewrite `config.py`, `preprocessor.py`, `vision_encoder.py`, `talker_executor.py`, `thinker.py`, and shared `components/common.py` to the V1 stage contract.
- `model_runner/ming_thinker_model_runner.py`: new Ming-specific thinker runner; wire into `model_worker.py` and `sglang_model_runner.py`.
- `scheduling/omni_scheduler.py`, `pipeline/mp_runner.py`, `pipeline/stage_process.py`, `serve/openai_api.py`: minor adjustments to support Ming's stage graph and chat-completion path.
-   Tests: tests/unit_test/ming_omni/test_{pipeline,thinker,talker,tp,tokenizer}.py, `tests/test_v1_omni_scheduler.py` and `tests/test_openai_api.py`.
## Related Issues
closes #405 
## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

### TTS

Category | Metric | v0 | v1 | Δ
-- | -- | -- | -- | --
Generation speed (Ming → audio, n=50, concurrency=1) | Completed / failed | 50 / 0 | 50 / 0 | —
Generation speed | Latency mean | 0.839 s | 0.580 s | -30.9%
Generation speed | Latency median | 0.808 s | 0.367 s | -54.6%
Generation speed | Latency p95 | 1.280 s | 0.607 s | -52.6%
Generation speed | Latency p99 | 1.431 s | 5.204 s | +263.7%
Generation speed | Audio duration mean | 4.140 s | 7.692 s | +85.8%
Generation speed | RTF mean (latency/audio) | 0.2074 | 0.0969 | -53.3%
Generation speed | RTF median | 0.2017 | 0.0508 | -74.8%
Generation speed | Throughput | 1.192 req/s | 1.723 req/s | +44.5%
Accuracy — WER (Whisper-large-v3 readback) | WER corpus | 2.30 % | 4.26 % | +85.2%
Accuracy — WER | WER per-sample mean | 2.50 % | 4.25 % | +70.0%
Accuracy — WER | WER per-sample median | 0.00 % | 0.00 % | —
Accuracy — WER | WER per-sample std | 6.49 % | 14.78 % | +127.7%
Accuracy — WER | WER per-sample p95 | 15.60 % | 15.60 % | 0%
Accuracy — WER | WER per-sample max | 33.33 % | 100.00 % | +200.0%
Accuracy — WER | WER<50% corpus (clean samples only) | 2.30 % | 2.70 % | +17.4%
Accuracy — WER | Samples with WER>50% | 0 / 50 (0.0 %) | 1 / 50 (2.0 %) | — (0→1)
ASR speed (Whisper-large-v3 evaluator, n=50) | Latency mean / median | 0.307 s / 0.292 s | 0.330 s / 0.296 s | +7.5% / +1.4%
ASR speed | Latency p95 / p99 | 0.421 s / 0.767 s | 0.541 s / 1.099 s | +28.5% / +43.3%
ASR speed | Total ASR time | 15.35 s | 16.50 s | +7.5%
ASR speed | Throughput | 3.257 samples/s | 3.030 samples/s | -7.0%
ASR speed | RTF mean / median | 0.0794 / 0.0703 | 0.0469 / 0.0397 | -40.9% / -43.5%
ASR speed | Audio processed | 207.00 s | 384.59 s | +85.8%


<!-- notionvc: 2831b9b7-9826-4305-adba-dc8d1d635319 -->

<h3>MMMU</h3>

Category | Metric | v0 | v1 | Δ
-- | -- | -- | -- | --
Accuracy | Total samples | 50 | 50 | —
Accuracy | Correct | 30 | 32 | +6.7%
Accuracy | Accuracy | 60.0% | 64.0% | +6.7%
Accuracy | Failed requests | 0 | 0 | —
Accuracy | MC parse fallback | 3 | 1 | -66.7%
Speed | Concurrency | 4 | 4 | —
Speed | Completed requests | 50 | 50 | —
Speed | Latency mean | 37.272 s | 8.321 s | -77.7%
Speed | Latency median | 35.339 s | 4.958 s | -86.0%
Speed | Latency p95 | 70.986 s | 17.864 s | -74.8%
Speed | Latency p99 | 79.375 s | 18.086 s | -77.2%
Speed | Throughput | 0.103 req/s | 0.461 req/s | +347.6%


<!-- notionvc: 251bbcff-381d-4b17-a9e1-a87114091938 -->

<h3>MMSU</h3>

Category | Metric | v0 | v1 | Δ
-- | -- | -- | -- | --
Accuracy | Total samples | 50 | 50 | —
Accuracy | Successful | 50 | 50 | —
Accuracy | Parseable | 50 | 50 | —
Accuracy | Correct | 22 | 30 | +36.4%
Accuracy | Overall accuracy | 44.00% | 60.00% | +36.4%
Per-category | Perception (N=23) | 30.43% | 47.83% | +57.2%
Per-category | Reasoning (N=27) | 55.56% | 70.37% | +26.7%
Speed | Latency mean | 0.377 s | 0.784 s | +108.0%
Speed | Latency p95 | 0.406 s | 1.154 s | +184.2%
Speed | Audio mean | 1.074 s | 2.661 s | +147.8%
Speed | RTF mean | 0.4246 | 0.4267 | +0.5%
Speed | Throughput | 10.32 req/s | 4.97 req/s | -51.8%
Speed | Audio returned | 50 / 50 | 50 / 50 | —


<!-- notionvc: a068d54a-52f2-44e7-bb89-b1d1d4a1008c -->

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Draft PRs are skipped even if labeled.
