### PR TITLE
deps: declare funasr, zhconv, zhon for SeedTTS ZH eval

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,11 @@ dependencies = [
     "pytest-asyncio>=0.21.0",
     "jiwer",
     "scipy>=1.10.0",
-    "openai-whisper==20250625",
+    "openai-whisper==20250625",  # EN ASR for SeedTTS WER eval
+    # SeedTTS ZH transcribe + text normalization
+    "funasr>=1.3.0",          # Paraformer-zh ASR for SeedTTS ZH eval
+    "zhconv>=1.4.0",          # trad-to-simplified normalization of FunASR output
+    "zhon>=2.0.0",            # Chinese punctuation set for reference-text normalization
     # SeedTTS speaker similarity (WavLM-large SV head). The pip-installed
     # package supplies s3prl.upstream.wavlm.hubconf at runtime, so no source
     # clone is required.


### PR DESCRIPTION
## What this PR does

Adds three runtime dependencies to `pyproject.toml` that `benchmarks/tasks/tts.py` already imports for SeedTTS ZH evaluation:

- `funasr`: used in [`load_asr_model()` (line 136)](https://github.com/sgl-project/sglang-omni/blob/a43d81cf465bf03e6e20eb66d8c4b38cc7410996/benchmarks/tasks/tts.py#L136) to load Paraformer-zh
- `zhconv`: used in [`transcribe()` (line 158)](https://github.com/sgl-project/sglang-omni/blob/a43d81cf465bf03e6e20eb66d8c4b38cc7410996/benchmarks/tasks/tts.py#L158) for traditional-to-simplified normalization of FunASR output
- `zhon`: used in [`normalize_text()` (line 101)](https://github.com/sgl-project/sglang-omni/blob/a43d81cf465bf03e6e20eb66d8c4b38cc7410996/benchmarks/tasks/tts.py#L101) for Chinese punctuation stripping in the reference text path

No code or behavior change in this PR: only the dependency declaration.

## Why

Without these in `pyproject.toml`, a clean `pip install -e .` followed by `benchmark_tts_seedtts.py --transcribe-only --lang zh` fails with successive errors:

```
ModuleNotFoundError: No module named 'funasr'
# after pip install funasr
ModuleNotFoundError: No module named 'zhconv'
# after pip install zhconv
ModuleNotFoundError: No module named 'zhon'
```

Placement: next to the existing benchmark deps (`openai-whisper`, `jiwer`, `s3prl`) which follow the same "benchmark-only runtime dep" pattern.

## Test plan

- Verified that a fresh `pip install -e .` followed by `benchmark_tts_seedtts.py --transcribe-only --lang zh` completes without `ModuleNotFoundError` after these deps are declared.
- Versions used in my reproduction: `funasr==1.3.1`, `zhconv==1.4.3`, `zhon==2.1.1`.
- Surfaced while reproducing the SeedTTS results in #451 on a single H200; full reproduction data and methodology in #451 (comment [4524074204](https://github.com/sgl-project/sglang-omni/pull/451#issuecomment-4524074204)).
