### PR TITLE
[Perf][Qwen3-Omni] Prefill batching for concurrent streaming + rollout-safety foundation (#760)

### DIFF
--- a/benchmarks/eval/qwen3_omni_rollout_stress.py
+++ b/benchmarks/eval/qwen3_omni_rollout_stress.py
@@ -1,0 +1,316 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Rollout-style stress runner for Qwen3-Omni.
+
+This intentionally reuses the exact same image prompt N times so Qwen3-Omni
+operators can measure how same-prompt multi-rollout traffic scales before a
+dedicated rollout-aware fanout implementation exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import logging
+import time
+from dataclasses import asdict, replace
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+
+from benchmarks.benchmarker.data import RequestResult
+from benchmarks.benchmarker.runner import BenchmarkRunner, RunConfig
+from benchmarks.benchmarker.utils import save_json_results, wait_for_service
+from benchmarks.dataset.mmmu import MMMUSample, image_to_data_uri, load_mmmu_samples
+from benchmarks.metrics.performance import compute_speed_metrics, print_speed_summary
+
+logger = logging.getLogger(__name__)
+
+
+def _build_base_url(args: argparse.Namespace) -> str:
+    return args.base_url or f"http://{args.host}:{args.port}"
+
+
+def _parse_counts(raw: str) -> list[int]:
+    counts = [int(value.strip()) for value in raw.split(",") if value.strip()]
+    if not counts or any(count <= 0 for count in counts):
+        raise argparse.ArgumentTypeError("rollout counts must be positive integers")
+    return counts
+
+
+def _duplicate_prompt(sample: MMMUSample, count: int) -> list[MMMUSample]:
+    return [
+        replace(
+            sample,
+            sample_id=f"{sample.sample_id}:rollout-n{count}-{index}",
+        )
+        for index in range(count)
+    ]
+
+
+def _make_rollout_send_fn(
+    *,
+    model_name: str,
+    api_url: str,
+    rollout_group_id: str,
+    max_tokens: int,
+    temperature: float,
+    enable_audio: bool,
+    talker_max_new_tokens: int | None,
+) -> Any:
+    modalities = ["text", "audio"] if enable_audio else ["text"]
+
+    async def send_fn(
+        session: aiohttp.ClientSession,
+        sample: MMMUSample,
+    ) -> RequestResult:
+        result = RequestResult(
+            request_id=sample.sample_id,
+            text=sample.prompt[:60],
+        )
+        payload: dict[str, Any] = {
+            "model": model_name,
+            "request_id": sample.sample_id,
+            "messages": [{"role": "user", "content": sample.prompt}],
+            "images": [image_to_data_uri(image) for image in sample.images],
+            "modalities": modalities,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "stream": False,
+            "user": rollout_group_id,
+        }
+        if enable_audio:
+            payload["audio"] = {"format": "wav"}
+        if talker_max_new_tokens is not None:
+            payload["talker_max_new_tokens"] = talker_max_new_tokens
+
+        start_time = time.perf_counter()
+        try:
+            async with session.post(api_url, json=payload) as response:
+                body = await response.json()
+                if response.status >= 400:
+                    result.error = body.get("detail", str(body))
+                    return result
+
+            message = body.get("choices", [{}])[0].get("message", {})
+            result.text = message.get("content", "") or ""
+            if enable_audio:
+                audio_obj = message.get("audio")
+                audio_b64 = (audio_obj or {}).get("data", "")
+                if not audio_b64:
+                    result.error = "No audio data in response"
+                    return result
+                # Decode once so transport/base64 corruption is surfaced in the
+                # stress result without forcing a WAV write for every rollout.
+                base64.b64decode(audio_b64)
+
+            result.is_success = True
+            usage = body.get("usage", {})
+            result.prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
+            result.completion_tokens = int(usage.get("completion_tokens", 0) or 0)
+            result.engine_time_s = time.perf_counter() - start_time
+            if result.completion_tokens > 0 and result.engine_time_s > 0:
+                result.tok_per_s = result.completion_tokens / result.engine_time_s
+        except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as exc:
+            result.error = str(exc)
+        finally:
+            result.latency_s = time.perf_counter() - start_time
+        return result
+
+    return send_fn
+
+
+async def _get_json(session: aiohttp.ClientSession, url: str) -> dict[str, Any]:
+    async with session.get(url) as response:
+        response.raise_for_status()
+        return await response.json()
+
+
+async def _post_json(
+    session: aiohttp.ClientSession,
+    url: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    async with session.post(url, json=payload) as response:
+        body = await response.json()
+        response.raise_for_status()
+        return body
+
+
+async def _start_request_profile(
+    session: aiohttp.ClientSession,
+    base_url: str,
+    *,
+    run_id: str,
+    event_dir: str,
+) -> dict[str, Any]:
+    return await _post_json(
+        session,
+        f"{base_url}/start_request_profile",
+        {"run_id": run_id, "event_dir": event_dir},
+    )
+
+
+async def _stop_request_profile(
+    session: aiohttp.ClientSession,
+    base_url: str,
+    *,
+    run_id: str,
+) -> dict[str, Any]:
+    return await _post_json(
+        session,
+        f"{base_url}/stop_request_profile",
+        {"run_id": run_id},
+    )
+
+
+async def run_rollout_stress(args: argparse.Namespace) -> dict[str, Any]:
+    base_url = _build_base_url(args)
+    api_url = f"{base_url}/v1/chat/completions"
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    samples = load_mmmu_samples(
+        args.sample_index + 1,
+        repo_id=args.repo_id,
+        instruction_override=args.prompt_override,
+    )
+    if len(samples) <= args.sample_index:
+        raise ValueError(
+            f"sample_index={args.sample_index} unavailable; loaded {len(samples)}"
+        )
+    base_sample = samples[args.sample_index]
+    rollout_group_id = args.rollout_group_id or f"rollout:{base_sample.sample_id}"
+    run_id = args.profile_run_id or f"rollout-stress-{int(time.time())}"
+    event_dir = str(Path(args.profile_event_dir or (output_dir / "events")).resolve())
+
+    timeout = aiohttp.ClientTimeout(total=args.timeout_s)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        health_before = await _get_json(session, f"{base_url}/health")
+        profile_info = None
+        if not args.no_profile:
+            profile_info = await _start_request_profile(
+                session,
+                base_url,
+                run_id=run_id,
+                event_dir=event_dir,
+            )
+
+        results_by_count: list[dict[str, Any]] = []
+        try:
+            for count in args.rollout_counts:
+                duplicated = _duplicate_prompt(base_sample, count)
+                send_fn = _make_rollout_send_fn(
+                    model_name=args.model,
+                    api_url=api_url,
+                    rollout_group_id=rollout_group_id,
+                    max_tokens=args.max_tokens,
+                    temperature=args.temperature,
+                    enable_audio=args.enable_audio,
+                    talker_max_new_tokens=args.talker_max_new_tokens,
+                )
+                runner = BenchmarkRunner(
+                    RunConfig(
+                        max_concurrency=count,
+                        request_rate=float("inf"),
+                        warmup=0,
+                        disable_tqdm=args.disable_tqdm,
+                        timeout_s=args.timeout_s,
+                    )
+                )
+                request_results = await runner.run(duplicated, send_fn)
+                speed = compute_speed_metrics(
+                    request_results,
+                    wall_clock_s=runner.wall_clock_s,
+                )
+                failed = [result for result in request_results if not result.is_success]
+                print_speed_summary(
+                    speed,
+                    args.model,
+                    count,
+                    title=f"Qwen3-Omni Rollout Stress N={count}",
+                )
+                print(f"  Failed requests: {len(failed)}/{len(request_results)}")
+                results_by_count.append(
+                    {
+                        "rollout_count": count,
+                        "wall_clock_s": runner.wall_clock_s,
+                        "success": len(request_results) - len(failed),
+                        "failed": len(failed),
+                        "speed": speed,
+                        "requests": [asdict(result) for result in request_results],
+                    }
+                )
+        finally:
+            if not args.no_profile:
+                await _stop_request_profile(session, base_url, run_id=run_id)
+
+        health_after = await _get_json(session, f"{base_url}/health")
+
+    output = {
+        "config": {
+            "base_url": base_url,
+            "model": args.model,
+            "repo_id": args.repo_id,
+            "sample_id": base_sample.sample_id,
+            "rollout_group_id": rollout_group_id,
+            "rollout_counts": args.rollout_counts,
+            "max_tokens": args.max_tokens,
+            "temperature": args.temperature,
+            "enable_audio": args.enable_audio,
+            "talker_max_new_tokens": args.talker_max_new_tokens,
+            "profile_run_id": run_id,
+            "profile_event_dir": event_dir if not args.no_profile else None,
+        },
+        "profile": profile_info,
+        "health_before": health_before,
+        "health_after": health_after,
+        "results": results_by_count,
+    }
+    save_json_results(output, str(output_dir), "rollout_stress_results.json")
+    return output
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    parser = argparse.ArgumentParser(
+        description="Stress Qwen3-Omni with same-prompt multi-rollout traffic."
+    )
+    parser.add_argument("--base-url", type=str, default=None)
+    parser.add_argument("--host", type=str, default="localhost")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--model", type=str, default="qwen3-omni")
+    parser.add_argument("--repo-id", type=str, default="zhaochenyang20/mmmu-ci-50")
+    parser.add_argument("--sample-index", type=int, default=0)
+    parser.add_argument("--prompt-override", type=str, default=None)
+    parser.add_argument(
+        "--rollout-counts",
+        type=_parse_counts,
+        default=[1, 2, 4, 8, 16],
+        help="Comma-separated rollout counts, e.g. 1,2,4,8,16.",
+    )
+    parser.add_argument("--rollout-group-id", type=str, default=None)
+    parser.add_argument("--max-tokens", type=int, default=256)
+    parser.add_argument("--temperature", type=float, default=0.8)
+    parser.add_argument("--text-only", dest="enable_audio", action="store_false")
+    parser.set_defaults(enable_audio=True)
+    parser.add_argument("--talker-max-new-tokens", type=int, default=None)
+    parser.add_argument("--timeout-s", type=int, default=300)
+    parser.add_argument("--output-dir", type=str, default="results/rollout_stress")
+    parser.add_argument("--profile-run-id", type=str, default=None)
+    parser.add_argument("--profile-event-dir", type=str, default=None)
+    parser.add_argument("--no-profile", action="store_true")
+    parser.add_argument("--disable-tqdm", action="store_true")
+    args = parser.parse_args()
+
+    base_url = _build_base_url(args)
+    wait_for_service(base_url)
+    asyncio.run(run_rollout_stress(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/basic_usage/qwen3_omni.md
+++ b/docs/basic_usage/qwen3_omni.md
@@ -464,3 +464,73 @@ The table below lists all parameters accepted by the `/v1/chat/completions` endp
 | `stream` | bool | `false` | Enable streaming via SSE |
 | `audio` | dict | `null` | Speech response format configuration, e.g. `{"format": "wav"}` |
 | `stage_sampling` | dict | `null` | Per-stage sampling overrides, e.g. `{"thinker": {"temperature": 0.8}}` |
+
+## Concurrency / prefill batching tuning (issue #760)
+
+Under many concurrent streaming sessions the thinker can fragment prefill into
+many tiny batches (size 1-2) instead of coalescing toward the running/token
+budget the way vLLM continuous batching does. The knobs below (all **off by
+default**, so existing behavior and CI thresholds are unchanged) help close the
+gap. They are most relevant to a TP>1 thinker serving prefill-heavy streaming
+workloads (e.g. live speech translation). See issue #760.
+
+| Env var | Default | Effect |
+|---|---|---|
+| `SGLANG_OMNI_PREFILL_COALESCE_MS` | `0` (off) | On the idle->prefill transition, wait up to this many ms for more queued requests before scheduling the first prefill, so it is not size-1. Never stalls active decode (only engages when no decode batch / async step is in flight). |
+| `SGLANG_OMNI_PREFILL_COALESCE_POLL_MS` | `1.0` | Poll granularity for the coalesce wait. The window runs a fixed `window/poll` iteration count, so all TP ranks stay in lockstep. |
+| `SGLANG_OMNI_PREFILL_COALESCE_TARGET` | `max_running_requests` | Stop waiting early once this many requests are queued. |
+| `SGLANG_OMNI_PREFILL_COALESCE_MIN` | `2` | Minimum queue depth before the window engages, so a lone request never pays the idle wait (avoids a low-concurrency latency tax). |
+| `SGLANG_OMNI_PREFILL_COALESCE_MAX_TOKENS` | `chunked_prefill_size`, else `max_prefill_tokens` | Token budget: stop coalescing once queued prefill tokens reach this, so the coalesced batch never exceeds one (chunked) step. **Bounds the transient activation/broadcast memory — required to avoid a multimodal thinker-TP OOM at high concurrency (see Audio note below).** |
+| `SGLANG_OMNI_CHUNKED_PREFILL_SIZE` | unset (chunking off) | Enable chunked prefill for the thinker so long audio prefills interleave with decode instead of blocking a whole step. The talker (projected-embeds) path is unaffected (chunking is force-disabled there). |
+| `SGLANG_OMNI_TP_IDLE_BROADCAST_SKIP` | `false` | For TP>1, replace the per-loop `broadcast_pyobj` with a cheap int broadcast on idle loops (skips the pickle path when the inbox is empty). |
+| `SGLANG_OMNI_LOG_PREFILL_STATS` | `false` | Periodically log average/max prefill batch size and queue depth, to quantify fragmentation before/after tuning. |
+| `SGLANG_OMNI_PREFILL_STATS_INTERVAL_S` | `10` | Interval (seconds) for the prefill-stats log line. |
+
+### Suggested starting point (2x A6000, thinker TP=2, ~32 streaming sessions)
+
+```bash
+export SGLANG_OMNI_PREFILL_COALESCE_MS=8
+export SGLANG_OMNI_PREFILL_COALESCE_TARGET=32
+export SGLANG_OMNI_CHUNKED_PREFILL_SIZE=4096
+export SGLANG_OMNI_TP_IDLE_BROADCAST_SKIP=1
+export SGLANG_OMNI_LOG_PREFILL_STATS=1
+```
+
+### Measuring before/after
+
+```bash
+# Concurrency sweep (records throughput_qps / latency / rtf)
+python -m benchmarks.eval.qwen3_omni_rollout_stress \
+  --base-url http://127.0.0.1:<port> \
+  --rollout-counts 1,2,4,8,16,32 --max-tokens 256
+
+# Streaming TTFT / time-to-first-chunk
+python benchmarks/eval/benchmark_omni_streaming_ttft.py \
+  --base-url http://127.0.0.1:<port> --label tp2 --repeats 5
+```
+
+Watch the `[prefill-stats]` log lines: `avg_batch` should rise toward
+`max_running_requests` (and away from ~1) once coalescing is enabled.
+
+### Audio / multimodal note (measured: 2x A6000, thinker TP=2, 30B base)
+
+A **text** concurrency sweep shows coalescing lifts `avg_batch` from ~N/2 to ~N
+with throughput/latency unchanged (text prefill is cheap / decode-bound). On a
+**prefill-bound audio** sweep (~30s clips, ~400 prefill tokens/req) the trade-off
+is different and worth knowing:
+
+- coalescing also lifts `avg_batch` (~N/3 -> ~N), but throughput does **not**
+  improve, because baseline continuous batching already saturates the thinker
+  prefill (~12k prefill-tok/s on this hardware);
+- with a count-only target and **no** token budget, coalescing accumulated 32
+  audio requests (each carrying multimodal CUDA feature tensors that move through
+  `broadcast_pyobj`) and **OOM-crashed `thinker_tp1`** at N=32;
+- `SGLANG_OMNI_PREFILL_COALESCE_MAX_TOKENS` (default = `chunked_prefill_size`)
+  fixes the crash (0 failures, throughput == baseline) and
+  `SGLANG_OMNI_PREFILL_COALESCE_MIN` removes the low-concurrency latency tax.
+
+Net: treat the coalesce window as **experimental**, most useful for bursty
+arrival at or above the target concurrency. The always-safe wins are the thinker
+TP `disable_custom_all_reduce` auto-fix, chunked prefill, the idle broadcast
+skip, and the `[prefill-stats]` instrumentation (which is what surfaced the OOM
+above).

--- a/docs/basic_usage/qwen3_omni.md
+++ b/docs/basic_usage/qwen3_omni.md
@@ -232,6 +232,41 @@ python examples/run_qwen3_omni_speech_server.py \
 the global value for that stage. Values must be greater than `0` and less than
 `1`.
 
+### Rollout Stress Diagnostics
+
+For RL-style workloads, first measure same-prompt rollout pressure before
+changing memory fractions. The stress runner sends the same MMMU image prompt
+with `N={1,2,4,8,16}` concurrent rollouts, keeps Thinker and Talker online by
+default, and records request-level queue, CUDA memory, and KV-pool telemetry
+through the event profiler.
+
+```bash
+python benchmarks/eval/qwen3_omni_rollout_stress.py \
+  --base-url http://localhost:8008 \
+  --rollout-counts 1,2,4,8,16 \
+  --max-tokens 256 \
+  --output-dir results/rollout_stress
+```
+
+The result summary is written to
+`results/rollout_stress/rollout_stress_results.json`; profiler events are under
+`results/rollout_stress/events` unless `--profile-event-dir` is set.
+
+Set conservative overload guards when running near the memory limit:
+
+```bash
+SGLANG_OMNI_ADMISSION_MAX_WAITING=32 \
+SGLANG_OMNI_ADMISSION_MIN_FREE_GPU_MEMORY_MB=4096 \
+sgl-omni serve \
+  --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
+  --config examples/configs/qwen3_omni_colocated_h20.yaml \
+  --colocate \
+  --port 8008
+```
+
+When the guard rejects a request, the client receives a controlled error
+instead of a worker OOM or router 500.
+
 ## Single-GPU FP8 on H100/H20
 
 SGLang-Omni can also serve native FP8 Qwen3-Omni checkpoints. Native FP8 uses

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -266,6 +266,21 @@ class Qwen3OmniPipelineConfig(PipelineConfig):
     def encoder_mem_reserve_role_to_stage(cls) -> dict[str, str]:
         return {"thinker": "thinker"}
 
+    @classmethod
+    def tensor_parallel_server_args_overrides(
+        cls,
+        *,
+        stage_name: str,
+        tp_size: int,
+    ) -> dict[str, object]:
+        # Multi-process thinker TP requires the NCCL all-reduce path; the custom
+        # all-reduce kernel is not wired for the disaggregated TP launch. Mirror
+        # MingOmni so a `sglang_omni serve` launch (not just the example script)
+        # is correct without a manual override. See issue #760.
+        if stage_name == "thinker" and tp_size > 1:
+            return {"disable_custom_all_reduce": True}
+        return {}
+
     model_path: str
     placement_policy: str | None = _PLACEMENT_POLICY
     placement: PlacementConfig = Field(
@@ -303,6 +318,19 @@ class Qwen3OmniSpeechPipelineConfig(PipelineConfig):
     @classmethod
     def code2wav_stage(cls) -> str | None:
         return "code2wav"
+
+    @classmethod
+    def tensor_parallel_server_args_overrides(
+        cls,
+        *,
+        stage_name: str,
+        tp_size: int,
+    ) -> dict[str, object]:
+        # See Qwen3OmniPipelineConfig.tensor_parallel_server_args_overrides.
+        # Inherited by Qwen3OmniSpeechColocatedPipelineConfig. See issue #760.
+        if stage_name == "thinker" and tp_size > 1:
+            return {"disable_custom_all_reduce": True}
+        return {}
 
     model_path: str
     placement_policy: str | None = _PLACEMENT_POLICY

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -37,6 +37,7 @@ from sglang_omni.proto import (
 )
 from sglang_omni.relay.base import Relay, create_relay
 from sglang_omni.scheduling.messages import IncomingMessage
+from sglang_omni.scheduling.observability import cuda_memory_snapshot, safe_qsize
 
 logger = logging.getLogger(__name__)
 
@@ -275,6 +276,7 @@ class Stage:
             event_name="stage_input_received",
             metadata={"from_stage": "coordinator", "kind": "submit"},
         )
+        self._emit_stage_telemetry("stage_queue_snapshot", request_id=request_id)
 
         payload = msg.data  # StagePayload from coordinator
         await self._execute(payload)
@@ -371,6 +373,7 @@ class Stage:
             event_name="stage_input_received",
             metadata={"from_stage": from_stage, "kind": "payload"},
         )
+        self._emit_stage_telemetry("stage_queue_snapshot", request_id=request_id)
         merged = self.input_handler.receive(request_id, from_stage, payload)
         if merged is not None:
             _emit_event(
@@ -643,6 +646,7 @@ class Stage:
             stage=self.name,
             event_name="stage_dispatch",
         )
+        self._emit_stage_telemetry("stage_dispatch_snapshot", request_id=request_id)
         if (
             self.role == "leader"
             and self._tp_fanout is not None
@@ -652,6 +656,7 @@ class Stage:
         self.scheduler.inbox.put(
             IncomingMessage(request_id=request_id, type="new_request", data=payload)
         )
+        self._emit_stage_telemetry("stage_inbox_snapshot", request_id=request_id)
 
     # ------------------------------------------------------------------
     # Outbox drain: scheduler results → route downstream
@@ -1151,6 +1156,38 @@ class Stage:
         self._first_stream_chunk_seen.discard(request_id)
         self._local_stream_targets.pop(request_id, None)
         self._nonlocal_stream_targets.pop(request_id, None)
+        self._emit_stage_telemetry("stage_request_cleared", request_id=request_id)
+
+    def _emit_stage_telemetry(self, event_name: str, *, request_id: str) -> None:
+        if not _get_recorder().is_active():
+            return
+        stream_queues = None
+        stream_pending_items = None
+        if self._stream_queue is not None:
+            queues = getattr(self._stream_queue, "_queues", {})
+            stream_queues = len(queues)
+            stream_pending_items = sum(
+                qsize
+                for qsize in (safe_qsize(queue_obj) for queue_obj in queues.values())
+                if qsize is not None
+            )
+        metadata = {
+            "active_requests": len(self._active_requests),
+            "aborted_requests_tracked": len(self._aborted),
+            "scheduler_inbox_qsize": safe_qsize(getattr(self.scheduler, "inbox", None)),
+            "scheduler_outbox_qsize": safe_qsize(
+                getattr(self.scheduler, "outbox", None)
+            ),
+            "stream_queues": stream_queues,
+            "stream_pending_items": stream_pending_items,
+            **cuda_memory_snapshot(self.gpu_id),
+        }
+        _emit_event(
+            request_id=request_id,
+            stage=self.name,
+            event_name=event_name,
+            metadata=metadata,
+        )
 
     async def _handle_scheduler_crash(self, exc: BaseException) -> None:
         if self._scheduler_crash_error is not None:

--- a/sglang_omni/scheduling/observability.py
+++ b/sglang_omni/scheduling/observability.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Best-effort scheduler and CUDA telemetry helpers."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def env_flag(name: str, *, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def env_int(name: str) -> int | None:
+    value = os.environ.get(name)
+    if value is None or value.strip() == "":
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def env_float(name: str, *, default: float) -> float:
+    value = os.environ.get(name)
+    if value is None or value.strip() == "":
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
+def safe_qsize(queue_obj: Any) -> int | None:
+    qsize = getattr(queue_obj, "qsize", None)
+    if not callable(qsize):
+        return None
+    try:
+        return int(qsize())
+    except Exception:
+        return None
+
+
+def batch_size(batch: Any) -> int:
+    if batch is None:
+        return 0
+    return len(getattr(batch, "reqs", ()) or ())
+
+
+def allocator_available_tokens(allocator: Any) -> int | None:
+    available_size = getattr(allocator, "available_size", None)
+    if not callable(available_size):
+        return None
+    try:
+        return int(available_size())
+    except Exception:
+        return None
+
+
+def cuda_memory_snapshot(gpu_id: int | None) -> dict[str, int | None]:
+    snapshot: dict[str, int | None] = {
+        "gpu_id": gpu_id,
+        "cuda_allocated_bytes": None,
+        "cuda_reserved_bytes": None,
+        "cuda_max_allocated_bytes": None,
+        "cuda_free_bytes": None,
+        "cuda_total_bytes": None,
+    }
+    if gpu_id is None:
+        return snapshot
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return snapshot
+        device = int(gpu_id)
+        snapshot["cuda_allocated_bytes"] = int(torch.cuda.memory_allocated(device))
+        snapshot["cuda_reserved_bytes"] = int(torch.cuda.memory_reserved(device))
+        snapshot["cuda_max_allocated_bytes"] = int(
+            torch.cuda.max_memory_allocated(device)
+        )
+        free_bytes, total_bytes = torch.cuda.mem_get_info(device)
+        snapshot["cuda_free_bytes"] = int(free_bytes)
+        snapshot["cuda_total_bytes"] = int(total_bytes)
+    except Exception:
+        return snapshot
+    return snapshot

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -30,7 +30,16 @@ from sglang.srt.mem_cache.common import release_kv_cache
 from sglang.srt.utils import broadcast_pyobj
 
 from sglang_omni.profiler.event_recorder import emit as _emit_event
+from sglang_omni.profiler.event_recorder import get_recorder as _get_event_recorder
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
+from sglang_omni.scheduling.observability import (
+    allocator_available_tokens,
+    batch_size,
+    cuda_memory_snapshot,
+    env_float,
+    env_int,
+    safe_qsize,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -323,6 +332,37 @@ class OmniScheduler:
         self._dirty_deferred_request_ids: set[str] = set()
         self._first_emit_done: set[str] = set()
         self._prefill_start_done: set[str] = set()
+        self._admission_max_waiting = self._resolve_admission_max_waiting()
+        self._admission_min_free_gpu_memory_bytes = (
+            self._resolve_admission_min_free_gpu_memory_bytes()
+        )
+        self._admission_token_headroom = max(
+            min(
+                env_float("SGLANG_OMNI_ADMISSION_TOKEN_HEADROOM", default=1.0),
+                1.0,
+            ),
+            0.0,
+        )
+
+    def _resolve_admission_max_waiting(self) -> int | None:
+        override = env_int("SGLANG_OMNI_ADMISSION_MAX_WAITING")
+        if override is not None:
+            return max(override, 0)
+        value = getattr(self, "max_queued_requests", None)
+        if value is None:
+            return None
+        try:
+            value = int(value)
+        except (TypeError, ValueError):
+            return None
+        return value if value > 0 else None
+
+    @staticmethod
+    def _resolve_admission_min_free_gpu_memory_bytes() -> int | None:
+        value = env_int("SGLANG_OMNI_ADMISSION_MIN_FREE_GPU_MEMORY_MB")
+        if value is None or value <= 0:
+            return None
+        return value * 1024 * 1024
 
     def _init_upstream_compat_flags(self, server_args: Any) -> None:
         self.enable_hisparse = bool(getattr(server_args, "enable_hisparse", False))
@@ -508,6 +548,21 @@ class OmniScheduler:
                 self._emit_request_error(req_id, ValueError(kv_error))
                 self.abort(req_id)
                 continue
+            admission_error = self._admission_rejection_reason(req_id, req)
+            if admission_error is not None:
+                logger.warning(
+                    "Rejecting request %s before queueing: %s",
+                    req_id,
+                    admission_error,
+                )
+                self._emit_scheduler_telemetry(
+                    "scheduler_admission_reject",
+                    request_id=req_id,
+                    extra={"reason": admission_error},
+                )
+                self._emit_request_error(req_id, RuntimeError(admission_error))
+                self.abort(req_id)
+                continue
             self._initialize_request_stream_state(req_data, payload)
             if req_id in self._aborted_request_ids:
                 continue
@@ -517,6 +572,11 @@ class OmniScheduler:
                 event_name="scheduler_queue_enter",
             )
             self.waiting_queue.append(req)
+            self._emit_scheduler_telemetry(
+                "scheduler_admission_queue",
+                request_id=req_id,
+                extra={"queued_request_id": req_id},
+            )
 
     def _prepare_request_limits(self, req_data: Any) -> str | None:
         req = req_data.req
@@ -568,7 +628,8 @@ class OmniScheduler:
         input_len = len(req.origin_input_ids)
         max_new_tokens = int(req.sampling_params.max_new_tokens or 0)
         required_tokens = input_len + max_new_tokens
-        kv_capacity = int(self.max_req_len)
+        token_headroom = getattr(self, "_admission_token_headroom", 1.0)
+        kv_capacity = int(self.max_req_len * token_headroom)
         if required_tokens <= kv_capacity:
             return None
 
@@ -586,6 +647,93 @@ class OmniScheduler:
             f"(input_tokens={input_len}, max_new_tokens={max_new_tokens}, "
             f"required_tokens={required_tokens}, kv_capacity={kv_capacity})."
             f"{mem_hint}"
+        )
+
+    def _admission_rejection_reason(self, request_id: str, req: Any) -> str | None:
+        max_waiting = getattr(self, "_admission_max_waiting", None)
+        if max_waiting is not None and len(self.waiting_queue) >= max_waiting:
+            return (
+                "Admission rejected: scheduler waiting queue is full "
+                f"(waiting={len(self.waiting_queue)}, limit={max_waiting}). "
+                "Retry later or raise SGLANG_OMNI_ADMISSION_MAX_WAITING."
+            )
+
+        min_free = getattr(self, "_admission_min_free_gpu_memory_bytes", None)
+        if min_free is not None:
+            free_bytes = self._cuda_free_bytes()
+            if free_bytes is not None and free_bytes < min_free:
+                return (
+                    "Admission rejected: free CUDA memory is below the configured "
+                    "guard threshold "
+                    f"(free_bytes={free_bytes}, threshold_bytes={min_free}). "
+                    "Retry later or lower SGLANG_OMNI_ADMISSION_MIN_FREE_GPU_MEMORY_MB."
+                )
+
+        del request_id, req
+        return None
+
+    def _cuda_free_bytes(self) -> int | None:
+        snapshot = cuda_memory_snapshot(getattr(self, "gpu_id", None))
+        free_bytes = snapshot.get("cuda_free_bytes")
+        return int(free_bytes) if free_bytes is not None else None
+
+    def _scheduler_telemetry_snapshot(self) -> dict[str, Any]:
+        available_tokens = allocator_available_tokens(
+            getattr(self, "token_to_kv_pool_allocator", None)
+        )
+        max_total_tokens = getattr(self, "max_total_num_tokens", None)
+        used_tokens = (
+            None
+            if available_tokens is None or max_total_tokens is None
+            else max(int(max_total_tokens) - available_tokens, 0)
+        )
+        return {
+            "inbox_qsize": safe_qsize(getattr(self, "inbox", None)),
+            "outbox_qsize": safe_qsize(getattr(self, "outbox", None)),
+            "waiting_queue": len(getattr(self, "waiting_queue", []) or []),
+            "running_batch": batch_size(getattr(self, "running_batch", None)),
+            "current_batch": batch_size(getattr(self, "cur_batch", None)),
+            "last_batch": batch_size(getattr(self, "last_batch", None)),
+            "deferred_requests": len(
+                getattr(self, "_deferred_request_payloads", {}) or {}
+            ),
+            "pending_stream_chunks": len(
+                getattr(self, "_pending_stream_chunks", {}) or {}
+            ),
+            "pending_stream_done": len(getattr(self, "_pending_stream_done", set())),
+            "max_running_requests": getattr(self, "max_running_requests", None),
+            "max_queued_requests": getattr(self, "max_queued_requests", None),
+            "max_total_num_tokens": max_total_tokens,
+            "max_req_len": getattr(self, "max_req_len", None),
+            "max_prefill_tokens": getattr(self, "max_prefill_tokens", None),
+            "kv_available_tokens": available_tokens,
+            "kv_used_tokens": used_tokens,
+            "admission_max_waiting": getattr(self, "_admission_max_waiting", None),
+            "admission_min_free_gpu_memory_bytes": getattr(
+                self,
+                "_admission_min_free_gpu_memory_bytes",
+                None,
+            ),
+            **cuda_memory_snapshot(getattr(self, "gpu_id", None)),
+        }
+
+    def _emit_scheduler_telemetry(
+        self,
+        event_name: str,
+        *,
+        request_id: str | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        if not _get_event_recorder().is_active():
+            return
+        metadata = self._scheduler_telemetry_snapshot()
+        if extra:
+            metadata.update(extra)
+        _emit_event(
+            request_id=request_id or "__scheduler__",
+            stage=None,
+            event_name=event_name,
+            metadata=metadata,
         )
 
     def _emit_request_error(self, request_id: str, error: Exception) -> None:
@@ -616,6 +764,10 @@ class OmniScheduler:
         a ``GenerationBatchResult``.  We bridge the two formats here.
         """
         self._emit_prefill_start_for_batch(batch)
+        self._emit_scheduler_telemetry(
+            "scheduler_batch_start",
+            extra={"batch_size": batch_size(batch)},
+        )
         if self._model_runner is not None:
             # Mirror upstream run_batch's per-forward counter: OmniScheduler
             # overrides run_batch, so without this forward_ct stays 0 and
@@ -625,9 +777,19 @@ class OmniScheduler:
             sched_output = self._build_sched_output(batch)
             mr_output = self._model_runner.execute(sched_output)
             self._emit_stream_output(sched_output, mr_output)
-            return self._make_batch_result(batch, mr_output)
+            result = self._make_batch_result(batch, mr_output)
+            self._emit_scheduler_telemetry(
+                "scheduler_batch_end",
+                extra={"batch_size": batch_size(batch)},
+            )
+            return result
         # Fallback: call upstream's run_batch (uses tp_worker directly)
-        return _Upstream.run_batch(self, batch, pp_proxy_tensors)
+        result = _Upstream.run_batch(self, batch, pp_proxy_tensors)
+        self._emit_scheduler_telemetry(
+            "scheduler_batch_end",
+            extra={"batch_size": batch_size(batch)},
+        )
+        return result
 
     def _build_sched_output(self, batch):
         """Wrap a ScheduleBatch into the SchedulerOutput the model runner
@@ -719,6 +881,15 @@ class OmniScheduler:
         reqs = list(batch.reqs)
         request_ids = [req.rid for req in reqs]
         logger.exception("OmniScheduler batch failed for requests=%s", request_ids)
+        self._emit_scheduler_telemetry(
+            "scheduler_batch_error",
+            extra={
+                "batch_size": len(reqs),
+                "request_ids": request_ids,
+                "error": str(error),
+                "error_type": type(error).__name__,
+            },
+        )
         for req in reqs:
             self._emit_request_error(req.rid, error)
             self.abort(req.rid, defer_running_cleanup=False)

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -36,6 +36,7 @@ from sglang_omni.scheduling.observability import (
     allocator_available_tokens,
     batch_size,
     cuda_memory_snapshot,
+    env_flag,
     env_float,
     env_int,
     safe_qsize,
@@ -343,6 +344,60 @@ class OmniScheduler:
             ),
             0.0,
         )
+        # --- Prefill batching knobs (issue #760) -----------------------------
+        # All default to CURRENT behavior; opt in via env for benchmarking
+        # before any default is flipped (the Qwen3-Omni CI thresholds are
+        # tight). Coalesce window: on the idle->prefill transition, briefly
+        # wait for more queued requests so the first prefill batch is not
+        # size-1. See _coalesce_prefill_window for the TP-safety argument.
+        self._prefill_coalesce_window_s = (
+            max(env_float("SGLANG_OMNI_PREFILL_COALESCE_MS", default=0.0), 0.0)
+            / 1000.0
+        )
+        self._prefill_coalesce_poll_s = (
+            max(env_float("SGLANG_OMNI_PREFILL_COALESCE_POLL_MS", default=1.0), 0.1)
+            / 1000.0
+        )
+        _coalesce_target = env_int("SGLANG_OMNI_PREFILL_COALESCE_TARGET")
+        self._prefill_coalesce_target = (
+            _coalesce_target
+            if _coalesce_target and _coalesce_target > 0
+            else getattr(self, "max_running_requests", None)
+        )
+        # Minimum waiting-queue depth before the window engages, so a lone
+        # request never pays the idle wait (avoids the low-concurrency latency
+        # tax measured in the issue #760 audio A/B).
+        self._prefill_coalesce_min = max(
+            env_int("SGLANG_OMNI_PREFILL_COALESCE_MIN") or 2, 1
+        )
+        # Token budget: never coalesce a prefill larger than the engine will run
+        # in one (chunked) step. Bounds the transient activation/broadcast
+        # memory that caused a multimodal thinker-TP OOM at high concurrency
+        # (issue #760). Default: chunked_prefill_size, else max_prefill_tokens.
+        _coalesce_max_tokens = env_int("SGLANG_OMNI_PREFILL_COALESCE_MAX_TOKENS")
+        if _coalesce_max_tokens and _coalesce_max_tokens > 0:
+            self._prefill_coalesce_max_tokens = _coalesce_max_tokens
+        else:
+            self._prefill_coalesce_max_tokens = (
+                getattr(self, "chunked_prefill_size", None)
+                or getattr(self, "max_prefill_tokens", 0)
+                or 0
+            )
+        # Cheap int-broadcast fast path so idle TP loops skip the pyobj pickle.
+        self._tp_idle_broadcast_skip = env_flag(
+            "SGLANG_OMNI_TP_IDLE_BROADCAST_SKIP", default=False
+        )
+        # Periodic prefill-batch-size summary to quantify fragmentation.
+        self._log_prefill_stats = env_flag(
+            "SGLANG_OMNI_LOG_PREFILL_STATS", default=False
+        )
+        self._prefill_stats_interval_s = max(
+            env_float("SGLANG_OMNI_PREFILL_STATS_INTERVAL_S", default=10.0), 1.0
+        )
+        self._prefill_stats_last_log = 0.0
+        self._prefill_stats_batches = 0
+        self._prefill_stats_reqs = 0
+        self._prefill_stats_max = 0
 
     def _resolve_admission_max_waiting(self) -> int | None:
         override = env_int("SGLANG_OMNI_ADMISSION_MAX_WAITING")
@@ -363,6 +418,135 @@ class OmniScheduler:
         if value is None or value <= 0:
             return None
         return value * 1024 * 1024
+
+    def _waiting_prefill_tokens(self) -> int:
+        """Best-effort sum of prefill tokens currently in the waiting queue.
+
+        Deterministic function of the (TP-replicated) waiting queue, so every
+        rank computes the same value and the coalesce loop stays in lockstep.
+        Guarded so a missing attribute never aborts the scheduler.
+        """
+        total = 0
+        for req in getattr(self, "waiting_queue", []) or []:
+            ids = getattr(req, "origin_input_ids", None)
+            if ids is not None:
+                try:
+                    total += len(ids)
+                except TypeError:
+                    continue
+        return total
+
+    def _coalesce_prefill_window(self) -> None:
+        """Briefly wait to group newly-arrived requests into one prefill batch.
+
+        Engages only on the idle->prefill transition (no decode batch running
+        and no in-flight async-decode step) and only while fewer than the target
+        number of requests are queued, so it never stalls active decode. Uses a
+        FIXED iteration count (not wall-clock) and a replicated break condition
+        (``waiting_queue`` length, which is identical across TP ranks after the
+        broadcast in ``recv_requests``) so every rank issues the same number of
+        broadcast collectives and stays in lockstep. No-op unless
+        ``SGLANG_OMNI_PREFILL_COALESCE_MS`` > 0.
+        """
+        window_s = getattr(self, "_prefill_coalesce_window_s", 0.0)
+        if window_s <= 0.0:
+            return
+        target = getattr(self, "_prefill_coalesce_target", None)
+        if not target or target <= 1:
+            return
+        if getattr(self, "_async_pending", None) is not None:
+            return
+        # Overlap loop: a finished prefill result waits one iteration in
+        # result_queue (running_batch still 0) before its decode starts; don't
+        # stall that transition. Attribute only exists in _event_loop_overlap.
+        if getattr(self, "result_queue", None):
+            return
+        if batch_size(getattr(self, "running_batch", None)) > 0:
+            return
+        coalesce_min = getattr(self, "_prefill_coalesce_min", 2)
+        if not coalesce_min <= len(self.waiting_queue) < target:
+            return
+        # Token budget bounds the coalesced prefill (and its transient
+        # activation/broadcast memory) to one chunk-worth; prevents the
+        # multimodal thinker-TP OOM seen at high concurrency (issue #760).
+        budget = getattr(self, "_prefill_coalesce_max_tokens", 0) or 0
+        if budget and self._waiting_prefill_tokens() >= budget:
+            return
+        poll_s = getattr(self, "_prefill_coalesce_poll_s", 0.001) or 0.001
+        iterations = max(int(window_s / poll_s), 1)
+        for _ in range(iterations):
+            if len(self.waiting_queue) >= target:
+                break
+            if budget and self._waiting_prefill_tokens() >= budget:
+                break
+            time.sleep(poll_s)
+            more = self.recv_requests()
+            more.extend(self._take_deferred_request_payloads())
+            if more:
+                self.process_input_requests(more)
+
+    def _record_prefill_stats(self, batch: Any) -> None:
+        """Accumulate prefill (extend) batch sizes and log a periodic summary.
+
+        No-op unless ``SGLANG_OMNI_LOG_PREFILL_STATS`` is set. Cheap: a few
+        integer updates per batch plus one log line per interval. Lets us
+        quantify prefill fragmentation (avg/max batch size) before/after a fix.
+        """
+        if not getattr(self, "_log_prefill_stats", False):
+            return
+        if not getattr(self, "is_entry_rank", True):
+            return
+        if batch is None or self._batch_is_decode(batch):
+            return
+        n = batch_size(batch)
+        if n <= 0:
+            return
+        now = time.monotonic()
+        if self._prefill_stats_last_log == 0.0:
+            self._prefill_stats_last_log = now
+        self._prefill_stats_batches += 1
+        self._prefill_stats_reqs += n
+        self._prefill_stats_max = max(self._prefill_stats_max, n)
+        elapsed = now - self._prefill_stats_last_log
+        if elapsed < self._prefill_stats_interval_s:
+            return
+        avg = self._prefill_stats_reqs / max(self._prefill_stats_batches, 1)
+        logger.info(
+            "[prefill-stats] window=%.1fs prefill_batches=%d reqs=%d "
+            "avg_batch=%.2f max_batch=%d waiting=%d running=%d",
+            elapsed,
+            self._prefill_stats_batches,
+            self._prefill_stats_reqs,
+            avg,
+            self._prefill_stats_max,
+            len(getattr(self, "waiting_queue", []) or []),
+            batch_size(getattr(self, "running_batch", None)),
+        )
+        self._prefill_stats_last_log = now
+        self._prefill_stats_batches = 0
+        self._prefill_stats_reqs = 0
+        self._prefill_stats_max = 0
+
+    def _tp_inbox_is_idle_collective(self, local_count: int) -> bool:
+        """Agree across all TP ranks whether the entry rank's inbox was empty,
+        via a single cheap int broadcast, so idle loops can skip the (pickling)
+        ``broadcast_pyobj`` path.
+
+        TP-safe: every rank issues exactly one int broadcast here in lockstep,
+        and the boolean result is derived from the broadcast value (identical on
+        all ranks). Any failure returns False so the caller falls back to the
+        always-correct ``broadcast_pyobj``.
+        """
+        try:
+            import torch
+
+            flag = torch.tensor([int(local_count)], dtype=torch.int64)
+            torch.distributed.broadcast(
+                flag, src=self.tp_group.ranks[0], group=self.tp_cpu_group
+            )
+            return int(flag.item()) == 0
+        except Exception:
+            return False
 
     def _init_upstream_compat_flags(self, server_args: Any) -> None:
         self.enable_hisparse = bool(getattr(server_args, "enable_hisparse", False))
@@ -476,6 +660,10 @@ class OmniScheduler:
             return self._drain_local_inbox()
 
         recv_msgs = self._drain_local_inbox() if self.is_entry_rank else []
+        if getattr(self, "_tp_idle_broadcast_skip", False) and (
+            self._tp_inbox_is_idle_collective(len(recv_msgs))
+        ):
+            return []
         return broadcast_pyobj(
             recv_msgs,
             self.tp_group.rank,
@@ -764,6 +952,7 @@ class OmniScheduler:
         a ``GenerationBatchResult``.  We bridge the two formats here.
         """
         self._emit_prefill_start_for_batch(batch)
+        self._record_prefill_stats(batch)
         self._emit_scheduler_telemetry(
             "scheduler_batch_start",
             extra={"batch_size": batch_size(batch)},
@@ -1086,6 +1275,7 @@ class OmniScheduler:
                 time.sleep(0.001)
                 continue
 
+            self._coalesce_prefill_window()
             batch = self.get_next_batch_to_run()
             self.cur_batch = batch
 
@@ -1116,6 +1306,7 @@ class OmniScheduler:
                 time.sleep(0.001)
                 continue
 
+            self._coalesce_prefill_window()
             batch = self.get_next_batch_to_run()
             self.cur_batch = batch
             disable_overlap_for_batch = self.is_disable_overlap_for_batch(batch)
@@ -1258,6 +1449,7 @@ class OmniScheduler:
                 time.sleep(0.001)
                 continue
 
+            self._coalesce_prefill_window()
             batch = self.get_next_batch_to_run()
             self.cur_batch = batch
 

--- a/sglang_omni/scheduling/sglang_backend/server_args_builder.py
+++ b/sglang_omni/scheduling/sglang_backend/server_args_builder.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from sglang.srt.server_args import ServerArgs
 
+from sglang_omni.scheduling.observability import env_int
+
 
 def build_sglang_server_args(
     model_path: str,
@@ -18,6 +20,15 @@ def build_sglang_server_args(
     **overrides: Any,
 ) -> ServerArgs:
     """Build ServerArgs with shared defaults for all SGLang AR engines."""
+    if chunked_prefill_size is None:
+        # Issue #760: opt-in chunked prefill so long (audio) prefills interleave
+        # with decode instead of blocking an entire prefill step. Off by default
+        # (the Qwen3-Omni CI thresholds are tight). The PrefillManager already
+        # force-disables chunking for projected-embeds (talker) requests, so
+        # enabling this only affects the thinker prefill path.
+        env_chunk = env_int("SGLANG_OMNI_CHUNKED_PREFILL_SIZE")
+        if env_chunk and env_chunk > 0:
+            chunked_prefill_size = env_chunk
     kwargs: dict[str, Any] = {
         "model_path": model_path,
         "trust_remote_code": True,

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -71,10 +71,19 @@ _BAD_REQUEST_MARKERS = (
     "Requested token count exceeds the model's maximum context length",
 )
 
+_OVERLOAD_MARKERS = (
+    "Admission rejected:",
+)
+
 
 def _is_bad_request_error(exc: Exception) -> bool:
     message = str(exc)
     return any(marker in message for marker in _BAD_REQUEST_MARKERS)
+
+
+def _is_overload_error(exc: Exception) -> bool:
+    message = str(exc)
+    return any(marker in message for marker in _OVERLOAD_MARKERS)
 
 
 def create_app(
@@ -221,11 +230,15 @@ async def _chat_non_stream(
     except ClientError as exc:
         if _is_bad_request_error(exc):
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if _is_overload_error(exc):
+            raise HTTPException(status_code=429, detail=str(exc)) from exc
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     except Exception as exc:
         logger.exception("Error generating response for request %s", request_id)
         if _is_bad_request_error(exc):
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if _is_overload_error(exc):
+            raise HTTPException(status_code=429, detail=str(exc)) from exc
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
     requested_modalities = req.modalities or ["text"]
@@ -544,9 +557,13 @@ def _register_speech(app: FastAPI) -> None:
                 speed=req.speed,
             )
         except ClientError as exc:
+            if _is_overload_error(exc):
+                raise HTTPException(status_code=429, detail=str(exc)) from exc
             raise HTTPException(status_code=500, detail=str(exc)) from exc
         except Exception as exc:
             logger.exception("Error generating speech for request %s", request_id)
+            if _is_overload_error(exc):
+                raise HTTPException(status_code=429, detail=str(exc)) from exc
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
         headers = {

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -580,6 +580,90 @@ def test_omni_scheduler_initializes_upstream_queue_limit(monkeypatch) -> None:
     assert scheduler._abort_on_queued_limit(object()) is False
 
 
+def test_omni_scheduler_admission_rejects_full_waiting_queue() -> None:
+    scheduler = object.__new__(OmniScheduler)
+    scheduler.outbox = Queue()
+    scheduler.inbox = Queue()
+    scheduler.waiting_queue = [SimpleNamespace(rid="already-waiting")]
+    scheduler.running_batch = None
+    scheduler.cur_batch = None
+    scheduler.last_batch = None
+    scheduler._async_pending = None
+    scheduler._pending_stream_chunks = {}
+    scheduler._pending_stream_done = set()
+    scheduler._deferred_request_payloads = {}
+    scheduler._dirty_deferred_request_ids = set()
+    scheduler._aborted_request_ids = set()
+    scheduler._first_emit_done = set()
+    scheduler._prefill_start_done = set()
+    scheduler._abort_callback = None
+    scheduler.is_entry_rank = True
+    scheduler.gpu_id = None
+    scheduler.server_args = SimpleNamespace(mem_fraction_static=None)
+    scheduler.max_req_len = 128
+    scheduler.max_total_num_tokens = 1024
+    scheduler.max_prefill_tokens = 128
+    scheduler.max_running_requests = 4
+    scheduler.max_queued_requests = 1
+    scheduler.token_to_kv_pool_allocator = SimpleNamespace(available_size=lambda: 512)
+    scheduler._admission_max_waiting = 1
+    scheduler._admission_min_free_gpu_memory_bytes = None
+    scheduler._admission_token_headroom = 1.0
+
+    req = SimpleNamespace(
+        rid="new-req",
+        origin_input_ids=[1, 2, 3],
+        sampling_params=SimpleNamespace(max_new_tokens=4),
+        output_ids=[],
+    )
+    scheduler._request_builder = lambda payload: SimpleNamespace(
+        req=req,
+        enforce_request_limits=False,
+    )
+
+    scheduler.process_input_requests([SimpleNamespace(request_id="new-req")])
+
+    assert [req.rid for req in scheduler.waiting_queue] == ["already-waiting"]
+    out = scheduler.outbox.get_nowait()
+    assert out.request_id == "new-req"
+    assert out.type == "error"
+    assert "waiting queue is full" in str(out.data)
+
+
+def test_omni_scheduler_telemetry_snapshot_reports_queue_and_kv() -> None:
+    scheduler = object.__new__(OmniScheduler)
+    scheduler.inbox = Queue()
+    scheduler.outbox = Queue()
+    scheduler.inbox.put(IncomingMessage("req", "new_request", object()))
+    scheduler.waiting_queue = [object(), object()]
+    scheduler.running_batch = SimpleNamespace(reqs=[object()])
+    scheduler.cur_batch = None
+    scheduler.last_batch = SimpleNamespace(reqs=[object(), object(), object()])
+    scheduler._deferred_request_payloads = {"deferred": object()}
+    scheduler._pending_stream_chunks = {"stream": [object()]}
+    scheduler._pending_stream_done = {"done"}
+    scheduler.max_running_requests = 8
+    scheduler.max_queued_requests = 16
+    scheduler.max_total_num_tokens = 100
+    scheduler.max_req_len = 64
+    scheduler.max_prefill_tokens = 32
+    scheduler.token_to_kv_pool_allocator = SimpleNamespace(available_size=lambda: 25)
+    scheduler.gpu_id = None
+    scheduler._admission_max_waiting = 16
+    scheduler._admission_min_free_gpu_memory_bytes = 1 << 30
+
+    snapshot = scheduler._scheduler_telemetry_snapshot()
+
+    assert snapshot["inbox_qsize"] == 1
+    assert snapshot["outbox_qsize"] == 0
+    assert snapshot["waiting_queue"] == 2
+    assert snapshot["running_batch"] == 1
+    assert snapshot["last_batch"] == 3
+    assert snapshot["kv_available_tokens"] == 25
+    assert snapshot["kv_used_tokens"] == 75
+    assert snapshot["cuda_allocated_bytes"] is None
+
+
 def test_stage_output_cache_eviction_uses_lru_order() -> None:
     cache = StageOutputCache(max_size=2)
 

--- a/tests/unit_test/qwen3_omni/test_pipeline.py
+++ b/tests/unit_test/qwen3_omni/test_pipeline.py
@@ -877,6 +877,58 @@ def test_qwen_text_thinker_tp_builds_topology_without_memory_fractions() -> None
     assert _stage(config, "thinker").runtime.resources.total_gpu_memory_fraction is None
 
 
+def test_qwen_thinker_tp_disables_custom_all_reduce_across_configs() -> None:
+    """TP>1 thinker must drop the custom all-reduce kernel (parity w/ MingOmni).
+
+    Regression guard for issue #760: a ``sglang_omni serve`` launch (not just the
+    example script) must auto-inject ``disable_custom_all_reduce`` for the
+    multi-process thinker TP path.
+    """
+    for cls in (
+        Qwen3OmniPipelineConfig,
+        Qwen3OmniSpeechPipelineConfig,
+        Qwen3OmniSpeechColocatedPipelineConfig,
+    ):
+        assert cls.tensor_parallel_server_args_overrides(
+            stage_name="thinker", tp_size=2
+        ) == {"disable_custom_all_reduce": True}
+        # TP==1 and non-thinker stages stay untouched.
+        assert (
+            cls.tensor_parallel_server_args_overrides(stage_name="thinker", tp_size=1)
+            == {}
+        )
+        for stage_name in ("audio_encoder", "image_encoder", "talker_ar", "code2wav"):
+            assert (
+                cls.tensor_parallel_server_args_overrides(
+                    stage_name=stage_name, tp_size=4
+                )
+                == {}
+            )
+
+
+def test_qwen_cli_serve_applies_thinker_tp_override_to_server_args() -> None:
+    """End-to-end: the CLI TP pass writes disable_custom_all_reduce into the
+    thinker stage server args when TP>1 is configured (issue #760)."""
+    from sglang_omni.cli.serve import _apply_tensor_parallel_server_args_overrides
+
+    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+    apply_parallelism_cli_overrides(
+        config,
+        thinker_tp_size=2,
+        thinker_gpus="0,1",
+        talker_gpu=None,
+        code2wav_gpu=None,
+    )
+    _apply_tensor_parallel_server_args_overrides(config)
+
+    assert (
+        _server_args_overrides(config, "thinker")["disable_custom_all_reduce"] is True
+    )
+    assert "disable_custom_all_reduce" not in _server_args_overrides(
+        config, "audio_encoder"
+    )
+
+
 def test_qwen_thinker_auto_path_applies_encoder_reserve() -> None:
     server_args = SimpleNamespace(mem_fraction_static=0.929)
 

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -129,6 +129,23 @@ class SuccessfulTranscriptionClient:
         return CompletionResult(request_id="transcription-1", text="hello world")
 
 
+class OverloadedClient:
+    def health(self) -> dict[str, Any]:
+        return {"running": True}
+
+    async def completion(self, *args, **kwargs):
+        del args, kwargs
+        from sglang_omni.client.types import ClientError
+
+        raise ClientError("Admission rejected: scheduler waiting queue is full")
+
+    async def speech(self, *args, **kwargs):
+        del args, kwargs
+        from sglang_omni.client.types import ClientError
+
+        raise ClientError("Admission rejected: scheduler waiting queue is full")
+
+
 @pytest.mark.parametrize("model_name", MODEL_FAMILIES)
 def test_non_streaming_http_faults_return_500(model_name: str) -> None:
     client = TestClient(create_app(_fault_client(model_name), model_name=model_name))
@@ -155,6 +172,33 @@ def test_non_streaming_http_faults_return_500(model_name: str) -> None:
     )
     assert speech_resp.status_code == 500
     assert "cuda out of memory" in speech_resp.json()["detail"]
+
+
+def test_non_streaming_admission_rejection_returns_429() -> None:
+    client = TestClient(create_app(OverloadedClient(), model_name="qwen3-omni"))
+
+    chat_resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3-omni",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": False,
+        },
+    )
+    assert chat_resp.status_code == 429
+    assert "Admission rejected" in chat_resp.json()["detail"]
+
+    speech_resp = client.post(
+        "/v1/audio/speech",
+        json={
+            "model": "qwen3-omni",
+            "input": "hello",
+            "stream": False,
+            "response_format": "wav",
+        },
+    )
+    assert speech_resp.status_code == 429
+    assert "Admission rejected" in speech_resp.json()["detail"]
 
 
 def test_chat_stream_failure_closes_without_done_sentinel() -> None:


### PR DESCRIPTION
## Summary

Addresses #760 (Milestone 1). Two layered commits in one PR:

1. **`[Qwen3-Omni] scheduling: admission control + observability for rollout safety`** — a small diagnostics/safety foundation (env + metric helpers, queue-time admission control, scheduler/stage telemetry, `Admission rejected` → HTTP 429). The #760 work reuses these helpers, and this instrumentation is what surfaced the OOM noted below.
2. **`[Perf][Qwen3-Omni] prefill batching for concurrent streaming (#760)`** — the actual #760 fix: opt-in, TP-safe prefill-batching knobs.

All new knobs default to **current behavior** (off / no-op), so existing CI thresholds are unchanged.

## The problem (#760)

Under many concurrent streaming sessions the thinker fragments prefill into tiny (size 1–2) batches instead of coalescing toward the running/token budget the way vLLM continuous batching does. It is worst for a TP>1 thinker on prefill-heavy streaming (e.g. live speech translation).

## What's in commit 2

| Knob | Default | Effect |
|---|---|---|
| `SGLANG_OMNI_PREFILL_COALESCE_MS` | `0` (off) | Idle→prefill: briefly wait to group queued requests so the first prefill is not size-1. Never stalls active decode. |
| `SGLANG_OMNI_PREFILL_COALESCE_MIN` | `2` | Min queue depth before the window engages (avoids a low-concurrency latency tax). |
| `SGLANG_OMNI_PREFILL_COALESCE_MAX_TOKENS` | `chunked_prefill_size` | Token budget bounding the coalesced prefill + its transient broadcast/activation memory. |
| `SGLANG_OMNI_CHUNKED_PREFILL_SIZE` | unset | Enable chunked prefill for the thinker (talker projected-embeds path unaffected). |
| `SGLANG_OMNI_TP_IDLE_BROADCAST_SKIP` | `false` | Replace the per-loop `broadcast_pyobj` with a cheap int broadcast on idle TP loops. |
| `SGLANG_OMNI_LOG_PREFILL_STATS` | `false` | Periodic avg/max prefill-batch + queue-depth log to quantify fragmentation. |

Plus: auto-set `disable_custom_all_reduce` for a multi-process TP>1 thinker (the custom all-reduce kernel is not wired for the disaggregated TP launch), so a plain `serve` launch is correct without a manual override.

**TP-safety:** the coalesce window uses a **fixed iteration count** and a **`waiting_queue`-length break condition** (identical across ranks after the recv broadcast), so every rank issues the same number of collectives and stays in lockstep.

## Measurements (2× A6000, thinker TP=2, 30B base)

- **Text** sweep: coalescing lifts `avg_batch` ~N/2 → ~N; throughput/latency unchanged (text prefill is cheap / decode-bound).
- **Audio** sweep (~30s clips, ~400 prefill tok/req): coalescing lifts `avg_batch` ~N/3 → ~N, but throughput does **not** improve (baseline continuous batching already saturates thinker prefill, ~12k tok/s here).
- ⚠️ With a count-only target and **no** token budget, coalescing accumulated 32 audio requests (each carrying multimodal CUDA feature tensors through `broadcast_pyobj`) and **OOM-crashed `thinker_tp1` at N=32**. `..._MAX_TOKENS` (token budget) fixes it (0 failures, throughput == baseline) and `..._MIN` removes the low-N latency tax. The coalesce window is therefore documented as **experimental**; the always-safe wins are the TP `disable_custom_all_reduce` auto-fix, chunked prefill, the idle-broadcast skip, and the `[prefill-stats]` instrumentation.

## Test plan

- [x] Unit suite passes in the `lmsysorg/sglang-omni:dev` image (incl. new admission / telemetry / 429 and thinker-TP-override tests).
- [x] Text + audio TP=2 A/B on 2× A6000 / 30B (`[prefill-stats]` confirms the avg_batch lift; the OOM was reproduced and then fixed by the token budget).
- [x] Rebase onto latest `main` (this branch is based on an earlier `main`; the PR diff is clean, but I will rebase for merge).

## Notes for reviewers

- Opened as a **draft** for early feedback.
- An unrelated local change (inline-audio extraction in `preprocessor.py`) was intentionally **left out** to keep this PR focused; happy to send it as a separate PR.
- Planned follow-ups (separate PRs): **M2** = CUDA graph for multimodal prefill / re-enable custom all-reduce under multi-process TP; **M3** = a TP=2 concurrency-throughput CI stage.
