### PR TITLE
[CI] Fix live label gate for Omni CI reruns

### DIFF
--- a/.github/workflows/omni-ci.yaml
+++ b/.github/workflows/omni-ci.yaml
@@ -9,7 +9,7 @@ name: Omni CI
 on:
   pull_request:
     branches: [main]
-    types: [labeled, synchronize, reopened, ready_for_review]
+    types: [opened, labeled, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:
@@ -32,18 +32,52 @@ env:
 
 jobs:
   preflight:
-    name: preflight - lint and mergeability
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (!github.event.pull_request.draft &&
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
+    name: omni-ci-gate
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Fetch latest PR gate state
+        if: ${{ github.event_name == 'pull_request' }}
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            // Reruns reuse the original pull_request event payload, so fetch
+            // live labels/draft state after /tag-and-rerun-ci adds run-ci.
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput("labels", JSON.stringify(pr.data.labels.map((label) => label.name)));
+            core.setOutput("draft", pr.data.draft ? "true" : "false");
+
+      - name: Log PR gate state
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          echo "PR labels: ${{ steps.pr.outputs.labels }}"
+          echo "PR draft: ${{ steps.pr.outputs.draft }}"
+
+      - name: Block draft PR
+        if: ${{ github.event_name == 'pull_request' && fromJson(steps.pr.outputs.draft) }}
+        run: |
+          echo "PR is draft. Blocking Omni CI."
+          exit 1
+
+      - name: Require run-ci label
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          if [[ "${{ contains(fromJson(steps.pr.outputs.labels), 'run-ci') }}" == "false" ]]; then
+            echo "Missing required label 'run-ci'. Add the label or use /tag-and-rerun-ci to opt into Omni CI."
+            exit 1
+          fi
+
       - name: Checkout workflow scripts
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Check PR lint and mergeability
         if: ${{ github.event_name == 'pull_request' }}
@@ -58,10 +92,7 @@ jobs:
   setup:
     name: setup - omni venv
     needs: preflight
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (!github.event.pull_request.draft &&
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
+    if: needs.preflight.result == 'success'
     runs-on: [self-hosted]
     timeout-minutes: 30
     container:
@@ -99,10 +130,7 @@ jobs:
   tts-ci:
     name: TTS CI
     needs: setup
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (!github.event.pull_request.draft &&
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
+    if: needs.setup.result == 'success'
     uses: ./.github/workflows/test-tts-ci.yaml
     secrets: inherit
 
@@ -111,10 +139,7 @@ jobs:
     needs: [setup, tts-ci]
     if: >-
       always() && !cancelled() &&
-      needs.setup.result == 'success' &&
-      (github.event_name == 'workflow_dispatch' ||
-       (!github.event.pull_request.draft &&
-        contains(github.event.pull_request.labels.*.name, 'run-ci')))
+      needs.setup.result == 'success'
     uses: ./.github/workflows/test-qwen3-omni-ci.yaml
     secrets: inherit
 
@@ -123,10 +148,7 @@ jobs:
     needs: [setup, qwen3-omni-ci]
     if: >-
       always() && !cancelled() &&
-      needs.setup.result == 'success' &&
-      (github.event_name == 'workflow_dispatch' ||
-       (!github.event.pull_request.draft &&
-        contains(github.event.pull_request.labels.*.name, 'run-ci')))
+      needs.setup.result == 'success'
     uses: ./.github/workflows/test.yaml
     secrets: inherit
 
@@ -135,10 +157,7 @@ jobs:
     needs: [setup, tts-ci, qwen3-omni-ci, pr-test]
     if: >-
       always() && !cancelled() &&
-      needs.setup.result == 'success' &&
-      (github.event_name == 'workflow_dispatch' ||
-       (!github.event.pull_request.draft &&
-        contains(github.event.pull_request.labels.*.name, 'run-ci')))
+      needs.setup.result == 'success'
     runs-on: [self-hosted]
     timeout-minutes: 5
     container:

--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -20,10 +20,6 @@ env:
 jobs:
   stage-1-thinker:
     name: stage 1 - thinker length integration
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (!github.event.pull_request.draft &&
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     runs-on: [self-hosted]
     timeout-minutes: 20
     container:
@@ -60,10 +56,6 @@ jobs:
 
   stage-2-tts:
     name: stage 2 - TTS speed + WER + SIM
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (!github.event.pull_request.draft &&
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     runs-on: [self-hosted]
     timeout-minutes: 25
     container:
@@ -117,10 +109,6 @@ jobs:
 
   stage-3-mmmu:
     name: stage 3 - MMMU accuracy + speed
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (!github.event.pull_request.draft &&
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     runs-on: [self-hosted]
     timeout-minutes: 20
     container:
@@ -161,10 +149,6 @@ jobs:
 
   stage-4-mmmu-talker:
     name: stage 4 - MMMU Talker
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (!github.event.pull_request.draft &&
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     runs-on: [self-hosted]
     timeout-minutes: 15
     container:
@@ -205,10 +189,6 @@ jobs:
 
   stage-5-mmsu:
     name: stage 5 - MMSU accuracy + speed
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (!github.event.pull_request.draft &&
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     runs-on: [self-hosted]
     timeout-minutes: 20
     container:
@@ -250,10 +230,6 @@ jobs:
 
   stage-6-mmsu-talker:
     name: stage 6 - MMSU Talker
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (!github.event.pull_request.draft &&
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     runs-on: [self-hosted]
     timeout-minutes: 15
     container:
@@ -294,10 +270,6 @@ jobs:
 
   stage-7-videomme:
     name: stage 7 - Video-MME accuracy + speed
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (!github.event.pull_request.draft &&
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     runs-on: [self-hosted]
     timeout-minutes: 30
     container:
@@ -338,10 +310,6 @@ jobs:
 
   stage-8-videomme-talker:
     name: stage 8 - Video-MME Talker
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (!github.event.pull_request.draft &&
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     runs-on: [self-hosted]
     timeout-minutes: 30
     container:
@@ -382,10 +350,6 @@ jobs:
 
   stage-9-videoamme:
     name: stage 9 - Video-AMME accuracy + speed
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (!github.event.pull_request.draft &&
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     runs-on: [self-hosted]
     timeout-minutes: 30
     container:
@@ -426,10 +390,6 @@ jobs:
 
   stage-10-videoamme-talker:
     name: stage 10 - Video-AMME Talker
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (!github.event.pull_request.draft &&
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     runs-on: [self-hosted]
     timeout-minutes: 30
     container:
@@ -470,10 +430,6 @@ jobs:
 
   stage-11-thinker-tp2:
     name: stage 11 - FP8 Thinker TP=2 (Video-AMME Talker)
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (!github.event.pull_request.draft &&
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
     runs-on: [self-hosted]
     timeout-minutes: 35
     container:


### PR DESCRIPTION
## Motivation

`/tag-and-rerun-ci` could add the `run-ci` label while the rerun still skipped Omni CI jobs. The skipped rerun used the original `pull_request` event payload, so workflow/job `if` checks against `github.event.pull_request.labels` did not see the newly added label.

This updates the Omni CI gate so reruns use the current PR label/draft state before deciding whether to run expensive self-hosted jobs.

## Modifications

- Add `opened` to the Omni CI `pull_request` events so new PRs get an initial preflight run that `/tag-and-rerun-ci` can rerun.
- Move the `run-ci` and draft checks into the `preflight` job using `actions/github-script` to fetch live PR state from the GitHub API.
- Keep self-hosted Omni jobs gated behind successful `preflight`/`setup`, instead of repeating stale event-payload label checks on each job.
- Remove duplicate frozen label/draft gates from the Qwen3 reusable workflow because it is only invoked by the top-level Omni CI workflow.
- Keep PR code checkout after the live label/draft gate in preflight.

## Root Cause

GitHub reruns reuse the original workflow event payload. When `/tag-and-rerun-ci` adds `run-ci`, a rerun of a previously skipped `pull_request` workflow still sees the old label list if the workflow reads `github.event.pull_request.labels`. That caused the label to appear on the PR while Omni CI remained skipped.
