### PR TITLE
[Voxtral] Cross-request batched vocoder decode

### DIFF
--- a/sglang_omni/models/voxtral_tts/pipeline/stages.py
+++ b/sglang_omni/models/voxtral_tts/pipeline/stages.py
@@ -350,16 +350,38 @@ def create_vocoder_executor(
     *,
     device: str = "cuda:0",
     gpu_id: int | None = None,
+    max_batch_size: int = 4,
+    max_batch_wait_ms: int = 2,
 ) -> SimpleScheduler:
-    """Factory for the vocoder (audio tokenizer decode) stage."""
+    """Factory for the vocoder (audio tokenizer decode) stage.
+
+    Concurrent requests are coalesced into a single ``decode_helper_batch_async``
+    call (``batch_compute_fn`` below). Voxtral's decoder is fully causal
+    (``CausalConv1d`` / ``CausalConvTranspose1d``), so the helper's pad-to-max +
+    crop does **not** contaminate across requests of different lengths (a
+    non-causal codec could not be padded this way). The batched output matches
+    single-request decode up to bf16 batch-dependent conv-algorithm noise
+    (rel ~1e-2, quality-neutral — WER-validated, same property as the Higgs
+    batched vocoder decode #574 / MOSS #651).
+    """
     checkpoint_dir = _resolve_checkpoint(model_path)
     if gpu_id is not None:
         device = f"cuda:{gpu_id}"
+    # Optional override of the vocoder coalescing batch size (1 disables batching).
+    max_batch_size = int(
+        os.environ.get("SGLANG_OMNI_VOXTRAL_VOCODER_MAX_BATCH", max_batch_size)
+    )
 
     logger.info("Loading Voxtral audio tokenizer for vocoding...")
     audio_tokenizer = _load_audio_tokenizer(checkpoint_dir, {}, device)
 
-    def _vocode(payload: StagePayload) -> StagePayload:
+    # Prepend warmup context frames so the causal decoder has initial context
+    # (mitigates boundary artifacts / noise at the start of the waveform); the
+    # samples corresponding to the warmup frames are trimmed after decoding.
+    n_warmup = 2
+
+    def _prepare(payload: StagePayload) -> tuple[Any, torch.Tensor, int]:
+        """payload -> (state, codes_with_warmup, warmup_samples)."""
         state = load_state(payload)
         audio_codes = state.audio_codes
 
@@ -368,11 +390,6 @@ def create_vocoder_executor(
         if not isinstance(audio_codes, torch.Tensor):
             audio_codes = torch.tensor(audio_codes)
 
-        # Prepend warmup context frames so the causal decoder has initial
-        # context (mitigates boundary artifacts / noise at the start of the
-        # waveform).  After decoding, the samples corresponding to the
-        # warmup frames are trimmed away.
-        n_warmup = 2
         warmup_samples = 0
         if audio_codes.shape[0] > 0:
             first_frame = audio_codes[0:1]
@@ -381,10 +398,12 @@ def create_vocoder_executor(
             warmup_samples = n_warmup * audio_tokenizer.downsample_factor
         else:
             codes_with_warmup = audio_codes
+        return state, codes_with_warmup, warmup_samples
 
-        results = audio_tokenizer.decode_helper_batch_async([codes_with_warmup])
-        audio_np = results[0]
-
+    def _postprocess(
+        payload: StagePayload, state: Any, audio_np: torch.Tensor, warmup_samples: int
+    ) -> StagePayload:
+        """(payload, state, decoded waveform, warmup_samples) -> audio payload."""
         # Trim warmup samples from the beginning
         if warmup_samples > 0 and len(audio_np) > warmup_samples:
             audio_np = audio_np[warmup_samples:]
@@ -423,4 +442,25 @@ def create_vocoder_executor(
 
         return payload
 
-    return SimpleScheduler(_vocode)
+    def _vocode(payload: StagePayload) -> StagePayload:
+        state, codes_with_warmup, warmup_samples = _prepare(payload)
+        audio_np = audio_tokenizer.decode_helper_batch_async([codes_with_warmup])[0]
+        return _postprocess(payload, state, audio_np, warmup_samples)
+
+    def _vocode_batch(payloads: list[StagePayload]) -> list[StagePayload]:
+        prepared = [_prepare(p) for p in payloads]
+        codes_list = [codes for (_, codes, _) in prepared]
+        # Single cross-request decode; helper pads to max chunk length and crops
+        # each back to its own length (causal-safe), returning one wav per input.
+        wavs = audio_tokenizer.decode_helper_batch_async(codes_list)
+        return [
+            _postprocess(payload, state, wav, warmup_samples)
+            for payload, (state, _, warmup_samples), wav in zip(payloads, prepared, wavs)
+        ]
+
+    return SimpleScheduler(
+        _vocode,
+        batch_compute_fn=_vocode_batch,
+        max_batch_size=max_batch_size,
+        max_batch_wait_ms=max_batch_wait_ms,
+    )

--- a/tests/unit_test/voxtral_tts/test_vocoder_batch.py
+++ b/tests/unit_test/voxtral_tts/test_vocoder_batch.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for Voxtral cross-request batched vocoder decode.
+
+The batch path coalesces concurrent requests into a single
+``decode_helper_batch_async`` call. With a deterministic fake tokenizer these
+tests assert the batch path produces, per request, output identical to the
+single path (warmup-trim / fade applied per request, results routed back to the
+right payload) and that it issues exactly one decode call for the whole batch.
+
+The fake decoder is deterministic, so equality here verifies routing/warmup/fade
+only. The real on-device numerics — cross-request batching is quality-neutral
+(bf16 batch-dependent conv-algo noise, not contamination, thanks to causality) —
+are covered by the on-device WER validation, not here.
+"""
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import numpy as np
+import torch
+
+from sglang_omni.models.voxtral_tts.io import VoxtralTTSState
+from sglang_omni.models.voxtral_tts.pipeline import stages
+from sglang_omni.proto import StagePayload
+
+
+class _FakeTokenizer:
+    """Returns a deterministic waveform per input so mis-routing is detectable."""
+
+    downsample_factor = 100
+    sampling_rate = 24_000
+
+    def __init__(self) -> None:
+        self.batch_lens: list[int] = []
+
+    def decode_helper_batch_async(self, codes_list):
+        self.batch_lens.append(len(codes_list))
+        return [
+            torch.arange(c.shape[0] * self.downsample_factor, dtype=torch.float32)
+            for c in codes_list
+        ]
+
+
+def _payload(codes: torch.Tensor) -> StagePayload:
+    state = VoxtralTTSState(audio_codes=codes)
+    return StagePayload(request_id="r", request=Mock(), data=state.to_dict())
+
+
+def _audio(payload: StagePayload) -> np.ndarray:
+    return np.frombuffer(payload.data["audio_waveform"], dtype=np.float32)
+
+
+def _make_scheduler(monkeypatch):
+    fake = _FakeTokenizer()
+    monkeypatch.setattr(stages, "_resolve_checkpoint", lambda p: p)
+    monkeypatch.setattr(stages, "_load_audio_tokenizer", lambda *a, **k: fake)
+    return stages.create_vocoder_executor("dummy", device="cpu"), fake
+
+
+def test_create_vocoder_executor_enables_batching(monkeypatch):
+    sched, _ = _make_scheduler(monkeypatch)
+    assert sched._batch_fn is not None
+    assert sched._max_batch_size == 4
+
+
+def test_batch_matches_single_mixed_lengths(monkeypatch):
+    sched, fake = _make_scheduler(monkeypatch)
+    K = 37
+    codes = [
+        torch.randint(0, 1024, (t, K), dtype=torch.long) for t in (10, 25, 7)
+    ]
+
+    singles = [sched._fn(_payload(c.clone())) for c in codes]
+    batched = sched._batch_fn([_payload(c.clone()) for c in codes])
+
+    assert len(batched) == len(singles)
+    for i in range(len(codes)):
+        np.testing.assert_array_equal(_audio(batched[i]), _audio(singles[i]))
+
+    # the batch path issued exactly one decode call covering all 3 requests
+    assert fake.batch_lens[-1] == 3
+
+
+def test_single_element_batch_matches_single(monkeypatch):
+    sched, _ = _make_scheduler(monkeypatch)
+    codes = torch.randint(0, 1024, (12, 37), dtype=torch.long)
+    single = sched._fn(_payload(codes.clone()))
+    batched = sched._batch_fn([_payload(codes.clone())])
+    np.testing.assert_array_equal(_audio(batched[0]), _audio(single))
+
+
+if __name__ == "__main__":
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

Coalesce concurrent Voxtral vocoder (audio-tokenizer decode) requests into a single `decode_helper_batch_async` call via `SimpleScheduler`'s `batch_compute_fn`, instead of decoding one request at a time. Implements the **"batched vocoder decode for Voxtral"** item from the Voxtral roadmap (#599).

This mirrors the Higgs batched vocoder decode (#574, merged), applied to Voxtral.

## Why it's safe (causality)

Voxtral's decoder is fully causal (`CausalConv1d` / `CausalConvTranspose1d`). `decode_helper_batch_async` already pads each request's chunks to the max chunk length and crops every output back to its own length; because the convolutions are causal, this pad-to-max + crop **does not contaminate across requests of different lengths** (a non-causal codec — e.g. Higgs' DAC — cannot be padded this way and must bucket by exact length).

Each request keeps its own warmup-context frames (prepended) and trims them independently after decode, so batching is purely a throughput optimization with no cross-request coupling.

Batched output matches single-request decode up to bf16 batch-dependent conv-algorithm noise (rel ~1e-2, quality-neutral) — the same property leveraged by #574, gated on WER rather than bit-exactness.

## Correctness

- New unit test `tests/unit_test/voxtral_tts/test_vocoder_batch.py` (deterministic fake tokenizer): asserts the batch path produces, per request, output identical to the single path across mixed request lengths (warmup-trim / fade applied per request, results routed back to the correct payload), and that it issues exactly one decode call covering the whole batch.
- On-device WER validation (below) confirms the bf16 numeric noise is quality-neutral.

## Performance

A800, `Voxtral-4B-TTS-2603`, `benchmark_tts_seedtts` (concurrency 16, 128 samples, `cheerful_female`, en):

| metric | baseline (batch=1) | batched (batch=4) | delta |
|---|---|---|---|
| throughput (req/s) | 6.063 | 6.869 | **+13.3%** |
| audio throughput (s/s) | 31.51 | 34.545 | +9.6% |
| mean latency (s) | 2.35 | 2.21 | −6% |
| RTF mean | 0.457 | 0.441 | better |
| WER corpus (whisper large-v3) | 0.51% | 0.44% | no regression |
| WER >50% outliers | 0 / 128 | 0 / 128 | — |
| success | 128 / 128 | 128 / 128 | — |

## Config

Batch size defaults to 4 (`max_batch_wait_ms=2`), overridable via `SGLANG_OMNI_VOXTRAL_VOCODER_MAX_BATCH` (set to `1` to disable batching). No change to `audio_tokenizer.py` or `simple_scheduler.py` — both already support this path.
