### PR TITLE
perf(scheduler): use time.sleep(0) for GIL yield in _event_loop_normal

### DIFF
--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -611,6 +611,12 @@ class OmniScheduler:
         # AR scheduler loop pins the GIL and the audio_encoder forward pass
         # (which is mostly Python-side dispatch into many small CUDA kernels)
         # slows ~600x, dropping audio QPS from >10 to <0.5.
+        #
+        # Note (Hayden): sleep(0) is sufficient — CPython yields the GIL and
+        # triggers the thread scheduler without entering the kernel via the
+        # nanosleep syscall. Verified on H200 / Qwen3-Omni: text c=8 wall
+        # -10% / TTFT -76%, audio c=4 (30s input) wall -10% / TTFT -12% /
+        # throughput +8%; no regression on either path. See #463.
         while self._running:
             recv_reqs = self.recv_requests()
             recv_reqs.extend(self._take_deferred_request_payloads())
@@ -627,7 +633,7 @@ class OmniScheduler:
                 self.process_batch_result(batch, result)
             else:
                 self.self_check_during_idle()
-                time.sleep(0.001)
+                time.sleep(0)
 
             self.last_batch = batch
             if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():


### PR DESCRIPTION
## Summary

The idle branch of `OmniScheduler._event_loop_normal` calls `time.sleep(0.001)` to yield the GIL so sibling non-AR stages (encoders, preprocessor) can make progress in single-process mode. The 1 ms is conservative — CPython's `time.sleep(0)` is already a GIL release point and triggers the thread scheduler without the `nanosleep(1ms)` syscall and its forced wait.

This PR switches the idle branch to `time.sleep(0)`. Chenyang's original Note is preserved verbatim; an attribution note is appended to record the verification.

Closes #463.

## Measured impact (H200 / Qwen3-Omni-30B-A3B-Instruct, c=8 streaming burst)

### Text-only c=8 (`max_tokens=512`, 3 reps)
| Config | wall_mean | TTFT p50 mean | throughput |
|---|---:|---:|---:|
| baseline (`sleep(0.001)`) | 9.73 s | 1.128 s | 423 t/s |
| **this PR (`sleep(0)`)** | **8.74 s** | **0.268 s** | **468 t/s** |
| **Δ** | **-10%** | **-76%** | **+11%** |

### Audio c=4 (30s synthetic audio input, `max_tokens=512`, 2 reps)
| Config | wall_mean | TTFT p50 mean | throughput |
|---|---:|---:|---:|
| baseline (`sleep(0.001)`) | 5.53 s | 0.606 s | 300 t/s |
| **this PR (`sleep(0)`)** | **4.96 s** | **0.536 s** | **325 t/s** |
| **Δ** | **-10%** | **-12%** | **+8%** |

A third ablation with the sleep deleted entirely reproduced the disaster Chenyang's Note warns about (5× wall / 12× TTFT / 3× throughput regression on the audio path) — confirming `sleep(0)`'s GIL yield is doing real work, not just hiding behind low concurrency. Full data in #463.

## Why this is safe

`time.sleep(0)` in CPython:
- releases the GIL ✓
- triggers the Python thread scheduler ✓
- does **not** enter the kernel via `nanosleep` (no forced wait)

So Chenyang's guarantee — "yield the GIL when idle so sibling threads aren't starved" — is fully preserved. The only difference is that we no longer pay a 1 ms forced wait per idle iter when no sibling actually wants the GIL.

The `_engine_paused` branch on line 619 keeps `time.sleep(0.001)` because its semantics (waiting for unpause, not GIL yield) are different.

## Test plan

- [x] Manual: H200 c=8 text-only burst, 3 reps, compared against main baseline
- [x] Manual: H200 c=4 audio burst (30 s synthetic audio input), 2 reps, compared against main baseline
- [x] Manual: ablation with sleep removed entirely to confirm the GIL yield path is load-bearing
- [ ] CI suites green
- [ ] Reviewer: confirm the original 600× audio QPS scenario (see #463 disclosure) still holds under `sleep(0)`

## Risk & untested scenarios

Disclosed in detail in #463. Briefly:
- Tested: single H200 / single-process mode (text default topology) / nixl relay backend / c≤8 / short bursts
- Not tested: multi-process speech-colocated topology / sustained load >1 minute / the original ">10 to <0.5 audio QPS" scenario described in the Chenyang Note (test config not in the codebase)

If a maintainer can share the test configuration that originally observed the 600× degradation, I can re-verify there as well.