### PR TITLE
[Qwen3-Omni] admission control + telemetry for rollout safety

### DIFF
--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -41,6 +41,7 @@ from sglang_omni.proto import (
 )
 from sglang_omni.relay.base import Relay, create_relay
 from sglang_omni.scheduling.messages import IncomingMessage
+from sglang_omni.scheduling.observability import cuda_memory_snapshot, safe_qsize
 
 logger = logging.getLogger(__name__)
 
@@ -286,6 +287,7 @@ class Stage:
             event_name="stage_input_received",
             metadata={"from_stage": "coordinator", "kind": "submit"},
         )
+        self._emit_stage_telemetry("stage_queue_snapshot", request_id=request_id)
 
         payload = msg.data  # StagePayload from coordinator
         await self._execute(payload)
@@ -382,6 +384,7 @@ class Stage:
             event_name="stage_input_received",
             metadata={"from_stage": from_stage, "kind": "payload"},
         )
+        self._emit_stage_telemetry("stage_queue_snapshot", request_id=request_id)
         merged = self.input_handler.receive(request_id, from_stage, payload)
         if merged is not None:
             _emit_event(
@@ -654,6 +657,7 @@ class Stage:
             stage=self.name,
             event_name="stage_dispatch",
         )
+        self._emit_stage_telemetry("stage_dispatch_snapshot", request_id=request_id)
         if (
             self.role == "leader"
             and self._tp_fanout is not None
@@ -663,6 +667,7 @@ class Stage:
         self.scheduler.inbox.put(
             IncomingMessage(request_id=request_id, type="new_request", data=payload)
         )
+        self._emit_stage_telemetry("stage_inbox_snapshot", request_id=request_id)
 
     async def _on_admin(self, msg: AdminMessage) -> None:
         operation = msg.operation
@@ -1277,6 +1282,37 @@ class Stage:
         self._first_stream_chunk_seen.discard(request_id)
         self._local_stream_targets.pop(request_id, None)
         self._nonlocal_stream_targets.pop(request_id, None)
+        self._emit_stage_telemetry("stage_request_cleared", request_id=request_id)
+
+    def _emit_stage_telemetry(self, event_name: str, *, request_id: str) -> None:
+        if not _get_recorder().is_active():
+            return
+        stream_queues = None
+        stream_pending_items = None
+        if self._stream_queue is not None:
+            queues = getattr(self._stream_queue, "_queues", {})
+            stream_queues = len(queues)
+            pending_sizes = [safe_qsize(queue) for queue in queues.values()]
+            stream_pending_items = sum(
+                qsize for qsize in pending_sizes if qsize is not None
+            )
+        metadata = {
+            "active_requests": len(self._active_requests),
+            "aborted_requests_tracked": len(self._aborted),
+            "scheduler_inbox_qsize": safe_qsize(getattr(self.scheduler, "inbox", None)),
+            "scheduler_outbox_qsize": safe_qsize(
+                getattr(self.scheduler, "outbox", None)
+            ),
+            "stream_queues": stream_queues,
+            "stream_pending_items": stream_pending_items,
+            **cuda_memory_snapshot(self.gpu_id),
+        }
+        _emit_event(
+            request_id=request_id,
+            stage=self.name,
+            event_name=event_name,
+            metadata=metadata,
+        )
 
     async def _handle_scheduler_crash(self, exc: BaseException) -> None:
         if self._scheduler_crash_error is not None:

--- a/sglang_omni/scheduling/env.py
+++ b/sglang_omni/scheduling/env.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Scheduler environment variable parsing helpers."""
+
+from __future__ import annotations
+
+import os
+
+
+def env_float(name: str, *, default: float) -> float:
+    value = os.environ.get(name)
+    if value is None or value.strip() == "":
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
+def env_int(name: str) -> int | None:
+    value = os.environ.get(name)
+    if value is None or value.strip() == "":
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None

--- a/sglang_omni/scheduling/observability.py
+++ b/sglang_omni/scheduling/observability.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Best-effort scheduler and CUDA telemetry helpers."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def env_float(name: str, *, default: float) -> float:
+    value = os.environ.get(name)
+    if value is None or value.strip() == "":
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
+def env_int(name: str) -> int | None:
+    value = os.environ.get(name)
+    if value is None or value.strip() == "":
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def safe_qsize(queue_obj: Any) -> int | None:
+    qsize = getattr(queue_obj, "qsize", None)
+    if not callable(qsize):
+        return None
+    try:
+        return int(qsize())
+    except Exception:
+        return None
+
+
+def batch_size(batch: Any) -> int:
+    if batch is None:
+        return 0
+    return len(getattr(batch, "reqs", ()) or ())
+
+
+def allocator_available_tokens(allocator: Any) -> int | None:
+    available_size = getattr(allocator, "available_size", None)
+    if not callable(available_size):
+        return None
+    try:
+        return int(available_size())
+    except Exception:
+        return None
+
+
+def cuda_memory_snapshot(gpu_id: int | None) -> dict[str, int | None]:
+    snapshot: dict[str, int | None] = {
+        "gpu_id": gpu_id,
+        "cuda_allocated_bytes": None,
+        "cuda_reserved_bytes": None,
+        "cuda_max_allocated_bytes": None,
+        "cuda_free_bytes": None,
+        "cuda_total_bytes": None,
+    }
+    if gpu_id is None:
+        return snapshot
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return snapshot
+        device = int(gpu_id)
+        snapshot["cuda_allocated_bytes"] = int(torch.cuda.memory_allocated(device))
+        snapshot["cuda_reserved_bytes"] = int(torch.cuda.memory_reserved(device))
+        snapshot["cuda_max_allocated_bytes"] = int(
+            torch.cuda.max_memory_allocated(device)
+        )
+        free_bytes, total_bytes = torch.cuda.mem_get_info(device)
+        snapshot["cuda_free_bytes"] = int(free_bytes)
+        snapshot["cuda_total_bytes"] = int(total_bytes)
+    except Exception:
+        return snapshot
+    return snapshot

--- a/sglang_omni/scheduling/observability.py
+++ b/sglang_omni/scheduling/observability.py
@@ -3,28 +3,7 @@
 
 from __future__ import annotations
 
-import os
 from typing import Any
-
-
-def env_float(name: str, *, default: float) -> float:
-    value = os.environ.get(name)
-    if value is None or value.strip() == "":
-        return default
-    try:
-        return float(value)
-    except ValueError:
-        return default
-
-
-def env_int(name: str) -> int | None:
-    value = os.environ.get(name)
-    if value is None or value.strip() == "":
-        return None
-    try:
-        return int(value)
-    except ValueError:
-        return None
 
 
 def safe_qsize(queue_obj: Any) -> int | None:

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -903,28 +903,18 @@ class OmniScheduler:
             return local_waiting
 
         value = torch.tensor([local_waiting], dtype=torch.int64)
-        try:
-            torch.distributed.all_reduce(
-                value,
-                op=torch.distributed.ReduceOp.MAX,
-                group=cpu_group,
-            )
-        except Exception:
-            logger.debug(
-                "Failed to compute TP-consistent waiting queue depth for admission",
-                exc_info=True,
-            )
-            return local_waiting
+        torch.distributed.all_reduce(
+            value,
+            op=torch.distributed.ReduceOp.MAX,
+            group=cpu_group,
+        )
         return int(value.item())
-
-    def _cuda_free_bytes(self) -> int | None:
-        snapshot = cuda_memory_snapshot(getattr(self, "gpu_id", None))
-        free_bytes = snapshot.get("cuda_free_bytes")
-        return int(free_bytes) if free_bytes is not None else None
 
     def _admission_cuda_free_bytes(self) -> int | None:
         """Return a TP-consistent free-memory value for admission decisions."""
-        local_free = self._cuda_free_bytes()
+        snapshot = cuda_memory_snapshot(getattr(self, "gpu_id", None))
+        free_bytes = snapshot.get("cuda_free_bytes")
+        local_free = int(free_bytes) if free_bytes is not None else None
         if getattr(self, "tp_size", 1) <= 1:
             return local_free
         cpu_group = getattr(self, "tp_cpu_group", None)
@@ -938,18 +928,11 @@ class OmniScheduler:
             ],
             dtype=torch.int64,
         )
-        try:
-            torch.distributed.all_reduce(
-                values,
-                op=torch.distributed.ReduceOp.MIN,
-                group=cpu_group,
-            )
-        except Exception:
-            logger.debug(
-                "Failed to compute TP-consistent CUDA free memory for admission",
-                exc_info=True,
-            )
-            return None
+        torch.distributed.all_reduce(
+            values,
+            op=torch.distributed.ReduceOp.MIN,
+            group=cpu_group,
+        )
         if int(values[0].item()) <= 0:
             return None
         return int(values[1].item())
@@ -1041,10 +1024,6 @@ class OmniScheduler:
         a ``GenerationBatchResult``.  We bridge the two formats here.
         """
         self._emit_prefill_start_for_batch(batch)
-        self._emit_scheduler_telemetry(
-            "scheduler_batch_start",
-            extra={"batch_size": batch_size(batch)},
-        )
         if self._model_runner is not None:
             # Mirror upstream run_batch's per-forward counter: OmniScheduler
             # overrides run_batch, so without this forward_ct stays 0 and
@@ -1055,18 +1034,9 @@ class OmniScheduler:
             mr_output = self._model_runner.execute(sched_output)
             self._emit_stream_output(sched_output, mr_output)
             result = self._make_batch_result(batch, mr_output)
-            self._emit_scheduler_telemetry(
-                "scheduler_batch_end",
-                extra={"batch_size": batch_size(batch)},
-            )
             return result
         # Fallback: call upstream's run_batch (uses tp_worker directly)
-        result = _Upstream.run_batch(self, batch, pp_proxy_tensors)
-        self._emit_scheduler_telemetry(
-            "scheduler_batch_end",
-            extra={"batch_size": batch_size(batch)},
-        )
-        return result
+        return _Upstream.run_batch(self, batch, pp_proxy_tensors)
 
     def _build_sched_output(self, batch):
         """Wrap a ScheduleBatch into the SchedulerOutput the model runner

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -865,12 +865,14 @@ class OmniScheduler:
 
     def _admission_rejection_reason(self, request_id: str, req: Any) -> str | None:
         max_waiting = getattr(self, "_admission_max_waiting", None)
-        if max_waiting is not None and len(self.waiting_queue) >= max_waiting:
-            return (
-                "Admission rejected: scheduler waiting queue is full "
-                f"(waiting={len(self.waiting_queue)}, limit={max_waiting}). "
-                "Retry later or raise SGLANG_OMNI_ADMISSION_MAX_WAITING."
-            )
+        if max_waiting is not None:
+            waiting = self._admission_waiting_queue_depth()
+            if waiting >= max_waiting:
+                return (
+                    "Admission rejected: scheduler waiting queue is full "
+                    f"(waiting={waiting}, limit={max_waiting}). "
+                    "Retry later or raise SGLANG_OMNI_ADMISSION_MAX_WAITING."
+                )
 
         min_free = getattr(self, "_admission_min_free_gpu_memory_bytes", None)
         if min_free is not None:
@@ -889,6 +891,30 @@ class OmniScheduler:
         del request_id, req
         return None
 
+    def _admission_waiting_queue_depth(self) -> int:
+        """Return a TP-consistent queue depth for max-waiting admission."""
+        local_waiting = len(self.waiting_queue)
+        if getattr(self, "tp_size", 1) <= 1:
+            return local_waiting
+        cpu_group = getattr(self, "tp_cpu_group", None)
+        if cpu_group is None:
+            return local_waiting
+
+        value = torch.tensor([local_waiting], dtype=torch.int64)
+        try:
+            torch.distributed.all_reduce(
+                value,
+                op=torch.distributed.ReduceOp.MAX,
+                group=cpu_group,
+            )
+        except Exception:
+            logger.debug(
+                "Failed to compute TP-consistent waiting queue depth for admission",
+                exc_info=True,
+            )
+            return local_waiting
+        return int(value.item())
+
     def _cuda_free_bytes(self) -> int | None:
         snapshot = cuda_memory_snapshot(getattr(self, "gpu_id", None))
         free_bytes = snapshot.get("cuda_free_bytes")
@@ -903,28 +929,28 @@ class OmniScheduler:
         if cpu_group is None:
             return None
 
+        values = torch.tensor(
+            [
+                1 if local_free is not None else 0,
+                int(local_free) if local_free is not None else 0,
+            ],
+            dtype=torch.int64,
+        )
         try:
-            values = torch.tensor(
-                [
-                    1 if local_free is not None else 0,
-                    int(local_free) if local_free is not None else 0,
-                ],
-                dtype=torch.int64,
-            )
             torch.distributed.all_reduce(
                 values,
                 op=torch.distributed.ReduceOp.MIN,
                 group=cpu_group,
             )
-            if int(values[0].item()) <= 0:
-                return None
-            return int(values[1].item())
         except Exception:
             logger.debug(
                 "Failed to compute TP-consistent CUDA free memory for admission",
                 exc_info=True,
             )
             return None
+        if int(values[0].item()) <= 0:
+            return None
+        return int(values[1].item())
 
     def _scheduler_telemetry_snapshot(self) -> dict[str, Any]:
         available_tokens = allocator_available_tokens(

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -45,13 +45,12 @@ from sglang_omni.proto.admin import (
     ADMIN_UPDATE_WEIGHTS_FROM_TENSOR,
     ADMIN_WEIGHTS_CHECKER,
 )
+from sglang_omni.scheduling.env import env_float, env_int
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
 from sglang_omni.scheduling.observability import (
     allocator_available_tokens,
     batch_size,
     cuda_memory_snapshot,
-    env_float,
-    env_int,
     safe_qsize,
 )
 
@@ -751,7 +750,7 @@ class OmniScheduler:
             self._emit_request_error(req_id, ValueError(kv_error))
             self.abort(req_id)
             return
-        admission_error = self._admission_rejection_reason(req_id, req)
+        admission_error = self._admission_rejection_reason()
         if admission_error is not None:
             logger.warning(
                 "Rejecting request %s before queueing: %s",
@@ -865,7 +864,7 @@ class OmniScheduler:
             f"{mem_hint}"
         )
 
-    def _admission_rejection_reason(self, request_id: str, req: Any) -> str | None:
+    def _admission_rejection_reason(self) -> str | None:
         max_waiting = getattr(self, "_admission_max_waiting", None)
         if max_waiting is not None:
             waiting = self._admission_waiting_queue_depth()
@@ -892,7 +891,6 @@ class OmniScheduler:
                     "Retry later or lower SGLANG_OMNI_ADMISSION_MIN_FREE_GPU_MEMORY_MB."
                 )
 
-        del request_id, req
         return None
 
     def _admission_waiting_queue_depth(self) -> int:

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -33,6 +33,7 @@ from sglang.srt.utils import broadcast_pyobj
 
 from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.profiler.event_recorder import get_active_stage as _get_active_stage
+from sglang_omni.profiler.event_recorder import get_recorder as _get_event_recorder
 from sglang_omni.proto.admin import (
     ADMIN_CONTINUE_GENERATION,
     ADMIN_DESTROY_WEIGHTS_UPDATE_GROUP,
@@ -45,6 +46,14 @@ from sglang_omni.proto.admin import (
     ADMIN_WEIGHTS_CHECKER,
 )
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
+from sglang_omni.scheduling.observability import (
+    allocator_available_tokens,
+    batch_size,
+    cuda_memory_snapshot,
+    env_float,
+    env_int,
+    safe_qsize,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -376,6 +385,40 @@ class OmniScheduler:
         self._dirty_deferred_request_ids: set[str] = set()
         self._first_emit_done: set[str] = set()
         self._prefill_start_done: set[str] = set()
+        # Opt-in overload guards evaluated at queue time. The default
+        # max_waiting mirrors the existing upstream max_queued_requests limit
+        # and surfaces a controlled rejection before an uncontrolled overload.
+        self._admission_max_waiting = self._resolve_admission_max_waiting()
+        self._admission_min_free_gpu_memory_bytes = (
+            self._resolve_admission_min_free_gpu_memory_bytes()
+        )
+        self._admission_token_headroom = max(
+            min(
+                env_float("SGLANG_OMNI_ADMISSION_TOKEN_HEADROOM", default=1.0),
+                1.0,
+            ),
+            0.0,
+        )
+
+    def _resolve_admission_max_waiting(self) -> int | None:
+        override = env_int("SGLANG_OMNI_ADMISSION_MAX_WAITING")
+        if override is not None:
+            return max(override, 0)
+        value = getattr(self, "max_queued_requests", None)
+        if value is None:
+            return None
+        try:
+            value = int(value)
+        except (TypeError, ValueError):
+            return None
+        return value if value > 0 else None
+
+    @staticmethod
+    def _resolve_admission_min_free_gpu_memory_bytes() -> int | None:
+        value = env_int("SGLANG_OMNI_ADMISSION_MIN_FREE_GPU_MEMORY_MB")
+        if value is None or value <= 0:
+            return None
+        return value * 1024 * 1024
 
     def _init_upstream_compat_flags(self, server_args: Any) -> None:
         self.enable_hisparse = bool(getattr(server_args, "enable_hisparse", False))
@@ -706,6 +749,21 @@ class OmniScheduler:
             self._emit_request_error(req_id, ValueError(kv_error))
             self.abort(req_id)
             return
+        admission_error = self._admission_rejection_reason(req_id, req)
+        if admission_error is not None:
+            logger.warning(
+                "Rejecting request %s before queueing: %s",
+                req_id,
+                admission_error,
+            )
+            self._emit_scheduler_telemetry(
+                "scheduler_admission_reject",
+                request_id=req_id,
+                extra={"reason": admission_error},
+            )
+            self._emit_request_error(req_id, RuntimeError(admission_error))
+            self.abort(req_id)
+            return
         self._initialize_request_stream_state(req_data, payload)
         for chunk in self._pending_stream_chunks.pop(req_id, []) or []:
             self._append_stream_chunk(req_data, chunk)
@@ -722,6 +780,11 @@ class OmniScheduler:
                 event_name="scheduler_queue_enter",
             )
             self.waiting_queue.append(req)
+            self._emit_scheduler_telemetry(
+                "scheduler_admission_queue",
+                request_id=req_id,
+                extra={"queued_request_id": req_id},
+            )
 
         if request_admission_lock_held:
             enqueue_if_live()
@@ -779,7 +842,8 @@ class OmniScheduler:
         input_len = len(req.origin_input_ids)
         max_new_tokens = int(req.sampling_params.max_new_tokens or 0)
         required_tokens = input_len + max_new_tokens
-        kv_capacity = int(self.max_req_len)
+        token_headroom = getattr(self, "_admission_token_headroom", 1.0)
+        kv_capacity = int(self.max_req_len * token_headroom)
         if required_tokens <= kv_capacity:
             return None
 
@@ -797,6 +861,128 @@ class OmniScheduler:
             f"(input_tokens={input_len}, max_new_tokens={max_new_tokens}, "
             f"required_tokens={required_tokens}, kv_capacity={kv_capacity})."
             f"{mem_hint}"
+        )
+
+    def _admission_rejection_reason(self, request_id: str, req: Any) -> str | None:
+        max_waiting = getattr(self, "_admission_max_waiting", None)
+        if max_waiting is not None and len(self.waiting_queue) >= max_waiting:
+            return (
+                "Admission rejected: scheduler waiting queue is full "
+                f"(waiting={len(self.waiting_queue)}, limit={max_waiting}). "
+                "Retry later or raise SGLANG_OMNI_ADMISSION_MAX_WAITING."
+            )
+
+        min_free = getattr(self, "_admission_min_free_gpu_memory_bytes", None)
+        if min_free is not None:
+            # TP ranks can have different local free memory. Reduce to a
+            # group-wide minimum before deciding so every rank appends or
+            # rejects the same payload and keeps waiting_queue in lockstep.
+            free_bytes = self._admission_cuda_free_bytes()
+            if free_bytes is not None and free_bytes < min_free:
+                return (
+                    "Admission rejected: free CUDA memory is below the configured "
+                    "guard threshold "
+                    f"(free_bytes={free_bytes}, threshold_bytes={min_free}). "
+                    "Retry later or lower SGLANG_OMNI_ADMISSION_MIN_FREE_GPU_MEMORY_MB."
+                )
+
+        del request_id, req
+        return None
+
+    def _cuda_free_bytes(self) -> int | None:
+        snapshot = cuda_memory_snapshot(getattr(self, "gpu_id", None))
+        free_bytes = snapshot.get("cuda_free_bytes")
+        return int(free_bytes) if free_bytes is not None else None
+
+    def _admission_cuda_free_bytes(self) -> int | None:
+        """Return a TP-consistent free-memory value for admission decisions."""
+        local_free = self._cuda_free_bytes()
+        if getattr(self, "tp_size", 1) <= 1:
+            return local_free
+        cpu_group = getattr(self, "tp_cpu_group", None)
+        if cpu_group is None:
+            return None
+
+        try:
+            values = torch.tensor(
+                [
+                    1 if local_free is not None else 0,
+                    int(local_free) if local_free is not None else 0,
+                ],
+                dtype=torch.int64,
+            )
+            torch.distributed.all_reduce(
+                values,
+                op=torch.distributed.ReduceOp.MIN,
+                group=cpu_group,
+            )
+            if int(values[0].item()) <= 0:
+                return None
+            return int(values[1].item())
+        except Exception:
+            logger.debug(
+                "Failed to compute TP-consistent CUDA free memory for admission",
+                exc_info=True,
+            )
+            return None
+
+    def _scheduler_telemetry_snapshot(self) -> dict[str, Any]:
+        available_tokens = allocator_available_tokens(
+            getattr(self, "token_to_kv_pool_allocator", None)
+        )
+        max_total_tokens = getattr(self, "max_total_num_tokens", None)
+        used_tokens = (
+            None
+            if available_tokens is None or max_total_tokens is None
+            else max(int(max_total_tokens) - available_tokens, 0)
+        )
+        return {
+            "inbox_qsize": safe_qsize(getattr(self, "inbox", None)),
+            "outbox_qsize": safe_qsize(getattr(self, "outbox", None)),
+            "waiting_queue": len(getattr(self, "waiting_queue", []) or []),
+            "running_batch": batch_size(getattr(self, "running_batch", None)),
+            "current_batch": batch_size(getattr(self, "cur_batch", None)),
+            "last_batch": batch_size(getattr(self, "last_batch", None)),
+            "deferred_requests": len(
+                getattr(self, "_deferred_request_payloads", {}) or {}
+            ),
+            "pending_stream_chunks": len(
+                getattr(self, "_pending_stream_chunks", {}) or {}
+            ),
+            "pending_stream_done": len(getattr(self, "_pending_stream_done", set())),
+            "max_running_requests": getattr(self, "max_running_requests", None),
+            "max_queued_requests": getattr(self, "max_queued_requests", None),
+            "max_total_num_tokens": max_total_tokens,
+            "max_req_len": getattr(self, "max_req_len", None),
+            "max_prefill_tokens": getattr(self, "max_prefill_tokens", None),
+            "kv_available_tokens": available_tokens,
+            "kv_used_tokens": used_tokens,
+            "admission_max_waiting": getattr(self, "_admission_max_waiting", None),
+            "admission_min_free_gpu_memory_bytes": getattr(
+                self,
+                "_admission_min_free_gpu_memory_bytes",
+                None,
+            ),
+            **cuda_memory_snapshot(getattr(self, "gpu_id", None)),
+        }
+
+    def _emit_scheduler_telemetry(
+        self,
+        event_name: str,
+        *,
+        request_id: str | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        if not _get_event_recorder().is_active():
+            return
+        metadata = self._scheduler_telemetry_snapshot()
+        if extra:
+            metadata.update(extra)
+        _emit_event(
+            request_id=request_id or "__scheduler__",
+            stage=None,
+            event_name=event_name,
+            metadata=metadata,
         )
 
     def _emit_request_error(self, request_id: str, error: Exception) -> None:
@@ -827,6 +1013,10 @@ class OmniScheduler:
         a ``GenerationBatchResult``.  We bridge the two formats here.
         """
         self._emit_prefill_start_for_batch(batch)
+        self._emit_scheduler_telemetry(
+            "scheduler_batch_start",
+            extra={"batch_size": batch_size(batch)},
+        )
         if self._model_runner is not None:
             # Mirror upstream run_batch's per-forward counter: OmniScheduler
             # overrides run_batch, so without this forward_ct stays 0 and
@@ -836,9 +1026,19 @@ class OmniScheduler:
             sched_output = self._build_sched_output(batch)
             mr_output = self._model_runner.execute(sched_output)
             self._emit_stream_output(sched_output, mr_output)
-            return self._make_batch_result(batch, mr_output)
+            result = self._make_batch_result(batch, mr_output)
+            self._emit_scheduler_telemetry(
+                "scheduler_batch_end",
+                extra={"batch_size": batch_size(batch)},
+            )
+            return result
         # Fallback: call upstream's run_batch (uses tp_worker directly)
-        return _Upstream.run_batch(self, batch, pp_proxy_tensors)
+        result = _Upstream.run_batch(self, batch, pp_proxy_tensors)
+        self._emit_scheduler_telemetry(
+            "scheduler_batch_end",
+            extra={"batch_size": batch_size(batch)},
+        )
+        return result
 
     def _build_sched_output(self, batch):
         """Wrap a ScheduleBatch into the SchedulerOutput the model runner
@@ -930,6 +1130,15 @@ class OmniScheduler:
         reqs = list(batch.reqs)
         request_ids = [req.rid for req in reqs]
         logger.exception("OmniScheduler batch failed for requests=%s", request_ids)
+        self._emit_scheduler_telemetry(
+            "scheduler_batch_error",
+            extra={
+                "batch_size": len(reqs),
+                "request_ids": request_ids,
+                "error": str(error),
+                "error_type": type(error).__name__,
+            },
+        )
         for req in reqs:
             self._emit_request_error(req.rid, error)
             self.abort(req.rid, defer_running_cleanup=False)

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -385,10 +385,10 @@ class OmniScheduler:
         self._first_emit_done: set[str] = set()
         self._prefill_start_done: set[str] = set()
         # note (luojiaxuan): Opt-in overload guards are evaluated at queue
-        # note (luojiaxuan): time. The default max_waiting mirrors the
-        # note (luojiaxuan): existing upstream max_queued_requests limit and
-        # note (luojiaxuan): surfaces a controlled rejection before an
-        # note (luojiaxuan): uncontrolled overload.
+        # time. The default max_waiting mirrors the
+        # existing upstream max_queued_requests limit and
+        # surfaces a controlled rejection before an
+        # uncontrolled overload.
         self._admission_max_waiting = self._resolve_admission_max_waiting()
         self._admission_min_free_gpu_memory_bytes = (
             self._resolve_admission_min_free_gpu_memory_bytes()
@@ -878,10 +878,10 @@ class OmniScheduler:
         min_free = getattr(self, "_admission_min_free_gpu_memory_bytes", None)
         if min_free is not None:
             # note (luojiaxuan): TP ranks can have different local free
-            # note (luojiaxuan): memory. Reduce to a group-wide minimum before
-            # note (luojiaxuan): deciding so every rank appends or rejects the
-            # note (luojiaxuan): same payload and keeps waiting_queue in
-            # note (luojiaxuan): lockstep.
+            # memory. Reduce to a group-wide minimum before
+            # deciding so every rank appends or rejects the
+            # same payload and keeps waiting_queue in
+            # lockstep.
             free_bytes = self._admission_cuda_free_bytes()
             if free_bytes is not None and free_bytes < min_free:
                 return (

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -385,9 +385,11 @@ class OmniScheduler:
         self._dirty_deferred_request_ids: set[str] = set()
         self._first_emit_done: set[str] = set()
         self._prefill_start_done: set[str] = set()
-        # Opt-in overload guards evaluated at queue time. The default
-        # max_waiting mirrors the existing upstream max_queued_requests limit
-        # and surfaces a controlled rejection before an uncontrolled overload.
+        # note (luojiaxuan): Opt-in overload guards are evaluated at queue
+        # note (luojiaxuan): time. The default max_waiting mirrors the
+        # note (luojiaxuan): existing upstream max_queued_requests limit and
+        # note (luojiaxuan): surfaces a controlled rejection before an
+        # note (luojiaxuan): uncontrolled overload.
         self._admission_max_waiting = self._resolve_admission_max_waiting()
         self._admission_min_free_gpu_memory_bytes = (
             self._resolve_admission_min_free_gpu_memory_bytes()
@@ -876,9 +878,11 @@ class OmniScheduler:
 
         min_free = getattr(self, "_admission_min_free_gpu_memory_bytes", None)
         if min_free is not None:
-            # TP ranks can have different local free memory. Reduce to a
-            # group-wide minimum before deciding so every rank appends or
-            # rejects the same payload and keeps waiting_queue in lockstep.
+            # note (luojiaxuan): TP ranks can have different local free
+            # note (luojiaxuan): memory. Reduce to a group-wide minimum before
+            # note (luojiaxuan): deciding so every rank appends or rejects the
+            # note (luojiaxuan): same payload and keeps waiting_queue in
+            # note (luojiaxuan): lockstep.
             free_bytes = self._admission_cuda_free_bytes()
             if free_bytes is not None and free_bytes < min_free:
                 return (

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -1180,9 +1180,7 @@ def _register_speech(app: FastAPI) -> None:
                 return speech_error_response(internal_error(str(exc)))
             except Exception as exc:
                 if _is_overload_error(exc):
-                    logger.warning(
-                        "Admission rejected request %s: %s", request_id, exc
-                    )
+                    logger.warning("Admission rejected request %s: %s", request_id, exc)
                     return speech_error_response(rate_limit_error(str(exc)))
                 logger.exception(
                     "Error preparing raw PCM speech stream for request %s",

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -684,11 +684,12 @@ async def _chat_non_stream(
             raise HTTPException(status_code=429, detail=str(exc)) from exc
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     except Exception as exc:
+        if _is_overload_error(exc):
+            logger.warning("Admission rejected request %s: %s", request_id, exc)
+            raise HTTPException(status_code=429, detail=str(exc)) from exc
         logger.exception("Error generating response for request %s", request_id)
         if _is_bad_request_error(exc):
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        if _is_overload_error(exc):
-            raise HTTPException(status_code=429, detail=str(exc)) from exc
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
     requested_modalities = req.modalities or ["text"]
@@ -1178,12 +1179,15 @@ def _register_speech(app: FastAPI) -> None:
                     return speech_error_response(rate_limit_error(str(exc)))
                 return speech_error_response(internal_error(str(exc)))
             except Exception as exc:
+                if _is_overload_error(exc):
+                    logger.warning(
+                        "Admission rejected request %s: %s", request_id, exc
+                    )
+                    return speech_error_response(rate_limit_error(str(exc)))
                 logger.exception(
                     "Error preparing raw PCM speech stream for request %s",
                     request_id,
                 )
-                if _is_overload_error(exc):
-                    return speech_error_response(rate_limit_error(str(exc)))
                 return speech_error_response(internal_error(str(exc)))
 
         try:
@@ -1200,9 +1204,10 @@ def _register_speech(app: FastAPI) -> None:
                 return speech_error_response(rate_limit_error(str(exc)))
             return speech_error_response(internal_error(str(exc)))
         except Exception as exc:
-            logger.exception("Error generating speech for request %s", request_id)
             if _is_overload_error(exc):
+                logger.warning("Admission rejected request %s: %s", request_id, exc)
                 return speech_error_response(rate_limit_error(str(exc)))
+            logger.exception("Error generating speech for request %s", request_id)
             return speech_error_response(internal_error(str(exc)))
 
         headers = {

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -100,6 +100,7 @@ from sglang_omni.serve.speech_errors import (
     bad_request,
     internal_error,
     openai_error_payload,
+    rate_limit_error,
     speech_error_response,
 )
 from sglang_omni.serve.speech_service import SpeechRequestValidator
@@ -119,6 +120,7 @@ _BAD_REQUEST_MARKERS = (
     "longer than the model's context length",
     "Requested token count exceeds the model's maximum context length",
 )
+_OVERLOAD_MARKERS = ("Admission rejected:",)
 
 
 def _is_bad_request_error(exc: Exception) -> bool:
@@ -167,6 +169,11 @@ class VoiceUploadBodyLimitMiddleware:
             await self.app(scope, limited_receive, send)
         except _RequestBodyTooLarge:
             await _send_voice_upload_too_large(send, self.max_bytes)
+
+
+def _is_overload_error(exc: Exception) -> bool:
+    message = str(exc)
+    return any(marker in message for marker in _OVERLOAD_MARKERS)
 
 
 def create_app(
@@ -673,11 +680,15 @@ async def _chat_non_stream(
     except ClientError as exc:
         if _is_bad_request_error(exc):
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if _is_overload_error(exc):
+            raise HTTPException(status_code=429, detail=str(exc)) from exc
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     except Exception as exc:
         logger.exception("Error generating response for request %s", request_id)
         if _is_bad_request_error(exc):
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if _is_overload_error(exc):
+            raise HTTPException(status_code=429, detail=str(exc)) from exc
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
     requested_modalities = req.modalities or ["text"]
@@ -1163,12 +1174,16 @@ def _register_speech(app: FastAPI) -> None:
                     speed=req.speed,
                 )
             except ClientError as exc:
+                if _is_overload_error(exc):
+                    return speech_error_response(rate_limit_error(str(exc)))
                 return speech_error_response(internal_error(str(exc)))
             except Exception as exc:
                 logger.exception(
                     "Error preparing raw PCM speech stream for request %s",
                     request_id,
                 )
+                if _is_overload_error(exc):
+                    return speech_error_response(rate_limit_error(str(exc)))
                 return speech_error_response(internal_error(str(exc)))
 
         try:
@@ -1181,9 +1196,13 @@ def _register_speech(app: FastAPI) -> None:
                 speed=req.speed,
             )
         except ClientError as exc:
+            if _is_overload_error(exc):
+                return speech_error_response(rate_limit_error(str(exc)))
             return speech_error_response(internal_error(str(exc)))
         except Exception as exc:
             logger.exception("Error generating speech for request %s", request_id)
+            if _is_overload_error(exc):
+                return speech_error_response(rate_limit_error(str(exc)))
             return speech_error_response(internal_error(str(exc)))
 
         headers = {

--- a/sglang_omni/serve/speech_errors.py
+++ b/sglang_omni/serve/speech_errors.py
@@ -93,6 +93,16 @@ def internal_error(message: str, *, param: str | None = None) -> SpeechAPIError:
     )
 
 
+def rate_limit_error(message: str, *, param: str | None = None) -> SpeechAPIError:
+    return SpeechAPIError(
+        message=message,
+        status_code=429,
+        error_type="rate_limit_error",
+        param=param,
+        code=None,
+    )
+
+
 def service_unavailable(message: str, *, param: str | None = None) -> SpeechAPIError:
     return SpeechAPIError(
         message=message,

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -276,6 +276,35 @@ def test_omni_scheduler_custom_runner_updates_next_input_ids() -> None:
     assert batch.input_ids.tolist() == [11, 12]
 
 
+def test_omni_scheduler_custom_runner_skips_hot_path_telemetry() -> None:
+    next_token_ids = torch.tensor([11], dtype=torch.int32)
+
+    class FakeModelRunner:
+        def execute(self, sched_output):
+            sched_output.batch_data.output_ids = next_token_ids
+            return SimpleNamespace(outputs={}, can_run_cuda_graph=False)
+
+    telemetry_calls: list[tuple] = []
+
+    def record_telemetry(*args, **kwargs):
+        telemetry_calls.append(args)
+
+    scheduler = object.__new__(OmniScheduler)
+    scheduler._model_runner = FakeModelRunner()
+    scheduler._stream_output_builder = None
+    scheduler._prefill_start_done = set()
+    scheduler._emit_scheduler_telemetry = record_telemetry
+
+    batch = SimpleNamespace(
+        reqs=[SimpleNamespace(rid="req-1", _omni_data=SimpleNamespace())],
+        output_ids=None,
+    )
+
+    scheduler._run_batch(batch)
+
+    assert telemetry_calls == []
+
+
 def test_omni_scheduler_custom_runner_advances_forward_ct() -> None:
     """OmniScheduler overrides upstream run_batch, so it must count forwards
     itself; otherwise forward_ct stays 0 and the SGLANG_TEST_RETRACT_INTERVAL
@@ -665,6 +694,23 @@ def test_omni_scheduler_admission_max_waiting_uses_tp_group_max(
     assert calls == [(torch.distributed.ReduceOp.MAX, scheduler.tp_cpu_group)]
 
 
+def test_omni_scheduler_admission_waiting_collective_error_propagates(
+    monkeypatch,
+) -> None:
+    scheduler = object.__new__(OmniScheduler)
+    scheduler.waiting_queue = []
+    scheduler.tp_size = 2
+    scheduler.tp_cpu_group = object()
+
+    def fake_all_reduce(values, *, op, group):
+        raise RuntimeError("collective failed")
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+
+    with pytest.raises(RuntimeError, match="collective failed"):
+        scheduler._admission_waiting_queue_depth()
+
+
 def test_omni_scheduler_admission_min_free_uses_tp_group_min(monkeypatch) -> None:
     scheduler = object.__new__(OmniScheduler)
     scheduler.waiting_queue = []
@@ -672,8 +718,12 @@ def test_omni_scheduler_admission_min_free_uses_tp_group_min(monkeypatch) -> Non
     scheduler.tp_cpu_group = object()
     scheduler._admission_max_waiting = None
     scheduler._admission_min_free_gpu_memory_bytes = 4 * 1024 * 1024
-    scheduler._cuda_free_bytes = lambda: 5 * 1024 * 1024
     calls: list[tuple[object, object]] = []
+    monkeypatch.setattr(
+        omni_scheduler_module,
+        "cuda_memory_snapshot",
+        lambda gpu_id: {"cuda_free_bytes": 5 * 1024 * 1024},
+    )
 
     def fake_all_reduce(values, *, op, group):
         calls.append((op, group))
@@ -686,6 +736,28 @@ def test_omni_scheduler_admission_min_free_uses_tp_group_min(monkeypatch) -> Non
     assert reason is not None
     assert "free CUDA memory is below" in reason
     assert calls == [(torch.distributed.ReduceOp.MIN, scheduler.tp_cpu_group)]
+
+
+def test_omni_scheduler_admission_free_collective_error_propagates(
+    monkeypatch,
+) -> None:
+    scheduler = object.__new__(OmniScheduler)
+    scheduler.tp_size = 2
+    scheduler.tp_cpu_group = object()
+    scheduler.gpu_id = 0
+    monkeypatch.setattr(
+        omni_scheduler_module,
+        "cuda_memory_snapshot",
+        lambda gpu_id: {"cuda_free_bytes": 5 * 1024 * 1024},
+    )
+
+    def fake_all_reduce(values, *, op, group):
+        raise RuntimeError("collective failed")
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+
+    with pytest.raises(RuntimeError, match="collective failed"):
+        scheduler._admission_cuda_free_bytes()
 
 
 def test_omni_scheduler_telemetry_snapshot_reports_queue_and_kv(monkeypatch) -> None:

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -591,7 +591,168 @@ def test_omni_scheduler_initializes_upstream_queue_limit(monkeypatch) -> None:
     )
 
     assert scheduler.max_queued_requests == 7
+    assert scheduler._admission_max_waiting == 7
     assert scheduler._abort_on_queued_limit(object()) is False
+
+
+def test_omni_scheduler_admission_rejects_full_waiting_queue() -> None:
+    scheduler = object.__new__(OmniScheduler)
+    scheduler.outbox = Queue()
+    scheduler.inbox = Queue()
+    scheduler.waiting_queue = [SimpleNamespace(rid="queued")]
+    scheduler._pending_stream_chunks = {}
+    scheduler._pending_stream_done = set()
+    scheduler._deferred_request_payloads = {}
+    scheduler._dirty_deferred_request_ids = set()
+    scheduler._aborted_request_ids = set()
+    scheduler.is_entry_rank = True
+    scheduler.running_batch = SimpleNamespace(reqs=[], batch_is_full=False)
+    scheduler.cur_batch = None
+    scheduler.last_batch = None
+    scheduler._abort_callback = None
+    scheduler._first_emit_done = set()
+    scheduler._prefill_start_done = set()
+    scheduler.tree_cache = None
+    scheduler.max_req_len = 16
+    scheduler.max_req_input_len = 15
+    scheduler.server_args = SimpleNamespace(mem_fraction_static=None)
+    scheduler._admission_max_waiting = 1
+    scheduler._admission_min_free_gpu_memory_bytes = None
+    scheduler._admission_token_headroom = 1.0
+
+    req = SimpleNamespace(
+        rid="req-new",
+        origin_input_ids=[1],
+        sampling_params=SimpleNamespace(max_new_tokens=1),
+        output_ids=[],
+    )
+    scheduler._request_builder = lambda _payload: SimpleNamespace(req=req)
+
+    scheduler.process_input_requests([SimpleNamespace(request_id="req-new")])
+
+    output = scheduler.outbox.get_nowait()
+    assert output.request_id == "req-new"
+    assert output.type == "error"
+    assert isinstance(output.data, RuntimeError)
+    assert "Admission rejected: scheduler waiting queue is full" in str(output.data)
+    assert [item.rid for item in scheduler.waiting_queue] == ["queued"]
+    assert scheduler._aborted_request_ids == {"req-new"}
+
+
+def test_omni_scheduler_admission_min_free_uses_tp_group_min(monkeypatch) -> None:
+    scheduler = object.__new__(OmniScheduler)
+    scheduler.waiting_queue = []
+    scheduler.tp_size = 2
+    scheduler.tp_cpu_group = object()
+    scheduler._admission_max_waiting = None
+    scheduler._admission_min_free_gpu_memory_bytes = 4 * 1024 * 1024
+    scheduler._cuda_free_bytes = lambda: 5 * 1024 * 1024
+    calls: list[tuple[object, object]] = []
+
+    def fake_all_reduce(values, *, op, group):
+        calls.append((op, group))
+        values[1] = 3 * 1024 * 1024
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+
+    reason = scheduler._admission_rejection_reason(
+        "req-min-free",
+        SimpleNamespace(rid="req-min-free"),
+    )
+
+    assert reason is not None
+    assert "free CUDA memory is below" in reason
+    assert calls == [(torch.distributed.ReduceOp.MIN, scheduler.tp_cpu_group)]
+
+
+def test_omni_scheduler_telemetry_snapshot_reports_queue_and_kv(monkeypatch) -> None:
+    scheduler = object.__new__(OmniScheduler)
+    scheduler.inbox = Queue()
+    scheduler.outbox = Queue()
+    scheduler.inbox.put(object())
+    scheduler.waiting_queue = [SimpleNamespace(rid="waiting")]
+    scheduler.running_batch = SimpleNamespace(reqs=[SimpleNamespace(rid="running")])
+    scheduler.cur_batch = None
+    scheduler.last_batch = None
+    scheduler._deferred_request_payloads = {"deferred": object()}
+    scheduler._pending_stream_chunks = {"streaming": [object()]}
+    scheduler._pending_stream_done = {"done"}
+    scheduler.max_running_requests = 8
+    scheduler.max_queued_requests = 16
+    scheduler.max_total_num_tokens = 128
+    scheduler.max_req_len = 64
+    scheduler.max_prefill_tokens = 32
+    scheduler.token_to_kv_pool_allocator = SimpleNamespace(
+        available_size=lambda: 96
+    )
+    scheduler._admission_max_waiting = 16
+    scheduler._admission_min_free_gpu_memory_bytes = 1024
+    scheduler.gpu_id = 0
+
+    monkeypatch.setattr(
+        omni_scheduler_module,
+        "_get_event_recorder",
+        lambda: SimpleNamespace(is_active=lambda: True),
+    )
+    monkeypatch.setattr(
+        omni_scheduler_module,
+        "cuda_memory_snapshot",
+        lambda gpu_id: {
+            "gpu_id": gpu_id,
+            "cuda_allocated_bytes": 10,
+            "cuda_reserved_bytes": 20,
+            "cuda_max_allocated_bytes": 30,
+            "cuda_free_bytes": 40,
+            "cuda_total_bytes": 50,
+        },
+    )
+    events: list[dict] = []
+    monkeypatch.setattr(
+        omni_scheduler_module,
+        "_emit_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+
+    scheduler._emit_scheduler_telemetry(
+        "scheduler_probe",
+        request_id="req-probe",
+        extra={"phase": "test"},
+    )
+
+    assert events == [
+        {
+            "request_id": "req-probe",
+            "stage": None,
+            "event_name": "scheduler_probe",
+            "metadata": {
+                "inbox_qsize": 1,
+                "outbox_qsize": 0,
+                "waiting_queue": 1,
+                "running_batch": 1,
+                "current_batch": 0,
+                "last_batch": 0,
+                "deferred_requests": 1,
+                "pending_stream_chunks": 1,
+                "pending_stream_done": 1,
+                "max_running_requests": 8,
+                "max_queued_requests": 16,
+                "max_total_num_tokens": 128,
+                "max_req_len": 64,
+                "max_prefill_tokens": 32,
+                "kv_available_tokens": 96,
+                "kv_used_tokens": 32,
+                "admission_max_waiting": 16,
+                "admission_min_free_gpu_memory_bytes": 1024,
+                "gpu_id": 0,
+                "cuda_allocated_bytes": 10,
+                "cuda_reserved_bytes": 20,
+                "cuda_max_allocated_bytes": 30,
+                "cuda_free_bytes": 40,
+                "cuda_total_bytes": 50,
+                "phase": "test",
+            },
+        }
+    ]
 
 
 def test_stage_output_cache_eviction_uses_lru_order() -> None:

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -657,10 +657,7 @@ def test_omni_scheduler_admission_max_waiting_uses_tp_group_max(
 
     monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
 
-    reason = scheduler._admission_rejection_reason(
-        "req-full-on-peer",
-        SimpleNamespace(rid="req-full-on-peer"),
-    )
+    reason = scheduler._admission_rejection_reason()
 
     assert reason is not None
     assert "scheduler waiting queue is full" in reason
@@ -684,10 +681,7 @@ def test_omni_scheduler_admission_min_free_uses_tp_group_min(monkeypatch) -> Non
 
     monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
 
-    reason = scheduler._admission_rejection_reason(
-        "req-min-free",
-        SimpleNamespace(rid="req-min-free"),
-    )
+    reason = scheduler._admission_rejection_reason()
 
     assert reason is not None
     assert "free CUDA memory is below" in reason

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -639,6 +639,35 @@ def test_omni_scheduler_admission_rejects_full_waiting_queue() -> None:
     assert scheduler._aborted_request_ids == {"req-new"}
 
 
+def test_omni_scheduler_admission_max_waiting_uses_tp_group_max(
+    monkeypatch,
+) -> None:
+    scheduler = object.__new__(OmniScheduler)
+    scheduler.waiting_queue = []
+    scheduler.tp_size = 2
+    scheduler.tp_cpu_group = object()
+    scheduler._admission_max_waiting = 1
+    scheduler._admission_min_free_gpu_memory_bytes = 4 * 1024 * 1024
+    calls: list[tuple[object, object]] = []
+
+    def fake_all_reduce(values, *, op, group):
+        calls.append((op, group))
+        assert op == torch.distributed.ReduceOp.MAX
+        values[0] = 1
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", fake_all_reduce)
+
+    reason = scheduler._admission_rejection_reason(
+        "req-full-on-peer",
+        SimpleNamespace(rid="req-full-on-peer"),
+    )
+
+    assert reason is not None
+    assert "scheduler waiting queue is full" in reason
+    assert "waiting=1" in reason
+    assert calls == [(torch.distributed.ReduceOp.MAX, scheduler.tp_cpu_group)]
+
+
 def test_omni_scheduler_admission_min_free_uses_tp_group_min(monkeypatch) -> None:
     scheduler = object.__new__(OmniScheduler)
     scheduler.waiting_queue = []

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -682,9 +682,7 @@ def test_omni_scheduler_telemetry_snapshot_reports_queue_and_kv(monkeypatch) -> 
     scheduler.max_total_num_tokens = 128
     scheduler.max_req_len = 64
     scheduler.max_prefill_tokens = 32
-    scheduler.token_to_kv_pool_allocator = SimpleNamespace(
-        available_size=lambda: 96
-    )
+    scheduler.token_to_kv_pool_allocator = SimpleNamespace(available_size=lambda: 96)
     scheduler._admission_max_waiting = 16
     scheduler._admission_min_free_gpu_memory_bytes = 1024
     scheduler.gpu_id = 0

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -8,7 +8,7 @@ from typing import Any
 import pytest
 from fastapi.testclient import TestClient
 
-from sglang_omni.client import Client, GenerateChunk
+from sglang_omni.client import Client, ClientError, GenerateChunk
 from sglang_omni.client.audio import encode_pcm
 from sglang_omni.client.types import GenerateRequest
 from sglang_omni.pipeline.coordinator import Coordinator
@@ -125,6 +125,33 @@ class SuccessfulSpeechClient:
             mime_type=f"audio/{response_format}",
             format=response_format,
         )
+
+
+class OverloadedClient:
+    def health(self) -> dict[str, Any]:
+        return {"running": True}
+
+    async def completion(
+        self,
+        request: GenerateRequest,
+        *,
+        request_id: str,
+        audio_format: str = "wav",
+    ):
+        del request, request_id, audio_format
+        raise ClientError("Admission rejected: scheduler waiting queue is full")
+
+    async def speech(
+        self,
+        request: GenerateRequest,
+        *,
+        request_id: str,
+        response_format: str = "wav",
+        speed: float = 1.0,
+        allow_format_fallback: bool = True,
+    ):
+        del request, request_id, response_format, speed, allow_format_fallback
+        raise ClientError("Admission rejected: scheduler waiting queue is full")
 
 
 class EmptyStreamingSpeechClient:
@@ -402,6 +429,34 @@ def test_non_streaming_http_faults_return_500(model_name: str) -> None:
     assert speech_resp.status_code == 500
     assert speech_resp.json()["error"]["type"] == "server_error"
     assert "cuda out of memory" in speech_resp.json()["error"]["message"]
+
+
+def test_non_streaming_admission_rejection_returns_429() -> None:
+    client = TestClient(create_app(OverloadedClient(), model_name="qwen3-omni"))
+
+    chat_resp = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "qwen3-omni",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": False,
+        },
+    )
+    assert chat_resp.status_code == 429
+    assert "Admission rejected" in chat_resp.json()["detail"]
+
+    speech_resp = client.post(
+        "/v1/audio/speech",
+        json={
+            "model": "qwen3-omni",
+            "input": "hello",
+            "stream": False,
+            "response_format": "wav",
+        },
+    )
+    assert speech_resp.status_code == 429
+    assert speech_resp.json()["error"]["type"] == "rate_limit_error"
+    assert "Admission rejected" in speech_resp.json()["error"]["message"]
 
 
 def test_speech_endpoint_rejects_invalid_request_with_openai_error() -> None:


### PR DESCRIPTION
## Summary
> :warning: **Stacked on the #760 PR (#771).** Until #771 merges, this diff also
> includes its commit — please review **after** #771 lands (then it reduces to
> the admission/telemetry changes only). Opened as draft for that reason.

Opt-in **overload protection + observability** so concurrent serving fails
controlled instead of OOM-ing a worker. All guards default off / current
behavior.

Code only — no `docs/basic_usage` change. The admission knobs are operational
overload controls, so their mechanics are inline comments in
`scheduling/omni_scheduler.py` and the operator-facing table lives here rather
than in the basic-usage guide.

- `scheduler`: admission control at queue time — reject when the waiting queue
  is full (`SGLANG_OMNI_ADMISSION_MAX_WAITING`) or free CUDA memory is below a
  guard (`SGLANG_OMNI_ADMISSION_MIN_FREE_GPU_MEMORY_MB`), plus a per-request
  KV-headroom factor (`SGLANG_OMNI_ADMISSION_TOKEN_HEADROOM`).
- `serve/openai_api`: map an "Admission rejected" error to **HTTP 429** (instead
  of a worker OOM or a router 500).
- `observability`: CUDA-memory, KV-allocator, and queue-size helpers (extends
  the small module added in #771).
- `scheduler` + stage telemetry (queue/inbox/outbox/KV/CUDA snapshots) emitted
  through the existing event profiler when it is active.

## Admission knobs (all default OFF / current behavior)

| Env var | Default | Effect |
|---|---|---|
| `SGLANG_OMNI_ADMISSION_MAX_WAITING` | `max_queued_requests` | Reject new requests when the scheduler waiting queue is at/above this depth. |
| `SGLANG_OMNI_ADMISSION_MIN_FREE_GPU_MEMORY_MB` | unset (off) | Reject when free CUDA memory is below this guard. |
| `SGLANG_OMNI_ADMISSION_TOKEN_HEADROOM` | `1.0` | Per-request KV-headroom factor applied to the capacity check. |

Example (controlled overload instead of a crash):

```bash
SGLANG_OMNI_ADMISSION_MAX_WAITING=32 \
SGLANG_OMNI_ADMISSION_MIN_FREE_GPU_MEMORY_MB=4096 \
sgl-omni serve --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
  --config examples/configs/qwen3_omni_colocated_h20.yaml --colocate --port 8008
```

Files unique to this PR (on top of #771): `pipeline/stage/runtime.py`,
`serve/openai_api.py`, `scheduling/observability.py` (+3 helpers),
`scheduling/omni_scheduler.py` (admission/telemetry), and the two test files.

## Test plan
- [x] Rebased cleanly onto the updated #771 (current `main`); re-ran
  `tests/unit_test/pipeline/test_scheduler.py` and
  `tests/unit_test/serve/test_openai_api.py` — **passed** (admission rejection,
  telemetry snapshot, and the 429 path).

---
_3-PR split of #769 (single-responsibility): stress tool #770 | #760 prefill batching + TP fix #771 | admission + telemetry #772 (stacked on #771)._
