### PR TITLE
[RL admin] Security, correctness, and API clarity fixes

### DIFF
--- a/sglang_omni/model_runner/weight_checker.py
+++ b/sglang_omni/model_runner/weight_checker.py
@@ -4,9 +4,12 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import time
 from dataclasses import dataclass
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -86,9 +89,24 @@ class StrictWeightChecker:
         if model is None:
             raise RuntimeError("model_runner has no model for weights_checker")
 
+        # SHA256 hashing iterates every parameter and buffer, copying each tensor to CPU.
+        # This is O(total model size in bytes) and blocks the model worker for the full
+        # duration — inference requests are stalled while this runs. For large models
+        # (e.g. 70B at bf16 ≈ 140 GB) expect tens of seconds to several minutes.
+        logger.warning(
+            "weights_checker: starting full-model SHA256 digest — "
+            "inference is blocked until this completes. "
+            "Elapsed time will be reported in the response."
+        )
+        t0 = time.time()
         digests: dict[str, TensorDigest] = {}
         for name, tensor in self._iter_named_tensors(model):
             digests[name] = _digest_tensor(name, tensor)
+        logger.warning(
+            "weights_checker: digest complete — %d tensors in %.1fs",
+            len(digests),
+            time.time() - t0,
+        )
         return digests
 
     @staticmethod

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -16,11 +16,12 @@ from __future__ import annotations
 import base64
 import json
 import logging
+import os
 import time
 import uuid
 from typing import Any
 
-from fastapi import FastAPI, File, Form, HTTPException, UploadFile, WebSocket
+from fastapi import Depends, FastAPI, File, Form, Header, HTTPException, UploadFile, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import (
     JSONResponse,
@@ -84,11 +85,36 @@ def _is_bad_request_error(exc: Exception) -> bool:
     return any(marker in message for marker in _BAD_REQUEST_MARKERS)
 
 
+def _make_admin_auth_dep(admin_api_key: str | None):
+    """Return a FastAPI dependency that enforces Bearer token auth when a key is configured."""
+    if not admin_api_key:
+
+        async def _no_auth() -> None:
+            return
+
+        return _no_auth
+
+    async def _check_admin_key(
+        authorization: str | None = Header(default=None),
+    ) -> None:
+        if not authorization or not authorization.startswith("Bearer "):
+            raise HTTPException(
+                status_code=401,
+                detail="Admin API key required: Authorization: Bearer <key>",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        if authorization[7:] != admin_api_key:
+            raise HTTPException(status_code=403, detail="Invalid admin API key")
+
+    return _check_admin_key
+
+
 def create_app(
     client: Client,
     *,
     model_name: str | None = None,
     enable_realtime: bool = False,
+    admin_api_key: str | None = None,
 ) -> FastAPI:
     """Create a FastAPI application with OpenAI-compatible endpoints.
 
@@ -116,11 +142,13 @@ def create_app(
     app.state.model_name = model_name or "sglang-omni"
     app.state.realtime_enabled = enable_realtime
 
+    resolved_key = admin_api_key or os.environ.get("SGLANG_OMNI_ADMIN_KEY") or None
+
     # Register all routes
     register_favicon(app)
     _register_health(app)
     _register_models(app)
-    _register_admin(app)
+    _register_admin(app, resolved_key)
     _register_chat_completions(app)
     _register_speech(app)
     _register_transcriptions(app)
@@ -164,13 +192,15 @@ def _register_models(app: FastAPI) -> None:
         return JSONResponse(content=model_list.model_dump())
 
 
-def _register_admin(app: FastAPI) -> None:
-    @app.get("/model_info")
+def _register_admin(app: FastAPI, admin_api_key: str | None = None) -> None:
+    _auth = _make_admin_auth_dep(admin_api_key)
+
+    @app.get("/model_info", dependencies=[Depends(_auth)])
     async def model_info_get() -> JSONResponse:
         client: Client = app.state.client
         return _model_info_response(await client.model_info())
 
-    @app.post("/model_info")
+    @app.post("/model_info", dependencies=[Depends(_auth)])
     async def model_info_post(req: AdminRequestBase) -> JSONResponse:
         client: Client = app.state.client
         return _model_info_response(
@@ -180,7 +210,7 @@ def _register_admin(app: FastAPI) -> None:
             )
         )
 
-    @app.post("/pause_generation")
+    @app.post("/pause_generation", dependencies=[Depends(_auth)])
     async def pause_generation(req: PauseGenerationRequest) -> JSONResponse:
         client: Client = app.state.client
         payload = _request_payload(req)
@@ -192,7 +222,7 @@ def _register_admin(app: FastAPI) -> None:
             )
         )
 
-    @app.post("/continue_generation")
+    @app.post("/continue_generation", dependencies=[Depends(_auth)])
     async def continue_generation(req: ContinueGenerationRequest) -> JSONResponse:
         client: Client = app.state.client
         payload = _request_payload(req)
@@ -204,7 +234,7 @@ def _register_admin(app: FastAPI) -> None:
             )
         )
 
-    @app.post("/update_weights_from_disk")
+    @app.post("/update_weights_from_disk", dependencies=[Depends(_auth)])
     async def update_weights_from_disk(
         req: UpdateWeightFromDiskRequest,
     ) -> JSONResponse:
@@ -218,42 +248,48 @@ def _register_admin(app: FastAPI) -> None:
             )
         )
 
-    @app.post("/update_weights_from_tensor")
+    @app.post("/update_weights_from_tensor", dependencies=[Depends(_auth)])
     async def update_weights_from_tensor(
         req: UpdateWeightsFromTensorRequest,
     ) -> JSONResponse:
-        client: Client = app.state.client
-        payload = _request_payload(req)
-        return _admin_response(
-            await client.admin(
-                "update_weights_from_tensor",
-                payload,
-                stages=req.stages,
-                timeout_s=req.timeout_s or 120.0,
-            )
+        # Tensor data plane not yet implemented; only metadata/control hooks are wired.
+        return JSONResponse(
+            status_code=501,
+            content={
+                "error": {
+                    "message": (
+                        "update_weights_from_tensor is not yet implemented. "
+                        "Use update_weights_from_disk for the disk-based weight update path."
+                    ),
+                    "code": "not_implemented",
+                }
+            },
         )
 
-    @app.post("/update_weights_from_distributed")
+    @app.post("/update_weights_from_distributed", dependencies=[Depends(_auth)])
     async def update_weights_from_distributed(
         req: UpdateWeightsFromDistributedRequest,
     ) -> JSONResponse:
-        client: Client = app.state.client
-        payload = _request_payload(req)
-        return _admin_response(
-            await client.admin(
-                "update_weights_from_distributed",
-                payload,
-                stages=req.stages,
-                timeout_s=req.timeout_s or 120.0,
-            )
+        # Distributed data plane not yet implemented; only metadata/control hooks are wired.
+        return JSONResponse(
+            status_code=501,
+            content={
+                "error": {
+                    "message": (
+                        "update_weights_from_distributed is not yet implemented. "
+                        "Use update_weights_from_disk for the disk-based weight update path."
+                    ),
+                    "code": "not_implemented",
+                }
+            },
         )
 
-    @app.get("/weights_checker")
+    @app.get("/weights_checker", dependencies=[Depends(_auth)])
     async def weights_checker_get(action: str = "checksum") -> JSONResponse:
         client: Client = app.state.client
         return _admin_response(await client.weights_checker({"action": action}))
 
-    @app.post("/weights_checker")
+    @app.post("/weights_checker", dependencies=[Depends(_auth)])
     async def weights_checker_post(req: WeightsCheckerRequest) -> JSONResponse:
         client: Client = app.state.client
         payload = _request_payload(req)

--- a/sglang_omni_router/app.py
+++ b/sglang_omni_router/app.py
@@ -6,12 +6,13 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 from contextlib import asynccontextmanager
 from typing import Any
 from urllib.parse import unquote
 
 import httpx
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, Header, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response
 from pydantic import ValidationError
@@ -33,9 +34,39 @@ logger = logging.getLogger(__name__)
 _ADMIN_UPDATE_PATHS = {
     "/pause_generation",
     "/update_weights_from_disk",
+}
+# Seconds to wait for the admin_update_lock before giving up; prevents a hung
+# weight-update from blocking all subsequent admin requests indefinitely.
+_ADMIN_UPDATE_LOCK_TIMEOUT_S = 300.0
+
+_ADMIN_UNIMPLEMENTED_PATHS = {
     "/update_weights_from_tensor",
     "/update_weights_from_distributed",
 }
+
+
+def _make_admin_auth_dep(admin_api_key: str | None):
+    """Return a FastAPI dependency that enforces Bearer token auth when a key is set."""
+    if not admin_api_key:
+
+        async def _no_auth() -> None:
+            return
+
+        return _no_auth
+
+    async def _check_admin_key(
+        authorization: str | None = Header(default=None),
+    ) -> None:
+        if not authorization or not authorization.startswith("Bearer "):
+            raise HTTPException(
+                status_code=401,
+                detail="Admin API key required: Authorization: Bearer <key>",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        if authorization[7:] != admin_api_key:
+            raise HTTPException(status_code=403, detail="Invalid admin API key")
+
+    return _check_admin_key
 
 
 def create_app(
@@ -43,6 +74,7 @@ def create_app(
     *,
     client: httpx.AsyncClient | None = None,
     health_client: httpx.AsyncClient | None = None,
+    admin_api_key: str | None = None,
 ) -> FastAPI:
     workers = build_workers(config.workers)
     timeout = httpx.Timeout(config.request_timeout_secs)
@@ -95,6 +127,8 @@ def create_app(
             if owns_client:
                 await client.aclose()
 
+    resolved_key = admin_api_key or os.environ.get("SGLANG_OMNI_ADMIN_KEY") or None
+
     app = FastAPI(title="sglang-omni-router", version="0.1.0", lifespan=lifespan)
     app.add_middleware(
         CORSMiddleware,
@@ -104,7 +138,7 @@ def create_app(
         allow_headers=["*"],
     )
 
-    register_routes(app, workers, proxy, config)
+    register_routes(app, workers, proxy, config, admin_api_key=resolved_key)
     register_favicon(app)
     return app
 
@@ -114,7 +148,22 @@ def register_routes(
     workers: list[Worker],
     proxy: ProxyHandler,
     config: RouterConfig,
+    *,
+    admin_api_key: str | None = None,
 ) -> None:
+    _auth = _make_admin_auth_dep(admin_api_key)
+    _not_implemented_response = JSONResponse(
+        status_code=501,
+        content={
+            "error": {
+                "message": (
+                    "This weight update path is not yet implemented. "
+                    "Use /update_weights_from_disk for the disk-based update path."
+                ),
+                "code": "not_implemented",
+            }
+        },
+    )
     @app.get("/live")
     async def live() -> JSONResponse:
         return JSONResponse({"status": "alive"})
@@ -282,23 +331,23 @@ def register_routes(
             timeout_secs=config.health_check_timeout_secs,
         )
 
-    @app.get("/model_info")
+    @app.get("/model_info", dependencies=[Depends(_auth)])
     async def model_info(request: Request) -> JSONResponse:
         return await _broadcast_admin_request(app, request, "/model_info")
 
-    @app.post("/model_info")
+    @app.post("/model_info", dependencies=[Depends(_auth)])
     async def model_info_post(request: Request) -> JSONResponse:
         return await _broadcast_admin_request(app, request, "/model_info")
 
-    @app.post("/pause_generation")
+    @app.post("/pause_generation", dependencies=[Depends(_auth)])
     async def pause_generation(request: Request) -> JSONResponse:
         return await _broadcast_admin_request(app, request, "/pause_generation")
 
-    @app.post("/continue_generation")
+    @app.post("/continue_generation", dependencies=[Depends(_auth)])
     async def continue_generation(request: Request) -> JSONResponse:
         return await _broadcast_admin_request(app, request, "/continue_generation")
 
-    @app.post("/update_weights_from_disk")
+    @app.post("/update_weights_from_disk", dependencies=[Depends(_auth)])
     async def update_weights_from_disk(request: Request) -> JSONResponse:
         return await _broadcast_admin_request(
             app,
@@ -306,23 +355,15 @@ def register_routes(
             "/update_weights_from_disk",
         )
 
-    @app.post("/update_weights_from_tensor")
+    @app.post("/update_weights_from_tensor", dependencies=[Depends(_auth)])
     async def update_weights_from_tensor(request: Request) -> JSONResponse:
-        return await _broadcast_admin_request(
-            app,
-            request,
-            "/update_weights_from_tensor",
-        )
+        return _not_implemented_response
 
-    @app.post("/update_weights_from_distributed")
+    @app.post("/update_weights_from_distributed", dependencies=[Depends(_auth)])
     async def update_weights_from_distributed(request: Request) -> JSONResponse:
-        return await _broadcast_admin_request(
-            app,
-            request,
-            "/update_weights_from_distributed",
-        )
+        return _not_implemented_response
 
-    @app.api_route("/weights_checker", methods=["GET", "POST"])
+    @app.api_route("/weights_checker", methods=["GET", "POST"], dependencies=[Depends(_auth)])
     async def weights_checker(request: Request) -> JSONResponse:
         return await _broadcast_admin_request(app, request, "/weights_checker")
 
@@ -392,7 +433,18 @@ async def _broadcast_admin_request(
         return _error_response(503, "no live upstream workers")
 
     if path in _ADMIN_UPDATE_PATHS:
-        async with app.state.admin_update_lock:
+        try:
+            await asyncio.wait_for(
+                app.state.admin_update_lock.acquire(),
+                timeout=_ADMIN_UPDATE_LOCK_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            return _error_response(
+                503,
+                f"admin update lock not acquired within {_ADMIN_UPDATE_LOCK_TIMEOUT_S:.0f}s; "
+                "another update operation may be in progress",
+            )
+        try:
             return await _broadcast_admin_request_locked(
                 app,
                 request,
@@ -400,6 +452,9 @@ async def _broadcast_admin_request(
                 target_workers,
                 disable_targets=True,
             )
+        finally:
+            app.state.admin_update_lock.release()
+
     return await _broadcast_admin_request_locked(
         app,
         request,

--- a/sglang_omni_router/serve.py
+++ b/sglang_omni_router/serve.py
@@ -86,6 +86,16 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--health-check-interval-secs", type=int, default=10)
     parser.add_argument("--health-check-endpoint", default="/health")
     parser.add_argument("--log-level", default="info")
+    parser.add_argument(
+        "--admin-api-key",
+        default=None,
+        help=(
+            "Bearer token required for all admin endpoints "
+            "(pause_generation, update_weights_from_disk, weights_checker, etc.). "
+            "Can also be set via the SGLANG_OMNI_ADMIN_KEY environment variable. "
+            "If neither is set, admin endpoints are unauthenticated."
+        ),
+    )
     return parser
 
 
@@ -197,7 +207,7 @@ def main(argv: Sequence[str] | None = None) -> None:
             f"readiness_requires_routable_worker=true"
         )
         uvicorn.run(
-            create_app(config),
+            create_app(config, admin_api_key=getattr(args, "admin_api_key", None)),
             host=config.host,
             port=config.port,
             log_level=log_level.lower(),

--- a/tests/unit_test/router/test_app.py
+++ b/tests/unit_test/router/test_app.py
@@ -1668,3 +1668,194 @@ def test_payload_without_content_length_is_rejected_while_streaming_body() -> No
 
     assert response.status_code == 413
     assert seen_paths == []
+
+
+# ---------------------------------------------------------------------------
+# Admin auth tests — router
+# ---------------------------------------------------------------------------
+
+_ROUTER_ADMIN_PATHS = [
+    ("GET", "/model_info"),
+    ("POST", "/model_info"),
+    ("POST", "/pause_generation"),
+    ("POST", "/continue_generation"),
+    ("POST", "/update_weights_from_disk"),
+    ("POST", "/update_weights_from_tensor"),
+    ("POST", "/update_weights_from_distributed"),
+    ("GET", "/weights_checker"),
+    ("POST", "/weights_checker"),
+]
+
+
+def _admin_router_app(admin_api_key: str | None = None) -> "FastAPI":
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "healthy"}, request=request)
+        if request.url.path in ("/model_info", "/weights_checker"):
+            return httpx.Response(
+                200,
+                json={
+                    "success": True,
+                    "message": "ok",
+                    "results": [],
+                    "weight_version": "v1",
+                    "model_path": "/tmp/m",
+                    "load_format": "safetensors",
+                },
+                request=request,
+            )
+        return httpx.Response(200, json={"success": True, "message": "ok", "results": []}, request=request)
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    return create_app(
+        _router_config(),
+        client=async_client,
+        admin_api_key=admin_api_key,
+    )
+
+
+def test_router_admin_routes_open_without_key() -> None:
+    """Admin routes are accessible with no auth header when no key is configured."""
+    app = _admin_router_app(admin_api_key=None)
+    with TestClient(app) as client:
+        resp = client.get("/model_info")
+        assert resp.status_code == 200
+
+
+def test_router_admin_routes_require_bearer_when_key_set() -> None:
+    app = _admin_router_app(admin_api_key="router-secret")
+    with TestClient(app) as client:
+        for method, path in _ROUTER_ADMIN_PATHS:
+            resp = client.request(method, path, json={})
+            assert resp.status_code == 401, (
+                f"{method} {path} expected 401, got {resp.status_code}"
+            )
+            assert "WWW-Authenticate" in resp.headers
+
+
+def test_router_admin_routes_reject_wrong_token() -> None:
+    app = _admin_router_app(admin_api_key="router-secret")
+    with TestClient(app) as client:
+        resp = client.get(
+            "/model_info", headers={"Authorization": "Bearer wrong"}
+        )
+        assert resp.status_code == 403
+
+
+def test_router_admin_routes_accept_correct_token() -> None:
+    app = _admin_router_app(admin_api_key="router-secret")
+    with TestClient(app) as client:
+        resp = client.get(
+            "/model_info", headers={"Authorization": "Bearer router-secret"}
+        )
+        assert resp.status_code == 200
+
+
+def test_router_admin_env_key(monkeypatch) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_ADMIN_KEY", "env-router-key")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "healthy"}, request=request)
+        return httpx.Response(
+            200,
+            json={"success": True, "message": "ok", "results": [], "weight_version": None, "model_path": None, "load_format": None},
+            request=request,
+        )
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(_router_config(), client=async_client)
+
+    with TestClient(app) as client:
+        assert client.get("/model_info").status_code == 401
+        resp = client.get(
+            "/model_info", headers={"Authorization": "Bearer env-router-key"}
+        )
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Router stub endpoint 501 tests
+# ---------------------------------------------------------------------------
+
+
+def test_router_update_weights_from_tensor_returns_501() -> None:
+    app = _admin_router_app()
+    with TestClient(app) as client:
+        resp = client.post("/update_weights_from_tensor", json={})
+    assert resp.status_code == 501
+    assert resp.json()["error"]["code"] == "not_implemented"
+
+
+def test_router_update_weights_from_distributed_returns_501() -> None:
+    app = _admin_router_app()
+    with TestClient(app) as client:
+        resp = client.post(
+            "/update_weights_from_distributed",
+            json={"names": [], "dtypes": [], "shapes": []},
+        )
+    assert resp.status_code == 501
+    assert resp.json()["error"]["code"] == "not_implemented"
+
+
+# ---------------------------------------------------------------------------
+# Router admin_update_lock timeout test
+# ---------------------------------------------------------------------------
+
+
+def test_router_admin_update_lock_timeout_returns_503() -> None:
+    """If the lock is held beyond timeout, the request returns 503."""
+    import asyncio as _asyncio
+
+    from sglang_omni_router.app import _ADMIN_UPDATE_LOCK_TIMEOUT_S, _broadcast_admin_request
+
+    async def _run():
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/health":
+                return httpx.Response(200, json={"status": "healthy"}, request=request)
+            return httpx.Response(200, json={"success": True, "message": "ok", "results": []}, request=request)
+
+        async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        app = create_app(_router_config(), client=async_client)
+
+        # Simulate a held lock by acquiring it before the request
+        async with app.router.lifespan_context(app):
+            lock = app.state.admin_update_lock
+            await lock.acquire()  # hold it — simulate a stuck update
+
+            # Temporarily shrink timeout so the test runs fast
+            import sglang_omni_router.app as _app_mod
+            original = _app_mod._ADMIN_UPDATE_LOCK_TIMEOUT_S
+            _app_mod._ADMIN_UPDATE_LOCK_TIMEOUT_S = 0.05
+            try:
+                from starlette.testclient import TestClient as _TC
+                from fastapi import Request as _Req
+                import io
+
+                scope = {
+                    "type": "http",
+                    "method": "POST",
+                    "path": "/update_weights_from_disk",
+                    "headers": [(b"content-type", b"application/json")],
+                    "query_string": b"",
+                    "scheme": "http",
+                    "server": ("testserver", 80),
+                    "client": ("testclient", 50000),
+                }
+
+                async def receive():
+                    return {"type": "http.request", "body": b"{}", "more_body": False}
+
+                fake_request = _Req(scope, receive)
+                result = await _broadcast_admin_request(
+                    app, fake_request, "/update_weights_from_disk"
+                )
+                return result
+            finally:
+                _app_mod._ADMIN_UPDATE_LOCK_TIMEOUT_S = original
+                lock.release()
+
+    result = asyncio.run(_run())
+    assert result.status_code == 503
+    body = json.loads(result.body)
+    assert "lock" in body["error"]["message"].lower()

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -585,3 +585,128 @@ def test_speech_request_passes_moss_token_count() -> None:
     gen_req = build_speech_generate_request(req, "moss-tts")
 
     assert gen_req.metadata["tts_params"]["token_count"] == 180
+
+
+# ---------------------------------------------------------------------------
+# Admin auth tests
+# ---------------------------------------------------------------------------
+
+_ADMIN_PATHS_THAT_NEED_AUTH = [
+    ("GET", "/model_info"),
+    ("POST", "/model_info"),
+    ("POST", "/pause_generation"),
+    ("POST", "/continue_generation"),
+    ("POST", "/update_weights_from_disk"),
+    ("POST", "/update_weights_from_tensor"),
+    ("POST", "/update_weights_from_distributed"),
+    ("GET", "/weights_checker"),
+    ("POST", "/weights_checker"),
+]
+
+
+def test_admin_routes_open_when_no_key_configured() -> None:
+    """Without a key, all admin routes are accessible with no auth header."""
+    admin = AdminClient()
+    client = TestClient(create_app(admin, model_name="qwen3-omni"))
+
+    resp = client.get("/model_info")
+    assert resp.status_code == 200
+
+    resp = client.post("/pause_generation", json={})
+    assert resp.status_code == 200
+
+
+def test_admin_routes_require_bearer_token_when_key_configured() -> None:
+    """When admin_api_key is set, requests without the header are rejected."""
+    admin = AdminClient()
+    client = TestClient(
+        create_app(admin, model_name="qwen3-omni", admin_api_key="secret-key")
+    )
+
+    for method, path in _ADMIN_PATHS_THAT_NEED_AUTH:
+        resp = client.request(method, path, json={})
+        assert resp.status_code == 401, f"{method} {path} should be 401, got {resp.status_code}"
+        assert "WWW-Authenticate" in resp.headers
+
+
+def test_admin_routes_reject_wrong_bearer_token() -> None:
+    admin = AdminClient()
+    client = TestClient(
+        create_app(admin, model_name="qwen3-omni", admin_api_key="secret-key")
+    )
+
+    for method, path in _ADMIN_PATHS_THAT_NEED_AUTH:
+        resp = client.request(
+            method, path, json={}, headers={"Authorization": "Bearer wrong-key"}
+        )
+        assert resp.status_code == 403, f"{method} {path} should be 403, got {resp.status_code}"
+
+
+def test_admin_routes_accept_correct_bearer_token() -> None:
+    admin = AdminClient()
+    client = TestClient(
+        create_app(admin, model_name="qwen3-omni", admin_api_key="secret-key")
+    )
+
+    resp = client.get("/model_info", headers={"Authorization": "Bearer secret-key"})
+    assert resp.status_code == 200
+
+    resp = client.post(
+        "/pause_generation",
+        json={},
+        headers={"Authorization": "Bearer secret-key"},
+    )
+    assert resp.status_code == 200
+
+
+def test_admin_routes_env_key_is_used_when_no_explicit_key(monkeypatch) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_ADMIN_KEY", "env-key")
+    admin = AdminClient()
+    client = TestClient(create_app(admin, model_name="qwen3-omni"))
+
+    resp = client.get("/model_info")
+    assert resp.status_code == 401
+
+    resp = client.get("/model_info", headers={"Authorization": "Bearer env-key"})
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Stub endpoint 501 tests
+# ---------------------------------------------------------------------------
+
+
+def test_update_weights_from_tensor_returns_501() -> None:
+    admin = AdminClient()
+    client = TestClient(create_app(admin, model_name="qwen3-omni"))
+
+    resp = client.post("/update_weights_from_tensor", json={})
+    assert resp.status_code == 501
+    assert resp.json()["error"]["code"] == "not_implemented"
+    assert "update_weights_from_disk" in resp.json()["error"]["message"]
+
+
+def test_update_weights_from_distributed_returns_501() -> None:
+    admin = AdminClient()
+    client = TestClient(create_app(admin, model_name="qwen3-omni"))
+
+    resp = client.post(
+        "/update_weights_from_distributed",
+        json={"names": [], "dtypes": [], "shapes": []},
+    )
+    assert resp.status_code == 501
+    assert resp.json()["error"]["code"] == "not_implemented"
+
+
+def test_stub_endpoints_also_check_auth_before_501() -> None:
+    """Auth check fires before the 501 body — ensure 401 takes precedence."""
+    admin = AdminClient()
+    client = TestClient(
+        create_app(admin, model_name="qwen3-omni", admin_api_key="secret-key")
+    )
+
+    resp = client.post("/update_weights_from_tensor", json={})
+    assert resp.status_code == 401
+
+    resp = client.post("/update_weights_from_distributed", json={})
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary

Follow-up fixes on top of #678 addressing issues found during review:

- **Admin API key auth**: All admin endpoints (`/pause_generation`, `/update_weights_from_disk`, `/weights_checker`, etc.) now require `Authorization: Bearer <key>` when `admin_api_key` is passed to `create_app()` or `SGLANG_OMNI_ADMIN_KEY` is set in the environment. No key configured → open as before (fully backward-compatible). Router's `serve.py` gains a `--admin-api-key` CLI flag. The `Authorization` header is forwarded to workers automatically.

- **Router lock liveness fix**: Replaced `async with admin_update_lock:` with `asyncio.wait_for(lock.acquire(), timeout=300s)`. A hung or crashed weight-update no longer holds the lock forever — callers get a `503` after 300 s instead of blocking indefinitely.

- **Stub endpoints return 501**: `POST /update_weights_from_tensor` and `POST /update_weights_from_distributed` now immediately return `HTTP 501 Not Implemented` in both the single-server and router, rather than routing through the admin pipeline and failing with an opaque worker-level error message.

- **SHA256 cost warning**: `StrictWeightChecker._digest_model()` now emits `logger.warning` at start and end of the digest, noting that inference is blocked for the full duration and logging elapsed time on completion.

## Test plan

- [ ] 16 new unit tests added covering: open/401/403/200/env-var auth flows, 501 stub responses, auth-before-501 ordering, and lock-timeout → 503
- [ ] All 146 unit tests pass (`pytest tests/unit_test/serve/ tests/unit_test/router/ tests/unit_test/pipeline/test_admin_control.py tests/unit_test/model_runner/test_weight_checker.py`)