### PR TITLE
[Higgs] Enable torch.compile on AR backbone (decode-only fork)

### DIFF
--- a/issue_565_torch_compile_result.md
+++ b/issue_565_torch_compile_result.md
@@ -1,164 +1,144 @@
 # Issue #565 — Enable `torch.compile` for Higgs TTS AR backbone
 
 **Branch:** `feat/yichi/higgs-tts/torch_compile`
-**Status:** Production patch caps `_compiled_max_decode_bs=12` as the workaround. Root cause of the bs=16/32 catastrophic localized to an upstream sglang × inductor interaction. Multiple `sglang`-side fix candidates tried — one (V13: ascending capture order) eliminates the runaway and matches baseline quality, but **does not deliver throughput**. Holding the workaround pending an upstream owner.
+**Status:** Production patch ready. The previous `bs ≤ 12` cap is no longer needed — a one-shot eager forward before sglang's CG capture loop side-steps the upstream `sglang × inductor × CG` corruption at the first compiled+captured bs.
 
 ---
 
 ## TL;DR
 
-| Metric (single H200, SeedTTS EN) | Baseline (CG-on, no compile) | This PR (compile up to bs=12, eager bs≥13) |
-|---|---:|---:|
-| N=100, c=1   throughput (req/s) | 1.15 | **1.68**  (+46 %) |
-| N=100, c=1   RTF | 0.158 | 0.160 |
-| N=100, c=32  throughput | 5.96 | **9.22**  (+55 %) |
-| N=100, c=32  audio_s/s | 32.4 | **34.8** |
-| N=1088, c=16 WER excl > 50 % | 1.36 % (PR #534 report) | 1.32 % |
-| Catastrophic samples | 0 | 0 |
+`torch.compile`'s first dynamo trace during sglang's CUDA-graph capture loop allocates / initializes lazy CUDA state (cuBLAS handles, allocator pool, etc.) **inside the captured graph**. Replay of that graph then reads garbage at the slot the lazy init laid down → model emits broken logits → audio runs to `max_new_tokens` → catastrophic outliers.
 
-At c=16 we ship `_compiled_max_decode_bs=12`, so `bs==16` decode falls back to eager and dodges the upstream bug. Throughput at low concurrency is +46 %, but at c=16 with `max_running_requests=16` (and thus a fully compiled CG range up to bs=16) the bug fires; without the bs=12 cap the WER explodes.
+**The fix:** force all lazy CUDA init *outside* the capture window by running ONE eager forward at `bs=1` after `_compile_higgs_backbone` but before `init_device_graphs()`. ~12 lines in `stages.py`, no sglang patch required.
+
+Result vs no-compile baseline (SeedTTS-EN N=1088, single H200):
+
+| Config | Δ vs baseline |
+|---|---|
+| c=16 / mr=16 / cap=16 | outliers **50 → 2** (−96 %), WER excl 1.29 → 1.31 %, QPS 8.41 → 8.49 (+1 %) |
+| c=32 / mr=32 / cap=32 | outliers **50 → 4** (−92 %), WER excl 1.28 → 1.24 %, QPS 9.68 → 9.42 (−3 %) |
+
+Note: `torch.compile` itself doesn't deliver throughput on this workload (4 B decode-bound, bs ≤ 32). The PR's value is now (a) compile is **safe** to enable across the full bs range, and (b) the eager pre-warmup as a side-effect cuts most of Higgs's inherent c≥16 outliers from ~50/run to ~2–4/run.
 
 ---
 
 ## What the patch does
 
-Three files (one new), ~100 lines of code:
+Three files (one new), ~110 lines of code:
 
-1. **`sglang_omni/models/higgs_tts/sglang_qwen3_backbone.py`** (new) — `HiggsQwen3Model` subclasses sglang's `Qwen3Model` and overrides `forward` to pick between eager `self.layers` (prefill, bs > `_compiled_max_decode_bs`) and compiled `self._compiled_decode_layers` (decode, bs ≤ cap). `HiggsQwen3ForCausalLM` subclasses `Qwen3ForCausalLM` and swaps the inner `self.model`.
+1. **`sglang_omni/models/higgs_tts/sglang_qwen3_backbone.py`** (new) — `HiggsQwen3Model` subclasses sglang's `Qwen3Model` and overrides `forward` to pick between eager `self.layers` (prefill) and compiled `self._compiled_decode_layers` (decode). `HiggsQwen3ForCausalLM` subclasses `Qwen3ForCausalLM` and swaps the inner `self.model`.
 2. **`sglang_omni/models/higgs_tts/model.py`** — import the local fork; instantiate `HiggsQwen3ForCausalLM` instead of `Qwen3ForCausalLM`.
-3. **`sglang_omni/models/higgs_tts/stages.py`** — `_compile_higgs_backbone` populates the compiled-layers list and the bs cap. `create_sglang_tts_engine_executor` defers CG capture (`disable_cuda_graph=True` until after compile, then `init_device_graphs()`) so capture records compiled kernels rather than eager ones.
+3. **`sglang_omni/models/higgs_tts/stages.py`** —
+   - `_compile_higgs_backbone`: populate `_compiled_decode_layers`.
+   - `_warmup_eager_pre_cg` (NEW, ~12 lines): temporarily nulls `_compiled_decode_layers` (so dispatch falls back to eager `self.layers`), calls `model_runner._dummy_run(batch_size=1)`, restores the compiled list. Runs after `_compile_higgs_backbone` and before `init_device_graphs()`.
+   - `create_sglang_tts_engine_executor`: defers CG capture (`disable_cuda_graph=True` until after compile, then `init_device_graphs()`) so capture records compiled kernels.
 
 ---
 
-## Root-cause investigation — bs=16 catastrophic
+## Bug — what happens without the fix
 
-Initial attempt let bs=16 captured graphs run through compiled layers; that path produced 99–100/100 catastrophic outputs at c=32 (WER > 50 % on essentially every sample, audio runs to `max_new_tokens` instead of EOC).
+When `torch.compile` covers the largest bs in sglang's capture set, the CUDA graph for that bs returns corrupted logits on replay. Model never samples EOC → audio runs to `max_new_tokens=2048` (~80 s of audio per outlier). c=16 p99 latency goes from ~3 s (baseline) to ~19 s (no fix); c=32 p99 goes from ~5 s to ~27 s.
 
 ### Truth table (✓ = clean, ✗ = catastrophic 50–100/100)
 
-| # | bs | compile | CG capture | model | extra knob | Result |
+| # | bs | compile | CG | model | extra knob | Result |
 |:---:|:---:|:---:|:---:|:---:|:---|:---:|
-| 1 | 16 | off | off | Higgs | (eager baseline) | ✓ |
-| 2 | 16 | off | on  | Higgs | shipped path (CG-only at bs=16) | ✓ |
+| 1 | 16 | off | off | Higgs | eager baseline | ✓ |
+| 2 | 16 | off | on  | Higgs | CG-only at bs=16 | ✓ |
 | 3 | 16 | on  | off | Higgs | bs=16 not captured | ✓ |
-| 4 | ≤12 | on | on | Higgs | shipped path (small captured bs) | ✓ |
-| 5 | 16 | on  | on | toy (SDPA+MLP+RMSNorm) | pure `torch.cuda.CUDAGraph()` | ✓ |
+| 4 | ≤12 | on | on | Higgs | small captured bs only | ✓ |
+| 5 | 16 | on  | on | toy (SDPA+MLP+RMSNorm) | pure `torch.cuda.CUDAGraph` | ✓ |
 | 6 | **16** | **on** | **on** | **Higgs** | default config | **✗** |
 | 7 | 16 | on  | on | Higgs | only bs=16 captured (no smaller bs) | ✗ |
 | 8 | 16 | on  | on | Higgs | `mode=default` (no max-autotune) | ✗ |
 | 9 | 16 | on  | on | Higgs | `dynamic=True` (no static specialize) | ✗ |
 | 10 | 16 | on | on | Higgs | skip `set_torch_compile_config()` | ✗ |
 
-Bug fires **iff** all four hold simultaneously: `bs=16` AND `compile=on` AND `CG=on` AND model uses **sglang's stock Qwen3 layer** (rows 6–10). Removing any single one → clean.
+Bug fires iff: `compile=on` AND `CG=on` AND the bs being decoded is **the first one compiled inside sglang's capture loop**. Remove any single knob → clean.
 
-### Rejected candidate root causes
+### Numerical signature
 
-| Hypothesis | Ruled out by | Why not the cause |
-|---|:---:|---|
-| Multi-graph **pool sharing** across captures | row 7 | Capturing only bs=16 (no smaller bs) is still 50/50 catastrophic. No other captures to share pool with. |
-| **Aggressive autotune** kernel selection | row 8 | `mode=default` (no max-autotune) → still catastrophic. |
-| **Static specialization** at largest bs | row 9 | `dynamic=True` forces dynamic shape codegen → still catastrophic. |
-| `set_torch_compile_config()` inductor tweaks | row 10 | Skip the call entirely → still catastrophic. |
-| **Torch-generic** CG × compile bug | row 5 | Toy SDPA + MLP + RMSNorm at bs=16 → bit-identical to eager. |
-| **Compiled kernel is numerically wrong** | row 3 | Compile-on at bs=16 WITHOUT CG → 19800 per-layer hidden_states bit-identical to eager. Correct in isolation. |
-| Higgs **shadow buffers / sampler scatter** | hidden_states dump | The 6 % systematic norm drop is already present in `hidden_states` right after the backbone's final RMSNorm — before any Higgs-specific code touches it. Downstream is innocent victim. |
+Captured-replay `hidden_states` at the broken bs:
 
-### Captured-replay hidden_states at bs=16
-
-| | broken (CG + compile bs=16) | shipped (CG only, no compile bs=16) |
+| | broken | clean |
 |---|---:|---:|
-| n samples | 69 | 626 |
 | `hidden.norm` mean | **775.4** | **825.5** |
-| `hidden.norm` range | 716–823 | 811–831 |
-| NaN count | 0 | 0 |
+| NaN / inf | 0 | 0 |
 
-Broken bs=16 output is **systematically 6 % below** the clean baseline — no NaN, no inf, just a clean L2 norm shift. Signature consistent with "kernel reads partially stale memory" or "accumulator drops some iterations" rather than gross corruption. Propagated through hundreds of AR decode steps it manifests as catastrophic text generation.
+Systematic ~6 % L2-norm drop, no NaN — consistent with "kernel reads partially stale memory", not gross corruption. Propagated through hundreds of AR decode steps it manifests as wrong text content / runaway output.
 
-### Why this is an upstream bug
+### Ruled-out hypotheses
 
-Comparing the clean and broken regimes at bs=16 (rows 2 vs 6), the only differing code is which layer wrapper the loop iterates:
-
-- row 2: `self.layers[i]` — plain `Qwen3DecoderLayer` (sglang upstream)
-- row 6: `self._compiled_decode_layers[i]` — `torch.compile(Qwen3DecoderLayer)` (still upstream, wrapped by upstream `torch.compile`)
-
-Our wrapper code is trivial — no kernels, no math. The kernels actually executing inside the captured graph at bs=16 are **all from sglang upstream and PyTorch upstream** (`sgl_kernel.rmsnorm`, `silu_and_mul`, `fused_add_rmsnorm`, extern cuBLAS `mm`, inductor-emitted Triton). The capture mechanism (`init_device_graphs`) and the codegen (inductor) are both upstream.
-
-Combined with the rejected candidates above, the bug is constrained to:
-
-> some interaction between **sglang's `init_device_graphs` capture path** and **inductor-emitted kernels for sglang's stock Qwen3 layer composition** that fires only when the *largest* captured bs is also `torch.compile`-d.
-
-That interaction lives entirely above this repo.
+| Hypothesis | Killed by | Why not |
+|---|:---:|---|
+| Multi-graph **pool sharing** across captures | row 7 | Only bs=16 captured → still ✗ |
+| **Aggressive autotune** kernel selection | row 8 | `mode=default` → still ✗ |
+| **Static specialization** at largest bs | row 9 | `dynamic=True` → still ✗ |
+| `set_torch_compile_config` inductor tweaks | row 10 | Skip the call → still ✗ |
+| **Torch-generic** CG × compile bug | row 5 | Toy model at bs=16 → bit-identical to eager |
+| **Compiled kernel is wrong on its own** | row 3 | Compile-on, CG-off at bs=16 → 19 800 per-layer hidden_states bit-identical to eager |
+| Higgs **shadow buffers / sampler scatter** | dump | 6 % norm drop already present in `hidden_states` *before* any Higgs-specific code touches it |
 
 ---
 
-## sglang-side fix attempts (overnight pass)
+## How V14 (the eager pre-warmup) was reached
 
-After localising the bug upstream, I tried several fixes directly inside `sglang/srt/model_executor/cuda_graph_runner.py` to see if any of them could lift the bs=12 cap. Test rig: N=1088 SeedTTS EN, single H200, sample at `top_k=50 t=0.8`, `max_running_requests=16 cuda_graph_max_bs=16 _compiled_max_decode_bs=16 c=16` — i.e. bs=16 is BOTH captured AND compiled (the exact regime the cap currently dodges).
+Six fix attempts inside sglang or in stages.py at the failing config (mr=16/cap=16/c=16, where bs=16 is captured+compiled):
 
-| Variant | sglang change | Outcome |
+| Variant | Change | Outcome |
 |---|---|---|
-| V1 | `torch.cuda.synchronize()` + `torch.cuda.empty_cache()` between warmup and the `device.graph(...)` capture inside `capture_one_batch_size` | p99 = 19.0 s — no help |
-| V3 | Two-phase: warm every bs first (no capture), sync + empty cache, then capture every bs | partial — kills runaway but adds 50 mid-severity outliers, p99 = 3.3 s |
-| V5 | `torch.compile(layer, dynamic=True)` instead of static | p99 = 19.6 s — no help |
-| V11 | Skip `set_torch_compile_config()` entirely (drop `coordinate_descent_tuning`, `fx_graph_cache`, dynamo cache-size raise, `monkey_patch_torch_compile`) | p99 = 18.7 s — no help |
-| V10 | `compile_mode="default"` instead of `max-autotune-no-cudagraphs` | p99 = 19.4 s — no help |
-| **V13** | **Reverse capture order: capture `[1, 2, 4, 8, 12, 16]` ascending instead of `[16, 12, 8, 4, 2, 1]`** | **p99 = 3.19 s** ✓ no runaway, but no throughput win either |
+| V1 | `cuda.synchronize() + empty_cache()` between warmup and capture | p99 = 19.0 s — no help |
+| V3 | Two-phase: warmup every bs first (no capture), then capture every bs | partial — kills runaway but adds 50 mid-severity outliers |
+| V5 | `torch.compile(layer, dynamic=True)` | p99 = 19.6 s — no help |
+| V10 | `compile_mode="default"` | p99 = 19.4 s — no help |
+| V11 | Skip `set_torch_compile_config()` entirely | p99 = 18.7 s — no help |
+| V13 | Capture in ASCENDING order (largest bs last) | clean at c=16 but **catastrophic at c=1** — just moves the bug from bs=largest to bs=1 |
+| **V14** | **Eager `_dummy_run(bs=1)` before `init_device_graphs()`** | **clean across c=1 / c=16 / c=32** ✓ |
 
-V13 — capturing in ascending order so the largest bs (also the first dynamo trace) happens **last** rather than first — was the only thing that killed the runaway. Quality-wise V13 matches baseline (WER excl > 50 % = 1.35 % at c=16, 1.27–1.38 % at c=32, vs baseline 1.36 %). But it does **not** deliver throughput: at c=32 QPS drops from 9.68 (no compile) to 8.5–9.15 (V13 + compile). At c=16 QPS is essentially flat (8.74 vs 8.41 my-baseline).
+V13's failure at c=1 was the key signal: the bug isn't tied to "the largest bs", it's tied to **the first bs the dynamo trace runs against in sglang's capture loop**. Whatever cold CUDA init that trace pulls in lands inside the captured graph. V14 does that cold init separately in an eager forward, then sglang's capture sees a fully warm CUDA state.
 
-So V13 makes compile **safe** at the full bs range, but `torch.compile` at these workloads (decode-bound 4 B model, bs ≤ 32) just doesn't beat the existing eager kernels enough to pay for the extra compile/capture overhead.
+---
 
-### Full V13 comparison table
+## Full results — Baseline vs V14
 
-All 1088 SeedTTS-EN samples, single H200, ASR scorer on a separate GPU.
+All numbers: SeedTTS-EN, N=1088, single H200, `top_k=50 t=0.8`, ASR scorer on a separate GPU.
 
-#### c=16, `max_running_requests=16`, `cuda_graph_max_bs=16` (so `_compiled_max_decode_bs=16` actually puts compile at the largest captured bs)
+### c=16, max_running=16, cap=16
 
-| Run | sglang | compile | WER corpus | WER excl > 50 % | Outliers | Outlier max | p99 (s) | QPS |
-|---|---|---|---|---|---|---|---|---|
-| Baseline | upstream (reverse) | off | 6.36 % | 1.29 % | 50 | 3 740 % | 3.14 | 8.41 |
-| No fix | upstream (reverse) | **on** | (runaway) | — | runaway | — | **19.25** | 4.93 |
-| **V13** | **ascending** | **on** | 4.61 % | 1.35 % | 50 | 2 785 % | **3.19** | **8.74** |
+| Metric | Baseline (no compile) | **V14** | Δ |
+|---|---:|---:|---:|
+| Latency mean | 2.17 s | 1.78 s | −18 % |
+| Latency p99 | 3.14 s | 2.98 s | −5 % |
+| QPS | 8.41 | 8.49 | +1 % |
+| Output tokens mean | 104 | 123 | +18 % |
+| Audio duration mean | 3.86 s | 4.64 s | +20 % |
+| WER excl > 50 % | 1.29 % | 1.31 % | +0.02 pp (noise) |
+| Outliers (> 50 %) | 50 | **2** | **−96 %** |
 
-#### c=32, `max_running_requests=32`, `cuda_graph_max_bs=32`, `_compiled_max_decode_bs=32`
+### c=32, max_running=32, cap=32
 
-| Run | sglang | compile | WER corpus | WER excl > 50 % | Outliers | Outlier max | p99 (s) | QPS |
-|---|---|---|---|---|---|---|---|---|
-| Baseline | upstream (reverse) | off | 13.56 % | 1.28 % | 50 | 7 600 % | 5.38 | 9.68 |
-| No fix | upstream (reverse) | **on** | (runaway) | — | runaway | — | **26.95** | 7.27 |
-| **V13** | **ascending** | **on** | 9.55–9.61 % | 1.27–1.38 % | 50 | 4 100 % | 5.57–5.74 | 8.51–9.15 |
+| Metric | Baseline (no compile) | **V14** | Δ |
+|---|---:|---:|---:|
+| Latency mean | 3.31 s | 3.31 s | 0 |
+| Latency p99 | 5.38 s | 5.56 s | +3 % |
+| QPS | 9.68 | 9.42 | −3 % |
+| Output tokens mean | ~150 | 121 | −19 % |
+| WER excl > 50 % | 1.28 % | **1.24 %** | **−3 %** (relative) |
+| Outliers (> 50 %) | 50 | **4** | **−92 %** |
+| WER per-sample max | 7 600 % | 2 793 % | −63 % |
 
-#### Reading this table
+### c=1, N=50 (smoke test)
 
-- The **50 outliers** that appear in every row, including the no-compile baseline, are Higgs's inherent flakiness at higher concurrency — not the compile×CG bug. With V13 the outliers are *less severe* (lower max %) than baseline; without V13 + with compile they become catastrophic runaways.
-- **WER excl > 50 %** is the stable quality metric (matches PR #534's 1.36 %). All rows except the runaway ones are within noise of baseline.
-- **Throughput**: V13 + compile is essentially flat vs no-compile baseline. `torch.compile` here does not pay back its overhead.
-
-### Conclusion for upstream owner
-
-V13 is a one-line patch in `sglang/srt/model_executor/cuda_graph_runner.py` `capture()`:
-
-```diff
--            # Reverse the order to enable better memory sharing across cuda graphs.
--            capture_range = (
--                tqdm.tqdm(list(reversed(self.capture_bs)))
--                if get_tensor_model_parallel_rank() == 0
--                else reversed(self.capture_bs)
--            )
-+            capture_range = (
-+                tqdm.tqdm(list(self.capture_bs))
-+                if get_tensor_model_parallel_rank() == 0
-+                else iter(self.capture_bs)
-+            )
-```
-
-It side-steps the bug consistently but doesn't *explain* it, and reversing the capture order has a memory-pool-reuse cost upstream may not want to pay. We're holding the bs=12 workaround in this PR until someone with deeper knowledge of inductor / CUDA-graph memory-pool interaction can pin the actual root cause.
+| Metric | Baseline | **V14** |
+|---|---:|---:|
+| Latency mean | 0.79 s | 0.79 s |
+| Output tokens mean | 154 | 144 |
+| Audio duration mean | 5.88 s | 5.48 s |
 
 ---
 
 ## Open follow-ups
 
-1. **N=1088 full-set validation of the shipped (cap=12) path** — current PR ships with the cap; the +46 % / +55 % numbers above are N=100. The full-set numbers under the cap are in the table directly above (the c=16 V13 row mostly applies because at `_compiled_max_decode_bs=12` bs=16 is eager anyway, and the V13 question reduces to whether compile at bs∈{1,2,4,8,12} pays for itself — it doesn't in our tests).
-2. **`speaker_sim` not measured.** Can be added with `--similarity-only` on the saved audio dirs.
-3. **File an upstream sglang issue** with the diagnostic data above + the V13 evidence. Anyone running stock Qwen3 + `enable_torch_compile=True` + `cuda_graph_max_bs ≥ 16` is potentially affected.
-4. **Lift `_compiled_max_decode_bs` once upstream fixes the bug.** TODO marker is in `_compile_higgs_backbone` (`stages.py`).
+1. **`torch.compile` doesn't actually deliver throughput on this workload.** V14 is within ±3 % of baseline at the configs we tested. The PR's current value is "compile is safe to enable" + "outliers cut by ~95 %", not raw speed. Worth discussing whether to keep the compile path on by default.
+2. **Root cause unknown.** V14 sidesteps the bug but doesn't *explain* what specific lazy CUDA state the first dynamo trace is laying down. A teammate with deeper inductor + CUDA-graph knowledge could pin this down and file an upstream sglang issue.
+3. **`speaker_sim` not measured.** Worth adding with `--similarity-only` on the saved audio dirs.

--- a/issue_565_torch_compile_result.md
+++ b/issue_565_torch_compile_result.md
@@ -1,33 +1,38 @@
-# Issue #565 — Enable torch.compile for Higgs TTS AR backbone
+# Issue #565 — Enable `torch.compile` for Higgs TTS AR backbone
 
 **Branch:** `feat/yichi/higgs-tts/torch_compile`
-**Status:** Production patch ready. Root cause of the bs=16 catastrophic localized to an upstream sglang × inductor interaction — not fixable from this side, capped via `_compiled_max_decode_bs=12` as the workaround.
+**Status:** Production patch caps `_compiled_max_decode_bs=12` as the workaround. Root cause of the bs=16/32 catastrophic localized to an upstream sglang × inductor interaction. Multiple `sglang`-side fix candidates tried — one (V13: ascending capture order) eliminates the runaway and matches baseline quality, but **does not deliver throughput**. Holding the workaround pending an upstream owner.
+
+---
 
 ## TL;DR
 
-| Metric @ N=100 (single H200, `top_k=50`, `t=0.8`, SeedTTS EN) | baseline (CG-on, no compile) | this PR | Δ |
-|---|---:|---:|---:|
-| c=1   throughput (req/s) | 1.15 | **1.68** | **+46 %** |
-| c=1   RTF | 0.158 | 0.160 | +1 % |
-| c=8   throughput | 5.92 | 5.01\* | −15 %\* |
-| c=32  throughput | 5.96 | **9.22** | **+55 %** |
-| c=32  audio_s/s | 32.4 | **34.8** | +7 % |
-| WER (excl >50 % outliers) all c | 1.09–1.46 % | 1.00–1.91 % | within noise |
-| Catastrophic samples | 0 | 0 | — |
+| Metric (single H200, SeedTTS EN) | Baseline (CG-on, no compile) | This PR (compile up to bs=12, eager bs≥13) |
+|---|---:|---:|
+| N=100, c=1   throughput (req/s) | 1.15 | **1.68**  (+46 %) |
+| N=100, c=1   RTF | 0.158 | 0.160 |
+| N=100, c=32  throughput | 5.96 | **9.22**  (+55 %) |
+| N=100, c=32  audio_s/s | 32.4 | **34.8** |
+| N=1088, c=16 WER excl > 50 % | 1.36 % (PR #534 report) | 1.32 % |
+| Catastrophic samples | 0 | 0 |
 
-\* c=8 throughput is single-run noise (audio_dur drifted to 5.40 s vs 5.38 baseline — same prompts, different RNG outcomes); 0 catastrophic.
+At c=16 we ship `_compiled_max_decode_bs=12`, so `bs==16` decode falls back to eager and dodges the upstream bug. Throughput at low concurrency is +46 %, but at c=16 with `max_running_requests=16` (and thus a fully compiled CG range up to bs=16) the bug fires; without the bs=12 cap the WER explodes.
+
+---
 
 ## What the patch does
 
 Three files (one new), ~100 lines of code:
 
-1. **`sglang_omni/models/higgs_tts/sglang_qwen3_backbone.py`** (new) — `HiggsQwen3Model` subclasses sglang's `Qwen3Model` and overrides `forward` to pick between eager `self.layers` (prefill, bs > 12) and compiled `self._compiled_decode_layers` (decode, bs ≤ 12). `HiggsQwen3ForCausalLM` subclasses `Qwen3ForCausalLM` and swaps the inner `self.model`.
+1. **`sglang_omni/models/higgs_tts/sglang_qwen3_backbone.py`** (new) — `HiggsQwen3Model` subclasses sglang's `Qwen3Model` and overrides `forward` to pick between eager `self.layers` (prefill, bs > `_compiled_max_decode_bs`) and compiled `self._compiled_decode_layers` (decode, bs ≤ cap). `HiggsQwen3ForCausalLM` subclasses `Qwen3ForCausalLM` and swaps the inner `self.model`.
 2. **`sglang_omni/models/higgs_tts/model.py`** — import the local fork; instantiate `HiggsQwen3ForCausalLM` instead of `Qwen3ForCausalLM`.
 3. **`sglang_omni/models/higgs_tts/stages.py`** — `_compile_higgs_backbone` populates the compiled-layers list and the bs cap. `create_sglang_tts_engine_executor` defers CG capture (`disable_cuda_graph=True` until after compile, then `init_device_graphs()`) so capture records compiled kernels rather than eager ones.
 
+---
+
 ## Root-cause investigation — bs=16 catastrophic
 
-Initial attempt let bs=16 captured graphs run through compiled layers; that path produced 99–100/100 catastrophic outputs at c=32 (WER > 50 % on essentially every sample, audio runs to `max_new_tokens` instead of EOC). The investigation:
+Initial attempt let bs=16 captured graphs run through compiled layers; that path produced 99–100/100 catastrophic outputs at c=32 (WER > 50 % on essentially every sample, audio runs to `max_new_tokens` instead of EOC).
 
 ### Truth table (✓ = clean, ✗ = catastrophic 50–100/100)
 
@@ -36,15 +41,15 @@ Initial attempt let bs=16 captured graphs run through compiled layers; that path
 | 1 | 16 | off | off | Higgs | (eager baseline) | ✓ |
 | 2 | 16 | off | on  | Higgs | shipped path (CG-only at bs=16) | ✓ |
 | 3 | 16 | on  | off | Higgs | bs=16 not captured | ✓ |
-| 4 | ≤12 | on | on  | Higgs | shipped path (small captured bs) | ✓ |
-| 5 | 16 | on  | on  | toy (SDPA+MLP+RMSNorm) | pure `torch.cuda.CUDAGraph()` | ✓ |
+| 4 | ≤12 | on | on | Higgs | shipped path (small captured bs) | ✓ |
+| 5 | 16 | on  | on | toy (SDPA+MLP+RMSNorm) | pure `torch.cuda.CUDAGraph()` | ✓ |
 | 6 | **16** | **on** | **on** | **Higgs** | default config | **✗** |
-| 7 | 16 | on  | on  | Higgs | only bs=16 captured (no smaller bs) | ✗ |
-| 8 | 16 | on  | on  | Higgs | `mode=default` (no max-autotune) | ✗ |
-| 9 | 16 | on  | on  | Higgs | `dynamic=True` (no static specialize) | ✗ |
-| 10 | 16 | on | on  | Higgs | skip `set_torch_compile_config()` | ✗ |
+| 7 | 16 | on  | on | Higgs | only bs=16 captured (no smaller bs) | ✗ |
+| 8 | 16 | on  | on | Higgs | `mode=default` (no max-autotune) | ✗ |
+| 9 | 16 | on  | on | Higgs | `dynamic=True` (no static specialize) | ✗ |
+| 10 | 16 | on | on | Higgs | skip `set_torch_compile_config()` | ✗ |
 
-Bug fires **iff** all four are simultaneously: `bs=16` AND `compile=on` AND `CG=on` AND model uses **sglang's stock Qwen3 layer** (rows 6–10). Removing any single one → clean.
+Bug fires **iff** all four hold simultaneously: `bs=16` AND `compile=on` AND `CG=on` AND model uses **sglang's stock Qwen3 layer** (rows 6–10). Removing any single one → clean.
 
 ### Rejected candidate root causes
 
@@ -80,13 +85,80 @@ Our wrapper code is trivial — no kernels, no math. The kernels actually execut
 
 Combined with the rejected candidates above, the bug is constrained to:
 
-> some interaction between **sglang's `init_device_graphs` capture path** and **inductor-emitted kernels for sglang's stock Qwen3 layer composition** that fires only at `bs == cuda_graph_max_bs == 16`.
+> some interaction between **sglang's `init_device_graphs` capture path** and **inductor-emitted kernels for sglang's stock Qwen3 layer composition** that fires only when the *largest* captured bs is also `torch.compile`-d.
 
-That interaction lives entirely above this repo. The cap (`_compiled_max_decode_bs=12`) dodges it; lifting the cap to 16 is gated on the upstream fix and tracked as a TODO in `stages.py`.
+That interaction lives entirely above this repo.
+
+---
+
+## sglang-side fix attempts (overnight pass)
+
+After localising the bug upstream, I tried several fixes directly inside `sglang/srt/model_executor/cuda_graph_runner.py` to see if any of them could lift the bs=12 cap. Test rig: N=1088 SeedTTS EN, single H200, sample at `top_k=50 t=0.8`, `max_running_requests=16 cuda_graph_max_bs=16 _compiled_max_decode_bs=16 c=16` — i.e. bs=16 is BOTH captured AND compiled (the exact regime the cap currently dodges).
+
+| Variant | sglang change | Outcome |
+|---|---|---|
+| V1 | `torch.cuda.synchronize()` + `torch.cuda.empty_cache()` between warmup and the `device.graph(...)` capture inside `capture_one_batch_size` | p99 = 19.0 s — no help |
+| V3 | Two-phase: warm every bs first (no capture), sync + empty cache, then capture every bs | partial — kills runaway but adds 50 mid-severity outliers, p99 = 3.3 s |
+| V5 | `torch.compile(layer, dynamic=True)` instead of static | p99 = 19.6 s — no help |
+| V11 | Skip `set_torch_compile_config()` entirely (drop `coordinate_descent_tuning`, `fx_graph_cache`, dynamo cache-size raise, `monkey_patch_torch_compile`) | p99 = 18.7 s — no help |
+| V10 | `compile_mode="default"` instead of `max-autotune-no-cudagraphs` | p99 = 19.4 s — no help |
+| **V13** | **Reverse capture order: capture `[1, 2, 4, 8, 12, 16]` ascending instead of `[16, 12, 8, 4, 2, 1]`** | **p99 = 3.19 s** ✓ no runaway, but no throughput win either |
+
+V13 — capturing in ascending order so the largest bs (also the first dynamo trace) happens **last** rather than first — was the only thing that killed the runaway. Quality-wise V13 matches baseline (WER excl > 50 % = 1.35 % at c=16, 1.27–1.38 % at c=32, vs baseline 1.36 %). But it does **not** deliver throughput: at c=32 QPS drops from 9.68 (no compile) to 8.5–9.15 (V13 + compile). At c=16 QPS is essentially flat (8.74 vs 8.41 my-baseline).
+
+So V13 makes compile **safe** at the full bs range, but `torch.compile` at these workloads (decode-bound 4 B model, bs ≤ 32) just doesn't beat the existing eager kernels enough to pay for the extra compile/capture overhead.
+
+### Full V13 comparison table
+
+All 1088 SeedTTS-EN samples, single H200, ASR scorer on a separate GPU.
+
+#### c=16, `max_running_requests=16`, `cuda_graph_max_bs=16` (so `_compiled_max_decode_bs=16` actually puts compile at the largest captured bs)
+
+| Run | sglang | compile | WER corpus | WER excl > 50 % | Outliers | Outlier max | p99 (s) | QPS |
+|---|---|---|---|---|---|---|---|---|
+| Baseline | upstream (reverse) | off | 6.36 % | 1.29 % | 50 | 3 740 % | 3.14 | 8.41 |
+| No fix | upstream (reverse) | **on** | (runaway) | — | runaway | — | **19.25** | 4.93 |
+| **V13** | **ascending** | **on** | 4.61 % | 1.35 % | 50 | 2 785 % | **3.19** | **8.74** |
+
+#### c=32, `max_running_requests=32`, `cuda_graph_max_bs=32`, `_compiled_max_decode_bs=32`
+
+| Run | sglang | compile | WER corpus | WER excl > 50 % | Outliers | Outlier max | p99 (s) | QPS |
+|---|---|---|---|---|---|---|---|---|
+| Baseline | upstream (reverse) | off | 13.56 % | 1.28 % | 50 | 7 600 % | 5.38 | 9.68 |
+| No fix | upstream (reverse) | **on** | (runaway) | — | runaway | — | **26.95** | 7.27 |
+| **V13** | **ascending** | **on** | 9.55–9.61 % | 1.27–1.38 % | 50 | 4 100 % | 5.57–5.74 | 8.51–9.15 |
+
+#### Reading this table
+
+- The **50 outliers** that appear in every row, including the no-compile baseline, are Higgs's inherent flakiness at higher concurrency — not the compile×CG bug. With V13 the outliers are *less severe* (lower max %) than baseline; without V13 + with compile they become catastrophic runaways.
+- **WER excl > 50 %** is the stable quality metric (matches PR #534's 1.36 %). All rows except the runaway ones are within noise of baseline.
+- **Throughput**: V13 + compile is essentially flat vs no-compile baseline. `torch.compile` here does not pay back its overhead.
+
+### Conclusion for upstream owner
+
+V13 is a one-line patch in `sglang/srt/model_executor/cuda_graph_runner.py` `capture()`:
+
+```diff
+-            # Reverse the order to enable better memory sharing across cuda graphs.
+-            capture_range = (
+-                tqdm.tqdm(list(reversed(self.capture_bs)))
+-                if get_tensor_model_parallel_rank() == 0
+-                else reversed(self.capture_bs)
+-            )
++            capture_range = (
++                tqdm.tqdm(list(self.capture_bs))
++                if get_tensor_model_parallel_rank() == 0
++                else iter(self.capture_bs)
++            )
+```
+
+It side-steps the bug consistently but doesn't *explain* it, and reversing the capture order has a memory-pool-reuse cost upstream may not want to pay. We're holding the bs=12 workaround in this PR until someone with deeper knowledge of inductor / CUDA-graph memory-pool interaction can pin the actual root cause.
+
+---
 
 ## Open follow-ups
 
-1. **N=1088 full set validation.** This report is N=100 only.
+1. **N=1088 full-set validation of the shipped (cap=12) path** — current PR ships with the cap; the +46 % / +55 % numbers above are N=100. The full-set numbers under the cap are in the table directly above (the c=16 V13 row mostly applies because at `_compiled_max_decode_bs=12` bs=16 is eager anyway, and the V13 question reduces to whether compile at bs∈{1,2,4,8,12} pays for itself — it doesn't in our tests).
 2. **`speaker_sim` not measured.** Can be added with `--similarity-only` on the saved audio dirs.
-3. **File the upstream sglang issue** with the diagnostic data above. Anyone running stock Qwen3 + `enable_torch_compile=True` + `cuda_graph_max_bs ≥ 16` is potentially affected.
+3. **File an upstream sglang issue** with the diagnostic data above + the V13 evidence. Anyone running stock Qwen3 + `enable_torch_compile=True` + `cuda_graph_max_bs ≥ 16` is potentially affected.
 4. **Lift `_compiled_max_decode_bs` once upstream fixes the bug.** TODO marker is in `_compile_higgs_backbone` (`stages.py`).

--- a/issue_565_torch_compile_result.md
+++ b/issue_565_torch_compile_result.md
@@ -1,0 +1,92 @@
+# Issue #565 — Enable torch.compile for Higgs TTS AR backbone
+
+**Branch:** `feat/yichi/higgs-tts/torch_compile`
+**Status:** Production patch ready. Root cause of the bs=16 catastrophic localized to an upstream sglang × inductor interaction — not fixable from this side, capped via `_compiled_max_decode_bs=12` as the workaround.
+
+## TL;DR
+
+| Metric @ N=100 (single H200, `top_k=50`, `t=0.8`, SeedTTS EN) | baseline (CG-on, no compile) | this PR | Δ |
+|---|---:|---:|---:|
+| c=1   throughput (req/s) | 1.15 | **1.68** | **+46 %** |
+| c=1   RTF | 0.158 | 0.160 | +1 % |
+| c=8   throughput | 5.92 | 5.01\* | −15 %\* |
+| c=32  throughput | 5.96 | **9.22** | **+55 %** |
+| c=32  audio_s/s | 32.4 | **34.8** | +7 % |
+| WER (excl >50 % outliers) all c | 1.09–1.46 % | 1.00–1.91 % | within noise |
+| Catastrophic samples | 0 | 0 | — |
+
+\* c=8 throughput is single-run noise (audio_dur drifted to 5.40 s vs 5.38 baseline — same prompts, different RNG outcomes); 0 catastrophic.
+
+## What the patch does
+
+Three files (one new), ~100 lines of code:
+
+1. **`sglang_omni/models/higgs_tts/sglang_qwen3_backbone.py`** (new) — `HiggsQwen3Model` subclasses sglang's `Qwen3Model` and overrides `forward` to pick between eager `self.layers` (prefill, bs > 12) and compiled `self._compiled_decode_layers` (decode, bs ≤ 12). `HiggsQwen3ForCausalLM` subclasses `Qwen3ForCausalLM` and swaps the inner `self.model`.
+2. **`sglang_omni/models/higgs_tts/model.py`** — import the local fork; instantiate `HiggsQwen3ForCausalLM` instead of `Qwen3ForCausalLM`.
+3. **`sglang_omni/models/higgs_tts/stages.py`** — `_compile_higgs_backbone` populates the compiled-layers list and the bs cap. `create_sglang_tts_engine_executor` defers CG capture (`disable_cuda_graph=True` until after compile, then `init_device_graphs()`) so capture records compiled kernels rather than eager ones.
+
+## Root-cause investigation — bs=16 catastrophic
+
+Initial attempt let bs=16 captured graphs run through compiled layers; that path produced 99–100/100 catastrophic outputs at c=32 (WER > 50 % on essentially every sample, audio runs to `max_new_tokens` instead of EOC). The investigation:
+
+### Truth table (✓ = clean, ✗ = catastrophic 50–100/100)
+
+| # | bs | compile | CG capture | model | extra knob | Result |
+|:---:|:---:|:---:|:---:|:---:|:---|:---:|
+| 1 | 16 | off | off | Higgs | (eager baseline) | ✓ |
+| 2 | 16 | off | on  | Higgs | shipped path (CG-only at bs=16) | ✓ |
+| 3 | 16 | on  | off | Higgs | bs=16 not captured | ✓ |
+| 4 | ≤12 | on | on  | Higgs | shipped path (small captured bs) | ✓ |
+| 5 | 16 | on  | on  | toy (SDPA+MLP+RMSNorm) | pure `torch.cuda.CUDAGraph()` | ✓ |
+| 6 | **16** | **on** | **on** | **Higgs** | default config | **✗** |
+| 7 | 16 | on  | on  | Higgs | only bs=16 captured (no smaller bs) | ✗ |
+| 8 | 16 | on  | on  | Higgs | `mode=default` (no max-autotune) | ✗ |
+| 9 | 16 | on  | on  | Higgs | `dynamic=True` (no static specialize) | ✗ |
+| 10 | 16 | on | on  | Higgs | skip `set_torch_compile_config()` | ✗ |
+
+Bug fires **iff** all four are simultaneously: `bs=16` AND `compile=on` AND `CG=on` AND model uses **sglang's stock Qwen3 layer** (rows 6–10). Removing any single one → clean.
+
+### Rejected candidate root causes
+
+| Hypothesis | Ruled out by | Why not the cause |
+|---|:---:|---|
+| Multi-graph **pool sharing** across captures | row 7 | Capturing only bs=16 (no smaller bs) is still 50/50 catastrophic. No other captures to share pool with. |
+| **Aggressive autotune** kernel selection | row 8 | `mode=default` (no max-autotune) → still catastrophic. |
+| **Static specialization** at largest bs | row 9 | `dynamic=True` forces dynamic shape codegen → still catastrophic. |
+| `set_torch_compile_config()` inductor tweaks | row 10 | Skip the call entirely → still catastrophic. |
+| **Torch-generic** CG × compile bug | row 5 | Toy SDPA + MLP + RMSNorm at bs=16 → bit-identical to eager. |
+| **Compiled kernel is numerically wrong** | row 3 | Compile-on at bs=16 WITHOUT CG → 19800 per-layer hidden_states bit-identical to eager. Correct in isolation. |
+| Higgs **shadow buffers / sampler scatter** | hidden_states dump | The 6 % systematic norm drop is already present in `hidden_states` right after the backbone's final RMSNorm — before any Higgs-specific code touches it. Downstream is innocent victim. |
+
+### Captured-replay hidden_states at bs=16
+
+| | broken (CG + compile bs=16) | shipped (CG only, no compile bs=16) |
+|---|---:|---:|
+| n samples | 69 | 626 |
+| `hidden.norm` mean | **775.4** | **825.5** |
+| `hidden.norm` range | 716–823 | 811–831 |
+| NaN count | 0 | 0 |
+
+Broken bs=16 output is **systematically 6 % below** the clean baseline — no NaN, no inf, just a clean L2 norm shift. Signature consistent with "kernel reads partially stale memory" or "accumulator drops some iterations" rather than gross corruption. Propagated through hundreds of AR decode steps it manifests as catastrophic text generation.
+
+### Why this is an upstream bug
+
+Comparing the clean and broken regimes at bs=16 (rows 2 vs 6), the only differing code is which layer wrapper the loop iterates:
+
+- row 2: `self.layers[i]` — plain `Qwen3DecoderLayer` (sglang upstream)
+- row 6: `self._compiled_decode_layers[i]` — `torch.compile(Qwen3DecoderLayer)` (still upstream, wrapped by upstream `torch.compile`)
+
+Our wrapper code is trivial — no kernels, no math. The kernels actually executing inside the captured graph at bs=16 are **all from sglang upstream and PyTorch upstream** (`sgl_kernel.rmsnorm`, `silu_and_mul`, `fused_add_rmsnorm`, extern cuBLAS `mm`, inductor-emitted Triton). The capture mechanism (`init_device_graphs`) and the codegen (inductor) are both upstream.
+
+Combined with the rejected candidates above, the bug is constrained to:
+
+> some interaction between **sglang's `init_device_graphs` capture path** and **inductor-emitted kernels for sglang's stock Qwen3 layer composition** that fires only at `bs == cuda_graph_max_bs == 16`.
+
+That interaction lives entirely above this repo. The cap (`_compiled_max_decode_bs=12`) dodges it; lifting the cap to 16 is gated on the upstream fix and tracked as a TODO in `stages.py`.
+
+## Open follow-ups
+
+1. **N=1088 full set validation.** This report is N=100 only.
+2. **`speaker_sim` not measured.** Can be added with `--similarity-only` on the saved audio dirs.
+3. **File the upstream sglang issue** with the diagnostic data above. Anyone running stock Qwen3 + `enable_torch_compile=True` + `cuda_graph_max_bs ≥ 16` is potentially affected.
+4. **Lift `_compiled_max_decode_bs` once upstream fixes the bug.** TODO marker is in `_compile_higgs_backbone` (`stages.py`).

--- a/sglang_omni/models/higgs_tts/model.py
+++ b/sglang_omni/models/higgs_tts/model.py
@@ -8,7 +8,6 @@ from typing import Iterable, Tuple
 
 import torch
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
-from sglang.srt.models.qwen3 import Qwen3ForCausalLM
 from torch import nn
 
 from sglang_omni.models.higgs_tts.hf_config import HiggsMultimodalQwen3Config
@@ -22,6 +21,7 @@ from sglang_omni.models.higgs_tts.sampler import (
     batched_step,
     batched_step_direct,
 )
+from sglang_omni.models.higgs_tts.sglang_qwen3_backbone import HiggsQwen3ForCausalLM
 from sglang_omni.models.higgs_tts.weight_loader import DiscreteWeightMapper
 
 # Higgs ckpt prefixes → sglang Qwen3ForCausalLM parameter tree (under ``backbone.``).
@@ -100,7 +100,7 @@ class HiggsTTSModel(nn.Module):
         self.config = config
 
         text_config = config.get_text_config()
-        self.backbone = Qwen3ForCausalLM(
+        self.backbone = HiggsQwen3ForCausalLM(
             text_config,
             quant_config=quant_config,
             prefix=prefix + "backbone" if prefix else "backbone",
@@ -319,6 +319,12 @@ class HiggsTTSModel(nn.Module):
         only preallocated ``_cg_*`` buffers, no Python control flow on
         tensor values, no D2H syncs.
         """
+        # TODO(#578): at bs >= 16 (CUDA graph bucket), a small fraction of
+        # samples (~0.1-0.4%) produce catastrophic WER (>50%) that drags
+        # corpus WER from ~1.3% to ~4.7%. PR #503 shadow-buffer fix reduced
+        # the rate 10x but did not eliminate it. Root-cause is unknown —
+        # needs layer-by-layer diff of a catastrophic sample (bs>=16) vs the
+        # same prompt at bs=1 to find the first divergence point.
         batch_size = hidden_states_BD.shape[0]
         device = hidden_states_BD.device
 

--- a/sglang_omni/models/higgs_tts/sglang_qwen3_backbone.py
+++ b/sglang_omni/models/higgs_tts/sglang_qwen3_backbone.py
@@ -41,9 +41,9 @@ class HiggsQwen3Model(Qwen3Model):
             residual = pp_proxy_tensors["residual"]
 
         # Prefill keeps ``self.layers`` because its shape varies per request,
-        # which would force dynamo recompiles. bs above ``_compiled_max_decode_bs``
-        # also falls back to eager to dodge an upstream sglang × inductor bug at
-        # ``bs == cuda_graph_max_bs`` (see ``issue_565_torch_compile_result.md``).
+        # which would force dynamo recompiles. The ``_compiled_max_decode_bs``
+        # hook is kept for future workarounds; with the eager pre-warmup the
+        # full decode bs range is safe (see ``issue_565_torch_compile_result.md``).
         compiled = getattr(self, "_compiled_decode_layers", None)
         max_bs = getattr(self, "_compiled_max_decode_bs", None)
         forward_mode = getattr(forward_batch, "forward_mode", None)

--- a/sglang_omni/models/higgs_tts/sglang_qwen3_backbone.py
+++ b/sglang_omni/models/higgs_tts/sglang_qwen3_backbone.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Higgs-owned Qwen3 backbone with decode-only ``torch.compile`` hook.
+
+Mirrors :class:`sglang.srt.models.qwen2.Qwen2Model.forward` so we can pick
+between eager ``self.layers`` (prefill) and ``self._compiled_decode_layers``
+(decode, populated by :func:`stages._compile_higgs_backbone`).
+
+When syncing with newer sglang, diff ``Qwen2Model.forward`` against the
+loop here and port any new logic.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import torch
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.models.qwen3 import Qwen3ForCausalLM, Qwen3Model
+from sglang.srt.utils import add_prefix
+
+
+class HiggsQwen3Model(Qwen3Model):
+    """``Qwen3Model`` with a decode-only compile-layer indirection."""
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor = None,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ) -> Union[torch.Tensor, PPProxyTensors]:
+        if self.pp_group.is_first_rank:
+            hidden_states = (
+                self.embed_tokens(input_ids) if input_embeds is None else input_embeds
+            )
+            residual = None
+        else:
+            assert pp_proxy_tensors is not None
+            hidden_states = pp_proxy_tensors["hidden_states"]
+            residual = pp_proxy_tensors["residual"]
+
+        # Prefill keeps ``self.layers`` because its shape varies per request,
+        # which would force dynamo recompiles. bs above ``_compiled_max_decode_bs``
+        # also falls back to eager to dodge an upstream sglang × inductor bug at
+        # ``bs == cuda_graph_max_bs`` (see ``issue_565_torch_compile_result.md``).
+        compiled = getattr(self, "_compiled_decode_layers", None)
+        max_bs = getattr(self, "_compiled_max_decode_bs", None)
+        forward_mode = getattr(forward_batch, "forward_mode", None)
+        is_decode = bool(
+            forward_mode is not None
+            and getattr(forward_mode, "is_decode", lambda: False)()
+        )
+        bs = hidden_states.shape[0]
+        use_compiled = (
+            is_decode and compiled is not None and (max_bs is None or bs <= max_bs)
+        )
+        layers = compiled if use_compiled else self.layers
+
+        aux_hidden_states: list[torch.Tensor] = []
+        for i in range(self.start_layer, self.end_layer):
+            if i in self.layers_to_capture:
+                aux_hidden_states.append(
+                    hidden_states + residual if residual is not None else hidden_states
+                )
+            hidden_states, residual = layers[i](
+                positions, hidden_states, forward_batch, residual
+            )
+        if not self.pp_group.is_last_rank:
+            return PPProxyTensors(
+                {"hidden_states": hidden_states, "residual": residual}
+            )
+
+        if hidden_states.shape[0] != 0:
+            if residual is None:
+                hidden_states = self.norm(hidden_states)
+            else:
+                hidden_states, _ = self.norm(hidden_states, residual)
+
+        if len(aux_hidden_states) == 0:
+            return hidden_states
+        return hidden_states, aux_hidden_states
+
+
+class HiggsQwen3ForCausalLM(Qwen3ForCausalLM):
+    """``Qwen3ForCausalLM`` with the inner model replaced by :class:`HiggsQwen3Model`."""
+
+    def __init__(self, config, quant_config=None, prefix: str = "") -> None:
+        super().__init__(config=config, quant_config=quant_config, prefix=prefix)
+        # Re-tie ``lm_head`` after the model swap when ``tie_word_embeddings``
+        # had pointed it at the old ``embed_tokens``.
+        was_tied = (
+            self.pp_group.is_last_rank
+            and getattr(self, "lm_head", None) is self.model.embed_tokens
+        )
+        old_model = self.model
+        self.model = HiggsQwen3Model(
+            config,
+            quant_config=quant_config,
+            prefix=add_prefix("model", prefix),
+        )
+        if was_tied:
+            self.lm_head = self.model.embed_tokens
+        del old_model
+
+
+__all__ = ["HiggsQwen3Model", "HiggsQwen3ForCausalLM"]

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -245,12 +245,32 @@ def _compile_higgs_backbone(model: Any) -> None:
     inner._compiled_decode_layers = [
         torch.compile(layer, mode=compile_mode) for layer in layers
     ]
-    # bs above this falls back to eager ``self.layers`` to dodge an upstream
-    # sglang × inductor CG-capture bug at ``bs == cuda_graph_max_bs`` — see
-    # ``issue_565_torch_compile_result.md``.
-    # TODO (yichi): lift this cap to 16 (i.e. drop ``_compiled_max_decode_bs``
-    # entirely) once the upstream sglang × inductor CG-capture bug is fixed.
-    inner._compiled_max_decode_bs = 12
+    # ``_warmup_eager_pre_cg`` (called below) makes the full decode bs range
+    # safe under torch.compile + CG, so we no longer cap below the largest
+    # captured bs. Kept as a hook in case a future workaround needs it.
+    inner._compiled_max_decode_bs = 16
+
+
+def _warmup_eager_pre_cg(model_runner: Any) -> None:
+    """Run a single eager forward at bs=1 BEFORE CG capture starts.
+
+    Temporarily hides ``_compiled_decode_layers`` so the dispatch in
+    ``HiggsQwen3Model.forward`` falls back to ``self.layers``. The eager
+    forward initializes lazy CUDA state (allocator pools, cuBLAS handles,
+    etc.) that would otherwise get initialized inside the FIRST CG
+    capture's dynamo trace — a code path that empirically corrupts the
+    captured kernels for that bs.
+    """
+    inner = model_runner.model.backbone.model
+    saved = getattr(inner, "_compiled_decode_layers", None)
+    if saved is None:
+        return
+    inner._compiled_decode_layers = None
+    try:
+        model_runner._dummy_run(batch_size=1)
+        torch.cuda.synchronize()
+    finally:
+        inner._compiled_decode_layers = saved
 
 
 def create_sglang_tts_engine_executor(
@@ -272,9 +292,10 @@ def create_sglang_tts_engine_executor(
         "chunked_prefill_size": 8192,
         "dtype": "bfloat16",
         # Issue #565: torch.compile on the AR backbone (manual layer-by-layer,
-        # see :func:`_compile_higgs_backbone`). bs > 12 falls back to eager.
+        # see :func:`_compile_higgs_backbone`). The full bs range is safe
+        # thanks to the eager pre-warmup in ``_warmup_eager_pre_cg``.
         "enable_torch_compile": True,
-        "torch_compile_max_bs": 12,
+        "torch_compile_max_bs": 16,
         "sampling_backend": "pytorch",
         # Radix cache is namespaced per ref-audio via Req.extra_key (set in
         # build_sglang_higgs_request); shared -100 placeholder prefixes from
@@ -317,6 +338,12 @@ def create_sglang_tts_engine_executor(
         # and letting ``patch_model`` re-wrap the whole forward at capture
         # time triggers a device-side assert at bs ≥ 8.
         server_args.enable_torch_compile = False
+        # Warm up the model in eager mode BEFORE CG capture so the first
+        # compile dynamo trace during capture sees a fully-initialized CUDA
+        # state. Without this, lazy CUDA init (cuBLAS handle, allocator pool,
+        # etc.) lands inside the captured graph and corrupts replay at the
+        # first compiled+captured bs.
+        _warmup_eager_pre_cg(model_worker.model_runner)
 
     if want_cuda_graph:
         model_worker.model_runner.init_device_graphs()

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -228,6 +228,31 @@ def create_audio_encoder_executor(
     )
 
 
+def _compile_higgs_backbone(model: Any) -> None:
+    """Compile the Qwen3 decoder layers into ``_compiled_decode_layers``."""
+    backbone = getattr(model, "backbone", None)
+    inner = getattr(backbone, "model", None) if backbone is not None else None
+    layers = getattr(inner, "layers", None) if inner is not None else None
+    if layers is None:
+        return
+
+    from sglang.srt.model_executor.cuda_graph_runner import set_torch_compile_config
+
+    set_torch_compile_config()
+    compile_mode = os.environ.get(
+        "SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs"
+    )
+    inner._compiled_decode_layers = [
+        torch.compile(layer, mode=compile_mode) for layer in layers
+    ]
+    # bs above this falls back to eager ``self.layers`` to dodge an upstream
+    # sglang × inductor CG-capture bug at ``bs == cuda_graph_max_bs`` — see
+    # ``issue_565_torch_compile_result.md``.
+    # TODO (yichi): lift this cap to 16 (i.e. drop ``_compiled_max_decode_bs``
+    # entirely) once the upstream sglang × inductor CG-capture bug is fixed.
+    inner._compiled_max_decode_bs = 12
+
+
 def create_sglang_tts_engine_executor(
     model_path: str,
     *,
@@ -246,6 +271,11 @@ def create_sglang_tts_engine_executor(
         "max_running_requests": 16,
         "chunked_prefill_size": 8192,
         "dtype": "bfloat16",
+        # Issue #565: torch.compile on the AR backbone (manual layer-by-layer,
+        # see :func:`_compile_higgs_backbone`). bs > 12 falls back to eager.
+        "enable_torch_compile": True,
+        "torch_compile_max_bs": 12,
+        "sampling_backend": "pytorch",
         # Radix cache is namespaced per ref-audio via Req.extra_key (set in
         # build_sglang_higgs_request); shared -100 placeholder prefixes from
         # different ref audios can't cross-contaminate the KV tree.
@@ -260,6 +290,12 @@ def create_sglang_tts_engine_executor(
     )
     server_args.disable_overlap_schedule = True
 
+    # Defer CG capture until AFTER manual layer-by-layer torch.compile so the
+    # captured graphs record the compiled kernels rather than eager ones.
+    want_cuda_graph = not bool(getattr(server_args, "disable_cuda_graph", False))
+    if want_cuda_graph:
+        server_args.disable_cuda_graph = True
+
     (
         model_worker,
         tree_cache,
@@ -270,7 +306,20 @@ def create_sglang_tts_engine_executor(
         model_config,
     ) = create_sglang_infrastructure(server_args, gpu_id)
 
+    if want_cuda_graph:
+        server_args.disable_cuda_graph = False
+
     truncate_rope_to_bf16(model_worker.model_runner.model)
+
+    if bool(getattr(server_args, "enable_torch_compile", False)):
+        _compile_higgs_backbone(model_worker.model_runner.model)
+        # Disable sglang's auto-compile path: we already wrapped the layers,
+        # and letting ``patch_model`` re-wrap the whole forward at capture
+        # time triggers a device-side assert at bs ≥ 8.
+        server_args.enable_torch_compile = False
+
+    if want_cuda_graph:
+        model_worker.model_runner.init_device_graphs()
 
     output_proc = SGLangOutputProcessor(
         capture_hidden=False,


### PR DESCRIPTION
## Summary

Compile sglang's Qwen3 decoder layers via a thin fork (`HiggsQwen3Model`). Each layer is wrapped with `torch.compile(layer, mode="max-autotune-no-cudagraphs")` and stored on `model._compiled_decode_layers`. The fork's `forward` dispatches eager (prefill) vs compiled (decode).

CG capture is deferred until after compile so captured graphs record the compiled kernels.

**`_warmup_eager_pre_cg()`** — one eager forward at `bs=1` after `_compile_higgs_backbone` and before `init_device_graphs()` — forces lazy CUDA init (cuBLAS handle, allocator pool, …) to happen **outside** the CG capture window. Without it, the first dynamo trace inside sglang's capture loop pulls that lazy init *into* the captured graph and replay returns corrupted logits → audio runs to `max_new_tokens` → catastrophic outliers.

With the pre-warmup, the previous `bs ≤ 12` cap is no longer needed: `_compiled_max_decode_bs = 16` and `torch_compile_max_bs = 16`.

## Results vs no-compile baseline (SeedTTS-EN N=1088, single H200)

### c=16, max_running=16, cap=16

| Metric | Baseline | This PR | Δ |
|---|---:|---:|---:|
| Latency p99 | 3.14 s | 2.98 s | −5 % |
| QPS | 8.41 | 8.49 | +1 % |
| **WER excl > 50 %** | 1.29 % | 1.31 % | +0.02 pp (noise) |
| **Outliers (> 50 %)** | **50** | **2** | **−96 %** |

### c=32, max_running=32, cap=32

| Metric | Baseline | This PR | Δ |
|---|---:|---:|---:|
| Latency p99 | 5.38 s | 5.56 s | +3 % |
| QPS | 9.68 | 9.42 | −3 % |
| **WER excl > 50 %** | 1.28 % | **1.24 %** | **−3 %** rel |
| **Outliers (> 50 %)** | **50** | **4** | **−92 %** |
| WER per-sample max | 7 600 % | 2 793 % | −63 % |

Side-effect: the eager pre-warmup also cuts most of Higgs's inherent c ≥ 16 outliers (50 → ~3), so aggregate WER actually matches or beats baseline.

### Honest caveat

`torch.compile` itself doesn't deliver throughput on this workload (4 B decode-bound, bs ≤ 32). QPS lands within ±3 % of baseline. The PR's value is now:
1. compile is **safe** to enable across the full bs range, and
2. as a side effect, ~95 % of Higgs's inherent c ≥ 16 outliers go away.

## The bug, briefly

When `torch.compile` covers the first bs in sglang's capture loop, the resulting CG returns corrupted logits on replay (~6 % L2-norm drop in `hidden_states`, no NaN). Truth-tabled across 10 combinations — fires iff `compile=on AND CG=on AND that bs is the first one compiled inside the capture loop`. Six fixes attempted before V14 landed: `sync+empty_cache`, two-phase warmup, `dynamic=True`, skipping `set_torch_compile_config`, `mode=default`, ascending capture order — none rooted the bug cleanly. V13 (ascending order) was close but just moved the corruption from bs=largest to bs=1 (catastrophic at c=1).

Full investigation (truth table, hidden-states numerical signature, ruled-out hypotheses, all 7 fix attempts incl. V14) is in `issue_565_torch_compile_result.md` on this branch.

## Requested changes from sglang

V14 is a workaround in our wrapper, not a real fix. Things we'd want upstream sglang to do:

1. **Pin the actual root cause.** Why does the FIRST compile dynamo trace inside `CUDAGraphRunner.capture()` pull lazy CUDA state into the captured graph? Likely candidate: cuBLAS handle init / inductor scratch allocator first-touch happens during `run_once` warmup at iter 1, with `is_capture_mode` already true on the parent stream. A deeper inductor + CUDA-graph owner could nail this with the diagnostic data in `issue_565_torch_compile_result.md`.
2. **Force an eager warmup inside sglang's CG capture path** when `enable_torch_compile=True` (or per-layer compile is detected on the model). One internal `_dummy_run`-style call before the for-loop in `CUDAGraphRunner.capture()` would make the entire ecosystem immune to this class of bug — no model-specific patches needed downstream.
3. **Document the requirement.** Until (2) lands, the docstring on `init_device_graphs()` / `CUDAGraphRunner.capture()` should call out that the caller is responsible for pre-warming CUDA state if `torch.compile` is in play; otherwise the first captured bs is silently corrupted.

## Test plan

- [x] N=1088 SeedTTS-EN @ c=16 + c=32 — perf tables above
- [x] N=50 c=1 smoke test — matches baseline (lat 0.79 s, tokens 144, audio 5.48 s)
- [ ] `speaker_sim` evaluation
- [ ] Upstream sglang issue with the V14 evidence
