### PR TITLE
[Fix] Qwen3-Omni: handle thinker kv capacity overflow

### DIFF
--- a/.claude/skills/running-eval-suite/models/qwen3-omni/config.yaml
+++ b/.claude/skills/running-eval-suite/models/qwen3-omni/config.yaml
@@ -17,6 +17,7 @@
 #   locate.source_workload      workload tag WITHOUT the [hardware,] prefix; e.g. "V1-pipeline, full-set, c=8".
 #                               At runtime the skill prepends the detected hw tag → "[H200, V1-pipeline, full-set, c=8]"
 #   server                      server launch template; {port} {model} {gpus} {repo_root} substituted
+#   server_extra_by_hardware    optional hardware tag -> extra server args appended to server
 #   server_gpus                 1 (text-only) or 2 (full-pipeline talker)
 #   server_health               health URL ({port} substituted)
 #   server_boot_timeout_s       seconds to wait for /health 2xx
@@ -471,6 +472,8 @@ rows:
       config_substring: "thinker-talker, ci-50, c=8"
       source_workload: "c=8, max_tokens=256"
     server: "python -m sglang_omni.cli serve --model-path {model} --talker-cuda-graph on --port {port}"
+    server_extra_by_hardware:
+      H100: "--thinker-mem-fraction-static 0.8"
     server_gpus: 2
     server_health: "http://localhost:{port}/health"
     server_boot_timeout_s: 600
@@ -516,6 +519,8 @@ rows:
       config_substring: "thinker-talker, ci-50, c=8"
       source_workload: "c=8, max_tokens=256"
     server: "python -m sglang_omni.cli serve --model-path {model} --talker-cuda-graph on --port {port}"
+    server_extra_by_hardware:
+      H100: "--thinker-mem-fraction-static 0.8"
     server_gpus: 2
     server_health: "http://localhost:{port}/health"
     server_boot_timeout_s: 600
@@ -543,6 +548,8 @@ rows:
       config_substring: "thinker-talker, ci-50, c=8"
       source_workload: "c=8, max_tokens=256"
     server: "python -m sglang_omni.cli serve --model-path {model} --talker-cuda-graph on --port {port}"
+    server_extra_by_hardware:
+      H100: "--thinker-mem-fraction-static 0.8"
     server_gpus: 2
     server_health: "http://localhost:{port}/health"
     server_boot_timeout_s: 600

--- a/.claude/skills/running-eval-suite/runner.py
+++ b/.claude/skills/running-eval-suite/runner.py
@@ -599,9 +599,11 @@ class ServerHandle:
 
 def launch_server(cmd_template: str, *, port: int, model: str,
                   gpus_csv: str, log_path: Path, repo_root: Path = Path("."),
+                  server_extra: str = "",
                   env_extra: dict | None = None) -> ServerHandle:
-    cmd = cmd_template.format(port=port, model=model, gpus=gpus_csv,
-                              repo_root=str(repo_root))
+    cmd = " ".join(part for part in (cmd_template, server_extra) if part)
+    cmd = cmd.format(port=port, model=model, gpus=gpus_csv,
+                     repo_root=str(repo_root))
     env = dict(os.environ)
     if env_extra:
         env.update(env_extra)
@@ -698,7 +700,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         gpu_pool = [int(s.strip()) for s in args.gpu_pool.split(",") if s.strip()]
         print(f"gpu_pool: {gpu_pool}")
     for row in selected:
-        row_state = _run_one_row(row, py, root, out, rounds, smoke, cfg,
+        row_state = _run_one_row(row, py, root, out, rounds, smoke, cfg, hw,
                                  gpu_pool=gpu_pool)
         if row_state["status"] == "ok" and smoke is None:
             row_state["edit"] = _try_edit_inplace(
@@ -751,7 +753,7 @@ def cmd_run(args: argparse.Namespace) -> int:
 
 
 def _run_one_row(row: dict, py: str, root: Path, out_root: Path,
-                 rounds: int, smoke: int | None, cfg: dict,
+                 rounds: int, smoke: int | None, cfg: dict, hw: str,
                  gpu_pool: list[int] | None = None) -> dict:
     row_id = row["id"]
     row_dir = out_root / row_id
@@ -797,6 +799,7 @@ def _run_one_row(row: dict, py: str, root: Path, out_root: Path,
         round_dir = row_dir / f"round_{k}"
         round_dir.mkdir(parents=True, exist_ok=True)
         rstate = _run_one_round(row, py, root, round_dir, gpus_csv, smoke, cfg,
+                                hw,
                                 asr_device=asr_device)
         rounds_state.append(rstate)
         if rstate["status"] != "ok":
@@ -832,7 +835,7 @@ def _run_one_row(row: dict, py: str, root: Path, out_root: Path,
 
 
 def _run_one_round(row: dict, py: str, root: Path, round_dir: Path,
-                   gpus_csv: str, smoke: int | None, cfg: dict, *,
+                   gpus_csv: str, smoke: int | None, cfg: dict, hw: str, *,
                    asr_device: str = "cpu") -> dict:
     port = free_port()
     server_log = round_dir / "server.log"
@@ -841,13 +844,14 @@ def _run_one_round(row: dict, py: str, root: Path, round_dir: Path,
     out_dir.mkdir(exist_ok=True)
 
     server_cmd_tmpl = row["server"]
+    server_extra = (row.get("server_extra_by_hardware") or {}).get(hw, "")
     model_id = row.get("hf_model_id") or cfg.get("hf_model_id", "")
 
     print(f"  [{round_dir.name}] launching server (port={port}) ...", flush=True)
     handle = launch_server(
         server_cmd_tmpl,
         port=port, model=model_id, gpus_csv=gpus_csv, log_path=server_log,
-        repo_root=root,
+        repo_root=root, server_extra=server_extra,
     )
     try:
         health = row.get("server_health", "http://localhost:{port}/health").format(port=port)

--- a/benchmarks/eval/benchmark_omni_videoamme.py
+++ b/benchmarks/eval/benchmark_omni_videoamme.py
@@ -34,7 +34,7 @@ Accuracy
 | Qwen3-Omni | thinker-only, ci-50, c=8 | 66.00%   | 33/50   | 0      | 0           | PR #411 [H200, c=8, max_tokens=256] |
 | Qwen3-Omni | thinker-talker, ci-50, c=8 | 64.00%   | 32/50   | 0      | 0           | PR #411 [H200, c=8, max_tokens=256] |
 | Qwen3-Omni | thinker-only, ci-50, c=8 | 66.00%   | 33/50   | 0      | 0           | PR #411 [H100, c=8, max_tokens=256] |
-<!-- thinker-talker accuracy row omitted on H100: same hang as the speed/wer tables — talker pipeline never returns under --enable-audio + video input on H100, so all 50 requests time out at 300 s and the row would be 0/50 garbage. -->
+| Qwen3-Omni | thinker-talker, ci-50, c=8 | 68.00%   | 34/50   | 0      | 0           | local [H100, c=8, max_tokens=256] |
 
 Speed
 
@@ -43,7 +43,7 @@ Speed
 | Qwen3-Omni | thinker-only, ci-50, c=8 | 50        | 0      | 44.530         | 46.846           | 52.694        | 53.180        | 1.0            | 0.9           | 40.0            | 2025             | 21684.0            | 1084218             | 0.167          | PR #411 [H200, c=8, max_tokens=256] |
 | Qwen3-Omni | thinker-talker, ci-50, c=8 | 50        | 0      | 40.423         | 40.063           | 63.088        | 81.046        | 1.1            | 1.0           | 41.0            | 2050             | 21684.0            | 1084218             | 0.193          | PR #411 [H200, c=8, max_tokens=256] |
 | Qwen3-Omni | thinker-only, ci-50, c=8 | 50        | 0      | 38.408         | 40.320           | 44.883        | 45.764        | 1.2            | 1.1           | 44.0            | 2181             | 21684.0            | 1084218             | 0.194          | PR #411 [H100, c=8, max_tokens=256] |
-<!-- thinker-talker speed/wer rows omitted on H100: Qwen3-Omni audio output via talker pipeline hangs server-side at c=8 --enable-audio (preprocessing completes, generation never returns); all requests time out at 300 s. Workload not reproducible on this hardware/build. -->
+| Qwen3-Omni | thinker-talker, ci-50, c=8 | 50        | 0      | 33.618         | 33.365           | 46.380        | 58.321        | 1.3            | 1.3           | 42.0            | 2123             | 21684.0            | 1084218             | 0.230          | local [H100, c=8, max_tokens=256] |
 
 
 Talker WER
@@ -51,7 +51,7 @@ Talker WER
 | Model      | Config                    | evaluated | skipped | wer_corpus | wer_per_sample_mean | wer_per_sample_p95 | wer_per_sample_max | n_above_50_pct_wer | rtf_mean | audio_duration_mean_s | Source                                                              |
 | ---------- | ------------------------- | --------- | ------- | ---------- | ------------------- | ------------------ | ------------------ | ------------------ | -------- | --------------------- | ------------------------------------------------------------------- |
 | Qwen3-Omni | thinker-talker, ci-50, c=8 | 50/50     | 0       | 2.58%      | 18.87%              | 155.00%            | 200.00%            | 6                  | 6.3183   | 11.750                | PR #411 [H200, c=8, max_tokens=256] |
-<!-- thinker-talker WER row omitted on H100: same talker hang as accuracy/speed — server never produces audio output under --enable-audio + video input on H100, so there is nothing to transcribe. -->
+| Qwen3-Omni | thinker-talker, ci-50, c=8 | 50/50     | 0       | 2.29%      | 11.94%              | 100.00%            | 200.00%            | 4                  | 6.0412   | 12.356                | local [H100, c=8, max_tokens=256] |
 
 Local v1 Pipeline Result (this workspace, 2026-05-01)
 

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -10,6 +10,7 @@ When an upstream method (e.g. ``get_next_batch_to_run``) internally calls
 it to this instance.  This gives us the full scheduling MRO without
 inheriting from ``SGLangScheduler``.
 """
+
 from __future__ import annotations
 
 import logging
@@ -437,6 +438,21 @@ class OmniScheduler:
             req = req_data.req
             req._omni_data = req_data
             req_id = req.rid
+            kv_error = self._request_kv_capacity_error(req)
+            if kv_error is not None:
+                logger.warning(
+                    "Rejecting request %s before scheduling: %s",
+                    req_id,
+                    kv_error,
+                )
+                self.outbox.put(
+                    OutgoingMessage(
+                        request_id=req_id,
+                        type="error",
+                        data=ValueError(kv_error),
+                    )
+                )
+                continue
             self._initialize_request_stream_state(req_data, payload)
             if req_id in self._aborted_request_ids:
                 continue
@@ -467,6 +483,30 @@ class OmniScheduler:
     def _is_batch_ready_to_run(self, batch: Any) -> bool:
         del batch
         return True
+
+    def _request_kv_capacity_error(self, req: Any) -> str | None:
+        input_len = len(req.origin_input_ids)
+        max_new_tokens = int(req.sampling_params.max_new_tokens or 0)
+        required_tokens = input_len + max_new_tokens
+        kv_capacity = int(self.max_req_len)
+        if required_tokens <= kv_capacity:
+            return None
+
+        mem_fraction = self.server_args.mem_fraction_static
+        if mem_fraction is not None:
+            mem_hint = (
+                f" Current mem_fraction_static is {mem_fraction:.3f}; try setting "
+                "--thinker-mem-fraction-static higher."
+            )
+        else:
+            mem_hint = " Try setting a higher --thinker-mem-fraction-static value."
+
+        return (
+            "Request requires more tokens than the thinker KV cache can hold "
+            f"(input_tokens={input_len}, max_new_tokens={max_new_tokens}, "
+            f"required_tokens={required_tokens}, kv_capacity={kv_capacity})."
+            f"{mem_hint}"
+        )
 
     def run_batch(self, batch, pp_proxy_tensors=None):
         """Run a batch through the model runner.


### PR DESCRIPTION
## Motivation
  Qwen3-Omni Video-AMME thinker + talker can fail on H100 when the thinker KV cache capacity is smaller than the prompt length required by the workload. The request previously stalled until timeout instead of failing with a clear error.

  ## Modifications

  - Add a pre-scheduling KV capacity check in the omni scheduler and return a clear error when a request exceeds thinker KV capacity.
  - Update the running-eval-suite skill to set `--thinker-mem-fraction-static 0.8` for H100 Video-AMME thinker + talker runs.
  - Refresh H100 Video-AMME thinker + talker benchmark results.

  ## Related Issues

#460 

  ## Accuracy Test

  Video-AMME thinker + talker on H100, 50 samples, c=8, max_tokens=256, --thinker-mem-fraction-static 0.8:

  - Accuracy: 68.0% (34/50)
  - Failed requests: 0
  - WER corpus: 2.29%

  ## Benchmark & Profiling

  Video-AMME thinker + talker on H100, 50 samples, c=8, max_tokens=256, --thinker-mem-fraction-static 0.8:

  - Latency mean: 33.618s
  - Latency p95: 46.380s
  - Throughput: 0.230 req/s

  ## Checklist

  - [x] Format your code according with pre-commit.
  - [ ] Add unit tests.
  - [ ] Update documentation / docstrings / example tutorials as needed.
  - [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.