### PR TITLE
[WIP] Bump SGLang to 0.5.12 and fix smoke regressions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,17 +16,18 @@ dependencies = [
     "numpy>=1.24.0",          # Array operations
     "pydantic>=2.0.0",        # Data validation and serialization
     "PyYAML>=6.0",            # YAML config parsing
-    "torch==2.9.1",          # PyTorch for tensor operations
-    "torchvision==0.24.1",    # torchvision for vision processor
+    "torch==2.11.0",          # PyTorch for tensor operations
+    "torchvision==0.26.0",    # torchvision for vision processor
     "accelerate>=0.27.0",     # init_empty_weights for meta initialization
-    "transformers<5.0",   # HF models/tokenizers
+    "transformers==5.6.0",   # HF models/tokenizers; pinned by sglang 0.5.12
+    "kernels>=0.12.0,<0.13", # Compatible with transformers 5.6 hub kernels
     "safetensors>=0.4.3",     # Direct weight loading
     "pillow>=10.0.0",         # Required by AutoImageProcessor
     "huggingface-hub>=0.36.0",# HF model downloads
     "datasets>=2.14.0",       # Arrow-based SeedTTS dataset loading
     "fastapi>=0.110.0",       # OpenAI-compatible API adapter
     "uvicorn>=0.23.0",        # ASGI server for FastAPI
-    "sglang==0.5.8",
+    "sglang==0.5.12",
     "nixl",
     "mooncake-transfer-engine>=0.3.0",
     "logger",
@@ -63,7 +64,8 @@ dependencies = [
     "omegaconf",
     "descript-audiotools",
     "descript-audio-codec",
-    "torchaudio",
+    "torchaudio==2.11.0",
+    "torchcodec==0.11.1",     # Matches sglang==0.5.12 dependency
     # Gradio playground
     "gradio>=4.0.0",
     # Ming-Omni

--- a/sglang_omni/model_runner/_sglang_qwen3_vl_patches.py
+++ b/sglang_omni/model_runner/_sglang_qwen3_vl_patches.py
@@ -26,9 +26,7 @@ _APPLY_LOCK = threading.Lock()
 # Released sglang versions whose Qwen3VLMoeVisionModel layout matches the
 # patch. Dev builds (``0.0.0.dev1+...``) are accepted with a warning since
 # they are unversioned snapshots that may or may not match.
-_SUPPORTED_SGLANG_VERSIONS: frozenset[str] = frozenset(
-    {"0.5.8", "0.5.8.post1", "0.5.12"}
-)
+_SUPPORTED_SGLANG_VERSIONS: frozenset[str] = frozenset({"0.5.12"})
 
 # Instance attributes the patches read; preflight checks each is present
 # either as a class-level descriptor or as a self.<name> = assignment in

--- a/sglang_omni/model_runner/_sglang_qwen3_vl_patches.py
+++ b/sglang_omni/model_runner/_sglang_qwen3_vl_patches.py
@@ -26,7 +26,9 @@ _APPLY_LOCK = threading.Lock()
 # Released sglang versions whose Qwen3VLMoeVisionModel layout matches the
 # patch. Dev builds (``0.0.0.dev1+...``) are accepted with a warning since
 # they are unversioned snapshots that may or may not match.
-_SUPPORTED_SGLANG_VERSIONS: frozenset[str] = frozenset({"0.5.8", "0.5.8.post1"})
+_SUPPORTED_SGLANG_VERSIONS: frozenset[str] = frozenset(
+    {"0.5.8", "0.5.8.post1", "0.5.12"}
+)
 
 # Instance attributes the patches read; preflight checks each is present
 # either as a class-level descriptor or as a self.<name> = assignment in

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -375,7 +375,6 @@ def _get_config_value(config: object, key: str) -> object | None:
 
 
 def _is_fp8_cutlass_moe_supported() -> bool:
-    """Mirror pinned SGLang 0.5.8 FP8 CUTLASS MoE assertions."""
     try:
         from sglang.srt.layers.quantization.fp8_utils import cutlass_fp8_supported
         from sglang.srt.utils import is_sm90_supported, is_sm100_supported

--- a/sglang_omni/models/ming_omni/talker/talker_module/modules.py
+++ b/sglang_omni/models/ming_omni/talker/talker_module/modules.py
@@ -6,19 +6,34 @@ from torch import nn
 from x_transformers.x_transformers import apply_rotary_pos_emb
 
 
-def is_package_available(package_name: str) -> bool:
-    try:
-        import importlib
-
-        package_exists = importlib.util.find_spec(package_name) is not None
-        return package_exists
-    except Exception:
-        return False
-
-
-if is_package_available("flash_attn"):
+_FLASH_ATTN_IMPORT_ERROR: Exception | None = None
+try:
     from flash_attn import flash_attn_func, flash_attn_varlen_func
     from flash_attn.bert_padding import pad_input, unpad_input
+except (ImportError, ModuleNotFoundError) as exc:
+    flash_attn_func = None
+    flash_attn_varlen_func = None
+    pad_input = None
+    unpad_input = None
+    _FLASH_ATTN_IMPORT_ERROR = exc
+
+
+def is_flash_attn_available() -> bool:
+    return (
+        flash_attn_func is not None
+        and flash_attn_varlen_func is not None
+        and pad_input is not None
+        and unpad_input is not None
+    )
+
+
+def _raise_flash_attn_unavailable() -> None:
+    raise ImportError(
+        "Ming flash_attn backend requires the legacy flash_attn API "
+        "with flash_attn_func and flash_attn_varlen_func. The installed "
+        "flash-attn package does not expose those symbols; use "
+        "attn_backend=\"torch\" or install a compatible flash-attn build."
+    ) from _FLASH_ATTN_IMPORT_ERROR
 
 
 class RMSNorm(nn.Module):
@@ -105,10 +120,8 @@ class Attention(nn.Module):
         self.to_out.append(nn.Linear(self.inner_dim, dim))
         self.to_out.append(nn.Dropout(dropout))
 
-        if attn_backend == "flash_attn":
-            assert is_package_available(
-                "flash_attn"
-            ), "Please install flash-attn first."
+        if attn_backend == "flash_attn" and not is_flash_attn_available():
+            _raise_flash_attn_unavailable()
 
         self.pe_attn_head = pe_attn_head
         self.attn_backend = attn_backend
@@ -190,6 +203,8 @@ class Attention(nn.Module):
             x = x.transpose(1, 2).reshape(batch_size, -1, self.heads * head_dim)
 
         elif self.attn_backend == "flash_attn":
+            if not is_flash_attn_available():
+                _raise_flash_attn_unavailable()
             query = query.transpose(1, 2)  # [b, h, n, d] -> [b, n, h, d]
             key = key.transpose(1, 2)
             value = value.transpose(1, 2)

--- a/sglang_omni/models/moss_tts/model_runner.py
+++ b/sglang_omni/models/moss_tts/model_runner.py
@@ -448,12 +448,40 @@ class MossTTSModelRunner(ModelRunner):
         positions_row = MossTTSModelRunner._as_row_tensor(
             positions, num_rows, torch.long, device
         )
-        sampled = multinomial_with_seed(probs, seeds_row, positions_row).view(-1)
-
         fallback = (~do_sample) | (probs.sum(dim=-1) <= 0)
-        if bool(fallback.any()):
-            sampled[fallback] = torch.argmax(logits[fallback], dim=-1)
+        sample_mask = ~fallback
+        sampled = torch.argmax(logits, dim=-1)
+        if bool(sample_mask.any()):
+            if device.type == "cpu":
+                sampled[sample_mask] = MossTTSModelRunner._multinomial_with_seed_cpu(
+                    probs[sample_mask],
+                    seeds_row[sample_mask],
+                    positions_row[sample_mask],
+                )
+            else:
+                sampled[sample_mask] = multinomial_with_seed(
+                    probs[sample_mask],
+                    seeds_row[sample_mask],
+                    positions_row[sample_mask],
+                ).view(-1)
         return sampled.to(torch.long)
+
+    @staticmethod
+    def _multinomial_with_seed_cpu(
+        probs: torch.Tensor,
+        seeds: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> torch.Tensor:
+        rows = []
+        for row, seed, position in zip(probs, seeds, positions, strict=True):
+            mixed_seed = (
+                int(seed.item())
+                + 0x9E3779B97F4A7C15 * int(position.item() + 1)
+            ) % (2**63 - 1)
+            generator = torch.Generator(device="cpu")
+            generator.manual_seed(mixed_seed)
+            rows.append(torch.multinomial(row.cpu(), 1, generator=generator)[0])
+        return torch.stack(rows).to(device=probs.device, dtype=torch.long)
 
     @staticmethod
     def _apply_top_k(scores: torch.Tensor, top_k_row: torch.Tensor) -> torch.Tensor:

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -213,14 +213,15 @@ def make_qwen3_asr_scheduler_adapters(
         # item's pad_value against input_ids. The omni scheduler does not run
         # pad_input_ids for us, so compute the pad_value, replace the
         # <|audio_pad|> placeholders with it, and record the placeholder span as
-        # item.offsets ([(start, end)] half-open) — sglang reads both.
+        # item.offsets. SGLang treats offsets as inclusive in its chunked
+        # prefill embedding path.
         audio_item.set_pad_value()
         audio_start = input_ids.index(audio_pad_token_id)
         input_ids = [
             audio_item.pad_value if tok == audio_pad_token_id else tok
             for tok in input_ids
         ]
-        audio_item.offsets = [(audio_start, audio_start + num_audio_tokens)]
+        audio_item.offsets = [(audio_start, audio_start + num_audio_tokens - 1)]
 
         mm_inputs = MultimodalInputs(
             mm_items=[audio_item],

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -185,9 +185,8 @@ def make_qwen3_asr_scheduler_adapters(
                 (features.shape[0], features.shape[-1]), dtype=torch.long
             )
         # Keep the full padded mel; the model's get_audio_feature uses the mask
-        # to select valid frames. (Its no-mask branch transposes wrong, so the
-        # mask path must be taken — we hand the mask over via model_specific_data
-        # since sglang 0.5.8's MultimodalDataItem has no such field.)
+        # to select valid frames. Its no-mask branch transposes wrong, so the
+        # mask path must be taken.
         num_mel_frames = int(feature_attention_mask.sum().item())
         num_audio_tokens = int(qwen3_asr_num_audio_tokens(num_mel_frames))
         logger.debug(
@@ -205,10 +204,10 @@ def make_qwen3_asr_scheduler_adapters(
             modality=Modality.AUDIO,
             hash=_audio_fingerprint_int(fingerprint),
             feature=features,
+            model_specific_data={
+                "feature_attention_mask": feature_attention_mask,
+            },
         )
-        # get_audio_feature reads item.feature_attention_mask via __getattr__;
-        # stash it in model_specific_data (not a real dataclass field in 0.5.8).
-        audio_item.set("feature_attention_mask", feature_attention_mask)
         # general_mm_embed_routine locates audio positions by matching each
         # item's pad_value against input_ids. The omni scheduler does not run
         # pad_input_ids for us, so compute the pad_value, replace the

--- a/sglang_omni/models/qwen3_omni/components/talker.py
+++ b/sglang_omni/models/qwen3_omni/components/talker.py
@@ -4,7 +4,6 @@ SGLang-native Talker model for Qwen3-Omni compatiable with hf formatting.
 
 from __future__ import annotations
 
-import copy
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -46,22 +45,6 @@ def _bind_default_weight_loaders(module: nn.Module) -> None:
     for param in module.parameters():
         if not hasattr(param, "weight_loader"):
             param.weight_loader = default_weight_loader
-
-
-def _quant_config_for_code_predictor_dense_mlp(
-    quant_config: Optional[QuantizationConfig],
-) -> Optional[QuantizationConfig]:
-    """Keep dense code-predictor MLP projections quantized under SGLang 0.5.8."""
-    ignored_layers = getattr(quant_config, "ignored_layers", None)
-    if not ignored_layers or "mlp.gate" not in ignored_layers:
-        return quant_config
-
-    # FIXME (Ratish): when upgrading past SGLang 0.5.8. Newer SGLang uses
-    # dotted-boundary ignored-layer matching, so this local workaround should be
-    # removed once this repo depends on that behavior.
-    cloned = copy.copy(quant_config)
-    cloned.ignored_layers = [layer for layer in ignored_layers if layer != "mlp.gate"]
-    return cloned
 
 
 def _repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
@@ -506,9 +489,6 @@ class Qwen3OmniMoeTalkerCodePredictor(nn.Module):
         # 5 dense decoder layers
         alt_stream = torch.cuda.Stream()
         self.model.layers = nn.ModuleList()
-        dense_mlp_quant_config = _quant_config_for_code_predictor_dense_mlp(
-            quant_config
-        )
         for idx in range(cp_config.num_hidden_layers):
             # Create a decoder layer similar to Thinker but with dense MLP
             layer = nn.Module()
@@ -532,7 +512,7 @@ class Qwen3OmniMoeTalkerCodePredictor(nn.Module):
             layer.mlp = Qwen3OmniMoeTalkerDenseMLP(
                 cp_config.hidden_size,
                 cp_config.intermediate_size,
-                quant_config=dense_mlp_quant_config,
+                quant_config=quant_config,
                 prefix=add_prefix(f"model.layers.{idx}.mlp", prefix),
             )
             layer.input_layernorm = RMSNorm(

--- a/sglang_omni/models/qwen3_omni/hf_config.py
+++ b/sglang_omni/models/qwen3_omni/hf_config.py
@@ -20,9 +20,9 @@ def _normalize_rope_scaling(
         normalized["rope_type"] = normalized["type"]
 
     if _MROPE_ROPE_SCALING_KEYS.intersection(normalized.keys()):
-        # SGLang 0.5.8 selects MRotaryEmbedding from rope_type/type="default"
-        # plus mrope_section. Passing "mrope" reaches the generic rope switch
-        # and fails before the talker can start.
+        # SGLang selects MRotaryEmbedding from rope_type/type="default" plus
+        # mrope_section. Passing "mrope" reaches the generic rope switch and
+        # fails because "mrope" is not a recognized rope_type in SGLang.
         rope_type = normalized.get("rope_type", normalized.get("type", "default"))
         if rope_type == "mrope":
             rope_type = "default"

--- a/sglang_omni/models/qwen3_tts/compat.py
+++ b/sglang_omni/models/qwen3_tts/compat.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compatibility shims for upstream qwen-tts."""
+
+from __future__ import annotations
+
+import inspect
+import threading
+from typing import Any, Callable
+
+import torch
+
+_APPLY_LOCK = threading.Lock()
+_PATCHED_FLAG = "_sglang_omni_qwen_tts_compat_patched"
+
+
+def _compute_default_rope_parameters(
+    config: Any,
+    device: torch.device | None = None,
+    seq_len: int | None = None,
+    layer_type: str | None = None,
+) -> tuple[torch.Tensor, float]:
+    del seq_len, layer_type
+    base = getattr(config, "rope_theta", getattr(config, "default_theta", 10000.0))
+    partial_rotary_factor = getattr(config, "partial_rotary_factor", 1.0)
+    head_dim = getattr(config, "head_dim", None)
+    if head_dim is None:
+        head_dim = config.hidden_size // config.num_attention_heads
+    dim = int(head_dim * partial_rotary_factor)
+    inv_freq = 1.0 / (
+        base
+        ** (
+            torch.arange(0, dim, 2, dtype=torch.int64).to(
+                device=device, dtype=torch.float
+            )
+            / dim
+        )
+    )
+    return inv_freq, 1.0
+
+
+def apply_qwen_tts_transformers_compatibility_patches() -> None:
+    """Patch Transformers APIs expected by qwen-tts 0.1.x.
+
+    qwen-tts 0.1.1 still uses @check_model_inputs(). Transformers 5.x
+    changed that helper to check_model_inputs(func), so install a small
+    adapter before qwen_tts imports copy the symbol.
+    """
+    from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+    from transformers.utils import generic
+
+    with _APPLY_LOCK:
+        ROPE_INIT_FUNCTIONS.setdefault("default", _compute_default_rope_parameters)
+
+        current = generic.check_model_inputs
+        if getattr(current, _PATCHED_FLAG, False):
+            return
+
+        try:
+            signature = inspect.signature(current)
+        except (TypeError, ValueError):
+            return
+
+        params = list(signature.parameters.values())
+        needs_func_arg = (
+            len(params) == 1
+            and params[0].default is inspect.Parameter.empty
+            and params[0].kind
+            in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            )
+        )
+        if not needs_func_arg:
+            return
+
+        original = current
+
+        def check_model_inputs_compat(
+            func: Callable[..., Any] | None = None,
+        ) -> Callable[..., Any]:
+            if func is None:
+
+                def decorator(inner: Callable[..., Any]) -> Callable[..., Any]:
+                    return original(inner)
+
+                return decorator
+            return original(func)
+
+        check_model_inputs_compat.__name__ = getattr(
+            original, "__name__", "check_model_inputs"
+        )
+        check_model_inputs_compat.__doc__ = getattr(original, "__doc__", None)
+        setattr(check_model_inputs_compat, _PATCHED_FLAG, True)
+        generic.check_model_inputs = check_model_inputs_compat

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -11,6 +11,9 @@ from sglang.srt.layers.sampler import multinomial_with_seed
 from sglang.srt.utils import add_prefix
 from torch import nn
 
+from sglang_omni.models.qwen3_tts.compat import (
+    apply_qwen_tts_transformers_compatibility_patches,
+)
 from sglang_omni.models.qwen3_omni.components.talker import (  # noqa: E501
     Qwen3OmniMoeTalkerDenseMLP,
     ResizeMLP,
@@ -167,7 +170,7 @@ class Qwen3TTSTalkerTextModel(nn.Module):
         residual = None
         layers = self.layers
         if is_decode:
-            layers = self._compiled_decode_layers
+            layers = getattr(self, "_compiled_decode_layers", self.layers)
         for idx in range(self.start_layer, self.end_layer):
             hidden_states, residual = layers[idx](
                 positions=positions,
@@ -270,6 +273,7 @@ class Qwen3TTSTalker(nn.Module):
         )
 
         if root_config is not None and self.tts_model_type == "base":
+            apply_qwen_tts_transformers_compatibility_patches()
             from qwen_tts.core.models.modeling_qwen3_tts import Qwen3TTSSpeakerEncoder
 
             self.speaker_encoder = Qwen3TTSSpeakerEncoder(
@@ -376,6 +380,7 @@ class Qwen3TTSTalker(nn.Module):
 
     @torch.inference_mode()
     def extract_speaker_embedding(self, audio, sr):
+        apply_qwen_tts_transformers_compatibility_patches()
         from qwen_tts.core.models.modeling_qwen3_tts import mel_spectrogram
 
         if sr != self.speaker_encoder_sample_rate:

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -9,6 +9,9 @@ from typing import Any
 
 import torch
 
+from sglang_omni.models.qwen3_tts.compat import (
+    apply_qwen_tts_transformers_compatibility_patches,
+)
 from sglang_omni.models.qwen3_tts.payload_types import Qwen3TTSState
 from sglang_omni.models.qwen3_tts.request_builders import (
     cleanup_prepared_qwen3_tts_request,
@@ -53,6 +56,7 @@ def _load_qwen3_tts_tokenizer(
     dtype: str,
     attn_implementation: str | None,
 ):
+    apply_qwen_tts_transformers_compatibility_patches()
     try:
         from qwen_tts import Qwen3TTSTokenizer
     except ImportError as exc:
@@ -73,6 +77,7 @@ def _load_qwen3_tts_tokenizer(
 
 
 def _register_qwen3_tts_hf_config() -> None:
+    apply_qwen_tts_transformers_compatibility_patches()
     try:
         from qwen_tts.core.models import Qwen3TTSConfig
         from transformers import AutoConfig
@@ -166,7 +171,9 @@ def create_sglang_tts_engine_executor(
     gpu_id: int | None = None,
     dtype: str = "bfloat16",
     attn_implementation: str | None = None,
+    server_args_overrides: dict[str, Any] | None = None,
 ) -> Any:
+    apply_qwen_tts_transformers_compatibility_patches()
     from qwen_tts import Qwen3TTSModel
     from transformers import AutoProcessor
 
@@ -184,19 +191,25 @@ def create_sglang_tts_engine_executor(
         device = f"cuda:{gpu_id}"
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0
 
+    overrides: dict[str, Any] = {
+        "dtype": dtype,
+        "disable_cuda_graph": False,
+        "disable_overlap_schedule": True,
+        "enable_torch_compile": True,
+        "mem_fraction_static": 0.85,
+        "max_prefill_tokens": 8192,
+        "max_running_requests": 16,
+        "sampling_backend": "pytorch",
+        "torch_compile_max_bs": 16,
+        "trust_remote_code": True,
+    }
+    if server_args_overrides:
+        overrides.update(server_args_overrides)
+
     server_args = build_sglang_server_args(
         checkpoint_dir,
         context_length=8192,
-        dtype=dtype,
-        disable_cuda_graph=False,
-        disable_overlap_schedule=True,
-        enable_torch_compile=True,
-        mem_fraction_static=0.85,
-        max_prefill_tokens=8192,
-        max_running_requests=16,
-        sampling_backend="pytorch",
-        torch_compile_max_bs=16,
-        trust_remote_code=True,
+        **overrides,
     )
 
     want_cuda_graph = not bool(getattr(server_args, "disable_cuda_graph", False))

--- a/tests/test_model/test_v1_encoder_qwen3_vl_hf_parity.py
+++ b/tests/test_model/test_v1_encoder_qwen3_vl_hf_parity.py
@@ -15,7 +15,7 @@ Run:
     pytest -v -m benchmark tests/test_model/test_v1_encoder_qwen3_vl_hf_parity.py
 
 Requires:
-    - 1× H100 (or equivalent ≥ 80GB GPU) with sglang==0.5.8 and transformers
+    - 1× H100 (or equivalent ≥ 80GB GPU) with sglang==0.5.12 and transformers
     - HF cache populated for ``Qwen/Qwen3-Omni-30B-A3B-Instruct``
 """
 from __future__ import annotations

--- a/tests/unit_test/higgs_tts/test_request_builders.py
+++ b/tests/unit_test/higgs_tts/test_request_builders.py
@@ -14,7 +14,7 @@ from sglang_omni.proto import OmniRequest, StagePayload
 def test_higgs_scheduler_adapters_clamp_cap_and_record_engine_time(
     monkeypatch,
 ) -> None:
-    ticks = iter([10.0, 12.5])
+    ticks = iter([0.0, 0.0, 10.0, 12.5])
     reset_calls: list[str] = []
     monkeypatch.setattr(
         request_builders.time,

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -18,6 +18,16 @@ from sglang_omni.scheduling.threaded_simple_scheduler import ThreadedSimpleSched
 from tests.unit_test.pipeline.helpers import run_scheduler
 
 
+def _set_upstream_request_limit_state(
+    scheduler: OmniScheduler,
+    *,
+    page_size: int = 1,
+    max_total_num_tokens: int = 16,
+) -> None:
+    scheduler.page_size = page_size
+    scheduler.max_total_num_tokens = max_total_num_tokens
+
+
 def test_simple_scheduler_batch_and_error_contracts() -> None:
     """Preserves batched success output and per-request batch failure emission."""
     good = SimpleScheduler(
@@ -586,6 +596,7 @@ def test_omni_scheduler_prepares_custom_request_token_budget() -> None:
     scheduler._aborted_request_ids = set()
     scheduler.max_req_len = 6
     scheduler.max_req_input_len = 5
+    _set_upstream_request_limit_state(scheduler)
 
     sampling_params = SimpleNamespace(max_new_tokens=10)
     req = SimpleNamespace(
@@ -617,6 +628,7 @@ def test_omni_scheduler_rejects_custom_request_over_context() -> None:
     scheduler._aborted_request_ids = set()
     scheduler.max_req_len = 6
     scheduler.max_req_input_len = 5
+    _set_upstream_request_limit_state(scheduler)
     scheduler.running_batch = SimpleNamespace(reqs=[], batch_is_full=False)
     scheduler.cur_batch = None
     scheduler.last_batch = None
@@ -668,6 +680,7 @@ def test_omni_scheduler_follower_rejections_do_not_emit_errors() -> None:
     scheduler.tree_cache = None
     scheduler.max_req_len = 6
     scheduler.max_req_input_len = 5
+    _set_upstream_request_limit_state(scheduler)
     scheduler.server_args = SimpleNamespace(mem_fraction_static=0.85)
 
     over_context_req = SimpleNamespace(

--- a/tests/unit_test/qwen3_asr/test_request_builders.py
+++ b/tests/unit_test/qwen3_asr/test_request_builders.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import numpy as np
 import torch
 
 from sglang_omni.models.qwen3_asr.audio_lengths import (
@@ -33,6 +36,11 @@ class _FakeTokenizer:
         self.encode_calls.append(text)
         assert text == "<asr_text>"
         return [100, 101]
+
+    def __call__(self, text: str, *, add_special_tokens: bool = False):
+        assert not add_special_tokens
+        audio_pad_count = text.count("<|audio_pad|>")
+        return SimpleNamespace(input_ids=[11] + [42] * audio_pad_count + [12, 13, 14])
 
     def decode(
         self,
@@ -72,6 +80,41 @@ def test_qwen3_asr_audio_token_length_formula_is_shared() -> None:
     assert torch.equal(qwen3_asr_audio_token_lengths(lengths), expected)
     assert torch.equal(processor._get_feat_extract_output_lengths(lengths), expected)
     assert qwen3_asr_num_audio_tokens(3000) == 390
+
+
+def test_qwen3_asr_request_builder_records_inclusive_audio_offsets(monkeypatch) -> None:
+    import sglang_omni.models.qwen3_asr.request_builders as request_builders
+
+    num_mel_frames = 101
+    num_audio_tokens = qwen3_asr_num_audio_tokens(num_mel_frames)
+    feature_extractor = lambda *args, **kwargs: SimpleNamespace(
+        input_features=torch.zeros((1, 128, 3000)),
+        attention_mask=torch.ones((1, num_mel_frames), dtype=torch.long),
+    )
+    monkeypatch.setattr(
+        request_builders,
+        "load_audio",
+        lambda source: np.zeros(1600, dtype=np.float32),
+    )
+    request_builder, _ = make_qwen3_asr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=32,
+        feature_extractor=feature_extractor,
+    )
+    payload = StagePayload(
+        request_id="req-asr",
+        request=OmniRequest(inputs={"audio_bytes": b"wav"}),
+        data={},
+    )
+
+    data = request_builder(payload)
+
+    audio_item = data.req.multimodal_inputs.mm_items[0]
+    start, end = audio_item.offsets[0]
+    assert end - start + 1 == num_audio_tokens
+    assert data.prompt_token_ids[start : end + 1] == (
+        [audio_item.pad_value] * num_audio_tokens
+    )
 
 
 def test_qwen3_asr_result_adapter_decodes_without_text_round_trip() -> None:

--- a/tests/unit_test/qwen3_asr/test_request_builders.py
+++ b/tests/unit_test/qwen3_asr/test_request_builders.py
@@ -111,6 +111,7 @@ def test_qwen3_asr_request_builder_records_inclusive_audio_offsets(monkeypatch) 
 
     audio_item = data.req.multimodal_inputs.mm_items[0]
     start, end = audio_item.offsets[0]
+    assert audio_item.feature_attention_mask.shape == (1, num_mel_frames)
     assert end - start + 1 == num_audio_tokens
     assert data.prompt_token_ids[start : end + 1] == (
         [audio_item.pad_value] * num_audio_tokens

--- a/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
+++ b/tests/unit_test/qwen3_omni/test_fp8_backend_config.py
@@ -391,14 +391,13 @@ def test_model_config_has_moe_prefers_effective_text_config() -> None:
         pytest.param(False, True, False, False, id="cutlass_runtime_rejected"),
     ],
 )
-def test_fp8_cutlass_moe_support_matches_sglang_0_5_8_contract(
+def test_fp8_cutlass_moe_support_check(
     monkeypatch: pytest.MonkeyPatch,
     cutlass_supported: bool,
     sm90_supported: bool,
     sm100_supported: bool,
     expected_supported: bool,
 ) -> None:
-    """Mirrors the CUTLASS FP8 MoE assertions in pinned SGLang 0.5.8."""
     _install_fake_cutlass_support_modules(
         monkeypatch,
         cutlass_supported=cutlass_supported,

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -13,7 +13,6 @@ from sglang_omni.model_runner.thinker_model_runner import ThinkerModelRunner
 from sglang_omni.models.qwen3_omni.components.talker import (
     Qwen3OmniTalker,
     _bind_default_weight_loaders,
-    _quant_config_for_code_predictor_dense_mlp,
 )
 from sglang_omni.models.qwen3_omni.components.talker_input import build_assistant_part
 from sglang_omni.models.qwen3_omni.components.talker_prefill import TalkerPrefillBuilder
@@ -1241,33 +1240,6 @@ def test_qwen_talker_keeps_existing_read_only_weight_loader() -> None:
     _bind_default_weight_loaders(module)
 
     assert module.param.weight_loader == "existing"
-
-
-def test_qwen_talker_code_predictor_dense_mlp_ignores_only_router_gate_skip() -> None:
-    """Prevents SGLang 0.5.8 substring skips from dequantizing gate_up_proj."""
-
-    class FakeQuantConfig:
-        ignored_layers = ["mlp.gate", "lm_head", "thinker.visual"]
-
-    original = FakeQuantConfig()
-
-    dense_mlp_config = _quant_config_for_code_predictor_dense_mlp(original)
-
-    assert dense_mlp_config is not original
-    assert original.ignored_layers == ["mlp.gate", "lm_head", "thinker.visual"]
-    assert dense_mlp_config.ignored_layers == ["lm_head", "thinker.visual"]
-
-
-def test_qwen_talker_code_predictor_quant_config_is_unchanged_without_router_skip() -> (
-    None
-):
-    class FakeQuantConfig:
-        ignored_layers = ["lm_head"]
-
-    original = FakeQuantConfig()
-
-    assert _quant_config_for_code_predictor_dense_mlp(original) is original
-    assert _quant_config_for_code_predictor_dense_mlp(None) is None
 
 
 def test_qwen_talker_activation_dtype_comes_from_codec_embedding() -> None:

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -1377,7 +1377,6 @@ def test_qwen3_tts_decode_forward_does_not_clear_feedback_mask(
     torch.nn.Module.__init__(model)
     model.codec_embedding = torch.nn.Embedding(8, 4)
     model.layers = torch.nn.ModuleList([])
-    model._compiled_decode_layers = model.layers
     model.start_layer = 0
     model.end_layer = 0
     model.norm = IdentityNorm()
@@ -1666,10 +1665,9 @@ def test_qwen3_tts_compile_backbone_compiles_every_layer(
     ]
 
 
-def test_qwen3_tts_engine_reenables_cuda_graph_after_bootstrap(
+def test_qwen3_tts_engine_applies_compat_overrides_and_reenables_cuda_graph(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Qwen3-TTS defers graph capture until custom buffers are ready."""
     install_fake_sglang(monkeypatch)
     from transformers import AutoProcessor
 
@@ -1681,6 +1679,19 @@ def test_qwen3_tts_engine_reenables_cuda_graph_after_bootstrap(
     from sglang_omni.scheduling import bootstrap as bootstrap_mod
     from sglang_omni.scheduling import omni_scheduler as scheduler_mod
     from sglang_omni.scheduling import sglang_backend
+    from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+    from transformers.utils import generic
+
+    check_model_inputs_calls = []
+
+    def transformers_56_check_model_inputs(func):
+        check_model_inputs_calls.append(func)
+        return f"wrapped:{func.__name__}"
+
+    monkeypatch.setattr(
+        generic, "check_model_inputs", transformers_56_check_model_inputs
+    )
+    monkeypatch.delitem(ROPE_INIT_FUNCTIONS, "default", raising=False)
 
     build_kwargs: dict = {}
     infrastructure_saw_graph_disabled: list[bool] = []
@@ -1789,12 +1800,41 @@ def test_qwen3_tts_engine_reenables_cuda_graph_after_bootstrap(
         lambda **kwargs: SimpleNamespace(**kwargs),
     )
 
-    scheduler = stages.create_sglang_tts_engine_executor("model", device="cuda:0")
+    scheduler = stages.create_sglang_tts_engine_executor(
+        "model",
+        device="cuda:0",
+        server_args_overrides={"mem_fraction_static": 0.7, "max_running_requests": 2},
+    )
 
     assert build_kwargs["disable_cuda_graph"] is False
     assert build_kwargs["enable_torch_compile"] is True
     assert build_kwargs["sampling_backend"] == "pytorch"
+    assert build_kwargs["mem_fraction_static"] == 0.7
+    assert build_kwargs["max_running_requests"] == 2
     assert build_kwargs["torch_compile_max_bs"] == 16
+
+    def target():
+        return None
+
+    decorator = generic.check_model_inputs()
+    assert decorator(target) == "wrapped:target"
+    assert generic.check_model_inputs(target) == "wrapped:target"
+    assert check_model_inputs_calls == [target, target]
+
+    inv_freq, attention_scaling = ROPE_INIT_FUNCTIONS["default"](
+        SimpleNamespace(
+            rope_theta=10000.0,
+            hidden_size=8,
+            num_attention_heads=2,
+        ),
+        None,
+    )
+    assert attention_scaling == 1.0
+    torch.testing.assert_close(
+        inv_freq,
+        torch.tensor([1.0, 0.01], dtype=torch.float32),
+    )
+
     assert infrastructure_saw_graph_disabled == [True]
     assert len(compile_calls) == 1
     assert init_graph_calls == [True]


### PR DESCRIPTION
## Motivation

Part of #658.

This PR moves the local SGLang Omni stack toward `sglang==0.5.12` and fixes the first set of compatibility regressions found during installation, unit testing, and local model smoke tests.

I noticed #677 and #679 are also working on the dependency bump, so this is intentionally positioned as supplemental runtime validation/fix work rather than a complete resolution of #658.

## Modifications

- Bump the pinned runtime stack:
  - `sglang==0.5.12`
  - `transformers==5.6.0`
  - `torch==2.11.0`
  - matching `torchvision`, `torchaudio`, and `torchcodec` versions.
- Restrict the Qwen3-VL patch allowlist to the revalidated SGLang `0.5.12` baseline.
- Update Qwen3-ASR request building for SGLang 0.5.12 multimodal behavior:
  - use inclusive multimodal offsets;
  - pass `feature_attention_mask` through `model_specific_data`.
- Remove the old Qwen3-Omni talker dense-MLP quantization workaround tied to SGLang 0.5.8.
- Fix unit-level compatibility regressions in:
  - Scheduler request-limit fixtures;
  - Higgs TTS request-builder timing test;
  - MOSS TTS CPU/unit-test sampling paths;
  - Ming legacy flash-attn symbol detection;
  - Qwen3 TTS Transformers 5 compatibility.
- Add Qwen3 TTS compatibility handling for Transformers 5 changes around:
  - `check_model_inputs`;
  - default RoPE initialization;
  - eager decode fallback when torch compile is disabled.
- Allow Qwen3 TTS engine startup to pass SGLang server-args overrides, which was needed for constrained-memory local smoke testing.

## Validation

Unit tests:

```bash
.venv-sglang-upgrade/bin/python -m pytest tests/unit_test -q
```

Result:

```text
1014 passed, 24 warnings
```

Local model smoke tests:

- Qwen3-ASR:
  - model: `Qwen3-ASR-1.7B`
  - result: request completed successfully and returned expected transcription-style text.
- Qwen3-TTS:
  - model: `Qwen3-TTS-12Hz-1.7B-Base`
  - endpoint: `/v1/audio/speech`
  - result: request completed successfully and produced a valid WAV response.
- Qwen3-Omni:
  - model: `Qwen3-Omni-30B-A3B-Instruct`
  - endpoint: `/v1/chat/completions`
  - result: text-only chat request completed successfully.


## Remaining Work

This PR does not claim to fully close #658. Remaining validation/work includes:

- broader Qwen3-Omni text/audio/video e2e validation;
- talker audio generation quality / WER checks;
- benchmark-style checks such as MMMU, MMSU, Video-MME, and Video-AMME where applicable;
- FP8 runtime validation if support is expected to remain unchanged;
- Blackwell CI coverage, if available.

## Related Issues

Refs #658.
