### PR TITLE
[Qwen3-Omni] vectorize per-row Python loops in talker AR hot path

### DIFF
--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -244,12 +244,13 @@ class ModelRunner:
             rep_toks.extend(unique)
             rep_penalties.extend([float(penalty)] * len(unique))
         if rep_rows:
+            orig_dtype = logits.dtype
             rows_t = torch.tensor(rep_rows, dtype=torch.long, device=device)
             toks_t = torch.tensor(rep_toks, dtype=torch.long, device=device)
-            pens_t = torch.tensor(rep_penalties, dtype=logits.dtype, device=device)
-            scores = logits[rows_t, toks_t]
+            pens_t = torch.tensor(rep_penalties, dtype=torch.float32, device=device)
+            scores = logits[rows_t, toks_t].to(torch.float32)
             scores = torch.where(scores > 0, scores / pens_t, scores * pens_t)
-            logits[rows_t, toks_t] = scores
+            logits[rows_t, toks_t] = scores.to(orig_dtype)
 
     def _apply_codec_suppress_tokens(self, logits_output: Any, requests: list) -> None:
         logits = logits_output.next_token_logits

--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -223,6 +223,11 @@ class ModelRunner:
         logits = logits_output.next_token_logits
         if logits is None or logits.ndim != 2:
             return
+        vocab = logits.shape[1]
+        device = logits.device
+        rep_rows: list[int] = []
+        rep_toks: list[int] = []
+        rep_penalties: list[float] = []
         for row_idx, sched_req in enumerate(requests):
             data = sched_req.data
             req = data.req
@@ -232,19 +237,28 @@ class ModelRunner:
             output_ids = req.output_ids
             if not output_ids:
                 continue
-            token_ids = list(set(output_ids))
-            valid = [t for t in token_ids if 0 <= t < logits.shape[1]]
-            if not valid:
+            unique = {int(t) for t in output_ids if 0 <= int(t) < vocab}
+            if not unique:
                 continue
-            idx = torch.tensor(valid, dtype=torch.long, device=logits.device)
-            scores = logits[row_idx, idx]
-            scores = torch.where(scores > 0, scores / penalty, scores * penalty)
-            logits[row_idx, idx] = scores
+            rep_rows.extend([row_idx] * len(unique))
+            rep_toks.extend(unique)
+            rep_penalties.extend([float(penalty)] * len(unique))
+        if rep_rows:
+            rows_t = torch.tensor(rep_rows, dtype=torch.long, device=device)
+            toks_t = torch.tensor(rep_toks, dtype=torch.long, device=device)
+            pens_t = torch.tensor(rep_penalties, dtype=logits.dtype, device=device)
+            scores = logits[rows_t, toks_t]
+            scores = torch.where(scores > 0, scores / pens_t, scores * pens_t)
+            logits[rows_t, toks_t] = scores
 
     def _apply_codec_suppress_tokens(self, logits_output: Any, requests: list) -> None:
         logits = logits_output.next_token_logits
         if logits is None or logits.ndim != 2:
             return
+        vocab = logits.shape[1]
+        device = logits.device
+        sup_rows: list[int] = []
+        sup_toks: list[int] = []
         for row_idx, sched_req in enumerate(requests):
             data = sched_req.data
             suppress_tokens = data.suppress_tokens
@@ -254,5 +268,12 @@ class ModelRunner:
             if not suppress_tokens:
                 continue
             for token_id in suppress_tokens:
-                if 0 <= int(token_id) < logits.shape[1]:
-                    logits[row_idx, int(token_id)] = float("-inf")
+                tok = int(token_id)
+                if 0 <= tok < vocab:
+                    sup_rows.append(row_idx)
+                    sup_toks.append(tok)
+        if sup_rows:
+            logits[
+                torch.tensor(sup_rows, dtype=torch.long, device=device),
+                torch.tensor(sup_toks, dtype=torch.long, device=device),
+            ] = float("-inf")

--- a/sglang_omni/models/qwen3_omni/components/talker.py
+++ b/sglang_omni/models/qwen3_omni/components/talker.py
@@ -883,53 +883,93 @@ class Qwen3OmniTalker(nn.Module):
 
     def prepare_decode_buffers(self, requests: list) -> None:
         batch_size = len(requests)
+        if batch_size == 0:
+            return
+
+        device = self._repetition_mask.device
+        rep_vocab = self._repetition_mask.shape[1]
+        sup_vocab = self._suppress_mask.shape[1]
+
         self._repetition_mask[:batch_size] = False
-        self._repetition_penalties[:batch_size].fill_(1.0)
         self._suppress_mask[:batch_size] = False
-        self._sampling_temperatures[:batch_size].fill_(1.0)
-        self._sampling_top_ps[:batch_size].fill_(1.0)
-        self._sampling_top_ks[:batch_size].fill_(1)
-        self._sampling_min_ps[:batch_size].zero_()
-        self._sampling_seeds[:batch_size].zero_()
+
+        rep_penalties: list[float] = []
+        temperatures: list[float] = []
+        top_ps: list[float] = []
+        top_ks: list[int] = []
+        min_ps: list[float] = []
+        sampling_seeds: list[int] = []
+        rep_rows: list[int] = []
+        rep_toks: list[int] = []
+        sup_rows: list[int] = []
+        sup_toks: list[int] = []
 
         for row_idx, sched_req in enumerate(requests):
             data = sched_req.data
             req = data.req
-            sampling_params = req.sampling_params
+            sp = req.sampling_params
 
-            penalty = float(sampling_params.repetition_penalty)
-            self._repetition_penalties[row_idx, 0] = penalty
-            self._sampling_temperatures[row_idx, 0] = float(sampling_params.temperature)
-            self._sampling_top_ps[row_idx] = float(sampling_params.top_p)
-            self._sampling_top_ks[row_idx] = int(sampling_params.top_k)
-            self._sampling_min_ps[row_idx] = float(sampling_params.min_p)
-            req_seed = sampling_params.sampling_seed
-            if req_seed is not None:
-                self._sampling_seeds[row_idx] = int(req_seed)
+            penalty = float(sp.repetition_penalty)
+            rep_penalties.append(penalty)
+            temperatures.append(float(sp.temperature))
+            top_ps.append(float(sp.top_p))
+            top_ks.append(int(sp.top_k))
+            min_ps.append(float(sp.min_p))
+            seed = sp.sampling_seed
+            sampling_seeds.append(int(seed) if seed is not None else 0)
+
             if penalty != 1.0 and req.output_ids:
-                token_ids = torch.as_tensor(
-                    list({int(token_id) for token_id in req.output_ids}),
-                    dtype=torch.long,
-                    device=self._repetition_mask.device,
-                )
-                valid = token_ids[
-                    (token_ids >= 0) & (token_ids < self._repetition_mask.shape[1])
-                ]
-                if valid.numel() > 0:
-                    self._repetition_mask[row_idx, valid] = True
+                unique = {
+                    t
+                    for t in (int(tok) for tok in req.output_ids)
+                    if 0 <= t < rep_vocab
+                }
+                if unique:
+                    rep_rows.extend([row_idx] * len(unique))
+                    rep_toks.extend(unique)
 
             suppress_tokens = data.suppress_tokens or req._codec_suppress_tokens
             if suppress_tokens:
-                token_ids = torch.as_tensor(
-                    [int(token_id) for token_id in suppress_tokens],
-                    dtype=torch.long,
-                    device=self._suppress_mask.device,
-                )
-                valid = token_ids[
-                    (token_ids >= 0) & (token_ids < self._suppress_mask.shape[1])
+                valid_sup = [
+                    t
+                    for t in (int(tok) for tok in suppress_tokens)
+                    if 0 <= t < sup_vocab
                 ]
-                if valid.numel() > 0:
-                    self._suppress_mask[row_idx, valid] = True
+                if valid_sup:
+                    sup_rows.extend([row_idx] * len(valid_sup))
+                    sup_toks.extend(valid_sup)
+
+        rep_pen_dtype = self._repetition_penalties.dtype
+        self._repetition_penalties[:batch_size, 0] = torch.tensor(
+            rep_penalties, dtype=rep_pen_dtype, device=device
+        )
+        self._sampling_temperatures[:batch_size, 0] = torch.tensor(
+            temperatures, dtype=self._sampling_temperatures.dtype, device=device
+        )
+        self._sampling_top_ps[:batch_size] = torch.tensor(
+            top_ps, dtype=self._sampling_top_ps.dtype, device=device
+        )
+        self._sampling_top_ks[:batch_size] = torch.tensor(
+            top_ks, dtype=self._sampling_top_ks.dtype, device=device
+        )
+        self._sampling_min_ps[:batch_size] = torch.tensor(
+            min_ps, dtype=self._sampling_min_ps.dtype, device=device
+        )
+        self._sampling_seeds[:batch_size] = torch.tensor(
+            sampling_seeds, dtype=self._sampling_seeds.dtype, device=device
+        )
+
+        if rep_rows:
+            self._repetition_mask[
+                torch.tensor(rep_rows, dtype=torch.long, device=device),
+                torch.tensor(rep_toks, dtype=torch.long, device=device),
+            ] = True
+
+        if sup_rows:
+            self._suppress_mask[
+                torch.tensor(sup_rows, dtype=torch.long, device=device),
+                torch.tensor(sup_toks, dtype=torch.long, device=device),
+            ] = True
 
     def prepare_input_embeds(
         self,

--- a/sglang_omni/models/qwen3_omni/talker_model_runner.py
+++ b/sglang_omni/models/qwen3_omni/talker_model_runner.py
@@ -201,6 +201,8 @@ class QwenTalkerModelRunner(ModelRunner):
         feedback_mask = self.model._feedback_mask
         feedback_mask[:batch_size] = False
 
+        rows: list[int] = []
+        embeds: list[torch.Tensor] = []
         for row_idx, sched_req in enumerate(requests):
             combined = self._take_next_decode_input_embed(
                 sched_req=sched_req,
@@ -209,8 +211,13 @@ class QwenTalkerModelRunner(ModelRunner):
             )
             if combined is None:
                 continue
-            feedback_buffer[row_idx].copy_(combined)
-            feedback_mask[row_idx] = True
+            rows.append(row_idx)
+            embeds.append(combined)
+        if rows:
+            rows_t = torch.tensor(rows, dtype=torch.long, device=feedback_buffer.device)
+            embeds_stacked = torch.stack(embeds, dim=0)
+            feedback_buffer[rows_t] = embeds_stacked
+            feedback_mask[rows_t] = True
 
     @staticmethod
     def _data_has_next_decode_input(data: Any) -> bool:

--- a/tests/README.md
+++ b/tests/README.md
@@ -36,6 +36,7 @@ tests/
     │   ├── test_code2wav.py
     │   ├── test_colocation_config.py
     │   ├── test_config_manager.py
+    │   ├── test_logit_shaping.py
     │   ├── test_pipeline.py
     │   ├── test_sglang_ar_budget.py
     │   ├── test_streaming.py
@@ -181,7 +182,8 @@ that happened to contain an older version of the test.
   - colocation config and SGLang AR budget contracts
   - `PipelineState` request builders
   - talker behavior
-  - Code2Wav streaming/cleanup behavior.
+  - Code2Wav streaming/cleanup behavior
+  - logit-shaping helpers (e.g. repetition penalty) numerical equivalence with the original per-row scalar formulas.
 
 - `unit_test/router/`: SGLang-Omni Router unit tests:
   - router CLI/config behavior

--- a/tests/unit_test/qwen3_omni/test_logit_shaping.py
+++ b/tests/unit_test/qwen3_omni/test_logit_shaping.py
@@ -1,0 +1,66 @@
+"""Regression tests for ModelRunner logit-shaping helpers."""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+import torch
+
+from sglang_omni.model_runner.base import ModelRunner
+
+
+def _make_requests(output_ids_per_row, penalty: float):
+    reqs = []
+    for ids in output_ids_per_row:
+        sp = types.SimpleNamespace(repetition_penalty=penalty)
+        req = types.SimpleNamespace(sampling_params=sp, output_ids=ids)
+        data = types.SimpleNamespace(req=req)
+        reqs.append(types.SimpleNamespace(data=data))
+    return reqs
+
+
+def _scalar_reference(logits, requests, penalty):
+    out = logits.clone()
+    for row_idx, sched_req in enumerate(requests):
+        ids = sched_req.data.req.output_ids
+        if not ids:
+            continue
+        unique = list({int(t) for t in ids if 0 <= int(t) < out.shape[1]})
+        if not unique:
+            continue
+        idx = torch.tensor(unique, dtype=torch.long, device=out.device)
+        scores = out[row_idx, idx]
+        scores = torch.where(scores > 0, scores / penalty, scores * penalty)
+        out[row_idx, idx] = scores
+    return out
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_apply_repetition_penalty_matches_scalar_reference(dtype):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    vocab = 256
+    batch = 8
+    penalty = 1.2
+    torch.manual_seed(42)
+    logits_orig = (
+        torch.randn(batch, vocab, dtype=dtype, device=device) * 2.0
+    ).contiguous()
+
+    rng = torch.Generator(device="cpu").manual_seed(7)
+    output_ids = [
+        torch.randperm(vocab, generator=rng)[:32].tolist() for _ in range(batch)
+    ]
+
+    requests = _make_requests(output_ids, penalty)
+    logits_output = types.SimpleNamespace(next_token_logits=logits_orig.clone())
+
+    ModelRunner._apply_repetition_penalty(
+        types.SimpleNamespace(), logits_output, requests
+    )
+    actual = logits_output.next_token_logits
+    expected = _scalar_reference(logits_orig, requests, penalty)
+
+    tol = {torch.float16: 2.5e-3, torch.bfloat16: 1e-2, torch.float32: 1e-6}[dtype]
+    diff = (actual - expected).abs().max().item()
+    assert diff <= tol, f"max abs diff {diff:.6f} > tol {tol:.6f} for {dtype}"


### PR DESCRIPTION
Vectorize four per-row Python loops in the talker AR hot path. Each loop collected per-row index lists in Python and then issued one batched advanced-indexing scatter — same pattern across all four sites, no numerical operation changed

2×H200, seed-tts-eval, EN VC=F, C=16, stream=True, 5R restart-per-round mean:

| run | latency_mean(s) | rtf | qps | wer_corpus | wer<50 | n>50 |
|---|---:|---:|---:|---:|---:|---:|
| main `dde550c` (baseline) | 3.013 ± 0.07 | 0.836 ± 0.020 | 5.30 ± 0.13 | 2.72 % | 2.21 % | 8 |
| + `prepare_decode_buffers` alone (5R) | **2.591 ± 0.04** | 0.725 | 6.16 | 2.76 % | 2.25 % | 8 |
| + full bundle (5R) | **2.274 ± 0.018** | **0.641 ± 0.005** | **7.02 ± 0.05** | 2.75 % | 2.24 % | 8 |

**Cumulative: latency −24.5 %, RTF −23.3 %, QPS +32.4 %. WER and n50 unchanged.**

Closes, Part of #486.