### PR TITLE
[Router] Retry transient worker failures to fix flaky Qwen3-Omni MMMU CI

### DIFF
--- a/sglang_omni_router/config.py
+++ b/sglang_omni_router/config.py
@@ -127,6 +127,8 @@ class RouterConfig(BaseModel):
     request_timeout_secs: int = 1800
     max_payload_size: int = 512 * 1024 * 1024
     max_connections: int = 100
+    max_request_retries: int = 2
+    retry_backoff_secs: float = 0.5
     health_failure_threshold: int = 3
     health_success_threshold: int = 2
     health_check_timeout_secs: int = 5
@@ -153,6 +155,20 @@ class RouterConfig(BaseModel):
     def _validate_positive_int(cls, value: int) -> int:
         if value <= 0:
             raise ValueError("value must be > 0")
+        return value
+
+    @field_validator("max_request_retries")
+    @classmethod
+    def _validate_non_negative_int(cls, value: int) -> int:
+        if value < 0:
+            raise ValueError("value must be >= 0")
+        return value
+
+    @field_validator("retry_backoff_secs")
+    @classmethod
+    def _validate_non_negative_float(cls, value: float) -> float:
+        if value < 0:
+            raise ValueError("value must be >= 0")
         return value
 
     @field_validator("health_check_endpoint")
@@ -186,6 +202,8 @@ def build_router_config(
     request_timeout_secs: int = 1800,
     max_payload_size: int = 512 * 1024 * 1024,
     max_connections: int = 100,
+    max_request_retries: int = 2,
+    retry_backoff_secs: float = 0.5,
     health_failure_threshold: int = 3,
     health_success_threshold: int = 2,
     health_check_timeout_secs: int = 5,
@@ -208,6 +226,8 @@ def build_router_config(
         request_timeout_secs=request_timeout_secs,
         max_payload_size=max_payload_size,
         max_connections=max_connections,
+        max_request_retries=max_request_retries,
+        retry_backoff_secs=retry_backoff_secs,
         health_failure_threshold=health_failure_threshold,
         health_success_threshold=health_success_threshold,
         health_check_timeout_secs=health_check_timeout_secs,

--- a/sglang_omni_router/proxy.py
+++ b/sglang_omni_router/proxy.py
@@ -200,6 +200,40 @@ class ProxyHandler:
         metadata: RouteMetadata,
         worker: Worker,
     ) -> Response:
+        # Buffered inference requests are idempotent, so a transient upstream
+        # failure (connection error, 5xx, 408, 429) on one worker is retried on
+        # another routable worker — or the same one after a backoff when it is
+        # the only candidate left. This absorbs intermittent worker hiccups
+        # (e.g. colocated thinker OOM) instead of surfacing them as hard
+        # failures to the client.
+        tried: set[str] = set()
+        max_attempts = 1 + self._config.max_request_retries
+        attempt = 0
+        while True:
+            attempt += 1
+            tried.add(worker.worker_id)
+            response, retryable = await self._attempt_non_streaming(
+                request, path, body, metadata, worker, attempt
+            )
+            if not retryable or attempt >= max_attempts:
+                return response
+            next_worker = self._select_retry_worker(metadata, exclude=tried)
+            if next_worker is None:
+                next_worker = self._select_retry_worker(metadata, exclude=set())
+            if next_worker is None:
+                return response
+            await self._retry_backoff(attempt)
+            worker = next_worker
+
+    async def _attempt_non_streaming(
+        self,
+        request: Request,
+        path: str,
+        body: bytes,
+        metadata: RouteMetadata,
+        worker: Worker,
+        attempt: int,
+    ) -> tuple[Response, bool]:
         with worker.request_guard():
             start_time = time.perf_counter()
             upstream_url = build_upstream_url(worker, path, request)
@@ -224,14 +258,19 @@ class ProxyHandler:
                     status_code=502,
                     outcome="upstream_error",
                     start_time=start_time,
+                    attempt=attempt,
                 )
-                return JSONResponse(
-                    status_code=502,
-                    content={"error": {"message": "upstream request failed"}},
-                    headers=self._diagnostic_headers(worker, metadata),
+                return (
+                    JSONResponse(
+                        status_code=502,
+                        content={"error": {"message": "upstream request failed"}},
+                        headers=self._diagnostic_headers(worker, metadata, attempt),
+                    ),
+                    True,
                 )
 
-            if response.status_code in WORKER_REQUEST_FAILURE_STATUS_CODES:
+            retryable = response.status_code in WORKER_REQUEST_FAILURE_STATUS_CODES
+            if retryable:
                 self._record_worker_request_failure(
                     worker,
                     status_code=response.status_code,
@@ -246,14 +285,18 @@ class ProxyHandler:
                 status_code=response.status_code,
                 outcome=outcome,
                 start_time=start_time,
+                attempt=attempt,
             )
             headers = filter_response_headers(response.headers, buffered=True)
-            headers.update(self._diagnostic_headers(worker, metadata))
-            return Response(
-                content=response.content,
-                status_code=response.status_code,
-                headers=headers,
-                media_type=response.headers.get("content-type"),
+            headers.update(self._diagnostic_headers(worker, metadata, attempt))
+            return (
+                Response(
+                    content=response.content,
+                    status_code=response.status_code,
+                    headers=headers,
+                    media_type=response.headers.get("content-type"),
+                ),
+                retryable,
             )
 
     async def _forward_streaming(
@@ -264,36 +307,53 @@ class ProxyHandler:
         metadata: RouteMetadata,
         worker: Worker,
     ) -> StreamingResponse | JSONResponse:
-        start_time = time.perf_counter()
-        upstream_request = self._client.build_request(
-            request.method,
-            build_upstream_url(worker, path, request),
-            content=body,
-            headers=filter_request_headers(request),
-        )
-        worker.increment_active()
-        try:
-            upstream = await self._client.send(upstream_request, stream=True)
-        except httpx.HTTPError as exc:
-            worker.decrement_active()
-            worker.record_routed_request()
-            self._record_worker_request_failure(
-                worker,
-                error=type(exc).__name__,
+        # Streaming responses can only be retried before any bytes reach the
+        # client, so failover here covers the initial connect/send only. Once
+        # the upstream stream is established the body is relayed as-is.
+        tried: set[str] = set()
+        max_attempts = 1 + self._config.max_request_retries
+        attempt = 0
+        while True:
+            attempt += 1
+            tried.add(worker.worker_id)
+            start_time = time.perf_counter()
+            upstream_request = self._client.build_request(
+                request.method,
+                build_upstream_url(worker, path, request),
+                content=body,
+                headers=filter_request_headers(request),
             )
-            self._log_route_completion(
-                worker=worker,
-                path=path,
-                metadata=metadata,
-                status_code=502,
-                outcome="upstream_error",
-                start_time=start_time,
-            )
-            return JSONResponse(
-                status_code=502,
-                content={"error": {"message": "upstream request failed"}},
-                headers=self._diagnostic_headers(worker, metadata),
-            )
+            worker.increment_active()
+            try:
+                upstream = await self._client.send(upstream_request, stream=True)
+                break
+            except httpx.HTTPError as exc:
+                worker.decrement_active()
+                worker.record_routed_request()
+                self._record_worker_request_failure(
+                    worker,
+                    error=type(exc).__name__,
+                )
+                self._log_route_completion(
+                    worker=worker,
+                    path=path,
+                    metadata=metadata,
+                    status_code=502,
+                    outcome="upstream_error",
+                    start_time=start_time,
+                    attempt=attempt,
+                )
+                next_worker = self._select_retry_worker(metadata, exclude=tried)
+                if next_worker is None:
+                    next_worker = self._select_retry_worker(metadata, exclude=set())
+                if attempt >= max_attempts or next_worker is None:
+                    return JSONResponse(
+                        status_code=502,
+                        content={"error": {"message": "upstream request failed"}},
+                        headers=self._diagnostic_headers(worker, metadata, attempt),
+                    )
+                await self._retry_backoff(attempt)
+                worker = next_worker
 
         worker_failure_recorded = False
 
@@ -342,11 +402,12 @@ class ProxyHandler:
                     status_code=upstream.status_code,
                     outcome=outcome,
                     start_time=start_time,
+                    attempt=attempt,
                 )
 
         try:
             headers = filter_response_headers(upstream.headers)
-            headers.update(self._diagnostic_headers(worker, metadata))
+            headers.update(self._diagnostic_headers(worker, metadata, attempt))
         except Exception:
             await upstream.aclose()
             worker.decrement_active()
@@ -358,15 +419,37 @@ class ProxyHandler:
             media_type=upstream.headers.get("content-type", "text/event-stream"),
         )
 
+    def _select_retry_worker(
+        self,
+        metadata: RouteMetadata,
+        *,
+        exclude: set[str],
+    ) -> Worker | None:
+        try:
+            return self._selector.select(
+                self._workers,
+                required_capabilities=metadata.required_capabilities,
+                requested_model=metadata.model,
+                exclude=exclude,
+            )
+        except NoEligibleWorkerError:
+            return None
+
+    async def _retry_backoff(self, attempt: int) -> None:
+        delay = self._config.retry_backoff_secs * (2 ** (attempt - 1))
+        if delay > 0:
+            await asyncio.sleep(delay)
+
     def _diagnostic_headers(
         self,
         worker: Worker,
         metadata: RouteMetadata,
+        attempt: int,
     ) -> dict[str, str]:
         return {
             "X-SGLang-Omni-Worker": worker.worker_id,
             "X-SGLang-Omni-Request-ID": metadata.request_id,
-            "X-SGLang-Omni-Route-Attempt": "1",
+            "X-SGLang-Omni-Route-Attempt": str(attempt),
         }
 
     def _record_worker_request_failure(
@@ -398,6 +481,7 @@ class ProxyHandler:
         status_code: int,
         outcome: str,
         start_time: float,
+        attempt: int = 1,
     ) -> None:
         duration_ms = (time.perf_counter() - start_time) * 1000
         logger.info(
@@ -405,7 +489,7 @@ class ProxyHandler:
             f"worker={worker.display_id} path={path} stream={metadata.stream} "
             f"capabilities={_format_capabilities(metadata.required_capabilities)} "
             f"status_code={status_code} duration_ms={duration_ms:.2f} "
-            f"outcome={outcome}",
+            f"outcome={outcome} attempt={attempt}",
         )
 
     def _log_route_rejection(

--- a/sglang_omni_router/selector.py
+++ b/sglang_omni_router/selector.py
@@ -25,11 +25,14 @@ class WorkerSelector:
         *,
         required_capabilities: set[Capability],
         requested_model: str | None = None,
+        exclude: set[str] | None = None,
     ) -> Worker:
+        excluded = exclude or set()
         candidates = [
             worker
             for worker in workers
             if worker.is_routable
+            and worker.worker_id not in excluded
             and all(worker.supports(capability) for capability in required_capabilities)
         ]
         if requested_model is not None and any(worker.model for worker in candidates):

--- a/sglang_omni_router/serve.py
+++ b/sglang_omni_router/serve.py
@@ -80,6 +80,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--request-timeout-secs", type=int, default=1800)
     parser.add_argument("--max-payload-size", type=int, default=512 * 1024 * 1024)
     parser.add_argument("--max-connections", type=int, default=100)
+    parser.add_argument("--max-request-retries", type=int, default=2)
+    parser.add_argument("--retry-backoff-secs", type=float, default=0.5)
     parser.add_argument("--health-failure-threshold", type=int, default=3)
     parser.add_argument("--health-success-threshold", type=int, default=2)
     parser.add_argument("--health-check-timeout-secs", type=int, default=5)
@@ -137,6 +139,8 @@ def build_config_from_args(
         request_timeout_secs=args.request_timeout_secs,
         max_payload_size=args.max_payload_size,
         max_connections=args.max_connections,
+        max_request_retries=args.max_request_retries,
+        retry_backoff_secs=args.retry_backoff_secs,
         health_failure_threshold=args.health_failure_threshold,
         health_success_threshold=args.health_success_threshold,
         health_check_timeout_secs=args.health_check_timeout_secs,
@@ -189,6 +193,8 @@ def main(argv: Sequence[str] | None = None) -> None:
             f"policy={config.policy} | "
             f"max_payload_size={config.max_payload_size} | "
             f"max_connections={config.max_connections} | "
+            f"max_request_retries={config.max_request_retries} | "
+            f"retry_backoff_secs={config.retry_backoff_secs} | "
             f"health_failure_threshold={config.health_failure_threshold} | "
             f"health_success_threshold={config.health_success_threshold} | "
             f"health_check_endpoint={config.health_check_endpoint} | "

--- a/tests/unit_test/router/test_app.py
+++ b/tests/unit_test/router/test_app.py
@@ -26,6 +26,8 @@ def _router_config(
     max_connections: int = 100,
     health_failure_threshold: int = 1,
     health_check_timeout_secs: int = 5,
+    max_request_retries: int = 0,
+    retry_backoff_secs: float = 0.0,
     worker_configs: list[WorkerConfig] | None = None,
 ) -> RouterConfig:
     return RouterConfig(
@@ -37,6 +39,8 @@ def _router_config(
         policy=policy,
         max_payload_size=max_payload_size,
         max_connections=max_connections,
+        max_request_retries=max_request_retries,
+        retry_backoff_secs=retry_backoff_secs,
         health_success_threshold=1,
         health_failure_threshold=health_failure_threshold,
         health_check_timeout_secs=health_check_timeout_secs,
@@ -817,6 +821,251 @@ def test_retryable_upstream_status_refreshes_worker_routability() -> None:
     assert seen_workers == ["worker-a:8101", "worker-b:8102"]
     assert app.state.workers[0].state == "unhealthy"
     assert app.state.workers[0].last_error == "status=502"
+
+
+def test_transient_status_fails_over_to_next_worker() -> None:
+    seen_workers: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "healthy"}, request=request)
+        if request.url.path == "/v1/chat/completions":
+            seen_workers.append(_request_netloc(request))
+            if _request_netloc(request) == "worker-a:8101":
+                return httpx.Response(500, content=b"thinker oom", request=request)
+            return httpx.Response(200, json={"ok": True}, request=request)
+        raise AssertionError(f"unexpected request path: {request.url.path}")
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(
+        _router_config(max_request_retries=2, health_failure_threshold=5),
+        client=async_client,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": "qwen3-omni", "messages": []},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert response.headers["x-sglang-omni-route-attempt"] == "2"
+    assert seen_workers == ["worker-a:8101", "worker-b:8102"]
+    worker_a, worker_b = app.state.workers
+    assert worker_a.failed_requests == 1
+    assert worker_b.successful_requests == 1
+    assert all(worker.active_requests == 0 for worker in app.state.workers)
+
+
+def test_connection_error_fails_over_to_next_worker() -> None:
+    seen_workers: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "healthy"}, request=request)
+        if request.url.path == "/v1/chat/completions":
+            seen_workers.append(_request_netloc(request))
+            if _request_netloc(request) == "worker-a:8101":
+                raise httpx.ConnectError("worker down", request=request)
+            return httpx.Response(200, json={"ok": True}, request=request)
+        raise AssertionError(f"unexpected request path: {request.url.path}")
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(
+        _router_config(max_request_retries=2, health_failure_threshold=5),
+        client=async_client,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": "qwen3-omni", "messages": []},
+        )
+
+    assert response.status_code == 200
+    assert response.headers["x-sglang-omni-route-attempt"] == "2"
+    assert seen_workers == ["worker-a:8101", "worker-b:8102"]
+    assert all(worker.active_requests == 0 for worker in app.state.workers)
+
+
+def test_retry_reuses_only_routable_worker_after_backoff() -> None:
+    seen: list[int] = []
+    statuses = iter([503, 503, 200])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "healthy"}, request=request)
+        if request.url.path == "/v1/chat/completions":
+            status = next(statuses)
+            seen.append(status)
+            if status == 200:
+                return httpx.Response(200, json={"ok": True}, request=request)
+            return httpx.Response(status, content=b"busy", request=request)
+        raise AssertionError(f"unexpected request path: {request.url.path}")
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(
+        _router_config(
+            max_request_retries=2,
+            health_failure_threshold=5,
+            worker_configs=[WorkerConfig(url="http://worker-a:8101")],
+        ),
+        client=async_client,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": "qwen3-omni", "messages": []},
+        )
+
+    assert response.status_code == 200
+    assert response.headers["x-sglang-omni-route-attempt"] == "3"
+    assert seen == [503, 503, 200]
+    worker = app.state.workers[0]
+    assert worker.routed_requests == 3
+    assert worker.failed_requests == 2
+    assert worker.successful_requests == 1
+
+
+def test_retry_exhaustion_surfaces_last_upstream_failure() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "healthy"}, request=request)
+        if request.url.path == "/v1/chat/completions":
+            return httpx.Response(503, content=b"overloaded", request=request)
+        raise AssertionError(f"unexpected request path: {request.url.path}")
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(
+        _router_config(
+            max_request_retries=3,
+            health_failure_threshold=5,
+            worker_configs=[WorkerConfig(url="http://worker-a:8101")],
+        ),
+        client=async_client,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": "qwen3-omni", "messages": []},
+        )
+
+    assert response.status_code == 503
+    assert response.content == b"overloaded"
+    assert response.headers["x-sglang-omni-route-attempt"] == "4"
+    worker = app.state.workers[0]
+    assert worker.routed_requests == 4
+    assert worker.failed_requests == 4
+
+
+def test_retry_applies_backoff_between_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backoff_attempts: list[int] = []
+    statuses = iter([500, 200])
+
+    async def fake_backoff(self: object, attempt: int) -> None:
+        backoff_attempts.append(attempt)
+
+    monkeypatch.setattr(proxy_module.ProxyHandler, "_retry_backoff", fake_backoff)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "healthy"}, request=request)
+        if request.url.path == "/v1/chat/completions":
+            if next(statuses) == 200:
+                return httpx.Response(200, json={"ok": True}, request=request)
+            return httpx.Response(500, content=b"oom", request=request)
+        raise AssertionError(f"unexpected request path: {request.url.path}")
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(
+        _router_config(
+            max_request_retries=2,
+            health_failure_threshold=5,
+            worker_configs=[WorkerConfig(url="http://worker-a:8101")],
+        ),
+        client=async_client,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": "qwen3-omni", "messages": []},
+        )
+
+    assert response.status_code == 200
+    assert backoff_attempts == [1]
+
+
+def test_client_error_status_is_not_retried() -> None:
+    seen_workers: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "healthy"}, request=request)
+        if request.url.path == "/v1/chat/completions":
+            seen_workers.append(_request_netloc(request))
+            return httpx.Response(400, json={"error": "bad"}, request=request)
+        raise AssertionError(f"unexpected request path: {request.url.path}")
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(
+        _router_config(max_request_retries=2, health_failure_threshold=5),
+        client=async_client,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": "qwen3-omni", "messages": []},
+        )
+
+    assert response.status_code == 400
+    assert response.headers["x-sglang-omni-route-attempt"] == "1"
+    assert seen_workers == ["worker-a:8101"]
+
+
+def test_streaming_initial_connection_error_fails_over() -> None:
+    seen_workers: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "healthy"}, request=request)
+        if request.url.path == "/v1/chat/completions":
+            seen_workers.append(_request_netloc(request))
+            if _request_netloc(request) == "worker-a:8101":
+                raise httpx.ConnectError("worker down", request=request)
+            return httpx.Response(
+                200,
+                content=b"data: hello\n\n",
+                headers={"content-type": "text/event-stream"},
+                request=request,
+            )
+        raise AssertionError(f"unexpected request path: {request.url.path}")
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(
+        _router_config(max_request_retries=2, health_failure_threshold=5),
+        client=async_client,
+    )
+
+    with TestClient(app) as client:
+        with client.stream(
+            "POST",
+            "/v1/chat/completions",
+            json={"model": "qwen3-omni", "stream": True},
+        ) as response:
+            body = b"".join(response.iter_bytes())
+
+    assert response.status_code == 200
+    assert body == b"data: hello\n\n"
+    assert response.headers["x-sglang-omni-route-attempt"] == "2"
+    assert seen_workers == ["worker-a:8101", "worker-b:8102"]
+    assert all(worker.active_requests == 0 for worker in app.state.workers)
 
 
 def test_worker_validation_error_does_not_refresh_worker_routability() -> None:

--- a/tests/unit_test/router/test_core.py
+++ b/tests/unit_test/router/test_core.py
@@ -579,6 +579,33 @@ def test_router_config_rejects_non_positive_integer_knobs(field: str) -> None:
         )
 
 
+@pytest.mark.parametrize("field", ["max_request_retries", "retry_backoff_secs"])
+def test_router_config_rejects_negative_retry_knobs(field: str) -> None:
+    with pytest.raises(ValidationError, match="value must be >= 0"):
+        RouterConfig(
+            workers=[WorkerConfig(url="http://127.0.0.1:8101")],
+            **{field: -1},
+        )
+
+
+def test_router_config_allows_disabling_retries() -> None:
+    config = RouterConfig(
+        workers=[WorkerConfig(url="http://127.0.0.1:8101")],
+        max_request_retries=0,
+        retry_backoff_secs=0.0,
+    )
+
+    assert config.max_request_retries == 0
+    assert config.retry_backoff_secs == 0.0
+
+
+def test_router_config_retry_defaults() -> None:
+    config = RouterConfig(workers=[WorkerConfig(url="http://127.0.0.1:8101")])
+
+    assert config.max_request_retries == 2
+    assert config.retry_backoff_secs == 0.5
+
+
 def test_router_config_rejects_hyphenated_policy_aliases() -> None:
     with pytest.raises(ValidationError):
         RouterConfig(
@@ -680,6 +707,34 @@ def test_selector_excludes_disabled_workers() -> None:
         selector.select(workers, required_capabilities={"chat"}).url
         == "http://127.0.0.1:8102"
     )
+
+
+def test_selector_excludes_tried_workers() -> None:
+    workers = build_workers(
+        [
+            WorkerConfig(url="http://127.0.0.1:8101"),
+            WorkerConfig(url="http://127.0.0.1:8102"),
+        ]
+    )
+    for worker in workers:
+        worker.state = "healthy"
+
+    selector = WorkerSelector("round_robin")
+
+    assert (
+        selector.select(
+            workers,
+            required_capabilities={"chat"},
+            exclude={workers[0].worker_id},
+        ).url
+        == "http://127.0.0.1:8102"
+    )
+    with pytest.raises(NoEligibleWorkerError):
+        selector.select(
+            workers,
+            required_capabilities={"chat"},
+            exclude={workers[0].worker_id, workers[1].worker_id},
+        )
 
 
 def test_selector_requires_all_capabilities() -> None:


### PR DESCRIPTION
### Problem at #627

The Qwen3-Omni MMMU CI (`test_mmmu_accuracy_and_speed`) is flaky: out of 50
requests under the colocated 2-worker router, a few intermittently fail (HTTP
500, timeouts, empty responses, or a worker going unhealthy mid-run). The test
requires `0/50` failures, so a single transient hiccup — e.g. a colocated
thinker OOM — fails the stage. It reproduces on H20/H100/H200, so it is not
hardware-specific.

### Root cause

The router proxy had **no retry/failover**. When an upstream worker returned a
transient failure status (500/502/503/504/408/429) or hit a connection error,
`ProxyHandler` recorded the failure for health tracking but forwarded the error
straight back to the client. The `X-SGLang-Omni-Route-Attempt` header was even
hardcoded to `"1"`, indicating failover was intended but never implemented. With
2 colocated workers available, a transient failure on one worker became a hard
client failure instead of being retried on the other.

### Fix

Add bounded retry/failover to the router proxy. Inference requests are
idempotent, so on a transient failure the request is re-routed to another
routable worker (or the same one after a backoff when it is the only candidate
left), up to a configurable number of attempts with exponential backoff. Only
non-transient outcomes (success, 4xx client errors) and exhausted retries are
returned to the client.

- `sglang_omni_router/config.py`: new `max_request_retries` (default `2`) and
  `retry_backoff_secs` (default `0.5`) knobs, with non-negative validation, wired
  through `build_router_config`.
- `sglang_omni_router/selector.py`: `select(...)` gains an `exclude` set so the
  proxy can prefer a worker it has not tried yet.
- `sglang_omni_router/proxy.py`: non-streaming requests retry transient failures
  across workers; streaming requests fail over on the initial connect/send
  (before any bytes reach the client) so streaming semantics stay intact; the
  `X-SGLang-Omni-Route-Attempt` header and route-completion logs now report the
  real attempt number.
- `sglang_omni_router/serve.py`: `--max-request-retries` / `--retry-backoff-secs`
  CLI flags and startup-log fields.

The colocated launcher uses the new defaults automatically (2 retries, 0.5s
backoff), so a transient thinker OOM/500 is transparently retried on the healthy
worker and the 50-sample run no longer reports spurious failures.

### Tests

Added unit tests (no GPU required):
- Transient 5xx and connection errors fail over to the next worker.
- Single routable worker is retried after backoff; retries are exhausted and the
  last upstream failure is surfaced.
- Backoff is applied between attempts; 4xx client errors are not retried.
- Streaming initial connection error fails over.
- Selector `exclude`; config validation/defaults for the new knobs.

`tests/unit_test/router/` — 111 passed.

### Validation note

Unit tests run and pass locally (CPU only). The end-to-end MMMU CI
(`tests/test_model/test_qwen3_omni_mmmu_ci.py`) needs a GPU and will be run on a
GPU machine after this PR.
