### PR TITLE
[Feat] Support MOSS-TTS async decode opt-in

### DIFF
--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -14,9 +14,10 @@ logger = logging.getLogger(__name__)
 
 _STAGE_TOGGLE_MODE = Literal["default", "on", "off"]
 _QWEN_COLOCATED_CONFIG_CLASS = "Qwen3OmniSpeechColocatedPipelineConfig"
-_HIGGS_ASYNC_DECODE_FACTORY = (
-    "sglang_omni.models.higgs_tts.stages.create_sglang_tts_engine_executor"
-)
+_ASYNC_DECODE_FACTORIES = {
+    "sglang_omni.models.higgs_tts.stages.create_sglang_tts_engine_executor",
+    "sglang_omni.models.moss_tts.stages.create_sglang_tts_engine_executor",
+}
 _QWEN_PARTIAL_START_TALKER_FACTORY = (
     "sglang_omni.models.qwen3_omni.stages.create_talker_ar_executor_from_config"
 )
@@ -670,7 +671,9 @@ def _apply_stage_factory_args_override(
     updates: dict[str, object],
     reason: str,
     supported_factory: str | None = None,
+    supported_factories: set[str] | None = None,
     flag_name: str | None = None,
+    supported_display: str | None = None,
 ) -> None:
     matching_stages = _find_matching_stages(
         pipeline_config,
@@ -678,10 +681,14 @@ def _apply_stage_factory_args_override(
         reason=reason,
     )
     for stage in matching_stages:
-        if supported_factory is not None and stage.factory != supported_factory:
+        allowed = supported_factories
+        if allowed is None and supported_factory is not None:
+            allowed = {supported_factory}
+        if allowed is not None and stage.factory not in allowed:
             display_flag = flag_name or reason
+            supported = supported_display or "the supported stage factories"
             raise typer.BadParameter(
-                f"{display_flag} currently supports only Higgs TTS; "
+                f"{display_flag} currently supports only {supported}; "
                 f"stage {stage.name!r} uses factory {stage.factory!r}"
             )
         factory_args = dict(stage.factory_args or {})
@@ -728,8 +735,9 @@ def apply_async_decode_cli_overrides(
         stage_name="tts_engine",
         updates=updates,
         reason="async decode override",
-        supported_factory=_HIGGS_ASYNC_DECODE_FACTORY,
+        supported_factories=_ASYNC_DECODE_FACTORIES,
         flag_name="--async-decode/--async-decode-min-batch-size",
+        supported_display="Higgs TTS and MOSS-TTS",
     )
     return pipeline_config
 
@@ -982,7 +990,7 @@ def serve(
                 "One-step-lookahead async decode for the tts_engine stage: "
                 "default|on|off. When on, per-step host collect overlaps the "
                 "next GPU forward. 'default' uses the pipeline config default "
-                "(on for Higgs TTS). Currently supported by Higgs TTS."
+                "(on for Higgs TTS). Currently supported by Higgs TTS and MOSS-TTS."
             ),
         ),
     ] = "default",

--- a/sglang_omni/models/moss_tts/model_runner.py
+++ b/sglang_omni/models/moss_tts/model_runner.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import sys
 from typing import Any
 
 import torch
@@ -14,6 +15,27 @@ from sglang_omni.scheduling.types import RequestOutput
 
 _NEG_INF = float("-inf")
 _INT64_MAX = torch.iinfo(torch.int64).max
+
+
+class _MossFinishMatchedToken:
+    def __init__(self, matched: int):
+        self.matched = matched
+
+    def to_json(self):
+        return {"type": "stop", "matched": self.matched}
+
+
+class _MossFinishLength:
+    def __init__(self, length: int):
+        self.length = length
+
+    def to_json(self):
+        return {"type": "length", "length": self.length}
+
+
+def _finish_reason_class(name: str, fallback: type):
+    module = sys.modules.get("sglang.srt.managers.schedule_batch")
+    return getattr(module, name, fallback) if module is not None else fallback
 
 
 class MossTTSModelRunner(ModelRunner):
@@ -68,6 +90,30 @@ class MossTTSModelRunner(ModelRunner):
     ) -> None:
         self._collect_moss_step(result, forward_batch, schedule_batch, requests)
 
+    def post_decode_launch(
+        self,
+        result: Any,
+        forward_batch: Any,
+        requests: list,
+    ) -> None:
+        self._collect_moss_step(
+            result, forward_batch, None, requests, defer_finish=True
+        )
+        return None
+
+    def post_decode_resolve(
+        self,
+        host_buf: Any,
+        result: Any,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list,
+    ) -> None:
+        del host_buf, result, forward_batch, schedule_batch
+        for sched_req in requests:
+            self._apply_moss_pending_finish(sched_req.data)
+        return None
+
     def _build_prefill_input_embeds(
         self,
         forward_batch: Any,
@@ -119,7 +165,11 @@ class MossTTSModelRunner(ModelRunner):
             )
         rows = []
         for sched_req in requests:
-            queue = sched_req.data.pending_feedback_queue
+            data = sched_req.data
+            if bool(getattr(data, "moss_stop_pending", False)):
+                rows.append(torch.zeros(self.model.hidden_size, device=weight.device))
+                continue
+            queue = data.pending_feedback_queue
             if not queue:
                 rows.append(torch.zeros(self.model.hidden_size, device=weight.device))
                 continue
@@ -144,6 +194,8 @@ class MossTTSModelRunner(ModelRunner):
         forward_batch: Any,
         schedule_batch: Any,
         requests: list,
+        *,
+        defer_finish: bool = False,
     ) -> None:
         channel_logits = self._channel_logits_from_result(result, forward_batch)
         n_vq = len(channel_logits) - 1
@@ -154,15 +206,91 @@ class MossTTSModelRunner(ModelRunner):
 
         datas = [sched_req.data for sched_req in requests]
         rows = self._sample_rows(channel_logits, datas, n_vq=n_vq)
+        self._commit_moss_rows(result, requests, rows, defer_finish=defer_finish)
 
-        next_token_ids = rows[:, 0].contiguous()
-        result.next_token_ids = next_token_ids
-        schedule_batch.output_ids = next_token_ids
+        if schedule_batch is not None:
+            schedule_batch.output_ids = result.next_token_ids
+
+    def _commit_moss_rows(
+        self,
+        result: Any,
+        requests: list,
+        rows: torch.Tensor,
+        *,
+        defer_finish: bool = False,
+    ) -> None:
+        result.next_token_ids = rows[:, 0].contiguous()
+        if not requests:
+            return
+
         embeds = self.model._prepare_multi_modal_inputs(
             rows.to(device=self.model.device)
-        )
-        self._pending_rows = rows
-        self._pending_embeds = embeds.detach()
+        ).detach()
+        eos_id = int(self.model.config.im_end_token_id)
+
+        for row_idx, sched_req in enumerate(requests):
+            data = sched_req.data
+            req = getattr(data, "req", None)
+            req_finished = bool(req is not None and req.finished())
+            if bool(getattr(data, "moss_stop_pending", False)) or req_finished:
+                continue
+
+            self._advance_moss_sampling_step(data)
+            row = rows[row_idx].detach().clone()
+            if int(row[0].item()) == eos_id:
+                data.moss_stop_pending = True
+                data.moss_pending_finish = ("stop", eos_id)
+                if not defer_finish:
+                    self._apply_moss_pending_finish(data)
+                continue
+
+            data.output_rows.append(row)
+            if self._moss_reaches_length_boundary(data, req):
+                data.moss_stop_pending = True
+                max_new_tokens = self._moss_max_new_tokens(data, req)
+                if max_new_tokens is not None:
+                    data.moss_pending_finish = ("length", max_new_tokens)
+                    if not defer_finish:
+                        self._apply_moss_pending_finish(data)
+                continue
+
+            data.pending_feedback_queue.append(embeds[row_idx].detach().clone())
+
+    @staticmethod
+    def _moss_max_new_tokens(data: Any, req: Any) -> int | None:
+        sampling_params = getattr(req, "sampling_params", None)
+        max_new_tokens = getattr(sampling_params, "max_new_tokens", None)
+        if max_new_tokens is None:
+            max_new_tokens = getattr(data, "max_new_tokens", None)
+        if max_new_tokens is None or int(max_new_tokens) <= 0:
+            return None
+        return int(max_new_tokens)
+
+    @staticmethod
+    def _moss_reaches_length_boundary(data: Any, req: Any) -> bool:
+        max_new_tokens = MossTTSModelRunner._moss_max_new_tokens(data, req)
+        if max_new_tokens is None:
+            return False
+        output_ids = getattr(req, "output_ids", None) if req is not None else None
+        return len(output_ids or []) + 1 >= max_new_tokens
+
+    @staticmethod
+    def _apply_moss_pending_finish(data: Any) -> None:
+        pending = getattr(data, "moss_pending_finish", None)
+        if pending is None:
+            return
+        req = getattr(data, "req", None)
+        if req is not None and getattr(req, "finished_reason", None) is None:
+            kind, value = pending
+            if kind == "stop":
+                finish_cls = _finish_reason_class(
+                    "FINISH_MATCHED_TOKEN", _MossFinishMatchedToken
+                )
+                req.finished_reason = finish_cls(int(value))
+            elif kind == "length":
+                finish_cls = _finish_reason_class("FINISH_LENGTH", _MossFinishLength)
+                req.finished_reason = finish_cls(int(value))
+        data.moss_pending_finish = None
 
     def _channel_logits_from_result(
         self,
@@ -205,6 +333,22 @@ class MossTTSModelRunner(ModelRunner):
         data.delay_state = state
         return state
 
+    @staticmethod
+    def _moss_sampling_steps(data: Any) -> int:
+        value = getattr(data, "moss_sampling_steps", None)
+        generation_steps = int(data.generation_steps or 0)
+        if value is None:
+            value = generation_steps
+            data.moss_sampling_steps = value
+        elif generation_steps > int(value):
+            value = generation_steps
+            data.moss_sampling_steps = value
+        return int(value)
+
+    @staticmethod
+    def _advance_moss_sampling_step(data: Any) -> None:
+        data.moss_sampling_steps = MossTTSModelRunner._moss_sampling_steps(data) + 1
+
     def _sample_rows(
         self,
         channel_logits: list[torch.Tensor],
@@ -236,7 +380,9 @@ class MossTTSModelRunner(ModelRunner):
         delayed = delay_state[:, 1]
         is_audio = delay_state[:, 2].bool()
         gen_steps = torch.tensor(
-            [int(d.generation_steps) for d in datas], dtype=torch.long, device=device
+            [self._moss_sampling_steps(d) for d in datas],
+            dtype=torch.long,
+            device=device,
         )
         text_temp = torch.tensor(
             [float(d.text_temperature) for d in datas],
@@ -540,19 +686,7 @@ class MossTTSModelRunner(ModelRunner):
         outputs: dict[str, RequestOutput],
     ) -> None:
         del result
-        rows = self._pending_rows
-        embeds = self._pending_embeds
+        del scheduler_output
+        del outputs
         self._pending_rows = None
         self._pending_embeds = None
-        if rows is None or embeds is None:
-            return
-
-        eos_id = int(self.model.config.im_end_token_id)
-        for row_idx, sched_req in enumerate(scheduler_output.requests):
-            req_output = outputs[sched_req.request_id]
-            if req_output.data is None or int(req_output.data) == eos_id:
-                continue
-            sched_req.data.output_rows.append(rows[row_idx].detach().clone())
-            sched_req.data.pending_feedback_queue.append(
-                embeds[row_idx].detach().clone()
-            )

--- a/sglang_omni/models/moss_tts/request_builders.py
+++ b/sglang_omni/models/moss_tts/request_builders.py
@@ -71,6 +71,9 @@ class MossTTSSGLangRequestData(ARRequestData):
     req: Any = None
     synced: bool = False
     generation_steps: int = 0
+    moss_sampling_steps: int | None = None
+    moss_stop_pending: bool = False
+    moss_pending_finish: tuple[str, int] | None = None
     suppress_tokens: list[int] | None = None
     input_embeds_are_projected: bool = False
     prefill_input_embeds: torch.Tensor | None = None
@@ -96,6 +99,10 @@ class MossTTSSGLangRequestData(ARRequestData):
     delayed_length: int = _INF_DELAY
     is_audio: bool = False
     engine_start_s: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.moss_sampling_steps is None:
+            self.moss_sampling_steps = int(self.generation_steps)
 
 
 @dataclass

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -210,6 +210,8 @@ def create_sglang_tts_engine_executor(
     gpu_id: int | None = None,
     dtype: str = "bfloat16",
     server_args_overrides: dict[str, Any] | None = None,
+    enable_async_decode: bool = False,
+    async_decode_min_batch_size: int = 2,
 ) -> Any:
     from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
     from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
@@ -291,6 +293,8 @@ def create_sglang_tts_engine_executor(
         request_builder=request_builder,
         result_adapter=result_adapter,
         abort_callback=cleanup_prepared_moss_tts_request,
+        enable_async_decode=enable_async_decode,
+        async_decode_min_batch_size=async_decode_min_batch_size,
     )
 
 

--- a/tests/unit_test/higgs_tts/test_cli_async_decode.py
+++ b/tests/unit_test/higgs_tts/test_cli_async_decode.py
@@ -84,7 +84,10 @@ def test_async_decode_cli_invalid_mode_rejected():
 
 def test_async_decode_cli_rejects_unsupported_config():
     config = Qwen3TTSPipelineConfig(model_path="dummy")
-    with pytest.raises(typer.BadParameter, match="currently supports only Higgs TTS"):
+    with pytest.raises(
+        typer.BadParameter,
+        match="currently supports only Higgs TTS and MOSS-TTS",
+    ):
         apply_async_decode_cli_overrides(
             config, async_decode="off", async_decode_min_batch_size=None
         )

--- a/tests/unit_test/moss_tts/test_async_decode_runner.py
+++ b/tests/unit_test/moss_tts/test_async_decode_runner.py
@@ -1,0 +1,516 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Iterator
+
+import pytest
+import torch
+
+from sglang_omni.models.moss_tts.request_builders import MossTTSSGLangRequestData
+from sglang_omni.scheduling.types import RequestOutput
+
+_MISSING = object()
+
+
+def _multinomial_with_seed(
+    probs: torch.Tensor, seeds: torch.Tensor, positions: torch.Tensor
+) -> torch.Tensor:
+    del seeds, positions
+    return torch.multinomial(probs, num_samples=1)
+
+
+@contextmanager
+def _patched_moss_runner_cls() -> Iterator[type]:
+    sampler_module_name = "sglang.srt.layers.sampler"
+    runner_module_name = "sglang_omni.models.moss_tts.model_runner"
+    parent_module_name = "sglang_omni.models.moss_tts"
+    runner_attr = "model_runner"
+
+    previous_sampler = sys.modules.get(sampler_module_name, _MISSING)
+    previous_runner = sys.modules.get(runner_module_name, _MISSING)
+    parent_module = sys.modules.get(parent_module_name)
+    previous_parent_attr = (
+        getattr(parent_module, runner_attr, _MISSING)
+        if parent_module is not None
+        else _MISSING
+    )
+
+    sampler_stub = types.ModuleType(sampler_module_name)
+    sampler_stub.multinomial_with_seed = _multinomial_with_seed
+    sys.modules[sampler_module_name] = sampler_stub
+    sys.modules.pop(runner_module_name, None)
+
+    try:
+        module = importlib.import_module(runner_module_name)
+        yield module.MossTTSModelRunner
+    finally:
+        sys.modules.pop(runner_module_name, None)
+        if previous_runner is not _MISSING:
+            sys.modules[runner_module_name] = previous_runner
+
+        if previous_sampler is _MISSING:
+            sys.modules.pop(sampler_module_name, None)
+        else:
+            sys.modules[sampler_module_name] = previous_sampler
+
+        if parent_module is not None:
+            if previous_parent_attr is _MISSING:
+                try:
+                    delattr(parent_module, runner_attr)
+                except AttributeError:
+                    pass
+            else:
+                setattr(parent_module, runner_attr, previous_parent_attr)
+
+
+@pytest.fixture()
+def moss_runner_cls():
+    with _patched_moss_runner_cls() as runner_cls:
+        yield runner_cls
+
+
+def _cfg() -> SimpleNamespace:
+    return SimpleNamespace(
+        pad_token_id=0,
+        audio_start_token_id=10,
+        audio_end_token_id=11,
+        audio_assistant_gen_slot_token_id=12,
+        audio_assistant_delay_slot_token_id=13,
+        audio_pad_code=4,
+        im_end_token_id=14,
+    )
+
+
+def _runner_for_commit_tests(runner_cls: type):
+    runner = runner_cls.__new__(runner_cls)
+    runner.model = SimpleNamespace(
+        config=SimpleNamespace(im_end_token_id=14),
+        device=torch.device("cpu"),
+        _prepare_multi_modal_inputs=lambda rows: rows.to(torch.float32)[:, :3],
+    )
+    runner._pending_rows = None
+    runner._pending_embeds = None
+    return runner
+
+
+def _unfinished_req(*, max_new_tokens: int = 8):
+    req = SimpleNamespace(
+        output_ids=[],
+        sampling_params=SimpleNamespace(max_new_tokens=max_new_tokens),
+        finished_reason=None,
+    )
+    req.finished = lambda: req.finished_reason is not None
+    return req
+
+
+def _eos_collect_fixture(runner_cls: type):
+    cfg = _cfg()
+    runner = runner_cls.__new__(runner_cls)
+    runner.model = SimpleNamespace(
+        config=cfg,
+        device=torch.device("cpu"),
+        _prepare_multi_modal_inputs=lambda rows: rows.to(torch.float32),
+    )
+    req = _unfinished_req()
+    data = MossTTSSGLangRequestData(
+        req=req,
+        generation_steps=0,
+        moss_sampling_steps=3,
+        sampling_seed=0,
+        text_temperature=0.0,
+        text_top_p=1.0,
+        text_top_k=-1,
+        audio_temperature=0.0,
+        audio_top_p=1.0,
+        audio_top_k=-1,
+    )
+    text_logits = torch.full((1, 20), -100.0)
+    text_logits[0, cfg.im_end_token_id] = 10.0
+    result = SimpleNamespace(
+        logits_output=SimpleNamespace(
+            customized_info={
+                "moss_tts_channel_logits": [
+                    text_logits,
+                    torch.zeros((1, 5)),
+                    torch.zeros((1, 5)),
+                ]
+            }
+        )
+    )
+    sched_req = SimpleNamespace(request_id="req-eos", data=data)
+    return runner, req, data, result, sched_req, cfg
+
+
+def test_moss_runner_patch_restores_modules_in_process() -> None:
+    sampler_module_name = "sglang.srt.layers.sampler"
+    runner_module_name = "sglang_omni.models.moss_tts.model_runner"
+    parent_module_name = "sglang_omni.models.moss_tts"
+    runner_attr = "model_runner"
+
+    previous_sampler = sys.modules.get(sampler_module_name, _MISSING)
+    previous_runner = sys.modules.get(runner_module_name, _MISSING)
+    parent_module = sys.modules.get(parent_module_name)
+    previous_parent_attr = (
+        getattr(parent_module, runner_attr, _MISSING)
+        if parent_module is not None
+        else _MISSING
+    )
+
+    with _patched_moss_runner_cls() as runner_cls:
+        assert runner_cls.__name__ == "MossTTSModelRunner"
+        assert sys.modules.get(sampler_module_name) is not previous_sampler
+
+    if previous_sampler is _MISSING:
+        assert sampler_module_name not in sys.modules
+    else:
+        assert sys.modules.get(sampler_module_name) is previous_sampler
+    if previous_runner is _MISSING:
+        assert runner_module_name not in sys.modules
+    else:
+        assert sys.modules.get(runner_module_name) is previous_runner
+    if parent_module is not None:
+        if previous_parent_attr is _MISSING:
+            assert not hasattr(parent_module, runner_attr)
+        else:
+            assert getattr(parent_module, runner_attr) is previous_parent_attr
+
+
+def test_moss_async_state_defaults_follow_sync_generation_step() -> None:
+    data = MossTTSSGLangRequestData(generation_steps=3)
+
+    assert data.moss_sampling_steps == 3
+    assert data.moss_stop_pending is False
+
+
+def test_moss_sampling_steps_falls_back_to_zero_when_generation_steps_is_none(
+    moss_runner_cls,
+) -> None:
+    data = SimpleNamespace(generation_steps=None)
+
+    assert moss_runner_cls._moss_sampling_steps(data) == 0
+    assert data.moss_sampling_steps == 0
+
+
+def test_moss_sampling_steps_uses_generation_steps_as_floor(
+    moss_runner_cls,
+) -> None:
+    data = SimpleNamespace(generation_steps=4, moss_sampling_steps=0)
+
+    assert moss_runner_cls._moss_sampling_steps(data) == 4
+    assert data.moss_sampling_steps == 4
+
+
+def test_sample_rows_uses_moss_sampling_steps_not_finalize_generation_steps(
+    moss_runner_cls,
+) -> None:
+    cfg = _cfg()
+    runner = moss_runner_cls.__new__(moss_runner_cls)
+    runner.model = SimpleNamespace(config=cfg)
+    data = SimpleNamespace(
+        generation_steps=0,
+        moss_sampling_steps=3,
+        audio_length=0,
+        delayed_length=-1,
+        is_audio=False,
+        delay_state=None,
+        sampling_seed=0,
+        text_temperature=0.0,
+        text_top_p=1.0,
+        text_top_k=-1,
+        audio_temperature=0.0,
+        audio_top_p=1.0,
+        audio_top_k=-1,
+        audio_repetition_penalty=1.0,
+        prompt_rows=None,
+        output_rows=[],
+    )
+    text_logits = torch.full((1, 20), -100.0)
+    text_logits[0, cfg.im_end_token_id] = 10.0
+    audio0_logits = torch.zeros((1, 5))
+    audio1_logits = torch.zeros((1, 5))
+
+    rows = runner._sample_rows(
+        [text_logits, audio0_logits, audio1_logits], [data], n_vq=2
+    )
+
+    assert int(rows[0, 0]) == cfg.im_end_token_id
+
+
+def test_collect_moss_step_advances_moss_sampling_steps(
+    moss_runner_cls,
+) -> None:
+    cfg = _cfg()
+    runner = moss_runner_cls.__new__(moss_runner_cls)
+    runner.model = SimpleNamespace(
+        config=cfg,
+        device=torch.device("cpu"),
+        _prepare_multi_modal_inputs=lambda rows: rows.to(torch.float32),
+    )
+    data = SimpleNamespace(
+        generation_steps=0,
+        moss_sampling_steps=0,
+        audio_length=0,
+        delayed_length=-1,
+        is_audio=False,
+        delay_state=None,
+        sampling_seed=0,
+        text_temperature=0.0,
+        text_top_p=1.0,
+        text_top_k=-1,
+        audio_temperature=0.0,
+        audio_top_p=1.0,
+        audio_top_k=-1,
+        audio_repetition_penalty=1.0,
+        prompt_rows=None,
+        output_rows=[],
+        pending_feedback_queue=[],
+        req=SimpleNamespace(output_ids=[], finished=lambda: False),
+        max_new_tokens=4,
+    )
+    text_logits = torch.zeros((1, 20))
+    audio0_logits = torch.zeros((1, 5))
+    audio1_logits = torch.zeros((1, 5))
+    result = SimpleNamespace(
+        logits_output=SimpleNamespace(
+            customized_info={
+                "moss_tts_channel_logits": [text_logits, audio0_logits, audio1_logits]
+            }
+        )
+    )
+    schedule_batch = SimpleNamespace(output_ids=None)
+
+    runner._collect_moss_step(
+        result,
+        forward_batch=SimpleNamespace(),
+        schedule_batch=schedule_batch,
+        requests=[SimpleNamespace(data=data)],
+    )
+
+    assert data.moss_sampling_steps == 1
+
+
+def test_sync_eos_collect_marks_sglang_request_finished(moss_runner_cls) -> None:
+    runner, req, data, result, sched_req, cfg = _eos_collect_fixture(moss_runner_cls)
+
+    runner.post_decode(
+        result,
+        forward_batch=SimpleNamespace(),
+        schedule_batch=SimpleNamespace(output_ids=None),
+        requests=[sched_req],
+    )
+
+    assert data.moss_stop_pending is True
+    assert req.finished()
+    assert req.finished_reason.to_json() == {
+        "type": "stop",
+        "matched": cfg.im_end_token_id,
+    }
+
+
+def test_async_eos_finish_is_deferred_until_resolve(moss_runner_cls) -> None:
+    runner, req, data, result, sched_req, cfg = _eos_collect_fixture(moss_runner_cls)
+
+    runner.post_decode_launch(
+        result,
+        forward_batch=SimpleNamespace(),
+        requests=[sched_req],
+    )
+
+    assert result.next_token_ids.tolist() == [cfg.im_end_token_id]
+    assert data.moss_stop_pending is True
+    assert not req.finished()
+
+    runner.post_decode_resolve(
+        None,
+        result,
+        object(),
+        object(),
+        [sched_req],
+    )
+
+    assert req.finished()
+    assert req.finished_reason.to_json() == {
+        "type": "stop",
+        "matched": cfg.im_end_token_id,
+    }
+
+
+def test_sync_length_boundary_marks_sglang_request_finished(moss_runner_cls) -> None:
+    runner = _runner_for_commit_tests(moss_runner_cls)
+    req = _unfinished_req(max_new_tokens=4)
+    req.output_ids = [1, 2, 3]
+    data = MossTTSSGLangRequestData(
+        req=req,
+        generation_steps=0,
+        moss_sampling_steps=0,
+    )
+    result = SimpleNamespace()
+
+    runner._commit_moss_rows(
+        result,
+        [SimpleNamespace(data=data)],
+        torch.tensor([[12, 2, 4]], dtype=torch.long),
+    )
+
+    assert data.moss_stop_pending is True
+    assert req.finished()
+    assert req.finished_reason.to_json() == {"type": "length", "length": 4}
+
+
+def test_commit_rows_appends_feedback_without_post_process_outputs(
+    moss_runner_cls,
+) -> None:
+    runner = _runner_for_commit_tests(moss_runner_cls)
+    req = SimpleNamespace(
+        output_ids=[],
+        sampling_params=SimpleNamespace(max_new_tokens=4),
+        finished=lambda: False,
+    )
+    data = MossTTSSGLangRequestData(
+        req=req,
+        generation_steps=0,
+        moss_sampling_steps=0,
+    )
+    sched_req = SimpleNamespace(data=data)
+    result = SimpleNamespace()
+    rows = torch.tensor([[12, 2, 4]], dtype=torch.long)
+
+    runner._commit_moss_rows(result, [sched_req], rows)
+
+    assert result.next_token_ids.tolist() == [12]
+    assert [row.tolist() for row in data.output_rows] == [[12, 2, 4]]
+    assert len(data.pending_feedback_queue) == 1
+    assert torch.equal(
+        data.pending_feedback_queue[0],
+        torch.tensor([12.0, 2.0, 4.0]),
+    )
+    assert data.moss_sampling_steps == 1
+
+
+def test_post_process_outputs_no_longer_appends_rows_or_feedback(
+    moss_runner_cls,
+) -> None:
+    runner = _runner_for_commit_tests(moss_runner_cls)
+    runner._pending_rows = torch.tensor([[12, 2, 4]], dtype=torch.long)
+    runner._pending_embeds = torch.ones((1, 3))
+    data = SimpleNamespace(output_rows=[], pending_feedback_queue=[])
+    requests = [SimpleNamespace(request_id="active", data=data)]
+
+    runner.post_process_outputs(
+        object(),
+        SimpleNamespace(requests=requests),
+        {"active": RequestOutput("active", data=12)},
+    )
+
+    assert data.output_rows == []
+    assert data.pending_feedback_queue == []
+    assert runner._pending_rows is None
+    assert runner._pending_embeds is None
+
+
+def test_stop_pending_before_decode_uses_dummy_embedding_without_consuming_feedback(
+    moss_runner_cls,
+) -> None:
+    runner = moss_runner_cls.__new__(moss_runner_cls)
+    embedding = torch.nn.Embedding(2, 3)
+    runner.model = SimpleNamespace(hidden_size=3, _decode_input_embedding=embedding)
+    feedback = torch.ones(3)
+    data = SimpleNamespace(
+        moss_stop_pending=True,
+        pending_feedback_queue=[feedback],
+    )
+    forward_batch = SimpleNamespace(input_ids=torch.full((1,), 99, dtype=torch.long))
+
+    runner._write_decode_input_embedding(forward_batch, [SimpleNamespace(data=data)])
+
+    assert forward_batch.input_ids.tolist() == [0]
+    assert torch.equal(embedding.weight[0].detach(), torch.zeros(3))
+    assert data.pending_feedback_queue == [feedback]
+
+
+def test_stop_pending_collect_skips_overrun_row_and_counter(
+    moss_runner_cls,
+) -> None:
+    runner = _runner_for_commit_tests(moss_runner_cls)
+    data = MossTTSSGLangRequestData(
+        output_rows=[],
+        moss_sampling_steps=5,
+        moss_stop_pending=True,
+        req=SimpleNamespace(
+            output_ids=[1, 2],
+            sampling_params=SimpleNamespace(max_new_tokens=8),
+            finished=lambda: False,
+        ),
+    )
+    result = SimpleNamespace()
+
+    runner._commit_moss_rows(
+        result,
+        [SimpleNamespace(data=data)],
+        torch.tensor([[12, 2, 4]], dtype=torch.long),
+    )
+
+    assert result.next_token_ids.tolist() == [12]
+    assert data.output_rows == []
+    assert len(data.pending_feedback_queue) == 0
+    assert data.moss_sampling_steps == 5
+
+
+def test_post_decode_launch_collects_rows_and_publishes_token_ids(
+    moss_runner_cls,
+) -> None:
+    runner = _runner_for_commit_tests(moss_runner_cls)
+
+    def fake_collect(result, forward_batch, schedule_batch, requests, **kwargs):
+        del forward_batch, schedule_batch
+        rows = torch.tensor([[12, 2, 4]], dtype=torch.long)
+        runner._commit_moss_rows(result, requests, rows, **kwargs)
+
+    runner._collect_moss_step = fake_collect
+    req = SimpleNamespace(
+        output_ids=[],
+        sampling_params=SimpleNamespace(max_new_tokens=8),
+        finished=lambda: False,
+    )
+    data = MossTTSSGLangRequestData(
+        output_rows=[],
+        req=req,
+        generation_steps=0,
+        moss_sampling_steps=0,
+    )
+    result = SimpleNamespace(next_token_ids=None)
+
+    host_buf = runner.post_decode_launch(
+        result,
+        object(),
+        [SimpleNamespace(data=data)],
+    )
+
+    assert host_buf is None
+    assert result.next_token_ids.tolist() == [12]
+    assert [row.tolist() for row in data.output_rows] == [[12, 2, 4]]
+
+
+def test_post_decode_resolve_is_noop_for_moss_state(
+    moss_runner_cls,
+) -> None:
+    runner = _runner_for_commit_tests(moss_runner_cls)
+    data = SimpleNamespace(output_rows=[], pending_feedback_queue=[])
+    result = SimpleNamespace(next_token_ids=torch.tensor([12]))
+
+    runner.post_decode_resolve(
+        None,
+        result,
+        object(),
+        object(),
+        [SimpleNamespace(data=data)],
+    )
+
+    assert data.output_rows == []
+    assert data.pending_feedback_queue == []
+    assert result.next_token_ids.tolist() == [12]

--- a/tests/unit_test/moss_tts/test_cli_async_decode.py
+++ b/tests/unit_test/moss_tts/test_cli_async_decode.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from sglang_omni.cli.serve import apply_async_decode_cli_overrides
+from sglang_omni.config import resolve_stage_factory_args
+from sglang_omni.models.moss_tts.config import MossTTSPipelineConfig
+
+
+def _tts_engine_args(config):
+    stage = next(s for s in config.stages if s.name == "tts_engine")
+    return resolve_stage_factory_args(stage, config)
+
+
+def test_moss_async_decode_cli_override_can_enable_and_disable() -> None:
+    config = MossTTSPipelineConfig(model_path="dummy")
+
+    apply_async_decode_cli_overrides(
+        config, async_decode="on", async_decode_min_batch_size=4
+    )
+    args = _tts_engine_args(config)
+    assert args["enable_async_decode"] is True
+    assert args["async_decode_min_batch_size"] == 4
+
+    apply_async_decode_cli_overrides(
+        config, async_decode="off", async_decode_min_batch_size=None
+    )
+    assert _tts_engine_args(config)["enable_async_decode"] is False

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -239,6 +239,111 @@ def test_moss_tts_engine_uses_auto_mem_fraction_by_default(monkeypatch) -> None:
     assert captured["model_arch_override"] == "MossTTSDelaySGLangModel"
 
 
+def test_moss_tts_engine_passes_async_decode_args(monkeypatch) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    captured: dict[str, object] = {}
+
+    def fake_build_sglang_server_args(model_path, context_length, **kwargs):
+        captured["model_path"] = model_path
+        captured["context_length"] = context_length
+        captured["build_kwargs"] = dict(kwargs)
+        return SimpleNamespace(
+            disable_cuda_graph=kwargs["disable_cuda_graph"],
+            disable_overlap_schedule=False,
+        )
+
+    def fake_create_sglang_infrastructure(
+        server_args,
+        gpu_id,
+        *,
+        model_arch_override=None,
+    ):
+        captured["gpu_id"] = gpu_id
+        captured["model_arch_override"] = model_arch_override
+        model = object()
+        model_runner = SimpleNamespace(
+            model=model,
+            init_device_graphs=lambda: captured.setdefault("graph_inits", 0) or None,
+        )
+        model_worker = SimpleNamespace(model_runner=model_runner)
+        return (
+            model_worker,
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+        )
+
+    class FakeOutputProcessor:
+        def __init__(self, **kwargs) -> None:
+            captured["output_processor_kwargs"] = kwargs
+
+    class FakeMossTTSModelRunner:
+        def __init__(self, model_worker, output_proc) -> None:
+            captured["model_runner_args"] = (model_worker, output_proc)
+
+    class FakeOmniScheduler:
+        def __init__(self, **kwargs) -> None:
+            captured["scheduler_kwargs"] = kwargs
+
+    fake_model_runner_module = types.ModuleType(
+        "sglang_omni.models.moss_tts.model_runner"
+    )
+    fake_model_runner_module.MossTTSModelRunner = FakeMossTTSModelRunner
+    fake_bootstrap_module = types.ModuleType("sglang_omni.scheduling.bootstrap")
+    fake_bootstrap_module.create_sglang_infrastructure = (
+        fake_create_sglang_infrastructure
+    )
+    fake_omni_scheduler_module = types.ModuleType(
+        "sglang_omni.scheduling.omni_scheduler"
+    )
+    fake_omni_scheduler_module.OmniScheduler = FakeOmniScheduler
+    fake_sglang_backend_module = types.ModuleType(
+        "sglang_omni.scheduling.sglang_backend"
+    )
+    fake_sglang_backend_module.SGLangOutputProcessor = FakeOutputProcessor
+    fake_sglang_backend_module.build_sglang_server_args = fake_build_sglang_server_args
+
+    monkeypatch.setattr(stages, "_resolve_checkpoint", lambda model_path: model_path)
+    monkeypatch.setattr(
+        stages,
+        "make_moss_tts_scheduler_adapters",
+        lambda model: (lambda payload: payload, lambda data: data),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.models.moss_tts.model_runner",
+        fake_model_runner_module,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.scheduling.bootstrap",
+        fake_bootstrap_module,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.scheduling.omni_scheduler",
+        fake_omni_scheduler_module,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.scheduling.sglang_backend",
+        fake_sglang_backend_module,
+    )
+
+    stages.create_sglang_tts_engine_executor(
+        "OpenMOSS-Team/MOSS-TTS-v1.5",
+        enable_async_decode=True,
+        async_decode_min_batch_size=4,
+    )
+
+    assert captured["scheduler_kwargs"]["enable_async_decode"] is True
+    assert captured["scheduler_kwargs"]["async_decode_min_batch_size"] == 4
+
+
 def test_moss_tts_talker_torch_compile_cli_override_targets_tts_engine() -> None:
     from sglang_omni.cli.serve import apply_torch_compile_cli_overrides
 
@@ -775,7 +880,7 @@ def test_moss_channel_logits_use_decode_metadata(
     assert metadata.next_token_logits_buffer is None
 
 
-def test_moss_post_process_outputs_skips_im_end() -> None:
+def test_moss_post_process_outputs_is_noop_for_rows_and_feedback() -> None:
     from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
 
     runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
@@ -802,10 +907,12 @@ def test_moss_post_process_outputs_skips_im_end() -> None:
         },
     )
 
-    assert [row.tolist() for row in requests[0].data.output_rows] == [[12, 2, 4]]
-    assert len(requests[0].data.pending_feedback_queue) == 1
+    assert requests[0].data.output_rows == []
+    assert requests[0].data.pending_feedback_queue == []
     assert requests[1].data.output_rows == []
     assert requests[1].data.pending_feedback_queue == []
+    assert runner._pending_rows is None
+    assert runner._pending_embeds is None
 
 
 def test_moss_delay_codec_splits_non_pad_segments() -> None:


### PR DESCRIPTION
## Summary

Implements opt-in async decode support for MOSS-TTS, following the Higgs launch/resolve split while keeping MOSS async disabled by default.

- Move MOSS row, feedback embedding, delay-state, and sampling-step commits into the collect path so one-step lookahead cannot overwrite runner-global pending state.
- Add MOSS async `post_decode_launch` / `post_decode_resolve` hooks, launch-side stop/length guards, and pending finish bridging back to SGLang's `finished_reason`.
- Wire `enable_async_decode` and `async_decode_min_batch_size` through the MOSS TTS engine factory and the shared `--async-decode` CLI override.
- Add unit coverage for async hook behavior, stop/length overrun protection, launch-side sampling-step semantics, CLI plumbing, and MOSS pipeline wiring.

## Why async stays opt-in for MOSS

MOSS and Higgs both have strict step-to-step decode dependencies. The important difference is the existing state ownership model. Higgs keeps decode feedback state in a per-request / row-indexed sampler pool, so async launch can update stable per-request rows without relying on a runner-global pending slot.

MOSS currently keeps next-step feedback in request-local Python state (`output_rows`, `pending_feedback_queue`, delay state, sampling counters), while the old synchronous runner staged rows/embeddings through runner-global `_pending_rows` / `_pending_embeds`. Those runner-global pending slots are unsafe under one-step lookahead because step N+1 can launch before step N is resolved.

This PR therefore uses a correctness-first design based on the current MOSS state model: launch commits the sampled row, feedback embedding, delay state, and pending stop/length state before the next decode step is scheduled. That makes async decode correct and opt-in usable, but it also leaves very little work in resolve to overlap. The A800 validation below confirms this: async event waits are hits, while most cost stays in launch.

To get a larger async speedup, MOSS likely needs a deeper refactor toward the Higgs-style model: a per-request / row-indexed MOSS feedback buffer or pool where launch writes next-step feedback into stable rows, `before_decode` reads those rows directly, and request-state/output commit can be decoupled from the heavy launch path.

The A800 validation below did not show a stable default-on win. After the stop fix, async-on token counts were comparable to async-off and did not run away, but latency/throughput were roughly flat to slightly slower depending on the run. This PR therefore only adds opt-in support via config/CLI.

## Correctness validation

Stop/length handling:

- MOSS launch now publishes `result.next_token_ids` immediately so SGLang remains the source of truth for final stop/length finish reasons.
- MOSS also marks launch-side `moss_stop_pending` / pending finish state so a one-step lookahead overrun cannot append extra MOSS rows or feedback before SGLang resolves the request.
- The launch-side `moss_sampling_steps` counter feeds `_sample_rows`, avoiding the async one-step lag from base `generation_steps` finalize.

Audio smoke:

- A800 GPU c4 smoke run generated 4 audio files.
- Manual listening check: audio quality was normal and generated content matched the corresponding text/file.

## Benchmark / profiling results

Environment:

- A800 GPU 80 GB
- Model: `OpenMOSS-Team/MOSS-TTS-v1.5`
- Existing remote HF/model cache, no model download during runs
- `--talker-cuda-graph off`
- `benchmarks.eval.benchmark_tts_seedtts`
- Generate-only, English references, `--token-count auto`

Normal c4 benchmark after the stop fix:

| Mode | Mean latency | QPS | Output throughput | Notes |
|---|---:|---:|---:|---|
| async off | 4.885 s | 0.804 | 69.5 tok/s | baseline |
| async on | 4.993 s | 0.788 | 68.1 tok/s | slightly slower |

Profiled c4/32 A-B run:

| Mode | Completed | Failed | Mean latency | QPS | Output tokens |
|---|---:|---:|---:|---:|---:|
| async off | 32 | 0 | 4.957 s | 0.770 | 2706 |
| async on | 32 | 0 | 4.947 s | 0.775 | 2706 |

Representative async profile from the same run:

- `query_hit=820`, `query_miss=0`: lookahead did not block on the CUDA event.
- `resolve.post_decode_resolve ~= 0.003 ms`
- `resolve.finalize ~= 0.049 ms`
- `scheduler.process_batch_result ~= 0.078 ms`
- `launch.prepare_and_forward ~= 17.6 ms`
- `launch.post_decode_launch ~= 7.9 ms`
- MOSS collect breakdown:
  - `sample_rows ~= 4.4 ms`
  - `channel_logits ~= 2.2 ms`
  - `feedback_embeds ~= 1.1 ms`

Interpretation: async overlap is functioning, but the resolve-side work is already tiny. Most MOSS decode cost remains launch-side in this PR because the current MOSS request-state/feedback-queue implementation requires next-step feedback to be prepared before the next launch.

## Follow-up optimization observations

These were investigated separately and are not included in this PR:

- Selective audio-head logits reduced `channel_logits` from about 2.26 ms to about 1.58-1.63 ms, but c4/32 end-to-end improvement was small.
- Top-k subset sampling reduced `sample_rows` from about 4.42 ms to about 4.20 ms, but mean latency only moved from about 4.85 s to about 4.84 s.
- Any top-k subset implementation must preserve `multinomial_with_seed` semantics, because its deterministic Gumbel noise is derived from the original token id / column index.

Likely future launch-side targets:

- reduce GPU-host scalar syncs in `_sample_rows`;
- reduce full-vocab top-p/top-k work while preserving fixed-seed semantics;
- optimize feedback embedding construction when most audio channels are pad;
- refactor MOSS feedback ownership toward a Higgs-style per-request / row-indexed feedback buffer so async can decouple next-step feedback staging from request-state/output commit.

## reference
https://github.com/sgl-project/sglang-omni/issues/637
