### PR TITLE
[ZONOS2] Add ZONOS2 pipeline skeleton

### DIFF
--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -28,6 +28,12 @@ uv pip install --no-deps qwen-tts==0.1.1
 | [Qwen3-TTS CustomVoice](../cookbook/qwen3_tts.md) | `examples/configs/qwen3_tts_0_6b_customvoice.yaml` | Text-only requests use the checkpoint speaker table; missing `voice` defaults to `Vivian` |
 | [Qwen3-TTS VoiceDesign](../cookbook/qwen3_tts.md) | `examples/configs/qwen3_tts_1_7b_voicedesign.yaml` | Requires `task_type="VoiceDesign"` and non-empty `instructions`; no reference audio is required |
 | [MOSS-TTS](../cookbook/moss_tts.md) | `examples/configs/moss_tts.yaml` | Voice cloning via `ref_audio` or `references[0].audio_path` (+ `text`); duration via `${token:N}` or `token_count`; benchmark at `--max-concurrency 8` |
+| [Zyphra ZONOS2](https://huggingface.co/Zyphra/ZONOS2) | `examples/configs/zonos2.yaml` | Integration skeleton only; runtime serving is not implemented yet |
+
+ZONOS2 is tracked as an integration skeleton for the text-frontend → speaker-embedding →
+multi-codebook MoE decode → DAC vocoder pipeline. The config is available for development
+and review, but launching it will raise `NotImplementedError` until the runtime stages are
+ported.
 
 ## Launch the Server
 

--- a/examples/configs/zonos2.yaml
+++ b/examples/configs/zonos2.yaml
@@ -1,0 +1,3 @@
+config_cls: ZONOS2PipelineConfig
+model_path: Zyphra/ZONOS2
+relay_backend: shm

--- a/sglang_omni/models/zonos2/__init__.py
+++ b/sglang_omni/models/zonos2/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ZONOS2 TTS model integration package."""

--- a/sglang_omni/models/zonos2/config.py
+++ b/sglang_omni/models/zonos2/config.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pipeline configuration for Zyphra ZONOS2 TTS."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from sglang_omni.config import PipelineConfig, StageConfig
+
+_PKG = "sglang_omni.models.zonos2"
+
+
+class ZONOS2PipelineConfig(PipelineConfig):
+    """4-stage ZONOS2 pipeline skeleton.
+
+    The integration is intentionally limited to configuration and registration.
+    Runtime stage factories raise a clear ``NotImplementedError`` until the
+    ZONOS2 text frontend, speaker conditioning, multi-codebook MoE decode, and
+    DAC vocoder are ported from the reference implementation.
+    """
+
+    architecture: ClassVar[str] = "Zonos2ForConditionalGeneration"
+    architecture_aliases: ClassVar[tuple[str, ...]] = (
+        "ZONOS2ForConditionalGeneration",
+        "Zonos2TTSForConditionalGeneration",
+    )
+
+    model_path: str
+    entry_stage: str = "text_frontend"
+    stages: list[StageConfig] = [
+        StageConfig(
+            name="text_frontend",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_text_frontend_executor",
+            next="speaker_embedding",
+        ),
+        StageConfig(
+            name="speaker_embedding",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_speaker_embedding_executor",
+            next="tts_engine",
+        ),
+        StageConfig(
+            name="tts_engine",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_sglang_tts_engine_executor",
+            factory_args={"gpu_id": 0, "dtype": "bfloat16"},
+            gpu=0,
+            next="vocoder",
+        ),
+        StageConfig(
+            name="vocoder",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_dac_vocoder_executor",
+            factory_args={"gpu_id": 0, "dtype": "bfloat16"},
+            gpu=0,
+            terminal=True,
+        ),
+    ]
+
+
+EntryClass = ZONOS2PipelineConfig

--- a/sglang_omni/models/zonos2/payload_types.py
+++ b/sglang_omni/models/zonos2/payload_types.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ZONOS2 TTS pipeline state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ZONOS2State:
+    """Per-request state placeholder for ZONOS2 generation."""
+
+    text: str = ""
+    language: str = "auto"
+    voice: str | None = None
+    ref_audio: Any | None = None
+    ref_text: str | None = None
+    generation_kwargs: dict[str, Any] = field(default_factory=dict)
+    frame_width: int = 9
+    codebook_size: int = 1024
+    sample_rate: int = 44100
+    audio_codes: Any | None = None
+    audio_samples: Any | None = None
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    engine_time_s: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "text": self.text,
+            "language": self.language,
+            "generation_kwargs": dict(self.generation_kwargs),
+            "frame_width": self.frame_width,
+            "codebook_size": self.codebook_size,
+            "sample_rate": self.sample_rate,
+        }
+        if self.voice is not None:
+            data["voice"] = self.voice
+        if self.ref_audio is not None:
+            data["ref_audio"] = self.ref_audio
+        if self.ref_text is not None:
+            data["ref_text"] = self.ref_text
+        if self.audio_codes is not None:
+            data["audio_codes"] = self.audio_codes
+        if self.audio_samples is not None:
+            data["audio_samples"] = self.audio_samples
+        if self.prompt_tokens:
+            data["prompt_tokens"] = self.prompt_tokens
+        if self.completion_tokens:
+            data["completion_tokens"] = self.completion_tokens
+        if self.engine_time_s:
+            data["engine_time_s"] = self.engine_time_s
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Any) -> "ZONOS2State":
+        if not isinstance(data, dict):
+            data = {}
+        generation_kwargs = data.get("generation_kwargs")
+        return cls(
+            text=str(data.get("text", "")),
+            language=str(data.get("language") or "auto"),
+            voice=data.get("voice"),
+            ref_audio=data.get("ref_audio"),
+            ref_text=data.get("ref_text"),
+            generation_kwargs=(
+                dict(generation_kwargs) if isinstance(generation_kwargs, dict) else {}
+            ),
+            frame_width=int(data.get("frame_width", 9) or 9),
+            codebook_size=int(data.get("codebook_size", 1024) or 1024),
+            sample_rate=int(data.get("sample_rate", 44100) or 44100),
+            audio_codes=data.get("audio_codes"),
+            audio_samples=data.get("audio_samples"),
+            prompt_tokens=int(data.get("prompt_tokens", 0) or 0),
+            completion_tokens=int(data.get("completion_tokens", 0) or 0),
+            engine_time_s=float(data.get("engine_time_s", 0.0) or 0.0),
+        )

--- a/sglang_omni/models/zonos2/request_builders.py
+++ b/sglang_omni/models/zonos2/request_builders.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Request helpers for the ZONOS2 pipeline skeleton."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sglang_omni.models.zonos2.payload_types import ZONOS2State
+from sglang_omni.proto import StagePayload
+
+
+def build_zonos2_state_from_request(payload: StagePayload) -> ZONOS2State:
+    """Build placeholder ZONOS2 state from an OpenAI-compatible TTS request."""
+    request = payload.request
+    extra_body: dict[str, Any] = getattr(request, "extra_body", None) or {}
+    references = (
+        getattr(request, "references", None) or extra_body.get("references") or []
+    )
+    ref_audio = getattr(request, "ref_audio", None) or extra_body.get("ref_audio")
+    ref_text = getattr(request, "ref_text", None) or extra_body.get("ref_text")
+    if references and isinstance(references, list):
+        first_reference = references[0]
+        if isinstance(first_reference, dict):
+            ref_audio = ref_audio or first_reference.get("audio_path")
+            ref_text = ref_text or first_reference.get("text")
+
+    generation_kwargs = extra_body.get("generation_kwargs")
+    return ZONOS2State(
+        text=str(getattr(request, "input", "") or ""),
+        language=str(extra_body.get("language") or "auto"),
+        voice=getattr(request, "voice", None) or extra_body.get("voice"),
+        ref_audio=ref_audio,
+        ref_text=ref_text,
+        generation_kwargs=(
+            dict(generation_kwargs) if isinstance(generation_kwargs, dict) else {}
+        ),
+    )

--- a/sglang_omni/models/zonos2/stages.py
+++ b/sglang_omni/models/zonos2/stages.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stage factories for the Zyphra ZONOS2 TTS pipeline skeleton."""
+
+from __future__ import annotations
+
+_ZONOS2_NOT_IMPLEMENTED = (
+    "ZONOS2 runtime support is not implemented yet. This package currently "
+    "registers the pipeline shape for issue #775; the text frontend, speaker "
+    "conditioning, multi-codebook MoE decode, and DAC vocoder still need to be "
+    "ported before serving Zyphra/ZONOS2."
+)
+
+
+def _raise_not_implemented(*args, **kwargs):
+    raise NotImplementedError(_ZONOS2_NOT_IMPLEMENTED)
+
+
+def create_text_frontend_executor(*args, **kwargs):
+    """Create the ZONOS2 text normalization/tokenization stage."""
+    return _raise_not_implemented(*args, **kwargs)
+
+
+def create_speaker_embedding_executor(*args, **kwargs):
+    """Create the ZONOS2 speaker/reference conditioning stage."""
+    return _raise_not_implemented(*args, **kwargs)
+
+
+def create_sglang_tts_engine_executor(*args, **kwargs):
+    """Create the ZONOS2 multi-codebook MoE decode stage."""
+    return _raise_not_implemented(*args, **kwargs)
+
+
+def create_dac_vocoder_executor(*args, **kwargs):
+    """Create the ZONOS2 DAC vocoder stage."""
+    return _raise_not_implemented(*args, **kwargs)

--- a/tests/unit_test/zonos2/__init__.py
+++ b/tests/unit_test/zonos2/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/unit_test/zonos2/test_pipeline.py
+++ b/tests/unit_test/zonos2/test_pipeline.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from sglang_omni.config.manager import ConfigManager
+from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+from sglang_omni.models.zonos2.config import ZONOS2PipelineConfig
+from sglang_omni.models.zonos2.payload_types import ZONOS2State
+from sglang_omni.models.zonos2.stages import create_sglang_tts_engine_executor
+
+
+def test_zonos2_config_is_registered():
+    assert (
+        PIPELINE_CONFIG_REGISTRY.get_config("Zonos2ForConditionalGeneration")
+        is ZONOS2PipelineConfig
+    )
+    assert (
+        PIPELINE_CONFIG_REGISTRY.get_config("ZONOS2ForConditionalGeneration")
+        is ZONOS2PipelineConfig
+    )
+
+
+def test_zonos2_pipeline_shape():
+    config = ZONOS2PipelineConfig(model_path="Zyphra/ZONOS2")
+
+    assert config.entry_stage == "text_frontend"
+    assert [stage.name for stage in config.stages] == [
+        "text_frontend",
+        "speaker_embedding",
+        "tts_engine",
+        "vocoder",
+    ]
+    assert config.stages[0].next == "speaker_embedding"
+    assert config.stages[1].next == "tts_engine"
+    assert config.stages[2].next == "vocoder"
+    assert config.stages[3].terminal is True
+
+
+def test_zonos2_example_config_loads():
+    manager = ConfigManager.from_file("examples/configs/zonos2.yaml")
+
+    assert isinstance(manager.config, ZONOS2PipelineConfig)
+    assert manager.config.model_path == "Zyphra/ZONOS2"
+
+
+def test_zonos2_state_round_trip_defaults():
+    state = ZONOS2State(text="hello", ref_audio="speaker.wav", ref_text="hi")
+
+    restored = ZONOS2State.from_dict(state.to_dict())
+
+    assert restored.text == "hello"
+    assert restored.ref_audio == "speaker.wav"
+    assert restored.ref_text == "hi"
+    assert restored.frame_width == 9
+    assert restored.codebook_size == 1024
+    assert restored.sample_rate == 44100
+
+
+def test_zonos2_runtime_factories_are_explicitly_unimplemented():
+    with pytest.raises(NotImplementedError, match="ZONOS2 runtime support"):
+        create_sglang_tts_engine_executor()


### PR DESCRIPTION
## Motivation

Zyphra ZONOS2 is tracked in #775 as a candidate TTS MoE model for SGLang Omni. This PR adds the initial integration skeleton so the model has a registered pipeline shape and development entry points before the runtime implementation is ported.

## Modifications

- Add `sglang_omni.models.zonos2` package.
- Add `ZONOS2PipelineConfig` with a 4-stage pipeline:
  - `text_frontend`
  - `speaker_embedding`
  - `tts_engine`
  - `vocoder`
- Register ZONOS2 architecture aliases through the existing pipeline config registry.
- Add placeholder runtime stage factories that explicitly raise `NotImplementedError`.
- Add placeholder `ZONOS2State` and request helper for future OpenAI-compatible TTS request handling.
- Add `examples/configs/zonos2.yaml`.
- Update TTS usage docs to list ZONOS2 as an integration skeleton, not a runnable serving backend yet.
- Add lightweight unit tests for config registration, pipeline shape, example config loading, state round-trip defaults, and explicit unimplemented runtime behavior.

## Related Issues

Related to #775

## Accuracy Test

Not applicable. This PR only adds the ZONOS2 configuration/registration skeleton and does not implement model-side execution, kernels, architecture inference, vocoder output, or accuracy-affecting logic.

## Benchmark & Profiling

Not applicable. This PR does not enable runtime serving and is not expected to affect throughput or latency.

## Checklist

- [ ] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.