### PR TITLE
[Qwen3-TTS] Real incremental streaming for Base/reference-cloning

### DIFF
--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -161,6 +161,13 @@ curl -N -X POST http://localhost:8000/v1/audio/speech \
 
 The server returns a stream of SSE events. Each event contains an `audio.speech.chunk` object with a base64-encoded audio chunk. The stream ends with `data: [DONE]`.
 
+Qwen3-TTS streaming is real incremental streaming for Base/reference-cloning
+requests. CustomVoice and VoiceDesign requests may still produce a single final
+audio event because those modes use the model's non-streaming prompt path.
+For raw PCM clients, the server defaults `initial_codec_chunk_frames` to `1`
+to reduce first-audio latency; set it to `0` to use the steady chunk size from
+the first vocoder decode.
+
 For clients that want a continuous byte stream instead of SSE framing, request raw PCM explicitly:
 
 ```bash

--- a/docs/cookbook/qwen3_tts.md
+++ b/docs/cookbook/qwen3_tts.md
@@ -126,7 +126,12 @@ curl -X POST http://localhost:8000/v1/audio/speech \
 
 ### Streaming
 
-Set `"stream": true` to receive audio chunks in real time over Server-Sent Events (SSE):
+Set `"stream": true` to receive audio chunks while Qwen3-TTS Base is still
+generating codec frames. For Base/reference-cloning checkpoints, SGLang-Omni
+streams generated codec rows from `tts_engine` into the vocoder and returns
+incremental audio chunks over SSE. CustomVoice and VoiceDesign checkpoints keep
+the existing full-result behavior because their prompt path uses Qwen's
+non-streaming model mode.
 
 ```bash
 curl -N -X POST http://localhost:8000/v1/audio/speech \

--- a/sglang_omni/models/qwen3_tts/config.py
+++ b/sglang_omni/models/qwen3_tts/config.py
@@ -30,6 +30,7 @@ class Qwen3TTSPipelineConfig(PipelineConfig):
             factory_args={"gpu_id": 0, "dtype": "bfloat16"},
             gpu=0,
             next="vocoder",
+            stream_to=["vocoder"],
         ),
         StageConfig(
             name="vocoder",
@@ -38,6 +39,7 @@ class Qwen3TTSPipelineConfig(PipelineConfig):
             factory_args={"gpu_id": 0, "dtype": "bfloat16"},
             gpu=0,
             terminal=True,
+            can_accept_stream_before_payload=True,
         ),
     ]
 

--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -10,6 +10,7 @@ from sglang.srt.managers.scheduler import GenerationBatchResult
 
 from sglang_omni.model_runner.base import ModelRunner
 from sglang_omni.models.qwen3_omni.talker_model_runner import QwenTalkerModelRunner
+from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.types import RequestOutput
 
 
@@ -19,6 +20,11 @@ class Qwen3TTSModelRunner(ModelRunner):
     def __init__(self, tp_worker: Any, output_processor: Any):
         super().__init__(tp_worker, output_processor)
         self._has_pending_code_step = False
+        self._outbox: Any | None = None
+        self._vocoder_target = "vocoder"
+
+    def set_stream_outbox(self, outbox: Any) -> None:
+        self._outbox = outbox
 
     def before_prefill(
         self,
@@ -155,6 +161,23 @@ class Qwen3TTSModelRunner(ModelRunner):
             feedback = self.model._output_embeds[row_idx].detach().clone()
             sched_req.data.output_codes.append(code_chunk)
             sched_req.data.pending_feedback_queue.append(feedback)
+            self._emit_code_chunk(sched_req, code_chunk)
+
+    def _emit_code_chunk(self, sched_req: Any, code_chunk: torch.Tensor) -> None:
+        if self._outbox is None:
+            return
+        metadata = getattr(sched_req.data, "stream_metadata", None)
+        if metadata is None:
+            return
+        self._outbox.put(
+            OutgoingMessage(
+                request_id=sched_req.request_id,
+                type="stream",
+                target=self._vocoder_target,
+                data=code_chunk,
+                metadata=metadata,
+            )
+        )
 
     def _sample_positions(
         self, forward_batch: Any, device: torch.device

--- a/sglang_omni/models/qwen3_tts/model_runner.py
+++ b/sglang_omni/models/qwen3_tts/model_runner.py
@@ -164,16 +164,17 @@ class Qwen3TTSModelRunner(ModelRunner):
             self._emit_code_chunk(sched_req, code_chunk)
 
     def _emit_code_chunk(self, sched_req: Any, code_chunk: torch.Tensor) -> None:
-        if self._outbox is None:
+        outbox = getattr(self, "_outbox", None)
+        if outbox is None:
             return
         metadata = getattr(sched_req.data, "stream_metadata", None)
         if metadata is None:
             return
-        self._outbox.put(
+        outbox.put(
             OutgoingMessage(
                 request_id=sched_req.request_id,
                 type="stream",
-                target=self._vocoder_target,
+                target=getattr(self, "_vocoder_target", "vocoder"),
                 data=code_chunk,
                 metadata=metadata,
             )

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -14,6 +14,7 @@ import torch
 
 from sglang_omni.models.qwen3_omni.pending_text_queue import PendingTextTensorQueue
 from sglang_omni.models.qwen3_tts.payload_types import Qwen3TTSState
+from sglang_omni.models.tts_streaming import INITIAL_CODEC_CHUNK_FRAMES_PARAM
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
 
@@ -81,6 +82,44 @@ def derive_qwen3_tts_sampling_seeds(seed: int) -> tuple[int, int]:
     )
 
 
+QWEN3_TTS_STREAM_CODEC = "qwen3_tts"
+
+
+def build_qwen3_tts_stream_metadata(
+    payload: StagePayload,
+    state: Qwen3TTSState,
+    *,
+    num_codebooks: int,
+) -> dict[str, Any] | None:
+    params = payload.request.params
+    if not isinstance(params, dict):
+        raise TypeError(
+            f"Qwen3-TTS request params must be a dict, got {type(params).__name__}"
+        )
+    if not bool(params.get("stream", False)):
+        return None
+    if state.non_streaming_mode:
+        return None
+    num_codebooks = int(num_codebooks)
+    if num_codebooks <= 0:
+        raise ValueError(
+            f"Qwen3-TTS stream num_codebooks must be > 0, got {num_codebooks}"
+        )
+
+    metadata: dict[str, Any] = {
+        "modality": "audio_codes",
+        "stream": True,
+        "codec": QWEN3_TTS_STREAM_CODEC,
+        "sample_rate": int(state.sample_rate),
+        "num_codebooks": num_codebooks,
+    }
+    if params.get(INITIAL_CODEC_CHUNK_FRAMES_PARAM) is not None:
+        metadata[INITIAL_CODEC_CHUNK_FRAMES_PARAM] = params[
+            INITIAL_CODEC_CHUNK_FRAMES_PARAM
+        ]
+    return metadata
+
+
 @dataclass
 class Qwen3TTSSGLangRequestData(SGLangARRequestData):
     """Qwen3-TTS scheduler-owned request state."""
@@ -97,6 +136,8 @@ class Qwen3TTSSGLangRequestData(SGLangARRequestData):
     subtalker_top_k: int = 50
     subtalker_sampling_seed: int = field(default_factory=_new_qwen3_tts_sampling_seed)
     engine_start_s: float = 0.0
+    num_codebooks: int = 0
+    stream_metadata: dict[str, Any] | None = None
 
 
 @dataclass
@@ -753,6 +794,9 @@ def build_sglang_qwen3_tts_request(
     ref_code_len = (
         int(prepared.ref_code.shape[0]) if prepared.ref_code is not None else 0
     )
+    num_codebooks = int(getattr(model.config, "num_code_groups", 0) or 0)
+    if num_codebooks <= 0 and prepared.ref_code is not None:
+        num_codebooks = int(prepared.ref_code.shape[1])
     data = Qwen3TTSSGLangRequestData(
         input_ids=prepared.input_ids,
         attention_mask=prepared.attention_mask,
@@ -772,6 +816,12 @@ def build_sglang_qwen3_tts_request(
         subtalker_top_k=int(gen_kwargs.get("subtalker_top_k", 50)),
         subtalker_sampling_seed=subtalker_sampling_seed,
         engine_start_s=time.perf_counter(),
+        num_codebooks=num_codebooks,
+        stream_metadata=build_qwen3_tts_stream_metadata(
+            payload,
+            state,
+            num_codebooks=num_codebooks,
+        ),
     )
     data.suppress_tokens = list(req._codec_suppress_tokens)
     data.pending_text_queue = PendingTextTensorQueue.from_tensor(

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -83,6 +83,10 @@ def derive_qwen3_tts_sampling_seeds(seed: int) -> tuple[int, int]:
 
 
 QWEN3_TTS_STREAM_CODEC = "qwen3_tts"
+# Upper bound on ref-clone frames shipped to the streaming vocoder as decode
+# left-context. The vocoder re-clamps to its own ``left_context_frames``; this
+# only caps the per-chunk metadata size (kept well under the CUDA-IPC inline limit).
+QWEN3_TTS_REF_CONTEXT_CAP = 25
 
 
 def build_qwen3_tts_stream_metadata(
@@ -90,6 +94,7 @@ def build_qwen3_tts_stream_metadata(
     state: Qwen3TTSState,
     *,
     num_codebooks: int,
+    ref_code: torch.Tensor | None = None,
 ) -> dict[str, Any] | None:
     params = payload.request.params
     if not isinstance(params, dict):
@@ -117,6 +122,15 @@ def build_qwen3_tts_stream_metadata(
         metadata[INITIAL_CODEC_CHUNK_FRAMES_PARAM] = params[
             INITIAL_CODEC_CHUNK_FRAMES_PARAM
         ]
+    # Reference-clone acoustic left-context. Non-streaming decodes
+    # ``[ref_code ++ output_codes]`` then trims the ref prefix, so its first
+    # output frames carry the clone's acoustic history. Streaming decodes
+    # output codes alone, so seed the vocoder's first window with the tail of
+    # the ref codes to recover that onset context (parity with the
+    # ``ref_code is not None and ref_code.shape[0] > 0`` guard non-streaming uses).
+    if ref_code is not None and int(ref_code.shape[0]) > 0:
+        tail = ref_code[-QWEN3_TTS_REF_CONTEXT_CAP:].to(dtype=torch.long).cpu()
+        metadata["ref_context_codes"] = tail.tolist()
     return metadata
 
 
@@ -821,6 +835,7 @@ def build_sglang_qwen3_tts_request(
             payload,
             state,
             num_codebooks=num_codebooks,
+            ref_code=prepared.ref_code,
         ),
     )
     data.suppress_tokens = list(req._codec_suppress_tokens)

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -16,9 +16,11 @@ from sglang_omni.models.qwen3_tts.request_builders import (
     preprocess_qwen3_tts_payload,
     set_qwen3_tts_preprocessing_context,
 )
+from sglang_omni.models.qwen3_tts.streaming_vocoder import (
+    Qwen3TTSStreamingVocoderScheduler,
+)
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
-from sglang_omni.utils.audio_payload import audio_waveform_payload
 
 logger = logging.getLogger(__name__)
 
@@ -170,13 +172,10 @@ def create_sglang_tts_engine_executor(
     from qwen_tts import Qwen3TTSModel
     from transformers import AutoProcessor
 
-    from sglang_omni.models.qwen3_tts.model_runner import Qwen3TTSModelRunner
-    from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
-    from sglang_omni.scheduling.omni_scheduler import OmniScheduler
-    from sglang_omni.scheduling.sglang_backend import (
-        SGLangOutputProcessor,
-        build_sglang_server_args,
-    )
+    import sglang_omni.models.qwen3_tts.model_runner as model_runner_mod
+    import sglang_omni.scheduling.bootstrap as bootstrap_mod
+    import sglang_omni.scheduling.omni_scheduler as omni_scheduler_mod
+    import sglang_omni.scheduling.sglang_backend as sglang_backend_mod
 
     _register_qwen3_tts_hf_config()
     checkpoint_dir = _resolve_checkpoint(model_path)
@@ -184,7 +183,7 @@ def create_sglang_tts_engine_executor(
         device = f"cuda:{gpu_id}"
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0
 
-    server_args = build_sglang_server_args(
+    server_args = sglang_backend_mod.build_sglang_server_args(
         checkpoint_dir,
         context_length=8192,
         dtype=dtype,
@@ -211,7 +210,7 @@ def create_sglang_tts_engine_executor(
         prefill_mgr,
         decode_mgr,
         model_config,
-    ) = create_sglang_infrastructure(
+    ) = bootstrap_mod.create_sglang_infrastructure(
         server_args,
         gpu_id,
         model_arch_override="Qwen3TTSTalker",
@@ -241,7 +240,7 @@ def create_sglang_tts_engine_executor(
     if want_cuda_graph:
         model_worker.model_runner.init_device_graphs()
 
-    output_proc = SGLangOutputProcessor(
+    output_proc = sglang_backend_mod.SGLangOutputProcessor(
         capture_hidden=False,
         capture_hidden_layers=None,
         model=model,
@@ -251,7 +250,8 @@ def create_sglang_tts_engine_executor(
         wrapper=wrapper,
     )
 
-    return OmniScheduler(
+    model_runner = model_runner_mod.Qwen3TTSModelRunner(model_worker, output_proc)
+    scheduler = omni_scheduler_mod.OmniScheduler(
         tp_worker=model_worker,
         tree_cache=tree_cache,
         req_to_token_pool=req_to_token_pool,
@@ -260,11 +260,13 @@ def create_sglang_tts_engine_executor(
         model_config=model_config,
         prefill_manager=prefill_mgr,
         decode_manager=decode_mgr,
-        model_runner=Qwen3TTSModelRunner(model_worker, output_proc),
+        model_runner=model_runner,
         request_builder=request_builder,
         result_adapter=result_adapter,
         abort_callback=cleanup_prepared_qwen3_tts_request,
     )
+    model_runner.set_stream_outbox(scheduler.outbox)
+    return scheduler
 
 
 def create_tts_engine_executor(*args, **kwargs) -> Any:
@@ -280,7 +282,9 @@ def create_vocoder_executor(
     attn_implementation: str | None = None,
     max_batch_size: int = 8,
     max_batch_wait_ms: int = 2,
-) -> SimpleScheduler:
+    stream_chunk_frames: int = 6,
+    left_context_frames: int = 6,
+) -> Qwen3TTSStreamingVocoderScheduler:
     if gpu_id is not None:
         device = f"cuda:{gpu_id}"
     tokenizer = _load_qwen3_tts_tokenizer(
@@ -289,68 +293,10 @@ def create_vocoder_executor(
         dtype=dtype,
         attn_implementation=attn_implementation,
     )
-
-    def _prepare_vocoder_item(
-        payload: StagePayload,
-    ) -> tuple[Qwen3TTSState, torch.Tensor]:
-        state = load_state(payload)
-        if state.audio_codes is None:
-            raise RuntimeError("Qwen3-TTS vocoder requires audio_codes from tts_engine")
-
-        codes = torch.as_tensor(state.audio_codes, dtype=torch.long)
-        return state, codes
-
-    def _store_vocoder_result(
-        payload: StagePayload,
-        state: Qwen3TTSState,
-        codes: torch.Tensor,
-        wav: Any,
-        sample_rate: int,
-    ) -> StagePayload:
-        if wav is None:
-            raise RuntimeError("Qwen3-TTS speech tokenizer did not return audio")
-
-        if state.ref_code_len:
-            total_len = int(codes.shape[0])
-            cut = int(state.ref_code_len / max(total_len, 1) * wav.shape[0])
-            wav = wav[cut:]
-        audio_payload = audio_waveform_payload(wav, source_hint="Qwen3-TTS")
-        state.audio_samples = None
-        state.sample_rate = int(sample_rate)
-        state.audio_codes = None
-
-        payload = store_state(payload, state)
-        payload.data.update(audio_payload)
-        payload.data["sample_rate"] = state.sample_rate
-        payload.data["modality"] = "audio"
-        usage = _build_usage(state)
-        if usage is not None:
-            payload.data["usage"] = usage
-        return payload
-
-    def _vocode(payload: StagePayload) -> StagePayload:
-        state, codes = _prepare_vocoder_item(payload)
-        wavs, sample_rate = tokenizer.decode([{"audio_codes": codes}])
-        wav = wavs[0] if wavs else None
-        return _store_vocoder_result(payload, state, codes, wav, sample_rate)
-
-    def _vocode_batch(payloads: list[StagePayload]) -> list[StagePayload]:
-        items = [_prepare_vocoder_item(payload) for payload in payloads]
-        wavs, sample_rate = tokenizer.decode(
-            [{"audio_codes": codes} for _, codes in items]
-        )
-        if len(wavs) != len(items):
-            raise RuntimeError(
-                f"Qwen3-TTS speech tokenizer returned {len(wavs)} audios for {len(items)} requests"
-            )
-        return [
-            _store_vocoder_result(payload, state, codes, wav, sample_rate)
-            for payload, (state, codes), wav in zip(payloads, items, wavs)
-        ]
-
-    return SimpleScheduler(
-        _vocode,
-        batch_compute_fn=_vocode_batch,
+    return Qwen3TTSStreamingVocoderScheduler(
+        tokenizer,
         max_batch_size=max_batch_size,
         max_batch_wait_ms=max_batch_wait_ms,
+        stream_chunk_frames=stream_chunk_frames,
+        left_context_frames=left_context_frames,
     )

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -1,0 +1,420 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Streaming vocoder scheduler for Qwen3-TTS."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+import numpy as np
+import torch
+
+from sglang_omni.models.qwen3_tts.payload_types import Qwen3TTSState
+from sglang_omni.models.tts_streaming import (
+    INITIAL_CODEC_CHUNK_FRAMES_PARAM,
+    resolve_initial_codec_chunk_frames,
+)
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.messages import OutgoingMessage
+from sglang_omni.scheduling.streaming_simple_scheduler import StreamingSimpleScheduler
+from sglang_omni.utils.audio_payload import audio_waveform_payload
+
+
+@dataclass
+class _Qwen3TTSStreamState:
+    rows: list[torch.Tensor] = field(default_factory=list)
+    emitted_frame_count: int = 0
+    decoded_audio_chunks: list[np.ndarray] = field(default_factory=list)
+    num_codebooks: int | None = None
+    sample_rate: int = 24000
+    initial_codec_chunk_frames: int = 0
+    has_emitted: bool = False
+
+
+class Qwen3TTSStreamingVocoderScheduler(StreamingSimpleScheduler):
+    """Decode Qwen3-TTS codec rows incrementally, with batched final decode."""
+
+    def __init__(
+        self,
+        tokenizer: Any,
+        *,
+        stream_chunk_frames: int = 6,
+        left_context_frames: int = 6,
+        max_batch_size: int = 8,
+        max_batch_wait_ms: int = 2,
+    ) -> None:
+        if stream_chunk_frames <= 0:
+            raise ValueError("stream_chunk_frames must be > 0")
+        if left_context_frames < 0:
+            raise ValueError("left_context_frames must be >= 0")
+        if max_batch_size <= 0:
+            raise ValueError("max_batch_size must be > 0")
+        if max_batch_wait_ms < 0:
+            raise ValueError("max_batch_wait_ms must be >= 0")
+
+        self._tokenizer = tokenizer
+        self._stream_chunk_frames = int(stream_chunk_frames)
+        self._left_context_frames = int(left_context_frames)
+        self._stream_states: dict[str, _Qwen3TTSStreamState] = {}
+
+        super().__init__(
+            self._vocode_payload,
+            batch_compute_fn=self._vocode_payloads,
+            max_batch_size=max_batch_size,
+            max_batch_wait_ms=max_batch_wait_ms,
+        )
+
+    def is_streaming_payload(self, payload: StagePayload) -> bool:
+        params = payload.request.params
+        if not isinstance(params, dict):
+            raise TypeError(
+                f"Qwen3-TTS request params must be a dict, got {type(params).__name__}"
+            )
+        state = Qwen3TTSState.from_dict(payload.data)
+        return bool(params.get("stream", False)) and not state.non_streaming_mode
+
+    def on_streaming_new_request(self, request_id: str, payload: StagePayload) -> None:
+        state = Qwen3TTSState.from_dict(payload.data)
+        stream_state = self._stream_states.setdefault(
+            request_id, _Qwen3TTSStreamState()
+        )
+        stream_state.sample_rate = int(state.sample_rate)
+        self._latch_initial_codec_chunk_frames_from_mapping(
+            request_id,
+            stream_state,
+            (
+                payload.request.params
+                if isinstance(payload.request.params, dict)
+                else None
+            ),
+        )
+
+    def on_stream_chunk(
+        self, request_id: str, item: StreamItem
+    ) -> list[OutgoingMessage]:
+        state = self._stream_states.setdefault(request_id, _Qwen3TTSStreamState())
+        self._latch_stream_metadata(request_id, state, item.metadata)
+
+        row = item.data
+        if not isinstance(row, torch.Tensor):
+            raise TypeError(
+                f"Qwen3-TTS stream chunk for {request_id!r} must carry a torch.Tensor, "
+                f"got {type(row).__name__}"
+            )
+        row = row.to(dtype=torch.long)
+        if row.ndim != 1:
+            raise ValueError(
+                f"Qwen3-TTS stream chunk must be 1-D [codebooks], "
+                f"got {tuple(row.shape)}"
+            )
+
+        num_codebooks = self._require_num_codebooks(state, request_id)
+        if int(row.shape[0]) != num_codebooks:
+            raise ValueError(
+                f"Qwen3-TTS stream chunk has {int(row.shape[0])} codebooks, "
+                f"expected {num_codebooks}"
+            )
+        state.rows.append(row)
+
+        output = self._decode_delta(state, is_final=False)
+        if output is None:
+            return []
+        return [
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                data=output,
+                metadata={"modality": "audio"},
+            )
+        ]
+
+    def on_stream_done(self, request_id: str) -> list[OutgoingMessage]:
+        payload = self._stream_payloads[request_id]
+        state = self._stream_states.setdefault(request_id, _Qwen3TTSStreamState())
+        output = self._decode_delta(state, is_final=True)
+
+        messages: list[OutgoingMessage] = []
+        if output is not None:
+            messages.append(
+                OutgoingMessage(
+                    request_id=request_id,
+                    type="stream",
+                    data=output,
+                    metadata={"modality": "audio"},
+                )
+            )
+
+        final_data: dict[str, Any] = {
+            "modality": "audio",
+            "sample_rate": int(state.sample_rate),
+        }
+        usage = self._build_usage(Qwen3TTSState.from_dict(payload.data))
+        if usage is not None:
+            final_data["usage"] = usage
+        messages.append(
+            OutgoingMessage(
+                request_id=request_id,
+                type="result",
+                data=StagePayload(
+                    request_id=payload.request_id,
+                    request=payload.request,
+                    data=final_data,
+                ),
+            )
+        )
+        return messages
+
+    def clear_stream_state(self, request_id: str) -> None:
+        self._stream_states.pop(request_id, None)
+
+    def _latch_stream_metadata(
+        self,
+        request_id: str,
+        state: _Qwen3TTSStreamState,
+        metadata: dict[str, Any] | None,
+    ) -> None:
+        if not isinstance(metadata, dict):
+            raise RuntimeError(
+                f"Qwen3-TTS stream chunk for {request_id!r} is missing metadata"
+            )
+        if metadata.get("modality") != "audio_codes":
+            raise ValueError(
+                f"Qwen3-TTS stream chunk modality must be audio_codes, "
+                f"got {metadata.get('modality')!r}"
+            )
+        if metadata.get("stream") is not True:
+            raise RuntimeError(
+                f"Qwen3-TTS stream chunk for {request_id!r} must include "
+                "metadata['stream'] == True"
+            )
+        if metadata.get("codec") != "qwen3_tts":
+            raise ValueError(
+                f"Qwen3-TTS stream chunk codec must be qwen3_tts, "
+                f"got {metadata.get('codec')!r}"
+            )
+        if "num_codebooks" not in metadata:
+            raise RuntimeError(
+                f"Qwen3-TTS stream chunk for {request_id!r} is missing num_codebooks"
+            )
+        self._latch_num_codebooks(
+            request_id,
+            state,
+            metadata["num_codebooks"],
+            source="stream metadata",
+        )
+        if "sample_rate" in metadata:
+            self._latch_sample_rate(
+                request_id,
+                state,
+                metadata["sample_rate"],
+                source="stream metadata",
+            )
+        if INITIAL_CODEC_CHUNK_FRAMES_PARAM in metadata:
+            self._latch_initial_codec_chunk_frames_from_mapping(
+                request_id,
+                state,
+                metadata,
+            )
+
+    @staticmethod
+    def _latch_num_codebooks(
+        request_id: str,
+        state: _Qwen3TTSStreamState,
+        value: Any,
+        *,
+        source: str,
+    ) -> None:
+        try:
+            num_codebooks = int(value)
+        except (TypeError, ValueError) as exc:
+            raise TypeError(
+                f"Qwen3-TTS {source} for {request_id!r} must include integer "
+                "num_codebooks"
+            ) from exc
+        if num_codebooks <= 0:
+            raise ValueError(
+                f"Qwen3-TTS {source} for {request_id!r} has invalid "
+                f"num_codebooks={num_codebooks}"
+            )
+        if state.num_codebooks is not None and state.num_codebooks != num_codebooks:
+            raise ValueError(
+                f"Qwen3-TTS stream num_codebooks changed for {request_id!r}: "
+                f"{state.num_codebooks} -> {num_codebooks}"
+            )
+        state.num_codebooks = num_codebooks
+
+    @staticmethod
+    def _latch_sample_rate(
+        request_id: str,
+        state: _Qwen3TTSStreamState,
+        value: Any,
+        *,
+        source: str,
+    ) -> None:
+        try:
+            sample_rate = int(value)
+        except (TypeError, ValueError) as exc:
+            raise TypeError(
+                f"Qwen3-TTS {source} for {request_id!r} must include integer "
+                "sample_rate"
+            ) from exc
+        if sample_rate <= 0:
+            raise ValueError(
+                f"Qwen3-TTS {source} for {request_id!r} has invalid "
+                f"sample_rate={sample_rate}"
+            )
+        if state.sample_rate and state.sample_rate != sample_rate:
+            raise ValueError(
+                f"Qwen3-TTS stream sample_rate changed for {request_id!r}: "
+                f"{state.sample_rate} -> {sample_rate}"
+            )
+        state.sample_rate = sample_rate
+
+    def _latch_initial_codec_chunk_frames_from_mapping(
+        self,
+        request_id: str,
+        state: _Qwen3TTSStreamState,
+        params: Mapping[str, Any] | None,
+    ) -> None:
+        del request_id
+        state.initial_codec_chunk_frames = resolve_initial_codec_chunk_frames(
+            params,
+            steady_chunk_frames=self._stream_chunk_frames,
+        )
+
+    @staticmethod
+    def _require_num_codebooks(
+        state: _Qwen3TTSStreamState,
+        request_id: str,
+    ) -> int:
+        if state.num_codebooks is None:
+            raise RuntimeError(
+                f"Qwen3-TTS stream contract for {request_id!r} is missing num_codebooks"
+            )
+        return state.num_codebooks
+
+    def _decode_delta(
+        self,
+        state: _Qwen3TTSStreamState,
+        *,
+        is_final: bool,
+    ) -> dict[str, Any] | None:
+        total_frames = len(state.rows)
+        if total_frames == 0 or total_frames <= state.emitted_frame_count:
+            return None
+
+        next_chunk_frames = (
+            state.initial_codec_chunk_frames
+            if state.initial_codec_chunk_frames > 0 and not state.has_emitted
+            else self._stream_chunk_frames
+        )
+        emit_until = total_frames
+        if not is_final:
+            target = state.emitted_frame_count + next_chunk_frames
+            if total_frames < target:
+                return None
+            emit_until = target
+
+        window_start = max(0, state.emitted_frame_count - self._left_context_frames)
+        rows = state.rows[window_start:emit_until]
+        audio = self._decode_rows(rows)
+        decoded_frames = emit_until - window_start
+        samples_per_frame = max(int(audio.shape[0]) // max(decoded_frames, 1), 1)
+        trim_frames = state.emitted_frame_count - window_start
+        trim_samples = min(int(trim_frames * samples_per_frame), int(audio.shape[0]))
+        delta = np.ascontiguousarray(audio[trim_samples:], dtype=np.float32)
+        if delta.size == 0:
+            return None
+
+        state.emitted_frame_count = emit_until
+        state.has_emitted = True
+        state.decoded_audio_chunks.append(delta)
+        return audio_waveform_payload(
+            delta,
+            sample_rate=state.sample_rate,
+            modality="audio",
+            source_hint="Qwen3-TTS streaming",
+        )
+
+    def _decode_rows(self, rows: list[torch.Tensor]) -> np.ndarray:
+        codes = torch.stack(rows, dim=0).to(dtype=torch.long)
+        wavs, _sample_rate = self._tokenizer.decode([{"audio_codes": codes}])
+        wav = wavs[0] if wavs else None
+        if wav is None:
+            raise RuntimeError("Qwen3-TTS speech tokenizer did not return audio")
+        return np.asarray(wav, dtype=np.float32).reshape(-1)
+
+    def _vocode_payload(self, payload: StagePayload) -> StagePayload:
+        return self._vocode_payloads([payload])[0]
+
+    def _vocode_payloads(self, payloads: list[StagePayload]) -> list[StagePayload]:
+        items = [self._prepare_vocoder_item(payload) for payload in payloads]
+        wavs, sample_rate = self._tokenizer.decode(
+            [{"audio_codes": codes} for _, codes in items]
+        )
+        if len(wavs) != len(items):
+            raise RuntimeError(
+                f"Qwen3-TTS speech tokenizer returned {len(wavs)} audios "
+                f"for {len(items)} requests"
+            )
+        return [
+            self._store_vocoder_result(payload, state, codes, wav, sample_rate)
+            for payload, (state, codes), wav in zip(payloads, items, wavs)
+        ]
+
+    @staticmethod
+    def _prepare_vocoder_item(
+        payload: StagePayload,
+    ) -> tuple[Qwen3TTSState, torch.Tensor]:
+        state = Qwen3TTSState.from_dict(payload.data)
+        if state.audio_codes is None:
+            raise RuntimeError("Qwen3-TTS vocoder requires audio_codes from tts_engine")
+        codes = torch.as_tensor(state.audio_codes, dtype=torch.long)
+        return state, codes
+
+    @classmethod
+    def _store_vocoder_result(
+        cls,
+        payload: StagePayload,
+        state: Qwen3TTSState,
+        codes: torch.Tensor,
+        wav: Any,
+        sample_rate: int,
+    ) -> StagePayload:
+        if wav is None:
+            raise RuntimeError("Qwen3-TTS speech tokenizer did not return audio")
+
+        if state.ref_code_len:
+            total_len = int(codes.shape[0])
+            cut = int(state.ref_code_len / max(total_len, 1) * wav.shape[0])
+            wav = wav[cut:]
+        audio_payload = audio_waveform_payload(wav, source_hint="Qwen3-TTS")
+        state.audio_samples = None
+        state.sample_rate = int(sample_rate)
+        state.audio_codes = None
+
+        payload.data = state.to_dict()
+        payload.data.update(audio_payload)
+        payload.data["sample_rate"] = state.sample_rate
+        payload.data["modality"] = "audio"
+        usage = cls._build_usage(state)
+        if usage is not None:
+            payload.data["usage"] = usage
+        return payload
+
+    @staticmethod
+    def _build_usage(state: Qwen3TTSState) -> dict[str, Any] | None:
+        if not (state.prompt_tokens or state.completion_tokens or state.engine_time_s):
+            return None
+        usage: dict[str, Any] = {
+            "prompt_tokens": state.prompt_tokens,
+            "completion_tokens": state.completion_tokens,
+            "total_tokens": state.prompt_tokens + state.completion_tokens,
+        }
+        if state.engine_time_s:
+            usage["engine_time_s"] = round(float(state.engine_time_s), 6)
+        return usage
+
+
+__all__ = ["Qwen3TTSStreamingVocoderScheduler"]

--- a/sglang_omni/models/qwen3_tts/streaming_vocoder.py
+++ b/sglang_omni/models/qwen3_tts/streaming_vocoder.py
@@ -30,6 +30,7 @@ class _Qwen3TTSStreamState:
     sample_rate: int = 24000
     initial_codec_chunk_frames: int = 0
     has_emitted: bool = False
+    ref_seeded: bool = False
 
 
 class Qwen3TTSStreamingVocoderScheduler(StreamingSimpleScheduler):
@@ -216,6 +217,50 @@ class Qwen3TTSStreamingVocoderScheduler(StreamingSimpleScheduler):
                 state,
                 metadata,
             )
+        self._maybe_seed_ref_context(
+            request_id, state, metadata.get("ref_context_codes")
+        )
+
+    def _maybe_seed_ref_context(
+        self,
+        request_id: str,
+        state: _Qwen3TTSStreamState,
+        ref_context_codes: Any,
+    ) -> None:
+        """Seed the first decode window with reference-clone left-context.
+
+        Non-streaming decodes ``[ref_code ++ output_codes]`` and trims the ref
+        prefix, so its first output frames carry the clone's acoustic history.
+        Streaming decodes output codes alone; we prepend the tail of the ref
+        codes (clamped to ``left_context_frames``) as already-emitted rows so the
+        first window's overlap-decode sees that history and then trims it away,
+        exactly as ``_decode_delta`` trims any left-context. Consumed once, before
+        any output row arrives; never marks ``has_emitted`` so the
+        ``initial_codec_chunk_frames`` first-chunk latency path is preserved.
+        """
+        if (
+            ref_context_codes is None
+            or state.ref_seeded
+            or state.has_emitted
+            or state.rows
+            or self._left_context_frames <= 0
+        ):
+            state.ref_seeded = True
+            return
+        num_codebooks = self._require_num_codebooks(state, request_id)
+        seeded: list[torch.Tensor] = []
+        for frame in ref_context_codes[-self._left_context_frames :]:
+            row = torch.as_tensor(frame, dtype=torch.long).reshape(-1)
+            if int(row.shape[0]) != num_codebooks:
+                state.ref_seeded = True
+                return
+            seeded.append(row)
+        if not seeded:
+            state.ref_seeded = True
+            return
+        state.rows.extend(seeded)
+        state.emitted_frame_count = len(seeded)
+        state.ref_seeded = True
 
     @staticmethod
     def _latch_num_codebooks(
@@ -338,7 +383,15 @@ class Qwen3TTSStreamingVocoderScheduler(StreamingSimpleScheduler):
         )
 
     def _decode_rows(self, rows: list[torch.Tensor]) -> np.ndarray:
-        codes = torch.stack(rows, dim=0).to(dtype=torch.long)
+        # Seeded ref-context rows arrive on CPU (relayed as plain ints in
+        # metadata) while emitted output rows keep the model's device, so
+        # normalize to the native output device before stacking. The last row
+        # is always an emitted output frame; ``.to`` is a no-op when devices
+        # already match (the common, unseeded path).
+        target_device = rows[-1].device
+        codes = torch.stack([row.to(target_device) for row in rows], dim=0).to(
+            dtype=torch.long
+        )
         wavs, _sample_rate = self._tokenizer.decode([{"audio_codes": codes}])
         wav = wavs[0] if wavs else None
         if wav is None:

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -217,6 +217,9 @@ def test_qwen3_tts_config_and_registry_contracts() -> None:
         "vocoder",
     ]
     assert config.stages[1].factory.endswith("create_sglang_tts_engine_executor")
+    assert config.stages[1].next == "vocoder"
+    assert config.stages[1].stream_to == ["vocoder"]
+    assert config.stages[2].can_accept_stream_before_payload is True
     assert config.terminal_stages == ["vocoder"]
     assert config.gpu_placement == {"tts_engine": 0, "vocoder": 0}
     assert "device" not in config.stages[1].factory_args

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import queue
 import sys
 import threading
 import types
@@ -1320,6 +1321,72 @@ def test_qwen3_tts_collect_codes_excludes_semantic_eos(
 
     runner.post_process_outputs(result, SimpleNamespace(requests=requests), {})
     assert len(requests[0].data.output_codes) == 1
+
+
+def test_qwen3_tts_model_runner_emits_stream_code_chunks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang(monkeypatch)
+    from sglang_omni.models.qwen3_tts.model_runner import Qwen3TTSModelRunner
+
+    runner = Qwen3TTSModelRunner.__new__(Qwen3TTSModelRunner)
+    runner._has_pending_code_step = True
+    runner._outbox = queue.Queue()
+    runner._vocoder_target = "vocoder"
+    runner.model = SimpleNamespace(
+        config=SimpleNamespace(codec_eos_token_id=42),
+        _output_codes=torch.tensor([[1, 2], [3, 4]], dtype=torch.long),
+        _output_embeds=torch.tensor([[0.1, 0.2], [0.3, 0.4]]),
+    )
+    active_data = Qwen3TTSSGLangRequestData(
+        stream_metadata={
+            "modality": "audio_codes",
+            "stream": True,
+            "codec": "qwen3_tts",
+            "sample_rate": 24000,
+            "num_codebooks": 2,
+        }
+    )
+    eos_data = Qwen3TTSSGLangRequestData(
+        stream_metadata={
+            "modality": "audio_codes",
+            "stream": True,
+            "codec": "qwen3_tts",
+            "sample_rate": 24000,
+            "num_codebooks": 2,
+        }
+    )
+    requests = [
+        SimpleNamespace(request_id="active", data=active_data),
+        SimpleNamespace(request_id="eos", data=eos_data),
+    ]
+    outputs = {
+        "active": RequestOutput("active", data=7),
+        "eos": RequestOutput("eos", data=42),
+    }
+
+    runner.post_process_outputs(
+        result=SimpleNamespace(),
+        scheduler_output=SimpleNamespace(requests=requests),
+        outputs=outputs,
+    )
+
+    out = runner._outbox.get_nowait()
+    assert out.request_id == "active"
+    assert out.type == "stream"
+    assert out.target == "vocoder"
+    assert out.data.tolist() == [1, 2]
+    assert out.metadata == {
+        "modality": "audio_codes",
+        "stream": True,
+        "codec": "qwen3_tts",
+        "sample_rate": 24000,
+        "num_codebooks": 2,
+    }
+    with pytest.raises(queue.Empty):
+        runner._outbox.get_nowait()
+    assert [chunk.tolist() for chunk in active_data.output_codes] == [[1, 2]]
+    assert eos_data.output_codes == []
 
 
 def test_qwen3_tts_steady_decode_reports_cuda_graph_ready(

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -22,11 +22,13 @@ from sglang_omni.models.qwen3_tts.request_builders import (
     Qwen3TTSSGLangRequestData,
     apply_sglang_qwen3_tts_result,
     build_embedding_cache_key_ids,
+    build_qwen3_tts_stream_metadata,
     build_qwen3_tts_state,
     build_sglang_qwen3_tts_request,
     derive_qwen3_tts_sampling_seeds,
 )
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+from sglang_omni.models.tts_streaming import INITIAL_CODEC_CHUNK_FRAMES_PARAM
 from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.scheduling.messages import IncomingMessage
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler
@@ -323,6 +325,82 @@ def test_qwen3_tts_ignores_client_sampling_defaults() -> None:
     state = build_qwen3_tts_state(payload)
 
     assert state.generation_kwargs == {"max_new_tokens": 2048}
+
+
+def test_qwen3_tts_stream_metadata_for_base_stream_request() -> None:
+    payload = make_payload(
+        inputs={
+            "input": "hello",
+            "references": [{"audio_path": "ref.wav", "text": "hi"}],
+        },
+        params={"stream": True, INITIAL_CODEC_CHUNK_FRAMES_PARAM: "1"},
+    )
+    state = Qwen3TTSState(
+        task_type="Base",
+        non_streaming_mode=False,
+        sample_rate=24000,
+    )
+
+    metadata = build_qwen3_tts_stream_metadata(
+        payload,
+        state,
+        num_codebooks=4,
+    )
+
+    assert metadata == {
+        "modality": "audio_codes",
+        "stream": True,
+        "codec": "qwen3_tts",
+        "sample_rate": 24000,
+        "num_codebooks": 4,
+        INITIAL_CODEC_CHUNK_FRAMES_PARAM: "1",
+    }
+
+
+def test_qwen3_tts_stream_metadata_disabled_for_non_streaming_model_mode() -> None:
+    payload = make_payload(inputs="hello", params={"stream": True})
+    state = Qwen3TTSState(
+        task_type="CustomVoice",
+        non_streaming_mode=True,
+        sample_rate=24000,
+    )
+
+    metadata = build_qwen3_tts_stream_metadata(
+        payload,
+        state,
+        num_codebooks=4,
+    )
+
+    assert metadata is None
+
+
+def test_qwen3_tts_stream_metadata_disabled_without_client_stream() -> None:
+    payload = make_payload(inputs="hello", params={"stream": False})
+    state = Qwen3TTSState(
+        task_type="Base",
+        non_streaming_mode=False,
+        sample_rate=24000,
+    )
+
+    metadata = build_qwen3_tts_stream_metadata(
+        payload,
+        state,
+        num_codebooks=4,
+    )
+
+    assert metadata is None
+
+
+def test_qwen3_tts_stream_metadata_rejects_missing_codebook_count() -> None:
+    payload = make_payload(inputs="hello", params={"stream": True})
+    state = Qwen3TTSState(
+        task_type="Base",
+        non_streaming_mode=False,
+        sample_rate=24000,
+    )
+
+    with pytest.raises(ValueError, match="num_codebooks"):
+        build_qwen3_tts_stream_metadata(payload, state, num_codebooks=0)
 
 
 def test_qwen3_tts_embedding_cache_keys_are_stable_and_content_based() -> None:

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -358,6 +358,33 @@ def test_qwen3_tts_stream_metadata_for_base_stream_request() -> None:
     }
 
 
+def test_qwen3_tts_stream_metadata_injects_ref_context_tail() -> None:
+    payload = make_payload(
+        inputs={
+            "input": "hello",
+            "references": [{"audio_path": "ref.wav", "text": "hi"}],
+        },
+        params={"stream": True},
+    )
+    state = Qwen3TTSState(
+        task_type="Base",
+        non_streaming_mode=False,
+        sample_rate=24000,
+    )
+    # 30 ref frames, 2 codebooks; only the last CAP (25) ride the wire.
+    ref_code = torch.arange(60, dtype=torch.long).reshape(30, 2)
+
+    metadata = build_qwen3_tts_stream_metadata(
+        payload,
+        state,
+        num_codebooks=2,
+        ref_code=ref_code,
+    )
+
+    assert metadata["ref_context_codes"] == ref_code[-25:].tolist()
+    assert len(metadata["ref_context_codes"]) == 25
+
+
 def test_qwen3_tts_stream_metadata_disabled_for_non_streaming_model_mode() -> None:
     payload = make_payload(inputs="hello", params={"stream": True})
     state = Qwen3TTSState(
@@ -1977,7 +2004,7 @@ def test_qwen3_tts_engine_reenables_cuda_graph_after_bootstrap(
     monkeypatch.setattr(
         scheduler_mod,
         "OmniScheduler",
-        lambda **kwargs: SimpleNamespace(**kwargs),
+        lambda **kwargs: SimpleNamespace(outbox=object(), **kwargs),
     )
 
     scheduler = stages.create_sglang_tts_engine_executor("model", device="cuda:0")

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -23,8 +23,8 @@ from sglang_omni.models.qwen3_tts.request_builders import (
     Qwen3TTSSGLangRequestData,
     apply_sglang_qwen3_tts_result,
     build_embedding_cache_key_ids,
-    build_qwen3_tts_stream_metadata,
     build_qwen3_tts_state,
+    build_qwen3_tts_stream_metadata,
     build_sglang_qwen3_tts_request,
     derive_qwen3_tts_sampling_seeds,
 )
@@ -786,6 +786,39 @@ def test_qwen3_tts_vocoder_batches_decode_requests(
     assert "audio_codes" not in results[0].data
     second_audio = np.frombuffer(results[1].data["audio_waveform"], dtype=np.float32)
     assert second_audio.tolist() == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+
+
+def test_qwen3_tts_create_vocoder_executor_returns_streaming_scheduler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.qwen3_tts import stages
+    from sglang_omni.models.qwen3_tts.streaming_vocoder import (
+        Qwen3TTSStreamingVocoderScheduler,
+    )
+
+    class FakeTokenizer:
+        def decode(self, encoded):
+            return [torch.arange(4, dtype=torch.float32) for _ in encoded], 24000
+
+    monkeypatch.setattr(
+        stages,
+        "_load_qwen3_tts_tokenizer",
+        lambda *args, **kwargs: FakeTokenizer(),
+    )
+
+    scheduler = stages.create_vocoder_executor(
+        "model",
+        max_batch_size=2,
+        max_batch_wait_ms=3,
+        stream_chunk_frames=4,
+        left_context_frames=2,
+    )
+
+    assert isinstance(scheduler, Qwen3TTSStreamingVocoderScheduler)
+    assert scheduler._max_batch_size == 2
+    assert scheduler._max_batch_wait_s == pytest.approx(0.003)
+    assert scheduler._stream_chunk_frames == 4
+    assert scheduler._left_context_frames == 2
 
 
 def test_qwen3_tts_result_adapter_keeps_code_handoff_tensor_native() -> None:
@@ -1926,10 +1959,20 @@ def test_qwen3_tts_engine_reenables_cuda_graph_after_bootstrap(
         "SGLangOutputProcessor",
         lambda **kwargs: SimpleNamespace(**kwargs),
     )
+
+    class FakeModelRunner:
+        def __init__(self, *args, **kwargs) -> None:
+            self.args = args
+            self.kwargs = kwargs
+            self.outbox = None
+
+        def set_stream_outbox(self, outbox) -> None:
+            self.outbox = outbox
+
     monkeypatch.setattr(
         model_runner_mod,
         "Qwen3TTSModelRunner",
-        lambda *args, **kwargs: SimpleNamespace(args=args, kwargs=kwargs),
+        FakeModelRunner,
     )
     monkeypatch.setattr(
         scheduler_mod,
@@ -1950,3 +1993,94 @@ def test_qwen3_tts_engine_reenables_cuda_graph_after_bootstrap(
     assert scheduler.server_args.enable_torch_compile is False
     assert scheduler.server_args.torch_compile_max_bs == 16
     clear_qwen3_tts_preprocessing_context()
+
+
+def test_qwen3_tts_engine_factory_sets_model_runner_stream_outbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sglang_omni.models.qwen3_tts.model_runner as model_runner_mod
+    import sglang_omni.scheduling.bootstrap as bootstrap_mod
+    import sglang_omni.scheduling.omni_scheduler as omni_scheduler_mod
+    import sglang_omni.scheduling.sglang_backend as sglang_backend_mod
+    from sglang_omni.models.qwen3_tts import stages
+
+    created = {}
+
+    class FakeModelRunner:
+        def __init__(self, model_worker, output_proc):
+            del model_worker, output_proc
+            self.outbox = None
+            created["runner"] = self
+
+        def set_stream_outbox(self, outbox):
+            self.outbox = outbox
+
+    class FakeScheduler:
+        def __init__(self, **kwargs):
+            self.outbox = object()
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(stages, "_register_qwen3_tts_hf_config", lambda: None)
+    monkeypatch.setattr(stages, "_resolve_checkpoint", lambda model_path: model_path)
+    monkeypatch.setattr(stages, "_load_qwen3_tts_tokenizer", lambda *a, **k: object())
+    monkeypatch.setattr(
+        stages,
+        "_load_qwen3_tts_generate_defaults",
+        lambda checkpoint: {},
+    )
+    monkeypatch.setattr(stages, "_compile_qwen3_tts_backbone", lambda model: None)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "qwen_tts",
+        SimpleNamespace(Qwen3TTSModel=lambda **kwargs: SimpleNamespace(**kwargs)),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "transformers",
+        SimpleNamespace(
+            AutoProcessor=SimpleNamespace(from_pretrained=lambda *a, **k: object())
+        ),
+    )
+
+    fake_model = SimpleNamespace(load_speech_tokenizer=lambda tokenizer: None)
+    fake_worker = SimpleNamespace(model_runner=SimpleNamespace(model=fake_model))
+
+    monkeypatch.setattr(
+        bootstrap_mod,
+        "create_sglang_infrastructure",
+        lambda *a, **k: (
+            fake_worker,
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+        ),
+    )
+    monkeypatch.setattr(
+        sglang_backend_mod,
+        "build_sglang_server_args",
+        lambda *a, **k: SimpleNamespace(
+            disable_cuda_graph=True,
+            enable_torch_compile=False,
+        ),
+    )
+    monkeypatch.setattr(
+        sglang_backend_mod,
+        "SGLangOutputProcessor",
+        lambda **kwargs: object(),
+    )
+    monkeypatch.setattr(omni_scheduler_mod, "OmniScheduler", FakeScheduler)
+    monkeypatch.setattr(
+        stages,
+        "make_qwen3_tts_scheduler_adapters",
+        lambda **kwargs: (lambda payload: payload, lambda data: data),
+        raising=False,
+    )
+    monkeypatch.setattr(model_runner_mod, "Qwen3TTSModelRunner", FakeModelRunner)
+
+    scheduler = stages.create_sglang_tts_engine_executor("model", device="cuda:0")
+
+    assert created["runner"].outbox is scheduler.outbox

--- a/tests/unit_test/qwen3_tts/test_streaming_vocoder.py
+++ b/tests/unit_test/qwen3_tts/test_streaming_vocoder.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from sglang_omni.models.qwen3_tts.payload_types import Qwen3TTSState
+from sglang_omni.models.qwen3_tts.streaming_vocoder import (
+    Qwen3TTSStreamingVocoderScheduler,
+)
+from sglang_omni.models.tts_streaming import INITIAL_CODEC_CHUNK_FRAMES_PARAM
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
+from sglang_omni.proto import OmniRequest, StagePayload
+
+
+class FakeQwen3TTSTokenizer:
+    def __init__(self) -> None:
+        self.decode_inputs: list[torch.Tensor] = []
+
+    def decode(self, encoded):
+        wavs = []
+        for item in encoded:
+            codes = torch.as_tensor(item["audio_codes"], dtype=torch.long)
+            self.decode_inputs.append(codes.clone())
+            frames = int(codes.shape[0])
+            offset = int(codes[0, 0].item()) if frames else 0
+            wavs.append(torch.arange(offset, offset + frames * 2, dtype=torch.float32))
+        return wavs, 24000
+
+
+def _payload(
+    *,
+    request_id: str = "req",
+    stream: bool,
+    audio_codes: torch.Tensor | None = None,
+    non_streaming_mode: bool = False,
+    initial_codec_chunk_frames: int | None = None,
+) -> StagePayload:
+    params = {"stream": stream}
+    if initial_codec_chunk_frames is not None:
+        params[INITIAL_CODEC_CHUNK_FRAMES_PARAM] = initial_codec_chunk_frames
+    state = Qwen3TTSState(
+        audio_codes=audio_codes,
+        sample_rate=24000,
+        non_streaming_mode=non_streaming_mode,
+        prompt_tokens=2,
+        completion_tokens=0 if audio_codes is None else int(audio_codes.shape[0]),
+    )
+    return StagePayload(
+        request_id=request_id,
+        request=OmniRequest(inputs="hello", params=params),
+        data=state.to_dict(),
+    )
+
+
+def _item(row: torch.Tensor, *, chunk_id: int = 0) -> StreamItem:
+    return StreamItem(
+        from_stage="tts_engine",
+        data=row,
+        metadata={
+            "modality": "audio_codes",
+            "stream": True,
+            "codec": "qwen3_tts",
+            "sample_rate": 24000,
+            "num_codebooks": int(row.numel()),
+        },
+        chunk_id=chunk_id,
+    )
+
+
+def _drain(scheduler: Qwen3TTSStreamingVocoderScheduler):
+    messages = []
+    while not scheduler.outbox.empty():
+        messages.append(scheduler.outbox.get_nowait())
+    return messages
+
+
+def test_qwen3_tts_streaming_vocoder_emits_incremental_audio() -> None:
+    tokenizer = FakeQwen3TTSTokenizer()
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        tokenizer,
+        stream_chunk_frames=3,
+        left_context_frames=0,
+    )
+    payload = _payload(stream=True)
+    rows = [
+        torch.tensor([1, 11], dtype=torch.long),
+        torch.tensor([2, 12], dtype=torch.long),
+        torch.tensor([3, 13], dtype=torch.long),
+    ]
+
+    scheduler._on_streaming_new_request("req", payload)
+    for idx, row in enumerate(rows):
+        scheduler._on_chunk("req", _item(row, chunk_id=idx))
+
+    stream_messages = [msg for msg in _drain(scheduler) if msg.type == "stream"]
+    assert len(stream_messages) == 1
+    first = stream_messages[0]
+    assert first.metadata == {"modality": "audio"}
+    assert first.data["sample_rate"] == 24000
+    audio = np.frombuffer(first.data["audio_waveform"], dtype=np.float32)
+    assert audio.tolist() == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    assert tokenizer.decode_inputs[0].tolist() == [[1, 11], [2, 12], [3, 13]]
+
+
+def test_qwen3_tts_initial_codec_chunk_frames_controls_first_audio() -> None:
+    tokenizer = FakeQwen3TTSTokenizer()
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        tokenizer,
+        stream_chunk_frames=4,
+        left_context_frames=0,
+    )
+    payload = _payload(stream=True, initial_codec_chunk_frames=1)
+
+    scheduler._on_streaming_new_request("req", payload)
+    scheduler._on_chunk("req", _item(torch.tensor([7, 17], dtype=torch.long)))
+
+    stream_messages = [msg for msg in _drain(scheduler) if msg.type == "stream"]
+    assert len(stream_messages) == 1
+    audio = np.frombuffer(stream_messages[0].data["audio_waveform"], dtype=np.float32)
+    assert audio.tolist() == [7.0, 8.0]
+
+
+def test_qwen3_tts_streaming_vocoder_final_result_is_metadata_only() -> None:
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        FakeQwen3TTSTokenizer(),
+        stream_chunk_frames=2,
+        left_context_frames=0,
+    )
+    payload = _payload(stream=True)
+
+    scheduler._on_streaming_new_request("req", payload)
+    scheduler._on_chunk("req", _item(torch.tensor([1, 11], dtype=torch.long)))
+    scheduler._on_chunk("req", _item(torch.tensor([2, 12], dtype=torch.long)))
+    scheduler._on_done("req")
+
+    results = [msg for msg in _drain(scheduler) if msg.type == "result"]
+    assert len(results) == 1
+    final_data = results[0].data.data
+    assert final_data["modality"] == "audio"
+    assert final_data["sample_rate"] == 24000
+    assert "audio_waveform" not in final_data
+    assert final_data["usage"] == {
+        "prompt_tokens": 2,
+        "completion_tokens": 0,
+        "total_tokens": 2,
+    }
+
+
+def test_qwen3_tts_non_streaming_vocoder_batches_decode_requests() -> None:
+    tokenizer = FakeQwen3TTSTokenizer()
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        tokenizer,
+        max_batch_size=2,
+        max_batch_wait_ms=3,
+    )
+    first = _payload(
+        request_id="first",
+        stream=False,
+        audio_codes=torch.tensor([[1, 11], [2, 12]], dtype=torch.long),
+    )
+    second = _payload(
+        request_id="second",
+        stream=False,
+        audio_codes=torch.tensor([[5, 15], [6, 16]], dtype=torch.long),
+    )
+
+    results = scheduler._batch_fn([first, second])
+
+    assert scheduler._max_batch_size == 2
+    assert scheduler._max_batch_wait_s == pytest.approx(0.003)
+    assert len(tokenizer.decode_inputs) == 2
+    assert results[0].data["sample_rate"] == 24000
+    first_audio = np.frombuffer(results[0].data["audio_waveform"], dtype=np.float32)
+    second_audio = np.frombuffer(results[1].data["audio_waveform"], dtype=np.float32)
+    assert first_audio.tolist() == [1.0, 2.0, 3.0, 4.0]
+    assert second_audio.tolist() == [5.0, 6.0, 7.0, 8.0]

--- a/tests/unit_test/qwen3_tts/test_streaming_vocoder.py
+++ b/tests/unit_test/qwen3_tts/test_streaming_vocoder.py
@@ -54,17 +54,25 @@ def _payload(
     )
 
 
-def _item(row: torch.Tensor, *, chunk_id: int = 0) -> StreamItem:
+def _item(
+    row: torch.Tensor,
+    *,
+    chunk_id: int = 0,
+    ref_context_codes: list[list[int]] | None = None,
+) -> StreamItem:
+    metadata = {
+        "modality": "audio_codes",
+        "stream": True,
+        "codec": "qwen3_tts",
+        "sample_rate": 24000,
+        "num_codebooks": int(row.numel()),
+    }
+    if ref_context_codes is not None:
+        metadata["ref_context_codes"] = ref_context_codes
     return StreamItem(
         from_stage="tts_engine",
         data=row,
-        metadata={
-            "modality": "audio_codes",
-            "stream": True,
-            "codec": "qwen3_tts",
-            "sample_rate": 24000,
-            "num_codebooks": int(row.numel()),
-        },
+        metadata=metadata,
         chunk_id=chunk_id,
     )
 
@@ -174,6 +182,156 @@ def test_qwen3_tts_streaming_vocoder_final_result_is_metadata_only() -> None:
         "completion_tokens": 0,
         "total_tokens": 2,
     }
+
+
+def test_qwen3_tts_streaming_seeds_ref_context_as_trimmed_left_context() -> None:
+    """Ref-clone codes seed the first window as left-context, then get trimmed.
+
+    The emitted audio covers only the output frames, but the decode input
+    carries the seed rows so the onset has the clone's acoustic history.
+    """
+    tokenizer = FakeQwen3TTSTokenizer()
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        tokenizer,
+        stream_chunk_frames=3,
+        left_context_frames=3,
+    )
+    payload = _payload(stream=True)
+    ref_ctx = [[100, 200], [101, 201], [102, 202]]
+
+    scheduler._on_streaming_new_request("req", payload)
+    out_rows = [
+        torch.tensor([1, 11], dtype=torch.long),
+        torch.tensor([2, 12], dtype=torch.long),
+        torch.tensor([3, 13], dtype=torch.long),
+    ]
+    for idx, row in enumerate(out_rows):
+        scheduler._on_chunk("req", _item(row, chunk_id=idx, ref_context_codes=ref_ctx))
+
+    stream_messages = [msg for msg in _drain(scheduler) if msg.type == "stream"]
+    assert len(stream_messages) == 1
+    audio = np.frombuffer(stream_messages[0].data["audio_waveform"], dtype=np.float32)
+    # decode of [seed(3) ++ output(3)] = arange(100, 112); first 3 frames (6
+    # samples) are the trimmed seed left-context.
+    assert audio.tolist() == [106.0, 107.0, 108.0, 109.0, 110.0, 111.0]
+    assert tokenizer.decode_inputs[0].tolist() == [
+        [100, 200],
+        [101, 201],
+        [102, 202],
+        [1, 11],
+        [2, 12],
+        [3, 13],
+    ]
+
+
+def test_qwen3_tts_streaming_without_ref_context_is_unseeded() -> None:
+    """No ref_context_codes in metadata => first decode is output-only."""
+    tokenizer = FakeQwen3TTSTokenizer()
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        tokenizer,
+        stream_chunk_frames=3,
+        left_context_frames=3,
+    )
+    payload = _payload(stream=True)
+
+    scheduler._on_streaming_new_request("req", payload)
+    for idx, row in enumerate(
+        [
+            torch.tensor([1, 11], dtype=torch.long),
+            torch.tensor([2, 12], dtype=torch.long),
+            torch.tensor([3, 13], dtype=torch.long),
+        ]
+    ):
+        scheduler._on_chunk("req", _item(row, chunk_id=idx))
+
+    stream_messages = [msg for msg in _drain(scheduler) if msg.type == "stream"]
+    assert len(stream_messages) == 1
+    audio = np.frombuffer(stream_messages[0].data["audio_waveform"], dtype=np.float32)
+    assert audio.tolist() == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    assert tokenizer.decode_inputs[0].tolist() == [[1, 11], [2, 12], [3, 13]]
+
+
+def test_qwen3_tts_streaming_clamps_ref_context_to_left_context_frames() -> None:
+    """Over-supplied ref frames are clamped to the tail of left_context_frames."""
+    tokenizer = FakeQwen3TTSTokenizer()
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        tokenizer,
+        stream_chunk_frames=3,
+        left_context_frames=3,
+    )
+    payload = _payload(stream=True)
+    ref_ctx = [[90, 190], [91, 191], [92, 192], [93, 193], [94, 194]]
+
+    scheduler._on_streaming_new_request("req", payload)
+    for idx, row in enumerate(
+        [
+            torch.tensor([1, 11], dtype=torch.long),
+            torch.tensor([2, 12], dtype=torch.long),
+            torch.tensor([3, 13], dtype=torch.long),
+        ]
+    ):
+        scheduler._on_chunk("req", _item(row, chunk_id=idx, ref_context_codes=ref_ctx))
+
+    _drain(scheduler)
+    # Only the last 3 ref frames seed the window.
+    assert tokenizer.decode_inputs[0].tolist() == [
+        [92, 192],
+        [93, 193],
+        [94, 194],
+        [1, 11],
+        [2, 12],
+        [3, 13],
+    ]
+
+
+def test_qwen3_tts_streaming_skips_ref_context_on_codebook_mismatch() -> None:
+    """Ref frames with the wrong codebook width are ignored (decode stays unseeded)."""
+    tokenizer = FakeQwen3TTSTokenizer()
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        tokenizer,
+        stream_chunk_frames=3,
+        left_context_frames=3,
+    )
+    payload = _payload(stream=True)
+    ref_ctx = [[1, 2, 3], [4, 5, 6]]  # 3 codebooks; rows carry 2
+
+    scheduler._on_streaming_new_request("req", payload)
+    for idx, row in enumerate(
+        [
+            torch.tensor([1, 11], dtype=torch.long),
+            torch.tensor([2, 12], dtype=torch.long),
+            torch.tensor([3, 13], dtype=torch.long),
+        ]
+    ):
+        scheduler._on_chunk("req", _item(row, chunk_id=idx, ref_context_codes=ref_ctx))
+
+    _drain(scheduler)
+    assert tokenizer.decode_inputs[0].tolist() == [[1, 11], [2, 12], [3, 13]]
+
+
+def test_qwen3_tts_streaming_seeds_ref_context_only_once() -> None:
+    """Metadata rides every chunk, but seeding happens exactly once."""
+    tokenizer = FakeQwen3TTSTokenizer()
+    scheduler = Qwen3TTSStreamingVocoderScheduler(
+        tokenizer,
+        stream_chunk_frames=3,
+        left_context_frames=3,
+    )
+    payload = _payload(stream=True)
+    ref_ctx = [[100, 200], [101, 201], [102, 202]]
+
+    scheduler._on_streaming_new_request("req", payload)
+    out_rows = [torch.tensor([i, i + 10], dtype=torch.long) for i in range(1, 7)]
+    for idx, row in enumerate(out_rows):
+        scheduler._on_chunk("req", _item(row, chunk_id=idx, ref_context_codes=ref_ctx))
+
+    _drain(scheduler)
+    state = scheduler._stream_states["req"]
+    assert state.ref_seeded is True
+    # 3 seed rows + 6 output rows, seeded exactly once.
+    assert len(state.rows) == 3 + 6
+    assert [r.tolist() for r in state.rows[:3]] == ref_ctx
+    assert [r.tolist() for r in state.rows[3:]] == [r.tolist() for r in out_rows]
 
 
 def test_qwen3_tts_non_streaming_vocoder_batches_decode_requests() -> None:

--- a/tests/unit_test/qwen3_tts/test_streaming_vocoder.py
+++ b/tests/unit_test/qwen3_tts/test_streaming_vocoder.py
@@ -104,7 +104,7 @@ def test_qwen3_tts_streaming_vocoder_emits_incremental_audio() -> None:
     assert tokenizer.decode_inputs[0].tolist() == [[1, 11], [2, 12], [3, 13]]
 
 
-def test_qwen3_tts_initial_codec_chunk_frames_controls_first_audio() -> None:
+def test_qwen3_tts_initial_codec_chunk_frames_only_controls_first_audio() -> None:
     tokenizer = FakeQwen3TTSTokenizer()
     scheduler = Qwen3TTSStreamingVocoderScheduler(
         tokenizer,
@@ -120,6 +120,34 @@ def test_qwen3_tts_initial_codec_chunk_frames_controls_first_audio() -> None:
     assert len(stream_messages) == 1
     audio = np.frombuffer(stream_messages[0].data["audio_waveform"], dtype=np.float32)
     assert audio.tolist() == [7.0, 8.0]
+
+    for idx, row in enumerate(
+        [
+            torch.tensor([8, 18], dtype=torch.long),
+            torch.tensor([9, 19], dtype=torch.long),
+            torch.tensor([10, 20], dtype=torch.long),
+        ],
+        start=1,
+    ):
+        scheduler._on_chunk("req", _item(row, chunk_id=idx))
+
+    stream_messages = [msg for msg in _drain(scheduler) if msg.type == "stream"]
+    assert stream_messages == []
+
+    scheduler._on_chunk(
+        "req", _item(torch.tensor([11, 21], dtype=torch.long), chunk_id=4)
+    )
+
+    stream_messages = [msg for msg in _drain(scheduler) if msg.type == "stream"]
+    assert len(stream_messages) == 1
+    audio = np.frombuffer(stream_messages[0].data["audio_waveform"], dtype=np.float32)
+    assert audio.tolist() == [8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0]
+    assert tokenizer.decode_inputs[1].tolist() == [
+        [8, 18],
+        [9, 19],
+        [10, 20],
+        [11, 21],
+    ]
 
 
 def test_qwen3_tts_streaming_vocoder_final_result_is_metadata_only() -> None:

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -322,6 +322,20 @@ def test_raw_pcm_speech_request_defaults_initial_codec_chunk_frames() -> None:
     assert gen_req.extra_params["initial_codec_chunk_frames"] == 1
 
 
+def test_speech_stream_passes_initial_codec_chunk_frames_for_raw_pcm() -> None:
+    req = CreateSpeechRequest(
+        input="hello",
+        stream=True,
+        stream_format="audio",
+        response_format="pcm",
+    )
+
+    gen_req = build_speech_generate_request(req, default_model="qwen3-tts")
+
+    assert gen_req.stream is True
+    assert gen_req.extra_params["initial_codec_chunk_frames"] == 1
+
+
 def test_sse_speech_request_does_not_default_initial_codec_chunk_frames() -> None:
     req = CreateSpeechRequest(
         input="hello",
@@ -331,6 +345,19 @@ def test_sse_speech_request_does_not_default_initial_codec_chunk_frames() -> Non
 
     gen_req = build_speech_generate_request(req, default_model="higgs-audio-v2")
 
+    assert "initial_codec_chunk_frames" not in gen_req.extra_params
+
+
+def test_speech_sse_stream_does_not_force_initial_codec_chunk_frames() -> None:
+    req = CreateSpeechRequest(
+        input="hello",
+        stream=True,
+        stream_format="sse",
+    )
+
+    gen_req = build_speech_generate_request(req, default_model="qwen3-tts")
+
+    assert gen_req.stream is True
     assert "initial_codec_chunk_frames" not in gen_req.extra_params
 
 


### PR DESCRIPTION
## Motivation

Qwen3-TTS `stream=true` previously returned a single final audio event — the vocoder only ran after `tts_engine` finished all codec frames, so first-audio latency equaled full generation time. This wires real incremental streaming: codec rows flow from `tts_engine` into the vocoder as they are generated.

## Modifications

- `config.py`: engine stage `stream_to=["vocoder"]`; vocoder stage `can_accept_stream_before_payload=True` (standard streaming contract).
- `model_runner.py`: `Qwen3TTSModelRunner._emit_code_chunk` pushes each generated `code_chunk` to the vocoder via `scheduler.outbox`; no-op when outbox/`stream_metadata` absent.
- `request_builders.py`: `build_qwen3_tts_stream_metadata` emits `num_codebooks`/`sample_rate`/codec tag; returns `None` for `non_streaming_mode` (CustomVoice/VoiceDesign).
- `streaming_vocoder.py` (new): `Qwen3TTSStreamingVocoderScheduler` extends `StreamingSimpleScheduler` — left-context-window chunk decode + trim, `initial_codec_chunk_frames` for low first-audio latency, retains batched non-streaming decode path.
- `docs/`: document streaming scope and `initial_codec_chunk_frames`.

Scope: Base / reference-cloning get real incremental streaming. CustomVoice / VoiceDesign keep full-result behavior (Qwen non-streaming prompt path).

## Benchmark

```

  ┌───────────┬────────┬──────┬──────┬─────────┬────────┬─────────┬───────┬──────────┬───────┬──────────┬─────────┬─────────┬────────┬──────────────────┐
  │  Variant  │ Stream │ Done │ Fail │  Lat    │  Lat   │  RTF    │ req/s │  Audio   │ tok/s │  TTFC    │  TTFC   │  ITL    │ Chunks │      Notes       │
  │           │        │      │      │  mean   │  p95   │  mean   │       │   s/s    │       │   mean   │   p95   │  mean   │        │                  │
  ├───────────┼────────┼──────┼──────┼─────────┼────────┼─────────┼───────┼──────────┼───────┼──────────┼─────────┼─────────┼────────┼──────────────────┤
  │ Base      │ false  │ 50   │ 0    │ 2.302   │ 3.467  │ 0.585   │ 3.278 │ 13.102   │ 163.8 │ 2.302*   │ 3.467*  │ —       │ 1      │ one final        │
  │           │        │      │      │         │        │         │       │          │       │          │         │         │        │ payload          │
  ├───────────┼────────┼──────┼──────┼─────────┼────────┼─────────┼───────┼──────────┼───────┼──────────┼─────────┼─────────┼────────┼──────────────────┤
  │ Streaming │ true   │ 50   │ 0    │ 2.831   │ 4.367  │ 0.724   │ 2.699 │ 10.616   │ 132.7 │ 0.433    │ 0.596   │ 0.315   │ 8.58   │ incremental SSE  │
  └───────────┴────────┴──────┴──────┴─────────┴────────┴─────────┴───────┴──────────┴───────┴──────────┴─────────┴─────────┴────────┴──────────────────┘

```

| Metric | Baseline | Streaming | Delta |
|---|---:|---:|---:|
| Latency mean (s) | 1.353 | 1.465 | +8.3% |
| Latency p95 (s) | 2.051 | 2.514 | +22.6% |
| RTF mean | 0.2476 | 0.2713 | +9.6% |
| Throughput (req/s) | 9.993 | 9.079 | −9.1% |
| Audio throughput (s/s) | 55.303 | 49.799 | −10.0% |
| Output tok/s | 691.3 | 622.5 | −10.0% |
| Output tokens total | 3459 | 3428 | −0.9% |
| Audio duration mean (s) | 5.534 | 5.485 | −0.9% |


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [x] Add unit tests (`test_streaming_vocoder.py`, `test_pipeline.py`, `test_openai_api.py`).