### PR TITLE
Enabling torch.compile + CUDA Graph for Qwen3-TTS and Voxtral-TTS AR backbones

### DIFF
--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -183,6 +183,8 @@ class TtsSeedttsBenchmarkConfig:
     # "cheerful_female" server-side); voice-cloning models such as S2-Pro
     # ignore it and take the speaker from ref_audio/ref_text instead.
     voice: str | None = None
+    task_type: str | None = None
+    instructions: str | None = None
     # Default is voice-clone ON — S2-Pro's canonical flow uses the
     # seed-tts-eval reference audio.  The ``--no-ref-audio`` CLI flag flips
     # this to False for plain TTS models that do not accept ref audio.
@@ -235,6 +237,8 @@ def _build_results_config(
         "voice_clone": config.voice_clone,
         "ref_format": config.ref_format,
         "voice": config.voice,
+        "task_type": config.task_type,
+        "instructions": config.instructions,
         "stream": config.stream,
         "max_samples": config.max_samples,
         "max_new_tokens": config.max_new_tokens,
@@ -268,6 +272,8 @@ async def run_tts_seedtts_benchmark(
         no_ref_audio=not config.voice_clone,
         ref_format=config.ref_format,
         voice=config.voice,
+        task_type=config.task_type,
+        instructions=config.instructions,
         save_audio_dir=save_audio_dir,
         **generation_kwargs,
     )
@@ -304,6 +310,8 @@ def run_tts_seedtts_transcribe(config: TtsSeedttsBenchmarkConfig) -> dict:
         "voice_clone": config.voice_clone,
         "ref_format": config.ref_format,
         "voice": config.voice,
+        "task_type": config.task_type,
+        "instructions": config.instructions,
         "max_new_tokens": config.max_new_tokens,
         "temperature": config.temperature,
         "max_samples": config.max_samples,
@@ -328,6 +336,8 @@ def _config_from_args(args: argparse.Namespace) -> TtsSeedttsBenchmarkConfig:
         model=args.model,
         meta=args.meta,
         voice=args.voice,
+        task_type=args.task_type,
+        instructions=args.instructions,
         voice_clone=voice_clone,
         ref_format=args.ref_format,
         output_dir=args.output_dir,
@@ -383,6 +393,18 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             "as fishaudio/s2-pro, which take the speaker from ref_audio in "
             "the meta file."
         ),
+    )
+    parser.add_argument(
+        "--task-type",
+        type=str,
+        default=None,
+        help="Model-specific TTS task type, for example Base, CustomVoice, or VoiceDesign.",
+    )
+    parser.add_argument(
+        "--instructions",
+        type=str,
+        default=None,
+        help="Model-specific style or voice-design instructions.",
     )
     parser.add_argument(
         "--meta",

--- a/benchmarks/tasks/tts.py
+++ b/benchmarks/tasks/tts.py
@@ -1034,6 +1034,8 @@ def _build_tts_payload(
     no_ref_audio: bool = False,
     ref_format: str = "flat",
     voice: str | None = None,
+    task_type: str | None = None,
+    instructions: str | None = None,
     **gen_kwargs,
 ) -> dict:
     payload: dict = {
@@ -1051,6 +1053,10 @@ def _build_tts_payload(
             payload["ref_text"] = sample.ref_text
     if voice is not None:
         payload["voice"] = voice
+    if task_type is not None:
+        payload["task_type"] = task_type
+    if instructions is not None:
+        payload["instructions"] = instructions
     for key, value in gen_kwargs.items():
         if value is not None:
             payload[key] = value
@@ -1248,6 +1254,8 @@ def make_tts_send_fn(
     no_ref_audio: bool = False,
     ref_format: str = "flat",
     voice: str | None = None,
+    task_type: str | None = None,
+    instructions: str | None = None,
     save_audio_dir: str | None = None,
     **gen_kwargs,
 ) -> SendFn:
@@ -1267,6 +1275,8 @@ def make_tts_send_fn(
             no_ref_audio=no_ref_audio,
             ref_format=ref_format,
             voice=voice,
+            task_type=task_type,
+            instructions=instructions,
             **gen_kwargs,
         )
         start_time = time.perf_counter()

--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -1,6 +1,6 @@
 # TTS Model Usage
 
-This guide uses [Fish Speech S2-Pro](https://huggingface.co/fishaudio/s2-pro) as an example TTS (text-to-speech) model with SGLang-Omni and the OpenAI-compatible API. The same `/v1/audio/speech` endpoint also supports Voxtral TTS and Qwen3-TTS Base.
+This guide uses [Fish Speech S2-Pro](https://huggingface.co/fishaudio/s2-pro) as an example TTS (text-to-speech) model with SGLang-Omni and the OpenAI-compatible API. The same `/v1/audio/speech` endpoint also supports Voxtral TTS and Qwen3-TTS.
 
 ## Prerequisites
 
@@ -10,7 +10,7 @@ Install `sglang-omni` by following [Installation](../get_started/installation.md
 hf download fishaudio/s2-pro
 ```
 
-Qwen3-TTS Base uses the upstream `qwen-tts` package, which currently requires
+Qwen3-TTS uses the upstream `qwen-tts` package, which currently requires
 Transformers 4.57.3. Install it only in environments that serve Qwen3-TTS:
 
 ```bash
@@ -25,6 +25,8 @@ uv pip install --no-deps qwen-tts==0.1.1
 | Fish Speech S2-Pro | `examples/configs/s2pro_tts.yaml` | Supports plain TTS and voice cloning with `references` |
 | [Voxtral TTS](../cookbook/voxtral_tts.md) | `examples/configs/voxtral_tts.yaml` | Uses `input`, `voice`, `response_format`, and `max_new_tokens`; use `--no-ref-audio` for SeedTTS benchmarking |
 | [Qwen3-TTS Base](../cookbook/qwen3_tts.md) | `examples/configs/qwen3_tts_0_6b.yaml`, `examples/configs/qwen3_tts_1_7b.yaml` | Requires reference audio through `ref_audio` or `references[0].audio_path`; `language` defaults to `auto` |
+| Qwen3-TTS CustomVoice | `examples/configs/qwen3_tts_0_6b_customvoice.yaml` | Text-only requests use the checkpoint speaker table; missing `voice` defaults to `Vivian` |
+| Qwen3-TTS VoiceDesign | `examples/configs/qwen3_tts_1_7b_voicedesign.yaml` | Requires `task_type="VoiceDesign"` and non-empty `instructions`; no reference audio is required |
 
 ## Launch the Server
 
@@ -53,9 +55,28 @@ sgl-omni serve \
   --port 8000
 ```
 
+For Qwen3-TTS CustomVoice:
+
+```bash
+sgl-omni serve \
+  --model-path Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice \
+  --config examples/configs/qwen3_tts_0_6b_customvoice.yaml \
+  --port 8000
+```
+
+For Qwen3-TTS VoiceDesign:
+
+```bash
+sgl-omni serve \
+  --model-path Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign \
+  --config examples/configs/qwen3_tts_1_7b_voicedesign.yaml \
+  --port 8000
+```
+
 ## Use Curl
 
-For Fish Speech S2-Pro and Voxtral TTS, generate speech from text without any reference audio:
+Generate speech from text without any reference audio. This is valid for
+Qwen3-TTS CustomVoice, Voxtral, and S2-Pro. It is not valid for Qwen3-TTS Base.
 
 ```bash
 curl -X POST http://localhost:8000/v1/audio/speech \
@@ -75,6 +96,19 @@ curl -X POST http://localhost:8000/v1/audio/speech \
     "ref_text": "We asked over twenty different people, and they all said it was his."
   }' \
   --output output.wav
+```
+
+Qwen3-TTS VoiceDesign uses text plus voice instructions:
+
+```bash
+curl -X POST http://localhost:8000/v1/audio/speech \
+    -H "Content-Type: application/json" \
+    -d '{
+      "input": "Hello, how are you?",
+      "task_type": "VoiceDesign",
+      "instructions": "A warm, natural young adult voice."
+    }' \
+    --output output.wav
 ```
 
 For natural-sounding Fish Speech S2-Pro results, use Voice Cloning with a reference audio clip.
@@ -221,6 +255,8 @@ The table below lists all parameters accepted by the `/v1/audio/speech` endpoint
 | `ref_audio` | string | `null` | Reference audio path / URL / base64 string; equivalent to `references[0].audio_path` |
 | `ref_text` | string | `null` | Transcript for `ref_audio`; equivalent to `references[0].text` |
 | `language` | string | `null` | Model-specific language hint; Qwen3-TTS Base defaults to `auto` |
+| `task_type` | string | `null` | Qwen3-TTS task type: `Base`, `CustomVoice`, or `VoiceDesign`; inferred as `Base` when reference audio/text is present, otherwise `CustomVoice` |
+| `instructions` | string | `null` | Qwen3-TTS style or VoiceDesign instructions |
 | `max_new_tokens` | int | `null` | Maximum number of generated tokens |
 | `temperature` | float | `null` | Sampling temperature |
 | `top_p` | float | `null` | Top-p sampling |

--- a/examples/configs/qwen3_tts_0_6b_customvoice.yaml
+++ b/examples/configs/qwen3_tts_0_6b_customvoice.yaml
@@ -1,0 +1,3 @@
+config_cls: Qwen3TTSPipelineConfig
+model_path: Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice
+relay_backend: shm

--- a/examples/configs/qwen3_tts_1_7b_voicedesign.yaml
+++ b/examples/configs/qwen3_tts_1_7b_voicedesign.yaml
@@ -1,0 +1,3 @@
+config_cls: Qwen3TTSPipelineConfig
+model_path: Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign
+relay_backend: shm

--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -40,9 +40,9 @@ class Qwen3TTSModelRunner(ModelRunner):
         schedule_batch: Any,
         requests: list,
     ) -> GenerationBatchResult | None:
-        del forward_batch, schedule_batch
+        del schedule_batch
         self.model.prepare_decode_buffers(requests)
-        self._write_feedback_buffers(requests)
+        self._write_feedback_buffers(forward_batch, requests)
         return None
 
     def post_prefill(
@@ -170,22 +170,47 @@ class Qwen3TTSModelRunner(ModelRunner):
 
         raise RuntimeError("Qwen3-TTS subtalker sampling requires semantic positions")
 
-    def _write_feedback_buffers(self, requests: list) -> None:
+    def _write_feedback_buffers(self, forward_batch: Any, requests: list) -> None:
         batch_size = len(requests)
-        feedback_buffer = self.model._feedback_buffer
-        feedback_mask = self.model._feedback_mask
-        feedback_mask[:batch_size] = False
+        if batch_size == 0:
+            return
+        decode_feedback_embedding = self.model._decode_feedback_embedding
+        input_ids = forward_batch.input_ids
+        if input_ids.numel() < batch_size:
+            raise RuntimeError(
+                "Qwen3-TTS decode input_ids must contain one row id per request"
+            )
+        if batch_size > decode_feedback_embedding.num_embeddings:
+            raise RuntimeError(
+                "Qwen3-TTS decode batch exceeds staged feedback embedding rows"
+            )
+        row_ids = torch.arange(
+            batch_size,
+            device=input_ids.device,
+            dtype=input_ids.dtype,
+        )
+        rows = []
 
         for row_idx, sched_req in enumerate(requests):
             combined = QwenTalkerModelRunner._take_next_decode_input_embed(
                 sched_req=sched_req,
-                device=feedback_buffer.device,
-                dtype=feedback_buffer.dtype,
+                device=decode_feedback_embedding.weight.device,
+                dtype=decode_feedback_embedding.weight.dtype,
             )
             if combined is None:
-                continue
-            feedback_buffer[row_idx].copy_(combined)
-            feedback_mask[row_idx] = True
+                token_id = input_ids[row_idx : row_idx + 1].to(
+                    device=decode_feedback_embedding.weight.device
+                )
+                combined = self.model.get_input_embeddings()(token_id).reshape(-1)
+            rows.append(combined)
+        stacked = torch.stack(rows, dim=0).to(
+            device=decode_feedback_embedding.weight.device,
+            dtype=decode_feedback_embedding.weight.dtype,
+        )
+        with torch.no_grad():
+            decode_feedback_embedding.weight[:batch_size].copy_(stacked)
+        # During graph decode, input_ids carries staged embedding row ids.
+        input_ids[:batch_size].copy_(row_ids)
 
     def _build_prefill_input_embeds(
         self,

--- a/sglang_omni/models/qwen3_tts/payload_types.py
+++ b/sglang_omni/models/qwen3_tts/payload_types.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Qwen3-TTS Base pipeline state."""
+"""Qwen3-TTS pipeline state."""
 
 from __future__ import annotations
 
@@ -9,10 +9,14 @@ from typing import Any
 
 @dataclass
 class Qwen3TTSState:
-    """Per-request state for Qwen3-TTS Base voice cloning."""
+    """Per-request state for Qwen3-TTS generation."""
 
     text: str = ""
+    task_type: str = "Base"
+    task_type_explicit: bool = False
     language: str = "auto"
+    voice: str | None = None
+    instructions: str | None = None
     ref_audio: Any | None = None
     ref_text: str | None = None
     x_vector_only_mode: bool = False
@@ -40,12 +44,18 @@ class Qwen3TTSState:
     def to_dict(self) -> dict[str, Any]:
         data: dict[str, Any] = {
             "text": self.text,
+            "task_type": self.task_type,
+            "task_type_explicit": self.task_type_explicit,
             "language": self.language,
             "x_vector_only_mode": self.x_vector_only_mode,
             "non_streaming_mode": self.non_streaming_mode,
             "generation_kwargs": dict(self.generation_kwargs),
             "sample_rate": self.sample_rate,
         }
+        if self.voice is not None:
+            data["voice"] = self.voice
+        if self.instructions is not None:
+            data["instructions"] = self.instructions
         if self.ref_audio is not None:
             data["ref_audio"] = self.ref_audio
         if self.ref_text is not None:
@@ -73,7 +83,11 @@ class Qwen3TTSState:
         generation_kwargs = data.get("generation_kwargs")
         return cls(
             text=str(data.get("text", "")),
+            task_type=str(data.get("task_type") or "Base"),
+            task_type_explicit=bool(data.get("task_type_explicit", False)),
             language=str(data.get("language") or "auto"),
+            voice=data.get("voice"),
+            instructions=data.get("instructions"),
             ref_audio=data.get("ref_audio"),
             ref_text=data.get("ref_text"),
             x_vector_only_mode=bool(data.get("x_vector_only_mode", False)),

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Request mapping helpers for Qwen3-TTS Base."""
+"""Request mapping helpers for Qwen3-TTS."""
 
 from __future__ import annotations
 
@@ -18,6 +18,10 @@ from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
 
 QWEN3_TTS_DEFAULT_MAX_NEW_TOKENS = 2048
+QWEN3_TTS_TASK_BASE = "Base"
+QWEN3_TTS_TASK_CUSTOM_VOICE = "CustomVoice"
+QWEN3_TTS_TASK_VOICE_DESIGN = "VoiceDesign"
+QWEN3_TTS_DEFAULT_CUSTOM_VOICE = "Vivian"
 _QWEN3_TTS_PREPARED_MARKER = "_qwen3_tts_prepared_request"
 
 _GENERATION_FIELDS = (
@@ -184,23 +188,80 @@ def build_qwen3_tts_state(payload: StagePayload) -> Qwen3TTSState:
         tts_params = {}
 
     text, references = normalize_qwen3_tts_inputs(inputs)
-    ref_audio, ref_text = resolve_voice_clone_reference(references, tts_params)
+    has_reference = has_voice_clone_reference(references, tts_params)
+    task_type_raw = tts_params.get("task_type") or params.get("task_type")
+    task_type_explicit = task_type_raw is not None and str(task_type_raw).strip() != ""
+    task_type = normalize_qwen3_tts_task_type(
+        task_type_raw, has_reference=has_reference
+    )
     language = normalize_language(tts_params.get("language") or params.get("language"))
-    x_vector_only_mode = resolve_x_vector_only_mode(
+    instructions = resolve_optional_text(
+        tts_params.get("instructions")
+        or tts_params.get("instruct")
+        or params.get("instructions")
+        or params.get("instruct")
+    )
+    ref_audio = None
+    ref_text = None
+    x_vector_only_mode = False
+    non_streaming_mode = resolve_non_streaming_mode(
+        task_type=task_type,
         params=params,
         tts_params=tts_params,
-        ref_text=ref_text,
     )
+    voice = normalize_qwen3_tts_voice(
+        tts_params.get("voice") or tts_params.get("speaker") or params.get("voice")
+    )
+
+    if task_type == QWEN3_TTS_TASK_BASE:
+        ref_audio, ref_text = resolve_voice_clone_reference(references, tts_params)
+        x_vector_only_mode = resolve_x_vector_only_mode(
+            params=params,
+            tts_params=tts_params,
+            ref_text=ref_text,
+        )
+        if not x_vector_only_mode and not ref_text:
+            raise ValueError(
+                "Qwen3-TTS Base requires non-empty ref_text unless "
+                "x_vector_only_mode is enabled"
+            )
+    elif task_type == QWEN3_TTS_TASK_CUSTOM_VOICE:
+        if has_param(tts_params, params, "ref_text") or references_contain_text(
+            references
+        ):
+            raise ValueError("Qwen3-TTS CustomVoice does not accept ref_text")
+        if has_param(tts_params, params, "x_vector_only_mode"):
+            raise ValueError("Qwen3-TTS CustomVoice does not accept x_vector_only_mode")
+        voice = voice or QWEN3_TTS_DEFAULT_CUSTOM_VOICE
+        non_streaming_mode = True
+    elif task_type == QWEN3_TTS_TASK_VOICE_DESIGN:
+        if has_param(tts_params, params, "ref_text") or references_contain_text(
+            references
+        ):
+            raise ValueError("Qwen3-TTS VoiceDesign does not accept ref_text")
+        if has_param(tts_params, params, "x_vector_only_mode"):
+            raise ValueError("Qwen3-TTS VoiceDesign does not accept x_vector_only_mode")
+        if not instructions:
+            raise ValueError("Qwen3-TTS VoiceDesign requires instructions")
+        voice = None
+        non_streaming_mode = True
+    else:
+        raise AssertionError(f"unhandled Qwen3-TTS task type: {task_type}")
+
     seed = tts_params["seed"] if "seed" in tts_params else params.get("seed")
     normalized_seed = _normalize_qwen3_tts_seed(seed) if seed is not None else None
 
     return Qwen3TTSState(
         text=text,
+        task_type=task_type,
+        task_type_explicit=task_type_explicit,
         language=language,
+        voice=voice,
+        instructions=instructions,
         ref_audio=ref_audio,
         ref_text=ref_text,
         x_vector_only_mode=x_vector_only_mode,
-        non_streaming_mode=bool(params.get("non_streaming_mode", False)),
+        non_streaming_mode=non_streaming_mode,
         generation_kwargs=build_generation_kwargs(params, tts_params=tts_params),
         seed=normalized_seed,
     )
@@ -238,6 +299,80 @@ def resolve_voice_clone_reference(
             "Qwen3-TTS Base requires reference audio via ref_audio or references[0].audio_path"
         )
     return ref_audio, str(ref_text) if ref_text is not None else None
+
+
+def has_voice_clone_reference(
+    references: list[dict[str, Any]],
+    tts_params: dict[str, Any],
+) -> bool:
+    if references:
+        reference = references[0]
+        if any(
+            reference.get(key) is not None
+            for key in ("audio_path", "ref_audio", "audio", "text")
+        ):
+            return True
+    return (
+        tts_params.get("ref_audio") is not None
+        or tts_params.get("ref_text") is not None
+    )
+
+
+def references_contain_text(references: list[dict[str, Any]]) -> bool:
+    return any(reference.get("text") is not None for reference in references)
+
+
+def normalize_qwen3_tts_task_type(
+    task_type: Any,
+    *,
+    has_reference: bool,
+) -> str:
+    if task_type is None or str(task_type).strip() == "":
+        return QWEN3_TTS_TASK_BASE if has_reference else QWEN3_TTS_TASK_CUSTOM_VOICE
+    normalized = str(task_type).replace("_", "").replace("-", "").lower()
+    if normalized == "base":
+        return QWEN3_TTS_TASK_BASE
+    if normalized == "customvoice":
+        return QWEN3_TTS_TASK_CUSTOM_VOICE
+    if normalized == "voicedesign":
+        return QWEN3_TTS_TASK_VOICE_DESIGN
+    raise ValueError(
+        "Qwen3-TTS task_type must be one of Base, CustomVoice, or VoiceDesign"
+    )
+
+
+def resolve_optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def normalize_qwen3_tts_voice(value: Any) -> str | None:
+    voice = resolve_optional_text(value)
+    if voice is None or voice.lower() == "default":
+        return None
+    return voice
+
+
+def has_param(
+    tts_params: dict[str, Any],
+    params: dict[str, Any],
+    name: str,
+) -> bool:
+    return name in tts_params or name in params
+
+
+def resolve_non_streaming_mode(
+    *,
+    task_type: str,
+    params: dict[str, Any],
+    tts_params: dict[str, Any],
+) -> bool:
+    for source in (params, tts_params):
+        if "non_streaming_mode" in source:
+            return bool(source["non_streaming_mode"])
+    return task_type in (QWEN3_TTS_TASK_CUSTOM_VOICE, QWEN3_TTS_TASK_VOICE_DESIGN)
 
 
 def normalize_language(language: Any) -> str:
@@ -321,14 +456,57 @@ def _build_qwen3_tts_pad_embed(model: Any) -> torch.Tensor:
         )
 
 
-def _prepare_qwen3_tts_request(
-    payload: StagePayload,
+def _build_instruct_id(wrapper: Any, instructions: str | None) -> torch.Tensor | None:
+    if not instructions:
+        return None
+    if hasattr(wrapper, "_build_instruct_text"):
+        instruct_text = wrapper._build_instruct_text(instructions)
+    else:
+        instruct_text = f"<|im_start|>user\n{instructions}<|im_end|>\n"
+    return wrapper._tokenize_texts([instruct_text])[0]
+
+
+def _normalized_model_type(model: Any) -> str:
+    model_type = getattr(model, "tts_model_type", None)
+    if model_type is None:
+        model_type = getattr(
+            getattr(model, "root_config", None), "tts_model_type", None
+        )
+    normalized = str(model_type or "base").replace("-", "_").strip().lower()
+    if normalized == "customvoice":
+        return "custom_voice"
+    if normalized == "voicedesign":
+        return "voice_design"
+    return normalized
+
+
+def _validate_qwen3_tts_model_task(model: Any, state: Qwen3TTSState) -> None:
+    model_type = _normalized_model_type(model)
+    if model_type == "base" and state.task_type != QWEN3_TTS_TASK_BASE:
+        if not state.task_type_explicit:
+            raise ValueError(
+                "Qwen3-TTS Base requires ref_audio or speaker_embedding; "
+                "text-only requests require a CustomVoice or VoiceDesign checkpoint"
+            )
+        raise ValueError(
+            f"Qwen3-TTS Base checkpoint does not support {state.task_type}"
+        )
+    if model_type == "custom_voice" and state.task_type != QWEN3_TTS_TASK_CUSTOM_VOICE:
+        raise ValueError(
+            f"Qwen3-TTS CustomVoice checkpoint does not support {state.task_type}"
+        )
+    if model_type == "voice_design" and state.task_type != QWEN3_TTS_TASK_VOICE_DESIGN:
+        raise ValueError(
+            f"Qwen3-TTS VoiceDesign checkpoint does not support {state.task_type}"
+        )
+
+
+def _prepare_qwen3_tts_base_request(
     *,
+    state: Qwen3TTSState,
     model: Any,
     wrapper: Any,
-) -> Qwen3TTSPreparedRequest:
-    state = build_qwen3_tts_state(payload)
-
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
     with torch.no_grad():
         prompt_items = wrapper.create_voice_clone_prompt(
             ref_audio=state.ref_audio,
@@ -346,20 +524,98 @@ def _prepare_qwen3_tts_request(
         if ref_text
         else None
     )
-    gen_kwargs = wrapper._merge_generate_kwargs(**state.generation_kwargs)
+    instruct_id = _build_instruct_id(wrapper, state.instructions)
     with torch.no_grad():
-        (
-            input_embeds,
-            attention_mask,
-            trailing_text_hidden,
-            ref_code,
-        ) = model.build_voice_clone_inputs(
+        return model.build_voice_clone_inputs(
             input_id=input_id,
             ref_id=ref_id,
             voice_clone_prompt=voice_clone_prompt,
             language=state.language,
             non_streaming_mode=state.non_streaming_mode,
+            instruct_id=instruct_id,
         )
+
+
+def _prepare_qwen3_tts_custom_voice_request(
+    *,
+    state: Qwen3TTSState,
+    model: Any,
+    wrapper: Any,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    input_id = wrapper._tokenize_texts([wrapper._build_assistant_text(state.text)])[0]
+    instruct_id = _build_instruct_id(wrapper, state.instructions)
+    with torch.no_grad():
+        return model.build_custom_voice_inputs(
+            input_id=input_id,
+            voice=state.voice or QWEN3_TTS_DEFAULT_CUSTOM_VOICE,
+            language=state.language,
+            non_streaming_mode=state.non_streaming_mode,
+            instruct_id=instruct_id,
+        )
+
+
+def _prepare_qwen3_tts_voice_design_request(
+    *,
+    state: Qwen3TTSState,
+    model: Any,
+    wrapper: Any,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
+    input_id = wrapper._tokenize_texts([wrapper._build_assistant_text(state.text)])[0]
+    instruct_id = _build_instruct_id(wrapper, state.instructions)
+    with torch.no_grad():
+        return model.build_voice_design_inputs(
+            input_id=input_id,
+            language=state.language,
+            non_streaming_mode=state.non_streaming_mode,
+            instruct_id=instruct_id,
+        )
+
+
+def _prepare_qwen3_tts_request(
+    payload: StagePayload,
+    *,
+    model: Any,
+    wrapper: Any,
+) -> Qwen3TTSPreparedRequest:
+    state = build_qwen3_tts_state(payload)
+
+    _validate_qwen3_tts_model_task(model, state)
+    gen_kwargs = wrapper._merge_generate_kwargs(**state.generation_kwargs)
+    if state.task_type == QWEN3_TTS_TASK_BASE:
+        (
+            input_embeds,
+            attention_mask,
+            trailing_text_hidden,
+            ref_code,
+        ) = _prepare_qwen3_tts_base_request(
+            state=state,
+            model=model,
+            wrapper=wrapper,
+        )
+    elif state.task_type == QWEN3_TTS_TASK_CUSTOM_VOICE:
+        (
+            input_embeds,
+            attention_mask,
+            trailing_text_hidden,
+            ref_code,
+        ) = _prepare_qwen3_tts_custom_voice_request(
+            state=state,
+            model=model,
+            wrapper=wrapper,
+        )
+    elif state.task_type == QWEN3_TTS_TASK_VOICE_DESIGN:
+        (
+            input_embeds,
+            attention_mask,
+            trailing_text_hidden,
+            ref_code,
+        ) = _prepare_qwen3_tts_voice_design_request(
+            state=state,
+            model=model,
+            wrapper=wrapper,
+        )
+    else:
+        raise AssertionError(f"unhandled Qwen3-TTS task type: {state.task_type}")
 
     feedback_buffer = model.model._feedback_buffer
     prompt_input_embeds = (

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -226,6 +226,10 @@ def build_qwen3_tts_state(payload: StagePayload) -> Qwen3TTSState:
                 "x_vector_only_mode is enabled"
             )
     elif task_type == QWEN3_TTS_TASK_CUSTOM_VOICE:
+        if has_param(tts_params, params, "ref_audio") or references_contain_audio(
+            references
+        ):
+            raise ValueError("Qwen3-TTS CustomVoice does not accept ref_audio")
         if has_param(tts_params, params, "ref_text") or references_contain_text(
             references
         ):
@@ -235,6 +239,10 @@ def build_qwen3_tts_state(payload: StagePayload) -> Qwen3TTSState:
         voice = voice or QWEN3_TTS_DEFAULT_CUSTOM_VOICE
         non_streaming_mode = True
     elif task_type == QWEN3_TTS_TASK_VOICE_DESIGN:
+        if has_param(tts_params, params, "ref_audio") or references_contain_audio(
+            references
+        ):
+            raise ValueError("Qwen3-TTS VoiceDesign does not accept ref_audio")
         if has_param(tts_params, params, "ref_text") or references_contain_text(
             references
         ):
@@ -305,16 +313,19 @@ def has_voice_clone_reference(
     references: list[dict[str, Any]],
     tts_params: dict[str, Any],
 ) -> bool:
-    if references:
-        reference = references[0]
-        if any(
-            reference.get(key) is not None
-            for key in ("audio_path", "ref_audio", "audio", "text")
-        ):
-            return True
+    if references_contain_audio(references) or references_contain_text(references):
+        return True
     return (
         tts_params.get("ref_audio") is not None
         or tts_params.get("ref_text") is not None
+    )
+
+
+def references_contain_audio(references: list[dict[str, Any]]) -> bool:
+    return any(
+        reference.get(key) is not None
+        for reference in references
+        for key in ("audio_path", "ref_audio", "audio")
     )
 
 

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -158,11 +158,7 @@ class Qwen3TTSTalkerTextModel(nn.Module):
         is_decode = forward_mode is not None and forward_mode.is_decode()
         if input_embeds is None:
             if is_decode:
-                row_ids = input_ids.clamp(
-                    min=0,
-                    max=self._decode_feedback_embedding.num_embeddings - 1,
-                )
-                hidden_states = self._decode_feedback_embedding(row_ids)
+                hidden_states = self._decode_feedback_embedding(input_ids)
             else:
                 hidden_states = self._build_input_hidden_states(input_ids)
         else:
@@ -171,7 +167,7 @@ class Qwen3TTSTalkerTextModel(nn.Module):
         residual = None
         layers = self.layers
         if is_decode:
-            layers = getattr(self, "_compiled_decode_layers", self.layers)
+            layers = self._compiled_decode_layers
         for idx in range(self.start_layer, self.end_layer):
             hidden_states, residual = layers[idx](
                 positions=positions,

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -372,7 +372,7 @@ class Qwen3TTSTalker(nn.Module):
         return ["auto", *list(self.config.codec_language_id.keys())]
 
     def get_supported_speakers(self):
-        return self.config.spk_id.keys()
+        return (getattr(self.config, "spk_id", None) or {}).keys()
 
     @torch.inference_mode()
     def extract_speaker_embedding(self, audio, sr):
@@ -403,22 +403,19 @@ class Qwen3TTSTalker(nn.Module):
             for emb in voice_clone_prompt["ref_spk_embedding"]
         ]
 
-    def build_voice_clone_inputs(
+    def _build_instruct_embed(
+        self,
+        instruct_id: torch.Tensor | None,
+    ) -> torch.Tensor | None:
+        if instruct_id is None:
+            return None
+        return self.text_projection(self.get_text_embeddings()(instruct_id))
+
+    def _build_tts_special_embeds(
         self,
         *,
-        input_id: torch.Tensor,
-        ref_id: torch.Tensor | None,
-        voice_clone_prompt: dict[str, Any],
-        language: str,
-        non_streaming_mode: bool,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
-        voice_clone_spk_embeds = self.generate_speaker_prompt(voice_clone_prompt)
-        speaker_embed = voice_clone_spk_embeds[0]
-
-        language_id = None
-        if language.lower() != "auto":
-            language_id = self.config.codec_language_id[language.lower()]
-
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         ids = torch.tensor(
             [
                 [
@@ -428,12 +425,34 @@ class Qwen3TTSTalker(nn.Module):
                 ]
             ],
             device=self.device,
-            dtype=input_id.dtype,
+            dtype=dtype,
         )
-        tts_bos_embed, tts_eos_embed, tts_pad_embed = self.text_projection(
-            self.get_text_embeddings()(ids)
-        ).chunk(3, dim=1)
+        return self.text_projection(self.get_text_embeddings()(ids)).chunk(3, dim=1)
 
+    def _resolve_language_id(
+        self,
+        *,
+        language: str,
+        voice: str | None = None,
+    ) -> int | None:
+        if language.lower() != "auto":
+            return self.config.codec_language_id[language.lower()]
+        if voice is None:
+            return None
+        spk_is_dialect = getattr(self.config, "spk_is_dialect", None) or {}
+        dialect = spk_is_dialect.get(voice.lower())
+        if isinstance(dialect, str) and dialect:
+            return self.config.codec_language_id.get(dialect)
+        return None
+
+    def _build_codec_prefill(
+        self,
+        *,
+        language: str,
+        dtype: torch.dtype,
+        voice: str | None = None,
+    ) -> torch.Tensor:
+        language_id = self._resolve_language_id(language=language, voice=voice)
         if language_id is None:
             codec_prefill = [
                 self.config.codec_nothink_id,
@@ -447,9 +466,109 @@ class Qwen3TTSTalker(nn.Module):
                 language_id,
                 self.config.codec_think_eos_id,
             ]
+        return self.get_input_embeddings()(
+            torch.tensor([codec_prefill], device=self.device, dtype=dtype)
+        )
 
-        codec_input_0 = self.get_input_embeddings()(
-            torch.tensor([codec_prefill], device=self.device, dtype=input_id.dtype)
+    def _finish_text_prompt(
+        self,
+        *,
+        talker_input_embed: torch.Tensor,
+        input_id: torch.Tensor,
+        codec_last_embed: torch.Tensor,
+        tts_pad_embed: torch.Tensor,
+        tts_eos_embed: torch.Tensor,
+        non_streaming_mode: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if non_streaming_mode:
+            text_all = self.text_projection(
+                self.get_text_embeddings()(input_id[:, 3:-5])
+            )
+            text_all = torch.cat([text_all, tts_eos_embed], dim=1)
+            pad_ids = torch.full(
+                (1, int(text_all.shape[1])),
+                int(self.config.codec_pad_id),
+                device=self.device,
+                dtype=input_id.dtype,
+            )
+            talker_input_embed = torch.cat(
+                [
+                    talker_input_embed,
+                    text_all + self.get_input_embeddings()(pad_ids),
+                    tts_pad_embed
+                    + self.get_input_embeddings()(
+                        torch.tensor(
+                            [[self.config.codec_bos_id]],
+                            device=self.device,
+                            dtype=input_id.dtype,
+                        )
+                    ),
+                ],
+                dim=1,
+            )
+            return talker_input_embed, tts_pad_embed
+
+        first_text = (
+            self.text_projection(self.get_text_embeddings()(input_id[:, 3:4]))
+            + codec_last_embed
+        )
+        talker_input_embed = torch.cat([talker_input_embed, first_text], dim=1)
+        trailing_text_hidden = torch.cat(
+            [
+                self.text_projection(self.get_text_embeddings()(input_id[:, 4:-5])),
+                tts_eos_embed,
+            ],
+            dim=1,
+        )
+        return talker_input_embed, trailing_text_hidden
+
+    def _apply_instruct_prefix(
+        self,
+        talker_input_embed: torch.Tensor,
+        instruct_id: torch.Tensor | None,
+    ) -> torch.Tensor:
+        instruct_embed = self._build_instruct_embed(instruct_id)
+        if instruct_embed is None:
+            return talker_input_embed
+        return torch.cat([instruct_embed, talker_input_embed], dim=1)
+
+    def _build_conditioned_prompt_prefix(
+        self,
+        *,
+        input_id: torch.Tensor,
+        codec_input: torch.Tensor,
+        tts_bos_embed: torch.Tensor,
+        tts_pad_embed: torch.Tensor,
+    ) -> torch.Tensor:
+        role_embed = self.text_projection(self.get_text_embeddings()(input_id[:, :3]))
+        prompt_embed = (
+            torch.cat(
+                [tts_pad_embed.expand(-1, codec_input.shape[1] - 2, -1), tts_bos_embed],
+                dim=1,
+            )
+            + codec_input[:, :-1]
+        )
+        return torch.cat([role_embed, prompt_embed], dim=1)
+
+    def build_voice_clone_inputs(
+        self,
+        *,
+        input_id: torch.Tensor,
+        ref_id: torch.Tensor | None,
+        voice_clone_prompt: dict[str, Any],
+        language: str,
+        non_streaming_mode: bool,
+        instruct_id: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        voice_clone_spk_embeds = self.generate_speaker_prompt(voice_clone_prompt)
+        speaker_embed = voice_clone_spk_embeds[0]
+
+        tts_bos_embed, tts_eos_embed, tts_pad_embed = self._build_tts_special_embeds(
+            dtype=input_id.dtype
+        )
+        codec_input_0 = self._build_codec_prefill(
+            language=language,
+            dtype=input_id.dtype,
         )
         codec_input_1 = self.get_input_embeddings()(
             torch.tensor(
@@ -461,16 +580,12 @@ class Qwen3TTSTalker(nn.Module):
         codec_input = torch.cat(
             [codec_input_0, speaker_embed.view(1, 1, -1), codec_input_1], dim=1
         )
-
-        role_embed = self.text_projection(self.get_text_embeddings()(input_id[:, :3]))
-        prompt_embed = (
-            torch.cat(
-                [tts_pad_embed.expand(-1, codec_input.shape[1] - 2, -1), tts_bos_embed],
-                dim=1,
-            )
-            + codec_input[:, :-1]
+        talker_input_embed = self._build_conditioned_prompt_prefix(
+            input_id=input_id,
+            codec_input=codec_input,
+            tts_bos_embed=tts_bos_embed,
+            tts_pad_embed=tts_pad_embed,
         )
-        talker_input_embed = torch.cat([role_embed, prompt_embed], dim=1)
 
         ref_code = None
         ref_codes = voice_clone_prompt.get("ref_code")
@@ -490,61 +605,139 @@ class Qwen3TTSTalker(nn.Module):
             )
             talker_input_embed = torch.cat([talker_input_embed, icl_embed], dim=1)
         else:
-            first_text = (
-                self.text_projection(self.get_text_embeddings()(input_id[:, 3:4]))
-                + codec_input[:, -1:]
+            talker_input_embed, trailing_text_hidden = self._finish_text_prompt(
+                talker_input_embed=talker_input_embed,
+                input_id=input_id,
+                codec_last_embed=codec_input[:, -1:],
+                tts_pad_embed=tts_pad_embed,
+                tts_eos_embed=tts_eos_embed,
+                non_streaming_mode=non_streaming_mode,
             )
-            talker_input_embed = torch.cat([talker_input_embed, first_text], dim=1)
-            if non_streaming_mode:
-                talker_input_embed = torch.cat(
-                    [
-                        talker_input_embed[:, :-1],
-                        torch.cat(
-                            [
-                                self.text_projection(
-                                    self.get_text_embeddings()(input_id[:, 3:-5])
-                                ),
-                                tts_eos_embed,
-                            ],
-                            dim=1,
-                        )
-                        + self.get_input_embeddings()(
-                            torch.tensor(
-                                [
-                                    [self.config.codec_pad_id]
-                                    * (input_id[:, 3:-5].shape[1] + 1)
-                                ],
-                                device=self.device,
-                                dtype=input_id.dtype,
-                            )
-                        ),
-                        tts_pad_embed
-                        + self.get_input_embeddings()(
-                            torch.tensor(
-                                [[self.config.codec_bos_id]],
-                                device=self.device,
-                                dtype=input_id.dtype,
-                            )
-                        ),
-                    ],
-                    dim=1,
-                )
-                trailing_text_hidden = tts_pad_embed
-            else:
-                trailing_text_hidden = torch.cat(
-                    [
-                        self.text_projection(
-                            self.get_text_embeddings()(input_id[:, 4:-5])
-                        ),
-                        tts_eos_embed,
-                    ],
-                    dim=1,
-                )
 
+        talker_input_embed = self._apply_instruct_prefix(
+            talker_input_embed,
+            instruct_id,
+        )
         attention_mask = torch.ones(
             (1, talker_input_embed.shape[1]), device=self.device, dtype=torch.long
         )
         return talker_input_embed, attention_mask, trailing_text_hidden, ref_code
+
+    def build_custom_voice_inputs(
+        self,
+        *,
+        input_id: torch.Tensor,
+        voice: str,
+        language: str,
+        non_streaming_mode: bool,
+        instruct_id: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, None]:
+        spk_id = getattr(self.config, "spk_id", None) or {}
+        if not spk_id:
+            raise ValueError(
+                "Qwen3-TTS CustomVoice requires a checkpoint with configured spk_id"
+            )
+        speaker_key = voice.lower()
+        spk_id_map = {str(key).lower(): value for key, value in spk_id.items()}
+        if speaker_key not in spk_id_map:
+            supported = ", ".join(sorted(str(key) for key in spk_id))
+            raise ValueError(
+                f"Unsupported Qwen3-TTS CustomVoice speaker {voice!r}. "
+                f"Supported speakers: {supported}"
+            )
+
+        tts_bos_embed, tts_eos_embed, tts_pad_embed = self._build_tts_special_embeds(
+            dtype=input_id.dtype
+        )
+        codec_input_0 = self._build_codec_prefill(
+            language=language,
+            dtype=input_id.dtype,
+            voice=speaker_key,
+        )
+        speaker_embed = self.get_input_embeddings()(
+            torch.tensor(
+                [spk_id_map[speaker_key]], device=self.device, dtype=input_id.dtype
+            )
+        ).view(1, 1, -1)
+        codec_input_1 = self.get_input_embeddings()(
+            torch.tensor(
+                [[self.config.codec_pad_id, self.config.codec_bos_id]],
+                device=self.device,
+                dtype=input_id.dtype,
+            )
+        )
+        codec_input = torch.cat([codec_input_0, speaker_embed, codec_input_1], dim=1)
+        talker_input_embed = self._build_conditioned_prompt_prefix(
+            input_id=input_id,
+            codec_input=codec_input,
+            tts_bos_embed=tts_bos_embed,
+            tts_pad_embed=tts_pad_embed,
+        )
+        talker_input_embed, trailing_text_hidden = self._finish_text_prompt(
+            talker_input_embed=talker_input_embed,
+            input_id=input_id,
+            codec_last_embed=codec_input[:, -1:],
+            tts_pad_embed=tts_pad_embed,
+            tts_eos_embed=tts_eos_embed,
+            non_streaming_mode=non_streaming_mode,
+        )
+        talker_input_embed = self._apply_instruct_prefix(
+            talker_input_embed,
+            instruct_id,
+        )
+        attention_mask = torch.ones(
+            (1, talker_input_embed.shape[1]), device=self.device, dtype=torch.long
+        )
+        return talker_input_embed, attention_mask, trailing_text_hidden, None
+
+    def build_voice_design_inputs(
+        self,
+        *,
+        input_id: torch.Tensor,
+        language: str,
+        non_streaming_mode: bool,
+        instruct_id: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, None]:
+        if instruct_id is None:
+            raise ValueError("Qwen3-TTS VoiceDesign requires instructions")
+
+        tts_bos_embed, tts_eos_embed, tts_pad_embed = self._build_tts_special_embeds(
+            dtype=input_id.dtype
+        )
+        codec_input_0 = self._build_codec_prefill(
+            language=language,
+            dtype=input_id.dtype,
+        )
+        codec_input_1 = self.get_input_embeddings()(
+            torch.tensor(
+                [[self.config.codec_pad_id, self.config.codec_bos_id]],
+                device=self.device,
+                dtype=input_id.dtype,
+            )
+        )
+        codec_input = torch.cat([codec_input_0, codec_input_1], dim=1)
+        talker_input_embed = self._build_conditioned_prompt_prefix(
+            input_id=input_id,
+            codec_input=codec_input,
+            tts_bos_embed=tts_bos_embed,
+            tts_pad_embed=tts_pad_embed,
+        )
+        talker_input_embed, trailing_text_hidden = self._finish_text_prompt(
+            talker_input_embed=talker_input_embed,
+            input_id=input_id,
+            codec_last_embed=codec_input[:, -1:],
+            tts_pad_embed=tts_pad_embed,
+            tts_eos_embed=tts_eos_embed,
+            non_streaming_mode=non_streaming_mode,
+        )
+        talker_input_embed = self._apply_instruct_prefix(
+            talker_input_embed,
+            instruct_id,
+        )
+        attention_mask = torch.ones(
+            (1, talker_input_embed.shape[1]), device=self.device, dtype=torch.long
+        )
+        return talker_input_embed, attention_mask, trailing_text_hidden, None
 
     def generate_icl_prompt(
         self,

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -120,12 +120,32 @@ class Qwen3TTSTalkerTextModel(nn.Module):
             dtype=torch.bool,
             device=self.codec_embedding.weight.device,
         )
+        self._decode_feedback_embedding = nn.Embedding(
+            max_batch_size,
+            config.hidden_size,
+            device=self.codec_embedding.weight.device,
+            dtype=self.codec_embedding.weight.dtype,
+        )
+        self._decode_feedback_embedding.weight.requires_grad_(False)
 
     def get_input_embeddings(self):
         return self.codec_embedding
 
     def get_text_embeddings(self):
         return self.text_embedding
+
+    def _build_input_hidden_states(
+        self,
+        input_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        hidden_states = self.codec_embedding(input_ids)
+        bs = hidden_states.shape[0]
+        feedback_mask = self._feedback_mask[:bs]
+        return torch.where(
+            feedback_mask.unsqueeze(-1),
+            self._feedback_buffer[:bs].to(hidden_states.dtype),
+            hidden_states,
+        )
 
     def forward(
         self,
@@ -134,22 +154,26 @@ class Qwen3TTSTalkerTextModel(nn.Module):
         forward_batch: ForwardBatch,
         input_embeds: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        forward_mode = getattr(forward_batch, "forward_mode", None)
+        is_decode = forward_mode is not None and forward_mode.is_decode()
         if input_embeds is None:
-            hidden_states = self.codec_embedding(input_ids)
-            bs = hidden_states.shape[0]
-            feedback_mask = self._feedback_mask[:bs]
-            hidden_states = torch.where(
-                feedback_mask.unsqueeze(-1),
-                self._feedback_buffer[:bs].to(hidden_states.dtype),
-                hidden_states,
-            )
-            self._feedback_mask[:bs] = False
+            if is_decode:
+                row_ids = input_ids.clamp(
+                    min=0,
+                    max=self._decode_feedback_embedding.num_embeddings - 1,
+                )
+                hidden_states = self._decode_feedback_embedding(row_ids)
+            else:
+                hidden_states = self._build_input_hidden_states(input_ids)
         else:
             hidden_states = input_embeds
 
         residual = None
+        layers = self.layers
+        if is_decode:
+            layers = getattr(self, "_compiled_decode_layers", self.layers)
         for idx in range(self.start_layer, self.end_layer):
-            hidden_states, residual = self.layers[idx](
+            hidden_states, residual = layers[idx](
                 positions=positions,
                 hidden_states=hidden_states,
                 forward_batch=forward_batch,
@@ -267,6 +291,7 @@ class Qwen3TTSTalker(nn.Module):
         dtype = self.model.codec_embedding.weight.dtype
         self._feedback_buffer = self.model._feedback_buffer
         self._feedback_mask = self.model._feedback_mask
+        self._decode_feedback_embedding = self.model._decode_feedback_embedding
         self._predictor_input_buffer = torch.zeros(
             max_batch_size,
             predictor_len,

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -106,6 +106,38 @@ def _load_qwen3_tts_generate_defaults(checkpoint_dir: str) -> dict[str, Any]:
     return data if isinstance(data, dict) else {}
 
 
+def _compile_qwen3_tts_backbone(model: Any) -> None:
+    """Compile decoder blocks while leaving decode-input staging eager."""
+
+    text_model = model.model
+    layers = text_model.layers
+
+    from sglang.srt.model_executor.cuda_graph_runner import set_torch_compile_config
+
+    set_torch_compile_config()
+    compile_mode = os.environ.get(
+        "SGLANG_TORCH_COMPILE_MODE",
+        "max-autotune-no-cudagraphs",
+    )
+    text_model._compiled_decode_layers = [
+        torch.compile(layer, mode=compile_mode) for layer in layers
+    ]
+
+
+def _audio_to_list(audio: Any) -> list[float]:
+    if isinstance(audio, torch.Tensor):
+        return audio.detach().float().cpu().flatten().tolist()
+    try:
+        import numpy as np
+
+        array = np.asarray(audio, dtype=np.float32).reshape(-1)
+        return array.tolist()
+    except (TypeError, ValueError) as exc:
+        raise TypeError(
+            f"Unsupported Qwen3-TTS audio output type: {type(audio)}"
+        ) from exc
+
+
 def _build_usage(state: Qwen3TTSState) -> dict[str, Any] | None:
     if not (state.prompt_tokens or state.completion_tokens or state.engine_time_s):
         return None
@@ -156,14 +188,20 @@ def create_sglang_tts_engine_executor(
         checkpoint_dir,
         context_length=8192,
         dtype=dtype,
-        disable_cuda_graph=True,
+        disable_cuda_graph=False,
         disable_overlap_schedule=True,
+        enable_torch_compile=True,
         mem_fraction_static=0.85,
         max_prefill_tokens=8192,
         max_running_requests=16,
         sampling_backend="pytorch",
+        torch_compile_max_bs=16,
         trust_remote_code=True,
     )
+
+    want_cuda_graph = not bool(getattr(server_args, "disable_cuda_graph", False))
+    if want_cuda_graph:
+        server_args.disable_cuda_graph = True
 
     (
         model_worker,
@@ -178,6 +216,9 @@ def create_sglang_tts_engine_executor(
         gpu_id,
         model_arch_override="Qwen3TTSTalker",
     )
+
+    if want_cuda_graph:
+        server_args.disable_cuda_graph = False
 
     model = model_worker.model_runner.model
     speech_tokenizer = _load_qwen3_tts_tokenizer(
@@ -194,6 +235,11 @@ def create_sglang_tts_engine_executor(
         generate_defaults=_load_qwen3_tts_generate_defaults(checkpoint_dir),
     )
     set_qwen3_tts_preprocessing_context(model=model, wrapper=wrapper)
+    if bool(getattr(server_args, "enable_torch_compile", False)):
+        _compile_qwen3_tts_backbone(model)
+        server_args.enable_torch_compile = False
+    if want_cuda_graph:
+        model_worker.model_runner.init_device_graphs()
 
     output_proc = SGLangOutputProcessor(
         capture_hidden=False,

--- a/sglang_omni/models/voxtral_tts/model_runner.py
+++ b/sglang_omni/models/voxtral_tts/model_runner.py
@@ -26,8 +26,10 @@ class VoxtralTTSModelRunner(ModelRunner):
         requests: list,
     ) -> GenerationBatchResult | None:
         del schedule_batch
-        input_embeds = self._build_prefill_input_embeds(forward_batch, requests)
-        return self._forward_with_input_embeds(forward_batch, input_embeds)
+        forward_batch.input_embeds = self._build_prefill_input_embeds(
+            forward_batch, requests
+        )
+        return None
 
     def prepare_decode(
         self,
@@ -35,19 +37,25 @@ class VoxtralTTSModelRunner(ModelRunner):
         schedule_batch: Any,
         requests: list,
     ) -> GenerationBatchResult | None:
-        del schedule_batch
+        del forward_batch, schedule_batch
+        self._write_decode_input_embed_buffer(requests)
+        return None
+
+    def _write_decode_input_embed_buffer(self, requests: list) -> None:
+        batch_size = len(requests)
+        buffer = self.model._decode_input_embed_buffer
         rows = []
         for sched_req in requests:
             queue = sched_req.data.pending_feedback_queue
             if not queue:
-                rows.append(torch.zeros(self.model.hidden_size))
+                rows.append(torch.zeros(self.model.hidden_size, device=buffer.device))
                 continue
             rows.append(queue.popleft())
-        input_embeds = torch.stack(rows, dim=0).to(
-            device=forward_batch.input_ids.device,
-            dtype=next(self.model.parameters()).dtype,
+        stacked = torch.stack(rows, dim=0).to(
+            device=buffer.device,
+            dtype=buffer.dtype,
         )
-        return self._forward_with_input_embeds(forward_batch, input_embeds)
+        buffer[:batch_size].copy_(stacked)
 
     def post_prefill(
         self,
@@ -151,26 +159,3 @@ class VoxtralTTSModelRunner(ModelRunner):
             sched_req.data.pending_feedback_queue.append(
                 embeds[row_idx, 0].detach().clone()
             )
-
-    def _forward_with_input_embeds(
-        self,
-        forward_batch: Any,
-        input_embeds: torch.Tensor,
-    ) -> GenerationBatchResult:
-        model_runner = self.tp_worker.model_runner
-        model_runner.attn_backend.init_forward_metadata(forward_batch)
-        input_embeds = input_embeds.to(
-            device=forward_batch.input_ids.device,
-            dtype=next(self.model.parameters()).dtype,
-        )
-        logits_output = self.model(
-            input_ids=forward_batch.input_ids,
-            positions=forward_batch.positions,
-            forward_batch=forward_batch,
-            input_embeds=input_embeds,
-        )
-        return GenerationBatchResult(
-            logits_output=logits_output,
-            next_token_ids=None,
-            can_run_cuda_graph=False,
-        )

--- a/sglang_omni/models/voxtral_tts/model_runner.py
+++ b/sglang_omni/models/voxtral_tts/model_runner.py
@@ -43,6 +43,8 @@ class VoxtralTTSModelRunner(ModelRunner):
 
     def _write_decode_input_embed_buffer(self, requests: list) -> None:
         batch_size = len(requests)
+        if batch_size == 0:
+            return
         buffer = self.model._decode_input_embed_buffer
         rows = []
         for sched_req in requests:

--- a/sglang_omni/models/voxtral_tts/pipeline/stages.py
+++ b/sglang_omni/models/voxtral_tts/pipeline/stages.py
@@ -213,6 +213,7 @@ def create_generation_executor(
     voice_embeddings = _load_voxtral_voice_embeddings(checkpoint_dir, device)
     model = model_worker.model_runner.model
     if want_cuda_graph:
+        # Voxtral uses SGLang's native compile path during graph capture.
         model_worker.model_runner.init_device_graphs()
 
     request_builder, result_adapter = make_voxtral_scheduler_adapters(

--- a/sglang_omni/models/voxtral_tts/pipeline/stages.py
+++ b/sglang_omni/models/voxtral_tts/pipeline/stages.py
@@ -182,13 +182,20 @@ def create_generation_executor(
         checkpoint_dir,
         context_length=8192,
         dtype="bfloat16",
-        disable_cuda_graph=True,
+        disable_cuda_graph=False,
         disable_overlap_schedule=True,
         decrypted_config_file=_write_voxtral_sglang_config(checkpoint_dir),
+        enable_torch_compile=True,
         mem_fraction_static=0.85,
         max_prefill_tokens=8192,
         max_running_requests=16,
+        sampling_backend="pytorch",
+        torch_compile_max_bs=16,
     )
+
+    want_cuda_graph = not bool(getattr(server_args, "disable_cuda_graph", False))
+    if want_cuda_graph:
+        server_args.disable_cuda_graph = True
 
     (
         model_worker,
@@ -200,8 +207,14 @@ def create_generation_executor(
         model_config,
     ) = create_sglang_infrastructure(server_args, gpu_id)
 
+    if want_cuda_graph:
+        server_args.disable_cuda_graph = False
+
     voice_embeddings = _load_voxtral_voice_embeddings(checkpoint_dir, device)
     model = model_worker.model_runner.model
+    if want_cuda_graph:
+        model_worker.model_runner.init_device_graphs()
+
     request_builder, result_adapter = make_voxtral_scheduler_adapters(
         model=model,
         voice_embeddings=voice_embeddings,

--- a/sglang_omni/models/voxtral_tts/sglang_model.py
+++ b/sglang_omni/models/voxtral_tts/sglang_model.py
@@ -189,6 +189,14 @@ class VoxtralSGLangTTSModel(nn.Module):
         )
         self.audio_token_id = self.voxtral_config.audio_model_args.audio_token_id
         self.hidden_size = text_cfg.dim
+        max_batch_size = server_args.max_running_requests
+        embed_weight = next(self.language_model.embed_tokens.parameters())
+        self._decode_input_embed_buffer = torch.zeros(
+            max_batch_size,
+            text_cfg.dim,
+            device=embed_weight.device,
+            dtype=embed_weight.dtype,
+        )
 
     def get_input_embeddings(self):
         return self.language_model.embed_tokens
@@ -201,6 +209,8 @@ class VoxtralSGLangTTSModel(nn.Module):
         forward_batch: ForwardBatch,
         input_embeds: torch.Tensor | None = None,
     ) -> LogitsProcessorOutput:
+        if input_embeds is None and forward_batch.forward_mode.is_decode():
+            input_embeds = self._decode_input_embed_buffer[: input_ids.shape[0]]
         hidden_states = self.language_model(
             input_ids=input_ids,
             positions=positions,
@@ -210,8 +220,11 @@ class VoxtralSGLangTTSModel(nn.Module):
         if forward_batch.forward_mode.is_extend():
             last_index = self._extend_last_index(forward_batch, hidden_states.device)
             hidden_states = hidden_states[last_index]
+        # Voxtral samples acoustic codes from hidden_states in the model runner,
+        # but SGLang's CUDA graph replay expects this field to be sliceable.
+        next_token_logits = hidden_states.new_empty((hidden_states.shape[0], 1))
         return LogitsProcessorOutput(
-            next_token_logits=None,
+            next_token_logits=next_token_logits,
             hidden_states=hidden_states,
         )
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -233,11 +233,12 @@ that happened to contain an older version of the test.
   - Bailing tokenizer loader fallback for vocab compatibility
   - TP topology validation (rank-specific stage specs, talker/thinker GPU collision detection, server_args alignment before infra init).
 
-- `unit_test/qwen3_tts/`: Qwen3-TTS Base unit tests:
+- `unit_test/qwen3_tts/`: Qwen3-TTS unit tests:
   - pipeline config and registry contracts
   - OmniScheduler-backed AR stage factory wiring
   - request mapping for `ref_audio` / `ref_text` and `references`
   - model-owned default preservation for language and sampling parameters
+  - Base, CustomVoice, and VoiceDesign request validation
   - voice-clone reference validation
   - pipeline payload state serialization.
 

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -1070,6 +1070,20 @@ def test_qwen3_tts_steady_decode_reports_cuda_graph_ready(
     assert fake_forward_batch.input_ids.tolist() == [0]
 
 
+def test_qwen3_tts_decode_feedback_empty_batch_noops() -> None:
+    from sglang_omni.models.qwen3_tts.model_runner import Qwen3TTSModelRunner
+
+    runner = Qwen3TTSModelRunner.__new__(Qwen3TTSModelRunner)
+    runner.model = SimpleNamespace(
+        _decode_feedback_embedding=torch.nn.Embedding(1, 4),
+    )
+    forward_batch = SimpleNamespace(input_ids=torch.empty(0, dtype=torch.long))
+
+    runner._write_feedback_buffers(forward_batch, [])
+
+    assert forward_batch.input_ids.numel() == 0
+
+
 def test_qwen3_tts_decode_forward_does_not_clear_feedback_mask(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1086,6 +1100,7 @@ def test_qwen3_tts_decode_forward_does_not_clear_feedback_mask(
     torch.nn.Module.__init__(model)
     model.codec_embedding = torch.nn.Embedding(8, 4)
     model.layers = torch.nn.ModuleList([])
+    model._compiled_decode_layers = model.layers
     model.start_layer = 0
     model.end_layer = 0
     model.norm = IdentityNorm()
@@ -1097,7 +1112,7 @@ def test_qwen3_tts_decode_forward_does_not_clear_feedback_mask(
         model._decode_feedback_embedding.weight[0].fill_(7.0)
 
     output = model.forward(
-        input_ids=torch.tensor([1]),
+        input_ids=torch.tensor([0]),
         positions=torch.tensor([0]),
         forward_batch=SimpleNamespace(
             forward_mode=SimpleNamespace(is_decode=lambda: True),
@@ -1106,6 +1121,32 @@ def test_qwen3_tts_decode_forward_does_not_clear_feedback_mask(
 
     assert torch.equal(output, model._decode_feedback_embedding.weight[:1])
     assert bool(model._feedback_mask[0]) is True
+
+
+def test_qwen3_tts_decode_forward_rejects_invalid_feedback_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang(monkeypatch)
+    from sglang_omni.models.qwen3_tts.sglang_model import Qwen3TTSTalkerTextModel
+
+    model = Qwen3TTSTalkerTextModel.__new__(Qwen3TTSTalkerTextModel)
+    torch.nn.Module.__init__(model)
+    model.codec_embedding = torch.nn.Embedding(8, 4)
+    model.layers = torch.nn.ModuleList([])
+    model._compiled_decode_layers = model.layers
+    model.start_layer = 0
+    model.end_layer = 0
+    model.norm = torch.nn.Identity()
+    model._decode_feedback_embedding = torch.nn.Embedding(1, 4)
+
+    with pytest.raises(IndexError):
+        model.forward(
+            input_ids=torch.tensor([1]),
+            positions=torch.tensor([0]),
+            forward_batch=SimpleNamespace(
+                forward_mode=SimpleNamespace(is_decode=lambda: True),
+            ),
+        )
 
 
 def test_qwen3_tts_prepare_decode_buffers_collects_private_subtalker_seeds(
@@ -1300,6 +1341,52 @@ def test_qwen3_tts_sampled_subtalker_requires_semantic_positions(
             torch.tensor([[0.0, 0.0]]),
             0,
         )
+
+
+def test_qwen3_tts_compile_backbone_requires_text_layers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang(monkeypatch)
+    from sglang_omni.models.qwen3_tts.stages import _compile_qwen3_tts_backbone
+
+    with pytest.raises(AttributeError):
+        _compile_qwen3_tts_backbone(SimpleNamespace())
+
+
+def test_qwen3_tts_compile_backbone_compiles_every_layer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang(monkeypatch)
+    from sglang_omni.models.qwen3_tts.stages import _compile_qwen3_tts_backbone
+
+    set_config_calls = []
+    compiled = []
+    cuda_graph_runner = types.ModuleType("sglang.srt.model_executor.cuda_graph_runner")
+    cuda_graph_runner.set_torch_compile_config = lambda: set_config_calls.append(True)
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang.srt.model_executor.cuda_graph_runner",
+        cuda_graph_runner,
+    )
+
+    def fake_compile(layer, *, mode):
+        compiled.append((layer, mode))
+        return f"compiled-{len(compiled)}"
+
+    monkeypatch.setattr(torch, "compile", fake_compile)
+    layers = [object(), object(), object()]
+    text_model = SimpleNamespace(layers=layers)
+    model = SimpleNamespace(model=text_model)
+
+    _compile_qwen3_tts_backbone(model)
+
+    assert set_config_calls == [True]
+    assert compiled == [(layer, "max-autotune-no-cudagraphs") for layer in layers]
+    assert text_model._compiled_decode_layers == [
+        "compiled-1",
+        "compiled-2",
+        "compiled-3",
+    ]
 
 
 def test_qwen3_tts_engine_reenables_cuda_graph_after_bootstrap(

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -476,6 +476,46 @@ def test_qwen3_tts_custom_voice_rejects_base_only_fields() -> None:
         build_qwen3_tts_state(payload)
 
 
+@pytest.mark.parametrize(
+    ("task_type", "extra_tts_params", "match"),
+    [
+        ("CustomVoice", {}, "CustomVoice does not accept ref_audio"),
+        (
+            "VoiceDesign",
+            {"instructions": "A warm adult voice."},
+            "VoiceDesign does not accept ref_audio",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    ("inputs", "tts_params"),
+    [
+        ("target", {"ref_audio": "voice.wav"}),
+        ({"text": "target", "references": [{"audio_path": "voice.wav"}]}, {}),
+        ({"text": "target", "references": [{"ref_audio": "voice.wav"}]}, {}),
+        ({"text": "target", "references": [{"audio": "voice.wav"}]}, {}),
+    ],
+)
+def test_qwen3_tts_non_base_tasks_reject_audio_references(
+    task_type: str,
+    extra_tts_params: dict[str, str],
+    match: str,
+    inputs: object,
+    tts_params: dict[str, str],
+) -> None:
+    payload = make_payload(
+        inputs=inputs,
+        tts_params={
+            "task_type": task_type,
+            **extra_tts_params,
+            **tts_params,
+        },
+    )
+
+    with pytest.raises(ValueError, match=match):
+        build_qwen3_tts_state(payload)
+
+
 def test_qwen3_tts_voice_design_requires_instructions() -> None:
     payload = make_payload(
         inputs="target",

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -233,7 +233,11 @@ def test_qwen3_tts_config_and_registry_contracts() -> None:
 def test_qwen3_tts_state_round_trip_preserves_request_fields() -> None:
     state = Qwen3TTSState(
         text="hello",
+        task_type="CustomVoice",
+        task_type_explicit=True,
         language="en",
+        voice="Vivian",
+        instructions="warm",
         ref_audio="voice.wav",
         ref_text="reference",
         generation_kwargs={"max_new_tokens": 128, "temperature": 0.7},
@@ -244,7 +248,11 @@ def test_qwen3_tts_state_round_trip_preserves_request_fields() -> None:
     )
     restored = Qwen3TTSState.from_dict(state.to_dict())
     assert restored.text == "hello"
+    assert restored.task_type == "CustomVoice"
+    assert restored.task_type_explicit is True
     assert restored.language == "en"
+    assert restored.voice == "Vivian"
+    assert restored.instructions == "warm"
     assert restored.ref_audio == "voice.wav"
     assert restored.ref_text == "reference"
     assert restored.generation_kwargs["max_new_tokens"] == 128
@@ -270,6 +278,7 @@ def test_qwen3_tts_maps_references_and_keeps_upstream_sampling_defaults() -> Non
     state = build_qwen3_tts_state(payload)
 
     assert state.text == "target"
+    assert state.task_type == "Base"
     assert state.language == "auto"
     assert state.ref_audio == "voice.wav"
     assert state.ref_text == "reference"
@@ -444,6 +453,56 @@ def test_qwen3_tts_public_seed_derivation_is_stable() -> None:
     assert derive_qwen3_tts_sampling_seeds(123456) == (709979716, 2088621061)
 
 
+def test_qwen3_tts_text_only_defaults_to_custom_voice() -> None:
+    payload = make_payload(inputs="target", tts_params={"voice": "default"})
+
+    state = build_qwen3_tts_state(payload)
+
+    assert state.task_type == "CustomVoice"
+    assert state.task_type_explicit is False
+    assert state.voice == "Vivian"
+    assert state.ref_audio is None
+    assert state.ref_text is None
+    assert state.non_streaming_mode is True
+
+
+def test_qwen3_tts_custom_voice_rejects_base_only_fields() -> None:
+    payload = make_payload(
+        inputs="target",
+        tts_params={"task_type": "CustomVoice", "ref_text": "reference"},
+    )
+
+    with pytest.raises(ValueError, match="CustomVoice does not accept ref_text"):
+        build_qwen3_tts_state(payload)
+
+
+def test_qwen3_tts_voice_design_requires_instructions() -> None:
+    payload = make_payload(
+        inputs="target",
+        tts_params={"task_type": "VoiceDesign"},
+    )
+
+    with pytest.raises(ValueError, match="VoiceDesign requires instructions"):
+        build_qwen3_tts_state(payload)
+
+
+def test_qwen3_tts_voice_design_state_forces_non_streaming() -> None:
+    payload = make_payload(
+        inputs="target",
+        tts_params={
+            "task_type": "VoiceDesign",
+            "instructions": "A warm adult voice.",
+        },
+    )
+
+    state = build_qwen3_tts_state(payload)
+
+    assert state.task_type == "VoiceDesign"
+    assert state.instructions == "A warm adult voice."
+    assert state.voice is None
+    assert state.non_streaming_mode is True
+
+
 def test_qwen3_tts_uses_x_vector_only_when_ref_text_is_missing() -> None:
     payload = make_payload(
         inputs={"text": "target", "references": [{"audio_path": "voice.wav"}]},
@@ -457,7 +516,7 @@ def test_qwen3_tts_uses_x_vector_only_when_ref_text_is_missing() -> None:
 
 
 def test_qwen3_tts_rejects_missing_reference_audio() -> None:
-    payload = make_payload(inputs="target")
+    payload = make_payload(inputs="target", tts_params={"task_type": "Base"})
 
     with pytest.raises(ValueError, match="requires reference audio"):
         build_qwen3_tts_state(payload)
@@ -515,6 +574,44 @@ def test_qwen3_tts_predictor_codec_embeddings_use_talker_hidden_size(
 
     assert predictor.model.codec_embedding[0].weight.shape == (2048, 2048)
     assert predictor.small_to_mtp_projection.weight.shape == (1024, 2048)
+
+
+def test_qwen3_tts_custom_voice_requires_speaker_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang(monkeypatch)
+    from sglang_omni.models.qwen3_tts.sglang_model import Qwen3TTSTalker
+
+    talker = Qwen3TTSTalker.__new__(Qwen3TTSTalker)
+    talker.config = SimpleNamespace(spk_id={})
+
+    with pytest.raises(ValueError, match="configured spk_id"):
+        Qwen3TTSTalker.build_custom_voice_inputs(
+            talker,
+            input_id=torch.arange(8, dtype=torch.long).unsqueeze(0),
+            voice="Vivian",
+            language="auto",
+            non_streaming_mode=True,
+        )
+
+
+def test_qwen3_tts_custom_voice_rejects_invalid_speaker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang(monkeypatch)
+    from sglang_omni.models.qwen3_tts.sglang_model import Qwen3TTSTalker
+
+    talker = Qwen3TTSTalker.__new__(Qwen3TTSTalker)
+    talker.config = SimpleNamespace(spk_id={"Vivian": 3065})
+
+    with pytest.raises(ValueError, match="Unsupported Qwen3-TTS CustomVoice speaker"):
+        Qwen3TTSTalker.build_custom_voice_inputs(
+            talker,
+            input_id=torch.arange(8, dtype=torch.long).unsqueeze(0),
+            voice="Missing",
+            language="auto",
+            non_streaming_mode=True,
+        )
 
 
 def test_qwen3_tts_vocoder_batches_decode_requests(
@@ -725,6 +822,140 @@ def test_qwen3_tts_prepared_payload_missing_state_fails_without_rebuild(
                 config=SimpleNamespace(codec_eos_token_id=42, vocab_size=1200)
             ),
             wrapper=object(),
+        )
+
+
+def test_qwen3_tts_prepare_custom_voice_uses_speaker_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, object]] = []
+
+    class FakeWrapper:
+        def _build_assistant_text(self, text):
+            return f"assistant:{text}"
+
+        def _build_instruct_text(self, text):
+            return f"instruct:{text}"
+
+        def _tokenize_texts(self, texts):
+            return [torch.arange(8, dtype=torch.long).unsqueeze(0) for _ in texts]
+
+        def _merge_generate_kwargs(self, **kwargs):
+            return kwargs
+
+        def create_voice_clone_prompt(self, **kwargs):
+            calls.append(("base", kwargs))
+            return []
+
+    class FakeModel:
+        tts_model_type = "custom_voice"
+        model = SimpleNamespace(_feedback_buffer=torch.zeros(4, 4))
+
+        def build_custom_voice_inputs(self, **kwargs):
+            calls.append(("custom", kwargs))
+            return (
+                torch.ones(1, 3, 4),
+                torch.ones(1, 3, dtype=torch.long),
+                torch.ones(1, 1, 4),
+                None,
+            )
+
+    monkeypatch.setattr(
+        qwen3_request_builders,
+        "_build_qwen3_tts_pad_embed",
+        lambda model: torch.zeros(4),
+    )
+
+    prepared = qwen3_request_builders._prepare_qwen3_tts_request(
+        make_payload(
+            inputs="target",
+            tts_params={
+                "task_type": "CustomVoice",
+                "voice": "Ryan",
+                "instructions": "calm",
+            },
+        ),
+        model=FakeModel(),
+        wrapper=FakeWrapper(),
+    )
+
+    assert prepared.state.task_type == "CustomVoice"
+    assert prepared.state.voice == "Ryan"
+    assert [name for name, _ in calls] == ["custom"]
+    kwargs = calls[0][1]
+    assert kwargs["voice"] == "Ryan"
+    assert kwargs["instruct_id"] is not None
+
+
+def test_qwen3_tts_prepare_voice_design_uses_instruction_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict] = []
+
+    class FakeWrapper:
+        def _build_assistant_text(self, text):
+            return f"assistant:{text}"
+
+        def _build_instruct_text(self, text):
+            return f"instruct:{text}"
+
+        def _tokenize_texts(self, texts):
+            return [torch.arange(8, dtype=torch.long).unsqueeze(0) for _ in texts]
+
+        def _merge_generate_kwargs(self, **kwargs):
+            return kwargs
+
+    class FakeModel:
+        tts_model_type = "voice_design"
+        model = SimpleNamespace(_feedback_buffer=torch.zeros(4, 4))
+
+        def build_voice_design_inputs(self, **kwargs):
+            calls.append(kwargs)
+            return (
+                torch.ones(1, 3, 4),
+                torch.ones(1, 3, dtype=torch.long),
+                torch.ones(1, 1, 4),
+                None,
+            )
+
+    monkeypatch.setattr(
+        qwen3_request_builders,
+        "_build_qwen3_tts_pad_embed",
+        lambda model: torch.zeros(4),
+    )
+
+    prepared = qwen3_request_builders._prepare_qwen3_tts_request(
+        make_payload(
+            inputs="target",
+            tts_params={
+                "task_type": "VoiceDesign",
+                "instructions": "A warm adult voice.",
+            },
+        ),
+        model=FakeModel(),
+        wrapper=FakeWrapper(),
+    )
+
+    assert prepared.state.task_type == "VoiceDesign"
+    assert prepared.state.instructions == "A warm adult voice."
+    assert len(calls) == 1
+    assert calls[0]["instruct_id"] is not None
+
+
+def test_qwen3_tts_base_checkpoint_text_only_rejects_custom_voice_default() -> None:
+    class FakeWrapper:
+        def _merge_generate_kwargs(self, **kwargs):
+            return kwargs
+
+    model = SimpleNamespace(tts_model_type="base")
+
+    with pytest.raises(
+        ValueError, match="Base requires ref_audio or speaker_embedding"
+    ):
+        qwen3_request_builders._prepare_qwen3_tts_request(
+            make_payload(inputs="target"),
+            model=model,
+            wrapper=FakeWrapper(),
         )
 
 
@@ -1014,8 +1245,13 @@ def test_qwen3_tts_steady_decode_reports_cuda_graph_ready(
             del requests
             self.prepare_calls += 1
 
-        def code_predictor_forward(self, layer0_codes, hidden) -> None:
-            del layer0_codes, hidden
+        def code_predictor_forward(
+            self,
+            layer0_codes,
+            hidden,
+            semantic_positions=None,
+        ) -> None:
+            del layer0_codes, hidden, semantic_positions
 
     class FakeTPWorker:
         gpu_id = 0
@@ -1035,7 +1271,7 @@ def test_qwen3_tts_steady_decode_reports_cuda_graph_ready(
         def process(self, model_output, scheduler_output):
             del model_output
             return {
-                req.request_id: SimpleNamespace(extra={})
+                req.request_id: RequestOutput(req.request_id, data=7)
                 for req in scheduler_output.requests
             }
 

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -969,6 +969,147 @@ def test_qwen3_tts_collect_codes_excludes_semantic_eos(
     assert len(requests[0].data.output_codes) == 1
 
 
+def test_qwen3_tts_steady_decode_reports_cuda_graph_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Decode should use SGLang's graph-capable forward result."""
+    install_fake_sglang(monkeypatch)
+    from sglang.srt.model_executor import forward_batch_info
+
+    from sglang_omni.models.qwen3_omni.talker_model_runner import (
+        QwenTalkerModelRunner,
+    )
+    from sglang_omni.models.qwen3_tts.model_runner import Qwen3TTSModelRunner
+
+    fake_forward_batch = SimpleNamespace(
+        input_ids=torch.tensor([1]),
+        positions=torch.tensor([0]),
+        mrope_positions=None,
+    )
+    monkeypatch.setattr(
+        forward_batch_info.ForwardBatch,
+        "init_new",
+        staticmethod(lambda model_worker_batch, model_runner: fake_forward_batch),
+    )
+    monkeypatch.setattr(
+        QwenTalkerModelRunner,
+        "_take_next_decode_input_embed",
+        staticmethod(
+            lambda *, sched_req, device, dtype: torch.ones(
+                4, device=device, dtype=dtype
+            )
+        ),
+    )
+
+    class FakeQwenModel:
+        config = SimpleNamespace(codec_eos_token_id=-1)
+
+        def __init__(self) -> None:
+            self._feedback_buffer = torch.zeros(1, 4)
+            self._feedback_mask = torch.zeros(1, dtype=torch.bool)
+            self._decode_feedback_embedding = torch.nn.Embedding(1, 4)
+            self._output_codes = torch.ones(1, 2)
+            self._output_embeds = torch.ones(1, 4)
+            self.prepare_calls = 0
+
+        def prepare_decode_buffers(self, requests) -> None:
+            del requests
+            self.prepare_calls += 1
+
+        def code_predictor_forward(self, layer0_codes, hidden) -> None:
+            del layer0_codes, hidden
+
+    class FakeTPWorker:
+        gpu_id = 0
+        model_runner = SimpleNamespace(model=FakeQwenModel())
+
+        def forward_batch_generation(self, forward_batch):
+            del forward_batch
+            return SimpleNamespace(
+                logits_output=SimpleNamespace(hidden_states=torch.ones(1, 4)),
+                next_token_ids=torch.tensor([7]),
+                can_run_cuda_graph=True,
+            )
+
+    class FakeOutputProcessor:
+        _capture_hidden = False
+
+        def process(self, model_output, scheduler_output):
+            del model_output
+            return {
+                req.request_id: SimpleNamespace(extra={})
+                for req in scheduler_output.requests
+            }
+
+    runner = Qwen3TTSModelRunner.__new__(Qwen3TTSModelRunner)
+    runner.tp_worker = FakeTPWorker()
+    runner.output_processor = FakeOutputProcessor()
+    runner.device = torch.device("cpu")
+    runner.model = runner.tp_worker.model_runner.model
+
+    data = SimpleNamespace(
+        req=SimpleNamespace(sampling_params=SimpleNamespace(repetition_penalty=1.0)),
+        output_codes=[],
+        pending_feedback_queue=[],
+        generation_steps=0,
+        extra_model_outputs={},
+    )
+    request = SimpleNamespace(request_id="req", data=data)
+    schedule_batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(is_extend=lambda: False),
+        is_prefill_only=False,
+        output_ids=None,
+        get_model_worker_batch=lambda: SimpleNamespace(),
+    )
+
+    output = runner.execute(
+        SimpleNamespace(requests=[request], batch_data=schedule_batch)
+    )
+
+    assert output.can_run_cuda_graph is True
+    assert schedule_batch.output_ids.tolist() == [7]
+    assert runner.model.prepare_calls == 1
+    assert fake_forward_batch.input_ids.tolist() == [0]
+
+
+def test_qwen3_tts_decode_forward_does_not_clear_feedback_mask(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang(monkeypatch)
+    from sglang_omni.models.qwen3_tts.sglang_model import Qwen3TTSTalkerTextModel
+
+    class IdentityNorm(torch.nn.Module):
+        def forward(self, hidden_states, residual=None):
+            if residual is None:
+                return hidden_states
+            return hidden_states, residual
+
+    model = Qwen3TTSTalkerTextModel.__new__(Qwen3TTSTalkerTextModel)
+    torch.nn.Module.__init__(model)
+    model.codec_embedding = torch.nn.Embedding(8, 4)
+    model.layers = torch.nn.ModuleList([])
+    model.start_layer = 0
+    model.end_layer = 0
+    model.norm = IdentityNorm()
+    model._feedback_buffer = torch.full((1, 4), 5.0)
+    model._feedback_mask = torch.tensor([True])
+    model._decode_feedback_embedding = torch.nn.Embedding(1, 4)
+    model._decode_feedback_embedding.weight.requires_grad_(False)
+    with torch.no_grad():
+        model._decode_feedback_embedding.weight[0].fill_(7.0)
+
+    output = model.forward(
+        input_ids=torch.tensor([1]),
+        positions=torch.tensor([0]),
+        forward_batch=SimpleNamespace(
+            forward_mode=SimpleNamespace(is_decode=lambda: True),
+        ),
+    )
+
+    assert torch.equal(output, model._decode_feedback_embedding.weight[:1])
+    assert bool(model._feedback_mask[0]) is True
+
+
 def test_qwen3_tts_prepare_decode_buffers_collects_private_subtalker_seeds(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1163,10 +1304,10 @@ def test_qwen3_tts_sampled_subtalker_requires_semantic_positions(
         )
 
 
-def test_qwen3_tts_engine_keeps_cuda_graph_disabled_after_bootstrap(
+def test_qwen3_tts_engine_reenables_cuda_graph_after_bootstrap(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Qwen3-TTS CUDA graph support remains disabled until a follow-up PR."""
+    """Qwen3-TTS defers graph capture until custom buffers are ready."""
     install_fake_sglang(monkeypatch)
     from transformers import AutoProcessor
 
@@ -1278,9 +1419,10 @@ def test_qwen3_tts_engine_keeps_cuda_graph_disabled_after_bootstrap(
 
     scheduler = stages.create_sglang_tts_engine_executor("model", device="cuda:0")
 
-    assert build_kwargs["disable_cuda_graph"] is True
+    assert build_kwargs["disable_cuda_graph"] is False
+    assert build_kwargs["enable_torch_compile"] is True
     assert build_kwargs["sampling_backend"] == "pytorch"
     assert infrastructure_saw_graph_disabled == [True]
-    assert init_graph_calls == []
-    assert scheduler.server_args.disable_cuda_graph is True
+    assert init_graph_calls == [True]
+    assert scheduler.server_args.disable_cuda_graph is False
     clear_qwen3_tts_preprocessing_context()

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -1321,6 +1321,7 @@ def test_qwen3_tts_engine_reenables_cuda_graph_after_bootstrap(
     build_kwargs: dict = {}
     infrastructure_saw_graph_disabled: list[bool] = []
     init_graph_calls: list[bool] = []
+    compile_calls: list[bool] = []
 
     class FakeModel:
         def load_speech_tokenizer(self, tokenizer) -> None:
@@ -1332,6 +1333,8 @@ def test_qwen3_tts_engine_reenables_cuda_graph_after_bootstrap(
             self.model = FakeModel()
 
         def init_device_graphs(self) -> None:
+            assert self.server_args.enable_torch_compile is False
+            assert self.server_args.torch_compile_max_bs == 16
             init_graph_calls.append(True)
 
     class FakeWorker:
@@ -1363,6 +1366,11 @@ def test_qwen3_tts_engine_reenables_cuda_graph_after_bootstrap(
         "make_qwen3_tts_scheduler_adapters",
         lambda **kwargs: (lambda payload: payload, lambda data: data),
     )
+    monkeypatch.setattr(
+        stages,
+        "_compile_qwen3_tts_backbone",
+        lambda model: compile_calls.append(model),
+    )
 
     def fake_build_sglang_server_args(model_path, context_length, **kwargs):
         del model_path, context_length
@@ -1370,10 +1378,12 @@ def test_qwen3_tts_engine_reenables_cuda_graph_after_bootstrap(
         return SimpleNamespace(
             disable_cuda_graph=kwargs["disable_cuda_graph"],
             disable_overlap_schedule=kwargs["disable_overlap_schedule"],
+            enable_torch_compile=kwargs["enable_torch_compile"],
             page_size=1,
             chunked_prefill_size=0,
             max_prefill_tokens=kwargs["max_prefill_tokens"],
             max_running_requests=kwargs["max_running_requests"],
+            torch_compile_max_bs=kwargs["torch_compile_max_bs"],
         )
 
     def fake_create_sglang_infrastructure(server_args, gpu_id, **kwargs):
@@ -1420,7 +1430,11 @@ def test_qwen3_tts_engine_reenables_cuda_graph_after_bootstrap(
     assert build_kwargs["disable_cuda_graph"] is False
     assert build_kwargs["enable_torch_compile"] is True
     assert build_kwargs["sampling_backend"] == "pytorch"
+    assert build_kwargs["torch_compile_max_bs"] == 16
     assert infrastructure_saw_graph_disabled == [True]
+    assert len(compile_calls) == 1
     assert init_graph_calls == [True]
     assert scheduler.server_args.disable_cuda_graph is False
+    assert scheduler.server_args.enable_torch_compile is False
+    assert scheduler.server_args.torch_compile_max_bs == 16
     clear_qwen3_tts_preprocessing_context()

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -976,9 +976,7 @@ def test_qwen3_tts_steady_decode_reports_cuda_graph_ready(
     install_fake_sglang(monkeypatch)
     from sglang.srt.model_executor import forward_batch_info
 
-    from sglang_omni.models.qwen3_omni.talker_model_runner import (
-        QwenTalkerModelRunner,
-    )
+    from sglang_omni.models.qwen3_omni.talker_model_runner import QwenTalkerModelRunner
     from sglang_omni.models.qwen3_tts.model_runner import Qwen3TTSModelRunner
 
     fake_forward_batch = SimpleNamespace(

--- a/tests/unit_test/voxtral_tts/test_pipeline.py
+++ b/tests/unit_test/voxtral_tts/test_pipeline.py
@@ -244,6 +244,24 @@ def test_voxtral_decode_writes_feedback_buffer_for_standard_forward() -> None:
     )
 
 
+def test_voxtral_decode_empty_batch_keeps_feedback_buffer() -> None:
+    from sglang_omni.models.voxtral_tts.model_runner import VoxtralTTSModelRunner
+
+    runner = VoxtralTTSModelRunner.__new__(VoxtralTTSModelRunner)
+    runner.model = SimpleNamespace(
+        hidden_size=3,
+        _decode_input_embed_buffer=torch.ones(1, 3, dtype=torch.float16),
+    )
+
+    result = runner.prepare_decode(object(), object(), [])
+
+    assert result is None
+    assert torch.equal(
+        runner.model._decode_input_embed_buffer,
+        torch.ones(1, 3, dtype=torch.float16),
+    )
+
+
 def test_voxtral_steady_decode_reports_cuda_graph_ready(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_test/voxtral_tts/test_pipeline.py
+++ b/tests/unit_test/voxtral_tts/test_pipeline.py
@@ -224,9 +224,7 @@ def test_voxtral_decode_writes_feedback_buffer_for_standard_forward() -> None:
     )
     first = SimpleNamespace(
         data=SimpleNamespace(
-            pending_feedback_queue=collections.deque(
-                [torch.tensor([1.0, 2.0, 3.0])]
-            )
+            pending_feedback_queue=collections.deque([torch.tensor([1.0, 2.0, 3.0])])
         )
     )
     second = SimpleNamespace(

--- a/tests/unit_test/voxtral_tts/test_pipeline.py
+++ b/tests/unit_test/voxtral_tts/test_pipeline.py
@@ -313,7 +313,7 @@ def test_voxtral_steady_decode_reports_cuda_graph_ready(
         def process(self, model_output, scheduler_output):
             del model_output
             return {
-                req.request_id: SimpleNamespace(extra={})
+                req.request_id: RequestOutput(req.request_id, data=5)
                 for req in scheduler_output.requests
             }
 

--- a/tests/unit_test/voxtral_tts/test_pipeline.py
+++ b/tests/unit_test/voxtral_tts/test_pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections
 from types import SimpleNamespace
 
 import numpy as np
@@ -211,3 +212,262 @@ def test_voxtral_collect_audio_step_reuses_output_tokens_for_eos_filter() -> Non
 
     runner.post_process_outputs(result, SimpleNamespace(requests=requests), {})
     assert len(requests[0].data.output_codes) == 1
+
+
+def test_voxtral_decode_writes_feedback_buffer_for_standard_forward() -> None:
+    from sglang_omni.models.voxtral_tts.model_runner import VoxtralTTSModelRunner
+
+    runner = VoxtralTTSModelRunner.__new__(VoxtralTTSModelRunner)
+    runner.model = SimpleNamespace(
+        hidden_size=3,
+        _decode_input_embed_buffer=torch.zeros(2, 3, dtype=torch.float16),
+    )
+    first = SimpleNamespace(
+        data=SimpleNamespace(
+            pending_feedback_queue=collections.deque(
+                [torch.tensor([1.0, 2.0, 3.0])]
+            )
+        )
+    )
+    second = SimpleNamespace(
+        data=SimpleNamespace(pending_feedback_queue=collections.deque())
+    )
+
+    result = runner.prepare_decode(object(), object(), [first, second])
+
+    assert result is None
+    assert not first.data.pending_feedback_queue
+    assert torch.equal(
+        runner.model._decode_input_embed_buffer,
+        torch.tensor(
+            [[1.0, 2.0, 3.0], [0.0, 0.0, 0.0]],
+            dtype=torch.float16,
+        ),
+    )
+
+
+def test_voxtral_steady_decode_reports_cuda_graph_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Decode should use SGLang's graph-capable forward result."""
+    from sglang.srt.model_executor import forward_batch_info
+
+    from sglang_omni.models.voxtral_tts.model_runner import VoxtralTTSModelRunner
+
+    fake_forward_batch = SimpleNamespace(
+        input_ids=torch.tensor([1]),
+        positions=torch.tensor([0]),
+        mrope_positions=None,
+    )
+    monkeypatch.setattr(
+        forward_batch_info.ForwardBatch,
+        "init_new",
+        staticmethod(lambda model_worker_batch, model_runner: fake_forward_batch),
+    )
+
+    class FakeVoxtralModel:
+        hidden_size = 3
+
+        def __init__(self) -> None:
+            self._decode_input_embed_buffer = torch.zeros(1, 3)
+
+        def acoustic_transformer(self, hidden):
+            assert hidden.shape == (1, 3)
+            return torch.tensor([[5]])
+
+        def audio_token_embedding(self, codes):
+            del codes
+            return torch.ones(1, 1, 3)
+
+    class FakeTPWorker:
+        gpu_id = 0
+        model_runner = SimpleNamespace(model=FakeVoxtralModel())
+
+        def forward_batch_generation(self, forward_batch):
+            del forward_batch
+            return SimpleNamespace(
+                logits_output=SimpleNamespace(hidden_states=torch.ones(1, 3)),
+                next_token_ids=None,
+                can_run_cuda_graph=True,
+            )
+
+    class FakeOutputProcessor:
+        _capture_hidden = False
+
+        def process(self, model_output, scheduler_output):
+            del model_output
+            return {
+                req.request_id: SimpleNamespace(extra={})
+                for req in scheduler_output.requests
+            }
+
+    runner = VoxtralTTSModelRunner.__new__(VoxtralTTSModelRunner)
+    runner.tp_worker = FakeTPWorker()
+    runner.output_processor = FakeOutputProcessor()
+    runner.device = torch.device("cpu")
+    runner.model = runner.tp_worker.model_runner.model
+
+    data = SimpleNamespace(
+        pending_feedback_queue=collections.deque([torch.tensor([1.0, 2.0, 3.0])]),
+        output_codes=[],
+        generation_steps=0,
+        extra_model_outputs={},
+    )
+    request = SimpleNamespace(request_id="req", data=data)
+    schedule_batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(is_extend=lambda: False),
+        is_prefill_only=False,
+        output_ids=None,
+        get_model_worker_batch=lambda: SimpleNamespace(),
+    )
+
+    output = runner.execute(
+        SimpleNamespace(requests=[request], batch_data=schedule_batch)
+    )
+
+    assert output.can_run_cuda_graph is True
+    assert schedule_batch.output_ids.tolist() == [5]
+    assert torch.equal(
+        runner.model._decode_input_embed_buffer,
+        torch.tensor([[1.0, 2.0, 3.0]]),
+    )
+
+
+def test_voxtral_forward_returns_graph_compatible_logits() -> None:
+    from sglang_omni.models.voxtral_tts.sglang_model import VoxtralSGLangTTSModel
+
+    model = VoxtralSGLangTTSModel.__new__(VoxtralSGLangTTSModel)
+    model._decode_input_embed_buffer = torch.arange(6, dtype=torch.float32).reshape(
+        2, 3
+    )
+
+    def fake_language_model(input_ids, positions, forward_batch, input_embeds=None):
+        del input_ids, positions, forward_batch
+        assert input_embeds is not None
+        return input_embeds + 1
+
+    model.language_model = fake_language_model
+    forward_batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(
+            is_decode=lambda: True,
+            is_extend=lambda: False,
+        )
+    )
+
+    output = model.forward(
+        torch.tensor([1, 2]),
+        torch.tensor([0, 1]),
+        forward_batch,
+    )
+
+    assert output.hidden_states.shape == (2, 3)
+    assert output.next_token_logits.shape == (2, 1)
+    assert output.next_token_logits.dtype == output.hidden_states.dtype
+    assert output.next_token_logits.device == output.hidden_states.device
+
+
+def test_voxtral_generation_reenables_cuda_graph_after_bootstrap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.voxtral_tts import model_runner as model_runner_mod
+    from sglang_omni.models.voxtral_tts import request_builders
+    from sglang_omni.models.voxtral_tts.pipeline import stages
+    from sglang_omni.scheduling import bootstrap as bootstrap_mod
+    from sglang_omni.scheduling import omni_scheduler as scheduler_mod
+    from sglang_omni.scheduling import sglang_backend
+
+    build_kwargs: dict = {}
+    infrastructure_saw_graph_disabled: list[bool] = []
+    init_graph_calls: list[bool] = []
+
+    class FakeModel:
+        pass
+
+    class FakeSGLangRunner:
+        def __init__(self, server_args) -> None:
+            self.server_args = server_args
+            self.model = FakeModel()
+
+        def init_device_graphs(self) -> None:
+            init_graph_calls.append(True)
+
+    class FakeWorker:
+        def __init__(self, server_args) -> None:
+            self.model_runner = FakeSGLangRunner(server_args)
+
+    monkeypatch.setattr(stages, "_resolve_checkpoint", lambda model_path: model_path)
+    monkeypatch.setattr(
+        stages,
+        "_write_voxtral_sglang_config",
+        lambda checkpoint_dir: f"{checkpoint_dir}/config.json",
+    )
+    monkeypatch.setattr(
+        stages,
+        "_load_voxtral_voice_embeddings",
+        lambda checkpoint_dir, device: {},
+    )
+    monkeypatch.setattr(
+        request_builders,
+        "make_voxtral_scheduler_adapters",
+        lambda **kwargs: (lambda payload: payload, lambda data: data),
+    )
+
+    def fake_build_sglang_server_args(model_path, context_length, **kwargs):
+        del model_path, context_length
+        build_kwargs.update(kwargs)
+        return SimpleNamespace(
+            disable_cuda_graph=kwargs["disable_cuda_graph"],
+            disable_overlap_schedule=kwargs["disable_overlap_schedule"],
+            page_size=1,
+            chunked_prefill_size=0,
+            max_prefill_tokens=kwargs["max_prefill_tokens"],
+            max_running_requests=kwargs["max_running_requests"],
+        )
+
+    def fake_create_sglang_infrastructure(server_args, gpu_id, **kwargs):
+        del gpu_id, kwargs
+        infrastructure_saw_graph_disabled.append(bool(server_args.disable_cuda_graph))
+        return (
+            FakeWorker(server_args),
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            SimpleNamespace(),
+        )
+
+    monkeypatch.setattr(
+        sglang_backend,
+        "build_sglang_server_args",
+        fake_build_sglang_server_args,
+    )
+    monkeypatch.setattr(
+        bootstrap_mod,
+        "create_sglang_infrastructure",
+        fake_create_sglang_infrastructure,
+    )
+    monkeypatch.setattr(
+        sglang_backend,
+        "SGLangOutputProcessor",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    monkeypatch.setattr(
+        model_runner_mod,
+        "VoxtralTTSModelRunner",
+        lambda *args, **kwargs: SimpleNamespace(args=args, kwargs=kwargs),
+    )
+    monkeypatch.setattr(
+        scheduler_mod,
+        "OmniScheduler",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    scheduler = stages.create_generation_executor("model", device="cuda:0")
+
+    assert build_kwargs["disable_cuda_graph"] is False
+    assert build_kwargs["enable_torch_compile"] is True
+    assert build_kwargs["sampling_backend"] == "pytorch"
+    assert infrastructure_saw_graph_disabled == [True]
+    assert init_graph_calls == [True]
+    assert scheduler.server_args.disable_cuda_graph is False

--- a/tests/unit_test/voxtral_tts/test_pipeline.py
+++ b/tests/unit_test/voxtral_tts/test_pipeline.py
@@ -387,6 +387,8 @@ def test_voxtral_generation_reenables_cuda_graph_after_bootstrap(
             self.model = FakeModel()
 
         def init_device_graphs(self) -> None:
+            assert self.server_args.enable_torch_compile is True
+            assert self.server_args.torch_compile_max_bs == 16
             init_graph_calls.append(True)
 
     class FakeWorker:
@@ -416,10 +418,12 @@ def test_voxtral_generation_reenables_cuda_graph_after_bootstrap(
         return SimpleNamespace(
             disable_cuda_graph=kwargs["disable_cuda_graph"],
             disable_overlap_schedule=kwargs["disable_overlap_schedule"],
+            enable_torch_compile=kwargs["enable_torch_compile"],
             page_size=1,
             chunked_prefill_size=0,
             max_prefill_tokens=kwargs["max_prefill_tokens"],
             max_running_requests=kwargs["max_running_requests"],
+            torch_compile_max_bs=kwargs["torch_compile_max_bs"],
         )
 
     def fake_create_sglang_infrastructure(server_args, gpu_id, **kwargs):
@@ -466,6 +470,9 @@ def test_voxtral_generation_reenables_cuda_graph_after_bootstrap(
     assert build_kwargs["disable_cuda_graph"] is False
     assert build_kwargs["enable_torch_compile"] is True
     assert build_kwargs["sampling_backend"] == "pytorch"
+    assert build_kwargs["torch_compile_max_bs"] == 16
     assert infrastructure_saw_graph_disabled == [True]
     assert init_graph_calls == [True]
     assert scheduler.server_args.disable_cuda_graph is False
+    assert scheduler.server_args.enable_torch_compile is True
+    assert scheduler.server_args.torch_compile_max_bs == 16


### PR DESCRIPTION
Full H200 SeedTTS validation completed for the torch.compile + CUDA Graph PR.

Setup: 4-GPU sharded non-streaming runs with c=16 per shard, using `benchmarks/eval/benchmark_tts_seedtts.py` with generate-only followed by transcribe-only. Decode logs show CUDA graph replay (`cuda graph: True`) for both Qwen3-TTS and Voxtral.

| Model / config | Split | WER / CER | Samples | Failed / skipped | Throughput | rtf_mean | Delta vs #451 baseline |
|---|---:|---:|---:|---:|---:|---:|---:|
| Qwen/Qwen3-TTS-12Hz-0.6B-Base | EN | WER 1.13% | 1088/1088 | 0 / 0 | 10.684 req/s | 1.3823 | qps +12.6%, RTF -9.4% |
| Qwen/Qwen3-TTS-12Hz-0.6B-Base | ZH | CER 1.08% | 2020/2020 | 0 / 0 | 8.312 req/s | 1.2516 | qps +11.6%, RTF -9.1% |
| Qwen/Qwen3-TTS-12Hz-1.7B-Base | EN | WER 0.95% | 1088/1088 | 0 / 0 | 10.548 req/s | 1.4211 | qps +12.3%, RTF -9.0% |
| Qwen/Qwen3-TTS-12Hz-1.7B-Base | ZH | CER 0.98% | 2020/2020 | 0 / 0 | 8.328 req/s | 1.2711 | qps +11.5%, RTF -9.8% |
| mistralai/Voxtral-4B-TTS-2603, no-ref, cheerful_female | EN | WER 1.26% | 1088/1088 | 0 / 0 | 30.956 req/s | 0.3434 | qps +20.9%, RTF -16.5% |
| mistralai/Voxtral-4B-TTS-2603, no-ref, cheerful_female | ZH | CER 150.56% | 2020/2020 | 0 / 0 | 14.272 req/s | 0.3066 | RTF -18.6%; ZH is not acceptance-gated |

Acceptance-gated rows pass: Qwen3-TTS 0.6B/1.7B EN+ZH and Voxtral EN all improve qps and RTF versus the #451 H200 baseline while staying within the requested WER/CER bounds. Voxtral ZH is included for continuity only; accuracy remains non-comparable because Voxtral TTS does not document Chinese support.

Qwen3-TTS 0.6B EN needed an isolated rerun because two earlier attempts hit one max-length repetition outlier each, matching the stochastic error mode before. The final acceptance row above has no max-length audio outlier; max generated audio duration was 9.12s.

Checks passed:

- `python -m py_compile` on touched Qwen3-TTS/Voxtral files and tests
- `git diff --check`
- `/data/wenyao/sglang-omni/.venv/bin/python -m pytest -q tests/unit_test/qwen3_tts tests/unit_test/voxtral_tts` (`29 passed, 2 warnings`)
- `PYTHONPATH=/home/sglang-omni/gaokaiz/sglang-omni-pref520 /data/wenyao/sglang-omni/.venv/bin/python -m benchmarks.eval.benchmark_tts_seedtts --help`
