### PR TITLE
ci(qwen3-omni): remove dedicated setup job, install deps per stage

### DIFF
--- a/.github/scripts/ci_priority_gate.py
+++ b/.github/scripts/ci_priority_gate.py
@@ -15,6 +15,8 @@ import urllib.request
 ACTIVE_STATUSES = ("queued", "in_progress", "waiting", "pending", "requested")
 BLOCKING_COMPLETED_STATUSES = ("failure", "timed_out", "cancelled")
 BLOCKING_JOB_CONCLUSIONS = {"failure", "timed_out", "cancelled"}
+PRIORITY_GATE_JOB_NAME = "priority gate"
+REUSABLE_JOB_SEPARATOR = " / "
 DEFAULT_PRIORITY_WORKFLOWS = (
     "PR Test",
     "PR Test (Examples)",
@@ -98,19 +100,19 @@ def _priority_workflows() -> set[str]:
     return set(DEFAULT_PRIORITY_WORKFLOWS)
 
 
-def _is_current_run_high_priority(
+def _current_run_priority_state(
     client: GitHubClient,
     event: dict,
     *,
     run_label: str,
     high_priority_label: str,
     stage_name: str,
-) -> bool:
+) -> str:
     if os.environ.get("GITHUB_EVENT_NAME") != "pull_request" and not event.get(
         "pull_request"
     ):
         print("Non-PR event; priority gate is bypassed.")
-        return True
+        return "bypass"
 
     pr_number = _pr_number_from_payload(event)
     labels = _label_names_from_payload(event)
@@ -126,16 +128,16 @@ def _is_current_run_high_priority(
         stage_message = f" for `{stage_name}`" if stage_name else ""
         print(
             f"Current PR has both `{run_label}` and `{high_priority_label}`; "
-            f"priority gate is bypassed{stage_message}."
+            f"entering high-priority stage gate{stage_message}."
         )
-        return True
+        return "high"
 
     stage_message = f" `{stage_name}`" if stage_name else ""
     print(
         f"Current PR is normal priority; waiting behind active{stage_message} "
         f"`{run_label}` + `{high_priority_label}` CI work."
     )
-    return False
+    return "normal"
 
 
 def _labels_for_pr(
@@ -177,6 +179,41 @@ def _job_matches_stage(job_name: str | None, stage_name: str) -> bool:
     return f" / {stage_name} (" in job_name
 
 
+def _is_priority_gate_job(job_name: str | None) -> bool:
+    if not job_name:
+        return False
+    return job_name == PRIORITY_GATE_JOB_NAME or job_name.endswith(
+        f"{REUSABLE_JOB_SEPARATOR}{PRIORITY_GATE_JOB_NAME}"
+    )
+
+
+def _job_matches_priority_gate(job_name: str | None, stage_name: str) -> bool:
+    if not job_name:
+        return False
+    if not stage_name:
+        return job_name == PRIORITY_GATE_JOB_NAME
+    return job_name == f"{stage_name}{REUSABLE_JOB_SEPARATOR}{PRIORITY_GATE_JOB_NAME}"
+
+
+def _reusable_caller_name(job_name: str | None) -> str:
+    if not job_name or REUSABLE_JOB_SEPARATOR not in job_name:
+        return ""
+    return job_name.split(REUSABLE_JOB_SEPARATOR, 1)[0]
+
+
+def _is_reusable_stage_runner_job(job_name: str | None) -> bool:
+    return bool(
+        job_name
+        and REUSABLE_JOB_SEPARATOR in job_name
+        and not _is_priority_gate_job(job_name)
+    )
+
+
+def _job_sort_key(job: dict) -> tuple[str, int]:
+    job_id = job.get("job_id", job["id"])
+    return (str(job.get("started_at") or job.get("created_at") or ""), int(job_id))
+
+
 def _active_matching_jobs(
     client: GitHubClient,
     *,
@@ -209,6 +246,132 @@ def _blocking_completed_jobs(
             continue
         matches.append(job)
     return matches
+
+
+def _high_priority_stage_gate_blockers(
+    client: GitHubClient,
+    *,
+    current_run_id: int,
+    priority_workflows: set[str],
+    run_label: str,
+    high_priority_label: str,
+    stage_name: str,
+) -> list[dict]:
+    label_cache: dict[int, set[str]] = {}
+    blockers: list[dict] = []
+    gate_contenders: list[dict] = []
+    seen_run_ids: set[int] = set()
+
+    for status in ACTIVE_STATUSES:
+        for run in client.paginate("/actions/runs", {"status": status}):
+            run_id = int(run["id"])
+            if run_id in seen_run_ids:
+                continue
+            seen_run_ids.add(run_id)
+
+            if priority_workflows and run.get("name") not in priority_workflows:
+                continue
+            if run.get("event") != "pull_request":
+                continue
+
+            is_high_priority_run = False
+            pr_number = None
+            for pr in run.get("pull_requests") or []:
+                pr_number = int(pr["number"])
+                labels = _labels_for_pr(client, label_cache, pr_number)
+                if run_label in labels and high_priority_label in labels:
+                    is_high_priority_run = True
+                    break
+            if not is_high_priority_run:
+                continue
+
+            jobs = list(client.paginate(f"/actions/runs/{run_id}/jobs"))
+            active_runner_stages = set()
+            completed_runner_stages = set()
+
+            for job in jobs:
+                job_name = job.get("name")
+                if not _is_reusable_stage_runner_job(job_name):
+                    continue
+                caller_name = _reusable_caller_name(job_name)
+                if job.get("status") in ACTIVE_STATUSES:
+                    active_runner_stages.add(caller_name)
+                    blockers.append(
+                        {
+                            "id": run_id,
+                            "name": run.get("name"),
+                            "pr": pr_number,
+                            "status": run.get("status"),
+                            "url": run.get("html_url"),
+                            "job": job_name,
+                            "job_status": job.get("status"),
+                            "job_conclusion": job.get("conclusion"),
+                        }
+                    )
+                elif job.get("status") == "completed":
+                    completed_runner_stages.add(caller_name)
+
+            for job in jobs:
+                job_name = job.get("name")
+                if not _is_priority_gate_job(job_name):
+                    continue
+                gate_stage = _reusable_caller_name(job_name)
+                if job.get("status") in ACTIVE_STATUSES:
+                    gate_contenders.append(
+                        {
+                            "id": run_id,
+                            "name": run.get("name"),
+                            "pr": pr_number,
+                            "status": run.get("status"),
+                            "url": run.get("html_url"),
+                            "job": job_name,
+                            "job_status": job.get("status"),
+                            "job_conclusion": job.get("conclusion"),
+                            "job_id": int(job["id"]),
+                            "started_at": job.get("started_at"),
+                            "created_at": job.get("created_at"),
+                        }
+                    )
+                elif (
+                    job.get("status") == "completed"
+                    and job.get("conclusion") == "success"
+                    and gate_stage
+                    and gate_stage not in active_runner_stages
+                    and gate_stage not in completed_runner_stages
+                ):
+                    blockers.append(
+                        {
+                            "id": run_id,
+                            "name": run.get("name"),
+                            "pr": pr_number,
+                            "status": run.get("status"),
+                            "url": run.get("html_url"),
+                            "job": job_name,
+                            "job_status": "waiting for stage job",
+                            "job_conclusion": None,
+                        }
+                    )
+
+    if blockers:
+        return blockers
+    if not gate_contenders:
+        return []
+
+    current_gates = [
+        job
+        for job in gate_contenders
+        if job["id"] == current_run_id
+        and _job_matches_priority_gate(job.get("job"), stage_name)
+    ]
+    if not current_gates:
+        winner = min(gate_contenders, key=_job_sort_key)
+        return [winner]
+
+    current_gate = min(current_gates, key=_job_sort_key)
+    winner = min(gate_contenders, key=_job_sort_key)
+    if current_gate["job_id"] == winner["job_id"]:
+        return []
+    return [winner]
 
 
 def _active_high_priority_runs(
@@ -335,27 +498,40 @@ def main() -> int:
     event = _load_event()
     client = GitHubClient(repo, token)
 
-    if _is_current_run_high_priority(
+    priority_state = _current_run_priority_state(
         client,
         event,
         run_label=run_label,
         high_priority_label=high_priority_label,
         stage_name=stage_name,
-    ):
+    )
+    if priority_state == "bypass":
         return 0
 
     deadline = time.monotonic() + timeout_seconds
 
     while True:
         try:
-            active_runs = _active_high_priority_runs(
-                client,
-                current_run_id=current_run_id,
-                priority_workflows=workflows,
-                run_label=run_label,
-                high_priority_label=high_priority_label,
-                stage_name=stage_name,
-            )
+            if priority_state == "high" and stage_name:
+                active_runs = _high_priority_stage_gate_blockers(
+                    client,
+                    current_run_id=current_run_id,
+                    priority_workflows=workflows,
+                    run_label=run_label,
+                    high_priority_label=high_priority_label,
+                    stage_name=stage_name,
+                )
+            elif priority_state == "high":
+                active_runs = []
+            else:
+                active_runs = _active_high_priority_runs(
+                    client,
+                    current_run_id=current_run_id,
+                    priority_workflows=workflows,
+                    run_label=run_label,
+                    high_priority_label=high_priority_label,
+                    stage_name=stage_name,
+                )
         except urllib.error.HTTPError as exc:
             print(f"GitHub API request failed: HTTP {exc.code} {exc.reason}")
             print(exc.read().decode("utf-8", errors="replace"))
@@ -363,13 +539,22 @@ def main() -> int:
 
         if not active_runs:
             stage_message = f" `{stage_name}`" if stage_name else ""
-            print(
-                f"No active high-priority{stage_message} CI work found; "
-                "normal-priority CI can start."
-            )
+            if priority_state == "high":
+                print(
+                    f"High-priority{stage_message} gate acquired; "
+                    "stage CI can start."
+                )
+            else:
+                print(
+                    f"No active high-priority{stage_message} CI work found; "
+                    "normal-priority CI can start."
+                )
             return 0
 
-        print("Waiting for active high-priority CI work:")
+        if priority_state == "high":
+            print("Waiting for the active high-priority stage slot:")
+        else:
+            print("Waiting for active high-priority CI work:")
         for run in active_runs:
             job_state = run.get("job_conclusion") or run.get("job_status")
             job_message = f", job={run['job']} ({job_state})" if "job" in run else ""

--- a/.github/scripts/ci_priority_gate.py
+++ b/.github/scripts/ci_priority_gate.py
@@ -214,6 +214,10 @@ def _job_sort_key(job: dict) -> tuple[str, int]:
     return (str(job.get("started_at") or job.get("created_at") or ""), int(job_id))
 
 
+def _stage_gate_sort_key(job: dict) -> tuple[int, str, int]:
+    return (int(job.get("run_priority", 1)), *_job_sort_key(job))
+
+
 def _active_matching_jobs(
     client: GitHubClient,
     *,
@@ -248,7 +252,11 @@ def _blocking_completed_jobs(
     return matches
 
 
-def _high_priority_stage_gate_blockers(
+def _run_priority_from_labels(labels: set[str], *, high_priority_label: str) -> int:
+    return 0 if high_priority_label in labels else 1
+
+
+def _stage_gate_blockers(
     client: GitHubClient,
     *,
     current_run_id: int,
@@ -274,15 +282,20 @@ def _high_priority_stage_gate_blockers(
             if run.get("event") != "pull_request":
                 continue
 
-            is_high_priority_run = False
+            is_ci_run = False
+            run_priority = 1
             pr_number = None
             for pr in run.get("pull_requests") or []:
                 pr_number = int(pr["number"])
                 labels = _labels_for_pr(client, label_cache, pr_number)
-                if run_label in labels and high_priority_label in labels:
-                    is_high_priority_run = True
+                if run_label in labels:
+                    is_ci_run = True
+                    run_priority = _run_priority_from_labels(
+                        labels,
+                        high_priority_label=high_priority_label,
+                    )
                     break
-            if not is_high_priority_run:
+            if not is_ci_run:
                 continue
 
             jobs = list(client.paginate(f"/actions/runs/{run_id}/jobs"))
@@ -306,6 +319,7 @@ def _high_priority_stage_gate_blockers(
                             "job": job_name,
                             "job_status": job.get("status"),
                             "job_conclusion": job.get("conclusion"),
+                            "run_priority": run_priority,
                         }
                     )
                 elif job.get("status") == "completed":
@@ -330,6 +344,7 @@ def _high_priority_stage_gate_blockers(
                             "job_id": int(job["id"]),
                             "started_at": job.get("started_at"),
                             "created_at": job.get("created_at"),
+                            "run_priority": run_priority,
                         }
                     )
                 elif (
@@ -349,6 +364,7 @@ def _high_priority_stage_gate_blockers(
                             "job": job_name,
                             "job_status": "waiting for stage job",
                             "job_conclusion": None,
+                            "run_priority": run_priority,
                         }
                     )
 
@@ -364,11 +380,11 @@ def _high_priority_stage_gate_blockers(
         and _job_matches_priority_gate(job.get("job"), stage_name)
     ]
     if not current_gates:
-        winner = min(gate_contenders, key=_job_sort_key)
+        winner = min(gate_contenders, key=_stage_gate_sort_key)
         return [winner]
 
-    current_gate = min(current_gates, key=_job_sort_key)
-    winner = min(gate_contenders, key=_job_sort_key)
+    current_gate = min(current_gates, key=_stage_gate_sort_key)
+    winner = min(gate_contenders, key=_stage_gate_sort_key)
     if current_gate["job_id"] == winner["job_id"]:
         return []
     return [winner]
@@ -512,8 +528,8 @@ def main() -> int:
 
     while True:
         try:
-            if priority_state == "high" and stage_name:
-                active_runs = _high_priority_stage_gate_blockers(
+            if stage_name:
+                active_runs = _stage_gate_blockers(
                     client,
                     current_run_id=current_run_id,
                     priority_workflows=workflows,
@@ -544,6 +560,8 @@ def main() -> int:
                     f"High-priority{stage_message} gate acquired; "
                     "stage CI can start."
                 )
+            elif stage_name:
+                print(f"Stage gate acquired for{stage_message}; stage CI can start.")
             else:
                 print(
                     f"No active high-priority{stage_message} CI work found; "
@@ -551,8 +569,8 @@ def main() -> int:
                 )
             return 0
 
-        if priority_state == "high":
-            print("Waiting for the active high-priority stage slot:")
+        if stage_name:
+            print("Waiting for the active CI stage slot:")
         else:
             print("Waiting for active high-priority CI work:")
         for run in active_runs:

--- a/.github/workflows/rerun-ci.yaml
+++ b/.github/workflows/rerun-ci.yaml
@@ -21,6 +21,22 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const failedConclusions = new Set(['failure', 'cancelled', 'timed_out']);
+            const priorityGateName = 'priority gate';
+            const reusableSeparator = ' / ';
+
+            function priorityGateFor(jobName) {
+              const parts = jobName.split(reusableSeparator);
+              if (parts.length < 2) {
+                return null;
+              }
+              const callee = parts[parts.length - 1];
+              if (callee === priorityGateName) {
+                return jobName;
+              }
+              return `${parts[0]}${reusableSeparator}${priorityGateName}`;
+            }
+
             // Get the PR head SHA
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
@@ -30,27 +46,57 @@ jobs:
             const headSha = pr.head.sha;
 
             // List workflow runs for this commit
-            const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
+            const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               head_sha: headSha,
+              per_page: 100,
             });
 
-            let reranCount = 0;
-            for (const run of runs.workflow_runs) {
-              if (run.conclusion === 'failure' || run.conclusion === 'cancelled') {
-                await github.rest.actions.reRunWorkflowFailedJobs({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  run_id: run.id,
+            const jobsToRerun = new Map();
+            for (const run of runs) {
+              if (!failedConclusions.has(run.conclusion)) {
+                continue;
+              }
+
+              const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+                per_page: 100,
+              });
+              const jobByName = new Map(jobs.map((job) => [job.name, job]));
+
+              for (const job of jobs) {
+                if (!failedConclusions.has(job.conclusion)) {
+                  continue;
+                }
+
+                const gateName = priorityGateFor(job.name);
+                const rerunJob = gateName && jobByName.has(gateName)
+                  ? jobByName.get(gateName)
+                  : job;
+
+                jobsToRerun.set(rerunJob.id, {
+                  id: rerunJob.id,
+                  name: rerunJob.name,
+                  workflow: run.name,
+                  runId: run.id,
                 });
-                console.log(`Re-ran failed jobs for: ${run.name} (${run.id})`);
-                reranCount++;
               }
             }
 
-            if (reranCount === 0) {
-              console.log('No failed or cancelled workflow runs found to rerun.');
+            for (const job of jobsToRerun.values()) {
+              await github.request('POST /repos/{owner}/{repo}/actions/jobs/{job_id}/rerun', {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  job_id: job.id,
+                });
+              console.log(`Re-ran ${job.workflow} job: ${job.name} (${job.id}) from run ${job.runId}`);
+            }
+
+            if (jobsToRerun.size === 0) {
+              console.log('No failed or cancelled jobs found to rerun.');
             } else {
-              console.log(`Reran ${reranCount} workflow(s).`);
+              console.log(`Reran ${jobsToRerun.size} job(s).`);
             }

--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -17,24 +17,25 @@ permissions:
   issues: read
 
 # DAG:
-#   setup ──► stage-1-thinker
-#         ├─► stage-2-tts
-#         ├─► stage-3-mmmu
-#         ├─► stage-4-mmmu-talker
-#         ├─► stage-5-mmsu
-#         ├─► stage-6-mmsu-talker
-#         ├─► stage-7-videomme
-#         ├─► stage-8-videomme-talker
-#         ├─► stage-9-videoamme
-#         ├─► stage-10-videoamme-talker
-#         └─► stage-11-thinker-tp2
-# Each reusable stage runs an internal ubuntu-latest priority gate before
-# requesting a self-hosted runner.
+#   stage-1-thinker
+#   stage-2-tts
+#   stage-3-mmmu
+#   stage-4-mmmu-talker
+#   stage-5-mmsu
+#   stage-6-mmsu-talker
+#   stage-7-videomme
+#   stage-8-videomme-talker
+#   stage-9-videoamme
+#   stage-10-videoamme-talker
+#   stage-11-thinker-tp2
+# All 11 reusable stages are dispatched in parallel. Each stage runs an
+# internal ubuntu-latest priority gate before requesting a self-hosted runner
+# and installs deps independently via omni-setup (install-deps: true).
 
 jobs:
-  setup:
-    name: setup
-    # CI gate — runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
+  stage-1-thinker:
+    name: stage 1 - thinker length integration
+    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
     # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
     if: >-
       github.event_name == 'workflow_dispatch' ||
@@ -42,27 +43,10 @@ jobs:
        contains(github.event.pull_request.labels.*.name, 'run-ci'))
     uses: ./.github/workflows/_omni-priority-stage.yaml
     with:
-      stage-name: setup
-      job-timeout-minutes: "15"
-      venv-name: omni-qwen3
-      install-deps: "true"
-      save-cache-always: "true"
-      save-cache-script: |
-        if omni-qwen3/bin/python -c "import torch; import av; from whisper.normalizers import EnglishTextNormalizer" 2>/dev/null; then
-          rm -rf /github/home/omni-qwen3
-          cp -p -r omni-qwen3 /github/home/
-        else
-          echo "::warning::Skipping cache save — venv appears incomplete or corrupted"
-        fi
-
-  stage-1-thinker:
-    name: stage 1 - thinker length integration
-    needs: setup
-    uses: ./.github/workflows/_omni-priority-stage.yaml
-    with:
       stage-name: stage 1 - thinker length integration
       job-timeout-minutes: "10"
       venv-name: omni-qwen3
+      install-deps: "true"
       run-script: |
         source omni-qwen3/bin/activate
         export PYTHONPATH=$PWD
@@ -74,12 +58,18 @@ jobs:
 
   stage-2-tts:
     name: stage 2 - TTS speed + WER + SIM
-    needs: setup
+    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
+    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft &&
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     uses: ./.github/workflows/_omni-priority-stage.yaml
     with:
       stage-name: stage 2 - TTS speed + WER + SIM
       job-timeout-minutes: "10"
       venv-name: omni-qwen3
+      install-deps: "true"
       pre-run-script: |
         source omni-qwen3/bin/activate
         export HF_ENDPOINT=https://hf-mirror.com
@@ -103,12 +93,18 @@ jobs:
 
   stage-3-mmmu:
     name: stage 3 - MMMU accuracy + speed
-    needs: setup
+    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
+    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft &&
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     uses: ./.github/workflows/_omni-priority-stage.yaml
     with:
       stage-name: stage 3 - MMMU accuracy + speed
       job-timeout-minutes: "10"
       venv-name: omni-qwen3
+      install-deps: "true"
       run-script: |
         source omni-qwen3/bin/activate
         export PYTHONPATH=$PWD
@@ -124,12 +120,18 @@ jobs:
 
   stage-4-mmmu-talker:
     name: stage 4 - MMMU Talker
-    needs: setup
+    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
+    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft &&
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     uses: ./.github/workflows/_omni-priority-stage.yaml
     with:
       stage-name: stage 4 - MMMU Talker
       job-timeout-minutes: "10"
       venv-name: omni-qwen3
+      install-deps: "true"
       run-script: |
         source omni-qwen3/bin/activate
         export PYTHONPATH=$PWD
@@ -145,12 +147,18 @@ jobs:
 
   stage-5-mmsu:
     name: stage 5 - MMSU accuracy + speed
-    needs: setup
+    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
+    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft &&
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     uses: ./.github/workflows/_omni-priority-stage.yaml
     with:
       stage-name: stage 5 - MMSU accuracy + speed
       job-timeout-minutes: "10"
       venv-name: omni-qwen3
+      install-deps: "true"
       run-script: |
         source omni-qwen3/bin/activate
         export PYTHONPATH=$PWD
@@ -167,12 +175,18 @@ jobs:
 
   stage-6-mmsu-talker:
     name: stage 6 - MMSU Talker
-    needs: setup
+    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
+    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft &&
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     uses: ./.github/workflows/_omni-priority-stage.yaml
     with:
       stage-name: stage 6 - MMSU Talker
       job-timeout-minutes: "10"
       venv-name: omni-qwen3
+      install-deps: "true"
       run-script: |
         source omni-qwen3/bin/activate
         export PYTHONPATH=$PWD
@@ -188,12 +202,18 @@ jobs:
 
   stage-7-videomme:
     name: stage 7 - Video-MME accuracy + speed
-    needs: setup
+    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
+    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft &&
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     uses: ./.github/workflows/_omni-priority-stage.yaml
     with:
       stage-name: stage 7 - Video-MME accuracy + speed
       job-timeout-minutes: "10"
       venv-name: omni-qwen3
+      install-deps: "true"
       run-script: |
         source omni-qwen3/bin/activate
         export PYTHONPATH=$PWD
@@ -209,12 +229,18 @@ jobs:
 
   stage-8-videomme-talker:
     name: stage 8 - Video-MME Talker
-    needs: setup
+    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
+    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft &&
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     uses: ./.github/workflows/_omni-priority-stage.yaml
     with:
       stage-name: stage 8 - Video-MME Talker
       job-timeout-minutes: "10"
       venv-name: omni-qwen3
+      install-deps: "true"
       run-script: |
         source omni-qwen3/bin/activate
         export PYTHONPATH=$PWD
@@ -230,12 +256,18 @@ jobs:
 
   stage-9-videoamme:
     name: stage 9 - Video-AMME accuracy + speed
-    needs: setup
+    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
+    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft &&
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     uses: ./.github/workflows/_omni-priority-stage.yaml
     with:
       stage-name: stage 9 - Video-AMME accuracy + speed
       job-timeout-minutes: "10"
       venv-name: omni-qwen3
+      install-deps: "true"
       run-script: |
         source omni-qwen3/bin/activate
         export PYTHONPATH=$PWD
@@ -251,12 +283,18 @@ jobs:
 
   stage-10-videoamme-talker:
     name: stage 10 - Video-AMME Talker
-    needs: setup
+    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
+    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft &&
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     uses: ./.github/workflows/_omni-priority-stage.yaml
     with:
       stage-name: stage 10 - Video-AMME Talker
       job-timeout-minutes: "10"
       venv-name: omni-qwen3
+      install-deps: "true"
       run-script: |
         source omni-qwen3/bin/activate
         export PYTHONPATH=$PWD
@@ -272,12 +310,18 @@ jobs:
 
   stage-11-thinker-tp2:
     name: stage 11 - Thinker TP=2 (Video-AMME Talker)
-    needs: setup
+    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
+    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.pull_request.draft &&
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     uses: ./.github/workflows/_omni-priority-stage.yaml
     with:
       stage-name: stage 11 - Thinker TP=2 (Video-AMME Talker)
       job-timeout-minutes: "10"
       venv-name: omni-qwen3
+      install-deps: "true"
       run-script: |
         source omni-qwen3/bin/activate
         export PYTHONPATH=$PWD

--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -17,6 +17,7 @@ permissions:
   issues: read
 
 # DAG:
+#   All 11 stages are dispatched in parallel.
 #   stage-1-thinker
 #   stage-2-tts
 #   stage-3-mmmu
@@ -28,15 +29,10 @@ permissions:
 #   stage-9-videoamme
 #   stage-10-videoamme-talker
 #   stage-11-thinker-tp2
-# All 11 reusable stages are dispatched in parallel. Each stage runs an
-# internal ubuntu-latest priority gate before requesting a self-hosted runner
-# and installs deps independently via omni-setup (install-deps: true).
 
 jobs:
   stage-1-thinker:
     name: stage 1 - thinker length integration
-    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
-    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (!github.event.pull_request.draft &&
@@ -58,8 +54,6 @@ jobs:
 
   stage-2-tts:
     name: stage 2 - TTS speed + WER + SIM
-    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
-    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (!github.event.pull_request.draft &&
@@ -93,8 +87,6 @@ jobs:
 
   stage-3-mmmu:
     name: stage 3 - MMMU accuracy + speed
-    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
-    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (!github.event.pull_request.draft &&
@@ -120,8 +112,6 @@ jobs:
 
   stage-4-mmmu-talker:
     name: stage 4 - MMMU Talker
-    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
-    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (!github.event.pull_request.draft &&
@@ -147,8 +137,6 @@ jobs:
 
   stage-5-mmsu:
     name: stage 5 - MMSU accuracy + speed
-    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
-    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (!github.event.pull_request.draft &&
@@ -175,8 +163,6 @@ jobs:
 
   stage-6-mmsu-talker:
     name: stage 6 - MMSU Talker
-    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
-    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (!github.event.pull_request.draft &&
@@ -202,8 +188,6 @@ jobs:
 
   stage-7-videomme:
     name: stage 7 - Video-MME accuracy + speed
-    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
-    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (!github.event.pull_request.draft &&
@@ -229,8 +213,6 @@ jobs:
 
   stage-8-videomme-talker:
     name: stage 8 - Video-MME Talker
-    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
-    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (!github.event.pull_request.draft &&
@@ -256,8 +238,6 @@ jobs:
 
   stage-9-videoamme:
     name: stage 9 - Video-AMME accuracy + speed
-    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
-    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (!github.event.pull_request.draft &&
@@ -283,8 +263,6 @@ jobs:
 
   stage-10-videoamme-talker:
     name: stage 10 - Video-AMME Talker
-    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
-    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (!github.event.pull_request.draft &&
@@ -310,8 +288,6 @@ jobs:
 
   stage-11-thinker-tp2:
     name: stage 11 - Thinker TP=2 (Video-AMME Talker)
-    # CI gate - runs on workflow_dispatch, or on non-draft PRs carrying the `run-ci` label.
-    # Keep in sync with the same gate in test.yaml / test-examples.yaml / test-s2pro-ci.yaml.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (!github.event.pull_request.draft &&


### PR DESCRIPTION
## Motivation

The dedicated `setup` job existed to install dependencies once and save the venv to `/github/home/omni-qwen3`, which the 11 test stages would then restore. However, this introduced ~1-2 minutes of container start/stop overhead before any test could begin, and the stages still had to wait for setup to complete even though they are otherwise independent.

## Modifications

- Remove the `setup` job from `test-qwen3-omni-ci.yaml`
- All 11 stages now depend directly on `priority-gate` instead of `setup`
- Each stage calls `omni-setup` with `install-deps: "true"`, so it installs dependencies independently using the uv package cache persisted on the host at `/github/home/.cache/uv`
- Update the DAG comment to reflect the new topology

The uv cache at `/github/home/.cache/uv` is written automatically by uv on every download and persists on the host between workflow runs, so cache hits are preserved. Even if the cache is absent, each stage self-heals by downloading from PyPI — no manual intervention or retry needed.

## Related Issues

N/A

## Accuracy Test

N/A — CI-only change, no model code modified.

## Benchmark & Profiling

Removes ~1-2 min of setup container overhead per CI run.

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
