### PR TITLE
[codex] Support current SGLang chunk counter

### DIFF
--- a/sglang_omni/model_runner/ming_thinker_model_runner.py
+++ b/sglang_omni/model_runner/ming_thinker_model_runner.py
@@ -9,6 +9,7 @@ import torch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 
 from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.scheduling.chunking import get_inflight_middle_chunks
 
 
 class MingThinkerModelRunner(ModelRunner):
@@ -94,7 +95,7 @@ class MingThinkerModelRunner(ModelRunner):
             req_input_ids = forward_batch.input_ids[start:end]
             consumed = getattr(req, "_omni_consumed", None) or {}
             pad_values = omni_inputs.get("pad_values", {})
-            is_final_chunk = getattr(req, "is_chunked", 0) == 0
+            is_final_chunk = get_inflight_middle_chunks(req) == 0
             req_id = self._request_id(req)
 
             for modality, embed_key, token_id in [

--- a/sglang_omni/model_runner/thinker_model_runner.py
+++ b/sglang_omni/model_runner/thinker_model_runner.py
@@ -14,6 +14,7 @@ import torch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 
 from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.scheduling.chunking import get_inflight_middle_chunks
 
 logger = logging.getLogger(__name__)
 
@@ -229,7 +230,7 @@ class ThinkerModelRunner(ModelRunner):
                     deepstack_visual_embeds_list.append(ds_embeds)
                     visual_pos_masks_list.append(global_mask)
 
-            if req.is_chunked == 0:
+            if get_inflight_middle_chunks(req) == 0:
                 req.omni_model_inputs = None
                 req._omni_consumed = None
 

--- a/sglang_omni/models/fishaudio_s2_pro/fish_scheduler.py
+++ b/sglang_omni/models/fishaudio_s2_pro/fish_scheduler.py
@@ -16,6 +16,10 @@ from typing import Any
 
 from sglang.srt.mem_cache.common import release_kv_cache
 
+from sglang_omni.scheduling.chunking import (
+    decrement_inflight_middle_chunks,
+    get_inflight_middle_chunks,
+)
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
 from sglang_omni.scheduling.types import (
     ModelRunnerOutput,
@@ -252,8 +256,8 @@ class FishIterationController:
         data = request.data
         req = data.req
 
-        if req.is_chunked > 0:
-            req.is_chunked -= 1
+        if get_inflight_middle_chunks(req) > 0:
+            decrement_inflight_middle_chunks(req)
             return
 
         if output_token_id is not None:
@@ -271,7 +275,7 @@ class FishIterationController:
         self, request: SchedulerRequest, output_token_id: int | None
     ) -> bool:
         data = request.data
-        if data.req.is_chunked > 0:
+        if get_inflight_middle_chunks(data.req) > 0:
             return False
 
         semantic_token = output_token_id

--- a/sglang_omni/models/fishaudio_s2_pro/model_runner.py
+++ b/sglang_omni/models/fishaudio_s2_pro/model_runner.py
@@ -8,6 +8,7 @@ from typing import Any
 import torch
 
 from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.scheduling.chunking import get_inflight_middle_chunks
 
 
 def collect_s2pro_step_outputs(
@@ -28,7 +29,7 @@ def collect_s2pro_step_outputs(
 
     for row_idx, sched_req in enumerate(requests):
         data = sched_req.data
-        if data.req.is_chunked > 0:
+        if get_inflight_middle_chunks(data.req) > 0:
             continue
 
         semantic_token = semantic_tokens[row_idx]

--- a/sglang_omni/models/higgs_tts/model_runner.py
+++ b/sglang_omni/models/higgs_tts/model_runner.py
@@ -21,6 +21,7 @@ from sglang_omni.models.higgs_tts.model import _flat_sampling_attr
 from sglang_omni.models.higgs_tts.sampler import K_MAX
 from sglang_omni.models.higgs_tts.text_tokenizer import AUDIO_PLACEHOLDER_ID
 from sglang_omni.models.higgs_tts.utils import EOC_ID
+from sglang_omni.scheduling.chunking import get_inflight_middle_chunks
 from sglang_omni.scheduling.messages import OutgoingMessage
 
 logger = logging.getLogger(__name__)
@@ -264,7 +265,7 @@ class HiggsTTSModelRunner(ModelRunner):
         for b, sched_req in enumerate(requests):
             data = sched_req.data
             req = data.req
-            if req.is_chunked > 0:
+            if get_inflight_middle_chunks(req) > 0:
                 cb0_per_row.append(0)
                 continue
             # Already finished in an earlier step? Skip its append. Under async
@@ -349,7 +350,12 @@ class HiggsTTSModelRunner(ModelRunner):
             rid = sched_req.request_id
             row = model._rid_to_row.get(rid)
             codes_log = model._output_codes.get(rid)
-            if req.is_chunked > 0 or row is None or not codes_log or req.finished():
+            if (
+                get_inflight_middle_chunks(req) > 0
+                or row is None
+                or not codes_log
+                or req.finished()
+            ):
                 cb0_per_row.append(0)
                 continue
             codes_N = codes_log[-1]

--- a/sglang_omni/models/ming_omni/bootstrap.py
+++ b/sglang_omni/models/ming_omni/bootstrap.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 
 from sglang_omni.models.ming_omni.pipeline.sampling import build_ming_sampling_params
+from sglang_omni.scheduling.chunking import get_inflight_middle_chunks
 
 logger = logging.getLogger(__name__)
 
@@ -272,7 +273,7 @@ def make_thinker_stream_output_builder(
         # Suppress while chunked prefill is still consuming prompt tokens —
         # prompt-side states could otherwise masquerade as the first
         # assistant token and leak prompt content into TTS.
-        if req is not None and int(getattr(req, "is_chunked", 0) or 0) > 0:
+        if req is not None and get_inflight_middle_chunks(req) > 0:
             return []
         if req_output.data is None or req is None:
             return []

--- a/sglang_omni/models/qwen3_omni/request_builders.py
+++ b/sglang_omni/models/qwen3_omni/request_builders.py
@@ -18,6 +18,7 @@ from sglang_omni.models.qwen3_omni.pending_text_queue import (
     coerce_pending_text_queue,
 )
 from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.scheduling.chunking import get_inflight_middle_chunks
 from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
 from sglang_omni.scheduling.types import ARRequestData
@@ -831,7 +832,7 @@ def make_thinker_stream_output_builder():
         request_id: str, req_data: Any, req_output: Any
     ) -> list[OutgoingMessage]:
         req = getattr(req_data, "req", None)
-        if req is not None and int(getattr(req, "is_chunked", 0) or 0) > 0:
+        if req is not None and get_inflight_middle_chunks(req) > 0:
             # While chunked prefill is still consuming prompt tokens, suppress
             # hidden-state streaming to the talker.
             # Emitting chunks this early lets prompt-side states masquerade as the

--- a/sglang_omni/scheduling/chunking.py
+++ b/sglang_omni/scheduling/chunking.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compatibility helpers for SGLang chunked-prefill request counters."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def get_inflight_middle_chunks(req: Any) -> int:
+    return int(
+        getattr(req, "inflight_middle_chunks", getattr(req, "is_chunked", 0)) or 0
+    )
+
+
+def _try_setattr(obj: Any, name: str, value: int) -> bool:
+    try:
+        setattr(obj, name, value)
+    except AttributeError:
+        return False
+    return True
+
+
+def set_inflight_middle_chunks(req: Any, value: int) -> None:
+    value = max(int(value), 0)
+    wrote = False
+    if hasattr(req, "inflight_middle_chunks"):
+        wrote = _try_setattr(req, "inflight_middle_chunks", value) or wrote
+    if hasattr(req, "is_chunked"):
+        wrote = _try_setattr(req, "is_chunked", value) or wrote
+    if not wrote:
+        _try_setattr(req, "inflight_middle_chunks", value)
+
+
+def increment_inflight_middle_chunks(req: Any) -> None:
+    set_inflight_middle_chunks(req, get_inflight_middle_chunks(req) + 1)
+
+
+def decrement_inflight_middle_chunks(req: Any) -> None:
+    set_inflight_middle_chunks(req, get_inflight_middle_chunks(req) - 1)

--- a/sglang_omni/scheduling/dllm_scheduler.py
+++ b/sglang_omni/scheduling/dllm_scheduler.py
@@ -19,6 +19,7 @@ from sglang.srt.mem_cache.common import release_kv_cache
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
+from sglang_omni.scheduling.chunking import increment_inflight_middle_chunks
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
 
 logger = logging.getLogger(__name__)
@@ -185,7 +186,7 @@ class DllmScheduler:
         ]
 
         for req in self._staging_queue:
-            req.is_chunked += 1
+            increment_inflight_middle_chunks(req)
 
         new_batch = ScheduleBatch.init_new(
             reqs=adder.can_run_list,

--- a/sglang_omni/scheduling/sglang_backend/prefill.py
+++ b/sglang_omni/scheduling/sglang_backend/prefill.py
@@ -7,6 +7,8 @@ from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
 from sglang.srt.managers.schedule_policy import PrefillAdder
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
+from sglang_omni.scheduling.chunking import increment_inflight_middle_chunks
+
 logger = logging.getLogger(__name__)
 
 
@@ -129,7 +131,7 @@ class PrefillManager:
             )
 
         if self.chunked_req is not None:
-            self.chunked_req.is_chunked += 1
+            increment_inflight_middle_chunks(self.chunked_req)
 
         # Batch dataclass of req for return
         new_batch = ScheduleBatch.init_new(

--- a/tests/unit_test/fishaudio_s2_pro/test_tts.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_tts.py
@@ -667,6 +667,24 @@ def test_fish_s2pro_chunked_step_does_not_mutate_decode_state() -> None:
     assert tree_cache.cached_requests == 0
 
 
+def test_fish_s2pro_current_sglang_chunk_counter_is_supported() -> None:
+    tree_cache = _CountingTreeCache()
+    controller = FishIterationController(tree_cache, IM_END_TOKEN_ID)
+    request = _make_s2pro_request("req-current-chunked", is_chunked=0)
+    delattr(request.data.req, "is_chunked")
+    request.data.req.inflight_middle_chunks = 1
+
+    result = _collect_s2pro_step([request], [[SEMANTIC_TOKEN_ID, 11, 22]])
+    semantic_token = _update_request_from_step(controller, request, result)
+
+    assert not controller.is_finished(request, semantic_token)
+    assert request.data.req.inflight_middle_chunks == 0
+    assert request.data.req.output_ids == []
+    assert request.data.output_codes == []
+    assert request.data.previous_semantic_tokens == []
+    assert tree_cache.cached_requests == 0
+
+
 def test_fish_s2pro_max_tokens_sets_length_finish_reason() -> None:
     tree_cache = _CountingTreeCache()
     controller = FishIterationController(tree_cache, IM_END_TOKEN_ID)

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -454,7 +454,11 @@ def test_higgs_model_runner_collect_cg_mixed_batch() -> None:
     )
     # row0 chunked, row1 was-done, row2 active (not done), row3 active (EOC done).
     reqs = [
-        SimpleNamespace(is_chunked=1, finished_reason=None, finished=lambda: False),
+        SimpleNamespace(
+            inflight_middle_chunks=1,
+            finished_reason=None,
+            finished=lambda: False,
+        ),
         SimpleNamespace(is_chunked=0, finished_reason=None, finished=lambda: False),
         SimpleNamespace(is_chunked=0, finished_reason=None, finished=lambda: False),
         SimpleNamespace(is_chunked=0, finished_reason=None, finished=lambda: False),

--- a/tests/unit_test/ming_omni/test_streaming_e2e_glue.py
+++ b/tests/unit_test/ming_omni/test_streaming_e2e_glue.py
@@ -68,6 +68,20 @@ def test_thinker_stream_builder_suppresses_during_chunked_prefill():
     assert msgs == []
 
 
+def test_thinker_stream_builder_suppresses_current_chunk_counter():
+    builder = make_thinker_stream_output_builder(
+        tokenizer=_FakeTokenizer(),
+        eos_token_id=None,
+    )
+    req = _make_req()
+    delattr(req, "is_chunked")
+    req.inflight_middle_chunks = 1
+    req_data = _make_req_data(req)
+
+    msgs = builder("req-current-chunk", req_data, _make_req_output(5))
+    assert msgs == []
+
+
 def test_thinker_stream_builder_buffers_incomplete_utf8():
     # Tokenizer that produces an incomplete UTF-8 sequence on first call.
     class _IncompleteThenComplete:

--- a/tests/unit_test/ming_omni/test_thinker.py
+++ b/tests/unit_test/ming_omni/test_thinker.py
@@ -417,6 +417,8 @@ def test_ming_runner_keeps_chunk_state_until_final_chunk(monkeypatch) -> None:
     image_embeds = torch.tensor([[20.0, 21.0], [22.0, 23.0]])
     model_inputs = {"image_embeds": image_embeds}
     req = _fake_req(model_inputs, is_chunked=1, rid="chunked-image")
+    delattr(req, "is_chunked")
+    req.inflight_middle_chunks = 1
     forward_batch, schedule_batch = _fake_batch(torch, [3, 1], req)
 
     input_embeds = runner._inject_multimodal_embeds(forward_batch, schedule_batch)
@@ -425,7 +427,7 @@ def test_ming_runner_keeps_chunk_state_until_final_chunk(monkeypatch) -> None:
     assert req.omni_model_inputs is model_inputs
     assert req._omni_consumed == {"image": 1}
 
-    req.is_chunked = 0
+    req.inflight_middle_chunks = 0
     forward_batch, schedule_batch = _fake_batch(torch, [3, 2], req)
 
     input_embeds = runner._inject_multimodal_embeds(forward_batch, schedule_batch)

--- a/tests/unit_test/qwen3_omni/test_streaming.py
+++ b/tests/unit_test/qwen3_omni/test_streaming.py
@@ -174,6 +174,20 @@ def test_qwen_thinker_stream_builder_keeps_talker_for_audio_output():
     assert [msg.target for msg in messages] == ["decode", "talker_ar"]
 
 
+def test_qwen_thinker_stream_builder_suppresses_current_chunk_counter():
+    builder = make_thinker_stream_output_builder()
+    req_data = SimpleNamespace(
+        req=SimpleNamespace(inflight_middle_chunks=1),
+        stage_payload=_thinker_stage_payload(["audio"]),
+    )
+    req_output = SimpleNamespace(
+        data=11,
+        extra={"hidden_states": torch.tensor([[1.0, 2.0]])},
+    )
+
+    assert builder("req-current-chunk", req_data, req_output) == []
+
+
 def test_qwen_thinker_stream_builder_keeps_talker_when_modalities_missing():
     builder = make_thinker_stream_output_builder()
     req_data = SimpleNamespace(

--- a/tests/unit_test/test_scheduling_chunking.py
+++ b/tests/unit_test/test_scheduling_chunking.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from sglang_omni.scheduling.chunking import (
+    decrement_inflight_middle_chunks,
+    get_inflight_middle_chunks,
+    increment_inflight_middle_chunks,
+    set_inflight_middle_chunks,
+)
+
+
+def test_chunking_helpers_prefer_current_sglang_counter() -> None:
+    req = SimpleNamespace(inflight_middle_chunks=2)
+
+    assert get_inflight_middle_chunks(req) == 2
+    decrement_inflight_middle_chunks(req)
+
+    assert req.inflight_middle_chunks == 1
+    assert not hasattr(req, "is_chunked")
+
+
+def test_chunking_helpers_support_legacy_counter_only() -> None:
+    req = SimpleNamespace(is_chunked=0)
+
+    increment_inflight_middle_chunks(req)
+    set_inflight_middle_chunks(req, 3)
+
+    assert get_inflight_middle_chunks(req) == 3
+    assert req.is_chunked == 3


### PR DESCRIPTION
## Summary

- add `sglang_omni.scheduling.chunking` helpers for the chunked-prefill request counter
- prefer current SGLang's `req.inflight_middle_chunks` and fall back to legacy `req.is_chunked`
- update prefill/dLLM increment sites and Omni model/stream output paths to use the helper
- add coverage for both current and legacy counter names

## Why

SGLang renamed the request mid-chunk counter from `is_chunked` to `inflight_middle_chunks` in sglang PR `#25720` / commit `fa37b6865` on 2026-05-19. The old name looked like a boolean, but the field is really a counter for in-flight middle chunks during chunked prefill.

SGLang-Omni still had direct reads and writes to `req.is_chunked`. When running with newer SGLang request objects, those reads can misclassify a request as no longer chunked, and writes can fail to update the counter SGLang now consumes.

## What changed

The new helper centralizes the compatibility policy:

- reads use `inflight_middle_chunks` when present
- reads fall back to `is_chunked` for older SGLang versions
- writes update whichever counter field exists
- counter values are clamped at zero when decrementing

This keeps Fish S2-Pro, Higgs TTS, generic thinker runners, Ming/Qwen3 streaming guards, dLLM staging, and the SGLang prefill wrapper aligned with both field names.

## Validation

Remote H200 container, `PYTHONPATH=/tmp/sglang_chunk_compat_validate:/tmp/sglang_dep_16b3_clean/python`:

```bash
pytest -q \
  tests/unit_test/test_scheduling_chunking.py \
  tests/unit_test/fishaudio_s2_pro/test_tts.py \
  tests/unit_test/higgs_tts/test_pipeline.py \
  tests/unit_test/ming_omni/test_streaming_e2e_glue.py \
  tests/unit_test/ming_omni/test_thinker.py \
  tests/unit_test/qwen3_omni/test_streaming.py
```

Result: `106 passed, 20 warnings in 13.06s`.
