### PR TITLE
[Feature] Add support for opus audio format

### DIFF
--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -258,7 +258,7 @@ The table below lists all parameters accepted by the `/v1/audio/speech` endpoint
 |---|---|---|---|
 | `input` | string | (required) | Text to synthesize |
 | `voice` | string | `"default"` | Voice identifier |
-| `response_format` | string | `"wav"` | Output audio format |
+| `response_format` | string | `"wav"` | Output audio format (`wav`, `mp3`, `flac`, `opus`, `aac`, `pcm`) |
 | `speed` | float | `1.0` | Playback speed multiplier |
 | `stream` | bool | `false` | Enable streaming via SSE |
 | `references` | list | `null` | Reference audio for voice cloning; each item has `audio_path` (local path / remote url) and `text` |

--- a/docs/cookbook/higgs_tts.md
+++ b/docs/cookbook/higgs_tts.md
@@ -425,7 +425,7 @@ resp = requests.post(
 |---|---|---|---|
 | `input` | string | (required) | Text to synthesize |
 | `voice` | string | `"default"` | Voice identifier (ignored when `references` is set) |
-| `response_format` | string | `"wav"` | Output audio format |
+| `response_format` | string | `"wav"` | Output audio format (`wav`, `mp3`, `flac`, `opus`, `aac`, `pcm`) |
 | `stream` | bool | `false` | Enable streaming via SSE |
 | `references` | list | `null` | Reference audio for voice cloning; each item has `audio_path` (local path or HTTP URL) and `text` (transcript) |
 | `reference_codes` | list[list[int]] | `null` | Pre-encoded discrete codes, shape `[T, 8]` — alternative to `references[0].audio_path` |

--- a/docs/cookbook/voxtral_tts.md
+++ b/docs/cookbook/voxtral_tts.md
@@ -109,7 +109,7 @@ Each event carries a base64-encoded audio chunk; the stream ends with `data: [DO
 | `input` | (required) | Text to synthesize |
 | `voice` | `cheerful_female` | Preset voice name from the checkpoint's `voice_embedding/` directory |
 | `max_new_tokens` | `4096` | Maximum number of generated acoustic tokens |
-| `response_format` | `wav` | Output container |
+| `response_format` | `wav` | Output container (`wav`, `mp3`, `flac`, `opus`, `aac`, `pcm`) |
 | `stream` | `false` | Stream audio chunks over SSE |
 
 > Voxtral generation is **deterministic**: the engine fixes `temperature` to `0.0`, so sampling

--- a/sglang_omni/client/audio.py
+++ b/sglang_omni/client/audio.py
@@ -123,6 +123,62 @@ def encode_wav(audio: np.ndarray, sample_rate: int) -> bytes:
     return buf.getvalue()
 
 
+def _resample_linear(audio: np.ndarray, orig_sr: int, target_sr: int) -> np.ndarray:
+    if orig_sr == target_sr:
+        return audio.astype(np.float32, copy=False)
+    if audio.size == 0:
+        return audio.astype(np.float32, copy=False)
+    duration = audio.shape[0] / float(orig_sr)
+    new_len = max(int(round(duration * target_sr)), 1)
+    old_idx = np.arange(audio.shape[0], dtype=np.float64)
+    new_idx = np.linspace(0.0, audio.shape[0] - 1, num=new_len, dtype=np.float64)
+    return np.interp(new_idx, old_idx, audio).astype(np.float32)
+
+
+def encode_opus(audio: np.ndarray, sample_rate: int) -> bytes:
+    """Encode float32 audio numpy array to Ogg/Opus format using PyAV."""
+    import io
+
+    import av
+
+    valid_rates = {8000, 12000, 16000, 24000, 48000}
+    if sample_rate not in valid_rates:
+        nearest_rate = min(valid_rates, key=lambda r: abs(r - sample_rate))
+        audio = _resample_linear(audio, sample_rate, nearest_rate)
+        sample_rate = nearest_rate
+
+    buf = io.BytesIO()
+    container = av.open(buf, mode="w", format="ogg")
+
+    try:
+        try:
+            stream = container.add_stream("libopus", rate=sample_rate)
+        except av.CodecError:
+            stream = container.add_stream("opus", rate=sample_rate)
+    except av.CodecError as e:
+        container.close()
+        raise RuntimeError(
+            "Neither 'libopus' nor 'opus' codec is supported by PyAV."
+        ) from e
+
+    stream.layout = "mono"
+
+    # FFmpeg libopus expects float-planar (fltp) or s16-planar (s16p) formats
+    frame = av.AudioFrame.from_ndarray(
+        audio.reshape(1, -1), format="fltp", layout="mono"
+    )
+    frame.sample_rate = sample_rate
+
+    for packet in stream.encode(frame):
+        container.mux(packet)
+
+    for packet in stream.encode(None):
+        container.mux(packet)
+
+    container.close()
+    return buf.getvalue()
+
+
 def encode_pcm(audio: np.ndarray, sample_rate: int) -> bytes:
     """Encode audio as raw 16-bit PCM bytes."""
     audio = np.clip(audio, -1.0, 1.0)
@@ -172,6 +228,14 @@ def encode_audio(
 
     if fmt == "pcm":
         return encode_pcm(arr, sample_rate), mime
+
+    if fmt == "opus":
+        try:
+            return encode_opus(arr, sample_rate), mime
+        except Exception as e:
+            logger.warning(
+                "PyAV OPUS encoding failed (%s); falling back to pydub/WAV", str(e)
+            )
 
     if fmt in ("mp3", "flac", "opus", "aac"):
         # Try soundfile for FLAC

--- a/tests/unit_test/client/test_audio.py
+++ b/tests/unit_test/client/test_audio.py
@@ -1,0 +1,115 @@
+import numpy as np
+import pytest
+
+from sglang_omni.client.audio import (
+    FORMAT_MIME_TYPES,
+    audio_to_base64,
+    encode_audio,
+    encode_opus,
+    encode_pcm,
+    encode_wav,
+    to_numpy,
+)
+
+
+def test_to_numpy():
+    # Numpy array
+    arr = np.array([0.1, -0.2, 0.3], dtype=np.float32)
+    res = to_numpy(arr)
+    assert np.allclose(arr, res)
+    assert res.dtype == np.float32
+
+    # List/tuple
+    res_list = to_numpy([0.1, -0.2, 0.3])
+    assert np.allclose(arr, res_list)
+    assert res_list.dtype == np.float32
+
+    # PCM16 bytes
+    pcm_bytes = b"\x00\x00\x00\x40\x00\x80"  # [0, 16384, -32768] in int16
+    expected = np.array([0.0, 0.5, -1.0], dtype=np.float32)
+    res_bytes = to_numpy(pcm_bytes)
+    assert np.allclose(expected, res_bytes, atol=1e-4)
+
+
+def test_encode_wav():
+    # Generate 1 sec sine wave
+    sr = 24000
+    t = np.linspace(0, 1, sr, endpoint=False)
+    audio = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+
+    wav_bytes = encode_wav(audio, sr)
+    assert isinstance(wav_bytes, bytes)
+    assert wav_bytes.startswith(b"RIFF")
+    assert b"WAVE" in wav_bytes[:16]
+
+
+def test_encode_pcm():
+    audio = np.array([0.0, 0.5, -1.0, 1.2], dtype=np.float32)
+    pcm_bytes = encode_pcm(audio, 16000)
+    assert isinstance(pcm_bytes, bytes)
+    # Check expected int16 values (clamped to [-1, 1]): [0, 16383, -32767, 32767]
+    expected = np.array([0, 16383, -32767, 32767], dtype=np.int16)
+    actual = np.frombuffer(pcm_bytes, dtype=np.int16)
+    assert np.array_equal(expected, actual)
+
+
+def test_encode_opus():
+    try:
+        pass
+    except ImportError:
+        pytest.skip("PyAV (av) is not installed in this environment")
+
+    # Generate 1 sec sine wave at valid sample rate
+    sr = 24000
+    t = np.linspace(0, 1, sr, endpoint=False)
+    audio = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+
+    opus_bytes = encode_opus(audio, sr)
+    assert isinstance(opus_bytes, bytes)
+    # Ogg container format starts with OggS
+    assert opus_bytes.startswith(b"OggS")
+
+
+def test_encode_opus_resampling():
+    try:
+        pass
+    except ImportError:
+        pytest.skip("PyAV (av) is not installed in this environment")
+
+    # Generate audio at invalid sample rate for Opus (e.g. 44100 Hz)
+    sr = 44100
+    t = np.linspace(0, 1, sr, endpoint=False)
+    audio = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+
+    # Calling encode_opus should internally resample to 48000 Hz or similar and succeed
+    opus_bytes = encode_opus(audio, sr)
+    assert isinstance(opus_bytes, bytes)
+    assert opus_bytes.startswith(b"OggS")
+
+
+def test_encode_audio_opus():
+    # Test encoding to OPUS via the main encode_audio API
+    sr = 24000
+    t = np.linspace(0, 0.5, sr // 2, endpoint=False)
+    audio = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+
+    encoded_bytes, mime = encode_audio(audio, response_format="opus", sample_rate=sr)
+    assert mime == FORMAT_MIME_TYPES["opus"]
+    # If av is installed, we expect OggS. Otherwise, it falls back to WAV (RIFF)
+    try:
+        assert encoded_bytes.startswith(b"OggS")
+    except ImportError:
+        assert encoded_bytes.startswith(b"RIFF")
+
+
+def test_audio_to_base64():
+    audio = np.array([0.0, 0.1, -0.1], dtype=np.float32)
+    b64_str = audio_to_base64(audio, sample_rate=16000, output_format="pcm")
+    assert isinstance(b64_str, str)
+    # Decode to check
+    import base64
+
+    pcm_bytes = base64.b64decode(b64_str)
+    actual = np.frombuffer(pcm_bytes, dtype=np.int16)
+    expected = (audio * 32767.0).astype(np.int16)
+    assert np.array_equal(expected, actual)


### PR DESCRIPTION
## Motivation

Add opus output format support

## Modifications

- Unit test: test_audio.py
- `encode_opus` method in audio.py for opus format encoding from generated waveform
- Update to TTS docs with newly added format

## Related Issues

- TBA

## Accuracy Test
- Unit test with synthetic waves

## Benchmark & Profiling
- N/A

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Draft PRs are skipped even if labeled.

cc @zhaochenyang20 @PopSoda2002 