### PR TITLE
[Fix] align Ming benchmark plumbing

### DIFF
--- a/sglang_omni/client/client.py
+++ b/sglang_omni/client/client.py
@@ -315,6 +315,9 @@ class Client:
                 text = decode_result.get("text")
                 if isinstance(text, str):
                     chunk.text = text
+                finish_reason = decode_result.get("finish_reason")
+                if finish_reason is not None:
+                    chunk.finish_reason = finish_reason
                 Client._set_audio_data(chunk, audio_result)
                 chunk.usage = Client._build_usage_info(
                     decode_result

--- a/sglang_omni/models/ming_omni/bootstrap.py
+++ b/sglang_omni/models/ming_omni/bootstrap.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from sglang_omni.models.ming_omni.pipeline.sampling import build_ming_sampling_params
+
 logger = logging.getLogger(__name__)
 
 
@@ -107,7 +109,6 @@ def make_thinker_scheduler_adapters(
 
     def request_builder(payload):
         from sglang.srt.managers.schedule_batch import Req
-        from sglang.srt.sampling.sampling_params import SamplingParams
 
         from sglang_omni.models.ming_omni.io import PipelineState
         from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
@@ -153,14 +154,11 @@ def make_thinker_scheduler_adapters(
         input_ids_list = input_ids.to(dtype=_torch_long()).flatten().tolist()
 
         params = payload.request.params or {}
-        max_new_tokens = params.get("max_new_tokens", 2048)
-        temperature = params.get("temperature", 0.0)
-        sampling_params = SamplingParams(
-            max_new_tokens=max_new_tokens,
-            temperature=temperature,
+        sampling_params, max_new_tokens, temperature = build_ming_sampling_params(
+            params,
+            tokenizer=tokenizer,
+            vocab_size=vocab_size,
         )
-        sampling_params.normalize(tokenizer)
-        sampling_params.verify(vocab_size)
 
         eos_token_ids = _collect_eos_token_ids(tokenizer)
         req = Req(

--- a/sglang_omni/models/ming_omni/components/talker_executor.py
+++ b/sglang_omni/models/ming_omni/components/talker_executor.py
@@ -23,11 +23,17 @@ from pathlib import Path
 
 import torch
 
+from sglang_omni.models.ming_omni.pipeline.usage import build_text_usage
 from sglang_omni.proto import StagePayload
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_VOICE = "DB30"
+
+
+def _build_talker_usage(payload: StagePayload) -> dict[str, int]:
+    data = payload.data if isinstance(payload.data, dict) else {}
+    return build_text_usage(data)
 
 
 class MingTalkerExecutor:
@@ -186,7 +192,13 @@ class MingTalkerExecutor:
             result = StagePayload(
                 request_id=request_id,
                 request=payload.request,
-                data={"audio_waveform": None, "sample_rate": 44100, "duration": 0.0},
+                data={
+                    "audio_waveform": None,
+                    "sample_rate": 44100,
+                    "duration": 0.0,
+                    "modality": "audio",
+                    "usage": _build_talker_usage(payload),
+                },
             )
             await self._results.put(result)
             return
@@ -220,6 +232,8 @@ class MingTalkerExecutor:
                 "audio_waveform_shape": waveform_shape,
                 "sample_rate": sample_rate,
                 "duration": duration,
+                "modality": "audio",
+                "usage": _build_talker_usage(payload),
             },
         )
         await self._results.put(result)
@@ -262,6 +276,7 @@ class MingTalkerExecutor:
                 "sample_rate": 44100,
                 "duration": 0.0,
                 "skipped": True,
+                "usage": _build_talker_usage(payload),
             },
         )
 

--- a/sglang_omni/models/ming_omni/pipeline/engine_io.py
+++ b/sglang_omni/models/ming_omni/pipeline/engine_io.py
@@ -9,6 +9,7 @@ import torch
 
 from sglang_omni.engines.omni.runtime import ARRequestData, EncoderRequestData
 from sglang_omni.models.ming_omni.io import PipelineState, ThinkerOutput
+from sglang_omni.models.ming_omni.pipeline.sampling import build_ming_sampling_params
 
 if TYPE_CHECKING:
     from sglang_omni.engines.omni.runtime.sglang_ar import SGLangARRequestData
@@ -103,7 +104,6 @@ def build_sglang_thinker_request(
     Ming uses standard 1D RoPE (no M-RoPE), so no special position computation needed.
     """
     from sglang.srt.managers.schedule_batch import Req
-    from sglang.srt.sampling.sampling_params import SamplingParams
 
     from sglang_omni.engines.omni.runtime.sglang_ar import SGLangARRequestData
 
@@ -128,15 +128,11 @@ def build_sglang_thinker_request(
     capture_keys = thinker_inputs.get("capture_model_output_keys", ())
     model_inputs.pop("attention_mask", None)
 
-    max_new_tokens = params.get("max_new_tokens", 2048)
-    temperature = params.get("temperature", 0.0)
-
-    sampling_params = SamplingParams(
-        max_new_tokens=max_new_tokens,
-        temperature=temperature,
+    sampling_params, max_new_tokens, temperature = build_ming_sampling_params(
+        params,
+        tokenizer=tokenizer,
+        vocab_size=vocab_size,
     )
-    sampling_params.normalize(tokenizer)
-    sampling_params.verify(vocab_size)
 
     eos_token_id = getattr(tokenizer, "eos_token_id", None)
     eos_token_ids = {eos_token_id} if eos_token_id is not None else None

--- a/sglang_omni/models/ming_omni/pipeline/sampling.py
+++ b/sglang_omni/models/ming_omni/pipeline/sampling.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Sampling helpers for Ming-Omni thinker requests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_ming_sampling_kwargs(params: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "max_new_tokens": params.get("max_new_tokens", 2048),
+        "temperature": params.get("temperature", 0.0),
+        "top_p": params.get("top_p", 1.0),
+        "top_k": params.get("top_k", -1),
+        "min_p": params.get("min_p", 0.0),
+        "repetition_penalty": params.get("repetition_penalty", 1.0),
+        "stop": params.get("stop") or [],
+        "stop_token_ids": params.get("stop_token_ids") or [],
+        "sampling_seed": params.get("seed"),
+    }
+
+
+def build_ming_sampling_params(
+    params: dict[str, Any],
+    *,
+    tokenizer: Any,
+    vocab_size: int,
+):
+    from sglang.srt.sampling.sampling_params import SamplingParams
+
+    kwargs = build_ming_sampling_kwargs(params)
+    sampling_params = SamplingParams(**kwargs)
+    sampling_params.normalize(tokenizer)
+    sampling_params.verify(vocab_size)
+    return sampling_params, kwargs["max_new_tokens"], kwargs["temperature"]

--- a/sglang_omni/models/ming_omni/pipeline/usage.py
+++ b/sglang_omni/models/ming_omni/pipeline/usage.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Usage accounting helpers for Ming-Omni pipeline outputs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def _mapping_get(value: Any, key: str, default: Any = None) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(key, default)
+    return getattr(value, key, default)
+
+
+def _count_ids(ids: Any) -> int:
+    if ids is None:
+        return 0
+    if hasattr(ids, "numel"):
+        return int(ids.numel())
+    try:
+        return len(ids)
+    except TypeError:
+        return 0
+
+
+def build_text_usage(
+    state: Any,
+    thinker_out: Mapping[str, Any] | None = None,
+) -> dict[str, int]:
+    """Build OpenAI-style token usage for Ming thinker text generation."""
+
+    prompt = _mapping_get(state, "prompt", None)
+
+    resolved_thinker_out = thinker_out
+    if resolved_thinker_out is None:
+        candidate = _mapping_get(state, "thinker_out", None)
+        resolved_thinker_out = candidate if isinstance(candidate, Mapping) else {}
+
+    prompt_tokens = _count_ids(_mapping_get(prompt, "input_ids"))
+    completion_tokens = _count_ids(resolved_thinker_out.get("output_ids"))
+    return {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": prompt_tokens + completion_tokens,
+    }

--- a/sglang_omni/models/ming_omni/stages.py
+++ b/sglang_omni/models/ming_omni/stages.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from sglang_omni.models.ming_omni.io import PipelineState
 from sglang_omni.models.ming_omni.pipeline.next_stage import AUDIO_STAGE, IMAGE_STAGE
+from sglang_omni.models.ming_omni.pipeline.usage import build_text_usage
 from sglang_omni.proto import StagePayload
 
 
@@ -87,6 +88,17 @@ def _single_encoder_stage_name(state: PipelineState) -> str:
             f"Expected exactly one encoder output in payload, got {sorted(state.encoder_outs)}"
         )
     return next(iter(state.encoder_outs))
+
+
+def _attach_decode_final_metadata(
+    result: dict[str, Any],
+    state: PipelineState,
+    thinker_out: dict[str, Any],
+) -> None:
+    finish_reason = thinker_out.get("finish_reason")
+    if finish_reason is not None:
+        result.setdefault("finish_reason", finish_reason)
+    result.setdefault("usage", build_text_usage(state, thinker_out))
 
 
 def create_preprocessing_executor(model_path: str):
@@ -303,6 +315,7 @@ def create_decode_executor(model_path: str):
                 result["text"] = tokenizer.decode(output_ids, skip_special_tokens=True)
                 result.setdefault("modality", "text")
 
+        _attach_decode_final_metadata(result, state, thinker_out)
         payload.data = result
         return payload
 

--- a/tests/unit_test/ming_omni/test_pipeline.py
+++ b/tests/unit_test/ming_omni/test_pipeline.py
@@ -460,3 +460,28 @@ def test_ming_init_model_config_registers_auto_config_before_loading(
     worker._init_model_config()
 
     assert call_order == ["register", "from_server_args"]
+
+
+def test_ming_decode_metadata_includes_usage_and_finish_reason() -> None:
+    from sglang_omni.models.ming_omni.io import PipelineState
+    from sglang_omni.models.ming_omni.stages import _attach_decode_final_metadata
+
+    class TensorLike:
+        def numel(self) -> int:
+            return 5
+
+    state = PipelineState(prompt={"input_ids": TensorLike()})
+    thinker_out = {
+        "output_ids": [10, 11, 12],
+        "finish_reason": "length",
+    }
+    result: dict[str, object] = {}
+
+    _attach_decode_final_metadata(result, state, thinker_out)
+
+    assert result["finish_reason"] == "length"
+    assert result["usage"] == {
+        "prompt_tokens": 5,
+        "completion_tokens": 3,
+        "total_tokens": 8,
+    }

--- a/tests/unit_test/ming_omni/test_sampling_params.py
+++ b/tests/unit_test/ming_omni/test_sampling_params.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ming thinker sampling parameter forwarding tests."""
+
+from __future__ import annotations
+
+
+def test_ming_sampling_kwargs_forward_request_controls() -> None:
+    from sglang_omni.models.ming_omni.pipeline.sampling import (
+        build_ming_sampling_kwargs,
+    )
+
+    kwargs = build_ming_sampling_kwargs(
+        {
+            "max_new_tokens": 33,
+            "temperature": 0.7,
+            "top_p": 0.8,
+            "top_k": 40,
+            "min_p": 0.05,
+            "repetition_penalty": 1.1,
+            "stop": ["\n\n", "Answer:"],
+            "stop_token_ids": [123, 456],
+            "seed": 99,
+        }
+    )
+
+    assert kwargs == {
+        "max_new_tokens": 33,
+        "temperature": 0.7,
+        "top_p": 0.8,
+        "top_k": 40,
+        "min_p": 0.05,
+        "repetition_penalty": 1.1,
+        "stop": ["\n\n", "Answer:"],
+        "stop_token_ids": [123, 456],
+        "sampling_seed": 99,
+    }
+
+
+def test_ming_sampling_kwargs_match_qwen3_defaults_when_absent() -> None:
+    from sglang_omni.models.ming_omni.pipeline.sampling import (
+        build_ming_sampling_kwargs,
+    )
+
+    kwargs = build_ming_sampling_kwargs({})
+
+    assert kwargs == {
+        "max_new_tokens": 2048,
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "top_k": -1,
+        "min_p": 0.0,
+        "repetition_penalty": 1.0,
+        "stop": [],
+        "stop_token_ids": [],
+        "sampling_seed": None,
+    }

--- a/tests/unit_test/ming_omni/test_talker.py
+++ b/tests/unit_test/ming_omni/test_talker.py
@@ -137,6 +137,7 @@ def test_default_result_builder_merges_decode_and_talker_audio() -> None:
         {
             "decode": {
                 "text": "hi",
+                "finish_reason": "length",
                 "usage": {"prompt_tokens": 2, "completion_tokens": 1},
             },
             "talker": _waveform_payload(waveform),
@@ -144,6 +145,7 @@ def test_default_result_builder_merges_decode_and_talker_audio() -> None:
     )
 
     assert chunk.text == "hi"
+    assert chunk.finish_reason == "length"
     assert chunk.modality == "audio"
     assert chunk.sample_rate == 44100
     np.testing.assert_array_equal(chunk.audio_data, waveform)
@@ -197,3 +199,74 @@ def test_default_result_builder_still_merges_decode_and_code2wav_audio() -> None
     assert chunk.usage.prompt_tokens == 5
     assert chunk.usage.completion_tokens == 7
     assert chunk.usage.total_tokens == 12
+
+
+def test_ming_talker_audio_result_includes_modality_and_text_usage(monkeypatch) -> None:
+    module_name = "sglang_omni.models.ming_omni.components.talker_executor"
+    parent_name = "sglang_omni.models.ming_omni.components"
+    sys.modules.pop(module_name, None)
+
+    fake_torch = ModuleType("torch")
+    fake_torch.bfloat16 = "bfloat16"
+    fake_torch.Tensor = object
+
+    def no_grad():
+        def decorator(fn):
+            return fn
+
+        return decorator
+
+    fake_torch.no_grad = no_grad
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    try:
+        module = importlib.import_module(module_name)
+        from sglang_omni.proto import OmniRequest, StagePayload
+
+        class TensorLike:
+            def numel(self) -> int:
+                return 4
+
+        class FakeWaveform:
+            def cpu(self):
+                return self
+
+            def float(self):
+                return self
+
+            def numpy(self):
+                return np.array([0.1, -0.1], dtype=np.float32)
+
+        executor = module.MingTalkerExecutor(model_path="/fake/model/path")
+        payload = StagePayload(
+            request_id="req-audio",
+            request=OmniRequest(inputs=[]),
+            data={
+                "prompt": {"input_ids": TensorLike()},
+                "thinker_out": {"output_ids": [1, 2, 3]},
+            },
+        )
+        monkeypatch.setattr(executor, "_extract_text", lambda _payload: "hello")
+        monkeypatch.setattr(
+            executor,
+            "_generate_speech",
+            lambda _text: (FakeWaveform(), 44100, 0.2),
+        )
+
+        async def run_request():
+            await executor.add_request(payload)
+            return await executor.get_result()
+
+        result = asyncio.run(run_request())
+
+        assert result.data["modality"] == "audio"
+        assert result.data["usage"] == {
+            "prompt_tokens": 4,
+            "completion_tokens": 3,
+            "total_tokens": 7,
+        }
+    finally:
+        sys.modules.pop(module_name, None)
+        parent = sys.modules.get(parent_name)
+        if parent is not None and hasattr(parent, "talker_executor"):
+            delattr(parent, "talker_executor")

--- a/tests/unit_test/ming_omni/test_usage.py
+++ b/tests/unit_test/ming_omni/test_usage.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ming usage accounting tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+class _TensorLike:
+    def __init__(self, n: int):
+        self._n = n
+
+    def numel(self) -> int:
+        return self._n
+
+
+def test_build_text_usage_counts_tensor_prompt_and_output_ids() -> None:
+    from sglang_omni.models.ming_omni.pipeline.usage import build_text_usage
+
+    state = SimpleNamespace(
+        prompt={"input_ids": _TensorLike(11)},
+        thinker_out={"output_ids": [101, 102, 103]},
+    )
+
+    assert build_text_usage(state) == {
+        "prompt_tokens": 11,
+        "completion_tokens": 3,
+        "total_tokens": 14,
+    }
+
+
+def test_build_text_usage_counts_attribute_prompt_input_ids() -> None:
+    from sglang_omni.models.ming_omni.io import PipelineState
+    from sglang_omni.models.ming_omni.pipeline.usage import build_text_usage
+
+    class PromptObject:
+        input_ids = _TensorLike(11)
+
+    state = PipelineState(
+        prompt=PromptObject(),  # type: ignore[arg-type]
+        thinker_out={"output_ids": [101, 102, 103]},
+    )
+
+    assert build_text_usage(state) == {
+        "prompt_tokens": 11,
+        "completion_tokens": 3,
+        "total_tokens": 14,
+    }
+
+
+def test_build_text_usage_counts_list_prompt_and_explicit_thinker_out() -> None:
+    from sglang_omni.models.ming_omni.pipeline.usage import build_text_usage
+
+    state = {"prompt": {"input_ids": [1, 2, 3, 4]}, "thinker_out": {}}
+    thinker_out = {"output_ids": [8, 9]}
+
+    assert build_text_usage(state, thinker_out) == {
+        "prompt_tokens": 4,
+        "completion_tokens": 2,
+        "total_tokens": 6,
+    }
+
+
+def test_build_text_usage_defaults_missing_ids_to_zero() -> None:
+    from sglang_omni.models.ming_omni.pipeline.usage import build_text_usage
+
+    assert build_text_usage({}) == {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+    }


### PR DESCRIPTION
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Fix Ming-Omni benchmark plumbing gaps on the existing chat/text path so OpenAI-compatible responses expose token usage, finish reasons, and forwarded sampling/stop controls consistently with the Qwen3-Omni reference path.

## Modifications

<!-- Describe the changes made in this PR. -->

- Add shared Ming helpers for text-token usage accounting and thinker sampling parameter construction.
- Attach `usage` and `finish_reason` to Ming decode final results.
- Preserve decode `finish_reason` when merging decode + talker/code2wav terminal results.
- Add talker audio `modality: "audio"` and fallback text-token usage metadata.
- Forward Ming thinker request controls for `top_p`, `top_k`, `min_p`, `repetition_penalty`, `seed`, `stop`, and `stop_token_ids`.
- Add focused unit coverage for usage accounting, decode metadata, audio merge metadata, talker metadata, and sampling kwargs.

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

N/A

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

Not run. This PR changes API/pipeline metadata plumbing and request parameter forwarding; it does not change model architecture, kernels, or weights. Real GPU benchmark validation is still needed before marking ready.

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

Not run. Expected performance impact is negligible; this adds response metadata and forwards existing request parameters. Local validation:

- `uv run --no-sync pre-commit run --files ...`
- `uv run --no-sync pytest tests/unit_test/ming_omni -q` (`48 passed`)
- `uv run --no-sync pytest tests/unit_test/serve/test_openai_api.py -q` (`1 passed`)
- `uv run --no-sync pytest tests/unit_test/qwen3_omni/test_streaming.py -q` (`24 passed`)
- `uv run --no-sync python -m compileall -q sglang_omni/models/ming_omni sglang_omni/client tests/unit_test/ming_omni`
- `git diff --check -- . ':!.gitignore' ':!.agents'`

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Draft PRs are skipped even if labeled.
