### PR TITLE
[Perf] MOSS-TTS: batched vocoder decode

### DIFF
--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -305,7 +305,7 @@ def create_vocoder_executor(
     gpu_id: int | None = None,
     dtype: str = "float32",
     max_batch_size: int = 8,
-    max_batch_wait_ms: int = 100,
+    max_batch_wait_ms: int = 50,
 ) -> SimpleScheduler:
     if gpu_id is not None:
         device = f"cuda:{gpu_id}"
@@ -384,7 +384,6 @@ def create_vocoder_executor(
         return _store_vocoder_result(payload, state, wav, sample_rate)
 
     def _vocode_batch(payloads: list[StagePayload]) -> list[StagePayload]:
-        # print(f"[BATCH] vocoder batch size: {len(payloads)}", flush=True)
         all_segments = []
         payload_segment_ranges = []
         states = []
@@ -423,8 +422,12 @@ def create_vocoder_executor(
             ]
             nq = int(codes_list[0].shape[0])
             max_t = max(int(c.shape[1]) for c in codes_list)
-            audio_codes = torch.zeros(nq, len(codes_list), max_t, device=device, dtype=torch.long)
-            padding_mask = torch.zeros(len(codes_list), max_t, device=device, dtype=torch.bool)
+            audio_codes = torch.zeros(
+                nq, len(codes_list), max_t, device=device, dtype=torch.long
+            )
+            padding_mask = torch.zeros(
+                len(codes_list), max_t, device=device, dtype=torch.bool
+            )
             for i, c in enumerate(codes_list):
                 t = int(c.shape[1])
                 audio_codes[:, i, :t] = c
@@ -451,7 +454,6 @@ def create_vocoder_executor(
             )
             results.append(_store_vocoder_result(payload, state, waveform, sample_rate))
         return results
-
 
     return SimpleScheduler(
         _vocode,

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -305,7 +305,7 @@ def create_vocoder_executor(
     gpu_id: int | None = None,
     dtype: str = "float32",
     max_batch_size: int = 8,
-    max_batch_wait_ms: int = 2,
+    max_batch_wait_ms: int = 100,
 ) -> SimpleScheduler:
     if gpu_id is not None:
         device = f"cuda:{gpu_id}"
@@ -384,16 +384,24 @@ def create_vocoder_executor(
         return _store_vocoder_result(payload, state, wav, sample_rate)
 
     def _vocode_batch(payloads: list[StagePayload]) -> list[StagePayload]:
+        # print(f"[BATCH] vocoder batch size: {len(payloads)}", flush=True)
         all_segments = []
         payload_segment_ranges = []
         states = []
         audio_pad_code = int(
-            getattr(
-                getattr(processor, "model_config", None),
-                "audio_pad_code",
-                1024,
-            )
+            getattr(getattr(processor, "model_config", None), "audio_pad_code", 1024)
         )
+        sample_rate = int(
+            getattr(getattr(processor, "model_config", None), "sampling_rate", 0)
+            or getattr(
+                getattr(getattr(processor, "audio_tokenizer", None), "config", None),
+                "sampling_rate",
+                0,
+            )
+            or 24000
+        )
+        device = next(processor.audio_tokenizer.parameters()).device
+
         for payload in payloads:
             state, delayed_codes = _prepare_vocoder_item(payload)
             segments = split_moss_audio_segments(
@@ -406,19 +414,29 @@ def create_vocoder_executor(
             payload_segment_ranges.append((start, len(all_segments)))
             states.append(state)
 
-        all_waveforms = (
-            processor.decode_audio_codes(all_segments) if all_segments else []
-        )
-
-        sample_rate = int(
-            getattr(getattr(processor, "model_config", None), "sampling_rate", 0)
-            or getattr(
-                getattr(getattr(processor, "audio_tokenizer", None), "config", None),
-                "sampling_rate",
-                0,
+        if not all_segments:
+            all_waveforms = []
+        else:
+            codes_list = [
+                seg.transpose(0, 1).contiguous().to(device=device, dtype=torch.long)
+                for seg in all_segments
+            ]
+            nq = int(codes_list[0].shape[0])
+            max_t = max(int(c.shape[1]) for c in codes_list)
+            audio_codes = torch.zeros(nq, len(codes_list), max_t, device=device, dtype=torch.long)
+            padding_mask = torch.zeros(len(codes_list), max_t, device=device, dtype=torch.bool)
+            for i, c in enumerate(codes_list):
+                t = int(c.shape[1])
+                audio_codes[:, i, :t] = c
+                padding_mask[i, :t] = True
+            dec = processor.audio_tokenizer.decode(
+                audio_codes, padding_mask=padding_mask, return_dict=True
             )
-            or 24000
-        )
+            all_waveforms = []
+            for i in range(len(codes_list)):
+                length_i = int(dec.audio_lengths[i].item())
+                wav = dec.audio[i, 0, :length_i].contiguous().to(torch.float32).cpu()
+                all_waveforms.append(wav)
 
         results = []
         for i, payload in enumerate(payloads):
@@ -433,6 +451,7 @@ def create_vocoder_executor(
             )
             results.append(_store_vocoder_result(payload, state, waveform, sample_rate))
         return results
+
 
     return SimpleScheduler(
         _vocode,

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -384,6 +384,8 @@ def create_vocoder_executor(
         return _store_vocoder_result(payload, state, wav, sample_rate)
 
     def _vocode_batch(payloads: list[StagePayload]) -> list[StagePayload]:
+        if not payloads:
+            return []
         all_segments = []
         payload_segment_ranges = []
         states = []

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -390,15 +390,6 @@ def create_vocoder_executor(
         audio_pad_code = int(
             getattr(getattr(processor, "model_config", None), "audio_pad_code", 1024)
         )
-        sample_rate = int(
-            getattr(getattr(processor, "model_config", None), "sampling_rate", 0)
-            or getattr(
-                getattr(getattr(processor, "audio_tokenizer", None), "config", None),
-                "sampling_rate",
-                0,
-            )
-            or 24000
-        )
         device = next(processor.audio_tokenizer.parameters()).device
 
         for payload in payloads:
@@ -412,6 +403,17 @@ def create_vocoder_executor(
             all_segments.extend(segments)
             payload_segment_ranges.append((start, len(all_segments)))
             states.append(state)
+
+        sample_rate = int(
+            getattr(getattr(processor, "model_config", None), "sampling_rate", 0)
+            or getattr(
+                getattr(getattr(processor, "audio_tokenizer", None), "config", None),
+                "sampling_rate",
+                0,
+            )
+            or states[0].sample_rate
+            or 24000
+        )
 
         if not all_segments:
             all_waveforms = []

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -305,7 +305,7 @@ def create_vocoder_executor(
     gpu_id: int | None = None,
     dtype: str = "float32",
     max_batch_size: int = 8,
-    max_batch_wait_ms: int = 50,
+    max_batch_wait_ms: int = 2,
 ) -> SimpleScheduler:
     if gpu_id is not None:
         device = f"cuda:{gpu_id}"

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -384,7 +384,55 @@ def create_vocoder_executor(
         return _store_vocoder_result(payload, state, wav, sample_rate)
 
     def _vocode_batch(payloads: list[StagePayload]) -> list[StagePayload]:
-        return [_vocode(payload) for payload in payloads]
+        all_segments = []
+        payload_segment_ranges = []
+        states = []
+        audio_pad_code = int(
+            getattr(
+                getattr(processor, "model_config", None),
+                "audio_pad_code",
+                1024,
+            )
+        )
+        for payload in payloads:
+            state, delayed_codes = _prepare_vocoder_item(payload)
+            segments = split_moss_audio_segments(
+                delayed_codes.to(device=device, dtype=torch.long),
+                audio_pad_code=audio_pad_code,
+                assistant_start_length=int(state.assistant_start_length),
+            )
+            start = len(all_segments)
+            all_segments.extend(segments)
+            payload_segment_ranges.append((start, len(all_segments)))
+            states.append(state)
+
+        all_waveforms = (
+            processor.decode_audio_codes(all_segments) if all_segments else []
+        )
+
+        sample_rate = int(
+            getattr(getattr(processor, "model_config", None), "sampling_rate", 0)
+            or getattr(
+                getattr(getattr(processor, "audio_tokenizer", None), "config", None),
+                "sampling_rate",
+                0,
+            )
+            or 24000
+        )
+
+        results = []
+        for i, payload in enumerate(payloads):
+            state = states[i]
+            start, end = payload_segment_ranges[i]
+            wav_chunks = all_waveforms[start:end]
+            if not wav_chunks:
+                raise RuntimeError("MOSS-TTS vocoder decoded no audio segments")
+            waveform = torch.cat(
+                [torch.as_tensor(w).detach().reshape(-1).to("cpu") for w in wav_chunks],
+                dim=0,
+            )
+            results.append(_store_vocoder_result(payload, state, waveform, sample_rate))
+        return results
 
     return SimpleScheduler(
         _vocode,

--- a/tests/unit_test/moss_tts/test_vocoder_batch.py
+++ b/tests/unit_test/moss_tts/test_vocoder_batch.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import torch
+
+from sglang_omni.models.moss_tts.payload_types import MossTTSState
+from sglang_omni.proto import OmniRequest, StagePayload
+
+
+def make_payload(request_id: str, delayed_codes: torch.Tensor) -> StagePayload:
+    state = MossTTSState(
+        delayed_audio_codes=delayed_codes,
+        assistant_start_length=0,
+    )
+    return StagePayload(
+        request_id=request_id,
+        request=OmniRequest(inputs="hello", params={}, metadata={}),
+        data=state.to_dict(),
+    )
+
+
+def make_mock_processor(waveforms: list[torch.Tensor]) -> MagicMock:
+    processor = MagicMock()
+    processor.model_config.audio_pad_code = 1024
+    processor.model_config.sampling_rate = 24000
+    processor.audio_tokenizer = None
+    processor.decode_audio_codes.return_value = waveforms
+    return processor
+
+
+def test_vocode_batch_calls_decode_once():
+    """_vocode_batch should call decode_audio_codes exactly once for a batch."""
+    from sglang_omni.models.moss_tts.stages import create_vocoder_executor
+
+    codes1 = torch.tensor([[1, 1024], [2, 3], [1024, 4], [1024, 1024]], dtype=torch.long)
+    codes2 = torch.tensor([[5, 1024], [6, 7], [1024, 8], [1024, 1024]], dtype=torch.long)
+
+    payload1 = make_payload("req-1", codes1)
+    payload2 = make_payload("req-2", codes2)
+
+    wav1 = torch.ones(100)
+    wav2 = torch.ones(80)
+    mock_processor = make_mock_processor([wav1, wav2])
+
+    with patch(
+        "sglang_omni.models.moss_tts.stages._load_moss_processor",
+        return_value=mock_processor,
+    ):
+        scheduler = create_vocoder_executor("fake/model", device="cpu")
+        results = scheduler._batch_fn([payload1, payload2])
+
+    assert mock_processor.decode_audio_codes.call_count == 1
+    assert len(results) == 2
+
+
+def test_vocode_batch_distributes_waveforms_correctly():
+    """Each payload should get its own waveform back."""
+    from sglang_omni.models.moss_tts.stages import create_vocoder_executor
+
+    codes1 = torch.tensor([[1, 1024], [2, 3], [1024, 4], [1024, 1024]], dtype=torch.long)
+    codes2 = torch.tensor([[5, 1024], [6, 7], [1024, 8], [1024, 1024]], dtype=torch.long)
+
+    payload1 = make_payload("req-1", codes1)
+    payload2 = make_payload("req-2", codes2)
+
+    wav1 = torch.full((100,), 1.0)
+    wav2 = torch.full((80,), 2.0)
+    mock_processor = make_mock_processor([wav1, wav2])
+
+    with patch(
+        "sglang_omni.models.moss_tts.stages._load_moss_processor",
+        return_value=mock_processor,
+    ):
+        scheduler = create_vocoder_executor("fake/model", device="cpu")
+        results = scheduler._batch_fn([payload1, payload2])
+
+    audio1 = torch.from_numpy(np.frombuffer(results[0].data["audio_waveform"], dtype=np.float32).copy())
+    audio2 = torch.from_numpy(np.frombuffer(results[1].data["audio_waveform"], dtype=np.float32).copy())
+
+    assert torch.allclose(audio1, wav1)
+    assert torch.allclose(audio2, wav2)
+
+
+def test_vocode_batch_single_payload():
+    """batch size 1 should still work correctly."""
+    from sglang_omni.models.moss_tts.stages import create_vocoder_executor
+
+    codes = torch.tensor([[1, 1024], [2, 3], [1024, 4], [1024, 1024]], dtype=torch.long)
+    payload = make_payload("req-1", codes)
+    wav = torch.ones(100)
+    mock_processor = make_mock_processor([wav])
+
+    with patch(
+        "sglang_omni.models.moss_tts.stages._load_moss_processor",
+        return_value=mock_processor,
+    ):
+        scheduler = create_vocoder_executor("fake/model", device="cpu")
+        results = scheduler._batch_fn([payload])
+
+    assert mock_processor.decode_audio_codes.call_count == 1
+    assert len(results) == 1

--- a/tests/unit_test/moss_tts/test_vocoder_batch.py
+++ b/tests/unit_test/moss_tts/test_vocoder_batch.py
@@ -36,8 +36,12 @@ def test_vocode_batch_calls_decode_once():
     """_vocode_batch should call decode_audio_codes exactly once for a batch."""
     from sglang_omni.models.moss_tts.stages import create_vocoder_executor
 
-    codes1 = torch.tensor([[1, 1024], [2, 3], [1024, 4], [1024, 1024]], dtype=torch.long)
-    codes2 = torch.tensor([[5, 1024], [6, 7], [1024, 8], [1024, 1024]], dtype=torch.long)
+    codes1 = torch.tensor(
+        [[1, 1024], [2, 3], [1024, 4], [1024, 1024]], dtype=torch.long
+    )
+    codes2 = torch.tensor(
+        [[5, 1024], [6, 7], [1024, 8], [1024, 1024]], dtype=torch.long
+    )
 
     payload1 = make_payload("req-1", codes1)
     payload2 = make_payload("req-2", codes2)
@@ -61,8 +65,12 @@ def test_vocode_batch_distributes_waveforms_correctly():
     """Each payload should get its own waveform back."""
     from sglang_omni.models.moss_tts.stages import create_vocoder_executor
 
-    codes1 = torch.tensor([[1, 1024], [2, 3], [1024, 4], [1024, 1024]], dtype=torch.long)
-    codes2 = torch.tensor([[5, 1024], [6, 7], [1024, 8], [1024, 1024]], dtype=torch.long)
+    codes1 = torch.tensor(
+        [[1, 1024], [2, 3], [1024, 4], [1024, 1024]], dtype=torch.long
+    )
+    codes2 = torch.tensor(
+        [[5, 1024], [6, 7], [1024, 8], [1024, 1024]], dtype=torch.long
+    )
 
     payload1 = make_payload("req-1", codes1)
     payload2 = make_payload("req-2", codes2)
@@ -78,8 +86,12 @@ def test_vocode_batch_distributes_waveforms_correctly():
         scheduler = create_vocoder_executor("fake/model", device="cpu")
         results = scheduler._batch_fn([payload1, payload2])
 
-    audio1 = torch.from_numpy(np.frombuffer(results[0].data["audio_waveform"], dtype=np.float32).copy())
-    audio2 = torch.from_numpy(np.frombuffer(results[1].data["audio_waveform"], dtype=np.float32).copy())
+    audio1 = torch.from_numpy(
+        np.frombuffer(results[0].data["audio_waveform"], dtype=np.float32).copy()
+    )
+    audio2 = torch.from_numpy(
+        np.frombuffer(results[1].data["audio_waveform"], dtype=np.float32).copy()
+    )
 
     assert torch.allclose(audio1, wav1)
     assert torch.allclose(audio2, wav2)

--- a/tests/unit_test/moss_tts/test_vocoder_batch.py
+++ b/tests/unit_test/moss_tts/test_vocoder_batch.py
@@ -27,8 +27,19 @@ def make_mock_processor(waveforms: list[torch.Tensor]) -> MagicMock:
     processor = MagicMock()
     processor.model_config.audio_pad_code = 1024
     processor.model_config.sampling_rate = 24000
-    processor.audio_tokenizer = None
-    processor.decode_audio_codes.return_value = waveforms
+
+    mock_audio_tokenizer = MagicMock()
+    mock_audio_tokenizer.parameters.return_value = iter([torch.zeros(1)])
+    
+    mock_dec = MagicMock()
+    mock_dec.audio_lengths = torch.tensor([w.shape[0] for w in waveforms])
+    mock_dec.audio = torch.stack([
+        torch.nn.functional.pad(w, (0, max(w.shape[0] for w in waveforms) - w.shape[0])).unsqueeze(0)
+        for w in waveforms
+    ]).unsqueeze(1) 
+    mock_audio_tokenizer.decode.return_value = mock_dec
+    
+    processor.audio_tokenizer = mock_audio_tokenizer
     return processor
 
 
@@ -57,7 +68,7 @@ def test_vocode_batch_calls_decode_once():
         scheduler = create_vocoder_executor("fake/model", device="cpu")
         results = scheduler._batch_fn([payload1, payload2])
 
-    assert mock_processor.decode_audio_codes.call_count == 1
+    assert mock_processor.audio_tokenizer.decode.call_count == 1
     assert len(results) == 2
 
 
@@ -113,5 +124,5 @@ def test_vocode_batch_single_payload():
         scheduler = create_vocoder_executor("fake/model", device="cpu")
         results = scheduler._batch_fn([payload])
 
-    assert mock_processor.decode_audio_codes.call_count == 1
+    assert mock_processor.audio_tokenizer.decode.call_count == 1
     assert len(results) == 1

--- a/tests/unit_test/moss_tts/test_vocoder_batch.py
+++ b/tests/unit_test/moss_tts/test_vocoder_batch.py
@@ -33,12 +33,10 @@ def make_mock_processor(waveforms: list[torch.Tensor]) -> MagicMock:
     
     mock_dec = MagicMock()
     mock_dec.audio_lengths = torch.tensor([w.shape[0] for w in waveforms])
-    mock_dec.audio = torch.stack([
-        torch.nn.functional.pad(w, (0, max(w.shape[0] for w in waveforms) - w.shape[0])).unsqueeze(0)
-        for w in waveforms
-    ]).unsqueeze(1) 
+    mock_dec.audio = torch.zeros(len(waveforms), 1, max(w.shape[0] for w in waveforms))
+    for i, w in enumerate(waveforms):
+        mock_dec.audio[i, 0, :w.shape[0]] = w
     mock_audio_tokenizer.decode.return_value = mock_dec
-    
     processor.audio_tokenizer = mock_audio_tokenizer
     return processor
 

--- a/tests/unit_test/moss_tts/test_vocoder_batch.py
+++ b/tests/unit_test/moss_tts/test_vocoder_batch.py
@@ -30,12 +30,12 @@ def make_mock_processor(waveforms: list[torch.Tensor]) -> MagicMock:
 
     mock_audio_tokenizer = MagicMock()
     mock_audio_tokenizer.parameters.return_value = iter([torch.zeros(1)])
-    
+
     mock_dec = MagicMock()
     mock_dec.audio_lengths = torch.tensor([w.shape[0] for w in waveforms])
     mock_dec.audio = torch.zeros(len(waveforms), 1, max(w.shape[0] for w in waveforms))
     for i, w in enumerate(waveforms):
-        mock_dec.audio[i, 0, :w.shape[0]] = w
+        mock_dec.audio[i, 0, : w.shape[0]] = w
     mock_audio_tokenizer.decode.return_value = mock_dec
     processor.audio_tokenizer = mock_audio_tokenizer
     return processor
@@ -124,3 +124,41 @@ def test_vocode_batch_single_payload():
 
     assert mock_processor.audio_tokenizer.decode.call_count == 1
     assert len(results) == 1
+
+
+def test_vocode_batch_multi_segment_payload():
+    """A payload with two audio segments should cat them into one waveform."""
+    from sglang_omni.models.moss_tts.stages import create_vocoder_executor
+
+    codes = torch.tensor([[1, 1024], [2, 3], [1024, 4], [1024, 1024]], dtype=torch.long)
+    payload = make_payload("req-1", codes)
+
+    seg0_wav = torch.full((100,), 1.0)
+    seg1_wav = torch.full((80,), 2.0)
+    mock_processor = make_mock_processor([seg0_wav, seg1_wav])
+
+    seg0 = torch.zeros(10, 2, dtype=torch.long)
+    seg1 = torch.zeros(8, 2, dtype=torch.long)
+
+    with (
+        patch(
+            "sglang_omni.models.moss_tts.stages._load_moss_processor",
+            return_value=mock_processor,
+        ),
+        patch(
+            "sglang_omni.models.moss_tts.stages.split_moss_audio_segments",
+            return_value=[seg0, seg1],
+        ),
+    ):
+        scheduler = create_vocoder_executor("fake/model", device="cpu")
+        results = scheduler._batch_fn([payload])
+
+    assert mock_processor.audio_tokenizer.decode.call_count == 1
+    call_args = mock_processor.audio_tokenizer.decode.call_args
+    assert call_args[0][0].shape[1] == 2
+
+    audio = torch.from_numpy(
+        np.frombuffer(results[0].data["audio_waveform"], dtype=np.float32).copy()
+    )
+    expected = torch.cat([seg0_wav, seg1_wav])
+    assert torch.allclose(audio, expected)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

`_vocode_batch` in `stages.py` iterates over payloads serially despite `SimpleScheduler` supporting `batch_compute_fn`. The original implementation called `processor.decode_audio_codes` per request (B=1). `decode_audio_codes` hardcodes `chunk_duration=8` internally, which triggers the MOSS Audio Tokenizer's streaming path and raises `ValueError` for `batch_size > 1`. This PR bypasses that path by calling `processor.audio_tokenizer.decode` directly without `chunk_duration`, routing through `_decode_frame` which supports arbitrary batch size.

## Modifications

- `sglang_omni/models/moss_tts/stages.py`: rewrite `_vocode_batch` to collect all segments across payloads, pad to `[NQ, B, T]`, call `audio_tokenizer.decode` once, then distribute results back. Increase `max_batch_wait_ms` from 2 → 50 (aligned with `qwen3_omni`).
- `tests/unit_test/moss_tts/test_vocoder_batch.py`: 4 unit tests — decode called once per batch, waveforms correctly routed, batch size 1, multi-segment payload.

## Related Issues

Addresses #637's batched vocoder decode item

## Accuracy Test

WER regression (seed-tts-eval-50, EN, concurrency=16, `max_new_tokens=4096`, 5 runs each):

| | run1 | run2 | run3 | run4 | run5 | mean |
|---|---|---|---|---|---|---|
| baseline | 1.064% | 1.596% | 1.418% | 0.887% | 2.128% | 1.418% |
| batch    | 1.064% | 1.596% | 1.241% | 1.596% | 2.305% | 1.560% |

Diff +0.142%; within run-to-run noise (~1.2% variance).

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Draft PRs are skipped even if labeled.
