### PR TITLE
[Perf]  Enable S2-Pro Fast-AR torch-compile on decode path.

### DIFF
--- a/sglang_omni/models/fishaudio_s2_pro/config.py
+++ b/sglang_omni/models/fishaudio_s2_pro/config.py
@@ -15,6 +15,10 @@ class S2ProPipelineConfig(PipelineConfig):
 
     architecture: ClassVar[str] = "FishQwen3OmniForCausalLM"
 
+    @classmethod
+    def talker_sglang_role_to_stage(cls) -> dict[str, str]:
+        return {"talker": "tts_engine"}
+
     model_path: str
     stages: list[StageConfig] = [
         StageConfig(

--- a/sglang_omni/models/fishaudio_s2_pro/fish_speech/models/text2semantic/modeling.py
+++ b/sglang_omni/models/fishaudio_s2_pro/fish_speech/models/text2semantic/modeling.py
@@ -948,9 +948,9 @@ class FishQwen3AudioDecoder(PreTrainedModel):
         self._eager_forward_kvcached_layers: list[
             Callable[[Tensor, Tensor, Tensor], Tensor]
         ] = [layer.forward_kvcached for layer in self.layers]
-        self._compiled_forward_kvcached_layers: list[
-            Callable[[Tensor, Tensor, Tensor], Tensor]
-        ] | None = None
+        self._compiled_forward_kvcached_layers: (
+            list[Callable[[Tensor, Tensor, Tensor], Tensor]] | None
+        ) = None
         self._compiled_forward_kvcached_max_bs = 0
         self.norm = RMSNorm(config.dim, eps=config.norm_eps)
         self.output = nn.Linear(config.dim, config.vocab_size, bias=False)

--- a/sglang_omni/models/fishaudio_s2_pro/fish_speech/models/text2semantic/modeling.py
+++ b/sglang_omni/models/fishaudio_s2_pro/fish_speech/models/text2semantic/modeling.py
@@ -1009,12 +1009,11 @@ class FishQwen3AudioDecoder(PreTrainedModel):
                 layer.attention.kv_cache.k_cache.zero_()
                 layer.attention.kv_cache.v_cache.zero_()
 
-    def compile_forward_kvcached_layers(self, *, mode: str) -> int:
-        """Compile Fast AR decoder layer calls used by the codebook loop."""
-        self._forward_kvcached_layers = [
-            torch.compile(layer.forward_kvcached, mode=mode) for layer in self.layers
-        ]
-        return len(self._forward_kvcached_layers)
+    def set_forward_kvcached_layers(
+        self,
+        forward_kvcached_layers: list[Callable[[Tensor, Tensor, Tensor], Tensor]],
+    ) -> None:
+        self._forward_kvcached_layers = forward_kvcached_layers
 
     def forward_kvcached(
         self,
@@ -1041,8 +1040,8 @@ class FishQwen3AudioDecoder(PreTrainedModel):
         # cache_seqlens: current position in cache for each batch item
         cache_seqlens = self.input_pos.expand(bsz).to(torch.int32)
 
-        for layer_call in self._forward_kvcached_layers:
-            x = layer_call(x, freqs_cis, cache_seqlens)
+        for layer in self._forward_kvcached_layers:
+            x = layer(x, freqs_cis, cache_seqlens)
 
         x = self.norm(x)
         return self.output(x)

--- a/sglang_omni/models/fishaudio_s2_pro/fish_speech/models/text2semantic/modeling.py
+++ b/sglang_omni/models/fishaudio_s2_pro/fish_speech/models/text2semantic/modeling.py
@@ -1031,9 +1031,13 @@ class FishQwen3AudioDecoder(PreTrainedModel):
         # cache_seqlens: current position in cache for each batch item
         cache_seqlens = self.input_pos.expand(bsz).to(torch.int32)
 
-        layers = getattr(self, "_compiled_layers", self.layers)
-        for layer in layers:
-            x = layer.forward_kvcached(x, freqs_cis, cache_seqlens)
+        compiled_layers = getattr(self, "_compiled_kvcached_layers", None)
+        if compiled_layers is not None:
+            for compiled_layer in compiled_layers:
+                x = compiled_layer(x, freqs_cis, cache_seqlens)
+        else:
+            for layer in self.layers:
+                x = layer.forward_kvcached(x, freqs_cis, cache_seqlens)
 
         x = self.norm(x)
         return self.output(x)

--- a/sglang_omni/models/fishaudio_s2_pro/fish_speech/models/text2semantic/modeling.py
+++ b/sglang_omni/models/fishaudio_s2_pro/fish_speech/models/text2semantic/modeling.py
@@ -1031,7 +1031,8 @@ class FishQwen3AudioDecoder(PreTrainedModel):
         # cache_seqlens: current position in cache for each batch item
         cache_seqlens = self.input_pos.expand(bsz).to(torch.int32)
 
-        for layer in self.layers:
+        layers = getattr(self, "_compiled_layers", self.layers)
+        for layer in layers:
             x = layer.forward_kvcached(x, freqs_cis, cache_seqlens)
 
         x = self.norm(x)

--- a/sglang_omni/models/fishaudio_s2_pro/fish_speech/models/text2semantic/modeling.py
+++ b/sglang_omni/models/fishaudio_s2_pro/fish_speech/models/text2semantic/modeling.py
@@ -945,9 +945,13 @@ class FishQwen3AudioDecoder(PreTrainedModel):
         self.layers = nn.ModuleList(
             [TransformerBlock(config) for _ in range(config.n_layer)]
         )
-        self._forward_kvcached_layers: list[
+        self._eager_forward_kvcached_layers: list[
             Callable[[Tensor, Tensor, Tensor], Tensor]
         ] = [layer.forward_kvcached for layer in self.layers]
+        self._compiled_forward_kvcached_layers: list[
+            Callable[[Tensor, Tensor, Tensor], Tensor]
+        ] | None = None
+        self._compiled_forward_kvcached_max_bs = 0
         self.norm = RMSNorm(config.dim, eps=config.norm_eps)
         self.output = nn.Linear(config.dim, config.vocab_size, bias=False)
 
@@ -1009,11 +1013,28 @@ class FishQwen3AudioDecoder(PreTrainedModel):
                 layer.attention.kv_cache.k_cache.zero_()
                 layer.attention.kv_cache.v_cache.zero_()
 
-    def set_forward_kvcached_layers(
+    def set_compiled_forward_kvcached_layers(
         self,
         forward_kvcached_layers: list[Callable[[Tensor, Tensor, Tensor], Tensor]],
+        *,
+        max_batch_size: int,
     ) -> None:
-        self._forward_kvcached_layers = forward_kvcached_layers
+        if max_batch_size < 1:
+            raise ValueError("max_batch_size must be >= 1")
+        if len(forward_kvcached_layers) != len(self.layers):
+            raise ValueError("compiled layer count must match decoder layer count")
+        self._compiled_forward_kvcached_layers = forward_kvcached_layers
+        self._compiled_forward_kvcached_max_bs = max_batch_size
+
+    def _select_forward_kvcached_layers(
+        self, bsz: int
+    ) -> list[Callable[[Tensor, Tensor, Tensor], Tensor]]:
+        if (
+            self._compiled_forward_kvcached_layers is not None
+            and bsz <= self._compiled_forward_kvcached_max_bs
+        ):
+            return self._compiled_forward_kvcached_layers
+        return self._eager_forward_kvcached_layers
 
     def forward_kvcached(
         self,
@@ -1040,7 +1061,7 @@ class FishQwen3AudioDecoder(PreTrainedModel):
         # cache_seqlens: current position in cache for each batch item
         cache_seqlens = self.input_pos.expand(bsz).to(torch.int32)
 
-        for layer in self._forward_kvcached_layers:
+        for layer in self._select_forward_kvcached_layers(bsz):
             x = layer(x, freqs_cis, cache_seqlens)
 
         x = self.norm(x)

--- a/sglang_omni/models/fishaudio_s2_pro/fish_speech/models/text2semantic/modeling.py
+++ b/sglang_omni/models/fishaudio_s2_pro/fish_speech/models/text2semantic/modeling.py
@@ -10,7 +10,7 @@ This module contains the model implementations:
 import math
 import os
 from dataclasses import dataclass
-from typing import Optional
+from typing import Callable, Optional
 
 import torch
 import torch.nn as nn
@@ -945,6 +945,9 @@ class FishQwen3AudioDecoder(PreTrainedModel):
         self.layers = nn.ModuleList(
             [TransformerBlock(config) for _ in range(config.n_layer)]
         )
+        self._forward_kvcached_layers: list[
+            Callable[[Tensor, Tensor, Tensor], Tensor]
+        ] = [layer.forward_kvcached for layer in self.layers]
         self.norm = RMSNorm(config.dim, eps=config.norm_eps)
         self.output = nn.Linear(config.dim, config.vocab_size, bias=False)
 
@@ -1006,6 +1009,13 @@ class FishQwen3AudioDecoder(PreTrainedModel):
                 layer.attention.kv_cache.k_cache.zero_()
                 layer.attention.kv_cache.v_cache.zero_()
 
+    def compile_forward_kvcached_layers(self, *, mode: str) -> int:
+        """Compile Fast AR decoder layer calls used by the codebook loop."""
+        self._forward_kvcached_layers = [
+            torch.compile(layer.forward_kvcached, mode=mode) for layer in self.layers
+        ]
+        return len(self._forward_kvcached_layers)
+
     def forward_kvcached(
         self,
         x: Tensor,
@@ -1031,13 +1041,8 @@ class FishQwen3AudioDecoder(PreTrainedModel):
         # cache_seqlens: current position in cache for each batch item
         cache_seqlens = self.input_pos.expand(bsz).to(torch.int32)
 
-        compiled_layers = getattr(self, "_compiled_kvcached_layers", None)
-        if compiled_layers is not None:
-            for compiled_layer in compiled_layers:
-                x = compiled_layer(x, freqs_cis, cache_seqlens)
-        else:
-            for layer in self.layers:
-                x = layer.forward_kvcached(x, freqs_cis, cache_seqlens)
+        for layer_call in self._forward_kvcached_layers:
+            x = layer_call(x, freqs_cis, cache_seqlens)
 
         x = self.norm(x)
         return self.output(x)

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -31,12 +31,14 @@ def _compile_s2pro_codebook_decoder(model: Any) -> None:
         "max-autotune-no-cudagraphs",
     )
     audio_decoder = model._audio_decoder
-    compiled_layer_count = audio_decoder.compile_forward_kvcached_layers(
-        mode=compile_mode
-    )
+    compiled_forward_kvcached_layers = [
+        torch.compile(layer.forward_kvcached, mode=compile_mode)
+        for layer in audio_decoder.layers
+    ]
+    audio_decoder.set_forward_kvcached_layers(compiled_forward_kvcached_layers)
     logger.info(
         "Compiled %d Fast AR decoder layers (mode=%s)",
-        compiled_layer_count,
+        len(compiled_forward_kvcached_layers),
         compile_mode,
     )
 

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -21,6 +21,27 @@ from sglang_omni.proto import StagePayload
 logger = logging.getLogger(__name__)
 
 
+def _compile_s2pro_codebook_decoder(model: Any) -> None:
+    """Compile Fast AR decoder layers while leaving sampling and loop control eager."""
+    from sglang.srt.model_executor.cuda_graph_runner import set_torch_compile_config
+
+    set_torch_compile_config()
+    compile_mode = os.environ.get(
+        "SGLANG_TORCH_COMPILE_MODE",
+        "max-autotune-no-cudagraphs",
+    )
+    audio_decoder = model._audio_decoder
+    audio_decoder._compiled_layers = [
+        torch.compile(layer, mode=compile_mode, fullgraph=True)
+        for layer in audio_decoder.layers
+    ]
+    logger.info(
+        "Compiled %d Fast AR decoder layers (mode=%s)",
+        len(audio_decoder._compiled_layers),
+        compile_mode,
+    )
+
+
 def _resolve_checkpoint(checkpoint: str) -> str:
     if os.path.isdir(checkpoint):
         return checkpoint
@@ -239,6 +260,10 @@ def create_sglang_tts_engine_executor(
         codebook_size=codebook_size,
         ras_window=ras_window,
     )
+
+    if bool(getattr(server_args, "enable_torch_compile", False)):
+        _compile_s2pro_codebook_decoder(model_worker.model_runner.model)
+        server_args.enable_torch_compile = False
 
     if want_cuda_graph:
         model_worker.model_runner.init_device_graphs()

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -31,13 +31,13 @@ def _compile_s2pro_codebook_decoder(model: Any) -> None:
         "max-autotune-no-cudagraphs",
     )
     audio_decoder = model._audio_decoder
-    audio_decoder._compiled_layers = [
-        torch.compile(layer, mode=compile_mode, fullgraph=True)
+    audio_decoder._compiled_kvcached_layers = [
+        torch.compile(layer.forward_kvcached, mode=compile_mode)
         for layer in audio_decoder.layers
     ]
     logger.info(
         "Compiled %d Fast AR decoder layers (mode=%s)",
-        len(audio_decoder._compiled_layers),
+        len(audio_decoder._compiled_kvcached_layers),
         compile_mode,
     )
 

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -31,13 +31,12 @@ def _compile_s2pro_codebook_decoder(model: Any) -> None:
         "max-autotune-no-cudagraphs",
     )
     audio_decoder = model._audio_decoder
-    audio_decoder._compiled_kvcached_layers = [
-        torch.compile(layer.forward_kvcached, mode=compile_mode)
-        for layer in audio_decoder.layers
-    ]
+    compiled_layer_count = audio_decoder.compile_forward_kvcached_layers(
+        mode=compile_mode
+    )
     logger.info(
         "Compiled %d Fast AR decoder layers (mode=%s)",
-        len(audio_decoder._compiled_kvcached_layers),
+        compiled_layer_count,
         compile_mode,
     )
 
@@ -211,6 +210,8 @@ def create_sglang_tts_engine_executor(
         "max_running_requests": 64,
         "chunked_prefill_size": 8192,
         "dtype": "bfloat16",
+        "enable_torch_compile": True,
+        "torch_compile_max_bs": 16,
         "random_seed": int.from_bytes(os.urandom(4), "little") & 0x7FFFFFFF,
     }
     if server_args_overrides:

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -21,9 +21,12 @@ from sglang_omni.proto import StagePayload
 logger = logging.getLogger(__name__)
 
 
-def _compile_s2pro_codebook_decoder(model: Any) -> None:
+def _compile_s2pro_codebook_decoder(model: Any, *, max_batch_size: int) -> None:
     """Compile Fast AR decoder layers while leaving sampling and loop control eager."""
     from sglang.srt.model_executor.cuda_graph_runner import set_torch_compile_config
+
+    if max_batch_size < 1:
+        raise ValueError("max_batch_size must be >= 1")
 
     set_torch_compile_config()
     compile_mode = os.environ.get(
@@ -35,11 +38,15 @@ def _compile_s2pro_codebook_decoder(model: Any) -> None:
         torch.compile(layer.forward_kvcached, mode=compile_mode)
         for layer in audio_decoder.layers
     ]
-    audio_decoder.set_forward_kvcached_layers(compiled_forward_kvcached_layers)
+    audio_decoder.set_compiled_forward_kvcached_layers(
+        compiled_forward_kvcached_layers,
+        max_batch_size=max_batch_size,
+    )
     logger.info(
-        "Compiled %d Fast AR decoder layers (mode=%s)",
+        "Compiled %d Fast AR decoder layers (mode=%s, max_batch_size=%d)",
         len(compiled_forward_kvcached_layers),
         compile_mode,
+        max_batch_size,
     )
 
 
@@ -265,7 +272,10 @@ def create_sglang_tts_engine_executor(
     )
 
     if bool(getattr(server_args, "enable_torch_compile", False)):
-        _compile_s2pro_codebook_decoder(model_worker.model_runner.model)
+        _compile_s2pro_codebook_decoder(
+            model_worker.model_runner.model,
+            max_batch_size=server_args.torch_compile_max_bs,
+        )
         server_args.enable_torch_compile = False
 
     if want_cuda_graph:

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -243,7 +243,7 @@ def test_s2pro_compile_helper_targets_forward_kvcached(
         compile_calls.append((target, mode, kwargs))
         return f"compiled-{len(compile_calls)}"
 
-    monkeypatch.setattr(stages.torch, "compile", fake_compile)
+    monkeypatch.setattr(torch, "compile", fake_compile)
     monkeypatch.setenv("SGLANG_TORCH_COMPILE_MODE", "reduce-overhead")
 
     class _Layer:
@@ -253,18 +253,29 @@ def test_s2pro_compile_helper_targets_forward_kvcached(
             del freqs_cis, cache_seqlens
             return x
 
-    layers = [_Layer()]
-    model = SimpleNamespace(_audio_decoder=SimpleNamespace(layers=layers))
+    class _AudioDecoder:
+        def __init__(self) -> None:
+            self.layers = [_Layer()]
+
+        def compile_forward_kvcached_layers(self, *, mode: str) -> int:
+            self._forward_kvcached_layers = [
+                torch.compile(layer.forward_kvcached, mode=mode)
+                for layer in self.layers
+            ]
+            return len(self._forward_kvcached_layers)
+
+    audio_decoder = _AudioDecoder()
+    model = SimpleNamespace(_audio_decoder=audio_decoder)
 
     stages._compile_s2pro_codebook_decoder(model)
 
     assert len(compile_calls) == 1
     target, mode, kwargs = compile_calls[0]
-    assert getattr(target, "__self__", None) is layers[0]
+    assert getattr(target, "__self__", None) is audio_decoder.layers[0]
     assert getattr(target, "__name__", "") == "forward_kvcached"
     assert mode == "reduce-overhead"
     assert kwargs == {}
-    assert model._audio_decoder._compiled_kvcached_layers == ["compiled-1"]
+    assert audio_decoder._forward_kvcached_layers == ["compiled-1"]
 
 
 def test_decoder_forward_kvcached_uses_compiled_callables_when_present() -> None:
@@ -302,8 +313,7 @@ def test_decoder_forward_kvcached_uses_compiled_callables_when_present() -> None
         seen_calls.append("b")
         return x + 3
 
-    decoder._compiled_kvcached_layers = [compiled_a, compiled_b]
-    decoder._compiled_layers = [object()]
+    decoder._forward_kvcached_layers = [compiled_a, compiled_b]
 
     x = torch.ones((2, 1, 4), dtype=torch.float32)
     out = FishQwen3AudioDecoder.forward_kvcached(decoder, x=x, codebook_idx=2)

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -358,8 +358,8 @@ def test_s2pro_engine_disables_generic_compile_after_local_compile(
 
     fake_sglang_backend = ModuleType("sglang_omni.scheduling.sglang_backend")
     fake_sglang_backend.build_sglang_server_args = fake_build_sglang_server_args
-    fake_sglang_backend.SGLangOutputProcessor = (
-        lambda **kwargs: SimpleNamespace(**kwargs)
+    fake_sglang_backend.SGLangOutputProcessor = lambda **kwargs: SimpleNamespace(
+        **kwargs
     )
 
     fake_fish_scheduler = ModuleType(
@@ -373,8 +373,8 @@ def test_s2pro_engine_disables_generic_compile_after_local_compile(
     fake_fish_scheduler.FishScheduler = _FakeFishScheduler
 
     fake_model_runner = ModuleType("sglang_omni.models.fishaudio_s2_pro.model_runner")
-    fake_model_runner.FishS2ProModelRunner = (
-        lambda *args, **kwargs: SimpleNamespace(args=args, kwargs=kwargs)
+    fake_model_runner.FishS2ProModelRunner = lambda *args, **kwargs: SimpleNamespace(
+        args=args, kwargs=kwargs
     )
 
     monkeypatch.setitem(

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -257,15 +257,19 @@ def test_s2pro_compile_helper_targets_forward_kvcached(
         def __init__(self) -> None:
             self.layers = [_Layer()]
 
-        def set_forward_kvcached_layers(
-            self, forward_kvcached_layers: list[object]
+        def set_compiled_forward_kvcached_layers(
+            self,
+            forward_kvcached_layers: list[object],
+            *,
+            max_batch_size: int,
         ) -> None:
-            self._forward_kvcached_layers = forward_kvcached_layers
+            self._compiled_forward_kvcached_layers = forward_kvcached_layers
+            self._compiled_forward_kvcached_max_bs = max_batch_size
 
     audio_decoder = _AudioDecoder()
     model = SimpleNamespace(_audio_decoder=audio_decoder)
 
-    stages._compile_s2pro_codebook_decoder(model)
+    stages._compile_s2pro_codebook_decoder(model, max_batch_size=2)
 
     assert len(compile_calls) == 1
     target, mode, kwargs = compile_calls[0]
@@ -273,10 +277,150 @@ def test_s2pro_compile_helper_targets_forward_kvcached(
     assert getattr(target, "__name__", "") == "forward_kvcached"
     assert mode == "reduce-overhead"
     assert kwargs == {}
-    assert audio_decoder._forward_kvcached_layers == ["compiled-1"]
+    assert audio_decoder._compiled_forward_kvcached_layers == ["compiled-1"]
+    assert audio_decoder._compiled_forward_kvcached_max_bs == 2
 
 
-def test_decoder_forward_kvcached_uses_compiled_callables_when_present() -> None:
+def test_s2pro_engine_disables_generic_compile_after_local_compile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stages = importlib.import_module("sglang_omni.models.fishaudio_s2_pro.stages")
+    monkeypatch.setattr(stages, "_resolve_checkpoint", lambda model_path: model_path)
+
+    build_kwargs: dict[str, object] = {}
+    infrastructure_saw_graph_disabled: list[bool] = []
+    compile_calls: list[tuple[object, int]] = []
+    init_graph_calls: list[bool] = []
+
+    class _FakeSGLangRunner:
+        def __init__(self, server_args: SimpleNamespace) -> None:
+            self.server_args = server_args
+            self.model = SimpleNamespace()
+
+        def init_device_graphs(self) -> None:
+            assert self.server_args.enable_torch_compile is False
+            assert self.server_args.torch_compile_max_bs == 16
+            init_graph_calls.append(True)
+
+    class _FakeWorker:
+        def __init__(self, server_args: SimpleNamespace) -> None:
+            self.model_runner = _FakeSGLangRunner(server_args)
+
+    fake_bootstrap = ModuleType("sglang_omni.models.fishaudio_s2_pro.bootstrap")
+    fake_bootstrap.patch_fish_config_for_sglang = lambda: None
+    fake_bootstrap.truncate_rope_to_bf16 = lambda model: None
+    fake_bootstrap.load_audio_decoder = lambda checkpoint_dir, device: (
+        SimpleNamespace(),
+        10,
+        4096,
+        FakeFishTokenizer(),
+    )
+    fake_bootstrap.bootstrap_text_model_for_decode = lambda **kwargs: None
+
+    def fake_build_sglang_server_args(
+        model_path: str,
+        context_length: int,
+        **kwargs: object,
+    ) -> SimpleNamespace:
+        del model_path, context_length
+        build_kwargs.update(kwargs)
+        return SimpleNamespace(
+            disable_cuda_graph=kwargs["disable_cuda_graph"],
+            enable_torch_compile=kwargs["enable_torch_compile"],
+            torch_compile_max_bs=kwargs["torch_compile_max_bs"],
+            max_running_requests=kwargs["max_running_requests"],
+            page_size=1,
+            chunked_prefill_size=kwargs["chunked_prefill_size"],
+            max_prefill_tokens=16384,
+            attention_backend=None,
+        )
+
+    def fake_create_sglang_infrastructure(
+        server_args: SimpleNamespace,
+        gpu_id: int,
+    ) -> tuple[object, object, object, object, object, object, object]:
+        assert gpu_id == 0
+        infrastructure_saw_graph_disabled.append(bool(server_args.disable_cuda_graph))
+        return (
+            _FakeWorker(server_args),
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            SimpleNamespace(),
+        )
+
+    fake_scheduler_bootstrap = ModuleType("sglang_omni.scheduling.bootstrap")
+    fake_scheduler_bootstrap.create_sglang_infrastructure = (
+        fake_create_sglang_infrastructure
+    )
+
+    fake_sglang_backend = ModuleType("sglang_omni.scheduling.sglang_backend")
+    fake_sglang_backend.build_sglang_server_args = fake_build_sglang_server_args
+    fake_sglang_backend.SGLangOutputProcessor = (
+        lambda **kwargs: SimpleNamespace(**kwargs)
+    )
+
+    fake_fish_scheduler = ModuleType(
+        "sglang_omni.models.fishaudio_s2_pro.fish_scheduler"
+    )
+
+    class _FakeFishScheduler:
+        def __init__(self, **kwargs: object) -> None:
+            self.__dict__.update(kwargs)
+
+    fake_fish_scheduler.FishScheduler = _FakeFishScheduler
+
+    fake_model_runner = ModuleType("sglang_omni.models.fishaudio_s2_pro.model_runner")
+    fake_model_runner.FishS2ProModelRunner = (
+        lambda *args, **kwargs: SimpleNamespace(args=args, kwargs=kwargs)
+    )
+
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.models.fishaudio_s2_pro.bootstrap",
+        fake_bootstrap,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.scheduling.bootstrap",
+        fake_scheduler_bootstrap,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.scheduling.sglang_backend",
+        fake_sglang_backend,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.models.fishaudio_s2_pro.fish_scheduler",
+        fake_fish_scheduler,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.models.fishaudio_s2_pro.model_runner",
+        fake_model_runner,
+    )
+
+    def fake_compile(model: object, *, max_batch_size: int) -> None:
+        compile_calls.append((model, max_batch_size))
+
+    monkeypatch.setattr(stages, "_compile_s2pro_codebook_decoder", fake_compile)
+
+    scheduler = stages.create_sglang_tts_engine_executor("model", device="cuda:0")
+
+    assert build_kwargs["enable_torch_compile"] is True
+    assert build_kwargs["torch_compile_max_bs"] == 16
+    assert infrastructure_saw_graph_disabled == [True]
+    assert compile_calls == [(scheduler.model_runner.args[0].model_runner.model, 16)]
+    assert init_graph_calls == [True]
+    assert scheduler.server_args.disable_cuda_graph is False
+    assert scheduler.server_args.enable_torch_compile is False
+    assert scheduler.server_args.torch_compile_max_bs == 16
+
+
+def test_decoder_forward_kvcached_obeys_compiled_batch_size_cap() -> None:
     from sglang_omni.models.fishaudio_s2_pro.fish_speech.models.text2semantic.modeling import (
         FishQwen3AudioDecoder,
     )
@@ -285,36 +429,41 @@ def test_decoder_forward_kvcached_uses_compiled_callables_when_present() -> None
         def forward_kvcached(
             self, x: torch.Tensor, freqs_cis: torch.Tensor, cache_seqlens: torch.Tensor
         ) -> torch.Tensor:
-            del x, freqs_cis, cache_seqlens
-            raise AssertionError("eager layer path should be bypassed")
+            del freqs_cis, cache_seqlens
+            seen_calls.append("eager")
+            return x + 10
 
     decoder = object.__new__(FishQwen3AudioDecoder)
     decoder.input_pos = torch.zeros(1, dtype=torch.long)
     decoder.freqs_cis = torch.zeros(8, 1, 1, dtype=torch.float32)
-    decoder.layers = [_EagerLayer(), _EagerLayer()]
-    decoder.norm = lambda x: x + 1
-    decoder.output = lambda x: x * 2
+    decoder.layers = [_EagerLayer()]
+    decoder._eager_forward_kvcached_layers = [
+        layer.forward_kvcached for layer in decoder.layers
+    ]
+    decoder.norm = lambda x: x
+    decoder.output = lambda x: x
 
     seen_calls: list[str] = []
 
-    def compiled_a(
+    def compiled(
         x: torch.Tensor, freqs_cis: torch.Tensor, cache_seqlens: torch.Tensor
     ) -> torch.Tensor:
         del freqs_cis, cache_seqlens
-        seen_calls.append("a")
-        return x + 2
+        seen_calls.append("compiled")
+        return x + 1
 
-    def compiled_b(
-        x: torch.Tensor, freqs_cis: torch.Tensor, cache_seqlens: torch.Tensor
-    ) -> torch.Tensor:
-        del freqs_cis, cache_seqlens
-        seen_calls.append("b")
-        return x + 3
+    decoder._compiled_forward_kvcached_layers = [compiled]
+    decoder._compiled_forward_kvcached_max_bs = 2
 
-    decoder._forward_kvcached_layers = [compiled_a, compiled_b]
-
-    x = torch.ones((2, 1, 4), dtype=torch.float32)
+    x = torch.zeros((2, 1, 4), dtype=torch.float32)
     out = FishQwen3AudioDecoder.forward_kvcached(decoder, x=x, codebook_idx=2)
 
-    assert torch.equal(out, torch.full_like(x, 14.0))
-    assert seen_calls == ["a", "b"]
+    assert torch.equal(out, torch.ones_like(x))
+    assert seen_calls == ["compiled"]
+
+    seen_calls.clear()
+    x = torch.zeros((3, 1, 4), dtype=torch.float32)
+    out = FishQwen3AudioDecoder.forward_kvcached(decoder, x=x, codebook_idx=2)
+
+    assert torch.equal(out, torch.full_like(x, 10.0))
+    assert seen_calls == ["eager"]

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+
 import pytest
 import torch
+import typer
 
+from sglang_omni.cli.serve import apply_torch_compile_cli_overrides
 from sglang_omni.models.fishaudio_s2_pro.config import S2ProPipelineConfig
 from sglang_omni.models.fishaudio_s2_pro.payload_types import S2ProState
 from sglang_omni.models.fishaudio_s2_pro.request_builders import (
@@ -152,3 +158,155 @@ def test_fish_tts_accepts_default_top_k_sentinel() -> None:
     req_data = build_sglang_tts_request(state, tokenizer, request_id="top-k-default")
 
     assert req_data.top_k == -1
+
+
+def _server_args_overrides(config: S2ProPipelineConfig, name: str) -> dict[str, object]:
+    stage = next(stage for stage in config.stages if stage.name == name)
+    return dict(stage.factory_args.get("server_args_overrides") or {})
+
+
+@pytest.mark.parametrize(
+    "talker_mode,talker_max_bs,expected",
+    [
+        ("on", None, {"enable_torch_compile": True}),
+        ("off", None, {"enable_torch_compile": False}),
+        ("default", 2, {"torch_compile_max_bs": 2}),
+        ("on", 4, {"enable_torch_compile": True, "torch_compile_max_bs": 4}),
+    ],
+)
+def test_s2pro_cli_talker_torch_compile_targets_tts_engine(
+    talker_mode: str,
+    talker_max_bs: int | None,
+    expected: dict[str, object],
+) -> None:
+    config = S2ProPipelineConfig(model_path="model")
+
+    apply_torch_compile_cli_overrides(
+        config,
+        thinker_torch_compile="default",
+        talker_torch_compile=talker_mode,
+        thinker_torch_compile_max_bs=None,
+        talker_torch_compile_max_bs=talker_max_bs,
+    )
+
+    assert _server_args_overrides(config, "tts_engine") == expected
+    assert _server_args_overrides(config, "vocoder") == {}
+
+
+def test_s2pro_cli_talker_torch_compile_default_is_noop() -> None:
+    config = S2ProPipelineConfig(model_path="model")
+
+    apply_torch_compile_cli_overrides(
+        config,
+        thinker_torch_compile="default",
+        talker_torch_compile="default",
+        thinker_torch_compile_max_bs=None,
+        talker_torch_compile_max_bs=None,
+    )
+
+    assert _server_args_overrides(config, "tts_engine") == {}
+
+
+def test_s2pro_cli_talker_torch_compile_max_bs_rejects_non_positive() -> None:
+    config = S2ProPipelineConfig(model_path="model")
+
+    with pytest.raises(
+        typer.BadParameter,
+        match="torch compile max batch size must be >= 1",
+    ):
+        apply_torch_compile_cli_overrides(
+            config,
+            thinker_torch_compile="default",
+            talker_torch_compile="default",
+            thinker_torch_compile_max_bs=None,
+            talker_torch_compile_max_bs=0,
+        )
+
+
+def test_s2pro_compile_helper_targets_forward_kvcached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", "/tmp")
+    stages = importlib.import_module("sglang_omni.models.fishaudio_s2_pro.stages")
+
+    fake_runner = ModuleType("sglang.srt.model_executor.cuda_graph_runner")
+    fake_runner.set_torch_compile_config = lambda: None
+    monkeypatch.setitem(
+        sys.modules, "sglang.srt.model_executor.cuda_graph_runner", fake_runner
+    )
+
+    compile_calls: list[tuple[object, str | None, dict[str, object]]] = []
+
+    def fake_compile(
+        target: object, *, mode: str | None = None, **kwargs: object
+    ) -> object:
+        compile_calls.append((target, mode, kwargs))
+        return f"compiled-{len(compile_calls)}"
+
+    monkeypatch.setattr(stages.torch, "compile", fake_compile)
+    monkeypatch.setenv("SGLANG_TORCH_COMPILE_MODE", "reduce-overhead")
+
+    class _Layer:
+        def forward_kvcached(
+            self, x: torch.Tensor, freqs_cis: torch.Tensor, cache_seqlens: torch.Tensor
+        ) -> torch.Tensor:
+            del freqs_cis, cache_seqlens
+            return x
+
+    layers = [_Layer()]
+    model = SimpleNamespace(_audio_decoder=SimpleNamespace(layers=layers))
+
+    stages._compile_s2pro_codebook_decoder(model)
+
+    assert len(compile_calls) == 1
+    target, mode, kwargs = compile_calls[0]
+    assert getattr(target, "__self__", None) is layers[0]
+    assert getattr(target, "__name__", "") == "forward_kvcached"
+    assert mode == "reduce-overhead"
+    assert kwargs == {}
+    assert model._audio_decoder._compiled_kvcached_layers == ["compiled-1"]
+
+
+def test_decoder_forward_kvcached_uses_compiled_callables_when_present() -> None:
+    from sglang_omni.models.fishaudio_s2_pro.fish_speech.models.text2semantic.modeling import (
+        FishQwen3AudioDecoder,
+    )
+
+    class _EagerLayer:
+        def forward_kvcached(
+            self, x: torch.Tensor, freqs_cis: torch.Tensor, cache_seqlens: torch.Tensor
+        ) -> torch.Tensor:
+            del x, freqs_cis, cache_seqlens
+            raise AssertionError("eager layer path should be bypassed")
+
+    decoder = object.__new__(FishQwen3AudioDecoder)
+    decoder.input_pos = torch.zeros(1, dtype=torch.long)
+    decoder.freqs_cis = torch.zeros(8, 1, 1, dtype=torch.float32)
+    decoder.layers = [_EagerLayer(), _EagerLayer()]
+    decoder.norm = lambda x: x + 1
+    decoder.output = lambda x: x * 2
+
+    seen_calls: list[str] = []
+
+    def compiled_a(
+        x: torch.Tensor, freqs_cis: torch.Tensor, cache_seqlens: torch.Tensor
+    ) -> torch.Tensor:
+        del freqs_cis, cache_seqlens
+        seen_calls.append("a")
+        return x + 2
+
+    def compiled_b(
+        x: torch.Tensor, freqs_cis: torch.Tensor, cache_seqlens: torch.Tensor
+    ) -> torch.Tensor:
+        del freqs_cis, cache_seqlens
+        seen_calls.append("b")
+        return x + 3
+
+    decoder._compiled_kvcached_layers = [compiled_a, compiled_b]
+    decoder._compiled_layers = [object()]
+
+    x = torch.ones((2, 1, 4), dtype=torch.float32)
+    out = FishQwen3AudioDecoder.forward_kvcached(decoder, x=x, codebook_idx=2)
+
+    assert torch.equal(out, torch.full_like(x, 14.0))
+    assert seen_calls == ["a", "b"]

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -257,12 +257,10 @@ def test_s2pro_compile_helper_targets_forward_kvcached(
         def __init__(self) -> None:
             self.layers = [_Layer()]
 
-        def compile_forward_kvcached_layers(self, *, mode: str) -> int:
-            self._forward_kvcached_layers = [
-                torch.compile(layer.forward_kvcached, mode=mode)
-                for layer in self.layers
-            ]
-            return len(self._forward_kvcached_layers)
+        def set_forward_kvcached_layers(
+            self, forward_kvcached_layers: list[object]
+        ) -> None:
+            self._forward_kvcached_layers = forward_kvcached_layers
 
     audio_decoder = _AudioDecoder()
     model = SimpleNamespace(_audio_decoder=audio_decoder)


### PR DESCRIPTION
## Motivation

Enable effective torch-compile acceleration for S2-Pro fast AR decode path and make its CLI compile controls apply to the pipeline stage.

## Modifications
1. `sglang_omni/models/fishaudio_s2_pro/config.py`
- Added `talker_sglang_role_to_stage()` override to map `talker` to `tts_engine`.

2. `sglang_omni/models/fishaudio_s2_pro/stages.py`
- Added `_compile_s2pro_codebook_decoder(model, max_batch_size=...)` helper.
- Enables S2-Pro talker compile by default with `enable_torch_compile=True` and `torch_compile_max_bs=16`.
- Compiles the audio decoder layer `forward_kvcached` bound methods (not module `forward`) during stage setup.
- Installs the compiled callable list with `audio_decoder.set_compiled_forward_kvcached_layers(..., max_batch_size=server_args.torch_compile_max_bs)` before CUDA graph capture.
- Uses `SGLANG_TORCH_COMPILE_MODE` (default: `max-autotune-no-cudagraphs`).
- Runs local S2-Pro compile when `server_args.enable_torch_compile` is set, then disables generic engine-level compile (`server_args.enable_torch_compile = False`) after local compile setup.
- Keeps the local compiled path governed by `torch_compile_max_bs`, even after generic engine-level compile is disabled for CUDA graph capture.

3. `sglang_omni/models/fishaudio_s2_pro/fish_speech/models/text2semantic/modeling.py`
- Initializes `_eager_forward_kvcached_layers` to eager `layer.forward_kvcached` callables.
- Added `FishQwen3AudioDecoder.set_compiled_forward_kvcached_layers(..., max_batch_size=...)` so stage setup can register compiled callables without putting `torch.compile(...)` in the model file.
- Keeps eager and compiled callable lists side by side.
- Dispatches once at `forward_kvcached` entry: batches `<= torch_compile_max_bs` use compiled callables, while larger batches use eager callables.
- Avoids dynamic attribute lookup/fallback in the repeated codebook loop and prevents capture batches above the cap from triggering extra local Inductor compilations.

4. `tests/unit_test/fishaudio_s2_pro/test_pipeline.py`
- Added CLI override coverage for S2-Pro talker compile flags targeting `tts_engine`.
- Added regression coverage for the stage compile helper.
- Added engine setup regression coverage that S2-Pro defaults pass `enable_torch_compile=True` and `torch_compile_max_bs=16`, the local helper receives the same cap, and generic compile is disabled before CUDA graph capture.
- Added decoder dispatch regression coverage that batches at or below the cap use compiled callables and batches above the cap use eager execution.

## Related Issues
https://github.com/sgl-project/sglang-omni/issues/571

## Accuracy Test
**Setup:**
- SeedTTS EN full set (`1088` samples), `concurrency=16`, `warmup=1`
- 3 runs each:
  - baseline: `main` @ `f1302c0`
  - compile: `s2pro-fast-dec-compile` @ `a647c78` (`--talker-torch-compile on`)

| Metric | Baseline | Compile |
| --- | ---: | ---: |
| `WER corpus` | `1.0131%` | `0.9964%` |
| `WER per-sample mean` | `0.9661%` | `0.9532%` |
| `Speaker similarity mean` | `64.9245` | `65.0996` |
| `Evaluated / skipped` | `1088 / 0` | `1088 / 0` |

## Benchmark & Profiling
Same setup as described in the _Accuracy Test_ section, 3 runs per variant. 
| Metric | Baseline (mean ± std) | Compile (mean ± std) | Delta (Compile vs Baseline) |
| --- | ---: | ---: | ---: |
| `latency_mean_s` | `16.196 ± 0.490` | `16.168 ± 0.227` | `-0.17%` |
| `latency_p95_s` | `22.058 ± 0.355` | `21.903 ± 0.183` | `-0.70%` |
| `throughput_qps` | `0.983 ± 0.031` | `0.984 ± 0.014` | `+0.10%` |
| `rtf_mean` | `4.404 ± 0.131` | `4.393 ± 0.060` | `-0.25%` |
| `audio_throughput_s_per_s` | `3.901 ± 0.119` | `3.908 ± 0.060` | `+0.19%` |
| `output_tok_per_req_s` | `76.767 ± 0.586` | `91.400 ± 0.100` | `+19.06%` |
| `output_throughput` (tok/s) | `84.000 ± 2.587` | `84.133 ± 1.274` | `+0.16%` |
| `startup_ready_s` | `55.737 ± 0.579` | `62.076 ± 9.547` | `+11.37%`* |
| `cold_first_request_s` | `8.256 ± 1.173` | `8.446 ± 0.903` | `+2.30%` |
| `completed / failed` | `1088 / 0` | `1088 / 0` | `no change` |

  *_The large std on compile `startup_ready_s` (`62.076 ± 9.547`) is dominated by one outlier run (`73.085s`): in compile run 3, the preprocessing-stage HuggingFace `Fetching 13 files` step took about `15s`, while it was near-instant in compile runs 1/2. If that outlier is excluded, compile `startup_ready_s` mean is `56.572s`._

### Summary:
- Decode-path efficiency improved strongly (`output_tok_per_req_s` +19.06%).
- End-to-end serving KPIs (`latency`, `throughput`, `rtf`) are effectively flat (within about ±1%).

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Draft PRs are skipped even if labeled.
