### PR TITLE
[Benchmark] Add higgs in tts benchmarking

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -30,7 +30,12 @@ python -m sglang_omni.cli serve \
     --model-path fishaudio/s2-pro \
     --config examples/configs/s2pro_tts.yaml --port 8000
 
-# Voxtral-4B-TTS — for section 2d (plain TTS, no voice cloning)
+# Higgs-Audio-V3-TTS — for section 2d (voice cloning)
+python -m sglang_omni.cli serve \
+    --model-path boson-sglang/higgs-audio-v3-tts-4b-base \
+    --config examples/configs/higgs_tts.yaml --port 8000
+
+# Voxtral-4B-TTS — for section 2e (plain TTS, no voice cloning)
 python -m sglang_omni.cli serve \
     --model-path mistralai/Voxtral-4B-TTS-2603 --port 8000
 
@@ -61,7 +66,13 @@ python -m benchmarks.eval.benchmark_tts_seedtts \
     --model fishaudio/s2-pro \
     --output-dir results/s2pro_en --lang en --device cuda:0
 
-# 2d. Voxtral — full pipeline without voice cloning
+# 2d. Higgs — full pipeline with voice cloning
+python -m benchmarks.eval.benchmark_tts_seedtts \
+    --meta zhaochenyang20/seed-tts-eval-arrow \
+    --model boson-sglang/higgs-audio-v3-tts-4b-base --port 8000 \
+    --output-dir results/higgs_en --lang en --max-samples 50 --concurrency 8
+
+# 2e. Voxtral — full pipeline without voice cloning
 python -m benchmarks.eval.benchmark_tts_seedtts \
     --meta zhaochenyang20/seed-tts-eval-arrow \
     --model mistralai/Voxtral-4B-TTS-2603 --port 8000 \
@@ -124,7 +135,7 @@ python -m benchmarks.eval.benchmark_omni_videoamme \
 
 | Script | Task | Model | API |
 |--------|------|-------|-----|
-| `eval/benchmark_tts_seedtts.py` | TTS speed + WER (unified) | e.g. S2-Pro, Voxtral | `/v1/audio/speech` |
+| `eval/benchmark_tts_seedtts.py` | TTS speed + WER (unified) | e.g. S2-Pro, Higgs, Voxtral | `/v1/audio/speech` |
 | `eval/benchmark_omni_seedtts.py` | TTS speed + WER (unified) | Qwen3-Omni | `/v1/chat/completions` |
 | `eval/benchmark_omni_mmsu.py` | MMSU (audio comprehension) | Qwen3-Omni | `/v1/chat/completions` |
 | `eval/benchmark_omni_mmmu.py` | MMMU (VLM accuracy + speed) | Qwen3-Omni | `/v1/chat/completions` |

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -3,8 +3,8 @@
 
 Note (Qiujiang, Chenyang):
 
-1. Voice-clone models (e.g. fishaudio/s2-pro): default uses ref_audio /
-  ref_text from the meta file.
+1. Voice-clone models (e.g. fishaudio/s2-pro, boson-sglang/higgs-audio-v3-tts-4b-base):
+  default uses ref_audio / ref_text from the meta file.
 2. Plain TTS (e.g. mistralai/Voxtral-4B-TTS-2603): use --no-ref-audio and
   --voice for a server-side speaker preset.
 
@@ -24,11 +24,23 @@ Usage:
         --model-path mistralai/Voxtral-4B-TTS-2603 \
         --port 8000
 
+    3. For Higgs-Audio-V3-TTS:
+    python -m sglang_omni.cli serve \
+        --model-path boson-sglang/higgs-audio-v3-tts-4b-base \
+        --config examples/configs/higgs_tts.yaml \
+        --port 8000
+
     # Full pipeline (generate + transcribe) — voice cloning
     python -m benchmarks.eval.benchmark_tts_seedtts \
         --meta zhaochenyang20/seed-tts-eval-arrow \
         --max-concurrency 16 \
         --model fishaudio/s2-pro --port 8000
+
+    # Full pipeline — voice cloning (Higgs)
+    python -m benchmarks.eval.benchmark_tts_seedtts \
+        --meta zhaochenyang20/seed-tts-eval-arrow \
+        --max-concurrency 16 \
+        --model boson-sglang/higgs-audio-v3-tts-4b-base --port 8000
 
     # Full pipeline — plain TTS (no ref audio from testset)
     python -m benchmarks.eval.benchmark_tts_seedtts \

--- a/benchmarks/tasks/tts.py
+++ b/benchmarks/tasks/tts.py
@@ -635,15 +635,12 @@ class VoiceCloneTTS:
         temperature: float = 0.8,
         seed: int | None = None,
     ) -> tuple[bytes, float]:
-        payload: dict = {
-            "model": model_name,
-            "input": sample.target_text,
-            "ref_audio": sample.ref_audio,
-            "ref_text": sample.ref_text,
-            "response_format": "wav",
-            "max_new_tokens": max_new_tokens,
-            "temperature": temperature,
-        }
+        payload = _build_tts_payload(
+            sample,
+            model_name,
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+        )
         if seed is not None:
             payload["seed"] = seed
 
@@ -672,16 +669,13 @@ class VoiceCloneTTS:
         seed: int | None = None,
     ) -> tuple[bytes, float]:
         """Generate speech via streaming SSE, concatenate audio chunks into WAV."""
-        payload: dict = {
-            "model": model_name,
-            "input": sample.target_text,
-            "ref_audio": sample.ref_audio,
-            "ref_text": sample.ref_text,
-            "response_format": "wav",
-            "max_new_tokens": max_new_tokens,
-            "temperature": temperature,
-            "stream": True,
-        }
+        payload = _build_tts_payload(
+            sample,
+            model_name,
+            stream=True,
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+        )
         if seed is not None:
             payload["seed"] = seed
 
@@ -984,6 +978,10 @@ class VoiceCloneOmni:
 # ---------------------------------------------------------------------------
 
 
+def _uses_references_format(model_name: str) -> bool:
+    return "higgs" in model_name.lower()
+
+
 def _build_tts_payload(
     sample: SampleInput,
     model_name: str,
@@ -999,8 +997,13 @@ def _build_tts_payload(
         "response_format": "wav",
     }
     if not no_ref_audio:
-        payload["ref_audio"] = sample.ref_audio
-        payload["ref_text"] = sample.ref_text
+        if _uses_references_format(model_name):
+            payload["references"] = [
+                {"audio_path": sample.ref_audio, "text": sample.ref_text}
+            ]
+        else:
+            payload["ref_audio"] = sample.ref_audio
+            payload["ref_text"] = sample.ref_text
     if voice is not None:
         payload["voice"] = voice
     for key, value in gen_kwargs.items():


### PR DESCRIPTION
## Motivation

The SeedTTS benchmark currently supports S2-Pro and Voxtral but not Higgs TTS.
Higgs uses a different payload format for voice cloning — it sends reference audio via a `references` array instead of flat `ref_audio`/`ref_text` fields. This PR adds Higgs support so all three TTS models can be evaluated through the same benchmark pipeline.

## Modifications

**`benchmarks/tasks/tts.py`**

- Add `_uses_references_format()` predicate to detect Higgs models by name.
- Update `_build_tts_payload()` to emit the `references` array format when the model is Higgs, and the existing `ref_audio`/`ref_text` fields otherwise.
- Refactor `VoiceCloneTTS.generate()` and `VoiceCloneTTS.generate_stream()` to use the shared `_build_tts_payload()` helper, removing duplicated payload construction.

**`benchmarks/eval/benchmark_tts_seedtts.py`**

- Add Higgs server launch example and benchmark usage to the docstring.
- List Higgs as a voice-cloning model alongside S2-Pro in the header note.

## Related Issues

<!-- Link to any related issues here. -->

## Accuracy Test

SeedTTS full-set evaluation on 1x H200, concurrency=1.

| Model | Lang | WER (corpus) | WER (mean) | Speaker Sim | Evaluated |
|-------|------|-------------|------------|-------------|-----------|
| Higgs | EN   | 1.40%       | 1.43%      | 66.04       | 1088/1088 |
| Higgs | ZH   | 1.19%       | 1.13%      | 72.54       | 2020/2020 |

## Benchmark & Profiling

Generation speed on 1x H200, concurrency=1.

| Model | Lang | Latency (mean) | Latency (p95) | RTF | Throughput (req/s) |
|-------|------|---------------|--------------|-----|-------------------|
| Higgs | EN   | 0.708s        | 0.931s       | 0.156 | 1.41            |
| Higgs | ZH   | 0.809s        | 1.060s       | 0.142 | 1.24            |

<details>
<summary>Reproduce</summary>

```bash
# Server (Higgs)
sgl-omni serve \
    --model-path boson-sglang/higgs-audio-v3-tts-4b-base \
    --config examples/configs/higgs_tts.yaml \
    --port 8000

# Generate
python -m benchmarks.eval.benchmark_tts_seedtts \
    --generate-only \
    --meta seedtts_testset/en/meta.lst \
    --model boson-sglang/higgs-audio-v3-tts-4b-base --port 8000 \
    --concurrency 1 --warmup 3

# WER
python -m benchmarks.eval.benchmark_tts_seedtts \
    --transcribe-only \
    --meta seedtts_testset/en/meta.lst \
    --model boson-sglang/higgs-audio-v3-tts-4b-base \
    --output-dir <output-dir> --lang en --device cuda:0

# Speaker similarity
python -m benchmarks.eval.benchmark_tts_seedtts \
    --similarity-only \
    --meta seedtts_testset/en/meta.lst \
    --model boson-sglang/higgs-audio-v3-tts-4b-base \
    --output-dir <output-dir> --lang en --device cuda:0
```

</details>

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the `run-ci` label. Once labeled, every subsequent push re-triggers CI as long as the label remains. Draft PRs are skipped even if labeled.