### PR TITLE
feat(scheduler): add max_concurrency to SimpleScheduler for parallel _fn dispatch

### DIFF
--- a/sglang_omni/scheduling/simple_scheduler.py
+++ b/sglang_omni/scheduling/simple_scheduler.py
@@ -245,7 +245,8 @@ class SimpleScheduler:
         try:
             await asyncio.gather(bridge_task, *worker_tasks)
         except asyncio.CancelledError:
-            pass
+            # Expected during shutdown/task cancellation; suppress intentionally.
+            logger.debug("SimpleScheduler: _run_workers cancelled during shutdown")
 
     def stop(self) -> None:
         self._running = False

--- a/sglang_omni/scheduling/simple_scheduler.py
+++ b/sglang_omni/scheduling/simple_scheduler.py
@@ -37,6 +37,7 @@ class SimpleScheduler:
         max_batch_wait_ms: int = 0,
         request_cost_fn: Callable[[Any], int] | None = None,
         max_batch_cost: int | None = None,
+        max_concurrency: int = 1,
     ):
         self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
         self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
@@ -48,6 +49,15 @@ class SimpleScheduler:
         self._max_batch_cost = (
             max(int(max_batch_cost), 0) if max_batch_cost is not None else None
         )
+        # max_concurrency > 1 spawns N worker coroutines that dispatch ``compute_fn``
+        # via ``asyncio.to_thread`` so synchronous chunks do not pin the event loop.
+        # Requires ``compute_fn`` to be re-entrant. Mutually exclusive with the
+        # ``batch_compute_fn`` path (set one or the other, not both).
+        self._max_concurrency = max(int(max_concurrency), 1)
+        if self._max_concurrency > 1 and batch_compute_fn is not None:
+            raise ValueError(
+                "max_concurrency > 1 and batch_compute_fn are mutually exclusive"
+            )
         self._running = False
         self._pending_messages: collections.deque[IncomingMessage] = collections.deque()
 
@@ -151,6 +161,12 @@ class SimpleScheduler:
     def start(self) -> None:
         """Run the processing loop (blocks the thread)."""
         self._running = True
+        if self._max_concurrency > 1:
+            self._start_concurrent()
+        else:
+            self._start_serial()
+
+    def _start_serial(self) -> None:
         loop = asyncio.new_event_loop()
         try:
             while self._running:
@@ -175,6 +191,61 @@ class SimpleScheduler:
                             )
         finally:
             loop.close()
+
+    def _start_concurrent(self) -> None:
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(self._run_workers(loop))
+        finally:
+            loop.close()
+
+    async def _run_workers(self, loop: asyncio.AbstractEventLoop) -> None:
+        async_inbox: asyncio.Queue[IncomingMessage] = asyncio.Queue()
+
+        async def bridge_inbox() -> None:
+            while self._running:
+                try:
+                    msg = await loop.run_in_executor(
+                        None, lambda: self.inbox.get(timeout=0.05)
+                    )
+                except _queue_mod.Empty:
+                    continue
+                await async_inbox.put(msg)
+
+        async def worker() -> None:
+            while self._running:
+                try:
+                    msg = await asyncio.wait_for(async_inbox.get(), timeout=0.1)
+                except asyncio.TimeoutError:
+                    continue
+                if msg.type != "new_request":
+                    continue
+                try:
+                    if asyncio.iscoroutinefunction(self._fn):
+                        # async compute_fn: run on a worker thread under its own
+                        # event loop so sync chunks inside it do not pin the
+                        # scheduler's event loop.
+                        def _run_async_in_thread() -> Any:
+                            return asyncio.run(self._fn(msg.data))
+
+                        result = await asyncio.to_thread(_run_async_in_thread)
+                    else:
+                        result = await asyncio.to_thread(self._fn, msg.data)
+                    self._emit_result(msg.request_id, result, self.outbox)
+                except Exception as exc:
+                    logger.exception(
+                        "SimpleScheduler: compute_fn failed for %s", msg.request_id
+                    )
+                    self._emit_error(msg.request_id, exc, self.outbox)
+
+        bridge_task = asyncio.create_task(bridge_inbox())
+        worker_tasks = [
+            asyncio.create_task(worker()) for _ in range(self._max_concurrency)
+        ]
+        try:
+            await asyncio.gather(bridge_task, *worker_tasks)
+        except asyncio.CancelledError:
+            pass
 
     def stop(self) -> None:
         self._running = False

--- a/sglang_omni/scheduling/simple_scheduler.py
+++ b/sglang_omni/scheduling/simple_scheduler.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 
 import asyncio
 import collections
+import inspect
 import logging
 import queue as _queue_mod
 import time
-from typing import Any, Callable
+from typing import Any, Awaitable, Callable
 
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
 
@@ -49,10 +50,11 @@ class SimpleScheduler:
         self._max_batch_cost = (
             max(int(max_batch_cost), 0) if max_batch_cost is not None else None
         )
-        # max_concurrency > 1 spawns N worker coroutines that dispatch ``compute_fn``
-        # via ``asyncio.to_thread`` so synchronous chunks do not pin the event loop.
-        # Requires ``compute_fn`` to be re-entrant. Mutually exclusive with the
-        # ``batch_compute_fn`` path (set one or the other, not both).
+        # Note (Chenchen, Chenyang):
+        # max_concurrency > 1 spawns N worker coroutines that dispatch compute_fn
+        # via asyncio.to_thread so synchronous chunks do not pin the event loop.
+        # Requires compute_fn to be re-entrant. Mutually exclusive with the
+        # batch_compute_fn path (set one or the other, not both).
         self._max_concurrency = max(int(max_concurrency), 1)
         if self._max_concurrency > 1 and batch_compute_fn is not None:
             raise ValueError(
@@ -158,6 +160,16 @@ class SimpleScheduler:
         for msg, result in zip(batch, results):
             self._emit_result(msg.request_id, result, self.outbox)
 
+    @staticmethod
+    async def _await_result(result: Awaitable[Any]) -> Any:
+        return await result
+
+    def _run_compute_in_thread(self, payload: Any) -> Any:
+        result = self._fn(payload)
+        if inspect.isawaitable(result):
+            result = asyncio.run(self._await_result(result))
+        return result
+
     def start(self) -> None:
         """Run the processing loop (blocks the thread)."""
         self._running = True
@@ -221,16 +233,9 @@ class SimpleScheduler:
                 if msg.type != "new_request":
                     continue
                 try:
-                    if asyncio.iscoroutinefunction(self._fn):
-                        # async compute_fn: run on a worker thread under its own
-                        # event loop so sync chunks inside it do not pin the
-                        # scheduler's event loop.
-                        def _run_async_in_thread() -> Any:
-                            return asyncio.run(self._fn(msg.data))
-
-                        result = await asyncio.to_thread(_run_async_in_thread)
-                    else:
-                        result = await asyncio.to_thread(self._fn, msg.data)
+                    result = await asyncio.to_thread(
+                        self._run_compute_in_thread, msg.data
+                    )
                     self._emit_result(msg.request_id, result, self.outbox)
                 except Exception as exc:
                     logger.exception(

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,6 +21,7 @@ tests/
     │   ├── test_coordinator.py
     │   ├── test_ipc.py
     │   ├── test_scheduler.py
+    │   ├── test_simple_scheduler_concurrent.py
     │   └── test_stage.py
     ├── qwen3_omni/
     │   ├── test_code2wav.py
@@ -142,7 +143,9 @@ that happened to contain an older version of the test.
   - IPC lifecycle
   - scheduler batching
   - scheduler errors
-  - scheduler concurrency.
+  - scheduler concurrency
+  - scheduler callable contracts, including sync wrappers and callable objects
+    that return awaitables.
 - `unit_test/qwen3_omni/` Qwen3-Omni unit tests:
 
   - public CLI/config behavior

--- a/tests/unit_test/pipeline/test_simple_scheduler_concurrent.py
+++ b/tests/unit_test/pipeline/test_simple_scheduler_concurrent.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for SimpleScheduler ``max_concurrency`` dispatch path.
+
+Kept in a separate file from test_scheduler.py because that module imports
+``torch`` at top level (for OmniScheduler / StageOutputCache tests). These
+tests only exercise the SimpleScheduler scheduling layer and have no torch
+dependency.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from sglang_omni.scheduling.messages import IncomingMessage
+from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+
+
+def run_scheduler(
+    scheduler: SimpleScheduler,
+    messages: list[IncomingMessage],
+    *,
+    output_count: int,
+    before_collect: Callable[[], None] | None = None,
+) -> list[Any]:
+    """Inlined copy of tests.unit_test.pipeline.helpers.run_scheduler to avoid
+    the torch transitive import in helpers.py."""
+    thread = threading.Thread(target=scheduler.start, daemon=True)
+    thread.start()
+    try:
+        for message in messages:
+            scheduler.inbox.put(message)
+        if before_collect is not None:
+            before_collect()
+        return [scheduler.outbox.get(timeout=2.0) for _ in range(output_count)]
+    finally:
+        scheduler.stop()
+        thread.join(timeout=2.0)
+
+
+def test_max_concurrency_runs_sync_fn_in_parallel() -> None:
+    """Two sync ``compute_fn`` invocations must be in flight simultaneously
+    when ``max_concurrency=2``, not serialized."""
+    started: list[str] = []
+    lock = threading.Lock()
+    both_started = threading.Event()
+    release = threading.Event()
+
+    def compute(payload: str) -> str:
+        with lock:
+            started.append(payload)
+            if len(started) == 2:
+                both_started.set()
+        assert release.wait(timeout=2.0)
+        return payload.upper()
+
+    def wait_for_both_started() -> None:
+        try:
+            assert both_started.wait(timeout=2.0)
+        finally:
+            release.set()
+
+    outputs = run_scheduler(
+        SimpleScheduler(compute, max_concurrency=2),
+        [
+            IncomingMessage("req-1", "new_request", "a"),
+            IncomingMessage("req-2", "new_request", "b"),
+        ],
+        output_count=2,
+        before_collect=wait_for_both_started,
+    )
+
+    assert {out.request_id for out in outputs} == {"req-1", "req-2"}
+    assert {out.data for out in outputs} == {"A", "B"}
+
+
+def test_max_concurrency_runs_async_fn_in_parallel() -> None:
+    """async ``compute_fn`` must also run concurrently (worker thread spins
+    its own event loop so sync chunks inside the coroutine do not pin the
+    scheduler's loop)."""
+    started: list[str] = []
+    lock = threading.Lock()
+    both_started = threading.Event()
+    release = threading.Event()
+
+    async def compute(payload: str) -> str:
+        with lock:
+            started.append(payload)
+            if len(started) == 2:
+                both_started.set()
+        assert release.wait(timeout=2.0)
+        return payload.upper()
+
+    def wait_for_both_started() -> None:
+        try:
+            assert both_started.wait(timeout=2.0)
+        finally:
+            release.set()
+
+    outputs = run_scheduler(
+        SimpleScheduler(compute, max_concurrency=2),
+        [
+            IncomingMessage("req-1", "new_request", "a"),
+            IncomingMessage("req-2", "new_request", "b"),
+        ],
+        output_count=2,
+        before_collect=wait_for_both_started,
+    )
+
+    assert {out.request_id for out in outputs} == {"req-1", "req-2"}
+    assert {out.data for out in outputs} == {"A", "B"}
+
+
+def test_max_concurrency_reports_worker_errors() -> None:
+    """Per-request exceptions in the concurrent path land as outbox errors
+    tagged with the originating request_id."""
+
+    def compute(payload: str) -> str:
+        raise RuntimeError(payload)
+
+    outputs = run_scheduler(
+        SimpleScheduler(compute, max_concurrency=2),
+        [
+            IncomingMessage("req-1", "new_request", "boom-1"),
+            IncomingMessage("req-2", "new_request", "boom-2"),
+        ],
+        output_count=2,
+    )
+
+    assert {out.request_id for out in outputs} == {"req-1", "req-2"}
+    assert all(
+        out.type == "error" and isinstance(out.data, RuntimeError) for out in outputs
+    )
+
+
+def test_max_concurrency_with_batch_fn_is_rejected() -> None:
+    """``max_concurrency > 1`` and ``batch_compute_fn`` are mutually exclusive
+    construction options."""
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        SimpleScheduler(
+            lambda payload: payload,
+            batch_compute_fn=lambda payloads: payloads,
+            max_batch_size=2,
+            max_concurrency=4,
+        )
+
+
+def test_default_max_concurrency_is_one_for_backcompat() -> None:
+    """Without ``max_concurrency``, behavior matches the historical serial path."""
+    started: list[str] = []
+    lock = threading.Lock()
+    release = threading.Event()
+
+    def compute(payload: str) -> str:
+        with lock:
+            started.append(payload)
+        assert release.wait(timeout=2.0)
+        return payload
+
+    def release_after_first_started() -> None:
+        # Give the scheduler thread a moment to start the first request.
+        deadline = threading.Event()
+        deadline.wait(0.1)
+        # Only one should have started; the second is still queued.
+        with lock:
+            assert len(started) == 1, f"expected serial dispatch, got {started}"
+        release.set()
+
+    outputs = run_scheduler(
+        SimpleScheduler(compute),  # default max_concurrency=1
+        [
+            IncomingMessage("req-1", "new_request", "first"),
+            IncomingMessage("req-2", "new_request", "second"),
+        ],
+        output_count=2,
+        before_collect=release_after_first_started,
+    )
+
+    assert [out.request_id for out in outputs] == ["req-1", "req-2"]

--- a/tests/unit_test/pipeline/test_simple_scheduler_concurrent.py
+++ b/tests/unit_test/pipeline/test_simple_scheduler_concurrent.py
@@ -1,14 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for SimpleScheduler ``max_concurrency`` dispatch path.
+"""Tests for SimpleScheduler max_concurrency dispatch path.
 
 Kept in a separate file from test_scheduler.py because that module imports
-``torch`` at top level (for OmniScheduler / StageOutputCache tests). These
+torch at top level (for OmniScheduler / StageOutputCache tests). These
 tests only exercise the SimpleScheduler scheduling layer and have no torch
 dependency.
 """
 
 from __future__ import annotations
 
+import asyncio
 import threading
 from collections.abc import Callable
 from typing import Any
@@ -27,7 +28,12 @@ def run_scheduler(
     before_collect: Callable[[], None] | None = None,
 ) -> list[Any]:
     """Inlined copy of tests.unit_test.pipeline.helpers.run_scheduler to avoid
-    the torch transitive import in helpers.py."""
+    the torch transitive import in helpers.py.
+
+    Note (Chenchen, Chenyang):
+    This is a copy of tests.unit_test.pipeline.helpers.run_scheduler to avoid
+    the torch transitive import in helpers.py.
+    """
     thread = threading.Thread(target=scheduler.start, daemon=True)
     thread.start()
     try:
@@ -134,6 +140,67 @@ def test_max_concurrency_reports_worker_errors() -> None:
     assert all(
         out.type == "error" and isinstance(out.data, RuntimeError) for out in outputs
     )
+
+
+def test_max_concurrency_awaits_coroutine_returned_by_sync_callable() -> None:
+    """Sync wrappers that return coroutines must emit the awaited result."""
+
+    async def compute_async(payload: str) -> str:
+        await asyncio.sleep(0)
+        return payload.upper()
+
+    def compute(payload: str):
+        return compute_async(payload)
+
+    outputs = run_scheduler(
+        SimpleScheduler(compute, max_concurrency=2),
+        [IncomingMessage("req-await", "new_request", "payload")],
+        output_count=1,
+    )
+
+    assert outputs[0].request_id == "req-await"
+    assert outputs[0].type == "result"
+    assert outputs[0].data == "PAYLOAD"
+
+
+def test_max_concurrency_awaits_async_call_object() -> None:
+    """Callable objects with async __call__ must not emit coroutine objects."""
+
+    class Compute:
+        async def __call__(self, payload: str) -> str:
+            await asyncio.sleep(0)
+            return payload.upper()
+
+    outputs = run_scheduler(
+        SimpleScheduler(Compute(), max_concurrency=2),
+        [IncomingMessage("req-call", "new_request", "payload")],
+        output_count=1,
+    )
+
+    assert outputs[0].request_id == "req-call"
+    assert outputs[0].type == "result"
+    assert outputs[0].data == "PAYLOAD"
+
+
+def test_max_concurrency_reports_errors_from_returned_coroutines() -> None:
+    """Returned coroutine exceptions must become per-request error rows."""
+
+    async def compute_async(payload: str) -> str:
+        await asyncio.sleep(0)
+        raise RuntimeError(payload)
+
+    def compute(payload: str):
+        return compute_async(payload)
+
+    outputs = run_scheduler(
+        SimpleScheduler(compute, max_concurrency=2),
+        [IncomingMessage("req-await-error", "new_request", "boom")],
+        output_count=1,
+    )
+
+    assert outputs[0].request_id == "req-await-error"
+    assert outputs[0].type == "error"
+    assert isinstance(outputs[0].data, RuntimeError)
 
 
 def test_max_concurrency_with_batch_fn_is_rejected() -> None:


### PR DESCRIPTION
## Summary

Addresses #452 (SimpleScheduler serializes inbox messages). Adds a `max_concurrency: int = 1` parameter that, when > 1, spawns N worker coroutines and dispatches `compute_fn` through `asyncio.to_thread` so synchronous chunks inside the callable (e.g. the HF processor call inside `Qwen3OmniPreprocessor.__call__`) do not pin the scheduler's event loop.

Default behavior unchanged.

## Why `asyncio.to_thread` (not plain `asyncio.gather`)

From the [micro-benchmark in #452](https://github.com/sgl-project/sglang-omni/issues/452), 8 concurrent `inbox.put` with a 50 ms `_fn`:

| `_fn` shape | baseline | `asyncio.gather` | `asyncio.to_thread` |
|---|---:|---:|---:|
| pure async | 410 ms | 52 ms (7.9×) | 54 ms (7.6×) |
| **half async + half sync (matches real `Qwen3OmniPreprocessor`)** | 429 ms | 255 ms (1.7×) | **60 ms (7.1×)** |
| pure sync | 438 ms | 429 ms (1.0×) | 55 ms (7.9×) |

`asyncio.gather` only yields 1.7× on the realistic shape because the sync `self.processor(...)` call (`preprocessor.py:374`) pins the event loop. `asyncio.to_thread` reliably parallelizes all three shapes.

## Design notes

- `max_concurrency=1` (default) routes through `_start_serial`, which is the existing code path — no behavior change for current callers.
- `max_concurrency>1` routes through `_start_concurrent`, which runs an inbox-bridge coroutine plus N workers. The bridge moves messages from the thread-safe `queue.Queue` inbox into an `asyncio.Queue` via `run_in_executor`. Workers pull from the asyncio queue and dispatch `_fn` through `asyncio.to_thread`. Async callables run under their own event loop inside the worker thread via `asyncio.run` so sync chunks inside them also stay off the scheduler loop.
- `max_concurrency>1` and `batch_compute_fn` are mutually exclusive at construction — combining the two would require deciding how a batched `_fn` interacts with worker fan-out, which is out of scope here.

## Test plan

- [x] `tests/unit_test/pipeline/test_simple_scheduler_concurrent.py` (5 tests, 0 torch dependency):
    - sync `compute_fn` runs in parallel with `max_concurrency=2` (uses a `threading.Event` rendezvous to assert both invocations are in flight before either returns)
    - async `compute_fn` runs in parallel with `max_concurrency=2`
    - per-request exceptions land as outbox error rows with correct `request_id`
    - `max_concurrency>1` + `batch_compute_fn` raises `ValueError` at construction
    - default `max_concurrency=1` preserves serial dispatch ordering
- [x] All 5 pass locally: `pytest tests/unit_test/pipeline/test_simple_scheduler_concurrent.py -v` → 5 passed in 0.54s
- [ ] Maintainer verification on a real H200 run to measure TTFT p50 improvement once a stage is wired to use `max_concurrency>1`

## Out of scope (follow-up work)

This PR delivers the scheduler capability only. Wiring it into specific stages (`create_preprocessing_executor`, `create_aggregate_executor`, GPU-side encoders) is intentionally left as a separate PR because:

- CPU-bound stages (preprocessing, mm_aggregate) can use `max_concurrency = server.max_concurrency` directly.
- GPU-bound stages (image_encoder, audio_encoder) need KV-memory headroom analysis to pick a safe N.
- Decision belongs with maintainers familiar with the per-stage cost model.

## Related

- Issue: #452
- Original observation: #379 follow-up comment