### PR TITLE
Add support for pyAV-based mp3, aac, opus audio encoding

### DIFF
--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -274,7 +274,7 @@ The table below lists all parameters accepted by the `/v1/audio/speech` endpoint
 |---|---|---|---|
 | `input` | string | (required) | Text to synthesize |
 | `voice` | string | `"default"` | Voice identifier |
-| `response_format` | string | `"wav"` | Output audio format |
+| `response_format` | string | `"wav"` | Output audio format (`wav`, `mp3`, `flac`, `opus`, `aac`, `pcm`) |
 | `speed` | float | `1.0` | Playback speed multiplier |
 | `stream` | bool | `false` | Enable streaming via SSE |
 | `stream_format` | string | `"sse"` | Streaming transport. Use `"audio"` with `stream=true` and `response_format="pcm"` for raw PCM bytes; the response headers declare the stream sample rate, channel count, and bit depth |

--- a/docs/cookbook/higgs_tts.md
+++ b/docs/cookbook/higgs_tts.md
@@ -555,7 +555,7 @@ Pair each token with the matching onomatopoeia immediately after it.
 |---|---|---|---|
 | `input` | string | (required) | Text to synthesize |
 | `voice` | string | `"default"` | Voice identifier (ignored when `references` is set) |
-| `response_format` | string | `"wav"` | Output audio format |
+| `response_format` | string | `"wav"` | Output audio format (`wav`, `mp3`, `flac`, `opus`, `aac`, `pcm`) |
 | `stream` | bool | `false` | Enable streaming via SSE |
 | `references` | list | `null` | Reference audio for voice cloning; each item has `audio_path` (local path or HTTP URL) and `text` (transcript) |
 | `ref_audio` / `ref_text` | string | `null` | Shorthand for `references[0].audio_path` / `references[0].text` |

--- a/docs/cookbook/voxtral_tts.md
+++ b/docs/cookbook/voxtral_tts.md
@@ -110,7 +110,7 @@ Each event carries a base64-encoded audio chunk; the stream ends with `data: [DO
 | `input` | (required) | Text to synthesize |
 | `voice` | `cheerful_female` | Preset voice name from the checkpoint's `voice_embedding/` directory |
 | `max_new_tokens` | `4096` | Maximum number of generated acoustic tokens |
-| `response_format` | `wav` | Output container |
+| `response_format` | `wav` | Output container (`wav`, `mp3`, `flac`, `opus`, `aac`, `pcm`) |
 | `stream` | `false` | Stream audio chunks over SSE |
 
 > Voxtral generation is **deterministic**: the engine fixes `temperature` to `0.0`, so sampling

--- a/sglang_omni/client/audio.py
+++ b/sglang_omni/client/audio.py
@@ -30,6 +30,52 @@ FORMAT_MIME_TYPES: dict[str, str] = {
 # Default sample rate for generated audio
 DEFAULT_SAMPLE_RATE = 24000
 
+# Configurations for PyAV encoding
+PYAV_ENCODE_CONFIGS = {
+    "opus": {
+        "container": "ogg",
+        "codecs": ("libopus", "opus"),
+        "valid_rates": {8000, 12000, 16000, 24000, 48000},
+    },
+    "aac": {
+        "container": "adts",
+        "codecs": ("aac",),
+        "valid_rates": {
+            7350,
+            8000,
+            11025,
+            12000,
+            16000,
+            22050,
+            24000,
+            32000,
+            44100,
+            48000,
+            64000,
+            88200,
+            96000,
+        },
+    },
+    "mp3": {
+        "container": "mp3",
+        "codecs": ("libmp3lame", "mp3"),
+        "valid_rates": {
+            8000,
+            11025,
+            12000,
+            16000,
+            22050,
+            24000,
+            32000,
+            44100,
+            48000,
+            64000,
+            88200,
+            96000,
+        },
+    },
+}
+
 
 def to_numpy(audio: Any) -> np.ndarray:
     """Convert audio data to a numpy float32 array.
@@ -123,6 +169,70 @@ def encode_wav(audio: np.ndarray, sample_rate: int) -> bytes:
     return buf.getvalue()
 
 
+def _resample_linear(audio: np.ndarray, orig_sr: int, target_sr: int) -> np.ndarray:
+    if orig_sr == target_sr:
+        return audio.astype(np.float32, copy=False)
+    if audio.size == 0:
+        return audio.astype(np.float32, copy=False)
+    duration = audio.shape[0] / float(orig_sr)
+    new_len = max(int(round(duration * target_sr)), 1)
+    old_idx = np.arange(audio.shape[0], dtype=np.float64)
+    new_idx = np.linspace(0.0, audio.shape[0] - 1, num=new_len, dtype=np.float64)
+    return np.interp(new_idx, old_idx, audio).astype(np.float32)
+
+
+def _encode_with_pyav(
+    audio: np.ndarray,
+    sample_rate: int,
+    container_format: str,
+    codecs: tuple[str, ...],
+    valid_rates: set[int],
+) -> bytes:
+    import io
+
+    import av
+
+    if sample_rate not in valid_rates:
+        nearest_rate = min(valid_rates, key=lambda r: abs(r - sample_rate))
+        audio = _resample_linear(audio, sample_rate, nearest_rate)
+        sample_rate = nearest_rate
+
+    buf = io.BytesIO()
+    container = av.open(buf, mode="w", format=container_format)
+
+    stream = None
+    for codec in codecs:
+        try:
+            stream = container.add_stream(codec, rate=sample_rate)
+            break
+        except av.CodecError:
+            continue
+
+    if stream is None:
+        container.close()
+        codecs_str = "', '".join(codecs)
+        raise RuntimeError(
+            f"None of the codecs ('{codecs_str}') are supported by PyAV."
+        )
+
+    stream.layout = "mono"
+
+    # FFmpeg expects float-planar (fltp) format for these codecs
+    frame = av.AudioFrame.from_ndarray(
+        audio.reshape(1, -1), format="fltp", layout="mono"
+    )
+    frame.sample_rate = sample_rate
+
+    for packet in stream.encode(frame):
+        container.mux(packet)
+
+    for packet in stream.encode(None):
+        container.mux(packet)
+
+    container.close()
+    return buf.getvalue()
+
+
 def encode_pcm(audio: np.ndarray, sample_rate: int) -> bytes:
     """Encode audio as raw 16-bit PCM bytes."""
     audio = np.clip(audio, -1.0, 1.0)
@@ -173,22 +283,24 @@ def encode_audio(
     if fmt == "pcm":
         return encode_pcm(arr, sample_rate), mime
 
-    if fmt in ("mp3", "flac", "opus", "aac"):
-        # Try soundfile for FLAC
-        if fmt == "flac":
-            try:
-                import soundfile as sf
+    if fmt in ("opus", "aac", "mp3"):
+        try:
+            config = PYAV_ENCODE_CONFIGS[fmt]
+            encoded_bytes = _encode_with_pyav(
+                arr,
+                sample_rate,
+                container_format=config["container"],
+                codecs=config["codecs"],
+                valid_rates=config["valid_rates"],
+            )
+            return encoded_bytes, mime
+        except Exception as e:
+            logger.warning(
+                "PyAV %s encoding failed (%s); falling back to pydub/WAV",
+                fmt.upper(),
+                str(e),
+            )
 
-                buf = io.BytesIO()
-                sf.write(buf, arr, sample_rate, format="FLAC")
-                return buf.getvalue(), mime
-            except ImportError:
-                logger.warning(
-                    "soundfile not installed; falling back to WAV for FLAC request"
-                )
-                return encode_wav(arr, sample_rate), FORMAT_MIME_TYPES["wav"]
-
-        # Try pydub for MP3/AAC/OPUS
         try:
             from pydub import AudioSegment
 
@@ -201,6 +313,19 @@ def encode_audio(
         except ImportError:
             logger.warning(
                 "pydub not installed; falling back to WAV for %s request", fmt
+            )
+            return encode_wav(arr, sample_rate), FORMAT_MIME_TYPES["wav"]
+
+    if fmt == "flac":
+        try:
+            import soundfile as sf
+
+            buf = io.BytesIO()
+            sf.write(buf, arr, sample_rate, format="FLAC")
+            return buf.getvalue(), mime
+        except ImportError:
+            logger.warning(
+                "soundfile not installed; falling back to WAV for FLAC request"
             )
             return encode_wav(arr, sample_rate), FORMAT_MIME_TYPES["wav"]
 

--- a/tests/unit_test/client/test_audio.py
+++ b/tests/unit_test/client/test_audio.py
@@ -1,0 +1,144 @@
+import numpy as np
+
+from sglang_omni.client.audio import (
+    FORMAT_MIME_TYPES,
+    audio_to_base64,
+    encode_audio,
+    encode_pcm,
+    encode_wav,
+    to_numpy,
+)
+
+
+def test_to_numpy():
+    # Numpy array
+    arr = np.array([0.1, -0.2, 0.3], dtype=np.float32)
+    res = to_numpy(arr)
+    assert np.allclose(arr, res)
+    assert res.dtype == np.float32
+
+    # List/tuple
+    res_list = to_numpy([0.1, -0.2, 0.3])
+    assert np.allclose(arr, res_list)
+    assert res_list.dtype == np.float32
+
+    # PCM16 bytes
+    pcm_bytes = b"\x00\x00\x00\x40\x00\x80"  # [0, 16384, -32768] in int16
+    expected = np.array([0.0, 0.5, -1.0], dtype=np.float32)
+    res_bytes = to_numpy(pcm_bytes)
+    assert np.allclose(expected, res_bytes, atol=1e-4)
+
+
+def test_encode_wav():
+    # Generate 1 sec sine wave
+    sr = 24000
+    t = np.linspace(0, 1, sr, endpoint=False)
+    audio = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+
+    wav_bytes = encode_wav(audio, sr)
+    assert isinstance(wav_bytes, bytes)
+    assert wav_bytes.startswith(b"RIFF")
+    assert b"WAVE" in wav_bytes[:16]
+
+
+def test_encode_pcm():
+    audio = np.array([0.0, 0.5, -1.0, 1.2], dtype=np.float32)
+    pcm_bytes = encode_pcm(audio, 16000)
+    assert isinstance(pcm_bytes, bytes)
+    # Check expected int16 values (clamped to [-1, 1]): [0, 16383, -32767, 32767]
+    expected = np.array([0, 16383, -32767, 32767], dtype=np.int16)
+    actual = np.frombuffer(pcm_bytes, dtype=np.int16)
+    assert np.array_equal(expected, actual)
+
+
+def test_encode_audio_opus():
+    sr = 24000
+    t = np.linspace(0, 1, sr, endpoint=False)
+    audio = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+
+    encoded_bytes, mime = encode_audio(audio, response_format="opus", sample_rate=sr)
+    assert mime == FORMAT_MIME_TYPES["opus"]
+    try:
+        assert encoded_bytes.startswith(b"OggS")
+    except ImportError:
+        assert encoded_bytes.startswith(b"RIFF")
+
+
+def test_encode_audio_opus_resampling():
+    sr = 44100  # invalid sample rate for Opus
+    t = np.linspace(0, 1, sr, endpoint=False)
+    audio = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+
+    encoded_bytes, mime = encode_audio(audio, response_format="opus", sample_rate=sr)
+    assert mime == FORMAT_MIME_TYPES["opus"]
+    try:
+        assert encoded_bytes.startswith(b"OggS")
+    except ImportError:
+        assert encoded_bytes.startswith(b"RIFF")
+
+
+def test_encode_audio_aac():
+    sr = 24000
+    t = np.linspace(0, 1, sr, endpoint=False)
+    audio = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+
+    encoded_bytes, mime = encode_audio(audio, response_format="aac", sample_rate=sr)
+    assert mime == FORMAT_MIME_TYPES["aac"]
+    try:
+        assert encoded_bytes[0] == 0xFF
+        assert (encoded_bytes[1] & 0xF0) == 0xF0
+    except ImportError:
+        assert encoded_bytes.startswith(b"RIFF")
+
+
+def test_encode_audio_aac_resampling():
+    sr = 12345  # invalid sample rate for AAC
+    t = np.linspace(0, 1, sr, endpoint=False)
+    audio = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+
+    encoded_bytes, mime = encode_audio(audio, response_format="aac", sample_rate=sr)
+    assert mime == FORMAT_MIME_TYPES["aac"]
+    try:
+        assert encoded_bytes[0] == 0xFF
+        assert (encoded_bytes[1] & 0xF0) == 0xF0
+    except ImportError:
+        assert encoded_bytes.startswith(b"RIFF")
+
+
+def test_encode_audio_mp3():
+    sr = 24000
+    t = np.linspace(0, 1, sr, endpoint=False)
+    audio = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+
+    encoded_bytes, mime = encode_audio(audio, response_format="mp3", sample_rate=sr)
+    assert mime == FORMAT_MIME_TYPES["mp3"]
+    try:
+        assert encoded_bytes.startswith(b"ID3")
+    except ImportError:
+        assert encoded_bytes.startswith(b"RIFF")
+
+
+def test_encode_audio_mp3_resampling():
+    sr = 12345  # invalid sample rate for MP3
+    t = np.linspace(0, 1, sr, endpoint=False)
+    audio = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+
+    encoded_bytes, mime = encode_audio(audio, response_format="mp3", sample_rate=sr)
+    assert mime == FORMAT_MIME_TYPES["mp3"]
+    try:
+        assert encoded_bytes.startswith(b"ID3")
+    except ImportError:
+        assert encoded_bytes.startswith(b"RIFF")
+
+
+def test_audio_to_base64():
+    audio = np.array([0.0, 0.1, -0.1], dtype=np.float32)
+    b64_str = audio_to_base64(audio, sample_rate=16000, output_format="pcm")
+    assert isinstance(b64_str, str)
+    # Decode to check
+    import base64
+
+    pcm_bytes = base64.b64decode(b64_str)
+    actual = np.frombuffer(pcm_bytes, dtype=np.int16)
+    expected = (audio * 32767.0).astype(np.int16)
+    assert np.array_equal(expected, actual)


### PR DESCRIPTION
## Motivation

Add PyAV-based encoding for opus/mp3/aac formats, replacing #667 

## Modifications
- Unit test: client/test_audio.py
- pyav-based helper method in audio.py for opus/mp3/aac encoding from generated waveforms
- Update to TTS docs with newly added format

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.