### PR TITLE
[Perf] Reference audio cache for MOSS-TTS-Local-v1.5 (LRU + single-flight dedup)

### DIFF
--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -25,7 +25,6 @@ import base64
 import logging
 import os
 import threading
-from collections import OrderedDict
 from pathlib import Path
 from typing import Any
 
@@ -49,7 +48,16 @@ from sglang_omni.models.higgs_tts.utils import (
 from sglang_omni.models.higgs_tts.vocoder_scheduler import (
     HiggsStreamingVocoderScheduler,
 )
-from sglang_omni.preprocessing.cache_key import hash_bytes, hash_media_item
+
+# _REF_PATH_HASH_MEMO is the shared memo object, re-exported so tests can
+# reset it; the underscored alias keeps this module's historical API.
+from sglang_omni.preprocessing.cache_key import _REF_PATH_HASH_MEMO  # noqa: F401
+from sglang_omni.preprocessing.cache_key import (
+    hash_media_item,
+)
+from sglang_omni.preprocessing.cache_key import (
+    reference_path_cache_key as _reference_path_cache_key,
+)
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler
@@ -71,90 +79,9 @@ _REF_CODE_CACHE_MAX_ITEMS = 256
 _REF_CODE_CACHE_MAX_BYTES = 256 * 1024 * 1024
 _REF_WAVEFORM_CACHE_MAX_ITEMS = 256
 _REF_WAVEFORM_CACHE_MAX_BYTES = 512 * 1024 * 1024
-_REF_PATH_HASH_MEMO_MAX_ITEMS = 1024
-_REF_PATH_HASH_SENTINEL_BYTES = 8192
-_REF_PATH_HASH_MEMO: OrderedDict[str, tuple[str, str]] = OrderedDict()
-_REF_PATH_HASH_MEMO_LOCK = threading.Lock()
 
 # Saturates near c=16 on H100/H200; higher client concurrency only queues.
 DEFAULT_MAX_CONCURRENCY = 16
-
-
-def _reference_path_hash_memo_key(path: Path) -> tuple[str, int] | None:
-    try:
-        if not path.is_file():
-            return None
-        stat_result = path.stat()
-        memo_key = (
-            f"{path.resolve()}:"
-            f"{stat_result.st_size}:"
-            f"{stat_result.st_mtime_ns}:"
-            f"{stat_result.st_ctime_ns}"
-        )
-        return memo_key, int(stat_result.st_size)
-    except OSError:
-        return None
-
-
-def _reference_path_sentinel(path: Path, file_size: int) -> str | None:
-    try:
-        chunk_size = min(_REF_PATH_HASH_SENTINEL_BYTES, file_size)
-        with path.open("rb") as f:
-            chunks = [f.read(chunk_size)]
-            if file_size > _REF_PATH_HASH_SENTINEL_BYTES:
-                middle_offset = max((file_size - chunk_size) // 2, 0)
-                f.seek(middle_offset)
-                chunks.append(f.read(chunk_size))
-            if file_size > 2 * _REF_PATH_HASH_SENTINEL_BYTES:
-                f.seek(max(file_size - chunk_size, 0))
-                chunks.append(f.read(chunk_size))
-        return hash_bytes(b"".join(chunks) + f"|size:{file_size}".encode())
-    except OSError:
-        return None
-
-
-def _get_reference_path_hash(memo_key: str, sentinel: str) -> str | None:
-    with _REF_PATH_HASH_MEMO_LOCK:
-        cached = _REF_PATH_HASH_MEMO.get(memo_key)
-        if cached is None:
-            return None
-        cached_sentinel, digest = cached
-        if cached_sentinel != sentinel:
-            _REF_PATH_HASH_MEMO.pop(memo_key, None)
-            return None
-        _REF_PATH_HASH_MEMO.move_to_end(memo_key)
-        return digest
-
-
-def _put_reference_path_hash(memo_key: str, sentinel: str, digest: str) -> None:
-    with _REF_PATH_HASH_MEMO_LOCK:
-        _REF_PATH_HASH_MEMO[memo_key] = (sentinel, digest)
-        _REF_PATH_HASH_MEMO.move_to_end(memo_key)
-        while len(_REF_PATH_HASH_MEMO) > _REF_PATH_HASH_MEMO_MAX_ITEMS:
-            _REF_PATH_HASH_MEMO.popitem(last=False)
-
-
-def _reference_path_cache_key(path_like: str | Path) -> str | None:
-    # Memoized full-content hash. The stat tuple avoids rereading stable local
-    # refs while still invalidating normal and rapid same-size replacements.
-    path = Path(str(path_like)).expanduser()
-    memo = _reference_path_hash_memo_key(path)
-    if memo is None:
-        return None
-    memo_key, file_size = memo
-    sentinel = _reference_path_sentinel(path, file_size)
-    if sentinel is None:
-        return None
-    digest = _get_reference_path_hash(memo_key, sentinel)
-    if digest is not None:
-        return f"file:{digest}"
-    try:
-        digest = hash_bytes(path.read_bytes())
-    except OSError:
-        return None
-    if _reference_path_hash_memo_key(path) == memo:
-        _put_reference_path_hash(memo_key, sentinel, digest)
-    return f"file:{digest}"
 
 
 def _reference_audio_cache_key(reference_audio: Any) -> str | None:

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -52,9 +52,7 @@ from sglang_omni.models.higgs_tts.vocoder_scheduler import (
 # _REF_PATH_HASH_MEMO is the shared memo object, re-exported so tests can
 # reset it; the underscored alias keeps this module's historical API.
 from sglang_omni.preprocessing.cache_key import _REF_PATH_HASH_MEMO  # noqa: F401
-from sglang_omni.preprocessing.cache_key import (
-    hash_media_item,
-)
+from sglang_omni.preprocessing.cache_key import hash_media_item
 from sglang_omni.preprocessing.cache_key import (
     reference_path_cache_key as _reference_path_cache_key,
 )

--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -18,7 +18,12 @@ def _stages(*, codec_device: str) -> list[StageConfig]:
             name="preprocessing",
             process="pipeline",
             factory=f"{_PKG}.stages.create_preprocessing_executor",
-            factory_args={"device": codec_device},
+            factory_args={
+                "device": codec_device,
+                "ref_audio_cache": True,
+                "ref_audio_cache_max_items": 256,
+                "ref_audio_cache_max_bytes": 64 * 1024 * 1024,
+            },
             gpu=0,
             next="tts_engine",
         ),

--- a/sglang_omni/models/moss_tts_local/request_builders.py
+++ b/sglang_omni/models/moss_tts_local/request_builders.py
@@ -251,12 +251,10 @@ def _build_processor_message(
     ref_audio = state.ref_audio
     if reference_encoder is not None and isinstance(ref_audio, str):
         if _DATA_URI_RE.match(ref_audio) is None:
-            # File-path references encode through the shared coalescer so
-            # concurrent requests share one batched codec forward instead of
-            # serializing ~0.25 GPU-seconds each.
+            # File-path refs share one batched codec forward via the coalescer.
             reference = [reference_encoder.encode(ref_audio)]
         elif hasattr(reference_encoder, "encode_data_uri"):
-            # Data-URI references through the same LRU cache (bytes: keyspace).
+            # Data-URI refs through the same LRU (bytes: keyspace).
             reference = [
                 reference_encoder.encode_data_uri(ref_audio, processor=processor)
             ]

--- a/sglang_omni/models/moss_tts_local/request_builders.py
+++ b/sglang_omni/models/moss_tts_local/request_builders.py
@@ -249,15 +249,19 @@ def _build_processor_message(
     from sglang_omni.models.moss_tts.request_builders import _DATA_URI_RE
 
     ref_audio = state.ref_audio
-    if (
-        reference_encoder is not None
-        and isinstance(ref_audio, str)
-        and _DATA_URI_RE.match(ref_audio) is None
-    ):
-        # File-path references encode through the shared coalescer so
-        # concurrent requests share one batched codec forward instead of
-        # serializing ~0.25 GPU-seconds each.
-        reference = [reference_encoder.encode(ref_audio)]
+    if reference_encoder is not None and isinstance(ref_audio, str):
+        if _DATA_URI_RE.match(ref_audio) is None:
+            # File-path references encode through the shared coalescer so
+            # concurrent requests share one batched codec forward instead of
+            # serializing ~0.25 GPU-seconds each.
+            reference = [reference_encoder.encode(ref_audio)]
+        elif hasattr(reference_encoder, "encode_data_uri"):
+            # Data-URI references through the same LRU cache (bytes: keyspace).
+            reference = [
+                reference_encoder.encode_data_uri(ref_audio, processor=processor)
+            ]
+        else:
+            reference = _reference_for_processor(processor, ref_audio)
     else:
         reference = _reference_for_processor(processor, ref_audio)
     return processor.build_user_message(

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -264,7 +264,10 @@ class CachedReferenceEncoder:
         path = str(path)
         # Duration gate first: >100 s must never enter the cache or inflight dict.
         _BatchedReferenceEncoder._check_reference_duration(path)
-        key = _reference_path_cache_key(path)
+        # trust_stat: skip the sentinel byte-read on memo hits — the codes cache
+        # lookup needs the key on every request, so the stat-only fast path saves
+        # an 8-24 KB read on the hot fixed-speaker path (idea from #740).
+        key = _reference_path_cache_key(path, trust_stat=True)
         if key is None:
             # Uncacheable (URL, missing file, etc.) — bypass entirely.
             return self._encoder.encode(path)
@@ -311,7 +314,7 @@ class CachedReferenceEncoder:
             raise
 
         # TOCTOU re-stat: skip cache if file changed between key computation and encode.
-        rekey = _reference_path_cache_key(path)
+        rekey = _reference_path_cache_key(path, trust_stat=True)
         stored = result.detach().to("cpu", dtype=torch.int32)
         with self._lock:
             if rekey == key:

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import logging
+import os
 import queue
 import threading
 import time
@@ -449,6 +450,17 @@ def create_preprocessing_executor(
     ref_audio_cache_max_items: int = 256,
     ref_audio_cache_max_bytes: int = 64 * 1024 * 1024,
 ) -> SimpleScheduler:
+    # Runtime kill switch / A-B toggle: MOSS_REF_AUDIO_CACHE=0 disables the cache
+    # without a config edit (the design's "线上回退" lever). Unset => kwarg default.
+    env_toggle = os.environ.get("MOSS_REF_AUDIO_CACHE")
+    if env_toggle is not None:
+        ref_audio_cache = env_toggle.strip().lower() not in (
+            "0",
+            "false",
+            "no",
+            "off",
+            "",
+        )
     device = _resolve_codec_device(device, gpu_id)
     processor = _load_moss_tts_local_processor(model_path, device=device)
     reference_encoder: Any = _BatchedReferenceEncoder(

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -7,6 +7,7 @@ import concurrent.futures
 import logging
 import queue
 import threading
+import time
 from typing import Any
 
 import torch
@@ -257,6 +258,7 @@ class CachedReferenceEncoder:
         self._hits = 0
         self._misses = 0
         self._merged = 0
+        self._last_log_time: float = 0.0
 
     def encode(self, path: str) -> torch.Tensor:
         path = str(path)
@@ -317,7 +319,28 @@ class CachedReferenceEncoder:
             self._inflight.pop(key, None)
         leader_fut.set_result(stored)
         # Return the original tensor (miss path == cache-off path, bit-identical).
+        self._maybe_log()
         return result
+
+    def _maybe_log(self) -> None:
+        now = time.monotonic()
+        if now - self._last_log_time < 60.0:
+            return
+        with self._lock:
+            if now - self._last_log_time < 60.0:
+                return
+            self._last_log_time = now
+            snapshot = (
+                self._hits,
+                self._misses,
+                self._merged,
+                len(self._cache._cache),
+                self._cache.current_bytes,
+            )
+        logger.info(
+            "MOSS-TTS Local ref cache: hits=%d misses=%d merged=%d entries=%d bytes=%d",
+            *snapshot,
+        )
 
     def stats(self) -> dict:
         with self._lock:
@@ -338,14 +361,23 @@ def create_preprocessing_executor(
     max_concurrency: int = 16,
     encode_batch_size: int = 8,
     encode_batch_wait_ms: int = 4,
+    ref_audio_cache: bool = True,
+    ref_audio_cache_max_items: int = 256,
+    ref_audio_cache_max_bytes: int = 64 * 1024 * 1024,
 ) -> SimpleScheduler:
     device = _resolve_codec_device(device, gpu_id)
     processor = _load_moss_tts_local_processor(model_path, device=device)
-    reference_encoder = _BatchedReferenceEncoder(
+    reference_encoder: Any = _BatchedReferenceEncoder(
         processor,
         max_batch_size=encode_batch_size,
         max_batch_wait_ms=encode_batch_wait_ms,
     )
+    if ref_audio_cache:
+        reference_encoder = CachedReferenceEncoder(
+            reference_encoder,
+            max_items=ref_audio_cache_max_items,
+            max_bytes=ref_audio_cache_max_bytes,
+        )
     set_moss_tts_local_preprocessing_context(
         processor=processor, reference_encoder=reference_encoder
     )

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -342,6 +342,87 @@ class CachedReferenceEncoder:
             *snapshot,
         )
 
+    def encode_data_uri(self, ref_audio: str, *, processor: Any) -> torch.Tensor:
+        """Cache-aware encode for data-URI references (bytes: keyspace).
+
+        Adds the duration check that _reference_for_processor lacks, and routes
+        through the same LRU + single-flight machinery as file-path references.
+        file: and bytes: keys never collide because the encode chains differ.
+        """
+        import base64
+        import io
+
+        from sglang_omni.models.moss_tts.request_builders import _DATA_URI_RE
+        from sglang_omni.preprocessing.cache_key import hash_bytes as _hash_bytes
+
+        match = _DATA_URI_RE.match(ref_audio)
+        if match is None:
+            raise ValueError(f"encode_data_uri: not a data URI ({ref_audio[:40]!r}...)")
+
+        raw = base64.b64decode(match.group("data"))
+        key = f"bytes:{_hash_bytes(raw)}"
+
+        leader_fut: concurrent.futures.Future | None = None
+        follower_fut: concurrent.futures.Future | None = None
+
+        with self._lock:
+            stored = self._cache.get(key)
+            if stored is not None:
+                self._hits += 1
+                out = stored.clone().to(torch.long)
+            elif key in self._inflight:
+                self._merged += 1
+                follower_fut = self._inflight[key]
+            else:
+                self._misses += 1
+                leader_fut = concurrent.futures.Future()
+                self._inflight[key] = leader_fut
+
+        if stored is not None:
+            self._maybe_log()
+            return out  # type: ignore[return-value]
+
+        if follower_fut is not None:
+            timeout = _BatchedReferenceEncoder.ENCODE_TIMEOUT_S + 10
+            try:
+                stored = follower_fut.result(timeout=timeout)
+            except Exception as cause:
+                raise RuntimeError(
+                    f"reference encode failed (data-URI, merged): {cause}"
+                ) from cause
+            self._maybe_log()
+            return stored.clone().to(torch.long)
+
+        # Leader: decode audio, check duration, encode.
+        assert leader_fut is not None
+        try:
+            import soundfile as sf
+
+            audio, sample_rate = sf.read(
+                io.BytesIO(raw), dtype="float32", always_2d=True
+            )
+            duration = audio.shape[0] / max(int(sample_rate), 1)
+            if duration > _BatchedReferenceEncoder.MAX_REFERENCE_SECONDS:
+                raise ValueError(
+                    f"reference audio is {duration:.1f}s long; the limit is "
+                    f"{_BatchedReferenceEncoder.MAX_REFERENCE_SECONDS:.0f}s"
+                )
+            wav = torch.from_numpy(audio.T)
+            result = processor.encode_audios_from_wav([wav], int(sample_rate))[0]
+        except BaseException as exc:
+            with self._lock:
+                self._inflight.pop(key, None)
+            leader_fut.set_exception(exc)
+            raise
+
+        stored = result.detach().to("cpu", dtype=torch.int32)
+        with self._lock:
+            self._cache.put(key, stored)
+            self._inflight.pop(key, None)
+        leader_fut.set_result(stored)
+        self._maybe_log()
+        return result
+
     def stats(self) -> dict:
         with self._lock:
             return {

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -26,8 +26,12 @@ from sglang_omni.models.moss_tts_local.request_builders import (
     preprocess_moss_tts_local_payload,
     set_moss_tts_local_preprocessing_context,
 )
+from sglang_omni.preprocessing.cache_key import (
+    reference_path_cache_key as _reference_path_cache_key,
+)
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+from sglang_omni.scheduling.stage_cache import StageOutputCache
 from sglang_omni.utils.audio_payload import audio_waveform_payload
 
 logger = logging.getLogger(__name__)
@@ -225,6 +229,105 @@ class _BatchedReferenceEncoder:
                     )
                 else:
                     future.set_result(outcome)
+
+
+class CachedReferenceEncoder:
+    """Content-addressed LRU cache + single-flight dedup in front of _BatchedReferenceEncoder.
+
+    Miss path returns the encoder's tensor unchanged (bit-identical to cache-off).
+    Hit path returns a fresh .clone().to(long) so callers cannot mutate cached state.
+    Stores codes as int32 on CPU (lossless for codebook values in [0, 1023]).
+    """
+
+    def __init__(
+        self,
+        encoder: _BatchedReferenceEncoder,
+        *,
+        max_items: int = 256,
+        max_bytes: int = 64 * 1024 * 1024,
+    ) -> None:
+        self._encoder = encoder
+        self._cache = StageOutputCache(
+            max_size=max_items,
+            max_bytes=max_bytes,
+            cache_device="cpu",
+        )
+        self._lock = threading.Lock()
+        self._inflight: dict[str, concurrent.futures.Future] = {}
+        self._hits = 0
+        self._misses = 0
+        self._merged = 0
+
+    def encode(self, path: str) -> torch.Tensor:
+        path = str(path)
+        # Duration gate first: >100 s must never enter the cache or inflight dict.
+        _BatchedReferenceEncoder._check_reference_duration(path)
+        key = _reference_path_cache_key(path)
+        if key is None:
+            # Uncacheable (URL, missing file, etc.) — bypass entirely.
+            return self._encoder.encode(path)
+
+        leader_fut: concurrent.futures.Future | None = None
+        follower_fut: concurrent.futures.Future | None = None
+
+        with self._lock:
+            stored = self._cache.get(key)
+            if stored is not None:
+                self._hits += 1
+                return stored.clone().to(torch.long)
+            if key in self._inflight:
+                self._merged += 1
+                follower_fut = self._inflight[key]
+            else:
+                self._misses += 1
+                leader_fut = concurrent.futures.Future()
+                self._inflight[key] = leader_fut
+
+        if follower_fut is not None:
+            # Follower: wait for leader, return independent clone.
+            # Wrap any exception in a fresh instance so each waiter gets an
+            # independent object (a shared instance mutated by concurrent
+            # re-raises would corrupt all tracebacks — same issue as in
+            # _BatchedReferenceEncoder._worker, L216-221 of the original).
+            timeout = _BatchedReferenceEncoder.ENCODE_TIMEOUT_S + 10
+            try:
+                stored = follower_fut.result(timeout=timeout)
+            except Exception as cause:
+                raise RuntimeError(
+                    f"reference encode failed for {path!r}: {cause}"
+                ) from cause
+            return stored.clone().to(torch.long)
+
+        # Leader: encode then cache.
+        assert leader_fut is not None
+        try:
+            result = self._encoder.encode(path)
+        except BaseException as exc:
+            with self._lock:
+                self._inflight.pop(key, None)
+            leader_fut.set_exception(exc)
+            raise
+
+        # TOCTOU re-stat: skip cache if file changed between key computation and encode.
+        rekey = _reference_path_cache_key(path)
+        stored = result.detach().to("cpu", dtype=torch.int32)
+        with self._lock:
+            if rekey == key:
+                self._cache.put(key, stored)
+            self._inflight.pop(key, None)
+        leader_fut.set_result(stored)
+        # Return the original tensor (miss path == cache-off path, bit-identical).
+        return result
+
+    def stats(self) -> dict:
+        with self._lock:
+            return {
+                "hits": self._hits,
+                "misses": self._misses,
+                "merged": self._merged,
+                "entries": len(self._cache._cache),
+                "bytes": self._cache.current_bytes,
+            }
 
 
 def create_preprocessing_executor(

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -241,6 +241,9 @@ class CachedReferenceEncoder:
     Stores codes as int32 on CPU (lossless for codebook values in [0, 1023]).
     """
 
+    # Cadence for the periodic stats log; class attr so it is easy to tune.
+    LOG_INTERVAL_S = 60.0
+
     def __init__(
         self,
         encoder: _BatchedReferenceEncoder,
@@ -248,6 +251,12 @@ class CachedReferenceEncoder:
         max_items: int = 256,
         max_bytes: int = 64 * 1024 * 1024,
     ) -> None:
+        # Fail fast on non-positive capacities: a negative max_items makes
+        # StageOutputCache evict from an empty dict and KeyError at request time.
+        if max_items < 1:
+            raise ValueError(f"ref_audio_cache_max_items must be >= 1, got {max_items}")
+        if max_bytes < 1:
+            raise ValueError(f"ref_audio_cache_max_bytes must be >= 1, got {max_bytes}")
         self._encoder = encoder
         self._cache = StageOutputCache(
             max_size=max_items,
@@ -266,12 +275,29 @@ class CachedReferenceEncoder:
         # Note(Jiaxin): duration gate runs first — a >100 s ref must never reach
         # the cache or the inflight dict.
         _BatchedReferenceEncoder._check_reference_duration(path)
-        # trust_stat: stat-only fast path; the codes lookup needs the key on every
-        # request (see reference_path_cache_key).
-        key = _reference_path_cache_key(path, trust_stat=True)
+        # trust_stat left False (review feedback): keep the sentinel byte-read so a
+        # same-size+mtime+ctime overwrite cannot stale-hit. The flag stays available
+        # in reference_path_cache_key for deployments that guarantee immutable refs.
+        key = _reference_path_cache_key(path)
         if key is None:
             return self._encoder.encode(path)  # uncacheable (URL/missing) -> bypass
+        return self._cached_encode(
+            key,
+            lambda: self._encoder.encode(path),
+            desc=repr(path),
+            # TOCTOU re-stat: skip the put if the file changed during the encode.
+            revalidate=lambda: _reference_path_cache_key(path) == key,
+        )
 
+    def _cached_encode(
+        self, key: str, encode_fn, *, desc: str, revalidate=None
+    ) -> torch.Tensor:
+        """Single-flight skeleton shared by encode() and encode_data_uri().
+
+        Hit -> independent .clone().to(long). Miss leader runs encode_fn and returns
+        its tensor unchanged (bit-identical to cache-off). revalidate(), if given, is
+        evaluated outside the lock and gates the put (TOCTOU guard for file paths).
+        """
         leader_fut: concurrent.futures.Future | None = None
         follower_fut: concurrent.futures.Future | None = None
 
@@ -279,15 +305,18 @@ class CachedReferenceEncoder:
             stored = self._cache.get(key)
             if stored is not None:
                 self._hits += 1
-                # Note(Jiaxin): clone on hit so callers can't mutate the shared entry.
-                return stored.clone().to(torch.long)
-            if key in self._inflight:
+            elif key in self._inflight:
                 self._merged += 1
                 follower_fut = self._inflight[key]
             else:
                 self._misses += 1
                 leader_fut = concurrent.futures.Future()
                 self._inflight[key] = leader_fut
+
+        if stored is not None:
+            # Note(Jiaxin): clone on hit so callers can't mutate the shared entry.
+            self._maybe_log()
+            return stored.clone().to(torch.long)
 
         if follower_fut is not None:
             # Note(Jiaxin): each follower raises a FRESH RuntimeError — sharing one
@@ -298,24 +327,23 @@ class CachedReferenceEncoder:
                 stored = follower_fut.result(timeout=timeout)
             except Exception as cause:
                 raise RuntimeError(
-                    f"reference encode failed for {path!r}: {cause}"
+                    f"reference encode failed for {desc}: {cause}"
                 ) from cause
             return stored.clone().to(torch.long)
 
         assert leader_fut is not None
         try:
-            result = self._encoder.encode(path)
+            result = encode_fn()
         except BaseException as exc:
             with self._lock:
                 self._inflight.pop(key, None)
             leader_fut.set_exception(exc)
             raise
 
-        # TOCTOU re-stat: skip the put if the file changed during the encode.
-        rekey = _reference_path_cache_key(path, trust_stat=True)
+        do_put = revalidate() if revalidate is not None else True
         stored = result.detach().to("cpu", dtype=torch.int32)
         with self._lock:
-            if rekey == key:
+            if do_put:
                 self._cache.put(key, stored)
             self._inflight.pop(key, None)
         leader_fut.set_result(stored)
@@ -327,7 +355,7 @@ class CachedReferenceEncoder:
         if now - self._last_log_time < 60.0:
             return
         with self._lock:
-            if now - self._last_log_time < 60.0:
+            if now - self._last_log_time < self.LOG_INTERVAL_S:
                 return
             self._last_log_time = now
             snapshot = (
@@ -362,44 +390,15 @@ class CachedReferenceEncoder:
         raw = base64.b64decode(match.group("data"))
         key = f"bytes:{_hash_bytes(raw)}"
 
-        leader_fut: concurrent.futures.Future | None = None
-        follower_fut: concurrent.futures.Future | None = None
-
-        with self._lock:
-            stored = self._cache.get(key)
-            if stored is not None:
-                self._hits += 1
-                out = stored.clone().to(torch.long)
-            elif key in self._inflight:
-                self._merged += 1
-                follower_fut = self._inflight[key]
-            else:
-                self._misses += 1
-                leader_fut = concurrent.futures.Future()
-                self._inflight[key] = leader_fut
-
-        if stored is not None:
-            self._maybe_log()
-            return out  # type: ignore[return-value]
-
-        if follower_fut is not None:
-            timeout = _BatchedReferenceEncoder.ENCODE_TIMEOUT_S + 10
-            try:
-                stored = follower_fut.result(timeout=timeout)
-            except Exception as cause:
-                raise RuntimeError(
-                    f"reference encode failed (data-URI, merged): {cause}"
-                ) from cause
-            self._maybe_log()
-            return stored.clone().to(torch.long)
-
-        assert leader_fut is not None
-        try:
+        def _encode() -> torch.Tensor:
             import soundfile as sf
 
             audio, sample_rate = sf.read(
                 io.BytesIO(raw), dtype="float32", always_2d=True
             )
+            # Note(Jiaxin): the duration check runs inside the leader (not before
+            # inflight registration like the file path) so concurrent same-payload
+            # requests share one sf.read of a potentially large decoded buffer.
             duration = audio.shape[0] / max(int(sample_rate), 1)
             if duration > _BatchedReferenceEncoder.MAX_REFERENCE_SECONDS:
                 raise ValueError(
@@ -407,20 +406,9 @@ class CachedReferenceEncoder:
                     f"{_BatchedReferenceEncoder.MAX_REFERENCE_SECONDS:.0f}s"
                 )
             wav = torch.from_numpy(audio.T)
-            result = processor.encode_audios_from_wav([wav], int(sample_rate))[0]
-        except BaseException as exc:
-            with self._lock:
-                self._inflight.pop(key, None)
-            leader_fut.set_exception(exc)
-            raise
+            return processor.encode_audios_from_wav([wav], int(sample_rate))[0]
 
-        stored = result.detach().to("cpu", dtype=torch.int32)
-        with self._lock:
-            self._cache.put(key, stored)
-            self._inflight.pop(key, None)
-        leader_fut.set_result(stored)
-        self._maybe_log()
-        return result
+        return self._cached_encode(key, _encode, desc="data-URI")
 
     def stats(self) -> dict:
         with self._lock:

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -263,15 +263,14 @@ class CachedReferenceEncoder:
 
     def encode(self, path: str) -> torch.Tensor:
         path = str(path)
-        # Duration gate first: >100 s must never enter the cache or inflight dict.
+        # Note(Jiaxin): duration gate runs first — a >100 s ref must never reach
+        # the cache or the inflight dict.
         _BatchedReferenceEncoder._check_reference_duration(path)
-        # trust_stat: skip the sentinel byte-read on memo hits — the codes cache
-        # lookup needs the key on every request, so the stat-only fast path saves
-        # an 8-24 KB read on the hot fixed-speaker path (idea from #740).
+        # trust_stat: stat-only fast path; the codes lookup needs the key on every
+        # request (see reference_path_cache_key).
         key = _reference_path_cache_key(path, trust_stat=True)
         if key is None:
-            # Uncacheable (URL, missing file, etc.) — bypass entirely.
-            return self._encoder.encode(path)
+            return self._encoder.encode(path)  # uncacheable (URL/missing) -> bypass
 
         leader_fut: concurrent.futures.Future | None = None
         follower_fut: concurrent.futures.Future | None = None
@@ -280,6 +279,7 @@ class CachedReferenceEncoder:
             stored = self._cache.get(key)
             if stored is not None:
                 self._hits += 1
+                # Note(Jiaxin): clone on hit so callers can't mutate the shared entry.
                 return stored.clone().to(torch.long)
             if key in self._inflight:
                 self._merged += 1
@@ -290,11 +290,9 @@ class CachedReferenceEncoder:
                 self._inflight[key] = leader_fut
 
         if follower_fut is not None:
-            # Follower: wait for leader, return independent clone.
-            # Wrap any exception in a fresh instance so each waiter gets an
-            # independent object (a shared instance mutated by concurrent
-            # re-raises would corrupt all tracebacks — same issue as in
-            # _BatchedReferenceEncoder._worker, L216-221 of the original).
+            # Note(Jiaxin): each follower raises a FRESH RuntimeError — sharing one
+            # exception instance lets concurrent re-raises corrupt its traceback
+            # (same lesson as _BatchedReferenceEncoder._worker).
             timeout = _BatchedReferenceEncoder.ENCODE_TIMEOUT_S + 10
             try:
                 stored = follower_fut.result(timeout=timeout)
@@ -304,7 +302,6 @@ class CachedReferenceEncoder:
                 ) from cause
             return stored.clone().to(torch.long)
 
-        # Leader: encode then cache.
         assert leader_fut is not None
         try:
             result = self._encoder.encode(path)
@@ -314,7 +311,7 @@ class CachedReferenceEncoder:
             leader_fut.set_exception(exc)
             raise
 
-        # TOCTOU re-stat: skip cache if file changed between key computation and encode.
+        # TOCTOU re-stat: skip the put if the file changed during the encode.
         rekey = _reference_path_cache_key(path, trust_stat=True)
         stored = result.detach().to("cpu", dtype=torch.int32)
         with self._lock:
@@ -322,9 +319,8 @@ class CachedReferenceEncoder:
                 self._cache.put(key, stored)
             self._inflight.pop(key, None)
         leader_fut.set_result(stored)
-        # Return the original tensor (miss path == cache-off path, bit-identical).
         self._maybe_log()
-        return result
+        return result  # original tensor: miss path stays bit-identical to cache-off
 
     def _maybe_log(self) -> None:
         now = time.monotonic()
@@ -347,11 +343,11 @@ class CachedReferenceEncoder:
         )
 
     def encode_data_uri(self, ref_audio: str, *, processor: Any) -> torch.Tensor:
-        """Cache-aware encode for data-URI references (bytes: keyspace).
+        """Cache-aware encode for data-URI refs through the same LRU + single-flight
+        as file paths (adds the duration check _reference_for_processor lacks).
 
-        Adds the duration check that _reference_for_processor lacks, and routes
-        through the same LRU + single-flight machinery as file-path references.
-        file: and bytes: keys never collide because the encode chains differ.
+        Note(Jiaxin): file: and bytes: keyspaces never collide — the two decode
+        chains differ, so codes aren't guaranteed identical for the "same" audio.
         """
         import base64
         import io
@@ -397,7 +393,6 @@ class CachedReferenceEncoder:
             self._maybe_log()
             return stored.clone().to(torch.long)
 
-        # Leader: decode audio, check duration, encode.
         assert leader_fut is not None
         try:
             import soundfile as sf
@@ -450,8 +445,8 @@ def create_preprocessing_executor(
     ref_audio_cache_max_items: int = 256,
     ref_audio_cache_max_bytes: int = 64 * 1024 * 1024,
 ) -> SimpleScheduler:
-    # Runtime kill switch / A-B toggle: MOSS_REF_AUDIO_CACHE=0 disables the cache
-    # without a config edit (the design's "线上回退" lever). Unset => kwarg default.
+    # MOSS_REF_AUDIO_CACHE=0 disables the cache at startup (ops kill switch / A-B
+    # toggle) without a config edit; unset => kwarg default.
     env_toggle = os.environ.get("MOSS_REF_AUDIO_CACHE")
     if env_toggle is not None:
         ref_audio_cache = env_toggle.strip().lower() not in (

--- a/sglang_omni/preprocessing/cache_key.py
+++ b/sglang_omni/preprocessing/cache_key.py
@@ -105,8 +105,7 @@ def _get_reference_path_hash(memo_key: str, sentinel: str) -> str | None:
 
 
 def _get_reference_path_hash_by_memo_key(memo_key: str) -> str | None:
-    # Fast-path lookup: trust the stat tuple in memo_key and skip the sentinel
-    # byte-read. Used only by trust_stat=True callers.
+    # Memo lookup ignoring the sentinel; trust_stat=True callers only.
     with _REF_PATH_HASH_MEMO_LOCK:
         cached = _REF_PATH_HASH_MEMO.get(memo_key)
         if cached is None:
@@ -126,16 +125,11 @@ def _put_reference_path_hash(memo_key: str, sentinel: str, digest: str) -> None:
 def reference_path_cache_key(
     path_like: str | Path, *, trust_stat: bool = False
 ) -> str | None:
-    # Memoized full-content hash. The stat tuple avoids rereading stable local
-    # refs while still invalidating normal and rapid same-size replacements.
-    #
-    # trust_stat (opt-in, absorbed from #740, co-authored idea: GaokaiZhang):
-    # treat the (size, mtime_ns, ctime_ns) stat tuple as content identity and
-    # skip the sentinel byte-read on memo hits. This trades the sentinel's
-    # narrow protection (same size+mtime+ctime, different content — only
-    # reachable by clock rollback during a write) for a zero-I/O hot path.
-    # Default False keeps the sentinel-validated behavior for Higgs, which
-    # shares this helper; the produced key is byte-identical in both modes.
+    # Memoized full-content hash; the stat tuple skips rereads of stable files.
+    # Note(Jiaxin): trust_stat (opt-in, from #740) trusts the (size,mtime,ctime)
+    # stat tuple and skips the sentinel byte-read on memo hits; the accepted gap
+    # is same-size+mtime+ctime-with-different-content (reachable only by clock
+    # rollback). Default False keeps Higgs's sentinel path; keys are identical.
     path = Path(str(path_like)).expanduser()
     memo = _reference_path_hash_memo_key(path)
     if memo is None:

--- a/sglang_omni/preprocessing/cache_key.py
+++ b/sglang_omni/preprocessing/cache_key.py
@@ -104,6 +104,17 @@ def _get_reference_path_hash(memo_key: str, sentinel: str) -> str | None:
         return digest
 
 
+def _get_reference_path_hash_by_memo_key(memo_key: str) -> str | None:
+    # Fast-path lookup: trust the stat tuple in memo_key and skip the sentinel
+    # byte-read. Used only by trust_stat=True callers.
+    with _REF_PATH_HASH_MEMO_LOCK:
+        cached = _REF_PATH_HASH_MEMO.get(memo_key)
+        if cached is None:
+            return None
+        _REF_PATH_HASH_MEMO.move_to_end(memo_key)
+        return cached[1]
+
+
 def _put_reference_path_hash(memo_key: str, sentinel: str, digest: str) -> None:
     with _REF_PATH_HASH_MEMO_LOCK:
         _REF_PATH_HASH_MEMO[memo_key] = (sentinel, digest)
@@ -112,25 +123,45 @@ def _put_reference_path_hash(memo_key: str, sentinel: str, digest: str) -> None:
             _REF_PATH_HASH_MEMO.popitem(last=False)
 
 
-def reference_path_cache_key(path_like: str | Path) -> str | None:
+def reference_path_cache_key(
+    path_like: str | Path, *, trust_stat: bool = False
+) -> str | None:
     # Memoized full-content hash. The stat tuple avoids rereading stable local
     # refs while still invalidating normal and rapid same-size replacements.
+    #
+    # trust_stat (opt-in, absorbed from #740, co-authored idea: GaokaiZhang):
+    # treat the (size, mtime_ns, ctime_ns) stat tuple as content identity and
+    # skip the sentinel byte-read on memo hits. This trades the sentinel's
+    # narrow protection (same size+mtime+ctime, different content — only
+    # reachable by clock rollback during a write) for a zero-I/O hot path.
+    # Default False keeps the sentinel-validated behavior for Higgs, which
+    # shares this helper; the produced key is byte-identical in both modes.
     path = Path(str(path_like)).expanduser()
     memo = _reference_path_hash_memo_key(path)
     if memo is None:
         return None
     memo_key, file_size = memo
+
+    if trust_stat:
+        digest = _get_reference_path_hash_by_memo_key(memo_key)
+        if digest is not None:
+            return f"file:{digest}"
+
     sentinel = _reference_path_sentinel(path, file_size)
     if sentinel is None:
         return None
-    digest = _get_reference_path_hash(memo_key, sentinel)
-    if digest is not None:
-        return f"file:{digest}"
+
+    if not trust_stat:
+        digest = _get_reference_path_hash(memo_key, sentinel)
+        if digest is not None:
+            return f"file:{digest}"
+
     try:
         digest = hash_bytes(path.read_bytes())
     except OSError:
         return None
     if _reference_path_hash_memo_key(path) == memo:
+        # Always store the sentinel so default callers still validate this entry.
         _put_reference_path_hash(memo_key, sentinel, digest)
     return f"file:{digest}"
 

--- a/sglang_omni/preprocessing/cache_key.py
+++ b/sglang_omni/preprocessing/cache_key.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Callable
 from urllib.parse import urlparse
@@ -48,6 +50,89 @@ def hash_file_sampled(
 
     payload = head + tail + f"|size:{file_size}".encode()
     return xxhash.xxh3_64(payload).hexdigest()
+
+
+_REF_PATH_HASH_MEMO_MAX_ITEMS = 1024
+_REF_PATH_HASH_SENTINEL_BYTES = 8192
+_REF_PATH_HASH_MEMO: OrderedDict[str, tuple[str, str]] = OrderedDict()
+_REF_PATH_HASH_MEMO_LOCK = threading.Lock()
+
+
+def _reference_path_hash_memo_key(path: Path) -> tuple[str, int] | None:
+    try:
+        if not path.is_file():
+            return None
+        stat_result = path.stat()
+        memo_key = (
+            f"{path.resolve()}:"
+            f"{stat_result.st_size}:"
+            f"{stat_result.st_mtime_ns}:"
+            f"{stat_result.st_ctime_ns}"
+        )
+        return memo_key, int(stat_result.st_size)
+    except OSError:
+        return None
+
+
+def _reference_path_sentinel(path: Path, file_size: int) -> str | None:
+    try:
+        chunk_size = min(_REF_PATH_HASH_SENTINEL_BYTES, file_size)
+        with path.open("rb") as f:
+            chunks = [f.read(chunk_size)]
+            if file_size > _REF_PATH_HASH_SENTINEL_BYTES:
+                middle_offset = max((file_size - chunk_size) // 2, 0)
+                f.seek(middle_offset)
+                chunks.append(f.read(chunk_size))
+            if file_size > 2 * _REF_PATH_HASH_SENTINEL_BYTES:
+                f.seek(max(file_size - chunk_size, 0))
+                chunks.append(f.read(chunk_size))
+        return hash_bytes(b"".join(chunks) + f"|size:{file_size}".encode())
+    except OSError:
+        return None
+
+
+def _get_reference_path_hash(memo_key: str, sentinel: str) -> str | None:
+    with _REF_PATH_HASH_MEMO_LOCK:
+        cached = _REF_PATH_HASH_MEMO.get(memo_key)
+        if cached is None:
+            return None
+        cached_sentinel, digest = cached
+        if cached_sentinel != sentinel:
+            _REF_PATH_HASH_MEMO.pop(memo_key, None)
+            return None
+        _REF_PATH_HASH_MEMO.move_to_end(memo_key)
+        return digest
+
+
+def _put_reference_path_hash(memo_key: str, sentinel: str, digest: str) -> None:
+    with _REF_PATH_HASH_MEMO_LOCK:
+        _REF_PATH_HASH_MEMO[memo_key] = (sentinel, digest)
+        _REF_PATH_HASH_MEMO.move_to_end(memo_key)
+        while len(_REF_PATH_HASH_MEMO) > _REF_PATH_HASH_MEMO_MAX_ITEMS:
+            _REF_PATH_HASH_MEMO.popitem(last=False)
+
+
+def reference_path_cache_key(path_like: str | Path) -> str | None:
+    # Memoized full-content hash. The stat tuple avoids rereading stable local
+    # refs while still invalidating normal and rapid same-size replacements.
+    path = Path(str(path_like)).expanduser()
+    memo = _reference_path_hash_memo_key(path)
+    if memo is None:
+        return None
+    memo_key, file_size = memo
+    sentinel = _reference_path_sentinel(path, file_size)
+    if sentinel is None:
+        return None
+    digest = _get_reference_path_hash(memo_key, sentinel)
+    if digest is not None:
+        return f"file:{digest}"
+    try:
+        digest = hash_bytes(path.read_bytes())
+    except OSError:
+        return None
+    if _reference_path_hash_memo_key(path) == memo:
+        _put_reference_path_hash(memo_key, sentinel, digest)
+    return f"file:{digest}"
 
 
 def hash_media_item(item: Any) -> str | None:

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -299,6 +299,29 @@ def _payload(text: str = "hello") -> StagePayload:
     )
 
 
+def test_create_preprocessing_executor_env_toggle(monkeypatch):
+    from sglang_omni.models.moss_tts_local import request_builders as rb
+    from sglang_omni.models.moss_tts_local import stages
+
+    monkeypatch.setattr(
+        stages, "_load_moss_tts_local_processor", lambda *a, **k: _FakeProcessor()
+    )
+
+    # MOSS_REF_AUDIO_CACHE=0 disables the wrapper at startup (kill switch).
+    monkeypatch.setenv("MOSS_REF_AUDIO_CACHE", "0")
+    stages.create_preprocessing_executor("model", device="cpu")
+    assert not isinstance(
+        rb._PREPROCESSING_CONTEXT.reference_encoder, stages.CachedReferenceEncoder
+    )
+
+    # Unset -> kwarg default (True) -> wrapped.
+    monkeypatch.delenv("MOSS_REF_AUDIO_CACHE")
+    stages.create_preprocessing_executor("model", device="cpu")
+    assert isinstance(
+        rb._PREPROCESSING_CONTEXT.reference_encoder, stages.CachedReferenceEncoder
+    )
+
+
 def test_preprocess_and_result_adapter():
     set_moss_tts_local_preprocessing_context(processor=_FakeProcessor())
     try:

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -565,6 +565,330 @@ def test_batched_reference_encoder_coalesces_and_isolates_errors():
     assert any(len(c) > 1 for c in calls) or len(calls) >= 3
 
 
+# ---------------------------------------------------------------------------
+# CachedReferenceEncoder  (T3–T9)
+# ---------------------------------------------------------------------------
+
+
+def test_cached_reference_encoder_on_off_hit_bit_identical(tmp_path):
+    """T5: OFF / ON-miss / ON-hit produce bit-identical prompt_rows and input_ids_list.
+
+    Uses int32 boundary value 1023 to verify lossless round-trip through storage.
+    ON-hit encode counter must stay at 1 (no second encode issued).
+    """
+    from sglang_omni.models.moss_tts_local.request_builders import (
+        _prepare_moss_tts_local_request,
+    )
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+
+    ref_file = tmp_path / "ref.wav"
+    ref_file.write_bytes(b"fake wav bytes for T5")
+    encode_count = 0
+
+    class _FakeBatched:
+        def encode(self, path: str) -> torch.Tensor:
+            nonlocal encode_count
+            encode_count += 1
+            # Boundary value 1023 exercises int32 round-trip; varies by path length.
+            codes = torch.full((10, N_VQ), 1023, dtype=torch.long)
+            codes[0, 0] = len(path) % 1024
+            return codes
+
+    class _RefAwareProcessor:
+        """Folds reference tensor sum into rows so bit-identity is non-trivial."""
+
+        @staticmethod
+        def build_user_message(**kwargs):
+            return dict(kwargs, role="user")
+
+        def __call__(self, conversations, mode):
+            assert mode == "generation"
+            msg = conversations[0][0]
+            ref = msg.get("reference") or []
+            ref_val = (
+                int(ref[0].sum().item()) % 1024
+                if ref and isinstance(ref[0], torch.Tensor)
+                else 0
+            )
+            seq = 8
+            rows = torch.full((1, seq, N_VQ + 1), ref_val, dtype=torch.long)
+            rows[0, :, 0] = torch.arange(seq)
+            rows[0, -1, 0] = 151669
+            return {"input_ids": rows}
+
+    def _ref_payload(rid: str) -> StagePayload:
+        return StagePayload(
+            request_id=rid,
+            request=OmniRequest(
+                inputs={"text": "hello", "references": [{"audio": str(ref_file)}]},
+                params={},
+                metadata={},
+            ),
+            data={},
+        )
+
+    processor = _RefAwareProcessor()
+    fake_batched = _FakeBatched()
+
+    # OFF: raw encoder, no cache wrapper
+    prepared_off = _prepare_moss_tts_local_request(
+        _ref_payload("t5-off"), processor=processor, reference_encoder=fake_batched
+    )
+    assert encode_count == 1
+
+    # ON-miss: first call to CachedReferenceEncoder (cache empty)
+    cached_enc = CachedReferenceEncoder(fake_batched, max_items=256, max_bytes=64 << 20)
+    encode_count = 0
+    prepared_miss = _prepare_moss_tts_local_request(
+        _ref_payload("t5-miss"), processor=processor, reference_encoder=cached_enc
+    )
+    assert encode_count == 1, "ON-miss must call underlying encode exactly once"
+
+    # ON-hit: second call, same file — cache must serve without re-encoding
+    prepared_hit = _prepare_moss_tts_local_request(
+        _ref_payload("t5-hit"), processor=processor, reference_encoder=cached_enc
+    )
+    assert encode_count == 1, "ON-hit must NOT call underlying encode again"
+
+    # Hard gate: all three paths produce identical prompt_rows and input_ids_list
+    assert torch.equal(prepared_off.prompt_rows, prepared_miss.prompt_rows)
+    assert torch.equal(prepared_off.prompt_rows, prepared_hit.prompt_rows)
+    assert prepared_off.input_ids_list == prepared_miss.input_ids_list
+    assert prepared_off.input_ids_list == prepared_hit.input_ids_list
+
+    stats = cached_enc.stats()
+    assert stats["hits"] == 1
+    assert stats["misses"] == 1
+    assert stats["merged"] == 0
+
+
+def test_cached_reference_encoder_lru_eviction(tmp_path):
+    """T3: LRU eviction by item count and by byte budget."""
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+
+    encode_log = []
+
+    class _FakeBatched:
+        def encode(self, path: str) -> torch.Tensor:
+            encode_log.append(path)
+            return torch.full((2, N_VQ), ord(path[-1]), dtype=torch.long)
+
+    # --- item-count eviction: max_items=2, insert 3 ---
+    enc = CachedReferenceEncoder(_FakeBatched(), max_items=2, max_bytes=64 << 20)
+    files = [tmp_path / f"{c}.wav" for c in "abc"]
+    for i, f in enumerate(files):
+        f.write_bytes(bytes([i + 1]) * 16)  # distinct content → distinct cache keys
+    for f in files:
+        enc.encode(str(f))
+    encode_log.clear()
+    # 'a' was evicted (LRU); 'b' and 'c' are still cached
+    enc.encode(str(files[1]))  # b — should hit
+    enc.encode(str(files[2]))  # c — should hit
+    assert encode_log == [], "b and c should be cached (not re-encoded)"
+    enc.encode(str(files[0]))  # a — must re-encode
+    assert len(encode_log) == 1 and str(files[0]) in encode_log[0]
+
+    # --- byte-budget eviction: each entry is 2*12*4=96 bytes as int32 ---
+    entry_bytes = 2 * N_VQ * 4  # int32
+    enc2 = CachedReferenceEncoder(_FakeBatched(), max_items=1000, max_bytes=entry_bytes)
+    f1, f2 = tmp_path / "d.wav", tmp_path / "e.wav"
+    f1.write_bytes(b"y" * 16)
+    f2.write_bytes(b"z" * 16)
+    encode_log.clear()
+    enc2.encode(str(f1))
+    enc2.encode(str(f2))  # f1 evicted by byte budget
+    encode_log.clear()
+    enc2.encode(str(f2))  # e — should hit
+    assert encode_log == [], "f2 should be cached"
+    enc2.encode(str(f1))  # d — must re-encode
+    assert len(encode_log) == 1
+
+    # --- oversized entry is gracefully rejected, does not crash ---
+    enc3 = CachedReferenceEncoder(_FakeBatched(), max_items=10, max_bytes=1)
+    f3 = tmp_path / "big.wav"
+    f3.write_bytes(b"big" * 16)
+    result = enc3.encode(str(f3))
+    assert result is not None  # still returns a value
+
+
+def test_cached_reference_encoder_true_concurrency_dedup(tmp_path):
+    """T4: concurrent same-key requests — exactly 1 encode, all results torch.equal,
+    data_ptr pairwise distinct (each caller gets an independent clone).
+    """
+    import threading as _threading
+
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+
+    ref = tmp_path / "ref.wav"
+    ref.write_bytes(b"concurrent test")
+
+    gate = _threading.Event()
+    call_count = 0
+
+    class _GatedBatched:
+        def encode(self, path: str) -> torch.Tensor:
+            nonlocal call_count
+            gate.wait()  # stall until all threads have registered
+            call_count += 1
+            return torch.full((5, N_VQ), 42, dtype=torch.long)
+
+    N = 8
+    enc = CachedReferenceEncoder(_GatedBatched(), max_items=256, max_bytes=64 << 20)
+    results = [None] * N
+    errors = []
+
+    def worker(idx):
+        try:
+            results[idx] = enc.encode(str(ref))
+        except Exception as e:
+            errors.append(e)
+
+    threads = [_threading.Thread(target=worker, args=(i,)) for i in range(N)]
+    for t in threads:
+        t.start()
+    # Give threads time to block inside encode() before releasing gate
+    import time
+
+    time.sleep(0.05)
+    gate.set()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert not errors, f"unexpected errors: {errors}"
+    assert call_count == 1, f"expected 1 encode call, got {call_count}"
+    assert all(r is not None for r in results)
+    ref_tensor = results[0]
+    for r in results[1:]:
+        assert torch.equal(ref_tensor, r), "results not bit-identical"
+    ptrs = [r.data_ptr() for r in results]
+    assert len(set(ptrs)) == len(ptrs), "data_ptr not pairwise distinct (shared tensor)"
+
+    stats = enc.stats()
+    assert stats["misses"] == 1
+    assert stats["merged"] == N - 1
+    assert stats["hits"] == 0
+
+
+def test_cached_reference_encoder_failure_does_not_poison(tmp_path):
+    """T6: leader failure fans out independent exception instances; cache stays clean;
+    third request becomes new leader and succeeds.
+    """
+    import threading as _threading
+
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+
+    ref = tmp_path / "flaky.wav"
+    ref.write_bytes(b"flaky")
+
+    gate = _threading.Event()
+    call_count = 0
+
+    class _FlakyBatched:
+        def encode(self, path: str) -> torch.Tensor:
+            nonlocal call_count
+            call_count += 1
+            gate.wait()
+            if call_count == 1:
+                raise RuntimeError("transient encode failure")
+            return torch.full((3, N_VQ), 7, dtype=torch.long)
+
+    enc = CachedReferenceEncoder(_FlakyBatched(), max_items=256, max_bytes=64 << 20)
+    exc_results = [None, None]
+
+    def fail_worker(idx):
+        try:
+            enc.encode(str(ref))
+        except Exception as e:
+            exc_results[idx] = e
+
+    t0 = _threading.Thread(target=fail_worker, args=(0,))
+    t1 = _threading.Thread(target=fail_worker, args=(1,))
+    t0.start()
+    t1.start()
+    import time
+
+    time.sleep(0.05)
+    gate.set()
+    t0.join(timeout=10)
+    t1.join(timeout=10)
+
+    # Both threads got an exception
+    assert exc_results[0] is not None
+    assert exc_results[1] is not None
+    # Each gets an independent instance (not the same object)
+    assert exc_results[0] is not exc_results[1]
+    # Cache not poisoned
+    assert enc.stats()["entries"] == 0
+    # inflight cleared
+    assert len(enc._inflight) == 0
+
+    # Third request succeeds (new leader)
+    gate.clear()
+    gate.set()
+    result = enc.encode(str(ref))
+    assert result is not None
+    assert torch.equal(result, torch.full((3, N_VQ), 7, dtype=torch.long))
+
+
+def test_cached_reference_encoder_return_value_isolation(tmp_path):
+    """T7: mutating the returned tensor does not corrupt the cached copy."""
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+
+    ref = tmp_path / "iso.wav"
+    ref.write_bytes(b"isolation test")
+
+    class _FakeBatched:
+        def encode(self, path: str) -> torch.Tensor:
+            return torch.full((4, N_VQ), 99, dtype=torch.long)
+
+    enc = CachedReferenceEncoder(_FakeBatched(), max_items=256, max_bytes=64 << 20)
+    enc.encode(str(ref))  # miss — populates cache
+
+    hit1 = enc.encode(str(ref))  # first hit
+    hit1.fill_(-1)  # mutate in place
+
+    hit2 = enc.encode(str(ref))  # second hit — must still be 99
+    assert torch.all(hit2 == 99), "cache was corrupted by mutation of first hit result"
+
+
+def test_cached_reference_encoder_duration_gate(tmp_path, monkeypatch):
+    """T8: references over 100 s are rejected before touching the cache."""
+    import torchaudio
+
+    from sglang_omni.models.moss_tts_local.stages import (
+        CachedReferenceEncoder,
+        _BatchedReferenceEncoder,
+    )
+
+    ref = tmp_path / "long.wav"
+    ref.write_bytes(b"fake long audio")
+    encode_count = 0
+
+    class _FakeBatched:
+        def encode(self, path: str) -> torch.Tensor:
+            nonlocal encode_count
+            encode_count += 1
+            return torch.zeros((5, N_VQ), dtype=torch.long)
+
+    # Patch torchaudio.info to report a 200-second file
+    class _FakeInfo:
+        num_frames = 200 * 48000
+        sample_rate = 48000
+
+    monkeypatch.setattr(torchaudio, "info", lambda path: _FakeInfo(), raising=False)
+
+    enc = CachedReferenceEncoder(_FakeBatched(), max_items=256, max_bytes=64 << 20)
+
+    # _BatchedReferenceEncoder.encode checks duration before enqueuing; CachedReferenceEncoder
+    # calls through to the underlying encoder so the duration check still fires.
+    with pytest.raises(ValueError, match="100"):
+        enc.encode(str(ref))
+
+    assert encode_count == 0, "oversized reference must not reach the codec"
+    assert enc.stats()["entries"] == 0
+    assert len(enc._inflight) == 0
+
+
 def test_branchless_sampler_matches_eager_sampler():
     """The CUDA-graphable sampler must reproduce the eager path exactly."""
     pytest.importorskip("sglang")

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -734,6 +734,22 @@ def test_cached_reference_encoder_lru_eviction(tmp_path):
     assert result is not None  # still returns a value
 
 
+def test_cached_reference_encoder_rejects_nonpositive_capacity():
+    """Negative/zero capacities fail fast at construction (P3, review)."""
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+
+    class _FakeBatched:
+        def encode(self, path: str) -> torch.Tensor:
+            return torch.zeros((2, N_VQ), dtype=torch.long)
+
+    with pytest.raises(ValueError, match="max_items"):
+        CachedReferenceEncoder(_FakeBatched(), max_items=-1)
+    with pytest.raises(ValueError, match="max_items"):
+        CachedReferenceEncoder(_FakeBatched(), max_items=0)
+    with pytest.raises(ValueError, match="max_bytes"):
+        CachedReferenceEncoder(_FakeBatched(), max_bytes=0)
+
+
 def test_cached_reference_encoder_true_concurrency_dedup(tmp_path):
     """T4: concurrent same-key requests — exactly 1 encode, all results torch.equal,
     data_ptr pairwise distinct (each caller gets an independent clone).

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -889,6 +889,134 @@ def test_cached_reference_encoder_duration_gate(tmp_path, monkeypatch):
     assert len(enc._inflight) == 0
 
 
+# ---------------------------------------------------------------------------
+# Data-URI path (commit 4): bytes: keyspace + duration check
+# ---------------------------------------------------------------------------
+
+
+def _make_wav_data_uri(
+    n_samples: int = 100, sample_rate: int = 16000
+) -> tuple[str, bytes]:
+    """Minimal 16-bit mono PCM WAV wrapped as a data URI."""
+    import base64
+
+    samples = b"\x00\x00" * n_samples
+    data_size = len(samples)
+    header = struct.pack(
+        "<4sI4s4sIHHIIHH4sI",
+        b"RIFF",
+        36 + data_size,
+        b"WAVE",
+        b"fmt ",
+        16,
+        1,
+        1,
+        sample_rate,
+        sample_rate * 2,
+        2,
+        16,
+        b"data",
+        data_size,
+    )
+    raw = header + samples
+    return f"data:audio/wav;base64,{base64.b64encode(raw).decode()}", raw
+
+
+def test_cached_reference_encoder_data_uri_hit_miss(tmp_path):
+    """bytes: keyspace: same data-URI encoded twice → 1 encode_audios_from_wav call."""
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+
+    data_uri, _ = _make_wav_data_uri()
+    wav_call_count = 0
+
+    class _FakeProc:
+        def encode_audios_from_wav(self, wavs, sample_rate):
+            nonlocal wav_call_count
+            wav_call_count += 1
+            return [torch.full((5, N_VQ), 42, dtype=torch.long)]
+
+    enc = CachedReferenceEncoder(
+        None, max_items=256, max_bytes=64 << 20  # type: ignore[arg-type]
+    )
+    proc = _FakeProc()
+    enc.encode_data_uri(data_uri, processor=proc)
+    assert wav_call_count == 1, "first call must encode"
+
+    result2 = enc.encode_data_uri(data_uri, processor=proc)
+    assert wav_call_count == 1, "second call must hit cache"
+    assert torch.equal(result2, torch.full((5, N_VQ), 42, dtype=torch.long))
+
+    stats = enc.stats()
+    assert stats["hits"] == 1
+    assert stats["misses"] == 1
+
+
+def test_cached_reference_encoder_file_bytes_keyspaces_do_not_collide(tmp_path):
+    """file: and bytes: keys are independent; same-content file ≠ data-URI in cache."""
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+
+    data_uri, raw = _make_wav_data_uri()
+
+    # Write the same raw bytes as a file
+    ref_file = tmp_path / "ref.wav"
+    ref_file.write_bytes(raw)
+
+    encode_count = 0
+
+    class _FakeBatched:
+        def encode(self, path: str) -> torch.Tensor:
+            nonlocal encode_count
+            encode_count += 1
+            return torch.full((5, N_VQ), 7, dtype=torch.long)
+
+    class _FakeProc:
+        def encode_audios_from_wav(self, wavs, sample_rate):
+            return [torch.full((5, N_VQ), 7, dtype=torch.long)]
+
+    enc = CachedReferenceEncoder(_FakeBatched(), max_items=256, max_bytes=64 << 20)
+    enc.encode(str(ref_file))  # populates file: key
+    enc.encode_data_uri(data_uri, processor=_FakeProc())  # must NOT hit file: entry
+
+    assert (
+        enc.stats()["misses"] == 2
+    ), "file: and bytes: are independent keyspaces; data-URI must be a fresh miss"
+
+
+def test_cached_reference_encoder_data_uri_duration_gate():
+    """data-URI references over 100 s are rejected."""
+    import base64
+    import io
+
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+
+    pytest.importorskip("soundfile")
+    import soundfile as sf
+
+    # Build a 200-second silent WAV (at 8 kHz to keep size small)
+    sample_rate = 8000
+    n_samples = 200 * sample_rate
+    buf = io.BytesIO()
+    import numpy as np
+
+    sf.write(buf, np.zeros(n_samples, dtype=np.float32), sample_rate, format="WAV")
+    raw = buf.getvalue()
+    uri = f"data:audio/wav;base64,{base64.b64encode(raw).decode()}"
+
+    enc = CachedReferenceEncoder(
+        None, max_items=256, max_bytes=64 << 20  # type: ignore[arg-type]
+    )
+
+    class _FakeProc:
+        def encode_audios_from_wav(self, wavs, sr):
+            return [torch.zeros((5, N_VQ), dtype=torch.long)]
+
+    with pytest.raises(ValueError, match="100"):
+        enc.encode_data_uri(uri, processor=_FakeProc())
+
+    assert enc.stats()["entries"] == 0
+    assert len(enc._inflight) == 0
+
+
 def test_branchless_sampler_matches_eager_sampler():
     """The CUDA-graphable sampler must reproduce the eager path exactly."""
     pytest.importorskip("sglang")

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -878,10 +878,7 @@ def test_cached_reference_encoder_duration_gate(tmp_path, monkeypatch):
     """T8: references over 100 s are rejected before touching the cache."""
     import torchaudio
 
-    from sglang_omni.models.moss_tts_local.stages import (
-        CachedReferenceEncoder,
-        _BatchedReferenceEncoder,
-    )
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
 
     ref = tmp_path / "long.wav"
     ref.write_bytes(b"fake long audio")

--- a/tests/unit_test/preprocessing/test_cache_key.py
+++ b/tests/unit_test/preprocessing/test_cache_key.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the shared reference-audio path cache-key helpers."""
+
+from sglang_omni.preprocessing import cache_key
+
+
+def test_reference_path_cache_key_tracks_file_content(tmp_path) -> None:
+    ref_audio = tmp_path / "ref.wav"
+    ref_audio.write_bytes(b"a")
+    first_key = cache_key.reference_path_cache_key(ref_audio)
+
+    # Same content -> stable key (so repeat requests hit the cache).
+    assert first_key == cache_key.reference_path_cache_key(ref_audio)
+
+    ref_audio.write_bytes(b"longer")
+    second_key = cache_key.reference_path_cache_key(ref_audio)
+
+    # Different content -> different key (so a replaced file is not stale-served).
+    assert first_key is not None and first_key.startswith("file:")
+    assert second_key is not None and second_key.startswith("file:")
+    assert first_key != second_key
+
+
+def test_reference_path_cache_key_same_size_edit_and_non_files(tmp_path) -> None:
+    # Same path, same size, same head/tail, different middle must not stale-hit.
+    head, tail = b"H" * 8192, b"T" * 8192
+    ref_audio = tmp_path / "ref.wav"
+    ref_audio.write_bytes(head + b"a" * 4096 + tail)
+    key_a = cache_key.reference_path_cache_key(ref_audio)
+    ref_audio.write_bytes(head + b"b" * 4096 + tail)  # same size, middle differs
+    assert key_a is not None
+    assert key_a != cache_key.reference_path_cache_key(ref_audio)
+
+    # URLs and missing files resolve to no key (callers bypass the cache).
+    assert cache_key.reference_path_cache_key("https://example.com/ref.wav") is None
+    assert cache_key.reference_path_cache_key(str(tmp_path / "missing.wav")) is None
+
+
+def test_reference_path_cache_key_memoizes_stable_file_hash(
+    monkeypatch, tmp_path
+) -> None:
+    ref_audio = tmp_path / "ref.wav"
+    ref_audio.write_bytes(b"fake wav bytes")
+    cache_key._REF_PATH_HASH_MEMO.clear()
+    read_calls = 0
+    original_read_bytes = cache_key.Path.read_bytes
+
+    def counting_read_bytes(path):
+        nonlocal read_calls
+        if path == ref_audio:
+            read_calls += 1
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(cache_key.Path, "read_bytes", counting_read_bytes)
+
+    first_key = cache_key.reference_path_cache_key(ref_audio)
+    second_key = cache_key.reference_path_cache_key(ref_audio)
+
+    assert first_key == second_key
+    assert read_calls == 1

--- a/tests/unit_test/preprocessing/test_cache_key.py
+++ b/tests/unit_test/preprocessing/test_cache_key.py
@@ -58,3 +58,66 @@ def test_reference_path_cache_key_memoizes_stable_file_hash(
 
     assert first_key == second_key
     assert read_calls == 1
+
+
+def test_reference_path_cache_key_trust_stat_skips_sentinel_on_hit(
+    monkeypatch, tmp_path
+) -> None:
+    # The opt-in trust_stat fast path (absorbed from #740) trusts the
+    # (size, mtime_ns, ctime_ns) stat tuple as content identity and skips the
+    # sentinel byte-read on memo hits. Co-authored idea: GaokaiZhang (#740).
+    ref_audio = tmp_path / "ref.wav"
+    ref_audio.write_bytes(b"fake wav bytes")
+    cache_key._REF_PATH_HASH_MEMO.clear()
+
+    sentinel_calls = 0
+    original_sentinel = cache_key._reference_path_sentinel
+
+    def counting_sentinel(path, file_size):
+        nonlocal sentinel_calls
+        sentinel_calls += 1
+        return original_sentinel(path, file_size)
+
+    monkeypatch.setattr(cache_key, "_reference_path_sentinel", counting_sentinel)
+
+    # First call (memo miss) must still compute the sentinel once so the memo
+    # entry stays valid for default (trust_stat=False) callers like Higgs.
+    first = cache_key.reference_path_cache_key(ref_audio, trust_stat=True)
+    assert sentinel_calls == 1
+    # Second call (memo hit) takes the fast path: no further sentinel read.
+    second = cache_key.reference_path_cache_key(ref_audio, trust_stat=True)
+    assert sentinel_calls == 1
+    assert first == second
+
+
+def test_reference_path_cache_key_trust_stat_keyspace_matches_default(
+    tmp_path,
+) -> None:
+    # trust_stat must produce a byte-identical key to the default path for the
+    # same content, so both callers share one keyspace.
+    ref_audio = tmp_path / "ref.wav"
+    ref_audio.write_bytes(b"shared content bytes")
+
+    cache_key._REF_PATH_HASH_MEMO.clear()
+    key_default = cache_key.reference_path_cache_key(ref_audio)
+    cache_key._REF_PATH_HASH_MEMO.clear()
+    key_trust = cache_key.reference_path_cache_key(ref_audio, trust_stat=True)
+
+    assert key_default is not None and key_default.startswith("file:")
+    assert key_default == key_trust
+
+
+def test_reference_path_cache_key_trust_stat_invalidates_on_stat_change(
+    tmp_path,
+) -> None:
+    # A real content replacement that changes the stat tuple still invalidates.
+    ref_audio = tmp_path / "ref.wav"
+    ref_audio.write_bytes(b"a" * 64)
+    cache_key._REF_PATH_HASH_MEMO.clear()
+    key_a = cache_key.reference_path_cache_key(ref_audio, trust_stat=True)
+
+    ref_audio.write_bytes(b"b" * 128)  # different size -> stat tuple changes
+    key_b = cache_key.reference_path_cache_key(ref_audio, trust_stat=True)
+
+    assert key_a is not None and key_b is not None
+    assert key_a != key_b


### PR DESCRIPTION
# [Perf] Reference audio cache for MOSS-TTS-Local-v1.5 (LRU + single-flight dedup)

Addresses #731 (roadmap: #637) — the MOSS-TTS reference-audio encoder LRU cache.  
Builds on AkazaAkane's prior design in #648 and the Higgs reference cache in #605.

---

## Motivation

MOSS-TTS-Local-v1.5's `_BatchedReferenceEncoder` runs the ~1B-param causal codec encoder
for every reference audio, costing roughly **0.25 GPU-seconds per encode** on the codec
device. #728 already coalesces concurrent requests into batches (up to 8 per 4 ms window,
`stages.py:202`), but the same reference arriving at different times still re-encodes
independently. For the common "fixed speaker" workload this is redundant work on a GPU
already shared with AR prefill.

Radix-cache in the SGLang backend covers AR-side prefix reuse (#728 body); this PR targets
only the **encode side** (the incremental cost above and beyond what #728 provides).

---

## What this PR does (5 commits)

| Commit | Title | Key change |
|---|---|---|
| a5fa07c | `[Refactor]` Extract shared reference-audio cache key helpers | Higgs memo/sentinel/hash functions → `preprocessing/cache_key.py`; Higgs re-exports aliases (zero behaviour change) |
| 400e189 | `[Perf]` Add cached reference encoder for MOSS-TTS Local | `CachedReferenceEncoder` wrapping `_BatchedReferenceEncoder` |
| 6a7b7b1 | `[Config]` Wire ref-audio cache flags into preprocessing executor | Three kwargs + `config.py` factory_args; 60 s stats logging |
| b19baa7 | `[Perf]` Cache data-URI references (bytes: keyspace) + add duration gate | `encode_data_uri`; `bytes:` keyspace; data-URI duration check |
| fa4c22a | `[Perf]` Add opt-in stat-trusting fast path for reference cache keys | `trust_stat` flag (zero-I/O memo hit); co-authored with GaokaiZhang (#740) |
| 2855ac1 | `[Review]` Address review | validate capacity; DRY `_cached_encode`; **MOSS defaults `trust_stat=False`**; log cadence constant |

---

## Cross-model note (commit a5fa07c touches `higgs_tts/stages.py`)

Commit 1 is a pure **extraction refactor** of `higgs_tts/stages.py`: the memo dict,
sentinel reader, and `reference_path_cache_key` function were moved verbatim into
`sglang_omni/preprocessing/cache_key.py`, and `higgs_tts/stages.py` now re-imports them
at the same names (`stages.py:53–60`). No Higgs logic was changed; all existing Higgs
tests pass without modification (`tests/unit_test/higgs_tts/test_pipeline.py:117–194`).
The refactor is a prerequisite so MOSS-TTS-Local can share the same key scheme without
duplicating 80 lines.

---

## Architecture

```
request
  └─ CachedReferenceEncoder.encode(path)
        │
        ├─ 1. duration gate (>100 s → reject)           stages.py:266
        │     (file path: gated first via cheap torchaudio.info;
        │      data-URI: checked inside the leader so concurrent
        │      same-payload requests share one sf.read)
        ├─ 2. key = reference_path_cache_key(path)       stages.py:267
        │       └─ stat-memo (size+mtime+ctime) → sentinel (8 KB×3) → xxh3_64
        │          → "file:{hex}" or None (missing/URL)  cache_key.py:115–135
        │
        ├─ 3. cache hit → return stored.clone().to(long) stages.py:276–280
        ├─ 4. in-flight (single-flight) → follower waits stages.py:280–286
        └─ 5. miss → register leader Future
                └─ _BatchedReferenceEncoder.encode(path) (4 ms coalescer)
                        └─ processor.encode_audios_from_path(unique_paths)
                              ↓
               TOCTOU re-stat before put               stages.py:313–319
               cache.put(key, stored_int32_cpu)
               future.set_result(stored)
```

**Keyspaces** (two distinct prefixes, never cross-contaminate):

| Input | Prefix | Key content |
|---|---|---|
| File path | `file:` | xxh3\_64 of full file bytes, gated by stat-memo + sentinel |
| data-URI | `bytes:` | xxh3\_64 of raw decoded bytes |
| Missing / URL / tensor | `None` | cache and single-flight bypassed entirely |

**Storage**: `detach().to("cpu", torch.int32)` — matches Higgs code-cache discipline
(`higgs_tts/stages.py:365`). On hit: `.clone().to(torch.long)`. On miss: original codec
tensor returned unchanged (bit-identical to OFF=True path).

**Capacity defaults** (`config.py:23–25`):

| Flag | Default | Worst-case RAM |
|---|---|---|
| `ref_audio_cache_max_items` | 256 | ~15 MB (100 s clips × 12 VQ × 4 B × 256) |
| `ref_audio_cache_max_bytes` | 64 MiB | hard backstop |

**Failure semantics**: leader failure clears `_inflight` without writing to cache;
each follower receives an independent `RuntimeError(...) from cause` (not the shared
exception instance — mirrors the existing `stages.py:216–221` note in
`_BatchedReferenceEncoder`). Third request becomes a new leader and may succeed.

---

## Correctness gate

Unit test `test_cached_reference_encoder_on_off_hit_bit_identical` (`test_pipeline.py:~490`):
- Runs the full `_prepare_moss_tts_local_request` chain with a fake-but-correct processor
- Asserts OFF path == ON-miss path == ON-hit path (identical `prompt_rows` and
  `input_ids_list`)
- Verifies int32 round-trip is lossless at the boundary value 1023
- Confirms `encode_count == 1` on the second (hit) call

Smoke test on novita-h100 with real MOSS-TTS-Local-Transformer-v1.5 weights (GPU 3):
- hit-path CPU tensor accepted by `processor.build_user_message` ✓
- T=62 frames / 5.0 s = 12.40 Hz ≈ 12.5 Hz empirically confirmed ✓

---

## Benchmark

### Corroborating numbers from #740 (same approach, GaokaiZhang's implementation)

> These measure #740's implementation of the same content-keyed LRU, not this
> branch's code. They corroborate the mechanism; our own Phase 3 numbers on this
> branch (table below) will be the primary evidence. Source: #740 PR body, 2×H100.

- Hit-path effect (same reference, sequential requests, live server): first request
  (miss) **2.44 s** → subsequent requests (hits) **0.81 s** mean.
- SeedTTS EN full (pure miss path, every reference unique), c=16, 2×H100:
  rtf_mean **0.4811**, WER 2.27% raw / 1.71% excl., 1088/1088, 0 failed, 7.91 req/s.
  Same-day baseline on merged main: rtf_mean 0.5053, WER 2.21% raw / 1.79% excl.
  (deltas within the run-to-run band documented in #728).

### Our Phase 3 (this branch) — measured

> **Environment (full disclosure):** novita-h100. A sole-occupant run was planned on NUMA1
> (GPU5+6); mid-run an unrelated co-tenant took GPU6+7 and saturated NUMA1 CPU, so the
> benchmark **migrated to GPU4+5 with CPU pinned to NUMA0** (`numactl --cpunodebind=0
> --membind=0`). Cross-NUMA GPU access is a **constant** overhead identical for the ON and
> OFF arms and every round (ABAB interleaved), so it does **not bias the A/B** — it only
> shifts the absolute rtf baseline. Each round ran a co-tenant-contamination gate; all 6
> Load-A rounds passed clean. Full methodology + per-round data in the run report.

**Load A — SeedTTS EN full set (1088), ABAB ON/OFF ×3 (1088/1088 each, 0 failed)**

| metric | Cache OFF (mean ± 95% CI) | Cache ON (mean ± 95% CI) |
|---|---|---|
| RTF mean | 0.5096 ± 0.0387 | 0.4973 ± 0.0257 |
| throughput req/s | 7.443 ± 0.633 | 7.637 ± 0.414 |
| RTF p99 | 1.0547 ± 0.1942 | 1.0029 ± 0.0450 |

The ON/OFF 95% CIs **overlap** → the cache is statistically indistinguishable from OFF =
**no regression** (zero measurable overhead). The nominal ~2.5% ON edge is within noise at 3
rounds; the saved encode work surfaces as returned GPU headroom (below), not an rtf gain at
c=16 where AR generation dominates.

**Native reuse + savings (hard counts).** SeedTTS EN recurs speakers across target texts, so
the standard benchmark itself exercises the cache. One full-set ON snapshot:

| lookups | encodes (misses) | hits | merged (single-flight) | reuse | encodes avoided | GPU-s saved |
|---|---|---|---|---|---|---|
| 915 | 566 | 71 | 278 | 38.1% | 349 | ~87 |

`merged` (single-flight dedup) is a capability **#740 lacks** — hundreds of concurrent
same-reference requests folded onto one in-flight encode instead of re-encoding.

**WER sanity (quality non-regression):** ON **2.39% raw / 1.82% excl-outliers** vs OFF
**2.22% raw / 1.68% excl** (Qwen3-ASR, 1088/1088 each, 6 outliers each). The ~0.17%
difference is AR sampling noise (temp=0.8 → non-identical audio run-to-run) — same band as
#740's 2.27%/2.21%. Codes-level ON==re-encode identity is separately proven by unit test
T5; WER_ON ≈ WER_OFF confirms no audible regression.

**Load B — fixed-speaker reuse sweep (N=512, cache ON), mechanism curve (hard counts):**

| K speakers | encodes performed (=K) | encodes saved (512−K) | GPU-s saved (×0.25) | hit-rate |
|---|---|---|---|---|
| 1 | 1 | 511 | ~128 | 0.998 |
| 4 | 4 | 508 | ~127 | 0.992 |
| 16 | 16 | 496 | ~124 | 0.969 |
| 64 | 64 | 448 | ~112 | 0.875 |
| 256 | 256 | 256 | ~64 | 0.500 |

Lower K → more reuse → more encodes skipped → more GPU-seconds returned to the AR engine.
(Load-B end-to-end throughput was AR-generation-bound with token-count uncontrolled in the
client, so it is **not** a cache comparison; the value is the exact encode/GPU-second
savings above, which are hard counts with zero statistical noise.)

---

## Relation to #740 and #730

**#740** ("[Perf] MOSS-TTS Local: content-keyed LRU for reference codes", GaokaiZhang)
independently implemented the same #637 roadmap item. We have **converged on this PR
as the base** (coordinated with GaokaiZhang). The stat-only memo fast path from #740 is
incorporated here as the opt-in `trust_stat` flag (**MOSS defaults it `False` per review;
opt-in for immutable-reference deployments**) (commit "Add opt-in stat-trusting fast
path", co-authored with GaokaiZhang), and #740's benchmark numbers are cited below with
attribution. #740 will close in favor of this PR.

**#730 / #744** (decouple): #744 ("Split preprocessing; add audio_encoder stage") is the
MOSS-TTS-Local half of the #730 decouple — it moves the heavy reference-encode work out of
`preprocessing` into a dedicated `audio_encoder` stage. This PR is **complementary**: the
cache is an outer wrapper around that encoder and migrates with it. When #744 merges after
#743, the `CachedReferenceEncoder` wrapping and its flags move from
`create_preprocessing_executor` to `create_audio_encoder_executor` (~13 lines, no logic
change); reference-encode semantics are byte-identical across the split. Porting the same
cache to the older `moss_tts` (Delay) path is a separate follow-up (cf. AkazaAkane's
#648/#699).

---

## Cap discussion / Future work

The reference encode cache and the AR-side prefix cache are **orthogonal**: a cache hit
eliminates the codec GPU-second but still consumes a preprocessing-worker slot from
`max_concurrency=16`. If the AR concurrency cap is raised to 32 in a future PR,
`preprocessing max_concurrency=16` may become the new bottleneck under high load —
the cache shifts where time is spent (codec → Python dispatch) but does not by itself
increase the worker pool size. Raising `max_concurrency` in tandem, or combining with
the async-decode lookahead work in the pipeline, would complete the optimisation.

---

## Testing

```
pytest tests/unit_test/moss_tts_local/test_pipeline.py  -x   # T1–T9 + existing tests
pytest tests/unit_test/higgs_tts/test_pipeline.py       -x   # Higgs regression (T1/T2)
pytest tests/unit_test/preprocessing/                   -x   # key helper tests
```

94 collected, 94 passed on novita-h100 (sglang-omni docker, full deps).

New tests added:

| Test | What it covers |
|---|---|
| `test_cached_reference_encoder_on_off_hit_bit_identical` | Bit-identical gate (T5) |
| `test_cached_reference_encoder_lru_eviction` | Item-count + byte-budget eviction (T3) |
| `test_cached_reference_encoder_true_concurrency_dedup` | Single-flight, 8 threads (T4) |
| `test_cached_reference_encoder_failure_does_not_poison` | Independent exceptions, no cache poison (T6) |
| `test_cached_reference_encoder_return_value_isolation` | Clone isolation (T7) |
| `test_cached_reference_encoder_duration_gate` | >100 s rejected pre-inflight (T8) |
| `test_cached_reference_encoder_data_uri_hit_miss` | bytes: keyspace hit/miss |
| `test_cached_reference_encoder_file_bytes_keyspaces_do_not_collide` | Keyspace isolation |
| `test_cached_reference_encoder_data_uri_duration_gate` | data-URI duration check |
