### PR TITLE
feat(api): harden tts api contract

### DIFF
--- a/sglang_omni/serve/protocol.py
+++ b/sglang_omni/serve/protocol.py
@@ -209,7 +209,9 @@ class CreateSpeechRequest(BaseModel):
     ref_audio: str | None = None  # path or URL to reference audio
     ref_text: str | None = None  # transcript of reference audio
     references: list[SpeechReference] | None = None  # S2-Pro-style refs
-    token_count: int | None = Field(default=None, gt=0)  # MOSS-TTS duration token target
+    token_count: int | None = Field(
+        default=None, gt=0
+    )  # MOSS-TTS duration token target
     duration_tokens: int | None = Field(default=None, gt=0)  # alias for token_count
     initial_codec_chunk_frames: int | None = Field(default=None, ge=0)
 
@@ -240,7 +242,9 @@ class CreateSpeechRequest(BaseModel):
                 raise ValueError('stream_format="audio" requires response_format="pcm"')
 
         if self.token_count is not None and self.duration_tokens is not None:
-            raise ValueError("token_count and duration_tokens are aliases; provide only one")
+            raise ValueError(
+                "token_count and duration_tokens are aliases; provide only one"
+            )
 
         if self.ref_text is not None and self.ref_audio is None:
             raise ValueError("ref_text requires ref_audio")

--- a/sglang_omni/serve/protocol.py
+++ b/sglang_omni/serve/protocol.py
@@ -167,6 +167,20 @@ class SpeechReference(BaseModel):
     text: str | None = None
     vq_codes: list[list[int]] | list[int] | None = None
 
+    @model_validator(mode="after")
+    def validate_reference_payload(self) -> "SpeechReference":
+        """Require exactly one model-independent reference audio payload.
+
+        ``text`` is only the optional transcript. The actual audio payload is
+        either raw reference audio via ``audio_path`` or precomputed``vq_codes``.
+        Providing both is ambiguous.
+        """
+        if self.audio_path is None and self.vq_codes is None:
+            raise ValueError("reference requires audio_path or vq_codes")
+        if self.audio_path is not None and self.vq_codes is not None:
+            raise ValueError("reference must not provide both audio_path and vq_codes")
+        return self
+
 
 class CreateSpeechRequest(BaseModel):
     """OpenAI-compatible text-to-speech request.
@@ -182,7 +196,7 @@ class CreateSpeechRequest(BaseModel):
     input: str
     voice: str = "default"
     response_format: str = "wav"
-    speed: float = 1.0
+    speed: float = Field(default=1.0, gt=0)
     stream: bool = False
     stream_format: Literal["sse", "audio"] = "sse"
 
@@ -195,28 +209,45 @@ class CreateSpeechRequest(BaseModel):
     ref_audio: str | None = None  # path or URL to reference audio
     ref_text: str | None = None  # transcript of reference audio
     references: list[SpeechReference] | None = None  # S2-Pro-style refs
-    token_count: int | None = None  # MOSS-TTS duration token target
-    duration_tokens: int | None = None  # alias for token_count
+    token_count: int | None = Field(default=None, gt=0)  # MOSS-TTS duration token target
+    duration_tokens: int | None = Field(default=None, gt=0)  # alias for token_count
     initial_codec_chunk_frames: int | None = Field(default=None, ge=0)
 
     # Generation parameters
-    max_new_tokens: int | None = None
-    temperature: float | None = None
-    top_p: float | None = None
+    max_new_tokens: int | None = Field(default=None, gt=0)
+    temperature: float | None = Field(default=None, ge=0)
+    top_p: float | None = Field(default=None, gt=0, le=1)
     top_k: int | None = None
-    repetition_penalty: float | None = None
-    seed: int | None = None
+    repetition_penalty: float | None = Field(default=None, gt=0)
+    seed: int | None = Field(default=None, ge=0)
 
     # Per-stage overrides (sglang-omni specific)
     stage_params: dict[str, dict[str, Any]] | None = None
 
     @model_validator(mode="after")
-    def validate_stream_format(self) -> "CreateSpeechRequest":
+    def validate_speech_contract(self) -> "CreateSpeechRequest":
+        self.response_format = self.response_format.strip().lower()
+        if self.response_format not in {"aac", "flac", "mp3", "opus", "pcm", "wav"}:
+            raise ValueError("unsupported response_format")
+
+        if self.top_k is not None and self.top_k != -1 and self.top_k < 1:
+            raise ValueError("top_k must be -1 or a positive integer")
+
         if self.stream_format == "audio":
             if not self.stream:
                 raise ValueError('stream_format="audio" requires stream=true')
             if self.response_format.lower() != "pcm":
                 raise ValueError('stream_format="audio" requires response_format="pcm"')
+
+        if self.token_count is not None and self.duration_tokens is not None:
+            raise ValueError("token_count and duration_tokens are aliases; provide only one")
+
+        if self.ref_text is not None and self.ref_audio is None:
+            raise ValueError("ref_text requires ref_audio")
+
+        if self.references and self.ref_audio is not None:
+            raise ValueError("do not mix references with ref_audio/ref_text shorthand")
+
         return self
 
 

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 
 from sglang_omni.client import Client, GenerateChunk
 from sglang_omni.client.audio import encode_pcm
@@ -294,6 +295,61 @@ def test_speech_stream_audio_format_rejects_non_pcm_response_format() -> None:
     assert 400 <= response.status_code < 500
     assert "stream_format" in response.text
     assert "pcm" in response.text.lower()
+
+
+def test_speech_endpoint_rejects_unknown_response_format() -> None:
+    client = TestClient(
+        create_app(SuccessfulSpeechClient(), model_name="higgs-audio-v2")
+    )
+
+    response = client.post(
+        "/v1/audio/speech",
+        json={
+            "input": "hello",
+            "response_format": "ogg",
+        },
+    )
+
+    assert 400 <= response.status_code < 500
+    assert "response_format" in response.text
+
+
+def test_speech_request_normalizes_response_format() -> None:
+    req = CreateSpeechRequest(input="hello", response_format=" WAV ")
+
+    assert req.response_format == "wav"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"input": "hello", "response_format": "ogg"},
+        {"input": "hello", "speed": 0},
+        {"input": "hello", "token_count": 0},
+        {"input": "hello", "duration_tokens": 0},
+        {"input": "hello", "token_count": 1, "duration_tokens": 1},
+        {"input": "hello", "max_new_tokens": 0},
+        {"input": "hello", "top_p": 0},
+        {"input": "hello", "top_p": 1.1},
+        {"input": "hello", "top_k": 0},
+        {"input": "hello", "repetition_penalty": 0},
+        {"input": "hello", "seed": -1},
+        {"input": "hello", "ref_text": "reference"},
+        {"input": "hello", "references": [{}]},
+        {
+            "input": "hello",
+            "references": [{"audio_path": "voice.wav", "vq_codes": [1, 2]}],
+        },
+        {
+            "input": "hello",
+            "references": [{"audio_path": "voice.wav"}],
+            "ref_audio": "other.wav",
+        },
+    ],
+)
+def test_speech_request_rejects_invalid_contract(payload: dict[str, Any]) -> None:
+    with pytest.raises(ValidationError):
+        CreateSpeechRequest(**payload)
 
 
 def test_speech_request_carries_initial_codec_chunk_frames() -> None:


### PR DESCRIPTION
## Motivation

close https://github.com/sgl-project/sglang-omni/issues/657

`/v1/audio/speech` currently lets several malformed or ambiguous requests reach model-specific code paths. This makes failures backend-dependent and can turn simple API contract problems into 5xx errors.

## Changes

| Parameter | Existing validation | Added in this PR |
|---|---|---|
| `model` | Optional string. | - |
| `input` | Required string. | -|
| `voice` | String with default `default`. | - |
| `response_format` | String with default `wav`; only checked indirectly when `stream_format=audio`. | Strip and lowercase the value; reject formats outside `aac`, `flac`, `mp3`, `opus`, `pcm`, `wav`. |
| `speed` | Float with default `1.0`. | Must be greater than `0`. |
| `stream` | Boolean with default `false`. | - |
| `stream_format` | Must be `sse` or `audio`; `audio` requires `stream=true` and `response_format=pcm`. | Same contract, now checked after `response_format` normalization. |
| `task_type` | Optional string. | - |
| `language` | Optional string. | - |
| `instructions` | Optional string. | - |
| `ref_audio` | Optional string. | Cannot be mixed with non-empty `references`. |
| `ref_text` | Optional string. | Requires `ref_audio`. |
| `references` | Optional list of `SpeechReference`; empty list accepted. | Non-empty `references` cannot be mixed with `ref_audio` / `ref_text` shorthand. |
| `references[].audio_path` | Optional string. | Each reference must provide exactly one payload field: `audio_path` or `vq_codes`. |
| `references[].text` | Optional transcript string. | Text alone is not a valid reference payload. |
| `references[].vq_codes` | Optional integer list payload. | Mutually exclusive with `audio_path`; no shape validation added. |
| `token_count` | Optional integer. | Must be greater than `0`; mutually exclusive with `duration_tokens`. |
| `duration_tokens` | Optional integer. | Must be greater than `0`; alias of `token_count` and mutually exclusive with it. |
| `initial_codec_chunk_frames` | Optional integer greater than or equal to `0`. | - |
| `max_new_tokens` | Optional integer. | Must be greater than `0`. |
| `temperature` | Optional number. | Must be greater than or equal to `0`. |
| `top_p` | Optional number. | Must be in `(0, 1]`. |
| `top_k` | Optional integer. | Must be `-1` or a positive integer. |
| `repetition_penalty` | Optional number. | Must be greater than `0`; no model-specific upper bound. |
| `seed` | Optional integer. | Must be greater than or equal to `0`. |
| `stage_params` | Optional nested dictionary. | - |

## Testing
```
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 580.142                Driver Version: 580.142        CUDA Version: 13.0     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA H100 PCIe               On  |   00000000:D5:00.0 Off |                    0 |
| N/A   27C    P0             78W /  310W |   75535MiB /  81559MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|    0   N/A  N/A            4929      C   .../sglang-omni/.venv/bin/python      75526MiB |
+-----------------------------------------------------------------------------------------+
...
INFO:     Started server process [3069]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
2026-06-07 10:59:25,440 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Prefill batch, #new-seq: 1, #new-token: 8, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0,
2026-06-07 10:59:27,303 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 48, token usage: 0.00, cuda graph: True, gen throughput (token/s): 2.23, #queue-req: 0,
INFO:     127.0.0.1:51496 - "POST /v1/audio/speech HTTP/1.1" 200 OK
2026-06-07 10:59:30,640 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Prefill batch, #new-seq: 1, #new-token: 183, #cached-token: 0, token usage: 0.00, #running-req: 0, #queue-req: 0,
2026-06-07 10:59:30,843 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 200, token usage: 0.00, cuda graph: True, gen throughput (token/s): 11.30, #queue-req: 0,
INFO:     127.0.0.1:51508 - "POST /v1/audio/speech HTTP/1.1" 200 OK
2026-06-07 10:59:31,265 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 182, token usage: 0.00, #running-req: 0, #queue-req: 0,
2026-06-07 10:59:31,342 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 187, token usage: 0.00, cuda graph: True, gen throughput (token/s): 80.18, #queue-req: 0,
2026-06-07 10:59:31,659 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 227, token usage: 0.00, cuda graph: True, gen throughput (token/s): 126.29, #queue-req: 0,
INFO:     127.0.0.1:49272 - "POST /v1/audio/speech HTTP/1.1" 200 OK
2026-06-07 10:59:31,843 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 7, token usage: 0.00, #running-req: 0, #queue-req: 0,
2026-06-07 10:59:32,140 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 40, token usage: 0.00, cuda graph: True, gen throughput (token/s): 83.17, #queue-req: 0,
INFO:     127.0.0.1:49286 - "POST /v1/audio/speech HTTP/1.1" 200 OK
2026-06-07 10:59:32,431 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 7, token usage: 0.00, #running-req: 0, #queue-req: 0,
2026-06-07 10:59:32,625 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 26, token usage: 0.00, cuda graph: True, gen throughput (token/s): 82.34, #queue-req: 0,
INFO:     127.0.0.1:49294 - "POST /v1/audio/speech HTTP/1.1" 200 OK
2026-06-07 10:59:33,057 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 7, token usage: 0.00, #running-req: 0, #queue-req: 0,
2026-06-07 10:59:33,110 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 9, token usage: 0.00, cuda graph: True, gen throughput (token/s): 82.57, #queue-req: 0,
2026-06-07 10:59:33,423 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 49, token usage: 0.00, cuda graph: True, gen throughput (token/s): 127.76, #queue-req: 0,
INFO:     127.0.0.1:49298 - "POST /v1/audio/speech HTTP/1.1" 200 OK
2026-06-07 10:59:33,729 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 7, token usage: 0.00, #running-req: 0, #queue-req: 0,
2026-06-07 10:59:33,907 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 25, token usage: 0.00, cuda graph: True, gen throughput (token/s): 82.61, #queue-req: 0,
2026-06-07 10:59:34,219 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 65, token usage: 0.00, cuda graph: True, gen throughput (token/s): 128.41, #queue-req: 0,
INFO:     127.0.0.1:49308 - "POST /v1/audio/speech HTTP/1.1" 200 OK
2026-06-07 10:59:34,411 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 7, token usage: 0.00, #running-req: 0, #queue-req: 0,
2026-06-07 10:59:34,751 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 45, token usage: 0.00, cuda graph: True, gen throughput (token/s): 75.09, #queue-req: 0,
INFO:     127.0.0.1:49312 - "POST /v1/audio/speech HTTP/1.1" 200 OK
2026-06-07 10:59:35,018 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 7, token usage: 0.00, #running-req: 0, #queue-req: 0,
2026-06-07 10:59:35,235 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 30, token usage: 0.00, cuda graph: True, gen throughput (token/s): 82.66, #queue-req: 0,
INFO:     127.0.0.1:49314 - "POST /v1/audio/speech HTTP/1.1" 200 OK
2026-06-07 10:59:35,538 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 7, token usage: 0.00, #running-req: 0, #queue-req: 0,
2026-06-07 10:59:35,657 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 17, token usage: 0.00, cuda graph: True, gen throughput (token/s): 94.83, #queue-req: 0,
2026-06-07 10:59:35,970 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 57, token usage: 0.00, cuda graph: True, gen throughput (token/s): 127.63, #queue-req: 0,
INFO:     127.0.0.1:49318 - "POST /v1/audio/speech HTTP/1.1" 200 OK
INFO:     127.0.0.1:49334 - "POST /v1/audio/speech HTTP/1.1" 200 OK
2026-06-07 10:59:36,186 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 7, token usage: 0.00, #running-req: 0, #queue-req: 0,
2026-06-07 10:59:36,468 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 34, token usage: 0.00, cuda graph: True, gen throughput (token/s): 80.41, #queue-req: 0,
2026-06-07 10:59:36,826 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 0, token usage: 0.00, cuda graph: True, gen throughput (token/s): 111.77, #queue-req: 0,
2026-06-07 10:59:36,951 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 7, token usage: 0.00, #running-req: 0, #queue-req: 0,
2026-06-07 10:59:37,363 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 48, token usage: 0.00, cuda graph: True, gen throughput (token/s): 74.46, #queue-req: 0,
INFO:     127.0.0.1:49344 - "POST /v1/audio/speech HTTP/1.1" 200 OK
2026-06-07 10:59:37,655 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Prefill batch, #new-seq: 1, #new-token: 3, #cached-token: 2, token usage: 0.00, #running-req: 0, #queue-req: 0,
INFO:     127.0.0.1:49356 - "POST /v1/audio/speech HTTP/1.1" 200 OK
2026-06-07 10:59:37,948 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 4, token usage: 0.00, #running-req: 0, #queue-req: 0,
2026-06-07 10:59:38,048 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 12, token usage: 0.00, cuda graph: True, gen throughput (token/s): 58.41, #queue-req: 0,
INFO:     127.0.0.1:49360 - "POST /v1/audio/speech HTTP/1.1" 200 OK
2026-06-07 10:59:38,152 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 7, token usage: 0.00, #running-req: 0, #queue-req: 0,
2026-06-07 10:59:38,441 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 40, token usage: 0.00, cuda graph: True, gen throughput (token/s): 101.67, #queue-req: 0,
INFO:     127.0.0.1:49370 - "POST /v1/audio/speech HTTP/1.1" 200 OK
2026-06-07 10:59:38,705 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 7, token usage: 0.00, #running-req: 0, #queue-req: 0,
2026-06-07 10:59:38,842 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 20, token usage: 0.00, cuda graph: True, gen throughput (token/s): 99.81, #queue-req: 0,
2026-06-07 10:59:39,153 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Decode batch, #running-req: 1, #token: 60, token usage: 0.00, cuda graph: True, gen throughput (token/s): 128.57, #queue-req: 0,
INFO:     127.0.0.1:49378 - "POST /v1/audio/speech HTTP/1.1" 200 OK
2026-06-07 10:59:39,300 [INFO] sglang.srt.managers.scheduler_metrics_mixin: Prefill batch, #new-seq: 1, #new-token: 1, #cached-token: 4, token usage: 0.00, #running-req: 0, #queue-req: 0,
INFO:     127.0.0.1:49386 - "POST /v1/audio/speech HTTP/1.1" 200 OK
INFO:     127.0.0.1:49402 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:49414 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:49422 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:49424 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:49438 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:49452 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:49460 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:38906 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:38910 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:38922 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:38930 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:38938 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:38940 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:38950 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:38954 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:38968 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:38976 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:38982 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:38996 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:39006 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:39012 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:39020 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:39036 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:39042 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
INFO:     127.0.0.1:39050 - "POST /v1/audio/speech HTTP/1.1" 422 Unprocessable Entity
```

| Parameter | Request | Result |
|---|---|---|
| `response_format` | `{"input":"Speech contract smoke test.","response_format":" WAV "}` | 200 |
| `response_format` | `{"input":"Speech contract smoke test.","response_format":"pcm"}` | 200 |
| `response_format` | `{"input":"Speech contract smoke test.","response_format":"mp3"}` | 200 |
| `response_format` | `{"input":"Speech contract smoke test.","response_format":"flac"}` | 200 |
| `response_format` | `{"input":"Speech contract smoke test.","response_format":"opus"}` | 200 |
| `response_format` | `{"input":"Speech contract smoke test.","response_format":"aac"}` | 200 |
| `response_format` | `{"input":"Speech contract smoke test.","response_format":"ogg"}` | 422 |
| `response_format` | `{"input":"Speech contract smoke test.","response_format":null}` | 422 |
| `speed` | `{"input":"Speech contract smoke test.","speed":0.5}` | 200 |
| `speed` | `{"input":"Speech contract smoke test.","speed":1.5}` | 200 |
| `speed` | `{"input":"Speech contract smoke test.","speed":0}` | 422 |
| `speed` | `{"input":"Speech contract smoke test.","speed":-1}` | 422 |
| `stream_format` / `stream` / `response_format` | `{"input":"Speech contract smoke test.","stream":true,"response_format":"wav"}` | 200 |
| `stream_format` / `stream` / `response_format` | `{"input":"Speech contract smoke test.","stream":true,"stream_format":"audio","response_format":"pcm"}` | 200 |
| `stream_format` / `stream` / `response_format` | `{"input":"Speech contract smoke test.","stream_format":"audio","response_format":"pcm"}` | 422 |
| `stream_format` / `stream` / `response_format` | `{"input":"Speech contract smoke test.","stream":true,"stream_format":"audio","response_format":"wav"}` | 422 |
| `stream_format` | `{"input":"Speech contract smoke test.","stream_format":"chunked"}` | 422 |
| `token_count` | `{"input":"SGLang Omni makes speech contract testing easier.","token_count":64,"max_new_tokens":512}` | 200 |
| `duration_tokens` | `{"input":"SGLang Omni makes speech contract testing easier.","duration_tokens":64,"max_new_tokens":512}` | 200 |
| `token_count` | `{"input":"Speech contract smoke test.","token_count":0}` | 422 |
| `duration_tokens` | `{"input":"Speech contract smoke test.","duration_tokens":0}` | 422 |
| `token_count` / `duration_tokens` | `{"input":"Speech contract smoke test.","token_count":8,"duration_tokens":8}` | 422 |
| `initial_codec_chunk_frames` | `{"input":"Speech contract smoke test.","stream":true,"stream_format":"audio","response_format":"pcm","initial_codec_chunk_frames":0}` | 200 |
| `initial_codec_chunk_frames` | `{"input":"Speech contract smoke test.","initial_codec_chunk_frames":-1}` | 422 |
| `max_new_tokens` | `{"input":"Hello.","max_new_tokens":16}` | 200 |
| `max_new_tokens` | `{"input":"Speech contract smoke test.","max_new_tokens":0}` | 422 |
| `temperature` | `{"input":"Hello.","max_new_tokens":16,"temperature":0}` | 200 |
| `temperature` | `{"input":"SGLang Omni makes speech contract testing easier.","max_new_tokens":512,"temperature":0.8}` | 200 |
| `temperature` | `{"input":"Speech contract smoke test.","temperature":-0.01}` | 422 |
| `top_p` | `{"input":"Hello.","max_new_tokens":16,"top_p":1}` | 200 |
| `top_p` | `{"input":"Speech contract smoke test.","top_p":0}` | 422 |
| `top_p` | `{"input":"Speech contract smoke test.","top_p":1.01}` | 422 |
| `top_k` | `{"input":"Hello.","max_new_tokens":16,"top_k":-1}` | 200 |
| `top_k` | `{"input":"Hello.","max_new_tokens":16,"top_k":1}` | 200 |
| `top_k` | `{"input":"SGLang Omni makes speech contract testing easier.","top_k":4096,"max_new_tokens":512}` | 200 |
| `top_k` | `{"input":"Speech contract smoke test.","top_k":0}` | 422 |
| `top_k` | `{"input":"Speech contract smoke test.","top_k":-2}` | 422 |
| `repetition_penalty` | `{"input":"Hello.","max_new_tokens":16,"repetition_penalty":1.1}` | 200 |
| `repetition_penalty` | `{"input":"SGLang Omni makes speech contract testing easier.","max_new_tokens":512,"repetition_penalty":2.1}` | 200 |
| `repetition_penalty` | `{"input":"Speech contract smoke test.","repetition_penalty":0}` | 422 |
| `seed` | `{"input":"Hello.","max_new_tokens":16,"seed":0}` | 200 |
| `seed` | `{"input":"Speech contract smoke test.","seed":-1}` | 422 |
| `references` | `{"input":"Speech contract smoke test.","references":[{"audio_path":"docs/_static/audio/male-voice.wav","text":"Hey, Adam here. Let's create something that feels real, sounds human, and connects every time."}]}` | 200 |
| `ref_audio` / `ref_text` | `{"input":"Speech contract smoke test.","ref_audio":"docs/_static/audio/male-voice.wav","ref_text":"Hey, Adam here. Let's create something that feels real, sounds human, and connects every time."}` | 200 |
| `references` | `{"input":"Speech contract smoke test.","references":[]}` | 200 |
| `ref_text` | `{"input":"Speech contract smoke test.","ref_text":"Hey, Adam here. Let's create something that feels real, sounds human, and connects every time."}` | 422 |
| `references` | `{"input":"Speech contract smoke test.","references":[{}]}` | 422 |
| `references[].text` | `{"input":"Speech contract smoke test.","references":[{"text":"Hey, Adam here. Let's create something that feels real, sounds human, and connects every time."}]}` | 422 |
| `references[].audio_path` / `references[].vq_codes` | `{"input":"Speech contract smoke test.","references":[{"audio_path":"docs/_static/audio/male-voice.wav","vq_codes":[1,2]}]}` | 422 |
| `ref_audio` / `references` | `{"input":"Speech contract smoke test.","ref_audio":"docs/_static/audio/male-voice.wav","references":[{"audio_path":"docs/_static/audio/male-voice.wav","text":"Hey, Adam here. Let's create something that feels real, sounds human, and connects every time."}]}` | 422 |

## RFC

This implementation only performs the most basic parameter validation.
Open to other opinions :)
