### PR TITLE
[Perf] Compile MOSS-TTS v1.5 audio encoder behind opt-in

### DIFF
--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -20,6 +20,9 @@ def _stages(*, codec_device: str) -> list[StageConfig]:
             factory=f"{_PKG}.stages.create_preprocessing_executor",
             factory_args={
                 "device": codec_device,
+                "enable_quantizer_torch_compile": False,
+                "quantizer_torch_compile_mode": "default",
+                "quantizer_torch_compile_warmup_seconds": [1.0],
                 "ref_audio_cache": True,
                 "ref_audio_cache_max_items": 256,
                 "ref_audio_cache_max_bytes": 64 * 1024 * 1024,

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -9,6 +9,7 @@ import os
 import queue
 import threading
 import time
+from collections.abc import Sequence
 from typing import Any
 
 import torch
@@ -102,6 +103,89 @@ def _load_moss_tts_local_processor(model_path: str, *, device: str) -> Any:
             # would corrupt the quantizer codebooks.
             audio_tokenizer.to(device)
     return processor
+
+
+def _normalize_quantizer_compile_warmup_seconds(
+    warmup_seconds: Sequence[float] | None,
+) -> tuple[float, ...]:
+    source = (1.0,) if warmup_seconds is None else warmup_seconds
+    values = tuple(float(value) for value in source)
+    if not values:
+        raise RuntimeError("MOSS-TTS Local quantizer torch.compile warmup is empty")
+    for value in values:
+        if value <= 0:
+            raise RuntimeError(
+                "MOSS-TTS Local quantizer torch.compile warmup seconds "
+                "must be positive"
+            )
+    return values
+
+
+def _quantizer_compile_sample_rate(processor: Any) -> int:
+    sample_rate = int(processor.audio_tokenizer.sampling_rate)
+    if sample_rate <= 0:
+        raise RuntimeError(
+            "MOSS-TTS Local quantizer torch.compile warmup sample rate must be positive"
+        )
+    return sample_rate
+
+
+def _quantizer_compile_channels(processor: Any) -> int:
+    channels = int(processor.audio_tokenizer.number_channels)
+    if channels <= 0:
+        raise RuntimeError(
+            "MOSS-TTS Local quantizer torch.compile warmup channels must be positive"
+        )
+    return channels
+
+
+def _warmup_moss_tts_local_quantizer(
+    processor: Any,
+    warmup_seconds: Sequence[float],
+) -> None:
+    encode_audios = processor.encode_audios_from_wav
+    if not callable(encode_audios):
+        raise RuntimeError(
+            "MOSS-TTS Local processor.encode_audios_from_wav is unavailable"
+        )
+    sample_rate = _quantizer_compile_sample_rate(processor)
+    channels = _quantizer_compile_channels(processor)
+    for seconds in warmup_seconds:
+        num_samples = max(1, int(round(float(seconds) * sample_rate)))
+        wav = torch.zeros((channels, num_samples), dtype=torch.float32)
+        encode_audios([wav], sample_rate)
+
+
+def _compile_moss_tts_local_quantizer(
+    processor: Any,
+    *,
+    compile_mode: str | None = "default",
+    warmup_seconds: Sequence[float] | None = None,
+) -> None:
+    audio_tokenizer = processor.audio_tokenizer
+    quantizer = audio_tokenizer.quantizer
+    if not callable(quantizer):
+        raise RuntimeError("MOSS-TTS Local audio_tokenizer quantizer is not callable")
+
+    compile_kwargs: dict[str, Any] = {"fullgraph": False, "dynamic": True}
+    if compile_mode is not None:
+        compile_kwargs["mode"] = compile_mode
+    normalized_warmup = _normalize_quantizer_compile_warmup_seconds(warmup_seconds)
+
+    try:
+        audio_tokenizer.quantizer = torch.compile(quantizer, **compile_kwargs)
+        _warmup_moss_tts_local_quantizer(processor, normalized_warmup)
+    except Exception:
+        audio_tokenizer.quantizer = quantizer
+        logger.exception("MOSS-TTS Local quantizer torch.compile failed")
+        raise
+
+    logger.info(
+        "Enabled MOSS-TTS Local quantizer torch.compile "
+        "(mode=%s, warmup_seconds=%s)",
+        compile_mode,
+        list(normalized_warmup),
+    )
 
 
 class _BatchedReferenceEncoder:
@@ -409,6 +493,9 @@ def create_preprocessing_executor(
     ref_audio_cache: bool = True,
     ref_audio_cache_max_items: int = 256,
     ref_audio_cache_max_bytes: int = 64 * 1024 * 1024,
+    enable_quantizer_torch_compile: bool = False,
+    quantizer_torch_compile_mode: str | None = "default",
+    quantizer_torch_compile_warmup_seconds: Sequence[float] | None = None,
 ) -> SimpleScheduler:
     # MOSS_REF_AUDIO_CACHE=0 disables the cache at startup (ops kill switch / A-B
     # toggle) without a config edit; unset => kwarg default.
@@ -423,6 +510,12 @@ def create_preprocessing_executor(
         )
     device = _resolve_codec_device(device, gpu_id)
     processor = _load_moss_tts_local_processor(model_path, device=device)
+    if enable_quantizer_torch_compile:
+        _compile_moss_tts_local_quantizer(
+            processor,
+            compile_mode=quantizer_torch_compile_mode,
+            warmup_seconds=quantizer_torch_compile_warmup_seconds,
+        )
     reference_encoder: Any = _BatchedReferenceEncoder(
         processor,
         max_batch_size=encode_batch_size,

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -332,56 +332,82 @@ def test_create_preprocessing_executor_env_toggle(monkeypatch):
     )
 
 
-def test_quantizer_torch_compile_wraps_forward_and_warms_up(monkeypatch):
+class _RecordingQuantizer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.calls = 0
+        self.compiled_calls = 0
+        self.last_n_quantizers = "unset"
+
+    @torch.no_grad()
+    def forward(self, z, input_length, n_quantizers=None):
+        del input_length
+        self.calls += 1
+        self.last_n_quantizers = n_quantizers
+        return z
+
+
+class _CompiledQuantizer(torch.nn.Module):
+    def __init__(self, eager_quantizer):
+        super().__init__()
+        self.eager_quantizer = eager_quantizer
+
+    def forward(self, *args, **kwargs):
+        self.eager_quantizer.compiled_calls += 1
+        return self.eager_quantizer(*args, **kwargs)
+
+
+class _WarmupFailingQuantizer(torch.nn.Module):
+    def forward(self, *args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("warmup failed")
+
+
+class _FakeAudioTokenizer(torch.nn.Module):
+    def __init__(
+        self,
+        *,
+        number_channels: int = 1,
+        sampling_rate: int = 48000,
+    ):
+        super().__init__()
+        self.number_channels = number_channels
+        self.sampling_rate = sampling_rate
+        self.quantizer = _RecordingQuantizer()
+
+
+class _FakeQuantizerProcessor:
+    def __init__(
+        self,
+        *,
+        number_channels: int = 1,
+        sampling_rate: int = 48000,
+    ):
+        self.audio_tokenizer = _FakeAudioTokenizer(
+            number_channels=number_channels,
+            sampling_rate=sampling_rate,
+        )
+        self.warmup_shapes = []
+
+    def encode_audios_from_wav(self, wavs, sample_rate):
+        assert sample_rate == self.audio_tokenizer.sampling_rate
+        self.warmup_shapes.append(tuple(wavs[0].shape))
+        input_length = torch.tensor([wavs[0].shape[-1]])
+        return [
+            self.audio_tokenizer.quantizer(wavs[0], input_length, n_quantizers=None)
+        ]
+
+
+def test_quantizer_torch_compile_replaces_module_and_warms_up(monkeypatch):
     from sglang_omni.models.moss_tts_local import stages
 
-    class _FakeQuantizer(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.calls = 0
-            self.compiled_calls = 0
-            self.last_n_quantizers = "unset"
-
-        @torch.no_grad()
-        def forward(self, z, input_length, n_quantizers=None):
-            del input_length
-            self.calls += 1
-            self.last_n_quantizers = n_quantizers
-            return z
-
-    class _FakeAudioTokenizer(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.quantizer = _FakeQuantizer()
-
-    class _FakeModelConfig:
-        sampling_rate = 24000
-
-    class _FakeProcessor:
-        def __init__(self):
-            self.audio_tokenizer = _FakeAudioTokenizer()
-            self.model_config = _FakeModelConfig()
-            self.warmup_shapes = []
-
-        def encode_audios_from_wav(self, wavs, sample_rate):
-            assert sample_rate == 24000
-            self.warmup_shapes.append(tuple(wavs[0].shape))
-            input_length = torch.tensor([wavs[0].shape[-1]])
-            return [
-                self.audio_tokenizer.quantizer(wavs[0], input_length, n_quantizers=None)
-            ]
-
     compile_calls = []
-    processor = _FakeProcessor()
+    processor = _FakeQuantizerProcessor(sampling_rate=24000)
+    eager_quantizer = processor.audio_tokenizer.quantizer
 
     def fake_compile(target, **kwargs):
         compile_calls.append((target, kwargs))
-
-        def wrapped(*args, **inner_kwargs):
-            processor.audio_tokenizer.quantizer.compiled_calls += 1
-            return target(*args, **inner_kwargs)
-
-        return wrapped
+        return _CompiledQuantizer(target)
 
     monkeypatch.setattr(torch, "compile", fake_compile)
 
@@ -393,48 +419,23 @@ def test_quantizer_torch_compile_wraps_forward_and_warms_up(monkeypatch):
 
     assert len(compile_calls) == 1
     target, kwargs = compile_calls[0]
-    assert getattr(target, "__name__", "") == "forward"
+    assert target is eager_quantizer
     assert kwargs == {
         "fullgraph": False,
         "dynamic": True,
         "mode": "reduce-overhead",
     }
+    assert isinstance(processor.audio_tokenizer.quantizer, _CompiledQuantizer)
     assert processor.warmup_shapes == [(1, 24000), (1, 72000)]
-    assert processor.audio_tokenizer.quantizer.calls == 2
-    assert processor.audio_tokenizer.quantizer.compiled_calls == 2
-    assert processor.audio_tokenizer.quantizer.last_n_quantizers is None
+    assert eager_quantizer.calls == 2
+    assert eager_quantizer.compiled_calls == 2
+    assert eager_quantizer.last_n_quantizers is None
 
 
 def test_quantizer_torch_compile_warmup_uses_tokenizer_channels(monkeypatch):
     from sglang_omni.models.moss_tts_local import stages
 
-    class _FakeQuantizer(torch.nn.Module):
-        def forward(self, z, input_length, n_quantizers=None):
-            del input_length, n_quantizers
-            return z
-
-    class _FakeAudioTokenizer(torch.nn.Module):
-        number_channels = 2
-        sampling_rate = 48000
-
-        def __init__(self):
-            super().__init__()
-            self.quantizer = _FakeQuantizer()
-
-    class _FakeProcessor:
-        def __init__(self):
-            self.audio_tokenizer = _FakeAudioTokenizer()
-            self.warmup_shapes = []
-
-        def encode_audios_from_wav(self, wavs, sample_rate):
-            assert sample_rate == 48000
-            self.warmup_shapes.append(tuple(wavs[0].shape))
-            if tuple(wavs[0].shape) != (2, 48000):
-                raise AssertionError(f"bad warmup shape: {tuple(wavs[0].shape)}")
-            input_length = torch.tensor([wavs[0].shape[-1]])
-            return [self.audio_tokenizer.quantizer(wavs[0], input_length)]
-
-    processor = _FakeProcessor()
+    processor = _FakeQuantizerProcessor(number_channels=2, sampling_rate=48000)
     monkeypatch.setattr(torch, "compile", lambda target, **kwargs: target)
 
     stages._compile_moss_tts_local_quantizer(
@@ -445,45 +446,21 @@ def test_quantizer_torch_compile_warmup_uses_tokenizer_channels(monkeypatch):
     assert processor.warmup_shapes == [(2, 48000)]
 
 
-def test_quantizer_torch_compile_failure_restores_forward(monkeypatch):
+def test_quantizer_torch_compile_failure_restores_module(monkeypatch):
     from sglang_omni.models.moss_tts_local import stages
 
-    class _FakeQuantizer(torch.nn.Module):
-        @torch.no_grad()
-        def forward(self, z, input_length, n_quantizers=None):
-            del input_length, n_quantizers
-            return z
-
-    class _FakeAudioTokenizer(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.quantizer = _FakeQuantizer()
-
-    class _FakeProcessor:
-        def __init__(self):
-            self.audio_tokenizer = _FakeAudioTokenizer()
-
-        def encode_audios_from_wav(self, wavs, sample_rate):
-            del sample_rate
-            input_length = torch.tensor([wavs[0].shape[-1]])
-            return [self.audio_tokenizer.quantizer(wavs[0], input_length)]
-
-    def fake_compile(*args, **kwargs):
-        del args, kwargs
-
-        def wrapped(*args, **kwargs):
-            del args, kwargs
-            raise RuntimeError("warmup failed")
-
-        return wrapped
+    def fake_compile(target, **kwargs):
+        del target, kwargs
+        return _WarmupFailingQuantizer()
 
     monkeypatch.setattr(torch, "compile", fake_compile)
-    processor = _FakeProcessor()
+    processor = _FakeQuantizerProcessor()
+    eager_quantizer = processor.audio_tokenizer.quantizer
 
-    with pytest.raises(RuntimeError, match="quantizer torch.compile failed"):
+    with pytest.raises(RuntimeError, match="warmup failed"):
         stages._compile_moss_tts_local_quantizer(processor)
 
-    assert "forward" not in processor.audio_tokenizer.quantizer.__dict__
+    assert processor.audio_tokenizer.quantizer is eager_quantizer
     value = torch.tensor([[1.0]])
     assert torch.equal(processor.encode_audios_from_wav([value], 48000)[0], value)
 
@@ -515,13 +492,13 @@ def test_create_preprocessing_executor_quantizer_compile_wiring(monkeypatch):
     assert captured == [(processor, "reduce-overhead", [1.0, 2.0])]
 
     captured.clear()
-    monkeypatch.setenv("MOSS_LOCAL_QUANTIZER_TORCH_COMPILE", "0")
     stages.create_preprocessing_executor(
         "model",
         device="cpu",
         enable_quantizer_torch_compile=True,
+        encode_batch_size=8,
     )
-    assert captured == []
+    assert captured == [(processor, "default", None)]
 
 
 def test_preprocess_and_result_adapter():

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -405,6 +405,46 @@ def test_quantizer_torch_compile_wraps_forward_and_warms_up(monkeypatch):
     assert processor.audio_tokenizer.quantizer.last_n_quantizers is None
 
 
+def test_quantizer_torch_compile_warmup_uses_tokenizer_channels(monkeypatch):
+    from sglang_omni.models.moss_tts_local import stages
+
+    class _FakeQuantizer(torch.nn.Module):
+        def forward(self, z, input_length, n_quantizers=None):
+            del input_length, n_quantizers
+            return z
+
+    class _FakeAudioTokenizer(torch.nn.Module):
+        number_channels = 2
+        sampling_rate = 48000
+
+        def __init__(self):
+            super().__init__()
+            self.quantizer = _FakeQuantizer()
+
+    class _FakeProcessor:
+        def __init__(self):
+            self.audio_tokenizer = _FakeAudioTokenizer()
+            self.warmup_shapes = []
+
+        def encode_audios_from_wav(self, wavs, sample_rate):
+            assert sample_rate == 48000
+            self.warmup_shapes.append(tuple(wavs[0].shape))
+            if tuple(wavs[0].shape) != (2, 48000):
+                raise AssertionError(f"bad warmup shape: {tuple(wavs[0].shape)}")
+            input_length = torch.tensor([wavs[0].shape[-1]])
+            return [self.audio_tokenizer.quantizer(wavs[0], input_length)]
+
+    processor = _FakeProcessor()
+    monkeypatch.setattr(torch, "compile", lambda target, **kwargs: target)
+
+    stages._compile_moss_tts_local_quantizer(
+        processor,
+        warmup_seconds=[1.0],
+    )
+
+    assert processor.warmup_shapes == [(2, 48000)]
+
+
 def test_quantizer_torch_compile_failure_restores_forward(monkeypatch):
     from sglang_omni.models.moss_tts_local import stages
 

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -175,6 +175,16 @@ def test_pipeline_stage_wiring():
     assert stages["preprocessing"].process == "pipeline"
     assert stages["preprocessing"].gpu == 0
     assert stages["preprocessing"].factory_args["device"] == "cuda:1"
+    assert (
+        stages["preprocessing"].factory_args["enable_quantizer_torch_compile"] is False
+    )
+    assert (
+        stages["preprocessing"].factory_args["quantizer_torch_compile_mode"]
+        == "default"
+    )
+    assert stages["preprocessing"].factory_args[
+        "quantizer_torch_compile_warmup_seconds"
+    ] == [1.0]
     assert stages["tts_engine"].process == "pipeline"
     assert stages["tts_engine"].gpu == 0
     assert stages["vocoder"].process == "pipeline"
@@ -320,6 +330,160 @@ def test_create_preprocessing_executor_env_toggle(monkeypatch):
     assert isinstance(
         rb._PREPROCESSING_CONTEXT.reference_encoder, stages.CachedReferenceEncoder
     )
+
+
+def test_quantizer_torch_compile_wraps_forward_and_warms_up(monkeypatch):
+    from sglang_omni.models.moss_tts_local import stages
+
+    class _FakeQuantizer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+            self.compiled_calls = 0
+            self.last_n_quantizers = "unset"
+
+        @torch.no_grad()
+        def forward(self, z, input_length, n_quantizers=None):
+            del input_length
+            self.calls += 1
+            self.last_n_quantizers = n_quantizers
+            return z
+
+    class _FakeAudioTokenizer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.quantizer = _FakeQuantizer()
+
+    class _FakeModelConfig:
+        sampling_rate = 24000
+
+    class _FakeProcessor:
+        def __init__(self):
+            self.audio_tokenizer = _FakeAudioTokenizer()
+            self.model_config = _FakeModelConfig()
+            self.warmup_shapes = []
+
+        def encode_audios_from_wav(self, wavs, sample_rate):
+            assert sample_rate == 24000
+            self.warmup_shapes.append(tuple(wavs[0].shape))
+            input_length = torch.tensor([wavs[0].shape[-1]])
+            return [
+                self.audio_tokenizer.quantizer(
+                    wavs[0], input_length, n_quantizers=None
+                )
+            ]
+
+    compile_calls = []
+    processor = _FakeProcessor()
+
+    def fake_compile(target, **kwargs):
+        compile_calls.append((target, kwargs))
+
+        def wrapped(*args, **inner_kwargs):
+            processor.audio_tokenizer.quantizer.compiled_calls += 1
+            return target(*args, **inner_kwargs)
+
+        return wrapped
+
+    monkeypatch.setattr(torch, "compile", fake_compile)
+
+    stages._compile_moss_tts_local_quantizer(
+        processor,
+        compile_mode="reduce-overhead",
+        warmup_seconds=[1.0, 3.0],
+    )
+
+    assert len(compile_calls) == 1
+    target, kwargs = compile_calls[0]
+    assert getattr(target, "__name__", "") == "forward"
+    assert kwargs == {
+        "fullgraph": False,
+        "dynamic": True,
+        "mode": "reduce-overhead",
+    }
+    assert processor.warmup_shapes == [(1, 24000), (1, 72000)]
+    assert processor.audio_tokenizer.quantizer.calls == 2
+    assert processor.audio_tokenizer.quantizer.compiled_calls == 2
+    assert processor.audio_tokenizer.quantizer.last_n_quantizers is None
+
+
+def test_quantizer_torch_compile_failure_restores_forward(monkeypatch):
+    from sglang_omni.models.moss_tts_local import stages
+
+    class _FakeQuantizer(torch.nn.Module):
+        @torch.no_grad()
+        def forward(self, z, input_length, n_quantizers=None):
+            del input_length, n_quantizers
+            return z
+
+    class _FakeAudioTokenizer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.quantizer = _FakeQuantizer()
+
+    class _FakeProcessor:
+        def __init__(self):
+            self.audio_tokenizer = _FakeAudioTokenizer()
+
+        def encode_audios_from_wav(self, wavs, sample_rate):
+            del sample_rate
+            input_length = torch.tensor([wavs[0].shape[-1]])
+            return [self.audio_tokenizer.quantizer(wavs[0], input_length)]
+
+    def fake_compile(*args, **kwargs):
+        del args, kwargs
+
+        def wrapped(*args, **kwargs):
+            del args, kwargs
+            raise RuntimeError("warmup failed")
+
+        return wrapped
+
+    monkeypatch.setattr(torch, "compile", fake_compile)
+    processor = _FakeProcessor()
+
+    with pytest.raises(RuntimeError, match="quantizer torch.compile failed"):
+        stages._compile_moss_tts_local_quantizer(processor)
+
+    assert "forward" not in processor.audio_tokenizer.quantizer.__dict__
+    value = torch.tensor([[1.0]])
+    assert torch.equal(processor.encode_audios_from_wav([value], 48000)[0], value)
+
+
+def test_create_preprocessing_executor_quantizer_compile_wiring(monkeypatch):
+    from sglang_omni.models.moss_tts_local import stages
+
+    captured = []
+    processor = _FakeProcessor()
+
+    monkeypatch.setattr(
+        stages, "_load_moss_tts_local_processor", lambda *a, **k: processor
+    )
+    monkeypatch.setattr(
+        stages,
+        "_compile_moss_tts_local_quantizer",
+        lambda proc, *, compile_mode, warmup_seconds: captured.append(
+            (proc, compile_mode, warmup_seconds)
+        ),
+    )
+
+    stages.create_preprocessing_executor(
+        "model",
+        device="cpu",
+        enable_quantizer_torch_compile=True,
+        quantizer_torch_compile_mode="reduce-overhead",
+        quantizer_torch_compile_warmup_seconds=[1.0, 2.0],
+    )
+    assert captured == [(processor, "reduce-overhead", [1.0, 2.0])]
+
+    captured.clear()
+    monkeypatch.setenv("MOSS_LOCAL_QUANTIZER_TORCH_COMPILE", "0")
+    stages.create_preprocessing_executor(
+        "model",
+        device="cpu",
+        enable_quantizer_torch_compile=True,
+    )
+    assert captured == []
 
 
 def test_preprocess_and_result_adapter():

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -368,9 +368,7 @@ def test_quantizer_torch_compile_wraps_forward_and_warms_up(monkeypatch):
             self.warmup_shapes.append(tuple(wavs[0].shape))
             input_length = torch.tensor([wavs[0].shape[-1]])
             return [
-                self.audio_tokenizer.quantizer(
-                    wavs[0], input_length, n_quantizers=None
-                )
+                self.audio_tokenizer.quantizer(wavs[0], input_length, n_quantizers=None)
             ]
 
     compile_calls = []


### PR DESCRIPTION
## Motivation

MOSS-TTS Local reference-audio preprocessing runs through the codec encoder and quantizer before the AR engine can generate audio. This PR adds an opt-in `torch.compile` path for the codec quantizer so we can reduce preprocessing overhead under concurrent serving, while keeping the default runtime behavior unchanged.

## Modifications

1. `sglang_omni/models/moss_tts_local/stages.py`
   - Adds `enable_quantizer_torch_compile`, `quantizer_torch_compile_mode`, and `quantizer_torch_compile_warmup_seconds` to `create_preprocessing_executor`.
   - Compiles the loaded processor's `audio_tokenizer.quantizer.forward` with `torch.compile(fullgraph=False, dynamic=True, mode=...)`, then wraps the compiled callable with `torch.no_grad()`.
   - Warms the compiled quantizer through `processor.encode_audios_from_wav()` using configurable positive warmup durations and the processor/tokenizer sample rate.
   - Restores the original instance `forward` on compile or warmup failure and raises a clear runtime error.
   - Adds `MOSS_LOCAL_QUANTIZER_TORCH_COMPILE=0|false|no|off` as an ops kill switch, and reuses the same env-disable parsing for `MOSS_REF_AUDIO_CACHE`.

2. `sglang_omni/models/moss_tts_local/config.py`
   - Wires the preprocessing stage with explicit default compile settings:
     `enable_quantizer_torch_compile=false`, `quantizer_torch_compile_mode=default`, and `quantizer_torch_compile_warmup_seconds=[1.0]`.

3. `tests/unit_test/moss_tts_local/test_pipeline.py`
   - Covers default config wiring, compile wrapper/warmup behavior, failure restoration, preprocessing executor wiring, and the env kill switch.

## Related Issues
#733 

## Accuracy Test

**Setup:**

- Baseline: `main @ c8ea7ad` using `configs/moss_tts_local_main.yaml`
- Candidate: `feat/moss-tts-quantizer-torch-compile @ 465f4c4`
- Model: `OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5`
- Dataset/eval: SeedTTS EN, `zhaochenyang20/seed-tts-eval-arrow`, 1088 samples per variant/concurrency
- Runtime: one run per variant at concurrency 1 and 16, logical `cuda:0` for the AR engine and `cuda:1` for preprocessing/vocoder codec processors
- Hardware/software: 2x NVIDIA H100

All WER and speaker-similarity checks evaluated 1088/1088 samples with 0 skipped.

| Concurrency | Metric | Baseline | Candidate | 
| ---: | --- | ---: | ---: | 
| 1 | Corpus WER | 0.020598 | 0.020682 | 
| 1 | Speaker similarity | 65.186785 | 65.198589 | 
| 16 | Corpus WER | 0.024115 | 0.022942 |
| 16 | Speaker similarity | 65.239819 | 65.477828 | 

## Benchmark & Profiling

Same setup as described in the _Accuracy Test_ section.

| Concurrency | Metric | Baseline | Candidate | Delta |
| ---: | --- | ---: | ---: | ---: |
| 1 | Failed requests | 0 | 0 | 0 |
| 1 | Mean latency | 0.621 s | 0.624 s | +0.48% |
| 1 | P95 latency | 0.839 s | 0.841 s | +0.24% |
| 1 | Mean RTF | 0.1437 | 0.1442 | +0.35% |
| 1 | Throughput | 1.609 QPS | 1.603 QPS | -0.37% |
| 16 | Failed requests | 0 | 0 | 0 |
| 16 | Mean latency | 1.587 s | 1.514 s | -4.60% |
| 16 | P95 latency | 2.024 s | 1.966 s | -2.87% |
| 16 | Mean RTF | 0.3782 | 0.3596 | -4.92% |
| 16 | Throughput | 10.042 QPS | 10.521 QPS | +4.77% |


### Summary:

- c=1 is effectively neutral in this single run, with all latency, throughput, and quality deltas below 0.5%.
- c=16 improves end-to-end serving metrics: mean latency -4.60%, p95 latency -2.87%, mean RTF -4.92%, and throughput +4.77%, with no quality regression.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Draft PRs are skipped even if labeled.
