### PR TITLE
docs(router): add user-facing troubleshooting guide

### DIFF
--- a/docs/basic_usage/omni_router.md
+++ b/docs/basic_usage/omni_router.md
@@ -394,3 +394,122 @@ point with:
 ```bash
 python -m sglang_omni_router.serve --help
 ```
+
+## Troubleshooting
+
+### Worker Stuck in `unknown` State
+
+A worker starts in `unknown` and stays there until it passes
+`health_success_threshold` consecutive health checks. This is normal at
+startup. If a worker remains `unknown` beyond the expected startup window:
+
+1. Confirm the worker process is reachable on its port:
+   ```bash
+   curl -i http://127.0.0.1:8011/health
+   ```
+2. Check `last_error` in `/workers` for the exact connection failure:
+   ```bash
+   curl -s http://127.0.0.1:8008/workers | python3 -c "
+   import json, sys
+   for w in json.load(sys.stdin)['workers']:
+       print(w['display_id'], w['health_state'], w['last_error'])
+   "
+   ```
+3. Verify `--health-check-endpoint` matches the path the worker actually
+   serves (default `/health`).
+
+### Worker Stuck in `unhealthy` State
+
+An `unhealthy` worker re-enters the routable pool once it passes
+`health_success_threshold` consecutive health checks. If it does not recover:
+
+1. Check `last_error` and `consecutive_failures` via `/workers`.
+2. Confirm the worker process has not crashed:
+   ```bash
+   curl -i http://127.0.0.1:8011/health
+   ```
+3. To force a reset without restarting the router, quarantine the worker and
+   then clear the dead flag so health checks can re-qualify it:
+   ```bash
+   curl -s -X PUT http://127.0.0.1:8008/workers/http%3A%2F%2F127.0.0.1%3A8011 \
+     -H "Content-Type: application/json" -d '{"is_dead": true}'
+   curl -s -X PUT http://127.0.0.1:8008/workers/http%3A%2F%2F127.0.0.1%3A8011 \
+     -H "Content-Type: application/json" -d '{"is_dead": false}'
+   ```
+
+### Router Returns 503 on Every Request
+
+`503` means no worker is currently routable. Check `/workers` first:
+
+```bash
+curl -s http://127.0.0.1:8008/workers
+```
+
+Common causes:
+
+- **Workers still starting**: `routable_workers` is zero but `health_state`
+  values are `unknown`. Wait for the health check loop to qualify them, or
+  lower `--health-check-interval-secs` during debugging.
+- **All workers unhealthy**: `health_state` is `unhealthy` for every worker.
+  Check `last_error` per worker (see [Worker Stuck in unhealthy State](#worker-stuck-in-unhealthy-state)).
+- **Capability mismatch**: workers are routable but none supports the
+  capabilities the request requires. See
+  [Mixed-Capability Pool](#mixed-capability-pool-requests-always-return-503).
+
+### Mixed-Capability Pool: Requests Always Return 503
+
+When using `--worker-config` with heterogeneous workers, a request returns
+`503` if no routable worker declares all the capabilities the request needs.
+
+Inspect what each worker currently advertises:
+
+```bash
+curl -s http://127.0.0.1:8008/workers | python3 -c "
+import json, sys
+for w in json.load(sys.stdin)['workers']:
+    print(w['display_id'], w['routable'], sorted(w['capabilities']))
+"
+```
+
+To isolate whether the issue is capability routing or worker health, force a
+specific capability set with a request header and check whether the request
+succeeds:
+
+```bash
+curl http://127.0.0.1:8008/v1/chat/completions \
+  -H "X-SGLang-Omni-Route-Capabilities: chat" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "qwen3-omni", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 8}'
+```
+
+If this succeeds, the original request requires a capability that no worker
+declares. Update the worker `capabilities` list in `--worker-config` or the
+launcher `worker_capabilities` field to match what the workers actually
+support.
+
+### Draining a Worker Before Taking It Offline
+
+Disable the worker first so the router stops sending new requests to it, then
+wait for in-flight requests to finish before deleting it:
+
+```bash
+# Stop new requests from being routed to this worker
+curl -s -X PUT http://127.0.0.1:8008/workers/http%3A%2F%2F127.0.0.1%3A8013 \
+  -H "Content-Type: application/json" -d '{"disabled": true}'
+
+# Wait until active_requests reaches zero
+while true; do
+  active=$(curl -s http://127.0.0.1:8008/workers | python3 -c "
+import json, sys
+workers = json.load(sys.stdin)['workers']
+target = next((w for w in workers if '8013' in w['url']), None)
+print(target['active_requests'] if target else 0)
+")
+  echo "active_requests=$active"
+  [ "$active" = "0" ] && break
+  sleep 2
+done
+
+# Remove the worker entry and stop the worker process
+curl -s -X DELETE http://127.0.0.1:8008/workers/http%3A%2F%2F127.0.0.1%3A8013
+```

--- a/docs/basic_usage/omni_router.md
+++ b/docs/basic_usage/omni_router.md
@@ -475,14 +475,16 @@ Use the response and health signals to choose the next step:
 | Model request: `503`, `type=overloaded_error`, `Retry-After: 1` | Router admission is full. | Back off and inspect `inflight`, `max_inflight`, and `rejected_total` in `/health`. |
 | Model request: `503`, `message=no eligible upstream` | No routable worker matches the request. | Check worker routability, model, and capabilities. |
 | Model request: `503` with `X-SGLang-Omni-Worker` | The selected worker returned `503`. | Inspect that worker's logs and `/health` endpoint. |
-| Streaming response starts with `200` but ends early | The worker failed after response headers were relayed, so the status can no longer become `502`. An SSE response ends with a terminal `upstream stream failed before completion` event whose body carries `"code": 502`; the HTTP status stays `200`. A non-SSE response, such as audio or JSON, truncates with no error frame. | Check the route-completion log for `outcome=stream_error` (a client disconnect logs `stream_cancelled` instead), then inspect the selected worker. |
+| Streaming response starts with `200` but ends early | The upstream stream failed after the HTTP status was sent. SSE responses end with an `upstream stream failed before completion` event whose body carries `"code": 502`; non-SSE streaming bodies truncate without an error frame. | Check the route-completion log for `outcome=stream_error` (a client disconnect logs `stream_cancelled` instead), then inspect the selected worker. |
 
 For admission limits, rejection logs, and capacity guidance, see
-[Overload Behavior](#overload-behavior). Selection failures contain
-`reason=no_eligible_upstream` plus the inferred model and capabilities. They
-occur before a worker is chosen and therefore have no
-`X-SGLang-Omni-Worker` header. A worker-returned `503` does not by itself evict
-the worker.
+[Overload Behavior](#overload-behavior).
+
+Selection failures contain `reason=no_eligible_upstream` plus the inferred model
+and capabilities. They occur before a worker is chosen and therefore have no
+`X-SGLang-Omni-Worker` header.
+
+A worker-returned `503` does not by itself evict the worker.
 
 ### Distinguish `502` Responses
 

--- a/docs/basic_usage/omni_router.md
+++ b/docs/basic_usage/omni_router.md
@@ -469,24 +469,26 @@ Use the response and health signals to choose the next step:
 |---|---|---|
 | `/live` fails | The Router process is not reachable. | Check the process, bind address, port, and startup logs. |
 | `/live` is `200`, `/ready` is `503` | No worker is routable. | Inspect the worker states in `/workers`. |
+| Model request: `413`, `message=payload too large` | The request body exceeds `--max-payload-size`. | Reduce the request size or, after checking memory and concurrency impact, raise the configured limit. |
+| Large JSON model request: `400` requiring a route-hint header | JSON bodies larger than 1 MiB are not fully parsed, so the Router cannot infer the model or capabilities needed to select from a mixed worker pool. | Set the header named in the error message, such as `x-sglang-omni-route-model` or `x-sglang-omni-route-capabilities`; see [Routing Behavior](#routing-behavior). |
+| Model request: `400`, `message` names a route-hint header | A route-hint header is malformed or disagrees with the JSON body: an empty value, an unsupported capability, or a value that conflicts with the body's `model` or `stream`. | Read the message; it names the offending header. The rejection log records the same message in `reason=`, with spaces replaced by underscores. |
 | Model request: `503`, `type=overloaded_error`, `Retry-After: 1` | Router admission is full. | Back off and inspect `inflight`, `max_inflight`, and `rejected_total` in `/health`. |
 | Model request: `503`, `message=no eligible upstream` | No routable worker matches the request. | Check worker routability, model, and capabilities. |
 | Model request: `503` with `X-SGLang-Omni-Worker` | The selected worker returned `503`. | Inspect that worker's logs and `/health` endpoint. |
+| Streaming response starts with `200` but ends early | The worker failed after response headers were relayed, so the status can no longer become `502`. An SSE response ends with a terminal `upstream stream failed before completion` event whose body carries `"code": 502`; the HTTP status stays `200`. A non-SSE response, such as audio or JSON, truncates with no error frame. | Check the route-completion log for `outcome=stream_error` (a client disconnect logs `stream_cancelled` instead), then inspect the selected worker. |
 
-Admission rejection logs contain `reason=router_overloaded`; selection failures
-contain `reason=no_eligible_upstream` plus the inferred model and capabilities.
-A selection failure occurs before a worker is chosen and therefore has no
+For admission limits, rejection logs, and capacity guidance, see
+[Overload Behavior](#overload-behavior). Selection failures contain
+`reason=no_eligible_upstream` plus the inferred model and capabilities. They
+occur before a worker is chosen and therefore have no
 `X-SGLang-Omni-Worker` header. A worker-returned `503` does not by itself evict
 the worker.
 
-Measure worker-pool capacity and acceptable latency before raising
-`--max-connections` or `--max-inflight`; a higher bound can replace fast
-rejections with a longer queue.
-
 ### Distinguish `502` Responses
 
-Both kinds of `502` include `X-SGLang-Omni-Worker`; use the body to distinguish
-them:
+For model requests that select a single worker, a `502` with
+`X-SGLang-Omni-Worker` can come from either the Router or the selected worker.
+Use the body to distinguish them:
 
 - `{"error": {"message": "upstream request failed"}}`: the Router selected a
   worker, but a connection error or timeout prevented it from obtaining a
@@ -495,20 +497,26 @@ them:
 - Any other body: the selected worker returned its own `502`, which the Router
   relayed. Investigate that worker's upstream dependencies.
 
-Transport failures and worker-returned `502` or `504` responses count toward
-`--health-failure-threshold`. A threshold of `1` marks the worker unhealthy on
-the first such failure.
+This distinction does not apply to `/v1/models` or administrative broadcast
+routes. Those routes may return a Router-generated `502` without selecting a
+single worker and therefore without `X-SGLang-Omni-Worker`.
+
+For how transport failures and worker-returned `502` or `504` responses affect
+worker health, see [Failure Handling](#failure-handling).
 
 ### Inspect Worker State
 
-Print the fields used to determine routability:
+Print the fields used to determine routability. `worker_id` is the
+percent-encoded identifier the admin routes expect; `display_id` is the
+host and port shown in logs:
 
 ```bash
 curl -s http://127.0.0.1:8008/workers | python3 -c '
 import json, sys
 for worker in json.load(sys.stdin)["workers"]:
     print(
-        worker["display_id"],
+        "worker_id=" + worker["worker_id"],
+        "display_id=" + worker["display_id"],
         "state=" + worker["health_state"],
         "disabled=" + str(worker["disabled"]),
         "routable=" + str(worker["routable"]),
@@ -582,9 +590,10 @@ curl -fsS -X DELETE "http://127.0.0.1:8008/workers/${worker_id}"
 )
 ```
 
-Copy `worker_id` from `/workers` rather than constructing it manually, and raise
-`max_wait_secs` for workloads whose responses can legitimately exceed the
-default 30-minute drain window.
+Copy `worker_id` from `/workers` rather than constructing it manually; the
+snippet in [Inspect Worker State](#inspect-worker-state) prints it in a form you
+can paste directly. Raise `max_wait_secs` for workloads whose responses can
+legitimately exceed the default 30-minute drain window.
 
 Deleting a worker removes only its Router registration. Stop the worker process
 separately after the drain completes.

--- a/docs/basic_usage/omni_router.md
+++ b/docs/basic_usage/omni_router.md
@@ -456,3 +456,135 @@ point with:
 ```bash
 python -m sglang_omni_router.serve --help
 ```
+
+## Troubleshooting
+
+Check the Router and worker pool before restarting any process — see
+[Check Router and Worker State](#check-router-and-worker-state) for the endpoint
+commands and their meanings.
+
+Use the response and health signals to choose the next step:
+
+| Signal | Meaning | Action |
+|---|---|---|
+| `/live` fails | The Router process is not reachable. | Check the process, bind address, port, and startup logs. |
+| `/live` is `200`, `/ready` is `503` | No worker is routable. | Inspect the worker states in `/workers`. |
+| Model request: `503`, `type=overloaded_error`, `Retry-After: 1` | Router admission is full. | Back off and inspect `inflight`, `max_inflight`, and `rejected_total` in `/health`. |
+| Model request: `503`, `message=no eligible upstream` | No routable worker matches the request. | Check worker routability, model, and capabilities. |
+| Model request: `503` with `X-SGLang-Omni-Worker` | The selected worker returned `503`. | Inspect that worker's logs and `/health` endpoint. |
+
+Admission rejection logs contain `reason=router_overloaded`; selection failures
+contain `reason=no_eligible_upstream` plus the inferred model and capabilities.
+A selection failure occurs before a worker is chosen and therefore has no
+`X-SGLang-Omni-Worker` header. A worker-returned `503` does not by itself evict
+the worker.
+
+Measure worker-pool capacity and acceptable latency before raising
+`--max-connections` or `--max-inflight`; a higher bound can replace fast
+rejections with a longer queue.
+
+### Distinguish `502` Responses
+
+Both kinds of `502` include `X-SGLang-Omni-Worker`; use the body to distinguish
+them:
+
+- `{"error": {"message": "upstream request failed"}}`: the Router selected a
+  worker, but a connection error or timeout prevented it from obtaining a
+  response. Check the selected worker process, its port, and its `/health`
+  endpoint.
+- Any other body: the selected worker returned its own `502`, which the Router
+  relayed. Investigate that worker's upstream dependencies.
+
+Transport failures and worker-returned `502` or `504` responses count toward
+`--health-failure-threshold`. A threshold of `1` marks the worker unhealthy on
+the first such failure.
+
+### Inspect Worker State
+
+Print the fields used to determine routability:
+
+```bash
+curl -s http://127.0.0.1:8008/workers | python3 -c '
+import json, sys
+for worker in json.load(sys.stdin)["workers"]:
+    print(
+        worker["display_id"],
+        "state=" + worker["health_state"],
+        "disabled=" + str(worker["disabled"]),
+        "routable=" + str(worker["routable"]),
+        "failures=" + str(worker["consecutive_failures"]),
+        "last_error=" + str(worker["last_error"]),
+    )
+'
+```
+
+| State | Meaning and action |
+|---|---|
+| `unknown` | The worker has not passed `--health-success-threshold` checks. Confirm its `/health` endpoint is reachable and wait for startup checks. |
+| `unhealthy` | Failures reached `--health-failure-threshold`. Inspect `last_status_code`, `last_error`, and worker logs. Successful checks restore it automatically. |
+| `dead` | The worker was manually quarantined and health probes skip it. Resolve the problem before clearing `is_dead`; the Router checks health before routing to it again. |
+| `disabled: true` | The worker is administratively excluded even if healthy. Re-enable it only when it is ready for new requests. |
+
+Also verify that `--health-check-endpoint` matches the endpoint exposed by the
+worker.
+
+For `no eligible upstream`, compare the request with each routable worker's
+`model` and `capabilities` in `/workers`; see
+[Routing Behavior](#routing-behavior) for the capability mapping and route-hint
+headers.
+
+Model filtering applies only when at least one candidate worker advertises a
+`model`. Do not clear model metadata to work around a mismatch: if no candidate
+advertises a model, the Router stops filtering by model.
+
+### Drain and Remove a Worker
+
+Disable the worker first so it receives no new requests, wait for
+`active_requests` to reach zero, and then delete it:
+
+```bash
+(  # subshell: a failed step exits the procedure, not your shell
+worker_id='http%3A%2F%2F127.0.0.1%3A8013'
+max_wait_secs=1800
+deadline=$((SECONDS + max_wait_secs))
+
+curl -fsS -X PUT "http://127.0.0.1:8008/workers/${worker_id}" \
+  -H "Content-Type: application/json" \
+  -d '{"disabled":true}' ||
+  exit 1
+
+while true; do
+  active_requests=$(
+    curl -fsS http://127.0.0.1:8008/workers |
+      python3 -c '
+import json, sys
+target = sys.argv[1]
+workers = json.load(sys.stdin)["workers"]
+worker = next((item for item in workers if item["worker_id"] == target), None)
+print(worker["active_requests"] if worker else "missing")
+' "${worker_id}"
+  ) || exit 1
+  case "${active_requests}" in
+    0) break ;;
+    missing)
+      echo "worker ${worker_id} is not registered; check /workers" >&2
+      exit 1
+      ;;
+  esac
+  if (( SECONDS >= deadline )); then
+    echo "timed out waiting for ${worker_id} to drain" >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+curl -fsS -X DELETE "http://127.0.0.1:8008/workers/${worker_id}"
+)
+```
+
+Copy `worker_id` from `/workers` rather than constructing it manually, and raise
+`max_wait_secs` for workloads whose responses can legitimately exceed the
+default 30-minute drain window.
+
+Deleting a worker removes only its Router registration. Stop the worker process
+separately after the drain completes.


### PR DESCRIPTION
## Motivation

The Router documentation describes routing and recovery behavior, but it does not provide a symptom-oriented guide for operators diagnosing common failures.

This PR adds troubleshooting guidance for the Router behavior and interfaces available on the current `main` branch. Multi-process Router and CP/DP troubleshooting are intentionally out of scope until those interfaces land.

## Modifications

Updated `docs/basic_usage/omni_router.md` with a `Troubleshooting` section covering:

- distinguishing Router admission overload, no eligible upstream, and worker-returned `503` responses
- distinguishing Router-generated and worker-relayed `502` responses
- inspecting `unknown`, `unhealthy`, `dead`, and administratively disabled workers
- diagnosing model and capability mismatches
- safely draining and removing a worker with bounded waiting and explicit error handling

The original E2E test proposal has been removed from this PR scope and can be tracked separately if needed.

## Validation

- `python -m pytest tests/unit_test/router/test_app.py tests/unit_test/router/test_core.py -q`
- 160 passed
- `git diff --check`

## Related

Related to #401

## Checklist

- [x] Format documentation and examples
- [x] Validate Router unit tests with CPU mocks
- [x] Update documentation
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed (not applicable to this documentation-only change)
- [ ] For reviewers: If you have not made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.