### PR TITLE
docs(higgs-tts): streaming plan + Stage 0 codec chunkability probe

### DIFF
--- a/_perf_bench/probe_codec_chunking.py
+++ b/_perf_bench/probe_codec_chunking.py
@@ -1,0 +1,264 @@
+"""Stage 0 probe for the Higgs TTS streaming plan
+(docs/dev/higgs_tts/streaming_plan.md).
+
+Answers the only question that gates the rest of the design:
+
+    Can ``HiggsAudioCodec.decode`` be called on overlapping chunks of
+    a single utterance's codes and produce audio that's perceptually
+    indistinguishable from a one-shot decode of the same codes?
+
+Algorithm
+---------
+
+For each of N reference WAVs:
+
+  1. ``codes_TN = codec.encode_reference(wav)`` — gold codes.
+  2. ``wav_full = codec.decode(codes_TN)`` — one-shot baseline.
+  3. For each ``(stride, overlap, crossfade_samples)`` in a sweep grid:
+       a. Walk ``codes_TN`` in windows ``[start - overlap, start + stride]``
+          (clamped at 0). Decode each window with ``codec.decode``.
+       b. Drop the first ``overlap * frame_length`` samples of each
+          chunk; that's the overlap with the previous chunk's tail.
+          The very first chunk drops nothing.
+       c. Linear-crossfade ``crossfade_samples`` of each chunk's head
+          into the previous chunk's tail.
+       d. Concatenate.
+  4. Compare ``wav_chunked`` vs ``wav_full``:
+       - mse: mean (wav_chunked - wav_full[:L])**2
+       - peak_diff: max |wav_chunked - wav_full[:L]|
+       - n_click_edges: count of windows where local peak diff > 0.05
+
+Output
+------
+
+A summary table per (stride, overlap, crossfade) showing mse / peak_diff /
+n_click_edges averaged across the N samples. The smallest config with
+``mse < 1e-4`` and ``n_click_edges == 0`` is the streaming-design pick.
+
+Usage
+-----
+
+    docker exec sglang_omni_test bash -lc '\\
+        python _perf_bench/probe_codec_chunking.py \\
+            --model-path boson-sglang/higgs-audio-v3-tts-4b-base \\
+            --seed-tts /ceph/data/higgs_audio_eval/zero_shot_tts/seed_tts/en \\
+            --n 5'
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+from dataclasses import dataclass
+
+import torch
+import torchaudio
+
+from sglang_omni.models.higgs_tts.audio_codec import HiggsAudioCodec
+
+
+# Higgs codec frame stride (samples per code frame). 24 kHz / 75 Hz = 320.
+FRAME_LENGTH = 320
+
+# Sweep grid. Stride is the (data frames) added per chunk; overlap is the
+# number of frames of context re-fed from the previous chunk (to fix any
+# receptive-field discontinuity); crossfade_samples is the linear blend
+# applied across chunk boundaries.
+STRIDES = [10, 20, 40]
+OVERLAPS = [0, 5, 10, 20, 40]
+CROSSFADES = [0, 256, 512]
+
+
+@dataclass
+class ChunkConfig:
+    stride: int
+    overlap: int
+    crossfade_samples: int
+
+
+def parse_meta(path: str) -> list[tuple[str, str, str, str]]:
+    rows = []
+    with open(path) as f:
+        for ln in f:
+            ln = ln.strip()
+            if not ln:
+                continue
+            parts = ln.split("|")
+            if len(parts) == 4:
+                rows.append(tuple(parts))
+    return rows
+
+
+def load_wav(path: str, target_sr: int) -> torch.Tensor:
+    wav, sr = torchaudio.load(path)
+    if wav.shape[0] > 1:
+        wav = wav.mean(dim=0, keepdim=True)
+    if sr != target_sr:
+        wav = torchaudio.functional.resample(wav, sr, target_sr)
+    return wav.squeeze(0).to(torch.float32)
+
+
+def chunked_decode(
+    codec: HiggsAudioCodec, codes_TN: torch.Tensor, cfg: ChunkConfig
+) -> torch.Tensor:
+    """Decode ``codes_TN`` chunk-by-chunk under ``cfg``, mimicking what
+    the streaming vocoder will do at runtime.
+    """
+    T = int(codes_TN.shape[0])
+    if cfg.stride <= 0:
+        raise ValueError("stride must be positive")
+
+    audio_pieces: list[torch.Tensor] = []
+    emitted = 0  # data frames already emitted
+
+    while emitted < T:
+        window_start = max(0, emitted - cfg.overlap)
+        window_end = min(T, emitted + cfg.stride)
+        window = codes_TN[window_start:window_end]
+        decoded = codec.decode(window).to(torch.float32)
+        drop_samples = (emitted - window_start) * FRAME_LENGTH
+        if drop_samples >= decoded.shape[-1]:
+            emitted = window_end
+            continue
+        new_audio = decoded[drop_samples:]
+
+        if audio_pieces and cfg.crossfade_samples > 0:
+            prev_tail = audio_pieces[-1]
+            n = min(
+                cfg.crossfade_samples,
+                int(prev_tail.shape[-1]),
+                int(new_audio.shape[-1]),
+            )
+            if n > 0:
+                fade_in = torch.linspace(0.0, 1.0, n, dtype=new_audio.dtype)
+                fade_out = 1.0 - fade_in
+                blended = prev_tail[-n:] * fade_out + new_audio[:n] * fade_in
+                audio_pieces[-1] = torch.cat([prev_tail[:-n], blended])
+                new_audio = new_audio[n:]
+
+        audio_pieces.append(new_audio)
+        emitted = window_end
+
+    return torch.cat(audio_pieces) if audio_pieces else torch.zeros(0)
+
+
+def count_click_edges(
+    diff: torch.Tensor, window: int = 10, threshold: float = 0.05
+) -> int:
+    """Heuristic: a "click" shows up as a localised spike in
+    ``|chunked - full|``. Count non-overlapping windows of ``window``
+    samples where the in-window peak exceeds ``threshold``.
+    """
+    if diff.numel() == 0:
+        return 0
+    abs_diff = diff.abs()
+    n_windows = abs_diff.numel() // window
+    if n_windows == 0:
+        return int(abs_diff.max().item() > threshold)
+    trimmed = abs_diff[: n_windows * window].view(n_windows, window)
+    peaks = trimmed.max(dim=-1).values
+    return int((peaks > threshold).sum().item())
+
+
+def evaluate(
+    codec: HiggsAudioCodec, codes_TN: torch.Tensor, cfg: ChunkConfig
+) -> dict:
+    wav_full = codec.decode(codes_TN).to(torch.float32)
+    wav_chunked = chunked_decode(codec, codes_TN, cfg)
+    L = min(int(wav_full.shape[-1]), int(wav_chunked.shape[-1]))
+    diff = wav_chunked[:L] - wav_full[:L]
+    return {
+        "mse": float((diff * diff).mean().item()),
+        "peak_diff": float(diff.abs().max().item()),
+        "n_click_edges": count_click_edges(diff),
+        "len_full": int(wav_full.shape[-1]),
+        "len_chunked": int(wav_chunked.shape[-1]),
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument(
+        "--model-path",
+        default="boson-sglang/higgs-audio-v3-tts-4b-base",
+        help="Higgs TTS checkpoint (codec weights are bundled inside).",
+    )
+    ap.add_argument(
+        "--seed-tts",
+        default="/ceph/data/higgs_audio_eval/zero_shot_tts/seed_tts/en",
+        help="Path to a seed-tts/en directory with meta.lst.",
+    )
+    ap.add_argument("--n", type=int, default=5, help="Number of WAVs to probe.")
+    ap.add_argument(
+        "--device", default="cuda:0", help="CUDA device for the codec."
+    )
+    args = ap.parse_args()
+
+    codec = HiggsAudioCodec.from_pretrained(
+        args.model_path, device=args.device, dtype=torch.float32
+    )
+    sr = codec.SAMPLE_RATE
+
+    meta = parse_meta(os.path.join(args.seed_tts, "meta.lst"))[: args.n]
+    if not meta:
+        raise RuntimeError(f"no meta.lst entries under {args.seed_tts}")
+
+    samples: list[torch.Tensor] = []
+    for _utt_id, _ref_text, rel, _target in meta:
+        wav = load_wav(os.path.join(args.seed_tts, rel), sr)
+        codes_TN = codec.encode_reference(wav, sample_rate=sr)
+        samples.append(codes_TN)
+        print(f"[probe] loaded {rel}: T={codes_TN.shape[0]} frames")
+
+    configs = [
+        ChunkConfig(stride=s, overlap=o, crossfade_samples=c)
+        for s in STRIDES
+        for o in OVERLAPS
+        for c in CROSSFADES
+    ]
+    print(f"\n[probe] sweeping {len(configs)} (stride, overlap, xfade) configs "
+          f"x {len(samples)} samples")
+    print()
+    print(f"{'stride':>6} {'over':>4} {'xfade':>5}  "
+          f"{'mse(mean)':>11} {'peak(max)':>10} {'clicks(sum)':>11}")
+    print("-" * 64)
+
+    best: tuple[ChunkConfig, float] | None = None
+    for cfg in configs:
+        per_sample = [evaluate(codec, codes, cfg) for codes in samples]
+        mse_mean = statistics.fmean(r["mse"] for r in per_sample)
+        peak_max = max(r["peak_diff"] for r in per_sample)
+        clicks_sum = sum(r["n_click_edges"] for r in per_sample)
+        print(
+            f"{cfg.stride:>6d} {cfg.overlap:>4d} {cfg.crossfade_samples:>5d}  "
+            f"{mse_mean:>11.4e} {peak_max:>10.4f} {clicks_sum:>11d}"
+        )
+        if (
+            mse_mean < 1e-4
+            and clicks_sum == 0
+            and (
+                best is None
+                or (cfg.overlap + cfg.crossfade_samples / FRAME_LENGTH)
+                < (best[0].overlap + best[0].crossfade_samples / FRAME_LENGTH)
+            )
+        ):
+            best = (cfg, mse_mean)
+
+    print()
+    if best is not None:
+        cfg, mse = best
+        print(
+            f"[probe] RECOMMENDATION: stride={cfg.stride} overlap={cfg.overlap} "
+            f"crossfade_samples={cfg.crossfade_samples}  (mse={mse:.2e})"
+        )
+    else:
+        print(
+            "[probe] No config met the acceptance bar (mse<1e-4 and no clicks). "
+            "Likely options: (a) raise overlap further, (b) widen the sweep, or "
+            "(c) fall back to 'wait-N-then-stream' (degenerate streaming)."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/dev/higgs_tts/streaming_plan.md
+++ b/docs/dev/higgs_tts/streaming_plan.md
@@ -1,0 +1,225 @@
+# Higgs TTS — Streaming Output (Dynamic Frame Accumulation)
+
+Tracking doc for adding HTTP-streaming `audio/speech` output to Higgs
+TTS, using the dynamic frame accumulation pattern Baseten describes
+for Qwen3-TTS. **Status: plan + Stage 0 probe only.**
+
+## Why
+
+Today `/v1/audio/speech` with Higgs TTS is request/response: client
+waits for the entire AR + vocoder pipeline before any audio comes
+back. Time-to-first-audio (TTFA) at C=1 is ~1.1 s (Stage 4 with
+CUDA Graph). For interactive voice agents this needs to drop into
+the 300–500 ms range.
+
+Two known wins, both compatible with the CUDA Graph path:
+
+1. **Per-step code emission**: AR engine emits one code row each
+   decode step into a stream channel instead of buffering until EOC.
+2. **Dynamic frame accumulation in the vocoder**: vocoder decodes a
+   small first chunk (~10 frames, ~133 ms audio) for low TTFA, then
+   ramps up to large chunks (~90 frames, ~1.2 s audio) so the codec
+   forward stays well-batched as concurrency rises.
+
+sglang-omni's `fishaudio_s2_pro` model **already implements this exact
+pattern** (`streaming_vocoder.py:S2ProVocoderScheduler`, 627 LOC). The
+work below ports that template to Higgs TTS, with one
+Higgs-specific complication: the delay-pattern codec.
+
+## Existing pieces we don't need to touch
+
+- **HTTP layer**: `/v1/audio/speech?stream=true` → `_speech_stream`
+  SSE handler (`serve/openai_api.py:528`) already iterates
+  `client.generate(...)`, encodes each chunk with `encode_audio`
+  (WAV / MP3 / PCM), and emits SSE.
+- **Pipeline IPC**: stage→stage `type="stream"` messages with a
+  `target=` field already route to a named downstream stage; relay /
+  coordinator handle it. `S2ProVocoderScheduler` is proof.
+- **`reverse_delay_pattern`**: in `utils.py`, unit-tested. Recovers
+  `[T, N]` data codes from `[T + N − 1, N]` delayed codes.
+
+## What changes
+
+```
+┌───────────────┐  per-step      ┌────────────────┐  type=stream
+│ HiggsTTSModel │── 1 delayed ──▶│ HiggsScheduler │── target=vocoder
+│  (AR decode)  │   code row     │                │   data=codes[1, N]
+└───────────────┘  [N, 1]        └────────────────┘
+                                          │
+                                          ▼
+                                 ┌────────────────────┐ type=stream
+                                 │ HiggsStreaming     │── data={audio,
+                                 │ VocoderScheduler   │        sample_rate}
+                                 └────────────────────┘
+                                          │
+                                          ▼
+                                  /v1/audio/speech
+                                  (SSE chunks)
+```
+
+## Stages
+
+### Stage 0 — Codec chunkability probe ⏳
+
+**Why first**: highest-pull/lowest-cost question. If Higgs's
+codec decoder has a large receptive field or non-stationary
+behaviour, chunked decode produces audible artifacts at boundaries
+and the whole streaming design has to fall back to "wait-N-then-stream"
+(degenerate streaming). Knowing this up front sets the rest of the
+parameter sweep.
+
+**Tool**: `_perf_bench/probe_codec_chunking.py`
+
+Algorithm:
+
+1. Load codec via `HiggsAudioCodec.from_pretrained`.
+2. For N=5 reference WAVs (use `seed-tts/en` clips):
+   - `codes_TN = codec.encode_reference(wav)` → `[T, 8]`.
+   - `wav_full = codec.decode(codes_TN)` → one-shot baseline.
+   - For each `(stride, overlap)` in a sweep grid:
+     - Decode in chunks of `stride + overlap` data frames.
+     - Drop the first `overlap * frame_length` samples of each
+       chunk (those overlap the previous chunk's tail).
+     - Optionally apply linear-crossfade on chunk boundaries.
+     - Concatenate.
+3. Compare `wav_chunked` vs `wav_full`:
+   - per-sample MSE
+   - peak abs diff
+   - count of edges exceeding `peak_diff > 0.05` in any
+     10-sample window (proxy for clicks).
+4. Report a table; recommend `(stride, overlap, crossfade_samples)`.
+
+**Accept**: there exists `(stride=10, overlap, crossfade)` with
+chunked-vs-full MSE < 1e-4 and zero click edges. If not, escalate
+the overlap until it does, or fall back to "wait N-frame warmup
+before going streaming" mode.
+
+### Stage 1 — Per-step code emission
+
+**Files**: `model_runner.py`, `request_builders.py`
+
+- `HiggsSGLangRequestData` gains `latest_stream_code_chunk: torch.Tensor | None = None`.
+- `_collect_step_outputs_cg` (decode path, the captured one) writes
+  `data.latest_stream_code_chunk = codes_N.unsqueeze(0)` (shape
+  `[1, N]`) each step, alongside the existing
+  `data.output_codes.append`. Prefill path mirrors it.
+
+**Accept**: decode of a 50-step request leaves `latest_stream_code_chunk`
+present on 50 individual scheduler ticks (snapshot test).
+
+### Stage 2 — Scheduler emit
+
+**Files**: `higgs_scheduler.py`
+
+Add `_emit_stream_chunk(request)` modeled on
+`fish_scheduler.py:427`:
+
+```python
+def _emit_stream_chunk(self, request):
+    if not payload.request.params.get("stream"):
+        return
+    codes = data.latest_stream_code_chunk
+    if codes is None:
+        return
+    self.outbox.put(OutgoingMessage(
+        request_id=request.request_id, type="stream",
+        data=codes, target="vocoder",
+        metadata={"modality": "audio_codes"},
+    ))
+    data.latest_stream_code_chunk = None
+```
+
+Call from `HiggsScheduler.update()` after `iteration_controller.update_request`,
+before the finish check. On finish, emit `type="stream_done"`.
+
+**Accept**: pcap-equivalent — server log shows N stream messages
++ 1 stream_done per streaming request, before the result message.
+
+### Stage 3 — Streaming vocoder
+
+**Files**: new `higgs_streaming_vocoder.py` (~700 LOC), close port
+of `streaming_vocoder.py`.
+
+Key differences from s2_pro:
+
+1. **Delay pattern**: state holds `delayed_codes_LN`, accumulated
+   one row per AR step. To emit `stride` data frames, need
+   `total_delayed >= last_data_emitted + stride + N - 1` rows.
+
+2. **Decode**: inside the trigger,
+   `data_codes_TN = reverse_delay_pattern(delayed_codes_LN[start:])`
+   then call `codec.decode`.
+
+3. **`stream_overlap_tokens` and `stream_crossfade_samples`** —
+   pin to whatever Stage 0 recommends.
+
+4. **trim**: drop emitted data + delay-window rows after each chunk
+   to bound memory.
+
+**Accept**: single-request streaming output, codes-domain MSE vs
+batch path is 0 (same codes), audio-domain MSE matches Stage 0's
+chunked-vs-full result.
+
+### Stage 4 — Pipeline wiring
+
+**Files**: `stages.py`, `config.py`
+
+- Unify vocoder stage: same scheduler handles both streaming
+  (`type=stream` / `type=stream_done`) and batch (`type=new_request`)
+  paths. Non-stream requests route through the original batch
+  decode path internally; only stream requests use the per-chunk
+  accumulator.
+- `stages.py:create_vocoder_executor` takes the new scheduler.
+- `config.py` exposes `stream_stride`, `stream_followup_stride`,
+  `stream_overlap_tokens`, `stream_crossfade_samples` as
+  `factory_args`.
+
+**Accept**: existing N=100 batch bench unchanged; new streaming
+request returns multiple audio chunks via SSE.
+
+### Stage 5 — Test + tuning
+
+**Files**: `tests/test_higgs_tts_streaming.py`,
+`_perf_bench/bench_streaming.py`.
+
+- Streaming smoke: open `stream=True`, record per-chunk wall
+  timestamps + sample counts. Verify:
+  - TTFA p50 ≤ 500 ms
+  - audio_s/s C=1 ≥ 3.0 (Stage 4 baseline was 3.55)
+  - first chunk size ≈ `stream_stride * frame_length` samples
+- Cross-check: concatenated streamed audio vs single-shot WAV from
+  same prompt + seed → sample MSE on the same range as Stage 0
+  predicted.
+- Sweep grid: `stream_stride ∈ {4, 8, 16}`,
+  `stream_followup_stride ∈ {32, 64, 128}`; pick TTFA p95 vs
+  throughput pareto knee.
+
+**Accept**: TTFA p50 < 500 ms and no audible artifacts on listening
+test of 5 outputs.
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Higgs codec chunked-decode has audible boundary artifacts | **Medium** | Stage 0 measures this directly; fallback is wait-N-then-stream |
+| `overlap` value needed is too large (≥40 frames) for low TTFA | Low | Stage 0 sweep finds the smallest viable value |
+| `stream` message firehose stalls coordinator at high C | Low | s2_pro proves this works at C=16+ |
+| CUDA Graph + streaming interaction | Very low | streaming only adds scheduler / vocoder code paths; the captured forward is untouched |
+| MP3 streaming doesn't work (mp3 chunks aren't independently decodable) | Low | Use PCM or OGG/Opus for streaming response_format; document the limitation |
+
+## Out of scope
+
+- WebSocket / Realtime API (`sglang_omni/serve/realtime/`).
+- Smarter chunk sizing (e.g. adaptive based on observed concurrency).
+- Stop-mid-stream / abort handling beyond what s2_pro already does.
+
+## Timeline
+
+| Stage | Days | Cumulative |
+|---|---|---|
+| 0. Codec probe | 0.5 | 0.5 |
+| 1. Per-step emission | 0.5 | 1 |
+| 2. Scheduler emit | 0.5 | 1.5 |
+| 3. Streaming vocoder | 2 | 3.5 |
+| 4. Pipeline wiring | 0.5 | 4 |
+| 5. Test + tuning | 1 | 5 |


### PR DESCRIPTION
## Summary

Tracking doc + a single self-contained probe script for adding HTTP-streaming `audio/speech` output to Higgs TTS using the dynamic frame accumulation pattern from [Baseten's Qwen3-TTS blog post](https://www.baseten.co/blog/cost-efficient-high-performance-qwen3-tts/).

sglang-omni's `fishaudio_s2_pro` already implements this pattern (`streaming_vocoder.py:S2ProVocoderScheduler`):

- first chunk: `stream_stride=10` frames (~133 ms audio, low TTFA)
- subsequent chunks: `stream_followup_stride=90` frames (~1.2 s, larger batches in the codec forward → higher concurrent throughput)
- `stream_overlap_tokens=20` of re-decoded context + a 512-sample linear crossfade glues adjacent chunks without audible seams

The plan is largely a port of that template, with one Higgs-specific twist — Higgs uses an `N=8` delay pattern, so to emit `stride` data frames the vocoder must wait for `stride + N - 1` delayed frames and apply `reverse_delay_pattern` before calling `codec.decode`.

## What's in this PR

| File | Purpose |
|---|---|
| `docs/dev/higgs_tts/streaming_plan.md` | Full streaming plan: stages, timeline, risks, exit criteria |
| `_perf_bench/probe_codec_chunking.py` | Stage 0 probe — sweeps `(stride, overlap, crossfade_samples)` and reports MSE / peak diff / click-edge count vs one-shot baseline |

**No production code changes.** The probe is a research-mode script under `_perf_bench/`; the plan doc is under `docs/dev/`.

## Why probe first

Stage 0 answers the only question that gates the rest of the design:

> Can `HiggsAudioCodec.decode` be called on overlapping chunks of a single utterance's codes and produce audio perceptually indistinguishable from a one-shot decode?

If yes → port the s2_pro pattern (~5 days of work, well-scoped). If no → fall back to "wait-N-then-stream" (degenerate streaming, ~half-day) and document the limitation.

## How to run the probe

```bash
docker exec sglang_omni_test bash -lc '
  python _perf_bench/probe_codec_chunking.py \
    --model-path boson-sglang/higgs-audio-v3-tts-4b-base \
    --seed-tts /ceph/data/higgs_audio_eval/zero_shot_tts/seed_tts/en \
    --n 5'
```

Output is a table of `(stride, overlap, crossfade) → mse / peak_diff / click_count` plus a recommendation line.

## Test plan

- [ ] Run probe; confirm at least one `(stride, overlap, crossfade)` hits MSE < 1e-4 and zero click edges
- [ ] If the cleanest pick has `overlap > 20`, expand the sweep (Stage 0 is allowed to iterate)
- [ ] Pin the chosen values into `streaming_plan.md` Stage 3 acceptance criteria
- [ ] Then open follow-up PRs implementing Stages 1–5

🤖 Generated with [Claude Code](https://claude.com/claude-code)