### PR TITLE
[Perf] MOSS-TTS Local v1.5: native pool-resident CUDA graph for the frame-decode sampling path

### DIFF
--- a/sglang_omni/models/moss_tts_local/local_transformer.py
+++ b/sglang_omni/models/moss_tts_local/local_transformer.py
@@ -183,6 +183,15 @@ class MossTTSLocalTransformer(nn.Module):
         ]
         self._kv_capacity = capacity
 
+    def reserve_and_freeze_kv_cache(
+        self, batch_size: int, device: torch.device, dtype: torch.dtype
+    ) -> None:
+        """Size the KV cache for ``batch_size`` then freeze it. Single
+        pre-capture entry point, so the ensure-then-freeze ordering lives here
+        rather than in callers."""
+        self._ensure_kv_cache(batch_size, device, dtype)
+        self.freeze_kv_cache()
+
     def step(self, hidden_states: torch.Tensor, position: int) -> torch.Tensor:
         """One micro-step for the whole batch."""
         if not 0 <= position < self.max_positions:

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import bisect
 from typing import Any
 
 import torch
@@ -19,11 +20,9 @@ class MossTTSLocalModelRunner(ModelRunner):
     """Drives the per-frame local-transformer decode and feedback embeddings.
 
     Per step: the backbone (radix-cached, CUDA-graphed) produces one hidden
-    state per request; :meth:`_collect_frame` then runs the batched local
-    micro-decode — a binary continue/stop decision and 12 sequentially
-    sampled RVQ codes — and stages the next frame's summed embedding through
-    ``model._decode_input_embedding`` so the next decode step stays
-    CUDA-graph-replayable (decode input_ids are row indices).
+    state per request. Prefill collection runs the local micro-decode in the
+    runner; decode collection reads the frame sampled inside model forward and
+    staged in the row-indexed decode-state pool.
     """
 
     _outbox: Any | None = None
@@ -59,7 +58,7 @@ class MossTTSLocalModelRunner(ModelRunner):
     ) -> None:
         del is_lookahead
         del schedule_batch
-        self._write_decode_input_embedding(forward_batch, requests)
+        self._prepare_forward_sample_inputs(forward_batch, requests)
 
     def post_prefill(
         self,
@@ -74,7 +73,7 @@ class MossTTSLocalModelRunner(ModelRunner):
             is_prefill_only = False
         if bool(is_prefill_only):
             return
-        self._collect_frame(result, forward_batch, schedule_batch, requests)
+        self._collect_frame_legacy(result, forward_batch, schedule_batch, requests)
 
     def post_decode(
         self,
@@ -83,7 +82,10 @@ class MossTTSLocalModelRunner(ModelRunner):
         schedule_batch: Any,
         requests: list,
     ) -> None:
-        self._collect_frame(result, forward_batch, schedule_batch, requests)
+        if bool(getattr(forward_batch, "moss_has_audio_repetition_penalty", False)):
+            self._collect_frame_legacy(result, forward_batch, schedule_batch, requests)
+            return
+        self._collect_frame_from_forward_sample(result, schedule_batch, requests)
 
     def lookahead_eligible(self, batch: Any) -> bool:
         """Route to sync when the batch cannot take the graphed frame-decode
@@ -177,37 +179,236 @@ class MossTTSLocalModelRunner(ModelRunner):
         forward_batch: Any,
         requests: list,
     ) -> None:
-        batch_size = len(requests)
-        if batch_size == 0:
+        self._prepare_forward_sample_inputs(forward_batch, requests)
+
+    def _decode_staging_batch_size(self, raw_batch_size: int) -> int:
+        """Return the model-buffer rows SGLang may read for this decode step.
+
+        SGLang's cuda graph runner receives the raw ForwardBatch, then pads it
+        to the next captured ``cuda_graph_bs`` bucket during replay. The model
+        staging buffers are outside SGLang's GraphInputBuffers, so they must be
+        prefilled up to the same bucket here.
+        """
+        raw_batch_size = int(raw_batch_size)
+        if raw_batch_size <= 0:
+            return 0
+        if not bool(getattr(self.model, "_moss_local_decode_graph_padding", False)):
+            return raw_batch_size
+        buckets = sorted(
+            {
+                int(bs)
+                for bs in getattr(self.model, "_moss_local_decode_cuda_graph_bs", [])
+                if int(bs) > 0
+            }
+        )
+        if not buckets:
+            return raw_batch_size
+        idx = bisect.bisect_left(buckets, raw_batch_size)
+        return buckets[idx] if idx < len(buckets) else raw_batch_size
+
+    def _prepare_forward_sample_inputs(
+        self,
+        forward_batch: Any,
+        requests: list,
+    ) -> None:
+        if not requests:
+            self._forward_sample_pool_rows = []
+            self._forward_sample_pool_row_t = None
+            self._forward_sample_rids = []
+            self._forward_sample_native_decode = True
             return
-        pool = self.model._state_pool
-        weight = self.model._decode_input_embedding.weight
-        if forward_batch.input_ids.numel() < batch_size:
+        n_real = len(requests)
+        raw_batch_size = int(getattr(forward_batch, "batch_size", n_real) or n_real)
+        staging_batch_size = self._decode_staging_batch_size(raw_batch_size)
+        model = self.model
+        max_rows = int(model._cg_pool_rows.shape[0])
+        if raw_batch_size < n_real:
             raise RuntimeError(
-                "MOSS-TTS Local decode input_ids must contain one row id per request"
+                "MOSS-TTS Local decode graph batch is smaller than the "
+                f"real batch ({raw_batch_size} < {n_real})"
             )
-        if batch_size > pool.padding_row:
+        if forward_batch.input_ids.numel() < raw_batch_size:
             raise RuntimeError(
-                "MOSS-TTS Local decode batch exceeds the staged decode-embedding "
-                f"rows ({batch_size} > {pool.padding_row})"
+                "MOSS-TTS Local decode input_ids must contain " "one row id per request"
             )
+        if staging_batch_size > max_rows:
+            raise RuntimeError(
+                "MOSS-TTS Local decode batch exceeds staging buffers "
+                f"({staging_batch_size} > {max_rows})"
+            )
+
+        pool = model._state_pool
         row_tensor, pool_rows, has_audio_repetition_penalty = pool.prepare_active_rows(
             requests
         )
+        staged_pool_rows = list(pool_rows)
+        if staging_batch_size > n_real:
+            staged_pool_rows.extend([pool.padding_row] * (staging_batch_size - n_real))
+        row_t = torch.tensor(
+            staged_pool_rows, dtype=torch.long, device=pool.feedback_embeds.device
+        )
+
         with torch.no_grad():
-            weight[:batch_size].copy_(pool.feedback_embeds[row_tensor])
+            model._cg_pool_rows[:staging_batch_size].copy_(
+                row_t.to(device=model._cg_pool_rows.device)
+            )
+            active_rows_t = model._cg_pool_rows[:staging_batch_size].to(
+                device=pool.feedback_embeds.device
+            )
+            model._cg_active_feedback_embeds[:staging_batch_size].copy_(
+                pool.feedback_embeds[active_rows_t].to(
+                    device=model._cg_active_feedback_embeds.device,
+                    dtype=model._cg_active_feedback_embeds.dtype,
+                )
+            )
+            model._cg_active_text_temp[:staging_batch_size].copy_(
+                pool.text_temp[active_rows_t].to(
+                    device=model._cg_active_text_temp.device,
+                    dtype=model._cg_active_text_temp.dtype,
+                )
+            )
+            model._cg_active_text_top_p[:staging_batch_size].copy_(
+                pool.text_top_p[active_rows_t].to(
+                    device=model._cg_active_text_top_p.device,
+                    dtype=model._cg_active_text_top_p.dtype,
+                )
+            )
+            model._cg_active_text_top_k[:staging_batch_size].copy_(
+                pool.text_top_k[active_rows_t].to(
+                    device=model._cg_active_text_top_k.device,
+                    dtype=model._cg_active_text_top_k.dtype,
+                )
+            )
+            model._cg_active_audio_temp[:staging_batch_size].copy_(
+                pool.audio_temp[active_rows_t].to(
+                    device=model._cg_active_audio_temp.device,
+                    dtype=model._cg_active_audio_temp.dtype,
+                )
+            )
+            model._cg_active_audio_top_p[:staging_batch_size].copy_(
+                pool.audio_top_p[active_rows_t].to(
+                    device=model._cg_active_audio_top_p.device,
+                    dtype=model._cg_active_audio_top_p.dtype,
+                )
+            )
+            model._cg_active_audio_top_k[:staging_batch_size].copy_(
+                pool.audio_top_k[active_rows_t].to(
+                    device=model._cg_active_audio_top_k.device,
+                    dtype=model._cg_active_audio_top_k.dtype,
+                )
+            )
+            model._cg_active_seeds[:staging_batch_size].copy_(
+                pool.seeds[active_rows_t].to(
+                    device=model._cg_active_seeds.device,
+                    dtype=model._cg_active_seeds.dtype,
+                )
+            )
+            model._cg_active_sampling_steps[:staging_batch_size].copy_(
+                pool.sampling_steps[active_rows_t].to(
+                    device=model._cg_active_sampling_steps.device,
+                    dtype=model._cg_active_sampling_steps.dtype,
+                )
+            )
+            model._cg_active_audio_repetition_penalty[:staging_batch_size].copy_(
+                pool.audio_repetition_penalty[active_rows_t].to(
+                    device=model._cg_active_audio_repetition_penalty.device,
+                    dtype=model._cg_active_audio_repetition_penalty.dtype,
+                )
+            )
+
+        row_ids = torch.arange(
+            raw_batch_size,
+            dtype=torch.long,
+            device=forward_batch.input_ids.device,
+        )
+        forward_batch.input_ids[:raw_batch_size].copy_(row_ids)
         forward_batch.moss_pool_row_t = row_tensor
         forward_batch.moss_pool_rows = pool_rows
         forward_batch.moss_has_audio_repetition_penalty = has_audio_repetition_penalty
 
-        row_ids = torch.arange(
-            batch_size,
-            dtype=torch.long,
-            device=forward_batch.input_ids.device,
-        )
-        forward_batch.input_ids[:batch_size].copy_(row_ids)
+        self._forward_sample_pool_rows = pool_rows
+        self._forward_sample_pool_row_t = row_tensor
+        self._forward_sample_rids = [sched_req.request_id for sched_req in requests]
+        self._forward_sample_native_decode = not has_audio_repetition_penalty
 
     def _collect_frame(
+        self,
+        result: Any,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list,
+    ) -> None:
+        self._collect_frame_legacy(result, forward_batch, schedule_batch, requests)
+
+    def _collect_frame_from_forward_sample(
+        self,
+        result: Any,
+        schedule_batch: Any,
+        requests: list,
+    ) -> None:
+        # Sampling already ran inside MossTTSLocalSGLangModel.forward() via the
+        # native decode-forward path. Collection only snapshots the fixed
+        # active-slot step buffers and publishes the graph-computed token ids.
+        if not requests:
+            return
+        n_real = len(requests)
+        current_rids = [sched_req.request_id for sched_req in requests]
+        staged_rids = list(getattr(self, "_forward_sample_rids", []))
+        pool_rows = list(getattr(self, "_forward_sample_pool_rows", []))
+        if staged_rids[:n_real] != current_rids:
+            raise RuntimeError(
+                "MOSS-TTS Local decode pool request alignment broken: "
+                f"{staged_rids[:n_real]} != {current_rids}"
+            )
+        if len(pool_rows) < n_real:
+            raise RuntimeError(
+                "MOSS-TTS Local decode pool row staging is incomplete: "
+                f"{len(pool_rows)} < {n_real}"
+            )
+
+        model = self.model
+        pool = model._state_pool
+        rows = model._cg_step_rows[:n_real]
+        next_token_ids = model._cg_step_next_token_ids[:n_real]
+        result.next_token_ids = next_token_ids
+        if schedule_batch is not None:
+            schedule_batch.output_ids = next_token_ids
+
+        emit_indices = [
+            i
+            for i, sched_req in enumerate(requests)
+            if not self._is_chunked_request(sched_req)
+        ]
+        if not emit_indices:
+            return
+
+        emit_index_t = torch.tensor(emit_indices, dtype=torch.long, device=rows.device)
+        emit_pool_rows = [pool_rows[i] for i in emit_indices]
+        cached_row_t = getattr(self, "_forward_sample_pool_row_t", None)
+        if isinstance(cached_row_t, torch.Tensor) and int(cached_row_t.numel()) >= n_real:
+            emit_row_t = cached_row_t.index_select(
+                0, emit_index_t.to(device=cached_row_t.device)
+            )
+        else:
+            emit_row_t = torch.tensor(
+                emit_pool_rows,
+                dtype=torch.long,
+                device=pool.feedback_embeds.device,
+            )
+        emit_row_t = emit_row_t.to(device=pool.feedback_embeds.device, dtype=torch.long)
+        pool.feedback_embeds[emit_row_t] = model._cg_active_next_feedback_embeds[
+            emit_index_t.to(device=model._cg_active_next_feedback_embeds.device)
+        ].to(device=pool.feedback_embeds.device, dtype=pool.feedback_embeds.dtype)
+        pool.sampling_steps[emit_row_t] = model._cg_active_next_sampling_steps[
+            emit_index_t.to(device=model._cg_active_next_sampling_steps.device)
+        ].to(device=pool.sampling_steps.device, dtype=torch.int64)
+        result.moss_journal = MossTTSLocalDecodeJournal(
+            rids=[requests[i].request_id for i in emit_indices],
+            pool_rows=emit_pool_rows,
+            rows=rows.index_select(0, emit_index_t),
+        )
+
+    def _collect_frame_legacy(
         self,
         result: Any,
         forward_batch: Any,
@@ -418,20 +619,31 @@ class MossTTSLocalModelRunner(ModelRunner):
         return rows, end_id
 
     def post_decode_launch(self, result: Any, forward_batch: Any, requests: list):
-        """Async-decode GPU half of ``post_decode``: run the frame micro-decode
-        (``_run_frame_decode``) and publish the device-computed radix ids, no
-        host sync. Returns a private device snapshot of those ids for resolve:
-        the base aliases ``next_token_ids`` onto ``output_ids``, which the next
-        step overwrites in place before this step's lagged resolve, clobbering
-        the stop id and silently dropping a bs=1 eos finish (4096-frame runaway).
-        The clone preserves it; resolve swaps it back.
+        """Async-decode GPU half of ``post_decode``: publish the native
+        forward-sampled frame ids, no host sync. Returns a private device
+        snapshot of those ids for resolve: the base aliases ``next_token_ids``
+        onto ``output_ids``, which the next step overwrites in place before this
+        step's lagged resolve, clobbering the stop id and silently dropping a
+        bs=1 eos finish (4096-frame runaway). The clone preserves it; resolve
+        swaps it back.
         """
         if not requests:
             return None
-        rows, end_id = self._run_frame_decode(result, forward_batch, requests)
-        next_token_ids = self._row_radix_token_ids(rows, rows[:, 0], end_id)
-        result.next_token_ids = next_token_ids
-        return next_token_ids.clone()
+        if (
+            not bool(getattr(self, "_forward_sample_native_decode", False))
+            or (
+                forward_batch is not None
+                and bool(
+                    getattr(forward_batch, "moss_has_audio_repetition_penalty", False)
+                )
+            )
+        ):
+            rows, end_id = self._run_frame_decode(result, forward_batch, requests)
+            next_token_ids = self._row_radix_token_ids(rows, rows[:, 0], end_id)
+            result.next_token_ids = next_token_ids
+            return next_token_ids.clone()
+        self._collect_frame_from_forward_sample(result, None, requests)
+        return result.next_token_ids.clone()
 
     def post_decode_resolve(
         self,

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import bisect
 from typing import Any
 
 import torch
@@ -88,7 +87,7 @@ class MossTTSLocalModelRunner(ModelRunner):
             is_prefill_only = False
         if bool(is_prefill_only):
             return
-        self._collect_frame_eager(result, forward_batch, schedule_batch, requests)
+        self._collect_frame_in_runner(result, forward_batch, schedule_batch, requests)
 
     def post_decode(
         self,
@@ -100,7 +99,7 @@ class MossTTSLocalModelRunner(ModelRunner):
         if not bool(getattr(self, "_forward_sample_native_decode", False)) or bool(
             getattr(forward_batch, "moss_has_audio_repetition_penalty", False)
         ):
-            self._collect_frame_eager(result, forward_batch, schedule_batch, requests)
+            self._collect_frame_in_runner(result, forward_batch, schedule_batch, requests)
             return
         self._collect_frame_from_forward_sample(result, schedule_batch, requests)
 
@@ -191,40 +190,6 @@ class MossTTSLocalModelRunner(ModelRunner):
             dtype=self.model.dtype,
         )
 
-    def _decode_staging_batch_size(self, raw_batch_size: int) -> int:
-        """Return the model-buffer rows SGLang may read for this decode step.
-
-        SGLang's cuda graph runner receives the raw ForwardBatch, then pads it
-        to the next captured ``cuda_graph_bs`` bucket during replay. The model
-        staging buffers are outside SGLang's GraphInputBuffers, so they must be
-        prefilled up to the same bucket here.
-        """
-        raw_batch_size = int(raw_batch_size)
-        if raw_batch_size <= 0:
-            return 0
-        if not bool(getattr(self.model, "_moss_local_decode_graph_padding", False)):
-            return raw_batch_size
-        buckets = sorted(
-            {
-                int(bs)
-                for bs in getattr(self.model, "_moss_local_decode_cuda_graph_bs", [])
-                if int(bs) > 0
-            }
-        )
-        if not buckets:
-            return raw_batch_size
-        idx = bisect.bisect_left(buckets, raw_batch_size)
-        if idx >= len(buckets):
-            return raw_batch_size
-        staging_batch_size = buckets[idx]
-        try:
-            frame_graph_max_bs = int(self.model.frame_graph_max_bs)
-        except AttributeError:
-            frame_graph_max_bs = max(buckets)
-        if staging_batch_size > frame_graph_max_bs:
-            return raw_batch_size
-        return staging_batch_size
-
     def _prepare_forward_sample_inputs(
         self,
         forward_batch: Any,
@@ -238,23 +203,22 @@ class MossTTSLocalModelRunner(ModelRunner):
             self.model._moss_local_forward_native_decode_active = False
             return
         n_real = len(requests)
-        raw_batch_size = int(getattr(forward_batch, "batch_size", n_real) or n_real)
-        staging_batch_size = self._decode_staging_batch_size(raw_batch_size)
+        batch_size = int(getattr(forward_batch, "batch_size", n_real) or n_real)
         model = self.model
         max_rows = int(model._cg_pool_rows.shape[0])
-        if raw_batch_size < n_real:
+        if batch_size < n_real:
             raise RuntimeError(
-                "MOSS-TTS Local decode graph batch is smaller than the "
-                f"real batch ({raw_batch_size} < {n_real})"
+                "MOSS-TTS Local decode batch is smaller than the "
+                f"real batch ({batch_size} < {n_real})"
             )
-        if forward_batch.input_ids.numel() < raw_batch_size:
+        if forward_batch.input_ids.numel() < batch_size:
             raise RuntimeError(
-                "MOSS-TTS Local decode input_ids must contain " "one row id per request"
+                "MOSS-TTS Local decode input_ids must contain one row id per request"
             )
-        if staging_batch_size > max_rows:
+        if batch_size > max_rows:
             raise RuntimeError(
                 "MOSS-TTS Local decode batch exceeds staging buffers "
-                f"({staging_batch_size} > {max_rows})"
+                f"({batch_size} > {max_rows})"
             )
 
         pool = model._state_pool
@@ -266,50 +230,37 @@ class MossTTSLocalModelRunner(ModelRunner):
         except AttributeError:
             frame_graph_max_bs = 0
         use_forward_native_decode = (
-            bool(getattr(model, "_moss_local_forward_native_decode_enabled", False))
+            getattr(model, "_moss_local_native_decode_enabled", False)
             and not has_audio_repetition_penalty
-            and raw_batch_size <= frame_graph_max_bs
+            and batch_size <= frame_graph_max_bs
         )
         model._moss_local_forward_native_decode_active = use_forward_native_decode
         staged_pool_rows = list(pool_rows)
-        if staging_batch_size > n_real:
-            staged_pool_rows.extend([pool.padding_row] * (staging_batch_size - n_real))
+        if batch_size > n_real:
+            staged_pool_rows.extend([pool.padding_row] * (batch_size - n_real))
         row_t = torch.tensor(
             staged_pool_rows, dtype=torch.long, device=pool.feedback_embeds.device
         )
+        stage_fields = self._DYNAMIC_STAGE_FIELDS
+        if use_forward_native_decode:
+            stage_fields = stage_fields + self._STATIC_STAGE_FIELDS
 
         with torch.no_grad():
-            model._cg_pool_rows[:staging_batch_size].copy_(
+            model._cg_pool_rows[:batch_size].copy_(
                 row_t.to(device=model._cg_pool_rows.device)
             )
-            active_rows_t = model._cg_pool_rows[:staging_batch_size].to(
+            active_rows_t = model._cg_pool_rows[:batch_size].to(
                 device=pool.feedback_embeds.device
             )
-            for dst_name, src_name in self._DYNAMIC_STAGE_FIELDS:
+            for dst_name, src_name in stage_fields:
                 dst = getattr(model, dst_name)
                 src = getattr(pool, src_name)
-                dst[:staging_batch_size].copy_(
+                dst[:batch_size].copy_(
                     src[active_rows_t].to(device=dst.device, dtype=dst.dtype)
-                )
-            static_copy_slots = 0
-            if use_forward_native_decode:
-                static_copy_slots = self._stage_static_fields_for_changed_rows(
-                    model,
-                    pool,
-                    active_rows_t,
-                    staging_batch_size,
                 )
             stats = getattr(model, "_moss_local_decode_stats", None)
             if isinstance(stats, dict):
-                stats["raw_batch_size"] = raw_batch_size
-                stats["staging_batch_size"] = staging_batch_size
-                stats["dynamic_stage_copy_slots"] = (
-                    stats.get("dynamic_stage_copy_slots", 0)
-                    + staging_batch_size * len(self._DYNAMIC_STAGE_FIELDS)
-                )
-                stats["static_stage_copy_slots"] = (
-                    stats.get("static_stage_copy_slots", 0) + static_copy_slots
-                )
+                stats["batch_size"] = batch_size
                 key = (
                     "forward_native_enabled_count"
                     if use_forward_native_decode
@@ -318,11 +269,11 @@ class MossTTSLocalModelRunner(ModelRunner):
                 stats[key] = stats.get(key, 0) + 1
 
         row_ids = torch.arange(
-            raw_batch_size,
+            batch_size,
             dtype=torch.long,
             device=forward_batch.input_ids.device,
         )
-        forward_batch.input_ids[:raw_batch_size].copy_(row_ids)
+        forward_batch.input_ids[:batch_size].copy_(row_ids)
         forward_batch.moss_pool_row_t = row_tensor
         forward_batch.moss_pool_rows = pool_rows
         forward_batch.moss_has_audio_repetition_penalty = has_audio_repetition_penalty
@@ -331,69 +282,6 @@ class MossTTSLocalModelRunner(ModelRunner):
         self._forward_sample_pool_row_t = row_tensor
         self._forward_sample_rids = [sched_req.request_id for sched_req in requests]
         self._forward_sample_native_decode = use_forward_native_decode
-
-    def _stage_static_fields_for_changed_rows(
-        self,
-        model: Any,
-        pool: Any,
-        active_rows_t: torch.Tensor,
-        staging_batch_size: int,
-    ) -> int:
-        if not hasattr(model, "_cg_active_pool_rows_cached"):
-            model._cg_active_pool_rows_cached = torch.full_like(
-                model._cg_pool_rows, -1
-            )
-        if not hasattr(model, "_cg_active_pool_row_versions_cached"):
-            model._cg_active_pool_row_versions_cached = torch.full_like(
-                model._cg_pool_rows, -1
-            )
-        active_rows_for_cache = model._cg_pool_rows[:staging_batch_size]
-        active_versions = pool.params_versions[active_rows_t].to(
-            device=active_rows_for_cache.device,
-            dtype=torch.int64,
-        )
-        cached_rows = model._cg_active_pool_rows_cached[:staging_batch_size]
-        cached_versions = model._cg_active_pool_row_versions_cached[
-            :staging_batch_size
-        ]
-        changed = (cached_rows != active_rows_for_cache) | (
-            cached_versions != active_versions
-        )
-        changed_idx = torch.nonzero(changed, as_tuple=False).flatten()
-        num_changed = int(changed_idx.numel())
-        if num_changed == 0:
-            return 0
-        changed_rows = active_rows_t.index_select(
-            0, changed_idx.to(active_rows_t.device)
-        )
-        for dst_name, src_name in self._STATIC_STAGE_FIELDS:
-            dst = getattr(model, dst_name)
-            src = getattr(pool, src_name)
-            dst.index_copy_(
-                0,
-                changed_idx.to(device=dst.device),
-                src[changed_rows].to(device=dst.device, dtype=dst.dtype),
-            )
-        cached_rows.index_copy_(
-            0,
-            changed_idx.to(device=cached_rows.device),
-            active_rows_for_cache.index_select(0, changed_idx),
-        )
-        cached_versions.index_copy_(
-            0,
-            changed_idx.to(device=cached_versions.device),
-            active_versions.index_select(0, changed_idx),
-        )
-        return num_changed * len(self._STATIC_STAGE_FIELDS)
-
-    def _collect_frame(
-        self,
-        result: Any,
-        forward_batch: Any,
-        schedule_batch: Any,
-        requests: list,
-    ) -> None:
-        self._collect_frame_eager(result, forward_batch, schedule_batch, requests)
 
     def _collect_frame_from_forward_sample(
         self,
@@ -467,7 +355,7 @@ class MossTTSLocalModelRunner(ModelRunner):
             rows=rows.index_select(0, emit_index_t),
         )
 
-    def _collect_frame_eager(
+    def _collect_frame_in_runner(
         self,
         result: Any,
         forward_batch: Any,
@@ -484,7 +372,7 @@ class MossTTSLocalModelRunner(ModelRunner):
         schedule_batch.output_ids = next_token_ids
 
     def _run_frame_decode(self, result: Any, forward_batch: Any, requests: list):
-        """GPU half shared by sync ``_collect_frame`` and async
+        """GPU half shared by sync ``_collect_frame_in_runner`` and async
         ``post_decode_launch``. Returns ``(rows, end_id)`` and does NOT publish
         ``next_token_ids``; the caller does, because the async path keeps a
         private device snapshot of the published ids for resolve to restore.

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -73,7 +73,7 @@ class MossTTSLocalModelRunner(ModelRunner):
             is_prefill_only = False
         if bool(is_prefill_only):
             return
-        self._collect_frame_legacy(result, forward_batch, schedule_batch, requests)
+        self._collect_frame_eager(result, forward_batch, schedule_batch, requests)
 
     def post_decode(
         self,
@@ -83,7 +83,7 @@ class MossTTSLocalModelRunner(ModelRunner):
         requests: list,
     ) -> None:
         if bool(getattr(forward_batch, "moss_has_audio_repetition_penalty", False)):
-            self._collect_frame_legacy(result, forward_batch, schedule_batch, requests)
+            self._collect_frame_eager(result, forward_batch, schedule_batch, requests)
             return
         self._collect_frame_from_forward_sample(result, schedule_batch, requests)
 
@@ -173,13 +173,6 @@ class MossTTSLocalModelRunner(ModelRunner):
             device=forward_batch.input_ids.device,
             dtype=self.model.dtype,
         )
-
-    def _write_decode_input_embedding(
-        self,
-        forward_batch: Any,
-        requests: list,
-    ) -> None:
-        self._prepare_forward_sample_inputs(forward_batch, requests)
 
     def _decode_staging_batch_size(self, raw_batch_size: int) -> int:
         """Return the model-buffer rows SGLang may read for this decode step.
@@ -338,7 +331,7 @@ class MossTTSLocalModelRunner(ModelRunner):
         schedule_batch: Any,
         requests: list,
     ) -> None:
-        self._collect_frame_legacy(result, forward_batch, schedule_batch, requests)
+        self._collect_frame_eager(result, forward_batch, schedule_batch, requests)
 
     def _collect_frame_from_forward_sample(
         self,
@@ -385,7 +378,10 @@ class MossTTSLocalModelRunner(ModelRunner):
         emit_index_t = torch.tensor(emit_indices, dtype=torch.long, device=rows.device)
         emit_pool_rows = [pool_rows[i] for i in emit_indices]
         cached_row_t = getattr(self, "_forward_sample_pool_row_t", None)
-        if isinstance(cached_row_t, torch.Tensor) and int(cached_row_t.numel()) >= n_real:
+        if (
+            isinstance(cached_row_t, torch.Tensor)
+            and int(cached_row_t.numel()) >= n_real
+        ):
             emit_row_t = cached_row_t.index_select(
                 0, emit_index_t.to(device=cached_row_t.device)
             )
@@ -408,7 +404,7 @@ class MossTTSLocalModelRunner(ModelRunner):
             rows=rows.index_select(0, emit_index_t),
         )
 
-    def _collect_frame_legacy(
+    def _collect_frame_eager(
         self,
         result: Any,
         forward_batch: Any,
@@ -629,14 +625,9 @@ class MossTTSLocalModelRunner(ModelRunner):
         """
         if not requests:
             return None
-        if (
-            not bool(getattr(self, "_forward_sample_native_decode", False))
-            or (
-                forward_batch is not None
-                and bool(
-                    getattr(forward_batch, "moss_has_audio_repetition_penalty", False)
-                )
-            )
+        if not bool(getattr(self, "_forward_sample_native_decode", False)) or (
+            forward_batch is not None
+            and bool(getattr(forward_batch, "moss_has_audio_repetition_penalty", False))
         ):
             rows, end_id = self._run_frame_decode(result, forward_batch, requests)
             next_token_ids = self._row_radix_token_ids(rows, rows[:, 0], end_id)

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -28,8 +28,11 @@ class MossTTSLocalModelRunner(ModelRunner):
     _outbox: Any | None = None
     _vocoder_target = "vocoder"
 
-    _STAGE_FIELDS = (
+    _DYNAMIC_STAGE_FIELDS = (
         ("_cg_active_feedback_embeds", "feedback_embeds"),
+        ("_cg_active_sampling_steps", "sampling_steps"),
+    )
+    _STATIC_STAGE_FIELDS = (
         ("_cg_active_text_temp", "text_temp"),
         ("_cg_active_text_top_p", "text_top_p"),
         ("_cg_active_text_top_k", "text_top_k"),
@@ -37,7 +40,6 @@ class MossTTSLocalModelRunner(ModelRunner):
         ("_cg_active_audio_top_p", "audio_top_p"),
         ("_cg_active_audio_top_k", "audio_top_k"),
         ("_cg_active_seeds", "seeds"),
-        ("_cg_active_sampling_steps", "sampling_steps"),
         ("_cg_active_audio_repetition_penalty", "audio_repetition_penalty"),
     )
 
@@ -95,7 +97,9 @@ class MossTTSLocalModelRunner(ModelRunner):
         schedule_batch: Any,
         requests: list,
     ) -> None:
-        if bool(getattr(forward_batch, "moss_has_audio_repetition_penalty", False)):
+        if not bool(getattr(self, "_forward_sample_native_decode", False)) or bool(
+            getattr(forward_batch, "moss_has_audio_repetition_penalty", False)
+        ):
             self._collect_frame_eager(result, forward_batch, schedule_batch, requests)
             return
         self._collect_frame_from_forward_sample(result, schedule_batch, requests)
@@ -210,7 +214,16 @@ class MossTTSLocalModelRunner(ModelRunner):
         if not buckets:
             return raw_batch_size
         idx = bisect.bisect_left(buckets, raw_batch_size)
-        return buckets[idx] if idx < len(buckets) else raw_batch_size
+        if idx >= len(buckets):
+            return raw_batch_size
+        staging_batch_size = buckets[idx]
+        try:
+            frame_graph_max_bs = int(self.model.frame_graph_max_bs)
+        except AttributeError:
+            frame_graph_max_bs = max(buckets)
+        if staging_batch_size > frame_graph_max_bs:
+            return raw_batch_size
+        return staging_batch_size
 
     def _prepare_forward_sample_inputs(
         self,
@@ -221,7 +234,8 @@ class MossTTSLocalModelRunner(ModelRunner):
             self._forward_sample_pool_rows = []
             self._forward_sample_pool_row_t = None
             self._forward_sample_rids = []
-            self._forward_sample_native_decode = True
+            self._forward_sample_native_decode = False
+            self.model._moss_local_forward_native_decode_active = False
             return
         n_real = len(requests)
         raw_batch_size = int(getattr(forward_batch, "batch_size", n_real) or n_real)
@@ -247,6 +261,16 @@ class MossTTSLocalModelRunner(ModelRunner):
         row_tensor, pool_rows, has_audio_repetition_penalty = pool.prepare_active_rows(
             requests
         )
+        try:
+            frame_graph_max_bs = int(model.frame_graph_max_bs)
+        except AttributeError:
+            frame_graph_max_bs = 0
+        use_forward_native_decode = (
+            bool(getattr(model, "_moss_local_forward_native_decode_enabled", False))
+            and not has_audio_repetition_penalty
+            and raw_batch_size <= frame_graph_max_bs
+        )
+        model._moss_local_forward_native_decode_active = use_forward_native_decode
         staged_pool_rows = list(pool_rows)
         if staging_batch_size > n_real:
             staged_pool_rows.extend([pool.padding_row] * (staging_batch_size - n_real))
@@ -261,12 +285,37 @@ class MossTTSLocalModelRunner(ModelRunner):
             active_rows_t = model._cg_pool_rows[:staging_batch_size].to(
                 device=pool.feedback_embeds.device
             )
-            for dst_name, src_name in self._STAGE_FIELDS:
+            for dst_name, src_name in self._DYNAMIC_STAGE_FIELDS:
                 dst = getattr(model, dst_name)
                 src = getattr(pool, src_name)
                 dst[:staging_batch_size].copy_(
                     src[active_rows_t].to(device=dst.device, dtype=dst.dtype)
                 )
+            static_copy_slots = 0
+            if use_forward_native_decode:
+                static_copy_slots = self._stage_static_fields_for_changed_rows(
+                    model,
+                    pool,
+                    active_rows_t,
+                    staging_batch_size,
+                )
+            stats = getattr(model, "_moss_local_decode_stats", None)
+            if isinstance(stats, dict):
+                stats["raw_batch_size"] = raw_batch_size
+                stats["staging_batch_size"] = staging_batch_size
+                stats["dynamic_stage_copy_slots"] = (
+                    stats.get("dynamic_stage_copy_slots", 0)
+                    + staging_batch_size * len(self._DYNAMIC_STAGE_FIELDS)
+                )
+                stats["static_stage_copy_slots"] = (
+                    stats.get("static_stage_copy_slots", 0) + static_copy_slots
+                )
+                key = (
+                    "forward_native_enabled_count"
+                    if use_forward_native_decode
+                    else "forward_native_fallback_count"
+                )
+                stats[key] = stats.get(key, 0) + 1
 
         row_ids = torch.arange(
             raw_batch_size,
@@ -281,7 +330,61 @@ class MossTTSLocalModelRunner(ModelRunner):
         self._forward_sample_pool_rows = pool_rows
         self._forward_sample_pool_row_t = row_tensor
         self._forward_sample_rids = [sched_req.request_id for sched_req in requests]
-        self._forward_sample_native_decode = not has_audio_repetition_penalty
+        self._forward_sample_native_decode = use_forward_native_decode
+
+    def _stage_static_fields_for_changed_rows(
+        self,
+        model: Any,
+        pool: Any,
+        active_rows_t: torch.Tensor,
+        staging_batch_size: int,
+    ) -> int:
+        if not hasattr(model, "_cg_active_pool_rows_cached"):
+            model._cg_active_pool_rows_cached = torch.full_like(
+                model._cg_pool_rows, -1
+            )
+        if not hasattr(model, "_cg_active_pool_row_versions_cached"):
+            model._cg_active_pool_row_versions_cached = torch.full_like(
+                model._cg_pool_rows, -1
+            )
+        active_rows_for_cache = model._cg_pool_rows[:staging_batch_size]
+        active_versions = pool.params_versions[active_rows_t].to(
+            device=active_rows_for_cache.device,
+            dtype=torch.int64,
+        )
+        cached_rows = model._cg_active_pool_rows_cached[:staging_batch_size]
+        cached_versions = model._cg_active_pool_row_versions_cached[
+            :staging_batch_size
+        ]
+        changed = (cached_rows != active_rows_for_cache) | (
+            cached_versions != active_versions
+        )
+        changed_idx = torch.nonzero(changed, as_tuple=False).flatten()
+        num_changed = int(changed_idx.numel())
+        if num_changed == 0:
+            return 0
+        changed_rows = active_rows_t.index_select(
+            0, changed_idx.to(active_rows_t.device)
+        )
+        for dst_name, src_name in self._STATIC_STAGE_FIELDS:
+            dst = getattr(model, dst_name)
+            src = getattr(pool, src_name)
+            dst.index_copy_(
+                0,
+                changed_idx.to(device=dst.device),
+                src[changed_rows].to(device=dst.device, dtype=dst.dtype),
+            )
+        cached_rows.index_copy_(
+            0,
+            changed_idx.to(device=cached_rows.device),
+            active_rows_for_cache.index_select(0, changed_idx),
+        )
+        cached_versions.index_copy_(
+            0,
+            changed_idx.to(device=cached_versions.device),
+            active_versions.index_select(0, changed_idx),
+        )
+        return num_changed * len(self._STATIC_STAGE_FIELDS)
 
     def _collect_frame(
         self,

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -28,6 +28,19 @@ class MossTTSLocalModelRunner(ModelRunner):
     _outbox: Any | None = None
     _vocoder_target = "vocoder"
 
+    _STAGE_FIELDS = (
+        ("_cg_active_feedback_embeds", "feedback_embeds"),
+        ("_cg_active_text_temp", "text_temp"),
+        ("_cg_active_text_top_p", "text_top_p"),
+        ("_cg_active_text_top_k", "text_top_k"),
+        ("_cg_active_audio_temp", "audio_temp"),
+        ("_cg_active_audio_top_p", "audio_top_p"),
+        ("_cg_active_audio_top_k", "audio_top_k"),
+        ("_cg_active_seeds", "seeds"),
+        ("_cg_active_sampling_steps", "sampling_steps"),
+        ("_cg_active_audio_repetition_penalty", "audio_repetition_penalty"),
+    )
+
     def __init__(self, tp_worker: Any, output_processor: Any):
         super().__init__(tp_worker, output_processor)
         self._outbox: Any | None = None
@@ -248,66 +261,12 @@ class MossTTSLocalModelRunner(ModelRunner):
             active_rows_t = model._cg_pool_rows[:staging_batch_size].to(
                 device=pool.feedback_embeds.device
             )
-            model._cg_active_feedback_embeds[:staging_batch_size].copy_(
-                pool.feedback_embeds[active_rows_t].to(
-                    device=model._cg_active_feedback_embeds.device,
-                    dtype=model._cg_active_feedback_embeds.dtype,
+            for dst_name, src_name in self._STAGE_FIELDS:
+                dst = getattr(model, dst_name)
+                src = getattr(pool, src_name)
+                dst[:staging_batch_size].copy_(
+                    src[active_rows_t].to(device=dst.device, dtype=dst.dtype)
                 )
-            )
-            model._cg_active_text_temp[:staging_batch_size].copy_(
-                pool.text_temp[active_rows_t].to(
-                    device=model._cg_active_text_temp.device,
-                    dtype=model._cg_active_text_temp.dtype,
-                )
-            )
-            model._cg_active_text_top_p[:staging_batch_size].copy_(
-                pool.text_top_p[active_rows_t].to(
-                    device=model._cg_active_text_top_p.device,
-                    dtype=model._cg_active_text_top_p.dtype,
-                )
-            )
-            model._cg_active_text_top_k[:staging_batch_size].copy_(
-                pool.text_top_k[active_rows_t].to(
-                    device=model._cg_active_text_top_k.device,
-                    dtype=model._cg_active_text_top_k.dtype,
-                )
-            )
-            model._cg_active_audio_temp[:staging_batch_size].copy_(
-                pool.audio_temp[active_rows_t].to(
-                    device=model._cg_active_audio_temp.device,
-                    dtype=model._cg_active_audio_temp.dtype,
-                )
-            )
-            model._cg_active_audio_top_p[:staging_batch_size].copy_(
-                pool.audio_top_p[active_rows_t].to(
-                    device=model._cg_active_audio_top_p.device,
-                    dtype=model._cg_active_audio_top_p.dtype,
-                )
-            )
-            model._cg_active_audio_top_k[:staging_batch_size].copy_(
-                pool.audio_top_k[active_rows_t].to(
-                    device=model._cg_active_audio_top_k.device,
-                    dtype=model._cg_active_audio_top_k.dtype,
-                )
-            )
-            model._cg_active_seeds[:staging_batch_size].copy_(
-                pool.seeds[active_rows_t].to(
-                    device=model._cg_active_seeds.device,
-                    dtype=model._cg_active_seeds.dtype,
-                )
-            )
-            model._cg_active_sampling_steps[:staging_batch_size].copy_(
-                pool.sampling_steps[active_rows_t].to(
-                    device=model._cg_active_sampling_steps.device,
-                    dtype=model._cg_active_sampling_steps.dtype,
-                )
-            )
-            model._cg_active_audio_repetition_penalty[:staging_batch_size].copy_(
-                pool.audio_repetition_penalty[active_rows_t].to(
-                    device=model._cg_active_audio_repetition_penalty.device,
-                    dtype=model._cg_active_audio_repetition_penalty.dtype,
-                )
-            )
 
         row_ids = torch.arange(
             raw_batch_size,
@@ -339,9 +298,10 @@ class MossTTSLocalModelRunner(ModelRunner):
         schedule_batch: Any,
         requests: list,
     ) -> None:
-        # Sampling already ran inside MossTTSLocalSGLangModel.forward() via the
-        # native decode-forward path. Collection only snapshots the fixed
-        # active-slot step buffers and publishes the graph-computed token ids.
+        # Notes (Xinran): Sampling already ran inside
+        # MossTTSLocalSGLangModel.forward() via the native decode-forward path.
+        # Collection only snapshots the fixed active-slot step buffers and
+        # publishes the graph-computed token ids.
         if not requests:
             return
         n_real = len(requests)

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -400,7 +400,6 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         )
         if is_decode:
             batch_size = int(sample_hidden_states.shape[0])
-            self._check_active_decode_buffers()
             num_channels = int(self.n_vq) + 1
             active_sampling_steps = self._cg_active_sampling_steps[:batch_size]
             base_positions = active_sampling_steps * num_channels

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -137,6 +137,11 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             dtype=weight.dtype,
         )
         self._decode_input_embedding.weight.requires_grad_(False)
+        self._moss_local_decode_cuda_graph_bs: list[int] = []
+        self._moss_local_decode_graph_padding = False
+        self._moss_local_decode_graph_padding_ratio_threshold = 1.15
+        self._moss_local_forward_native_decode_enabled = False
+        self._moss_local_forward_native_decode_active = False
         self.init_forward_sample_buffers()
 
         # Row-indexed decode-state pool: next-step-critical per-request state
@@ -164,6 +169,18 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         self._cg_pool_rows = torch.full(
             (max_running_requests,),
             max_running_requests,
+            device=device,
+            dtype=torch.int64,
+        )
+        self._cg_active_pool_rows_cached = torch.full(
+            (max_running_requests,),
+            -1,
+            device=device,
+            dtype=torch.int64,
+        )
+        self._cg_active_pool_row_versions_cached = torch.full(
+            (max_running_requests,),
+            -1,
             device=device,
             dtype=torch.int64,
         )
@@ -397,7 +414,6 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         )
         if input_embeds is None:
             if is_decode:
-                self._check_active_decode_buffers()
                 batch_size = int(input_ids.shape[0])
                 input_embeds = self._cg_active_feedback_embeds[:batch_size]
             elif self.pp_group.is_first_rank:
@@ -419,7 +435,9 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             hidden_states,
             forward_batch,
         )
-        if is_decode:
+        if is_decode and bool(
+            getattr(self, "_moss_local_forward_native_decode_active", False)
+        ):
             batch_size = int(sample_hidden_states.shape[0])
             num_channels = int(self.n_vq) + 1
             active_sampling_steps = self._cg_active_sampling_steps[:batch_size]

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -146,9 +146,13 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         max_running_requests = int(weight.shape[0])
         device = weight.device
         dtype = weight.dtype
-        # The pool has max_running_requests + 1 rows; the last row is reserved
-        # for CUDA graph padding. The pool may not be constructed yet, but its
-        # padding row is therefore exactly max_running_requests.
+        # Notes (Xinran): These tensors are model-owned active-slot staging
+        # buffers. before_decode copies request-owned pool state into the
+        # active input buffers, forward() writes one step of sampled rows and
+        # next-step feedback into the output buffers, and collection commits
+        # those outputs back to the durable pool rows. The default pool row is
+        # max_running_requests, which is the reserved padding row once the pool
+        # is constructed.
         self._cg_pool_rows = torch.full(
             (max_running_requests,),
             max_running_requests,
@@ -429,9 +433,7 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             self._cg_active_next_feedback_embeds[:batch_size] = feedback.to(
                 dtype=self._cg_active_next_feedback_embeds.dtype
             )
-            self._cg_active_next_sampling_steps[:batch_size] = (
-                active_sampling_steps + 1
-            )
+            self._cg_active_next_sampling_steps[:batch_size] = active_sampling_steps + 1
 
         # Prefill flow consumes hidden_states in the model runner and samples
         # there. Decode flow above has already written the sampled frame to

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -357,30 +357,6 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             raise RuntimeError("MOSS-TTS Local decode state pool is not initialized")
         return self._cg_pool_rows, self._state_pool
 
-    def _check_active_decode_buffers(self) -> None:
-        required = (
-            "_cg_active_feedback_embeds",
-            "_cg_active_text_temp",
-            "_cg_active_text_top_p",
-            "_cg_active_text_top_k",
-            "_cg_active_audio_temp",
-            "_cg_active_audio_top_p",
-            "_cg_active_audio_top_k",
-            "_cg_active_seeds",
-            "_cg_active_sampling_steps",
-            "_cg_active_audio_repetition_penalty",
-            "_cg_active_next_feedback_embeds",
-            "_cg_active_next_sampling_steps",
-            "_cg_step_rows",
-            "_cg_step_next_token_ids",
-        )
-        missing = [name for name in required if not hasattr(self, name)]
-        if missing:
-            raise RuntimeError(
-                "MOSS-TTS Local active decode buffers are not initialized: "
-                + ", ".join(missing)
-            )
-
     @torch.no_grad()
     def forward(
         self,

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -137,10 +137,6 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             dtype=weight.dtype,
         )
         self._decode_input_embedding.weight.requires_grad_(False)
-        self._moss_local_decode_cuda_graph_bs: list[int] = []
-        self._moss_local_decode_graph_padding = False
-        self._moss_local_decode_graph_padding_ratio_threshold = 1.15
-        self._moss_local_forward_native_decode_enabled = False
         self._moss_local_forward_native_decode_active = False
         self.init_forward_sample_buffers()
 
@@ -169,18 +165,6 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         self._cg_pool_rows = torch.full(
             (max_running_requests,),
             max_running_requests,
-            device=device,
-            dtype=torch.int64,
-        )
-        self._cg_active_pool_rows_cached = torch.full(
-            (max_running_requests,),
-            -1,
-            device=device,
-            dtype=torch.int64,
-        )
-        self._cg_active_pool_row_versions_cached = torch.full(
-            (max_running_requests,),
-            -1,
             device=device,
             dtype=torch.int64,
         )
@@ -600,6 +584,26 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         return stop_choice, torch.stack(codes, dim=-1), feedback
 
     @torch.no_grad()
+    def prepare_frame_decode_for_capture(self, batch_sizes: list[int]) -> None:
+        """Size + freeze the local-transformer KV cache and compile the frame
+        sampler, sizing the KV for the largest batch any decode path can see.
+
+        Must run before *either* graph that contains the frame decode is
+        captured: the standalone frame graphs (``init_frame_decode_graphs``) and
+        the backbone decode graph when the native in-``forward()`` sampling path
+        is armed (the captured graph bakes in the ``_native_decode_active``
+        branch, so the local transformer must already be ready at capture).
+        """
+        buckets = sorted({int(bs) for bs in batch_sizes})
+        if not buckets:
+            return
+        max_eager_bs = int(self._decode_input_embedding.weight.shape[0])
+        self.local_transformer.reserve_and_freeze_kv_cache(
+            max(max(buckets), max_eager_bs), self.device, self.dtype
+        )
+        self._ensure_frame_sampler_compile()
+
+    @torch.no_grad()
     def init_frame_decode_graphs(self, batch_sizes: list[int]) -> None:
         """Capture the per-frame local decode (1 + n_vq micro-steps plus all
         13 seeded sampling passes) into one CUDA graph per batch-size bucket.
@@ -612,15 +616,7 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         if not buckets:
             return
         device = self.device
-        # The captured graphs hold raw pointers into the local KV buffers, so
-        # size them for the largest batch any path (graphed or eager fallback)
-        # can see and freeze them against reallocation.
-        max_eager_bs = int(self._decode_input_embedding.weight.shape[0])
-        self.local_transformer._ensure_kv_cache(
-            max(max(buckets), max_eager_bs), device, self.dtype
-        )
-        self.local_transformer.freeze_kv_cache()
-        self._ensure_frame_sampler_compile()
+        # Note(yichi): caller must prepare_frame_decode_for_capture before calling this.
         frame_decode = self._decode_frame_graphable
         self._frame_graphs: dict[
             int,

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -37,6 +37,7 @@ from sglang_omni.models.moss_tts_local.local_transformer import (
 from sglang_omni.models.moss_tts_local.payload_types import (
     moss_tts_local_special_token_defaults,
 )
+from sglang_omni.models.moss_tts_local.radix_hash import gpu_radix_row_hash
 from sglang_omni.models.moss_tts_local.state_pool import MossTTSLocalDecodeStatePool
 
 logger = logging.getLogger(__name__)
@@ -128,6 +129,7 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             dtype=weight.dtype,
         )
         self._decode_input_embedding.weight.requires_grad_(False)
+        self.init_forward_sample_buffers()
 
         # Row-indexed decode-state pool: next-step-critical per-request state
         # (next-frame feedback embedding, sampling params/seed, generation step)
@@ -137,6 +139,73 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         self._state_pool = MossTTSLocalDecodeStatePool(self)
         self._compiled_frame_sampler: Callable[..., torch.Tensor] | None = None
         self._frame_compile_configured = False
+
+    def init_forward_sample_buffers(self) -> None:
+        """Allocate fixed active-batch decode buffers for captured decode."""
+        weight = self._decode_input_embedding.weight
+        max_running_requests = int(weight.shape[0])
+        device = weight.device
+        dtype = weight.dtype
+        # The pool has max_running_requests + 1 rows; the last row is reserved
+        # for CUDA graph padding. The pool may not be constructed yet, but its
+        # padding row is therefore exactly max_running_requests.
+        self._cg_pool_rows = torch.full(
+            (max_running_requests,),
+            max_running_requests,
+            device=device,
+            dtype=torch.int64,
+        )
+        self._cg_active_feedback_embeds = torch.zeros(
+            max_running_requests,
+            self.hidden_size,
+            device=device,
+            dtype=dtype,
+        )
+        self._cg_active_text_temp = torch.ones(
+            max_running_requests, device=device, dtype=torch.float32
+        )
+        self._cg_active_text_top_p = torch.ones(
+            max_running_requests, device=device, dtype=torch.float32
+        )
+        self._cg_active_audio_temp = torch.ones(
+            max_running_requests, device=device, dtype=torch.float32
+        )
+        self._cg_active_audio_top_p = torch.ones(
+            max_running_requests, device=device, dtype=torch.float32
+        )
+        self._cg_active_text_top_k = torch.full(
+            (max_running_requests,), 50, device=device, dtype=torch.int64
+        )
+        self._cg_active_audio_top_k = torch.full(
+            (max_running_requests,), 25, device=device, dtype=torch.int64
+        )
+        self._cg_active_seeds = torch.zeros(
+            max_running_requests, device=device, dtype=torch.int64
+        )
+        self._cg_active_sampling_steps = torch.zeros(
+            max_running_requests, device=device, dtype=torch.int64
+        )
+        self._cg_active_audio_repetition_penalty = torch.ones(
+            max_running_requests, device=device, dtype=torch.float32
+        )
+        self._cg_active_next_feedback_embeds = torch.zeros(
+            max_running_requests,
+            self.hidden_size,
+            device=device,
+            dtype=dtype,
+        )
+        self._cg_active_next_sampling_steps = torch.zeros(
+            max_running_requests, device=device, dtype=torch.int64
+        )
+        self._cg_step_rows = torch.zeros(
+            max_running_requests,
+            int(self.n_vq) + 1,
+            device=device,
+            dtype=torch.int64,
+        )
+        self._cg_step_next_token_ids = torch.zeros(
+            max_running_requests, device=device, dtype=torch.int64
+        )
 
     def acquire_row(self, rid: str) -> int:
         """Assign (or return the existing) decode-state pool row for ``rid``."""
@@ -279,6 +348,39 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             embeds = embeds + embed_layer(input_ids_2d[:, idx])
         return embeds
 
+    def _decode_pool_state(
+        self,
+    ) -> tuple[torch.Tensor, MossTTSLocalDecodeStatePool]:
+        if not hasattr(self, "_cg_pool_rows"):
+            raise RuntimeError("MOSS-TTS Local decode pool rows are not initialized")
+        if not hasattr(self, "_state_pool"):
+            raise RuntimeError("MOSS-TTS Local decode state pool is not initialized")
+        return self._cg_pool_rows, self._state_pool
+
+    def _check_active_decode_buffers(self) -> None:
+        required = (
+            "_cg_active_feedback_embeds",
+            "_cg_active_text_temp",
+            "_cg_active_text_top_p",
+            "_cg_active_text_top_k",
+            "_cg_active_audio_temp",
+            "_cg_active_audio_top_p",
+            "_cg_active_audio_top_k",
+            "_cg_active_seeds",
+            "_cg_active_sampling_steps",
+            "_cg_active_audio_repetition_penalty",
+            "_cg_active_next_feedback_embeds",
+            "_cg_active_next_sampling_steps",
+            "_cg_step_rows",
+            "_cg_step_next_token_ids",
+        )
+        missing = [name for name in required if not hasattr(self, name)]
+        if missing:
+            raise RuntimeError(
+                "MOSS-TTS Local active decode buffers are not initialized: "
+                + ", ".join(missing)
+            )
+
     @torch.no_grad()
     def forward(
         self,
@@ -290,15 +392,17 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         input_embeds_are_projected: bool = False,
     ) -> LogitsProcessorOutput:
         del input_embeds_are_projected
+        forward_mode = getattr(forward_batch, "forward_mode", None)
+        is_decode = (
+            forward_mode is not None
+            and hasattr(forward_mode, "is_decode")
+            and bool(forward_mode.is_decode())
+        )
         if input_embeds is None:
-            forward_mode = getattr(forward_batch, "forward_mode", None)
-            is_decode = (
-                forward_mode is not None
-                and hasattr(forward_mode, "is_decode")
-                and bool(forward_mode.is_decode())
-            )
             if is_decode:
-                input_embeds = self._decode_input_embedding(input_ids)
+                self._check_active_decode_buffers()
+                batch_size = int(input_ids.shape[0])
+                input_embeds = self._cg_active_feedback_embeds[:batch_size]
             elif self.pp_group.is_first_rank:
                 input_embeds = self._prepare_multi_modal_inputs(input_ids)
             else:
@@ -318,10 +422,46 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             hidden_states,
             forward_batch,
         )
-        # The local-transformer frame decode (binary stop head + 12 sequential
-        # codebook samples) runs in the model runner after the graph-captured
-        # backbone returns; emitting hidden states with dummy logits keeps the
-        # backbone CUDA-graph replay free of model-specific outputs.
+        if is_decode:
+            batch_size = int(sample_hidden_states.shape[0])
+            self._check_active_decode_buffers()
+            num_channels = int(self.n_vq) + 1
+            active_sampling_steps = self._cg_active_sampling_steps[:batch_size]
+            base_positions = active_sampling_steps * num_channels
+            stop_choice, codes, feedback = self._decode_frame_graphable(
+                sample_hidden_states,
+                text_temperature=self._cg_active_text_temp[:batch_size],
+                text_top_p=self._cg_active_text_top_p[:batch_size],
+                text_top_k=self._cg_active_text_top_k[:batch_size],
+                audio_temperature=self._cg_active_audio_temp[:batch_size],
+                audio_top_p=self._cg_active_audio_top_p[:batch_size],
+                audio_top_k=self._cg_active_audio_top_k[:batch_size],
+                seeds=self._cg_active_seeds[:batch_size],
+                base_positions=base_positions,
+            )
+            slot_id = int(self.config.audio_assistant_slot_token_id)
+            end_id = int(self.config.audio_end_token_id)
+            next_text = torch.where(
+                stop_choice == 0,
+                torch.full_like(stop_choice, slot_id),
+                torch.full_like(stop_choice, end_id),
+            )
+            rows = self._cg_step_rows[:batch_size]
+            rows[:, 0] = next_text
+            rows[:, 1:] = codes
+            next_token_ids = gpu_radix_row_hash(rows, next_text, end_id)
+            self._cg_step_next_token_ids[:batch_size] = next_token_ids
+            self._cg_active_next_feedback_embeds[:batch_size] = feedback.to(
+                dtype=self._cg_active_next_feedback_embeds.dtype
+            )
+            self._cg_active_next_sampling_steps[:batch_size] = (
+                active_sampling_steps + 1
+            )
+
+        # Prefill flow consumes hidden_states in the model runner and samples
+        # there. Decode flow above has already written the sampled frame to
+        # fixed staging buffers. Dummy logits keep SGLang's output contract
+        # satisfied.
         dummy_logits = sample_hidden_states.new_empty(
             (sample_hidden_states.shape[0], 1)
         )

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -38,7 +38,15 @@ from sglang_omni.models.moss_tts_local.payload_types import (
     moss_tts_local_special_token_defaults,
 )
 from sglang_omni.models.moss_tts_local.radix_hash import gpu_radix_row_hash
-from sglang_omni.models.moss_tts_local.state_pool import MossTTSLocalDecodeStatePool
+from sglang_omni.models.moss_tts_local.state_pool import (
+    DEFAULT_AUDIO_REPETITION_PENALTY,
+    DEFAULT_AUDIO_TOP_K,
+    DEFAULT_SAMPLING_SEED,
+    DEFAULT_SAMPLING_TEMPERATURE,
+    DEFAULT_TEXT_TOP_K,
+    DEFAULT_TOP_P,
+    MossTTSLocalDecodeStatePool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -165,32 +173,50 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             device=device,
             dtype=dtype,
         )
-        self._cg_active_text_temp = torch.ones(
-            max_running_requests, device=device, dtype=torch.float32
+        self._cg_active_text_temp = torch.full(
+            (max_running_requests,),
+            DEFAULT_SAMPLING_TEMPERATURE,
+            device=device,
+            dtype=torch.float32,
         )
-        self._cg_active_text_top_p = torch.ones(
-            max_running_requests, device=device, dtype=torch.float32
+        self._cg_active_text_top_p = torch.full(
+            (max_running_requests,), DEFAULT_TOP_P, device=device, dtype=torch.float32
         )
-        self._cg_active_audio_temp = torch.ones(
-            max_running_requests, device=device, dtype=torch.float32
+        self._cg_active_audio_temp = torch.full(
+            (max_running_requests,),
+            DEFAULT_SAMPLING_TEMPERATURE,
+            device=device,
+            dtype=torch.float32,
         )
-        self._cg_active_audio_top_p = torch.ones(
-            max_running_requests, device=device, dtype=torch.float32
+        self._cg_active_audio_top_p = torch.full(
+            (max_running_requests,), DEFAULT_TOP_P, device=device, dtype=torch.float32
         )
         self._cg_active_text_top_k = torch.full(
-            (max_running_requests,), 50, device=device, dtype=torch.int64
+            (max_running_requests,),
+            DEFAULT_TEXT_TOP_K,
+            device=device,
+            dtype=torch.int64,
         )
         self._cg_active_audio_top_k = torch.full(
-            (max_running_requests,), 25, device=device, dtype=torch.int64
+            (max_running_requests,),
+            DEFAULT_AUDIO_TOP_K,
+            device=device,
+            dtype=torch.int64,
         )
-        self._cg_active_seeds = torch.zeros(
-            max_running_requests, device=device, dtype=torch.int64
+        self._cg_active_seeds = torch.full(
+            (max_running_requests,),
+            DEFAULT_SAMPLING_SEED,
+            device=device,
+            dtype=torch.int64,
         )
         self._cg_active_sampling_steps = torch.zeros(
             max_running_requests, device=device, dtype=torch.int64
         )
-        self._cg_active_audio_repetition_penalty = torch.ones(
-            max_running_requests, device=device, dtype=torch.float32
+        self._cg_active_audio_repetition_penalty = torch.full(
+            (max_running_requests,),
+            DEFAULT_AUDIO_REPETITION_PENALTY,
+            device=device,
+            dtype=torch.float32,
         )
         self._cg_active_next_feedback_embeds = torch.zeros(
             max_running_requests,
@@ -352,15 +378,6 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             embeds = embeds + embed_layer(input_ids_2d[:, idx])
         return embeds
 
-    def _decode_pool_state(
-        self,
-    ) -> tuple[torch.Tensor, MossTTSLocalDecodeStatePool]:
-        if not hasattr(self, "_cg_pool_rows"):
-            raise RuntimeError("MOSS-TTS Local decode pool rows are not initialized")
-        if not hasattr(self, "_state_pool"):
-            raise RuntimeError("MOSS-TTS Local decode state pool is not initialized")
-        return self._cg_pool_rows, self._state_pool
-
     @torch.no_grad()
     def forward(
         self,
@@ -435,10 +452,10 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             )
             self._cg_active_next_sampling_steps[:batch_size] = active_sampling_steps + 1
 
-        # Prefill flow consumes hidden_states in the model runner and samples
-        # there. Decode flow above has already written the sampled frame to
-        # fixed staging buffers. Dummy logits keep SGLang's output contract
-        # satisfied.
+        # Notes (Xinran): Prefill flow consumes hidden_states in the model
+        # runner and samples there. Decode flow above has already written the
+        # sampled frame to fixed staging buffers. Dummy logits keep SGLang's
+        # output contract satisfied.
         dummy_logits = sample_hidden_states.new_empty(
             (sample_hidden_states.shape[0], 1)
         )
@@ -599,21 +616,33 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
                 "hidden_states": torch.zeros(
                     bucket, self.hidden_size, device=device, dtype=self.dtype
                 ),
-                "text_temperature": torch.ones(
-                    bucket, device=device, dtype=torch.float32
+                "text_temperature": torch.full(
+                    (bucket,),
+                    DEFAULT_SAMPLING_TEMPERATURE,
+                    device=device,
+                    dtype=torch.float32,
                 ),
-                "text_top_p": torch.ones(bucket, device=device, dtype=torch.float32),
+                "text_top_p": torch.full(
+                    (bucket,), DEFAULT_TOP_P, device=device, dtype=torch.float32
+                ),
                 "text_top_k": torch.full(
-                    (bucket,), 50, device=device, dtype=torch.long
+                    (bucket,), DEFAULT_TEXT_TOP_K, device=device, dtype=torch.long
                 ),
-                "audio_temperature": torch.ones(
-                    bucket, device=device, dtype=torch.float32
+                "audio_temperature": torch.full(
+                    (bucket,),
+                    DEFAULT_SAMPLING_TEMPERATURE,
+                    device=device,
+                    dtype=torch.float32,
                 ),
-                "audio_top_p": torch.ones(bucket, device=device, dtype=torch.float32),
+                "audio_top_p": torch.full(
+                    (bucket,), DEFAULT_TOP_P, device=device, dtype=torch.float32
+                ),
                 "audio_top_k": torch.full(
-                    (bucket,), 25, device=device, dtype=torch.long
+                    (bucket,), DEFAULT_AUDIO_TOP_K, device=device, dtype=torch.long
                 ),
-                "seeds": torch.zeros(bucket, device=device, dtype=torch.long),
+                "seeds": torch.full(
+                    (bucket,), DEFAULT_SAMPLING_SEED, device=device, dtype=torch.long
+                ),
                 "base_positions": torch.zeros(bucket, device=device, dtype=torch.long),
             }
             warmup_stream = torch.cuda.Stream()

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -457,6 +457,9 @@ def create_sglang_tts_engine_executor(
     server_args_overrides: dict[str, Any] | None = None,
     enable_async_decode: bool = False,
     async_decode_min_batch_size: int = 2,
+    # Note(yichi): default to False for now since we don't see very good
+    # improvement on performance from the native in-forward decode CUDA graph.
+    forward_native_decode_enabled: bool = False,
 ) -> Any:
     from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
     from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
@@ -489,24 +492,6 @@ def create_sglang_tts_engine_executor(
     }
     if server_args_overrides:
         overrides.update(server_args_overrides)
-    forward_native_decode_enabled = bool(
-        overrides.pop(
-            "forward_native_decode_enabled",
-            overrides.pop("moss_local_forward_native_decode_enabled", False),
-        )
-    )
-    decode_graph_padding = bool(
-        overrides.pop(
-            "decode_graph_padding",
-            overrides.pop("moss_local_decode_graph_padding", False),
-        )
-    )
-    decode_graph_padding_ratio_threshold = float(
-        overrides.pop(
-            "decode_graph_padding_ratio_threshold",
-            overrides.pop("moss_local_decode_graph_padding_ratio_threshold", 1.15),
-        )
-    )
 
     server_args = build_sglang_server_args(
         checkpoint_dir,
@@ -536,17 +521,17 @@ def create_sglang_tts_engine_executor(
         server_args.disable_cuda_graph = False
 
     model = model_worker.model_runner.model
-    model._moss_local_forward_native_decode_enabled = forward_native_decode_enabled
     model._moss_local_forward_native_decode_active = False
-    model._moss_local_decode_graph_padding = False
-    model._moss_local_decode_graph_padding_ratio_threshold = (
-        decode_graph_padding_ratio_threshold
-    )
+    model._moss_local_native_decode_enabled = bool(forward_native_decode_enabled)
     if want_cuda_graph:
-        model_worker.model_runner.init_device_graphs()
         cuda_graph_bs = list(overrides.get("cuda_graph_bs") or [1, 2, 4, 8, 16])
-        model._moss_local_decode_cuda_graph_bs = cuda_graph_bs
-        model._moss_local_decode_graph_padding = decode_graph_padding
+        model.prepare_frame_decode_for_capture(cuda_graph_bs)
+        # Only bake the native in-forward sampling into the backbone graph when
+        # the flag is on; otherwise capture the plain decode and let the runner
+        # use the standalone frame-decode graphs.
+        if model._moss_local_native_decode_enabled:
+            model._moss_local_forward_native_decode_active = True
+        model_worker.model_runner.init_device_graphs()
         # Also graph the per-frame local-transformer decode (1 + n_vq
         # micro-steps and 13 seeded sampling passes per frame): eager it is
         # kernel-launch-bound at ~22 ms/frame independent of batch size.

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -87,6 +87,7 @@ def _load_moss_tts_local_processor(model_path: str, *, device: str) -> Any:
             processor = processor_cls.from_pretrained(
                 checkpoint_dir,
                 trust_remote_code=True,
+                codec_weight_dtype=None,
             )
     except Exception as exc:
         raise RuntimeError(_MOSS_TTS_LOCAL_INSTALL_HINT) from exc
@@ -488,6 +489,24 @@ def create_sglang_tts_engine_executor(
     }
     if server_args_overrides:
         overrides.update(server_args_overrides)
+    forward_native_decode_enabled = bool(
+        overrides.pop(
+            "forward_native_decode_enabled",
+            overrides.pop("moss_local_forward_native_decode_enabled", False),
+        )
+    )
+    decode_graph_padding = bool(
+        overrides.pop(
+            "decode_graph_padding",
+            overrides.pop("moss_local_decode_graph_padding", False),
+        )
+    )
+    decode_graph_padding_ratio_threshold = float(
+        overrides.pop(
+            "decode_graph_padding_ratio_threshold",
+            overrides.pop("moss_local_decode_graph_padding_ratio_threshold", 1.15),
+        )
+    )
 
     server_args = build_sglang_server_args(
         checkpoint_dir,
@@ -517,14 +536,21 @@ def create_sglang_tts_engine_executor(
         server_args.disable_cuda_graph = False
 
     model = model_worker.model_runner.model
+    model._moss_local_forward_native_decode_enabled = forward_native_decode_enabled
+    model._moss_local_forward_native_decode_active = False
+    model._moss_local_decode_graph_padding = False
+    model._moss_local_decode_graph_padding_ratio_threshold = (
+        decode_graph_padding_ratio_threshold
+    )
     if want_cuda_graph:
         model_worker.model_runner.init_device_graphs()
+        cuda_graph_bs = list(overrides.get("cuda_graph_bs") or [1, 2, 4, 8, 16])
+        model._moss_local_decode_cuda_graph_bs = cuda_graph_bs
+        model._moss_local_decode_graph_padding = decode_graph_padding
         # Also graph the per-frame local-transformer decode (1 + n_vq
         # micro-steps and 13 seeded sampling passes per frame): eager it is
         # kernel-launch-bound at ~22 ms/frame independent of batch size.
-        model.init_frame_decode_graphs(
-            list(overrides.get("cuda_graph_bs") or [1, 2, 4, 8, 16])
-        )
+        model.init_frame_decode_graphs(cuda_graph_bs)
 
     output_proc = SGLangOutputProcessor(
         capture_hidden=False,

--- a/sglang_omni/models/moss_tts_local/state_pool.py
+++ b/sglang_omni/models/moss_tts_local/state_pool.py
@@ -4,8 +4,8 @@
 Next-step-critical per-request decode state (the next frame's feedback
 embedding, request-static sampling parameters/seed, repetition penalty state,
 and generation step) lives in stable, process-lifetime GPU buffers indexed by a
-per-request row.
-Output-only frame collection moves to a per-step
+per-request row. The decode CUDA graph uses model-owned active-batch input and
+output buffers; output-only frame collection then snapshots those step buffers into a
 :class:`MossTTSLocalDecodeJournal`.
 
 ``P = max_running_requests + 1`` rows indexed by a per-request row. The last
@@ -97,13 +97,13 @@ class MossTTSLocalDecodeStatePool:
             device=self.device,
             dtype=torch.bool,
         )
-
         self._rid_to_row: dict[str, int] = {}
         self._params_written_rids: set[str] = set()
         self._audio_repetition_penalty_rows: set[int] = set()
         # Real rows 0..P-2 are assignable; the padding row stays out of the
         # free list so it is never handed to a request.
         self._free_rows: list[int] = list(range(self.padding_row))
+        self._set_padding_defaults()
 
     def acquire_row(self, rid: str) -> int:
         """Assign (or return the existing) row for ``rid``.
@@ -134,8 +134,16 @@ class MossTTSLocalDecodeStatePool:
         self._free_rows.append(row_idx)
 
     def reset_row(self, row_idx: int) -> None:
-        """Zero every field of ``row_idx`` (clears stranded feedback/params)."""
+        """Reset ``row_idx`` while preserving safe defaults for padding."""
         self.feedback_embeds[row_idx].zero_()
+        self.generation_steps[row_idx] = 0
+        self.sampling_steps[row_idx] = 0
+        self.audio_repetition_penalty[row_idx] = 0.0
+        self.audio_token_presence[row_idx].zero_()
+        self._audio_repetition_penalty_rows.discard(int(row_idx))
+        if row_idx == self.padding_row:
+            self._set_padding_defaults()
+            return
         self.text_temp[row_idx] = 0.0
         self.text_top_p[row_idx] = 0.0
         self.audio_temp[row_idx] = 0.0
@@ -143,9 +151,20 @@ class MossTTSLocalDecodeStatePool:
         self.text_top_k[row_idx] = 0
         self.audio_top_k[row_idx] = 0
         self.seeds[row_idx] = 0
+
+    def _set_padding_defaults(self) -> None:
+        """Sampling defaults used when CUDA graph buckets include padding."""
+        row_idx = self.padding_row
+        self.text_temp[row_idx] = 1.0
+        self.text_top_p[row_idx] = 1.0
+        self.text_top_k[row_idx] = 50
+        self.audio_temp[row_idx] = 1.0
+        self.audio_top_p[row_idx] = 1.0
+        self.audio_top_k[row_idx] = 25
+        self.seeds[row_idx] = 0
         self.generation_steps[row_idx] = 0
         self.sampling_steps[row_idx] = 0
-        self.audio_repetition_penalty[row_idx] = 0.0
+        self.audio_repetition_penalty[row_idx] = 1.0
         self.audio_token_presence[row_idx].zero_()
         self._audio_repetition_penalty_rows.discard(int(row_idx))
 
@@ -249,7 +268,7 @@ class MossTTSLocalDecodeStatePool:
         )
 
     def rebuild_audio_history(self, rid: str, output_rows: list[torch.Tensor]) -> bool:
-        """Rebuild ``rid``'s pool-resident history after retraction re-prefill."""
+        """Rebuild ``rid``'s audio history after retraction re-prefill."""
         row_idx = self.row_for(rid)
         if row_idx is None:
             return False

--- a/sglang_omni/models/moss_tts_local/state_pool.py
+++ b/sglang_omni/models/moss_tts_local/state_pool.py
@@ -20,6 +20,13 @@ from typing import Any
 
 import torch
 
+DEFAULT_SAMPLING_TEMPERATURE = 1.0
+DEFAULT_TOP_P = 1.0
+DEFAULT_TEXT_TOP_K = 50
+DEFAULT_AUDIO_TOP_K = 25
+DEFAULT_SAMPLING_SEED = 0
+DEFAULT_AUDIO_REPETITION_PENALTY = 1.0
+
 
 class MossTTSLocalDecodeStatePool:
     """Row-indexed pool of next-step-critical decode state.
@@ -155,16 +162,16 @@ class MossTTSLocalDecodeStatePool:
     def _set_padding_defaults(self) -> None:
         """Sampling defaults used when CUDA graph buckets include padding."""
         row_idx = self.padding_row
-        self.text_temp[row_idx] = 1.0
-        self.text_top_p[row_idx] = 1.0
-        self.text_top_k[row_idx] = 50
-        self.audio_temp[row_idx] = 1.0
-        self.audio_top_p[row_idx] = 1.0
-        self.audio_top_k[row_idx] = 25
-        self.seeds[row_idx] = 0
+        self.text_temp[row_idx] = DEFAULT_SAMPLING_TEMPERATURE
+        self.text_top_p[row_idx] = DEFAULT_TOP_P
+        self.text_top_k[row_idx] = DEFAULT_TEXT_TOP_K
+        self.audio_temp[row_idx] = DEFAULT_SAMPLING_TEMPERATURE
+        self.audio_top_p[row_idx] = DEFAULT_TOP_P
+        self.audio_top_k[row_idx] = DEFAULT_AUDIO_TOP_K
+        self.seeds[row_idx] = DEFAULT_SAMPLING_SEED
         self.generation_steps[row_idx] = 0
         self.sampling_steps[row_idx] = 0
-        self.audio_repetition_penalty[row_idx] = 1.0
+        self.audio_repetition_penalty[row_idx] = DEFAULT_AUDIO_REPETITION_PENALTY
         self.audio_token_presence[row_idx].zero_()
         self._audio_repetition_penalty_rows.discard(int(row_idx))
 

--- a/sglang_omni/models/moss_tts_local/state_pool.py
+++ b/sglang_omni/models/moss_tts_local/state_pool.py
@@ -97,6 +97,9 @@ class MossTTSLocalDecodeStatePool:
         self.audio_repetition_penalty = torch.zeros(
             self.num_rows, device=self.device, dtype=torch.float32
         )
+        self.params_versions = torch.zeros(
+            self.num_rows, device=self.device, dtype=torch.int64
+        )
         self.audio_token_presence = torch.zeros(
             self.num_rows,
             self.n_vq,
@@ -147,6 +150,7 @@ class MossTTSLocalDecodeStatePool:
         self.sampling_steps[row_idx] = 0
         self.audio_repetition_penalty[row_idx] = 0.0
         self.audio_token_presence[row_idx].zero_()
+        self.params_versions[row_idx] += 1
         self._audio_repetition_penalty_rows.discard(int(row_idx))
         if row_idx == self.padding_row:
             self._set_padding_defaults()
@@ -198,6 +202,7 @@ class MossTTSLocalDecodeStatePool:
             self._audio_repetition_penalty_rows.discard(int(row_idx))
         else:
             self._audio_repetition_penalty_rows.add(int(row_idx))
+        self.params_versions[row_idx] += 1
 
     def ensure_params(self, row_idx: int, rid: str, data: Any) -> None:
         """Write request-static params once for the current row acquisition."""

--- a/sglang_omni/models/moss_tts_local/state_pool.py
+++ b/sglang_omni/models/moss_tts_local/state_pool.py
@@ -97,9 +97,6 @@ class MossTTSLocalDecodeStatePool:
         self.audio_repetition_penalty = torch.zeros(
             self.num_rows, device=self.device, dtype=torch.float32
         )
-        self.params_versions = torch.zeros(
-            self.num_rows, device=self.device, dtype=torch.int64
-        )
         self.audio_token_presence = torch.zeros(
             self.num_rows,
             self.n_vq,
@@ -150,7 +147,6 @@ class MossTTSLocalDecodeStatePool:
         self.sampling_steps[row_idx] = 0
         self.audio_repetition_penalty[row_idx] = 0.0
         self.audio_token_presence[row_idx].zero_()
-        self.params_versions[row_idx] += 1
         self._audio_repetition_penalty_rows.discard(int(row_idx))
         if row_idx == self.padding_row:
             self._set_padding_defaults()
@@ -164,7 +160,8 @@ class MossTTSLocalDecodeStatePool:
         self.seeds[row_idx] = 0
 
     def _set_padding_defaults(self) -> None:
-        """Sampling defaults used when CUDA graph buckets include padding."""
+        """Safe sampling defaults for the reserved padding row that scheduler
+        pad slots (``batch_size > len(requests)``) point at."""
         row_idx = self.padding_row
         self.text_temp[row_idx] = DEFAULT_SAMPLING_TEMPERATURE
         self.text_top_p[row_idx] = DEFAULT_TOP_P
@@ -202,7 +199,6 @@ class MossTTSLocalDecodeStatePool:
             self._audio_repetition_penalty_rows.discard(int(row_idx))
         else:
             self._audio_repetition_penalty_rows.add(int(row_idx))
-        self.params_versions[row_idx] += 1
 
     def ensure_params(self, row_idx: int, rid: str, data: Any) -> None:
         """Write request-static params once for the current row acquisition."""

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import sys
 import struct
+import types
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -206,6 +209,159 @@ def test_special_token_defaults_match_v15_checkpoint():
     assert defaults["audio_user_slot_token_id"] == 151654
     assert defaults["audio_assistant_slot_token_id"] == 151656
     assert defaults["audio_pad_code"] == 1024
+
+
+def test_engine_init_sets_local_decode_cuda_graph_buckets(monkeypatch):
+    from sglang_omni.models.moss_tts_local import stages
+
+    captured: dict[str, object] = {
+        "models": [],
+        "frame_decode_graph_bs": [],
+        "build_kwargs": [],
+    }
+
+    def fake_build_sglang_server_args(model_path, context_length, **kwargs):
+        captured["model_path"] = model_path
+        captured["context_length"] = context_length
+        captured["build_kwargs"].append(dict(kwargs))
+        server_args = SimpleNamespace(disable_cuda_graph=kwargs["disable_cuda_graph"])
+        if "disable_cuda_graph_padding" in kwargs:
+            server_args.disable_cuda_graph_padding = kwargs[
+                "disable_cuda_graph_padding"
+            ]
+        return server_args
+
+    def fake_create_sglang_infrastructure(
+        server_args,
+        gpu_id,
+        *,
+        model_arch_override=None,
+    ):
+        captured["gpu_id"] = gpu_id
+        captured["model_arch_override"] = model_arch_override
+
+        class FakeModel:
+            def init_frame_decode_graphs(self, batch_sizes):
+                captured["frame_decode_graph_bs"].append(batch_sizes)
+
+            def reset_request(self, request_id):
+                del request_id
+
+        model = FakeModel()
+        captured["models"].append(model)
+
+        def init_device_graphs():
+            captured["graph_inits"] = int(captured.get("graph_inits", 0)) + 1
+
+        model_worker = SimpleNamespace(
+            model_runner=SimpleNamespace(
+                model=model,
+                init_device_graphs=init_device_graphs,
+            )
+        )
+        return (
+            model_worker,
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+        )
+
+    class FakeOutputProcessor:
+        def __init__(self, **kwargs) -> None:
+            captured["output_processor_kwargs"] = kwargs
+
+    class FakeMossTTSLocalModelRunner:
+        def __init__(self, model_worker, output_proc) -> None:
+            captured["model_runner_args"] = (model_worker, output_proc)
+
+    class FakeOmniScheduler:
+        def __init__(self, **kwargs) -> None:
+            captured["scheduler_kwargs"] = kwargs
+
+    fake_model_runner_module = types.ModuleType(
+        "sglang_omni.models.moss_tts_local.model_runner"
+    )
+    fake_model_runner_module.MossTTSLocalModelRunner = FakeMossTTSLocalModelRunner
+
+    fake_backend_module = types.ModuleType("sglang_omni.scheduling.sglang_backend")
+    fake_backend_module.build_sglang_server_args = fake_build_sglang_server_args
+    fake_backend_module.SGLangOutputProcessor = FakeOutputProcessor
+
+    fake_bootstrap_module = types.ModuleType("sglang_omni.scheduling.bootstrap")
+    fake_bootstrap_module.create_sglang_infrastructure = (
+        fake_create_sglang_infrastructure
+    )
+
+    fake_omni_scheduler_module = types.ModuleType(
+        "sglang_omni.scheduling.omni_scheduler"
+    )
+    fake_omni_scheduler_module.OmniScheduler = FakeOmniScheduler
+
+    monkeypatch.setattr(stages, "_resolve_checkpoint", lambda model_path: model_path)
+    monkeypatch.setattr(
+        stages,
+        "make_moss_tts_local_scheduler_adapters",
+        lambda model: (lambda payload: payload, lambda data: data),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.models.moss_tts_local.model_runner",
+        fake_model_runner_module,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.scheduling.sglang_backend",
+        fake_backend_module,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.scheduling.bootstrap",
+        fake_bootstrap_module,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.scheduling.omni_scheduler",
+        fake_omni_scheduler_module,
+    )
+
+    stages.create_sglang_tts_engine_executor("OpenMOSS-Team/moss-local-test")
+    stages.create_sglang_tts_engine_executor(
+        "OpenMOSS-Team/moss-local-test",
+        server_args_overrides={
+            "cuda_graph_bs": [1, 4],
+            "decode_graph_padding": True,
+            "decode_graph_padding_ratio_threshold": 1.25,
+            "forward_native_decode_enabled": True,
+        },
+    )
+
+    default_model, override_model = captured["models"]
+    default_graph_bs, override_graph_bs = captured["frame_decode_graph_bs"]
+
+    assert default_model._moss_local_decode_cuda_graph_bs == [1, 2, 4, 8, 16]
+    assert default_model._moss_local_decode_graph_padding is False
+    assert default_model._moss_local_decode_graph_padding_ratio_threshold == 1.15
+    assert default_model._moss_local_forward_native_decode_enabled is False
+    assert default_model._moss_local_forward_native_decode_active is False
+    assert default_graph_bs is default_model._moss_local_decode_cuda_graph_bs
+    assert default_graph_bs == [1, 2, 4, 8, 16]
+
+    assert override_model._moss_local_decode_cuda_graph_bs == [1, 4]
+    assert override_model._moss_local_decode_graph_padding is True
+    assert override_model._moss_local_decode_graph_padding_ratio_threshold == 1.25
+    assert override_model._moss_local_forward_native_decode_enabled is True
+    assert override_model._moss_local_forward_native_decode_active is False
+    assert override_graph_bs is override_model._moss_local_decode_cuda_graph_bs
+    assert override_graph_bs == [1, 4]
+    assert "decode_graph_padding" not in captured["build_kwargs"][1]
+    assert "forward_native_decode_enabled" not in captured["build_kwargs"][1]
+
+    assert captured["graph_inits"] == 2
+    assert captured["context_length"] == 8192
+    assert captured["model_arch_override"] == "MossTTSLocalSGLangModel"
 
 
 # ---------------------------------------------------------------------------
@@ -447,8 +603,6 @@ def test_row_radix_token_ids_hash_rows_and_keep_eos():
 
 
 def test_audio_history_presence_mask_excludes_prompt_rows():
-    from types import SimpleNamespace
-
     from sglang_omni.models.moss_tts_local.state_pool import MossTTSLocalDecodeStatePool
 
     model = SimpleNamespace(

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -241,8 +241,14 @@ def test_engine_init_sets_local_decode_cuda_graph_buckets(monkeypatch):
         captured["model_arch_override"] = model_arch_override
 
         class FakeModel:
+            def __init__(self):
+                self.prepared_frame_decode_bs = None
+
             def init_frame_decode_graphs(self, batch_sizes):
                 captured["frame_decode_graph_bs"].append(batch_sizes)
+
+            def prepare_frame_decode_for_capture(self, batch_sizes):
+                self.prepared_frame_decode_bs = list(batch_sizes)
 
             def reset_request(self, request_id):
                 del request_id
@@ -277,9 +283,13 @@ def test_engine_init_sets_local_decode_cuda_graph_buckets(monkeypatch):
         def __init__(self, model_worker, output_proc) -> None:
             captured["model_runner_args"] = (model_worker, output_proc)
 
+        def set_stream_outbox(self, outbox) -> None:
+            captured["stream_outbox"] = outbox
+
     class FakeOmniScheduler:
         def __init__(self, **kwargs) -> None:
             captured["scheduler_kwargs"] = kwargs
+            self.outbox = None
 
     fake_model_runner_module = types.ModuleType(
         "sglang_omni.models.moss_tts_local.model_runner"
@@ -332,32 +342,23 @@ def test_engine_init_sets_local_decode_cuda_graph_buckets(monkeypatch):
         "OpenMOSS-Team/moss-local-test",
         server_args_overrides={
             "cuda_graph_bs": [1, 4],
-            "decode_graph_padding": True,
-            "decode_graph_padding_ratio_threshold": 1.25,
-            "forward_native_decode_enabled": True,
         },
+        forward_native_decode_enabled=True,
     )
 
     default_model, override_model = captured["models"]
     default_graph_bs, override_graph_bs = captured["frame_decode_graph_bs"]
 
-    assert default_model._moss_local_decode_cuda_graph_bs == [1, 2, 4, 8, 16]
-    assert default_model._moss_local_decode_graph_padding is False
-    assert default_model._moss_local_decode_graph_padding_ratio_threshold == 1.15
-    assert default_model._moss_local_forward_native_decode_enabled is False
+    # Native in-forward decode defaults to off; the frame-decode graphs are still
+    # captured so the runner's standalone path stays graphed.
     assert default_model._moss_local_forward_native_decode_active is False
-    assert default_graph_bs is default_model._moss_local_decode_cuda_graph_bs
+    assert default_model.prepared_frame_decode_bs == [1, 2, 4, 8, 16]
     assert default_graph_bs == [1, 2, 4, 8, 16]
 
-    assert override_model._moss_local_decode_cuda_graph_bs == [1, 4]
-    assert override_model._moss_local_decode_graph_padding is True
-    assert override_model._moss_local_decode_graph_padding_ratio_threshold == 1.25
-    assert override_model._moss_local_forward_native_decode_enabled is True
-    assert override_model._moss_local_forward_native_decode_active is False
-    assert override_graph_bs is override_model._moss_local_decode_cuda_graph_bs
+    # Opt-in flag arms the native in-forward decode path.
+    assert override_model._moss_local_forward_native_decode_active is True
+    assert override_model.prepared_frame_decode_bs == [1, 4]
     assert override_graph_bs == [1, 4]
-    assert "decode_graph_padding" not in captured["build_kwargs"][1]
-    assert "forward_native_decode_enabled" not in captured["build_kwargs"][1]
 
     assert captured["graph_inits"] == 2
     assert captured["context_length"] == 8192
@@ -1471,7 +1472,8 @@ def test_lookahead_eligible_routes_eager_batches_to_sync():
 
 def test_async_launch_resolve_matches_sync_collect():
     """post_decode_launch + post_decode_resolve must yield the same published
-    next_token_ids and the same output_rows append as synchronous _collect_frame.
+    next_token_ids and the same output_rows append as synchronous
+    _collect_frame_in_runner.
     The launch hands resolve a device snapshot of the published ids so they
     survive the next step clobbering the aliased output_ids tensor in place; CPU
     stub: eager decode (no CUDA graph).
@@ -1535,7 +1537,7 @@ def test_async_launch_resolve_matches_sync_collect():
     # Synchronous collect.
     rs = _make_runner()
     req_s, res_s, sb_s = _sched_req(), _result(), types.SimpleNamespace()
-    rs._collect_frame(res_s, None, sb_s, [req_s])
+    rs._collect_frame_in_runner(res_s, None, sb_s, [req_s])
 
     # Async launch + resolve (separate runner/pool to avoid cross-overwrite).
     ra = _make_runner()

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -58,12 +58,6 @@ def _init_active_decode_buffers(model: SimpleNamespace) -> None:
         dtype=torch.int64,
         device=device,
     )
-    model._cg_active_pool_rows_cached = torch.full(
-        (max_running_requests,), -1, dtype=torch.int64, device=device
-    )
-    model._cg_active_pool_row_versions_cached = torch.full(
-        (max_running_requests,), -1, dtype=torch.int64, device=device
-    )
     model._cg_active_feedback_embeds = torch.zeros(
         max_running_requests, hidden_size, dtype=dtype, device=device
     )
@@ -493,11 +487,8 @@ def _forward_sample_model(max_running_requests: int = 4) -> SimpleNamespace:
         audio_end_token_id=1001,
     )
     model.device = torch.device("cpu")
-    model._moss_local_decode_cuda_graph_bs = [1, 2, 4, 8, 16]
-    model._moss_local_decode_graph_padding = False
-    model._moss_local_decode_graph_padding_ratio_threshold = 1.15
-    model._moss_local_forward_native_decode_enabled = False
     model._moss_local_forward_native_decode_active = False
+    model._moss_local_native_decode_enabled = True
     model._state_pool = MossTTSLocalDecodeStatePool(model)
     _init_active_decode_buffers(model)
     return model
@@ -602,10 +593,8 @@ def test_before_decode_stages_forward_sample_buffers_and_padding():
     assert model._moss_local_forward_native_decode_active is False
 
 
-def test_before_decode_stages_to_cuda_graph_bucket_when_padding_enabled():
+def test_before_decode_pads_scheduler_slots_to_padding_row():
     model = _forward_sample_model(max_running_requests=4)
-    model._moss_local_decode_cuda_graph_bs = [1, 2, 4]
-    model._moss_local_decode_graph_padding = True
     model.frame_graph_max_bs = 4
     pool = model._state_pool
     row = pool.acquire_row("a")
@@ -630,8 +619,8 @@ def test_before_decode_stages_to_cuda_graph_bucket_when_padding_enabled():
     assert torch.equal(model._decode_input_embedding.weight, original_weight)
     assert torch.equal(forward_batch.input_ids, torch.tensor([0, 1, 2]))
     assert torch.equal(
-        model._cg_pool_rows[:4],
-        torch.tensor([row, pool.padding_row, pool.padding_row, pool.padding_row]),
+        model._cg_pool_rows[:3],
+        torch.tensor([row, pool.padding_row, pool.padding_row]),
     )
     assert pool.text_temp[pool.padding_row].item() == DEFAULT_SAMPLING_TEMPERATURE
     assert int(pool.text_top_k[pool.padding_row]) == DEFAULT_TEXT_TOP_K
@@ -642,38 +631,17 @@ def test_before_decode_stages_to_cuda_graph_bucket_when_padding_enabled():
         == DEFAULT_AUDIO_REPETITION_PENALTY
     )
     assert torch.equal(
-        model._cg_active_feedback_embeds[:4],
+        model._cg_active_feedback_embeds[:3],
         pool.feedback_embeds[
-            torch.tensor([row, pool.padding_row, pool.padding_row, pool.padding_row])
+            torch.tensor([row, pool.padding_row, pool.padding_row])
         ],
     )
-    assert torch.equal(model._cg_active_sampling_steps[:4], torch.tensor([0, 0, 0, 0]))
+    assert torch.equal(model._cg_active_sampling_steps[:3], torch.tensor([0, 0, 0]))
 
 
-def test_decode_staging_batch_size_uses_graph_buckets_and_max_graph_bs():
-    model = _forward_sample_model(max_running_requests=16)
-    model._moss_local_decode_cuda_graph_bs = [1, 2, 4, 8, 16]
-    model.frame_graph_max_bs = 16
-    runner = object.__new__(MossTTSLocalModelRunner)
-    runner.model = model
-
-    model._moss_local_decode_graph_padding = False
-    assert runner._decode_staging_batch_size(15) == 15
-
-    model._moss_local_decode_graph_padding = True
-    assert runner._decode_staging_batch_size(15) == 16
-    assert runner._decode_staging_batch_size(9) == 16
-    assert runner._decode_staging_batch_size(17) == 17
-
-    model.frame_graph_max_bs = 8
-    assert runner._decode_staging_batch_size(15) == 15
-
-
-def test_forward_native_static_staging_cache_uses_pool_param_versions():
+def test_forward_native_stages_static_sampling_params_every_step():
     model = _forward_sample_model(max_running_requests=2)
-    model._moss_local_forward_native_decode_enabled = True
     model.frame_graph_max_bs = 2
-    model._moss_local_decode_stats = {}
     pool = model._state_pool
     runner = object.__new__(MossTTSLocalModelRunner)
     runner.model = model
@@ -688,32 +656,19 @@ def test_forward_native_static_staging_cache_uses_pool_param_versions():
     assert row is not None
     assert runner._forward_sample_native_decode is True
     assert model._moss_local_forward_native_decode_active is True
-    assert model._moss_local_decode_stats["static_stage_copy_slots"] == len(
-        MossTTSLocalModelRunner._STATIC_STAGE_FIELDS
-    )
     assert float(model._cg_active_text_temp[0]) == float(pool.text_temp[row])
     assert int(model._cg_active_seeds[0]) == 3
 
-    pool.sampling_steps[row] = 5
-    runner.before_decode(forward_batch, SimpleNamespace(), [request])
-
-    assert int(model._cg_active_sampling_steps[0]) == 5
-    assert model._moss_local_decode_stats["static_stage_copy_slots"] == len(
-        MossTTSLocalModelRunner._STATIC_STAGE_FIELDS
-    )
-
+    # No version cache: every step re-stages the static params straight from the
+    # pool, so a later param edit shows up on the next before_decode.
     pool.write_params(row, _decode_data(seed=9, generation_steps=0))
     runner.before_decode(forward_batch, SimpleNamespace(), [request])
 
     assert int(model._cg_active_seeds[0]) == 9
-    assert model._moss_local_decode_stats["static_stage_copy_slots"] == 2 * len(
-        MossTTSLocalModelRunner._STATIC_STAGE_FIELDS
-    )
 
 
 def test_forward_native_gate_falls_back_for_penalty_and_oversized_batch():
     model = _forward_sample_model(max_running_requests=4)
-    model._moss_local_forward_native_decode_enabled = True
     model.frame_graph_max_bs = 4
     runner = object.__new__(MossTTSLocalModelRunner)
     runner.model = model
@@ -731,7 +686,6 @@ def test_forward_native_gate_falls_back_for_penalty_and_oversized_batch():
     assert model._moss_local_forward_native_decode_active is False
 
     model = _forward_sample_model(max_running_requests=4)
-    model._moss_local_forward_native_decode_enabled = True
     model.frame_graph_max_bs = 1
     runner.model = model
     requests = [
@@ -826,7 +780,7 @@ def test_double_collect_overwrites_feedback():
             logits_output=SimpleNamespace(hidden_states=torch.zeros(1, hidden_size))
         )
         schedule_batch = SimpleNamespace()
-        runner._collect_frame_eager(result, None, schedule_batch, [request])
+        runner._collect_frame_in_runner(result, None, schedule_batch, [request])
 
     row = pool.row_for("rid")
     assert row is not None
@@ -889,7 +843,7 @@ def test_collect_frame_reads_generation_steps_from_pool():
         logits_output=SimpleNamespace(hidden_states=torch.zeros(1, hidden_size))
     )
 
-    runner._collect_frame(result, SimpleNamespace(), SimpleNamespace(), [request])
+    runner._collect_frame_in_runner(result, SimpleNamespace(), SimpleNamespace(), [request])
 
     assert torch.equal(captured["base_positions"], torch.tensor([4 * 13]))
     assert int(pool.sampling_steps[row]) == 5
@@ -945,8 +899,8 @@ def test_pool_sampling_position_leads_unresolved_lookahead_launches():
         logits_output=SimpleNamespace(hidden_states=torch.zeros(1, hidden_size))
     )
 
-    runner._collect_frame(result, SimpleNamespace(), SimpleNamespace(), [request])
-    runner._collect_frame(result, SimpleNamespace(), SimpleNamespace(), [request])
+    runner._collect_frame_in_runner(result, SimpleNamespace(), SimpleNamespace(), [request])
+    runner._collect_frame_in_runner(result, SimpleNamespace(), SimpleNamespace(), [request])
 
     row = pool.row_for("rid")
     assert row is not None
@@ -1037,7 +991,7 @@ def test_collect_frame_uses_eager_path_when_audio_repetition_penalty_active(
         logits_output=SimpleNamespace(hidden_states=torch.zeros(1, hidden_size))
     )
 
-    runner._collect_frame(result, SimpleNamespace(), SimpleNamespace(), [request])
+    runner._collect_frame_in_runner(result, SimpleNamespace(), SimpleNamespace(), [request])
 
     assert called["eager"] is True
     assert len(sampled_audio_logits) == 1
@@ -1141,7 +1095,7 @@ def test_cached_pool_rows_drive_collect_and_batched_step_commit():
     schedule_batch = SimpleNamespace(is_prefill_only=False, output_ids=None)
     scheduler_output = SimpleNamespace(requests=requests)
 
-    runner._collect_frame(result, forward_batch, schedule_batch, requests)
+    runner._collect_frame_in_runner(result, forward_batch, schedule_batch, requests)
 
     assert torch.equal(captured["base_positions"], torch.tensor([4 * 13, 8 * 13]))
     assert result.moss_journal.pool_rows == [row_a, row_b]
@@ -1321,7 +1275,7 @@ def test_collect_frame_skips_chunked_feedback_and_journal():
     )
     schedule_batch = SimpleNamespace()
 
-    runner._collect_frame_eager(result, None, schedule_batch, requests)
+    runner._collect_frame_in_runner(result, None, schedule_batch, requests)
 
     chunked_row = pool.row_for("chunked")
     normal_row = pool.row_for("normal")
@@ -1497,7 +1451,7 @@ def test_forward_sample_collect_matches_eager_graph_collect():
     eager_batch = SimpleNamespace()
     eager_requests = requests()
 
-    eager_runner._collect_frame_eager(
+    eager_runner._collect_frame_in_runner(
         eager_result, SimpleNamespace(), eager_batch, eager_requests
     )
 
@@ -1541,7 +1495,7 @@ def test_decode_collect_routes_repetition_penalty_to_eager_fallback():
     runner = object.__new__(MossTTSLocalModelRunner)
     runner.model = model
     calls = []
-    runner._collect_frame_eager = lambda *args: calls.append("eager")
+    runner._collect_frame_in_runner = lambda *args: calls.append("eager")
     runner._collect_frame_from_forward_sample = lambda *args: calls.append("pool")
     request = SimpleNamespace(
         request_id="rid",
@@ -1741,7 +1695,7 @@ def test_post_prefill_collection_remains_eager_for_forward_sample_path():
     runner = object.__new__(MossTTSLocalModelRunner)
     runner.model = model
     calls = []
-    runner._collect_frame_eager = lambda *args: calls.append("eager")
+    runner._collect_frame_in_runner = lambda *args: calls.append("eager")
     runner._collect_frame_from_forward_sample = lambda *args: calls.append("pool")
     request = SimpleNamespace(
         request_id="rid",

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -636,9 +636,7 @@ def test_before_decode_stages_to_cuda_graph_bucket_when_padding_enabled():
             torch.tensor([row, pool.padding_row, pool.padding_row, pool.padding_row])
         ],
     )
-    assert torch.equal(
-        model._cg_active_sampling_steps[:4], torch.tensor([0, 0, 0, 0])
-    )
+    assert torch.equal(model._cg_active_sampling_steps[:4], torch.tensor([0, 0, 0, 0]))
 
 
 def test_fresh_row_zeros_feedback():
@@ -720,7 +718,7 @@ def test_double_collect_overwrites_feedback():
             logits_output=SimpleNamespace(hidden_states=torch.zeros(1, hidden_size))
         )
         schedule_batch = SimpleNamespace()
-        runner._collect_frame_legacy(result, None, schedule_batch, [request])
+        runner._collect_frame_eager(result, None, schedule_batch, [request])
 
     row = pool.row_for("rid")
     assert row is not None
@@ -993,7 +991,7 @@ def test_cached_pool_rows_drive_collect_and_batched_step_commit():
     ]
 
     forward_batch = SimpleNamespace(input_ids=torch.full((2,), -1, dtype=torch.long))
-    runner._write_decode_input_embedding(forward_batch, requests)
+    runner._prepare_forward_sample_inputs(forward_batch, requests)
 
     row_t = forward_batch.moss_pool_row_t.clone()
     row_a, row_b = int(row_t[0]), int(row_t[1])
@@ -1215,7 +1213,7 @@ def test_collect_frame_skips_chunked_feedback_and_journal():
     )
     schedule_batch = SimpleNamespace()
 
-    runner._collect_frame_legacy(result, None, schedule_batch, requests)
+    runner._collect_frame_eager(result, None, schedule_batch, requests)
 
     chunked_row = pool.row_for("chunked")
     normal_row = pool.row_for("normal")
@@ -1344,7 +1342,7 @@ def test_resume_with_empty_output_rows_still_resets_sampling_steps():
     assert data.sampling_steps == 1
 
 
-def test_forward_sample_collect_matches_legacy_graph_collect():
+def test_forward_sample_collect_matches_eager_graph_collect():
     def make_runner_and_model():
         model = _forward_sample_model(max_running_requests=4)
         model.frame_graph_max_bs = 4
@@ -1378,21 +1376,21 @@ def test_forward_sample_collect_matches_legacy_graph_collect():
             ),
         ]
 
-    legacy_runner, legacy_model = make_runner_and_model()
+    eager_runner, eager_model = make_runner_and_model()
 
     def decode_frame_graphed(hidden_states, **kwargs):
         del hidden_states, kwargs
         return stop_choice, codes, feedback
 
-    legacy_model.decode_frame_graphed = decode_frame_graphed
-    legacy_result = SimpleNamespace(
+    eager_model.decode_frame_graphed = decode_frame_graphed
+    eager_result = SimpleNamespace(
         logits_output=SimpleNamespace(hidden_states=torch.zeros(2, _HIDDEN))
     )
-    legacy_batch = SimpleNamespace()
-    legacy_requests = requests()
+    eager_batch = SimpleNamespace()
+    eager_requests = requests()
 
-    legacy_runner._collect_frame_legacy(
-        legacy_result, SimpleNamespace(), legacy_batch, legacy_requests
+    eager_runner._collect_frame_eager(
+        eager_result, SimpleNamespace(), eager_batch, eager_requests
     )
 
     new_runner, new_model = make_runner_and_model()
@@ -1404,7 +1402,7 @@ def test_forward_sample_collect_matches_legacy_graph_collect():
     new_runner.before_decode(forward_batch, SimpleNamespace(), new_requests)
     new_pool = new_model._state_pool
     new_model._cg_step_rows[:2] = rows
-    new_model._cg_step_next_token_ids[:2] = legacy_result.next_token_ids
+    new_model._cg_step_next_token_ids[:2] = eager_result.next_token_ids
     new_model._cg_active_next_feedback_embeds[:2] = feedback
     new_model._cg_active_next_sampling_steps[:2] = torch.tensor([1, 1])
     new_result = SimpleNamespace(logits_output=SimpleNamespace())
@@ -1412,15 +1410,15 @@ def test_forward_sample_collect_matches_legacy_graph_collect():
 
     new_runner._collect_frame_from_forward_sample(new_result, new_batch, new_requests)
 
-    assert torch.equal(new_result.next_token_ids, legacy_result.next_token_ids)
-    assert torch.equal(new_batch.output_ids, legacy_batch.output_ids)
-    assert new_result.moss_journal.rids == legacy_result.moss_journal.rids
-    assert new_result.moss_journal.pool_rows == legacy_result.moss_journal.pool_rows
-    assert torch.equal(new_result.moss_journal.rows, legacy_result.moss_journal.rows)
+    assert torch.equal(new_result.next_token_ids, eager_result.next_token_ids)
+    assert torch.equal(new_batch.output_ids, eager_batch.output_ids)
+    assert new_result.moss_journal.rids == eager_result.moss_journal.rids
+    assert new_result.moss_journal.pool_rows == eager_result.moss_journal.pool_rows
+    assert torch.equal(new_result.moss_journal.rows, eager_result.moss_journal.rows)
     assert torch.equal(
         new_model._state_pool.feedback_embeds[new_model._state_pool.row_for("normal")],
-        legacy_model._state_pool.feedback_embeds[
-            legacy_model._state_pool.row_for("normal")
+        eager_model._state_pool.feedback_embeds[
+            eager_model._state_pool.row_for("normal")
         ],
     )
     assert torch.equal(
@@ -1429,13 +1427,13 @@ def test_forward_sample_collect_matches_legacy_graph_collect():
     )
 
 
-def test_decode_collect_routes_repetition_penalty_to_legacy_fallback():
+def test_decode_collect_routes_repetition_penalty_to_eager_fallback():
     model = _forward_sample_model(max_running_requests=2)
     pool = model._state_pool
     runner = object.__new__(MossTTSLocalModelRunner)
     runner.model = model
     calls = []
-    runner._collect_frame_legacy = lambda *args: calls.append("legacy")
+    runner._collect_frame_eager = lambda *args: calls.append("eager")
     runner._collect_frame_from_forward_sample = lambda *args: calls.append("pool")
     request = SimpleNamespace(
         request_id="rid",
@@ -1464,15 +1462,13 @@ def test_decode_collect_routes_repetition_penalty_to_legacy_fallback():
         [request],
     )
 
-    assert calls == ["legacy"]
+    assert calls == ["eager"]
     assert torch.equal(pool.feedback_embeds[row], original_feedback)
     assert torch.equal(pool.sampling_steps[row], original_sampling_steps)
 
 
 def test_native_decode_forward_uses_active_buffers_without_pool_writes():
-    from sglang_omni.models.moss_tts_local.sglang_model import (
-        MossTTSLocalSGLangModel,
-    )
+    from sglang_omni.models.moss_tts_local.sglang_model import MossTTSLocalSGLangModel
 
     model = object.__new__(MossTTSLocalSGLangModel)
     torch.nn.Module.__init__(model)
@@ -1561,9 +1557,7 @@ def test_native_decode_forward_uses_active_buffers_without_pool_writes():
 
 
 def test_native_decode_forward_outputs_active_buffers_for_fallback_without_pool_writes():
-    from sglang_omni.models.moss_tts_local.sglang_model import (
-        MossTTSLocalSGLangModel,
-    )
+    from sglang_omni.models.moss_tts_local.sglang_model import MossTTSLocalSGLangModel
 
     model = object.__new__(MossTTSLocalSGLangModel)
     torch.nn.Module.__init__(model)
@@ -1634,12 +1628,12 @@ def test_native_decode_forward_outputs_active_buffers_for_fallback_without_pool_
     assert int(model._cg_active_next_sampling_steps[0]) == 5
 
 
-def test_post_prefill_collection_remains_legacy_for_forward_sample_path():
+def test_post_prefill_collection_remains_eager_for_forward_sample_path():
     model = _forward_sample_model(max_running_requests=2)
     runner = object.__new__(MossTTSLocalModelRunner)
     runner.model = model
     calls = []
-    runner._collect_frame_legacy = lambda *args: calls.append("legacy")
+    runner._collect_frame_eager = lambda *args: calls.append("eager")
     runner._collect_frame_from_forward_sample = lambda *args: calls.append("pool")
     request = SimpleNamespace(
         request_id="rid",
@@ -1652,7 +1646,7 @@ def test_post_prefill_collection_remains_legacy_for_forward_sample_path():
 
     runner.post_prefill(result, forward_batch, SimpleNamespace(), [request])
 
-    assert calls == ["legacy"]
+    assert calls == ["eager"]
 
 
 def test_journal_rid_assertion_fires():

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -18,6 +18,12 @@ from sglang_omni.models.moss_tts_local.request_builders import (
     make_moss_tts_local_scheduler_adapters,
 )
 from sglang_omni.models.moss_tts_local.state_pool import (
+    DEFAULT_AUDIO_REPETITION_PENALTY,
+    DEFAULT_AUDIO_TOP_K,
+    DEFAULT_SAMPLING_SEED,
+    DEFAULT_SAMPLING_TEMPERATURE,
+    DEFAULT_TEXT_TOP_K,
+    DEFAULT_TOP_P,
     MossTTSLocalDecodeJournal,
     MossTTSLocalDecodeStatePool,
 )
@@ -55,32 +61,44 @@ def _init_active_decode_buffers(model: SimpleNamespace) -> None:
     model._cg_active_feedback_embeds = torch.zeros(
         max_running_requests, hidden_size, dtype=dtype, device=device
     )
-    model._cg_active_text_temp = torch.ones(
-        max_running_requests, dtype=torch.float32, device=device
+    model._cg_active_text_temp = torch.full(
+        (max_running_requests,),
+        DEFAULT_SAMPLING_TEMPERATURE,
+        dtype=torch.float32,
+        device=device,
     )
-    model._cg_active_text_top_p = torch.ones(
-        max_running_requests, dtype=torch.float32, device=device
+    model._cg_active_text_top_p = torch.full(
+        (max_running_requests,), DEFAULT_TOP_P, dtype=torch.float32, device=device
     )
-    model._cg_active_audio_temp = torch.ones(
-        max_running_requests, dtype=torch.float32, device=device
+    model._cg_active_audio_temp = torch.full(
+        (max_running_requests,),
+        DEFAULT_SAMPLING_TEMPERATURE,
+        dtype=torch.float32,
+        device=device,
     )
-    model._cg_active_audio_top_p = torch.ones(
-        max_running_requests, dtype=torch.float32, device=device
+    model._cg_active_audio_top_p = torch.full(
+        (max_running_requests,), DEFAULT_TOP_P, dtype=torch.float32, device=device
     )
     model._cg_active_text_top_k = torch.full(
-        (max_running_requests,), 50, dtype=torch.int64, device=device
+        (max_running_requests,), DEFAULT_TEXT_TOP_K, dtype=torch.int64, device=device
     )
     model._cg_active_audio_top_k = torch.full(
-        (max_running_requests,), 25, dtype=torch.int64, device=device
+        (max_running_requests,), DEFAULT_AUDIO_TOP_K, dtype=torch.int64, device=device
     )
-    model._cg_active_seeds = torch.zeros(
-        max_running_requests, dtype=torch.int64, device=device
+    model._cg_active_seeds = torch.full(
+        (max_running_requests,),
+        DEFAULT_SAMPLING_SEED,
+        dtype=torch.int64,
+        device=device,
     )
     model._cg_active_sampling_steps = torch.zeros(
         max_running_requests, dtype=torch.int64, device=device
     )
-    model._cg_active_audio_repetition_penalty = torch.ones(
-        max_running_requests, dtype=torch.float32, device=device
+    model._cg_active_audio_repetition_penalty = torch.full(
+        (max_running_requests,),
+        DEFAULT_AUDIO_REPETITION_PENALTY,
+        dtype=torch.float32,
+        device=device,
     )
     model._cg_active_next_feedback_embeds = torch.zeros(
         max_running_requests, hidden_size, dtype=dtype, device=device
@@ -148,20 +166,20 @@ def test_pool_dims_derive_from_embedding_weight():
 def test_padding_row_has_safe_sampling_defaults():
     pool = MossTTSLocalDecodeStatePool(_model(max_running_requests=4))
     row = pool.padding_row
-    assert pool.text_temp[row].item() == 1.0
-    assert pool.text_top_p[row].item() == 1.0
-    assert int(pool.text_top_k[row]) == 50
-    assert pool.audio_temp[row].item() == 1.0
-    assert pool.audio_top_p[row].item() == 1.0
-    assert int(pool.audio_top_k[row]) == 25
-    assert int(pool.seeds[row]) == 0
-    assert pool.audio_repetition_penalty[row].item() == 1.0
+    assert pool.text_temp[row].item() == DEFAULT_SAMPLING_TEMPERATURE
+    assert pool.text_top_p[row].item() == DEFAULT_TOP_P
+    assert int(pool.text_top_k[row]) == DEFAULT_TEXT_TOP_K
+    assert pool.audio_temp[row].item() == DEFAULT_SAMPLING_TEMPERATURE
+    assert pool.audio_top_p[row].item() == DEFAULT_TOP_P
+    assert int(pool.audio_top_k[row]) == DEFAULT_AUDIO_TOP_K
+    assert int(pool.seeds[row]) == DEFAULT_SAMPLING_SEED
+    assert pool.audio_repetition_penalty[row].item() == DEFAULT_AUDIO_REPETITION_PENALTY
 
     pool.text_temp[row] = 0.0
     pool.text_top_k[row] = 0
     pool.reset_row(row)
-    assert pool.text_temp[row].item() == 1.0
-    assert int(pool.text_top_k[row]) == 50
+    assert pool.text_temp[row].item() == DEFAULT_SAMPLING_TEMPERATURE
+    assert int(pool.text_top_k[row]) == DEFAULT_TEXT_TOP_K
 
 
 def test_acquire_is_idempotent_by_rid():
@@ -543,30 +561,49 @@ def test_before_decode_stages_forward_sample_buffers_and_padding():
     )
     torch.testing.assert_close(
         model._cg_active_text_temp[:4],
-        torch.tensor([0.53, 0.55, 1.0, 1.0], dtype=torch.float32),
+        torch.tensor(
+            [
+                0.53,
+                0.55,
+                DEFAULT_SAMPLING_TEMPERATURE,
+                DEFAULT_SAMPLING_TEMPERATURE,
+            ],
+            dtype=torch.float32,
+        ),
     )
     torch.testing.assert_close(
         model._cg_active_text_top_p[:4],
-        torch.tensor([0.9, 0.9, 1.0, 1.0], dtype=torch.float32),
+        torch.tensor([0.9, 0.9, DEFAULT_TOP_P, DEFAULT_TOP_P], dtype=torch.float32),
     )
     assert torch.equal(
         model._cg_active_text_top_k[:4],
-        torch.tensor([43, 45, 50, 50], dtype=torch.long),
+        torch.tensor([43, 45, DEFAULT_TEXT_TOP_K, DEFAULT_TEXT_TOP_K]),
     )
     torch.testing.assert_close(
         model._cg_active_audio_temp[:4],
-        torch.tensor([1.7, 1.7, 1.0, 1.0], dtype=torch.float32),
+        torch.tensor(
+            [
+                1.7,
+                1.7,
+                DEFAULT_SAMPLING_TEMPERATURE,
+                DEFAULT_SAMPLING_TEMPERATURE,
+            ],
+            dtype=torch.float32,
+        ),
     )
     torch.testing.assert_close(
         model._cg_active_audio_top_p[:4],
-        torch.tensor([0.8, 0.8, 1.0, 1.0], dtype=torch.float32),
+        torch.tensor([0.8, 0.8, DEFAULT_TOP_P, DEFAULT_TOP_P], dtype=torch.float32),
     )
     assert torch.equal(
         model._cg_active_audio_top_k[:4],
-        torch.tensor([25, 17, 25, 25], dtype=torch.long),
+        torch.tensor(
+            [DEFAULT_AUDIO_TOP_K, 17, DEFAULT_AUDIO_TOP_K, DEFAULT_AUDIO_TOP_K]
+        ),
     )
     assert torch.equal(
-        model._cg_active_seeds[:4], torch.tensor([3, 5, 0, 0], dtype=torch.long)
+        model._cg_active_seeds[:4],
+        torch.tensor([3, 5, DEFAULT_SAMPLING_SEED, DEFAULT_SAMPLING_SEED]),
     )
     assert torch.equal(
         model._cg_active_sampling_steps[:4],
@@ -574,7 +611,10 @@ def test_before_decode_stages_forward_sample_buffers_and_padding():
     )
     torch.testing.assert_close(
         model._cg_active_audio_repetition_penalty[:4],
-        torch.tensor([1.0, 1.0, 1.0, 1.0], dtype=torch.float32),
+        torch.tensor(
+            [DEFAULT_AUDIO_REPETITION_PENALTY] * 4,
+            dtype=torch.float32,
+        ),
     )
     torch.testing.assert_close(
         pool.text_temp[torch.tensor([row_a, row_b])],
@@ -584,12 +624,15 @@ def test_before_decode_stages_forward_sample_buffers_and_padding():
         pool.audio_top_k[torch.tensor([row_a, row_b])], torch.tensor([25, 17])
     )
     assert torch.equal(pool.seeds[torch.tensor([row_a, row_b])], torch.tensor([3, 5]))
-    assert pool.text_temp[pool.padding_row].item() == 1.0
-    assert pool.audio_top_p[pool.padding_row].item() == 1.0
-    assert int(pool.text_top_k[pool.padding_row]) == 50
-    assert int(pool.audio_top_k[pool.padding_row]) == 25
-    assert int(pool.seeds[pool.padding_row]) == 0
-    assert pool.audio_repetition_penalty[pool.padding_row].item() == 1.0
+    assert pool.text_temp[pool.padding_row].item() == DEFAULT_SAMPLING_TEMPERATURE
+    assert pool.audio_top_p[pool.padding_row].item() == DEFAULT_TOP_P
+    assert int(pool.text_top_k[pool.padding_row]) == DEFAULT_TEXT_TOP_K
+    assert int(pool.audio_top_k[pool.padding_row]) == DEFAULT_AUDIO_TOP_K
+    assert int(pool.seeds[pool.padding_row]) == DEFAULT_SAMPLING_SEED
+    assert (
+        pool.audio_repetition_penalty[pool.padding_row].item()
+        == DEFAULT_AUDIO_REPETITION_PENALTY
+    )
     assert runner._forward_sample_pool_rows == [row_a, row_b]
     assert torch.equal(runner._forward_sample_pool_row_t, torch.tensor([row_a, row_b]))
     assert runner._forward_sample_rids == ["a", "b"]
@@ -625,11 +668,14 @@ def test_before_decode_stages_to_cuda_graph_bucket_when_padding_enabled():
         model._cg_pool_rows[:4],
         torch.tensor([row, pool.padding_row, pool.padding_row, pool.padding_row]),
     )
-    assert pool.text_temp[pool.padding_row].item() == 1.0
-    assert int(pool.text_top_k[pool.padding_row]) == 50
-    assert int(pool.audio_top_k[pool.padding_row]) == 25
-    assert int(pool.seeds[pool.padding_row]) == 0
-    assert pool.audio_repetition_penalty[pool.padding_row].item() == 1.0
+    assert pool.text_temp[pool.padding_row].item() == DEFAULT_SAMPLING_TEMPERATURE
+    assert int(pool.text_top_k[pool.padding_row]) == DEFAULT_TEXT_TOP_K
+    assert int(pool.audio_top_k[pool.padding_row]) == DEFAULT_AUDIO_TOP_K
+    assert int(pool.seeds[pool.padding_row]) == DEFAULT_SAMPLING_SEED
+    assert (
+        pool.audio_repetition_penalty[pool.padding_row].item()
+        == DEFAULT_AUDIO_REPETITION_PENALTY
+    )
     assert torch.equal(
         model._cg_active_feedback_embeds[:4],
         pool.feedback_embeds[

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -58,6 +58,12 @@ def _init_active_decode_buffers(model: SimpleNamespace) -> None:
         dtype=torch.int64,
         device=device,
     )
+    model._cg_active_pool_rows_cached = torch.full(
+        (max_running_requests,), -1, dtype=torch.int64, device=device
+    )
+    model._cg_active_pool_row_versions_cached = torch.full(
+        (max_running_requests,), -1, dtype=torch.int64, device=device
+    )
     model._cg_active_feedback_embeds = torch.zeros(
         max_running_requests, hidden_size, dtype=dtype, device=device
     )
@@ -489,6 +495,9 @@ def _forward_sample_model(max_running_requests: int = 4) -> SimpleNamespace:
     model.device = torch.device("cpu")
     model._moss_local_decode_cuda_graph_bs = [1, 2, 4, 8, 16]
     model._moss_local_decode_graph_padding = False
+    model._moss_local_decode_graph_padding_ratio_threshold = 1.15
+    model._moss_local_forward_native_decode_enabled = False
+    model._moss_local_forward_native_decode_active = False
     model._state_pool = MossTTSLocalDecodeStatePool(model)
     _init_active_decode_buffers(model)
     return model
@@ -560,65 +569,18 @@ def test_before_decode_stages_forward_sample_buffers_and_padding():
         ],
     )
     torch.testing.assert_close(
-        model._cg_active_text_temp[:4],
+        pool.text_temp[torch.tensor([row_a, row_b])],
         torch.tensor(
             [
                 0.53,
                 0.55,
-                DEFAULT_SAMPLING_TEMPERATURE,
-                DEFAULT_SAMPLING_TEMPERATURE,
             ],
             dtype=torch.float32,
         ),
-    )
-    torch.testing.assert_close(
-        model._cg_active_text_top_p[:4],
-        torch.tensor([0.9, 0.9, DEFAULT_TOP_P, DEFAULT_TOP_P], dtype=torch.float32),
-    )
-    assert torch.equal(
-        model._cg_active_text_top_k[:4],
-        torch.tensor([43, 45, DEFAULT_TEXT_TOP_K, DEFAULT_TEXT_TOP_K]),
-    )
-    torch.testing.assert_close(
-        model._cg_active_audio_temp[:4],
-        torch.tensor(
-            [
-                1.7,
-                1.7,
-                DEFAULT_SAMPLING_TEMPERATURE,
-                DEFAULT_SAMPLING_TEMPERATURE,
-            ],
-            dtype=torch.float32,
-        ),
-    )
-    torch.testing.assert_close(
-        model._cg_active_audio_top_p[:4],
-        torch.tensor([0.8, 0.8, DEFAULT_TOP_P, DEFAULT_TOP_P], dtype=torch.float32),
-    )
-    assert torch.equal(
-        model._cg_active_audio_top_k[:4],
-        torch.tensor(
-            [DEFAULT_AUDIO_TOP_K, 17, DEFAULT_AUDIO_TOP_K, DEFAULT_AUDIO_TOP_K]
-        ),
-    )
-    assert torch.equal(
-        model._cg_active_seeds[:4],
-        torch.tensor([3, 5, DEFAULT_SAMPLING_SEED, DEFAULT_SAMPLING_SEED]),
     )
     assert torch.equal(
         model._cg_active_sampling_steps[:4],
         torch.tensor([2, 4, 0, 0], dtype=torch.long),
-    )
-    torch.testing.assert_close(
-        model._cg_active_audio_repetition_penalty[:4],
-        torch.tensor(
-            [DEFAULT_AUDIO_REPETITION_PENALTY] * 4,
-            dtype=torch.float32,
-        ),
-    )
-    torch.testing.assert_close(
-        pool.text_temp[torch.tensor([row_a, row_b])],
-        torch.tensor([0.53, 0.55], dtype=torch.float32),
     )
     assert torch.equal(
         pool.audio_top_k[torch.tensor([row_a, row_b])], torch.tensor([25, 17])
@@ -636,12 +598,15 @@ def test_before_decode_stages_forward_sample_buffers_and_padding():
     assert runner._forward_sample_pool_rows == [row_a, row_b]
     assert torch.equal(runner._forward_sample_pool_row_t, torch.tensor([row_a, row_b]))
     assert runner._forward_sample_rids == ["a", "b"]
+    assert runner._forward_sample_native_decode is False
+    assert model._moss_local_forward_native_decode_active is False
 
 
 def test_before_decode_stages_to_cuda_graph_bucket_when_padding_enabled():
     model = _forward_sample_model(max_running_requests=4)
     model._moss_local_decode_cuda_graph_bs = [1, 2, 4]
     model._moss_local_decode_graph_padding = True
+    model.frame_graph_max_bs = 4
     pool = model._state_pool
     row = pool.acquire_row("a")
     pool.feedback_embeds[row] = torch.arange(_HIDDEN, dtype=torch.bfloat16)
@@ -683,6 +648,103 @@ def test_before_decode_stages_to_cuda_graph_bucket_when_padding_enabled():
         ],
     )
     assert torch.equal(model._cg_active_sampling_steps[:4], torch.tensor([0, 0, 0, 0]))
+
+
+def test_decode_staging_batch_size_uses_graph_buckets_and_max_graph_bs():
+    model = _forward_sample_model(max_running_requests=16)
+    model._moss_local_decode_cuda_graph_bs = [1, 2, 4, 8, 16]
+    model.frame_graph_max_bs = 16
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+
+    model._moss_local_decode_graph_padding = False
+    assert runner._decode_staging_batch_size(15) == 15
+
+    model._moss_local_decode_graph_padding = True
+    assert runner._decode_staging_batch_size(15) == 16
+    assert runner._decode_staging_batch_size(9) == 16
+    assert runner._decode_staging_batch_size(17) == 17
+
+    model.frame_graph_max_bs = 8
+    assert runner._decode_staging_batch_size(15) == 15
+
+
+def test_forward_native_static_staging_cache_uses_pool_param_versions():
+    model = _forward_sample_model(max_running_requests=2)
+    model._moss_local_forward_native_decode_enabled = True
+    model.frame_graph_max_bs = 2
+    model._moss_local_decode_stats = {}
+    pool = model._state_pool
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    request = SimpleNamespace(
+        request_id="rid", data=_decode_data(seed=3, generation_steps=0)
+    )
+    forward_batch = SimpleNamespace(input_ids=torch.full((1,), -1, dtype=torch.long))
+
+    runner.before_decode(forward_batch, SimpleNamespace(), [request])
+
+    row = pool.row_for("rid")
+    assert row is not None
+    assert runner._forward_sample_native_decode is True
+    assert model._moss_local_forward_native_decode_active is True
+    assert model._moss_local_decode_stats["static_stage_copy_slots"] == len(
+        MossTTSLocalModelRunner._STATIC_STAGE_FIELDS
+    )
+    assert float(model._cg_active_text_temp[0]) == float(pool.text_temp[row])
+    assert int(model._cg_active_seeds[0]) == 3
+
+    pool.sampling_steps[row] = 5
+    runner.before_decode(forward_batch, SimpleNamespace(), [request])
+
+    assert int(model._cg_active_sampling_steps[0]) == 5
+    assert model._moss_local_decode_stats["static_stage_copy_slots"] == len(
+        MossTTSLocalModelRunner._STATIC_STAGE_FIELDS
+    )
+
+    pool.write_params(row, _decode_data(seed=9, generation_steps=0))
+    runner.before_decode(forward_batch, SimpleNamespace(), [request])
+
+    assert int(model._cg_active_seeds[0]) == 9
+    assert model._moss_local_decode_stats["static_stage_copy_slots"] == 2 * len(
+        MossTTSLocalModelRunner._STATIC_STAGE_FIELDS
+    )
+
+
+def test_forward_native_gate_falls_back_for_penalty_and_oversized_batch():
+    model = _forward_sample_model(max_running_requests=4)
+    model._moss_local_forward_native_decode_enabled = True
+    model.frame_graph_max_bs = 4
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    forward_batch = SimpleNamespace(
+        batch_size=1, input_ids=torch.full((1,), -1, dtype=torch.long)
+    )
+
+    request = SimpleNamespace(
+        request_id="penalty",
+        data=_decode_data(seed=1, generation_steps=0, audio_repetition_penalty=1.2),
+    )
+    runner.before_decode(forward_batch, SimpleNamespace(), [request])
+
+    assert runner._forward_sample_native_decode is False
+    assert model._moss_local_forward_native_decode_active is False
+
+    model = _forward_sample_model(max_running_requests=4)
+    model._moss_local_forward_native_decode_enabled = True
+    model.frame_graph_max_bs = 1
+    runner.model = model
+    requests = [
+        SimpleNamespace(request_id="a", data=_decode_data(seed=1, generation_steps=0)),
+        SimpleNamespace(request_id="b", data=_decode_data(seed=2, generation_steps=0)),
+    ]
+    forward_batch = SimpleNamespace(
+        batch_size=2, input_ids=torch.full((2,), -1, dtype=torch.long)
+    )
+    runner.before_decode(forward_batch, SimpleNamespace(), requests)
+
+    assert runner._forward_sample_native_decode is False
+    assert model._moss_local_forward_native_decode_active is False
 
 
 def test_fresh_row_zeros_feedback():
@@ -1531,6 +1593,7 @@ def test_native_decode_forward_uses_active_buffers_without_pool_writes():
     pool = MossTTSLocalDecodeStatePool(model)
     model._state_pool = pool
     _init_active_decode_buffers(model)
+    model._moss_local_forward_native_decode_active = True
 
     row = pool.acquire_row("rid")
     pool.write_params(row, _params(seed=7))
@@ -1620,6 +1683,7 @@ def test_native_decode_forward_outputs_active_buffers_for_fallback_without_pool_
     pool = MossTTSLocalDecodeStatePool(model)
     model._state_pool = pool
     _init_active_decode_buffers(model)
+    model._moss_local_forward_native_decode_active = False
 
     row = pool.acquire_row("rid")
     pool.write_params(row, _params(seed=7, audio_repetition_penalty=1.2))
@@ -1643,11 +1707,11 @@ def test_native_decode_forward_outputs_active_buffers_for_fallback_without_pool_
             return torch.ones((1, _HIDDEN), dtype=torch.bfloat16)
 
     model.model = _Backbone()
-    model._decode_frame_graphable = lambda hidden_states, **kwargs: (
-        torch.zeros(1, dtype=torch.long),
-        torch.full((1, 12), 7, dtype=torch.long),
-        torch.full((1, _HIDDEN), 3, dtype=torch.bfloat16),
-    )
+    def fail_decode_frame_graphable(hidden_states, **kwargs):
+        del hidden_states, kwargs
+        raise AssertionError("fallback forward must not run native frame decode")
+
+    model._decode_frame_graphable = fail_decode_frame_graphable
     model._select_sample_hidden_states = (
         lambda hidden_states, forward_batch: hidden_states
     )
@@ -1655,7 +1719,7 @@ def test_native_decode_forward_outputs_active_buffers_for_fallback_without_pool_
     forward_batch = SimpleNamespace(
         forward_mode=SimpleNamespace(is_decode=lambda: True)
     )
-    model.forward(
+    result = model.forward(
         torch.zeros(1, dtype=torch.long),
         torch.zeros(1, dtype=torch.long),
         forward_batch,
@@ -1663,15 +1727,13 @@ def test_native_decode_forward_outputs_active_buffers_for_fallback_without_pool_
 
     assert torch.equal(pool.feedback_embeds[row], original_feedback)
     assert int(pool.sampling_steps[row]) == 4
-    assert torch.equal(
-        model._cg_step_rows[0],
-        torch.cat([torch.tensor([1000]), torch.full((12,), 7, dtype=torch.long)]),
-    )
+    assert torch.equal(model._cg_step_rows[0], torch.zeros(13, dtype=torch.long))
     assert torch.equal(
         model._cg_active_next_feedback_embeds[0],
-        torch.full((_HIDDEN,), 3, dtype=torch.bfloat16),
+        torch.zeros(_HIDDEN, dtype=torch.bfloat16),
     )
-    assert int(model._cg_active_next_sampling_steps[0]) == 5
+    assert int(model._cg_active_next_sampling_steps[0]) == 0
+    assert torch.equal(result.hidden_states, torch.ones((1, _HIDDEN)).bfloat16())
 
 
 def test_post_prefill_collection_remains_eager_for_forward_sample_path():

--- a/tests/unit_test/moss_tts_local/test_state_pool.py
+++ b/tests/unit_test/moss_tts_local/test_state_pool.py
@@ -36,6 +36,66 @@ def _model(max_running_requests: int = 4) -> SimpleNamespace:
     )
 
 
+def _init_active_decode_buffers(model: SimpleNamespace) -> None:
+    weight = model._decode_input_embedding.weight
+    max_running_requests = int(weight.shape[0])
+    hidden_size = int(weight.shape[1])
+    device = weight.device
+    dtype = weight.dtype
+    n_vq = int(getattr(model.config, "n_vq", 12))
+    padding_row = getattr(getattr(model, "_state_pool", None), "padding_row", None)
+    if padding_row is None:
+        padding_row = max_running_requests
+    model._cg_pool_rows = torch.full(
+        (max_running_requests,),
+        int(padding_row),
+        dtype=torch.int64,
+        device=device,
+    )
+    model._cg_active_feedback_embeds = torch.zeros(
+        max_running_requests, hidden_size, dtype=dtype, device=device
+    )
+    model._cg_active_text_temp = torch.ones(
+        max_running_requests, dtype=torch.float32, device=device
+    )
+    model._cg_active_text_top_p = torch.ones(
+        max_running_requests, dtype=torch.float32, device=device
+    )
+    model._cg_active_audio_temp = torch.ones(
+        max_running_requests, dtype=torch.float32, device=device
+    )
+    model._cg_active_audio_top_p = torch.ones(
+        max_running_requests, dtype=torch.float32, device=device
+    )
+    model._cg_active_text_top_k = torch.full(
+        (max_running_requests,), 50, dtype=torch.int64, device=device
+    )
+    model._cg_active_audio_top_k = torch.full(
+        (max_running_requests,), 25, dtype=torch.int64, device=device
+    )
+    model._cg_active_seeds = torch.zeros(
+        max_running_requests, dtype=torch.int64, device=device
+    )
+    model._cg_active_sampling_steps = torch.zeros(
+        max_running_requests, dtype=torch.int64, device=device
+    )
+    model._cg_active_audio_repetition_penalty = torch.ones(
+        max_running_requests, dtype=torch.float32, device=device
+    )
+    model._cg_active_next_feedback_embeds = torch.zeros(
+        max_running_requests, hidden_size, dtype=dtype, device=device
+    )
+    model._cg_active_next_sampling_steps = torch.zeros(
+        max_running_requests, dtype=torch.int64, device=device
+    )
+    model._cg_step_rows = torch.zeros(
+        max_running_requests, n_vq + 1, dtype=torch.int64, device=device
+    )
+    model._cg_step_next_token_ids = torch.zeros(
+        max_running_requests, dtype=torch.int64, device=device
+    )
+
+
 def _params(seed: int = 7, audio_repetition_penalty: float = 1.0) -> SimpleNamespace:
     return SimpleNamespace(
         text_temperature=0.5,
@@ -57,12 +117,12 @@ def test_pool_dims_derive_from_embedding_weight():
     assert pool.hidden_size == _HIDDEN
     assert pool.feedback_embeds.shape == (5, _HIDDEN)
     assert pool.feedback_embeds.dtype == torch.bfloat16
-    for field in (pool.text_temp, pool.text_top_p, pool.audio_temp, pool.audio_top_p):
-        assert field.shape == (5,)
-        assert field.dtype == torch.float32
-    for field in (pool.text_top_k, pool.audio_top_k, pool.seeds):
-        assert field.shape == (5,)
-        assert field.dtype == torch.int64
+    for name in ("text_temp", "text_top_p", "audio_temp", "audio_top_p"):
+        assert getattr(pool, name).shape == (5,)
+        assert getattr(pool, name).dtype == torch.float32
+    for name in ("text_top_k", "audio_top_k", "seeds"):
+        assert getattr(pool, name).shape == (5,)
+        assert getattr(pool, name).dtype == torch.int64
     assert pool.generation_steps.shape == (5,)
     assert pool.generation_steps.dtype == torch.int64
     assert pool.sampling_steps.shape == (5,)
@@ -71,6 +131,37 @@ def test_pool_dims_derive_from_embedding_weight():
     assert pool.audio_repetition_penalty.dtype == torch.float32
     assert pool.audio_token_presence.shape == (5, 12, 1024)
     assert pool.audio_token_presence.dtype == torch.bool
+    for removed in (
+        "base_positions",
+        "stop_choice",
+        "codes",
+        "rows",
+        "sample_feedback_embeds",
+        "step_stop_choice",
+        "step_codes",
+        "step_rows",
+        "step_next_token_ids",
+    ):
+        assert not hasattr(pool, removed)
+
+
+def test_padding_row_has_safe_sampling_defaults():
+    pool = MossTTSLocalDecodeStatePool(_model(max_running_requests=4))
+    row = pool.padding_row
+    assert pool.text_temp[row].item() == 1.0
+    assert pool.text_top_p[row].item() == 1.0
+    assert int(pool.text_top_k[row]) == 50
+    assert pool.audio_temp[row].item() == 1.0
+    assert pool.audio_top_p[row].item() == 1.0
+    assert int(pool.audio_top_k[row]) == 25
+    assert int(pool.seeds[row]) == 0
+    assert pool.audio_repetition_penalty[row].item() == 1.0
+
+    pool.text_temp[row] = 0.0
+    pool.text_top_k[row] = 0
+    pool.reset_row(row)
+    assert pool.text_temp[row].item() == 1.0
+    assert int(pool.text_top_k[row]) == 50
 
 
 def test_acquire_is_idempotent_by_rid():
@@ -146,19 +237,19 @@ def test_reset_row_zeroes_all_fields():
     pool.feedback_embeds[row].fill_(2.0)
     pool.reset_row(row)
     assert torch.all(pool.feedback_embeds[row] == 0)
-    for field in (
-        pool.text_temp,
-        pool.text_top_p,
-        pool.audio_temp,
-        pool.audio_top_p,
-        pool.text_top_k,
-        pool.audio_top_k,
-        pool.seeds,
-        pool.generation_steps,
-        pool.sampling_steps,
-        pool.audio_repetition_penalty,
+    for name in (
+        "text_temp",
+        "text_top_p",
+        "audio_temp",
+        "audio_top_p",
+        "text_top_k",
+        "audio_top_k",
+        "seeds",
+        "generation_steps",
+        "sampling_steps",
+        "audio_repetition_penalty",
     ):
-        assert field[row] == 0
+        assert getattr(pool, name)[row] == 0
     assert int(torch.count_nonzero(pool.audio_token_presence[row])) == 0
 
 
@@ -337,47 +428,236 @@ def test_journal_holds_fields():
     assert torch.equal(journal.rows, rows)
 
 
-def test_feedback_gather_equals_old_popleft():
-    model = _model(max_running_requests=4)
-    pool = MossTTSLocalDecodeStatePool(model)
-    model._state_pool = pool
+def test_before_decode_stages_pool_rows_instead_of_copying_feedback():
+    model = _forward_sample_model(max_running_requests=4)
+    pool = model._state_pool
     rows = [pool.acquire_row("a"), pool.acquire_row("b")]
-    expected = torch.stack(
+    feedback = torch.stack(
         [
             torch.arange(_HIDDEN, dtype=torch.bfloat16),
             torch.arange(_HIDDEN, dtype=torch.bfloat16) + 10,
         ],
         dim=0,
     )
-    pool.feedback_embeds[torch.tensor(rows, dtype=torch.long)] = expected
+    pool.feedback_embeds[torch.tensor(rows, dtype=torch.long)] = feedback
 
     runner = object.__new__(MossTTSLocalModelRunner)
     runner.model = model
     forward_batch = SimpleNamespace(input_ids=torch.full((2,), -1, dtype=torch.long))
     requests = [
-        SimpleNamespace(request_id="a", data=_params(seed=1)),
-        SimpleNamespace(request_id="b", data=_params(seed=2)),
+        SimpleNamespace(request_id="a", data=_decode_data(seed=1, generation_steps=0)),
+        SimpleNamespace(request_id="b", data=_decode_data(seed=2, generation_steps=0)),
     ]
+    original_weight = model._decode_input_embedding.weight.clone()
 
-    runner._write_decode_input_embedding(forward_batch, requests)
+    runner._prepare_forward_sample_inputs(forward_batch, requests)
 
-    assert torch.equal(model._decode_input_embedding.weight[:2], expected)
+    assert torch.equal(model._decode_input_embedding.weight, original_weight)
     assert torch.equal(forward_batch.input_ids, torch.tensor([0, 1]))
+    assert torch.equal(
+        model._cg_pool_rows[:2],
+        torch.tensor(rows, dtype=torch.long),
+    )
+    assert torch.equal(model._cg_active_feedback_embeds[:2], feedback)
+
+
+def _forward_sample_model(max_running_requests: int = 4) -> SimpleNamespace:
+    model = _model(max_running_requests=max_running_requests)
+    model.config = SimpleNamespace(
+        n_vq=12,
+        audio_assistant_slot_token_id=1000,
+        audio_end_token_id=1001,
+    )
+    model.device = torch.device("cpu")
+    model._moss_local_decode_cuda_graph_bs = [1, 2, 4, 8, 16]
+    model._moss_local_decode_graph_padding = False
+    model._state_pool = MossTTSLocalDecodeStatePool(model)
+    _init_active_decode_buffers(model)
+    return model
+
+
+def _decode_data(
+    *,
+    seed: int,
+    generation_steps: int,
+    audio_top_k: int = 25,
+    audio_repetition_penalty: float = 1.0,
+    is_chunked: int = 0,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        req=SimpleNamespace(is_chunked=is_chunked),
+        text_temperature=0.5 + seed / 100,
+        text_top_p=0.9,
+        text_top_k=40 + seed,
+        audio_temperature=1.7,
+        audio_top_p=0.8,
+        audio_top_k=audio_top_k,
+        sampling_seed=seed,
+        generation_steps=generation_steps,
+        audio_repetition_penalty=audio_repetition_penalty,
+        output_rows=[],
+    )
+
+
+def test_before_decode_stages_forward_sample_buffers_and_padding():
+    model = _forward_sample_model(max_running_requests=4)
+    pool = model._state_pool
+    row_a = pool.acquire_row("a")
+    row_b = pool.acquire_row("b")
+    pool.feedback_embeds[row_a] = torch.arange(_HIDDEN, dtype=torch.bfloat16)
+    pool.feedback_embeds[row_b] = torch.arange(_HIDDEN, dtype=torch.bfloat16) + 10
+    pool.sampling_steps[row_a] = 2
+    pool.sampling_steps[row_b] = 4
+    pool.feedback_embeds[pool.padding_row] = torch.full(
+        (_HIDDEN,), 99, dtype=torch.bfloat16
+    )
+
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    requests = [
+        SimpleNamespace(request_id="a", data=_decode_data(seed=3, generation_steps=2)),
+        SimpleNamespace(
+            request_id="b",
+            data=_decode_data(seed=5, generation_steps=4, audio_top_k=17),
+        ),
+    ]
+    forward_batch = SimpleNamespace(
+        batch_size=4,
+        input_ids=torch.full((4,), -1, dtype=torch.long),
+    )
+    original_weight = model._decode_input_embedding.weight.clone()
+
+    runner.before_decode(forward_batch, SimpleNamespace(), requests)
+
+    assert torch.equal(model._decode_input_embedding.weight, original_weight)
+    assert torch.equal(forward_batch.input_ids, torch.tensor([0, 1, 2, 3]))
+    assert torch.equal(
+        model._cg_pool_rows[:4],
+        torch.tensor([row_a, row_b, pool.padding_row, pool.padding_row]),
+    )
+    torch.testing.assert_close(
+        model._cg_active_feedback_embeds[:4],
+        pool.feedback_embeds[
+            torch.tensor([row_a, row_b, pool.padding_row, pool.padding_row])
+        ],
+    )
+    torch.testing.assert_close(
+        model._cg_active_text_temp[:4],
+        torch.tensor([0.53, 0.55, 1.0, 1.0], dtype=torch.float32),
+    )
+    torch.testing.assert_close(
+        model._cg_active_text_top_p[:4],
+        torch.tensor([0.9, 0.9, 1.0, 1.0], dtype=torch.float32),
+    )
+    assert torch.equal(
+        model._cg_active_text_top_k[:4],
+        torch.tensor([43, 45, 50, 50], dtype=torch.long),
+    )
+    torch.testing.assert_close(
+        model._cg_active_audio_temp[:4],
+        torch.tensor([1.7, 1.7, 1.0, 1.0], dtype=torch.float32),
+    )
+    torch.testing.assert_close(
+        model._cg_active_audio_top_p[:4],
+        torch.tensor([0.8, 0.8, 1.0, 1.0], dtype=torch.float32),
+    )
+    assert torch.equal(
+        model._cg_active_audio_top_k[:4],
+        torch.tensor([25, 17, 25, 25], dtype=torch.long),
+    )
+    assert torch.equal(
+        model._cg_active_seeds[:4], torch.tensor([3, 5, 0, 0], dtype=torch.long)
+    )
+    assert torch.equal(
+        model._cg_active_sampling_steps[:4],
+        torch.tensor([2, 4, 0, 0], dtype=torch.long),
+    )
+    torch.testing.assert_close(
+        model._cg_active_audio_repetition_penalty[:4],
+        torch.tensor([1.0, 1.0, 1.0, 1.0], dtype=torch.float32),
+    )
+    torch.testing.assert_close(
+        pool.text_temp[torch.tensor([row_a, row_b])],
+        torch.tensor([0.53, 0.55], dtype=torch.float32),
+    )
+    assert torch.equal(
+        pool.audio_top_k[torch.tensor([row_a, row_b])], torch.tensor([25, 17])
+    )
+    assert torch.equal(pool.seeds[torch.tensor([row_a, row_b])], torch.tensor([3, 5]))
+    assert pool.text_temp[pool.padding_row].item() == 1.0
+    assert pool.audio_top_p[pool.padding_row].item() == 1.0
+    assert int(pool.text_top_k[pool.padding_row]) == 50
+    assert int(pool.audio_top_k[pool.padding_row]) == 25
+    assert int(pool.seeds[pool.padding_row]) == 0
+    assert pool.audio_repetition_penalty[pool.padding_row].item() == 1.0
+    assert runner._forward_sample_pool_rows == [row_a, row_b]
+    assert torch.equal(runner._forward_sample_pool_row_t, torch.tensor([row_a, row_b]))
+    assert runner._forward_sample_rids == ["a", "b"]
+
+
+def test_before_decode_stages_to_cuda_graph_bucket_when_padding_enabled():
+    model = _forward_sample_model(max_running_requests=4)
+    model._moss_local_decode_cuda_graph_bs = [1, 2, 4]
+    model._moss_local_decode_graph_padding = True
+    pool = model._state_pool
+    row = pool.acquire_row("a")
+    pool.feedback_embeds[row] = torch.arange(_HIDDEN, dtype=torch.bfloat16)
+    pool.feedback_embeds[pool.padding_row] = torch.full(
+        (_HIDDEN,), 11, dtype=torch.bfloat16
+    )
+
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    request = SimpleNamespace(
+        request_id="a", data=_decode_data(seed=3, generation_steps=2)
+    )
+    forward_batch = SimpleNamespace(
+        batch_size=3,
+        input_ids=torch.full((3,), -1, dtype=torch.long),
+    )
+    original_weight = model._decode_input_embedding.weight.clone()
+
+    runner.before_decode(forward_batch, SimpleNamespace(), [request])
+
+    assert torch.equal(model._decode_input_embedding.weight, original_weight)
+    assert torch.equal(forward_batch.input_ids, torch.tensor([0, 1, 2]))
+    assert torch.equal(
+        model._cg_pool_rows[:4],
+        torch.tensor([row, pool.padding_row, pool.padding_row, pool.padding_row]),
+    )
+    assert pool.text_temp[pool.padding_row].item() == 1.0
+    assert int(pool.text_top_k[pool.padding_row]) == 50
+    assert int(pool.audio_top_k[pool.padding_row]) == 25
+    assert int(pool.seeds[pool.padding_row]) == 0
+    assert pool.audio_repetition_penalty[pool.padding_row].item() == 1.0
+    assert torch.equal(
+        model._cg_active_feedback_embeds[:4],
+        pool.feedback_embeds[
+            torch.tensor([row, pool.padding_row, pool.padding_row, pool.padding_row])
+        ],
+    )
+    assert torch.equal(
+        model._cg_active_sampling_steps[:4], torch.tensor([0, 0, 0, 0])
+    )
 
 
 def test_fresh_row_zeros_feedback():
-    model = _model(max_running_requests=2)
-    pool = MossTTSLocalDecodeStatePool(model)
-    model._state_pool = pool
+    model = _forward_sample_model(max_running_requests=2)
+    pool = model._state_pool
     runner = object.__new__(MossTTSLocalModelRunner)
     runner.model = model
     forward_batch = SimpleNamespace(input_ids=torch.full((1,), -1, dtype=torch.long))
-    requests = [SimpleNamespace(request_id="fresh", data=_params(seed=1))]
+    requests = [
+        SimpleNamespace(
+            request_id="fresh", data=_decode_data(seed=1, generation_steps=0)
+        )
+    ]
 
-    runner._write_decode_input_embedding(forward_batch, requests)
+    runner._prepare_forward_sample_inputs(forward_batch, requests)
 
+    assert torch.equal(model._cg_pool_rows[:1], torch.tensor([pool.row_for("fresh")]))
     assert torch.equal(
-        model._decode_input_embedding.weight[:1],
+        model._cg_active_feedback_embeds[:1],
         torch.zeros((1, _HIDDEN), dtype=torch.bfloat16),
     )
 
@@ -440,7 +720,7 @@ def test_double_collect_overwrites_feedback():
             logits_output=SimpleNamespace(hidden_states=torch.zeros(1, hidden_size))
         )
         schedule_batch = SimpleNamespace()
-        runner._collect_frame(result, None, schedule_batch, [request])
+        runner._collect_frame_legacy(result, None, schedule_batch, [request])
 
     row = pool.row_for("rid")
     assert row is not None
@@ -681,6 +961,7 @@ def test_cached_pool_rows_drive_collect_and_batched_step_commit():
     )
     pool = MossTTSLocalDecodeStatePool(model)
     model._state_pool = pool
+    _init_active_decode_buffers(model)
     runner = object.__new__(MossTTSLocalModelRunner)
     runner.model = model
     runner.output_processor = SimpleNamespace(
@@ -934,7 +1215,7 @@ def test_collect_frame_skips_chunked_feedback_and_journal():
     )
     schedule_batch = SimpleNamespace()
 
-    runner._collect_frame(result, None, schedule_batch, requests)
+    runner._collect_frame_legacy(result, None, schedule_batch, requests)
 
     chunked_row = pool.row_for("chunked")
     normal_row = pool.row_for("normal")
@@ -1061,6 +1342,317 @@ def test_resume_with_empty_output_rows_still_resets_sampling_steps():
     # The next collect then samples the resumed frame at position 0, not stale 1.
     assert MossTTSLocalModelRunner._advance_sampling_position(data) == 0
     assert data.sampling_steps == 1
+
+
+def test_forward_sample_collect_matches_legacy_graph_collect():
+    def make_runner_and_model():
+        model = _forward_sample_model(max_running_requests=4)
+        model.frame_graph_max_bs = 4
+        model.acquire_row = model._state_pool.acquire_row
+        runner = object.__new__(MossTTSLocalModelRunner)
+        runner.model = model
+        return runner, model
+
+    codes = torch.stack(
+        [torch.arange(12, dtype=torch.long), torch.arange(12, dtype=torch.long) + 20],
+        dim=0,
+    )
+    stop_choice = torch.tensor([0, 1], dtype=torch.long)
+    feedback = torch.tensor(
+        [[3, 3, 3, 3, 3, 3, 3, 3], [7, 7, 7, 7, 7, 7, 7, 7]],
+        dtype=torch.bfloat16,
+    )
+    rows = torch.empty((2, 13), dtype=torch.long)
+    rows[:, 0] = torch.tensor([1000, 1001], dtype=torch.long)
+    rows[:, 1:] = codes
+
+    def requests():
+        return [
+            SimpleNamespace(
+                request_id="chunked",
+                data=_decode_data(seed=1, generation_steps=0, is_chunked=1),
+            ),
+            SimpleNamespace(
+                request_id="normal",
+                data=_decode_data(seed=2, generation_steps=0, is_chunked=0),
+            ),
+        ]
+
+    legacy_runner, legacy_model = make_runner_and_model()
+
+    def decode_frame_graphed(hidden_states, **kwargs):
+        del hidden_states, kwargs
+        return stop_choice, codes, feedback
+
+    legacy_model.decode_frame_graphed = decode_frame_graphed
+    legacy_result = SimpleNamespace(
+        logits_output=SimpleNamespace(hidden_states=torch.zeros(2, _HIDDEN))
+    )
+    legacy_batch = SimpleNamespace()
+    legacy_requests = requests()
+
+    legacy_runner._collect_frame_legacy(
+        legacy_result, SimpleNamespace(), legacy_batch, legacy_requests
+    )
+
+    new_runner, new_model = make_runner_and_model()
+    new_requests = requests()
+    forward_batch = SimpleNamespace(
+        batch_size=2,
+        input_ids=torch.full((2,), -1, dtype=torch.long),
+    )
+    new_runner.before_decode(forward_batch, SimpleNamespace(), new_requests)
+    new_pool = new_model._state_pool
+    new_model._cg_step_rows[:2] = rows
+    new_model._cg_step_next_token_ids[:2] = legacy_result.next_token_ids
+    new_model._cg_active_next_feedback_embeds[:2] = feedback
+    new_model._cg_active_next_sampling_steps[:2] = torch.tensor([1, 1])
+    new_result = SimpleNamespace(logits_output=SimpleNamespace())
+    new_batch = SimpleNamespace()
+
+    new_runner._collect_frame_from_forward_sample(new_result, new_batch, new_requests)
+
+    assert torch.equal(new_result.next_token_ids, legacy_result.next_token_ids)
+    assert torch.equal(new_batch.output_ids, legacy_batch.output_ids)
+    assert new_result.moss_journal.rids == legacy_result.moss_journal.rids
+    assert new_result.moss_journal.pool_rows == legacy_result.moss_journal.pool_rows
+    assert torch.equal(new_result.moss_journal.rows, legacy_result.moss_journal.rows)
+    assert torch.equal(
+        new_model._state_pool.feedback_embeds[new_model._state_pool.row_for("normal")],
+        legacy_model._state_pool.feedback_embeds[
+            legacy_model._state_pool.row_for("normal")
+        ],
+    )
+    assert torch.equal(
+        new_model._state_pool.feedback_embeds[new_model._state_pool.row_for("chunked")],
+        torch.zeros(_HIDDEN, dtype=torch.bfloat16),
+    )
+
+
+def test_decode_collect_routes_repetition_penalty_to_legacy_fallback():
+    model = _forward_sample_model(max_running_requests=2)
+    pool = model._state_pool
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    calls = []
+    runner._collect_frame_legacy = lambda *args: calls.append("legacy")
+    runner._collect_frame_from_forward_sample = lambda *args: calls.append("pool")
+    request = SimpleNamespace(
+        request_id="rid",
+        data=_decode_data(seed=1, generation_steps=0, audio_repetition_penalty=1.2),
+    )
+    row = pool.acquire_row("rid")
+    pool.feedback_embeds[row] = torch.arange(_HIDDEN, dtype=torch.bfloat16)
+    original_feedback = pool.feedback_embeds[row].clone()
+    original_sampling_steps = pool.sampling_steps[row].clone()
+    runner._forward_sample_pool_rows = [row]
+    runner._forward_sample_pool_row_t = torch.tensor([row], dtype=torch.long)
+    runner._forward_sample_rids = ["rid"]
+    runner._forward_sample_native_decode = False
+    model._cg_step_rows[0] = torch.arange(13, dtype=torch.long)
+    model._cg_step_next_token_ids[0] = 123
+    model._cg_active_next_feedback_embeds[0] = torch.full(
+        (_HIDDEN,), 9, dtype=torch.bfloat16
+    )
+    model._cg_active_next_sampling_steps[0] = 77
+    result = SimpleNamespace(logits_output=SimpleNamespace())
+
+    runner.post_decode(
+        result,
+        SimpleNamespace(moss_has_audio_repetition_penalty=True),
+        SimpleNamespace(),
+        [request],
+    )
+
+    assert calls == ["legacy"]
+    assert torch.equal(pool.feedback_embeds[row], original_feedback)
+    assert torch.equal(pool.sampling_steps[row], original_sampling_steps)
+
+
+def test_native_decode_forward_uses_active_buffers_without_pool_writes():
+    from sglang_omni.models.moss_tts_local.sglang_model import (
+        MossTTSLocalSGLangModel,
+    )
+
+    model = object.__new__(MossTTSLocalSGLangModel)
+    torch.nn.Module.__init__(model)
+    model.pp_group = SimpleNamespace(is_first_rank=True, is_last_rank=True)
+    model.config = SimpleNamespace(
+        n_vq=12,
+        audio_assistant_slot_token_id=1000,
+        audio_end_token_id=1001,
+    )
+    model.n_vq = 12
+    model._decode_input_embedding = SimpleNamespace(
+        weight=torch.zeros(2, _HIDDEN, dtype=torch.bfloat16)
+    )
+    pool = MossTTSLocalDecodeStatePool(model)
+    model._state_pool = pool
+    _init_active_decode_buffers(model)
+
+    row = pool.acquire_row("rid")
+    pool.write_params(row, _params(seed=7))
+    pool.sampling_steps[row] = 4
+    feedback_in = torch.arange(_HIDDEN, dtype=torch.bfloat16)
+    pool.feedback_embeds[row] = feedback_in
+    model._cg_pool_rows[0] = row
+    model._cg_active_feedback_embeds[0] = feedback_in
+    model._cg_active_text_temp[0] = pool.text_temp[row]
+    model._cg_active_text_top_p[0] = pool.text_top_p[row]
+    model._cg_active_text_top_k[0] = pool.text_top_k[row]
+    model._cg_active_audio_temp[0] = pool.audio_temp[row]
+    model._cg_active_audio_top_p[0] = pool.audio_top_p[row]
+    model._cg_active_audio_top_k[0] = pool.audio_top_k[row]
+    model._cg_active_seeds[0] = pool.seeds[row]
+    model._cg_active_sampling_steps[0] = pool.sampling_steps[row]
+    model._cg_active_audio_repetition_penalty[0] = pool.audio_repetition_penalty[row]
+    original_feedback = pool.feedback_embeds[row].clone()
+    original_sampling_steps = pool.sampling_steps[row].clone()
+
+    captured = {}
+
+    class _Backbone:
+        def __call__(self, **kwargs):
+            captured["input_embeds"] = kwargs["input_embeds"].detach().clone()
+            return torch.ones((1, _HIDDEN), dtype=torch.bfloat16)
+
+    def _decode_frame_graphable(hidden_states, **kwargs):
+        captured["base_positions"] = kwargs["base_positions"].detach().clone()
+        assert torch.equal(kwargs["seeds"], torch.tensor([7]))
+        assert hidden_states.shape == (1, _HIDDEN)
+        return (
+            torch.zeros(1, dtype=torch.long),
+            torch.arange(12, dtype=torch.long).reshape(1, 12),
+            torch.full((1, _HIDDEN), 3, dtype=torch.bfloat16),
+        )
+
+    model.model = _Backbone()
+    model._decode_frame_graphable = _decode_frame_graphable
+    model._select_sample_hidden_states = (
+        lambda hidden_states, forward_batch: hidden_states
+    )
+
+    forward_batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(is_decode=lambda: True)
+    )
+    result = model.forward(
+        torch.zeros(1, dtype=torch.long),
+        torch.zeros(1, dtype=torch.long),
+        forward_batch,
+    )
+
+    assert torch.equal(captured["input_embeds"], feedback_in.reshape(1, _HIDDEN))
+    assert torch.equal(captured["base_positions"], torch.tensor([4 * 13]))
+    assert torch.equal(
+        model._cg_step_rows[0],
+        torch.cat([torch.tensor([1000]), torch.arange(12, dtype=torch.long)]),
+    )
+    assert torch.equal(pool.feedback_embeds[row], original_feedback)
+    assert torch.equal(pool.sampling_steps[row], original_sampling_steps)
+    assert torch.equal(
+        model._cg_active_next_feedback_embeds[0],
+        torch.full((_HIDDEN,), 3).bfloat16(),
+    )
+    assert int(model._cg_active_next_sampling_steps[0]) == 5
+    assert torch.equal(result.hidden_states, torch.ones((1, _HIDDEN)).bfloat16())
+    assert result.next_token_logits.shape == torch.Size([1, 1])
+    assert int(model._cg_step_next_token_ids[0]) != 1000
+    assert int(model._cg_step_next_token_ids[0]) < 151643
+
+
+def test_native_decode_forward_outputs_active_buffers_for_fallback_without_pool_writes():
+    from sglang_omni.models.moss_tts_local.sglang_model import (
+        MossTTSLocalSGLangModel,
+    )
+
+    model = object.__new__(MossTTSLocalSGLangModel)
+    torch.nn.Module.__init__(model)
+    model.pp_group = SimpleNamespace(is_first_rank=True, is_last_rank=True)
+    model.config = SimpleNamespace(
+        n_vq=12,
+        audio_assistant_slot_token_id=1000,
+        audio_end_token_id=1001,
+    )
+    model.n_vq = 12
+    model._decode_input_embedding = SimpleNamespace(
+        weight=torch.zeros(1, _HIDDEN, dtype=torch.bfloat16)
+    )
+    pool = MossTTSLocalDecodeStatePool(model)
+    model._state_pool = pool
+    _init_active_decode_buffers(model)
+
+    row = pool.acquire_row("rid")
+    pool.write_params(row, _params(seed=7, audio_repetition_penalty=1.2))
+    pool.sampling_steps[row] = 4
+    original_feedback = torch.arange(_HIDDEN, dtype=torch.bfloat16)
+    pool.feedback_embeds[row] = original_feedback
+    model._cg_pool_rows[0] = row
+    model._cg_active_feedback_embeds[0] = original_feedback
+    model._cg_active_text_temp[0] = pool.text_temp[row]
+    model._cg_active_text_top_p[0] = pool.text_top_p[row]
+    model._cg_active_text_top_k[0] = pool.text_top_k[row]
+    model._cg_active_audio_temp[0] = pool.audio_temp[row]
+    model._cg_active_audio_top_p[0] = pool.audio_top_p[row]
+    model._cg_active_audio_top_k[0] = pool.audio_top_k[row]
+    model._cg_active_seeds[0] = pool.seeds[row]
+    model._cg_active_sampling_steps[0] = pool.sampling_steps[row]
+    model._cg_active_audio_repetition_penalty[0] = pool.audio_repetition_penalty[row]
+
+    class _Backbone:
+        def __call__(self, **kwargs):
+            return torch.ones((1, _HIDDEN), dtype=torch.bfloat16)
+
+    model.model = _Backbone()
+    model._decode_frame_graphable = lambda hidden_states, **kwargs: (
+        torch.zeros(1, dtype=torch.long),
+        torch.full((1, 12), 7, dtype=torch.long),
+        torch.full((1, _HIDDEN), 3, dtype=torch.bfloat16),
+    )
+    model._select_sample_hidden_states = (
+        lambda hidden_states, forward_batch: hidden_states
+    )
+
+    forward_batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(is_decode=lambda: True)
+    )
+    model.forward(
+        torch.zeros(1, dtype=torch.long),
+        torch.zeros(1, dtype=torch.long),
+        forward_batch,
+    )
+
+    assert torch.equal(pool.feedback_embeds[row], original_feedback)
+    assert int(pool.sampling_steps[row]) == 4
+    assert torch.equal(
+        model._cg_step_rows[0],
+        torch.cat([torch.tensor([1000]), torch.full((12,), 7, dtype=torch.long)]),
+    )
+    assert torch.equal(
+        model._cg_active_next_feedback_embeds[0],
+        torch.full((_HIDDEN,), 3, dtype=torch.bfloat16),
+    )
+    assert int(model._cg_active_next_sampling_steps[0]) == 5
+
+
+def test_post_prefill_collection_remains_legacy_for_forward_sample_path():
+    model = _forward_sample_model(max_running_requests=2)
+    runner = object.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    calls = []
+    runner._collect_frame_legacy = lambda *args: calls.append("legacy")
+    runner._collect_frame_from_forward_sample = lambda *args: calls.append("pool")
+    request = SimpleNamespace(
+        request_id="rid",
+        data=_decode_data(seed=1, generation_steps=0),
+    )
+    forward_batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(is_decode=lambda: False),
+    )
+    result = SimpleNamespace(logits_output=SimpleNamespace())
+
+    runner.post_prefill(result, forward_batch, SimpleNamespace(), [request])
+
+    assert calls == ["legacy"]
 
 
 def test_journal_rid_assertion_fires():


### PR DESCRIPTION
## Motivation

Make the MOSS-TTS Local decode path CUDA-graph-friendly by moving decode
inputs and sampled outputs into the row-indexed decode-state pool.

The previous implementation had two decode modes behind a forward-sampling
bool. The old fallback path copied the next-step feedback embedding into
`_decode_input_embedding.weight`, while the native path used a separate set of
private `_cg_*` staging buffers for sampling params, base positions, sampled
rows, and feedback embeddings. That left the decode state split across several
places and made CUDA graph capture harder to reason about.

This PR removes that split. Decode now has one state model:

- `before_decode` stages only stable pool row ids in `_cg_pool_rows`;
- model forward reads decode input embeddings from `pool.feedback_embeds`;
- model forward runs the local frame sampling step during decode;
- model forward writes sampled rows and candidate feedback back into pool
  outputs;
- runner collection snapshots those pool outputs and keeps the existing
  request journal / chunked-prefill behavior.

close #736

## What Changed

- Added fixed active-batch decode staging buffers on
  `MossTTSLocalSGLangModel` for CUDA-graph replay: pool-row ids, feedback
  embeddings, sampling params/seeds/steps, next feedback/steps, sampled rows,
  and graph-computed next token ids.
- Kept the decode-state pool focused on durable per-request state: feedback
  embedding, sampling params/seed, generation/sampling steps, and audio
  repetition-penalty history. Per-step sampled rows and token ids now live in
  model-owned active-slot buffers instead of pool-owned output buffers.
- Updated `before_decode` to stage pool state into the model active buffers and
  write decode `input_ids` as active slot ids. It also pads staging up to the
  CUDA graph bucket size when graph padding is enabled, routing extra slots to
  the reserved padding row.
- Kept the reserved padding row out of normal allocation and gave it safe
  sampling defaults (`temperature=1.0`, `top_p=1.0`, text top-k `50`, audio
  top-k `25`, seed `0`, repetition penalty `1.0`) so padded graph slots can be
  sampled without touching real request state.
- Moved the normal decode sampling path into
  `MossTTSLocalSGLangModel.forward()`: decode forward reads staged feedback,
  runs `_decode_frame_graphable`, writes sampled multi-channel rows, computes
  GPU radix token ids, and stages the next feedback embedding / sampling step.
- Updated decode collection and async launch to consume the forward-sampled
  active buffers, publish `next_token_ids`, journal emitted rows, and commit
  next feedback / sampling steps back into the request's pool row.
- Preserved the legacy hidden-state collection path for prefill and for decode
  requests with non-default `audio_repetition_penalty`; lookahead eligibility
  continues to reject batches that exceed the frame graph limit or require that
  repetition-penalty fallback.
- Stopped mutating `_decode_input_embedding.weight` during decode preparation.
  The table remains only a sizing/device anchor for the pool and active decode
  buffers.
- Expanded CPU unit coverage for padding defaults, bucket padding, active
  buffer staging, native forward-sample collection, repetition-penalty fallback,
  async decode launch, and the no-pool-write contract inside decode forward.

## Design Rationale

The key idea is to make the pool row the single durable identity for a running
request's decode state. `_cg_pool_rows` is intentionally small and
graph-friendly: it only maps the current batch slots to stable pool rows. The
larger state tensors live in process-lifetime pool buffers, so graph replay can
read/write fixed addresses while requests come and go.

This also makes decode retraction/resume easier to reason about. Feedback for
the next decode step, the sampling base position, and the sampled row produced
by the current step all live under the same request-owned row. Collection then
copies the step output into the journal before the next replay can overwrite
the pool output buffers.

The padding row remains reserved and is never acquired by a real request. CUDA
graph bucket padding can route non-real rows there without mutating real
request state.

## Correctness

Focused unit tests:

```bash
PYTHONPATH=$PWD .venv/bin/python -m pytest \
  tests/unit_test/moss_tts_local/test_state_pool.py \
  tests/unit_test/moss_tts_local/test_pipeline.py -q
```

Result:

```text
72 passed, 2 warnings
```

The tests cover pool buffer shape/defaults, row-id staging, decode embedding
immutability, missing internal state errors, pool-output collection,
chunked-prefill feedback suppression, and decode collection with repetition
penalty enabled.

## Main Comparison Benchmark

Benchmark source: `moss_tts_native_forward_sampling_benchmark.md`.

Setup:

- Model: `/root/sglang-omni/model_cache/moss_tts_local_v15`
- Endpoint: `/v1/audio/speech`
- Request args: `token_count=96`, `max_new_tokens=192`, `seed=1234`,
  `response_format=wav`
- GPU observed in service logs: NVIDIA H800 PCIe


Baseline note: plain `main` did not start in this environment because the
cached remote processor passed `codec_weight_dtype` into codec
`AutoModel.from_pretrained`, while the cached codec class rejected that
argument. To obtain a runnable main baseline without modifying the main
worktree source, the main service was launched with a startup-only
`sitecustomize.py` shim that drops `codec_weight_dtype` from
`AutoModel.from_pretrained`. The runner/model code under test still came from
main.

Delta columns are current branch relative to the main baseline. Negative wall
clock / latency is better; positive throughput is better.

| Case | Main ok | Current ok | Main audio total (s) | Current audio total (s) | Wall delta | Audio throughput delta | Mean latency delta | P95 latency delta |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| c4/n8 | 8/0 | 8/0 | 30.72 | 30.72 | -0.86% | +0.87% | -0.57% | -1.86% |
| c8/n32 | 32/0 | 32/0 | 122.88 | 122.88 | -1.19% | +1.20% | -1.12% | -2.84% |
| c16/n64 | 64/0 | 64/0 | 245.80 | 245.76 | -2.37% | +2.41% | -1.77% | -7.12% |


Observations:

- All compared cases completed successfully on both main baseline and current
  branch.
- Current branch is faster than main in all three cases. The clearest
  throughput gain is c16/n64: `14.9518x` audio throughput vs `14.5996x` on
  main (`+2.41%`).
- Tail latency is lower in all three cases: p95 improves by `1.86%`, `2.84%`,
  and `7.12%` for c4, c8, and c16 respectively.
- These are single-run results per case. Treat differences below about
  `1-2%` as noise unless repeated runs confirm the trend.

## Checklist

- [ ] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as long as
the label remains. Draft PRs are skipped even if labeled.
