### PR TITLE
[Docs] rewrite README and switch to Apache-2.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,193 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 auroa-project
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as submitted to the Licensor for inclusion
+      in the Work by the copyright owner or by an individual or Legal Entity
+      authorized to submit on behalf of the copyright owner. For the purposes
+      of this definition, "submitted" means any form of electronic, verbal,
+      or written communication sent to the Licensor or its representatives,
+      including but not limited to communication on electronic mailing lists,
+      source code control systems, and issue tracking systems that are managed
+      by, or on behalf of, the Licensor for the purpose of discussing and
+      improving the Work, but excluding communication that is conspicuously
+      marked or designated in writing by the copyright owner as "Not a
+      Contribution."
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and included
+      within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by the combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a cross-claim
+      or counterclaim in a lawsuit) alleging that the Work or any patent
+      claim embodied in the Work constitutes direct or contributory patent
+      infringement, then any patent licenses granted to You under this License
+      for that Work shall terminate as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or in addition to the
+          NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, copy, modify, and
+      distribute those modifications and the Derivative Works as a whole,
+      so long as Your use, reproduction, and distribution of the Work
+      otherwise complies with the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or reproducing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or all other
+      commercial damages or losses), even if such Contributor has been
+      advised of the possibility of such damages.
+
+   9. Accepting Warranty or Liability. While redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a fee
+      for, acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may offer such obligations only on Your
+      own behalf and on Your sole responsibility, not on behalf of any other
+      Contributor, and only if You agree to indemnify, defend, and hold each
+      Contributor harmless for any liability incurred by, or claims asserted
+      against, such Contributor by reason of your accepting any such
+      warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the format in question. Please include an
+      administrative note at the top of each file using a NOTICE file
+      or similar mechanism, and this notice next to each copyright.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -15,16 +15,6 @@
 <a href="https://slack.sglang.ai"><b>Join Slack</b></a>
 </p>
 
-## News
-- [2026/05] 🔥 Qwen3-Omni talker partial-start enabled by default ([PR #617](https://github.com/sgl-project/sglang-omni/pull/617)).
-- [2026/05] 🔥 Streaming TTS schedulers with framework-level support ([PR #614](https://github.com/sgl-project/sglang-omni/pull/614)).
-- [2026/05] 🔥 Higgs TTS streaming vocoder with batched decode for higher throughput ([PR #574](https://github.com/sgl-project/sglang-omni/pull/574)).
-- [2026/05] 🔥 Ming-Omni streaming TTS support ([PR #506](https://github.com/sgl-project/sglang-omni/pull/506)).
-- [2026/05] torch.compile + CUDA Graph for Qwen3-TTS and Voxtral-TTS AR backbones ([PR #527](https://github.com/sgl-project/sglang-omni/pull/527)).
-- [2026/05] Higgs TTS async decode (one-step lookahead) for lower latency ([PR #590](https://github.com/sgl-project/sglang-omni/pull/590)).
-- [2026/05] Qwen3-Omni talker partial-prefix startup for faster first-token latency ([PR #475](https://github.com/sgl-project/sglang-omni/pull/475)).
-- [2026/05] New cookbooks: LLaDA2.0-Uni ([PR #598](https://github.com/sgl-project/sglang-omni/pull/598)), Voxtral TTS + Qwen3 TTS ([PR #585](https://github.com/sgl-project/sglang-omni/pull/585)), Higgs Audio V3 TTS ([PR #560](https://github.com/sgl-project/sglang-omni/pull/560)).
-
 ## About
 
 SGLang-Omni is a high-performance serving framework for omni and multimodal models, built on top of [SGLang](https://github.com/sgl-project/sglang). It is designed to orchestrate multi-stage pipelines with low latency and OpenAI-compatible APIs.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![license](https://img.shields.io/github/license/sgl-project/sglang-omni.svg)](https://github.com/sgl-project/sglang-omni/tree/main/LICENSE)
 [![issue resolution](https://img.shields.io/github/issues-closed-raw/sgl-project/sglang-omni)](https://github.com/sgl-project/sglang-omni/issues)
 [![open issues](https://img.shields.io/github/issues-raw/sgl-project/sglang-omni)](https://github.com/sgl-project/sglang-omni/issues)
-[![Slack](https://img.shields.io/badge/slack-sglang-blue?logo=slack)](https://slack.sglang.ai)
 [![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/sgl-project/sglang-omni)
 
 </div>
@@ -14,7 +13,8 @@
 <p align="center">
 <a href="https://sgl-project.github.io/sglang-omni/"><b>Documentation</b></a> |
 <a href="./benchmarks/README.md"><b>Benchmarks</b></a> |
-<a href="./examples/README.md"><b>Examples</b></a>
+<a href="./examples/README.md"><b>Examples</b></a> |
+<a href="https://slack.sglang.ai"><b>Slack</b></a>
 </p>
 
 ## News

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 --------------------------------------------------------------------------------
 
 <p align="center">
-<a href="https://sglang-omni.readthedocs.io/"><b>Documentation</b></a> |
+<a href="https://docs.sglang-omni.ai/"><b>Documentation</b></a> |
 <a href="./benchmarks/README.md"><b>Benchmarks</b></a> |
 <a href="./examples/README.md"><b>Examples</b></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -36,11 +36,14 @@ Core features:
 
 | Model | Type | Notes |
 |-------|------|-------|
-| [bosonai/higgs-audio-v3-tts-4b-base](https://huggingface.co/bosonai/higgs-audio-v3-tts-4b-base) | TTS | Voice cloning |
+| [boson-sglang/higgs-audio-v3-tts-4b-base](https://huggingface.co/boson-sglang/higgs-audio-v3-tts-4b-base) | TTS | Voice cloning |
 | [fishaudio/s2-pro](https://huggingface.co/fishaudio/s2-pro) | TTS | Voice cloning, streaming |
 | [mistralai/Voxtral-4B-TTS-2603](https://huggingface.co/mistralai/Voxtral-4B-TTS-2603) | TTS | Speaker presets |
-| [Qwen/Qwen3-Omni-7B](https://huggingface.co/Qwen/Qwen3-Omni-7B) | Omni | Speech + text I/O |
-| [Ming-Omni](https://huggingface.co/inclusionAI/Ming-Omni) | Omni | Streaming TTS |
+| [Qwen/Qwen3-TTS-12Hz-0.6B-Base](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-0.6B-Base) | TTS | Voice cloning |
+| [Qwen/Qwen3-TTS-12Hz-1.7B-Base](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base) | TTS | Voice cloning |
+| [Qwen/Qwen3-Omni-30B-A3B-Instruct](https://huggingface.co/Qwen/Qwen3-Omni-30B-A3B-Instruct) | Omni | Speech + text I/O |
+| [inclusionAI/Ming-flash-omni-2.0](https://huggingface.co/inclusionAI/Ming-flash-omni-2.0) | Omni | Streaming TTS |
+| [inclusionAI/LLaDA2.0-Uni](https://huggingface.co/inclusionAI/LLaDA2.0-Uni) | Omni | Text + image I/O |
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Core features:
 - **Multi-Stage Pipeline**: Flexible framework for orchestrating preprocessing, AR engine, codec, and vocoder stages across processes and GPUs.
 - **Native SGLang Integration**: Leverages SGLang's RadixAttention, continuous batching, and CUDA Graph optimizations for the AR backbone.
 - **OpenAI-Compatible Server**: Drop-in `/v1/audio/speech` and `/v1/chat/completions` endpoints with real-time streaming support.
-- **Broad Model Support**: Supports a growing set of TTS and omni models including Higgs Audio, Fish Audio S2-Pro, Voxtral TTS, Qwen3-Omni, and Ming-Omni.
+- **Broad Model Support**: Supports a growing set of TTS and omni models including Higgs Audio, Fish Audio S2-Pro, Voxtral TTS, Qwen3 TTS, Qwen3-Omni, Ming-Omni, and LLaDA2.0-Uni.
 
 ## Supported Models
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Core features:
 | [inclusionAI/Ming-flash-omni-2.0](https://huggingface.co/inclusionAI/Ming-flash-omni-2.0) | Omni | Streaming TTS |
 | [inclusionAI/LLaDA2.0-Uni](https://huggingface.co/inclusionAI/LLaDA2.0-Uni) | Omni | Text + image I/O |
 
-## Quick Start
+## Get Started
 
 - [Installation](./docs/get_started/installation.md)
 - [Developer Reference](./docs/developer_reference/main.md)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![license](https://img.shields.io/github/license/sgl-project/sglang-omni.svg)](https://github.com/sgl-project/sglang-omni/tree/main/LICENSE)
 [![issue resolution](https://img.shields.io/github/issues-closed-raw/sgl-project/sglang-omni)](https://github.com/sgl-project/sglang-omni/issues)
 [![open issues](https://img.shields.io/github/issues-raw/sgl-project/sglang-omni)](https://github.com/sgl-project/sglang-omni/issues)
+[![Slack](https://img.shields.io/badge/slack-sglang-blue?logo=slack)](https://slack.sglang.ai)
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/sgl-project/sglang-omni)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@
 
 <p align="center">
 <a href="https://sgl-project.github.io/sglang-omni/"><b>Documentation</b></a> |
-<a href="./benchmarks/README.md"><b>Benchmarks</b></a> |
-<a href="./examples/README.md"><b>Examples</b></a> |
-<a href="https://slack.sglang.ai"><b>Slack</b></a>
+<a href="https://slack.sglang.ai"><b>Join Slack</b></a>
 </p>
 
 ## News

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Core features:
 
 | Model | Type | Notes |
 |-------|------|-------|
-| [boson-sglang/higgs-audio-v3-tts-4b-base](https://huggingface.co/boson-sglang/higgs-audio-v3-tts-4b-base) | TTS | Voice cloning |
+| [boson-sglang/higgs-audio-v3-tts-4b-base](https://huggingface.co/boson-sglang/higgs-audio-v3-tts-4b-base) | TTS | Voice cloning, streaming, 100+ languages |
 | [fishaudio/s2-pro](https://huggingface.co/fishaudio/s2-pro) | TTS | Voice cloning, streaming |
-| [mistralai/Voxtral-4B-TTS-2603](https://huggingface.co/mistralai/Voxtral-4B-TTS-2603) | TTS | Speaker presets |
-| [Qwen/Qwen3-TTS-12Hz-Base](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base) | TTS | Voice cloning, 0.6B / 1.7B |
-| [Qwen/Qwen3-Omni-30B-A3B-Instruct](https://huggingface.co/Qwen/Qwen3-Omni-30B-A3B-Instruct) | Omni | Speech + text I/O |
+| [mistralai/Voxtral-4B-TTS-2603](https://huggingface.co/mistralai/Voxtral-4B-TTS-2603) | TTS | Named voices, streaming, 9 languages |
+| [Qwen/Qwen3-TTS-12Hz-Base](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base) | TTS | Voice cloning, streaming, 10 languages, 0.6B / 1.7B |
+| [Qwen/Qwen3-Omni-30B-A3B-Instruct](https://huggingface.co/Qwen/Qwen3-Omni-30B-A3B-Instruct) | Omni | Text, image, audio, video → text + audio |
 | [inclusionAI/Ming-flash-omni-2.0](https://huggingface.co/inclusionAI/Ming-flash-omni-2.0) | Omni | Streaming TTS |
-| [inclusionAI/LLaDA2.0-Uni](https://huggingface.co/inclusionAI/LLaDA2.0-Uni) | Omni | Text + image I/O |
+| [inclusionAI/LLaDA2.0-Uni](https://huggingface.co/inclusionAI/LLaDA2.0-Uni) | Multimodal | Text + image understanding and generation |
 
 ## Get Started
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 --------------------------------------------------------------------------------
 
 <p align="center">
-<a href="https://docs.sglang-omni.ai/"><b>Documentation</b></a> |
+<a href="https://sgl-project.github.io/sglang-omni/"><b>Documentation</b></a> |
 <a href="./benchmarks/README.md"><b>Benchmarks</b></a> |
 <a href="./examples/README.md"><b>Examples</b></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -16,10 +16,14 @@
 </p>
 
 ## News
+- [2026/05] 🔥 Qwen3-Omni talker partial-start enabled by default ([PR #617](https://github.com/sgl-project/sglang-omni/pull/617)).
+- [2026/05] 🔥 Streaming TTS schedulers with framework-level support ([PR #614](https://github.com/sgl-project/sglang-omni/pull/614)).
 - [2026/05] 🔥 Higgs TTS streaming vocoder with batched decode for higher throughput ([PR #574](https://github.com/sgl-project/sglang-omni/pull/574)).
 - [2026/05] 🔥 Ming-Omni streaming TTS support ([PR #506](https://github.com/sgl-project/sglang-omni/pull/506)).
+- [2026/05] torch.compile + CUDA Graph for Qwen3-TTS and Voxtral-TTS AR backbones ([PR #527](https://github.com/sgl-project/sglang-omni/pull/527)).
+- [2026/05] Higgs TTS async decode (one-step lookahead) for lower latency ([PR #590](https://github.com/sgl-project/sglang-omni/pull/590)).
 - [2026/05] Qwen3-Omni talker partial-prefix startup for faster first-token latency ([PR #475](https://github.com/sgl-project/sglang-omni/pull/475)).
-- [2026/05] Higgs Audio V3 TTS cookbook ([PR #560](https://github.com/sgl-project/sglang-omni/pull/560)).
+- [2026/05] New cookbooks: LLaDA2.0-Uni ([PR #598](https://github.com/sgl-project/sglang-omni/pull/598)), Voxtral TTS + Qwen3 TTS ([PR #585](https://github.com/sgl-project/sglang-omni/pull/585)), Higgs Audio V3 TTS ([PR #560](https://github.com/sgl-project/sglang-omni/pull/560)).
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ Core features:
 | [boson-sglang/higgs-audio-v3-tts-4b-base](https://huggingface.co/boson-sglang/higgs-audio-v3-tts-4b-base) | TTS | Voice cloning |
 | [fishaudio/s2-pro](https://huggingface.co/fishaudio/s2-pro) | TTS | Voice cloning, streaming |
 | [mistralai/Voxtral-4B-TTS-2603](https://huggingface.co/mistralai/Voxtral-4B-TTS-2603) | TTS | Speaker presets |
-| [Qwen/Qwen3-TTS-12Hz-0.6B-Base](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-0.6B-Base) | TTS | Voice cloning |
-| [Qwen/Qwen3-TTS-12Hz-1.7B-Base](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base) | TTS | Voice cloning |
+| [Qwen/Qwen3-TTS-12Hz-Base](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base) | TTS | Voice cloning, 0.6B / 1.7B |
 | [Qwen/Qwen3-Omni-30B-A3B-Instruct](https://huggingface.co/Qwen/Qwen3-Omni-30B-A3B-Instruct) | Omni | Speech + text I/O |
 | [inclusionAI/Ming-flash-omni-2.0](https://huggingface.co/inclusionAI/Ming-flash-omni-2.0) | Omni | Streaming TTS |
 | [inclusionAI/LLaDA2.0-Uni](https://huggingface.co/inclusionAI/LLaDA2.0-Uni) | Omni | Text + image I/O |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 
 SGLang-Omni is a high-performance serving framework for omni and multimodal models, built on top of [SGLang](https://github.com/sgl-project/sglang). It is designed to orchestrate multi-stage pipelines with low latency and OpenAI-compatible APIs.
 
+Modern omni models — such as speech-output LLMs and multimodal generation systems — decompose into heterogeneous stages with fundamentally different computational profiles: a compute-bound thinker, a memory-bound talker, a latency-sensitive codec. SGLang-Omni is built around a **computation-centric design**: each stage runs its own independent scheduler tuned to its bottleneck, communicates through a shared inbox/outbox abstraction, and transfers tensors via zero-copy shared memory. This prevents any single stage from degrading the others and allows new models to plug into the framework by declaring a pipeline topology rather than building an inference system from scratch.
+
 Core features:
 
 - **Multi-Stage Pipeline**: Flexible framework for orchestrating preprocessing, AR engine, codec, and vocoder stages across processes and GPUs.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,50 @@
-# SGLang-Omni
+<div align="center">
+<img src="https://raw.githubusercontent.com/sgl-project/sglang-omni/main/docs/_static/image/sgl-omni-logo.png" alt="logo" width="400"></img>
 
-SGLang-Omni is an ecosystem project for SGLang.
-Omni models refer to models that have multi-modal inputs and multi-modal outputs.
-These models typically consist of multiple stages, making SGLang's LLM-specific architecture no longer suitable.
-Therefore, SGLang-Omni is designed to provide the ability to orchestrate multi-stage pipeline with high performance and real-time API support.
-Our core features include:
+[![license](https://img.shields.io/github/license/sgl-project/sglang-omni.svg)](https://github.com/sgl-project/sglang-omni/tree/main/LICENSE)
+[![issue resolution](https://img.shields.io/github/issues-closed-raw/sgl-project/sglang-omni)](https://github.com/sgl-project/sglang-omni/issues)
+[![open issues](https://img.shields.io/github/issues-raw/sgl-project/sglang-omni)](https://github.com/sgl-project/sglang-omni/issues)
 
-- Native Integration with SGLang for performance
-- Multi-Stage Pipeline Framework for Omni Models
-- OpenAI-Compatible Server with Real-Time API support
+</div>
+
+--------------------------------------------------------------------------------
+
+<p align="center">
+<a href="https://sglang-omni.readthedocs.io/"><b>Documentation</b></a> |
+<a href="./benchmarks/README.md"><b>Benchmarks</b></a> |
+<a href="./examples/README.md"><b>Examples</b></a>
+</p>
+
+## News
+- [2026/05] 🔥 Higgs TTS streaming vocoder with batched decode for higher throughput ([PR #574](https://github.com/sgl-project/sglang-omni/pull/574)).
+- [2026/05] 🔥 Ming-Omni streaming TTS support ([PR #506](https://github.com/sgl-project/sglang-omni/pull/506)).
+- [2026/04] Qwen3-Omni talker partial-prefix startup for faster first-token latency ([PR #475](https://github.com/sgl-project/sglang-omni/pull/475)).
+- [2026/04] Higgs Audio V3 TTS cookbook ([PR #560](https://github.com/sgl-project/sglang-omni/pull/560)).
+
+## About
+
+SGLang-Omni is a high-performance serving framework for omni and multimodal models, built on top of [SGLang](https://github.com/sgl-project/sglang). It is designed to orchestrate multi-stage pipelines with low latency and OpenAI-compatible APIs.
+
+Core features:
+
+- **Multi-Stage Pipeline**: Flexible framework for orchestrating preprocessing, AR engine, codec, and vocoder stages across processes and GPUs.
+- **Native SGLang Integration**: Leverages SGLang's RadixAttention, continuous batching, and CUDA Graph optimizations for the AR backbone.
+- **OpenAI-Compatible Server**: Drop-in `/v1/audio/speech` and `/v1/chat/completions` endpoints with real-time streaming support.
+- **Broad Model Support**: Supports a growing set of TTS and omni models including Higgs Audio, Fish Audio S2-Pro, Voxtral TTS, Qwen3-Omni, and Ming-Omni.
+
+## Supported Models
+
+| Model | Type | Notes |
+|-------|------|-------|
+| [bosonai/higgs-audio-v3-tts-4b-base](https://huggingface.co/bosonai/higgs-audio-v3-tts-4b-base) | TTS | Voice cloning |
+| [fishaudio/s2-pro](https://huggingface.co/fishaudio/s2-pro) | TTS | Voice cloning, streaming |
+| [mistralai/Voxtral-4B-TTS-2603](https://huggingface.co/mistralai/Voxtral-4B-TTS-2603) | TTS | Speaker presets |
+| [Qwen/Qwen3-Omni-7B](https://huggingface.co/Qwen/Qwen3-Omni-7B) | Omni | Speech + text I/O |
+| [Ming-Omni](https://huggingface.co/inclusionAI/Ming-Omni) | Omni | Streaming TTS |
 
 ## Quick Start
 
-We will host the documentation upon open-sourcing. For now, you can find the documentation in the [docs](./docs) folder.
-
-- [Get Started](./docs/get_started/installation.md)
+- [Installation](./docs/get_started/installation.md)
 - [Developer Reference](./docs/developer_reference/main.md)
 - [Benchmarks](./benchmarks/README.md)
 - [Examples](./examples/README.md)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,5 @@ Core features:
 ## Get Started
 
 - [Installation](./docs/get_started/installation.md)
+- [Cookbook](./docs/cookbook/)
 - [Developer Reference](./docs/developer_reference/main.md)
-- [Benchmarks](./benchmarks/README.md)
-- [Examples](./examples/README.md)

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 ## News
 - [2026/05] 🔥 Higgs TTS streaming vocoder with batched decode for higher throughput ([PR #574](https://github.com/sgl-project/sglang-omni/pull/574)).
 - [2026/05] 🔥 Ming-Omni streaming TTS support ([PR #506](https://github.com/sgl-project/sglang-omni/pull/506)).
-- [2026/04] Qwen3-Omni talker partial-prefix startup for faster first-token latency ([PR #475](https://github.com/sgl-project/sglang-omni/pull/475)).
-- [2026/04] Higgs Audio V3 TTS cookbook ([PR #560](https://github.com/sgl-project/sglang-omni/pull/560)).
+- [2026/05] Qwen3-Omni talker partial-prefix startup for faster first-token latency ([PR #475](https://github.com/sgl-project/sglang-omni/pull/475)).
+- [2026/05] Higgs Audio V3 TTS cookbook ([PR #560](https://github.com/sgl-project/sglang-omni/pull/560)).
 
 ## About
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,8 @@ SGLang-Omni
 
 SGLang-Omni is a high-performance serving framework for omni and multimodal models, built on top of `SGLang <https://github.com/sgl-project/sglang>`_. It is designed to orchestrate multi-stage pipelines with low latency and OpenAI-compatible APIs.
 
+Modern omni models — such as speech-output LLMs and multimodal generation systems — decompose into heterogeneous stages with fundamentally different computational profiles: a compute-bound thinker, a memory-bound talker, a latency-sensitive codec. SGLang-Omni is built around a **computation-centric design**: each stage runs its own independent scheduler tuned to its bottleneck, communicates through a shared inbox/outbox abstraction, and transfers tensors via zero-copy shared memory. This prevents any single stage from degrading the others and allows new models to plug into the framework by declaring a pipeline topology rather than building an inference system from scratch.
+
 About
 -----
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,15 +1,14 @@
 SGLang-Omni
 =======================
 
-SGLang-Omni is an ecosystem project for SGLang.
-Omni models refer to models that have multi-modal inputs and multi-modal outputs.
-These models typically consist of multiple stages, making SGLang's LLM-specific architecture no longer suitable.
-Therefore, SGLang-Omni is designed to provide the ability to orchestrate multi-stage pipeline with high performance and real-time API support.
-Our core features include:
+SGLang-Omni is a high-performance serving framework for omni and multimodal models, built on top of `SGLang <https://github.com/sgl-project/sglang>`_. It is designed to orchestrate multi-stage pipelines with low latency and OpenAI-compatible APIs.
 
-- Native Integration with SGLang for performance
-- Multi-Stage Pipeline Framework for Omni Models
-- OpenAI-Compatible Server with Real-Time API support
+Core features:
+
+- **Multi-Stage Pipeline**: Flexible framework for orchestrating preprocessing, AR engine, codec, and vocoder stages across processes and GPUs.
+- **Native SGLang Integration**: Leverages SGLang's RadixAttention, continuous batching, and CUDA Graph optimizations for the AR backbone.
+- **OpenAI-Compatible Server**: Drop-in ``/v1/audio/speech`` and ``/v1/chat/completions`` endpoints with real-time streaming support.
+- **Broad Model Support**: Supports a growing set of TTS and omni models including Higgs Audio, Fish Audio S2-Pro, Voxtral TTS, Qwen3 TTS, Qwen3-Omni, Ming-Omni, and LLaDA2.0-Uni.
 
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,18 +3,6 @@ SGLang-Omni
 
 SGLang-Omni is a high-performance serving framework for omni and multimodal models, built on top of `SGLang <https://github.com/sgl-project/sglang>`_. It is designed to orchestrate multi-stage pipelines with low latency and OpenAI-compatible APIs.
 
-News
-----
-
-- [2026/05] 🔥 Qwen3-Omni talker partial-start enabled by default (`PR #617 <https://github.com/sgl-project/sglang-omni/pull/617>`_).
-- [2026/05] 🔥 Streaming TTS schedulers with framework-level support (`PR #614 <https://github.com/sgl-project/sglang-omni/pull/614>`_).
-- [2026/05] 🔥 Higgs TTS streaming vocoder with batched decode for higher throughput (`PR #574 <https://github.com/sgl-project/sglang-omni/pull/574>`_).
-- [2026/05] 🔥 Ming-Omni streaming TTS support (`PR #506 <https://github.com/sgl-project/sglang-omni/pull/506>`_).
-- [2026/05] torch.compile + CUDA Graph for Qwen3-TTS and Voxtral-TTS AR backbones (`PR #527 <https://github.com/sgl-project/sglang-omni/pull/527>`_).
-- [2026/05] Higgs TTS async decode (one-step lookahead) for lower latency (`PR #590 <https://github.com/sgl-project/sglang-omni/pull/590>`_).
-- [2026/05] Qwen3-Omni talker partial-prefix startup for faster first-token latency (`PR #475 <https://github.com/sgl-project/sglang-omni/pull/475>`_).
-- [2026/05] New cookbooks: LLaDA2.0-Uni (`PR #598 <https://github.com/sgl-project/sglang-omni/pull/598>`_), Voxtral TTS + Qwen3 TTS (`PR #585 <https://github.com/sgl-project/sglang-omni/pull/585>`_), Higgs Audio V3 TTS (`PR #560 <https://github.com/sgl-project/sglang-omni/pull/560>`_).
-
 About
 -----
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,12 +3,59 @@ SGLang-Omni
 
 SGLang-Omni is a high-performance serving framework for omni and multimodal models, built on top of `SGLang <https://github.com/sgl-project/sglang>`_. It is designed to orchestrate multi-stage pipelines with low latency and OpenAI-compatible APIs.
 
+News
+----
+
+- [2026/05] 🔥 Qwen3-Omni talker partial-start enabled by default (`PR #617 <https://github.com/sgl-project/sglang-omni/pull/617>`_).
+- [2026/05] 🔥 Streaming TTS schedulers with framework-level support (`PR #614 <https://github.com/sgl-project/sglang-omni/pull/614>`_).
+- [2026/05] 🔥 Higgs TTS streaming vocoder with batched decode for higher throughput (`PR #574 <https://github.com/sgl-project/sglang-omni/pull/574>`_).
+- [2026/05] 🔥 Ming-Omni streaming TTS support (`PR #506 <https://github.com/sgl-project/sglang-omni/pull/506>`_).
+- [2026/05] torch.compile + CUDA Graph for Qwen3-TTS and Voxtral-TTS AR backbones (`PR #527 <https://github.com/sgl-project/sglang-omni/pull/527>`_).
+- [2026/05] Higgs TTS async decode (one-step lookahead) for lower latency (`PR #590 <https://github.com/sgl-project/sglang-omni/pull/590>`_).
+- [2026/05] Qwen3-Omni talker partial-prefix startup for faster first-token latency (`PR #475 <https://github.com/sgl-project/sglang-omni/pull/475>`_).
+- [2026/05] New cookbooks: LLaDA2.0-Uni (`PR #598 <https://github.com/sgl-project/sglang-omni/pull/598>`_), Voxtral TTS + Qwen3 TTS (`PR #585 <https://github.com/sgl-project/sglang-omni/pull/585>`_), Higgs Audio V3 TTS (`PR #560 <https://github.com/sgl-project/sglang-omni/pull/560>`_).
+
+About
+-----
+
 Core features:
 
 - **Multi-Stage Pipeline**: Flexible framework for orchestrating preprocessing, AR engine, codec, and vocoder stages across processes and GPUs.
 - **Native SGLang Integration**: Leverages SGLang's RadixAttention, continuous batching, and CUDA Graph optimizations for the AR backbone.
 - **OpenAI-Compatible Server**: Drop-in ``/v1/audio/speech`` and ``/v1/chat/completions`` endpoints with real-time streaming support.
 - **Broad Model Support**: Supports a growing set of TTS and omni models including Higgs Audio, Fish Audio S2-Pro, Voxtral TTS, Qwen3 TTS, Qwen3-Omni, Ming-Omni, and LLaDA2.0-Uni.
+
+Supported Models
+----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 45 15 40
+
+   * - Model
+     - Type
+     - Notes
+   * - `boson-sglang/higgs-audio-v3-tts-4b-base <https://huggingface.co/boson-sglang/higgs-audio-v3-tts-4b-base>`_
+     - TTS
+     - Voice cloning, streaming, 100+ languages
+   * - `fishaudio/s2-pro <https://huggingface.co/fishaudio/s2-pro>`_
+     - TTS
+     - Voice cloning, streaming
+   * - `mistralai/Voxtral-4B-TTS-2603 <https://huggingface.co/mistralai/Voxtral-4B-TTS-2603>`_
+     - TTS
+     - Named voices, streaming, 9 languages
+   * - `Qwen/Qwen3-TTS-12Hz-Base <https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base>`_
+     - TTS
+     - Voice cloning, streaming, 10 languages, 0.6B / 1.7B
+   * - `Qwen/Qwen3-Omni-30B-A3B-Instruct <https://huggingface.co/Qwen/Qwen3-Omni-30B-A3B-Instruct>`_
+     - Omni
+     - Text, image, audio, video → text + audio
+   * - `inclusionAI/Ming-flash-omni-2.0 <https://huggingface.co/inclusionAI/Ming-flash-omni-2.0>`_
+     - Omni
+     - Streaming TTS
+   * - `inclusionAI/LLaDA2.0-Uni <https://huggingface.co/inclusionAI/LLaDA2.0-Uni>`_
+     - Multimodal
+     - Text + image understanding and generation
 
 
 .. toctree::


### PR DESCRIPTION
## Summary

- Switch license from MIT to Apache-2.0
- Rewrite README: add badges (DeepWiki, Slack), fix documentation URL, expand News and Supported Models table with all current models and accurate notes

https://github.com/sgl-project/sglang-omni/tree/docs/update-readme

<img width="2940" height="1750" alt="image" src="https://github.com/user-attachments/assets/3e31b260-c052-435b-9850-fa1ac80d175a" />
