### PR TITLE
[Feat] Improve multiprocess runtime cleanup

### DIFF
--- a/docs/developer_reference/apiserver_design.md
+++ b/docs/developer_reference/apiserver_design.md
@@ -64,7 +64,7 @@ It:
 - starts the pipeline runtime
 - creates the `Client`
 - creates the FastAPI app
-- mounts profiling routes on the single-process path
+- mounts profiling/control routes
 - runs Uvicorn
 - stops the runtime on shutdown
 
@@ -80,11 +80,13 @@ The current server exposes these main routes:
 | `GET` | `/v1/models` | Single-model listing for the active pipeline |
 | `POST` | `/v1/chat/completions` | Chat completions, including streaming and optional audio |
 | `POST` | `/v1/audio/speech` | Text-to-speech, raw audio response or SSE chunks when `stream=true` |
-| `POST` | `/start_profile` | Added by the single-process built-in launcher |
-| `POST` | `/stop_profile` | Added by the single-process built-in launcher |
+| `POST` | `/start_profile` | Added by the built-in launcher/control-route helper |
+| `POST` | `/stop_profile` | Added by the built-in launcher/control-route helper |
 
-The profiling routes are mounted by the single-process `launch_server()` path. The
-current multi-process launcher path does not mount them.
+The built-in `launch_server()` path mounts these routes for the active runner.
+Custom FastAPI embedding paths can mount the same route surface with
+`sglang_omni.serve.mount_control_routes(app, runner.stage_control_endpoints, ...)`
+and should close the returned control client during shutdown.
 
 ## Request Mapping
 

--- a/examples/run_ming_omni_speech_server.py
+++ b/examples/run_ming_omni_speech_server.py
@@ -88,6 +88,7 @@ async def main_async(args: argparse.Namespace) -> None:
     from sglang_omni.client import Client
     from sglang_omni.models.ming_omni.config import MingOmniSpeechPipelineConfig
     from sglang_omni.pipeline.mp_runner import MultiProcessPipelineRunner
+    from sglang_omni.serve import mount_control_routes
     from sglang_omni.serve.openai_api import create_app
 
     gpu_placement = {
@@ -115,9 +116,15 @@ async def main_async(args: argparse.Namespace) -> None:
     await runner.start(timeout=600)
     logger.info("Pipeline ready.")
 
+    profiler_ctl = None
     try:
         client = Client(runner.coordinator)
         app = create_app(client, model_name=args.model_name)
+        profiler_ctl = mount_control_routes(
+            app,
+            runner.stage_control_endpoints,
+            profiler_dir=os.environ.get("SGLANG_TORCH_PROFILER_DIR"),
+        )
 
         server_config = uvicorn.Config(
             app,
@@ -128,6 +135,8 @@ async def main_async(args: argparse.Namespace) -> None:
         server = uvicorn.Server(server_config)
         await server.serve()
     finally:
+        if profiler_ctl is not None:
+            await profiler_ctl.close()
         logger.info("Shutting down pipeline...")
         await runner.stop()
         logger.info("Pipeline stopped.")

--- a/sglang_omni/pipeline/control_plane.py
+++ b/sglang_omni/pipeline/control_plane.py
@@ -279,6 +279,8 @@ class StageControlPlane:
 
     async def start(self) -> None:
         """Initialize all sockets."""
+        if self._recv_socket is not None:
+            return
         # Socket to receive work
         self._recv_socket = PullSocket(self.recv_endpoint, bind=True)
         await self._recv_socket.start()
@@ -387,6 +389,8 @@ class CoordinatorControlPlane:
 
     async def start(self) -> None:
         """Initialize all sockets."""
+        if self._completion_socket is not None:
+            return
         # Socket to receive completions
         self._completion_socket = PullSocket(self.completion_endpoint, bind=True)
         await self._completion_socket.start()

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -25,6 +25,7 @@ from sglang_omni.pipeline import Coordinator
 from sglang_omni.pipeline.runtime_config import (
     IpcRuntimeDir,
     PipelineRuntimePrep,
+    TcpEndpointReservation,
     build_relay_config,
     prepare_pipeline_runtime,
 )
@@ -287,6 +288,7 @@ class MultiProcessPipelineRunner:
         self._fatal_event: asyncio.Event | None = None
         self._fatal_error: BaseException | None = None
         self._prep: PipelineRuntimePrep | None = None
+        self._endpoint_reservation: TcpEndpointReservation | None = None
         self._started = False
 
     @property
@@ -326,6 +328,7 @@ class MultiProcessPipelineRunner:
             )
             self._prep = prep
             self._ipc_runtime_dir = prep.runtime_dir
+            self._endpoint_reservation = prep.endpoint_reservation
             groups = _build_stage_groups(
                 self._config,
                 ctx,
@@ -342,6 +345,7 @@ class MultiProcessPipelineRunner:
                 entry_stage=prep.entry_stage,
                 terminal_stages=self._config.terminal_stages or None,
             )
+            self._release_endpoint_reservations({"completion", "abort"})
             await self._coordinator.start()
             self._completion_task = asyncio.create_task(
                 self._coordinator.run_completion_loop()
@@ -349,6 +353,12 @@ class MultiProcessPipelineRunner:
 
             self._groups = groups
             for group in self._groups:
+                self._release_endpoint_reservations(
+                    {
+                        f"stage_{stage_name}"
+                        for stage_name in group.stage_control_endpoints
+                    }
+                )
                 group.spawn(ctx)
 
             await asyncio.gather(*(g.wait_ready(timeout) for g in self._groups))
@@ -365,6 +375,7 @@ class MultiProcessPipelineRunner:
                     self._coordinator.register_stage(stage_name, endpoint)
 
             self._started = True
+            self._release_endpoint_reservations()
             self._monitor_task = asyncio.create_task(self._monitor_children())
 
             total_stages = sum(
@@ -425,6 +436,13 @@ class MultiProcessPipelineRunner:
         self._ipc_runtime_dir.close()
         self._ipc_runtime_dir = None
 
+    def _release_endpoint_reservations(self, keys: set[str] | None = None) -> None:
+        if self._endpoint_reservation is None:
+            return
+        self._endpoint_reservation.release(keys)
+        if not self._endpoint_reservation.keys:
+            self._endpoint_reservation = None
+
     async def stop(self) -> None:
         if not self._started:
             return
@@ -455,6 +473,7 @@ class MultiProcessPipelineRunner:
         self._coordinator = None
 
         self._close_runtime_dir()
+        self._release_endpoint_reservations()
 
     async def _cleanup_on_failure(self) -> None:
         """Best-effort cleanup after a failed start()."""
@@ -467,6 +486,7 @@ class MultiProcessPipelineRunner:
                 if p.is_alive():
                     p.kill()
                     p.join(timeout=2)
+            group.close_control_channels()
         self._groups.clear()
 
         await self._cancel_completion_task()
@@ -479,3 +499,4 @@ class MultiProcessPipelineRunner:
             self._coordinator = None
 
         self._close_runtime_dir()
+        self._release_endpoint_reservations()

--- a/sglang_omni/pipeline/runtime_config.py
+++ b/sglang_omni/pipeline/runtime_config.py
@@ -10,6 +10,7 @@ import socket
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from sglang_omni.config.placement import StagePlacementPlan, build_stage_placement_plan
 from sglang_omni.config.schema import PipelineConfig, StageConfig
@@ -46,6 +47,48 @@ class IpcRuntimeDir:
             logger.warning("Failed to remove IPC runtime dir %s: %s", self.path, exc)
 
 
+class TcpEndpointReservation:
+    """Parent-owned TCP port reservations for one pipeline startup.
+
+    These sockets keep auto-selected TCP ports owned while runtime prep builds
+    the launch plan. The runner releases each endpoint when handing ownership
+    to the component that binds it.
+    """
+
+    def __init__(self, sockets: dict[str, socket.socket]):
+        self._sockets = dict(sockets)
+
+    def __repr__(self) -> str:
+        return f"TcpEndpointReservation(keys={sorted(self._sockets)})"
+
+    @property
+    def keys(self) -> set[str]:
+        return set(self._sockets)
+
+    def release(
+        self,
+        keys: list[str] | tuple[str, ...] | set[str] | None = None,
+    ) -> None:
+        selected = list(self._sockets) if keys is None else list(keys)
+        for key in selected:
+            sock = self._sockets.pop(key, None)
+            if sock is None:
+                continue
+            try:
+                sock.close()
+            except OSError as exc:
+                logger.warning("Failed to release TCP endpoint %s: %s", key, exc)
+
+    def close(self) -> None:
+        self.release()
+
+
+@dataclass(frozen=True)
+class EndpointAllocation:
+    endpoints: dict[str, str]
+    reservation: TcpEndpointReservation | None = None
+
+
 @dataclass(frozen=True)
 class PipelineRuntimePrep:
     """Prepared stage, endpoint, placement, and topology state."""
@@ -58,6 +101,7 @@ class PipelineRuntimePrep:
     process_plan: ProcessTopologyPlan
     runtime_dir: IpcRuntimeDir | None
     runtime_dir_created_here: bool
+    endpoint_reservation: TcpEndpointReservation | None = None
 
 
 def create_ipc_runtime_dir(config: PipelineConfig) -> IpcRuntimeDir | None:
@@ -96,11 +140,12 @@ def prepare_pipeline_runtime(
             placement_plan,
             stages_cfg=stages_cfg,
         )
-        endpoints = allocate_endpoints(
+        endpoint_allocation = allocate_pipeline_endpoints(
             config,
             stages=stages_cfg,
             ipc_base_dir=runtime_dir.path if runtime_dir else None,
         )
+        endpoints = endpoint_allocation.endpoints
     except Exception:
         if created_runtime_dir is not None:
             created_runtime_dir.close()
@@ -115,6 +160,7 @@ def prepare_pipeline_runtime(
         process_plan=process_plan,
         runtime_dir=runtime_dir,
         runtime_dir_created_here=runtime_dir_created_here,
+        endpoint_reservation=endpoint_allocation.reservation,
     )
 
 
@@ -164,29 +210,64 @@ def parse_gpu_id(device: str) -> int | None:
     raise ValueError(f"Unsupported device string: {device}")
 
 
-def find_free_tcp_ports(start: int, count: int) -> list[int]:
-    """Find *count* available TCP ports starting from *start*."""
-    ports: list[int] = []
+def reserve_free_tcp_ports(
+    start: int,
+    count: int,
+    *,
+    exclude_ports: set[int] | None = None,
+) -> list[socket.socket]:
+    """Reserve *count* available TCP ports starting from *start*.
+
+    The returned sockets remain bound until closed by the caller.
+    """
+
+    sockets: list[socket.socket] = []
+    excluded = exclude_ports or set()
     port = start
-    while len(ports) < count:
-        try:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.bind(("127.0.0.1", port))
-                ports.append(port)
-        except OSError:
-            # Port is already bound or otherwise unbindable; advance to the
-            # next candidate.
-            pass
-        port += 1
-    return ports
+    try:
+        while len(sockets) < count:
+            if port in excluded:
+                port += 1
+                continue
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            try:
+                sock.bind(("127.0.0.1", port))
+            except OSError:
+                sock.close()
+            else:
+                sockets.append(sock)
+            port += 1
+    except Exception:
+        for sock in sockets:
+            sock.close()
+        raise
+    return sockets
 
 
-def allocate_endpoints(
+def _tcp_endpoint_port(endpoint: str) -> int | None:
+    parsed = urlsplit(endpoint)
+    if parsed.scheme != "tcp":
+        return None
+    try:
+        return parsed.port
+    except ValueError:
+        return None
+
+
+def _explicit_tcp_ports(endpoints: dict[str, str]) -> set[int]:
+    return {
+        port
+        for endpoint in endpoints.values()
+        if (port := _tcp_endpoint_port(endpoint)) is not None
+    }
+
+
+def allocate_pipeline_endpoints(
     config: PipelineConfig,
     *,
     stages: list[StageConfig],
     ipc_base_dir: Path | None = None,
-) -> dict[str, str]:
+) -> EndpointAllocation:
     endpoints: dict[str, str] = {}
 
     if config.completion_endpoint:
@@ -204,21 +285,46 @@ def allocate_endpoints(
             endpoints[f"stage_{stage.name}"] = (
                 f"ipc://{base_dir}/stage_{stage.name}.sock"
             )
-        return endpoints
+        return EndpointAllocation(endpoints=endpoints)
 
     if config.endpoints.scheme == "tcp":
-        needed = 2 + len(stages)
-        ports = find_free_tcp_ports(config.endpoints.base_port, needed)
-        idx = 0
+        endpoint_keys: list[str] = []
         if "completion" not in endpoints:
-            endpoints["completion"] = f"tcp://127.0.0.1:{ports[idx]}"
-            idx += 1
+            endpoint_keys.append("completion")
         if "abort" not in endpoints:
-            endpoints["abort"] = f"tcp://127.0.0.1:{ports[idx]}"
-            idx += 1
+            endpoint_keys.append("abort")
         for stage in stages:
-            endpoints[f"stage_{stage.name}"] = f"tcp://127.0.0.1:{ports[idx]}"
-            idx += 1
-        return endpoints
+            endpoint_keys.append(f"stage_{stage.name}")
+
+        reserved_sockets = reserve_free_tcp_ports(
+            config.endpoints.base_port,
+            len(endpoint_keys),
+            exclude_ports=_explicit_tcp_ports(endpoints),
+        )
+        reservation_sockets: dict[str, socket.socket] = {}
+        for key, sock in zip(endpoint_keys, reserved_sockets, strict=True):
+            port = sock.getsockname()[1]
+            endpoints[key] = f"tcp://127.0.0.1:{port}"
+            reservation_sockets[key] = sock
+        reservation = (
+            TcpEndpointReservation(reservation_sockets) if reservation_sockets else None
+        )
+        return EndpointAllocation(endpoints=endpoints, reservation=reservation)
 
     raise ValueError(f"Unknown endpoint scheme: {config.endpoints.scheme}")
+
+
+def allocate_endpoints(
+    config: PipelineConfig,
+    *,
+    stages: list[StageConfig],
+    ipc_base_dir: Path | None = None,
+) -> dict[str, str]:
+    allocation = allocate_pipeline_endpoints(
+        config,
+        stages=stages,
+        ipc_base_dir=ipc_base_dir,
+    )
+    if allocation.reservation is not None:
+        allocation.reservation.close()
+    return allocation.endpoints

--- a/sglang_omni/pipeline/stage_group.py
+++ b/sglang_omni/pipeline/stage_group.py
@@ -6,9 +6,10 @@ import asyncio
 import logging
 import multiprocessing
 import os
+import queue as queue_mod
 import time
-from contextlib import contextmanager
-from typing import Sequence
+from contextlib import contextmanager, suppress
+from typing import Any, Sequence
 
 from sglang_omni.pipeline.stage_process import (
     StageProcessSpec,
@@ -76,6 +77,7 @@ class StageGroup:
         self.process_specs = list(process_specs)
         self._processes: list[multiprocessing.Process] = []
         self._ready_events: list[multiprocessing.Event] = []
+        self._startup_error_queues: list[Any] = []
 
     @property
     def process_count(self) -> int:
@@ -117,17 +119,23 @@ class StageGroup:
         """Spawn the OS process(es) owned by this group."""
         for spec in self.process_specs:
             event = ctx.Event()
+            startup_error_queue = ctx.Queue()
             proc_name = _process_name(spec)
             proc = ctx.Process(
                 target=stage_process_main,
-                args=(spec, event),
+                args=(spec, event, startup_error_queue),
                 name=proc_name,
                 daemon=True,
             )
-            with _patched_spawn_env(spec):
-                proc.start()
+            try:
+                with _patched_spawn_env(spec):
+                    proc.start()
+            except Exception:
+                _close_queue(startup_error_queue)
+                raise
             self._processes.append(proc)
             self._ready_events.append(event)
+            self._startup_error_queues.append(startup_error_queue)
 
         logger.info(
             "StageGroup %s: spawned %d process(es) (pids=%s)",
@@ -149,14 +157,28 @@ class StageGroup:
             while not event.is_set():
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
+                    startup_error = await loop.run_in_executor(
+                        None,
+                        self._read_startup_error,
+                        i,
+                        0.0,
+                    )
+                    details = _format_startup_error(startup_error)
                     raise TimeoutError(
                         f"Process {process_label} did not become ready "
-                        f"within {timeout:.0f}s"
+                        f"within {timeout:.0f}s{details}"
                     )
                 if not proc.is_alive():
+                    startup_error = await loop.run_in_executor(
+                        None,
+                        self._read_startup_error,
+                        i,
+                        0.2,
+                    )
+                    details = _format_startup_error(startup_error)
                     raise RuntimeError(
                         f"Process {process_label} died during startup "
-                        f"(exit code {proc.exitcode})"
+                        f"(exit code {proc.exitcode}){details}"
                     )
                 await loop.run_in_executor(None, event.wait, min(remaining, 1.0))
 
@@ -177,20 +199,66 @@ class StageGroup:
                 )
         return ", ".join(parts) if parts else "(none)"
 
+    def _read_startup_error(self, index: int, timeout: float) -> Any | None:
+        if index >= len(self._startup_error_queues):
+            return None
+        q = self._startup_error_queues[index]
+        try:
+            if timeout <= 0:
+                return q.get_nowait()
+            return q.get(timeout=timeout)
+        except queue_mod.Empty:
+            return None
+        except Exception:
+            logger.debug(
+                "Failed to read startup error for group %s index %s",
+                self.group_name,
+                index,
+                exc_info=True,
+            )
+            return None
+
+    def close_control_channels(self) -> None:
+        """Close parent-owned multiprocessing queues for this group."""
+        queues: list[Any] = []
+        queues.extend(self._startup_error_queues)
+        for process_spec in self.process_specs:
+            for stage_spec in process_spec.stage_specs:
+                queues.extend(stage_spec.follower_work_queues)
+                queues.extend(stage_spec.follower_abort_queues)
+                if stage_spec.internal_work_queue is not None:
+                    queues.append(stage_spec.internal_work_queue)
+                if stage_spec.internal_abort_queue is not None:
+                    queues.append(stage_spec.internal_abort_queue)
+        seen: set[int] = set()
+        for q in queues:
+            marker = id(q)
+            if marker in seen:
+                continue
+            seen.add(marker)
+            _close_queue(q)
+
     async def shutdown(self, join_timeout: float = 30.0) -> None:
 
-        for p in self._processes:
-            p.join(timeout=join_timeout)
-            if p.is_alive():
-                logger.warning("Terminating stuck process %s (pid=%s)", p.name, p.pid)
-                p.terminate()
-                p.join(timeout=5)
+        try:
+            for p in self._processes:
+                p.join(timeout=join_timeout)
                 if p.is_alive():
-                    p.kill()
-                    p.join(timeout=2)
-
-        self._processes.clear()
-        self._ready_events.clear()
+                    logger.warning(
+                        "Terminating stuck process %s (pid=%s)",
+                        p.name,
+                        p.pid,
+                    )
+                    p.terminate()
+                    p.join(timeout=5)
+                    if p.is_alive():
+                        p.kill()
+                        p.join(timeout=2)
+        finally:
+            self.close_control_channels()
+            self._processes.clear()
+            self._ready_events.clear()
+            self._startup_error_queues.clear()
 
 
 def _process_name(spec: StageWorkerProcessSpec) -> str:
@@ -202,3 +270,31 @@ def _process_name(spec: StageWorkerProcessSpec) -> str:
     if stage_spec.role == "leader":
         return f"stage-{stage_spec.stage_name}-leader"
     return f"stage-{stage_spec.stage_name}-tp{stage_spec.tp_rank}-follower"
+
+
+def _format_startup_error(error: Any | None) -> str:
+    if error is None:
+        return ""
+    if isinstance(error, dict):
+        process_name = error.get("process_name")
+        stage_names = error.get("stage_names")
+        traceback_text = error.get("traceback")
+        header = (
+            f"\nStartup failure detail from process {process_name!r}, "
+            f"stages={stage_names}:"
+        )
+        if traceback_text:
+            return f"{header}\n{traceback_text}"
+        return header
+    return f"\nStartup failure detail: {error}"
+
+
+def _close_queue(q: Any) -> None:
+    close = getattr(q, "close", None)
+    if callable(close):
+        with suppress(Exception):
+            close()
+    join_thread = getattr(q, "join_thread", None)
+    if callable(join_thread):
+        with suppress(Exception):
+            join_thread()

--- a/sglang_omni/pipeline/stage_process.py
+++ b/sglang_omni/pipeline/stage_process.py
@@ -9,6 +9,7 @@ import logging
 import multiprocessing
 import os
 import sys
+from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import Any, Literal, Mapping
 
@@ -99,25 +100,38 @@ class StageWorkerProcessSpec:
 def stage_process_main(
     spec: StageWorkerProcessSpec,
     ready_event: multiprocessing.Event,
+    startup_error_queue: Any | None = None,
 ) -> None:
     """Subprocess entrypoint: construct stage(s) from *spec* and run them."""
     logging.basicConfig(level=logging.INFO, stream=sys.stdout)
-    if not spec.stage_specs:
-        raise ValueError(f"Process {spec.process_name!r} requires at least one stage")
     log = logging.getLogger(f"stage_process.{spec.process_name}")
 
     try:
+        if not spec.stage_specs:
+            raise ValueError(
+                f"Process {spec.process_name!r} requires at least one stage"
+            )
         for stage_spec in spec.stage_specs:
             _prepare_cuda_environment(stage_spec, log)
         _run_process(spec, ready_event, log)
     except Exception:
         import traceback
 
+        traceback_text = traceback.format_exc()
         log.error(
             "Stage process %s failed:\n%s",
             spec.process_name,
-            traceback.format_exc(),
+            traceback_text,
         )
+        if startup_error_queue is not None:
+            with suppress(Exception):
+                startup_error_queue.put(
+                    {
+                        "process_name": spec.process_name,
+                        "stage_names": [s.stage_name for s in spec.stage_specs],
+                        "traceback": traceback_text,
+                    }
+                )
         sys.exit(1)
 
 
@@ -140,11 +154,41 @@ def _run_process(
       live in this process, cold-start time degrades from ``max`` to ``sum``
       across them.
     """
-    stages = [_construct_stage(stage_spec, log) for stage_spec in spec.stage_specs]
+    control_planes = [
+        _construct_control_plane(stage_spec) for stage_spec in spec.stage_specs
+    ]
 
     async def _start_and_run():
         tasks: list[asyncio.Task] = []
+        stages: list[Stage] = []
+        startup_bound_control_planes: list[Any] = []
+        startup_bound_stages: list[Stage] = []
         try:
+            for control_plane in control_planes:
+                startup_bound_control_planes.append(control_plane)
+                await control_plane.start()
+            for stage_spec, control_plane in zip(
+                spec.stage_specs,
+                control_planes,
+                strict=True,
+            ):
+                stage = _construct_stage(
+                    stage_spec,
+                    log,
+                    control_plane=control_plane,
+                    construct_scheduler=False,
+                )
+                stages.append(stage)
+                startup_bound_stages.append(stage)
+            for stage, stage_spec in zip(stages, spec.stage_specs, strict=True):
+                gpu_id = _resolve_runtime_gpu_id(stage_spec)
+                log.info(
+                    "Building scheduler for %s (tp_rank=%d/%d) ...",
+                    stage_spec.stage_name,
+                    stage_spec.tp_rank,
+                    stage_spec.tp_size,
+                )
+                stage.scheduler = _construct_scheduler(stage_spec, gpu_id, log)
             for stage in stages:
                 await stage.start()
             log.info(
@@ -160,37 +204,57 @@ def _run_process(
                 task.cancel()
             if tasks:
                 await asyncio.gather(*tasks, return_exceptions=True)
+                startup_bound_stages.clear()
             for stage in stages:
-                if getattr(stage, "_running", False):
+                if getattr(stage, "_running", False) or stage in startup_bound_stages:
                     await stage.stop()
+            attached_control_planes = {id(stage.control_plane) for stage in stages}
+            for control_plane in startup_bound_control_planes:
+                if id(control_plane) not in attached_control_planes:
+                    control_plane.close()
 
     asyncio.run(_start_and_run())
+
+
+def _construct_control_plane(spec: StageProcessSpec) -> Any:
+    if spec.owns_external_io:
+        return StageControlPlane(
+            stage_name=spec.stage_name,
+            recv_endpoint=spec.recv_endpoint,
+            coordinator_endpoint=spec.coordinator_endpoint,
+            abort_endpoint=spec.abort_endpoint,
+        )
+    return TPFollowerControlPlane(
+        stage_name=spec.stage_name,
+        recv_endpoint=spec.recv_endpoint,
+        work_queue=spec.internal_work_queue,
+        abort_queue=spec.internal_abort_queue,
+    )
 
 
 def _construct_stage(
     spec: StageProcessSpec,
     log: logging.Logger,
+    *,
+    control_plane: Any | None = None,
+    construct_scheduler: bool = True,
 ) -> Stage:
-    gpu_id = spec.relay_config.get("gpu_id")
-    if gpu_id is None:
-        gpu_id = spec.factory_args.get("gpu_id")
-    if gpu_id is None and _factory_args_use_cuda(spec.factory_args):
-        gpu_id = spec.gpu_id
+    gpu_id = _resolve_runtime_gpu_id(spec)
     if gpu_id is not None:
         import torch
 
         torch.cuda.set_device(int(gpu_id))
         log.info("Set current CUDA device to %s for stage %s", gpu_id, spec.stage_name)
 
-    # --- Build scheduler via factory ---
-    log.info(
-        "Building scheduler for %s (tp_rank=%d/%d) ...",
-        spec.stage_name,
-        spec.tp_rank,
-        spec.tp_size,
-    )
-
-    scheduler = _construct_scheduler(spec, gpu_id, log)
+    scheduler = None
+    if construct_scheduler:
+        log.info(
+            "Building scheduler for %s (tp_rank=%d/%d) ...",
+            spec.stage_name,
+            spec.tp_rank,
+            spec.tp_size,
+        )
+        scheduler = _construct_scheduler(spec, gpu_id, log)
 
     # --- Build routing ---
     if spec.is_terminal:
@@ -218,20 +282,8 @@ def _construct_stage(
         for target, dotted_path in spec.project_payload.items()
     }
 
-    if spec.owns_external_io:
-        control_plane = StageControlPlane(
-            stage_name=spec.stage_name,
-            recv_endpoint=spec.recv_endpoint,
-            coordinator_endpoint=spec.coordinator_endpoint,
-            abort_endpoint=spec.abort_endpoint,
-        )
-    else:
-        control_plane = TPFollowerControlPlane(
-            stage_name=spec.stage_name,
-            recv_endpoint=spec.recv_endpoint,
-            work_queue=spec.internal_work_queue,
-            abort_queue=spec.internal_abort_queue,
-        )
+    if control_plane is None:
+        control_plane = _construct_control_plane(spec)
 
     tp_fanout = None
     if spec.is_leader:
@@ -264,6 +316,15 @@ def _construct_stage(
         stage._stream_queue = StreamQueue(max_pending=4096)
 
     return stage
+
+
+def _resolve_runtime_gpu_id(spec: StageProcessSpec) -> int | None:
+    gpu_id = spec.relay_config.get("gpu_id")
+    if gpu_id is None:
+        gpu_id = spec.factory_args.get("gpu_id")
+    if gpu_id is None and _factory_args_use_cuda(spec.factory_args):
+        gpu_id = spec.gpu_id
+    return gpu_id
 
 
 def _construct_scheduler(

--- a/sglang_omni/profiler/profiler_control.py
+++ b/sglang_omni/profiler/profiler_control.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any
 
 from sglang_omni.pipeline.control_plane import PushSocket
 from sglang_omni.proto import ProfilerStartMessage, ProfilerStopMessage
@@ -42,7 +41,6 @@ class ProfilerControlClient:
         self,
         run_id: str,
         trace_path_template: str,
-        config: dict[str, Any] | None = None,
         stages: list[str] | None = None,
     ) -> None:
         await self.start()

--- a/sglang_omni/serve/__init__.py
+++ b/sglang_omni/serve/__init__.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """HTTP serving utilities."""
 
+from sglang_omni.serve.control_routes import mount_control_routes
 from sglang_omni.serve.launcher import launch_server
 from sglang_omni.serve.openai_api import create_app
 
-__all__ = ["create_app", "launch_server"]
+__all__ = ["create_app", "launch_server", "mount_control_routes"]

--- a/sglang_omni/serve/control_routes.py
+++ b/sglang_omni/serve/control_routes.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reusable HTTP control routes for pipeline servers."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Mapping
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from sglang_omni.profiler.profiler_control import ProfilerControlClient
+
+
+def _default_run_id() -> str:
+    return time.strftime("run_%Y%m%d_%H%M%S")
+
+
+def _default_template(profiler_dir: str, run_id: str) -> str:
+    return os.path.join(profiler_dir, run_id, "trace")
+
+
+class StartProfileRequest(BaseModel):
+    run_id: str | None = None
+    trace_path_template: str | None = None
+
+
+class StopProfileRequest(BaseModel):
+    run_id: str | None = None
+
+
+def mount_control_routes(
+    app,
+    stage_control_endpoints: Mapping[str, str],
+    *,
+    profiler_dir: str | None = None,
+) -> ProfilerControlClient:
+    """Mount profiler/control routes and return the client they use.
+
+    Callers that own an app outside :func:`launch_server` should close the
+    returned client during shutdown.
+    """
+
+    profiler_ctl = ProfilerControlClient(dict(stage_control_endpoints))
+    router = APIRouter()
+
+    @router.post("/start_profile")
+    async def start(req: StartProfileRequest):
+        run_id = req.run_id or _default_run_id()
+        if req.trace_path_template is not None:
+            tpl = req.trace_path_template
+        elif profiler_dir is not None:
+            tpl = _default_template(profiler_dir, run_id)
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "trace_path_template is required when "
+                    "SGLANG_TORCH_PROFILER_DIR is not set"
+                ),
+            )
+        await profiler_ctl.broadcast_start(
+            run_id=run_id,
+            trace_path_template=tpl,
+        )
+        return {"run_id": run_id, "trace_path_template": tpl}
+
+    @router.post("/stop_profile")
+    async def stop(req: StopProfileRequest):
+        run_id = req.run_id or "default"
+        await profiler_ctl.broadcast_stop(run_id=run_id)
+        return {"run_id": run_id}
+
+    app.include_router(router)
+    return profiler_ctl

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -28,18 +28,16 @@ import asyncio
 import logging
 import os
 import socket
-import time
 from contextlib import suppress
 from typing import Any
 
 import uvicorn
-from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
 
 from sglang_omni.client import Client
 from sglang_omni.config import PipelineConfig
 from sglang_omni.pipeline.mp_runner import MultiProcessPipelineRunner
 from sglang_omni.profiler.profiler_control import ProfilerControlClient
+from sglang_omni.serve.control_routes import mount_control_routes
 from sglang_omni.serve.openai_api import create_app
 from sglang_omni.utils.gpu_memory import (
     GpuDeviceInfo,
@@ -68,14 +66,6 @@ def _find_available_port(host: str, port: int) -> int:
         free_port = s.getsockname()[1]
     logger.warning("Using port %d instead.", free_port)
     return free_port
-
-
-def _default_run_id() -> str:
-    return time.strftime("run_%Y%m%d_%H%M%S")
-
-
-def _default_template(profiler_dir: str, run_id: str) -> str:
-    return os.path.join(profiler_dir, run_id, "trace")
 
 
 # ---------------------------------------------------------------------------
@@ -147,52 +137,6 @@ def _placement_log_summary(
     }
 
 
-class StartReq(BaseModel):
-    run_id: str | None = None
-    trace_path_template: str | None = None
-    config: dict[str, Any] | None = None
-
-
-class StopReq(BaseModel):
-    run_id: str | None = None
-
-
-def _mount_profiler_routes(
-    app, profiler_ctl: ProfilerControlClient, profiler_dir: str | None
-) -> None:
-    router = APIRouter()
-
-    @router.post("/start_profile")
-    async def start(req: StartReq):
-        run_id = req.run_id or _default_run_id()
-        if req.trace_path_template is not None:
-            tpl = req.trace_path_template
-        elif profiler_dir is not None:
-            tpl = _default_template(profiler_dir, run_id)
-        else:
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    "trace_path_template is required when "
-                    "SGLANG_TORCH_PROFILER_DIR is not set"
-                ),
-            )
-        await profiler_ctl.broadcast_start(
-            run_id=run_id,
-            trace_path_template=tpl,
-            config=req.config,
-        )
-        return {"run_id": run_id, "trace_path_template": tpl}
-
-    @router.post("/stop_profile")
-    async def stop(req: StopReq):
-        run_id = req.run_id or "default"
-        await profiler_ctl.broadcast_stop(run_id=run_id)
-        return {"run_id": run_id}
-
-    app.include_router(router)
-
-
 async def _run_server(
     pipeline_config: PipelineConfig,
     *,
@@ -236,6 +180,7 @@ async def _run_server(
         len(gpu_ids),
     )
 
+    profiler_ctl: ProfilerControlClient | None = None
     try:
         cl_kwargs = client_kwargs or {}
         client = Client(coordinator, **cl_kwargs)
@@ -245,8 +190,11 @@ async def _run_server(
             enable_realtime=enable_realtime,
         )
         profiler_dir = os.environ.get("SGLANG_TORCH_PROFILER_DIR")
-        profiler_ctl = ProfilerControlClient(mp_runner.stage_control_endpoints)
-        _mount_profiler_routes(app, profiler_ctl, profiler_dir)
+        profiler_ctl = mount_control_routes(
+            app,
+            mp_runner.stage_control_endpoints,
+            profiler_dir=profiler_dir,
+        )
 
         config = uvicorn.Config(
             app,
@@ -258,6 +206,8 @@ async def _run_server(
         server = uvicorn.Server(config)
         await _serve_with_failure_watch(server, [mp_runner.wait_failed()])
     finally:
+        if profiler_ctl is not None:
+            await profiler_ctl.close()
         logger.info("Shutting down pipeline …")
         await mp_runner.stop()
         logger.info("Pipeline stopped.")

--- a/tests/unit_test/pipeline/test_ipc.py
+++ b/tests/unit_test/pipeline/test_ipc.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import logging
+import queue
+import socket
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -14,11 +17,17 @@ import sglang_omni.pipeline.mp_runner as mp_runner
 import sglang_omni.pipeline.runtime_config as runtime_config
 import sglang_omni.pipeline.stage.runtime as stage_runtime
 from sglang_omni.config.schema import EndpointsConfig, PipelineConfig, StageConfig
+from sglang_omni.pipeline.stage_group import StageGroup
+from sglang_omni.pipeline.stage_process import StageProcessSpec, StageWorkerProcessSpec
 from tests.unit_test.fixtures.pipeline_fakes import FakeMpContext, FakeRelay
 
 
 def noop_factory():
     return None
+
+
+def failing_factory():
+    raise RuntimeError("factory boom")
 
 
 class _FakeControlPlane:
@@ -109,7 +118,11 @@ def test_prepare_pipeline_runtime_owns_or_preserves_ipc_runtime_dir(
         del args, kwargs
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(runtime_config, "allocate_endpoints", fail_allocate_endpoints)
+    monkeypatch.setattr(
+        runtime_config,
+        "allocate_pipeline_endpoints",
+        fail_allocate_endpoints,
+    )
 
     with pytest.raises(RuntimeError, match="boom"):
         runtime_config.prepare_pipeline_runtime(config)
@@ -180,6 +193,144 @@ def test_ipc_stage_groups_use_unique_endpoints_for_same_model_name(
     assert list(tmp_path.iterdir()) == []
 
 
+def test_tcp_endpoint_reservation_owns_ports_until_released(tmp_path: Path) -> None:
+    config = _make_config(tmp_path, scheme="tcp")
+    prep = runtime_config.prepare_pipeline_runtime(config)
+    reservation = prep.endpoint_reservation
+    assert reservation is not None
+
+    endpoint = prep.endpoints["stage_preprocessing"]
+    port = int(endpoint.rsplit(":", 1)[1])
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            with pytest.raises(OSError):
+                probe.bind(("127.0.0.1", port))
+
+        reservation.release({"stage_preprocessing"})
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.bind(("127.0.0.1", port))
+    finally:
+        reservation.close()
+
+
+def test_tcp_endpoint_reservation_skips_explicit_tcp_ports(tmp_path: Path) -> None:
+    probe_sockets = runtime_config.reserve_free_tcp_ports(32123, 3)
+    base_port = probe_sockets[0].getsockname()[1]
+    for sock in probe_sockets:
+        sock.close()
+
+    config = PipelineConfig(
+        model_path="Qwen/Qwen3-Omni-30B-A3B-Instruct",
+        entry_stage="preprocessing",
+        stages=[
+            StageConfig(
+                name="preprocessing",
+                process="pipeline",
+                factory=f"{__name__}.noop_factory",
+                terminal=True,
+            )
+        ],
+        endpoints=EndpointsConfig(
+            scheme="tcp",
+            base_path=str(tmp_path),
+            base_port=base_port,
+        ),
+        completion_endpoint=f"tcp://127.0.0.1:{base_port}",
+    )
+    prep = runtime_config.prepare_pipeline_runtime(config)
+    reservation = prep.endpoint_reservation
+    assert reservation is not None
+    try:
+        auto_ports = {
+            int(prep.endpoints["abort"].rsplit(":", 1)[1]),
+            int(prep.endpoints["stage_preprocessing"].rsplit(":", 1)[1]),
+        }
+        assert prep.endpoints["completion"] == f"tcp://127.0.0.1:{base_port}"
+        assert base_port not in auto_ports
+        assert reservation.keys == {"abort", "stage_preprocessing"}
+    finally:
+        reservation.close()
+
+
+def test_stage_process_binds_control_plane_before_stage_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class ReadyEvent:
+        def __init__(self) -> None:
+            self.is_ready = False
+
+        def set(self) -> None:
+            self.is_ready = True
+            events.append("ready")
+
+    class RecordingControlPlane:
+        def __init__(
+            self,
+            *,
+            stage_name: str,
+            recv_endpoint: str,
+            coordinator_endpoint: str,
+            abort_endpoint: str,
+        ) -> None:
+            del coordinator_endpoint, abort_endpoint
+            self.stage_name = stage_name
+            self.recv_endpoint = recv_endpoint
+
+        async def start(self) -> None:
+            events.append("control_start")
+
+        def close(self) -> None:
+            events.append("control_close")
+
+    class RecordingStage:
+        def __init__(self, *, name: str, control_plane, scheduler, **kwargs) -> None:
+            del kwargs
+            events.append("stage_construct")
+            self.name = name
+            self.control_plane = control_plane
+            self.scheduler = scheduler
+            self._running = False
+
+        async def start(self) -> None:
+            events.append("stage_start")
+            self._running = True
+
+        async def run(self) -> None:
+            events.append("stage_run")
+
+        async def stop(self) -> None:
+            events.append("stage_stop")
+            self._running = False
+
+    import sglang_omni.pipeline.stage_process as stage_process
+
+    monkeypatch.setattr(stage_process, "StageControlPlane", RecordingControlPlane)
+    monkeypatch.setattr(stage_process, "Stage", RecordingStage)
+
+    ready_event = ReadyEvent()
+    stage_process._run_process(
+        StageWorkerProcessSpec(
+            process_name="pipeline",
+            stage_specs=[
+                StageProcessSpec(
+                    stage_name="preprocessing",
+                    factory=f"{__name__}.noop_factory",
+                    recv_endpoint="tcp://127.0.0.1:32123",
+                    coordinator_endpoint="tcp://127.0.0.1:32124",
+                    abort_endpoint="tcp://127.0.0.1:32125",
+                )
+            ],
+        ),
+        ready_event,
+        logging.getLogger("test_stage_process_order"),
+    )
+
+    assert ready_event.is_ready
+    assert events.index("control_start") < events.index("stage_construct")
+
+
 @pytest.mark.asyncio
 async def test_mp_runner_cleans_runtime_dir_on_start_failure(
     tmp_path: Path,
@@ -240,6 +391,10 @@ async def test_mp_runner_cleans_spawned_groups_when_later_spawn_fails(
             self.stage_name = stage_name
             self.fail_spawn = fail_spawn
             self.process = FakeProcess() if not fail_spawn else None
+            self.stage_control_endpoints = {
+                stage_name: f"ipc://stage_{stage_name}.sock"
+            }
+            self.channels_closed = False
 
         @property
         def processes(self) -> list[FakeProcess]:
@@ -252,6 +407,9 @@ async def test_mp_runner_cleans_spawned_groups_when_later_spawn_fails(
 
         async def wait_ready(self, timeout: float) -> None:
             del timeout
+
+        def close_control_channels(self) -> None:
+            self.channels_closed = True
 
     first_group = FakeGroup("preprocessing")
     second_group = FakeGroup("thinker", fail_spawn=True)
@@ -268,7 +426,135 @@ async def test_mp_runner_cleans_spawned_groups_when_later_spawn_fails(
 
     assert first_group.process.terminated
     assert first_group.process.join_count >= 1
+    assert first_group.channels_closed
+    assert second_group.channels_closed
     assert list(tmp_path.iterdir()) == []
+
+
+class _FakeEvent:
+    def is_set(self) -> bool:
+        return False
+
+    def wait(self, timeout=None) -> bool:
+        del timeout
+        return False
+
+
+class _DeadProcess:
+    pid = 123
+    exitcode = 1
+
+    def is_alive(self) -> bool:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_stage_group_startup_failure_includes_child_traceback() -> None:
+    group = StageGroup(
+        "pipeline",
+        [
+            StageWorkerProcessSpec(
+                process_name="pipeline",
+                stage_specs=[StageProcessSpec(stage_name="preprocessing")],
+            )
+        ],
+    )
+    group._processes = [_DeadProcess()]  # noqa: SLF001 - targeted lifecycle test
+    group._ready_events = [_FakeEvent()]  # noqa: SLF001
+    errors: queue.Queue[dict[str, object]] = queue.Queue()
+    errors.put(
+        {
+            "process_name": "pipeline",
+            "stage_names": ["preprocessing"],
+            "traceback": "Traceback (most recent call last):\nRuntimeError: boom",
+        }
+    )
+    group._startup_error_queues = [errors]  # noqa: SLF001
+
+    with pytest.raises(RuntimeError, match="RuntimeError: boom"):
+        await group.wait_ready(timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_mp_runner_startup_failure_includes_child_factory_traceback(
+    tmp_path: Path,
+) -> None:
+    config = PipelineConfig(
+        model_path="Qwen/Qwen3-Omni-30B-A3B-Instruct",
+        name="x",
+        entry_stage="preprocessing",
+        stages=[
+            StageConfig(
+                name="preprocessing",
+                process="pipeline",
+                factory=f"{__name__}.failing_factory",
+                terminal=True,
+            )
+        ],
+        endpoints=EndpointsConfig(scheme="ipc", base_path=str(tmp_path)),
+    )
+    runner = mp_runner.MultiProcessPipelineRunner(config)
+
+    with pytest.raises(RuntimeError, match="factory boom"):
+        await runner.start(timeout=10.0)
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_stage_group_closes_parent_owned_control_queues() -> None:
+    class CloseableQueue:
+        def __init__(self) -> None:
+            self.closed = 0
+            self.joined = 0
+
+        def close(self) -> None:
+            self.closed += 1
+
+        def join_thread(self) -> None:
+            self.joined += 1
+
+    work_q = CloseableQueue()
+    abort_q = CloseableQueue()
+    startup_q = CloseableQueue()
+    group = StageGroup(
+        "thinker",
+        [
+            StageWorkerProcessSpec(
+                process_name="thinker_tp0",
+                stage_specs=[
+                    StageProcessSpec(
+                        stage_name="thinker",
+                        role="leader",
+                        tp_size=2,
+                        follower_work_queues=[work_q],
+                        follower_abort_queues=[abort_q],
+                    )
+                ],
+            ),
+            StageWorkerProcessSpec(
+                process_name="thinker_tp1",
+                stage_specs=[
+                    StageProcessSpec(
+                        stage_name="thinker",
+                        role="follower",
+                        tp_size=2,
+                        internal_work_queue=work_q,
+                        internal_abort_queue=abort_q,
+                    )
+                ],
+            ),
+        ],
+    )
+    group._startup_error_queues = [startup_q]  # noqa: SLF001
+
+    group.close_control_channels()
+
+    assert work_q.closed == 1
+    assert work_q.joined == 1
+    assert abort_q.closed == 1
+    assert abort_q.joined == 1
+    assert startup_q.closed == 1
+    assert startup_q.joined == 1
 
 
 @pytest.mark.asyncio
@@ -420,6 +706,49 @@ async def test_launcher_uses_runner_and_mounts_profiler_routes(
     mounted_paths = {route.path for route in app.routes}
     assert "/start_profile" in mounted_paths
     assert "/stop_profile" in mounted_paths
+
+
+@pytest.mark.asyncio
+async def test_launcher_closes_mounted_control_route_client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _make_config(tmp_path)
+    server_serve = AsyncMock(return_value=None)
+
+    from sglang_omni.serve import launcher
+
+    class FakeProfilerClient:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+    profiler_client = FakeProfilerClient()
+
+    def fake_mount_control_routes(app, stage_control_endpoints, *, profiler_dir=None):
+        del stage_control_endpoints, profiler_dir
+
+        async def start_profile():
+            return {}
+
+        async def stop_profile():
+            return {}
+
+        app.add_api_route("/start_profile", start_profile, methods=["POST"])
+        app.add_api_route("/stop_profile", stop_profile, methods=["POST"])
+        return profiler_client
+
+    monkeypatch.setattr(launcher, "mount_control_routes", fake_mount_control_routes)
+
+    await _run_launcher_with_fake_runner(
+        config=config,
+        serve_mock=server_serve,
+        monkeypatch=monkeypatch,
+    )
+
+    assert profiler_client.closed
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
#459 

Improves multiprocess runtime cleanup before the full topology refactor.

Centralizes TCP endpoint reservation/release ownership in runtime prep and runner startup.
Adds clearer runtime/control channel lifecycle cleanup on shutdown and failed startup.
Propagates child process startup failures with traceback context.
Moves profiling/control routes into shared mount_control_routes() for all launcher paths.