### PR TITLE
docs: note PEP 668 externally-managed-environment caveat

### DIFF
--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -20,14 +20,14 @@ uv pip install -v .
 uv pip install -v -e .
 ```
 
-> **Note:** On Debian Bookworm / Ubuntu 23.04+ system Python (including the `frankleeeee/sglang-omni:dev` Docker image), use the `uv venv` flow above. Installing into system Python directly (e.g., `pip install -e .`) triggers [PEP 668](https://peps.python.org/pep-0668/):
+> **Note:** On Debian Bookworm / Ubuntu 23.04+ systems with an externally-managed system Python (including the `frankleeeee/sglang-omni:dev` Docker image), use the `uv venv` flow above. Installing into system Python directly (e.g., `pip install -e .`) triggers [PEP 668](https://peps.python.org/pep-0668/):
 >
 > ```
 > error: externally-managed-environment
 > × This environment is externally managed
 > ```
 >
-> Either use the venv flow, or pass `--break-system-packages` to the installer to override.
+> Either use the venv flow, or pass `--break-system-packages` explicitly (e.g., `pip install -e . --break-system-packages` or `uv pip install --system --break-system-packages -e .`).
 
 
 ## 🐳 Use Docker

--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -20,6 +20,15 @@ uv pip install -v .
 uv pip install -v -e .
 ```
 
+> **Note:** On Debian Bookworm / Ubuntu 23.04+ system Python (including the `frankleeeee/sglang-omni:dev` Docker image), use the `uv venv` flow above. Installing into system Python directly (e.g., `pip install -e .`) triggers [PEP 668](https://peps.python.org/pep-0668/):
+>
+> ```
+> error: externally-managed-environment
+> × This environment is externally managed
+> ```
+>
+> Either use the venv flow, or pass `--break-system-packages` to the installer to override.
+
 
 ## 🐳 Use Docker
 


### PR DESCRIPTION
## What this PR does

Adds a note to `docs/get_started/installation.md` clarifying that on Debian Bookworm / Ubuntu 23.04+ system Python (which includes the recommended `frankleeeee/sglang-omni:dev` Docker image), the install flow needs to use the `uv venv` step rather than installing into system Python. Installing into system Python triggers a PEP 668 `externally-managed-environment` error that can stop new contributors at install time.

## Why

The current install block teaches the venv flow but does not explain why the venv step is required, or what to do when a user runs `pip install -e .` directly against system Python. The error they see is:

```
error: externally-managed-environment
× This environment is externally managed
```

Including the exact error text makes it search-engine findable, so the next user who searches for the message lands on this page.

## Test plan

- Verified the existing `uv venv` flow still works as documented; this PR adds explanation only, no command change.
- Reproduced the PEP 668 error by running `pip install -e .` in `frankleeeee/sglang-omni:dev` without activating the venv.
