### PR TITLE
Refactor MOSS decode state into row-indexed pool

### DIFF
--- a/sglang_omni/models/moss_tts/model_runner.py
+++ b/sglang_omni/models/moss_tts/model_runner.py
@@ -10,6 +10,7 @@ from sglang.srt.layers.sampler import multinomial_with_seed
 
 from sglang_omni.model_runner.base import ModelRunner
 from sglang_omni.models.moss_tts.request_builders import _INF_DELAY
+from sglang_omni.models.moss_tts.state_pool import MossDecodeJournal
 from sglang_omni.scheduling.types import RequestOutput
 
 _NEG_INF = float("-inf")
@@ -23,6 +24,7 @@ class MossTTSModelRunner(ModelRunner):
         super().__init__(tp_worker, output_processor)
         self._pending_rows: torch.Tensor | None = None
         self._pending_embeds: torch.Tensor | None = None
+        self._pending_journals: list[MossDecodeJournal] | None = None
 
     def custom_prefill_forward(
         self,
@@ -117,8 +119,14 @@ class MossTTSModelRunner(ModelRunner):
                 "MOSS-TTS decode batch exceeds the staged decode-embedding rows "
                 f"({batch_size} > {int(weight.shape[0])})"
             )
+        pool = getattr(self.model, "_decode_state_pool", None)
         rows = []
         for sched_req in requests:
+            request_id = getattr(sched_req, "request_id", None)
+            if pool is not None and request_id is not None:
+                row = pool.acquire_row(str(request_id))
+                rows.append(pool.feedback_or_zero(row))
+                continue
             queue = sched_req.data.pending_feedback_queue
             if not queue:
                 rows.append(torch.zeros(self.model.hidden_size, device=weight.device))
@@ -153,7 +161,21 @@ class MossTTSModelRunner(ModelRunner):
             return
 
         datas = [sched_req.data for sched_req in requests]
-        rows = self._sample_rows(channel_logits, datas, n_vq=n_vq)
+        pool = getattr(self.model, "_decode_state_pool", None)
+        pool_rows = None
+        if pool is not None:
+            pool_rows = torch.tensor(
+                [
+                    pool.acquire_row(str(sched_req.request_id))
+                    for sched_req in requests
+                    if getattr(sched_req, "request_id", None) is not None
+                ],
+                dtype=torch.long,
+                device=channel_logits[0].device,
+            )
+            if int(pool_rows.numel()) != len(requests):
+                pool_rows = None
+        rows = self._sample_rows(channel_logits, datas, n_vq=n_vq, pool_rows=pool_rows)
 
         next_token_ids = rows[:, 0].contiguous()
         result.next_token_ids = next_token_ids
@@ -161,8 +183,84 @@ class MossTTSModelRunner(ModelRunner):
         embeds = self.model._prepare_multi_modal_inputs(
             rows.to(device=self.model.device)
         )
+        if pool is not None:
+            journals = []
+            eos_id = getattr(getattr(self.model, "config", None), "im_end_token_id", None)
+            eos_id = None if eos_id is None else int(eos_id)
+            for row_idx, sched_req in enumerate(requests):
+                request_id = getattr(sched_req, "request_id", None)
+                if request_id is None:
+                    continue
+                pool_row = pool.acquire_row(str(request_id))
+                token_id = int(rows[row_idx, 0].item())
+                pool.sampling_steps[pool_row] += 1
+                if eos_id is not None and token_id == eos_id:
+                    pool.clear_feedback(pool_row)
+                    pool.mark_stop(pool_row, kind=1, value=eos_id)
+                    journals.append(
+                        MossDecodeJournal(
+                            request_id=str(request_id),
+                            row=pool_row,
+                            sampled_row=None,
+                            next_token_id=token_id,
+                            emit_output_row=False,
+                            finish_kind="stop",
+                            finish_value=eos_id,
+                        )
+                    )
+                    continue
+                pool.append_generated_row(pool_row, rows[row_idx].detach())
+                max_new_tokens = self._moss_max_new_tokens(sched_req.data)
+                if (
+                    max_new_tokens is not None
+                    and self._moss_reaches_length_boundary(
+                        sched_req.data, max_new_tokens
+                    )
+                ):
+                    pool.clear_feedback(pool_row)
+                    pool.mark_stop(pool_row, kind=2, value=max_new_tokens)
+                    journals.append(
+                        MossDecodeJournal(
+                            request_id=str(request_id),
+                            row=pool_row,
+                            sampled_row=rows[row_idx].detach().clone(),
+                            next_token_id=token_id,
+                            emit_output_row=True,
+                            finish_kind="length",
+                            finish_value=max_new_tokens,
+                        )
+                    )
+                    continue
+                pool.write_feedback(pool_row, embeds[row_idx].detach())
+                journals.append(
+                    MossDecodeJournal(
+                        request_id=str(request_id),
+                        row=pool_row,
+                        sampled_row=rows[row_idx].detach().clone(),
+                        next_token_id=token_id,
+                        emit_output_row=True,
+                    )
+                )
+            self._pending_journals = journals
         self._pending_rows = rows
         self._pending_embeds = embeds.detach()
+
+    @staticmethod
+    def _moss_max_new_tokens(data: Any) -> int | None:
+        req = getattr(data, "req", None)
+        sampling_params = getattr(req, "sampling_params", None)
+        max_new_tokens = getattr(sampling_params, "max_new_tokens", None)
+        if max_new_tokens is None:
+            max_new_tokens = getattr(data, "max_new_tokens", None)
+        if max_new_tokens is None or int(max_new_tokens) <= 0:
+            return None
+        return int(max_new_tokens)
+
+    @staticmethod
+    def _moss_reaches_length_boundary(data: Any, max_new_tokens: int) -> bool:
+        req = getattr(data, "req", None)
+        output_ids = getattr(req, "output_ids", None) if req is not None else None
+        return len(output_ids or []) + 1 >= int(max_new_tokens)
 
     def _channel_logits_from_result(
         self,
@@ -211,6 +309,7 @@ class MossTTSModelRunner(ModelRunner):
         datas: list,
         *,
         n_vq: int,
+        pool_rows: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """One batched MOSS-TTS delay-pattern decode step over the whole batch.
 
@@ -229,15 +328,40 @@ class MossTTSModelRunner(ModelRunner):
         im_end = int(cfg.im_end_token_id)
         audio_pad_code = int(cfg.audio_pad_code)
 
-        delay_state = torch.stack(
-            [self._delay_state_tensor(d, device) for d in datas], dim=0
-        )
+        pool = getattr(self.model, "_decode_state_pool", None)
+        use_pool = pool is not None and pool_rows is not None
+        if use_pool:
+            pool_rows = pool_rows.to(device=pool.delay_state.device, dtype=torch.long)
+            needs_init = ~pool.delay_initialized[pool_rows]
+            if bool(needs_init.any()):
+                init_state = torch.stack(
+                    [
+                        self._delay_state_tensor(data, pool.delay_state.device)
+                        for data in datas
+                    ],
+                    dim=0,
+                )
+                pool.delay_state[pool_rows[needs_init]] = init_state[needs_init].to(
+                    device=pool.delay_state.device,
+                    dtype=pool.delay_state.dtype,
+                )
+                pool.delay_initialized[pool_rows[needs_init]] = True
+            delay_state = pool.delay_state[pool_rows].to(device=device, dtype=torch.long)
+        else:
+            delay_state = torch.stack(
+                [self._delay_state_tensor(d, device) for d in datas], dim=0
+            )
         audio_lengths = delay_state[:, 0]
         delayed = delay_state[:, 1]
         is_audio = delay_state[:, 2].bool()
-        gen_steps = torch.tensor(
-            [int(d.generation_steps) for d in datas], dtype=torch.long, device=device
-        )
+        if use_pool:
+            gen_steps = pool.sampling_steps[pool_rows].to(device=device, dtype=torch.long)
+        else:
+            gen_steps = torch.tensor(
+                [int(d.generation_steps) for d in datas],
+                dtype=torch.long,
+                device=device,
+            )
         text_temp = torch.tensor(
             [float(d.text_temperature) for d in datas],
             dtype=torch.float32,
@@ -342,7 +466,12 @@ class MossTTSModelRunner(ModelRunner):
             if 0 <= audio_pad_code < audio_logits.shape[-1]:
                 audio_logits[..., audio_pad_code:] = _NEG_INF
             if bool((audio_rep != 1.0).any()):
-                self._apply_audio_repetition_penalty(audio_logits, datas, n_vq=n_vq)
+                self._apply_audio_repetition_penalty(
+                    audio_logits,
+                    datas,
+                    n_vq=n_vq,
+                    pool_rows=pool_rows if use_pool else None,
+                )
             audio_temp_full = audio_temp.unsqueeze(1).expand(batch_size, n_vq)
             audio_top_p_full = audio_top_p.unsqueeze(1).expand(batch_size, n_vq)
             audio_top_k_full = audio_top_k.unsqueeze(1).expand(batch_size, n_vq)
@@ -371,8 +500,15 @@ class MossTTSModelRunner(ModelRunner):
         delayed[delayed > n_vq] = _INT64_MAX
 
         next_state = torch.stack((audio_lengths, delayed, is_audio.long()), dim=1)
+        if use_pool:
+            pool.delay_state[pool_rows] = next_state.to(
+                device=pool.delay_state.device,
+                dtype=pool.delay_state.dtype,
+            )
+            pool.delay_initialized[pool_rows] = True
         for i, data in enumerate(datas):
-            data.delay_state = next_state[i].detach()
+            if not use_pool:
+                data.delay_state = next_state[i].detach()
             if device.type == "cpu":
                 data.audio_length = int(next_state[i, 0])
                 delayed_i = int(next_state[i, 1])
@@ -491,12 +627,13 @@ class MossTTSModelRunner(ModelRunner):
         )
         return scores.masked_fill(remove_scattered, _NEG_INF)
 
-    @staticmethod
     def _apply_audio_repetition_penalty(
+        self,
         audio_logits: torch.Tensor,
         datas: list,
         *,
         n_vq: int,
+        pool_rows: torch.Tensor | None = None,
     ) -> None:
         """In-place delay-pattern repetition penalty, per request and codebook.
 
@@ -507,6 +644,7 @@ class MossTTSModelRunner(ModelRunner):
         """
         device = audio_logits.device
         vocab = audio_logits.shape[-1]
+        pool = getattr(self.model, "_decode_state_pool", None)
         for i, data in enumerate(datas):
             penalty = float(data.audio_repetition_penalty)
             if penalty == 1.0:
@@ -515,9 +653,14 @@ class MossTTSModelRunner(ModelRunner):
             prompt_rows = getattr(data, "prompt_rows", None)
             if prompt_rows is not None and prompt_rows.numel() > 0:
                 parts.append(prompt_rows[:, 1:])
-            output_rows = getattr(data, "output_rows", None)
-            if output_rows:
-                parts.append(torch.stack(output_rows, dim=0)[:, 1:])
+            if pool is not None and pool_rows is not None:
+                history = pool.generated_history(int(pool_rows[i].item()))
+                if history.numel() > 0:
+                    parts.append(history[:, 1:])
+            if not parts:
+                output_rows = getattr(data, "output_rows", None)
+                if output_rows:
+                    parts.append(torch.stack(output_rows, dim=0)[:, 1:])
             if not parts:
                 continue
             history = torch.cat(
@@ -540,6 +683,28 @@ class MossTTSModelRunner(ModelRunner):
         outputs: dict[str, RequestOutput],
     ) -> None:
         del result
+        journals = getattr(self, "_pending_journals", None)
+        self._pending_journals = None
+        if journals is not None:
+            self._pending_rows = None
+            self._pending_embeds = None
+            journals_by_id = {journal.request_id: journal for journal in journals}
+            eos_id = int(self.model.config.im_end_token_id)
+            for sched_req in scheduler_output.requests:
+                journal = journals_by_id.get(sched_req.request_id)
+                if journal is None:
+                    continue
+                req_output = outputs[sched_req.request_id]
+                if (
+                    not journal.emit_output_row
+                    or journal.sampled_row is None
+                    or req_output.data is None
+                    or int(req_output.data) == eos_id
+                ):
+                    continue
+                sched_req.data.output_rows.append(journal.sampled_row.detach().clone())
+            return
+
         rows = self._pending_rows
         embeds = self._pending_embeds
         self._pending_rows = None

--- a/sglang_omni/models/moss_tts/request_builders.py
+++ b/sglang_omni/models/moss_tts/request_builders.py
@@ -684,6 +684,10 @@ def make_moss_tts_scheduler_adapters(*, model: Any):
         return build_sglang_moss_tts_request(payload, model=model)
 
     def result_adapter(data: MossTTSSGLangRequestData) -> StagePayload:
-        return apply_sglang_moss_tts_result(data.stage_payload, data)
+        result = apply_sglang_moss_tts_result(data.stage_payload, data)
+        reset_request = getattr(model, "reset_request", None)
+        if reset_request is not None:
+            reset_request(data.stage_payload.request_id)
+        return result
 
     return request_builder, result_adapter

--- a/sglang_omni/models/moss_tts/sglang_model.py
+++ b/sglang_omni/models/moss_tts/sglang_model.py
@@ -30,6 +30,7 @@ from sglang.srt.models.qwen3 import Qwen3Model
 from sglang.srt.utils import add_prefix
 
 from sglang_omni.models.moss_tts.payload_types import moss_tts_special_token_defaults
+from sglang_omni.models.moss_tts.state_pool import MossDecodeStatePool
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +137,23 @@ class MossTTSDelaySGLangModel(torch.nn.Module):
             dtype=weight.dtype,
         )
         self._decode_input_embedding.weight.requires_grad_(False)
+        self._decode_state_pool = MossDecodeStatePool(
+            max_batch_size=int(max_batch_size or 1),
+            hidden_size=self.hidden_size,
+            max_new_tokens=int(getattr(self.config, "max_new_tokens", 4096)),
+            num_channels=int(self.config.channels),
+            device=weight.device,
+            dtype=weight.dtype,
+        )
+
+    def acquire_decode_row(self, req_id: str) -> int:
+        return self._decode_state_pool.acquire_row(req_id)
+
+    def release_row(self, req_id: str) -> None:
+        self._decode_state_pool.release_row(req_id)
+
+    def reset_request(self, req_id: str) -> None:
+        self.release_row(req_id)
 
     @staticmethod
     def _normalize_config(config: Any) -> Any:

--- a/sglang_omni/models/moss_tts/state_pool.py
+++ b/sglang_omni/models/moss_tts/state_pool.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Row-indexed MOSS-TTS decode state.
+
+The pool stores next-step-critical decode state in stable per-request rows.
+It mirrors the ownership model used by Higgs's sampler pool, while keeping
+MOSS-specific state such as feedback embeddings and generated row history.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass
+class MossDecodeJournal:
+    request_id: str
+    row: int
+    sampled_row: torch.Tensor | None
+    next_token_id: int | None
+    emit_output_row: bool
+    finish_kind: str | None = None
+    finish_value: int | None = None
+
+
+class MossDecodeStatePool:
+    """Per-request MOSS decode state stored as fixed row-indexed tensors."""
+
+    def __init__(
+        self,
+        *,
+        max_batch_size: int,
+        hidden_size: int,
+        max_new_tokens: int,
+        num_channels: int,
+        device: torch.device | str,
+        dtype: torch.dtype,
+    ) -> None:
+        if int(max_batch_size) <= 0:
+            raise ValueError("max_batch_size must be > 0")
+        if int(hidden_size) <= 0:
+            raise ValueError("hidden_size must be > 0")
+        if int(max_new_tokens) <= 0:
+            raise ValueError("max_new_tokens must be > 0")
+        if int(num_channels) <= 0:
+            raise ValueError("num_channels must be > 0")
+
+        self.max_batch_size = int(max_batch_size)
+        self.hidden_size = int(hidden_size)
+        self.max_new_tokens = int(max_new_tokens)
+        self.num_channels = int(num_channels)
+        self.device = torch.device(device)
+        self.dtype = dtype
+
+        pool_size = self.max_batch_size + 1
+        self.padding_row = self.max_batch_size
+        self._rid_to_row: dict[str, int] = {}
+        self._free_rows: list[int] = list(range(self.max_batch_size))
+
+        self.feedback_embeds = torch.zeros(
+            pool_size, self.hidden_size, dtype=self.dtype, device=self.device
+        )
+        self.has_feedback = torch.zeros(pool_size, dtype=torch.bool, device=self.device)
+        self.delay_state = torch.zeros(pool_size, 3, dtype=torch.long, device=self.device)
+        self.delay_initialized = torch.zeros(
+            pool_size, dtype=torch.bool, device=self.device
+        )
+        self.sampling_steps = torch.zeros(
+            pool_size, dtype=torch.long, device=self.device
+        )
+        self.generated_rows = torch.zeros(
+            pool_size,
+            self.max_new_tokens,
+            self.num_channels,
+            dtype=torch.long,
+            device=self.device,
+        )
+        self.generated_lengths = torch.zeros(
+            pool_size, dtype=torch.long, device=self.device
+        )
+        self.stop_pending = torch.zeros(pool_size, dtype=torch.bool, device=self.device)
+        self.finish_kind = torch.zeros(pool_size, dtype=torch.long, device=self.device)
+        self.finish_value = torch.zeros(pool_size, dtype=torch.long, device=self.device)
+
+        self.reset_row(self.padding_row)
+
+    def acquire_row(self, request_id: str) -> int:
+        rid = str(request_id)
+        row = self._rid_to_row.get(rid)
+        if row is not None:
+            return row
+        if not self._free_rows:
+            raise RuntimeError(
+                "MOSS decode state pool exhausted "
+                f"(max_batch_size={self.max_batch_size})"
+            )
+        row = self._free_rows.pop()
+        self._rid_to_row[rid] = row
+        self.reset_row(row)
+        return row
+
+    def row_for(self, request_id: str) -> int | None:
+        return self._rid_to_row.get(str(request_id))
+
+    def release_row(self, request_id: str) -> None:
+        row = self._rid_to_row.pop(str(request_id), None)
+        if row is None:
+            return
+        self.reset_row(row)
+        self._free_rows.append(row)
+
+    def reset_row(self, row: int) -> None:
+        row = int(row)
+        self.feedback_embeds[row].zero_()
+        self.has_feedback[row] = False
+        self.delay_state[row].zero_()
+        self.delay_initialized[row] = False
+        self.sampling_steps[row] = 0
+        self.generated_rows[row].zero_()
+        self.generated_lengths[row] = 0
+        self.stop_pending[row] = False
+        self.finish_kind[row] = 0
+        self.finish_value[row] = 0
+
+    def feedback_or_zero(self, row: int) -> torch.Tensor:
+        row = int(row)
+        if bool(self.has_feedback[row].item()):
+            return self.feedback_embeds[row]
+        return torch.zeros(self.hidden_size, dtype=self.dtype, device=self.device)
+
+    def write_feedback(self, row: int, embed: torch.Tensor) -> None:
+        row = int(row)
+        self.feedback_embeds[row].copy_(
+            embed.to(device=self.device, dtype=self.dtype).view(self.hidden_size)
+        )
+        self.has_feedback[row] = True
+
+    def clear_feedback(self, row: int) -> None:
+        row = int(row)
+        self.feedback_embeds[row].zero_()
+        self.has_feedback[row] = False
+
+    def append_generated_row(self, row: int, codes: torch.Tensor) -> None:
+        row = int(row)
+        length = int(self.generated_lengths[row].item())
+        if length >= self.max_new_tokens:
+            raise RuntimeError(
+                "MOSS decode generated history is full "
+                f"(max_new_tokens={self.max_new_tokens})"
+            )
+        self.generated_rows[row, length].copy_(
+            codes.to(device=self.device, dtype=torch.long).view(self.num_channels)
+        )
+        self.generated_lengths[row] = length + 1
+
+    def generated_history(self, row: int) -> torch.Tensor:
+        row = int(row)
+        length = int(self.generated_lengths[row].item())
+        return self.generated_rows[row, :length]
+
+    def mark_stop(self, row: int, *, kind: int, value: int) -> None:
+        row = int(row)
+        self.stop_pending[row] = True
+        self.finish_kind[row] = int(kind)
+        self.finish_value[row] = int(value)

--- a/tests/unit_test/moss_tts/test_decode_state_pool.py
+++ b/tests/unit_test/moss_tts/test_decode_state_pool.py
@@ -17,7 +17,16 @@ from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.scheduling.types import RequestOutput
 
 
+@pytest.fixture(autouse=True)
+def cleanup_model_runner_import():
+    yield
+    sys.modules.pop("sglang_omni.models.moss_tts.model_runner", None)
+
+
 def install_fake_sglang_sampler(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delitem(
+        sys.modules, "sglang_omni.models.moss_tts.model_runner", raising=False
+    )
     modules = {
         "sglang": types.ModuleType("sglang"),
         "sglang.srt": types.ModuleType("sglang.srt"),

--- a/tests/unit_test/moss_tts/test_decode_state_pool.py
+++ b/tests/unit_test/moss_tts/test_decode_state_pool.py
@@ -1,0 +1,671 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.models.moss_tts.payload_types import MossTTSState
+from sglang_omni.models.moss_tts.request_builders import (
+    make_moss_tts_scheduler_adapters,
+)
+from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.scheduling.types import RequestOutput
+
+
+def install_fake_sglang_sampler(monkeypatch: pytest.MonkeyPatch) -> None:
+    modules = {
+        "sglang": types.ModuleType("sglang"),
+        "sglang.srt": types.ModuleType("sglang.srt"),
+        "sglang.srt.layers": types.ModuleType("sglang.srt.layers"),
+        "sglang.srt.layers.sampler": types.ModuleType("sglang.srt.layers.sampler"),
+    }
+    for name in ("sglang", "sglang.srt", "sglang.srt.layers"):
+        modules[name].__path__ = []
+    modules["sglang"].srt = modules["sglang.srt"]
+    modules["sglang.srt"].layers = modules["sglang.srt.layers"]
+    modules["sglang.srt.layers"].sampler = modules["sglang.srt.layers.sampler"]
+    modules["sglang.srt.layers.sampler"].multinomial_with_seed = (
+        lambda probs, seeds, positions: torch.argmax(probs, dim=-1, keepdim=True)
+    )
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+
+def test_state_pool_acquire_release_and_exhaustion() -> None:
+    from sglang_omni.models.moss_tts.state_pool import MossDecodeStatePool
+
+    pool = MossDecodeStatePool(
+        max_batch_size=1,
+        hidden_size=3,
+        max_new_tokens=4,
+        num_channels=5,
+        device="cpu",
+        dtype=torch.float32,
+    )
+
+    assert pool.padding_row == 1
+
+    row = pool.acquire_row("req-a")
+    assert row == 0
+    assert pool.acquire_row("req-a") == row
+    assert pool.row_for("req-a") == row
+
+    with pytest.raises(RuntimeError, match="MOSS decode state pool exhausted"):
+        pool.acquire_row("req-b")
+
+    pool.release_row("req-a")
+    assert pool.row_for("req-a") is None
+    assert pool.acquire_row("req-b") == row
+
+
+def test_state_pool_release_resets_stale_request_state() -> None:
+    from sglang_omni.models.moss_tts.state_pool import MossDecodeStatePool
+
+    pool = MossDecodeStatePool(
+        max_batch_size=1,
+        hidden_size=3,
+        max_new_tokens=4,
+        num_channels=5,
+        device="cpu",
+        dtype=torch.float32,
+    )
+
+    row = pool.acquire_row("req-a")
+    pool.write_feedback(row, torch.tensor([1.0, 2.0, 3.0]))
+    pool.append_generated_row(row, torch.tensor([10, 11, 12, 13, 14]))
+    pool.mark_stop(row, kind=1, value=99)
+
+    assert torch.equal(pool.feedback_or_zero(row), torch.tensor([1.0, 2.0, 3.0]))
+    assert pool.generated_history(row).shape == (1, 5)
+    assert pool.stop_pending[row].item()
+
+    pool.release_row("req-a")
+    reused = pool.acquire_row("req-b")
+    assert reused == row
+
+    assert torch.equal(pool.feedback_or_zero(reused), torch.zeros(3))
+    assert pool.generated_history(reused).shape == (0, 5)
+    assert not pool.stop_pending[reused].item()
+
+
+def test_state_pool_generated_history_is_bounded() -> None:
+    from sglang_omni.models.moss_tts.state_pool import MossDecodeStatePool
+
+    pool = MossDecodeStatePool(
+        max_batch_size=1,
+        hidden_size=2,
+        max_new_tokens=2,
+        num_channels=3,
+        device="cpu",
+        dtype=torch.float32,
+    )
+
+    row = pool.acquire_row("req-a")
+    first = torch.tensor([1, 2, 3])
+    second = torch.tensor([4, 5, 6])
+    pool.append_generated_row(row, first)
+    pool.append_generated_row(row, second)
+
+    assert torch.equal(pool.generated_history(row), torch.stack([first, second]))
+
+    with pytest.raises(RuntimeError, match="generated history is full"):
+        pool.append_generated_row(row, torch.tensor([7, 8, 9]))
+
+
+def test_moss_result_adapter_releases_decode_state_row() -> None:
+    released: list[str] = []
+    model = SimpleNamespace(
+        reset_request=lambda request_id: released.append(str(request_id))
+    )
+    _, result_adapter = make_moss_tts_scheduler_adapters(model=model)
+    payload = StagePayload(
+        request_id="req-a",
+        request=OmniRequest(inputs="hello"),
+        data=MossTTSState(text="hello").to_dict(),
+    )
+    data = SimpleNamespace(
+        stage_payload=payload,
+        state=MossTTSState(text="hello"),
+        assistant_prefix_rows=None,
+        output_rows=[],
+        prompt_rows=torch.empty((0, 3), dtype=torch.long),
+        input_ids=torch.tensor([1, 2, 3], dtype=torch.long),
+        engine_start_s=0.0,
+    )
+
+    result = result_adapter(data)
+
+    assert result.request_id == "req-a"
+    assert released == ["req-a"]
+
+
+def test_model_reset_request_releases_decode_state_row() -> None:
+    from sglang_omni.models.moss_tts.state_pool import MossDecodeStatePool
+
+    pool = MossDecodeStatePool(
+        max_batch_size=1,
+        hidden_size=3,
+        max_new_tokens=4,
+        num_channels=3,
+        device="cpu",
+        dtype=torch.float32,
+    )
+    model = SimpleNamespace(_decode_state_pool=pool)
+    model.reset_request = lambda request_id: model._decode_state_pool.release_row(
+        request_id
+    )
+    row = pool.acquire_row("req-a")
+    pool.write_feedback(row, torch.tensor([1.0, 2.0, 3.0]))
+    pool.delay_initialized[row] = True
+    pool.append_generated_row(row, torch.tensor([7, 8, 9]))
+    pool.mark_stop(row, kind=2, value=4)
+
+    model.reset_request("req-a")
+    reused = pool.acquire_row("req-b")
+
+    assert reused == row
+    assert torch.equal(pool.feedback_or_zero(reused), torch.zeros(3))
+    assert not pool.delay_initialized[reused].item()
+    assert pool.generated_history(reused).shape == (0, 3)
+    assert not pool.stop_pending[reused].item()
+
+
+def test_decode_input_embedding_reads_feedback_from_state_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang_sampler(monkeypatch)
+
+    from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+    from sglang_omni.models.moss_tts.state_pool import MossDecodeStatePool
+
+    pool = MossDecodeStatePool(
+        max_batch_size=2,
+        hidden_size=3,
+        max_new_tokens=4,
+        num_channels=5,
+        device="cpu",
+        dtype=torch.float32,
+    )
+    row_a = pool.acquire_row("req-a")
+    row_b = pool.acquire_row("req-b")
+    pool.write_feedback(row_a, torch.tensor([1.0, 2.0, 3.0]))
+    pool.write_feedback(row_b, torch.tensor([4.0, 5.0, 6.0]))
+
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    embedding = torch.nn.Embedding(4, 3)
+    runner.model = SimpleNamespace(
+        hidden_size=3,
+        _decode_input_embedding=embedding,
+        _decode_state_pool=pool,
+    )
+    forward_batch = SimpleNamespace(input_ids=torch.full((2,), 99, dtype=torch.long))
+    requests = [
+        SimpleNamespace(
+            request_id="req-a",
+            data=SimpleNamespace(pending_feedback_queue=[]),
+        ),
+        SimpleNamespace(
+            request_id="req-b",
+            data=SimpleNamespace(pending_feedback_queue=[]),
+        ),
+    ]
+
+    runner._write_decode_input_embedding(forward_batch, requests)
+
+    assert forward_batch.input_ids.tolist() == [0, 1]
+    assert torch.equal(embedding.weight[0].detach(), torch.tensor([1.0, 2.0, 3.0]))
+    assert torch.equal(embedding.weight[1].detach(), torch.tensor([4.0, 5.0, 6.0]))
+    assert requests[0].data.pending_feedback_queue == []
+    assert requests[1].data.pending_feedback_queue == []
+
+
+def test_decode_input_embedding_survives_batch_reorder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang_sampler(monkeypatch)
+
+    from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+    from sglang_omni.models.moss_tts.state_pool import MossDecodeStatePool
+
+    pool = MossDecodeStatePool(
+        max_batch_size=2,
+        hidden_size=3,
+        max_new_tokens=4,
+        num_channels=5,
+        device="cpu",
+        dtype=torch.float32,
+    )
+    row_a = pool.acquire_row("req-a")
+    row_b = pool.acquire_row("req-b")
+    pool.write_feedback(row_a, torch.tensor([1.0, 2.0, 3.0]))
+    pool.write_feedback(row_b, torch.tensor([4.0, 5.0, 6.0]))
+
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    embedding = torch.nn.Embedding(4, 3)
+    runner.model = SimpleNamespace(
+        hidden_size=3,
+        _decode_input_embedding=embedding,
+        _decode_state_pool=pool,
+    )
+    forward_batch = SimpleNamespace(input_ids=torch.full((2,), 99, dtype=torch.long))
+    requests = [
+        SimpleNamespace(request_id="req-b", data=SimpleNamespace()),
+        SimpleNamespace(request_id="req-a", data=SimpleNamespace()),
+    ]
+
+    runner._write_decode_input_embedding(forward_batch, requests)
+
+    assert torch.equal(embedding.weight[0].detach(), torch.tensor([4.0, 5.0, 6.0]))
+    assert torch.equal(embedding.weight[1].detach(), torch.tensor([1.0, 2.0, 3.0]))
+
+
+def test_collect_moss_step_writes_next_feedback_to_state_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang_sampler(monkeypatch)
+
+    from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+    from sglang_omni.models.moss_tts.state_pool import MossDecodeStatePool
+
+    pool = MossDecodeStatePool(
+        max_batch_size=1,
+        hidden_size=3,
+        max_new_tokens=4,
+        num_channels=3,
+        device="cpu",
+        dtype=torch.float32,
+    )
+    row = pool.acquire_row("req-a")
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    runner._pending_rows = None
+    runner._pending_embeds = None
+    runner.model = SimpleNamespace(
+        device=torch.device("cpu"),
+        hidden_size=3,
+        _decode_state_pool=pool,
+        _prepare_multi_modal_inputs=lambda rows: rows.to(torch.float32) + 0.5,
+    )
+    runner._channel_logits_from_result = lambda result, forward_batch: [
+        torch.empty(1, 1),
+        torch.empty(1, 1),
+    ]
+    runner._sample_rows = lambda channel_logits, datas, n_vq, **kwargs: torch.tensor(
+        [[7, 8, 9]], dtype=torch.long
+    )
+    result = SimpleNamespace(next_token_ids=None)
+    schedule_batch = SimpleNamespace(output_ids=None)
+    requests = [
+        SimpleNamespace(
+            request_id="req-a",
+            data=SimpleNamespace(pending_feedback_queue=[]),
+        )
+    ]
+
+    runner._collect_moss_step(result, object(), schedule_batch, requests)
+
+    assert torch.equal(pool.feedback_or_zero(row), torch.tensor([7.5, 8.5, 9.5]))
+    assert torch.equal(pool.generated_history(row), torch.tensor([[7, 8, 9]]))
+    assert torch.equal(result.next_token_ids, torch.tensor([7]))
+    assert torch.equal(schedule_batch.output_ids, torch.tensor([7]))
+    assert int(pool.sampling_steps[row].item()) == 1
+
+
+def test_collect_moss_step_does_not_write_feedback_for_im_end(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang_sampler(monkeypatch)
+
+    from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+    from sglang_omni.models.moss_tts.state_pool import MossDecodeStatePool
+
+    pool = MossDecodeStatePool(
+        max_batch_size=1,
+        hidden_size=3,
+        max_new_tokens=4,
+        num_channels=3,
+        device="cpu",
+        dtype=torch.float32,
+    )
+    row = pool.acquire_row("req-a")
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    runner._pending_rows = None
+    runner._pending_embeds = None
+    runner.model = SimpleNamespace(
+        config=SimpleNamespace(im_end_token_id=5),
+        device=torch.device("cpu"),
+        hidden_size=3,
+        _decode_state_pool=pool,
+        _prepare_multi_modal_inputs=lambda rows: rows.to(torch.float32) + 0.5,
+    )
+    runner._channel_logits_from_result = lambda result, forward_batch: [
+        torch.empty(1, 1),
+        torch.empty(1, 1),
+    ]
+    runner._sample_rows = lambda channel_logits, datas, n_vq, **kwargs: torch.tensor(
+        [[5, 8, 9]], dtype=torch.long
+    )
+    result = SimpleNamespace(next_token_ids=None)
+    schedule_batch = SimpleNamespace(output_ids=None)
+    requests = [
+        SimpleNamespace(
+            request_id="req-a",
+            data=SimpleNamespace(pending_feedback_queue=[]),
+        )
+    ]
+
+    runner._collect_moss_step(result, object(), schedule_batch, requests)
+
+    assert torch.equal(pool.feedback_or_zero(row), torch.zeros(3))
+    assert pool.generated_history(row).shape == (0, 3)
+    assert pool.stop_pending[row].item()
+    assert runner._pending_journals is not None
+    assert runner._pending_journals[0].emit_output_row is False
+
+
+def test_collect_moss_step_freezes_feedback_at_length_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang_sampler(monkeypatch)
+
+    from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+    from sglang_omni.models.moss_tts.state_pool import MossDecodeStatePool
+
+    pool = MossDecodeStatePool(
+        max_batch_size=1,
+        hidden_size=3,
+        max_new_tokens=4,
+        num_channels=3,
+        device="cpu",
+        dtype=torch.float32,
+    )
+    row = pool.acquire_row("req-a")
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    runner._pending_rows = None
+    runner._pending_embeds = None
+    runner.model = SimpleNamespace(
+        config=SimpleNamespace(im_end_token_id=5),
+        device=torch.device("cpu"),
+        hidden_size=3,
+        _decode_state_pool=pool,
+        _prepare_multi_modal_inputs=lambda rows: rows.to(torch.float32) + 0.5,
+    )
+    runner._channel_logits_from_result = lambda result, forward_batch: [
+        torch.empty(1, 1),
+        torch.empty(1, 1),
+    ]
+    runner._sample_rows = lambda channel_logits, datas, n_vq, **kwargs: torch.tensor(
+        [[7, 8, 9]], dtype=torch.long
+    )
+    result = SimpleNamespace(next_token_ids=None)
+    schedule_batch = SimpleNamespace(output_ids=None)
+    req = SimpleNamespace(
+        output_ids=[101],
+        sampling_params=SimpleNamespace(max_new_tokens=2),
+    )
+    data = SimpleNamespace(req=req, pending_feedback_queue=[])
+    requests = [SimpleNamespace(request_id="req-a", data=data)]
+
+    runner._collect_moss_step(result, object(), schedule_batch, requests)
+
+    assert torch.equal(pool.feedback_or_zero(row), torch.zeros(3))
+    assert torch.equal(pool.generated_history(row), torch.tensor([[7, 8, 9]]))
+    assert pool.stop_pending[row].item()
+    assert runner._pending_journals is not None
+    journal = runner._pending_journals[0]
+    assert journal.emit_output_row is True
+    assert journal.finish_kind == "length"
+    assert journal.finish_value == 2
+
+
+def test_sample_rows_uses_pool_sampling_steps_for_early_im_end_mask(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang_sampler(monkeypatch)
+
+    from sglang_omni.models.moss_tts.model_runner import (
+        _INT64_MAX,
+        MossTTSModelRunner,
+    )
+    from sglang_omni.models.moss_tts.state_pool import MossDecodeStatePool
+
+    cfg = SimpleNamespace(
+        pad_token_id=0,
+        audio_assistant_gen_slot_token_id=1,
+        audio_assistant_delay_slot_token_id=2,
+        audio_start_token_id=3,
+        audio_end_token_id=4,
+        im_end_token_id=5,
+        audio_pad_code=6,
+    )
+    pool = MossDecodeStatePool(
+        max_batch_size=1,
+        hidden_size=3,
+        max_new_tokens=4,
+        num_channels=2,
+        device="cpu",
+        dtype=torch.float32,
+    )
+    row = pool.acquire_row("req-a")
+    pool.delay_state[row] = torch.tensor([0, _INT64_MAX, 0], dtype=torch.long)
+    pool.sampling_steps[row] = 0
+
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    runner.model = SimpleNamespace(config=cfg, _decode_state_pool=pool)
+    data = SimpleNamespace(
+        generation_steps=99,
+        text_temperature=0.0,
+        text_top_p=1.0,
+        text_top_k=-1,
+        audio_temperature=0.0,
+        audio_top_p=1.0,
+        audio_top_k=-1,
+        audio_repetition_penalty=1.0,
+        sampling_seed=123,
+        prompt_rows=None,
+        output_rows=[],
+        delay_state=torch.tensor([0, _INT64_MAX, 0], dtype=torch.long),
+        audio_length=0,
+        delayed_length=_INT64_MAX,
+        is_audio=False,
+    )
+    text_logits = torch.zeros(1, 7)
+    text_logits[0, cfg.im_end_token_id] = 100.0
+    text_logits[0, cfg.audio_start_token_id] = 90.0
+    audio_logits = torch.zeros(1, 7)
+
+    rows = runner._sample_rows(
+        [text_logits, audio_logits],
+        [data],
+        n_vq=1,
+        pool_rows=torch.tensor([row], dtype=torch.long),
+    )
+
+    assert int(rows[0, 0].item()) == cfg.audio_start_token_id
+
+
+def test_sample_rows_initializes_pool_delay_state_from_request_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang_sampler(monkeypatch)
+
+    from sglang_omni.models.moss_tts.model_runner import (
+        _INT64_MAX,
+        MossTTSModelRunner,
+    )
+    from sglang_omni.models.moss_tts.state_pool import MossDecodeStatePool
+
+    cfg = SimpleNamespace(
+        pad_token_id=0,
+        audio_assistant_gen_slot_token_id=1,
+        audio_assistant_delay_slot_token_id=2,
+        audio_start_token_id=3,
+        audio_end_token_id=4,
+        im_end_token_id=5,
+        audio_pad_code=6,
+    )
+    pool = MossDecodeStatePool(
+        max_batch_size=1,
+        hidden_size=3,
+        max_new_tokens=4,
+        num_channels=2,
+        device="cpu",
+        dtype=torch.float32,
+    )
+    row = pool.acquire_row("req-a")
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    runner.model = SimpleNamespace(config=cfg, _decode_state_pool=pool)
+    data = SimpleNamespace(
+        generation_steps=0,
+        text_temperature=0.0,
+        text_top_p=1.0,
+        text_top_k=-1,
+        audio_temperature=0.0,
+        audio_top_p=1.0,
+        audio_top_k=-1,
+        audio_repetition_penalty=1.0,
+        sampling_seed=123,
+        prompt_rows=None,
+        output_rows=[],
+        delay_state=torch.tensor([0, _INT64_MAX, 0], dtype=torch.long),
+        audio_length=0,
+        delayed_length=_INT64_MAX,
+        is_audio=False,
+    )
+    text_logits = torch.zeros(1, 7)
+    text_logits[0, cfg.im_end_token_id] = 100.0
+    text_logits[0, cfg.audio_start_token_id] = 90.0
+    audio_logits = torch.zeros(1, 7)
+
+    rows = runner._sample_rows(
+        [text_logits, audio_logits],
+        [data],
+        n_vq=1,
+        pool_rows=torch.tensor([row], dtype=torch.long),
+    )
+
+    assert int(rows[0, 0].item()) == cfg.audio_start_token_id
+
+
+def test_repetition_penalty_reads_generated_history_from_state_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang_sampler(monkeypatch)
+
+    from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+    from sglang_omni.models.moss_tts.state_pool import MossDecodeStatePool
+
+    pool = MossDecodeStatePool(
+        max_batch_size=1,
+        hidden_size=3,
+        max_new_tokens=4,
+        num_channels=2,
+        device="cpu",
+        dtype=torch.float32,
+    )
+    row = pool.acquire_row("req-a")
+    pool.append_generated_row(row, torch.tensor([10, 2]))
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    runner.model = SimpleNamespace(_decode_state_pool=pool)
+    audio_logits = torch.zeros(1, 1, 8)
+    audio_logits[0, 0, 2] = 10.0
+    data = SimpleNamespace(
+        audio_repetition_penalty=2.0,
+        prompt_rows=None,
+        output_rows=[],
+    )
+
+    runner._apply_audio_repetition_penalty(
+        audio_logits,
+        [data],
+        n_vq=1,
+        pool_rows=torch.tensor([row], dtype=torch.long),
+    )
+
+    assert float(audio_logits[0, 0, 2].item()) == 5.0
+
+
+def test_post_process_outputs_applies_decode_journals_without_pending_embeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang_sampler(monkeypatch)
+
+    from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+    from sglang_omni.models.moss_tts.state_pool import MossDecodeJournal
+
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    runner.model = SimpleNamespace(config=SimpleNamespace(im_end_token_id=5))
+    runner._pending_rows = None
+    runner._pending_embeds = None
+    runner._pending_journals = [
+        MossDecodeJournal(
+            request_id="req-a",
+            row=0,
+            sampled_row=torch.tensor([7, 8, 9]),
+            next_token_id=7,
+            emit_output_row=True,
+        )
+    ]
+    data = SimpleNamespace(output_rows=[], pending_feedback_queue=[])
+    scheduler_output = SimpleNamespace(
+        requests=[SimpleNamespace(request_id="req-a", data=data)]
+    )
+    outputs = {"req-a": RequestOutput(request_id="req-a", data=7)}
+
+    runner.post_process_outputs(object(), scheduler_output, outputs)
+
+    assert len(data.output_rows) == 1
+    assert torch.equal(data.output_rows[0], torch.tensor([7, 8, 9]))
+    assert data.pending_feedback_queue == []
+    assert runner._pending_journals is None
+
+
+def test_post_process_outputs_applies_journals_by_request_id_after_reorder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    install_fake_sglang_sampler(monkeypatch)
+
+    from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+    from sglang_omni.models.moss_tts.state_pool import MossDecodeJournal
+
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    runner.model = SimpleNamespace(config=SimpleNamespace(im_end_token_id=5))
+    runner._pending_rows = None
+    runner._pending_embeds = None
+    runner._pending_journals = [
+        MossDecodeJournal(
+            request_id="req-a",
+            row=0,
+            sampled_row=torch.tensor([7, 8, 9]),
+            next_token_id=7,
+            emit_output_row=True,
+        ),
+        MossDecodeJournal(
+            request_id="req-b",
+            row=1,
+            sampled_row=torch.tensor([10, 11, 12]),
+            next_token_id=10,
+            emit_output_row=True,
+        ),
+    ]
+    data_a = SimpleNamespace(output_rows=[], pending_feedback_queue=[])
+    data_b = SimpleNamespace(output_rows=[], pending_feedback_queue=[])
+    scheduler_output = SimpleNamespace(
+        requests=[
+            SimpleNamespace(request_id="req-b", data=data_b),
+            SimpleNamespace(request_id="req-a", data=data_a),
+        ]
+    )
+    outputs = {
+        "req-a": RequestOutput(request_id="req-a", data=7),
+        "req-b": RequestOutput(request_id="req-b", data=10),
+    }
+
+    runner.post_process_outputs(object(), scheduler_output, outputs)
+
+    assert torch.equal(data_a.output_rows[0], torch.tensor([7, 8, 9]))
+    assert torch.equal(data_b.output_rows[0], torch.tensor([10, 11, 12]))


### PR DESCRIPTION
## Summary
- Add `MossDecodeStatePool` for stable per-request / row-indexed decode state.
- Store next-step feedback, delay state, sampling steps, generated history, and stop state in the pool.
- Make MOSS decode input read feedback from the pool when available.
- Write sampled feedback/history/step state back to the pool during collect.
- Add `MossDecodeJournal` so output-row append can be applied from journal state instead of runner-global `_pending_rows/_pending_embeds`.
- Release/reset pool rows from the result adapter.