### PR TITLE
[Perf] Optimize Higgs TTS reference code caching

### DIFF
--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -245,6 +245,7 @@ def _build_results_config(
         "stream": config.stream,
         "max_samples": config.max_samples,
         "max_new_tokens": config.max_new_tokens,
+        "seed": config.seed,
         "warmup": config.warmup,
         "concurrency": config.concurrency,
         "request_rate": config.request_rate,

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -199,6 +199,7 @@ class TtsSeedttsBenchmarkConfig:
     top_p: float | None = None
     top_k: int | None = None
     repetition_penalty: float | None = None
+    seed: int | None = None
     warmup: int = 1
     concurrency: int = 1
     request_rate: float = float("inf")
@@ -222,6 +223,8 @@ def _build_generation_kwargs(config: TtsSeedttsBenchmarkConfig) -> dict:
         generation_kwargs["top_k"] = config.top_k
     if config.repetition_penalty is not None:
         generation_kwargs["repetition_penalty"] = config.repetition_penalty
+    if config.seed is not None:
+        generation_kwargs["seed"] = config.seed
     return generation_kwargs
 
 
@@ -347,6 +350,7 @@ def _config_from_args(args: argparse.Namespace) -> TtsSeedttsBenchmarkConfig:
         top_p=args.top_p,
         top_k=args.top_k,
         repetition_penalty=args.repetition_penalty,
+        seed=args.seed,
         warmup=args.warmup,
         concurrency=args.concurrency,
         request_rate=args.request_rate,
@@ -437,6 +441,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--top-p", type=float, default=None)
     parser.add_argument("--top-k", type=int, default=None)
     parser.add_argument("--repetition-penalty", type=float, default=None)
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Per-request sampler seed for reproducible generation.",
+    )
     parser.add_argument("--warmup", type=int, default=1)
     parser.add_argument(
         "--concurrency",

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -14,19 +14,9 @@ logger = logging.getLogger(__name__)
 
 _STAGE_TOGGLE_MODE = Literal["default", "on", "off"]
 _QWEN_COLOCATED_CONFIG_CLASS = "Qwen3OmniSpeechColocatedPipelineConfig"
-_HIGGS_PREPROCESSING_FACTORY = (
-    "sglang_omni.models.higgs_tts.stages.create_preprocessing_executor"
-)
-_HIGGS_AUDIO_ENCODER_FACTORY = (
-    "sglang_omni.models.higgs_tts.stages.create_audio_encoder_executor"
-)
 _HIGGS_ASYNC_DECODE_FACTORY = (
     "sglang_omni.models.higgs_tts.stages.create_sglang_tts_engine_executor"
 )
-_HIGGS_REF_CODE_CACHE_FACTORIES = {
-    "preprocessing": _HIGGS_PREPROCESSING_FACTORY,
-    "audio_encoder": _HIGGS_AUDIO_ENCODER_FACTORY,
-}
 
 
 def launch_server(*args: object, **kwargs: object) -> object:
@@ -693,26 +683,6 @@ def apply_async_decode_cli_overrides(
     return pipeline_config
 
 
-def apply_higgs_ref_code_cache_cli_overrides(
-    pipeline_config: PipelineConfig,
-    *,
-    higgs_ref_code_cache: bool,
-) -> PipelineConfig:
-    if higgs_ref_code_cache:
-        return pipeline_config
-
-    for stage_name, factory in _HIGGS_REF_CODE_CACHE_FACTORIES.items():
-        _apply_stage_factory_args_override(
-            pipeline_config,
-            stage_name=stage_name,
-            updates={"enable_ref_code_cache": False},
-            reason="Higgs reference-code cache override",
-            supported_factory=factory,
-            flag_name="--no-higgs-ref-code-cache",
-        )
-    return pipeline_config
-
-
 def apply_torch_compile_cli_overrides(
     pipeline_config: PipelineConfig,
     *,
@@ -962,16 +932,6 @@ def serve(
             ),
         ),
     ] = None,
-    higgs_ref_code_cache: Annotated[
-        bool,
-        typer.Option(
-            "--higgs-ref-code-cache/--no-higgs-ref-code-cache",
-            help=(
-                "Enable Higgs TTS reference audio/code cache. Enabled by "
-                "default for Higgs TTS."
-            ),
-        ),
-    ] = True,
 ) -> None:
     """Serve the pipeline."""
     logging.basicConfig(
@@ -1045,10 +1005,6 @@ def serve(
         merged_config,
         enable_async_decode=enable_async_decode,
         async_decode_min_batch_size=async_decode_min_batch_size,
-    )
-    merged_config = apply_higgs_ref_code_cache_cli_overrides(
-        merged_config,
-        higgs_ref_code_cache=higgs_ref_code_cache,
     )
 
     if _should_print_merged_config(colocate=colocate, log_level=log_level):

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -14,9 +14,19 @@ logger = logging.getLogger(__name__)
 
 _STAGE_TOGGLE_MODE = Literal["default", "on", "off"]
 _QWEN_COLOCATED_CONFIG_CLASS = "Qwen3OmniSpeechColocatedPipelineConfig"
+_HIGGS_PREPROCESSING_FACTORY = (
+    "sglang_omni.models.higgs_tts.stages.create_preprocessing_executor"
+)
+_HIGGS_AUDIO_ENCODER_FACTORY = (
+    "sglang_omni.models.higgs_tts.stages.create_audio_encoder_executor"
+)
 _HIGGS_ASYNC_DECODE_FACTORY = (
     "sglang_omni.models.higgs_tts.stages.create_sglang_tts_engine_executor"
 )
+_HIGGS_REF_CODE_CACHE_FACTORIES = {
+    "preprocessing": _HIGGS_PREPROCESSING_FACTORY,
+    "audio_encoder": _HIGGS_AUDIO_ENCODER_FACTORY,
+}
 
 
 def launch_server(*args: object, **kwargs: object) -> object:
@@ -683,6 +693,26 @@ def apply_async_decode_cli_overrides(
     return pipeline_config
 
 
+def apply_higgs_ref_code_cache_cli_overrides(
+    pipeline_config: PipelineConfig,
+    *,
+    higgs_ref_code_cache: bool,
+) -> PipelineConfig:
+    if higgs_ref_code_cache:
+        return pipeline_config
+
+    for stage_name, factory in _HIGGS_REF_CODE_CACHE_FACTORIES.items():
+        _apply_stage_factory_args_override(
+            pipeline_config,
+            stage_name=stage_name,
+            updates={"enable_ref_code_cache": False},
+            reason="Higgs reference-code cache override",
+            supported_factory=factory,
+            flag_name="--no-higgs-ref-code-cache",
+        )
+    return pipeline_config
+
+
 def apply_torch_compile_cli_overrides(
     pipeline_config: PipelineConfig,
     *,
@@ -932,6 +962,16 @@ def serve(
             ),
         ),
     ] = None,
+    higgs_ref_code_cache: Annotated[
+        bool,
+        typer.Option(
+            "--higgs-ref-code-cache/--no-higgs-ref-code-cache",
+            help=(
+                "Enable Higgs TTS reference audio/code cache. Enabled by "
+                "default for Higgs TTS."
+            ),
+        ),
+    ] = True,
 ) -> None:
     """Serve the pipeline."""
     logging.basicConfig(
@@ -1005,6 +1045,10 @@ def serve(
         merged_config,
         enable_async_decode=enable_async_decode,
         async_decode_min_batch_size=async_decode_min_batch_size,
+    )
+    merged_config = apply_higgs_ref_code_cache_cli_overrides(
+        merged_config,
+        higgs_ref_code_cache=higgs_ref_code_cache,
     )
 
     if _should_print_merged_config(colocate=colocate, log_level=log_level):

--- a/sglang_omni/models/higgs_tts/payload_types.py
+++ b/sglang_omni/models/higgs_tts/payload_types.py
@@ -22,6 +22,7 @@ class HiggsTtsState:
     target_text: str | None = None
     reference_text: str | None = None
     reference_waveform: Any | None = None  # mono 24 kHz [1, 1, L] torch.Tensor
+    reference_cache_key: str | None = None
 
     num_codebooks: int = 8
     codebook_size: int = 1026  # 1024 data + <|boc|> + <|eoc|>
@@ -59,6 +60,8 @@ class HiggsTtsState:
             data["reference_text"] = self.reference_text
         if self.reference_waveform is not None:
             data["reference_waveform"] = self.reference_waveform
+        if self.reference_cache_key is not None:
+            data["reference_cache_key"] = self.reference_cache_key
         for key in ("top_p", "top_k", "seed"):
             value = getattr(self, key)
             if value is not None:
@@ -82,6 +85,7 @@ class HiggsTtsState:
             target_text=data.get("target_text"),
             reference_text=data.get("reference_text"),
             reference_waveform=data.get("reference_waveform"),
+            reference_cache_key=data.get("reference_cache_key"),
             num_codebooks=data.get("num_codebooks", 8),
             codebook_size=data.get("codebook_size", 1026),
             max_new_tokens=data.get("max_new_tokens", 2048),

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -22,8 +22,13 @@ Pipeline shape::
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import logging
 import os
+import threading
+from collections import OrderedDict
+from pathlib import Path
 from typing import Any
 
 import torch
@@ -61,6 +66,102 @@ logger = logging.getLogger(__name__)
 # Codec runs at 75 Hz; chunked prefill of the multi-codebook prompt is unsafe
 # (sampler state machine has no rollback) so reject inputs past chunked_prefill_size.
 _MAX_REF_AUDIO_SEC = 100
+_REF_CODE_CACHE_MAX_ITEMS = 256
+_REF_CODE_CACHE_ENV = "SGLANG_OMNI_HIGGS_REF_CODE_CACHE"
+_REF_WAVEFORM_CACHE_MAX_ITEMS = 256
+
+
+def _ref_code_cache_enabled() -> bool:
+    return os.getenv(_REF_CODE_CACHE_ENV) == "1"
+
+
+def _reference_path_cache_key(path_like: str | Path) -> str | None:
+    path = Path(path_like).expanduser().resolve()
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return f"path:{path}:{stat.st_size}:{stat.st_mtime_ns}"
+
+
+def _reference_audio_cache_key(reference_audio: Any) -> str | None:
+    if isinstance(reference_audio, (str, Path)):
+        return _reference_path_cache_key(reference_audio)
+    if not isinstance(reference_audio, dict):
+        return None
+    path = reference_audio.get("audio_path") or reference_audio.get("path")
+    if path:
+        return _reference_path_cache_key(path)
+    if "bytes" in reference_audio:
+        data = reference_audio["bytes"]
+        if isinstance(data, str):
+            data = data.encode()
+        return "bytes:" + hashlib.blake2b(data, digest_size=16).hexdigest()
+    encoded = reference_audio.get("base64") or reference_audio.get("data")
+    if encoded is None:
+        return None
+    if isinstance(encoded, str):
+        raw = base64.b64decode(encoded)
+    else:
+        raw = bytes(encoded)
+    media_type = reference_audio.get("media_type", "audio/wav")
+    digest = hashlib.blake2b(raw, digest_size=16).hexdigest()
+    return f"base64:{media_type}:{digest}"
+
+
+def _waveform_cache_get(
+    cache: OrderedDict[str, torch.Tensor],
+    lock: threading.Lock,
+    key: str | None,
+) -> torch.Tensor | None:
+    if key is None:
+        return None
+    with lock:
+        cached = cache.get(key)
+        if cached is None:
+            return None
+        cache.move_to_end(key)
+        return cached.clone()
+
+
+def _waveform_cache_put(
+    cache: OrderedDict[str, torch.Tensor],
+    lock: threading.Lock,
+    key: str | None,
+    value: torch.Tensor,
+) -> None:
+    if key is None:
+        return
+    with lock:
+        cache[key] = value.detach().clone()
+        cache.move_to_end(key)
+        while len(cache) > _REF_WAVEFORM_CACHE_MAX_ITEMS:
+            cache.popitem(last=False)
+
+
+def _cache_get(
+    cache: OrderedDict[str, list[list[int]]], key: str | None
+) -> list[list[int]] | None:
+    if key is None:
+        return None
+    cached = cache.get(key)
+    if cached is None:
+        return None
+    cache.move_to_end(key)
+    return [list(row) for row in cached]
+
+
+def _cache_put(
+    cache: OrderedDict[str, list[list[int]]],
+    key: str | None,
+    value: list[list[int]],
+) -> None:
+    if key is None:
+        return
+    cache[key] = [list(row) for row in value]
+    cache.move_to_end(key)
+    while len(cache) > _REF_CODE_CACHE_MAX_ITEMS:
+        cache.popitem(last=False)
 
 
 def create_preprocessing_executor(
@@ -84,6 +185,8 @@ def create_preprocessing_executor(
     raw = Tokenizer.from_file(os.path.join(checkpoint_dir, "tokenizer.json"))
     tokenizer = PreTrainedTokenizerFast(tokenizer_object=raw)
     adapter = HiggsTokenizerAdapter(tokenizer)
+    reference_waveform_cache: OrderedDict[str, torch.Tensor] = OrderedDict()
+    reference_waveform_cache_lock = threading.Lock()
 
     def _preprocess(payload: StagePayload) -> StagePayload:
         inputs = payload.request.inputs or {}
@@ -117,17 +220,34 @@ def create_preprocessing_executor(
             )
 
         waveform_tensor = None
+        reference_cache_key = None
         if ref_codes_TN is None and inputs.get("reference_audio") is not None:
-            waveform_np, sample_rate = load_audio_to_24k(inputs["reference_audio"])
-            wav = torch.from_numpy(waveform_np)
-            if sample_rate != 24000:
-                wav = F_audio.resample(wav, sample_rate, 24000)
-            if wav.shape[-1] > _MAX_REF_AUDIO_SEC * 24000:
-                raise ValueError(
-                    f"reference_audio is too long "
-                    f"({wav.shape[-1] / 24000:.1f}s); cap at {_MAX_REF_AUDIO_SEC}s."
+            reference_audio = inputs["reference_audio"]
+            reference_cache_key = _reference_audio_cache_key(reference_audio)
+            if _ref_code_cache_enabled():
+                waveform_tensor = _waveform_cache_get(
+                    reference_waveform_cache,
+                    reference_waveform_cache_lock,
+                    reference_cache_key,
                 )
-            waveform_tensor = wav.view(1, 1, -1).contiguous().float()
+            if waveform_tensor is None:
+                waveform_np, sample_rate = load_audio_to_24k(reference_audio)
+                wav = torch.from_numpy(waveform_np)
+                if sample_rate != 24000:
+                    wav = F_audio.resample(wav, sample_rate, 24000)
+                if wav.shape[-1] > _MAX_REF_AUDIO_SEC * 24000:
+                    raise ValueError(
+                        f"reference_audio is too long "
+                        f"({wav.shape[-1] / 24000:.1f}s); cap at {_MAX_REF_AUDIO_SEC}s."
+                    )
+                waveform_tensor = wav.view(1, 1, -1).contiguous().float()
+                if _ref_code_cache_enabled():
+                    _waveform_cache_put(
+                        reference_waveform_cache,
+                        reference_waveform_cache_lock,
+                        reference_cache_key,
+                        waveform_tensor,
+                    )
 
         if ref_codes_TN is not None:
             delayed = apply_delay_pattern(ref_codes_TN)
@@ -156,6 +276,7 @@ def create_preprocessing_executor(
             prompt_token_ids=prompt_ids,
             reference_codes_delayed=ref_codes_delayed,
             reference_waveform=waveform_tensor,
+            reference_cache_key=reference_cache_key,
             target_text=target_text_for_encoder,
             reference_text=reference_text_for_encoder,
             num_codebooks=num_codebooks,
@@ -199,6 +320,7 @@ def create_audio_encoder_executor(
     codec.encode_reference(
         torch.zeros(codec.SAMPLE_RATE), sample_rate=codec.SAMPLE_RATE
     )
+    reference_code_cache: OrderedDict[str, list[list[int]]] = OrderedDict()
 
     def _encode(payload: StagePayload) -> StagePayload:
         state = HiggsTtsState.from_dict(payload.data)
@@ -206,22 +328,36 @@ def create_audio_encoder_executor(
         if waveform is None:
             return payload
 
-        ref_codes_TN = codec.encode_reference(waveform, sample_rate=24000).to(
-            torch.long
+        delayed_rows = (
+            _cache_get(reference_code_cache, state.reference_cache_key)
+            if _ref_code_cache_enabled()
+            else None
         )
-        if ref_codes_TN.ndim != 2 or ref_codes_TN.shape[1] != num_codebooks:
-            raise ValueError(
-                f"codec output must be [T, {num_codebooks}], got "
-                f"{tuple(ref_codes_TN.shape)}"
+        if delayed_rows is None:
+            ref_codes_TN = codec.encode_reference(waveform, sample_rate=24000).to(
+                torch.long
             )
-        delayed = apply_delay_pattern(ref_codes_TN)
-        state.reference_codes_delayed = delayed.tolist()
+            if ref_codes_TN.ndim != 2 or ref_codes_TN.shape[1] != num_codebooks:
+                raise ValueError(
+                    f"codec output must be [T, {num_codebooks}], got "
+                    f"{tuple(ref_codes_TN.shape)}"
+                )
+            delayed = apply_delay_pattern(ref_codes_TN)
+            delayed_rows = delayed.tolist()
+            if _ref_code_cache_enabled():
+                _cache_put(
+                    reference_code_cache,
+                    state.reference_cache_key,
+                    delayed_rows,
+                )
+        state.reference_codes_delayed = delayed_rows
         state.prompt_token_ids = adapter.build_prompt(
             state.target_text or "",
-            num_ref_tokens=delayed.shape[0],
+            num_ref_tokens=len(delayed_rows),
             reference_text=state.reference_text,
         )
         state.reference_waveform = None
+        state.reference_cache_key = None
         state.target_text = None
         state.reference_text = None
         payload.data = state.to_dict()

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -76,8 +76,7 @@ def _ref_code_cache_enabled() -> bool:
 
 
 def _reference_audio_cache_key(reference_audio: Any) -> str | None:
-    """Stable cache key for a reference-audio input.
-    """
+    """Stable cache key for a reference-audio input."""
     if isinstance(reference_audio, (str, Path)):
         return hash_media_item(reference_audio)
     if not isinstance(reference_audio, dict):

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -45,10 +45,10 @@ from sglang_omni.models.higgs_tts.utils import (
     to_codes_TN,
     truncate_rope_to_bf16,
 )
-from sglang_omni.preprocessing.cache_key import hash_bytes, hash_media_item
 from sglang_omni.models.higgs_tts.vocoder_scheduler import (
     HiggsStreamingVocoderScheduler,
 )
+from sglang_omni.preprocessing.cache_key import hash_bytes, hash_media_item
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -111,7 +111,6 @@ def create_preprocessing_executor(
     num_codebooks: int = 8,
     codebook_size: int = 1026,
     max_concurrency: int = 8,
-    enable_ref_code_cache: bool = True,
 ):
     """CPU stage: text tokenize + optional ref-audio file IO.
 
@@ -133,7 +132,6 @@ def create_preprocessing_executor(
         max_bytes=_REF_WAVEFORM_CACHE_MAX_BYTES,
     )
     reference_waveform_cache_lock = threading.Lock()
-    reference_cache_enabled = bool(enable_ref_code_cache)
 
     def _preprocess(payload: StagePayload) -> StagePayload:
         inputs = payload.request.inputs or {}
@@ -170,12 +168,11 @@ def create_preprocessing_executor(
         reference_cache_key = None
         if ref_codes_TN is None and inputs.get("reference_audio") is not None:
             reference_audio = inputs["reference_audio"]
-            if reference_cache_enabled:
-                reference_cache_key = _reference_audio_cache_key(reference_audio)
-                with reference_waveform_cache_lock:
-                    cached_waveform = reference_waveform_cache.get(reference_cache_key)
-                if cached_waveform is not None:
-                    waveform_tensor = cached_waveform.clone()
+            reference_cache_key = _reference_audio_cache_key(reference_audio)
+            with reference_waveform_cache_lock:
+                cached_waveform = reference_waveform_cache.get(reference_cache_key)
+            if cached_waveform is not None:
+                waveform_tensor = cached_waveform.clone()
             if waveform_tensor is None:
                 waveform_np, sample_rate = load_audio_to_24k(reference_audio)
                 wav = torch.from_numpy(waveform_np)
@@ -187,11 +184,10 @@ def create_preprocessing_executor(
                         f"({wav.shape[-1] / 24000:.1f}s); cap at {_MAX_REF_AUDIO_SEC}s."
                     )
                 waveform_tensor = wav.view(1, 1, -1).contiguous().float()
-                if reference_cache_enabled:
-                    with reference_waveform_cache_lock:
-                        reference_waveform_cache.put(
-                            reference_cache_key, waveform_tensor.clone()
-                        )
+                with reference_waveform_cache_lock:
+                    reference_waveform_cache.put(
+                        reference_cache_key, waveform_tensor.clone()
+                    )
 
         if ref_codes_TN is not None:
             delayed = apply_delay_pattern(ref_codes_TN)
@@ -245,7 +241,6 @@ def create_audio_encoder_executor(
     num_codebooks: int = 8,
     max_batch_size: int = 8,
     max_batch_wait_ms: int = 2,
-    enable_ref_code_cache: bool = True,
 ):
     """GPU stage: codec-encode raw ref audio → delayed codes + prompt assembly.
 
@@ -272,7 +267,6 @@ def create_audio_encoder_executor(
         max_bytes=_REF_CODE_CACHE_MAX_BYTES,
         cache_device="cpu",
     )
-    reference_cache_enabled = bool(enable_ref_code_cache)
 
     def _encode(payload: StagePayload) -> StagePayload:
         state = HiggsTtsState.from_dict(payload.data)
@@ -280,11 +274,7 @@ def create_audio_encoder_executor(
         if waveform is None:
             return payload
 
-        cached_delayed = (
-            reference_code_cache.get(state.reference_cache_key)
-            if reference_cache_enabled
-            else None
-        )
+        cached_delayed = reference_code_cache.get(state.reference_cache_key)
         if cached_delayed is not None:
             delayed_rows = cached_delayed.tolist()
         else:
@@ -298,10 +288,9 @@ def create_audio_encoder_executor(
                 )
             delayed = apply_delay_pattern(ref_codes_TN)
             delayed_rows = delayed.tolist()
-            if reference_cache_enabled:
-                reference_code_cache.put(
-                    state.reference_cache_key, delayed.to("cpu", torch.int32)
-                )
+            reference_code_cache.put(
+                state.reference_cache_key, delayed.to("cpu", torch.int32)
+            )
         state.reference_codes_delayed = delayed_rows
         state.prompt_token_ids = adapter.build_prompt(
             state.target_text or "",

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -48,7 +48,7 @@ from sglang_omni.models.higgs_tts.utils import (
     to_codes_TN,
     truncate_rope_to_bf16,
 )
-from sglang_omni.preprocessing.cache_key import hash_media_item
+from sglang_omni.preprocessing.cache_key import hash_bytes, hash_media_item
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler
@@ -67,23 +67,37 @@ logger = logging.getLogger(__name__)
 # (sampler state machine has no rollback) so reject inputs past chunked_prefill_size.
 _MAX_REF_AUDIO_SEC = 100
 _REF_CODE_CACHE_MAX_ITEMS = 256
+_REF_CODE_CACHE_MAX_BYTES = 256 * 1024 * 1024
 _REF_CODE_CACHE_ENV = "SGLANG_OMNI_HIGGS_REF_CODE_CACHE"
 _REF_WAVEFORM_CACHE_MAX_ITEMS = 256
+_REF_WAVEFORM_CACHE_MAX_BYTES = 512 * 1024 * 1024
 
 
 def _ref_code_cache_enabled() -> bool:
     return os.getenv(_REF_CODE_CACHE_ENV) == "1"
 
 
+def _reference_path_cache_key(path_like: str | Path) -> str | None:
+    # Full-content hash, not hash_media_item's sampled head/tail+size hash
+    # (which stale-hits a same-size middle edit). None for URLs/missing files.
+    try:
+        path = Path(str(path_like)).expanduser()
+        if not path.is_file():
+            return None
+        return f"file:{hash_bytes(path.read_bytes())}"
+    except OSError:
+        return None
+
+
 def _reference_audio_cache_key(reference_audio: Any) -> str | None:
     """Stable cache key for a reference-audio input."""
     if isinstance(reference_audio, (str, Path)):
-        return hash_media_item(reference_audio)
+        return _reference_path_cache_key(reference_audio)
     if not isinstance(reference_audio, dict):
         return None
     path = reference_audio.get("audio_path") or reference_audio.get("path")
     if path:
-        return hash_media_item(path)
+        return _reference_path_cache_key(path)
     if "bytes" in reference_audio:
         data = reference_audio["bytes"]
         if isinstance(data, str):
@@ -118,7 +132,11 @@ def create_preprocessing_executor(
     tokenizer = PreTrainedTokenizerFast(tokenizer_object=raw)
     adapter = HiggsTokenizerAdapter(tokenizer)
     # Runs on a ThreadedSimpleScheduler pool for preprocessing;
-    reference_waveform_cache = StageOutputCache(max_size=_REF_WAVEFORM_CACHE_MAX_ITEMS)
+    reference_waveform_cache = StageOutputCache(
+        max_size=_REF_WAVEFORM_CACHE_MAX_ITEMS,
+        max_bytes=_REF_WAVEFORM_CACHE_MAX_BYTES,
+        cache_device="cpu",
+    )
     reference_waveform_cache_lock = threading.Lock()
 
     def _preprocess(payload: StagePayload) -> StagePayload:
@@ -251,8 +269,13 @@ def create_audio_encoder_executor(
     codec.encode_reference(
         torch.zeros(codec.SAMPLE_RATE), sample_rate=codec.SAMPLE_RATE
     )
-    # Single-threaded SimpleScheduler stage, so no lock needed.
-    reference_code_cache = StageOutputCache(max_size=_REF_CODE_CACHE_MAX_ITEMS)
+    # Single-threaded SimpleScheduler stage, so no lock needed. Cache a CPU
+    # tensor (not list[list[int]]) so StageOutputCache can byte-bound it.
+    reference_code_cache = StageOutputCache(
+        max_size=_REF_CODE_CACHE_MAX_ITEMS,
+        max_bytes=_REF_CODE_CACHE_MAX_BYTES,
+        cache_device="cpu",
+    )
 
     def _encode(payload: StagePayload) -> StagePayload:
         state = HiggsTtsState.from_dict(payload.data)
@@ -261,12 +284,14 @@ def create_audio_encoder_executor(
             return payload
 
         cache_enabled = _ref_code_cache_enabled()
-        delayed_rows = (
+        cached_delayed = (
             reference_code_cache.get(state.reference_cache_key)
             if cache_enabled
             else None
         )
-        if delayed_rows is None:
+        if cached_delayed is not None:
+            delayed_rows = cached_delayed.tolist()
+        else:
             ref_codes_TN = codec.encode_reference(waveform, sample_rate=24000).to(
                 torch.long
             )
@@ -278,7 +303,9 @@ def create_audio_encoder_executor(
             delayed = apply_delay_pattern(ref_codes_TN)
             delayed_rows = delayed.tolist()
             if cache_enabled:
-                reference_code_cache.put(state.reference_cache_key, delayed_rows)
+                reference_code_cache.put(
+                    state.reference_cache_key, delayed.to("cpu", torch.int32)
+                )
         state.reference_codes_delayed = delayed_rows
         state.prompt_token_ids = adapter.build_prompt(
             state.target_text or "",

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -25,6 +25,7 @@ import base64
 import logging
 import os
 import threading
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any
 
@@ -70,18 +71,87 @@ _REF_CODE_CACHE_MAX_ITEMS = 256
 _REF_CODE_CACHE_MAX_BYTES = 256 * 1024 * 1024
 _REF_WAVEFORM_CACHE_MAX_ITEMS = 256
 _REF_WAVEFORM_CACHE_MAX_BYTES = 512 * 1024 * 1024
+_REF_PATH_HASH_MEMO_MAX_ITEMS = 1024
+_REF_PATH_HASH_SENTINEL_BYTES = 8192
+_REF_PATH_HASH_MEMO: OrderedDict[str, tuple[str, str]] = OrderedDict()
+_REF_PATH_HASH_MEMO_LOCK = threading.Lock()
+
+
+def _reference_path_hash_memo_key(path: Path) -> tuple[str, int] | None:
+    try:
+        if not path.is_file():
+            return None
+        stat_result = path.stat()
+        memo_key = (
+            f"{path.resolve()}:"
+            f"{stat_result.st_size}:"
+            f"{stat_result.st_mtime_ns}:"
+            f"{stat_result.st_ctime_ns}"
+        )
+        return memo_key, int(stat_result.st_size)
+    except OSError:
+        return None
+
+
+def _reference_path_sentinel(path: Path, file_size: int) -> str | None:
+    try:
+        chunk_size = min(_REF_PATH_HASH_SENTINEL_BYTES, file_size)
+        with path.open("rb") as f:
+            chunks = [f.read(chunk_size)]
+            if file_size > _REF_PATH_HASH_SENTINEL_BYTES:
+                middle_offset = max((file_size - chunk_size) // 2, 0)
+                f.seek(middle_offset)
+                chunks.append(f.read(chunk_size))
+            if file_size > 2 * _REF_PATH_HASH_SENTINEL_BYTES:
+                f.seek(max(file_size - chunk_size, 0))
+                chunks.append(f.read(chunk_size))
+        return hash_bytes(b"".join(chunks) + f"|size:{file_size}".encode())
+    except OSError:
+        return None
+
+
+def _get_reference_path_hash(memo_key: str, sentinel: str) -> str | None:
+    with _REF_PATH_HASH_MEMO_LOCK:
+        cached = _REF_PATH_HASH_MEMO.get(memo_key)
+        if cached is None:
+            return None
+        cached_sentinel, digest = cached
+        if cached_sentinel != sentinel:
+            _REF_PATH_HASH_MEMO.pop(memo_key, None)
+            return None
+        _REF_PATH_HASH_MEMO.move_to_end(memo_key)
+        return digest
+
+
+def _put_reference_path_hash(memo_key: str, sentinel: str, digest: str) -> None:
+    with _REF_PATH_HASH_MEMO_LOCK:
+        _REF_PATH_HASH_MEMO[memo_key] = (sentinel, digest)
+        _REF_PATH_HASH_MEMO.move_to_end(memo_key)
+        while len(_REF_PATH_HASH_MEMO) > _REF_PATH_HASH_MEMO_MAX_ITEMS:
+            _REF_PATH_HASH_MEMO.popitem(last=False)
 
 
 def _reference_path_cache_key(path_like: str | Path) -> str | None:
-    # Full-content hash, not hash_media_item's sampled head/tail+size hash
-    # (which stale-hits a same-size middle edit). None for URLs/missing files.
+    # Memoized full-content hash. The stat tuple avoids rereading stable local
+    # refs while still invalidating normal and rapid same-size replacements.
+    path = Path(str(path_like)).expanduser()
+    memo = _reference_path_hash_memo_key(path)
+    if memo is None:
+        return None
+    memo_key, file_size = memo
+    sentinel = _reference_path_sentinel(path, file_size)
+    if sentinel is None:
+        return None
+    digest = _get_reference_path_hash(memo_key, sentinel)
+    if digest is not None:
+        return f"file:{digest}"
     try:
-        path = Path(str(path_like)).expanduser()
-        if not path.is_file():
-            return None
-        return f"file:{hash_bytes(path.read_bytes())}"
+        digest = hash_bytes(path.read_bytes())
     except OSError:
         return None
+    if _reference_path_hash_memo_key(path) == memo:
+        _put_reference_path_hash(memo_key, sentinel, digest)
+    return f"file:{digest}"
 
 
 def _reference_audio_cache_key(reference_audio: Any) -> str | None:

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -135,7 +135,6 @@ def create_preprocessing_executor(
     reference_waveform_cache = StageOutputCache(
         max_size=_REF_WAVEFORM_CACHE_MAX_ITEMS,
         max_bytes=_REF_WAVEFORM_CACHE_MAX_BYTES,
-        cache_device="cpu",
     )
     reference_waveform_cache_lock = threading.Lock()
 
@@ -195,7 +194,7 @@ def create_preprocessing_executor(
                 if cache_enabled:
                     with reference_waveform_cache_lock:
                         reference_waveform_cache.put(
-                            reference_cache_key, waveform_tensor
+                            reference_cache_key, waveform_tensor.clone()
                         )
 
         if ref_codes_TN is not None:

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -23,11 +23,9 @@ Pipeline shape::
 from __future__ import annotations
 
 import base64
-import hashlib
 import logging
 import os
 import threading
-from collections import OrderedDict
 from pathlib import Path
 from typing import Any
 
@@ -50,6 +48,7 @@ from sglang_omni.models.higgs_tts.utils import (
     to_codes_TN,
     truncate_rope_to_bf16,
 )
+from sglang_omni.preprocessing.cache_key import hash_media_item
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler
@@ -58,6 +57,7 @@ from sglang_omni.scheduling.sglang_backend import (
     build_sglang_server_args,
 )
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+from sglang_omni.scheduling.stage_cache import StageOutputCache
 from sglang_omni.scheduling.threaded_simple_scheduler import ThreadedSimpleScheduler
 
 logger = logging.getLogger(__name__)
@@ -75,93 +75,26 @@ def _ref_code_cache_enabled() -> bool:
     return os.getenv(_REF_CODE_CACHE_ENV) == "1"
 
 
-def _reference_path_cache_key(path_like: str | Path) -> str | None:
-    path = Path(path_like).expanduser().resolve()
-    try:
-        stat = path.stat()
-    except OSError:
-        return None
-    return f"path:{path}:{stat.st_size}:{stat.st_mtime_ns}"
-
-
 def _reference_audio_cache_key(reference_audio: Any) -> str | None:
+    """Stable cache key for a reference-audio input.
+    """
     if isinstance(reference_audio, (str, Path)):
-        return _reference_path_cache_key(reference_audio)
+        return hash_media_item(reference_audio)
     if not isinstance(reference_audio, dict):
         return None
     path = reference_audio.get("audio_path") or reference_audio.get("path")
     if path:
-        return _reference_path_cache_key(path)
+        return hash_media_item(path)
     if "bytes" in reference_audio:
         data = reference_audio["bytes"]
         if isinstance(data, str):
             data = data.encode()
-        return "bytes:" + hashlib.blake2b(data, digest_size=16).hexdigest()
+        return hash_media_item(data)
     encoded = reference_audio.get("base64") or reference_audio.get("data")
     if encoded is None:
         return None
-    if isinstance(encoded, str):
-        raw = base64.b64decode(encoded)
-    else:
-        raw = bytes(encoded)
-    media_type = reference_audio.get("media_type", "audio/wav")
-    digest = hashlib.blake2b(raw, digest_size=16).hexdigest()
-    return f"base64:{media_type}:{digest}"
-
-
-def _waveform_cache_get(
-    cache: OrderedDict[str, torch.Tensor],
-    lock: threading.Lock,
-    key: str | None,
-) -> torch.Tensor | None:
-    if key is None:
-        return None
-    with lock:
-        cached = cache.get(key)
-        if cached is None:
-            return None
-        cache.move_to_end(key)
-        return cached.clone()
-
-
-def _waveform_cache_put(
-    cache: OrderedDict[str, torch.Tensor],
-    lock: threading.Lock,
-    key: str | None,
-    value: torch.Tensor,
-) -> None:
-    if key is None:
-        return
-    with lock:
-        cache[key] = value.detach().clone()
-        cache.move_to_end(key)
-        while len(cache) > _REF_WAVEFORM_CACHE_MAX_ITEMS:
-            cache.popitem(last=False)
-
-
-def _cache_get(
-    cache: OrderedDict[str, list[list[int]]], key: str | None
-) -> list[list[int]] | None:
-    if key is None:
-        return None
-    cached = cache.get(key)
-    if cached is None:
-        return None
-    cache.move_to_end(key)
-    return [list(row) for row in cached]
-
-
-def _cache_put(
-    cache: OrderedDict[str, list[list[int]]],
-    key: str | None,
-    value: list[list[int]],
-) -> None:
-    if key is None:
-        return
-    cache[key] = [list(row) for row in value]
-    cache.move_to_end(key)
-    while len(cache) > _REF_CODE_CACHE_MAX_ITEMS:
-        cache.popitem(last=False)
+    raw = base64.b64decode(encoded) if isinstance(encoded, str) else bytes(encoded)
+    return hash_media_item(raw)
 
 
 def create_preprocessing_executor(
@@ -185,7 +118,8 @@ def create_preprocessing_executor(
     raw = Tokenizer.from_file(os.path.join(checkpoint_dir, "tokenizer.json"))
     tokenizer = PreTrainedTokenizerFast(tokenizer_object=raw)
     adapter = HiggsTokenizerAdapter(tokenizer)
-    reference_waveform_cache: OrderedDict[str, torch.Tensor] = OrderedDict()
+    # Runs on a ThreadedSimpleScheduler pool for preprocessing;
+    reference_waveform_cache = StageOutputCache(max_size=_REF_WAVEFORM_CACHE_MAX_ITEMS)
     reference_waveform_cache_lock = threading.Lock()
 
     def _preprocess(payload: StagePayload) -> StagePayload:
@@ -223,13 +157,13 @@ def create_preprocessing_executor(
         reference_cache_key = None
         if ref_codes_TN is None and inputs.get("reference_audio") is not None:
             reference_audio = inputs["reference_audio"]
-            reference_cache_key = _reference_audio_cache_key(reference_audio)
-            if _ref_code_cache_enabled():
-                waveform_tensor = _waveform_cache_get(
-                    reference_waveform_cache,
-                    reference_waveform_cache_lock,
-                    reference_cache_key,
-                )
+            cache_enabled = _ref_code_cache_enabled()
+            if cache_enabled:
+                reference_cache_key = _reference_audio_cache_key(reference_audio)
+                with reference_waveform_cache_lock:
+                    cached_waveform = reference_waveform_cache.get(reference_cache_key)
+                if cached_waveform is not None:
+                    waveform_tensor = cached_waveform.clone()
             if waveform_tensor is None:
                 waveform_np, sample_rate = load_audio_to_24k(reference_audio)
                 wav = torch.from_numpy(waveform_np)
@@ -241,13 +175,11 @@ def create_preprocessing_executor(
                         f"({wav.shape[-1] / 24000:.1f}s); cap at {_MAX_REF_AUDIO_SEC}s."
                     )
                 waveform_tensor = wav.view(1, 1, -1).contiguous().float()
-                if _ref_code_cache_enabled():
-                    _waveform_cache_put(
-                        reference_waveform_cache,
-                        reference_waveform_cache_lock,
-                        reference_cache_key,
-                        waveform_tensor,
-                    )
+                if cache_enabled:
+                    with reference_waveform_cache_lock:
+                        reference_waveform_cache.put(
+                            reference_cache_key, waveform_tensor
+                        )
 
         if ref_codes_TN is not None:
             delayed = apply_delay_pattern(ref_codes_TN)
@@ -320,7 +252,8 @@ def create_audio_encoder_executor(
     codec.encode_reference(
         torch.zeros(codec.SAMPLE_RATE), sample_rate=codec.SAMPLE_RATE
     )
-    reference_code_cache: OrderedDict[str, list[list[int]]] = OrderedDict()
+    # Single-threaded SimpleScheduler stage, so no lock needed.
+    reference_code_cache = StageOutputCache(max_size=_REF_CODE_CACHE_MAX_ITEMS)
 
     def _encode(payload: StagePayload) -> StagePayload:
         state = HiggsTtsState.from_dict(payload.data)
@@ -328,9 +261,10 @@ def create_audio_encoder_executor(
         if waveform is None:
             return payload
 
+        cache_enabled = _ref_code_cache_enabled()
         delayed_rows = (
-            _cache_get(reference_code_cache, state.reference_cache_key)
-            if _ref_code_cache_enabled()
+            reference_code_cache.get(state.reference_cache_key)
+            if cache_enabled
             else None
         )
         if delayed_rows is None:
@@ -344,12 +278,8 @@ def create_audio_encoder_executor(
                 )
             delayed = apply_delay_pattern(ref_codes_TN)
             delayed_rows = delayed.tolist()
-            if _ref_code_cache_enabled():
-                _cache_put(
-                    reference_code_cache,
-                    state.reference_cache_key,
-                    delayed_rows,
-                )
+            if cache_enabled:
+                reference_code_cache.put(state.reference_cache_key, delayed_rows)
         state.reference_codes_delayed = delayed_rows
         state.prompt_token_ids = adapter.build_prompt(
             state.target_text or "",

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -68,13 +68,8 @@ logger = logging.getLogger(__name__)
 _MAX_REF_AUDIO_SEC = 100
 _REF_CODE_CACHE_MAX_ITEMS = 256
 _REF_CODE_CACHE_MAX_BYTES = 256 * 1024 * 1024
-_REF_CODE_CACHE_ENV = "SGLANG_OMNI_HIGGS_REF_CODE_CACHE"
 _REF_WAVEFORM_CACHE_MAX_ITEMS = 256
 _REF_WAVEFORM_CACHE_MAX_BYTES = 512 * 1024 * 1024
-
-
-def _ref_code_cache_enabled() -> bool:
-    return os.getenv(_REF_CODE_CACHE_ENV) == "1"
 
 
 def _reference_path_cache_key(path_like: str | Path) -> str | None:
@@ -116,6 +111,7 @@ def create_preprocessing_executor(
     num_codebooks: int = 8,
     codebook_size: int = 1026,
     max_concurrency: int = 8,
+    enable_ref_code_cache: bool = True,
 ):
     """CPU stage: text tokenize + optional ref-audio file IO.
 
@@ -137,6 +133,7 @@ def create_preprocessing_executor(
         max_bytes=_REF_WAVEFORM_CACHE_MAX_BYTES,
     )
     reference_waveform_cache_lock = threading.Lock()
+    reference_cache_enabled = bool(enable_ref_code_cache)
 
     def _preprocess(payload: StagePayload) -> StagePayload:
         inputs = payload.request.inputs or {}
@@ -173,8 +170,7 @@ def create_preprocessing_executor(
         reference_cache_key = None
         if ref_codes_TN is None and inputs.get("reference_audio") is not None:
             reference_audio = inputs["reference_audio"]
-            cache_enabled = _ref_code_cache_enabled()
-            if cache_enabled:
+            if reference_cache_enabled:
                 reference_cache_key = _reference_audio_cache_key(reference_audio)
                 with reference_waveform_cache_lock:
                     cached_waveform = reference_waveform_cache.get(reference_cache_key)
@@ -191,7 +187,7 @@ def create_preprocessing_executor(
                         f"({wav.shape[-1] / 24000:.1f}s); cap at {_MAX_REF_AUDIO_SEC}s."
                     )
                 waveform_tensor = wav.view(1, 1, -1).contiguous().float()
-                if cache_enabled:
+                if reference_cache_enabled:
                     with reference_waveform_cache_lock:
                         reference_waveform_cache.put(
                             reference_cache_key, waveform_tensor.clone()
@@ -249,6 +245,7 @@ def create_audio_encoder_executor(
     num_codebooks: int = 8,
     max_batch_size: int = 8,
     max_batch_wait_ms: int = 2,
+    enable_ref_code_cache: bool = True,
 ):
     """GPU stage: codec-encode raw ref audio → delayed codes + prompt assembly.
 
@@ -275,6 +272,7 @@ def create_audio_encoder_executor(
         max_bytes=_REF_CODE_CACHE_MAX_BYTES,
         cache_device="cpu",
     )
+    reference_cache_enabled = bool(enable_ref_code_cache)
 
     def _encode(payload: StagePayload) -> StagePayload:
         state = HiggsTtsState.from_dict(payload.data)
@@ -282,10 +280,9 @@ def create_audio_encoder_executor(
         if waveform is None:
             return payload
 
-        cache_enabled = _ref_code_cache_enabled()
         cached_delayed = (
             reference_code_cache.get(state.reference_cache_key)
-            if cache_enabled
+            if reference_cache_enabled
             else None
         )
         if cached_delayed is not None:
@@ -301,7 +298,7 @@ def create_audio_encoder_executor(
                 )
             delayed = apply_delay_pattern(ref_codes_TN)
             delayed_rows = delayed.tolist()
-            if cache_enabled:
+            if reference_cache_enabled:
                 reference_code_cache.put(
                     state.reference_cache_key, delayed.to("cpu", torch.int32)
                 )

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import numpy as np
 import torch
 
+from sglang_omni.cli.serve import apply_higgs_ref_code_cache_cli_overrides
 from sglang_omni.models.higgs_tts import stages
 from sglang_omni.models.higgs_tts.config import HiggsTtsPipelineConfig
 from sglang_omni.models.higgs_tts.model_runner import HiggsTTSModelRunner
@@ -25,6 +26,24 @@ def test_higgs_streaming_pipeline_routes_chunks_to_vocoder() -> None:
 
     assert stages_by_name["tts_engine"].stream_to == ["vocoder"]
     assert stages_by_name["vocoder"].can_accept_stream_before_payload is True
+
+
+def test_higgs_ref_code_cache_server_arg_disables_cache_stages() -> None:
+    config = HiggsTtsPipelineConfig(model_path="fake-model")
+
+    apply_higgs_ref_code_cache_cli_overrides(
+        config,
+        higgs_ref_code_cache=False,
+    )
+
+    stages_by_name = {stage.name: stage for stage in config.stages}
+    assert (
+        stages_by_name["preprocessing"].factory_args["enable_ref_code_cache"] is False
+    )
+    assert (
+        stages_by_name["audio_encoder"].factory_args["enable_ref_code_cache"] is False
+    )
+    assert "enable_ref_code_cache" not in stages_by_name["tts_engine"].factory_args
 
 
 def test_higgs_tts_engine_enables_cuda_graph_by_default(monkeypatch) -> None:
@@ -160,8 +179,7 @@ def test_higgs_reference_cache_key_ignores_media_type() -> None:
     assert stages._reference_audio_cache_key({"bytes": raw}) == key_wav
 
 
-def test_higgs_audio_encoder_uses_guarded_reference_code_cache(monkeypatch) -> None:
-    monkeypatch.setenv("SGLANG_OMNI_HIGGS_REF_CODE_CACHE", "1")
+def test_higgs_audio_encoder_uses_reference_code_cache_by_default(monkeypatch) -> None:
     monkeypatch.setattr(stages, "resolve_checkpoint", lambda model_path: model_path)
     monkeypatch.setattr(
         stages.Tokenizer,
@@ -234,8 +252,7 @@ def test_higgs_audio_encoder_uses_guarded_reference_code_cache(monkeypatch) -> N
     assert "reference_cache_key" not in second.data
 
 
-def test_higgs_audio_encoder_cache_is_env_guarded(monkeypatch) -> None:
-    monkeypatch.delenv("SGLANG_OMNI_HIGGS_REF_CODE_CACHE", raising=False)
+def test_higgs_audio_encoder_cache_can_be_disabled_by_server_arg(monkeypatch) -> None:
     monkeypatch.setattr(stages, "resolve_checkpoint", lambda model_path: model_path)
     monkeypatch.setattr(stages.Tokenizer, "from_file", lambda _path: object())
     monkeypatch.setattr(
@@ -271,6 +288,7 @@ def test_higgs_audio_encoder_cache_is_env_guarded(monkeypatch) -> None:
         "ckpt",
         device="cuda:0",
         num_codebooks=2,
+        enable_ref_code_cache=False,
     )
     # Ignore the construction-time codec warm-up call added by #612.
     fake_codec.calls = 0
@@ -293,8 +311,9 @@ def test_higgs_audio_encoder_cache_is_env_guarded(monkeypatch) -> None:
     assert fake_codec.calls == 2
 
 
-def test_higgs_preprocessing_uses_guarded_waveform_cache(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("SGLANG_OMNI_HIGGS_REF_CODE_CACHE", "1")
+def test_higgs_preprocessing_uses_waveform_cache_by_default(
+    monkeypatch, tmp_path
+) -> None:
     monkeypatch.setattr(stages, "resolve_checkpoint", lambda model_path: model_path)
     monkeypatch.setattr(stages.Tokenizer, "from_file", lambda _path: object())
     monkeypatch.setattr(
@@ -345,8 +364,9 @@ def test_higgs_preprocessing_uses_guarded_waveform_cache(monkeypatch, tmp_path) 
     )
 
 
-def test_higgs_preprocessing_waveform_cache_is_env_guarded(monkeypatch) -> None:
-    monkeypatch.delenv("SGLANG_OMNI_HIGGS_REF_CODE_CACHE", raising=False)
+def test_higgs_preprocessing_waveform_cache_can_be_disabled_by_server_arg(
+    monkeypatch,
+) -> None:
     monkeypatch.setattr(stages, "resolve_checkpoint", lambda model_path: model_path)
     monkeypatch.setattr(stages.Tokenizer, "from_file", lambda _path: object())
     monkeypatch.setattr(
@@ -365,7 +385,11 @@ def test_higgs_preprocessing_waveform_cache_is_env_guarded(monkeypatch) -> None:
 
     monkeypatch.setattr(stages, "load_audio_to_24k", fake_load_audio_to_24k)
 
-    scheduler = stages.create_preprocessing_executor("ckpt", num_codebooks=2)
+    scheduler = stages.create_preprocessing_executor(
+        "ckpt",
+        num_codebooks=2,
+        enable_ref_code_cache=False,
+    )
 
     def make_payload(request_id: str) -> StagePayload:
         return StagePayload(

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -106,6 +106,20 @@ def test_higgs_reference_cache_key_tracks_file_content(tmp_path) -> None:
     assert first_key != second_key
 
 
+def test_higgs_reference_cache_key_same_size_edit_and_urls(tmp_path) -> None:
+    # Same path, same size, same head/tail, different middle must not stale-hit.
+    head, tail = b"H" * 8192, b"T" * 8192
+    ref_audio = tmp_path / "ref.wav"
+    ref_audio.write_bytes(head + b"a" * 4096 + tail)
+    key_a = stages._reference_audio_cache_key(ref_audio)
+    ref_audio.write_bytes(head + b"b" * 4096 + tail)  # same size, middle differs
+    assert key_a is not None and key_a != stages._reference_audio_cache_key(ref_audio)
+
+    # URLs and missing files are not cached.
+    assert stages._reference_audio_cache_key("https://example.com/ref.wav") is None
+    assert stages._reference_audio_cache_key(str(tmp_path / "missing.wav")) is None
+
+
 def test_higgs_reference_cache_key_ignores_media_type() -> None:
     raw = b"\x01\x02\x03fake-audio-bytes"
     encoded = base64.b64encode(raw).decode()

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -143,6 +143,30 @@ def test_higgs_reference_cache_key_same_size_edit_and_urls(tmp_path) -> None:
     assert stages._reference_audio_cache_key(str(tmp_path / "missing.wav")) is None
 
 
+def test_higgs_reference_cache_key_memoizes_stable_file_hash(
+    monkeypatch, tmp_path
+) -> None:
+    ref_audio = tmp_path / "ref.wav"
+    ref_audio.write_bytes(b"fake wav bytes")
+    stages._REF_PATH_HASH_MEMO.clear()
+    read_calls = 0
+    original_read_bytes = stages.Path.read_bytes
+
+    def counting_read_bytes(path):
+        nonlocal read_calls
+        if path == ref_audio:
+            read_calls += 1
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(stages.Path, "read_bytes", counting_read_bytes)
+
+    first_key = stages._reference_audio_cache_key(ref_audio)
+    second_key = stages._reference_audio_cache_key(ref_audio)
+
+    assert first_key == second_key
+    assert read_calls == 1
+
+
 def test_higgs_reference_cache_key_ignores_media_type() -> None:
     raw = b"\x01\x02\x03fake-audio-bytes"
     encoded = base64.b64encode(raw).decode()

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import base64
 from types import SimpleNamespace
 
 import numpy as np
@@ -88,19 +89,38 @@ def test_higgs_reference_cache_key_round_trip() -> None:
     assert restored.reference_cache_key == "path:/tmp/ref.wav"
 
 
-def test_higgs_reference_cache_key_tracks_path_metadata(tmp_path) -> None:
+def test_higgs_reference_cache_key_tracks_file_content(tmp_path) -> None:
     ref_audio = tmp_path / "ref.wav"
     ref_audio.write_bytes(b"a")
     first_key = stages._reference_audio_cache_key(ref_audio)
 
+    # Same content -> stable key (so repeat requests hit the cache).
+    assert first_key == stages._reference_audio_cache_key(ref_audio)
+
     ref_audio.write_bytes(b"longer")
     second_key = stages._reference_audio_cache_key(ref_audio)
 
-    assert first_key is not None
-    assert first_key.startswith(f"path:{ref_audio.resolve()}:1:")
-    assert second_key is not None
-    assert second_key.startswith(f"path:{ref_audio.resolve()}:6:")
+    # Different content -> different key (so a replaced file is not stale-served).
+    assert first_key is not None and first_key.startswith("file:")
+    assert second_key is not None and second_key.startswith("file:")
     assert first_key != second_key
+
+
+def test_higgs_reference_cache_key_ignores_media_type() -> None:
+    raw = b"\x01\x02\x03fake-audio-bytes"
+    encoded = base64.b64encode(raw).decode()
+    key_wav = stages._reference_audio_cache_key(
+        {"base64": encoded, "media_type": "audio/wav"}
+    )
+    key_mp3 = stages._reference_audio_cache_key(
+        {"base64": encoded, "media_type": "audio/mpeg"}
+    )
+
+    # media_type is a decode hint the codec ignores, so it must not split keys.
+    assert key_wav is not None
+    assert key_wav == key_mp3
+    # Raw bytes and equivalent base64 resolve to the same content key.
+    assert stages._reference_audio_cache_key({"bytes": raw}) == key_wav
 
 
 def test_higgs_audio_encoder_uses_guarded_reference_code_cache(monkeypatch) -> None:
@@ -163,9 +183,9 @@ def test_higgs_audio_encoder_uses_guarded_reference_code_cache(monkeypatch) -> N
     second = encode(make_payload("second"))
 
     assert fake_codec.calls == 1
-    assert first.data["reference_codes_delayed"] == second.data[
-        "reference_codes_delayed"
-    ]
+    assert (
+        first.data["reference_codes_delayed"] == second.data["reference_codes_delayed"]
+    )
     assert first.data["prompt_token_ids"] == [5, 3, 7]
     assert second.data["prompt_token_ids"] == [5, 3, 7]
     assert "reference_waveform" not in second.data
@@ -257,9 +277,7 @@ def test_higgs_preprocessing_uses_guarded_waveform_cache(monkeypatch, tmp_path) 
             request=OmniRequest(
                 inputs={
                     "text": "hello",
-                    "references": [
-                        {"audio_path": str(ref_audio), "text": "speaker"}
-                    ],
+                    "references": [{"audio_path": str(ref_audio), "text": "speaker"}],
                 },
                 params={},
             ),

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -2,6 +2,7 @@
 
 from types import SimpleNamespace
 
+import numpy as np
 import torch
 
 from sglang_omni.models.higgs_tts import stages
@@ -77,6 +78,243 @@ def test_higgs_tts_engine_enables_cuda_graph_by_default(monkeypatch) -> None:
     assert captured["overrides"]["cuda_graph_max_bs"] == 32
     assert captured["server_args"].disable_overlap_schedule is True
     assert captured["adapter_kwargs"] == {"max_new_tokens_cap": 2048}
+
+
+def test_higgs_reference_cache_key_round_trip() -> None:
+    state = HiggsTtsState(reference_cache_key="path:/tmp/ref.wav")
+
+    restored = HiggsTtsState.from_dict(state.to_dict())
+
+    assert restored.reference_cache_key == "path:/tmp/ref.wav"
+
+
+def test_higgs_reference_cache_key_tracks_path_metadata(tmp_path) -> None:
+    ref_audio = tmp_path / "ref.wav"
+    ref_audio.write_bytes(b"a")
+    first_key = stages._reference_audio_cache_key(ref_audio)
+
+    ref_audio.write_bytes(b"longer")
+    second_key = stages._reference_audio_cache_key(ref_audio)
+
+    assert first_key is not None
+    assert first_key.startswith(f"path:{ref_audio.resolve()}:1:")
+    assert second_key is not None
+    assert second_key.startswith(f"path:{ref_audio.resolve()}:6:")
+    assert first_key != second_key
+
+
+def test_higgs_audio_encoder_uses_guarded_reference_code_cache(monkeypatch) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_HIGGS_REF_CODE_CACHE", "1")
+    monkeypatch.setattr(stages, "resolve_checkpoint", lambda model_path: model_path)
+    monkeypatch.setattr(
+        stages.Tokenizer,
+        "from_file",
+        lambda _path: object(),
+    )
+    monkeypatch.setattr(
+        stages,
+        "PreTrainedTokenizerFast",
+        lambda tokenizer_object: object(),
+    )
+
+    class FakeAdapter:
+        def __init__(self, _tokenizer) -> None:
+            pass
+
+        def build_prompt(
+            self, text: str, *, num_ref_tokens: int, reference_text: str | None
+        ) -> list[int]:
+            return [len(text), num_ref_tokens, len(reference_text or "")]
+
+    class FakeCodec:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def encode_reference(self, waveform, sample_rate: int) -> torch.Tensor:
+            self.calls += 1
+            return torch.tensor([[11, 12], [21, 22]], dtype=torch.long)
+
+    fake_codec = FakeCodec()
+    monkeypatch.setattr(stages, "HiggsTokenizerAdapter", FakeAdapter)
+    monkeypatch.setattr(stages, "get_or_load_codec", lambda *args, **kwargs: fake_codec)
+
+    scheduler = stages.create_audio_encoder_executor(
+        "ckpt",
+        device="cuda:0",
+        num_codebooks=2,
+    )
+    encode = scheduler._fn
+
+    def make_payload(request_id: str) -> StagePayload:
+        state = HiggsTtsState(
+            reference_waveform=torch.zeros(1, 1, 16),
+            reference_cache_key="path:/tmp/ref.wav",
+            target_text="hello",
+            reference_text="speaker",
+            num_codebooks=2,
+        )
+        return StagePayload(
+            request_id=request_id,
+            request=OmniRequest(inputs={}),
+            data=state.to_dict(),
+        )
+
+    first = encode(make_payload("first"))
+    second = encode(make_payload("second"))
+
+    assert fake_codec.calls == 1
+    assert first.data["reference_codes_delayed"] == second.data[
+        "reference_codes_delayed"
+    ]
+    assert first.data["prompt_token_ids"] == [5, 3, 7]
+    assert second.data["prompt_token_ids"] == [5, 3, 7]
+    assert "reference_waveform" not in second.data
+    assert "reference_cache_key" not in second.data
+
+
+def test_higgs_audio_encoder_cache_is_env_guarded(monkeypatch) -> None:
+    monkeypatch.delenv("SGLANG_OMNI_HIGGS_REF_CODE_CACHE", raising=False)
+    monkeypatch.setattr(stages, "resolve_checkpoint", lambda model_path: model_path)
+    monkeypatch.setattr(stages.Tokenizer, "from_file", lambda _path: object())
+    monkeypatch.setattr(
+        stages,
+        "PreTrainedTokenizerFast",
+        lambda tokenizer_object: object(),
+    )
+    monkeypatch.setattr(
+        stages,
+        "HiggsTokenizerAdapter",
+        lambda _tokenizer: SimpleNamespace(
+            build_prompt=lambda text, *, num_ref_tokens, reference_text: [
+                num_ref_tokens
+            ]
+        ),
+    )
+
+    class FakeCodec:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def encode_reference(self, waveform, sample_rate: int) -> torch.Tensor:
+            self.calls += 1
+            return torch.tensor([[self.calls, 2]], dtype=torch.long)
+
+    fake_codec = FakeCodec()
+    monkeypatch.setattr(stages, "get_or_load_codec", lambda *args, **kwargs: fake_codec)
+
+    scheduler = stages.create_audio_encoder_executor(
+        "ckpt",
+        device="cuda:0",
+        num_codebooks=2,
+    )
+    encode = scheduler._fn
+
+    def make_payload(request_id: str) -> StagePayload:
+        return StagePayload(
+            request_id=request_id,
+            request=OmniRequest(inputs={}),
+            data=HiggsTtsState(
+                reference_waveform=torch.zeros(1, 1, 16),
+                reference_cache_key="path:/tmp/ref.wav",
+                num_codebooks=2,
+            ).to_dict(),
+        )
+
+    encode(make_payload("first"))
+    encode(make_payload("second"))
+
+    assert fake_codec.calls == 2
+
+
+def test_higgs_preprocessing_uses_guarded_waveform_cache(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_HIGGS_REF_CODE_CACHE", "1")
+    monkeypatch.setattr(stages, "resolve_checkpoint", lambda model_path: model_path)
+    monkeypatch.setattr(stages.Tokenizer, "from_file", lambda _path: object())
+    monkeypatch.setattr(
+        stages,
+        "PreTrainedTokenizerFast",
+        lambda tokenizer_object: object(),
+    )
+    monkeypatch.setattr(stages, "HiggsTokenizerAdapter", lambda _tokenizer: object())
+
+    load_calls = 0
+
+    def fake_load_audio_to_24k(reference_audio):
+        nonlocal load_calls
+        load_calls += 1
+        return np.zeros(16, dtype=np.float32), 24000
+
+    monkeypatch.setattr(stages, "load_audio_to_24k", fake_load_audio_to_24k)
+
+    scheduler = stages.create_preprocessing_executor("ckpt", num_codebooks=2)
+    preprocess = scheduler._fn
+    ref_audio = tmp_path / "ref.wav"
+    ref_audio.write_bytes(b"fake wav bytes")
+
+    def make_payload(request_id: str) -> StagePayload:
+        return StagePayload(
+            request_id=request_id,
+            request=OmniRequest(
+                inputs={
+                    "text": "hello",
+                    "references": [
+                        {"audio_path": str(ref_audio), "text": "speaker"}
+                    ],
+                },
+                params={},
+            ),
+            data={},
+        )
+
+    first = preprocess(make_payload("first"))
+    second = preprocess(make_payload("second"))
+    first_state = HiggsTtsState.from_dict(first.data)
+    second_state = HiggsTtsState.from_dict(second.data)
+
+    assert load_calls == 1
+    assert first_state.reference_cache_key == second_state.reference_cache_key
+    assert torch.equal(first_state.reference_waveform, second_state.reference_waveform)
+    assert (
+        first_state.reference_waveform.data_ptr()
+        != second_state.reference_waveform.data_ptr()
+    )
+
+
+def test_higgs_preprocessing_waveform_cache_is_env_guarded(monkeypatch) -> None:
+    monkeypatch.delenv("SGLANG_OMNI_HIGGS_REF_CODE_CACHE", raising=False)
+    monkeypatch.setattr(stages, "resolve_checkpoint", lambda model_path: model_path)
+    monkeypatch.setattr(stages.Tokenizer, "from_file", lambda _path: object())
+    monkeypatch.setattr(
+        stages,
+        "PreTrainedTokenizerFast",
+        lambda tokenizer_object: object(),
+    )
+    monkeypatch.setattr(stages, "HiggsTokenizerAdapter", lambda _tokenizer: object())
+
+    load_calls = 0
+
+    def fake_load_audio_to_24k(reference_audio):
+        nonlocal load_calls
+        load_calls += 1
+        return np.zeros(16, dtype=np.float32), 24000
+
+    monkeypatch.setattr(stages, "load_audio_to_24k", fake_load_audio_to_24k)
+
+    scheduler = stages.create_preprocessing_executor("ckpt", num_codebooks=2)
+
+    def make_payload(request_id: str) -> StagePayload:
+        return StagePayload(
+            request_id=request_id,
+            request=OmniRequest(
+                inputs={"text": "hello", "reference_audio": "/tmp/ref.wav"}
+            ),
+            data={},
+        )
+
+    scheduler._fn(make_payload("first"))
+    scheduler._fn(make_payload("second"))
+
+    assert load_calls == 2
 
 
 def test_higgs_model_runner_marks_sampler_finish() -> None:

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -147,8 +147,11 @@ def test_higgs_audio_encoder_uses_guarded_reference_code_cache(monkeypatch) -> N
             return [len(text), num_ref_tokens, len(reference_text or "")]
 
     class FakeCodec:
+        SAMPLE_RATE = 24000
+
         def __init__(self) -> None:
             self.calls = 0
+            self.model = SimpleNamespace(acoustic_encoder=torch.nn.Identity())
 
         def encode_reference(self, waveform, sample_rate: int) -> torch.Tensor:
             self.calls += 1
@@ -163,6 +166,8 @@ def test_higgs_audio_encoder_uses_guarded_reference_code_cache(monkeypatch) -> N
         device="cuda:0",
         num_codebooks=2,
     )
+    # Ignore the construction-time codec warm-up call added by #612.
+    fake_codec.calls = 0
     encode = scheduler._fn
 
     def make_payload(request_id: str) -> StagePayload:
@@ -212,8 +217,11 @@ def test_higgs_audio_encoder_cache_is_env_guarded(monkeypatch) -> None:
     )
 
     class FakeCodec:
+        SAMPLE_RATE = 24000
+
         def __init__(self) -> None:
             self.calls = 0
+            self.model = SimpleNamespace(acoustic_encoder=torch.nn.Identity())
 
         def encode_reference(self, waveform, sample_rate: int) -> torch.Tensor:
             self.calls += 1
@@ -227,6 +235,8 @@ def test_higgs_audio_encoder_cache_is_env_guarded(monkeypatch) -> None:
         device="cuda:0",
         num_codebooks=2,
     )
+    # Ignore the construction-time codec warm-up call added by #612.
+    fake_codec.calls = 0
     encode = scheduler._fn
 
     def make_payload(request_id: str) -> StagePayload:

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -7,7 +7,6 @@ from types import SimpleNamespace
 import numpy as np
 import torch
 
-from sglang_omni.cli.serve import apply_higgs_ref_code_cache_cli_overrides
 from sglang_omni.models.higgs_tts import stages
 from sglang_omni.models.higgs_tts.config import HiggsTtsPipelineConfig
 from sglang_omni.models.higgs_tts.model_runner import HiggsTTSModelRunner
@@ -26,24 +25,6 @@ def test_higgs_streaming_pipeline_routes_chunks_to_vocoder() -> None:
 
     assert stages_by_name["tts_engine"].stream_to == ["vocoder"]
     assert stages_by_name["vocoder"].can_accept_stream_before_payload is True
-
-
-def test_higgs_ref_code_cache_server_arg_disables_cache_stages() -> None:
-    config = HiggsTtsPipelineConfig(model_path="fake-model")
-
-    apply_higgs_ref_code_cache_cli_overrides(
-        config,
-        higgs_ref_code_cache=False,
-    )
-
-    stages_by_name = {stage.name: stage for stage in config.stages}
-    assert (
-        stages_by_name["preprocessing"].factory_args["enable_ref_code_cache"] is False
-    )
-    assert (
-        stages_by_name["audio_encoder"].factory_args["enable_ref_code_cache"] is False
-    )
-    assert "enable_ref_code_cache" not in stages_by_name["tts_engine"].factory_args
 
 
 def test_higgs_tts_engine_enables_cuda_graph_by_default(monkeypatch) -> None:
@@ -179,7 +160,7 @@ def test_higgs_reference_cache_key_ignores_media_type() -> None:
     assert stages._reference_audio_cache_key({"bytes": raw}) == key_wav
 
 
-def test_higgs_audio_encoder_uses_reference_code_cache_by_default(monkeypatch) -> None:
+def test_higgs_audio_encoder_uses_reference_code_cache(monkeypatch) -> None:
     monkeypatch.setattr(stages, "resolve_checkpoint", lambda model_path: model_path)
     monkeypatch.setattr(
         stages.Tokenizer,
@@ -252,68 +233,7 @@ def test_higgs_audio_encoder_uses_reference_code_cache_by_default(monkeypatch) -
     assert "reference_cache_key" not in second.data
 
 
-def test_higgs_audio_encoder_cache_can_be_disabled_by_server_arg(monkeypatch) -> None:
-    monkeypatch.setattr(stages, "resolve_checkpoint", lambda model_path: model_path)
-    monkeypatch.setattr(stages.Tokenizer, "from_file", lambda _path: object())
-    monkeypatch.setattr(
-        stages,
-        "PreTrainedTokenizerFast",
-        lambda tokenizer_object: object(),
-    )
-    monkeypatch.setattr(
-        stages,
-        "HiggsTokenizerAdapter",
-        lambda _tokenizer: SimpleNamespace(
-            build_prompt=lambda text, *, num_ref_tokens, reference_text: [
-                num_ref_tokens
-            ]
-        ),
-    )
-
-    class FakeCodec:
-        SAMPLE_RATE = 24000
-
-        def __init__(self) -> None:
-            self.calls = 0
-            self.model = SimpleNamespace(acoustic_encoder=torch.nn.Identity())
-
-        def encode_reference(self, waveform, sample_rate: int) -> torch.Tensor:
-            self.calls += 1
-            return torch.tensor([[self.calls, 2]], dtype=torch.long)
-
-    fake_codec = FakeCodec()
-    monkeypatch.setattr(stages, "get_or_load_codec", lambda *args, **kwargs: fake_codec)
-
-    scheduler = stages.create_audio_encoder_executor(
-        "ckpt",
-        device="cuda:0",
-        num_codebooks=2,
-        enable_ref_code_cache=False,
-    )
-    # Ignore the construction-time codec warm-up call added by #612.
-    fake_codec.calls = 0
-    encode = scheduler._fn
-
-    def make_payload(request_id: str) -> StagePayload:
-        return StagePayload(
-            request_id=request_id,
-            request=OmniRequest(inputs={}),
-            data=HiggsTtsState(
-                reference_waveform=torch.zeros(1, 1, 16),
-                reference_cache_key="path:/tmp/ref.wav",
-                num_codebooks=2,
-            ).to_dict(),
-        )
-
-    encode(make_payload("first"))
-    encode(make_payload("second"))
-
-    assert fake_codec.calls == 2
-
-
-def test_higgs_preprocessing_uses_waveform_cache_by_default(
-    monkeypatch, tmp_path
-) -> None:
+def test_higgs_preprocessing_uses_waveform_cache(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(stages, "resolve_checkpoint", lambda model_path: model_path)
     monkeypatch.setattr(stages.Tokenizer, "from_file", lambda _path: object())
     monkeypatch.setattr(
@@ -362,48 +282,6 @@ def test_higgs_preprocessing_uses_waveform_cache_by_default(
         first_state.reference_waveform.data_ptr()
         != second_state.reference_waveform.data_ptr()
     )
-
-
-def test_higgs_preprocessing_waveform_cache_can_be_disabled_by_server_arg(
-    monkeypatch,
-) -> None:
-    monkeypatch.setattr(stages, "resolve_checkpoint", lambda model_path: model_path)
-    monkeypatch.setattr(stages.Tokenizer, "from_file", lambda _path: object())
-    monkeypatch.setattr(
-        stages,
-        "PreTrainedTokenizerFast",
-        lambda tokenizer_object: object(),
-    )
-    monkeypatch.setattr(stages, "HiggsTokenizerAdapter", lambda _tokenizer: object())
-
-    load_calls = 0
-
-    def fake_load_audio_to_24k(reference_audio):
-        nonlocal load_calls
-        load_calls += 1
-        return np.zeros(16, dtype=np.float32), 24000
-
-    monkeypatch.setattr(stages, "load_audio_to_24k", fake_load_audio_to_24k)
-
-    scheduler = stages.create_preprocessing_executor(
-        "ckpt",
-        num_codebooks=2,
-        enable_ref_code_cache=False,
-    )
-
-    def make_payload(request_id: str) -> StagePayload:
-        return StagePayload(
-            request_id=request_id,
-            request=OmniRequest(
-                inputs={"text": "hello", "reference_audio": "/tmp/ref.wav"}
-            ),
-            data={},
-        )
-
-    scheduler._fn(make_payload("first"))
-    scheduler._fn(make_payload("second"))
-
-    assert load_calls == 2
 
 
 def test_higgs_model_runner_marks_sampler_finish() -> None:


### PR DESCRIPTION
## Summary

This PR adds an opt-in Higgs TTS reference cache guarded by `SGLANG_OMNI_HIGGS_REF_CODE_CACHE=1`.

The cache avoids repeated work for repeated reference audio by:
- deriving stable cache keys for path, raw bytes, and base64/data audio inputs;
- including local path `size` and `mtime_ns` in the key so replacing a file at the same path does not hit stale cached data;
- caching the loaded/resampled reference waveform in preprocessing;
- caching delayed reference codec codes in the audio encoder stage;
- leaving default behavior unchanged when the env var is unset.

## Upstream readiness

Rebased onto current `sgl-project/sglang-omni:main` (`0a8da7a`). Checked locally:

```bash
git diff --check origin/main..HEAD
python3 -m py_compile \
  sglang_omni/models/higgs_tts/payload_types.py \
  sglang_omni/models/higgs_tts/stages.py \
  tests/unit_test/higgs_tts/test_pipeline.py
```

Both passed. Local pytest collection is blocked by the local macOS Python environment: `torchaudio` cannot load `libtorchaudio.so`, and the local `transformers` version is missing `Qwen2_5_VLProcessor`. The functional test result below is from the H200 validation environment.

## Correctness

Environment:
- Host/container: `ion-h200-8`, `sglang_omni_bbuf`
- GPU: H200, `CUDA_VISIBLE_DEVICES=1`
- Base commit: `e3e9413a3899ab3db5ddc4dcd22baed8089904ab`
- Runtime `PYTHONPATH`: worktree plus `/sgl-workspace/sglang/python`

Command:

```bash
CUDA_VISIBLE_DEVICES=1 \
PYTHONPATH=/home/sglang-omni/bbuf/experiments/omni_h200_goal_20260527_1452/sglang-omni-latest-e3e9413:/sgl-workspace/sglang/python \
SGLANG_OMNI_HIGGS_REF_CODE_CACHE=1 \
pytest -q tests/unit_test/higgs_tts -q
```

Result:

```text
10 passed, 2 warnings in 7.59s
```

Artifact:
`/home/sglang-omni/bbuf/experiments/omni_h200_goal_20260527_1452/artifacts_latest/correctness/higgs_after_waveform_cache_rerun_20260527_204134`

## Performance

Benchmark workload:

```bash
CUDA_VISIBLE_DEVICES=1 \
PYTHONPATH=/home/sglang-omni/bbuf/experiments/omni_h200_goal_20260527_1452/sglang-omni-latest-e3e9413:/sgl-workspace/sglang/python \
python -m benchmarks.eval.benchmark_tts_seedtts \
  --generate-only \
  --meta zhaochenyang20/seed-tts-eval-arrow \
  --model boson-sglang/higgs-audio-v3-tts-4b-base \
  --ref-format references \
  --max-samples 16 \
  --concurrency 16 \
  --warmup 1 \
  --max-new-tokens 2048 \
  --lang en \
  --disable-tqdm \
  --port 30181 \
  --output-dir REPDIR
```

Median over 3 repetitions on GPU 1:

| metric | baseline | optimized | delta |
| --- | ---: | ---: | ---: |
| throughput_qps | 7.514 | 8.527 | +13.482% |
| latency_mean_s | 1.684 | 1.465 | -13.005% |
| latency_p95_s | 2.087 | 1.833 | -12.171% |
| rtf_mean | 0.4239 | 0.3657 | -13.730% |
| audio_throughput_s_per_s | 31.558 | 35.922 | +13.829% |

Artifact:
`/home/sglang-omni/bbuf/experiments/omni_h200_goal_20260527_1452/artifacts_latest/benchmarks_higgs_waveform_cache_20260527_204539/summary.md`
