### PR TITLE
Fix tracked CI venv symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ build/
 venv/
 .venv/
 env/
+/omni
 
 # IDE
 .idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,6 @@ repos:
     rev: v5.0.0
     hooks:
       - id: check-symlinks
-        exclude: ^(omni|omni-tts)$
       - id: destroyed-symlinks
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/omni
+++ b/omni
@@ -1,1 +1,0 @@
-/github/home/calibration/omni

--- a/omni-tts
+++ b/omni-tts
@@ -1,1 +1,0 @@
-/github/home/calibration/tts/omni-tts


### PR DESCRIPTION
Removes CI-generated root venv symlinks from the repository and restores the broken-symlink pre-commit check. Adds /omni to .gitignore because CI setup recreates it as a local venv link.