### PR TITLE
[LLaDA2-Uni] Set default attention backend to flashinfer

### DIFF
--- a/sglang_omni/models/llada2_uni/stages.py
+++ b/sglang_omni/models/llada2_uni/stages.py
@@ -92,7 +92,10 @@ def create_sglang_dllm_thinker_executor_from_config(
     from sglang_omni.models.llada2_uni.bootstrap import create_dllm_thinker_scheduler
     from sglang_omni.scheduling.sglang_backend import build_sglang_server_args
 
-    overrides = {"disable_cuda_graph": True}
+    overrides: dict[str, Any] = {
+        "attention_backend": "flashinfer",
+        "disable_cuda_graph": True,
+    }
     overrides.update(server_args_overrides or {})
 
     server_args = build_sglang_server_args(


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

The fully supported attention backend for llada2_uni is flashinfer. Previously, we implicitly set the attention backend to flashinfer by enabling CUDA graph. A recent change disables CUDA graph for llada2_uni by default, which exposes the issue that the attention backend may be automatically chosen to one that llada2_uni doesn't support. This PR explicitly sets the attention backend to flashinfer for llada2_uni to fix this issue.

## Modifications

Update llada2_uni to use flashinfer as the default attention backend.

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Draft PRs are skipped even if labeled.
