### PR TITLE
Upgrade pinned 0.5.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,17 +16,17 @@ dependencies = [
     "numpy>=1.24.0",          # Array operations
     "pydantic>=2.0.0",        # Data validation and serialization
     "PyYAML>=6.0",            # YAML config parsing
-    "torch==2.9.1",          # PyTorch for tensor operations
-    "torchvision==0.24.1",    # torchvision for vision processor
+    "torch==2.11.0",          # PyTorch for tensor operations
+    "torchvision==0.26.0",    # torchvision for vision processor, pinned version based on torch 2.11.0
     "accelerate>=0.27.0",     # init_empty_weights for meta initialization
-    "transformers<5.0",   # HF models/tokenizers
+    "transformers=5.6.0",   # HF models/tokenizers
     "safetensors>=0.4.3",     # Direct weight loading
     "pillow>=10.0.0",         # Required by AutoImageProcessor
     "huggingface-hub>=0.36.0",# HF model downloads
     "datasets>=2.14.0",       # Arrow-based SeedTTS dataset loading
     "fastapi>=0.110.0",       # OpenAI-compatible API adapter
     "uvicorn>=0.23.0",        # ASGI server for FastAPI
-    "sglang==0.5.8",
+    "sglang==0.5.12",
     "nixl",
     "mooncake-transfer-engine>=0.3.0",
     "logger",
@@ -42,7 +42,7 @@ dependencies = [
     "openai==2.6.1",
     "openai-harmony==0.0.4",
     "soundfile>=0.12.0",
-    "mistral-common[audio]>=1.8.0",
+    "mistral_common[audio]>=1.11.0",
     # /v1/realtime — server-side VAD
     "silero-vad>=5.1",
     "onnxruntime>=1.17",
@@ -63,7 +63,7 @@ dependencies = [
     "omegaconf",
     "descript-audiotools",
     "descript-audio-codec",
-    "torchaudio",
+    "torchaudio==2.11.0",
     # Gradio playground
     "gradio>=4.0.0",
     # Ming-Omni

--- a/sglang_omni/model_runner/_sglang_qwen3_vl_patches.py
+++ b/sglang_omni/model_runner/_sglang_qwen3_vl_patches.py
@@ -26,7 +26,7 @@ _APPLY_LOCK = threading.Lock()
 # Released sglang versions whose Qwen3VLMoeVisionModel layout matches the
 # patch. Dev builds (``0.0.0.dev1+...``) are accepted with a warning since
 # they are unversioned snapshots that may or may not match.
-_SUPPORTED_SGLANG_VERSIONS: frozenset[str] = frozenset({"0.5.8", "0.5.8.post1"})
+_SUPPORTED_SGLANG_VERSIONS: frozenset[str] = frozenset({"0.5.12", "0.5.12.post1"})
 
 # Instance attributes the patches read; preflight checks each is present
 # either as a class-level descriptor or as a self.<name> = assignment in

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -375,7 +375,7 @@ def _get_config_value(config: object, key: str) -> object | None:
 
 
 def _is_fp8_cutlass_moe_supported() -> bool:
-    """Mirror pinned SGLang 0.5.8 FP8 CUTLASS MoE assertions."""
+    """Mirror pinned SGLang 0.5.12 FP8 CUTLASS MoE assertions."""
     try:
         from sglang.srt.layers.quantization.fp8_utils import cutlass_fp8_supported
         from sglang.srt.utils import is_sm90_supported, is_sm100_supported

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -205,10 +205,10 @@ def make_qwen3_asr_scheduler_adapters(
             modality=Modality.AUDIO,
             hash=_audio_fingerprint_int(fingerprint),
             feature=features,
+            model_specific_data={
+                "feature_attention_mask": feature_attention_mask,
+            }
         )
-        # get_audio_feature reads item.feature_attention_mask via __getattr__;
-        # stash it in model_specific_data (not a real dataclass field in 0.5.8).
-        audio_item.set("feature_attention_mask", feature_attention_mask)
         # general_mm_embed_routine locates audio positions by matching each
         # item's pad_value against input_ids. The omni scheduler does not run
         # pad_input_ids for us, so compute the pad_value, replace the

--- a/sglang_omni/models/qwen3_omni/components/talker.py
+++ b/sglang_omni/models/qwen3_omni/components/talker.py
@@ -48,22 +48,6 @@ def _bind_default_weight_loaders(module: nn.Module) -> None:
             param.weight_loader = default_weight_loader
 
 
-def _quant_config_for_code_predictor_dense_mlp(
-    quant_config: Optional[QuantizationConfig],
-) -> Optional[QuantizationConfig]:
-    """Keep dense code-predictor MLP projections quantized under SGLang 0.5.8."""
-    ignored_layers = getattr(quant_config, "ignored_layers", None)
-    if not ignored_layers or "mlp.gate" not in ignored_layers:
-        return quant_config
-
-    # FIXME (Ratish): when upgrading past SGLang 0.5.8. Newer SGLang uses
-    # dotted-boundary ignored-layer matching, so this local workaround should be
-    # removed once this repo depends on that behavior.
-    cloned = copy.copy(quant_config)
-    cloned.ignored_layers = [layer for layer in ignored_layers if layer != "mlp.gate"]
-    return cloned
-
-
 def _repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     """Repeat KV heads to match the number of query heads."""
     batch, num_kv_heads, seq_len, head_dim = hidden_states.shape
@@ -506,9 +490,6 @@ class Qwen3OmniMoeTalkerCodePredictor(nn.Module):
         # 5 dense decoder layers
         alt_stream = torch.cuda.Stream()
         self.model.layers = nn.ModuleList()
-        dense_mlp_quant_config = _quant_config_for_code_predictor_dense_mlp(
-            quant_config
-        )
         for idx in range(cp_config.num_hidden_layers):
             # Create a decoder layer similar to Thinker but with dense MLP
             layer = nn.Module()
@@ -532,7 +513,7 @@ class Qwen3OmniMoeTalkerCodePredictor(nn.Module):
             layer.mlp = Qwen3OmniMoeTalkerDenseMLP(
                 cp_config.hidden_size,
                 cp_config.intermediate_size,
-                quant_config=dense_mlp_quant_config,
+                quant_config=quant_config,
                 prefix=add_prefix(f"model.layers.{idx}.mlp", prefix),
             )
             layer.input_layernorm = RMSNorm(

--- a/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
+++ b/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
@@ -391,14 +391,14 @@ def test_model_config_has_moe_prefers_effective_text_config() -> None:
         pytest.param(False, True, False, False, id="cutlass_runtime_rejected"),
     ],
 )
-def test_fp8_cutlass_moe_support_matches_sglang_0_5_8_contract(
+def test_fp8_cutlass_moe_support_matches_sglang_0_5_12_contract(
     monkeypatch: pytest.MonkeyPatch,
     cutlass_supported: bool,
     sm90_supported: bool,
     sm100_supported: bool,
     expected_supported: bool,
 ) -> None:
-    """Mirrors the CUTLASS FP8 MoE assertions in pinned SGLang 0.5.8."""
+    """Mirrors the CUTLASS FP8 MoE assertions in pinned SGLang 0.5.12."""
     _install_fake_cutlass_support_modules(
         monkeypatch,
         cutlass_supported=cutlass_supported,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Upgrade sglang version from 0.5.8 -> 0.5.12 #658.
**To Reviewers: Here is a draft. Will update the description with changes.**

WIP:
1. DeepGEMM compile workaround
2. Replace hand-rolled encoder glue with the new upstream encoder APIs where available.
3. (Optional?) Bring up and add CI coverage on a Blackwell Machine 

## Modifications

1. Upgrade the version pin and allowlist for supported SGLang version. Also update other related dependency version based on SGLang 0.5.12 branch.
2. Remove custom fix/workaround unblocked by 0.5.8 -> 0.5.12 upgrade(Specifically under "[Version-tied debt to clear during the upgrade](https://github.com/sgl-project/sglang-omni/issues/658#issue-4573492531)". Including:
    1. Remove the local workaround for ignore_layer due to prefix pattern matching: **Code cleanup**
    2. Existing FP8 CUTLASS MoE assertion: **No-op**. Verfied with 0.5.12 and there is no update on the type check function, so update it according to 0.5.12 version. Update the function comment as well as the test case name
    3. Stashed field model_specific_data: **Update initialization**(See example in [upstream](https://github.com/sgl-project/sglang/blob/v0.5.12/python/sglang/srt/multimodal/processors/mimo_v2.py#L1915-L1928))
    4. 0.5.8 MRotaryEmbedding selection: **No-op**


## Related Issues

Fix #658.

## Accuracy Test

Will follow up on e2e tests

## Benchmark & Profiling

N/A

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Draft PRs are skipped even if labeled.
