### PR TITLE
[Bugfix] thread chunk sample_rate into completion WAV encoding

### DIFF
--- a/sglang_omni/client/client.py
+++ b/sglang_omni/client/client.py
@@ -89,6 +89,7 @@ class Client:
         audio_chunks: list[Any] = []
         last_chunk: GenerateChunk | None = None
         finish_reason: str | None = None
+        sample_rate: int | None = None
 
         async for chunk in self.generate(request, request_id=request_id):
             last_chunk = chunk
@@ -96,6 +97,8 @@ class Client:
                 text_parts.append(chunk.text)
             if chunk.audio_data is not None:
                 audio_chunks.append(chunk.audio_data)
+            if chunk.sample_rate is not None:
+                sample_rate = chunk.sample_rate
             if chunk.finish_reason is not None:
                 finish_reason = chunk.finish_reason
 
@@ -110,7 +113,10 @@ class Client:
                 combined = audio_chunks[0]
             else:
                 combined = np.concatenate([to_numpy(c) for c in audio_chunks])
-            audio_b64 = audio_to_base64(combined, output_format=audio_format)
+            encode_kwargs: dict[str, Any] = {"output_format": audio_format}
+            if sample_rate is not None:
+                encode_kwargs["sample_rate"] = sample_rate
+            audio_b64 = audio_to_base64(combined, **encode_kwargs)
             audio = CompletionAudio(
                 id=f"audio-{request_id}",
                 data=audio_b64,


### PR DESCRIPTION

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Client.completion was calling audio_to_base64 without forwarding chunk.sample_rate, so the encoder fell back to DEFAULT_SAMPLE_RATE (24000 Hz) in client/audio.py. Talker stages that emit 44.1 kHz audio (e.g. Ming AudioVAE) ended up with a 24 kHz WAV header, so playback ran at ~0.54x speed and every duration measurement was inflated by ~1.84x.

Capture sample_rate from the generate stream the same way the streaming speech path already does (client.py _speech_stream), and pass it through to audio_to_base64. Header sample rate now matches the actual sample data on the chat-completions code path.

## Modifications

sglang_omni/client/client.py only

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Draft PRs are skipped even if labeled.
