### PR TITLE
[Benchmark] Update SeedTTS WER recipe and S2-Pro reference results

### DIFF
--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -322,6 +322,7 @@ def run_tts_seedtts_transcribe(config: TtsSeedttsBenchmarkConfig) -> dict:
         config,
         wer_config=wer_config,
         generation_mode=generation_mode,
+        wer_variant="seed_tts",
     )
 
 

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -101,6 +101,10 @@ outlier-excluded corpus WER is 1.36%.
 | S2-Pro | EN, stream=True  | 1.06%      | 1.02%               | 0.00%                 | 3.5%               | 1088/1088 | 0       | PR #411 [H100, full-set, c=16] |
 | S2-Pro | ZH, stream=False | 0.92%      | 0.87%               | 0.00%                 | 2.1%               | 2020/2020 | 0       | PR #411 [H100, full-set, c=16] |
 | S2-Pro | ZH, stream=True  | 0.90%      | 0.86%               | 0.00%                 | 2.1%               | 2020/2020 | 0       | PR #411 [H100, full-set, c=16] |
+| S2-Pro | EN, stream=False | 1.65%      | 1.63%               | 0.00%                 | 4.6%               | 1088/1088 | 0       | PR #645 [H100, full-set, c=16] |
+| S2-Pro | EN, stream=True  | 1.53%      | 1.50%               | 0.00%                 | 4.4%               | 1088/1088 | 0       | PR #645 [H100, full-set, c=16] |
+| S2-Pro | ZH, stream=False | 0.91%      | 0.86%               | 0.00%                 | 2.1%               | 2020/2020 | 0       | PR #645 [H100, full-set, c=16] |
+| S2-Pro | ZH, stream=True  | 0.90%      | 0.86%               | 0.00%                 | 2.1%               | 2020/2020 | 0       | PR #645 [H100, full-set, c=16] |
 | Higgs TTS | EN, stream=False | 4.68%   | 4.16%               | 0.00%                 | 91.2%              | 1088/1088 | 0       | PR #534 [H200, full-set, c=16, CUDA Graph on, torch.compile off] |
 | Higgs TTS | ZH, stream=False | 1.14%   | 1.08%               | 0.00%                 | 2.7%               | 2020/2020 | 0       | PR #534 [H200, full-set, c=16, CUDA Graph on, torch.compile off] |
 
@@ -120,6 +124,10 @@ Generation speed (generation.speed)
 | S2-Pro | EN, stream=True  | 12.164         | 16.717        | 3.265    | 1.308          | 67.0                           | PR #411 [H100, V1-pipeline, full-set, c=16] |
 | S2-Pro | ZH, stream=False | 12.028         | 15.526        | 2.256    | 1.327          | 65.7                           | PR #411 [H100, V1-pipeline, full-set, c=16] |
 | S2-Pro | ZH, stream=True  | 11.417         | 15.020        | 2.141    | 1.398          | 65.5                           | PR #411 [H100, V1-pipeline, full-set, c=16] |
+| S2-Pro | EN, stream=False | 16.685         | 22.016        | 4.518    | 0.953          | 63.3                           | PR #645 [H100, full-set, c=16] |
+| S2-Pro | EN, stream=True  | 16.453         | 22.002        | 4.460    | 0.966          | 54.8                           | PR #645 [H100, full-set, c=16] |
+| S2-Pro | ZH, stream=False | 16.442         | 20.345        | 3.115    | 0.970          | 66.9                           | PR #645 [H100, full-set, c=16] |
+| S2-Pro | ZH, stream=True  | 16.348         | 20.560        | 3.096    | 0.976          | 55.7                           | PR #645 [H100, full-set, c=16] |
 | Higgs TTS | EN, stream=False | 1.749       | 2.600         | 0.425    | 9.104          | 112.9                          | PR #534 [H200, full-set, c=16, CUDA Graph on, torch.compile off] |
 | Higgs TTS | ZH, stream=False | 1.629       | 2.110         | 0.282    | 9.792          | 109.9                          | PR #534 [H200, full-set, c=16, CUDA Graph on, torch.compile off] |
 
@@ -135,6 +143,8 @@ ASR speed (accuracy.asr_speed) — Whisper-large-v3 for EN, FunASR paraformer-zh
 | --------- | ---- | ------------------ | ------------ | ---------------------------- | ----------------------------------------------- |
 | S2-Pro    | EN   | 0.297              | 0.0772       | 3.36                         | PR #393 [H200, from S2-Pro EN stream=False run] |
 | S2-Pro    | ZH   | 0.294              | 0.0556       | 3.40                         | PR #393 [H200, from S2-Pro ZH stream=False run] |
+| S2-Pro    | EN   | 0.285              | 0.0762       | 3.50                         | PR #645 [H100, from S2-Pro EN stream=False run] |
+| S2-Pro    | ZH   | 0.095              | 0.0179       | 10.56                        | PR #645 [H100, from S2-Pro ZH stream=False run] |
 | Higgs TTS | EN   | 0.360              | 0.0835       | 2.78                         | PR #534 [H200, from Higgs TTS EN stream=False run] |
 | Higgs TTS | ZH   | 0.0867             | 0.0157       | 11.53                        | PR #534 [H200, from Higgs TTS ZH stream=False run] |
 """

--- a/benchmarks/metrics/wer.py
+++ b/benchmarks/metrics/wer.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import functools
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -238,3 +239,49 @@ def print_asr_speed_summary(metrics: dict, model_name: str) -> None:
             f"  {'Audio processed (s):':<{lw}} " f"{metrics['asr_audio_processed_s']}"
         )
     print(f"{'=' * w}")
+
+
+# ---------------------------------------------------------------------------
+# Seed-TTS WER — used by benchmark_tts_seedtts. Reference:
+# https://github.com/BytedanceSpeech/seed-tts-eval/blob/main/run_wer.py
+# ---------------------------------------------------------------------------
+
+
+@functools.lru_cache(maxsize=1)
+def _seed_tts_punct() -> str:
+    import string
+
+    from zhon.hanzi import punctuation as zh_punctuation
+
+    return zh_punctuation + string.punctuation
+
+
+def calculate_wer_seed_tts(ref: str, hyp: str, lang: str):
+    """Per-sample SeedTTS WER (en/zh). Returns ``(WordOutput, ref_n, hyp_n)``.
+
+    Strips ``zhon.hanzi.punctuation + string.punctuation`` (except ``'``),
+    collapses double spaces, char-tokenizes for zh / lowercases for en,
+    then runs ``jiwer.process_words``.
+    """
+    import jiwer
+
+    punct = _seed_tts_punct()
+    for x in punct:
+        if x == "'":
+            continue
+        ref = ref.replace(x, "")
+        hyp = hyp.replace(x, "")
+
+    ref = ref.replace("  ", " ")
+    hyp = hyp.replace("  ", " ")
+
+    if lang == "zh":
+        ref_n = " ".join(list(ref))
+        hyp_n = " ".join(list(hyp))
+    elif lang == "en":
+        ref_n = ref.lower()
+        hyp_n = hyp.lower()
+    else:
+        raise NotImplementedError(f"seed_tts WER only supports en/zh, got {lang!r}")
+
+    return jiwer.process_words(ref_n, hyp_n), ref_n, hyp_n

--- a/benchmarks/tasks/tts.py
+++ b/benchmarks/tasks/tts.py
@@ -47,6 +47,7 @@ from benchmarks.metrics.speaker_similarity_assets import (
 from benchmarks.metrics.wer import (
     calculate_asr_speed_metrics,
     calculate_wer_metrics,
+    calculate_wer_seed_tts,
     print_asr_speed_summary,
     print_wer_summary,
 )
@@ -116,23 +117,7 @@ def normalize_text(text: str, lang: str) -> str:
 def load_asr_model(lang: str, device: str, generation_mode: str | None = None):
     """Load ASR model for voice clone WER evaluation."""
     mode_suffix = f" for {generation_mode} generation" if generation_mode else ""
-    if lang == "en":
-        from transformers import pipeline
-
-        logger.info(
-            f"Loading Whisper-large-v3 on {device}{mode_suffix} "
-            "(pipeline, chunk_length_s=30)..."
-        )
-        t0 = time.perf_counter()
-        pipe = pipeline(
-            "automatic-speech-recognition",
-            model="openai/whisper-large-v3",
-            chunk_length_s=30,
-            device=device,
-        )
-        logger.info(f"Whisper loaded in {time.perf_counter() - t0:.1f}s{mode_suffix}")
-        return {"type": "whisper", "pipeline": pipe}
-    elif lang == "zh":
+    if lang == "zh":
         from funasr import AutoModel
 
         logger.info(f"Loading FunASR paraformer-zh{mode_suffix}...")
@@ -140,20 +125,59 @@ def load_asr_model(lang: str, device: str, generation_mode: str | None = None):
         model = AutoModel(model="paraformer-zh")
         logger.info(f"FunASR loaded in {time.perf_counter() - t0:.1f}s{mode_suffix}")
         return {"type": "funasr", "model": model}
-    else:
-        raise ValueError(f"Unsupported language: {lang}")
+
+    # Raw WhisperProcessor + WhisperForConditionalGeneration in float32 with
+    # forced_decoder_ids for the target language, rather than the HF pipeline,
+    # so transcribe can decode without 30 s chunking (truncation=False,
+    # return_timestamps=True).
+    from transformers import WhisperForConditionalGeneration, WhisperProcessor
+
+    logger.info(f"Loading Whisper-large-v3 on {device}{mode_suffix} (lang={lang})...")
+    t0 = time.perf_counter()
+    processor = WhisperProcessor.from_pretrained("openai/whisper-large-v3")
+    model = WhisperForConditionalGeneration.from_pretrained(
+        "openai/whisper-large-v3", torch_dtype=torch.float32
+    ).to(device)
+    model.eval()
+    forced_decoder_ids = processor.get_decoder_prompt_ids(
+        language=lang, task="transcribe"
+    )
+    logger.info(f"Whisper loaded in {time.perf_counter() - t0:.1f}s{mode_suffix}")
+    return {
+        "type": "whisper",
+        "processor": processor,
+        "model": model,
+        "forced_decoder_ids": forced_decoder_ids,
+        "lang": lang,
+    }
 
 
 def transcribe(asr: dict, wav_path: str, lang: str, device: str) -> str:
     if asr["type"] == "whisper":
-        # pipeline internally chunks at chunk_length_s=30 with stride overlap,
-        # so outputs longer than 30 s are transcribed end-to-end rather than
-        # silently truncated to the first 30 s.
-        result = asr["pipeline"](
-            wav_path,
-            generate_kwargs={"language": "english", "task": "transcribe"},
-        )
-        return result["text"]
+        # 16 kHz load, no truncation, forced_decoder_ids for the target
+        # language, and return_timestamps=True so clips longer than 30 s
+        # decode end-to-end.
+        import librosa
+
+        processor = asr["processor"]
+        model = asr["model"]
+        signal = librosa.load(wav_path, sr=16000)[0]
+        inputs = processor(
+            signal,
+            sampling_rate=16000,
+            return_tensors="pt",
+            return_attention_mask=True,
+            truncation=False,
+            padding="longest",
+        ).to(device)
+        with torch.no_grad():
+            predicted_ids = model.generate(
+                **inputs,
+                forced_decoder_ids=asr["forced_decoder_ids"],
+                return_timestamps=True,
+            )
+        text = processor.batch_decode(predicted_ids, skip_special_tokens=True)[0]
+        return text.strip()
     elif asr["type"] == "funasr":
         import zhconv
 
@@ -170,8 +194,15 @@ def transcribe_and_compute_wer(
     asr: dict,
     lang: str,
     device: str,
+    wer_variant: str = "legacy",
 ) -> SampleOutput:
-    """Transcribe audio and compute per-sample WER metrics."""
+    """Transcribe audio and compute per-sample WER metrics.
+
+    ``wer_variant`` selects the text-normalization recipe:
+      - ``"legacy"``  : Whisper EnglishTextNormalizer (en) / zhon-strip +
+        char-tokenize (zh)
+      - ``"seed_tts"``: BytedanceSpeech seed-tts-eval recipe (en/zh only).
+    """
     try:
         hyp_text = transcribe(asr, wav_path, lang, device)
     except Exception as exc:
@@ -180,14 +211,25 @@ def transcribe_and_compute_wer(
         return output
 
     output.whisper_text = hyp_text
-    output.ref_norm = normalize_text(output.target_text, lang)
-    output.hyp_norm = normalize_text(hyp_text, lang)
+
+    if wer_variant == "seed_tts":
+        measures, output.ref_norm, output.hyp_norm = calculate_wer_seed_tts(
+            output.target_text, hyp_text, lang
+        )
+    elif wer_variant == "legacy":
+        output.ref_norm = normalize_text(output.target_text, lang)
+        output.hyp_norm = normalize_text(hyp_text, lang)
+        if not output.ref_norm:
+            output.error = "Empty reference after normalization"
+            return output
+        measures = process_words(output.ref_norm, output.hyp_norm)
+    else:
+        raise ValueError(f"Unknown wer_variant: {wer_variant!r}")
 
     if not output.ref_norm:
         output.error = "Empty reference after normalization"
         return output
 
-    measures = process_words(output.ref_norm, output.hyp_norm)
     output.wer = measures.wer
     output.substitutions = measures.substitutions
     output.deletions = measures.deletions
@@ -541,6 +583,7 @@ def _transcribe_one_entry(
     asr: dict,
     lang: str,
     device: str,
+    wer_variant: str = "legacy",
 ) -> SampleOutput:
     """Transcribe a single ``generated.json`` entry and compute its WER."""
     output = SampleOutput(
@@ -554,7 +597,9 @@ def _transcribe_one_entry(
     output.latency_s = entry.get("latency_s", 0.0)
     output.audio_duration_s = entry.get("audio_duration_s", 0.0)
     asr_t0 = time.perf_counter()
-    output = transcribe_and_compute_wer(output, entry["wav_path"], asr, lang, device)
+    output = transcribe_and_compute_wer(
+        output, entry["wav_path"], asr, lang, device, wer_variant=wer_variant
+    )
     output.asr_latency_s = time.perf_counter() - asr_t0
     return output
 
@@ -593,12 +638,16 @@ def run_seedtts_transcribe(
     wer_config: dict,
     generation_mode: str | None = None,
     log_per_sample: bool = False,
+    wer_variant: str = "legacy",
 ) -> dict:
     """Transcribe saved audio, compute WER + ASR-speed metrics, and persist them.
 
     Shared pipeline used by both Qwen3-Omni and S2-Pro seed-tts-eval benchmarks.
     The caller-specific ``wer_config`` dict is embedded in ``wer_results.json``
     to preserve backward-compatible fields.
+
+    ``wer_variant`` selects the text-normalization recipe; see
+    :func:`transcribe_and_compute_wer`.
 
     Returns a dict with keys:
         - ``wer_summary``: corpus-level WER metrics (see :func:`calculate_wer_metrics`)
@@ -621,7 +670,9 @@ def run_seedtts_transcribe(
     )
     outputs: list[SampleOutput] = []
     for idx, entry in enumerate(tqdm(generated, desc=tqdm_desc)):
-        output = _transcribe_one_entry(entry, asr, config.lang, config.device)
+        output = _transcribe_one_entry(
+            entry, asr, config.lang, config.device, wer_variant=wer_variant
+        )
         outputs.append(output)
         _log_transcribe_result(
             idx=idx,


### PR DESCRIPTION
Full seed-tts-eval set, run end-to-end on isolated (exclusive) H100 nodes:

 | Config | WER (per-sample mean) | wer_corpus | evaluated | skipped |
 | --- | --- | --- | --- | --- |
 | EN, stream=False | 1.63% | 1.65% | 1088/1088 | 0 |
 | EN, stream=True  | 1.50% | 1.53% | 1088/1088 | 0 |
 | ZH, stream=False | 0.86% | 0.91% | 2020/2020 | 0 |
 | ZH, stream=True  | 0.86% | 0.90% | 2020/2020 | 0 |

 WER matches existing reference rows; the new `WhisperProcessor`/`forced_decoder_ids` decode path produces correct results across the full set, with all samples evaluated and none skipped.

 ## Benchmark & Profiling

 Generation-speed and ASR-speed numbers for the same runs are recorded in the reference tables in `benchmark_tts_seedtts.py` (latency / RTF / throughput per config). These are reproducibility references
 for the full set, not CI thresholds.

 ## Checklist

 - [x] Format your code according with pre-commit.
 - [ ] Add unit tests.
 - [x] Update documentation / docstrings / example tutorials as needed.
 - [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
 - [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.