### PR TITLE
[nit] fix two typos and broken link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Update your Jupyter notebooks in the appropriate subdirectories under `docs/`. I
 ```bash
 bash serve.sh
 
-# if you want to ues a custom port
+# if you want to use a custom port
 PORT=8080 make serve
 ```
 ---

--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -349,4 +349,4 @@ The launcher starts the backend first, waits for `/health`, then starts the Grad
 python -m playground.tts.app --api-base http://localhost:8000
 ```
 
-A demo play video is available [here](https://x.com/lmsysorg/status/2031412267213008984/video/1). We highly recommend using playground since audio data is hard to intertact with by CLI.
+A demo play video is available [here](https://x.com/lmsysorg/status/2031412267213008984/video/1). We highly recommend using playground since audio data is hard to interact with by CLI.

--- a/docs/cookbook/voxtral_tts.md
+++ b/docs/cookbook/voxtral_tts.md
@@ -135,7 +135,7 @@ Whisper-large-v3. Hardware: 1× H200 SXM.
 | Throughput (req/s) | 5.40 |
 | Completed / failed requests | 1088 / 0 |
 
-Reproduce with the SeedTTS command in our [seedTTS benchmark](./benchmarks/README.md). The Voxtral
+Reproduce with the SeedTTS command in our [seedTTS benchmark](../../benchmarks/README.md). The Voxtral
 model card also quotes ~70 ms first-audio latency at concurrency 1; the table above is a
 throughput-oriented run at concurrency 16, so its RTF reflects batched load rather than the
 latency-optimized single-stream figure. Output is 24 kHz.


### PR DESCRIPTION
## Summary

Three tiny doc fixes surfaced by a typo/bug scan over `docs/`:

- `docs/README.md:24` — `ues` → `use`
- `docs/basic_usage/tts.md:352` — `intertact` → `interact`
- `docs/cookbook/voxtral_tts.md:138` — the SeedTTS benchmark link was `./benchmarks/README.md`, which resolves to `docs/cookbook/benchmarks/README.md` (does not exist). The actual file lives at the repo root, so the relative path is `../../benchmarks/README.md`.

## Test plan

- [x] Visual diff review — three single-line edits, no code touched
- [x] Verified the corrected link target `benchmarks/README.md` exists at the repo root
- [ ] (Reviewer) Render `docs/cookbook/voxtral_tts.md` on GitHub or the docs site and confirm the SeedTTS benchmark link navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)