### PR TITLE
[Bugfix] Fix ming omni talker voice preset loading and add generation duration guard

### DIFF
--- a/sglang_omni/models/ming_omni/components/streaming_talker.py
+++ b/sglang_omni/models/ming_omni/components/streaming_talker.py
@@ -371,6 +371,35 @@ class MingStreamingTalkerScheduler:
             sr = getattr(owner, "sample_rate", None)
         return int(sr) if sr is not None else None
 
+    def _validate_voice_presets(
+        self, voice_dict: dict, manifest_path: str, talker_dir: str
+    ) -> None:
+        """Resolve relative prompt-wav paths and validate the manifest.
+
+        Mutates ``voice_dict`` in place so each entry's ``prompt_wav_path``
+        becomes an absolute path on disk.
+        """
+        if self._voice is not None and self._voice not in voice_dict:
+            raise ValueError(
+                f"[TALKER_STREAM] default voice {self._voice!r} not found in "
+                f"{manifest_path}; available presets: "
+                f"{sorted(voice_dict.keys())}"
+            )
+        for name, entry in voice_dict.items():
+            rel_path = entry.get("prompt_wav_path")
+            if rel_path is None:
+                raise ValueError(
+                    f"[TALKER_STREAM] voice preset {name!r} in "
+                    f"{manifest_path} is missing prompt_wav_path"
+                )
+            resolved = os.path.join(talker_dir, rel_path)
+            if not os.path.isfile(resolved):
+                raise FileNotFoundError(
+                    f"[TALKER_STREAM] voice preset {name!r} references "
+                    f"missing prompt wav {resolved}"
+                )
+            entry["prompt_wav_path"] = resolved
+
     # ------------------------------------------------------------------ model load
     def _load_models(self) -> None:
         if self._model_path is None:
@@ -410,13 +439,17 @@ class MingStreamingTalkerScheduler:
         if os.path.exists(voice_json):
             with open(voice_json) as f:
                 voice_dict = json.load(f)
-            for value in voice_dict.values():
-                value["prompt_wav_path"] = os.path.join(
-                    talker_dir, value["prompt_wav_path"]
-                )
+            self._validate_voice_presets(voice_dict, voice_json, talker_dir)
             talker.set_voice_presets(voice_dict)
+        elif self._voice is not None:
+            raise FileNotFoundError(
+                f"[TALKER_STREAM] voice_name.json not found at {voice_json}; "
+                f"default voice {self._voice!r} cannot be resolved"
+            )
         else:
-            logger.warning("[TALKER_STREAM] voice_name.json missing at %s", voice_json)
+            logger.info(
+                "[TALKER_STREAM] no voice_name.json at %s; presets disabled", voice_json
+            )
 
         campplus = os.path.join(talker_dir, "campplus.onnx")
         try:

--- a/sglang_omni/models/ming_omni/components/talker_executor.py
+++ b/sglang_omni/models/ming_omni/components/talker_executor.py
@@ -110,14 +110,19 @@ class MingTalkerExecutor:
         if os.path.exists(voice_json_path):
             with open(voice_json_path, "r") as f:
                 voice_dict = json.load(f)
-            for key in voice_dict:
-                voice_dict[key]["prompt_wav_path"] = os.path.join(
-                    self._talker_model_path,
-                    voice_dict[key]["prompt_wav_path"],
-                )
+            self._validate_voice_presets(
+                voice_dict, voice_json_path, self._talker_model_path
+            )
             self._talker.set_voice_presets(voice_dict)
+        elif self._voice is not None:
+            raise FileNotFoundError(
+                f"[TALKER] voice_name.json not found at {voice_json_path}; "
+                f"default voice {self._voice!r} cannot be resolved"
+            )
         else:
-            logger.warning("[TALKER] voice_name.json not found at %s", voice_json_path)
+            logger.info(
+                "[TALKER] no voice_name.json at %s; presets disabled", voice_json_path
+            )
 
         # 6. Load speaker embedding extractor (optional)
         campplus_path = os.path.join(self._talker_model_path, "campplus.onnx")
@@ -279,6 +284,35 @@ class MingTalkerExecutor:
                 "usage": _build_talker_usage(payload),
             },
         )
+
+    def _validate_voice_presets(
+        self, voice_dict: dict, manifest_path: str, talker_dir: str
+    ) -> None:
+        """Resolve relative prompt-wav paths and validate the manifest.
+
+        Mutates ``voice_dict`` in place so each entry's ``prompt_wav_path``
+        becomes an absolute path on disk.
+        """
+        if self._voice is not None and self._voice not in voice_dict:
+            raise ValueError(
+                f"[TALKER] default voice {self._voice!r} not found in "
+                f"{manifest_path}; available presets: "
+                f"{sorted(voice_dict.keys())}"
+            )
+        for name, entry in voice_dict.items():
+            rel_path = entry.get("prompt_wav_path")
+            if rel_path is None:
+                raise ValueError(
+                    f"[TALKER] voice preset {name!r} in {manifest_path} is "
+                    f"missing prompt_wav_path"
+                )
+            resolved = os.path.join(talker_dir, rel_path)
+            if not os.path.isfile(resolved):
+                raise FileNotFoundError(
+                    f"[TALKER] voice preset {name!r} references missing "
+                    f"prompt wav {resolved}"
+                )
+            entry["prompt_wav_path"] = resolved
 
     def _extract_text(self, payload: StagePayload) -> str:
         """Extract generated text from the thinker output in the payload."""

--- a/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
+++ b/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
@@ -457,6 +457,7 @@ class MingOmniTalker(nn.Module):
         sigma=0.25,
         temperature=0,
         abort_event: threading.Event | None = None,
+        max_decode_steps: int | None = None,
     ):
         step = 0
         target_dtype = torch.bfloat16
@@ -516,9 +517,15 @@ class MingOmniTalker(nn.Module):
                 (attention_mask == 0), 1
             )
 
-            max_decode_steps = (max_cache_len - prefill_len) // self.patch_size
+            cache_max_decode_steps = (max_cache_len - prefill_len) // self.patch_size
+            if max_decode_steps is None:
+                effective_max_decode_steps = cache_max_decode_steps
+            else:
+                effective_max_decode_steps = min(
+                    cache_max_decode_steps, max_decode_steps
+                )
 
-            while step < 1000 and step < max_decode_steps:
+            while step < 1000 and step < effective_max_decode_steps:
                 if abort_event is not None and abort_event.is_set():
                     raise asyncio.CancelledError()
                 if step == 0:
@@ -593,11 +600,15 @@ class MingOmniTalker(nn.Module):
                 if abort_event is not None and abort_event.is_set():
                     raise asyncio.CancelledError()
 
-                if step > min_new_token and stop_out.cpu()[0, 1] > 0.5:
-                    yield gen_lat, True
+                is_stop = step > min_new_token and bool(stop_out.cpu()[0, 1] > 0.5)
+                last_chunk = (
+                    is_stop
+                    or step + 1 >= effective_max_decode_steps
+                    or step + 1 >= 1000
+                )
+                yield gen_lat, last_chunk
+                if last_chunk:
                     break
-
-                yield gen_lat, False
                 step += 1
         finally:
             self.model_graph_pool.put(
@@ -625,6 +636,7 @@ class MingOmniTalker(nn.Module):
         sigma=0.25,
         temperature=0,
         abort_event: threading.Event | None = None,
+        max_decode_steps: int | None = None,
     ):
         assert (
             self.tokenizer is not None
@@ -720,6 +732,7 @@ class MingOmniTalker(nn.Module):
                 sigma=sigma,
                 temperature=temperature,
                 abort_event=abort_event,
+                max_decode_steps=max_decode_steps,
             ):
                 yield audio_token
 
@@ -809,6 +822,7 @@ class MingOmniTalker(nn.Module):
         temperature=0,
         token_queue: queue.Queue | None = None,
         abort_event: threading.Event | None = None,
+        max_decode_steps: int | None = None,
     ):
         try:
             with torch.cuda.stream(torch.cuda.Stream(self.device)):
@@ -824,6 +838,7 @@ class MingOmniTalker(nn.Module):
                     sigma=sigma,
                     temperature=temperature,
                     abort_event=abort_event,
+                    max_decode_steps=max_decode_steps,
                 ):
                     if abort_event is not None and abort_event.is_set():
                         raise asyncio.CancelledError()
@@ -854,6 +869,7 @@ class MingOmniTalker(nn.Module):
         sigma=0.25,
         temperature=0,
         abort_event: threading.Event | None = None,
+        max_decode_steps: int | None = None,
     ):
         with torch.cuda.stream(torch.cuda.Stream(self.device)):
             this_uuid = str(uuid.uuid1())
@@ -888,6 +904,7 @@ class MingOmniTalker(nn.Module):
                     temperature,
                     token_queue=token_queue,
                     abort_event=effective_abort_event,
+                    max_decode_steps=max_decode_steps,
                 )
 
                 if stream:
@@ -1022,6 +1039,32 @@ class MingOmniTalker(nn.Module):
             "spk_emb": spk_emb_list if spk_emb_list else None,
         }
         logger.info("register_prompt_wav: %s", key)
+
+    def duration_capped_steps(
+        self,
+        text_len: int,
+        audio_detokenizer,
+        requested_max_steps: int,
+    ) -> int:
+        """Cap CFM decode steps by an audio-duration heuristic from the
+        Ming reference inference: up to ~0.36s/char with a 2.0s floor.
+        """
+        if audio_detokenizer is None:
+            return requested_max_steps
+        try:
+            sample_rate = float(audio_detokenizer.config.sample_rate)
+            vae_patch_size = float(getattr(audio_detokenizer.encoder, "patch_size", 1))
+            hop_size = float(audio_detokenizer.encoder.hop_size)
+        except AttributeError:
+            return requested_max_steps
+        seconds_per_step = (
+            float(self.patch_size) * vae_patch_size * hop_size
+        ) / sample_rate
+        if seconds_per_step <= 0:
+            return requested_max_steps
+        max_duration_s = max(2.0, float(text_len) * (5818.0 / 16000.0))
+        max_steps_by_duration = max(1, int(max_duration_s / seconds_per_step))
+        return min(requested_max_steps, max_steps_by_duration)
 
     def get_prompt_emb(
         self,
@@ -1206,6 +1249,12 @@ class MingOmniTalker(nn.Module):
             use_stream = stream and (count == 0)
             all_wavs: list = []
 
+            segment_max_decode_steps = self.duration_capped_steps(
+                text_len=len(text),
+                audio_detokenizer=audio_detokenizer,
+                requested_max_steps=1000,
+            )
+
             for idx, this_tts_speech_dict in enumerate(
                 self.tts_job(
                     prompt=prompt,
@@ -1218,6 +1267,7 @@ class MingOmniTalker(nn.Module):
                     prompt_wav_emb=prompt_wav_emb,
                     stream=use_stream,
                     abort_event=abort_event,
+                    max_decode_steps=segment_max_decode_steps,
                 )
             ):
                 tts_speech = this_tts_speech_dict["tts_speech"]
@@ -1282,13 +1332,30 @@ class MingOmniTalker(nn.Module):
         instruction = None
         abort_event = kwargs.get("abort_event")
 
+        # Resolve before grabbing a CUDA stream so bad requests fail fast
+        # without holding CUDA resources.
+        if prompt_wav_path is not None:
+            pass
+        elif voice_name is not None and voice_name in self.voice_json_dict:
+            prompt_text = self.voice_json_dict[voice_name]["prompt_text"]
+            prompt_wav_path = self.voice_json_dict[voice_name]["prompt_wav_path"]
+        elif voice_name is not None:
+            raise ValueError(
+                f"voice_name={voice_name!r} not found in loaded voice presets "
+                f"(available: {sorted(self.voice_json_dict)}). Without a preset "
+                f"or explicit prompt_wav_path the talker would run without a "
+                f"speaker anchor and produce drifting voice output. Either "
+                f"install talker/data/voice_name.json with this voice or pass "
+                f"prompt_wav_path explicitly."
+            )
+        else:
+            raise ValueError(
+                "omni_audio_generation requires either voice_name (resolved via "
+                "loaded voice presets) or prompt_wav_path. Both are None."
+            )
+
         with torch.cuda.stream(torch.cuda.Stream(self.device)):
             self.initial_graph()
-
-            if voice_name is not None and voice_name in self.voice_json_dict:
-                assert prompt_wav_path is None and prompt_text is None
-                prompt_text = self.voice_json_dict[voice_name]["prompt_text"]
-                prompt_wav_path = self.voice_json_dict[voice_name]["prompt_wav_path"]
 
             prompt_wav_lat, prompt_wav_emb, spk_emb = self.get_prompt_emb(
                 prompt_wav_path,
@@ -1349,6 +1416,11 @@ class MingOmniTalker(nn.Module):
                 "SPEECH_SOUND",
                 "PODCAST",
             ]:
+                non_segmented_max_decode_steps = self.duration_capped_steps(
+                    text_len=len(text),
+                    audio_detokenizer=audio_detokenizer,
+                    requested_max_steps=1000,
+                )
                 for this_tts_speech_dict in self.tts_job(
                     prompt=prompt,
                     text=text,
@@ -1363,6 +1435,7 @@ class MingOmniTalker(nn.Module):
                     sigma=sigma,
                     temperature=temperature,
                     abort_event=abort_event if stream else None,
+                    max_decode_steps=non_segmented_max_decode_steps,
                 ):
                     yield this_tts_speech_dict["tts_speech"], None, None, None
             else:

--- a/tests/README.md
+++ b/tests/README.md
@@ -49,6 +49,7 @@ tests/
     │   ├── test_omni_serve.py
     │   ├── test_pipeline.py
     │   ├── test_talker.py
+    │   ├── test_talker_voice_validation.py
     │   ├── test_thinker.py
     │   ├── test_tokenizer.py
     │   └── test_tp.py
@@ -233,6 +234,7 @@ that happened to contain an older version of the test.
   - image/vision encoder TP context preservation
   - audio/image preprocessor placeholder construction and cache-key plumbing
   - talker executor request gating and result-builder modality merging
+  - talker voice-preset validation (load-time manifest / wav existence, request-time prompt_wav_path priority), duration-cap heuristic, and `generate()` final-chunk flush across stop-token and step-ceiling exits
   - Bailing tokenizer loader fallback for vocab compatibility
   - TP topology validation (rank-specific stage specs, talker/thinker GPU collision detection, server_args alignment before infra init).
 

--- a/tests/unit_test/ming_omni/test_talker_voice_validation.py
+++ b/tests/unit_test/ming_omni/test_talker_voice_validation.py
@@ -1,0 +1,472 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Voice-preset validation, duration cap, and final-chunk flush."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from sglang_omni.models.ming_omni.components.streaming_talker import (
+    MingStreamingTalkerScheduler,
+)
+from sglang_omni.models.ming_omni.components.talker_executor import MingTalkerExecutor
+from sglang_omni.models.ming_omni.talker.modeling_ming_omni_talker import MingOmniTalker
+
+
+def _write_voice_manifest(
+    talker_dir: Path, presets: dict, wav_files: dict | None = None
+) -> Path:
+    """Write a voice_name.json manifest plus referenced wav stubs."""
+    data_dir = talker_dir / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    manifest = data_dir / "voice_name.json"
+    manifest.write_text(json.dumps(presets), encoding="utf-8")
+    if wav_files is not None:
+        for rel, content in wav_files.items():
+            wav_path = talker_dir / rel
+            wav_path.parent.mkdir(parents=True, exist_ok=True)
+            wav_path.write_bytes(content)
+    return manifest
+
+
+def test_executor_validate_resolves_paths_when_default_voice_present(tmp_path: Path):
+    talker_dir = tmp_path / "talker"
+    wav_rel = "spks/DB30.wav"
+    manifest = _write_voice_manifest(
+        talker_dir,
+        {"DB30": {"prompt_text": "x", "prompt_wav_path": wav_rel}},
+        {wav_rel: b"\x00" * 16},
+    )
+    voice_dict = {"DB30": {"prompt_text": "x", "prompt_wav_path": wav_rel}}
+    executor = MingTalkerExecutor(
+        model_path=str(tmp_path / "model"),
+        talker_model_path=str(talker_dir),
+        voice="DB30",
+    )
+    executor._validate_voice_presets(voice_dict, str(manifest), str(talker_dir))
+    assert voice_dict["DB30"]["prompt_wav_path"] == str(talker_dir / wav_rel)
+
+
+def test_executor_validate_raises_when_default_voice_missing(tmp_path: Path):
+    talker_dir = tmp_path / "talker"
+    wav_rel = "spks/OTHER.wav"
+    manifest = _write_voice_manifest(
+        talker_dir,
+        {"OTHER": {"prompt_text": "x", "prompt_wav_path": wav_rel}},
+        {wav_rel: b"\x00" * 16},
+    )
+    voice_dict = {"OTHER": {"prompt_text": "x", "prompt_wav_path": wav_rel}}
+    executor = MingTalkerExecutor(
+        model_path=str(tmp_path / "model"),
+        talker_model_path=str(talker_dir),
+        voice="DB30",
+    )
+    with pytest.raises(ValueError, match="default voice 'DB30' not found"):
+        executor._validate_voice_presets(voice_dict, str(manifest), str(talker_dir))
+
+
+def test_executor_validate_raises_when_wav_missing(tmp_path: Path):
+    talker_dir = tmp_path / "talker"
+    wav_rel = "spks/DB30.wav"
+    manifest = _write_voice_manifest(
+        talker_dir,
+        {"DB30": {"prompt_text": "x", "prompt_wav_path": wav_rel}},
+        wav_files=None,
+    )
+    voice_dict = {"DB30": {"prompt_text": "x", "prompt_wav_path": wav_rel}}
+    executor = MingTalkerExecutor(
+        model_path=str(tmp_path / "model"),
+        talker_model_path=str(talker_dir),
+        voice="DB30",
+    )
+    with pytest.raises(FileNotFoundError, match="missing prompt wav"):
+        executor._validate_voice_presets(voice_dict, str(manifest), str(talker_dir))
+
+
+def test_executor_validate_raises_value_error_not_key_error_on_bad_manifest(
+    tmp_path: Path,
+):
+    """Manifest entry without prompt_wav_path must surface a clear ValueError,
+    not a bare KeyError from dict[...] access."""
+    talker_dir = tmp_path / "talker"
+    manifest = _write_voice_manifest(
+        talker_dir,
+        {"DB30": {"prompt_text": "x"}},  # missing prompt_wav_path key
+    )
+    voice_dict = {"DB30": {"prompt_text": "x"}}
+    executor = MingTalkerExecutor(
+        model_path=str(tmp_path / "model"),
+        talker_model_path=str(talker_dir),
+        voice="DB30",
+    )
+    with pytest.raises(ValueError, match="missing prompt_wav_path"):
+        executor._validate_voice_presets(voice_dict, str(manifest), str(talker_dir))
+
+
+def test_executor_validate_allows_voice_none_with_unrelated_presets(tmp_path: Path):
+    talker_dir = tmp_path / "talker"
+    wav_rel = "spks/OTHER.wav"
+    manifest = _write_voice_manifest(
+        talker_dir,
+        {"OTHER": {"prompt_text": "x", "prompt_wav_path": wav_rel}},
+        {wav_rel: b"\x00" * 16},
+    )
+    voice_dict = {"OTHER": {"prompt_text": "x", "prompt_wav_path": wav_rel}}
+    executor = MingTalkerExecutor(
+        model_path=str(tmp_path / "model"),
+        talker_model_path=str(talker_dir),
+        voice=None,
+    )
+    executor._validate_voice_presets(voice_dict, str(manifest), str(talker_dir))
+
+
+def test_scheduler_validate_raises_when_default_voice_missing(tmp_path: Path):
+    talker_dir = tmp_path / "talker"
+    wav_rel = "spks/OTHER.wav"
+    manifest = _write_voice_manifest(
+        talker_dir,
+        {"OTHER": {"prompt_text": "x", "prompt_wav_path": wav_rel}},
+        {wav_rel: b"\x00" * 16},
+    )
+    voice_dict = {"OTHER": {"prompt_text": "x", "prompt_wav_path": wav_rel}}
+    scheduler = MingStreamingTalkerScheduler(
+        model_path=str(tmp_path / "model"),
+        voice="DB30",
+        talker=object(),
+        sample_rate=44100,
+    )
+    with pytest.raises(ValueError, match="default voice 'DB30' not found"):
+        scheduler._validate_voice_presets(voice_dict, str(manifest), str(talker_dir))
+
+
+def test_scheduler_validate_raises_when_wav_missing(tmp_path: Path):
+    talker_dir = tmp_path / "talker"
+    wav_rel = "spks/DB30.wav"
+    manifest = _write_voice_manifest(
+        talker_dir,
+        {"DB30": {"prompt_text": "x", "prompt_wav_path": wav_rel}},
+        wav_files=None,
+    )
+    voice_dict = {"DB30": {"prompt_text": "x", "prompt_wav_path": wav_rel}}
+    scheduler = MingStreamingTalkerScheduler(
+        model_path=str(tmp_path / "model"),
+        voice="DB30",
+        talker=object(),
+        sample_rate=44100,
+    )
+    with pytest.raises(FileNotFoundError, match="missing prompt wav"):
+        scheduler._validate_voice_presets(voice_dict, str(manifest), str(talker_dir))
+
+
+def test_scheduler_validate_raises_value_error_on_bad_manifest(tmp_path: Path):
+    talker_dir = tmp_path / "talker"
+    manifest = _write_voice_manifest(
+        talker_dir,
+        {"DB30": {"prompt_text": "x"}},  # missing prompt_wav_path key
+    )
+    voice_dict = {"DB30": {"prompt_text": "x"}}
+    scheduler = MingStreamingTalkerScheduler(
+        model_path=str(tmp_path / "model"),
+        voice="DB30",
+        talker=object(),
+        sample_rate=44100,
+    )
+    with pytest.raises(ValueError, match="missing prompt_wav_path"):
+        scheduler._validate_voice_presets(voice_dict, str(manifest), str(talker_dir))
+
+
+def _bare_talker(voice_json_dict: dict | None = None) -> MingOmniTalker:
+    talker = object.__new__(MingOmniTalker)
+    talker.voice_json_dict = voice_json_dict if voice_json_dict is not None else {}
+    return talker
+
+
+def test_omni_audio_generation_unknown_voice_no_prompt_wav_raises():
+    talker = _bare_talker()
+    gen = MingOmniTalker.omni_audio_generation(
+        talker,
+        tts_text="hi",
+        voice_name="DB30",
+        prompt_wav_path=None,
+    )
+    with pytest.raises(ValueError, match="not found in loaded voice presets"):
+        next(gen)
+
+
+def test_omni_audio_generation_no_voice_no_prompt_wav_raises():
+    talker = _bare_talker()
+    gen = MingOmniTalker.omni_audio_generation(
+        talker,
+        tts_text="hi",
+        voice_name=None,
+        prompt_wav_path=None,
+    )
+    with pytest.raises(ValueError, match="requires either voice_name"):
+        next(gen)
+
+
+def test_omni_audio_generation_explicit_prompt_wav_overrides_preset(monkeypatch):
+    """An explicit prompt_wav_path must take precedence over a registered
+    preset (callers use this to override the voice for a single request)."""
+    talker = _bare_talker(
+        voice_json_dict={
+            "DB30": {
+                "prompt_text": "preset text",
+                "prompt_wav_path": "/preset/wav.wav",
+            }
+        }
+    )
+
+    captured = {}
+
+    def fake_run(
+        self,
+        text,
+        prompt,
+        instruction,
+        spk_emb,
+        audio_detok,
+        prompt_text,
+        prompt_wav_lat,
+        prompt_wav_emb,
+        **kwargs,
+    ):
+        captured["prompt_text"] = prompt_text
+        if False:
+            yield None
+
+    def fake_get_prompt_emb(self, prompt_wav_path, *args, **kwargs):
+        captured["prompt_wav_path"] = prompt_wav_path
+        return None, None, None
+
+    monkeypatch.setattr(MingOmniTalker, "_run_tts_segments", fake_run)
+    monkeypatch.setattr(MingOmniTalker, "get_prompt_emb", fake_get_prompt_emb)
+    monkeypatch.setattr(
+        MingOmniTalker, "initial_graph", lambda self: None, raising=False
+    )
+
+    import torch as _torch
+
+    class _NullStream:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(_torch.cuda, "stream", lambda s: _NullStream())
+    monkeypatch.setattr(
+        _torch.cuda, "Stream", lambda device=None: object(), raising=False
+    )
+    monkeypatch.setattr(
+        MingOmniTalker,
+        "device",
+        property(lambda self: "cuda:0"),
+        raising=False,
+    )
+
+    list(
+        MingOmniTalker.omni_audio_generation(
+            talker,
+            tts_text="hi",
+            voice_name="DB30",
+            prompt_wav_path="/explicit/override.wav",
+            prompt_text="explicit text",
+        )
+    )
+
+    assert captured["prompt_wav_path"] == "/explicit/override.wav"
+    assert captured["prompt_text"] == "explicit text"
+
+
+def _fake_detokenizer(sample_rate=44100, vae_patch_size=4, hop_size=480):
+    encoder = SimpleNamespace(patch_size=vae_patch_size, hop_size=hop_size)
+    config = SimpleNamespace(sample_rate=sample_rate)
+    return SimpleNamespace(encoder=encoder, config=config)
+
+
+def test_duration_capped_steps_short_text_uses_floor():
+    talker = object.__new__(MingOmniTalker)
+    talker.patch_size = 2
+
+    detok = _fake_detokenizer()
+    seconds_per_step = (2 * 4 * 480) / 44100  # ≈ 0.0871
+    expected = max(1, int(2.0 / seconds_per_step))  # short-text floor = 2.0s
+
+    capped = talker.duration_capped_steps(
+        text_len=1, audio_detokenizer=detok, requested_max_steps=10_000
+    )
+    assert capped == expected
+
+
+def test_duration_capped_steps_long_text_uses_per_char_rate():
+    talker = object.__new__(MingOmniTalker)
+    talker.patch_size = 2
+    detok = _fake_detokenizer()
+
+    text_len = 100
+    seconds_per_step = (2 * 4 * 480) / 44100
+    max_duration_s = max(2.0, text_len * (5818.0 / 16000.0))
+    expected = max(1, int(max_duration_s / seconds_per_step))
+
+    capped = talker.duration_capped_steps(
+        text_len=text_len,
+        audio_detokenizer=detok,
+        requested_max_steps=10_000,
+    )
+    assert capped == expected
+
+
+def test_duration_capped_steps_respects_requested_ceiling():
+    talker = object.__new__(MingOmniTalker)
+    talker.patch_size = 2
+    detok = _fake_detokenizer()
+
+    capped = talker.duration_capped_steps(
+        text_len=100, audio_detokenizer=detok, requested_max_steps=5
+    )
+    assert capped == 5
+
+
+def test_duration_capped_steps_no_detokenizer_is_passthrough():
+    talker = object.__new__(MingOmniTalker)
+    talker.patch_size = 2
+    capped = talker.duration_capped_steps(
+        text_len=100, audio_detokenizer=None, requested_max_steps=42
+    )
+    assert capped == 42
+
+
+def test_duration_capped_steps_missing_encoder_attr_is_passthrough():
+    talker = object.__new__(MingOmniTalker)
+    talker.patch_size = 2
+    detok = SimpleNamespace(
+        encoder=SimpleNamespace(patch_size=4),
+        config=SimpleNamespace(sample_rate=44100),
+    )
+    capped = talker.duration_capped_steps(
+        text_len=100, audio_detokenizer=detok, requested_max_steps=42
+    )
+    assert capped == 42
+
+
+def _stub_for_generate(talker: MingOmniTalker, num_steps_before_stop: int):
+    """Wire MingOmniTalker.generate's collaborators with deterministic stubs."""
+    import torch as _torch
+
+    target_device = _torch.device("cpu")
+
+    talker.his_patch_size = 1
+    talker.patch_size = 1
+    talker.latent_dim = 1
+    talker.model = SimpleNamespace(
+        config=SimpleNamespace(),
+        device=target_device,
+    )
+
+    class _NoopCache:
+        def __init__(self):
+            self.calls = []
+
+        def reset(self):
+            pass
+
+        def get_seq_length(self):
+            return 1
+
+    pool_state = {
+        "tuple": (_NoopCache(), None, None, None, None, None, None),
+    }
+    talker.model_graph_pool = SimpleNamespace(
+        get=lambda: pool_state["tuple"],
+        put=lambda x: pool_state.__setitem__("tuple", x),
+    )
+
+    def _fake_forward(**kwargs):
+        return SimpleNamespace(
+            hidden_states=(_torch.zeros(1, 1, 1, device=target_device),),
+        )
+
+    talker.model = _fake_forward
+    type(talker).device = property(lambda self: target_device)
+
+    step_counter = {"n": 0}
+
+    def _execute(hidden_out, his_lat, cfg, sigma, temperature, abort_event):
+        n = step_counter["n"]
+        step_counter["n"] += 1
+        gen_lat = _torch.full((1, 1, 1), float(n), device=target_device)
+        new_embeds = _torch.zeros(1, 1, 1, device=target_device)
+        stop_value = (
+            1.0
+            if (num_steps_before_stop is not None and n == num_steps_before_stop)
+            else 0.0
+        )
+        stop_out = _torch.tensor([[0.0, stop_value]], device=target_device)
+        return gen_lat, new_embeds, stop_out
+
+    talker.sampler_pool = SimpleNamespace(execute=_execute)
+
+
+def test_generate_emits_final_true_when_stop_token_fires(monkeypatch):
+    """Stop-token exit terminates with last_chunk=True."""
+    import torch as _torch
+
+    talker = object.__new__(MingOmniTalker)
+    _stub_for_generate(talker, num_steps_before_stop=4)
+
+    monkeypatch.setattr(
+        "sglang_omni.models.ming_omni.talker.modeling_ming_omni_talker." "StaticCache",
+        lambda **kw: object(),
+    )
+
+    input_ids = _torch.zeros(1, 2, dtype=_torch.long)
+    inputs_embeds = _torch.zeros(1, 2, 1)
+
+    yields = list(
+        MingOmniTalker.generate(
+            talker,
+            input_ids=input_ids,
+            inputs_embeds=inputs_embeds,
+            min_new_token=0,
+            max_decode_steps=20,
+        )
+    )
+    assert len(yields) >= 2
+    flags = [bool(flag) for _, flag in yields]
+    assert flags[-1] is True
+    assert all(flag is False for flag in flags[:-1])
+
+
+def test_generate_emits_final_true_when_duration_cap_hits(monkeypatch):
+    """Loop exit via effective_max_decode_steps ceiling must still emit a
+    last_chunk=True so the streaming VAE flushes its tail."""
+    import torch as _torch
+
+    talker = object.__new__(MingOmniTalker)
+    # never trigger stop_out=1.0 inside the loop
+    _stub_for_generate(talker, num_steps_before_stop=None)
+
+    monkeypatch.setattr(
+        "sglang_omni.models.ming_omni.talker.modeling_ming_omni_talker." "StaticCache",
+        lambda **kw: object(),
+    )
+
+    input_ids = _torch.zeros(1, 2, dtype=_torch.long)
+    inputs_embeds = _torch.zeros(1, 2, 1)
+
+    yields = list(
+        MingOmniTalker.generate(
+            talker,
+            input_ids=input_ids,
+            inputs_embeds=inputs_embeds,
+            min_new_token=0,
+            max_decode_steps=3,
+        )
+    )
+    assert len(yields) == 3
+    flags = [bool(flag) for _, flag in yields]
+    assert flags == [False, False, True]


### PR DESCRIPTION

## Motivation

When `talker/data/voice_name.json` is missing from the model mount the server logged a warning and kept serving with an empty `voice_json_dict`. The default voice `"DB30"` then never resolved to a prompt wav, so CFM ran with `prompt_wav_lat=None` — no speaker anchor at all — and output drifted away from DB30 within seconds.

## Modifications

  - `MingTalkerExecutor` and `MingStreamingTalkerScheduler` now fail fast at load time when:
    - a default voice is configured but `voice_name.json` is missing → `FileNotFoundError`,
    - the default-voice key is not present in the manifest → `ValueError`,
    - any preset entry is missing `prompt_wav_path` → `ValueError` (not a bare `KeyError` from `dict[…]` lookup),
    - any referenced wav file does not exist on disk → `FileNotFoundError`.
  - `_validate_voice_presets` owns both the relative→absolute path resolution and the existence check, so malformed manifests surface with a clear message at the right layer.
  - `MingOmniTalker.omni_audio_generation` resolves speaker conditioning in this order:
    1. explicit `prompt_wav_path` wins (per-request override of preset),
    2. else `voice_name` is looked up in `voice_json_dict`,
    3. else raise. `voice_name=None` AND `prompt_wav_path=None` still raises.
    Resolution is hoisted out of the CUDA stream context so bad requests don't hold CUDA resources.
## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Draft PRs are skipped even if labeled.
