### PR TITLE
[Qwen3] Add H200 colocated config

### DIFF
--- a/docs/basic_usage/omni_router.md
+++ b/docs/basic_usage/omni_router.md
@@ -55,7 +55,7 @@ launcher:
   num_gpus_per_worker: 1
   worker_host: 127.0.0.1
   worker_base_port: 8011
-  worker_extra_args: "--config examples/configs/qwen3_omni_colocated.yaml --colocate"
+  worker_extra_args: "--config examples/configs/qwen3_omni_colocated_h20.yaml --colocate"
   wait_timeout: 600
 ```
 
@@ -68,10 +68,13 @@ when the router exits.
 
 `num_gpus_per_worker` controls automatic GPU grouping. The default Qwen3-Omni
 router example uses colocated workers: each complete speech worker runs on one
-GPU through `examples/configs/qwen3_omni_colocated.yaml`. With
+GPU through `examples/configs/qwen3_omni_colocated_h20.yaml`. With
 `num_workers: 2` and `num_gpus_per_worker: 1`, the launcher assigns GPU `0` to
 the first worker and GPU `1` to the second worker when two CUDA devices are
 visible.
+
+Use `examples/configs/qwen3_omni_colocated_h200.yaml` instead for single-H200
+workers.
 
 Set `worker_gpu_ids` only when you need explicit placement. Each entry maps one
 `CUDA_VISIBLE_DEVICES` value to one worker, for example
@@ -118,7 +121,7 @@ Qwen3-Omni speech workers on different GPUs and ports:
 CUDA_VISIBLE_DEVICES=0 sgl-omni serve \
   --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
   --model-name qwen3-omni \
-  --config examples/configs/qwen3_omni_colocated.yaml \
+  --config examples/configs/qwen3_omni_colocated_h20.yaml \
   --colocate \
   --host 0.0.0.0 \
   --port 8011
@@ -128,7 +131,7 @@ CUDA_VISIBLE_DEVICES=0 sgl-omni serve \
 CUDA_VISIBLE_DEVICES=1 sgl-omni serve \
   --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
   --model-name qwen3-omni \
-  --config examples/configs/qwen3_omni_colocated.yaml \
+  --config examples/configs/qwen3_omni_colocated_h20.yaml \
   --colocate \
   --host 0.0.0.0 \
   --port 8012

--- a/docs/basic_usage/qwen3_omni.md
+++ b/docs/basic_usage/qwen3_omni.md
@@ -164,10 +164,12 @@ Speech mode can run as a colocated one-GPU worker using the colocated config:
 ```bash
 sgl-omni serve \
   --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
-  --config examples/configs/qwen3_omni_colocated.yaml \
+  --config examples/configs/qwen3_omni_colocated_h20.yaml \
   --colocate \
   --port 8008
 ```
+
+Use `examples/configs/qwen3_omni_colocated_h200.yaml` on single-H200 workers.
 
 For manual multi-GPU placement, use the example script:
 

--- a/examples/configs/qwen3_omni_colocated_h20.yaml
+++ b/examples/configs/qwen3_omni_colocated_h20.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Example single-GPU colocated Qwen3-Omni launcher config.
+# Example single-H20 colocated Qwen3-Omni launcher config.
 # The Python pipeline config owns the stage topology; this file only sets the
 # runtime memory budgets needed for colocated launch.
 #
@@ -9,7 +9,7 @@
 # backend workspaces, activation peaks, and allocator fragmentation.
 
 config_cls: Qwen3OmniSpeechColocatedPipelineConfig
-name: qwen3-omni-colocated
+name: qwen3-omni-colocated-h20
 model_path: Qwen/Qwen3-Omni-30B-A3B-Instruct
 relay_backend: shm
 

--- a/examples/configs/qwen3_omni_colocated_h200.yaml
+++ b/examples/configs/qwen3_omni_colocated_h200.yaml
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Example single-H200 colocated Qwen3-Omni launcher config.
+# The Python pipeline config owns the stage topology; this file only sets the
+# runtime memory budgets needed for colocated launch.
+#
+# This profile keeps about 6% of device memory outside stage budgets for CUDA
+# graph capture, backend workspaces, activation peaks, and allocator
+# fragmentation.
+
+config_cls: Qwen3OmniSpeechColocatedPipelineConfig
+name: qwen3-omni-colocated-h200
+model_path: Qwen/Qwen3-Omni-30B-A3B-Instruct
+relay_backend: shm
+
+stage_overrides:
+  image_encoder:
+    runtime:
+      resources:
+        total_gpu_memory_fraction: 0.017
+
+  audio_encoder:
+    runtime:
+      resources:
+        total_gpu_memory_fraction: 0.017
+
+  thinker:
+    runtime:
+      resources:
+        total_gpu_memory_fraction: 0.769
+
+  talker_ar:
+    runtime:
+      resources:
+        total_gpu_memory_fraction: 0.123
+
+  code2wav:
+    runtime:
+      resources:
+        total_gpu_memory_fraction: 0.014

--- a/examples/configs/qwen3_omni_router.yaml
+++ b/examples/configs/qwen3_omni_router.yaml
@@ -6,5 +6,5 @@ launcher:
   num_gpus_per_worker: 1
   worker_host: 127.0.0.1
   worker_base_port: 8011
-  worker_extra_args: "--config examples/configs/qwen3_omni_colocated.yaml --colocate"
+  worker_extra_args: "--config examples/configs/qwen3_omni_colocated_h20.yaml --colocate"
   wait_timeout: 600

--- a/tests/test_model/conftest.py
+++ b/tests/test_model/conftest.py
@@ -34,7 +34,7 @@ QWEN3_OMNI_TEST_MODEL_PATH = os.environ.get(
 QWEN3_OMNI_MODEL_NAME = "qwen3-omni"
 QWEN3_OMNI_ROUTER_WAIT_TIMEOUT = 180
 QWEN3_OMNI_COLOCATED_WORKER_ARGS = (
-    "--config examples/configs/qwen3_omni_colocated.yaml --colocate"
+    "--config examples/configs/qwen3_omni_colocated_h20.yaml --colocate"
 )
 QWEN3_OMNI_VIDEO_WORKER_ARGS = (
     f"{QWEN3_OMNI_COLOCATED_WORKER_ARGS} "

--- a/tests/test_model/test_qwen3_omni_thinker_length.py
+++ b/tests/test_model/test_qwen3_omni_thinker_length.py
@@ -43,7 +43,7 @@ def _post_chat(
 @pytest.fixture(scope="module")
 def router_server(tmp_path_factory: pytest.TempPathFactory):
     worker_extra_args = (
-        "--config examples/configs/qwen3_omni_colocated.yaml "
+        "--config examples/configs/qwen3_omni_colocated_h20.yaml "
         "--colocate "
         f"--stages.0.factory-args.thinker-max-seq-len {THINKER_MAX_SEQ_LEN} "
         f"--stages.4.factory-args.thinker-max-seq-len {THINKER_MAX_SEQ_LEN}"

--- a/tests/unit_test/qwen3_omni/test_config_manager.py
+++ b/tests/unit_test/qwen3_omni/test_config_manager.py
@@ -89,8 +89,8 @@ def test_config_manager_rejects_trailing_key_without_value() -> None:
         )
 
 
-def test_qwen3_omni_colocated_example_config_loads_and_plans() -> None:
-    config_path = _REPO_ROOT / "examples" / "configs" / "qwen3_omni_colocated.yaml"
+def test_qwen3_omni_h20_colocated_example_config_loads_and_plans() -> None:
+    config_path = _REPO_ROOT / "examples" / "configs" / "qwen3_omni_colocated_h20.yaml"
     config_text = config_path.read_text()
 
     manager = ConfigManager.from_file(str(config_path))
@@ -101,7 +101,7 @@ def test_qwen3_omni_colocated_example_config_loads_and_plans() -> None:
     assert "stages:" not in config_text
     assert "factory:" not in config_text
     assert isinstance(config, Qwen3OmniSpeechColocatedPipelineConfig)
-    assert config.name == "qwen3-omni-colocated"
+    assert config.name == "qwen3-omni-colocated-h20"
     assert plan.gpus[0].total_gpu_memory_fraction == pytest.approx(0.94)
     assert [group.name for group in topology.groups] == [
         "preprocessing",
@@ -150,8 +150,8 @@ def test_qwen_preprocessing_runtime_video_fps_resolves_to_factory_arg() -> None:
     assert args["video_fps"] == 2.0
 
 
-def test_colocated_example_reserve_keeps_raw_budget_in_resolved_config() -> None:
-    config_path = _REPO_ROOT / "examples" / "configs" / "qwen3_omni_colocated.yaml"
+def test_h20_colocated_example_reserve_keeps_raw_budget_in_resolved_config() -> None:
+    config_path = _REPO_ROOT / "examples" / "configs" / "qwen3_omni_colocated_h20.yaml"
     config = ConfigManager.from_file(str(config_path)).config
 
     apply_encoder_mem_reserve_cli_override(


### PR DESCRIPTION
## Motivation

Add an H200-specific Qwen3-Omni colocated profile and make the existing H20 profile explicit in the filename. The H20 profile is valid on H200, but it leaves more of the larger H200 memory pool outside the AR stage budgets than necessary. The H200 profile keeps the same overall reserve policy while allocating more of the stage budget to thinker/talker.

## Modifications

- Rename `examples/configs/qwen3_omni_colocated.yaml` to `examples/configs/qwen3_omni_colocated_h20.yaml` so the existing calibrated profile is clearly labeled as H20-specific.
- Add `examples/configs/qwen3_omni_colocated_h200.yaml` with H200 stage memory fractions:
  - `image_encoder=0.017`
  - `audio_encoder=0.017`
  - `thinker=0.769`
  - `talker_ar=0.123`
  - `code2wav=0.014`
- Update router examples, Qwen3-Omni docs, and test fixtures to reference the renamed H20 config.

The H200 thinker value is the raw stage budget. The existing Qwen3-Omni stage factory still applies `encoder_mem_reserve=0.05`, so the observed effective SGLang thinker budget is `0.719`.

## Accuracy Tests

Manual H200 validation through the router-backed 2-colocated-worker SeedTTS path:

| Config | Completed | Failed | WER corpus | >50% WER | Worker split |
|---|---:|---:|---:|---:|---|
| H20 profile | 50 | 0 | 0.014184 | 0 | 31 / 20 |
| H200 profile | 50 | 0 | 0.014184 | 0 | 28 / 23 |

Startup logs confirmed the H200 thinker reserve was applied on both workers:

```text
stage=thinker ... total_gpu_memory_fraction=0.769 effective_total_gpu_memory_fraction=0.719 mem_fraction_static=0.719 encoder_mem_reserve=0.05
stage=talker_ar ... total_gpu_memory_fraction=0.123 mem_fraction_static=0.123
```

## Speed Tests and Profiling

Both tested on H200:

| Config | Throughput QPS | Mean s | P95 s | RTF mean |
|---|---:|---:|---:|---:|
| H20 profile | 6.055 | 2.403 | 4.256 | 0.8017 |
| H200 profile | 6.282 | 2.347 | 4.108 | 0.7909 |

## Checklist

- [x] Format your code according to the contribution guide.
- [x] Add or update tests as needed.
- [x] Update documentation as needed.
- [x] Provide accuracy and speed results when the change affects them.
