### PR TITLE
[Qwen3] add video runtime budget config

### DIFF
--- a/sglang_omni/config/runtime.py
+++ b/sglang_omni/config/runtime.py
@@ -9,7 +9,14 @@ from typing import Any
 from sglang_omni.config.schema import PipelineConfig, StageConfig
 from sglang_omni.utils.imports import import_string
 
-_MAPPED_STAGE_RUNTIME_FIELDS = ("max_seq_len", "video_fps")
+_MAPPED_STAGE_RUNTIME_FIELDS = (
+    "max_seq_len",
+    "video_fps",
+    "video_max_frames",
+    "video_min_pixels",
+    "video_max_pixels",
+    "video_total_pixels",
+)
 
 
 def resolve_stage_factory_args(

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -90,6 +90,10 @@ class StageRuntimeConfig(BaseModel):
     resources: StageResourceConfig = Field(default_factory=StageResourceConfig)
     max_seq_len: int | None = None
     video_fps: float | None = None
+    video_max_frames: int | None = None
+    video_min_pixels: int | None = None
+    video_max_pixels: int | None = None
+    video_total_pixels: int | None = None
     sglang_server_args: SGLangServerArgsConfig = Field(
         default_factory=SGLangServerArgsConfig
     )
@@ -99,6 +103,15 @@ class StageRuntimeConfig(BaseModel):
             raise ValueError("runtime.max_seq_len must be positive")
         if self.video_fps is not None and self.video_fps <= 0:
             raise ValueError("runtime.video_fps must be positive")
+        for field_name in (
+            "video_max_frames",
+            "video_min_pixels",
+            "video_max_pixels",
+            "video_total_pixels",
+        ):
+            value = getattr(self, field_name)
+            if value is not None and value <= 0:
+                raise ValueError(f"runtime.{field_name} must be positive")
 
 
 class PlacementConfig(BaseModel):

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -29,6 +29,10 @@ def _preprocessing_stage(*, process: str) -> StageConfig:
         runtime_arg_map={
             "max_seq_len": "thinker_max_seq_len",
             "video_fps": "video_fps",
+            "video_max_frames": "video_max_frames",
+            "video_min_pixels": "video_min_pixels",
+            "video_max_pixels": "video_max_pixels",
+            "video_total_pixels": "video_total_pixels",
         },
         next=["image_encoder", "audio_encoder", "mm_aggregate"],
         route_fn=f"{_PKG}.request_builders.resolve_preprocessing_next_stages",

--- a/tests/unit_test/pipeline/test_runtime_schema.py
+++ b/tests/unit_test/pipeline/test_runtime_schema.py
@@ -58,6 +58,14 @@ def test_invalid_stage_runtime_values_raise() -> None:
         StageRuntimeConfig(max_seq_len=0)
     with pytest.raises(ValueError, match="video_fps"):
         StageRuntimeConfig(video_fps=-1.0)
+    with pytest.raises(ValueError, match="video_max_frames"):
+        StageRuntimeConfig(video_max_frames=0)
+    with pytest.raises(ValueError, match="video_min_pixels"):
+        StageRuntimeConfig(video_min_pixels=0)
+    with pytest.raises(ValueError, match="video_max_pixels"):
+        StageRuntimeConfig(video_max_pixels=0)
+    with pytest.raises(ValueError, match="video_total_pixels"):
+        StageRuntimeConfig(video_total_pixels=0)
 
 
 def test_stage_rejects_terminal_with_next() -> None:

--- a/tests/unit_test/qwen3_omni/test_config_manager.py
+++ b/tests/unit_test/qwen3_omni/test_config_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from qwen_vl_utils import vision_process as qwen_vision
 
 from sglang_omni.cli.serve import apply_encoder_mem_reserve_cli_override
 from sglang_omni.config import (
@@ -18,6 +19,12 @@ from sglang_omni.models.qwen3_omni.config import (
 )
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_QWEN_VIDEO_FPS = qwen_vision.FPS
+_QWEN_VIDEO_MAX_FRAMES = qwen_vision.FPS_MAX_FRAMES
+_QWEN_VIDEO_MIN_PIXELS = qwen_vision.VIDEO_MIN_PIXELS
+_QWEN_VIDEO_MAX_PIXELS = qwen_vision.VIDEO_MAX_PIXELS
+_QWEN_VIDEO_TOTAL_PIXELS = qwen_vision.VIDEO_TOTAL_PIXELS
 
 
 def _stage(config, name: str):
@@ -169,14 +176,53 @@ def test_qwen3_omni_mmsu_example_config_uses_text_pipeline() -> None:
     assert thinker_args["server_args_overrides"]["max_running_requests"] == 4
 
 
-def test_qwen_preprocessing_runtime_video_fps_resolves_to_factory_arg() -> None:
+def test_qwen_preprocessing_runtime_video_budget_resolves_to_factory_arg() -> None:
     config = Qwen3OmniSpeechColocatedPipelineConfig(model_path="dummy")
     preprocessing = _stage(config, "preprocessing")
-    preprocessing.runtime.video_fps = 2.0
+    preprocessing.runtime.video_fps = _QWEN_VIDEO_FPS
+    preprocessing.runtime.video_max_frames = _QWEN_VIDEO_MAX_FRAMES
+    preprocessing.runtime.video_min_pixels = _QWEN_VIDEO_MIN_PIXELS
+    preprocessing.runtime.video_max_pixels = _QWEN_VIDEO_MAX_PIXELS
+    preprocessing.runtime.video_total_pixels = _QWEN_VIDEO_TOTAL_PIXELS
 
     args = resolve_stage_factory_args(preprocessing, config)
 
-    assert args["video_fps"] == 2.0
+    assert args["video_fps"] == _QWEN_VIDEO_FPS
+    assert args["video_max_frames"] == _QWEN_VIDEO_MAX_FRAMES
+    assert args["video_min_pixels"] == _QWEN_VIDEO_MIN_PIXELS
+    assert args["video_max_pixels"] == _QWEN_VIDEO_MAX_PIXELS
+    assert args["video_total_pixels"] == _QWEN_VIDEO_TOTAL_PIXELS
+
+
+def test_qwen_preprocessing_stage_override_video_budget_resolves_to_factory_arg(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "qwen_video_budget.yaml"
+    config_path.write_text(
+        f"""
+config_cls: Qwen3OmniSpeechColocatedPipelineConfig
+model_path: dummy
+stage_overrides:
+  preprocessing:
+    runtime:
+      video_fps: {_QWEN_VIDEO_FPS}
+      video_max_frames: {_QWEN_VIDEO_MAX_FRAMES}
+      video_min_pixels: {_QWEN_VIDEO_MIN_PIXELS}
+      video_max_pixels: {_QWEN_VIDEO_MAX_PIXELS}
+      video_total_pixels: {_QWEN_VIDEO_TOTAL_PIXELS}
+"""
+    )
+
+    config = ConfigManager.from_file(str(config_path)).config
+    preprocessing = _stage(config, "preprocessing")
+
+    args = resolve_stage_factory_args(preprocessing, config)
+
+    assert args["video_fps"] == _QWEN_VIDEO_FPS
+    assert args["video_max_frames"] == _QWEN_VIDEO_MAX_FRAMES
+    assert args["video_min_pixels"] == _QWEN_VIDEO_MIN_PIXELS
+    assert args["video_max_pixels"] == _QWEN_VIDEO_MAX_PIXELS
+    assert args["video_total_pixels"] == _QWEN_VIDEO_TOTAL_PIXELS
 
 
 def test_h20_colocated_example_reserve_keeps_raw_budget_in_resolved_config() -> None:


### PR DESCRIPTION
As titled.

Add typed runtime config for Qwen3 video preprocessing budget:
`video_max_frames`, `video_min_pixels`, `video_max_pixels`, `video_total_pixels`.

Tested:
`python -m pytest tests/unit_test/pipeline/test_runtime_schema.py tests/unit_test/pipeline/test_runtime_adapter.py tests/unit_test/qwen3_omni/test_config_manager.py -q`