### PR TITLE
[CI] add edwingao28 to CI permissions

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -4,6 +4,11 @@
         "can_rerun_failed_ci": true,
         "reason": "custom override"
     },
+    "edwingao28": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "reason": "custom override"
+    },
     "zhaochenyang20": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,


### PR DESCRIPTION
## Motivation

Add `edwingao28` to `.github/CI_PERMISSIONS.json` to allow running CI slash commands (`/tag-and-rerun-ci`, `/run-failed-ci`).

Discussed with @Ratish1, who suggested opening this PR.

## Modifications

- Add `edwingao28` entry to `.github/CI_PERMISSIONS.json` (sorted via `update_ci_permission.py --sort-only`)