### PR TITLE
[Bugfix] Drop gpu->list->gpu round-trip from qwen3-omni talker request-build

### DIFF
--- a/sglang_omni/models/qwen3_omni/request_builders.py
+++ b/sglang_omni/models/qwen3_omni/request_builders.py
@@ -553,6 +553,7 @@ def build_sglang_talker_request(
         vocab_size=codec_vocab_size,
     )
     req.tokenizer = tokenizer
+    req._input_embeds_are_projected = bool(input_embeds_are_projected)
     req.omni_model_inputs = dict(talker_model_inputs or {})
     req._omni_consumed = None
     req._codec_suppress_tokens = (

--- a/sglang_omni/models/qwen3_omni/request_builders.py
+++ b/sglang_omni/models/qwen3_omni/request_builders.py
@@ -493,8 +493,8 @@ def build_sglang_talker_request(
 ) -> "SGLangARRequestData":
     """Build SGLang AR request for the Talker from thinker hidden states.
 
-    Stores thinker hidden states as Req.input_embeds so SGLang's pipeline
-    passes them through ForwardBatch.input_embeds -> model.forward(input_embeds=...).
+    Keeps embedding tensors GPU-resident on SGLangARRequestData.prefill_input_embeds
+    so the model runner can read them directly without a list round-trip.
     Uses dummy input_ids of matching length for position tracking, while the
     request data keeps a device-backed FIFO of future text rows for decode.
 
@@ -509,20 +509,15 @@ def build_sglang_talker_request(
     # SGLangARRequestData already imported at module level
 
     if talker_input_embeds is not None:
-        input_embeds = talker_input_embeds.float().cpu().tolist()
+        prefill_embeds_tensor = talker_input_embeds
         input_ids_tensor = torch.as_tensor(talker_input_ids, dtype=torch.long)
         input_ids_list = input_ids_tensor.tolist()
         seq_len = len(input_ids_list)
     else:
-        # thinker_hidden_states: [seq_len, thinker_hidden_size]
         seq_len = thinker_hidden_states.shape[0]
-
-        # Dummy input_ids — codec BOS token repeated for each position
         input_ids_list = [codec_bos_id] * seq_len
         input_ids_tensor = torch.tensor(input_ids_list, dtype=torch.long)
-
-        # Convert hidden states to list-of-lists for Req.input_embeds
-        input_embeds = thinker_hidden_states.float().cpu().tolist()
+        prefill_embeds_tensor = thinker_hidden_states
 
     sampling_params = SamplingParams(
         max_new_tokens=max_new_tokens,
@@ -543,7 +538,7 @@ def build_sglang_talker_request(
         origin_input_text="",
         origin_input_ids=input_ids_list,
         sampling_params=sampling_params,
-        input_embeds=input_embeds,
+        input_embeds=None,
         eos_token_ids={int(codec_eos_id)} if codec_eos_id is not None else None,
         vocab_size=codec_vocab_size,
     )
@@ -591,6 +586,7 @@ def build_sglang_talker_request(
         temperature=temperature,
         output_ids=req.output_ids,
         req=req,
+        prefill_input_embeds=prefill_embeds_tensor,
     )
     data.suppress_tokens = list(req._codec_suppress_tokens or [])
     data.talker_model_inputs = dict(talker_model_inputs or {})

--- a/sglang_omni/models/qwen3_omni/request_builders.py
+++ b/sglang_omni/models/qwen3_omni/request_builders.py
@@ -547,8 +547,7 @@ def build_sglang_talker_request(
         sampling_params=sampling_params,
         # Convert hidden states to list-of-lists for Req.input_embeds
         input_embeds=(
-            None if input_embeds_are_projected
-            else prefill_embeds_tensor.cpu().tolist()
+            None if input_embeds_are_projected else prefill_embeds_tensor.cpu().tolist()
         ),
         eos_token_ids={int(codec_eos_id)} if codec_eos_id is not None else None,
         vocab_size=codec_vocab_size,
@@ -597,7 +596,9 @@ def build_sglang_talker_request(
         temperature=temperature,
         output_ids=req.output_ids,
         req=req,
-        prefill_input_embeds=prefill_embeds_tensor if input_embeds_are_projected else None,
+        prefill_input_embeds=(
+            prefill_embeds_tensor if input_embeds_are_projected else None
+        ),
     )
     data.suppress_tokens = list(req._codec_suppress_tokens or [])
     data.talker_model_inputs = dict(talker_model_inputs or {})

--- a/sglang_omni/models/qwen3_omni/request_builders.py
+++ b/sglang_omni/models/qwen3_omni/request_builders.py
@@ -546,7 +546,10 @@ def build_sglang_talker_request(
         origin_input_ids=input_ids_list,
         sampling_params=sampling_params,
         # Convert hidden states to list-of-lists for Req.input_embeds
-        input_embeds=prefill_embeds_tensor.cpu().tolist(),
+        input_embeds=(
+            None if input_embeds_are_projected
+            else prefill_embeds_tensor.cpu().tolist()
+        ),
         eos_token_ids={int(codec_eos_id)} if codec_eos_id is not None else None,
         vocab_size=codec_vocab_size,
     )
@@ -594,7 +597,7 @@ def build_sglang_talker_request(
         temperature=temperature,
         output_ids=req.output_ids,
         req=req,
-        prefill_input_embeds=prefill_embeds_tensor,
+        prefill_input_embeds=prefill_embeds_tensor if input_embeds_are_projected else None,
     )
     data.suppress_tokens = list(req._codec_suppress_tokens or [])
     data.talker_model_inputs = dict(talker_model_inputs or {})

--- a/sglang_omni/models/qwen3_omni/request_builders.py
+++ b/sglang_omni/models/qwen3_omni/request_builders.py
@@ -493,13 +493,12 @@ def build_sglang_talker_request(
 ) -> "SGLangARRequestData":
     """Build SGLang AR request for the Talker from thinker hidden states.
 
-    Stores thinker hidden states as Req.input_embeds so SGLang's pipeline
-    passes them through ForwardBatch.input_embeds -> model.forward(input_embeds=...).
     Uses dummy input_ids of matching length for position tracking, while the
     request data keeps a device-backed FIFO of future text rows for decode.
 
-    Also stores the original tensor on SGLangARRequestData.prefill_input_embeds
-    so the model runner can skip the list→tensor reconversion during prefill.
+    Stores the original tensor on SGLangARRequestData.prefill_input_embeds
+    when input_embeds_are_projected, so the model runner can skip the
+    list→tensor reconversion during prefill.
 
     Args:
         thinker_hidden_states: Embed layer hidden states [seq_len, hidden_size].

--- a/sglang_omni/models/qwen3_omni/request_builders.py
+++ b/sglang_omni/models/qwen3_omni/request_builders.py
@@ -493,10 +493,9 @@ def build_sglang_talker_request(
 ) -> "SGLangARRequestData":
     """Build SGLang AR request for the Talker from thinker hidden states.
 
-    Keeps embedding tensors GPU-resident on SGLangARRequestData.prefill_input_embeds
-    so the model runner can read them directly without a list round-trip.
-    Uses dummy input_ids of matching length for position tracking, while the
-    request data keeps a device-backed FIFO of future text rows for decode.
+    Populates Req.input_embeds (list-of-lists) to honour the upstream contract,
+    and also stores the original tensor on SGLangARRequestData.prefill_input_embeds
+    so the model runner can skip the list→tensor reconversion.
 
     Args:
         thinker_hidden_states: Embed layer hidden states [seq_len, hidden_size].
@@ -538,7 +537,7 @@ def build_sglang_talker_request(
         origin_input_text="",
         origin_input_ids=input_ids_list,
         sampling_params=sampling_params,
-        input_embeds=None,
+        input_embeds=prefill_embeds_tensor.cpu().tolist(),
         eos_token_ids={int(codec_eos_id)} if codec_eos_id is not None else None,
         vocab_size=codec_vocab_size,
     )

--- a/sglang_omni/models/qwen3_omni/request_builders.py
+++ b/sglang_omni/models/qwen3_omni/request_builders.py
@@ -493,9 +493,13 @@ def build_sglang_talker_request(
 ) -> "SGLangARRequestData":
     """Build SGLang AR request for the Talker from thinker hidden states.
 
-    Populates Req.input_embeds (list-of-lists) to honour the upstream contract,
-    and also stores the original tensor on SGLangARRequestData.prefill_input_embeds
-    so the model runner can skip the list→tensor reconversion.
+    Stores thinker hidden states as Req.input_embeds so SGLang's pipeline
+    passes them through ForwardBatch.input_embeds -> model.forward(input_embeds=...).
+    Uses dummy input_ids of matching length for position tracking, while the
+    request data keeps a device-backed FIFO of future text rows for decode.
+
+    Also stores the original tensor on SGLangARRequestData.prefill_input_embeds
+    so the model runner can skip the list→tensor reconversion during prefill.
 
     Args:
         thinker_hidden_states: Embed layer hidden states [seq_len, hidden_size].
@@ -513,9 +517,13 @@ def build_sglang_talker_request(
         input_ids_list = input_ids_tensor.tolist()
         seq_len = len(input_ids_list)
     else:
+        # thinker_hidden_states: [seq_len, thinker_hidden_size]
         seq_len = thinker_hidden_states.shape[0]
+
+        # Dummy input_ids — codec BOS token repeated for each position
         input_ids_list = [codec_bos_id] * seq_len
         input_ids_tensor = torch.tensor(input_ids_list, dtype=torch.long)
+
         prefill_embeds_tensor = thinker_hidden_states
 
     sampling_params = SamplingParams(
@@ -537,6 +545,7 @@ def build_sglang_talker_request(
         origin_input_text="",
         origin_input_ids=input_ids_list,
         sampling_params=sampling_params,
+        # Convert hidden states to list-of-lists for Req.input_embeds
         input_embeds=prefill_embeds_tensor.cpu().tolist(),
         eos_token_ids={int(codec_eos_id)} if codec_eos_id is not None else None,
         vocab_size=codec_vocab_size,

--- a/sglang_omni/models/qwen3_omni/talker_model_runner.py
+++ b/sglang_omni/models/qwen3_omni/talker_model_runner.py
@@ -166,12 +166,19 @@ class QwenTalkerModelRunner(ModelRunner):
         if not has_projected:
             return None
 
-        input_embeds = forward_batch.input_embeds
         projected_flags = [
             bool(req.data.input_embeds_are_projected) for req in requests
         ]
-        input_embeds_are_projected = bool(projected_flags) and all(projected_flags)
-        if input_embeds is None:
+        has_projected_requests = any(projected_flags)
+        if has_projected_requests and not all(projected_flags):
+            raise RuntimeError(
+                "Talker projected and unprojected prefill requests cannot be "
+                "batched together"
+            )
+
+        input_embeds_are_projected = has_projected_requests
+        input_embeds = forward_batch.input_embeds
+        if has_projected_requests:
             parts: list[torch.Tensor] = []
             for sched_req in requests:
                 req = sched_req.data.req
@@ -188,6 +195,8 @@ class QwenTalkerModelRunner(ModelRunner):
             if not parts:
                 return None
             input_embeds = torch.cat(parts, dim=0)
+        elif input_embeds is None:
+            return None
 
         expected_rows = int(forward_batch.input_ids.shape[0])
         if input_embeds.shape[0] != expected_rows:
@@ -402,7 +411,7 @@ class QwenTalkerModelRunner(ModelRunner):
 
     @staticmethod
     def _append_decode_input_history(data: Any, row: torch.Tensor) -> None:
-        QwenTalkerModelRunner._decode_input_history(data).append(row.detach().clone())
+        QwenTalkerModelRunner._decode_input_history(data).append(row.detach())
 
     @staticmethod
     def _decode_row(

--- a/sglang_omni/models/qwen3_omni/talker_model_runner.py
+++ b/sglang_omni/models/qwen3_omni/talker_model_runner.py
@@ -68,6 +68,9 @@ class QwenTalkerModelRunner(ModelRunner):
         schedule_batch: Any,
         requests: list,
     ) -> None:
+        for sched_req in requests:
+            sched_req.data.prefill_input_embeds = None
+
         if not self._feedback_enabled:
             return
 
@@ -170,20 +173,28 @@ class QwenTalkerModelRunner(ModelRunner):
         ]
         input_embeds_are_projected = bool(projected_flags) and all(projected_flags)
         if input_embeds is None:
-            rows = []
+            parts: list[torch.Tensor] = []
             for sched_req in requests:
-                req = sched_req.data.req
-                embeds = req.input_embeds
-                if embeds:
-                    prefix_len = len(req.prefix_indices)
-                    rows.extend(embeds[prefix_len:])
-            if not rows:
+                tensor = sched_req.data.prefill_input_embeds
+                if tensor is not None:
+                    parts.append(tensor)
+                else:
+                    req = sched_req.data.req
+                    embeds = req.input_embeds
+                    if embeds:
+                        prefix_len = len(req.prefix_indices)
+                        list_rows = embeds[prefix_len:]
+                        if list_rows:
+                            parts.append(
+                                torch.as_tensor(
+                                    list_rows,
+                                    device=forward_batch.input_ids.device,
+                                    dtype=torch.float32,
+                                )
+                            )
+            if not parts:
                 return None
-            input_embeds = torch.as_tensor(
-                rows,
-                device=forward_batch.input_ids.device,
-                dtype=torch.float32,
-            )
+            input_embeds = torch.cat(parts, dim=0)
 
         result = self._forward_with_input_embeds(
             forward_batch,

--- a/sglang_omni/models/qwen3_omni/talker_model_runner.py
+++ b/sglang_omni/models/qwen3_omni/talker_model_runner.py
@@ -185,11 +185,13 @@ class QwenTalkerModelRunner(ModelRunner):
                         prefix_len = len(req.prefix_indices)
                         list_rows = embeds[prefix_len:]
                         if list_rows:
-                            parts.append(torch.as_tensor(
-                                list_rows,
-                                device=forward_batch.input_ids.device,
-                                dtype=torch.float32,
-                            ))
+                            parts.append(
+                                torch.as_tensor(
+                                    list_rows,
+                                    device=forward_batch.input_ids.device,
+                                    dtype=torch.float32,
+                                )
+                            )
             if not parts:
                 return None
             input_embeds = torch.cat(parts, dim=0)

--- a/sglang_omni/models/qwen3_omni/talker_model_runner.py
+++ b/sglang_omni/models/qwen3_omni/talker_model_runner.py
@@ -185,13 +185,11 @@ class QwenTalkerModelRunner(ModelRunner):
                         prefix_len = len(req.prefix_indices)
                         list_rows = embeds[prefix_len:]
                         if list_rows:
-                            parts.append(
-                                torch.as_tensor(
-                                    list_rows,
-                                    device=forward_batch.input_ids.device,
-                                    dtype=torch.float32,
-                                )
-                            )
+                            parts.append(torch.as_tensor(
+                                list_rows,
+                                device=forward_batch.input_ids.device,
+                                dtype=torch.float32,
+                            ))
             if not parts:
                 return None
             input_embeds = torch.cat(parts, dim=0)

--- a/sglang_omni/models/qwen3_omni/talker_model_runner.py
+++ b/sglang_omni/models/qwen3_omni/talker_model_runner.py
@@ -68,9 +68,8 @@ class QwenTalkerModelRunner(ModelRunner):
         schedule_batch: Any,
         requests: list,
     ) -> None:
-        for sched_req in requests:
-            sched_req.data.prefill_input_embeds = None
-
+        # Note (Xuesong): Do not clear data.prefill_input_embeds: decode retract may requeue
+        # the Req for another prefill pass and Req.input_embeds is None.
         if not self._feedback_enabled:
             return
 

--- a/sglang_omni/models/qwen3_omni/talker_model_runner.py
+++ b/sglang_omni/models/qwen3_omni/talker_model_runner.py
@@ -177,26 +177,24 @@ class QwenTalkerModelRunner(ModelRunner):
                 req = sched_req.data.req
                 prefix_len = len(req.prefix_indices)
                 extend_len = int(req.extend_input_len)
-                tensor = sched_req.data.prefill_input_embeds
-                if tensor is not None:
-                    tensor = tensor[prefix_len : prefix_len + extend_len]
-                    if tensor.shape[0] > 0:
-                        parts.append(tensor)
-                else:
-                    embeds = req.input_embeds
-                    if embeds:
-                        list_rows = embeds[prefix_len : prefix_len + extend_len]
-                        if list_rows:
-                            parts.append(
-                                torch.as_tensor(
-                                    list_rows,
-                                    device=forward_batch.input_ids.device,
-                                    dtype=torch.float32,
-                                )
-                            )
+                part = self._projected_prefill_slice(
+                    sched_req=sched_req,
+                    prefix_len=prefix_len,
+                    extend_len=extend_len,
+                    device=forward_batch.input_ids.device,
+                )
+                if part is not None and part.shape[0] > 0:
+                    parts.append(part)
             if not parts:
                 return None
             input_embeds = torch.cat(parts, dim=0)
+
+        expected_rows = int(forward_batch.input_ids.shape[0])
+        if input_embeds.shape[0] != expected_rows:
+            raise RuntimeError(
+                "Talker projected prefill embeds must align with forward input_ids: "
+                f"got {input_embeds.shape[0]} rows for {expected_rows} input ids"
+            )
 
         result = self._forward_with_input_embeds(
             forward_batch,
@@ -204,6 +202,127 @@ class QwenTalkerModelRunner(ModelRunner):
             input_embeds_are_projected=input_embeds_are_projected,
         )
         return result
+
+    @staticmethod
+    def _projected_prefill_slice(
+        *,
+        sched_req: Any,
+        prefix_len: int,
+        extend_len: int,
+        device: torch.device,
+    ) -> torch.Tensor | None:
+        if extend_len <= 0:
+            return None
+
+        data = sched_req.data
+        req = data.req
+        end = prefix_len + extend_len
+        tensor = data.prefill_input_embeds
+        if tensor is not None:
+            prompt_len = int(tensor.shape[0])
+            dtype = tensor.dtype
+            embed_device = tensor.device
+            parts = QwenTalkerModelRunner._prefill_prompt_parts_from_tensor(
+                tensor=tensor,
+                prefix_len=prefix_len,
+                end=end,
+            )
+        else:
+            embeds = req.input_embeds
+            if not embeds:
+                return None
+            prompt_len = len(embeds)
+            dtype = torch.float32
+            embed_device = device
+            parts = QwenTalkerModelRunner._prefill_prompt_parts_from_list(
+                embeds=embeds,
+                prefix_len=prefix_len,
+                end=end,
+                device=device,
+            )
+
+        if end > prompt_len:
+            generated = QwenTalkerModelRunner._generated_prefill_slice(
+                sched_req=sched_req,
+                gen_start=max(prefix_len, prompt_len) - prompt_len,
+                gen_end=end - prompt_len,
+                device=embed_device,
+                dtype=dtype,
+            )
+            if generated is not None:
+                parts.append(generated)
+
+        if not parts:
+            return None
+        return torch.cat(parts, dim=0)
+
+    @staticmethod
+    def _prefill_prompt_parts_from_tensor(
+        *,
+        tensor: torch.Tensor,
+        prefix_len: int,
+        end: int,
+    ) -> list[torch.Tensor]:
+        prompt_len = int(tensor.shape[0])
+        start = min(prefix_len, prompt_len)
+        stop = min(end, prompt_len)
+        return [tensor[start:stop]] if stop > start else []
+
+    @staticmethod
+    def _prefill_prompt_parts_from_list(
+        *,
+        embeds: list,
+        prefix_len: int,
+        end: int,
+        device: torch.device,
+    ) -> list[torch.Tensor]:
+        prompt_len = len(embeds)
+        start = min(prefix_len, prompt_len)
+        stop = min(end, prompt_len)
+        if stop <= start:
+            return []
+        return [
+            torch.as_tensor(
+                embeds[start:stop],
+                device=device,
+                dtype=torch.float32,
+            )
+        ]
+
+    @staticmethod
+    def _generated_prefill_slice(
+        *,
+        sched_req: Any,
+        gen_start: int,
+        gen_end: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> torch.Tensor | None:
+        if gen_end <= gen_start:
+            return None
+
+        data = sched_req.data
+        history = QwenTalkerModelRunner._decode_input_history(data)
+        while len(history) < gen_end:
+            combined = QwenTalkerModelRunner._take_next_decode_input_embed(
+                sched_req=sched_req,
+                device=device,
+                dtype=dtype,
+            )
+            if combined is None:
+                raise RuntimeError(
+                    "Cannot replay retracted talker decode tokens: missing "
+                    "feedback/text input embeds for generated-token prefill"
+                )
+            QwenTalkerModelRunner._append_decode_input_history(data, combined)
+
+        rows = [
+            QwenTalkerModelRunner._decode_row(row, device=device, dtype=dtype)
+            for row in history[gen_start:gen_end]
+        ]
+        if not rows:
+            return None
+        return torch.stack(rows, dim=0)
 
     def _write_feedback_buffers(self, requests: list) -> None:
         batch_size = len(requests)
@@ -224,6 +343,7 @@ class QwenTalkerModelRunner(ModelRunner):
             )
             if combined is None:
                 continue
+            self._append_decode_input_history(sched_req.data, combined)
             rows.append(row_idx)
             embeds.append(combined)
         if rows:
@@ -271,6 +391,18 @@ class QwenTalkerModelRunner(ModelRunner):
         if hasattr(queue, "__getitem__"):
             return queue[0]
         return None
+
+    @staticmethod
+    def _decode_input_history(data: Any) -> list[torch.Tensor]:
+        history = getattr(data, "decode_input_embeds", None)
+        if history is None:
+            history = []
+            data.decode_input_embeds = history
+        return history
+
+    @staticmethod
+    def _append_decode_input_history(data: Any, row: torch.Tensor) -> None:
+        QwenTalkerModelRunner._decode_input_history(data).append(row.detach().clone())
 
     @staticmethod
     def _decode_row(

--- a/sglang_omni/models/qwen3_omni/talker_model_runner.py
+++ b/sglang_omni/models/qwen3_omni/talker_model_runner.py
@@ -177,7 +177,11 @@ class QwenTalkerModelRunner(ModelRunner):
             for sched_req in requests:
                 tensor = sched_req.data.prefill_input_embeds
                 if tensor is not None:
-                    parts.append(tensor)
+                    prefix_len = len(sched_req.data.req.prefix_indices)
+                    if prefix_len > 0:
+                        tensor = tensor[prefix_len:]
+                    if tensor.shape[0] > 0:
+                        parts.append(tensor)
                 else:
                     req = sched_req.data.req
                     embeds = req.input_embeds

--- a/sglang_omni/models/qwen3_omni/talker_model_runner.py
+++ b/sglang_omni/models/qwen3_omni/talker_model_runner.py
@@ -175,19 +175,18 @@ class QwenTalkerModelRunner(ModelRunner):
         if input_embeds is None:
             parts: list[torch.Tensor] = []
             for sched_req in requests:
+                req = sched_req.data.req
+                prefix_len = len(req.prefix_indices)
+                extend_len = int(req.extend_input_len)
                 tensor = sched_req.data.prefill_input_embeds
                 if tensor is not None:
-                    prefix_len = len(sched_req.data.req.prefix_indices)
-                    if prefix_len > 0:
-                        tensor = tensor[prefix_len:]
+                    tensor = tensor[prefix_len : prefix_len + extend_len]
                     if tensor.shape[0] > 0:
                         parts.append(tensor)
                 else:
-                    req = sched_req.data.req
                     embeds = req.input_embeds
                     if embeds:
-                        prefix_len = len(req.prefix_indices)
-                        list_rows = embeds[prefix_len:]
+                        list_rows = embeds[prefix_len : prefix_len + extend_len]
                         if list_rows:
                             parts.append(
                                 torch.as_tensor(

--- a/sglang_omni/models/qwen3_omni/talker_model_runner.py
+++ b/sglang_omni/models/qwen3_omni/talker_model_runner.py
@@ -68,8 +68,9 @@ class QwenTalkerModelRunner(ModelRunner):
         schedule_batch: Any,
         requests: list,
     ) -> None:
-        # Note (Xuesong): Do not clear data.prefill_input_embeds: decode retract may requeue
-        # the Req for another prefill pass and Req.input_embeds is None.
+        for sched_req in requests:
+            sched_req.data.prefill_input_embeds = None
+
         if not self._feedback_enabled:
             return
 

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -134,6 +134,7 @@ class OmniScheduler:
         self.max_total_num_tokens = mr.max_total_num_tokens
         self.max_prefill_tokens = server_args.max_prefill_tokens
         self.max_running_requests = server_args.max_running_requests
+        self.max_queued_requests = server_args.max_queued_requests
         self.max_req_len = min(
             server_args.context_length - 1,
             self.max_total_num_tokens - 1,

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -604,6 +604,9 @@ class OmniScheduler:
             )
             result = self._result_adapter(data)
 
+            data.prefill_input_embeds = None
+            data.decode_input_embeds = None
+
             self.outbox.put(
                 OutgoingMessage(
                     request_id=rid,

--- a/sglang_omni/scheduling/sglang_backend/request_data.py
+++ b/sglang_omni/scheduling/sglang_backend/request_data.py
@@ -23,6 +23,7 @@ class SGLangARRequestData(ARRequestData):
     repetition_penalty: float = 1.0
     input_embeds_are_projected: bool = False
     prefill_input_embeds: "torch.Tensor | None" = None
+    decode_input_embeds: list["torch.Tensor"] = field(default_factory=list)
     stage_payload: Any = None
     talker_model_inputs: dict[str, Any] = field(default_factory=dict)
     pending_feedback_queue: Any = field(default_factory=collections.deque)

--- a/sglang_omni/scheduling/sglang_backend/request_data.py
+++ b/sglang_omni/scheduling/sglang_backend/request_data.py
@@ -22,6 +22,7 @@ class SGLangARRequestData(ARRequestData):
     top_k: int = -1
     repetition_penalty: float = 1.0
     input_embeds_are_projected: bool = False
+    prefill_input_embeds: "torch.Tensor | None" = None
     stage_payload: Any = None
     talker_model_inputs: dict[str, Any] = field(default_factory=dict)
     pending_feedback_queue: Any = field(default_factory=collections.deque)

--- a/tests/README.md
+++ b/tests/README.md
@@ -185,7 +185,9 @@ that happened to contain an older version of the test.
   - memory flag contracts
   - colocation config and SGLang AR budget contracts
   - `PipelineState` request builders
-  - talker behavior
+  - talker behavior, including projected prefill tensor storage/slicing, decode
+    feedback/text FIFO consumption, and replay of generated-token input embeds
+    after decode retract
   - Code2Wav streaming/cleanup behavior
   - logit-shaping helpers (e.g. repetition penalty) numerical equivalence with the original per-row scalar formulas.
 

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -126,6 +126,61 @@ def test_omni_scheduler_default_stream_done_sets_generic_flag() -> None:
     assert req_data.stream_done is True
 
 
+def test_omni_scheduler_initializes_upstream_queue_limit(monkeypatch) -> None:
+    """Upstream requeue helpers read max_queued_requests on OmniScheduler."""
+    monkeypatch.setattr(
+        OmniScheduler, "_init_parallel_state", lambda self, _tp_worker: None
+    )
+    monkeypatch.setattr(
+        OmniScheduler,
+        "init_metrics",
+        lambda self, *_args, **_kwargs: None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "sglang.srt.server_args.get_global_server_args",
+        lambda: SimpleNamespace(pp_max_micro_batch_size=None),
+    )
+    tp_worker = SimpleNamespace(
+        gpu_id=0,
+        tp_rank=0,
+        model_runner=SimpleNamespace(max_total_num_tokens=128),
+        random_seed=0,
+        device=torch.device("cpu"),
+    )
+    server_args = SimpleNamespace(
+        tp_size=1,
+        pp_size=1,
+        page_size=1,
+        max_prefill_tokens=32,
+        max_running_requests=2,
+        max_queued_requests=7,
+        context_length=128,
+        chunked_prefill_size=0,
+        enable_mixed_chunk=False,
+        schedule_policy="fcfs",
+        enable_hierarchical_cache=False,
+        enable_priority_scheduling=False,
+        schedule_low_priority_values_first=False,
+        priority_scheduling_preemption_threshold=0,
+        schedule_conservativeness=1.0,
+        enable_metrics=False,
+        enable_metrics_for_all_schedulers=False,
+    )
+
+    scheduler = OmniScheduler(
+        tp_worker=tp_worker,
+        tree_cache=None,
+        req_to_token_pool=None,
+        token_to_kv_pool_allocator=None,
+        server_args=server_args,
+        model_config=SimpleNamespace(),
+    )
+
+    assert scheduler.max_queued_requests == 7
+    assert scheduler._abort_on_queued_limit(object()) is False
+
+
 def test_stage_output_cache_eviction_uses_lru_order() -> None:
     cache = StageOutputCache(max_size=2)
 

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -360,6 +360,7 @@ def test_qwen_model_runner_and_code_predictor_tensor_contracts() -> None:
     assert sampled.shape == (2, 1)
     assert sampled[:, 0].tolist() == [2, 0]
 
+
 @pytest.fixture()
 def _patch_sampling(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
@@ -457,6 +458,7 @@ def test_post_prefill_clears_prefill_embeds() -> None:
         requests=[sched_req],
     )
     assert sched_req.data.prefill_input_embeds is None
+
 
 @pytest.mark.benchmark
 @pytest.mark.usefixtures("_patch_sampling")

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -567,10 +567,11 @@ def test_projected_prefill_full_prefix_hit_returns_none() -> None:
     assert result is None
 
 
-def test_post_prefill_clears_prefill_embeds() -> None:
-    """post_prefill releases the prefill_input_embeds reference."""
+def test_post_prefill_preserves_prefill_embeds_for_retract() -> None:
+    """post_prefill keeps prefill_input_embeds so retract can re-prefill."""
+    embeds = torch.randn(4, 8)
     sched_req = _sched_req(
-        prefill_input_embeds=torch.randn(4, 8),
+        prefill_input_embeds=embeds,
         pending_feedback_queue=deque(),
         pending_text_queue=deque(),
         tts_pad_embed=None,
@@ -586,7 +587,58 @@ def test_post_prefill_clears_prefill_embeds() -> None:
         schedule_batch=None,
         requests=[sched_req],
     )
-    assert sched_req.data.prefill_input_embeds is None
+    assert sched_req.data.prefill_input_embeds is embeds
+
+
+def test_projected_prefill_survives_decode_retract() -> None:
+    """Re-prefill after a simulated decode retract still feeds projected embeds."""
+    full_embeds = torch.randn(10, 64)
+    sched_req = _sched_req(
+        input_embeds_are_projected=True,
+        prefill_input_embeds=full_embeds,
+        req=SimpleNamespace(
+            input_embeds=None,
+            prefix_indices=[],
+            extend_input_len=10,
+        ),
+        pending_feedback_queue=deque(),
+        pending_text_queue=deque(),
+        tts_pad_embed=None,
+        thinker_chunks_done=True,
+    )
+    forward_batch = SimpleNamespace(
+        input_embeds=None,
+        input_ids=torch.zeros(10, dtype=torch.long),
+    )
+
+    runner = object.__new__(QwenTalkerModelRunner)
+    runner._feedback_enabled = False
+    runner._forward_with_input_embeds = (
+        lambda self, fb, *, input_embeds, **kw: SimpleNamespace(
+            next_token_ids=None, logits_output=None, _embeds=input_embeds
+        )
+    ).__get__(runner)
+
+    first = runner._run_projected_prefill_forward(
+        forward_batch, schedule_batch=None, requests=[sched_req]
+    )
+    assert torch.equal(first._embeds, full_embeds)
+
+    runner.post_prefill(
+        first,
+        forward_batch=None,
+        schedule_batch=None,
+        requests=[sched_req],
+    )
+
+    sched_req.data.req.prefix_indices = []
+    sched_req.data.req.extend_input_len = 10
+
+    second = runner._run_projected_prefill_forward(
+        forward_batch, schedule_batch=None, requests=[sched_req]
+    )
+    assert second is not None, "retract+re-prefill must not silently lose embeds"
+    assert torch.equal(second._embeds, full_embeds)
 
 
 @pytest.mark.benchmark

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -392,8 +392,7 @@ class TestBuildTalkerRequestTensorStorage:
         )
 
         assert data.prefill_input_embeds is embeds
-        assert isinstance(data.req.input_embeds, list)
-        assert len(data.req.input_embeds) == seq_len
+        assert data.req.input_embeds is None
         assert data.input_embeds_are_projected is True
 
     def test_hidden_states_path(self) -> None:
@@ -406,7 +405,7 @@ class TestBuildTalkerRequestTensorStorage:
             codec_vocab_size=4096,
         )
 
-        assert data.prefill_input_embeds is hidden_states
+        assert data.prefill_input_embeds is None
         assert isinstance(data.req.input_embeds, list)
         assert len(data.req.input_embeds) == seq_len
 
@@ -436,6 +435,58 @@ def test_projected_prefill_reads_tensor_from_data() -> None:
     )
 
     assert torch.equal(result._embeds, embeds)
+
+
+def test_projected_prefill_slices_tensor_by_prefix_indices() -> None:
+    """Tensor path slices by prefix_indices, matching the list fallback."""
+    full_embeds = torch.randn(10, 64)
+    prefix_len = 3
+    sched_req = _sched_req(
+        input_embeds_are_projected=True,
+        prefill_input_embeds=full_embeds,
+        req=SimpleNamespace(input_embeds=None, prefix_indices=list(range(prefix_len))),
+    )
+    forward_batch = SimpleNamespace(
+        input_embeds=None,
+        input_ids=torch.zeros(7, dtype=torch.long),
+    )
+
+    runner = object.__new__(QwenTalkerModelRunner)
+    runner._forward_with_input_embeds = (
+        lambda self, fb, *, input_embeds, **kw: SimpleNamespace(
+            next_token_ids=None, logits_output=None, _embeds=input_embeds
+        )
+    ).__get__(runner)
+
+    result = runner._run_projected_prefill_forward(
+        forward_batch, schedule_batch=None, requests=[sched_req]
+    )
+
+    expected = full_embeds[prefix_len:]
+    assert result._embeds.shape == expected.shape
+    assert torch.equal(result._embeds, expected)
+
+
+def test_projected_prefill_full_prefix_hit_returns_none() -> None:
+    """Full prefix hit produces no embeds, method returns None."""
+    embeds = torch.randn(5, 64)
+    sched_req = _sched_req(
+        input_embeds_are_projected=True,
+        prefill_input_embeds=embeds,
+        req=SimpleNamespace(input_embeds=None, prefix_indices=list(range(5))),
+    )
+    forward_batch = SimpleNamespace(
+        input_embeds=None,
+        input_ids=torch.zeros(0, dtype=torch.long),
+    )
+
+    runner = object.__new__(QwenTalkerModelRunner)
+
+    result = runner._run_projected_prefill_forward(
+        forward_batch, schedule_batch=None, requests=[sched_req]
+    )
+
+    assert result is None
 
 
 def test_post_prefill_clears_prefill_embeds() -> None:

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -624,11 +624,10 @@ def test_projected_prefill_full_prefix_hit_returns_none() -> None:
     assert result is None
 
 
-def test_post_prefill_preserves_prefill_embeds_for_retract() -> None:
-    """post_prefill keeps prefill_input_embeds so retract can re-prefill."""
-    embeds = torch.randn(4, 8)
+def test_post_prefill_clears_prefill_embeds() -> None:
+    """post_prefill releases the prefill_input_embeds reference."""
     sched_req = _sched_req(
-        prefill_input_embeds=embeds,
+        prefill_input_embeds=torch.randn(4, 8),
         pending_feedback_queue=deque(),
         pending_text_queue=deque(),
         tts_pad_embed=None,
@@ -644,58 +643,7 @@ def test_post_prefill_preserves_prefill_embeds_for_retract() -> None:
         schedule_batch=None,
         requests=[sched_req],
     )
-    assert sched_req.data.prefill_input_embeds is embeds
-
-
-def test_projected_prefill_survives_decode_retract() -> None:
-    """Re-prefill after a simulated decode retract still feeds projected embeds."""
-    full_embeds = torch.randn(10, 64)
-    sched_req = _sched_req(
-        input_embeds_are_projected=True,
-        prefill_input_embeds=full_embeds,
-        req=SimpleNamespace(
-            input_embeds=None,
-            prefix_indices=[],
-            extend_input_len=10,
-        ),
-        pending_feedback_queue=deque(),
-        pending_text_queue=deque(),
-        tts_pad_embed=None,
-        thinker_chunks_done=True,
-    )
-    forward_batch = SimpleNamespace(
-        input_embeds=None,
-        input_ids=torch.zeros(10, dtype=torch.long),
-    )
-
-    runner = object.__new__(QwenTalkerModelRunner)
-    runner._feedback_enabled = False
-    runner._forward_with_input_embeds = (
-        lambda self, fb, *, input_embeds, **kw: SimpleNamespace(
-            next_token_ids=None, logits_output=None, _embeds=input_embeds
-        )
-    ).__get__(runner)
-
-    first = runner._run_projected_prefill_forward(
-        forward_batch, schedule_batch=None, requests=[sched_req]
-    )
-    assert torch.equal(first._embeds, full_embeds)
-
-    runner.post_prefill(
-        first,
-        forward_batch=None,
-        schedule_batch=None,
-        requests=[sched_req],
-    )
-
-    sched_req.data.req.prefix_indices = []
-    sched_req.data.req.extend_input_len = 10
-
-    second = runner._run_projected_prefill_forward(
-        forward_batch, schedule_batch=None, requests=[sched_req]
-    )
-    assert second is not None, "retract+re-prefill must not silently lose embeds"
-    assert torch.equal(second._embeds, full_embeds)
+    assert sched_req.data.prefill_input_embeds is None
 
 
 def test_write_feedback_buffers_records_decode_input_history() -> None:

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -416,7 +416,7 @@ def test_projected_prefill_reads_tensor_from_data() -> None:
     sched_req = _sched_req(
         input_embeds_are_projected=True,
         prefill_input_embeds=embeds,
-        req=SimpleNamespace(input_embeds=None, prefix_indices=[]),
+        req=SimpleNamespace(input_embeds=None, prefix_indices=[], extend_input_len=10),
     )
     forward_batch = SimpleNamespace(
         input_embeds=None,
@@ -444,7 +444,11 @@ def test_projected_prefill_slices_tensor_by_prefix_indices() -> None:
     sched_req = _sched_req(
         input_embeds_are_projected=True,
         prefill_input_embeds=full_embeds,
-        req=SimpleNamespace(input_embeds=None, prefix_indices=list(range(prefix_len))),
+        req=SimpleNamespace(
+            input_embeds=None,
+            prefix_indices=list(range(prefix_len)),
+            extend_input_len=7,
+        ),
     )
     forward_batch = SimpleNamespace(
         input_embeds=None,
@@ -467,13 +471,85 @@ def test_projected_prefill_slices_tensor_by_prefix_indices() -> None:
     assert torch.equal(result._embeds, expected)
 
 
+def test_projected_prefill_slices_tensor_by_extend_input_len() -> None:
+    """Tensor path slices by prefix and extend length, matching SGLang prefill."""
+    full_embeds = torch.randn(10, 64)
+    prefix_len = 3
+    extend_len = 4
+    sched_req = _sched_req(
+        input_embeds_are_projected=True,
+        prefill_input_embeds=full_embeds,
+        req=SimpleNamespace(
+            input_embeds=None,
+            prefix_indices=list(range(prefix_len)),
+            extend_input_len=extend_len,
+        ),
+    )
+    forward_batch = SimpleNamespace(
+        input_embeds=None,
+        input_ids=torch.zeros(extend_len, dtype=torch.long),
+    )
+
+    runner = object.__new__(QwenTalkerModelRunner)
+    runner._forward_with_input_embeds = (
+        lambda self, fb, *, input_embeds, **kw: SimpleNamespace(
+            next_token_ids=None, logits_output=None, _embeds=input_embeds
+        )
+    ).__get__(runner)
+
+    result = runner._run_projected_prefill_forward(
+        forward_batch, schedule_batch=None, requests=[sched_req]
+    )
+
+    expected = full_embeds[prefix_len : prefix_len + extend_len]
+    assert result._embeds.shape == expected.shape
+    assert torch.equal(result._embeds, expected)
+
+
+def test_projected_prefill_list_fallback_slices_by_extend_input_len() -> None:
+    """List fallback keeps the same prefill slice contract as the tensor path."""
+    full_embeds = torch.randn(10, 64)
+    prefix_len = 2
+    extend_len = 5
+    sched_req = _sched_req(
+        input_embeds_are_projected=True,
+        prefill_input_embeds=None,
+        req=SimpleNamespace(
+            input_embeds=full_embeds.tolist(),
+            prefix_indices=list(range(prefix_len)),
+            extend_input_len=extend_len,
+        ),
+    )
+    forward_batch = SimpleNamespace(
+        input_embeds=None,
+        input_ids=torch.zeros(extend_len, dtype=torch.long),
+    )
+
+    runner = object.__new__(QwenTalkerModelRunner)
+    runner._forward_with_input_embeds = (
+        lambda self, fb, *, input_embeds, **kw: SimpleNamespace(
+            next_token_ids=None, logits_output=None, _embeds=input_embeds
+        )
+    ).__get__(runner)
+
+    result = runner._run_projected_prefill_forward(
+        forward_batch, schedule_batch=None, requests=[sched_req]
+    )
+
+    expected = full_embeds[prefix_len : prefix_len + extend_len]
+    assert result._embeds.shape == expected.shape
+    assert torch.allclose(result._embeds, expected)
+
+
 def test_projected_prefill_full_prefix_hit_returns_none() -> None:
     """Full prefix hit produces no embeds, method returns None."""
     embeds = torch.randn(5, 64)
     sched_req = _sched_req(
         input_embeds_are_projected=True,
         prefill_input_embeds=embeds,
-        req=SimpleNamespace(input_embeds=None, prefix_indices=list(range(5))),
+        req=SimpleNamespace(
+            input_embeds=None, prefix_indices=list(range(5)), extend_input_len=0
+        ),
     )
     forward_batch = SimpleNamespace(
         input_embeds=None,

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -16,8 +16,10 @@ from sglang_omni.models.qwen3_omni.pending_text_queue import (
     PendingTextTensorQueue,
     coerce_pending_text_queue,
 )
+from sglang_omni.models.qwen3_omni.request_builders import build_sglang_talker_request
 from sglang_omni.models.qwen3_omni.talker_model_runner import QwenTalkerModelRunner
 from sglang_omni.models.qwen3_omni.talker_scheduler import QwenTalkerScheduler
+from tests.unit_test.fixtures.qwen_fakes import FakeQwenTokenizer
 
 
 def _sched_req(**data_kwargs: object) -> SimpleNamespace:
@@ -356,3 +358,112 @@ def test_qwen_model_runner_and_code_predictor_tensor_contracts() -> None:
     sampled = Qwen3OmniTalker._sample_code_predictor_token(logits)
     assert sampled.shape == (2, 1)
     assert sampled[:, 0].tolist() == [2, 0]
+
+
+def _patch_sglang_sampling(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "sglang.srt.sampling.sampling_params.SamplingParams.normalize",
+        lambda self, tokenizer: None,
+    )
+    monkeypatch.setattr(
+        "sglang.srt.sampling.sampling_params.SamplingParams.verify",
+        lambda self, vocab_size: None,
+    )
+
+
+def test_build_talker_request_stores_tensor_via_projected_embeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Projected talker embeds are kept as a tensor, not converted to a list."""
+    _patch_sglang_sampling(monkeypatch)
+
+    seq_len, hidden = 64, 128
+    talker_embeds = torch.randn(seq_len, hidden)
+    talker_ids = torch.arange(seq_len, dtype=torch.long)
+
+    data = build_sglang_talker_request(
+        thinker_hidden_states=torch.empty(0),
+        tokenizer=FakeQwenTokenizer(),
+        codec_vocab_size=4096,
+        talker_input_embeds=talker_embeds,
+        talker_input_ids=talker_ids,
+        input_embeds_are_projected=True,
+    )
+
+    assert data.prefill_input_embeds is talker_embeds
+    assert data.req.input_embeds is None
+    assert data.input_embeds_are_projected is True
+    assert data.input_ids.shape == (seq_len,)
+
+
+def test_build_talker_request_stores_tensor_via_hidden_states(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Thinker hidden states path also keeps the tensor on data, not Req."""
+    _patch_sglang_sampling(monkeypatch)
+
+    seq_len, hidden = 32, 256
+    hidden_states = torch.randn(seq_len, hidden)
+
+    data = build_sglang_talker_request(
+        thinker_hidden_states=hidden_states,
+        tokenizer=FakeQwenTokenizer(),
+        codec_vocab_size=4096,
+    )
+
+    assert data.prefill_input_embeds is hidden_states
+    assert data.req.input_embeds is None
+    assert data.input_ids.shape == (seq_len,)
+
+
+def test_projected_prefill_reads_tensor_from_data() -> None:
+    """Model runner reads prefill_input_embeds from request data, not Req."""
+    embeds = torch.randn(10, 64)
+    sched_req = _sched_req(
+        input_embeds_are_projected=True,
+        prefill_input_embeds=embeds,
+        req=SimpleNamespace(input_embeds=None, prefix_indices=[]),
+    )
+    forward_batch = SimpleNamespace(
+        input_embeds=None,
+        input_ids=torch.zeros(10, dtype=torch.long),
+    )
+
+    captured: dict[str, torch.Tensor] = {}
+    orig_forward = QwenTalkerModelRunner._forward_with_input_embeds
+
+    def capture_forward(self, forward_batch, *, input_embeds, **kwargs):
+        captured["input_embeds"] = input_embeds
+        return SimpleNamespace(next_token_ids=None, logits_output=None)
+
+    runner = object.__new__(QwenTalkerModelRunner)
+    runner._forward_with_input_embeds = capture_forward.__get__(runner)
+
+    runner._run_projected_prefill_forward(
+        forward_batch, schedule_batch=None, requests=[sched_req]
+    )
+
+    assert "input_embeds" in captured
+    assert torch.equal(captured["input_embeds"], embeds)
+
+
+def test_post_prefill_clears_prefill_embeds() -> None:
+    """post_prefill releases the prefill_input_embeds reference."""
+    embeds = torch.randn(4, 8)
+    sched_req = _sched_req(
+        prefill_input_embeds=embeds,
+        pending_feedback_queue=deque(),
+        pending_text_queue=deque(),
+        tts_pad_embed=None,
+        thinker_chunks_done=True,
+    )
+
+    runner = object.__new__(QwenTalkerModelRunner)
+    runner._feedback_enabled = False
+
+    result = SimpleNamespace(next_token_ids=None)
+    runner.post_prefill(
+        result, forward_batch=None, schedule_batch=None, requests=[sched_req]
+    )
+
+    assert sched_req.data.prefill_input_embeds is None

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections import deque
 from types import SimpleNamespace
 
@@ -359,65 +360,58 @@ def test_qwen_model_runner_and_code_predictor_tensor_contracts() -> None:
     assert sampled.shape == (2, 1)
     assert sampled[:, 0].tolist() == [2, 0]
 
-
-def _patch_sglang_sampling(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture()
+def _patch_sampling(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "sglang.srt.sampling.sampling_params.SamplingParams.normalize",
-        lambda self, tokenizer: None,
+        lambda _self, _tok: None,
     )
     monkeypatch.setattr(
         "sglang.srt.sampling.sampling_params.SamplingParams.verify",
-        lambda self, vocab_size: None,
+        lambda _self, _vs: None,
     )
 
 
-def test_build_talker_request_stores_tensor_via_projected_embeds(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Projected talker embeds are kept as a tensor, not converted to a list."""
-    _patch_sglang_sampling(monkeypatch)
+@pytest.mark.usefixtures("_patch_sampling")
+class TestBuildTalkerRequestTensorStorage:
+    """build_sglang_talker_request stores the tensor and honours the Req list contract."""
 
-    seq_len, hidden = 64, 128
-    talker_embeds = torch.randn(seq_len, hidden)
-    talker_ids = torch.arange(seq_len, dtype=torch.long)
+    def test_projected_embeds_path(self) -> None:
+        seq_len, hidden = 64, 128
+        embeds = torch.randn(seq_len, hidden)
+        ids = torch.arange(seq_len, dtype=torch.long)
 
-    data = build_sglang_talker_request(
-        thinker_hidden_states=torch.empty(0),
-        tokenizer=FakeQwenTokenizer(),
-        codec_vocab_size=4096,
-        talker_input_embeds=talker_embeds,
-        talker_input_ids=talker_ids,
-        input_embeds_are_projected=True,
-    )
+        data = build_sglang_talker_request(
+            thinker_hidden_states=torch.empty(0),
+            tokenizer=FakeQwenTokenizer(),
+            codec_vocab_size=4096,
+            talker_input_embeds=embeds,
+            talker_input_ids=ids,
+            input_embeds_are_projected=True,
+        )
 
-    assert data.prefill_input_embeds is talker_embeds
-    assert data.req.input_embeds is None
-    assert data.input_embeds_are_projected is True
-    assert data.input_ids.shape == (seq_len,)
+        assert data.prefill_input_embeds is embeds
+        assert isinstance(data.req.input_embeds, list)
+        assert len(data.req.input_embeds) == seq_len
+        assert data.input_embeds_are_projected is True
 
+    def test_hidden_states_path(self) -> None:
+        seq_len, hidden = 32, 256
+        hidden_states = torch.randn(seq_len, hidden)
 
-def test_build_talker_request_stores_tensor_via_hidden_states(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Thinker hidden states path also keeps the tensor on data, not Req."""
-    _patch_sglang_sampling(monkeypatch)
+        data = build_sglang_talker_request(
+            thinker_hidden_states=hidden_states,
+            tokenizer=FakeQwenTokenizer(),
+            codec_vocab_size=4096,
+        )
 
-    seq_len, hidden = 32, 256
-    hidden_states = torch.randn(seq_len, hidden)
-
-    data = build_sglang_talker_request(
-        thinker_hidden_states=hidden_states,
-        tokenizer=FakeQwenTokenizer(),
-        codec_vocab_size=4096,
-    )
-
-    assert data.prefill_input_embeds is hidden_states
-    assert data.req.input_embeds is None
-    assert data.input_ids.shape == (seq_len,)
+        assert data.prefill_input_embeds is hidden_states
+        assert isinstance(data.req.input_embeds, list)
+        assert len(data.req.input_embeds) == seq_len
 
 
 def test_projected_prefill_reads_tensor_from_data() -> None:
-    """Model runner reads prefill_input_embeds from request data, not Req."""
+    """Model runner reads prefill_input_embeds, not Req.input_embeds."""
     embeds = torch.randn(10, 64)
     sched_req = _sched_req(
         input_embeds_are_projected=True,
@@ -429,29 +423,24 @@ def test_projected_prefill_reads_tensor_from_data() -> None:
         input_ids=torch.zeros(10, dtype=torch.long),
     )
 
-    captured: dict[str, torch.Tensor] = {}
-    orig_forward = QwenTalkerModelRunner._forward_with_input_embeds
-
-    def capture_forward(self, forward_batch, *, input_embeds, **kwargs):
-        captured["input_embeds"] = input_embeds
-        return SimpleNamespace(next_token_ids=None, logits_output=None)
-
     runner = object.__new__(QwenTalkerModelRunner)
-    runner._forward_with_input_embeds = capture_forward.__get__(runner)
+    runner._forward_with_input_embeds = (
+        lambda self, fb, *, input_embeds, **kw: SimpleNamespace(
+            next_token_ids=None, logits_output=None, _embeds=input_embeds
+        )
+    ).__get__(runner)
 
-    runner._run_projected_prefill_forward(
+    result = runner._run_projected_prefill_forward(
         forward_batch, schedule_batch=None, requests=[sched_req]
     )
 
-    assert "input_embeds" in captured
-    assert torch.equal(captured["input_embeds"], embeds)
+    assert torch.equal(result._embeds, embeds)
 
 
 def test_post_prefill_clears_prefill_embeds() -> None:
     """post_prefill releases the prefill_input_embeds reference."""
-    embeds = torch.randn(4, 8)
     sched_req = _sched_req(
-        prefill_input_embeds=embeds,
+        prefill_input_embeds=torch.randn(4, 8),
         pending_feedback_queue=deque(),
         pending_text_queue=deque(),
         tts_pad_embed=None,
@@ -461,9 +450,39 @@ def test_post_prefill_clears_prefill_embeds() -> None:
     runner = object.__new__(QwenTalkerModelRunner)
     runner._feedback_enabled = False
 
-    result = SimpleNamespace(next_token_ids=None)
     runner.post_prefill(
-        result, forward_batch=None, schedule_batch=None, requests=[sched_req]
+        SimpleNamespace(next_token_ids=None),
+        forward_batch=None,
+        schedule_batch=None,
+        requests=[sched_req],
     )
-
     assert sched_req.data.prefill_input_embeds is None
+
+@pytest.mark.benchmark
+@pytest.mark.usefixtures("_patch_sampling")
+@pytest.mark.parametrize("seq_len", [256, 2048, 4096])
+def test_build_talker_request_wall_clock(seq_len: int) -> None:
+    """Wall-clock for request build at representative seq_lens."""
+    embeds = torch.randn(seq_len, 2048)
+    ids = torch.arange(seq_len, dtype=torch.long)
+    tokenizer = FakeQwenTokenizer()
+
+    def _build():
+        return build_sglang_talker_request(
+            thinker_hidden_states=torch.empty(0),
+            tokenizer=tokenizer,
+            codec_vocab_size=4096,
+            talker_input_embeds=embeds,
+            talker_input_ids=ids,
+            input_embeds_are_projected=True,
+        )
+
+    for _ in range(3):
+        _build()
+
+    t0 = time.perf_counter()
+    for _ in range(20):
+        _build()
+    mean_ms = (time.perf_counter() - t0) / 20 * 1000
+
+    print(f"\n[seq_len={seq_len}] mean={mean_ms:.2f}ms  floats={seq_len * 2048:,}")

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -393,6 +393,7 @@ class TestBuildTalkerRequestTensorStorage:
 
         assert data.prefill_input_embeds is embeds
         assert data.req.input_embeds is None
+        assert data.req._input_embeds_are_projected is True
         assert data.input_embeds_are_projected is True
 
     def test_hidden_states_path(self) -> None:
@@ -408,6 +409,7 @@ class TestBuildTalkerRequestTensorStorage:
         assert data.prefill_input_embeds is None
         assert isinstance(data.req.input_embeds, list)
         assert len(data.req.input_embeds) == seq_len
+        assert data.req._input_embeds_are_projected is False
 
 
 def test_projected_prefill_reads_tensor_from_data() -> None:

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -641,6 +641,88 @@ def test_projected_prefill_survives_decode_retract() -> None:
     assert torch.equal(second._embeds, full_embeds)
 
 
+def test_write_feedback_buffers_records_decode_input_history() -> None:
+    """Decode inputs consumed by the feedback buffer are replayable after retract."""
+    feedback_buffer = torch.zeros(1, 2)
+    feedback_mask = torch.zeros(1, dtype=torch.bool)
+    sched_req = _sched_req(
+        pending_feedback_queue=deque([torch.tensor([1.0, 2.0])]),
+        pending_text_queue=deque([torch.tensor([20.0, 30.0])]),
+        decode_input_embeds=[],
+    )
+
+    runner = object.__new__(QwenTalkerModelRunner)
+    runner.model = SimpleNamespace(
+        _feedback_buffer=feedback_buffer,
+        _feedback_mask=feedback_mask,
+    )
+
+    runner._write_feedback_buffers([sched_req])
+
+    assert feedback_mask.tolist() == [True]
+    assert torch.equal(feedback_buffer[0], torch.tensor([21.0, 32.0]))
+    assert len(sched_req.data.decode_input_embeds) == 1
+    assert torch.equal(
+        sched_req.data.decode_input_embeds[0],
+        torch.tensor([21.0, 32.0]),
+    )
+
+
+def test_projected_prefill_retract_replays_generated_decode_inputs() -> None:
+    """Retracted prefill can span prompt suffix and generated codec tokens."""
+    full_embeds = torch.arange(20, dtype=torch.float32).reshape(10, 2)
+    decode_history = [
+        torch.tensor([100.0, 101.0]),
+        torch.tensor([200.0, 201.0]),
+    ]
+    sched_req = _sched_req(
+        input_embeds_are_projected=True,
+        prefill_input_embeds=full_embeds,
+        decode_input_embeds=decode_history,
+        pending_feedback_queue=deque([torch.tensor([3.0, 4.0])]),
+        pending_text_queue=deque([torch.tensor([30.0, 40.0])]),
+        req=SimpleNamespace(
+            input_embeds=None,
+            prefix_indices=list(range(8)),
+            extend_input_len=5,
+            output_ids=[11, 12, 13],
+        ),
+    )
+    forward_batch = SimpleNamespace(
+        input_embeds=None,
+        input_ids=torch.zeros(5, dtype=torch.long),
+    )
+
+    runner = object.__new__(QwenTalkerModelRunner)
+    runner._forward_with_input_embeds = (
+        lambda self, fb, *, input_embeds, **kw: SimpleNamespace(
+            next_token_ids=None, logits_output=None, _embeds=input_embeds
+        )
+    ).__get__(runner)
+
+    result = runner._run_projected_prefill_forward(
+        forward_batch, schedule_batch=None, requests=[sched_req]
+    )
+
+    expected = torch.cat(
+        [
+            full_embeds[8:10],
+            torch.stack(
+                [
+                    torch.tensor([100.0, 101.0]),
+                    torch.tensor([200.0, 201.0]),
+                    torch.tensor([33.0, 44.0]),
+                ]
+            ),
+        ],
+        dim=0,
+    )
+    assert torch.equal(result._embeds, expected)
+    assert len(sched_req.data.decode_input_embeds) == 3
+    assert len(sched_req.data.pending_feedback_queue) == 0
+    assert len(sched_req.data.pending_text_queue) == 0
+
+
 @pytest.mark.benchmark
 @pytest.mark.usefixtures("_patch_sampling")
 @pytest.mark.parametrize("seq_len", [256, 2048, 4096])

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -543,6 +543,63 @@ def test_projected_prefill_list_fallback_slices_by_extend_input_len() -> None:
     assert torch.allclose(result._embeds, expected)
 
 
+def test_projected_prefill_prefers_request_data_over_forward_embeds() -> None:
+    """Projected rows live on request data, not ForwardBatch.input_embeds."""
+    embeds = torch.randn(4, 8)
+    stale_forward_embeds = torch.full((2, 8), -1.0)
+    sched_req = _sched_req(
+        input_embeds_are_projected=True,
+        prefill_input_embeds=embeds,
+        req=SimpleNamespace(input_embeds=None, prefix_indices=[], extend_input_len=4),
+    )
+    forward_batch = SimpleNamespace(
+        input_embeds=stale_forward_embeds,
+        input_ids=torch.zeros(4, dtype=torch.long),
+    )
+
+    runner = object.__new__(QwenTalkerModelRunner)
+    runner._forward_with_input_embeds = (
+        lambda self, fb, *, input_embeds, **kw: SimpleNamespace(
+            next_token_ids=None, logits_output=None, _embeds=input_embeds
+        )
+    ).__get__(runner)
+
+    result = runner._run_projected_prefill_forward(
+        forward_batch, schedule_batch=None, requests=[sched_req]
+    )
+
+    assert torch.equal(result._embeds, embeds)
+
+
+def test_projected_prefill_rejects_mixed_projected_and_list_batch() -> None:
+    """The model forward has one projection mode, so mixed batches are invalid."""
+    projected_req = _sched_req(
+        input_embeds_are_projected=True,
+        prefill_input_embeds=torch.randn(2, 8),
+        req=SimpleNamespace(input_embeds=None, prefix_indices=[], extend_input_len=2),
+    )
+    list_req = _sched_req(
+        input_embeds_are_projected=False,
+        prefill_input_embeds=None,
+        req=SimpleNamespace(
+            input_embeds=torch.randn(2, 8).tolist(),
+            prefix_indices=[],
+            extend_input_len=2,
+        ),
+    )
+    forward_batch = SimpleNamespace(
+        input_embeds=torch.randn(2, 8),
+        input_ids=torch.zeros(4, dtype=torch.long),
+    )
+
+    runner = object.__new__(QwenTalkerModelRunner)
+
+    with pytest.raises(RuntimeError, match="cannot be batched together"):
+        runner._run_projected_prefill_forward(
+            forward_batch, schedule_batch=None, requests=[projected_req, list_req]
+        )
+
+
 def test_projected_prefill_full_prefix_hit_returns_none() -> None:
     """Full prefix hit produces no embeds, method returns None."""
     embeds = torch.randn(5, 64)

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -624,10 +624,11 @@ def test_projected_prefill_full_prefix_hit_returns_none() -> None:
     assert result is None
 
 
-def test_post_prefill_clears_prefill_embeds() -> None:
-    """post_prefill releases the prefill_input_embeds reference."""
+def test_post_prefill_preserves_prefill_embeds_for_retract() -> None:
+    """post_prefill keeps prefill_input_embeds so retract can re-prefill."""
+    embeds = torch.randn(4, 8)
     sched_req = _sched_req(
-        prefill_input_embeds=torch.randn(4, 8),
+        prefill_input_embeds=embeds,
         pending_feedback_queue=deque(),
         pending_text_queue=deque(),
         tts_pad_embed=None,
@@ -643,7 +644,58 @@ def test_post_prefill_clears_prefill_embeds() -> None:
         schedule_batch=None,
         requests=[sched_req],
     )
-    assert sched_req.data.prefill_input_embeds is None
+    assert sched_req.data.prefill_input_embeds is embeds
+
+
+def test_projected_prefill_survives_decode_retract() -> None:
+    """Re-prefill after a simulated decode retract still feeds projected embeds."""
+    full_embeds = torch.randn(10, 64)
+    sched_req = _sched_req(
+        input_embeds_are_projected=True,
+        prefill_input_embeds=full_embeds,
+        req=SimpleNamespace(
+            input_embeds=None,
+            prefix_indices=[],
+            extend_input_len=10,
+        ),
+        pending_feedback_queue=deque(),
+        pending_text_queue=deque(),
+        tts_pad_embed=None,
+        thinker_chunks_done=True,
+    )
+    forward_batch = SimpleNamespace(
+        input_embeds=None,
+        input_ids=torch.zeros(10, dtype=torch.long),
+    )
+
+    runner = object.__new__(QwenTalkerModelRunner)
+    runner._feedback_enabled = False
+    runner._forward_with_input_embeds = (
+        lambda self, fb, *, input_embeds, **kw: SimpleNamespace(
+            next_token_ids=None, logits_output=None, _embeds=input_embeds
+        )
+    ).__get__(runner)
+
+    first = runner._run_projected_prefill_forward(
+        forward_batch, schedule_batch=None, requests=[sched_req]
+    )
+    assert torch.equal(first._embeds, full_embeds)
+
+    runner.post_prefill(
+        first,
+        forward_batch=None,
+        schedule_batch=None,
+        requests=[sched_req],
+    )
+
+    sched_req.data.req.prefix_indices = []
+    sched_req.data.req.extend_input_len = 10
+
+    second = runner._run_projected_prefill_forward(
+        forward_batch, schedule_batch=None, requests=[sched_req]
+    )
+    assert second is not None, "retract+re-prefill must not silently lose embeds"
+    assert torch.equal(second._embeds, full_embeds)
 
 
 def test_write_feedback_buffers_records_decode_input_history() -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->
## Motivation
This PR is for #484. The old path allocates ~8M Python floats at seq_len=4096 with hidden_dim=2048 via `.cpu().tolist()`, then immediately converts them back to a GPU tensor via `torch.as_tensor`. This is wasted work when the model runner already has access to the original tensor.

## Modifications
Drop the GPU->list->GPU round-trip from the Qwen3-Omni talker request-build path. The prefill embedding tensor is now carried on `SGLangARRequestData.prefill_input_embeds` so the model runner reads it directly, skipping the `.cpu().tolist()` materialization and the subsequent `torch.as_tensor` reconversion.

**`request_builders.py`**
- Removed `.cpu().tolist()` on the projected-embeds path -- `Req.input_embeds` is set to `None` when `input_embeds_are_projected=True`
- Stored the original GPU tensor on `data.prefill_input_embeds` (projected path only)

**`talker_model_runner.py`**
- Primary path in `_run_projected_prefill_forward`: reads tensor from `data.prefill_input_embeds`, slices by `prefix_indices`
- Fallback: reads from `Req.input_embeds` (list path, for non-projected embeds)
- `post_prefill` frees the tensor reference to release GPU memory

**`request_data.py`**
- Added `prefill_input_embeds: torch.Tensor | None` field to `SGLangARRequestData`

**`test_talker.py`** -- 7 new tests:
- Tensor storage for projected and hidden-states paths
- Model runner reads tensor, not list
- Prefix-indices slicing on tensor path
- Full prefix hit returns None
- GPU memory freed after prefill
- Wall-clock microbenchmark (parametrized by seq_len)

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->
#484 

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

Run with 1x H200.

### Wall-Clock: `build_sglang_talker_request` (CPU, no GPU)

Measures the time to execute `build_sglang_talker_request()` end-to-end. The function converts thinker hidden states into a talker request object. Cost is dominated by `.cpu().tolist()` (copying floats from tensor into nested Python lists).

**Method:** 20 iterations, first 5 dropped as warmup. Input: `torch.randn(seq_len, 2048)` passed as `thinker_hidden_states`.

| seq_len | Main (ms) | Feature (ms) | Delta |
|---------|-----------|-------------|-------|
| 256 | 19.70 | 19.50 | -1.0% |
| 2048 | 236.96 | 238.39 | +0.6% |
| 4096 | 475.07 | 482.75 | +1.6% |

Build cost is unchanged since both branches still do `.cpu().tolist()` for `Req.input_embeds`. The PR's savings happen later — during model runner prefill where the tensor is read directly from `prefill_input_embeds`, avoiding the list→tensor reconversion.

### TTFT + ITL (colocated, 1 GPU)

Server topology: `sgl-omni serve --colocate` on a single H200 GPU. Each request gets a unique prompt prefix (`[N] ...`) to bust SGLang's prefix cache — no cache hits between requests.

max_tokens=2048, n=20, warmup=3, concurrency=16:

| Metric | Main | Feature | Delta |
|--------|------|---------|-------|
| TTFT mean | 35.790s | 35.892s | +0.3% |
| TTFT median | 39.801s | 40.056s | +0.6% |
| TTFT p95 | 40.011s | 40.267s | +0.6% |
| TTFT p99 | 40.011s | 40.267s | +0.6% |
| ITL mean | 341.1ms | 345.6ms | +1.3% |
| ITL median | 370.5ms | 382.0ms | +3.1% |
| ITL p95 | 473.1ms | 484.9ms | +2.5% |
| ITL p99 | 644.0ms | 632.9ms | -1.7% |
| Total mean | 175.327s | 177.233s | +1.1% |

**Conclusion:** No meaningful regression. All differences are within run-to-run noise. The end-to-end latency is dominated by model inference, not request building. The PR avoids one tensor→list→tensor round-trip during prefill and drops a wasted `.float()` upcast.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Draft PRs are skipped even if labeled.
