### PR TITLE
[Model] Add MOSS-TTS-Local-Transformer-v1.5 support

### DIFF
--- a/examples/configs/moss_tts_local.yaml
+++ b/examples/configs/moss_tts_local.yaml
@@ -1,0 +1,3 @@
+config_cls: MossTTSLocalPipelineConfig
+model_path: OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5
+relay_backend: shm

--- a/sglang_omni/client/audio.py
+++ b/sglang_omni/client/audio.py
@@ -130,13 +130,21 @@ def apply_speed(
 
 
 def encode_wav(audio: np.ndarray, sample_rate: int) -> bytes:
-    """Encode audio as a WAV file (16-bit PCM)."""
+    """Encode audio as a WAV file (16-bit PCM).
+
+    Accepts rank-1 mono or rank-2 ``(channels, samples)`` input; multi-channel
+    samples are interleaved per the WAV spec.
+    """
     # Clamp to [-1, 1]
     audio = np.clip(audio, -1.0, 1.0)
     pcm = (audio * 32767.0).astype(np.int16)
-    pcm_bytes = pcm.tobytes()
+    if pcm.ndim == 2:
+        num_channels = int(pcm.shape[0])
+        pcm_bytes = np.ascontiguousarray(pcm.T).tobytes()
+    else:
+        num_channels = 1
+        pcm_bytes = pcm.tobytes()
 
-    num_channels = 1
     bits_per_sample = 16
     byte_rate = sample_rate * num_channels * bits_per_sample // 8
     block_align = num_channels * bits_per_sample // 8
@@ -234,9 +242,15 @@ def _encode_with_pyav(
 
 
 def encode_pcm(audio: np.ndarray, sample_rate: int) -> bytes:
-    """Encode audio as raw 16-bit PCM bytes."""
+    """Encode audio as raw 16-bit PCM bytes.
+
+    Rank-2 ``(channels, samples)`` input is interleaved sample-major.
+    """
     audio = np.clip(audio, -1.0, 1.0)
-    return (audio * 32767.0).astype(np.int16).tobytes()
+    pcm = (audio * 32767.0).astype(np.int16)
+    if pcm.ndim == 2:
+        pcm = np.ascontiguousarray(pcm.T)
+    return pcm.tobytes()
 
 
 def encode_audio(
@@ -263,16 +277,22 @@ def encode_audio(
     if arr.ndim > 1:
         arr = arr.squeeze()
     if arr.ndim > 1:
-        # Multi-channel: take first channel.
-        # Handle both (channels, samples) and (samples, channels).
-        if arr.shape[0] < arr.shape[-1]:
+        # Multi-channel: normalize to (channels, samples). WAV and PCM keep
+        # every channel (interleaved); the compressed mono encoders fall back
+        # to the first channel as before.
+        if arr.shape[0] > arr.shape[-1]:
+            arr = arr.T
+        if response_format.lower().strip() not in ("wav", "pcm"):
             arr = arr[0]
-        else:
-            arr = arr[:, 0]
 
     # Apply speed
     if speed != 1.0:
-        arr, sample_rate = apply_speed(arr, speed, sample_rate)
+        if arr.ndim > 1:
+            adjusted = [apply_speed(channel, speed, sample_rate) for channel in arr]
+            arr = np.stack([channel for channel, _ in adjusted])
+            sample_rate = adjusted[0][1]
+        else:
+            arr, sample_rate = apply_speed(arr, speed, sample_rate)
 
     fmt = response_format.lower().strip()
     mime = FORMAT_MIME_TYPES.get(fmt, "application/octet-stream")

--- a/sglang_omni/client/audio.py
+++ b/sglang_omni/client/audio.py
@@ -277,13 +277,13 @@ def encode_audio(
     if arr.ndim > 1:
         arr = arr.squeeze()
     if arr.ndim > 1:
-        # Multi-channel: normalize to (channels, samples). WAV and PCM keep
-        # every channel (interleaved); the compressed mono encoders fall back
-        # to the first channel as before.
+        # Multi-channel: normalize to (channels, samples). Only WAV carries
+        # channel metadata, so it keeps every channel; raw PCM and the
+        # compressed mono encoders downmix to preserve the mono contract.
         if arr.shape[0] > arr.shape[-1]:
             arr = arr.T
-        if response_format.lower().strip() not in ("wav", "pcm"):
-            arr = arr[0]
+        if response_format.lower().strip() != "wav":
+            arr = arr.mean(axis=0).astype(np.float32)
 
     # Apply speed
     if speed != 1.0:

--- a/sglang_omni/client/audio.py
+++ b/sglang_omni/client/audio.py
@@ -130,11 +130,7 @@ def apply_speed(
 
 
 def encode_wav(audio: np.ndarray, sample_rate: int) -> bytes:
-    """Encode audio as a WAV file (16-bit PCM).
-
-    Accepts rank-1 mono or rank-2 ``(channels, samples)`` input; multi-channel
-    samples are interleaved per the WAV spec.
-    """
+    """Encode audio as a WAV file (16-bit PCM)."""
     # Clamp to [-1, 1]
     audio = np.clip(audio, -1.0, 1.0)
     pcm = (audio * 32767.0).astype(np.int16)
@@ -242,10 +238,7 @@ def _encode_with_pyav(
 
 
 def encode_pcm(audio: np.ndarray, sample_rate: int) -> bytes:
-    """Encode audio as raw 16-bit PCM bytes.
-
-    Rank-2 ``(channels, samples)`` input is interleaved sample-major.
-    """
+    """Encode audio as raw 16-bit PCM bytes."""
     audio = np.clip(audio, -1.0, 1.0)
     pcm = (audio * 32767.0).astype(np.int16)
     if pcm.ndim == 2:
@@ -273,19 +266,14 @@ def encode_audio(
     """
     arr = to_numpy(audio)
 
-    # Flatten to 1D if needed
     if arr.ndim > 1:
         arr = arr.squeeze()
     if arr.ndim > 1:
-        # Multi-channel: normalize to (channels, samples). Only WAV carries
-        # channel metadata, so it keeps every channel; raw PCM and the
-        # compressed mono encoders downmix to preserve the mono contract.
         if arr.shape[0] > arr.shape[-1]:
             arr = arr.T
         if response_format.lower().strip() != "wav":
             arr = arr.mean(axis=0).astype(np.float32)
 
-    # Apply speed
     if speed != 1.0:
         if arr.ndim > 1:
             adjusted = [apply_speed(channel, speed, sample_rate) for channel in arr]
@@ -349,7 +337,6 @@ def encode_audio(
             )
             return encode_wav(arr, sample_rate), FORMAT_MIME_TYPES["wav"]
 
-    # Unknown format -> fall back to WAV
     logger.warning("Unknown audio format '%s'; falling back to WAV", fmt)
     return encode_wav(arr, sample_rate), FORMAT_MIME_TYPES["wav"]
 

--- a/sglang_omni/client/client.py
+++ b/sglang_omni/client/client.py
@@ -195,7 +195,10 @@ class Client:
         if len(audio_chunks) == 1:
             audio_data = audio_chunks[0]
         else:
-            audio_data = np.concatenate([to_numpy(c) for c in audio_chunks])
+            arrays = [to_numpy(c) for c in audio_chunks]
+            # Rank-2 chunks are [channels, samples]: concatenate on time.
+            axis = -1 if arrays[0].ndim > 1 else 0
+            audio_data = np.concatenate(arrays, axis=axis)
 
         encode_kwargs: dict[str, Any] = {
             "response_format": response_format,

--- a/sglang_omni/client/client.py
+++ b/sglang_omni/client/client.py
@@ -208,7 +208,6 @@ class Client:
             audio_data = audio_chunks[0]
         else:
             arrays = [to_numpy(c) for c in audio_chunks]
-            # Rank-2 chunks are [channels, samples]: concatenate on time.
             axis = -1 if arrays[0].ndim > 1 else 0
             audio_data = np.concatenate(arrays, axis=axis)
 

--- a/sglang_omni/client/client.py
+++ b/sglang_omni/client/client.py
@@ -10,6 +10,7 @@ from typing import Any, AsyncIterator, Callable
 import numpy as np
 
 from sglang_omni.client.audio import (
+    DEFAULT_SAMPLE_RATE,
     FORMAT_MIME_TYPES,
     audio_to_base64,
     encode_audio,
@@ -87,6 +88,7 @@ class Client:
         """
         text_parts: list[str] = []
         audio_chunks: list[Any] = []
+        sample_rate: int | None = None
         last_chunk: GenerateChunk | None = None
         finish_reason: str | None = None
 
@@ -96,6 +98,8 @@ class Client:
                 text_parts.append(chunk.text)
             if chunk.audio_data is not None:
                 audio_chunks.append(chunk.audio_data)
+            if chunk.sample_rate is not None:
+                sample_rate = chunk.sample_rate
             if chunk.finish_reason is not None:
                 finish_reason = chunk.finish_reason
 
@@ -109,8 +113,14 @@ class Client:
             if len(audio_chunks) == 1:
                 combined = audio_chunks[0]
             else:
-                combined = np.concatenate([to_numpy(c) for c in audio_chunks])
-            audio_b64 = audio_to_base64(combined, output_format=audio_format)
+                arrays = [to_numpy(c) for c in audio_chunks]
+                axis = -1 if arrays[0].ndim > 1 else 0
+                combined = np.concatenate(arrays, axis=axis)
+            audio_b64 = audio_to_base64(
+                combined,
+                sample_rate=sample_rate or DEFAULT_SAMPLE_RATE,
+                output_format=audio_format,
+            )
             audio = CompletionAudio(
                 id=f"audio-{request_id}",
                 data=audio_b64,
@@ -145,7 +155,9 @@ class Client:
             audio_b64: str | None = None
             if chunk.modality == "audio" and chunk.audio_data is not None:
                 audio_b64 = audio_to_base64(
-                    chunk.audio_data, output_format=audio_format
+                    chunk.audio_data,
+                    sample_rate=chunk.sample_rate or DEFAULT_SAMPLE_RATE,
+                    output_format=audio_format,
                 )
 
             yield CompletionStreamChunk(

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -28,6 +28,7 @@ _ARCH_CONFIG_MAP: dict[str, tuple[str, str | None]] = {
     "Qwen3ASRForConditionalGeneration": ("thinker_config", "text_config"),
     "Qwen3TTSTalker": ("talker_config", None),
     "MossTTSDelaySGLangModel": ("language_config", None),
+    "MossTTSLocalSGLangModel": ("language_config", None),
 }
 
 

--- a/sglang_omni/model_runner/sglang_model_runner.py
+++ b/sglang_omni/model_runner/sglang_model_runner.py
@@ -91,6 +91,7 @@ class SGLModelRunner(ModelRunner):
             "HiggsMultimodalQwen3ForConditionalGeneration": "sglang_omni.models.higgs_tts.model:HiggsTTSModel",
             "Qwen3TTSTalker": "sglang_omni.models.qwen3_tts.sglang_model:Qwen3TTSTalker",
             "MossTTSDelaySGLangModel": "sglang_omni.models.moss_tts.sglang_model:MossTTSDelaySGLangModel",
+            "MossTTSLocalSGLangModel": "sglang_omni.models.moss_tts_local.sglang_model:MossTTSLocalSGLangModel",
             "VoxtralSGLangTTSModel": "sglang_omni.models.voxtral_tts.sglang_model:VoxtralSGLangTTSModel",
             "LLaDA2MoeModelLM": "sglang_omni.models.llada2_uni.components.thinker:LLaDA2MoeModelLM",
             "WhisperForConditionalGeneration": "sglang_omni.models.whisper_asr.sglang_model:WhisperForConditionalGeneration",

--- a/sglang_omni/models/moss_tts_local/__init__.py
+++ b/sglang_omni/models/moss_tts_local/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MOSS-TTS Local (v1.5) pipeline package."""

--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pipeline configuration for MOSS-TTS Local (v1.5)."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from sglang_omni.config import PipelineConfig, StageConfig
+
+_PKG = "sglang_omni.models.moss_tts_local"
+
+
+class MossTTSLocalPipelineConfig(PipelineConfig):
+    """MOSS-TTS Local pipeline: preprocessing -> AR engine -> vocoder.
+
+    Resolves OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5, whose checkpoint
+    declares ``architectures: ["MossTTSLocalModel"]``, so serving by model id
+    works without an explicit config file. The AR engine runs on GPU 0; the
+    48 kHz stereo v2 codec (reference encode + vocoder) auto-places on the
+    second visible GPU when one exists — its ~1B-param encoder otherwise
+    competes with the AR decode loop — and falls back to GPU 0 on
+    single-GPU hosts.
+    """
+
+    architecture: ClassVar[str] = "MossTTSLocalModel"
+    architecture_aliases: ClassVar[tuple[str, ...]] = (
+        "MossTTSLocal",
+        "MossTTSLocalForConditionalGeneration",
+    )
+
+    @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"talker": "tts_engine"}
+
+    @classmethod
+    def talker_sglang_role_to_stage(cls) -> dict[str, str]:
+        return {"talker": "tts_engine"}
+
+    model_path: str
+    stages: list[StageConfig] = [
+        StageConfig(
+            name="preprocessing",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_preprocessing_executor",
+            gpu=0,
+            next="tts_engine",
+        ),
+        StageConfig(
+            name="tts_engine",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_sglang_tts_engine_executor",
+            factory_args={"gpu_id": 0, "dtype": "bfloat16"},
+            gpu=0,
+            next="vocoder",
+        ),
+        StageConfig(
+            name="vocoder",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_vocoder_executor",
+            gpu=0,
+            terminal=True,
+        ),
+    ]
+
+
+EntryClass = MossTTSLocalPipelineConfig

--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -42,18 +42,7 @@ def _stages(*, codec_device: str) -> list[StageConfig]:
 
 
 class MossTTSLocalPipelineConfig(PipelineConfig):
-    """MOSS-TTS Local pipeline: preprocessing -> AR engine -> vocoder.
-
-    Resolves OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5, whose checkpoint
-    declares ``architectures: ["MossTTSLocalModel"]``, so serving by model id
-    works without an explicit config file. The AR engine runs on GPU 0; the
-    48 kHz stereo v2 codec (reference encode + vocoder) is explicitly placed
-    on GPU 1 because its ~1B-param encoder otherwise competes with the AR
-    decode loop. The three stages stay in one process because preprocessing
-    hands scheduler-owned prompt state to the AR request builder through an
-    in-process table. Use ``MossTTSLocalColocatedPipelineConfig`` for single-GPU
-    deployments.
-    """
+    """MOSS-TTS Local pipeline: preprocessing -> AR engine -> vocoder."""
 
     architecture: ClassVar[str] = "MossTTSLocalModel"
     architecture_aliases: ClassVar[tuple[str, ...]] = (

--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -5,9 +5,40 @@ from __future__ import annotations
 
 from typing import ClassVar
 
+from pydantic import Field
+
 from sglang_omni.config import PipelineConfig, StageConfig
 
 _PKG = "sglang_omni.models.moss_tts_local"
+
+
+def _stages(*, codec_device: str) -> list[StageConfig]:
+    return [
+        StageConfig(
+            name="preprocessing",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_preprocessing_executor",
+            factory_args={"device": codec_device},
+            gpu=0,
+            next="tts_engine",
+        ),
+        StageConfig(
+            name="tts_engine",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_sglang_tts_engine_executor",
+            factory_args={"gpu_id": 0, "dtype": "bfloat16"},
+            gpu=0,
+            next="vocoder",
+        ),
+        StageConfig(
+            name="vocoder",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_vocoder_executor",
+            factory_args={"device": codec_device},
+            gpu=0,
+            terminal=True,
+        ),
+    ]
 
 
 class MossTTSLocalPipelineConfig(PipelineConfig):
@@ -16,10 +47,12 @@ class MossTTSLocalPipelineConfig(PipelineConfig):
     Resolves OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5, whose checkpoint
     declares ``architectures: ["MossTTSLocalModel"]``, so serving by model id
     works without an explicit config file. The AR engine runs on GPU 0; the
-    48 kHz stereo v2 codec (reference encode + vocoder) auto-places on the
-    second visible GPU when one exists — its ~1B-param encoder otherwise
-    competes with the AR decode loop — and falls back to GPU 0 on
-    single-GPU hosts.
+    48 kHz stereo v2 codec (reference encode + vocoder) is explicitly placed
+    on GPU 1 because its ~1B-param encoder otherwise competes with the AR
+    decode loop. The three stages stay in one process because preprocessing
+    hands scheduler-owned prompt state to the AR request builder through an
+    in-process table. Use ``MossTTSLocalColocatedPipelineConfig`` for single-GPU
+    deployments.
     """
 
     architecture: ClassVar[str] = "MossTTSLocalModel"
@@ -37,30 +70,22 @@ class MossTTSLocalPipelineConfig(PipelineConfig):
         return {"talker": "tts_engine"}
 
     model_path: str
-    stages: list[StageConfig] = [
-        StageConfig(
-            name="preprocessing",
-            process="pipeline",
-            factory=f"{_PKG}.stages.create_preprocessing_executor",
-            gpu=0,
-            next="tts_engine",
-        ),
-        StageConfig(
-            name="tts_engine",
-            process="pipeline",
-            factory=f"{_PKG}.stages.create_sglang_tts_engine_executor",
-            factory_args={"gpu_id": 0, "dtype": "bfloat16"},
-            gpu=0,
-            next="vocoder",
-        ),
-        StageConfig(
-            name="vocoder",
-            process="pipeline",
-            factory=f"{_PKG}.stages.create_vocoder_executor",
-            gpu=0,
-            terminal=True,
-        ),
-    ]
+    stages: list[StageConfig] = Field(
+        default_factory=lambda: _stages(codec_device="cuda:1")
+    )
+
+
+class MossTTSLocalColocatedPipelineConfig(MossTTSLocalPipelineConfig):
+    """Single-GPU variant that colocates the codec with the AR engine."""
+
+    stages: list[StageConfig] = Field(
+        default_factory=lambda: _stages(codec_device="cuda:0")
+    )
 
 
 EntryClass = MossTTSLocalPipelineConfig
+
+Variants = {
+    "default": MossTTSLocalPipelineConfig,
+    "colocated": MossTTSLocalColocatedPipelineConfig,
+}

--- a/sglang_omni/models/moss_tts_local/local_transformer.py
+++ b/sglang_omni/models/moss_tts_local/local_transformer.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native batched port of the MOSS-TTS-Local frame-local transformer.
+
+The upstream checkpoint (``gpt2_decoder.MossTTSNanoGPT2Model``) is a 1-layer
+GPT-2-style block (pre-LN, fused-QKV ``nn.Linear``, silu MLP) with
+interleaved-pair RoPE. Per audio frame it consumes the global backbone's last
+hidden state at local position 0 and then one sampled-code embedding per RVQ
+channel, attending over at most ``n_vq + 1`` positions through a static KV
+cache. This port keeps that math but runs every micro-step batched over the
+whole decode batch with persistent per-layer KV buffers, so the runner can
+drive one frame for all running requests with ``n_vq`` sequential steps.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def sample_seeded_branchless(
+    logits: torch.Tensor,
+    *,
+    temperature: torch.Tensor,
+    top_p: torch.Tensor,
+    top_k: torch.Tensor,
+    seeds: torch.Tensor,
+    positions: torch.Tensor,
+) -> torch.Tensor:
+    """Seeded temperature/top-k/top-p sampling without host control flow.
+
+    Mirrors ``MossTTSModelRunner._sample_tokens`` numerics but is free of
+    ``.item()``/data-dependent branches so it can run under CUDA graph
+    capture. ``logits`` is fp32 ``[rows, vocab]``.
+    """
+    from sglang.srt.layers.sampler import multinomial_with_seed
+
+    vocab = logits.shape[-1]
+    do_sample = temperature > 0
+    safe_temp = torch.where(do_sample, temperature, torch.ones_like(temperature))
+    scores = logits / safe_temp.unsqueeze(1)
+
+    # Top-k: always rank the full vocab, then read each row's own k-th value
+    # as its threshold (inactive rows get -inf thresholds).
+    k_active = (top_k > 0) & (top_k < vocab)
+    k_clamped = top_k.clamp(min=1, max=vocab)
+    sorted_scores, sorted_indices = torch.sort(scores, descending=True, dim=-1)
+    kth = sorted_scores.gather(1, (k_clamped - 1).unsqueeze(1))
+    threshold = torch.where(
+        k_active.unsqueeze(1), kth, torch.full_like(kth, float("-inf"))
+    )
+    scores = scores.masked_fill(scores < threshold, float("-inf"))
+
+    # Top-p over the same descending order (re-softmax after the top-k mask).
+    p_active = (top_p > 0.0) & (top_p < 1.0)
+    sorted_masked = sorted_scores.masked_fill(sorted_scores < threshold, float("-inf"))
+    probs_sorted = torch.softmax(sorted_masked, dim=-1)
+    cumulative = torch.cumsum(probs_sorted, dim=-1)
+    remove = cumulative > top_p.unsqueeze(1)
+    remove[..., 1:] = remove[..., :-1].clone()
+    remove[..., 0] = False
+    remove = remove & p_active.unsqueeze(1)
+    remove_scattered = torch.zeros_like(scores, dtype=torch.bool).scatter_(
+        -1, sorted_indices, remove
+    )
+    scores = scores.masked_fill(remove_scattered, float("-inf"))
+
+    probs = torch.softmax(scores, dim=-1)
+    probs = torch.nan_to_num(probs, nan=0.0, posinf=0.0, neginf=0.0)
+    sampled = multinomial_with_seed(probs, seeds, positions).view(-1)
+    fallback = (~do_sample) | (probs.sum(dim=-1) <= 0)
+    return torch.where(fallback, torch.argmax(logits, dim=-1), sampled)
+
+
+def _rotate_half_interleaved(x: torch.Tensor) -> torch.Tensor:
+    """Interleaved-pair rotation: [x0, x1, x2, x3, ...] -> [-x1, x0, -x3, x2, ...].
+
+    Matches the upstream ``gpt2_decoder.rotate_half`` (GPT-J style), which is
+    NOT the half-split rotation used by the Qwen3 backbone.
+    """
+    even = x[..., ::2]
+    odd = x[..., 1::2]
+    return torch.stack((-odd, even), dim=-1).reshape_as(x)
+
+
+class MossTTSLocalMLP(nn.Module):
+    def __init__(self, hidden_size: int, inner_size: int) -> None:
+        super().__init__()
+        self.fc_in = nn.Linear(hidden_size, inner_size)
+        self.fc_out = nn.Linear(inner_size, hidden_size)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.fc_out(F.silu(self.fc_in(hidden_states)))
+
+
+class MossTTSLocalAttention(nn.Module):
+    def __init__(self, hidden_size: int, num_heads: int) -> None:
+        super().__init__()
+        if hidden_size % num_heads != 0:
+            raise ValueError(
+                f"hidden_size={hidden_size} not divisible by num_heads={num_heads}"
+            )
+        self.num_heads = num_heads
+        self.head_dim = hidden_size // num_heads
+        self.c_attn = nn.Linear(hidden_size, 3 * hidden_size)
+        self.c_proj = nn.Linear(hidden_size, hidden_size)
+
+
+class MossTTSLocalBlock(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        inner_size: int,
+        layer_norm_eps: float,
+    ) -> None:
+        super().__init__()
+        self.ln_1 = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
+        self.attn = MossTTSLocalAttention(hidden_size, num_heads)
+        self.ln_2 = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
+        self.mlp = MossTTSLocalMLP(hidden_size, inner_size)
+
+
+class MossTTSLocalTransformer(nn.Module):
+    """Batched incremental decoder over <= ``max_positions`` local positions.
+
+    Submodule names (``h.{i}.ln_1 / attn.c_attn / attn.c_proj / ln_2 /
+    mlp.fc_in / mlp.fc_out`` and ``ln_f``) mirror the checkpoint layout under
+    the ``local_transformer.`` prefix so weights load without remapping.
+    """
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int,
+        num_heads: int,
+        inner_size: int,
+        num_layers: int,
+        max_positions: int,
+        rope_base: float,
+        layer_norm_eps: float = 1e-6,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = int(hidden_size)
+        self.num_heads = int(num_heads)
+        self.head_dim = self.hidden_size // self.num_heads
+        self.max_positions = int(max_positions)
+        self.h = nn.ModuleList(
+            [
+                MossTTSLocalBlock(hidden_size, num_heads, inner_size, layer_norm_eps)
+                for _ in range(int(num_layers))
+            ]
+        )
+        self.ln_f = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
+
+        # Upstream computes inv_freq in fp32 and casts cos/sin to the
+        # activation dtype per call; precompute the fp32 tables once.
+        inv_freq = 1.0 / (
+            float(rope_base)
+            ** (torch.arange(0, self.head_dim, 2, dtype=torch.float32) / self.head_dim)
+        )
+        positions = torch.arange(self.max_positions, dtype=torch.float32)
+        freqs = torch.outer(positions, inv_freq)
+        self.register_buffer(
+            "rope_cos", freqs.cos().repeat_interleave(2, dim=-1), persistent=False
+        )
+        self.register_buffer(
+            "rope_sin", freqs.sin().repeat_interleave(2, dim=-1), persistent=False
+        )
+
+        self._kv_cache: list[tuple[torch.Tensor, torch.Tensor]] = []
+        self._kv_capacity = 0
+
+    def _ensure_kv_cache(
+        self, batch_size: int, device: torch.device, dtype: torch.dtype
+    ) -> None:
+        if (
+            self._kv_capacity >= batch_size
+            and self._kv_cache
+            and self._kv_cache[0][0].device == device
+            and self._kv_cache[0][0].dtype == dtype
+        ):
+            return
+        capacity = max(batch_size, self._kv_capacity, 1)
+        shape = (capacity, self.num_heads, self.max_positions, self.head_dim)
+        self._kv_cache = [
+            (
+                torch.empty(shape, device=device, dtype=dtype),
+                torch.empty(shape, device=device, dtype=dtype),
+            )
+            for _ in self.h
+        ]
+        self._kv_capacity = capacity
+
+    def step(self, hidden_states: torch.Tensor, position: int) -> torch.Tensor:
+        """One micro-step for the whole batch.
+
+        Args:
+            hidden_states: ``[batch, hidden]`` input embedding for this local
+                position (the global hidden state at position 0, then one
+                sampled-code embedding per subsequent position).
+            position: local position index in ``[0, max_positions)``. Position
+                ``p`` attends over cached positions ``0..p``. Callers step
+                positions ``0, 1, 2, ...`` in order each frame; restarting at
+                0 implicitly resets the frame's cache window.
+
+        Returns:
+            ``[batch, hidden]`` final-norm hidden state for sampling.
+        """
+        if not 0 <= position < self.max_positions:
+            raise ValueError(
+                f"local position {position} out of range [0, {self.max_positions})"
+            )
+        batch_size = hidden_states.shape[0]
+        self._ensure_kv_cache(batch_size, hidden_states.device, hidden_states.dtype)
+        cos = self.rope_cos[position].to(dtype=hidden_states.dtype)
+        sin = self.rope_sin[position].to(dtype=hidden_states.dtype)
+
+        x = hidden_states
+        for layer_idx, block in enumerate(self.h):
+            normed = block.ln_1(x)
+            qkv = block.attn.c_attn(normed)
+            query, key, value = qkv.split(self.hidden_size, dim=-1)
+            query = query.view(batch_size, self.num_heads, self.head_dim)
+            key = key.view(batch_size, self.num_heads, self.head_dim)
+            value = value.view(batch_size, self.num_heads, self.head_dim)
+            query = query * cos + _rotate_half_interleaved(query) * sin
+            key = key * cos + _rotate_half_interleaved(key) * sin
+
+            key_cache, value_cache = self._kv_cache[layer_idx]
+            key_cache[:batch_size, :, position] = key
+            value_cache[:batch_size, :, position] = value
+
+            attn_out = F.scaled_dot_product_attention(
+                query.unsqueeze(2),
+                key_cache[:batch_size, :, : position + 1],
+                value_cache[:batch_size, :, : position + 1],
+            )
+            attn_out = attn_out.squeeze(2).reshape(batch_size, self.hidden_size)
+            x = x + block.attn.c_proj(attn_out)
+            x = x + block.mlp(block.ln_2(x))
+        return self.ln_f(x)

--- a/sglang_omni/models/moss_tts_local/local_transformer.py
+++ b/sglang_omni/models/moss_tts_local/local_transformer.py
@@ -170,6 +170,13 @@ class MossTTSLocalTransformer(nn.Module):
 
         self._kv_cache: list[tuple[torch.Tensor, torch.Tensor]] = []
         self._kv_capacity = 0
+        self._kv_frozen = False
+
+    def freeze_kv_cache(self) -> None:
+        """Forbid KV reallocation; captured CUDA graphs hold raw pointers
+        into the current buffers, so growing them would leave the graphs
+        reading freed memory."""
+        self._kv_frozen = True
 
     def _ensure_kv_cache(
         self, batch_size: int, device: torch.device, dtype: torch.dtype
@@ -181,6 +188,11 @@ class MossTTSLocalTransformer(nn.Module):
             and self._kv_cache[0][0].dtype == dtype
         ):
             return
+        if self._kv_frozen:
+            raise RuntimeError(
+                "local-transformer KV cache is frozen after CUDA graph capture "
+                f"(capacity {self._kv_capacity}, requested {batch_size})"
+            )
         capacity = max(batch_size, self._kv_capacity, 1)
         shape = (capacity, self.num_heads, self.max_positions, self.head_dim)
         self._kv_cache = [

--- a/sglang_omni/models/moss_tts_local/local_transformer.py
+++ b/sglang_omni/models/moss_tts_local/local_transformer.py
@@ -1,15 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Native batched port of the MOSS-TTS-Local frame-local transformer.
-
-The upstream checkpoint (``gpt2_decoder.MossTTSNanoGPT2Model``) is a 1-layer
-GPT-2-style block (pre-LN, fused-QKV ``nn.Linear``, silu MLP) with
-interleaved-pair RoPE. Per audio frame it consumes the global backbone's last
-hidden state at local position 0 and then one sampled-code embedding per RVQ
-channel, attending over at most ``n_vq + 1`` positions through a static KV
-cache. This port keeps that math but runs every micro-step batched over the
-whole decode batch with persistent per-layer KV buffers, so the runner can
-drive one frame for all running requests with ``n_vq`` sequential steps.
-"""
+"""Native batched port of the MOSS-TTS-Local frame-local transformer."""
 
 from __future__ import annotations
 
@@ -27,12 +17,7 @@ def sample_seeded_branchless(
     seeds: torch.Tensor,
     positions: torch.Tensor,
 ) -> torch.Tensor:
-    """Seeded temperature/top-k/top-p sampling without host control flow.
-
-    Mirrors ``MossTTSModelRunner._sample_tokens`` numerics but is free of
-    ``.item()``/data-dependent branches so it can run under CUDA graph
-    capture. ``logits`` is fp32 ``[rows, vocab]``.
-    """
+    """Seeded temperature/top-k/top-p sampling without host control flow."""
     from sglang.srt.layers.sampler import multinomial_with_seed
 
     vocab = logits.shape[-1]
@@ -40,8 +25,6 @@ def sample_seeded_branchless(
     safe_temp = torch.where(do_sample, temperature, torch.ones_like(temperature))
     scores = logits / safe_temp.unsqueeze(1)
 
-    # Top-k: always rank the full vocab, then read each row's own k-th value
-    # as its threshold (inactive rows get -inf thresholds).
     k_active = (top_k > 0) & (top_k < vocab)
     k_clamped = top_k.clamp(min=1, max=vocab)
     sorted_scores, sorted_indices = torch.sort(scores, descending=True, dim=-1)
@@ -51,7 +34,6 @@ def sample_seeded_branchless(
     )
     scores = scores.masked_fill(scores < threshold, float("-inf"))
 
-    # Top-p over the same descending order (re-softmax after the top-k mask).
     p_active = (top_p > 0.0) & (top_p < 1.0)
     sorted_masked = sorted_scores.masked_fill(sorted_scores < threshold, float("-inf"))
     probs_sorted = torch.softmax(sorted_masked, dim=-1)
@@ -73,11 +55,7 @@ def sample_seeded_branchless(
 
 
 def _rotate_half_interleaved(x: torch.Tensor) -> torch.Tensor:
-    """Interleaved-pair rotation: [x0, x1, x2, x3, ...] -> [-x1, x0, -x3, x2, ...].
-
-    Matches the upstream ``gpt2_decoder.rotate_half`` (GPT-J style), which is
-    NOT the half-split rotation used by the Qwen3 backbone.
-    """
+    """Interleaved-pair rotation: [x0, x1, x2, x3, ...] -> [-x1, x0, -x3, x2, ...]."""
     even = x[..., ::2]
     odd = x[..., 1::2]
     return torch.stack((-odd, even), dim=-1).reshape_as(x)
@@ -153,8 +131,6 @@ class MossTTSLocalTransformer(nn.Module):
         )
         self.ln_f = nn.LayerNorm(hidden_size, eps=layer_norm_eps)
 
-        # Upstream computes inv_freq in fp32 and casts cos/sin to the
-        # activation dtype per call; precompute the fp32 tables once.
         inv_freq = 1.0 / (
             float(rope_base)
             ** (torch.arange(0, self.head_dim, 2, dtype=torch.float32) / self.head_dim)
@@ -205,20 +181,7 @@ class MossTTSLocalTransformer(nn.Module):
         self._kv_capacity = capacity
 
     def step(self, hidden_states: torch.Tensor, position: int) -> torch.Tensor:
-        """One micro-step for the whole batch.
-
-        Args:
-            hidden_states: ``[batch, hidden]`` input embedding for this local
-                position (the global hidden state at position 0, then one
-                sampled-code embedding per subsequent position).
-            position: local position index in ``[0, max_positions)``. Position
-                ``p`` attends over cached positions ``0..p``. Callers step
-                positions ``0, 1, 2, ...`` in order each frame; restarting at
-                0 implicitly resets the frame's cache window.
-
-        Returns:
-            ``[batch, hidden]`` final-norm hidden state for sampling.
-        """
+        """One micro-step for the whole batch."""
         if not 0 <= position < self.max_positions:
             raise ValueError(
                 f"local position {position} out of range [0, {self.max_positions})"

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -154,7 +154,9 @@ class MossTTSLocalModelRunner(ModelRunner):
             return
         hidden_states = getattr(result.logits_output, "hidden_states", None)
         if not isinstance(hidden_states, torch.Tensor):
-            raise RuntimeError("MOSS-TTS Local model output did not include hidden states")
+            raise RuntimeError(
+                "MOSS-TTS Local model output did not include hidden states"
+            )
         if hidden_states.ndim == 3:
             hidden_states = hidden_states[:, -1, :]
 
@@ -219,9 +221,8 @@ class MossTTSLocalModelRunner(ModelRunner):
                 positions=gen_steps * num_channels + channel + 1,
             )
 
-        use_graph = (
-            rep_histories is None
-            and batch_size <= getattr(self.model, "frame_graph_max_bs", 0)
+        use_graph = rep_histories is None and batch_size <= getattr(
+            self.model, "frame_graph_max_bs", 0
         )
         if use_graph:
             stop_choice, codes = self.model.decode_frame_graphed(
@@ -250,9 +251,7 @@ class MossTTSLocalModelRunner(ModelRunner):
             torch.full((batch_size,), end_id, dtype=torch.long, device=device),
         )
 
-        rows = torch.empty(
-            (batch_size, num_channels), dtype=torch.long, device=device
-        )
+        rows = torch.empty((batch_size, num_channels), dtype=torch.long, device=device)
         rows[:, 0] = next_text
         rows[:, 1:] = codes
 

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -1,0 +1,335 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MOSS-TTS Local (v1.5) model runner for OmniScheduler."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+from sglang_omni.scheduling.types import RequestOutput
+
+
+class MossTTSLocalModelRunner(ModelRunner):
+    """Drives the per-frame local-transformer decode and feedback embeddings.
+
+    Per step: the backbone (radix-cached, CUDA-graphed) produces one hidden
+    state per request; :meth:`_collect_frame` then runs the batched local
+    micro-decode — a binary continue/stop decision and 12 sequentially
+    sampled RVQ codes — and stages the next frame's summed embedding through
+    ``model._decode_input_embedding`` so the next decode step stays
+    CUDA-graph-replayable (decode input_ids are row indices).
+    """
+
+    def __init__(self, tp_worker: Any, output_processor: Any):
+        super().__init__(tp_worker, output_processor)
+        self._pending_rows: torch.Tensor | None = None
+        self._pending_embeds: torch.Tensor | None = None
+
+    def custom_prefill_forward(
+        self,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list,
+    ) -> None:
+        del schedule_batch
+        forward_batch.input_embeds = self._build_prefill_input_embeds(
+            forward_batch, requests
+        )
+        return None
+
+    def before_decode(
+        self,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list,
+        *,
+        is_lookahead: bool = False,
+    ) -> None:
+        del is_lookahead
+        del schedule_batch
+        self._write_decode_input_embedding(forward_batch, requests)
+
+    def post_prefill(
+        self,
+        result: Any,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list,
+    ) -> None:
+        if bool(getattr(schedule_batch, "is_prefill_only", False)):
+            return
+        self._collect_frame(result, forward_batch, schedule_batch, requests)
+
+    def post_decode(
+        self,
+        result: Any,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list,
+    ) -> None:
+        self._collect_frame(result, forward_batch, schedule_batch, requests)
+
+    def _build_prefill_input_embeds(
+        self,
+        forward_batch: Any,
+        requests: list,
+    ) -> torch.Tensor:
+        pieces = []
+        for sched_req in requests:
+            data = sched_req.data
+            req = data.req
+            rows = data.prompt_rows
+            if rows is None:
+                raise RuntimeError("MOSS-TTS Local prefill requires prompt_rows")
+            req_len = int(req.extend_input_len)
+            prefix_len = len(req.prefix_indices)
+            current_rows = rows[prefix_len : prefix_len + req_len]
+            embeds = self.model._prepare_multi_modal_inputs(
+                current_rows.to(device=forward_batch.input_ids.device)
+            )
+            pieces.append(embeds)
+        if not pieces:
+            return torch.empty(
+                (0, self.model.hidden_size),
+                device=forward_batch.input_ids.device,
+                dtype=self.model.dtype,
+            )
+        return torch.cat(pieces, dim=0).to(
+            device=forward_batch.input_ids.device,
+            dtype=self.model.dtype,
+        )
+
+    def _write_decode_input_embedding(
+        self,
+        forward_batch: Any,
+        requests: list,
+    ) -> None:
+        batch_size = len(requests)
+        if batch_size == 0:
+            return
+        embedding = self.model._decode_input_embedding
+        weight = embedding.weight
+        if forward_batch.input_ids.numel() < batch_size:
+            raise RuntimeError(
+                "MOSS-TTS Local decode input_ids must contain one row id per request"
+            )
+        if batch_size > int(weight.shape[0]):
+            raise RuntimeError(
+                "MOSS-TTS Local decode batch exceeds the staged decode-embedding "
+                f"rows ({batch_size} > {int(weight.shape[0])})"
+            )
+        rows = []
+        for sched_req in requests:
+            queue = sched_req.data.pending_feedback_queue
+            if not queue:
+                rows.append(torch.zeros(self.model.hidden_size, device=weight.device))
+                continue
+            if hasattr(queue, "popleft"):
+                rows.append(queue.popleft())
+            else:
+                rows.append(queue.pop(0))
+        stacked = torch.stack(rows, dim=0).to(device=weight.device, dtype=weight.dtype)
+        with torch.no_grad():
+            weight[:batch_size].copy_(stacked)
+
+        row_ids = torch.arange(
+            batch_size,
+            dtype=torch.long,
+            device=forward_batch.input_ids.device,
+        )
+        forward_batch.input_ids[:batch_size].copy_(row_ids)
+
+    def _collect_frame(
+        self,
+        result: Any,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list,
+    ) -> None:
+        del forward_batch
+        if not requests:
+            return
+        hidden_states = getattr(result.logits_output, "hidden_states", None)
+        if not isinstance(hidden_states, torch.Tensor):
+            raise RuntimeError("MOSS-TTS Local model output did not include hidden states")
+        if hidden_states.ndim == 3:
+            hidden_states = hidden_states[:, -1, :]
+
+        cfg = self.model.config
+        device = hidden_states.device
+        datas = [sched_req.data for sched_req in requests]
+        batch_size = len(datas)
+        num_channels = int(cfg.n_vq) + 1
+
+        text_temp = torch.tensor(
+            [float(d.text_temperature) for d in datas],
+            dtype=torch.float32,
+            device=device,
+        )
+        text_top_p = torch.tensor(
+            [float(d.text_top_p) for d in datas], dtype=torch.float32, device=device
+        )
+        text_top_k = torch.tensor(
+            [int(d.text_top_k) for d in datas], dtype=torch.long, device=device
+        )
+        audio_temp = torch.tensor(
+            [float(d.audio_temperature) for d in datas],
+            dtype=torch.float32,
+            device=device,
+        )
+        audio_top_p = torch.tensor(
+            [float(d.audio_top_p) for d in datas], dtype=torch.float32, device=device
+        )
+        audio_top_k = torch.tensor(
+            [int(d.audio_top_k) for d in datas], dtype=torch.long, device=device
+        )
+        sampling_seeds = torch.tensor(
+            [int(d.sampling_seed) for d in datas], dtype=torch.long, device=device
+        )
+        gen_steps = torch.tensor(
+            [int(d.generation_steps) for d in datas], dtype=torch.long, device=device
+        )
+        rep_penalties = [float(d.audio_repetition_penalty) for d in datas]
+        rep_histories = self._gather_rep_histories(datas, rep_penalties, device)
+
+        def sample_text(logits: torch.Tensor) -> torch.Tensor:
+            return MossTTSModelRunner._sample_tokens(
+                logits,
+                temperature=text_temp,
+                top_p=text_top_p,
+                top_k=text_top_k,
+                seeds=sampling_seeds,
+                positions=gen_steps * num_channels,
+            )
+
+        def sample_audio(logits: torch.Tensor, channel: int) -> torch.Tensor:
+            if rep_histories is not None:
+                self._apply_audio_repetition_penalty(
+                    logits, rep_histories, rep_penalties, channel
+                )
+            return MossTTSModelRunner._sample_tokens(
+                logits,
+                temperature=audio_temp,
+                top_p=audio_top_p,
+                top_k=audio_top_k,
+                seeds=sampling_seeds,
+                positions=gen_steps * num_channels + channel + 1,
+            )
+
+        use_graph = (
+            rep_histories is None
+            and batch_size <= getattr(self.model, "frame_graph_max_bs", 0)
+        )
+        if use_graph:
+            stop_choice, codes = self.model.decode_frame_graphed(
+                hidden_states,
+                text_temperature=text_temp,
+                text_top_p=text_top_p,
+                text_top_k=text_top_k,
+                audio_temperature=audio_temp,
+                audio_top_p=audio_top_p,
+                audio_top_k=audio_top_k,
+                seeds=sampling_seeds,
+                base_positions=gen_steps * num_channels,
+            )
+        else:
+            stop_choice, codes = self.model.decode_frame(
+                hidden_states,
+                sample_text=sample_text,
+                sample_audio=sample_audio,
+            )
+
+        slot_id = int(cfg.audio_assistant_slot_token_id)
+        end_id = int(cfg.audio_end_token_id)
+        next_text = torch.where(
+            stop_choice == 0,
+            torch.full((batch_size,), slot_id, dtype=torch.long, device=device),
+            torch.full((batch_size,), end_id, dtype=torch.long, device=device),
+        )
+
+        rows = torch.empty(
+            (batch_size, num_channels), dtype=torch.long, device=device
+        )
+        rows[:, 0] = next_text
+        rows[:, 1:] = codes
+
+        result.next_token_ids = next_text
+        schedule_batch.output_ids = next_text
+        embeds = self.model._prepare_multi_modal_inputs(
+            rows.to(device=self.model.device)
+        )
+        self._pending_rows = rows
+        self._pending_embeds = embeds.detach()
+
+    @staticmethod
+    def _gather_rep_histories(
+        datas: list,
+        rep_penalties: list[float],
+        device: torch.device,
+    ) -> list[torch.Tensor | None] | None:
+        """Per-request generated-code history, only when a penalty is active.
+
+        Upstream v1.5 applies the audio repetition penalty over each channel's
+        previously *generated* frames only (the prompt's reference codes are
+        excluded), so the history snapshot is taken from ``output_rows``.
+        """
+        if all(penalty == 1.0 for penalty in rep_penalties):
+            return None
+        histories: list[torch.Tensor | None] = []
+        for data, penalty in zip(datas, rep_penalties):
+            if penalty == 1.0 or not data.output_rows:
+                histories.append(None)
+                continue
+            stacked = torch.stack(data.output_rows, dim=0)[:, 1:]
+            histories.append(stacked.to(device=device, dtype=torch.long))
+        return histories
+
+    @staticmethod
+    def _apply_audio_repetition_penalty(
+        logits: torch.Tensor,
+        histories: list[torch.Tensor | None],
+        penalties: list[float],
+        channel: int,
+    ) -> None:
+        """In-place penalty on fp32 logits, matching upstream order (before
+        temperature scaling)."""
+        vocab = logits.shape[-1]
+        for row, (history, penalty) in enumerate(zip(histories, penalties)):
+            if history is None or penalty == 1.0:
+                continue
+            tokens = torch.unique(history[:, channel])
+            tokens = tokens[(tokens >= 0) & (tokens < vocab)]
+            if tokens.numel() == 0:
+                continue
+            scores = logits[row, tokens]
+            logits[row, tokens] = torch.where(
+                scores < 0, scores * penalty, scores / penalty
+            )
+
+    def post_process_outputs(
+        self,
+        result: Any,
+        scheduler_output: Any,
+        outputs: dict[str, RequestOutput],
+    ) -> None:
+        del result
+        rows = self._pending_rows
+        embeds = self._pending_embeds
+        self._pending_rows = None
+        self._pending_embeds = None
+        if rows is None or embeds is None:
+            return
+
+        end_id = int(self.model.config.audio_end_token_id)
+        for row_idx, sched_req in enumerate(scheduler_output.requests):
+            req_output = outputs[sched_req.request_id]
+            if req_output.data is None or int(req_output.data) == end_id:
+                # Stop decision: no frame is emitted alongside audio_end.
+                continue
+            sched_req.data.output_rows.append(rows[row_idx].detach().clone())
+            sched_req.data.pending_feedback_queue.append(
+                embeds[row_idx].detach().clone()
+            )

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -166,31 +166,59 @@ class MossTTSLocalModelRunner(ModelRunner):
         batch_size = len(datas)
         num_channels = int(cfg.n_vq) + 1
 
-        text_temp = torch.tensor(
-            [float(d.text_temperature) for d in datas],
-            dtype=torch.float32,
-            device=device,
-        )
-        text_top_p = torch.tensor(
-            [float(d.text_top_p) for d in datas], dtype=torch.float32, device=device
-        )
-        text_top_k = torch.tensor(
-            [int(d.text_top_k) for d in datas], dtype=torch.long, device=device
-        )
-        audio_temp = torch.tensor(
-            [float(d.audio_temperature) for d in datas],
-            dtype=torch.float32,
-            device=device,
-        )
-        audio_top_p = torch.tensor(
-            [float(d.audio_top_p) for d in datas], dtype=torch.float32, device=device
-        )
-        audio_top_k = torch.tensor(
-            [int(d.audio_top_k) for d in datas], dtype=torch.long, device=device
-        )
-        sampling_seeds = torch.tensor(
-            [int(d.sampling_seed) for d in datas], dtype=torch.long, device=device
-        )
+        # The static per-request sampling parameters only change with batch
+        # composition, so rebuild them once per composition; gen_steps moves
+        # every step and is rebuilt each time.
+        cache_key = tuple(sched_req.request_id for sched_req in requests)
+        cached = getattr(self, "_param_cache", None)
+        if cached is None or cached[0] != cache_key:
+            params = {
+                "text_temp": torch.tensor(
+                    [float(d.text_temperature) for d in datas],
+                    dtype=torch.float32,
+                    device=device,
+                ),
+                "text_top_p": torch.tensor(
+                    [float(d.text_top_p) for d in datas],
+                    dtype=torch.float32,
+                    device=device,
+                ),
+                "text_top_k": torch.tensor(
+                    [int(d.text_top_k) for d in datas],
+                    dtype=torch.long,
+                    device=device,
+                ),
+                "audio_temp": torch.tensor(
+                    [float(d.audio_temperature) for d in datas],
+                    dtype=torch.float32,
+                    device=device,
+                ),
+                "audio_top_p": torch.tensor(
+                    [float(d.audio_top_p) for d in datas],
+                    dtype=torch.float32,
+                    device=device,
+                ),
+                "audio_top_k": torch.tensor(
+                    [int(d.audio_top_k) for d in datas],
+                    dtype=torch.long,
+                    device=device,
+                ),
+                "seeds": torch.tensor(
+                    [int(d.sampling_seed) for d in datas],
+                    dtype=torch.long,
+                    device=device,
+                ),
+            }
+            self._param_cache = (cache_key, params)
+        else:
+            params = cached[1]
+        text_temp = params["text_temp"]
+        text_top_p = params["text_top_p"]
+        text_top_k = params["text_top_k"]
+        audio_temp = params["audio_temp"]
+        audio_top_p = params["audio_top_p"]
+        audio_top_k = params["audio_top_k"]
+        sampling_seeds = params["seeds"]
         gen_steps = torch.tensor(
             [int(d.generation_steps) for d in datas], dtype=torch.long, device=device
         )
@@ -225,7 +253,7 @@ class MossTTSLocalModelRunner(ModelRunner):
             self.model, "frame_graph_max_bs", 0
         )
         if use_graph:
-            stop_choice, codes = self.model.decode_frame_graphed(
+            stop_choice, codes, feedback = self.model.decode_frame_graphed(
                 hidden_states,
                 text_temperature=text_temp,
                 text_top_p=text_top_p,
@@ -236,12 +264,17 @@ class MossTTSLocalModelRunner(ModelRunner):
                 seeds=sampling_seeds,
                 base_positions=gen_steps * num_channels,
             )
+            # The graph outputs are static buffers that the next replay (any
+            # later prefill or decode step) overwrites; snapshot what we keep.
+            codes = codes.clone()
+            embeds = feedback.clone()
         else:
             stop_choice, codes = self.model.decode_frame(
                 hidden_states,
                 sample_text=sample_text,
                 sample_audio=sample_audio,
             )
+            embeds = None
 
         slot_id = int(cfg.audio_assistant_slot_token_id)
         end_id = int(cfg.audio_end_token_id)
@@ -257,9 +290,10 @@ class MossTTSLocalModelRunner(ModelRunner):
 
         result.next_token_ids = next_text
         schedule_batch.output_ids = next_text
-        embeds = self.model._prepare_multi_modal_inputs(
-            rows.to(device=self.model.device)
-        )
+        if embeds is None:
+            embeds = self.model._prepare_multi_modal_inputs(
+                rows.to(device=self.model.device)
+            )
         self._pending_rows = rows
         self._pending_embeds = embeds.detach()
 
@@ -323,12 +357,12 @@ class MossTTSLocalModelRunner(ModelRunner):
             return
 
         end_id = int(self.model.config.audio_end_token_id)
+        # rows/embeds are step-private tensors (the graph outputs were
+        # snapshotted in _collect_frame), so per-request views are stable.
         for row_idx, sched_req in enumerate(scheduler_output.requests):
             req_output = outputs[sched_req.request_id]
             if req_output.data is None or int(req_output.data) == end_id:
                 # Stop decision: no frame is emitted alongside audio_end.
                 continue
-            sched_req.data.output_rows.append(rows[row_idx].detach().clone())
-            sched_req.data.pending_feedback_queue.append(
-                embeds[row_idx].detach().clone()
-            )
+            sched_req.data.output_rows.append(rows[row_idx])
+            sched_req.data.pending_feedback_queue.append(embeds[row_idx])

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -304,14 +304,45 @@ class MossTTSLocalModelRunner(ModelRunner):
         rows[:, 0] = next_text
         rows[:, 1:] = codes
 
-        result.next_token_ids = next_text
-        schedule_batch.output_ids = next_text
+        next_token_ids = self._row_radix_token_ids(rows, next_text, end_id)
+        result.next_token_ids = next_token_ids
+        schedule_batch.output_ids = next_token_ids
         if embeds is None:
             embeds = self.model._prepare_multi_modal_inputs(
                 rows.to(device=self.model.device)
             )
         self._pending_rows = rows
         self._pending_embeds = embeds.detach()
+
+    @staticmethod
+    def _row_radix_token_ids(
+        rows: torch.Tensor,
+        next_text: torch.Tensor,
+        end_id: int,
+    ) -> torch.Tensor:
+        """Radix-cache token ids for generated frames.
+
+        The scheduler appends one token id per frame to the request's KV
+        chain, and the radix tree keys on those ids. The text channel alone is
+        the same assistant-slot id for every continuing frame of every
+        request, so a re-prefill after retraction could falsely prefix-match
+        into another identical-prompt request's cached generated region. Hash
+        the full multi-channel row — the same keying used for prompt rows —
+        so a radix match implies identical audio content (a per-position id
+        clash is ~1/151643 and only matters on top of an identical full
+        prefix). The hash is folded below the special-token band because the
+        scheduler finishes any request whose generated id crosses the vocab
+        boundary (``Req._check_vocab_boundary_finish``); the stop decision
+        keeps the raw audio_end id so eos detection still fires.
+        """
+        from sglang_omni.models.moss_tts.request_builders import build_row_cache_key_ids
+
+        # <|endoftext|> 151643 opens the special/control id band.
+        hash_space = 151643
+        hashed = torch.tensor(
+            build_row_cache_key_ids(rows), dtype=torch.long, device=rows.device
+        )
+        return torch.where(next_text == end_id, next_text, hashed % hash_space)
 
     @staticmethod
     def _gather_rep_histories(

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -86,7 +86,23 @@ class MossTTSLocalModelRunner(ModelRunner):
                 raise RuntimeError("MOSS-TTS Local prefill requires prompt_rows")
             req_len = int(req.extend_input_len)
             prefix_len = len(req.prefix_indices)
+            if data.output_rows:
+                # KV-pressure retraction re-prefills with an extend region
+                # spanning already-generated frames; their rows live in
+                # output_rows, not prompt_rows. The resumed prefill samples
+                # the next frame itself, superseding any feedback embedding
+                # stranded by the retraction.
+                generated = torch.stack(data.output_rows, dim=0)
+                rows = torch.cat([rows.to(generated.device), generated], dim=0)
+                data.pending_feedback_queue.clear()
             current_rows = rows[prefix_len : prefix_len + req_len]
+            if int(current_rows.shape[0]) != req_len:
+                raise RuntimeError(
+                    f"MOSS-TTS Local prefill row mismatch for {req.rid}: have "
+                    f"{int(current_rows.shape[0])} rows, need {req_len} "
+                    f"(prefix={prefix_len}, prompt={int(data.prompt_rows.shape[0])}, "
+                    f"generated={len(data.output_rows)})"
+                )
             embeds = self.model._prepare_multi_modal_inputs(
                 current_rows.to(device=forward_batch.input_ids.device)
             )

--- a/sglang_omni/models/moss_tts_local/payload_types.py
+++ b/sglang_omni/models/moss_tts_local/payload_types.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MOSS-TTS Local (v1.5) pipeline state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+def moss_tts_local_special_token_defaults(
+    audio_vocab_size: int = 1024,
+) -> tuple[tuple[str, int], ...]:
+    """Default special-token ids for MOSS-TTS-Local-Transformer-v1.5.
+
+    These differ from the MOSS Delay family: the Local release introduces
+    dedicated ``<|audio_start|>``/``<|audio_end|>`` tokens and reuses the
+    Qwen vision/video pad ids as the user/assistant audio slot tokens.
+    """
+    return (
+        ("audio_start_token_id", 151669),
+        ("audio_end_token_id", 151670),
+        ("audio_user_slot_token_id", 151654),
+        ("audio_assistant_slot_token_id", 151656),
+        ("audio_assistant_gen_slot_token_id", 151656),
+        ("audio_pad_token_id", int(audio_vocab_size)),
+        ("audio_pad_code", int(audio_vocab_size)),
+        ("im_start_token_id", 151644),
+        ("im_end_token_id", 151645),
+        ("pad_token_id", 151643),
+    )
+
+
+@dataclass
+class MossTTSLocalState:
+    """Per-request state for MOSS-TTS Local generation."""
+
+    text: str = ""
+    ref_audio: Any | None = None
+    ref_text: str | None = None
+    language: str | None = None
+    instructions: str | None = None
+    token_count: int | None = None
+    generation_kwargs: dict[str, Any] = field(default_factory=dict)
+    audio_codes: Any | None = None
+    sample_rate: int = 48000
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    engine_time_s: float = 0.0
+
+    @staticmethod
+    def _tensor_to_payload(value: Any) -> Any:
+        try:
+            import torch
+        except ImportError:
+            torch = None
+        if torch is not None and isinstance(value, torch.Tensor):
+            return value.detach().cpu()
+        return value
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "text": self.text,
+            "generation_kwargs": dict(self.generation_kwargs),
+            "sample_rate": int(self.sample_rate),
+        }
+        if self.ref_audio is not None:
+            data["ref_audio"] = self.ref_audio
+        if self.ref_text is not None:
+            data["ref_text"] = self.ref_text
+        if self.language is not None:
+            data["language"] = self.language
+        if self.instructions is not None:
+            data["instructions"] = self.instructions
+        if self.token_count is not None:
+            data["token_count"] = int(self.token_count)
+        if self.audio_codes is not None:
+            data["audio_codes"] = self._tensor_to_payload(self.audio_codes)
+        if self.prompt_tokens:
+            data["prompt_tokens"] = int(self.prompt_tokens)
+        if self.completion_tokens:
+            data["completion_tokens"] = int(self.completion_tokens)
+        if self.engine_time_s:
+            data["engine_time_s"] = float(self.engine_time_s)
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Any) -> "MossTTSLocalState":
+        if not isinstance(data, dict):
+            data = {}
+        generation_kwargs = data.get("generation_kwargs")
+        return cls(
+            text=str(data.get("text", "")),
+            ref_audio=data.get("ref_audio"),
+            ref_text=data.get("ref_text"),
+            language=data.get("language"),
+            instructions=data.get("instructions"),
+            token_count=(
+                int(data["token_count"])
+                if data.get("token_count") is not None
+                else None
+            ),
+            generation_kwargs=(
+                dict(generation_kwargs) if isinstance(generation_kwargs, dict) else {}
+            ),
+            audio_codes=data.get("audio_codes"),
+            sample_rate=int(data.get("sample_rate", 48000) or 48000),
+            prompt_tokens=int(data.get("prompt_tokens", 0) or 0),
+            completion_tokens=int(data.get("completion_tokens", 0) or 0),
+            engine_time_s=float(data.get("engine_time_s", 0.0) or 0.0),
+        )

--- a/sglang_omni/models/moss_tts_local/request_builders.py
+++ b/sglang_omni/models/moss_tts_local/request_builders.py
@@ -1,0 +1,443 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Request mapping helpers for MOSS-TTS Local (v1.5)."""
+
+from __future__ import annotations
+
+import collections
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+
+from sglang_omni.models.moss_tts.request_builders import (
+    MOSS_TTS_DEFAULT_MAX_NEW_TOKENS,
+    _new_moss_tts_sampling_seed,
+    _reference_for_processor,
+    _resolve_optional_text,
+    _resolve_token_count,
+    _validate_moss_tts_generation_kwargs,
+    build_row_cache_key_ids,
+    derive_moss_tts_sampling_seed,
+    normalize_moss_tts_inputs,
+    resolve_moss_reference,
+)
+from sglang_omni.models.moss_tts_local.payload_types import MossTTSLocalState
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.types import ARRequestData
+
+_MOSS_TTS_LOCAL_PREPARED_MARKER = "_moss_tts_local_prepared_request"
+
+
+@dataclass
+class MossTTSLocalSGLangRequestData(ARRequestData):
+    """Scheduler-owned request state for MOSS-TTS Local."""
+
+    enforce_request_limits: bool = True
+    req: Any = None
+    synced: bool = False
+    generation_steps: int = 0
+    suppress_tokens: list[int] | None = None
+    input_embeds_are_projected: bool = False
+    stage_payload: Any = None
+    state: MossTTSLocalState = field(default_factory=MossTTSLocalState)
+    model_config: Any = None
+    prompt_rows: torch.Tensor | None = None
+    output_rows: list[torch.Tensor] = field(default_factory=list)
+    pending_feedback_queue: Any = field(default_factory=collections.deque)
+    # Checkpoint generate() defaults: the binary continue/stop head samples at
+    # plain temperature 1.0 while the audio channels use the model-card
+    # recommendation (1.7 / 0.8 / 25, repetition penalty off).
+    text_temperature: float = 1.0
+    text_top_p: float = 1.0
+    text_top_k: int = 50
+    audio_temperature: float = 1.7
+    audio_top_p: float = 0.8
+    audio_top_k: int = 25
+    audio_repetition_penalty: float = 1.0
+    seed: int | None = None
+    sampling_seed: int = field(default_factory=_new_moss_tts_sampling_seed)
+    engine_start_s: float = 0.0
+
+
+@dataclass
+class MossTTSLocalPreparedRequest:
+    """Heavy preprocessing output consumed by the AR scheduler."""
+
+    state: MossTTSLocalState
+    input_ids_list: list[int]
+    input_ids: torch.Tensor
+    prompt_rows: torch.Tensor
+    gen_kwargs: dict[str, Any]
+
+
+@dataclass
+class _PreprocessingContext:
+    processor: Any
+    reference_encoder: Any = None
+
+
+_PREPROCESSING_CONTEXT: _PreprocessingContext | None = None
+_PREPARED_REQUESTS: dict[str, MossTTSLocalPreparedRequest] = {}
+_INFLIGHT_REQUESTS: set[str] = set()
+_ABORTED_REQUESTS: set[str] = set()
+_PREPARED_REQUESTS_LOCK = threading.Lock()
+
+
+def set_moss_tts_local_preprocessing_context(
+    *, processor: Any, reference_encoder: Any = None
+) -> None:
+    global _PREPROCESSING_CONTEXT
+    with _PREPARED_REQUESTS_LOCK:
+        _PREPROCESSING_CONTEXT = _PreprocessingContext(
+            processor=processor, reference_encoder=reference_encoder
+        )
+        _PREPARED_REQUESTS.clear()
+        _INFLIGHT_REQUESTS.clear()
+        _ABORTED_REQUESTS.clear()
+
+
+def clear_moss_tts_local_preprocessing_context() -> None:
+    global _PREPROCESSING_CONTEXT
+    with _PREPARED_REQUESTS_LOCK:
+        _PREPROCESSING_CONTEXT = None
+        _PREPARED_REQUESTS.clear()
+        _INFLIGHT_REQUESTS.clear()
+        _ABORTED_REQUESTS.clear()
+
+
+def cleanup_prepared_moss_tts_local_request(request_id: str) -> None:
+    """Drop any prepared handoff for an aborted request (see MOSS Delay)."""
+    rid = str(request_id)
+    with _PREPARED_REQUESTS_LOCK:
+        if _PREPARED_REQUESTS.pop(rid, None) is not None:
+            return
+        if rid in _INFLIGHT_REQUESTS:
+            _ABORTED_REQUESTS.add(rid)
+
+
+def pop_prepared_moss_tts_local_request(
+    payload: StagePayload,
+) -> MossTTSLocalPreparedRequest | None:
+    data = payload.data if isinstance(payload.data, dict) else {}
+    marker = data.get(_MOSS_TTS_LOCAL_PREPARED_MARKER)
+    if marker is None:
+        return None
+    with _PREPARED_REQUESTS_LOCK:
+        prepared = _PREPARED_REQUESTS.pop(str(marker), None)
+    if prepared is None:
+        raise RuntimeError(
+            "MOSS-TTS Local preprocessing state is missing for prepared payload "
+            f"{marker!r}; the AR scheduler must not rebuild it"
+        )
+    return prepared
+
+
+def build_moss_tts_local_state(payload: StagePayload) -> MossTTSLocalState:
+    inputs = payload.request.inputs or {}
+    params = payload.request.params or {}
+    metadata = payload.request.metadata or {}
+    tts_params = metadata.get("tts_params")
+    if not isinstance(tts_params, dict):
+        tts_params = {}
+
+    text, references = normalize_moss_tts_inputs(inputs)
+    ref_audio, ref_text = resolve_moss_reference(references, tts_params)
+    language = _resolve_optional_text(
+        tts_params.get("language") or params.get("language")
+    )
+    instructions = _resolve_optional_text(
+        tts_params.get("instructions")
+        or tts_params.get("instruct")
+        or params.get("instructions")
+        or params.get("instruct")
+    )
+    text, token_count = _resolve_token_count(text, params, tts_params)
+    return MossTTSLocalState(
+        text=text,
+        ref_audio=ref_audio,
+        ref_text=ref_text,
+        language=language,
+        instructions=instructions,
+        token_count=token_count,
+        generation_kwargs=build_generation_kwargs(params, tts_params=tts_params),
+    )
+
+
+def build_generation_kwargs(
+    params: dict[str, Any],
+    *,
+    tts_params: dict[str, Any],
+) -> dict[str, Any]:
+    explicit_generation_params = tts_params.get("explicit_generation_params")
+    if isinstance(explicit_generation_params, (list, tuple, set)):
+        explicit_fields = {str(field) for field in explicit_generation_params}
+    else:
+        explicit_fields = set()
+
+    raw_max_new_tokens = params.get("max_new_tokens")
+    if raw_max_new_tokens is None:
+        max_new_tokens = MOSS_TTS_DEFAULT_MAX_NEW_TOKENS
+    elif isinstance(raw_max_new_tokens, bool):
+        raise ValueError(
+            f"MOSS-TTS max_new_tokens must be an integer, got {raw_max_new_tokens!r}"
+        )
+    else:
+        max_new_tokens = int(raw_max_new_tokens)
+
+    generation_kwargs: dict[str, Any] = {
+        "max_new_tokens": max_new_tokens,
+        # Checkpoint generate() / model-card defaults for v1.5.
+        "text_temperature": 1.0,
+        "audio_temperature": 1.7,
+        "text_top_p": 1.0,
+        "audio_top_p": 0.8,
+        "text_top_k": 50,
+        "audio_top_k": 25,
+        "audio_repetition_penalty": 1.0,
+    }
+
+    if "temperature" in explicit_fields and params.get("temperature") is not None:
+        generation_kwargs["text_temperature"] = float(params["temperature"])
+        generation_kwargs["audio_temperature"] = float(params["temperature"])
+    if "top_p" in explicit_fields and params.get("top_p") is not None:
+        generation_kwargs["text_top_p"] = float(params["top_p"])
+        generation_kwargs["audio_top_p"] = float(params["top_p"])
+    if "top_k" in explicit_fields and params.get("top_k") is not None:
+        generation_kwargs["text_top_k"] = int(params["top_k"])
+        generation_kwargs["audio_top_k"] = int(params["top_k"])
+    if (
+        "repetition_penalty" in explicit_fields
+        and params.get("repetition_penalty") is not None
+    ):
+        generation_kwargs["audio_repetition_penalty"] = float(
+            params["repetition_penalty"]
+        )
+
+    for source in (tts_params, params):
+        for field_name in (
+            "text_temperature",
+            "text_top_p",
+            "text_top_k",
+            "audio_temperature",
+            "audio_top_p",
+            "audio_top_k",
+            "audio_repetition_penalty",
+        ):
+            if source.get(field_name) is not None:
+                value = source[field_name]
+                generation_kwargs[field_name] = (
+                    int(value) if field_name.endswith("top_k") else float(value)
+                )
+
+    seed = tts_params.get("seed")
+    if seed is None:
+        seed = params.get("seed")
+    if seed is not None:
+        generation_kwargs["seed"] = seed
+
+    _validate_moss_tts_generation_kwargs(generation_kwargs)
+    return generation_kwargs
+
+
+def _build_processor_message(
+    processor: Any,
+    state: MossTTSLocalState,
+    reference_encoder: Any = None,
+) -> dict[str, Any]:
+    from sglang_omni.models.moss_tts.request_builders import _DATA_URI_RE
+
+    ref_audio = state.ref_audio
+    if (
+        reference_encoder is not None
+        and isinstance(ref_audio, str)
+        and _DATA_URI_RE.match(ref_audio) is None
+    ):
+        # File-path references encode through the shared coalescer so
+        # concurrent requests share one batched codec forward instead of
+        # serializing ~0.25 GPU-seconds each.
+        reference = [reference_encoder.encode(ref_audio)]
+    else:
+        reference = _reference_for_processor(processor, ref_audio)
+    return processor.build_user_message(
+        text=state.text,
+        reference=reference,
+        instruction=state.instructions,
+        tokens=state.token_count,
+        language=state.language,
+    )
+
+
+def _prepare_moss_tts_local_request(
+    payload: StagePayload,
+    *,
+    processor: Any,
+    reference_encoder: Any = None,
+) -> MossTTSLocalPreparedRequest:
+    state = build_moss_tts_local_state(payload)
+    message = _build_processor_message(processor, state, reference_encoder)
+    batch = processor([[message]], mode="generation")
+    input_rows = batch["input_ids"]
+    if input_rows.ndim != 3 or int(input_rows.shape[0]) != 1:
+        raise ValueError(
+            "MOSS-TTS Local processor must return input_ids with shape [1, T, C]"
+        )
+    prompt_rows = input_rows[0].detach().to(dtype=torch.long, device="cpu")
+    input_ids_list = build_row_cache_key_ids(prompt_rows)
+    return MossTTSLocalPreparedRequest(
+        state=state,
+        input_ids_list=input_ids_list,
+        input_ids=torch.tensor(input_ids_list, dtype=torch.long),
+        prompt_rows=prompt_rows,
+        gen_kwargs=state.generation_kwargs,
+    )
+
+
+def preprocess_moss_tts_local_payload(payload: StagePayload) -> StagePayload:
+    """Run prompt/reference preprocessing outside the AR scheduler."""
+
+    rid = str(payload.request_id)
+    with _PREPARED_REQUESTS_LOCK:
+        context = _PREPROCESSING_CONTEXT
+        if context is not None:
+            _INFLIGHT_REQUESTS.add(rid)
+    if context is None:
+        raise RuntimeError(
+            "MOSS-TTS Local preprocessing context is not initialized; "
+            "create_preprocessing_executor must register it before requests run"
+        )
+
+    try:
+        prepared = _prepare_moss_tts_local_request(
+            payload,
+            processor=context.processor,
+            reference_encoder=context.reference_encoder,
+        )
+    except BaseException:
+        with _PREPARED_REQUESTS_LOCK:
+            _INFLIGHT_REQUESTS.discard(rid)
+            _ABORTED_REQUESTS.discard(rid)
+        raise
+    with _PREPARED_REQUESTS_LOCK:
+        _INFLIGHT_REQUESTS.discard(rid)
+        aborted = rid in _ABORTED_REQUESTS
+        _ABORTED_REQUESTS.discard(rid)
+        if not aborted:
+            _PREPARED_REQUESTS[rid] = prepared
+
+    data = prepared.state.to_dict()
+    data[_MOSS_TTS_LOCAL_PREPARED_MARKER] = payload.request_id
+    return StagePayload(
+        request_id=payload.request_id, request=payload.request, data=data
+    )
+
+
+def build_sglang_moss_tts_local_request(
+    payload: StagePayload,
+    *,
+    model: Any,
+) -> MossTTSLocalSGLangRequestData:
+    from sglang.srt.managers.schedule_batch import Req
+    from sglang.srt.sampling.sampling_params import SamplingParams
+
+    prepared = pop_prepared_moss_tts_local_request(payload)
+    if prepared is None:
+        raise RuntimeError(
+            "MOSS-TTS Local AR request builder requires a payload prepared by "
+            "preprocess_moss_tts_local_payload"
+        )
+
+    cfg = model.config
+    gen_kwargs = prepared.gen_kwargs
+    max_new_tokens = int(
+        gen_kwargs.get("max_new_tokens", MOSS_TTS_DEFAULT_MAX_NEW_TOKENS)
+    )
+    audio_end = int(cfg.audio_end_token_id)
+    sampling_params = SamplingParams(
+        max_new_tokens=max_new_tokens,
+        temperature=0.0,
+        stop_token_ids=[audio_end],
+    )
+    sampling_params.normalize(None)
+    sampling_params.verify(int(cfg.vocab_size_list[0]))
+
+    req = Req(
+        rid=payload.request_id,
+        origin_input_text="",
+        origin_input_ids=prepared.input_ids_list,
+        sampling_params=sampling_params,
+        eos_token_ids={audio_end},
+        vocab_size=int(cfg.vocab_size_list[0]),
+    )
+    req.tokenizer = None
+    req._input_embeds_are_projected = True
+    req._codec_suppress_tokens = None
+
+    data = MossTTSLocalSGLangRequestData(
+        input_ids=prepared.input_ids,
+        max_new_tokens=max_new_tokens,
+        temperature=0.0,
+        output_ids=req.output_ids,
+        req=req,
+        state=prepared.state,
+        model_config=cfg,
+        prompt_rows=prepared.prompt_rows,
+        text_temperature=float(gen_kwargs.get("text_temperature", 1.0)),
+        text_top_p=float(gen_kwargs.get("text_top_p", 1.0)),
+        text_top_k=int(gen_kwargs.get("text_top_k", 50)),
+        audio_temperature=float(gen_kwargs.get("audio_temperature", 1.7)),
+        audio_top_p=float(gen_kwargs.get("audio_top_p", 0.8)),
+        audio_top_k=int(gen_kwargs.get("audio_top_k", 25)),
+        audio_repetition_penalty=float(
+            gen_kwargs.get("audio_repetition_penalty", 1.0)
+        ),
+        seed=gen_kwargs.get("seed"),
+        sampling_seed=(
+            derive_moss_tts_sampling_seed(gen_kwargs["seed"])
+            if gen_kwargs.get("seed") is not None
+            else _new_moss_tts_sampling_seed()
+        ),
+        engine_start_s=time.perf_counter(),
+    )
+    data.input_embeds_are_projected = True
+    data.stage_payload = payload
+    return data
+
+
+def apply_sglang_moss_tts_local_result(
+    payload: StagePayload,
+    data: MossTTSLocalSGLangRequestData,
+) -> StagePayload:
+    state = data.state
+    n_vq = (
+        int(data.prompt_rows.shape[1] - 1)
+        if data.prompt_rows is not None and data.prompt_rows.ndim == 2
+        else 12
+    )
+    if data.output_rows:
+        generated_rows = torch.stack(data.output_rows, dim=0).to(dtype=torch.long)
+        state.audio_codes = generated_rows[:, 1:].detach().cpu()
+    else:
+        state.audio_codes = torch.empty((0, n_vq), dtype=torch.long)
+
+    state.prompt_tokens = len(data.input_ids) if data.input_ids is not None else 0
+    state.completion_tokens = len(data.output_rows)
+    state.engine_time_s = time.perf_counter() - data.engine_start_s
+    return StagePayload(
+        request_id=payload.request_id,
+        request=payload.request,
+        data=state.to_dict(),
+    )
+
+
+def make_moss_tts_local_scheduler_adapters(*, model: Any):
+    """Build StagePayload <-> SGLang request adapters for MOSS-TTS Local."""
+
+    def request_builder(payload: StagePayload) -> MossTTSLocalSGLangRequestData:
+        return build_sglang_moss_tts_local_request(payload, model=model)
+
+    def result_adapter(data: MossTTSLocalSGLangRequestData) -> StagePayload:
+        return apply_sglang_moss_tts_local_result(data.stage_payload, data)
+
+    return request_builder, result_adapter

--- a/sglang_omni/models/moss_tts_local/request_builders.py
+++ b/sglang_omni/models/moss_tts_local/request_builders.py
@@ -389,9 +389,7 @@ def build_sglang_moss_tts_local_request(
         audio_temperature=float(gen_kwargs.get("audio_temperature", 1.7)),
         audio_top_p=float(gen_kwargs.get("audio_top_p", 0.8)),
         audio_top_k=int(gen_kwargs.get("audio_top_k", 25)),
-        audio_repetition_penalty=float(
-            gen_kwargs.get("audio_repetition_penalty", 1.0)
-        ),
+        audio_repetition_penalty=float(gen_kwargs.get("audio_repetition_penalty", 1.0)),
         seed=gen_kwargs.get("seed"),
         sampling_seed=(
             derive_moss_tts_sampling_seed(gen_kwargs["seed"])

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -105,9 +105,7 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             num_layers=int(getattr(self.config, "local_transformer_layers", 1)),
             max_positions=self.n_vq + 1,
             rope_base=float(self._cfg_get(gpt2_cfg, "rope_base", 1_000_000.0)),
-            layer_norm_eps=float(
-                self._cfg_get(gpt2_cfg, "layer_norm_epsilon", 1e-6)
-            ),
+            layer_norm_eps=float(self._cfg_get(gpt2_cfg, "layer_norm_epsilon", 1e-6)),
         )
         # Binary continue/stop head over the local position-0 hidden state:
         # index 0 -> audio_assistant_slot (emit a frame), 1 -> audio_end (stop).
@@ -404,7 +402,9 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             return
         device = self.device
         self.local_transformer._ensure_kv_cache(max(buckets), device, self.dtype)
-        self._frame_graphs: dict[int, tuple[Any, dict[str, torch.Tensor], torch.Tensor, torch.Tensor]] = {}
+        self._frame_graphs: dict[
+            int, tuple[Any, dict[str, torch.Tensor], torch.Tensor, torch.Tensor]
+        ] = {}
 
         for bucket in buckets:
             static_inputs = {
@@ -426,9 +426,7 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
                     (bucket,), 25, device=device, dtype=torch.long
                 ),
                 "seeds": torch.zeros(bucket, device=device, dtype=torch.long),
-                "base_positions": torch.zeros(
-                    bucket, device=device, dtype=torch.long
-                ),
+                "base_positions": torch.zeros(bucket, device=device, dtype=torch.long),
             }
             warmup_stream = torch.cuda.Stream()
             warmup_stream.wait_stream(torch.cuda.current_stream())
@@ -581,9 +579,7 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
                     rows = int(loaded_weight.shape[0])
                     with torch.no_grad():
                         param.data[:rows].copy_(
-                            loaded_weight.to(
-                                device=param.device, dtype=param.dtype
-                            )
+                            loaded_weight.to(device=param.device, dtype=param.dtype)
                         )
                 continue
 

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -1,0 +1,671 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SGLang-native MOSS-TTS Local (v1.5) model wrapper.
+
+Architecture: a 36-layer Qwen3 global backbone consumes one summed embedding
+per audio frame (text channel + 12 RVQ code channels); a 1-layer frame-local
+transformer then decodes the next frame from the backbone's last hidden state
+— a binary continue/stop decision followed by 12 sequentially sampled RVQ
+codes, each fed back as the next local-position embedding.
+
+The backbone runs under SGLang's scheduler (radix cache + CUDA graph); the
+local transformer micro-loop runs batched in :meth:`decode_frame`, driven by
+the model runner after each backbone step.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Iterable, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from sglang.srt.distributed import get_pp_group
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
+from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.qwen3 import Qwen3Model
+from sglang.srt.utils import add_prefix
+
+from sglang_omni.models.moss_tts_local.local_transformer import (
+    MossTTSLocalTransformer,
+    sample_seeded_branchless,
+)
+from sglang_omni.models.moss_tts_local.payload_types import (
+    moss_tts_local_special_token_defaults,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _as_qwen3_config(config: Any) -> Any:
+    from transformers import Qwen3Config
+
+    if isinstance(config, Qwen3Config):
+        return config
+    if isinstance(config, dict):
+        return Qwen3Config(**config)
+    if hasattr(config, "to_dict"):
+        return Qwen3Config(**config.to_dict())
+    return config
+
+
+class MossTTSLocalSGLangModel(torch.nn.Module):
+    """MOSS-TTS Local AR model: Qwen3 backbone + 1-layer local transformer."""
+
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+    def __init__(
+        self,
+        config: Any,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.pp_group = get_pp_group()
+        self.config = self._normalize_config(config)
+        self.quant_config = quant_config
+        self.hidden_size = int(self.config.hidden_size)
+        self.n_vq = int(self.config.n_vq)
+
+        # Channel 0: text vocab; channels 1..n_vq: per-codebook tables with one
+        # extra row for audio_pad_code so prompt-row embedding sums need no
+        # masking — the pad row is zeroed after weight loading.
+        self.embedding_list = torch.nn.ModuleList()
+        if self.pp_group.is_first_rank:
+            for idx in range(self.config.channels):
+                self.embedding_list.append(
+                    VocabParallelEmbedding(
+                        int(self.config.vocab_size_list[idx]),
+                        self.hidden_size,
+                        quant_config=quant_config,
+                        prefix=add_prefix(f"embedding_list.{idx}", prefix),
+                    )
+                )
+        else:
+            for _ in range(self.config.channels):
+                self.embedding_list.append(PPMissingLayer())
+
+        self.model = Qwen3Model(
+            config=self.config.language_config,
+            quant_config=quant_config,
+            prefix=add_prefix("model", prefix),
+        )
+
+        gpt2_cfg = self.config.gpt2_config
+        self.local_transformer = MossTTSLocalTransformer(
+            hidden_size=self.hidden_size,
+            num_heads=int(self._cfg_get(gpt2_cfg, "n_head", 32)),
+            inner_size=int(self._cfg_get(gpt2_cfg, "n_inner", 4 * self.hidden_size)),
+            num_layers=int(getattr(self.config, "local_transformer_layers", 1)),
+            max_positions=self.n_vq + 1,
+            rope_base=float(self._cfg_get(gpt2_cfg, "rope_base", 1_000_000.0)),
+            layer_norm_eps=float(
+                self._cfg_get(gpt2_cfg, "layer_norm_epsilon", 1e-6)
+            ),
+        )
+        # Binary continue/stop head over the local position-0 hidden state:
+        # index 0 -> audio_assistant_slot (emit a frame), 1 -> audio_end (stop).
+        self.local_text_lm_head = torch.nn.Linear(self.hidden_size, 2, bias=False)
+
+        max_batch_size = None
+        try:
+            from sglang.srt.server_args import get_global_server_args
+
+            max_batch_size = get_global_server_args().max_running_requests
+        except Exception:
+            max_batch_size = None
+        weight = self._first_embedding_weight()
+        self._decode_input_embedding = torch.nn.Embedding(
+            int(max_batch_size or 1),
+            self.hidden_size,
+            device=weight.device,
+            dtype=weight.dtype,
+        )
+        self._decode_input_embedding.weight.requires_grad_(False)
+
+    @staticmethod
+    def _cfg_get(config: Any, name: str, default: Any) -> Any:
+        if isinstance(config, dict):
+            value = config.get(name, default)
+        else:
+            value = getattr(config, name, default)
+        return default if value is None else value
+
+    @staticmethod
+    def _normalize_config(config: Any) -> Any:
+        qwen3_config = getattr(config, "qwen3_config", None)
+        if qwen3_config is None:
+            qwen3_config = getattr(config, "language_config", None)
+        language_config = _as_qwen3_config(qwen3_config)
+        try:
+            config.language_config = language_config
+        except AttributeError:
+            # MossTTSLocalConfig.language_config is a read-only property
+            # mirroring qwen3_config; normalize through the backing field.
+            config.qwen3_config = language_config
+        config.hidden_size = int(
+            getattr(config, "hidden_size", None) or language_config.hidden_size
+        )
+        config.vocab_size = int(
+            getattr(config, "vocab_size", None) or language_config.vocab_size
+        )
+        config.n_vq = int(getattr(config, "n_vq", 12))
+        config.channels = int(getattr(config, "channels", config.n_vq + 1))
+        audio_vocab_size = int(getattr(config, "audio_vocab_size", 1024) or 1024)
+        config.audio_vocab_size = audio_vocab_size
+        if not getattr(config, "vocab_size_list", None):
+            config.vocab_size_list = [config.vocab_size] + [audio_vocab_size + 1] * (
+                config.channels - 1
+            )
+        for attr, default in moss_tts_local_special_token_defaults(audio_vocab_size):
+            if getattr(config, attr, None) is None:
+                setattr(config, attr, default)
+        if not getattr(config, "pad_token", None):
+            text_pad = int(getattr(config, "pad_token_id", 0) or 0)
+            audio_pad = int(config.audio_pad_code)
+            config.pad_token = [text_pad] + [audio_pad] * (config.channels - 1)
+        config.language_config.channels = config.channels
+        config.language_config.vocab_size_list = list(config.vocab_size_list)
+        config.language_config.pad_token = list(config.pad_token)
+        return config
+
+    def _first_embedding_weight(self) -> torch.Tensor:
+        for layer in self.embedding_list:
+            weight = getattr(layer, "weight", None)
+            if isinstance(weight, torch.Tensor):
+                return weight
+        return torch.empty((), dtype=torch.float32)
+
+    @property
+    def start_layer(self) -> int:
+        return self.model.start_layer
+
+    @property
+    def end_layer(self) -> int:
+        return self.model.end_layer
+
+    @property
+    def device(self) -> torch.device:
+        return self._first_embedding_weight().device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self._first_embedding_weight().dtype
+
+    def _audio_embedding_weight(self, channel: int) -> torch.Tensor:
+        """Rows 0..audio_vocab_size-1 of codebook ``channel``'s table."""
+        weight = self.embedding_list[channel + 1].weight
+        return weight[: int(self.config.audio_vocab_size)]
+
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self._prepare_multi_modal_inputs(input_ids)
+
+    def _prepare_multi_modal_inputs(self, input_ids: torch.LongTensor) -> torch.Tensor:
+        """Sum text + per-codebook embeddings for ``[T, channels]`` rows.
+
+        Pad codes (``audio_pad_code``) hit the zeroed extra row of each audio
+        table, matching the upstream zero-mask semantics without masking.
+        """
+        if input_ids.dim() == 1:
+            channels = int(self.config.channels)
+            total_tokens = int(input_ids.shape[0])
+            if total_tokens % channels == 0:
+                input_ids_2d = input_ids.view(total_tokens // channels, channels)
+            else:
+                # Profiling/warmup passes flat dummy ids of arbitrary length:
+                # treat each id as a text token over pad audio rows.
+                input_ids_2d = torch.empty(
+                    (total_tokens, channels),
+                    dtype=input_ids.dtype,
+                    device=input_ids.device,
+                )
+                pad_token = self.config.pad_token
+                for idx in range(channels):
+                    input_ids_2d[:, idx].fill_(int(pad_token[idx]))
+                input_ids_2d[:, 0] = input_ids
+        elif input_ids.dim() == 2:
+            input_ids_2d = input_ids
+        else:
+            raise ValueError(
+                "MOSS-TTS Local input_ids must be rank-1 flattened rows or "
+                f"rank-2 multi-channel rows, got shape {tuple(input_ids.shape)}"
+            )
+
+        if int(input_ids_2d.shape[-1]) != int(self.config.channels):
+            raise ValueError(
+                f"MOSS-TTS Local expected {self.config.channels} channels, "
+                f"got {input_ids_2d.shape[-1]}"
+            )
+
+        weight = self._first_embedding_weight()
+        embeds = torch.zeros(
+            input_ids_2d.shape[0],
+            self.hidden_size,
+            device=input_ids_2d.device,
+            dtype=weight.dtype,
+        )
+        for idx, embed_layer in enumerate(self.embedding_list):
+            embeds = embeds + embed_layer(input_ids_2d[:, idx])
+        return embeds
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: Optional[torch.Tensor] = None,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+        input_embeds_are_projected: bool = False,
+    ) -> LogitsProcessorOutput:
+        del input_embeds_are_projected
+        if input_embeds is None:
+            forward_mode = getattr(forward_batch, "forward_mode", None)
+            is_decode = (
+                forward_mode is not None
+                and hasattr(forward_mode, "is_decode")
+                and bool(forward_mode.is_decode())
+            )
+            if is_decode:
+                input_embeds = self._decode_input_embedding(input_ids)
+            elif self.pp_group.is_first_rank:
+                input_embeds = self._prepare_multi_modal_inputs(input_ids)
+            else:
+                input_embeds = None
+
+        hidden_states = self.model(
+            input_ids=None,
+            positions=positions,
+            forward_batch=forward_batch,
+            input_embeds=input_embeds,
+            pp_proxy_tensors=pp_proxy_tensors,
+        )
+        if not self.pp_group.is_last_rank:
+            return hidden_states
+
+        sample_hidden_states = self._select_sample_hidden_states(
+            hidden_states,
+            forward_batch,
+        )
+        # The local-transformer frame decode (binary stop head + 12 sequential
+        # codebook samples) runs in the model runner after the graph-captured
+        # backbone returns; emitting hidden states with dummy logits keeps the
+        # backbone CUDA-graph replay free of model-specific outputs.
+        dummy_logits = sample_hidden_states.new_empty(
+            (sample_hidden_states.shape[0], 1)
+        )
+        return LogitsProcessorOutput(
+            next_token_logits=dummy_logits,
+            hidden_states=sample_hidden_states,
+        )
+
+    @staticmethod
+    def _select_sample_hidden_states(
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        forward_mode = getattr(forward_batch, "forward_mode", None)
+        is_extend = (
+            forward_mode is not None
+            and hasattr(forward_mode, "is_extend")
+            and bool(forward_mode.is_extend())
+        )
+        if not is_extend:
+            return hidden_states
+        extend_seq_lens = getattr(forward_batch, "extend_seq_lens", None)
+        if extend_seq_lens is None:
+            return hidden_states[-1:].contiguous()
+        last_index = (
+            torch.cumsum(
+                extend_seq_lens.to(device=hidden_states.device, dtype=torch.long), dim=0
+            )
+            - 1
+        )
+        return hidden_states[last_index]
+
+    # ------------------------------------------------------------------
+    # Frame decode: eager path (callback-driven) and CUDA-graphed path
+    # ------------------------------------------------------------------
+
+    _sample_seeded_branchless = staticmethod(sample_seeded_branchless)
+
+    @torch.no_grad()
+    def _decode_frame_graphable(
+        self,
+        hidden_states: torch.Tensor,
+        text_temperature: torch.Tensor,
+        text_top_p: torch.Tensor,
+        text_top_k: torch.Tensor,
+        audio_temperature: torch.Tensor,
+        audio_top_p: torch.Tensor,
+        audio_top_k: torch.Tensor,
+        seeds: torch.Tensor,
+        base_positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Branchless frame decode used both eagerly and under graph capture.
+
+        ``base_positions`` is ``generation_steps * (n_vq + 1)``; channel
+        ``c``'s sampling position is ``base_positions + c + 1`` and the binary
+        text decision samples at ``base_positions``, matching the eager path.
+        Repetition penalty is not supported here (the runner falls back to
+        the eager path when a request enables it).
+        """
+        local_hidden = self.local_transformer.step(
+            hidden_states.to(dtype=self.dtype), 0
+        )
+        text_logits = F.linear(local_hidden, self.local_text_lm_head.weight).float()
+        stop_choice = self._sample_seeded_branchless(
+            text_logits,
+            temperature=text_temperature,
+            top_p=text_top_p,
+            top_k=text_top_k,
+            seeds=seeds,
+            positions=base_positions,
+        )
+
+        codes = []
+        current = local_hidden
+        for channel in range(self.n_vq):
+            head_weight = self._audio_embedding_weight(channel)
+            logits = F.linear(current, head_weight).float()
+            code = self._sample_seeded_branchless(
+                logits,
+                temperature=audio_temperature,
+                top_p=audio_top_p,
+                top_k=audio_top_k,
+                seeds=seeds,
+                positions=base_positions + channel + 1,
+            )
+            codes.append(code)
+            if channel + 1 < self.n_vq:
+                next_embed = F.embedding(code, head_weight)
+                current = self.local_transformer.step(
+                    next_embed.to(dtype=self.dtype), channel + 1
+                )
+        return stop_choice, torch.stack(codes, dim=-1)
+
+    @torch.no_grad()
+    def init_frame_decode_graphs(self, batch_sizes: list[int]) -> None:
+        """Capture the per-frame local decode (1 + n_vq micro-steps plus all
+        13 seeded sampling passes) into one CUDA graph per batch-size bucket.
+
+        Eager execution launches ~500 kernels per frame (~22 ms regardless of
+        batch size); replay collapses that to a few milliseconds. Must run
+        during engine init while the device is otherwise idle.
+        """
+        buckets = sorted({int(bs) for bs in batch_sizes})
+        if not buckets:
+            return
+        device = self.device
+        self.local_transformer._ensure_kv_cache(max(buckets), device, self.dtype)
+        self._frame_graphs: dict[int, tuple[Any, dict[str, torch.Tensor], torch.Tensor, torch.Tensor]] = {}
+
+        for bucket in buckets:
+            static_inputs = {
+                "hidden_states": torch.zeros(
+                    bucket, self.hidden_size, device=device, dtype=self.dtype
+                ),
+                "text_temperature": torch.ones(
+                    bucket, device=device, dtype=torch.float32
+                ),
+                "text_top_p": torch.ones(bucket, device=device, dtype=torch.float32),
+                "text_top_k": torch.full(
+                    (bucket,), 50, device=device, dtype=torch.long
+                ),
+                "audio_temperature": torch.ones(
+                    bucket, device=device, dtype=torch.float32
+                ),
+                "audio_top_p": torch.ones(bucket, device=device, dtype=torch.float32),
+                "audio_top_k": torch.full(
+                    (bucket,), 25, device=device, dtype=torch.long
+                ),
+                "seeds": torch.zeros(bucket, device=device, dtype=torch.long),
+                "base_positions": torch.zeros(
+                    bucket, device=device, dtype=torch.long
+                ),
+            }
+            warmup_stream = torch.cuda.Stream()
+            warmup_stream.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(warmup_stream):
+                for _ in range(2):
+                    self._decode_frame_graphable(**static_inputs)
+            torch.cuda.current_stream().wait_stream(warmup_stream)
+            torch.cuda.synchronize()
+
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                stop_choice, codes = self._decode_frame_graphable(**static_inputs)
+            self._frame_graphs[bucket] = (graph, static_inputs, stop_choice, codes)
+        logger.info(
+            "MOSS-TTS Local frame-decode CUDA graphs captured for bs=%s", buckets
+        )
+
+    @property
+    def frame_graph_max_bs(self) -> int:
+        graphs = getattr(self, "_frame_graphs", None)
+        return max(graphs) if graphs else 0
+
+    @torch.no_grad()
+    def decode_frame_graphed(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        text_temperature: torch.Tensor,
+        text_top_p: torch.Tensor,
+        text_top_k: torch.Tensor,
+        audio_temperature: torch.Tensor,
+        audio_top_p: torch.Tensor,
+        audio_top_k: torch.Tensor,
+        seeds: torch.Tensor,
+        base_positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Replay the captured frame decode for this batch (padded up to the
+        nearest bucket; padding rows sample garbage that the caller discards).
+        """
+        batch_size = hidden_states.shape[0]
+        bucket = min(b for b in self._frame_graphs if b >= batch_size)
+        graph, static_inputs, stop_choice, codes = self._frame_graphs[bucket]
+
+        static_inputs["hidden_states"][:batch_size].copy_(
+            hidden_states.to(dtype=self.dtype)
+        )
+        if batch_size < bucket:
+            static_inputs["hidden_states"][batch_size:].zero_()
+        for key, value in (
+            ("text_temperature", text_temperature),
+            ("text_top_p", text_top_p),
+            ("text_top_k", text_top_k),
+            ("audio_temperature", audio_temperature),
+            ("audio_top_p", audio_top_p),
+            ("audio_top_k", audio_top_k),
+            ("seeds", seeds),
+            ("base_positions", base_positions),
+        ):
+            buf = static_inputs[key]
+            buf[:batch_size].copy_(value)
+            if batch_size < bucket:
+                buf[batch_size:].fill_(1 if buf.dtype.is_floating_point else 1)
+        graph.replay()
+        return stop_choice[:batch_size], codes[:batch_size]
+
+    @torch.no_grad()
+    def decode_frame(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        sample_text: Callable[[torch.Tensor], torch.Tensor],
+        sample_audio: Callable[[torch.Tensor, int], torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Decode one audio frame for the whole batch.
+
+        Args:
+            hidden_states: ``[batch, hidden]`` backbone last hidden states.
+            sample_text: maps ``[batch, 2]`` fp32 binary-head logits to a
+                ``[batch]`` long tensor of indices (0=continue, 1=stop).
+            sample_audio: maps (``[batch, audio_vocab]`` fp32 logits, channel)
+                to a ``[batch]`` long tensor of codes.
+
+        Returns:
+            ``(stop_choice [batch], codes [batch, n_vq])``. Codes are sampled
+            for every row regardless of the stop choice; the runner discards
+            frames of rows that chose stop, mirroring the upstream loop which
+            never emits a frame alongside ``audio_end``.
+        """
+        local_hidden = self.local_transformer.step(
+            hidden_states.to(dtype=self.dtype), 0
+        )
+        text_logits = F.linear(local_hidden, self.local_text_lm_head.weight)
+        stop_choice = sample_text(text_logits.float())
+
+        codes = []
+        current = local_hidden
+        for channel in range(self.n_vq):
+            head_weight = self._audio_embedding_weight(channel)
+            logits = F.linear(current, head_weight)
+            code = sample_audio(logits.float(), channel)
+            codes.append(code)
+            if channel + 1 < self.n_vq:
+                next_embed = F.embedding(code, head_weight)
+                current = self.local_transformer.step(
+                    next_embed.to(dtype=self.dtype), channel + 1
+                )
+        return stop_choice, torch.stack(codes, dim=-1)
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> None:
+        stacked_params_mapping = [
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        params_dict = dict(self.named_parameters())
+
+        for original_name, loaded_weight in weights:
+            name = original_name
+            if name.startswith("transformer."):
+                name = "model." + name[len("transformer.") :]
+
+            layer_id = get_layer_id(name)
+            if (
+                layer_id is not None
+                and hasattr(self.model, "start_layer")
+                and (
+                    layer_id < self.model.start_layer
+                    or layer_id >= self.model.end_layer
+                )
+            ):
+                continue
+            if "rotary_emb.inv_freq" in name:
+                continue
+
+            # Tied heads: the checkpoint may carry text_lm_head /
+            # audio_lm_heads tensors that alias embed_tokens /
+            # audio_embeddings; the embedding tables are authoritative here.
+            if name.startswith("text_lm_head.") or name.startswith("audio_lm_heads."):
+                continue
+
+            if name.startswith("audio_embeddings.") and name.endswith(".weight"):
+                mapped = self._map_audio_embedding_name(name)
+                if mapped is not None and mapped in params_dict:
+                    # The checkpoint table has audio_vocab_size rows while the
+                    # module reserves an extra (zeroed) pad row, so copy the
+                    # real rows directly instead of using the vocab loader.
+                    param = params_dict[mapped]
+                    rows = int(loaded_weight.shape[0])
+                    with torch.no_grad():
+                        param.data[:rows].copy_(
+                            loaded_weight.to(
+                                device=param.device, dtype=param.dtype
+                            )
+                        )
+                continue
+
+            if name.startswith("local_transformer.") or name.startswith(
+                "local_text_lm_head."
+            ):
+                param = params_dict.get(name)
+                if param is not None:
+                    self._load_param(param, loaded_weight)
+                else:
+                    logger.warning(
+                        "MOSS-TTS Local parameter %s not found", original_name
+                    )
+                continue
+
+            if name == "model.embed_tokens.weight":
+                mapped = "embedding_list.0.weight"
+                if mapped in params_dict:
+                    self._load_param(params_dict[mapped], loaded_weight)
+                # Fall through: the backbone's own embed_tokens also loads.
+
+            mapped_stacked = False
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                mapped_name = name.replace(weight_name, param_name)
+                if mapped_name.endswith(".bias") and mapped_name not in params_dict:
+                    mapped_stacked = True
+                    break
+                param = params_dict.get(mapped_name)
+                if param is None:
+                    break
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight, shard_id)
+                mapped_stacked = True
+                break
+            if mapped_stacked:
+                continue
+
+            if name.endswith(".bias") and name not in params_dict:
+                continue
+            param = params_dict.get(name)
+            if param is not None:
+                self._load_param(param, loaded_weight)
+            else:
+                logger.warning("MOSS-TTS Local parameter %s not found", original_name)
+
+        self._zero_audio_pad_rows()
+
+    def _zero_audio_pad_rows(self) -> None:
+        """Zero rows >= audio_vocab_size so pad codes embed to exactly zero."""
+        audio_vocab_size = int(self.config.audio_vocab_size)
+        with torch.no_grad():
+            for layer in self.embedding_list[1:]:
+                weight = getattr(layer, "weight", None)
+                if (
+                    isinstance(weight, torch.Tensor)
+                    and weight.shape[0] > audio_vocab_size
+                ):
+                    weight[audio_vocab_size:].zero_()
+
+    @staticmethod
+    def _map_audio_embedding_name(name: str) -> str | None:
+        try:
+            idx = int(name.split(".")[1]) + 1
+        except (IndexError, ValueError):
+            return None
+        return f"embedding_list.{idx}.weight"
+
+    @staticmethod
+    def _load_param(param: torch.nn.Parameter, loaded_weight: torch.Tensor) -> None:
+        weight_loader = getattr(param, "weight_loader", default_weight_loader)
+        weight_loader(param, loaded_weight)
+
+    def get_embed_and_head(self) -> tuple[list[Any], list[Any]]:
+        embed_weights = [
+            getattr(layer, "weight", None) for layer in self.embedding_list
+        ]
+        return embed_weights, [self.local_text_lm_head.weight]
+
+    def load_kv_cache_scales(self, quantization_param_path: str) -> None:
+        self.model.load_kv_cache_scales(quantization_param_path)
+
+
+EntryClass = MossTTSLocalSGLangModel

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -345,7 +345,7 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         audio_top_k: torch.Tensor,
         seeds: torch.Tensor,
         base_positions: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Branchless frame decode used both eagerly and under graph capture.
 
         ``base_positions`` is ``generation_steps * (n_vq + 1)``; channel
@@ -353,6 +353,12 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         text decision samples at ``base_positions``, matching the eager path.
         Repetition penalty is not supported here (the runner falls back to
         the eager path when a request enables it).
+
+        Returns ``(stop_choice, codes, feedback_embeds)`` where
+        ``feedback_embeds`` is the next backbone input embedding for a
+        continuing row — the assistant-slot text embedding plus all 12 code
+        embeddings, summed in the same channel order as
+        ``_prepare_multi_modal_inputs``.
         """
         local_hidden = self.local_transformer.step(
             hidden_states.to(dtype=self.dtype), 0
@@ -367,6 +373,10 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             positions=base_positions,
         )
 
+        slot_ids = torch.full_like(
+            seeds, int(self.config.audio_assistant_slot_token_id)
+        )
+        feedback = self.embedding_list[0](slot_ids)
         codes = []
         current = local_hidden
         for channel in range(self.n_vq):
@@ -381,12 +391,13 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
                 positions=base_positions + channel + 1,
             )
             codes.append(code)
+            code_embed = F.embedding(code, head_weight)
+            feedback = feedback + code_embed
             if channel + 1 < self.n_vq:
-                next_embed = F.embedding(code, head_weight)
                 current = self.local_transformer.step(
-                    next_embed.to(dtype=self.dtype), channel + 1
+                    code_embed.to(dtype=self.dtype), channel + 1
                 )
-        return stop_choice, torch.stack(codes, dim=-1)
+        return stop_choice, torch.stack(codes, dim=-1), feedback
 
     @torch.no_grad()
     def init_frame_decode_graphs(self, batch_sizes: list[int]) -> None:
@@ -401,9 +412,19 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         if not buckets:
             return
         device = self.device
-        self.local_transformer._ensure_kv_cache(max(buckets), device, self.dtype)
+        # The captured graphs hold raw pointers into the local KV buffers, so
+        # size them for the largest batch any path (graphed or eager fallback)
+        # can see and freeze them against reallocation.
+        max_eager_bs = int(self._decode_input_embedding.weight.shape[0])
+        self.local_transformer._ensure_kv_cache(
+            max(max(buckets), max_eager_bs), device, self.dtype
+        )
+        self.local_transformer.freeze_kv_cache()
         self._frame_graphs: dict[
-            int, tuple[Any, dict[str, torch.Tensor], torch.Tensor, torch.Tensor]
+            int,
+            tuple[
+                Any, dict[str, torch.Tensor], torch.Tensor, torch.Tensor, torch.Tensor
+            ],
         ] = {}
 
         for bucket in buckets:
@@ -438,8 +459,16 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
 
             graph = torch.cuda.CUDAGraph()
             with torch.cuda.graph(graph):
-                stop_choice, codes = self._decode_frame_graphable(**static_inputs)
-            self._frame_graphs[bucket] = (graph, static_inputs, stop_choice, codes)
+                stop_choice, codes, feedback = self._decode_frame_graphable(
+                    **static_inputs
+                )
+            self._frame_graphs[bucket] = (
+                graph,
+                static_inputs,
+                stop_choice,
+                codes,
+                feedback,
+            )
         logger.info(
             "MOSS-TTS Local frame-decode CUDA graphs captured for bs=%s", buckets
         )
@@ -462,13 +491,17 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         audio_top_k: torch.Tensor,
         seeds: torch.Tensor,
         base_positions: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Replay the captured frame decode for this batch (padded up to the
         nearest bucket; padding rows sample garbage that the caller discards).
+
+        The returned tensors are slices of the graph's static output buffers:
+        the caller must copy anything it keeps before the next replay (any
+        later prefill or decode step replays these graphs).
         """
         batch_size = hidden_states.shape[0]
         bucket = min(b for b in self._frame_graphs if b >= batch_size)
-        graph, static_inputs, stop_choice, codes = self._frame_graphs[bucket]
+        graph, static_inputs, stop_choice, codes, feedback = self._frame_graphs[bucket]
 
         static_inputs["hidden_states"][:batch_size].copy_(
             hidden_states.to(dtype=self.dtype)
@@ -490,7 +523,7 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             if batch_size < bucket:
                 buf[batch_size:].fill_(1 if buf.dtype.is_floating_point else 1)
         graph.replay()
-        return stop_choice[:batch_size], codes[:batch_size]
+        return stop_choice[:batch_size], codes[:batch_size], feedback[:batch_size]
 
     @torch.no_grad()
     def decode_frame(

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -187,9 +187,9 @@ class _BatchedReferenceEncoder:
                 )
                 for path in unique_paths:
                     try:
-                        results[path] = self._processor.encode_audios_from_path(
-                            [path]
-                        )[0]
+                        results[path] = self._processor.encode_audios_from_path([path])[
+                            0
+                        ]
                     except Exception as exc:
                         results[path] = exc
             for path, future in batch:

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -219,7 +219,11 @@ class _BatchedReferenceEncoder:
             for path, future in batch:
                 outcome = results.get(path)
                 if isinstance(outcome, Exception):
-                    future.set_exception(outcome)
+                    # Fresh exception per future: a shared instance would be
+                    # mutated concurrently by every waiter's traceback raise.
+                    future.set_exception(
+                        RuntimeError(f"reference encode failed for {path}: {outcome}")
+                    )
                 elif outcome is None:
                     future.set_exception(
                         RuntimeError(f"reference encode produced no codes: {path}")

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -39,12 +39,11 @@ _MOSS_TTS_LOCAL_INSTALL_HINT = (
 )
 
 # NOTE: the preprocessing and vocoder stages each load their own processor
-# (and thus their own ~4.3 GB bf16 codec instance) even though both run in the
-# pipeline process. The codec's chunked decode flips module-global streaming
-# state (`model.streaming()`), so a decode on a shared instance corrupts any
-# concurrently running reference encode; with separate instances the encoder
-# side only ever runs stateless forwards and the streaming decode stays
-# confined to the single-threaded vocoder batch loop.
+# (and thus their own ~4.3 GB bf16 codec instance). The codec's chunked decode
+# flips module-global streaming state (`model.streaming()`), so a decode on a
+# shared instance corrupts any concurrently running reference encode; with
+# separate instances the encoder side only ever runs stateless forwards and the
+# streaming decode stays confined to the single-threaded vocoder batch loop.
 
 
 def load_state(payload: StagePayload) -> MossTTSLocalState:
@@ -66,23 +65,19 @@ def _normalize_processor_config(processor: Any) -> None:
             setattr(model_config, attr, default)
 
 
-def _resolve_codec_device(device: str | None) -> str:
+def _resolve_codec_device(device: str | None, gpu_id: int | None) -> str:
     """Pick the codec GPU for the preprocessing/vocoder stages.
 
     The ~1B-param codec encoder costs ~0.25 GPU-seconds per reference, which
-    at concurrency 16 starves the AR engine when both share one device. With
-    an explicit ``device`` that placement is honored; otherwise the codec
-    tensors land on the second visible GPU when one exists, else GPU 0. Only
-    the module placement moves — the stages stay in the single pipeline
-    process group on GPU 0 (one process group must not span GPUs).
+    at concurrency 16 starves the AR engine when both share one device.
+    The default config passes an explicit ``device`` so the second-GPU codec
+    placement is visible in the pipeline config. ``gpu_id`` remains a fallback
+    for custom colocated configs and launcher-injected runtime defaults.
     """
     if device:
         return device
-    try:
-        if torch.cuda.device_count() > 1:
-            return "cuda:1"
-    except Exception:
-        pass
+    if gpu_id is not None:
+        return f"cuda:{int(gpu_id)}"
     return "cuda:0"
 
 
@@ -236,11 +231,12 @@ def create_preprocessing_executor(
     model_path: str,
     *,
     device: str | None = None,
+    gpu_id: int | None = None,
     max_concurrency: int = 16,
     encode_batch_size: int = 8,
     encode_batch_wait_ms: int = 4,
 ) -> SimpleScheduler:
-    device = _resolve_codec_device(device)
+    device = _resolve_codec_device(device, gpu_id)
     processor = _load_moss_tts_local_processor(model_path, device=device)
     reference_encoder = _BatchedReferenceEncoder(
         processor,
@@ -372,10 +368,11 @@ def create_vocoder_executor(
     model_path: str,
     *,
     device: str | None = None,
+    gpu_id: int | None = None,
     max_batch_size: int = 8,
     max_batch_wait_ms: int = 2,
 ) -> SimpleScheduler:
-    device = _resolve_codec_device(device)
+    device = _resolve_codec_device(device, gpu_id)
     processor = _load_moss_tts_local_processor(model_path, device=device)
 
     def _prepare_codes(

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -1,0 +1,419 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stage factories for the MOSS-TTS Local (v1.5) pipeline."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import logging
+import queue
+import threading
+from typing import Any
+
+import torch
+
+from sglang_omni.models.moss_tts.stages import (
+    _load_moss_processor_class,
+    _moss_transformers_processor_compat,
+    _resolve_checkpoint,
+)
+from sglang_omni.models.moss_tts_local.payload_types import (
+    MossTTSLocalState,
+    moss_tts_local_special_token_defaults,
+)
+from sglang_omni.models.moss_tts_local.request_builders import (
+    cleanup_prepared_moss_tts_local_request,
+    make_moss_tts_local_scheduler_adapters,
+    preprocess_moss_tts_local_payload,
+    set_moss_tts_local_preprocessing_context,
+)
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+from sglang_omni.utils.audio_payload import audio_waveform_payload
+
+logger = logging.getLogger(__name__)
+
+_MOSS_TTS_LOCAL_INSTALL_HINT = (
+    "MOSS-TTS Local support requires the upstream custom Transformers code. "
+    "Launch with trust_remote_code=True and make sure the checkpoint can load "
+    "OpenMOSS-Team/MOSS-Audio-Tokenizer-v2."
+)
+
+# NOTE: the preprocessing and vocoder stages each load their own processor
+# (and thus their own ~4.3 GB bf16 codec instance) even though both run in the
+# pipeline process. The codec's chunked decode flips module-global streaming
+# state (`model.streaming()`), so a decode on a shared instance corrupts any
+# concurrently running reference encode; with separate instances the encoder
+# side only ever runs stateless forwards and the streaming decode stays
+# confined to the single-threaded vocoder batch loop.
+
+
+def load_state(payload: StagePayload) -> MossTTSLocalState:
+    return MossTTSLocalState.from_dict(payload.data)
+
+
+def store_state(payload: StagePayload, state: MossTTSLocalState) -> StagePayload:
+    payload.data = state.to_dict()
+    return payload
+
+
+def _normalize_processor_config(processor: Any) -> None:
+    model_config = getattr(processor, "model_config", None)
+    if model_config is None:
+        return
+    audio_vocab_size = int(getattr(model_config, "audio_vocab_size", 1024) or 1024)
+    for attr, default in moss_tts_local_special_token_defaults(audio_vocab_size):
+        if getattr(model_config, attr, None) is None:
+            setattr(model_config, attr, default)
+
+
+def _resolve_codec_device(device: str | None) -> str:
+    """Pick the codec GPU for the preprocessing/vocoder stages.
+
+    The ~1B-param codec encoder costs ~0.25 GPU-seconds per reference, which
+    at concurrency 16 starves the AR engine when both share one device. With
+    an explicit ``device`` that placement is honored; otherwise the codec
+    tensors land on the second visible GPU when one exists, else GPU 0. Only
+    the module placement moves — the stages stay in the single pipeline
+    process group on GPU 0 (one process group must not span GPUs).
+    """
+    if device:
+        return device
+    try:
+        if torch.cuda.device_count() > 1:
+            return "cuda:1"
+    except Exception:
+        pass
+    return "cuda:0"
+
+
+def _load_moss_tts_local_processor(model_path: str, *, device: str) -> Any:
+    checkpoint_dir = _resolve_checkpoint(model_path)
+    logger.info(
+        "Loading MOSS-TTS Local processor from %s on %s", checkpoint_dir, device
+    )
+    try:
+        with _moss_transformers_processor_compat():
+            processor_cls = _load_moss_processor_class(checkpoint_dir)
+            processor = processor_cls.from_pretrained(
+                checkpoint_dir,
+                trust_remote_code=True,
+            )
+    except Exception as exc:
+        raise RuntimeError(_MOSS_TTS_LOCAL_INSTALL_HINT) from exc
+
+    _normalize_processor_config(processor)
+    audio_tokenizer = getattr(processor, "audio_tokenizer", None)
+    if audio_tokenizer is not None:
+        if hasattr(audio_tokenizer, "eval"):
+            audio_tokenizer.eval()
+        if hasattr(audio_tokenizer, "to"):
+            # Device move only: the v2 codec manages its own dtypes (bf16
+            # encoder/decoder with an fp32 quantizer); a blanket dtype cast
+            # would corrupt the quantizer codebooks.
+            audio_tokenizer.to(device)
+    return processor
+
+
+def _build_usage(state: MossTTSLocalState) -> dict[str, Any] | None:
+    if not (state.prompt_tokens or state.completion_tokens or state.engine_time_s):
+        return None
+    usage = {
+        "prompt_tokens": int(state.prompt_tokens),
+        "completion_tokens": int(state.completion_tokens),
+        "total_tokens": int(state.prompt_tokens + state.completion_tokens),
+    }
+    if state.engine_time_s:
+        usage["engine_time_s"] = round(float(state.engine_time_s), 6)
+    return usage
+
+
+class _BatchedReferenceEncoder:
+    """Coalesces concurrent reference-audio encodes into batched codec calls.
+
+    Each request needs its reference run through the ~1B-param codec encoder
+    (~0.25 GPU-seconds). The preprocessing workers call :meth:`encode`
+    concurrently; a single daemon thread drains the queue and encodes up to
+    ``max_batch_size`` files in one ``batch_encode`` forward, which costs
+    barely more than a single encode. Failures fall back to per-item encodes
+    so one bad file only fails its own request.
+    """
+
+    def __init__(
+        self,
+        processor: Any,
+        *,
+        max_batch_size: int = 8,
+        max_batch_wait_ms: int = 4,
+    ) -> None:
+        self._processor = processor
+        self._max_batch_size = max(int(max_batch_size), 1)
+        self._max_wait_s = max(float(max_batch_wait_ms), 0.0) / 1000.0
+        self._queue: queue.Queue[tuple[str, concurrent.futures.Future]] = queue.Queue()
+        self._thread = threading.Thread(
+            target=self._worker, name="moss-local-ref-encode", daemon=True
+        )
+        self._thread.start()
+
+    def encode(self, path: str) -> torch.Tensor:
+        """Encode one reference file; blocks until its batch completes."""
+        future: concurrent.futures.Future = concurrent.futures.Future()
+        self._queue.put((str(path), future))
+        return future.result()
+
+    def _drain_batch(self) -> list[tuple[str, concurrent.futures.Future]]:
+        batch = [self._queue.get()]
+        while len(batch) < self._max_batch_size:
+            try:
+                if self._max_wait_s > 0:
+                    batch.append(self._queue.get(timeout=self._max_wait_s))
+                else:
+                    batch.append(self._queue.get_nowait())
+            except queue.Empty:
+                break
+        return batch
+
+    def _worker(self) -> None:
+        while True:
+            batch = self._drain_batch()
+            unique_paths = list(dict.fromkeys(path for path, _ in batch))
+            results: dict[str, Any] = {}
+            try:
+                encoded = self._processor.encode_audios_from_path(unique_paths)
+                results = dict(zip(unique_paths, encoded))
+            except Exception:
+                logger.exception(
+                    "MOSS-TTS Local batched reference encode failed; "
+                    "retrying per item"
+                )
+                for path in unique_paths:
+                    try:
+                        results[path] = self._processor.encode_audios_from_path(
+                            [path]
+                        )[0]
+                    except Exception as exc:
+                        results[path] = exc
+            for path, future in batch:
+                outcome = results.get(path)
+                if isinstance(outcome, Exception):
+                    future.set_exception(outcome)
+                elif outcome is None:
+                    future.set_exception(
+                        RuntimeError(f"reference encode produced no codes: {path}")
+                    )
+                else:
+                    future.set_result(outcome)
+
+
+def create_preprocessing_executor(
+    model_path: str,
+    *,
+    device: str | None = None,
+    max_concurrency: int = 16,
+    encode_batch_size: int = 8,
+    encode_batch_wait_ms: int = 4,
+) -> SimpleScheduler:
+    device = _resolve_codec_device(device)
+    processor = _load_moss_tts_local_processor(model_path, device=device)
+    reference_encoder = _BatchedReferenceEncoder(
+        processor,
+        max_batch_size=encode_batch_size,
+        max_batch_wait_ms=encode_batch_wait_ms,
+    )
+    set_moss_tts_local_preprocessing_context(
+        processor=processor, reference_encoder=reference_encoder
+    )
+    # Reference encoding runs through the ~1B-param causal codec encoder, so
+    # unlike MOSS Delay the audio tokenizer must live on the GPU; threads
+    # release the GIL during the codec forward, keeping the AR engine fed.
+    return SimpleScheduler(
+        preprocess_moss_tts_local_payload,
+        abort_callback=cleanup_prepared_moss_tts_local_request,
+        max_concurrency=max_concurrency,
+    )
+
+
+def create_sglang_tts_engine_executor(
+    model_path: str,
+    *,
+    device: str = "cuda:0",
+    gpu_id: int | None = None,
+    dtype: str = "bfloat16",
+    server_args_overrides: dict[str, Any] | None = None,
+) -> Any:
+    from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
+    from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
+    from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+    from sglang_omni.scheduling.sglang_backend import (
+        SGLangOutputProcessor,
+        build_sglang_server_args,
+    )
+
+    checkpoint_dir = _resolve_checkpoint(model_path)
+    if gpu_id is not None:
+        device = f"cuda:{gpu_id}"
+    gpu_id = int(device.split(":")[-1]) if ":" in device else 0
+
+    overrides: dict[str, Any] = {
+        "dtype": dtype,
+        "cuda_graph_bs": [1, 2, 4, 8, 16],
+        "cuda_graph_max_bs": 16,
+        "disable_cuda_graph": False,
+        "disable_overlap_schedule": True,
+        "enable_torch_compile": False,
+        "max_prefill_tokens": 8192,
+        "max_running_requests": 16,
+        # Leave headroom for the two ~4.3 GB bf16 codec instances plus their
+        # activations: on multi-GPU hosts the codec lives on the second GPU
+        # (0.6 of an 80 GB card still gives the 4B backbone a ~35 GB KV pool);
+        # on a single GPU everything co-locates, so back off further.
+        "mem_fraction_static": 0.6 if torch.cuda.device_count() > 1 else 0.5,
+        "sampling_backend": "pytorch",
+        "torch_compile_max_bs": 16,
+        "trust_remote_code": True,
+    }
+    if server_args_overrides:
+        overrides.update(server_args_overrides)
+
+    server_args = build_sglang_server_args(
+        checkpoint_dir,
+        context_length=8192,
+        **overrides,
+    )
+
+    want_cuda_graph = not bool(getattr(server_args, "disable_cuda_graph", False))
+    if want_cuda_graph:
+        server_args.disable_cuda_graph = True
+
+    (
+        model_worker,
+        tree_cache,
+        req_to_token_pool,
+        token_to_kv_pool_allocator,
+        prefill_mgr,
+        decode_mgr,
+        model_config,
+    ) = create_sglang_infrastructure(
+        server_args,
+        gpu_id,
+        model_arch_override="MossTTSLocalSGLangModel",
+    )
+
+    if want_cuda_graph:
+        server_args.disable_cuda_graph = False
+
+    model = model_worker.model_runner.model
+    if want_cuda_graph:
+        model_worker.model_runner.init_device_graphs()
+        # Also graph the per-frame local-transformer decode (1 + n_vq
+        # micro-steps and 13 seeded sampling passes per frame): eager it is
+        # kernel-launch-bound at ~22 ms/frame independent of batch size.
+        model.init_frame_decode_graphs(
+            list(overrides.get("cuda_graph_bs") or [1, 2, 4, 8, 16])
+        )
+
+    output_proc = SGLangOutputProcessor(
+        capture_hidden=False,
+        capture_hidden_layers=None,
+        model=model,
+    )
+    request_builder, result_adapter = make_moss_tts_local_scheduler_adapters(
+        model=model
+    )
+
+    return OmniScheduler(
+        tp_worker=model_worker,
+        tree_cache=tree_cache,
+        req_to_token_pool=req_to_token_pool,
+        token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+        server_args=server_args,
+        model_config=model_config,
+        prefill_manager=prefill_mgr,
+        decode_manager=decode_mgr,
+        model_runner=MossTTSLocalModelRunner(model_worker, output_proc),
+        request_builder=request_builder,
+        result_adapter=result_adapter,
+        abort_callback=cleanup_prepared_moss_tts_local_request,
+    )
+
+
+def create_tts_engine_executor(*args, **kwargs) -> Any:
+    return create_sglang_tts_engine_executor(*args, **kwargs)
+
+
+def create_vocoder_executor(
+    model_path: str,
+    *,
+    device: str | None = None,
+    max_batch_size: int = 8,
+    max_batch_wait_ms: int = 2,
+) -> SimpleScheduler:
+    device = _resolve_codec_device(device)
+    processor = _load_moss_tts_local_processor(model_path, device=device)
+
+    def _prepare_codes(payload: StagePayload) -> tuple[MossTTSLocalState, torch.Tensor]:
+        state = load_state(payload)
+        if state.audio_codes is None:
+            raise RuntimeError("MOSS-TTS Local vocoder requires audio_codes")
+        codes = torch.as_tensor(state.audio_codes, dtype=torch.long)
+        if codes.numel() == 0:
+            raise RuntimeError("MOSS-TTS Local generated no audio codes")
+        return state, codes
+
+    def _store_vocoder_result(
+        payload: StagePayload,
+        state: MossTTSLocalState,
+        wav: torch.Tensor,
+        sample_rate: int,
+    ) -> StagePayload:
+        # The v2 codec is natively stereo: keep the [channels, samples]
+        # layout end to end so the client receives a 2-channel waveform.
+        audio_payload = audio_waveform_payload(
+            wav, source_hint="MOSS-TTS Local", keep_channels=True
+        )
+        state.audio_codes = None
+        state.sample_rate = int(sample_rate)
+        payload = store_state(payload, state)
+        payload.data.update(audio_payload)
+        payload.data["sample_rate"] = state.sample_rate
+        payload.data["modality"] = "audio"
+        usage = _build_usage(state)
+        if usage is not None:
+            payload.data["usage"] = usage
+        return payload
+
+    def _sample_rate() -> int:
+        return int(
+            getattr(getattr(processor, "model_config", None), "sampling_rate", 0)
+            or getattr(
+                getattr(getattr(processor, "audio_tokenizer", None), "config", None),
+                "sampling_rate",
+                0,
+            )
+            or 48000
+        )
+
+    def _vocode_batch(payloads: list[StagePayload]) -> list[StagePayload]:
+        prepared = [_prepare_codes(payload) for payload in payloads]
+        codes_list = [codes for _, codes in prepared]
+        decoded = processor.decode_audio_codes(codes_list)
+        if len(decoded) != len(payloads):
+            raise RuntimeError(
+                "MOSS-TTS Local vocoder returned "
+                f"{len(decoded)} waveforms for {len(payloads)} requests"
+            )
+        sample_rate = _sample_rate()
+        results = []
+        for payload, (state, _), wav in zip(payloads, prepared, decoded):
+            wav = torch.as_tensor(wav).detach().to("cpu")
+            results.append(_store_vocoder_result(payload, state, wav, sample_rate))
+        return results
+
+    def _vocode(payload: StagePayload) -> StagePayload:
+        return _vocode_batch([payload])[0]
+
+    return SimpleScheduler(
+        _vocode,
+        batch_compute_fn=_vocode_batch,
+        max_batch_size=max_batch_size,
+        max_batch_wait_ms=max_batch_wait_ms,
+    )

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -138,6 +138,13 @@ class _BatchedReferenceEncoder:
     so one bad file only fails its own request.
     """
 
+    # Mirrors the Higgs reference-audio cap: bounds both encoder runtime and
+    # the batch-padding memory amplification.
+    MAX_REFERENCE_SECONDS = 100.0
+    # An encode batch takes well under a second; a result this late means the
+    # worker died or wedged, so fail the request instead of hanging the slot.
+    ENCODE_TIMEOUT_S = 120.0
+
     def __init__(
         self,
         processor: Any,
@@ -154,11 +161,28 @@ class _BatchedReferenceEncoder:
         )
         self._thread.start()
 
+    @classmethod
+    def _check_reference_duration(cls, path: str) -> None:
+        try:
+            import torchaudio
+
+            info = torchaudio.info(path)
+            duration = info.num_frames / max(int(info.sample_rate), 1)
+        except Exception:
+            return  # unreadable files fail with a clearer error in the codec
+        if duration > cls.MAX_REFERENCE_SECONDS:
+            raise ValueError(
+                f"reference audio is {duration:.1f}s long; the limit is "
+                f"{cls.MAX_REFERENCE_SECONDS:.0f}s"
+            )
+
     def encode(self, path: str) -> torch.Tensor:
         """Encode one reference file; blocks until its batch completes."""
+        path = str(path)
+        self._check_reference_duration(path)
         future: concurrent.futures.Future = concurrent.futures.Future()
-        self._queue.put((str(path), future))
-        return future.result()
+        self._queue.put((path, future))
+        return future.result(timeout=self.ENCODE_TIMEOUT_S)
 
     def _drain_batch(self) -> list[tuple[str, concurrent.futures.Future]]:
         batch = [self._queue.get()]
@@ -350,13 +374,17 @@ def create_vocoder_executor(
     device = _resolve_codec_device(device)
     processor = _load_moss_tts_local_processor(model_path, device=device)
 
-    def _prepare_codes(payload: StagePayload) -> tuple[MossTTSLocalState, torch.Tensor]:
+    def _prepare_codes(
+        payload: StagePayload,
+    ) -> tuple[MossTTSLocalState, torch.Tensor | None]:
         state = load_state(payload)
         if state.audio_codes is None:
             raise RuntimeError("MOSS-TTS Local vocoder requires audio_codes")
         codes = torch.as_tensor(state.audio_codes, dtype=torch.long)
         if codes.numel() == 0:
-            raise RuntimeError("MOSS-TTS Local generated no audio codes")
+            # Immediate stop decision: emit no audio so only this request
+            # fails downstream instead of poisoning the whole decode batch.
+            return state, None
         return state, codes
 
     def _store_vocoder_result(
@@ -394,17 +422,18 @@ def create_vocoder_executor(
 
     def _vocode_batch(payloads: list[StagePayload]) -> list[StagePayload]:
         prepared = [_prepare_codes(payload) for payload in payloads]
-        codes_list = [codes for _, codes in prepared]
-        decoded = processor.decode_audio_codes(codes_list)
-        if len(decoded) != len(payloads):
-            raise RuntimeError(
-                "MOSS-TTS Local vocoder returned "
-                f"{len(decoded)} waveforms for {len(payloads)} requests"
-            )
+        codes_list = [codes for _, codes in prepared if codes is not None]
+        decoded = iter(processor.decode_audio_codes(codes_list))
         sample_rate = _sample_rate()
         results = []
-        for payload, (state, _), wav in zip(payloads, prepared, decoded):
-            wav = torch.as_tensor(wav).detach().to("cpu")
+        for payload, (state, codes) in zip(payloads, prepared):
+            if codes is None:
+                # No audio fields: the client surfaces a per-request
+                # "no audio output" error without failing batch peers.
+                state.audio_codes = None
+                results.append(store_state(payload, state))
+                continue
+            wav = torch.as_tensor(next(decoded)).detach().to("cpu")
             results.append(_store_vocoder_result(payload, state, wav, sample_rate))
         return results
 

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -724,10 +724,11 @@ def _select_speech_audio_delta(
     if audio.ndim > 1:
         audio = audio.squeeze()
     if audio.ndim > 1:
-        if audio.shape[0] < audio.shape[-1]:
-            audio = audio[0]
-        else:
-            audio = audio[:, 0]
+        # Streaming chunks are mono; downmix multi-channel payloads
+        # (e.g. the 48 kHz stereo MOSS-TTS Local codec) instead of
+        # silently dropping channels.
+        channel_axis = 0 if audio.shape[0] < audio.shape[-1] else -1
+        audio = audio.mean(axis=channel_axis).astype("float32")
 
     total_samples = int(audio.shape[-1]) if audio.ndim else 0
     if not is_terminal:

--- a/sglang_omni/utils/audio_payload.py
+++ b/sglang_omni/utils/audio_payload.py
@@ -15,15 +15,25 @@ def audio_waveform_payload(
     sample_rate: int | None = None,
     modality: str | None = None,
     source_hint: str = "audio",
+    keep_channels: bool = False,
 ) -> dict[str, Any]:
+    """Serialize a waveform into the relay payload format.
+
+    With ``keep_channels`` a rank-2 ``[channels, samples]`` waveform keeps its
+    shape (for natively multi-channel codecs); otherwise it is flattened to
+    mono-style rank-1, preserving the historical behavior.
+    """
     if isinstance(audio, torch.Tensor):
-        audio = audio.detach().float().cpu().reshape(-1).numpy()
+        audio = audio.detach().float().cpu().numpy()
     try:
-        array = np.asarray(audio, dtype=np.float32).reshape(-1)
+        array = np.asarray(audio, dtype=np.float32)
+        if not (keep_channels and array.ndim == 2):
+            array = array.reshape(-1)
     except (TypeError, ValueError) as exc:
         raise TypeError(
             f"Unsupported {source_hint} audio output type: {type(audio)}"
         ) from exc
+    array = np.ascontiguousarray(array)
     payload: dict[str, Any] = {
         "audio_waveform": array.tobytes(),
         "audio_waveform_shape": list(array.shape),

--- a/sglang_omni/utils/hf.py
+++ b/sglang_omni/utils/hf.py
@@ -26,6 +26,7 @@ from transformers.utils.hub import cached_file
 _CONFIG_MODEL_TYPE_TO_ARCH = {
     "moss_tts_delay": "MossTTSDelayModel",
     "moss_tts_delay_with_codec": "MossTTSDelayWithCodec",
+    "moss_tts_local": "MossTTSLocalModel",
     "qwen3_tts": "Qwen3TTSForConditionalGeneration",
     "voxtral_tts": "VoxtralTTSForConditionalGeneration",
 }

--- a/tests/unit_test/moss_tts_local/__init__.py
+++ b/tests/unit_test/moss_tts_local/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -365,6 +365,29 @@ def test_audio_repetition_penalty_matches_upstream_semantics():
     )
 
 
+def test_row_radix_token_ids_hash_rows_and_keep_eos():
+    from sglang_omni.models.moss_tts.request_builders import build_row_cache_key_ids
+    from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
+
+    end_id = 151670
+    slot_id = 151656
+    rows = torch.full((3, N_VQ + 1), 7, dtype=torch.long)
+    rows[:, 0] = torch.tensor([slot_id, end_id, slot_id])
+    rows[2, 1:] = torch.arange(N_VQ)
+    next_text = rows[:, 0].clone()
+
+    out = MossTTSLocalModelRunner._row_radix_token_ids(rows, next_text, end_id)
+    expected = [k % 151643 for k in build_row_cache_key_ids(rows)]
+    assert int(out[1]) == end_id  # stop decision keeps the raw eos id
+    assert int(out[0]) == expected[0]
+    assert int(out[2]) == expected[2]
+    assert int(out[0]) != int(out[2])  # different codes -> different keys
+    assert int(out[0]) != slot_id  # no longer the constant slot id
+    # Generated ids must stay inside the vocab: the scheduler finishes any
+    # request whose output id crosses the vocab boundary.
+    assert all(0 <= int(v) < 151936 for v in out)
+
+
 def test_gather_rep_histories_excludes_prompt_and_inactive_rows():
     from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
 

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -365,6 +365,120 @@ def test_audio_repetition_penalty_matches_upstream_semantics():
     )
 
 
+def test_gather_rep_histories_excludes_prompt_and_inactive_rows():
+    from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
+
+    class _Data:
+        def __init__(self, rows):
+            self.output_rows = rows
+
+    row = torch.cat([torch.tensor([151656]), torch.arange(N_VQ, dtype=torch.long)])
+    active = _Data([row, row + 0])
+    inactive = _Data([row])
+    empty = _Data([])
+
+    histories = MossTTSLocalModelRunner._gather_rep_histories(
+        [active, inactive, empty], [1.5, 1.0, 1.5], torch.device("cpu")
+    )
+    assert histories is not None
+    assert histories[0].shape == (2, N_VQ)  # generated frames only, channel cols
+    assert histories[1] is None  # unit penalty -> skipped
+    assert histories[2] is None  # no frames yet
+    # All penalties at 1.0 -> no history gathering at all.
+    assert (
+        MossTTSLocalModelRunner._gather_rep_histories(
+            [active], [1.0], torch.device("cpu")
+        )
+        is None
+    )
+
+
+def test_build_generation_kwargs_precedence():
+    # Direct field names apply tts_params-then-params (params wins, matching
+    # the MOSS Delay semantics); both override the explicit generic aliases.
+    kwargs = build_generation_kwargs(
+        {"temperature": 0.5, "audio_temperature": 1.2},
+        tts_params={
+            "explicit_generation_params": ["temperature"],
+            "audio_temperature": 1.9,
+        },
+    )
+    assert kwargs["text_temperature"] == 0.5
+    assert kwargs["audio_temperature"] == 1.2
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_decode_frame_graphed_matches_branchless_eager():
+    """The captured frame graph must reproduce the branchless eager decode."""
+    from sglang_omni.models.moss_tts_local.local_transformer import (
+        sample_seeded_branchless,
+    )
+
+    torch.manual_seed(11)
+    device = torch.device("cuda")
+    module = MossTTSLocalTransformer(
+        hidden_size=64,
+        num_heads=4,
+        inner_size=96,
+        num_layers=1,
+        max_positions=N_VQ + 1,
+        rope_base=1_000_000.0,
+    ).to(device=device, dtype=torch.bfloat16)
+    tables = [
+        torch.randn(64, 64, device=device, dtype=torch.bfloat16) for _ in range(N_VQ)
+    ]
+
+    def frame(hidden, seeds, base):
+        current = module.step(hidden, 0)
+        codes = []
+        for channel in range(N_VQ):
+            logits = (current.float() @ tables[channel].float().T)[:, :32]
+            code = sample_seeded_branchless(
+                logits,
+                temperature=torch.full((hidden.shape[0],), 1.7, device=device),
+                top_p=torch.full((hidden.shape[0],), 0.8, device=device),
+                top_k=torch.full(
+                    (hidden.shape[0],), 25, device=device, dtype=torch.long
+                ),
+                seeds=seeds,
+                positions=base + channel + 1,
+            )
+            codes.append(code)
+            if channel + 1 < N_VQ:
+                embed = torch.nn.functional.embedding(code, tables[channel][:32])
+                current = module.step(embed.to(torch.bfloat16), channel + 1)
+        return torch.stack(codes, dim=-1)
+
+    batch = 4
+    static_hidden = torch.zeros(batch, 64, device=device, dtype=torch.bfloat16)
+    static_seeds = torch.zeros(batch, device=device, dtype=torch.long)
+    static_base = torch.zeros(batch, device=device, dtype=torch.long)
+
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(2):
+            frame(static_hidden, static_seeds, static_base)
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graphed_codes = frame(static_hidden, static_seeds, static_base)
+
+    hidden = torch.randn(batch, 64, device=device, dtype=torch.bfloat16)
+    seeds = torch.arange(batch, device=device, dtype=torch.long) * 999
+    base = torch.full((batch,), 13, device=device, dtype=torch.long)
+
+    static_hidden.copy_(hidden)
+    static_seeds.copy_(seeds)
+    static_base.copy_(base)
+    graph.replay()
+    from_graph = graphed_codes.clone()
+
+    eager = frame(hidden, seeds, base)
+    torch.testing.assert_close(from_graph, eager)
+
+
 def test_batched_reference_encoder_coalesces_and_isolates_errors():
     import threading
 

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import struct
-import types
 
 import numpy as np
 import pytest
@@ -60,8 +59,7 @@ def _reference_full_forward(
     head_dim = module.head_dim
 
     inv_freq = 1.0 / (
-        1_000_000.0
-        ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim)
+        1_000_000.0 ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim)
     )
     positions = torch.arange(seq, dtype=torch.float32)
     freqs = torch.outer(positions, inv_freq)
@@ -110,9 +108,7 @@ def test_local_transformer_incremental_matches_full_recompute(num_layers: int):
     inputs = torch.randn(batch, seq, 64)
 
     reference = _reference_full_forward(module, inputs)
-    stepped = torch.stack(
-        [module.step(inputs[:, t], t) for t in range(seq)], dim=1
-    )
+    stepped = torch.stack([module.step(inputs[:, t], t) for t in range(seq)], dim=1)
     torch.testing.assert_close(stepped, reference, rtol=1e-4, atol=1e-5)
 
 
@@ -164,9 +160,10 @@ def test_registry_resolves_local_architecture():
 
 
 def test_pipeline_stage_wiring():
-    stages = {stage.name: stage for stage in MossTTSLocalPipelineConfig.model_fields[
-        "stages"
-    ].default}
+    stages = {
+        stage.name: stage
+        for stage in MossTTSLocalPipelineConfig.model_fields["stages"].default
+    }
     assert set(stages) == {"preprocessing", "tts_engine", "vocoder"}
     assert stages["preprocessing"].next == "tts_engine"
     assert stages["tts_engine"].next == "vocoder"
@@ -307,9 +304,7 @@ def test_preprocess_and_result_adapter():
             engine_start_s=0.0,
         )
         data.output_rows = [
-            torch.cat(
-                [torch.tensor([151656]), torch.arange(N_VQ, dtype=torch.long)]
-            )
+            torch.cat([torch.tensor([151656]), torch.arange(N_VQ, dtype=torch.long)])
             for _ in range(3)
         ]
         result = apply_sglang_moss_tts_local_result(payload, data)
@@ -343,9 +338,7 @@ def test_result_adapter_empty_generation():
 
 
 def test_audio_repetition_penalty_matches_upstream_semantics():
-    from sglang_omni.models.moss_tts_local.model_runner import (
-        MossTTSLocalModelRunner,
-    )
+    from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
 
     logits = torch.tensor(
         [[2.0, -1.0, 0.5, 3.0], [1.0, 1.0, 1.0, 1.0]], dtype=torch.float32

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -1,0 +1,493 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import struct
+import types
+
+import numpy as np
+import pytest
+import torch
+
+from sglang_omni.client.audio import encode_audio, encode_wav
+from sglang_omni.models.moss_tts_local.config import MossTTSLocalPipelineConfig
+from sglang_omni.models.moss_tts_local.local_transformer import (
+    MossTTSLocalTransformer,
+    _rotate_half_interleaved,
+)
+from sglang_omni.models.moss_tts_local.payload_types import (
+    MossTTSLocalState,
+    moss_tts_local_special_token_defaults,
+)
+from sglang_omni.models.moss_tts_local.request_builders import (
+    MossTTSLocalSGLangRequestData,
+    apply_sglang_moss_tts_local_result,
+    build_generation_kwargs,
+    build_moss_tts_local_state,
+    clear_moss_tts_local_preprocessing_context,
+    preprocess_moss_tts_local_payload,
+    set_moss_tts_local_preprocessing_context,
+)
+from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.utils.audio_payload import audio_waveform_payload
+
+N_VQ = 12
+
+
+# ---------------------------------------------------------------------------
+# Local transformer numerics
+# ---------------------------------------------------------------------------
+
+
+def _hf_rotate_half(hidden_states: torch.Tensor) -> torch.Tensor:
+    """Verbatim port of the upstream gpt2_decoder.rotate_half."""
+    even = hidden_states[..., ::2]
+    odd = hidden_states[..., 1::2]
+    return torch.stack((-odd, even), dim=-1).reshape_as(hidden_states)
+
+
+def _reference_full_forward(
+    module: MossTTSLocalTransformer, inputs: torch.Tensor
+) -> torch.Tensor:
+    """Full-sequence forward replicating the upstream eager math.
+
+    ``inputs`` is ``[batch, seq, hidden]``; positions are 0..seq-1 with a
+    causal mask, interleaved RoPE, fp32 softmax via explicit matmuls.
+    """
+    batch, seq, hidden = inputs.shape
+    num_heads = module.num_heads
+    head_dim = module.head_dim
+
+    inv_freq = 1.0 / (
+        1_000_000.0
+        ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim)
+    )
+    positions = torch.arange(seq, dtype=torch.float32)
+    freqs = torch.outer(positions, inv_freq)
+    cos = freqs.cos().repeat_interleave(2, dim=-1)
+    sin = freqs.sin().repeat_interleave(2, dim=-1)
+
+    x = inputs
+    for block in module.h:
+        normed = block.ln_1(x)
+        qkv = block.attn.c_attn(normed)
+        query, key, value = qkv.split(hidden, dim=-1)
+        query = query.view(batch, seq, num_heads, head_dim)
+        key = key.view(batch, seq, num_heads, head_dim)
+        value = value.view(batch, seq, num_heads, head_dim)
+        cos_b = cos.view(1, seq, 1, head_dim)
+        sin_b = sin.view(1, seq, 1, head_dim)
+        query = query * cos_b + _hf_rotate_half(query) * sin_b
+        key = key * cos_b + _hf_rotate_half(key) * sin_b
+
+        query = query.transpose(1, 2)
+        key = key.transpose(1, 2)
+        value = value.transpose(1, 2)
+        scores = torch.matmul(query, key.transpose(-1, -2)) / head_dim**0.5
+        causal = torch.tril(torch.ones(seq, seq, dtype=torch.bool))
+        scores = scores.masked_fill(~causal, float("-inf"))
+        probs = torch.softmax(scores, dim=-1)
+        attn = torch.matmul(probs, value).transpose(1, 2).reshape(batch, seq, hidden)
+        x = x + block.attn.c_proj(attn)
+        x = x + block.mlp(block.ln_2(x))
+    return module.ln_f(x)
+
+
+@pytest.mark.parametrize("num_layers", [1, 2])
+def test_local_transformer_incremental_matches_full_recompute(num_layers: int):
+    torch.manual_seed(0)
+    module = MossTTSLocalTransformer(
+        hidden_size=64,
+        num_heads=4,
+        inner_size=96,
+        num_layers=num_layers,
+        max_positions=N_VQ + 1,
+        rope_base=1_000_000.0,
+    )
+    module.eval()
+    batch, seq = 3, N_VQ + 1
+    inputs = torch.randn(batch, seq, 64)
+
+    reference = _reference_full_forward(module, inputs)
+    stepped = torch.stack(
+        [module.step(inputs[:, t], t) for t in range(seq)], dim=1
+    )
+    torch.testing.assert_close(stepped, reference, rtol=1e-4, atol=1e-5)
+
+
+def test_local_transformer_kv_cache_grows_with_batch():
+    module = MossTTSLocalTransformer(
+        hidden_size=32,
+        num_heads=2,
+        inner_size=48,
+        num_layers=1,
+        max_positions=N_VQ + 1,
+        rope_base=1_000_000.0,
+    )
+    out_small = module.step(torch.randn(2, 32), 0)
+    assert out_small.shape == (2, 32)
+    out_large = module.step(torch.randn(8, 32), 0)
+    assert out_large.shape == (8, 32)
+    assert module._kv_capacity >= 8
+
+
+def test_local_transformer_rejects_out_of_range_position():
+    module = MossTTSLocalTransformer(
+        hidden_size=32,
+        num_heads=2,
+        inner_size=48,
+        num_layers=1,
+        max_positions=N_VQ + 1,
+        rope_base=1_000_000.0,
+    )
+    with pytest.raises(ValueError):
+        module.step(torch.randn(1, 32), N_VQ + 1)
+
+
+def test_rotate_half_interleaved_matches_upstream():
+    x = torch.randn(5, 4, 8)
+    torch.testing.assert_close(_rotate_half_interleaved(x), _hf_rotate_half(x))
+
+
+# ---------------------------------------------------------------------------
+# Registry / config
+# ---------------------------------------------------------------------------
+
+
+def test_registry_resolves_local_architecture():
+    config_cls = PIPELINE_CONFIG_REGISTRY.get_config("MossTTSLocalModel")
+    assert config_cls is MossTTSLocalPipelineConfig
+    # The Delay family keeps its own architecture.
+    delay_cls = PIPELINE_CONFIG_REGISTRY.get_config("MossTTSDelayModel")
+    assert delay_cls is not MossTTSLocalPipelineConfig
+
+
+def test_pipeline_stage_wiring():
+    stages = {stage.name: stage for stage in MossTTSLocalPipelineConfig.model_fields[
+        "stages"
+    ].default}
+    assert set(stages) == {"preprocessing", "tts_engine", "vocoder"}
+    assert stages["preprocessing"].next == "tts_engine"
+    assert stages["tts_engine"].next == "vocoder"
+    assert stages["vocoder"].terminal
+    for stage in stages.values():
+        assert "moss_tts_local" in stage.factory
+
+
+def test_special_token_defaults_match_v15_checkpoint():
+    defaults = dict(moss_tts_local_special_token_defaults())
+    assert defaults["audio_start_token_id"] == 151669
+    assert defaults["audio_end_token_id"] == 151670
+    assert defaults["audio_user_slot_token_id"] == 151654
+    assert defaults["audio_assistant_slot_token_id"] == 151656
+    assert defaults["audio_pad_code"] == 1024
+
+
+# ---------------------------------------------------------------------------
+# Generation kwargs / state
+# ---------------------------------------------------------------------------
+
+
+def test_build_generation_kwargs_defaults():
+    kwargs = build_generation_kwargs({}, tts_params={})
+    assert kwargs["max_new_tokens"] == 4096
+    assert kwargs["text_temperature"] == 1.0
+    assert kwargs["text_top_p"] == 1.0
+    assert kwargs["text_top_k"] == 50
+    assert kwargs["audio_temperature"] == 1.7
+    assert kwargs["audio_top_p"] == 0.8
+    assert kwargs["audio_top_k"] == 25
+    assert kwargs["audio_repetition_penalty"] == 1.0
+
+
+def test_build_generation_kwargs_explicit_overrides():
+    kwargs = build_generation_kwargs(
+        {"temperature": 0.9, "top_p": 0.7},
+        tts_params={
+            "explicit_generation_params": ["temperature", "top_p"],
+            "audio_top_k": 11,
+        },
+    )
+    assert kwargs["text_temperature"] == 0.9
+    assert kwargs["audio_temperature"] == 0.9
+    assert kwargs["audio_top_p"] == 0.7
+    assert kwargs["audio_top_k"] == 11
+
+
+def test_state_round_trip():
+    state = MossTTSLocalState(
+        text="hello",
+        language="English",
+        token_count=125,
+        audio_codes=torch.zeros((3, N_VQ), dtype=torch.long),
+        sample_rate=48000,
+        prompt_tokens=7,
+        completion_tokens=3,
+    )
+    restored = MossTTSLocalState.from_dict(state.to_dict())
+    assert restored.text == "hello"
+    assert restored.language == "English"
+    assert restored.token_count == 125
+    assert restored.sample_rate == 48000
+    assert torch.as_tensor(restored.audio_codes).shape == (3, N_VQ)
+
+
+def test_build_state_token_count_and_language():
+    payload = StagePayload(
+        request_id="r0",
+        request=OmniRequest(
+            inputs={"text": "${token:50} hello world", "references": []},
+            params={"language": "English"},
+            metadata={},
+        ),
+        data={},
+    )
+    state = build_moss_tts_local_state(payload)
+    assert state.token_count == 50
+    assert state.text == "hello world"
+    assert state.language == "English"
+
+
+# ---------------------------------------------------------------------------
+# Preprocessing handoff + result adapter
+# ---------------------------------------------------------------------------
+
+
+class _FakeProcessor:
+    """Builds deterministic [1, T, 13] rows from the message text length."""
+
+    @staticmethod
+    def build_user_message(**kwargs):
+        return dict(kwargs, role="user")
+
+    def __call__(self, conversations, mode):
+        assert mode == "generation"
+        message = conversations[0][0]
+        text = str(message.get("text", ""))
+        seq = max(4, len(text) % 7 + 4)
+        rows = torch.full((1, seq, N_VQ + 1), 1024, dtype=torch.long)
+        rows[0, :, 0] = torch.arange(seq)
+        rows[0, -1, 0] = 151669  # trailing audio_start row
+        return {"input_ids": rows}
+
+
+def _payload(text: str = "hello") -> StagePayload:
+    return StagePayload(
+        request_id="req-1",
+        request=OmniRequest(inputs={"text": text}, params={}, metadata={}),
+        data={},
+    )
+
+
+def test_preprocess_and_result_adapter():
+    set_moss_tts_local_preprocessing_context(processor=_FakeProcessor())
+    try:
+        payload = preprocess_moss_tts_local_payload(_payload())
+        assert payload.data.get("_moss_tts_local_prepared_request") == "req-1"
+
+        from sglang_omni.models.moss_tts_local.request_builders import (
+            pop_prepared_moss_tts_local_request,
+        )
+
+        prepared = pop_prepared_moss_tts_local_request(payload)
+        assert prepared is not None
+        assert prepared.prompt_rows.ndim == 2
+        assert prepared.prompt_rows.shape[1] == N_VQ + 1
+        assert len(prepared.input_ids_list) == prepared.prompt_rows.shape[0]
+
+        data = MossTTSLocalSGLangRequestData(
+            input_ids=prepared.input_ids,
+            max_new_tokens=16,
+            temperature=0.0,
+            output_ids=[],
+            state=prepared.state,
+            prompt_rows=prepared.prompt_rows,
+            stage_payload=payload,
+            engine_start_s=0.0,
+        )
+        data.output_rows = [
+            torch.cat(
+                [torch.tensor([151656]), torch.arange(N_VQ, dtype=torch.long)]
+            )
+            for _ in range(3)
+        ]
+        result = apply_sglang_moss_tts_local_result(payload, data)
+        codes = torch.as_tensor(result.data["audio_codes"])
+        assert codes.shape == (3, N_VQ)
+        assert result.data["completion_tokens"] == 3
+        assert result.data["prompt_tokens"] == prepared.prompt_rows.shape[0]
+    finally:
+        clear_moss_tts_local_preprocessing_context()
+
+
+def test_result_adapter_empty_generation():
+    payload = _payload()
+    data = MossTTSLocalSGLangRequestData(
+        input_ids=torch.zeros(4, dtype=torch.long),
+        max_new_tokens=16,
+        temperature=0.0,
+        output_ids=[],
+        prompt_rows=torch.full((4, N_VQ + 1), 1024, dtype=torch.long),
+        stage_payload=payload,
+        engine_start_s=0.0,
+    )
+    result = apply_sglang_moss_tts_local_result(payload, data)
+    codes = torch.as_tensor(result.data["audio_codes"])
+    assert codes.shape == (0, N_VQ)
+
+
+# ---------------------------------------------------------------------------
+# Repetition penalty parity
+# ---------------------------------------------------------------------------
+
+
+def test_audio_repetition_penalty_matches_upstream_semantics():
+    from sglang_omni.models.moss_tts_local.model_runner import (
+        MossTTSLocalModelRunner,
+    )
+
+    logits = torch.tensor(
+        [[2.0, -1.0, 0.5, 3.0], [1.0, 1.0, 1.0, 1.0]], dtype=torch.float32
+    )
+    history_row0 = torch.tensor([[0, 9], [2, 9]], dtype=torch.long)  # channel 0: {0, 2}
+    histories = [history_row0, None]
+    expected = logits.clone()
+    penalty = 1.5
+    expected[0, 0] = expected[0, 0] / penalty  # positive -> divide
+    expected[0, 2] = expected[0, 2] / penalty
+
+    MossTTSLocalModelRunner._apply_audio_repetition_penalty(
+        logits, histories, [penalty, 1.0], channel=0
+    )
+    torch.testing.assert_close(logits, expected)
+
+    # Negative scores multiply.
+    logits2 = torch.tensor([[-2.0, 1.0]], dtype=torch.float32)
+    MossTTSLocalModelRunner._apply_audio_repetition_penalty(
+        logits2, [torch.tensor([[0]], dtype=torch.long)], [2.0], channel=0
+    )
+    torch.testing.assert_close(
+        logits2, torch.tensor([[-4.0, 1.0]], dtype=torch.float32)
+    )
+
+
+def test_batched_reference_encoder_coalesces_and_isolates_errors():
+    import threading
+
+    from sglang_omni.models.moss_tts_local.stages import _BatchedReferenceEncoder
+
+    calls = []
+
+    class _FakeCodecProcessor:
+        def encode_audios_from_path(self, paths):
+            calls.append(list(paths))
+            out = []
+            for p in paths:
+                if "bad" in p:
+                    raise RuntimeError(f"cannot read {p}")
+                out.append(torch.full((4, N_VQ), len(p), dtype=torch.long))
+            return out
+
+    encoder = _BatchedReferenceEncoder(
+        _FakeCodecProcessor(), max_batch_size=4, max_batch_wait_ms=20
+    )
+    results = {}
+
+    def run(path):
+        try:
+            results[path] = encoder.encode(path)
+        except Exception as exc:
+            results[path] = exc
+
+    threads = [threading.Thread(target=run, args=(p,)) for p in ("aa", "bbb", "bad1")]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert isinstance(results["bad1"], Exception)
+    assert results["aa"].shape == (4, N_VQ) and int(results["aa"][0, 0]) == 2
+    assert results["bbb"].shape == (4, N_VQ) and int(results["bbb"][0, 0]) == 3
+    # The failing batch retried per item; good items still succeeded.
+    assert any(len(c) > 1 for c in calls) or len(calls) >= 3
+
+
+def test_branchless_sampler_matches_eager_sampler():
+    """The CUDA-graphable sampler must reproduce the eager path exactly."""
+    pytest.importorskip("sglang")
+    from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+    from sglang_omni.models.moss_tts_local.local_transformer import (
+        sample_seeded_branchless,
+    )
+
+    torch.manual_seed(7)
+    rows, vocab = 6, 64
+    logits = torch.randn(rows, vocab, dtype=torch.float32) * 3
+    temperature = torch.tensor([1.7, 1.0, 0.5, 1.7, 0.0, 1.7])
+    top_p = torch.tensor([0.8, 1.0, 0.9, 0.8, 0.8, 0.8])
+    top_k = torch.tensor([25, 50, 8, 64, 25, 1], dtype=torch.long)
+    seeds = torch.arange(rows, dtype=torch.long) * 1234567
+    positions = torch.arange(rows, dtype=torch.long) * 13
+
+    eager = MossTTSModelRunner._sample_tokens(
+        logits.clone(),
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+        seeds=seeds,
+        positions=positions,
+    )
+    branchless = sample_seeded_branchless(
+        logits.clone(),
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+        seeds=seeds,
+        positions=positions,
+    )
+    torch.testing.assert_close(eager, branchless)
+
+
+# ---------------------------------------------------------------------------
+# Stereo audio payload + encoding
+# ---------------------------------------------------------------------------
+
+
+def test_audio_waveform_payload_keeps_stereo_shape():
+    wav = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    payload = audio_waveform_payload(wav, keep_channels=True)
+    assert payload["audio_waveform_shape"] == [2, 4]
+    restored = np.frombuffer(payload["audio_waveform"], dtype=np.float32).reshape(2, 4)
+    np.testing.assert_allclose(restored, wav.numpy())
+    # Default behavior still flattens.
+    flat = audio_waveform_payload(wav)
+    assert flat["audio_waveform_shape"] == [8]
+
+
+def test_encode_wav_stereo_header_and_interleave():
+    stereo = np.stack(
+        [np.full(4, 0.5, dtype=np.float32), np.full(4, -0.5, dtype=np.float32)]
+    )
+    blob = encode_wav(stereo, 48000)
+    assert blob[:4] == b"RIFF" and blob[8:12] == b"WAVE"
+    num_channels = struct.unpack("<H", blob[22:24])[0]
+    sample_rate = struct.unpack("<I", blob[24:28])[0]
+    assert num_channels == 2
+    assert sample_rate == 48000
+    pcm = np.frombuffer(blob[44:], dtype=np.int16).reshape(-1, 2)
+    assert (pcm[:, 0] > 0).all() and (pcm[:, 1] < 0).all()
+
+
+def test_encode_audio_stereo_wav_and_mono_fallback():
+    stereo = np.stack(
+        [np.ones(64, dtype=np.float32) * 0.1, np.ones(64, dtype=np.float32) * -0.1]
+    )
+    blob, mime = encode_audio(stereo, response_format="wav", sample_rate=48000)
+    assert mime == "audio/wav"
+    assert struct.unpack("<H", blob[22:24])[0] == 2
+    # Mono input keeps the legacy single-channel header.
+    mono_blob, _ = encode_audio(
+        np.ones(64, dtype=np.float32) * 0.1, response_format="wav", sample_rate=48000
+    )
+    assert struct.unpack("<H", mono_blob[22:24])[0] == 1

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -9,7 +9,11 @@ import pytest
 import torch
 
 from sglang_omni.client.audio import encode_audio, encode_wav
-from sglang_omni.models.moss_tts_local.config import MossTTSLocalPipelineConfig
+from sglang_omni.config.placement import build_stage_placement_plan
+from sglang_omni.models.moss_tts_local.config import (
+    MossTTSLocalColocatedPipelineConfig,
+    MossTTSLocalPipelineConfig,
+)
 from sglang_omni.models.moss_tts_local.local_transformer import (
     MossTTSLocalTransformer,
     _rotate_half_interleaved,
@@ -160,16 +164,34 @@ def test_registry_resolves_local_architecture():
 
 
 def test_pipeline_stage_wiring():
-    stages = {
-        stage.name: stage
-        for stage in MossTTSLocalPipelineConfig.model_fields["stages"].default
-    }
+    config = MossTTSLocalPipelineConfig(model_path="OpenMOSS-Team/moss-local-test")
+    stages = {stage.name: stage for stage in config.stages}
     assert set(stages) == {"preprocessing", "tts_engine", "vocoder"}
     assert stages["preprocessing"].next == "tts_engine"
     assert stages["tts_engine"].next == "vocoder"
     assert stages["vocoder"].terminal
     for stage in stages.values():
         assert "moss_tts_local" in stage.factory
+    assert stages["preprocessing"].process == "pipeline"
+    assert stages["preprocessing"].gpu == 0
+    assert stages["preprocessing"].factory_args["device"] == "cuda:1"
+    assert stages["tts_engine"].process == "pipeline"
+    assert stages["tts_engine"].gpu == 0
+    assert stages["vocoder"].process == "pipeline"
+    assert stages["vocoder"].gpu == 0
+    assert stages["vocoder"].factory_args["device"] == "cuda:1"
+
+    placement = build_stage_placement_plan(config)
+    assert placement.stages["tts_engine"].gpu_ids == (0,)
+    assert placement.stages["preprocessing"].gpu_ids == (0,)
+    assert placement.stages["vocoder"].gpu_ids == (0,)
+
+    colocated = MossTTSLocalColocatedPipelineConfig(
+        model_path="OpenMOSS-Team/moss-local-test"
+    )
+    colocated_stages = {stage.name: stage for stage in colocated.stages}
+    assert colocated_stages["preprocessing"].factory_args["device"] == "cuda:0"
+    assert colocated_stages["vocoder"].factory_args["device"] == "cuda:0"
 
 
 def test_special_token_defaults_match_v15_checkpoint():

--- a/tests/unit_test/qwen3_omni/test_streaming.py
+++ b/tests/unit_test/qwen3_omni/test_streaming.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import struct
 import threading
 from dataclasses import dataclass
 from types import SimpleNamespace
@@ -1033,6 +1035,70 @@ def test_client_completion_stream_non_streaming_keeps_full_text():
     assert len(chunks) == 1
     assert chunks[0].text == "hi there"
     assert chunks[0].finish_reason == "stop"
+
+
+def test_client_completion_audio_uses_chunk_sample_rate():
+    from sglang_omni.client.client import Client
+    from sglang_omni.client.types import GenerateRequest
+
+    coordinator = _FakeCoordinatorForClient(
+        [],
+        submit_result={
+            "audio_data": [0.0, 0.1, -0.1, 0.0],
+            "sample_rate": 48000,
+            "modality": "audio",
+        },
+    )
+    client = Client(coordinator=coordinator)
+
+    result = asyncio.run(
+        client.completion(
+            GenerateRequest(prompt="ignored", stream=False),
+            request_id="req-1",
+            audio_format="wav",
+        )
+    )
+
+    assert result.audio is not None
+    wav = base64.b64decode(result.audio.data)
+    assert struct.unpack("<I", wav[24:28])[0] == 48000
+
+
+def test_client_completion_stream_audio_uses_chunk_sample_rate():
+    from sglang_omni.client.client import Client
+    from sglang_omni.client.types import GenerateRequest
+    from sglang_omni.proto import StreamMessage
+
+    messages = [
+        StreamMessage(
+            request_id="req-1",
+            from_stage="vocoder",
+            chunk={
+                "audio_data": [0.0, 0.1, -0.1, 0.0],
+                "sample_rate": 48000,
+                "modality": "audio",
+            },
+            stage_name="vocoder",
+            modality="audio",
+        )
+    ]
+    client = Client(coordinator=_FakeCoordinatorForClient(messages))
+
+    async def _collect():
+        out = []
+        async for chunk in client.completion_stream(
+            GenerateRequest(prompt="ignored", stream=True),
+            request_id="req-1",
+            audio_format="wav",
+        ):
+            out.append(chunk)
+        return out
+
+    chunks = asyncio.run(_collect())
+
+    assert chunks[0].audio_b64 is not None
+    wav = base64.b64decode(chunks[0].audio_b64)
+    assert struct.unpack("<I", wav[24:28])[0] == 48000
 
 
 def test_client_speech_forces_non_streaming_request(


### PR DESCRIPTION
Adds native serving for [OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5](https://huggingface.co/OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5) (#637, TODO item 1: model support with radix cache).

v1.5 is not a delay-pattern model: the 36-layer Qwen3 backbone consumes one summed embedding per 12.5 Hz frame (text channel + 12 RVQ channels), and a 1-layer frame-local transformer decodes each frame — a binary continue/stop head, then 12 sequentially sampled codebooks, each fed back as the next local position. The codec is MOSS-Audio-Tokenizer-v2 (~2B params, RVQ-12, native 48 kHz stereo).

## Implementation

- 3-stage pipeline (preprocessing → AR engine → vocoder) following the MOSS Delay layout from #609. Serving by model id resolves directly: the v1.5 checkpoint declares `architectures: ["MossTTSLocalModel"]`.
- Radix cache: multi-channel prompt rows hash to surrogate token ids (the MOSS Delay scheme), so repeated reference audio hits the prefix cache; prefill skips `prefix_indices`.
- Backbone decode runs under SGLang CUDA graphs (next-frame embeddings staged through a fixed table; decode input_ids are row indices).
- The per-frame local decode (1+12 micro-steps plus 13 seeded sampling passes) is also CUDA-graph captured per batch-size bucket. Eager it is launch-bound at ~22 ms/frame; replay takes ~4 ms. Falls back to eager when `audio_repetition_penalty != 1`.
- Reference encodes coalesce into batched codec calls (a single encode costs ~0.25 GPU-seconds through the ~1B-param encoder; concurrent requests share one `batch_encode`). Codec stages auto-place on the second visible GPU, falling back to GPU 0 on single-GPU hosts. The preprocessing and vocoder stages keep separate codec instances because the codec's chunked decode flips module-global streaming state.
- Output stays stereo end to end: `[2, N]` 48 kHz payloads and multi-channel WAV/PCM encoding in the serve path (mono models unaffected).
- Sampling is seeded per (request, step, channel) via `multinomial_with_seed`, so `seed` reproduces at any concurrency. Defaults match the model card: text 1.0/1.0/50, audio 1.7/0.8/25, repetition penalty 1.0.

## Validation (full Seed-TTS-eval, EN)

2×H100 80GB (GPU 0: AR engine, GPU 1: codec encode + vocoder), DP 1, no router, served by model id with stock defaults; ASR Qwen/Qwen3-ASR-1.7B.

| Model / config | Split | WER / CER | Samples | Failed / skipped | Throughput | rtf_mean |
|---|---|---|---|---|---|---|
| MOSS-TTS-Local-v1.5, c=16, token-count auto, 2×H100 | EN | WER 1.86% raw / 1.65% excl. >50% outliers | 1088/1088 | 0 / 0 | 7.78 req/s | 0.4878 |
| MOSS-TTS-Local-v1.5, c=16, token-count auto, 2×H100 | ZH | CER 1.30% raw / 1.17% excl. >50% outliers | 2020/2020 | 0 / 0 | 8.62 req/s | 0.3306 |

EN rtf p99 0.999, mean latency 2.05 s. For comparison, the MOSS Delay EN reference in the benchmark header is WER 1.93% / rtf 0.913 (H100, c=16). 2×H100 is one DP-1 replica with the AR engine on GPU 0 and the codec stages on GPU 1; single-GPU serving works but the codec encoder contends with the decode loop.

Run-to-run note: a repeat EN run measured rtf_mean 0.53 / WER 2.66% raw, 1.86% excl. — the raw WER swings with the count of >50%-WER runaway samples (3 vs 11 of 1088 across runs; same tail behavior is visible in the Delay reference and the v1.0 numbers in #716), while the excluded-outlier metric stays within ASR noise.

Repro:

```bash
CUDA_VISIBLE_DEVICES=0,1 sgl-omni serve --model-path OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5 --port 8021
python -m benchmarks.eval.benchmark_tts_seedtts --meta zhaochenyang20/seed-tts-eval-arrow --lang en \
  --model OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5 --port 8021 \
  --ref-format references --token-count auto --max-concurrency 16 --output-dir results/moss_local_en
```

20 CPU unit tests under `tests/unit_test/moss_tts_local/`: local-transformer incremental-vs-recompute equivalence (incl. interleaved RoPE), graph/eager sampler parity, registry resolution, prompt/state builders, repetition-penalty semantics, stereo payload + WAV encoding.

Relation to #716: that PR targets the v1.0 depth-transformer checkpoint, whose config declares the Delay architecture (explicit config file required). v1.5 ships its own `moss_tts_local` model type, so this path is independent; both use the `models/moss_tts_local` module name, so whichever lands second needs a rebase.

Follow-ups: streaming output, async decode (row-indexed state pool), ZH split numbers.