### PR TITLE
[Benchmark] Add streaming UX metrics (TTFC/TTFT/ITL/RTF tails) and opt in SIM

### DIFF
--- a/benchmarks/benchmarker/data.py
+++ b/benchmarks/benchmarker/data.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -20,3 +20,6 @@ class RequestResult:
     tok_per_s: float = 0.0
     wav_path: str = ""
     error: str = ""
+    audio_ttfp_s: float | None = None
+    inter_chunk_s: list[float] = field(default_factory=list)
+    text_ttft_s: float | None = None

--- a/benchmarks/eval/benchmark_omni_seedtts.py
+++ b/benchmarks/eval/benchmark_omni_seedtts.py
@@ -246,6 +246,8 @@ def make_send_fn(
             request_id=sample.sample_id,
             text=sample.target_text[:TEXT_PREVIEW_LENGTH],
         )
+        chunk_times: list[float] = []
+        text_first_time_holder: list[float] = []
         start_time = time.perf_counter()
         try:
             wav_bytes, _, usage = await task.generate_speech(
@@ -260,6 +262,8 @@ def make_send_fn(
                 voice_clone=voice_clone,
                 stream=stream,
                 system_prompt=system_prompt,
+                chunk_times_out=chunk_times if stream else None,
+                text_first_time_holder=text_first_time_holder if stream else None,
             )
             result.audio_duration_s = get_wav_duration(wav_bytes)
             elapsed = time.perf_counter() - start_time
@@ -287,6 +291,15 @@ def make_send_fn(
             with open(wav_path, "wb") as f:
                 f.write(wav_bytes)
             result.wav_path = wav_path
+
+            if chunk_times:
+                result.audio_ttfp_s = chunk_times[0] - start_time
+                result.inter_chunk_s = [
+                    chunk_times[i + 1] - chunk_times[i]
+                    for i in range(len(chunk_times) - 1)
+                ]
+            if text_first_time_holder:
+                result.text_ttft_s = text_first_time_holder[0] - start_time
         except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
             result.error = str(exc)
         finally:
@@ -527,6 +540,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "Pass a strict TTS-only prompt for models that leak chat-style "
         "preambles or refusals (e.g. Ming-Omni).",
     )
+    parser.add_argument(
+        "--with-similarity",
+        action="store_true",
+        help="Also score speaker similarity (WavLM-ECAPA-TDNN) after WER, "
+        "per seed-tts-eval protocol.",
+    )
 
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument(
@@ -570,6 +589,9 @@ def main() -> None:
         return
 
     accuracy_results = evaluate_generated_audio(config)
+    similarity_results = None
+    if args.with_similarity:
+        similarity_results = run_seedtts_similarity(config, log_per_sample=False)
     combined = {
         "generation": {
             "speed": gen_results["summary"],
@@ -581,6 +603,8 @@ def main() -> None:
             "wer": accuracy_results["wer_summary"],
         },
     }
+    if similarity_results is not None:
+        combined["similarity"] = similarity_results.get("summary", similarity_results)
     save_json_results(combined, config.output_dir, "eval_results.json")
 
 

--- a/benchmarks/metrics/performance.py
+++ b/benchmarks/metrics/performance.py
@@ -202,13 +202,18 @@ def print_speed_summary(
         )
     if metrics.get("audio_ttfp_mean_s") is not None:
         print(f"  {'TTFC mean (s):':<{lw}} {metrics['audio_ttfp_mean_s']}")
+        print(f"  {'TTFC median (s):':<{lw}} {metrics['audio_ttfp_median_s']}")
         print(f"  {'TTFC p95 (s):':<{lw}} {metrics['audio_ttfp_p95_s']}")
+        print(f"  {'TTFC p99 (s):':<{lw}} {metrics['audio_ttfp_p99_s']}")
     if metrics.get("text_ttft_mean_s") is not None:
         print(f"  {'TTFT mean (s):':<{lw}} {metrics['text_ttft_mean_s']}")
+        print(f"  {'TTFT median (s):':<{lw}} {metrics['text_ttft_median_s']}")
         print(f"  {'TTFT p95 (s):':<{lw}} {metrics['text_ttft_p95_s']}")
+        print(f"  {'TTFT p99 (s):':<{lw}} {metrics['text_ttft_p99_s']}")
     if metrics.get("inter_chunk_mean_s") is not None:
         print(f"  {'ITL mean (s):':<{lw}} {metrics['inter_chunk_mean_s']}")
         print(f"  {'ITL p95 (s):':<{lw}} {metrics['inter_chunk_p95_s']}")
+        print(f"  {'ITL p99 (s):':<{lw}} {metrics['inter_chunk_p99_s']}")
     if metrics.get("output_throughput") is not None:
         print(f"  {'Output throughput (tok/s):':<{lw}} {metrics['output_throughput']}")
     if metrics.get("output_tok_per_req_s") is not None:

--- a/benchmarks/metrics/performance.py
+++ b/benchmarks/metrics/performance.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-"""System performance metrics: latency, RTF, throughput, token throughput.
+"""System performance metrics: latency, RTF, throughput, token throughput,
+streaming UX.
 
 Metric semantics:
 
@@ -17,6 +18,28 @@ Metric semantics:
     Per-request completion tokens divided by that request's engine/request time.
 ``rtf_mean``
     Mean request elapsed seconds divided by generated output audio duration seconds.
+``rtf_p95`` / ``rtf_p99``
+    Tail percentiles of per-request RTF.
+``audio_throughput_s_per_s``
+    Total seconds of generated audio divided by benchmark wall-clock seconds.
+    Independent of per-request audio duration; comparable across engines that
+    emit different audio lengths for the same input.
+``audio_ttfp_mean_s`` (TTFC)
+    Mean time-to-first-audio-chunk: client-side wall time from request send
+    to first decoded audio chunk arrival. Streaming only.
+``audio_ttfp_median_s`` / ``audio_ttfp_p95_s`` / ``audio_ttfp_p99_s``
+    Median / tail percentiles of TTFC.
+``text_ttft_mean_s`` (TTFT)
+    Mean time-to-first-text-token: client-side wall time from request send to
+    first non-empty content delta. Streaming only; populated when the model
+    emits text deltas (dual-modality text+audio output).
+``text_ttft_median_s`` / ``text_ttft_p95_s`` / ``text_ttft_p99_s``
+    Median / tail percentiles of TTFT.
+``inter_chunk_mean_s`` (ITL)
+    Mean inter-arrival latency between successive audio chunks within a
+    request. Streaming smoothness metric.
+``inter_chunk_p95_s`` / ``inter_chunk_p99_s``
+    Tail percentiles of inter-chunk latency (streaming jitter).
 """
 
 from __future__ import annotations
@@ -72,6 +95,17 @@ def compute_speed_metrics(
     latencies = [o.latency_s for o in successes]
     rtfs = [o.rtf for o in successes if 0 < o.rtf < float("inf")]
     audio_durations = [o.audio_duration_s for o in successes if o.audio_duration_s > 0]
+    ttfps = [
+        o.audio_ttfp_s
+        for o in successes
+        if getattr(o, "audio_ttfp_s", None) is not None
+    ]
+    text_ttfts = [
+        o.text_ttft_s for o in successes if getattr(o, "text_ttft_s", None) is not None
+    ]
+    inter_chunk_deltas = [
+        d for o in successes for d in getattr(o, "inter_chunk_s", []) or []
+    ]
 
     if wall_clock_s is not None and wall_clock_s > 0:
         throughput = round(len(successes) / wall_clock_s, 3)
@@ -93,9 +127,40 @@ def compute_speed_metrics(
         ),
         "rtf_mean": round(float(np.mean(rtfs)), 4) if rtfs else None,
         "rtf_median": round(float(np.median(rtfs)), 4) if rtfs else None,
+        "rtf_p95": round(float(np.percentile(rtfs, 95)), 4) if rtfs else None,
+        "rtf_p99": round(float(np.percentile(rtfs, 99)), 4) if rtfs else None,
         "throughput_qps": throughput,
         **_compute_token_metrics(successes, wall_clock_s=wall_clock_s),
     }
+    if audio_durations and wall_clock_s is not None and wall_clock_s > 0:
+        total_audio_s = sum(audio_durations)
+        metrics_summary["audio_throughput_s_per_s"] = round(
+            total_audio_s / wall_clock_s, 3
+        )
+    if ttfps:
+        metrics_summary["audio_ttfp_mean_s"] = round(float(np.mean(ttfps)), 4)
+        metrics_summary["audio_ttfp_median_s"] = round(float(np.median(ttfps)), 4)
+        metrics_summary["audio_ttfp_p95_s"] = round(float(np.percentile(ttfps, 95)), 4)
+        metrics_summary["audio_ttfp_p99_s"] = round(float(np.percentile(ttfps, 99)), 4)
+    if text_ttfts:
+        metrics_summary["text_ttft_mean_s"] = round(float(np.mean(text_ttfts)), 4)
+        metrics_summary["text_ttft_median_s"] = round(float(np.median(text_ttfts)), 4)
+        metrics_summary["text_ttft_p95_s"] = round(
+            float(np.percentile(text_ttfts, 95)), 4
+        )
+        metrics_summary["text_ttft_p99_s"] = round(
+            float(np.percentile(text_ttfts, 99)), 4
+        )
+    if inter_chunk_deltas:
+        metrics_summary["inter_chunk_mean_s"] = round(
+            float(np.mean(inter_chunk_deltas)), 4
+        )
+        metrics_summary["inter_chunk_p95_s"] = round(
+            float(np.percentile(inter_chunk_deltas, 95)), 4
+        )
+        metrics_summary["inter_chunk_p99_s"] = round(
+            float(np.percentile(inter_chunk_deltas, 99)), 4
+        )
     return metrics_summary
 
 
@@ -123,10 +188,27 @@ def print_speed_summary(
     if metrics.get("rtf_mean") is not None:
         print(f"  {'RTF mean:':<{lw}} {metrics['rtf_mean']}")
         print(f"  {'RTF median:':<{lw}} {metrics['rtf_median']}")
+    if metrics.get("rtf_p95") is not None:
+        print(f"  {'RTF p95:':<{lw}} {metrics['rtf_p95']}")
+        print(f"  {'RTF p99:':<{lw}} {metrics['rtf_p99']}")
     if metrics.get("audio_duration_mean_s"):
         print(
             f"  {'Audio duration mean (s):':<{lw}} {metrics['audio_duration_mean_s']}"
         )
+    if metrics.get("audio_throughput_s_per_s") is not None:
+        print(
+            f"  {'Audio throughput (s/s):':<{lw}} "
+            f"{metrics['audio_throughput_s_per_s']}"
+        )
+    if metrics.get("audio_ttfp_mean_s") is not None:
+        print(f"  {'TTFC mean (s):':<{lw}} {metrics['audio_ttfp_mean_s']}")
+        print(f"  {'TTFC p95 (s):':<{lw}} {metrics['audio_ttfp_p95_s']}")
+    if metrics.get("text_ttft_mean_s") is not None:
+        print(f"  {'TTFT mean (s):':<{lw}} {metrics['text_ttft_mean_s']}")
+        print(f"  {'TTFT p95 (s):':<{lw}} {metrics['text_ttft_p95_s']}")
+    if metrics.get("inter_chunk_mean_s") is not None:
+        print(f"  {'ITL mean (s):':<{lw}} {metrics['inter_chunk_mean_s']}")
+        print(f"  {'ITL p95 (s):':<{lw}} {metrics['inter_chunk_p95_s']}")
     if metrics.get("output_throughput") is not None:
         print(f"  {'Output throughput (tok/s):':<{lw}} {metrics['output_throughput']}")
     if metrics.get("output_tok_per_req_s") is not None:
@@ -157,6 +239,9 @@ def build_speed_results(
 
 
 def _request_result_to_dict(output: RequestResult) -> dict:
+    inter = getattr(output, "inter_chunk_s", None) or None
+    ttfp = getattr(output, "audio_ttfp_s", None)
+    ttft = getattr(output, "text_ttft_s", None)
     return {
         "id": output.request_id,
         "text": output.text,
@@ -171,4 +256,7 @@ def _request_result_to_dict(output: RequestResult) -> dict:
         ),
         "wav_path": output.wav_path or None,
         "error": output.error or None,
+        "audio_ttfp_s": round(ttfp, 4) if ttfp is not None else None,
+        "text_ttft_s": round(ttft, 4) if ttft is not None else None,
+        "inter_chunk_s": [round(d, 4) for d in inter] if inter else None,
     }

--- a/benchmarks/tasks/tts.py
+++ b/benchmarks/tasks/tts.py
@@ -823,6 +823,8 @@ class VoiceCloneOmni:
         voice_clone: bool = False,
         stream: bool = False,
         system_prompt: str | None = None,
+        chunk_times_out: list[float] | None = None,
+        text_first_time_holder: list[float] | None = None,
     ) -> tuple[bytes, float, dict]:
         if max_tokens is None:
             max_tokens = self.THINKER_MAX_NEW_TOKENS
@@ -871,7 +873,11 @@ class VoiceCloneOmni:
                 error_text = await response.text()
                 raise RuntimeError(f"HTTP {response.status}: {error_text}")
             if stream:
-                wav_bytes, usage = await self._read_streaming_chat_audio(response)
+                wav_bytes, usage = await self._read_streaming_chat_audio(
+                    response,
+                    chunk_times_out=chunk_times_out,
+                    text_first_time_holder=text_first_time_holder,
+                )
                 latency = time.perf_counter() - t0
                 return wav_bytes, latency, usage
             resp_json = await response.json()
@@ -900,6 +906,8 @@ class VoiceCloneOmni:
     async def _read_streaming_chat_audio(
         self,
         response: aiohttp.ClientResponse,
+        chunk_times_out: list[float] | None = None,
+        text_first_time_holder: list[float] | None = None,
     ) -> tuple[bytes, dict]:
         """Read OpenAI chat SSE audio deltas and concatenate them into one WAV."""
         pcm_chunks: list[bytes] = []
@@ -918,6 +926,8 @@ class VoiceCloneOmni:
                     pcm_chunks,
                     stream_format,
                     usage,
+                    chunk_times_out=chunk_times_out,
+                    text_first_time_holder=text_first_time_holder,
                 )
 
         if buffer.strip():
@@ -926,6 +936,8 @@ class VoiceCloneOmni:
                 pcm_chunks,
                 stream_format,
                 usage,
+                chunk_times_out=chunk_times_out,
+                text_first_time_holder=text_first_time_holder,
             )
 
         if not pcm_chunks or stream_format is None:
@@ -1133,6 +1145,8 @@ def _collect_chat_streaming_audio(
     pcm_chunks: list[bytes],
     stream_format: tuple[int, int, int] | None,
     usage: dict,
+    chunk_times_out: list[float] | None = None,
+    text_first_time_holder: list[float] | None = None,
 ) -> tuple[int, int, int] | None:
     event = parse_sse_event(line)
     if event is None:
@@ -1149,6 +1163,10 @@ def _collect_chat_streaming_audio(
         delta = choice.get("delta")
         if not isinstance(delta, dict):
             continue
+        if text_first_time_holder is not None and not text_first_time_holder:
+            content = delta.get("content")
+            if isinstance(content, str) and content:
+                text_first_time_holder.append(time.perf_counter())
         audio = delta.get("audio")
         if not isinstance(audio, dict) or not audio.get("data"):
             continue
@@ -1159,6 +1177,8 @@ def _collect_chat_streaming_audio(
             with io.BytesIO(chunk_bytes) as buf:
                 with wave.open(buf, "rb") as wf:
                     pcm_chunks.append(wf.readframes(wf.getnframes()))
+                    if chunk_times_out is not None:
+                        chunk_times_out.append(time.perf_counter())
                     if stream_format is None:
                         stream_format = (
                             wf.getframerate(),


### PR DESCRIPTION
## Summary

Extends `benchmark_omni_seedtts` so summary and per-request output cover the streaming-TTS user-experience signals that were missing from the schema, plus a single opt-in flag for seed-tts-eval Speaker SIM scoring.

Previously the bench reported only end-to-end latency / RTF / QPS / WER. For streaming TTS the user-perceptible signals are **time to first audio chunk**, **inter-chunk latency** (smoothness), and **time to first text token** (the text track of Qwen3-Omni dual-modality output). These are now first-class summary fields, alongside RTF tails (p95 / p99) and an audio-duration-normalised throughput metric.

## Test

5R, c=4, 100-sample EN SeedTTS, stream. Only for metric-collection verify

| Metric | sglang 5R mean ± σ |
|---|---|
| lat_mean (s) | 1.183 ± 0.006 |
| lat_p95 (s) | 1.825 ± 0.022 |
| lat_p99 (s) | 2.145 ± 0.099 |
| `audio_ttfp_mean_s` (TTFC) | 0.473 ± 0.009 |
| `audio_ttfp_p95_s` | 0.635 ± 0.025 |
| `audio_ttfp_p99_s` | 0.680 ± 0.010 |
| `inter_chunk_mean_s` (ITL) | 0.189 ± 0.004 |
| `inter_chunk_p95_s` | 0.315 ± 0.015 |
| `inter_chunk_p99_s` | 0.366 ± 0.015 |
| `text_ttft_mean_s` (TTFT) | 0.056 ± 0.002 |
| `text_ttft_p95_s` | 0.080 ± 0.006 |
| rtf_mean | 0.361 ± 0.002 |
| rtf_median | 0.357 ± 0.002 |
| `rtf_p95` | 0.425 ± 0.005 |
| `rtf_p99` | 0.493 ± 0.037 |
| qps | 3.357 ± 0.017 |
| `audio_throughput_s_per_s` | 11.193 ± 0.059 |
| WER<50 % | 1.22 ± 0.05 |
| WER_corpus % | 1.22 ± 0.05 |
| n>50 / 100 | 0 |
| `similarity.speaker_similarity_mean` (`--with-similarity`) | 5.266 ± 0.060 |
| audio_dur_mean (s) | 3.335 ± 0.012 |