### PR TITLE
[Investigation] torch.compile for MOSS-TTS-Local AR backbone (negative result)

### DIFF
--- a/sglang_omni/models/moss_tts_local/moss_qwen3_backbone.py
+++ b/sglang_omni/models/moss_tts_local/moss_qwen3_backbone.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MOSS-TTS-Local-owned Qwen3 backbone with a decode-only ``torch.compile`` hook.
+
+Mirrors :meth:`sglang.srt.models.qwen3.Qwen3Model.forward` so we can pick
+between eager ``self.layers`` (prefill) and ``self._compiled_decode_layers``
+(decode, populated by :func:`stages._compile_moss_local_backbone`).
+
+Ported from the MOSS-TTS Delay variant (``moss_tts/moss_qwen3_backbone.py``),
+itself from the Higgs-TTS investigation (sgl-project/sglang-omni#579 /
+issue #565). MOSS-TTS Local uses the bare ``Qwen3Model`` as its AR backbone
+(``MossTTSLocalSGLangModel.model``); its frame-local decode and per-codebook
+heads live elsewhere, so we only need to subclass the inner backbone.
+
+When syncing with newer sglang, diff ``Qwen3Model.forward`` against the loop
+here and port any new logic.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import torch
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.models.qwen3 import Qwen3Model
+
+
+class MossLocalQwen3Model(Qwen3Model):
+    """``Qwen3Model`` with a decode-only compile-layer indirection."""
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor = None,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ) -> Union[torch.Tensor, PPProxyTensors]:
+        if self.pp_group.is_first_rank:
+            hidden_states = (
+                self.embed_tokens(input_ids) if input_embeds is None else input_embeds
+            )
+            residual = None
+        else:
+            assert pp_proxy_tensors is not None
+            hidden_states = pp_proxy_tensors["hidden_states"]
+            residual = pp_proxy_tensors["residual"]
+
+        # Prefill keeps ``self.layers`` because its shape varies per request,
+        # which would force dynamo recompiles. Decode uses the compiled layers
+        # when available. The ``_compiled_max_decode_bs`` hook is kept for
+        # future workarounds; with the eager pre-warmup in stages the full
+        # decode bs range is safe (see Higgs issue_565_torch_compile_result.md).
+        compiled = getattr(self, "_compiled_decode_layers", None)
+        max_bs = getattr(self, "_compiled_max_decode_bs", None)
+        forward_mode = getattr(forward_batch, "forward_mode", None)
+        is_decode = bool(
+            forward_mode is not None
+            and getattr(forward_mode, "is_decode", lambda: False)()
+        )
+        bs = hidden_states.shape[0]
+        use_compiled = (
+            is_decode and compiled is not None and (max_bs is None or bs <= max_bs)
+        )
+        layers = compiled if use_compiled else self.layers
+
+        aux_hidden_states: list[torch.Tensor] = []
+        for i in range(self.start_layer, self.end_layer):
+            if i in self.layers_to_capture:
+                aux_hidden_states.append(
+                    hidden_states + residual if residual is not None else hidden_states
+                )
+            hidden_states, residual = layers[i](
+                positions, hidden_states, forward_batch, residual
+            )
+        if not self.pp_group.is_last_rank:
+            return PPProxyTensors(
+                {"hidden_states": hidden_states, "residual": residual}
+            )
+
+        if hidden_states.shape[0] != 0:
+            if residual is None:
+                hidden_states = self.norm(hidden_states)
+            else:
+                hidden_states, _ = self.norm(hidden_states, residual)
+
+        if len(aux_hidden_states) == 0:
+            return hidden_states
+        return hidden_states, aux_hidden_states
+
+
+__all__ = ["MossLocalQwen3Model"]

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -28,11 +28,11 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTe
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.utils import add_prefix
 
-from sglang_omni.models.moss_tts_local.moss_qwen3_backbone import MossLocalQwen3Model
 from sglang_omni.models.moss_tts_local.local_transformer import (
     MossTTSLocalTransformer,
     sample_seeded_branchless,
 )
+from sglang_omni.models.moss_tts_local.moss_qwen3_backbone import MossLocalQwen3Model
 from sglang_omni.models.moss_tts_local.payload_types import (
     moss_tts_local_special_token_defaults,
 )

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -26,9 +26,9 @@ from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
 from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_loader.weight_utils import default_weight_loader
-from sglang.srt.models.qwen3 import Qwen3Model
 from sglang.srt.utils import add_prefix
 
+from sglang_omni.models.moss_tts_local.moss_qwen3_backbone import MossLocalQwen3Model
 from sglang_omni.models.moss_tts_local.local_transformer import (
     MossTTSLocalTransformer,
     sample_seeded_branchless,
@@ -91,7 +91,7 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             for _ in range(self.config.channels):
                 self.embedding_list.append(PPMissingLayer())
 
-        self.model = Qwen3Model(
+        self.model = MossLocalQwen3Model(
             config=self.config.language_config,
             quant_config=quant_config,
             prefix=add_prefix("model", prefix),

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -257,6 +257,14 @@ def create_preprocessing_executor(
     )
 
 
+def _env_flag(name: str, default: bool) -> bool:
+    """Read a boolean toggle from the environment (perf A/B knobs)."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
 def _compile_moss_local_backbone(model: Any) -> None:
     """Per-layer ``torch.compile`` the AR backbone for the decode path.
 
@@ -328,12 +336,13 @@ def create_sglang_tts_engine_executor(
         "dtype": dtype,
         "cuda_graph_bs": [1, 2, 4, 8, 16],
         "cuda_graph_max_bs": 16,
-        "disable_cuda_graph": False,
+        # Perf A/B knobs for the 2x2 cross-validation matrix (compile x CG).
+        # Default = compile ON, CG ON (the headline config of this branch).
+        #   MOSS_TTS_DISABLE_CUDA_GRAPH=1   -> skip backbone CUDA graphs
+        #   MOSS_TTS_ENABLE_TORCH_COMPILE=0 -> skip AR-backbone torch.compile
+        "disable_cuda_graph": _env_flag("MOSS_TTS_DISABLE_CUDA_GRAPH", False),
         "disable_overlap_schedule": True,
-        # Compile the AR backbone decode path (manual per-layer, see
-        # _compile_moss_local_backbone). This branch exists to A/B compile vs
-        # main, so it is always on here; check out main for the baseline.
-        "enable_torch_compile": True,
+        "enable_torch_compile": _env_flag("MOSS_TTS_ENABLE_TORCH_COMPILE", True),
         "max_prefill_tokens": 8192,
         "max_running_requests": 16,
         # Leave headroom for the two ~4.3 GB bf16 codec instances plus their

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import logging
+import os
 import queue
 import threading
 from typing import Any
@@ -256,6 +257,60 @@ def create_preprocessing_executor(
     )
 
 
+def _env_flag(name: str, default: bool) -> bool:
+    """Read a boolean toggle from the environment (A/B perf knobs)."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _compile_moss_local_backbone(model: Any) -> None:
+    """Per-layer ``torch.compile`` the AR backbone for the decode path.
+
+    Populates ``inner._compiled_decode_layers`` consumed by
+    ``MossLocalQwen3Model.forward``. Prefill keeps eager ``self.layers``.
+    """
+    inner = getattr(model, "model", None)
+    layers = getattr(inner, "layers", None) if inner is not None else None
+    if layers is None:
+        logger.warning("MOSS-TTS-Local torch.compile: no backbone layers found")
+        return
+    from sglang.srt.model_executor.cuda_graph_runner import set_torch_compile_config
+
+    set_torch_compile_config()
+    compile_mode = os.environ.get(
+        "SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs"
+    )
+    inner._compiled_decode_layers = [
+        torch.compile(layer, mode=compile_mode) for layer in layers
+    ]
+    inner._compiled_max_decode_bs = 16
+    logger.info(
+        "MOSS-TTS-Local torch.compile: compiled %d backbone layers (mode=%s)",
+        len(layers),
+        compile_mode,
+    )
+
+
+def _warmup_eager_pre_cg(model_runner: Any) -> None:
+    """One eager bs=1 forward before CUDA-graph capture (#565 CG-corruption fix).
+
+    Lazy CUDA init from the compiled layers must not land inside the first
+    captured graph, so we hide the compiled layers and run one eager decode.
+    """
+    inner = getattr(model_runner.model, "model", None)
+    saved = getattr(inner, "_compiled_decode_layers", None)
+    if saved is None:
+        return
+    inner._compiled_decode_layers = None
+    try:
+        model_runner._dummy_run(batch_size=1)
+        torch.cuda.synchronize()
+    finally:
+        inner._compiled_decode_layers = saved
+
+
 def create_sglang_tts_engine_executor(
     model_path: str,
     *,
@@ -281,9 +336,12 @@ def create_sglang_tts_engine_executor(
         "dtype": dtype,
         "cuda_graph_bs": [1, 2, 4, 8, 16],
         "cuda_graph_max_bs": 16,
-        "disable_cuda_graph": False,
+        # A/B perf knobs (env-gated, default behaves exactly like main):
+        #   MOSS_TTS_DISABLE_CUDA_GRAPH=1  -> skip backbone CUDA graphs
+        #   MOSS_TTS_ENABLE_TORCH_COMPILE=1 -> compile the AR backbone decode path
+        "disable_cuda_graph": _env_flag("MOSS_TTS_DISABLE_CUDA_GRAPH", False),
         "disable_overlap_schedule": True,
-        "enable_torch_compile": False,
+        "enable_torch_compile": _env_flag("MOSS_TTS_ENABLE_TORCH_COMPILE", False),
         "max_prefill_tokens": 8192,
         "max_running_requests": 16,
         # Leave headroom for the two ~4.3 GB bf16 codec instances plus their
@@ -326,6 +384,16 @@ def create_sglang_tts_engine_executor(
         server_args.disable_cuda_graph = False
 
     model = model_worker.model_runner.model
+
+    # torch.compile the AR backbone decode path before any CUDA-graph capture.
+    # We do the per-layer compile manually (and then disable sglang's own
+    # auto-compile) so prefill stays eager and only decode uses compiled layers.
+    if bool(getattr(server_args, "enable_torch_compile", False)):
+        _compile_moss_local_backbone(model)
+        server_args.enable_torch_compile = False
+        if want_cuda_graph:
+            _warmup_eager_pre_cg(model_worker.model_runner)
+
     if want_cuda_graph:
         model_worker.model_runner.init_device_graphs()
         # Also graph the per-frame local-transformer decode (1 + n_vq

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -336,10 +336,11 @@ def create_sglang_tts_engine_executor(
         "dtype": dtype,
         "cuda_graph_bs": [1, 2, 4, 8, 16],
         "cuda_graph_max_bs": 16,
-        # Perf A/B knobs for the 2x2 cross-validation matrix (compile x CG).
+        # Perf A/B knobs for the backbone compile-vs-CG cross-validation.
         # Default = compile ON, CG ON (the headline config of this branch).
-        #   MOSS_TTS_DISABLE_CUDA_GRAPH=1   -> skip backbone CUDA graphs
-        #   MOSS_TTS_ENABLE_TORCH_COMPILE=0 -> skip AR-backbone torch.compile
+        #   MOSS_TTS_ENABLE_TORCH_COMPILE=0       -> skip AR-backbone torch.compile
+        #   MOSS_TTS_DISABLE_BACKBONE_CUDA_GRAPH=1-> skip ONLY backbone CG (frame CG stays on)
+        #   MOSS_TTS_DISABLE_CUDA_GRAPH=1         -> skip BOTH backbone and frame CG
         "disable_cuda_graph": _env_flag("MOSS_TTS_DISABLE_CUDA_GRAPH", False),
         "disable_overlap_schedule": True,
         "enable_torch_compile": _env_flag("MOSS_TTS_ENABLE_TORCH_COMPILE", True),
@@ -363,8 +364,24 @@ def create_sglang_tts_engine_executor(
         **overrides,
     )
 
-    want_cuda_graph = not bool(getattr(server_args, "disable_cuda_graph", False))
-    if want_cuda_graph:
+    # CUDA-graph scope. This model double-graphs two independent hot paths:
+    # the AR backbone (sglang init_device_graphs) and the per-frame local
+    # transformer (omni init_frame_decode_graphs, captured via its own
+    # torch.cuda.CUDAGraph). The global MOSS_TTS_DISABLE_CUDA_GRAPH (folded
+    # into server_args above) kills BOTH; the finer
+    # MOSS_TTS_DISABLE_BACKBONE_CUDA_GRAPH skips ONLY the backbone graph while
+    # keeping the frame graph on -- this isolates the backbone for the
+    # compile-vs-CG cross-validation (the frame loop is ~22 ms/frame eager and
+    # would otherwise dominate every measurement).
+    want_frame_cg = not bool(getattr(server_args, "disable_cuda_graph", False))
+    want_backbone_cg = want_frame_cg and not _env_flag(
+        "MOSS_TTS_DISABLE_BACKBONE_CUDA_GRAPH", False
+    )
+
+    # Suppress sglang's own backbone-CG capture during infra build so we can
+    # (optionally) compile first and capture manually. Leaving it suppressed
+    # (no restore below) keeps the backbone eager.
+    if not bool(getattr(server_args, "disable_cuda_graph", False)):
         server_args.disable_cuda_graph = True
 
     (
@@ -381,7 +398,7 @@ def create_sglang_tts_engine_executor(
         model_arch_override="MossTTSLocalSGLangModel",
     )
 
-    if want_cuda_graph:
+    if want_backbone_cg:
         server_args.disable_cuda_graph = False
 
     model = model_worker.model_runner.model
@@ -392,14 +409,15 @@ def create_sglang_tts_engine_executor(
     if bool(getattr(server_args, "enable_torch_compile", False)):
         _compile_moss_local_backbone(model)
         server_args.enable_torch_compile = False
-        if want_cuda_graph:
+        if want_backbone_cg:
             _warmup_eager_pre_cg(model_worker.model_runner)
 
-    if want_cuda_graph:
+    if want_backbone_cg:
         model_worker.model_runner.init_device_graphs()
-        # Also graph the per-frame local-transformer decode (1 + n_vq
-        # micro-steps and 13 seeded sampling passes per frame): eager it is
-        # kernel-launch-bound at ~22 ms/frame independent of batch size.
+    if want_frame_cg:
+        # Graph the per-frame local-transformer decode (1 + n_vq micro-steps
+        # and 13 seeded sampling passes per frame): eager it is kernel-launch-
+        # bound at ~22 ms/frame independent of batch size.
         model.init_frame_decode_graphs(
             list(overrides.get("cuda_graph_bs") or [1, 2, 4, 8, 16])
         )

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -257,14 +257,6 @@ def create_preprocessing_executor(
     )
 
 
-def _env_flag(name: str, default: bool) -> bool:
-    """Read a boolean toggle from the environment (A/B perf knobs)."""
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
-    return raw.strip().lower() in ("1", "true", "yes", "on")
-
-
 def _compile_moss_local_backbone(model: Any) -> None:
     """Per-layer ``torch.compile`` the AR backbone for the decode path.
 
@@ -336,12 +328,12 @@ def create_sglang_tts_engine_executor(
         "dtype": dtype,
         "cuda_graph_bs": [1, 2, 4, 8, 16],
         "cuda_graph_max_bs": 16,
-        # A/B perf knobs (env-gated, default behaves exactly like main):
-        #   MOSS_TTS_DISABLE_CUDA_GRAPH=1  -> skip backbone CUDA graphs
-        #   MOSS_TTS_ENABLE_TORCH_COMPILE=1 -> compile the AR backbone decode path
-        "disable_cuda_graph": _env_flag("MOSS_TTS_DISABLE_CUDA_GRAPH", False),
+        "disable_cuda_graph": False,
         "disable_overlap_schedule": True,
-        "enable_torch_compile": _env_flag("MOSS_TTS_ENABLE_TORCH_COMPILE", False),
+        # Compile the AR backbone decode path (manual per-layer, see
+        # _compile_moss_local_backbone). This branch exists to A/B compile vs
+        # main, so it is always on here; check out main for the baseline.
+        "enable_torch_compile": True,
         "max_prefill_tokens": 8192,
         "max_running_requests": 16,
         # Leave headroom for the two ~4.3 GB bf16 codec instances plus their


### PR DESCRIPTION
## Motivation

Issue #737 proposes enabling `torch.compile` for the MOSS-TTS AR backbone, citing a "~2× speedup proven on Higgs". This PR investigates that for the **Local** variant (`OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5`).

The premise needs correcting first: Higgs (#579) actually measured ±3% (no gain) and that PR was closed unmerged; the real ~2× came from S2-Pro, which has an inner codebook loop that MOSS-TTS-Local does not have. So rather than flip a default blindly, this branch adds an **env-gated** compile path and cross-validates `torch.compile` against the existing AR-backbone CUDA graph.

**Result: a negative one.** The backbone CUDA graph already captures all the decode kernel-launch overhead `torch.compile` would optimize, so compile adds **no measurable speedup on top of CG** — the on-vs-off delta is within ±1.5% and flips sign between concurrency levels (run-to-run noise). This is the apples-to-apples comparison the merge decision rests on. (Compile *without* the backbone CG is much slower, but that config is not apples-to-apples — see the caveat under the benchmark table.) This PR is opened as **draft** to share the code + data; recommendation is **not** to enable compile for this model.

## Modifications

All behind env vars; **defaults reproduce `main`** (compile off has no effect on the graph path). Branch `perf/moss-tts-local-torch-compile`.

- `moss_qwen3_backbone.py` (new): `MossLocalQwen3Model(Qwen3Model)` with a decode-only dispatch — eager `self.layers` for prefill (shape varies → would force dynamo recompiles), `_compiled_decode_layers` for decode when populated. Mirrors `Qwen2Model.forward` (the forward `Qwen3Model` inherits) except the one dispatch line; must be re-diffed against sglang on bumps.
- `sglang_model.py`: uses `MossLocalQwen3Model` instead of the bare `Qwen3Model`.
- `stages.py`: `_compile_moss_local_backbone` (manual per-layer `torch.compile`, then disable sglang auto-compile), `_warmup_eager_pre_cg` (one eager bs=1 forward before `init_device_graphs()` — the #565/#579 CG-corruption fix), and env toggles + a backbone/frame CG split so the matrix can be run cleanly:
  - `MOSS_TTS_ENABLE_TORCH_COMPILE` (default 1 on this branch; compile the AR backbone)
  - `MOSS_TTS_DISABLE_BACKBONE_CUDA_GRAPH` (skip *only* the backbone CG; frame CG stays)
  - `MOSS_TTS_DISABLE_CUDA_GRAPH` (skip both backbone and frame CG)

## Related Issues

Investigates #737. Background: #579 (Higgs, closed unmerged), #565.

## Benchmark & Profiling

**Setup.** `MOSS-TTS-Local-Transformer-v1.5`, 2-GPU config; Seed-TTS-Eval **EN full 1088**, `--token-count auto --ref-format references`; WER scorer `Qwen/Qwen3-ASR-1.7B`. The **per-frame local-transformer CUDA graph is ON in all four cells**; only the AR-backbone path varies (eager frame loop is ~22 ms/frame and would otherwise dominate). `compile mode = max-autotune-no-cudagraphs`. Single run per cell, at concurrency 8 and 16.

**2×2 — AR-backbone RTF mean (lower = better)**

concurrency = 16:

| compile \ backbone CG | **off** | **on** |
|---|---|---|
| **off** | 0.5561 *(eager)* | **0.3562** † |
| **on**  | 1.3713 *(2.47× slower)* | 0.3519 |

concurrency = 8:

| compile \ backbone CG | **off** | **on** |
|---|---|---|
| **off** | 0.4176 *(eager)* | **0.2480** † |
| **on**  | 0.9823 *(2.35× slower)* | 0.2515 |

† ≈ current `main` behavior (compile off, both CUDA graphs on).

**Caveat on the compile-only cells (backbone CG off, compile on).** These are *not* apples-to-apples. Without the backbone CUDA graph, decode batch size is not padded to a fixed set `[1,2,4,8,16]` (padding is a CUDA-graph behavior), so under concurrency the batch size varies freely and `torch.compile` (especially `max-autotune`) repeatedly hits new shapes → recompilation / dynamic-shape kernels. The ~2.4× slowdown vs eager is therefore largely an artifact of the unpadded config, **not** evidence that compiled kernels are intrinsically slower. These cells are included for completeness only; **the merge decision rests solely on the ②→④ comparison** (both padded, both graphs on, compile the only variable).

**Full metrics — concurrency = 16**

| cell | RTF mean | RTF med | RTF p95 | lat mean (s) | req/s | out tok/s | WER micro | WER excl>50% |
|---|---|---|---|---|---|---|---|---|
| ① eager | 0.5561 | 0.5276 | 0.8074 | 2.353 | 6.775 | 372.8 | 3.30% | 1.67% |
| ② CG only (≈ main) | 0.3562 | 0.3390 | 0.5218 | 1.498 | 10.640 | 585.3 | 2.21% | 1.63% |
| ③ compile only | 1.3713 | 1.2892 | 2.0191 | 5.753 | 2.774 | 152.6 | 2.21% | 1.72% |
| ④ compile + CG | 0.3519 | 0.3337 | 0.5114 | 1.476 | 10.785 | 593.3 | 2.02% | 1.61% |

**Full metrics — concurrency = 8**

| cell | RTF mean | RTF med | RTF p95 | lat mean (s) | req/s | out tok/s | WER micro | WER excl>50% |
|---|---|---|---|---|---|---|---|---|
| ① eager | 0.4176 | 0.4027 | 0.5516 | 1.792 | 4.455 | 245.1 | 2.03% | 1.70% |
| ② CG only (≈ main) | 0.2480 | 0.2402 | 0.3336 | 1.055 | 7.565 | 416.2 | 2.34% | 1.61% |
| ③ compile only | 0.9823 | 0.9412 | 1.3207 | 4.167 | 1.917 | 105.5 | 2.27% | 1.63% |
| ④ compile + CG | 0.2515 | 0.2432 | 0.3463 | 1.069 | 7.468 | 410.8 | 2.24% | 1.83% |

**Reading**

| comparison | meaning | c=8 | c=16 |
|---|---|---|---|
| ①→② | add CUDA graph | RTF −40.6%, tput +69.8% | RTF −35.9%, tput +57.0% |
| ②→④ | add compile **on top of** CG | +1.4% (slower) | −1.2% (faster) |
| ①→③ | compile **instead of** CG | 2.35× slower | 2.47× slower |

- **CUDA graph is the entire backbone win** (~36–41% RTF, +57–70% throughput).
- **compile adds nothing on top of CG** — the ②→④ delta flips sign between concurrency levels and stays within ±1.5%, i.e. noise. This is the load-bearing result.
- **compile-only (no backbone CG) is ~2.4× slower** than eager, but see the caveat above: that config leaves decode shapes unpadded, so the slowdown is most likely recompilation/dynamic-shape overhead rather than an intrinsic cost of the compiled kernels. Not used for the decision.
- **Quality unchanged** — WER excl-outlier 1.6–1.7% everywhere.

## Accuracy Test

WER (Seed-TTS-Eval EN, Qwen3-ASR-1.7B) is unchanged across all four configs — see the WER columns above. No accuracy regression from the compile path.

## Recommendation

Do **not** enable `torch.compile` for MOSS-TTS-Local: net-zero speedup on top of the existing CUDA graph (±1.5%, within noise), and the `MossLocalQwen3Model` fork carries real maintenance cost (mirroring `Qwen2Model.forward`, re-diff on every sglang bump). Opened as a draft to record the investigation and data; happy to close if maintainers agree it shouldn't land.

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
