### PR TITLE
[Docs] Refresh Higgs TTS cookbook to align with the model card

### DIFF
--- a/docs/cookbook/higgs_tts.md
+++ b/docs/cookbook/higgs_tts.md
@@ -28,19 +28,6 @@ The model reaches **single-digit WER/CER on 100 languages**, which split into tw
 
 🇦🇱 Albanian · 🇲🇼🇿🇲 Chichewa/Nyanja · 🇮🇳🇵🇰 Eastern Punjabi · 🇺🇬 Ganda · 🇮🇸 Icelandic · 🇮🇪 Irish · 🇩🇿 Kabyle · 🇨🇻 Kabuverdianu · 🇰🇪 Kamba · 🇻🇦 Latin · 🇱🇺 Luxembourgish · 🇪🇹🇰🇪 Oromo · 🇦🇫🇵🇰 Pashto · 🇵🇰🇮🇳 Sindhi · 🇸🇴 Somali · 🇦🇴 Umbundu · 🇬🇧 Welsh
 
-## Control Tokens
-
-All tags follow `<|category:value|>` syntax and can be inserted mid-utterance.
-
-- **Emotion** — `elation`, `amusement`, `enthusiasm`, `determination`, `pride`, `contentment`, `affection`, `relief`, `contemplation`, `confusion`, `surprise`, `awe`, `longing`, `arousal`, `anger`, `fear`, `disgust`, `bitterness`, `sadness`, `shame`, `helplessness`
-- **Style** — `singing`, `shouting`, `whispering`
-- **Sound effects** — `cough`, `laughter`, `crying`, `screaming`, `burping`, `humming`, `sigh`, `sniff`, `sneeze`
-- **Prosody**
-  - Speed — `speed_very_slow` (&approx;0.65×), `speed_slow` (&approx;0.85×), `speed_fast` (&approx;1.2×), `speed_very_fast` (&approx;1.4×)
-  - Pauses — `pause` (&approx;400–700 ms), `long_pause` (&approx;700–1500 ms)
-  - Pitch — `pitch_low` (&approx;−3 st), `pitch_high` (&approx;+2.5 st)
-  - Delivery — `expressive_high`, `expressive_low`
-
 ## Evaluation Benchmarks
 
 ### Multilingual Voice Clone
@@ -286,10 +273,19 @@ Audio chunks have `"finish_reason": null` and carry audio data in `audio.data`. 
 
 ### Inline Control Tokens
 
-Embed control tokens directly in the `input` field. Tokens from different
-categories can be combined.
+All tags follow `<|category:value|>` syntax and can be inserted mid-utterance.
 
-Each request is a single **turn**, and two rules make control tokens reliable:
+- **Emotion** — `elation`, `amusement`, `enthusiasm`, `determination`, `pride`, `contentment`, `affection`, `relief`, `contemplation`, `confusion`, `surprise`, `awe`, `longing`, `arousal`, `anger`, `fear`, `disgust`, `bitterness`, `sadness`, `shame`, `helplessness`
+- **Style** — `singing`, `shouting`, `whispering`
+- **Sound effects** — `cough`, `laughter`, `crying`, `screaming`, `burping`, `humming`, `sigh`, `sniff`, `sneeze`
+- **Prosody**
+  - Speed — `speed_very_slow` (&approx;0.65×), `speed_slow` (&approx;0.85×), `speed_fast` (&approx;1.2×), `speed_very_fast` (&approx;1.4×)
+  - Pauses — `pause` (&approx;400–700 ms), `long_pause` (&approx;700–1500 ms)
+  - Pitch — `pitch_low` (&approx;−3 st), `pitch_high` (&approx;+2.5 st)
+  - Delivery — `expressive_high`, `expressive_low`
+
+Embed control tokens directly in the `input` field. Tokens from different
+categories can be combined. Each request is a single **turn**, and two rules make control tokens reliable:
 
 1. **Lead the turn with the delivery tokens.** Emotion (`<|emotion:…|>`), Style
    (`<|style:…|>`), and the prosody *speed* (`<|prosody:speed_…|>`), *pitch*
@@ -302,8 +298,7 @@ Each request is a single **turn**, and two rules make control tokens reliable:
 2. **Pair every sound effect with its onomatopoeia.** A `<|sfx:…|>` token lands
    best when the matching written sound follows it immediately
    (e.g. `<|sfx:laughter|>Haha`, `<|sfx:sigh|>Uh`, `<|sfx:sneeze|>Achoo`) — the
-   onomatopoeia gives the model the acoustic cue to realize the effect. See the
-   [Sound Effects](#sound-effects) table for suggested pairings.
+   onomatopoeia gives the model the acoustic cue to realize the effect.
 
 **Demo**
 
@@ -495,71 +490,6 @@ Reference output:
   <source src="../_static/audio/gaokao-listening.wav" type="audio/wav">
 </audio>
 
-#### Emotion
-
-| Token | Description |
-|---|---|
-| `<\|emotion:elation\|>` | Elation / joy |
-| `<\|emotion:amusement\|>` | Amusement / playful laughter |
-| `<\|emotion:enthusiasm\|>` | Enthusiasm / excitement |
-| `<\|emotion:determination\|>` | Determination / firmness |
-| `<\|emotion:pride\|>` | Pride / confidence |
-| `<\|emotion:contentment\|>` | Calm satisfaction |
-| `<\|emotion:affection\|>` | Warmth / affection |
-| `<\|emotion:relief\|>` | Relief |
-| `<\|emotion:contemplation\|>` | Thoughtful / reflective |
-| `<\|emotion:confusion\|>` | Confused |
-| `<\|emotion:surprise\|>` | Surprised |
-| `<\|emotion:awe\|>` | Awe / wonder |
-| `<\|emotion:longing\|>` | Longing / yearning |
-| `<\|emotion:arousal\|>` | Heightened desire |
-| `<\|emotion:anger\|>` | Anger |
-| `<\|emotion:fear\|>` | Fear |
-| `<\|emotion:disgust\|>` | Disgust |
-| `<\|emotion:bitterness\|>` | Bitterness |
-| `<\|emotion:sadness\|>` | Sadness |
-| `<\|emotion:shame\|>` | Shame |
-| `<\|emotion:helplessness\|>` | Helplessness |
-
-#### Style
-
-| Token | Description |
-|---|---|
-| `<\|style:singing\|>` | Singing |
-| `<\|style:shouting\|>` | Shouting / projected voice |
-| `<\|style:whispering\|>` | Whisper |
-
-#### Sound Effects
-
-Pair each token with the matching onomatopoeia immediately after it.
-
-| Token | Description | Suggested onomatopoeia |
-|---|---|---|
-| `<\|sfx:cough\|>` | Cough | Ahem |
-| `<\|sfx:laughter\|>` | Laughter | Haha / Hehe |
-| `<\|sfx:crying\|>` | Crying | Boohoo / Sob |
-| `<\|sfx:screaming\|>` | Screaming | Ahh / Aaah |
-| `<\|sfx:burping\|>` | Burping | Burp |
-| `<\|sfx:humming\|>` | Humming | Hmm / Mmm |
-| `<\|sfx:sigh\|>` | Sigh | Uh / Ahh |
-| `<\|sfx:sniff\|>` | Sniff | Sff |
-| `<\|sfx:sneeze\|>` | Sneeze | Achoo |
-
-#### Prosody
-
-| Token | Effect |
-|---|---|
-| `<\|prosody:speed_very_slow\|>` | ~0.65× speed |
-| `<\|prosody:speed_slow\|>` | ~0.85× speed |
-| `<\|prosody:speed_fast\|>` | ~1.2× speed |
-| `<\|prosody:speed_very_fast\|>` | ~1.4× speed |
-| `<\|prosody:pitch_low\|>` | ~−3 semitones |
-| `<\|prosody:pitch_high\|>` | ~+2.5 semitones |
-| `<\|prosody:pause\|>` | ~400–700 ms pause |
-| `<\|prosody:long_pause\|>` | ~700–1500 ms pause |
-| `<\|prosody:expressive_high\|>` | More expressive delivery |
-| `<\|prosody:expressive_low\|>` | Flatter delivery |
-
 ### Pre-encoded reference codes
 For high-throughput pipelines (e.g. RL rollout) where the same reference audio is reused across many requests, you can encode the reference audio offline and pass the discrete codes directly via `reference_codes` — this skips the server-side codec encode step. Shape must be `[T, num_codebooks=8]`.
 
@@ -595,12 +525,12 @@ resp = requests.post(
 
 ### Throughput
 
-Throughput on Seed-TTS EN (full set, 1088 samples). Each row is the mean of 3 complete runs (1088/1088 succeeded). Hardware: 1× H100.
+Throughput on Seed-TTS EN (full set, **N=1088** per run). Client `--max-concurrency` sweep against a Higgs server (`max_running_requests=16`, bf16, CUDA Graph on). Each row is the **mean of 3 runs**. Hardware: **1× H100**.
 
-| Concurrency | Mean latency | RTF (per-req) | audio_s/s |
-|---:|---:|---:|---:|
-| 1 | 617 ms | 0.147 | 6.89 |
-| 2 | 742 ms | 0.180 | 11.37 |
-| 4 | 733 ms | 0.177 | 22.84 |
-| 8 | 898 ms | 0.217 | 37.38 |
-| 16 | 1079 ms | 0.262 | 61.84 |
+| Concurrency | Throughput (req/s) | Mean latency | RTF (per-req) | audio_s/s |
+|---:|---:|---:|---:|---:|
+| 1 | 1.62 | 617 ms | 0.147 | 6.89 |
+| 2 | 2.70 | 742 ms | 0.180 | 11.37 |
+| 4 | 5.45 | 733 ms | 0.177 | 22.84 |
+| 8 | 8.91 | 898 ms | 0.217 | 37.38 |
+| 16 | 14.74 | 1079 ms | 0.262 | 61.84 |

--- a/docs/cookbook/higgs_tts.md
+++ b/docs/cookbook/higgs_tts.md
@@ -1,19 +1,7 @@
 # Higgs TTS
 
 [Higgs Audio v3 TTS](https://huggingface.co/bosonai/higgs-audio-v3-tts-4b)
-is a text-to-speech model from Boson AI built on a Qwen3-4B backbone. It generates
-24 kHz speech through 8 discrete codebooks and supports 100 languages, voice cloning from a
-reference clip, and fine-grained inline control over emotion, style, sound effects, and prosody.
-
-## Highlights
-
-- **Multilingual** — 100 languages with single-digit WER/CER
-- **Voice clone accuracy** — high-fidelity zero-shot speaker cloning from reference clips
-- **Inline control** via `<|emotion:…|>`, `<|style:…|>`, `<|sfx:…|>`, `<|prosody:…|>` tags
-
-The **100-language single-digit WER/CER** claim comes from our internal **Higgs-Multilingual** benchmark — an extension of FLEURS-102 covering 111 languages and dialects, of which Higgs Audio v3 TTS reaches single-digit WER/CER on 100.
-
-## Architecture
+is a text-to-speech model from Boson AI. It generates **24 kHz speech** and supports **100 languages**, voice cloning from a reference clip, and fine-grained **inline control** over emotion, style, sound effects, and prosody.
 
 ![Higgs Audio v3 Generation Architecture](../_static/image/higgs-architecture.png)
 
@@ -22,9 +10,62 @@ Higgs autoregressive decoder consumes interleaved text and audio tokens. Audio i
 | Component | Spec |
 |---|---|
 | Backbone | ~4B autoregressive decoder (36 L, hidden=2560, GQA 32/8) |
-| Audio tokens | 8 codebooks × 1026 vocab, delay pattern |
 | Multi-codebook embedding / head | Fused single-tensor, tied with text embedding |
 | Context length | 8,192 tokens (training sequence length) |
+| Audio tokens | 8 codebooks × 1026 vocab, delay pattern |
+| Sample rate | 24 kHz |
+| Frame rate | 25 fps (40 ms / frame) |
+
+## Supported Languages
+
+The model reaches **single-digit WER/CER on 100 languages**, which split into two tiers.
+
+### WER/CER under 5 — polished, production-quality (82)
+
+🇿🇦 Afrikaans · 🇸🇦🇪🇬 Arabic · 🇦🇲 Armenian · 🇮🇳 Assamese · 🇪🇸 Asturian · 🇦🇿 Azerbaijani · 🇷🇺 Bashkir · 🇪🇸 Basque · 🇧🇾 Belarusian · 🇧🇩🇮🇳 Bengali · 🇧🇦 Bosnian · 🇧🇬 Bulgarian · 🇪🇸 Catalan · 🇵🇭 Cebuano · 🇮🇶 Central Kurdish · 🇨🇳 Chinese · 🇭🇷 Croatian · 🇨🇿 Czech · 🇩🇰 Danish · 🇳🇱🇧🇪 Dutch · 🇷🇺 Eastern Mari · 🇺🇸🇬🇧🇦🇺 English · 🌐 Esperanto · 🇪🇪 Estonian · 🇫🇮 Finnish · 🇫🇷🇨🇦 French · 🇪🇸 Galician · 🇬🇪 Georgian · 🇩🇪🇦🇹 German · 🇬🇷 Greek · 🇮🇳 Gujarati · 🇭🇹 Haitian Creole · 🇳🇬 Hausa · 🇮🇱 Hebrew · 🇮🇳 Hindi · 🇭🇺 Hungarian · 🇮🇩 Indonesian · 🇮🇹 Italian · 🇮🇩 Javanese · 🇮🇳 Kannada · 🇰🇿 Kazakh · 🇷🇼 Kinyarwanda · 🇰🇬 Kyrgyz · 🇱🇻 Latvian · 🇨🇩 Lingala · 🇱🇹 Lithuanian · 🇰🇪 Luo · 🇲🇰 Macedonian · 🇲🇾🇮🇩 Malay · 🇮🇳 Malayalam · 🇲🇹 Maltese · 🇳🇿 Māori · 🇮🇳 Marathi · 🇲🇳 Mongolian · 🇳🇵 Nepali · 🇳🇴 Norwegian · 🇫🇷 Occitan · 🇮🇷🇦🇫 Persian · 🇵🇱 Polish · 🇵🇹🇧🇷 Portuguese · 🇷🇴 Romanian · 🇷🇺 Russian · 🇿🇦 Sepedi · 🇷🇸 Serbian · 🇿🇼 Shona · 🇸🇰 Slovak · 🇸🇮 Slovene · 🇪🇸🇲🇽 Spanish · 🇹🇿🇰🇪 Swahili · 🇸🇪 Swedish · 🇵🇭 Tagalog · 🇹🇯 Tajik · 🇮🇳🇱🇰 Tamil · 🇮🇳 Telugu · 🇹🇷 Turkish · 🇺🇦 Ukrainian · 🇵🇰🇮🇳 Urdu · 🇨🇳 Uyghur · 🇺🇿 Uzbek · 🇻🇳 Vietnamese · 🇿🇦 Xhosa · 🇿🇦 Zulu · 🇰🇷 Korean
+
+### WER/CER between 5 and 10 — usable, but less polished (18)
+
+🇦🇱 Albanian · 🇲🇼🇿🇲 Chichewa/Nyanja · 🇮🇳🇵🇰 Eastern Punjabi · 🇺🇬 Ganda · 🇮🇸 Icelandic · 🇮🇪 Irish · 🇩🇿 Kabyle · 🇨🇻 Kabuverdianu · 🇰🇪 Kamba · 🇻🇦 Latin · 🇱🇺 Luxembourgish · 🇪🇹🇰🇪 Oromo · 🇦🇫🇵🇰 Pashto · 🇵🇰🇮🇳 Sindhi · 🇸🇴 Somali · 🇦🇴 Umbundu · 🇬🇧 Welsh
+
+## Control Tokens
+
+All tags follow `<|category:value|>` syntax and can be inserted mid-utterance.
+
+- **Emotion** — `elation`, `amusement`, `enthusiasm`, `determination`, `pride`, `contentment`, `affection`, `relief`, `contemplation`, `confusion`, `surprise`, `awe`, `longing`, `arousal`, `anger`, `fear`, `disgust`, `bitterness`, `sadness`, `shame`, `helplessness`
+- **Style** — `singing`, `shouting`, `whispering`
+- **Sound effects** — `cough`, `laughter`, `crying`, `screaming`, `burping`, `humming`, `sigh`, `sniff`, `sneeze`
+- **Prosody**
+  - Speed — `speed_very_slow` (&approx;0.65×), `speed_slow` (&approx;0.85×), `speed_fast` (&approx;1.2×), `speed_very_fast` (&approx;1.4×)
+  - Pauses — `pause` (&approx;400–700 ms), `long_pause` (&approx;700–1500 ms)
+  - Pitch — `pitch_low` (&approx;−3 st), `pitch_high` (&approx;+2.5 st)
+  - Delivery — `expressive_high`, `expressive_low`
+
+## Evaluation Benchmarks
+
+### Multilingual Voice Clone
+
+We evaluate Higgs Audio v3 TTS on public multilingual TTS suites and our internal 111-language Higgs-Multilingual set, covering both common and lower-resource languages.
+
+WER / CER (↓, ×100) macro-averaged across each benchmark's language set. Lower is better; **bold** marks the best per row. All numbers are reproducible end-to-end with original metrics and normalization.
+
+| Benchmark | Higgs Audio v2 | Higgs Audio v3 | Fish Audio S2 Pro | Qwen3-TTS-1.7B | VibeVoice-7B | IndexTTS-2 | MiMo-Audio-7B-Instruct | MOSS-TTS-v1.5 | OmniVoice | ChatterBox | FireRedTTS-2 |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| SeedTTS | 2.10 | **1.11** | 1.31 | 1.30 | 3.59 | 1.63 | 3.70 | 1.73 | 1.21 | 17.00 | 1.72 |
+| CV3 | 21.19 | **4.41** | 4.60 | 7.73 | 11.66 | 129.26 | 71.55 | 6.11 | 4.92 | 32.62 | 19.20 |
+| MiniMax-Multilingual | 49.86 | **2.74** | 5.15 | 27.41 | 8.21 | 112.91 | 85.67 | 3.78 | 2.98 | 49.30 | 12.52 |
+| Higgs-Multilingual | 52.24 | **3.61** | 8.68 | 97.09 | 13.74 | 57.71 | 59.61 | 21.28 | 3.63 | 57.52 | 33.69 |
+
+### Emergent TTS
+
+Win-rate (↑) per category — judge preference vs the BASELINE row; **bold** marks the highest win-rate per column. For a fair comparison, every model shares the same reference audio per prompt, and we run the benchmark text verbatim — no inline control tags inserted.
+
+| Model | Overall ↑ | Emotions ↑ | Foreign Words ↑ | Paralinguistics ↑ | Complex Pronunciation ↑ | Questions ↑ | Syntactic Complexity ↑ |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Higgs Audio v3 | **53.65%** | 53.75% | **48.75%** | **68.57%** | 25.10% | **61.43%** | **60.71%** |
+| Fish Audio S2 Pro | 43.80% | 53.04% | 33.93% | 53.75% | 18.16% | 55.00% | 45.71% |
+| Qwen3-TTS-1.7B | 38.84% | 45.54% | 24.64% | 44.29% | **30.00%** | 53.39% | 34.11% |
+| OmniVoice | 40.82% | **61.07%** | 28.75% | 52.68% | 13.67% | 45.00% | 40.36% |
 
 ## Prerequisites
 
@@ -554,26 +595,12 @@ resp = requests.post(
 
 ### Throughput
 
-[TODO (yichi, Huapeng): This should be updated in the last minute.]
-
-Throughput on seed-tts en (N=50 per concurrency, sequential thread pool, A100 40GB, bf16):
+Throughput on Seed-TTS EN (full set, 1088 samples). Each row is the mean of 3 complete runs (1088/1088 succeeded). Hardware: 1× H100.
 
 | Concurrency | Mean latency | RTF (per-req) | audio_s/s |
 |---:|---:|---:|---:|
-| 1 | [—] | [—] | [—] |
-| 16 | [—] | [—] | [—] |
-| 32 | [—] | [—] | [—] |
-
-## Evaluation Benchmarks
-
-We report **WER / CER** (↓, %) and **WavLM speaker similarity** (↑, ×100) on the Seed-TTS zero-shot voice-cloning benchmark.
-
-### Seed-TTS
-
-| Lang | WER ↓ | SIM ↑ |
-|---|---|---|
-| en | [0.80] | [73.00] |
-| zh | [1.46] | [67.26] |
-| **macro** | **[1.13]** | **[70.13]** |
-
-Results are generated with SGLang Omni. WER/CER and speaker similarity follow the original text normalization and metric implementation from [seed-tts-eval](https://github.com/BytedanceSpeech/seed-tts-eval).
+| 1 | 617 ms | 0.147 | 6.89 |
+| 2 | 742 ms | 0.180 | 11.37 |
+| 4 | 733 ms | 0.177 | 22.84 |
+| 8 | 898 ms | 0.217 | 37.38 |
+| 16 | 1079 ms | 0.262 | 61.84 |


### PR DESCRIPTION
Aligns the Higgs TTS cookbook with the official model card and fills in measured numbers. Docs-only; no code changes.

### Changes
- Condense the intro and drop the redundant **Highlights** block.
- Add a **Supported Languages** section (100 languages, split into two WER/CER tiers).
- Present **control tokens** as compact per-category lists.
- Replace the eval section with the model-card comparison tables (**Multilingual Voice Clone** + **Emergent TTS**).
- Fill the **Throughput** table with measured Seed-TTS EN numbers (1× H100).

Rebased onto current `main`, so the PCM streaming controls from #655 are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)