### PR TITLE
[Realtime]: define audio buffer overflow error

### DIFF
--- a/sglang_omni/serve/realtime/audio_buffer.py
+++ b/sglang_omni/serve/realtime/audio_buffer.py
@@ -11,6 +11,14 @@ import wave
 DEFAULT_MAX_BUFFER_BYTES = 60 * 16000 * 2
 
 
+class BufferOverflow(ValueError):
+    """Raised when a realtime input audio buffer exceeds its byte limit."""
+
+    def __init__(self, max_bytes: int) -> None:
+        self.max_bytes = max_bytes
+        super().__init__(f"Realtime audio buffer exceeded max_bytes={max_bytes}")
+
+
 class RealtimeAudioBuffer:
     """Append-only buffer of raw little-endian PCM16 bytes."""
 


### PR DESCRIPTION
## Motivation

The realtime PCM16 audio buffer has a hard byte limit, but the overflow path raises `BufferOverflow` without defining it. 

## Changes

- Add `BufferOverflow(ValueError)` in the realtime audio buffer module.

## Testing

Verified on 1*H100 with `bosonai/higgs-audio-v3-tts-4b` and `/v1/realtime` enabled.

Server log:

```text
INFO:     Started server process [2863]
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
INFO:     127.0.0.1:55812 - "GET /health HTTP/1.1" 200 OK
INFO:     127.0.0.1:55028 - "GET /v1/models HTTP/1.1" 200 OK
INFO:     127.0.0.1:51700 - "WebSocket /v1/realtime" [accepted]
INFO:     connection open
ERROR:    Exception in ASGI application
  File "/root/sglang-omni/sglang_omni/serve/realtime/session.py", line 159, in handle_audio_append
    decoded_len = self.audio_buffer.append_b64(event.audio)
  File "/root/sglang-omni/sglang_omni/serve/realtime/audio_buffer.py", line 42, in append_b64
    raise BufferOverflow(self.max_bytes)
sglang_omni.serve.realtime.audio_buffer.BufferOverflow: Realtime audio buffer exceeded max_bytes=1920000
INFO:     connection closed
INFO:     127.0.0.1:41550 - "GET /health HTTP/1.1" 200 OK
```

Client log:

```text
Connecting to ws://127.0.0.1:8000/v1/realtime
Received initial event: session.created
Sending input_audio_buffer.append chunk=1 raw_bytes=262144 base64_chars=349528 cumulative_raw=262144
Sending input_audio_buffer.append chunk=2 raw_bytes=262144 base64_chars=349528 cumulative_raw=524288
Sending input_audio_buffer.append chunk=3 raw_bytes=262144 base64_chars=349528 cumulative_raw=786432
Sending input_audio_buffer.append chunk=4 raw_bytes=262144 base64_chars=349528 cumulative_raw=1048576
Sending input_audio_buffer.append chunk=5 raw_bytes=262144 base64_chars=349528 cumulative_raw=1310720
Sending input_audio_buffer.append chunk=6 raw_bytes=262144 base64_chars=349528 cumulative_raw=1572864
Sending input_audio_buffer.append chunk=7 raw_bytes=262144 base64_chars=349528 cumulative_raw=1835008
Sending input_audio_buffer.append chunk=8 raw_bytes=84994 base64_chars=113328 cumulative_raw=1920002
WebSocket closed after oversized append. Check server logs for BufferOverflow.
close_code=1000 close_reason=''
```

## RFC

This PR only makes the existing overflow path use a real, readable exception. I am open to discussion if returning a structured realtime error event, keeping the WebSocket open, or defining client retry behavior is necessary.