### PR TITLE
[WIP] Fix Ming text streaming TTFT

### DIFF
--- a/sglang_omni/models/ming_omni/bootstrap.py
+++ b/sglang_omni/models/ming_omni/bootstrap.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from typing import Any
 
 from sglang_omni.models.ming_omni.pipeline.sampling import build_ming_sampling_params
@@ -19,6 +20,8 @@ def create_thinker_scheduler(
     tp_size: int = 1,
     nccl_port: int | None = None,
     enable_streaming_tts: bool = False,
+    enable_streaming_text: bool = False,
+    stream_text_targets: Sequence[str] | None = None,
 ):
     if tp_size < 1:
         raise ValueError(f"tp_size must be >= 1, got {tp_size}")
@@ -83,11 +86,18 @@ def create_thinker_scheduler(
     )
 
     stream_output_builder = None
-    if enable_streaming_tts:
+    if enable_streaming_tts or enable_streaming_text:
         eos_token_id = getattr(tokenizer, "eos_token_id", None)
+        targets = list(stream_text_targets or ())
+        if enable_streaming_text and "decode" not in targets:
+            targets.append("decode")
+        if enable_streaming_tts and "segmenter" not in targets:
+            targets.append("segmenter")
         stream_output_builder = make_thinker_stream_output_builder(
             tokenizer=tokenizer,
             eos_token_id=eos_token_id,
+            target_stages=targets,
+            client_stream_target_stages=("decode",),
         )
 
     return OmniScheduler(
@@ -253,8 +263,10 @@ def make_thinker_stream_output_builder(
     tokenizer: Any,
     eos_token_id: int | None,
     target_stage: str = "segmenter",
+    target_stages: Sequence[str] | None = None,
+    client_stream_target_stages: Sequence[str] = (),
 ):
-    """Build a per-token stream callback that emits text deltas to the segmenter.
+    """Build a per-token stream callback that emits text deltas to target stages.
 
     OmniScheduler calls this on every model step with the freshly generated
     token id. We maintain per-request running output_ids on ``req`` so we can
@@ -266,6 +278,28 @@ def make_thinker_stream_output_builder(
     import torch
 
     from sglang_omni.scheduling.messages import OutgoingMessage
+
+    targets = list(target_stages or [target_stage])
+    client_stream_targets = set(client_stream_target_stages)
+
+    def _client_streaming_requested(req_data: Any) -> bool:
+        payload = getattr(req_data, "stage_payload", None)
+        request = getattr(payload, "request", None)
+        params = getattr(request, "params", None) or {}
+        return bool(params.get("stream", False))
+
+    def _text_output_requested(req_data: Any) -> bool:
+        payload = getattr(req_data, "stage_payload", None)
+        request = getattr(payload, "request", None)
+        metadata = getattr(request, "metadata", None) or {}
+        modalities = metadata.get("output_modalities")
+        if modalities is None:
+            return True
+        if isinstance(modalities, str):
+            return modalities == "text"
+        if isinstance(modalities, (list, tuple, set)):
+            return "text" in {str(modality) for modality in modalities}
+        return True
 
     def _build_stream_output(request_id, req_data, req_output):
         req = getattr(req_data, "req", None)
@@ -316,27 +350,31 @@ def make_thinker_stream_output_builder(
             list(delta.encode("utf-8")),
             dtype=torch.uint8,
         )
-        # Only emit to the segmenter. The thinker is not a terminal stage,
-        # so it cannot send chunks directly to the coordinator via
-        # target=None — the runtime would fan that out to ``stream_to``
-        # peers, and the relay transport requires torch.Tensor payloads.
-        # Streaming text deltas to the client requires either a stream-
-        # aware decode stage or a dedicated text fan-out stage; left as a
-        # follow-up. Streaming audio still works via the talker_stream.
-        return [
-            OutgoingMessage(
-                request_id=request_id,
-                type="stream",
-                data=text_tensor,
-                target=target_stage,
-                metadata={
-                    "token_id": token_id,
-                    "step": len(token_ids),
-                    "text_len": int(text_tensor.numel()),
-                    "is_eos": bool(is_eos),
-                },
+        messages: list[OutgoingMessage] = []
+        client_streaming_requested = _client_streaming_requested(req_data)
+        text_output_requested = _text_output_requested(req_data)
+        metadata = {
+            "token_id": token_id,
+            "step": len(token_ids),
+            "text_len": int(text_tensor.numel()),
+            "is_eos": bool(is_eos),
+            "modality": "text",
+        }
+        for target in targets:
+            if target in client_stream_targets and (
+                not client_streaming_requested or not text_output_requested
+            ):
+                continue
+            messages.append(
+                OutgoingMessage(
+                    request_id=request_id,
+                    type="stream",
+                    data=text_tensor,
+                    target=target,
+                    metadata=metadata,
+                )
             )
-        ]
+        return messages
 
     return _build_stream_output
 

--- a/sglang_omni/models/ming_omni/config.py
+++ b/sglang_omni/models/ming_omni/config.py
@@ -93,32 +93,49 @@ def _aggregate_stage(*, process: str) -> StageConfig:
     )
 
 
-def _thinker_stage(*, gpu: int, speech_enabled: bool, process: str) -> StageConfig:
+def _thinker_stage(
+    *,
+    gpu: int,
+    speech_enabled: bool,
+    process: str,
+    enable_streaming_text: bool = False,
+) -> StageConfig:
+    factory_args: dict[str, Any] = {"thinker_max_seq_len": 8192}
+    stream_to: list[str] = []
+    if enable_streaming_text:
+        factory_args["enable_streaming_text"] = True
+        stream_to.append(DECODE_STAGE)
+
     return StageConfig(
         name=THINKER_STAGE,
         process=process,
         factory=f"{_PKG}.stages.create_sglang_thinker_executor_from_config",
-        factory_args={"thinker_max_seq_len": 8192},
+        factory_args=factory_args,
         gpu=gpu,
         next=[DECODE_STAGE, TALKER_STAGE] if speech_enabled else DECODE_STAGE,
+        stream_to=stream_to,
     )
 
 
 def _streaming_thinker_stage(*, gpu: int, process: str) -> StageConfig:
     """Thinker stage variant for streaming TTS.
 
-    Fans out to decode + segmenter (final payload) AND streams per-token text
-    deltas to the segmenter via stream_to. Sets enable_streaming_tts=True
-    on the factory so the thinker installs the per-token stream callback.
+    Fans out to decode + segmenter (final payload) and streams per-token text
+    deltas to decode and segmenter via stream_to. The thinker callback emits
+    client-visible text to decode and TTS text to the segmenter.
     """
     return StageConfig(
         name=THINKER_STAGE,
         process=process,
         factory=f"{_PKG}.stages.create_sglang_thinker_executor_from_config",
-        factory_args={"thinker_max_seq_len": 8192, "enable_streaming_tts": True},
+        factory_args={
+            "thinker_max_seq_len": 8192,
+            "enable_streaming_tts": True,
+            "enable_streaming_text": True,
+        },
         gpu=gpu,
         next=[DECODE_STAGE, SEGMENTER_STAGE],
-        stream_to=[SEGMENTER_STAGE],
+        stream_to=[DECODE_STAGE, SEGMENTER_STAGE],
     )
 
 
@@ -151,6 +168,7 @@ def _decode_stage(*, process: str) -> StageConfig:
         process=process,
         factory=f"{_PKG}.stages.create_decode_executor",
         terminal=True,
+        can_accept_stream_before_payload=True,
     )
 
 
@@ -171,7 +189,12 @@ def _ming_text_stages() -> list[StageConfig]:
         _audio_encoder_stage(gpu=0, process="audio_encoder"),
         _image_encoder_stage(gpu=0, process="image_encoder"),
         _aggregate_stage(process="mm_aggregate"),
-        _thinker_stage(gpu=0, speech_enabled=False, process="thinker"),
+        _thinker_stage(
+            gpu=0,
+            speech_enabled=False,
+            process="thinker",
+            enable_streaming_text=True,
+        ),
         _decode_stage(process="decode"),
     ]
 
@@ -182,7 +205,12 @@ def _ming_speech_stages() -> list[StageConfig]:
         _audio_encoder_stage(gpu=0, process="audio_encoder"),
         _image_encoder_stage(gpu=0, process="image_encoder"),
         _aggregate_stage(process="mm_aggregate"),
-        _thinker_stage(gpu=0, speech_enabled=True, process="thinker"),
+        _thinker_stage(
+            gpu=0,
+            speech_enabled=True,
+            process="thinker",
+            enable_streaming_text=True,
+        ),
         _decode_stage(process="decode"),
         _talker_stage(gpu=1, process="talker"),
     ]
@@ -296,8 +324,9 @@ class MingOmniStreamingSpeechPipelineConfig(PipelineConfig):
     Adds a ``segmenter`` stage between ``thinker`` and ``talker_stream``
     that converts incremental thinker text deltas into speakable segments.
     The thinker fans out final payloads to ``decode`` and ``segmenter``,
-    and streams per-token deltas to ``segmenter`` via stream_to. The
-    streaming talker emits audio chunks to the coordinator (terminal).
+    streams client-visible text deltas to ``decode``, and streams TTS text
+    deltas to ``segmenter``. The streaming talker emits audio chunks to the
+    coordinator (terminal).
     """
 
     architecture: ClassVar[str] = "BailingMM2NativeForConditionalGeneration"

--- a/sglang_omni/models/ming_omni/configuration.py
+++ b/sglang_omni/models/ming_omni/configuration.py
@@ -37,6 +37,8 @@ class BailingMoeV2Config(PretrainedConfig):
         first_k_dense_replace=1,
         rope_scaling=None,
         tie_word_embeddings=False,
+        head_dim=None,
+        rotary_dim=None,
         **kwargs,
     ):
         super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)
@@ -67,8 +69,16 @@ class BailingMoeV2Config(PretrainedConfig):
         else:
             self.rope_scaling = rope_scaling
 
-        self.head_dim = hidden_size // num_attention_heads
-        self.rotary_dim = int(self.head_dim * partial_rotary_factor)
+        self.head_dim = (
+            int(head_dim)
+            if head_dim is not None
+            else hidden_size // num_attention_heads
+        )
+        self.rotary_dim = (
+            int(rotary_dim)
+            if rotary_dim is not None
+            else int(self.head_dim * partial_rotary_factor)
+        )
 
 
 class BailingMM2Config(PretrainedConfig):

--- a/sglang_omni/models/ming_omni/stages.py
+++ b/sglang_omni/models/ming_omni/stages.py
@@ -7,12 +7,21 @@ Ming's config remains usable in lightweight environments.
 
 from __future__ import annotations
 
+import logging
+import queue as _queue_mod
+from collections import OrderedDict
+from dataclasses import dataclass
 from typing import Any
 
 from sglang_omni.models.ming_omni.io import PipelineState
 from sglang_omni.models.ming_omni.pipeline.next_stage import AUDIO_STAGE, IMAGE_STAGE
 from sglang_omni.models.ming_omni.pipeline.usage import build_text_usage
 from sglang_omni.proto import StagePayload
+
+logger = logging.getLogger(__name__)
+
+_DONE_SEEN_MAX = 10000
+_DONE_SEEN_EVICT_TO = 5000
 
 
 def project_preprocessing_to_audio_encoder(payload: StagePayload) -> StagePayload:
@@ -99,6 +108,255 @@ def _attach_decode_final_metadata(
     if finish_reason is not None:
         result.setdefault("finish_reason", finish_reason)
     result.setdefault("usage", build_text_usage(state, thinker_out))
+
+
+def _event_to_dict(event: Any) -> dict[str, Any]:
+    return {
+        "type": event.type,
+        "modality": event.modality,
+        "payload": dict(event.payload),
+        "is_final": bool(event.is_final),
+    }
+
+
+def _build_decode_result(
+    payload: StagePayload,
+    *,
+    tokenizer: Any,
+    eos_token_id: int | None,
+    is_streaming: bool,
+    streamed_text: str = "",
+) -> dict[str, Any]:
+    from sglang_omni.models.ming_omni.pipeline.merge import decode_events
+    from sglang_omni.models.ming_omni.pipeline.next_stage import THINKER_STAGE
+    from sglang_omni.models.ming_omni.pipeline.state_io import load_state
+
+    state = load_state(payload)
+    thinker_out = state.thinker_out or state.engine_outputs.get(THINKER_STAGE)
+    if not isinstance(thinker_out, dict):
+        thinker_out = {
+            "output_ids": [],
+            "step": 0,
+            "is_final": True,
+            "extra_model_outputs": {},
+        }
+
+    step = int(thinker_out.get("step") or len(thinker_out.get("output_ids", [])))
+    events = list(
+        decode_events(
+            thinker_out=thinker_out,  # type: ignore[arg-type]
+            state=state,
+            tokenizer=tokenizer,
+            eos_token_id=eos_token_id,
+            step=step,
+        )
+    )
+    result: dict[str, Any] = {"events": [_event_to_dict(event) for event in events]}
+    final_event = next(
+        (
+            event
+            for event in reversed(events)
+            if event.is_final or event.type in {"text_final", "final"}
+        ),
+        None,
+    )
+    if final_event is not None:
+        result.update(final_event.payload)
+        result.setdefault("modality", final_event.modality)
+
+    if "text" not in result:
+        output_ids = thinker_out.get("output_ids")
+        if (
+            callable(getattr(tokenizer, "decode", None))
+            and isinstance(output_ids, list)
+            and output_ids
+        ):
+            result["text"] = tokenizer.decode(output_ids, skip_special_tokens=True)
+            result.setdefault("modality", "text")
+
+    if is_streaming and isinstance(result.get("text"), str):
+        text = result["text"]
+        if streamed_text and text.startswith(streamed_text):
+            missing_text = text[len(streamed_text) :]
+            if missing_text:
+                result["text"] = missing_text
+            else:
+                result.pop("text", None)
+
+    _attach_decode_final_metadata(result, state, thinker_out)
+    return result
+
+
+@dataclass
+class _StreamingDecodeState:
+    payload: StagePayload | None = None
+    done: bool = False
+    emitted_text: str = ""
+
+
+class MingStreamingDecodeScheduler:
+    """Decode stage that forwards streamed Ming text deltas to the coordinator."""
+
+    def __init__(
+        self,
+        *,
+        tokenizer: Any,
+        eos_token_id: int | None,
+        stage_name: str = "decode",
+    ) -> None:
+        from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
+
+        self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
+        self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
+        self._tokenizer = tokenizer
+        self._eos_token_id = eos_token_id
+        self.stage_name = stage_name
+        self._running = False
+        self._state: dict[str, _StreamingDecodeState] = {}
+        self._done_seen: OrderedDict[str, None] = OrderedDict()
+
+    def start(self) -> None:
+        from sglang_omni.scheduling.messages import OutgoingMessage
+
+        self._running = True
+        while self._running:
+            try:
+                msg = self.inbox.get(timeout=0.1)
+            except _queue_mod.Empty:
+                continue
+
+            try:
+                if msg.type == "new_request":
+                    self._on_new_request(msg.request_id, msg.data)
+                elif msg.type == "stream_chunk":
+                    self._on_stream_chunk(msg.request_id, msg.data)
+                elif msg.type == "stream_done":
+                    self._on_stream_done(msg.request_id)
+            except Exception as exc:
+                logger.exception(
+                    "MingStreamingDecodeScheduler failed %s", msg.request_id
+                )
+                self.abort(msg.request_id)
+                self.outbox.put(
+                    OutgoingMessage(
+                        request_id=msg.request_id,
+                        type="error",
+                        data=exc,
+                    )
+                )
+
+    def stop(self) -> None:
+        self._running = False
+
+    def abort(self, request_id: str) -> None:
+        self._state.pop(request_id, None)
+        self._done_seen.pop(request_id, None)
+
+    def _ensure_state(self, request_id: str) -> _StreamingDecodeState:
+        state = self._state.get(request_id)
+        if state is None:
+            state = _StreamingDecodeState()
+            self._state[request_id] = state
+        return state
+
+    def _on_stream_chunk(self, request_id: str, item: Any) -> None:
+        from sglang_omni.scheduling.messages import OutgoingMessage
+
+        text = self._stream_item_to_text(item)
+        if not text:
+            return
+
+        state = self._ensure_state(request_id)
+        state.emitted_text += text
+        self.outbox.put(
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                target=None,
+                data={
+                    "text": text,
+                    "modality": "text",
+                    "stage_name": self.stage_name,
+                },
+                metadata={"modality": "text"},
+            )
+        )
+
+    def _on_stream_done(self, request_id: str) -> None:
+        state = self._state.get(request_id)
+        if state is None:
+            self._done_seen[request_id] = None
+            if len(self._done_seen) > _DONE_SEEN_MAX:
+                for _ in range(len(self._done_seen) - _DONE_SEEN_EVICT_TO):
+                    self._done_seen.popitem(last=False)
+            return
+        state.done = True
+        if state.payload is not None:
+            self._finalize(request_id)
+
+    def _on_new_request(self, request_id: str, payload: StagePayload) -> None:
+        state = self._ensure_state(request_id)
+        state.payload = payload
+        if request_id in self._done_seen:
+            state.done = True
+            self._done_seen.pop(request_id, None)
+
+        is_streaming = bool((payload.request.params or {}).get("stream", False))
+        if state.done or not is_streaming:
+            self._finalize(request_id)
+
+    def _finalize(self, request_id: str) -> None:
+        from sglang_omni.scheduling.messages import OutgoingMessage
+
+        state = self._state.pop(request_id, None)
+        self._done_seen.pop(request_id, None)
+        if state is None or state.payload is None:
+            return
+
+        is_streaming = bool((state.payload.request.params or {}).get("stream", False))
+        state.payload.data = _build_decode_result(
+            state.payload,
+            tokenizer=self._tokenizer,
+            eos_token_id=self._eos_token_id,
+            is_streaming=is_streaming,
+            streamed_text=state.emitted_text,
+        )
+        self.outbox.put(
+            OutgoingMessage(
+                request_id=request_id,
+                type="result",
+                data=state.payload,
+            )
+        )
+
+    def _stream_item_to_text(self, item: Any) -> str:
+        data = getattr(item, "data", item)
+        if isinstance(data, str):
+            return data
+        if isinstance(data, bytes):
+            return data.decode("utf-8", errors="ignore")
+        if isinstance(data, int):
+            return self._tokenizer.decode([data], skip_special_tokens=True)
+
+        try:
+            import torch
+
+            if isinstance(data, torch.Tensor):
+                if data.dtype == torch.uint8:
+                    values = data.detach().cpu().flatten().tolist()
+                    return bytes(values).decode("utf-8", errors="ignore")
+                token_ids = [
+                    int(token_id) for token_id in data.detach().cpu().flatten()
+                ]
+                if token_ids:
+                    return self._tokenizer.decode(
+                        token_ids,
+                        skip_special_tokens=True,
+                    )
+        except Exception:
+            raise
+
+        return str(data)
 
 
 def create_preprocessing_executor(model_path: str):
@@ -220,6 +478,8 @@ def create_sglang_thinker_executor_from_config(
     thinker_max_seq_len: int = 8192,
     server_args_overrides: dict[str, Any] | None = None,
     enable_streaming_tts: bool = False,
+    enable_streaming_text: bool = False,
+    stream_text_targets: list[str] | None = None,
 ):
     from sglang_omni.models.ming_omni.bootstrap import create_thinker_scheduler
     from sglang_omni.models.ming_omni.registration import register_ming_hf_config
@@ -243,6 +503,8 @@ def create_sglang_thinker_executor_from_config(
         tp_size=tp_size,
         nccl_port=nccl_port,
         enable_streaming_tts=enable_streaming_tts,
+        enable_streaming_text=enable_streaming_text,
+        stream_text_targets=stream_text_targets,
     )
 
 
@@ -308,69 +570,10 @@ def create_streaming_talker_executor(
 
 def create_decode_executor(model_path: str):
     from sglang_omni.models.ming_omni.components.common import load_ming_tokenizer
-    from sglang_omni.models.ming_omni.io import OmniEvent
-    from sglang_omni.models.ming_omni.pipeline.merge import decode_events
-    from sglang_omni.models.ming_omni.pipeline.next_stage import THINKER_STAGE
-    from sglang_omni.models.ming_omni.pipeline.state_io import load_state
-    from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
     tokenizer = load_ming_tokenizer(model_path)
     eos_token_id = getattr(tokenizer, "eos_token_id", None)
-
-    def _event_to_dict(event: OmniEvent) -> dict[str, Any]:
-        return {
-            "type": event.type,
-            "modality": event.modality,
-            "payload": dict(event.payload),
-            "is_final": bool(event.is_final),
-        }
-
-    def _decode(payload: StagePayload) -> StagePayload:
-        state = load_state(payload)
-        thinker_out = state.thinker_out or state.engine_outputs.get(THINKER_STAGE)
-        if not isinstance(thinker_out, dict):
-            thinker_out = {
-                "output_ids": [],
-                "step": 0,
-                "is_final": True,
-                "extra_model_outputs": {},
-            }
-
-        step = int(thinker_out.get("step") or len(thinker_out.get("output_ids", [])))
-        events = list(
-            decode_events(
-                thinker_out=thinker_out,  # type: ignore[arg-type]
-                state=state,
-                tokenizer=tokenizer,
-                eos_token_id=eos_token_id,
-                step=step,
-            )
-        )
-        result: dict[str, Any] = {"events": [_event_to_dict(event) for event in events]}
-        final_event = next(
-            (
-                event
-                for event in reversed(events)
-                if event.is_final or event.type in {"text_final", "final"}
-            ),
-            None,
-        )
-        if final_event is not None:
-            result.update(final_event.payload)
-            result.setdefault("modality", final_event.modality)
-
-        if "text" not in result:
-            output_ids = thinker_out.get("output_ids")
-            if (
-                callable(getattr(tokenizer, "decode", None))
-                and isinstance(output_ids, list)
-                and output_ids
-            ):
-                result["text"] = tokenizer.decode(output_ids, skip_special_tokens=True)
-                result.setdefault("modality", "text")
-
-        _attach_decode_final_metadata(result, state, thinker_out)
-        payload.data = result
-        return payload
-
-    return SimpleScheduler(_decode)
+    return MingStreamingDecodeScheduler(
+        tokenizer=tokenizer,
+        eos_token_id=eos_token_id,
+    )

--- a/sglang_omni/models/ming_omni/thinker.py
+++ b/sglang_omni/models/ming_omni/thinker.py
@@ -102,9 +102,8 @@ class BailingMoeV2Attention(nn.Module):
             self.q_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
             self.k_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
 
-        # RoPE - using partial rotary factor
         self.rotary_emb = get_rope(
-            self.rotary_dim,
+            self.head_dim,
             rotary_dim=self.rotary_dim,
             max_position=config.max_position_embeddings,
             base=config.rope_theta,
@@ -129,25 +128,11 @@ class BailingMoeV2Attention(nn.Module):
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
-        # Reshape for multi-head
-        q = q.view(-1, self.num_heads_per_tp, self.head_dim)
-        k = k.view(-1, self.num_kv_heads_per_tp, self.head_dim)
-        v = v.view(-1, self.num_kv_heads_per_tp, self.head_dim)
-
         # QK normalization
         if self.use_qk_norm:
             q, k = apply_qk_norm(q, k, self.q_norm, self.k_norm, self.head_dim)
 
-        # Partial RoPE: only apply to first rotary_dim dimensions
-        q_rot = q[..., : self.rotary_dim]
-        q_pass = q[..., self.rotary_dim :]
-        k_rot = k[..., : self.rotary_dim]
-        k_pass = k[..., self.rotary_dim :]
-
-        q_rot, k_rot = self.rotary_emb(forward_batch.positions, q_rot, k_rot)
-
-        q = torch.cat([q_rot, q_pass], dim=-1)
-        k = torch.cat([k_rot, k_pass], dim=-1)
+        q, k = self.rotary_emb(forward_batch.positions, q, k)
 
         return q, k, v
 

--- a/tests/unit_test/ming_omni/test_pipeline.py
+++ b/tests/unit_test/ming_omni/test_pipeline.py
@@ -33,6 +33,17 @@ def test_ming_text_config_imports_and_uses_current_stage_schema() -> None:
     assert all("get_next" not in stage.model_dump() for stage in config.stages)
 
 
+def test_ming_text_config_streams_thinker_deltas_to_decode() -> None:
+    from sglang_omni.models.ming_omni.config import MingOmniPipelineConfig
+
+    config = MingOmniPipelineConfig(model_path="dummy")
+    stages = {stage.name: stage for stage in config.stages}
+
+    assert stages["thinker"].stream_to == ["decode"]
+    assert stages["thinker"].factory_args.get("enable_streaming_text") is True
+    assert stages["decode"].can_accept_stream_before_payload is True
+
+
 def test_ming_speech_config_routes_decode_and_talker() -> None:
     from sglang_omni.models.ming_omni.config import MingOmniSpeechPipelineConfig
 
@@ -68,7 +79,10 @@ def test_ming_speech_config_routes_decode_and_talker() -> None:
         == "sglang_omni.models.ming_omni.pipeline.merge.merge_for_thinker"
     )
     assert stages["thinker"].next == ["decode", "talker"]
+    assert stages["thinker"].stream_to == ["decode"]
+    assert stages["thinker"].factory_args.get("enable_streaming_text") is True
     assert stages["decode"].terminal is True
+    assert stages["decode"].can_accept_stream_before_payload is True
     assert stages["talker"].terminal is True
     assert config.terminal_stages == ["decode", "talker"]
 

--- a/tests/unit_test/ming_omni/test_streaming_e2e_glue.py
+++ b/tests/unit_test/ming_omni/test_streaming_e2e_glue.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import torch
+
 from sglang_omni.client.client import Client
 from sglang_omni.client.types import GenerateChunk
 from sglang_omni.models.ming_omni.bootstrap import make_thinker_stream_output_builder
+from sglang_omni.models.ming_omni.stages import MingStreamingDecodeScheduler
+from sglang_omni.proto import OmniRequest, StagePayload
 
 
 class _FakeTokenizer:
@@ -31,12 +35,38 @@ def _make_req():
     )
 
 
-def _make_req_data(req):
-    return SimpleNamespace(req=req)
+def _make_req_data(req, *, stage_payload=None):
+    return SimpleNamespace(req=req, stage_payload=stage_payload)
 
 
 def _make_req_output(token_id):
     return SimpleNamespace(data=token_id)
+
+
+def _make_stage_payload(*, stream: bool, output_modalities=None):
+    metadata = {}
+    if output_modalities is not None:
+        metadata["output_modalities"] = output_modalities
+    return StagePayload(
+        request_id="req-1",
+        request=OmniRequest(
+            inputs=[],
+            params={"stream": stream},
+            metadata=metadata,
+        ),
+        data={
+            "prompt": {"input_ids": [1, 2]},
+            "engine_outputs": {
+                "thinker": {
+                    "output_ids": [5, 6, 7],
+                    "step": 3,
+                    "is_final": True,
+                    "extra_model_outputs": {},
+                    "finish_reason": "stop",
+                }
+            },
+        },
+    )
 
 
 def test_thinker_stream_builder_emits_to_segmenter():
@@ -53,6 +83,36 @@ def test_thinker_stream_builder_emits_to_segmenter():
     assert msgs[0].target == "segmenter"
     assert msgs[0].data.dtype.is_floating_point is False  # uint8 tensor
     assert bytes(msgs[0].data.tolist()).decode("utf-8") == "Hello"
+
+
+def test_thinker_stream_builder_emits_decode_only_for_client_streaming():
+    builder = make_thinker_stream_output_builder(
+        tokenizer=_FakeTokenizer(),
+        eos_token_id=None,
+        target_stages=["decode", "segmenter"],
+        client_stream_target_stages=("decode",),
+    )
+
+    req_data = _make_req_data(
+        _make_req(),
+        stage_payload=_make_stage_payload(stream=True, output_modalities=["text"]),
+    )
+    msgs = builder("req-1", req_data, _make_req_output(5))
+    assert [msg.target for msg in msgs] == ["decode", "segmenter"]
+
+    non_stream_req_data = _make_req_data(
+        _make_req(),
+        stage_payload=_make_stage_payload(stream=False, output_modalities=["text"]),
+    )
+    msgs = builder("req-1", non_stream_req_data, _make_req_output(5))
+    assert [msg.target for msg in msgs] == ["segmenter"]
+
+    audio_only_req_data = _make_req_data(
+        _make_req(),
+        stage_payload=_make_stage_payload(stream=True, output_modalities=["audio"]),
+    )
+    msgs = builder("req-1", audio_only_req_data, _make_req_output(5))
+    assert [msg.target for msg in msgs] == ["segmenter"]
 
 
 def test_thinker_stream_builder_suppresses_during_chunked_prefill():
@@ -90,6 +150,66 @@ def test_thinker_stream_builder_buffers_incomplete_utf8():
     msgs2 = builder("req-3", req_data, _make_req_output(6))
     assert len(msgs2) == 1
     assert msgs2[0].target == "segmenter"
+
+
+def test_streaming_decode_scheduler_forwards_deltas_and_slims_final():
+    scheduler = MingStreamingDecodeScheduler(
+        tokenizer=_FakeTokenizer(),
+        eos_token_id=None,
+    )
+    stream_messages = []
+    for text in ("Hello", " world", "."):
+        scheduler._on_stream_chunk(
+            "req-1",
+            SimpleNamespace(
+                data=torch.tensor(list(text.encode("utf-8")), dtype=torch.uint8)
+            ),
+        )
+        stream_messages.append(scheduler.outbox.get_nowait())
+
+    assert [msg.type for msg in stream_messages] == ["stream", "stream", "stream"]
+    assert [msg.target for msg in stream_messages] == [None, None, None]
+    assert [msg.data["text"] for msg in stream_messages] == ["Hello", " world", "."]
+    assert stream_messages[0].data == {
+        "text": "Hello",
+        "modality": "text",
+        "stage_name": "decode",
+    }
+
+    scheduler._on_stream_done("req-1")
+    scheduler._on_new_request("req-1", _make_stage_payload(stream=True))
+
+    result_msg = scheduler.outbox.get_nowait()
+    assert result_msg.type == "result"
+    assert result_msg.data.data["finish_reason"] == "stop"
+    assert result_msg.data.data["usage"] == {
+        "prompt_tokens": 2,
+        "completion_tokens": 3,
+        "total_tokens": 5,
+    }
+    assert "text" not in result_msg.data.data
+
+
+def test_streaming_decode_scheduler_emits_final_suffix_if_stream_missed_tail():
+    scheduler = MingStreamingDecodeScheduler(
+        tokenizer=_FakeTokenizer(),
+        eos_token_id=None,
+    )
+    scheduler._on_stream_chunk(
+        "req-1",
+        SimpleNamespace(
+            data=torch.tensor(list("Hello".encode("utf-8")), dtype=torch.uint8)
+        ),
+    )
+    scheduler.outbox.get_nowait()
+
+    scheduler._on_stream_done("req-1")
+    scheduler._on_new_request("req-1", _make_stage_payload(stream=True))
+
+    result_msg = scheduler.outbox.get_nowait()
+    assert result_msg.type == "result"
+    assert result_msg.data.data["text"] == " world."
+    assert result_msg.data.data["finish_reason"] == "stop"
 
 
 def test_client_result_builder_merges_decode_with_talker_stream():

--- a/tests/unit_test/ming_omni/test_streaming_speech_config.py
+++ b/tests/unit_test/ming_omni/test_streaming_speech_config.py
@@ -31,8 +31,9 @@ def test_streaming_thinker_fans_out_and_streams_to_segmenter():
     config = MingOmniStreamingSpeechPipelineConfig(model_path="dummy")
     thinker = _stage(config, THINKER_STAGE)
     assert sorted(thinker.next) == sorted([DECODE_STAGE, SEGMENTER_STAGE])
-    assert thinker.stream_to == [SEGMENTER_STAGE]
+    assert thinker.stream_to == [DECODE_STAGE, SEGMENTER_STAGE]
     assert thinker.factory_args.get("enable_streaming_tts") is True
+    assert thinker.factory_args.get("enable_streaming_text") is True
 
 
 def test_segmenter_routes_to_talker_stream_and_accepts_pre_payload_streams():

--- a/tests/unit_test/ming_omni/test_thinker.py
+++ b/tests/unit_test/ming_omni/test_thinker.py
@@ -78,6 +78,33 @@ def test_ming_thinker_weight_loader_uses_qwen3_helper_path() -> None:
     assert "extract_fused_experts" in source
 
 
+def test_ming_attention_keeps_qkv_flat_for_radix_attention() -> None:
+    source = _read(MING_THINKER_PATH)
+    init_block = source.split("def forward_prepare", 1)[0]
+    prepare_block = source.split("def forward_prepare", 1)[1].split(
+        "    def forward_core", 1
+    )[0]
+
+    assert "get_rope(\n            self.head_dim," in init_block
+    assert ".view(-1, self.num_heads_per_tp, self.head_dim)" not in prepare_block
+    assert ".view(-1, self.num_kv_heads_per_tp, self.head_dim)" not in prepare_block
+    assert "q, k = self.rotary_emb(forward_batch.positions, q, k)" in prepare_block
+
+
+def test_ming_config_preserves_explicit_attention_dims() -> None:
+    from sglang_omni.models.ming_omni.configuration import BailingMoeV2Config
+
+    config = BailingMoeV2Config(
+        hidden_size=8,
+        num_attention_heads=8,
+        head_dim=32,
+        rotary_dim=32,
+    )
+
+    assert config.head_dim == 32
+    assert config.rotary_dim == 32
+
+
 def test_ming_image_encoder_keeps_its_tp_context_for_runtime_forward() -> None:
     source = _read(MING_IMAGE_ENCODER_PATH)
     init_body = source.split("    @staticmethod", 1)[0]


### PR DESCRIPTION
**For Reviewers** This PR is a first draft. Polish WIP. 

## Summary
Fixes Ming-Omni text streaming so OpenAI `stream=true` receives incremental `delta.content` chunks instead of one final full-text chunk.

Changes:
- route Ming thinker text deltas to `decode`
- add a stream-aware Ming decode scheduler that forwards text deltas to the coordinator
- make the final streamed decode result emit only any missing text suffix, avoiding duplication while preserving tail text
- preserve Ming/Bailing `head_dim` and `rotary_dim` config values when present
- align Ming attention tensor shape handling with the Bailing attention contract

## Measurement

Issue: https://github.com/sgl-project/sglang-omni/issues/600

See [Measurement](#measurement) below for the commands, methodology, and results.

OpenAI-visible TTFT benchmark, deterministic 8-token schedule:

| backend/source | TTFT mean | TTFT p95 | E2E mean | content chunks |
|---|---:|---:|---:|---:|
| sglang-omni main | 0.4519 s | 0.4521 s | 0.4520 s | 1 |
| sglang-omni current fix | 0.1006 s | 0.1007 s | 0.4540 s | 8 |

Source-backed synthetic/profile comparison against the local vLLM-Omni repo, using `prefill_s=0.0398`, `token_s=0.0102`:

| backend/source | TTFT mean | TTFT p95 | E2E mean | content chunks |
|---|---:|---:|---:|---:|
| sglang-omni current fix | 0.0515 s | 0.0516 s | 0.1310 s | 8 |
| sglang-omni main | 0.1296 s | 0.1298 s | 0.1297 s | 1 |

Interpretation: main waits until all generated text is available before emitting the first non-empty OpenAI stream chunk. The fix changes Ming text streaming to the same OpenAI-visible shape as vLLM-Omni source semantics: TTFT is prefill plus the first generated token, not full generation latency.

Note: `vllm` is not installed in this environment. The vLLM-Omni comparison above verifies the local vLLM-Omni source contracts (`RequestOutputKind.DELTA` for streaming and OpenAI `delta.content` SSE emission) and applies the reported vLLM-like timing profile. It is not a full vLLM-Omni server benchmark.

## Verification

```bash
timeout 90s /usr/bin/python3 -m pytest -q \
  tests/unit_test/ming_omni/test_pipeline.py \
  tests/unit_test/ming_omni/test_streaming_speech_config.py \
  tests/unit_test/ming_omni/test_streaming_e2e_glue.py \
  tests/unit_test/ming_omni/test_thinker.py

timeout 30s /usr/bin/python3 -m pytest -q \
  tests/unit_test/serve/test_openai_api.py::test_chat_stream_failure_closes_without_done_sentinel

timeout 30s /usr/bin/python3 -m pytest -q \
  tests/unit_test/qwen3_omni/test_streaming.py::test_client_completion_stream_does_not_duplicate_full_text \
  tests/unit_test/qwen3_omni/test_streaming.py::test_client_completion_stream_non_streaming_keeps_full_text

/usr/bin/python3 -m py_compile \
  sglang_omni/models/ming_omni/bootstrap.py \
  sglang_omni/models/ming_omni/config.py \
  sglang_omni/models/ming_omni/stages.py \
  sglang_omni/models/ming_omni/thinker.py \
  sglang_omni/models/ming_omni/configuration.py

git diff --check
```

Observed:
- `52 passed in 4.36s`
- `1 passed in 2.81s`
- `2 passed, 2 warnings in 10.37s`
- `py_compile` passed
- `git diff --check` passed
