### PR TITLE
Avoid repeated Higgs CG decode D2H copies

### DIFF
--- a/sglang_omni/models/higgs_tts/model.py
+++ b/sglang_omni/models/higgs_tts/model.py
@@ -171,6 +171,9 @@ class HiggsTTSModel(nn.Module):
             pool_size, num_codebooks, dtype=torch.long, device=cg_device
         )
         self._cg_was_done = torch.zeros(pool_size, dtype=torch.bool, device=cg_device)
+        self._cg_collect_BM = torch.zeros(
+            pool_size, num_codebooks + 2, dtype=torch.long, device=cg_device
+        )
 
         self._cg_active_delay_count = torch.zeros(
             pool_size, dtype=torch.int32, device=cg_device
@@ -360,6 +363,9 @@ class HiggsTTSModel(nn.Module):
         self._cg_active_generation_done[:batch_size] = new_generation_done_B
         self._cg_active_last_codes[:batch_size] = new_last_codes_BN
         self._cg_codes_BN[:batch_size] = codes_BN
+        self._cg_collect_BM[:batch_size, 0] = self._cg_was_done[:batch_size]
+        self._cg_collect_BM[:batch_size, 1] = new_generation_done_B
+        self._cg_collect_BM[:batch_size, 2:] = codes_BN
 
         text_vocab_size = self.backbone.config.vocab_size
         return torch.zeros(

--- a/sglang_omni/models/higgs_tts/model_runner.py
+++ b/sglang_omni/models/higgs_tts/model_runner.py
@@ -148,9 +148,7 @@ class HiggsTTSModelRunner(ModelRunner):
         pool.generation_done[rows_t] = model._cg_active_generation_done[:n_real]
         pool.last_codes[rows_t] = model._cg_active_last_codes[:n_real]
 
-        was_done_cpu = model._cg_was_done[:n_real].cpu().tolist()
-        codes_BN_cpu = model._cg_codes_BN[:n_real].detach().cpu().clone()
-        gen_done_after_cpu = model._cg_active_generation_done[:n_real].cpu().tolist()
+        collect_cpu = self._collect_cg_step_outputs_to_cpu(n_real)
         cb0_per_row: list[int] = []
         for b, sched_req in enumerate(requests):
             data = sched_req.data
@@ -158,20 +156,28 @@ class HiggsTTSModelRunner(ModelRunner):
             if req.is_chunked > 0:
                 cb0_per_row.append(0)
                 continue
-            if was_done_cpu[b]:
+            row_cpu = collect_cpu[b]
+            if bool(row_cpu[0].item()):
                 cb0_per_row.append(0)
                 continue
-            codes_N = codes_BN_cpu[b]
-            data.output_codes.append(codes_N.to(torch.long))
-            data.generation_done = bool(gen_done_after_cpu[b])
+            codes_N = row_cpu[2:].to(torch.long)
+            data.output_codes.append(codes_N.clone())
+            data.generation_done = bool(row_cpu[1].item())
             self._mark_sampler_finished(req, data.generation_done)
-            cb0_per_row.append(int(codes_N[0].item()))
+            cb0_per_row.append(int(row_cpu[2].item()))
 
         result.next_token_ids = torch.tensor(
             cb0_per_row,
             dtype=torch.long,
             device=result.logits_output.next_token_logits.device,
         )
+
+    def _collect_cg_step_outputs_to_cpu(self, n_real: int) -> torch.Tensor:
+        model = self.model
+        collect_BM = model._cg_collect_BM[
+            :n_real, : model._cg_codes_BN.shape[1] + 2
+        ]
+        return collect_BM.detach().cpu()
 
     def _build_prefill_input_embeds(
         self,

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -114,6 +114,7 @@ def test_higgs_model_runner_marks_sampler_finish_cg() -> None:
         _cg_active_last_codes=torch.tensor([[1, 2, 3]]),
         _cg_was_done=torch.tensor([False]),
         _cg_codes_BN=torch.tensor([[EOC_ID, 1, 2]]),
+        _cg_collect_BM=torch.tensor([[0, 1, EOC_ID, 1, 2]]),
         _sampler_pool=SimpleNamespace(
             delay_count=torch.zeros(1, dtype=torch.int32),
             eoc_countdown=torch.zeros(1, dtype=torch.int32),
@@ -137,6 +138,74 @@ def test_higgs_model_runner_marks_sampler_finish_cg() -> None:
     assert data.generation_done is True
     assert req.finished_reason.to_json() == {"type": "stop", "matched": EOC_ID}
     assert len(data.output_codes) == 1
+
+
+def test_higgs_model_runner_collects_cg_outputs_with_single_cpu_pack(
+    monkeypatch,
+) -> None:
+    runner = object.__new__(HiggsTTSModelRunner)
+    collect_buffer = torch.tensor(
+        [
+            [1, 0, 101, 102, 103],
+            [0, 1, EOC_ID, 7, 8],
+        ],
+        dtype=torch.long,
+    )
+    runner.model = SimpleNamespace(
+        _cg_row_indices=torch.tensor([0, 1]),
+        _cg_active_delay_count=torch.tensor([8, 8], dtype=torch.int32),
+        _cg_active_eoc_countdown=torch.tensor([0, 0], dtype=torch.int32),
+        _cg_active_generation_done=torch.tensor([False, True]),
+        _cg_active_last_codes=torch.tensor([[1, 2, 3], [4, 5, 6]]),
+        _cg_was_done=torch.tensor([True, False]),
+        _cg_codes_BN=torch.tensor([[101, 102, 103], [EOC_ID, 7, 8]]),
+        _cg_collect_BM=collect_buffer,
+        _sampler_pool=SimpleNamespace(
+            delay_count=torch.zeros(2, dtype=torch.int32),
+            eoc_countdown=torch.zeros(2, dtype=torch.int32),
+            generation_done=torch.zeros(2, dtype=torch.bool),
+            last_codes=torch.zeros((2, 3), dtype=torch.long),
+        ),
+    )
+    done_req = SimpleNamespace(is_chunked=0, finished_reason=object())
+    active_req = SimpleNamespace(is_chunked=0, finished_reason=None)
+    done_data = SimpleNamespace(req=done_req, output_codes=[], generation_done=False)
+    active_data = SimpleNamespace(
+        req=active_req, output_codes=[], generation_done=False
+    )
+    result = SimpleNamespace(
+        logits_output=SimpleNamespace(next_token_logits=torch.zeros(2, 4))
+    )
+    forward_batch = SimpleNamespace(batch_size=2)
+    cpu_calls: list[tuple[int, ...]] = []
+    orig_cpu = torch.Tensor.cpu
+
+    def counted_cpu(tensor, *args, **kwargs):
+        cpu_calls.append(tuple(tensor.shape))
+        return orig_cpu(tensor, *args, **kwargs)
+
+    monkeypatch.setattr(torch.Tensor, "cpu", counted_cpu)
+
+    runner._collect_step_outputs_cg(
+        result,
+        forward_batch,
+        [
+            SimpleNamespace(request_id="done", data=done_data),
+            SimpleNamespace(request_id="active", data=active_data),
+        ],
+    )
+
+    assert done_data.output_codes == []
+    assert active_data.generation_done is True
+    assert active_req.finished_reason.to_json() == {"type": "stop", "matched": EOC_ID}
+    assert len(active_data.output_codes) == 1
+    assert torch.equal(active_data.output_codes[0], torch.tensor([EOC_ID, 7, 8]))
+    assert result.next_token_ids.tolist() == [0, EOC_ID]
+    assert torch.equal(
+        collect_buffer,
+        torch.tensor([[1, 0, 101, 102, 103], [0, 1, EOC_ID, 7, 8]]),
+    )
+    assert cpu_calls == [(2, 5)]
 
 
 def test_higgs_model_runner_skips_already_finished_eager_request() -> None:


### PR DESCRIPTION
## Motivation

`_collect_step_outputs_cg` copies three tensors back for one decode-step result.

## Modifications

Pack the CG decode result on device and copy it back once.

Add a unit test for the packed collect path.

## Related Issues

Fixes #564

## Accuracy Test

No sampling change.

## Benchmark & Profiling

4090 collect-only median: `38-39us -> 16-17us`.

## Checklist

- [x] Add unit tests.
- [x] Provide profiling result.
