### PR TITLE
[Dep] Bump sglang 0.5.8 → 0.5.12 and transformers to >=5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ dependencies = [
     "numpy>=1.24.0",          # Array operations
     "pydantic>=2.0.0",        # Data validation and serialization
     "PyYAML>=6.0",            # YAML config parsing
-    "torch==2.9.1",          # PyTorch for tensor operations
-    "torchvision==0.24.1",    # torchvision for vision processor
+    "torch==2.11.0",          # PyTorch for tensor operations; matches sglang==0.5.12
+    "torchvision==0.26.0",    # torchvision for vision processor
     "accelerate>=0.27.0",     # init_empty_weights for meta initialization
     "transformers>=5.0",  # HF models/tokenizers; SGLang >=0.5.10 requires transformers 5.x
     "safetensors>=0.4.3",     # Direct weight loading
@@ -63,7 +63,7 @@ dependencies = [
     "omegaconf",
     "descript-audiotools",
     "descript-audio-codec",
-    "torchaudio",
+    "torchaudio==2.11.0",
     # Gradio playground
     "gradio>=4.0.0",
     # Ming-Omni
@@ -79,6 +79,9 @@ sgl-omni-router = "sglang_omni_router.serve:main"
 [tool.uv]
 override-dependencies = [
     "protobuf>=6.31.1,<7.0.0",
+    # kernels>=0.15 breaks transformers 5.x hub_kernels (LayerRepository missing version).
+    # Pin until transformers ships a fix (tracked upstream: huggingface/transformers#46039).
+    "kernels<0.15",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,14 +19,14 @@ dependencies = [
     "torch==2.9.1",          # PyTorch for tensor operations
     "torchvision==0.24.1",    # torchvision for vision processor
     "accelerate>=0.27.0",     # init_empty_weights for meta initialization
-    "transformers<5.0",   # HF models/tokenizers
+    "transformers>=5.0",  # HF models/tokenizers; SGLang >=0.5.10 requires transformers 5.x
     "safetensors>=0.4.3",     # Direct weight loading
     "pillow>=10.0.0",         # Required by AutoImageProcessor
     "huggingface-hub>=0.36.0",# HF model downloads
     "datasets>=2.14.0",       # Arrow-based SeedTTS dataset loading
     "fastapi>=0.110.0",       # OpenAI-compatible API adapter
     "uvicorn>=0.23.0",        # ASGI server for FastAPI
-    "sglang==0.5.8",
+    "sglang==0.5.12",
     "nixl",
     "mooncake-transfer-engine>=0.3.0",
     "logger",

--- a/sglang_omni/model_runner/_sglang_qwen3_vl_patches.py
+++ b/sglang_omni/model_runner/_sglang_qwen3_vl_patches.py
@@ -26,7 +26,18 @@ _APPLY_LOCK = threading.Lock()
 # Released sglang versions whose Qwen3VLMoeVisionModel layout matches the
 # patch. Dev builds (``0.0.0.dev1+...``) are accepted with a warning since
 # they are unversioned snapshots that may or may not match.
-_SUPPORTED_SGLANG_VERSIONS: frozenset[str] = frozenset({"0.5.8", "0.5.8.post1"})
+_SUPPORTED_SGLANG_VERSIONS: frozenset[str] = frozenset(
+    {
+        "0.5.8",
+        "0.5.8.post1",
+        "0.5.9",
+        "0.5.10",
+        "0.5.10.post1",
+        "0.5.11",
+        "0.5.12",
+        "0.5.12.post1",
+    }
+)
 
 # Instance attributes the patches read; preflight checks each is present
 # either as a class-level descriptor or as a self.<name> = assignment in

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -375,7 +375,7 @@ def _get_config_value(config: object, key: str) -> object | None:
 
 
 def _is_fp8_cutlass_moe_supported() -> bool:
-    """Mirror pinned SGLang 0.5.8 FP8 CUTLASS MoE assertions."""
+    """Check SGLang FP8 CUTLASS MoE support requirements."""
     try:
         from sglang.srt.layers.quantization.fp8_utils import cutlass_fp8_supported
         from sglang.srt.utils import is_sm90_supported, is_sm100_supported

--- a/sglang_omni/models/qwen3_omni/components/talker.py
+++ b/sglang_omni/models/qwen3_omni/components/talker.py
@@ -4,7 +4,6 @@ SGLang-native Talker model for Qwen3-Omni compatiable with hf formatting.
 
 from __future__ import annotations
 
-import copy
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -46,22 +45,6 @@ def _bind_default_weight_loaders(module: nn.Module) -> None:
     for param in module.parameters():
         if not hasattr(param, "weight_loader"):
             param.weight_loader = default_weight_loader
-
-
-def _quant_config_for_code_predictor_dense_mlp(
-    quant_config: Optional[QuantizationConfig],
-) -> Optional[QuantizationConfig]:
-    """Keep dense code-predictor MLP projections quantized under SGLang 0.5.8."""
-    ignored_layers = getattr(quant_config, "ignored_layers", None)
-    if not ignored_layers or "mlp.gate" not in ignored_layers:
-        return quant_config
-
-    # FIXME (Ratish): when upgrading past SGLang 0.5.8. Newer SGLang uses
-    # dotted-boundary ignored-layer matching, so this local workaround should be
-    # removed once this repo depends on that behavior.
-    cloned = copy.copy(quant_config)
-    cloned.ignored_layers = [layer for layer in ignored_layers if layer != "mlp.gate"]
-    return cloned
 
 
 def _repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
@@ -506,9 +489,6 @@ class Qwen3OmniMoeTalkerCodePredictor(nn.Module):
         # 5 dense decoder layers
         alt_stream = torch.cuda.Stream()
         self.model.layers = nn.ModuleList()
-        dense_mlp_quant_config = _quant_config_for_code_predictor_dense_mlp(
-            quant_config
-        )
         for idx in range(cp_config.num_hidden_layers):
             # Create a decoder layer similar to Thinker but with dense MLP
             layer = nn.Module()
@@ -532,7 +512,7 @@ class Qwen3OmniMoeTalkerCodePredictor(nn.Module):
             layer.mlp = Qwen3OmniMoeTalkerDenseMLP(
                 cp_config.hidden_size,
                 cp_config.intermediate_size,
-                quant_config=dense_mlp_quant_config,
+                quant_config=quant_config,
                 prefix=add_prefix(f"model.layers.{idx}.mlp", prefix),
             )
             layer.input_layernorm = RMSNorm(

--- a/sglang_omni/models/qwen3_omni/hf_config.py
+++ b/sglang_omni/models/qwen3_omni/hf_config.py
@@ -20,9 +20,9 @@ def _normalize_rope_scaling(
         normalized["rope_type"] = normalized["type"]
 
     if _MROPE_ROPE_SCALING_KEYS.intersection(normalized.keys()):
-        # SGLang 0.5.8 selects MRotaryEmbedding from rope_type/type="default"
-        # plus mrope_section. Passing "mrope" reaches the generic rope switch
-        # and fails before the talker can start.
+        # SGLang selects MRotaryEmbedding from rope_type/type="default" plus
+        # mrope_section. Passing "mrope" reaches the generic rope switch and
+        # fails because "mrope" is not a recognised rope_type in SGLang.
         rope_type = normalized.get("rope_type", normalized.get("type", "default"))
         if rope_type == "mrope":
             rope_type = "default"

--- a/tests/test_model/test_v1_encoder_qwen3_vl_hf_parity.py
+++ b/tests/test_model/test_v1_encoder_qwen3_vl_hf_parity.py
@@ -15,7 +15,7 @@ Run:
     pytest -v -m benchmark tests/test_model/test_v1_encoder_qwen3_vl_hf_parity.py
 
 Requires:
-    - 1× H100 (or equivalent ≥ 80GB GPU) with sglang==0.5.8 and transformers
+    - 1× H100 (or equivalent ≥ 80GB GPU) with sglang==0.5.12 and transformers
     - HF cache populated for ``Qwen/Qwen3-Omni-30B-A3B-Instruct``
 """
 from __future__ import annotations

--- a/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
+++ b/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
@@ -391,14 +391,14 @@ def test_model_config_has_moe_prefers_effective_text_config() -> None:
         pytest.param(False, True, False, False, id="cutlass_runtime_rejected"),
     ],
 )
-def test_fp8_cutlass_moe_support_matches_sglang_0_5_8_contract(
+def test_fp8_cutlass_moe_support_check(
     monkeypatch: pytest.MonkeyPatch,
     cutlass_supported: bool,
     sm90_supported: bool,
     sm100_supported: bool,
     expected_supported: bool,
 ) -> None:
-    """Mirrors the CUTLASS FP8 MoE assertions in pinned SGLang 0.5.8."""
+    """Validates the CUTLASS FP8 MoE support check."""
     _install_fake_cutlass_support_modules(
         monkeypatch,
         cutlass_supported=cutlass_supported,

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -13,7 +13,6 @@ from sglang_omni.model_runner.thinker_model_runner import ThinkerModelRunner
 from sglang_omni.models.qwen3_omni.components.talker import (
     Qwen3OmniTalker,
     _bind_default_weight_loaders,
-    _quant_config_for_code_predictor_dense_mlp,
 )
 from sglang_omni.models.qwen3_omni.components.talker_input import build_assistant_part
 from sglang_omni.models.qwen3_omni.components.talker_prefill import TalkerPrefillBuilder
@@ -1241,33 +1240,6 @@ def test_qwen_talker_keeps_existing_read_only_weight_loader() -> None:
     _bind_default_weight_loaders(module)
 
     assert module.param.weight_loader == "existing"
-
-
-def test_qwen_talker_code_predictor_dense_mlp_ignores_only_router_gate_skip() -> None:
-    """Prevents SGLang 0.5.8 substring skips from dequantizing gate_up_proj."""
-
-    class FakeQuantConfig:
-        ignored_layers = ["mlp.gate", "lm_head", "thinker.visual"]
-
-    original = FakeQuantConfig()
-
-    dense_mlp_config = _quant_config_for_code_predictor_dense_mlp(original)
-
-    assert dense_mlp_config is not original
-    assert original.ignored_layers == ["mlp.gate", "lm_head", "thinker.visual"]
-    assert dense_mlp_config.ignored_layers == ["lm_head", "thinker.visual"]
-
-
-def test_qwen_talker_code_predictor_quant_config_is_unchanged_without_router_skip() -> (
-    None
-):
-    class FakeQuantConfig:
-        ignored_layers = ["lm_head"]
-
-    original = FakeQuantConfig()
-
-    assert _quant_config_for_code_predictor_dense_mlp(original) is original
-    assert _quant_config_for_code_predictor_dense_mlp(None) is None
 
 
 def test_qwen_talker_activation_dtype_comes_from_codec_embedding() -> None:


### PR DESCRIPTION




<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

- pyproject.toml: pin sglang==0.5.12; relax transformers<5.0 → >=5.0 (SGLang >=0.5.10 requires transformers 5.x)
- _sglang_qwen3_vl_patches.py: expand _SUPPORTED_SGLANG_VERSIONS to include 0.5.9 through 0.5.12.post1
- talker.py: remove _quant_config_for_code_predictor_dense_mlp and its mlp.gate substring-matching workaround; SGLang >=0.5.9 uses dotted-boundary matching so "mlp.gate" no longer bleeds into "mlp.gate_up_proj"
- hf_config.py, model_worker.py: drop stale "0.5.8" from comments
- tests: remove the two unit tests that validated the removed workaround; update version references in docstrings/requirements

## Related Issues

Closes #658

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Draft PRs are skipped even if labeled.
