### PR TITLE
[CI] Add CI retry wrapper for flaky benchmark stages and add High-Priority Queue

### DIFF
--- a/.github/scripts/ci_priority_gate.py
+++ b/.github/scripts/ci_priority_gate.py
@@ -171,9 +171,7 @@ def main() -> int:
     token = os.environ["GITHUB_TOKEN"]
     current_run_id = int(os.environ["GITHUB_RUN_ID"])
     run_label = os.environ.get("OMNI_CI_RUN_LABEL", "run-ci")
-    high_priority_label = os.environ.get(
-        "OMNI_CI_HIGH_PRIORITY_LABEL", "high-priority"
-    )
+    high_priority_label = os.environ.get("OMNI_CI_HIGH_PRIORITY_LABEL", "high-priority")
     poll_seconds = _env_int("OMNI_CI_PRIORITY_POLL_SECONDS", 30)
     timeout_seconds = _env_int("OMNI_CI_PRIORITY_TIMEOUT_SECONDS", 6 * 60 * 60)
     workflows = _priority_workflows()
@@ -204,7 +202,9 @@ def main() -> int:
             return 1
 
         if not active_runs:
-            print("No active high-priority CI runs found; normal-priority CI can start.")
+            print(
+                "No active high-priority CI runs found; normal-priority CI can start."
+            )
             return 0
 
         print("Waiting for active high-priority CI runs:")

--- a/.github/scripts/ci_priority_gate.py
+++ b/.github/scripts/ci_priority_gate.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+
+"""Wait normal-priority CI behind active high-priority PR CI runs."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+ACTIVE_STATUSES = ("queued", "in_progress", "waiting", "pending", "requested")
+DEFAULT_PRIORITY_WORKFLOWS = (
+    "PR Test",
+    "PR Test (Examples)",
+    "Qwen3-Omni CI",
+    "S2-Pro CI",
+)
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, str(default))
+    try:
+        value = int(raw)
+    except ValueError:
+        raise SystemExit(f"{name} must be an integer; got {raw!r}") from None
+    if value < 0:
+        raise SystemExit(f"{name} must be non-negative; got {value}")
+    return value
+
+
+class GitHubClient:
+    def __init__(self, repo: str, token: str) -> None:
+        self.repo = repo
+        self.token = token
+
+    def get(self, path: str, params: dict[str, str | int] | None = None):
+        url = f"https://api.github.com/repos/{self.repo}{path}"
+        if params:
+            url += "?" + urllib.parse.urlencode(params)
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read())
+
+    def paginate(self, path: str, params: dict[str, str | int] | None = None):
+        page = 1
+        while True:
+            request_params = dict(params or {})
+            request_params.update({"per_page": 100, "page": page})
+            data = self.get(path, request_params)
+            if isinstance(data, dict):
+                items = next((v for v in data.values() if isinstance(v, list)), [])
+            else:
+                items = data
+            yield from items
+            if len(items) < 100:
+                break
+            page += 1
+
+
+def _load_event() -> dict:
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        return {}
+    with open(event_path) as f:
+        return json.load(f)
+
+
+def _label_names_from_payload(event: dict) -> set[str]:
+    pull_request = event.get("pull_request") or {}
+    return {label["name"] for label in pull_request.get("labels", [])}
+
+
+def _priority_workflows() -> set[str]:
+    raw = os.environ.get("OMNI_CI_PRIORITY_WORKFLOWS")
+    if raw:
+        return {name.strip() for name in raw.split(",") if name.strip()}
+    return set(DEFAULT_PRIORITY_WORKFLOWS)
+
+
+def _is_current_run_high_priority(
+    event: dict,
+    *,
+    run_label: str,
+    high_priority_label: str,
+) -> bool:
+    if os.environ.get("GITHUB_EVENT_NAME") != "pull_request":
+        print("Non-PR event; priority gate is bypassed.")
+        return True
+
+    labels = _label_names_from_payload(event)
+    if high_priority_label in labels and run_label in labels:
+        print(
+            f"Current PR has both `{run_label}` and `{high_priority_label}`; "
+            "priority gate is bypassed."
+        )
+        return True
+
+    print(
+        f"Current PR is normal priority; waiting behind active `{run_label}` + "
+        f"`{high_priority_label}` CI runs."
+    )
+    return False
+
+
+def _labels_for_pr(
+    client: GitHubClient,
+    label_cache: dict[int, set[str]],
+    pr_number: int,
+) -> set[str]:
+    if pr_number not in label_cache:
+        labels = client.paginate(f"/issues/{pr_number}/labels")
+        label_cache[pr_number] = {label["name"] for label in labels}
+    return label_cache[pr_number]
+
+
+def _active_high_priority_runs(
+    client: GitHubClient,
+    *,
+    current_run_id: int,
+    priority_workflows: set[str],
+    run_label: str,
+    high_priority_label: str,
+) -> list[dict]:
+    label_cache: dict[int, set[str]] = {}
+    matches: list[dict] = []
+    seen_run_ids: set[int] = set()
+
+    for status in ACTIVE_STATUSES:
+        for run in client.paginate("/actions/runs", {"status": status}):
+            run_id = int(run["id"])
+            if run_id == current_run_id or run_id in seen_run_ids:
+                continue
+            seen_run_ids.add(run_id)
+
+            if priority_workflows and run.get("name") not in priority_workflows:
+                continue
+            if run.get("event") != "pull_request":
+                continue
+
+            for pr in run.get("pull_requests") or []:
+                pr_number = int(pr["number"])
+                labels = _labels_for_pr(client, label_cache, pr_number)
+                if run_label in labels and high_priority_label in labels:
+                    matches.append(
+                        {
+                            "id": run_id,
+                            "name": run.get("name"),
+                            "pr": pr_number,
+                            "status": run.get("status"),
+                            "url": run.get("html_url"),
+                        }
+                    )
+                    break
+
+    return matches
+
+
+def main() -> int:
+    repo = os.environ["GITHUB_REPOSITORY"]
+    token = os.environ["GITHUB_TOKEN"]
+    current_run_id = int(os.environ["GITHUB_RUN_ID"])
+    run_label = os.environ.get("OMNI_CI_RUN_LABEL", "run-ci")
+    high_priority_label = os.environ.get(
+        "OMNI_CI_HIGH_PRIORITY_LABEL", "high-priority"
+    )
+    poll_seconds = _env_int("OMNI_CI_PRIORITY_POLL_SECONDS", 30)
+    timeout_seconds = _env_int("OMNI_CI_PRIORITY_TIMEOUT_SECONDS", 6 * 60 * 60)
+    workflows = _priority_workflows()
+    event = _load_event()
+
+    if _is_current_run_high_priority(
+        event,
+        run_label=run_label,
+        high_priority_label=high_priority_label,
+    ):
+        return 0
+
+    client = GitHubClient(repo, token)
+    deadline = time.monotonic() + timeout_seconds
+
+    while True:
+        try:
+            active_runs = _active_high_priority_runs(
+                client,
+                current_run_id=current_run_id,
+                priority_workflows=workflows,
+                run_label=run_label,
+                high_priority_label=high_priority_label,
+            )
+        except urllib.error.HTTPError as exc:
+            print(f"GitHub API request failed: HTTP {exc.code} {exc.reason}")
+            print(exc.read().decode("utf-8", errors="replace"))
+            return 1
+
+        if not active_runs:
+            print("No active high-priority CI runs found; normal-priority CI can start.")
+            return 0
+
+        print("Waiting for active high-priority CI runs:")
+        for run in active_runs:
+            print(
+                f"  - {run['name']} for PR #{run['pr']} "
+                f"({run['status']}, run_id={run['id']}): {run['url']}"
+            )
+
+        if time.monotonic() >= deadline:
+            print(
+                "Timed out waiting for high-priority CI runs after "
+                f"{timeout_seconds} seconds."
+            )
+            return 1
+
+        time.sleep(poll_seconds)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/run_flaky_pytest.sh
+++ b/.github/scripts/run_flaky_pytest.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+max_attempts="${OMNI_CI_MAX_ATTEMPTS:-2}"
+retry_delay_seconds="${OMNI_CI_RETRY_DELAY_SECONDS:-10}"
+stage_label="${OMNI_CI_STAGE_LABEL:-${GITHUB_JOB:-pytest stage}}"
+
+if ! [[ "${max_attempts}" =~ ^[0-9]+$ ]] || [ "${max_attempts}" -lt 1 ]; then
+  echo "::error::OMNI_CI_MAX_ATTEMPTS must be a positive integer; got '${max_attempts}'"
+  exit 2
+fi
+
+if ! [[ "${retry_delay_seconds}" =~ ^[0-9]+$ ]]; then
+  echo "::error::OMNI_CI_RETRY_DELAY_SECONDS must be a non-negative integer; got '${retry_delay_seconds}'"
+  exit 2
+fi
+
+if [ "${1:-}" = "--" ]; then
+  shift
+fi
+
+if [ "$#" -eq 0 ]; then
+  echo "::error::run_flaky_pytest.sh requires a pytest command"
+  exit 2
+fi
+
+slug="$(printf '%s' "${stage_label}" | tr -cs 'A-Za-z0-9._-' '-' | sed 's/^-//;s/-$//')"
+if [ -z "${slug}" ]; then
+  slug="pytest-stage"
+fi
+
+log_root="${RUNNER_TEMP:-/tmp}/omni-ci-retry"
+mkdir -p "${log_root}"
+
+has_hard_failure() {
+  local log_file="$1"
+
+  grep -Eiq \
+    '(CUDA out of memory|OutOfMemoryError|No space left on device|Segmentation fault|core dumped|exit code 13[79]|returned non-zero exit status 13[79]|SIGKILL|SIGTERM|Server failed to start|server process.*exit|Connection refused|connection refused|Health check failed)' \
+    "${log_file}"
+}
+
+has_retryable_metric_assertion() {
+  local log_file="$1"
+
+  grep -Eiq \
+    '(AssertionError|FAILED .* - AssertionError|E +assert).*(threshold|throughput_qps|tok_per_s_agg|latency_mean_s|rtf_mean|accuracy|WER|wer_|speaker_similarity|similarity)' \
+    "${log_file}" ||
+    grep -Eiq \
+      '(threshold|throughput_qps|tok_per_s_agg|latency_mean_s|rtf_mean|accuracy|WER|wer_|speaker_similarity|similarity).*(AssertionError|FAILED|E +assert)' \
+      "${log_file}"
+}
+
+should_retry() {
+  local status="$1"
+  local log_file="$2"
+
+  # Pytest exits 1 for ordinary test failures. Exit codes 2+ indicate
+  # interruption, internal errors, bad invocation, or collection problems.
+  [ "${status}" -eq 1 ] || return 1
+  grep -Eq '=+ FAILURES =+|FAILED .+ - AssertionError|AssertionError' "${log_file}" || return 1
+  ! has_hard_failure "${log_file}" || return 1
+  has_retryable_metric_assertion "${log_file}"
+}
+
+cleanup_between_attempts() {
+  echo "Cleaning GPU state before retry..."
+  bash .github/scripts/delete_gpu_process.sh || {
+    echo "::warning::GPU cleanup failed before retry; continuing to preserve the retry signal"
+  }
+  rm -rf /github/home/.cache/flashinfer || true
+  if [ "${retry_delay_seconds}" -gt 0 ]; then
+    sleep "${retry_delay_seconds}"
+  fi
+}
+
+attempt=1
+last_status=0
+
+while [ "${attempt}" -le "${max_attempts}" ]; do
+  log_file="${log_root}/${slug}-attempt-${attempt}.log"
+
+  echo "::group::${stage_label} attempt ${attempt}/${max_attempts}"
+  "$@" 2>&1 | tee "${log_file}"
+  last_status="${PIPESTATUS[0]}"
+  echo "::endgroup::"
+
+  if [ "${last_status}" -eq 0 ]; then
+    if [ "${attempt}" -gt 1 ]; then
+      echo "::notice::${stage_label} passed on attempt ${attempt}/${max_attempts}"
+    fi
+    exit 0
+  fi
+
+  echo "${stage_label} attempt ${attempt}/${max_attempts} failed with exit code ${last_status}."
+  echo "Attempt log: ${log_file}"
+
+  if [ "${attempt}" -ge "${max_attempts}" ]; then
+    break
+  fi
+
+  if should_retry "${last_status}" "${log_file}"; then
+    echo "::warning::Retrying ${stage_label}; failure looks like a flaky metric assertion."
+    cleanup_between_attempts
+    attempt=$((attempt + 1))
+    continue
+  fi
+
+  echo "Not retrying ${stage_label}; failure does not match the flaky metric assertion policy."
+  exit "${last_status}"
+done
+
+echo "::error::${stage_label} failed after ${max_attempts} attempt(s)."
+exit "${last_status}"

--- a/.github/workflows/test-examples.yaml
+++ b/.github/workflows/test-examples.yaml
@@ -12,9 +12,34 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read
+  pull-requests: read
+  issues: read
 
 jobs:
+  priority-gate:
+    name: priority gate
+    # CI gate — runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
+    # Keep in sync with the same gate in test.yaml / test-qwen3-omni-ci.yaml / test-s2pro-ci.yaml.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft &&
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Wait behind high-priority CI
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python .github/scripts/ci_priority_gate.py
+
   unit-test:
+    needs: priority-gate
     # CI gate — runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
     # Keep in sync with the same gate in test.yaml / test-qwen3-omni-ci.yaml / test-s2pro-ci.yaml.
     if: >-

--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -65,7 +65,7 @@ jobs:
     name: stage 1 - thinker length integration
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 20
+    timeout-minutes: 40
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -82,7 +82,8 @@ jobs:
         run: |
           source omni-qwen3/bin/activate
           export PYTHONPATH=$PWD
-          pytest tests/test_model/test_qwen3_omni_thinker_length.py -v -s -x
+          bash .github/scripts/run_flaky_pytest.sh \
+            pytest tests/test_model/test_qwen3_omni_thinker_length.py -v -s -x
         env:
           HF_ENDPOINT: https://hf-mirror.com
           TORCHINDUCTOR_CACHE_DIR: /github/home/.torchinductor
@@ -97,7 +98,7 @@ jobs:
     name: stage 2 - TTS speed + WER + SIM
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 25
+    timeout-minutes: 50
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -123,7 +124,8 @@ jobs:
         run: |
           source omni-qwen3/bin/activate
           export PYTHONPATH=$PWD
-          pytest tests/test_model/test_qwen3_omni_tts_ci.py -v -s -x
+          bash .github/scripts/run_flaky_pytest.sh \
+            pytest tests/test_model/test_qwen3_omni_tts_ci.py -v -s -x
         env:
           HF_ENDPOINT: https://hf-mirror.com
           SGLANG_SEEDTTS50_DIR: /github/home/seedtts-50
@@ -146,7 +148,7 @@ jobs:
     name: stage 3 - MMMU accuracy + speed
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 20
+    timeout-minutes: 40
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -163,7 +165,8 @@ jobs:
         run: |
           source omni-qwen3/bin/activate
           export PYTHONPATH=$PWD
-          pytest tests/test_model/test_qwen3_omni_mmmu_ci.py -v -s -x
+          bash .github/scripts/run_flaky_pytest.sh \
+            pytest tests/test_model/test_qwen3_omni_mmmu_ci.py -v -s -x
         env:
           HF_ENDPOINT: https://hf-mirror.com
           TORCHINDUCTOR_CACHE_DIR: /github/home/.torchinductor
@@ -182,7 +185,7 @@ jobs:
     name: stage 4 - MMMU Talker
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 15
+    timeout-minutes: 30
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -199,7 +202,8 @@ jobs:
         run: |
           source omni-qwen3/bin/activate
           export PYTHONPATH=$PWD
-          pytest tests/test_model/test_qwen3_omni_mmmu_talker_ci.py -v -s -x
+          bash .github/scripts/run_flaky_pytest.sh \
+            pytest tests/test_model/test_qwen3_omni_mmmu_talker_ci.py -v -s -x
         env:
           HF_ENDPOINT: https://hf-mirror.com
           TORCHINDUCTOR_CACHE_DIR: /github/home/.torchinductor
@@ -218,7 +222,7 @@ jobs:
     name: stage 5 - MMSU accuracy + speed
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 20
+    timeout-minutes: 40
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -235,7 +239,8 @@ jobs:
         run: |
           source omni-qwen3/bin/activate
           export PYTHONPATH=$PWD
-          pytest tests/test_model/test_qwen3_omni_mmsu_ci.py -v -s -x
+          bash .github/scripts/run_flaky_pytest.sh \
+            pytest tests/test_model/test_qwen3_omni_mmsu_ci.py -v -s -x
         env:
           HF_ENDPOINT: https://hf-mirror.com
           TORCHINDUCTOR_CACHE_DIR: /github/home/.torchinductor
@@ -255,7 +260,7 @@ jobs:
     name: stage 6 - MMSU Talker
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 15
+    timeout-minutes: 30
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -272,7 +277,8 @@ jobs:
         run: |
           source omni-qwen3/bin/activate
           export PYTHONPATH=$PWD
-          pytest tests/test_model/test_qwen3_omni_mmsu_talker_ci.py -v -s -x
+          bash .github/scripts/run_flaky_pytest.sh \
+            pytest tests/test_model/test_qwen3_omni_mmsu_talker_ci.py -v -s -x
         env:
           HF_ENDPOINT: https://hf-mirror.com
           TORCHINDUCTOR_CACHE_DIR: /github/home/.torchinductor
@@ -291,7 +297,7 @@ jobs:
     name: stage 7 - Video-MME accuracy + speed
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 30
+    timeout-minutes: 60
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -308,7 +314,8 @@ jobs:
         run: |
           source omni-qwen3/bin/activate
           export PYTHONPATH=$PWD
-          pytest tests/test_model/test_qwen3_omni_videomme_ci.py -v -s -x
+          bash .github/scripts/run_flaky_pytest.sh \
+            pytest tests/test_model/test_qwen3_omni_videomme_ci.py -v -s -x
         env:
           HF_ENDPOINT: https://hf-mirror.com
           TORCHINDUCTOR_CACHE_DIR: /github/home/.torchinductor
@@ -327,7 +334,7 @@ jobs:
     name: stage 8 - Video-MME Talker
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 30
+    timeout-minutes: 60
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -344,7 +351,8 @@ jobs:
         run: |
           source omni-qwen3/bin/activate
           export PYTHONPATH=$PWD
-          pytest tests/test_model/test_qwen3_omni_videomme_talker_ci.py -v -s -x
+          bash .github/scripts/run_flaky_pytest.sh \
+            pytest tests/test_model/test_qwen3_omni_videomme_talker_ci.py -v -s -x
         env:
           HF_ENDPOINT: https://hf-mirror.com
           TORCHINDUCTOR_CACHE_DIR: /github/home/.torchinductor
@@ -363,7 +371,7 @@ jobs:
     name: stage 9 - Video-AMME accuracy + speed
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 30
+    timeout-minutes: 60
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -380,7 +388,8 @@ jobs:
         run: |
           source omni-qwen3/bin/activate
           export PYTHONPATH=$PWD
-          pytest tests/test_model/test_qwen3_omni_videoamme_ci.py -v -s -x
+          bash .github/scripts/run_flaky_pytest.sh \
+            pytest tests/test_model/test_qwen3_omni_videoamme_ci.py -v -s -x
         env:
           HF_ENDPOINT: https://hf-mirror.com
           TORCHINDUCTOR_CACHE_DIR: /github/home/.torchinductor
@@ -399,7 +408,7 @@ jobs:
     name: stage 10 - Video-AMME Talker
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 30
+    timeout-minutes: 60
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -416,7 +425,8 @@ jobs:
         run: |
           source omni-qwen3/bin/activate
           export PYTHONPATH=$PWD
-          pytest tests/test_model/test_qwen3_omni_videoamme_talker_ci.py -v -s -x
+          bash .github/scripts/run_flaky_pytest.sh \
+            pytest tests/test_model/test_qwen3_omni_videoamme_talker_ci.py -v -s -x
         env:
           HF_ENDPOINT: https://hf-mirror.com
           TORCHINDUCTOR_CACHE_DIR: /github/home/.torchinductor
@@ -435,7 +445,7 @@ jobs:
     name: stage 11 - Thinker TP=2 (Video-AMME Talker)
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 35
+    timeout-minutes: 70
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -452,7 +462,8 @@ jobs:
         run: |
           source omni-qwen3/bin/activate
           export PYTHONPATH=$PWD
-          pytest tests/test_model/test_qwen3_omni_videoamme_talker_tp2_ci.py -v -s -x
+          bash .github/scripts/run_flaky_pytest.sh \
+            pytest tests/test_model/test_qwen3_omni_videoamme_talker_tp2_ci.py -v -s -x
         env:
           HF_ENDPOINT: https://hf-mirror.com
           TORCHINDUCTOR_CACHE_DIR: /github/home/.torchinductor

--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -12,24 +12,49 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read
+  pull-requests: read
+  issues: read
 
 # DAG:
-#   setup ──► stage-1-thinker
-#         ├─► stage-2-tts
-#         ├─► stage-3-mmmu
-#         ├─► stage-4-mmmu-talker
-#         ├─► stage-5-mmsu
-#         ├─► stage-6-mmsu-talker
-#         ├─► stage-7-videomme
-#         ├─► stage-8-videomme-talker
-#         ├─► stage-9-videoamme
-#         ├─► stage-10-videoamme-talker
-#         └─► stage-11-thinker-tp2
+#   priority-gate ──► setup ──► stage-1-thinker
+#                            ├─► stage-2-tts
+#                            ├─► stage-3-mmmu
+#                            ├─► stage-4-mmmu-talker
+#                            ├─► stage-5-mmsu
+#                            ├─► stage-6-mmsu-talker
+#                            ├─► stage-7-videomme
+#                            ├─► stage-8-videomme-talker
+#                            ├─► stage-9-videoamme
+#                            ├─► stage-10-videoamme-talker
+#                            └─► stage-11-thinker-tp2
 # All 11 stages run in parallel after setup passes — they are independent.
 
 jobs:
+  priority-gate:
+    name: priority gate
+    # CI gate — runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
+    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft &&
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Wait behind high-priority CI
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python .github/scripts/ci_priority_gate.py
+
   setup:
     name: setup
+    needs: priority-gate
     # CI gate — runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
     # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
     if: >-
@@ -65,7 +90,7 @@ jobs:
     name: stage 1 - thinker length integration
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 40
+    timeout-minutes: 10
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -98,7 +123,7 @@ jobs:
     name: stage 2 - TTS speed + WER + SIM
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 50
+    timeout-minutes: 10
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -148,7 +173,7 @@ jobs:
     name: stage 3 - MMMU accuracy + speed
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 40
+    timeout-minutes: 10
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -185,7 +210,7 @@ jobs:
     name: stage 4 - MMMU Talker
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 30
+    timeout-minutes: 10
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -222,7 +247,7 @@ jobs:
     name: stage 5 - MMSU accuracy + speed
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 40
+    timeout-minutes: 10
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -260,7 +285,7 @@ jobs:
     name: stage 6 - MMSU Talker
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 30
+    timeout-minutes: 10
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -297,7 +322,7 @@ jobs:
     name: stage 7 - Video-MME accuracy + speed
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 60
+    timeout-minutes: 10
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -334,7 +359,7 @@ jobs:
     name: stage 8 - Video-MME Talker
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 60
+    timeout-minutes: 10
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -371,7 +396,7 @@ jobs:
     name: stage 9 - Video-AMME accuracy + speed
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 60
+    timeout-minutes: 10
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -408,7 +433,7 @@ jobs:
     name: stage 10 - Video-AMME Talker
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 60
+    timeout-minutes: 10
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -445,7 +470,7 @@ jobs:
     name: stage 11 - Thinker TP=2 (Video-AMME Talker)
     needs: setup
     runs-on: [self-hosted]
-    timeout-minutes: 70
+    timeout-minutes: 10
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm

--- a/.github/workflows/test-s2pro-ci.yaml
+++ b/.github/workflows/test-s2pro-ci.yaml
@@ -72,7 +72,7 @@ jobs:
     name: stage 1 - non-streaming
     needs: docs
     runs-on: [self-hosted]
-    timeout-minutes: 15
+    timeout-minutes: 30
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -98,7 +98,8 @@ jobs:
         run: |
           source omni-s2pro/bin/activate
           export PYTHONPATH=$PWD
-          pytest tests/test_model/test_s2pro_tts_ci.py -v -s -x --concurrency 16 --s2pro-stage s2pro-stage-1-nonstream
+          bash .github/scripts/run_flaky_pytest.sh \
+            pytest tests/test_model/test_s2pro_tts_ci.py -v -s -x --concurrency 16 --s2pro-stage s2pro-stage-1-nonstream
         env:
           HF_ENDPOINT: https://hf-mirror.com
           SGLANG_SEEDTTS50_DIR: /github/home/seedtts-50
@@ -124,7 +125,7 @@ jobs:
     name: stage 2 - streaming
     needs: docs
     runs-on: [self-hosted]
-    timeout-minutes: 5
+    timeout-minutes: 10
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm
@@ -141,7 +142,8 @@ jobs:
         run: |
           source omni-s2pro/bin/activate
           export PYTHONPATH=$PWD
-          pytest tests/test_model/test_s2pro_tts_ci.py -v -s -x --concurrency 16 --s2pro-stage s2pro-stage-2-stream
+          bash .github/scripts/run_flaky_pytest.sh \
+            pytest tests/test_model/test_s2pro_tts_ci.py -v -s -x --concurrency 16 --s2pro-stage s2pro-stage-2-stream
         env:
           HF_ENDPOINT: https://hf-mirror.com
           SGLANG_SEEDTTS50_DIR: /github/home/seedtts-50

--- a/.github/workflows/test-s2pro-ci.yaml
+++ b/.github/workflows/test-s2pro-ci.yaml
@@ -12,15 +12,40 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read
+  pull-requests: read
+  issues: read
 
 # DAG:
-#   docs ──► stage-1-non-streaming ──┐
-#        └─► stage-2-streaming ──────┤
-#                                    └──► stage-3-consistency
+#   priority-gate ──► docs ──► stage-1-non-streaming ──┐
+#                         └─► stage-2-streaming ───────┤
+#                                                       └──► stage-3-consistency
 
 jobs:
+  priority-gate:
+    name: priority gate
+    # CI gate — runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
+    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-qwen3-omni-ci.yaml.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft &&
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Wait behind high-priority CI
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python .github/scripts/ci_priority_gate.py
+
   docs:
     name: docs
+    needs: priority-gate
     # CI gate — runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
     # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-qwen3-omni-ci.yaml.
     if: >-
@@ -72,7 +97,7 @@ jobs:
     name: stage 1 - non-streaming
     needs: docs
     runs-on: [self-hosted]
-    timeout-minutes: 30
+    timeout-minutes: 10
     container:
       image: frankleeeee/sglang-omni:dev
       options: --gpus all --rm -v /dev/shm:/dev/shm

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,9 +12,34 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read
+  pull-requests: read
+  issues: read
 
 jobs:
+  priority-gate:
+    name: priority gate
+    # CI gate — runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
+    # Keep in sync with the same gate in test-examples.yaml / test-qwen3-omni-ci.yaml / test-s2pro-ci.yaml.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft &&
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Wait behind high-priority CI
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python .github/scripts/ci_priority_gate.py
+
   unit-test:
+    needs: priority-gate
     # CI gate — runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
     # Keep in sync with the same gate in test-examples.yaml / test-qwen3-omni-ci.yaml / test-s2pro-ci.yaml.
     if: >-


### PR DESCRIPTION

## Summary

  Add CI support for two reliability/scheduling improvements:

  - Automatically rerun flaky benchmark/e2e pytest stages once when the failure looks like a metric threshold assertion.
  - Add a `high-priority` PR label gate so high-priority `run-ci` workloads get self-hosted runners before normal `run-ci` workloads.

  ## Details

  ### Flaky metric rerun

  Adds `.github/scripts/run_flaky_pytest.sh`, a small wrapper around pytest commands.

  Behavior:

  - Defaults to 2 total attempts.
  - Retries only when pytest exits with an ordinary test failure and the log matches metric assertion patterns such as:
    - `accuracy`
    - `threshold`
    - `throughput_qps`
    - `tok_per_s_agg`
    - `latency_mean_s`
    - `rtf_mean`
    - `WER`
    - `speaker_similarity`
  - Does not retry hard failures such as:
    - CUDA OOM
    - SIGKILL/SIGTERM
    - server startup failures
    - server process exits
    - connection refused
    - disk-full failures
  - Cleans GPU processes and flashinfer cache before retrying.

  This is wired into:

  - `Qwen3-Omni CI` benchmark/e2e stages
  - `S2-Pro CI` benchmark stages

  Stage timeouts are capped at 10 minutes for rerun-enabled stages.

  ### High-priority CI gate

  Adds `.github/scripts/ci_priority_gate.py`.

  Behavior:

  - Applies to CI workflows gated by `run-ci`:
    - `PR Test`
    - `PR Test (Examples)`
    - `Qwen3-Omni CI`
    - `S2-Pro CI`
  - PRs with both `run-ci` and `high-priority` bypass the gate.
  - PRs with only `run-ci` wait on `ubuntu-latest` until active `run-ci + high-priority` CI runs finish.
  - The waiting gate does not occupy self-hosted GPU runners.