### PR TITLE
[codex] Slim Higgs TTS vocoder audio payload

### DIFF
--- a/sglang_omni/models/higgs_tts/vocoder_scheduler.py
+++ b/sglang_omni/models/higgs_tts/vocoder_scheduler.py
@@ -403,16 +403,16 @@ class HiggsStreamingVocoderScheduler(StreamingSimpleScheduler):
         state: HiggsTtsState,
         waveform: torch.Tensor | None,
     ) -> StagePayload:
-        if waveform is not None:
-            audio_np = waveform.detach().to(torch.float32).cpu().numpy()
-            payload.data["audio_data"] = audio_np.tolist()
-        else:
-            payload.data["audio_data"] = []
-        payload.data["sample_rate"] = self._sample_rate
-        payload.data["modality"] = "audio"
+        data = audio_waveform_payload(
+            waveform if waveform is not None else [],
+            sample_rate=self._sample_rate,
+            modality="audio",
+            source_hint="Higgs TTS vocoder",
+        )
         usage = self._build_usage(state)
         if usage is not None:
-            payload.data["usage"] = usage
+            data["usage"] = usage
+        payload.data = data
         return payload
 
     def _decode_state_to_audio(self, state: HiggsTtsState) -> torch.Tensor | None:

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -569,14 +569,16 @@ def test_higgs_tts_vocoder_batches_decode_requests(
 
     assert decode_batch_sizes == [2], "should call decode_batch once with 2 items"
     assert len(results) == 2
-    assert len(results[0].data["audio_data"]) > 0
+    audio = np.frombuffer(results[0].data["audio_waveform"], dtype=np.float32)
+    assert audio.size > 0
+    assert "audio_data" not in results[0].data
     assert results[0].data["usage"]["prompt_tokens"] == 5
 
 
 def test_higgs_tts_vocoder_batch_handles_empty_items(
     monkeypatch,
 ) -> None:
-    """Items with empty/too-short codes get empty audio_data, not a crash."""
+    """Items with empty/too-short codes get empty waveform payloads, not a crash."""
     decode_batch_sizes = _fake_codec_fixtures(monkeypatch)
 
     scheduler = stages.create_vocoder_executor("fake-model", max_batch_size=4)
@@ -596,9 +598,11 @@ def test_higgs_tts_vocoder_batch_handles_empty_items(
     results = scheduler._batch_fn(payloads)
 
     assert decode_batch_sizes == [1], "only the valid item should be batched"
-    assert results[0].data["audio_data"] == []
-    assert results[1].data["audio_data"] == []
-    assert len(results[2].data["audio_data"]) > 0
+    assert results[0].data["audio_waveform_shape"] == [0]
+    assert results[1].data["audio_waveform_shape"] == [0]
+    audio = np.frombuffer(results[2].data["audio_waveform"], dtype=np.float32)
+    assert audio.size > 0
+    assert all("audio_data" not in result.data for result in results)
 
 
 class _FakeHiggsStreamingCodec:


### PR DESCRIPTION
## Summary

- emit Higgs TTS final vocoder audio with the shared compact `audio_waveform` payload
- preserve `sample_rate`, `modality`, and `usage` metadata
- update Higgs vocoder tests to assert the binary waveform schema

## Why this helps

The previous final vocoder path converted each `float32` waveform sample into a Python float list via `numpy().tolist()`. For typical TTS outputs this creates many Python objects and makes the scheduler result payload expensive to build and move through the internal pipeline.

The streaming path and other TTS implementations already use `audio_waveform_payload()`, which keeps the same `float32` PCM samples as contiguous bytes plus shape/dtype metadata. This PR applies the same representation to the Higgs final vocoder output.

## Equivalence

The vocoder waveform computation is unchanged. Both paths detach the tensor, move it to CPU, and represent it as `float32` PCM. The new payload stores:

- `audio_waveform`: raw `float32` bytes
- `audio_waveform_shape`: original flattened shape
- `audio_waveform_dtype`: `float32`

Clients reconstruct the same numeric samples with `np.frombuffer(..., dtype=np.float32).reshape(...)`. Empty outputs remain empty waveforms with shape `[0]`, and `usage` is preserved.

## Validation

- `pytest -q tests/unit_test/higgs_tts/test_pipeline.py`
  - remote H200 container, `PYTHONPATH=/tmp/sglang_higgs_payload_validate:/tmp/sglang_dep_16b3_clean/python`
  - `27 passed, 20 warnings in 11.21s`

Benchmark from the same optimization pass on 64 Higgs requests:

- mean latency: `2.220s -> 2.115s` (`-4.73%`)
- p95 latency: `2.948s -> 2.714s` (`-7.94%`)
- QPS: `3.945 -> 4.095` (`+3.80%`)
