### PR TITLE
[Higgs] torch.compile the DAC audio encoder

### DIFF
--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -196,6 +196,9 @@ def create_audio_encoder_executor(
     codec.model.acoustic_encoder = torch.compile(
         codec.model.acoustic_encoder, mode="default", dynamic=True
     )
+    codec.encode_reference(
+        torch.zeros(codec.SAMPLE_RATE), sample_rate=codec.SAMPLE_RATE
+    )
 
     def _encode(payload: StagePayload) -> StagePayload:
         state = HiggsTtsState.from_dict(payload.data)

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -193,6 +193,9 @@ def create_audio_encoder_executor(
     adapter = HiggsTokenizerAdapter(tokenizer)
 
     codec = get_or_load_codec(checkpoint_dir, device, dtype)
+    codec.model.acoustic_encoder = torch.compile(
+        codec.model.acoustic_encoder, mode="default", dynamic=True
+    )
 
     def _encode(payload: StagePayload) -> StagePayload:
         state = HiggsTtsState.from_dict(payload.data)


### PR DESCRIPTION
n=6 eager vs n=6 compiled, full 1088 SeedTTS-EN, c=16, 1×H200

| Metric | Eager (mean ± std) | Compiled (mean ± std) | Δ |
|---|---:|---:|---:|
| RTF (speed) | 0.462 ± 0.012 | 0.407 ± 0.007 | −11.8% |
| QPS (req/s) | 8.11 ± 0.36 | 8.80 ± 0.46 | +8.5% |
| Speaker similarity (WavLM, 0–100) | 66.42 ± 0.34 | 66.06 ± 0.18 | −0.55% |
| WER (excl >50% outliers) | 1.33 ± 0.07% | 1.38 ± 0.13% | +0.05pp |
| WER p95 (worst-5% tail) | 9.24 ± 0.37% | 9.85 ± 0.37% | +0.6pp |

 −11.8% RTF for −0.55% SIM plus a +0.6pp worsening of the WER tail (p95).