### PR TITLE
docs(README): point Higgs TTS to public bosonai/higgs-audio-v3-tts-4b; 102 languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Core features:
 
 | Model | Type | Notes |
 |-------|------|-------|
-| [boson-sglang/higgs-audio-v3-tts-4b-base](https://huggingface.co/boson-sglang/higgs-audio-v3-tts-4b-base) | TTS | Voice cloning, streaming, 100+ languages |
+| [bosonai/higgs-audio-v3-tts-4b](https://huggingface.co/bosonai/higgs-audio-v3-tts-4b) | TTS | Voice cloning, streaming, 102 languages |
 | [fishaudio/s2-pro](https://huggingface.co/fishaudio/s2-pro) | TTS | Voice cloning, streaming |
 | [mistralai/Voxtral-4B-TTS-2603](https://huggingface.co/mistralai/Voxtral-4B-TTS-2603) | TTS | Named voices, streaming, 9 languages |
 | [Qwen/Qwen3-TTS-12Hz-Base](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-1.7B-Base) | TTS | Voice cloning, streaming, 10 languages, 0.6B / 1.7B |


### PR DESCRIPTION
## What

Update the Higgs Audio TTS row in the **Supported Models** table:

- Point the model link to the public weights at
  [`bosonai/higgs-audio-v3-tts-4b`](https://huggingface.co/bosonai/higgs-audio-v3-tts-4b)
  (previously `boson-sglang/higgs-audio-v3-tts-4b-base`).
- Update the language coverage note from "100+ languages" to the exact
  **102 languages**.

## Why

The previously linked repo is not public; `bosonai/higgs-audio-v3-tts-4b` is the
public release users should pull. The model now supports 102 languages.

Docs-only change — single line in `README.md`, no code impact.
