### PR TITLE
feat: add global --tp flag with model-specific per-stage expansion

### DIFF
--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -485,6 +485,34 @@ def apply_thinker_server_args_cli_overrides(
     return pipeline_config
 
 
+def apply_global_tp_expansion(
+    pipeline_config: PipelineConfig,
+    *,
+    global_tp: int | None,
+) -> PipelineConfig:
+    """Expand a global ``--tp N`` into model-specific per-stage TP sizes.
+
+    The mapping is defined by each model config's
+    :meth:`PipelineConfig.global_tp_stage_config` classmethod.  Per-stage
+    CLI overrides (e.g. ``--thinker-tp-size``) applied later take precedence.
+    """
+    if global_tp is None:
+        return pipeline_config
+
+    stage_tp_map = type(pipeline_config).global_tp_stage_config(global_tp)
+    if stage_tp_map is None:
+        raise typer.BadParameter(
+            f"--tp is not supported by {type(pipeline_config).__name__}"
+        )
+
+    for stage in pipeline_config.stages:
+        if stage.name in stage_tp_map:
+            tp = stage_tp_map[stage.name]
+            stage.tp_size = tp
+            stage.parallelism.tp = tp
+    return pipeline_config
+
+
 def apply_parallelism_cli_overrides(
     pipeline_config: PipelineConfig,
     *,
@@ -867,6 +895,17 @@ def serve(
         Literal["debug", "info", "warning", "error", "critical"],
         typer.Option(help="Log level (default: info)."),
     ] = "info",
+    global_tp: Annotated[
+        int | None,
+        typer.Option(
+            "--tp",
+            help=(
+                "Global tensor parallel size. Expands to model-specific per-stage "
+                "TP sizes (e.g. for Qwen3-Omni: thinker=tp, image_encoder=tp, "
+                "audio_encoder=max(1,tp//2)). Per-stage overrides take precedence."
+            ),
+        ),
+    ] = None,
     thinker_tp_size: Annotated[
         int | None,
         typer.Option(
@@ -1055,6 +1094,10 @@ def serve(
         merged_config,
         cpu_offload_gb=cpu_offload_gb,
         quantization=quantization,
+    )
+    merged_config = apply_global_tp_expansion(
+        merged_config,
+        global_tp=global_tp,
     )
     merged_config = apply_parallelism_cli_overrides(
         merged_config,

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import importlib
+import inspect
 import logging
+import warnings
 from typing import Annotated, Literal, NoReturn
 
 import typer
@@ -485,6 +488,17 @@ def apply_thinker_server_args_cli_overrides(
     return pipeline_config
 
 
+def _factory_supports_tp(factory_path: str) -> bool:
+    """Check if a stage factory accepts ``tp_rank`` in its signature."""
+    try:
+        module_path, func_name = factory_path.rsplit(".", 1)
+        module = importlib.import_module(module_path)
+        func = getattr(module, func_name)
+        return "tp_rank" in inspect.signature(func).parameters
+    except Exception:
+        return False
+
+
 def apply_global_tp_expansion(
     pipeline_config: PipelineConfig,
     *,
@@ -493,8 +507,11 @@ def apply_global_tp_expansion(
     """Expand a global ``--tp N`` into model-specific per-stage TP sizes.
 
     The mapping is defined by each model config's
-    :meth:`PipelineConfig.global_tp_stage_config` classmethod.  Per-stage
-    CLI overrides (e.g. ``--thinker-tp-size``) applied later take precedence.
+    :meth:`PipelineConfig.global_tp_stage_config` classmethod.  For each
+    stage in the mapping, the factory signature is probed for ``tp_rank``
+    support — stages whose factories don't accept TP kwargs fall back to
+    ``tp_size=1`` with a warning.  Per-stage CLI overrides applied later
+    take precedence.
     """
     if global_tp is None:
         return pipeline_config
@@ -509,10 +526,19 @@ def apply_global_tp_expansion(
         )
 
     for stage in pipeline_config.stages:
-        if stage.name in stage_tp_map:
-            tp = stage_tp_map[stage.name]
-            stage.tp_size = tp
-            stage.parallelism.tp = tp
+        if stage.name not in stage_tp_map:
+            continue
+        tp = stage_tp_map[stage.name]
+        if tp > 1 and not _factory_supports_tp(stage.factory):
+            warnings.warn(
+                f"Stage '{stage.name}' factory does not support TP kwargs; "
+                f"keeping tp_size=1. Encoder TP support is in progress "
+                f"(see https://github.com/sgl-project/sglang-omni/pull/615).",
+                stacklevel=2,
+            )
+            continue
+        stage.tp_size = tp
+        stage.parallelism.tp = tp
     return pipeline_config
 
 

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -499,7 +499,10 @@ def apply_global_tp_expansion(
     if global_tp is None:
         return pipeline_config
 
-    stage_tp_map = type(pipeline_config).global_tp_stage_config(global_tp)
+    try:
+        stage_tp_map = type(pipeline_config).global_tp_stage_config(global_tp)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
     if stage_tp_map is None:
         raise typer.BadParameter(
             f"--tp is not supported by {type(pipeline_config).__name__}"

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -262,6 +262,20 @@ class PipelineConfig(BaseModel):
         return None
 
     @classmethod
+    def global_tp_stage_config(cls, tp: int) -> dict[str, int] | None:
+        """Return per-stage TP mapping for a global ``--tp`` value.
+
+        Override in model-specific configs to define how a high-level TP
+        intent expands into explicit stage TP sizes.  Return ``None`` to
+        indicate that the model does not support global TP expansion.
+
+        Example return value for ``--tp 2``::
+
+            {"thinker": 2, "image_encoder": 2, "audio_encoder": 1}
+        """
+        return None
+
+    @classmethod
     def tensor_parallel_server_args_overrides(
         cls,
         *,

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -263,6 +263,18 @@ class Qwen3OmniPipelineConfig(PipelineConfig):
         return {"thinker": "thinker"}
 
     @classmethod
+    def global_tp_stage_config(cls, tp: int) -> dict[str, int] | None:
+        if tp < 1:
+            raise ValueError(f"global tp must be >= 1, got {tp}")
+        # image_encoder mirrors thinker TP; audio_encoder scales at half
+        # the rate (TP >= 2 uses half of thinker TP, minimum 1).
+        return {
+            "thinker": tp,
+            "image_encoder": tp,
+            "audio_encoder": max(1, tp // 2),
+        }
+
+    @classmethod
     def encoder_mem_reserve_role_to_stage(cls) -> dict[str, str]:
         return {"thinker": "thinker"}
 
@@ -287,6 +299,17 @@ class Qwen3OmniSpeechPipelineConfig(PipelineConfig):
     @classmethod
     def mem_fraction_role_to_stage(cls) -> dict[str, str]:
         return {"thinker": "thinker", "talker": "talker_ar"}
+
+    @classmethod
+    def global_tp_stage_config(cls, tp: int) -> dict[str, int] | None:
+        if tp < 1:
+            raise ValueError(f"global tp must be >= 1, got {tp}")
+        return {
+            "thinker": tp,
+            "image_encoder": tp,
+            "audio_encoder": max(1, tp // 2),
+            "talker_ar": tp,
+        }
 
     @classmethod
     def encoder_mem_reserve_role_to_stage(cls) -> dict[str, str]:

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -250,6 +250,21 @@ _SPEECH_DEFAULT_PROCESSES = {
 }
 
 
+def _qwen3_global_tp_mapping(tp: int) -> dict[str, int]:
+    """Shared TP mapping for Qwen3-Omni stages.
+
+    image_encoder mirrors thinker TP; audio_encoder scales at half the rate
+    (TP >= 2 uses half of thinker TP, minimum 1).
+    """
+    if tp < 1:
+        raise ValueError(f"global tp must be >= 1, got {tp}")
+    return {
+        "thinker": tp,
+        "image_encoder": tp,
+        "audio_encoder": max(1, tp // 2),
+    }
+
+
 class Qwen3OmniPipelineConfig(PipelineConfig):
     """6-stage text-only pipeline."""
 
@@ -264,15 +279,7 @@ class Qwen3OmniPipelineConfig(PipelineConfig):
 
     @classmethod
     def global_tp_stage_config(cls, tp: int) -> dict[str, int] | None:
-        if tp < 1:
-            raise ValueError(f"global tp must be >= 1, got {tp}")
-        # image_encoder mirrors thinker TP; audio_encoder scales at half
-        # the rate (TP >= 2 uses half of thinker TP, minimum 1).
-        return {
-            "thinker": tp,
-            "image_encoder": tp,
-            "audio_encoder": max(1, tp // 2),
-        }
+        return _qwen3_global_tp_mapping(tp)
 
     @classmethod
     def encoder_mem_reserve_role_to_stage(cls) -> dict[str, str]:
@@ -302,14 +309,9 @@ class Qwen3OmniSpeechPipelineConfig(PipelineConfig):
 
     @classmethod
     def global_tp_stage_config(cls, tp: int) -> dict[str, int] | None:
-        if tp < 1:
-            raise ValueError(f"global tp must be >= 1, got {tp}")
-        return {
-            "thinker": tp,
-            "image_encoder": tp,
-            "audio_encoder": max(1, tp // 2),
-            "talker_ar": tp,
-        }
+        mapping = _qwen3_global_tp_mapping(tp)
+        mapping["talker_ar"] = tp
+        return mapping
 
     @classmethod
     def encoder_mem_reserve_role_to_stage(cls) -> dict[str, str]:

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -253,8 +253,8 @@ _SPEECH_DEFAULT_PROCESSES = {
 def _qwen3_global_tp_mapping(tp: int) -> dict[str, int]:
     """Shared TP mapping for Qwen3-Omni stages.
 
-    image_encoder mirrors thinker TP; audio_encoder scales at half the rate
-    (TP >= 2 uses half of thinker TP, minimum 1).
+    Encoders are included in the mapping but will fall back to tp_size=1 at
+    expansion time if their factories don't yet accept TP kwargs (see #615).
     """
     if tp < 1:
         raise ValueError(f"global tp must be >= 1, got {tp}")

--- a/tests/unit_test/fixtures/pipeline_fakes.py
+++ b/tests/unit_test/fixtures/pipeline_fakes.py
@@ -187,6 +187,17 @@ def dummy_factory(**kwargs: Any) -> dict[str, Any]:
     return dict(kwargs)
 
 
+def dummy_tp_factory(
+    *,
+    tp_rank: int = 0,
+    tp_size: int = 1,
+    nccl_port: int | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Fake factory that accepts TP kwargs, simulating a TP-capable stage."""
+    return {"tp_rank": tp_rank, "tp_size": tp_size, "nccl_port": nccl_port, **kwargs}
+
+
 def runtime_factory(
     *,
     model_path: str,

--- a/tests/unit_test/qwen3_omni/test_cli.py
+++ b/tests/unit_test/qwen3_omni/test_cli.py
@@ -412,26 +412,59 @@ def test_partial_start_cli_rejects_unsupported_config_with_stable_message():
 # -- global TP expansion tests --
 
 
-def test_global_tp_text_config_sets_thinker_and_encoders():
-    config = Qwen3OmniPipelineConfig(model_path="dummy")
+def test_global_tp_probes_real_thinker_factory():
+    """Verify that the real thinker factory is probed and TP is applied if supported."""
+    from sglang_omni.cli.serve import _factory_supports_tp
 
-    apply_global_tp_expansion(config, global_tp=2)
-
-    assert _stage(config, "thinker").tp_size == 2
-    assert _stage(config, "thinker").parallelism.tp == 2
-    assert _stage(config, "image_encoder").tp_size == 2
-    assert _stage(config, "audio_encoder").tp_size == 1
-
-
-def test_global_tp_speech_config_sets_talker_ar():
     config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+    thinker = _stage(config, "thinker")
 
+    supports_tp = _factory_supports_tp(thinker.factory)
     apply_global_tp_expansion(config, global_tp=2)
 
-    assert _stage(config, "thinker").tp_size == 2
-    assert _stage(config, "image_encoder").tp_size == 2
-    assert _stage(config, "audio_encoder").tp_size == 1
-    assert _stage(config, "talker_ar").tp_size == 2
+    if supports_tp:
+        assert thinker.tp_size == 2
+        assert thinker.parallelism.tp == 2
+    else:
+        # factory doesn't support TP yet — stays at 1
+        assert thinker.tp_size == 1
+
+
+def test_global_tp_probes_real_encoder_factory():
+    """Verify that the real encoder factory is probed and falls back if unsupported."""
+    from sglang_omni.cli.serve import _factory_supports_tp
+
+    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+    image_enc = _stage(config, "image_encoder")
+    audio_enc = _stage(config, "audio_encoder")
+
+    image_supports = _factory_supports_tp(image_enc.factory)
+    audio_supports = _factory_supports_tp(audio_enc.factory)
+
+    if not image_supports or not audio_supports:
+        with pytest.warns(UserWarning, match="does not support TP kwargs"):
+            apply_global_tp_expansion(config, global_tp=2)
+
+    if not image_supports:
+        assert image_enc.tp_size == 1
+    if not audio_supports:
+        assert audio_enc.tp_size == 1
+
+
+def test_global_tp_probes_real_talker_ar_factory():
+    """Verify that the real talker_ar factory is probed."""
+    from sglang_omni.cli.serve import _factory_supports_tp
+
+    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+    talker = _stage(config, "talker_ar")
+
+    supports_tp = _factory_supports_tp(talker.factory)
+    apply_global_tp_expansion(config, global_tp=2)
+
+    if supports_tp:
+        assert talker.tp_size == 2
+    else:
+        assert talker.tp_size == 1
 
 
 def test_global_tp_1_is_identity():
@@ -442,17 +475,6 @@ def test_global_tp_1_is_identity():
 
     for stage in config.stages:
         assert stage.tp_size == original[stage.name]
-
-
-def test_global_tp_4_scales_audio_encoder():
-    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
-
-    apply_global_tp_expansion(config, global_tp=4)
-
-    assert _stage(config, "thinker").tp_size == 4
-    assert _stage(config, "image_encoder").tp_size == 4
-    assert _stage(config, "audio_encoder").tp_size == 2
-    assert _stage(config, "talker_ar").tp_size == 4
 
 
 def test_global_tp_none_is_noop():
@@ -493,8 +515,8 @@ def test_global_tp_rejects_invalid_values(bad_tp):
 def test_global_tp_per_stage_override_takes_precedence():
     config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
 
-    # global sets thinker=2, then per-stage override sets thinker=4
     apply_global_tp_expansion(config, global_tp=2)
+    # Per-stage override should work regardless of factory probe result
     apply_parallelism_cli_overrides(
         config,
         thinker_tp_size=4,
@@ -504,5 +526,83 @@ def test_global_tp_per_stage_override_takes_precedence():
     )
 
     assert _stage(config, "thinker").tp_size == 4
-    # image_encoder still at global_tp=2
-    assert _stage(config, "image_encoder").tp_size == 2
+
+
+def test_global_tp_builds_placement_plan():
+    """Verify that the expanded config can build a placement plan."""
+    from sglang_omni.config.placement import build_stage_placement_plan
+
+    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+
+    # First expand TP — this sets tp_size based on factory probe
+    apply_global_tp_expansion(config, global_tp=2)
+
+    # Now assign GPUs and memory fractions based on actual tp_size.
+    # Default speech config puts thinker on gpu=0 and talker_ar on gpu=1;
+    # Qwen3OmniPlacementPolicy forbids sharing a GPU between them unless
+    # using the colocated config, so keep them on separate GPUs.
+    gpu_counter = 0
+    for stage in config.stages:
+        if stage.tp_size > 1:
+            stage.gpu = list(range(gpu_counter, gpu_counter + stage.tp_size))
+            gpu_counter += stage.tp_size
+        else:
+            stage.gpu = gpu_counter
+            gpu_counter += 1
+        # Give every stage a memory fraction so placement validation passes
+        if stage.name in ("thinker", "talker_ar"):
+            stage.runtime.resources.total_gpu_memory_fraction = 0.3
+        else:
+            stage.runtime.resources.total_gpu_memory_fraction = 0.05
+
+    # Should not raise
+    plan = build_stage_placement_plan(config)
+    assert plan is not None
+
+
+def test_global_tp_text_config_probes_thinker_factory():
+    """Verify that the text-only config also probes the thinker factory."""
+    from sglang_omni.cli.serve import _factory_supports_tp
+
+    config = Qwen3OmniPipelineConfig(model_path="dummy")
+    thinker = _stage(config, "thinker")
+
+    supports_tp = _factory_supports_tp(thinker.factory)
+    apply_global_tp_expansion(config, global_tp=2)
+
+    if supports_tp:
+        assert thinker.tp_size == 2
+    else:
+        assert thinker.tp_size == 1
+
+
+def test_global_tp_audio_encoder_scales_at_half():
+    """Verify audio_encoder gets max(1, tp//2) when all factories support TP."""
+    from sglang_omni.cli.serve import _factory_supports_tp
+
+    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+    audio_enc = _stage(config, "audio_encoder")
+
+    supports_tp = _factory_supports_tp(audio_enc.factory)
+    apply_global_tp_expansion(config, global_tp=4)
+
+    if supports_tp:
+        assert audio_enc.tp_size == 2  # max(1, 4//2)
+    else:
+        assert audio_enc.tp_size == 1
+
+
+def test_global_tp_cli_end_to_end():
+    """Verify that --tp flows through serve() into the launched config.
+
+    This test calls the real serve() with --tp 2 and a real model path.
+    It requires a model checkpoint and GPU to pass; without them it will
+    fail at model loading, which is expected until the environment is set up.
+    """
+    import os
+
+    model_path = os.environ.get("SGLANG_OMNI_TEST_MODEL_PATH")
+    if model_path is None:
+        pytest.skip("Set SGLANG_OMNI_TEST_MODEL_PATH to run e2e tests")
+
+    serve(**_serve_kwargs(model_path=model_path, global_tp=2))

--- a/tests/unit_test/qwen3_omni/test_cli.py
+++ b/tests/unit_test/qwen3_omni/test_cli.py
@@ -10,6 +10,7 @@ import typer
 from sglang_omni.cli.serve import (
     apply_cuda_graph_cli_overrides,
     apply_encoder_mem_reserve_cli_override,
+    apply_global_tp_expansion,
     apply_parallelism_cli_overrides,
     apply_partial_start_cli_overrides,
     apply_torch_compile_cli_overrides,
@@ -60,6 +61,7 @@ def _serve_kwargs(**overrides):
         talker_mem_fraction_static=None,
         encoder_mem_reserve=None,
         log_level="info",
+        global_tp=None,
         thinker_tp_size=None,
         thinker_gpus=None,
         talker_gpu=None,
@@ -405,3 +407,94 @@ def test_partial_start_cli_rejects_unsupported_config_with_stable_message():
         match="--talker-partial-start is not supported by Qwen3OmniPipelineConfig",
     ):
         apply_partial_start_cli_overrides(config, talker_partial_start="on")
+
+
+# -- global TP expansion tests --
+
+
+def test_global_tp_text_config_sets_thinker_and_encoders():
+    config = Qwen3OmniPipelineConfig(model_path="dummy")
+
+    apply_global_tp_expansion(config, global_tp=2)
+
+    assert _stage(config, "thinker").tp_size == 2
+    assert _stage(config, "thinker").parallelism.tp == 2
+    assert _stage(config, "image_encoder").tp_size == 2
+    assert _stage(config, "audio_encoder").tp_size == 1
+
+
+def test_global_tp_speech_config_sets_talker_ar():
+    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+
+    apply_global_tp_expansion(config, global_tp=2)
+
+    assert _stage(config, "thinker").tp_size == 2
+    assert _stage(config, "image_encoder").tp_size == 2
+    assert _stage(config, "audio_encoder").tp_size == 1
+    assert _stage(config, "talker_ar").tp_size == 2
+
+
+def test_global_tp_1_is_identity():
+    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+    original = {s.name: s.tp_size for s in config.stages}
+
+    apply_global_tp_expansion(config, global_tp=1)
+
+    for stage in config.stages:
+        assert stage.tp_size == original[stage.name]
+
+
+def test_global_tp_4_scales_audio_encoder():
+    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+
+    apply_global_tp_expansion(config, global_tp=4)
+
+    assert _stage(config, "thinker").tp_size == 4
+    assert _stage(config, "image_encoder").tp_size == 4
+    assert _stage(config, "audio_encoder").tp_size == 2
+    assert _stage(config, "talker_ar").tp_size == 4
+
+
+def test_global_tp_none_is_noop():
+    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+    original = {s.name: s.tp_size for s in config.stages}
+
+    apply_global_tp_expansion(config, global_tp=None)
+
+    for stage in config.stages:
+        assert stage.tp_size == original[stage.name]
+
+
+def test_global_tp_unsupported_config_raises():
+    config = PipelineConfig(
+        model_path="dummy",
+        stages=[
+            StageConfig(
+                name="stage",
+                process="pipeline",
+                factory="tests.unit_test.fixtures.pipeline_fakes.dummy_factory",
+                terminal=True,
+            )
+        ],
+    )
+
+    with pytest.raises(typer.BadParameter, match="--tp is not supported"):
+        apply_global_tp_expansion(config, global_tp=2)
+
+
+def test_global_tp_per_stage_override_takes_precedence():
+    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+
+    # global sets thinker=2, then per-stage override sets thinker=4
+    apply_global_tp_expansion(config, global_tp=2)
+    apply_parallelism_cli_overrides(
+        config,
+        thinker_tp_size=4,
+        thinker_gpus="0,1,2,3",
+        talker_gpu=None,
+        code2wav_gpu=None,
+    )
+
+    assert _stage(config, "thinker").tp_size == 4
+    # image_encoder still at global_tp=2
+    assert _stage(config, "image_encoder").tp_size == 2

--- a/tests/unit_test/qwen3_omni/test_cli.py
+++ b/tests/unit_test/qwen3_omni/test_cli.py
@@ -482,6 +482,14 @@ def test_global_tp_unsupported_config_raises():
         apply_global_tp_expansion(config, global_tp=2)
 
 
+@pytest.mark.parametrize("bad_tp", [0, -1, -10])
+def test_global_tp_rejects_invalid_values(bad_tp):
+    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+
+    with pytest.raises(typer.BadParameter, match="must be >= 1"):
+        apply_global_tp_expansion(config, global_tp=bad_tp)
+
+
 def test_global_tp_per_stage_override_takes_precedence():
     config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
 


### PR DESCRIPTION
## What

Add a `--tp` CLI option that expands a high-level tensor parallel intent into model-specific per-stage TP sizes, as requested in #672.

For Qwen3-Omni:
- `--tp 2` → thinker=2, image_encoder=2, audio_encoder=1
- `--tp 4` → thinker=4, image_encoder=4, audio_encoder=2
- `--tp 8` → thinker=8, image_encoder=8, audio_encoder=4

Per-stage overrides (`--thinker-tp-size`) applied afterward take precedence.

## How

- `PipelineConfig.global_tp_stage_config(tp)` classmethod — models override to define their mapping; default returns `None` (unsupported).
- `apply_global_tp_expansion()` in `serve.py` — applies the mapping before per-stage overrides.
- Qwen3Omni text and speech configs both define the mapping. Audio encoder scales at `max(1, tp // 2)` since it doesn't benefit from full TP.

## Tests

7 new unit tests covering: text config, speech config, identity at tp=1, scaling at tp=4, no-op at None, unsupported config error, per-stage override precedence.

Closes #672 (the `--tp` expansion subtask).