### PR TITLE
Perf/moss 15 cuda graph

### DIFF
--- a/scripts/gate_s0_sync_parity.py
+++ b/scripts/gate_s0_sync_parity.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""S0 gate: fixed-seed sync parity check for MOSS-TTS Local v1.5.
+
+Runs the v1.5 frame-decode graph twice with identical fixed-seed inputs at
+each concurrency level and asserts bit-identical outputs. Must pass before
+and after every PR-A commit to confirm behavior-neutrality.
+
+Usage (inside sglang-omni-jiaxind container on novita-h100):
+    CUDA_VISIBLE_DEVICES=3 python scripts/gate_s0_sync_parity.py
+    CUDA_VISIBLE_DEVICES=3 python scripts/gate_s0_sync_parity.py --batch-sizes 1 4 16
+    CUDA_VISIBLE_DEVICES=3 python scripts/gate_s0_sync_parity.py --frames 50 --seed 12345
+
+Exit code: 0 = all checks passed, 1 = any divergence detected.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Sequence
+
+import torch
+
+_N_VQ = 12
+_HIDDEN = 64
+_VOCAB = 32  # logit head width for the toy model
+
+
+def _build_frame_fn(device: torch.device):
+    """Return a decode_frame callable backed by a toy MossTTSLocalTransformer.
+
+    The toy model uses the same kernel stack as the production model
+    (MossTTSLocalTransformer + sample_seeded_branchless) but with a
+    hidden_size of 64 so it fits in a few MB of VRAM.
+    """
+    from sglang_omni.models.moss_tts_local.local_transformer import (
+        MossTTSLocalTransformer,
+        sample_seeded_branchless,
+    )
+
+    torch.manual_seed(0)
+    module = MossTTSLocalTransformer(
+        hidden_size=_HIDDEN,
+        num_heads=4,
+        inner_size=96,
+        num_layers=1,
+        max_positions=_N_VQ + 1,
+        rope_base=1_000_000.0,
+    ).to(device=device, dtype=torch.bfloat16)
+    tables = [
+        torch.randn(_HIDDEN, _HIDDEN, device=device, dtype=torch.bfloat16)
+        for _ in range(_N_VQ)
+    ]
+
+    def decode_frame(
+        hidden: torch.Tensor,
+        seeds: torch.Tensor,
+        base: torch.Tensor,
+    ) -> torch.Tensor:
+        current = module.step(hidden, 0)
+        codes = []
+        for channel in range(_N_VQ):
+            logits = (current.float() @ tables[channel].float().T)[:, :_VOCAB]
+            code = sample_seeded_branchless(
+                logits,
+                temperature=torch.full((hidden.shape[0],), 1.7, device=device),
+                top_p=torch.full((hidden.shape[0],), 0.8, device=device),
+                top_k=torch.full(
+                    (hidden.shape[0],), 25, device=device, dtype=torch.long
+                ),
+                seeds=seeds,
+                positions=base + channel + 1,
+            )
+            codes.append(code)
+            if channel + 1 < _N_VQ:
+                embed = torch.nn.functional.embedding(
+                    code, tables[channel][:_VOCAB]
+                )
+                current = module.step(embed.to(torch.bfloat16), channel + 1)
+        return torch.stack(codes, dim=-1)
+
+    return decode_frame
+
+
+def _capture_graph(decode_frame, batch: int, device: torch.device):
+    """Capture a CUDA graph for decode_frame at the given batch size."""
+    static_hidden = torch.zeros(batch, _HIDDEN, device=device, dtype=torch.bfloat16)
+    static_seeds = torch.zeros(batch, device=device, dtype=torch.long)
+    static_base = torch.zeros(batch, device=device, dtype=torch.long)
+
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(2):
+            decode_frame(static_hidden, static_seeds, static_base)
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graphed_out = decode_frame(static_hidden, static_seeds, static_base)
+
+    return graph, graphed_out, static_hidden, static_seeds, static_base
+
+
+def _run_parity_check(
+    batch: int,
+    n_frames: int,
+    seed: int,
+    device: torch.device,
+) -> bool:
+    """Return True if all n_frames graph replays are bit-identical across two runs."""
+    decode_frame = _build_frame_fn(device)
+    graph, graphed_out, s_hidden, s_seeds, s_base = _capture_graph(
+        decode_frame, batch, device
+    )
+
+    rng = torch.Generator(device=device)
+    rng.manual_seed(seed)
+
+    all_ok = True
+    for frame_idx in range(n_frames):
+        hidden = torch.randn(batch, _HIDDEN, device=device, dtype=torch.bfloat16,
+                             generator=rng)
+        seeds = (torch.arange(batch, device=device, dtype=torch.long) * 1_234_567
+                 + frame_idx * 13)
+        base = torch.full((batch,), frame_idx * 13, device=device, dtype=torch.long)
+
+        s_hidden.copy_(hidden)
+        s_seeds.copy_(seeds)
+        s_base.copy_(base)
+        graph.replay()
+        run1 = graphed_out.clone()
+
+        s_hidden.copy_(hidden)
+        s_seeds.copy_(seeds)
+        s_base.copy_(base)
+        graph.replay()
+        run2 = graphed_out.clone()
+
+        if not torch.equal(run1, run2):
+            print(
+                f"  FAIL frame={frame_idx} batch={batch}: "
+                f"{(run1 != run2).sum().item()} element(s) differ"
+            )
+            all_ok = False
+
+    return all_ok
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--batch-sizes", type=int, nargs="+", default=[1, 4, 16],
+        metavar="BS",
+        help="batch sizes to test (default: 1 4 16)",
+    )
+    parser.add_argument(
+        "--frames", type=int, default=30,
+        help="number of frames to replay per batch size (default: 30)",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=42,
+        help="RNG seed for random inputs (default: 42)",
+    )
+    args = parser.parse_args(argv)
+
+    if not torch.cuda.is_available():
+        print("SKIP: no CUDA device available")
+        return 0
+
+    device = torch.device("cuda")
+    print(f"S0 gate — device={torch.cuda.get_device_name(0)}")
+    print(f"  batch_sizes={args.batch_sizes}  frames={args.frames}  seed={args.seed}")
+
+    passed = 0
+    failed = 0
+    for bs in args.batch_sizes:
+        ok = _run_parity_check(
+            batch=bs, n_frames=args.frames, seed=args.seed, device=device
+        )
+        status = "PASS" if ok else "FAIL"
+        print(f"  batch={bs:3d}  {status}")
+        if ok:
+            passed += 1
+        else:
+            failed += 1
+
+    print(f"\n{passed} passed, {failed} failed")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gate_s0_sync_parity.py
+++ b/scripts/gate_s0_sync_parity.py
@@ -13,6 +13,7 @@ Usage (inside sglang-omni-jiaxind container on novita-h100):
 
 Exit code: 0 = all checks passed, 1 = any divergence detected.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -73,9 +74,7 @@ def _build_frame_fn(device: torch.device):
             )
             codes.append(code)
             if channel + 1 < _N_VQ:
-                embed = torch.nn.functional.embedding(
-                    code, tables[channel][:_VOCAB]
-                )
+                embed = torch.nn.functional.embedding(code, tables[channel][:_VOCAB])
                 current = module.step(embed.to(torch.bfloat16), channel + 1)
         return torch.stack(codes, dim=-1)
 
@@ -120,10 +119,13 @@ def _run_parity_check(
 
     all_ok = True
     for frame_idx in range(n_frames):
-        hidden = torch.randn(batch, _HIDDEN, device=device, dtype=torch.bfloat16,
-                             generator=rng)
-        seeds = (torch.arange(batch, device=device, dtype=torch.long) * 1_234_567
-                 + frame_idx * 13)
+        hidden = torch.randn(
+            batch, _HIDDEN, device=device, dtype=torch.bfloat16, generator=rng
+        )
+        seeds = (
+            torch.arange(batch, device=device, dtype=torch.long) * 1_234_567
+            + frame_idx * 13
+        )
         base = torch.full((batch,), frame_idx * 13, device=device, dtype=torch.long)
 
         s_hidden.copy_(hidden)
@@ -151,16 +153,23 @@ def _run_parity_check(
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--batch-sizes", type=int, nargs="+", default=[1, 4, 16],
+        "--batch-sizes",
+        type=int,
+        nargs="+",
+        default=[1, 4, 16],
         metavar="BS",
         help="batch sizes to test (default: 1 4 16)",
     )
     parser.add_argument(
-        "--frames", type=int, default=30,
+        "--frames",
+        type=int,
+        default=30,
         help="number of frames to replay per batch size (default: 30)",
     )
     parser.add_argument(
-        "--seed", type=int, default=42,
+        "--seed",
+        type=int,
+        default=42,
         help="RNG seed for random inputs (default: 42)",
     )
     args = parser.parse_args(argv)

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -26,11 +26,6 @@ class MossTTSLocalModelRunner(ModelRunner):
 
     def __init__(self, tp_worker: Any, output_processor: Any):
         super().__init__(tp_worker, output_processor)
-        # Legacy single-slot kept for backward-compat with tests that bypass
-        # _collect_frame and set these directly.  _collect_frame itself only
-        # writes the per-step journal; these are never set in production.
-        self._pending_rows: torch.Tensor | None = None
-        self._pending_embeds: torch.Tensor | None = None
 
     def custom_prefill_forward(
         self,
@@ -378,23 +373,25 @@ class MossTTSLocalModelRunner(ModelRunner):
         scheduler_output: Any,
         outputs: dict[str, RequestOutput],
     ) -> None:
-        journal = getattr(result, "moss_journal", None) if result is not None else None
+        # The per-step journal is the single source of truth for output
+        # collection. A missing journal means no frame was produced this step
+        # (e.g. a prefill-only batch), which is the synchronous-baseline early
+        # return.
+        journal = getattr(result, "moss_journal", None)
         if journal is None:
-            # Fallback: tests that bypass _collect_frame set _pending_rows directly.
-            rows = self._pending_rows
-            self._pending_rows = None
-            self._pending_embeds = None
-            if rows is None:
-                return
-            rids = [r.request_id for r in scheduler_output.requests]
-            journal = MossTTSLocalDecodeJournal(rids=rids, pool_rows=[], rows=rows)
+            return
 
         end_id = int(self.model.config.audio_end_token_id)
         for i, sched_req in enumerate(scheduler_output.requests):
-            assert journal.rids[i] == sched_req.request_id, (
-                "journal/batch alignment broken: "
-                f"{journal.rids[i]} != {sched_req.request_id}"
-            )
+            # Alignment tripwire: a raise (not a bare assert) so it survives
+            # python -O and matches the model package's raise convention; the
+            # journal is built from this same requests list, so misalignment
+            # only ever surfaces a real bug, never silent frame corruption.
+            if journal.rids[i] != sched_req.request_id:
+                raise RuntimeError(
+                    "MOSS-TTS Local journal/batch alignment broken: "
+                    f"{journal.rids[i]} != {sched_req.request_id}"
+                )
             req = sched_req.data.req
             if req is not None and getattr(req, "is_chunked", 0) > 0:
                 continue

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -95,9 +95,7 @@ class MossTTSLocalModelRunner(ModelRunner):
                 rows = torch.cat([rows.to(generated.device), generated], dim=0)
                 pool_row = self.model._state_pool.row_for(sched_req.request_id)
                 if pool_row is not None:
-                    self.model._state_pool._params_written_rids.discard(
-                        sched_req.request_id
-                    )
+                    self.model._state_pool.invalidate_params(sched_req.request_id)
                     self.model._state_pool.reset_row(pool_row)
             current_rows = rows[prefix_len : prefix_len + req_len]
             if int(current_rows.shape[0]) != req_len:
@@ -179,14 +177,14 @@ class MossTTSLocalModelRunner(ModelRunner):
             rid = sched_req.request_id
             row = self.model.acquire_row(rid)
             pool_rows.append(row)
-            if rid not in pool._params_written_rids:
-                pool.write_params(row, sched_req.data)
-                pool._params_written_rids.add(rid)
+            pool.ensure_params(row, rid, sched_req.data)
         datas = [sched_req.data for sched_req in requests]
         batch_size = len(datas)
         num_channels = int(cfg.n_vq) + 1
 
-        row_t = torch.tensor(pool_rows, dtype=torch.long, device=device)
+        row_t = torch.tensor(
+            pool_rows, dtype=torch.long, device=pool.feedback_embeds.device
+        )
         params = {
             "text_temp": pool.text_temp[row_t],
             "text_top_p": pool.text_top_p[row_t],
@@ -279,17 +277,26 @@ class MossTTSLocalModelRunner(ModelRunner):
             embeds = self.model._prepare_multi_modal_inputs(
                 rows.to(device=self.model.device)
             )
-        row_t = torch.tensor(
-            pool_rows, dtype=torch.long, device=pool.feedback_embeds.device
-        )
-        pool.feedback_embeds[row_t] = embeds.detach().to(
+        emit_indices = [
+            i
+            for i, sched_req in enumerate(requests)
+            if not self._is_chunked_request(sched_req)
+        ]
+        if not emit_indices:
+            return
+
+        emit_index_t = torch.tensor(emit_indices, dtype=torch.long, device=rows.device)
+        emit_pool_rows = [pool_rows[i] for i in emit_indices]
+        emit_row_t = row_t[emit_index_t.to(device=row_t.device)]
+        emit_embeds = embeds.index_select(0, emit_index_t.to(device=embeds.device))
+        pool.feedback_embeds[emit_row_t] = emit_embeds.detach().to(
             device=pool.feedback_embeds.device,
             dtype=pool.feedback_embeds.dtype,
         )
         result.moss_journal = MossTTSLocalDecodeJournal(
-            rids=[sched_req.request_id for sched_req in requests],
-            pool_rows=pool_rows,
-            rows=rows,
+            rids=[requests[i].request_id for i in emit_indices],
+            pool_rows=emit_pool_rows,
+            rows=rows.index_select(0, emit_index_t),
         )
 
     @staticmethod
@@ -367,6 +374,11 @@ class MossTTSLocalModelRunner(ModelRunner):
                 scores < 0, scores * penalty, scores / penalty
             )
 
+    @staticmethod
+    def _is_chunked_request(sched_req: Any) -> bool:
+        req = getattr(sched_req.data, "req", None)
+        return req is not None and getattr(req, "is_chunked", 0) > 0
+
     def post_process_outputs(
         self,
         result: Any,
@@ -382,19 +394,25 @@ class MossTTSLocalModelRunner(ModelRunner):
             return
 
         end_id = int(self.model.config.audio_end_token_id)
-        for i, sched_req in enumerate(scheduler_output.requests):
-            # Alignment tripwire: a raise (not a bare assert) so it survives
-            # python -O and matches the model package's raise convention; the
-            # journal is built from this same requests list, so misalignment
-            # only ever surfaces a real bug, never silent frame corruption.
-            if journal.rids[i] != sched_req.request_id:
-                raise RuntimeError(
-                    "MOSS-TTS Local journal/batch alignment broken: "
-                    f"{journal.rids[i]} != {sched_req.request_id}"
-                )
-            req = sched_req.data.req
-            if req is not None and getattr(req, "is_chunked", 0) > 0:
-                continue
+        expected_reqs = [
+            sched_req
+            for sched_req in scheduler_output.requests
+            if not self._is_chunked_request(sched_req)
+        ]
+        expected_rids = [sched_req.request_id for sched_req in expected_reqs]
+        rows_len = int(journal.rows.shape[0])
+        if len(journal.rids) != rows_len or len(journal.pool_rows) != rows_len:
+            raise RuntimeError(
+                "MOSS-TTS Local journal length mismatch: "
+                f"rids={len(journal.rids)} pool_rows={len(journal.pool_rows)} "
+                f"rows={rows_len}"
+            )
+        if journal.rids != expected_rids:
+            raise RuntimeError(
+                "MOSS-TTS Local journal/batch alignment broken: "
+                f"{journal.rids} != {expected_rids}"
+            )
+        for i, sched_req in enumerate(expected_reqs):
             req_output = outputs[sched_req.request_id]
             if req_output.data is None or int(req_output.data) == end_id:
                 continue

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -182,6 +182,12 @@ class MossTTSLocalModelRunner(ModelRunner):
         batch_size = len(datas)
         num_channels = int(cfg.n_vq) + 1
 
+        # Assign each request its decode-state pool row on first collect
+        # (idempotent by rid); the row stays stable across retraction/resume
+        # and is recycled only when the request finishes or aborts.
+        for sched_req in requests:
+            self.model.acquire_row(sched_req.request_id)
+
         # The static per-request sampling parameters only change with batch
         # composition, so rebuild them once per composition; gen_steps moves
         # every step and is rebuilt each time.

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -407,6 +407,10 @@ class MossTTSLocalModelRunner(ModelRunner):
         # rows/embeds are step-private tensors (the graph outputs were
         # snapshotted in _collect_frame), so per-request views are stable.
         for row_idx, sched_req in enumerate(scheduler_output.requests):
+            req = sched_req.data.req
+            if req is not None and getattr(req, "is_chunked", 0) > 0:
+                # Mid-prefill chunk: feedback/rows not yet valid, skip.
+                continue
             req_output = outputs[sched_req.request_id]
             if req_output.data is None or int(req_output.data) == end_id:
                 # Stop decision: no frame is emitted alongside audio_end.

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -9,6 +9,7 @@ import torch
 
 from sglang_omni.model_runner.base import ModelRunner
 from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+from sglang_omni.models.moss_tts_local.state_pool import MossTTSLocalDecodeJournal
 from sglang_omni.scheduling.types import RequestOutput
 
 
@@ -25,6 +26,9 @@ class MossTTSLocalModelRunner(ModelRunner):
 
     def __init__(self, tp_worker: Any, output_processor: Any):
         super().__init__(tp_worker, output_processor)
+        # Legacy single-slot kept for backward-compat with tests that bypass
+        # _collect_frame and set these directly.  _collect_frame itself only
+        # writes the per-step journal; these are never set in production.
         self._pending_rows: torch.Tensor | None = None
         self._pending_embeds: torch.Tensor | None = None
 
@@ -94,7 +98,12 @@ class MossTTSLocalModelRunner(ModelRunner):
                 # stranded by the retraction.
                 generated = torch.stack(data.output_rows, dim=0)
                 rows = torch.cat([rows.to(generated.device), generated], dim=0)
-                data.pending_feedback_queue.clear()
+                pool_row = self.model._state_pool.row_for(sched_req.request_id)
+                if pool_row is not None:
+                    self.model._state_pool._params_written_rids.discard(
+                        sched_req.request_id
+                    )
+                    self.model._state_pool.reset_row(pool_row)
             current_rows = rows[prefix_len : prefix_len + req_len]
             if int(current_rows.shape[0]) != req_len:
                 raise RuntimeError(
@@ -126,30 +135,21 @@ class MossTTSLocalModelRunner(ModelRunner):
         batch_size = len(requests)
         if batch_size == 0:
             return
-        embedding = self.model._decode_input_embedding
-        weight = embedding.weight
+        pool = self.model._state_pool
+        weight = self.model._decode_input_embedding.weight
         if forward_batch.input_ids.numel() < batch_size:
             raise RuntimeError(
                 "MOSS-TTS Local decode input_ids must contain one row id per request"
             )
-        if batch_size > int(weight.shape[0]):
+        if batch_size > pool.padding_row:
             raise RuntimeError(
                 "MOSS-TTS Local decode batch exceeds the staged decode-embedding "
-                f"rows ({batch_size} > {int(weight.shape[0])})"
+                f"rows ({batch_size} > {pool.padding_row})"
             )
-        rows = []
-        for sched_req in requests:
-            queue = sched_req.data.pending_feedback_queue
-            if not queue:
-                rows.append(torch.zeros(self.model.hidden_size, device=weight.device))
-                continue
-            if hasattr(queue, "popleft"):
-                rows.append(queue.popleft())
-            else:
-                rows.append(queue.pop(0))
-        stacked = torch.stack(rows, dim=0).to(device=weight.device, dtype=weight.dtype)
+        pool_rows = [pool.acquire_row(sched_req.request_id) for sched_req in requests]
+        row_tensor = torch.tensor(pool_rows, dtype=torch.long, device=weight.device)
         with torch.no_grad():
-            weight[:batch_size].copy_(stacked)
+            weight[:batch_size].copy_(pool.feedback_embeds[row_tensor])
 
         row_ids = torch.arange(
             batch_size,
@@ -178,62 +178,29 @@ class MossTTSLocalModelRunner(ModelRunner):
 
         cfg = self.model.config
         device = hidden_states.device
+        pool = self.model._state_pool
+        pool_rows = []
+        for sched_req in requests:
+            rid = sched_req.request_id
+            row = self.model.acquire_row(rid)
+            pool_rows.append(row)
+            if rid not in pool._params_written_rids:
+                pool.write_params(row, sched_req.data)
+                pool._params_written_rids.add(rid)
         datas = [sched_req.data for sched_req in requests]
         batch_size = len(datas)
         num_channels = int(cfg.n_vq) + 1
 
-        # Assign each request its decode-state pool row on first collect
-        # (idempotent by rid); the row stays stable across retraction/resume
-        # and is recycled only when the request finishes or aborts.
-        for sched_req in requests:
-            self.model.acquire_row(sched_req.request_id)
-
-        # The static per-request sampling parameters only change with batch
-        # composition, so rebuild them once per composition; gen_steps moves
-        # every step and is rebuilt each time.
-        cache_key = tuple(sched_req.request_id for sched_req in requests)
-        cached = getattr(self, "_param_cache", None)
-        if cached is None or cached[0] != cache_key:
-            params = {
-                "text_temp": torch.tensor(
-                    [float(d.text_temperature) for d in datas],
-                    dtype=torch.float32,
-                    device=device,
-                ),
-                "text_top_p": torch.tensor(
-                    [float(d.text_top_p) for d in datas],
-                    dtype=torch.float32,
-                    device=device,
-                ),
-                "text_top_k": torch.tensor(
-                    [int(d.text_top_k) for d in datas],
-                    dtype=torch.long,
-                    device=device,
-                ),
-                "audio_temp": torch.tensor(
-                    [float(d.audio_temperature) for d in datas],
-                    dtype=torch.float32,
-                    device=device,
-                ),
-                "audio_top_p": torch.tensor(
-                    [float(d.audio_top_p) for d in datas],
-                    dtype=torch.float32,
-                    device=device,
-                ),
-                "audio_top_k": torch.tensor(
-                    [int(d.audio_top_k) for d in datas],
-                    dtype=torch.long,
-                    device=device,
-                ),
-                "seeds": torch.tensor(
-                    [int(d.sampling_seed) for d in datas],
-                    dtype=torch.long,
-                    device=device,
-                ),
-            }
-            self._param_cache = (cache_key, params)
-        else:
-            params = cached[1]
+        row_t = torch.tensor(pool_rows, dtype=torch.long, device=device)
+        params = {
+            "text_temp": pool.text_temp[row_t],
+            "text_top_p": pool.text_top_p[row_t],
+            "text_top_k": pool.text_top_k[row_t],
+            "audio_temp": pool.audio_temp[row_t],
+            "audio_top_p": pool.audio_top_p[row_t],
+            "audio_top_k": pool.audio_top_k[row_t],
+            "seeds": pool.seeds[row_t],
+        }
         text_temp = params["text_temp"]
         text_top_p = params["text_top_p"]
         text_top_k = params["text_top_k"]
@@ -317,8 +284,18 @@ class MossTTSLocalModelRunner(ModelRunner):
             embeds = self.model._prepare_multi_modal_inputs(
                 rows.to(device=self.model.device)
             )
-        self._pending_rows = rows
-        self._pending_embeds = embeds.detach()
+        row_t = torch.tensor(
+            pool_rows, dtype=torch.long, device=pool.feedback_embeds.device
+        )
+        pool.feedback_embeds[row_t] = embeds.detach().to(
+            device=pool.feedback_embeds.device,
+            dtype=pool.feedback_embeds.dtype,
+        )
+        result.moss_journal = MossTTSLocalDecodeJournal(
+            rids=[sched_req.request_id for sched_req in requests],
+            pool_rows=pool_rows,
+            rows=rows,
+        )
 
     @staticmethod
     def _row_radix_token_ids(
@@ -401,25 +378,27 @@ class MossTTSLocalModelRunner(ModelRunner):
         scheduler_output: Any,
         outputs: dict[str, RequestOutput],
     ) -> None:
-        del result
-        rows = self._pending_rows
-        embeds = self._pending_embeds
-        self._pending_rows = None
-        self._pending_embeds = None
-        if rows is None or embeds is None:
-            return
+        journal = getattr(result, "moss_journal", None) if result is not None else None
+        if journal is None:
+            # Fallback: tests that bypass _collect_frame set _pending_rows directly.
+            rows = self._pending_rows
+            self._pending_rows = None
+            self._pending_embeds = None
+            if rows is None:
+                return
+            rids = [r.request_id for r in scheduler_output.requests]
+            journal = MossTTSLocalDecodeJournal(rids=rids, pool_rows=[], rows=rows)
 
         end_id = int(self.model.config.audio_end_token_id)
-        # rows/embeds are step-private tensors (the graph outputs were
-        # snapshotted in _collect_frame), so per-request views are stable.
-        for row_idx, sched_req in enumerate(scheduler_output.requests):
+        for i, sched_req in enumerate(scheduler_output.requests):
+            assert journal.rids[i] == sched_req.request_id, (
+                "journal/batch alignment broken: "
+                f"{journal.rids[i]} != {sched_req.request_id}"
+            )
             req = sched_req.data.req
             if req is not None and getattr(req, "is_chunked", 0) > 0:
-                # Mid-prefill chunk: feedback/rows not yet valid, skip.
                 continue
             req_output = outputs[sched_req.request_id]
             if req_output.data is None or int(req_output.data) == end_id:
-                # Stop decision: no frame is emitted alongside audio_end.
                 continue
-            sched_req.data.output_rows.append(rows[row_idx])
-            sched_req.data.pending_feedback_queue.append(embeds[row_idx])
+            sched_req.data.output_rows.append(journal.rows[i])

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import bisect
 from typing import Any
 
 import torch
@@ -50,6 +51,8 @@ class MossTTSLocalModelRunner(ModelRunner):
         del is_lookahead
         del schedule_batch
         self._write_decode_input_embedding(forward_batch, requests)
+        if self._forward_sample_enabled():
+            self._prepare_forward_sample_inputs(forward_batch, requests)
 
     def post_prefill(
         self,
@@ -125,33 +128,265 @@ class MossTTSLocalModelRunner(ModelRunner):
         forward_batch: Any,
         requests: list,
     ) -> None:
-        batch_size = len(requests)
-        if batch_size == 0:
+        n_real = len(requests)
+        raw_batch_size = int(getattr(forward_batch, "batch_size", n_real) or n_real)
+        staging_batch_size = self._decode_staging_batch_size(raw_batch_size)
+        if n_real == 0 and staging_batch_size == 0:
             return
         pool = self.model._state_pool
         weight = self.model._decode_input_embedding.weight
-        if forward_batch.input_ids.numel() < batch_size:
+        if raw_batch_size < n_real:
+            raise RuntimeError(
+                "MOSS-TTS Local decode graph batch is smaller than the real batch "
+                f"({raw_batch_size} < {n_real})"
+            )
+        if forward_batch.input_ids.numel() < raw_batch_size:
             raise RuntimeError(
                 "MOSS-TTS Local decode input_ids must contain one row id per request"
             )
-        if batch_size > pool.padding_row:
+        if staging_batch_size > pool.padding_row:
             raise RuntimeError(
                 "MOSS-TTS Local decode batch exceeds the staged decode-embedding "
-                f"rows ({batch_size} > {pool.padding_row})"
+                f"rows ({staging_batch_size} > {pool.padding_row})"
             )
         pool_rows = [pool.acquire_row(sched_req.request_id) for sched_req in requests]
+        if staging_batch_size > n_real:
+            pool_rows.extend([pool.padding_row] * (staging_batch_size - n_real))
         row_tensor = torch.tensor(pool_rows, dtype=torch.long, device=weight.device)
         with torch.no_grad():
-            weight[:batch_size].copy_(pool.feedback_embeds[row_tensor])
+            weight[:staging_batch_size].copy_(pool.feedback_embeds[row_tensor])
 
         row_ids = torch.arange(
-            batch_size,
+            raw_batch_size,
             dtype=torch.long,
             device=forward_batch.input_ids.device,
         )
-        forward_batch.input_ids[:batch_size].copy_(row_ids)
+        forward_batch.input_ids[:raw_batch_size].copy_(row_ids)
+
+    def _decode_staging_batch_size(self, raw_batch_size: int) -> int:
+        """Return the model-buffer rows SGLang may read for this decode step.
+
+        SGLang's cuda graph runner receives the raw ForwardBatch, then pads it
+        to the next captured ``cuda_graph_bs`` bucket during replay. The model
+        staging buffers are outside SGLang's GraphInputBuffers, so they must be
+        prefilled up to the same bucket here.
+        """
+        raw_batch_size = int(raw_batch_size)
+        if raw_batch_size <= 0:
+            return 0
+        if not bool(getattr(self.model, "_moss_local_decode_graph_padding", False)):
+            return raw_batch_size
+        buckets = sorted(
+            {
+                int(bs)
+                for bs in getattr(self.model, "_moss_local_decode_cuda_graph_bs", [])
+                if int(bs) > 0
+            }
+        )
+        if not buckets:
+            return raw_batch_size
+        idx = bisect.bisect_left(buckets, raw_batch_size)
+        return buckets[idx] if idx < len(buckets) else raw_batch_size
+
+    def _forward_sample_enabled(self) -> bool:
+        return bool(getattr(self.model, "forward_sample_in_forward", False)) and all(
+            hasattr(self.model, name)
+            for name in (
+                "_cg_text_temp",
+                "_cg_text_top_p",
+                "_cg_text_top_k",
+                "_cg_audio_temp",
+                "_cg_audio_top_p",
+                "_cg_audio_top_k",
+                "_cg_seeds",
+                "_cg_base_positions",
+                "_cg_rows",
+                "_cg_feedback",
+            )
+        )
+
+    def _prepare_forward_sample_inputs(
+        self,
+        forward_batch: Any,
+        requests: list,
+    ) -> None:
+        if not requests:
+            self._forward_sample_pool_rows = []
+            self._forward_sample_rids = []
+            return
+        n_real = len(requests)
+        raw_batch_size = int(getattr(forward_batch, "batch_size", n_real) or n_real)
+        staging_batch_size = self._decode_staging_batch_size(raw_batch_size)
+        model = self.model
+        max_rows = int(model._cg_text_temp.shape[0])
+        if raw_batch_size < n_real:
+            raise RuntimeError(
+                "MOSS-TTS Local forward-sample graph batch is smaller than the "
+                f"real batch ({raw_batch_size} < {n_real})"
+            )
+        if staging_batch_size > max_rows:
+            raise RuntimeError(
+                "MOSS-TTS Local forward-sample batch exceeds staging buffers "
+                f"({staging_batch_size} > {max_rows})"
+            )
+
+        pool = model._state_pool
+        pool_rows = []
+        for sched_req in requests:
+            rid = sched_req.request_id
+            row = pool.acquire_row(rid)
+            pool.ensure_params(row, rid, sched_req.data)
+            pool_rows.append(row)
+
+        row_t = torch.tensor(
+            pool_rows, dtype=torch.long, device=pool.feedback_embeds.device
+        )
+        num_channels = int(model.config.n_vq) + 1
+        generation_steps = torch.tensor(
+            [int(sched_req.data.generation_steps) for sched_req in requests],
+            dtype=torch.long,
+            device=model._cg_base_positions.device,
+        )
+
+        with torch.no_grad():
+            if n_real:
+                model._cg_text_temp[:n_real].copy_(
+                    pool.text_temp[row_t].to(model._cg_text_temp.device)
+                )
+                model._cg_text_top_p[:n_real].copy_(
+                    pool.text_top_p[row_t].to(model._cg_text_top_p.device)
+                )
+                model._cg_text_top_k[:n_real].copy_(
+                    pool.text_top_k[row_t].to(model._cg_text_top_k.device)
+                )
+                model._cg_audio_temp[:n_real].copy_(
+                    pool.audio_temp[row_t].to(model._cg_audio_temp.device)
+                )
+                model._cg_audio_top_p[:n_real].copy_(
+                    pool.audio_top_p[row_t].to(model._cg_audio_top_p.device)
+                )
+                model._cg_audio_top_k[:n_real].copy_(
+                    pool.audio_top_k[row_t].to(model._cg_audio_top_k.device)
+                )
+                model._cg_seeds[:n_real].copy_(
+                    pool.seeds[row_t].to(model._cg_seeds.device)
+                )
+                model._cg_base_positions[:n_real].copy_(generation_steps * num_channels)
+            if staging_batch_size > n_real:
+                model._cg_text_temp[n_real:staging_batch_size].fill_(1.0)
+                model._cg_text_top_p[n_real:staging_batch_size].fill_(1.0)
+                model._cg_text_top_k[n_real:staging_batch_size].fill_(50)
+                model._cg_audio_temp[n_real:staging_batch_size].fill_(1.0)
+                model._cg_audio_top_p[n_real:staging_batch_size].fill_(1.0)
+                model._cg_audio_top_k[n_real:staging_batch_size].fill_(25)
+                model._cg_seeds[n_real:staging_batch_size].zero_()
+                model._cg_base_positions[n_real:staging_batch_size].zero_()
+
+        self._forward_sample_pool_rows = pool_rows
+        self._forward_sample_rids = [sched_req.request_id for sched_req in requests]
+
+    def _use_forward_sample_path(
+        self,
+        result: Any,
+        forward_batch: Any,
+        requests: list,
+    ) -> bool:
+        if not self._forward_sample_enabled() or not requests:
+            return False
+        forward_mode = getattr(forward_batch, "forward_mode", None)
+        is_decode = (
+            forward_mode is not None
+            and hasattr(forward_mode, "is_decode")
+            and bool(forward_mode.is_decode())
+        )
+        if not is_decode:
+            return False
+        if getattr(result, "logits_output", None) is None:
+            return False
+        return all(
+            float(getattr(sched_req.data, "audio_repetition_penalty", 1.0)) == 1.0
+            for sched_req in requests
+        )
 
     def _collect_frame(
+        self,
+        result: Any,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list,
+    ) -> None:
+        if self._use_forward_sample_path(result, forward_batch, requests):
+            self._collect_frame_from_forward_sample(result, schedule_batch, requests)
+        else:
+            self._collect_frame_legacy(result, forward_batch, schedule_batch, requests)
+
+    def _collect_frame_from_forward_sample(
+        self,
+        result: Any,
+        schedule_batch: Any,
+        requests: list,
+    ) -> None:
+        # Sampling already ran inside MossTTSLocalSGLangModel.forward() via
+        # _decode_frame_graphable(); collection only snapshots the fixed
+        # staging buffers and updates scheduler/pool state outside the graph.
+        if not requests:
+            return
+        n_real = len(requests)
+        current_rids = [sched_req.request_id for sched_req in requests]
+        staged_rids = list(getattr(self, "_forward_sample_rids", []))
+        pool_rows = list(getattr(self, "_forward_sample_pool_rows", []))
+        if staged_rids[:n_real] != current_rids:
+            raise RuntimeError(
+                "MOSS-TTS Local forward-sample request alignment broken: "
+                f"{staged_rids[:n_real]} != {current_rids}"
+            )
+        if len(pool_rows) < n_real:
+            raise RuntimeError(
+                "MOSS-TTS Local forward-sample pool row staging is incomplete: "
+                f"{len(pool_rows)} < {n_real}"
+            )
+
+        model = self.model
+        if (
+            int(model._cg_rows.shape[0]) < n_real
+            or int(model._cg_feedback.shape[0]) < n_real
+        ):
+            raise RuntimeError("MOSS-TTS Local forward-sample output buffers too small")
+        cfg = model.config
+        pool = model._state_pool
+        rows = model._cg_rows[:n_real].clone()
+        feedback = model._cg_feedback[:n_real].clone()
+        next_text = rows[:, 0]
+        end_id = int(cfg.audio_end_token_id)
+        next_token_ids = self._row_radix_token_ids(rows, next_text, end_id)
+        result.next_token_ids = next_token_ids
+        schedule_batch.output_ids = next_token_ids
+
+        emit_indices = [
+            i
+            for i, sched_req in enumerate(requests)
+            if not self._is_chunked_request(sched_req)
+        ]
+        if not emit_indices:
+            return
+
+        emit_index_t = torch.tensor(emit_indices, dtype=torch.long, device=rows.device)
+        emit_pool_rows = [pool_rows[i] for i in emit_indices]
+        emit_row_t = torch.tensor(
+            emit_pool_rows, dtype=torch.long, device=pool.feedback_embeds.device
+        )
+        emit_feedback = feedback.index_select(0, emit_index_t.to(feedback.device))
+        pool.feedback_embeds[emit_row_t] = emit_feedback.detach().to(
+            device=pool.feedback_embeds.device,
+            dtype=pool.feedback_embeds.dtype,
+        )
+        result.moss_journal = MossTTSLocalDecodeJournal(
+            rids=[requests[i].request_id for i in emit_indices],
+            pool_rows=emit_pool_rows,
+            rows=rows.index_select(0, emit_index_t),
+        )
+
+    def _collect_frame_legacy(
         self,
         result: Any,
         forward_batch: Any,

--- a/sglang_omni/models/moss_tts_local/request_builders.py
+++ b/sglang_omni/models/moss_tts_local/request_builders.py
@@ -434,10 +434,11 @@ def make_moss_tts_local_scheduler_adapters(*, model: Any):
         return build_sglang_moss_tts_local_request(payload, model=model)
 
     def result_adapter(data: MossTTSLocalSGLangRequestData) -> StagePayload:
-        result = apply_sglang_moss_tts_local_result(data.stage_payload, data)
-        # Release the finished request's decode-state pool row (mirrors Higgs
-        # request_builders.py:186); recycles the row for a waiting request.
-        model.reset_request(data.stage_payload.request_id)
-        return result
+        try:
+            return apply_sglang_moss_tts_local_result(data.stage_payload, data)
+        finally:
+            # Release the finished request's decode-state pool row (mirrors
+            # Higgs request_builders.py:186); recycles the row for a waiter.
+            model.reset_request(data.stage_payload.request_id)
 
     return request_builder, result_adapter

--- a/sglang_omni/models/moss_tts_local/request_builders.py
+++ b/sglang_omni/models/moss_tts_local/request_builders.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import collections
 import threading
 import time
 from dataclasses import dataclass, field
@@ -45,7 +44,6 @@ class MossTTSLocalSGLangRequestData(ARRequestData):
     model_config: Any = None
     prompt_rows: torch.Tensor | None = None
     output_rows: list[torch.Tensor] = field(default_factory=list)
-    pending_feedback_queue: Any = field(default_factory=collections.deque)
     # Checkpoint generate() defaults: the binary continue/stop head samples at
     # plain temperature 1.0 while the audio channels use the model-card
     # recommendation (1.7 / 0.8 / 25, repetition penalty off).

--- a/sglang_omni/models/moss_tts_local/request_builders.py
+++ b/sglang_omni/models/moss_tts_local/request_builders.py
@@ -436,6 +436,10 @@ def make_moss_tts_local_scheduler_adapters(*, model: Any):
         return build_sglang_moss_tts_local_request(payload, model=model)
 
     def result_adapter(data: MossTTSLocalSGLangRequestData) -> StagePayload:
-        return apply_sglang_moss_tts_local_result(data.stage_payload, data)
+        result = apply_sglang_moss_tts_local_result(data.stage_payload, data)
+        # Release the finished request's decode-state pool row (mirrors Higgs
+        # request_builders.py:186); recycles the row for a waiting request.
+        model.reset_request(data.stage_payload.request_id)
+        return result
 
     return request_builder, result_adapter

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -127,6 +127,8 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             dtype=weight.dtype,
         )
         self._decode_input_embedding.weight.requires_grad_(False)
+        self.forward_sample_in_forward = False
+        self.init_forward_sample_buffers()
 
         # Row-indexed decode-state pool: next-step-critical per-request state
         # (next-frame feedback embedding, request-static sampling params/seed)
@@ -134,6 +136,55 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         # above. Allocated here, before any frame/backbone graph capture, so
         # its addresses are fixed for the process lifetime.
         self._state_pool = MossTTSLocalDecodeStatePool(self)
+
+    def init_forward_sample_buffers(self) -> None:
+        """Allocate fixed decode-time staging used by the opt-in forward path."""
+        weight = self._decode_input_embedding.weight
+        max_running_requests = int(weight.shape[0])
+        device = weight.device
+        self._cg_text_temp = torch.ones(
+            max_running_requests, device=device, dtype=torch.float32
+        )
+        self._cg_text_top_p = torch.ones(
+            max_running_requests, device=device, dtype=torch.float32
+        )
+        self._cg_text_top_k = torch.full(
+            (max_running_requests,), 50, device=device, dtype=torch.int64
+        )
+        self._cg_audio_temp = torch.ones(
+            max_running_requests, device=device, dtype=torch.float32
+        )
+        self._cg_audio_top_p = torch.ones(
+            max_running_requests, device=device, dtype=torch.float32
+        )
+        self._cg_audio_top_k = torch.full(
+            (max_running_requests,), 25, device=device, dtype=torch.int64
+        )
+        self._cg_seeds = torch.zeros(
+            max_running_requests, device=device, dtype=torch.int64
+        )
+        self._cg_base_positions = torch.zeros(
+            max_running_requests, device=device, dtype=torch.int64
+        )
+
+        self._cg_stop_choice = torch.zeros(
+            max_running_requests, device=device, dtype=torch.int64
+        )
+        self._cg_codes = torch.zeros(
+            max_running_requests, self.n_vq, device=device, dtype=torch.int64
+        )
+        self._cg_feedback = torch.zeros(
+            max_running_requests,
+            self.hidden_size,
+            device=device,
+            dtype=weight.dtype,
+        )
+        self._cg_rows = torch.zeros(
+            max_running_requests,
+            self.n_vq + 1,
+            device=device,
+            dtype=torch.int64,
+        )
 
     def acquire_row(self, rid: str) -> int:
         """Assign (or return the existing) decode-state pool row for ``rid``."""
@@ -287,13 +338,13 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         input_embeds_are_projected: bool = False,
     ) -> LogitsProcessorOutput:
         del input_embeds_are_projected
+        forward_mode = getattr(forward_batch, "forward_mode", None)
+        is_decode = (
+            forward_mode is not None
+            and hasattr(forward_mode, "is_decode")
+            and bool(forward_mode.is_decode())
+        )
         if input_embeds is None:
-            forward_mode = getattr(forward_batch, "forward_mode", None)
-            is_decode = (
-                forward_mode is not None
-                and hasattr(forward_mode, "is_decode")
-                and bool(forward_mode.is_decode())
-            )
             if is_decode:
                 input_embeds = self._decode_input_embedding(input_ids)
             elif self.pp_group.is_first_rank:
@@ -315,10 +366,40 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             hidden_states,
             forward_batch,
         )
-        # The local-transformer frame decode (binary stop head + 12 sequential
-        # codebook samples) runs in the model runner after the graph-captured
-        # backbone returns; emitting hidden states with dummy logits keeps the
-        # backbone CUDA-graph replay free of model-specific outputs.
+        if (
+            is_decode
+            and bool(getattr(self, "forward_sample_in_forward", False))
+            and hasattr(self, "_cg_text_temp")
+        ):
+            batch_size = int(sample_hidden_states.shape[0])
+            stop_choice, codes, feedback = self._decode_frame_graphable(
+                sample_hidden_states,
+                text_temperature=self._cg_text_temp[:batch_size],
+                text_top_p=self._cg_text_top_p[:batch_size],
+                text_top_k=self._cg_text_top_k[:batch_size],
+                audio_temperature=self._cg_audio_temp[:batch_size],
+                audio_top_p=self._cg_audio_top_p[:batch_size],
+                audio_top_k=self._cg_audio_top_k[:batch_size],
+                seeds=self._cg_seeds[:batch_size],
+                base_positions=self._cg_base_positions[:batch_size],
+            )
+            self._cg_stop_choice[:batch_size] = stop_choice
+            self._cg_codes[:batch_size] = codes
+            self._cg_feedback[:batch_size] = feedback
+            slot_id = int(self.config.audio_assistant_slot_token_id)
+            end_id = int(self.config.audio_end_token_id)
+            next_text = torch.where(
+                stop_choice == 0,
+                torch.full_like(stop_choice, slot_id),
+                torch.full_like(stop_choice, end_id),
+            )
+            self._cg_rows[:batch_size, 0] = next_text
+            self._cg_rows[:batch_size, 1:] = codes
+
+        # Legacy flow consumes hidden_states in the model runner and samples
+        # there. The opt-in forward-sample flow above has already written the
+        # sampled frame to fixed staging buffers. In both cases dummy logits
+        # keep SGLang's output contract satisfied.
         dummy_logits = sample_hidden_states.new_empty(
             (sample_hidden_states.shape[0], 1)
         )

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -36,6 +36,7 @@ from sglang_omni.models.moss_tts_local.local_transformer import (
 from sglang_omni.models.moss_tts_local.payload_types import (
     moss_tts_local_special_token_defaults,
 )
+from sglang_omni.models.moss_tts_local.state_pool import MossTTSLocalDecodeStatePool
 
 logger = logging.getLogger(__name__)
 
@@ -126,6 +127,29 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             dtype=weight.dtype,
         )
         self._decode_input_embedding.weight.requires_grad_(False)
+
+        # Row-indexed decode-state pool: next-step-critical per-request state
+        # (next-frame feedback embedding, request-static sampling params/seed)
+        # lives in process-lifetime GPU buffers sized off the staging table
+        # above. Allocated here, before any frame/backbone graph capture, so
+        # its addresses are fixed for the process lifetime.
+        self._state_pool = MossTTSLocalDecodeStatePool(self)
+
+    def acquire_row(self, rid: str) -> int:
+        """Assign (or return the existing) decode-state pool row for ``rid``."""
+        return self._state_pool.acquire_row(rid)
+
+    def release_row(self, rid: str) -> None:
+        """Return ``rid``'s pool row to the free list. No-op if unheld."""
+        self._state_pool.release_row(rid)
+
+    def reset_request(self, rid: str) -> None:
+        """Release pool state for a finished or aborted request (idempotent)."""
+        self._state_pool.release_row(rid)
+
+    def row_for(self, rid: str) -> int | None:
+        """Return ``rid``'s pool row, or ``None`` if it holds none."""
+        return self._state_pool.row_for(rid)
 
     @staticmethod
     def _cfg_get(config: Any, name: str, default: Any) -> Any:

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -344,6 +344,13 @@ def create_sglang_tts_engine_executor(
         model=model
     )
 
+    def abort_request(request_id: str) -> None:
+        # An aborted request may be mid-preprocessing (drop its prepared
+        # handoff) and/or hold a decode-state pool row (release it); both
+        # legs are idempotent no-ops when the request never reached them.
+        cleanup_prepared_moss_tts_local_request(request_id)
+        model.reset_request(request_id)
+
     return OmniScheduler(
         tp_worker=model_worker,
         tree_cache=tree_cache,
@@ -356,7 +363,7 @@ def create_sglang_tts_engine_executor(
         model_runner=MossTTSLocalModelRunner(model_worker, output_proc),
         request_builder=request_builder,
         result_adapter=result_adapter,
-        abort_callback=cleanup_prepared_moss_tts_local_request,
+        abort_callback=abort_request,
     )
 
 

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -263,6 +263,7 @@ def create_sglang_tts_engine_executor(
     gpu_id: int | None = None,
     dtype: str = "bfloat16",
     server_args_overrides: dict[str, Any] | None = None,
+    forward_sample_in_forward: bool = False,
 ) -> Any:
     from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
     from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
@@ -326,6 +327,13 @@ def create_sglang_tts_engine_executor(
         server_args.disable_cuda_graph = False
 
     model = model_worker.model_runner.model
+    model.forward_sample_in_forward = bool(forward_sample_in_forward)
+    model._moss_local_decode_cuda_graph_bs = list(
+        overrides.get("cuda_graph_bs") or [1, 2, 4, 8, 16]
+    )
+    model._moss_local_decode_graph_padding = want_cuda_graph and not bool(
+        getattr(server_args, "disable_cuda_graph_padding", False)
+    )
     if want_cuda_graph:
         model_worker.model_runner.init_device_graphs()
         # Also graph the per-frame local-transformer decode (1 + n_vq

--- a/sglang_omni/models/moss_tts_local/state_pool.py
+++ b/sglang_omni/models/moss_tts_local/state_pool.py
@@ -3,9 +3,7 @@
 
 Next-step-critical per-request decode state (the next frame's feedback
 embedding and the request-static sampling parameters/seed) lives in stable,
-process-lifetime GPU buffers indexed by a per-request row, replacing the
-request-local Python objects (``pending_feedback_queue``, ``_param_cache``)
-that the previous design carried on each scheduler request. Output-only frame
+process-lifetime GPU buffers indexed by a per-request row. Output-only frame
 collection moves to a per-step :class:`MossTTSLocalDecodeJournal`.
 
 The layout mirrors the Higgs ``HiggsBatchedSamplerState`` row pool and the
@@ -72,6 +70,7 @@ class MossTTSLocalDecodeStatePool:
         self.seeds = torch.zeros(self.num_rows, device=self.device, dtype=torch.int64)
 
         self._rid_to_row: dict[str, int] = {}
+        self._params_written_rids: set[str] = set()
         # Real rows 0..P-2 are assignable; the padding row stays out of the
         # free list so it is never handed to a request.
         self._free_rows: list[int] = list(range(self.padding_row))
@@ -100,6 +99,7 @@ class MossTTSLocalDecodeStatePool:
         row_idx = self._rid_to_row.pop(rid, None)
         if row_idx is None:
             return
+        self._params_written_rids.discard(rid)
         self.reset_row(row_idx)
         self._free_rows.append(row_idx)
 

--- a/sglang_omni/models/moss_tts_local/state_pool.py
+++ b/sglang_omni/models/moss_tts_local/state_pool.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Row-indexed decode-state pool for MOSS-TTS Local (v1.5).
+
+Next-step-critical per-request decode state (the next frame's feedback
+embedding and the request-static sampling parameters/seed) lives in stable,
+process-lifetime GPU buffers indexed by a per-request row, replacing the
+request-local Python objects (``pending_feedback_queue``, ``_param_cache``)
+that the previous design carried on each scheduler request. Output-only frame
+collection moves to a per-step :class:`MossTTSLocalDecodeJournal`.
+
+The layout mirrors the Higgs ``HiggsBatchedSamplerState`` row pool and the
+Delay-path ``MossDecodeStatePool`` (#719): ``P = max_running_requests + 1``
+rows, with the last row (``padding_row = P - 1``) reserved — never acquired,
+never request-owned — so a future CUDA-graph that must route non-real/done
+rows somewhere has a stable target (#736). The buffer addresses are fixed for
+the process lifetime; adding a field is ABI-additive.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+
+class MossTTSLocalDecodeStatePool:
+    """Row-indexed pool of next-step-critical decode state.
+
+    Sizing and placement are derived from ``model._decode_input_embedding``
+    (itself sized at runtime from ``max_running_requests``) so the pool tracks
+    the configured concurrency cap without any literal row count.
+    """
+
+    def __init__(self, model: Any) -> None:
+        self.model = model
+        weight = model._decode_input_embedding.weight
+        # P = max_running_requests + 1; the +1 is the reserved padding row.
+        self.num_rows = int(weight.shape[0]) + 1
+        self.padding_row = self.num_rows - 1
+        self.hidden_size = int(weight.shape[1])
+        self.device = weight.device
+        self.dtype = weight.dtype
+
+        # Feedback embedding for the next decode step (one row per request);
+        # bf16 to match the staging table dtype so before_decode's gather is a
+        # plain copy and the future zero-copy aliasing (#736) is a drop-in.
+        self.feedback_embeds = torch.zeros(
+            self.num_rows,
+            self.hidden_size,
+            device=self.device,
+            dtype=self.dtype,
+        )
+        # Request-static sampling parameters / seed (written once at acquire).
+        self.text_temp = torch.zeros(
+            self.num_rows, device=self.device, dtype=torch.float32
+        )
+        self.text_top_p = torch.zeros(
+            self.num_rows, device=self.device, dtype=torch.float32
+        )
+        self.audio_temp = torch.zeros(
+            self.num_rows, device=self.device, dtype=torch.float32
+        )
+        self.audio_top_p = torch.zeros(
+            self.num_rows, device=self.device, dtype=torch.float32
+        )
+        self.text_top_k = torch.zeros(
+            self.num_rows, device=self.device, dtype=torch.int64
+        )
+        self.audio_top_k = torch.zeros(
+            self.num_rows, device=self.device, dtype=torch.int64
+        )
+        self.seeds = torch.zeros(self.num_rows, device=self.device, dtype=torch.int64)
+
+        self._rid_to_row: dict[str, int] = {}
+        # Real rows 0..P-2 are assignable; the padding row stays out of the
+        # free list so it is never handed to a request.
+        self._free_rows: list[int] = list(range(self.padding_row))
+
+    def acquire_row(self, rid: str) -> int:
+        """Assign (or return the existing) row for ``rid``.
+
+        Idempotent by rid: a request that already holds a row keeps it (the
+        first-collect call site invokes this defensively every step). Raises
+        ``RuntimeError`` when the pool is exhausted.
+        """
+        existing = self._rid_to_row.get(rid)
+        if existing is not None:
+            return existing
+        if not self._free_rows:
+            raise RuntimeError(
+                "MOSS-TTS Local decode-state pool exhausted "
+                f"({self.padding_row} rows, all held); raise max_running_requests"
+            )
+        row_idx = self._free_rows.pop()
+        self._rid_to_row[rid] = row_idx
+        return row_idx
+
+    def release_row(self, rid: str) -> None:
+        """Free ``rid``'s row and reset it. No-op if ``rid`` holds no row."""
+        row_idx = self._rid_to_row.pop(rid, None)
+        if row_idx is None:
+            return
+        self.reset_row(row_idx)
+        self._free_rows.append(row_idx)
+
+    def reset_row(self, row_idx: int) -> None:
+        """Zero every field of ``row_idx`` (clears stranded feedback/params)."""
+        self.feedback_embeds[row_idx].zero_()
+        self.text_temp[row_idx] = 0.0
+        self.text_top_p[row_idx] = 0.0
+        self.audio_temp[row_idx] = 0.0
+        self.audio_top_p[row_idx] = 0.0
+        self.text_top_k[row_idx] = 0
+        self.audio_top_k[row_idx] = 0
+        self.seeds[row_idx] = 0
+
+    def write_params(self, row_idx: int, data: Any) -> None:
+        """Write the seven request-static sampling fields into ``row_idx``.
+
+        Routed through the same ``float(...)``/``int(...)`` host casts the
+        previous per-composition ``_param_cache`` used so the rounded values
+        are bit-identical.
+        """
+        self.text_temp[row_idx] = float(data.text_temperature)
+        self.text_top_p[row_idx] = float(data.text_top_p)
+        self.audio_temp[row_idx] = float(data.audio_temperature)
+        self.audio_top_p[row_idx] = float(data.audio_top_p)
+        self.text_top_k[row_idx] = int(data.text_top_k)
+        self.audio_top_k[row_idx] = int(data.audio_top_k)
+        self.seeds[row_idx] = int(data.sampling_seed)
+
+    def row_for(self, rid: str) -> int | None:
+        """Return ``rid``'s row, or ``None`` if it holds no row."""
+        return self._rid_to_row.get(rid)
+
+
+class MossTTSLocalDecodeJournal:
+    """Step-private record carrying the frame this step produced to collection.
+
+    Pool rows are overwritten by the same request every step, so they cannot
+    carry the "consume one step later" output data. The journal pins the
+    per-step ``rows`` tensor together with the request ids (for an alignment
+    assertion at apply time) and the pool rows the step touched; it is attached
+    to the step's ``batch_result`` so the async-decode lookahead window (PR-B)
+    keeps it alive until resolve.
+    """
+
+    def __init__(
+        self,
+        rids: list[str],
+        pool_rows: list[int],
+        rows: torch.Tensor,
+    ) -> None:
+        self.rids = rids
+        self.pool_rows = pool_rows
+        self.rows = rows

--- a/sglang_omni/models/moss_tts_local/state_pool.py
+++ b/sglang_omni/models/moss_tts_local/state_pool.py
@@ -129,6 +129,16 @@ class MossTTSLocalDecodeStatePool:
         self.audio_top_k[row_idx] = int(data.audio_top_k)
         self.seeds[row_idx] = int(data.sampling_seed)
 
+    def ensure_params(self, row_idx: int, rid: str, data: Any) -> None:
+        """Write request-static params once for the current row acquisition."""
+        if rid not in self._params_written_rids:
+            self.write_params(row_idx, data)
+            self._params_written_rids.add(rid)
+
+    def invalidate_params(self, rid: str) -> None:
+        """Force params to be rewritten on the next ``ensure_params`` call."""
+        self._params_written_rids.discard(rid)
+
     def row_for(self, rid: str) -> int | None:
         """Return ``rid``'s row, or ``None`` if it holds no row."""
         return self._rid_to_row.get(rid)

--- a/tests/README.md
+++ b/tests/README.md
@@ -313,6 +313,12 @@ that happened to contain an older version of the test.
   - preprocessing handoff and abort cleanup behavior
   - delay-pattern runner, codec splitting, and seeded sampling contracts.
 
+- `unit_test/moss_tts_local/`: MOSS-TTS Local unit tests:
+  - pipeline config, request builders, and scheduler adapter contracts
+  - decode-state pool acquisition, cleanup, and resume/retraction lifecycle
+  - chunked prefill feedback/journal suppression and postprocess alignment checks
+  - synchronous frame-decode parity harness and S0 gate coverage.
+
 - `unit_test/router/`: SGLang-Omni Router unit tests:
   - router CLI/config behavior
   - worker metadata and health-state contracts

--- a/tests/unit_test/moss_tts_local/test_parity_harness.py
+++ b/tests/unit_test/moss_tts_local/test_parity_harness.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fixed-seed sync parity harness: gate scaffold for PR-A bit-identity.
+
+CPU tests exercise the comparison fixtures and the apply-result data flow.
+The GPU test (skipped without CUDA) verifies the frame-decode graph is
+deterministic and serves as the S0 gate baseline; it must not be modified
+after initial commit.
+"""
+from __future__ import annotations
+
+import torch
+import pytest
+
+from sglang_omni.models.moss_tts_local.request_builders import (
+    MossTTSLocalSGLangRequestData,
+    apply_sglang_moss_tts_local_result,
+)
+from sglang_omni.proto import OmniRequest, StagePayload
+
+_N_VQ = 12
+_AUDIO_END_ID = 151670  # audio_end_token_id default (payload_types.py)
+
+
+def _payload(request_id: str = "r0") -> StagePayload:
+    return StagePayload(
+        request_id=request_id,
+        request=OmniRequest(inputs={"text": "hello"}, params={}, metadata={}),
+        data={},
+    )
+
+
+def _data_with_rows(n_frames: int, seed: int) -> MossTTSLocalSGLangRequestData:
+    """Build request data with fixed-seed deterministic output_rows."""
+    torch.manual_seed(seed)
+    data = MossTTSLocalSGLangRequestData(
+        input_ids=torch.zeros(4, dtype=torch.long),
+        max_new_tokens=64,
+        temperature=0.0,
+        output_ids=[],
+        prompt_rows=torch.full((4, _N_VQ + 1), 1024, dtype=torch.long),
+        stage_payload=_payload(),
+        engine_start_s=0.0,
+    )
+    for _ in range(n_frames):
+        row = torch.cat([
+            torch.tensor([1000]),  # non-stop slot
+            torch.randint(0, 1024, (_N_VQ,)),
+        ])
+        data.output_rows.append(row)
+    return data
+
+
+def _audio_codes(data: MossTTSLocalSGLangRequestData) -> torch.Tensor:
+    result = apply_sglang_moss_tts_local_result(data.stage_payload, data)
+    return torch.as_tensor(result.data["audio_codes"])
+
+
+# ---------------------------------------------------------------------------
+# CPU parity fixture tests
+# ---------------------------------------------------------------------------
+
+
+def test_parity_identical_output_rows_give_identical_audio_codes():
+    """Same seed → identical output_rows → bit-identical audio_codes.
+
+    Core harness assertion: PR-A must not break this.
+    """
+    codes_a = _audio_codes(_data_with_rows(5, seed=42))
+    codes_b = _audio_codes(_data_with_rows(5, seed=42))
+    assert torch.equal(codes_a, codes_b)
+
+
+def test_parity_different_seeds_give_different_audio_codes():
+    """Different seeds → different rows → different audio_codes.
+
+    Validates the harness is sensitive enough to detect divergence.
+    """
+    codes_a = _audio_codes(_data_with_rows(5, seed=1))
+    codes_b = _audio_codes(_data_with_rows(5, seed=2))
+    assert not torch.equal(codes_a, codes_b), "harness must detect divergence"
+
+
+def test_parity_empty_output_rows_produce_empty_audio_codes():
+    data = MossTTSLocalSGLangRequestData(
+        input_ids=torch.zeros(4, dtype=torch.long),
+        max_new_tokens=64,
+        temperature=0.0,
+        output_ids=[],
+        prompt_rows=torch.full((4, _N_VQ + 1), 1024, dtype=torch.long),
+        stage_payload=_payload(),
+        engine_start_s=0.0,
+    )
+    codes = _audio_codes(data)
+    assert codes.shape == (0, _N_VQ)
+
+
+# ---------------------------------------------------------------------------
+# GPU gate scaffold (S0 baseline — do NOT modify after initial commit)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_s0_graph_replay_is_deterministic():
+    """Two CUDA-graph replays with identical inputs must produce bit-identical outputs.
+
+    This test pins the S0 gate baseline for PR-A. It exercises the same
+    decode-frame kernel as the production v1.5 pipeline (MossTTSLocalTransformer
+    + sample_seeded_branchless loop). Do NOT modify after initial commit.
+    """
+    from sglang_omni.models.moss_tts_local.local_transformer import (
+        MossTTSLocalTransformer,
+        sample_seeded_branchless,
+    )
+
+    device = torch.device("cuda")
+    torch.manual_seed(0)
+    module = MossTTSLocalTransformer(
+        hidden_size=64,
+        num_heads=4,
+        inner_size=96,
+        num_layers=1,
+        max_positions=_N_VQ + 1,
+        rope_base=1_000_000.0,
+    ).to(device=device, dtype=torch.bfloat16)
+    tables = [
+        torch.randn(64, 64, device=device, dtype=torch.bfloat16)
+        for _ in range(_N_VQ)
+    ]
+
+    def decode_frame(
+        hidden: torch.Tensor,
+        seeds: torch.Tensor,
+        base: torch.Tensor,
+    ) -> torch.Tensor:
+        current = module.step(hidden, 0)
+        codes = []
+        for channel in range(_N_VQ):
+            logits = (current.float() @ tables[channel].float().T)[:, :32]
+            code = sample_seeded_branchless(
+                logits,
+                temperature=torch.full((hidden.shape[0],), 1.0, device=device),
+                top_p=torch.full((hidden.shape[0],), 1.0, device=device),
+                top_k=torch.full(
+                    (hidden.shape[0],), 32, device=device, dtype=torch.long
+                ),
+                seeds=seeds,
+                positions=base + channel + 1,
+            )
+            codes.append(code)
+            if channel + 1 < _N_VQ:
+                embed = torch.nn.functional.embedding(code, tables[channel][:32])
+                current = module.step(embed.to(torch.bfloat16), channel + 1)
+        return torch.stack(codes, dim=-1)
+
+    batch = 4
+    static_hidden = torch.zeros(batch, 64, device=device, dtype=torch.bfloat16)
+    static_seeds = torch.zeros(batch, device=device, dtype=torch.long)
+    static_base = torch.zeros(batch, device=device, dtype=torch.long)
+
+    # Warmup two passes before capture (required for CUDA graph stability).
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(2):
+            decode_frame(static_hidden, static_seeds, static_base)
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graphed_codes = decode_frame(static_hidden, static_seeds, static_base)
+
+    hidden = torch.randn(batch, 64, device=device, dtype=torch.bfloat16)
+    seeds = torch.arange(batch, device=device, dtype=torch.long) * 1_234_567
+    base = torch.full((batch,), 26, device=device, dtype=torch.long)
+
+    static_hidden.copy_(hidden)
+    static_seeds.copy_(seeds)
+    static_base.copy_(base)
+    graph.replay()
+    run1 = graphed_codes.clone()
+
+    static_hidden.copy_(hidden)
+    static_seeds.copy_(seeds)
+    static_base.copy_(base)
+    graph.replay()
+    run2 = graphed_codes.clone()
+
+    assert torch.equal(run1, run2), (
+        "CUDA graph replay with identical inputs must be bit-identical; "
+        "any divergence indicates non-determinism in the decode kernel"
+    )

--- a/tests/unit_test/moss_tts_local/test_parity_harness.py
+++ b/tests/unit_test/moss_tts_local/test_parity_harness.py
@@ -6,10 +6,11 @@ The GPU test (skipped without CUDA) verifies the frame-decode graph is
 deterministic and serves as the S0 gate baseline; it must not be modified
 after initial commit.
 """
+
 from __future__ import annotations
 
-import torch
 import pytest
+import torch
 
 from sglang_omni.models.moss_tts_local.request_builders import (
     MossTTSLocalSGLangRequestData,
@@ -18,7 +19,6 @@ from sglang_omni.models.moss_tts_local.request_builders import (
 from sglang_omni.proto import OmniRequest, StagePayload
 
 _N_VQ = 12
-_AUDIO_END_ID = 151670  # audio_end_token_id default (payload_types.py)
 
 
 def _payload(request_id: str = "r0") -> StagePayload:
@@ -42,10 +42,12 @@ def _data_with_rows(n_frames: int, seed: int) -> MossTTSLocalSGLangRequestData:
         engine_start_s=0.0,
     )
     for _ in range(n_frames):
-        row = torch.cat([
-            torch.tensor([1000]),  # non-stop slot
-            torch.randint(0, 1024, (_N_VQ,)),
-        ])
+        row = torch.cat(
+            [
+                torch.tensor([1000]),  # non-stop slot
+                torch.randint(0, 1024, (_N_VQ,)),
+            ]
+        )
         data.output_rows.append(row)
     return data
 
@@ -123,8 +125,7 @@ def test_s0_graph_replay_is_deterministic():
         rope_base=1_000_000.0,
     ).to(device=device, dtype=torch.bfloat16)
     tables = [
-        torch.randn(64, 64, device=device, dtype=torch.bfloat16)
-        for _ in range(_N_VQ)
+        torch.randn(64, 64, device=device, dtype=torch.bfloat16) for _ in range(_N_VQ)
     ]
 
     def decode_frame(

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -194,6 +194,105 @@ def test_pipeline_stage_wiring():
     assert colocated_stages["vocoder"].factory_args["device"] == "cuda:0"
 
 
+def test_tts_engine_forward_sample_flag_and_graph_init(monkeypatch):
+    import sys
+    from types import ModuleType, SimpleNamespace
+
+    from sglang_omni.models.moss_tts_local import stages
+
+    build_kwargs = []
+    infrastructure_saw_graph_disabled = []
+    init_graph_calls = []
+    frame_graph_calls = []
+    models = []
+
+    class _FakeSGLangRunner:
+        def __init__(self, model):
+            self.model = model
+
+        def init_device_graphs(self):
+            init_graph_calls.append(True)
+
+    class _FakeWorker:
+        gpu_id = 0
+
+        def __init__(self):
+            model = SimpleNamespace(
+                forward_sample_in_forward=None,
+                init_frame_decode_graphs=lambda buckets: frame_graph_calls.append(
+                    list(buckets)
+                ),
+            )
+            models.append(model)
+            self.model_runner = _FakeSGLangRunner(model)
+
+    def fake_build_sglang_server_args(model_path, context_length, **kwargs):
+        del model_path, context_length
+        build_kwargs.append(dict(kwargs))
+        return SimpleNamespace(disable_cuda_graph=kwargs["disable_cuda_graph"])
+
+    def fake_create_sglang_infrastructure(server_args, gpu_id, **kwargs):
+        del kwargs
+        assert gpu_id == 0
+        infrastructure_saw_graph_disabled.append(bool(server_args.disable_cuda_graph))
+        return (
+            _FakeWorker(),
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            SimpleNamespace(),
+        )
+
+    class _FakeScheduler:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    fake_bootstrap = ModuleType("sglang_omni.scheduling.bootstrap")
+    fake_bootstrap.create_sglang_infrastructure = fake_create_sglang_infrastructure
+    fake_backend = ModuleType("sglang_omni.scheduling.sglang_backend")
+    fake_backend.build_sglang_server_args = fake_build_sglang_server_args
+    fake_backend.SGLangOutputProcessor = lambda **kwargs: SimpleNamespace(**kwargs)
+    fake_scheduler = ModuleType("sglang_omni.scheduling.omni_scheduler")
+    fake_scheduler.OmniScheduler = _FakeScheduler
+    fake_runner = ModuleType("sglang_omni.models.moss_tts_local.model_runner")
+    fake_runner.MossTTSLocalModelRunner = lambda *args, **kwargs: SimpleNamespace(
+        args=args, kwargs=kwargs
+    )
+
+    monkeypatch.setitem(sys.modules, "sglang_omni.scheduling.bootstrap", fake_bootstrap)
+    monkeypatch.setitem(
+        sys.modules, "sglang_omni.scheduling.sglang_backend", fake_backend
+    )
+    monkeypatch.setitem(
+        sys.modules, "sglang_omni.scheduling.omni_scheduler", fake_scheduler
+    )
+    monkeypatch.setitem(
+        sys.modules, "sglang_omni.models.moss_tts_local.model_runner", fake_runner
+    )
+    monkeypatch.setattr(stages, "_resolve_checkpoint", lambda model_path: model_path)
+    monkeypatch.setattr(
+        stages,
+        "make_moss_tts_local_scheduler_adapters",
+        lambda **kwargs: (object(), object()),
+    )
+
+    stages.create_sglang_tts_engine_executor("model", device="cuda:0")
+    stages.create_sglang_tts_engine_executor(
+        "model", device="cuda:0", forward_sample_in_forward=True
+    )
+
+    assert models[0].forward_sample_in_forward is False
+    assert models[1].forward_sample_in_forward is True
+    assert all("forward_sample_in_forward" not in kwargs for kwargs in build_kwargs)
+    assert infrastructure_saw_graph_disabled == [True, True]
+    assert len(init_graph_calls) == 2
+    assert frame_graph_calls == [[1, 2, 4, 8, 16], [1, 2, 4, 8, 16]]
+    assert models[1]._moss_local_decode_cuda_graph_bs == [1, 2, 4, 8, 16]
+    assert models[1]._moss_local_decode_graph_padding is True
+
+
 def test_special_token_defaults_match_v15_checkpoint():
     defaults = dict(moss_tts_local_special_token_defaults())
     assert defaults["audio_start_token_id"] == 151669

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -643,3 +643,59 @@ def test_encode_audio_stereo_wav_and_mono_fallback():
         np.ones(64, dtype=np.float32) * 0.1, response_format="wav", sample_rate=48000
     )
     assert struct.unpack("<H", mono_blob[22:24])[0] == 1
+
+
+# ---------------------------------------------------------------------------
+# is_chunked guard in post_process_outputs (bugfix)
+# ---------------------------------------------------------------------------
+
+
+def test_post_process_outputs_skips_chunked_rows():
+    """Chunked-prefill rows must not be appended to output_rows."""
+    pytest.importorskip("sglang")
+    import types
+
+    from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
+
+    batch_size = 2
+
+    # Minimal model stub providing only what post_process_outputs needs.
+    model_stub = types.SimpleNamespace(
+        config=types.SimpleNamespace(audio_end_token_id=151670)
+    )
+    runner = MossTTSLocalModelRunner.__new__(MossTTSLocalModelRunner)
+    runner.model = model_stub
+
+    # Two rows: row 0 is chunked (mid-prefill), row 1 is normal.
+    rows = torch.arange(batch_size * (N_VQ + 1), dtype=torch.long).reshape(
+        batch_size, N_VQ + 1
+    )
+    embeds = torch.zeros(batch_size, 64, dtype=torch.float32)
+    runner._pending_rows = rows
+    runner._pending_embeds = embeds
+
+    # Build minimal sched_req stubs.
+    def _req(is_chunked):
+        return types.SimpleNamespace(is_chunked=is_chunked)
+
+    def _sched_req(rid, is_chunked):
+        data = types.SimpleNamespace(
+            req=_req(is_chunked),
+            output_rows=[],
+            pending_feedback_queue=[],
+        )
+        return types.SimpleNamespace(request_id=rid, data=data)
+
+    req_a = _sched_req("r0", is_chunked=1)  # mid-prefill chunk, must be skipped
+    req_b = _sched_req("r1", is_chunked=0)  # normal decode row
+
+    sched_output = types.SimpleNamespace(requests=[req_a, req_b])
+    outputs = {
+        "r0": types.SimpleNamespace(data=1000),  # non-end token
+        "r1": types.SimpleNamespace(data=1001),  # non-end token
+    }
+
+    runner.post_process_outputs(None, sched_output, outputs)
+
+    assert req_a.data.output_rows == [], "chunked row must not be appended"
+    assert len(req_b.data.output_rows) == 1, "normal row must be appended"

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -656,9 +656,7 @@ def test_post_process_outputs_skips_chunked_rows():
     import types
 
     from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
-    from sglang_omni.models.moss_tts_local.state_pool import (
-        MossTTSLocalDecodeJournal,
-    )
+    from sglang_omni.models.moss_tts_local.state_pool import MossTTSLocalDecodeJournal
 
     batch_size = 2
 
@@ -691,10 +689,11 @@ def test_post_process_outputs_skips_chunked_rows():
         "r1": types.SimpleNamespace(data=1001),  # non-end token
     }
 
-    # Output collection goes solely through the per-step journal.
+    # Output collection goes solely through the per-step journal. Chunked rows
+    # are not journaled because no frame should be emitted or fed back.
     result = types.SimpleNamespace(
         moss_journal=MossTTSLocalDecodeJournal(
-            rids=["r0", "r1"], pool_rows=[0, 1], rows=rows
+            rids=["r1"], pool_rows=[1], rows=rows[1:]
         )
     )
     runner.post_process_outputs(result, sched_output, outputs)

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -656,6 +656,9 @@ def test_post_process_outputs_skips_chunked_rows():
     import types
 
     from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
+    from sglang_omni.models.moss_tts_local.state_pool import (
+        MossTTSLocalDecodeJournal,
+    )
 
     batch_size = 2
 
@@ -670,20 +673,13 @@ def test_post_process_outputs_skips_chunked_rows():
     rows = torch.arange(batch_size * (N_VQ + 1), dtype=torch.long).reshape(
         batch_size, N_VQ + 1
     )
-    embeds = torch.zeros(batch_size, 64, dtype=torch.float32)
-    runner._pending_rows = rows
-    runner._pending_embeds = embeds
 
     # Build minimal sched_req stubs.
     def _req(is_chunked):
         return types.SimpleNamespace(is_chunked=is_chunked)
 
     def _sched_req(rid, is_chunked):
-        data = types.SimpleNamespace(
-            req=_req(is_chunked),
-            output_rows=[],
-            pending_feedback_queue=[],
-        )
+        data = types.SimpleNamespace(req=_req(is_chunked), output_rows=[])
         return types.SimpleNamespace(request_id=rid, data=data)
 
     req_a = _sched_req("r0", is_chunked=1)  # mid-prefill chunk, must be skipped
@@ -695,7 +691,13 @@ def test_post_process_outputs_skips_chunked_rows():
         "r1": types.SimpleNamespace(data=1001),  # non-end token
     }
 
-    runner.post_process_outputs(None, sched_output, outputs)
+    # Output collection goes solely through the per-step journal.
+    result = types.SimpleNamespace(
+        moss_journal=MossTTSLocalDecodeJournal(
+            rids=["r0", "r1"], pool_rows=[0, 1], rows=rows
+        )
+    )
+    runner.post_process_outputs(result, sched_output, outputs)
 
     assert req_a.data.output_rows == [], "chunked row must not be appended"
     assert len(req_b.data.output_rows) == 1, "normal row must be appended"

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -284,3 +284,70 @@ def test_double_collect_overwrites_feedback():
         torch.full((hidden_size,), 2, dtype=torch.bfloat16),
     )
 
+
+def test_journal_rid_assertion_fires():
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = SimpleNamespace(config=SimpleNamespace(audio_end_token_id=1001))
+    journal = MossTTSLocalDecodeJournal(
+        rids=["other"],
+        pool_rows=[0],
+        rows=torch.zeros((1, 13), dtype=torch.long),
+    )
+    result = SimpleNamespace(moss_journal=journal)
+    sched_req = SimpleNamespace(
+        request_id="rid",
+        data=SimpleNamespace(req=None, output_rows=[]),
+    )
+    scheduler_output = SimpleNamespace(requests=[sched_req])
+    outputs = {"rid": SimpleNamespace(data=1000)}
+
+    try:
+        runner.post_process_outputs(result, scheduler_output, outputs)
+    except AssertionError as exc:
+        assert "journal/batch alignment broken" in str(exc)
+    else:
+        raise AssertionError("expected journal rid mismatch to assert")
+
+
+def test_stop_row_not_appended_via_journal():
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = SimpleNamespace(config=SimpleNamespace(audio_end_token_id=1001))
+    row = torch.arange(13, dtype=torch.long)
+    result = SimpleNamespace(
+        moss_journal=MossTTSLocalDecodeJournal(
+            rids=["rid"],
+            pool_rows=[0],
+            rows=row.reshape(1, 13),
+        )
+    )
+    data = SimpleNamespace(req=None, output_rows=[])
+    sched_req = SimpleNamespace(request_id="rid", data=data)
+    scheduler_output = SimpleNamespace(requests=[sched_req])
+    outputs = {"rid": SimpleNamespace(data=1001)}
+
+    runner.post_process_outputs(result, scheduler_output, outputs)
+
+    assert data.output_rows == []
+
+
+def test_journal_rows_appended_to_output_rows():
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = SimpleNamespace(config=SimpleNamespace(audio_end_token_id=1001))
+    row = torch.arange(13, dtype=torch.long)
+    result = SimpleNamespace(
+        moss_journal=MossTTSLocalDecodeJournal(
+            rids=["rid"],
+            pool_rows=[0],
+            rows=row.reshape(1, 13),
+        )
+    )
+    data = SimpleNamespace(req=None, output_rows=[])
+    sched_req = SimpleNamespace(request_id="rid", data=data)
+    scheduler_output = SimpleNamespace(requests=[sched_req])
+    outputs = {"rid": SimpleNamespace(data=1000)}
+
+    runner.post_process_outputs(result, scheduler_output, outputs)
+
+    assert len(data.output_rows) == 1
+    assert torch.equal(data.output_rows[0], row)
+

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 
 import torch
 
+from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
 from sglang_omni.models.moss_tts_local.state_pool import (
     MossTTSLocalDecodeJournal,
     MossTTSLocalDecodeStatePool,
@@ -169,3 +170,117 @@ def test_journal_holds_fields():
     assert journal.rids == ["a", "b"]
     assert journal.pool_rows == [0, 1]
     assert torch.equal(journal.rows, rows)
+
+
+def test_feedback_gather_equals_old_popleft():
+    model = _model(max_running_requests=4)
+    pool = MossTTSLocalDecodeStatePool(model)
+    model._state_pool = pool
+    rows = [pool.acquire_row("a"), pool.acquire_row("b")]
+    expected = torch.stack(
+        [
+            torch.arange(_HIDDEN, dtype=torch.bfloat16),
+            torch.arange(_HIDDEN, dtype=torch.bfloat16) + 10,
+        ],
+        dim=0,
+    )
+    pool.feedback_embeds[torch.tensor(rows, dtype=torch.long)] = expected
+
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    forward_batch = SimpleNamespace(input_ids=torch.full((2,), -1, dtype=torch.long))
+    requests = [
+        SimpleNamespace(request_id="a", data=SimpleNamespace()),
+        SimpleNamespace(request_id="b", data=SimpleNamespace()),
+    ]
+
+    runner._write_decode_input_embedding(forward_batch, requests)
+
+    assert torch.equal(model._decode_input_embedding.weight[:2], expected)
+    assert torch.equal(forward_batch.input_ids, torch.tensor([0, 1]))
+
+
+def test_fresh_row_zeros_feedback():
+    model = _model(max_running_requests=2)
+    pool = MossTTSLocalDecodeStatePool(model)
+    model._state_pool = pool
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    forward_batch = SimpleNamespace(input_ids=torch.full((1,), -1, dtype=torch.long))
+    requests = [SimpleNamespace(request_id="fresh", data=SimpleNamespace())]
+
+    runner._write_decode_input_embedding(forward_batch, requests)
+
+    assert torch.equal(
+        model._decode_input_embedding.weight[:1],
+        torch.zeros((1, _HIDDEN), dtype=torch.bfloat16),
+    )
+
+
+def test_double_collect_overwrites_feedback():
+    hidden_size = 4
+    weight = torch.zeros(2, hidden_size, dtype=torch.bfloat16)
+    embedding = SimpleNamespace(weight=weight)
+    model = SimpleNamespace(
+        _decode_input_embedding=embedding,
+        _state_pool=None,
+        config=SimpleNamespace(
+            n_vq=12,
+            audio_assistant_slot_token_id=1000,
+            audio_end_token_id=1001,
+        ),
+        frame_graph_max_bs=0,
+        device=torch.device("cpu"),
+    )
+    pool = MossTTSLocalDecodeStatePool(model)
+    model._state_pool = pool
+    model.acquire_row = pool.acquire_row
+    embeds = [
+        torch.full((1, hidden_size), 1, dtype=torch.bfloat16),
+        torch.full((1, hidden_size), 2, dtype=torch.bfloat16),
+    ]
+
+    def decode_frame(hidden_states, *, sample_text, sample_audio):
+        del hidden_states, sample_text, sample_audio
+        return (
+            torch.zeros(1, dtype=torch.long),
+            torch.full((1, 12), 7, dtype=torch.long),
+        )
+
+    def prepare_multi_modal_inputs(rows):
+        del rows
+        return embeds.pop(0)
+
+    model.decode_frame = decode_frame
+    model._prepare_multi_modal_inputs = prepare_multi_modal_inputs
+
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    data = SimpleNamespace(
+        text_temperature=1.0,
+        text_top_p=1.0,
+        text_top_k=50,
+        audio_temperature=1.0,
+        audio_top_p=1.0,
+        audio_top_k=50,
+        sampling_seed=0,
+        generation_steps=0,
+        audio_repetition_penalty=1.0,
+        output_rows=[],
+    )
+    request = SimpleNamespace(request_id="rid", data=data)
+
+    for _ in range(2):
+        result = SimpleNamespace(
+            logits_output=SimpleNamespace(hidden_states=torch.zeros(1, hidden_size))
+        )
+        schedule_batch = SimpleNamespace()
+        runner._collect_frame(result, None, schedule_batch, [request])
+
+    row = pool.row_for("rid")
+    assert row is not None
+    assert torch.equal(
+        pool.feedback_embeds[row],
+        torch.full((hidden_size,), 2, dtype=torch.bfloat16),
+    )
+

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -351,3 +351,50 @@ def test_journal_rows_appended_to_output_rows():
     assert len(data.output_rows) == 1
     assert torch.equal(data.output_rows[0], row)
 
+
+def test_param_gather_matches_old_cache():
+    pool = MossTTSLocalDecodeStatePool(_model(max_running_requests=2))
+    data = _params(seed=12345)
+    row = pool.acquire_row("rid")
+    pool.write_params(row, data)
+    row_t = torch.tensor([row], dtype=torch.long, device=pool.device)
+
+    params = {
+        "text_temp": pool.text_temp[row_t],
+        "text_top_p": pool.text_top_p[row_t],
+        "text_top_k": pool.text_top_k[row_t],
+        "audio_temp": pool.audio_temp[row_t],
+        "audio_top_p": pool.audio_top_p[row_t],
+        "audio_top_k": pool.audio_top_k[row_t],
+        "seeds": pool.seeds[row_t],
+    }
+
+    assert torch.equal(
+        params["text_temp"],
+        torch.tensor([float(data.text_temperature)], dtype=torch.float32),
+    )
+    assert torch.equal(
+        params["text_top_p"],
+        torch.tensor([float(data.text_top_p)], dtype=torch.float32),
+    )
+    assert torch.equal(
+        params["text_top_k"],
+        torch.tensor([int(data.text_top_k)], dtype=torch.long),
+    )
+    assert torch.equal(
+        params["audio_temp"],
+        torch.tensor([float(data.audio_temperature)], dtype=torch.float32),
+    )
+    assert torch.equal(
+        params["audio_top_p"],
+        torch.tensor([float(data.audio_top_p)], dtype=torch.float32),
+    )
+    assert torch.equal(
+        params["audio_top_k"],
+        torch.tensor([int(data.audio_top_k)], dtype=torch.long),
+    )
+    assert torch.equal(
+        params["seeds"],
+        torch.tensor([int(data.sampling_seed)], dtype=torch.long),
+    )
+

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -12,10 +12,15 @@ from types import SimpleNamespace
 import torch
 
 from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
+from sglang_omni.models.moss_tts_local.request_builders import (
+    MossTTSLocalSGLangRequestData,
+    make_moss_tts_local_scheduler_adapters,
+)
 from sglang_omni.models.moss_tts_local.state_pool import (
     MossTTSLocalDecodeJournal,
     MossTTSLocalDecodeStatePool,
 )
+from sglang_omni.proto import OmniRequest, StagePayload
 
 _HIDDEN = 8
 
@@ -155,6 +160,18 @@ def test_write_params_does_not_touch_other_rows():
     pool.write_params(row_a, _params(seed=1))
     assert pool.seeds[row_b] == 0
     assert pool.text_temp[row_b] == 0.0
+
+
+def test_ensure_params_writes_once_until_invalidated():
+    pool = MossTTSLocalDecodeStatePool(_model())
+    row = pool.acquire_row("a")
+    pool.ensure_params(row, "a", _params(seed=1))
+    pool.ensure_params(row, "a", _params(seed=2))
+    assert int(pool.seeds[row]) == 1
+
+    pool.invalidate_params("a")
+    pool.ensure_params(row, "a", _params(seed=2))
+    assert int(pool.seeds[row]) == 2
 
 
 def test_row_for_returns_none_when_unheld():
@@ -301,8 +318,7 @@ def test_resume_reprefill_overwrites_stranded_feedback():
     model._state_pool = pool
 
     row = pool.acquire_row("a")
-    pool.write_params(row, _params(seed=1))
-    pool._params_written_rids.add("a")
+    pool.ensure_params(row, "a", _params(seed=1))
     # Feedback stranded by the retraction (must be wiped by the resume).
     pool.feedback_embeds[row].fill_(5.0)
 
@@ -325,7 +341,90 @@ def test_resume_reprefill_overwrites_stranded_feedback():
     runner._build_prefill_input_embeds(forward_batch, [sched_req])
 
     assert torch.all(pool.feedback_embeds[row] == 0), "stranded feedback must be wiped"
-    assert "a" not in pool._params_written_rids, "params must be re-written on resume"
+    pool.ensure_params(row, "a", _params(seed=2))
+    assert int(pool.seeds[row]) == 2, "params must be re-written on resume"
+
+
+def test_collect_frame_skips_chunked_feedback_and_journal():
+    hidden_size = 4
+    weight = torch.zeros(3, hidden_size, dtype=torch.bfloat16)
+    embedding = SimpleNamespace(weight=weight)
+    model = SimpleNamespace(
+        _decode_input_embedding=embedding,
+        _state_pool=None,
+        config=SimpleNamespace(
+            n_vq=12,
+            audio_assistant_slot_token_id=1000,
+            audio_end_token_id=1001,
+        ),
+        frame_graph_max_bs=0,
+        device=torch.device("cpu"),
+    )
+    pool = MossTTSLocalDecodeStatePool(model)
+    model._state_pool = pool
+    model.acquire_row = pool.acquire_row
+
+    def decode_frame(hidden_states, *, sample_text, sample_audio):
+        del hidden_states, sample_text, sample_audio
+        return (
+            torch.zeros(2, dtype=torch.long),
+            torch.full((2, 12), 7, dtype=torch.long),
+        )
+
+    def prepare_multi_modal_inputs(rows):
+        del rows
+        return torch.tensor(
+            [[1, 1, 1, 1], [2, 2, 2, 2]],
+            dtype=torch.bfloat16,
+        )
+
+    model.decode_frame = decode_frame
+    model._prepare_multi_modal_inputs = prepare_multi_modal_inputs
+
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+
+    def data(is_chunked):
+        return SimpleNamespace(
+            req=SimpleNamespace(is_chunked=is_chunked),
+            text_temperature=1.0,
+            text_top_p=1.0,
+            text_top_k=50,
+            audio_temperature=1.0,
+            audio_top_p=1.0,
+            audio_top_k=50,
+            sampling_seed=0,
+            generation_steps=0,
+            audio_repetition_penalty=1.0,
+            output_rows=[],
+        )
+
+    requests = [
+        SimpleNamespace(request_id="chunked", data=data(is_chunked=1)),
+        SimpleNamespace(request_id="normal", data=data(is_chunked=0)),
+    ]
+    result = SimpleNamespace(
+        logits_output=SimpleNamespace(hidden_states=torch.zeros(2, hidden_size))
+    )
+    schedule_batch = SimpleNamespace()
+
+    runner._collect_frame(result, None, schedule_batch, requests)
+
+    chunked_row = pool.row_for("chunked")
+    normal_row = pool.row_for("normal")
+    assert chunked_row is not None
+    assert normal_row is not None
+    assert torch.equal(
+        pool.feedback_embeds[chunked_row],
+        torch.zeros(hidden_size, dtype=torch.bfloat16),
+    )
+    assert torch.equal(
+        pool.feedback_embeds[normal_row],
+        torch.full((hidden_size,), 2, dtype=torch.bfloat16),
+    )
+    assert result.moss_journal.rids == ["normal"]
+    assert result.moss_journal.pool_rows == [normal_row]
+    assert result.moss_journal.rows.shape == (1, 13)
 
 
 def test_journal_rid_assertion_fires():
@@ -350,6 +449,30 @@ def test_journal_rid_assertion_fires():
         assert "journal/batch alignment broken" in str(exc)
     else:
         raise AssertionError("expected journal rid mismatch to raise")
+
+
+def test_journal_length_mismatch_raises_runtime_error():
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = SimpleNamespace(config=SimpleNamespace(audio_end_token_id=1001))
+    journal = MossTTSLocalDecodeJournal(
+        rids=["rid"],
+        pool_rows=[],
+        rows=torch.zeros((1, 13), dtype=torch.long),
+    )
+    result = SimpleNamespace(moss_journal=journal)
+    sched_req = SimpleNamespace(
+        request_id="rid",
+        data=SimpleNamespace(req=None, output_rows=[]),
+    )
+    scheduler_output = SimpleNamespace(requests=[sched_req])
+    outputs = {"rid": SimpleNamespace(data=1000)}
+
+    try:
+        runner.post_process_outputs(result, scheduler_output, outputs)
+    except RuntimeError as exc:
+        assert "journal length mismatch" in str(exc)
+    else:
+        raise AssertionError("expected journal length mismatch to raise")
 
 
 def test_stop_row_not_appended_via_journal():
@@ -441,3 +564,34 @@ def test_param_gather_matches_old_cache():
         torch.tensor([int(data.sampling_seed)], dtype=torch.long),
     )
 
+
+def test_result_adapter_releases_row_when_apply_raises():
+    reset_calls = []
+    model = SimpleNamespace(reset_request=lambda rid: reset_calls.append(rid))
+    _, result_adapter = make_moss_tts_local_scheduler_adapters(model=model)
+    payload = StagePayload(
+        request_id="rid",
+        request=OmniRequest(inputs={}, params={}, metadata={}),
+        data={},
+    )
+    data = MossTTSLocalSGLangRequestData(
+        input_ids=torch.zeros(1, dtype=torch.long),
+        max_new_tokens=1,
+        temperature=0.0,
+        output_ids=[],
+        prompt_rows=torch.zeros((1, 13), dtype=torch.long),
+        output_rows=[
+            torch.zeros(13, dtype=torch.long),
+            torch.zeros(12, dtype=torch.long),
+        ],
+        stage_payload=payload,
+    )
+
+    try:
+        result_adapter(data)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("expected malformed output_rows to raise")
+
+    assert reset_calls == ["rid"]

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the MOSS-TTS Local decode-state pool (PR-A c3).
+
+CPU-only: the pool derives its sizing/placement from a fake model exposing a
+``_decode_input_embedding.weight`` tensor, so no CUDA is required.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from sglang_omni.models.moss_tts_local.state_pool import (
+    MossTTSLocalDecodeJournal,
+    MossTTSLocalDecodeStatePool,
+)
+
+_HIDDEN = 8
+
+
+def _model(max_running_requests: int = 4) -> SimpleNamespace:
+    """Fake model exposing only what the pool reads."""
+    weight = torch.zeros(max_running_requests, _HIDDEN, dtype=torch.bfloat16)
+    embedding = SimpleNamespace(weight=weight)
+    return SimpleNamespace(_decode_input_embedding=embedding)
+
+
+def _params(seed: int = 7) -> SimpleNamespace:
+    return SimpleNamespace(
+        text_temperature=0.5,
+        text_top_p=0.9,
+        text_top_k=40,
+        audio_temperature=1.7,
+        audio_top_p=0.8,
+        audio_top_k=25,
+        sampling_seed=seed,
+    )
+
+
+def test_pool_dims_derive_from_embedding_weight():
+    """P = weight.shape[0] + 1; no literal row count, padding row reserved."""
+    pool = MossTTSLocalDecodeStatePool(_model(max_running_requests=4))
+    assert pool.num_rows == 5
+    assert pool.padding_row == 4
+    assert pool.hidden_size == _HIDDEN
+    assert pool.feedback_embeds.shape == (5, _HIDDEN)
+    assert pool.feedback_embeds.dtype == torch.bfloat16
+    for name in ("text_temp", "text_top_p", "audio_temp", "audio_top_p"):
+        assert getattr(pool, name).shape == (5,)
+        assert getattr(pool, name).dtype == torch.float32
+    for name in ("text_top_k", "audio_top_k", "seeds"):
+        assert getattr(pool, name).shape == (5,)
+        assert getattr(pool, name).dtype == torch.int64
+
+
+def test_acquire_is_idempotent_by_rid():
+    pool = MossTTSLocalDecodeStatePool(_model())
+    first = pool.acquire_row("a")
+    again = pool.acquire_row("a")
+    assert first == again
+    # A second rid takes a different row.
+    other = pool.acquire_row("b")
+    assert other != first
+
+
+def test_padding_row_never_acquired():
+    """Real rows are 0..P-2; the padding row stays out of every assignment."""
+    pool = MossTTSLocalDecodeStatePool(_model(max_running_requests=4))
+    acquired = {pool.acquire_row(f"r{i}") for i in range(4)}
+    assert acquired == {0, 1, 2, 3}
+    assert pool.padding_row not in acquired
+
+
+def test_pool_exhaustion_raises():
+    pool = MossTTSLocalDecodeStatePool(_model(max_running_requests=2))
+    pool.acquire_row("a")
+    pool.acquire_row("b")
+    try:
+        pool.acquire_row("c")
+    except RuntimeError as exc:
+        assert "exhausted" in str(exc)
+    else:
+        raise AssertionError("expected RuntimeError on pool exhaustion")
+
+
+def test_release_is_noop_for_unheld_rid():
+    pool = MossTTSLocalDecodeStatePool(_model())
+    # No row held: release must not raise or perturb the free list.
+    free_before = list(pool._free_rows)
+    pool.release_row("ghost")
+    assert pool._free_rows == free_before
+
+
+def test_release_frees_and_recycles_row():
+    pool = MossTTSLocalDecodeStatePool(_model(max_running_requests=2))
+    row_a = pool.acquire_row("a")
+    pool.acquire_row("b")
+    pool.release_row("a")
+    assert pool.row_for("a") is None
+    # The freed row is reusable.
+    row_c = pool.acquire_row("c")
+    assert row_c == row_a
+
+
+def test_release_resets_row_fields():
+    pool = MossTTSLocalDecodeStatePool(_model())
+    row = pool.acquire_row("a")
+    pool.write_params(row, _params(seed=123))
+    pool.feedback_embeds[row].fill_(1.0)
+    pool.release_row("a")
+    assert torch.all(pool.feedback_embeds[row] == 0)
+    assert pool.text_temp[row] == 0.0
+    assert pool.audio_top_k[row] == 0
+    assert pool.seeds[row] == 0
+
+
+def test_reset_row_zeroes_all_fields():
+    pool = MossTTSLocalDecodeStatePool(_model())
+    row = pool.acquire_row("a")
+    pool.write_params(row, _params(seed=99))
+    pool.feedback_embeds[row].fill_(2.0)
+    pool.reset_row(row)
+    assert torch.all(pool.feedback_embeds[row] == 0)
+    for name in (
+        "text_temp",
+        "text_top_p",
+        "audio_temp",
+        "audio_top_p",
+        "text_top_k",
+        "audio_top_k",
+        "seeds",
+    ):
+        assert getattr(pool, name)[row] == 0
+
+
+def test_write_params_writes_request_static_fields():
+    pool = MossTTSLocalDecodeStatePool(_model())
+    row = pool.acquire_row("a")
+    pool.write_params(row, _params(seed=555))
+    assert pool.text_temp[row].item() == torch.tensor(0.5, dtype=torch.float32).item()
+    assert pool.text_top_p[row].item() == torch.tensor(0.9, dtype=torch.float32).item()
+    assert pool.audio_temp[row].item() == torch.tensor(1.7, dtype=torch.float32).item()
+    assert pool.audio_top_p[row].item() == torch.tensor(0.8, dtype=torch.float32).item()
+    assert int(pool.text_top_k[row]) == 40
+    assert int(pool.audio_top_k[row]) == 25
+    assert int(pool.seeds[row]) == 555
+
+
+def test_write_params_does_not_touch_other_rows():
+    pool = MossTTSLocalDecodeStatePool(_model())
+    row_a = pool.acquire_row("a")
+    row_b = pool.acquire_row("b")
+    pool.write_params(row_a, _params(seed=1))
+    assert pool.seeds[row_b] == 0
+    assert pool.text_temp[row_b] == 0.0
+
+
+def test_row_for_returns_none_when_unheld():
+    pool = MossTTSLocalDecodeStatePool(_model())
+    assert pool.row_for("nobody") is None
+    row = pool.acquire_row("a")
+    assert pool.row_for("a") == row
+
+
+def test_journal_holds_fields():
+    rows = torch.arange(2 * 13, dtype=torch.long).reshape(2, 13)
+    journal = MossTTSLocalDecodeJournal(rids=["a", "b"], pool_rows=[0, 1], rows=rows)
+    assert journal.rids == ["a", "b"]
+    assert journal.pool_rows == [0, 1]
+    assert torch.equal(journal.rows, rows)

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -285,6 +285,49 @@ def test_double_collect_overwrites_feedback():
     )
 
 
+def test_resume_reprefill_overwrites_stranded_feedback():
+    """Retraction resume wipes the stranded feedback row and forces a param
+    re-write — the pool-row replacement for the old
+    ``pending_feedback_queue.clear()``. Drives the retraction branch of
+    ``_build_prefill_input_embeds`` (the only path that resets a live row).
+    """
+    model = _model(max_running_requests=4)
+    model.hidden_size = _HIDDEN
+    model.dtype = torch.bfloat16
+    model._prepare_multi_modal_inputs = lambda rows: torch.zeros(
+        (rows.shape[0], _HIDDEN), dtype=torch.bfloat16
+    )
+    pool = MossTTSLocalDecodeStatePool(model)
+    model._state_pool = pool
+
+    row = pool.acquire_row("a")
+    pool.write_params(row, _params(seed=1))
+    pool._params_written_rids.add("a")
+    # Feedback stranded by the retraction (must be wiped by the resume).
+    pool.feedback_embeds[row].fill_(5.0)
+
+    # prompt_rows (2 frames) + already-generated output_rows (3 frames); the
+    # resume re-prefills the whole span, so extend_input_len = 2 + 3.
+    width = 13
+    prompt_rows = torch.zeros((2, width), dtype=torch.long)
+    generated = [torch.zeros(width, dtype=torch.long) for _ in range(3)]
+    data = SimpleNamespace(
+        req=SimpleNamespace(extend_input_len=5, prefix_indices=[], rid="a"),
+        prompt_rows=prompt_rows,
+        output_rows=generated,
+    )
+    sched_req = SimpleNamespace(request_id="a", data=data)
+
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    forward_batch = SimpleNamespace(input_ids=torch.zeros(5, dtype=torch.long))
+
+    runner._build_prefill_input_embeds(forward_batch, [sched_req])
+
+    assert torch.all(pool.feedback_embeds[row] == 0), "stranded feedback must be wiped"
+    assert "a" not in pool._params_written_rids, "params must be re-written on resume"
+
+
 def test_journal_rid_assertion_fires():
     runner = object.__new__(MossTTSLocalModelRunner)
     runner.model = SimpleNamespace(config=SimpleNamespace(audio_end_token_id=1001))
@@ -303,10 +346,10 @@ def test_journal_rid_assertion_fires():
 
     try:
         runner.post_process_outputs(result, scheduler_output, outputs)
-    except AssertionError as exc:
+    except RuntimeError as exc:
         assert "journal/batch alignment broken" in str(exc)
     else:
-        raise AssertionError("expected journal rid mismatch to assert")
+        raise AssertionError("expected journal rid mismatch to raise")
 
 
 def test_stop_row_not_appended_via_journal():

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -217,6 +217,152 @@ def test_feedback_gather_equals_old_popleft():
     assert torch.equal(forward_batch.input_ids, torch.tensor([0, 1]))
 
 
+def _forward_sample_model(max_running_requests: int = 4) -> SimpleNamespace:
+    model = _model(max_running_requests=max_running_requests)
+    model.config = SimpleNamespace(
+        n_vq=12,
+        audio_assistant_slot_token_id=1000,
+        audio_end_token_id=1001,
+    )
+    model.device = torch.device("cpu")
+    model.forward_sample_in_forward = True
+    model._moss_local_decode_cuda_graph_bs = [1, 2, 4, 8, 16]
+    model._moss_local_decode_graph_padding = False
+    model._state_pool = MossTTSLocalDecodeStatePool(model)
+    hidden = model._decode_input_embedding.weight.shape[1]
+    model._cg_text_temp = torch.ones(max_running_requests, dtype=torch.float32)
+    model._cg_text_top_p = torch.ones(max_running_requests, dtype=torch.float32)
+    model._cg_text_top_k = torch.full((max_running_requests,), 50, dtype=torch.int64)
+    model._cg_audio_temp = torch.ones(max_running_requests, dtype=torch.float32)
+    model._cg_audio_top_p = torch.ones(max_running_requests, dtype=torch.float32)
+    model._cg_audio_top_k = torch.full((max_running_requests,), 25, dtype=torch.int64)
+    model._cg_seeds = torch.zeros(max_running_requests, dtype=torch.int64)
+    model._cg_base_positions = torch.zeros(max_running_requests, dtype=torch.int64)
+    model._cg_rows = torch.zeros(max_running_requests, 13, dtype=torch.int64)
+    model._cg_feedback = torch.zeros(
+        max_running_requests, hidden, dtype=model._decode_input_embedding.weight.dtype
+    )
+    return model
+
+
+def _decode_data(
+    *,
+    seed: int,
+    generation_steps: int,
+    audio_top_k: int = 25,
+    audio_repetition_penalty: float = 1.0,
+    is_chunked: int = 0,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        req=SimpleNamespace(is_chunked=is_chunked),
+        text_temperature=0.5 + seed / 100,
+        text_top_p=0.9,
+        text_top_k=40 + seed,
+        audio_temperature=1.7,
+        audio_top_p=0.8,
+        audio_top_k=audio_top_k,
+        sampling_seed=seed,
+        generation_steps=generation_steps,
+        audio_repetition_penalty=audio_repetition_penalty,
+        output_rows=[],
+    )
+
+
+def test_before_decode_stages_forward_sample_buffers_and_padding():
+    model = _forward_sample_model(max_running_requests=4)
+    pool = model._state_pool
+    row_a = pool.acquire_row("a")
+    row_b = pool.acquire_row("b")
+    pool.feedback_embeds[row_a] = torch.arange(_HIDDEN, dtype=torch.bfloat16)
+    pool.feedback_embeds[row_b] = torch.arange(_HIDDEN, dtype=torch.bfloat16) + 10
+    pool.feedback_embeds[pool.padding_row] = torch.full(
+        (_HIDDEN,), 99, dtype=torch.bfloat16
+    )
+
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    requests = [
+        SimpleNamespace(request_id="a", data=_decode_data(seed=3, generation_steps=2)),
+        SimpleNamespace(
+            request_id="b",
+            data=_decode_data(seed=5, generation_steps=4, audio_top_k=17),
+        ),
+    ]
+    forward_batch = SimpleNamespace(
+        batch_size=4,
+        input_ids=torch.full((4,), -1, dtype=torch.long),
+    )
+
+    runner.before_decode(forward_batch, SimpleNamespace(), requests)
+
+    expected_feedback = torch.stack(
+        [
+            pool.feedback_embeds[row_a],
+            pool.feedback_embeds[row_b],
+            pool.feedback_embeds[pool.padding_row],
+            pool.feedback_embeds[pool.padding_row],
+        ],
+        dim=0,
+    )
+    assert torch.equal(model._decode_input_embedding.weight[:4], expected_feedback)
+    assert torch.equal(forward_batch.input_ids, torch.tensor([0, 1, 2, 3]))
+    torch.testing.assert_close(
+        model._cg_text_temp[:2], torch.tensor([0.53, 0.55], dtype=torch.float32)
+    )
+    assert torch.equal(model._cg_audio_top_k[:2], torch.tensor([25, 17]))
+    assert torch.equal(model._cg_seeds[:2], torch.tensor([3, 5]))
+    assert torch.equal(model._cg_base_positions[:2], torch.tensor([26, 52]))
+    torch.testing.assert_close(model._cg_text_temp[2:4], torch.ones(2))
+    torch.testing.assert_close(model._cg_audio_top_p[2:4], torch.ones(2))
+    assert torch.equal(model._cg_text_top_k[2:4], torch.tensor([50, 50]))
+    assert torch.equal(model._cg_audio_top_k[2:4], torch.tensor([25, 25]))
+    assert torch.equal(model._cg_seeds[2:4], torch.tensor([0, 0]))
+    assert torch.equal(model._cg_base_positions[2:4], torch.tensor([0, 0]))
+    assert runner._forward_sample_pool_rows == [row_a, row_b]
+    assert runner._forward_sample_rids == ["a", "b"]
+
+
+def test_before_decode_stages_to_cuda_graph_bucket_when_padding_enabled():
+    model = _forward_sample_model(max_running_requests=4)
+    model._moss_local_decode_cuda_graph_bs = [1, 2, 4]
+    model._moss_local_decode_graph_padding = True
+    pool = model._state_pool
+    row = pool.acquire_row("a")
+    pool.feedback_embeds[row] = torch.arange(_HIDDEN, dtype=torch.bfloat16)
+    pool.feedback_embeds[pool.padding_row] = torch.full(
+        (_HIDDEN,), 11, dtype=torch.bfloat16
+    )
+
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    request = SimpleNamespace(
+        request_id="a", data=_decode_data(seed=3, generation_steps=2)
+    )
+    forward_batch = SimpleNamespace(
+        batch_size=3,
+        input_ids=torch.full((3,), -1, dtype=torch.long),
+    )
+
+    runner.before_decode(forward_batch, SimpleNamespace(), [request])
+
+    expected_feedback = torch.stack(
+        [
+            pool.feedback_embeds[row],
+            pool.feedback_embeds[pool.padding_row],
+            pool.feedback_embeds[pool.padding_row],
+            pool.feedback_embeds[pool.padding_row],
+        ],
+        dim=0,
+    )
+    assert torch.equal(model._decode_input_embedding.weight[:4], expected_feedback)
+    assert torch.equal(forward_batch.input_ids, torch.tensor([0, 1, 2]))
+    torch.testing.assert_close(model._cg_text_temp[1:4], torch.ones(3))
+    assert torch.equal(model._cg_text_top_k[1:4], torch.tensor([50, 50, 50]))
+    assert torch.equal(model._cg_audio_top_k[1:4], torch.tensor([25, 25, 25]))
+    assert torch.equal(model._cg_seeds[1:4], torch.tensor([0, 0, 0]))
+    assert torch.equal(model._cg_base_positions[1:4], torch.tensor([0, 0, 0]))
+
+
 def test_fresh_row_zeros_feedback():
     model = _model(max_running_requests=2)
     pool = MossTTSLocalDecodeStatePool(model)
@@ -425,6 +571,130 @@ def test_collect_frame_skips_chunked_feedback_and_journal():
     assert result.moss_journal.rids == ["normal"]
     assert result.moss_journal.pool_rows == [normal_row]
     assert result.moss_journal.rows.shape == (1, 13)
+
+
+def test_forward_sample_collect_matches_legacy_graph_collect():
+    def make_runner_and_model():
+        model = _forward_sample_model(max_running_requests=4)
+        model.frame_graph_max_bs = 4
+        model.acquire_row = model._state_pool.acquire_row
+        runner = object.__new__(MossTTSLocalModelRunner)
+        runner.model = model
+        return runner, model
+
+    codes = torch.stack(
+        [torch.arange(12, dtype=torch.long), torch.arange(12, dtype=torch.long) + 20],
+        dim=0,
+    )
+    stop_choice = torch.tensor([0, 1], dtype=torch.long)
+    feedback = torch.tensor(
+        [[3, 3, 3, 3, 3, 3, 3, 3], [7, 7, 7, 7, 7, 7, 7, 7]],
+        dtype=torch.bfloat16,
+    )
+    rows = torch.empty((2, 13), dtype=torch.long)
+    rows[:, 0] = torch.tensor([1000, 1001], dtype=torch.long)
+    rows[:, 1:] = codes
+
+    def requests():
+        return [
+            SimpleNamespace(
+                request_id="chunked",
+                data=_decode_data(seed=1, generation_steps=0, is_chunked=1),
+            ),
+            SimpleNamespace(
+                request_id="normal",
+                data=_decode_data(seed=2, generation_steps=0, is_chunked=0),
+            ),
+        ]
+
+    legacy_runner, legacy_model = make_runner_and_model()
+
+    def decode_frame_graphed(hidden_states, **kwargs):
+        del hidden_states, kwargs
+        return stop_choice, codes, feedback
+
+    legacy_model.decode_frame_graphed = decode_frame_graphed
+    legacy_result = SimpleNamespace(
+        logits_output=SimpleNamespace(hidden_states=torch.zeros(2, _HIDDEN))
+    )
+    legacy_batch = SimpleNamespace()
+    legacy_requests = requests()
+
+    legacy_runner._collect_frame_legacy(
+        legacy_result, SimpleNamespace(), legacy_batch, legacy_requests
+    )
+
+    new_runner, new_model = make_runner_and_model()
+    new_requests = requests()
+    forward_batch = SimpleNamespace(
+        batch_size=2,
+        input_ids=torch.full((2,), -1, dtype=torch.long),
+    )
+    new_runner.before_decode(forward_batch, SimpleNamespace(), new_requests)
+    new_model._cg_rows[:2] = rows
+    new_model._cg_feedback[:2] = feedback
+    new_result = SimpleNamespace(logits_output=SimpleNamespace())
+    new_batch = SimpleNamespace()
+
+    new_runner._collect_frame_from_forward_sample(new_result, new_batch, new_requests)
+
+    assert torch.equal(new_result.next_token_ids, legacy_result.next_token_ids)
+    assert torch.equal(new_batch.output_ids, legacy_batch.output_ids)
+    assert new_result.moss_journal.rids == legacy_result.moss_journal.rids
+    assert new_result.moss_journal.pool_rows == legacy_result.moss_journal.pool_rows
+    assert torch.equal(new_result.moss_journal.rows, legacy_result.moss_journal.rows)
+    assert torch.equal(
+        new_model._state_pool.feedback_embeds[new_model._state_pool.row_for("normal")],
+        legacy_model._state_pool.feedback_embeds[
+            legacy_model._state_pool.row_for("normal")
+        ],
+    )
+    assert torch.equal(
+        new_model._state_pool.feedback_embeds[new_model._state_pool.row_for("chunked")],
+        torch.zeros(_HIDDEN, dtype=torch.bfloat16),
+    )
+
+
+def test_collect_frame_repetition_penalty_falls_back_to_legacy():
+    model = _forward_sample_model(max_running_requests=2)
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    calls = []
+    runner._collect_frame_legacy = lambda *args: calls.append("legacy")
+    runner._collect_frame_from_forward_sample = lambda *args: calls.append("new")
+    request = SimpleNamespace(
+        request_id="rid",
+        data=_decode_data(seed=1, generation_steps=0, audio_repetition_penalty=1.2),
+    )
+    forward_batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(is_decode=lambda: True),
+    )
+    result = SimpleNamespace(logits_output=SimpleNamespace())
+
+    runner._collect_frame(result, forward_batch, SimpleNamespace(), [request])
+
+    assert calls == ["legacy"]
+
+
+def test_post_prefill_collection_remains_legacy_for_forward_sample_path():
+    model = _forward_sample_model(max_running_requests=2)
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    calls = []
+    runner._collect_frame_legacy = lambda *args: calls.append("legacy")
+    runner._collect_frame_from_forward_sample = lambda *args: calls.append("new")
+    request = SimpleNamespace(
+        request_id="rid",
+        data=_decode_data(seed=1, generation_steps=0),
+    )
+    forward_batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(is_decode=lambda: False),
+    )
+    result = SimpleNamespace(logits_output=SimpleNamespace())
+
+    runner.post_prefill(result, forward_batch, SimpleNamespace(), [request])
+
+    assert calls == ["legacy"]
 
 
 def test_journal_rid_assertion_fires():


### PR DESCRIPTION
  ## Motivation

  This PR improves the MOSS-TTS Local decode path by preparing it for CUDA-graph-friendly forward sampling. The goal is to reduce Python/kernel-launch overhead in steady-state decode by allowing the local frame sampling step to run inside the SGLang model forward graph, while preserving the existing legacy decode path as a fallback.

  ## Modifications

  - Added fixed GPU staging buffers for MOSS-TTS Local forward-time sampling inputs and outputs.
  - Added an opt-in `forward_sample_in_forward` path that runs local frame decode inside `MossTTSLocalSGLangModel.forward()`.
  - Staged per-request sampling parameters, seeds, base positions, and feedback embeddings before decode so SGLang CUDA graph replay can read stable tensor addresses.
  - Collected sampled rows and feedback embeddings from fixed `_cg_*` output buffers after forward replay.
  - Preserved the legacy post-forward frame decode path for unsupported cases, including audio repetition penalty.
  - Added unit coverage for graph-bucket staging, forward-sample collection, fallback behavior, and CUDA graph initialization wiring.

  ## Related Issues

  N/A

  ## Accuracy Test

  TODO: Add MOSS-TTS Local accuracy/parity results.

  Planned checks:
  - Compare generated rows/audio between the legacy frame-decode path and the forward-sample path on fixed seeds.
  - Run SeedTTS-style voice cloning samples and report WER / qualitative parity.

  ## Benchmark & Profiling

  TODO: Add throughput / latency numbers.

  Planned benchmark:
  - `benchmarks/eval/benchmark_tts_seedtts.py`
  - Model: `OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5`
  - Compare legacy path vs `forward_sample_in_forward=True`
  - Report latency, throughput, RTF, and output tokens/sec at selected concurrency levels.

  ## Checklist

  - [ ] Format your code according with pre-commit.
  - [x] Add unit tests.
  - [ ] Update documentation / docstrings / example tutorials as needed.
  - [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
  - [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the
  PR.

  ## CI

  CI runs on self-hosted GPU runners and requires a maintainer to add the
  `run-ci` label. Once labeled, every subsequent push re-triggers CI as
  long as the label remains. Draft PRs are skipped even if labeled.