### PR TITLE
[Perf] Pool MOSS-TTS Local frame launch state

### DIFF
--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -329,6 +329,14 @@ class ModelRunner:
         """Hook after ``generation_steps`` is committed on request data."""
         return None
 
+    def on_generation_steps_advanced(
+        self, advanced_steps: list[tuple[Any, int]], forward_batch: Any
+    ) -> None:
+        """Batch hook after ``generation_steps`` are committed on request data."""
+        del forward_batch
+        for sched_req, generation_steps in advanced_steps:
+            self.on_generation_step_advanced(sched_req, generation_steps)
+
     def _finalize(
         self,
         batch_result,
@@ -372,16 +380,19 @@ class ModelRunner:
         outputs = self.output_processor.process(batch_result, scheduler_output)
         self.post_process_outputs(batch_result, scheduler_output, outputs)
         skip_rids = (skip_rids or set()) | self.finalize_skip_rids(scheduler_output)
+        advanced_steps = []
         for sched_req in scheduler_output.requests:
             if sched_req.request_id in skip_rids:
                 continue
             data = sched_req.data
             data.generation_steps = int(data.generation_steps) + 1
-            self.on_generation_step_advanced(sched_req, data.generation_steps)
+            advanced_steps.append((sched_req, data.generation_steps))
             req_output = outputs[sched_req.request_id]
             extra = req_output.extra
             if isinstance(extra, dict) and extra:
                 data.extra_model_outputs.update(extra)
+        if advanced_steps:
+            self.on_generation_steps_advanced(advanced_steps, forward_batch)
         req_ids = [req.request_id for req in scheduler_output.requests]
         req_id_to_index = {req_id: idx for idx, req_id in enumerate(req_ids)}
 

--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -323,6 +323,12 @@ class ModelRunner:
         """
         return set()
 
+    def on_generation_step_advanced(
+        self, sched_req: Any, generation_steps: int
+    ) -> None:
+        """Hook after ``generation_steps`` is committed on request data."""
+        return None
+
     def _finalize(
         self,
         batch_result,
@@ -371,6 +377,7 @@ class ModelRunner:
                 continue
             data = sched_req.data
             data.generation_steps = int(data.generation_steps) + 1
+            self.on_generation_step_advanced(sched_req, data.generation_steps)
             req_output = outputs[sched_req.request_id]
             extra = req_output.extra
             if isinstance(extra, dict) and extra:

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -95,6 +95,7 @@ class MossTTSLocalModelRunner(ModelRunner):
         forward_batch: Any,
         requests: list,
     ) -> torch.Tensor:
+        self._stage_repetition_penalty_state(forward_batch, requests)
         pieces = []
         for sched_req in requests:
             data = sched_req.data
@@ -162,6 +163,7 @@ class MossTTSLocalModelRunner(ModelRunner):
                 "MOSS-TTS Local decode batch exceeds the staged decode-embedding "
                 f"rows ({batch_size} > {pool.padding_row})"
             )
+        self._stage_repetition_penalty_state(forward_batch, requests)
         row_tensor, pool_rows = pool.prepare_active_rows(requests)
         with torch.no_grad():
             weight[:batch_size].copy_(pool.feedback_embeds[row_tensor])
@@ -184,14 +186,14 @@ class MossTTSLocalModelRunner(ModelRunner):
     ) -> None:
         if not requests:
             return
-        rows, end_id = self._run_frame_decode(result, requests)
+        rows, end_id = self._run_frame_decode(result, forward_batch, requests)
         # Radix key is a capture-safe GPU hash: a device op, no host sync.
         next_text = rows[:, 0]
         next_token_ids = self._row_radix_token_ids(rows, next_text, end_id)
         result.next_token_ids = next_token_ids
         schedule_batch.output_ids = next_token_ids
 
-    def _run_frame_decode(self, result: Any, requests: list):
+    def _run_frame_decode(self, result: Any, forward_batch: Any, requests: list):
         """GPU half shared by sync ``_collect_frame`` and async
         ``post_decode_launch``. Returns ``(rows, end_id)`` and does NOT publish
         ``next_token_ids``; the caller does, because the async path keeps a
@@ -208,8 +210,7 @@ class MossTTSLocalModelRunner(ModelRunner):
         cfg = self.model.config
         device = hidden_states.device
         pool = self.model._state_pool
-        datas = [sched_req.data for sched_req in requests]
-        batch_size = len(datas)
+        batch_size = len(requests)
         num_channels = int(cfg.n_vq) + 1
 
         row_t = getattr(forward_batch, "moss_pool_row_t", None)
@@ -241,8 +242,13 @@ class MossTTSLocalModelRunner(ModelRunner):
             if not self._is_chunked_request(sched_req)
         }
         gen_steps = pool.generation_steps[row_t].to(device=device)
-        rep_penalties = [float(d.audio_repetition_penalty) for d in datas]
-        rep_histories = self._gather_rep_histories(datas, rep_penalties, device)
+        rep_penalties = getattr(forward_batch, "moss_rep_penalties", None)
+        rep_datas = getattr(forward_batch, "moss_rep_datas", None)
+        rep_histories = (
+            None
+            if rep_datas is None or rep_penalties is None
+            else self._gather_rep_histories(rep_datas, rep_penalties, device)
+        )
 
         def sample_text(logits: torch.Tensor) -> torch.Tensor:
             return MossTTSModelRunner._sample_tokens(
@@ -341,10 +347,9 @@ class MossTTSLocalModelRunner(ModelRunner):
         the stop id and silently dropping a bs=1 eos finish (4096-frame runaway).
         The clone preserves it; resolve swaps it back.
         """
-        del forward_batch
         if not requests:
             return None
-        rows, end_id = self._run_frame_decode(result, requests)
+        rows, end_id = self._run_frame_decode(result, forward_batch, requests)
         next_token_ids = self._row_radix_token_ids(rows, rows[:, 0], end_id)
         result.next_token_ids = next_token_ids
         return next_token_ids.clone()
@@ -408,6 +413,27 @@ class MossTTSLocalModelRunner(ModelRunner):
         )
         data.sampling_steps = s + 1
         return s
+
+    @staticmethod
+    def _stage_repetition_penalty_state(forward_batch: Any, requests: list) -> None:
+        """Attach slow-path repetition state only when a penalty is active."""
+        if not requests:
+            forward_batch.moss_rep_datas = None
+            forward_batch.moss_rep_penalties = None
+            return
+        active = any(
+            float(getattr(sched_req.data, "audio_repetition_penalty", 1.0)) != 1.0
+            for sched_req in requests
+        )
+        if not active:
+            forward_batch.moss_rep_datas = None
+            forward_batch.moss_rep_penalties = None
+            return
+        forward_batch.moss_rep_datas = [sched_req.data for sched_req in requests]
+        forward_batch.moss_rep_penalties = [
+            float(getattr(sched_req.data, "audio_repetition_penalty", 1.0))
+            for sched_req in requests
+        ]
 
     @staticmethod
     def _gather_rep_histories(

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -481,6 +481,33 @@ class MossTTSLocalModelRunner(ModelRunner):
         if pool is not None:
             pool.commit_generation_step(sched_req.request_id, generation_steps)
 
+    def on_generation_steps_advanced(
+        self, advanced_steps: list[tuple[Any, int]], forward_batch: Any
+    ) -> None:
+        pool = getattr(self.model, "_state_pool", None)
+        if pool is None or not advanced_steps:
+            return
+        steps = [int(generation_steps) for _, generation_steps in advanced_steps]
+        row_t = getattr(forward_batch, "moss_pool_row_t", None)
+        if row_t is not None and int(row_t.numel()) == len(steps):
+            step_t = torch.tensor(steps, dtype=torch.long, device=row_t.device)
+            pool.commit_generation_steps(row_t, step_t)
+            return
+        rows = []
+        row_steps = []
+        for sched_req, generation_steps in advanced_steps:
+            row = pool.row_for(sched_req.request_id)
+            if row is None:
+                continue
+            rows.append(row)
+            row_steps.append(int(generation_steps))
+        if not rows:
+            return
+        device = pool.generation_steps.device
+        row_t = torch.tensor(rows, dtype=torch.long, device=device)
+        step_t = torch.tensor(row_steps, dtype=torch.long, device=device)
+        pool.commit_generation_steps(row_t, step_t)
+
     def post_process_outputs(
         self,
         result: Any,

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -82,15 +82,29 @@ class MossTTSLocalModelRunner(ModelRunner):
         rep-history gather lags one frame under lookahead and would diverge from
         sync) or ``bs > frame_graph_max_bs``.
         """
-        reqs = getattr(batch, "reqs", None) or []
-        if len(reqs) > int(getattr(self.model, "frame_graph_max_bs", 0)):
+        try:
+            reqs = batch.reqs
+        except AttributeError:
+            reqs = None
+        reqs = reqs or []
+        try:
+            frame_graph_max_bs = self.model.frame_graph_max_bs
+        except AttributeError:
+            frame_graph_max_bs = 0
+        if len(reqs) > int(frame_graph_max_bs):
             return False
         for req in reqs:
-            data = getattr(req, "_omni_data", None)
-            if (
-                data is not None
-                and float(getattr(data, "audio_repetition_penalty", 1.0)) != 1.0
-            ):
+            try:
+                data = req._omni_data
+            except AttributeError:
+                data = None
+            if data is None:
+                continue
+            try:
+                audio_repetition_penalty = data.audio_repetition_penalty
+            except AttributeError:
+                audio_repetition_penalty = 1.0
+            if float(audio_repetition_penalty) != 1.0:
                 return False
         return True
 
@@ -121,8 +135,9 @@ class MossTTSLocalModelRunner(ModelRunner):
             # any retraction re-prefill, including one retracted before it emitted
             # a frame (empty output_rows). Both are no-ops for a fresh prefill:
             # the counters are already aligned and no pool row is held.
-            data.sampling_steps = int(getattr(data, "generation_steps", 0))
-            pool.reset_for_refill(sched_req.request_id, int(data.generation_steps))
+            generation_steps = int(data.generation_steps)
+            data.sampling_steps = generation_steps
+            pool.reset_for_refill(sched_req.request_id, generation_steps)
             if data.output_rows:
                 pool.rebuild_audio_history(sched_req.request_id, data.output_rows)
             current_rows = rows[prefix_len : prefix_len + req_len]
@@ -264,7 +279,10 @@ class MossTTSLocalModelRunner(ModelRunner):
             for i, sched_req in enumerate(requests)
             if not self._is_chunked_request(sched_req)
         }
-        gen_steps = pool.generation_steps[row_t].to(device=device)
+        gen_steps = torch.maximum(
+            pool.sampling_steps[row_t].to(device=device),
+            pool.generation_steps[row_t].to(device=device),
+        )
         rep_penalties = pool.audio_repetition_penalty[row_t].to(
             device=device, dtype=torch.float32
         )
@@ -355,6 +373,12 @@ class MossTTSLocalModelRunner(ModelRunner):
             emit_pool_rows = [pool_rows[i] for i in emit_indices]
             emit_row_t = row_t[emit_index_t.to(device=row_t.device)]
             emit_rows = rows.index_select(0, emit_index_t)
+            emit_steps = gen_steps.index_select(
+                0, emit_index_t.to(device=gen_steps.device)
+            )
+            pool.sampling_steps[emit_row_t] = (emit_steps + 1).to(
+                device=pool.sampling_steps.device, dtype=torch.int64
+            )
             if has_audio_repetition_penalty:
                 keep_history = (
                     next_text.index_select(0, emit_index_t.to(device=next_text.device))
@@ -454,9 +478,11 @@ class MossTTSLocalModelRunner(ModelRunner):
         under lookahead generation_steps lags, so the floor lifts launch(N+1) off
         the stale N.
         """
-        s = max(
-            int(getattr(data, "sampling_steps", None) or 0), int(data.generation_steps)
-        )
+        try:
+            sampling_steps = data.sampling_steps
+        except AttributeError:
+            sampling_steps = None
+        s = max(int(sampling_steps or 0), int(data.generation_steps))
         data.sampling_steps = s + 1
         return s
 
@@ -590,10 +616,15 @@ class MossTTSLocalModelRunner(ModelRunner):
             # output_rows / the vocoder. No-op on the sync path.
             req = sched_req.data.req
             if req is not None:
-                finished_fn = getattr(req, "finished", None)
-                if (callable(finished_fn) and finished_fn()) or bool(
-                    getattr(req, "is_retracted", False)
-                ):
+                try:
+                    finished_fn = req.finished
+                except AttributeError:
+                    finished_fn = None
+                try:
+                    is_retracted = req.is_retracted
+                except AttributeError:
+                    is_retracted = False
+                if (callable(finished_fn) and finished_fn()) or bool(is_retracted):
                     continue
             req_output = outputs[sched_req.request_id]
             if req_output.data is None or int(req_output.data) == end_id:

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -95,7 +95,6 @@ class MossTTSLocalModelRunner(ModelRunner):
         forward_batch: Any,
         requests: list,
     ) -> torch.Tensor:
-        self._stage_repetition_penalty_state(forward_batch, requests)
         pieces = []
         for sched_req in requests:
             data = sched_req.data
@@ -105,6 +104,7 @@ class MossTTSLocalModelRunner(ModelRunner):
                 raise RuntimeError("MOSS-TTS Local prefill requires prompt_rows")
             req_len = int(req.extend_input_len)
             prefix_len = len(req.prefix_indices)
+            pool = self.model._state_pool
             if data.output_rows:
                 # KV-pressure retraction re-prefills with an extend region
                 # spanning already-generated frames; their rows live in
@@ -118,9 +118,9 @@ class MossTTSLocalModelRunner(ModelRunner):
             # a frame (empty output_rows). Both are no-ops for a fresh prefill:
             # the counters are already aligned and no pool row is held.
             data.sampling_steps = int(getattr(data, "generation_steps", 0))
-            self.model._state_pool.reset_for_refill(
-                sched_req.request_id, int(data.generation_steps)
-            )
+            pool.reset_for_refill(sched_req.request_id, int(data.generation_steps))
+            if data.output_rows:
+                pool.rebuild_audio_history(sched_req.request_id, data.output_rows)
             current_rows = rows[prefix_len : prefix_len + req_len]
             if int(current_rows.shape[0]) != req_len:
                 raise RuntimeError(
@@ -163,12 +163,14 @@ class MossTTSLocalModelRunner(ModelRunner):
                 "MOSS-TTS Local decode batch exceeds the staged decode-embedding "
                 f"rows ({batch_size} > {pool.padding_row})"
             )
-        self._stage_repetition_penalty_state(forward_batch, requests)
-        row_tensor, pool_rows = pool.prepare_active_rows(requests)
+        row_tensor, pool_rows, has_audio_repetition_penalty = pool.prepare_active_rows(
+            requests
+        )
         with torch.no_grad():
             weight[:batch_size].copy_(pool.feedback_embeds[row_tensor])
         forward_batch.moss_pool_row_t = row_tensor
         forward_batch.moss_pool_rows = pool_rows
+        forward_batch.moss_has_audio_repetition_penalty = has_audio_repetition_penalty
 
         row_ids = torch.arange(
             batch_size,
@@ -216,7 +218,17 @@ class MossTTSLocalModelRunner(ModelRunner):
         row_t = getattr(forward_batch, "moss_pool_row_t", None)
         pool_rows = getattr(forward_batch, "moss_pool_rows", None)
         if row_t is None or pool_rows is None:
-            row_t, pool_rows = pool.prepare_active_rows(requests)
+            row_t, pool_rows, has_audio_repetition_penalty = pool.prepare_active_rows(
+                requests
+            )
+        else:
+            has_audio_repetition_penalty = getattr(
+                forward_batch, "moss_has_audio_repetition_penalty", None
+            )
+            if has_audio_repetition_penalty is None:
+                has_audio_repetition_penalty = pool.rows_have_audio_repetition_penalty(
+                    pool_rows
+                )
         params = {
             "text_temp": pool.text_temp[row_t],
             "text_top_p": pool.text_top_p[row_t],
@@ -242,12 +254,8 @@ class MossTTSLocalModelRunner(ModelRunner):
             if not self._is_chunked_request(sched_req)
         }
         gen_steps = pool.generation_steps[row_t].to(device=device)
-        rep_penalties = getattr(forward_batch, "moss_rep_penalties", None)
-        rep_datas = getattr(forward_batch, "moss_rep_datas", None)
-        rep_histories = (
-            None
-            if rep_datas is None or rep_penalties is None
-            else self._gather_rep_histories(rep_datas, rep_penalties, device)
+        rep_penalties = pool.audio_repetition_penalty[row_t].to(
+            device=device, dtype=torch.float32
         )
 
         def sample_text(logits: torch.Tensor) -> torch.Tensor:
@@ -261,9 +269,16 @@ class MossTTSLocalModelRunner(ModelRunner):
             )
 
         def sample_audio(logits: torch.Tensor, channel: int) -> torch.Tensor:
-            if rep_histories is not None:
-                self._apply_audio_repetition_penalty(
-                    logits, rep_histories, rep_penalties, channel
+            if has_audio_repetition_penalty:
+                presence = pool.audio_token_presence[row_t, channel].to(
+                    device=logits.device
+                )
+                if int(presence.shape[-1]) != int(logits.shape[-1]):
+                    presence = presence[:, : logits.shape[-1]]
+                self._apply_audio_repetition_penalty_mask(
+                    logits,
+                    presence,
+                    rep_penalties.to(device=logits.device, dtype=logits.dtype),
                 )
             return MossTTSModelRunner._sample_tokens(
                 logits,
@@ -274,7 +289,7 @@ class MossTTSLocalModelRunner(ModelRunner):
                 positions=gen_steps * num_channels + channel + 1,
             )
 
-        use_graph = rep_histories is None and batch_size <= getattr(
+        use_graph = not has_audio_repetition_penalty and batch_size <= getattr(
             self.model, "frame_graph_max_bs", 0
         )
         if use_graph:
@@ -324,6 +339,22 @@ class MossTTSLocalModelRunner(ModelRunner):
             )
             emit_pool_rows = [pool_rows[i] for i in emit_indices]
             emit_row_t = row_t[emit_index_t.to(device=row_t.device)]
+            emit_rows = rows.index_select(0, emit_index_t)
+            if has_audio_repetition_penalty:
+                keep_history = (
+                    next_text.index_select(0, emit_index_t.to(device=next_text.device))
+                    != end_id
+                )
+                emit_penalty_active = (
+                    pool.audio_repetition_penalty[emit_row_t]
+                    .to(device=keep_history.device)
+                    .ne(1.0)
+                )
+                keep_history = keep_history & emit_penalty_active
+                pool.update_audio_history(
+                    emit_row_t[keep_history.to(device=emit_row_t.device)],
+                    emit_rows[keep_history.to(device=emit_rows.device)],
+                )
             emit_embeds = embeds.index_select(0, emit_index_t.to(device=embeds.device))
             pool.feedback_embeds[emit_row_t] = emit_embeds.detach().to(
                 device=pool.feedback_embeds.device,
@@ -332,7 +363,7 @@ class MossTTSLocalModelRunner(ModelRunner):
             result.moss_journal = MossTTSLocalDecodeJournal(
                 rids=[requests[i].request_id for i in emit_indices],
                 pool_rows=emit_pool_rows,
-                rows=rows.index_select(0, emit_index_t),
+                rows=emit_rows,
             )
         # Always return rows so both the sync inline path and the async launch
         # publish next_token_ids; an all-chunked batch just attaches no journal.
@@ -415,70 +446,23 @@ class MossTTSLocalModelRunner(ModelRunner):
         return s
 
     @staticmethod
-    def _stage_repetition_penalty_state(forward_batch: Any, requests: list) -> None:
-        """Attach slow-path repetition state only when a penalty is active."""
-        if not requests:
-            forward_batch.moss_rep_datas = None
-            forward_batch.moss_rep_penalties = None
-            return
-        active = any(
-            float(getattr(sched_req.data, "audio_repetition_penalty", 1.0)) != 1.0
-            for sched_req in requests
-        )
-        if not active:
-            forward_batch.moss_rep_datas = None
-            forward_batch.moss_rep_penalties = None
-            return
-        forward_batch.moss_rep_datas = [sched_req.data for sched_req in requests]
-        forward_batch.moss_rep_penalties = [
-            float(getattr(sched_req.data, "audio_repetition_penalty", 1.0))
-            for sched_req in requests
-        ]
-
-    @staticmethod
-    def _gather_rep_histories(
-        datas: list,
-        rep_penalties: list[float],
-        device: torch.device,
-    ) -> list[torch.Tensor | None] | None:
-        """Per-request generated-code history, only when a penalty is active.
-
-        Upstream v1.5 applies the audio repetition penalty over each channel's
-        previously *generated* frames only (the prompt's reference codes are
-        excluded), so the history snapshot is taken from ``output_rows``.
-        """
-        if all(penalty == 1.0 for penalty in rep_penalties):
-            return None
-        histories: list[torch.Tensor | None] = []
-        for data, penalty in zip(datas, rep_penalties):
-            if penalty == 1.0 or not data.output_rows:
-                histories.append(None)
-                continue
-            stacked = torch.stack(data.output_rows, dim=0)[:, 1:]
-            histories.append(stacked.to(device=device, dtype=torch.long))
-        return histories
-
-    @staticmethod
-    def _apply_audio_repetition_penalty(
+    def _apply_audio_repetition_penalty_mask(
         logits: torch.Tensor,
-        histories: list[torch.Tensor | None],
-        penalties: list[float],
-        channel: int,
+        token_presence: torch.Tensor,
+        penalties: torch.Tensor,
     ) -> None:
         """In-place penalty on fp32 logits, matching upstream order (before
         temperature scaling)."""
-        vocab = logits.shape[-1]
-        for row, (history, penalty) in enumerate(zip(histories, penalties)):
-            if history is None or penalty == 1.0:
-                continue
-            tokens = torch.unique(history[:, channel])
-            tokens = tokens[(tokens >= 0) & (tokens < vocab)]
-            if tokens.numel() == 0:
-                continue
-            scores = logits[row, tokens]
-            logits[row, tokens] = torch.where(
-                scores < 0, scores * penalty, scores / penalty
-            )
+        penalties = penalties.to(device=logits.device, dtype=logits.dtype)
+        active = token_presence.to(device=logits.device, dtype=torch.bool) & (
+            penalties != 1.0
+        ).unsqueeze(-1)
+        scale = torch.where(
+            logits < 0,
+            penalties.unsqueeze(-1),
+            torch.reciprocal(penalties).unsqueeze(-1),
+        )
+        logits.copy_(torch.where(active, logits * scale, logits))
 
     @staticmethod
     def _is_chunked_request(sched_req: Any) -> bool:

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -457,12 +457,9 @@ class MossTTSLocalModelRunner(ModelRunner):
         active = token_presence.to(device=logits.device, dtype=torch.bool) & (
             penalties != 1.0
         ).unsqueeze(-1)
-        scale = torch.where(
-            logits < 0,
-            penalties.unsqueeze(-1),
-            torch.reciprocal(penalties).unsqueeze(-1),
-        )
-        logits.copy_(torch.where(active, logits * scale, logits))
+        penalties = penalties.unsqueeze(-1)
+        penalized = torch.where(logits < 0, logits * penalties, logits / penalties)
+        logits.copy_(torch.where(active, penalized, logits))
 
     @staticmethod
     def _is_chunked_request(sched_req: Any) -> bool:

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -59,7 +59,11 @@ class MossTTSLocalModelRunner(ModelRunner):
         schedule_batch: Any,
         requests: list,
     ) -> None:
-        if bool(getattr(schedule_batch, "is_prefill_only", False)):
+        try:
+            is_prefill_only = schedule_batch.is_prefill_only
+        except AttributeError:
+            is_prefill_only = False
+        if bool(is_prefill_only):
             return
         self._collect_frame(result, forward_batch, schedule_batch, requests)
 
@@ -201,7 +205,12 @@ class MossTTSLocalModelRunner(ModelRunner):
         ``next_token_ids``; the caller does, because the async path keeps a
         private device snapshot of the published ids for resolve to restore.
         """
-        hidden_states = getattr(result.logits_output, "hidden_states", None)
+        try:
+            hidden_states = result.logits_output.hidden_states
+        except AttributeError as exc:
+            raise RuntimeError(
+                "MOSS-TTS Local model output did not include hidden states"
+            ) from exc
         if not isinstance(hidden_states, torch.Tensor):
             raise RuntimeError(
                 "MOSS-TTS Local model output did not include hidden states"
@@ -215,17 +224,19 @@ class MossTTSLocalModelRunner(ModelRunner):
         batch_size = len(requests)
         num_channels = int(cfg.n_vq) + 1
 
-        row_t = getattr(forward_batch, "moss_pool_row_t", None)
-        pool_rows = getattr(forward_batch, "moss_pool_rows", None)
-        if row_t is None or pool_rows is None:
+        try:
+            row_t = forward_batch.moss_pool_row_t
+            pool_rows = forward_batch.moss_pool_rows
+        except AttributeError:
             row_t, pool_rows, has_audio_repetition_penalty = pool.prepare_active_rows(
                 requests
             )
         else:
-            has_audio_repetition_penalty = getattr(
-                forward_batch, "moss_has_audio_repetition_penalty", None
-            )
-            if has_audio_repetition_penalty is None:
+            try:
+                has_audio_repetition_penalty = (
+                    forward_batch.moss_has_audio_repetition_penalty
+                )
+            except AttributeError:
                 has_audio_repetition_penalty = pool.rows_have_audio_repetition_penalty(
                     pool_rows
                 )
@@ -289,8 +300,12 @@ class MossTTSLocalModelRunner(ModelRunner):
                 positions=gen_steps * num_channels + channel + 1,
             )
 
-        use_graph = not has_audio_repetition_penalty and batch_size <= getattr(
-            self.model, "frame_graph_max_bs", 0
+        try:
+            frame_graph_max_bs = int(self.model.frame_graph_max_bs)
+        except AttributeError:
+            frame_graph_max_bs = 0
+        use_graph = (
+            not has_audio_repetition_penalty and batch_size <= frame_graph_max_bs
         )
         if use_graph:
             stop_choice, codes, feedback = self.model.decode_frame_graphed(
@@ -463,8 +478,17 @@ class MossTTSLocalModelRunner(ModelRunner):
 
     @staticmethod
     def _is_chunked_request(sched_req: Any) -> bool:
-        req = getattr(sched_req.data, "req", None)
-        return req is not None and getattr(req, "is_chunked", 0) > 0
+        try:
+            req = sched_req.data.req
+        except AttributeError:
+            return False
+        if req is None:
+            return False
+        try:
+            is_chunked = req.is_chunked
+        except AttributeError:
+            return False
+        return int(is_chunked) > 0
 
     def finalize_skip_rids(self, scheduler_output) -> set[str]:
         """Non-final chunked-prefill rows must not advance ``generation_steps``.
@@ -484,18 +508,27 @@ class MossTTSLocalModelRunner(ModelRunner):
     def on_generation_step_advanced(
         self, sched_req: Any, generation_steps: int
     ) -> None:
-        pool = getattr(self.model, "_state_pool", None)
+        try:
+            pool = self.model._state_pool
+        except AttributeError:
+            return
         if pool is not None:
             pool.commit_generation_step(sched_req.request_id, generation_steps)
 
     def on_generation_steps_advanced(
         self, advanced_steps: list[tuple[Any, int]], forward_batch: Any
     ) -> None:
-        pool = getattr(self.model, "_state_pool", None)
+        try:
+            pool = self.model._state_pool
+        except AttributeError:
+            return
         if pool is None or not advanced_steps:
             return
         steps = [int(generation_steps) for _, generation_steps in advanced_steps]
-        row_t = getattr(forward_batch, "moss_pool_row_t", None)
+        try:
+            row_t = forward_batch.moss_pool_row_t
+        except AttributeError:
+            row_t = None
         if row_t is not None and int(row_t.numel()) == len(steps):
             step_t = torch.tensor(steps, dtype=torch.long, device=row_t.device)
             pool.commit_generation_steps(row_t, step_t)
@@ -525,7 +558,10 @@ class MossTTSLocalModelRunner(ModelRunner):
         # collection. A missing journal means no frame was produced this step
         # (e.g. a prefill-only batch), which is the synchronous-baseline early
         # return.
-        journal = getattr(result, "moss_journal", None)
+        try:
+            journal = result.moss_journal
+        except AttributeError:
+            return
         if journal is None:
             return
 

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -117,7 +117,9 @@ class MossTTSLocalModelRunner(ModelRunner):
             # a frame (empty output_rows). Both are no-ops for a fresh prefill:
             # the counters are already aligned and no pool row is held.
             data.sampling_steps = int(getattr(data, "generation_steps", 0))
-            self.model._state_pool.reset_for_refill(sched_req.request_id)
+            self.model._state_pool.reset_for_refill(
+                sched_req.request_id, int(data.generation_steps)
+            )
             current_rows = rows[prefix_len : prefix_len + req_len]
             if int(current_rows.shape[0]) != req_len:
                 raise RuntimeError(
@@ -160,10 +162,11 @@ class MossTTSLocalModelRunner(ModelRunner):
                 "MOSS-TTS Local decode batch exceeds the staged decode-embedding "
                 f"rows ({batch_size} > {pool.padding_row})"
             )
-        pool_rows = [pool.acquire_row(sched_req.request_id) for sched_req in requests]
-        row_tensor = torch.tensor(pool_rows, dtype=torch.long, device=weight.device)
+        row_tensor, pool_rows = pool.prepare_active_rows(requests)
         with torch.no_grad():
             weight[:batch_size].copy_(pool.feedback_embeds[row_tensor])
+        forward_batch.moss_pool_row_t = row_tensor
+        forward_batch.moss_pool_rows = pool_rows
 
         row_ids = torch.arange(
             batch_size,
@@ -179,7 +182,6 @@ class MossTTSLocalModelRunner(ModelRunner):
         schedule_batch: Any,
         requests: list,
     ) -> None:
-        del forward_batch
         if not requests:
             return
         rows, end_id = self._run_frame_decode(result, requests)
@@ -206,19 +208,14 @@ class MossTTSLocalModelRunner(ModelRunner):
         cfg = self.model.config
         device = hidden_states.device
         pool = self.model._state_pool
-        pool_rows = []
-        for sched_req in requests:
-            rid = sched_req.request_id
-            row = self.model.acquire_row(rid)
-            pool_rows.append(row)
-            pool.ensure_params(row, rid, sched_req.data)
         datas = [sched_req.data for sched_req in requests]
         batch_size = len(datas)
         num_channels = int(cfg.n_vq) + 1
 
-        row_t = torch.tensor(
-            pool_rows, dtype=torch.long, device=pool.feedback_embeds.device
-        )
+        row_t = getattr(forward_batch, "moss_pool_row_t", None)
+        pool_rows = getattr(forward_batch, "moss_pool_rows", None)
+        if row_t is None or pool_rows is None:
+            row_t, pool_rows = pool.prepare_active_rows(requests)
         params = {
             "text_temp": pool.text_temp[row_t],
             "text_top_p": pool.text_top_p[row_t],
@@ -243,21 +240,7 @@ class MossTTSLocalModelRunner(ModelRunner):
             for i, sched_req in enumerate(requests)
             if not self._is_chunked_request(sched_req)
         }
-        gen_steps = torch.tensor(
-            [
-                (
-                    self._advance_sampling_position(d)
-                    if i in emit_set
-                    else max(
-                        int(getattr(d, "sampling_steps", None) or 0),
-                        int(d.generation_steps),
-                    )
-                )
-                for i, d in enumerate(datas)
-            ],
-            dtype=torch.long,
-            device=device,
-        )
+        gen_steps = pool.generation_steps[row_t].to(device=device)
         rep_penalties = [float(d.audio_repetition_penalty) for d in datas]
         rep_histories = self._gather_rep_histories(datas, rep_penalties, device)
 
@@ -490,6 +473,13 @@ class MossTTSLocalModelRunner(ModelRunner):
             for sched_req in scheduler_output.requests
             if self._is_chunked_request(sched_req)
         }
+
+    def on_generation_step_advanced(
+        self, sched_req: Any, generation_steps: int
+    ) -> None:
+        pool = getattr(self.model, "_state_pool", None)
+        if pool is not None:
+            pool.commit_generation_step(sched_req.request_id, generation_steps)
 
     def post_process_outputs(
         self,

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -129,7 +129,7 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         self._decode_input_embedding.weight.requires_grad_(False)
 
         # Row-indexed decode-state pool: next-step-critical per-request state
-        # (next-frame feedback embedding, request-static sampling params/seed)
+        # (next-frame feedback embedding, sampling params/seed, generation step)
         # lives in process-lifetime GPU buffers sized off the staging table
         # above. Allocated here, before any frame/backbone graph capture, so
         # its addresses are fixed for the process lifetime.

--- a/sglang_omni/models/moss_tts_local/state_pool.py
+++ b/sglang_omni/models/moss_tts_local/state_pool.py
@@ -148,6 +148,16 @@ class MossTTSLocalDecodeStatePool:
             return
         self.generation_steps[row_idx] = int(generation_steps)
 
+    def commit_generation_steps(
+        self, row_t: torch.Tensor, generation_steps: torch.Tensor
+    ) -> None:
+        """Mirror committed generation steps into active pool rows in one write."""
+        if row_t.numel() == 0:
+            return
+        self.generation_steps[row_t] = generation_steps.to(
+            device=self.device, dtype=torch.int64
+        )
+
     def reset_for_refill(self, rid: str, generation_steps: int = 0) -> bool:
         """Invalidate params and zero ``rid``'s row for a retraction re-prefill.
 

--- a/sglang_omni/models/moss_tts_local/state_pool.py
+++ b/sglang_omni/models/moss_tts_local/state_pool.py
@@ -2,9 +2,10 @@
 """Row-indexed decode-state pool for MOSS-TTS Local (v1.5).
 
 Next-step-critical per-request decode state (the next frame's feedback
-embedding and the request-static sampling parameters/seed) lives in stable,
-process-lifetime GPU buffers indexed by a per-request row. Output-only frame
-collection moves to a per-step :class:`MossTTSLocalDecodeJournal`.
+embedding, request-static sampling parameters/seed, and generation step) lives
+in stable, process-lifetime GPU buffers indexed by a per-request row.
+Output-only frame collection moves to a per-step
+:class:`MossTTSLocalDecodeJournal`.
 
 ``P = max_running_requests + 1`` rows indexed by a per-request row. The last
 row (``padding_row = P - 1``) is reserved — never acquired — as a stable
@@ -65,6 +66,9 @@ class MossTTSLocalDecodeStatePool:
             self.num_rows, device=self.device, dtype=torch.int64
         )
         self.seeds = torch.zeros(self.num_rows, device=self.device, dtype=torch.int64)
+        self.generation_steps = torch.zeros(
+            self.num_rows, device=self.device, dtype=torch.int64
+        )
 
         self._rid_to_row: dict[str, int] = {}
         self._params_written_rids: set[str] = set()
@@ -110,6 +114,7 @@ class MossTTSLocalDecodeStatePool:
         self.text_top_k[row_idx] = 0
         self.audio_top_k[row_idx] = 0
         self.seeds[row_idx] = 0
+        self.generation_steps[row_idx] = 0
 
     def write_params(self, row_idx: int, data: Any) -> None:
         """Write the seven request-static sampling fields into ``row_idx``.
@@ -136,7 +141,14 @@ class MossTTSLocalDecodeStatePool:
         """Force params to be rewritten on the next ``ensure_params`` call."""
         self._params_written_rids.discard(rid)
 
-    def reset_for_refill(self, rid: str) -> bool:
+    def commit_generation_step(self, rid: str, generation_steps: int) -> None:
+        """Mirror the request's committed generation step into its pool row."""
+        row_idx = self.row_for(rid)
+        if row_idx is None:
+            return
+        self.generation_steps[row_idx] = int(generation_steps)
+
+    def reset_for_refill(self, rid: str, generation_steps: int = 0) -> bool:
         """Invalidate params and zero ``rid``'s row for a retraction re-prefill.
 
         Returns ``False`` (no-op) when ``rid`` holds no row.
@@ -146,11 +158,24 @@ class MossTTSLocalDecodeStatePool:
             return False
         self.invalidate_params(rid)
         self.reset_row(row_idx)
+        self.generation_steps[row_idx] = int(generation_steps)
         return True
 
     def row_for(self, rid: str) -> int | None:
         """Return ``rid``'s row, or ``None`` if it holds no row."""
         return self._rid_to_row.get(rid)
+
+    def prepare_active_rows(
+        self, requests: list[Any]
+    ) -> tuple[torch.Tensor, list[int]]:
+        """Acquire active rows and write request-static params for this batch."""
+        pool_rows = []
+        for sched_req in requests:
+            rid = sched_req.request_id
+            row_idx = self.acquire_row(rid)
+            pool_rows.append(row_idx)
+            self.ensure_params(row_idx, rid, sched_req.data)
+        return torch.tensor(pool_rows, dtype=torch.long, device=self.device), pool_rows
 
 
 class MossTTSLocalDecodeJournal:

--- a/sglang_omni/models/moss_tts_local/state_pool.py
+++ b/sglang_omni/models/moss_tts_local/state_pool.py
@@ -38,9 +38,20 @@ class MossTTSLocalDecodeStatePool:
         self.hidden_size = int(weight.shape[1])
         self.device = weight.device
         self.dtype = weight.dtype
-        config = getattr(model, "config", None)
-        self.n_vq = int(getattr(config, "n_vq", 12) or 12)
-        self.audio_vocab_size = int(getattr(config, "audio_vocab_size", 1024) or 1024)
+        try:
+            config = model.config
+        except AttributeError:
+            config = None
+        try:
+            n_vq = config.n_vq
+        except AttributeError:
+            n_vq = 12
+        try:
+            audio_vocab_size = config.audio_vocab_size
+        except AttributeError:
+            audio_vocab_size = 1024
+        self.n_vq = int(n_vq or 12)
+        self.audio_vocab_size = int(audio_vocab_size or 1024)
 
         # Feedback embedding for the next decode step; bf16 matches the staging
         # table dtype so before_decode's gather is a plain copy (#736).
@@ -148,7 +159,10 @@ class MossTTSLocalDecodeStatePool:
         self.text_top_k[row_idx] = int(data.text_top_k)
         self.audio_top_k[row_idx] = int(data.audio_top_k)
         self.seeds[row_idx] = int(data.sampling_seed)
-        audio_repetition_penalty = float(getattr(data, "audio_repetition_penalty", 1.0))
+        try:
+            audio_repetition_penalty = float(data.audio_repetition_penalty)
+        except AttributeError:
+            audio_repetition_penalty = 1.0
         self.audio_repetition_penalty[row_idx] = audio_repetition_penalty
         if audio_repetition_penalty == 1.0:
             self._audio_repetition_penalty_rows.discard(int(row_idx))

--- a/sglang_omni/models/moss_tts_local/state_pool.py
+++ b/sglang_omni/models/moss_tts_local/state_pool.py
@@ -84,6 +84,9 @@ class MossTTSLocalDecodeStatePool:
         self.generation_steps = torch.zeros(
             self.num_rows, device=self.device, dtype=torch.int64
         )
+        self.sampling_steps = torch.zeros(
+            self.num_rows, device=self.device, dtype=torch.int64
+        )
         self.audio_repetition_penalty = torch.zeros(
             self.num_rows, device=self.device, dtype=torch.float32
         )
@@ -141,6 +144,7 @@ class MossTTSLocalDecodeStatePool:
         self.audio_top_k[row_idx] = 0
         self.seeds[row_idx] = 0
         self.generation_steps[row_idx] = 0
+        self.sampling_steps[row_idx] = 0
         self.audio_repetition_penalty[row_idx] = 0.0
         self.audio_token_presence[row_idx].zero_()
         self._audio_repetition_penalty_rows.discard(int(row_idx))
@@ -184,7 +188,12 @@ class MossTTSLocalDecodeStatePool:
         row_idx = self.row_for(rid)
         if row_idx is None:
             return
-        self.generation_steps[row_idx] = int(generation_steps)
+        step = int(generation_steps)
+        self.generation_steps[row_idx] = step
+        self.sampling_steps[row_idx] = torch.maximum(
+            self.sampling_steps[row_idx],
+            torch.tensor(step, device=self.device, dtype=torch.int64),
+        )
 
     def commit_generation_steps(
         self, row_t: torch.Tensor, generation_steps: torch.Tensor
@@ -192,9 +201,10 @@ class MossTTSLocalDecodeStatePool:
         """Mirror committed generation steps into active pool rows in one write."""
         if row_t.numel() == 0:
             return
-        self.generation_steps[row_t] = generation_steps.to(
-            device=self.device, dtype=torch.int64
-        )
+        steps = generation_steps.to(device=self.device, dtype=torch.int64)
+        row_t = row_t.to(device=self.device, dtype=torch.long)
+        self.generation_steps[row_t] = steps
+        self.sampling_steps[row_t] = torch.maximum(self.sampling_steps[row_t], steps)
 
     def reset_for_refill(self, rid: str, generation_steps: int = 0) -> bool:
         """Invalidate params and zero ``rid``'s row for a retraction re-prefill.
@@ -207,6 +217,7 @@ class MossTTSLocalDecodeStatePool:
         self.invalidate_params(rid)
         self.reset_row(row_idx)
         self.generation_steps[row_idx] = int(generation_steps)
+        self.sampling_steps[row_idx] = int(generation_steps)
         return True
 
     def rows_have_audio_repetition_penalty(self, pool_rows: list[int]) -> bool:

--- a/sglang_omni/models/moss_tts_local/state_pool.py
+++ b/sglang_omni/models/moss_tts_local/state_pool.py
@@ -2,8 +2,9 @@
 """Row-indexed decode-state pool for MOSS-TTS Local (v1.5).
 
 Next-step-critical per-request decode state (the next frame's feedback
-embedding, request-static sampling parameters/seed, and generation step) lives
-in stable, process-lifetime GPU buffers indexed by a per-request row.
+embedding, request-static sampling parameters/seed, repetition penalty state,
+and generation step) lives in stable, process-lifetime GPU buffers indexed by a
+per-request row.
 Output-only frame collection moves to a per-step
 :class:`MossTTSLocalDecodeJournal`.
 
@@ -37,6 +38,9 @@ class MossTTSLocalDecodeStatePool:
         self.hidden_size = int(weight.shape[1])
         self.device = weight.device
         self.dtype = weight.dtype
+        config = getattr(model, "config", None)
+        self.n_vq = int(getattr(config, "n_vq", 12) or 12)
+        self.audio_vocab_size = int(getattr(config, "audio_vocab_size", 1024) or 1024)
 
         # Feedback embedding for the next decode step; bf16 matches the staging
         # table dtype so before_decode's gather is a plain copy (#736).
@@ -69,9 +73,20 @@ class MossTTSLocalDecodeStatePool:
         self.generation_steps = torch.zeros(
             self.num_rows, device=self.device, dtype=torch.int64
         )
+        self.audio_repetition_penalty = torch.zeros(
+            self.num_rows, device=self.device, dtype=torch.float32
+        )
+        self.audio_token_presence = torch.zeros(
+            self.num_rows,
+            self.n_vq,
+            self.audio_vocab_size,
+            device=self.device,
+            dtype=torch.bool,
+        )
 
         self._rid_to_row: dict[str, int] = {}
         self._params_written_rids: set[str] = set()
+        self._audio_repetition_penalty_rows: set[int] = set()
         # Real rows 0..P-2 are assignable; the padding row stays out of the
         # free list so it is never handed to a request.
         self._free_rows: list[int] = list(range(self.padding_row))
@@ -115,6 +130,9 @@ class MossTTSLocalDecodeStatePool:
         self.audio_top_k[row_idx] = 0
         self.seeds[row_idx] = 0
         self.generation_steps[row_idx] = 0
+        self.audio_repetition_penalty[row_idx] = 0.0
+        self.audio_token_presence[row_idx].zero_()
+        self._audio_repetition_penalty_rows.discard(int(row_idx))
 
     def write_params(self, row_idx: int, data: Any) -> None:
         """Write the seven request-static sampling fields into ``row_idx``.
@@ -130,6 +148,12 @@ class MossTTSLocalDecodeStatePool:
         self.text_top_k[row_idx] = int(data.text_top_k)
         self.audio_top_k[row_idx] = int(data.audio_top_k)
         self.seeds[row_idx] = int(data.sampling_seed)
+        audio_repetition_penalty = float(getattr(data, "audio_repetition_penalty", 1.0))
+        self.audio_repetition_penalty[row_idx] = audio_repetition_penalty
+        if audio_repetition_penalty == 1.0:
+            self._audio_repetition_penalty_rows.discard(int(row_idx))
+        else:
+            self._audio_repetition_penalty_rows.add(int(row_idx))
 
     def ensure_params(self, row_idx: int, rid: str, data: Any) -> None:
         """Write request-static params once for the current row acquisition."""
@@ -171,21 +195,74 @@ class MossTTSLocalDecodeStatePool:
         self.generation_steps[row_idx] = int(generation_steps)
         return True
 
+    def rows_have_audio_repetition_penalty(self, pool_rows: list[int]) -> bool:
+        """Return whether any host row has a non-default audio penalty."""
+        return any(int(row) in self._audio_repetition_penalty_rows for row in pool_rows)
+
+    def update_audio_history(self, row_t: torch.Tensor, rows: torch.Tensor) -> None:
+        """Mark generated audio codes as present for future repetition penalty."""
+        if row_t.numel() == 0:
+            return
+        if rows.ndim != 2 or int(rows.shape[1]) != self.n_vq + 1:
+            raise RuntimeError(
+                "MOSS-TTS Local audio history rows must have shape "
+                f"[B, {self.n_vq + 1}], got {tuple(rows.shape)}"
+            )
+        codes = rows[:, 1:].to(device=self.device, dtype=torch.long)
+        row_t = row_t.to(device=self.device, dtype=torch.long)
+        if int(row_t.numel()) != int(codes.shape[0]):
+            raise RuntimeError(
+                "MOSS-TTS Local audio history row index mismatch: "
+                f"{int(row_t.numel())} rows for {int(codes.shape[0])} code rows"
+            )
+        valid = (codes >= 0) & (codes < self.audio_vocab_size)
+        row_idx = row_t.view(-1, 1).expand_as(codes)
+        channel_idx = torch.arange(self.n_vq, device=self.device).view(1, -1)
+        channel_idx = channel_idx.expand_as(codes)
+        self.audio_token_presence[row_idx[valid], channel_idx[valid], codes[valid]] = (
+            True
+        )
+
+    def rebuild_audio_history(self, rid: str, output_rows: list[torch.Tensor]) -> bool:
+        """Rebuild ``rid``'s pool-resident history after retraction re-prefill."""
+        row_idx = self.row_for(rid)
+        if row_idx is None:
+            return False
+        self.audio_token_presence[row_idx].zero_()
+        if not output_rows:
+            return True
+        rows = torch.stack(output_rows, dim=0)
+        row_t = torch.full(
+            (int(rows.shape[0]),),
+            int(row_idx),
+            dtype=torch.long,
+            device=self.device,
+        )
+        self.update_audio_history(row_t, rows)
+        return True
+
     def row_for(self, rid: str) -> int | None:
         """Return ``rid``'s row, or ``None`` if it holds no row."""
         return self._rid_to_row.get(rid)
 
     def prepare_active_rows(
         self, requests: list[Any]
-    ) -> tuple[torch.Tensor, list[int]]:
+    ) -> tuple[torch.Tensor, list[int], bool]:
         """Acquire active rows and write request-static params for this batch."""
         pool_rows = []
+        has_audio_repetition_penalty = False
         for sched_req in requests:
             rid = sched_req.request_id
             row_idx = self.acquire_row(rid)
             pool_rows.append(row_idx)
             self.ensure_params(row_idx, rid, sched_req.data)
-        return torch.tensor(pool_rows, dtype=torch.long, device=self.device), pool_rows
+            if int(row_idx) in self._audio_repetition_penalty_rows:
+                has_audio_repetition_penalty = True
+        return (
+            torch.tensor(pool_rows, dtype=torch.long, device=self.device),
+            pool_rows,
+            has_audio_repetition_penalty,
+        )
 
 
 class MossTTSLocalDecodeJournal:

--- a/tests/README.md
+++ b/tests/README.md
@@ -315,7 +315,7 @@ that happened to contain an older version of the test.
 
 - `unit_test/moss_tts_local/`: MOSS-TTS Local unit tests:
   - pipeline config, request builders, and scheduler adapter contracts
-  - decode-state pool acquisition, cleanup, and resume/retraction lifecycle
+  - decode-state pool acquisition, launch-state gathers, cleanup, and resume/retraction lifecycle
   - chunked prefill feedback/journal suppression and postprocess alignment checks
   - synchronous frame-decode parity harness and S0 gate coverage.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -315,7 +315,7 @@ that happened to contain an older version of the test.
 
 - `unit_test/moss_tts_local/`: MOSS-TTS Local unit tests:
   - pipeline config, request builders, and scheduler adapter contracts
-  - decode-state pool acquisition, launch-state gathers, cleanup, and resume/retraction lifecycle
+  - decode-state pool acquisition, launch-state gathers, repetition-penalty history, cleanup, and resume/retraction lifecycle
   - chunked prefill feedback/journal suppression and postprocess alignment checks
   - synchronous frame-decode parity harness and S0 gate coverage.
 

--- a/tests/unit_test/model_runner/test_base_hooks.py
+++ b/tests/unit_test/model_runner/test_base_hooks.py
@@ -172,3 +172,43 @@ def test_execute_falls_back_to_standard_forward_after_before_hook(
     ]
     assert output.can_run_cuda_graph is False
     assert not hasattr(ModelRunner, "prepare_prefill")
+
+
+def test_finalize_default_batch_generation_hook_calls_single_hook() -> None:
+    calls: list[tuple[str, int]] = []
+
+    class RecordingRunner(ModelRunner):
+        def on_generation_step_advanced(self, sched_req, generation_steps):
+            calls.append((sched_req.request_id, generation_steps))
+
+    runner = object.__new__(RecordingRunner)
+    runner.output_processor = SimpleNamespace(
+        process=lambda result, scheduler_output: {
+            req.request_id: SimpleNamespace(extra={})
+            for req in scheduler_output.requests
+        },
+    )
+    requests = [
+        SimpleNamespace(
+            request_id="req-1",
+            data=SimpleNamespace(generation_steps=0, extra_model_outputs={}),
+        ),
+        SimpleNamespace(
+            request_id="req-2",
+            data=SimpleNamespace(generation_steps=4, extra_model_outputs={}),
+        ),
+    ]
+
+    runner._finalize(
+        SimpleNamespace(
+            next_token_ids=torch.tensor([1, 2]),
+            logits_output=None,
+            can_run_cuda_graph=False,
+        ),
+        SimpleNamespace(),
+        SimpleNamespace(is_prefill_only=False, output_ids=None),
+        SimpleNamespace(seq_lens=[1, 1], input_ids=torch.zeros(2, dtype=torch.long)),
+        SimpleNamespace(requests=requests),
+    )
+
+    assert calls == [("req-1", 1), ("req-2", 5)]

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -382,28 +382,33 @@ def test_result_adapter_empty_generation():
 # ---------------------------------------------------------------------------
 
 
-def test_audio_repetition_penalty_matches_upstream_semantics():
+def test_audio_repetition_penalty_mask_matches_upstream_semantics():
     from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
 
     logits = torch.tensor(
         [[2.0, -1.0, 0.5, 3.0], [1.0, 1.0, 1.0, 1.0]], dtype=torch.float32
     )
-    history_row0 = torch.tensor([[0, 9], [2, 9]], dtype=torch.long)  # channel 0: {0, 2}
-    histories = [history_row0, None]
+    token_presence = torch.tensor(
+        [
+            [True, False, True, False],
+            [True, True, False, False],
+        ],
+        dtype=torch.bool,
+    )
     expected = logits.clone()
     penalty = 1.5
     expected[0, 0] = expected[0, 0] / penalty  # positive -> divide
     expected[0, 2] = expected[0, 2] / penalty
 
-    MossTTSLocalModelRunner._apply_audio_repetition_penalty(
-        logits, histories, [penalty, 1.0], channel=0
+    MossTTSLocalModelRunner._apply_audio_repetition_penalty_mask(
+        logits, token_presence, torch.tensor([penalty, 1.0])
     )
     torch.testing.assert_close(logits, expected)
 
     # Negative scores multiply.
     logits2 = torch.tensor([[-2.0, 1.0]], dtype=torch.float32)
-    MossTTSLocalModelRunner._apply_audio_repetition_penalty(
-        logits2, [torch.tensor([[0]], dtype=torch.long)], [2.0], channel=0
+    MossTTSLocalModelRunner._apply_audio_repetition_penalty_mask(
+        logits2, torch.tensor([[True, False]]), torch.tensor([2.0])
     )
     torch.testing.assert_close(
         logits2, torch.tensor([[-4.0, 1.0]], dtype=torch.float32)
@@ -435,69 +440,30 @@ def test_row_radix_token_ids_hash_rows_and_keep_eos():
     assert all(0 <= int(v) < 151936 for v in out)
 
 
-def test_gather_rep_histories_excludes_prompt_and_inactive_rows():
-    from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
-
-    class _Data:
-        def __init__(self, rows):
-            self.output_rows = rows
-
-    row = torch.cat([torch.tensor([151656]), torch.arange(N_VQ, dtype=torch.long)])
-    active = _Data([row, row + 0])
-    inactive = _Data([row])
-    empty = _Data([])
-
-    histories = MossTTSLocalModelRunner._gather_rep_histories(
-        [active, inactive, empty], [1.5, 1.0, 1.5], torch.device("cpu")
-    )
-    assert histories is not None
-    assert histories[0].shape == (2, N_VQ)  # generated frames only, channel cols
-    assert histories[1] is None  # unit penalty -> skipped
-    assert histories[2] is None  # no frames yet
-    # All penalties at 1.0 -> no history gathering at all.
-    assert (
-        MossTTSLocalModelRunner._gather_rep_histories(
-            [active], [1.0], torch.device("cpu")
-        )
-        is None
-    )
-
-
-def test_stage_repetition_penalty_state_only_materializes_slow_path_data():
+def test_audio_history_presence_mask_excludes_prompt_rows():
     from types import SimpleNamespace
 
-    from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
+    from sglang_omni.models.moss_tts_local.state_pool import MossTTSLocalDecodeStatePool
 
-    no_penalty = [
-        SimpleNamespace(
-            data=SimpleNamespace(audio_repetition_penalty=1.0, output_rows=[])
-        )
-    ]
-    forward_batch = SimpleNamespace()
-
-    MossTTSLocalModelRunner._stage_repetition_penalty_state(forward_batch, no_penalty)
-
-    assert forward_batch.moss_rep_datas is None
-    assert forward_batch.moss_rep_penalties is None
-
-    active = [
-        SimpleNamespace(
-            data=SimpleNamespace(audio_repetition_penalty=1.0, output_rows=[])
+    model = SimpleNamespace(
+        _decode_input_embedding=SimpleNamespace(
+            weight=torch.zeros(2, 4, dtype=torch.bfloat16)
         ),
-        SimpleNamespace(
-            data=SimpleNamespace(audio_repetition_penalty=1.2, output_rows=[])
-        ),
-    ]
+        config=SimpleNamespace(n_vq=N_VQ, audio_vocab_size=1024),
+    )
+    pool = MossTTSLocalDecodeStatePool(model)
+    row = pool.acquire_row("rid")
+    prompt_row = torch.cat(
+        [torch.tensor([151656]), torch.full((N_VQ,), 99, dtype=torch.long)]
+    )
+    generated_row = torch.cat(
+        [torch.tensor([151656]), torch.arange(N_VQ, dtype=torch.long)]
+    )
 
-    MossTTSLocalModelRunner._stage_repetition_penalty_state(forward_batch, active)
+    pool.update_audio_history(torch.tensor([row]), generated_row.reshape(1, -1))
 
-    assert [
-        float(d.audio_repetition_penalty) for d in forward_batch.moss_rep_datas
-    ] == [
-        1.0,
-        1.2,
-    ]
-    assert forward_batch.moss_rep_penalties == [1.0, 1.2]
+    assert bool(pool.audio_token_presence[row, 0, 0])
+    assert not bool(pool.audio_token_presence[row, 0, int(prompt_row[1])])
 
 
 def test_build_generation_kwargs_precedence():

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -1539,21 +1539,27 @@ def test_chunked_rows_do_not_advance_sampling_steps():
             output_rows=[],
         )
 
+    def _pool_sampling_steps(runner, rid):
+        pool = runner.model._state_pool
+        row = pool.row_for(rid)
+        assert row is not None
+        return int(pool.sampling_steps[row])
+
     # Single-shot prefill: the only chunk is final, advances sampling_steps to 1.
     r = _make_runner()
     single = types.SimpleNamespace(request_id="r", data=_data(is_chunked=0))
-    r._run_frame_decode(_result(), [single])
-    assert single.data.sampling_steps == 1
+    r._run_frame_decode(_result(), types.SimpleNamespace(), [single])
+    assert _pool_sampling_steps(r, "r") == 1
 
     # Three-chunk prefill on the same request: the mid chunks do not advance, the
     # final chunk does, so the end state matches the single-shot path.
     r = _make_runner()
     data = _data(is_chunked=2)
     sched = types.SimpleNamespace(request_id="r", data=data)
-    for is_chunked in (2, 1, 0):
+    for is_chunked, expected_steps in ((2, 0), (1, 0), (0, 1)):
         data.req.is_chunked = is_chunked
-        r._run_frame_decode(_result(), [sched])
-    assert data.sampling_steps == 1
+        r._run_frame_decode(_result(), types.SimpleNamespace(), [sched])
+        assert _pool_sampling_steps(r, "r") == expected_steps
 
 
 def test_async_decode_cli_accepts_moss_local():

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -463,6 +463,43 @@ def test_gather_rep_histories_excludes_prompt_and_inactive_rows():
     )
 
 
+def test_stage_repetition_penalty_state_only_materializes_slow_path_data():
+    from types import SimpleNamespace
+
+    from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
+
+    no_penalty = [
+        SimpleNamespace(
+            data=SimpleNamespace(audio_repetition_penalty=1.0, output_rows=[])
+        )
+    ]
+    forward_batch = SimpleNamespace()
+
+    MossTTSLocalModelRunner._stage_repetition_penalty_state(forward_batch, no_penalty)
+
+    assert forward_batch.moss_rep_datas is None
+    assert forward_batch.moss_rep_penalties is None
+
+    active = [
+        SimpleNamespace(
+            data=SimpleNamespace(audio_repetition_penalty=1.0, output_rows=[])
+        ),
+        SimpleNamespace(
+            data=SimpleNamespace(audio_repetition_penalty=1.2, output_rows=[])
+        ),
+    ]
+
+    MossTTSLocalModelRunner._stage_repetition_penalty_state(forward_batch, active)
+
+    assert [
+        float(d.audio_repetition_penalty) for d in forward_batch.moss_rep_datas
+    ] == [
+        1.0,
+        1.2,
+    ]
+    assert forward_batch.moss_rep_penalties == [1.0, 1.2]
+
+
 def test_build_generation_kwargs_precedence():
     # Direct field names apply tts_params-then-params (params wins, matching
     # the MOSS Delay semantics); both override the explicit generic aliases.

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -196,6 +196,20 @@ def test_commit_generation_step_updates_active_row():
     assert int(pool.generation_steps[row]) == 7
 
 
+def test_commit_generation_steps_updates_active_rows():
+    pool = MossTTSLocalDecodeStatePool(_model())
+    row_a = pool.acquire_row("a")
+    row_b = pool.acquire_row("b")
+
+    pool.commit_generation_steps(
+        torch.tensor([row_a, row_b], dtype=torch.long),
+        torch.tensor([7, 9], dtype=torch.long),
+    )
+
+    assert int(pool.generation_steps[row_a]) == 7
+    assert int(pool.generation_steps[row_b]) == 9
+
+
 def test_reset_for_refill_clears_active_row():
     pool = MossTTSLocalDecodeStatePool(_model())
     row = pool.acquire_row("a")

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 
 import torch
 
+from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
 from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
 from sglang_omni.models.moss_tts_local.request_builders import (
     MossTTSLocalSGLangRequestData,
@@ -56,12 +57,12 @@ def test_pool_dims_derive_from_embedding_weight():
     assert pool.hidden_size == _HIDDEN
     assert pool.feedback_embeds.shape == (5, _HIDDEN)
     assert pool.feedback_embeds.dtype == torch.bfloat16
-    for name in ("text_temp", "text_top_p", "audio_temp", "audio_top_p"):
-        assert getattr(pool, name).shape == (5,)
-        assert getattr(pool, name).dtype == torch.float32
-    for name in ("text_top_k", "audio_top_k", "seeds"):
-        assert getattr(pool, name).shape == (5,)
-        assert getattr(pool, name).dtype == torch.int64
+    for field in (pool.text_temp, pool.text_top_p, pool.audio_temp, pool.audio_top_p):
+        assert field.shape == (5,)
+        assert field.dtype == torch.float32
+    for field in (pool.text_top_k, pool.audio_top_k, pool.seeds):
+        assert field.shape == (5,)
+        assert field.dtype == torch.int64
     assert pool.generation_steps.shape == (5,)
     assert pool.generation_steps.dtype == torch.int64
     assert pool.audio_repetition_penalty.shape == (5,)
@@ -142,18 +143,18 @@ def test_reset_row_zeroes_all_fields():
     pool.feedback_embeds[row].fill_(2.0)
     pool.reset_row(row)
     assert torch.all(pool.feedback_embeds[row] == 0)
-    for name in (
-        "text_temp",
-        "text_top_p",
-        "audio_temp",
-        "audio_top_p",
-        "text_top_k",
-        "audio_top_k",
-        "seeds",
-        "generation_steps",
-        "audio_repetition_penalty",
+    for field in (
+        pool.text_temp,
+        pool.text_top_p,
+        pool.audio_temp,
+        pool.audio_top_p,
+        pool.text_top_k,
+        pool.audio_top_k,
+        pool.seeds,
+        pool.generation_steps,
+        pool.audio_repetition_penalty,
     ):
-        assert getattr(pool, name)[row] == 0
+        assert field[row] == 0
     assert int(torch.count_nonzero(pool.audio_token_presence[row])) == 0
 
 
@@ -499,7 +500,9 @@ def test_collect_frame_reads_generation_steps_from_pool():
     assert torch.equal(captured["base_positions"], torch.tensor([4 * 13]))
 
 
-def test_collect_frame_uses_eager_path_when_audio_repetition_penalty_active():
+def test_collect_frame_uses_eager_path_when_audio_repetition_penalty_active(
+    monkeypatch,
+):
     hidden_size = 4
     weight = torch.zeros(2, hidden_size, dtype=torch.bfloat16)
     embedding = SimpleNamespace(weight=weight)
@@ -518,17 +521,35 @@ def test_collect_frame_uses_eager_path_when_audio_repetition_penalty_active():
     pool = MossTTSLocalDecodeStatePool(model)
     model._state_pool = pool
     called = {"eager": False}
+    sampled_audio_logits = []
+
+    def sample_tokens(logits, *, temperature, top_p, top_k, seeds, positions):
+        del temperature, top_p, top_k, seeds, positions
+        sampled_audio_logits.append(logits.detach().clone())
+        return torch.argmax(logits, dim=-1)
+
+    monkeypatch.setattr(
+        MossTTSModelRunner,
+        "_sample_tokens",
+        staticmethod(sample_tokens),
+    )
 
     def decode_frame_graphed(*args, **kwargs):
         del args, kwargs
         raise AssertionError("penalty-enabled frames must not use graph replay")
 
     def decode_frame(hidden_states, *, sample_text, sample_audio):
-        del hidden_states, sample_text, sample_audio
+        del hidden_states, sample_text
         called["eager"] = True
+        audio_logits = torch.zeros(1, 1024, dtype=torch.float32)
+        audio_logits[0, 7] = 10.0
+        audio_logits[0, 8] = 6.0
+        channel0 = sample_audio(audio_logits, 0)
+        codes = torch.full((1, 12), 99, dtype=torch.long)
+        codes[:, 0] = channel0
         return (
             torch.zeros(1, dtype=torch.long),
-            torch.full((1, 12), 7, dtype=torch.long),
+            codes,
         )
 
     model.decode_frame_graphed = decode_frame_graphed
@@ -549,10 +570,13 @@ def test_collect_frame_uses_eager_path_when_audio_repetition_penalty_active():
         audio_top_k=50,
         sampling_seed=0,
         generation_steps=0,
-        audio_repetition_penalty=1.2,
+        audio_repetition_penalty=2.0,
         output_rows=[],
     )
     request = SimpleNamespace(request_id="rid", data=data)
+    row = pool.acquire_row("rid")
+    pool.ensure_params(row, "rid", data)
+    pool.audio_token_presence[row, 0, 7] = True
     result = SimpleNamespace(
         logits_output=SimpleNamespace(hidden_states=torch.zeros(1, hidden_size))
     )
@@ -560,9 +584,13 @@ def test_collect_frame_uses_eager_path_when_audio_repetition_penalty_active():
     runner._collect_frame(result, SimpleNamespace(), SimpleNamespace(), [request])
 
     assert called["eager"] is True
-    row = pool.row_for("rid")
-    assert row is not None
+    assert len(sampled_audio_logits) == 1
+    assert sampled_audio_logits[0][0, 7].item() == 5.0
+    assert sampled_audio_logits[0][0, 8].item() == 6.0
+    assert pool.row_for("rid") == row
     assert bool(pool.audio_token_presence[row, 0, 7])
+    assert bool(pool.audio_token_presence[row, 0, 8])
+    assert not bool(pool.audio_token_presence[row, 1, 8])
 
 
 def test_cached_pool_rows_drive_collect_and_batched_step_commit():

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -58,6 +58,8 @@ def test_pool_dims_derive_from_embedding_weight():
     for name in ("text_top_k", "audio_top_k", "seeds"):
         assert getattr(pool, name).shape == (5,)
         assert getattr(pool, name).dtype == torch.int64
+    assert pool.generation_steps.shape == (5,)
+    assert pool.generation_steps.dtype == torch.int64
 
 
 def test_acquire_is_idempotent_by_rid():
@@ -113,12 +115,14 @@ def test_release_resets_row_fields():
     pool = MossTTSLocalDecodeStatePool(_model())
     row = pool.acquire_row("a")
     pool.write_params(row, _params(seed=123))
+    pool.commit_generation_step("a", 3)
     pool.feedback_embeds[row].fill_(1.0)
     pool.release_row("a")
     assert torch.all(pool.feedback_embeds[row] == 0)
     assert pool.text_temp[row] == 0.0
     assert pool.audio_top_k[row] == 0
     assert pool.seeds[row] == 0
+    assert pool.generation_steps[row] == 0
 
 
 def test_reset_row_zeroes_all_fields():
@@ -136,6 +140,7 @@ def test_reset_row_zeroes_all_fields():
         "text_top_k",
         "audio_top_k",
         "seeds",
+        "generation_steps",
     ):
         assert getattr(pool, name)[row] == 0
 
@@ -181,15 +186,27 @@ def test_row_for_returns_none_when_unheld():
     assert pool.row_for("a") == row
 
 
+def test_commit_generation_step_updates_active_row():
+    pool = MossTTSLocalDecodeStatePool(_model())
+    row = pool.acquire_row("a")
+
+    pool.commit_generation_step("a", 7)
+    pool.commit_generation_step("ghost", 3)
+
+    assert int(pool.generation_steps[row]) == 7
+
+
 def test_reset_for_refill_clears_active_row():
     pool = MossTTSLocalDecodeStatePool(_model())
     row = pool.acquire_row("a")
     pool.ensure_params(row, "a", _params(seed=1))
+    pool.commit_generation_step("a", 4)
     pool.feedback_embeds[row] = 1.0
 
-    assert pool.reset_for_refill("a") is True
+    assert pool.reset_for_refill("a", generation_steps=4) is True
     assert int(pool.seeds[row]) == 0
     assert int(torch.count_nonzero(pool.feedback_embeds[row])) == 0
+    assert int(pool.generation_steps[row]) == 4
     # params were invalidated, so the next ensure_params re-writes them.
     pool.ensure_params(row, "a", _params(seed=2))
     assert int(pool.seeds[row]) == 2
@@ -204,6 +221,21 @@ def test_reset_for_refill_is_noop_for_unheld_rid():
     # the held row and its write-once flag are untouched.
     pool.ensure_params(row, "a", _params(seed=9))
     assert int(pool.seeds[row]) == 1
+
+
+def test_prepare_active_rows_gathers_rows_and_params():
+    pool = MossTTSLocalDecodeStatePool(_model(max_running_requests=2))
+    reqs = [
+        SimpleNamespace(request_id="a", data=_params(seed=11)),
+        SimpleNamespace(request_id="b", data=_params(seed=22)),
+    ]
+
+    row_t, rows = pool.prepare_active_rows(reqs)
+
+    assert row_t.dtype == torch.long
+    assert row_t.device == pool.device
+    assert rows == [pool.row_for("a"), pool.row_for("b")]
+    assert torch.equal(pool.seeds[row_t], torch.tensor([11, 22], dtype=torch.long))
 
 
 def test_journal_holds_fields():
@@ -232,8 +264,8 @@ def test_feedback_gather_equals_old_popleft():
     runner.model = model
     forward_batch = SimpleNamespace(input_ids=torch.full((2,), -1, dtype=torch.long))
     requests = [
-        SimpleNamespace(request_id="a", data=SimpleNamespace()),
-        SimpleNamespace(request_id="b", data=SimpleNamespace()),
+        SimpleNamespace(request_id="a", data=_params(seed=1)),
+        SimpleNamespace(request_id="b", data=_params(seed=2)),
     ]
 
     runner._write_decode_input_embedding(forward_batch, requests)
@@ -249,7 +281,7 @@ def test_fresh_row_zeros_feedback():
     runner = object.__new__(MossTTSLocalModelRunner)
     runner.model = model
     forward_batch = SimpleNamespace(input_ids=torch.full((1,), -1, dtype=torch.long))
-    requests = [SimpleNamespace(request_id="fresh", data=SimpleNamespace())]
+    requests = [SimpleNamespace(request_id="fresh", data=_params(seed=1))]
 
     runner._write_decode_input_embedding(forward_batch, requests)
 
@@ -327,6 +359,103 @@ def test_double_collect_overwrites_feedback():
     )
 
 
+def test_collect_frame_reads_generation_steps_from_pool():
+    hidden_size = 4
+    weight = torch.zeros(2, hidden_size, dtype=torch.bfloat16)
+    embedding = SimpleNamespace(weight=weight)
+    model = SimpleNamespace(
+        _decode_input_embedding=embedding,
+        _state_pool=None,
+        config=SimpleNamespace(
+            n_vq=12,
+            audio_assistant_slot_token_id=1000,
+            audio_end_token_id=1001,
+        ),
+        frame_graph_max_bs=1,
+        device=torch.device("cpu"),
+    )
+    pool = MossTTSLocalDecodeStatePool(model)
+    model._state_pool = pool
+    captured = {}
+
+    def decode_frame_graphed(hidden_states, **kwargs):
+        del hidden_states
+        captured["base_positions"] = kwargs["base_positions"].detach().clone()
+        return (
+            torch.zeros(1, dtype=torch.long),
+            torch.full((1, 12), 7, dtype=torch.long),
+            torch.ones((1, hidden_size), dtype=torch.bfloat16),
+        )
+
+    model.decode_frame_graphed = decode_frame_graphed
+
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    data = SimpleNamespace(
+        req=SimpleNamespace(is_chunked=0),
+        text_temperature=1.0,
+        text_top_p=1.0,
+        text_top_k=50,
+        audio_temperature=1.0,
+        audio_top_p=1.0,
+        audio_top_k=50,
+        sampling_seed=0,
+        generation_steps=99,
+        audio_repetition_penalty=1.0,
+        output_rows=[],
+    )
+    request = SimpleNamespace(request_id="rid", data=data)
+    row = pool.acquire_row("rid")
+    pool.ensure_params(row, "rid", data)
+    pool.commit_generation_step("rid", 4)
+    result = SimpleNamespace(
+        logits_output=SimpleNamespace(hidden_states=torch.zeros(1, hidden_size))
+    )
+
+    runner._collect_frame(result, SimpleNamespace(), SimpleNamespace(), [request])
+
+    assert torch.equal(captured["base_positions"], torch.tensor([4 * 13]))
+
+
+def test_finalize_commits_generation_steps_to_pool():
+    model = _model(max_running_requests=2)
+    pool = MossTTSLocalDecodeStatePool(model)
+    model._state_pool = pool
+    model.config = SimpleNamespace(audio_end_token_id=1001)
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    runner.output_processor = SimpleNamespace(
+        process=lambda batch_result, scheduler_output: {
+            req.request_id: SimpleNamespace(data=1000, extra=None)
+            for req in scheduler_output.requests
+        }
+    )
+    data = SimpleNamespace(
+        req=SimpleNamespace(is_chunked=0),
+        generation_steps=0,
+        extra_model_outputs={},
+        output_rows=[],
+    )
+    sched_req = SimpleNamespace(request_id="rid", data=data)
+    row = pool.acquire_row("rid")
+
+    runner._finalize(
+        SimpleNamespace(
+            next_token_ids=torch.tensor([0]),
+            logits_output=None,
+            can_run_cuda_graph=False,
+            moss_journal=None,
+        ),
+        SimpleNamespace(),
+        SimpleNamespace(is_prefill_only=False, output_ids=None),
+        SimpleNamespace(seq_lens=[1], input_ids=torch.zeros(1, dtype=torch.long)),
+        SimpleNamespace(requests=[sched_req]),
+    )
+
+    assert data.generation_steps == 1
+    assert int(pool.generation_steps[row]) == 1
+
+
 def test_resume_reprefill_overwrites_stranded_feedback():
     """Retraction resume wipes the stranded feedback row and forces a param
     re-write — the pool-row replacement for the old
@@ -344,6 +473,7 @@ def test_resume_reprefill_overwrites_stranded_feedback():
 
     row = pool.acquire_row("a")
     pool.ensure_params(row, "a", _params(seed=1))
+    pool.commit_generation_step("a", 3)
     # Feedback stranded by the retraction (must be wiped by the resume).
     pool.feedback_embeds[row].fill_(5.0)
 
@@ -356,6 +486,7 @@ def test_resume_reprefill_overwrites_stranded_feedback():
         req=SimpleNamespace(extend_input_len=5, prefix_indices=[], rid="a"),
         prompt_rows=prompt_rows,
         output_rows=generated,
+        generation_steps=3,
     )
     sched_req = SimpleNamespace(request_id="a", data=data)
 
@@ -366,6 +497,7 @@ def test_resume_reprefill_overwrites_stranded_feedback():
     runner._build_prefill_input_embeds(forward_batch, [sched_req])
 
     assert torch.all(pool.feedback_embeds[row] == 0), "stranded feedback must be wiped"
+    assert int(pool.generation_steps[row]) == 3, "resume must preserve sample position"
     pool.ensure_params(row, "a", _params(seed=2))
     assert int(pool.seeds[row]) == 2, "params must be re-written on resume"
 

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -65,6 +65,8 @@ def test_pool_dims_derive_from_embedding_weight():
         assert field.dtype == torch.int64
     assert pool.generation_steps.shape == (5,)
     assert pool.generation_steps.dtype == torch.int64
+    assert pool.sampling_steps.shape == (5,)
+    assert pool.sampling_steps.dtype == torch.int64
     assert pool.audio_repetition_penalty.shape == (5,)
     assert pool.audio_repetition_penalty.dtype == torch.float32
     assert pool.audio_token_presence.shape == (5, 12, 1024)
@@ -132,6 +134,7 @@ def test_release_resets_row_fields():
     assert pool.audio_top_k[row] == 0
     assert pool.seeds[row] == 0
     assert pool.generation_steps[row] == 0
+    assert pool.sampling_steps[row] == 0
     assert pool.audio_repetition_penalty[row] == 0.0
     assert int(torch.count_nonzero(pool.audio_token_presence[row])) == 0
 
@@ -152,6 +155,7 @@ def test_reset_row_zeroes_all_fields():
         pool.audio_top_k,
         pool.seeds,
         pool.generation_steps,
+        pool.sampling_steps,
         pool.audio_repetition_penalty,
     ):
         assert field[row] == 0
@@ -212,6 +216,7 @@ def test_commit_generation_step_updates_active_row():
     pool.commit_generation_step("ghost", 3)
 
     assert int(pool.generation_steps[row]) == 7
+    assert int(pool.sampling_steps[row]) == 7
 
 
 def test_commit_generation_steps_updates_active_rows():
@@ -226,6 +231,8 @@ def test_commit_generation_steps_updates_active_rows():
 
     assert int(pool.generation_steps[row_a]) == 7
     assert int(pool.generation_steps[row_b]) == 9
+    assert int(pool.sampling_steps[row_a]) == 7
+    assert int(pool.sampling_steps[row_b]) == 9
 
 
 def test_reset_for_refill_clears_active_row():
@@ -241,6 +248,7 @@ def test_reset_for_refill_clears_active_row():
     assert int(torch.count_nonzero(pool.feedback_embeds[row])) == 0
     assert int(torch.count_nonzero(pool.audio_token_presence[row])) == 0
     assert int(pool.generation_steps[row]) == 4
+    assert int(pool.sampling_steps[row]) == 4
     # params were invalidated, so the next ensure_params re-writes them.
     pool.ensure_params(row, "a", _params(seed=2))
     assert int(pool.seeds[row]) == 2
@@ -498,6 +506,68 @@ def test_collect_frame_reads_generation_steps_from_pool():
     runner._collect_frame(result, SimpleNamespace(), SimpleNamespace(), [request])
 
     assert torch.equal(captured["base_positions"], torch.tensor([4 * 13]))
+    assert int(pool.sampling_steps[row]) == 5
+
+
+def test_pool_sampling_position_leads_unresolved_lookahead_launches():
+    hidden_size = 4
+    weight = torch.zeros(2, hidden_size, dtype=torch.bfloat16)
+    embedding = SimpleNamespace(weight=weight)
+    model = SimpleNamespace(
+        _decode_input_embedding=embedding,
+        _state_pool=None,
+        config=SimpleNamespace(
+            n_vq=12,
+            audio_assistant_slot_token_id=1000,
+            audio_end_token_id=1001,
+        ),
+        frame_graph_max_bs=1,
+        device=torch.device("cpu"),
+    )
+    pool = MossTTSLocalDecodeStatePool(model)
+    model._state_pool = pool
+    captured = []
+
+    def decode_frame_graphed(hidden_states, **kwargs):
+        del hidden_states
+        captured.append(kwargs["base_positions"].detach().clone())
+        return (
+            torch.zeros(1, dtype=torch.long),
+            torch.full((1, 12), 7, dtype=torch.long),
+            torch.ones((1, hidden_size), dtype=torch.bfloat16),
+        )
+
+    model.decode_frame_graphed = decode_frame_graphed
+
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    data = SimpleNamespace(
+        req=SimpleNamespace(is_chunked=0),
+        text_temperature=1.0,
+        text_top_p=1.0,
+        text_top_k=50,
+        audio_temperature=1.0,
+        audio_top_p=1.0,
+        audio_top_k=50,
+        sampling_seed=0,
+        generation_steps=0,
+        audio_repetition_penalty=1.0,
+        output_rows=[],
+    )
+    request = SimpleNamespace(request_id="rid", data=data)
+    result = SimpleNamespace(
+        logits_output=SimpleNamespace(hidden_states=torch.zeros(1, hidden_size))
+    )
+
+    runner._collect_frame(result, SimpleNamespace(), SimpleNamespace(), [request])
+    runner._collect_frame(result, SimpleNamespace(), SimpleNamespace(), [request])
+
+    row = pool.row_for("rid")
+    assert row is not None
+    assert torch.equal(captured[0], torch.tensor([0]))
+    assert torch.equal(captured[1], torch.tensor([13]))
+    assert int(pool.generation_steps[row]) == 0
+    assert int(pool.sampling_steps[row]) == 2
 
 
 def test_collect_frame_uses_eager_path_when_audio_repetition_penalty_active(
@@ -690,6 +760,8 @@ def test_cached_pool_rows_drive_collect_and_batched_step_commit():
     assert result.moss_journal.pool_rows == [row_a, row_b]
     assert torch.equal(pool.feedback_embeds[row_a], torch.full((4,), 3).bfloat16())
     assert torch.equal(pool.feedback_embeds[row_b], torch.full((4,), 5).bfloat16())
+    assert int(pool.sampling_steps[row_a]) == 5
+    assert int(pool.sampling_steps[row_b]) == 9
 
     runner._finalize(
         result,
@@ -926,7 +998,8 @@ def test_resume_resets_sampling_steps_to_generation_steps():
     )
     pool = MossTTSLocalDecodeStatePool(model)
     model._state_pool = pool
-    pool.acquire_row("a")
+    row = pool.acquire_row("a")
+    pool.sampling_steps[row] = 99
 
     width = 13
     data = SimpleNamespace(
@@ -947,6 +1020,7 @@ def test_resume_resets_sampling_steps_to_generation_steps():
     assert (
         data.sampling_steps == 3
     ), "resume must reset sampling_steps to generation_steps"
+    assert int(pool.sampling_steps[row]) == 3
 
 
 def test_resume_with_empty_output_rows_still_resets_sampling_steps():
@@ -963,7 +1037,8 @@ def test_resume_with_empty_output_rows_still_resets_sampling_steps():
     )
     pool = MossTTSLocalDecodeStatePool(model)
     model._state_pool = pool
-    pool.acquire_row("a")  # launched once, so it holds a row
+    row = pool.acquire_row("a")  # launched once, so it holds a row
+    pool.sampling_steps[row] = 1
 
     width = 13
     data = SimpleNamespace(
@@ -982,6 +1057,7 @@ def test_resume_with_empty_output_rows_still_resets_sampling_steps():
     runner._build_prefill_input_embeds(forward_batch, [sched_req])
 
     assert data.sampling_steps == 0, "empty-output_rows resume must still reset"
+    assert int(pool.sampling_steps[row]) == 0
     # The next collect then samples the resumed frame at position 0, not stale 1.
     assert MossTTSLocalModelRunner._advance_sampling_position(data) == 0
     assert data.sampling_steps == 1

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -565,6 +565,118 @@ def test_collect_frame_uses_eager_path_when_audio_repetition_penalty_active():
     assert bool(pool.audio_token_presence[row, 0, 7])
 
 
+def test_cached_pool_rows_drive_collect_and_batched_step_commit():
+    hidden_size = 4
+    weight = torch.zeros(4, hidden_size, dtype=torch.bfloat16)
+    embedding = SimpleNamespace(weight=weight)
+    model = SimpleNamespace(
+        _decode_input_embedding=embedding,
+        _state_pool=None,
+        config=SimpleNamespace(
+            n_vq=12,
+            audio_vocab_size=1024,
+            audio_assistant_slot_token_id=1000,
+            audio_end_token_id=1001,
+        ),
+        frame_graph_max_bs=4,
+        device=torch.device("cpu"),
+    )
+    pool = MossTTSLocalDecodeStatePool(model)
+    model._state_pool = pool
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    runner.output_processor = SimpleNamespace(
+        process=lambda batch_result, scheduler_output: {
+            req.request_id: SimpleNamespace(data=1000, extra=None)
+            for req in scheduler_output.requests
+        }
+    )
+
+    def data(step, seed):
+        return SimpleNamespace(
+            req=SimpleNamespace(is_chunked=0),
+            text_temperature=1.0,
+            text_top_p=1.0,
+            text_top_k=50,
+            audio_temperature=1.0,
+            audio_top_p=1.0,
+            audio_top_k=50,
+            sampling_seed=seed,
+            generation_steps=step,
+            audio_repetition_penalty=1.0,
+            output_rows=[],
+            extra_model_outputs={},
+        )
+
+    requests = [
+        SimpleNamespace(request_id="a", data=data(step=4, seed=11)),
+        SimpleNamespace(request_id="b", data=data(step=8, seed=22)),
+    ]
+
+    forward_batch = SimpleNamespace(input_ids=torch.full((2,), -1, dtype=torch.long))
+    runner._write_decode_input_embedding(forward_batch, requests)
+
+    row_t = forward_batch.moss_pool_row_t.clone()
+    row_a, row_b = int(row_t[0]), int(row_t[1])
+    assert [row_a, row_b] != [0, 1]
+    assert forward_batch.moss_pool_rows == [row_a, row_b]
+    assert torch.equal(forward_batch.input_ids, torch.tensor([0, 1]))
+
+    def fail_prepare_active_rows(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("collect path must reuse cached moss_pool_row_t")
+
+    pool.prepare_active_rows = fail_prepare_active_rows
+    pool.commit_generation_steps(row_t, torch.tensor([4, 8], dtype=torch.long))
+    captured = {}
+
+    def decode_frame_graphed(hidden_states, **kwargs):
+        del hidden_states
+        captured["base_positions"] = kwargs["base_positions"].detach().clone()
+        return (
+            torch.zeros(2, dtype=torch.long),
+            torch.stack(
+                [
+                    torch.full((12,), 7, dtype=torch.long),
+                    torch.full((12,), 9, dtype=torch.long),
+                ],
+                dim=0,
+            ),
+            torch.tensor(
+                [[3, 3, 3, 3], [5, 5, 5, 5]],
+                dtype=torch.bfloat16,
+            ),
+        )
+
+    model.decode_frame_graphed = decode_frame_graphed
+    result = SimpleNamespace(
+        logits_output=SimpleNamespace(hidden_states=torch.zeros(2, hidden_size)),
+        can_run_cuda_graph=False,
+    )
+    schedule_batch = SimpleNamespace(is_prefill_only=False, output_ids=None)
+    scheduler_output = SimpleNamespace(requests=requests)
+
+    runner._collect_frame(result, forward_batch, schedule_batch, requests)
+
+    assert torch.equal(captured["base_positions"], torch.tensor([4 * 13, 8 * 13]))
+    assert result.moss_journal.pool_rows == [row_a, row_b]
+    assert torch.equal(pool.feedback_embeds[row_a], torch.full((4,), 3).bfloat16())
+    assert torch.equal(pool.feedback_embeds[row_b], torch.full((4,), 5).bfloat16())
+
+    runner._finalize(
+        result,
+        forward_batch,
+        schedule_batch,
+        SimpleNamespace(seq_lens=[1, 1], input_ids=torch.zeros(2, dtype=torch.long)),
+        scheduler_output,
+    )
+
+    assert requests[0].data.generation_steps == 5
+    assert requests[1].data.generation_steps == 9
+    assert int(pool.generation_steps[row_a]) == 5
+    assert int(pool.generation_steps[row_b]) == 9
+
+
 def test_finalize_commits_generation_steps_to_pool():
     model = _model(max_running_requests=2)
     pool = MossTTSLocalDecodeStatePool(model)

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -29,10 +29,13 @@ def _model(max_running_requests: int = 4) -> SimpleNamespace:
     """Fake model exposing only what the pool reads."""
     weight = torch.zeros(max_running_requests, _HIDDEN, dtype=torch.bfloat16)
     embedding = SimpleNamespace(weight=weight)
-    return SimpleNamespace(_decode_input_embedding=embedding)
+    return SimpleNamespace(
+        _decode_input_embedding=embedding,
+        config=SimpleNamespace(n_vq=12, audio_vocab_size=1024),
+    )
 
 
-def _params(seed: int = 7) -> SimpleNamespace:
+def _params(seed: int = 7, audio_repetition_penalty: float = 1.0) -> SimpleNamespace:
     return SimpleNamespace(
         text_temperature=0.5,
         text_top_p=0.9,
@@ -41,6 +44,7 @@ def _params(seed: int = 7) -> SimpleNamespace:
         audio_top_p=0.8,
         audio_top_k=25,
         sampling_seed=seed,
+        audio_repetition_penalty=audio_repetition_penalty,
     )
 
 
@@ -60,6 +64,10 @@ def test_pool_dims_derive_from_embedding_weight():
         assert getattr(pool, name).dtype == torch.int64
     assert pool.generation_steps.shape == (5,)
     assert pool.generation_steps.dtype == torch.int64
+    assert pool.audio_repetition_penalty.shape == (5,)
+    assert pool.audio_repetition_penalty.dtype == torch.float32
+    assert pool.audio_token_presence.shape == (5, 12, 1024)
+    assert pool.audio_token_presence.dtype == torch.bool
 
 
 def test_acquire_is_idempotent_by_rid():
@@ -123,6 +131,8 @@ def test_release_resets_row_fields():
     assert pool.audio_top_k[row] == 0
     assert pool.seeds[row] == 0
     assert pool.generation_steps[row] == 0
+    assert pool.audio_repetition_penalty[row] == 0.0
+    assert int(torch.count_nonzero(pool.audio_token_presence[row])) == 0
 
 
 def test_reset_row_zeroes_all_fields():
@@ -141,14 +151,16 @@ def test_reset_row_zeroes_all_fields():
         "audio_top_k",
         "seeds",
         "generation_steps",
+        "audio_repetition_penalty",
     ):
         assert getattr(pool, name)[row] == 0
+    assert int(torch.count_nonzero(pool.audio_token_presence[row])) == 0
 
 
 def test_write_params_writes_request_static_fields():
     pool = MossTTSLocalDecodeStatePool(_model())
     row = pool.acquire_row("a")
-    pool.write_params(row, _params(seed=555))
+    pool.write_params(row, _params(seed=555, audio_repetition_penalty=1.25))
     assert pool.text_temp[row].item() == torch.tensor(0.5, dtype=torch.float32).item()
     assert pool.text_top_p[row].item() == torch.tensor(0.9, dtype=torch.float32).item()
     assert pool.audio_temp[row].item() == torch.tensor(1.7, dtype=torch.float32).item()
@@ -156,6 +168,11 @@ def test_write_params_writes_request_static_fields():
     assert int(pool.text_top_k[row]) == 40
     assert int(pool.audio_top_k[row]) == 25
     assert int(pool.seeds[row]) == 555
+    assert (
+        pool.audio_repetition_penalty[row].item()
+        == torch.tensor(1.25, dtype=torch.float32).item()
+    )
+    assert pool.rows_have_audio_repetition_penalty([row]) is True
 
 
 def test_write_params_does_not_touch_other_rows():
@@ -216,10 +233,12 @@ def test_reset_for_refill_clears_active_row():
     pool.ensure_params(row, "a", _params(seed=1))
     pool.commit_generation_step("a", 4)
     pool.feedback_embeds[row] = 1.0
+    pool.audio_token_presence[row, 0, 7] = True
 
     assert pool.reset_for_refill("a", generation_steps=4) is True
     assert int(pool.seeds[row]) == 0
     assert int(torch.count_nonzero(pool.feedback_embeds[row])) == 0
+    assert int(torch.count_nonzero(pool.audio_token_presence[row])) == 0
     assert int(pool.generation_steps[row]) == 4
     # params were invalidated, so the next ensure_params re-writes them.
     pool.ensure_params(row, "a", _params(seed=2))
@@ -244,12 +263,61 @@ def test_prepare_active_rows_gathers_rows_and_params():
         SimpleNamespace(request_id="b", data=_params(seed=22)),
     ]
 
-    row_t, rows = pool.prepare_active_rows(reqs)
+    row_t, rows, has_audio_repetition_penalty = pool.prepare_active_rows(reqs)
 
     assert row_t.dtype == torch.long
     assert row_t.device == pool.device
     assert rows == [pool.row_for("a"), pool.row_for("b")]
     assert torch.equal(pool.seeds[row_t], torch.tensor([11, 22], dtype=torch.long))
+    assert has_audio_repetition_penalty is False
+
+
+def test_prepare_active_rows_reports_audio_repetition_penalty_from_pool():
+    pool = MossTTSLocalDecodeStatePool(_model(max_running_requests=2))
+    reqs = [
+        SimpleNamespace(request_id="a", data=_params(seed=11)),
+        SimpleNamespace(
+            request_id="b", data=_params(seed=22, audio_repetition_penalty=1.2)
+        ),
+    ]
+
+    _, rows, has_audio_repetition_penalty = pool.prepare_active_rows(reqs)
+
+    assert has_audio_repetition_penalty is True
+    assert pool.rows_have_audio_repetition_penalty(rows) is True
+
+
+def test_audio_history_updates_pool_presence_mask():
+    pool = MossTTSLocalDecodeStatePool(_model(max_running_requests=2))
+    row_a = pool.acquire_row("a")
+    row_b = pool.acquire_row("b")
+    rows = torch.full((2, 13), 999, dtype=torch.long)
+    rows[:, 1:] = torch.arange(24, dtype=torch.long).reshape(2, 12)
+    rows[1, 2] = 2048
+
+    pool.update_audio_history(torch.tensor([row_a, row_b]), rows)
+
+    assert bool(pool.audio_token_presence[row_a, 0, 0])
+    assert bool(pool.audio_token_presence[row_a, 11, 11])
+    assert bool(pool.audio_token_presence[row_b, 0, 12])
+    assert not bool(pool.audio_token_presence[row_b, 1, 2047 % 1024])
+
+
+def test_rebuild_audio_history_clears_stale_presence():
+    pool = MossTTSLocalDecodeStatePool(_model())
+    row = pool.acquire_row("a")
+    pool.audio_token_presence[row, 0, 99] = True
+    rows = []
+    for token in (3, 5):
+        row_t = torch.full((13,), 0, dtype=torch.long)
+        row_t[1:] = token
+        rows.append(row_t)
+
+    assert pool.rebuild_audio_history("a", rows) is True
+
+    assert not bool(pool.audio_token_presence[row, 0, 99])
+    assert bool(pool.audio_token_presence[row, 0, 3])
+    assert bool(pool.audio_token_presence[row, 0, 5])
 
 
 def test_journal_holds_fields():
@@ -431,6 +499,72 @@ def test_collect_frame_reads_generation_steps_from_pool():
     assert torch.equal(captured["base_positions"], torch.tensor([4 * 13]))
 
 
+def test_collect_frame_uses_eager_path_when_audio_repetition_penalty_active():
+    hidden_size = 4
+    weight = torch.zeros(2, hidden_size, dtype=torch.bfloat16)
+    embedding = SimpleNamespace(weight=weight)
+    model = SimpleNamespace(
+        _decode_input_embedding=embedding,
+        _state_pool=None,
+        config=SimpleNamespace(
+            n_vq=12,
+            audio_vocab_size=1024,
+            audio_assistant_slot_token_id=1000,
+            audio_end_token_id=1001,
+        ),
+        frame_graph_max_bs=1,
+        device=torch.device("cpu"),
+    )
+    pool = MossTTSLocalDecodeStatePool(model)
+    model._state_pool = pool
+    called = {"eager": False}
+
+    def decode_frame_graphed(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("penalty-enabled frames must not use graph replay")
+
+    def decode_frame(hidden_states, *, sample_text, sample_audio):
+        del hidden_states, sample_text, sample_audio
+        called["eager"] = True
+        return (
+            torch.zeros(1, dtype=torch.long),
+            torch.full((1, 12), 7, dtype=torch.long),
+        )
+
+    model.decode_frame_graphed = decode_frame_graphed
+    model.decode_frame = decode_frame
+    model._prepare_multi_modal_inputs = lambda rows: torch.ones(
+        (rows.shape[0], hidden_size), dtype=torch.bfloat16
+    )
+
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    data = SimpleNamespace(
+        req=SimpleNamespace(is_chunked=0),
+        text_temperature=1.0,
+        text_top_p=1.0,
+        text_top_k=50,
+        audio_temperature=1.0,
+        audio_top_p=1.0,
+        audio_top_k=50,
+        sampling_seed=0,
+        generation_steps=0,
+        audio_repetition_penalty=1.2,
+        output_rows=[],
+    )
+    request = SimpleNamespace(request_id="rid", data=data)
+    result = SimpleNamespace(
+        logits_output=SimpleNamespace(hidden_states=torch.zeros(1, hidden_size))
+    )
+
+    runner._collect_frame(result, SimpleNamespace(), SimpleNamespace(), [request])
+
+    assert called["eager"] is True
+    row = pool.row_for("rid")
+    assert row is not None
+    assert bool(pool.audio_token_presence[row, 0, 7])
+
+
 def test_finalize_commits_generation_steps_to_pool():
     model = _model(max_running_requests=2)
     pool = MossTTSLocalDecodeStatePool(model)
@@ -490,12 +624,17 @@ def test_resume_reprefill_overwrites_stranded_feedback():
     pool.commit_generation_step("a", 3)
     # Feedback stranded by the retraction (must be wiped by the resume).
     pool.feedback_embeds[row].fill_(5.0)
+    pool.audio_token_presence[row, 0, 99] = True
 
     # prompt_rows (2 frames) + already-generated output_rows (3 frames); the
     # resume re-prefills the whole span, so extend_input_len = 2 + 3.
     width = 13
     prompt_rows = torch.zeros((2, width), dtype=torch.long)
-    generated = [torch.zeros(width, dtype=torch.long) for _ in range(3)]
+    generated = []
+    for token in (4, 5, 6):
+        row_t = torch.zeros(width, dtype=torch.long)
+        row_t[1:] = token
+        generated.append(row_t)
     data = SimpleNamespace(
         req=SimpleNamespace(extend_input_len=5, prefix_indices=[], rid="a"),
         prompt_rows=prompt_rows,
@@ -512,6 +651,10 @@ def test_resume_reprefill_overwrites_stranded_feedback():
 
     assert torch.all(pool.feedback_embeds[row] == 0), "stranded feedback must be wiped"
     assert int(pool.generation_steps[row]) == 3, "resume must preserve sample position"
+    assert not bool(pool.audio_token_presence[row, 0, 99])
+    assert bool(pool.audio_token_presence[row, 0, 4])
+    assert bool(pool.audio_token_presence[row, 0, 5])
+    assert bool(pool.audio_token_presence[row, 0, 6])
     pool.ensure_params(row, "a", _params(seed=2))
     assert int(pool.seeds[row]) == 2, "params must be re-written on resume"
 
@@ -596,6 +739,8 @@ def test_collect_frame_skips_chunked_feedback_and_journal():
     assert result.moss_journal.rids == ["normal"]
     assert result.moss_journal.pool_rows == [normal_row]
     assert result.moss_journal.rows.shape == (1, 13)
+    assert int(torch.count_nonzero(pool.audio_token_presence[chunked_row])) == 0
+    assert int(torch.count_nonzero(pool.audio_token_presence[normal_row])) == 0
 
 
 def test_sampling_position_floor_is_sync_noop():


### PR DESCRIPTION
## Summary

Closes #757.

- add pool-resident `[P]` `generation_steps` for MOSS-TTS Local decode launch state
- prepare active pool rows once and reuse `row_t` so `_collect_frame` gathers launch inputs from pool tensors
- mirror committed `generation_steps` into the pool through a batch model-runner hook while preserving retraction/re-prefill position
- move MOSS Local audio repetition penalty state into the pool: `[P]` penalty tensor plus `[P, n_vq, audio_vocab]` generated-token presence mask
- keep the normal no-penalty frame path graphable and mask-free; penalty-enabled rows use the eager frame path with pool-resident history
- extend MOSS local state-pool tests, base runner hook tests, and the test catalog entry

## Why

The MOSS-TTS Local frame path already stores feedback embeddings and request-static sampling params in row-indexed pool tensors. `_collect_frame` still rebuilt active rows, `generation_steps`, and repetition-penalty history from Python request objects each frame. This moves the remaining next-step launch state into the pool so the launch path can gather with `row_t`, matching the #757 follow-up from the #745 review.

For repetition penalty specifically, `audio_repetition_penalty` is now request-static pool state and generated audio history is a pool-resident presence mask. The default no-penalty path does not build request-local `datas` and does not update the history mask. When a request enables audio repetition penalty, the runner intentionally bypasses frame-decode CUDA graph replay for that batch, applies the penalty from pool tensors, updates only active penalty rows after emitted frames, and rebuilds the mask from `output_rows` only on the retraction/re-prefill slow path.

## Performance / CUDA Graph Note

This does **not** claim a large end-to-end TTS latency win. The measured impact is local to the graph replay launch-prep path:

- CUDA graph behavior was tested on H100: both `origin/main` and this PR capture `bs=[1,2,4,8,16]`; the latest PR run logs both SGLang backbone graph capture and `MOSS-TTS Local frame-decode CUDA graphs captured for bs=[1, 2, 4, 8, 16]`.
- The no-penalty path remains the CUDA-graph path: it does not materialize request-local `datas`, does not walk `data.output_rows`, and does not update the repetition-history mask.
- The penalty-enabled path remains eager because frame-decode graphs do not include repetition-penalty logit mutation; the eager path now reads pool tensors/masks instead of reconstructing per-request history inside `_collect_frame`.
- Synthetic launch-only prep benchmark (`_collect_frame` active rows + params + `generation_steps`, no model/vocoder/HTTP): new path reduces representative per-step prep from `65.53us -> 43.74us` at bs=16, `69.75us -> 43.73us` at bs=32, and `79.77us -> 44.17us` at bs=64.
- Synthetic total prep benchmark including the generation-step pool commit after switching to batch commit: bs=1 is slightly slower (`84.87us -> 86.06us`), bs=4 is roughly flat (`87.46us -> 87.18us`), and larger batches improve modestly: bs=8 `91.31us -> 89.70us`, bs=16 `93.60us -> 91.52us`, bs=32 `101.41us -> 96.70us`.
- E2E single-request smoke did not show a meaningful request-level win: `x-engine-time` mean was effectively flat (`0.276331s` main vs `0.276070s` PR), while HTTP wall time was noisier and slightly slower (`0.369102s` main vs `0.374820s` PR). Treat this as a hot-path cleanup / graph-readiness change, not an E2E throughput claim.

## Validation

Local:
- `python -m compileall -q sglang_omni/models/moss_tts_local/model_runner.py sglang_omni/models/moss_tts_local/state_pool.py tests/unit_test/moss_tts_local/test_state_pool.py tests/unit_test/moss_tts_local/test_pipeline.py`
- `git diff --check`
- pre-commit hooks during commit: passed

Remote H100 unit tests:
- env: `FLASHINFER_DISABLE_VERSION_CHECK=1` to bypass the container existing flashinfer/flashinfer-jit-cache version mismatch
- `pytest -q tests/unit_test/moss_tts_local/test_state_pool.py tests/unit_test/moss_tts_local/test_pipeline.py -q`: completed 100%, 2 warnings
- `pytest -q tests/unit_test/moss_tts_local/test_state_pool.py::test_cached_pool_rows_drive_collect_and_batched_step_commit -q`: passed, 2 warnings
- `pytest -q tests/unit_test/moss_tts_local -q`: completed 100%, 2 warnings

Remote H100 E2E:
- host/container: `novita-h100-omni` / `sglang-omni-hayden`
- server snapshot: runtime code at `a47c6abf`; latest `0e3aaf8d` is test-only
- config: `examples/configs/moss_tts_local.yaml`, model `OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5`
- launch: `CUDA_VISIBLE_DEVICES=6,7 FLASHINFER_DISABLE_VERSION_CHECK=1 PYTHONPATH=. python -m sglang_omni.cli serve --config examples/configs/moss_tts_local.yaml --host 127.0.0.1 --port 28257 --log-level info`
- readiness: `GET /health` -> `200`; server selected an alternate free port when `28257` was still occupied by the previous validation process
- no-penalty request: `POST /v1/audio/speech` with `${token:8}`, `max_new_tokens=12`, `seed=11` -> `HTTP 200`, `content-type: audio/wav`, `184364` bytes, `x-engine-time: 0.595348`
- penalty request: same payload plus `repetition_penalty=1.2` -> `HTTP 200`, `content-type: audio/wav`, `184364` bytes, `x-engine-time: 0.514209`
- cleanup: temporary server processes and `/tmp/sglang_omni_issue757_pf` snapshot removed; remaining GPU process on host GPU 7 belonged to a different container, not this validation
