### PR TITLE
[CI] apply a 25% slack for all worst-of-5 corpus wer thresholds

### DIFF
--- a/tests/test_model/test_qwen3_omni_mmmu_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmmu_talker_ci.py
@@ -34,6 +34,7 @@ from benchmarks.metrics.wer import print_wer_summary
 from sglang_omni.utils import find_available_port
 from tests.utils import (
     apply_slack,
+    apply_wer_slack,
     assert_speed_thresholds,
     assert_wer_partitioned,
     server_log_file,
@@ -66,7 +67,10 @@ MMMU_AUDIO_MIN_ACCURACY = 0.7
 # WER thresholds use a partitioned view of the per-sample distribution:
 #  - corpus WER over the "sane" subset (per-sample WER <= 50%)
 #  - count of catastrophic failures (per-sample WER > 50%)
-MMMU_AUDIO_WER_BELOW_50_CORPUS_MAX = 0.19
+MMMU_AUDIO_WER_BELOW_50_CORPUS_MAX = 0.1777
+MMMU_AUDIO_WER_BELOW_50_CORPUS_THRESHOLD = apply_wer_slack(
+    MMMU_AUDIO_WER_BELOW_50_CORPUS_MAX
+)
 MMMU_AUDIO_N_ABOVE_50_MAX = 2
 
 _MMMU_AUDIO_P95 = {
@@ -153,7 +157,7 @@ def test_mmmu_audio_wer_and_speed(
     assert "wer" in results, "Audio WER results missing from eval output"
     assert_wer_partitioned(
         results["wer"],
-        max_wer_below_50_corpus=MMMU_AUDIO_WER_BELOW_50_CORPUS_MAX,
+        max_wer_below_50_corpus=MMMU_AUDIO_WER_BELOW_50_CORPUS_THRESHOLD,
         max_n_above_50=MMMU_AUDIO_N_ABOVE_50_MAX,
     )
 

--- a/tests/test_model/test_qwen3_omni_mmsu_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_talker_ci.py
@@ -34,6 +34,7 @@ from sglang_omni.utils import find_available_port
 from tests.utils import (
     ServerHandle,
     apply_slack,
+    apply_wer_slack,
     assert_speed_thresholds,
     assert_wer_partitioned,
     server_log_file,
@@ -69,6 +70,9 @@ MMSU_AUDIO_MIN_ACCURACY = 0.5
 
 # Retuned after Qwen3-Omni talker sampler fix: MMSU talker stayed clean.
 MMSU_AUDIO_WER_BELOW_50_CORPUS_MAX = 0.024945770065075923
+MMSU_AUDIO_WER_BELOW_50_CORPUS_THRESHOLD = apply_wer_slack(
+    MMSU_AUDIO_WER_BELOW_50_CORPUS_MAX
+)
 MMSU_AUDIO_N_ABOVE_50_MAX = 0
 
 _MMSU_AUDIO_P95 = {
@@ -170,7 +174,7 @@ def test_mmsu_audio_wer_and_speed(
     assert "wer" in results, "Audio WER results missing from eval output"
     assert_wer_partitioned(
         results["wer"],
-        max_wer_below_50_corpus=MMSU_AUDIO_WER_BELOW_50_CORPUS_MAX,
+        max_wer_below_50_corpus=MMSU_AUDIO_WER_BELOW_50_CORPUS_THRESHOLD,
         max_n_above_50=MMSU_AUDIO_N_ABOVE_50_MAX,
     )
 

--- a/tests/test_model/test_qwen3_omni_tts_ci.py
+++ b/tests/test_model/test_qwen3_omni_tts_ci.py
@@ -28,6 +28,7 @@ from benchmarks.metrics.wer import print_wer_summary
 from sglang_omni.utils import find_available_port
 from tests.utils import (
     apply_slack,
+    apply_wer_slack,
     assert_per_request_fields,
     assert_speed_thresholds,
     assert_summary_metrics,
@@ -50,6 +51,7 @@ STARTUP_TIMEOUT = 300
 WER_TIMEOUT = 600
 
 VC_WER_BELOW_50_CORPUS_MAX = 0.014184397163120567
+VC_WER_BELOW_50_CORPUS_THRESHOLD = apply_wer_slack(VC_WER_BELOW_50_CORPUS_MAX)
 VC_N_ABOVE_50_MAX = 0
 
 # Note (Chenyang): The thresholds for the throughput_qps of tests/test_model/test_qwen3_omni_tts_ci.py
@@ -285,7 +287,7 @@ def test_voice_cloning_wer(
     print_wer_summary(results["summary"], "qwen3-omni")
     assert_wer_partitioned(
         results,
-        max_wer_below_50_corpus=VC_WER_BELOW_50_CORPUS_MAX,
+        max_wer_below_50_corpus=VC_WER_BELOW_50_CORPUS_THRESHOLD,
         max_n_above_50=VC_N_ABOVE_50_MAX,
     )
 

--- a/tests/test_model/test_qwen3_omni_videoamme_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_videoamme_talker_ci.py
@@ -28,6 +28,7 @@ from benchmarks.metrics.wer import print_wer_summary
 from tests.utils import (
     ServerHandle,
     apply_slack,
+    apply_wer_slack,
     assert_speed_thresholds,
     assert_wer_partitioned,
 )
@@ -37,7 +38,10 @@ MAX_SAMPLES = 10
 MAX_TOKENS = 256
 
 VIDEOAMME_TALKER_THINKER_TEXT_MIN_ACCURACY = 0.4
-VIDEOAMME_TALKER_WER_BELOW_50_CORPUS_MAX = 0.015
+VIDEOAMME_TALKER_WER_BELOW_50_CORPUS_MAX = 0.0133
+VIDEOAMME_TALKER_WER_BELOW_50_CORPUS_THRESHOLD = apply_wer_slack(
+    VIDEOAMME_TALKER_WER_BELOW_50_CORPUS_MAX
+)
 VIDEOAMME_TALKER_N_ABOVE_50_MAX = 1
 
 _VIDEOAMME_TALKER_AUDIO_P95 = {
@@ -104,7 +108,7 @@ def test_videoamme_talker_accuracy_wer_and_speed(
     assert "wer" in results, "Audio WER results missing from Video-AMME Talker output"
     assert_wer_partitioned(
         results["wer"],
-        max_wer_below_50_corpus=VIDEOAMME_TALKER_WER_BELOW_50_CORPUS_MAX,
+        max_wer_below_50_corpus=VIDEOAMME_TALKER_WER_BELOW_50_CORPUS_THRESHOLD,
         max_n_above_50=VIDEOAMME_TALKER_N_ABOVE_50_MAX,
     )
     assert_speed_thresholds(results["speed"], VIDEOAMME_TALKER_THRESHOLDS, CONCURRENCY)

--- a/tests/test_model/test_qwen3_omni_videomme_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_videomme_talker_ci.py
@@ -37,6 +37,7 @@ from benchmarks.metrics.wer import print_wer_summary
 from tests.utils import (
     ServerHandle,
     apply_slack,
+    apply_wer_slack,
     assert_speed_thresholds,
     assert_wer_partitioned,
 )
@@ -52,6 +53,9 @@ SHORT_ANSWER_PROMPT = (
 VIDEOMME_TALKER_THINKER_TEXT_MIN_ACCURACY = 0.5
 # Retuned after Qwen3-Omni talker sampler fix: Video-MME talker stayed clean.
 VIDEOMME_TALKER_WER_BELOW_50_CORPUS_MAX = 0.014005602240896359
+VIDEOMME_TALKER_WER_BELOW_50_CORPUS_THRESHOLD = apply_wer_slack(
+    VIDEOMME_TALKER_WER_BELOW_50_CORPUS_MAX
+)
 VIDEOMME_TALKER_N_ABOVE_50_MAX = 0
 
 _VIDEOMME_TALKER_AUDIO_P95 = {
@@ -126,7 +130,7 @@ def test_videomme_tts_accuracy_wer_and_speed(
     assert "wer" in results, "Audio WER results missing from Video-MME Talker output"
     assert_wer_partitioned(
         results["wer"],
-        max_wer_below_50_corpus=VIDEOMME_TALKER_WER_BELOW_50_CORPUS_MAX,
+        max_wer_below_50_corpus=VIDEOMME_TALKER_WER_BELOW_50_CORPUS_THRESHOLD,
         max_n_above_50=VIDEOMME_TALKER_N_ABOVE_50_MAX,
     )
     assert_speed_thresholds(results["speed"], VIDEOMME_TALKER_THRESHOLDS, CONCURRENCY)

--- a/tests/test_model/test_s2pro_tts_ci.py
+++ b/tests/test_model/test_s2pro_tts_ci.py
@@ -47,6 +47,7 @@ from tests.test_model.conftest import (
 )
 from tests.utils import (
     apply_slack,
+    apply_wer_slack,
     assert_per_request_fields,
     assert_speed_thresholds,
     assert_streaming_consistency,
@@ -90,8 +91,10 @@ THRESHOLD_SLACK_HIGHER = 0.75
 THRESHOLD_SLACK_LOWER = 1.25
 
 VC_WER_MAX_CORPUS = 0.010638297872340425
+VC_WER_CORPUS_THRESHOLD = apply_wer_slack(VC_WER_MAX_CORPUS)
 VC_WER_MAX_PER_SAMPLE = 0.25
-VC_STREAM_WER_MAX_CORPUS = 0.03
+VC_STREAM_WER_MAX_CORPUS = 0.0258
+VC_STREAM_WER_CORPUS_THRESHOLD = apply_wer_slack(VC_STREAM_WER_MAX_CORPUS)
 VC_STREAM_WER_MAX_PER_SAMPLE = 0.17
 
 # Note (Chenyang): Only thresholds for concurrency 8 are dedicatedly tuned, others
@@ -539,7 +542,7 @@ def test_voice_cloning_wer(
             str(dataset_dir / "en" / "meta.lst"),
             wer_input_dirs["non_stream"][concurrency],
         )
-        assert_wer_results(results, VC_WER_MAX_CORPUS, VC_WER_MAX_PER_SAMPLE)
+        assert_wer_results(results, VC_WER_CORPUS_THRESHOLD, VC_WER_MAX_PER_SAMPLE)
 
 
 @pytest.mark.s2pro_stage(S2PRO_STAGE_STREAM)
@@ -562,7 +565,9 @@ def test_voice_cloning_streaming_wer(
             stream=True,
         )
         assert_wer_results(
-            results, VC_STREAM_WER_MAX_CORPUS, VC_STREAM_WER_MAX_PER_SAMPLE
+            results,
+            VC_STREAM_WER_CORPUS_THRESHOLD,
+            VC_STREAM_WER_MAX_PER_SAMPLE,
         )
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -235,6 +235,11 @@ def apply_slack(
     return result
 
 
+def apply_wer_slack(reference: float, slack: float = 1.25) -> float:
+    """Derive a max WER threshold from a reference value with uniform slack."""
+    return round(reference * slack, 4)
+
+
 def assert_speed_thresholds(summary: dict, thresholds: dict, concurrency: int) -> None:
     """Assert speed benchmark summary meets threshold requirements.
 


### PR DESCRIPTION
## Summary

Apply a consistent 25% slack to corpus-level WER thresholds in Qwen3-Omni and S2-Pro CI tests.

The original `*_MAX` constants are kept as reference values. The actual assertion thresholds are now derived through `apply_wer_slack(...)` and stored in `*_THRESHOLD` constants.

## Changes

- Added `apply_wer_slack(reference, slack=1.25)` in `tests/utils.py`.
- Applied WER slack to Qwen3-Omni TTS, MMMU talker, MMSU talker, Video-MME talker, and Video-AMME talker CI tests.
- Applied WER slack to S2-Pro non-streaming and streaming TTS WER tests.
- According to the experiment results in PR #422 , set worst-of-5 corpus WER for all stages.
