### PR TITLE
[Perf] Reference audio cache for MOSS-TTS-Local-v1.5 (LRU + single-flight dedup)

### DIFF
--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -25,7 +25,6 @@ import base64
 import logging
 import os
 import threading
-from collections import OrderedDict
 from pathlib import Path
 from typing import Any
 
@@ -49,7 +48,14 @@ from sglang_omni.models.higgs_tts.utils import (
 from sglang_omni.models.higgs_tts.vocoder_scheduler import (
     HiggsStreamingVocoderScheduler,
 )
-from sglang_omni.preprocessing.cache_key import hash_bytes, hash_media_item
+
+# _REF_PATH_HASH_MEMO is the shared memo object, re-exported so tests can
+# reset it; the underscored alias keeps this module's historical API.
+from sglang_omni.preprocessing.cache_key import _REF_PATH_HASH_MEMO  # noqa: F401
+from sglang_omni.preprocessing.cache_key import hash_media_item
+from sglang_omni.preprocessing.cache_key import (
+    reference_path_cache_key as _reference_path_cache_key,
+)
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler
@@ -71,90 +77,9 @@ _REF_CODE_CACHE_MAX_ITEMS = 256
 _REF_CODE_CACHE_MAX_BYTES = 256 * 1024 * 1024
 _REF_WAVEFORM_CACHE_MAX_ITEMS = 256
 _REF_WAVEFORM_CACHE_MAX_BYTES = 512 * 1024 * 1024
-_REF_PATH_HASH_MEMO_MAX_ITEMS = 1024
-_REF_PATH_HASH_SENTINEL_BYTES = 8192
-_REF_PATH_HASH_MEMO: OrderedDict[str, tuple[str, str]] = OrderedDict()
-_REF_PATH_HASH_MEMO_LOCK = threading.Lock()
 
 # Saturates near c=16 on H100/H200; higher client concurrency only queues.
 DEFAULT_MAX_CONCURRENCY = 16
-
-
-def _reference_path_hash_memo_key(path: Path) -> tuple[str, int] | None:
-    try:
-        if not path.is_file():
-            return None
-        stat_result = path.stat()
-        memo_key = (
-            f"{path.resolve()}:"
-            f"{stat_result.st_size}:"
-            f"{stat_result.st_mtime_ns}:"
-            f"{stat_result.st_ctime_ns}"
-        )
-        return memo_key, int(stat_result.st_size)
-    except OSError:
-        return None
-
-
-def _reference_path_sentinel(path: Path, file_size: int) -> str | None:
-    try:
-        chunk_size = min(_REF_PATH_HASH_SENTINEL_BYTES, file_size)
-        with path.open("rb") as f:
-            chunks = [f.read(chunk_size)]
-            if file_size > _REF_PATH_HASH_SENTINEL_BYTES:
-                middle_offset = max((file_size - chunk_size) // 2, 0)
-                f.seek(middle_offset)
-                chunks.append(f.read(chunk_size))
-            if file_size > 2 * _REF_PATH_HASH_SENTINEL_BYTES:
-                f.seek(max(file_size - chunk_size, 0))
-                chunks.append(f.read(chunk_size))
-        return hash_bytes(b"".join(chunks) + f"|size:{file_size}".encode())
-    except OSError:
-        return None
-
-
-def _get_reference_path_hash(memo_key: str, sentinel: str) -> str | None:
-    with _REF_PATH_HASH_MEMO_LOCK:
-        cached = _REF_PATH_HASH_MEMO.get(memo_key)
-        if cached is None:
-            return None
-        cached_sentinel, digest = cached
-        if cached_sentinel != sentinel:
-            _REF_PATH_HASH_MEMO.pop(memo_key, None)
-            return None
-        _REF_PATH_HASH_MEMO.move_to_end(memo_key)
-        return digest
-
-
-def _put_reference_path_hash(memo_key: str, sentinel: str, digest: str) -> None:
-    with _REF_PATH_HASH_MEMO_LOCK:
-        _REF_PATH_HASH_MEMO[memo_key] = (sentinel, digest)
-        _REF_PATH_HASH_MEMO.move_to_end(memo_key)
-        while len(_REF_PATH_HASH_MEMO) > _REF_PATH_HASH_MEMO_MAX_ITEMS:
-            _REF_PATH_HASH_MEMO.popitem(last=False)
-
-
-def _reference_path_cache_key(path_like: str | Path) -> str | None:
-    # Memoized full-content hash. The stat tuple avoids rereading stable local
-    # refs while still invalidating normal and rapid same-size replacements.
-    path = Path(str(path_like)).expanduser()
-    memo = _reference_path_hash_memo_key(path)
-    if memo is None:
-        return None
-    memo_key, file_size = memo
-    sentinel = _reference_path_sentinel(path, file_size)
-    if sentinel is None:
-        return None
-    digest = _get_reference_path_hash(memo_key, sentinel)
-    if digest is not None:
-        return f"file:{digest}"
-    try:
-        digest = hash_bytes(path.read_bytes())
-    except OSError:
-        return None
-    if _reference_path_hash_memo_key(path) == memo:
-        _put_reference_path_hash(memo_key, sentinel, digest)
-    return f"file:{digest}"
 
 
 def _reference_audio_cache_key(reference_audio: Any) -> str | None:

--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -18,7 +18,12 @@ def _stages(*, codec_device: str) -> list[StageConfig]:
             name="preprocessing",
             process="pipeline",
             factory=f"{_PKG}.stages.create_preprocessing_executor",
-            factory_args={"device": codec_device},
+            factory_args={
+                "device": codec_device,
+                "ref_audio_cache": True,
+                "ref_audio_cache_max_items": 256,
+                "ref_audio_cache_max_bytes": 64 * 1024 * 1024,
+            },
             gpu=0,
             next="tts_engine",
         ),

--- a/sglang_omni/models/moss_tts_local/request_builders.py
+++ b/sglang_omni/models/moss_tts_local/request_builders.py
@@ -249,15 +249,17 @@ def _build_processor_message(
     from sglang_omni.models.moss_tts.request_builders import _DATA_URI_RE
 
     ref_audio = state.ref_audio
-    if (
-        reference_encoder is not None
-        and isinstance(ref_audio, str)
-        and _DATA_URI_RE.match(ref_audio) is None
-    ):
-        # File-path references encode through the shared coalescer so
-        # concurrent requests share one batched codec forward instead of
-        # serializing ~0.25 GPU-seconds each.
-        reference = [reference_encoder.encode(ref_audio)]
+    if reference_encoder is not None and isinstance(ref_audio, str):
+        if _DATA_URI_RE.match(ref_audio) is None:
+            # File-path refs share one batched codec forward via the coalescer.
+            reference = [reference_encoder.encode(ref_audio)]
+        elif hasattr(reference_encoder, "encode_data_uri"):
+            # Data-URI refs through the same LRU (bytes: keyspace).
+            reference = [
+                reference_encoder.encode_data_uri(ref_audio, processor=processor)
+            ]
+        else:
+            reference = _reference_for_processor(processor, ref_audio)
     else:
         reference = _reference_for_processor(processor, ref_audio)
     return processor.build_user_message(

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 import concurrent.futures
 import logging
+import os
 import queue
 import threading
+import time
 from typing import Any
 
 import torch
@@ -26,8 +28,12 @@ from sglang_omni.models.moss_tts_local.request_builders import (
     preprocess_moss_tts_local_payload,
     set_moss_tts_local_preprocessing_context,
 )
+from sglang_omni.preprocessing.cache_key import (
+    reference_path_cache_key as _reference_path_cache_key,
+)
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+from sglang_omni.scheduling.stage_cache import StageOutputCache
 from sglang_omni.utils.audio_payload import audio_waveform_payload
 
 logger = logging.getLogger(__name__)
@@ -227,6 +233,194 @@ class _BatchedReferenceEncoder:
                     future.set_result(outcome)
 
 
+class CachedReferenceEncoder:
+    """Content-addressed LRU cache + single-flight dedup in front of _BatchedReferenceEncoder.
+
+    Miss path returns the encoder's tensor unchanged (bit-identical to cache-off).
+    Hit path returns a fresh .clone().to(long) so callers cannot mutate cached state.
+    Stores codes as int32 on CPU (lossless for codebook values in [0, 1023]).
+    """
+
+    # Cadence for the periodic stats log; class attr so it is easy to tune.
+    LOG_INTERVAL_S = 60.0
+
+    def __init__(
+        self,
+        encoder: _BatchedReferenceEncoder,
+        *,
+        max_items: int = 256,
+        max_bytes: int = 64 * 1024 * 1024,
+    ) -> None:
+        # Fail fast on non-positive capacities: a negative max_items makes
+        # StageOutputCache evict from an empty dict and KeyError at request time.
+        if max_items < 1:
+            raise ValueError(f"ref_audio_cache_max_items must be >= 1, got {max_items}")
+        if max_bytes < 1:
+            raise ValueError(f"ref_audio_cache_max_bytes must be >= 1, got {max_bytes}")
+        self._encoder = encoder
+        self._cache = StageOutputCache(
+            max_size=max_items,
+            max_bytes=max_bytes,
+            cache_device="cpu",
+        )
+        self._lock = threading.Lock()
+        self._inflight: dict[str, concurrent.futures.Future] = {}
+        self._hits = 0
+        self._misses = 0
+        self._merged = 0
+        self._last_log_time: float = 0.0
+
+    def encode(self, path: str) -> torch.Tensor:
+        path = str(path)
+        # Note(Jiaxin): duration gate runs first — a >100 s ref must never reach
+        # the cache or the inflight dict.
+        _BatchedReferenceEncoder._check_reference_duration(path)
+        # trust_stat left False (review feedback): keep the sentinel byte-read so a
+        # same-size+mtime+ctime overwrite cannot stale-hit. The flag stays available
+        # in reference_path_cache_key for deployments that guarantee immutable refs.
+        key = _reference_path_cache_key(path)
+        if key is None:
+            return self._encoder.encode(path)  # uncacheable (URL/missing) -> bypass
+        return self._cached_encode(
+            key,
+            lambda: self._encoder.encode(path),
+            desc=repr(path),
+            # TOCTOU re-stat: skip the put if the file changed during the encode.
+            revalidate=lambda: _reference_path_cache_key(path) == key,
+        )
+
+    def _cached_encode(
+        self, key: str, encode_fn, *, desc: str, revalidate=None
+    ) -> torch.Tensor:
+        """Single-flight skeleton shared by encode() and encode_data_uri().
+
+        Hit -> independent .clone().to(long). Miss leader runs encode_fn and returns
+        its tensor unchanged (bit-identical to cache-off). revalidate(), if given, is
+        evaluated outside the lock and gates the put (TOCTOU guard for file paths).
+        """
+        leader_fut: concurrent.futures.Future | None = None
+        follower_fut: concurrent.futures.Future | None = None
+
+        with self._lock:
+            stored = self._cache.get(key)
+            if stored is not None:
+                self._hits += 1
+            elif key in self._inflight:
+                self._merged += 1
+                follower_fut = self._inflight[key]
+            else:
+                self._misses += 1
+                leader_fut = concurrent.futures.Future()
+                self._inflight[key] = leader_fut
+
+        if stored is not None:
+            # Note(Jiaxin): clone on hit so callers can't mutate the shared entry.
+            self._maybe_log()
+            return stored.clone().to(torch.long)
+
+        if follower_fut is not None:
+            # Note(Jiaxin): each follower raises a FRESH RuntimeError — sharing one
+            # exception instance lets concurrent re-raises corrupt its traceback
+            # (same lesson as _BatchedReferenceEncoder._worker).
+            timeout = _BatchedReferenceEncoder.ENCODE_TIMEOUT_S + 10
+            try:
+                stored = follower_fut.result(timeout=timeout)
+            except Exception as cause:
+                raise RuntimeError(
+                    f"reference encode failed for {desc}: {cause}"
+                ) from cause
+            return stored.clone().to(torch.long)
+
+        assert leader_fut is not None
+        try:
+            result = encode_fn()
+        except BaseException as exc:
+            with self._lock:
+                self._inflight.pop(key, None)
+            leader_fut.set_exception(exc)
+            raise
+
+        do_put = revalidate() if revalidate is not None else True
+        stored = result.detach().to("cpu", dtype=torch.int32)
+        with self._lock:
+            if do_put:
+                self._cache.put(key, stored)
+            self._inflight.pop(key, None)
+        leader_fut.set_result(stored)
+        self._maybe_log()
+        return result  # original tensor: miss path stays bit-identical to cache-off
+
+    def _maybe_log(self) -> None:
+        now = time.monotonic()
+        if now - self._last_log_time < 60.0:
+            return
+        with self._lock:
+            if now - self._last_log_time < self.LOG_INTERVAL_S:
+                return
+            self._last_log_time = now
+            snapshot = (
+                self._hits,
+                self._misses,
+                self._merged,
+                len(self._cache._cache),
+                self._cache.current_bytes,
+            )
+        logger.info(
+            "MOSS-TTS Local ref cache: hits=%d misses=%d merged=%d entries=%d bytes=%d",
+            *snapshot,
+        )
+
+    def encode_data_uri(self, ref_audio: str, *, processor: Any) -> torch.Tensor:
+        """Cache-aware encode for data-URI refs through the same LRU + single-flight
+        as file paths (adds the duration check _reference_for_processor lacks).
+
+        Note(Jiaxin): file: and bytes: keyspaces never collide — the two decode
+        chains differ, so codes aren't guaranteed identical for the "same" audio.
+        """
+        import base64
+        import io
+
+        from sglang_omni.models.moss_tts.request_builders import _DATA_URI_RE
+        from sglang_omni.preprocessing.cache_key import hash_bytes as _hash_bytes
+
+        match = _DATA_URI_RE.match(ref_audio)
+        if match is None:
+            raise ValueError(f"encode_data_uri: not a data URI ({ref_audio[:40]!r}...)")
+
+        raw = base64.b64decode(match.group("data"))
+        key = f"bytes:{_hash_bytes(raw)}"
+
+        def _encode() -> torch.Tensor:
+            import soundfile as sf
+
+            audio, sample_rate = sf.read(
+                io.BytesIO(raw), dtype="float32", always_2d=True
+            )
+            # Note(Jiaxin): the duration check runs inside the leader (not before
+            # inflight registration like the file path) so concurrent same-payload
+            # requests share one sf.read of a potentially large decoded buffer.
+            duration = audio.shape[0] / max(int(sample_rate), 1)
+            if duration > _BatchedReferenceEncoder.MAX_REFERENCE_SECONDS:
+                raise ValueError(
+                    f"reference audio is {duration:.1f}s long; the limit is "
+                    f"{_BatchedReferenceEncoder.MAX_REFERENCE_SECONDS:.0f}s"
+                )
+            wav = torch.from_numpy(audio.T)
+            return processor.encode_audios_from_wav([wav], int(sample_rate))[0]
+
+        return self._cached_encode(key, _encode, desc="data-URI")
+
+    def stats(self) -> dict:
+        with self._lock:
+            return {
+                "hits": self._hits,
+                "misses": self._misses,
+                "merged": self._merged,
+                "entries": len(self._cache._cache),
+                "bytes": self._cache.current_bytes,
+            }
+
+
 def create_preprocessing_executor(
     model_path: str,
     *,
@@ -235,14 +429,34 @@ def create_preprocessing_executor(
     max_concurrency: int = 16,
     encode_batch_size: int = 8,
     encode_batch_wait_ms: int = 4,
+    ref_audio_cache: bool = True,
+    ref_audio_cache_max_items: int = 256,
+    ref_audio_cache_max_bytes: int = 64 * 1024 * 1024,
 ) -> SimpleScheduler:
+    # MOSS_REF_AUDIO_CACHE=0 disables the cache at startup (ops kill switch / A-B
+    # toggle) without a config edit; unset => kwarg default.
+    env_toggle = os.environ.get("MOSS_REF_AUDIO_CACHE")
+    if env_toggle is not None:
+        ref_audio_cache = env_toggle.strip().lower() not in (
+            "0",
+            "false",
+            "no",
+            "off",
+            "",
+        )
     device = _resolve_codec_device(device, gpu_id)
     processor = _load_moss_tts_local_processor(model_path, device=device)
-    reference_encoder = _BatchedReferenceEncoder(
+    reference_encoder: Any = _BatchedReferenceEncoder(
         processor,
         max_batch_size=encode_batch_size,
         max_batch_wait_ms=encode_batch_wait_ms,
     )
+    if ref_audio_cache:
+        reference_encoder = CachedReferenceEncoder(
+            reference_encoder,
+            max_items=ref_audio_cache_max_items,
+            max_bytes=ref_audio_cache_max_bytes,
+        )
     set_moss_tts_local_preprocessing_context(
         processor=processor, reference_encoder=reference_encoder
     )

--- a/sglang_omni/preprocessing/cache_key.py
+++ b/sglang_omni/preprocessing/cache_key.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Callable
 from urllib.parse import urlparse
@@ -48,6 +50,114 @@ def hash_file_sampled(
 
     payload = head + tail + f"|size:{file_size}".encode()
     return xxhash.xxh3_64(payload).hexdigest()
+
+
+_REF_PATH_HASH_MEMO_MAX_ITEMS = 1024
+_REF_PATH_HASH_SENTINEL_BYTES = 8192
+_REF_PATH_HASH_MEMO: OrderedDict[str, tuple[str, str]] = OrderedDict()
+_REF_PATH_HASH_MEMO_LOCK = threading.Lock()
+
+
+def _reference_path_hash_memo_key(path: Path) -> tuple[str, int] | None:
+    try:
+        if not path.is_file():
+            return None
+        stat_result = path.stat()
+        memo_key = (
+            f"{path.resolve()}:"
+            f"{stat_result.st_size}:"
+            f"{stat_result.st_mtime_ns}:"
+            f"{stat_result.st_ctime_ns}"
+        )
+        return memo_key, int(stat_result.st_size)
+    except OSError:
+        return None
+
+
+def _reference_path_sentinel(path: Path, file_size: int) -> str | None:
+    try:
+        chunk_size = min(_REF_PATH_HASH_SENTINEL_BYTES, file_size)
+        with path.open("rb") as f:
+            chunks = [f.read(chunk_size)]
+            if file_size > _REF_PATH_HASH_SENTINEL_BYTES:
+                middle_offset = max((file_size - chunk_size) // 2, 0)
+                f.seek(middle_offset)
+                chunks.append(f.read(chunk_size))
+            if file_size > 2 * _REF_PATH_HASH_SENTINEL_BYTES:
+                f.seek(max(file_size - chunk_size, 0))
+                chunks.append(f.read(chunk_size))
+        return hash_bytes(b"".join(chunks) + f"|size:{file_size}".encode())
+    except OSError:
+        return None
+
+
+def _get_reference_path_hash(memo_key: str, sentinel: str) -> str | None:
+    with _REF_PATH_HASH_MEMO_LOCK:
+        cached = _REF_PATH_HASH_MEMO.get(memo_key)
+        if cached is None:
+            return None
+        cached_sentinel, digest = cached
+        if cached_sentinel != sentinel:
+            _REF_PATH_HASH_MEMO.pop(memo_key, None)
+            return None
+        _REF_PATH_HASH_MEMO.move_to_end(memo_key)
+        return digest
+
+
+def _get_reference_path_hash_by_memo_key(memo_key: str) -> str | None:
+    # Memo lookup ignoring the sentinel; trust_stat=True callers only.
+    with _REF_PATH_HASH_MEMO_LOCK:
+        cached = _REF_PATH_HASH_MEMO.get(memo_key)
+        if cached is None:
+            return None
+        _REF_PATH_HASH_MEMO.move_to_end(memo_key)
+        return cached[1]
+
+
+def _put_reference_path_hash(memo_key: str, sentinel: str, digest: str) -> None:
+    with _REF_PATH_HASH_MEMO_LOCK:
+        _REF_PATH_HASH_MEMO[memo_key] = (sentinel, digest)
+        _REF_PATH_HASH_MEMO.move_to_end(memo_key)
+        while len(_REF_PATH_HASH_MEMO) > _REF_PATH_HASH_MEMO_MAX_ITEMS:
+            _REF_PATH_HASH_MEMO.popitem(last=False)
+
+
+def reference_path_cache_key(
+    path_like: str | Path, *, trust_stat: bool = False
+) -> str | None:
+    # Memoized full-content hash; the stat tuple skips rereads of stable files.
+    # Note(Jiaxin): trust_stat (opt-in, from #740) trusts the (size,mtime,ctime)
+    # stat tuple and skips the sentinel byte-read on memo hits; the accepted gap
+    # is same-size+mtime+ctime-with-different-content (reachable only by clock
+    # rollback). Default False keeps Higgs's sentinel path; keys are identical.
+    path = Path(str(path_like)).expanduser()
+    memo = _reference_path_hash_memo_key(path)
+    if memo is None:
+        return None
+    memo_key, file_size = memo
+
+    if trust_stat:
+        digest = _get_reference_path_hash_by_memo_key(memo_key)
+        if digest is not None:
+            return f"file:{digest}"
+
+    sentinel = _reference_path_sentinel(path, file_size)
+    if sentinel is None:
+        return None
+
+    if not trust_stat:
+        digest = _get_reference_path_hash(memo_key, sentinel)
+        if digest is not None:
+            return f"file:{digest}"
+
+    try:
+        digest = hash_bytes(path.read_bytes())
+    except OSError:
+        return None
+    if _reference_path_hash_memo_key(path) == memo:
+        # Always store the sentinel so default callers still validate this entry.
+        _put_reference_path_hash(memo_key, sentinel, digest)
+    return f"file:{digest}"
 
 
 def hash_media_item(item: Any) -> str | None:

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -299,6 +299,29 @@ def _payload(text: str = "hello") -> StagePayload:
     )
 
 
+def test_create_preprocessing_executor_env_toggle(monkeypatch):
+    from sglang_omni.models.moss_tts_local import request_builders as rb
+    from sglang_omni.models.moss_tts_local import stages
+
+    monkeypatch.setattr(
+        stages, "_load_moss_tts_local_processor", lambda *a, **k: _FakeProcessor()
+    )
+
+    # MOSS_REF_AUDIO_CACHE=0 disables the wrapper at startup (kill switch).
+    monkeypatch.setenv("MOSS_REF_AUDIO_CACHE", "0")
+    stages.create_preprocessing_executor("model", device="cpu")
+    assert not isinstance(
+        rb._PREPROCESSING_CONTEXT.reference_encoder, stages.CachedReferenceEncoder
+    )
+
+    # Unset -> kwarg default (True) -> wrapped.
+    monkeypatch.delenv("MOSS_REF_AUDIO_CACHE")
+    stages.create_preprocessing_executor("model", device="cpu")
+    assert isinstance(
+        rb._PREPROCESSING_CONTEXT.reference_encoder, stages.CachedReferenceEncoder
+    )
+
+
 def test_preprocess_and_result_adapter():
     set_moss_tts_local_preprocessing_context(processor=_FakeProcessor())
     try:
@@ -563,6 +586,471 @@ def test_batched_reference_encoder_coalesces_and_isolates_errors():
     assert results["bbb"].shape == (4, N_VQ) and int(results["bbb"][0, 0]) == 3
     # The failing batch retried per item; good items still succeeded.
     assert any(len(c) > 1 for c in calls) or len(calls) >= 3
+
+
+# ---------------------------------------------------------------------------
+# CachedReferenceEncoder  (T3–T9)
+# ---------------------------------------------------------------------------
+
+
+def test_cached_reference_encoder_on_off_hit_bit_identical(tmp_path):
+    """T5: OFF / ON-miss / ON-hit produce bit-identical prompt_rows and input_ids_list.
+
+    Uses int32 boundary value 1023 to verify lossless round-trip through storage.
+    ON-hit encode counter must stay at 1 (no second encode issued).
+    """
+    from sglang_omni.models.moss_tts_local.request_builders import (
+        _prepare_moss_tts_local_request,
+    )
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+
+    ref_file = tmp_path / "ref.wav"
+    ref_file.write_bytes(b"fake wav bytes for T5")
+    encode_count = 0
+
+    class _FakeBatched:
+        def encode(self, path: str) -> torch.Tensor:
+            nonlocal encode_count
+            encode_count += 1
+            # Boundary value 1023 exercises int32 round-trip; varies by path length.
+            codes = torch.full((10, N_VQ), 1023, dtype=torch.long)
+            codes[0, 0] = len(path) % 1024
+            return codes
+
+    class _RefAwareProcessor:
+        """Folds reference tensor sum into rows so bit-identity is non-trivial."""
+
+        @staticmethod
+        def build_user_message(**kwargs):
+            return dict(kwargs, role="user")
+
+        def __call__(self, conversations, mode):
+            assert mode == "generation"
+            msg = conversations[0][0]
+            ref = msg.get("reference") or []
+            ref_val = (
+                int(ref[0].sum().item()) % 1024
+                if ref and isinstance(ref[0], torch.Tensor)
+                else 0
+            )
+            seq = 8
+            rows = torch.full((1, seq, N_VQ + 1), ref_val, dtype=torch.long)
+            rows[0, :, 0] = torch.arange(seq)
+            rows[0, -1, 0] = 151669
+            return {"input_ids": rows}
+
+    def _ref_payload(rid: str) -> StagePayload:
+        return StagePayload(
+            request_id=rid,
+            request=OmniRequest(
+                inputs={"text": "hello", "references": [{"audio": str(ref_file)}]},
+                params={},
+                metadata={},
+            ),
+            data={},
+        )
+
+    processor = _RefAwareProcessor()
+    fake_batched = _FakeBatched()
+
+    # OFF: raw encoder, no cache wrapper
+    prepared_off = _prepare_moss_tts_local_request(
+        _ref_payload("t5-off"), processor=processor, reference_encoder=fake_batched
+    )
+    assert encode_count == 1
+
+    # ON-miss: first call to CachedReferenceEncoder (cache empty)
+    cached_enc = CachedReferenceEncoder(fake_batched, max_items=256, max_bytes=64 << 20)
+    encode_count = 0
+    prepared_miss = _prepare_moss_tts_local_request(
+        _ref_payload("t5-miss"), processor=processor, reference_encoder=cached_enc
+    )
+    assert encode_count == 1, "ON-miss must call underlying encode exactly once"
+
+    # ON-hit: second call, same file — cache must serve without re-encoding
+    prepared_hit = _prepare_moss_tts_local_request(
+        _ref_payload("t5-hit"), processor=processor, reference_encoder=cached_enc
+    )
+    assert encode_count == 1, "ON-hit must NOT call underlying encode again"
+
+    # Hard gate: all three paths produce identical prompt_rows and input_ids_list
+    assert torch.equal(prepared_off.prompt_rows, prepared_miss.prompt_rows)
+    assert torch.equal(prepared_off.prompt_rows, prepared_hit.prompt_rows)
+    assert prepared_off.input_ids_list == prepared_miss.input_ids_list
+    assert prepared_off.input_ids_list == prepared_hit.input_ids_list
+
+    stats = cached_enc.stats()
+    assert stats["hits"] == 1
+    assert stats["misses"] == 1
+    assert stats["merged"] == 0
+
+
+def test_cached_reference_encoder_lru_eviction(tmp_path):
+    """T3: LRU eviction by item count and by byte budget."""
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+
+    encode_log = []
+
+    class _FakeBatched:
+        def encode(self, path: str) -> torch.Tensor:
+            encode_log.append(path)
+            return torch.full((2, N_VQ), ord(path[-1]), dtype=torch.long)
+
+    # --- item-count eviction: max_items=2, insert 3 ---
+    enc = CachedReferenceEncoder(_FakeBatched(), max_items=2, max_bytes=64 << 20)
+    files = [tmp_path / f"{c}.wav" for c in "abc"]
+    for i, f in enumerate(files):
+        f.write_bytes(bytes([i + 1]) * 16)  # distinct content → distinct cache keys
+    for f in files:
+        enc.encode(str(f))
+    encode_log.clear()
+    # 'a' was evicted (LRU); 'b' and 'c' are still cached
+    enc.encode(str(files[1]))  # b — should hit
+    enc.encode(str(files[2]))  # c — should hit
+    assert encode_log == [], "b and c should be cached (not re-encoded)"
+    enc.encode(str(files[0]))  # a — must re-encode
+    assert len(encode_log) == 1 and str(files[0]) in encode_log[0]
+
+    # --- byte-budget eviction: each entry is 2*12*4=96 bytes as int32 ---
+    entry_bytes = 2 * N_VQ * 4  # int32
+    enc2 = CachedReferenceEncoder(_FakeBatched(), max_items=1000, max_bytes=entry_bytes)
+    f1, f2 = tmp_path / "d.wav", tmp_path / "e.wav"
+    f1.write_bytes(b"y" * 16)
+    f2.write_bytes(b"z" * 16)
+    encode_log.clear()
+    enc2.encode(str(f1))
+    enc2.encode(str(f2))  # f1 evicted by byte budget
+    encode_log.clear()
+    enc2.encode(str(f2))  # e — should hit
+    assert encode_log == [], "f2 should be cached"
+    enc2.encode(str(f1))  # d — must re-encode
+    assert len(encode_log) == 1
+
+    # --- oversized entry is gracefully rejected, does not crash ---
+    enc3 = CachedReferenceEncoder(_FakeBatched(), max_items=10, max_bytes=1)
+    f3 = tmp_path / "big.wav"
+    f3.write_bytes(b"big" * 16)
+    result = enc3.encode(str(f3))
+    assert result is not None  # still returns a value
+
+
+def test_cached_reference_encoder_rejects_nonpositive_capacity():
+    """Negative/zero capacities fail fast at construction (P3, review)."""
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+
+    class _FakeBatched:
+        def encode(self, path: str) -> torch.Tensor:
+            return torch.zeros((2, N_VQ), dtype=torch.long)
+
+    with pytest.raises(ValueError, match="max_items"):
+        CachedReferenceEncoder(_FakeBatched(), max_items=-1)
+    with pytest.raises(ValueError, match="max_items"):
+        CachedReferenceEncoder(_FakeBatched(), max_items=0)
+    with pytest.raises(ValueError, match="max_bytes"):
+        CachedReferenceEncoder(_FakeBatched(), max_bytes=0)
+
+
+def test_cached_reference_encoder_true_concurrency_dedup(tmp_path):
+    """T4: concurrent same-key requests — exactly 1 encode, all results torch.equal,
+    data_ptr pairwise distinct (each caller gets an independent clone).
+    """
+    import threading as _threading
+
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+
+    ref = tmp_path / "ref.wav"
+    ref.write_bytes(b"concurrent test")
+
+    gate = _threading.Event()
+    call_count = 0
+
+    class _GatedBatched:
+        def encode(self, path: str) -> torch.Tensor:
+            nonlocal call_count
+            gate.wait()  # stall until all threads have registered
+            call_count += 1
+            return torch.full((5, N_VQ), 42, dtype=torch.long)
+
+    N = 8
+    enc = CachedReferenceEncoder(_GatedBatched(), max_items=256, max_bytes=64 << 20)
+    results = [None] * N
+    errors = []
+
+    def worker(idx):
+        try:
+            results[idx] = enc.encode(str(ref))
+        except Exception as e:
+            errors.append(e)
+
+    threads = [_threading.Thread(target=worker, args=(i,)) for i in range(N)]
+    for t in threads:
+        t.start()
+    # Give threads time to block inside encode() before releasing gate
+    import time
+
+    time.sleep(0.05)
+    gate.set()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert not errors, f"unexpected errors: {errors}"
+    assert call_count == 1, f"expected 1 encode call, got {call_count}"
+    assert all(r is not None for r in results)
+    ref_tensor = results[0]
+    for r in results[1:]:
+        assert torch.equal(ref_tensor, r), "results not bit-identical"
+    ptrs = [r.data_ptr() for r in results]
+    assert len(set(ptrs)) == len(ptrs), "data_ptr not pairwise distinct (shared tensor)"
+
+    stats = enc.stats()
+    assert stats["misses"] == 1
+    assert stats["merged"] == N - 1
+    assert stats["hits"] == 0
+
+
+def test_cached_reference_encoder_failure_does_not_poison(tmp_path):
+    """T6: leader failure fans out independent exception instances; cache stays clean;
+    third request becomes new leader and succeeds.
+    """
+    import threading as _threading
+
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+
+    ref = tmp_path / "flaky.wav"
+    ref.write_bytes(b"flaky")
+
+    gate = _threading.Event()
+    call_count = 0
+
+    class _FlakyBatched:
+        def encode(self, path: str) -> torch.Tensor:
+            nonlocal call_count
+            call_count += 1
+            gate.wait()
+            if call_count == 1:
+                raise RuntimeError("transient encode failure")
+            return torch.full((3, N_VQ), 7, dtype=torch.long)
+
+    enc = CachedReferenceEncoder(_FlakyBatched(), max_items=256, max_bytes=64 << 20)
+    exc_results = [None, None]
+
+    def fail_worker(idx):
+        try:
+            enc.encode(str(ref))
+        except Exception as e:
+            exc_results[idx] = e
+
+    t0 = _threading.Thread(target=fail_worker, args=(0,))
+    t1 = _threading.Thread(target=fail_worker, args=(1,))
+    t0.start()
+    t1.start()
+    import time
+
+    time.sleep(0.05)
+    gate.set()
+    t0.join(timeout=10)
+    t1.join(timeout=10)
+
+    # Both threads got an exception
+    assert exc_results[0] is not None
+    assert exc_results[1] is not None
+    # Each gets an independent instance (not the same object)
+    assert exc_results[0] is not exc_results[1]
+    # Cache not poisoned
+    assert enc.stats()["entries"] == 0
+    # inflight cleared
+    assert len(enc._inflight) == 0
+
+    # Third request succeeds (new leader)
+    gate.clear()
+    gate.set()
+    result = enc.encode(str(ref))
+    assert result is not None
+    assert torch.equal(result, torch.full((3, N_VQ), 7, dtype=torch.long))
+
+
+def test_cached_reference_encoder_return_value_isolation(tmp_path):
+    """T7: mutating the returned tensor does not corrupt the cached copy."""
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+
+    ref = tmp_path / "iso.wav"
+    ref.write_bytes(b"isolation test")
+
+    class _FakeBatched:
+        def encode(self, path: str) -> torch.Tensor:
+            return torch.full((4, N_VQ), 99, dtype=torch.long)
+
+    enc = CachedReferenceEncoder(_FakeBatched(), max_items=256, max_bytes=64 << 20)
+    enc.encode(str(ref))  # miss — populates cache
+
+    hit1 = enc.encode(str(ref))  # first hit
+    hit1.fill_(-1)  # mutate in place
+
+    hit2 = enc.encode(str(ref))  # second hit — must still be 99
+    assert torch.all(hit2 == 99), "cache was corrupted by mutation of first hit result"
+
+
+def test_cached_reference_encoder_duration_gate(tmp_path, monkeypatch):
+    """T8: references over 100 s are rejected before touching the cache."""
+    import torchaudio
+
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+
+    ref = tmp_path / "long.wav"
+    ref.write_bytes(b"fake long audio")
+    encode_count = 0
+
+    class _FakeBatched:
+        def encode(self, path: str) -> torch.Tensor:
+            nonlocal encode_count
+            encode_count += 1
+            return torch.zeros((5, N_VQ), dtype=torch.long)
+
+    # Patch torchaudio.info to report a 200-second file
+    class _FakeInfo:
+        num_frames = 200 * 48000
+        sample_rate = 48000
+
+    monkeypatch.setattr(torchaudio, "info", lambda path: _FakeInfo(), raising=False)
+
+    enc = CachedReferenceEncoder(_FakeBatched(), max_items=256, max_bytes=64 << 20)
+
+    # _BatchedReferenceEncoder.encode checks duration before enqueuing; CachedReferenceEncoder
+    # calls through to the underlying encoder so the duration check still fires.
+    with pytest.raises(ValueError, match="100"):
+        enc.encode(str(ref))
+
+    assert encode_count == 0, "oversized reference must not reach the codec"
+    assert enc.stats()["entries"] == 0
+    assert len(enc._inflight) == 0
+
+
+# ---------------------------------------------------------------------------
+# Data-URI path (commit 4): bytes: keyspace + duration check
+# ---------------------------------------------------------------------------
+
+
+def _make_wav_data_uri(
+    n_samples: int = 100, sample_rate: int = 16000
+) -> tuple[str, bytes]:
+    """Minimal 16-bit mono PCM WAV wrapped as a data URI."""
+    import base64
+
+    samples = b"\x00\x00" * n_samples
+    data_size = len(samples)
+    header = struct.pack(
+        "<4sI4s4sIHHIIHH4sI",
+        b"RIFF",
+        36 + data_size,
+        b"WAVE",
+        b"fmt ",
+        16,
+        1,
+        1,
+        sample_rate,
+        sample_rate * 2,
+        2,
+        16,
+        b"data",
+        data_size,
+    )
+    raw = header + samples
+    return f"data:audio/wav;base64,{base64.b64encode(raw).decode()}", raw
+
+
+def test_cached_reference_encoder_data_uri_hit_miss(tmp_path):
+    """bytes: keyspace: same data-URI encoded twice → 1 encode_audios_from_wav call."""
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+
+    data_uri, _ = _make_wav_data_uri()
+    wav_call_count = 0
+
+    class _FakeProc:
+        def encode_audios_from_wav(self, wavs, sample_rate):
+            nonlocal wav_call_count
+            wav_call_count += 1
+            return [torch.full((5, N_VQ), 42, dtype=torch.long)]
+
+    enc = CachedReferenceEncoder(
+        None, max_items=256, max_bytes=64 << 20  # type: ignore[arg-type]
+    )
+    proc = _FakeProc()
+    enc.encode_data_uri(data_uri, processor=proc)
+    assert wav_call_count == 1, "first call must encode"
+
+    result2 = enc.encode_data_uri(data_uri, processor=proc)
+    assert wav_call_count == 1, "second call must hit cache"
+    assert torch.equal(result2, torch.full((5, N_VQ), 42, dtype=torch.long))
+
+    stats = enc.stats()
+    assert stats["hits"] == 1
+    assert stats["misses"] == 1
+
+
+def test_cached_reference_encoder_file_bytes_keyspaces_do_not_collide(tmp_path):
+    """file: and bytes: keys are independent; same-content file ≠ data-URI in cache."""
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+
+    data_uri, raw = _make_wav_data_uri()
+
+    # Write the same raw bytes as a file
+    ref_file = tmp_path / "ref.wav"
+    ref_file.write_bytes(raw)
+
+    encode_count = 0
+
+    class _FakeBatched:
+        def encode(self, path: str) -> torch.Tensor:
+            nonlocal encode_count
+            encode_count += 1
+            return torch.full((5, N_VQ), 7, dtype=torch.long)
+
+    class _FakeProc:
+        def encode_audios_from_wav(self, wavs, sample_rate):
+            return [torch.full((5, N_VQ), 7, dtype=torch.long)]
+
+    enc = CachedReferenceEncoder(_FakeBatched(), max_items=256, max_bytes=64 << 20)
+    enc.encode(str(ref_file))  # populates file: key
+    enc.encode_data_uri(data_uri, processor=_FakeProc())  # must NOT hit file: entry
+
+    assert (
+        enc.stats()["misses"] == 2
+    ), "file: and bytes: are independent keyspaces; data-URI must be a fresh miss"
+
+
+def test_cached_reference_encoder_data_uri_duration_gate():
+    """data-URI references over 100 s are rejected."""
+    import base64
+    import io
+
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+
+    pytest.importorskip("soundfile")
+    import soundfile as sf
+
+    # Build a 200-second silent WAV (at 8 kHz to keep size small)
+    sample_rate = 8000
+    n_samples = 200 * sample_rate
+    buf = io.BytesIO()
+    import numpy as np
+
+    sf.write(buf, np.zeros(n_samples, dtype=np.float32), sample_rate, format="WAV")
+    raw = buf.getvalue()
+    uri = f"data:audio/wav;base64,{base64.b64encode(raw).decode()}"
+
+    enc = CachedReferenceEncoder(
+        None, max_items=256, max_bytes=64 << 20  # type: ignore[arg-type]
+    )
+
+    class _FakeProc:
+        def encode_audios_from_wav(self, wavs, sr):
+            return [torch.zeros((5, N_VQ), dtype=torch.long)]
+
+    with pytest.raises(ValueError, match="100"):
+        enc.encode_data_uri(uri, processor=_FakeProc())
+
+    assert enc.stats()["entries"] == 0
+    assert len(enc._inflight) == 0
 
 
 def test_branchless_sampler_matches_eager_sampler():

--- a/tests/unit_test/preprocessing/test_cache_key.py
+++ b/tests/unit_test/preprocessing/test_cache_key.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the shared reference-audio path cache-key helpers."""
+
+from sglang_omni.preprocessing import cache_key
+
+
+def test_reference_path_cache_key_tracks_file_content(tmp_path) -> None:
+    ref_audio = tmp_path / "ref.wav"
+    ref_audio.write_bytes(b"a")
+    first_key = cache_key.reference_path_cache_key(ref_audio)
+
+    # Same content -> stable key (so repeat requests hit the cache).
+    assert first_key == cache_key.reference_path_cache_key(ref_audio)
+
+    ref_audio.write_bytes(b"longer")
+    second_key = cache_key.reference_path_cache_key(ref_audio)
+
+    # Different content -> different key (so a replaced file is not stale-served).
+    assert first_key is not None and first_key.startswith("file:")
+    assert second_key is not None and second_key.startswith("file:")
+    assert first_key != second_key
+
+
+def test_reference_path_cache_key_same_size_edit_and_non_files(tmp_path) -> None:
+    # Same path, same size, same head/tail, different middle must not stale-hit.
+    head, tail = b"H" * 8192, b"T" * 8192
+    ref_audio = tmp_path / "ref.wav"
+    ref_audio.write_bytes(head + b"a" * 4096 + tail)
+    key_a = cache_key.reference_path_cache_key(ref_audio)
+    ref_audio.write_bytes(head + b"b" * 4096 + tail)  # same size, middle differs
+    assert key_a is not None
+    assert key_a != cache_key.reference_path_cache_key(ref_audio)
+
+    # URLs and missing files resolve to no key (callers bypass the cache).
+    assert cache_key.reference_path_cache_key("https://example.com/ref.wav") is None
+    assert cache_key.reference_path_cache_key(str(tmp_path / "missing.wav")) is None
+
+
+def test_reference_path_cache_key_memoizes_stable_file_hash(
+    monkeypatch, tmp_path
+) -> None:
+    ref_audio = tmp_path / "ref.wav"
+    ref_audio.write_bytes(b"fake wav bytes")
+    cache_key._REF_PATH_HASH_MEMO.clear()
+    read_calls = 0
+    original_read_bytes = cache_key.Path.read_bytes
+
+    def counting_read_bytes(path):
+        nonlocal read_calls
+        if path == ref_audio:
+            read_calls += 1
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(cache_key.Path, "read_bytes", counting_read_bytes)
+
+    first_key = cache_key.reference_path_cache_key(ref_audio)
+    second_key = cache_key.reference_path_cache_key(ref_audio)
+
+    assert first_key == second_key
+    assert read_calls == 1
+
+
+def test_reference_path_cache_key_trust_stat_skips_sentinel_on_hit(
+    monkeypatch, tmp_path
+) -> None:
+    # The opt-in trust_stat fast path (absorbed from #740) trusts the
+    # (size, mtime_ns, ctime_ns) stat tuple as content identity and skips the
+    # sentinel byte-read on memo hits. Co-authored idea: GaokaiZhang (#740).
+    ref_audio = tmp_path / "ref.wav"
+    ref_audio.write_bytes(b"fake wav bytes")
+    cache_key._REF_PATH_HASH_MEMO.clear()
+
+    sentinel_calls = 0
+    original_sentinel = cache_key._reference_path_sentinel
+
+    def counting_sentinel(path, file_size):
+        nonlocal sentinel_calls
+        sentinel_calls += 1
+        return original_sentinel(path, file_size)
+
+    monkeypatch.setattr(cache_key, "_reference_path_sentinel", counting_sentinel)
+
+    # First call (memo miss) must still compute the sentinel once so the memo
+    # entry stays valid for default (trust_stat=False) callers like Higgs.
+    first = cache_key.reference_path_cache_key(ref_audio, trust_stat=True)
+    assert sentinel_calls == 1
+    # Second call (memo hit) takes the fast path: no further sentinel read.
+    second = cache_key.reference_path_cache_key(ref_audio, trust_stat=True)
+    assert sentinel_calls == 1
+    assert first == second
+
+
+def test_reference_path_cache_key_trust_stat_keyspace_matches_default(
+    tmp_path,
+) -> None:
+    # trust_stat must produce a byte-identical key to the default path for the
+    # same content, so both callers share one keyspace.
+    ref_audio = tmp_path / "ref.wav"
+    ref_audio.write_bytes(b"shared content bytes")
+
+    cache_key._REF_PATH_HASH_MEMO.clear()
+    key_default = cache_key.reference_path_cache_key(ref_audio)
+    cache_key._REF_PATH_HASH_MEMO.clear()
+    key_trust = cache_key.reference_path_cache_key(ref_audio, trust_stat=True)
+
+    assert key_default is not None and key_default.startswith("file:")
+    assert key_default == key_trust
+
+
+def test_reference_path_cache_key_trust_stat_invalidates_on_stat_change(
+    tmp_path,
+) -> None:
+    # A real content replacement that changes the stat tuple still invalidates.
+    ref_audio = tmp_path / "ref.wav"
+    ref_audio.write_bytes(b"a" * 64)
+    cache_key._REF_PATH_HASH_MEMO.clear()
+    key_a = cache_key.reference_path_cache_key(ref_audio, trust_stat=True)
+
+    ref_audio.write_bytes(b"b" * 128)  # different size -> stat tuple changes
+    key_b = cache_key.reference_path_cache_key(ref_audio, trust_stat=True)
+
+    assert key_a is not None and key_b is not None
+    assert key_a != key_b


### PR DESCRIPTION
Step 2 of 2 (follows #747). Re-applies the MOSS-TTS-Local v1.5 reference-audio cache from #743 with correctly-formatted `Co-authored-by:` trailers, so @AkazaAkane, @JiaxinD and @GaokaiZhang are properly credited.

**Zero code change vs. before the revert:** this branch's tree SHA is byte-identical to the original #743 merge (`c74b289…`). Net effect of #747 + this PR is purely a commit-message/attribution fix.
