### PR TITLE
[Higgs]: Optimize Higgs async decode resolve output handling

### DIFF
--- a/sglang_omni/models/higgs_tts/model_runner.py
+++ b/sglang_omni/models/higgs_tts/model_runner.py
@@ -105,7 +105,12 @@ class HiggsTTSModelRunner(ModelRunner):
         if len(requests) == 0:
             return
         n_real = len(requests)
-        self._decode_collect_host(host_buf[:n_real], result, requests)
+        self._decode_collect_host(
+            host_buf[:n_real],
+            result,
+            requests,
+            next_token_device=None,
+        )
 
     def _populate_cg_buffers(
         self, forward_batch, requests, *, is_lookahead: bool = False
@@ -222,7 +227,12 @@ class HiggsTTSModelRunner(ModelRunner):
             )
         staging = self._decode_pack_gpu(n_real)
         combined_cpu = staging[:n_real].cpu()  # one blocking D2H (sync path)
-        self._decode_collect_host(combined_cpu, result, requests)
+        self._decode_collect_host(
+            combined_cpu,
+            result,
+            requests,
+            next_token_device=result.logits_output.next_token_logits.device,
+        )
 
     def _decode_pack_gpu(self, n_real: int) -> torch.Tensor:
         """Scatter shadow sampler state back into the pool and pack the three
@@ -246,12 +256,22 @@ class HiggsTTSModelRunner(ModelRunner):
         return staging
 
     def _decode_collect_host(
-        self, combined_cpu: torch.Tensor, result: Any, requests: list
+        self,
+        combined_cpu: torch.Tensor,
+        result: Any,
+        requests: list,
+        *,
+        next_token_device: torch.device | None,
     ) -> None:
         """Host-side collect loop over an already-D2H'd staging snapshot:
         append per-request codes, mark finishes, build ``result.next_token_ids``.
         Skips chunked and already-done rows (the latter is what makes the
         one-step-lookahead overrun harmless — see r1_idempotency_check.md).
+
+        ``next_token_device`` is set for synchronous decode because those ids
+        feed the next step. Async resolve passes ``None``: launch already
+        published GPU codebook-0, and resolve only needs a CPU tensor for
+        output processing.
         """
         model = self.model
         num_codebooks = model._cg_codes_BN.shape[1]
@@ -284,11 +304,14 @@ class HiggsTTSModelRunner(ModelRunner):
             self._mark_sampler_finished(req, data.generation_done)
             cb0_per_row.append(int(codes_N[0].item()))
 
-        result.next_token_ids = torch.tensor(
-            cb0_per_row,
-            dtype=torch.long,
-            device=result.logits_output.next_token_logits.device,
-        )
+        if next_token_device is None:
+            result.next_token_ids = torch.tensor(cb0_per_row, dtype=torch.long)
+        else:
+            result.next_token_ids = torch.tensor(
+                cb0_per_row,
+                dtype=torch.long,
+                device=next_token_device,
+            )
 
     def _build_prefill_input_embeds(
         self,


### PR DESCRIPTION
## Motivation

Higgs async decode launch already publishes the GPU codebook-0 token for the next autoregressive step. During async resolve, the lagged step only needs `next_token_ids` for output processing, where it is converted with `.tolist()`.

This PR avoids rebuilding that resolve-side tensor on the GPU. The synchronous path still publishes `next_token_ids` on the logits device, so the next decode step behavior is unchanged when async decode is off.

## Modifications

- Thread `next_token_device` through `HiggsTTSModelRunner._decode_collect_host`.
- Pass the logits device from the synchronous decode path so `schedule_batch.output_ids` remains a GPU tensor for the next decode step.
- Pass `None` from async resolve so the lagged output-processing tensor is created on CPU.
- Leave sampling, logits, stop conditions, streaming emission, and output-code accumulation unchanged.

## Accuracy / Seed Note

The Seed-TTS benchmark run used the benchmark default `seed: null`, so generated token counts, audio length, and WER are sampled-run metrics rather than deterministic output equality checks. The change does not alter sampler math, logits, temperature/top-p/top-k, or stop handling.

## Speed Tests and Profiling

Full Seed-TTS EN benchmark, concurrency 8, 1088 / 1088 requests completed, non-streaming, async decode enabled.

| Metric | Main | This PR | Delta |
|---|---:|---:|---:|
| Latency mean (s) | 0.891 | 0.828 | -7.1% |
| Latency median (s) | 0.850 | 0.793 | -6.7% |
| Latency p95 (s) | 1.263 | 1.181 | -6.5% |
| Latency p99 (s) | 1.483 | 1.393 | -6.1% |
| RTF mean | 0.2073 | 0.1940 | -6.4% |
| Audio throughput (s/s) | 37.100 | 41.965 | +13.1% |
| Output throughput (tok/s) | 986.3 | 1116.6 | +13.2% |
| Throughput (req/s) | 8.400 | 9.645 | +14.8% |
| Output tokens total | 127751 | 125968 | -1.4% |
| WER corpus | 1.16% | 1.11% | -0.05 pp |
