### PR TITLE
[Ming-Omni] Support Streaming TTS for v1 Pipeline

### DIFF
--- a/examples/run_ming_omni_speech_server.py
+++ b/examples/run_ming_omni_speech_server.py
@@ -82,6 +82,27 @@ def parse_args() -> argparse.Namespace:
             "If omitted, SGLang chooses automatically."
         ),
     )
+    parser.add_argument(
+        "--cpu-offload-gb",
+        type=int,
+        default=None,
+        help=(
+            "Offload N GiB of thinker weights to CPU. Required for "
+            "Ming-flash-omni-2.0 (~200 GB MoE weights) on a single GPU. "
+            "Mirrors the text launcher's default of 80."
+        ),
+    )
+    # Streaming TTS
+    parser.add_argument(
+        "--enable-streaming-tts",
+        action="store_true",
+        help=(
+            "Use the 8-stage streaming-TTS pipeline (segmenter + streaming "
+            "talker) for sub-second time-to-first-audio. Default keeps the "
+            "non-streaming 7-stage speech pipeline."
+        ),
+    )
+
     # Server
     parser.add_argument("--host", type=str, default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8000)
@@ -147,28 +168,44 @@ def _set_thinker_tp(config: Any, *, start_gpu: int, tp_size: int) -> None:
 
 
 def _launch_speech_server(args: argparse.Namespace) -> None:
-    from sglang_omni.models.ming_omni.config import MingOmniSpeechPipelineConfig
+    from sglang_omni.models.ming_omni.config import (
+        MingOmniSpeechPipelineConfig,
+        MingOmniStreamingSpeechPipelineConfig,
+    )
     from sglang_omni.serve import launch_server
 
     _validate_fraction("--mem-fraction-static", args.mem_fraction_static)
 
-    config = MingOmniSpeechPipelineConfig(
-        model_path=args.model_path,
-        relay_backend=args.relay_backend,
-    )
+    if getattr(args, "enable_streaming_tts", False):
+        config = MingOmniStreamingSpeechPipelineConfig(
+            model_path=args.model_path,
+            relay_backend=args.relay_backend,
+        )
+        talker_stage_name = "talker_stream"
+        gpu_validator = config._validate_talker_stream_gpu_not_in_thinker_tp_range
+    else:
+        config = MingOmniSpeechPipelineConfig(
+            model_path=args.model_path,
+            relay_backend=args.relay_backend,
+        )
+        talker_stage_name = "talker"
+        gpu_validator = config._validate_talker_gpu_not_in_thinker_tp_range
+
     _set_thinker_tp(
         config,
         start_gpu=args.gpu_thinker,
         tp_size=int(args.tp_size),
     )
-    _set_stage_gpu(config, "talker", args.gpu_talker)
-    config._validate_talker_gpu_not_in_thinker_tp_range()
+    _set_stage_gpu(config, talker_stage_name, args.gpu_talker)
+    gpu_validator()
 
     server_arg_updates: dict[str, object] = {}
     if args.tp_size and args.tp_size > 1:
         server_arg_updates["disable_custom_all_reduce"] = True
     if args.mem_fraction_static is not None:
         server_arg_updates["mem_fraction_static"] = args.mem_fraction_static
+    if getattr(args, "cpu_offload_gb", None) is not None:
+        server_arg_updates["cpu_offload_gb"] = args.cpu_offload_gb
     if server_arg_updates:
         _apply_stage_factory_updates(
             config,
@@ -177,7 +214,7 @@ def _launch_speech_server(args: argparse.Namespace) -> None:
         )
     _apply_stage_factory_updates(
         config,
-        stage_name="talker",
+        stage_name=talker_stage_name,
         updates={"voice": args.voice},
     )
 

--- a/sglang_omni/client/client.py
+++ b/sglang_omni/client/client.py
@@ -303,10 +303,11 @@ class Client:
             result.request_id = request_id
             return result
         if isinstance(result, dict):
-            # Multi-terminal merged result, e.g. decode + code2wav/talker.
+            # Multi-terminal merged result, e.g. decode + code2wav/talker/
+            # talker_stream.
             audio_result = None
             if "decode" in result:
-                for audio_stage in ("code2wav", "talker"):
+                for audio_stage in ("code2wav", "talker", "talker_stream"):
                     if audio_stage in result:
                         audio_result = result[audio_stage] or {}
                         break

--- a/sglang_omni/models/ming_omni/bootstrap.py
+++ b/sglang_omni/models/ming_omni/bootstrap.py
@@ -316,6 +316,13 @@ def make_thinker_stream_output_builder(
             list(delta.encode("utf-8")),
             dtype=torch.uint8,
         )
+        # Only emit to the segmenter. The thinker is not a terminal stage,
+        # so it cannot send chunks directly to the coordinator via
+        # target=None — the runtime would fan that out to ``stream_to``
+        # peers, and the relay transport requires torch.Tensor payloads.
+        # Streaming text deltas to the client requires either a stream-
+        # aware decode stage or a dedicated text fan-out stage; left as a
+        # follow-up. Streaming audio still works via the talker_stream.
         return [
             OutgoingMessage(
                 request_id=request_id,

--- a/sglang_omni/models/ming_omni/bootstrap.py
+++ b/sglang_omni/models/ming_omni/bootstrap.py
@@ -18,6 +18,7 @@ def create_thinker_scheduler(
     tp_rank: int = 0,
     tp_size: int = 1,
     nccl_port: int | None = None,
+    enable_streaming_tts: bool = False,
 ):
     if tp_size < 1:
         raise ValueError(f"tp_size must be >= 1, got {tp_size}")
@@ -81,6 +82,14 @@ def create_thinker_scheduler(
         video_token_id=video_token_id,
     )
 
+    stream_output_builder = None
+    if enable_streaming_tts:
+        eos_token_id = getattr(tokenizer, "eos_token_id", None)
+        stream_output_builder = make_thinker_stream_output_builder(
+            tokenizer=tokenizer,
+            eos_token_id=eos_token_id,
+        )
+
     return OmniScheduler(
         tp_worker=model_worker,
         tree_cache=tree_cache,
@@ -93,6 +102,7 @@ def create_thinker_scheduler(
         model_runner=model_runner,
         request_builder=request_builder,
         result_adapter=result_adapter,
+        stream_output_builder=stream_output_builder,
     )
 
 
@@ -236,6 +246,92 @@ def make_thinker_scheduler_adapters(
         )
 
     return request_builder, result_adapter
+
+
+def make_thinker_stream_output_builder(
+    *,
+    tokenizer: Any,
+    eos_token_id: int | None,
+    target_stage: str = "segmenter",
+):
+    """Build a per-token stream callback that emits text deltas to the segmenter.
+
+    OmniScheduler calls this on every model step with the freshly generated
+    token id. We maintain per-request running output_ids on ``req`` so we can
+    incrementally decode and compute the text delta to push to the segmenter.
+
+    Incomplete UTF-8 sequences (``\\ufffd`` in the decoded result) are buffered
+    until the next token completes them.
+    """
+    import torch
+
+    from sglang_omni.scheduling.messages import OutgoingMessage
+
+    def _build_stream_output(request_id, req_data, req_output):
+        req = getattr(req_data, "req", None)
+        # Suppress while chunked prefill is still consuming prompt tokens —
+        # prompt-side states could otherwise masquerade as the first
+        # assistant token and leak prompt content into TTS.
+        if req is not None and int(getattr(req, "is_chunked", 0) or 0) > 0:
+            return []
+        if req_output.data is None or req is None:
+            return []
+
+        try:
+            token_id = int(req_output.data)
+        except (TypeError, ValueError):
+            return []
+
+        # Per-request state lives on ``req`` so it is automatically GC'd when
+        # the SGLang scheduler drops the request.
+        token_ids = getattr(req, "_ming_stream_token_ids", None)
+        if token_ids is None:
+            token_ids = []
+            req._ming_stream_token_ids = token_ids
+        emitted = getattr(req, "_ming_stream_emitted_text", "")
+
+        is_eos = eos_token_id is not None and token_id == int(eos_token_id)
+        if not is_eos:
+            token_ids.append(token_id)
+
+        if not token_ids:
+            return []
+
+        decoded = tokenizer.decode(token_ids, skip_special_tokens=True)
+        # Buffer until the trailing multi-byte char completes.
+        if "\ufffd" in decoded:
+            return []
+
+        if decoded.startswith(emitted):
+            delta = decoded[len(emitted) :]
+        else:
+            # Defensive: detokenizer rewrote earlier text — re-emit full.
+            delta = decoded
+        if not delta:
+            return []
+
+        req._ming_stream_emitted_text = decoded
+
+        text_tensor = torch.tensor(
+            list(delta.encode("utf-8")),
+            dtype=torch.uint8,
+        )
+        return [
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                data=text_tensor,
+                target=target_stage,
+                metadata={
+                    "token_id": token_id,
+                    "step": len(token_ids),
+                    "text_len": int(text_tensor.numel()),
+                    "is_eos": bool(is_eos),
+                },
+            )
+        ]
+
+    return _build_stream_output
 
 
 def _torch_long():

--- a/sglang_omni/models/ming_omni/components/streaming_segmenter.py
+++ b/sglang_omni/models/ming_omni/components/streaming_segmenter.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Streaming text segmenter scheduler for Ming-Omni V1.
+
+Bridges incremental text deltas from the thinker (via the stream channel)
+into speakable segments routed to the streaming talker. Uses the pure-logic
+``SegmenterState`` from ``streaming_text``.
+
+Wire-up:
+- Thinker emits per-token uint8-text-deltas to this stage via ``stream_to``.
+- Thinker also fans out its final payload to this stage via ``next`` (so we
+  know when generation is done and to attach the per-request handle).
+- This stage emits per-segment uint8 tensors to ``talker_stream`` via
+  ``stream_to``, then emits a result payload when both the upstream stream
+  is done AND the main payload has arrived.
+"""
+
+from __future__ import annotations
+
+import logging
+import queue as _queue_mod
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from sglang_omni.models.ming_omni.components.streaming_text import (
+    SegmenterConfig,
+    SegmenterState,
+    TextSegment,
+    TokenCountFn,
+    text_to_uint8_tensor,
+    uint8_tensor_to_text,
+)
+from sglang_omni.models.ming_omni.pipeline.next_stage import TALKER_STREAM_STAGE
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
+
+logger = logging.getLogger(__name__)
+
+
+def _default_token_count(text: str) -> int:
+    # Whitespace tokens for English; codepoint length for CJK fallback.
+    return len(text.split()) or len(text)
+
+
+@dataclass
+class _RequestState:
+    segmenter: SegmenterState
+    payload: StagePayload | None = None
+    payload_arrived: bool = False
+    stream_done: bool = False
+    finalized: bool = False
+    aborted: bool = False
+    segment_count: int = 0
+    first_text_ms: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class MingStreamingSegmenterScheduler:
+    """Stream-aware scheduler for the Ming streaming TTS segmenter stage.
+
+    Same inbox/outbox contract as SimpleScheduler so the stage runtime can
+    drive it without branching. Single-threaded: ``start()`` blocks on the
+    inbox loop until ``stop()``.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: SegmenterConfig | None = None,
+        token_count_fn: TokenCountFn | None = None,
+        target_stage: str = TALKER_STREAM_STAGE,
+    ) -> None:
+        self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
+        self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
+
+        self._config = config or SegmenterConfig()
+        self._token_count_fn = token_count_fn or _default_token_count
+        self._target_stage = target_stage
+        self._running = False
+        self._states: dict[str, _RequestState] = {}
+
+    # ------------------------------------------------------------------ lifecycle
+    def start(self) -> None:
+        self._running = True
+        while self._running:
+            try:
+                msg = self.inbox.get(timeout=0.1)
+            except _queue_mod.Empty:
+                self._tick_first_segment_timeouts()
+                continue
+            try:
+                self._handle_message(msg)
+            except Exception as exc:
+                logger.exception(
+                    "MingStreamingSegmenterScheduler: failed handling %s for %s",
+                    msg.type,
+                    msg.request_id,
+                )
+                self._emit_error(msg.request_id, exc)
+                self._states.pop(msg.request_id, None)
+
+    def stop(self) -> None:
+        self._running = False
+
+    def abort(self, request_id: str) -> None:
+        state = self._states.get(request_id)
+        if state is None:
+            return
+        state.aborted = True
+        # Drop without finalizing — the runtime will close the stream queue.
+        self._states.pop(request_id, None)
+
+    # ------------------------------------------------------------------ dispatch
+    def _handle_message(self, msg: IncomingMessage) -> None:
+        if msg.type == "new_request":
+            self._on_new_request(msg)
+        elif msg.type == "stream_chunk":
+            self._on_stream_chunk(msg)
+        elif msg.type == "stream_done":
+            self._on_stream_done(msg)
+        else:
+            logger.debug("MingStreamingSegmenter: ignored message type=%s", msg.type)
+
+    # ------------------------------------------------------------------ payload arrival
+    def _on_new_request(self, msg: IncomingMessage) -> None:
+        request_id = msg.request_id
+        payload = msg.data
+        state = self._states.get(request_id)
+        if state is None:
+            state = _RequestState(
+                segmenter=SegmenterState(self._config, self._token_count_fn),
+            )
+            self._states[request_id] = state
+        state.payload = payload
+        state.payload_arrived = True
+        # If the upstream stream already signalled done before the payload
+        # arrived, finalize now.
+        if state.stream_done and not state.finalized:
+            self._finalize(request_id, state)
+
+    # ------------------------------------------------------------------ stream chunk
+    def _on_stream_chunk(self, msg: IncomingMessage) -> None:
+        request_id = msg.request_id
+        item = msg.data
+        state = self._states.get(request_id)
+        if state is None:
+            # First sight of this request: create state so we can buffer
+            # incoming text even before the thinker's main payload arrives.
+            state = _RequestState(
+                segmenter=SegmenterState(self._config, self._token_count_fn),
+            )
+            self._states[request_id] = state
+        if state.aborted or state.finalized:
+            return
+        if not isinstance(item, StreamItem):
+            return
+
+        text = uint8_tensor_to_text(item.data)
+        if not text:
+            return
+        now_ms = self._now_ms()
+        if state.first_text_ms is None:
+            state.first_text_ms = now_ms
+
+        for segment in state.segmenter.push(text, now_ms=now_ms):
+            self._emit_segment(request_id, segment)
+            state.segment_count += 1
+            state.first_text_ms = None
+
+    # ------------------------------------------------------------------ stream done
+    def _on_stream_done(self, msg: IncomingMessage) -> None:
+        request_id = msg.request_id
+        state = self._states.get(request_id)
+        if state is None:
+            return
+        state.stream_done = True
+        if state.payload_arrived and not state.finalized:
+            self._finalize(request_id, state)
+
+    # ------------------------------------------------------------------ first-seg timer
+    def _tick_first_segment_timeouts(self) -> None:
+        if not self._states:
+            return
+        now_ms = self._now_ms()
+        wait = self._config.first_segment_max_wait_ms
+        for request_id, state in list(self._states.items()):
+            if state.aborted or state.finalized or state.segment_count != 0:
+                continue
+            if state.first_text_ms is None:
+                continue
+            if now_ms - state.first_text_ms < wait:
+                continue
+            if (
+                state.segmenter.buffer_token_count()
+                < self._config.first_segment_min_tokens
+            ):
+                continue
+            for segment in state.segmenter.push("", now_ms=now_ms):
+                self._emit_segment(request_id, segment)
+                state.segment_count += 1
+                state.first_text_ms = None
+
+    # ------------------------------------------------------------------ finalize
+    def _finalize(self, request_id: str, state: _RequestState) -> None:
+        if state.finalized:
+            return
+        state.finalized = True
+
+        final_segments = state.segmenter.flush()
+        if not final_segments:
+            final_segments = [TextSegment(
+                segment_id=state.segment_count,
+                text="",
+                is_final_segment=True,
+            )]
+        for segment in final_segments:
+            self._emit_segment(request_id, segment)
+            state.segment_count += 1
+
+        payload = state.payload
+        # If we received streams but the payload never arrived (defensive),
+        # synthesize an empty payload so the result channel is closed.
+        if payload is None:
+            payload = StagePayload(request_id=request_id, request=None, data={})
+        data = payload.data if isinstance(payload.data, dict) else {}
+        payload.data = {
+            **data,
+            "segment_count": state.segment_count,
+            "aborted": False,
+        }
+        self.outbox.put(
+            OutgoingMessage(
+                request_id=request_id,
+                type="result",
+                data=payload,
+            )
+        )
+        self._states.pop(request_id, None)
+
+    # ------------------------------------------------------------------ emit helpers
+    def _emit_segment(self, request_id: str, segment: TextSegment) -> None:
+        data = text_to_uint8_tensor(segment.text)
+        self.outbox.put(
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                data=data,
+                target=self._target_stage,
+                metadata={
+                    "segment_id": segment.segment_id,
+                    "is_final_segment": bool(segment.is_final_segment),
+                    "text_len": int(data.numel()),
+                },
+            )
+        )
+
+    def _emit_error(self, request_id: str, exc: BaseException) -> None:
+        self.outbox.put(
+            OutgoingMessage(
+                request_id=request_id,
+                type="error",
+                data=exc,
+            )
+        )
+
+    @staticmethod
+    def _now_ms() -> int:
+        return int(time.monotonic() * 1000)

--- a/sglang_omni/models/ming_omni/components/streaming_segmenter.py
+++ b/sglang_omni/models/ming_omni/components/streaming_segmenter.py
@@ -209,11 +209,13 @@ class MingStreamingSegmenterScheduler:
 
         final_segments = state.segmenter.flush()
         if not final_segments:
-            final_segments = [TextSegment(
-                segment_id=state.segment_count,
-                text="",
-                is_final_segment=True,
-            )]
+            final_segments = [
+                TextSegment(
+                    segment_id=state.segment_count,
+                    text="",
+                    is_final_segment=True,
+                )
+            ]
         for segment in final_segments:
             self._emit_segment(request_id, segment)
             state.segment_count += 1
@@ -223,9 +225,12 @@ class MingStreamingSegmenterScheduler:
         # synthesize an empty payload so the result channel is closed.
         if payload is None:
             payload = StagePayload(request_id=request_id, request=None, data={})
-        data = payload.data if isinstance(payload.data, dict) else {}
+        # Strip the upstream tensor-laden state dict; only forward the
+        # segmenter's own summary stats. The talker_stream stage doesn't
+        # need the thinker_out / prompt / encoder_outs fields, and they
+        # carry torch.Tensor instances that downstream msgpack can't
+        # serialize when emitting the terminal result.
         payload.data = {
-            **data,
             "segment_count": state.segment_count,
             "aborted": False,
         }

--- a/sglang_omni/models/ming_omni/components/streaming_talker.py
+++ b/sglang_omni/models/ming_omni/components/streaming_talker.py
@@ -1,0 +1,449 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Streaming talker scheduler for Ming-Omni V1.
+
+Consumes text segments emitted by the segmenter stage and produces audio
+chunks by driving ``MingOmniTalker.omni_audio_generation(stream=True, ...)``.
+Each audio chunk is published on the outbox stream channel with ``target=None``
+so the stage runtime forwards it directly to the coordinator (terminal).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import queue as _queue_mod
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+from sglang_omni.models.ming_omni.components.streaming_text import uint8_tensor_to_text
+from sglang_omni.models.ming_omni.pipeline.next_stage import TALKER_STREAM_STAGE
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_VOICE = "DB30"
+DEFAULT_SAMPLE_RATE = 44100
+
+
+@dataclass
+class _RequestState:
+    payload: StagePayload | None = None
+    payload_arrived: bool = False
+    stream_done: bool = False
+    finalized: bool = False
+    aborted: bool = False
+    abort_event: threading.Event = field(default_factory=threading.Event)
+    segment_count: int = 0
+    audio_chunk_count: int = 0
+    request_t_start_s: float = field(default_factory=time.perf_counter)
+    first_audio_emit_ms: float | None = None
+
+
+class MingStreamingTalkerScheduler:
+    """Stream-aware scheduler that turns text segments into audio chunks.
+
+    Same inbox/outbox/start/stop/abort contract as ``SimpleScheduler`` /
+    ``MingStreamingSegmenterScheduler`` so the V1 stage runtime drives it
+    without branching.
+    """
+
+    def __init__(
+        self,
+        model_path: str | None = None,
+        *,
+        device: str = "cuda",
+        voice: str = DEFAULT_VOICE,
+        talker: Any | None = None,
+        audio_detokenizer: Any | None = None,
+        sample_rate: int | None = None,
+    ) -> None:
+        self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
+        self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
+
+        self._model_path = model_path
+        self._device = device
+        self._voice = voice
+        self._talker = talker
+        self._audio_detokenizer = audio_detokenizer
+        self._sample_rate = sample_rate
+
+        self._running = False
+        self._states: dict[str, _RequestState] = {}
+        self._states_lock = threading.Lock()
+
+    # ------------------------------------------------------------------ lifecycle
+    def start(self) -> None:
+        self._running = True
+        if self._talker is None:
+            self._load_models()
+        if self._sample_rate is None:
+            self._sample_rate = self._resolve_sample_rate()
+
+        while self._running:
+            try:
+                msg = self.inbox.get(timeout=0.1)
+            except _queue_mod.Empty:
+                continue
+            try:
+                self._handle_message(msg)
+            except Exception as exc:
+                logger.exception(
+                    "MingStreamingTalkerScheduler: failed handling %s for %s",
+                    msg.type,
+                    msg.request_id,
+                )
+                self.outbox.put(
+                    OutgoingMessage(request_id=msg.request_id, type="error", data=exc)
+                )
+                self._discard_state(msg.request_id)
+
+    def stop(self) -> None:
+        self._running = False
+        # Signal abort on every still-active request so any in-flight talker
+        # generation unwinds in time.
+        with self._states_lock:
+            for state in self._states.values():
+                state.abort_event.set()
+
+    def abort(self, request_id: str) -> None:
+        with self._states_lock:
+            state = self._states.get(request_id)
+            if state is None:
+                return
+            state.aborted = True
+            state.abort_event.set()
+
+    # ------------------------------------------------------------------ dispatch
+    def _handle_message(self, msg: IncomingMessage) -> None:
+        if msg.type == "new_request":
+            self._on_new_request(msg)
+        elif msg.type == "stream_chunk":
+            self._on_stream_chunk(msg)
+        elif msg.type == "stream_done":
+            self._on_stream_done(msg)
+        else:
+            logger.debug("MingStreamingTalker: ignored message type=%s", msg.type)
+
+    # ------------------------------------------------------------------ handlers
+    def _on_new_request(self, msg: IncomingMessage) -> None:
+        request_id = msg.request_id
+        with self._states_lock:
+            state = self._states.get(request_id)
+            if state is None:
+                state = _RequestState()
+                self._states[request_id] = state
+            state.payload = msg.data
+            state.payload_arrived = True
+            should_finalize = state.stream_done and not state.finalized
+        if should_finalize:
+            self._finalize(request_id)
+
+    def _on_stream_chunk(self, msg: IncomingMessage) -> None:
+        request_id = msg.request_id
+        item = msg.data
+        if not isinstance(item, StreamItem):
+            return
+        with self._states_lock:
+            state = self._states.get(request_id)
+            if state is None:
+                state = _RequestState()
+                self._states[request_id] = state
+            if state.aborted or state.finalized:
+                return
+
+        metadata = dict(item.metadata or {})
+        is_final_segment = bool(metadata.get("is_final_segment", False))
+        text = uint8_tensor_to_text(item.data)
+        if text:
+            self._generate_audio_for_segment(
+                request_id=request_id,
+                state=state,
+                text=text,
+                segment_id=int(metadata.get("segment_id", state.segment_count)),
+            )
+            state.segment_count += 1
+        # is_final_segment is informational; we still wait for stream_done
+        # to finalize the result payload.
+        if is_final_segment:
+            logger.debug(
+                "[TALKER_STREAM] saw final segment for %s segment_count=%d",
+                request_id,
+                state.segment_count,
+            )
+
+    def _on_stream_done(self, msg: IncomingMessage) -> None:
+        request_id = msg.request_id
+        with self._states_lock:
+            state = self._states.get(request_id)
+            if state is None:
+                return
+            state.stream_done = True
+            should_finalize = state.payload_arrived and not state.finalized
+        if should_finalize:
+            self._finalize(request_id)
+
+    # ------------------------------------------------------------------ generation
+    def _generate_audio_for_segment(
+        self,
+        *,
+        request_id: str,
+        state: _RequestState,
+        text: str,
+        segment_id: int,
+    ) -> None:
+        if self._talker is None:
+            raise RuntimeError("Talker model not loaded")
+        t_start = time.perf_counter()
+        generator = self._build_generation_iterator(text, state.abort_event)
+        try:
+            for item in generator:
+                if state.abort_event.is_set():
+                    break
+                waveform = self._extract_waveform(item)
+                if waveform is None or self._waveform_numel(waveform) == 0:
+                    continue
+                if state.first_audio_emit_ms is None:
+                    state.first_audio_emit_ms = (
+                        time.perf_counter() - state.request_t_start_s
+                    ) * 1000.0
+                self._emit_audio_chunk(
+                    request_id, state, waveform, segment_id=segment_id
+                )
+        except BaseException as exc:  # CancelledError from abort surfaces here
+            import asyncio as _asyncio
+
+            if isinstance(exc, _asyncio.CancelledError):
+                logger.info(
+                    "[TALKER_STREAM] segment %d aborted for %s", segment_id, request_id
+                )
+                return
+            raise
+        finally:
+            logger.debug(
+                "[TALKER_STREAM] segment %d for %s took %.2fs",
+                segment_id,
+                request_id,
+                time.perf_counter() - t_start,
+            )
+
+    def _build_generation_iterator(
+        self, text: str, abort_event: threading.Event
+    ) -> Any:
+        if hasattr(self._talker, "omni_audio_generation"):
+            return self._talker.omni_audio_generation(
+                tts_text=text,
+                voice_name=self._voice,
+                audio_detokenizer=self._audio_detokenizer,
+                stream=True,
+                abort_event=abort_event,
+            )
+        if hasattr(self._talker, "instruct_audio_generation"):
+            return self._talker.instruct_audio_generation(
+                prompt="Please generate speech based on the following description.\n",
+                text=text,
+                audio_detokenizer=self._audio_detokenizer,
+                stream=True,
+                abort_event=abort_event,
+            )
+        raise RuntimeError("Talker has no streaming generation method")
+
+    # ------------------------------------------------------------------ outbox
+    def _emit_audio_chunk(
+        self,
+        request_id: str,
+        state: _RequestState,
+        waveform: Any,
+        *,
+        segment_id: int,
+    ) -> None:
+        audio_bytes, shape, dtype = self._serialize_waveform(waveform)
+        payload: dict[str, Any] = {
+            "modality": "audio",
+            "audio_waveform": audio_bytes,
+            "audio_waveform_shape": shape,
+            "audio_waveform_dtype": dtype,
+            "sample_rate": self._resolve_sample_rate(),
+            "stage_name": TALKER_STREAM_STAGE,
+            "segment_id": segment_id,
+        }
+        if state.first_audio_emit_ms is not None:
+            payload["talker_first_audio_ms"] = state.first_audio_emit_ms
+        state.audio_chunk_count += 1
+        self.outbox.put(
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                target=None,
+                data=payload,
+                metadata={"modality": "audio", "segment_id": segment_id},
+            )
+        )
+
+    def _finalize(self, request_id: str) -> None:
+        with self._states_lock:
+            state = self._states.get(request_id)
+            if state is None or state.finalized:
+                return
+            state.finalized = True
+
+        # Build the final result payload as a fresh small dict — do not
+        # inherit the upstream StagePayload.data which contains tensors
+        # (prompt.input_ids, encoder_outs, etc.). The terminal result is
+        # serialized via msgpack to the coordinator and cannot carry
+        # torch.Tensor objects.
+        payload = state.payload
+        if payload is None:
+            payload = StagePayload(request_id=request_id, request=None, data={})
+        payload.data = {
+            "modality": "audio",
+            "audio_chunk_count": state.audio_chunk_count,
+            "segment_count": state.segment_count,
+            "first_audio_emit_ms": state.first_audio_emit_ms,
+            "aborted": state.aborted,
+        }
+        self.outbox.put(
+            OutgoingMessage(request_id=request_id, type="result", data=payload)
+        )
+        self._discard_state(request_id)
+
+    def _discard_state(self, request_id: str) -> None:
+        with self._states_lock:
+            self._states.pop(request_id, None)
+
+    # ------------------------------------------------------------------ helpers
+    @staticmethod
+    def _extract_waveform(item: Any) -> Any | None:
+        if isinstance(item, tuple):
+            return item[0] if item else None
+        return item
+
+    @staticmethod
+    def _waveform_numel(waveform: Any) -> int:
+        if isinstance(waveform, torch.Tensor):
+            return int(waveform.numel())
+        if isinstance(waveform, np.ndarray):
+            return int(waveform.size)
+        if isinstance(waveform, (bytes, bytearray, memoryview)):
+            return len(waveform)
+        return int(np.asarray(waveform).size)
+
+    @staticmethod
+    def _serialize_waveform(waveform: Any) -> tuple[bytes, list[int], str]:
+        if isinstance(waveform, torch.Tensor):
+            array = waveform.detach().cpu().float().numpy()
+        elif isinstance(waveform, np.ndarray):
+            array = waveform.astype(np.float32, copy=False)
+        elif isinstance(waveform, (bytes, bytearray, memoryview)):
+            raw = bytes(waveform)
+            return raw, [len(raw)], "uint8"
+        else:
+            array = np.asarray(waveform, dtype=np.float32)
+        array = np.asarray(array, dtype=np.float32)
+        return array.tobytes(), list(array.shape), str(array.dtype)
+
+    def _resolve_sample_rate(self) -> int:
+        if self._sample_rate is not None:
+            return int(self._sample_rate)
+        for owner in (self._audio_detokenizer, self._talker):
+            sr = self._sample_rate_from(owner)
+            if sr is not None:
+                self._sample_rate = sr
+                return sr
+        self._sample_rate = DEFAULT_SAMPLE_RATE
+        return self._sample_rate
+
+    @staticmethod
+    def _sample_rate_from(owner: Any) -> int | None:
+        if owner is None:
+            return None
+        config = getattr(owner, "config", None)
+        sr = getattr(config, "sample_rate", None)
+        if sr is None:
+            sr = getattr(owner, "sample_rate", None)
+        return int(sr) if sr is not None else None
+
+    # ------------------------------------------------------------------ model load
+    def _load_models(self) -> None:
+        if self._model_path is None:
+            raise RuntimeError(
+                "MingStreamingTalkerScheduler needs model_path to load talker"
+            )
+        from transformers import AutoTokenizer
+
+        from sglang_omni.models.ming_omni.talker import (
+            MingOmniTalker,
+            MingOmniTalkerConfig,
+            SpkembExtractor,
+        )
+        from sglang_omni.models.ming_omni.talker.audio_vae.modeling_audio_vae import (
+            AudioVAE,
+        )
+        from sglang_omni.models.weight_loader import load_weights_by_prefix
+
+        t_start = time.perf_counter()
+        talker_dir = str(Path(self._model_path) / "talker")
+        logger.info(
+            "[TALKER_STREAM] loading talker from %s device=%s",
+            talker_dir,
+            self._device,
+        )
+        config = MingOmniTalkerConfig.from_pretrained_dir(talker_dir)
+        talker = MingOmniTalker(config)
+        talker.eval()
+        weights = load_weights_by_prefix(talker_dir, prefix="")
+        talker.load_weights(weights.items())
+        talker.to(device=self._device, dtype=torch.bfloat16)
+        talker.set_tokenizer(
+            AutoTokenizer.from_pretrained(str(Path(talker_dir) / "llm"))
+        )
+
+        voice_json = os.path.join(talker_dir, "data", "voice_name.json")
+        if os.path.exists(voice_json):
+            with open(voice_json) as f:
+                voice_dict = json.load(f)
+            for value in voice_dict.values():
+                value["prompt_wav_path"] = os.path.join(
+                    talker_dir, value["prompt_wav_path"]
+                )
+            talker.set_voice_presets(voice_dict)
+        else:
+            logger.warning("[TALKER_STREAM] voice_name.json missing at %s", voice_json)
+
+        campplus = os.path.join(talker_dir, "campplus.onnx")
+        try:
+            talker.set_spkemb_extractor(SpkembExtractor(campplus))
+        except (ImportError, Exception) as exc:
+            logger.warning("[TALKER_STREAM] SpkembExtractor unavailable: %s", exc)
+
+        try:
+            from talker_tn.talker_tn import TalkerTN
+
+            talker.set_normalizer(TalkerTN())
+        except ImportError:
+            logger.warning("[TALKER_STREAM] TalkerTN unavailable; identity normalizer")
+
+        vae_dir = str(Path(talker_dir) / "vae")
+        vae = None
+        if Path(vae_dir).exists():
+            vae = AudioVAE.from_pretrained(vae_dir, dtype=torch.bfloat16)
+            vae.to(self._device)
+            vae.eval()
+        else:
+            logger.warning("[TALKER_STREAM] AudioVAE missing at %s", vae_dir)
+
+        talker.initial_graph()
+        self._talker = talker
+        self._audio_detokenizer = vae
+        logger.info(
+            "[TALKER_STREAM] talker loaded in %.2fs",
+            time.perf_counter() - t_start,
+        )

--- a/sglang_omni/models/ming_omni/components/streaming_text.py
+++ b/sglang_omni/models/ming_omni/components/streaming_text.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import torch
+
+from sglang_omni.pipeline.stage.stream_queue import StreamSignal
+from sglang_omni.proto import StagePayload
+
+TokenCountFn = Callable[[str], int]
+
+
+_SEGMENT_END_PUNCTUATION = (".", "!", "?", "。", "！", "？", "；", ";")
+
+
+@dataclass
+class CompletedResult:
+    request_id: str
+    payload: StagePayload | None = None
+    error: BaseException | None = None
+
+
+def is_done_signal(item: Any) -> bool:
+    if item is None:
+        return True
+    return isinstance(item, StreamSignal) and item.is_done and item.error is None
+
+
+def text_to_uint8_tensor(text: str) -> torch.Tensor:
+    return torch.tensor(list(text.encode("utf-8")), dtype=torch.uint8)
+
+
+def uint8_tensor_to_text(tensor: torch.Tensor) -> str:
+    if tensor.dtype != torch.uint8:
+        raise TypeError("uint8_tensor_to_text expects a torch.uint8 tensor")
+    values = tensor.detach().cpu().flatten().tolist()
+    return bytes(values).decode("utf-8", errors="ignore")
+
+
+def split_whitespace_tokens(text: str, max_tokens: int) -> tuple[str, str]:
+    parts = text.split()
+    if len(parts) <= max_tokens:
+        return text, ""
+    return " ".join(parts[:max_tokens]), " ".join(parts[max_tokens:])
+
+
+@dataclass(frozen=True)
+class SegmenterConfig:
+    segment_min_tokens: int = 8
+    segment_max_tokens: int = 40
+    first_segment_min_tokens: int = 4
+    first_segment_max_wait_ms: int = 450
+
+    def __post_init__(self) -> None:
+        if self.segment_min_tokens <= 0:
+            raise ValueError("segment_min_tokens must be positive")
+        if self.segment_max_tokens <= 0:
+            raise ValueError("segment_max_tokens must be positive")
+        if self.first_segment_min_tokens <= 0:
+            raise ValueError("first_segment_min_tokens must be positive")
+        if self.segment_min_tokens > self.segment_max_tokens:
+            raise ValueError("segment_min_tokens must be <= segment_max_tokens")
+        if self.first_segment_min_tokens > self.segment_max_tokens:
+            raise ValueError("first_segment_min_tokens must be <= segment_max_tokens")
+        if self.first_segment_max_wait_ms < 0:
+            raise ValueError("first_segment_max_wait_ms must be non-negative")
+
+
+@dataclass(frozen=True)
+class TextSegment:
+    segment_id: int
+    text: str
+    is_final_segment: bool = False
+
+
+class SegmenterState:
+    def __init__(
+        self,
+        config: SegmenterConfig,
+        token_count_fn: TokenCountFn,
+    ) -> None:
+        self.config = config
+        self.token_count_fn = token_count_fn
+        self._buffer = ""
+        self._segment_id = 0
+        self._first_text_ms: int | None = None
+
+    def push(self, text: str, *, now_ms: int) -> list[TextSegment]:
+        if text and self._first_text_ms is None:
+            self._first_text_ms = now_ms
+        self._buffer += text
+        if not self._buffer:
+            return []
+
+        tokens = self.token_count_fn(self._buffer)
+        if tokens >= self.config.segment_max_tokens:
+            return [self._emit_max_window(now_ms=now_ms)]
+
+        first_timeout_ready = (
+            self._segment_id == 0
+            and self._first_text_ms is not None
+            and tokens >= self.config.first_segment_min_tokens
+            and now_ms - self._first_text_ms >= self.config.first_segment_max_wait_ms
+        )
+        should_emit = (
+            tokens >= self.config.segment_min_tokens
+            and self._has_segment_end_punctuation()
+        ) or first_timeout_ready
+        if not should_emit:
+            return []
+
+        return [self._emit(is_final_segment=False)]
+
+    def buffer_token_count(self) -> int:
+        return self.token_count_fn(self._buffer) if self._buffer else 0
+
+    def flush(self) -> list[TextSegment]:
+        if not self._buffer:
+            return []
+        return [self._emit(is_final_segment=True)]
+
+    def _has_segment_end_punctuation(self) -> bool:
+        return self._buffer.rstrip().endswith(_SEGMENT_END_PUNCTUATION)
+
+    def _emit_max_window(self, *, now_ms: int) -> TextSegment:
+        text, remainder = split_whitespace_tokens(
+            self._buffer, self.config.segment_max_tokens
+        )
+        return self._emit_text(
+            text=text,
+            remainder=remainder,
+            is_final_segment=False,
+            remainder_start_ms=now_ms if remainder else None,
+        )
+
+    def _emit(self, *, is_final_segment: bool) -> TextSegment:
+        return self._emit_text(
+            text=self._buffer,
+            remainder="",
+            is_final_segment=is_final_segment,
+            remainder_start_ms=None,
+        )
+
+    def _emit_text(
+        self,
+        *,
+        text: str,
+        remainder: str,
+        is_final_segment: bool,
+        remainder_start_ms: int | None,
+    ) -> TextSegment:
+        segment = TextSegment(
+            segment_id=self._segment_id,
+            text=text,
+            is_final_segment=is_final_segment,
+        )
+        self._segment_id += 1
+        self._buffer = remainder
+        self._first_text_ms = remainder_start_ms
+        return segment

--- a/sglang_omni/models/ming_omni/config.py
+++ b/sglang_omni/models/ming_omni/config.py
@@ -14,7 +14,9 @@ from sglang_omni.models.ming_omni.pipeline.next_stage import (
     DECODE_STAGE,
     IMAGE_STAGE,
     PREPROCESSING_STAGE,
+    SEGMENTER_STAGE,
     TALKER_STAGE,
+    TALKER_STREAM_STAGE,
     THINKER_STAGE,
 )
 
@@ -102,6 +104,47 @@ def _thinker_stage(*, gpu: int, speech_enabled: bool, process: str) -> StageConf
     )
 
 
+def _streaming_thinker_stage(*, gpu: int, process: str) -> StageConfig:
+    """Thinker stage variant for streaming TTS.
+
+    Fans out to decode + segmenter (final payload) AND streams per-token text
+    deltas to the segmenter via stream_to. Sets enable_streaming_tts=True
+    on the factory so the thinker installs the per-token stream callback.
+    """
+    return StageConfig(
+        name=THINKER_STAGE,
+        process=process,
+        factory=f"{_PKG}.stages.create_sglang_thinker_executor_from_config",
+        factory_args={"thinker_max_seq_len": 8192, "enable_streaming_tts": True},
+        gpu=gpu,
+        next=[DECODE_STAGE, SEGMENTER_STAGE],
+        stream_to=[SEGMENTER_STAGE],
+    )
+
+
+def _segmenter_stage(*, process: str) -> StageConfig:
+    return StageConfig(
+        name=SEGMENTER_STAGE,
+        process=process,
+        factory=f"{_PKG}.stages.create_streaming_segmenter_executor",
+        next=TALKER_STREAM_STAGE,
+        stream_to=[TALKER_STREAM_STAGE],
+        can_accept_stream_before_payload=True,
+    )
+
+
+def _talker_stream_stage(*, gpu: int, process: str) -> StageConfig:
+    return StageConfig(
+        name=TALKER_STREAM_STAGE,
+        process=process,
+        factory=f"{_PKG}.stages.create_streaming_talker_executor",
+        factory_args={"device": "cuda", "voice": "DB30"},
+        gpu=gpu,
+        terminal=True,
+        can_accept_stream_before_payload=True,
+    )
+
+
 def _decode_stage(*, process: str) -> StageConfig:
     return StageConfig(
         name=DECODE_STAGE,
@@ -142,6 +185,19 @@ def _ming_speech_stages() -> list[StageConfig]:
         _thinker_stage(gpu=0, speech_enabled=True, process="thinker"),
         _decode_stage(process="decode"),
         _talker_stage(gpu=1, process="talker"),
+    ]
+
+
+def _ming_streaming_speech_stages() -> list[StageConfig]:
+    return [
+        _preprocessing_stage(process="preprocessing"),
+        _audio_encoder_stage(gpu=0, process="audio_encoder"),
+        _image_encoder_stage(gpu=0, process="image_encoder"),
+        _aggregate_stage(process="mm_aggregate"),
+        _streaming_thinker_stage(gpu=0, process="thinker"),
+        _decode_stage(process="decode"),
+        _segmenter_stage(process="segmenter"),
+        _talker_stream_stage(gpu=1, process="talker_stream"),
     ]
 
 
@@ -198,9 +254,55 @@ class MingOmniSpeechPipelineConfig(PipelineConfig):
         )
 
 
+class MingOmniStreamingSpeechPipelineConfig(PipelineConfig):
+    """8-stage streaming-TTS speech pipeline.
+
+    Adds a ``segmenter`` stage between ``thinker`` and ``talker_stream``
+    that converts incremental thinker text deltas into speakable segments.
+    The thinker fans out final payloads to ``decode`` and ``segmenter``,
+    and streams per-token deltas to ``segmenter`` via stream_to. The
+    streaming talker emits audio chunks to the coordinator (terminal).
+    """
+
+    architecture: ClassVar[str] = "BailingMoeV2ForCausalLM"
+
+    model_path: str
+    entry_stage: str = PREPROCESSING_STAGE
+    placement: PlacementConfig = Field(
+        default_factory=lambda: PlacementConfig(
+            require_memory_fraction_for_colocation=False
+        )
+    )
+    stages: list[StageConfig] = Field(default_factory=_ming_streaming_speech_stages)
+
+    def model_post_init(self, __context: Any = None) -> None:
+        super().model_post_init(__context)
+        self._validate_talker_stream_gpu_not_in_thinker_tp_range()
+
+    def _validate_talker_stream_gpu_not_in_thinker_tp_range(self) -> None:
+        thinker = _stage_by_name(self.stages, THINKER_STAGE)
+        talker = _stage_by_name(self.stages, TALKER_STREAM_STAGE)
+        if thinker is None or talker is None:
+            return
+
+        thinker_gpus = _stage_gpu_set(thinker.gpu, thinker.tp_size)
+        talker_gpus = _stage_gpu_set(talker.gpu, talker.tp_size)
+        collisions = thinker_gpus & talker_gpus
+        if not collisions:
+            return
+
+        raise ValueError(
+            "Ming-Omni streaming-speech talker GPU collides with thinker TP range: "
+            f"talker gpus={sorted(talker_gpus)}, "
+            f"thinker gpus={sorted(thinker_gpus)}, "
+            f"collisions={sorted(collisions)}"
+        )
+
+
 EntryClass = MingOmniPipelineConfig
 
 Variants = {
     "text": MingOmniPipelineConfig,
     "speech": MingOmniSpeechPipelineConfig,
+    "streaming_speech": MingOmniStreamingSpeechPipelineConfig,
 }

--- a/sglang_omni/models/ming_omni/pipeline/next_stage.py
+++ b/sglang_omni/models/ming_omni/pipeline/next_stage.py
@@ -15,6 +15,8 @@ AGGREGATE_STAGE = "mm_aggregate"
 THINKER_STAGE = "thinker"
 DECODE_STAGE = "decode"
 TALKER_STAGE = "talker"
+SEGMENTER_STAGE = "segmenter"
+TALKER_STREAM_STAGE = "talker_stream"
 
 
 def preprocessing_next(request_id: str, output: Any) -> list[str]:

--- a/sglang_omni/models/ming_omni/stages.py
+++ b/sglang_omni/models/ming_omni/stages.py
@@ -122,6 +122,33 @@ def create_aggregate_executor():
     return SimpleScheduler(_identity)
 
 
+def create_streaming_segmenter_executor(
+    *,
+    segment_min_tokens: int = 8,
+    segment_max_tokens: int = 40,
+    first_segment_min_tokens: int = 4,
+    first_segment_max_wait_ms: int = 450,
+):
+    """Factory for the streaming TTS segmenter stage.
+
+    Returns a stream-aware scheduler that consumes text deltas from the
+    thinker's stream channel and emits speakable segments on its own
+    stream channel to the talker stream stage.
+    """
+    from sglang_omni.models.ming_omni.components.streaming_segmenter import (
+        MingStreamingSegmenterScheduler,
+    )
+    from sglang_omni.models.ming_omni.components.streaming_text import SegmenterConfig
+
+    config = SegmenterConfig(
+        segment_min_tokens=segment_min_tokens,
+        segment_max_tokens=segment_max_tokens,
+        first_segment_min_tokens=first_segment_min_tokens,
+        first_segment_max_wait_ms=first_segment_max_wait_ms,
+    )
+    return MingStreamingSegmenterScheduler(config=config)
+
+
 def create_audio_encoder_executor(
     model_path: str,
     *,

--- a/sglang_omni/models/ming_omni/stages.py
+++ b/sglang_omni/models/ming_omni/stages.py
@@ -192,6 +192,7 @@ def create_sglang_thinker_executor_from_config(
     nccl_port: int | None = None,
     thinker_max_seq_len: int = 8192,
     server_args_overrides: dict[str, Any] | None = None,
+    enable_streaming_tts: bool = False,
 ):
     from sglang_omni.models.ming_omni.bootstrap import create_thinker_scheduler
     from sglang_omni.models.ming_omni.registration import register_ming_hf_config
@@ -214,6 +215,7 @@ def create_sglang_thinker_executor_from_config(
         tp_rank=tp_rank,
         tp_size=tp_size,
         nccl_port=nccl_port,
+        enable_streaming_tts=enable_streaming_tts,
     )
 
 

--- a/sglang_omni/models/ming_omni/stages.py
+++ b/sglang_omni/models/ming_omni/stages.py
@@ -281,6 +281,31 @@ def create_talker_executor(
     return SimpleScheduler(_talk)
 
 
+def create_streaming_talker_executor(
+    model_path: str,
+    *,
+    device: str = "cuda",
+    voice: str = "DB30",
+):
+    """Factory for the streaming TTS talker stage.
+
+    Consumes text segments emitted by the segmenter and produces audio
+    chunks on the outbox stream channel. Terminal stage — chunks go to
+    the coordinator and out to the client.
+    """
+    from sglang_omni.models.ming_omni.components.streaming_talker import (
+        MingStreamingTalkerScheduler,
+    )
+    from sglang_omni.models.weight_loader import resolve_model_path
+
+    local_path = resolve_model_path(model_path)
+    return MingStreamingTalkerScheduler(
+        model_path=local_path,
+        device=device,
+        voice=voice,
+    )
+
+
 def create_decode_executor(model_path: str):
     from sglang_omni.models.ming_omni.components.common import load_ming_tokenizer
     from sglang_omni.models.ming_omni.io import OmniEvent

--- a/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
+++ b/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
@@ -7,12 +7,12 @@ infrastructure, CFM/DiT/Aggregator modules and generation.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import math
 import queue
 import re
 import threading
-import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from queue import Queue
@@ -34,6 +34,8 @@ from .talker_module.cfm import CFM, get_epss_timesteps
 from .talker_module.dit import DiT
 
 logger = logging.getLogger(__name__)
+
+_TOKEN_DONE = object()
 
 # ---------- Optional: onnxruntime for speaker embedding ----------
 try:
@@ -109,8 +111,16 @@ class CFMGraphExecutor:
         self.graph = None
 
     def execute(
-        self, input_tensor, his_lat, cfg_strength=2.0, sigma=0.25, temperature=0.0
+        self,
+        input_tensor,
+        his_lat,
+        cfg_strength=2.0,
+        sigma=0.25,
+        temperature=0.0,
+        abort_event: threading.Event | None = None,
     ):
+        if abort_event is not None and abort_event.is_set():
+            raise asyncio.CancelledError()
         bat_size, his_patch_size, z_dim = his_lat.shape
         randn_tensor = torch.randn(
             (bat_size, self.config.patch_size, z_dim),
@@ -127,7 +137,11 @@ class CFMGraphExecutor:
         )
 
         if not self.initialized:
-            self._initialize_graph(input_tensor, his_lat, randn_tensor, sde_rnd)
+            if abort_event is not None and abort_event.is_set():
+                raise asyncio.CancelledError()
+            self._initialize_graph(
+                input_tensor, his_lat, randn_tensor, sde_rnd, abort_event
+            )
 
         self.last_hidden_state_placeholder.copy_(input_tensor)
         self.his_lat_placeholder.copy_(his_lat)
@@ -138,7 +152,13 @@ class CFMGraphExecutor:
         self.sde_args_placeholder[2] = temperature
         self.sde_rnd_placeholder.copy_(sde_rnd)
 
+        if abort_event is not None and abort_event.is_set():
+            raise asyncio.CancelledError()
+        # Python abort checks inside CFM.sample run during capture; replay is
+        # bounded by explicit checks before and after the CUDA graph replay.
         self.graph.replay()
+        if abort_event is not None and abort_event.is_set():
+            raise asyncio.CancelledError()
 
         gen_lat = torch.empty_like(self.gen_lat_placeholder)
         gen_lat.copy_(self.gen_lat_placeholder)
@@ -149,7 +169,9 @@ class CFMGraphExecutor:
 
         return gen_lat, inputs_embeds, stop_out
 
-    def _initialize_graph(self, input_tensor, his_lat, randn_tensor, sde_rnd):
+    def _initialize_graph(
+        self, input_tensor, his_lat, randn_tensor, sde_rnd, abort_event=None
+    ):
         self.last_hidden_state_placeholder = torch.empty_like(input_tensor)
         self.his_lat_placeholder = torch.empty_like(his_lat)
         self.randn_like_placeholder = torch.empty_like(randn_tensor)
@@ -163,20 +185,33 @@ class CFMGraphExecutor:
         )
         self.sde_rnd_placeholder = torch.empty_like(sde_rnd)
 
+        # (wenyao) Aborting CFM.sample during torch.cuda.graph capture corrupts the
+        # partial graph. Pass abort_event=None during capture; the caller
+        # (execute) checks abort before _initialize_graph and on every replay.
         self.graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(self.graph):
-            self.gen_lat_placeholder = self.cfm.sample(
-                self.last_hidden_state_placeholder,
-                self.his_lat_placeholder,
-                self.randn_like_placeholder,
-                self.t_placeholder,
-                self.sde_args_placeholder,
-                self.sde_rnd_placeholder,
-            )
-            self.inputs_embeds_placeholder = self.aggregator(self.gen_lat_placeholder)
-            self.stop_out_placeholder = self.stop_head(
-                self.last_hidden_state_placeholder[:, -1, :]
-            ).softmax(dim=-1)
+        try:
+            with torch.cuda.graph(self.graph):
+                self.gen_lat_placeholder = self.cfm.sample(
+                    self.last_hidden_state_placeholder,
+                    self.his_lat_placeholder,
+                    self.randn_like_placeholder,
+                    self.t_placeholder,
+                    self.sde_args_placeholder,
+                    self.sde_rnd_placeholder,
+                    abort_event=None,
+                )
+                self.inputs_embeds_placeholder = self.aggregator(
+                    self.gen_lat_placeholder
+                )
+                self.stop_out_placeholder = self.stop_head(
+                    self.last_hidden_state_placeholder[:, -1, :]
+                ).softmax(dim=-1)
+        except BaseException:
+            self.graph = None
+            self.gen_lat_placeholder = None
+            self.inputs_embeds_placeholder = None
+            self.stop_out_placeholder = None
+            raise
 
         self.initialized = True
 
@@ -206,12 +241,18 @@ class CFMGraphExecutorPool:
             self.pool.put(executor)
 
     def execute(
-        self, input_tensor, his_lat, cfg_strength=2.0, sigma=0.25, temperature=0.0
+        self,
+        input_tensor,
+        his_lat,
+        cfg_strength=2.0,
+        sigma=0.25,
+        temperature=0.0,
+        abort_event: threading.Event | None = None,
     ):
         executor = self.acquire()
         try:
             return executor.execute(
-                input_tensor, his_lat, cfg_strength, sigma, temperature
+                input_tensor, his_lat, cfg_strength, sigma, temperature, abort_event
             )
         finally:
             self.release(executor)
@@ -373,24 +414,25 @@ class MingOmniTalker(nn.Module):
                         "Please generate speech based on the following description.\n"
                     )
                     text = "Initialize compilation graph"
-                    future = self.executor.submit(
-                        self.llm_job,
-                        prompt,
-                        text,
-                        None,
-                        None,
-                        "",
-                        None,
-                        None,
-                        this_uuid,
-                    )
-                    future.result()
-
-                    with self.lock:
-                        self.tts_speech_token_dict.pop(this_uuid)
-                        self.llm_end_dict.pop(this_uuid)
-                        self.vae_cache.pop(this_uuid)
-                        self.sil_holder_cache.pop(this_uuid)
+                    try:
+                        future = self.executor.submit(
+                            self.llm_job,
+                            prompt,
+                            text,
+                            None,
+                            None,
+                            "",
+                            None,
+                            None,
+                            this_uuid,
+                        )
+                        future.result()
+                    finally:
+                        with self.lock:
+                            self.tts_speech_token_dict.pop(this_uuid, None)
+                            self.llm_end_dict.pop(this_uuid, None)
+                            self.vae_cache.pop(this_uuid, None)
+                            self.sil_holder_cache.pop(this_uuid, None)
 
                 self.initialized = True
 
@@ -414,6 +456,7 @@ class MingOmniTalker(nn.Module):
         cfg=2.0,
         sigma=0.25,
         temperature=0,
+        abort_event: threading.Event | None = None,
     ):
         step = 0
         target_dtype = torch.bfloat16
@@ -446,121 +489,128 @@ class MingOmniTalker(nn.Module):
             model_graph,
         ) = self.model_graph_pool.get()
 
-        if past_key_values is None:
-            past_key_values = StaticCache(
-                config=self.model.config,
-                max_batch_size=1,
-                max_cache_len=max_cache_len,
-                device=self.model.device,
-                dtype=target_dtype,
-            )
-        else:
-            if hasattr(past_key_values, "reset"):
-                past_key_values.reset()
-            elif hasattr(past_key_values, "key_cache"):
-                for layer_idx in range(len(past_key_values.key_cache)):
-                    past_key_values.key_cache[layer_idx].zero_()
-                    past_key_values.value_cache[layer_idx].zero_()
-            else:
-                for layer in past_key_values.layers:
-                    layer.keys.zero_()
-                    layer.values.zero_()
-
-        prefill_len = inputs_embeds.shape[1]
-        attention_mask = torch.ones(input_ids.shape).to(input_ids.device)
-        position_ids = (attention_mask.cumsum(-1) - 1).masked_fill_(
-            (attention_mask == 0), 1
-        )
-
-        max_decode_steps = (max_cache_len - prefill_len) // self.patch_size
-
-        while step < 1000 and step < max_decode_steps:
-            if step == 0:
-                prefill_cache_position = torch.arange(
-                    0, prefill_len, device=inputs_embeds.device
-                )
-                outputs = self.model(
-                    position_ids=position_ids,
-                    cache_position=prefill_cache_position,
-                    past_key_values=past_key_values,
-                    inputs_embeds=inputs_embeds,
-                    use_cache=True,
-                    output_hidden_states=True,
+        try:
+            if past_key_values is None:
+                past_key_values = StaticCache(
+                    config=self.model.config,
+                    max_batch_size=1,
+                    max_cache_len=max_cache_len,
+                    device=self.model.device,
+                    dtype=target_dtype,
                 )
             else:
-                past_seen_tokens = past_key_values.get_seq_length()
-                cache_position = torch.arange(
-                    past_seen_tokens,
-                    past_seen_tokens + inputs_embeds.shape[1],
-                    device=inputs_embeds.device,
-                )
-
-                if model_graph is None:
-                    model_graph = torch.cuda.CUDAGraph()
-                    inputs_embeds_placeholder = torch.empty_like(inputs_embeds)
-                    position_ids_placeholder = None
-                    attention_mask_placeholder = None
-                    cache_position_placeholder = torch.empty_like(cache_position)
-
-                    inputs_embeds_placeholder.copy_(inputs_embeds)
-                    cache_position_placeholder.copy_(cache_position)
-
-                    with torch.cuda.graph(model_graph):
-                        outputs_placeholder = self.model(
-                            position_ids=position_ids_placeholder,
-                            cache_position=cache_position_placeholder,
-                            attention_mask=attention_mask_placeholder,
-                            past_key_values=past_key_values,
-                            inputs_embeds=inputs_embeds_placeholder,
-                            use_cache=True,
-                            output_hidden_states=True,
-                        )
+                if hasattr(past_key_values, "reset"):
+                    past_key_values.reset()
+                elif hasattr(past_key_values, "key_cache"):
+                    for layer_idx in range(len(past_key_values.key_cache)):
+                        past_key_values.key_cache[layer_idx].zero_()
+                        past_key_values.value_cache[layer_idx].zero_()
                 else:
-                    inputs_embeds_placeholder.copy_(inputs_embeds)
-                    if cache_position_placeholder is not None:
+                    for layer in past_key_values.layers:
+                        layer.keys.zero_()
+                        layer.values.zero_()
+
+            prefill_len = inputs_embeds.shape[1]
+            attention_mask = torch.ones(input_ids.shape).to(input_ids.device)
+            position_ids = (attention_mask.cumsum(-1) - 1).masked_fill_(
+                (attention_mask == 0), 1
+            )
+
+            max_decode_steps = (max_cache_len - prefill_len) // self.patch_size
+
+            while step < 1000 and step < max_decode_steps:
+                if abort_event is not None and abort_event.is_set():
+                    raise asyncio.CancelledError()
+                if step == 0:
+                    prefill_cache_position = torch.arange(
+                        0, prefill_len, device=inputs_embeds.device
+                    )
+                    outputs = self.model(
+                        position_ids=position_ids,
+                        cache_position=prefill_cache_position,
+                        past_key_values=past_key_values,
+                        inputs_embeds=inputs_embeds,
+                        use_cache=True,
+                        output_hidden_states=True,
+                    )
+                else:
+                    past_seen_tokens = past_key_values.get_seq_length()
+                    cache_position = torch.arange(
+                        past_seen_tokens,
+                        past_seen_tokens + inputs_embeds.shape[1],
+                        device=inputs_embeds.device,
+                    )
+
+                    if model_graph is None:
+                        model_graph = torch.cuda.CUDAGraph()
+                        inputs_embeds_placeholder = torch.empty_like(inputs_embeds)
+                        position_ids_placeholder = None
+                        attention_mask_placeholder = None
+                        cache_position_placeholder = torch.empty_like(cache_position)
+
+                        inputs_embeds_placeholder.copy_(inputs_embeds)
                         cache_position_placeholder.copy_(cache_position)
-                    model_graph.replay()
 
-                outputs = outputs_placeholder
+                        with torch.cuda.graph(model_graph):
+                            outputs_placeholder = self.model(
+                                position_ids=position_ids_placeholder,
+                                cache_position=cache_position_placeholder,
+                                attention_mask=attention_mask_placeholder,
+                                past_key_values=past_key_values,
+                                inputs_embeds=inputs_embeds_placeholder,
+                                use_cache=True,
+                                output_hidden_states=True,
+                            )
+                    else:
+                        inputs_embeds_placeholder.copy_(inputs_embeds)
+                        if cache_position_placeholder is not None:
+                            cache_position_placeholder.copy_(cache_position)
+                        model_graph.replay()
 
-            hidden_out = outputs.hidden_states[-1][:, -1:, :]
+                    outputs = outputs_placeholder
 
-            gen_lat, inputs_embeds, stop_out = self.sampler_pool.execute(
-                hidden_out,
-                his_lat,
-                cfg,
-                sigma,
-                temperature,
-            )
+                hidden_out = outputs.hidden_states[-1][:, -1:, :]
 
-            if self.his_patch_size == self.patch_size:
-                his_lat = gen_lat
-            elif self.his_patch_size > self.patch_size:
-                his_lat = torch.cat(
-                    [his_lat[:, self.patch_size - self.his_patch_size :], gen_lat],
-                    dim=1,
+                gen_lat, inputs_embeds, stop_out = self.sampler_pool.execute(
+                    hidden_out,
+                    his_lat,
+                    cfg,
+                    sigma,
+                    temperature,
+                    abort_event,
                 )
-            else:
-                raise NotImplementedError
 
-            if step > min_new_token and stop_out.cpu()[0, 1] > 0.5:
-                yield gen_lat, True
-                break
+                if self.his_patch_size == self.patch_size:
+                    his_lat = gen_lat
+                elif self.his_patch_size > self.patch_size:
+                    his_lat = torch.cat(
+                        [his_lat[:, self.patch_size - self.his_patch_size :], gen_lat],
+                        dim=1,
+                    )
+                else:
+                    raise NotImplementedError
 
-            yield gen_lat, False
-            step += 1
+                if abort_event is not None and abort_event.is_set():
+                    raise asyncio.CancelledError()
 
-        self.model_graph_pool.put(
-            (
-                past_key_values,
-                inputs_embeds_placeholder,
-                cache_position_placeholder,
-                position_ids_placeholder,
-                attention_mask_placeholder,
-                outputs_placeholder,
-                model_graph,
+                if step > min_new_token and stop_out.cpu()[0, 1] > 0.5:
+                    yield gen_lat, True
+                    break
+
+                yield gen_lat, False
+                step += 1
+        finally:
+            self.model_graph_pool.put(
+                (
+                    past_key_values,
+                    inputs_embeds_placeholder,
+                    cache_position_placeholder,
+                    position_ids_placeholder,
+                    attention_mask_placeholder,
+                    outputs_placeholder,
+                    model_graph,
+                )
             )
-        )
 
     def omni_audio_generation_func(
         self,
@@ -574,6 +624,7 @@ class MingOmniTalker(nn.Module):
         cfg=2.0,
         sigma=0.25,
         temperature=0,
+        abort_event: threading.Event | None = None,
     ):
         assert (
             self.tokenizer is not None
@@ -668,6 +719,7 @@ class MingOmniTalker(nn.Module):
                 cfg=cfg,
                 sigma=sigma,
                 temperature=temperature,
+                abort_event=abort_event,
             ):
                 yield audio_token
 
@@ -755,23 +807,37 @@ class MingOmniTalker(nn.Module):
         cfg=2.0,
         sigma=0.25,
         temperature=0,
+        token_queue: queue.Queue | None = None,
+        abort_event: threading.Event | None = None,
     ):
-        with torch.cuda.stream(torch.cuda.Stream(self.device)):
-            for audio_token in self.omni_audio_generation_func(
-                prompt=prompt,
-                text=text,
-                spk_emb=spk_emb,
-                instruction=instruction,
-                prompt_text=prompt_text,
-                prompt_wav_lat=prompt_wav_lat,
-                prompt_wav_emb=prompt_wav_emb,
-                cfg=cfg,
-                sigma=sigma,
-                temperature=temperature,
-            ):
-                torch.cuda.current_stream().synchronize()
-                self.tts_speech_token_dict[this_uuid].append(audio_token)
-        self.llm_end_dict[this_uuid] = True
+        try:
+            with torch.cuda.stream(torch.cuda.Stream(self.device)):
+                for audio_token in self.omni_audio_generation_func(
+                    prompt=prompt,
+                    text=text,
+                    spk_emb=spk_emb,
+                    instruction=instruction,
+                    prompt_text=prompt_text,
+                    prompt_wav_lat=prompt_wav_lat,
+                    prompt_wav_emb=prompt_wav_emb,
+                    cfg=cfg,
+                    sigma=sigma,
+                    temperature=temperature,
+                    abort_event=abort_event,
+                ):
+                    if abort_event is not None and abort_event.is_set():
+                        raise asyncio.CancelledError()
+                    torch.cuda.current_stream().synchronize()
+                    if token_queue is not None:
+                        token_queue.put(audio_token)
+                    else:
+                        self.tts_speech_token_dict[this_uuid].append(audio_token)
+        finally:
+            with self.lock:
+                if this_uuid in self.llm_end_dict:
+                    self.llm_end_dict[this_uuid] = True
+            if token_queue is not None:
+                token_queue.put(_TOKEN_DONE)
 
     def tts_job(
         self,
@@ -787,9 +853,16 @@ class MingOmniTalker(nn.Module):
         cfg=2.0,
         sigma=0.25,
         temperature=0,
+        abort_event: threading.Event | None = None,
     ):
         with torch.cuda.stream(torch.cuda.Stream(self.device)):
             this_uuid = str(uuid.uuid1())
+            token_queue = queue.Queue() if stream else None
+            effective_abort_event = abort_event
+            if stream and effective_abort_event is None:
+                effective_abort_event = threading.Event()
+            completed = False
+            future = None
             with self.lock:
                 self.tts_speech_token_dict[this_uuid] = []
                 self.llm_end_dict[this_uuid] = False
@@ -799,36 +872,50 @@ class MingOmniTalker(nn.Module):
                 }
                 self.sil_holder_cache[this_uuid] = None
 
-            future = self.executor.submit(
-                self.llm_job,
-                prompt,
-                text,
-                spk_emb,
-                instruction,
-                prompt_text,
-                prompt_wav_lat,
-                prompt_wav_emb,
-                this_uuid,
-                cfg,
-                sigma,
-                temperature,
-            )
+            try:
+                future = self.executor.submit(
+                    self.llm_job,
+                    prompt,
+                    text,
+                    spk_emb,
+                    instruction,
+                    prompt_text,
+                    prompt_wav_lat,
+                    prompt_wav_emb,
+                    this_uuid,
+                    cfg,
+                    sigma,
+                    temperature,
+                    token_queue=token_queue,
+                    abort_event=effective_abort_event,
+                )
 
-            if stream:
-                token_offset = 0
-                while True:
-                    if future.done():
-                        exc = future.exception()
-                        if exc:
-                            raise exc
-                    time.sleep(0.1)
-                    nxt = len(self.tts_speech_token_dict[this_uuid])
-                    if nxt > token_offset:
-                        this_tts_speech_token = self.tts_speech_token_dict[this_uuid][
-                            token_offset:nxt
-                        ]
-                        last_chunk = this_tts_speech_token[-1][-1]
-                        this_tts_speech_token = [ii[0] for ii in this_tts_speech_token]
+                if stream:
+                    assert token_queue is not None
+                    # 25ms wakeup keeps the abort_event check responsive when
+                    # llm_job has not yet pushed a token or _TOKEN_DONE.
+                    # Worst-case external abort latency is bounded by this poll
+                    # interval plus one inner generator step.
+                    while True:
+                        if (
+                            effective_abort_event is not None
+                            and effective_abort_event.is_set()
+                        ):
+                            raise asyncio.CancelledError()
+                        if future.done():
+                            exc = future.exception()
+                            if exc:
+                                raise exc
+                        try:
+                            queue_item = token_queue.get(timeout=0.025)
+                        except queue.Empty:
+                            continue
+                        if queue_item is _TOKEN_DONE:
+                            future.result()
+                            completed = True
+                            break
+                        last_chunk = queue_item[-1]
+                        this_tts_speech_token = [queue_item[0]]
                         this_tts_speech, self.vae_cache[this_uuid] = self.token2wav(
                             audio_detokenizer=audio_detokenizer,
                             token=this_tts_speech_token,
@@ -836,41 +923,43 @@ class MingOmniTalker(nn.Module):
                             stream=True,
                             last_chunk=last_chunk,
                         )
-                        token_offset = nxt
                         yield {"tts_speech": this_tts_speech.cpu()}
+                else:
+                    future.result()
+                    this_tts_speech_token = self.tts_speech_token_dict[this_uuid]
+                    this_tts_speech_token = [ii[0] for ii in this_tts_speech_token]
+                    this_tts_speech, self.vae_cache[this_uuid] = self.token2wav(
+                        audio_detokenizer=audio_detokenizer,
+                        token=this_tts_speech_token,
+                        cache=self.vae_cache[this_uuid],
+                        stream=False,
+                        last_chunk=True,
+                    )
+                    (
+                        this_tts_speech,
+                        self.sil_holder_cache[this_uuid],
+                    ) = self.silence_holder(
+                        this_tts_speech,
+                        audio_detokenizer.config.sample_rate,
+                        self.sil_holder_cache[this_uuid],
+                        True,
+                    )
+                    yield {"tts_speech": this_tts_speech.cpu()}
+                    completed = True
 
-                    if self.llm_end_dict[this_uuid] and token_offset == len(
-                        self.tts_speech_token_dict[this_uuid]
-                    ):
-                        break
-                future.result()
-            else:
-                future.result()
-                this_tts_speech_token = self.tts_speech_token_dict[this_uuid]
-                this_tts_speech_token = [ii[0] for ii in this_tts_speech_token]
-                this_tts_speech, self.vae_cache[this_uuid] = self.token2wav(
-                    audio_detokenizer=audio_detokenizer,
-                    token=this_tts_speech_token,
-                    cache=self.vae_cache[this_uuid],
-                    stream=False,
-                    last_chunk=True,
-                )
-                this_tts_speech, self.sil_holder_cache[this_uuid] = self.silence_holder(
-                    this_tts_speech,
-                    audio_detokenizer.config.sample_rate,
-                    self.sil_holder_cache[this_uuid],
-                    True,
-                )
-                yield {"tts_speech": this_tts_speech.cpu()}
-
-            if torch.cuda.is_available():
-                torch.cuda.current_stream().synchronize()
-
-            with self.lock:
-                self.tts_speech_token_dict.pop(this_uuid)
-                self.llm_end_dict.pop(this_uuid)
-                self.vae_cache.pop(this_uuid)
-                self.sil_holder_cache.pop(this_uuid)
+                if torch.cuda.is_available():
+                    torch.cuda.current_stream().synchronize()
+            finally:
+                if stream and not completed:
+                    if effective_abort_event is not None:
+                        effective_abort_event.set()
+                    if future is not None:
+                        future.cancel()
+                with self.lock:
+                    self.tts_speech_token_dict.pop(this_uuid, None)
+                    self.llm_end_dict.pop(this_uuid, None)
+                    self.vae_cache.pop(this_uuid, None)
+                    self.sil_holder_cache.pop(this_uuid, None)
 
     def register_prompt_wav(self, prompt_wav_path, audio_detokenizer):
         if isinstance(prompt_wav_path, str):
@@ -976,6 +1065,7 @@ class MingOmniTalker(nn.Module):
         prompt_wav_emb,
         stream,
         max_length=50,
+        abort_event: threading.Event | None = None,
     ):
         count = 0
         cache_position: dict = {}
@@ -1045,6 +1135,7 @@ class MingOmniTalker(nn.Module):
                     max_length,
                     wds_lg_zh,
                     wds_lg_en,
+                    abort_event,
                 )
                 count += 1
                 streaming_text = []
@@ -1067,6 +1158,7 @@ class MingOmniTalker(nn.Module):
                 max_length,
                 wds_lg_zh,
                 wds_lg_en,
+                abort_event,
             )
 
     def _process_segment(
@@ -1085,6 +1177,7 @@ class MingOmniTalker(nn.Module):
         max_length,
         wds_lg_zh,
         wds_lg_en,
+        abort_event: threading.Event | None = None,
     ):
         sub_output_dict = cut_text_by_semantic_length(streaming_text, max_length)
         text_list = sub_output_dict["fragments"]
@@ -1124,6 +1217,7 @@ class MingOmniTalker(nn.Module):
                     prompt_wav_lat=prompt_wav_lat,
                     prompt_wav_emb=prompt_wav_emb,
                     stream=use_stream,
+                    abort_event=abort_event,
                 )
             ):
                 tts_speech = this_tts_speech_dict["tts_speech"]
@@ -1186,6 +1280,7 @@ class MingOmniTalker(nn.Module):
         text = tts_text
         prompt = "Please generate speech based on the following description.\n"
         instruction = None
+        abort_event = kwargs.get("abort_event")
 
         with torch.cuda.stream(torch.cuda.Stream(self.device)):
             self.initial_graph()
@@ -1211,8 +1306,9 @@ class MingOmniTalker(nn.Module):
                 prompt_text,
                 prompt_wav_lat,
                 prompt_wav_emb,
-                stream,
-                max_length,
+                stream=stream,
+                max_length=max_length,
+                abort_event=abort_event if stream else None,
             )
 
     def instruct_audio_generation(
@@ -1234,6 +1330,7 @@ class MingOmniTalker(nn.Module):
         taskname="TTS",
         **kwargs,
     ):
+        abort_event = kwargs.get("abort_event")
         with torch.cuda.stream(torch.cuda.Stream(self.device)):
             self.initial_graph()
 
@@ -1265,6 +1362,7 @@ class MingOmniTalker(nn.Module):
                     cfg=cfg,
                     sigma=sigma,
                     temperature=temperature,
+                    abort_event=abort_event if stream else None,
                 ):
                     yield this_tts_speech_dict["tts_speech"], None, None, None
             else:
@@ -1277,6 +1375,7 @@ class MingOmniTalker(nn.Module):
                     prompt_text,
                     prompt_wav_lat,
                     prompt_wav_emb,
-                    stream,
-                    max_length,
+                    stream=stream,
+                    max_length=max_length,
+                    abort_event=abort_event if stream else None,
                 )

--- a/sglang_omni/models/ming_omni/talker/talker_module/cfm.py
+++ b/sglang_omni/models/ming_omni/talker/talker_module/cfm.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 import torch
 import torch.nn.functional as F
 from torch import nn
@@ -31,8 +33,12 @@ class CFM(nn.Module):
         self.sway_sampling_coef = sway_sampling_coef
 
     @torch.no_grad()
-    def sample(self, llm_cond, lat_cond, y0, t, sde_args, sde_rnd):
+    def sample(self, llm_cond, lat_cond, y0, t, sde_args, sde_rnd, abort_event=None):
         # cfg_strength=2, sigma=0, temperature=0
+        def check_abort():
+            if abort_event is not None and abort_event.is_set():
+                raise asyncio.CancelledError()
+
         def fn(fn_t, x):
             pred_cfg = self.model.forward_with_cfg(x, fn_t, llm_cond, lat_cond, None)
             pred, null_pred = torch.chunk(pred_cfg, 2, dim=0)
@@ -43,6 +49,7 @@ class CFM(nn.Module):
 
         trajectory = [y0]
         for step in range(self.steps):
+            check_abort()
             dt = t[step + 1] - t[step]
             y0 = y0 + fn(t[step], y0) * dt
             y0 = (

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -316,6 +316,13 @@ class OmniScheduler:
         self.use_ngram_embedding = False
         self.return_health_check_ipcs = []
         self.enable_overlap_mlx = False
+        # Upstream scheduler_runtime_checker_mixin._streaming_session_count
+        # iterates ``self.session_controller.sessions.values()`` during
+        # report_decode_stats. We don't host SGLang's interactive-session
+        # feature, so a stub with an empty sessions dict is sufficient.
+        from types import SimpleNamespace
+
+        self.session_controller = SimpleNamespace(sessions={})
 
     def self_check_during_idle(self) -> None:
         self.new_token_ratio = self.init_new_token_ratio

--- a/tests/unit_test/ming_omni/test_streaming_e2e_glue.py
+++ b/tests/unit_test/ming_omni/test_streaming_e2e_glue.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Glue tests for streaming TTS: thinker emits + client merges."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from sglang_omni.client.client import Client
+from sglang_omni.client.types import GenerateChunk
+from sglang_omni.models.ming_omni.bootstrap import make_thinker_stream_output_builder
+
+
+class _FakeTokenizer:
+    def __init__(self) -> None:
+        self.vocab = {
+            5: "Hello",
+            6: " world",
+            7: ".",
+            8: " Tail",
+        }
+
+    def decode(self, ids, skip_special_tokens=True):
+        return "".join(self.vocab.get(int(i), "") for i in ids)
+
+
+def _make_req():
+    return SimpleNamespace(
+        is_chunked=0,
+        _ming_stream_token_ids=None,
+        _ming_stream_emitted_text="",
+    )
+
+
+def _make_req_data(req):
+    return SimpleNamespace(req=req)
+
+
+def _make_req_output(token_id):
+    return SimpleNamespace(data=token_id)
+
+
+def test_thinker_stream_builder_emits_to_segmenter():
+    builder = make_thinker_stream_output_builder(
+        tokenizer=_FakeTokenizer(),
+        eos_token_id=None,
+    )
+    req = _make_req()
+    req_data = _make_req_data(req)
+
+    msgs = builder("req-1", req_data, _make_req_output(5))
+    # Thinker is not terminal, so only inter-stage stream to segmenter.
+    assert len(msgs) == 1
+    assert msgs[0].target == "segmenter"
+    assert msgs[0].data.dtype.is_floating_point is False  # uint8 tensor
+    assert bytes(msgs[0].data.tolist()).decode("utf-8") == "Hello"
+
+
+def test_thinker_stream_builder_suppresses_during_chunked_prefill():
+    builder = make_thinker_stream_output_builder(
+        tokenizer=_FakeTokenizer(),
+        eos_token_id=None,
+    )
+    req = _make_req()
+    req.is_chunked = 1  # still consuming prompt chunks
+    req_data = _make_req_data(req)
+
+    msgs = builder("req-2", req_data, _make_req_output(5))
+    assert msgs == []
+
+
+def test_thinker_stream_builder_buffers_incomplete_utf8():
+    # Tokenizer that produces an incomplete UTF-8 sequence on first call.
+    class _IncompleteThenComplete:
+        calls = 0
+
+        def decode(self, ids, skip_special_tokens=True):
+            type(self).calls += 1
+            return "Hello\ufffd" if type(self).calls == 1 else "Hello\u4e16"
+
+    builder = make_thinker_stream_output_builder(
+        tokenizer=_IncompleteThenComplete(),
+        eos_token_id=None,
+    )
+    req = _make_req()
+    req_data = _make_req_data(req)
+    # First token: incomplete -> no emit.
+    msgs1 = builder("req-3", req_data, _make_req_output(5))
+    assert msgs1 == []
+    # Second token: completes UTF-8 -> emit one segmenter message with full delta.
+    msgs2 = builder("req-3", req_data, _make_req_output(6))
+    assert len(msgs2) == 1
+    assert msgs2[0].target == "segmenter"
+
+
+def test_client_result_builder_merges_decode_with_talker_stream():
+    audio_bytes = (0).to_bytes(4, "little") * 8  # 8 float32 zero samples
+    merged = {
+        "decode": {"text": "Hello world.", "modality": "text"},
+        "talker_stream": {
+            "modality": "audio",
+            "audio_waveform": audio_bytes,
+            "audio_waveform_dtype": "float32",
+            "audio_waveform_shape": [8],
+            "sample_rate": 44100,
+        },
+    }
+    chunk: GenerateChunk = Client._default_result_builder("req-x", merged)
+    assert chunk.text == "Hello world."
+    assert chunk.modality == "audio"
+    assert chunk.audio_data is not None
+    assert int(chunk.audio_data.shape[0]) == 8
+    assert chunk.sample_rate == 44100

--- a/tests/unit_test/ming_omni/test_streaming_segmenter.py
+++ b/tests/unit_test/ming_omni/test_streaming_segmenter.py
@@ -115,8 +115,10 @@ def test_segmenter_emits_sentence_then_finalizes_on_done():
         assert m.target == TALKER_STREAM_STAGE
     # Final segment is flagged.
     assert streams[-1].metadata["is_final_segment"] is True
-    # Original payload data must be preserved on the result.
-    assert results[0].data.data["keep"] == "me"
+    # Final-result payload must be a clean small dict (no tensor-laden
+    # upstream state, which would break msgpack serialization to coord).
+    assert "keep" not in results[0].data.data
+    assert results[0].data.data["aborted"] is False
 
 
 def test_segmenter_handles_stream_arriving_before_payload():

--- a/tests/unit_test/ming_omni/test_streaming_segmenter.py
+++ b/tests/unit_test/ming_omni/test_streaming_segmenter.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for MingStreamingSegmenterScheduler."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Iterator
+
+from sglang_omni.models.ming_omni.components.streaming_segmenter import (
+    MingStreamingSegmenterScheduler,
+)
+from sglang_omni.models.ming_omni.components.streaming_text import (
+    SegmenterConfig,
+    text_to_uint8_tensor,
+    uint8_tensor_to_text,
+)
+from sglang_omni.models.ming_omni.pipeline.next_stage import TALKER_STREAM_STAGE
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
+
+
+def _run_scheduler(
+    scheduler: MingStreamingSegmenterScheduler,
+) -> threading.Thread:
+    thread = threading.Thread(target=scheduler.start, daemon=True)
+    thread.start()
+    return thread
+
+
+def _drain_outbox(
+    scheduler: MingStreamingSegmenterScheduler, *, until_request_id: str
+) -> list[OutgoingMessage]:
+    """Drain outbox until we see a final 'result' message for the request."""
+    collected: list[OutgoingMessage] = []
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        try:
+            msg = scheduler.outbox.get(timeout=0.2)
+        except Exception:
+            continue
+        collected.append(msg)
+        if msg.request_id == until_request_id and msg.type == "result":
+            return collected
+    raise AssertionError(
+        f"timed out waiting for final result; got {[m.type for m in collected]}"
+    )
+
+
+def _push_text_chunks(
+    scheduler: MingStreamingSegmenterScheduler,
+    request_id: str,
+    chunks: Iterator[str],
+) -> None:
+    for chunk in chunks:
+        scheduler.inbox.put(
+            IncomingMessage(
+                request_id=request_id,
+                type="stream_chunk",
+                data=StreamItem(
+                    chunk_id=0,
+                    data=text_to_uint8_tensor(chunk),
+                    from_stage="thinker",
+                    metadata=None,
+                ),
+            )
+        )
+
+
+def test_segmenter_emits_sentence_then_finalizes_on_done():
+    cfg = SegmenterConfig(
+        segment_min_tokens=2,
+        segment_max_tokens=20,
+        first_segment_min_tokens=2,
+        first_segment_max_wait_ms=10_000,
+    )
+    sched = MingStreamingSegmenterScheduler(config=cfg)
+    thread = _run_scheduler(sched)
+    try:
+        rid = "req-1"
+        # Main payload (handle) arrives first.
+        payload = StagePayload(
+            request_id=rid,
+            request=None,
+            data={"keep": "me"},
+        )
+        sched.inbox.put(
+            IncomingMessage(request_id=rid, type="new_request", data=payload)
+        )
+
+        _push_text_chunks(
+            sched,
+            rid,
+            iter(["Hello world.", " Tail piece"]),
+        )
+        sched.inbox.put(IncomingMessage(request_id=rid, type="stream_done"))
+
+        messages = _drain_outbox(sched, until_request_id=rid)
+    finally:
+        sched.stop()
+        thread.join(timeout=1.0)
+
+    streams = [m for m in messages if m.type == "stream"]
+    results = [m for m in messages if m.type == "result"]
+    assert len(results) == 1
+    assert results[0].data.data["segment_count"] == len(streams)
+    # First non-empty segment must contain the first sentence.
+    non_empty = [m for m in streams if m.metadata["text_len"] > 0]
+    assert non_empty, f"no non-empty stream segments: {streams}"
+    first_text = uint8_tensor_to_text(non_empty[0].data)
+    assert "Hello world." in first_text
+    # All stream messages must route to talker_stream.
+    for m in streams:
+        assert m.target == TALKER_STREAM_STAGE
+    # Final segment is flagged.
+    assert streams[-1].metadata["is_final_segment"] is True
+    # Original payload data must be preserved on the result.
+    assert results[0].data.data["keep"] == "me"
+
+
+def test_segmenter_handles_stream_arriving_before_payload():
+    cfg = SegmenterConfig(
+        segment_min_tokens=2,
+        segment_max_tokens=20,
+        first_segment_min_tokens=2,
+        first_segment_max_wait_ms=10_000,
+    )
+    sched = MingStreamingSegmenterScheduler(config=cfg)
+    thread = _run_scheduler(sched)
+    try:
+        rid = "req-pre"
+        # Stream arrives before the main payload.
+        _push_text_chunks(sched, rid, iter(["Hi there. "]))
+        sched.inbox.put(IncomingMessage(request_id=rid, type="stream_done"))
+        # Give scheduler a chance to buffer.
+        time.sleep(0.05)
+        payload = StagePayload(request_id=rid, request=None, data={})
+        sched.inbox.put(
+            IncomingMessage(request_id=rid, type="new_request", data=payload)
+        )
+        messages = _drain_outbox(sched, until_request_id=rid)
+    finally:
+        sched.stop()
+        thread.join(timeout=1.0)
+
+    streams = [m for m in messages if m.type == "stream"]
+    assert any(uint8_tensor_to_text(m.data).strip() == "Hi there." for m in streams)
+
+
+def test_segmenter_first_segment_timeout_emits_before_punctuation():
+    cfg = SegmenterConfig(
+        segment_min_tokens=100,  # very large so punctuation alone won't fire
+        segment_max_tokens=200,
+        first_segment_min_tokens=2,
+        first_segment_max_wait_ms=50,
+    )
+    sched = MingStreamingSegmenterScheduler(config=cfg)
+    thread = _run_scheduler(sched)
+    try:
+        rid = "req-timeout"
+        payload = StagePayload(request_id=rid, request=None, data={})
+        sched.inbox.put(
+            IncomingMessage(request_id=rid, type="new_request", data=payload)
+        )
+        # Push two short tokens that don't end in punctuation.
+        _push_text_chunks(sched, rid, iter(["hello world"]))
+        # Wait past first_segment_max_wait_ms; the inbox-empty tick should
+        # flush the first segment.
+        time.sleep(0.3)
+        sched.inbox.put(IncomingMessage(request_id=rid, type="stream_done"))
+        messages = _drain_outbox(sched, until_request_id=rid)
+    finally:
+        sched.stop()
+        thread.join(timeout=1.0)
+
+    streams = [m for m in messages if m.type == "stream"]
+    non_empty = [m for m in streams if m.metadata["text_len"] > 0]
+    # First non-empty stream message must arrive without trailing punctuation.
+    assert non_empty, "first-segment timeout did not emit"
+    first = uint8_tensor_to_text(non_empty[0].data)
+    assert "hello" in first

--- a/tests/unit_test/ming_omni/test_streaming_speech_config.py
+++ b/tests/unit_test/ming_omni/test_streaming_speech_config.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for MingOmniStreamingSpeechPipelineConfig wiring."""
+
+from __future__ import annotations
+
+import pytest
+
+from sglang_omni.models.ming_omni.config import MingOmniStreamingSpeechPipelineConfig
+from sglang_omni.models.ming_omni.pipeline.next_stage import (
+    DECODE_STAGE,
+    SEGMENTER_STAGE,
+    TALKER_STREAM_STAGE,
+    THINKER_STAGE,
+)
+
+
+def _stage(config, name):
+    return next(s for s in config.stages if s.name == name)
+
+
+def test_streaming_speech_topology_wires_segmenter_between_thinker_and_talker():
+    config = MingOmniStreamingSpeechPipelineConfig(model_path="dummy")
+    names = [s.name for s in config.stages]
+    assert SEGMENTER_STAGE in names
+    assert TALKER_STREAM_STAGE in names
+    # Old non-streaming talker must NOT be present.
+    assert "talker" not in names
+
+
+def test_streaming_thinker_fans_out_and_streams_to_segmenter():
+    config = MingOmniStreamingSpeechPipelineConfig(model_path="dummy")
+    thinker = _stage(config, THINKER_STAGE)
+    assert sorted(thinker.next) == sorted([DECODE_STAGE, SEGMENTER_STAGE])
+    assert thinker.stream_to == [SEGMENTER_STAGE]
+    assert thinker.factory_args.get("enable_streaming_tts") is True
+
+
+def test_segmenter_routes_to_talker_stream_and_accepts_pre_payload_streams():
+    config = MingOmniStreamingSpeechPipelineConfig(model_path="dummy")
+    seg = _stage(config, SEGMENTER_STAGE)
+    assert seg.next == TALKER_STREAM_STAGE
+    assert seg.stream_to == [TALKER_STREAM_STAGE]
+    assert seg.can_accept_stream_before_payload is True
+
+
+def test_talker_stream_is_terminal_and_accepts_pre_payload_streams():
+    config = MingOmniStreamingSpeechPipelineConfig(model_path="dummy")
+    talker = _stage(config, TALKER_STREAM_STAGE)
+    assert talker.terminal is True
+    assert talker.can_accept_stream_before_payload is True
+
+
+def test_streaming_speech_rejects_talker_gpu_in_thinker_tp_range():
+    config = MingOmniStreamingSpeechPipelineConfig(model_path="dummy")
+    thinker = _stage(config, THINKER_STAGE)
+    talker = _stage(config, TALKER_STREAM_STAGE)
+    thinker.gpu = [0, 1]
+    thinker.tp_size = 2
+    talker.gpu = 1  # collides
+    with pytest.raises(ValueError, match="collides with thinker TP range"):
+        config._validate_talker_stream_gpu_not_in_thinker_tp_range()
+
+
+def test_variants_dict_exposes_streaming_variant():
+    from sglang_omni.models.ming_omni.config import Variants
+
+    assert "streaming_speech" in Variants
+    assert Variants["streaming_speech"] is MingOmniStreamingSpeechPipelineConfig

--- a/tests/unit_test/ming_omni/test_streaming_talker.py
+++ b/tests/unit_test/ming_omni/test_streaming_talker.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for MingStreamingTalkerScheduler with a fake talker."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+import numpy as np
+import torch
+
+from sglang_omni.models.ming_omni.components.streaming_talker import (
+    MingStreamingTalkerScheduler,
+)
+from sglang_omni.models.ming_omni.components.streaming_text import text_to_uint8_tensor
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
+
+
+class _FakeTalker:
+    """Stand-in for MingOmniTalker that yields one waveform per call."""
+
+    def __init__(self, *, samples_per_call: int = 512, sample_rate: int = 44100):
+        self.samples_per_call = samples_per_call
+        self.sample_rate = sample_rate
+        self.calls: list[str] = []
+
+    def omni_audio_generation(
+        self,
+        *,
+        tts_text: str,
+        voice_name: str,
+        audio_detokenizer: Any,
+        stream: bool,
+        abort_event: threading.Event | None = None,
+    ):
+        self.calls.append(tts_text)
+        # Two chunks per segment so we can assert >1 emit.
+        for _ in range(2):
+            if abort_event is not None and abort_event.is_set():
+                return
+            wav = torch.zeros(self.samples_per_call, dtype=torch.float32)
+            yield (wav, None, None, None)
+
+
+def _make_scheduler(**kwargs) -> MingStreamingTalkerScheduler:
+    talker = kwargs.pop("talker", None) or _FakeTalker()
+    return MingStreamingTalkerScheduler(
+        talker=talker,
+        sample_rate=talker.sample_rate,
+        **kwargs,
+    )
+
+
+def _run(scheduler: MingStreamingTalkerScheduler) -> threading.Thread:
+    thread = threading.Thread(target=scheduler.start, daemon=True)
+    thread.start()
+    return thread
+
+
+def _drain(
+    scheduler: MingStreamingTalkerScheduler, *, until_request_id: str
+) -> list[OutgoingMessage]:
+    collected: list[OutgoingMessage] = []
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        try:
+            msg = scheduler.outbox.get(timeout=0.2)
+        except Exception:
+            continue
+        collected.append(msg)
+        if msg.request_id == until_request_id and msg.type == "result":
+            return collected
+    raise AssertionError(
+        f"timed out waiting for result; got {[m.type for m in collected]}"
+    )
+
+
+def _segment(scheduler, rid: str, text: str, *, segment_id: int, final: bool = False):
+    scheduler.inbox.put(
+        IncomingMessage(
+            request_id=rid,
+            type="stream_chunk",
+            data=StreamItem(
+                chunk_id=0,
+                data=text_to_uint8_tensor(text),
+                from_stage="segmenter",
+                metadata={
+                    "segment_id": segment_id,
+                    "is_final_segment": final,
+                    "text_len": len(text),
+                },
+            ),
+        )
+    )
+
+
+def test_streaming_talker_emits_audio_per_segment_then_finalizes():
+    sched = _make_scheduler()
+    thread = _run(sched)
+    try:
+        rid = "req-1"
+        sched.inbox.put(
+            IncomingMessage(
+                request_id=rid,
+                type="new_request",
+                data=StagePayload(request_id=rid, request=None, data={"keep": "x"}),
+            )
+        )
+        _segment(sched, rid, "Hello.", segment_id=0)
+        _segment(sched, rid, "World.", segment_id=1, final=True)
+        sched.inbox.put(IncomingMessage(request_id=rid, type="stream_done"))
+        msgs = _drain(sched, until_request_id=rid)
+    finally:
+        sched.stop()
+        thread.join(timeout=1.0)
+
+    streams = [m for m in msgs if m.type == "stream"]
+    results = [m for m in msgs if m.type == "result"]
+    # 2 segments × 2 audio chunks each = 4 stream messages.
+    assert len(streams) == 4, f"expected 4 audio chunks, got {len(streams)}"
+    assert all(m.target is None for m in streams)
+    for m in streams:
+        assert m.data["modality"] == "audio"
+        # waveform decodes to expected sample count.
+        arr = np.frombuffer(m.data["audio_waveform"], dtype=np.float32)
+        assert arr.size == 512
+    assert len(results) == 1
+    assert results[0].data.data["audio_chunk_count"] == 4
+    assert results[0].data.data["segment_count"] == 2
+    assert results[0].data.data["aborted"] is False
+    # Final result must be a clean dict (no upstream-inherited fields)
+    # so msgpack can serialize it to the coordinator.
+    assert "keep" not in results[0].data.data
+    assert results[0].data.data["modality"] == "audio"
+
+
+def test_streaming_talker_stream_before_payload_buffers_correctly():
+    sched = _make_scheduler()
+    thread = _run(sched)
+    try:
+        rid = "req-pre"
+        _segment(sched, rid, "Early bird.", segment_id=0, final=True)
+        sched.inbox.put(IncomingMessage(request_id=rid, type="stream_done"))
+        time.sleep(0.1)  # let scheduler buffer
+        sched.inbox.put(
+            IncomingMessage(
+                request_id=rid,
+                type="new_request",
+                data=StagePayload(request_id=rid, request=None, data={}),
+            )
+        )
+        msgs = _drain(sched, until_request_id=rid)
+    finally:
+        sched.stop()
+        thread.join(timeout=1.0)
+
+    streams = [m for m in msgs if m.type == "stream"]
+    assert len(streams) == 2  # one segment × 2 chunks
+
+
+def test_streaming_talker_abort_short_circuits_generation():
+    class _SlowTalker(_FakeTalker):
+        def omni_audio_generation(
+            self, *, tts_text, voice_name, audio_detokenizer, stream, abort_event=None
+        ):
+            self.calls.append(tts_text)
+            for _ in range(10):
+                if abort_event is not None and abort_event.is_set():
+                    return
+                time.sleep(0.02)
+                yield (torch.zeros(256, dtype=torch.float32), None, None, None)
+
+    talker = _SlowTalker()
+    sched = _make_scheduler(talker=talker)
+    thread = _run(sched)
+    try:
+        rid = "req-abort"
+        sched.inbox.put(
+            IncomingMessage(
+                request_id=rid,
+                type="new_request",
+                data=StagePayload(request_id=rid, request=None, data={}),
+            )
+        )
+        _segment(sched, rid, "long segment", segment_id=0)
+        # Let a couple chunks emit, then abort.
+        time.sleep(0.05)
+        sched.abort(rid)
+        # Mark stream done so the scheduler finalizes the aborted request.
+        sched.inbox.put(IncomingMessage(request_id=rid, type="stream_done"))
+        # Also send the new_request first if not already — already sent.
+        msgs = _drain(sched, until_request_id=rid)
+    finally:
+        sched.stop()
+        thread.join(timeout=1.0)
+
+    streams = [m for m in msgs if m.type == "stream"]
+    # Aborted segment must produce fewer than the 10 chunks the slow talker
+    # would otherwise generate.
+    assert 0 < len(streams) < 10
+    results = [m for m in msgs if m.type == "result"]
+    assert len(results) == 1
+    assert results[0].data.data["aborted"] is True

--- a/tests/unit_test/ming_omni/test_streaming_text.py
+++ b/tests/unit_test/ming_omni/test_streaming_text.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from sglang_omni.models.ming_omni.components.streaming_text import (
+    SegmenterConfig,
+    SegmenterState,
+    text_to_uint8_tensor,
+    uint8_tensor_to_text,
+)
+
+
+def _token_count(text: str) -> int:
+    return len(text.split())
+
+
+def test_utf8_tensor_round_trip_chinese_and_english():
+    text = "world，streaming TTS!"
+
+    assert uint8_tensor_to_text(text_to_uint8_tensor(text)) == text
+
+
+def test_segmenter_flushes_on_punctuation_after_min_tokens():
+    state = SegmenterState(
+        SegmenterConfig(
+            segment_min_tokens=2,
+            segment_max_tokens=10,
+            first_segment_max_wait_ms=500,
+        ),
+        token_count_fn=_token_count,
+    )
+
+    assert state.push("hello", now_ms=0) == []
+    out = state.push(" world.", now_ms=10)
+
+    assert [segment.text for segment in out] == ["hello world."]
+    assert out[0].is_final_segment is False
+
+
+def test_first_segment_max_wait_flushes_before_punctuation():
+    state = SegmenterState(
+        SegmenterConfig(
+            segment_min_tokens=10,
+            segment_max_tokens=40,
+            first_segment_min_tokens=3,
+            first_segment_max_wait_ms=400,
+        ),
+        token_count_fn=_token_count,
+    )
+
+    assert state.push("one two three", now_ms=0) == []
+    out = state.push("", now_ms=401)
+
+    assert [segment.text for segment in out] == ["one two three"]
+    assert out[0].is_final_segment is False
+
+
+def test_segmenter_caps_max_tokens_and_retains_overflow():
+    state = SegmenterState(
+        SegmenterConfig(
+            segment_min_tokens=1,
+            segment_max_tokens=3,
+            first_segment_min_tokens=3,
+            first_segment_max_wait_ms=9999,
+        ),
+        token_count_fn=_token_count,
+    )
+
+    out = state.push("one two three four five", now_ms=0)
+    tail = state.flush()
+
+    assert [segment.text for segment in out] == ["one two three"]
+    assert [segment.text for segment in tail] == ["four five"]


### PR DESCRIPTION
## Summary

Adds an opt-in streaming-TTS pipeline variant to Ming-Omni V1, modelled on the V0 design in #378 but adapted to the `sglang_omni_v1` staged-pipeline framework. With `--enable-streaming-tts`, the OpenAI-compatible chat endpoint begins emitting audio chunks **per sentence** instead of waiting for the entire utterance to finish synthesizing, dramatically reducing time-to-first-audio. Default behavior (the existing 7-stage non-streaming speech pipeline) is unchanged.

## Motivation

The V1 Ming-Omni pipeline (#437) preserves the V0 contract of one-shot, end-of-generation audio delivery. For a 50-character Chinese utterance this means the user waits for both the thinker (~Ns) **and** the entire talker run (~Ms) before hearing anything. #378 showed this can be cut to ~600 ms on V0 by sentence-splitting the thinker output and pipelining TTS — this PR ports the same idea to V1.

Architecturally V1 is a better home for this because the thinker, segmenter, and talker each run in their own OS process and communicate via the existing `stream_to` / `can_accept_stream_before_payload` plumbing already used by Qwen3-Omni's talker_ar.

## Architecture

New 8-stage pipeline `MingOmniStreamingSpeechPipelineConfig` (`Variants["streaming_speech"]`):
```
preprocessing → audio_encoder ↘
              → image_encoder → mm_aggregate → thinker ─stream→ segmenter ─stream→ talker_stream → (coordinator)
                                                  │                 │
                                                  └─next→ decode    └─next→ talker_stream
                                                  └─next→ segmenter
```
- **thinker** (existing `OmniScheduler`): adds an opt-in `stream_output_builder`. Per generated token it does an incremental `tokenizer.decode`, computes the text delta, and emits a `uint8` tensor to the segmenter via the `stream_to`
channel. Per-request running token list and emitted text are stashed on the SGLang `Req` so they GC with the request.
- **segmenter** (new `MingStreamingSegmenterScheduler`): pure-Python stream-aware scheduler with the same `inbox`/`outbox`/`start`/`stop`/`abort` contract as `SimpleScheduler`. Consumes uint8 text deltas, runs them through the V0-reused
`SegmenterState` (punctuation + min/max token thresholds + 450 ms first-segment timeout), and emits per-segment uint8 tensors to talker_stream.
- **talker_stream** (new `MingStreamingTalkerScheduler`): terminal stream-aware scheduler. For each incoming text segment it drives `talker.omni_audio_generation(stream=True, abort_event=...)` synchronously and publishes each yielded
waveform as `OutgoingMessage(type="stream", target=None)` so the runtime forwards it directly to the coordinator (same pattern as `code2wav_scheduler`).

The runtime already handles all the wiring (`stream_to`, `can_accept_stream_before_payload`, terminal output to coordinator); no changes to `pipeline/` were needed.

## Talker model changes (cherry-picked from #378)

To make the underlying `MingOmniTalker` actually streamable and abortable:

- Thread `abort_event: threading.Event` through `CFM.sample`, `CFMGraphExecutor.execute/_initialize_graph`, `CFMGraphExecutorPool`, `omni_audio_generation_func`, `omni_audio_generation`, and `instruct_audio_generation`. CUDA-graph capture is
 fenced with `abort_event=None` because aborting mid-capture corrupts the partial graph; checks happen before capture and on every replay.
- Replace the 100 ms `time.sleep` polling between LLM tokens with a 25 ms `token_queue.get(timeout=...)` wakeup that also polls `abort_event` and `future.done()`. Bounds external-abort latency to ~25 ms + one inner generator step. New
`_TOKEN_DONE` sentinel unblocks the consumer cleanly when `llm_job` finishes.
- `abort_event` defaults to `None` everywhere, so the existing non-streaming `MingTalkerExecutor` path is unaffected.

## Client / API changes

- `Client._default_result_builder` recognizes `"talker_stream"` as an audio terminal alongside `"code2wav"`/`"talker"` when merging multi-terminal results.
- `examples/run_ming_omni_speech_server.py` gains `--enable-streaming-tts` to select the new variant and route `--gpu-talker` to the `talker_stream` stage. Also adds `--cpu-offload-gb` since the speech launcher previously didn't expose it.
- No changes to `serve/openai_api.py` were needed — the SSE `_chat_stream` path already handles per-chunk audio (`modality="audio"` + `audio_b64`) and the finish-chunk text/audio retention fix from #437 already covers our final aggregate.

## OmniScheduler stub (small drive-by fix)

Adds a `session_controller = SimpleNamespace(sessions={})` stub to `OmniScheduler._init_upstream_compat_flags`. Upstream SGLang's `scheduler_runtime_checker_mixin._streaming_session_count` accesses `self.session_controller.sessions.values()`
 during `report_decode_stats` and crashed the V1 thinker on generations longer than a handful of tokens. We don't host SGLang's interactive-session feature so an empty stub is sufficient. Strictly speaking this is independent of streaming
TTS but it blocked e2e validation.

## Key design decisions

- **Sentence-level segmentation, not token-level.** Per-token TTS is meaningless and the segmenter mirrors V0: emit on `[.!?。！？;；]` after `min_tokens` OR when the first segment has waited `first_segment_max_wait_ms`. Buffer incomplete
UTF-8 (`\ufffd` in decoded) until the next token completes it.
- **Text deltas go to segmenter only, not also to coordinator.** I initially had the thinker dual-emit (segmenter + terminal) so the client would see streaming text. This crashes because (a) the relay transport requires `torch.Tensor`
payloads, not the `dict` you'd want for terminal text, and (b) `target=None` from a non-terminal stage fans out to `stream_to` peers, not to the coordinator. So streaming text to the client is deferred — the user still sees one final text
chunk via the decode stage. Streaming audio works fully.
- **State stashed on the SGLang `Req` object** rather than in a closure-level dict, so it dies with the request and there's no manual cleanup.
- **Final-result payloads are fresh small dicts.** Forwarding the upstream `state.to_dict()` (`prompt.input_ids`, `encoder_outs`, etc.) trips msgpack on terminal serialization because of the embedded tensors. Both the segmenter and
talker_stream now emit only their own summary fields.
- **Synchronous talker generation inside the scheduler thread.** V0 used a daemon thread + `loop.call_soon_threadsafe` because its scheduler ran on the asyncio loop. V1 schedulers already run on a dedicated thread, so we just iterate the
talker generator directly and push waveforms straight to `outbox` — simpler, no cross-thread queue.

## Testing

### Unit (60 ming_omni tests pass on H20 pod)

- `test_streaming_text.py` (4): UTF-8 round-trip, punctuation-flush, first-segment timeout, max-tokens cap.
- `test_streaming_segmenter.py` (3): punctuation emit + clean final payload; stream-before-payload buffering; first-segment timeout under inbox-idle.
- `test_streaming_talker.py` (3): fake-talker per-segment emits + clean final payload + audio-chunk count; stream-before-payload buffering; abort short-circuits a slow talker.
- `test_streaming_speech_config.py` (6): new variant topology (`next` / `stream_to` / `can_accept_stream_before_payload`), `Variants` registration, GPU-collision validator.
- `test_streaming_e2e_glue.py` (4): thinker stream builder emits to segmenter, suppresses during chunked prefill, buffers incomplete UTF-8; client result builder merges `decode` + `talker_stream`.

### End-to-end on H20 pod (TP=2 thinker, GPU 2 talker_stream)

```bash
python examples/run_ming_omni_speech_server.py \
  --model-path /home/admin/models/inclusionAI/Ming-flash-omni-2___0 \
  --enable-streaming-tts \
  --gpu-thinker 0 --gpu-talker 2 \
  --tp-size 2 --port 8765 --mem-fraction-static 0.9

curl -sN -X POST http://127.0.0.1:8765/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"ming-omni","messages":[{"role":"user","content":"用两句话介绍上海。"}],
       "max_tokens":150,"stream":true,"modalities":["text","audio"],"audio":{"format":"wav"}}'

Result: 12 SSE chunks in 2924 ms.

┌─────────┬───────────────────────────────────────┬────────────────────────────┐
│  Chunk  │                Content                │            Size            │
├─────────┼───────────────────────────────────────┼────────────────────────────┤
│ #00     │ role=assistant + full text (94 chars) │ text 94                    │
├─────────┼───────────────────────────────────────┼────────────────────────────┤
│ #01–#10 │ 10 independent audio waveform chunks  │ 34 KB – 646 KB base64 each │
├─────────┼───────────────────────────────────────┼────────────────────────────┤
│ #11     │ finish_reason=stop                    │ (empty)                    │
└─────────┴───────────────────────────────────────┴────────────────────────────┘

Average inter-audio-chunk gap ≈ 290 ms, consistent with sentence-level cuts on a two-sentence reply. All 8 stages remained healthy after the request; no pipeline-internal errors in the server log (the only ERROR lines are SGLang's noisy
optional-import warnings for mooncake, nixl, gemma4, glm_ocr, glmasr).

Known limitations

- Streaming text to the client is not yet enabled — the SSE response carries the full text in one delta.content chunk. To enable, either (a) make decode stream-aware so it consumes thinker token-id streams and emits text-delta terminal
chunks, or (b) add a small dedicated text-fanout terminal stage that mirrors the segmenter's input. Both are clean follow-ups.
- No formal TTFB benchmark vs the non-streaming baseline yet. V0 #378 reported ~6× improvement (3756 ms → 587 ms); we should reproduce that on V1. Belongs in a follow-up PR with a small benchmark harness.
- Ming-flash-omni-2.0 ships without top-level tokenizer files on HF/ModelScope; this is upstream's choice and orthogonal to this PR. common.py:load_ming_tokenizer already falls back to Ming-flash-omni-Preview for exactly this reason.

Files changed

sglang_omni/models/ming_omni/components/streaming_text.py        (new, 161)
sglang_omni/models/ming_omni/components/streaming_segmenter.py   (new, ~250)
sglang_omni/models/ming_omni/components/streaming_talker.py      (new, ~380)
sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py (+331/-225, abort_event)
sglang_omni/models/ming_omni/talker/talker_module/cfm.py         (+9/-2, abort_event)
sglang_omni/models/ming_omni/bootstrap.py                        (+100, stream_output_builder)
sglang_omni/models/ming_omni/config.py                           (+streaming variant)
sglang_omni/models/ming_omni/stages.py                           (+2 factories, threading)
sglang_omni/models/ming_omni/pipeline/next_stage.py              (+SEGMENTER_STAGE, TALKER_STREAM_STAGE)
sglang_omni/client/client.py                                     (+talker_stream recognition)
sglang_omni/scheduling/omni_scheduler.py                         (+session_controller stub)
examples/run_ming_omni_speech_server.py                          (+--enable-streaming-tts, --cpu-offload-gb)
tests/unit_test/ming_omni/test_streaming_*.py                    (5 new files, 20 tests)

Test plan

- All 60 ming_omni unit tests pass locally and on the H20 pod
- Non-streaming speech pipeline still constructs and tests pass (defaults unchanged)
- Streaming speech variant launches end-to-end with model loaded
- Live SSE request returns multiple audio chunks within a single response
- Server remains healthy after the request (no dead stage processes)
- TTFB benchmark vs non-streaming (follow-up)
- Streaming text deltas to client (follow-up)
- Abort-mid-stream behavior under real load (only fake-talker tested)