### PR TITLE
[Ming-Omni] Support Video Understanding for V1 Pipeline

### DIFF
--- a/sglang_omni/models/ming_omni/components/image_encoder.py
+++ b/sglang_omni/models/ming_omni/components/image_encoder.py
@@ -180,50 +180,66 @@ class MingImageEncoder(nn.Module):
             parallel_state.destroy_model_parallel()
             logger.info("Cleaned up model parallel state for thinker reuse")
 
-    def forward(
+    def _encode(
         self,
         pixel_values: torch.Tensor,
-        image_grid_thw: torch.Tensor,
-        **kwargs: Any,
-    ) -> dict[str, torch.Tensor]:
-        """Encode images and return embeddings.
-
-        Args:
-            pixel_values: Flattened pixel values [total_patches, patch_dim].
-            image_grid_thw: [num_images, 3] tensor of (t, h, w).
-
-        Returns:
-            Dict with:
-            - ``image_embeds`` [seq_len, llm_hidden_size] (L2-normalized)
-            - ``image_grid_thw`` [num_images, 3]
-            - ``image_token_counts`` [num_images] per-image token counts
-        """
+        grid_thw: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run vision encoder + projector, return (embeds, token_counts)."""
         pixel_values = pixel_values.to(
             device=self.visual.device, dtype=self.visual.dtype
         )
-        image_grid_thw = image_grid_thw.to(device=self.visual.device)
+        grid_thw = grid_thw.to(device=self.visual.device)
 
         with torch.no_grad():
-            image_embeds = self.visual(pixel_values, image_grid_thw)
-
+            embeds = self.visual(pixel_values, grid_thw)
             # Deepstack: use only base merger output for projection
             if self.visual.use_deepstack:
-                image_embeds = image_embeds[:, : self.visual.image_emb_dim]
+                embeds = embeds[:, : self.visual.image_emb_dim]
+            embeds = self.linear_proj(embeds)
+            embeds = F.normalize(embeds, dim=-1)
 
-            image_embeds = self.linear_proj(image_embeds)
-            image_embeds = F.normalize(image_embeds, dim=-1)
-
-        # Per-image token counts after spatial merge: t * h * w / merge^2
         merge_sq = self._spatial_merge_size**2
-        image_token_counts = (
-            image_grid_thw[:, 0] * image_grid_thw[:, 1] * image_grid_thw[:, 2]
-        ) // merge_sq
+        token_counts = (grid_thw[:, 0] * grid_thw[:, 1] * grid_thw[:, 2]) // merge_sq
+        return embeds, token_counts
 
-        return {
-            "image_embeds": image_embeds,
-            "image_grid_thw": image_grid_thw,
-            "image_token_counts": image_token_counts,
-        }
+    def forward(
+        self,
+        pixel_values: torch.Tensor | None = None,
+        image_grid_thw: torch.Tensor | None = None,
+        pixel_values_videos: torch.Tensor | None = None,
+        video_grid_thw: torch.Tensor | None = None,
+        **kwargs: Any,
+    ) -> dict[str, torch.Tensor]:
+        """Encode images and/or videos and return embeddings.
+
+        Args:
+            pixel_values: Flattened image patches [total_patches, patch_dim].
+            image_grid_thw: [num_images, 3] tensor of (t, h, w).
+            pixel_values_videos: Flattened video patches [total_patches, patch_dim].
+            video_grid_thw: [num_videos, 3] tensor of (t, h, w).
+
+        Returns:
+            Dict with whichever of these keys apply:
+            - ``image_embeds``, ``image_grid_thw``, ``image_token_counts``
+            - ``video_embeds``, ``video_grid_thw``, ``video_token_counts``
+        """
+        result: dict[str, torch.Tensor] = {}
+        if pixel_values is not None and image_grid_thw is not None:
+            image_embeds, image_token_counts = self._encode(
+                pixel_values, image_grid_thw
+            )
+            result["image_embeds"] = image_embeds
+            result["image_grid_thw"] = image_grid_thw.to(device=self.visual.device)
+            result["image_token_counts"] = image_token_counts
+        if pixel_values_videos is not None and video_grid_thw is not None:
+            video_embeds, video_token_counts = self._encode(
+                pixel_values_videos, video_grid_thw
+            )
+            result["video_embeds"] = video_embeds
+            result["video_grid_thw"] = video_grid_thw.to(device=self.visual.device)
+            result["video_token_counts"] = video_token_counts
+        return result
 
 
 def _resolve_dtype(dtype: str | None) -> torch.dtype:

--- a/sglang_omni/models/ming_omni/components/preprocessor.py
+++ b/sglang_omni/models/ming_omni/components/preprocessor.py
@@ -295,9 +295,12 @@ class MingPreprocessor:
         for v in videos:
             t = v
             if isinstance(t, torch.Tensor):
-                arr = t.detach().cpu().to(torch.uint8).numpy()
+                # load_video_path resizes with BICUBIC + antialias and returns
+                # a float tensor; BICUBIC can overshoot outside [0, 255] and
+                # to(uint8) wraps rather than saturates. Clamp before casting.
+                arr = t.detach().cpu().clamp_(0, 255).to(torch.uint8).numpy()
             else:
-                arr = np.asarray(t).astype(np.uint8)
+                arr = np.clip(np.asarray(t), 0, 255).astype(np.uint8)
             # (T, C, H, W) -> (T, H, W, C)
             if arr.ndim == 4 and arr.shape[1] in (1, 3):
                 arr = np.transpose(arr, (0, 2, 3, 1))
@@ -393,7 +396,26 @@ class MingPreprocessor:
         # placeholder positions (which share the same generic image_patch_token).
         image_cache_key = compute_image_cache_key(raw_images) if raw_images else None
         audio_cache_key = compute_audio_cache_key(audio_urls) if audio_urls else None
-        video_cache_key = compute_video_cache_key(raw_videos) if raw_videos else None
+        video_cache_key = (
+            compute_video_cache_key(
+                raw_videos,
+                fps=float(video_fps) if video_fps is not None else None,
+                max_frames=(
+                    int(video_max_frames) if video_max_frames is not None else None
+                ),
+                min_pixels=(
+                    int(video_min_pixels) if video_min_pixels is not None else None
+                ),
+                max_pixels=(
+                    int(video_max_pixels) if video_max_pixels is not None else None
+                ),
+                total_pixels=(
+                    int(video_total_pixels) if video_total_pixels is not None else None
+                ),
+            )
+            if raw_videos
+            else None
+        )
 
         # --- Load images, videos and audio concurrently ---
         image_coro = ensure_image_list_async(raw_images) if raw_images else None

--- a/sglang_omni/models/ming_omni/components/preprocessor.py
+++ b/sglang_omni/models/ming_omni/components/preprocessor.py
@@ -21,6 +21,10 @@ from sglang_omni.preprocessing.image import (
     compute_image_cache_key,
     ensure_image_list_async,
 )
+from sglang_omni.preprocessing.video import (
+    compute_video_cache_key,
+    ensure_video_list_async,
+)
 from sglang_omni.proto import StagePayload
 
 logger = logging.getLogger(__name__)
@@ -42,6 +46,10 @@ END_OF_AUDIO = "<end_of_audio>"
 IMAGE_START = "<image>"
 IMAGE_END = "</image>"
 IMAGE_PATCH = "<imagePatch>"
+
+VIDEO_START = "<video>"
+VIDEO_END = "</video>"
+VIDEO_PATCH = "<videoPatch>"
 
 # Whisper mel spectrogram parameters
 WHISPER_N_MELS = 128
@@ -173,6 +181,34 @@ def _inject_top_level_audios(
     return messages
 
 
+def _inject_top_level_videos(
+    messages: list[dict[str, Any]],
+    videos: list[str],
+) -> list[dict[str, Any]]:
+    """Convert top-level ``videos`` into inline content items.
+
+    Mirrors ``_inject_top_level_audios``: text comes before video so attention
+    can condition the video interpretation on the user's instruction.
+    """
+    messages = list(messages)
+    video_items: list[dict[str, Any]] = [
+        {"type": "video_url", "video_url": {"url": url}} for url in videos
+    ]
+    for idx, msg in enumerate(messages):
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content", "")
+        new_content: list[dict[str, Any]] = []
+        if isinstance(content, str):
+            new_content.append({"type": "text", "text": content})
+        elif isinstance(content, list):
+            new_content.extend(content)
+        new_content.extend(video_items)
+        messages[idx] = {**msg, "content": new_content}
+        break
+    return messages
+
+
 class MingPreprocessor:
     """Preprocessor for Ming-Omni model.
 
@@ -198,6 +234,9 @@ class MingPreprocessor:
         self._image_patch_id = getattr(llm_config, "image_patch_token", None)
         if self._image_patch_id is None:
             self._image_patch_id = self._tokenizer.convert_tokens_to_ids(IMAGE_PATCH)
+        self._video_patch_id = getattr(llm_config, "video_patch_token", None)
+        if self._video_patch_id is None:
+            self._video_patch_id = self._tokenizer.convert_tokens_to_ids(VIDEO_PATCH)
 
         # Lazy-init image processor
         self._image_processor = None
@@ -237,6 +276,45 @@ class MingPreprocessor:
         )
         return pixel_values, image_grid_thw, token_counts
 
+    def _process_videos(
+        self, videos: list[Any]
+    ) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
+        """Process video frames into pixel_values_videos, video_grid_thw, token counts.
+
+        ``videos`` is a list where each item is the per-video frame stack
+        produced by ``ensure_video_list_async`` (torch.Tensor shape ``(T, C, H, W)``
+        of float pixels in 0..255). ``Qwen2VLImageProcessor.preprocess(videos=...)``
+        groups consecutive frames by ``temporal_patch_size`` and returns flattened
+        patches plus ``video_grid_thw`` with the merged temporal dim.
+        """
+        processor = self._get_image_processor()
+        # Convert per-video tensors to numpy arrays in (T, H, W, C) uint8 — the
+        # format Qwen2VLImageProcessor expects when ``videos`` is a list of
+        # per-video frame stacks.
+        np_videos: list[np.ndarray] = []
+        for v in videos:
+            t = v
+            if isinstance(t, torch.Tensor):
+                arr = t.detach().cpu().to(torch.uint8).numpy()
+            else:
+                arr = np.asarray(t).astype(np.uint8)
+            # (T, C, H, W) -> (T, H, W, C)
+            if arr.ndim == 4 and arr.shape[1] in (1, 3):
+                arr = np.transpose(arr, (0, 2, 3, 1))
+            np_videos.append(arr)
+        # ``processor.__call__`` requires ``images`` as a positional argument;
+        # call ``preprocess`` directly so we can pass only ``videos``.
+        result = processor.preprocess(
+            images=None, videos=np_videos, return_tensors="pt"
+        )
+        pixel_values_videos = result["pixel_values_videos"]
+        video_grid_thw = result["video_grid_thw"]
+        token_counts = _estimate_image_tokens(
+            video_grid_thw.tolist(),
+            self._vision_config.spatial_merge_size,
+        )
+        return pixel_values_videos, video_grid_thw, token_counts
+
     async def __call__(self, payload: StagePayload) -> StagePayload:
         """Process a chat completion request into pipeline state."""
         request = payload.request
@@ -246,10 +324,22 @@ class MingPreprocessor:
             messages = raw_inputs
             audio_urls = []
             top_level_images: list[str] = []
+            top_level_videos: list[str] = []
+            video_fps = None
+            video_max_frames = None
+            video_min_pixels = None
+            video_max_pixels = None
+            video_total_pixels = None
         else:
             messages = raw_inputs.get("messages", [])
             audio_urls = raw_inputs.get("audios", [])
             top_level_images = raw_inputs.get("images") or []
+            top_level_videos = raw_inputs.get("videos") or []
+            video_fps = raw_inputs.get("video_fps")
+            video_max_frames = raw_inputs.get("video_max_frames")
+            video_min_pixels = raw_inputs.get("video_min_pixels")
+            video_max_pixels = raw_inputs.get("video_max_pixels")
+            video_total_pixels = raw_inputs.get("video_total_pixels")
 
         # If top-level images are provided (e.g. {"images": ["url1", ...]}),
         # inject them as inline content items in the first user message so that
@@ -258,9 +348,12 @@ class MingPreprocessor:
             messages = _inject_top_level_images(messages, top_level_images)
         if audio_urls:
             messages = _inject_top_level_audios(messages, audio_urls)
+        if top_level_videos:
+            messages = _inject_top_level_videos(messages, top_level_videos)
 
-        # --- Extract image URLs/data from messages ---
+        # --- Extract image / video URLs/data from messages ---
         raw_images: list[Any] = []
+        raw_videos: list[Any] = []
         for msg in messages:
             content = msg.get("content", "")
             if isinstance(content, list):
@@ -280,6 +373,19 @@ class MingPreprocessor:
                             img = item.get("image", "")
                             if img:
                                 raw_images.append(img)
+                        elif item_type == "video_url":
+                            url_data = item.get("video_url", {})
+                            url = (
+                                url_data.get("url", "")
+                                if isinstance(url_data, dict)
+                                else str(url_data)
+                            )
+                            if url:
+                                raw_videos.append(url)
+                        elif item_type == "video":
+                            vid = item.get("video", "")
+                            if vid:
+                                raw_videos.append(vid)
 
         # Compute cache keys BEFORE async loading; same content -> same key so
         # SGLang's radix prefix cache can correctly reuse KVs across requests, and
@@ -287,9 +393,30 @@ class MingPreprocessor:
         # placeholder positions (which share the same generic image_patch_token).
         image_cache_key = compute_image_cache_key(raw_images) if raw_images else None
         audio_cache_key = compute_audio_cache_key(audio_urls) if audio_urls else None
+        video_cache_key = compute_video_cache_key(raw_videos) if raw_videos else None
 
-        # --- Load images and audio concurrently ---
+        # --- Load images, videos and audio concurrently ---
         image_coro = ensure_image_list_async(raw_images) if raw_images else None
+        video_coro = (
+            ensure_video_list_async(
+                raw_videos,
+                fps=float(video_fps) if video_fps is not None else None,
+                max_frames=(
+                    int(video_max_frames) if video_max_frames is not None else None
+                ),
+                min_pixels=(
+                    int(video_min_pixels) if video_min_pixels is not None else None
+                ),
+                max_pixels=(
+                    int(video_max_pixels) if video_max_pixels is not None else None
+                ),
+                total_pixels=(
+                    int(video_total_pixels) if video_total_pixels is not None else None
+                ),
+            )
+            if raw_videos
+            else None
+        )
         audio_coros = (
             [
                 asyncio.to_thread(load_audio_path, url, target_sr=WHISPER_SAMPLE_RATE)
@@ -303,6 +430,8 @@ class MingPreprocessor:
         all_tasks: list[Any] = []
         if image_coro is not None:
             all_tasks.append(image_coro)
+        if video_coro is not None:
+            all_tasks.append(video_coro)
         all_tasks.extend(audio_coros)
 
         if all_tasks:
@@ -310,17 +439,26 @@ class MingPreprocessor:
         else:
             results = []
 
-        # Unpack results
+        # Unpack results in the same order as they were appended
         images: list[Any] = []
+        videos: list[Any] = []
+        idx = 0
         if image_coro is not None:
-            img_result = results[0]
+            img_result = results[idx]
+            idx += 1
             if isinstance(img_result, list):
                 images = img_result
             elif isinstance(img_result, BaseException):
                 logger.error("Failed to load images: %s", img_result)
-            audio_results = results[1:]
-        else:
-            audio_results = results
+        if video_coro is not None:
+            vid_result = results[idx]
+            idx += 1
+            if isinstance(vid_result, BaseException):
+                logger.error("Failed to load videos: %s", vid_result)
+            else:
+                # ensure_video_list_async returns (videos, sample_fps, audio)
+                videos = vid_result[0] if isinstance(vid_result, tuple) else vid_result
+        audio_results = results[idx:]
 
         waveforms: list[np.ndarray] = [
             a for a in audio_results if isinstance(a, np.ndarray)
@@ -335,6 +473,18 @@ class MingPreprocessor:
             pixel_values, image_grid_thw, image_token_counts = await asyncio.to_thread(
                 self._process_images, images
             )
+
+        # --- Process videos ---
+        video_token_counts: list[int] = []
+        pixel_values_videos: torch.Tensor | None = None
+        video_grid_thw: torch.Tensor | None = None
+
+        if videos:
+            (
+                pixel_values_videos,
+                video_grid_thw,
+                video_token_counts,
+            ) = await asyncio.to_thread(self._process_videos, videos)
 
         # --- Compute mel features FIRST so we know exact placeholder counts ---
         mel_features_list: list[torch.Tensor] = []
@@ -358,6 +508,7 @@ class MingPreprocessor:
             messages,
             audio_token_counts=audio_token_counts,
             image_token_counts=image_token_counts,
+            video_token_counts=video_token_counts,
         )
         input_ids_tensor = torch.tensor([input_ids], dtype=torch.long)
         attention_mask = torch.ones_like(input_ids_tensor)
@@ -396,13 +547,24 @@ class MingPreprocessor:
             if audio_cache_key:
                 encoder_inputs[AUDIO_STAGE]["cache_key"] = audio_cache_key
 
-        if pixel_values is not None and image_grid_thw is not None:
-            encoder_inputs[IMAGE_STAGE] = {
-                "pixel_values": pixel_values,
-                "image_grid_thw": image_grid_thw,
-            }
+        has_image = pixel_values is not None and image_grid_thw is not None
+        has_video = pixel_values_videos is not None and video_grid_thw is not None
+        if has_image or has_video:
+            stage_inputs: dict[str, Any] = {}
+            if has_image:
+                stage_inputs["pixel_values"] = pixel_values
+                stage_inputs["image_grid_thw"] = image_grid_thw
+            if has_video:
+                stage_inputs["pixel_values_videos"] = pixel_values_videos
+                stage_inputs["video_grid_thw"] = video_grid_thw
+            keys = []
             if image_cache_key:
-                encoder_inputs[IMAGE_STAGE]["cache_key"] = image_cache_key
+                keys.append(f"img:{image_cache_key}")
+            if video_cache_key:
+                keys.append(f"vid:{video_cache_key}")
+            if keys:
+                stage_inputs["cache_key"] = "|".join(keys)
+            encoder_inputs[IMAGE_STAGE] = stage_inputs
 
         state = PipelineState(
             raw_inputs=raw_inputs,
@@ -422,6 +584,7 @@ class MingPreprocessor:
         *,
         audio_token_counts: list[int] | None = None,
         image_token_counts: list[int] | None = None,
+        video_token_counts: list[int] | None = None,
     ) -> tuple[str, list[int], list[int]]:
         """Build Ming-Omni chat prompt and token IDs with modality placeholders.
 
@@ -440,11 +603,13 @@ class MingPreprocessor:
         """
         a_counts = audio_token_counts or []
         i_counts = image_token_counts or []
+        v_counts = video_token_counts or []
         parts: list[str] = []
         input_ids: list[int] = []
         text_buffer: list[str] = []
         audio_idx = 0
         image_idx = 0
+        video_idx = 0
 
         def flush_text() -> None:
             if not text_buffer:
@@ -540,6 +705,18 @@ class MingPreprocessor:
                                 n_tokens,
                             )
                             image_idx += 1
+                        elif item_type in ("video_url", "video"):
+                            n_tokens = (
+                                v_counts[video_idx] if video_idx < len(v_counts) else 1
+                            )
+                            append_placeholder(
+                                VIDEO_START,
+                                VIDEO_PATCH,
+                                VIDEO_END,
+                                self._video_patch_id,
+                                n_tokens,
+                            )
+                            video_idx += 1
                     elif isinstance(item, str):
                         append_text(item)
                 append_text(role_end)

--- a/sglang_omni/models/ming_omni/pipeline/merge.py
+++ b/sglang_omni/models/ming_omni/pipeline/merge.py
@@ -117,9 +117,14 @@ def build_thinker_inputs(
     image_ck = (encoder_inputs.get(IMAGE_STAGE) or {}).get("cache_key")
     audio_ck = (encoder_inputs.get(AUDIO_STAGE) or {}).get("cache_key")
     if image_ck:
-        # image_ck already namespaces image vs video (img:.../vid:...) when both
-        # are present so we keep one cache key for the combined visual stage.
+        # Image and video share the same encoder cache key, so prefix them
+        # differently so the SGLang adapter's modality-keyed lookup
+        # (media_cache_keys.get("image"|"video")) gives each its own hashed
+        # pad value. Without the "video" entry, video placeholder tokens
+        # keep their raw token id and alias in the radix prefix cache
+        # across different videos with the same placeholder count.
         media_cache_keys["image"] = f"image:{image_ck}"
+        media_cache_keys["video"] = f"video:{image_ck}"
     if audio_ck:
         media_cache_keys["audio"] = f"audio:{audio_ck}"
 

--- a/sglang_omni/models/ming_omni/pipeline/merge.py
+++ b/sglang_omni/models/ming_omni/pipeline/merge.py
@@ -87,6 +87,11 @@ def build_thinker_inputs(
         if isinstance(image_out, dict)
         else None
     )
+    video_embeds = (
+        _as_tensor(image_out.get("video_embeds"))
+        if isinstance(image_out, dict)
+        else None
+    )
 
     thinker_model_inputs: dict[str, Any] = {}
 
@@ -102,11 +107,18 @@ def build_thinker_inputs(
             image_embeds = image_embeds.squeeze(0)
         thinker_model_inputs["image_embeds"] = image_embeds
 
+    if _non_empty(video_embeds):
+        if video_embeds.dim() == 3:
+            video_embeds = video_embeds.squeeze(0)
+        thinker_model_inputs["video_embeds"] = video_embeds
+
     media_cache_keys: dict[str, str] = {}
     encoder_inputs = state.encoder_inputs or {}
     image_ck = (encoder_inputs.get(IMAGE_STAGE) or {}).get("cache_key")
     audio_ck = (encoder_inputs.get(AUDIO_STAGE) or {}).get("cache_key")
     if image_ck:
+        # image_ck already namespaces image vs video (img:.../vid:...) when both
+        # are present so we keep one cache key for the combined visual stage.
         media_cache_keys["image"] = f"image:{image_ck}"
     if audio_ck:
         media_cache_keys["audio"] = f"audio:{audio_ck}"

--- a/sglang_omni/preprocessing/video.py
+++ b/sglang_omni/preprocessing/video.py
@@ -383,8 +383,31 @@ def build_video_mm_inputs(hf_inputs: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def compute_video_cache_key(videos: Any) -> str | None:
-    return compute_media_cache_key(videos, prefix="video")
+def compute_video_cache_key(
+    videos: Any,
+    *,
+    fps: float | None = None,
+    max_frames: int | None = None,
+    min_pixels: int | None = None,
+    max_pixels: int | None = None,
+    total_pixels: int | None = None,
+) -> str | None:
+    """Compute cache key from raw video inputs + effective decode params.
+
+    Decode params change the resulting frame count and thus the encoder
+    output length. They must be part of the cache key — otherwise an entry
+    produced under one (fps, max_frames, pixel-limit) tuple could be
+    returned for a request with different params, yielding ``video_embeds``
+    whose length no longer matches the prompt placeholders.
+    """
+    base = compute_media_cache_key(videos, prefix="video")
+    if base is None:
+        return None
+    decode_sig = (
+        f"|fps={fps}|max_frames={max_frames}"
+        f"|min_px={min_pixels}|max_px={max_pixels}|total_px={total_pixels}"
+    )
+    return base + decode_sig
 
 
 def _check_if_video_has_audio(video_path: str | Path) -> bool:

--- a/tests/unit_test/ming_omni/test_pipeline.py
+++ b/tests/unit_test/ming_omni/test_pipeline.py
@@ -582,3 +582,177 @@ def test_ming_merge_extracts_video_embeds_into_thinker_inputs() -> None:
     assert "video_embeds" in model_inputs
     assert tuple(model_inputs["video_embeds"].shape) == (12, 8)
     assert result["media_cache_keys"]["image"] == "image:img:abc|vid:def"
+    # Video must have its own modality-keyed cache entry; the SGLang adapter
+    # looks up media_cache_keys.get("video") separately and without this
+    # entry video patch tokens would alias in the radix prefix cache.
+    assert result["media_cache_keys"]["video"] == "video:img:abc|vid:def"
+
+
+def test_compute_video_cache_key_changes_with_decode_params() -> None:
+    """Different fps/max_frames/pixel limits must produce distinct cache keys.
+
+    Without this, the encoder cache could return ``video_embeds`` whose
+    length doesn't match the prompt placeholders for the new request.
+    """
+    from sglang_omni.preprocessing.video import compute_video_cache_key
+
+    videos = ["/tmp/clip.mp4"]
+    base = compute_video_cache_key(videos)
+    k_fps_1 = compute_video_cache_key(videos, fps=1.0)
+    k_fps_8 = compute_video_cache_key(videos, fps=8.0)
+    k_frames_16 = compute_video_cache_key(videos, max_frames=16)
+    k_min_px = compute_video_cache_key(videos, min_pixels=128)
+    k_max_px = compute_video_cache_key(videos, max_pixels=4096)
+    k_total_px = compute_video_cache_key(videos, total_pixels=65536)
+    k_all = compute_video_cache_key(
+        videos,
+        fps=8.0,
+        max_frames=16,
+        min_pixels=128,
+        max_pixels=4096,
+        total_pixels=65536,
+    )
+
+    # Every param shift produces a distinct key.
+    distinct = {
+        base,
+        k_fps_1,
+        k_fps_8,
+        k_frames_16,
+        k_min_px,
+        k_max_px,
+        k_total_px,
+        k_all,
+    }
+    assert len(distinct) == 8
+
+    # Same params -> same key (deterministic).
+    assert k_fps_8 == compute_video_cache_key(videos, fps=8.0)
+
+    # Empty / None input still returns None (no cache).
+    assert compute_video_cache_key(None, fps=8.0) is None
+    assert compute_video_cache_key([], fps=8.0) is None
+
+
+def _make_fake_ming_image_encoder(spatial_merge_size: int = 2):
+    """Build a MingImageEncoder shell whose ``_encode`` returns synthetic
+    tensors with the real shape contract (embeds rows == sum(token_counts)).
+
+    Bypasses nn.Module.__init__ so we don't need vision-encoder weights, and
+    only exercises ``forward``'s dispatch + the embeds/token_counts invariant.
+    """
+    import types
+
+    import torch
+
+    from sglang_omni.models.ming_omni.components.image_encoder import MingImageEncoder
+
+    enc = object.__new__(MingImageEncoder)
+    enc.__dict__["_spatial_merge_size"] = spatial_merge_size
+    enc.__dict__["visual"] = types.SimpleNamespace(device=torch.device("cpu"))
+
+    def fake_encode(pixel_values, grid_thw):
+        merge_sq = spatial_merge_size**2
+        token_counts = (grid_thw[:, 0] * grid_thw[:, 1] * grid_thw[:, 2]) // merge_sq
+        total = int(token_counts.sum().item())
+        embeds = torch.zeros(total, 8)  # hidden_dim doesn't matter for shape test
+        return embeds, token_counts
+
+    enc.__dict__["_encode"] = fake_encode
+    return enc
+
+
+def test_ming_image_encoder_forward_video_embeds_match_token_counts() -> None:
+    """video_embeds.shape[0] MUST equal sum(video_token_counts).
+
+    This is the placeholder-count contract: the encoder's output length has
+    to match the number of <video_patch> slots the prompt reserved for it.
+    Signature tests alone don't catch a regression where forward silently
+    returns wrong-length embeds.
+    """
+    import torch
+
+    from sglang_omni.models.ming_omni.components.image_encoder import MingImageEncoder
+
+    enc = _make_fake_ming_image_encoder()
+    # Two videos: (t=2, h=4, w=4) and (t=1, h=6, w=6).
+    # With merge_sq=4: tokens = 8 and 9, total = 17.
+    video_grid_thw = torch.tensor([[2, 4, 4], [1, 6, 6]], dtype=torch.long)
+    pixel_values_videos = torch.zeros(100, 16)
+
+    out = MingImageEncoder.forward(
+        enc,
+        pixel_values_videos=pixel_values_videos,
+        video_grid_thw=video_grid_thw,
+    )
+
+    assert {"video_embeds", "video_grid_thw", "video_token_counts"} <= set(out)
+    assert "image_embeds" not in out
+    expected_total = int(out["video_token_counts"].sum().item())
+    assert expected_total == 17
+    assert out["video_embeds"].shape[0] == expected_total
+
+
+def test_ming_image_encoder_forward_handles_image_and_video_together() -> None:
+    """Mixed image+video request must produce both modalities with the
+    embeds/token_counts invariant holding independently for each."""
+    import torch
+
+    from sglang_omni.models.ming_omni.components.image_encoder import MingImageEncoder
+
+    enc = _make_fake_ming_image_encoder()
+    out = MingImageEncoder.forward(
+        enc,
+        pixel_values=torch.zeros(50, 16),
+        image_grid_thw=torch.tensor([[1, 4, 4]], dtype=torch.long),  # 4 tokens
+        pixel_values_videos=torch.zeros(100, 16),
+        video_grid_thw=torch.tensor([[2, 4, 4]], dtype=torch.long),  # 8 tokens
+    )
+
+    assert {
+        "image_embeds",
+        "image_grid_thw",
+        "image_token_counts",
+        "video_embeds",
+        "video_grid_thw",
+        "video_token_counts",
+    } <= set(out)
+    assert (
+        out["image_embeds"].shape[0] == int(out["image_token_counts"].sum().item()) == 4
+    )
+    assert (
+        out["video_embeds"].shape[0] == int(out["video_token_counts"].sum().item()) == 8
+    )
+
+
+def test_ming_image_encoder_forward_skips_video_when_grid_thw_missing() -> None:
+    """If only one of (pixel_values_videos, video_grid_thw) is provided,
+    the encoder must silently skip the video path rather than crash.
+
+    This locks the current defensive behavior: upstream stages that fail to
+    produce a usable video pair (e.g. partial decode failure) won't take
+    down the encoder, the request just produces no video_embeds.
+    """
+    import torch
+
+    from sglang_omni.models.ming_omni.components.image_encoder import MingImageEncoder
+
+    enc = _make_fake_ming_image_encoder()
+
+    # pixel_values_videos without video_grid_thw -> skipped.
+    out = MingImageEncoder.forward(
+        enc,
+        pixel_values_videos=torch.zeros(100, 16),
+        video_grid_thw=None,
+    )
+    assert "video_embeds" not in out
+    assert "video_grid_thw" not in out
+
+    # video_grid_thw without pixel_values_videos -> also skipped.
+    out = MingImageEncoder.forward(
+        enc,
+        pixel_values_videos=None,
+        video_grid_thw=torch.tensor([[2, 4, 4]], dtype=torch.long),
+    )
+    assert "video_embeds" not in out
+    assert "video_grid_thw" not in out

--- a/tests/unit_test/ming_omni/test_pipeline.py
+++ b/tests/unit_test/ming_omni/test_pipeline.py
@@ -485,3 +485,100 @@ def test_ming_decode_metadata_includes_usage_and_finish_reason() -> None:
         "completion_tokens": 3,
         "total_tokens": 8,
     }
+
+
+def test_ming_preprocessor_injects_top_level_videos_as_inline_content() -> None:
+    """``videos=[...]`` at the top level becomes an inline ``video_url`` item.
+
+    Mirrors the existing ``_inject_top_level_images`` contract so the rest of
+    the preprocessor handles top-level and inline video requests identically.
+    """
+    from sglang_omni.models.ming_omni.components.preprocessor import (
+        _inject_top_level_videos,
+    )
+
+    messages = [
+        {"role": "system", "content": "你是助手"},
+        {"role": "user", "content": "What is happening?"},
+    ]
+    out = _inject_top_level_videos(messages, ["/tmp/clip.mp4"])
+
+    # System message untouched, only first user message extended.
+    assert out[0] == {"role": "system", "content": "你是助手"}
+    assert out[1]["role"] == "user"
+    # Ming-Omni was trained with text BEFORE the media item in user turns
+    # (see _inject_top_level_audios docstring), so videos go after text too.
+    assert out[1]["content"] == [
+        {"type": "text", "text": "What is happening?"},
+        {"type": "video_url", "video_url": {"url": "/tmp/clip.mp4"}},
+    ]
+    # Original list unchanged (helper does a shallow copy).
+    assert messages[1]["content"] == "What is happening?"
+
+
+def test_ming_image_encoder_forward_accepts_video_inputs() -> None:
+    """MingImageEncoder.forward should accept optional video kwargs.
+
+    Videos reuse the image encoder stage (Qwen3-Omni pattern); the signature
+    must expose ``pixel_values_videos`` + ``video_grid_thw`` so the
+    preprocessing → image_encoder stage path can flow both modalities.
+    """
+    from sglang_omni.models.ming_omni.components.image_encoder import MingImageEncoder
+
+    params = inspect.signature(MingImageEncoder.forward).parameters
+    for name in (
+        "pixel_values",
+        "image_grid_thw",
+        "pixel_values_videos",
+        "video_grid_thw",
+    ):
+        assert name in params, f"missing forward kwarg: {name}"
+        assert params[name].default is None, (
+            f"{name} must default to None so the image stage can be invoked "
+            "with images only, videos only, or both."
+        )
+
+
+def test_ming_merge_extracts_video_embeds_into_thinker_inputs() -> None:
+    """build_thinker_inputs must route ``video_embeds`` from the image stage.
+
+    The thinker model_runner injects multimodal embeddings by token id; this
+    test verifies ``merge.build_thinker_inputs`` exposes video_embeds the same
+    way it already exposes image_embeds/audio_embeds.
+    """
+    import torch
+
+    from sglang_omni.models.ming_omni.io import PipelineState
+    from sglang_omni.models.ming_omni.pipeline.merge import build_thinker_inputs
+    from sglang_omni.models.ming_omni.pipeline.next_stage import (
+        AUDIO_STAGE,
+        IMAGE_STAGE,
+    )
+
+    state = PipelineState(
+        raw_inputs={},
+        prompt={
+            "input_ids": torch.zeros((1, 1), dtype=torch.long),
+            "attention_mask": torch.ones((1, 1), dtype=torch.long),
+            "prompt_text": "",
+        },
+        encoder_inputs={
+            IMAGE_STAGE: {"cache_key": "img:abc|vid:def"},
+        },
+    )
+
+    encoder_outs = {
+        AUDIO_STAGE: {},
+        IMAGE_STAGE: {
+            "image_embeds": torch.randn(4, 8),
+            "video_embeds": torch.randn(12, 8),
+        },
+    }
+
+    result = build_thinker_inputs(state, encoder_outs)
+
+    model_inputs = result.get("model_inputs", {})
+    assert "image_embeds" in model_inputs
+    assert "video_embeds" in model_inputs
+    assert tuple(model_inputs["video_embeds"].shape) == (12, 8)
+    assert result["media_cache_keys"]["image"] == "image:img:abc|vid:def"


### PR DESCRIPTION
## Summary

Adds video understanding support to the Ming-Omni V1 pipeline. Videos flow through the existing `image_encoder` stage alongside images producing `video_embeds` that the thinker model runner injects at `video_patch_token` positions.

No new stage or process is added. `MingOmniVisionEncoder` already handles temporal patches via Conv3D, and `ming_thinker_model_runner` already routes `video_embeds` by token id; this PR fills in the missing preprocessor / encoder forward / merge plumbing.

## Modifications

**`sglang_omni_v1/models/ming_omni/components/preprocessor.py`**
- Add `VIDEO_START` / `VIDEO_END` / `VIDEO_PATCH` modality tokens.
- Add `_inject_top_level_videos`, mirroring `_inject_top_level_images`, so requests can pass `videos=[...]` at the top level or as inline `video_url` items.
- Resolve `_video_patch_id` from `llm_config.video_patch_token` with a tokenizer fallback.
- Extract `videos` from raw inputs and async-load via `ensure_video_list_async` together with images and audio.
- Add `_process_videos`, which calls `Qwen2VLImageProcessor.preprocess(images=None, videos=...)` and returns `pixel_values_videos` + `video_grid_thw` + token counts. The `images` positional has to be passed explicitly because `BaseImageProcessor.__call__` requires it.
- Populate `encoder_inputs[IMAGE_STAGE]` with `pixel_values_videos` / `video_grid_thw` alongside the image tensors. Combined cache key uses `img:.../vid:...` namespacing so prefix-cache reuse is correct for either modality alone or both together.
- Extend `_build_prompt` to handle `video_url` / `video` content items and emit `<videoPatch>` placeholders at the right positions.

**`sglang_omni_v1/models/ming_omni/components/image_encoder.py`**
- Factor the encoder + projector + L2-normalize path into a private `_encode(pixel_values, grid_thw)` helper so images and videos share the exact same compute.
- `forward()` now accepts optional `pixel_values_videos` / `video_grid_thw` kwargs (all four image/video inputs default to `None`). It returns `image_embeds` / `video_embeds` / token counts only for the modalities that were provided, so the same factory works for images-only, videos-only, or both.

**`sglang_omni_v1/models/ming_omni/pipeline/merge.py`**
- `build_thinker_inputs` extracts `video_embeds` from the image-stage output and injects it into `thinker_model_inputs` next to `image_embeds` / `audio_embeds`. The thinker runner already knows how to dispatch by token id.
- `media_cache_keys["image"]` carries the combined image/video namespace produced by the preprocessor.

## Tests

Three new unit tests in `tests/unit_test/ming_omni/test_pipeline.py`:

- `test_ming_preprocessor_injects_top_level_videos_as_inline_content` — `_inject_top_level_videos` produces the right inline `video_url` item, leaves the system message alone, and does not mutate the caller's list.
- `test_ming_image_encoder_forward_accepts_video_inputs` — `MingImageEncoder.forward` signature exposes `pixel_values_videos` / `video_grid_thw`; all four image/video kwargs default to `None`.
- `test_ming_merge_extracts_video_embeds_into_thinker_inputs` — `build_thinker_inputs` routes `video_embeds` from the image stage into `thinker_model_inputs` with shape preserved and `media_cache_keys` namespaced correctly.

All three pass on the H200 dev box.

## End-to-end validation

Launched the speech server with `--tp-size 2 --gpu-thinker 2 --gpu-talker 0 --mem-fraction-static 0.80` against `inclusionAI/Ming-flash-omni-2.0` on H200 and sent:

```json
{
  "model": "ming-omni",
  "messages": [
    {"role": "user", "content": "请简短描述这段视频里发生了什么。"}
  ],
  "videos": ["/sgl-workspace/sglang-omni-dev/tests/data/draw.mp4"],
  "video_max_frames": 16,
  "max_tokens": 200
}
```

Model output (excerpt):

> 这段视频呈现了**以俯视视角，拍摄一位身穿白色长袖衣物的人，手持一支白色触控笔，在平板电脑（如iPad）的屏幕上进行数字绘画**的场景... 屏幕上正在绘制的是一个**乐器（吉他）的轮廓图**...

Hits every keyword that the existing Qwen3-Omni docs test (`tests/docs/qwen3_omni/test_docs_qwen3_omni.py::EXPECTED_VIDEO_KEYWORDS = ["draw", "stylus", "pen", "tablet", "girl"]`) expects.

## Request formats supported

Top-level (Ming/Qwen3-Omni convention):

```json
{
  "model": "ming-omni",
  "messages": [{"role": "user", "content": "Describe the video"}],
  "videos": ["/path/to/clip.mp4"],
  "video_max_frames": 16
}
```

Inline content (OpenAI-style multimodal content array):

```json
{
  "messages": [{
    "role": "user",
    "content": [
      {"type": "video_url", "video_url": {"url": "/path/to/clip.mp4"}},
      {"type": "text", "text": "Describe the video"}
    ]
  }]
}
```

## Test plan

- [ ] `pytest tests/unit_test/ming_omni/test_pipeline.py -k video -v`
- [ ] Launch `examples/run_ming_omni_speech_server.py --version v1 ...` and send a request with `videos: ["..."]`
- [ ] Verify response references the video content (drawing / stylus / tablet for `draw.mp4`)
- [ ] Verify image-only and audio-only requests still work (no regression on the existing modalities)

## Note

This PR is based on V1 migration of Ming https://github.com/sgl-project/sglang-omni/pull/437. Need to be merged after #437.