### PR TITLE
CI stage 10 / stage 11 (Video-AMME Talker) fail frequently — need root-cause investigation

### DIFF
--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -424,9 +424,9 @@ jobs:
         with:
           stage-label: Video-AMME Talker (WER + speed)
           artifact-path-globs: |
-            */videoamme_audio/videoamme_results.json
+            */videoamme_audio*/videoamme_results.json
           artifact-upload-name: qwen3-omni-videoamme-talker-results
-          artifact-upload-path: /tmp/**/videoamme_audio/videoamme_results.json
+          artifact-upload-path: /tmp/**/videoamme_audio*/videoamme_results.json
 
   stage-11-thinker-tp2:
     name: stage 11 - FP8 Thinker TP=2 (Video-AMME Talker)
@@ -464,6 +464,6 @@ jobs:
         with:
           stage-label: FP8 Thinker TP=2 (Video-AMME Talker accuracy + WER + speed)
           artifact-path-globs: |
-            */videoamme_audio/videoamme_results.json
+            */videoamme_audio*/videoamme_results.json
           artifact-upload-name: qwen3-omni-thinker-tp2-results
-          artifact-upload-path: /tmp/**/videoamme_audio/videoamme_results.json
+          artifact-upload-path: /tmp/**/videoamme_audio*/videoamme_results.json

--- a/sglang_omni/models/qwen3_omni/components/talker_prefill.py
+++ b/sglang_omni/models/qwen3_omni/components/talker_prefill.py
@@ -195,10 +195,7 @@ class TalkerPrefillBuilder:
 
         assistant_token_ids = self.extract_chunk_token_ids(thinker_chunks)
         assistant_embed = self._load_prompt_token_embeddings(assistant_token_ids)
-        assistant_hidden = torch.stack(
-            [self.chunk_layer_hidden_or_embed(chunk) for chunk in thinker_chunks],
-            dim=0,
-        ).to(device=self._device, dtype=self._dtype)
+        assistant_hidden = self.stack_chunk_hidden_rows(thinker_chunks)
 
         thinker_input_ids = torch.cat([prompt_ids, assistant_token_ids], dim=0)
         thinker_embed = torch.cat([prompt_embed, assistant_embed], dim=0)
@@ -283,6 +280,18 @@ class TalkerPrefillBuilder:
         if isinstance(layer_hidden, torch.Tensor):
             return layer_hidden
         return chunk.data
+
+    def stack_chunk_hidden_rows(self, thinker_chunks: list[Any]) -> torch.Tensor:
+        return torch.stack(
+            [
+                self.chunk_layer_hidden_or_embed(chunk).to(
+                    device=self._device,
+                    dtype=self._dtype,
+                )
+                for chunk in thinker_chunks
+            ],
+            dim=0,
+        )
 
     def project_assistant_chunk(self, chunk: Any) -> torch.Tensor:
         metadata = chunk.metadata or {}

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -256,6 +256,32 @@ def test_qwen_talker_prefill_keeps_future_rows_device_backed() -> None:
     assert queue[0].device.type == "meta"
 
 
+def test_qwen_talker_prefill_stacks_chunk_rows_after_device_normalization() -> None:
+    """Prevents mixed CPU/CUDA thinker chunks from failing before projection."""
+    builder = object.__new__(TalkerPrefillBuilder)
+    builder._device = torch.device("meta")
+    builder._dtype = torch.float16
+
+    chunks = [
+        SimpleNamespace(
+            data=torch.ones((3,), dtype=torch.float32),
+            metadata={},
+        ),
+        SimpleNamespace(
+            data=torch.zeros((3,), dtype=torch.float32),
+            metadata={
+                "layer_hidden": torch.empty((3,), device="meta", dtype=torch.float32)
+            },
+        ),
+    ]
+
+    rows = builder.stack_chunk_hidden_rows(chunks)
+
+    assert rows.shape == (2, 3)
+    assert rows.device.type == "meta"
+    assert rows.dtype == torch.float16
+
+
 def test_pending_text_queue_rejects_unexpected_rank() -> None:
     """Keeps queue shape handling explicit instead of flattening unknown ranks."""
     queue = PendingTextTensorQueue()


### PR DESCRIPTION
## Summary

This PR fixes a Qwen3-Omni Talker CI failure in the Video-AMME Talker path.

Stage 10 (`test_qwen3_omni_videoamme_talker_ci.py`) was failing with HTTP
500s from the Talker pipeline. Recent CI logs showed the root cause was a
tensor device mismatch during Talker prompt prefill:

```text
RuntimeError: Expected all tensors to be on the same device,
but got tensors is on cuda:0, different from other tensors on cpu
```

The failure happened while assembling assistant thinker hidden rows before
Talker projection.

## Root Cause

`TalkerPrefillBuilder.build_prompt_prefill()` previously stacked thinker chunk
hidden rows before moving them to the Talker device:

```python
assistant_hidden = torch.stack(
    [self.chunk_layer_hidden_or_embed(chunk) for chunk in thinker_chunks],
    dim=0,
).to(device=self._device, dtype=self._dtype)
```

This assumes all chunk tensors are already on the same device before
`torch.stack`.

In practice, some chunks can provide `metadata["layer_hidden"]` already on CUDA,
while fallback `chunk.data` may still be on CPU. Since `torch.stack` requires
all inputs to already share the same device, the `.to(...)` after `stack` was
too late.

This mainly affects the Talker path:

- Stage 9, Video-AMME text-only, does not enter Talker prefill and can pass.
- Stage 10/11, Video-AMME Talker, enter Talker prefill and can fail with
  worker-side 500s.

## Fix

Normalize each thinker chunk row to the Talker device and dtype before stacking:

```python
assistant_hidden = self.stack_chunk_hidden_rows(thinker_chunks)
```

with:

```python
def stack_chunk_hidden_rows(self, thinker_chunks: list[Any]) -> torch.Tensor:
    return torch.stack(
        [
            self.chunk_layer_hidden_or_embed(chunk).to(
                device=self._device,
                dtype=self._dtype,
            )
            for chunk in thinker_chunks
        ],
        dim=0,
    )
```

This makes the prefill path robust to mixed CPU/CUDA chunk sources.

## Tests

Added a focused regression test covering mixed-device chunk rows before
stacking:

```bash
pytest tests/unit_test/qwen3_omni/test_talker.py::test_qwen_talker_prefill_stacks_chunk_rows_after_device_normalization -q
```

Also verified touched Python files compile locally:

```bash
python -m py_compile \
  sglang_omni/models/qwen3_omni/components/talker_prefill.py \
  tests/unit_test/qwen3_omni/test_talker.py
```

## CI Artifact Fix

This PR also fixes the Video-AMME Talker artifact glob in the Qwen3-Omni CI
workflow.

The tests use:

```python
tmp_path_factory.mktemp("videoamme_audio")
```

which creates directories like `videoamme_audio0`, but the workflow only matched
`videoamme_audio`. As a result, failed runs often printed/uploaded zero result
files.

The workflow now matches:

```text
*/videoamme_audio*/videoamme_results.json
```

so future failures should preserve the per-sample benchmark JSON for debugging.
