### PR TITLE
Add HiggsAudioCodec.encode_batch (batched audio encoder)

### DIFF
--- a/sglang_omni/models/higgs_tts/audio_codec.py
+++ b/sglang_omni/models/higgs_tts/audio_codec.py
@@ -186,6 +186,50 @@ class HiggsAudioCodec:
         return codes_BNT.squeeze(0).transpose(0, 1).to(torch.long).cpu()
 
     @torch.no_grad()
+    def encode_batch(self, waveforms: list[torch.Tensor]) -> list[torch.Tensor]:
+        """Batch-encode ``[1, 1, L_i]`` float32 waveforms → ``[T_i, N]`` int64 code tensors.
+
+        Only same-length items are batched into a single forward pass.
+        The non-causal acoustic encoder corrupts shorter items when padded to
+        a longer ``L_max``, so mixed-length inputs are encoded per-bucket.
+        Clips shorter than ``SAMPLE_RATE`` samples are zero-padded before
+        bucketing, matching the behaviour of :meth:`encode_reference`.
+        """
+        if not waveforms:
+            return []
+        if len(waveforms) == 1:
+            return [self.encode_reference(waveforms[0])]
+
+        padded: list[torch.Tensor] = []
+        for w in waveforms:
+            wav = w.to(torch.float32)
+            if wav.shape[-1] < self.SAMPLE_RATE:
+                wav = F.pad(wav, (0, self.SAMPLE_RATE - wav.shape[-1]))
+            padded.append(wav)
+
+        buckets: dict[int, list[int]] = {}
+        for i, w in enumerate(padded):
+            buckets.setdefault(w.shape[-1], []).append(i)
+
+        results: list[torch.Tensor | None] = [None] * len(waveforms)
+        for indices in buckets.values():
+            if len(indices) == 1:
+                results[indices[0]] = self.encode_reference(padded[indices[0]])
+            else:
+                batch = torch.cat([padded[i] for i in indices])  # [B, 1, L]
+                batch = batch.to(device=self.device, dtype=self._dtype)
+                codes_BNT = self.model.encode(batch).audio_codes  # [B, N, T]
+                for j, idx in enumerate(indices):
+                    results[idx] = codes_BNT[j].transpose(0, 1).to(torch.long).cpu()
+
+        out: list[torch.Tensor] = []
+        for i, result in enumerate(results):
+            if result is None:
+                raise RuntimeError(f"encode_batch did not produce codes for item {i}")
+            out.append(result)
+        return out
+
+    @torch.no_grad()
     def decode(self, codes_TN: torch.Tensor) -> torch.Tensor:
         """``[T, num_codebooks]`` → mono waveform ``[L]``."""
         if codes_TN.ndim != 2:

--- a/sglang_omni/models/higgs_tts/audio_codec.py
+++ b/sglang_omni/models/higgs_tts/audio_codec.py
@@ -260,6 +260,7 @@ class HiggsAudioCodec:
     @torch.no_grad()
     def decode_batch(self, codes_list: list[torch.Tensor]) -> list[torch.Tensor]:
         """Batch-decode variable-length ``[T_i, N]`` tensors into ``[L_i]`` waveforms."""
+
         def _batch_fn(batch_items: list[torch.Tensor]) -> list[torch.Tensor]:
             stacked = torch.stack(batch_items)
             codes_BNT = stacked.transpose(1, 2).to(device=self.device, dtype=torch.long)

--- a/sglang_omni/models/higgs_tts/audio_codec.py
+++ b/sglang_omni/models/higgs_tts/audio_codec.py
@@ -185,49 +185,63 @@ class HiggsAudioCodec:
         codes_BNT = self.model.encode(wav).audio_codes
         return codes_BNT.squeeze(0).transpose(0, 1).to(torch.long).cpu()
 
-    @torch.no_grad()
-    def encode_batch(self, waveforms: list[torch.Tensor]) -> list[torch.Tensor]:
-        """Batch-encode ``[1, 1, L_i]`` float32 waveforms → ``[T_i, N]`` int64 code tensors.
-
-        Only same-length items are batched into a single forward pass.
-        The non-causal acoustic encoder corrupts shorter items when padded to
-        a longer ``L_max``, so mixed-length inputs are encoded per-bucket.
-        Clips shorter than ``SAMPLE_RATE`` samples are zero-padded before
-        bucketing, matching the behaviour of :meth:`encode_reference`.
-        """
-        if not waveforms:
+    def _bucketed_batch(
+        self,
+        items: list[torch.Tensor],
+        *,
+        bucket_key_fn,
+        single_fn,
+        batch_fn,
+        error_label: str,
+    ) -> list[torch.Tensor]:
+        """Run single_fn on singleton buckets and batch_fn on multi-item buckets."""
+        if not items:
             return []
-        if len(waveforms) == 1:
-            return [self.encode_reference(waveforms[0])]
-
-        padded: list[torch.Tensor] = []
-        for w in waveforms:
-            wav = w.to(torch.float32)
-            if wav.shape[-1] < self.SAMPLE_RATE:
-                wav = F.pad(wav, (0, self.SAMPLE_RATE - wav.shape[-1]))
-            padded.append(wav)
+        if len(items) == 1:
+            return [single_fn(items[0])]
 
         buckets: dict[int, list[int]] = {}
-        for i, w in enumerate(padded):
-            buckets.setdefault(w.shape[-1], []).append(i)
+        for i, item in enumerate(items):
+            buckets.setdefault(bucket_key_fn(item), []).append(i)
 
-        results: list[torch.Tensor | None] = [None] * len(waveforms)
+        results: list[torch.Tensor | None] = [None] * len(items)
         for indices in buckets.values():
             if len(indices) == 1:
-                results[indices[0]] = self.encode_reference(padded[indices[0]])
+                results[indices[0]] = single_fn(items[indices[0]])
             else:
-                batch = torch.cat([padded[i] for i in indices])  # [B, 1, L]
-                batch = batch.to(device=self.device, dtype=self._dtype)
-                codes_BNT = self.model.encode(batch).audio_codes  # [B, N, T]
-                for j, idx in enumerate(indices):
-                    results[idx] = codes_BNT[j].transpose(0, 1).to(torch.long).cpu()
+                batch_results = batch_fn([items[i] for i in indices])
+                for idx, result in zip(indices, batch_results):
+                    results[idx] = result
 
         out: list[torch.Tensor] = []
         for i, result in enumerate(results):
             if result is None:
-                raise RuntimeError(f"encode_batch did not produce codes for item {i}")
+                raise RuntimeError(f"{error_label} did not produce result for item {i}")
             out.append(result)
         return out
+
+    @torch.no_grad()
+    def encode_batch(self, waveforms: list[torch.Tensor]) -> list[torch.Tensor]:
+        # Offline/bulk encoding utility.
+        padded: list[torch.Tensor] = []
+        for w in waveforms:
+            wav = _to_mono_3d(w).to(torch.float32)
+            if wav.shape[-1] < self.SAMPLE_RATE:
+                wav = F.pad(wav, (0, self.SAMPLE_RATE - wav.shape[-1]))
+            padded.append(wav)
+
+        def _batch_fn(batch_items: list[torch.Tensor]) -> list[torch.Tensor]:
+            batch = torch.cat(batch_items).to(device=self.device, dtype=self._dtype)
+            codes_BNT = self.model.encode(batch).audio_codes.to(torch.long).cpu()
+            return [codes_BNT[j].transpose(0, 1) for j in range(len(batch_items))]
+
+        return self._bucketed_batch(
+            padded,
+            bucket_key_fn=lambda w: w.shape[-1],
+            single_fn=self.encode_reference,
+            batch_fn=_batch_fn,
+            error_label="encode_batch",
+        )
 
     @torch.no_grad()
     def decode(self, codes_TN: torch.Tensor) -> torch.Tensor:
@@ -245,40 +259,20 @@ class HiggsAudioCodec:
 
     @torch.no_grad()
     def decode_batch(self, codes_list: list[torch.Tensor]) -> list[torch.Tensor]:
-        """Batch-decode variable-length ``[T_i, N]`` tensors into ``[L_i]`` waveforms.
+        """Batch-decode variable-length ``[T_i, N]`` tensors into ``[L_i]`` waveforms."""
+        def _batch_fn(batch_items: list[torch.Tensor]) -> list[torch.Tensor]:
+            stacked = torch.stack(batch_items)
+            codes_BNT = stacked.transpose(1, 2).to(device=self.device, dtype=torch.long)
+            audio = self.model.decode(codes_BNT).audio_values.cpu()
+            return [audio[j, 0] for j in range(len(batch_items))]
 
-        Only same-length items are batched into a single forward pass.
-        The non-causal DAC decoder corrupts shorter items when padded to
-        a longer ``T_max``, so mixed-length inputs are decoded per-bucket.
-        """
-        if not codes_list:
-            return []
-        if len(codes_list) == 1:
-            return [self.decode(codes_list[0])]
-
-        buckets: dict[int, list[int]] = {}
-        for i, c in enumerate(codes_list):
-            buckets.setdefault(c.shape[0], []).append(i)
-
-        results: list[torch.Tensor | None] = [None] * len(codes_list)
-        for indices in buckets.values():
-            if len(indices) == 1:
-                results[indices[0]] = self.decode(codes_list[indices[0]])
-            else:
-                stacked = torch.stack([codes_list[i] for i in indices])
-                codes_BNT = stacked.transpose(1, 2).to(
-                    device=self.device, dtype=torch.long
-                )
-                audio = self.model.decode(codes_BNT).audio_values.cpu()
-                for j, idx in enumerate(indices):
-                    results[idx] = audio[j, 0]
-
-        out: list[torch.Tensor] = []
-        for i, result in enumerate(results):
-            if result is None:
-                raise RuntimeError(f"decode_batch did not produce audio for item {i}")
-            out.append(result)
-        return out
+        return self._bucketed_batch(
+            codes_list,
+            bucket_key_fn=lambda c: c.shape[0],
+            single_fn=self.decode,
+            batch_fn=_batch_fn,
+            error_label="decode_batch",
+        )
 
 
 __all__ = ["HiggsAudioCodec"]

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -940,7 +940,11 @@ def test_higgs_audio_codec_encode_batch_different_lengths_separate_calls() -> No
 def test_higgs_audio_codec_encode_batch_order_preserved() -> None:
     calls: list = []
     codec = _make_fake_encoder_codec(calls)
-    wavs = [torch.zeros(1, 1, 48000), torch.zeros(1, 1, 24000), torch.zeros(1, 1, 48000)]
+    wavs = [
+        torch.zeros(1, 1, 48000),
+        torch.zeros(1, 1, 24000),
+        torch.zeros(1, 1, 48000),
+    ]
     results = codec.encode_batch(wavs)
     assert len(results) == 3
     assert results[0].shape[0] == 150

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -944,15 +944,21 @@ def test_higgs_audio_codec_encode_batch_order_preserved() -> None:
     calls: list = []
     codec = _make_fake_encoder_codec(calls)
     wavs = [
-        torch.zeros(1, 1, 48000),
-        torch.zeros(1, 1, 24000),
-        torch.zeros(1, 1, 48000),
+        torch.full((1, 1, 48000), 0.3),
+        torch.full((1, 1, 24000), 0.5),
+        torch.full((1, 1, 48000), 0.7),
     ]
+    ref0 = codec.encode_reference(wavs[0])
+    ref1 = codec.encode_reference(wavs[1])
+    ref2 = codec.encode_reference(wavs[2])
+    calls.clear()
+
     results = codec.encode_batch(wavs)
+
     assert len(results) == 3
-    assert results[0].shape[0] == 150
-    assert results[1].shape[0] == 75
-    assert results[2].shape[0] == 150
+    assert torch.equal(results[0], ref0)
+    assert torch.equal(results[1], ref1)
+    assert torch.equal(results[2], ref2)
 
 
 def test_higgs_audio_codec_encode_batch_matches_encode_reference() -> None:

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -870,31 +870,34 @@ def test_decode_batch_bit_exact_with_single_decode() -> None:
     assert torch.equal(single_b, batch_results[1])
 
 
-# ---------------------------------------------------------------------------
-# HiggsAudioCodec.encode_batch
-# ---------------------------------------------------------------------------
-
-
 def _make_fake_encoder_codec(encode_calls: list):
-    """Return a HiggsAudioCodec whose model.encode is mocked."""
-    from unittest.mock import MagicMock
+    """Build a HiggsAudioCodec wrapping a FakeModel that logs encode calls.
 
+    Each item in the batch gets codes filled with ``int(batch[i,0,0]*100)``,
+    making outputs distinguishable by the waveform's first sample value.
+    """
     from sglang_omni.models.higgs_tts.audio_codec import HiggsAudioCodec
 
     N = 8  # num_codebooks
 
-    def fake_model_encode(batch: torch.Tensor):
-        B, _, L = batch.shape
-        T = max(L // 320, 1)
-        encode_calls.append(tuple(batch.shape))
-        result = MagicMock()
-        result.audio_codes = torch.zeros(B, N, T, dtype=torch.long)
-        return result
+    class FakeModel:
+        def encode(self, batch: torch.Tensor):
+            B, _, L = batch.shape
+            T = max(L // 320, 1)
+            encode_calls.append(tuple(batch.shape))
+            codes = torch.zeros(B, N, T, dtype=torch.long)
+            for i in range(B):
+                codes[i] = int(round(batch[i, 0, 0].item() * 100))
+            return SimpleNamespace(audio_codes=codes)
 
-    mock_model = MagicMock()
-    mock_model.encode.side_effect = fake_model_encode
-    mock_model.parameters.return_value = iter([torch.zeros(1)])
-    return HiggsAudioCodec(mock_model, device=torch.device("cpu"))
+        def parameters(self):
+            return iter([torch.zeros(1)])
+
+    codec = object.__new__(HiggsAudioCodec)
+    codec.model = FakeModel()
+    codec.device = torch.device("cpu")
+    codec._dtype = torch.float32
+    return codec
 
 
 def test_higgs_audio_codec_encode_batch_empty() -> None:
@@ -950,3 +953,43 @@ def test_higgs_audio_codec_encode_batch_order_preserved() -> None:
     assert results[0].shape[0] == 150
     assert results[1].shape[0] == 75
     assert results[2].shape[0] == 150
+
+
+def test_higgs_audio_codec_encode_batch_matches_encode_reference() -> None:
+    """encode_batch must produce bit-exact codes vs per-item encode_reference."""
+    calls: list = []
+    codec = _make_fake_encoder_codec(calls)
+    wav1 = torch.full((1, 1, 24000), 0.3)
+    wav2 = torch.full((1, 1, 24000), 0.7)
+    wav3 = torch.full((1, 1, 48000), 0.5)
+
+    ref1 = codec.encode_reference(wav1)
+    ref2 = codec.encode_reference(wav2)
+    ref3 = codec.encode_reference(wav3)
+    calls.clear()
+
+    batch_results = codec.encode_batch([wav1, wav2, wav3])
+
+    assert torch.equal(batch_results[0], ref1)
+    assert torch.equal(batch_results[1], ref2)
+    assert torch.equal(batch_results[2], ref3)
+
+
+def test_higgs_audio_codec_encode_batch_input_normalisation() -> None:
+    """1-D tensor, 2-D tensor, and np.ndarray inputs all normalise to the same codes."""
+    calls: list = []
+    codec = _make_fake_encoder_codec(calls)
+    amp = 0.4
+
+    wav_3d = torch.full((1, 1, 24000), amp)
+    wav_2d = torch.full((1, 24000), amp)
+    wav_1d = torch.full((24000,), amp)
+    wav_np = np.full(24000, amp, dtype=np.float32)
+
+    ref = codec.encode_reference(wav_3d)
+    calls.clear()
+
+    results = codec.encode_batch([wav_3d, wav_2d, wav_1d, wav_np])
+
+    for i, r in enumerate(results):
+        assert torch.equal(r, ref), f"input format {i} produced different codes than encode_reference"

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -992,4 +992,6 @@ def test_higgs_audio_codec_encode_batch_input_normalisation() -> None:
     results = codec.encode_batch([wav_3d, wav_2d, wav_1d, wav_np])
 
     for i, r in enumerate(results):
-        assert torch.equal(r, ref), f"input format {i} produced different codes than encode_reference"
+        assert torch.equal(
+            r, ref
+        ), f"input format {i} produced different codes than encode_reference"

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -868,3 +868,81 @@ def test_decode_batch_bit_exact_with_single_decode() -> None:
     assert call_log == [(2, 10)]
     assert torch.equal(single_a, batch_results[0])
     assert torch.equal(single_b, batch_results[1])
+
+
+# ---------------------------------------------------------------------------
+# HiggsAudioCodec.encode_batch
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_encoder_codec(encode_calls: list):
+    """Return a HiggsAudioCodec whose model.encode is mocked."""
+    from unittest.mock import MagicMock
+
+    from sglang_omni.models.higgs_tts.audio_codec import HiggsAudioCodec
+
+    N = 8  # num_codebooks
+
+    def fake_model_encode(batch: torch.Tensor):
+        B, _, L = batch.shape
+        T = max(L // 320, 1)
+        encode_calls.append(tuple(batch.shape))
+        result = MagicMock()
+        result.audio_codes = torch.zeros(B, N, T, dtype=torch.long)
+        return result
+
+    mock_model = MagicMock()
+    mock_model.encode.side_effect = fake_model_encode
+    mock_model.parameters.return_value = iter([torch.zeros(1)])
+    return HiggsAudioCodec(mock_model, device=torch.device("cpu"))
+
+
+def test_higgs_audio_codec_encode_batch_empty() -> None:
+    codec = _make_fake_encoder_codec([])
+    assert codec.encode_batch([]) == []
+
+
+def test_higgs_audio_codec_encode_batch_same_length_batched() -> None:
+    calls: list = []
+    codec = _make_fake_encoder_codec(calls)
+    wav1 = torch.zeros(1, 1, 24000)
+    wav2 = torch.ones(1, 1, 24000) * 0.5
+    results = codec.encode_batch([wav1, wav2])
+    assert len(calls) == 1, "same-length waveforms must batch into one forward pass"
+    assert calls[0] == (2, 1, 24000)
+    assert len(results) == 2
+    assert all(r.shape == (75, 8) for r in results)
+
+
+def test_higgs_audio_codec_encode_batch_short_waveforms_padded_and_batched() -> None:
+    calls: list = []
+    codec = _make_fake_encoder_codec(calls)
+    wav1 = torch.zeros(1, 1, 8000)
+    wav2 = torch.zeros(1, 1, 12000)
+    results = codec.encode_batch([wav1, wav2])
+    assert len(calls) == 1, "short waveforms must be padded to same length and batched"
+    assert calls[0] == (2, 1, 24000)
+    assert len(results) == 2
+
+
+def test_higgs_audio_codec_encode_batch_different_lengths_separate_calls() -> None:
+    calls: list = []
+    codec = _make_fake_encoder_codec(calls)
+    wav1 = torch.zeros(1, 1, 24000)
+    wav2 = torch.zeros(1, 1, 48000)
+    results = codec.encode_batch([wav1, wav2])
+    assert len(calls) == 2, "different-length waveforms must use separate passes"
+    assert len(results) == 2
+    assert results[0].shape[0] == 75
+    assert results[1].shape[0] == 150
+
+
+def test_higgs_audio_codec_encode_batch_order_preserved() -> None:
+    calls: list = []
+    codec = _make_fake_encoder_codec(calls)
+    wavs = [torch.zeros(1, 1, 48000), torch.zeros(1, 1, 24000), torch.zeros(1, 1, 48000)]
+    results = codec.encode_batch(wavs)
+    assert len(results) == 3
+    assert results[0].shape[0] == 150
+    assert results[1].shape[0] == 75
+    assert results[2].shape[0] == 150


### PR DESCRIPTION
## Motivation

`HiggsAudioV2TokenizerModel.encode()` natively supports batched forward `[B, 1, L] -> [B, N, T]`, but `HiggsAudioCodec` only exposed single-clip `encode_reference`. For offline / bulk encoding use cases (dataset pre-encoding, batch reference-audio ingestion, eval-time preprocessing), users had to loop externally and could not exploit GPU parallelism.

This PR adds `HiggsAudioCodec.encode_batch` as the standard API for offline / bulk encoding. We **also** evaluated wiring it into the serving pipeline's `audio_encoder` stage — that turned out to regress throughput, so it is not wired in. See appendix.

## Modifications

### `HiggsAudioCodec.encode_batch(waveforms)` — new public API

Accepts `List[Tensor[1, 1, L_i]]` and returns the per-clip codes. Design notes:

- **Length bucketing.** The acoustic encoder uses symmetric (non-causal) Conv1d padding, so zero-padding shorter waveforms to a common `L_max` and running a single forward corrupts the codes. We bucket by exact length — **only equal-length waveforms are stacked into a single `[B, 1, L]` forward**; unequal lengths fall back to per-bucket `encode_reference` calls.
- **Short-clip alignment.** Clips shorter than `SAMPLE_RATE` samples (1 s @ 24 kHz) are zero-padded to 1 s before bucketing, matching `encode_reference` behaviour.
- **Order preservation.** Output order matches input order across buckets.
- **Empty input.** Returns an empty list.

### Unit tests — `tests/unit_test/higgs_tts/test_pipeline.py`

Five tests covering the above:

- `test_higgs_audio_codec_encode_batch_empty` — empty input
- `test_higgs_audio_codec_encode_batch_same_length_batched` — equal-length stacked into one forward
- `test_higgs_audio_codec_encode_batch_short_waveforms_padded_and_batched` — short clips padded to 1 s before bucketing
- `test_higgs_audio_codec_encode_batch_different_lengths_separate_calls` — unequal lengths use separate per-bucket calls
- `test_higgs_audio_codec_encode_batch_order_preserved` — output order preserved across buckets

## Use Cases

- Offline dataset pre-encoding — encode an entire reference-audio corpus in one pass
- Bulk reference-audio ingestion / migration tools
- Eval / benchmark preprocessing

## Appendix: Why this is NOT wired into the serving pipeline

We also evaluated wiring `batch_compute_fn=_encode_batch` into `create_audio_encoder_executor` (mirroring the batched vocoder in #574). Full SeedTTS EN evaluation (1088 samples) on **1× NVIDIA H200**, temperature=0.8, top-k=50. Base commit: `10d0402` (main). Model: `boson-sglang/higgs-audio-v3-tts-4b-base`.

### Speed

| Metric | c=1 main | c=1 batch | c=16 main | c=16 batch | c=32 main | c=32 batch |
|--------|----------|-----------|-----------|------------|-----------|------------|
| Latency mean (s) | 0.662 | 0.675 | 1.639 | 2.003 | 2.921 | 3.897 |
| Latency median (s) | 0.588 | 0.599 | 1.513 | 1.872 | 2.762 | 3.827 |
| Latency p95 (s) | 0.861 | 0.882 | 2.168 | 2.703 | 3.530 | 4.636 |
| Latency p99 (s) | 1.183 | 1.254 | 2.808 | 3.192 | 4.065 | 5.207 |
| RTF mean | 0.146 | 0.149 | 0.380 | 0.476 | 0.695 | 0.967 |
| **Throughput (req/s)** | **1.511** | **1.481** | **9.390** | **7.678** | **10.823** | **8.097** |
| Output tokens (mean) | 124 | 124 | 122 | 126 | 124 | 126 |

### Quality

| Metric | c=1 main | c=1 batch | c=16 main | c=16 batch | c=32 main | c=32 batch |
|--------|----------|-----------|-----------|------------|-----------|------------|
| WER corpus (excl >50%) | 1.35% | 1.35% | 1.40% | 1.32% | 1.47% | 1.30% |
| >50% WER samples | 1 | 1 | 3 | 4 | 0 | 2 |

### Throughput delta

| Concurrency | main (req/s) | batch (req/s) | Delta |
|-------------|--------------|---------------|-------|
| 1 | 1.511 | 1.481 | **-2.0%** |
| 16 | 9.390 | 7.678 | **-18.2%** |
| 32 | 10.823 | 8.097 | **-25.2%** |

### Root cause

The encoder and AR engine share a single GPU, and the AR engine is the actual bottleneck (~79% of per-request time). Batching the encoder makes its GPU usage burstier and steals cycles from the AR engine — the added latency scales with concurrency (+364 ms at c=16, +976 ms at c=32) and lands downstream on AR decode, not in the encoder itself. This contrasts with the vocoder (#574), which sits **after** the AR engine and therefore does not contend with the bottleneck.

The serving-side "avoid recomputing the same reference's codes" win is already handled by the reference-code cache in #605.

## Related Issues

#603

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
