### PR TITLE
Add streaming TTS schedulers

### DIFF
--- a/docs/cookbook/higgs_tts.md
+++ b/docs/cookbook/higgs_tts.md
@@ -142,6 +142,8 @@ Unlike a standard request where you wait for the full audio to be generated befo
 
 Higgs TTS implements streaming via [Server-Sent Events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events). Each SSE event carries a base64-encoded WAV chunk. Your client can decode and play each chunk as it arrives, rather than buffering the entire response.
 
+Enable streaming by setting `"stream": true` in the request body. During generation, the vocoder emits incremental audio chunks; the terminal event is intentionally slim and carries metadata such as `sample_rate` and `usage` instead of repeating the full waveform. Inside the pipeline, audio chunks use the compact `audio_waveform` payload (`bytes` plus `audio_waveform_shape`, `audio_waveform_dtype`, and `sample_rate`), which the HTTP layer encodes into the SSE `audio.data` field.
+
 1. Use curl
 
 Set `"stream": true` in your request body:

--- a/sglang_omni/models/fishaudio_s2_pro/streaming_vocoder.py
+++ b/sglang_omni/models/fishaudio_s2_pro/streaming_vocoder.py
@@ -3,23 +3,21 @@
 
 from __future__ import annotations
 
-import collections
+import asyncio
 import logging
-import queue as _queue_mod
-import time
 from dataclasses import dataclass, field
 from typing import Any
 
 import torch
 
 from sglang_omni.models.fishaudio_s2_pro.payload_types import S2ProState
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
+from sglang_omni.scheduling.streaming_simple_scheduler import StreamingSimpleScheduler
+from sglang_omni.utils.audio_payload import audio_waveform_payload
 
 logger = logging.getLogger(__name__)
-
-_ABORTED_REQUEST_ID_LIMIT = 10000
-_ABORTED_REQUEST_ID_RETAINED = 5000
 
 
 @dataclass
@@ -268,11 +266,12 @@ def trim_retained_stream_codes(
 def _build_audio_chunk_payload(
     audio_data: torch.Tensor, *, sample_rate: int
 ) -> dict[str, Any]:
-    return {
-        "audio_data": audio_data.cpu().tolist(),
-        "sample_rate": sample_rate,
-        "modality": "audio",
-    }
+    return audio_waveform_payload(
+        audio_data,
+        sample_rate=sample_rate,
+        modality="audio",
+        source_hint="S2-Pro streaming",
+    )
 
 
 def _build_usage(state: S2ProState) -> dict[str, Any] | None:
@@ -289,7 +288,7 @@ def _build_usage(state: S2ProState) -> dict[str, Any] | None:
     return usage
 
 
-class S2ProVocoderScheduler:
+class S2ProVocoderScheduler(StreamingSimpleScheduler):
     """Fish S2-Pro vocoder scheduler with streaming and batch final paths."""
 
     def __init__(
@@ -313,8 +312,6 @@ class S2ProVocoderScheduler:
                 "stream_crossfade_samples and max_batch_wait_ms must be >= 0"
             )
 
-        self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
-        self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
         self._codec = codec
         self._device = torch.device(device)
         self._stream_stride = int(stream_stride)
@@ -323,135 +320,36 @@ class S2ProVocoderScheduler:
             codec, stream_overlap_tokens
         )
         self._stream_crossfade_samples = int(stream_crossfade_samples)
-        self._max_batch_size = int(max_batch_size)
-        self._max_batch_wait_s = float(max_batch_wait_ms) / 1000.0
-        self._running = False
-        self._pending_messages: collections.deque[IncomingMessage] = collections.deque()
-
-        self._payloads: dict[str, StagePayload] = {}
         self._stream_states: dict[str, _StreamVocoderState] = {}
-        self._pending_done: set[str] = set()
-        self._aborted_request_ids: set[str] = set()
 
-    def start(self) -> None:
-        self._running = True
-        while self._running:
-            msg = self._next_message()
-            if msg is None:
-                continue
-            if msg.request_id in self._aborted_request_ids:
-                continue
-            try:
-                if msg.type == "new_request":
-                    self._handle_new_request_batch(self._collect_new_request_batch(msg))
-                elif msg.type == "stream_chunk":
-                    self._on_chunk(msg.request_id, msg.data)
-                elif msg.type == "stream_done":
-                    self._on_done(msg.request_id)
-                else:
-                    raise ValueError(f"Unsupported vocoder message type: {msg.type}")
-            except Exception as exc:
-                logger.exception("S2ProVocoderScheduler failed for %s", msg.request_id)
-                self.outbox.put(
-                    OutgoingMessage(
-                        request_id=msg.request_id,
-                        type="error",
-                        data=exc,
-                    )
-                )
-                self.abort(msg.request_id)
+        super().__init__(
+            lambda payload: self._vocode_payload(payload),
+            batch_compute_fn=lambda payloads: self._vocode_payloads(payloads),
+            max_batch_size=max_batch_size,
+            max_batch_wait_ms=max_batch_wait_ms,
+        )
+        self._payloads = self._stream_payloads
 
-    def stop(self) -> None:
-        self._running = False
+    def is_streaming_payload(self, payload: StagePayload) -> bool:
+        return self._is_streaming_payload(payload)
 
-    def abort(self, request_id: str) -> None:
-        self._record_aborted_request_id(request_id)
-        self._clear_request_state(request_id, keep_aborted=True)
+    def validate_non_streaming_payload(self, payload: StagePayload) -> None:
+        self._validate_payload_state(payload)
 
-    def _record_aborted_request_id(self, request_id: str) -> None:
-        self._aborted_request_ids.add(request_id)
-        if len(self._aborted_request_ids) <= _ABORTED_REQUEST_ID_LIMIT:
-            return
-
-        # Note (Ratish): keep aborted ids bounded for late queued messages;
-        # do not drain the shared inbox because it owns request order.
-        excess = len(self._aborted_request_ids) - _ABORTED_REQUEST_ID_RETAINED
-        to_remove = list(self._aborted_request_ids)[:excess]
-        self._aborted_request_ids -= set(to_remove)
-
-    def _clear_request_state(
-        self, request_id: str, *, keep_aborted: bool = False
-    ) -> None:
-        self._payloads.pop(request_id, None)
-        self._stream_states.pop(request_id, None)
-        self._pending_done.discard(request_id)
-        if not keep_aborted:
-            self._aborted_request_ids.discard(request_id)
-
-    def _next_message(self) -> IncomingMessage | None:
-        if self._pending_messages:
-            return self._pending_messages.popleft()
-        try:
-            return self.inbox.get(timeout=0.1)
-        except _queue_mod.Empty:
-            return None
-
-    def _collect_new_request_batch(
-        self, first_msg: IncomingMessage
-    ) -> list[IncomingMessage]:
-        batch = [first_msg]
-        if self._max_batch_size <= 1 or self._is_streaming_payload(first_msg.data):
-            return batch
-
-        deadline = time.monotonic() + self._max_batch_wait_s
-        while len(batch) < self._max_batch_size:
-            try:
-                msg = self.inbox.get_nowait()
-            except _queue_mod.Empty:
-                remaining = deadline - time.monotonic()
-                if remaining <= 0:
-                    break
-                try:
-                    msg = self.inbox.get(timeout=remaining)
-                except _queue_mod.Empty:
-                    break
-
-            if msg.request_id in self._aborted_request_ids:
-                continue
-            if msg.type == "new_request" and not self._is_streaming_payload(msg.data):
-                batch.append(msg)
-            else:
-                self._pending_messages.append(msg)
-                break
-        return batch
-
-    def _handle_new_request_batch(self, batch: list[IncomingMessage]) -> None:
-        streaming = []
-        non_streaming = []
-        for msg in batch:
-            if self._is_streaming_payload(msg.data):
-                streaming.append(msg)
-            else:
-                non_streaming.append(msg)
-        for msg in streaming:
-            self._on_streaming_new_request(msg.request_id, msg.data)
-        if non_streaming:
-            self._vocode_non_streaming_batch(non_streaming)
-
-    def _on_streaming_new_request(self, request_id: str, payload: StagePayload) -> None:
-        self._aborted_request_ids.discard(request_id)
-        self._payloads[request_id] = payload
+    def on_streaming_new_request(self, request_id: str, payload: StagePayload) -> None:
+        del payload
         self._stream_states.setdefault(request_id, _StreamVocoderState())
-        if request_id in self._pending_done:
-            self._pending_done.discard(request_id)
-            self._on_done(request_id)
 
-    def _on_chunk(self, request_id: str, chunk: Any) -> None:
-        if request_id in self._aborted_request_ids:
-            return
+    def on_stream_chunk(
+        self, request_id: str, chunk: StreamItem
+    ) -> list[OutgoingMessage]:
         state = self._stream_states.setdefault(request_id, _StreamVocoderState())
         codes = chunk.data
-        assert isinstance(codes, torch.Tensor)
+        if not isinstance(codes, torch.Tensor):
+            raise TypeError(
+                f"S2-Pro stream chunk for {request_id!r} must carry a torch.Tensor, "
+                f"got {type(codes).__name__}"
+            )
         output = build_stream_vocoder_chunk(
             state,
             codes,
@@ -462,26 +360,22 @@ class S2ProVocoderScheduler:
             stream_overlap_tokens=self._stream_overlap_tokens,
             stream_crossfade_samples=self._stream_crossfade_samples,
         )
-        if output is not None and request_id not in self._aborted_request_ids:
-            self.outbox.put(
-                OutgoingMessage(
-                    request_id=request_id,
-                    type="stream",
-                    data=output,
-                    metadata={"modality": "audio"},
-                )
+        if output is None:
+            return []
+        return [
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                data=output,
+                metadata={"modality": "audio"},
             )
+        ]
 
-    def _on_done(self, request_id: str) -> None:
-        if request_id in self._aborted_request_ids:
-            return
-        if request_id not in self._stream_states:
-            return
-        if request_id not in self._payloads:
-            self._pending_done.add(request_id)
-            return
+    def on_stream_done(self, request_id: str) -> list[OutgoingMessage]:
+        state = self._stream_states.get(request_id)
+        if state is None:
+            return []
 
-        state = self._stream_states[request_id]
         output = flush_stream_vocoder_chunk(
             state,
             codec=self._codec,
@@ -489,8 +383,9 @@ class S2ProVocoderScheduler:
             stream_overlap_tokens=self._stream_overlap_tokens,
             stream_crossfade_samples=self._stream_crossfade_samples,
         )
-        if output is not None and request_id not in self._aborted_request_ids:
-            self.outbox.put(
+        messages: list[OutgoingMessage] = []
+        if output is not None:
+            messages.append(
                 OutgoingMessage(
                     request_id=request_id,
                     type="stream",
@@ -499,69 +394,45 @@ class S2ProVocoderScheduler:
                 )
             )
 
-        payload = self._payloads.get(request_id)
-        if payload is None or request_id in self._aborted_request_ids:
-            return
+        payload = self._payloads[request_id]
         result = self._vocode_payload(payload)
-        if request_id in self._aborted_request_ids:
-            return
-        self.outbox.put(
+        messages.append(
             OutgoingMessage(
                 request_id=request_id,
                 type="result",
                 data=result,
             )
         )
-        self._clear_request_state(request_id)
+        return messages
+
+    def clear_stream_state(self, request_id: str) -> None:
+        self._stream_states.pop(request_id, None)
+
+    def _on_done(self, request_id: str) -> None:
+        if request_id not in self._stream_states and request_id not in self._payloads:
+            return
+        super()._on_done(request_id)
 
     def _vocode_non_streaming_batch(self, batch: list[IncomingMessage]) -> None:
-        batch = [
-            msg for msg in batch if msg.request_id not in self._aborted_request_ids
-        ]
-        if not batch:
-            return
-        for msg in batch:
-            self._pending_done.discard(msg.request_id)
-
-        valid_messages: list[IncomingMessage] = []
-        valid_payloads: list[StagePayload] = []
-        for msg in batch:
-            try:
-                self._validate_payload_state(msg.data)
-            except Exception as exc:
-                self.outbox.put(
-                    OutgoingMessage(
-                        request_id=msg.request_id,
-                        type="error",
-                        data=exc,
-                    )
-                )
-                continue
-            valid_messages.append(msg)
-            valid_payloads.append(msg.data)
-
-        if not valid_messages:
-            return
-
+        loop = asyncio.new_event_loop()
         try:
-            results = self._vocode_payloads(valid_payloads)
-        except Exception as exc:
-            for msg in valid_messages:
-                self.outbox.put(
-                    OutgoingMessage(request_id=msg.request_id, type="error", data=exc)
-                )
-            return
+            self._run_non_streaming_batch(batch, loop)
+        finally:
+            loop.close()
 
-        for msg, result in zip(valid_messages, results):
-            if msg.request_id in self._aborted_request_ids:
-                continue
-            self.outbox.put(
-                OutgoingMessage(
-                    request_id=msg.request_id,
-                    type="result",
-                    data=result,
-                )
-            )
+    def _handle_new_request_batch(
+        self,
+        batch: list[IncomingMessage],
+        loop: asyncio.AbstractEventLoop | None = None,
+    ) -> None:
+        owns_loop = loop is None
+        if loop is None:
+            loop = asyncio.new_event_loop()
+        try:
+            super()._handle_new_request_batch(batch, loop)
+        finally:
+            if owns_loop:
+                loop.close()
 
     def _vocode_payload(self, payload: StagePayload) -> StagePayload:
         return self._vocode_payloads([payload])[0]

--- a/sglang_omni/models/fishaudio_s2_pro/streaming_vocoder.py
+++ b/sglang_omni/models/fishaudio_s2_pro/streaming_vocoder.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from dataclasses import dataclass, field
 from typing import Any
@@ -13,7 +12,7 @@ import torch
 from sglang_omni.models.fishaudio_s2_pro.payload_types import S2ProState
 from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from sglang_omni.proto import StagePayload
-from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
+from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.streaming_simple_scheduler import StreamingSimpleScheduler
 from sglang_omni.utils.audio_payload import audio_waveform_payload
 
@@ -323,8 +322,8 @@ class S2ProVocoderScheduler(StreamingSimpleScheduler):
         self._stream_states: dict[str, _StreamVocoderState] = {}
 
         super().__init__(
-            lambda payload: self._vocode_payload(payload),
-            batch_compute_fn=lambda payloads: self._vocode_payloads(payloads),
+            self._vocode_payload,
+            batch_compute_fn=self._vocode_payloads,
             max_batch_size=max_batch_size,
             max_batch_wait_ms=max_batch_wait_ms,
         )
@@ -407,32 +406,6 @@ class S2ProVocoderScheduler(StreamingSimpleScheduler):
 
     def clear_stream_state(self, request_id: str) -> None:
         self._stream_states.pop(request_id, None)
-
-    def _on_done(self, request_id: str) -> None:
-        if request_id not in self._stream_states and request_id not in self._payloads:
-            return
-        super()._on_done(request_id)
-
-    def _vocode_non_streaming_batch(self, batch: list[IncomingMessage]) -> None:
-        loop = asyncio.new_event_loop()
-        try:
-            self._run_non_streaming_batch(batch, loop)
-        finally:
-            loop.close()
-
-    def _handle_new_request_batch(
-        self,
-        batch: list[IncomingMessage],
-        loop: asyncio.AbstractEventLoop | None = None,
-    ) -> None:
-        owns_loop = loop is None
-        if loop is None:
-            loop = asyncio.new_event_loop()
-        try:
-            super()._handle_new_request_batch(batch, loop)
-        finally:
-            if owns_loop:
-                loop.close()
 
     def _vocode_payload(self, payload: StagePayload) -> StagePayload:
         return self._vocode_payloads([payload])[0]

--- a/sglang_omni/models/higgs_tts/config.py
+++ b/sglang_omni/models/higgs_tts/config.py
@@ -46,6 +46,7 @@ class HiggsTtsPipelineConfig(PipelineConfig):
             factory_args={"device": "cuda", "max_new_tokens": 2048},
             gpu=0,
             next="vocoder",
+            stream_to=["vocoder"],
         ),
         StageConfig(
             name="vocoder",
@@ -54,6 +55,7 @@ class HiggsTtsPipelineConfig(PipelineConfig):
             factory_args={"device": "cuda"},
             gpu=0,
             terminal=True,
+            can_accept_stream_before_payload=True,
         ),
     ]
 

--- a/sglang_omni/models/higgs_tts/model_runner.py
+++ b/sglang_omni/models/higgs_tts/model_runner.py
@@ -21,12 +21,21 @@ from sglang_omni.models.higgs_tts.model import _flat_sampling_attr
 from sglang_omni.models.higgs_tts.sampler import K_MAX
 from sglang_omni.models.higgs_tts.text_tokenizer import AUDIO_PLACEHOLDER_ID
 from sglang_omni.models.higgs_tts.utils import EOC_ID
+from sglang_omni.scheduling.messages import OutgoingMessage
 
 logger = logging.getLogger(__name__)
 
 
 class HiggsTTSModelRunner(ModelRunner):
     """ModelRunner for :class:`HiggsTTSModel`."""
+
+    def __init__(self, tp_worker: Any, output_processor: Any) -> None:
+        super().__init__(tp_worker, output_processor)
+        self._outbox: Any | None = None
+        self._vocoder_target = "vocoder"
+
+    def set_stream_outbox(self, outbox: Any) -> None:
+        self._outbox = outbox
 
     def prepare_prefill(self, forward_batch, schedule_batch, requests):
         del schedule_batch
@@ -273,6 +282,7 @@ class HiggsTTSModelRunner(ModelRunner):
             codes_N = codes_BN_cpu[b]
             data.output_codes.append(codes_N.to(torch.long))
             data.generation_done = bool(gen_done_after_cpu[b])
+            self._emit_code_chunk(sched_req, codes_N)
             self._mark_sampler_finished(req, data.generation_done)
             cb0_per_row.append(int(codes_N[0].item()))
 
@@ -345,6 +355,7 @@ class HiggsTTSModelRunner(ModelRunner):
             codes_N = codes_log[-1]
             data.output_codes.append(codes_N.detach().cpu().clone())
             data.generation_done = bool(model._sampler_pool.generation_done[row].item())
+            self._emit_code_chunk(sched_req, data.output_codes[-1])
             self._mark_sampler_finished(req, data.generation_done)
             cb0_per_row.append(int(codes_N[0].item()))
 
@@ -359,6 +370,49 @@ class HiggsTTSModelRunner(ModelRunner):
         """Bridge Higgs sampler completion into upstream SGLang finish state."""
         if generation_done and req.finished_reason is None:
             req.finished_reason = FINISH_MATCHED_TOKEN(EOC_ID)
+
+    def _emit_code_chunk(self, sched_req: Any, codes_N: torch.Tensor) -> None:
+        if self._outbox is None:
+            return
+        metadata = self._stream_metadata_for_request(sched_req)
+        if metadata is None:
+            return
+        # codes_N is already CPU in both eager and CUDA-graph collection paths.
+        self._outbox.put(
+            OutgoingMessage(
+                request_id=sched_req.request_id,
+                type="stream",
+                target=self._vocoder_target,
+                data=codes_N.to(torch.long).clone(),
+                metadata=metadata,
+            )
+        )
+
+    @staticmethod
+    def _stream_metadata_for_request(sched_req: Any) -> dict[str, Any] | None:
+        data = sched_req.data
+        stage_payload = data.stage_payload
+        params = stage_payload.request.params
+        if not isinstance(params, dict):
+            raise TypeError(
+                f"Higgs request params must be a dict, got {type(params).__name__}"
+            )
+        if not bool(params.get("stream", False)):
+            return None
+
+        num_codebooks = int(data.num_codebooks)
+        codebook_size = int(data.codebook_size)
+        if num_codebooks <= 0 or codebook_size <= 2:
+            raise ValueError(
+                f"Invalid Higgs stream codec contract: "
+                f"num_codebooks={num_codebooks}, codebook_size={codebook_size}"
+            )
+        return {
+            "modality": "audio_codes",
+            "stream": True,
+            "num_codebooks": num_codebooks,
+            "codebook_size": codebook_size,
+        }
 
 
 __all__ = ["HiggsTTSModelRunner"]

--- a/sglang_omni/models/higgs_tts/model_runner.py
+++ b/sglang_omni/models/higgs_tts/model_runner.py
@@ -279,8 +279,8 @@ class HiggsTTSModelRunner(ModelRunner):
             if was_done_cpu[b]:
                 cb0_per_row.append(0)
                 continue
-            codes_N = codes_BN_cpu[b]
-            data.output_codes.append(codes_N.to(torch.long))
+            codes_N = codes_BN_cpu[b].to(torch.long).clone()
+            data.output_codes.append(codes_N)
             data.generation_done = bool(gen_done_after_cpu[b])
             self._emit_code_chunk(sched_req, codes_N)
             self._mark_sampler_finished(req, data.generation_done)
@@ -374,45 +374,18 @@ class HiggsTTSModelRunner(ModelRunner):
     def _emit_code_chunk(self, sched_req: Any, codes_N: torch.Tensor) -> None:
         if self._outbox is None:
             return
-        metadata = self._stream_metadata_for_request(sched_req)
+        metadata = sched_req.data.stream_metadata
         if metadata is None:
             return
-        # codes_N is already CPU in both eager and CUDA-graph collection paths.
         self._outbox.put(
             OutgoingMessage(
                 request_id=sched_req.request_id,
                 type="stream",
                 target=self._vocoder_target,
-                data=codes_N.to(torch.long).clone(),
+                data=codes_N,
                 metadata=metadata,
             )
         )
-
-    @staticmethod
-    def _stream_metadata_for_request(sched_req: Any) -> dict[str, Any] | None:
-        data = sched_req.data
-        stage_payload = data.stage_payload
-        params = stage_payload.request.params
-        if not isinstance(params, dict):
-            raise TypeError(
-                f"Higgs request params must be a dict, got {type(params).__name__}"
-            )
-        if not bool(params.get("stream", False)):
-            return None
-
-        num_codebooks = int(data.num_codebooks)
-        codebook_size = int(data.codebook_size)
-        if num_codebooks <= 0 or codebook_size <= 2:
-            raise ValueError(
-                f"Invalid Higgs stream codec contract: "
-                f"num_codebooks={num_codebooks}, codebook_size={codebook_size}"
-            )
-        return {
-            "modality": "audio_codes",
-            "stream": True,
-            "num_codebooks": num_codebooks,
-            "codebook_size": codebook_size,
-        }
 
 
 __all__ = ["HiggsTTSModelRunner"]

--- a/sglang_omni/models/higgs_tts/request_builders.py
+++ b/sglang_omni/models/higgs_tts/request_builders.py
@@ -28,6 +28,7 @@ class HiggsSGLangRequestData(SGLangARRequestData):
     output_codes: list[torch.Tensor] = field(default_factory=list)
     generation_done: bool = False
     engine_start_s: float = 0.0
+    stream_metadata: dict[str, Any] | None = None
 
 
 class _ResettableHiggsModel(Protocol):
@@ -108,6 +109,32 @@ def build_sglang_higgs_request(
     )
 
 
+def build_higgs_stream_metadata(
+    payload: StagePayload, data: HiggsSGLangRequestData
+) -> dict[str, Any] | None:
+    params = payload.request.params
+    if not isinstance(params, dict):
+        raise TypeError(
+            f"Higgs request params must be a dict, got {type(params).__name__}"
+        )
+    if not bool(params.get("stream", False)):
+        return None
+
+    num_codebooks = int(data.num_codebooks)
+    codebook_size = int(data.codebook_size)
+    if num_codebooks <= 0 or codebook_size <= 2:
+        raise ValueError(
+            f"Invalid Higgs stream codec contract: "
+            f"num_codebooks={num_codebooks}, codebook_size={codebook_size}"
+        )
+    return {
+        "modality": "audio_codes",
+        "stream": True,
+        "num_codebooks": num_codebooks,
+        "codebook_size": codebook_size,
+    }
+
+
 def apply_higgs_result(state: HiggsTtsState, data: HiggsSGLangRequestData) -> None:
     if data.output_codes:
         codes = torch.stack(data.output_codes, dim=0).to(torch.long)
@@ -141,6 +168,7 @@ def make_higgs_scheduler_adapters(
         data = build_sglang_higgs_request(state, request_id=payload.request_id)
         data.engine_start_s = time.perf_counter()
         data.stage_payload = payload
+        data.stream_metadata = build_higgs_stream_metadata(payload, data)
         return data
 
     def result_adapter(data: HiggsSGLangRequestData) -> StagePayload:
@@ -162,6 +190,7 @@ def make_higgs_scheduler_adapters(
 __all__ = [
     "HiggsSGLangRequestData",
     "apply_higgs_result",
+    "build_higgs_stream_metadata",
     "build_sglang_higgs_request",
     "make_higgs_scheduler_adapters",
 ]

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -15,9 +15,8 @@ Pipeline shape::
   sglang's worker; the model runner computes the fused multi-codebook
   embedding inline in prefill from ``reference_codes_delayed`` and overlays
   it at ``-100`` placeholder positions. Returns a :class:`OmniScheduler`.
-- ``create_vocoder_executor``: reverses the delay pattern, decodes via
-  :class:`HiggsAudioCodec` into a mono 24 kHz waveform. Returns a
-  :class:`SimpleScheduler`.
+- ``create_vocoder_executor``: creates the Higgs vocoder scheduler, preserving
+  batched non-streaming decode and incremental streaming audio chunks.
 """
 
 from __future__ import annotations
@@ -31,7 +30,6 @@ import torchaudio.functional as F_audio
 from tokenizers import Tokenizer
 from transformers import PreTrainedTokenizerFast
 
-from sglang_omni.models.higgs_tts.audio_codec import HiggsAudioCodec
 from sglang_omni.models.higgs_tts.model_runner import HiggsTTSModelRunner
 from sglang_omni.models.higgs_tts.payload_types import HiggsTtsState
 from sglang_omni.models.higgs_tts.request_builders import make_higgs_scheduler_adapters
@@ -41,9 +39,11 @@ from sglang_omni.models.higgs_tts.utils import (
     get_or_load_codec,
     load_audio_to_24k,
     resolve_checkpoint,
-    reverse_delay_pattern,
     to_codes_TN,
     truncate_rope_to_bf16,
+)
+from sglang_omni.models.higgs_tts.vocoder_scheduler import (
+    HiggsStreamingVocoderScheduler,
 )
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
@@ -286,7 +286,7 @@ def create_sglang_tts_engine_executor(
         max_new_tokens_cap=max_new_tokens,
     )
 
-    return OmniScheduler(
+    scheduler = OmniScheduler(
         tp_worker=model_worker,
         tree_cache=tree_cache,
         req_to_token_pool=req_to_token_pool,
@@ -302,6 +302,8 @@ def create_sglang_tts_engine_executor(
         enable_async_decode=enable_async_decode,
         async_decode_min_batch_size=async_decode_min_batch_size,
     )
+    model_runner.set_stream_outbox(scheduler.outbox)
+    return scheduler
 
 
 def create_vocoder_executor(
@@ -311,6 +313,10 @@ def create_vocoder_executor(
     dtype: str = "bfloat16",
     max_batch_size: int = 4,
     max_batch_wait_ms: int = 2,
+    stream_stride: int = 75,
+    stream_followup_stride: int = 75,
+    stream_overlap_tokens: int = 8,
+    stream_holdback_tokens: int = 4,
 ):
     """Decode Higgs delayed codes to a mono 24 kHz waveform.
 
@@ -318,76 +324,15 @@ def create_vocoder_executor(
     """
     checkpoint_dir = resolve_checkpoint(model_path)
     codec = get_or_load_codec(checkpoint_dir, device, dtype)
-    sample_rate = HiggsAudioCodec.SAMPLE_RATE
 
-    def _prepare_vocoder_item(
-        payload: StagePayload,
-    ) -> tuple[HiggsTtsState, torch.Tensor | None]:
-        state = HiggsTtsState.from_dict(payload.data)
-        delayed_rows = state.output_codes_delayed
-        if not delayed_rows:
-            return state, None
-        delayed_LN = torch.tensor(delayed_rows, dtype=torch.long)
-        if delayed_LN.shape[0] < state.num_codebooks:
-            return state, None
-        codes_TN = reverse_delay_pattern(delayed_LN)
-        codec_vocab = state.codebook_size - 2
-        return state, torch.where(
-            codes_TN >= codec_vocab, torch.zeros_like(codes_TN), codes_TN
-        )
-
-    def _store_vocoder_result(
-        payload: StagePayload,
-        state: HiggsTtsState,
-        waveform: torch.Tensor | None,
-    ) -> StagePayload:
-        if waveform is not None:
-            audio_np = waveform.detach().to(torch.float32).cpu().numpy()
-            payload.data["audio_data"] = audio_np.tolist()
-        else:
-            payload.data["audio_data"] = []
-        payload.data["sample_rate"] = sample_rate
-        payload.data["modality"] = "audio"
-        if state.prompt_tokens or state.completion_tokens or state.engine_time_s:
-            usage = {
-                "prompt_tokens": state.prompt_tokens,
-                "completion_tokens": state.completion_tokens,
-                "total_tokens": state.prompt_tokens + state.completion_tokens,
-            }
-            if state.engine_time_s:
-                usage["engine_time_s"] = round(state.engine_time_s, 6)
-            payload.data["usage"] = usage
-        return payload
-
-    def _vocode(payload: StagePayload) -> StagePayload:
-        state, codes_TN = _prepare_vocoder_item(payload)
-        waveform = codec.decode(codes_TN) if codes_TN is not None else None
-        return _store_vocoder_result(payload, state, waveform)
-
-    def _vocode_batch(payloads: list[StagePayload]) -> list[StagePayload]:
-        items = [_prepare_vocoder_item(p) for p in payloads]
-        valid = [(i, codes) for i, (_, codes) in enumerate(items) if codes is not None]
-        waveforms: list[torch.Tensor | None] = [None] * len(items)
-        if valid:
-            indices, codes_list = zip(*valid)
-            wavs = codec.decode_batch(list(codes_list))
-            if len(wavs) != len(valid):
-                raise RuntimeError(
-                    f"Higgs vocoder decode_batch returned {len(wavs)} audios "
-                    f"for {len(valid)} requests"
-                )
-            for idx, wav in zip(indices, wavs):
-                waveforms[idx] = wav
-        return [
-            _store_vocoder_result(payload, state, wav)
-            for payload, (state, _), wav in zip(payloads, items, waveforms)
-        ]
-
-    return SimpleScheduler(
-        _vocode,
-        batch_compute_fn=_vocode_batch,
+    return HiggsStreamingVocoderScheduler(
+        codec,
         max_batch_size=max_batch_size,
         max_batch_wait_ms=max_batch_wait_ms,
+        stream_stride=stream_stride,
+        stream_followup_stride=stream_followup_stride,
+        stream_overlap_tokens=stream_overlap_tokens,
+        stream_holdback_tokens=stream_holdback_tokens,
     )
 
 

--- a/sglang_omni/models/higgs_tts/vocoder_scheduler.py
+++ b/sglang_omni/models/higgs_tts/vocoder_scheduler.py
@@ -56,10 +56,11 @@ class HiggsStreamingVocoderScheduler(StreamingSimpleScheduler):
         self._stream_holdback_tokens = int(stream_holdback_tokens)
         self._sample_rate = HiggsAudioCodec.SAMPLE_RATE
         self._stream_states: dict[str, _HiggsStreamState] = {}
+        self._samples_per_frame = self._resolve_samples_per_frame(codec)
 
         super().__init__(
-            lambda payload: self._vocode_payload(payload),
-            batch_compute_fn=lambda payloads: self._vocode_payloads(payloads),
+            self._vocode_payload,
+            batch_compute_fn=self._vocode_payloads,
             max_batch_size=max_batch_size,
             max_batch_wait_ms=max_batch_wait_ms,
         )
@@ -299,7 +300,10 @@ class HiggsStreamingVocoderScheduler(StreamingSimpleScheduler):
         emit_until_raw = raw_total
         if not is_final and self._stream_holdback_tokens:
             emit_until_raw = max(0, raw_total - self._stream_holdback_tokens)
-        if emit_until_raw <= state.emitted_raw_frames:
+        can_flush_codec_tail = is_final and self._samples_per_frame is not None
+        if emit_until_raw < state.emitted_raw_frames or (
+            emit_until_raw == state.emitted_raw_frames and not can_flush_codec_tail
+        ):
             state.next_decode_rows = delayed_count + self._stream_followup_stride
             return None
 
@@ -315,10 +319,17 @@ class HiggsStreamingVocoderScheduler(StreamingSimpleScheduler):
         )
 
         decoded_raw_frames = emit_until_raw - window_start_raw
-        samples_per_frame = max(int(audio.shape[-1]) // max(decoded_raw_frames, 1), 1)
+        samples_per_frame = self._samples_per_frame or max(
+            int(audio.shape[-1]) // max(decoded_raw_frames, 1), 1
+        )
         trim_frames = state.emitted_raw_frames - window_start_raw
         trim_samples = min(int(trim_frames * samples_per_frame), int(audio.shape[-1]))
-        delta = audio[trim_samples:].contiguous()
+        if not is_final and self._samples_per_frame is not None:
+            new_frames = emit_until_raw - state.emitted_raw_frames
+            emit_samples = int(new_frames * samples_per_frame)
+            delta = audio[trim_samples : trim_samples + emit_samples].contiguous()
+        else:
+            delta = audio[trim_samples:].contiguous()
         if delta.numel() == 0:
             state.next_decode_rows = delayed_count + self._stream_followup_stride
             return None
@@ -449,6 +460,15 @@ class HiggsStreamingVocoderScheduler(StreamingSimpleScheduler):
         if state.engine_time_s:
             usage["engine_time_s"] = round(state.engine_time_s, 6)
         return usage
+
+    @staticmethod
+    def _resolve_samples_per_frame(codec: HiggsAudioCodec) -> int | None:
+        hop_length = getattr(getattr(codec, "model", None), "config", None)
+        hop_length = getattr(hop_length, "hop_length", None)
+        if hop_length is None:
+            return None
+        hop_length_i = int(hop_length)
+        return hop_length_i if hop_length_i > 0 else None
 
 
 __all__ = ["HiggsStreamingVocoderScheduler"]

--- a/sglang_omni/models/higgs_tts/vocoder_scheduler.py
+++ b/sglang_omni/models/higgs_tts/vocoder_scheduler.py
@@ -1,0 +1,454 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Streaming vocoder scheduler for Higgs TTS."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+
+from sglang_omni.models.higgs_tts.audio_codec import HiggsAudioCodec
+from sglang_omni.models.higgs_tts.payload_types import HiggsTtsState
+from sglang_omni.models.higgs_tts.utils import reverse_delay_pattern
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.messages import OutgoingMessage
+from sglang_omni.scheduling.streaming_simple_scheduler import StreamingSimpleScheduler
+from sglang_omni.utils.audio_payload import audio_waveform_payload
+
+
+@dataclass
+class _HiggsStreamState:
+    delayed_rows: list[torch.Tensor] = field(default_factory=list)
+    emitted_raw_frames: int = 0
+    next_decode_rows: int = 0
+    has_emitted: bool = False
+    num_codebooks: int | None = None
+    codebook_size: int | None = None
+
+
+class HiggsStreamingVocoderScheduler(StreamingSimpleScheduler):
+    """Decode Higgs codec rows incrementally, with batched final decode."""
+
+    def __init__(
+        self,
+        codec: HiggsAudioCodec,
+        *,
+        stream_stride: int = 75,
+        stream_followup_stride: int = 75,
+        stream_overlap_tokens: int = 8,
+        stream_holdback_tokens: int = 4,
+        max_batch_size: int = 4,
+        max_batch_wait_ms: int = 2,
+    ) -> None:
+        if stream_stride <= 0 or stream_followup_stride <= 0:
+            raise ValueError("stream_stride and stream_followup_stride must be > 0")
+        if stream_overlap_tokens < 0:
+            raise ValueError("stream_overlap_tokens must be >= 0")
+        if stream_holdback_tokens < 0:
+            raise ValueError("stream_holdback_tokens must be >= 0")
+
+        self._codec = codec
+        self._stream_stride = int(stream_stride)
+        self._stream_followup_stride = int(stream_followup_stride)
+        self._stream_overlap_tokens = int(stream_overlap_tokens)
+        self._stream_holdback_tokens = int(stream_holdback_tokens)
+        self._sample_rate = HiggsAudioCodec.SAMPLE_RATE
+        self._stream_states: dict[str, _HiggsStreamState] = {}
+
+        super().__init__(
+            lambda payload: self._vocode_payload(payload),
+            batch_compute_fn=lambda payloads: self._vocode_payloads(payloads),
+            max_batch_size=max_batch_size,
+            max_batch_wait_ms=max_batch_wait_ms,
+        )
+
+    def is_streaming_payload(self, payload: StagePayload) -> bool:
+        params = payload.request.params
+        if not isinstance(params, dict):
+            raise TypeError(
+                f"Higgs request params must be a dict, got {type(params).__name__}"
+            )
+        return bool(params.get("stream", False))
+
+    def on_streaming_new_request(self, request_id: str, payload: StagePayload) -> None:
+        stream_state = self._stream_states.setdefault(request_id, _HiggsStreamState())
+        if not isinstance(payload.data, dict):
+            raise TypeError(
+                f"Higgs streaming payload for {request_id!r} must be a dict, "
+                f"got {type(payload.data).__name__}"
+            )
+        missing = [
+            key for key in ("num_codebooks", "codebook_size") if key not in payload.data
+        ]
+        if not missing:
+            self._latch_stream_contract(
+                request_id,
+                stream_state,
+                num_codebooks=payload.data["num_codebooks"],
+                codebook_size=payload.data["codebook_size"],
+                source="payload",
+            )
+            return
+        if (
+            stream_state.num_codebooks is not None
+            and stream_state.codebook_size is not None
+        ):
+            self._latch_stream_contract(
+                request_id,
+                stream_state,
+                num_codebooks=payload.data.get(
+                    "num_codebooks", stream_state.num_codebooks
+                ),
+                codebook_size=payload.data.get(
+                    "codebook_size", stream_state.codebook_size
+                ),
+                source="payload",
+            )
+            return
+        raise RuntimeError(
+            f"Higgs streaming payload for {request_id!r} is missing fields: "
+            f"{', '.join(missing)}"
+        )
+
+    def on_stream_chunk(
+        self, request_id: str, item: StreamItem
+    ) -> list[OutgoingMessage]:
+        state = self._stream_states.setdefault(request_id, _HiggsStreamState())
+        self._latch_stream_metadata(request_id, state, item.metadata)
+
+        row = item.data
+        if not isinstance(row, torch.Tensor):
+            raise TypeError(
+                f"Higgs stream chunk for {request_id!r} must carry a torch.Tensor, "
+                f"got {type(row).__name__}"
+            )
+        row = row.to(dtype=torch.long)
+        if row.ndim != 1:
+            raise ValueError(
+                f"Higgs stream chunk must be 1-D [N], got {tuple(row.shape)}"
+            )
+
+        num_codebooks = self._require_stream_contract(state, request_id)[0]
+        if int(row.shape[0]) != num_codebooks:
+            raise ValueError(
+                f"Higgs stream chunk has {int(row.shape[0])} codebooks, "
+                f"expected {num_codebooks}"
+            )
+        state.delayed_rows.append(row)
+
+        output = self._decode_delta(state, is_final=False)
+        if output is None:
+            return []
+        return [
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                data=output,
+                metadata={"modality": "audio"},
+            )
+        ]
+
+    def on_stream_done(self, request_id: str) -> list[OutgoingMessage]:
+        payload = self._stream_payloads[request_id]
+        state = self._stream_states.setdefault(request_id, _HiggsStreamState())
+        output = self._decode_delta(state, is_final=True)
+        if output is None and not state.has_emitted:
+            output = self._audio_payload_from_stage_payload(payload)
+
+        messages: list[OutgoingMessage] = []
+        if output is not None:
+            messages.append(
+                OutgoingMessage(
+                    request_id=request_id,
+                    type="stream",
+                    data=output,
+                    metadata={"modality": "audio"},
+                )
+            )
+
+        final_data: dict[str, Any] = {
+            "modality": "audio",
+            "sample_rate": self._sample_rate,
+        }
+        usage = self._build_usage(HiggsTtsState.from_dict(payload.data))
+        if usage is not None:
+            final_data["usage"] = usage
+        messages.append(
+            OutgoingMessage(
+                request_id=request_id,
+                type="result",
+                data=StagePayload(
+                    request_id=payload.request_id,
+                    request=payload.request,
+                    data=final_data,
+                ),
+            )
+        )
+        return messages
+
+    def clear_stream_state(self, request_id: str) -> None:
+        self._stream_states.pop(request_id, None)
+
+    def _latch_stream_metadata(
+        self,
+        request_id: str,
+        state: _HiggsStreamState,
+        metadata: dict[str, Any] | None,
+    ) -> None:
+        if not isinstance(metadata, dict):
+            if state.num_codebooks is None or state.codebook_size is None:
+                raise RuntimeError(
+                    f"Higgs stream chunk for {request_id!r} is missing metadata "
+                    "with num_codebooks and codebook_size"
+                )
+            return
+        if metadata.get("modality") not in (None, "audio_codes"):
+            raise ValueError(
+                f"Higgs stream chunk modality must be audio_codes, got "
+                f"{metadata.get('modality')!r}"
+            )
+        if metadata.get("stream") is not True:
+            raise RuntimeError(
+                f"Higgs stream chunk for {request_id!r} must include "
+                "metadata['stream'] == True"
+            )
+        missing = [
+            key for key in ("num_codebooks", "codebook_size") if key not in metadata
+        ]
+        if missing and (state.num_codebooks is None or state.codebook_size is None):
+            raise RuntimeError(
+                f"Higgs stream chunk for {request_id!r} is missing metadata fields: "
+                f"{', '.join(missing)}"
+            )
+        if "num_codebooks" in metadata and "codebook_size" in metadata:
+            self._latch_stream_contract(
+                request_id,
+                state,
+                num_codebooks=metadata["num_codebooks"],
+                codebook_size=metadata["codebook_size"],
+                source="stream metadata",
+            )
+
+    @staticmethod
+    def _latch_stream_contract(
+        request_id: str,
+        state: _HiggsStreamState,
+        *,
+        num_codebooks: Any,
+        codebook_size: Any,
+        source: str,
+    ) -> None:
+        try:
+            num_codebooks_i = int(num_codebooks)
+            codebook_size_i = int(codebook_size)
+        except (TypeError, ValueError) as exc:
+            raise TypeError(
+                f"Higgs {source} for {request_id!r} must include integer "
+                "num_codebooks and codebook_size"
+            ) from exc
+        if num_codebooks_i <= 0 or codebook_size_i <= 2:
+            raise ValueError(
+                f"Higgs {source} for {request_id!r} has invalid "
+                f"num_codebooks={num_codebooks_i}, codebook_size={codebook_size_i}"
+            )
+        if state.num_codebooks is not None and state.num_codebooks != num_codebooks_i:
+            raise ValueError(
+                f"Higgs stream num_codebooks changed for {request_id!r}: "
+                f"{state.num_codebooks} -> {num_codebooks_i}"
+            )
+        if state.codebook_size is not None and state.codebook_size != codebook_size_i:
+            raise ValueError(
+                f"Higgs stream codebook_size changed for {request_id!r}: "
+                f"{state.codebook_size} -> {codebook_size_i}"
+            )
+        state.num_codebooks = num_codebooks_i
+        state.codebook_size = codebook_size_i
+
+    @staticmethod
+    def _require_stream_contract(
+        state: _HiggsStreamState,
+        request_id: str,
+    ) -> tuple[int, int]:
+        if state.num_codebooks is None or state.codebook_size is None:
+            raise RuntimeError(
+                f"Higgs stream contract for {request_id!r} is missing "
+                "num_codebooks or codebook_size"
+            )
+        return state.num_codebooks, state.codebook_size
+
+    def _decode_delta(
+        self, state: _HiggsStreamState, *, is_final: bool
+    ) -> dict[str, Any] | None:
+        delayed_count = len(state.delayed_rows)
+        if delayed_count == 0:
+            return None
+        num_codebooks, codebook_size = self._require_stream_contract(state, "<stream>")
+        if delayed_count < num_codebooks:
+            return None
+        raw_total = delayed_count - num_codebooks + 1
+
+        next_decode_rows = state.next_decode_rows or max(
+            num_codebooks, self._stream_stride
+        )
+        if not is_final and delayed_count < next_decode_rows:
+            state.next_decode_rows = next_decode_rows
+            return None
+
+        emit_until_raw = raw_total
+        if not is_final and self._stream_holdback_tokens:
+            emit_until_raw = max(0, raw_total - self._stream_holdback_tokens)
+        if emit_until_raw <= state.emitted_raw_frames:
+            state.next_decode_rows = delayed_count + self._stream_followup_stride
+            return None
+
+        window_start_raw = max(
+            0, state.emitted_raw_frames - self._stream_overlap_tokens
+        )
+        rows_end = emit_until_raw + num_codebooks - 1
+        rows = state.delayed_rows[window_start_raw:rows_end]
+        audio = self._decode_delayed_rows(
+            rows,
+            num_codebooks=num_codebooks,
+            codebook_size=codebook_size,
+        )
+
+        decoded_raw_frames = emit_until_raw - window_start_raw
+        samples_per_frame = max(int(audio.shape[-1]) // max(decoded_raw_frames, 1), 1)
+        trim_frames = state.emitted_raw_frames - window_start_raw
+        trim_samples = min(int(trim_frames * samples_per_frame), int(audio.shape[-1]))
+        delta = audio[trim_samples:].contiguous()
+        if delta.numel() == 0:
+            state.next_decode_rows = delayed_count + self._stream_followup_stride
+            return None
+
+        state.emitted_raw_frames = emit_until_raw
+        state.next_decode_rows = delayed_count + self._stream_followup_stride
+        state.has_emitted = True
+        return audio_waveform_payload(
+            delta,
+            sample_rate=self._sample_rate,
+            modality="audio",
+            source_hint="Higgs TTS streaming",
+        )
+
+    def _audio_payload_from_stage_payload(
+        self, payload: StagePayload
+    ) -> dict[str, Any] | None:
+        state = HiggsTtsState.from_dict(payload.data)
+        audio = self._decode_state_to_audio(state)
+        if audio is None:
+            return None
+        return audio_waveform_payload(
+            audio,
+            sample_rate=self._sample_rate,
+            modality="audio",
+            source_hint="Higgs TTS streaming",
+        )
+
+    def _vocode_payload(self, payload: StagePayload) -> StagePayload:
+        return self._vocode_payloads([payload])[0]
+
+    def _vocode_payloads(self, payloads: list[StagePayload]) -> list[StagePayload]:
+        items = [self._prepare_vocoder_item(payload) for payload in payloads]
+        valid = [(i, codes) for i, (_, codes) in enumerate(items) if codes is not None]
+        waveforms: list[torch.Tensor | None] = [None] * len(items)
+        if valid:
+            indices, codes_list = zip(*valid)
+            wavs = self._codec.decode_batch(list(codes_list))
+            if len(wavs) != len(valid):
+                raise RuntimeError(
+                    f"Higgs vocoder decode_batch returned {len(wavs)} audios "
+                    f"for {len(valid)} requests"
+                )
+            for idx, wav in zip(indices, wavs):
+                waveforms[idx] = wav
+        return [
+            self._store_vocoder_result(payload, state, wav)
+            for payload, (state, _), wav in zip(payloads, items, waveforms)
+        ]
+
+    def _prepare_vocoder_item(
+        self,
+        payload: StagePayload,
+    ) -> tuple[HiggsTtsState, torch.Tensor | None]:
+        state = HiggsTtsState.from_dict(payload.data)
+        delayed_rows = state.output_codes_delayed
+        if not delayed_rows:
+            return state, None
+        delayed_LN = torch.tensor(delayed_rows, dtype=torch.long)
+        if delayed_LN.shape[0] < state.num_codebooks:
+            return state, None
+        codes_TN = reverse_delay_pattern(delayed_LN)
+        codec_vocab = int(state.codebook_size) - 2
+        return state, torch.where(
+            codes_TN >= codec_vocab, torch.zeros_like(codes_TN), codes_TN
+        )
+
+    def _store_vocoder_result(
+        self,
+        payload: StagePayload,
+        state: HiggsTtsState,
+        waveform: torch.Tensor | None,
+    ) -> StagePayload:
+        if waveform is not None:
+            audio_np = waveform.detach().to(torch.float32).cpu().numpy()
+            payload.data["audio_data"] = audio_np.tolist()
+        else:
+            payload.data["audio_data"] = []
+        payload.data["sample_rate"] = self._sample_rate
+        payload.data["modality"] = "audio"
+        usage = self._build_usage(state)
+        if usage is not None:
+            payload.data["usage"] = usage
+        return payload
+
+    def _decode_state_to_audio(self, state: HiggsTtsState) -> torch.Tensor | None:
+        delayed_rows = state.output_codes_delayed
+        if not delayed_rows:
+            return None
+        rows = [torch.tensor(row, dtype=torch.long) for row in delayed_rows]
+        if len(rows) < int(state.num_codebooks):
+            return None
+        return self._decode_delayed_rows(
+            rows,
+            num_codebooks=int(state.num_codebooks),
+            codebook_size=int(state.codebook_size),
+        )
+
+    def _decode_delayed_rows(
+        self,
+        rows: list[torch.Tensor],
+        *,
+        num_codebooks: int,
+        codebook_size: int,
+    ) -> torch.Tensor:
+        if len(rows) < int(num_codebooks):
+            raise ValueError(
+                f"Higgs delayed rows must include at least {num_codebooks} rows, "
+                f"got {len(rows)}"
+            )
+        delayed_LN = torch.stack(rows, dim=0).to(torch.long)
+        codes_TN = reverse_delay_pattern(delayed_LN)
+        codec_vocab = int(codebook_size) - 2
+        codes_TN = torch.where(
+            codes_TN >= codec_vocab, torch.zeros_like(codes_TN), codes_TN
+        )
+        return self._codec.decode(codes_TN).detach().to(torch.float32)
+
+    @staticmethod
+    def _build_usage(state: HiggsTtsState) -> dict[str, Any] | None:
+        if not (state.prompt_tokens or state.completion_tokens or state.engine_time_s):
+            return None
+        usage: dict[str, Any] = {
+            "prompt_tokens": state.prompt_tokens,
+            "completion_tokens": state.completion_tokens,
+            "total_tokens": state.prompt_tokens + state.completion_tokens,
+        }
+        if state.engine_time_s:
+            usage["engine_time_s"] = round(state.engine_time_s, 6)
+        return usage
+
+
+__all__ = ["HiggsStreamingVocoderScheduler"]

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -7,15 +7,17 @@ runs vocoder incrementally, outputs final audio via outbox.
 from __future__ import annotations
 
 import logging
-import queue as _queue_mod
 from typing import Any
 
 import numpy as np
 import torch
 
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.proto import StagePayload
-from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
+from sglang_omni.scheduling.messages import OutgoingMessage
+from sglang_omni.scheduling.streaming_simple_scheduler import StreamingSimpleScheduler
+from sglang_omni.utils.audio_payload import audio_waveform_payload
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +50,7 @@ def load_code2wav_model(
     return model
 
 
-class Code2WavScheduler:
+class Code2WavScheduler(StreamingSimpleScheduler):
     """Streaming vocoder scheduler. Same inbox/outbox interface as OmniScheduler."""
 
     def __init__(
@@ -60,8 +62,6 @@ class Code2WavScheduler:
         sample_rate: int = 24000,
         codec_eos_token_id: int = 2150,
     ):
-        self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
-        self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
         self._model = model
         self._device = torch.device(device)
         self._stream_chunk_size = max(int(stream_chunk_size), 1)
@@ -69,47 +69,28 @@ class Code2WavScheduler:
         self._sample_rate = sample_rate
         self._codec_eos_token_id = codec_eos_token_id
         self._total_upsample = int(model.total_upsample)
-        self._running = False
 
         # Per-request state
         self._code_chunks: dict[str, list[torch.Tensor]] = {}
         self._emitted: dict[str, int] = {}
         self._audio_chunks: dict[str, list[np.ndarray]] = {}
-        self._payloads: dict[str, StagePayload] = {}
-        self._pending_done: set[str] = set()
         self._stream_enabled: dict[str, bool] = {}
+        super().__init__(compute_fn=None)
+        self._payloads = self._stream_payloads
 
-    def start(self) -> None:
-        self._running = True
-        while self._running:
-            try:
-                msg = self.inbox.get(timeout=0.1)
-            except _queue_mod.Empty:
-                continue
+    def is_streaming_payload(self, payload: StagePayload) -> bool:
+        del payload
+        return True
 
-            if msg.type == "new_request":
-                self._ensure_request_state(msg.request_id)
-                self._payloads[msg.request_id] = msg.data
-                if msg.request_id in self._pending_done:
-                    self._pending_done.discard(msg.request_id)
-                    self._on_done(msg.request_id)
+    def on_streaming_new_request(self, request_id: str, payload: StagePayload) -> None:
+        del payload
+        self._ensure_request_state(request_id)
 
-            elif msg.type == "stream_chunk":
-                self._on_chunk(msg.request_id, msg.data)
-
-            elif msg.type == "stream_done":
-                self._on_done(msg.request_id)
-
-    def stop(self) -> None:
-        self._running = False
-
-    def abort(self, request_id: str) -> None:
+    def clear_stream_state(self, request_id: str) -> None:
         self._code_chunks.pop(request_id, None)
         self._emitted.pop(request_id, None)
         self._audio_chunks.pop(request_id, None)
-        self._payloads.pop(request_id, None)
         self._stream_enabled.pop(request_id, None)
-        self._pending_done.discard(request_id)
 
     def _fail_request(self, request_id: str, error: Exception) -> None:
         self.outbox.put(
@@ -128,7 +109,9 @@ class Code2WavScheduler:
         self._emitted[request_id] = 0
         self._audio_chunks[request_id] = []
 
-    def _on_chunk(self, request_id: str, chunk: Any) -> None:
+    def on_stream_chunk(
+        self, request_id: str, chunk: StreamItem
+    ) -> list[OutgoingMessage]:
         self._ensure_request_state(request_id)
 
         # Latch the stream flag from talker's metadata once per request.
@@ -145,7 +128,7 @@ class Code2WavScheduler:
                         "populate it."
                     ),
                 )
-                return
+                return []
             self._stream_enabled[request_id] = bool(meta["stream"])
 
         codes = chunk.data.to(device=self._device, dtype=torch.long)
@@ -163,25 +146,20 @@ class Code2WavScheduler:
                 logger.debug(
                     "Code2Wav skip EOS req=%s codes=%s", request_id, codes.tolist()
                 )
-            return
+            return []
         self._code_chunks[request_id].append(codes)
         ready = len(self._code_chunks[request_id]) - self._emitted[request_id]
         if ready >= self._stream_chunk_size:
-            self._decode_and_emit(request_id)
+            return self._decode_and_emit(request_id)
+        return []
 
-    def _on_done(self, request_id: str) -> None:
-        if request_id not in self._code_chunks:
-            self._pending_done.add(request_id)
-            return
-        if request_id not in self._payloads:
-            self._pending_done.add(request_id)
-            return
-
+    def on_stream_done(self, request_id: str) -> list[OutgoingMessage]:
         # Decode remaining
         chunks = self._code_chunks[request_id]
         emitted = self._emitted[request_id]
+        messages: list[OutgoingMessage] = []
         if chunks and emitted < len(chunks):
-            self._decode_and_emit(request_id)
+            messages.extend(self._decode_and_emit(request_id))
 
         # Build final output
         audio_parts = self._audio_chunks.get(request_id, [])
@@ -190,7 +168,7 @@ class Code2WavScheduler:
                 request_id,
                 RuntimeError(f"code2wav produced no audio for {request_id!r}"),
             )
-            return
+            return []
         full_audio = np.concatenate(audio_parts).astype(np.float32, copy=False)
         payload = self._payloads[request_id]
         if logger.isEnabledFor(logging.DEBUG):
@@ -212,7 +190,7 @@ class Code2WavScheduler:
             }
         else:
             final_data = self._build_audio_payload(full_audio)
-        self.outbox.put(
+        messages.append(
             OutgoingMessage(
                 request_id=request_id,
                 type="result",
@@ -223,20 +201,15 @@ class Code2WavScheduler:
                 ),
             )
         )
+        return messages
 
-        # Cleanup
-        self._code_chunks.pop(request_id, None)
-        self._emitted.pop(request_id, None)
-        self._audio_chunks.pop(request_id, None)
-        self._payloads.pop(request_id, None)
-        self._stream_enabled.pop(request_id, None)
-
-    def _decode_and_emit(self, request_id: str) -> None:
+    def _decode_and_emit(self, request_id: str) -> list[OutgoingMessage]:
         chunks = self._code_chunks[request_id]
         start = self._emitted[request_id]
         end = len(chunks)
         audio = self._decode_incremental(request_id, chunks, start, end)
         self._emitted[request_id] = end
+        messages: list[OutgoingMessage] = []
         if audio.size > 0:
             is_first = not self._audio_chunks[request_id]
             self._audio_chunks[request_id].append(audio)
@@ -248,7 +221,7 @@ class Code2WavScheduler:
                     metadata={"samples": int(audio.shape[0])},
                 )
             if self._stream_enabled.get(request_id, True):
-                self.outbox.put(
+                messages.append(
                     OutgoingMessage(
                         request_id=request_id,
                         type="stream",
@@ -257,6 +230,7 @@ class Code2WavScheduler:
                         metadata={"modality": "audio"},
                     )
                 )
+        return messages
 
     def _decode_incremental(
         self, request_id: str, code_chunks, start, end
@@ -286,14 +260,12 @@ class Code2WavScheduler:
         return audio
 
     def _build_audio_payload(self, audio: np.ndarray) -> dict[str, Any]:
-        audio = audio.astype(np.float32, copy=False)
-        return {
-            "audio_waveform": audio.tobytes(),
-            "audio_waveform_shape": list(audio.shape),
-            "audio_waveform_dtype": "float32",
-            "sample_rate": self._sample_rate,
-            "modality": "audio",
-        }
+        return audio_waveform_payload(
+            audio.astype(np.float32, copy=False),
+            sample_rate=self._sample_rate,
+            modality="audio",
+            source_hint="Qwen3-Omni code2wav",
+        )
 
 
 def create_code2wav_scheduler(

--- a/sglang_omni/scheduling/streaming_simple_scheduler.py
+++ b/sglang_omni/scheduling/streaming_simple_scheduler.py
@@ -1,0 +1,428 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared scheduler for simple stages that process streaming chunks.
+
+This keeps SimpleScheduler's inbox/outbox contract, but adds the request
+lifecycle needed by stream-processing stages such as vocoders:
+
+- ``new_request`` for both streaming setup and non-streaming compute
+- ``stream_chunk`` carrying a :class:`StreamItem`
+- ``stream_done`` that may arrive before the terminal payload
+- non-streaming single and batched compute
+"""
+
+from __future__ import annotations
+
+import asyncio
+import collections
+import logging
+import queue as _queue_mod
+import threading
+import time
+from typing import Any, Callable
+
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
+from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
+
+logger = logging.getLogger(__name__)
+
+_ABORTED_REQUEST_ID_LIMIT = 10000
+_ABORTED_REQUEST_ID_RETAINED = 5000
+
+
+class StreamingSimpleScheduler:
+    """Scheduler base for simple stages with streaming input.
+
+    Subclasses implement the streaming hooks. Non-streaming requests use
+    ``compute_fn`` / ``batch_compute_fn`` exactly like SimpleScheduler, while
+    streaming requests are kept out of the non-streaming batch path.
+    """
+
+    def __init__(
+        self,
+        compute_fn: Callable[[Any], Any] | None,
+        *,
+        batch_compute_fn: Callable[[list[Any]], list[Any]] | None = None,
+        max_batch_size: int = 1,
+        max_batch_wait_ms: int = 0,
+        request_cost_fn: Callable[[Any], int] | None = None,
+        max_batch_cost: int | None = None,
+        abort_callback: Callable[[str], None] | None = None,
+    ) -> None:
+        self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
+        self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
+        self.requires_tp_work_fanout: bool = True
+
+        self._fn = compute_fn
+        self._batch_fn = batch_compute_fn
+        self._max_batch_size = max(int(max_batch_size), 1)
+        self._max_batch_wait_s = max(float(max_batch_wait_ms), 0.0) / 1000.0
+        self._request_cost_fn = request_cost_fn
+        self._max_batch_cost = (
+            max(int(max_batch_cost), 0) if max_batch_cost is not None else None
+        )
+        self._abort_callback = abort_callback
+
+        self._running = False
+        self._pending_messages: collections.deque[IncomingMessage] = collections.deque()
+        self._pending_done: set[str] = set()
+        self._stream_payloads: dict[str, Any] = {}
+        self._aborted_request_ids: set[str] = set()
+        self._abort_lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Hooks for subclasses
+    # ------------------------------------------------------------------
+
+    def is_streaming_payload(self, payload: Any) -> bool:
+        return False
+
+    def validate_non_streaming_payload(self, payload: Any) -> None:
+        del payload
+
+    def on_streaming_new_request(self, request_id: str, payload: Any) -> None:
+        del request_id, payload
+
+    def on_stream_chunk(
+        self, request_id: str, item: StreamItem
+    ) -> list[OutgoingMessage]:
+        del request_id, item
+        return []
+
+    def on_stream_done(self, request_id: str) -> list[OutgoingMessage]:
+        del request_id
+        return []
+
+    def clear_stream_state(self, request_id: str) -> None:
+        del request_id
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        self._running = True
+        loop = asyncio.new_event_loop()
+        try:
+            while self._running:
+                msg = self._next_message()
+                if msg is None:
+                    continue
+                if self._is_aborted(msg.request_id):
+                    continue
+                try:
+                    self._handle_message(msg, loop)
+                except Exception as exc:
+                    logger.exception(
+                        "%s failed for %s",
+                        self.__class__.__name__,
+                        msg.request_id,
+                    )
+                    self._emit_error(msg.request_id, exc)
+                    self.abort(msg.request_id)
+        finally:
+            loop.close()
+
+    def stop(self) -> None:
+        self._running = False
+
+    def abort(self, request_id: str) -> None:
+        self._record_aborted_request_id(request_id)
+        self._clear_request_state(request_id, keep_aborted=True)
+        self._cleanup_aborted_request(request_id)
+
+    def _handle_message(
+        self, msg: IncomingMessage, loop: asyncio.AbstractEventLoop
+    ) -> None:
+        if msg.type == "new_request":
+            self._handle_new_request_batch(self._collect_new_request_batch(msg), loop)
+            return
+        if msg.type == "stream_chunk":
+            self._on_chunk(msg.request_id, msg.data)
+            return
+        if msg.type == "stream_done":
+            self._on_done(msg.request_id)
+            return
+        raise ValueError(f"Unsupported streaming scheduler message type: {msg.type}")
+
+    def _next_message(self) -> IncomingMessage | None:
+        if self._pending_messages:
+            return self._pending_messages.popleft()
+        try:
+            return self.inbox.get(timeout=0.1)
+        except _queue_mod.Empty:
+            return None
+
+    # ------------------------------------------------------------------
+    # Abort and cleanup
+    # ------------------------------------------------------------------
+
+    def _record_aborted_request_id(self, request_id: str) -> None:
+        with self._abort_lock:
+            self._aborted_request_ids.add(request_id)
+            if len(self._aborted_request_ids) <= _ABORTED_REQUEST_ID_LIMIT:
+                return
+            excess = len(self._aborted_request_ids) - _ABORTED_REQUEST_ID_RETAINED
+            for stale_request_id in list(self._aborted_request_ids)[:excess]:
+                self._aborted_request_ids.discard(stale_request_id)
+
+    def _is_aborted(self, request_id: str) -> bool:
+        with self._abort_lock:
+            return request_id in self._aborted_request_ids
+
+    def _clear_request_state(
+        self, request_id: str, *, keep_aborted: bool = False
+    ) -> None:
+        self._stream_payloads.pop(request_id, None)
+        self._pending_done.discard(request_id)
+        self.clear_stream_state(request_id)
+        if not keep_aborted:
+            with self._abort_lock:
+                self._aborted_request_ids.discard(request_id)
+
+    def _cleanup_aborted_request(self, request_id: str) -> None:
+        if self._abort_callback is None:
+            return
+        try:
+            self._abort_callback(request_id)
+        except Exception:
+            logger.exception(
+                "%s: abort cleanup failed for %s",
+                self.__class__.__name__,
+                request_id,
+            )
+
+    # ------------------------------------------------------------------
+    # Non-streaming path
+    # ------------------------------------------------------------------
+
+    def _message_cost(self, msg: IncomingMessage) -> int:
+        if self._request_cost_fn is None or msg.type != "new_request":
+            return 0
+        return max(int(self._request_cost_fn(msg.data)), 0)
+
+    def _collect_new_request_batch(
+        self, first_msg: IncomingMessage
+    ) -> list[IncomingMessage]:
+        batch = [first_msg]
+        if (
+            self._batch_fn is None
+            or self._max_batch_size <= 1
+            or self.is_streaming_payload(first_msg.data)
+        ):
+            return batch
+
+        batch_cost = self._message_cost(first_msg)
+        deadline = time.monotonic() + self._max_batch_wait_s
+        while len(batch) < self._max_batch_size:
+            try:
+                msg = self.inbox.get_nowait()
+            except _queue_mod.Empty:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                try:
+                    msg = self.inbox.get(timeout=remaining)
+                except _queue_mod.Empty:
+                    break
+
+            if self._is_aborted(msg.request_id):
+                continue
+            if msg.type != "new_request":
+                self._pending_messages.append(msg)
+                break
+            try:
+                is_streaming = self.is_streaming_payload(msg.data)
+            except Exception as exc:
+                self._emit_error(msg.request_id, exc)
+                self.abort(msg.request_id)
+                continue
+            if is_streaming:
+                self._pending_messages.append(msg)
+                break
+            if self._max_batch_cost is not None:
+                try:
+                    msg_cost = self._message_cost(msg)
+                except Exception as exc:
+                    self._emit_error(msg.request_id, exc)
+                    self.abort(msg.request_id)
+                    continue
+                if batch and batch_cost + msg_cost > self._max_batch_cost:
+                    self._pending_messages.appendleft(msg)
+                    break
+                batch_cost += msg_cost
+            batch.append(msg)
+        return batch
+
+    def _handle_new_request_batch(
+        self,
+        batch: list[IncomingMessage],
+        loop: asyncio.AbstractEventLoop | None = None,
+    ) -> None:
+        owns_loop = loop is None
+        if loop is None:
+            loop = asyncio.new_event_loop()
+        try:
+            self._handle_new_request_batch_with_loop(batch, loop)
+        finally:
+            if owns_loop:
+                loop.close()
+
+    def _handle_new_request_batch_with_loop(
+        self,
+        batch: list[IncomingMessage],
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        streaming: list[IncomingMessage] = []
+        non_streaming: list[IncomingMessage] = []
+        for msg in batch:
+            try:
+                is_streaming = self.is_streaming_payload(msg.data)
+            except Exception as exc:
+                self._emit_error(msg.request_id, exc)
+                self.abort(msg.request_id)
+                continue
+            if is_streaming:
+                streaming.append(msg)
+            else:
+                non_streaming.append(msg)
+
+        for msg in streaming:
+            if self._is_aborted(msg.request_id):
+                continue
+            self._handle_streaming_new_request(msg.request_id, msg.data)
+
+        if non_streaming:
+            self._run_non_streaming_batch(non_streaming, loop)
+
+    def _run_non_streaming_batch(
+        self,
+        batch: list[IncomingMessage],
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        active = [msg for msg in batch if not self._is_aborted(msg.request_id)]
+        if not active:
+            return
+        for msg in active:
+            self._pending_done.discard(msg.request_id)
+
+        valid: list[IncomingMessage] = []
+        for msg in active:
+            try:
+                self.validate_non_streaming_payload(msg.data)
+            except Exception as exc:
+                self._emit_error(msg.request_id, exc)
+                continue
+            valid.append(msg)
+        if not valid:
+            return
+
+        if self._batch_fn is None or len(valid) <= 1:
+            for msg in valid:
+                if self._is_aborted(msg.request_id):
+                    continue
+                try:
+                    result = self._run_compute(msg.data, loop)
+                except Exception as exc:
+                    if not self._is_aborted(msg.request_id):
+                        self._emit_error(msg.request_id, exc)
+                    continue
+                if not self._is_aborted(msg.request_id):
+                    self._emit_result(msg.request_id, result)
+            return
+
+        try:
+            results = self._batch_fn([msg.data for msg in valid])
+            if asyncio.iscoroutine(results):
+                results = loop.run_until_complete(results)
+        except Exception as exc:
+            for msg in valid:
+                if not self._is_aborted(msg.request_id):
+                    self._emit_error(msg.request_id, exc)
+            return
+        if len(results) != len(valid):
+            exc = ValueError(
+                f"batch_compute_fn returned {len(results)} results for "
+                f"{len(valid)} requests"
+            )
+            for msg in valid:
+                if not self._is_aborted(msg.request_id):
+                    self._emit_error(msg.request_id, exc)
+            return
+        for msg, result in zip(valid, results):
+            if not self._is_aborted(msg.request_id):
+                self._emit_result(msg.request_id, result)
+
+    def _run_compute(self, payload: Any, loop: asyncio.AbstractEventLoop) -> Any:
+        if self._fn is None:
+            raise RuntimeError(
+                f"{self.__class__.__name__} does not support non-streaming compute"
+            )
+        result = self._fn(payload)
+        if asyncio.iscoroutine(result):
+            result = loop.run_until_complete(result)
+        return result
+
+    # ------------------------------------------------------------------
+    # Streaming path
+    # ------------------------------------------------------------------
+
+    def _handle_streaming_new_request(self, request_id: str, payload: Any) -> None:
+        with self._abort_lock:
+            self._aborted_request_ids.discard(request_id)
+        self._stream_payloads[request_id] = payload
+        self.on_streaming_new_request(request_id, payload)
+        if request_id in self._pending_done:
+            self._pending_done.discard(request_id)
+            self._handle_stream_done(request_id)
+
+    def _handle_stream_chunk(self, request_id: str, item: Any) -> None:
+        if not isinstance(item, StreamItem):
+            raise TypeError(
+                f"{self.__class__.__name__} expected StreamItem for "
+                f"{request_id!r}, got {type(item).__name__}"
+            )
+        for out in self.on_stream_chunk(request_id, item):
+            if not self._is_aborted(request_id):
+                self.outbox.put(out)
+
+    def _handle_stream_done(self, request_id: str) -> None:
+        if request_id not in self._stream_payloads:
+            self._pending_done.add(request_id)
+            return
+        for out in self.on_stream_done(request_id):
+            if not self._is_aborted(request_id):
+                self.outbox.put(out)
+        if not self._is_aborted(request_id):
+            self._clear_request_state(request_id)
+
+    # Compatibility wrappers for existing tests and subclasses.
+    def _on_streaming_new_request(self, request_id: str, payload: Any) -> None:
+        self._handle_streaming_new_request(request_id, payload)
+
+    def _on_chunk(self, request_id: str, item: StreamItem) -> None:
+        self._handle_stream_chunk(request_id, item)
+
+    def _on_done(self, request_id: str) -> None:
+        self._handle_stream_done(request_id)
+
+    # ------------------------------------------------------------------
+    # Outbox helpers
+    # ------------------------------------------------------------------
+
+    def _emit_result(self, request_id: str, result: Any) -> None:
+        self.outbox.put(
+            OutgoingMessage(
+                request_id=request_id,
+                type="result",
+                data=result,
+            )
+        )
+
+    def _emit_error(self, request_id: str, error: BaseException) -> None:
+        self.outbox.put(
+            OutgoingMessage(
+                request_id=request_id,
+                type="error",
+                data=error,
+            )
+        )

--- a/sglang_omni/scheduling/streaming_simple_scheduler.py
+++ b/sglang_omni/scheduling/streaming_simple_scheduler.py
@@ -27,6 +27,8 @@ logger = logging.getLogger(__name__)
 
 _ABORTED_REQUEST_ID_LIMIT = 10000
 _ABORTED_REQUEST_ID_RETAINED = 5000
+_COMPLETED_NON_STREAMING_REQUEST_ID_LIMIT = 10000
+_COMPLETED_NON_STREAMING_REQUEST_ID_RETAINED = 5000
 
 
 class StreamingSimpleScheduler:
@@ -67,6 +69,7 @@ class StreamingSimpleScheduler:
         self._pending_done: set[str] = set()
         self._stream_payloads: dict[str, Any] = {}
         self._aborted_request_ids: set[str] = set()
+        self._completed_non_streaming_request_ids: set[str] = set()
         self._abort_lock = threading.Lock()
 
     # ------------------------------------------------------------------
@@ -178,6 +181,22 @@ class StreamingSimpleScheduler:
         if not keep_aborted:
             with self._abort_lock:
                 self._aborted_request_ids.discard(request_id)
+
+    def _record_completed_non_streaming_request_id(self, request_id: str) -> None:
+        self._completed_non_streaming_request_ids.add(request_id)
+        if (
+            len(self._completed_non_streaming_request_ids)
+            <= _COMPLETED_NON_STREAMING_REQUEST_ID_LIMIT
+        ):
+            return
+        excess = (
+            len(self._completed_non_streaming_request_ids)
+            - _COMPLETED_NON_STREAMING_REQUEST_ID_RETAINED
+        )
+        for stale_request_id in list(self._completed_non_streaming_request_ids)[
+            :excess
+        ]:
+            self._completed_non_streaming_request_ids.discard(stale_request_id)
 
     def _cleanup_aborted_request(self, request_id: str) -> None:
         if self._abort_callback is None:
@@ -311,6 +330,7 @@ class StreamingSimpleScheduler:
                 self.validate_non_streaming_payload(msg.data)
             except Exception as exc:
                 self._emit_error(msg.request_id, exc)
+                self._record_completed_non_streaming_request_id(msg.request_id)
                 continue
             valid.append(msg)
         if not valid:
@@ -325,9 +345,11 @@ class StreamingSimpleScheduler:
                 except Exception as exc:
                     if not self._is_aborted(msg.request_id):
                         self._emit_error(msg.request_id, exc)
+                        self._record_completed_non_streaming_request_id(msg.request_id)
                     continue
                 if not self._is_aborted(msg.request_id):
                     self._emit_result(msg.request_id, result)
+                    self._record_completed_non_streaming_request_id(msg.request_id)
             return
 
         try:
@@ -338,6 +360,7 @@ class StreamingSimpleScheduler:
             for msg in valid:
                 if not self._is_aborted(msg.request_id):
                     self._emit_error(msg.request_id, exc)
+                    self._record_completed_non_streaming_request_id(msg.request_id)
             return
         if len(results) != len(valid):
             exc = ValueError(
@@ -347,10 +370,12 @@ class StreamingSimpleScheduler:
             for msg in valid:
                 if not self._is_aborted(msg.request_id):
                     self._emit_error(msg.request_id, exc)
+                    self._record_completed_non_streaming_request_id(msg.request_id)
             return
         for msg, result in zip(valid, results):
             if not self._is_aborted(msg.request_id):
                 self._emit_result(msg.request_id, result)
+                self._record_completed_non_streaming_request_id(msg.request_id)
 
     def _run_compute(self, payload: Any, loop: asyncio.AbstractEventLoop) -> Any:
         if self._fn is None:
@@ -369,6 +394,7 @@ class StreamingSimpleScheduler:
     def _handle_streaming_new_request(self, request_id: str, payload: Any) -> None:
         with self._abort_lock:
             self._aborted_request_ids.discard(request_id)
+        self._completed_non_streaming_request_ids.discard(request_id)
         self._stream_payloads[request_id] = payload
         self.on_streaming_new_request(request_id, payload)
         if request_id in self._pending_done:
@@ -387,6 +413,8 @@ class StreamingSimpleScheduler:
 
     def _handle_stream_done(self, request_id: str) -> None:
         if request_id not in self._stream_payloads:
+            if request_id in self._completed_non_streaming_request_ids:
+                return
             self._pending_done.add(request_id)
             return
         for out in self.on_stream_done(request_id):

--- a/sglang_omni/scheduling/streaming_simple_scheduler.py
+++ b/sglang_omni/scheduling/streaming_simple_scheduler.py
@@ -70,6 +70,7 @@ class StreamingSimpleScheduler:
         self._stream_payloads: dict[str, Any] = {}
         self._aborted_request_ids: set[str] = set()
         self._completed_non_streaming_request_ids: set[str] = set()
+        self._state_lock = threading.RLock()
         self._abort_lock = threading.Lock()
 
     # ------------------------------------------------------------------
@@ -175,28 +176,30 @@ class StreamingSimpleScheduler:
     def _clear_request_state(
         self, request_id: str, *, keep_aborted: bool = False
     ) -> None:
-        self._stream_payloads.pop(request_id, None)
-        self._pending_done.discard(request_id)
-        self.clear_stream_state(request_id)
-        if not keep_aborted:
-            with self._abort_lock:
-                self._aborted_request_ids.discard(request_id)
+        with self._state_lock:
+            self._stream_payloads.pop(request_id, None)
+            self._pending_done.discard(request_id)
+            self.clear_stream_state(request_id)
+            if not keep_aborted:
+                with self._abort_lock:
+                    self._aborted_request_ids.discard(request_id)
 
     def _record_completed_non_streaming_request_id(self, request_id: str) -> None:
-        self._completed_non_streaming_request_ids.add(request_id)
-        if (
-            len(self._completed_non_streaming_request_ids)
-            <= _COMPLETED_NON_STREAMING_REQUEST_ID_LIMIT
-        ):
-            return
-        excess = (
-            len(self._completed_non_streaming_request_ids)
-            - _COMPLETED_NON_STREAMING_REQUEST_ID_RETAINED
-        )
-        for stale_request_id in list(self._completed_non_streaming_request_ids)[
-            :excess
-        ]:
-            self._completed_non_streaming_request_ids.discard(stale_request_id)
+        with self._state_lock:
+            self._completed_non_streaming_request_ids.add(request_id)
+            if (
+                len(self._completed_non_streaming_request_ids)
+                <= _COMPLETED_NON_STREAMING_REQUEST_ID_LIMIT
+            ):
+                return
+            excess = (
+                len(self._completed_non_streaming_request_ids)
+                - _COMPLETED_NON_STREAMING_REQUEST_ID_RETAINED
+            )
+            for stale_request_id in list(self._completed_non_streaming_request_ids)[
+                :excess
+            ]:
+                self._completed_non_streaming_request_ids.discard(stale_request_id)
 
     def _cleanup_aborted_request(self, request_id: str) -> None:
         if self._abort_callback is None:
@@ -321,8 +324,9 @@ class StreamingSimpleScheduler:
         active = [msg for msg in batch if not self._is_aborted(msg.request_id)]
         if not active:
             return
-        for msg in active:
-            self._pending_done.discard(msg.request_id)
+        with self._state_lock:
+            for msg in active:
+                self._pending_done.discard(msg.request_id)
 
         valid: list[IncomingMessage] = []
         for msg in active:
@@ -394,12 +398,13 @@ class StreamingSimpleScheduler:
     def _handle_streaming_new_request(self, request_id: str, payload: Any) -> None:
         with self._abort_lock:
             self._aborted_request_ids.discard(request_id)
-        self._completed_non_streaming_request_ids.discard(request_id)
-        self._stream_payloads[request_id] = payload
-        self.on_streaming_new_request(request_id, payload)
-        if request_id in self._pending_done:
-            self._pending_done.discard(request_id)
-            self._handle_stream_done(request_id)
+        with self._state_lock:
+            self._completed_non_streaming_request_ids.discard(request_id)
+            self._stream_payloads[request_id] = payload
+            self.on_streaming_new_request(request_id, payload)
+            if request_id in self._pending_done:
+                self._pending_done.discard(request_id)
+                self._handle_stream_done(request_id)
 
     def _handle_stream_chunk(self, request_id: str, item: Any) -> None:
         if not isinstance(item, StreamItem):
@@ -407,21 +412,23 @@ class StreamingSimpleScheduler:
                 f"{self.__class__.__name__} expected StreamItem for "
                 f"{request_id!r}, got {type(item).__name__}"
             )
-        for out in self.on_stream_chunk(request_id, item):
-            if not self._is_aborted(request_id):
-                self.outbox.put(out)
+        with self._state_lock:
+            for out in self.on_stream_chunk(request_id, item):
+                if not self._is_aborted(request_id):
+                    self.outbox.put(out)
 
     def _handle_stream_done(self, request_id: str) -> None:
-        if request_id not in self._stream_payloads:
-            if request_id in self._completed_non_streaming_request_ids:
+        with self._state_lock:
+            if request_id not in self._stream_payloads:
+                if request_id in self._completed_non_streaming_request_ids:
+                    return
+                self._pending_done.add(request_id)
                 return
-            self._pending_done.add(request_id)
-            return
-        for out in self.on_stream_done(request_id):
+            for out in self.on_stream_done(request_id):
+                if not self._is_aborted(request_id):
+                    self.outbox.put(out)
             if not self._is_aborted(request_id):
-                self.outbox.put(out)
-        if not self._is_aborted(request_id):
-            self._clear_request_state(request_id)
+                self._clear_request_state(request_id)
 
     # Compatibility wrappers for existing tests and subclasses.
     def _on_streaming_new_request(self, request_id: str, payload: Any) -> None:

--- a/sglang_omni/utils/audio_payload.py
+++ b/sglang_omni/utils/audio_payload.py
@@ -12,6 +12,8 @@ import torch
 def audio_waveform_payload(
     audio: Any,
     *,
+    sample_rate: int | None = None,
+    modality: str | None = None,
     source_hint: str = "audio",
 ) -> dict[str, Any]:
     if isinstance(audio, torch.Tensor):
@@ -22,8 +24,13 @@ def audio_waveform_payload(
         raise TypeError(
             f"Unsupported {source_hint} audio output type: {type(audio)}"
         ) from exc
-    return {
+    payload: dict[str, Any] = {
         "audio_waveform": array.tobytes(),
         "audio_waveform_shape": list(array.shape),
         "audio_waveform_dtype": "float32",
     }
+    if sample_rate is not None:
+        payload["sample_rate"] = int(sample_rate)
+    if modality is not None:
+        payload["modality"] = modality
+    return payload

--- a/tests/unit_test/fishaudio_s2_pro/test_streaming_vocoder.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_streaming_vocoder.py
@@ -5,6 +5,7 @@ import queue
 import threading
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 import torch
 
@@ -111,6 +112,15 @@ def _chunk(value: int = 1) -> StreamItem:
     return StreamItem(chunk_id=value, data=_code(value), from_stage="tts_engine")
 
 
+def _audio_tensor(payload: dict) -> torch.Tensor:
+    audio = np.frombuffer(payload["audio_waveform"], dtype=np.float32)
+    return torch.from_numpy(audio.copy()).reshape(payload["audio_waveform_shape"])
+
+
+def _audio_len(payload: dict) -> int:
+    return int(np.prod(payload["audio_waveform_shape"]))
+
+
 def _start_scheduler(
     *,
     stream_stride: int = 3,
@@ -149,7 +159,7 @@ def test_streaming_vocoder_chunk_cadence() -> None:
         first = scheduler.outbox.get(timeout=2.0)
         assert first.type == "stream"
         assert first.data["modality"] == "audio"
-        assert len(first.data["audio_data"]) == 12
+        assert _audio_len(first.data) == 12
 
         for value in range(4, 8):
             scheduler.inbox.put(IncomingMessage("req", "stream_chunk", _chunk(value)))
@@ -177,7 +187,7 @@ def test_streaming_vocoder_sample_level_matches_contextual_full_decode() -> None
             stream_crossfade_samples=0,
         )
         if output is not None:
-            chunks.append(torch.tensor(output["audio_data"]))
+            chunks.append(_audio_tensor(output))
 
     output = flush_stream_vocoder_chunk(
         state,
@@ -187,7 +197,7 @@ def test_streaming_vocoder_sample_level_matches_contextual_full_decode() -> None
         stream_crossfade_samples=0,
     )
     if output is not None:
-        chunks.append(torch.tensor(output["audio_data"]))
+        chunks.append(_audio_tensor(output))
 
     streaming_audio = torch.cat(chunks)
     full_audio = codec.from_indices(full_codes[1:][None])[0, 0]
@@ -241,7 +251,7 @@ def test_streaming_vocoder_zero_overlap_final_flush_emits_retained_tail() -> Non
 
     assert flush is not None
     assert flush["modality"] == "audio"
-    assert len(flush["audio_data"]) == 3
+    assert _audio_len(flush) == 3
     assert state.pending_tail is None
 
 
@@ -263,7 +273,7 @@ def test_streaming_vocoder_final_flush_clears_tail_when_codes_remain() -> None:
     )
 
     assert flush is not None
-    assert flush["audio_data"] == [1.0, 2.0, 3.0]
+    assert _audio_tensor(flush).tolist() == [1.0, 2.0, 3.0]
     assert state.pending_tail is None
 
 

--- a/tests/unit_test/fishaudio_s2_pro/test_streaming_vocoder.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_streaming_vocoder.py
@@ -314,6 +314,20 @@ def test_streaming_vocoder_done_before_payload_finalizes_after_new_request() -> 
         _stop_scheduler(scheduler, thread)
 
 
+def test_streaming_vocoder_zero_chunk_done_before_payload_finalizes() -> None:
+    scheduler, thread = _start_scheduler()
+    try:
+        scheduler.inbox.put(IncomingMessage("req", "stream_done"))
+        scheduler.inbox.put(IncomingMessage("req", "new_request", _payload("req")))
+        final = scheduler.outbox.get(timeout=2.0)
+        assert final.type == "result"
+        assert final.request_id == "req"
+        with pytest.raises(queue.Empty):
+            scheduler.outbox.get(timeout=0.2)
+    finally:
+        _stop_scheduler(scheduler, thread)
+
+
 def test_streaming_vocoder_final_payload_preserves_usage_and_authoritative_audio() -> (
     None
 ):
@@ -527,7 +541,7 @@ def test_non_streaming_vocoder_batch_isolates_invalid_payload() -> None:
         ),
     ]
 
-    scheduler._vocode_non_streaming_batch(messages)
+    scheduler._handle_new_request_batch(messages)
 
     outputs = [scheduler.outbox.get_nowait(), scheduler.outbox.get_nowait()]
     by_request = {out.request_id: out for out in outputs}
@@ -632,9 +646,9 @@ def test_non_streaming_vocoder_abort_during_batch_decode_suppresses_result() -> 
         scheduler.abort("aborted")
         return payloads
 
-    scheduler._vocode_payloads = _abort_during_decode
+    scheduler._batch_fn = _abort_during_decode
 
-    scheduler._vocode_non_streaming_batch(messages)
+    scheduler._handle_new_request_batch(messages)
 
     out = scheduler.outbox.get_nowait()
     assert out.request_id == "other"

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -1,14 +1,29 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import queue
 from types import SimpleNamespace
 
+import numpy as np
 import torch
 
 from sglang_omni.models.higgs_tts import stages
+from sglang_omni.models.higgs_tts.config import HiggsTtsPipelineConfig
 from sglang_omni.models.higgs_tts.model_runner import HiggsTTSModelRunner
 from sglang_omni.models.higgs_tts.payload_types import HiggsTtsState
-from sglang_omni.models.higgs_tts.utils import EOC_ID
+from sglang_omni.models.higgs_tts.utils import EOC_ID, apply_delay_pattern
+from sglang_omni.models.higgs_tts.vocoder_scheduler import (
+    HiggsStreamingVocoderScheduler,
+)
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from sglang_omni.proto import OmniRequest, StagePayload
+
+
+def test_higgs_streaming_pipeline_routes_chunks_to_vocoder() -> None:
+    config = HiggsTtsPipelineConfig(model_path="fake-model")
+    stages_by_name = {stage.name: stage for stage in config.stages}
+
+    assert stages_by_name["tts_engine"].stream_to == ["vocoder"]
+    assert stages_by_name["vocoder"].can_accept_stream_before_payload is True
 
 
 def test_higgs_tts_engine_enables_cuda_graph_by_default(monkeypatch) -> None:
@@ -46,9 +61,14 @@ def test_higgs_tts_engine_enables_cuda_graph_by_default(monkeypatch) -> None:
         def __init__(self, model_worker, output_proc) -> None:
             captured["model_runner_args"] = (model_worker, output_proc)
 
+        def set_stream_outbox(self, outbox) -> None:
+            self._outbox = outbox
+            captured["stream_outbox"] = outbox
+
     class FakeScheduler:
         def __init__(self, **kwargs) -> None:
             captured["scheduler_kwargs"] = kwargs
+            self.outbox = object()
 
     monkeypatch.setattr(stages, "resolve_checkpoint", lambda model_path: model_path)
     monkeypatch.setattr(
@@ -77,10 +97,16 @@ def test_higgs_tts_engine_enables_cuda_graph_by_default(monkeypatch) -> None:
     assert captured["overrides"]["cuda_graph_max_bs"] == 32
     assert captured["server_args"].disable_overlap_schedule is True
     assert captured["adapter_kwargs"] == {"max_new_tokens_cap": 2048}
+    assert (
+        captured["stream_outbox"]
+        is captured["scheduler_kwargs"]["model_runner"]._outbox
+    )
 
 
 def test_higgs_model_runner_marks_sampler_finish() -> None:
     runner = object.__new__(HiggsTTSModelRunner)
+    runner._outbox = None
+    runner._vocoder_target = "vocoder"
     runner.model = SimpleNamespace(
         _rid_to_row={"req": 0},
         _output_codes={"req": [torch.tensor([EOC_ID, 1, 2])]},
@@ -106,8 +132,58 @@ def test_higgs_model_runner_marks_sampler_finish() -> None:
     assert len(data.output_codes) == 1
 
 
+def test_higgs_model_runner_emits_strict_stream_metadata() -> None:
+    runner = object.__new__(HiggsTTSModelRunner)
+    runner._outbox = queue.Queue()
+    runner._vocoder_target = "vocoder"
+    runner.model = SimpleNamespace(
+        _rid_to_row={"req": 0},
+        _output_codes={"req": [torch.tensor([EOC_ID, 1, 2])]},
+        _sampler_pool=SimpleNamespace(generation_done=torch.tensor([True])),
+    )
+    req = SimpleNamespace(
+        is_chunked=0,
+        finished_reason=None,
+        finished=lambda: False,
+    )
+    payload = StagePayload(
+        request_id="req",
+        request=OmniRequest(inputs="", params={"stream": True}),
+        data={},
+    )
+    data = SimpleNamespace(
+        req=req,
+        output_codes=[],
+        generation_done=False,
+        stage_payload=payload,
+        num_codebooks=3,
+        codebook_size=17,
+    )
+    result = SimpleNamespace(
+        logits_output=SimpleNamespace(next_token_logits=torch.zeros(1, 4))
+    )
+
+    runner._collect_step_outputs(
+        result,
+        [SimpleNamespace(request_id="req", data=data)],
+    )
+
+    out = runner._outbox.get_nowait()
+    assert out.type == "stream"
+    assert out.target == "vocoder"
+    assert out.data.tolist() == [EOC_ID, 1, 2]
+    assert out.metadata == {
+        "modality": "audio_codes",
+        "stream": True,
+        "num_codebooks": 3,
+        "codebook_size": 17,
+    }
+
+
 def test_higgs_model_runner_marks_sampler_finish_cg() -> None:
     runner = object.__new__(HiggsTTSModelRunner)
+    runner._outbox = None
+    runner._vocoder_target = "vocoder"
     runner.model = SimpleNamespace(
         _cg_row_indices=torch.tensor([0]),
         _cg_active_delay_count=torch.tensor([8], dtype=torch.int32),
@@ -149,6 +225,8 @@ def test_higgs_model_runner_collect_cg_mixed_batch() -> None:
     """
     n, k = 4, 3
     runner = object.__new__(HiggsTTSModelRunner)
+    runner._outbox = None
+    runner._vocoder_target = "vocoder"
     runner.model = SimpleNamespace(
         _cg_row_indices=torch.arange(n),
         _cg_active_delay_count=torch.zeros(n, dtype=torch.int32),
@@ -200,6 +278,8 @@ def test_higgs_model_runner_collect_cg_mixed_batch() -> None:
 
 def test_higgs_model_runner_skips_already_finished_eager_request() -> None:
     runner = object.__new__(HiggsTTSModelRunner)
+    runner._outbox = None
+    runner._vocoder_target = "vocoder"
     runner.model = SimpleNamespace(
         _rid_to_row={"req": 0},
         _output_codes={"req": [torch.tensor([EOC_ID, 1, 2])]},
@@ -311,6 +391,136 @@ def test_higgs_tts_vocoder_batch_handles_empty_items(
     assert results[0].data["audio_data"] == []
     assert results[1].data["audio_data"] == []
     assert len(results[2].data["audio_data"]) > 0
+
+
+class _FakeHiggsStreamingCodec:
+    def __init__(self, samples_per_frame: int = 4) -> None:
+        self.samples_per_frame = samples_per_frame
+        self.decode_inputs: list[torch.Tensor] = []
+        self.decode_batch_sizes: list[int] = []
+
+    def decode(self, codes_TN: torch.Tensor) -> torch.Tensor:
+        self.decode_inputs.append(codes_TN.detach().clone())
+        frames = int(codes_TN.shape[0])
+        return torch.arange(frames * self.samples_per_frame, dtype=torch.float32)
+
+    def decode_batch(self, codes_list: list[torch.Tensor]) -> list[torch.Tensor]:
+        self.decode_batch_sizes.append(len(codes_list))
+        return [self.decode(codes) for codes in codes_list]
+
+
+def _higgs_stream_payload(
+    request_id: str,
+    *,
+    stream: bool,
+    delayed_rows: list[list[int]],
+    num_codebooks: int = 3,
+    codebook_size: int = 20,
+) -> StagePayload:
+    state = HiggsTtsState(
+        output_codes_delayed=delayed_rows,
+        num_codebooks=num_codebooks,
+        codebook_size=codebook_size,
+        prompt_tokens=2,
+        completion_tokens=len(delayed_rows),
+    )
+    return StagePayload(
+        request_id=request_id,
+        request=OmniRequest(inputs="", params={"stream": stream}),
+        data=state.to_dict(),
+    )
+
+
+def _higgs_stream_item(
+    row: torch.Tensor,
+    *,
+    num_codebooks: int = 3,
+    codebook_size: int = 20,
+) -> StreamItem:
+    return StreamItem(
+        chunk_id=0,
+        data=row,
+        from_stage="tts_engine",
+        metadata={
+            "modality": "audio_codes",
+            "stream": True,
+            "num_codebooks": num_codebooks,
+            "codebook_size": codebook_size,
+        },
+    )
+
+
+def test_higgs_streaming_vocoder_emits_compact_chunks_and_slim_final() -> None:
+    raw_codes = torch.tensor(
+        [
+            [1, 8, 9],
+            [2, 3, 10],
+            [4, 11, 12],
+            [1, 2, 3],
+        ],
+        dtype=torch.long,
+    )
+    delayed = apply_delay_pattern(raw_codes)
+    codec = _FakeHiggsStreamingCodec()
+    scheduler = HiggsStreamingVocoderScheduler(
+        codec,
+        stream_stride=3,
+        stream_followup_stride=2,
+        stream_holdback_tokens=0,
+    )
+    payload = _higgs_stream_payload(
+        "req",
+        stream=True,
+        delayed_rows=delayed.tolist(),
+        codebook_size=7,
+    )
+
+    scheduler._on_streaming_new_request("req", payload)
+    for idx, row in enumerate(delayed):
+        item = _higgs_stream_item(row, codebook_size=7)
+        item.chunk_id = idx
+        scheduler._on_chunk("req", item)
+    scheduler._on_done("req")
+
+    messages = _drain_higgs_outbox(scheduler)
+    stream_messages = [msg for msg in messages if msg.type == "stream"]
+    result_messages = [msg for msg in messages if msg.type == "result"]
+
+    assert stream_messages
+    first_chunk = stream_messages[0].data
+    assert "audio_waveform" in first_chunk
+    assert "audio_data" not in first_chunk
+    audio = np.frombuffer(first_chunk["audio_waveform"], dtype=np.float32)
+    assert audio.shape == tuple(first_chunk["audio_waveform_shape"])
+    assert first_chunk["audio_waveform_dtype"] == "float32"
+    assert first_chunk["sample_rate"] == 24000
+    assert codec.decode_inputs
+    assert all(int(codes.max().item()) < 5 for codes in codec.decode_inputs)
+
+    assert len(result_messages) == 1
+    final_data = result_messages[0].data.data
+    assert final_data == {
+        "modality": "audio",
+        "sample_rate": 24000,
+        "usage": {
+            "prompt_tokens": 2,
+            "completion_tokens": len(delayed),
+            "total_tokens": 2 + len(delayed),
+        },
+    }
+    assert "req" not in scheduler._pending_done
+    assert "req" not in scheduler._stream_states
+
+
+def _drain_higgs_outbox(
+    scheduler: HiggsStreamingVocoderScheduler,
+) -> list:
+    messages = []
+    while True:
+        try:
+            messages.append(scheduler.outbox.get_nowait())
+        except queue.Empty:
+            return messages
 
 
 def _make_fake_codec(call_log: list[tuple[int, int]]):

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -132,7 +132,7 @@ def test_higgs_model_runner_marks_sampler_finish() -> None:
     assert len(data.output_codes) == 1
 
 
-def test_higgs_model_runner_emits_strict_stream_metadata() -> None:
+def test_higgs_model_runner_emits_latched_stream_metadata() -> None:
     runner = object.__new__(HiggsTTSModelRunner)
     runner._outbox = queue.Queue()
     runner._vocoder_target = "vocoder"
@@ -146,18 +146,16 @@ def test_higgs_model_runner_emits_strict_stream_metadata() -> None:
         finished_reason=None,
         finished=lambda: False,
     )
-    payload = StagePayload(
-        request_id="req",
-        request=OmniRequest(inputs="", params={"stream": True}),
-        data={},
-    )
     data = SimpleNamespace(
         req=req,
         output_codes=[],
         generation_done=False,
-        stage_payload=payload,
-        num_codebooks=3,
-        codebook_size=17,
+        stream_metadata={
+            "modality": "audio_codes",
+            "stream": True,
+            "num_codebooks": 3,
+            "codebook_size": 17,
+        },
     )
     result = SimpleNamespace(
         logits_output=SimpleNamespace(next_token_logits=torch.zeros(1, 4))
@@ -409,6 +407,32 @@ class _FakeHiggsStreamingCodec:
         return [self.decode(codes) for codes in codes_list]
 
 
+class _FakeUnevenHiggsStreamingCodec:
+    class _Model:
+        class config:
+            hop_length = 5
+
+    def __init__(self, tail_samples: int = 3) -> None:
+        self.model = self._Model()
+        self.tail_samples = tail_samples
+
+    def decode(self, codes_TN: torch.Tensor) -> torch.Tensor:
+        frames = []
+        offsets = torch.arange(
+            self.model.config.hop_length,
+            dtype=torch.float32,
+        )
+        for row in codes_TN:
+            frames.append(row.sum().float().repeat(self.model.config.hop_length))
+            frames[-1] = frames[-1] + offsets / 10.0
+        body = torch.cat(frames) if frames else torch.empty(0, dtype=torch.float32)
+        tail = torch.arange(self.tail_samples, dtype=torch.float32) + 10_000
+        return torch.cat([body, tail])
+
+    def decode_batch(self, codes_list: list[torch.Tensor]) -> list[torch.Tensor]:
+        return [self.decode(codes) for codes in codes_list]
+
+
 def _higgs_stream_payload(
     request_id: str,
     *,
@@ -510,6 +534,53 @@ def test_higgs_streaming_vocoder_emits_compact_chunks_and_slim_final() -> None:
     }
     assert "req" not in scheduler._pending_done
     assert "req" not in scheduler._stream_states
+
+
+def test_higgs_streaming_vocoder_matches_full_decode_with_codec_tail() -> None:
+    raw_codes = torch.tensor(
+        [
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+            [10, 11, 12],
+            [13, 14, 15],
+            [16, 17, 18],
+        ],
+        dtype=torch.long,
+    )
+    delayed = apply_delay_pattern(raw_codes)
+    codec = _FakeUnevenHiggsStreamingCodec()
+    scheduler = HiggsStreamingVocoderScheduler(
+        codec,
+        stream_stride=3,
+        stream_followup_stride=2,
+        stream_overlap_tokens=1,
+        stream_holdback_tokens=0,
+    )
+    payload = _higgs_stream_payload(
+        "req",
+        stream=True,
+        delayed_rows=delayed.tolist(),
+        codebook_size=64,
+    )
+
+    full = scheduler._decode_state_to_audio(HiggsTtsState.from_dict(payload.data))
+    assert full is not None
+
+    scheduler._on_streaming_new_request("req", payload)
+    for idx, row in enumerate(delayed):
+        item = _higgs_stream_item(row, codebook_size=64)
+        item.chunk_id = idx
+        scheduler._on_chunk("req", item)
+    scheduler._on_done("req")
+
+    stream_chunks = [
+        np.frombuffer(msg.data["audio_waveform"], dtype=np.float32).copy()
+        for msg in _drain_higgs_outbox(scheduler)
+        if msg.type == "stream"
+    ]
+    streamed = np.concatenate(stream_chunks)
+    np.testing.assert_array_equal(streamed, full.numpy())
 
 
 def _drain_higgs_outbox(

--- a/tests/unit_test/pipeline/test_streaming_simple_scheduler.py
+++ b/tests/unit_test/pipeline/test_streaming_simple_scheduler.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import queue
+
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
+from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
+from sglang_omni.scheduling.streaming_simple_scheduler import StreamingSimpleScheduler
+
+
+def _payload(request_id: str, *, stream: bool = False) -> StagePayload:
+    return StagePayload(
+        request_id=request_id,
+        request=OmniRequest(inputs=[], params={"stream": stream}),
+        data={"request_id": request_id},
+    )
+
+
+class _TestStreamingScheduler(StreamingSimpleScheduler):
+    def __init__(self, *, max_batch_size: int = 4, max_batch_wait_ms: int = 0):
+        self.single_calls: list[str] = []
+        self.batch_calls: list[list[str]] = []
+        self.stream_state: set[str] = set()
+        super().__init__(
+            self._compute,
+            batch_compute_fn=self._compute_batch,
+            max_batch_size=max_batch_size,
+            max_batch_wait_ms=max_batch_wait_ms,
+        )
+
+    def is_streaming_payload(self, payload: StagePayload) -> bool:
+        return bool(payload.request.params.get("stream", False))
+
+    def on_streaming_new_request(self, request_id: str, payload: StagePayload) -> None:
+        del payload
+        self.stream_state.add(request_id)
+
+    def on_stream_chunk(
+        self, request_id: str, item: StreamItem
+    ) -> list[OutgoingMessage]:
+        self.stream_state.add(request_id)
+        return [
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                data={"chunk": item.data},
+                metadata={"modality": "test"},
+            )
+        ]
+
+    def on_stream_done(self, request_id: str) -> list[OutgoingMessage]:
+        return [
+            OutgoingMessage(
+                request_id=request_id,
+                type="result",
+                data={"done": request_id},
+            )
+        ]
+
+    def clear_stream_state(self, request_id: str) -> None:
+        self.stream_state.discard(request_id)
+
+    def _compute(self, payload: StagePayload) -> StagePayload:
+        self.single_calls.append(payload.request_id)
+        payload.data = {"single": payload.request_id}
+        return payload
+
+    def _compute_batch(self, payloads: list[StagePayload]) -> list[StagePayload]:
+        self.batch_calls.append([payload.request_id for payload in payloads])
+        for payload in payloads:
+            payload.data = {"batch": payload.request_id}
+        return payloads
+
+
+def _drain_results(scheduler: StreamingSimpleScheduler) -> list[OutgoingMessage]:
+    messages: list[OutgoingMessage] = []
+    while True:
+        try:
+            messages.append(scheduler.outbox.get_nowait())
+        except queue.Empty:
+            return messages
+
+
+def test_streaming_simple_scheduler_batches_non_streaming_requests() -> None:
+    scheduler = _TestStreamingScheduler(max_batch_size=3)
+    first = IncomingMessage("a", "new_request", _payload("a"))
+    scheduler.inbox.put(IncomingMessage("b", "new_request", _payload("b")))
+    scheduler.inbox.put(IncomingMessage("c", "new_request", _payload("c")))
+
+    batch = scheduler._collect_new_request_batch(first)
+    scheduler._handle_new_request_batch(batch)
+
+    assert scheduler.batch_calls == [["a", "b", "c"]]
+    assert [msg.request_id for msg in _drain_results(scheduler)] == ["a", "b", "c"]
+
+
+def test_streaming_simple_scheduler_keeps_streaming_request_out_of_batch() -> None:
+    scheduler = _TestStreamingScheduler(max_batch_size=3)
+    first = IncomingMessage("a", "new_request", _payload("a"))
+    scheduler.inbox.put(
+        IncomingMessage("stream", "new_request", _payload("stream", stream=True))
+    )
+    scheduler.inbox.put(IncomingMessage("b", "new_request", _payload("b")))
+
+    batch = scheduler._collect_new_request_batch(first)
+
+    assert [msg.request_id for msg in batch] == ["a"]
+    assert scheduler._next_message().request_id == "stream"
+    assert scheduler._next_message().request_id == "b"
+
+
+def test_streaming_simple_scheduler_done_before_payload_finalizes_later() -> None:
+    scheduler = _TestStreamingScheduler()
+
+    scheduler._on_done("req")
+    scheduler._on_streaming_new_request("req", _payload("req", stream=True))
+
+    out = scheduler.outbox.get_nowait()
+    assert out.type == "result"
+    assert out.data == {"done": "req"}
+    assert "req" not in scheduler._pending_done
+    assert "req" not in scheduler.stream_state
+
+
+def test_streaming_simple_scheduler_abort_clears_all_stream_state() -> None:
+    scheduler = _TestStreamingScheduler()
+    scheduler._stream_payloads["req"] = _payload("req", stream=True)
+    scheduler._pending_done.add("req")
+    scheduler.stream_state.add("req")
+
+    scheduler.abort("req")
+
+    assert "req" not in scheduler._stream_payloads
+    assert "req" not in scheduler._pending_done
+    assert "req" not in scheduler.stream_state
+    assert "req" in scheduler._aborted_request_ids
+
+
+def test_streaming_simple_scheduler_keeps_queued_control_message_out_of_batch() -> None:
+    scheduler = _TestStreamingScheduler(max_batch_size=3)
+    first = IncomingMessage("a", "new_request", _payload("a"))
+    chunk = StreamItem(chunk_id=0, data="x", from_stage="source")
+    scheduler.inbox.put(IncomingMessage("stream", "stream_chunk", chunk))
+    scheduler.inbox.put(IncomingMessage("b", "new_request", _payload("b")))
+
+    batch = scheduler._collect_new_request_batch(first)
+
+    assert [msg.request_id for msg in batch] == ["a"]
+    next_msg = scheduler._next_message()
+    assert next_msg.request_id == "stream"
+    assert next_msg.type == "stream_chunk"
+    assert scheduler._next_message().request_id == "b"

--- a/tests/unit_test/pipeline/test_streaming_simple_scheduler.py
+++ b/tests/unit_test/pipeline/test_streaming_simple_scheduler.py
@@ -123,6 +123,18 @@ def test_streaming_simple_scheduler_done_before_payload_finalizes_later() -> Non
     assert "req" not in scheduler.stream_state
 
 
+def test_streaming_simple_scheduler_ignores_late_non_streaming_done() -> None:
+    scheduler = _TestStreamingScheduler()
+
+    scheduler._handle_new_request_batch(
+        [IncomingMessage("req", "new_request", _payload("req", stream=False))]
+    )
+    scheduler._on_done("req")
+
+    assert scheduler.outbox.get_nowait().type == "result"
+    assert "req" not in scheduler._pending_done
+
+
 def test_streaming_simple_scheduler_abort_clears_all_stream_state() -> None:
     scheduler = _TestStreamingScheduler()
     scheduler._stream_payloads["req"] = _payload("req", stream=True)

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import numpy as np
 import torch
 
 from sglang_omni.models.qwen3_omni.components.code2wav_scheduler import (
     Code2WavScheduler,
 )
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from tests.unit_test.fixtures.qwen_fakes import FakeCode2WavModel, make_qwen_payload
 
 
@@ -28,13 +27,16 @@ def test_qwen_code2wav_streams_incrementally_and_abort_clears_state() -> None:
 
     chunk_meta = {"stream": False}  # non-streaming: final result carries full PCM
     scheduler._on_chunk(
-        "req-1", SimpleNamespace(data=torch.tensor([1, 10]), metadata=chunk_meta)
+        "req-1",
+        StreamItem(0, torch.tensor([1, 10]), "talker", metadata=chunk_meta),
     )
     scheduler._on_chunk(
-        "req-1", SimpleNamespace(data=torch.tensor([2, 20]), metadata=chunk_meta)
+        "req-1",
+        StreamItem(1, torch.tensor([2, 20]), "talker", metadata=chunk_meta),
     )
     scheduler._on_chunk(
-        "req-1", SimpleNamespace(data=torch.tensor([3, 30]), metadata=chunk_meta)
+        "req-1",
+        StreamItem(2, torch.tensor([3, 30]), "talker", metadata=chunk_meta),
     )
     scheduler._on_done("req-1")
 

--- a/tests/unit_test/qwen3_omni/test_streaming.py
+++ b/tests/unit_test/qwen3_omni/test_streaming.py
@@ -25,6 +25,7 @@ from sglang_omni.models.qwen3_omni.request_builders import (
     should_generate_audio_output,
 )
 from sglang_omni.pipeline.stage.runtime import Stage
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
 from sglang_omni.scheduling.sglang_backend import SGLangOutputProcessor
@@ -510,9 +511,14 @@ class _FakeCode2Wav:
         return torch.zeros(1, n_frames * self.total_upsample)
 
 
-def _make_code_chunk(metadata: dict | None) -> _StreamItem:
+def _make_code_chunk(metadata: dict | None) -> StreamItem:
     """One frame per chunk, single codebook, non-EOS code id."""
-    return _StreamItem(data=torch.tensor([7], dtype=torch.long), metadata=metadata)
+    return StreamItem(
+        chunk_id=0,
+        data=torch.tensor([7], dtype=torch.long),
+        from_stage="talker",
+        metadata=metadata,
+    )
 
 
 def test_code2wav_chunk_without_stream_metadata_emits_error():


### PR DESCRIPTION
## PR description

Adds a shared `StreamingSimpleScheduler` for stages that need chunked streaming input while preserving the batched non-streaming path. Wires Higgs TTS to a streaming vocoder scheduler, keeps final streaming responses slim, and aligns S2-Pro/Qwen audio chunk handling with compact waveform payloads.


## Higgs Audio V3 TTS

| Mode | Samples | Failed | WER corpus | WER excl >50% | >50% WER samples | Latency mean s | Latency median s | Latency p95 s | Latency p99 s | RTF mean | RTF p95 | Throughput req/s | Audio throughput s/s | First audio mean s | First audio p95 s | Text first token mean s | Text first token p95 s | Inter-chunk mean s | Inter-chunk p95 s |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| non-stream | 1088/1088 | 0 | 4.52% | 1.33% | 2 (0.18%) | 3.306 | 2.657 | 5.751 | 7.693 | 0.7606 | 1.3680 | 4.621 | 22.102 | - | - | - | - | - | - |
| stream | 1088/1088 | 0 | 3.92% | 1.44% | 1 (0.09%) | 1.427 | 1.224 | 1.817 | 2.600 | 0.3030 | 0.3627 | 11.166 | 54.623 | 0.8715 | 1.0240 | - | - | 0.4428 | 0.8112 |

## Fish Audio S2-Pro

| Mode | Samples | Failed | WER corpus | WER excl >50% | >50% WER samples | Latency mean s | Latency median s | Latency p95 s | Latency p99 s | RTF mean | RTF p95 | Throughput req/s | Audio throughput s/s | First audio mean s | First audio p95 s | Text first token mean s | Text first token p95 s | Inter-chunk mean s | Inter-chunk p95 s |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| non-stream | 1088/1088 | 0 | 1.05% | 1.05% | 0 (0.00%) | 15.326 | 13.374 | 23.805 | 56.077 | 4.1994 | 8.5636 | 1.038 | 4.135 | - | - | - | - | - | - |
| stream | 1088/1088 | 0 | 1.04% | 1.04% | 0 (0.00%) | 11.988 | 11.762 | 16.441 | 18.219 | 3.2517 | 5.2673 | 1.327 | 5.260 | 10.6754 | 14.9010 | - | - | 0.5817 | 1.6563 |

## Qwen3-Omni Code2Wav

| Mode | Samples | Failed | WER corpus | WER excl >50% | >50% WER samples | Latency mean s | Latency median s | Latency p95 s | Latency p99 s | RTF mean | RTF p95 | Throughput req/s | Audio throughput s/s | First audio mean s | First audio p95 s | Text first token mean s | Text first token p95 s | Inter-chunk mean s | Inter-chunk p95 s |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| non-stream | 1088/1088 | 0 | 2.11% | 1.92% | 3 (0.28%) | 3.535 | 3.452 | 5.321 | 6.850 | 0.9903 | 1.2054 | 4.500 | 16.295 | - | - | - | - | - | - |
| stream | 1088/1088 | 0 | 2.31% | 2.00% | 4 (0.37%) | 3.120 | 3.043 | 4.593 | 5.425 | 0.8721 | 0.9798 | 5.104 | 18.477 | 0.8819 | 1.0588 | 0.1313 | 0.1597 | 0.5433 | 0.7076 |
