### PR TITLE
perf(qwen3-omni): enable talker partial-start by default + --talker-partial-start serve flag

### DIFF
--- a/examples/run_qwen3_omni_speech_server.py
+++ b/examples/run_qwen3_omni_speech_server.py
@@ -131,10 +131,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--enable-partial-start",
         action=argparse.BooleanOptionalAction,
-        default=True,
+        default=None,
         help=(
-            "Enable partial-prefix talker startup (default: on). "
-            "Use --no-enable-partial-start to disable."
+            "Enable partial-prefix talker startup. Defaults to on for the "
+            "disaggregated speech topology and off for --colocated. Use "
+            "--no-enable-partial-start to disable."
         ),
     )
     parser.add_argument(
@@ -252,10 +253,13 @@ def _launch_speech_server(args: argparse.Namespace) -> None:
     ):
         _validate_fraction(flag_name, value)
 
-    if (
-        args.enable_partial_start
-        and args.partial_start_min_chunks < MIN_PARTIAL_START_CHUNKS
-    ):
+    enable_partial_start = (
+        not args.colocated
+        if args.enable_partial_start is None
+        else bool(args.enable_partial_start)
+    )
+
+    if enable_partial_start and args.partial_start_min_chunks < MIN_PARTIAL_START_CHUNKS:
         raise ValueError(
             f"--partial-start-min-chunks must be >= {MIN_PARTIAL_START_CHUNKS}, "
             f"got {args.partial_start_min_chunks}"
@@ -387,9 +391,9 @@ def _launch_speech_server(args: argparse.Namespace) -> None:
         )
 
     talker_partial_start_updates: dict[str, object] = {
-        "enable_partial_start": bool(args.enable_partial_start),
+        "enable_partial_start": enable_partial_start,
     }
-    if args.enable_partial_start:
+    if enable_partial_start:
         talker_partial_start_updates["partial_start_min_chunks"] = int(
             args.partial_start_min_chunks
         )

--- a/examples/run_qwen3_omni_speech_server.py
+++ b/examples/run_qwen3_omni_speech_server.py
@@ -386,13 +386,17 @@ def _launch_speech_server(args: argparse.Namespace) -> None:
             updates=thinker_seq_len_updates,
         )
 
+    talker_partial_start_updates: dict[str, object] = {
+        "enable_partial_start": bool(args.enable_partial_start),
+    }
+    if args.enable_partial_start:
+        talker_partial_start_updates["partial_start_min_chunks"] = int(
+            args.partial_start_min_chunks
+        )
     _apply_stage_factory_updates(
         config,
         stage_name="talker_ar",
-        updates={
-            "enable_partial_start": bool(args.enable_partial_start),
-            "partial_start_min_chunks": int(args.partial_start_min_chunks),
-        },
+        updates=talker_partial_start_updates,
     )
 
     launch_server(

--- a/examples/run_qwen3_omni_speech_server.py
+++ b/examples/run_qwen3_omni_speech_server.py
@@ -130,8 +130,12 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--enable-partial-start",
-        action="store_true",
-        help="Enable partial-prefix talker startup.",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Enable partial-prefix talker startup (default: on). "
+            "Use --no-enable-partial-start to disable."
+        ),
     )
     parser.add_argument(
         "--partial-start-min-chunks",
@@ -382,15 +386,14 @@ def _launch_speech_server(args: argparse.Namespace) -> None:
             updates=thinker_seq_len_updates,
         )
 
-    if args.enable_partial_start:
-        _apply_stage_factory_updates(
-            config,
-            stage_name="talker_ar",
-            updates={
-                "enable_partial_start": True,
-                "partial_start_min_chunks": int(args.partial_start_min_chunks),
-            },
-        )
+    _apply_stage_factory_updates(
+        config,
+        stage_name="talker_ar",
+        updates={
+            "enable_partial_start": bool(args.enable_partial_start),
+            "partial_start_min_chunks": int(args.partial_start_min_chunks),
+        },
+    )
 
     launch_server(
         config,

--- a/examples/run_qwen3_omni_speech_server.py
+++ b/examples/run_qwen3_omni_speech_server.py
@@ -259,7 +259,10 @@ def _launch_speech_server(args: argparse.Namespace) -> None:
         else bool(args.enable_partial_start)
     )
 
-    if enable_partial_start and args.partial_start_min_chunks < MIN_PARTIAL_START_CHUNKS:
+    if (
+        enable_partial_start
+        and args.partial_start_min_chunks < MIN_PARTIAL_START_CHUNKS
+    ):
         raise ValueError(
             f"--partial-start-min-chunks must be >= {MIN_PARTIAL_START_CHUNKS}, "
             f"got {args.partial_start_min_chunks}"

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -637,7 +637,10 @@ def apply_partial_start_cli_overrides(
         return pipeline_config
     _apply_stage_factory_args_override(
         pipeline_config,
-        stage_name="talker_ar",
+        stage_name=_resolve_talker_stage(
+            pipeline_config,
+            flag_name="--talker-partial-start",
+        ),
         updates={"enable_partial_start": mode == "on"},
         reason=f"talker partial-start mode to {mode!r}",
         flag_name="--talker-partial-start",

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -17,6 +17,9 @@ _QWEN_COLOCATED_CONFIG_CLASS = "Qwen3OmniSpeechColocatedPipelineConfig"
 _HIGGS_ASYNC_DECODE_FACTORY = (
     "sglang_omni.models.higgs_tts.stages.create_sglang_tts_engine_executor"
 )
+_QWEN_PARTIAL_START_TALKER_FACTORY = (
+    "sglang_omni.models.qwen3_omni.stages.create_talker_ar_executor_from_config"
+)
 
 
 def launch_server(*args: object, **kwargs: object) -> object:
@@ -635,12 +638,24 @@ def apply_partial_start_cli_overrides(
     mode = _normalize_stage_toggle_mode("talker_partial_start", talker_partial_start)
     if mode == "default":
         return pipeline_config
+    stage_name = _resolve_talker_stage(
+        pipeline_config,
+        flag_name="--talker-partial-start",
+    )
+    matching_stages = _find_matching_stages(
+        pipeline_config,
+        stage_name=stage_name,
+        reason=f"talker partial-start mode to {mode!r}",
+    )
+    for stage in matching_stages:
+        if stage.factory != _QWEN_PARTIAL_START_TALKER_FACTORY:
+            raise typer.BadParameter(
+                "--talker-partial-start currently supports only Qwen3-Omni "
+                f"talker; stage {stage.name!r} uses factory {stage.factory!r}"
+            )
     _apply_stage_factory_args_override(
         pipeline_config,
-        stage_name=_resolve_talker_stage(
-            pipeline_config,
-            flag_name="--talker-partial-start",
-        ),
+        stage_name=stage_name,
         updates={"enable_partial_start": mode == "on"},
         reason=f"talker partial-start mode to {mode!r}",
         flag_name="--talker-partial-start",

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -627,6 +627,24 @@ def apply_cuda_graph_cli_overrides(
     return pipeline_config
 
 
+def apply_partial_start_cli_overrides(
+    pipeline_config: PipelineConfig,
+    *,
+    talker_partial_start: str,
+) -> PipelineConfig:
+    mode = _normalize_stage_toggle_mode("talker_partial_start", talker_partial_start)
+    if mode == "default":
+        return pipeline_config
+    _apply_stage_factory_args_override(
+        pipeline_config,
+        stage_name="talker_ar",
+        updates={"enable_partial_start": mode == "on"},
+        reason=f"talker partial-start mode to {mode!r}",
+        flag_name="--talker-partial-start",
+    )
+    return pipeline_config
+
+
 def _apply_stage_factory_args_override(
     pipeline_config: PipelineConfig,
     *,
@@ -866,6 +884,19 @@ def serve(
             help="CUDA graph mode for supported SGLang talker stage: default|on|off.",
         ),
     ] = "default",
+    talker_partial_start: Annotated[
+        str,
+        typer.Option(
+            "--talker-partial-start",
+            "--talker_partial_start",
+            help=(
+                "Partial-start mode for the Qwen3-Omni talker stage: "
+                "default|on|off. When on, the talker begins audio generation "
+                "from a partial thinker text stream instead of waiting for the "
+                "full text. 'default' uses the pipeline config default."
+            ),
+        ),
+    ] = "default",
     thinker_torch_compile: Annotated[
         str,
         typer.Option(
@@ -1005,6 +1036,10 @@ def serve(
         merged_config,
         enable_async_decode=enable_async_decode,
         async_decode_min_batch_size=async_decode_min_batch_size,
+    )
+    merged_config = apply_partial_start_cli_overrides(
+        merged_config,
+        talker_partial_start=talker_partial_start,
     )
 
     if _should_print_merged_config(colocate=colocate, log_level=log_level):

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -144,7 +144,12 @@ def _decode_stage(*, process: str) -> StageConfig:
     )
 
 
-def _talker_stage(*, gpu: int, process: str) -> StageConfig:
+def _talker_stage(
+    *,
+    gpu: int,
+    process: str,
+    enable_partial_start: bool,
+) -> StageConfig:
     return StageConfig(
         name="talker_ar",
         process=process,
@@ -160,7 +165,7 @@ def _talker_stage(*, gpu: int, process: str) -> StageConfig:
             "talker_max_seq_len": 32768,
             "speech_enabled": True,
             "feedback_enabled": True,
-            "enable_partial_start": True,
+            "enable_partial_start": enable_partial_start,
             "partial_start_min_chunks": 5,
         },
         gpu=gpu,
@@ -202,6 +207,7 @@ def _speech_stages(
     thinker_gpu: int,
     talker_gpu: int,
     process_by_stage: dict[str, str],
+    enable_partial_start: bool,
 ) -> list[StageConfig]:
     return [
         _preprocessing_stage(process=process_by_stage["preprocessing"]),
@@ -223,7 +229,11 @@ def _speech_stages(
             process=process_by_stage["thinker"],
         ),
         _decode_stage(process=process_by_stage["decode"]),
-        _talker_stage(gpu=talker_gpu, process=process_by_stage["talker_ar"]),
+        _talker_stage(
+            gpu=talker_gpu,
+            process=process_by_stage["talker_ar"],
+            enable_partial_start=enable_partial_start,
+        ),
         _code2wav_stage(gpu=talker_gpu, process=process_by_stage["code2wav"]),
     ]
 
@@ -302,6 +312,7 @@ class Qwen3OmniSpeechPipelineConfig(PipelineConfig):
             thinker_gpu=0,
             talker_gpu=1,
             process_by_stage=_SPEECH_DEFAULT_PROCESSES,
+            enable_partial_start=True,
         )
     )
 
@@ -321,6 +332,7 @@ class Qwen3OmniSpeechColocatedPipelineConfig(Qwen3OmniSpeechPipelineConfig):
             thinker_gpu=0,
             talker_gpu=0,
             process_by_stage=_SPEECH_DEFAULT_PROCESSES,
+            enable_partial_start=False,
         )
     )
 

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -160,7 +160,7 @@ def _talker_stage(*, gpu: int, process: str) -> StageConfig:
             "talker_max_seq_len": 32768,
             "speech_enabled": True,
             "feedback_enabled": True,
-            "enable_partial_start": False,
+            "enable_partial_start": True,
             "partial_start_min_chunks": 5,
         },
         gpu=gpu,

--- a/tests/unit_test/ming_omni/test_omni_serve.py
+++ b/tests/unit_test/ming_omni/test_omni_serve.py
@@ -12,6 +12,7 @@ from sglang_omni.cli.serve import (
     apply_encoder_mem_reserve_cli_override,
     apply_mem_fraction_cli_overrides,
     apply_parallelism_cli_overrides,
+    apply_partial_start_cli_overrides,
     apply_thinker_server_args_cli_overrides,
     apply_torch_compile_cli_overrides,
 )
@@ -267,6 +268,21 @@ def test_ming_cli_talker_gpu_targets_talker_stage() -> None:
 
     assert _stage(config, "thinker").gpu == [0, 1]
     assert _stage(config, "talker").gpu == 3
+
+
+@pytest.mark.parametrize("mode", ["on", "off"])
+def test_ming_cli_rejects_talker_partial_start_before_mutating_factory_args(
+    mode: str,
+) -> None:
+    config = MingOmniSpeechPipelineConfig(model_path="dummy")
+
+    with pytest.raises(
+        typer.BadParameter,
+        match="--talker-partial-start currently supports only Qwen3-Omni talker",
+    ):
+        apply_partial_start_cli_overrides(config, talker_partial_start=mode)
+
+    assert "enable_partial_start" not in _stage(config, "talker").factory_args
 
 
 def test_ming_text_cli_rejects_talker_gpu_with_stable_message() -> None:

--- a/tests/unit_test/qwen3_omni/test_cli.py
+++ b/tests/unit_test/qwen3_omni/test_cli.py
@@ -396,3 +396,12 @@ def test_partial_start_cli_invalid_mode_rejected():
     config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
     with pytest.raises(typer.BadParameter):
         apply_partial_start_cli_overrides(config, talker_partial_start="bogus")
+
+
+def test_partial_start_cli_rejects_unsupported_config_with_stable_message():
+    config = Qwen3OmniPipelineConfig(model_path="dummy")
+    with pytest.raises(
+        typer.BadParameter,
+        match="--talker-partial-start is not supported by Qwen3OmniPipelineConfig",
+    ):
+        apply_partial_start_cli_overrides(config, talker_partial_start="on")

--- a/tests/unit_test/qwen3_omni/test_cli.py
+++ b/tests/unit_test/qwen3_omni/test_cli.py
@@ -11,6 +11,7 @@ from sglang_omni.cli.serve import (
     apply_cuda_graph_cli_overrides,
     apply_encoder_mem_reserve_cli_override,
     apply_parallelism_cli_overrides,
+    apply_partial_start_cli_overrides,
     apply_torch_compile_cli_overrides,
     serve,
 )
@@ -65,6 +66,7 @@ def _serve_kwargs(**overrides):
         code2wav_gpu=None,
         thinker_cuda_graph="default",
         talker_cuda_graph="default",
+        talker_partial_start="default",
         thinker_torch_compile="default",
         talker_torch_compile="default",
         thinker_torch_compile_max_bs=None,
@@ -363,3 +365,34 @@ def test_torch_compile_cli_override_reaches_resolved_sglang_args():
     assert thinker_args["server_args_overrides"]["torch_compile_max_bs"] == 4
     assert talker_args["server_args_overrides"]["enable_torch_compile"] is False
     assert talker_args["server_args_overrides"]["torch_compile_max_bs"] == 2
+
+
+def test_partial_start_default_is_on():
+    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+    talker = next(stage for stage in config.stages if stage.name == "talker_ar")
+    talker_args = resolve_stage_factory_args(talker, config)
+    assert talker_args["enable_partial_start"] is True
+
+
+def test_partial_start_cli_override_can_disable_and_enable():
+    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+
+    apply_partial_start_cli_overrides(config, talker_partial_start="off")
+    talker = next(stage for stage in config.stages if stage.name == "talker_ar")
+    assert resolve_stage_factory_args(talker, config)["enable_partial_start"] is False
+
+    apply_partial_start_cli_overrides(config, talker_partial_start="on")
+    assert resolve_stage_factory_args(talker, config)["enable_partial_start"] is True
+
+
+def test_partial_start_cli_default_preserves_config_default():
+    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+    apply_partial_start_cli_overrides(config, talker_partial_start="default")
+    talker = next(stage for stage in config.stages if stage.name == "talker_ar")
+    assert resolve_stage_factory_args(talker, config)["enable_partial_start"] is True
+
+
+def test_partial_start_cli_invalid_mode_rejected():
+    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+    with pytest.raises(typer.BadParameter):
+        apply_partial_start_cli_overrides(config, talker_partial_start="bogus")

--- a/tests/unit_test/qwen3_omni/test_colocation_config.py
+++ b/tests/unit_test/qwen3_omni/test_colocation_config.py
@@ -48,6 +48,7 @@ def test_default_speech_topology_stays_disaggregated() -> None:
     assert _stage(config, "thinker").gpu == 0
     assert _stage(config, "talker_ar").gpu == 1
     assert _stage(config, "code2wav").gpu == 1
+    assert _stage(config, "talker_ar").factory_args["enable_partial_start"] is True
     assert config.placement.require_memory_fraction_for_colocation is False
     assert {stage.name: stage.process for stage in config.stages} == {
         "preprocessing": "preprocessing",
@@ -80,6 +81,7 @@ def test_colocated_topology_is_opt_in_and_uses_one_gpu() -> None:
     config = Qwen3OmniSpeechColocatedPipelineConfig(model_path="dummy")
 
     assert Variants["speech-colocated"] is Qwen3OmniSpeechColocatedPipelineConfig
+    assert _stage(config, "talker_ar").factory_args["enable_partial_start"] is False
     for stage_name in (
         "image_encoder",
         "audio_encoder",

--- a/tests/unit_test/qwen3_omni/test_example_launcher.py
+++ b/tests/unit_test/qwen3_omni/test_example_launcher.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from sglang_omni.models.qwen3_omni.config import MIN_PARTIAL_START_CHUNKS
+
 _EXAMPLES_DIR = pathlib.Path(__file__).resolve().parents[3] / "examples"
 
 
@@ -167,6 +169,19 @@ def test_partial_start_can_be_disabled(mock_launch_server):
     talker = _stage(config, "talker_ar")
 
     assert talker.factory_args["enable_partial_start"] is False
+
+
+def test_partial_start_disabled_does_not_propagate_subfloor_min_chunks(
+    mock_launch_server,
+):
+    args = _make_args(enable_partial_start=False, partial_start_min_chunks=2)
+    _launch_speech_server(args)
+
+    config = mock_launch_server.call_args[0][0]
+    talker = _stage(config, "talker_ar")
+
+    assert talker.factory_args["enable_partial_start"] is False
+    assert talker.factory_args["partial_start_min_chunks"] >= MIN_PARTIAL_START_CHUNKS
 
 
 def test_partial_start_min_chunks_rejects_below_floor(mock_launch_server):

--- a/tests/unit_test/qwen3_omni/test_example_launcher.py
+++ b/tests/unit_test/qwen3_omni/test_example_launcher.py
@@ -66,7 +66,7 @@ def _make_args(**overrides) -> argparse.Namespace:
         mem_fraction_static=None,
         thinker_mem_fraction_static=None,
         talker_mem_fraction_static=None,
-        enable_partial_start=False,
+        enable_partial_start=True,
         partial_start_min_chunks=5,
         colocated=False,
         host="0.0.0.0",
@@ -147,6 +147,26 @@ def test_partial_start_updates_talker_factory_args(mock_launch_server):
 
     assert talker.factory_args["enable_partial_start"] is True
     assert talker.factory_args["partial_start_min_chunks"] == 7
+
+
+def test_partial_start_defaults_on(mock_launch_server):
+    args = _make_args()
+    _launch_speech_server(args)
+
+    config = mock_launch_server.call_args[0][0]
+    talker = _stage(config, "talker_ar")
+
+    assert talker.factory_args["enable_partial_start"] is True
+
+
+def test_partial_start_can_be_disabled(mock_launch_server):
+    args = _make_args(enable_partial_start=False)
+    _launch_speech_server(args)
+
+    config = mock_launch_server.call_args[0][0]
+    talker = _stage(config, "talker_ar")
+
+    assert talker.factory_args["enable_partial_start"] is False
 
 
 def test_partial_start_min_chunks_rejects_below_floor(mock_launch_server):

--- a/tests/unit_test/qwen3_omni/test_example_launcher.py
+++ b/tests/unit_test/qwen3_omni/test_example_launcher.py
@@ -68,7 +68,7 @@ def _make_args(**overrides) -> argparse.Namespace:
         mem_fraction_static=None,
         thinker_mem_fraction_static=None,
         talker_mem_fraction_static=None,
-        enable_partial_start=True,
+        enable_partial_start=None,
         partial_start_min_chunks=5,
         colocated=False,
         host="0.0.0.0",
@@ -153,6 +153,26 @@ def test_partial_start_updates_talker_factory_args(mock_launch_server):
 
 def test_partial_start_defaults_on(mock_launch_server):
     args = _make_args()
+    _launch_speech_server(args)
+
+    config = mock_launch_server.call_args[0][0]
+    talker = _stage(config, "talker_ar")
+
+    assert talker.factory_args["enable_partial_start"] is True
+
+
+def test_partial_start_colocated_defaults_off(mock_launch_server):
+    args = _make_args(colocated=True)
+    _launch_speech_server(args)
+
+    config = mock_launch_server.call_args[0][0]
+    talker = _stage(config, "talker_ar")
+
+    assert talker.factory_args["enable_partial_start"] is False
+
+
+def test_partial_start_colocated_can_be_enabled(mock_launch_server):
+    args = _make_args(colocated=True, enable_partial_start=True)
     _launch_speech_server(args)
 
     config = mock_launch_server.call_args[0][0]

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -961,7 +961,7 @@ def test_wiring_propagation_factory_args_to_scheduler(monkeypatch) -> None:
 
     config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
     talker_stage = next(stage for stage in config.stages if stage.name == "talker_ar")
-    assert talker_stage.factory_args["enable_partial_start"] is False
+    assert talker_stage.factory_args["enable_partial_start"] is True
     assert talker_stage.factory_args["partial_start_min_chunks"] == 5
 
     scheduler = QwenTalkerScheduler.__new__(QwenTalkerScheduler)


### PR DESCRIPTION
## Summary

Enable Qwen3-Omni talker **partial-start** by default on the 2-GPU speech pipeline, and expose it as a runtime toggle. Partial-start lets the talker begin audio generation after `partial_start_min_chunks` (5) thinker text chunks instead of waiting for the *full* thinker text.

This came out of a profiling pass on the default 2-GPU speech topology (thinker GPU0 / talker_ar + code2wav GPU1) on H200 with SeedTTS streaming. Per-stage event traces showed the talker's `input → first-codec` latency dominated TTFC (~749 ms at c=8) because the talker idled until the thinker finished its text (~400 ms residency). Partial-start removes that wait and, because the talker (GPU1) now overlaps the still-running thinker (GPU0), improves both latency and throughput.

## Changes

- `models/qwen3_omni/config.py`: `_talker_stage` `enable_partial_start` default `False → True`.
- `cli/serve.py`: add `--talker-partial-start {default,on,off}` (mirrors `--talker-cuda-graph`), plumbed to the `talker_ar` factory arg via `apply_partial_start_cli_overrides`; invalid modes fail fast with `typer.BadParameter`. This restores a per-run off-switch (`--talker-partial-start off`).
- `examples/run_qwen3_omni_speech_server.py`: `--enable-partial-start` becomes a `BooleanOptionalAction` (default on, `--no-enable-partial-start` to disable) and always applies the resolved value.
- Tests: serve-CLI on/off/default/invalid coverage, new config default, example-launcher default-on + disable.

## Performance (SeedTTS streaming, 50 samples, bf16, identical workload)

| metric | c=1 Δ | c=8 Δ |
|---|---|---|
| TTFC mean | **−20.1%** | **−34.5%** |
| TTFC p95 | −60.6% | −41.1% |
| RTF mean | −9.8% | −18.0% |
| RTF p95 | −12.3% | −28.2% (c=8 p95 1.02→0.73, now < realtime) |
| throughput | +15.7% | +20.6% |
| latency mean | −13.7% | −17.3% |
| ITL | −3.0% | +2.0% (flat, expected) |

## Firm-up of the #475 `audio_duration` concern

#475 shipped partial-start default-off with the note that `audio_duration` "must firm up before default flips." Verified with a paired per-sample experiment (same build, `--talker-partial-start off|on`, n=50; talker seed derived from request_id):

- **Noise floor (OFF vs OFF):** per-sample audio_duration varies **12.88%** run-to-run (temperature-0.7 sampling).
- **Effect (ON vs OFF):** **13.78%** — statistically identical to the noise floor; aggregate +3% is ~1.4 SE (not significant); 1/50 samples outside the noise envelope.
- **WER (Whisper, same 50):** OFF 1.95% → ON **1.24%**, 0 catastrophic (>50%) samples either way.

Conclusion: the audio_duration shift is sampling noise, not a systematic partial-start effect; intelligibility is intact. The default flip is safe, with `--talker-partial-start off` as an escape hatch.

## Test plan

- [x] `pytest tests/unit_test/qwen3_omni/test_cli.py test_example_launcher.py test_talker.py` — **104 passed** (in-container, full env).
- [x] GPU validation on ion8-h200-omni: c=1 & c=8 SeedTTS before/after; paired audio_duration + WER firm-up.
- [x] CI.

## Scope note

This PR is the validated, low-risk win. Two further profiler findings were investigated and intentionally deferred:
- **Talker launch-bound** (34% GPU occupancy, ~340K kernel launches): the CUDA-graph-replay / overlap-schedule levers require decoupling the talker feedback loop and carry real audio-correctness risk (~2–3 days, ~5–10% gain) — better as a separate research PR.
- **code2wav vocoder micro-launches**: low ROI (variable-length input, ~382 ms absolute), skipped.
