### PR TITLE
Split preprocessing; add audio_encoder stage

### DIFF
--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -18,6 +18,13 @@ def _stages(*, codec_device: str) -> list[StageConfig]:
             name="preprocessing",
             process="pipeline",
             factory=f"{_PKG}.stages.create_preprocessing_executor",
+            gpu=0,
+            next="audio_encoder",
+        ),
+        StageConfig(
+            name="audio_encoder",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_audio_encoder_executor",
             factory_args={"device": codec_device},
             gpu=0,
             next="tts_engine",
@@ -42,7 +49,7 @@ def _stages(*, codec_device: str) -> list[StageConfig]:
 
 
 class MossTTSLocalPipelineConfig(PipelineConfig):
-    """MOSS-TTS Local pipeline: preprocessing -> AR engine -> vocoder."""
+    """MOSS-TTS Local pipeline: preprocessing -> audio_encoder -> AR -> vocoder."""
 
     architecture: ClassVar[str] = "MossTTSLocalModel"
     architecture_aliases: ClassVar[tuple[str, ...]] = (

--- a/sglang_omni/models/moss_tts_local/request_builders.py
+++ b/sglang_omni/models/moss_tts_local/request_builders.py
@@ -73,24 +73,24 @@ class MossTTSLocalPreparedRequest:
 
 
 @dataclass
-class _PreprocessingContext:
+class _AudioEncoderContext:
     processor: Any
     reference_encoder: Any = None
 
 
-_PREPROCESSING_CONTEXT: _PreprocessingContext | None = None
+_AUDIO_ENCODER_CONTEXT: _AudioEncoderContext | None = None
 _PREPARED_REQUESTS: dict[str, MossTTSLocalPreparedRequest] = {}
 _INFLIGHT_REQUESTS: set[str] = set()
 _ABORTED_REQUESTS: set[str] = set()
 _PREPARED_REQUESTS_LOCK = threading.Lock()
 
 
-def set_moss_tts_local_preprocessing_context(
+def set_moss_tts_local_audio_encoder_context(
     *, processor: Any, reference_encoder: Any = None
 ) -> None:
-    global _PREPROCESSING_CONTEXT
+    global _AUDIO_ENCODER_CONTEXT
     with _PREPARED_REQUESTS_LOCK:
-        _PREPROCESSING_CONTEXT = _PreprocessingContext(
+        _AUDIO_ENCODER_CONTEXT = _AudioEncoderContext(
             processor=processor, reference_encoder=reference_encoder
         )
         _PREPARED_REQUESTS.clear()
@@ -98,13 +98,25 @@ def set_moss_tts_local_preprocessing_context(
         _ABORTED_REQUESTS.clear()
 
 
-def clear_moss_tts_local_preprocessing_context() -> None:
-    global _PREPROCESSING_CONTEXT
+def clear_moss_tts_local_audio_encoder_context() -> None:
+    global _AUDIO_ENCODER_CONTEXT
     with _PREPARED_REQUESTS_LOCK:
-        _PREPROCESSING_CONTEXT = None
+        _AUDIO_ENCODER_CONTEXT = None
         _PREPARED_REQUESTS.clear()
         _INFLIGHT_REQUESTS.clear()
         _ABORTED_REQUESTS.clear()
+
+
+def set_moss_tts_local_preprocessing_context(
+    *, processor: Any, reference_encoder: Any = None
+) -> None:
+    set_moss_tts_local_audio_encoder_context(
+        processor=processor, reference_encoder=reference_encoder
+    )
+
+
+def clear_moss_tts_local_preprocessing_context() -> None:
+    clear_moss_tts_local_audio_encoder_context()
 
 
 def cleanup_prepared_moss_tts_local_request(request_id: str) -> None:
@@ -128,7 +140,7 @@ def pop_prepared_moss_tts_local_request(
         prepared = _PREPARED_REQUESTS.pop(str(marker), None)
     if prepared is None:
         raise RuntimeError(
-            "MOSS-TTS Local preprocessing state is missing for prepared payload "
+            "MOSS-TTS Local audio encoder state is missing for prepared payload "
             f"{marker!r}; the AR scheduler must not rebuild it"
         )
     return prepared
@@ -272,10 +284,10 @@ def _build_processor_message(
 def _prepare_moss_tts_local_request(
     payload: StagePayload,
     *,
+    state: MossTTSLocalState,
     processor: Any,
     reference_encoder: Any = None,
 ) -> MossTTSLocalPreparedRequest:
-    state = build_moss_tts_local_state(payload)
     message = _build_processor_message(processor, state, reference_encoder)
     batch = processor([[message]], mode="generation")
     input_rows = batch["input_ids"]
@@ -295,22 +307,35 @@ def _prepare_moss_tts_local_request(
 
 
 def preprocess_moss_tts_local_payload(payload: StagePayload) -> StagePayload:
-    """Run prompt/reference preprocessing outside the AR scheduler."""
+    """Normalize the request into serializable MOSS-TTS Local state."""
+
+    state = build_moss_tts_local_state(payload)
+    return StagePayload(
+        request_id=payload.request_id,
+        request=payload.request,
+        data=state.to_dict(),
+    )
+
+
+def encode_moss_tts_local_payload(payload: StagePayload) -> StagePayload:
+    """Run reference encoding and prompt packing outside the AR scheduler."""
 
     rid = str(payload.request_id)
     with _PREPARED_REQUESTS_LOCK:
-        context = _PREPROCESSING_CONTEXT
+        context = _AUDIO_ENCODER_CONTEXT
         if context is not None:
             _INFLIGHT_REQUESTS.add(rid)
     if context is None:
         raise RuntimeError(
-            "MOSS-TTS Local preprocessing context is not initialized; "
-            "create_preprocessing_executor must register it before requests run"
+            "MOSS-TTS Local audio encoder context is not initialized; "
+            "create_audio_encoder_executor must register it before requests run"
         )
 
     try:
+        state = MossTTSLocalState.from_dict(payload.data)
         prepared = _prepare_moss_tts_local_request(
             payload,
+            state=state,
             processor=context.processor,
             reference_encoder=context.reference_encoder,
         )
@@ -345,7 +370,7 @@ def build_sglang_moss_tts_local_request(
     if prepared is None:
         raise RuntimeError(
             "MOSS-TTS Local AR request builder requires a payload prepared by "
-            "preprocess_moss_tts_local_payload"
+            "encode_moss_tts_local_payload"
         )
 
     cfg = model.config

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -22,9 +22,10 @@ from sglang_omni.models.moss_tts_local.payload_types import (
 )
 from sglang_omni.models.moss_tts_local.request_builders import (
     cleanup_prepared_moss_tts_local_request,
+    encode_moss_tts_local_payload,
     make_moss_tts_local_scheduler_adapters,
     preprocess_moss_tts_local_payload,
-    set_moss_tts_local_preprocessing_context,
+    set_moss_tts_local_audio_encoder_context,
 )
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
@@ -38,7 +39,7 @@ _MOSS_TTS_LOCAL_INSTALL_HINT = (
     "OpenMOSS-Team/MOSS-Audio-Tokenizer-v2."
 )
 
-# NOTE: the preprocessing and vocoder stages each load their own processor
+# NOTE: the audio_encoder and vocoder stages each load their own processor
 # (and thus their own ~4.3 GB bf16 codec instance). The codec's chunked decode
 # flips module-global streaming state (`model.streaming()`), so a decode on a
 # shared instance corrupts any concurrently running reference encode; with
@@ -66,7 +67,7 @@ def _normalize_processor_config(processor: Any) -> None:
 
 
 def _resolve_codec_device(device: str | None, gpu_id: int | None) -> str:
-    """Pick the codec GPU for the preprocessing/vocoder stages.
+    """Pick the codec GPU for the audio_encoder/vocoder stages.
 
     The ~1B-param codec encoder costs ~0.25 GPU-seconds per reference, which
     at concurrency 16 starves the AR engine when both share one device.
@@ -230,6 +231,18 @@ class _BatchedReferenceEncoder:
 def create_preprocessing_executor(
     model_path: str,
     *,
+    max_concurrency: int = 16,
+) -> SimpleScheduler:
+    del model_path
+    return SimpleScheduler(
+        preprocess_moss_tts_local_payload,
+        max_concurrency=max_concurrency,
+    )
+
+
+def create_audio_encoder_executor(
+    model_path: str,
+    *,
     device: str | None = None,
     gpu_id: int | None = None,
     max_concurrency: int = 16,
@@ -243,14 +256,14 @@ def create_preprocessing_executor(
         max_batch_size=encode_batch_size,
         max_batch_wait_ms=encode_batch_wait_ms,
     )
-    set_moss_tts_local_preprocessing_context(
+    set_moss_tts_local_audio_encoder_context(
         processor=processor, reference_encoder=reference_encoder
     )
     # Reference encoding runs through the ~1B-param causal codec encoder, so
     # unlike MOSS Delay the audio tokenizer must live on the GPU; threads
     # release the GIL during the codec forward, keeping the AR engine fed.
     return SimpleScheduler(
-        preprocess_moss_tts_local_payload,
+        encode_moss_tts_local_payload,
         abort_callback=cleanup_prepared_moss_tts_local_request,
         max_concurrency=max_concurrency,
     )

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import struct
+import sys
+import types
 
 import numpy as np
 import pytest
@@ -25,11 +27,15 @@ from sglang_omni.models.moss_tts_local.payload_types import (
 from sglang_omni.models.moss_tts_local.request_builders import (
     MossTTSLocalSGLangRequestData,
     apply_sglang_moss_tts_local_result,
+    build_sglang_moss_tts_local_request,
     build_generation_kwargs,
     build_moss_tts_local_state,
-    clear_moss_tts_local_preprocessing_context,
+    cleanup_prepared_moss_tts_local_request,
+    clear_moss_tts_local_audio_encoder_context,
+    encode_moss_tts_local_payload,
+    pop_prepared_moss_tts_local_request,
     preprocess_moss_tts_local_payload,
-    set_moss_tts_local_preprocessing_context,
+    set_moss_tts_local_audio_encoder_context,
 )
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 from sglang_omni.proto import OmniRequest, StagePayload
@@ -166,15 +172,19 @@ def test_registry_resolves_local_architecture():
 def test_pipeline_stage_wiring():
     config = MossTTSLocalPipelineConfig(model_path="OpenMOSS-Team/moss-local-test")
     stages = {stage.name: stage for stage in config.stages}
-    assert set(stages) == {"preprocessing", "tts_engine", "vocoder"}
-    assert stages["preprocessing"].next == "tts_engine"
+    assert set(stages) == {"preprocessing", "audio_encoder", "tts_engine", "vocoder"}
+    assert stages["preprocessing"].next == "audio_encoder"
+    assert stages["audio_encoder"].next == "tts_engine"
     assert stages["tts_engine"].next == "vocoder"
     assert stages["vocoder"].terminal
     for stage in stages.values():
         assert "moss_tts_local" in stage.factory
     assert stages["preprocessing"].process == "pipeline"
     assert stages["preprocessing"].gpu == 0
-    assert stages["preprocessing"].factory_args["device"] == "cuda:1"
+    assert stages["preprocessing"].factory_args == {}
+    assert stages["audio_encoder"].process == "pipeline"
+    assert stages["audio_encoder"].gpu == 0
+    assert stages["audio_encoder"].factory_args["device"] == "cuda:1"
     assert stages["tts_engine"].process == "pipeline"
     assert stages["tts_engine"].gpu == 0
     assert stages["vocoder"].process == "pipeline"
@@ -184,13 +194,15 @@ def test_pipeline_stage_wiring():
     placement = build_stage_placement_plan(config)
     assert placement.stages["tts_engine"].gpu_ids == (0,)
     assert placement.stages["preprocessing"].gpu_ids == (0,)
+    assert placement.stages["audio_encoder"].gpu_ids == (0,)
     assert placement.stages["vocoder"].gpu_ids == (0,)
 
     colocated = MossTTSLocalColocatedPipelineConfig(
         model_path="OpenMOSS-Team/moss-local-test"
     )
     colocated_stages = {stage.name: stage for stage in colocated.stages}
-    assert colocated_stages["preprocessing"].factory_args["device"] == "cuda:0"
+    assert colocated_stages["preprocessing"].factory_args == {}
+    assert colocated_stages["audio_encoder"].factory_args["device"] == "cuda:0"
     assert colocated_stages["vocoder"].factory_args["device"] == "cuda:0"
 
 
@@ -276,6 +288,9 @@ def test_build_state_token_count_and_language():
 class _FakeProcessor:
     """Builds deterministic [1, T, 13] rows from the message text length."""
 
+    def __init__(self):
+        self.messages = []
+
     @staticmethod
     def build_user_message(**kwargs):
         return dict(kwargs, role="user")
@@ -283,6 +298,7 @@ class _FakeProcessor:
     def __call__(self, conversations, mode):
         assert mode == "generation"
         message = conversations[0][0]
+        self.messages.append(message)
         text = str(message.get("text", ""))
         seq = max(4, len(text) % 7 + 4)
         rows = torch.full((1, seq, N_VQ + 1), 1024, dtype=torch.long)
@@ -299,15 +315,48 @@ def _payload(text: str = "hello") -> StagePayload:
     )
 
 
-def test_preprocess_and_result_adapter():
-    set_moss_tts_local_preprocessing_context(processor=_FakeProcessor())
-    try:
-        payload = preprocess_moss_tts_local_payload(_payload())
-        assert payload.data.get("_moss_tts_local_prepared_request") == "req-1"
+def test_preprocessing_output_contains_state_only():
+    payload = StagePayload(
+        request_id="req-1",
+        request=OmniRequest(
+            inputs={
+                "text": "${token:12} hello",
+                "references": [{"audio_path": "/tmp/ref.wav", "text": "speaker"}],
+            },
+            params={"language": "English"},
+            metadata={"tts_params": {"instructions": "calm"}},
+        ),
+        data={},
+    )
+    out = preprocess_moss_tts_local_payload(payload)
+    assert out.data["text"] == "hello"
+    assert out.data["ref_audio"] == "/tmp/ref.wav"
+    assert out.data["ref_text"] == "speaker"
+    assert out.data["language"] == "English"
+    assert out.data["instructions"] == "calm"
+    assert out.data["token_count"] == 12
+    assert "_moss_tts_local_prepared_request" not in out.data
 
-        from sglang_omni.models.moss_tts_local.request_builders import (
-            pop_prepared_moss_tts_local_request,
+
+def test_preprocessing_executor_does_not_load_processor(monkeypatch):
+    from sglang_omni.models.moss_tts_local import stages
+
+    def fail_load(*args, **kwargs):
+        raise AssertionError("preprocessing must not load the processor")
+
+    monkeypatch.setattr(stages, "_load_moss_tts_local_processor", fail_load)
+    scheduler = stages.create_preprocessing_executor("model", max_concurrency=3)
+    assert scheduler._fn is preprocess_moss_tts_local_payload
+    assert scheduler._max_concurrency == 3
+
+
+def test_audio_encoder_and_result_adapter():
+    set_moss_tts_local_audio_encoder_context(processor=_FakeProcessor())
+    try:
+        payload = encode_moss_tts_local_payload(
+            preprocess_moss_tts_local_payload(_payload())
         )
+        assert payload.data.get("_moss_tts_local_prepared_request") == "req-1"
 
         prepared = pop_prepared_moss_tts_local_request(payload)
         assert prepared is not None
@@ -335,7 +384,154 @@ def test_preprocess_and_result_adapter():
         assert result.data["completion_tokens"] == 3
         assert result.data["prompt_tokens"] == prepared.prompt_rows.shape[0]
     finally:
-        clear_moss_tts_local_preprocessing_context()
+        clear_moss_tts_local_audio_encoder_context()
+
+
+def test_audio_encoder_file_path_reference_uses_reference_encoder():
+    class _FakeReferenceEncoder:
+        def __init__(self):
+            self.paths = []
+
+        def encode(self, path):
+            self.paths.append(path)
+            return torch.full((2, N_VQ), 7, dtype=torch.long)
+
+    processor = _FakeProcessor()
+    reference_encoder = _FakeReferenceEncoder()
+    set_moss_tts_local_audio_encoder_context(
+        processor=processor, reference_encoder=reference_encoder
+    )
+    try:
+        payload = StagePayload(
+            request_id="req-1",
+            request=OmniRequest(
+                inputs={
+                    "text": "hello",
+                    "references": [{"audio_path": "/tmp/ref.wav"}],
+                },
+                params={},
+                metadata={},
+            ),
+            data={},
+        )
+        encoded = encode_moss_tts_local_payload(
+            preprocess_moss_tts_local_payload(payload)
+        )
+        prepared = pop_prepared_moss_tts_local_request(encoded)
+        assert prepared is not None
+        assert reference_encoder.paths == ["/tmp/ref.wav"]
+        assert len(processor.messages) == 1
+        reference = processor.messages[0]["reference"]
+        assert len(reference) == 1
+        torch.testing.assert_close(reference[0], torch.full((2, N_VQ), 7))
+    finally:
+        clear_moss_tts_local_audio_encoder_context()
+
+
+def test_audio_encoder_preserves_state_fields():
+    processor = _FakeProcessor()
+    set_moss_tts_local_audio_encoder_context(processor=processor)
+    try:
+        payload = StagePayload(
+            request_id="req-1",
+            request=OmniRequest(
+                inputs={"text": "${token:77} hello"},
+                params={
+                    "language": "English",
+                    "max_new_tokens": 123,
+                    "text_temperature": 0.4,
+                },
+                metadata={"tts_params": {"instructions": "bright"}},
+            ),
+            data={},
+        )
+        encoded = encode_moss_tts_local_payload(
+            preprocess_moss_tts_local_payload(payload)
+        )
+        prepared = pop_prepared_moss_tts_local_request(encoded)
+        assert prepared is not None
+        assert prepared.state.text == "hello"
+        assert prepared.state.language == "English"
+        assert prepared.state.instructions == "bright"
+        assert prepared.state.token_count == 77
+        assert prepared.gen_kwargs["max_new_tokens"] == 123
+        assert prepared.gen_kwargs["text_temperature"] == 0.4
+        assert prepared.input_ids_list == prepared.input_ids.tolist()
+    finally:
+        clear_moss_tts_local_audio_encoder_context()
+
+
+def test_audio_encoder_abort_cleanup_removes_prepared_handoff():
+    class _AbortReferenceEncoder:
+        def encode(self, path):
+            cleanup_prepared_moss_tts_local_request("req-1")
+            return torch.full((2, N_VQ), 7, dtype=torch.long)
+
+    set_moss_tts_local_audio_encoder_context(
+        processor=_FakeProcessor(), reference_encoder=_AbortReferenceEncoder()
+    )
+    try:
+        payload = StagePayload(
+            request_id="req-1",
+            request=OmniRequest(
+                inputs={
+                    "text": "hello",
+                    "references": [{"audio_path": "/tmp/ref.wav"}],
+                },
+                params={},
+                metadata={},
+            ),
+            data={},
+        )
+        encoded = encode_moss_tts_local_payload(
+            preprocess_moss_tts_local_payload(payload)
+        )
+        with pytest.raises(RuntimeError, match="missing"):
+            pop_prepared_moss_tts_local_request(encoded)
+    finally:
+        clear_moss_tts_local_audio_encoder_context()
+
+
+def test_tts_engine_rejects_unprepared_payload(monkeypatch):
+    class _FakeReq:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+            self.output_ids = []
+
+    class _FakeSamplingParams:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+        def normalize(self, tokenizer):
+            del tokenizer
+
+        def verify(self, vocab_size):
+            del vocab_size
+
+    modules = {
+        "sglang": types.ModuleType("sglang"),
+        "sglang.srt": types.ModuleType("sglang.srt"),
+        "sglang.srt.managers": types.ModuleType("sglang.srt.managers"),
+        "sglang.srt.managers.schedule_batch": types.ModuleType(
+            "sglang.srt.managers.schedule_batch"
+        ),
+        "sglang.srt.sampling": types.ModuleType("sglang.srt.sampling"),
+        "sglang.srt.sampling.sampling_params": types.ModuleType(
+            "sglang.srt.sampling.sampling_params"
+        ),
+    }
+    for name in ("sglang", "sglang.srt", "sglang.srt.managers", "sglang.srt.sampling"):
+        modules[name].__path__ = []
+    modules["sglang.srt.managers.schedule_batch"].Req = _FakeReq
+    modules["sglang.srt.sampling.sampling_params"].SamplingParams = _FakeSamplingParams
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    with pytest.raises(RuntimeError, match="encode_moss_tts_local_payload"):
+        build_sglang_moss_tts_local_request(
+            preprocess_moss_tts_local_payload(_payload()),
+            model=types.SimpleNamespace(config=types.SimpleNamespace()),
+        )
 
 
 def test_result_adapter_empty_generation():


### PR DESCRIPTION
## Motivation

This PR applies the MOSS Delay/Higgs-style stage boundary to
MOSS-TTS-Local-Transformer-v1.5.

Before:

```text
preprocessing -> tts_engine -> vocoder
```

After:

```text
preprocessing -> audio_encoder -> tts_engine -> vocoder
```

The goal is to keep preprocessing CPU/lightweight and isolate GPU codec
reference encoding plus prompt packing in a dedicated `audio_encoder` stage.

## Modifications

- Add an `audio_encoder` stage to `MossTTSLocalPipelineConfig`.
- Keep preprocessing limited to request normalization and serializable state construction.
- Move processor ownership, `_BatchedReferenceEncoder`, reference encoding, prompt row construction, and prepared-request handoff into `audio_encoder`.
- Preserve existing v1.5 batching behavior for reference encode.
- Preserve separate codec instances for `audio_encoder` and `vocoder` because vocoder decode mutates codec streaming state.
- Preserve `tts_engine` and `vocoder` behavior.
- Add unit coverage for the new split, including state-only preprocessing, audio encoder handoff, file-path reference encoding, abort cleanup, and unprepared payload rejection.

## Non-goals

- No reference-code LRU cache.
- No change to batched reference encode policy.
- No change to local-transformer frame decode.
- No change to vocoder batching or streaming.

## Related Issues

Related to #637 and #730.

## Accuracy Test

Not run. This is a stage-boundary refactor and should preserve model behavior.

## Benchmark & Profiling

Not run for this draft. The PR moves the existing batched reference encode into a dedicated stage without changing batching policy or decode behavior.

## Checklist

- [ ] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Draft PRs are skipped even if labeled.
