### PR TITLE
[Voxtral-TTS] Add OmniScheduler-backed adapter

### DIFF
--- a/sglang_omni/config/manager.py
+++ b/sglang_omni/config/manager.py
@@ -6,6 +6,11 @@ from transformers import AutoConfig
 
 from sglang_omni.config.schema import PipelineConfig
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+from sglang_omni.utils.hf import (
+    architecture_from_hf_config,
+    try_resolve_arch_from_mistral_config,
+    try_resolve_arch_from_raw_config,
+)
 
 
 class ConfigManager:
@@ -84,8 +89,35 @@ class ConfigManager:
         """Load config from model path, optionally selecting a variant."""
         import importlib
 
-        hf_config = AutoConfig.from_pretrained(model_path)
-        config_cls = PIPELINE_CONFIG_REGISTRY.get_config(hf_config.architectures[0])
+        arch: str | None = None
+
+        # 1) Hugging Face config.json (local snapshot or hub id)
+        try:
+            hf_config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+            arch = architecture_from_hf_config(hf_config)
+        except Exception:
+            pass
+
+        # 2) Mistral-format params.json (e.g. Voxtral TTS) when HF config is absent
+        if arch is None:
+            arch = try_resolve_arch_from_mistral_config(model_path)
+
+        # 3) Raw config.json fallback (e.g. models needing trust_remote_code)
+        if arch is None:
+            arch = try_resolve_arch_from_raw_config(model_path)
+
+        if arch is None:
+            supported = ", ".join(
+                sorted(PIPELINE_CONFIG_REGISTRY.get_supported_archs())
+            )
+            raise ValueError(
+                f"Could not resolve model architecture for {model_path!r}. "
+                "Use a Hugging Face model id or a local directory with config.json "
+                "(architectures) or Mistral params.json (model_type, e.g. voxtral_tts). "
+                f"Supported architectures: {supported}"
+            )
+
+        config_cls = PIPELINE_CONFIG_REGISTRY.get_config(arch)
 
         if variant:
             module = importlib.import_module(config_cls.__module__)

--- a/sglang_omni/model_runner/sglang_model_runner.py
+++ b/sglang_omni/model_runner/sglang_model_runner.py
@@ -89,12 +89,16 @@ class SGLModelRunner(ModelRunner):
             Qwen3OmniThinkerForCausalLM,
         )
         from sglang_omni.models.qwen3_omni.components.talker import Qwen3OmniTalker
+        from sglang_omni.models.voxtral_tts_v1.sglang_model import (
+            VoxtralSGLangTextModel,
+        )
 
         ModelRegistry.models["S2ProSGLangTextModel"] = S2ProSGLangTextModel
         ModelRegistry.models["Qwen3OmniTalker"] = Qwen3OmniTalker
         ModelRegistry.models["Qwen3OmniThinkerForCausalLM"] = (
             Qwen3OmniThinkerForCausalLM
         )
+        ModelRegistry.models["VoxtralSGLangTextModel"] = VoxtralSGLangTextModel
 
     def _profile_available_bytes(self, pre_model_load_memory: float) -> int:
         """Profile KV-cache headroom for colocated SGLang AR stages.

--- a/sglang_omni/models/voxtral_tts/__init__.py
+++ b/sglang_omni/models/voxtral_tts/__init__.py
@@ -1,5 +1,6 @@
-"""Voxtral-4B-TTS model support for sglang-omni."""
-
-from . import config
-
-__all__ = ["config"]
+"""Voxtral-4B-TTS shared modules (io / acoustic_transformer / audio_tokenizer
+/ model_config). The legacy V0 ``config`` and ``pipeline.stages`` are broken
+on upstream main since PR #435 (Retire SGLang Omni V0) and will be deleted
+in a follow-up PR; the canonical Voxtral pipeline now lives in
+``sglang_omni.models.voxtral_tts_v1``, which still imports the standalone
+modules in this package."""

--- a/sglang_omni/models/voxtral_tts_v1/__init__.py
+++ b/sglang_omni/models/voxtral_tts_v1/__init__.py
@@ -1,0 +1,8 @@
+"""Voxtral-TTS V1 (OmniScheduler-backed) — additive alongside the
+SimpleScheduler-based ``voxtral_tts`` package. The V0 path will be
+retired in a follow-up PR once V1 is fully validated end-to-end.
+"""
+
+from . import config
+
+__all__ = ["config"]

--- a/sglang_omni/models/voxtral_tts_v1/audio_modules.py
+++ b/sglang_omni/models/voxtral_tts_v1/audio_modules.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standalone audio modules for the Voxtral-TTS OmniScheduler path."""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from sglang_omni.models.voxtral_tts.acoustic_transformer import (
+    MultimodalAudioModelArgs,
+    from_nested_dict,
+)
+
+
+class MultiVocabEmbeddings(nn.Module):
+    """Embed audio tokens from multiple codebooks into a shared table.
+
+    Each codebook's IDs are shifted by the cumulative size of the prior
+    codebooks; total table size is padded to a multiple of 128.
+    """
+
+    def __init__(self, audio_model_args: dict, embedding_dim: int) -> None:
+        super().__init__()
+        self.model_args = from_nested_dict(MultimodalAudioModelArgs, audio_model_args)
+        self.codebook_sizes = list(
+            self.model_args.get_codebook_sizes(pad_to_multiple=None)
+        )
+        offsets = [0]
+        for sz in self.codebook_sizes[:-1]:
+            offsets.append(offsets[-1] + sz)
+        self.register_buffer(
+            "offsets", torch.tensor(offsets, dtype=torch.long), persistent=False
+        )
+        total_vocab = sum(self.codebook_sizes)
+        aligned_size = 128 * ((total_vocab + 127) // 128)
+        self.embeddings = nn.Embedding(aligned_size, embedding_dim)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        # input_ids: [batch, n_codebooks, seq_len]
+        shifted = input_ids + self.offsets[None, :, None]
+        return self.embeddings(shifted)

--- a/sglang_omni/models/voxtral_tts_v1/bootstrap.py
+++ b/sglang_omni/models/voxtral_tts_v1/bootstrap.py
@@ -1,0 +1,321 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Voxtral-TTS SGLang scheduler bootstrap."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from typing import Any
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_checkpoint(checkpoint: str) -> str:
+    if os.path.isdir(checkpoint):
+        return checkpoint
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(checkpoint)
+
+
+def _load_voice_embeddings(checkpoint_dir: str, device: str) -> dict[str, torch.Tensor]:
+    voice_dir = os.path.join(checkpoint_dir, "voice_embedding")
+    if not os.path.isdir(voice_dir):
+        raise FileNotFoundError(
+            f"Voxtral checkpoint at {checkpoint_dir!r} has no voice_embedding/ dir"
+        )
+    voice_embeddings: dict[str, torch.Tensor] = {}
+    for fname in sorted(os.listdir(voice_dir)):
+        if not fname.endswith(".pt"):
+            continue
+        name = fname.removesuffix(".pt")
+        emb = torch.load(
+            os.path.join(voice_dir, fname),
+            map_location=device,
+            weights_only=True,
+        )
+        voice_embeddings[name] = emb.to(dtype=torch.bfloat16)
+    if not voice_embeddings:
+        raise FileNotFoundError(
+            f"No .pt voice embeddings under {voice_dir!r}"
+        )
+    logger.info(
+        "Loaded %d voice embeddings: %s",
+        len(voice_embeddings),
+        list(voice_embeddings.keys()),
+    )
+    return voice_embeddings
+
+
+def _load_acoustic_and_embedding(
+    checkpoint_dir: str,
+    voxtral_config,
+    device: str,
+):
+    import glob
+
+    from safetensors import safe_open
+
+    from sglang_omni.models.voxtral_tts.acoustic_transformer import (
+        FlowMatchingAudioTransformer,
+    )
+    from sglang_omni.models.voxtral_tts_v1.audio_modules import MultiVocabEmbeddings
+
+    full_audio_args = {
+        "semantic_codebook_size": voxtral_config.audio_model_args.semantic_codebook_size,
+        "acoustic_codebook_size": voxtral_config.audio_model_args.acoustic_codebook_size,
+        "n_acoustic_codebook": voxtral_config.audio_model_args.n_acoustic_codebook,
+        "acoustic_transformer_args": voxtral_config.audio_model_args.acoustic_transformer_args,
+        "audio_encoding_args": voxtral_config.audio_model_args.audio_encoding_args,
+    }
+
+    acoustic_transformer = FlowMatchingAudioTransformer(full_audio_args)
+    audio_token_embedding = MultiVocabEmbeddings(
+        audio_model_args=full_audio_args,
+        embedding_dim=voxtral_config.text_config.dim,
+    )
+
+    shard_paths = sorted(glob.glob(os.path.join(checkpoint_dir, "*.safetensors")))
+    if not shard_paths:
+        raise FileNotFoundError(
+            f"No .safetensors shards in {checkpoint_dir} for acoustic load"
+        )
+
+    n_loaded_acoustic = 0
+    embedding_loaded = False
+    audio_embedding_key = (
+        "mm_audio_embeddings.audio_codebook_embeddings.embeddings.weight"
+    )
+    acoustic_prefix = "acoustic_transformer."
+
+    for path in shard_paths:
+        with safe_open(path, framework="pt", device="cpu") as fp:
+            for ckpt_key in fp.keys():
+                if ckpt_key == audio_embedding_key:
+                    tensor = fp.get_tensor(ckpt_key)
+                    audio_token_embedding.embeddings.weight.data.copy_(tensor)
+                    embedding_loaded = True
+                    continue
+                if ckpt_key.startswith(acoustic_prefix):
+                    tensor = fp.get_tensor(ckpt_key)
+                    param_name = ckpt_key[len(acoustic_prefix) :]
+                    acoustic_transformer.load_weight((param_name, tensor))
+                    n_loaded_acoustic += 1
+
+    logger.info(
+        "Voxtral acoustic_transformer: %d weights | audio_token_embedding: %s",
+        n_loaded_acoustic,
+        embedding_loaded,
+    )
+
+    acoustic_transformer = acoustic_transformer.to(
+        dtype=torch.bfloat16, device=device
+    ).eval()
+    audio_token_embedding = audio_token_embedding.to(
+        dtype=torch.bfloat16, device=device
+    ).eval()
+    return acoustic_transformer, audio_token_embedding
+
+
+def materialize_voxtral_config_json(checkpoint_dir: str) -> str:
+    """Synthesize a HF-style ``config.json`` from Mistral ``params.json``.
+
+    SGLang's AutoConfig path requires config.json; Voxtral ships only
+    params.json. If the checkpoint dir is read-only (HF cache snapshot),
+    fall back to a sibling working dir with symlinks to the shards.
+    """
+    if os.path.exists(os.path.join(checkpoint_dir, "config.json")):
+        return checkpoint_dir
+
+    params_path = os.path.join(checkpoint_dir, "params.json")
+    if not os.path.exists(params_path):
+        raise FileNotFoundError(
+            f"{checkpoint_dir} has neither config.json nor params.json"
+        )
+
+    with open(params_path) as f:
+        params = json.load(f)
+
+    hf_config = {
+        "model_type": "llama",
+        "architectures": ["VoxtralSGLangTextModel"],
+        "hidden_size": int(params["dim"]),
+        "num_attention_heads": int(params["n_heads"]),
+        "num_key_value_heads": int(params["n_kv_heads"]),
+        "num_hidden_layers": int(params["n_layers"]),
+        "intermediate_size": int(params["hidden_dim"]),
+        "head_dim": int(params["head_dim"]),
+        "vocab_size": int(params["vocab_size"]),
+        "max_position_embeddings": 32768,
+        "rope_theta": float(params["rope_theta"]),
+        "rms_norm_eps": float(params["norm_eps"]),
+        "torch_dtype": "bfloat16",
+        "tie_word_embeddings": bool(params.get("tied_embeddings", True)),
+        "rope_scaling": None,
+    }
+
+    config_path = os.path.join(checkpoint_dir, "config.json")
+    try:
+        with open(config_path, "w") as f:
+            json.dump(hf_config, f, indent=2)
+        logger.info(
+            "Wrote synthesized config.json into Voxtral checkpoint at %s",
+            checkpoint_dir,
+        )
+        return checkpoint_dir
+    except OSError as exc:
+        logger.info(
+            "Cannot write to %s (%s); creating a sibling working dir with "
+            "symlinked checkpoint shards.",
+            checkpoint_dir,
+            exc,
+        )
+
+    work_dir = tempfile.mkdtemp(prefix="voxtral_sglang_")
+    for entry in os.listdir(checkpoint_dir):
+        src = os.path.join(checkpoint_dir, entry)
+        dst = os.path.join(work_dir, entry)
+        os.symlink(src, dst)
+    with open(os.path.join(work_dir, "config.json"), "w") as f:
+        json.dump(hf_config, f, indent=2)
+    logger.info("Voxtral working dir at %s", work_dir)
+    return work_dir
+
+
+def create_voxtral_scheduler(
+    model_path: str,
+    *,
+    gpu_id: int = 0,
+    max_new_tokens: int = 4096,
+    context_length: int = 8192,
+    server_args_overrides: dict[str, Any] | None = None,
+):
+    """Build an ``OmniScheduler`` for Voxtral-TTS generation."""
+    from sglang_omni.models.voxtral_tts.acoustic_transformer import (
+        AudioSpecialTokens,
+    )
+    from sglang_omni.models.voxtral_tts.model_config import VoxtralModelConfig
+    from sglang_omni.models.voxtral_tts_v1.model_runner import VoxtralModelRunner
+    from sglang_omni.models.voxtral_tts_v1.request_builders import (
+        VoxtralAdapterContext,
+        make_voxtral_scheduler_adapters,
+    )
+    from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
+    from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+    from sglang_omni.scheduling.sglang_backend import (
+        SGLangOutputProcessor,
+        build_sglang_server_args,
+    )
+
+    checkpoint_dir = _resolve_checkpoint(model_path)
+    working_dir = materialize_voxtral_config_json(checkpoint_dir)
+    voxtral_config = VoxtralModelConfig.from_model_path(checkpoint_dir)
+    audio_token_id = int(voxtral_config.audio_model_args.audio_token_id)
+    end_audio_token_id = int(AudioSpecialTokens.id(AudioSpecialTokens.end_audio))
+
+    overrides: dict[str, Any] = {
+        "disable_cuda_graph": False,
+        "dtype": "bfloat16",
+        # Per-step feedback writes into _feedback_buffer happen synchronously
+        # in prepare_decode; SGLang's overlap_schedule would prefetch the
+        # next forward concurrently and race against those writes.
+        "disable_overlap_schedule": True,
+        # Radix prefix cache + voice-injected ``Req.input_embeds`` is a
+        # shape-mismatch crash: a 2nd matching prompt hits the cache,
+        # SGLang shrinks the extend slice, but Req.input_embeds still
+        # spans the full prompt → set_kv_buffer fails. Qwen3 talker
+        # disables radix for the same reason.
+        "disable_radix_cache": True,
+    }
+    if server_args_overrides:
+        overrides.update(server_args_overrides)
+
+    server_args = build_sglang_server_args(
+        working_dir,
+        context_length=context_length,
+        **overrides,
+    )
+    # Default to fa3 only when the user hasn't picked a backend (mirrors
+    # fishaudio_s2_pro).
+    if getattr(server_args, "attention_backend", None) is None:
+        server_args.attention_backend = "fa3"
+
+    # CUDA graph must be off during worker construction; re-enabled and
+    # captured after setup_feedback_buffer() so the captured decode
+    # branch reads a stable tensor identity.
+    want_cuda_graph = not bool(getattr(server_args, "disable_cuda_graph", False))
+    if want_cuda_graph:
+        server_args.disable_cuda_graph = True
+
+    (
+        model_worker,
+        tree_cache,
+        req_to_token_pool,
+        token_to_kv_pool_allocator,
+        prefill_mgr,
+        decode_mgr,
+        model_config,
+    ) = create_sglang_infrastructure(
+        server_args,
+        gpu_id,
+        model_arch_override="VoxtralSGLangTextModel",
+    )
+
+    model_worker.model_runner.model.setup_feedback_buffer(
+        int(server_args.max_running_requests)
+    )
+
+    if want_cuda_graph:
+        server_args.disable_cuda_graph = False
+        model_worker.model_runner.init_device_graphs()
+
+    output_proc = SGLangOutputProcessor(
+        capture_hidden=False,
+        capture_hidden_layers=None,
+        model=model_worker.model_runner.model,
+    )
+
+    device_str = f"cuda:{gpu_id}"
+    voice_embeddings = _load_voice_embeddings(checkpoint_dir, device=device_str)
+    embed_tokens = model_worker.model_runner.model.embed_tokens
+    acoustic_transformer, audio_token_embedding = _load_acoustic_and_embedding(
+        checkpoint_dir,
+        voxtral_config=voxtral_config,
+        device=device_str,
+    )
+
+    model_runner = VoxtralModelRunner(
+        model_worker,
+        output_proc,
+        acoustic_transformer=acoustic_transformer,
+        audio_token_embedding=audio_token_embedding,
+        end_audio_token_id=end_audio_token_id,
+    )
+
+    ctx = VoxtralAdapterContext(
+        embed_tokens=embed_tokens,
+        voice_embeddings=voice_embeddings,
+        audio_token_id=audio_token_id,
+        end_audio_token_id=end_audio_token_id,
+        vocab_size=int(voxtral_config.text_config.vocab_size),
+        max_new_tokens=max_new_tokens,
+    )
+    request_builder, result_adapter = make_voxtral_scheduler_adapters(ctx)
+
+    return OmniScheduler(
+        tp_worker=model_worker,
+        tree_cache=tree_cache,
+        req_to_token_pool=req_to_token_pool,
+        token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+        server_args=server_args,
+        model_config=model_config,
+        prefill_manager=prefill_mgr,
+        decode_manager=decode_mgr,
+        model_runner=model_runner,
+        request_builder=request_builder,
+        result_adapter=result_adapter,
+    )

--- a/sglang_omni/models/voxtral_tts_v1/config.py
+++ b/sglang_omni/models/voxtral_tts_v1/config.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pipeline configuration for Voxtral TTS V1 (OmniScheduler-backed)."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from sglang_omni.config import PipelineConfig, StageConfig
+
+_PKG = "sglang_omni.models.voxtral_tts_v1"
+
+
+class VoxtralTTSV1PipelineConfig(PipelineConfig):
+    architecture: ClassVar[str] = "VoxtralTTSForConditionalGeneration"
+
+    model_path: str
+    stages: list[StageConfig] = [
+        StageConfig(
+            name="preprocessing",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_preprocessing_executor",
+            next="generation",
+        ),
+        StageConfig(
+            name="generation",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_generation_executor",
+            factory_args={"device": "cuda:0", "max_new_tokens": 4096},
+            gpu=0,
+            next="vocoder",
+        ),
+        StageConfig(
+            name="vocoder",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_vocoder_executor",
+            factory_args={"device": "cuda:0"},
+            gpu=0,
+            terminal=True,
+        ),
+    ]
+
+
+EntryClass = VoxtralTTSV1PipelineConfig

--- a/sglang_omni/models/voxtral_tts_v1/model_runner.py
+++ b/sglang_omni/models/voxtral_tts_v1/model_runner.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Drives the Voxtral acoustic AR loop on top of SGLang."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from sglang_omni.model_runner.base import ModelRunner
+
+
+class VoxtralModelRunner(ModelRunner):
+    def __init__(
+        self,
+        tp_worker: Any,
+        output_processor: Any,
+        *,
+        acoustic_transformer: torch.nn.Module,
+        audio_token_embedding: torch.nn.Module,
+        end_audio_token_id: int,
+    ):
+        super().__init__(tp_worker, output_processor)
+        self._acoustic = acoustic_transformer
+        self._audio_token_embedding = audio_token_embedding
+        self._end_audio_token_id = int(end_audio_token_id)
+
+    # Sample first, then override the sampled token with codes[0] in our hook.
+    def sample_before_post_prefill(self, *_args, **_kwargs) -> bool:
+        return True
+
+    def sample_before_post_decode(self, *_args, **_kwargs) -> bool:
+        return True
+
+    def post_prefill(self, result, forward_batch, schedule_batch, requests):
+        self._acoustic_step(result, requests)
+
+    def post_decode(self, result, forward_batch, schedule_batch, requests):
+        self._acoustic_step(result, requests)
+
+    def _acoustic_step(self, result, requests):
+        hidden_states = self._extract_last_hidden(result, requests)
+        if hidden_states is None:
+            return
+
+        with torch.no_grad():
+            codes = self._acoustic(hidden_states)  # [batch, 37]
+
+        next_token_ids = getattr(result, "next_token_ids", None)
+        if next_token_ids is not None:
+            next_token_ids[: codes.shape[0]] = codes[:, 0]
+
+        feedback = self._audio_token_embedding(codes.unsqueeze(2)).sum(dim=1)
+        feedback = feedback.squeeze(1) if feedback.dim() == 3 else feedback
+        # Keep acoustic residuals on GPU per step; the result_adapter does a
+        # single stacked .cpu() once the request finishes.
+        residuals = codes[:, 1:]
+        for i, sched_req in enumerate(requests[: codes.shape[0]]):
+            data = sched_req.data
+            data.acoustic_codebook_residuals.append(residuals[i])
+            data.pending_feedback_queue.append(feedback[i])
+
+    @staticmethod
+    def _extract_last_hidden(result, requests):
+        logits_output = getattr(result, "logits_output", None)
+        if logits_output is None:
+            return None
+        hidden = getattr(logits_output, "hidden_states", None)
+        if hidden is None or hidden.dim() != 2:
+            return None
+        return hidden[: len(requests)]
+
+    def prepare_decode(self, forward_batch, schedule_batch, requests):
+        # In-place copy preserves _feedback_buffer's tensor identity so
+        # CUDA-graph-captured reads still hit the right storage.
+        buffer = self.model._feedback_buffer
+        for i, sched_req in enumerate(requests):
+            queue = sched_req.data.pending_feedback_queue
+            if queue:
+                buffer[i].copy_(queue.popleft().to(buffer.dtype))
+            else:
+                buffer[i].zero_()
+        return None

--- a/sglang_omni/models/voxtral_tts_v1/request_builders.py
+++ b/sglang_omni/models/voxtral_tts_v1/request_builders.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+"""StagePayload ↔ OmniScheduler adapters for Voxtral-TTS."""
+
+from __future__ import annotations
+
+import collections
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+
+from sglang_omni.models.voxtral_tts.io import VoxtralTTSState
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
+
+
+@dataclass
+class VoxtralSGLangRequestData(SGLangARRequestData):
+    # acoustic_codebook_residuals accumulates the 36 non-semantic codes per
+    # step; combined with the semantic column at result time to form
+    # [T, 37] for the vocoder.
+    voice: str | None = None
+    end_audio_token_id: int | None = None
+    acoustic_codebook_residuals: list[torch.Tensor] = field(default_factory=list)
+    pending_feedback_queue: collections.deque = field(default_factory=collections.deque)
+    max_new_tokens: int = 4096
+
+
+@dataclass
+class VoxtralAdapterContext:
+    """Per-checkpoint adapter wiring shared between the request builder and
+    the result adapter. Constructed once at bootstrap time."""
+
+    embed_tokens: Any
+    voice_embeddings: dict[str, torch.Tensor]
+    audio_token_id: int
+    end_audio_token_id: int
+    vocab_size: int
+    max_new_tokens: int = 4096
+
+
+def build_voxtral_request(
+    state: VoxtralTTSState,
+    *,
+    request_id: str,
+    ctx: VoxtralAdapterContext,
+) -> VoxtralSGLangRequestData:
+    from sglang.srt.managers.schedule_batch import Req
+    from sglang.srt.sampling.sampling_params import SamplingParams
+
+    input_ids_list = list(state.input_ids or [])
+    if not input_ids_list:
+        raise ValueError("Voxtral request has no input_ids")
+    input_ids = torch.tensor(input_ids_list, dtype=torch.long)
+    max_new_tokens = state.max_new_tokens or ctx.max_new_tokens
+
+    stop_token_ids = [ctx.end_audio_token_id]
+
+    sampling_params = SamplingParams(
+        max_new_tokens=max_new_tokens,
+        temperature=0.0,
+        top_p=1.0,
+        top_k=-1,
+        repetition_penalty=1.0,
+        stop_token_ids=stop_token_ids,
+    )
+    # Voxtral ships tekken.json (mistral-common), not a HF tokenizer;
+    # passing None bypasses SamplingParams' tokenizer-vocab assertion.
+    sampling_params.normalize(None)
+    sampling_params.verify(None)
+
+    req = Req(
+        rid=request_id,
+        origin_input_text="",
+        origin_input_ids=input_ids_list,
+        sampling_params=sampling_params,
+        vocab_size=ctx.vocab_size,
+        eos_token_ids=set(stop_token_ids),
+    )
+    # SGLang's Req has no default for these; the base sampler
+    # (_apply_codec_suppress_tokens) and prefill (_input_embeds_are_projected
+    # branch) read them unconditionally. Voxtral never suppresses tokens at
+    # the sampler — its semantic code is chosen in the acoustic step — and
+    # always provides hidden-size input_embeds (voice injection below).
+    req._codec_suppress_tokens = None
+    req._input_embeds_are_projected = True
+
+    voice = state.voice or "cheerful_female"
+    voice_emb = ctx.voice_embeddings.get(voice)
+    if voice_emb is None:
+        raise ValueError(
+            f"Voxtral voice {voice!r} not found; available: "
+            f"{sorted(ctx.voice_embeddings)}"
+        )
+
+    input_ids_dev = input_ids.to(ctx.embed_tokens.weight.device)
+    with torch.no_grad():
+        embeds = ctx.embed_tokens(input_ids_dev).to(dtype=voice_emb.dtype)
+        audio_positions = (input_ids_dev == ctx.audio_token_id).nonzero(as_tuple=True)[0]
+        n_voice_frames = min(int(audio_positions.shape[0]), int(voice_emb.shape[0]))
+        if n_voice_frames > 0:
+            embeds[audio_positions[:n_voice_frames]] = voice_emb[:n_voice_frames].to(
+                embeds.dtype
+            )
+    # schedule_batch.prepare_for_extend expects nested Python lists.
+    req.input_embeds = embeds.float().cpu().tolist()
+
+    return VoxtralSGLangRequestData(
+        input_ids=input_ids,
+        req=req,
+        voice=voice,
+        max_new_tokens=max_new_tokens,
+        end_audio_token_id=ctx.end_audio_token_id,
+    )
+
+
+def apply_voxtral_result(
+    state: VoxtralTTSState, data: VoxtralSGLangRequestData
+) -> None:
+    output_ids = data.req.output_ids
+    state.prompt_tokens = int(data.input_ids.shape[0])
+    if not output_ids:
+        state.audio_codes = torch.empty(0, 37, dtype=torch.long)
+        state.completion_tokens = 0
+        return
+
+    # Single per-request GPU→CPU sync of the acoustic residuals.
+    residuals = torch.stack(data.acoustic_codebook_residuals, dim=0).cpu()  # [T, 36]
+    semantic = torch.tensor(output_ids, dtype=torch.long).unsqueeze(1)  # [T, 1]
+    # SGLang stop-token logic appends end_audio to output_ids but the
+    # acoustic step never produces a residual row for it; trim to match.
+    n = min(semantic.shape[0], residuals.shape[0])
+    state.audio_codes = torch.cat([semantic[:n], residuals[:n]], dim=1)
+    state.completion_tokens = n
+
+
+def make_voxtral_scheduler_adapters(ctx: VoxtralAdapterContext):
+    """Return ``(request_builder, result_adapter)`` for OmniScheduler."""
+
+    def request_builder(payload: StagePayload) -> VoxtralSGLangRequestData:
+        state = VoxtralTTSState.from_dict(payload.data)
+        req_data = build_voxtral_request(
+            state, request_id=payload.request_id, ctx=ctx
+        )
+        req_data.stage_payload = payload
+        return req_data
+
+    def result_adapter(data: VoxtralSGLangRequestData) -> StagePayload:
+        payload = data.stage_payload
+        state = VoxtralTTSState.from_dict(payload.data)
+        apply_voxtral_result(state, data)
+        return StagePayload(
+            request_id=payload.request_id,
+            request=payload.request,
+            data=state.to_dict(),
+        )
+
+    return request_builder, result_adapter

--- a/sglang_omni/models/voxtral_tts_v1/sglang_model.py
+++ b/sglang_omni/models/voxtral_tts_v1/sglang_model.py
@@ -1,0 +1,361 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SGLang-native Voxtral-TTS text model."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable, Optional, Tuple
+
+import torch
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from torch import Tensor, nn
+
+from sglang_omni.vendor.sglang.core import ForwardBatch
+from sglang_omni.vendor.sglang.layers import (
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    RadixAttention,
+    RMSNorm,
+    RowParallelLinear,
+    VocabParallelEmbedding,
+    get_rope,
+)
+from sglang_omni.vendor.sglang.utils import make_layers
+
+logger = logging.getLogger(__name__)
+
+
+class VoxtralAttention(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        layer_id: int,
+        rope_base: float = 1_000_000.0,
+        max_position_embeddings: int = 32_768,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = head_dim
+        self.q_size = num_heads * head_dim
+        self.kv_size = num_kv_heads * head_dim
+        self.scaling = head_dim**-0.5
+
+        self.qkv_proj = QKVParallelLinear(
+            hidden_size,
+            head_dim,
+            num_heads,
+            num_kv_heads,
+            bias=False,
+        )
+        self.o_proj = RowParallelLinear(
+            num_heads * head_dim,
+            hidden_size,
+            bias=False,
+        )
+        # Mistral grouped RoPE (no Q/K re-interleave at load).
+        self.rotary_emb = get_rope(
+            head_dim,
+            rotary_dim=head_dim,
+            max_position=max_position_embeddings,
+            base=rope_base,
+            is_neox_style=False,
+        )
+        self.attn = RadixAttention(
+            num_heads,
+            head_dim,
+            self.scaling,
+            num_kv_heads=num_kv_heads,
+            layer_id=layer_id,
+        )
+
+    def forward(
+        self,
+        positions: Tensor,
+        hidden_states: Tensor,
+        forward_batch: ForwardBatch,
+    ) -> Tensor:
+        qkv, _ = self.qkv_proj(hidden_states)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q, k = self.rotary_emb(positions, q, k)
+        attn_output = self.attn(q, k, v, forward_batch)
+        output, _ = self.o_proj(attn_output)
+        return output
+
+
+class VoxtralDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        layer_id: int,
+        rope_base: float = 1_000_000.0,
+        max_position_embeddings: int = 32_768,
+        rms_norm_eps: float = 1e-5,
+    ) -> None:
+        super().__init__()
+        self.self_attn = VoxtralAttention(
+            hidden_size=hidden_size,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            layer_id=layer_id,
+            rope_base=rope_base,
+            max_position_embeddings=max_position_embeddings,
+        )
+        self.gate_up_proj = MergedColumnParallelLinear(
+            hidden_size,
+            [intermediate_size, intermediate_size],
+            bias=False,
+        )
+        self.down_proj = RowParallelLinear(
+            intermediate_size,
+            hidden_size,
+            bias=False,
+        )
+        self.input_layernorm = RMSNorm(hidden_size, eps=rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(hidden_size, eps=rms_norm_eps)
+
+    def forward(
+        self,
+        positions: Tensor,
+        hidden_states: Tensor,
+        forward_batch: ForwardBatch,
+        residual: Optional[Tensor],
+    ) -> Tuple[Tensor, Tensor]:
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+
+        hidden_states = self.self_attn(positions, hidden_states, forward_batch)
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+
+        gate_up, _ = self.gate_up_proj(hidden_states)
+        gate, up = gate_up.chunk(2, dim=-1)
+        hidden_states = torch.nn.functional.silu(gate) * up
+        del gate, up
+        hidden_states, _ = self.down_proj(hidden_states)
+        return hidden_states, residual
+
+
+class VoxtralSGLangTextModel(nn.Module):
+    """Voxtral-TTS LLM backbone (Llama-family GQA + RoPE + RMSNorm)."""
+
+    def __init__(
+        self,
+        config: Any = None,
+        quant_config: Any = None,
+        vocab_size: int = 131_072,
+        hidden_size: int = 3_072,
+        intermediate_size: int = 9_216,
+        num_layers: int = 26,
+        num_heads: int = 32,
+        num_kv_heads: int = 8,
+        head_dim: int = 128,
+        rope_base: float = 1_000_000.0,
+        max_position_embeddings: int = 32_768,
+        rms_norm_eps: float = 1e-5,
+        tie_word_embeddings: bool = True,
+    ) -> None:
+        super().__init__()
+
+        if config is not None:
+            vocab_size = config.vocab_size
+            hidden_size = config.hidden_size
+            intermediate_size = config.intermediate_size
+            num_layers = config.num_hidden_layers
+            num_heads = config.num_attention_heads
+            num_kv_heads = config.num_key_value_heads
+            head_dim = getattr(
+                config, "head_dim", hidden_size // num_heads
+            )
+            rope_base = getattr(config, "rope_theta", rope_base)
+            max_position_embeddings = getattr(
+                config, "max_position_embeddings", max_position_embeddings
+            )
+            rms_norm_eps = getattr(config, "rms_norm_eps", rms_norm_eps)
+            tie_word_embeddings = getattr(
+                config, "tie_word_embeddings", tie_word_embeddings
+            )
+
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.num_layers = num_layers
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = head_dim
+        self.tie_word_embeddings = tie_word_embeddings
+
+        self.embed_tokens = VocabParallelEmbedding(vocab_size, hidden_size)
+        self.start_layer = 0
+        self.end_layer = num_layers
+        self.layers = make_layers(
+            num_layers,
+            lambda idx, prefix: VoxtralDecoderLayer(
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                head_dim=head_dim,
+                layer_id=idx,
+                rope_base=rope_base,
+                max_position_embeddings=max_position_embeddings,
+                rms_norm_eps=rms_norm_eps,
+            ),
+            prefix="layers",
+        )
+        self.norm = RMSNorm(hidden_size, eps=rms_norm_eps)
+
+        if not tie_word_embeddings:
+            from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
+
+            self.lm_head = ParallelLMHead(vocab_size, hidden_size)
+
+        # Decode-time feedback storage; tensor identity is captured by the
+        # CUDA graph, contents are rewritten in-place each step.
+        self._feedback_buffer: Optional[Tensor] = None
+
+    def setup_feedback_buffer(self, max_batch_size: int) -> None:
+        device = self.embed_tokens.weight.device
+        dtype = self.embed_tokens.weight.dtype
+        self._feedback_buffer = torch.zeros(
+            max_batch_size, self.hidden_size, dtype=dtype, device=device
+        )
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        positions: Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: Optional[Tensor] = None,
+    ) -> LogitsProcessorOutput:
+        if input_embeds is None and forward_batch.input_embeds is not None:
+            input_embeds = forward_batch.input_embeds
+
+        # Prefill: voice-injected input_embeds (set by request builder).
+        # Decode: always read from _feedback_buffer so the CUDA-graph
+        # captured branch sees a stable tensor identity.
+        is_extend = forward_batch.forward_mode.is_extend()
+        if input_embeds is not None:
+            hidden_states = input_embeds
+        elif (not is_extend) and self._feedback_buffer is not None:
+            hidden_states = self._feedback_buffer[: input_ids.shape[0]]
+        else:
+            hidden_states = self.embed_tokens(input_ids)
+
+        residual = None
+        for layer_idx in range(self.start_layer, self.end_layer):
+            hidden_states, residual = self.layers[layer_idx](
+                positions, hidden_states, forward_batch, residual
+            )
+        hidden_states, _ = self.norm(hidden_states, residual)
+
+        if forward_batch.forward_mode.is_extend():
+            last_index = torch.cumsum(forward_batch.extend_seq_lens, dim=0) - 1
+            hidden_states = hidden_states[last_index]
+
+        # SGLang's sampler expects next_token_logits; the value is unused
+        # (post_decode overrides the sampled token from hidden_states).
+        if self.tie_word_embeddings:
+            logits = torch.nn.functional.linear(hidden_states, self.embed_tokens.weight)
+        else:
+            logits = self.lm_head(hidden_states)
+
+        return LogitsProcessorOutput(
+            next_token_logits=logits,
+            hidden_states=hidden_states,
+        )
+
+    def get_embed_tokens(self):
+        return self.embed_tokens
+
+    def load_weights(self, weights: Iterable[Tuple[str, Tensor]]):
+        params_dict = dict(self.named_parameters())
+        seen: set[str] = set()
+
+        for name, loaded_weight in weights:
+            target = _remap_voxtral_key(name)
+            if target is None:
+                continue
+
+            if isinstance(target, tuple):
+                target_name, shard_id = target
+                if target_name not in params_dict:
+                    logger.debug("Skipping fused target not in params: %s", target_name)
+                    continue
+                param = params_dict[target_name]
+                param.weight_loader(param, loaded_weight, shard_id)
+                seen.add(target_name)
+                continue
+
+            if target not in params_dict:
+                logger.debug("Skipping unknown target: %s (from %s)", target, name)
+                continue
+            param = params_dict[target]
+            weight_loader = getattr(param, "weight_loader", _default_weight_loader)
+            weight_loader(param, loaded_weight)
+            seen.add(target)
+
+        missing = sorted(set(params_dict.keys()) - seen)
+        if missing:
+            logger.warning(
+                "VoxtralSGLangTextModel: %d unloaded parameter(s); first few: %s",
+                len(missing),
+                missing[:5],
+            )
+
+
+# Mistral checkpoint suffix → SGLang param suffix. Tuple values target a
+# fused linear (QKVParallelLinear / MergedColumnParallelLinear) and carry
+# the shard_id.
+_LAYER_KEY_MAP: dict[str, "str | tuple[str, str | int]"] = {
+    "attention.wq.weight": ("self_attn.qkv_proj.weight", "q"),
+    "attention.wk.weight": ("self_attn.qkv_proj.weight", "k"),
+    "attention.wv.weight": ("self_attn.qkv_proj.weight", "v"),
+    "attention.wo.weight": "self_attn.o_proj.weight",
+    "attention_norm.weight": "input_layernorm.weight",
+    "feed_forward.w1.weight": ("gate_up_proj.weight", 0),
+    "feed_forward.w3.weight": ("gate_up_proj.weight", 1),
+    "feed_forward.w2.weight": "down_proj.weight",
+    "ffn_norm.weight": "post_attention_layernorm.weight",
+}
+
+_GLOBAL_KEY_MAP: dict[str, str] = {
+    "norm.weight": "norm.weight",
+    "mm_audio_embeddings.tok_embeddings.weight": "embed_tokens.weight",
+}
+
+
+def _remap_voxtral_key(name: str):
+    if name in _GLOBAL_KEY_MAP:
+        return _GLOBAL_KEY_MAP[name]
+
+    import re
+
+    m = re.match(r"^layers\.(\d+)\.(.+)$", name)
+    if m is None:
+        return None
+    layer_idx, suffix = m.group(1), m.group(2)
+    mapped = _LAYER_KEY_MAP.get(suffix)
+    if mapped is None:
+        return None
+    if isinstance(mapped, tuple):
+        target_suffix, shard = mapped
+        return (f"layers.{layer_idx}.{target_suffix}", shard)
+    return f"layers.{layer_idx}.{mapped}"
+
+
+def _default_weight_loader(param: nn.Parameter, loaded_weight: Tensor):
+    param.data.copy_(loaded_weight)
+
+
+EntryClass = VoxtralSGLangTextModel

--- a/sglang_omni/models/voxtral_tts_v1/stages.py
+++ b/sglang_omni/models/voxtral_tts_v1/stages.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stage factories for the Voxtral-TTS V1 pipeline."""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import time
+from typing import Any
+
+import torch
+
+from sglang_omni.models.voxtral_tts.io import VoxtralTTSState
+from sglang_omni.proto import StagePayload
+
+logger = logging.getLogger(__name__)
+
+
+_VOXTRAL_MISTRAL_COMMON_HINT = (
+    "Voxtral TTS requires the `mistral-common` package (Tekken speech "
+    "tokenizer). Install via `uv pip install 'mistral-common[audio]>=1.8.0'`."
+)
+
+
+def _import_mistral_common():
+    try:
+        from mistral_common.protocol.speech.request import SpeechRequest
+        from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
+    except ImportError as exc:
+        raise RuntimeError(_VOXTRAL_MISTRAL_COMMON_HINT) from exc
+    return SpeechRequest, MistralTokenizer
+
+
+def _resolve_checkpoint(checkpoint: str) -> str:
+    if os.path.isdir(checkpoint):
+        return checkpoint
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(checkpoint)
+
+
+def _load_state(payload: StagePayload) -> VoxtralTTSState:
+    return VoxtralTTSState.from_dict(payload.data)
+
+
+def _store_state(payload: StagePayload, state: VoxtralTTSState) -> StagePayload:
+    payload.data = state.to_dict()
+    return payload
+
+
+def create_preprocessing_executor(
+    model_path: str,
+    *,
+    max_concurrency: int = 8,
+):
+    from sglang_omni.scheduling.threaded_simple_scheduler import ThreadedSimpleScheduler
+
+    checkpoint_dir = _resolve_checkpoint(model_path)
+    SpeechRequest, MistralTokenizer = _import_mistral_common()
+    tekken_path = os.path.join(checkpoint_dir, "tekken.json")
+    tokenizer = MistralTokenizer.from_file(tekken_path)
+
+    def _preprocess(payload: StagePayload) -> StagePayload:
+        inputs = payload.request.inputs
+        params = payload.request.params or {}
+        metadata = payload.request.metadata or {}
+
+        if isinstance(inputs, str):
+            text = inputs
+        elif isinstance(inputs, dict):
+            text = inputs.get("text", "")
+        else:
+            text = str(inputs) if inputs else ""
+
+        tts_params = metadata.get("tts_params", {})
+        voice = tts_params.get("voice") or params.get("voice") or "cheerful_female"
+
+        encoded = tokenizer.encode_speech_request(
+            SpeechRequest(input=text, voice=voice)
+        )
+
+        max_new_tokens = params.get("max_new_tokens", 4096)
+        if isinstance(max_new_tokens, dict):
+            max_new_tokens = max_new_tokens.get("max_new_tokens", 4096)
+
+        state = VoxtralTTSState(
+            input_ids=list(encoded.tokens),
+            voice=voice,
+            max_new_tokens=max_new_tokens,
+        )
+        return _store_state(payload, state)
+
+    return ThreadedSimpleScheduler(_preprocess, max_concurrency=max_concurrency)
+
+
+def create_generation_executor(
+    model_path: str,
+    *,
+    device: str = "cuda:0",
+    max_new_tokens: int = 4096,
+    context_length: int = 8192,
+    server_args_overrides: dict | None = None,
+):
+    from sglang_omni.models.voxtral_tts_v1.bootstrap import create_voxtral_scheduler
+
+    gpu_id = int(device.split(":")[-1]) if ":" in device else 0
+    return create_voxtral_scheduler(
+        model_path,
+        gpu_id=gpu_id,
+        max_new_tokens=max_new_tokens,
+        context_length=context_length,
+        server_args_overrides=server_args_overrides,
+    )
+
+
+def _load_audio_tokenizer(checkpoint_dir: str, device: str):
+    import glob
+
+    from sglang.srt.model_loader.weight_utils import safetensors_weights_iterator
+
+    from sglang_omni.models.voxtral_tts.audio_tokenizer import VoxtralTTSAudioTokenizer
+    from sglang_omni.models.voxtral_tts.model_config import VoxtralModelConfig
+
+    config = VoxtralModelConfig.from_model_path(checkpoint_dir)
+    tokenizer = VoxtralTTSAudioTokenizer(
+        audio_tokenizer_args=config.audio_tokenizer_args,
+        audio_config={
+            "audio_model_args": config.audio_model_args.acoustic_transformer_args,
+        },
+    )
+
+    safetensors_files = sorted(glob.glob(os.path.join(checkpoint_dir, "*.safetensors")))
+    if not safetensors_files:
+        raise RuntimeError(f"No .safetensors files in {checkpoint_dir}")
+
+    t0 = time.perf_counter()
+    remapping_rules = [
+        (r"^audio_tokenizer\.(.*)$", r"\1"),
+        (
+            r"^mm_audio_embeddings\.audio_codebook_embeddings\.embeddings\.(weight|bias)",
+            r"audio_token_embedding.embeddings.\1",
+        ),
+    ]
+    for name, tensor in safetensors_weights_iterator(safetensors_files):
+        is_audio_tokenizer = name.startswith(
+            "mm_audio_embeddings.audio_codebook_embeddings"
+        ) or name.startswith("audio_tokenizer.")
+        if not is_audio_tokenizer:
+            continue
+        remapped = name
+        for pattern, repl in remapping_rules:
+            if re.fullmatch(pattern, remapped):
+                remapped = re.sub(pattern, repl, remapped)
+        tokenizer.load_weight((remapped, tensor))
+
+    tokenizer = tokenizer.to(dtype=torch.bfloat16, device=device).eval()
+    logger.info("Audio tokenizer loaded in %.2fs", time.perf_counter() - t0)
+    return tokenizer
+
+
+def create_vocoder_executor(
+    model_path: str,
+    *,
+    device: str = "cuda:0",
+):
+    from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+
+    checkpoint_dir = _resolve_checkpoint(model_path)
+    logger.info("Loading Voxtral audio tokenizer for vocoding...")
+    audio_tokenizer = _load_audio_tokenizer(checkpoint_dir, device)
+
+    def _vocode(payload: StagePayload) -> StagePayload:
+        state = _load_state(payload)
+        audio_codes = state.audio_codes
+
+        if audio_codes is None or (
+            isinstance(audio_codes, torch.Tensor) and audio_codes.numel() == 0
+        ):
+            state.audio_samples = []
+            payload = _store_state(payload, state)
+            payload.data["audio_data"] = []
+            payload.data["sample_rate"] = 24000
+            payload.data["modality"] = "audio"
+            return payload
+
+        if not isinstance(audio_codes, torch.Tensor):
+            audio_codes = torch.tensor(audio_codes)
+
+        # Warmup context for the causal decoder; trimmed after decode.
+        n_warmup = 2
+        warmup_samples = 0
+        if audio_codes.shape[0] > 0:
+            first_frame = audio_codes[0:1]
+            warmup = first_frame.repeat(n_warmup, 1)
+            codes_with_warmup = torch.cat([warmup, audio_codes], dim=0)
+            warmup_samples = n_warmup * audio_tokenizer.downsample_factor
+        else:
+            codes_with_warmup = audio_codes
+
+        results = audio_tokenizer.decode_helper_batch_async([codes_with_warmup])
+        audio_np = results[0]
+        if warmup_samples > 0 and len(audio_np) > warmup_samples:
+            audio_np = audio_np[warmup_samples:]
+
+        fade_in_ms = 10
+        fade_samples = min(
+            int(fade_in_ms * audio_tokenizer.sampling_rate / 1000),
+            len(audio_np),
+        )
+        if fade_samples > 0:
+            fade_in = torch.linspace(
+                0, 1, fade_samples, device=audio_np.device, dtype=audio_np.dtype,
+            )
+            audio_np[:fade_samples] = audio_np[:fade_samples] * fade_in
+
+        state.audio_samples = audio_np
+        state.sample_rate = audio_tokenizer.sampling_rate
+        payload = _store_state(payload, state)
+        payload.data["audio_data"] = audio_np.tolist()
+        payload.data["sample_rate"] = audio_tokenizer.sampling_rate
+        payload.data["modality"] = "audio"
+
+        if state.prompt_tokens or state.completion_tokens:
+            payload.data["usage"] = {
+                "prompt_tokens": state.prompt_tokens,
+                "completion_tokens": state.completion_tokens,
+                "total_tokens": state.prompt_tokens + state.completion_tokens,
+            }
+        return payload
+
+    return SimpleScheduler(_vocode)

--- a/tests/unit_test/voxtral_tts_v1/test_pipeline.py
+++ b/tests/unit_test/voxtral_tts_v1/test_pipeline.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from torch import nn
+
+from sglang_omni.models.voxtral_tts.io import VoxtralTTSState
+from sglang_omni.models.voxtral_tts_v1.config import VoxtralTTSV1PipelineConfig
+from sglang_omni.models.voxtral_tts_v1.request_builders import (
+    VoxtralAdapterContext,
+    VoxtralSGLangRequestData,
+    apply_voxtral_result,
+    build_voxtral_request,
+    make_voxtral_scheduler_adapters,
+)
+from sglang_omni.proto import OmniRequest, StagePayload
+
+
+def test_voxtral_pipeline_config_topology_and_validation() -> None:
+    """Preserves the 3-stage non-streaming topology under the V1 flat StageConfig schema."""
+    config = VoxtralTTSV1PipelineConfig(model_path="model")
+
+    assert [stage.name for stage in config.stages] == [
+        "preprocessing",
+        "generation",
+        "vocoder",
+    ]
+    assert config.resolved_entry_stage == "preprocessing"
+    assert config.terminal_stages == ["vocoder"]
+    assert config.gpu_placement == {"generation": 0, "vocoder": 0}
+
+    preprocessing, generation, vocoder = config.stages
+    assert preprocessing.next == "generation" and not preprocessing.terminal
+    assert generation.next == "vocoder" and not generation.terminal
+    assert generation.factory_args == {"device": "cuda:0", "max_new_tokens": 4096}
+    assert vocoder.terminal and vocoder.next is None
+    assert vocoder.factory_args == {"device": "cuda:0"}
+
+
+def test_voxtral_state_round_trips_through_dict() -> None:
+    """VoxtralTTSState survives the cross-stage dict serialization that
+    StagePayload.data uses. Tensor audio_codes survives; audio_samples is
+    serialized as a list for msgpack compatibility."""
+    audio_codes = torch.tensor(
+        [[100, 101, 102], [200, 201, 202]], dtype=torch.long
+    )
+    audio_samples = torch.tensor([0.1, -0.1, 0.2], dtype=torch.float32)
+    state = VoxtralTTSState(
+        input_ids=[1, 2, 3],
+        voice="cheerful_female",
+        max_new_tokens=512,
+        audio_codes=audio_codes,
+        prompt_tokens=10,
+        completion_tokens=7,
+        audio_samples=audio_samples,
+        sample_rate=24000,
+    )
+
+    restored = VoxtralTTSState.from_dict(state.to_dict())
+
+    assert restored.input_ids == [1, 2, 3]
+    assert restored.voice == "cheerful_female"
+    assert restored.max_new_tokens == 512
+    assert restored.prompt_tokens == 10
+    assert restored.completion_tokens == 7
+    assert restored.sample_rate == 24000
+    assert torch.equal(restored.audio_codes, audio_codes)
+    assert restored.audio_samples == audio_samples.tolist()
+
+
+def test_voxtral_stage_factory_dotted_paths_resolve_to_callables() -> None:
+    """Every StageConfig.factory must importlib-resolve to a callable, so the
+    pipeline compiler can wire stages without instantiating models."""
+    config = VoxtralTTSV1PipelineConfig(model_path="model")
+    for stage in config.stages:
+        module_path, _, attr = stage.factory.rpartition(".")
+        module = importlib.import_module(module_path)
+        fn = getattr(module, attr)
+        assert callable(fn), f"{stage.factory} did not resolve to a callable"
+
+
+@pytest.fixture(autouse=True)
+def _stub_sampling_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SamplingParams.normalize/verify require an HF tokenizer; bypass."""
+    monkeypatch.setattr(
+        "sglang.srt.sampling.sampling_params.SamplingParams.normalize",
+        lambda self, tokenizer: None,
+    )
+    monkeypatch.setattr(
+        "sglang.srt.sampling.sampling_params.SamplingParams.verify",
+        lambda self, vocab_size: None,
+    )
+
+
+def _make_ctx(
+    *,
+    audio_token_id: int = 10,
+    end_audio_token_id: int = 99,
+    vocab_size: int = 128,
+    voices: tuple[str, ...] = ("cheerful_female", "warm_male"),
+    hidden: int = 4,
+) -> VoxtralAdapterContext:
+    embed = nn.Embedding(vocab_size, hidden)
+    nn.init.zeros_(embed.weight)
+    return VoxtralAdapterContext(
+        embed_tokens=embed,
+        voice_embeddings={
+            name: torch.full((2, hidden), float(idx + 1), dtype=torch.bfloat16)
+            for idx, name in enumerate(voices)
+        },
+        audio_token_id=audio_token_id,
+        end_audio_token_id=end_audio_token_id,
+        vocab_size=vocab_size,
+        max_new_tokens=64,
+    )
+
+
+def test_build_voxtral_request_injects_voice_at_audio_positions() -> None:
+    """audio_token_id positions in input_ids are overwritten with the voice
+    embedding; other positions come from embed_tokens."""
+    ctx = _make_ctx(audio_token_id=10, hidden=4)
+    state = VoxtralTTSState(input_ids=[1, 10, 10, 2], voice="cheerful_female")
+
+    data = build_voxtral_request(state, request_id="r1", ctx=ctx)
+
+    assert data.voice == "cheerful_female"
+    assert data.end_audio_token_id == 99
+    embeds = torch.tensor(data.req.input_embeds, dtype=torch.float32)
+    assert embeds.shape == (4, 4)
+    # cheerful_female voice embedding is filled with 1.0; positions 1 and 2
+    # are audio_token_id and should be overwritten.
+    assert torch.allclose(embeds[1:3], torch.ones(2, 4))
+    # Non-audio positions still come from the zero-initialized embed_tokens.
+    assert torch.all(embeds[0] == 0) and torch.all(embeds[3] == 0)
+
+
+def test_build_voxtral_request_raises_on_unknown_voice() -> None:
+    """Voice not in the checkpoint dict is a hard error, not a silent fallback."""
+    ctx = _make_ctx()
+    state = VoxtralTTSState(input_ids=[1, 2, 3], voice="nonexistent")
+    with pytest.raises(ValueError, match="nonexistent"):
+        build_voxtral_request(state, request_id="r2", ctx=ctx)
+
+
+def test_build_voxtral_request_raises_on_empty_input_ids() -> None:
+    ctx = _make_ctx()
+    state = VoxtralTTSState(input_ids=[], voice="cheerful_female")
+    with pytest.raises(ValueError, match="input_ids"):
+        build_voxtral_request(state, request_id="r3", ctx=ctx)
+
+
+def test_apply_voxtral_result_concats_semantic_and_residuals() -> None:
+    """Result adapter stacks per-step residuals once and concatenates with
+    the semantic column to form the [T, 37] code grid for the vocoder."""
+    state = VoxtralTTSState(input_ids=[1, 2, 3, 4], voice="cheerful_female")
+    req = MagicMock()
+    req.output_ids = [5, 6, 7]
+    data = VoxtralSGLangRequestData(
+        input_ids=torch.tensor([1, 2, 3, 4]),
+        req=req,
+        voice="cheerful_female",
+        acoustic_codebook_residuals=[
+            torch.full((36,), float(t), dtype=torch.long) for t in (5, 6, 7)
+        ],
+    )
+
+    apply_voxtral_result(state, data)
+
+    assert state.prompt_tokens == 4
+    assert state.completion_tokens == 3
+    assert state.audio_codes.shape == (3, 37)
+    assert state.audio_codes[:, 0].tolist() == [5, 6, 7]
+    assert torch.all(state.audio_codes[:, 1:] == state.audio_codes[:, :1])
+
+
+def test_apply_voxtral_result_trims_dangling_end_audio_token() -> None:
+    """SGLang's stop-token logic appends end_audio to output_ids but the
+    acoustic step never produces a matching residual row; trim to match."""
+    state = VoxtralTTSState(input_ids=[1, 2], voice="cheerful_female")
+    req = MagicMock()
+    req.output_ids = [5, 6, 99]  # 99 = end_audio, has no residual
+    data = VoxtralSGLangRequestData(
+        input_ids=torch.tensor([1, 2]),
+        req=req,
+        voice="cheerful_female",
+        acoustic_codebook_residuals=[torch.zeros(36, dtype=torch.long) for _ in range(2)],
+    )
+
+    apply_voxtral_result(state, data)
+
+    assert state.completion_tokens == 2
+    assert state.audio_codes.shape == (2, 37)
+    assert state.audio_codes[:, 0].tolist() == [5, 6]
+
+
+def test_apply_voxtral_result_empty_output_yields_empty_codes() -> None:
+    state = VoxtralTTSState(input_ids=[1, 2], voice="cheerful_female")
+    req = MagicMock()
+    req.output_ids = []
+    data = VoxtralSGLangRequestData(
+        input_ids=torch.tensor([1, 2]),
+        req=req,
+        voice="cheerful_female",
+    )
+
+    apply_voxtral_result(state, data)
+
+    assert state.prompt_tokens == 2
+    assert state.completion_tokens == 0
+    assert state.audio_codes.shape == (0, 37)
+
+
+def test_scheduler_adapters_round_trip_payload() -> None:
+    """make_voxtral_scheduler_adapters returns a (builder, adapter) pair
+    that preserves StagePayload identity and serializes audio_codes back."""
+    ctx = _make_ctx()
+    state = VoxtralTTSState(input_ids=[1, 10, 2], voice="cheerful_female")
+    payload = StagePayload(
+        request_id="req-x",
+        request=OmniRequest(inputs="hello", params={}),
+        data=state.to_dict(),
+    )
+
+    request_builder, result_adapter = make_voxtral_scheduler_adapters(ctx)
+    data = request_builder(payload)
+    assert data.stage_payload is payload
+    data.req.output_ids = [42, 43]
+    data.acoustic_codebook_residuals = [
+        torch.full((36,), float(t), dtype=torch.long) for t in (42, 43)
+    ]
+
+    out = result_adapter(data)
+    assert out.request_id == "req-x"
+    assert out.request is payload.request
+    assert out.data["completion_tokens"] == 2
+    assert len(out.data["audio_codes"]) == 2
+    assert out.data["audio_codes"][0][0] == 42


### PR DESCRIPTION
## Summary

Adds Voxtral-TTS (`mistralai/Voxtral-4B-TTS-2603`) support via the
standard `OmniScheduler` (preferred over `SimpleScheduler` /
`FishScheduler` per the issue thread). Tracks
sgl-project/sglang-omni#444 (Voxtral half).

## Test plan

- [x] **Full SeedTTS EN benchmark** (1088 samples, `--max-concurrency 16`,
      voice=cheerful_female, ASR = Whisper-large-v3, H200 / bf16 / fa3 /
      CUDA graph on):

      Corpus WER       1.10%
      Median WER       0%    p95 9.1%   max 46.2%
      Failed gens      0/1088
      RTF mean         0.6092
      Throughput       4.66 QPS    Latency mean 3.42s

- [x] **Full SeedTTS CH benchmark** (2020 samples, same config,
      ASR = Whisper-large-v3):

      Corpus CER       105.4%  (see "CH note" below)
      Failed gens      0/2020
      RTF mean         0.4959
      Throughput       3.03 QPS    Latency mean 5.21s

## Score alignment

**EN**: 1.10% WER is within evaluation noise of Mistral's reported 1.23%
aggregate SeedTTS WER (Voxtral paper Table 3; aggregate covers EN+CH and
the paper does not specify the ASR model used). The interpretable claim
is that SGLang integration does not regress generation quality.

**CH**: out of scope, see below.

## CH note

Voxtral-TTS does not officially support Chinese — the checkpoint's voice
list and Mistral's model card cover EN/PT/NL/IT/FR/ES/DE/AR/HI only. On
SeedTTS-CH the model generates audio without failures but in non-Chinese
phonetic content, so the CER number is a coverage-out-of-scope artifact,
not a regression from the SGLang integration.

## Out of scope / follow-up

A follow-up PR will relocate the standalone shared modules
(`acoustic_transformer.py`, `audio_tokenizer.py`, `model_config.py`,
`io.py`) from the legacy `voxtral_tts/` package into `voxtral_tts_v1/`
and delete the rest of V0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
