### PR TITLE
[RFC][Feat] Remove TCP control-plane endpoints

### DIFF
--- a/docs/developer_reference/config.md
+++ b/docs/developer_reference/config.md
@@ -114,9 +114,7 @@ Derived from stages:
 | `relay_backend` | one of `shm`, `nccl`, `nixl`, `mooncake` | `shm` | Global relay backend used when creating per-stage relays. |
 | `fused_stages` | `list[list[str]]` | `[]` | Validated as adjacent stage groups, but fusion is not implemented yet. |
 | `runtime_overrides` | `dict[str, dict[str, Any]]` | `{}` | Per-stage factory argument overrides applied during runtime prep. |
-| `endpoints` | `EndpointsConfig` | IPC defaults | Endpoint allocation settings: `scheme`, `base_path`, and `base_port`. |
-| `completion_endpoint` | `str` or `None` | `None` | Optional explicit coordinator completion endpoint. |
-| `abort_endpoint` | `str` or `None` | `None` | Optional explicit coordinator abort broadcast endpoint. |
+| `endpoints` | `EndpointsConfig` | IPC defaults | Endpoint allocation settings. `base_path` controls where Unix-domain sockets are created. |
 | `terminal_stages_fn` | `str` or `None` | `None` | Dotted function path for request-aware terminal-stage resolution. The function receives the normalized `OmniRequest` and returns terminal stage names for that request, or `None` to use static terminals. |
 | `config_cls` | `str` or `None` | class name | Stored automatically and used when loading a saved config file. |
 

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -25,9 +25,7 @@ class EndpointsConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    scheme: Literal["ipc", "tcp"] = "ipc"
     base_path: str = "/tmp/sglang_omni"
-    base_port: int = 16000
 
 
 class ParallelismConfig(BaseModel):
@@ -214,8 +212,6 @@ class PipelineConfig(BaseModel):
     placement: PlacementConfig = Field(default_factory=PlacementConfig)
     placement_policy: str | None = None
     endpoints: EndpointsConfig = Field(default_factory=EndpointsConfig)
-    completion_endpoint: str | None = None
-    abort_endpoint: str | None = None
     terminal_stages_fn: str | None = None
     config_cls: str | None = None
 
@@ -258,7 +254,6 @@ class PipelineConfig(BaseModel):
             raise ValueError("Pipeline must define at least one stage")
         if len(names) != len(set(names)):
             raise ValueError("Stage names must be unique")
-
         entry = self.resolved_entry_stage
         if entry not in names:
             raise ValueError(f"entry_stage {entry!r} is not defined")

--- a/sglang_omni/pipeline/runtime_config.py
+++ b/sglang_omni/pipeline/runtime_config.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import logging
 import re
 import shutil
-import socket
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -56,15 +55,12 @@ class PipelineRuntimePrep:
     endpoints: dict[str, str]
     placement_plan: StagePlacementPlan
     process_plan: ProcessTopologyPlan
-    runtime_dir: IpcRuntimeDir | None
+    runtime_dir: IpcRuntimeDir
     runtime_dir_created_here: bool
 
 
-def create_ipc_runtime_dir(config: PipelineConfig) -> IpcRuntimeDir | None:
+def create_ipc_runtime_dir(config: PipelineConfig) -> IpcRuntimeDir:
     """Create a per-run IPC namespace for one pipeline instance."""
-    if config.endpoints.scheme != "ipc":
-        return None
-
     base_root = Path(config.endpoints.base_path)
     base_root.mkdir(parents=True, exist_ok=True)
 
@@ -82,11 +78,11 @@ def prepare_pipeline_runtime(
 ) -> PipelineRuntimePrep:
     """Prepare fused stages, endpoint allocation, and process topology."""
     runtime_dir = ipc_runtime_dir
-    created_runtime_dir = None
     if runtime_dir is None:
         runtime_dir = create_ipc_runtime_dir(config)
-        created_runtime_dir = runtime_dir
-    runtime_dir_created_here = created_runtime_dir is not None
+        runtime_dir_created_here = True
+    else:
+        runtime_dir_created_here = False
 
     try:
         stages_cfg, name_map, entry_stage = config.apply_fusion()
@@ -97,13 +93,12 @@ def prepare_pipeline_runtime(
             stages_cfg=stages_cfg,
         )
         endpoints = allocate_endpoints(
-            config,
             stages=stages_cfg,
-            ipc_base_dir=runtime_dir.path if runtime_dir else None,
+            ipc_base_dir=runtime_dir.path,
         )
     except Exception:
-        if created_runtime_dir is not None:
-            created_runtime_dir.close()
+        if runtime_dir_created_here:
+            runtime_dir.close()
         raise
 
     return PipelineRuntimePrep(
@@ -164,61 +159,16 @@ def parse_gpu_id(device: str) -> int | None:
     raise ValueError(f"Unsupported device string: {device}")
 
 
-def find_free_tcp_ports(start: int, count: int) -> list[int]:
-    """Find *count* available TCP ports starting from *start*."""
-    ports: list[int] = []
-    port = start
-    while len(ports) < count:
-        try:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.bind(("127.0.0.1", port))
-                ports.append(port)
-        except OSError:
-            # Port is already bound or otherwise unbindable; advance to the
-            # next candidate.
-            pass
-        port += 1
-    return ports
-
-
 def allocate_endpoints(
-    config: PipelineConfig,
     *,
     stages: list[StageConfig],
-    ipc_base_dir: Path | None = None,
+    ipc_base_dir: Path,
 ) -> dict[str, str]:
-    endpoints: dict[str, str] = {}
-
-    if config.completion_endpoint:
-        endpoints["completion"] = config.completion_endpoint
-    if config.abort_endpoint:
-        endpoints["abort"] = config.abort_endpoint
-
-    if config.endpoints.scheme == "ipc":
-        if ipc_base_dir is None:
-            raise ValueError("IPC endpoint allocation requires an IPC runtime dir")
-        base_dir = ipc_base_dir
-        endpoints.setdefault("completion", f"ipc://{base_dir}/completion.sock")
-        endpoints.setdefault("abort", f"ipc://{base_dir}/abort.sock")
-        for stage in stages:
-            endpoints[f"stage_{stage.name}"] = (
-                f"ipc://{base_dir}/stage_{stage.name}.sock"
-            )
-        return endpoints
-
-    if config.endpoints.scheme == "tcp":
-        needed = 2 + len(stages)
-        ports = find_free_tcp_ports(config.endpoints.base_port, needed)
-        idx = 0
-        if "completion" not in endpoints:
-            endpoints["completion"] = f"tcp://127.0.0.1:{ports[idx]}"
-            idx += 1
-        if "abort" not in endpoints:
-            endpoints["abort"] = f"tcp://127.0.0.1:{ports[idx]}"
-            idx += 1
-        for stage in stages:
-            endpoints[f"stage_{stage.name}"] = f"tcp://127.0.0.1:{ports[idx]}"
-            idx += 1
-        return endpoints
-
-    raise ValueError(f"Unknown endpoint scheme: {config.endpoints.scheme}")
+    base_dir = ipc_base_dir
+    endpoints = {
+        "completion": f"ipc://{base_dir}/completion.sock",
+        "abort": f"ipc://{base_dir}/abort.sock",
+    }
+    for stage in stages:
+        endpoints[f"stage_{stage.name}"] = f"ipc://{base_dir}/stage_{stage.name}.sock"
+    return endpoints

--- a/tests/unit_test/pipeline/test_compile.py
+++ b/tests/unit_test/pipeline/test_compile.py
@@ -67,12 +67,12 @@ def test_pipeline_schema_keeps_topology_and_validation_contracts() -> None:
         )
 
 
-def test_runner_specs_wire_routes_overrides_aggregation_and_streams() -> None:
+def test_runner_specs_wire_routes_overrides_aggregation_and_streams(tmp_path) -> None:
     """Preserves config-to-runtime wiring for routes, overrides, fan-in, and streams."""
     config = PipelineConfig(
         model_path="global-model",
         name="contract",
-        endpoints=EndpointsConfig(scheme="tcp"),
+        endpoints=EndpointsConfig(base_path=str(tmp_path)),
         runtime_overrides={"thinker": {"model_path": "runtime-model", "extra": "rt"}},
         stages=[
             stage("preprocess", next=["thinker", "aggregate"]),
@@ -97,15 +97,19 @@ def test_runner_specs_wire_routes_overrides_aggregation_and_streams() -> None:
     )
 
     prep = prepare_pipeline_runtime(config)
-    group = _build_stage_groups(
-        config,
-        ctx=FakeMpContext(),
-        stages_cfg=prep.stages_cfg,
-        name_map=prep.name_map,
-        endpoints=prep.endpoints,
-        placement_plan=prep.placement_plan,
-        process_plan=prep.process_plan,
-    )[0]
+    try:
+        group = _build_stage_groups(
+            config,
+            ctx=FakeMpContext(),
+            stages_cfg=prep.stages_cfg,
+            name_map=prep.name_map,
+            endpoints=prep.endpoints,
+            placement_plan=prep.placement_plan,
+            process_plan=prep.process_plan,
+        )[0]
+    finally:
+        assert prep.runtime_dir is not None
+        prep.runtime_dir.close()
     specs = {spec.stage_name: spec for spec in group.specs}
 
     assert prep.entry_stage == "preprocess"
@@ -122,12 +126,12 @@ def test_runner_specs_wire_routes_overrides_aggregation_and_streams() -> None:
     assert specs["thinker"].factory_args["extra"] == "rt"
 
 
-def test_mp_runner_preserves_tp_rank_and_visible_device_contracts() -> None:
+def test_mp_runner_preserves_tp_rank_and_visible_device_contracts(tmp_path) -> None:
     """Preserves TP process specs and one-visible-device env mapping."""
     config = PipelineConfig(
         model_path="model",
         name="mp",
-        endpoints=EndpointsConfig(scheme="tcp"),
+        endpoints=EndpointsConfig(base_path=str(tmp_path)),
         relay_backend="nccl",
         stages=[
             stage(
@@ -140,16 +144,19 @@ def test_mp_runner_preserves_tp_rank_and_visible_device_contracts() -> None:
         ],
     )
     prep = prepare_pipeline_runtime(config)
-
-    group = _build_stage_groups(
-        config,
-        ctx=FakeMpContext(),
-        stages_cfg=prep.stages_cfg,
-        name_map=prep.name_map,
-        endpoints=prep.endpoints,
-        placement_plan=prep.placement_plan,
-        process_plan=prep.process_plan,
-    )[0]
+    try:
+        group = _build_stage_groups(
+            config,
+            ctx=FakeMpContext(),
+            stages_cfg=prep.stages_cfg,
+            name_map=prep.name_map,
+            endpoints=prep.endpoints,
+            placement_plan=prep.placement_plan,
+            process_plan=prep.process_plan,
+        )[0]
+    finally:
+        assert prep.runtime_dir is not None
+        prep.runtime_dir.close()
     leader, follower = group.specs
     env = get_stage_process_env(follower, env={"CUDA_VISIBLE_DEVICES": "4,5,6,7"})
 
@@ -161,24 +168,27 @@ def test_mp_runner_preserves_tp_rank_and_visible_device_contracts() -> None:
     assert env["CUDA_VISIBLE_DEVICES"] == "7"
 
 
-def test_mp_runner_keeps_cpu_stage_without_gpu_identity() -> None:
+def test_mp_runner_keeps_cpu_stage_without_gpu_identity(tmp_path) -> None:
     config = PipelineConfig(
         model_path="model",
         name="mp",
-        endpoints=EndpointsConfig(scheme="tcp"),
+        endpoints=EndpointsConfig(base_path=str(tmp_path)),
         stages=[stage("preprocess", next="decode"), stage("decode", terminal=True)],
     )
     prep = prepare_pipeline_runtime(config)
-
-    group = _build_stage_groups(
-        config,
-        ctx=FakeMpContext(),
-        stages_cfg=prep.stages_cfg,
-        name_map=prep.name_map,
-        endpoints=prep.endpoints,
-        placement_plan=prep.placement_plan,
-        process_plan=prep.process_plan,
-    )[0]
+    try:
+        group = _build_stage_groups(
+            config,
+            ctx=FakeMpContext(),
+            stages_cfg=prep.stages_cfg,
+            name_map=prep.name_map,
+            endpoints=prep.endpoints,
+            placement_plan=prep.placement_plan,
+            process_plan=prep.process_plan,
+        )[0]
+    finally:
+        assert prep.runtime_dir is not None
+        prep.runtime_dir.close()
 
     assert group.specs[0].gpu_id is None
     assert group.specs[0].relay_config["gpu_id"] is None

--- a/tests/unit_test/pipeline/test_ipc.py
+++ b/tests/unit_test/pipeline/test_ipc.py
@@ -56,7 +56,7 @@ class _FakeCoordinator:
         self.stopped = True
 
 
-def _make_config(base_path: Path, *, scheme: str = "ipc") -> PipelineConfig:
+def _make_config(base_path: Path) -> PipelineConfig:
     return PipelineConfig(
         model_path="Qwen/Qwen3-Omni-30B-A3B-Instruct",
         entry_stage="preprocessing",
@@ -68,7 +68,7 @@ def _make_config(base_path: Path, *, scheme: str = "ipc") -> PipelineConfig:
                 terminal=True,
             )
         ],
-        endpoints=EndpointsConfig(scheme=scheme, base_path=str(base_path)),
+        endpoints=EndpointsConfig(base_path=str(base_path)),
     )
 
 
@@ -84,9 +84,6 @@ def _fake_stage_relay(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_ipc_runtime_dir_creation_and_close_contracts(tmp_path: Path) -> None:
     """Preserves IPC runtime directory creation, uniqueness, and idempotent cleanup."""
     ipc_config = _make_config(tmp_path)
-    tcp_config = _make_config(tmp_path, scheme="tcp")
-
-    assert runtime_config.create_ipc_runtime_dir(tcp_config) is None
 
     runtime_a = runtime_config.create_ipc_runtime_dir(ipc_config)
     runtime_b = runtime_config.create_ipc_runtime_dir(ipc_config)
@@ -297,7 +294,7 @@ async def test_mp_runner_startup_failure_includes_child_factory_traceback(
                 terminal=True,
             )
         ],
-        endpoints=EndpointsConfig(scheme="ipc", base_path=str(tmp_path)),
+        endpoints=EndpointsConfig(base_path=str(tmp_path)),
     )
     runner = mp_runner.MultiProcessPipelineRunner(config)
 


### PR DESCRIPTION
## Summary

Remove TCP endpoint support from the pipeline control plane and make IPC the only supported transport.

The control plane is used for local pipeline coordination messages, such as completion and abort endpoints between processes. Since these messages are intra-node process communication, IPC sockets are the expected path and TCP does not add a useful deployment mode here.

The existing TCP path was also not well implemented: endpoint reservation/allocation could diverge from the endpoint that later gets bound, so the port-based path was fragile. Instead of keeping an unused and unreliable alternate transport, this PR deletes the TCP branch and simplifies endpoint allocation around IPC.
