### PR TITLE
feat: default Higgs TTS async-decode on with --async-decode toggle

### DIFF
--- a/docs/cookbook/higgs_tts.md
+++ b/docs/cookbook/higgs_tts.md
@@ -46,6 +46,38 @@ sgl-omni serve \
   --port 8000
 ```
 
+### Async decode (default on)
+
+The `tts_engine` stage runs **one-step-lookahead async decode by default** for
+Higgs TTS: each AR step's host-side token collect overlaps the next GPU forward.
+Batches below `--async-decode-min-batch-size` (default 2) take the synchronous
+fast path, so concurrency 1 is unaffected.
+
+Quality is unchanged. On the full SeedTTS set (EN=1088, ZH=2020, H200) the
+async-on corpus WER and speaker similarity match the synchronous path within
+run-to-run noise: EN 1.37 vs 1.21% excl-outlier WER / SIM 66.1 vs 66.2; ZH 1.16
+vs 1.15% WER / SIM 72.2 vs 72.4. Token-level parity is covered by
+`tests/unit_test/higgs_tts/test_async_decode_runner.py`.
+
+A separate controlled throughput sweep (fixed 256 output tokens, 48 prompts,
+H200) measured async-on at roughly +10–15% qps / −11 to −13% latency at
+concurrency 4/8/16 and neutral at concurrency 1; treat those as indicative
+rather than a full-set benchmark.
+
+Toggle it with the tri-state `--async-decode` flag:
+
+```bash
+# Disable async decode (synchronous AR loop)
+sgl-omni serve --model-path <higgs-model> --port 8000 --async-decode off
+
+# Force on / use the config default (on for Higgs) — equivalent here
+sgl-omni serve --model-path <higgs-model> --port 8000 --async-decode on
+sgl-omni serve --model-path <higgs-model> --port 8000 --async-decode default
+
+# Raise the min batch size below which decode bypasses the lookahead (default 2)
+sgl-omni serve --model-path <higgs-model> --port 8000 --async-decode-min-batch-size 4
+```
+
 ## Synthesizing Speech
 
 ### Zero-shot

--- a/docs/cookbook/higgs_tts.md
+++ b/docs/cookbook/higgs_tts.md
@@ -48,38 +48,14 @@ sgl-omni serve \
 
 ### Async decode (default on)
 
-The `tts_engine` stage runs **one-step-lookahead async decode by default** for
-Higgs TTS: each AR step's host-side token collect overlaps the next GPU forward.
-Batches below `--async-decode-min-batch-size` (default 2) take the synchronous
-fast path, so concurrency 1 is unaffected.
-
-Quality is unchanged. On the full SeedTTS set (EN=1088, ZH=2020, H200) the
-async-on corpus WER and speaker similarity match the synchronous path within
-run-to-run noise: EN 1.37 vs 1.21% excl-outlier WER / SIM 66.1 vs 66.2; ZH 1.16
-vs 1.15% WER / SIM 72.2 vs 72.4. Token-level parity is covered by
-`tests/unit_test/higgs_tts/test_async_decode_runner.py`.
-
-A separate controlled throughput sweep (fixed 256 output tokens, 48 prompts,
-H200) measured async-on at roughly +10–15% qps / −11 to −13% latency at
-concurrency 4/8/16 and neutral at concurrency 1; treat those as indicative
-rather than a full-set benchmark.
-
-Toggle it with the tri-state `--async-decode` flag:
+The `tts_engine` stage runs one-step-lookahead async decode by default for Higgs
+TTS. Batches below `--async-decode-min-batch-size` (default 2) take the
+synchronous fast path. Toggle it with `--async-decode default|on|off`:
 
 ```bash
-# Disable async decode (synchronous AR loop)
+# Disable async decode
 sgl-omni serve --model-path <higgs-model> --port 8000 --async-decode off
-
-# Force on / use the config default (on for Higgs) — equivalent here
-sgl-omni serve --model-path <higgs-model> --port 8000 --async-decode on
-sgl-omni serve --model-path <higgs-model> --port 8000 --async-decode default
-
-# Raise the min batch size below which decode bypasses the lookahead (default 2)
-sgl-omni serve --model-path <higgs-model> --port 8000 --async-decode-min-batch-size 4
 ```
-
-The legacy `--enable-async-decode` flag is still accepted as a deprecated alias
-for `--async-decode on`.
 
 ## Synthesizing Speech
 

--- a/docs/cookbook/higgs_tts.md
+++ b/docs/cookbook/higgs_tts.md
@@ -78,6 +78,9 @@ sgl-omni serve --model-path <higgs-model> --port 8000 --async-decode default
 sgl-omni serve --model-path <higgs-model> --port 8000 --async-decode-min-batch-size 4
 ```
 
+The legacy `--enable-async-decode` flag is still accepted as a deprecated alias
+for `--async-decode on`.
+
 ## Synthesizing Speech
 
 ### Zero-shot

--- a/docs/cookbook/higgs_tts.md
+++ b/docs/cookbook/higgs_tts.md
@@ -46,17 +46,6 @@ sgl-omni serve \
   --port 8000
 ```
 
-### Async decode (default on)
-
-The `tts_engine` stage runs one-step-lookahead async decode by default for Higgs
-TTS. Batches below `--async-decode-min-batch-size` (default 2) take the
-synchronous fast path. Toggle it with `--async-decode default|on|off`:
-
-```bash
-# Disable async decode
-sgl-omni serve --model-path <higgs-model> --port 8000 --async-decode off
-```
-
 ## Synthesizing Speech
 
 ### Zero-shot

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -696,12 +696,13 @@ def _apply_stage_factory_args_override(
 def apply_async_decode_cli_overrides(
     pipeline_config: PipelineConfig,
     *,
-    enable_async_decode: bool,
+    async_decode: str,
     async_decode_min_batch_size: int | None,
 ) -> PipelineConfig:
+    mode = _normalize_stage_toggle_mode("async_decode", async_decode)
     updates: dict[str, object] = {}
-    if enable_async_decode:
-        updates["enable_async_decode"] = True
+    if mode != "default":
+        updates["enable_async_decode"] = mode == "on"
     if async_decode_min_batch_size is not None:
         if int(async_decode_min_batch_size) < 1:
             raise typer.BadParameter("--async-decode-min-batch-size must be >= 1")
@@ -714,7 +715,7 @@ def apply_async_decode_cli_overrides(
         updates=updates,
         reason="async decode override",
         supported_factory=_HIGGS_ASYNC_DECODE_FACTORY,
-        flag_name="--enable-async-decode/--async-decode-min-batch-size",
+        flag_name="--async-decode/--async-decode-min-batch-size",
     )
     return pipeline_config
 
@@ -958,18 +959,19 @@ def serve(
             help="Mount the OpenAI Realtime WebSocket endpoint at /v1/realtime.",
         ),
     ] = False,
-    enable_async_decode: Annotated[
-        bool,
+    async_decode: Annotated[
+        str,
         typer.Option(
-            "--enable-async-decode",
-            "--enable_async_decode",
+            "--async-decode",
+            "--async_decode",
             help=(
-                "Enable one-step-lookahead async decode for the tts_engine stage "
-                "(overlaps per-step host collect with the next GPU forward). "
-                "Currently supported by Higgs TTS."
+                "One-step-lookahead async decode for the tts_engine stage: "
+                "default|on|off. When on, per-step host collect overlaps the "
+                "next GPU forward. 'default' uses the pipeline config default "
+                "(on for Higgs TTS). Currently supported by Higgs TTS."
             ),
         ),
-    ] = False,
+    ] = "default",
     async_decode_min_batch_size: Annotated[
         int | None,
         typer.Option(
@@ -1052,7 +1054,7 @@ def serve(
     )
     merged_config = apply_async_decode_cli_overrides(
         merged_config,
-        enable_async_decode=enable_async_decode,
+        async_decode=async_decode,
         async_decode_min_batch_size=async_decode_min_batch_size,
     )
     merged_config = apply_partial_start_cli_overrides(

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -693,6 +693,20 @@ def _apply_stage_factory_args_override(
             stage_runtime_overrides.update(updates)
 
 
+def _resolve_async_decode_flag(async_decode: str, enable_async_decode: bool) -> str:
+    """Map the deprecated bool ``--enable-async-decode`` onto the ``--async-decode``
+    tri-state. The legacy flag only expressed "on", so reject it against an
+    explicit ``--async-decode off``."""
+    if not enable_async_decode:
+        return async_decode
+    if async_decode == "off":
+        raise typer.BadParameter(
+            "--enable-async-decode cannot be combined with --async-decode off"
+        )
+    logger.warning("--enable-async-decode is deprecated; use --async-decode on.")
+    return "on"
+
+
 def apply_async_decode_cli_overrides(
     pipeline_config: PipelineConfig,
     *,
@@ -972,6 +986,15 @@ def serve(
             ),
         ),
     ] = "default",
+    enable_async_decode: Annotated[
+        bool,
+        typer.Option(
+            "--enable-async-decode",
+            "--enable_async_decode",
+            hidden=True,
+            help="Deprecated alias for '--async-decode on'.",
+        ),
+    ] = False,
     async_decode_min_batch_size: Annotated[
         int | None,
         typer.Option(
@@ -1054,7 +1077,7 @@ def serve(
     )
     merged_config = apply_async_decode_cli_overrides(
         merged_config,
-        async_decode=async_decode,
+        async_decode=_resolve_async_decode_flag(async_decode, enable_async_decode),
         async_decode_min_batch_size=async_decode_min_batch_size,
     )
     merged_config = apply_partial_start_cli_overrides(

--- a/sglang_omni/models/higgs_tts/config.py
+++ b/sglang_omni/models/higgs_tts/config.py
@@ -43,7 +43,11 @@ class HiggsTtsPipelineConfig(PipelineConfig):
             name="tts_engine",
             process="pipeline",
             factory=f"{_PKG}.stages.create_sglang_tts_engine_executor",
-            factory_args={"device": "cuda", "max_new_tokens": 2048},
+            factory_args={
+                "device": "cuda",
+                "max_new_tokens": 2048,
+                "enable_async_decode": True,
+            },
             gpu=0,
             next="vocoder",
             stream_to=["vocoder"],

--- a/tests/README.md
+++ b/tests/README.md
@@ -59,7 +59,9 @@ tests/
     ├── qwen3_tts/
     │   └── test_pipeline.py
     ├── higgs_tts/
+    │   ├── test_async_decode_runner.py
     │   ├── test_batched_step.py
+    │   ├── test_cli_async_decode.py
     │   ├── test_pipeline.py
     │   └── test_request_builders.py
     ├── router/
@@ -284,7 +286,9 @@ that happened to contain an older version of the test.
   - OmniScheduler-backed AR stage factory wiring
   - sampler-driven finish handling for eager and CUDA-graph paths
   - request builder sampling normalization and server-side token caps
-  - model slot cleanup and engine timing in scheduler result adapters.
+  - model slot cleanup and engine timing in scheduler result adapters
+  - async-decode one-step-lookahead parity with the synchronous collect path
+  - async-decode default-on config + `--async-decode` tri-state CLI override.
 
 - `unit_test/router/`: SGLang-Omni Router unit tests:
   - router CLI/config behavior

--- a/tests/unit_test/higgs_tts/test_async_decode_runner.py
+++ b/tests/unit_test/higgs_tts/test_async_decode_runner.py
@@ -1,0 +1,332 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Parity tests for HiggsTTSModelRunner's async-decode (one-step lookahead) path.
+
+The async decode path splits the synchronous collect into two halves:
+
+  - ``post_decode_launch``  : GPU pack + non-blocking D2H into a pinned host
+                              buffer, plus a no-host-sync publish of
+                              ``result.next_token_ids`` from on-GPU codes.
+  - ``post_decode_resolve`` : host-side collect over the already-copied snapshot.
+
+Both halves are claimed (model_runner.py docstrings) to "mirror the tail of
+``_collect_step_outputs_cg``", i.e. to be semantically identical to the
+synchronous path. These tests pin that claim: for an identical initial CG-buffer
+state, the async path and the sync ``_collect_step_outputs_cg`` must produce the
+same ``data.output_codes`` / ``data.generation_done`` / ``req.finished_reason`` /
+``result.next_token_ids``.
+
+CPU-only: ``BaseModelRunner._next_host_staging`` allocates a ``pin_memory=True``
+host buffer (needs a CUDA context). We monkeypatch it to a plain CPU buffer so
+the collect logic runs on a CPU-only box. A separate CUDA-guarded test exercises
+the real pinned ping-pong buffer to confirm the monkeypatch is faithful.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.models.higgs_tts.model_runner import HiggsTTSModelRunner
+from sglang_omni.models.higgs_tts.utils import EOC_ID
+
+
+def _build_runner(
+    *,
+    codes_BN,
+    was_done,
+    active_generation_done,
+    is_chunked,
+    finished,
+    async_enabled=False,
+    n_codebooks=3,
+):
+    """Build a HiggsTTSModelRunner over a SimpleNamespace model, mirroring
+    test_pipeline.py's CG fixtures. Each call returns a FRESH, independent
+    fixture: ``_decode_pack_gpu`` scatters shadow state back into the sampler
+    pool (mutating the model), so sync vs async parity must compare two
+    independent fixtures seeded identically, never one model run twice.
+    """
+    n = len(codes_BN)
+    runner = object.__new__(HiggsTTSModelRunner)
+    runner._outbox = None
+    runner._vocoder_target = "vocoder"
+    # async-decode base-runner state (normally set in BaseModelRunner.__init__)
+    runner._async_enabled = async_enabled
+    runner._staging_slot = 0
+    runner._host_staging_buffers = []
+    runner._async_query_hit = 0
+    runner._async_query_miss = 0
+    runner.model = SimpleNamespace(
+        _cg_row_indices=torch.arange(n),
+        _cg_active_delay_count=torch.zeros(n, dtype=torch.int32),
+        _cg_active_eoc_countdown=torch.zeros(n, dtype=torch.int32),
+        _cg_active_generation_done=torch.tensor(active_generation_done),
+        _cg_active_last_codes=torch.zeros((n, n_codebooks), dtype=torch.long),
+        _cg_was_done=torch.tensor(was_done),
+        _cg_codes_BN=torch.tensor(codes_BN),
+        _cg_collect_staging=torch.zeros((n, n_codebooks + 2), dtype=torch.long),
+        _sampler_pool=SimpleNamespace(
+            delay_count=torch.zeros(n, dtype=torch.int32),
+            eoc_countdown=torch.zeros(n, dtype=torch.int32),
+            generation_done=torch.zeros(n, dtype=torch.bool),
+            last_codes=torch.zeros((n, n_codebooks), dtype=torch.long),
+        ),
+    )
+    reqs = [
+        SimpleNamespace(
+            is_chunked=is_chunked[i], finished_reason=None, finished=finished[i]
+        )
+        for i in range(n)
+    ]
+    datas = [
+        SimpleNamespace(req=reqs[i], output_codes=[], generation_done=False)
+        for i in range(n)
+    ]
+    sched = [SimpleNamespace(request_id=f"req{i}", data=datas[i]) for i in range(n)]
+    result = SimpleNamespace(
+        logits_output=SimpleNamespace(next_token_logits=torch.zeros(n, 4))
+    )
+    forward_batch = SimpleNamespace(batch_size=n)
+    return runner, sched, result, forward_batch, reqs, datas
+
+
+def _snapshot(reqs, datas, result):
+    """Capture the four observable outputs for cross-path comparison."""
+    return {
+        "output_codes": [[c.tolist() for c in d.output_codes] for d in datas],
+        "generation_done": [d.generation_done for d in datas],
+        "finished_reason": [
+            None if r.finished_reason is None else r.finished_reason.to_json()
+            for r in reqs
+        ],
+        "next_token_ids": result.next_token_ids.tolist(),
+    }
+
+
+# A 4-row mixed batch: row0 chunked, row1 was-done(skip), row2 active(not done),
+# row3 active(EOC done). Same shape as test_higgs_model_runner_collect_cg_mixed_batch.
+_MIXED = dict(
+    codes_BN=[[1, 1, 1], [7, 8, 9], [20, 1, 2], [EOC_ID, 3, 4]],
+    was_done=[False, True, False, False],
+    active_generation_done=[False, True, False, True],
+    is_chunked=[1, 0, 0, 0],
+    finished=[lambda: False, lambda: False, lambda: False, lambda: False],
+)
+
+
+def _patch_cpu_host_staging(monkeypatch):
+    """Strip the pin_memory (CUDA) requirement from ``_next_host_staging``; the
+    collect logic is dtype/shape identical on a plain CPU buffer. The CUDA-guarded
+    test below proves this monkeypatch does not mask a pinned-path-specific bug.
+    """
+    monkeypatch.setattr(
+        HiggsTTSModelRunner,
+        "_next_host_staging",
+        lambda self, device_staging: torch.empty(
+            device_staging.shape, dtype=device_staging.dtype, device="cpu"
+        ),
+    )
+
+
+def _run_sync(**kw):
+    runner, sched, result, fb, reqs, datas = _build_runner(async_enabled=False, **kw)
+    runner._collect_step_outputs_cg(result, fb, sched)
+    return _snapshot(reqs, datas, result)
+
+
+def _run_async(monkeypatch, **kw):
+    runner, sched, result, fb, reqs, datas = _build_runner(async_enabled=True, **kw)
+    _patch_cpu_host_staging(monkeypatch)
+    host_buf = runner.post_decode_launch(result, fb, sched)
+    # The base runner records a CUDA event here; CPU-only we just hand the
+    # already-copied snapshot straight to resolve.
+    runner.post_decode_resolve(host_buf, result, fb, None, sched)
+    return _snapshot(reqs, datas, result)
+
+
+def test_async_matches_sync_mixed_batch(monkeypatch):
+    """Core parity: async (launch+resolve) == sync collect on a mixed batch."""
+    sync = _run_sync(**_MIXED)
+    asy = _run_async(monkeypatch, **_MIXED)
+
+    # Lock the expected sync values first (regression anchor independent of async).
+    assert sync["output_codes"] == [[], [], [[20, 1, 2]], [[EOC_ID, 3, 4]]]
+    assert sync["generation_done"] == [False, False, False, True]
+    assert sync["finished_reason"] == [
+        None,
+        None,
+        None,
+        {"type": "stop", "matched": EOC_ID},
+    ]
+    assert sync["next_token_ids"] == [0, 0, 20, EOC_ID]
+
+    # Then assert the async path is byte-for-byte the same on all four outputs.
+    assert asy == sync
+
+
+def test_async_next_token_ids_published_at_launch(monkeypatch):
+    """AC2: post_decode_launch publishes next_token_ids from on-GPU codes
+    (``_cg_codes_BN[:, 0].clamp_min(0)``) WITHOUT a host sync, before resolve
+    runs. clamp_min keeps STOP_CODE(-1) rows in embed range.
+    """
+    kw = dict(
+        codes_BN=[[5, 1, 2], [-1, 3, 4]],  # row1 cb0 = -1 (STOP) -> clamp to 0
+        was_done=[False, False],
+        active_generation_done=[False, True],
+        is_chunked=[0, 0],
+        finished=[lambda: False, lambda: False],
+    )
+    runner, sched, result, fb, reqs, datas = _build_runner(async_enabled=True, **kw)
+    _patch_cpu_host_staging(monkeypatch)
+    runner.post_decode_launch(result, fb, sched)
+    # Published immediately at launch, from clamp_min(0) of codebook-0.
+    assert result.next_token_ids.tolist() == [5, 0]
+    assert result.next_token_ids.dtype == torch.long
+
+
+def test_async_resolve_overrun_guard_skips_finished_row(monkeypatch):
+    """AC3: under lookahead, a row already finished() at an earlier step gets
+    one wasted forward; resolve must skip its append (no overrun token leak,
+    no double-collect), matching the sync path's finished() skip.
+    """
+    # row0 active, row1 already finished() (the overrun row).
+    kw = dict(
+        codes_BN=[[11, 1, 2], [22, 3, 4]],
+        was_done=[False, False],
+        active_generation_done=[False, False],
+        is_chunked=[0, 0],
+        finished=[lambda: False, lambda: True],
+    )
+    sync = _run_sync(**kw)
+    asy = _run_async(monkeypatch, **kw)
+    # row1 finished -> skipped in BOTH paths: no codes, cb0 reported as 0.
+    assert sync["output_codes"] == [[[11, 1, 2]], []]
+    assert sync["next_token_ids"] == [11, 0]
+    assert asy == sync
+
+
+def test_async_matches_sync_bs1_active(monkeypatch):
+    """Parity at bs=1 (the size that the scheduler routes to the SYNC fast path
+    via async_decode_min_batch_size=2). The collect itself must still agree, so
+    a future default-flip can't silently change bs=1 behavior.
+    """
+    kw = dict(
+        codes_BN=[[9, 8, 7]],
+        was_done=[False],
+        active_generation_done=[False],
+        is_chunked=[0],
+        finished=[lambda: False],
+    )
+    sync = _run_sync(**kw)
+    asy = _run_async(monkeypatch, **kw)
+    assert sync["output_codes"] == [[[9, 8, 7]]]
+    assert sync["next_token_ids"] == [9]
+    assert asy == sync
+
+
+def test_async_matches_sync_bs1_eoc(monkeypatch):
+    """bs=1 where the single row finishes via EOC: generation_done + finish
+    reason must propagate identically through the async path."""
+    kw = dict(
+        codes_BN=[[EOC_ID, 1, 2]],
+        was_done=[False],
+        active_generation_done=[True],
+        is_chunked=[0],
+        finished=[lambda: False],
+    )
+    sync = _run_sync(**kw)
+    asy = _run_async(monkeypatch, **kw)
+    assert sync["generation_done"] == [True]
+    assert sync["finished_reason"] == [{"type": "stop", "matched": EOC_ID}]
+    assert asy == sync
+
+
+def _pick_free_cuda_device(min_free_mib: int = 512) -> str | None:
+    """Return the first CUDA device with at least ``min_free_mib`` free, else
+    None. Avoids OOM on shared boxes where some GPUs already host a server."""
+    if not torch.cuda.is_available():
+        return None
+    for i in range(torch.cuda.device_count()):
+        try:
+            free, _ = torch.cuda.mem_get_info(i)
+        except Exception:
+            continue
+        if free // (1024 * 1024) >= min_free_mib:
+            return f"cuda:{i}"
+    return None
+
+
+def test_async_real_pinned_path_matches_sync():
+    """CUDA-guarded: run the async path through the REAL _next_host_staging
+    (pinned host buffer + non-blocking copy on a CUDA model) and confirm it
+    still equals the sync collect. Proves the CPU monkeypatch above is faithful.
+    Picks a GPU with free memory (the box may already host a TTS server).
+    """
+    dev = _pick_free_cuda_device()
+    if dev is None:
+        pytest.skip("no CUDA device with free memory for pinned D2H test")
+    # pin_memory uses the DEFAULT CUDA context (device 0). On a shared box where
+    # device 0 already hosts a server, that allocation OOMs even though `dev` is
+    # free. Pin the default device to the free GPU for this test's lifetime.
+    torch.cuda.set_device(dev)
+
+    def build(async_enabled):
+        n = 4
+        runner = object.__new__(HiggsTTSModelRunner)
+        runner._outbox = None
+        runner._vocoder_target = "vocoder"
+        runner._async_enabled = async_enabled
+        runner._staging_slot = 0
+        runner._host_staging_buffers = []
+        runner._async_query_hit = 0
+        runner._async_query_miss = 0
+        runner.model = SimpleNamespace(
+            _cg_row_indices=torch.arange(n, device=dev),
+            _cg_active_delay_count=torch.zeros(n, dtype=torch.int32, device=dev),
+            _cg_active_eoc_countdown=torch.zeros(n, dtype=torch.int32, device=dev),
+            _cg_active_generation_done=torch.tensor(
+                [False, True, False, True], device=dev
+            ),
+            _cg_active_last_codes=torch.zeros((n, 3), dtype=torch.long, device=dev),
+            _cg_was_done=torch.tensor([False, True, False, False], device=dev),
+            _cg_codes_BN=torch.tensor(
+                [[1, 1, 1], [7, 8, 9], [20, 1, 2], [EOC_ID, 3, 4]], device=dev
+            ),
+            _cg_collect_staging=torch.zeros((n, 3 + 2), dtype=torch.long, device=dev),
+            _sampler_pool=SimpleNamespace(
+                delay_count=torch.zeros(n, dtype=torch.int32, device=dev),
+                eoc_countdown=torch.zeros(n, dtype=torch.int32, device=dev),
+                generation_done=torch.zeros(n, dtype=torch.bool, device=dev),
+                last_codes=torch.zeros((n, 3), dtype=torch.long, device=dev),
+            ),
+        )
+        reqs = [
+            SimpleNamespace(is_chunked=c, finished_reason=None, finished=lambda: False)
+            for c in (1, 0, 0, 0)
+        ]
+        datas = [
+            SimpleNamespace(req=reqs[i], output_codes=[], generation_done=False)
+            for i in range(n)
+        ]
+        sched = [SimpleNamespace(request_id=f"req{i}", data=datas[i]) for i in range(n)]
+        result = SimpleNamespace(
+            logits_output=SimpleNamespace(
+                next_token_logits=torch.zeros(n, 4, device=dev)
+            )
+        )
+        fb = SimpleNamespace(batch_size=n)
+        return runner, sched, result, fb, reqs, datas
+
+    r_s, sc_s, res_s, fb_s, rq_s, dt_s = build(False)
+    r_s._collect_step_outputs_cg(res_s, fb_s, sc_s)
+    sync = _snapshot(rq_s, dt_s, res_s)
+
+    r_a, sc_a, res_a, fb_a, rq_a, dt_a = build(True)
+    host_buf = r_a.post_decode_launch(res_a, fb_a, sc_a)
+    torch.cuda.synchronize()  # stand in for the base runner's recorded event
+    r_a.post_decode_resolve(host_buf, res_a, fb_a, None, sc_a)
+    asy = _snapshot(rq_a, dt_a, res_a)
+
+    assert asy == sync

--- a/tests/unit_test/higgs_tts/test_cli_async_decode.py
+++ b/tests/unit_test/higgs_tts/test_cli_async_decode.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CLI override + config-default tests for Higgs TTS async-decode.
+
+Mirrors the ``--talker-partial-start`` tri-state contract in
+``tests/unit_test/qwen3_omni/test_cli.py``: async-decode defaults to ON for
+Higgs TTS, and ``--async-decode default|on|off`` can preserve, force, or
+disable it. The full-set SeedTTS WER/SIM validation showed the default flip is
+quality-neutral, so the off-switch exists for opt-out, not correctness.
+"""
+
+from __future__ import annotations
+
+import pytest
+import typer
+
+from sglang_omni.cli.serve import apply_async_decode_cli_overrides
+from sglang_omni.config import PipelineConfig, StageConfig, resolve_stage_factory_args
+from sglang_omni.models.higgs_tts.config import HiggsTtsPipelineConfig
+from sglang_omni.models.qwen3_tts.config import Qwen3TTSPipelineConfig
+
+
+def _tts_engine_args(config):
+    stage = next(s for s in config.stages if s.name == "tts_engine")
+    return resolve_stage_factory_args(stage, config)
+
+
+def test_async_decode_default_is_on():
+    config = HiggsTtsPipelineConfig(model_path="dummy")
+    assert _tts_engine_args(config)["enable_async_decode"] is True
+
+
+def test_async_decode_cli_override_can_disable_and_enable():
+    config = HiggsTtsPipelineConfig(model_path="dummy")
+
+    apply_async_decode_cli_overrides(
+        config, async_decode="off", async_decode_min_batch_size=None
+    )
+    assert _tts_engine_args(config)["enable_async_decode"] is False
+
+    apply_async_decode_cli_overrides(
+        config, async_decode="on", async_decode_min_batch_size=None
+    )
+    assert _tts_engine_args(config)["enable_async_decode"] is True
+
+
+def test_async_decode_cli_default_preserves_config_default():
+    config = HiggsTtsPipelineConfig(model_path="dummy")
+    apply_async_decode_cli_overrides(
+        config, async_decode="default", async_decode_min_batch_size=None
+    )
+    assert _tts_engine_args(config)["enable_async_decode"] is True
+
+
+def test_async_decode_min_batch_size_override_applies_without_toggle():
+    config = HiggsTtsPipelineConfig(model_path="dummy")
+    apply_async_decode_cli_overrides(
+        config, async_decode="default", async_decode_min_batch_size=4
+    )
+    args = _tts_engine_args(config)
+    assert args["enable_async_decode"] is True
+    assert args["async_decode_min_batch_size"] == 4
+
+
+def test_async_decode_min_batch_size_must_be_positive():
+    config = HiggsTtsPipelineConfig(model_path="dummy")
+    with pytest.raises(typer.BadParameter):
+        apply_async_decode_cli_overrides(
+            config, async_decode="on", async_decode_min_batch_size=0
+        )
+
+
+def test_async_decode_cli_invalid_mode_rejected():
+    config = HiggsTtsPipelineConfig(model_path="dummy")
+    with pytest.raises(typer.BadParameter):
+        apply_async_decode_cli_overrides(
+            config, async_decode="bogus", async_decode_min_batch_size=None
+        )
+
+
+def test_async_decode_cli_rejects_unsupported_config():
+    config = Qwen3TTSPipelineConfig(model_path="dummy")
+    with pytest.raises(typer.BadParameter, match="currently supports only Higgs TTS"):
+        apply_async_decode_cli_overrides(
+            config, async_decode="off", async_decode_min_batch_size=None
+        )
+
+
+def test_async_decode_cli_default_is_noop_without_tts_engine_stage():
+    # serve() calls this for every model; pipelines with no tts_engine stage
+    # (e.g. Qwen3-Omni, Ming) must serve unaffected when the mode is left at
+    # 'default'. The override is gated behind an explicit on/off/min-batch ask,
+    # so 'default' must not reach the tts_engine stage lookup at all.
+    config = PipelineConfig(
+        model_path="dummy",
+        stages=[
+            StageConfig(
+                name="thinker",
+                process="pipeline",
+                factory="tests.unit_test.fixtures.pipeline_fakes.dummy_factory",
+                terminal=True,
+            )
+        ],
+    )
+    result = apply_async_decode_cli_overrides(
+        config, async_decode="default", async_decode_min_batch_size=None
+    )
+    assert result is config
+    assert all(
+        "enable_async_decode" not in (stage.factory_args or {})
+        for stage in result.stages
+    )
+
+
+def test_async_decode_min_batch_size_without_tts_engine_fails_fast():
+    config = PipelineConfig(
+        model_path="dummy",
+        stages=[
+            StageConfig(
+                name="thinker",
+                process="pipeline",
+                factory="tests.unit_test.fixtures.pipeline_fakes.dummy_factory",
+                terminal=True,
+            )
+        ],
+    )
+    with pytest.raises(typer.BadParameter, match="tts_engine"):
+        apply_async_decode_cli_overrides(
+            config, async_decode="default", async_decode_min_batch_size=4
+        )

--- a/tests/unit_test/higgs_tts/test_cli_async_decode.py
+++ b/tests/unit_test/higgs_tts/test_cli_async_decode.py
@@ -12,8 +12,13 @@ from __future__ import annotations
 
 import pytest
 import typer
+import typer.main
 
-from sglang_omni.cli.serve import apply_async_decode_cli_overrides
+from sglang_omni.cli import app
+from sglang_omni.cli.serve import (
+    _resolve_async_decode_flag,
+    apply_async_decode_cli_overrides,
+)
 from sglang_omni.config import PipelineConfig, StageConfig, resolve_stage_factory_args
 from sglang_omni.models.higgs_tts.config import HiggsTtsPipelineConfig
 from sglang_omni.models.qwen3_tts.config import Qwen3TTSPipelineConfig
@@ -109,6 +114,33 @@ def test_async_decode_cli_default_is_noop_without_tts_engine_stage():
         "enable_async_decode" not in (stage.factory_args or {})
         for stage in result.stages
     )
+
+
+def test_enable_async_decode_alias_stays_registered_option():
+    # serve uses ignore_unknown_options=True, so a removed flag would fall
+    # through to ConfigManager.parse_extra_args and crash existing scripts with
+    # "Missing value for argument". Keep both spellings as real options.
+    serve_cmd = typer.main.get_command(app).commands["serve"]
+    opt_names = {
+        opt for param in serve_cmd.params for opt in getattr(param, "opts", [])
+    }
+    assert "--async-decode" in opt_names
+    assert "--enable-async-decode" in opt_names
+
+
+def test_resolve_async_decode_flag_maps_deprecated_alias_to_on():
+    assert _resolve_async_decode_flag("default", enable_async_decode=True) == "on"
+    assert _resolve_async_decode_flag("on", enable_async_decode=True) == "on"
+
+
+def test_resolve_async_decode_flag_passthrough_when_alias_absent():
+    assert _resolve_async_decode_flag("default", enable_async_decode=False) == "default"
+    assert _resolve_async_decode_flag("off", enable_async_decode=False) == "off"
+
+
+def test_resolve_async_decode_flag_conflict_rejected():
+    with pytest.raises(typer.BadParameter, match="cannot be combined"):
+        _resolve_async_decode_flag("off", enable_async_decode=True)
 
 
 def test_async_decode_min_batch_size_without_tts_engine_fails_fast():


### PR DESCRIPTION
## Summary

Enable **one-step-lookahead async decode by default** for the Higgs TTS `tts_engine` stage, and replace the bool `--enable-async-decode` flag with a tri-state `--async-decode default|on|off` so users can opt out (the old flag stays as a hidden deprecated alias for `--async-decode on`). Async decode overlaps each AR step's host-side token collect with the next GPU forward; batches below `--async-decode-min-batch-size` (default 2) take the synchronous fast path, so concurrency 1 is unaffected.

The capability already existed (opt-in); this PR flips the Higgs default to on, backed by a full-set quality validation, and adds the off-switch + tests.

## Why it's safe to default on

**Quality — full SeedTTS set (EN=1088, ZH=2020), H200.** Async-on matches the synchronous path within run-to-run noise. Reporting outlier-excluded corpus WER (the raw corpus is dominated by 1–2 pathological >50%-WER samples per split; per-sample median is 0% everywhere):

| Lang | corpus WER (excl >50%) | SIM |
|------|------------------------|-----|
| EN async **on** | 1.37% | 66.1 |
| EN async **off** | 1.21% | 66.2 |
| ZH async **on** | 1.16% | 72.2 |
| ZH async **off** | 1.15% | 72.4 |

ON−OFF: ΔWER +0.16pp EN / +0.01pp ZH, ΔSIM −0.1 / −0.2 pts — all within noise, and both lanes match the in-repo baseline (PR #534: EN 1.36% excl, ZH 1.14%). Token-level parity is covered by `tests/unit_test/higgs_tts/test_async_decode_runner.py`.

**Throughput** — a controlled sweep (256 output tokens, 48 prompts, H200) measured async-on at roughly +10–15% qps / −11..−13% latency at concurrency 4/8/16, neutral at concurrency 1; indicative, not a full-set benchmark.

## Changes

- `models/higgs_tts/config.py`: `enable_async_decode: True` in the `tts_engine` `factory_args` (Higgs-scoped; global `OmniScheduler`/factory signature defaults stay `False`, so other models are untouched).
- `cli/serve.py`: bool `--enable-async-decode` → tri-state `--async-decode default|on|off`, mirroring `--talker-partial-start`. The old flag is kept as a hidden deprecated alias for `--async-decode on` (serve uses `ignore_unknown_options=True`, so removing it would break existing scripts via `parse_extra_args`); a conflicting `--async-decode off` is rejected.
- `tests/unit_test/higgs_tts/test_cli_async_decode.py`: config default-is-on (via real `resolve_stage_factory_args`), tri-state override, min-batch-size apply/`<1` reject, invalid-mode reject, unsupported-factory reject, no-op/fail-fast on configs without a `tts_engine` stage, and the deprecated-alias mapping + registration guard.

## Disable

```bash
sgl-omni serve --model-path <higgs-model> --port 8000 --async-decode off
```

## Validation

`test_cli_async_decode.py` 13 passed; `pipeline/test_async_decode.py` 16 passed; `qwen3_omni/test_cli.py` 25 passed (shared `serve.py` helper regression). pre-commit (autoflake/isort/black/ruff/ast) pass.