### PR TITLE
[Feature] Migrate SeedTTS benchmark datasets to Arrow/Parquet

### DIFF
--- a/.claude/skills/running-eval-suite/models/qwen3-omni/config.yaml
+++ b/.claude/skills/running-eval-suite/models/qwen3-omni/config.yaml
@@ -41,7 +41,7 @@ hf_datasets:
   - "zhaochenyang20/Video_MME"
   - "zhaochenyang20/Video_AMME_ci"
   - "zhaochenyang20/Video_MME_ci"
-  - "zhaochenyang20/seed-tts-eval"
+  - "zhaochenyang20/seed-tts-eval-arrow"
 
 # Auxiliary scoring resources — orthogonal to the main model+dataset; without
 # them rows usually run-to-completion but skip every sample at the ASR/WER
@@ -67,11 +67,6 @@ python_packages:
   - name: "zhon"
     install_cmd: "uv pip install zhon"
     used_for: "ZH punctuation set used by normalize_text(text, 'zh')"
-
-path_links:
-  - target: "seedtts_testset"
-    install_cmd: 'SNAP=$(ls -d ~/.cache/huggingface/hub/datasets--zhaochenyang20--seed-tts-eval/snapshots/*/ | head -1); ln -sfn "$SNAP" seedtts_testset'
-    used_for: "all seedtts + s2pro client cmds reference --meta seedtts_testset/{en,zh}/meta.lst relative to repo root"
 
 default_venv_python:
   - "/sgl-workspace/sglang-omni/.venv/bin/python"
@@ -263,7 +258,7 @@ rows:
       section_substring: "Accuracy (accuracy.wer)"
       config_substring: "EN, voice_clone=T"
       source_workload: "router, 2-worker, full-set, c=16, n=3 mean"
-    client: "python -m benchmarks.eval.benchmark_omni_seedtts --voice-clone --model qwen3-omni --port {port} --meta seedtts_testset/en/meta.lst --max-concurrency 16 --lang en --output-dir {output_dir} --asr-device {asr_gpu}"
+    client: "python -m benchmarks.eval.benchmark_omni_seedtts --voice-clone --model qwen3-omni --port {port} --meta zhaochenyang20/seed-tts-eval-arrow --max-concurrency 16 --lang en --output-dir {output_dir} --asr-device {asr_gpu}"
     result_json: "wer_results.json"
     cells:
       wer_corpus:            { path: "summary.wer_corpus",            format: "{v:.2%}" }
@@ -279,7 +274,7 @@ rows:
       section_substring: "Accuracy (accuracy.wer)"
       config_substring: "EN, voice_clone=F"
       source_workload: "router, 2-worker, full-set, c=16"
-    client: "python -m benchmarks.eval.benchmark_omni_seedtts --model qwen3-omni --port {port} --meta seedtts_testset/en/meta.lst --max-concurrency 16 --lang en --output-dir {output_dir} --asr-device {asr_gpu}"
+    client: "python -m benchmarks.eval.benchmark_omni_seedtts --model qwen3-omni --port {port} --meta zhaochenyang20/seed-tts-eval-arrow --max-concurrency 16 --lang en --output-dir {output_dir} --asr-device {asr_gpu}"
     result_json: "wer_results.json"
     cells:
       wer_corpus:            { path: "summary.wer_corpus",            format: "{v:.2%}" }
@@ -295,7 +290,7 @@ rows:
       section_substring: "Accuracy (accuracy.wer)"
       config_substring: "ZH, voice_clone=T"
       source_workload: "router, 2-worker, full-set, c=16"
-    client: "python -m benchmarks.eval.benchmark_omni_seedtts --voice-clone --model qwen3-omni --port {port} --meta seedtts_testset/zh/meta.lst --max-concurrency 16 --lang zh --output-dir {output_dir} --asr-device {asr_gpu}"
+    client: "python -m benchmarks.eval.benchmark_omni_seedtts --voice-clone --model qwen3-omni --port {port} --meta zhaochenyang20/seed-tts-eval-arrow --max-concurrency 16 --lang zh --output-dir {output_dir} --asr-device {asr_gpu}"
     result_json: "wer_results.json"
     cells:
       wer_corpus:            { path: "summary.wer_corpus",            format: "{v:.2%}" }
@@ -311,7 +306,7 @@ rows:
       section_substring: "Accuracy (accuracy.wer)"
       config_substring: "ZH, voice_clone=F"
       source_workload: "router, 2-worker, full-set, c=16"
-    client: "python -m benchmarks.eval.benchmark_omni_seedtts --model qwen3-omni --port {port} --meta seedtts_testset/zh/meta.lst --max-concurrency 16 --lang zh --output-dir {output_dir} --asr-device {asr_gpu}"
+    client: "python -m benchmarks.eval.benchmark_omni_seedtts --model qwen3-omni --port {port} --meta zhaochenyang20/seed-tts-eval-arrow --max-concurrency 16 --lang zh --output-dir {output_dir} --asr-device {asr_gpu}"
     result_json: "wer_results.json"
     cells:
       wer_corpus:            { path: "summary.wer_corpus",            format: "{v:.2%}" }
@@ -327,7 +322,7 @@ rows:
       section_substring: "Generation speed (generation.speed)"
       config_substring: "EN, voice_clone=T"
       source_workload: "router, 2-worker, full-set, c=16"
-    client: "python -m benchmarks.eval.benchmark_omni_seedtts --voice-clone --model qwen3-omni --port {port} --meta seedtts_testset/en/meta.lst --max-concurrency 16 --lang en --output-dir {output_dir} --asr-device {asr_gpu}"
+    client: "python -m benchmarks.eval.benchmark_omni_seedtts --voice-clone --model qwen3-omni --port {port} --meta zhaochenyang20/seed-tts-eval-arrow --max-concurrency 16 --lang en --output-dir {output_dir} --asr-device {asr_gpu}"
     result_json: "speed_results.json"
     cells:
       latency_mean_s: { path: "summary.latency_mean_s", format: "{v:.2f}" }
@@ -343,7 +338,7 @@ rows:
       section_substring: "Generation speed (generation.speed)"
       config_substring: "EN, voice_clone=F"
       source_workload: "router, 2-worker, full-set, c=16"
-    client: "python -m benchmarks.eval.benchmark_omni_seedtts --model qwen3-omni --port {port} --meta seedtts_testset/en/meta.lst --max-concurrency 16 --lang en --output-dir {output_dir} --asr-device {asr_gpu}"
+    client: "python -m benchmarks.eval.benchmark_omni_seedtts --model qwen3-omni --port {port} --meta zhaochenyang20/seed-tts-eval-arrow --max-concurrency 16 --lang en --output-dir {output_dir} --asr-device {asr_gpu}"
     result_json: "speed_results.json"
     cells:
       latency_mean_s: { path: "summary.latency_mean_s", format: "{v:.2f}" }
@@ -359,7 +354,7 @@ rows:
       section_substring: "Generation speed (generation.speed)"
       config_substring: "ZH, voice_clone=T"
       source_workload: "router, 2-worker, full-set, c=16"
-    client: "python -m benchmarks.eval.benchmark_omni_seedtts --voice-clone --model qwen3-omni --port {port} --meta seedtts_testset/zh/meta.lst --max-concurrency 16 --lang zh --output-dir {output_dir} --asr-device {asr_gpu}"
+    client: "python -m benchmarks.eval.benchmark_omni_seedtts --voice-clone --model qwen3-omni --port {port} --meta zhaochenyang20/seed-tts-eval-arrow --max-concurrency 16 --lang zh --output-dir {output_dir} --asr-device {asr_gpu}"
     result_json: "speed_results.json"
     cells:
       latency_mean_s: { path: "summary.latency_mean_s", format: "{v:.2f}" }
@@ -375,7 +370,7 @@ rows:
       section_substring: "Generation speed (generation.speed)"
       config_substring: "ZH, voice_clone=F"
       source_workload: "router, 2-worker, full-set, c=16"
-    client: "python -m benchmarks.eval.benchmark_omni_seedtts --model qwen3-omni --port {port} --meta seedtts_testset/zh/meta.lst --max-concurrency 16 --lang zh --output-dir {output_dir} --asr-device {asr_gpu}"
+    client: "python -m benchmarks.eval.benchmark_omni_seedtts --model qwen3-omni --port {port} --meta zhaochenyang20/seed-tts-eval-arrow --max-concurrency 16 --lang zh --output-dir {output_dir} --asr-device {asr_gpu}"
     result_json: "speed_results.json"
     cells:
       latency_mean_s: { path: "summary.latency_mean_s", format: "{v:.2f}" }
@@ -531,7 +526,7 @@ rows:
       section_substring: "Accuracy (accuracy.wer)"
       config_substring: "EN, stream=False"
       source_workload: "router, 2-worker, full-set, c=16"
-    client: "python -m benchmarks.eval.benchmark_tts_seedtts --model fishaudio/s2-pro --port {port} --meta seedtts_testset/en/meta.lst --max-concurrency 16 --lang en --output-dir {output_dir} --device {asr_gpu}"
+    client: "python -m benchmarks.eval.benchmark_tts_seedtts --model fishaudio/s2-pro --port {port} --meta zhaochenyang20/seed-tts-eval-arrow --max-concurrency 16 --lang en --output-dir {output_dir} --device {asr_gpu}"
     result_json: "wer_results.json"
     cells:
       wer_corpus:            { path: "summary.wer_corpus",            format: "{v:.2%}" }
@@ -548,7 +543,7 @@ rows:
       section_substring: "Accuracy (accuracy.wer)"
       config_substring: "EN, stream=True"
       source_workload: "router, 2-worker, full-set, c=16"
-    client: "python -m benchmarks.eval.benchmark_tts_seedtts --stream --model fishaudio/s2-pro --port {port} --meta seedtts_testset/en/meta.lst --max-concurrency 16 --lang en --output-dir {output_dir} --device {asr_gpu}"
+    client: "python -m benchmarks.eval.benchmark_tts_seedtts --stream --model fishaudio/s2-pro --port {port} --meta zhaochenyang20/seed-tts-eval-arrow --max-concurrency 16 --lang en --output-dir {output_dir} --device {asr_gpu}"
     result_json: "wer_results.json"
     cells:
       wer_corpus:            { path: "summary.wer_corpus",            format: "{v:.2%}" }
@@ -565,7 +560,7 @@ rows:
       section_substring: "Accuracy (accuracy.wer)"
       config_substring: "ZH, stream=False"
       source_workload: "router, 2-worker, full-set, c=16"
-    client: "python -m benchmarks.eval.benchmark_tts_seedtts --model fishaudio/s2-pro --port {port} --meta seedtts_testset/zh/meta.lst --max-concurrency 16 --lang zh --output-dir {output_dir} --device {asr_gpu}"
+    client: "python -m benchmarks.eval.benchmark_tts_seedtts --model fishaudio/s2-pro --port {port} --meta zhaochenyang20/seed-tts-eval-arrow --max-concurrency 16 --lang zh --output-dir {output_dir} --device {asr_gpu}"
     result_json: "wer_results.json"
     cells:
       wer_corpus:            { path: "summary.wer_corpus",            format: "{v:.2%}" }
@@ -582,7 +577,7 @@ rows:
       section_substring: "Accuracy (accuracy.wer)"
       config_substring: "ZH, stream=True"
       source_workload: "router, 2-worker, full-set, c=16"
-    client: "python -m benchmarks.eval.benchmark_tts_seedtts --stream --model fishaudio/s2-pro --port {port} --meta seedtts_testset/zh/meta.lst --max-concurrency 16 --lang zh --output-dir {output_dir} --device {asr_gpu}"
+    client: "python -m benchmarks.eval.benchmark_tts_seedtts --stream --model fishaudio/s2-pro --port {port} --meta zhaochenyang20/seed-tts-eval-arrow --max-concurrency 16 --lang zh --output-dir {output_dir} --device {asr_gpu}"
     result_json: "wer_results.json"
     cells:
       wer_corpus:            { path: "summary.wer_corpus",            format: "{v:.2%}" }
@@ -599,7 +594,7 @@ rows:
       section_substring: "Generation speed (generation.speed)"
       config_substring: "EN, stream=False"
       source_workload: "router, 2-worker, full-set, c=16"
-    client: "python -m benchmarks.eval.benchmark_tts_seedtts --model fishaudio/s2-pro --port {port} --meta seedtts_testset/en/meta.lst --max-concurrency 16 --lang en --output-dir {output_dir} --device {asr_gpu}"
+    client: "python -m benchmarks.eval.benchmark_tts_seedtts --model fishaudio/s2-pro --port {port} --meta zhaochenyang20/seed-tts-eval-arrow --max-concurrency 16 --lang en --output-dir {output_dir} --device {asr_gpu}"
     result_json: "speed_results.json"
     cells:
       latency_mean_s: { path: "summary.latency_mean_s", format: "{v:.3f}" }
@@ -616,7 +611,7 @@ rows:
       section_substring: "Generation speed (generation.speed)"
       config_substring: "EN, stream=True"
       source_workload: "router, 2-worker, full-set, c=16"
-    client: "python -m benchmarks.eval.benchmark_tts_seedtts --stream --model fishaudio/s2-pro --port {port} --meta seedtts_testset/en/meta.lst --max-concurrency 16 --lang en --output-dir {output_dir} --device {asr_gpu}"
+    client: "python -m benchmarks.eval.benchmark_tts_seedtts --stream --model fishaudio/s2-pro --port {port} --meta zhaochenyang20/seed-tts-eval-arrow --max-concurrency 16 --lang en --output-dir {output_dir} --device {asr_gpu}"
     result_json: "speed_results.json"
     cells:
       latency_mean_s: { path: "summary.latency_mean_s", format: "{v:.3f}" }
@@ -633,7 +628,7 @@ rows:
       section_substring: "Generation speed (generation.speed)"
       config_substring: "ZH, stream=False"
       source_workload: "router, 2-worker, full-set, c=16"
-    client: "python -m benchmarks.eval.benchmark_tts_seedtts --model fishaudio/s2-pro --port {port} --meta seedtts_testset/zh/meta.lst --max-concurrency 16 --lang zh --output-dir {output_dir} --device {asr_gpu}"
+    client: "python -m benchmarks.eval.benchmark_tts_seedtts --model fishaudio/s2-pro --port {port} --meta zhaochenyang20/seed-tts-eval-arrow --max-concurrency 16 --lang zh --output-dir {output_dir} --device {asr_gpu}"
     result_json: "speed_results.json"
     cells:
       latency_mean_s: { path: "summary.latency_mean_s", format: "{v:.3f}" }
@@ -650,7 +645,7 @@ rows:
       section_substring: "Generation speed (generation.speed)"
       config_substring: "ZH, stream=True"
       source_workload: "router, 2-worker, full-set, c=16"
-    client: "python -m benchmarks.eval.benchmark_tts_seedtts --stream --model fishaudio/s2-pro --port {port} --meta seedtts_testset/zh/meta.lst --max-concurrency 16 --lang zh --output-dir {output_dir} --device {asr_gpu}"
+    client: "python -m benchmarks.eval.benchmark_tts_seedtts --stream --model fishaudio/s2-pro --port {port} --meta zhaochenyang20/seed-tts-eval-arrow --max-concurrency 16 --lang zh --output-dir {output_dir} --device {asr_gpu}"
     result_json: "speed_results.json"
     cells:
       latency_mean_s: { path: "summary.latency_mean_s", format: "{v:.3f}" }

--- a/.claude/skills/tune-ci-thresholds/models/qwen3-omni-v1/config.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/qwen3-omni-v1/config.yaml
@@ -5,7 +5,7 @@ hf_model_id: "Qwen/Qwen3-Omni-30B-A3B-Instruct"
 hf_datasets:
   - "zhaochenyang20/mmsu-ci-2000"
   - "zhaochenyang20/mmmu-ci-50"
-  - "zhaochenyang20/seed-tts-eval-50"
+  - "zhaochenyang20/seed-tts-eval-50-arrow"
   - "zhaochenyang20/Video_MME_ci"
   - "zhaochenyang20/Video_AMME_ci"
 default_venv_python:

--- a/.claude/skills/tune-ci-thresholds/models/qwen3-omni-v1/config.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/qwen3-omni-v1/config.yaml
@@ -37,9 +37,7 @@ gpus_per_test:
 test_globs:
   - "tests/test_model/test_qwen3_omni_*_ci.py"
 # Per-test extra env vars. Key is the test filename (basename).
-extra_env:
-  test_qwen3_omni_tts_ci.py:
-    SGLANG_SEEDTTS50_DIR: "/github/home/seedtts-50"
+extra_env: {}
 # Stage-key base derivation: strip prefix + strip suffix from the test stem.
 stage_base_strip_prefix: "test_qwen3_omni_"
 stage_base_strip_suffix: "_ci"

--- a/.claude/skills/tune-ci-thresholds/models/qwen3-omni-v1/stages.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/qwen3-omni-v1/stages.yaml
@@ -405,8 +405,7 @@ tts_wer:
   test: tests/test_model/test_qwen3_omni_tts_ci.py
   title: "TTS Wer"
   group: wer
-  extra_env:
-    SGLANG_SEEDTTS50_DIR: "/github/home/seedtts-50"
+  extra_env: {}
   context_vars:
     - MAX_SAMPLES
     - CONCURRENCY
@@ -444,8 +443,7 @@ tts_speed:
   test: tests/test_model/test_qwen3_omni_tts_ci.py
   title: "TTS Speed"
   group: speed
-  extra_env:
-    SGLANG_SEEDTTS50_DIR: "/github/home/seedtts-50"
+  extra_env: {}
   context_vars:
     - MAX_SAMPLES
     - CONCURRENCY

--- a/.claude/skills/tune-ci-thresholds/models/s2-pro-v1/config.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/s2-pro-v1/config.yaml
@@ -27,9 +27,7 @@ gpus_per_test:
   test_s2pro_tts_ci.py: 2
 test_globs:
   - "tests/test_model/test_s2pro_tts_ci.py"
-extra_env:
-  test_s2pro_tts_ci.py:
-    SGLANG_SEEDTTS50_DIR: "/github/home/seedtts-50"
+extra_env: {}
 # Per-test extra pytest CLI args. test_s2pro_tts_ci.py needs `--concurrency 16`
 # to match the CI invocation; without it the test defaults to concurrency=1
 # (and writes results into vc_*_c1/ subdirs, not vc_*_c16/ where this config

--- a/.claude/skills/tune-ci-thresholds/models/s2-pro-v1/config.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/s2-pro-v1/config.yaml
@@ -15,7 +15,7 @@ name: s2-pro-v1
 description: "FishAudio S2-Pro voice-clone TTS"
 hf_model_id: "fishaudio/s2-pro"
 hf_datasets:
-  - "zhaochenyang20/seed-tts-eval-50"
+  - "zhaochenyang20/seed-tts-eval-50-arrow"
 # Per user override: this host shares the omni-qwen3 venv across all
 # models — there is no separate omni-s2pro venv to check.
 default_venv_python:

--- a/.claude/skills/tune-ci-thresholds/models/s2-pro-v1/stages.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/s2-pro-v1/stages.yaml
@@ -3,8 +3,7 @@ tts_nonstream_wer:
   test: tests/test_model/test_s2pro_tts_ci.py
   title: "TTS NONSTREAM Wer"
   group: wer
-  extra_env:
-    SGLANG_SEEDTTS50_DIR: "/github/home/seedtts-50"
+  extra_env: {}
   context_vars:
     - STREAMING_BENCHMARK_MAX_SAMPLES
   variant: "nonstream"
@@ -42,8 +41,7 @@ tts_nonstream_speed:
   test: tests/test_model/test_s2pro_tts_ci.py
   title: "TTS NONSTREAM Speed"
   group: speed
-  extra_env:
-    SGLANG_SEEDTTS50_DIR: "/github/home/seedtts-50"
+  extra_env: {}
   context_vars:
     - STREAMING_BENCHMARK_MAX_SAMPLES
   variant: "nonstream"
@@ -101,8 +99,7 @@ tts_stream_wer:
   test: tests/test_model/test_s2pro_tts_ci.py
   title: "TTS STREAM Wer"
   group: wer
-  extra_env:
-    SGLANG_SEEDTTS50_DIR: "/github/home/seedtts-50"
+  extra_env: {}
   context_vars:
     - STREAMING_BENCHMARK_MAX_SAMPLES
   variant: "stream"
@@ -140,8 +137,7 @@ tts_stream_speed:
   test: tests/test_model/test_s2pro_tts_ci.py
   title: "TTS STREAM Speed"
   group: speed
-  extra_env:
-    SGLANG_SEEDTTS50_DIR: "/github/home/seedtts-50"
+  extra_env: {}
   context_vars:
     - STREAMING_BENCHMARK_MAX_SAMPLES
   variant: "stream"

--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -126,7 +126,6 @@ jobs:
           pytest tests/test_model/test_qwen3_omni_tts_ci.py -v -s -x
         env:
           HF_ENDPOINT: https://hf-mirror.com
-          SGLANG_SEEDTTS50_DIR: /github/home/seedtts-50
           SEEDTTS_SIM_CACHE_DIR: /github/home/seedtts-wavlm-sim
           TORCHINDUCTOR_CACHE_DIR: /github/home/.torchinductor
 

--- a/.github/workflows/test-s2pro-ci.yaml
+++ b/.github/workflows/test-s2pro-ci.yaml
@@ -101,7 +101,6 @@ jobs:
           pytest tests/test_model/test_s2pro_tts_ci.py -v -s -x --concurrency 16 --s2pro-stage s2pro-stage-1-nonstream
         env:
           HF_ENDPOINT: https://hf-mirror.com
-          SGLANG_SEEDTTS50_DIR: /github/home/seedtts-50
           SEEDTTS_SIM_CACHE_DIR: /github/home/seedtts-wavlm-sim
           S2PRO_STAGE_OUTPUT_ROOT: ${{ github.workspace }}/stage-results/nonstream
           TORCHINDUCTOR_CACHE_DIR: /github/home/.torchinductor
@@ -144,7 +143,6 @@ jobs:
           pytest tests/test_model/test_s2pro_tts_ci.py -v -s -x --concurrency 16 --s2pro-stage s2pro-stage-2-stream
         env:
           HF_ENDPOINT: https://hf-mirror.com
-          SGLANG_SEEDTTS50_DIR: /github/home/seedtts-50
           S2PRO_STAGE_OUTPUT_ROOT: ${{ github.workspace }}/stage-results/stream
           TORCHINDUCTOR_CACHE_DIR: /github/home/.torchinductor
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -44,26 +44,26 @@ python -m sglang_omni.cli serve \
 
 # 2a. S2-Pro — full pipeline: generate + WER (server needed for phase 1 only)
 python -m benchmarks.eval.benchmark_tts_seedtts \
-    --meta seedtts_testset/en/meta.lst \
+    --meta zhaochenyang20/seed-tts-eval-arrow \
     --model fishaudio/s2-pro --port 8000 \
     --output-dir results/s2pro_en --lang en --max-samples 50 --concurrency 8
 
 # 2b. S2-Pro — generate only (speed metrics, no transcription)
 python -m benchmarks.eval.benchmark_tts_seedtts \
     --generate-only --stream \
-    --meta seedtts_testset/en/meta.lst \
+    --meta zhaochenyang20/seed-tts-eval-arrow \
     --model fishaudio/s2-pro --port 8000 --max-samples 50 --concurrency 8
 
 # 2c. S2-Pro — transcribe only (reuses audio from a prior generate run; no server)
 python -m benchmarks.eval.benchmark_tts_seedtts \
     --transcribe-only \
-    --meta seedtts_testset/en/meta.lst \
+    --meta zhaochenyang20/seed-tts-eval-arrow \
     --model fishaudio/s2-pro \
     --output-dir results/s2pro_en --lang en --device cuda:0
 
 # 2d. Voxtral — full pipeline without voice cloning
 python -m benchmarks.eval.benchmark_tts_seedtts \
-    --meta seedtts_testset/en/meta.lst \
+    --meta zhaochenyang20/seed-tts-eval-arrow \
     --model mistralai/Voxtral-4B-TTS-2603 --port 8000 \
     --max-concurrency 16 \
     --output-dir results/voxtral_en --lang en --max-samples 50 \
@@ -71,7 +71,7 @@ python -m benchmarks.eval.benchmark_tts_seedtts \
 
 # 3a. Qwen3-Omni — full pipeline (generate + transcribe)
 python -m benchmarks.eval.benchmark_omni_seedtts \
-    --meta seedtts_testset/en/meta.lst \
+    --meta zhaochenyang20/seed-tts-eval-arrow \
     --output-dir results/qwen3_omni_en \
     --max-concurrency 16 \
     --model qwen3-omni --port 8000 --max-samples 50
@@ -79,7 +79,7 @@ python -m benchmarks.eval.benchmark_omni_seedtts \
 # 3b. Qwen3-Omni — generate only (server required; use in CI to split phases)
 python -m benchmarks.eval.benchmark_omni_seedtts \
     --generate-only \
-    --meta seedtts_testset/en/meta.lst \
+    --meta zhaochenyang20/seed-tts-eval-arrow \
     --output-dir results/qwen3_omni_en \
     --max-concurrency 16 \
     --model qwen3-omni --port 8000 --max-samples 50
@@ -87,7 +87,7 @@ python -m benchmarks.eval.benchmark_omni_seedtts \
 # 3c. Qwen3-Omni — transcribe only (reuses audio; no server)
 python -m benchmarks.eval.benchmark_omni_seedtts \
     --transcribe-only \
-    --meta seedtts_testset/en/meta.lst \
+    --meta zhaochenyang20/seed-tts-eval-arrow \
     --output-dir results/qwen3_omni_en \
     --model qwen3-omni --lang en --device cuda:0
 
@@ -165,10 +165,9 @@ python -m benchmarks.dataset.prepare --dataset videomme      # full Video-MME
 python -m benchmarks.dataset.prepare --dataset videoamme-ci-50  # Video-AMME CI subset
 ```
 
-SeedTTS datasets are materialized into `./seedtts_testset/` (override with
-`--local-dir`). MMMU/MMSU/Video-MME/Video-AMME datasets are pre-warmed into the
-default HuggingFace cache and then consumed via `datasets.load_dataset(repo_id)`,
-so `--local-dir` is a no-op for them.
+All datasets are pre-warmed into the default HuggingFace cache via
+`datasets.load_dataset(repo_id)`.  SeedTTS Arrow repos stage audio to
+process-local tempfiles at load time; no manual `--local-dir` step is needed.
 
 Video-AMME is generated from the Video-MME CI subset by moving the
 question/options/instruction into per-sample WAV files. The benchmark request

--- a/benchmarks/dataset/prepare.py
+++ b/benchmarks/dataset/prepare.py
@@ -38,11 +38,18 @@ DATASETS: dict[str, str] = {
 
 def download_dataset(repo_id: str, *, quiet: bool = False) -> None:
     """Pre-warm the HuggingFace ``datasets`` cache for *repo_id*."""
-    from datasets import load_dataset
+    from datasets import get_dataset_config_names, load_dataset
 
     if not quiet:
         logger.info(f"Pre-warming HuggingFace cache for {repo_id} ...")
-    load_dataset(repo_id)
+
+    if repo_id == "MMMU/MMMU":
+        config_names = get_dataset_config_names(repo_id)
+        for config_name in config_names:
+            load_dataset(repo_id, config_name, split="validation")
+    else:
+        load_dataset(repo_id)
+
     if not quiet:
         logger.info(f"Dataset {repo_id} cached.")
 

--- a/benchmarks/dataset/prepare.py
+++ b/benchmarks/dataset/prepare.py
@@ -2,12 +2,9 @@
 """Dataset download helpers.
 
 Usage:
-    # SeedTTS family (downloads into ./seedtts_testset by default)
     python -m benchmarks.dataset.prepare --dataset seedtts
     python -m benchmarks.dataset.prepare --dataset seedtts-mini
     python -m benchmarks.dataset.prepare --dataset seedtts-50
-
-    # MMMU / MMSU / Video-MME / Video-AMME (pre-warm the HuggingFace datasets cache)
     python -m benchmarks.dataset.prepare --dataset mmmu
     python -m benchmarks.dataset.prepare --dataset mmmu-ci-50
     python -m benchmarks.dataset.prepare --dataset mmsu
@@ -21,15 +18,13 @@ from __future__ import annotations
 
 import argparse
 import logging
-import os
-import subprocess
 
 logger = logging.getLogger(__name__)
 
 DATASETS: dict[str, str] = {
-    "seedtts": "zhaochenyang20/seed-tts-eval",
-    "seedtts-mini": "zhaochenyang20/seed-tts-eval-mini",
-    "seedtts-50": "zhaochenyang20/seed-tts-eval-50",
+    "seedtts": "zhaochenyang20/seed-tts-eval-arrow",
+    "seedtts-mini": "zhaochenyang20/seed-tts-eval-mini-arrow",
+    "seedtts-50": "zhaochenyang20/seed-tts-eval-50-arrow",
     "mmmu": "MMMU/MMMU",
     "mmmu-ci-50": "zhaochenyang20/mmmu-ci-50",
     "mmsu": "ddwang2000/MMSU",
@@ -40,56 +35,16 @@ DATASETS: dict[str, str] = {
     "videoamme-ci-50": "zhaochenyang20/Video_AMME_ci",
 }
 
-_CLI_LOCAL_DIRS: dict[str, str] = {
-    "seedtts": "seedtts_testset",
-    "seedtts-mini": "seedtts_testset",
-    "seedtts-50": "seedtts_testset",
-}
 
-_SEEDTTS_EXISTENCE_MARKER = "en/meta.lst"
-
-
-def download_dataset(
-    repo_id: str,
-    local_dir: str | None = "seedtts_testset",
-    *,
-    existence_marker: str | None = _SEEDTTS_EXISTENCE_MARKER,
-    quiet: bool = False,
-) -> None:
-    """Download a HuggingFace dataset."""
-    if local_dir is not None and existence_marker:
-        marker_path = os.path.join(local_dir, existence_marker)
-        if os.path.exists(marker_path):
-            if not quiet:
-                logger.info(
-                    f"Dataset already exists at {local_dir}, skipping download."
-                )
-            return
+def download_dataset(repo_id: str, *, quiet: bool = False) -> None:
+    """Pre-warm the HuggingFace ``datasets`` cache for *repo_id*."""
+    from datasets import load_dataset
 
     if not quiet:
-        where = local_dir if local_dir is not None else "HuggingFace cache"
-        logger.info(f"Downloading {repo_id} to {where} ...")
-
-    cmd = [
-        "huggingface-cli",
-        "download",
-        repo_id,
-        "--repo-type",
-        "dataset",
-    ]
-    if local_dir is not None:
-        cmd += ["--local-dir", local_dir]
-
-    try:
-        subprocess.run(cmd, check=True, capture_output=quiet, text=True)
-    except subprocess.CalledProcessError as exc:
-        raise RuntimeError(
-            f"Failed to download dataset {repo_id}.\n"
-            f"stdout:\n{exc.stdout}\n"
-            f"stderr:\n{exc.stderr}"
-        ) from exc
+        logger.info(f"Pre-warming HuggingFace cache for {repo_id} ...")
+    load_dataset(repo_id)
     if not quiet:
-        logger.info(f"Dataset {repo_id} ready.")
+        logger.info(f"Dataset {repo_id} cached.")
 
 
 def main() -> None:
@@ -100,27 +55,10 @@ def main() -> None:
         default="seedtts",
         help="Dataset to download.",
     )
-    parser.add_argument(
-        "--local-dir",
-        default=None,
-        help="Override local directory for seedtts-family datasets. "
-        "Ignored for datasets that are pulled into the HuggingFace cache.",
-    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)
-
-    repo_id = DATASETS[args.dataset]
-    default_local_dir = _CLI_LOCAL_DIRS.get(args.dataset)
-    local_dir = args.local_dir or default_local_dir
-    existence_marker = (
-        _SEEDTTS_EXISTENCE_MARKER if args.dataset in _CLI_LOCAL_DIRS else None
-    )
-    download_dataset(
-        repo_id,
-        local_dir,
-        existence_marker=existence_marker,
-    )
+    download_dataset(DATASETS[args.dataset])
 
 
 if __name__ == "__main__":

--- a/benchmarks/dataset/seedtts.py
+++ b/benchmarks/dataset/seedtts.py
@@ -1,16 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 """SeedTTS dataset loader.
 
-Loads samples from HuggingFace Arrow/Parquet repos (e.g.
-``zhaochenyang20/seed-tts-eval-50-arrow``).  Audio bytes are staged to a
-process-scoped temporary directory so that downstream consumers (which
-expect filesystem paths) work unchanged.
+Supports two source formats:
+- Local ``meta.lst`` files (pipe-delimited: ``id|ref_text|ref_audio_path|target_text``)
+- HuggingFace Arrow/Parquet repos (e.g. ``zhaochenyang20/seed-tts-eval-50-arrow``)
+
+Arrow datasets stage WAV bytes to a process-scoped temporary directory so that
+downstream consumers (which expect filesystem paths) work unchanged.
 """
 
 from __future__ import annotations
 
 import atexit
 import logging
+import os
 import shutil
 import tempfile
 from dataclasses import dataclass
@@ -29,20 +32,64 @@ class SampleInput:
     target_text: str
 
 
-_STAGED_CACHE: dict[tuple[str, str], list[SampleInput]] = {}
+_STAGED_CACHE: dict[tuple[str, str, int | None], list[SampleInput]] = {}
 
 
 def load_seedtts_samples(
-    repo_id: str,
+    source: str,
     max_samples: int | None = None,
     *,
     split: str = "en",
 ) -> list[SampleInput]:
-    """Load SeedTTS evaluation samples from a HuggingFace Arrow dataset."""
-    cache_key = (repo_id, split)
+    """Load SeedTTS evaluation samples.
+
+    *source* is either a local ``meta.lst`` file path or a HuggingFace dataset
+    repo id (e.g. ``zhaochenyang20/seed-tts-eval-50-arrow``).  When a repo id
+    is given, the dataset is fetched via ``datasets.load_dataset`` and audio
+    bytes are staged to a temporary directory.
+    """
+    if os.path.isfile(source) or source.endswith(".lst"):
+        return _load_from_meta_lst(source, max_samples)
+    return _load_from_arrow(source, split, max_samples)
+
+
+def _load_from_meta_lst(path: str, max_samples: int | None) -> list[SampleInput]:
+    """Legacy loader: parse a pipe-delimited meta.lst file."""
+    base_dir = os.path.dirname(path)
+    samples: list[SampleInput] = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split("|")
+            if len(parts) < 4:
+                continue
+            samples.append(
+                SampleInput(
+                    sample_id=parts[0],
+                    ref_text=parts[1],
+                    ref_audio=os.path.join(base_dir, parts[2]),
+                    target_text=parts[3],
+                )
+            )
+            if max_samples is not None and len(samples) >= max_samples:
+                break
+    return samples
+
+
+def _load_from_arrow(
+    repo_id: str, split: str, max_samples: int | None
+) -> list[SampleInput]:
+    """Load from a HuggingFace Arrow/Parquet dataset repo."""
+    full_cache_key = (repo_id, split, None)
+    if full_cache_key in _STAGED_CACHE:
+        samples = _STAGED_CACHE[full_cache_key]
+        return samples[:max_samples] if max_samples is not None else list(samples)
+
+    cache_key = (repo_id, split, max_samples)
     if cache_key in _STAGED_CACHE:
-        samples = _STAGED_CACHE[cache_key]
-        return samples[:max_samples] if max_samples else list(samples)
+        return list(_STAGED_CACHE[cache_key])
 
     from datasets import Audio, load_dataset
 
@@ -56,6 +103,8 @@ def load_seedtts_samples(
         )
 
     ds = ds.cast_column("ref_audio", Audio(decode=False))
+    if max_samples is not None:
+        ds = ds.select(list(range(min(max_samples, len(ds)))))
 
     tmpdir = Path(tempfile.mkdtemp(prefix=f"seedtts_{split}_"))
     atexit.register(shutil.rmtree, str(tmpdir), True)
@@ -93,4 +142,4 @@ def load_seedtts_samples(
         "Loaded %d samples (%d unique audio files) from %s/%s",
         len(samples), len(written), repo_id, split,
     )
-    return samples[:max_samples] if max_samples else list(samples)
+    return list(samples)

--- a/benchmarks/dataset/seedtts.py
+++ b/benchmarks/dataset/seedtts.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""SeedTTS dataset loader for HuggingFace Arrow/Parquet repos.
+"""SeedTTS dataset loader for local meta.lst and HuggingFace Arrow/Parquet repos.
 
 Audio bytes are staged to a process-scoped temporary directory so downstream
-consumers (which expect filesystem paths) work unchanged.
+consumers (which expect filesystem paths) work unchanged for Arrow/Parquet
+sources. Local meta.lst files already point at local audio paths.
 """
 
 from __future__ import annotations
@@ -82,17 +83,43 @@ def load_seedtts_samples(
 ) -> list[SampleInput]:
     """Load SeedTTS evaluation samples.
 
-    *source* must be a HuggingFace dataset repo id (e.g.
-    ``zhaochenyang20/seed-tts-eval-50-arrow``). The dataset is fetched via
-    ``datasets.load_dataset`` and audio bytes are staged to a temporary
-    directory.
+    *source* may be either a local ``meta.lst`` file in seed-tts-eval format or
+    a HuggingFace dataset repo id (e.g.
+    ``zhaochenyang20/seed-tts-eval-50-arrow``). Arrow/Parquet datasets are
+    fetched via ``datasets.load_dataset`` and audio bytes are staged to a
+    temporary directory.
     """
     if os.path.isfile(source) or source.endswith(".lst"):
-        raise ValueError(
-            "Local SeedTTS meta.lst files are no longer supported. "
-            "Pass a HuggingFace Arrow/Parquet dataset repo id instead."
-        )
+        return _load_from_meta_lst(source, max_samples)
     return _load_from_arrow(source, split, max_samples)
+
+
+def _load_from_meta_lst(path: str, max_samples: int | None) -> list[SampleInput]:
+    """Parse a local seed-tts-eval meta.lst file."""
+    if max_samples is not None and max_samples <= 0:
+        return []
+
+    base_dir = os.path.dirname(path)
+    samples: list[SampleInput] = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split("|")
+            if len(parts) < 4:
+                continue
+            samples.append(
+                SampleInput(
+                    sample_id=parts[0],
+                    ref_text=parts[1],
+                    ref_audio=os.path.join(base_dir, parts[2]),
+                    target_text=parts[3],
+                )
+            )
+            if max_samples is not None and len(samples) >= max_samples:
+                break
+    return samples
 
 
 def _load_from_arrow(

--- a/benchmarks/dataset/seedtts.py
+++ b/benchmarks/dataset/seedtts.py
@@ -21,7 +21,13 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-_REQUIRED_COLUMNS = {"sample_id", "ref_text", "ref_audio_path", "target_text", "ref_audio"}
+_REQUIRED_COLUMNS = {
+    "sample_id",
+    "ref_text",
+    "ref_audio_path",
+    "target_text",
+    "ref_audio",
+}
 
 
 @dataclass
@@ -140,6 +146,9 @@ def _load_from_arrow(
     _STAGED_CACHE[cache_key] = samples
     logger.info(
         "Loaded %d samples (%d unique audio files) from %s/%s",
-        len(samples), len(written), repo_id, split,
+        len(samples),
+        len(written),
+        repo_id,
+        split,
     )
     return list(samples)

--- a/benchmarks/dataset/seedtts.py
+++ b/benchmarks/dataset/seedtts.py
@@ -1,12 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-"""SeedTTS dataset loader.
+"""SeedTTS dataset loader for HuggingFace Arrow/Parquet repos.
 
-Supports two source formats:
-- Local ``meta.lst`` files (pipe-delimited: ``id|ref_text|ref_audio_path|target_text``)
-- HuggingFace Arrow/Parquet repos (e.g. ``zhaochenyang20/seed-tts-eval-50-arrow``)
-
-Arrow datasets stage WAV bytes to a process-scoped temporary directory so that
-downstream consumers (which expect filesystem paths) work unchanged.
+Audio bytes are staged to a process-scoped temporary directory so downstream
+consumers (which expect filesystem paths) work unchanged.
 """
 
 from __future__ import annotations
@@ -17,7 +13,7 @@ import os
 import shutil
 import tempfile
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +37,43 @@ class SampleInput:
 _STAGED_CACHE: dict[tuple[str, str, int | None], list[SampleInput]] = {}
 
 
+def _resolve_staged_audio_path(
+    staging_root: Path,
+    rel_path: str,
+    *,
+    repo_id: str,
+    split: str,
+    sample_id: str,
+) -> Path:
+    raw_path = rel_path.strip() if isinstance(rel_path, str) else ""
+    error_prefix = (
+        f"Invalid ref_audio_path for {repo_id}/{split}/{sample_id}: {rel_path!r}"
+    )
+    if not raw_path:
+        raise ValueError(f"{error_prefix} (empty path)")
+
+    posix_path = PurePosixPath(raw_path)
+    windows_path = PureWindowsPath(raw_path)
+    if (
+        posix_path.is_absolute()
+        or windows_path.is_absolute()
+        or windows_path.drive
+        or windows_path.root
+    ):
+        raise ValueError(f"{error_prefix} (absolute or anchored path)")
+
+    if ".." in posix_path.parts or ".." in windows_path.parts:
+        raise ValueError(f"{error_prefix} (parent traversal)")
+
+    staging_root = staging_root.resolve()
+    wav_path = (staging_root / Path(raw_path)).resolve()
+    try:
+        wav_path.relative_to(staging_root)
+    except ValueError as exc:
+        raise ValueError(f"{error_prefix} (path escapes staging directory)") from exc
+    return wav_path
+
+
 def load_seedtts_samples(
     source: str,
     max_samples: int | None = None,
@@ -49,39 +82,17 @@ def load_seedtts_samples(
 ) -> list[SampleInput]:
     """Load SeedTTS evaluation samples.
 
-    *source* is either a local ``meta.lst`` file path or a HuggingFace dataset
-    repo id (e.g. ``zhaochenyang20/seed-tts-eval-50-arrow``).  When a repo id
-    is given, the dataset is fetched via ``datasets.load_dataset`` and audio
-    bytes are staged to a temporary directory.
+    *source* must be a HuggingFace dataset repo id (e.g.
+    ``zhaochenyang20/seed-tts-eval-50-arrow``). The dataset is fetched via
+    ``datasets.load_dataset`` and audio bytes are staged to a temporary
+    directory.
     """
     if os.path.isfile(source) or source.endswith(".lst"):
-        return _load_from_meta_lst(source, max_samples)
+        raise ValueError(
+            "Local SeedTTS meta.lst files are no longer supported. "
+            "Pass a HuggingFace Arrow/Parquet dataset repo id instead."
+        )
     return _load_from_arrow(source, split, max_samples)
-
-
-def _load_from_meta_lst(path: str, max_samples: int | None) -> list[SampleInput]:
-    """Legacy loader: parse a pipe-delimited meta.lst file."""
-    base_dir = os.path.dirname(path)
-    samples: list[SampleInput] = []
-    with open(path) as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            parts = line.split("|")
-            if len(parts) < 4:
-                continue
-            samples.append(
-                SampleInput(
-                    sample_id=parts[0],
-                    ref_text=parts[1],
-                    ref_audio=os.path.join(base_dir, parts[2]),
-                    target_text=parts[3],
-                )
-            )
-            if max_samples is not None and len(samples) >= max_samples:
-                break
-    return samples
 
 
 def _load_from_arrow(
@@ -118,9 +129,17 @@ def _load_from_arrow(
 
     samples: list[SampleInput] = []
     written: set[str] = set()
+    staging_root = tmpdir.resolve()
 
     for row in ds:
         rel = row["ref_audio_path"]
+        wav_path = _resolve_staged_audio_path(
+            staging_root,
+            rel,
+            repo_id=repo_id,
+            split=split,
+            sample_id=row["sample_id"],
+        )
         audio = row["ref_audio"] or {}
         audio_bytes = audio.get("bytes")
         if not audio_bytes:
@@ -128,11 +147,11 @@ def _load_from_arrow(
                 f"Empty audio bytes for {repo_id}/{split}/{row['sample_id']}"
             )
 
-        wav_path = tmpdir / rel
-        if rel not in written:
+        rel_key = wav_path.relative_to(staging_root).as_posix()
+        if rel_key not in written:
             wav_path.parent.mkdir(parents=True, exist_ok=True)
             wav_path.write_bytes(audio_bytes)
-            written.add(rel)
+            written.add(rel_key)
 
         samples.append(
             SampleInput(

--- a/benchmarks/dataset/seedtts.py
+++ b/benchmarks/dataset/seedtts.py
@@ -1,10 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
-"""SeedTTS dataset loader for seed-tts-eval meta.lst files."""
+"""SeedTTS dataset loader.
+
+Loads samples from HuggingFace Arrow/Parquet repos (e.g.
+``zhaochenyang20/seed-tts-eval-50-arrow``).  Audio bytes are staged to a
+process-scoped temporary directory so that downstream consumers (which
+expect filesystem paths) work unchanged.
+"""
 
 from __future__ import annotations
 
-import os
+import atexit
+import logging
+import shutil
+import tempfile
 from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_REQUIRED_COLUMNS = {"sample_id", "ref_text", "ref_audio_path", "target_text", "ref_audio"}
 
 
 @dataclass
@@ -15,34 +29,68 @@ class SampleInput:
     target_text: str
 
 
+_STAGED_CACHE: dict[tuple[str, str], list[SampleInput]] = {}
+
+
 def load_seedtts_samples(
-    path: str, max_samples: int | None = None
+    repo_id: str,
+    max_samples: int | None = None,
+    *,
+    split: str = "en",
 ) -> list[SampleInput]:
-    """Parse a seed-tts-eval meta.lst file.
+    """Load SeedTTS evaluation samples from a HuggingFace Arrow dataset."""
+    cache_key = (repo_id, split)
+    if cache_key in _STAGED_CACHE:
+        samples = _STAGED_CACHE[cache_key]
+        return samples[:max_samples] if max_samples else list(samples)
 
-    Format per line: ``id|ref_text|ref_audio_path|target_text``
+    from datasets import Audio, load_dataset
 
-    Note (chenyang): Detailed format description could be found at
-    https://huggingface.co/datasets/zhaochenyang20/seed-tts-eval
-    """
-    base_dir = os.path.dirname(path)
+    logger.info("Loading %s split=%s from HuggingFace ...", repo_id, split)
+    ds = load_dataset(repo_id, split=split)
+
+    missing = _REQUIRED_COLUMNS - set(ds.column_names)
+    if missing:
+        raise ValueError(
+            f"Dataset {repo_id} split={split} is missing columns: {missing}"
+        )
+
+    ds = ds.cast_column("ref_audio", Audio(decode=False))
+
+    tmpdir = Path(tempfile.mkdtemp(prefix=f"seedtts_{split}_"))
+    atexit.register(shutil.rmtree, str(tmpdir), True)
+    logger.info("Staging audio to %s", tmpdir)
+
     samples: list[SampleInput] = []
-    with open(path) as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            parts = line.split("|")
-            if len(parts) < 4:
-                continue
-            samples.append(
-                SampleInput(
-                    sample_id=parts[0],
-                    ref_text=parts[1],
-                    ref_audio=os.path.join(base_dir, parts[2]),
-                    target_text=parts[3],
-                )
+    written: set[str] = set()
+
+    for row in ds:
+        rel = row["ref_audio_path"]
+        audio = row["ref_audio"] or {}
+        audio_bytes = audio.get("bytes")
+        if not audio_bytes:
+            raise ValueError(
+                f"Empty audio bytes for {repo_id}/{split}/{row['sample_id']}"
             )
-            if max_samples and len(samples) >= max_samples:
-                break
-    return samples
+
+        wav_path = tmpdir / rel
+        if rel not in written:
+            wav_path.parent.mkdir(parents=True, exist_ok=True)
+            wav_path.write_bytes(audio_bytes)
+            written.add(rel)
+
+        samples.append(
+            SampleInput(
+                sample_id=row["sample_id"],
+                ref_text=row["ref_text"],
+                ref_audio=str(wav_path),
+                target_text=row["target_text"],
+            )
+        )
+
+    _STAGED_CACHE[cache_key] = samples
+    logger.info(
+        "Loaded %d samples (%d unique audio files) from %s/%s",
+        len(samples), len(written), repo_id, split,
+    )
+    return samples[:max_samples] if max_samples else list(samples)

--- a/benchmarks/eval/benchmark_omni_seedtts.py
+++ b/benchmarks/eval/benchmark_omni_seedtts.py
@@ -22,7 +22,7 @@ Usage:
 
     # Full pipeline (generate + transcribe)
     python -m benchmarks.eval.benchmark_omni_seedtts \
-        --meta seedtts_testset/en/meta.lst \
+        --meta zhaochenyang20/seed-tts-eval-arrow \
         --output-dir results/qwen3_omni_en \
         --max-concurrency 16 \
         --model qwen3-omni --port 8000 --max-samples 50
@@ -32,7 +32,7 @@ CI Usage:
     # Generate audio only (server must be running)
     python -m benchmarks.eval.benchmark_omni_seedtts \
         --generate-only \
-        --meta seedtts_testset/en/meta.lst \
+        --meta zhaochenyang20/seed-tts-eval-arrow \
         --output-dir results/qwen3_omni_en \
         --max-concurrency 16 \
         --model qwen3-omni --port 8000 --max-samples 50
@@ -40,7 +40,7 @@ CI Usage:
     # Transcribe + WER only (server not needed)
     python -m benchmarks.eval.benchmark_omni_seedtts \
         --transcribe-only \
-        --meta seedtts_testset/en/meta.lst \
+        --meta zhaochenyang20/seed-tts-eval-arrow \
         --output-dir results/qwen3_omni_en \
         --model qwen3-omni --lang en --device cuda:0
 
@@ -303,13 +303,10 @@ async def run_omni_seedtts_benchmark(
 
     Returns a dict with keys: summary, per_request, config.
     """
-    if not os.path.isfile(config.meta):
-        raise FileNotFoundError(f"Meta file not found: {config.meta}")
-
     base_url = build_base_url(config)
     api_url = f"{base_url}/v1/chat/completions"
 
-    samples = load_seedtts_samples(config.meta, config.max_samples)
+    samples = load_seedtts_samples(config.meta, config.max_samples, split=config.lang)
     logger.info(f"Prepared {len(samples)} requests")
 
     save_audio_dir = os.path.abspath(os.path.join(config.output_dir, "audio"))
@@ -429,8 +426,8 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "--testset",
         dest="meta",
         type=str,
-        default="seedtts_testset/en/meta.lst",
-        help="Path to a meta.lst file (seed-tts-eval format).",
+        default="zhaochenyang20/seed-tts-eval-arrow",
+        help="HuggingFace dataset repo id or path to a local meta.lst file.",
     )
     parser.add_argument(
         "--lang",

--- a/benchmarks/eval/benchmark_omni_seedtts.py
+++ b/benchmarks/eval/benchmark_omni_seedtts.py
@@ -427,7 +427,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         dest="meta",
         type=str,
         default="zhaochenyang20/seed-tts-eval-arrow",
-        help="HuggingFace dataset repo id or path to a local meta.lst file.",
+        help="HuggingFace Arrow/Parquet dataset repo id.",
     )
     parser.add_argument(
         "--lang",

--- a/benchmarks/eval/benchmark_omni_seedtts.py
+++ b/benchmarks/eval/benchmark_omni_seedtts.py
@@ -427,7 +427,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         dest="meta",
         type=str,
         default="zhaochenyang20/seed-tts-eval-arrow",
-        help="HuggingFace Arrow/Parquet dataset repo id.",
+        help="HuggingFace Arrow/Parquet dataset repo id or local meta.lst path.",
     )
     parser.add_argument(
         "--lang",

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -360,7 +360,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         dest="meta",
         type=str,
         default="zhaochenyang20/seed-tts-eval-arrow",
-        help="HuggingFace dataset repo id or path to a local meta.lst file.",
+        help="HuggingFace Arrow/Parquet dataset repo id.",
     )
     parser.add_argument(
         "--no-ref-audio",

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -360,7 +360,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         dest="meta",
         type=str,
         default="zhaochenyang20/seed-tts-eval-arrow",
-        help="HuggingFace Arrow/Parquet dataset repo id.",
+        help="HuggingFace Arrow/Parquet dataset repo id or local meta.lst path.",
     )
     parser.add_argument(
         "--no-ref-audio",

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -26,13 +26,13 @@ Usage:
 
     # Full pipeline (generate + transcribe) — voice cloning
     python -m benchmarks.eval.benchmark_tts_seedtts \
-        --meta seedtts_testset/en/meta.lst \
+        --meta zhaochenyang20/seed-tts-eval-arrow \
         --max-concurrency 16 \
         --model fishaudio/s2-pro --port 8000
 
     # Full pipeline — plain TTS (no ref audio from testset)
     python -m benchmarks.eval.benchmark_tts_seedtts \
-        --meta seedtts_testset/en/meta.lst \
+        --meta zhaochenyang20/seed-tts-eval-arrow \
         --model mistralai/Voxtral-4B-TTS-2603 --port 8000 \
         --max-concurrency 16 \
         --no-ref-audio --voice cheerful_female --max-samples 50
@@ -44,7 +44,7 @@ Usage (CI):
     # Generate audio only
     python -m benchmarks.eval.benchmark_tts_seedtts \
         --generate-only \
-        --meta seedtts_testset/en/meta.lst \
+        --meta zhaochenyang20/seed-tts-eval-arrow \
         --max-concurrency 16 \
         --output-dir results/s2pro_en \
         --model fishaudio/s2-pro --port 8000
@@ -52,7 +52,7 @@ Usage (CI):
     # Transcribe + WER only
     python -m benchmarks.eval.benchmark_tts_seedtts \
         --transcribe-only \
-        --meta seedtts_testset/en/meta.lst \
+        --meta zhaochenyang20/seed-tts-eval-arrow \
         --model fishaudio/s2-pro \
         --output-dir results/s2pro_en \
         --lang en --device cuda:0
@@ -224,13 +224,10 @@ async def run_tts_seedtts_benchmark(
 
     Returns a dict with keys: summary, per_request, config.
     """
-    if not os.path.isfile(config.meta):
-        raise FileNotFoundError(f"Meta file not found: {config.meta}")
-
     base_url = build_base_url(config)
     api_url = f"{base_url}/v1/audio/speech"
 
-    samples = load_seedtts_samples(config.meta, config.max_samples)
+    samples = load_seedtts_samples(config.meta, config.max_samples, split=config.lang)
     logger.info(f"Prepared {len(samples)} requests")
 
     save_audio_dir = os.path.abspath(os.path.join(config.output_dir, "audio"))
@@ -362,8 +359,8 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "--testset",
         dest="meta",
         type=str,
-        default="seedtts_testset/en/meta.lst",
-        help="Path to a meta.lst file (seed-tts-eval format).",
+        default="zhaochenyang20/seed-tts-eval-arrow",
+        help="HuggingFace dataset repo id or path to a local meta.lst file.",
     )
     parser.add_argument(
         "--no-ref-audio",

--- a/benchmarks/tasks/tts.py
+++ b/benchmarks/tasks/tts.py
@@ -334,7 +334,7 @@ def run_seedtts_similarity(
         generated: list[dict] = json.load(f)
     logger.info(f"Loaded {len(generated)} entries from {generated_path}")
 
-    split = getattr(config, "lang", "en")
+    split = config.lang
     ref_audio_by_id = {
         sample.sample_id: sample.ref_audio
         for sample in load_seedtts_samples(config.meta, split=split)

--- a/benchmarks/tasks/tts.py
+++ b/benchmarks/tasks/tts.py
@@ -316,6 +316,7 @@ class SeedttsSimilarityConfig(Protocol):
 
     model: str
     meta: str
+    lang: str
     output_dir: str
     device: str
     similarity_checkpoint: str | None
@@ -333,9 +334,10 @@ def run_seedtts_similarity(
         generated: list[dict] = json.load(f)
     logger.info(f"Loaded {len(generated)} entries from {generated_path}")
 
+    split = getattr(config, "lang", "en")
     ref_audio_by_id = {
         sample.sample_id: sample.ref_audio
-        for sample in load_seedtts_samples(config.meta)
+        for sample in load_seedtts_samples(config.meta, split=split)
     }
     device = config.device
     if "cuda" in device:

--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -232,7 +232,7 @@ Run EN and ZH after launching the target server on port 8000. Do not add benchma
 
 ```bash
 python -m benchmarks.eval.benchmark_tts_seedtts \
-  --meta seedtts_testset/en/meta.lst \
+  --meta zhaochenyang20/seed-tts-eval-arrow \
   --model Qwen/Qwen3-TTS-12Hz-0.6B-Base \
   --port 8000 \
   --output-dir results/qwen3_tts_0_6b_en \
@@ -240,7 +240,7 @@ python -m benchmarks.eval.benchmark_tts_seedtts \
   --max-concurrency 16
 
 python -m benchmarks.eval.benchmark_tts_seedtts \
-  --meta seedtts_testset/zh/meta.lst \
+  --meta zhaochenyang20/seed-tts-eval-arrow \
   --model Qwen/Qwen3-TTS-12Hz-0.6B-Base \
   --port 8000 \
   --output-dir results/qwen3_tts_0_6b_zh \
@@ -248,7 +248,7 @@ python -m benchmarks.eval.benchmark_tts_seedtts \
   --max-concurrency 16
 
 python -m benchmarks.eval.benchmark_tts_seedtts \
-  --meta seedtts_testset/en/meta.lst \
+  --meta zhaochenyang20/seed-tts-eval-arrow \
   --model Qwen/Qwen3-TTS-12Hz-1.7B-Base \
   --port 8000 \
   --output-dir results/qwen3_tts_1_7b_en \
@@ -256,7 +256,7 @@ python -m benchmarks.eval.benchmark_tts_seedtts \
   --max-concurrency 16
 
 python -m benchmarks.eval.benchmark_tts_seedtts \
-  --meta seedtts_testset/zh/meta.lst \
+  --meta zhaochenyang20/seed-tts-eval-arrow \
   --model Qwen/Qwen3-TTS-12Hz-1.7B-Base \
   --port 8000 \
   --output-dir results/qwen3_tts_1_7b_zh \
@@ -264,7 +264,7 @@ python -m benchmarks.eval.benchmark_tts_seedtts \
   --max-concurrency 16
 
 python -m benchmarks.eval.benchmark_tts_seedtts \
-  --meta seedtts_testset/en/meta.lst \
+  --meta zhaochenyang20/seed-tts-eval-arrow \
   --model mistralai/Voxtral-4B-TTS-2603 \
   --port 8000 \
   --output-dir results/voxtral_en \
@@ -275,7 +275,7 @@ python -m benchmarks.eval.benchmark_tts_seedtts \
   --voice cheerful_female
 
 python -m benchmarks.eval.benchmark_tts_seedtts \
-  --meta seedtts_testset/zh/meta.lst \
+  --meta zhaochenyang20/seed-tts-eval-arrow \
   --model mistralai/Voxtral-4B-TTS-2603 \
   --port 8000 \
   --output-dir results/voxtral_zh \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "safetensors>=0.4.3",     # Direct weight loading
     "pillow>=10.0.0",         # Required by AutoImageProcessor
     "huggingface-hub>=0.36.0",# HF model downloads
+    "datasets>=2.14.0",       # Arrow-based SeedTTS dataset loading
     "fastapi>=0.110.0",       # OpenAI-compatible API adapter
     "uvicorn>=0.23.0",        # ASGI server for FastAPI
     "sglang==0.5.8",

--- a/tests/test_model/run_ming_tp4.py
+++ b/tests/test_model/run_ming_tp4.py
@@ -111,7 +111,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--tts-meta",
         default="zhaochenyang20/seed-tts-eval-arrow",
-        help="HuggingFace dataset repo id or path to a local meta.lst file.",
+        help="HuggingFace Arrow/Parquet dataset repo id.",
     )
     parser.add_argument("--tts-lang", choices=["en", "zh"], default="en")
     parser.add_argument(

--- a/tests/test_model/run_ming_tp4.py
+++ b/tests/test_model/run_ming_tp4.py
@@ -111,7 +111,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--tts-meta",
         default="zhaochenyang20/seed-tts-eval-arrow",
-        help="HuggingFace Arrow/Parquet dataset repo id.",
+        help="HuggingFace Arrow/Parquet dataset repo id or local meta.lst path.",
     )
     parser.add_argument("--tts-lang", choices=["en", "zh"], default="en")
     parser.add_argument(

--- a/tests/test_model/run_ming_tp4.py
+++ b/tests/test_model/run_ming_tp4.py
@@ -110,8 +110,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--tts-max-concurrency", type=int, default=1)
     parser.add_argument(
         "--tts-meta",
-        default="seedtts_testset/en/meta.lst",
-        help="Path to a seed-tts-eval meta.lst file.",
+        default="zhaochenyang20/seed-tts-eval-arrow",
+        help="HuggingFace dataset repo id or path to a local meta.lst file.",
     )
     parser.add_argument("--tts-lang", choices=["en", "zh"], default="en")
     parser.add_argument(

--- a/tests/test_model/test_qwen3_omni_tts_ci.py
+++ b/tests/test_model/test_qwen3_omni_tts_ci.py
@@ -47,7 +47,6 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 CONCURRENCY = 16
 MAX_SAMPLES = 50
-DATASET_CACHE_ENV = "SGLANG_SEEDTTS50_DIR"
 # Optional user override: a path to a custom fine-tuned WavLM checkpoint.
 # When unset, the bootstrapper in benchmarks.metrics.speaker_similarity_assets
 # auto-downloads the official weights into the shared cache directory.
@@ -116,7 +115,7 @@ def _run_benchmark(
 
 
 def _run_wer_transcribe(
-    meta_path: str,
+    meta: str,
     output_dir: str,
     lang: str = "en",
     device: str = "cuda:0",
@@ -134,7 +133,7 @@ def _run_wer_transcribe(
         "benchmarks.eval.benchmark_omni_seedtts",
         "--transcribe-only",
         "--meta",
-        meta_path,
+        meta,
         "--output-dir",
         output_dir,
         "--model",
@@ -190,7 +189,7 @@ def _run_wer_transcribe(
 
 
 def _run_similarity(
-    meta_path: str,
+    meta: str,
     output_dir: str,
     checkpoint_path: str | None,
     *,
@@ -203,7 +202,7 @@ def _run_similarity(
         "benchmarks.eval.benchmark_omni_seedtts",
         "--similarity-only",
         "--meta",
-        meta_path,
+        meta,
         "--output-dir",
         output_dir,
         "--model",
@@ -260,14 +259,10 @@ def _assert_similarity_results(results: dict, min_mean: float) -> None:
 
 
 @pytest.fixture(scope="module")
-def dataset_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    override_dir = os.environ.get(DATASET_CACHE_ENV)
-    if override_dir:
-        root = Path(override_dir).expanduser()
-    else:
-        root = tmp_path_factory.mktemp("seed_tts_eval") / "data"
-    download_dataset(DATASETS["seedtts-50"], str(root), quiet=True)
-    return root
+def dataset_repo() -> str:
+    repo_id = DATASETS["seedtts-50"]
+    download_dataset(repo_id, quiet=True)
+    return repo_id
 
 
 @pytest.fixture(scope="module")
@@ -297,7 +292,7 @@ class _SpeedArtifacts:
 @pytest.fixture(scope="module")
 def speed_artifacts(
     qwen3_omni_router_server: ManagedRouterHandle,
-    dataset_dir: Path,
+    dataset_repo: str,
     tmp_path_factory: pytest.TempPathFactory,
 ) -> _SpeedArtifacts:
     """Run the speed benchmark once and expose its artifacts."""
@@ -314,7 +309,7 @@ def speed_artifacts(
 
         results = _run_benchmark(
             qwen3_omni_router_server.port,
-            str(dataset_dir / "en" / "meta.lst"),
+            dataset_repo,
             output_dir,
         )
     except Exception:
@@ -378,10 +373,10 @@ def test_voice_cloning_non_streaming(
 def test_voice_cloning_wer(
     qwen3_omni_router_server: ManagedRouterHandle,
     wer_audio_dir: str,
-    dataset_dir: Path,
+    dataset_repo: str,
 ) -> None:
     results = _run_wer_transcribe(
-        str(dataset_dir / "en" / "meta.lst"),
+        dataset_repo,
         wer_audio_dir,
     )
     print_wer_summary(results["summary"], "qwen3-omni")
@@ -396,7 +391,7 @@ def test_voice_cloning_wer(
 @pytest.mark.benchmark
 def test_voice_cloning_similarity(
     wer_audio_dir: str,
-    dataset_dir: Path,
+    dataset_repo: str,
     similarity_checkpoint: str | None,
 ) -> None:
     """Speaker similarity for Qwen3-Omni voice-clone output.
@@ -414,7 +409,7 @@ def test_voice_cloning_similarity(
     ``_assert_similarity_results(results, VC_SIMILARITY_MEAN_MIN)``.
     """
     results = _run_similarity(
-        str(dataset_dir / "en" / "meta.lst"),
+        dataset_repo,
         wer_audio_dir,
         similarity_checkpoint,
     )

--- a/tests/test_model/test_s2pro_tts_ci.py
+++ b/tests/test_model/test_s2pro_tts_ci.py
@@ -72,7 +72,6 @@ STARTUP_TIMEOUT = 180
 BENCHMARK_TIMEOUT = 600
 WER_TIMEOUT = 600
 SIMILARITY_TIMEOUT = 600
-DATASET_CACHE_ENV = "SGLANG_SEEDTTS50_DIR"
 # Optional user override: a path to a custom fine-tuned WavLM checkpoint.
 # When unset, the bootstrapper in benchmarks.metrics.speaker_similarity_assets
 # auto-downloads the official weights into the shared cache directory.
@@ -178,7 +177,7 @@ def _run_benchmark(
 
 
 def _run_wer_transcribe(
-    meta_path: str,
+    meta: str,
     output_dir: str,
     *,
     stream: bool = False,
@@ -192,7 +191,7 @@ def _run_wer_transcribe(
         WER_MODULE,
         "--transcribe-only",
         "--meta",
-        meta_path,
+        meta,
         "--output-dir",
         output_dir,
         "--model",
@@ -246,7 +245,7 @@ def _run_wer_transcribe(
 
 
 def _run_similarity(
-    meta_path: str,
+    meta: str,
     output_dir: str,
     checkpoint_path: str | None,
     *,
@@ -259,7 +258,7 @@ def _run_similarity(
         WER_MODULE,
         "--similarity-only",
         "--meta",
-        meta_path,
+        meta,
         "--output-dir",
         output_dir,
         "--model",
@@ -409,7 +408,7 @@ def _generate_consistency_inputs(
     # started when stage 3 actually needs to generate its own inputs (local
     # dev path).  In CI the artifact path returns early above.
     router_server = request.getfixturevalue("router_server")
-    dataset_dir = request.getfixturevalue("dataset_dir")
+    dataset_repo = request.getfixturevalue("dataset_repo")
     output_root = tmp_path_factory.mktemp("s2pro_consistency")
     for concurrency in selected_s2pro_tts_concurrencies:
         non_stream_key = f"vc_nonstream_c{concurrency}"
@@ -419,7 +418,7 @@ def _generate_consistency_inputs(
             output_dir = str(output_root / f"vc_nonstream_c{concurrency}")
             results = _run_benchmark(
                 router_server.port,
-                str(dataset_dir / "en" / "meta.lst"),
+                dataset_repo,
                 output_dir,
                 concurrency=concurrency,
             )
@@ -434,7 +433,7 @@ def _generate_consistency_inputs(
             output_dir = str(output_root / f"vc_stream_c{concurrency}")
             results = _run_benchmark(
                 router_server.port,
-                str(dataset_dir / "en" / "meta.lst"),
+                dataset_repo,
                 output_dir,
                 concurrency=concurrency,
                 max_samples=STREAMING_BENCHMARK_MAX_SAMPLES,
@@ -465,14 +464,10 @@ def _print_stage(stage: str, mode: str, concurrency: int, details: str = "") -> 
 
 
 @pytest.fixture(scope="module")
-def dataset_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    override_dir = os.environ.get(DATASET_CACHE_ENV)
-    if override_dir:
-        root = Path(override_dir).expanduser()
-    else:
-        root = tmp_path_factory.mktemp("seed_tts_eval") / "data"
-    download_dataset(DATASETS["seedtts-50"], str(root), quiet=True)
-    return root
+def dataset_repo() -> str:
+    repo_id = DATASETS["seedtts-50"]
+    download_dataset(repo_id, quiet=True)
+    return repo_id
 
 
 @pytest.fixture(scope="module")
@@ -552,7 +547,7 @@ def wer_input_dirs(
 @pytest.mark.benchmark
 def test_voice_cloning_non_streaming(
     router_server: ManagedRouterHandle,
-    dataset_dir: Path,
+    dataset_repo: str,
     tmp_path: Path,
     selected_s2pro_tts_concurrencies: tuple[int, ...],
 ) -> None:
@@ -566,7 +561,7 @@ def test_voice_cloning_non_streaming(
         try:
             results = _run_benchmark(
                 router_server.port,
-                str(dataset_dir / "en" / "meta.lst"),
+                dataset_repo,
                 output_dir,
                 concurrency=concurrency,
             )
@@ -591,7 +586,7 @@ def test_voice_cloning_non_streaming(
 @pytest.mark.benchmark
 def test_voice_cloning_streaming(
     router_server: ManagedRouterHandle,
-    dataset_dir: Path,
+    dataset_repo: str,
     tmp_path: Path,
     selected_s2pro_tts_concurrencies: tuple[int, ...],
 ) -> None:
@@ -607,7 +602,7 @@ def test_voice_cloning_streaming(
         try:
             results = _run_benchmark(
                 router_server.port,
-                str(dataset_dir / "en" / "meta.lst"),
+                dataset_repo,
                 output_dir,
                 concurrency=concurrency,
                 max_samples=STREAMING_BENCHMARK_MAX_SAMPLES,
@@ -650,7 +645,7 @@ def test_voice_cloning_streaming_consistency(
 @pytest.mark.benchmark
 def test_voice_cloning_wer(
     wer_input_dirs: dict[str, dict[int, str]],
-    dataset_dir: Path,
+    dataset_repo: str,
     selected_s2pro_tts_concurrencies: tuple[int, ...],
 ) -> None:
     for concurrency in selected_s2pro_tts_concurrencies:
@@ -661,7 +656,7 @@ def test_voice_cloning_wer(
             "transcribe speed-stage WAVs",
         )
         results = _run_wer_transcribe(
-            str(dataset_dir / "en" / "meta.lst"),
+            dataset_repo,
             wer_input_dirs["non_stream"][concurrency],
         )
         assert_wer_results(results, VC_WER_CORPUS_THRESHOLD, VC_WER_MAX_PER_SAMPLE)
@@ -671,7 +666,7 @@ def test_voice_cloning_wer(
 @pytest.mark.benchmark
 def test_voice_cloning_similarity(
     wer_input_dirs: dict[str, dict[int, str]],
-    dataset_dir: Path,
+    dataset_repo: str,
     similarity_checkpoint: str | None,
     selected_s2pro_tts_concurrencies: tuple[int, ...],
 ) -> None:
@@ -683,7 +678,7 @@ def test_voice_cloning_similarity(
             "score speed-stage WAVs",
         )
         results = _run_similarity(
-            str(dataset_dir / "en" / "meta.lst"),
+            dataset_repo,
             wer_input_dirs["non_stream"][concurrency],
             similarity_checkpoint,
         )
@@ -694,7 +689,7 @@ def test_voice_cloning_similarity(
 @pytest.mark.benchmark
 def test_voice_cloning_streaming_wer(
     wer_input_dirs: dict[str, dict[int, str]],
-    dataset_dir: Path,
+    dataset_repo: str,
     selected_s2pro_tts_concurrencies: tuple[int, ...],
 ) -> None:
     for concurrency in selected_s2pro_tts_concurrencies:
@@ -705,7 +700,7 @@ def test_voice_cloning_streaming_wer(
             f"transcribe {STREAMING_BENCHMARK_MAX_SAMPLES} speed-stage WAVs",
         )
         results = _run_wer_transcribe(
-            str(dataset_dir / "en" / "meta.lst"),
+            dataset_repo,
             wer_input_dirs["stream"][concurrency],
             stream=True,
         )

--- a/tests/unit_test/benchmarks/test_dataset_regressions.py
+++ b/tests/unit_test/benchmarks/test_dataset_regressions.py
@@ -4,6 +4,9 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
+import yaml
+
 from benchmarks.dataset import prepare, seedtts
 
 
@@ -57,7 +60,7 @@ def test_download_dataset_prewarms_all_mmmu_configs(monkeypatch) -> None:
     ]
 
 
-def test_load_seedtts_samples_accepts_local_meta_lst(tmp_path: Path) -> None:
+def test_load_seedtts_samples_rejects_local_meta_lst(tmp_path: Path) -> None:
     meta_dir = tmp_path / "en"
     meta_dir.mkdir()
     ref_audio = meta_dir / "ref.wav"
@@ -67,15 +70,8 @@ def test_load_seedtts_samples_accepts_local_meta_lst(tmp_path: Path) -> None:
         "sample-1|hello|ref.wav|target one\nsample-2|world|ref.wav|target two\n"
     )
 
-    samples = seedtts.load_seedtts_samples(str(meta_path), max_samples=1)
-
-    assert len(samples) == 1
-    assert samples[0] == seedtts.SampleInput(
-        sample_id="sample-1",
-        ref_text="hello",
-        ref_audio=str(ref_audio),
-        target_text="target one",
-    )
+    with pytest.raises(ValueError, match="no longer supported"):
+        seedtts.load_seedtts_samples(str(meta_path), max_samples=1)
 
 
 def test_load_seedtts_samples_stages_only_selected_rows(
@@ -129,3 +125,75 @@ def test_load_seedtts_samples_stages_only_selected_rows(
     ]
 
     seedtts._STAGED_CACHE.clear()
+
+
+@pytest.mark.parametrize(
+    ("ref_audio_path", "outside_name"),
+    [
+        ("../escape.wav", "escape.wav"),
+        (None, "absolute.wav"),
+    ],
+)
+def test_load_seedtts_samples_rejects_unsafe_audio_paths(
+    monkeypatch, tmp_path: Path, ref_audio_path: str | None, outside_name: str
+) -> None:
+    seedtts._STAGED_CACHE.clear()
+
+    stage_dir = tmp_path / "seedtts_stage"
+    stage_dir.mkdir()
+    outside_path = tmp_path / outside_name
+    rows = [
+        {
+            "sample_id": "sample-0",
+            "ref_text": "ref-0",
+            "ref_audio_path": (
+                ref_audio_path if ref_audio_path is not None else str(outside_path)
+            ),
+            "target_text": "target-0",
+            "ref_audio": {"bytes": b"audio-0"},
+        }
+    ]
+
+    def fake_load_dataset(repo_id: str, split: str):
+        assert repo_id == "zhaochenyang20/seed-tts-eval-arrow"
+        assert split == "en"
+        return _FakeDataset(rows)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "datasets",
+        types.SimpleNamespace(
+            Audio=lambda **kwargs: ("Audio", kwargs),
+            load_dataset=fake_load_dataset,
+        ),
+    )
+    monkeypatch.setattr(seedtts.tempfile, "mkdtemp", lambda prefix: str(stage_dir))
+    monkeypatch.setattr(seedtts.atexit, "register", lambda *args, **kwargs: None)
+
+    with pytest.raises(ValueError, match="Invalid ref_audio_path"):
+        seedtts.load_seedtts_samples(
+            "zhaochenyang20/seed-tts-eval-arrow",
+            max_samples=1,
+            split="en",
+        )
+
+    assert not outside_path.exists()
+    assert list(stage_dir.rglob("*.wav")) == []
+
+    seedtts._STAGED_CACHE.clear()
+
+
+def test_tune_ci_threshold_configs_use_arrow_seedtts_datasets() -> None:
+    models_dir = (
+        Path(__file__).resolve().parents[3]
+        / ".claude/skills/tune-ci-thresholds/models"
+    )
+
+    for config_path in sorted(models_dir.glob("*/config.yaml")):
+        config = yaml.safe_load(config_path.read_text())
+        for repo_id in config.get("hf_datasets", []):
+            if "seed-tts" not in repo_id:
+                continue
+            assert repo_id.endswith("-arrow"), (
+                f"{config_path} still points to a non-arrow SeedTTS dataset: {repo_id}"
+            )

--- a/tests/unit_test/benchmarks/test_dataset_regressions.py
+++ b/tests/unit_test/benchmarks/test_dataset_regressions.py
@@ -60,7 +60,7 @@ def test_download_dataset_prewarms_all_mmmu_configs(monkeypatch) -> None:
     ]
 
 
-def test_load_seedtts_samples_rejects_local_meta_lst(tmp_path: Path) -> None:
+def test_load_seedtts_samples_accepts_local_meta_lst(tmp_path: Path) -> None:
     meta_dir = tmp_path / "en"
     meta_dir.mkdir()
     ref_audio = meta_dir / "ref.wav"
@@ -70,8 +70,13 @@ def test_load_seedtts_samples_rejects_local_meta_lst(tmp_path: Path) -> None:
         "sample-1|hello|ref.wav|target one\nsample-2|world|ref.wav|target two\n"
     )
 
-    with pytest.raises(ValueError, match="no longer supported"):
-        seedtts.load_seedtts_samples(str(meta_path), max_samples=1)
+    samples = seedtts.load_seedtts_samples(str(meta_path), max_samples=1)
+
+    assert len(samples) == 1
+    assert samples[0].sample_id == "sample-1"
+    assert samples[0].ref_text == "hello"
+    assert samples[0].ref_audio == str(ref_audio)
+    assert samples[0].target_text == "target one"
 
 
 def test_load_seedtts_samples_stages_only_selected_rows(
@@ -185,8 +190,7 @@ def test_load_seedtts_samples_rejects_unsafe_audio_paths(
 
 def test_tune_ci_threshold_configs_use_arrow_seedtts_datasets() -> None:
     models_dir = (
-        Path(__file__).resolve().parents[3]
-        / ".claude/skills/tune-ci-thresholds/models"
+        Path(__file__).resolve().parents[3] / ".claude/skills/tune-ci-thresholds/models"
     )
 
     for config_path in sorted(models_dir.glob("*/config.yaml")):
@@ -194,6 +198,6 @@ def test_tune_ci_threshold_configs_use_arrow_seedtts_datasets() -> None:
         for repo_id in config.get("hf_datasets", []):
             if "seed-tts" not in repo_id:
                 continue
-            assert repo_id.endswith("-arrow"), (
-                f"{config_path} still points to a non-arrow SeedTTS dataset: {repo_id}"
-            )
+            assert repo_id.endswith(
+                "-arrow"
+            ), f"{config_path} still points to a non-arrow SeedTTS dataset: {repo_id}"

--- a/tests/unit_test/benchmarks/test_dataset_regressions.py
+++ b/tests/unit_test/benchmarks/test_dataset_regressions.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+from benchmarks.dataset import prepare, seedtts
+
+
+class _FakeDataset:
+    def __init__(self, rows: list[dict]) -> None:
+        self._rows = rows
+        self.column_names = list(rows[0].keys()) if rows else []
+        self.selected_indices: list[int] | None = None
+
+    def cast_column(self, _name: str, _audio_spec) -> "_FakeDataset":
+        return self
+
+    def select(self, indices: list[int]) -> "_FakeDataset":
+        self.selected_indices = list(indices)
+        return _FakeDataset([self._rows[i] for i in indices])
+
+    def __len__(self) -> int:
+        return len(self._rows)
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+def test_download_dataset_prewarms_all_mmmu_configs(monkeypatch) -> None:
+    calls: list[tuple[str, str | None, str | None]] = []
+
+    def fake_get_dataset_config_names(repo_id: str) -> list[str]:
+        assert repo_id == "MMMU/MMMU"
+        return ["Accounting", "Math"]
+
+    def fake_load_dataset(
+        repo_id: str, config_name: str | None = None, split: str | None = None
+    ):
+        calls.append((repo_id, config_name, split))
+        return object()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "datasets",
+        types.SimpleNamespace(
+            get_dataset_config_names=fake_get_dataset_config_names,
+            load_dataset=fake_load_dataset,
+        ),
+    )
+
+    prepare.download_dataset("MMMU/MMMU", quiet=True)
+
+    assert calls == [
+        ("MMMU/MMMU", "Accounting", "validation"),
+        ("MMMU/MMMU", "Math", "validation"),
+    ]
+
+
+def test_load_seedtts_samples_accepts_local_meta_lst(tmp_path: Path) -> None:
+    meta_dir = tmp_path / "en"
+    meta_dir.mkdir()
+    ref_audio = meta_dir / "ref.wav"
+    ref_audio.write_bytes(b"wav")
+    meta_path = meta_dir / "meta.lst"
+    meta_path.write_text(
+        "sample-1|hello|ref.wav|target one\nsample-2|world|ref.wav|target two\n"
+    )
+
+    samples = seedtts.load_seedtts_samples(str(meta_path), max_samples=1)
+
+    assert len(samples) == 1
+    assert samples[0] == seedtts.SampleInput(
+        sample_id="sample-1",
+        ref_text="hello",
+        ref_audio=str(ref_audio),
+        target_text="target one",
+    )
+
+
+def test_load_seedtts_samples_stages_only_selected_rows(
+    monkeypatch, tmp_path: Path
+) -> None:
+    seedtts._STAGED_CACHE.clear()
+
+    rows = [
+        {
+            "sample_id": f"sample-{idx}",
+            "ref_text": f"ref-{idx}",
+            "ref_audio_path": f"audio/{idx}.wav",
+            "target_text": f"target-{idx}",
+            "ref_audio": {"bytes": f"audio-{idx}".encode()},
+        }
+        for idx in range(5)
+    ]
+    dataset = _FakeDataset(rows)
+    stage_dir = tmp_path / "seedtts_stage"
+    stage_dir.mkdir()
+
+    def fake_load_dataset(repo_id: str, split: str):
+        assert repo_id == "zhaochenyang20/seed-tts-eval-arrow"
+        assert split == "en"
+        return dataset
+
+    monkeypatch.setitem(
+        sys.modules,
+        "datasets",
+        types.SimpleNamespace(
+            Audio=lambda **kwargs: ("Audio", kwargs),
+            load_dataset=fake_load_dataset,
+        ),
+    )
+    monkeypatch.setattr(seedtts.tempfile, "mkdtemp", lambda prefix: str(stage_dir))
+    monkeypatch.setattr(seedtts.atexit, "register", lambda *args, **kwargs: None)
+
+    samples = seedtts.load_seedtts_samples(
+        "zhaochenyang20/seed-tts-eval-arrow",
+        max_samples=2,
+        split="en",
+    )
+
+    assert dataset.selected_indices == [0, 1]
+    assert [sample.sample_id for sample in samples] == ["sample-0", "sample-1"]
+    assert sorted(
+        path.relative_to(stage_dir).as_posix() for path in stage_dir.rglob("*.wav")
+    ) == [
+        "audio/0.wav",
+        "audio/1.wav",
+    ]
+
+    seedtts._STAGED_CACHE.clear()


### PR DESCRIPTION
## Motivation

File-by-file downloads of `seed-tts-eval` can hit Hugging Face rate limits, and moving SeedTTS to Arrow/Parquet dataset repos also aligns it with datasets like MMMU and MMSU under a more consistent benchmark data-loading path.

## Modifications

- migrate SeedTTS benchmark loading to Arrow/Parquet dataset repos via `datasets`
- update benchmark defaults, docs, helper scripts, and CI fixtures to use dataset repo ids
- pre-warm benchmark datasets through the Hugging Face datasets cache
- keep local `meta.lst` support for SeedTTS
- keep `prepare --dataset mmmu` working by pre-warming all MMMU configs
- apply `max_samples` before SeedTTS audio staging
- add regression tests for the dataset loading paths

## Related Issues

N/A

## Accuracy Test

N/A. This PR only changes benchmark dataset loading.

Validation:
- `python -m pytest tests/unit_test/benchmarks/test_dataset_regressions.py -q`
- `pre-commit run --files benchmarks/dataset/prepare.py benchmarks/dataset/seedtts.py tests/unit_test/benchmarks/test_dataset_regressions.py`

## Benchmark & Profiling

N/A

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Draft PRs are skipped even if labeled.
