### PR TITLE
[Bugfix] Add real streaming for Voxtral TTS

### DIFF
--- a/sglang_omni/models/voxtral_tts/config.py
+++ b/sglang_omni/models/voxtral_tts/config.py
@@ -34,6 +34,7 @@ class VoxtralTTSPipelineConfig(PipelineConfig):
             factory_args={"gpu_id": 0, "max_new_tokens": 4096},
             gpu=0,
             next=VOCODER_STAGE,
+            stream_to=[VOCODER_STAGE],
         ),
         StageConfig(
             name=VOCODER_STAGE,
@@ -42,6 +43,7 @@ class VoxtralTTSPipelineConfig(PipelineConfig):
             factory_args={"gpu_id": 0},
             gpu=0,
             terminal=True,
+            can_accept_stream_before_payload=True,
         ),
     ]
 

--- a/sglang_omni/models/voxtral_tts/model_runner.py
+++ b/sglang_omni/models/voxtral_tts/model_runner.py
@@ -8,7 +8,9 @@ from typing import Any
 import torch
 
 from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.models.tts_streaming import INITIAL_CODEC_CHUNK_FRAMES_PARAM
 from sglang_omni.models.voxtral_tts.acoustic_transformer import AudioSpecialTokens
+from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.types import RequestOutput
 
 
@@ -17,6 +19,11 @@ class VoxtralTTSModelRunner(ModelRunner):
         super().__init__(tp_worker, output_processor)
         self._pending_audio_codes: torch.Tensor | None = None
         self._pending_audio_embeds: torch.Tensor | None = None
+        self._outbox: Any | None = None
+        self._vocoder_target = "vocoder"
+
+    def set_stream_outbox(self, outbox: Any) -> None:
+        self._outbox = outbox
 
     def before_prefill(
         self,
@@ -157,7 +164,38 @@ class VoxtralTTSModelRunner(ModelRunner):
             req_output = outputs[sched_req.request_id]
             if req_output.data is None or int(req_output.data) == eos_id:
                 continue
-            sched_req.data.output_codes.append(codes[row_idx].detach().clone())
+            code_chunk = codes[row_idx].detach().clone()
+            sched_req.data.output_codes.append(code_chunk)
             sched_req.data.pending_feedback_queue.append(
                 embeds[row_idx, 0].detach().clone()
             )
+            self._emit_code_chunk(sched_req, code_chunk)
+
+    def _emit_code_chunk(self, sched_req: Any, code_chunk: torch.Tensor) -> None:
+        outbox = getattr(self, "_outbox", None)
+        if outbox is None:
+            return
+        payload = getattr(sched_req.data, "stage_payload", None)
+        request = getattr(payload, "request", None)
+        params = getattr(request, "params", None)
+        if not isinstance(params, dict) or not params.get("stream", False):
+            return
+
+        metadata: dict[str, Any] = {
+            "modality": "audio_codes",
+            "stream": True,
+            "num_codebooks": int(code_chunk.numel()),
+        }
+        if INITIAL_CODEC_CHUNK_FRAMES_PARAM in params:
+            metadata[INITIAL_CODEC_CHUNK_FRAMES_PARAM] = params[
+                INITIAL_CODEC_CHUNK_FRAMES_PARAM
+            ]
+        outbox.put(
+            OutgoingMessage(
+                request_id=sched_req.request_id,
+                type="stream",
+                target=getattr(self, "_vocoder_target", "vocoder"),
+                data=code_chunk,
+                metadata=metadata,
+            )
+        )

--- a/sglang_omni/models/voxtral_tts/pipeline/stages.py
+++ b/sglang_omni/models/voxtral_tts/pipeline/stages.py
@@ -13,11 +13,11 @@ from typing import Any
 
 import torch
 
+from sglang_omni.models.voxtral_tts import streaming_vocoder
 from sglang_omni.models.voxtral_tts.io import VoxtralTTSState
-from sglang_omni.models.voxtral_tts.pipeline.state_io import load_state, store_state
+from sglang_omni.models.voxtral_tts.pipeline.state_io import store_state
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
-from sglang_omni.utils.audio_payload import audio_waveform_payload
 
 logger = logging.getLogger(__name__)
 
@@ -87,10 +87,7 @@ def _validate_voxtral_speech_params(
 
 
 def _ensure_non_empty_audio_codes(audio_codes: Any) -> None:
-    if audio_codes is None:
-        raise ValueError("Voxtral TTS generated no audio codes")
-    if isinstance(audio_codes, torch.Tensor) and audio_codes.numel() == 0:
-        raise ValueError("Voxtral TTS generated no audio codes")
+    streaming_vocoder._ensure_non_empty_audio_codes(audio_codes)
 
 
 # ---- Preprocessing ----
@@ -226,7 +223,8 @@ def create_generation_executor(
         model=model,
     )
 
-    return OmniScheduler(
+    model_runner = VoxtralTTSModelRunner(model_worker, output_proc)
+    scheduler = OmniScheduler(
         tp_worker=model_worker,
         tree_cache=tree_cache,
         req_to_token_pool=req_to_token_pool,
@@ -235,10 +233,13 @@ def create_generation_executor(
         model_config=model_config,
         prefill_manager=prefill_mgr,
         decode_manager=decode_mgr,
-        model_runner=VoxtralTTSModelRunner(model_worker, output_proc),
+        model_runner=model_runner,
         request_builder=request_builder,
         result_adapter=result_adapter,
     )
+    if hasattr(model_runner, "set_stream_outbox"):
+        model_runner.set_stream_outbox(scheduler.outbox)
+    return scheduler
 
 
 def _write_voxtral_sglang_config(checkpoint_dir: str) -> str:
@@ -350,7 +351,10 @@ def create_vocoder_executor(
     *,
     device: str = "cuda:0",
     gpu_id: int | None = None,
-) -> SimpleScheduler:
+    stream_stride: int = 10,
+    stream_followup_stride: int = 30,
+    stream_overlap_frames: int = 2,
+) -> streaming_vocoder.VoxtralStreamingVocoderScheduler:
     """Factory for the vocoder (audio tokenizer decode) stage."""
     checkpoint_dir = _resolve_checkpoint(model_path)
     if gpu_id is not None:
@@ -358,69 +362,10 @@ def create_vocoder_executor(
 
     logger.info("Loading Voxtral audio tokenizer for vocoding...")
     audio_tokenizer = _load_audio_tokenizer(checkpoint_dir, {}, device)
-
-    def _vocode(payload: StagePayload) -> StagePayload:
-        state = load_state(payload)
-        audio_codes = state.audio_codes
-
-        _ensure_non_empty_audio_codes(audio_codes)
-
-        if not isinstance(audio_codes, torch.Tensor):
-            audio_codes = torch.tensor(audio_codes)
-
-        # Prepend warmup context frames so the causal decoder has initial
-        # context (mitigates boundary artifacts / noise at the start of the
-        # waveform).  After decoding, the samples corresponding to the
-        # warmup frames are trimmed away.
-        n_warmup = 2
-        warmup_samples = 0
-        if audio_codes.shape[0] > 0:
-            first_frame = audio_codes[0:1]
-            warmup = first_frame.repeat(n_warmup, 1)
-            codes_with_warmup = torch.cat([warmup, audio_codes], dim=0)
-            warmup_samples = n_warmup * audio_tokenizer.downsample_factor
-        else:
-            codes_with_warmup = audio_codes
-
-        results = audio_tokenizer.decode_helper_batch_async([codes_with_warmup])
-        audio_np = results[0]
-
-        # Trim warmup samples from the beginning
-        if warmup_samples > 0 and len(audio_np) > warmup_samples:
-            audio_np = audio_np[warmup_samples:]
-
-        # Apply a short fade-in to smooth any residual onset artifacts
-        fade_in_ms = 10  # milliseconds
-        fade_samples = min(
-            int(fade_in_ms * audio_tokenizer.sampling_rate / 1000),
-            len(audio_np),
-        )
-        if fade_samples > 0:
-            fade_in = torch.linspace(
-                0,
-                1,
-                fade_samples,
-                device=audio_np.device,
-                dtype=audio_np.dtype,
-            )
-            audio_np[:fade_samples] = audio_np[:fade_samples] * fade_in
-
-        audio_payload = audio_waveform_payload(audio_np, source_hint="Voxtral TTS")
-        state.audio_samples = None
-        state.sample_rate = audio_tokenizer.sampling_rate
-        payload = store_state(payload, state)
-
-        payload.data.update(audio_payload)
-        payload.data["sample_rate"] = audio_tokenizer.sampling_rate
-        payload.data["modality"] = "audio"
-
-        if state.prompt_tokens or state.completion_tokens:
-            payload.data["usage"] = {
-                "prompt_tokens": state.prompt_tokens,
-                "completion_tokens": state.completion_tokens,
-                "total_tokens": state.prompt_tokens + state.completion_tokens,
-            }
-
-        return payload
-
-    return SimpleScheduler(_vocode)
+    return streaming_vocoder.VoxtralStreamingVocoderScheduler(
+        audio_tokenizer,
+        device=device,
+        stream_stride=stream_stride,
+        stream_followup_stride=stream_followup_stride,
+        stream_overlap_frames=stream_overlap_frames,
+    )

--- a/sglang_omni/models/voxtral_tts/streaming_vocoder.py
+++ b/sglang_omni/models/voxtral_tts/streaming_vocoder.py
@@ -1,0 +1,490 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Streaming vocoder scheduler for Voxtral TTS."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+import torch
+
+from sglang_omni.models.tts_streaming import (
+    INITIAL_CODEC_CHUNK_FRAMES_PARAM,
+    resolve_initial_codec_chunk_frames,
+)
+from sglang_omni.models.voxtral_tts.acoustic_transformer import AudioSpecialTokens
+from sglang_omni.models.voxtral_tts.io import VoxtralTTSState
+from sglang_omni.models.voxtral_tts.pipeline.state_io import load_state, store_state
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.messages import OutgoingMessage
+from sglang_omni.scheduling.streaming_simple_scheduler import StreamingSimpleScheduler
+from sglang_omni.utils.audio_payload import audio_waveform_payload
+
+
+def _ensure_non_empty_audio_codes(audio_codes: Any) -> None:
+    if audio_codes is None:
+        raise ValueError("Voxtral TTS generated no audio codes")
+    if isinstance(audio_codes, torch.Tensor) and audio_codes.numel() == 0:
+        raise ValueError("Voxtral TTS generated no audio codes")
+    if isinstance(audio_codes, (list, tuple)) and len(audio_codes) == 0:
+        raise ValueError("Voxtral TTS generated no audio codes")
+
+
+def _as_code_tensor(
+    audio_codes: Any,
+    *,
+    device: torch.device | str | None = None,
+) -> torch.Tensor:
+    _ensure_non_empty_audio_codes(audio_codes)
+    if isinstance(audio_codes, torch.Tensor):
+        tensor = audio_codes.detach()
+    else:
+        tensor = torch.as_tensor(audio_codes)
+    if tensor.numel() == 0:
+        raise ValueError("Voxtral TTS generated no audio codes")
+    if tensor.ndim == 1:
+        tensor = tensor.reshape(1, -1)
+    if tensor.ndim != 2:
+        raise ValueError(
+            f"Voxtral audio codes must be 2-D [frames, codebooks], "
+            f"got {tuple(tensor.shape)}"
+        )
+    return tensor.to(device=device, dtype=torch.long)
+
+
+def _to_audio_tensor(audio: Any) -> torch.Tensor:
+    if isinstance(audio, torch.Tensor):
+        return audio.detach().float().reshape(-1)
+    return torch.as_tensor(audio, dtype=torch.float32).reshape(-1)
+
+
+def _apply_fade_in(
+    audio: torch.Tensor,
+    *,
+    sample_rate: int,
+    fade_in_ms: int,
+) -> torch.Tensor:
+    fade_samples = min(int(fade_in_ms * sample_rate / 1000), int(audio.numel()))
+    if fade_samples <= 0:
+        return audio
+    fade_in = torch.linspace(
+        0,
+        1,
+        fade_samples,
+        device=audio.device,
+        dtype=audio.dtype,
+    )
+    audio = audio.clone()
+    audio[:fade_samples] = audio[:fade_samples] * fade_in
+    return audio
+
+
+def _decode_voxtral_codes(
+    audio_tokenizer: Any,
+    audio_codes: torch.Tensor,
+    *,
+    include_start_warmup: bool,
+    fade_in_ms: int = 0,
+) -> torch.Tensor:
+    n_warmup = 2
+    warmup_samples = 0
+    codes = audio_codes
+    if include_start_warmup and codes.shape[0] > 0:
+        warmup = codes[0:1].repeat(n_warmup, 1)
+        codes = torch.cat([warmup, codes], dim=0)
+        warmup_samples = int(n_warmup * audio_tokenizer.downsample_factor)
+
+    results = audio_tokenizer.decode_helper_batch_async([codes])
+    audio = _to_audio_tensor(results[0])
+
+    if warmup_samples > 0 and int(audio.numel()) > warmup_samples:
+        audio = audio[warmup_samples:]
+    if fade_in_ms > 0:
+        audio = _apply_fade_in(
+            audio,
+            sample_rate=int(audio_tokenizer.sampling_rate),
+            fade_in_ms=fade_in_ms,
+        )
+    return audio.contiguous()
+
+
+def build_voxtral_audio_payload(
+    audio_tokenizer: Any,
+    audio_codes: Any,
+    *,
+    device: torch.device | str | None = None,
+    fade_in_ms: int = 10,
+    source_hint: str = "Voxtral TTS",
+) -> dict[str, Any]:
+    codes = _as_code_tensor(audio_codes, device=device)
+    audio = _decode_voxtral_codes(
+        audio_tokenizer,
+        codes,
+        include_start_warmup=True,
+        fade_in_ms=fade_in_ms,
+    )
+    return audio_waveform_payload(
+        audio,
+        sample_rate=int(audio_tokenizer.sampling_rate),
+        modality="audio",
+        source_hint=source_hint,
+    )
+
+
+def store_voxtral_audio_result(
+    payload: StagePayload,
+    state: VoxtralTTSState,
+    audio_payload: dict[str, Any],
+    *,
+    sample_rate: int,
+) -> StagePayload:
+    state.audio_samples = None
+    state.sample_rate = int(sample_rate)
+    payload = store_state(payload, state)
+
+    payload.data.update(audio_payload)
+    payload.data["sample_rate"] = int(sample_rate)
+    payload.data["modality"] = "audio"
+
+    usage = build_voxtral_usage(state)
+    if usage is not None:
+        payload.data["usage"] = usage
+    return payload
+
+
+def build_voxtral_usage(state: VoxtralTTSState) -> dict[str, Any] | None:
+    if not (state.prompt_tokens or state.completion_tokens):
+        return None
+    return {
+        "prompt_tokens": state.prompt_tokens,
+        "completion_tokens": state.completion_tokens,
+        "total_tokens": state.prompt_tokens + state.completion_tokens,
+    }
+
+
+@dataclass
+class _VoxtralStreamState:
+    codes: list[torch.Tensor] = field(default_factory=list)
+    emitted_frames: int = 0
+    next_decode_frames: int = 0
+    has_emitted: bool = False
+    initial_codec_chunk_frames: int = 0
+    num_codebooks: int | None = None
+
+
+class VoxtralStreamingVocoderScheduler(StreamingSimpleScheduler):
+    """Decode Voxtral codec frames incrementally for streaming speech."""
+
+    def __init__(
+        self,
+        audio_tokenizer: Any,
+        *,
+        device: torch.device | str = "cuda:0",
+        stream_stride: int = 10,
+        stream_followup_stride: int = 30,
+        stream_overlap_frames: int = 2,
+        fade_in_ms: int = 10,
+    ) -> None:
+        if stream_stride <= 0 or stream_followup_stride <= 0:
+            raise ValueError("stream_stride and stream_followup_stride must be > 0")
+        if stream_overlap_frames < 0:
+            raise ValueError("stream_overlap_frames must be >= 0")
+        if fade_in_ms < 0:
+            raise ValueError("fade_in_ms must be >= 0")
+
+        self._audio_tokenizer = audio_tokenizer
+        self._device = torch.device(device)
+        self._stream_stride = int(stream_stride)
+        self._stream_followup_stride = int(stream_followup_stride)
+        self._stream_overlap_frames = int(stream_overlap_frames)
+        self._fade_in_ms = int(fade_in_ms)
+        self._sample_rate = int(audio_tokenizer.sampling_rate)
+        self._stream_states: dict[str, _VoxtralStreamState] = {}
+
+        super().__init__(self._vocode_payload)
+
+    def is_streaming_payload(self, payload: StagePayload) -> bool:
+        params = payload.request.params
+        if not isinstance(params, dict):
+            raise TypeError(
+                f"Voxtral request params must be a dict, got "
+                f"{type(params).__name__}"
+            )
+        return bool(params.get("stream", False))
+
+    def validate_non_streaming_payload(self, payload: StagePayload) -> None:
+        state = load_state(payload)
+        _ensure_non_empty_audio_codes(state.audio_codes)
+
+    def on_streaming_new_request(self, request_id: str, payload: StagePayload) -> None:
+        state = self._stream_states.setdefault(request_id, _VoxtralStreamState())
+        self._latch_initial_codec_chunk_frames_from_mapping(
+            request_id,
+            state,
+            (
+                payload.request.params
+                if isinstance(payload.request.params, dict)
+                else None
+            ),
+        )
+
+    def on_stream_chunk(
+        self, request_id: str, item: StreamItem
+    ) -> list[OutgoingMessage]:
+        state = self._stream_states.setdefault(request_id, _VoxtralStreamState())
+        self._latch_stream_metadata(request_id, state, item.metadata)
+
+        row = self._stream_row_tensor(request_id, item.data)
+        eos_id = AudioSpecialTokens.id(AudioSpecialTokens.end_audio)
+        if int(row[0].item()) == eos_id:
+            return []
+        if state.num_codebooks is not None and int(row.shape[0]) != state.num_codebooks:
+            raise ValueError(
+                f"Voxtral stream chunk has {int(row.shape[0])} codebooks, "
+                f"expected {state.num_codebooks}"
+            )
+
+        state.codes.append(row)
+        output = self._decode_delta(state, is_final=False)
+        if output is None:
+            return []
+        return [
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                data=output,
+                metadata={"modality": "audio"},
+            )
+        ]
+
+    def on_stream_done(self, request_id: str) -> list[OutgoingMessage]:
+        payload = self._stream_payloads[request_id]
+        state = self._stream_states.setdefault(request_id, _VoxtralStreamState())
+
+        output = self._decode_delta(state, is_final=True)
+        if output is None and not state.has_emitted:
+            output = self._audio_payload_from_stage_payload(payload)
+
+        messages: list[OutgoingMessage] = []
+        if output is not None:
+            messages.append(
+                OutgoingMessage(
+                    request_id=request_id,
+                    type="stream",
+                    data=output,
+                    metadata={"modality": "audio"},
+                )
+            )
+
+        final_data: dict[str, Any] = {
+            "modality": "audio",
+            "sample_rate": self._sample_rate,
+        }
+        usage = build_voxtral_usage(load_state(payload))
+        if usage is not None:
+            final_data["usage"] = usage
+        messages.append(
+            OutgoingMessage(
+                request_id=request_id,
+                type="result",
+                data=StagePayload(
+                    request_id=payload.request_id,
+                    request=payload.request,
+                    data=final_data,
+                ),
+            )
+        )
+        return messages
+
+    def clear_stream_state(self, request_id: str) -> None:
+        self._stream_states.pop(request_id, None)
+
+    def _latch_stream_metadata(
+        self,
+        request_id: str,
+        state: _VoxtralStreamState,
+        metadata: dict[str, Any] | None,
+    ) -> None:
+        if not isinstance(metadata, dict):
+            return
+        if metadata.get("modality") not in (None, "audio_codes"):
+            raise ValueError(
+                f"Voxtral stream chunk modality must be audio_codes, got "
+                f"{metadata.get('modality')!r}"
+            )
+        if metadata.get("stream") is not True:
+            raise RuntimeError(
+                f"Voxtral stream chunk for {request_id!r} must include "
+                "metadata['stream'] == True"
+            )
+        if "num_codebooks" in metadata:
+            self._latch_num_codebooks(
+                request_id,
+                state,
+                metadata["num_codebooks"],
+            )
+        if INITIAL_CODEC_CHUNK_FRAMES_PARAM in metadata:
+            self._latch_initial_codec_chunk_frames_from_mapping(
+                request_id,
+                state,
+                metadata,
+            )
+
+    @staticmethod
+    def _latch_num_codebooks(
+        request_id: str,
+        state: _VoxtralStreamState,
+        num_codebooks: Any,
+    ) -> None:
+        try:
+            value = int(num_codebooks)
+        except (TypeError, ValueError) as exc:
+            raise TypeError(
+                f"Voxtral stream chunk for {request_id!r} must include integer "
+                "num_codebooks"
+            ) from exc
+        if value <= 0:
+            raise ValueError(
+                f"Voxtral stream chunk for {request_id!r} has invalid "
+                f"num_codebooks={value}"
+            )
+        if state.num_codebooks is not None and state.num_codebooks != value:
+            raise ValueError(
+                f"Voxtral stream num_codebooks changed for {request_id!r}: "
+                f"{state.num_codebooks} -> {value}"
+            )
+        state.num_codebooks = value
+
+    def _latch_initial_codec_chunk_frames_from_mapping(
+        self,
+        request_id: str,
+        state: _VoxtralStreamState,
+        params: Mapping[str, Any] | None,
+    ) -> None:
+        del request_id
+        state.initial_codec_chunk_frames = resolve_initial_codec_chunk_frames(
+            params,
+            steady_chunk_frames=self._stream_stride,
+        )
+
+    def _stream_row_tensor(self, request_id: str, row: Any) -> torch.Tensor:
+        if isinstance(row, torch.Tensor):
+            tensor = row.detach()
+        else:
+            tensor = torch.as_tensor(row)
+        tensor = tensor.to(device=self._device, dtype=torch.long, non_blocking=True)
+        if tensor.ndim == 2 and int(tensor.shape[0]) == 1:
+            tensor = tensor[0]
+        if tensor.ndim != 1:
+            raise ValueError(
+                f"Voxtral stream chunk for {request_id!r} must be 1-D "
+                f"[codebooks], got {tuple(tensor.shape)}"
+            )
+        if tensor.numel() == 0:
+            raise ValueError(f"Voxtral stream chunk for {request_id!r} is empty")
+        return tensor
+
+    def _decode_delta(
+        self,
+        state: _VoxtralStreamState,
+        *,
+        is_final: bool,
+    ) -> dict[str, Any] | None:
+        total_frames = len(state.codes)
+        if total_frames == 0:
+            return None
+
+        use_initial_chunk = (
+            state.initial_codec_chunk_frames > 0
+            and state.initial_codec_chunk_frames < self._stream_stride
+            and not state.has_emitted
+        )
+        next_decode_frames = state.next_decode_frames or (
+            state.initial_codec_chunk_frames
+            if use_initial_chunk and not is_final
+            else self._stream_stride
+        )
+        if not is_final and total_frames < next_decode_frames:
+            state.next_decode_frames = next_decode_frames
+            return None
+
+        emit_until = total_frames
+        if use_initial_chunk and not is_final:
+            emit_until = min(total_frames, state.initial_codec_chunk_frames)
+        if emit_until <= state.emitted_frames:
+            state.next_decode_frames = total_frames + self._stream_followup_stride
+            return None
+
+        window_start = max(0, state.emitted_frames - self._stream_overlap_frames)
+        window = torch.stack(state.codes[window_start:emit_until], dim=0).to(
+            device=self._device,
+            dtype=torch.long,
+        )
+        audio = _decode_voxtral_codes(
+            self._audio_tokenizer,
+            window,
+            include_start_warmup=window_start == 0,
+            fade_in_ms=0,
+        )
+
+        trim_frames = state.emitted_frames - window_start
+        trim_samples = int(trim_frames * self._audio_tokenizer.downsample_factor)
+        if trim_samples > 0:
+            audio = audio[min(trim_samples, int(audio.numel())) :]
+        if audio.numel() == 0:
+            state.next_decode_frames = total_frames + self._stream_followup_stride
+            return None
+
+        if not state.has_emitted and self._fade_in_ms > 0:
+            audio = _apply_fade_in(
+                audio,
+                sample_rate=self._sample_rate,
+                fade_in_ms=self._fade_in_ms,
+            )
+
+        state.emitted_frames = emit_until
+        state.next_decode_frames = emit_until + self._stream_followup_stride
+        state.has_emitted = True
+        return audio_waveform_payload(
+            audio,
+            sample_rate=self._sample_rate,
+            modality="audio",
+            source_hint="Voxtral TTS streaming",
+        )
+
+    def _audio_payload_from_stage_payload(
+        self,
+        payload: StagePayload,
+    ) -> dict[str, Any]:
+        state = load_state(payload)
+        return build_voxtral_audio_payload(
+            self._audio_tokenizer,
+            state.audio_codes,
+            device=self._device,
+            fade_in_ms=self._fade_in_ms,
+            source_hint="Voxtral TTS streaming",
+        )
+
+    def _vocode_payload(self, payload: StagePayload) -> StagePayload:
+        state = load_state(payload)
+        audio_payload = build_voxtral_audio_payload(
+            self._audio_tokenizer,
+            state.audio_codes,
+            device=self._device,
+            fade_in_ms=self._fade_in_ms,
+        )
+        return store_voxtral_audio_result(
+            payload,
+            state,
+            audio_payload,
+            sample_rate=self._sample_rate,
+        )
+
+
+__all__ = [
+    "VoxtralStreamingVocoderScheduler",
+    "build_voxtral_audio_payload",
+    "store_voxtral_audio_result",
+    "_ensure_non_empty_audio_codes",
+]

--- a/tests/unit_test/voxtral_tts/test_pipeline.py
+++ b/tests/unit_test/voxtral_tts/test_pipeline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import collections
+import queue
 from types import SimpleNamespace
 
 import numpy as np
@@ -10,13 +11,35 @@ import pytest
 import torch
 
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+from sglang_omni.models.tts_streaming import INITIAL_CODEC_CHUNK_FRAMES_PARAM
 from sglang_omni.models.voxtral_tts.config import VoxtralTTSPipelineConfig
 from sglang_omni.models.voxtral_tts.io import VoxtralTTSState
 from sglang_omni.models.voxtral_tts.pipeline import stages
 from sglang_omni.models.voxtral_tts.request_builders import build_sglang_voxtral_request
+from sglang_omni.models.voxtral_tts.streaming_vocoder import (
+    VoxtralStreamingVocoderScheduler,
+)
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.scheduling.types import RequestOutput
 from sglang_omni.utils.audio_payload import audio_waveform_payload
+
+
+class _FakeVoxtralAudioTokenizer:
+    sampling_rate = 1000
+    downsample_factor = 2
+
+    def decode_helper_batch_async(self, codes_list: list[torch.Tensor]):
+        return [
+            codes[:, 0]
+            .to(dtype=torch.float32)
+            .repeat_interleave(self.downsample_factor)
+            for codes in codes_list
+        ]
+
+
+def _audio_values(payload: dict) -> np.ndarray:
+    return np.frombuffer(payload["audio_waveform"], dtype=np.float32).copy()
 
 
 def test_voxtral_tts_config_uses_current_stage_schema() -> None:
@@ -32,6 +55,8 @@ def test_voxtral_tts_config_uses_current_stage_schema() -> None:
     assert "device" not in config.stages[2].factory_args
     assert config.stages[1].factory_args["gpu_id"] == 0
     assert config.stages[2].factory_args["gpu_id"] == 0
+    assert config.stages[1].stream_to == ["vocoder"]
+    assert config.stages[2].can_accept_stream_before_payload is True
     assert {stage.process for stage in config.stages} == {"pipeline"}
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config("VoxtralTTSForConditionalGeneration")
@@ -162,6 +187,172 @@ def test_voxtral_audio_codes_payload_is_compact() -> None:
     assert "audio_codes_bytes" in data
     assert "audio_codes" not in data
     assert restored.audio_codes.tolist() == [[1, 2], [3, 4]]
+
+
+def test_voxtral_generation_streams_codec_rows_when_requested() -> None:
+    from sglang_omni.models.voxtral_tts.model_runner import VoxtralTTSModelRunner
+
+    runner = VoxtralTTSModelRunner.__new__(VoxtralTTSModelRunner)
+    runner._pending_audio_codes = torch.tensor([[11, 12, 13]], dtype=torch.long)
+    runner._pending_audio_embeds = torch.ones(1, 1, 3)
+    runner._outbox = queue.Queue()
+    runner._vocoder_target = "vocoder"
+
+    payload = StagePayload(
+        request_id="active",
+        request=OmniRequest(
+            inputs="",
+            params={"stream": True, INITIAL_CODEC_CHUNK_FRAMES_PARAM: 1},
+        ),
+        data={},
+    )
+    data = SimpleNamespace(
+        output_codes=[],
+        pending_feedback_queue=[],
+        stage_payload=payload,
+    )
+    request = SimpleNamespace(request_id="active", data=data)
+
+    runner.post_process_outputs(
+        None,
+        SimpleNamespace(requests=[request]),
+        {"active": RequestOutput("active", data=11)},
+    )
+
+    assert [chunk.tolist() for chunk in data.output_codes] == [[11, 12, 13]]
+    assert len(data.pending_feedback_queue) == 1
+    msg = runner._outbox.get_nowait()
+    assert msg.request_id == "active"
+    assert msg.type == "stream"
+    assert msg.target == "vocoder"
+    assert msg.data.tolist() == [11, 12, 13]
+    assert msg.metadata == {
+        "modality": "audio_codes",
+        "stream": True,
+        "num_codebooks": 3,
+        INITIAL_CODEC_CHUNK_FRAMES_PARAM: 1,
+    }
+
+
+def test_voxtral_generation_does_not_stream_without_stream_param() -> None:
+    from sglang_omni.models.voxtral_tts.model_runner import VoxtralTTSModelRunner
+
+    runner = VoxtralTTSModelRunner.__new__(VoxtralTTSModelRunner)
+    runner._pending_audio_codes = torch.tensor([[11, 12, 13]], dtype=torch.long)
+    runner._pending_audio_embeds = torch.ones(1, 1, 3)
+    runner._outbox = queue.Queue()
+
+    payload = StagePayload(
+        request_id="active",
+        request=OmniRequest(inputs="", params={"stream": False}),
+        data={},
+    )
+    data = SimpleNamespace(
+        output_codes=[],
+        pending_feedback_queue=[],
+        stage_payload=payload,
+    )
+    request = SimpleNamespace(request_id="active", data=data)
+
+    runner.post_process_outputs(
+        None,
+        SimpleNamespace(requests=[request]),
+        {"active": RequestOutput("active", data=11)},
+    )
+
+    assert [chunk.tolist() for chunk in data.output_codes] == [[11, 12, 13]]
+    assert runner._outbox.empty()
+
+
+def test_voxtral_streaming_vocoder_decodes_chunks_before_final_payload() -> None:
+    scheduler = VoxtralStreamingVocoderScheduler(
+        _FakeVoxtralAudioTokenizer(),
+        device="cpu",
+        stream_stride=2,
+        stream_followup_stride=2,
+        stream_overlap_frames=1,
+        fade_in_ms=0,
+    )
+    metadata = {"modality": "audio_codes", "stream": True, "num_codebooks": 2}
+
+    scheduler._on_chunk(
+        "req",
+        StreamItem(0, torch.tensor([10, 0]), "tts_generation", metadata),
+    )
+    assert scheduler.outbox.empty()
+
+    scheduler._on_chunk(
+        "req",
+        StreamItem(1, torch.tensor([11, 0]), "tts_generation", metadata),
+    )
+    first = scheduler.outbox.get_nowait()
+    assert first.type == "stream"
+    assert first.metadata == {"modality": "audio"}
+    assert _audio_values(first.data).tolist() == [10.0, 10.0, 11.0, 11.0]
+
+    scheduler._on_chunk(
+        "req",
+        StreamItem(2, torch.tensor([12, 0]), "tts_generation", metadata),
+    )
+    scheduler._on_done("req")
+    assert scheduler.outbox.empty()
+
+    state = VoxtralTTSState(
+        audio_codes=torch.tensor([[10, 0], [11, 0], [12, 0]], dtype=torch.long),
+        prompt_tokens=4,
+        completion_tokens=3,
+    )
+    payload = StagePayload(
+        request_id="req",
+        request=OmniRequest(inputs="", params={"stream": True}),
+        data=state.to_dict(),
+    )
+    scheduler._on_streaming_new_request("req", payload)
+
+    tail = scheduler.outbox.get_nowait()
+    final = scheduler.outbox.get_nowait()
+    assert tail.type == "stream"
+    assert _audio_values(tail.data).tolist() == [12.0, 12.0]
+    assert final.type == "result"
+    assert final.data.data == {
+        "modality": "audio",
+        "sample_rate": 1000,
+        "usage": {
+            "prompt_tokens": 4,
+            "completion_tokens": 3,
+            "total_tokens": 7,
+        },
+    }
+    assert "req" not in scheduler._stream_states
+
+
+def test_voxtral_streaming_vocoder_non_streaming_path_returns_full_audio() -> None:
+    scheduler = VoxtralStreamingVocoderScheduler(
+        _FakeVoxtralAudioTokenizer(),
+        device="cpu",
+        fade_in_ms=0,
+    )
+    state = VoxtralTTSState(
+        audio_codes=torch.tensor([[10, 0], [11, 0]], dtype=torch.long),
+        prompt_tokens=3,
+        completion_tokens=2,
+    )
+    payload = StagePayload(
+        request_id="req",
+        request=OmniRequest(inputs="", params={"stream": False}),
+        data=state.to_dict(),
+    )
+
+    result = scheduler._vocode_payload(payload)
+
+    assert result.data["modality"] == "audio"
+    assert result.data["sample_rate"] == 1000
+    assert _audio_values(result.data).tolist() == [10.0, 10.0, 11.0, 11.0]
+    assert result.data["usage"] == {
+        "prompt_tokens": 3,
+        "completion_tokens": 2,
+        "total_tokens": 5,
+    }
 
 
 def test_voxtral_collect_audio_step_reuses_output_tokens_for_eos_filter() -> None:


### PR DESCRIPTION
Added real streaming for Voxtral TTS

Benchmark result:
| Variant | Stream | Completed | Failed | Lat mean s | Lat p95 s | RTF mean | Throughput req/s | Audio throughput s/s | Output tok/s | TTFC mean s | TTFC p95 s | ITL mean s | Audio chunks mean | Notes |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
| baseline_non_streaming | false | 50 | 0 | 1.353 | 2.051 | 0.2476 | 9.993 | 55.303 | 691.3 | n/a | n/a | n/a | n/a | Full response only |
| variant_streaming_sse | true | 50 | 0 | 1.465 | 2.514 | 0.2713 | 9.079 | 49.799 | 622.5 | 0.3130 | 0.5157 | 0.4838 | 3.38 | Real SSE audio chunks |

| Metric | Baseline | Streaming | Delta |
|---|---:|---:|---:|
| Latency mean s | 1.353 | 1.465 | +8.3% |
| Latency p95 s | 2.051 | 2.514 | +22.6% |
| RTF mean | 0.2476 | 0.2713 | +9.6% |
| Throughput req/s | 9.993 | 9.079 | -9.1% |
| Audio throughput s/s | 55.303 | 49.799 | -10.0% |
| Output tok/s | 691.3 | 622.5 | -10.0% |
| Output tokens total | 3459 | 3428 | -0.9% |
| Audio duration mean s | 5.534 | 5.485 | -0.9% |
