### PR TITLE
[Qwen3]: Route preprocessing through active encoder branches

### DIFF
--- a/docs/developer_reference/config.md
+++ b/docs/developer_reference/config.md
@@ -81,6 +81,7 @@ stages = [
 | `tp_size` | `int` | `1` | Number of tensor-parallel ranks. Must match `len(gpu)` when `gpu` is a list. |
 | `process` | `str` or `None` | `None` | OS process group identifier. Non-TP stages with the same `process` value share a single OS process; today every non-TP stage must declare one explicitly (see also `_validate_general`). For TP stages, `process` is optional and acts as a prefix for the derived rank-process names (`{process}_tp{rank}`); if unset, the stage name is used as the prefix. |
 | `wait_for` | `list[str]` or `None` | `None` | Upstream stages required before this stage can execute a request. |
+| `wait_for_fn` | `str` or `None` | `None` | Dotted function path for request-aware fan-in source selection. The function receives `(request_id, from_stage, payload)` and returns the active subset of `wait_for`, or `None` when the payload does not determine the subset yet. |
 | `merge_fn` | `str` or `None` | `None` | Dotted import path to the fan-in merge function. Required when `wait_for` is set. |
 | `stream_to` | `list[str]` | `[]` | Static superset of streaming targets for chunks such as hidden states or codec codes. This is parallel to normal result routing. |
 | `stream_done_to_fn` | `str` or `None` | `None` | Dotted function path for request-aware stream-completion targets. The function receives `(request_id, stage_output)` and returns the active subset of `stream_to` targets that should receive the final done signal. |
@@ -91,6 +92,11 @@ Routing rule: set exactly one of `next` or `terminal=True`. `route_fn` is an
 optional request-aware override for stages that already declare `next`; keep
 `next` as the static topology declaration for validation. `route_fn` is not
 valid on terminal stages and must return downstream stage targets, not `None`.
+Fan-in follows the same static-superset pattern: keep `wait_for` as the full set
+of possible upstream stages, and use `wait_for_fn` only to select the active
+per-request subset. The returned subset must be non-empty and contained in
+`wait_for`; returning `None` keeps the request pending until another upstream
+payload can resolve the active set.
 When using `stream_done_to_fn`, keep `stream_to` as the static superset because
 runtime prep derives stream receivers and same-GPU stream paths from it.
 

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -163,6 +163,7 @@ class StageConfig(BaseModel):
 
     # --- Fan-in ---
     wait_for: list[str] | None = None
+    wait_for_fn: str | None = None
     merge_fn: str | None = None
 
     # --- Streaming ---
@@ -299,6 +300,8 @@ class PipelineConfig(BaseModel):
                     raise ValueError(
                         f"Stage {s.name!r} wait_for has unknown stages: {sorted(unknown)}"
                     )
+            elif s.wait_for_fn is not None:
+                raise ValueError(f"Stage {s.name!r} has wait_for_fn but no wait_for")
             if s.next is not None:
                 targets = [s.next] if isinstance(s.next, str) else s.next
                 unknown = set(targets) - set(names)

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -24,6 +24,7 @@ def _preprocessing_stage(*, process: str) -> StageConfig:
             "video_fps": "video_fps",
         },
         next=["image_encoder", "audio_encoder", "mm_aggregate"],
+        route_fn=f"{_PKG}.request_builders.resolve_preprocessing_next_stages",
         project_payload={
             "image_encoder": (
                 f"{_PKG}.request_builders.project_preprocessing_to_image_encoder"
@@ -72,6 +73,7 @@ def _aggregate_stage(*, process: str) -> StageConfig:
         process=process,
         factory=f"{_PKG}.stages.create_aggregate_executor",
         wait_for=["preprocessing", "image_encoder", "audio_encoder"],
+        wait_for_fn=f"{_PKG}.request_builders.resolve_mm_aggregate_wait_sources",
         merge_fn=f"{_PKG}.merge.merge_for_thinker",
         next="thinker",
     )

--- a/sglang_omni/models/qwen3_omni/request_builders.py
+++ b/sglang_omni/models/qwen3_omni/request_builders.py
@@ -27,6 +27,7 @@ AUDIO_STAGE = "audio_encoder"
 DECODE_STAGE = "decode"
 TALKER_STAGE = "talker_ar"
 CODE2WAV_STAGE = "code2wav"
+MM_AGGREGATE_STAGE = "mm_aggregate"
 
 
 def output_modalities(request: OmniRequest | None) -> set[str] | None:
@@ -79,6 +80,26 @@ def resolve_terminal_stages(request: OmniRequest) -> list[str]:
     if should_generate_audio_output(request):
         return [DECODE_STAGE, CODE2WAV_STAGE]
     return [DECODE_STAGE]
+
+
+def resolve_preprocessing_next_stages(
+    request_id: str, output: StagePayload
+) -> list[str]:
+    del request_id
+    state = PipelineState.from_dict(output.data)
+    return [*_active_encoder_stages(state.encoder_inputs), MM_AGGREGATE_STAGE]
+
+
+def resolve_mm_aggregate_wait_sources(
+    request_id: str,
+    from_stage: str,
+    payload: StagePayload,
+) -> list[str] | None:
+    del request_id
+    if from_stage != "preprocessing":
+        return None
+    state = PipelineState.from_dict(payload.data)
+    return ["preprocessing", *_active_encoder_stages(state.encoder_inputs)]
 
 
 @dataclass(slots=True)
@@ -215,9 +236,29 @@ def _project_encoder_input_metadata(
             stage_metadata["cache_key"] = cache_key
         if stage_inputs.get("_skip"):
             stage_metadata["_skip"] = True
+        elif _is_active_encoder_input(stage_inputs):
+            stage_metadata["_active"] = True
         if stage_metadata:
             projected[stage_name] = stage_metadata
     return projected
+
+
+def _active_encoder_stages(
+    encoder_inputs: dict[str, dict[str, Any]],
+) -> list[str]:
+    return [
+        stage_name
+        for stage_name in (IMAGE_STAGE, AUDIO_STAGE)
+        if _is_active_encoder_input(encoder_inputs.get(stage_name))
+    ]
+
+
+def _is_active_encoder_input(stage_inputs: Any) -> bool:
+    return (
+        isinstance(stage_inputs, dict)
+        and bool(stage_inputs)
+        and not bool(stage_inputs.get("_skip"))
+    )
 
 
 def _select_present_fields(

--- a/sglang_omni/models/qwen3_omni/request_builders.py
+++ b/sglang_omni/models/qwen3_omni/request_builders.py
@@ -87,7 +87,10 @@ def resolve_preprocessing_next_stages(
 ) -> list[str]:
     del request_id
     state = PipelineState.from_dict(output.data)
-    return [*_active_encoder_stages(state.encoder_inputs), MM_AGGREGATE_STAGE]
+    return [
+        *_encoder_stages_with_model_inputs(state.encoder_inputs),
+        MM_AGGREGATE_STAGE,
+    ]
 
 
 def resolve_mm_aggregate_wait_sources(
@@ -124,7 +127,9 @@ def build_encoder_request(
             skip_result=skip_result if isinstance(skip_result, dict) else {},
         )
     cache_key = inputs.get("cache_key")
-    model_inputs = {k: v for k, v in inputs.items() if k != "cache_key"}
+    model_inputs = {
+        k: v for k, v in inputs.items() if k not in ("cache_key", "_active")
+    }
     return EncoderRequestData(
         model_inputs=model_inputs,
         cache_key=str(cache_key) if cache_key is not None else None,
@@ -236,11 +241,21 @@ def _project_encoder_input_metadata(
             stage_metadata["cache_key"] = cache_key
         if stage_inputs.get("_skip"):
             stage_metadata["_skip"] = True
-        elif _is_active_encoder_input(stage_inputs):
+        elif _is_active_encoder_branch(stage_name, stage_inputs):
             stage_metadata["_active"] = True
         if stage_metadata:
             projected[stage_name] = stage_metadata
     return projected
+
+
+def _encoder_stages_with_model_inputs(
+    encoder_inputs: dict[str, dict[str, Any]],
+) -> list[str]:
+    return [
+        stage_name
+        for stage_name in (IMAGE_STAGE, AUDIO_STAGE)
+        if _has_encoder_model_input(stage_name, encoder_inputs.get(stage_name))
+    ]
 
 
 def _active_encoder_stages(
@@ -249,16 +264,32 @@ def _active_encoder_stages(
     return [
         stage_name
         for stage_name in (IMAGE_STAGE, AUDIO_STAGE)
-        if _is_active_encoder_input(encoder_inputs.get(stage_name))
+        if _is_active_encoder_branch(stage_name, encoder_inputs.get(stage_name))
     ]
 
 
-def _is_active_encoder_input(stage_inputs: Any) -> bool:
-    return (
-        isinstance(stage_inputs, dict)
-        and bool(stage_inputs)
-        and not bool(stage_inputs.get("_skip"))
-    )
+def _is_active_encoder_branch(stage_name: str, stage_inputs: Any) -> bool:
+    if not isinstance(stage_inputs, dict) or stage_inputs.get("_skip"):
+        return False
+    active_marker = stage_inputs.get("_active")
+    if active_marker is not None:
+        return active_marker is True
+    return _has_encoder_model_input(stage_name, stage_inputs)
+
+
+def _has_encoder_model_input(stage_name: str, stage_inputs: Any) -> bool:
+    if not isinstance(stage_inputs, dict) or stage_inputs.get("_skip"):
+        return False
+    if stage_inputs.get("_active") is False:
+        return False
+    if stage_name == IMAGE_STAGE:
+        return (
+            stage_inputs.get("pixel_values") is not None
+            or stage_inputs.get("pixel_values_videos") is not None
+        )
+    if stage_name == AUDIO_STAGE:
+        return stage_inputs.get("input_features") is not None
+    return False
 
 
 def _select_present_fields(

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -83,6 +83,7 @@ def _build_stage_groups(
             route_fn=stage_cfg.route_fn,
             is_terminal=stage_cfg.terminal,
             wait_for=stage_cfg.wait_for,
+            wait_for_fn=stage_cfg.wait_for_fn,
             merge_fn=stage_cfg.merge_fn,
             project_payload={
                 name_map.get(target, target): dotted_path

--- a/sglang_omni/pipeline/stage/input.py
+++ b/sglang_omni/pipeline/stage/input.py
@@ -3,11 +3,14 @@
 
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from typing import Any, Callable
 
 from sglang_omni.proto import StagePayload
 
 logger = logging.getLogger(__name__)
+
+ExpectedSourcesFn = Callable[[str, str, StagePayload], str | Iterable[str] | None]
 
 
 class InputHandler(ABC):
@@ -43,10 +46,13 @@ class AggregatedInput(InputHandler):
         self,
         sources: set[str],
         merge: Callable[[dict[str, StagePayload]], StagePayload],
+        expected_sources_fn: ExpectedSourcesFn | None = None,
     ):
         self._sources = sources
         self._merge = merge
+        self._expected_sources_fn = expected_sources_fn
         self._pending: dict[str, dict[str, Any]] = {}
+        self._expected_sources: dict[str, set[str]] = {}
 
     def receive(
         self, request_id: str, from_stage: str, data: Any
@@ -63,11 +69,72 @@ class AggregatedInput(InputHandler):
             self._pending[request_id] = {}
         self._pending[request_id][from_stage] = data
 
-        if set(self._pending[request_id].keys()) == self._sources:
+        expected_sources = self._expected_sources.get(request_id)
+        if expected_sources is None and self._expected_sources_fn is not None:
+            resolved = self._expected_sources_fn(request_id, from_stage, data)
+            if resolved is not None:
+                expected_sources = self._normalize_expected_sources(
+                    request_id,
+                    resolved,
+                )
+                self._expected_sources[request_id] = expected_sources
+        elif expected_sources is None:
+            expected_sources = self._sources
+
+        if expected_sources is None:
+            return None
+
+        pending_sources = set(self._pending[request_id])
+        unexpected = pending_sources - expected_sources
+        if unexpected:
+            raise ValueError(
+                "AggregatedInput: received sources outside expected fan-in for "
+                f"request {request_id}: {sorted(unexpected)}. "
+                f"Expected: {sorted(expected_sources)}"
+            )
+
+        if pending_sources == expected_sources:
             inputs = self._pending.pop(request_id)
+            self._expected_sources.pop(request_id, None)
             return self._merge(inputs)
 
         return None
 
+    def _normalize_expected_sources(
+        self,
+        request_id: str,
+        sources: str | Iterable[str],
+    ) -> set[str]:
+        if isinstance(sources, str):
+            expected = {sources}
+        else:
+            try:
+                expected = set(sources)
+            except TypeError as exc:
+                raise ValueError(
+                    "AggregatedInput: dynamic fan-in resolver returned unsupported "
+                    f"sources for request {request_id}: {sources!r}"
+                ) from exc
+        if not expected:
+            raise ValueError(
+                "AggregatedInput: dynamic fan-in resolver returned no sources "
+                f"for request {request_id}"
+            )
+        non_string = [source for source in expected if not isinstance(source, str)]
+        if non_string:
+            raise ValueError(
+                "AggregatedInput: dynamic fan-in resolver returned non-string "
+                f"sources for request {request_id}: {non_string!r}"
+            )
+        unknown = expected - self._sources
+        if unknown:
+            raise ValueError(
+                "AggregatedInput: dynamic fan-in resolver returned sources "
+                f"outside static wait_for for request {request_id}: "
+                f"{sorted(unknown)}. Allowed: {sorted(self._sources)}"
+            )
+        return expected
+
     def cancel(self, request_id: str) -> None:
         self._pending.pop(request_id, None)
+        self._expected_sources.pop(request_id, None)

--- a/sglang_omni/pipeline/stage_process.py
+++ b/sglang_omni/pipeline/stage_process.py
@@ -9,6 +9,7 @@ import logging
 import multiprocessing
 import os
 import sys
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any, Literal, Mapping
 
@@ -48,6 +49,7 @@ class StageProcessSpec:
 
     # Fan-in
     wait_for: list[str] | None = None
+    wait_for_fn: str | None = None
     merge_fn: str | None = None
     project_payload: dict[str, str] = field(default_factory=dict)
 
@@ -209,6 +211,21 @@ def _construct_stage(
     def _map_target_list(targets: str | list[str] | None) -> list[str]:
         return [spec.name_map.get(t, t) for t in _target_list(targets)]
 
+    def _map_wait_source_list(sources: str | Iterable[str] | None) -> list[Any] | None:
+        if sources is None:
+            return None
+        if isinstance(sources, str):
+            return [spec.name_map.get(sources, sources)]
+        if isinstance(sources, Iterable):
+            return [
+                spec.name_map.get(source, source) if isinstance(source, str) else source
+                for source in sources
+            ]
+        raise ValueError(
+            f"wait_for_fn for stage {spec.stage_name!r} returned unsupported "
+            f"source value {sources!r}"
+        )
+
     def _target_result(
         targets: str | list[str] | None,
         *,
@@ -277,7 +294,19 @@ def _construct_stage(
     if spec.wait_for and spec.merge_fn:
         merge_fn = import_string(spec.merge_fn)
         sources = {spec.name_map.get(n, n) for n in spec.wait_for}
-        input_handler = AggregatedInput(sources=sources, merge=merge_fn)
+        expected_sources_fn = None
+        if spec.wait_for_fn:
+            wait_for_fn = import_string(spec.wait_for_fn)
+
+            def expected_sources_fn(request_id, from_stage, data, _fn=wait_for_fn):
+                resolved_sources = _fn(request_id, from_stage, data)
+                return _map_wait_source_list(resolved_sources)
+
+        input_handler = AggregatedInput(
+            sources=sources,
+            merge=merge_fn,
+            expected_sources_fn=expected_sources_fn,
+        )
     else:
         input_handler = DirectInput()
     project_payload = {

--- a/tests/unit_test/fixtures/pipeline_fakes.py
+++ b/tests/unit_test/fixtures/pipeline_fakes.py
@@ -247,6 +247,33 @@ def identity_stream_targets(request_id: str, output: Any) -> list[str]:
     return ["talker"]
 
 
+def identity_wait_sources(
+    request_id: str,
+    from_stage: str,
+    payload: StagePayload,
+) -> list[str]:
+    del request_id, from_stage, payload
+    return ["preprocess", "thinker"]
+
+
+def tuple_wait_sources(
+    request_id: str,
+    from_stage: str,
+    payload: StagePayload,
+) -> tuple[str, str]:
+    del request_id, from_stage, payload
+    return ("preprocess", "thinker")
+
+
+def wait_sources_to_undeclared_stage(
+    request_id: str,
+    from_stage: str,
+    payload: StagePayload,
+) -> list[str]:
+    del request_id, from_stage, payload
+    return ["preprocess", "missing"]
+
+
 def route_to_undeclared_talker(request_id: str, output: Any) -> str:
     del request_id, output
     return "talker"

--- a/tests/unit_test/pipeline/test_compile.py
+++ b/tests/unit_test/pipeline/test_compile.py
@@ -65,6 +65,17 @@ def test_pipeline_schema_keeps_topology_and_validation_contracts() -> None:
                 stage("decode", terminal=True),
             ],
         )
+    with pytest.raises(ValueError, match="wait_for_fn but no wait_for"):
+        PipelineConfig(
+            model_path="model",
+            stages=[
+                stage(
+                    "aggregate",
+                    terminal=True,
+                    wait_for_fn=fake_factory_path("identity_wait_sources"),
+                )
+            ],
+        )
 
 
 def test_runner_specs_wire_routes_overrides_aggregation_and_streams() -> None:
@@ -89,6 +100,7 @@ def test_runner_specs_wire_routes_overrides_aggregation_and_streams() -> None:
             stage(
                 "aggregate",
                 wait_for=["preprocess", "thinker"],
+                wait_for_fn=fake_factory_path("identity_wait_sources"),
                 merge_fn=fake_factory_path("merge_payloads"),
                 terminal=True,
             ),
@@ -115,6 +127,7 @@ def test_runner_specs_wire_routes_overrides_aggregation_and_streams() -> None:
         "identity_stream_targets"
     )
     assert specs["aggregate"].wait_for == ["preprocess", "thinker"]
+    assert specs["aggregate"].wait_for_fn == fake_factory_path("identity_wait_sources")
     assert specs["aggregate"].merge_fn == fake_factory_path("merge_payloads")
     assert specs["talker"].is_stream_receiver
     assert specs["thinker"].same_gpu_targets == {"talker"}

--- a/tests/unit_test/pipeline/test_stage.py
+++ b/tests/unit_test/pipeline/test_stage.py
@@ -53,6 +53,52 @@ def test_aggregated_input_waits_per_request_without_cross_talk() -> None:
     assert req1.data == {"sources": ["image", "preprocess"]}
 
 
+def test_aggregated_input_supports_request_dynamic_source_sets() -> None:
+    """Preserves early-arriving payloads while narrowing fan-in per request."""
+
+    def _expected_sources(request_id, from_stage, payload):
+        del request_id
+        if from_stage != "preprocess":
+            return None
+        return payload.data["expected"]
+
+    handler = AggregatedInput(
+        {"preprocess", "image", "audio"},
+        lambda payloads: make_stage_payload(data={"sources": sorted(payloads)}),
+        expected_sources_fn=_expected_sources,
+    )
+
+    assert handler.receive("req-audio", "audio", make_stage_payload()) is None
+    audio = handler.receive(
+        "req-audio",
+        "preprocess",
+        make_stage_payload(data={"expected": ["preprocess", "audio"]}),
+    )
+    assert audio.data == {"sources": ["audio", "preprocess"]}
+
+    text = handler.receive(
+        "req-text",
+        "preprocess",
+        make_stage_payload(data={"expected": ["preprocess"]}),
+    )
+    assert text.data == {"sources": ["preprocess"]}
+
+
+def test_aggregated_input_rejects_dynamic_sources_outside_static_fanin() -> None:
+    def _invalid_sources(request_id, from_stage, payload):
+        del request_id, from_stage, payload
+        return ["preprocess", "audio"]
+
+    handler = AggregatedInput(
+        {"preprocess", "image"},
+        lambda payloads: make_stage_payload(data={"sources": sorted(payloads)}),
+        expected_sources_fn=_invalid_sources,
+    )
+
+    with pytest.raises(ValueError, match="outside static wait_for"):
+        handler.receive("req-1", "preprocess", make_stage_payload())
+
+
 def test_stage_routes_results_streams_and_clears_abort_state() -> None:
     """Preserves result routing, stream forwarding, and abort cleanup."""
 
@@ -127,6 +173,52 @@ def test_stage_process_rejects_dynamic_targets_outside_static_topology() -> None
         ValueError, match="stream_done_to_fn.*outside the static topology"
     ):
         stage_obj.get_stream_done_targets("req-1", payload)
+
+
+def test_stage_process_rejects_dynamic_wait_sources_outside_static_fanin() -> None:
+    spec = StageProcessSpec(
+        stage_name="aggregate",
+        factory=fake_factory_path("make_scheduler"),
+        next_stages="decode",
+        wait_for=["preprocess", "thinker"],
+        wait_for_fn=fake_factory_path("wait_sources_to_undeclared_stage"),
+        merge_fn=fake_factory_path("merge_payloads"),
+        recv_endpoint="inproc://aggregate",
+        coordinator_endpoint="inproc://coordinator",
+        abort_endpoint="inproc://abort",
+        stage_endpoints={"decode": "inproc://decode"},
+        relay_config={"relay_type": "shm", "slot_size_mb": 1},
+    )
+    stage_obj = _construct_stage(spec, logging.getLogger(__name__))
+
+    with pytest.raises(ValueError, match="outside static wait_for"):
+        stage_obj.input_handler.receive("req-1", "preprocess", make_stage_payload())
+
+
+def test_stage_process_accepts_iterable_dynamic_wait_sources() -> None:
+    spec = StageProcessSpec(
+        stage_name="aggregate",
+        factory=fake_factory_path("make_scheduler"),
+        next_stages="decode",
+        wait_for=["preprocess", "thinker"],
+        wait_for_fn=fake_factory_path("tuple_wait_sources"),
+        merge_fn=fake_factory_path("merge_payloads"),
+        recv_endpoint="inproc://aggregate",
+        coordinator_endpoint="inproc://coordinator",
+        abort_endpoint="inproc://abort",
+        stage_endpoints={"decode": "inproc://decode"},
+        relay_config={"relay_type": "shm", "slot_size_mb": 1},
+    )
+    stage_obj = _construct_stage(spec, logging.getLogger(__name__))
+
+    assert (
+        stage_obj.input_handler.receive("req-1", "preprocess", make_stage_payload())
+        is None
+    )
+    merged = stage_obj.input_handler.receive("req-1", "thinker", make_stage_payload())
+
+    assert merged is not None
+    assert merged.data["merged_sources"] == ["preprocess", "thinker"]
 
 
 def test_stage_run_raises_when_scheduler_thread_crashes() -> None:

--- a/tests/unit_test/qwen3_omni/test_pipeline.py
+++ b/tests/unit_test/qwen3_omni/test_pipeline.py
@@ -170,6 +170,21 @@ def test_qwen_preprocessing_routes_only_active_encoder_branches() -> None:
             ["preprocessing"],
         ),
         (
+            {"audio_encoder": {"cache_key": "audio-cache"}},
+            ["mm_aggregate"],
+            ["preprocessing"],
+        ),
+        (
+            {
+                "audio_encoder": {
+                    "_active": False,
+                    "input_features": torch.ones((1, 2, 3)),
+                }
+            },
+            ["mm_aggregate"],
+            ["preprocessing"],
+        ),
+        (
             {"image_encoder": {}},
             ["mm_aggregate"],
             ["preprocessing"],
@@ -221,6 +236,22 @@ def test_qwen_preprocessing_routes_only_active_encoder_branches() -> None:
             )
             is None
         )
+
+
+def test_qwen_aggregate_wait_sources_accept_projected_active_metadata() -> None:
+    payload = make_qwen_payload(
+        make_qwen_state(
+            encoder_inputs={
+                "audio_encoder": {"cache_key": "audio-cache", "_active": True}
+            }
+        )
+    )
+
+    assert resolve_mm_aggregate_wait_sources(
+        payload.request_id,
+        "preprocessing",
+        payload,
+    ) == ["preprocessing", "audio_encoder"]
 
 
 def test_qwen_aggregate_projection_marks_uncached_active_encoder_inputs() -> None:
@@ -640,11 +671,20 @@ def test_qwen_mm_aggregate_keeps_lightweight_inputs_and_prunes_after_merge() -> 
                 "pixel_values": torch.ones((2, 3)),
                 "image_grid_thw": torch.tensor([[1, 1, 2]]),
             },
-            "audio": {"audio_feature_lengths": torch.tensor([1])},
+            "audio": {
+                "feature_attention_mask": torch.ones((1, 2), dtype=torch.long),
+                "audio_feature_lengths": torch.tensor([2]),
+            },
         },
         encoder_inputs={
-            "image_encoder": {"cache_key": "image-cache"},
-            "audio_encoder": {"cache_key": "audio-cache"},
+            "image_encoder": {
+                "cache_key": "image-cache",
+                "pixel_values": torch.ones((2, 3)),
+            },
+            "audio_encoder": {
+                "cache_key": "audio-cache",
+                "input_features": torch.ones((1, 2, 3)),
+            },
         },
     )
 
@@ -659,16 +699,28 @@ def test_qwen_mm_aggregate_keeps_lightweight_inputs_and_prunes_after_merge() -> 
     image_state = PipelineState(
         encoder_outs={"image_encoder": {"image_embeds": torch.ones((2, 2))}}
     )
+    audio_state = PipelineState(
+        encoder_outs={
+            "audio_encoder": {
+                "audio_embeds": torch.ones((2, 2)),
+                "audio_feature_lengths": torch.tensor([2]),
+            }
+        }
+    )
     merged = merge_for_thinker(
         {
-            "preprocessing": make_qwen_payload(state),
+            "preprocessing": projected,
             "image_encoder": make_qwen_payload(image_state),
+            "audio_encoder": make_qwen_payload(audio_state),
         }
     )
     merged_state = PipelineState.from_dict(merged.data)
     assert merged_state.encoder_inputs == {}
     assert merged_state.encoder_outs == {}
     assert "image_embeds" in merged_state.thinker_inputs["model_inputs"]
+    assert "audio_embeds" in merged_state.thinker_inputs["model_inputs"]
+    assert "pixel_values" not in merged_state.mm_inputs["image"]
+    assert "input_features" not in merged_state.mm_inputs["audio"]
     assert merged_state.thinker_inputs["media_cache_keys"] == {
         "image": "image:image-cache",
         "video": "video:image-cache",

--- a/tests/unit_test/qwen3_omni/test_pipeline.py
+++ b/tests/unit_test/qwen3_omni/test_pipeline.py
@@ -25,6 +25,8 @@ from sglang_omni.models.qwen3_omni.payload_types import PipelineState
 from sglang_omni.models.qwen3_omni.request_builders import (
     build_sglang_thinker_request,
     project_preprocessing_to_mm_aggregate,
+    resolve_mm_aggregate_wait_sources,
+    resolve_preprocessing_next_stages,
 )
 from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.scheduling.sglang_backend.server_args_builder import (
@@ -71,11 +73,21 @@ def test_qwen_pipeline_config_and_state_contracts() -> None:
     )
     speech_thinker = _stage(speech_config, "thinker")
     text_thinker = _stage(text_config, "thinker")
+    preprocessing = _stage(speech_config, "preprocessing")
+    aggregate = _stage(speech_config, "mm_aggregate")
     # Speech-mode thinker streams hidden states to talker_ar AND text-token
     # ids to decode (for the streaming detokenizer); text-mode thinker
     # streams only to decode. Lock both so a regression here can't silently
     # disable per-token streaming for either path.
     request_builders_path = "sglang_omni.models.qwen3_omni.request_builders"
+    assert preprocessing.next == ["image_encoder", "audio_encoder", "mm_aggregate"]
+    assert preprocessing.route_fn == (
+        f"{request_builders_path}.resolve_preprocessing_next_stages"
+    )
+    assert aggregate.wait_for == ["preprocessing", "image_encoder", "audio_encoder"]
+    assert aggregate.wait_for_fn == (
+        f"{request_builders_path}.resolve_mm_aggregate_wait_sources"
+    )
     assert speech_thinker.stream_to == ["talker_ar", "decode"]
     assert speech_thinker.route_fn == (
         f"{request_builders_path}.resolve_thinker_next_stages"
@@ -137,6 +149,100 @@ def test_qwen_speech_config_wires_request_granular_active_subgraph() -> None:
     assert route_fn("default", default_payload) == ["decode", "talker_ar"]
     assert stream_done_to_fn("default", default_payload) == ["talker_ar", "decode"]
     assert terminal_stages_fn(default_payload.request) == ["decode", "code2wav"]
+
+
+def test_qwen_preprocessing_routes_only_active_encoder_branches() -> None:
+    def _payload(encoder_inputs):
+        return make_qwen_payload(make_qwen_state(encoder_inputs=encoder_inputs))
+
+    cases = [
+        (
+            {
+                "image_encoder": {"_skip": True, "_result": {}},
+                "audio_encoder": {"_skip": True, "_result": {}},
+            },
+            ["mm_aggregate"],
+            ["preprocessing"],
+        ),
+        (
+            {"audio_encoder": {}},
+            ["mm_aggregate"],
+            ["preprocessing"],
+        ),
+        (
+            {"image_encoder": {}},
+            ["mm_aggregate"],
+            ["preprocessing"],
+        ),
+        (
+            {"audio_encoder": {"input_features": torch.ones((1, 2, 3))}},
+            ["audio_encoder", "mm_aggregate"],
+            ["preprocessing", "audio_encoder"],
+        ),
+        (
+            {"image_encoder": {"pixel_values": torch.ones((1, 3))}},
+            ["image_encoder", "mm_aggregate"],
+            ["preprocessing", "image_encoder"],
+        ),
+        (
+            {"image_encoder": {"pixel_values_videos": torch.ones((1, 3))}},
+            ["image_encoder", "mm_aggregate"],
+            ["preprocessing", "image_encoder"],
+        ),
+        (
+            {
+                "image_encoder": {"pixel_values": torch.ones((1, 3))},
+                "audio_encoder": {"input_features": torch.ones((1, 2, 3))},
+            },
+            ["image_encoder", "audio_encoder", "mm_aggregate"],
+            ["preprocessing", "image_encoder", "audio_encoder"],
+        ),
+    ]
+
+    for encoder_inputs, expected_next, expected_wait in cases:
+        payload = _payload(encoder_inputs)
+        assert resolve_preprocessing_next_stages(payload.request_id, payload) == (
+            expected_next
+        )
+        aggregate_payload = project_preprocessing_to_mm_aggregate(payload)
+        assert (
+            resolve_mm_aggregate_wait_sources(
+                aggregate_payload.request_id,
+                "preprocessing",
+                aggregate_payload,
+            )
+            == expected_wait
+        )
+        assert (
+            resolve_mm_aggregate_wait_sources(
+                aggregate_payload.request_id,
+                "audio_encoder",
+                aggregate_payload,
+            )
+            is None
+        )
+
+
+def test_qwen_aggregate_projection_marks_uncached_active_encoder_inputs() -> None:
+    state = make_qwen_state(
+        encoder_inputs={
+            "audio_encoder": {"input_features": torch.ones((1, 2, 3))},
+            "image_encoder": {"_skip": True, "_result": {}},
+        }
+    )
+
+    projected = project_preprocessing_to_mm_aggregate(make_qwen_payload(state))
+    projected_state = PipelineState.from_dict(projected.data)
+
+    assert projected_state.encoder_inputs == {
+        "audio_encoder": {"_active": True},
+        "image_encoder": {"_skip": True},
+    }
+    assert resolve_mm_aggregate_wait_sources(
+        projected.request_id,
+        "preprocessing",
+        projected,
+    ) == ["preprocessing", "audio_encoder"]
 
 
 def test_qwen_builder_omits_mem_fraction_static_by_default() -> None:
@@ -546,8 +652,8 @@ def test_qwen_mm_aggregate_keeps_lightweight_inputs_and_prunes_after_merge() -> 
     projected_state = PipelineState.from_dict(projected.data)
     assert "pixel_values" not in projected_state.mm_inputs["image"]
     assert projected_state.encoder_inputs == {
-        "image_encoder": {"cache_key": "image-cache"},
-        "audio_encoder": {"cache_key": "audio-cache"},
+        "image_encoder": {"cache_key": "image-cache", "_active": True},
+        "audio_encoder": {"cache_key": "audio-cache", "_active": True},
     }
 
     image_state = PipelineState(


### PR DESCRIPTION
## Motivation

Qwen3-Omni preprocessing has static pipeline edges for all possible encoder branches, but each request only activates a subset of those branches. The pipeline already validates static routing supersets; this PR adds the matching request-level fan-in hook so aggregate stages can wait on the sources that are active for the current request.

This is a standalone routing/fan-in correctness change. It does not claim to be a benchmark threshold change or a full topology/performance fix.

## Modifications

- Added `StageConfig.wait_for_fn` and threaded it into stage-process construction so aggregate inputs can resolve expected sources per request while keeping the static `wait_for` set as the validation boundary.
- Extended `AggregatedInput` with request-scoped expected source sets. Dynamic sources must be non-empty strings contained in the static `wait_for` superset, and pending state is cleared on request cancellation.
- Updated Qwen3-Omni preprocessing routing so raw preprocessing payloads fan out only to encoder branches with real model inputs, then always continue to `mm_aggregate`.
- Updated Qwen3-Omni aggregate fan-in so `mm_aggregate` waits for preprocessing plus the projected active encoder branches for that request.
- Preserved lightweight encoder cache metadata in the preprocessing-to-aggregate projection, using `_active` only as aggregate metadata. Metadata such as `cache_key` alone no longer activates an encoder branch.
- Added unit coverage for dynamic fan-in validation, stage-process hook wiring, Qwen active-branch routing, metadata-only encoder inputs, projected active metadata, and the real projection-to-merge path.

## Accuracy Tests

N/A