### PR TITLE
feat(higgs-tts): enable CUDA graph decode path

### DIFF
--- a/sglang_omni/models/higgs_tts/model.py
+++ b/sglang_omni/models/higgs_tts/model.py
@@ -23,8 +23,7 @@ from sglang_omni.models.higgs_tts.modeling import (
     HiggsFusedMultiTextEmbedding,
     HiggsFusedMultiTextHead,
 )
-from sglang_omni.models.higgs_tts.sampler import STOP_CODE, HiggsSamplerState
-from sglang_omni.models.higgs_tts.sampler import step as sampler_step
+from sglang_omni.models.higgs_tts.sampler import HiggsSamplerState
 from sglang_omni.models.higgs_tts.weight_loader import DiscreteWeightMapper
 
 # Higgs ckpt prefixes → sglang Qwen3ForCausalLM parameter tree (under ``backbone.``).
@@ -115,6 +114,8 @@ class HiggsTTSModel(nn.Module):
         self._num_codebooks = num_codebooks
         self._codebook_vocab_size = vocab_size
         self._tie_modality = bool(enc_cfg.get("tie_word_embeddings", True))
+        self._decode_codes_buffer: torch.Tensor | None = None
+        self._decode_has_codes_buffer: torch.Tensor | None = None
 
         self.multimodal_embedding = _HiggsMultimodalEmbedding(
             num_codebooks=num_codebooks,
@@ -166,6 +167,44 @@ class HiggsTTSModel(nn.Module):
     def reset_request(self, req_id: str) -> None:
         self._slots.pop(req_id, None)
 
+    def init_decode_graph_buffers(self, max_reqs: int, device: torch.device) -> None:
+        """Allocate request-pool-indexed decode inputs for CUDA graph replay."""
+        self._decode_codes_buffer = torch.zeros(
+            (max_reqs, self._num_codebooks), dtype=torch.long, device=device
+        )
+        self._decode_has_codes_buffer = torch.zeros(
+            (max_reqs,), dtype=torch.bool, device=device
+        )
+
+    def update_decode_graph_buffer(
+        self,
+        req_pool_indices: torch.Tensor,
+        req_ids: list[str],
+    ) -> None:
+        """Copy per-request last codebook rows into graph-visible buffers."""
+        if self._decode_codes_buffer is None or self._decode_has_codes_buffer is None:
+            return
+
+        if not req_ids:
+            return
+
+        device = self._decode_codes_buffer.device
+        indices = req_pool_indices[: len(req_ids)].to(device=device, dtype=torch.long)
+        codes = torch.zeros(
+            (len(req_ids), self._num_codebooks), dtype=torch.long, device=device
+        )
+        has_codes = torch.zeros((len(req_ids),), dtype=torch.bool, device=device)
+        for i, rid in enumerate(req_ids):
+            slot = self._slots.get(rid)
+            last = None if slot is None else slot.sampler.last_codes
+            if last is None:
+                continue
+            codes[i].copy_(last.to(device=device, dtype=torch.long))
+            has_codes[i] = True
+
+        self._decode_codes_buffer[indices] = codes
+        self._decode_has_codes_buffer[indices] = has_codes
+
     def get_output_codes(self, req_id: str) -> torch.Tensor:
         slot = self._slots.get(req_id)
         if slot is None or not slot.output_codes:
@@ -175,52 +214,6 @@ class HiggsTTSModel(nn.Module):
                 device=self.multimodal_embedding.modality_embedding_0.weight.device,
             )
         return torch.stack(slot.output_codes, dim=0).to(torch.long)
-
-    @torch.no_grad()
-    def decode_codebooks_batch(
-        self,
-        hidden_states_BD: torch.Tensor,
-        req_ids: list[str],
-        gen_params: list[HiggsGenParams],
-    ) -> torch.Tensor:
-        """Sample multi-codebook tokens for one forward step.
-
-        Real codes land in ``self._slots[req_id].output_codes``; the returned
-        text-vocab logits are a structural placeholder that sglang's downstream
-        sampler walks over but whose ``next_token_ids`` are discarded by
-        :class:`HiggsTTSModelRunner`.
-        """
-        batch_size = hidden_states_BD.shape[0]
-        if len(req_ids) != batch_size or len(gen_params) != batch_size:
-            raise ValueError(
-                f"batch size mismatch: hidden={batch_size}, "
-                f"req_ids={len(req_ids)}, gen_params={len(gen_params)}"
-            )
-
-        # fp32 for softmax numerical stability.
-        logits_BNV = self.modality_head.generate(hidden_states_BD).to(torch.float32)
-
-        for b in range(batch_size):
-            slot = self.get_slot(req_ids[b])
-            params = gen_params[b]
-            codes_N = sampler_step(
-                logits_BNV[b],
-                slot.sampler,
-                temperature=params.temperature,
-                top_p=params.top_p,
-                top_k=params.top_k,
-            )
-            # STOP_CODE sentinel rows can arrive if a finished request is
-            # accidentally re-stepped; guard so output_codes stays clean.
-            if int(codes_N[0].item()) != STOP_CODE:
-                slot.output_codes.append(codes_N.detach().to(torch.long))
-
-        text_vocab_size = self.backbone.config.vocab_size
-        return torch.zeros(
-            (batch_size, text_vocab_size),
-            device=hidden_states_BD.device,
-            dtype=torch.float32,
-        )
 
     def forward(
         self,
@@ -235,12 +228,11 @@ class HiggsTTSModel(nn.Module):
         Prefill: caller supplies ``input_embeds`` with the ref-audio overlay
         already pasted at ``-100`` positions (see
         :class:`HiggsTTSModelRunner._build_prefill_input_embeds`).
-        Decode: input_embeds is rebuilt here from each slot's ``last_codes``.
+        Decode: input_embeds is rebuilt here from graph-visible request-pool
+        buffers when available, otherwise from each slot's ``last_codes``.
         """
-        req_ids, gen_params = self._extract_batch_metadata(forward_batch)
-
         if input_embeds is None and self._is_decode_step(forward_batch):
-            input_embeds = self._decode_step_embeds(req_ids, input_ids)
+            input_embeds = self._decode_step_embeds(forward_batch, input_ids)
 
         hidden_states = self.backbone.model(
             input_ids,
@@ -261,12 +253,14 @@ class HiggsTTSModel(nn.Module):
             if hidden_states_last.ndim == 3:
                 hidden_states_last = hidden_states_last[:, -1, :]
 
-        text_logits_BV = self.decode_codebooks_batch(
-            hidden_states_last, req_ids, gen_params
+        # fp32 for sampler numerical stability. Sampling and slot mutation stay
+        # outside model.forward so CUDA graph replay only covers tensor work.
+        codebook_logits_BNV = self.modality_head.generate(hidden_states_last).to(
+            torch.float32
         )
 
         return LogitsProcessorOutput(
-            next_token_logits=text_logits_BV,
+            next_token_logits=codebook_logits_BNV,
             hidden_states=hidden_states_last,
         )
 
@@ -318,35 +312,50 @@ class HiggsTTSModel(nn.Module):
             return int(seq_lens.shape[0])
         return int(getattr(forward_batch, "batch_size", 1))
 
-    def _decode_step_embeds(
-        self, req_ids: list[str], input_ids: torch.Tensor
-    ) -> torch.Tensor:
+    def _decode_step_embeds(self, forward_batch, input_ids: torch.Tensor) -> torch.Tensor:
         """Build per-step embeddings from each slot's ``last_codes``.
 
         Falls back to the text embedding for any request whose slot has no
         ``last_codes`` yet (scheduler may send us a token before we've decoded).
         """
         device = input_ids.device
-        N = self._num_codebooks
-        last_codes_stack: list[torch.Tensor] = []
-        mask: list[bool] = []
-        for rid in req_ids:
-            slot = self._slots.get(rid)
-            last = None if slot is None else slot.sampler.last_codes
-            if last is None:
-                last_codes_stack.append(torch.zeros(N, dtype=torch.long, device=device))
-                mask.append(False)
-            else:
-                last_codes_stack.append(last.to(device=device, dtype=torch.long))
-                mask.append(True)
-        codes_BN = torch.stack(last_codes_stack, dim=0)
+        req_pool_indices = getattr(forward_batch, "req_pool_indices", None)
+        if (
+            self._decode_codes_buffer is not None
+            and self._decode_has_codes_buffer is not None
+            and req_pool_indices is not None
+        ):
+            indices = req_pool_indices.to(
+                device=self._decode_codes_buffer.device, dtype=torch.long
+            )
+            codes_BN = self._decode_codes_buffer[indices].to(device=device)
+            mask_t = self._decode_has_codes_buffer[indices].to(device=device).unsqueeze(
+                -1
+            )
+        else:
+            req_ids, _ = self._extract_batch_metadata(forward_batch)
+            last_codes_stack: list[torch.Tensor] = []
+            mask: list[bool] = []
+            for rid in req_ids:
+                slot = self._slots.get(rid)
+                last = None if slot is None else slot.sampler.last_codes
+                if last is None:
+                    last_codes_stack.append(
+                        torch.zeros(self._num_codebooks, dtype=torch.long, device=device)
+                    )
+                    mask.append(False)
+                else:
+                    last_codes_stack.append(last.to(device=device, dtype=torch.long))
+                    mask.append(True)
+            codes_BN = torch.stack(last_codes_stack, dim=0)
+            mask_t = torch.tensor(mask, device=device).unsqueeze(-1)
+
         fused_embeds = self.multimodal_embedding.modality_embedding_0(codes_BN)
 
         text_embeds = self.backbone.model.embed_tokens(input_ids)
         if text_embeds.ndim == 3:
             text_embeds = text_embeds[:, -1, :]
 
-        mask_t = torch.tensor(mask, device=device).unsqueeze(-1)
         return torch.where(mask_t, fused_embeds.to(text_embeds.dtype), text_embeds)
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:

--- a/sglang_omni/models/higgs_tts/model_runner.py
+++ b/sglang_omni/models/higgs_tts/model_runner.py
@@ -22,6 +22,9 @@ from typing import Any
 import torch
 
 from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.models.higgs_tts.model import HiggsGenParams
+from sglang_omni.models.higgs_tts.sampler import STOP_CODE
+from sglang_omni.models.higgs_tts.sampler import step as sampler_step
 from sglang_omni.models.higgs_tts.text_tokenizer import AUDIO_PLACEHOLDER_ID
 
 logger = logging.getLogger(__name__)
@@ -45,6 +48,14 @@ class HiggsTTSModelRunner(ModelRunner):
     def prepare_decode(self, forward_batch, schedule_batch, requests):
         del schedule_batch
         forward_batch.req_ids = [req.request_id for req in requests]
+        req_pool_indices = getattr(forward_batch, "req_pool_indices", None)
+        if req_pool_indices is not None and hasattr(
+            self.model, "update_decode_graph_buffer"
+        ):
+            self.model.update_decode_graph_buffer(
+                req_pool_indices,
+                forward_batch.req_ids,
+            )
         return None
 
     def post_decode(self, result, forward_batch, schedule_batch, requests):
@@ -103,13 +114,31 @@ class HiggsTTSModelRunner(ModelRunner):
 
         model = self.model
         cb0_per_row: list[int] = []
-        for sched_req in requests:
+        logits = result.logits_output.next_token_logits
+        for row, sched_req in enumerate(requests):
             data = sched_req.data
             req = data.req
-            slot = model._slots.get(sched_req.request_id)
-            if req.is_chunked > 0 or slot is None or not slot.output_codes:
+            if req.is_chunked > 0:
                 cb0_per_row.append(0)
                 continue
+
+            slot = model.get_slot(sched_req.request_id)
+            params = self._gen_params(data)
+            codes_N = sampler_step(
+                logits[row],
+                slot.sampler,
+                temperature=params.temperature,
+                top_p=params.top_p,
+                top_k=params.top_k,
+            )
+            if int(codes_N[0].item()) != STOP_CODE:
+                slot.output_codes.append(codes_N.detach().to(torch.long))
+
+            if not slot.output_codes:
+                cb0_per_row.append(0)
+                data.generation_done = bool(slot.sampler.generation_done)
+                continue
+
             codes_N = slot.output_codes[-1]
             data.output_codes.append(codes_N.detach().cpu().clone())
             data.generation_done = bool(slot.sampler.generation_done)
@@ -119,6 +148,16 @@ class HiggsTTSModelRunner(ModelRunner):
             cb0_per_row,
             dtype=torch.long,
             device=result.logits_output.next_token_logits.device,
+        )
+
+    @staticmethod
+    def _gen_params(data: Any) -> HiggsGenParams:
+        top_p = getattr(data, "top_p", None)
+        top_k = getattr(data, "top_k", None)
+        return HiggsGenParams(
+            temperature=float(getattr(data, "temperature", 1.0)),
+            top_p=None if top_p is None or float(top_p) >= 1.0 else float(top_p),
+            top_k=None if top_k is None or int(top_k) <= 0 else int(top_k),
         )
 
 

--- a/sglang_omni/models/higgs_tts/sampler.py
+++ b/sglang_omni/models/higgs_tts/sampler.py
@@ -25,10 +25,10 @@ from dataclasses import dataclass
 
 import torch
 
-from sglang_omni.models.higgs_tts.utils import BOC_ID, EOC_ID
-
 # Sentinel returned by ``step`` after ``generation_done``; engine treats as stop.
 STOP_CODE = -1
+BOC_ID = 1024
+EOC_ID = 1025
 
 
 @dataclass
@@ -136,4 +136,4 @@ def step(
     return codes_N
 
 
-__all__ = ["STOP_CODE", "HiggsSamplerState", "step"]
+__all__ = ["BOC_ID", "EOC_ID", "STOP_CODE", "HiggsSamplerState", "step"]

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -240,8 +240,7 @@ def create_sglang_tts_engine_executor(
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0
 
     overrides: dict[str, Any] = {
-        # Per-request slot state + Python decode loop are not graph-capturable.
-        "disable_cuda_graph": True,
+        "disable_cuda_graph": False,
         "mem_fraction_static": 0.85,
         "max_running_requests": 16,
         "chunked_prefill_size": 8192,
@@ -259,6 +258,9 @@ def create_sglang_tts_engine_executor(
         **overrides,
     )
     server_args.disable_overlap_schedule = True
+    want_cuda_graph = not bool(getattr(server_args, "disable_cuda_graph", False))
+    if want_cuda_graph:
+        server_args.disable_cuda_graph = True
 
     (
         model_worker,
@@ -271,6 +273,14 @@ def create_sglang_tts_engine_executor(
     ) = create_sglang_infrastructure(server_args, gpu_id)
 
     truncate_rope_to_bf16(model_worker.model_runner.model)
+    if hasattr(model_worker.model_runner.model, "init_decode_graph_buffers"):
+        model_worker.model_runner.model.init_decode_graph_buffers(
+            req_to_token_pool.size,
+            torch.device(f"cuda:{gpu_id}"),
+        )
+    if want_cuda_graph:
+        server_args.disable_cuda_graph = False
+        model_worker.model_runner.init_device_graphs()
 
     output_proc = SGLangOutputProcessor(
         capture_hidden=False,

--- a/sglang_omni/models/higgs_tts/utils.py
+++ b/sglang_omni/models/higgs_tts/utils.py
@@ -20,13 +20,10 @@ import torch
 from huggingface_hub import snapshot_download
 
 from sglang_omni.models.higgs_tts.audio_codec import HiggsAudioCodec
+from sglang_omni.models.higgs_tts.sampler import BOC_ID, EOC_ID
 from sglang_omni.preprocessing.audio import AudioMediaIO
 from sglang_omni.preprocessing.base import _is_url
 from sglang_omni.preprocessing.resource_connector import global_http_connection
-
-# Codec-vocab specials (inside the [N*V] codebook space, NOT the text vocab).
-BOC_ID = 1024
-EOC_ID = 1025
 
 # Shared between audio_encoder + vocoder; one codec load saves ~1 GB VRAM.
 _CODEC_CACHE: dict[tuple[str, str, str], HiggsAudioCodec] = {}

--- a/tests/unit_test/higgs_tts/test_cuda_graph.py
+++ b/tests/unit_test/higgs_tts/test_cuda_graph.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+import importlib.machinery
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+_av = MagicMock()
+_av.__spec__ = importlib.machinery.ModuleSpec("av", loader=None)
+sys.modules.setdefault("av", _av)
+
+import torch
+
+from sglang_omni.models.higgs_tts.model import _RequestSlot
+from sglang_omni.models.higgs_tts.model_runner import HiggsTTSModelRunner
+from sglang_omni.models.higgs_tts.sampler import HiggsSamplerState
+
+
+def test_higgs_runner_samples_codebook_logits_outside_forward() -> None:
+    runner = object.__new__(HiggsTTSModelRunner)
+    runner.model = _FakeHiggsModel(num_codebooks=2)
+
+    logits = torch.zeros((1, 2, 4), dtype=torch.float32)
+    logits[0, 0, 2] = 10.0
+    logits[0, 1, 3] = 10.0
+    result = SimpleNamespace(
+        logits_output=SimpleNamespace(next_token_logits=logits),
+        next_token_ids=None,
+    )
+    request = SimpleNamespace(
+        request_id="req-1",
+        data=SimpleNamespace(
+            req=SimpleNamespace(is_chunked=0),
+            output_codes=[],
+            generation_done=False,
+            temperature=0.0,
+            top_p=1.0,
+            top_k=-1,
+        ),
+    )
+
+    runner._collect_step_outputs(result, [request])
+
+    assert result.next_token_ids.tolist() == [2]
+    assert len(request.data.output_codes) == 1
+    assert request.data.output_codes[0].tolist() == [2, 1024]
+
+
+def test_higgs_prepare_decode_updates_graph_visible_buffers() -> None:
+    model = _FakeHiggsModel(num_codebooks=2)
+    runner = object.__new__(HiggsTTSModelRunner)
+    runner.model = model
+    forward_batch = SimpleNamespace(req_ids=None, req_pool_indices=torch.tensor([5]))
+    request = SimpleNamespace(request_id="req-1")
+
+    runner.prepare_decode(forward_batch, None, [request])
+
+    assert forward_batch.req_ids == ["req-1"]
+    assert model.updated == [(torch.tensor([5]), ["req-1"])]
+
+
+class _FakeHiggsModel:
+    def __init__(self, num_codebooks: int) -> None:
+        self._num_codebooks = num_codebooks
+        self._slots: dict[str, _RequestSlot] = {
+            "req-1": _RequestSlot(
+                sampler=HiggsSamplerState(num_codebooks=num_codebooks)
+            )
+        }
+        self.updated = []
+
+    def get_slot(self, req_id: str) -> _RequestSlot:
+        return self._slots[req_id]
+
+    def update_decode_graph_buffer(
+        self, req_pool_indices: torch.Tensor, req_ids: list[str]
+    ) -> None:
+        self.updated.append((req_pool_indices.clone(), list(req_ids)))


### PR DESCRIPTION
## Summary

- Refactor Higgs TTS model forward so CUDA graph replay covers tensor work only: decode input embedding, Qwen3 backbone, and modality head projection.
- Move Higgs multi-codebook sampling and per-request slot mutation into the model runner post hook, outside graph capture/replay.
- Add request-pool-indexed decode codebook buffers so graph replay can consume the previous multi-codebook row without Python slot lookups.
- Enable Higgs TTS CUDA graph initialization by default using the same temporary-disable/capture-after-infra pattern used by Qwen3-Omni.

## Notes

This is a draft because it still needs a real Higgs GPU benchmark / parity run against `bosonai/higgs-audio-v2-generation-3B-base` to validate graph capture and output quality under live decoding.

Refs #478 (CUDA Graph acceleration item)

## Tests

- `python -m pytest tests/unit_test/higgs_tts/test_cuda_graph.py -q`
- `python -m pytest tests/unit_test/higgs_tts/test_cuda_graph.py tests/unit_test/fishaudio_s2_pro/test_pipeline.py -q`
- `python -m py_compile sglang_omni/models/higgs_tts/model.py sglang_omni/models/higgs_tts/model_runner.py sglang_omni/models/higgs_tts/stages.py sglang_omni/models/higgs_tts/sampler.py sglang_omni/models/higgs_tts/utils.py tests/unit_test/higgs_tts/test_cuda_graph.py`

`ruff` was not available in the local environment (`No module named ruff`).
