### PR TITLE
[Perf] Optimize Qwen3-TTS reference prompt path

### DIFF
--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -3,21 +3,22 @@
 
 from __future__ import annotations
 
-import copy
 import hashlib
 import os
 import threading
 import time
-from collections import OrderedDict
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 import torch
 
 from sglang_omni.models.qwen3_omni.pending_text_queue import PendingTextTensorQueue
 from sglang_omni.models.qwen3_tts.payload_types import Qwen3TTSState
+from sglang_omni.preprocessing.cache_key import hash_bytes
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
+from sglang_omni.scheduling.stage_cache import StageOutputCache
 
 QWEN3_TTS_DEFAULT_MAX_NEW_TOKENS = 2048
 QWEN3_TTS_TASK_BASE = "Base"
@@ -125,8 +126,17 @@ class Qwen3TTSPreprocessingContext:
 _PREPROCESSING_CONTEXT: Qwen3TTSPreprocessingContext | None = None
 _PREPARED_REQUESTS: dict[str, Qwen3TTSPreparedRequest] = {}
 _PREPARED_REQUESTS_LOCK = threading.Lock()
-_REFERENCE_PROMPT_CACHE: OrderedDict[str, list[Any]] = OrderedDict()
+# Long-lived server state, so bound it by bytes (not just item count) and keep
+# the cached reference tensors on the host so all-miss / low-reuse traffic cannot
+# pin GPU memory without bound. Mirrors the Higgs ref-cache and Qwen3 Omni encoder
+# cache patterns.
 _REFERENCE_PROMPT_CACHE_MAX_SIZE = 256
+_REFERENCE_PROMPT_CACHE_MAX_BYTES = 512 * 1024 * 1024
+_REFERENCE_PROMPT_CACHE = StageOutputCache(
+    max_size=_REFERENCE_PROMPT_CACHE_MAX_SIZE,
+    max_bytes=_REFERENCE_PROMPT_CACHE_MAX_BYTES,
+    cache_device="cpu",
+)
 
 
 def set_qwen3_tts_preprocessing_context(*, model: Any, wrapper: Any) -> None:
@@ -158,14 +168,17 @@ def _qwen3_tts_reference_prompt_cache_enabled() -> bool:
 
 def _hash_reference_audio(ref_audio: Any) -> str | None:
     if isinstance(ref_audio, str):
-        if os.path.isfile(ref_audio):
-            try:
-                stat = os.stat(ref_audio)
-            except OSError:
+        # Full-content hash for local files, not path+size+mtime (a same-size
+        # in-place edit, or a preserved mtime after cp -p / rsync, would
+        # stale-hit and synthesize with the old voice). URLs and missing paths
+        # are not cached: the string alone is not a sound content key.
+        try:
+            path = Path(ref_audio).expanduser()
+            if not path.is_file():
                 return None
-            return f"path:{os.path.abspath(ref_audio)}:{stat.st_size}:{stat.st_mtime_ns}"
-        digest = hashlib.blake2b(ref_audio.encode("utf-8"), digest_size=16).hexdigest()
-        return f"str:{digest}"
+            return f"file:{hash_bytes(path.read_bytes())}"
+        except OSError:
+            return None
 
     try:
         import numpy as np
@@ -173,12 +186,10 @@ def _hash_reference_audio(ref_audio: Any) -> str | None:
         if isinstance(ref_audio, tuple) and len(ref_audio) == 2:
             audio, sr = ref_audio
             array = np.asarray(audio, dtype=np.float32)
-            digest = hashlib.blake2b(array.tobytes(), digest_size=16).hexdigest()
-            return f"tuple:{int(sr)}:{array.shape}:{digest}"
+            return f"tuple:{int(sr)}:{array.shape}:{hash_bytes(array.tobytes())}"
         array = np.asarray(ref_audio, dtype=np.float32)
         if array.ndim > 0:
-            digest = hashlib.blake2b(array.tobytes(), digest_size=16).hexdigest()
-            return f"array:{array.shape}:{digest}"
+            return f"array:{array.shape}:{hash_bytes(array.tobytes())}"
     except (TypeError, ValueError):
         return None
     return None
@@ -192,33 +203,56 @@ def _reference_prompt_cache_key(state: Qwen3TTSState) -> str | None:
     return f"{audio_key}|ref_text:{ref_text}|xvec:{int(state.x_vector_only_mode)}"
 
 
-def _clone_cached_reference_prompt_item(item: Any) -> Any:
-    ref_code = getattr(item, "ref_code", None)
-    if isinstance(ref_code, torch.Tensor):
-        ref_code = ref_code.detach().clone()
-    ref_spk_embedding = getattr(item, "ref_spk_embedding", None)
-    if isinstance(ref_spk_embedding, torch.Tensor):
-        ref_spk_embedding = ref_spk_embedding.detach().clone()
-    kwargs = {
-        "ref_code": ref_code,
-        "ref_spk_embedding": ref_spk_embedding,
-        "x_vector_only_mode": bool(getattr(item, "x_vector_only_mode", False)),
-        "icl_mode": bool(getattr(item, "icl_mode", False)),
-        "ref_text": getattr(item, "ref_text", None),
-    }
+def _build_voice_clone_prompt_item(template_cls: type, kwargs: dict[str, Any]) -> Any:
     try:
         from qwen_tts.inference.qwen3_tts_model import VoiceClonePromptItem
 
         return VoiceClonePromptItem(**kwargs)
     except (ImportError, TypeError):
-        try:
-            return item.__class__(**kwargs)
-        except TypeError:
-            cloned = copy.copy(item)
-            for key, value in kwargs.items():
-                if hasattr(cloned, key):
-                    setattr(cloned, key, value)
-            return cloned
+        return template_cls(**kwargs)
+
+
+def _reference_prompt_item_to_cache_entry(item: Any) -> dict[str, Any]:
+    """Snapshot a prompt item into an independent, host-resident cache entry.
+
+    Tensors are detached, cloned, and moved to CPU so the cached copy neither
+    aliases the returned item (clone-on-put) nor pins GPU memory; the original
+    device is recorded so a cache hit can restore it. Only the lightweight class
+    is retained (not the original item, which would keep its GPU tensors alive).
+    """
+    device: str | None = None
+    snapshot: dict[str, Any] = {}
+    for field_name in ("ref_code", "ref_spk_embedding"):
+        value = getattr(item, field_name, None)
+        if isinstance(value, torch.Tensor):
+            if device is None:
+                device = str(value.device)
+            value = value.detach().to("cpu").clone()
+        snapshot[field_name] = value
+    snapshot["device"] = device
+    snapshot["template_cls"] = type(item)
+    snapshot["x_vector_only_mode"] = bool(getattr(item, "x_vector_only_mode", False))
+    snapshot["icl_mode"] = bool(getattr(item, "icl_mode", False))
+    snapshot["ref_text"] = getattr(item, "ref_text", None)
+    return snapshot
+
+
+def _reference_prompt_item_from_cache_entry(entry: dict[str, Any]) -> Any:
+    """Rebuild a fresh prompt item from a cache entry on its original device."""
+    device = entry.get("device")
+    kwargs: dict[str, Any] = {
+        "x_vector_only_mode": entry["x_vector_only_mode"],
+        "icl_mode": entry["icl_mode"],
+        "ref_text": entry["ref_text"],
+    }
+    for field_name in ("ref_code", "ref_spk_embedding"):
+        value = entry.get(field_name)
+        if isinstance(value, torch.Tensor):
+            value = value.detach().clone()
+            if device is not None:
+                value = value.to(device)
+        kwargs[field_name] = value
+    return _build_voice_clone_prompt_item(entry["template_cls"], kwargs)
 
 
 def _get_or_create_reference_prompt_items(
@@ -238,9 +272,8 @@ def _get_or_create_reference_prompt_items(
     if key is not None:
         with _PREPARED_REQUESTS_LOCK:
             cached = _REFERENCE_PROMPT_CACHE.get(key)
-            if cached is not None:
-                _REFERENCE_PROMPT_CACHE.move_to_end(key)
-                return [_clone_cached_reference_prompt_item(item) for item in cached]
+        if cached is not None:
+            return [_reference_prompt_item_from_cache_entry(entry) for entry in cached]
 
     with torch.no_grad():
         prompt_items = wrapper.create_voice_clone_prompt(
@@ -250,14 +283,11 @@ def _get_or_create_reference_prompt_items(
         )
 
     if key is not None:
-        cached_items = [
-            _clone_cached_reference_prompt_item(item) for item in prompt_items
+        cache_entries = [
+            _reference_prompt_item_to_cache_entry(item) for item in prompt_items
         ]
         with _PREPARED_REQUESTS_LOCK:
-            _REFERENCE_PROMPT_CACHE[key] = cached_items
-            _REFERENCE_PROMPT_CACHE.move_to_end(key)
-            while len(_REFERENCE_PROMPT_CACHE) > _REFERENCE_PROMPT_CACHE_MAX_SIZE:
-                _REFERENCE_PROMPT_CACHE.popitem(last=False)
+            _REFERENCE_PROMPT_CACHE.put(key, cache_entries)
     return prompt_items
 
 

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -3,10 +3,12 @@
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import os
 import threading
 import time
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -123,6 +125,8 @@ class Qwen3TTSPreprocessingContext:
 _PREPROCESSING_CONTEXT: Qwen3TTSPreprocessingContext | None = None
 _PREPARED_REQUESTS: dict[str, Qwen3TTSPreparedRequest] = {}
 _PREPARED_REQUESTS_LOCK = threading.Lock()
+_REFERENCE_PROMPT_CACHE: OrderedDict[str, list[Any]] = OrderedDict()
+_REFERENCE_PROMPT_CACHE_MAX_SIZE = 256
 
 
 def set_qwen3_tts_preprocessing_context(*, model: Any, wrapper: Any) -> None:
@@ -135,6 +139,7 @@ def set_qwen3_tts_preprocessing_context(*, model: Any, wrapper: Any) -> None:
             wrapper=wrapper,
         )
         _PREPARED_REQUESTS.clear()
+        _REFERENCE_PROMPT_CACHE.clear()
 
 
 def clear_qwen3_tts_preprocessing_context() -> None:
@@ -144,6 +149,116 @@ def clear_qwen3_tts_preprocessing_context() -> None:
     with _PREPARED_REQUESTS_LOCK:
         _PREPROCESSING_CONTEXT = None
         _PREPARED_REQUESTS.clear()
+        _REFERENCE_PROMPT_CACHE.clear()
+
+
+def _qwen3_tts_reference_prompt_cache_enabled() -> bool:
+    return os.getenv("SGLANG_OMNI_QWEN3_TTS_REF_PROMPT_CACHE") == "1"
+
+
+def _hash_reference_audio(ref_audio: Any) -> str | None:
+    if isinstance(ref_audio, str):
+        if os.path.isfile(ref_audio):
+            try:
+                stat = os.stat(ref_audio)
+            except OSError:
+                return None
+            return f"path:{os.path.abspath(ref_audio)}:{stat.st_size}:{stat.st_mtime_ns}"
+        digest = hashlib.blake2b(ref_audio.encode("utf-8"), digest_size=16).hexdigest()
+        return f"str:{digest}"
+
+    try:
+        import numpy as np
+
+        if isinstance(ref_audio, tuple) and len(ref_audio) == 2:
+            audio, sr = ref_audio
+            array = np.asarray(audio, dtype=np.float32)
+            digest = hashlib.blake2b(array.tobytes(), digest_size=16).hexdigest()
+            return f"tuple:{int(sr)}:{array.shape}:{digest}"
+        array = np.asarray(ref_audio, dtype=np.float32)
+        if array.ndim > 0:
+            digest = hashlib.blake2b(array.tobytes(), digest_size=16).hexdigest()
+            return f"array:{array.shape}:{digest}"
+    except (TypeError, ValueError):
+        return None
+    return None
+
+
+def _reference_prompt_cache_key(state: Qwen3TTSState) -> str | None:
+    audio_key = _hash_reference_audio(state.ref_audio)
+    if audio_key is None:
+        return None
+    ref_text = "" if state.ref_text is None else state.ref_text
+    return f"{audio_key}|ref_text:{ref_text}|xvec:{int(state.x_vector_only_mode)}"
+
+
+def _clone_cached_reference_prompt_item(item: Any) -> Any:
+    ref_code = getattr(item, "ref_code", None)
+    if isinstance(ref_code, torch.Tensor):
+        ref_code = ref_code.detach().clone()
+    ref_spk_embedding = getattr(item, "ref_spk_embedding", None)
+    if isinstance(ref_spk_embedding, torch.Tensor):
+        ref_spk_embedding = ref_spk_embedding.detach().clone()
+    kwargs = {
+        "ref_code": ref_code,
+        "ref_spk_embedding": ref_spk_embedding,
+        "x_vector_only_mode": bool(getattr(item, "x_vector_only_mode", False)),
+        "icl_mode": bool(getattr(item, "icl_mode", False)),
+        "ref_text": getattr(item, "ref_text", None),
+    }
+    try:
+        from qwen_tts.inference.qwen3_tts_model import VoiceClonePromptItem
+
+        return VoiceClonePromptItem(**kwargs)
+    except (ImportError, TypeError):
+        try:
+            return item.__class__(**kwargs)
+        except TypeError:
+            cloned = copy.copy(item)
+            for key, value in kwargs.items():
+                if hasattr(cloned, key):
+                    setattr(cloned, key, value)
+            return cloned
+
+
+def _get_or_create_reference_prompt_items(
+    state: Qwen3TTSState,
+    *,
+    wrapper: Any,
+) -> list[Any]:
+    if not _qwen3_tts_reference_prompt_cache_enabled():
+        with torch.no_grad():
+            return wrapper.create_voice_clone_prompt(
+                ref_audio=state.ref_audio,
+                ref_text=state.ref_text,
+                x_vector_only_mode=state.x_vector_only_mode,
+            )
+
+    key = _reference_prompt_cache_key(state)
+    if key is not None:
+        with _PREPARED_REQUESTS_LOCK:
+            cached = _REFERENCE_PROMPT_CACHE.get(key)
+            if cached is not None:
+                _REFERENCE_PROMPT_CACHE.move_to_end(key)
+                return [_clone_cached_reference_prompt_item(item) for item in cached]
+
+    with torch.no_grad():
+        prompt_items = wrapper.create_voice_clone_prompt(
+            ref_audio=state.ref_audio,
+            ref_text=state.ref_text,
+            x_vector_only_mode=state.x_vector_only_mode,
+        )
+
+    if key is not None:
+        cached_items = [
+            _clone_cached_reference_prompt_item(item) for item in prompt_items
+        ]
+        with _PREPARED_REQUESTS_LOCK:
+            _REFERENCE_PROMPT_CACHE[key] = cached_items
+            _REFERENCE_PROMPT_CACHE.move_to_end(key)
+            while len(_REFERENCE_PROMPT_CACHE) > _REFERENCE_PROMPT_CACHE_MAX_SIZE:
+                _REFERENCE_PROMPT_CACHE.popitem(last=False)
+    return prompt_items
 
 
 def _prepared_request_id(payload: StagePayload) -> str | None:
@@ -518,12 +633,7 @@ def _prepare_qwen3_tts_base_request(
     model: Any,
     wrapper: Any,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
-    with torch.no_grad():
-        prompt_items = wrapper.create_voice_clone_prompt(
-            ref_audio=state.ref_audio,
-            ref_text=state.ref_text,
-            x_vector_only_mode=state.x_vector_only_mode,
-        )
+    prompt_items = _get_or_create_reference_prompt_items(state, wrapper=wrapper)
     if len(prompt_items) != 1:
         raise ValueError("Qwen3-TTS expects exactly one voice-clone prompt")
     voice_clone_prompt = wrapper._prompt_items_to_voice_clone_prompt(prompt_items)

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -166,6 +166,8 @@ def create_sglang_tts_engine_executor(
     gpu_id: int | None = None,
     dtype: str = "bfloat16",
     attn_implementation: str | None = None,
+    disable_cuda_graph: bool = False,
+    server_args_overrides: dict[str, Any] | None = None,
 ) -> Any:
     from qwen_tts import Qwen3TTSModel
     from transformers import AutoProcessor
@@ -184,20 +186,22 @@ def create_sglang_tts_engine_executor(
         device = f"cuda:{gpu_id}"
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0
 
-    server_args = build_sglang_server_args(
-        checkpoint_dir,
-        context_length=8192,
-        dtype=dtype,
-        disable_cuda_graph=False,
-        disable_overlap_schedule=True,
-        enable_torch_compile=True,
-        mem_fraction_static=0.85,
-        max_prefill_tokens=8192,
-        max_running_requests=16,
-        sampling_backend="pytorch",
-        torch_compile_max_bs=16,
-        trust_remote_code=True,
-    )
+    server_arg_kwargs: dict[str, Any] = {
+        "context_length": 8192,
+        "dtype": dtype,
+        "disable_cuda_graph": disable_cuda_graph,
+        "disable_overlap_schedule": True,
+        "enable_torch_compile": True,
+        "mem_fraction_static": 0.85,
+        "max_prefill_tokens": 8192,
+        "max_running_requests": 16,
+        "sampling_backend": "pytorch",
+        "torch_compile_max_bs": 16,
+        "trust_remote_code": True,
+    }
+    if server_args_overrides:
+        server_arg_kwargs.update(server_args_overrides)
+    server_args = build_sglang_server_args(checkpoint_dir, **server_arg_kwargs)
 
     want_cuda_graph = not bool(getattr(server_args, "disable_cuda_graph", False))
     if want_cuda_graph:

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -378,10 +378,40 @@ def test_qwen3_tts_reference_prompt_cache_is_default_off(
     assert calls == 2
 
 
+def test_qwen3_tts_reference_audio_cache_key_content_and_urls(tmp_path) -> None:
+    # Local files are keyed by full content: a same-path, same-size, same
+    # head/tail, middle-only edit must change the key so a replaced reference
+    # audio is never served from a stale cache entry.
+    head, tail = b"H" * 8192, b"T" * 8192
+    ref_audio = tmp_path / "voice.wav"
+    ref_audio.write_bytes(head + b"a" * 4096 + tail)
+    key_a = qwen3_request_builders._hash_reference_audio(str(ref_audio))
+    ref_audio.write_bytes(head + b"b" * 4096 + tail)  # same size, middle differs
+    key_b = qwen3_request_builders._hash_reference_audio(str(ref_audio))
+    assert key_a is not None and key_a.startswith("file:")
+    assert key_a != key_b
+
+    # In-memory waveforms are content-addressed too.
+    assert (
+        qwen3_request_builders._hash_reference_audio(np.zeros(8, dtype=np.float32))
+        is not None
+    )
+
+    # URLs and missing files are not cached (the string alone is not a key).
+    assert qwen3_request_builders._hash_reference_audio("https://x/voice.wav") is None
+    assert (
+        qwen3_request_builders._hash_reference_audio(str(tmp_path / "missing.wav"))
+        is None
+    )
+
+
 def test_qwen3_tts_reference_prompt_cache_reuses_and_clones_prompt_items(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
 ) -> None:
     monkeypatch.setenv("SGLANG_OMNI_QWEN3_TTS_REF_PROMPT_CACHE", "1")
+    ref_audio = tmp_path / "voice.wav"
+    ref_audio.write_bytes(b"fake reference audio bytes")
 
     fake_qwen_tts = types.ModuleType("qwen_tts")
     fake_inference = types.ModuleType("qwen_tts.inference")
@@ -429,7 +459,7 @@ def test_qwen3_tts_reference_prompt_cache_reuses_and_clones_prompt_items(
             ]
 
     state = Qwen3TTSState(
-        ref_audio="voice.wav",
+        ref_audio=str(ref_audio),
         ref_text="reference",
         x_vector_only_mode=False,
     )

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -8,6 +8,7 @@ import threading
 import types
 from queue import Queue
 from types import SimpleNamespace
+from typing import Any
 
 import numpy as np
 import pytest
@@ -209,6 +210,13 @@ def make_payload(
     )
 
 
+@pytest.fixture(autouse=True)
+def clear_qwen3_tts_request_state():
+    qwen3_request_builders.clear_qwen3_tts_preprocessing_context()
+    yield
+    qwen3_request_builders.clear_qwen3_tts_preprocessing_context()
+
+
 def test_qwen3_tts_config_and_registry_contracts() -> None:
     config = Qwen3TTSPipelineConfig(model_path="model")
     assert [stage.name for stage in config.stages] == [
@@ -332,6 +340,115 @@ def test_qwen3_tts_embedding_cache_keys_are_stable_and_content_based() -> None:
     assert build_embedding_cache_key_ids(embeds) != build_embedding_cache_key_ids(
         different_same_length
     )
+
+
+def test_qwen3_tts_reference_prompt_cache_is_default_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SGLANG_OMNI_QWEN3_TTS_REF_PROMPT_CACHE", raising=False)
+    calls = 0
+
+    class FakeWrapper:
+        def create_voice_clone_prompt(self, **kwargs):
+            nonlocal calls
+            calls += 1
+            return [
+                SimpleNamespace(
+                    ref_code=torch.tensor([[calls]]),
+                    ref_spk_embedding=torch.tensor([float(calls)]),
+                    x_vector_only_mode=kwargs["x_vector_only_mode"],
+                    icl_mode=not kwargs["x_vector_only_mode"],
+                    ref_text=kwargs["ref_text"],
+                )
+            ]
+
+    state = Qwen3TTSState(
+        ref_audio="voice.wav",
+        ref_text="reference",
+        x_vector_only_mode=False,
+    )
+
+    qwen3_request_builders._get_or_create_reference_prompt_items(
+        state, wrapper=FakeWrapper()
+    )
+    qwen3_request_builders._get_or_create_reference_prompt_items(
+        state, wrapper=FakeWrapper()
+    )
+
+    assert calls == 2
+
+
+def test_qwen3_tts_reference_prompt_cache_reuses_and_clones_prompt_items(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_QWEN3_TTS_REF_PROMPT_CACHE", "1")
+
+    fake_qwen_tts = types.ModuleType("qwen_tts")
+    fake_inference = types.ModuleType("qwen_tts.inference")
+    fake_model_mod = types.ModuleType("qwen_tts.inference.qwen3_tts_model")
+
+    class FakeVoiceClonePromptItem:
+        def __init__(
+            self,
+            *,
+            ref_code,
+            ref_spk_embedding,
+            x_vector_only_mode,
+            icl_mode,
+            ref_text=None,
+        ) -> None:
+            self.ref_code = ref_code
+            self.ref_spk_embedding = ref_spk_embedding
+            self.x_vector_only_mode = x_vector_only_mode
+            self.icl_mode = icl_mode
+            self.ref_text = ref_text
+
+    fake_model_mod.VoiceClonePromptItem = FakeVoiceClonePromptItem
+    monkeypatch.setitem(sys.modules, "qwen_tts", fake_qwen_tts)
+    monkeypatch.setitem(sys.modules, "qwen_tts.inference", fake_inference)
+    monkeypatch.setitem(
+        sys.modules,
+        "qwen_tts.inference.qwen3_tts_model",
+        fake_model_mod,
+    )
+
+    calls = 0
+
+    class FakeWrapper:
+        def create_voice_clone_prompt(self, **kwargs):
+            nonlocal calls
+            calls += 1
+            return [
+                FakeVoiceClonePromptItem(
+                    ref_code=torch.tensor([[7, 8]]),
+                    ref_spk_embedding=torch.tensor([1.0, 2.0]),
+                    x_vector_only_mode=kwargs["x_vector_only_mode"],
+                    icl_mode=not kwargs["x_vector_only_mode"],
+                    ref_text=kwargs["ref_text"],
+                )
+            ]
+
+    state = Qwen3TTSState(
+        ref_audio="voice.wav",
+        ref_text="reference",
+        x_vector_only_mode=False,
+    )
+    wrapper = FakeWrapper()
+
+    first = qwen3_request_builders._get_or_create_reference_prompt_items(
+        state, wrapper=wrapper
+    )
+    first[0].ref_code.fill_(99)
+    first[0].ref_spk_embedding.fill_(99)
+    second = qwen3_request_builders._get_or_create_reference_prompt_items(
+        state, wrapper=wrapper
+    )
+
+    assert calls == 1
+    assert second[0].ref_code.tolist() == [[7, 8]]
+    assert second[0].ref_spk_embedding.tolist() == [1.0, 2.0]
+    assert second[0].ref_text == "reference"
+    assert second[0] is not first[0]
 
 
 def test_qwen3_tts_maps_ref_audio_form_and_explicit_sampling() -> None:
@@ -765,8 +882,42 @@ def test_qwen3_tts_request_data_keeps_decode_tensors_on_prepared_device(
     assert isinstance(data.semantic_sampling_seed, int)
     assert 0 <= data.semantic_sampling_seed <= 0x7FFFFFFF
     assert data.req.sampling_params.sampling_seed == data.semantic_sampling_seed
+    assert data.subtalker_dosample is True
     assert isinstance(data.subtalker_sampling_seed, int)
     assert 0 <= data.subtalker_sampling_seed <= 0x7FFFFFFF
+
+
+def test_qwen3_tts_request_data_preserves_explicit_subtalker_dosample(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang(monkeypatch)
+    payload = make_payload(inputs="target")
+    payload.data = {
+        qwen3_request_builders._QWEN3_TTS_PREPARED_MARKER: payload.request_id
+    }
+    prepared = Qwen3TTSPreparedRequest(
+        state=Qwen3TTSState(),
+        input_ids_list=[11, 12],
+        input_ids=torch.tensor([11, 12], dtype=torch.long),
+        attention_mask=torch.ones((1, 2), dtype=torch.long),
+        trailing_text_hidden=torch.randn(1, 4),
+        ref_code=None,
+        prompt_input_embeds=torch.randn(2, 4),
+        tts_pad_embed=torch.randn(4),
+        gen_kwargs={"max_new_tokens": 16, "subtalker_dosample": False},
+    )
+    with qwen3_request_builders._PREPARED_REQUESTS_LOCK:
+        qwen3_request_builders._PREPARED_REQUESTS[payload.request_id] = prepared
+
+    data = build_sglang_qwen3_tts_request(
+        payload,
+        model=SimpleNamespace(
+            config=SimpleNamespace(codec_eos_token_id=42, vocab_size=1200)
+        ),
+        wrapper=object(),
+    )
+
+    assert data.subtalker_dosample is False
 
 
 def test_qwen3_tts_request_data_uses_private_sampling_seeds(
@@ -1665,8 +1816,25 @@ def test_qwen3_tts_compile_backbone_compiles_every_layer(
     ]
 
 
-def test_qwen3_tts_engine_reenables_cuda_graph_after_bootstrap(
+@pytest.mark.parametrize(
+    (
+        "factory_kwargs",
+        "expected_build_disable_cuda_graph",
+        "expected_final_disable_cuda_graph",
+        "expected_init_graph_calls",
+    ),
+    [
+        ({}, False, False, [True]),
+        ({"disable_cuda_graph": True}, True, True, []),
+        ({"server_args_overrides": {"disable_cuda_graph": True}}, True, True, []),
+    ],
+)
+def test_qwen3_tts_engine_cuda_graph_defaults_on_and_can_disable(
     monkeypatch: pytest.MonkeyPatch,
+    factory_kwargs: dict[str, Any],
+    expected_build_disable_cuda_graph: bool,
+    expected_final_disable_cuda_graph: bool,
+    expected_init_graph_calls: list[bool],
 ) -> None:
     """Qwen3-TTS defers graph capture until custom buffers are ready."""
     install_fake_sglang(monkeypatch)
@@ -1788,16 +1956,18 @@ def test_qwen3_tts_engine_reenables_cuda_graph_after_bootstrap(
         lambda **kwargs: SimpleNamespace(**kwargs),
     )
 
-    scheduler = stages.create_sglang_tts_engine_executor("model", device="cuda:0")
+    scheduler = stages.create_sglang_tts_engine_executor(
+        "model", device="cuda:0", **factory_kwargs
+    )
 
-    assert build_kwargs["disable_cuda_graph"] is False
+    assert build_kwargs["disable_cuda_graph"] is expected_build_disable_cuda_graph
     assert build_kwargs["enable_torch_compile"] is True
     assert build_kwargs["sampling_backend"] == "pytorch"
     assert build_kwargs["torch_compile_max_bs"] == 16
     assert infrastructure_saw_graph_disabled == [True]
     assert len(compile_calls) == 1
-    assert init_graph_calls == [True]
-    assert scheduler.server_args.disable_cuda_graph is False
+    assert init_graph_calls == expected_init_graph_calls
+    assert scheduler.server_args.disable_cuda_graph is expected_final_disable_cuda_graph
     assert scheduler.server_args.enable_torch_compile is False
     assert scheduler.server_args.torch_compile_max_bs == 16
     clear_qwen3_tts_preprocessing_context()


### PR DESCRIPTION
## Summary

This PR keeps the Qwen3-TTS 0.6B optimization focused on behavior-preserving serving paths:

- `SGLANG_OMNI_QWEN3_TTS_REF_PROMPT_CACHE=1`: cache repeated voice-clone reference prompt items.
- Keep CUDA graph enabled by default on top of the current torch.compile + CUDA graph bootstrap path.
- CUDA graph can still be explicitly disabled through `disable_cuda_graph=True` or `server_args_overrides={"disable_cuda_graph": True}`.

No greedy subtalker path is included. The original subtalker sampling behavior is preserved.

## Upstream readiness

Rebased onto current `sgl-project/sglang-omni:main` (`0a8da7a`, after #527) and preserved the upstream torch.compile/CUDA graph setup while adding the explicit opt-out knobs.

Checked locally:

```bash
git diff --check
python3 -m py_compile \
  sglang_omni/models/qwen3_tts/request_builders.py \
  sglang_omni/models/qwen3_tts/stages.py \
  tests/unit_test/qwen3_tts/test_pipeline.py
```

Both passed. Local pytest collection is blocked by the local `transformers` version missing `Qwen2_5_VLProcessor`, so the functional test result below is from the H200 validation environment.

## Correctness

Environment:
- Host/container: `ion-h200-8`, `sglang_omni_bbuf`
- GPU: H200, `CUDA_VISIBLE_DEVICES=1`
- Base commit: `e3e9413a3899ab3db5ddc4dcd22baed8089904ab`
- Runtime `PYTHONPATH`: worktree plus `/sgl-workspace/sglang/python`

Command:

```bash
CUDA_VISIBLE_DEVICES=1 \
PYTHONPATH=/tmp/sglang_omni_qwen_pr2_fix:/sgl-workspace/sglang/python \
SGLANG_OMNI_QWEN3_TTS_REF_PROMPT_CACHE=1 \
pytest -q tests/unit_test/qwen3_tts -q
```

Result:

```text
37 passed
```

## Performance

Benchmark workload:

```bash
CUDA_VISIBLE_DEVICES=1 \
PYTHONPATH=DIR:/sgl-workspace/sglang/python \
python -m benchmarks.eval.benchmark_tts_seedtts \
  --generate-only \
  --meta zhaochenyang20/seed-tts-eval-arrow \
  --model Qwen/Qwen3-TTS-12Hz-0.6B-Base \
  --ref-format references \
  --max-samples 16 \
  --concurrency 16 \
  --warmup 1 \
  --max-new-tokens 2048 \
  --lang en \
  --disable-tqdm \
  --port PORT \
  --output-dir REPDIR
```

Median over 3 repetitions on GPU 1:

| metric | baseline | optimized | delta |
| --- | ---: | ---: | ---: |
| throughput_qps | 1.896 | 2.227 | +17.458% |
| latency_mean_s | 4.601 | 3.704 | -19.496% |
| latency_p95_s | 6.735 | 5.831 | -13.422% |
| rtf_mean | 1.0828 | 0.9183 | -15.192% |
| audio_throughput_s_per_s | 8.248 | 9.14 | +10.815% |

Artifact:
`/home/sglang-omni/bbuf/experiments/omni_h200_goal_20260527_1452/artifacts_latest/benchmarks_qwen_pr2_nogreedy_cgdefault_20260528_072124/summary.md`
