### PR TITLE
[Perf] MOSS-TTS Local v1.5: native pool-resident CUDA graph for the frame-decode sampling path

### DIFF
--- a/scripts/gate_s0_sync_parity.py
+++ b/scripts/gate_s0_sync_parity.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""S0 gate: fixed-seed sync parity check for MOSS-TTS Local v1.5.
+
+Runs the v1.5 frame-decode graph twice with identical fixed-seed inputs at
+each concurrency level and asserts bit-identical outputs. Must pass before
+and after every PR-A commit to confirm behavior-neutrality.
+
+Usage (inside sglang-omni-jiaxind container on novita-h100):
+    CUDA_VISIBLE_DEVICES=3 python scripts/gate_s0_sync_parity.py
+    CUDA_VISIBLE_DEVICES=3 python scripts/gate_s0_sync_parity.py --batch-sizes 1 4 16
+    CUDA_VISIBLE_DEVICES=3 python scripts/gate_s0_sync_parity.py --frames 50 --seed 12345
+
+Exit code: 0 = all checks passed, 1 = any divergence detected.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Sequence
+
+import torch
+
+_N_VQ = 12
+_HIDDEN = 64
+_VOCAB = 32  # logit head width for the toy model
+
+
+def _build_frame_fn(device: torch.device):
+    """Return a decode_frame callable backed by a toy MossTTSLocalTransformer.
+
+    The toy model uses the same kernel stack as the production model
+    (MossTTSLocalTransformer + sample_seeded_branchless) but with a
+    hidden_size of 64 so it fits in a few MB of VRAM.
+    """
+    from sglang_omni.models.moss_tts_local.local_transformer import (
+        MossTTSLocalTransformer,
+        sample_seeded_branchless,
+    )
+
+    torch.manual_seed(0)
+    module = MossTTSLocalTransformer(
+        hidden_size=_HIDDEN,
+        num_heads=4,
+        inner_size=96,
+        num_layers=1,
+        max_positions=_N_VQ + 1,
+        rope_base=1_000_000.0,
+    ).to(device=device, dtype=torch.bfloat16)
+    tables = [
+        torch.randn(_HIDDEN, _HIDDEN, device=device, dtype=torch.bfloat16)
+        for _ in range(_N_VQ)
+    ]
+
+    def decode_frame(
+        hidden: torch.Tensor,
+        seeds: torch.Tensor,
+        base: torch.Tensor,
+    ) -> torch.Tensor:
+        current = module.step(hidden, 0)
+        codes = []
+        for channel in range(_N_VQ):
+            logits = (current.float() @ tables[channel].float().T)[:, :_VOCAB]
+            code = sample_seeded_branchless(
+                logits,
+                temperature=torch.full((hidden.shape[0],), 1.7, device=device),
+                top_p=torch.full((hidden.shape[0],), 0.8, device=device),
+                top_k=torch.full(
+                    (hidden.shape[0],), 25, device=device, dtype=torch.long
+                ),
+                seeds=seeds,
+                positions=base + channel + 1,
+            )
+            codes.append(code)
+            if channel + 1 < _N_VQ:
+                embed = torch.nn.functional.embedding(
+                    code, tables[channel][:_VOCAB]
+                )
+                current = module.step(embed.to(torch.bfloat16), channel + 1)
+        return torch.stack(codes, dim=-1)
+
+    return decode_frame
+
+
+def _capture_graph(decode_frame, batch: int, device: torch.device):
+    """Capture a CUDA graph for decode_frame at the given batch size."""
+    static_hidden = torch.zeros(batch, _HIDDEN, device=device, dtype=torch.bfloat16)
+    static_seeds = torch.zeros(batch, device=device, dtype=torch.long)
+    static_base = torch.zeros(batch, device=device, dtype=torch.long)
+
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(2):
+            decode_frame(static_hidden, static_seeds, static_base)
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graphed_out = decode_frame(static_hidden, static_seeds, static_base)
+
+    return graph, graphed_out, static_hidden, static_seeds, static_base
+
+
+def _run_parity_check(
+    batch: int,
+    n_frames: int,
+    seed: int,
+    device: torch.device,
+) -> bool:
+    """Return True if all n_frames graph replays are bit-identical across two runs."""
+    decode_frame = _build_frame_fn(device)
+    graph, graphed_out, s_hidden, s_seeds, s_base = _capture_graph(
+        decode_frame, batch, device
+    )
+
+    rng = torch.Generator(device=device)
+    rng.manual_seed(seed)
+
+    all_ok = True
+    for frame_idx in range(n_frames):
+        hidden = torch.randn(batch, _HIDDEN, device=device, dtype=torch.bfloat16,
+                             generator=rng)
+        seeds = (torch.arange(batch, device=device, dtype=torch.long) * 1_234_567
+                 + frame_idx * 13)
+        base = torch.full((batch,), frame_idx * 13, device=device, dtype=torch.long)
+
+        s_hidden.copy_(hidden)
+        s_seeds.copy_(seeds)
+        s_base.copy_(base)
+        graph.replay()
+        run1 = graphed_out.clone()
+
+        s_hidden.copy_(hidden)
+        s_seeds.copy_(seeds)
+        s_base.copy_(base)
+        graph.replay()
+        run2 = graphed_out.clone()
+
+        if not torch.equal(run1, run2):
+            print(
+                f"  FAIL frame={frame_idx} batch={batch}: "
+                f"{(run1 != run2).sum().item()} element(s) differ"
+            )
+            all_ok = False
+
+    return all_ok
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--batch-sizes", type=int, nargs="+", default=[1, 4, 16],
+        metavar="BS",
+        help="batch sizes to test (default: 1 4 16)",
+    )
+    parser.add_argument(
+        "--frames", type=int, default=30,
+        help="number of frames to replay per batch size (default: 30)",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=42,
+        help="RNG seed for random inputs (default: 42)",
+    )
+    args = parser.parse_args(argv)
+
+    if not torch.cuda.is_available():
+        print("SKIP: no CUDA device available")
+        return 0
+
+    device = torch.device("cuda")
+    print(f"S0 gate — device={torch.cuda.get_device_name(0)}")
+    print(f"  batch_sizes={args.batch_sizes}  frames={args.frames}  seed={args.seed}")
+
+    passed = 0
+    failed = 0
+    for bs in args.batch_sizes:
+        ok = _run_parity_check(
+            batch=bs, n_frames=args.frames, seed=args.seed, device=device
+        )
+        status = "PASS" if ok else "FAIL"
+        print(f"  batch={bs:3d}  {status}")
+        if ok:
+            passed += 1
+        else:
+            failed += 1
+
+    print(f"\n{passed} passed, {failed} failed")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gate_s0_sync_parity.py
+++ b/scripts/gate_s0_sync_parity.py
@@ -13,6 +13,7 @@ Usage (inside sglang-omni-jiaxind container on novita-h100):
 
 Exit code: 0 = all checks passed, 1 = any divergence detected.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -73,9 +74,7 @@ def _build_frame_fn(device: torch.device):
             )
             codes.append(code)
             if channel + 1 < _N_VQ:
-                embed = torch.nn.functional.embedding(
-                    code, tables[channel][:_VOCAB]
-                )
+                embed = torch.nn.functional.embedding(code, tables[channel][:_VOCAB])
                 current = module.step(embed.to(torch.bfloat16), channel + 1)
         return torch.stack(codes, dim=-1)
 
@@ -120,10 +119,13 @@ def _run_parity_check(
 
     all_ok = True
     for frame_idx in range(n_frames):
-        hidden = torch.randn(batch, _HIDDEN, device=device, dtype=torch.bfloat16,
-                             generator=rng)
-        seeds = (torch.arange(batch, device=device, dtype=torch.long) * 1_234_567
-                 + frame_idx * 13)
+        hidden = torch.randn(
+            batch, _HIDDEN, device=device, dtype=torch.bfloat16, generator=rng
+        )
+        seeds = (
+            torch.arange(batch, device=device, dtype=torch.long) * 1_234_567
+            + frame_idx * 13
+        )
         base = torch.full((batch,), frame_idx * 13, device=device, dtype=torch.long)
 
         s_hidden.copy_(hidden)
@@ -151,16 +153,23 @@ def _run_parity_check(
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--batch-sizes", type=int, nargs="+", default=[1, 4, 16],
+        "--batch-sizes",
+        type=int,
+        nargs="+",
+        default=[1, 4, 16],
         metavar="BS",
         help="batch sizes to test (default: 1 4 16)",
     )
     parser.add_argument(
-        "--frames", type=int, default=30,
+        "--frames",
+        type=int,
+        default=30,
         help="number of frames to replay per batch size (default: 30)",
     )
     parser.add_argument(
-        "--seed", type=int, default=42,
+        "--seed",
+        type=int,
+        default=42,
         help="RNG seed for random inputs (default: 42)",
     )
     args = parser.parse_args(argv)

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import bisect
 from typing import Any
 
 import torch
@@ -51,6 +52,8 @@ class MossTTSLocalModelRunner(ModelRunner):
         del is_lookahead
         del schedule_batch
         self._write_decode_input_embedding(forward_batch, requests)
+        if self._forward_sample_enabled():
+            self._prepare_forward_sample_inputs(forward_batch, requests)
 
     def post_prefill(
         self,
@@ -123,33 +126,265 @@ class MossTTSLocalModelRunner(ModelRunner):
         forward_batch: Any,
         requests: list,
     ) -> None:
-        batch_size = len(requests)
-        if batch_size == 0:
+        n_real = len(requests)
+        raw_batch_size = int(getattr(forward_batch, "batch_size", n_real) or n_real)
+        staging_batch_size = self._decode_staging_batch_size(raw_batch_size)
+        if n_real == 0 and staging_batch_size == 0:
             return
         pool = self.model._state_pool
         weight = self.model._decode_input_embedding.weight
-        if forward_batch.input_ids.numel() < batch_size:
+        if raw_batch_size < n_real:
+            raise RuntimeError(
+                "MOSS-TTS Local decode graph batch is smaller than the real batch "
+                f"({raw_batch_size} < {n_real})"
+            )
+        if forward_batch.input_ids.numel() < raw_batch_size:
             raise RuntimeError(
                 "MOSS-TTS Local decode input_ids must contain one row id per request"
             )
-        if batch_size > pool.padding_row:
+        if staging_batch_size > pool.padding_row:
             raise RuntimeError(
                 "MOSS-TTS Local decode batch exceeds the staged decode-embedding "
-                f"rows ({batch_size} > {pool.padding_row})"
+                f"rows ({staging_batch_size} > {pool.padding_row})"
             )
         pool_rows = [pool.acquire_row(sched_req.request_id) for sched_req in requests]
+        if staging_batch_size > n_real:
+            pool_rows.extend([pool.padding_row] * (staging_batch_size - n_real))
         row_tensor = torch.tensor(pool_rows, dtype=torch.long, device=weight.device)
         with torch.no_grad():
-            weight[:batch_size].copy_(pool.feedback_embeds[row_tensor])
+            weight[:staging_batch_size].copy_(pool.feedback_embeds[row_tensor])
 
         row_ids = torch.arange(
-            batch_size,
+            raw_batch_size,
             dtype=torch.long,
             device=forward_batch.input_ids.device,
         )
-        forward_batch.input_ids[:batch_size].copy_(row_ids)
+        forward_batch.input_ids[:raw_batch_size].copy_(row_ids)
+
+    def _decode_staging_batch_size(self, raw_batch_size: int) -> int:
+        """Return the model-buffer rows SGLang may read for this decode step.
+
+        SGLang's cuda graph runner receives the raw ForwardBatch, then pads it
+        to the next captured ``cuda_graph_bs`` bucket during replay. The model
+        staging buffers are outside SGLang's GraphInputBuffers, so they must be
+        prefilled up to the same bucket here.
+        """
+        raw_batch_size = int(raw_batch_size)
+        if raw_batch_size <= 0:
+            return 0
+        if not bool(getattr(self.model, "_moss_local_decode_graph_padding", False)):
+            return raw_batch_size
+        buckets = sorted(
+            {
+                int(bs)
+                for bs in getattr(self.model, "_moss_local_decode_cuda_graph_bs", [])
+                if int(bs) > 0
+            }
+        )
+        if not buckets:
+            return raw_batch_size
+        idx = bisect.bisect_left(buckets, raw_batch_size)
+        return buckets[idx] if idx < len(buckets) else raw_batch_size
+
+    def _forward_sample_enabled(self) -> bool:
+        return bool(getattr(self.model, "forward_sample_in_forward", False)) and all(
+            hasattr(self.model, name)
+            for name in (
+                "_cg_text_temp",
+                "_cg_text_top_p",
+                "_cg_text_top_k",
+                "_cg_audio_temp",
+                "_cg_audio_top_p",
+                "_cg_audio_top_k",
+                "_cg_seeds",
+                "_cg_base_positions",
+                "_cg_rows",
+                "_cg_feedback",
+            )
+        )
+
+    def _prepare_forward_sample_inputs(
+        self,
+        forward_batch: Any,
+        requests: list,
+    ) -> None:
+        if not requests:
+            self._forward_sample_pool_rows = []
+            self._forward_sample_rids = []
+            return
+        n_real = len(requests)
+        raw_batch_size = int(getattr(forward_batch, "batch_size", n_real) or n_real)
+        staging_batch_size = self._decode_staging_batch_size(raw_batch_size)
+        model = self.model
+        max_rows = int(model._cg_text_temp.shape[0])
+        if raw_batch_size < n_real:
+            raise RuntimeError(
+                "MOSS-TTS Local forward-sample graph batch is smaller than the "
+                f"real batch ({raw_batch_size} < {n_real})"
+            )
+        if staging_batch_size > max_rows:
+            raise RuntimeError(
+                "MOSS-TTS Local forward-sample batch exceeds staging buffers "
+                f"({staging_batch_size} > {max_rows})"
+            )
+
+        pool = model._state_pool
+        pool_rows = []
+        for sched_req in requests:
+            rid = sched_req.request_id
+            row = pool.acquire_row(rid)
+            pool.ensure_params(row, rid, sched_req.data)
+            pool_rows.append(row)
+
+        row_t = torch.tensor(
+            pool_rows, dtype=torch.long, device=pool.feedback_embeds.device
+        )
+        num_channels = int(model.config.n_vq) + 1
+        generation_steps = torch.tensor(
+            [int(sched_req.data.generation_steps) for sched_req in requests],
+            dtype=torch.long,
+            device=model._cg_base_positions.device,
+        )
+
+        with torch.no_grad():
+            if n_real:
+                model._cg_text_temp[:n_real].copy_(
+                    pool.text_temp[row_t].to(model._cg_text_temp.device)
+                )
+                model._cg_text_top_p[:n_real].copy_(
+                    pool.text_top_p[row_t].to(model._cg_text_top_p.device)
+                )
+                model._cg_text_top_k[:n_real].copy_(
+                    pool.text_top_k[row_t].to(model._cg_text_top_k.device)
+                )
+                model._cg_audio_temp[:n_real].copy_(
+                    pool.audio_temp[row_t].to(model._cg_audio_temp.device)
+                )
+                model._cg_audio_top_p[:n_real].copy_(
+                    pool.audio_top_p[row_t].to(model._cg_audio_top_p.device)
+                )
+                model._cg_audio_top_k[:n_real].copy_(
+                    pool.audio_top_k[row_t].to(model._cg_audio_top_k.device)
+                )
+                model._cg_seeds[:n_real].copy_(
+                    pool.seeds[row_t].to(model._cg_seeds.device)
+                )
+                model._cg_base_positions[:n_real].copy_(generation_steps * num_channels)
+            if staging_batch_size > n_real:
+                model._cg_text_temp[n_real:staging_batch_size].fill_(1.0)
+                model._cg_text_top_p[n_real:staging_batch_size].fill_(1.0)
+                model._cg_text_top_k[n_real:staging_batch_size].fill_(50)
+                model._cg_audio_temp[n_real:staging_batch_size].fill_(1.0)
+                model._cg_audio_top_p[n_real:staging_batch_size].fill_(1.0)
+                model._cg_audio_top_k[n_real:staging_batch_size].fill_(25)
+                model._cg_seeds[n_real:staging_batch_size].zero_()
+                model._cg_base_positions[n_real:staging_batch_size].zero_()
+
+        self._forward_sample_pool_rows = pool_rows
+        self._forward_sample_rids = [sched_req.request_id for sched_req in requests]
+
+    def _use_forward_sample_path(
+        self,
+        result: Any,
+        forward_batch: Any,
+        requests: list,
+    ) -> bool:
+        if not self._forward_sample_enabled() or not requests:
+            return False
+        forward_mode = getattr(forward_batch, "forward_mode", None)
+        is_decode = (
+            forward_mode is not None
+            and hasattr(forward_mode, "is_decode")
+            and bool(forward_mode.is_decode())
+        )
+        if not is_decode:
+            return False
+        if getattr(result, "logits_output", None) is None:
+            return False
+        return all(
+            float(getattr(sched_req.data, "audio_repetition_penalty", 1.0)) == 1.0
+            for sched_req in requests
+        )
 
     def _collect_frame(
+        self,
+        result: Any,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list,
+    ) -> None:
+        if self._use_forward_sample_path(result, forward_batch, requests):
+            self._collect_frame_from_forward_sample(result, schedule_batch, requests)
+        else:
+            self._collect_frame_legacy(result, forward_batch, schedule_batch, requests)
+
+    def _collect_frame_from_forward_sample(
+        self,
+        result: Any,
+        schedule_batch: Any,
+        requests: list,
+    ) -> None:
+        # Sampling already ran inside MossTTSLocalSGLangModel.forward() via
+        # _decode_frame_graphable(); collection only snapshots the fixed
+        # staging buffers and updates scheduler/pool state outside the graph.
+        if not requests:
+            return
+        n_real = len(requests)
+        current_rids = [sched_req.request_id for sched_req in requests]
+        staged_rids = list(getattr(self, "_forward_sample_rids", []))
+        pool_rows = list(getattr(self, "_forward_sample_pool_rows", []))
+        if staged_rids[:n_real] != current_rids:
+            raise RuntimeError(
+                "MOSS-TTS Local forward-sample request alignment broken: "
+                f"{staged_rids[:n_real]} != {current_rids}"
+            )
+        if len(pool_rows) < n_real:
+            raise RuntimeError(
+                "MOSS-TTS Local forward-sample pool row staging is incomplete: "
+                f"{len(pool_rows)} < {n_real}"
+            )
+
+        model = self.model
+        if (
+            int(model._cg_rows.shape[0]) < n_real
+            or int(model._cg_feedback.shape[0]) < n_real
+        ):
+            raise RuntimeError("MOSS-TTS Local forward-sample output buffers too small")
+        cfg = model.config
+        pool = model._state_pool
+        rows = model._cg_rows[:n_real].clone()
+        feedback = model._cg_feedback[:n_real].clone()
+        next_text = rows[:, 0]
+        end_id = int(cfg.audio_end_token_id)
+        next_token_ids = self._row_radix_token_ids(rows, next_text, end_id)
+        result.next_token_ids = next_token_ids
+        schedule_batch.output_ids = next_token_ids
+
+        emit_indices = [
+            i
+            for i, sched_req in enumerate(requests)
+            if not self._is_chunked_request(sched_req)
+        ]
+        if not emit_indices:
+            return
+
+        emit_index_t = torch.tensor(emit_indices, dtype=torch.long, device=rows.device)
+        emit_pool_rows = [pool_rows[i] for i in emit_indices]
+        emit_row_t = torch.tensor(
+            emit_pool_rows, dtype=torch.long, device=pool.feedback_embeds.device
+        )
+        emit_feedback = feedback.index_select(0, emit_index_t.to(feedback.device))
+        pool.feedback_embeds[emit_row_t] = emit_feedback.detach().to(
+            device=pool.feedback_embeds.device,
+            dtype=pool.feedback_embeds.dtype,
+        )
+        result.moss_journal = MossTTSLocalDecodeJournal(
+            rids=[requests[i].request_id for i in emit_indices],
+            pool_rows=emit_pool_rows,
+            rows=rows.index_select(0, emit_index_t),
+        )
+
+    def _collect_frame_legacy(
         self,
         result: Any,
         forward_batch: Any,

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -22,8 +22,8 @@ class MossTTSLocalModelRunner(ModelRunner):
     state per request; :meth:`_collect_frame` then runs the batched local
     micro-decode — a binary continue/stop decision and 12 sequentially
     sampled RVQ codes — and stages the next frame's summed embedding through
-    ``model._decode_input_embedding`` so the next decode step stays
-    CUDA-graph-replayable (decode input_ids are row indices).
+    the row-indexed decode-state pool. The legacy path still mirrors that
+    feedback into ``model._decode_input_embedding`` for decode replay.
     """
 
     def __init__(self, tp_worker: Any, output_processor: Any):
@@ -51,9 +51,10 @@ class MossTTSLocalModelRunner(ModelRunner):
     ) -> None:
         del is_lookahead
         del schedule_batch
-        self._write_decode_input_embedding(forward_batch, requests)
         if self._forward_sample_enabled():
             self._prepare_forward_sample_inputs(forward_batch, requests)
+        else:
+            self._write_decode_input_embedding(forward_batch, requests)
 
     def post_prefill(
         self,
@@ -187,19 +188,26 @@ class MossTTSLocalModelRunner(ModelRunner):
         return buckets[idx] if idx < len(buckets) else raw_batch_size
 
     def _forward_sample_enabled(self) -> bool:
-        return bool(getattr(self.model, "forward_sample_in_forward", False)) and all(
-            hasattr(self.model, name)
+        if not (
+            bool(getattr(self.model, "forward_sample_in_forward", False))
+            and hasattr(self.model, "_cg_pool_rows")
+            and hasattr(self.model, "_state_pool")
+        ):
+            return False
+        pool = self.model._state_pool
+        return all(
+            hasattr(pool, name)
             for name in (
-                "_cg_text_temp",
-                "_cg_text_top_p",
-                "_cg_text_top_k",
-                "_cg_audio_temp",
-                "_cg_audio_top_p",
-                "_cg_audio_top_k",
-                "_cg_seeds",
-                "_cg_base_positions",
-                "_cg_rows",
-                "_cg_feedback",
+                "text_temp",
+                "text_top_p",
+                "text_top_k",
+                "audio_temp",
+                "audio_top_p",
+                "audio_top_k",
+                "seeds",
+                "base_positions",
+                "rows",
+                "sample_feedback_embeds",
             )
         )
 
@@ -216,11 +224,16 @@ class MossTTSLocalModelRunner(ModelRunner):
         raw_batch_size = int(getattr(forward_batch, "batch_size", n_real) or n_real)
         staging_batch_size = self._decode_staging_batch_size(raw_batch_size)
         model = self.model
-        max_rows = int(model._cg_text_temp.shape[0])
+        max_rows = int(model._cg_pool_rows.shape[0])
         if raw_batch_size < n_real:
             raise RuntimeError(
                 "MOSS-TTS Local forward-sample graph batch is smaller than the "
                 f"real batch ({raw_batch_size} < {n_real})"
+            )
+        if forward_batch.input_ids.numel() < raw_batch_size:
+            raise RuntimeError(
+                "MOSS-TTS Local forward-sample decode input_ids must contain "
+                "one row id per request"
             )
         if staging_batch_size > max_rows:
             raise RuntimeError(
@@ -236,49 +249,35 @@ class MossTTSLocalModelRunner(ModelRunner):
             pool.ensure_params(row, rid, sched_req.data)
             pool_rows.append(row)
 
-        row_t = torch.tensor(
-            pool_rows, dtype=torch.long, device=pool.feedback_embeds.device
-        )
         num_channels = int(model.config.n_vq) + 1
         generation_steps = torch.tensor(
             [int(sched_req.data.generation_steps) for sched_req in requests],
             dtype=torch.long,
-            device=model._cg_base_positions.device,
+            device=pool.base_positions.device,
+        )
+        staged_pool_rows = list(pool_rows)
+        if staging_batch_size > n_real:
+            staged_pool_rows.extend([pool.padding_row] * (staging_batch_size - n_real))
+        row_t = torch.tensor(
+            staged_pool_rows, dtype=torch.long, device=pool.feedback_embeds.device
         )
 
         with torch.no_grad():
             if n_real:
-                model._cg_text_temp[:n_real].copy_(
-                    pool.text_temp[row_t].to(model._cg_text_temp.device)
+                real_row_t = row_t[:n_real].to(device=pool.base_positions.device)
+                pool.base_positions.index_copy_(
+                    0, real_row_t, generation_steps * num_channels
                 )
-                model._cg_text_top_p[:n_real].copy_(
-                    pool.text_top_p[row_t].to(model._cg_text_top_p.device)
-                )
-                model._cg_text_top_k[:n_real].copy_(
-                    pool.text_top_k[row_t].to(model._cg_text_top_k.device)
-                )
-                model._cg_audio_temp[:n_real].copy_(
-                    pool.audio_temp[row_t].to(model._cg_audio_temp.device)
-                )
-                model._cg_audio_top_p[:n_real].copy_(
-                    pool.audio_top_p[row_t].to(model._cg_audio_top_p.device)
-                )
-                model._cg_audio_top_k[:n_real].copy_(
-                    pool.audio_top_k[row_t].to(model._cg_audio_top_k.device)
-                )
-                model._cg_seeds[:n_real].copy_(
-                    pool.seeds[row_t].to(model._cg_seeds.device)
-                )
-                model._cg_base_positions[:n_real].copy_(generation_steps * num_channels)
-            if staging_batch_size > n_real:
-                model._cg_text_temp[n_real:staging_batch_size].fill_(1.0)
-                model._cg_text_top_p[n_real:staging_batch_size].fill_(1.0)
-                model._cg_text_top_k[n_real:staging_batch_size].fill_(50)
-                model._cg_audio_temp[n_real:staging_batch_size].fill_(1.0)
-                model._cg_audio_top_p[n_real:staging_batch_size].fill_(1.0)
-                model._cg_audio_top_k[n_real:staging_batch_size].fill_(25)
-                model._cg_seeds[n_real:staging_batch_size].zero_()
-                model._cg_base_positions[n_real:staging_batch_size].zero_()
+            model._cg_pool_rows[:staging_batch_size].copy_(
+                row_t.to(device=model._cg_pool_rows.device)
+            )
+
+        row_ids = torch.arange(
+            raw_batch_size,
+            dtype=torch.long,
+            device=forward_batch.input_ids.device,
+        )
+        forward_batch.input_ids[:raw_batch_size].copy_(row_ids)
 
         self._forward_sample_pool_rows = pool_rows
         self._forward_sample_rids = [sched_req.request_id for sched_req in requests]
@@ -345,15 +344,13 @@ class MossTTSLocalModelRunner(ModelRunner):
             )
 
         model = self.model
-        if (
-            int(model._cg_rows.shape[0]) < n_real
-            or int(model._cg_feedback.shape[0]) < n_real
-        ):
-            raise RuntimeError("MOSS-TTS Local forward-sample output buffers too small")
         cfg = model.config
         pool = model._state_pool
-        rows = model._cg_rows[:n_real].clone()
-        feedback = model._cg_feedback[:n_real].clone()
+        pool_row_t = torch.tensor(
+            pool_rows[:n_real], dtype=torch.long, device=pool.device
+        )
+        rows = pool.rows.index_select(0, pool_row_t).clone()
+        feedback = pool.sample_feedback_embeds.index_select(0, pool_row_t).clone()
         next_text = rows[:, 0]
         end_id = int(cfg.audio_end_token_id)
         next_token_ids = self._row_radix_token_ids(rows, next_text, end_id)

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -127,6 +127,8 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             dtype=weight.dtype,
         )
         self._decode_input_embedding.weight.requires_grad_(False)
+        self.forward_sample_in_forward = False
+        self.init_forward_sample_buffers()
 
         # Row-indexed decode-state pool: next-step-critical per-request state
         # (next-frame feedback embedding, request-static sampling params/seed)
@@ -134,6 +136,55 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         # above. Allocated here, before any frame/backbone graph capture, so
         # its addresses are fixed for the process lifetime.
         self._state_pool = MossTTSLocalDecodeStatePool(self)
+
+    def init_forward_sample_buffers(self) -> None:
+        """Allocate fixed decode-time staging used by the opt-in forward path."""
+        weight = self._decode_input_embedding.weight
+        max_running_requests = int(weight.shape[0])
+        device = weight.device
+        self._cg_text_temp = torch.ones(
+            max_running_requests, device=device, dtype=torch.float32
+        )
+        self._cg_text_top_p = torch.ones(
+            max_running_requests, device=device, dtype=torch.float32
+        )
+        self._cg_text_top_k = torch.full(
+            (max_running_requests,), 50, device=device, dtype=torch.int64
+        )
+        self._cg_audio_temp = torch.ones(
+            max_running_requests, device=device, dtype=torch.float32
+        )
+        self._cg_audio_top_p = torch.ones(
+            max_running_requests, device=device, dtype=torch.float32
+        )
+        self._cg_audio_top_k = torch.full(
+            (max_running_requests,), 25, device=device, dtype=torch.int64
+        )
+        self._cg_seeds = torch.zeros(
+            max_running_requests, device=device, dtype=torch.int64
+        )
+        self._cg_base_positions = torch.zeros(
+            max_running_requests, device=device, dtype=torch.int64
+        )
+
+        self._cg_stop_choice = torch.zeros(
+            max_running_requests, device=device, dtype=torch.int64
+        )
+        self._cg_codes = torch.zeros(
+            max_running_requests, self.n_vq, device=device, dtype=torch.int64
+        )
+        self._cg_feedback = torch.zeros(
+            max_running_requests,
+            self.hidden_size,
+            device=device,
+            dtype=weight.dtype,
+        )
+        self._cg_rows = torch.zeros(
+            max_running_requests,
+            self.n_vq + 1,
+            device=device,
+            dtype=torch.int64,
+        )
 
     def acquire_row(self, rid: str) -> int:
         """Assign (or return the existing) decode-state pool row for ``rid``."""
@@ -287,13 +338,13 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         input_embeds_are_projected: bool = False,
     ) -> LogitsProcessorOutput:
         del input_embeds_are_projected
+        forward_mode = getattr(forward_batch, "forward_mode", None)
+        is_decode = (
+            forward_mode is not None
+            and hasattr(forward_mode, "is_decode")
+            and bool(forward_mode.is_decode())
+        )
         if input_embeds is None:
-            forward_mode = getattr(forward_batch, "forward_mode", None)
-            is_decode = (
-                forward_mode is not None
-                and hasattr(forward_mode, "is_decode")
-                and bool(forward_mode.is_decode())
-            )
             if is_decode:
                 input_embeds = self._decode_input_embedding(input_ids)
             elif self.pp_group.is_first_rank:
@@ -315,10 +366,40 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             hidden_states,
             forward_batch,
         )
-        # The local-transformer frame decode (binary stop head + 12 sequential
-        # codebook samples) runs in the model runner after the graph-captured
-        # backbone returns; emitting hidden states with dummy logits keeps the
-        # backbone CUDA-graph replay free of model-specific outputs.
+        if (
+            is_decode
+            and bool(getattr(self, "forward_sample_in_forward", False))
+            and hasattr(self, "_cg_text_temp")
+        ):
+            batch_size = int(sample_hidden_states.shape[0])
+            stop_choice, codes, feedback = self._decode_frame_graphable(
+                sample_hidden_states,
+                text_temperature=self._cg_text_temp[:batch_size],
+                text_top_p=self._cg_text_top_p[:batch_size],
+                text_top_k=self._cg_text_top_k[:batch_size],
+                audio_temperature=self._cg_audio_temp[:batch_size],
+                audio_top_p=self._cg_audio_top_p[:batch_size],
+                audio_top_k=self._cg_audio_top_k[:batch_size],
+                seeds=self._cg_seeds[:batch_size],
+                base_positions=self._cg_base_positions[:batch_size],
+            )
+            self._cg_stop_choice[:batch_size] = stop_choice
+            self._cg_codes[:batch_size] = codes
+            self._cg_feedback[:batch_size] = feedback
+            slot_id = int(self.config.audio_assistant_slot_token_id)
+            end_id = int(self.config.audio_end_token_id)
+            next_text = torch.where(
+                stop_choice == 0,
+                torch.full_like(stop_choice, slot_id),
+                torch.full_like(stop_choice, end_id),
+            )
+            self._cg_rows[:batch_size, 0] = next_text
+            self._cg_rows[:batch_size, 1:] = codes
+
+        # Legacy flow consumes hidden_states in the model runner and samples
+        # there. The opt-in forward-sample flow above has already written the
+        # sampled frame to fixed staging buffers. In both cases dummy logits
+        # keep SGLang's output contract satisfied.
         dummy_logits = sample_hidden_states.new_empty(
             (sample_hidden_states.shape[0], 1)
         )

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -138,50 +138,16 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         self._state_pool = MossTTSLocalDecodeStatePool(self)
 
     def init_forward_sample_buffers(self) -> None:
-        """Allocate fixed decode-time staging used by the opt-in forward path."""
+        """Allocate fixed decode-time row-id staging for the opt-in path."""
         weight = self._decode_input_embedding.weight
         max_running_requests = int(weight.shape[0])
         device = weight.device
-        self._cg_text_temp = torch.ones(
-            max_running_requests, device=device, dtype=torch.float32
-        )
-        self._cg_text_top_p = torch.ones(
-            max_running_requests, device=device, dtype=torch.float32
-        )
-        self._cg_text_top_k = torch.full(
-            (max_running_requests,), 50, device=device, dtype=torch.int64
-        )
-        self._cg_audio_temp = torch.ones(
-            max_running_requests, device=device, dtype=torch.float32
-        )
-        self._cg_audio_top_p = torch.ones(
-            max_running_requests, device=device, dtype=torch.float32
-        )
-        self._cg_audio_top_k = torch.full(
-            (max_running_requests,), 25, device=device, dtype=torch.int64
-        )
-        self._cg_seeds = torch.zeros(
-            max_running_requests, device=device, dtype=torch.int64
-        )
-        self._cg_base_positions = torch.zeros(
-            max_running_requests, device=device, dtype=torch.int64
-        )
-
-        self._cg_stop_choice = torch.zeros(
-            max_running_requests, device=device, dtype=torch.int64
-        )
-        self._cg_codes = torch.zeros(
-            max_running_requests, self.n_vq, device=device, dtype=torch.int64
-        )
-        self._cg_feedback = torch.zeros(
+        # The pool has max_running_requests + 1 rows; the last row is reserved
+        # for CUDA graph padding. The pool may not be constructed yet, but its
+        # padding row is therefore exactly max_running_requests.
+        self._cg_pool_rows = torch.full(
+            (max_running_requests,),
             max_running_requests,
-            self.hidden_size,
-            device=device,
-            dtype=weight.dtype,
-        )
-        self._cg_rows = torch.zeros(
-            max_running_requests,
-            self.n_vq + 1,
             device=device,
             dtype=torch.int64,
         )
@@ -346,7 +312,18 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         )
         if input_embeds is None:
             if is_decode:
-                input_embeds = self._decode_input_embedding(input_ids)
+                if (
+                    bool(getattr(self, "forward_sample_in_forward", False))
+                    and hasattr(self, "_cg_pool_rows")
+                    and hasattr(self, "_state_pool")
+                ):
+                    batch_size = int(input_ids.shape[0])
+                    row_ids = self._cg_pool_rows[:batch_size]
+                    input_embeds = F.embedding(
+                        row_ids, self._state_pool.feedback_embeds
+                    )
+                else:
+                    input_embeds = self._decode_input_embedding(input_ids)
             elif self.pp_group.is_first_rank:
                 input_embeds = self._prepare_multi_modal_inputs(input_ids)
             else:
@@ -369,23 +346,26 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         if (
             is_decode
             and bool(getattr(self, "forward_sample_in_forward", False))
-            and hasattr(self, "_cg_text_temp")
+            and hasattr(self, "_cg_pool_rows")
+            and hasattr(self, "_state_pool")
         ):
             batch_size = int(sample_hidden_states.shape[0])
+            pool = self._state_pool
+            row_ids = self._cg_pool_rows[:batch_size]
             stop_choice, codes, feedback = self._decode_frame_graphable(
                 sample_hidden_states,
-                text_temperature=self._cg_text_temp[:batch_size],
-                text_top_p=self._cg_text_top_p[:batch_size],
-                text_top_k=self._cg_text_top_k[:batch_size],
-                audio_temperature=self._cg_audio_temp[:batch_size],
-                audio_top_p=self._cg_audio_top_p[:batch_size],
-                audio_top_k=self._cg_audio_top_k[:batch_size],
-                seeds=self._cg_seeds[:batch_size],
-                base_positions=self._cg_base_positions[:batch_size],
+                text_temperature=pool.text_temp[row_ids],
+                text_top_p=pool.text_top_p[row_ids],
+                text_top_k=pool.text_top_k[row_ids],
+                audio_temperature=pool.audio_temp[row_ids],
+                audio_top_p=pool.audio_top_p[row_ids],
+                audio_top_k=pool.audio_top_k[row_ids],
+                seeds=pool.seeds[row_ids],
+                base_positions=pool.base_positions[row_ids],
             )
-            self._cg_stop_choice[:batch_size] = stop_choice
-            self._cg_codes[:batch_size] = codes
-            self._cg_feedback[:batch_size] = feedback
+            pool.stop_choice[row_ids] = stop_choice
+            pool.codes[row_ids] = codes
+            pool.sample_feedback_embeds[row_ids] = feedback
             slot_id = int(self.config.audio_assistant_slot_token_id)
             end_id = int(self.config.audio_end_token_id)
             next_text = torch.where(
@@ -393,8 +373,8 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
                 torch.full_like(stop_choice, slot_id),
                 torch.full_like(stop_choice, end_id),
             )
-            self._cg_rows[:batch_size, 0] = next_text
-            self._cg_rows[:batch_size, 1:] = codes
+            pool.rows[row_ids, 0] = next_text
+            pool.rows[row_ids, 1:] = codes
 
         # Legacy flow consumes hidden_states in the model runner and samples
         # there. The opt-in forward-sample flow above has already written the

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -477,6 +477,7 @@ def create_sglang_tts_engine_executor(
     gpu_id: int | None = None,
     dtype: str = "bfloat16",
     server_args_overrides: dict[str, Any] | None = None,
+    forward_sample_in_forward: bool = False,
 ) -> Any:
     from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
     from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
@@ -540,6 +541,13 @@ def create_sglang_tts_engine_executor(
         server_args.disable_cuda_graph = False
 
     model = model_worker.model_runner.model
+    model.forward_sample_in_forward = bool(forward_sample_in_forward)
+    model._moss_local_decode_cuda_graph_bs = list(
+        overrides.get("cuda_graph_bs") or [1, 2, 4, 8, 16]
+    )
+    model._moss_local_decode_graph_padding = want_cuda_graph and not bool(
+        getattr(server_args, "disable_cuda_graph_padding", False)
+    )
     if want_cuda_graph:
         model_worker.model_runner.init_device_graphs()
         # Also graph the per-frame local-transformer decode (1 + n_vq

--- a/sglang_omni/models/moss_tts_local/state_pool.py
+++ b/sglang_omni/models/moss_tts_local/state_pool.py
@@ -34,6 +34,7 @@ class MossTTSLocalDecodeStatePool:
         self.num_rows = int(weight.shape[0]) + 1
         self.padding_row = self.num_rows - 1
         self.hidden_size = int(weight.shape[1])
+        self.n_vq = int(getattr(getattr(model, "config", None), "n_vq", 12))
         self.device = weight.device
         self.dtype = weight.dtype
 
@@ -65,12 +66,37 @@ class MossTTSLocalDecodeStatePool:
             self.num_rows, device=self.device, dtype=torch.int64
         )
         self.seeds = torch.zeros(self.num_rows, device=self.device, dtype=torch.int64)
+        self.base_positions = torch.zeros(
+            self.num_rows, device=self.device, dtype=torch.int64
+        )
+        self.stop_choice = torch.zeros(
+            self.num_rows, device=self.device, dtype=torch.int64
+        )
+        self.codes = torch.zeros(
+            self.num_rows,
+            self.n_vq,
+            device=self.device,
+            dtype=torch.int64,
+        )
+        self.rows = torch.zeros(
+            self.num_rows,
+            self.n_vq + 1,
+            device=self.device,
+            dtype=torch.int64,
+        )
+        self.sample_feedback_embeds = torch.zeros(
+            self.num_rows,
+            self.hidden_size,
+            device=self.device,
+            dtype=self.dtype,
+        )
 
         self._rid_to_row: dict[str, int] = {}
         self._params_written_rids: set[str] = set()
         # Real rows 0..P-2 are assignable; the padding row stays out of the
         # free list so it is never handed to a request.
         self._free_rows: list[int] = list(range(self.padding_row))
+        self._set_padding_defaults()
 
     def acquire_row(self, rid: str) -> int:
         """Assign (or return the existing) row for ``rid``.
@@ -101,8 +127,16 @@ class MossTTSLocalDecodeStatePool:
         self._free_rows.append(row_idx)
 
     def reset_row(self, row_idx: int) -> None:
-        """Zero every field of ``row_idx`` (clears stranded feedback/params)."""
+        """Reset ``row_idx`` while preserving safe defaults for padding."""
         self.feedback_embeds[row_idx].zero_()
+        self.base_positions[row_idx] = 0
+        self.stop_choice[row_idx] = 0
+        self.codes[row_idx].zero_()
+        self.rows[row_idx].zero_()
+        self.sample_feedback_embeds[row_idx].zero_()
+        if row_idx == self.padding_row:
+            self._set_padding_defaults()
+            return
         self.text_temp[row_idx] = 0.0
         self.text_top_p[row_idx] = 0.0
         self.audio_temp[row_idx] = 0.0
@@ -110,6 +144,18 @@ class MossTTSLocalDecodeStatePool:
         self.text_top_k[row_idx] = 0
         self.audio_top_k[row_idx] = 0
         self.seeds[row_idx] = 0
+
+    def _set_padding_defaults(self) -> None:
+        """Sampling defaults used when CUDA graph buckets include padding."""
+        row_idx = self.padding_row
+        self.text_temp[row_idx] = 1.0
+        self.text_top_p[row_idx] = 1.0
+        self.text_top_k[row_idx] = 50
+        self.audio_temp[row_idx] = 1.0
+        self.audio_top_p[row_idx] = 1.0
+        self.audio_top_k[row_idx] = 25
+        self.seeds[row_idx] = 0
+        self.base_positions[row_idx] = 0
 
     def write_params(self, row_idx: int, data: Any) -> None:
         """Write the seven request-static sampling fields into ``row_idx``.

--- a/tests/unit_test/moss_tts_local/test_parity_harness.py
+++ b/tests/unit_test/moss_tts_local/test_parity_harness.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fixed-seed sync parity harness: gate scaffold for PR-A bit-identity.
+
+CPU tests exercise the comparison fixtures and the apply-result data flow.
+The GPU test (skipped without CUDA) verifies the frame-decode graph is
+deterministic and serves as the S0 gate baseline; it must not be modified
+after initial commit.
+"""
+from __future__ import annotations
+
+import torch
+import pytest
+
+from sglang_omni.models.moss_tts_local.request_builders import (
+    MossTTSLocalSGLangRequestData,
+    apply_sglang_moss_tts_local_result,
+)
+from sglang_omni.proto import OmniRequest, StagePayload
+
+_N_VQ = 12
+_AUDIO_END_ID = 151670  # audio_end_token_id default (payload_types.py)
+
+
+def _payload(request_id: str = "r0") -> StagePayload:
+    return StagePayload(
+        request_id=request_id,
+        request=OmniRequest(inputs={"text": "hello"}, params={}, metadata={}),
+        data={},
+    )
+
+
+def _data_with_rows(n_frames: int, seed: int) -> MossTTSLocalSGLangRequestData:
+    """Build request data with fixed-seed deterministic output_rows."""
+    torch.manual_seed(seed)
+    data = MossTTSLocalSGLangRequestData(
+        input_ids=torch.zeros(4, dtype=torch.long),
+        max_new_tokens=64,
+        temperature=0.0,
+        output_ids=[],
+        prompt_rows=torch.full((4, _N_VQ + 1), 1024, dtype=torch.long),
+        stage_payload=_payload(),
+        engine_start_s=0.0,
+    )
+    for _ in range(n_frames):
+        row = torch.cat([
+            torch.tensor([1000]),  # non-stop slot
+            torch.randint(0, 1024, (_N_VQ,)),
+        ])
+        data.output_rows.append(row)
+    return data
+
+
+def _audio_codes(data: MossTTSLocalSGLangRequestData) -> torch.Tensor:
+    result = apply_sglang_moss_tts_local_result(data.stage_payload, data)
+    return torch.as_tensor(result.data["audio_codes"])
+
+
+# ---------------------------------------------------------------------------
+# CPU parity fixture tests
+# ---------------------------------------------------------------------------
+
+
+def test_parity_identical_output_rows_give_identical_audio_codes():
+    """Same seed → identical output_rows → bit-identical audio_codes.
+
+    Core harness assertion: PR-A must not break this.
+    """
+    codes_a = _audio_codes(_data_with_rows(5, seed=42))
+    codes_b = _audio_codes(_data_with_rows(5, seed=42))
+    assert torch.equal(codes_a, codes_b)
+
+
+def test_parity_different_seeds_give_different_audio_codes():
+    """Different seeds → different rows → different audio_codes.
+
+    Validates the harness is sensitive enough to detect divergence.
+    """
+    codes_a = _audio_codes(_data_with_rows(5, seed=1))
+    codes_b = _audio_codes(_data_with_rows(5, seed=2))
+    assert not torch.equal(codes_a, codes_b), "harness must detect divergence"
+
+
+def test_parity_empty_output_rows_produce_empty_audio_codes():
+    data = MossTTSLocalSGLangRequestData(
+        input_ids=torch.zeros(4, dtype=torch.long),
+        max_new_tokens=64,
+        temperature=0.0,
+        output_ids=[],
+        prompt_rows=torch.full((4, _N_VQ + 1), 1024, dtype=torch.long),
+        stage_payload=_payload(),
+        engine_start_s=0.0,
+    )
+    codes = _audio_codes(data)
+    assert codes.shape == (0, _N_VQ)
+
+
+# ---------------------------------------------------------------------------
+# GPU gate scaffold (S0 baseline — do NOT modify after initial commit)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+def test_s0_graph_replay_is_deterministic():
+    """Two CUDA-graph replays with identical inputs must produce bit-identical outputs.
+
+    This test pins the S0 gate baseline for PR-A. It exercises the same
+    decode-frame kernel as the production v1.5 pipeline (MossTTSLocalTransformer
+    + sample_seeded_branchless loop). Do NOT modify after initial commit.
+    """
+    from sglang_omni.models.moss_tts_local.local_transformer import (
+        MossTTSLocalTransformer,
+        sample_seeded_branchless,
+    )
+
+    device = torch.device("cuda")
+    torch.manual_seed(0)
+    module = MossTTSLocalTransformer(
+        hidden_size=64,
+        num_heads=4,
+        inner_size=96,
+        num_layers=1,
+        max_positions=_N_VQ + 1,
+        rope_base=1_000_000.0,
+    ).to(device=device, dtype=torch.bfloat16)
+    tables = [
+        torch.randn(64, 64, device=device, dtype=torch.bfloat16)
+        for _ in range(_N_VQ)
+    ]
+
+    def decode_frame(
+        hidden: torch.Tensor,
+        seeds: torch.Tensor,
+        base: torch.Tensor,
+    ) -> torch.Tensor:
+        current = module.step(hidden, 0)
+        codes = []
+        for channel in range(_N_VQ):
+            logits = (current.float() @ tables[channel].float().T)[:, :32]
+            code = sample_seeded_branchless(
+                logits,
+                temperature=torch.full((hidden.shape[0],), 1.0, device=device),
+                top_p=torch.full((hidden.shape[0],), 1.0, device=device),
+                top_k=torch.full(
+                    (hidden.shape[0],), 32, device=device, dtype=torch.long
+                ),
+                seeds=seeds,
+                positions=base + channel + 1,
+            )
+            codes.append(code)
+            if channel + 1 < _N_VQ:
+                embed = torch.nn.functional.embedding(code, tables[channel][:32])
+                current = module.step(embed.to(torch.bfloat16), channel + 1)
+        return torch.stack(codes, dim=-1)
+
+    batch = 4
+    static_hidden = torch.zeros(batch, 64, device=device, dtype=torch.bfloat16)
+    static_seeds = torch.zeros(batch, device=device, dtype=torch.long)
+    static_base = torch.zeros(batch, device=device, dtype=torch.long)
+
+    # Warmup two passes before capture (required for CUDA graph stability).
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(2):
+            decode_frame(static_hidden, static_seeds, static_base)
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graphed_codes = decode_frame(static_hidden, static_seeds, static_base)
+
+    hidden = torch.randn(batch, 64, device=device, dtype=torch.bfloat16)
+    seeds = torch.arange(batch, device=device, dtype=torch.long) * 1_234_567
+    base = torch.full((batch,), 26, device=device, dtype=torch.long)
+
+    static_hidden.copy_(hidden)
+    static_seeds.copy_(seeds)
+    static_base.copy_(base)
+    graph.replay()
+    run1 = graphed_codes.clone()
+
+    static_hidden.copy_(hidden)
+    static_seeds.copy_(seeds)
+    static_base.copy_(base)
+    graph.replay()
+    run2 = graphed_codes.clone()
+
+    assert torch.equal(run1, run2), (
+        "CUDA graph replay with identical inputs must be bit-identical; "
+        "any divergence indicates non-determinism in the decode kernel"
+    )

--- a/tests/unit_test/moss_tts_local/test_parity_harness.py
+++ b/tests/unit_test/moss_tts_local/test_parity_harness.py
@@ -6,10 +6,11 @@ The GPU test (skipped without CUDA) verifies the frame-decode graph is
 deterministic and serves as the S0 gate baseline; it must not be modified
 after initial commit.
 """
+
 from __future__ import annotations
 
-import torch
 import pytest
+import torch
 
 from sglang_omni.models.moss_tts_local.request_builders import (
     MossTTSLocalSGLangRequestData,
@@ -18,7 +19,6 @@ from sglang_omni.models.moss_tts_local.request_builders import (
 from sglang_omni.proto import OmniRequest, StagePayload
 
 _N_VQ = 12
-_AUDIO_END_ID = 151670  # audio_end_token_id default (payload_types.py)
 
 
 def _payload(request_id: str = "r0") -> StagePayload:
@@ -42,10 +42,12 @@ def _data_with_rows(n_frames: int, seed: int) -> MossTTSLocalSGLangRequestData:
         engine_start_s=0.0,
     )
     for _ in range(n_frames):
-        row = torch.cat([
-            torch.tensor([1000]),  # non-stop slot
-            torch.randint(0, 1024, (_N_VQ,)),
-        ])
+        row = torch.cat(
+            [
+                torch.tensor([1000]),  # non-stop slot
+                torch.randint(0, 1024, (_N_VQ,)),
+            ]
+        )
         data.output_rows.append(row)
     return data
 
@@ -123,8 +125,7 @@ def test_s0_graph_replay_is_deterministic():
         rope_base=1_000_000.0,
     ).to(device=device, dtype=torch.bfloat16)
     tables = [
-        torch.randn(64, 64, device=device, dtype=torch.bfloat16)
-        for _ in range(_N_VQ)
+        torch.randn(64, 64, device=device, dtype=torch.bfloat16) for _ in range(_N_VQ)
     ]
 
     def decode_frame(

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -194,6 +194,105 @@ def test_pipeline_stage_wiring():
     assert colocated_stages["vocoder"].factory_args["device"] == "cuda:0"
 
 
+def test_tts_engine_forward_sample_flag_and_graph_init(monkeypatch):
+    import sys
+    from types import ModuleType, SimpleNamespace
+
+    from sglang_omni.models.moss_tts_local import stages
+
+    build_kwargs = []
+    infrastructure_saw_graph_disabled = []
+    init_graph_calls = []
+    frame_graph_calls = []
+    models = []
+
+    class _FakeSGLangRunner:
+        def __init__(self, model):
+            self.model = model
+
+        def init_device_graphs(self):
+            init_graph_calls.append(True)
+
+    class _FakeWorker:
+        gpu_id = 0
+
+        def __init__(self):
+            model = SimpleNamespace(
+                forward_sample_in_forward=None,
+                init_frame_decode_graphs=lambda buckets: frame_graph_calls.append(
+                    list(buckets)
+                ),
+            )
+            models.append(model)
+            self.model_runner = _FakeSGLangRunner(model)
+
+    def fake_build_sglang_server_args(model_path, context_length, **kwargs):
+        del model_path, context_length
+        build_kwargs.append(dict(kwargs))
+        return SimpleNamespace(disable_cuda_graph=kwargs["disable_cuda_graph"])
+
+    def fake_create_sglang_infrastructure(server_args, gpu_id, **kwargs):
+        del kwargs
+        assert gpu_id == 0
+        infrastructure_saw_graph_disabled.append(bool(server_args.disable_cuda_graph))
+        return (
+            _FakeWorker(),
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            SimpleNamespace(),
+        )
+
+    class _FakeScheduler:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    fake_bootstrap = ModuleType("sglang_omni.scheduling.bootstrap")
+    fake_bootstrap.create_sglang_infrastructure = fake_create_sglang_infrastructure
+    fake_backend = ModuleType("sglang_omni.scheduling.sglang_backend")
+    fake_backend.build_sglang_server_args = fake_build_sglang_server_args
+    fake_backend.SGLangOutputProcessor = lambda **kwargs: SimpleNamespace(**kwargs)
+    fake_scheduler = ModuleType("sglang_omni.scheduling.omni_scheduler")
+    fake_scheduler.OmniScheduler = _FakeScheduler
+    fake_runner = ModuleType("sglang_omni.models.moss_tts_local.model_runner")
+    fake_runner.MossTTSLocalModelRunner = lambda *args, **kwargs: SimpleNamespace(
+        args=args, kwargs=kwargs
+    )
+
+    monkeypatch.setitem(sys.modules, "sglang_omni.scheduling.bootstrap", fake_bootstrap)
+    monkeypatch.setitem(
+        sys.modules, "sglang_omni.scheduling.sglang_backend", fake_backend
+    )
+    monkeypatch.setitem(
+        sys.modules, "sglang_omni.scheduling.omni_scheduler", fake_scheduler
+    )
+    monkeypatch.setitem(
+        sys.modules, "sglang_omni.models.moss_tts_local.model_runner", fake_runner
+    )
+    monkeypatch.setattr(stages, "_resolve_checkpoint", lambda model_path: model_path)
+    monkeypatch.setattr(
+        stages,
+        "make_moss_tts_local_scheduler_adapters",
+        lambda **kwargs: (object(), object()),
+    )
+
+    stages.create_sglang_tts_engine_executor("model", device="cuda:0")
+    stages.create_sglang_tts_engine_executor(
+        "model", device="cuda:0", forward_sample_in_forward=True
+    )
+
+    assert models[0].forward_sample_in_forward is False
+    assert models[1].forward_sample_in_forward is True
+    assert all("forward_sample_in_forward" not in kwargs for kwargs in build_kwargs)
+    assert infrastructure_saw_graph_disabled == [True, True]
+    assert len(init_graph_calls) == 2
+    assert frame_graph_calls == [[1, 2, 4, 8, 16], [1, 2, 4, 8, 16]]
+    assert models[1]._moss_local_decode_cuda_graph_bs == [1, 2, 4, 8, 16]
+    assert models[1]._moss_local_decode_graph_padding is True
+
+
 def test_special_token_defaults_match_v15_checkpoint():
     defaults = dict(moss_tts_local_special_token_defaults())
     assert defaults["audio_start_token_id"] == 151669

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -242,6 +242,152 @@ def test_feedback_gather_equals_old_popleft():
     assert torch.equal(forward_batch.input_ids, torch.tensor([0, 1]))
 
 
+def _forward_sample_model(max_running_requests: int = 4) -> SimpleNamespace:
+    model = _model(max_running_requests=max_running_requests)
+    model.config = SimpleNamespace(
+        n_vq=12,
+        audio_assistant_slot_token_id=1000,
+        audio_end_token_id=1001,
+    )
+    model.device = torch.device("cpu")
+    model.forward_sample_in_forward = True
+    model._moss_local_decode_cuda_graph_bs = [1, 2, 4, 8, 16]
+    model._moss_local_decode_graph_padding = False
+    model._state_pool = MossTTSLocalDecodeStatePool(model)
+    hidden = model._decode_input_embedding.weight.shape[1]
+    model._cg_text_temp = torch.ones(max_running_requests, dtype=torch.float32)
+    model._cg_text_top_p = torch.ones(max_running_requests, dtype=torch.float32)
+    model._cg_text_top_k = torch.full((max_running_requests,), 50, dtype=torch.int64)
+    model._cg_audio_temp = torch.ones(max_running_requests, dtype=torch.float32)
+    model._cg_audio_top_p = torch.ones(max_running_requests, dtype=torch.float32)
+    model._cg_audio_top_k = torch.full((max_running_requests,), 25, dtype=torch.int64)
+    model._cg_seeds = torch.zeros(max_running_requests, dtype=torch.int64)
+    model._cg_base_positions = torch.zeros(max_running_requests, dtype=torch.int64)
+    model._cg_rows = torch.zeros(max_running_requests, 13, dtype=torch.int64)
+    model._cg_feedback = torch.zeros(
+        max_running_requests, hidden, dtype=model._decode_input_embedding.weight.dtype
+    )
+    return model
+
+
+def _decode_data(
+    *,
+    seed: int,
+    generation_steps: int,
+    audio_top_k: int = 25,
+    audio_repetition_penalty: float = 1.0,
+    is_chunked: int = 0,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        req=SimpleNamespace(is_chunked=is_chunked),
+        text_temperature=0.5 + seed / 100,
+        text_top_p=0.9,
+        text_top_k=40 + seed,
+        audio_temperature=1.7,
+        audio_top_p=0.8,
+        audio_top_k=audio_top_k,
+        sampling_seed=seed,
+        generation_steps=generation_steps,
+        audio_repetition_penalty=audio_repetition_penalty,
+        output_rows=[],
+    )
+
+
+def test_before_decode_stages_forward_sample_buffers_and_padding():
+    model = _forward_sample_model(max_running_requests=4)
+    pool = model._state_pool
+    row_a = pool.acquire_row("a")
+    row_b = pool.acquire_row("b")
+    pool.feedback_embeds[row_a] = torch.arange(_HIDDEN, dtype=torch.bfloat16)
+    pool.feedback_embeds[row_b] = torch.arange(_HIDDEN, dtype=torch.bfloat16) + 10
+    pool.feedback_embeds[pool.padding_row] = torch.full(
+        (_HIDDEN,), 99, dtype=torch.bfloat16
+    )
+
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    requests = [
+        SimpleNamespace(request_id="a", data=_decode_data(seed=3, generation_steps=2)),
+        SimpleNamespace(
+            request_id="b",
+            data=_decode_data(seed=5, generation_steps=4, audio_top_k=17),
+        ),
+    ]
+    forward_batch = SimpleNamespace(
+        batch_size=4,
+        input_ids=torch.full((4,), -1, dtype=torch.long),
+    )
+
+    runner.before_decode(forward_batch, SimpleNamespace(), requests)
+
+    expected_feedback = torch.stack(
+        [
+            pool.feedback_embeds[row_a],
+            pool.feedback_embeds[row_b],
+            pool.feedback_embeds[pool.padding_row],
+            pool.feedback_embeds[pool.padding_row],
+        ],
+        dim=0,
+    )
+    assert torch.equal(model._decode_input_embedding.weight[:4], expected_feedback)
+    assert torch.equal(forward_batch.input_ids, torch.tensor([0, 1, 2, 3]))
+    torch.testing.assert_close(
+        model._cg_text_temp[:2], torch.tensor([0.53, 0.55], dtype=torch.float32)
+    )
+    assert torch.equal(model._cg_audio_top_k[:2], torch.tensor([25, 17]))
+    assert torch.equal(model._cg_seeds[:2], torch.tensor([3, 5]))
+    assert torch.equal(model._cg_base_positions[:2], torch.tensor([26, 52]))
+    torch.testing.assert_close(model._cg_text_temp[2:4], torch.ones(2))
+    torch.testing.assert_close(model._cg_audio_top_p[2:4], torch.ones(2))
+    assert torch.equal(model._cg_text_top_k[2:4], torch.tensor([50, 50]))
+    assert torch.equal(model._cg_audio_top_k[2:4], torch.tensor([25, 25]))
+    assert torch.equal(model._cg_seeds[2:4], torch.tensor([0, 0]))
+    assert torch.equal(model._cg_base_positions[2:4], torch.tensor([0, 0]))
+    assert runner._forward_sample_pool_rows == [row_a, row_b]
+    assert runner._forward_sample_rids == ["a", "b"]
+
+
+def test_before_decode_stages_to_cuda_graph_bucket_when_padding_enabled():
+    model = _forward_sample_model(max_running_requests=4)
+    model._moss_local_decode_cuda_graph_bs = [1, 2, 4]
+    model._moss_local_decode_graph_padding = True
+    pool = model._state_pool
+    row = pool.acquire_row("a")
+    pool.feedback_embeds[row] = torch.arange(_HIDDEN, dtype=torch.bfloat16)
+    pool.feedback_embeds[pool.padding_row] = torch.full(
+        (_HIDDEN,), 11, dtype=torch.bfloat16
+    )
+
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    request = SimpleNamespace(
+        request_id="a", data=_decode_data(seed=3, generation_steps=2)
+    )
+    forward_batch = SimpleNamespace(
+        batch_size=3,
+        input_ids=torch.full((3,), -1, dtype=torch.long),
+    )
+
+    runner.before_decode(forward_batch, SimpleNamespace(), [request])
+
+    expected_feedback = torch.stack(
+        [
+            pool.feedback_embeds[row],
+            pool.feedback_embeds[pool.padding_row],
+            pool.feedback_embeds[pool.padding_row],
+            pool.feedback_embeds[pool.padding_row],
+        ],
+        dim=0,
+    )
+    assert torch.equal(model._decode_input_embedding.weight[:4], expected_feedback)
+    assert torch.equal(forward_batch.input_ids, torch.tensor([0, 1, 2]))
+    torch.testing.assert_close(model._cg_text_temp[1:4], torch.ones(3))
+    assert torch.equal(model._cg_text_top_k[1:4], torch.tensor([50, 50, 50]))
+    assert torch.equal(model._cg_audio_top_k[1:4], torch.tensor([25, 25, 25]))
+    assert torch.equal(model._cg_seeds[1:4], torch.tensor([0, 0, 0]))
+    assert torch.equal(model._cg_base_positions[1:4], torch.tensor([0, 0, 0]))
+
+
 def test_fresh_row_zeros_feedback():
     model = _model(max_running_requests=2)
     pool = MossTTSLocalDecodeStatePool(model)
@@ -450,6 +596,130 @@ def test_collect_frame_skips_chunked_feedback_and_journal():
     assert result.moss_journal.rids == ["normal"]
     assert result.moss_journal.pool_rows == [normal_row]
     assert result.moss_journal.rows.shape == (1, 13)
+
+
+def test_forward_sample_collect_matches_legacy_graph_collect():
+    def make_runner_and_model():
+        model = _forward_sample_model(max_running_requests=4)
+        model.frame_graph_max_bs = 4
+        model.acquire_row = model._state_pool.acquire_row
+        runner = object.__new__(MossTTSLocalModelRunner)
+        runner.model = model
+        return runner, model
+
+    codes = torch.stack(
+        [torch.arange(12, dtype=torch.long), torch.arange(12, dtype=torch.long) + 20],
+        dim=0,
+    )
+    stop_choice = torch.tensor([0, 1], dtype=torch.long)
+    feedback = torch.tensor(
+        [[3, 3, 3, 3, 3, 3, 3, 3], [7, 7, 7, 7, 7, 7, 7, 7]],
+        dtype=torch.bfloat16,
+    )
+    rows = torch.empty((2, 13), dtype=torch.long)
+    rows[:, 0] = torch.tensor([1000, 1001], dtype=torch.long)
+    rows[:, 1:] = codes
+
+    def requests():
+        return [
+            SimpleNamespace(
+                request_id="chunked",
+                data=_decode_data(seed=1, generation_steps=0, is_chunked=1),
+            ),
+            SimpleNamespace(
+                request_id="normal",
+                data=_decode_data(seed=2, generation_steps=0, is_chunked=0),
+            ),
+        ]
+
+    legacy_runner, legacy_model = make_runner_and_model()
+
+    def decode_frame_graphed(hidden_states, **kwargs):
+        del hidden_states, kwargs
+        return stop_choice, codes, feedback
+
+    legacy_model.decode_frame_graphed = decode_frame_graphed
+    legacy_result = SimpleNamespace(
+        logits_output=SimpleNamespace(hidden_states=torch.zeros(2, _HIDDEN))
+    )
+    legacy_batch = SimpleNamespace()
+    legacy_requests = requests()
+
+    legacy_runner._collect_frame_legacy(
+        legacy_result, SimpleNamespace(), legacy_batch, legacy_requests
+    )
+
+    new_runner, new_model = make_runner_and_model()
+    new_requests = requests()
+    forward_batch = SimpleNamespace(
+        batch_size=2,
+        input_ids=torch.full((2,), -1, dtype=torch.long),
+    )
+    new_runner.before_decode(forward_batch, SimpleNamespace(), new_requests)
+    new_model._cg_rows[:2] = rows
+    new_model._cg_feedback[:2] = feedback
+    new_result = SimpleNamespace(logits_output=SimpleNamespace())
+    new_batch = SimpleNamespace()
+
+    new_runner._collect_frame_from_forward_sample(new_result, new_batch, new_requests)
+
+    assert torch.equal(new_result.next_token_ids, legacy_result.next_token_ids)
+    assert torch.equal(new_batch.output_ids, legacy_batch.output_ids)
+    assert new_result.moss_journal.rids == legacy_result.moss_journal.rids
+    assert new_result.moss_journal.pool_rows == legacy_result.moss_journal.pool_rows
+    assert torch.equal(new_result.moss_journal.rows, legacy_result.moss_journal.rows)
+    assert torch.equal(
+        new_model._state_pool.feedback_embeds[new_model._state_pool.row_for("normal")],
+        legacy_model._state_pool.feedback_embeds[
+            legacy_model._state_pool.row_for("normal")
+        ],
+    )
+    assert torch.equal(
+        new_model._state_pool.feedback_embeds[new_model._state_pool.row_for("chunked")],
+        torch.zeros(_HIDDEN, dtype=torch.bfloat16),
+    )
+
+
+def test_collect_frame_repetition_penalty_falls_back_to_legacy():
+    model = _forward_sample_model(max_running_requests=2)
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    calls = []
+    runner._collect_frame_legacy = lambda *args: calls.append("legacy")
+    runner._collect_frame_from_forward_sample = lambda *args: calls.append("new")
+    request = SimpleNamespace(
+        request_id="rid",
+        data=_decode_data(seed=1, generation_steps=0, audio_repetition_penalty=1.2),
+    )
+    forward_batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(is_decode=lambda: True),
+    )
+    result = SimpleNamespace(logits_output=SimpleNamespace())
+
+    runner._collect_frame(result, forward_batch, SimpleNamespace(), [request])
+
+    assert calls == ["legacy"]
+
+
+def test_post_prefill_collection_remains_legacy_for_forward_sample_path():
+    model = _forward_sample_model(max_running_requests=2)
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    calls = []
+    runner._collect_frame_legacy = lambda *args: calls.append("legacy")
+    runner._collect_frame_from_forward_sample = lambda *args: calls.append("new")
+    request = SimpleNamespace(
+        request_id="rid",
+        data=_decode_data(seed=1, generation_steps=0),
+    )
+    forward_batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(is_decode=lambda: False),
+    )
+    result = SimpleNamespace(logits_output=SimpleNamespace())
+
+    runner.post_prefill(result, forward_batch, SimpleNamespace(), [request])
+
+    assert calls == ["legacy"]
 
 
 def test_journal_rid_assertion_fires():

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -58,6 +58,35 @@ def test_pool_dims_derive_from_embedding_weight():
     for name in ("text_top_k", "audio_top_k", "seeds"):
         assert getattr(pool, name).shape == (5,)
         assert getattr(pool, name).dtype == torch.int64
+    assert pool.base_positions.shape == (5,)
+    assert pool.base_positions.dtype == torch.int64
+    assert pool.stop_choice.shape == (5,)
+    assert pool.stop_choice.dtype == torch.int64
+    assert pool.codes.shape == (5, 12)
+    assert pool.codes.dtype == torch.int64
+    assert pool.rows.shape == (5, 13)
+    assert pool.rows.dtype == torch.int64
+    assert pool.sample_feedback_embeds.shape == (5, _HIDDEN)
+    assert pool.sample_feedback_embeds.dtype == torch.bfloat16
+
+
+def test_padding_row_has_safe_sampling_defaults():
+    pool = MossTTSLocalDecodeStatePool(_model(max_running_requests=4))
+    row = pool.padding_row
+    assert pool.text_temp[row].item() == 1.0
+    assert pool.text_top_p[row].item() == 1.0
+    assert int(pool.text_top_k[row]) == 50
+    assert pool.audio_temp[row].item() == 1.0
+    assert pool.audio_top_p[row].item() == 1.0
+    assert int(pool.audio_top_k[row]) == 25
+    assert int(pool.seeds[row]) == 0
+    assert int(pool.base_positions[row]) == 0
+
+    pool.text_temp[row] = 0.0
+    pool.text_top_k[row] = 0
+    pool.reset_row(row)
+    assert pool.text_temp[row].item() == 1.0
+    assert int(pool.text_top_k[row]) == 50
 
 
 def test_acquire_is_idempotent_by_rid():
@@ -114,11 +143,21 @@ def test_release_resets_row_fields():
     row = pool.acquire_row("a")
     pool.write_params(row, _params(seed=123))
     pool.feedback_embeds[row].fill_(1.0)
+    pool.base_positions[row] = 13
+    pool.stop_choice[row] = 1
+    pool.codes[row].fill_(3)
+    pool.rows[row].fill_(4)
+    pool.sample_feedback_embeds[row].fill_(5.0)
     pool.release_row("a")
     assert torch.all(pool.feedback_embeds[row] == 0)
     assert pool.text_temp[row] == 0.0
     assert pool.audio_top_k[row] == 0
     assert pool.seeds[row] == 0
+    assert pool.base_positions[row] == 0
+    assert pool.stop_choice[row] == 0
+    assert torch.all(pool.codes[row] == 0)
+    assert torch.all(pool.rows[row] == 0)
+    assert torch.all(pool.sample_feedback_embeds[row] == 0)
 
 
 def test_reset_row_zeroes_all_fields():
@@ -126,6 +165,11 @@ def test_reset_row_zeroes_all_fields():
     row = pool.acquire_row("a")
     pool.write_params(row, _params(seed=99))
     pool.feedback_embeds[row].fill_(2.0)
+    pool.base_positions[row] = 13
+    pool.stop_choice[row] = 1
+    pool.codes[row].fill_(3)
+    pool.rows[row].fill_(4)
+    pool.sample_feedback_embeds[row].fill_(5.0)
     pool.reset_row(row)
     assert torch.all(pool.feedback_embeds[row] == 0)
     for name in (
@@ -138,6 +182,11 @@ def test_reset_row_zeroes_all_fields():
         "seeds",
     ):
         assert getattr(pool, name)[row] == 0
+    assert pool.base_positions[row] == 0
+    assert pool.stop_choice[row] == 0
+    assert torch.all(pool.codes[row] == 0)
+    assert torch.all(pool.rows[row] == 0)
+    assert torch.all(pool.sample_feedback_embeds[row] == 0)
 
 
 def test_write_params_writes_request_static_fields():
@@ -254,18 +303,10 @@ def _forward_sample_model(max_running_requests: int = 4) -> SimpleNamespace:
     model._moss_local_decode_cuda_graph_bs = [1, 2, 4, 8, 16]
     model._moss_local_decode_graph_padding = False
     model._state_pool = MossTTSLocalDecodeStatePool(model)
-    hidden = model._decode_input_embedding.weight.shape[1]
-    model._cg_text_temp = torch.ones(max_running_requests, dtype=torch.float32)
-    model._cg_text_top_p = torch.ones(max_running_requests, dtype=torch.float32)
-    model._cg_text_top_k = torch.full((max_running_requests,), 50, dtype=torch.int64)
-    model._cg_audio_temp = torch.ones(max_running_requests, dtype=torch.float32)
-    model._cg_audio_top_p = torch.ones(max_running_requests, dtype=torch.float32)
-    model._cg_audio_top_k = torch.full((max_running_requests,), 25, dtype=torch.int64)
-    model._cg_seeds = torch.zeros(max_running_requests, dtype=torch.int64)
-    model._cg_base_positions = torch.zeros(max_running_requests, dtype=torch.int64)
-    model._cg_rows = torch.zeros(max_running_requests, 13, dtype=torch.int64)
-    model._cg_feedback = torch.zeros(
-        max_running_requests, hidden, dtype=model._decode_input_embedding.weight.dtype
+    model._cg_pool_rows = torch.full(
+        (max_running_requests,),
+        model._state_pool.padding_row,
+        dtype=torch.int64,
     )
     return model
 
@@ -317,32 +358,33 @@ def test_before_decode_stages_forward_sample_buffers_and_padding():
         batch_size=4,
         input_ids=torch.full((4,), -1, dtype=torch.long),
     )
+    original_weight = model._decode_input_embedding.weight.clone()
 
     runner.before_decode(forward_batch, SimpleNamespace(), requests)
 
-    expected_feedback = torch.stack(
-        [
-            pool.feedback_embeds[row_a],
-            pool.feedback_embeds[row_b],
-            pool.feedback_embeds[pool.padding_row],
-            pool.feedback_embeds[pool.padding_row],
-        ],
-        dim=0,
-    )
-    assert torch.equal(model._decode_input_embedding.weight[:4], expected_feedback)
+    assert torch.equal(model._decode_input_embedding.weight, original_weight)
     assert torch.equal(forward_batch.input_ids, torch.tensor([0, 1, 2, 3]))
-    torch.testing.assert_close(
-        model._cg_text_temp[:2], torch.tensor([0.53, 0.55], dtype=torch.float32)
+    assert torch.equal(
+        model._cg_pool_rows[:4],
+        torch.tensor([row_a, row_b, pool.padding_row, pool.padding_row]),
     )
-    assert torch.equal(model._cg_audio_top_k[:2], torch.tensor([25, 17]))
-    assert torch.equal(model._cg_seeds[:2], torch.tensor([3, 5]))
-    assert torch.equal(model._cg_base_positions[:2], torch.tensor([26, 52]))
-    torch.testing.assert_close(model._cg_text_temp[2:4], torch.ones(2))
-    torch.testing.assert_close(model._cg_audio_top_p[2:4], torch.ones(2))
-    assert torch.equal(model._cg_text_top_k[2:4], torch.tensor([50, 50]))
-    assert torch.equal(model._cg_audio_top_k[2:4], torch.tensor([25, 25]))
-    assert torch.equal(model._cg_seeds[2:4], torch.tensor([0, 0]))
-    assert torch.equal(model._cg_base_positions[2:4], torch.tensor([0, 0]))
+    torch.testing.assert_close(
+        pool.text_temp[torch.tensor([row_a, row_b])],
+        torch.tensor([0.53, 0.55], dtype=torch.float32),
+    )
+    assert torch.equal(
+        pool.audio_top_k[torch.tensor([row_a, row_b])], torch.tensor([25, 17])
+    )
+    assert torch.equal(pool.seeds[torch.tensor([row_a, row_b])], torch.tensor([3, 5]))
+    assert torch.equal(
+        pool.base_positions[torch.tensor([row_a, row_b])], torch.tensor([26, 52])
+    )
+    assert pool.text_temp[pool.padding_row].item() == 1.0
+    assert pool.audio_top_p[pool.padding_row].item() == 1.0
+    assert int(pool.text_top_k[pool.padding_row]) == 50
+    assert int(pool.audio_top_k[pool.padding_row]) == 25
+    assert int(pool.seeds[pool.padding_row]) == 0
+    assert int(pool.base_positions[pool.padding_row]) == 0
     assert runner._forward_sample_pool_rows == [row_a, row_b]
     assert runner._forward_sample_rids == ["a", "b"]
 
@@ -367,25 +409,21 @@ def test_before_decode_stages_to_cuda_graph_bucket_when_padding_enabled():
         batch_size=3,
         input_ids=torch.full((3,), -1, dtype=torch.long),
     )
+    original_weight = model._decode_input_embedding.weight.clone()
 
     runner.before_decode(forward_batch, SimpleNamespace(), [request])
 
-    expected_feedback = torch.stack(
-        [
-            pool.feedback_embeds[row],
-            pool.feedback_embeds[pool.padding_row],
-            pool.feedback_embeds[pool.padding_row],
-            pool.feedback_embeds[pool.padding_row],
-        ],
-        dim=0,
-    )
-    assert torch.equal(model._decode_input_embedding.weight[:4], expected_feedback)
+    assert torch.equal(model._decode_input_embedding.weight, original_weight)
     assert torch.equal(forward_batch.input_ids, torch.tensor([0, 1, 2]))
-    torch.testing.assert_close(model._cg_text_temp[1:4], torch.ones(3))
-    assert torch.equal(model._cg_text_top_k[1:4], torch.tensor([50, 50, 50]))
-    assert torch.equal(model._cg_audio_top_k[1:4], torch.tensor([25, 25, 25]))
-    assert torch.equal(model._cg_seeds[1:4], torch.tensor([0, 0, 0]))
-    assert torch.equal(model._cg_base_positions[1:4], torch.tensor([0, 0, 0]))
+    assert torch.equal(
+        model._cg_pool_rows[:4],
+        torch.tensor([row, pool.padding_row, pool.padding_row, pool.padding_row]),
+    )
+    assert pool.text_temp[pool.padding_row].item() == 1.0
+    assert int(pool.text_top_k[pool.padding_row]) == 50
+    assert int(pool.audio_top_k[pool.padding_row]) == 25
+    assert int(pool.seeds[pool.padding_row]) == 0
+    assert int(pool.base_positions[pool.padding_row]) == 0
 
 
 def test_fresh_row_zeros_feedback():
@@ -656,8 +694,12 @@ def test_forward_sample_collect_matches_legacy_graph_collect():
         input_ids=torch.full((2,), -1, dtype=torch.long),
     )
     new_runner.before_decode(forward_batch, SimpleNamespace(), new_requests)
-    new_model._cg_rows[:2] = rows
-    new_model._cg_feedback[:2] = feedback
+    new_pool = new_model._state_pool
+    new_pool_row_t = torch.tensor(
+        new_runner._forward_sample_pool_rows, dtype=torch.long, device=new_pool.device
+    )
+    new_pool.rows[new_pool_row_t] = rows
+    new_pool.sample_feedback_embeds[new_pool_row_t] = feedback
     new_result = SimpleNamespace(logits_output=SimpleNamespace())
     new_batch = SimpleNamespace()
 


### PR DESCRIPTION
## Motivation

Move the opt-in MOSS-TTS Local `forward_sample_in_forward` decode path toward pool-resident state for CUDA-graph-friendly execution.

Previously this path copied feedback embeddings, sampling params, base positions, and sampled outputs through private `_cg_*` staging buffers each decode step. This PR keeps only a small `_cg_pool_rows` row-id staging buffer and stores the stable decode inputs/outputs in `MossTTSLocalDecodeStatePool`.

This is related to #736, but does not close it. GPU-native radix hashing remains follow-up work.

## Modifications

- Added pool-owned buffers for forward-sample decode state:
  - `base_positions`
  - `stop_choice`
  - `codes`
  - `rows`
  - `sample_feedback_embeds`
- Preserved safe sampling defaults on the reserved padding row:
  - temperature/top-p: `1.0`
  - text top-k: `50`
  - audio top-k: `25`
  - seed/base position: `0`
- Replaced per-step `_cg_text_*`, `_cg_audio_*`, `_cg_seeds`, `_cg_base_positions`, `_cg_rows`, and `_cg_feedback` staging with `_cg_pool_rows`.
- Updated forward-sample decode preparation to:
  - acquire pool rows for real requests
  - pad CUDA graph buckets with `pool.padding_row`
  - write per-step `pool.base_positions`
  - avoid mutating `_decode_input_embedding.weight`
- Updated model forward decode to:
  - read feedback embeddings from `pool.feedback_embeds`
  - read sampling params/base positions from pool rows
  - write sampled frame rows and candidate feedback back into pool outputs
- Updated forward-sample collection to snapshot pool outputs and keep the existing chunked-request, journal, repetition-penalty fallback, and post-prefill legacy behavior.
- Added/updated focused unit tests for the pool buffers, padding defaults, row-id staging, decode embedding immutability, pool-output collection, chunked feedback behavior, and legacy fallbacks.

## Related Issues

Related to #736.

## Accuracy Test

Not run. This PR changes opt-in decode-state plumbing for `forward_sample_in_forward`, which remains disabled by default. Fixed-seed model parity requires GPU/model assets that were not available in this local environment.

## Benchmark & Profiling

Not run. This PR is expected to reduce per-step staging copies on the opt-in forward-sample path, but no throughput/latency benchmark was collected locally.

## Checklist

- [ ] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Draft PRs are skipped even if labeled.

Local test run:

```bash
PYTHONPATH=$PWD .venv/bin/python -m pytest \
  tests/unit_test/moss_tts_local/test_state_pool.py \
  tests/unit_test/moss_tts_local/test_pipeline.py -q
```

Result:

```text
56 passed, 2 warnings
```
