### PR TITLE
[Feature] Request-level profiler: timeline, stage breakdown, hop breakdown (#501)

### DIFF
--- a/docs/developer_reference/apiserver_design.md
+++ b/docs/developer_reference/apiserver_design.md
@@ -99,6 +99,10 @@ current multi-process launcher path does not mount them.
 }
 ```
 
+`/stop_profile` and `/stop_request_profile` both accept an optional
+`run_id`. Omitting it is a wildcard: every stage stops whatever profiler
+session is currently active.
+
 Request-level events are emitted as JSON lines under
 `<event_dir>/events_<stage>_<pid>.jsonl`. Use `python -m sglang_omni.profiler
 <event_dir>` to derive the timeline / stage / hop reports described in

--- a/docs/developer_reference/apiserver_design.md
+++ b/docs/developer_reference/apiserver_design.md
@@ -80,11 +80,29 @@ The current server exposes these main routes:
 | `GET` | `/v1/models` | Single-model listing for the active pipeline |
 | `POST` | `/v1/chat/completions` | Chat completions, including streaming and optional audio |
 | `POST` | `/v1/audio/speech` | Text-to-speech, raw audio response or SSE chunks when `stream=true` |
-| `POST` | `/start_profile` | Added by the single-process built-in launcher |
-| `POST` | `/stop_profile` | Added by the single-process built-in launcher |
+| `POST` | `/start_profile` | Torch trace + (optional) request-level events. Added by the built-in launcher |
+| `POST` | `/stop_profile` | Stops both torch trace and request-level events |
+| `POST` | `/start_request_profile` | Request-level event recorder only (no torch trace) |
+| `POST` | `/stop_request_profile` | Stops the request-level event recorder |
 
 The profiling routes are mounted by the single-process `launch_server()` path. The
 current multi-process launcher path does not mount them.
+
+`/start_profile` accepts:
+
+```jsonc
+{
+  "run_id": "demo-run",
+  "trace_path_template": "/tmp/profiles/demo-run/trace",  // torch trace template
+  "event_dir": "/tmp/profiles/demo-run/events",            // request-event JSONL dir (optional)
+  "enable_torch": true                                     // set false to skip torch trace
+}
+```
+
+Request-level events are emitted as JSON lines under
+`<event_dir>/events_<stage>_<pid>.jsonl`. Use `python -m sglang_omni.profiler
+<event_dir>` to derive the timeline / stage / hop reports described in
+`docs/developer_reference/profiler.md`.
 
 ## Request Mapping
 

--- a/docs/developer_reference/profiler.md
+++ b/docs/developer_reference/profiler.md
@@ -1,0 +1,112 @@
+# Request-level profiler
+
+This document describes the request-level profiler introduced for
+[issue #501](https://github.com/sgl-project/sglang-omni/issues/501).
+
+The goal is to reconstruct the full latency timeline of a request as it flows
+through the multi-stage pipeline, aggregate stage-local time, and surface
+stage-to-stage hop costs. The existing `TorchProfiler` keeps doing what it does
+(kernel-level Chrome traces); the request-level profiler runs alongside it and
+shares the same `run_id`.
+
+## Event model
+
+Every instrumentation point appends a single line of JSON to a per-process
+JSONL file. One event has the shape:
+
+```jsonc
+{
+  "request_id": "req-123",
+  "stage": "thinker",
+  "event_name": "scheduler_first_emit",
+  "timestamp_ns": 1717000000123456789,
+  "run_id": "demo-run",
+  "pid": 42,
+  "metadata": {"chunk_id": 0}
+}
+```
+
+Files are written under
+`<event_dir>/events_<stage>_<pid>.jsonl`. Stage files from different processes
+can be merged transparently by passing the directory to the views layer.
+
+### Standard event names
+
+| Layer | Event | Where it is emitted |
+|---|---|---|
+| Coordinator | `request_admission` | `Coordinator._submit_request` |
+| Coordinator | `coordinator_stream_received` | `Coordinator._handle_stream` |
+| Coordinator | `terminal_response` | `Coordinator._handle_completion` |
+| Stage | `stage_input_received` | `Stage._on_submit` / `Stage._on_data_ready` |
+| Stage | `stage_aggregate_ready` | `Stage._on_data_ready` after `InputHandler.receive` returns a merged payload |
+| Stage | `stage_dispatch` | `Stage._execute` (scheduler inbox put) |
+| Stage | `stage_complete` | `Stage._route_result` |
+| Stage | `stage_hop_sent` | `Stage._send_to_stage` |
+| Stage | `stage_stream_chunk_sent` | `Stage._send_stream_to_target` / `_send_stream_to_coordinator` |
+| Stage | `stage_stream_chunk_received` | `Stage._on_stream_chunk` |
+| AR scheduler | `scheduler_request_build_start` / `_end` | `OmniScheduler.process_input_requests` |
+| AR scheduler | `scheduler_prefill_start` | `OmniScheduler.process_input_requests` |
+| AR scheduler | `scheduler_first_emit` | `OmniScheduler.run_batch` (first stream-output emit per request) |
+| Code2Wav | `code2wav_first_audio` | `Code2WavScheduler._decode_and_emit` (first non-empty audio chunk) |
+
+Custom callsites can call `sglang_omni.profiler.event_recorder.emit(...)` to add
+domain-specific events — for example, model-specific preprocess timings or
+encoder warmups. Events from inactive recorders are no-ops; instrumentation
+sites do not need to guard against the disabled case.
+
+## Lifecycle
+
+The recorder is process-local. It is started on every stage and on the
+coordinator when `/start_profile` (or `/start_request_profile`) is hit:
+
+1. Launcher receives the HTTP request.
+2. Coordinator starts its local recorder pointed at `<event_dir>`.
+3. Launcher broadcasts `ProfilerStartMessage` over ZMQ to every stage,
+   carrying both the torch trace template and the `event_dir`.
+4. Each stage starts its own recorder for `event_dir` + its `stage` name.
+5. On `/stop_profile`, the recorder is closed everywhere; files remain on
+   disk under `<event_dir>`.
+
+The torch profiler and the event recorder share a `run_id`. Setting
+`enable_torch=false` on the request lets you record cheap JSONL events without
+paying for a kernel trace.
+
+## Generating reports
+
+Use the views module — directly in Python:
+
+```python
+from sglang_omni.profiler.views import build_report
+report = build_report("/tmp/profiles/demo-run/events")
+print(report["request_count"], len(report["stage_breakdown"]))
+```
+
+…or as a CLI:
+
+```bash
+python -m sglang_omni.profiler /tmp/profiles/demo-run/events --format table
+python -m sglang_omni.profiler /tmp/profiles/demo-run/events --format json --out report.json
+```
+
+The CLI / `build_report` returns three views derived from the same event
+stream:
+
+1. **Timeline** — per-request event list with `t_rel_ms` anchored at admission.
+2. **Stage breakdown** — pair `(open_event, close_event)` durations aggregated
+   per stage (count, total, avg, p50, p95, max).
+3. **Hop breakdown** — pair `stage_hop_sent`/`stage_input_received` and
+   `stage_stream_chunk_sent`/`stage_stream_chunk_received` durations per
+   (source, destination, kind).
+
+Hop pairs match across processes by `(request_id, source_stage, dest_stage,
+chunk_id?)`, so single requests can be reconstructed even when each stage is in
+its own subprocess.
+
+## Discipline
+
+- Recorder failures must never break serving: the emitter swallows write errors
+  and counts drops; the first failure is logged.
+- Tensors and large blobs MUST stay out of event metadata — keep metadata to
+  small scalars (ids, counts, durations, modality, error strings).
+- New event names should mirror existing naming: lowercase snake_case, prefix
+  with the layer that owns the event (`stage_*`, `scheduler_*`, etc.).

--- a/docs/developer_reference/profiler.md
+++ b/docs/developer_reference/profiler.md
@@ -32,22 +32,39 @@ can be merged transparently by passing the directory to the views layer.
 
 ### Standard event names
 
-| Layer | Event | Where it is emitted |
+The event taxonomy maps the high-level milestones laid out in issue #501 to
+concrete callsites. The recorder always attaches the active `stage` name to
+every event, so the same `scheduler_prefill_start` becomes "thinker prefill
+start" when emitted from the thinker process and "talker prefill start" when
+emitted from the talker process.
+
+| #501 milestone | Concrete event | Where |
 |---|---|---|
-| Coordinator | `request_admission` | `Coordinator._submit_request` |
-| Coordinator | `coordinator_stream_received` | `Coordinator._handle_stream` |
-| Coordinator | `terminal_response` | `Coordinator._handle_completion` |
-| Stage | `stage_input_received` | `Stage._on_submit` / `Stage._on_data_ready` |
-| Stage | `stage_aggregate_ready` | `Stage._on_data_ready` after `InputHandler.receive` returns a merged payload |
-| Stage | `stage_dispatch` | `Stage._execute` (scheduler inbox put) |
-| Stage | `stage_complete` | `Stage._route_result` |
-| Stage | `stage_hop_sent` | `Stage._send_to_stage` |
-| Stage | `stage_stream_chunk_sent` | `Stage._send_stream_to_target` / `_send_stream_to_coordinator` |
-| Stage | `stage_stream_chunk_received` | `Stage._on_stream_chunk` |
-| AR scheduler | `scheduler_request_build_start` / `_end` | `OmniScheduler.process_input_requests` |
-| AR scheduler | `scheduler_prefill_start` | `OmniScheduler.process_input_requests` |
-| AR scheduler | `scheduler_first_emit` | `OmniScheduler.run_batch` (first stream-output emit per request) |
-| Code2Wav | `code2wav_first_audio` | `Code2WavScheduler._decode_and_emit` (first non-empty audio chunk) |
+| request admission | `request_admission` | `Coordinator._submit_request` |
+| preprocessing start / end | `preprocess_start` / `preprocess_end` | `Qwen3OmniPreprocessor.__call__` |
+| encoder start / end | `encoder_start` / `encoder_end` (metadata `modality`, `batch_size`) | `create_image_encoder_executor`, `create_audio_encoder_executor` |
+| aggregate ready | `stage_aggregate_ready` | `Stage._on_data_ready` after `InputHandler.receive` returns a merged payload |
+| thinker prefill start | `scheduler_prefill_start` (stage=thinker) | `OmniScheduler.process_input_requests` |
+| thinker first token | `stage_first_stream_chunk_sent` (stage=thinker) | `Stage._send_stream_to_target` / `_send_stream_to_coordinator` |
+| first stream chunk sent | `stage_first_stream_chunk_sent` (terminal stage → coordinator) | same |
+| talker request build start / end | `scheduler_request_build_start` / `_end` (stage=talker) | `OmniScheduler.process_input_requests` |
+| talker prefill start | `scheduler_prefill_start` (stage=talker) | same |
+| first code chunk | `stage_first_stream_chunk_sent` (stage=talker) | `Stage._send_stream_to_target` |
+| code2wav first audio | `code2wav_first_audio` | `Code2WavScheduler._decode_and_emit` |
+| terminal response | `terminal_response` | `Coordinator._handle_completion` |
+
+Additional supporting events used for finer-grained breakdown:
+
+| Layer | Event | Notes |
+|---|---|---|
+| Coordinator | `coordinator_stream_received` | Each `StreamMessage` received on the coordinator |
+| Stage | `stage_input_received` | Submit or relay payload accepted (metadata `from_stage`) |
+| Stage | `stage_dispatch` | Scheduler inbox put |
+| Stage | `stage_complete` | Scheduler result routed onward (metadata `terminal`, `next`) |
+| Stage | `stage_hop_sent` | Payload `DataReadyMessage` sent to next stage |
+| Stage | `stage_stream_chunk_sent` | Each stream chunk (metadata `to_stage`, `chunk_id`, `modality`) |
+| Stage | `stage_stream_chunk_received` | Each stream chunk received |
+| AR scheduler | `scheduler_first_emit` | First `stream_output_builder` emission per request |
 
 Custom callsites can call `sglang_omni.profiler.event_recorder.emit(...)` to add
 domain-specific events — for example, model-specific preprocess timings or

--- a/docs/developer_reference/profiler.md
+++ b/docs/developer_reference/profiler.md
@@ -1,18 +1,24 @@
 # Request-level profiler
 
-This document describes the request-level profiler introduced for
-[issue #501](https://github.com/sgl-project/sglang-omni/issues/501).
+`sglang-omni` ships two complementary profilers that share the same `run_id`
+and are controlled by the same HTTP surface:
 
-The goal is to reconstruct the full latency timeline of a request as it flows
-through the multi-stage pipeline, aggregate stage-local time, and surface
-stage-to-stage hop costs. The existing `TorchProfiler` keeps doing what it does
-(kernel-level Chrome traces); the request-level profiler runs alongside it and
-shares the same `run_id`.
+- a **request-level event recorder** that writes a JSONL stream of
+  per-request milestones (admission, preprocess, encoder, prefill, first
+  token / first code chunk, hops, terminal response) — used to reconstruct
+  a single request's end-to-end timeline and to aggregate stage / hop costs
+  across a batch;
+- a **torch profiler** that produces a Chrome trace of kernel-level CPU /
+  CUDA activity — used to drill into a specific window once the event
+  recorder has identified where the time is going.
+
+Most diagnostics use the event recorder. The torch profiler is opt-in for
+deeper kernel investigation.
 
 ## Event model
 
 Every instrumentation point appends a single line of JSON to a per-process
-JSONL file. One event has the shape:
+JSONL file. The shape:
 
 ```jsonc
 {
@@ -26,34 +32,35 @@ JSONL file. One event has the shape:
 }
 ```
 
-Files are written under
-`<event_dir>/events_<stage>_<pid>.jsonl`. Stage files from different processes
-can be merged transparently by passing the directory to the views layer.
+Files are written under `<event_dir>/events_<stage>_<pid>.jsonl`. Multiple
+co-located stages in the same OS process share **one** JSONL file — the
+filename uses the first stage to start, and the per-event `stage` field
+identifies the owner. The views layer merges files from every process by
+`request_id`.
 
 ### Standard event names
 
-The event taxonomy maps the high-level milestones laid out in issue #501 to
-concrete callsites. The recorder always attaches the active `stage` name to
-every event, so the same `scheduler_prefill_start` becomes "thinker prefill
-start" when emitted from the thinker process and "talker prefill start" when
-emitted from the talker process.
+The recorder always attaches the active `stage` name to every event, so the
+same `scheduler_prefill_start` becomes "thinker prefill start" when emitted
+from the thinker process and "talker prefill start" when emitted from the
+talker process.
 
-| #501 milestone | Concrete event | Where |
+| Pipeline milestone | Concrete event | Source |
 |---|---|---|
-| request admission | `request_admission` | `Coordinator._submit_request` |
-| preprocessing start / end | `preprocess_start` / `preprocess_end` | `Qwen3OmniPreprocessor.__call__` |
-| encoder start / end | `encoder_start` / `encoder_end` (metadata `modality`, `batch_size`) | `create_image_encoder_executor`, `create_audio_encoder_executor` |
-| aggregate ready | `stage_aggregate_ready` | `Stage._on_data_ready` after `InputHandler.receive` returns a merged payload |
-| thinker prefill start | `scheduler_prefill_start` (stage=thinker) | `OmniScheduler.process_input_requests` |
-| thinker first token | `stage_first_stream_chunk_sent` (stage=thinker) | `Stage._send_stream_to_target` / `_send_stream_to_coordinator` |
-| first stream chunk sent | `stage_first_stream_chunk_sent` (terminal stage → coordinator) | same |
-| talker request build start / end | `scheduler_request_build_start` / `_end` (stage=talker) | `OmniScheduler.process_input_requests` |
-| talker prefill start | `scheduler_prefill_start` (stage=talker) | same |
-| first code chunk | `stage_first_stream_chunk_sent` (stage=talker) | `Stage._send_stream_to_target` |
-| code2wav first audio | `code2wav_first_audio` | `Code2WavScheduler._decode_and_emit` |
-| terminal response | `terminal_response` | `Coordinator._handle_completion` |
+| Request admission | `request_admission` | `Coordinator._submit_request` |
+| Preprocessing start / end | `preprocess_start` / `preprocess_end` | model preprocessor `__call__` |
+| Encoder start / end | `encoder_start` / `encoder_end` (metadata `modality`, `batch_size`) | image / audio encoder executors |
+| Aggregate ready | `stage_aggregate_ready` | `Stage._on_data_ready` after `InputHandler.receive` returns a merged payload |
+| Thinker prefill start | `scheduler_prefill_start` (stage = thinker) | `OmniScheduler.process_input_requests` |
+| Thinker first token | `stage_first_stream_chunk_sent` (stage = thinker) | `Stage._send_stream_to_target` / `_send_stream_to_coordinator` |
+| First stream chunk to client | `stage_first_stream_chunk_sent` (terminal stage → coordinator) | same |
+| Talker request build start / end | `scheduler_request_build_start` / `_end` (stage = talker) | `OmniScheduler.process_input_requests` |
+| Talker prefill start | `scheduler_prefill_start` (stage = talker) | same |
+| First code chunk | `stage_first_stream_chunk_sent` (stage = talker) | `Stage._send_stream_to_target` |
+| Code2Wav first audio | `code2wav_first_audio` | `Code2WavScheduler._decode_and_emit` |
+| Terminal response | `terminal_response` | `Coordinator._handle_completion` |
 
-Additional supporting events used for finer-grained breakdown:
+Supporting events used for finer-grained breakdown:
 
 | Layer | Event | Notes |
 |---|---|---|
@@ -66,31 +73,71 @@ Additional supporting events used for finer-grained breakdown:
 | Stage | `stage_stream_chunk_received` | Each stream chunk received |
 | AR scheduler | `scheduler_first_emit` | First `stream_output_builder` emission per request |
 
-Custom callsites can call `sglang_omni.profiler.event_recorder.emit(...)` to add
-domain-specific events — for example, model-specific preprocess timings or
-encoder warmups. Events from inactive recorders are no-ops; instrumentation
-sites do not need to guard against the disabled case.
+Custom callsites can call `sglang_omni.profiler.event_recorder.emit(...)` to
+add domain-specific events. Events from inactive recorders are no-ops, so
+instrumentation sites do not need to guard against the disabled case.
+
+### Active-stage attribution
+
+`emit(...)` accepts an explicit `stage=...` parameter; when the caller can't
+plumb the stage name down (preprocessor `__call__`, encoder callables,
+`OmniScheduler` / `Code2WavScheduler` internals), it can pass `stage=None`
+and the recorder fills it in from the **per-thread / per-task active
+stage**.
+
+`Stage._run_scheduler` binds `set_active_stage(self.name)` on the scheduler
+thread before invoking the scheduler. The binding uses both a
+`threading.local` slot (for plain `threading.Thread` workers) and a
+`contextvars.ContextVar` (so it propagates through `asyncio.to_thread` /
+`loop.run_in_executor`, which copy contextvars but not thread-local).
+Explicit `stage=...` on emit always wins; the active-stage binding is only
+consulted when the caller passes `stage=None`.
+
+To bind / unbind manually from your own thread:
+
+```python
+from sglang_omni.profiler.event_recorder import set_active_stage, reset_active_stage
+
+token = set_active_stage("my_stage")
+try:
+    ...
+finally:
+    reset_active_stage(token)
+```
+
+`reset_active_stage(None)` is the "scrub" form (used by test fixtures) and
+clears both the thread-local slot and the contextvar.
 
 ## Lifecycle
 
 The recorder is process-local. It is started on every stage and on the
-coordinator when `/start_profile` (or `/start_request_profile`) is hit:
+coordinator when `POST /start_profile` (or `POST /start_request_profile`)
+is hit:
 
 1. Launcher receives the HTTP request.
 2. Coordinator starts its local recorder pointed at `<event_dir>`.
 3. Launcher broadcasts `ProfilerStartMessage` over ZMQ to every stage,
    carrying both the torch trace template and the `event_dir`.
-4. Each stage starts its own recorder for `event_dir` + its `stage` name.
-5. On `/stop_profile`, the recorder is closed everywhere; files remain on
-   disk under `<event_dir>`.
+4. Each stage joins the per-process recorder. In a shared-process topology
+   the first stage to call `start()` wins the filename; every subsequent
+   stage in the same process writes to the same file and the per-event
+   `stage` field disambiguates.
+5. On `POST /stop_profile`, the recorder is closed everywhere; files
+   remain on disk under `<event_dir>`.
+
+`POST /stop_profile` and `POST /stop_request_profile` accept an optional
+`run_id` field. When **omitted**, the request is a wildcard: every stage
+stops whatever profiler session is currently active. When **set**, only
+stages whose active run matches stop. This makes the common case (caller
+didn't specify a run_id on either start or stop) work without ceremony.
 
 The torch profiler and the event recorder share a `run_id`. Setting
-`enable_torch=false` on the request lets you record cheap JSONL events without
+`enable_torch=false` on the start request records JSONL events without
 paying for a kernel trace.
 
 ## Generating reports
 
-Use the views module — directly in Python:
+Use the views module directly:
 
 ```python
 from sglang_omni.profiler.views import build_report
@@ -98,7 +145,7 @@ report = build_report("/tmp/profiles/demo-run/events")
 print(report["request_count"], len(report["stage_breakdown"]))
 ```
 
-…or as a CLI:
+…or via the CLI:
 
 ```bash
 python -m sglang_omni.profiler /tmp/profiles/demo-run/events --format table
@@ -108,22 +155,75 @@ python -m sglang_omni.profiler /tmp/profiles/demo-run/events --format json --out
 The CLI / `build_report` returns three views derived from the same event
 stream:
 
-1. **Timeline** — per-request event list with `t_rel_ms` anchored at admission.
-2. **Stage breakdown** — pair `(open_event, close_event)` durations aggregated
-   per stage (count, total, avg, p50, p95, max).
-3. **Hop breakdown** — pair `stage_hop_sent`/`stage_input_received` and
-   `stage_stream_chunk_sent`/`stage_stream_chunk_received` durations per
+1. **Timeline** — per-request event list with `t_rel_ms` anchored at
+   admission.
+2. **Stage breakdown** — `(open_event, close_event)` interval durations
+   aggregated per stage (count, total, avg, p50, p95, max). The same opener
+   can participate in multiple pairs (e.g. `scheduler_prefill_start` closes
+   against both `scheduler_first_emit` AND `stage_first_stream_chunk_sent`);
+   every pair gets its own pending stack so a close event for pair A does
+   not consume the opener of pair B.
+3. **Hop breakdown** — `stage_hop_sent` / `stage_input_received` and
+   `stage_stream_chunk_sent` / `stage_stream_chunk_received` durations per
    (source, destination, kind).
 
 Hop pairs match across processes by `(request_id, source_stage, dest_stage,
-chunk_id?)`, so single requests can be reconstructed even when each stage is in
-its own subprocess.
+chunk_id?)`, so a single request's path through subprocesses can be
+reconstructed even when each stage runs in its own process.
+
+## Torch profiler
+
+The torch profiler runs alongside the event recorder when
+`enable_torch=true` (the default for `/start_profile`). It records
+continuously between `start()` and `stop()` — no `schedule(...)`, no
+`step()` requirement — and exports a Chrome trace `*.trace.json.gz` on stop.
+
+The expensive introspection flags are opt-in via env vars so the default
+trace stays small enough to load in `chrome://tracing` or
+[`ui.perfetto.dev`](https://ui.perfetto.dev):
+
+| Env var | Effect |
+|---|---|
+| `SGLANG_TORCH_PROFILER_RECORD_SHAPES=1` | Record input tensor shapes per op |
+| `SGLANG_TORCH_PROFILER_PROFILE_MEMORY=1` | Track every CUDA caching-allocator alloc / free |
+| `SGLANG_TORCH_PROFILER_WITH_STACK=1` | Record the Python (and C++) call stack per op |
+| `SGLANG_TORCH_PROFILER_WITH_FLOPS=1` | Estimate FLOPs per op |
+
+With all four off (the default), a typical 10-sample MMMU run produces a
+trace in the tens of MB. With all four on, the same workload can produce a
+multi-GB trace — only opt in when you need that specific information.
+
+## HTTP surface
+
+| Method | Path | Body | Notes |
+|---|---|---|---|
+| POST | `/start_profile` | `{"run_id": ?, "trace_path_template": ?, "event_dir": ?, "enable_torch": true \| false, "config": ?}` | Starts torch trace + event recorder. `run_id` auto-generated if omitted. |
+| POST | `/stop_profile` | `{"run_id": ?}` | Stops torch trace + event recorder. Omitting `run_id` is a wildcard ("stop whatever's active"). |
+| POST | `/start_request_profile` | `{"run_id": ?, "event_dir": ?}` | Event recorder only — no torch trace. Lower overhead; safer to leave on. |
+| POST | `/stop_request_profile` | `{"run_id": ?}` | Same wildcard semantics as `/stop_profile`. |
+
+Example: record cheap events on every request without a kernel trace:
+
+```bash
+curl -X POST http://localhost:8000/start_request_profile \
+     -d '{"run_id":"demo","event_dir":"/tmp/profiles/demo/events"}'
+# … run traffic …
+curl -X POST http://localhost:8000/stop_request_profile -d '{}'
+python -m sglang_omni.profiler /tmp/profiles/demo/events --format table
+```
 
 ## Discipline
 
-- Recorder failures must never break serving: the emitter swallows write errors
-  and counts drops; the first failure is logged.
-- Tensors and large blobs MUST stay out of event metadata — keep metadata to
-  small scalars (ids, counts, durations, modality, error strings).
-- New event names should mirror existing naming: lowercase snake_case, prefix
-  with the layer that owns the event (`stage_*`, `scheduler_*`, etc.).
+- **Profiling must never break serving.** The emitter swallows write
+  errors and counts drops; the first failure is logged once.
+- **Tensors and large blobs stay out of event metadata.** Keep metadata
+  to small scalars (ids, counts, durations, modality, error strings). The
+  recorder enforces this defensively: if a tensor / numpy array ends up
+  in metadata, `_json_default` serializes a summary
+  (`{"__tensor_summary__": true, "type": ..., "shape": [...], "dtype":
+  "...", "device": "..."}`) instead of materializing the contents. 0-D
+  tensors / numpy scalars still serialize as plain scalars.
+- **Event naming.** Lowercase snake_case, prefix with the layer that
+  owns the event (`stage_*`, `scheduler_*`, `encoder_*`, etc.). Use the
+  stage name (not the event name) to distinguish "thinker prefill start"
+  from "talker prefill start".

--- a/docs/developer_reference/profiler.md
+++ b/docs/developer_reference/profiler.md
@@ -43,7 +43,9 @@ identifies the owner. The views layer merges files from every process by
 The recorder always attaches the active `stage` name to every event, so the
 same `scheduler_prefill_start` becomes "thinker prefill start" when emitted
 from the thinker process and "talker prefill start" when emitted from the
-talker process.
+talker process. `scheduler_queue_enter` marks a built request entering the
+scheduler queue; `scheduler_prefill_start` is emitted later, when the request's
+first executable prefill / extend batch is selected.
 
 | Pipeline milestone | Concrete event | Source |
 |---|---|---|
@@ -51,7 +53,7 @@ talker process.
 | Preprocessing start / end | `preprocess_start` / `preprocess_end` | model preprocessor `__call__` |
 | Encoder start / end | `encoder_start` / `encoder_end` (metadata `modality`, `batch_size`) | image / audio encoder executors |
 | Aggregate ready | `stage_aggregate_ready` | `Stage._on_data_ready` after `InputHandler.receive` returns a merged payload |
-| Thinker prefill start | `scheduler_prefill_start` (stage = thinker) | `OmniScheduler.process_input_requests` |
+| Thinker prefill start | `scheduler_prefill_start` (stage = thinker) | `OmniScheduler.run_batch` |
 | Thinker first token | `stage_first_stream_chunk_sent` (stage = thinker) | `Stage._send_stream_to_target` / `_send_stream_to_coordinator` |
 | First stream chunk to client | `stage_first_stream_chunk_sent` (terminal stage → coordinator) | same |
 | Talker request build start / end | `scheduler_request_build_start` / `_end` (stage = talker) | `OmniScheduler.process_input_requests` |
@@ -70,7 +72,8 @@ Supporting events used for finer-grained breakdown:
 | Stage | `stage_complete` | Scheduler result routed onward (metadata `terminal`, `next`) |
 | Stage | `stage_hop_sent` | Payload `DataReadyMessage` sent to next stage |
 | Stage | `stage_stream_chunk_sent` | Each stream chunk (metadata `to_stage`, `chunk_id`, `modality`) |
-| Stage | `stage_stream_chunk_received` | Each stream chunk received |
+| Stage | `stage_stream_chunk_received` | Each stream chunk materialized and ready for the receiver scheduler, including coordinator terminal chunks |
+| AR scheduler | `scheduler_queue_enter` | Built request entered the scheduler queue |
 | AR scheduler | `scheduler_first_emit` | First `stream_output_builder` emission per request |
 
 Custom callsites can call `sglang_omni.profiler.event_recorder.emit(...)` to
@@ -165,7 +168,8 @@ stream:
    not consume the opener of pair B.
 3. **Hop breakdown** — `stage_hop_sent` / `stage_input_received` and
    `stage_stream_chunk_sent` / `stage_stream_chunk_received` durations per
-   (source, destination, kind).
+   (source, destination, kind). Terminal stage stream chunks are paired the
+   same way with destination `coordinator`.
 
 Hop pairs match across processes by `(request_id, source_stage, dest_stage,
 chunk_id?)`, so a single request's path through subprocesses can be

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,3 +44,4 @@ Our core features include:
    developer_reference/pipeline.md
    developer_reference/config.md
    developer_reference/communication.md
+   developer_reference/profiler.md

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -13,6 +13,7 @@ from typing import Any
 import numpy as np
 import torch
 
+from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
 
@@ -237,7 +238,15 @@ class Code2WavScheduler:
         audio = self._decode_incremental(request_id, chunks, start, end)
         self._emitted[request_id] = end
         if audio.size > 0:
+            is_first = not self._audio_chunks[request_id]
             self._audio_chunks[request_id].append(audio)
+            if is_first:
+                _emit_event(
+                    request_id=request_id,
+                    stage=None,
+                    event_name="code2wav_first_audio",
+                    metadata={"samples": int(audio.shape[0])},
+                )
             if self._stream_enabled.get(request_id, True):
                 self.outbox.put(
                     OutgoingMessage(

--- a/sglang_omni/models/qwen3_omni/components/preprocessor.py
+++ b/sglang_omni/models/qwen3_omni/components/preprocessor.py
@@ -29,6 +29,7 @@ from sglang_omni.preprocessing import (
     ensure_video_list_async,
     normalize_messages,
 )
+from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.proto import StagePayload
 
 logger = logging.getLogger(__name__)
@@ -190,6 +191,22 @@ class Qwen3OmniPreprocessor:
         return result
 
     async def __call__(self, payload: StagePayload) -> StagePayload:
+        _emit_event(
+            request_id=payload.request_id,
+            stage=None,
+            event_name="preprocess_start",
+        )
+        try:
+            result = await self._call_impl(payload)
+        finally:
+            _emit_event(
+                request_id=payload.request_id,
+                stage=None,
+                event_name="preprocess_end",
+            )
+        return result
+
+    async def _call_impl(self, payload: StagePayload) -> StagePayload:
         inputs = payload.request.inputs
         if isinstance(inputs, dict):
             messages = inputs.get("messages", [])

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -27,6 +27,7 @@ from sglang_omni.models.qwen3_omni.request_builders import (
     apply_encoder_result,
     build_encoder_request,
 )
+from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.sglang_backend import (
     apply_encoder_mem_reserve,
@@ -794,19 +795,49 @@ def create_image_encoder_executor(
     )
 
     def _encode(payload: StagePayload) -> StagePayload:
-        return _run_single_encoder_payload(
-            payload,
-            stage_name=IMAGE_STAGE,
-            model=model,
-            cache=cache,
+        _emit_event(
+            request_id=payload.request_id,
+            stage=None,
+            event_name="encoder_start",
+            metadata={"modality": "image", "batch_size": 1},
         )
+        try:
+            return _run_single_encoder_payload(
+                payload,
+                stage_name=IMAGE_STAGE,
+                model=model,
+                cache=cache,
+            )
+        finally:
+            _emit_event(
+                request_id=payload.request_id,
+                stage=None,
+                event_name="encoder_end",
+                metadata={"modality": "image", "batch_size": 1},
+            )
 
     def _encode_batch(payloads: list[StagePayload]) -> list[StagePayload]:
-        return _batch_image_encoder_payloads(
-            payloads,
-            model=model,
-            cache=cache,
-        )
+        for p in payloads:
+            _emit_event(
+                request_id=p.request_id,
+                stage=None,
+                event_name="encoder_start",
+                metadata={"modality": "image", "batch_size": len(payloads)},
+            )
+        try:
+            return _batch_image_encoder_payloads(
+                payloads,
+                model=model,
+                cache=cache,
+            )
+        finally:
+            for p in payloads:
+                _emit_event(
+                    request_id=p.request_id,
+                    stage=None,
+                    event_name="encoder_end",
+                    metadata={"modality": "image", "batch_size": len(payloads)},
+                )
 
     # Preserve the calibrated image-encoder batching shape and add a small
     # batch_wait so video benchmarks at concurrency=16 batch together.
@@ -836,19 +867,49 @@ def create_audio_encoder_executor(
     )
 
     def _encode(payload: StagePayload) -> StagePayload:
-        return _run_single_encoder_payload(
-            payload,
-            stage_name=AUDIO_STAGE,
-            model=model,
-            cache=cache,
+        _emit_event(
+            request_id=payload.request_id,
+            stage=None,
+            event_name="encoder_start",
+            metadata={"modality": "audio", "batch_size": 1},
         )
+        try:
+            return _run_single_encoder_payload(
+                payload,
+                stage_name=AUDIO_STAGE,
+                model=model,
+                cache=cache,
+            )
+        finally:
+            _emit_event(
+                request_id=payload.request_id,
+                stage=None,
+                event_name="encoder_end",
+                metadata={"modality": "audio", "batch_size": 1},
+            )
 
     def _encode_batch(payloads: list[StagePayload]) -> list[StagePayload]:
-        return _batch_audio_encoder_payloads(
-            payloads,
-            model=model,
-            cache=cache,
-        )
+        for p in payloads:
+            _emit_event(
+                request_id=p.request_id,
+                stage=None,
+                event_name="encoder_start",
+                metadata={"modality": "audio", "batch_size": len(payloads)},
+            )
+        try:
+            return _batch_audio_encoder_payloads(
+                payloads,
+                model=model,
+                cache=cache,
+            )
+        finally:
+            for p in payloads:
+                _emit_event(
+                    request_id=p.request_id,
+                    stage=None,
+                    event_name="encoder_end",
+                    metadata={"modality": "audio", "batch_size": len(payloads)},
+                )
 
     return SimpleScheduler(
         _encode,

--- a/sglang_omni/pipeline/coordinator.py
+++ b/sglang_omni/pipeline/coordinator.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Sequence
 from typing import Any, AsyncIterator
 
 from sglang_omni.pipeline.control_plane import CoordinatorControlPlane
+from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.proto import (
     AbortMessage,
     CompleteMessage,
@@ -212,6 +213,13 @@ class Coordinator:
             data={"raw_inputs": request.inputs},
         )
 
+        _emit_event(
+            request_id=request_id,
+            stage="coordinator",
+            event_name="request_admission",
+            metadata={"entry_stage": self.entry_stage},
+        )
+
         # Submit to entry stage
         entry_info = self._stages[self.entry_stage]
         await self.control_plane.submit_to_stage(
@@ -305,6 +313,15 @@ class Coordinator:
             msg.from_stage,
             msg.success,
         )
+        _emit_event(
+            request_id=request_id,
+            stage="coordinator",
+            event_name="terminal_response",
+            metadata={
+                "from_stage": msg.from_stage,
+                "success": msg.success,
+            },
+        )
 
         if request_id not in self._requests:
             logger.warning(
@@ -383,6 +400,12 @@ class Coordinator:
         request_id = msg.request_id
         if request_id not in self._stream_queues:
             return
+        _emit_event(
+            request_id=request_id,
+            stage="coordinator",
+            event_name="coordinator_stream_received",
+            metadata={"from_stage": msg.from_stage, "modality": msg.modality},
+        )
         await self._stream_queues[request_id].put(msg)
 
     def get_request_info(self, request_id: str) -> RequestInfo | None:

--- a/sglang_omni/pipeline/coordinator.py
+++ b/sglang_omni/pipeline/coordinator.py
@@ -404,7 +404,21 @@ class Coordinator:
             request_id=request_id,
             stage="coordinator",
             event_name="coordinator_stream_received",
-            metadata={"from_stage": msg.from_stage, "modality": msg.modality},
+            metadata={
+                "from_stage": msg.from_stage,
+                "chunk_id": msg.chunk_id,
+                "modality": msg.modality,
+            },
+        )
+        _emit_event(
+            request_id=request_id,
+            stage="coordinator",
+            event_name="stage_stream_chunk_received",
+            metadata={
+                "from_stage": msg.from_stage,
+                "chunk_id": msg.chunk_id,
+                "modality": msg.modality,
+            },
         )
         await self._stream_queues[request_id].put(msg)
 

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -128,6 +128,11 @@ class Stage:
         self._active_requests: set[str] = set()
         self._stream_queue: StreamQueue | None = None
         self._stream_chunk_counters: dict[tuple[str, str], int] = {}
+        # Per-request marker: have we already emitted the first stream-chunk
+        # event for this request from this stage? Used to derive request-level
+        # milestones (thinker first token, talker first code chunk, etc.)
+        # without coupling Stage to model-specific naming.
+        self._first_stream_chunk_seen: set[str] = set()
         self._scheduler_thread: threading.Thread | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._scheduler_crash_error: BaseException | None = None
@@ -717,6 +722,17 @@ class Stage:
         key = (request_id, target)
         chunk_id = self._stream_chunk_counters.get(key, 0)
         self._stream_chunk_counters[key] = chunk_id + 1
+        chunk_modality = (
+            metadata.get("modality") if isinstance(metadata, dict) else None
+        )
+        if request_id not in self._first_stream_chunk_seen:
+            self._first_stream_chunk_seen.add(request_id)
+            _emit_event(
+                request_id=request_id,
+                stage=self.name,
+                event_name="stage_first_stream_chunk_sent",
+                metadata={"to_stage": target, "modality": chunk_modality},
+            )
         _emit_event(
             request_id=request_id,
             stage=self.name,
@@ -724,9 +740,7 @@ class Stage:
             metadata={
                 "to_stage": target,
                 "chunk_id": chunk_id,
-                "modality": (
-                    metadata.get("modality") if isinstance(metadata, dict) else None
-                ),
+                "modality": chunk_modality,
             },
         )
         await relay_io.send_stream_chunk(
@@ -769,6 +783,14 @@ class Stage:
             stage_name=self.name,
             modality=modality,
         )
+        if request_id not in self._first_stream_chunk_seen:
+            self._first_stream_chunk_seen.add(request_id)
+            _emit_event(
+                request_id=request_id,
+                stage=self.name,
+                event_name="stage_first_stream_chunk_sent",
+                metadata={"to_stage": "coordinator", "modality": modality},
+            )
         _emit_event(
             request_id=request_id,
             stage=self.name,
@@ -802,6 +824,7 @@ class Stage:
         ]
         for key in stale_keys:
             self._stream_chunk_counters.pop(key, None)
+        self._first_stream_chunk_seen.discard(request_id)
 
     async def _handle_scheduler_crash(self, exc: BaseException) -> None:
         if self._scheduler_crash_error is not None:

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -129,10 +129,7 @@ class Stage:
         self._active_requests: set[str] = set()
         self._stream_queue: StreamQueue | None = None
         self._stream_chunk_counters: dict[tuple[str, str], int] = {}
-        # Per-request marker: have we already emitted the first stream-chunk
-        # event for this request from this stage? Used to derive request-level
-        # milestones (thinker first token, talker first code chunk, etc.)
-        # without coupling Stage to model-specific naming.
+        # Per-request: did we already emit the first stream-chunk event?
         self._first_stream_chunk_seen: set[str] = set()
         self._scheduler_thread: threading.Thread | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
@@ -150,13 +147,8 @@ class Stage:
         if self.scheduler is not None:
 
             def _run_scheduler():
-                # Bind this stage's name to the active-stage context for
-                # this thread (and any asyncio.to_thread / run_in_executor
-                # descendants that copy contextvars). Callsites that pass
-                # ``stage=None`` to ``emit()`` — preprocessor, encoder
-                # callables, OmniScheduler internals, code2wav — will get
-                # the correct stage name even when this stage shares its
-                # process with siblings.
+                # Active-stage binding so ``emit(stage=None)`` from
+                # scheduler-thread descendants resolves to this stage.
                 _set_active_stage(self.name)
                 try:
                     if self.gpu_id is not None:
@@ -905,9 +897,7 @@ class Stage:
                 )
 
     def _on_profiler_stop(self, msg: ProfilerStopMessage) -> None:
-        # msg.run_id is None when the HTTP caller didn't specify a run id;
-        # in that case stop whatever's active. Otherwise only stop when
-        # the run id matches.
+        # run_id=None is a wildcard (stop whatever's active).
         if TorchProfiler.is_active() and (
             msg.run_id is None or TorchProfiler.get_active_run_id() == msg.run_id
         ):

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -20,6 +20,8 @@ from sglang_omni.pipeline import relay_io
 from sglang_omni.pipeline.stage.input import DirectInput, InputHandler
 from sglang_omni.pipeline.stage.stream_queue import StreamItem, StreamQueue
 from sglang_omni.pipeline.tp_control import TPLeaderFanout
+from sglang_omni.profiler.event_recorder import emit as _emit_event
+from sglang_omni.profiler.event_recorder import get_recorder as _get_recorder
 from sglang_omni.profiler.torch_profiler import TorchProfiler
 from sglang_omni.proto import (
     CompleteMessage,
@@ -251,6 +253,12 @@ class Stage:
         self._active_requests.add(request_id)
         if self._stream_queue is not None and not self._stream_queue.has(request_id):
             self._stream_queue.open(request_id)
+        _emit_event(
+            request_id=request_id,
+            stage=self.name,
+            event_name="stage_input_received",
+            metadata={"from_stage": "coordinator", "kind": "submit"},
+        )
 
         payload = msg.data  # StagePayload from coordinator
         await self._execute(payload)
@@ -280,9 +288,21 @@ class Stage:
         if request_id in self._aborted:
             return
 
+        _emit_event(
+            request_id=request_id,
+            stage=self.name,
+            event_name="stage_input_received",
+            metadata={"from_stage": msg.from_stage, "kind": "payload"},
+        )
         # Input aggregation
         merged = self.input_handler.receive(request_id, msg.from_stage, payload)
         if merged is not None:
+            _emit_event(
+                request_id=request_id,
+                stage=self.name,
+                event_name="stage_aggregate_ready",
+                metadata={"from_stage": msg.from_stage},
+            )
             await self._execute(merged)
 
     async def _on_stream_chunk(self, msg: DataReadyMessage) -> None:
@@ -291,6 +311,12 @@ class Stage:
             await self._discard_stream_chunk_data(msg)
             return
         self._active_requests.add(request_id)
+        _emit_event(
+            request_id=request_id,
+            stage=self.name,
+            event_name="stage_stream_chunk_received",
+            metadata={"from_stage": msg.from_stage, "chunk_id": msg.chunk_id},
+        )
 
         # Same-GPU CUDA IPC
         if isinstance(msg.shm_metadata, dict) and msg.shm_metadata.get("_ipc"):
@@ -508,6 +534,11 @@ class Stage:
 
     async def _execute(self, payload: Any) -> None:
         request_id = payload.request_id
+        _emit_event(
+            request_id=request_id,
+            stage=self.name,
+            event_name="stage_dispatch",
+        )
         self.scheduler.inbox.put(
             IncomingMessage(request_id=request_id, type="new_request", data=payload)
         )
@@ -614,6 +645,12 @@ class Stage:
         next_stages = self.get_next(request_id, result)
         if next_stages is None:
             # Terminal: notify coordinator
+            _emit_event(
+                request_id=request_id,
+                stage=self.name,
+                event_name="stage_complete",
+                metadata={"terminal": True},
+            )
             await self.control_plane.send_complete(
                 CompleteMessage(
                     request_id=request_id,
@@ -625,6 +662,12 @@ class Stage:
         else:
             if isinstance(next_stages, str):
                 next_stages = [next_stages]
+            _emit_event(
+                request_id=request_id,
+                stage=self.name,
+                event_name="stage_complete",
+                metadata={"terminal": False, "next": list(next_stages)},
+            )
             for target in next_stages:
                 await self._send_to_stage(request_id, target, result)
 
@@ -650,6 +693,12 @@ class Stage:
             to_stage=target,
             shm_metadata=metadata,
         )
+        _emit_event(
+            request_id=request_id,
+            stage=self.name,
+            event_name="stage_hop_sent",
+            metadata={"to_stage": target},
+        )
         await self.control_plane.send_to_stage(target, endpoint, msg)
         await op.wait_for_completion()
 
@@ -668,6 +717,18 @@ class Stage:
         key = (request_id, target)
         chunk_id = self._stream_chunk_counters.get(key, 0)
         self._stream_chunk_counters[key] = chunk_id + 1
+        _emit_event(
+            request_id=request_id,
+            stage=self.name,
+            event_name="stage_stream_chunk_sent",
+            metadata={
+                "to_stage": target,
+                "chunk_id": chunk_id,
+                "modality": (
+                    metadata.get("modality") if isinstance(metadata, dict) else None
+                ),
+            },
+        )
         await relay_io.send_stream_chunk(
             self.relay,
             self.control_plane,
@@ -707,6 +768,12 @@ class Stage:
             chunk=data,
             stage_name=self.name,
             modality=modality,
+        )
+        _emit_event(
+            request_id=request_id,
+            stage=self.name,
+            event_name="stage_stream_chunk_sent",
+            metadata={"to_stage": "coordinator", "modality": modality},
         )
         await self.control_plane.send_stream(msg)
 
@@ -785,15 +852,25 @@ class Stage:
         self.scheduler.abort(request_id)
 
     def _on_profiler_start(self, msg: ProfilerStartMessage) -> None:
-        if TorchProfiler.is_active():
-            return
         run_id = msg.run_id
-        base_tpl = msg.trace_path_template.format(run_id=run_id, stage=self.name)
-        template = f"{base_tpl}_pid{os.getpid()}"
-        prof_dir = os.environ.get("SGLANG_TORCH_PROFILER_DIR")
-        if prof_dir and not os.path.isabs(template):
-            template = os.path.join(prof_dir, template)
-        TorchProfiler.start(template, run_id=run_id)
+        if msg.enable_torch and not TorchProfiler.is_active():
+            base_tpl = msg.trace_path_template.format(run_id=run_id, stage=self.name)
+            template = f"{base_tpl}_pid{os.getpid()}"
+            prof_dir = os.environ.get("SGLANG_TORCH_PROFILER_DIR")
+            if prof_dir and not os.path.isabs(template):
+                template = os.path.join(prof_dir, template)
+            TorchProfiler.start(template, run_id=run_id)
+        if msg.event_dir is not None:
+            try:
+                _get_recorder().start(
+                    run_id=run_id, event_dir=msg.event_dir, stage=self.name
+                )
+            except Exception:
+                logger.warning(
+                    "Stage %s failed to start request event recorder",
+                    self.name,
+                    exc_info=True,
+                )
 
     def _on_profiler_stop(self, msg: ProfilerStopMessage) -> None:
         if (
@@ -801,6 +878,9 @@ class Stage:
             and TorchProfiler.get_active_run_id() == msg.run_id
         ):
             TorchProfiler.stop(run_id=msg.run_id)
+        recorder = _get_recorder()
+        if recorder.is_active() and recorder.active_run_id() == msg.run_id:
+            recorder.stop(run_id=msg.run_id)
 
     def _on_background_task_done(self, task: asyncio.Task, label: str) -> None:
         if task.cancelled():

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -22,6 +22,7 @@ from sglang_omni.pipeline.stage.stream_queue import StreamItem, StreamQueue
 from sglang_omni.pipeline.tp_control import TPLeaderFanout
 from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.profiler.event_recorder import get_recorder as _get_recorder
+from sglang_omni.profiler.event_recorder import set_active_stage as _set_active_stage
 from sglang_omni.profiler.torch_profiler import TorchProfiler
 from sglang_omni.proto import (
     CompleteMessage,
@@ -149,6 +150,14 @@ class Stage:
         if self.scheduler is not None:
 
             def _run_scheduler():
+                # Bind this stage's name to the active-stage context for
+                # this thread (and any asyncio.to_thread / run_in_executor
+                # descendants that copy contextvars). Callsites that pass
+                # ``stage=None`` to ``emit()`` — preprocessor, encoder
+                # callables, OmniScheduler internals, code2wav — will get
+                # the correct stage name even when this stage shares its
+                # process with siblings.
+                _set_active_stage(self.name)
                 try:
                     if self.gpu_id is not None:
                         import torch
@@ -896,13 +905,17 @@ class Stage:
                 )
 
     def _on_profiler_stop(self, msg: ProfilerStopMessage) -> None:
-        if (
-            TorchProfiler.is_active()
-            and TorchProfiler.get_active_run_id() == msg.run_id
+        # msg.run_id is None when the HTTP caller didn't specify a run id;
+        # in that case stop whatever's active. Otherwise only stop when
+        # the run id matches.
+        if TorchProfiler.is_active() and (
+            msg.run_id is None or TorchProfiler.get_active_run_id() == msg.run_id
         ):
             TorchProfiler.stop(run_id=msg.run_id)
         recorder = _get_recorder()
-        if recorder.is_active() and recorder.active_run_id() == msg.run_id:
+        if recorder.is_active() and (
+            msg.run_id is None or recorder.active_run_id() == msg.run_id
+        ):
             recorder.stop(run_id=msg.run_id)
 
     def _on_background_task_done(self, task: asyncio.Task, label: str) -> None:

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -317,12 +317,6 @@ class Stage:
             await self._discard_stream_chunk_data(msg)
             return
         self._active_requests.add(request_id)
-        _emit_event(
-            request_id=request_id,
-            stage=self.name,
-            event_name="stage_stream_chunk_received",
-            metadata={"from_stage": msg.from_stage, "chunk_id": msg.chunk_id},
-        )
 
         # Same-GPU CUDA IPC
         if isinstance(msg.shm_metadata, dict) and msg.shm_metadata.get("_ipc"):
@@ -339,6 +333,7 @@ class Stage:
                 return
             if request_id in self._aborted:
                 return
+            self._emit_stream_chunk_received(msg)
             await self._route_stream_item_or_fail(request_id, item)
             return
 
@@ -366,7 +361,16 @@ class Stage:
             from_stage=msg.from_stage,
             metadata=metadata,
         )
+        self._emit_stream_chunk_received(msg)
         await self._route_stream_item_or_fail(request_id, item)
+
+    def _emit_stream_chunk_received(self, msg: DataReadyMessage) -> None:
+        _emit_event(
+            request_id=msg.request_id,
+            stage=self.name,
+            event_name="stage_stream_chunk_received",
+            metadata={"from_stage": msg.from_stage, "chunk_id": msg.chunk_id},
+        )
 
     async def _route_stream_item_or_fail(
         self, request_id: str, item: StreamItem
@@ -777,12 +781,16 @@ class Stage:
         modality = metadata.get("modality") if isinstance(metadata, dict) else None
         if modality is None and isinstance(data, dict):
             modality = data.get("modality")
+        key = (request_id, "coordinator")
+        chunk_id = self._stream_chunk_counters.get(key, 0)
+        self._stream_chunk_counters[key] = chunk_id + 1
         msg = StreamMessage(
             request_id=request_id,
             from_stage=self.name,
             chunk=data,
             stage_name=self.name,
             modality=modality,
+            chunk_id=chunk_id,
         )
         if request_id not in self._first_stream_chunk_seen:
             self._first_stream_chunk_seen.add(request_id)
@@ -790,13 +798,21 @@ class Stage:
                 request_id=request_id,
                 stage=self.name,
                 event_name="stage_first_stream_chunk_sent",
-                metadata={"to_stage": "coordinator", "modality": modality},
+                metadata={
+                    "to_stage": "coordinator",
+                    "chunk_id": chunk_id,
+                    "modality": modality,
+                },
             )
         _emit_event(
             request_id=request_id,
             stage=self.name,
             event_name="stage_stream_chunk_sent",
-            metadata={"to_stage": "coordinator", "modality": modality},
+            metadata={
+                "to_stage": "coordinator",
+                "chunk_id": chunk_id,
+                "modality": modality,
+            },
         )
         await self.control_plane.send_stream(msg)
 

--- a/sglang_omni/profiler/__main__.py
+++ b/sglang_omni/profiler/__main__.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CLI for rendering request-level profiler reports.
+
+Usage::
+
+    python -m sglang_omni.profiler <event-dir-or-file> [--out report.json]
+    python -m sglang_omni.profiler events/ --format table
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from sglang_omni.profiler.views import build_report, format_table
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m sglang_omni.profiler",
+        description="Render request-level profiler views",
+    )
+    parser.add_argument(
+        "source",
+        help="Event JSONL file or directory of events_*.jsonl files",
+    )
+    parser.add_argument(
+        "--out",
+        default="-",
+        help="Output path; '-' writes to stdout (default)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "table"),
+        default="json",
+        help="Report format (default: json)",
+    )
+    args = parser.parse_args(argv)
+
+    report = build_report(args.source)
+    if args.format == "json":
+        text = json.dumps(report, indent=2)
+    else:
+        text = (
+            f"# Requests: {report['request_count']}\n\n"
+            "## Stage breakdown\n"
+            + format_table(
+                report["stage_breakdown"],
+                ["stage", "interval", "count", "total_ms", "avg_ms", "p95_ms"],
+            )
+            + "\n## Hop breakdown\n"
+            + format_table(
+                report["hop_breakdown"],
+                ["src", "dst", "kind", "count", "total_ms", "avg_ms", "p95_ms"],
+            )
+        )
+
+    if args.out == "-":
+        sys.stdout.write(text)
+        if not text.endswith("\n"):
+            sys.stdout.write("\n")
+    else:
+        with open(args.out, "w", encoding="utf-8") as fp:
+            fp.write(text)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(_main())

--- a/sglang_omni/profiler/event_recorder.py
+++ b/sglang_omni/profiler/event_recorder.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Request-level event recorder.
+
+Emits a stream of small JSONL events covering the per-request milestones laid
+out in https://github.com/sgl-project/sglang-omni/issues/501. Events from every
+process are written to ``<dir>/events_<stage>_<pid>.jsonl``; the views layer
+merges them back into a single per-request timeline.
+
+This module deliberately stays free of any sglang-omni dependency so it can be
+imported safely from any process (coordinator, stage, scheduler, model runner)
+without circular-import risk.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RequestEvent:
+    """A single point-in-time profiling event for one request.
+
+    The shape is intentionally narrow:
+    ``request_id``/``stage``/``event_name``/``timestamp_ns`` are required, and
+    free-form metadata lives in ``metadata`` so callers can attach token counts,
+    chunk ids, audio duration, queue depth, error strings, etc. without
+    forcing every event to grow new top-level fields.
+    """
+
+    request_id: str
+    stage: str
+    event_name: str
+    timestamp_ns: int
+    run_id: str | None = None
+    pid: int | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class RequestEventRecorder:
+    """Process-local JSONL event sink.
+
+    Thread-safe append: each call serializes one JSON object on its own line.
+    Lifetimes are controlled by ``start(run_id, event_dir, stage)`` /
+    ``stop()`` so the recorder can be toggled live via the existing
+    profiler control plane (``ProfilerStartMessage`` / ``ProfilerStopMessage``).
+
+    The recorder is exposed as a module-level singleton (`get_recorder`) so
+    arbitrary callsites can emit without threading a handle through every
+    constructor.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._run_id: str | None = None
+        self._stage: str | None = None
+        self._path: Path | None = None
+        self._fp: Any = None
+        self._pid: int = os.getpid()
+        self._dropped: int = 0
+
+    # ---- lifecycle -----------------------------------------------------
+
+    def is_active(self) -> bool:
+        return self._fp is not None
+
+    def active_run_id(self) -> str | None:
+        return self._run_id
+
+    def active_path(self) -> str | None:
+        return None if self._path is None else str(self._path)
+
+    def start(self, run_id: str, event_dir: str, stage: str) -> str:
+        """Open a fresh per-process JSONL file for this ``run_id``/``stage``.
+
+        Returns the absolute path of the opened file.
+        """
+        with self._lock:
+            if self._fp is not None:
+                if self._run_id == run_id and self._stage == stage:
+                    assert self._path is not None
+                    return str(self._path)
+                logger.warning(
+                    "RequestEventRecorder already active (run_id=%s, stage=%s); "
+                    "rotating to (run_id=%s, stage=%s)",
+                    self._run_id,
+                    self._stage,
+                    run_id,
+                    stage,
+                )
+                self._close_unlocked()
+
+            directory = Path(event_dir).expanduser().resolve()
+            directory.mkdir(parents=True, exist_ok=True)
+            path = directory / f"events_{stage}_{self._pid}.jsonl"
+            # Append mode keeps history if the same run_id is reused.
+            self._fp = path.open("a", buffering=1, encoding="utf-8")
+            self._run_id = run_id
+            self._stage = stage
+            self._path = path
+            self._dropped = 0
+            logger.info(
+                "RequestEventRecorder started run_id=%s stage=%s path=%s",
+                run_id,
+                stage,
+                path,
+            )
+            return str(path)
+
+    def stop(self, *, run_id: str | None = None) -> str | None:
+        """Close the active file. Returns the path that was written, if any.
+
+        If ``run_id`` is provided, the call is ignored unless it matches the
+        active run — mirrors :class:`TorchProfiler`.
+        """
+        with self._lock:
+            if self._fp is None:
+                return None
+            if (
+                run_id is not None
+                and self._run_id is not None
+                and run_id != self._run_id
+            ):
+                logger.warning(
+                    "Ignoring RequestEventRecorder stop for run_id=%s; active run_id=%s",
+                    run_id,
+                    self._run_id,
+                )
+                return None
+            path = str(self._path) if self._path is not None else None
+            self._close_unlocked()
+            return path
+
+    def _close_unlocked(self) -> None:
+        if self._fp is not None:
+            try:
+                self._fp.flush()
+                self._fp.close()
+            except Exception:
+                logger.warning(
+                    "RequestEventRecorder failed to close cleanly", exc_info=True
+                )
+        self._fp = None
+        self._run_id = None
+        self._stage = None
+        self._path = None
+
+    # ---- emit ----------------------------------------------------------
+
+    def emit(
+        self,
+        *,
+        request_id: str,
+        stage: str | None,
+        event_name: str,
+        metadata: Mapping[str, Any] | None = None,
+        timestamp_ns: int | None = None,
+    ) -> None:
+        """Append a single event. Silent no-op when the recorder is inactive.
+
+        The recorder is intentionally tolerant: any unexpected error during
+        emission must NOT propagate to the caller — profiling must never
+        break serving. Errors are logged once per occurrence and counted in
+        ``self._dropped``.
+        """
+        if self._fp is None:
+            return
+        ts = timestamp_ns if timestamp_ns is not None else time.time_ns()
+        # Capture file/run state under the lock so we can detect a concurrent
+        # stop() that closed the file out from under us.
+        with self._lock:
+            fp = self._fp
+            if fp is None:
+                return
+            event = RequestEvent(
+                request_id=request_id,
+                stage=stage if stage is not None else (self._stage or "unknown"),
+                event_name=event_name,
+                timestamp_ns=ts,
+                run_id=self._run_id,
+                pid=self._pid,
+                metadata=dict(metadata) if metadata else {},
+            )
+            try:
+                fp.write(json.dumps(event.to_dict(), default=_json_default))
+                fp.write("\n")
+            except Exception:
+                self._dropped += 1
+                # Log only the first failure per recorder lifetime to avoid
+                # swamping the log file.
+                if self._dropped == 1:
+                    logger.warning(
+                        "RequestEventRecorder failed to write event %s for %s",
+                        event_name,
+                        request_id,
+                        exc_info=True,
+                    )
+
+
+def _json_default(obj: Any) -> Any:
+    # Conservative fallback so unknown metadata types never break the recorder.
+    if hasattr(obj, "tolist"):
+        try:
+            return obj.tolist()
+        except Exception:  # pragma: no cover - last-resort path
+            pass
+    return repr(obj)
+
+
+_RECORDER = RequestEventRecorder()
+
+
+def get_recorder() -> RequestEventRecorder:
+    """Return the process-local recorder singleton."""
+    return _RECORDER
+
+
+def emit(
+    *,
+    request_id: str,
+    stage: str | None,
+    event_name: str,
+    metadata: Mapping[str, Any] | None = None,
+    timestamp_ns: int | None = None,
+) -> None:
+    """Convenience wrapper: ``emit(request_id=..., event_name=...)``.
+
+    Equivalent to ``get_recorder().emit(...)`` and is the form callers should
+    use at instrumentation sites.
+    """
+    _RECORDER.emit(
+        request_id=request_id,
+        stage=stage,
+        event_name=event_name,
+        metadata=metadata,
+        timestamp_ns=timestamp_ns,
+    )

--- a/sglang_omni/profiler/event_recorder.py
+++ b/sglang_omni/profiler/event_recorder.py
@@ -1,14 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Request-level event recorder.
 
-Emits a stream of small JSONL events covering the per-request milestones laid
-out in https://github.com/sgl-project/sglang-omni/issues/501. Events from every
-process are written to ``<dir>/events_<stage>_<pid>.jsonl``; the views layer
-merges them back into a single per-request timeline.
-
-This module deliberately stays free of any sglang-omni dependency so it can be
-imported safely from any process (coordinator, stage, scheduler, model runner)
-without circular-import risk.
+Each process appends events to ``<dir>/events_<stage>_<pid>.jsonl``; the
+views layer merges files by ``request_id``. Kept free of sglang-omni
+imports so it can be loaded from any process without circular risk.
 """
 
 from __future__ import annotations
@@ -26,27 +21,12 @@ from typing import Any, Mapping
 logger = logging.getLogger(__name__)
 
 
-# ---------------------------------------------------------------------------
-# Active-stage attribution
-# ---------------------------------------------------------------------------
-#
-# When multiple stages live in the same OS process (the declarative topology
-# does this for co-located ``role="single"`` stages), the recorder keeps ONE
-# file per process and the per-event ``stage`` field is the source of truth.
-# Most callsites pass ``stage=self.name`` explicitly, but library code that
-# can't easily plumb the stage name down (preprocessors, encoder callables,
-# OmniScheduler internals) calls ``emit(stage=None)`` and expects the
-# recorder to fill it in.
-#
-# A process-global fallback (the recorder's ``_stage``) is wrong: in a shared
-# process it's whichever stage called ``start()`` first, so every event from
-# every co-located stage would get that one name.
-#
-# Instead we expose a per-thread / per-task active stage. Stage's scheduler
-# thread sets it before invoking ``scheduler.start()``; emits in that thread
-# (and in any ``asyncio.to_thread`` / ``loop.run_in_executor`` descendants
-# that copy the context) see the correct stage name. Explicit ``stage=`` on
-# emit always wins.
+# Active-stage binding used when ``emit(stage=None)`` is called from code
+# that can't plumb the stage name down (preprocessor, encoder callable,
+# scheduler internals). Stage._run_scheduler binds the active stage on
+# the scheduler thread; the contextvar propagates through
+# ``asyncio.to_thread`` / ``loop.run_in_executor``, the thread-local
+# covers plain ``threading.Thread`` workers.
 
 _thread_active_stage = threading.local()
 _active_stage_cv: contextvars.ContextVar[str | None] = contextvars.ContextVar(
@@ -54,30 +34,14 @@ _active_stage_cv: contextvars.ContextVar[str | None] = contextvars.ContextVar(
 )
 
 
-def set_active_stage(stage: str | None) -> contextvars.Token | None:
-    """Bind ``stage`` as the active stage for the current thread / task.
-
-    Returns a ``contextvars.Token`` that ``reset_active_stage`` can use to
-    restore the previous value, or ``None`` if no contextvar binding was
-    performed (e.g. when ``stage`` is ``None`` and clearing was requested).
-
-    Sets BOTH a ``threading.local`` slot (for plain-thread callsites that
-    don't propagate contextvars) AND the contextvar (for asyncio /
-    ``run_in_executor`` callsites that copy context).
-    """
+def set_active_stage(stage: str | None) -> contextvars.Token:
+    """Bind ``stage`` for this thread / task. Returns a Token for reset."""
     _thread_active_stage.stage = stage
     return _active_stage_cv.set(stage)
 
 
 def reset_active_stage(token: contextvars.Token | None) -> None:
-    """Reverse a prior :func:`set_active_stage` call.
-
-    With a ``token``, restores the previous contextvar value (the standard
-    ``ContextVar.reset`` contract). Without a token, clears the binding by
-    setting the contextvar back to ``None`` — this is the form fixtures
-    use to scrub leaked active-stage state between tests, so it must
-    actually clear the contextvar and not just the ``threading.local``.
-    """
+    """Undo :func:`set_active_stage`. ``token=None`` clears the binding."""
     if token is not None:
         _active_stage_cv.reset(token)
     else:
@@ -86,13 +50,7 @@ def reset_active_stage(token: contextvars.Token | None) -> None:
 
 
 def get_active_stage() -> str | None:
-    """Return the active stage for this thread / task, or ``None``.
-
-    The contextvar takes precedence so asyncio tasks see the binding even
-    when running inside ``loop.run_in_executor`` (which copies context but
-    not thread-local). Thread-local is the fallback for plain
-    ``threading.Thread`` workers.
-    """
+    """Active stage for this thread / task, contextvar first."""
     stage = _active_stage_cv.get()
     if stage is not None:
         return stage
@@ -101,14 +59,7 @@ def get_active_stage() -> str | None:
 
 @dataclass(frozen=True)
 class RequestEvent:
-    """A single point-in-time profiling event for one request.
-
-    The shape is intentionally narrow:
-    ``request_id``/``stage``/``event_name``/``timestamp_ns`` are required, and
-    free-form metadata lives in ``metadata`` so callers can attach token counts,
-    chunk ids, audio duration, queue depth, error strings, etc. without
-    forcing every event to grow new top-level fields.
-    """
+    """A single point-in-time profiling event for one request."""
 
     request_id: str
     stage: str
@@ -123,17 +74,7 @@ class RequestEvent:
 
 
 class RequestEventRecorder:
-    """Process-local JSONL event sink.
-
-    Thread-safe append: each call serializes one JSON object on its own line.
-    Lifetimes are controlled by ``start(run_id, event_dir, stage)`` /
-    ``stop()`` so the recorder can be toggled live via the existing
-    profiler control plane (``ProfilerStartMessage`` / ``ProfilerStopMessage``).
-
-    The recorder is exposed as a module-level singleton (`get_recorder`) so
-    arbitrary callsites can emit without threading a handle through every
-    constructor.
-    """
+    """Process-local JSONL event sink. Toggled via profiler control plane."""
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
@@ -157,25 +98,14 @@ class RequestEventRecorder:
         return None if self._path is None else str(self._path)
 
     def start(self, run_id: str, event_dir: str, stage: str) -> str:
-        """Open (or join) the per-process JSONL file for this ``run_id``.
+        """Open (or join) the per-process JSONL file for ``run_id``.
 
-        Multiple stages can share one OS process (declarative topology,
-        co-located non-AR stages). When that happens each Stage will call
-        ``start()`` independently as it receives the profiler-start
-        broadcast. We keep ONE file per ``(run_id, pid)`` and let every
-        stage write into it — the per-event ``stage`` field makes the
-        owner unambiguous, and the views layer groups by ``request_id``
-        anyway. Only a different ``run_id`` (a brand-new profiling
-        session) triggers a rotation.
-
-        Returns the absolute path of the file the caller will write to.
+        Co-located stages share one file per ``(run_id, pid)``; only a
+        new ``run_id`` rotates. Returns the absolute path.
         """
         with self._lock:
             if self._fp is not None:
                 if self._run_id == run_id:
-                    # Same session — just register the additional stage so
-                    # the filename reflects the full set, and keep writing
-                    # to the existing file.
                     if stage not in self._stages:
                         self._stages.add(stage)
                     assert self._path is not None
@@ -190,11 +120,9 @@ class RequestEventRecorder:
 
             directory = Path(event_dir).expanduser().resolve()
             directory.mkdir(parents=True, exist_ok=True)
-            # Filename carries the FIRST stage to call start() in this
-            # process. Other stages in the same process append to this
-            # same file; their identity lives in each event's `stage`.
+            # Filename uses the first stage to join; per-event ``stage``
+            # disambiguates owners once others join.
             path = directory / f"events_{stage}_{self._pid}.jsonl"
-            # Append mode keeps history if the same run_id is reused.
             self._fp = path.open("a", buffering=1, encoding="utf-8")
             self._run_id = run_id
             self._stage = stage
@@ -210,11 +138,7 @@ class RequestEventRecorder:
             return str(path)
 
     def stop(self, *, run_id: str | None = None) -> str | None:
-        """Close the active file. Returns the path that was written, if any.
-
-        If ``run_id`` is provided, the call is ignored unless it matches the
-        active run — mirrors :class:`TorchProfiler`.
-        """
+        """Close the active file. ``run_id=None`` stops any active session."""
         with self._lock:
             if self._fp is None:
                 return None
@@ -259,28 +183,17 @@ class RequestEventRecorder:
         metadata: Mapping[str, Any] | None = None,
         timestamp_ns: int | None = None,
     ) -> None:
-        """Append a single event. Silent no-op when the recorder is inactive.
-
-        The recorder is intentionally tolerant: any unexpected error during
-        emission must NOT propagate to the caller — profiling must never
-        break serving. Errors are logged once per occurrence and counted in
-        ``self._dropped``.
-        """
+        """Append one event. No-op when inactive; errors are swallowed."""
         if self._fp is None:
             return
         ts = timestamp_ns if timestamp_ns is not None else time.time_ns()
-        # Capture file/run state under the lock so we can detect a concurrent
-        # stop() that closed the file out from under us.
         with self._lock:
             fp = self._fp
             if fp is None:
                 return
             if stage is None:
-                # Prefer the per-thread / per-task binding (Stage._run_scheduler
-                # sets it before invoking the scheduler). The process-global
-                # ``_stage`` is only used when nothing better is available,
-                # and is wrong in shared-process topologies — see module
-                # docstring.
+                # Prefer thread/task binding over the process-global
+                # ``_stage``, which is wrong in shared-process topologies.
                 stage = get_active_stage() or self._stage or "unknown"
             event = RequestEvent(
                 request_id=request_id,
@@ -296,8 +209,6 @@ class RequestEventRecorder:
                 fp.write("\n")
             except Exception:
                 self._dropped += 1
-                # Log only the first failure per recorder lifetime to avoid
-                # swamping the log file.
                 if self._dropped == 1:
                     logger.warning(
                         "RequestEventRecorder failed to write event %s for %s",
@@ -308,36 +219,22 @@ class RequestEventRecorder:
 
 
 def _json_default(obj: Any) -> Any:
-    """Fallback serializer for objects ``json.dumps`` doesn't know.
+    """Safe fallback for ``json.dumps``: summarise tensors, never materialise.
 
-    Profiler metadata must stay tiny — the profiler docs explicitly say
-    "large blobs stay out of metadata". Earlier versions of this function
-    called ``.tolist()`` on anything that had it, which materialised
-    arbitrarily large numpy arrays AND synchronised + copied GPU tensors
-    to CPU. Both can balloon a JSON line into megabytes and stall the hot
-    path.
-
-    Current behaviour:
-
-    - 0-D tensors / arrays (``shape == ()``) are scalars; return ``item()``.
-    - Higher-rank tensors / arrays return a SUMMARY dict
-      (``type``, ``shape``, ``dtype``, ``device``) — never the data.
-    - Everything else falls back to ``repr``.
+    Tensors / arrays return ``{__tensor_summary__, type, shape, dtype,
+    device}``; 0-D variants serialise as plain scalars; everything else
+    falls back to ``repr``.
     """
     shape = getattr(obj, "shape", None)
     dtype = getattr(obj, "dtype", None)
     if shape is not None and dtype is not None:
-        # 0-D tensor / array → behaves like a scalar.
-        # ``len(shape)`` works for ``torch.Size`` and ``numpy.ndarray.shape``
-        # (tuples). Some duck-typed objects expose a ``.shape`` that isn't
-        # sized — ``len()`` raises ``TypeError`` on those, and we fall
-        # through to the summary path instead of crashing the recorder.
         try:
             if len(shape) == 0 and hasattr(obj, "item"):
                 return obj.item()
         except TypeError:
+            # ``.shape`` without ``__len__`` — skip the 0-D fast path
+            # and fall through to the summary serializer below.
             pass
-        # Real tensor / array — refuse to materialise. Summary only.
         try:
             shape_list: Any = [int(d) for d in shape]
         except Exception:
@@ -369,11 +266,7 @@ def emit(
     metadata: Mapping[str, Any] | None = None,
     timestamp_ns: int | None = None,
 ) -> None:
-    """Convenience wrapper: ``emit(request_id=..., event_name=...)``.
-
-    Equivalent to ``get_recorder().emit(...)`` and is the form callers should
-    use at instrumentation sites.
-    """
+    """Module-level shortcut for ``get_recorder().emit(...)``."""
     _RECORDER.emit(
         request_id=request_id,
         stage=stage,

--- a/sglang_omni/profiler/event_recorder.py
+++ b/sglang_omni/profiler/event_recorder.py
@@ -13,6 +13,7 @@ without circular-import risk.
 
 from __future__ import annotations
 
+import contextvars
 import json
 import logging
 import os
@@ -23,6 +24,70 @@ from pathlib import Path
 from typing import Any, Mapping
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Active-stage attribution
+# ---------------------------------------------------------------------------
+#
+# When multiple stages live in the same OS process (the declarative topology
+# does this for co-located ``role="single"`` stages), the recorder keeps ONE
+# file per process and the per-event ``stage`` field is the source of truth.
+# Most callsites pass ``stage=self.name`` explicitly, but library code that
+# can't easily plumb the stage name down (preprocessors, encoder callables,
+# OmniScheduler internals) calls ``emit(stage=None)`` and expects the
+# recorder to fill it in.
+#
+# A process-global fallback (the recorder's ``_stage``) is wrong: in a shared
+# process it's whichever stage called ``start()`` first, so every event from
+# every co-located stage would get that one name.
+#
+# Instead we expose a per-thread / per-task active stage. Stage's scheduler
+# thread sets it before invoking ``scheduler.start()``; emits in that thread
+# (and in any ``asyncio.to_thread`` / ``loop.run_in_executor`` descendants
+# that copy the context) see the correct stage name. Explicit ``stage=`` on
+# emit always wins.
+
+_thread_active_stage = threading.local()
+_active_stage_cv: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "sglang_omni_active_stage", default=None
+)
+
+
+def set_active_stage(stage: str | None) -> contextvars.Token | None:
+    """Bind ``stage`` as the active stage for the current thread / task.
+
+    Returns a ``contextvars.Token`` that ``reset_active_stage`` can use to
+    restore the previous value, or ``None`` if no contextvar binding was
+    performed (e.g. when ``stage`` is ``None`` and clearing was requested).
+
+    Sets BOTH a ``threading.local`` slot (for plain-thread callsites that
+    don't propagate contextvars) AND the contextvar (for asyncio /
+    ``run_in_executor`` callsites that copy context).
+    """
+    _thread_active_stage.stage = stage
+    return _active_stage_cv.set(stage)
+
+
+def reset_active_stage(token: contextvars.Token | None) -> None:
+    """Reverse a prior :func:`set_active_stage` call."""
+    if token is not None:
+        _active_stage_cv.reset(token)
+    _thread_active_stage.stage = None
+
+
+def get_active_stage() -> str | None:
+    """Return the active stage for this thread / task, or ``None``.
+
+    The contextvar takes precedence so asyncio tasks see the binding even
+    when running inside ``loop.run_in_executor`` (which copies context but
+    not thread-local). Thread-local is the fallback for plain
+    ``threading.Thread`` workers.
+    """
+    stage = _active_stage_cv.get()
+    if stage is not None:
+        return stage
+    return getattr(_thread_active_stage, "stage", None)
 
 
 @dataclass(frozen=True)
@@ -201,9 +266,16 @@ class RequestEventRecorder:
             fp = self._fp
             if fp is None:
                 return
+            if stage is None:
+                # Prefer the per-thread / per-task binding (Stage._run_scheduler
+                # sets it before invoking the scheduler). The process-global
+                # ``_stage`` is only used when nothing better is available,
+                # and is wrong in shared-process topologies — see module
+                # docstring.
+                stage = get_active_stage() or self._stage or "unknown"
             event = RequestEvent(
                 request_id=request_id,
-                stage=stage if stage is not None else (self._stage or "unknown"),
+                stage=stage,
                 event_name=event_name,
                 timestamp_ns=ts,
                 run_id=self._run_id,
@@ -227,12 +299,44 @@ class RequestEventRecorder:
 
 
 def _json_default(obj: Any) -> Any:
-    # Conservative fallback so unknown metadata types never break the recorder.
-    if hasattr(obj, "tolist"):
+    """Fallback serializer for objects ``json.dumps`` doesn't know.
+
+    Profiler metadata must stay tiny — the profiler docs explicitly say
+    "large blobs stay out of metadata". Earlier versions of this function
+    called ``.tolist()`` on anything that had it, which materialised
+    arbitrarily large numpy arrays AND synchronised + copied GPU tensors
+    to CPU. Both can balloon a JSON line into megabytes and stall the hot
+    path.
+
+    Current behaviour:
+
+    - 0-D tensors / arrays (``shape == ()``) are scalars; return ``item()``.
+    - Higher-rank tensors / arrays return a SUMMARY dict
+      (``type``, ``shape``, ``dtype``, ``device``) — never the data.
+    - Everything else falls back to ``repr``.
+    """
+    shape = getattr(obj, "shape", None)
+    dtype = getattr(obj, "dtype", None)
+    if shape is not None and dtype is not None:
+        # 0-D tensor / array → behaves like a scalar.
         try:
-            return obj.tolist()
-        except Exception:  # pragma: no cover - last-resort path
+            if len(shape) == 0 and hasattr(obj, "item"):
+                return obj.item()
+        except TypeError:
             pass
+        # Real tensor / array — refuse to materialise. Summary only.
+        try:
+            shape_list: Any = [int(d) for d in shape]
+        except Exception:
+            shape_list = repr(shape)
+        device = getattr(obj, "device", None)
+        return {
+            "__tensor_summary__": True,
+            "type": type(obj).__name__,
+            "shape": shape_list,
+            "dtype": str(dtype),
+            "device": str(device) if device is not None else None,
+        }
     return repr(obj)
 
 

--- a/sglang_omni/profiler/event_recorder.py
+++ b/sglang_omni/profiler/event_recorder.py
@@ -70,9 +70,18 @@ def set_active_stage(stage: str | None) -> contextvars.Token | None:
 
 
 def reset_active_stage(token: contextvars.Token | None) -> None:
-    """Reverse a prior :func:`set_active_stage` call."""
+    """Reverse a prior :func:`set_active_stage` call.
+
+    With a ``token``, restores the previous contextvar value (the standard
+    ``ContextVar.reset`` contract). Without a token, clears the binding by
+    setting the contextvar back to ``None`` — this is the form fixtures
+    use to scrub leaked active-stage state between tests, so it must
+    actually clear the contextvar and not just the ``threading.local``.
+    """
     if token is not None:
         _active_stage_cv.reset(token)
+    else:
+        _active_stage_cv.set(None)
     _thread_active_stage.stage = None
 
 
@@ -319,6 +328,10 @@ def _json_default(obj: Any) -> Any:
     dtype = getattr(obj, "dtype", None)
     if shape is not None and dtype is not None:
         # 0-D tensor / array → behaves like a scalar.
+        # ``len(shape)`` works for ``torch.Size`` and ``numpy.ndarray.shape``
+        # (tuples). Some duck-typed objects expose a ``.shape`` that isn't
+        # sized — ``len()`` raises ``TypeError`` on those, and we fall
+        # through to the summary path instead of crashing the recorder.
         try:
             if len(shape) == 0 and hasattr(obj, "item"):
                 return obj.item()

--- a/sglang_omni/profiler/event_recorder.py
+++ b/sglang_omni/profiler/event_recorder.py
@@ -65,6 +65,7 @@ class RequestEventRecorder:
         self._lock = threading.Lock()
         self._run_id: str | None = None
         self._stage: str | None = None
+        self._stages: set[str] = set()
         self._path: Path | None = None
         self._fp: Any = None
         self._pid: int = os.getpid()
@@ -82,32 +83,48 @@ class RequestEventRecorder:
         return None if self._path is None else str(self._path)
 
     def start(self, run_id: str, event_dir: str, stage: str) -> str:
-        """Open a fresh per-process JSONL file for this ``run_id``/``stage``.
+        """Open (or join) the per-process JSONL file for this ``run_id``.
 
-        Returns the absolute path of the opened file.
+        Multiple stages can share one OS process (declarative topology,
+        co-located non-AR stages). When that happens each Stage will call
+        ``start()`` independently as it receives the profiler-start
+        broadcast. We keep ONE file per ``(run_id, pid)`` and let every
+        stage write into it — the per-event ``stage`` field makes the
+        owner unambiguous, and the views layer groups by ``request_id``
+        anyway. Only a different ``run_id`` (a brand-new profiling
+        session) triggers a rotation.
+
+        Returns the absolute path of the file the caller will write to.
         """
         with self._lock:
             if self._fp is not None:
-                if self._run_id == run_id and self._stage == stage:
+                if self._run_id == run_id:
+                    # Same session — just register the additional stage so
+                    # the filename reflects the full set, and keep writing
+                    # to the existing file.
+                    if stage not in self._stages:
+                        self._stages.add(stage)
                     assert self._path is not None
                     return str(self._path)
                 logger.warning(
-                    "RequestEventRecorder already active (run_id=%s, stage=%s); "
-                    "rotating to (run_id=%s, stage=%s)",
+                    "RequestEventRecorder already active (run_id=%s); "
+                    "rotating to run_id=%s",
                     self._run_id,
-                    self._stage,
                     run_id,
-                    stage,
                 )
                 self._close_unlocked()
 
             directory = Path(event_dir).expanduser().resolve()
             directory.mkdir(parents=True, exist_ok=True)
+            # Filename carries the FIRST stage to call start() in this
+            # process. Other stages in the same process append to this
+            # same file; their identity lives in each event's `stage`.
             path = directory / f"events_{stage}_{self._pid}.jsonl"
             # Append mode keeps history if the same run_id is reused.
             self._fp = path.open("a", buffering=1, encoding="utf-8")
             self._run_id = run_id
             self._stage = stage
+            self._stages = {stage}
             self._path = path
             self._dropped = 0
             logger.info(
@@ -154,6 +171,7 @@ class RequestEventRecorder:
         self._fp = None
         self._run_id = None
         self._stage = None
+        self._stages = set()
         self._path = None
 
     # ---- emit ----------------------------------------------------------

--- a/sglang_omni/profiler/profiler_control.py
+++ b/sglang_omni/profiler/profiler_control.py
@@ -44,19 +44,30 @@ class ProfilerControlClient:
         trace_path_template: str,
         config: dict[str, Any] | None = None,
         stages: list[str] | None = None,
+        event_dir: str | None = None,
+        enable_torch: bool = True,
     ) -> None:
         await self.start()
         assert self._socks is not None
         targets = stages or list(self._socks.keys())
         msg = ProfilerStartMessage(
-            run_id=run_id, trace_path_template=trace_path_template
+            run_id=run_id,
+            trace_path_template=trace_path_template,
+            event_dir=event_dir,
+            enable_torch=enable_torch,
         )
         for s in targets:
             sock = self._socks.get(s)
             if sock is None:
                 continue
             await sock.send(msg)
-        logger.info("Broadcast profiler_start run_id=%s to stages=%s", run_id, targets)
+        logger.info(
+            "Broadcast profiler_start run_id=%s event_dir=%s torch=%s to stages=%s",
+            run_id,
+            event_dir,
+            enable_torch,
+            targets,
+        )
 
     async def broadcast_stop(
         self,

--- a/sglang_omni/profiler/profiler_control.py
+++ b/sglang_omni/profiler/profiler_control.py
@@ -74,12 +74,7 @@ class ProfilerControlClient:
         run_id: str | None = None,
         stages: list[str] | None = None,
     ) -> None:
-        """Broadcast a stop message to all (or selected) stages.
-
-        ``run_id=None`` is a wildcard: each stage stops whatever profiler
-        session it currently has active. Use this when the HTTP caller
-        didn't specify a run id.
-        """
+        """Broadcast stop. ``run_id=None`` is a wildcard."""
         await self.start()
         assert self._socks is not None
         targets = stages or list(self._socks.keys())

--- a/sglang_omni/profiler/profiler_control.py
+++ b/sglang_omni/profiler/profiler_control.py
@@ -71,9 +71,15 @@ class ProfilerControlClient:
 
     async def broadcast_stop(
         self,
-        run_id: str,
+        run_id: str | None = None,
         stages: list[str] | None = None,
     ) -> None:
+        """Broadcast a stop message to all (or selected) stages.
+
+        ``run_id=None`` is a wildcard: each stage stops whatever profiler
+        session it currently has active. Use this when the HTTP caller
+        didn't specify a run id.
+        """
         await self.start()
         assert self._socks is not None
         targets = stages or list(self._socks.keys())

--- a/sglang_omni/profiler/torch_profiler.py
+++ b/sglang_omni/profiler/torch_profiler.py
@@ -105,20 +105,9 @@ class TorchProfiler(ProfilerBase):
                 except Exception as e:
                     logger.warning(f"[Rank {rank}] Failed to export trace: {e}")
 
-            # 4. Initialize profiler. We deliberately omit ``schedule`` so
-            # the profile records everything between ``start()`` and
-            # ``stop()``. With a schedule, ``on_trace_ready`` only fires
-            # after the active phase ends, which requires explicit
-            # ``step()`` calls — none of the AR loops drive that, so a
-            # scheduled profile silently drops its trace on stop. The
-            # default (no schedule) treats start/stop as one continuous
-            # active window and exports on stop.
-            #
-            # ``record_shapes`` / ``profile_memory`` / ``with_stack`` /
-            # ``with_flops`` are off by default because they balloon the
-            # trace into the multi-GB range over a typical benchmark
-            # window (filled host disks during a Qwen3-Omni MMMU run on
-            # H200). Opt them in via env vars for a deeper inspection.
+            # No ``schedule``: record continuously between start/stop.
+            # Expensive flags are env-var opt-in (default off keeps the
+            # trace tens of MB; all on can hit multi-GB).
             cls._profiler = profile(
                 activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
                 on_trace_ready=trace_handler,
@@ -170,10 +159,8 @@ class TorchProfiler(ProfilerBase):
             except Exception as e:
                 logger.warning("[Rank %s] Profiler stop failed: %s", rank, e)
 
-            # Export the trace directly. Without a `schedule`, the
-            # ``on_trace_ready`` callback isn't invoked automatically on
-            # stop, so we do the export here. ``export_chrome_trace``
-            # is safe to call after ``stop()``.
+            # No schedule → on_trace_ready isn't fired on stop, so
+            # export here.
             try:
                 os.makedirs(os.path.dirname(json_path), exist_ok=True)
                 profiler.export_chrome_trace(json_path)

--- a/sglang_omni/profiler/torch_profiler.py
+++ b/sglang_omni/profiler/torch_profiler.py
@@ -113,13 +113,21 @@ class TorchProfiler(ProfilerBase):
             # scheduled profile silently drops its trace on stop. The
             # default (no schedule) treats start/stop as one continuous
             # active window and exports on stop.
+            #
+            # ``record_shapes`` / ``profile_memory`` / ``with_stack`` /
+            # ``with_flops`` are off by default because they balloon the
+            # trace into the multi-GB range over a typical benchmark
+            # window (filled host disks during a Qwen3-Omni MMMU run on
+            # H200). Opt them in via env vars for a deeper inspection.
             cls._profiler = profile(
                 activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
                 on_trace_ready=trace_handler,
-                record_shapes=True,
-                profile_memory=True,
-                with_stack=True,
-                with_flops=True,
+                record_shapes=os.environ.get("SGLANG_TORCH_PROFILER_RECORD_SHAPES")
+                == "1",
+                profile_memory=os.environ.get("SGLANG_TORCH_PROFILER_PROFILE_MEMORY")
+                == "1",
+                with_stack=os.environ.get("SGLANG_TORCH_PROFILER_WITH_STACK") == "1",
+                with_flops=os.environ.get("SGLANG_TORCH_PROFILER_WITH_FLOPS") == "1",
             )
 
             # 5. Start profiling

--- a/sglang_omni/profiler/torch_profiler.py
+++ b/sglang_omni/profiler/torch_profiler.py
@@ -9,7 +9,6 @@ import subprocess
 import threading
 from contextlib import nullcontext
 
-import torch
 from torch.profiler import ProfilerActivity, profile
 
 from .base_profiler import ProfilerBase
@@ -106,14 +105,16 @@ class TorchProfiler(ProfilerBase):
                 except Exception as e:
                     logger.warning(f"[Rank {rank}] Failed to export trace: {e}")
 
-            # 4. Initialize profiler with long active period
+            # 4. Initialize profiler. We deliberately omit ``schedule`` so
+            # the profile records everything between ``start()`` and
+            # ``stop()``. With a schedule, ``on_trace_ready`` only fires
+            # after the active phase ends, which requires explicit
+            # ``step()`` calls — none of the AR loops drive that, so a
+            # scheduled profile silently drops its trace on stop. The
+            # default (no schedule) treats start/stop as one continuous
+            # active window and exports on stop.
             cls._profiler = profile(
                 activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
-                schedule=torch.profiler.schedule(
-                    wait=0,
-                    warmup=0,
-                    active=100000,  # long capture window
-                ),
                 on_trace_ready=trace_handler,
                 record_shapes=True,
                 profile_memory=True,
@@ -152,12 +153,38 @@ class TorchProfiler(ProfilerBase):
                 return None
 
             base_path = f"{cls._trace_template}_rank{rank}"
-            gz_path = f"{base_path}.trace.json.gz"
+            json_path = f"{base_path}.trace.json"
+            gz_path = f"{json_path}.gz"
 
+            profiler = cls._profiler
             try:
-                cls._profiler.stop()
+                profiler.stop()
             except Exception as e:
                 logger.warning("[Rank %s] Profiler stop failed: %s", rank, e)
+
+            # Export the trace directly. Without a `schedule`, the
+            # ``on_trace_ready`` callback isn't invoked automatically on
+            # stop, so we do the export here. ``export_chrome_trace``
+            # is safe to call after ``stop()``.
+            try:
+                os.makedirs(os.path.dirname(json_path), exist_ok=True)
+                profiler.export_chrome_trace(json_path)
+                logger.info("[Rank %s] Trace exported to %s", rank, json_path)
+                try:
+                    subprocess.Popen(["gzip", "-f", json_path])
+                    logger.info(
+                        "[Rank %s] Triggered background compression for %s",
+                        rank,
+                        json_path,
+                    )
+                except Exception as compress_err:
+                    logger.warning(
+                        "[Rank %s] Background gzip failed: %s",
+                        rank,
+                        compress_err,
+                    )
+            except Exception as e:
+                logger.warning("[Rank %s] Failed to export trace: %s", rank, e)
 
             cls._profiler = None
             cls._active_run_id = None

--- a/sglang_omni/profiler/views.py
+++ b/sglang_omni/profiler/views.py
@@ -147,12 +147,14 @@ def reconstruct_timelines(
 # multiple stages.
 _STAGE_INTERVAL_EVENTS = (
     ("stage_input_received", "stage_complete"),
-    ("scheduler_dispatch_start", "scheduler_dispatch_end"),
     ("encoder_start", "encoder_end"),
     ("preprocess_start", "preprocess_end"),
-    ("talker_request_build_start", "talker_request_build_end"),
-    ("thinker_prefill_start", "thinker_first_token"),
-    ("talker_prefill_start", "first_code_chunk"),
+    ("scheduler_request_build_start", "scheduler_request_build_end"),
+    # prefill_start → first stream chunk sent gives us thinker/talker
+    # TTFT and TTFCC (time-to-first-code-chunk) automatically because
+    # both events live in the same per-rank scheduler process.
+    ("scheduler_prefill_start", "stage_first_stream_chunk_sent"),
+    ("scheduler_prefill_start", "scheduler_first_emit"),
 )
 
 

--- a/sglang_omni/profiler/views.py
+++ b/sglang_omni/profiler/views.py
@@ -1,21 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Request-level profiler views.
+"""Profiler views: per-request timeline, stage breakdown, hop breakdown.
 
-Reads JSONL event files emitted by :mod:`sglang_omni.profiler.event_recorder`
-and derives the three standard reports specified by
-https://github.com/sgl-project/sglang-omni/issues/501:
-
-1. End-to-end latency timeline (per request)
-2. Stage breakdown (aggregate time per stage)
-3. Hop breakdown (aggregate time per stage-to-stage hop)
-
-The merge logic accepts:
-- a single JSONL file
-- a directory containing ``events_*_<pid>.jsonl`` files
-- a list of either of the above
-
-It is intentionally framework-free so reports can be generated on a laptop
-from a downloaded run directory.
+Reads JSONL events emitted by :mod:`sglang_omni.profiler.event_recorder`.
+Input may be a single file, a directory of ``events_*_<pid>.jsonl``, or a
+list of either. Framework-free so reports can be regenerated locally.
 """
 
 from __future__ import annotations
@@ -142,17 +130,14 @@ def reconstruct_timelines(
 # ---------------------------------------------------------------------------
 
 
-# Stage-level event pairs that frame an interval. The first event opens the
-# interval, the second closes it. Both are stage-local — they cannot span
-# multiple stages.
+# (opener, closer) pairs framing a stage-local interval. Opener can
+# appear in multiple pairs (e.g. prefill_start closes against both
+# first_emit and first_stream_chunk_sent → thinker TTFT / talker TTFCC).
 _STAGE_INTERVAL_EVENTS = (
     ("stage_input_received", "stage_complete"),
     ("encoder_start", "encoder_end"),
     ("preprocess_start", "preprocess_end"),
     ("scheduler_request_build_start", "scheduler_request_build_end"),
-    # prefill_start → first stream chunk sent gives us thinker/talker
-    # TTFT and TTFCC (time-to-first-code-chunk) automatically because
-    # both events live in the same per-rank scheduler process.
     ("scheduler_prefill_start", "stage_first_stream_chunk_sent"),
     ("scheduler_prefill_start", "scheduler_first_emit"),
 )
@@ -218,19 +203,14 @@ def compute_stage_intervals(
     source: str | Path | Iterable[str | Path] | None = None,
     interval_events: tuple[tuple[str, str], ...] = _STAGE_INTERVAL_EVENTS,
 ) -> list[StageInterval]:
-    """Pair open/close events into (stage, request_id)-scoped intervals.
-
-    The same opener can participate in multiple pairs (e.g.,
-    ``scheduler_prefill_start`` closes against both ``scheduler_first_emit``
-    *and* ``stage_first_stream_chunk_sent``). Each (opener, closer) pair owns
-    its own pending stack so a close event for pair A does not consume the
-    opener of pair B.
-    """
+    """Pair open/close events into (stage, request_id)-scoped intervals."""
     if timelines is None:
         if source is None:
             raise ValueError("compute_stage_intervals requires timelines or source")
         timelines = reconstruct_timelines(source)
 
+    # Per-pair lookup: one opener event seeds every pair it's in; each
+    # closer consumes only its own pair's stack.
     opens_to_pairs: dict[str, list[tuple[str, str]]] = defaultdict(list)
     closes_to_pairs: dict[str, list[tuple[str, str]]] = defaultdict(list)
     for opener, closer in interval_events:
@@ -239,17 +219,12 @@ def compute_stage_intervals(
 
     out: list[StageInterval] = []
     for rid, tl in timelines.items():
-        # Pending stack per (stage, opener, closer). One opener event seeds
-        # every pair it's part of; one closer event consumes only its own
-        # pair's stack, leaving sibling pairs unaffected.
         pending: dict[tuple[str, str, str], list[int]] = defaultdict(list)
         for ev in tl.events:
             name = ev.get("event_name")
             stage = ev.get("stage", "unknown")
             ts = int(ev.get("timestamp_ns", 0))
-            # An event may be both opener (for one pair) and closer (for
-            # another), e.g. in chained intervals (X, Y), (Y, Z) — handle
-            # both legs.
+            # An event may be both opener and closer (chained intervals).
             if name in opens_to_pairs:
                 for opener, closer in opens_to_pairs[name]:
                     pending[(stage, opener, closer)].append(ts)

--- a/sglang_omni/profiler/views.py
+++ b/sglang_omni/profiler/views.py
@@ -218,40 +218,57 @@ def compute_stage_intervals(
     source: str | Path | Iterable[str | Path] | None = None,
     interval_events: tuple[tuple[str, str], ...] = _STAGE_INTERVAL_EVENTS,
 ) -> list[StageInterval]:
-    """Pair open/close events into (stage, request_id)-scoped intervals."""
+    """Pair open/close events into (stage, request_id)-scoped intervals.
+
+    The same opener can participate in multiple pairs (e.g.,
+    ``scheduler_prefill_start`` closes against both ``scheduler_first_emit``
+    *and* ``stage_first_stream_chunk_sent``). Each (opener, closer) pair owns
+    its own pending stack so a close event for pair A does not consume the
+    opener of pair B.
+    """
     if timelines is None:
         if source is None:
             raise ValueError("compute_stage_intervals requires timelines or source")
         timelines = reconstruct_timelines(source)
-    opens_by_name = {open_ev: close_ev for open_ev, close_ev in interval_events}
-    close_by_name = {close_ev: open_ev for open_ev, close_ev in interval_events}
+
+    opens_to_pairs: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    closes_to_pairs: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    for opener, closer in interval_events:
+        opens_to_pairs[opener].append((opener, closer))
+        closes_to_pairs[closer].append((opener, closer))
 
     out: list[StageInterval] = []
     for rid, tl in timelines.items():
-        # Per-stage stack of pending open events keyed by event_name.
-        pending: dict[tuple[str, str], list[int]] = defaultdict(list)
+        # Pending stack per (stage, opener, closer). One opener event seeds
+        # every pair it's part of; one closer event consumes only its own
+        # pair's stack, leaving sibling pairs unaffected.
+        pending: dict[tuple[str, str, str], list[int]] = defaultdict(list)
         for ev in tl.events:
             name = ev.get("event_name")
             stage = ev.get("stage", "unknown")
             ts = int(ev.get("timestamp_ns", 0))
-            if name in opens_by_name:
-                pending[(stage, name)].append(ts)
-            elif name in close_by_name:
-                open_name = close_by_name[name]
-                stack = pending.get((stage, open_name))
-                if not stack:
-                    continue
-                open_ns = stack.pop(0)
-                out.append(
-                    StageInterval(
-                        request_id=rid,
-                        stage=stage,
-                        open_event=open_name,
-                        close_event=name,
-                        open_ns=open_ns,
-                        close_ns=ts,
+            # An event may be both opener (for one pair) and closer (for
+            # another), e.g. in chained intervals (X, Y), (Y, Z) — handle
+            # both legs.
+            if name in opens_to_pairs:
+                for opener, closer in opens_to_pairs[name]:
+                    pending[(stage, opener, closer)].append(ts)
+            if name in closes_to_pairs:
+                for opener, closer in closes_to_pairs[name]:
+                    stack = pending.get((stage, opener, closer))
+                    if not stack:
+                        continue
+                    open_ns = stack.pop(0)
+                    out.append(
+                        StageInterval(
+                            request_id=rid,
+                            stage=stage,
+                            open_event=opener,
+                            close_event=closer,
+                            open_ns=open_ns,
+                            close_ns=ts,
+                        )
                     )
-                )
     return out
 
 

--- a/sglang_omni/profiler/views.py
+++ b/sglang_omni/profiler/views.py
@@ -1,0 +1,417 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Request-level profiler views.
+
+Reads JSONL event files emitted by :mod:`sglang_omni.profiler.event_recorder`
+and derives the three standard reports specified by
+https://github.com/sgl-project/sglang-omni/issues/501:
+
+1. End-to-end latency timeline (per request)
+2. Stage breakdown (aggregate time per stage)
+3. Hop breakdown (aggregate time per stage-to-stage hop)
+
+The merge logic accepts:
+- a single JSONL file
+- a directory containing ``events_*_<pid>.jsonl`` files
+- a list of either of the above
+
+It is intentionally framework-free so reports can be generated on a laptop
+from a downloaded run directory.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Event loading
+# ---------------------------------------------------------------------------
+
+
+def iter_events(source: str | Path | Iterable[str | Path]) -> Iterator[dict[str, Any]]:
+    """Yield every JSON event from a file, directory, or list of either."""
+    paths: list[Path] = []
+    if isinstance(source, (str, Path)):
+        sources: list[str | Path] = [source]
+    else:
+        sources = list(source)
+    for raw in sources:
+        p = Path(raw).expanduser()
+        if p.is_dir():
+            paths.extend(sorted(p.glob("events_*.jsonl")))
+        elif p.is_file():
+            paths.append(p)
+        else:
+            logger.warning("iter_events: skipping non-existent path %s", p)
+    for path in paths:
+        with path.open("r", encoding="utf-8") as fp:
+            for line_no, line in enumerate(fp, 1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "iter_events: skipping malformed line %d in %s",
+                        line_no,
+                        path,
+                    )
+
+
+def load_events(source: str | Path | Iterable[str | Path]) -> list[dict[str, Any]]:
+    """Return all events sorted by ``timestamp_ns`` (stable)."""
+    events = list(iter_events(source))
+    events.sort(key=lambda e: e.get("timestamp_ns", 0))
+    return events
+
+
+# ---------------------------------------------------------------------------
+# View 1: per-request timeline
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RequestTimeline:
+    """All events for a single request, sorted by time."""
+
+    request_id: str
+    events: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def t0_ns(self) -> int | None:
+        if not self.events:
+            return None
+        return self.events[0]["timestamp_ns"]
+
+    @property
+    def t_end_ns(self) -> int | None:
+        if not self.events:
+            return None
+        return self.events[-1]["timestamp_ns"]
+
+    @property
+    def total_ms(self) -> float:
+        if not self.events:
+            return 0.0
+        t0 = self.t0_ns
+        t1 = self.t_end_ns
+        assert t0 is not None and t1 is not None
+        return (t1 - t0) / 1e6
+
+    def to_relative(self) -> list[dict[str, Any]]:
+        """Return events with an added ``t_rel_ms`` field anchored at t0."""
+        if not self.events:
+            return []
+        t0 = self.t0_ns
+        assert t0 is not None
+        result = []
+        for ev in self.events:
+            out = dict(ev)
+            out["t_rel_ms"] = (ev["timestamp_ns"] - t0) / 1e6
+            result.append(out)
+        return result
+
+
+def reconstruct_timelines(
+    source: str | Path | Iterable[str | Path],
+) -> dict[str, RequestTimeline]:
+    """Group every event by ``request_id`` into a per-request timeline."""
+    events = load_events(source)
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for ev in events:
+        rid = ev.get("request_id")
+        if not rid:
+            continue
+        grouped[rid].append(ev)
+    return {
+        rid: RequestTimeline(request_id=rid, events=evts)
+        for rid, evts in grouped.items()
+    }
+
+
+# ---------------------------------------------------------------------------
+# View 2: stage breakdown
+# ---------------------------------------------------------------------------
+
+
+# Stage-level event pairs that frame an interval. The first event opens the
+# interval, the second closes it. Both are stage-local — they cannot span
+# multiple stages.
+_STAGE_INTERVAL_EVENTS = (
+    ("stage_input_received", "stage_complete"),
+    ("scheduler_dispatch_start", "scheduler_dispatch_end"),
+    ("encoder_start", "encoder_end"),
+    ("preprocess_start", "preprocess_end"),
+    ("talker_request_build_start", "talker_request_build_end"),
+    ("thinker_prefill_start", "thinker_first_token"),
+    ("talker_prefill_start", "first_code_chunk"),
+)
+
+
+@dataclass
+class StageInterval:
+    """One occurrence of (open_event, close_event) inside a stage."""
+
+    request_id: str
+    stage: str
+    open_event: str
+    close_event: str
+    open_ns: int
+    close_ns: int
+
+    @property
+    def duration_ms(self) -> float:
+        return (self.close_ns - self.open_ns) / 1e6
+
+
+@dataclass
+class StageBreakdownRow:
+    stage: str
+    interval_name: str
+    count: int
+    total_ms: float
+    avg_ms: float
+    p50_ms: float
+    p95_ms: float
+    max_ms: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "stage": self.stage,
+            "interval": self.interval_name,
+            "count": self.count,
+            "total_ms": round(self.total_ms, 3),
+            "avg_ms": round(self.avg_ms, 3),
+            "p50_ms": round(self.p50_ms, 3),
+            "p95_ms": round(self.p95_ms, 3),
+            "max_ms": round(self.max_ms, 3),
+        }
+
+
+def _percentile(values: list[float], q: float) -> float:
+    """Linear-interpolation percentile. q in [0, 1]. ``values`` is sorted."""
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    k = (len(values) - 1) * q
+    f = int(k)
+    c = min(f + 1, len(values) - 1)
+    if f == c:
+        return values[f]
+    return values[f] + (values[c] - values[f]) * (k - f)
+
+
+def compute_stage_intervals(
+    timelines: dict[str, RequestTimeline] | None = None,
+    *,
+    source: str | Path | Iterable[str | Path] | None = None,
+    interval_events: tuple[tuple[str, str], ...] = _STAGE_INTERVAL_EVENTS,
+) -> list[StageInterval]:
+    """Pair open/close events into (stage, request_id)-scoped intervals."""
+    if timelines is None:
+        if source is None:
+            raise ValueError("compute_stage_intervals requires timelines or source")
+        timelines = reconstruct_timelines(source)
+    opens_by_name = {open_ev: close_ev for open_ev, close_ev in interval_events}
+    close_by_name = {close_ev: open_ev for open_ev, close_ev in interval_events}
+
+    out: list[StageInterval] = []
+    for rid, tl in timelines.items():
+        # Per-stage stack of pending open events keyed by event_name.
+        pending: dict[tuple[str, str], list[int]] = defaultdict(list)
+        for ev in tl.events:
+            name = ev.get("event_name")
+            stage = ev.get("stage", "unknown")
+            ts = int(ev.get("timestamp_ns", 0))
+            if name in opens_by_name:
+                pending[(stage, name)].append(ts)
+            elif name in close_by_name:
+                open_name = close_by_name[name]
+                stack = pending.get((stage, open_name))
+                if not stack:
+                    continue
+                open_ns = stack.pop(0)
+                out.append(
+                    StageInterval(
+                        request_id=rid,
+                        stage=stage,
+                        open_event=open_name,
+                        close_event=name,
+                        open_ns=open_ns,
+                        close_ns=ts,
+                    )
+                )
+    return out
+
+
+def stage_breakdown(
+    timelines: dict[str, RequestTimeline] | None = None,
+    *,
+    source: str | Path | Iterable[str | Path] | None = None,
+) -> list[StageBreakdownRow]:
+    """Aggregate interval durations by (stage, open/close pair)."""
+    intervals = compute_stage_intervals(timelines, source=source)
+    bucket: dict[tuple[str, str, str], list[float]] = defaultdict(list)
+    for it in intervals:
+        key = (it.stage, it.open_event, it.close_event)
+        bucket[key].append(it.duration_ms)
+    rows: list[StageBreakdownRow] = []
+    for (stage, open_ev, close_ev), durations in bucket.items():
+        durations.sort()
+        rows.append(
+            StageBreakdownRow(
+                stage=stage,
+                interval_name=f"{open_ev}->{close_ev}",
+                count=len(durations),
+                total_ms=sum(durations),
+                avg_ms=sum(durations) / len(durations),
+                p50_ms=_percentile(durations, 0.50),
+                p95_ms=_percentile(durations, 0.95),
+                max_ms=durations[-1],
+            )
+        )
+    rows.sort(key=lambda r: (-r.total_ms, r.stage))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# View 3: hop breakdown (stage_a -> stage_b)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HopBreakdownRow:
+    src_stage: str
+    dst_stage: str
+    kind: str  # "payload" or "stream_chunk"
+    count: int
+    total_ms: float
+    avg_ms: float
+    p50_ms: float
+    p95_ms: float
+    max_ms: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "src": self.src_stage,
+            "dst": self.dst_stage,
+            "kind": self.kind,
+            "count": self.count,
+            "total_ms": round(self.total_ms, 3),
+            "avg_ms": round(self.avg_ms, 3),
+            "p50_ms": round(self.p50_ms, 3),
+            "p95_ms": round(self.p95_ms, 3),
+            "max_ms": round(self.max_ms, 3),
+        }
+
+
+def hop_breakdown(
+    timelines: dict[str, RequestTimeline] | None = None,
+    *,
+    source: str | Path | Iterable[str | Path] | None = None,
+) -> list[HopBreakdownRow]:
+    """Pair `stage_hop_sent` / `stage_input_received` and stream-chunk variants.
+
+    Matching is keyed by ``(request_id, src_stage, dst_stage, chunk_id?)``.
+    ``chunk_id`` distinguishes stream-chunk hops; payload hops have none.
+    """
+    if timelines is None:
+        if source is None:
+            raise ValueError("hop_breakdown requires timelines or source")
+        timelines = reconstruct_timelines(source)
+
+    # Pending sends keyed by (rid, src, dst, kind, chunk_id_or_None) -> list of ts.
+    pending: dict[tuple[str, str, str, str, int | None], list[int]] = defaultdict(list)
+    durations: dict[tuple[str, str, str], list[float]] = defaultdict(list)
+
+    for rid, tl in timelines.items():
+        for ev in tl.events:
+            name = ev.get("event_name")
+            md = ev.get("metadata") or {}
+            ts = int(ev.get("timestamp_ns", 0))
+            stage = ev.get("stage", "unknown")
+            if name == "stage_hop_sent":
+                dst = md.get("to_stage", "?")
+                pending[(rid, stage, dst, "payload", None)].append(ts)
+            elif name == "stage_stream_chunk_sent":
+                dst = md.get("to_stage", "?")
+                chunk_id = md.get("chunk_id")
+                pending[(rid, stage, dst, "stream_chunk", chunk_id)].append(ts)
+            elif name == "stage_input_received":
+                src = md.get("from_stage")
+                if not src or src == "coordinator":
+                    continue
+                key = (rid, src, stage, "payload", None)
+                stack = pending.get(key)
+                if stack:
+                    open_ns = stack.pop(0)
+                    durations[(src, stage, "payload")].append((ts - open_ns) / 1e6)
+            elif name == "stage_stream_chunk_received":
+                src = md.get("from_stage")
+                chunk_id = md.get("chunk_id")
+                if not src:
+                    continue
+                key = (rid, src, stage, "stream_chunk", chunk_id)
+                stack = pending.get(key)
+                if stack:
+                    open_ns = stack.pop(0)
+                    durations[(src, stage, "stream_chunk")].append((ts - open_ns) / 1e6)
+
+    rows: list[HopBreakdownRow] = []
+    for (src, dst, kind), values in durations.items():
+        values.sort()
+        rows.append(
+            HopBreakdownRow(
+                src_stage=src,
+                dst_stage=dst,
+                kind=kind,
+                count=len(values),
+                total_ms=sum(values),
+                avg_ms=sum(values) / len(values),
+                p50_ms=_percentile(values, 0.50),
+                p95_ms=_percentile(values, 0.95),
+                max_ms=values[-1],
+            )
+        )
+    rows.sort(key=lambda r: (-r.total_ms, r.src_stage, r.dst_stage))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Report helpers
+# ---------------------------------------------------------------------------
+
+
+def build_report(source: str | Path | Iterable[str | Path]) -> dict[str, Any]:
+    """Return all three views as a single dict for JSON serialization."""
+    timelines = reconstruct_timelines(source)
+    return {
+        "timelines": {rid: tl.to_relative() for rid, tl in timelines.items()},
+        "stage_breakdown": [row.to_dict() for row in stage_breakdown(timelines)],
+        "hop_breakdown": [row.to_dict() for row in hop_breakdown(timelines)],
+        "request_count": len(timelines),
+    }
+
+
+def format_table(rows: list[dict[str, Any]], columns: list[str]) -> str:
+    """Pretty-print a list of dicts as a fixed-width table."""
+    if not rows:
+        return "(empty)\n"
+    widths = {
+        c: max(len(c), max(len(str(r.get(c, ""))) for r in rows)) for c in columns
+    }
+    header = " | ".join(c.ljust(widths[c]) for c in columns)
+    sep = "-+-".join("-" * widths[c] for c in columns)
+    body = "\n".join(
+        " | ".join(str(r.get(c, "")).ljust(widths[c]) for c in columns) for r in rows
+    )
+    return f"{header}\n{sep}\n{body}\n"

--- a/sglang_omni/proto/messages.py
+++ b/sglang_omni/proto/messages.py
@@ -179,9 +179,10 @@ class StreamMessage:
     stage_id: int | None = None
     stage_name: str | None = None
     modality: str | None = None
+    chunk_id: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d = {
             "type": "stream",
             "request_id": self.request_id,
             "from_stage": self.from_stage,
@@ -190,6 +191,9 @@ class StreamMessage:
             "stage_name": self.stage_name,
             "modality": self.modality,
         }
+        if self.chunk_id is not None:
+            d["chunk_id"] = self.chunk_id
+        return d
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "StreamMessage":
@@ -200,6 +204,7 @@ class StreamMessage:
             stage_id=d.get("stage_id"),
             stage_name=d.get("stage_name"),
             modality=d.get("modality"),
+            chunk_id=d.get("chunk_id"),
         )
 
 

--- a/sglang_omni/proto/messages.py
+++ b/sglang_omni/proto/messages.py
@@ -266,16 +266,23 @@ class ProfilerStartMessage:
 
 @dataclass
 class ProfilerStopMessage:
-    """Profiler stop for an entry."""
+    """Profiler stop for an entry.
 
-    run_id: str
+    ``run_id`` is optional. When ``None``, the receiving stage stops
+    whatever profiler session is currently active (used when a caller
+    invokes ``/stop_profile`` or ``/stop_request_profile`` without
+    specifying which session). When set, the stage only stops if its
+    active run matches.
+    """
+
+    run_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {"type": "profiler_stop", "run_id": self.run_id}
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "ProfilerStopMessage":
-        return cls(run_id=d["run_id"])
+        return cls(run_id=d.get("run_id"))
 
 
 def parse_message(

--- a/sglang_omni/proto/messages.py
+++ b/sglang_omni/proto/messages.py
@@ -242,12 +242,16 @@ class ProfilerStartMessage:
 
     run_id: str
     trace_path_template: str  # e.g. "/tmp/profiles/{run_id}/{stage}/trace"
+    event_dir: str | None = None  # Per-stage JSONL event sink dir for request profiling
+    enable_torch: bool = True  # When False, only request-level events are captured
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "type": "profiler_start",
             "run_id": self.run_id,
             "trace_path_template": self.trace_path_template,
+            "event_dir": self.event_dir,
+            "enable_torch": self.enable_torch,
         }
 
     @classmethod
@@ -255,6 +259,8 @@ class ProfilerStartMessage:
         return cls(
             run_id=d["run_id"],
             trace_path_template=d["trace_path_template"],
+            event_dir=d.get("event_dir"),
+            enable_torch=bool(d.get("enable_torch", True)),
         )
 
 

--- a/sglang_omni/proto/messages.py
+++ b/sglang_omni/proto/messages.py
@@ -266,14 +266,7 @@ class ProfilerStartMessage:
 
 @dataclass
 class ProfilerStopMessage:
-    """Profiler stop for an entry.
-
-    ``run_id`` is optional. When ``None``, the receiving stage stops
-    whatever profiler session is currently active (used when a caller
-    invokes ``/stop_profile`` or ``/stop_request_profile`` without
-    specifying which session). When set, the stage only stops if its
-    active run matches.
-    """
+    """Profiler stop. ``run_id=None`` is a wildcard (stop active session)."""
 
     run_id: str | None = None
 

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -301,6 +301,7 @@ class OmniScheduler:
         self._pending_stream_done: set[str] = set()
         self._deferred_request_payloads: dict[str, Any] = {}
         self._first_emit_done: set[str] = set()
+        self._prefill_start_done: set[str] = set()
 
     def _init_upstream_compat_flags(self, server_args: Any) -> None:
         self.enable_hisparse = bool(getattr(server_args, "enable_hisparse", False))
@@ -504,7 +505,7 @@ class OmniScheduler:
             _emit_event(
                 request_id=req_id,
                 stage=None,
-                event_name="scheduler_prefill_start",
+                event_name="scheduler_queue_enter",
             )
             self.waiting_queue.append(req)
 
@@ -588,6 +589,7 @@ class OmniScheduler:
         ``ModelRunnerOutput``.  The upstream ``process_batch_result`` expects
         a ``GenerationBatchResult``.  We bridge the two formats here.
         """
+        self._emit_prefill_start_for_batch(batch)
         if self._model_runner is not None:
             from sglang.srt.managers.scheduler import GenerationBatchResult
 
@@ -651,6 +653,24 @@ class OmniScheduler:
                 )
             self.abort(req.rid)
 
+    def _emit_prefill_start_for_batch(self, batch: Any) -> None:
+        """Emit once when a request's first executable batch is selected."""
+        metadata = {}
+        for attr in ("is_prefill_only", "is_extend_in_batch"):
+            if hasattr(batch, attr):
+                metadata[attr] = bool(getattr(batch, attr))
+        for req in getattr(batch, "reqs", []) or []:
+            rid = req.rid
+            if rid in self._prefill_start_done:
+                continue
+            self._prefill_start_done.add(rid)
+            _emit_event(
+                request_id=rid,
+                stage=None,
+                event_name="scheduler_prefill_start",
+                metadata=metadata,
+            )
+
     def stream_output(self, reqs, return_logprob=False, skip_req=None):
         """Intercept finished requests and emit to outbox.
 
@@ -681,6 +701,7 @@ class OmniScheduler:
             data.decode_input_embeds = None
 
             self._first_emit_done.discard(rid)
+            self._prefill_start_done.discard(rid)
             self.outbox.put(
                 OutgoingMessage(
                     request_id=rid,
@@ -733,6 +754,7 @@ class OmniScheduler:
         self._pending_stream_done.discard(request_id)
         self._deferred_request_payloads.pop(request_id, None)
         self._first_emit_done.discard(request_id)
+        self._prefill_start_done.discard(request_id)
         self.waiting_queue = [
             req for req in self.waiting_queue if req.rid != request_id
         ]

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -27,6 +27,7 @@ from sglang.srt.managers.scheduler import Scheduler as _Upstream
 from sglang.srt.managers.scheduler import validate_input_length
 from sglang.srt.utils import broadcast_pyobj
 
+from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
 
 logger = logging.getLogger(__name__)
@@ -299,6 +300,7 @@ class OmniScheduler:
         self._pending_stream_chunks: dict[str, list[Any]] = {}
         self._pending_stream_done: set[str] = set()
         self._deferred_request_payloads: dict[str, Any] = {}
+        self._first_emit_done: set[str] = set()
 
     def _init_upstream_compat_flags(self, server_args: Any) -> None:
         self.enable_hisparse = bool(getattr(server_args, "enable_hisparse", False))
@@ -446,6 +448,11 @@ class OmniScheduler:
             ):
                 self._deferred_request_payloads[req_id] = payload
                 continue
+            _emit_event(
+                request_id=req_id,
+                stage=None,
+                event_name="scheduler_request_build_start",
+            )
             try:
                 req_data = self._request_builder(payload)
             except Exception as exc:
@@ -462,6 +469,11 @@ class OmniScheduler:
             req = req_data.req
             req._omni_data = req_data
             req_id = req.rid
+            _emit_event(
+                request_id=req_id,
+                stage=None,
+                event_name="scheduler_request_build_end",
+            )
             if bool(getattr(req_data, "enforce_request_limits", False)):
                 error_msg = self._prepare_request_limits(req_data)
                 if error_msg:
@@ -489,6 +501,11 @@ class OmniScheduler:
             self._initialize_request_stream_state(req_data, payload)
             if req_id in self._aborted_request_ids:
                 continue
+            _emit_event(
+                request_id=req_id,
+                stage=None,
+                event_name="scheduler_prefill_start",
+            )
             self.waiting_queue.append(req)
 
     def _prepare_request_limits(self, req_data: Any) -> str | None:
@@ -588,12 +605,23 @@ class OmniScheduler:
 
             if self._stream_output_builder is not None:
                 for sched_req in sched_output.requests:
-                    req_output = mr_output.outputs[sched_req.request_id]
+                    rid = sched_req.request_id
+                    req_output = mr_output.outputs[rid]
+                    emitted_any = False
                     for msg in self._stream_output_builder(
-                        sched_req.request_id,
+                        rid,
                         sched_req.data,
                         req_output,
                     ):
+                        if not emitted_any:
+                            if rid not in self._first_emit_done:
+                                self._first_emit_done.add(rid)
+                                _emit_event(
+                                    request_id=rid,
+                                    stage=None,
+                                    event_name="scheduler_first_emit",
+                                )
+                            emitted_any = True
                         self.outbox.put(msg)
 
             # Convert ModelRunnerOutput → GenerationBatchResult
@@ -652,6 +680,7 @@ class OmniScheduler:
             data.prefill_input_embeds = None
             data.decode_input_embeds = None
 
+            self._first_emit_done.discard(rid)
             self.outbox.put(
                 OutgoingMessage(
                     request_id=rid,
@@ -703,6 +732,7 @@ class OmniScheduler:
         self._pending_stream_chunks.pop(request_id, None)
         self._pending_stream_done.discard(request_id)
         self._deferred_request_payloads.pop(request_id, None)
+        self._first_emit_done.discard(request_id)
         self.waiting_queue = [
             req for req in self.waiting_queue if req.rid != request_id
         ]

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -250,22 +250,27 @@ def _mount_profiler_routes(
 
     @router.post("/stop_profile")
     async def stop(req: StopReq):
-        run_id = req.run_id or "default"
+        # When the caller omits run_id we stop whatever's active (matches
+        # start_profile's auto-generated default behaviour). When they
+        # provide one, only stop if it matches.
+        run_id = req.run_id  # may be None
         recorder = _get_event_recorder()
-        if recorder.is_active() and recorder.active_run_id() in (run_id, "default"):
-            recorder.stop(run_id=recorder.active_run_id())
+        active = recorder.active_run_id() if recorder.is_active() else None
+        if recorder.is_active() and (run_id is None or active == run_id):
+            recorder.stop(run_id=active)
         await profiler_ctl.broadcast_stop(run_id=run_id)
-        return {"run_id": run_id}
+        return {"run_id": run_id or active}
 
     @router.post("/stop_request_profile")
     async def stop_request(req: StopReq):
         """Stop request-level event profiling."""
-        run_id = req.run_id or "default"
+        run_id = req.run_id  # may be None — see /stop_profile rationale
         recorder = _get_event_recorder()
-        if recorder.is_active() and recorder.active_run_id() in (run_id, "default"):
-            recorder.stop(run_id=recorder.active_run_id())
+        active = recorder.active_run_id() if recorder.is_active() else None
+        if recorder.is_active() and (run_id is None or active == run_id):
+            recorder.stop(run_id=active)
         await profiler_ctl.broadcast_stop(run_id=run_id)
-        return {"run_id": run_id}
+        return {"run_id": run_id or active}
 
     app.include_router(router)
 

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -39,6 +39,7 @@ from pydantic import BaseModel
 from sglang_omni.client import Client
 from sglang_omni.config import PipelineConfig
 from sglang_omni.pipeline.mp_runner import MultiProcessPipelineRunner
+from sglang_omni.profiler.event_recorder import get_recorder as _get_event_recorder
 from sglang_omni.profiler.profiler_control import ProfilerControlClient
 from sglang_omni.serve.openai_api import create_app
 from sglang_omni.utils.gpu_memory import (
@@ -151,10 +152,21 @@ class StartReq(BaseModel):
     run_id: str | None = None
     trace_path_template: str | None = None
     config: dict[str, Any] | None = None
+    event_dir: str | None = None
+    enable_torch: bool = True
 
 
 class StopReq(BaseModel):
     run_id: str | None = None
+
+
+class StartRequestProfileReq(BaseModel):
+    run_id: str | None = None
+    event_dir: str | None = None
+
+
+def _default_event_dir(profiler_dir: str, run_id: str) -> str:
+    return os.path.join(profiler_dir, run_id, "events")
 
 
 def _mount_profiler_routes(
@@ -177,16 +189,81 @@ def _mount_profiler_routes(
                     "SGLANG_TORCH_PROFILER_DIR is not set"
                 ),
             )
+        event_dir = req.event_dir
+        if event_dir is None and profiler_dir is not None:
+            event_dir = _default_event_dir(profiler_dir, run_id)
+        if event_dir is not None:
+            try:
+                _get_event_recorder().start(
+                    run_id=run_id, event_dir=event_dir, stage="coordinator"
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to start coordinator request event recorder",
+                    exc_info=True,
+                )
         await profiler_ctl.broadcast_start(
             run_id=run_id,
             trace_path_template=tpl,
             config=req.config,
+            event_dir=event_dir,
+            enable_torch=req.enable_torch,
         )
-        return {"run_id": run_id, "trace_path_template": tpl}
+        return {
+            "run_id": run_id,
+            "trace_path_template": tpl,
+            "event_dir": event_dir,
+            "enable_torch": req.enable_torch,
+        }
+
+    @router.post("/start_request_profile")
+    async def start_request(req: StartRequestProfileReq):
+        """Start request-level (JSONL) event profiling only (no torch trace)."""
+        run_id = req.run_id or _default_run_id()
+        event_dir = req.event_dir
+        if event_dir is None:
+            if profiler_dir is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "event_dir is required when "
+                        "SGLANG_TORCH_PROFILER_DIR is not set"
+                    ),
+                )
+            event_dir = _default_event_dir(profiler_dir, run_id)
+        try:
+            _get_event_recorder().start(
+                run_id=run_id, event_dir=event_dir, stage="coordinator"
+            )
+        except Exception:
+            logger.warning(
+                "Failed to start coordinator request event recorder",
+                exc_info=True,
+            )
+        await profiler_ctl.broadcast_start(
+            run_id=run_id,
+            trace_path_template="",
+            event_dir=event_dir,
+            enable_torch=False,
+        )
+        return {"run_id": run_id, "event_dir": event_dir}
 
     @router.post("/stop_profile")
     async def stop(req: StopReq):
         run_id = req.run_id or "default"
+        recorder = _get_event_recorder()
+        if recorder.is_active() and recorder.active_run_id() in (run_id, "default"):
+            recorder.stop(run_id=recorder.active_run_id())
+        await profiler_ctl.broadcast_stop(run_id=run_id)
+        return {"run_id": run_id}
+
+    @router.post("/stop_request_profile")
+    async def stop_request(req: StopReq):
+        """Stop request-level event profiling."""
+        run_id = req.run_id or "default"
+        recorder = _get_event_recorder()
+        if recorder.is_active() and recorder.active_run_id() in (run_id, "default"):
+            recorder.stop(run_id=recorder.active_run_id())
         await profiler_ctl.broadcast_stop(run_id=run_id)
         return {"run_id": run_id}
 

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -250,10 +250,8 @@ def _mount_profiler_routes(
 
     @router.post("/stop_profile")
     async def stop(req: StopReq):
-        # When the caller omits run_id we stop whatever's active (matches
-        # start_profile's auto-generated default behaviour). When they
-        # provide one, only stop if it matches.
-        run_id = req.run_id  # may be None
+        # run_id=None is a wildcard (stop whatever's active).
+        run_id = req.run_id
         recorder = _get_event_recorder()
         active = recorder.active_run_id() if recorder.is_active() else None
         if recorder.is_active() and (run_id is None or active == run_id):
@@ -264,7 +262,7 @@ def _mount_profiler_routes(
     @router.post("/stop_request_profile")
     async def stop_request(req: StopReq):
         """Stop request-level event profiling."""
-        run_id = req.run_id  # may be None — see /stop_profile rationale
+        run_id = req.run_id
         recorder = _get_event_recorder()
         active = recorder.active_run_id() if recorder.is_active() else None
         if recorder.is_active() and (run_id is None or active == run_id):

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -177,21 +177,32 @@ def _mount_profiler_routes(
     @router.post("/start_profile")
     async def start(req: StartReq):
         run_id = req.run_id or _default_run_id()
-        if req.trace_path_template is not None:
-            tpl = req.trace_path_template
-        elif profiler_dir is not None:
-            tpl = _default_template(profiler_dir, run_id)
-        else:
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    "trace_path_template is required when "
-                    "SGLANG_TORCH_PROFILER_DIR is not set"
-                ),
-            )
         event_dir = req.event_dir
         if event_dir is None and profiler_dir is not None:
             event_dir = _default_event_dir(profiler_dir, run_id)
+        if req.enable_torch:
+            if req.trace_path_template is not None:
+                tpl = req.trace_path_template
+            elif profiler_dir is not None:
+                tpl = _default_template(profiler_dir, run_id)
+            else:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "trace_path_template is required when "
+                        "SGLANG_TORCH_PROFILER_DIR is not set"
+                    ),
+                )
+        else:
+            if event_dir is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "event_dir is required when enable_torch=false and "
+                        "SGLANG_TORCH_PROFILER_DIR is not set"
+                    ),
+                )
+            tpl = req.trace_path_template or ""
         if event_dir is not None:
             try:
                 _get_event_recorder().start(

--- a/tests/README.md
+++ b/tests/README.md
@@ -243,5 +243,11 @@ that happened to contain an older version of the test.
   - SGLang-backed generation and vocoder GPU placement contracts
   - terminal stage behavior.
 
+- `unit_test/profiler/`: Request-level profiler unit tests:
+  - `RequestEvent` schema and JSONL emit/append behavior
+  - concurrent emit safety under multiple threads
+  - lifecycle (start / stop / run_id mismatch / stage substitution)
+  - timeline reconstruction, stage breakdown, hop breakdown, malformed-line tolerance.
+
 - `unit_test/fixtures/`: Shared fakes. Single-test
   helpers should stay local until a second test needs them.

--- a/tests/unit_test/pipeline/test_coordinator.py
+++ b/tests/unit_test/pipeline/test_coordinator.py
@@ -7,7 +7,7 @@ import asyncio
 import pytest
 
 from sglang_omni.pipeline.coordinator import Coordinator
-from sglang_omni.proto import CompleteMessage, OmniRequest
+from sglang_omni.proto import CompleteMessage, OmniRequest, StreamMessage
 from tests.unit_test.fixtures.pipeline_fakes import RecordingCoordinatorControlPlane
 
 
@@ -187,6 +187,67 @@ def test_coordinator_stream_uses_request_terminal_subset_after_cleanup() -> None
         assert [event.from_stage for event in events] == ["decode"]
 
     asyncio.run(_run())
+
+
+def test_coordinator_stream_received_event_pairs_terminal_chunk(monkeypatch) -> None:
+    events: list[dict] = []
+    monkeypatch.setattr(
+        "sglang_omni.pipeline.coordinator._emit_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["decode"],
+        )
+        queue: asyncio.Queue = asyncio.Queue()
+        coordinator._stream_queues["req-1"] = queue
+
+        await coordinator._handle_stream(
+            StreamMessage(
+                request_id="req-1",
+                from_stage="decode",
+                chunk={"text": "hi"},
+                modality="text",
+                chunk_id=1,
+            )
+        )
+
+        routed = queue.get_nowait()
+        assert routed.chunk_id == 1
+
+    asyncio.run(_run())
+
+    receive_events = [
+        event
+        for event in events
+        if event["event_name"] == "stage_stream_chunk_received"
+    ]
+    assert len(receive_events) == 1
+    assert receive_events[0]["stage"] == "coordinator"
+    assert receive_events[0]["metadata"] == {
+        "from_stage": "decode",
+        "chunk_id": 1,
+        "modality": "text",
+    }
+
+
+def test_stream_message_round_trips_terminal_chunk_id() -> None:
+    msg = StreamMessage(
+        request_id="req-1",
+        from_stage="decode",
+        chunk={"text": "hi"},
+        modality="text",
+        chunk_id=3,
+    )
+
+    round_trip = StreamMessage.from_dict(msg.to_dict())
+
+    assert round_trip.chunk_id == 3
+    assert round_trip.modality == "text"
 
 
 def test_coordinator_failure_completion_fails_fast_and_cleans_state() -> None:

--- a/tests/unit_test/pipeline/test_ipc.py
+++ b/tests/unit_test/pipeline/test_ipc.py
@@ -9,11 +9,13 @@ from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 import sglang_omni.pipeline.mp_runner as mp_runner
 import sglang_omni.pipeline.runtime_config as runtime_config
 import sglang_omni.pipeline.stage.runtime as stage_runtime
 from sglang_omni.config.schema import EndpointsConfig, PipelineConfig, StageConfig
+from sglang_omni.profiler.event_recorder import get_recorder
 from tests.unit_test.fixtures.pipeline_fakes import FakeMpContext, FakeRelay
 
 
@@ -454,6 +456,60 @@ async def test_launcher_uses_runner_and_mounts_profiler_routes(
     mounted_paths = {route.path for route in app.routes}
     assert "/start_profile" in mounted_paths
     assert "/stop_profile" in mounted_paths
+
+
+def test_start_profile_request_only_mode_does_not_require_trace_template(
+    tmp_path: Path,
+) -> None:
+    from sglang_omni.serve import launcher
+
+    class FakeProfilerControl:
+        def __init__(self) -> None:
+            self.starts: list[dict] = []
+
+        async def broadcast_start(self, **kwargs) -> None:
+            self.starts.append(kwargs)
+
+    app = FastAPI()
+    ctl = FakeProfilerControl()
+    launcher._mount_profiler_routes(app, ctl, profiler_dir=None)
+    event_dir = str(tmp_path / "events")
+
+    try:
+        with TestClient(app) as client:
+            resp = client.post(
+                "/start_profile",
+                json={"enable_torch": False, "event_dir": event_dir},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["enable_torch"] is False
+        assert body["trace_path_template"] == ""
+        assert body["event_dir"] == event_dir
+        assert ctl.starts
+        assert ctl.starts[0]["enable_torch"] is False
+        assert ctl.starts[0]["trace_path_template"] == ""
+        assert ctl.starts[0]["event_dir"] == event_dir
+    finally:
+        rec = get_recorder()
+        if rec.is_active():
+            rec.stop()
+
+
+def test_start_profile_torch_mode_still_requires_trace_template() -> None:
+    from sglang_omni.serve import launcher
+
+    class FakeProfilerControl:
+        async def broadcast_start(self, **kwargs) -> None:
+            raise AssertionError("start_profile should fail before broadcasting")
+
+    app = FastAPI()
+    launcher._mount_profiler_routes(app, FakeProfilerControl(), profiler_dir=None)
+
+    with TestClient(app) as client:
+        resp = client.post("/start_profile", json={"enable_torch": True})
+    assert resp.status_code == 400
+    assert "trace_path_template is required" in resp.json()["detail"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -152,6 +152,7 @@ def test_omni_scheduler_run_batch_failure_emits_error_and_aborts() -> None:
     scheduler._abort_callback = None
     scheduler.waiting_queue = []
     scheduler.last_batch = None
+    scheduler._prefill_start_done = set()
 
     batch = SimpleNamespace(
         reqs=[
@@ -176,6 +177,50 @@ def test_omni_scheduler_run_batch_failure_emits_error_and_aborts() -> None:
     assert scheduler._pending_stream_chunks == {}
     assert scheduler._pending_stream_done == set()
     assert scheduler._deferred_request_payloads == {}
+
+
+def test_omni_scheduler_distinguishes_queue_enter_from_prefill_start(
+    monkeypatch,
+) -> None:
+    """Queueing a built request must not report actual prefill execution."""
+    events: list[dict] = []
+    monkeypatch.setattr(
+        "sglang_omni.scheduling.omni_scheduler._emit_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+    scheduler = object.__new__(OmniScheduler)
+    scheduler.outbox = Queue()
+    scheduler.waiting_queue = []
+    scheduler._pending_stream_chunks = {}
+    scheduler._pending_stream_done = set()
+    scheduler._deferred_request_payloads = {}
+    scheduler._aborted_request_ids = set()
+    scheduler._prefill_start_done = set()
+    scheduler.max_req_len = 16
+    scheduler.max_req_input_len = 16
+
+    req = SimpleNamespace(
+        rid="req-delayed",
+        origin_input_ids=[1, 2, 3],
+        sampling_params=SimpleNamespace(max_new_tokens=1),
+        output_ids=[],
+    )
+    scheduler._request_builder = lambda payload: SimpleNamespace(req=req)
+
+    scheduler.process_input_requests([SimpleNamespace(request_id="req-delayed")])
+
+    names = [event["event_name"] for event in events]
+    assert "scheduler_queue_enter" in names
+    assert "scheduler_prefill_start" not in names
+    assert scheduler.waiting_queue == [req]
+
+    batch = SimpleNamespace(reqs=[req], is_prefill_only=True)
+    scheduler._emit_prefill_start_for_batch(batch)
+    scheduler._emit_prefill_start_for_batch(batch)
+
+    names = [event["event_name"] for event in events]
+    assert names.count("scheduler_prefill_start") == 1
+    assert names.index("scheduler_queue_enter") < names.index("scheduler_prefill_start")
 
 
 def test_omni_scheduler_initializes_upstream_queue_limit(monkeypatch) -> None:

--- a/tests/unit_test/pipeline/test_stage_streaming.py
+++ b/tests/unit_test/pipeline/test_stage_streaming.py
@@ -15,7 +15,7 @@ from sglang_omni.config.schema import StageConfig
 from sglang_omni.models.fishaudio_s2_pro.config import S2ProPipelineConfig
 from sglang_omni.pipeline import relay_io
 from sglang_omni.pipeline.stage.runtime import Stage
-from sglang_omni.pipeline.stage.stream_queue import StreamQueue
+from sglang_omni.pipeline.stage.stream_queue import StreamItem, StreamQueue
 from sglang_omni.proto import DataReadyMessage, OmniRequest, StagePayload
 from sglang_omni.scheduling.messages import OutgoingMessage
 
@@ -118,15 +118,23 @@ def test_terminal_scheduler_stream_routes_to_coordinator() -> None:
                 data={"audio_data": [0.1], "modality": "audio"},
             )
         )
+        scheduler.outbox.put(
+            OutgoingMessage(
+                request_id="req",
+                type="stream",
+                data={"audio_data": [0.2], "modality": "audio"},
+            )
+        )
 
         await stage._drain_outbox_external()
 
-        assert len(control_plane.streams) == 1
+        assert len(control_plane.streams) == 2
         msg = control_plane.streams[0]
         assert msg.request_id == "req"
         assert msg.from_stage == "vocoder"
         assert msg.chunk == {"audio_data": [0.1], "modality": "audio"}
         assert msg.modality == "audio"
+        assert [msg.chunk_id for msg in control_plane.streams] == [0, 1]
 
     asyncio.run(_run())
 
@@ -358,6 +366,110 @@ def test_stage_routes_pre_payload_stream_events_for_capable_receiver() -> None:
         assert payload_msg.data.data == {"ready": True}
 
     asyncio.run(_run())
+
+
+def test_stage_stream_chunk_received_after_ipc_materialization(monkeypatch) -> None:
+    """The paired receive event marks scheduler-ready chunks, not control arrival."""
+    order: list[str] = []
+
+    def fake_deserialize(msg):
+        order.append("deserialized")
+        return StreamItem(
+            chunk_id=msg.chunk_id,
+            data="chunk",
+            from_stage=msg.from_stage,
+            metadata=None,
+        )
+
+    async def fake_route(self, request_id, item):
+        del self, request_id, item
+        order.append("routed")
+
+    monkeypatch.setattr(Stage, "_deserialize_ipc_chunk", staticmethod(fake_deserialize))
+    monkeypatch.setattr(Stage, "_route_stream_item_or_fail", fake_route)
+    monkeypatch.setattr(
+        "sglang_omni.pipeline.stage.runtime._emit_event",
+        lambda **kwargs: order.append(kwargs["event_name"]),
+    )
+
+    async def _run() -> None:
+        stage = Stage(
+            name="vocoder",
+            role="single",
+            get_next=lambda request_id, output: None,
+            gpu_id=None,
+            endpoints={},
+            control_plane=_FakeControlPlane(),
+            relay=_FakeRelay(),
+            scheduler=SimpleNamespace(outbox=queue.Queue()),
+            can_accept_stream_before_payload=True,
+        )
+        await stage._on_stream_chunk(
+            DataReadyMessage(
+                request_id="req",
+                from_stage="tts_engine",
+                to_stage="vocoder",
+                shm_metadata={"_ipc": True, "tensor_bytes": b"unused"},
+                chunk_id=0,
+            )
+        )
+
+    asyncio.run(_run())
+
+    assert order == ["deserialized", "stage_stream_chunk_received", "routed"]
+
+
+def test_stage_stream_chunk_received_after_relay_materialization(monkeypatch) -> None:
+    """Cross-GPU chunks emit receive only after relay data and metadata are restored."""
+    order: list[str] = []
+
+    async def fake_read_blob(relay, key, metadata):
+        del relay, key, metadata
+        order.append("blob")
+        return "chunk"
+
+    async def fake_read_metadata(self, shm_metadata, blob_key):
+        del self, shm_metadata, blob_key
+        order.append("metadata")
+        return {"modality": "audio_codes"}
+
+    async def fake_route(self, request_id, item):
+        del self, request_id, item
+        order.append("routed")
+
+    monkeypatch.setattr(relay_io, "read_blob", fake_read_blob)
+    monkeypatch.setattr(Stage, "_read_chunk_metadata", fake_read_metadata)
+    monkeypatch.setattr(Stage, "_route_stream_item_or_fail", fake_route)
+    monkeypatch.setattr(
+        "sglang_omni.pipeline.stage.runtime._emit_event",
+        lambda **kwargs: order.append(kwargs["event_name"]),
+    )
+
+    async def _run() -> None:
+        stage = Stage(
+            name="vocoder",
+            role="single",
+            get_next=lambda request_id, output: None,
+            gpu_id=None,
+            endpoints={},
+            control_plane=_FakeControlPlane(),
+            relay=_FakeRelay(),
+            scheduler=SimpleNamespace(outbox=queue.Queue()),
+            can_accept_stream_before_payload=True,
+        )
+        await stage._on_stream_chunk(
+            DataReadyMessage(
+                request_id="req",
+                from_stage="tts_engine",
+                to_stage="vocoder",
+                shm_metadata={"relay_info": {}},
+                chunk_id=0,
+            )
+        )
+
+    asyncio.run(_run())
+
+    assert order == ["blob", "metadata", "stage_stream_chunk_received", "routed"]
 
 
 def test_stage_stream_error_fails_request_even_with_stream_queue() -> None:

--- a/tests/unit_test/profiler/test_event_recorder.py
+++ b/tests/unit_test/profiler/test_event_recorder.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for sglang_omni.profiler.event_recorder."""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from sglang_omni.profiler.event_recorder import (
+    RequestEvent,
+    RequestEventRecorder,
+    emit,
+    get_recorder,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_recorder():
+    """Make sure the process-global recorder is closed before every test."""
+    rec = get_recorder()
+    if rec.is_active():
+        rec.stop()
+    yield
+    if rec.is_active():
+        rec.stop()
+
+
+def _read_events(path: str) -> list[dict]:
+    with open(path, "r", encoding="utf-8") as fp:
+        return [json.loads(line) for line in fp if line.strip()]
+
+
+def test_event_dataclass_roundtrip() -> None:
+    ev = RequestEvent(
+        request_id="r1",
+        stage="thinker",
+        event_name="thinker_first_token",
+        timestamp_ns=1234,
+        run_id="run_x",
+        pid=99,
+        metadata={"chunk_id": 7},
+    )
+    d = ev.to_dict()
+    assert d["request_id"] == "r1"
+    assert d["stage"] == "thinker"
+    assert d["event_name"] == "thinker_first_token"
+    assert d["timestamp_ns"] == 1234
+    assert d["run_id"] == "run_x"
+    assert d["metadata"] == {"chunk_id": 7}
+
+
+def test_inactive_recorder_is_silent(tmp_path: Path) -> None:
+    """emit() must be a no-op when start() was never called."""
+    rec = RequestEventRecorder()
+    rec.emit(request_id="r1", stage="s", event_name="anything")
+    assert rec.is_active() is False
+
+
+def test_start_writes_jsonl_per_pid_stage(tmp_path: Path) -> None:
+    rec = get_recorder()
+    path = rec.start(run_id="r0", event_dir=str(tmp_path), stage="encoder")
+    try:
+        assert rec.is_active()
+        assert Path(path).parent == tmp_path
+        # Filename must encode stage + pid
+        name = Path(path).name
+        assert name.startswith("events_encoder_")
+        assert name.endswith(".jsonl")
+
+        rec.emit(request_id="r1", stage="encoder", event_name="encoder_start")
+        rec.emit(
+            request_id="r1",
+            stage="encoder",
+            event_name="encoder_end",
+            metadata={"items": 3},
+        )
+    finally:
+        rec.stop()
+
+    events = _read_events(path)
+    assert len(events) == 2
+    assert events[0]["event_name"] == "encoder_start"
+    assert events[0]["run_id"] == "r0"
+    assert events[0]["pid"] is not None
+    assert events[1]["metadata"] == {"items": 3}
+
+
+def test_default_stage_falls_back_to_active(tmp_path: Path) -> None:
+    rec = get_recorder()
+    rec.start(run_id="r0", event_dir=str(tmp_path), stage="thinker")
+    try:
+        rec.emit(request_id="r1", stage=None, event_name="scheduler_prefill_start")
+    finally:
+        path = rec.active_path()
+        rec.stop()
+    assert path is not None
+    events = _read_events(path)
+    assert events[0]["stage"] == "thinker"
+
+
+def test_stop_with_mismatched_run_id_is_noop(tmp_path: Path) -> None:
+    rec = get_recorder()
+    rec.start(run_id="r0", event_dir=str(tmp_path), stage="s")
+    try:
+        rec.stop(run_id="other")  # should NOT close
+        assert rec.is_active()
+    finally:
+        rec.stop()
+    assert rec.is_active() is False
+
+
+def test_concurrent_emits_are_safe(tmp_path: Path) -> None:
+    rec = get_recorder()
+    path = rec.start(run_id="r0", event_dir=str(tmp_path), stage="thinker")
+    n_threads = 8
+    n_per_thread = 50
+
+    def worker(tid: int) -> None:
+        for i in range(n_per_thread):
+            rec.emit(
+                request_id=f"req-{tid}",
+                stage="thinker",
+                event_name="stage_dispatch",
+                metadata={"i": i},
+            )
+
+    threads = [threading.Thread(target=worker, args=(t,)) for t in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    rec.stop()
+
+    events = _read_events(path)
+    assert len(events) == n_threads * n_per_thread
+    # Every line must be valid JSON with required fields
+    for ev in events:
+        assert ev["event_name"] == "stage_dispatch"
+        assert ev["request_id"].startswith("req-")
+        assert ev["run_id"] == "r0"
+
+
+def test_module_level_emit_uses_singleton(tmp_path: Path) -> None:
+    rec = get_recorder()
+    path = rec.start(run_id="r0", event_dir=str(tmp_path), stage="coord")
+    emit(request_id="r1", stage=None, event_name="request_admission")
+    rec.stop()
+    events = _read_events(path)
+    assert any(e["event_name"] == "request_admission" for e in events)

--- a/tests/unit_test/profiler/test_event_recorder.py
+++ b/tests/unit_test/profiler/test_event_recorder.py
@@ -150,3 +150,29 @@ def test_module_level_emit_uses_singleton(tmp_path: Path) -> None:
     rec.stop()
     events = _read_events(path)
     assert any(e["event_name"] == "request_admission" for e in events)
+
+
+def test_multi_stage_same_process_share_one_file(tmp_path: Path) -> None:
+    """Stages sharing one process must write to ONE JSONL file.
+
+    The previous rotating-per-stage behavior caused data routing bugs
+    when declarative topology co-located multiple non-AR stages in one
+    OS process. The first stage to call ``start()`` wins the filename;
+    later stages join the same file and rely on each event's ``stage``
+    field for identity.
+    """
+    rec = get_recorder()
+    p1 = rec.start(run_id="r0", event_dir=str(tmp_path), stage="preprocessing")
+    p2 = rec.start(run_id="r0", event_dir=str(tmp_path), stage="image_encoder")
+    p3 = rec.start(run_id="r0", event_dir=str(tmp_path), stage="thinker")
+    assert p1 == p2 == p3, "shared-process stages must reuse one file"
+    assert Path(p1).name.startswith("events_preprocessing_")
+
+    rec.emit(request_id="r1", stage="preprocessing", event_name="preprocess_start")
+    rec.emit(request_id="r1", stage="image_encoder", event_name="encoder_start")
+    rec.emit(request_id="r1", stage="thinker", event_name="stage_dispatch")
+    rec.stop()
+
+    events = _read_events(p1)
+    stages = {e["stage"] for e in events}
+    assert stages == {"preprocessing", "image_encoder", "thinker"}

--- a/tests/unit_test/profiler/test_event_recorder.py
+++ b/tests/unit_test/profiler/test_event_recorder.py
@@ -12,8 +12,11 @@ import pytest
 from sglang_omni.profiler.event_recorder import (
     RequestEvent,
     RequestEventRecorder,
+    _json_default,
     emit,
     get_recorder,
+    reset_active_stage,
+    set_active_stage,
 )
 
 
@@ -23,6 +26,8 @@ def _reset_recorder():
     rec = get_recorder()
     if rec.is_active():
         rec.stop()
+    # Clear any active-stage binding leaked from prior tests.
+    reset_active_stage(None)
     yield
     if rec.is_active():
         rec.stop()
@@ -176,3 +181,176 @@ def test_multi_stage_same_process_share_one_file(tmp_path: Path) -> None:
     events = _read_events(p1)
     stages = {e["stage"] for e in events}
     assert stages == {"preprocessing", "image_encoder", "thinker"}
+
+
+# ---------------------------------------------------------------------------
+# Active-stage attribution (review finding P1)
+# ---------------------------------------------------------------------------
+
+
+def test_emit_stage_none_uses_thread_local_active_stage(tmp_path: Path) -> None:
+    """``emit(stage=None)`` must pick up the per-thread active stage, not
+    the process-global ``_stage`` (which is the first stage to call start()
+    in a shared-process topology).
+
+    Regression for review finding P1: previously preprocessor / encoder /
+    OmniScheduler / code2wav all called ``emit(stage=None)`` and got
+    attributed to the first stage in the process.
+    """
+    rec = get_recorder()
+    p = rec.start(run_id="r0", event_dir=str(tmp_path), stage="preprocessing")
+    rec.start(run_id="r0", event_dir=str(tmp_path), stage="thinker")
+    rec.start(run_id="r0", event_dir=str(tmp_path), stage="decode")
+
+    # Main thread: no active stage → falls back to recorder's _stage
+    # ("preprocessing", first to call start()).
+    emit(request_id="r1", stage=None, event_name="from_main")
+
+    # Worker threads: each binds its own active stage, then emits.
+    def _worker(stage_name: str) -> None:
+        set_active_stage(stage_name)
+        try:
+            emit(request_id="r1", stage=None, event_name=f"from_{stage_name}")
+        finally:
+            reset_active_stage(None)
+
+    t_thinker = threading.Thread(target=_worker, args=("thinker",))
+    t_decode = threading.Thread(target=_worker, args=("decode",))
+    t_thinker.start()
+    t_decode.start()
+    t_thinker.join()
+    t_decode.join()
+
+    rec.stop()
+
+    events = _read_events(p)
+    by_event = {e["event_name"]: e["stage"] for e in events}
+    assert (
+        by_event["from_main"] == "preprocessing"
+    ), "main thread had no active stage; should fall back to recorder._stage"
+    assert (
+        by_event["from_thinker"] == "thinker"
+    ), "worker thread's set_active_stage('thinker') was ignored"
+    assert (
+        by_event["from_decode"] == "decode"
+    ), "worker thread's set_active_stage('decode') was ignored"
+
+
+def test_emit_stage_none_uses_contextvar_in_asyncio_executor(
+    tmp_path: Path,
+) -> None:
+    """The contextvar must propagate through asyncio.to_thread / executor.
+
+    SimpleScheduler in concurrent mode runs each compute_fn via
+    ``asyncio.to_thread``, which copies the context but NOT the parent
+    thread's threading.local. The contextvar variant is what makes
+    stage attribution work in that path.
+    """
+    import asyncio
+
+    rec = get_recorder()
+    p = rec.start(run_id="r0", event_dir=str(tmp_path), stage="first")
+    rec.start(run_id="r0", event_dir=str(tmp_path), stage="encoder")
+
+    seen: dict[str, str | None] = {}
+
+    def _compute() -> None:
+        # Simulate what SimpleScheduler's worker does after stage binding.
+        emit(request_id="r1", stage=None, event_name="from_executor")
+
+    async def _run() -> None:
+        set_active_stage("encoder")
+        try:
+            await asyncio.to_thread(_compute)
+        finally:
+            reset_active_stage(None)
+
+    asyncio.run(_run())
+    rec.stop()
+
+    events = _read_events(p)
+    by_event = {e["event_name"]: e["stage"] for e in events}
+    seen.update(by_event)
+    assert (
+        seen["from_executor"] == "encoder"
+    ), "contextvar didn't propagate through asyncio.to_thread"
+
+
+# ---------------------------------------------------------------------------
+# Safe metadata serialization (review finding P2)
+# ---------------------------------------------------------------------------
+
+
+def test_json_default_summarizes_tensor_without_materializing() -> None:
+    """``_json_default`` must NOT call .tolist() on tensors / arrays.
+
+    Regression for review finding P2: previously any object with .tolist()
+    got fully expanded; on a GPU tensor this synchronizes, copies to CPU,
+    and serializes potentially MBs of data inline — violating the "large
+    blobs stay out of metadata" rule.
+    """
+
+    class FakeTensor:
+        shape = (32, 1024, 4096)
+        dtype = "torch.float16"
+        device = "cuda:0"
+
+        def tolist(self):  # pragma: no cover - must not be called
+            raise AssertionError(
+                "_json_default called tolist() on a tensor — this is the "
+                "exact bug we're regressing against"
+            )
+
+        def item(self):  # pragma: no cover
+            raise AssertionError("item() called on multi-dim tensor")
+
+    out = _json_default(FakeTensor())
+    assert isinstance(out, dict)
+    assert out["__tensor_summary__"] is True
+    assert out["type"] == "FakeTensor"
+    assert out["shape"] == [32, 1024, 4096]
+    assert out["dtype"] == "torch.float16"
+    assert out["device"] == "cuda:0"
+
+
+def test_json_default_unwraps_zero_d_tensor_as_scalar() -> None:
+    """0-D tensors / numpy scalars should serialize as plain scalars."""
+
+    class FakeScalar:
+        shape = ()
+        dtype = "float32"
+
+        def item(self):
+            return 3.14
+
+    assert _json_default(FakeScalar()) == 3.14
+
+
+def test_emit_with_tensor_metadata_does_not_materialize(tmp_path: Path) -> None:
+    """End-to-end: even if a caller hands us a tensor in metadata, the
+    JSONL line must stay small and never call .tolist()."""
+
+    rec = get_recorder()
+    p = rec.start(run_id="r0", event_dir=str(tmp_path), stage="encoder")
+
+    class HugeTensor:
+        shape = (1024, 4096)
+        dtype = "torch.bfloat16"
+        device = "cuda:0"
+
+        def tolist(self):  # pragma: no cover
+            raise AssertionError("hot-path emit called tolist()")
+
+    rec.emit(
+        request_id="r1",
+        stage="encoder",
+        event_name="encoder_end",
+        metadata={"hidden_states": HugeTensor()},
+    )
+    rec.stop()
+
+    events = _read_events(p)
+    assert len(events) == 1
+    summary = events[0]["metadata"]["hidden_states"]
+    assert summary["__tensor_summary__"] is True
+    assert summary["shape"] == [1024, 4096]

--- a/tests/unit_test/profiler/test_event_recorder.py
+++ b/tests/unit_test/profiler/test_event_recorder.py
@@ -354,3 +354,57 @@ def test_emit_with_tensor_metadata_does_not_materialize(tmp_path: Path) -> None:
     summary = events[0]["metadata"]["hidden_states"]
     assert summary["__tensor_summary__"] is True
     assert summary["shape"] == [1024, 4096]
+
+
+# ---------------------------------------------------------------------------
+# Active-stage lifecycle (review finding P3)
+# ---------------------------------------------------------------------------
+
+
+def test_reset_active_stage_without_token_clears_both_thread_local_and_contextvar() -> (
+    None
+):
+    """``reset_active_stage(None)`` must clear the contextvar too.
+
+    Regression for review finding P3: the previous implementation only
+    cleared the ``threading.local`` slot. The contextvar value persisted,
+    so anyone using the helper to scrub state (test fixtures, ad-hoc
+    cleanup) would silently leak the active stage into the next caller
+    in the same context.
+    """
+    from sglang_omni.profiler import event_recorder
+
+    set_active_stage("leaks")
+    # Sanity: both backends are bound.
+    assert event_recorder._active_stage_cv.get() == "leaks"
+    assert getattr(event_recorder._thread_active_stage, "stage", None) == "leaks"
+
+    reset_active_stage(None)
+
+    # Both must now be empty.
+    assert (
+        event_recorder._active_stage_cv.get() is None
+    ), "contextvar still bound after reset_active_stage(None)"
+    assert getattr(event_recorder._thread_active_stage, "stage", None) is None
+    # And the public accessor agrees.
+    from sglang_omni.profiler.event_recorder import get_active_stage
+
+    assert get_active_stage() is None
+
+
+def test_reset_active_stage_with_token_restores_previous_value() -> None:
+    """The ``Token`` form must still work — the standard ContextVar contract."""
+    from sglang_omni.profiler.event_recorder import get_active_stage
+
+    outer_token = set_active_stage("outer")
+    try:
+        inner_token = set_active_stage("inner")
+        assert get_active_stage() == "inner"
+        reset_active_stage(inner_token)
+        # Reset restores the contextvar to "outer"; thread-local was
+        # blanked, but the contextvar takes precedence in get_active_stage.
+        assert get_active_stage() == "outer"
+    finally:
+        reset_active_stage(outer_token)
+        # After the outer reset, contextvar is back to its initial None.
+        assert get_active_stage() is None

--- a/tests/unit_test/profiler/test_stop_run_id.py
+++ b/tests/unit_test/profiler/test_stop_run_id.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression for review finding P2: stop without run_id was a no-op.
+
+The original bug:
+
+1. ``POST /start_request_profile`` with no ``run_id`` generates one of the
+   form ``run_<timestamp>``.
+2. ``POST /stop_request_profile`` with no ``run_id`` used ``"default"`` as
+   the value to broadcast.
+3. Each stage's stop handler only stopped when its active run id matched
+   the message — so a default-value stop was silently dropped, and the
+   recorder kept writing.
+
+The fix makes ``ProfilerStopMessage.run_id`` optional. ``None`` is a
+wildcard: stop whatever's active.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sglang_omni.profiler.event_recorder import get_recorder, reset_active_stage
+from sglang_omni.proto.messages import ProfilerStopMessage
+
+
+@pytest.fixture(autouse=True)
+def _reset_recorder():
+    rec = get_recorder()
+    if rec.is_active():
+        rec.stop()
+    reset_active_stage(None)
+
+
+def test_profiler_stop_message_supports_optional_run_id() -> None:
+    """The proto must accept run_id=None and round-trip cleanly."""
+    msg = ProfilerStopMessage()
+    assert msg.run_id is None
+    d = msg.to_dict()
+    assert d == {"type": "profiler_stop", "run_id": None}
+    round_trip = ProfilerStopMessage.from_dict(d)
+    assert round_trip.run_id is None
+
+
+def test_profiler_stop_message_legacy_run_id_round_trip() -> None:
+    """Existing callers that DO pass a run id must continue to work."""
+    msg = ProfilerStopMessage(run_id="abc")
+    d = msg.to_dict()
+    round_trip = ProfilerStopMessage.from_dict(d)
+    assert round_trip.run_id == "abc"
+
+
+def test_recorder_stop_with_none_run_id_unconditionally_stops(
+    tmp_path: Path,
+) -> None:
+    """A wildcard (None) stop must close the active recorder even when
+    the recorder was started with a specific run_id."""
+    rec = get_recorder()
+    rec.start(run_id="generated-run-12345", event_dir=str(tmp_path), stage="s")
+    assert rec.is_active()
+    rec.stop(run_id=None)
+    assert not rec.is_active()
+
+
+def test_recorder_stop_with_mismatched_run_id_is_still_noop(
+    tmp_path: Path,
+) -> None:
+    """A non-None mismatched run_id must NOT close the recorder
+    (preserved from earlier behavior)."""
+    rec = get_recorder()
+    rec.start(run_id="real-run", event_dir=str(tmp_path), stage="s")
+    rec.stop(run_id="other-run")
+    assert rec.is_active(), "mismatched non-None run_id should not stop"
+    rec.stop()  # cleanup

--- a/tests/unit_test/profiler/test_views.py
+++ b/tests/unit_test/profiler/test_views.py
@@ -270,6 +270,41 @@ def test_stage_breakdown_covers_preprocess_encoder_and_prefill(
     assert by_key[talker_ttfcc_key].total_ms == 4.0
 
 
+def test_stage_breakdown_emits_both_intervals_sharing_opener(
+    tmp_path: Path,
+) -> None:
+    """Two intervals sharing the same opener must both appear.
+
+    Regression for review finding P1: ``scheduler_prefill_start`` participates
+    in both ``-> scheduler_first_emit`` AND ``-> stage_first_stream_chunk_sent``.
+    Before the fix, the earlier-arriving close (``scheduler_first_emit``) popped
+    the opener, leaving nothing for the later close — so the issue #501
+    "thinker first token" / TTFCC interval silently disappeared from the
+    report.
+    """
+    events = [
+        _ev("r1", "thinker", "scheduler_prefill_start", 0),
+        _ev("r1", "thinker", "scheduler_first_emit", 3_000_000),  # 3 ms
+        _ev("r1", "thinker", "stage_first_stream_chunk_sent", 7_000_000),  # 7 ms
+    ]
+    _write_events(tmp_path / "events_x.jsonl", events)
+    rows = stage_breakdown(source=tmp_path)
+    by_key = {(r.stage, r.interval_name): r for r in rows}
+
+    first_emit_key = ("thinker", "scheduler_prefill_start->scheduler_first_emit")
+    first_chunk_key = (
+        "thinker",
+        "scheduler_prefill_start->stage_first_stream_chunk_sent",
+    )
+    assert first_emit_key in by_key, "scheduler_first_emit interval was dropped"
+    assert first_chunk_key in by_key, (
+        "stage_first_stream_chunk_sent interval was dropped — opener was "
+        "consumed by the sibling pair"
+    )
+    assert by_key[first_emit_key].total_ms == 3.0
+    assert by_key[first_chunk_key].total_ms == 7.0
+
+
 def test_build_report_returns_all_three_views(tmp_path: Path) -> None:
     events = [
         _ev("r1", "coordinator", "request_admission", 0),

--- a/tests/unit_test/profiler/test_views.py
+++ b/tests/unit_test/profiler/test_views.py
@@ -210,6 +210,66 @@ def test_hop_breakdown_pairs_stream_chunks_by_id(tmp_path: Path) -> None:
     assert r.count == 2
 
 
+def test_stage_breakdown_covers_preprocess_encoder_and_prefill(
+    tmp_path: Path,
+) -> None:
+    """The required intervals for #501 must be wired into the views layer."""
+    events = [
+        _ev("r1", "preprocessor", "preprocess_start", 0),
+        _ev("r1", "preprocessor", "preprocess_end", 1_000_000),  # 1ms
+        _ev("r1", "audio_encoder", "encoder_start", 1_100_000, modality="audio"),
+        _ev("r1", "audio_encoder", "encoder_end", 6_100_000, modality="audio"),  # 5ms
+        _ev("r1", "thinker", "scheduler_prefill_start", 6_200_000),
+        _ev(
+            "r1",
+            "thinker",
+            "stage_first_stream_chunk_sent",
+            10_200_000,  # 4ms thinker TTFT
+            to_stage="talker",
+        ),
+        _ev("r1", "talker", "scheduler_request_build_start", 10_300_000),
+        _ev("r1", "talker", "scheduler_request_build_end", 10_700_000),  # 0.4ms
+        _ev("r1", "talker", "scheduler_prefill_start", 10_800_000),
+        _ev(
+            "r1",
+            "talker",
+            "stage_first_stream_chunk_sent",
+            14_800_000,  # 4ms first code chunk
+            to_stage="code2wav",
+        ),
+    ]
+    _write_events(tmp_path / "events_x.jsonl", events)
+    rows = stage_breakdown(source=tmp_path)
+    by_key = {(r.stage, r.interval_name): r for r in rows}
+
+    assert ("preprocessor", "preprocess_start->preprocess_end") in by_key
+    assert by_key[("preprocessor", "preprocess_start->preprocess_end")].total_ms == 1.0
+
+    assert ("audio_encoder", "encoder_start->encoder_end") in by_key
+    assert by_key[("audio_encoder", "encoder_start->encoder_end")].total_ms == 5.0
+
+    thinker_ttft_key = (
+        "thinker",
+        "scheduler_prefill_start->stage_first_stream_chunk_sent",
+    )
+    assert thinker_ttft_key in by_key
+    assert by_key[thinker_ttft_key].total_ms == 4.0
+
+    talker_build_key = (
+        "talker",
+        "scheduler_request_build_start->scheduler_request_build_end",
+    )
+    assert talker_build_key in by_key
+    assert abs(by_key[talker_build_key].total_ms - 0.4) < 1e-9
+
+    talker_ttfcc_key = (
+        "talker",
+        "scheduler_prefill_start->stage_first_stream_chunk_sent",
+    )
+    assert talker_ttfcc_key in by_key
+    assert by_key[talker_ttfcc_key].total_ms == 4.0
+
+
 def test_build_report_returns_all_three_views(tmp_path: Path) -> None:
     events = [
         _ev("r1", "coordinator", "request_admission", 0),

--- a/tests/unit_test/profiler/test_views.py
+++ b/tests/unit_test/profiler/test_views.py
@@ -210,6 +210,53 @@ def test_hop_breakdown_pairs_stream_chunks_by_id(tmp_path: Path) -> None:
     assert r.count == 2
 
 
+def test_hop_breakdown_pairs_terminal_stream_chunks_to_coordinator(
+    tmp_path: Path,
+) -> None:
+    events = [
+        _ev(
+            "r1",
+            "decode",
+            "stage_stream_chunk_sent",
+            0,
+            to_stage="coordinator",
+            chunk_id=0,
+        ),
+        _ev(
+            "r1",
+            "decode",
+            "stage_stream_chunk_sent",
+            100_000,
+            to_stage="coordinator",
+            chunk_id=1,
+        ),
+        _ev(
+            "r1",
+            "coordinator",
+            "stage_stream_chunk_received",
+            1_000_000,
+            from_stage="decode",
+            chunk_id=0,
+        ),
+        _ev(
+            "r1",
+            "coordinator",
+            "stage_stream_chunk_received",
+            1_500_000,
+            from_stage="decode",
+            chunk_id=1,
+        ),
+    ]
+    _write_events(tmp_path / "events_x.jsonl", events)
+    rows = hop_breakdown(source=tmp_path)
+    assert len(rows) == 1
+    r = rows[0]
+    assert r.src_stage == "decode"
+    assert r.dst_stage == "coordinator"
+    assert r.kind == "stream_chunk"
+    assert r.count == 2
+
+
 def test_stage_breakdown_covers_preprocess_encoder_and_prefill(
     tmp_path: Path,
 ) -> None:
@@ -303,6 +350,32 @@ def test_stage_breakdown_emits_both_intervals_sharing_opener(
     )
     assert by_key[first_emit_key].total_ms == 3.0
     assert by_key[first_chunk_key].total_ms == 7.0
+
+
+def test_stage_breakdown_uses_prefill_start_not_queue_enter(
+    tmp_path: Path,
+) -> None:
+    events = [
+        _ev("r1", "thinker", "scheduler_queue_enter", 0),
+        _ev("r1", "thinker", "scheduler_prefill_start", 5_000_000),
+        _ev("r1", "thinker", "scheduler_first_emit", 7_000_000),
+        _ev("r1", "thinker", "stage_first_stream_chunk_sent", 10_000_000),
+    ]
+    _write_events(tmp_path / "events_x.jsonl", events)
+    rows = stage_breakdown(source=tmp_path)
+    by_key = {(r.stage, r.interval_name): r for r in rows}
+
+    assert (
+        by_key[("thinker", "scheduler_prefill_start->scheduler_first_emit")].total_ms
+        == 2.0
+    )
+    assert (
+        by_key[
+            ("thinker", "scheduler_prefill_start->stage_first_stream_chunk_sent")
+        ].total_ms
+        == 5.0
+    )
+    assert all("scheduler_queue_enter->" not in r.interval_name for r in rows)
 
 
 def test_build_report_returns_all_three_views(tmp_path: Path) -> None:

--- a/tests/unit_test/profiler/test_views.py
+++ b/tests/unit_test/profiler/test_views.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for sglang_omni.profiler.views (timeline / stage / hop)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from sglang_omni.profiler.views import (
+    build_report,
+    hop_breakdown,
+    reconstruct_timelines,
+    stage_breakdown,
+)
+
+
+def _write_events(path: Path, events: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fp:
+        for ev in events:
+            fp.write(json.dumps(ev))
+            fp.write("\n")
+
+
+def _ev(request_id, stage, name, ts, **md):
+    return {
+        "request_id": request_id,
+        "stage": stage,
+        "event_name": name,
+        "timestamp_ns": ts,
+        "run_id": "run_test",
+        "pid": os.getpid(),
+        "metadata": md,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Timeline
+# ---------------------------------------------------------------------------
+
+
+def test_reconstruct_timelines_sorts_per_request(tmp_path: Path) -> None:
+    events = [
+        _ev("r1", "coordinator", "request_admission", 1000),
+        _ev("r2", "coordinator", "request_admission", 1100),
+        _ev("r1", "encoder", "stage_input_received", 1500, from_stage="coordinator"),
+        _ev("r1", "coordinator", "terminal_response", 5000, from_stage="thinker"),
+    ]
+    p = tmp_path / "events_test_1.jsonl"
+    _write_events(p, events)
+
+    tls = reconstruct_timelines(tmp_path)
+    assert set(tls) == {"r1", "r2"}
+    assert [e["event_name"] for e in tls["r1"].events] == [
+        "request_admission",
+        "stage_input_received",
+        "terminal_response",
+    ]
+    rel = tls["r1"].to_relative()
+    assert rel[0]["t_rel_ms"] == 0.0
+    # 5000ns - 1000ns = 4000ns = 0.004ms
+    assert rel[-1]["t_rel_ms"] == 0.004
+
+
+def test_timeline_merges_multiple_files(tmp_path: Path) -> None:
+    file_a = tmp_path / "events_coordinator_1.jsonl"
+    file_b = tmp_path / "events_encoder_2.jsonl"
+    _write_events(file_a, [_ev("r1", "coordinator", "request_admission", 100)])
+    _write_events(
+        file_b,
+        [_ev("r1", "encoder", "stage_input_received", 200, from_stage="coordinator")],
+    )
+
+    tls = reconstruct_timelines(tmp_path)
+    assert "r1" in tls
+    names = [e["event_name"] for e in tls["r1"].events]
+    assert names == ["request_admission", "stage_input_received"]
+
+
+def test_iter_events_skips_malformed_lines(tmp_path: Path) -> None:
+    """A garbage line must not break the loader."""
+    p = tmp_path / "events_x_1.jsonl"
+    with p.open("w", encoding="utf-8") as fp:
+        fp.write(json.dumps(_ev("r1", "s", "a", 1)))
+        fp.write("\n")
+        fp.write("not-valid-json\n")
+        fp.write(json.dumps(_ev("r1", "s", "b", 2)))
+        fp.write("\n")
+    tls = reconstruct_timelines(tmp_path)
+    assert len(tls["r1"].events) == 2
+
+
+# ---------------------------------------------------------------------------
+# Stage breakdown
+# ---------------------------------------------------------------------------
+
+
+def test_stage_breakdown_pairs_open_close(tmp_path: Path) -> None:
+    events = [
+        _ev("r1", "encoder", "stage_input_received", 0, from_stage="coordinator"),
+        _ev("r1", "encoder", "stage_complete", 2_000_000),  # 2ms
+        _ev("r2", "encoder", "stage_input_received", 1, from_stage="coordinator"),
+        _ev("r2", "encoder", "stage_complete", 4_000_001),  # 4ms
+    ]
+    _write_events(tmp_path / "events_x.jsonl", events)
+    rows = stage_breakdown(source=tmp_path)
+    encoder_rows = [
+        r
+        for r in rows
+        if r.stage == "encoder"
+        and r.interval_name == "stage_input_received->stage_complete"
+    ]
+    assert len(encoder_rows) == 1
+    row = encoder_rows[0]
+    assert row.count == 2
+    assert row.total_ms == 6.0
+    assert row.avg_ms == 3.0
+    assert row.max_ms == 4.0
+
+
+def test_stage_breakdown_keeps_intervals_stage_local(tmp_path: Path) -> None:
+    """An open on stage A must not pair with a close on stage B."""
+    events = [
+        _ev("r1", "encoder", "stage_input_received", 0, from_stage="coordinator"),
+        _ev("r1", "thinker", "stage_complete", 1_000_000),
+        # No matching close on encoder for r1 → no encoder interval emitted.
+    ]
+    _write_events(tmp_path / "events_x.jsonl", events)
+    rows = stage_breakdown(source=tmp_path)
+    encoder_rows = [
+        r
+        for r in rows
+        if r.stage == "encoder"
+        and r.interval_name == "stage_input_received->stage_complete"
+    ]
+    assert encoder_rows == []
+
+
+# ---------------------------------------------------------------------------
+# Hop breakdown
+# ---------------------------------------------------------------------------
+
+
+def test_hop_breakdown_pairs_payload_send_recv(tmp_path: Path) -> None:
+    events = [
+        _ev("r1", "encoder", "stage_hop_sent", 0, to_stage="thinker"),
+        _ev(
+            "r1",
+            "thinker",
+            "stage_input_received",
+            500_000,  # 0.5ms hop
+            from_stage="encoder",
+            kind="payload",
+        ),
+    ]
+    _write_events(tmp_path / "events_x.jsonl", events)
+    rows = hop_breakdown(source=tmp_path)
+    assert len(rows) == 1
+    r = rows[0]
+    assert r.src_stage == "encoder"
+    assert r.dst_stage == "thinker"
+    assert r.kind == "payload"
+    assert r.count == 1
+    assert abs(r.total_ms - 0.5) < 1e-9
+
+
+def test_hop_breakdown_pairs_stream_chunks_by_id(tmp_path: Path) -> None:
+    events = [
+        _ev(
+            "r1",
+            "thinker",
+            "stage_stream_chunk_sent",
+            0,
+            to_stage="talker",
+            chunk_id=0,
+        ),
+        _ev(
+            "r1",
+            "thinker",
+            "stage_stream_chunk_sent",
+            100_000,
+            to_stage="talker",
+            chunk_id=1,
+        ),
+        _ev(
+            "r1",
+            "talker",
+            "stage_stream_chunk_received",
+            1_000_000,
+            from_stage="thinker",
+            chunk_id=0,
+        ),
+        _ev(
+            "r1",
+            "talker",
+            "stage_stream_chunk_received",
+            1_500_000,
+            from_stage="thinker",
+            chunk_id=1,
+        ),
+    ]
+    _write_events(tmp_path / "events_x.jsonl", events)
+    rows = hop_breakdown(source=tmp_path)
+    assert len(rows) == 1
+    r = rows[0]
+    assert r.src_stage == "thinker"
+    assert r.dst_stage == "talker"
+    assert r.kind == "stream_chunk"
+    assert r.count == 2
+
+
+def test_build_report_returns_all_three_views(tmp_path: Path) -> None:
+    events = [
+        _ev("r1", "coordinator", "request_admission", 0),
+        _ev("r1", "encoder", "stage_input_received", 100, from_stage="coordinator"),
+        _ev("r1", "encoder", "stage_complete", 2_000_000),
+        _ev("r1", "encoder", "stage_hop_sent", 2_100_000, to_stage="thinker"),
+        _ev(
+            "r1",
+            "thinker",
+            "stage_input_received",
+            3_000_000,
+            from_stage="encoder",
+        ),
+        _ev("r1", "coordinator", "terminal_response", 10_000_000),
+    ]
+    _write_events(tmp_path / "events_x.jsonl", events)
+    rep = build_report(tmp_path)
+    assert rep["request_count"] == 1
+    assert "r1" in rep["timelines"]
+    assert len(rep["timelines"]["r1"]) == 6
+    assert any(r["stage"] == "encoder" for r in rep["stage_breakdown"])
+    assert any(
+        r["src"] == "encoder" and r["dst"] == "thinker" for r in rep["hop_breakdown"]
+    )

--- a/tests/unit_test/qwen3_omni/test_streaming.py
+++ b/tests/unit_test/qwen3_omni/test_streaming.py
@@ -639,6 +639,7 @@ def _bare_stage(*, is_terminal: bool, owns_io: bool = True) -> Stage:
     s._active_requests = set()
     s._stream_queue = None
     s._stream_chunk_counters = {}
+    s._first_stream_chunk_seen = set()
     s.input_handler = SimpleNamespace(cancel=lambda request_id: None)
     s.scheduler = SimpleNamespace(abort=lambda request_id: None)
     s.control_plane = SimpleNamespace(completions=[])

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -613,6 +613,7 @@ def test_qwen3_tts_ar_scheduler_abort_cleans_prepared_state() -> None:
         scheduler._pending_stream_chunks = {}
         scheduler._pending_stream_done = set()
         scheduler._deferred_request_payloads = {}
+        scheduler._first_emit_done = set()
         scheduler.waiting_queue = []
         scheduler.running_batch = SimpleNamespace(reqs=[], batch_is_full=False)
         scheduler.cur_batch = None

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -614,6 +614,7 @@ def test_qwen3_tts_ar_scheduler_abort_cleans_prepared_state() -> None:
         scheduler._pending_stream_done = set()
         scheduler._deferred_request_payloads = {}
         scheduler._first_emit_done = set()
+        scheduler._prefill_start_done = set()
         scheduler.waiting_queue = []
         scheduler.running_batch = SimpleNamespace(reqs=[], batch_is_full=False)
         scheduler.cur_batch = None


### PR DESCRIPTION
## Summary

Implements the request-level profiler called for in #501 in full. The
profiler runs alongside the existing torch trace and shares its `run_id`.

- **Event recorder** (`sglang_omni/profiler/event_recorder.py`) —
  process-local JSONL sink with a thread-safe singleton and a tolerant
  `emit(...)` helper. Each process writes
  `<event_dir>/events_<stage>_<pid>.jsonl`. Emit errors are swallowed so
  profiling never breaks serving.
- **Views** (`sglang_omni/profiler/views.py`) — derives the three required
  reports from the JSONL stream: per-request timeline, stage breakdown
  (open/close interval durations with p50/p95/max), and hop breakdown
  (`stage_hop_sent → stage_input_received` plus stream-chunk variants
  matched by `chunk_id`).
- **CLI** (`python -m sglang_omni.profiler <event_dir>`) — JSON or table
  output for quick inspection.
- **Instrumentation** — all #501 milestones are covered:

| #501 milestone | Concrete event |
|---|---|
| request admission | `request_admission` |
| preprocessing start / end | `preprocess_start` / `preprocess_end` |
| encoder start / end | `encoder_start` / `encoder_end` (with modality, batch_size) |
| aggregate ready | `stage_aggregate_ready` |
| thinker prefill start | `scheduler_prefill_start` (stage=thinker) |
| thinker first token | `stage_first_stream_chunk_sent` (stage=thinker) |
| first stream chunk sent | `stage_first_stream_chunk_sent` (to coordinator) |
| talker request build start / end | `scheduler_request_build_start` / `_end` (stage=talker) |
| talker prefill start | `scheduler_prefill_start` (stage=talker) |
| first code chunk | `stage_first_stream_chunk_sent` (stage=talker) |
| code2wav first audio | `code2wav_first_audio` |
| terminal response | `terminal_response` |

The stage name on each event carries the layer info, so the same
`scheduler_prefill_start` becomes "thinker prefill start" vs "talker
prefill start" depending on which scheduler process emitted it.

- **Control plane** — extends `ProfilerStartMessage` with `event_dir`
  and `enable_torch` (defaults keep old behavior), broadcasts via the
  existing `ProfilerControlClient`, and toggles the recorder from
  Stage's `_on_profiler_start` / `_on_profiler_stop`. New endpoints
  `/start_request_profile` and `/stop_request_profile` enable
  JSONL-only profiling without paying for a torch kernel trace.

## Usage

```bash
curl -X POST http://localhost:8000/start_request_profile \
     -d '{"run_id":"demo","event_dir":"/tmp/demo/events"}'
# … run benchmark traffic …
curl -X POST http://localhost:8000/stop_request_profile -d '{"run_id":"demo"}'
python -m sglang_omni.profiler /tmp/demo/events --format table
```

## Test plan
- [x] 16 unit tests under `tests/unit_test/profiler/`
  (`pytest tests/unit_test/profiler/ -q`) — pass.
- [x] All five #501-required stage intervals are exercised end-to-end by
  `test_stage_breakdown_covers_preprocess_encoder_and_prefill`.
- [x] Backwards compat: `ProfilerStartMessage.from_dict` accepts the
  pre-existing payload shape (no `event_dir`/`enable_torch`).
- [x] CLI smoke test on a synthetic event directory renders the table
  and JSON reports.
- [ ] On-host validation: run Qwen3-Omni MMMU benchmark with the
  profiler enabled and confirm reports identify the expected hot stages
  and hops (artifacts uploaded to HaydenCC/profiles on HF).

Closes #501.