### PR TITLE
docs: clarify installation options and fix misleading comment

### DIFF
--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -1,15 +1,17 @@
 # 🚀 Get Started
 
-## 📦 Installation
+Choose one of the following methods to set up your environment. We highly recommend using Docker for development or production environment.
 
-We highly recommend to use our [Docker Image](#🐳-use-docker) for development or production environment. Otherwise, please make sure you have built and installed [`ucx`](https://github.com/openucx/ucx) in your environment.
+## 📦 Option 1: Installation
+
+Please make sure you have built and installed [`ucx`](https://github.com/openucx/ucx) in your environment.
 
 ```bash
 # clone this repository
 git clone git@github.com:sgl-project/sglang-omni.git
 cd sglang-omni
 
-# create a virtual environment in docker
+# create a virtual environment
 uv venv .venv -p 3.12
 source .venv/bin/activate
 
@@ -20,8 +22,7 @@ uv pip install -v .
 uv pip install -v -e .
 ```
 
-
-## 🐳 Use Docker
+## 🐳 Option 2: Use Docker
 
 We have build all necessary dependencies into our Docker Image, so you can simply pull and run it.
 


### PR DESCRIPTION
## Motivation
The current installation guide does not clearly indicate that "Installation" and "Use Docker" are two alternative methods. This caused confusion for new users who may attempt to follow both sections.

## Modifications
- Add a sentence at the top clarifying that the two sections are alternative setup methods, and recommend Docker for development or production
- Rename sections to "Option 1: Installation" and "Option 2: Use Docker"
- Fix misleading comment "create a virtual environment in docker" (this section does not use Docker)
- Move Docker recommendation sentence to the top for better clarity

## Related Issues
N/A