### PR TITLE
fix(api): gate speech usage headers behind opt-in

### DIFF
--- a/benchmarks/tasks/tts.py
+++ b/benchmarks/tasks/tts.py
@@ -65,6 +65,7 @@ MOSS_TTS_TOKEN_COUNT_AUTO = "auto"
 MOSS_TTS_ZH_TOKENS_PER_CHAR = 3.098411951313033
 MOSS_TTS_EN_TOKENS_PER_CHAR = 0.8673376262755219
 MOSS_TTS_MIN_AUTO_TOKEN_COUNT = 32
+TTS_USAGE_HEADERS = {"X-Include-Usage": "true"}
 UTMOS_BATCH_SIZE = 8
 
 
@@ -1859,7 +1860,9 @@ def make_tts_send_fn(
         )
         start_time = time.perf_counter()
         try:
-            async with session.post(api_url, json=payload) as response:
+            async with session.post(
+                api_url, json=payload, headers=TTS_USAGE_HEADERS
+            ) as response:
                 if response.status != 200:
                     result.error = f"HTTP {response.status}: {await response.text()}"
                 elif stream and stream_format == "audio":

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -18,9 +18,10 @@ import json
 import logging
 import time
 import uuid
+from collections.abc import Mapping
 from typing import Any
 
-from fastapi import FastAPI, File, Form, HTTPException, UploadFile, WebSocket
+from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import (
     JSONResponse,
@@ -35,6 +36,7 @@ from sglang_omni.client import (
     GenerateRequest,
     Message,
     SamplingParams,
+    UsageInfo,
 )
 from sglang_omni.client.audio import (
     DEFAULT_SAMPLE_RATE,
@@ -65,6 +67,8 @@ logger = logging.getLogger(__name__)
 MIME_TO_FORMAT = {mime: fmt for fmt, mime in FORMAT_MIME_TYPES.items()}
 STREAM_DONE_SENTINEL = "[DONE]"
 RAW_PCM_DEFAULT_INITIAL_CODEC_CHUNK_FRAMES = 1
+SPEECH_INCLUDE_USAGE_HEADER = "X-Include-Usage"
+SPEECH_INCLUDE_USAGE_TRUE_VALUES = {"1", "true", "yes", "on"}
 
 _BAD_REQUEST_MARKERS = (
     "longer than the model's context length",
@@ -75,6 +79,25 @@ _BAD_REQUEST_MARKERS = (
 def _is_bad_request_error(exc: Exception) -> bool:
     message = str(exc)
     return any(marker in message for marker in _BAD_REQUEST_MARKERS)
+
+
+def _should_include_speech_usage_headers(headers: Mapping[str, str]) -> bool:
+    value = headers.get(SPEECH_INCLUDE_USAGE_HEADER, "")
+    return value.strip().lower() in SPEECH_INCLUDE_USAGE_TRUE_VALUES
+
+
+def _build_speech_usage_headers(usage: UsageInfo | None) -> dict[str, str]:
+    if usage is None:
+        return {}
+
+    headers: dict[str, str] = {}
+    if usage.prompt_tokens is not None:
+        headers["X-Prompt-Tokens"] = str(usage.prompt_tokens)
+    if usage.completion_tokens is not None:
+        headers["X-Completion-Tokens"] = str(usage.completion_tokens)
+    if usage.engine_time_s is not None:
+        headers["X-Engine-Time"] = str(usage.engine_time_s)
+    return headers
 
 
 def create_app(
@@ -501,7 +524,7 @@ def _register_realtime(app: FastAPI) -> None:
 
 def _register_speech(app: FastAPI) -> None:
     @app.post("/v1/audio/speech")
-    async def create_speech(req: CreateSpeechRequest) -> Response:
+    async def create_speech(req: CreateSpeechRequest, request: Request) -> Response:
         client: Client = app.state.client
         default_model: str = app.state.model_name
 
@@ -552,13 +575,8 @@ def _register_speech(app: FastAPI) -> None:
         headers = {
             "Content-Disposition": f'attachment; filename="speech.{result.format}"',
         }
-        if result.usage is not None:
-            if result.usage.prompt_tokens is not None:
-                headers["X-Prompt-Tokens"] = str(result.usage.prompt_tokens)
-            if result.usage.completion_tokens is not None:
-                headers["X-Completion-Tokens"] = str(result.usage.completion_tokens)
-            if result.usage.engine_time_s is not None:
-                headers["X-Engine-Time"] = str(result.usage.engine_time_s)
+        if _should_include_speech_usage_headers(request.headers):
+            headers.update(_build_speech_usage_headers(result.usage))
 
         return Response(
             content=result.audio_bytes,

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -11,7 +11,7 @@ from fastapi.testclient import TestClient
 
 from sglang_omni.client import Client, GenerateChunk
 from sglang_omni.client.audio import encode_pcm
-from sglang_omni.client.types import GenerateRequest
+from sglang_omni.client.types import GenerateRequest, SpeechResult, UsageInfo
 from sglang_omni.pipeline.coordinator import Coordinator
 from sglang_omni.proto import CompleteMessage, OmniRequest, StreamMessage
 from sglang_omni.serve import create_app
@@ -108,6 +108,30 @@ class SuccessfulSpeechClient:
         )
 
 
+class SuccessfulNonStreamingSpeechClient:
+    def __init__(self, *, usage: UsageInfo | None = None) -> None:
+        self.usage = usage
+
+    def health(self) -> dict[str, Any]:
+        return {"running": True}
+
+    async def speech(
+        self,
+        request: Any,
+        *,
+        request_id: str,
+        response_format: str,
+        speed: float,
+    ) -> SpeechResult:
+        del request, request_id, speed
+        return SpeechResult(
+            audio_bytes=b"audio-bytes",
+            mime_type="audio/wav",
+            format=response_format,
+            usage=self.usage,
+        )
+
+
 class SuccessfulTranscriptionClient:
     def __init__(self) -> None:
         self.requests: list[GenerateRequest] = []
@@ -155,6 +179,77 @@ def test_non_streaming_http_faults_return_500(model_name: str) -> None:
     )
     assert speech_resp.status_code == 500
     assert "cuda out of memory" in speech_resp.json()["detail"]
+
+
+def test_speech_response_omits_usage_headers_by_default() -> None:
+    client = TestClient(
+        create_app(
+            SuccessfulNonStreamingSpeechClient(
+                usage=UsageInfo(
+                    prompt_tokens=3,
+                    completion_tokens=5,
+                    engine_time_s=0.25,
+                )
+            ),
+            model_name="higgs-audio-v2",
+        )
+    )
+
+    response = client.post(
+        "/v1/audio/speech",
+        json={"input": "hello", "response_format": "wav"},
+    )
+
+    assert response.status_code == 200
+    assert "X-Prompt-Tokens" not in response.headers
+    assert "X-Completion-Tokens" not in response.headers
+    assert "X-Engine-Time" not in response.headers
+
+
+def test_speech_response_includes_usage_headers_when_requested() -> None:
+    client = TestClient(
+        create_app(
+            SuccessfulNonStreamingSpeechClient(
+                usage=UsageInfo(
+                    prompt_tokens=3,
+                    completion_tokens=5,
+                    engine_time_s=0.25,
+                )
+            ),
+            model_name="higgs-audio-v2",
+        )
+    )
+
+    response = client.post(
+        "/v1/audio/speech",
+        headers={"X-Include-Usage": "true"},
+        json={"input": "hello", "response_format": "wav"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["X-Prompt-Tokens"] == "3"
+    assert response.headers["X-Completion-Tokens"] == "5"
+    assert response.headers["X-Engine-Time"] == "0.25"
+
+
+def test_speech_response_usage_opt_in_omits_empty_usage_headers() -> None:
+    client = TestClient(
+        create_app(
+            SuccessfulNonStreamingSpeechClient(usage=None),
+            model_name="higgs-audio-v2",
+        )
+    )
+
+    response = client.post(
+        "/v1/audio/speech",
+        headers={"X-Include-Usage": "true"},
+        json={"input": "hello", "response_format": "wav"},
+    )
+
+    assert response.status_code == 200
+    assert "X-Prompt-Tokens" not in response.headers
+    assert "X-Completion-Tokens" not in response.headers
+    assert "X-Engine-Time" not in response.headers
 
 
 def test_chat_stream_failure_closes_without_done_sentinel() -> None:


### PR DESCRIPTION
## Motivation

Implements Option A from #174.

`/v1/audio/speech` should stay OpenAI-compatible by default and return raw audio without non-standard usage headers. Benchmark/debug callers can still request usage headers explicitly.

## Changes

- Add an explicit `X-Include-Usage: true` opt-in for non-streaming speech usage headers.
- Keep `X-Prompt-Tokens`, `X-Completion-Tokens`, and `X-Engine-Time` out of default speech responses.
- Update the TTS benchmark HTTP send path to request usage headers explicitly, preserving existing token/engine-time metrics.
- Add focused OpenAI API tests for default behavior, opt-in behavior, and opt-in with missing usage.

Fixes #174

## Testing

- `pytest tests/unit_test/serve/test_openai_api.py -q`
- `python -m ruff check sglang_omni/serve/openai_api.py benchmarks/tasks/tts.py tests/unit_test/serve/test_openai_api.py`
