### PR TITLE
Fix: bound IPC namespace prefix to keep ipc:// paths under sun_path limit

### DIFF
--- a/sglang_omni/pipeline/runtime_config.py
+++ b/sglang_omni/pipeline/runtime_config.py
@@ -10,15 +10,17 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
+import zmq
+
 from sglang_omni.config.placement import StagePlacementPlan, build_stage_placement_plan
 from sglang_omni.config.schema import PipelineConfig, StageConfig
 from sglang_omni.config.topology import ProcessTopologyPlan, build_process_topology_plan
 
 logger = logging.getLogger(__name__)
 
-_IPC_SUN_PATH_BUDGET = 100
-_LONGEST_STAGE_NAME = 24
-_ENDPOINT_PATH_OVERHEAD = len("/-XXXXXXXX/stage_.sock")
+# PyZMQ checks the filesystem path after ``ipc://`` against this budget.
+_IPC_SUN_PATH_BUDGET = getattr(zmq, "IPC_PATH_MAX_LEN", 100)
+_TEMPFILE_RANDOM_SUFFIX_LEN = 8
 
 
 class IpcRuntimeDir:
@@ -63,17 +65,27 @@ class PipelineRuntimePrep:
     runtime_dir_created_here: bool
 
 
-def create_ipc_runtime_dir(config: PipelineConfig) -> IpcRuntimeDir:
+def create_ipc_runtime_dir(
+    config: PipelineConfig,
+    *,
+    stages: list[StageConfig] | None = None,
+) -> IpcRuntimeDir:
     """Create a per-run IPC namespace for one pipeline instance."""
     base_root = Path(config.endpoints.base_path)
     base_root.mkdir(parents=True, exist_ok=True)
+    if stages is None:
+        stages, _, _ = config.apply_fusion()
 
     namespace_prefix = re.sub(r"[^0-9a-z]+", "-", config.name.lower()).strip("-")
     if not namespace_prefix:
         namespace_prefix = "pipeline"
-    overhead = len(str(base_root)) + _ENDPOINT_PATH_OVERHEAD + _LONGEST_STAGE_NAME
-    namespace_prefix = namespace_prefix[: max(8, _IPC_SUN_PATH_BUDGET - overhead)]
-    path = Path(tempfile.mkdtemp(prefix=f"{namespace_prefix}-", dir=base_root))
+    namespace_prefix = _truncate_ipc_namespace_prefix(
+        namespace_prefix,
+        base_root=base_root,
+        stages=stages,
+    )
+    dir_prefix = f"{namespace_prefix}-" if namespace_prefix else ""
+    path = Path(tempfile.mkdtemp(prefix=dir_prefix, dir=base_root))
     return IpcRuntimeDir(path)
 
 
@@ -83,15 +95,15 @@ def prepare_pipeline_runtime(
     ipc_runtime_dir: IpcRuntimeDir | None = None,
 ) -> PipelineRuntimePrep:
     """Prepare fused stages, endpoint allocation, and process topology."""
+    stages_cfg, name_map, entry_stage = config.apply_fusion()
     runtime_dir = ipc_runtime_dir
     if runtime_dir is None:
-        runtime_dir = create_ipc_runtime_dir(config)
+        runtime_dir = create_ipc_runtime_dir(config, stages=stages_cfg)
         runtime_dir_created_here = True
     else:
         runtime_dir_created_here = False
 
     try:
-        stages_cfg, name_map, entry_stage = config.apply_fusion()
         placement_plan = build_stage_placement_plan(config, stages_cfg=stages_cfg)
         process_plan = build_process_topology_plan(
             config,
@@ -170,6 +182,7 @@ def allocate_endpoints(
     stages: list[StageConfig],
     ipc_base_dir: Path,
 ) -> dict[str, str]:
+    _validate_ipc_endpoint_budget(stages=stages, ipc_base_dir=ipc_base_dir)
     base_dir = ipc_base_dir
     endpoints = {
         "completion": f"ipc://{base_dir}/completion.sock",
@@ -178,3 +191,82 @@ def allocate_endpoints(
     for stage in stages:
         endpoints[f"stage_{stage.name}"] = f"ipc://{base_dir}/stage_{stage.name}.sock"
     return endpoints
+
+
+def _truncate_ipc_namespace_prefix(
+    namespace_prefix: str,
+    *,
+    base_root: Path,
+    stages: list[StageConfig],
+) -> str:
+    endpoint_suffix_len = _longest_endpoint_suffix_len(stages)
+    min_dir_len = _ipc_dir_len(
+        base_root=base_root,
+        namespace_prefix_len=0,
+        endpoint_suffix_len=endpoint_suffix_len,
+    )
+    if min_dir_len > _IPC_SUN_PATH_BUDGET:
+        _raise_ipc_path_budget_error(
+            base_path=base_root,
+            endpoint_suffix_len=endpoint_suffix_len,
+            path_len=min_dir_len,
+        )
+
+    max_prefix_len = (
+        _IPC_SUN_PATH_BUDGET
+        - len(str(base_root))
+        - len("/")
+        - len("-")
+        - _TEMPFILE_RANDOM_SUFFIX_LEN
+        - endpoint_suffix_len
+    )
+    if max_prefix_len <= 0:
+        return ""
+    return namespace_prefix[:max_prefix_len]
+
+
+def _validate_ipc_endpoint_budget(
+    *,
+    stages: list[StageConfig],
+    ipc_base_dir: Path,
+) -> None:
+    endpoint_suffix_len = _longest_endpoint_suffix_len(stages)
+    path_len = len(str(ipc_base_dir)) + endpoint_suffix_len
+    if path_len > _IPC_SUN_PATH_BUDGET:
+        _raise_ipc_path_budget_error(
+            base_path=ipc_base_dir,
+            endpoint_suffix_len=endpoint_suffix_len,
+            path_len=path_len,
+        )
+
+
+def _longest_endpoint_suffix_len(stages: list[StageConfig]) -> int:
+    suffixes = [len("/completion.sock"), len("/abort.sock")]
+    suffixes.extend(len(f"/stage_{stage.name}.sock") for stage in stages)
+    return max(suffixes)
+
+
+def _ipc_dir_len(
+    *,
+    base_root: Path,
+    namespace_prefix_len: int,
+    endpoint_suffix_len: int,
+) -> int:
+    dir_name_len = namespace_prefix_len + _TEMPFILE_RANDOM_SUFFIX_LEN
+    if namespace_prefix_len:
+        dir_name_len += len("-")
+    return len(str(base_root)) + len("/") + dir_name_len + endpoint_suffix_len
+
+
+def _raise_ipc_path_budget_error(
+    *,
+    base_path: Path,
+    endpoint_suffix_len: int,
+    path_len: int,
+) -> None:
+    raise ValueError(
+        "IPC endpoint path would exceed the Unix-domain socket path limit "
+        f"({_IPC_SUN_PATH_BUDGET} chars): base path {str(base_path)!r} plus "
+        f"longest endpoint suffix length {endpoint_suffix_len} yields {path_len} "
+        "chars. Shorten endpoints.base_path or stage names."
+    )

--- a/sglang_omni/pipeline/runtime_config.py
+++ b/sglang_omni/pipeline/runtime_config.py
@@ -16,6 +16,10 @@ from sglang_omni.config.topology import ProcessTopologyPlan, build_process_topol
 
 logger = logging.getLogger(__name__)
 
+_IPC_SUN_PATH_BUDGET = 100
+_LONGEST_STAGE_NAME = 24
+_ENDPOINT_PATH_OVERHEAD = len("/-XXXXXXXX/stage_.sock")
+
 
 class IpcRuntimeDir:
     """Runtime-owned IPC directory for one pipeline instance."""
@@ -67,6 +71,8 @@ def create_ipc_runtime_dir(config: PipelineConfig) -> IpcRuntimeDir:
     namespace_prefix = re.sub(r"[^0-9a-z]+", "-", config.name.lower()).strip("-")
     if not namespace_prefix:
         namespace_prefix = "pipeline"
+    overhead = len(str(base_root)) + _ENDPOINT_PATH_OVERHEAD + _LONGEST_STAGE_NAME
+    namespace_prefix = namespace_prefix[: max(8, _IPC_SUN_PATH_BUDGET - overhead)]
     path = Path(tempfile.mkdtemp(prefix=f"{namespace_prefix}-", dir=base_root))
     return IpcRuntimeDir(path)
 


### PR DESCRIPTION
## Problem

Serving a model whose path is long (e.g. a full HuggingFace cache path) crashes at startup:

```
zmq.error.ZMQError: ipc path "/tmp/sglang_omni/home-sglang-omni-cache-huggingface-hub-models--.../stage_preprocessing.sock" is longer than 107 characters (sizeof(sockaddr_un.sun_path)).
```

`create_ipc_runtime_dir` (`sglang_omni/pipeline/runtime_config.py`) derives the per-run IPC directory from `config.name` — which defaults to the **model path** when `--model-name` is unset — with no length bound:

```python
namespace_prefix = re.sub(r"[^0-9a-z]+", "-", config.name.lower()).strip("-")
path = Path(tempfile.mkdtemp(prefix=f"{namespace_prefix}-", dir=base_root))
```

The longest endpoint built from this dir is `ipc://{base_dir}/stage_{name}.sock`. Unix domain sockets cap the path (`sockaddr_un.sun_path`) at ~107 chars, so a long model path overflows it and ZMQ refuses to bind.

## When it was introduced

- The unbounded `config.name`-derived prefix landed in **#461** (`[Refactor] stage-gpu-process topology`) — harmless then, because the control plane used **TCP** endpoints, which have no `sun_path` limit.
- It became a real crash in **#509** (`[Refactor] Remove TCP control-plane endpoints`), which switched the control plane to `ipc://` Unix domain sockets.

## Fix

Bound the model-name-derived prefix so the longest `ipc://` path always fits, computed from the fixed parts of the path:

```python
overhead = len(str(base_root)) + _ENDPOINT_PATH_OVERHEAD + _LONGEST_STAGE_NAME
namespace_prefix = namespace_prefix[: max(8, _IPC_SUN_PATH_BUDGET - overhead)]
```

`mkdtemp`'s random suffix still guarantees uniqueness, so only the human-readable prefix is truncated. Robust to a long `base_path` too, not just long model names.

## Verification

Calling the real `create_ipc_runtime_dir` with a 127-char model name + a real `zmq` ipc bind:

| | longest ipc path | `zmq` bind |
|---|---|---|
| before | 174 chars | **FAILED** (`sun_path > 107`) |
| after | 89 chars | **OK** |