### PR TITLE
[Perf] Increase MOSS-TTS Local reference audio cache capacity

### DIFF
--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -21,7 +21,7 @@ def _stages(*, codec_device: str) -> list[StageConfig]:
             factory_args={
                 "device": codec_device,
                 "ref_audio_cache": True,
-                "ref_audio_cache_max_items": 256,
+                "ref_audio_cache_max_items": 1024,
                 "ref_audio_cache_max_bytes": 64 * 1024 * 1024,
             },
             gpu=0,

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -407,7 +407,7 @@ def create_preprocessing_executor(
     encode_batch_size: int = 8,
     encode_batch_wait_ms: int = 4,
     ref_audio_cache: bool = True,
-    ref_audio_cache_max_items: int = 256,
+    ref_audio_cache_max_items: int = 1024,
     ref_audio_cache_max_bytes: int = 64 * 1024 * 1024,
 ) -> SimpleScheduler:
     # MOSS_REF_AUDIO_CACHE=0 disables the cache at startup (ops kill switch / A-B

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -175,6 +175,7 @@ def test_pipeline_stage_wiring():
     assert stages["preprocessing"].process == "pipeline"
     assert stages["preprocessing"].gpu == 0
     assert stages["preprocessing"].factory_args["device"] == "cuda:1"
+    assert stages["preprocessing"].factory_args["ref_audio_cache_max_items"] == 1024
     assert stages["tts_engine"].process == "pipeline"
     assert stages["tts_engine"].gpu == 0
     assert stages["vocoder"].process == "pipeline"
@@ -191,6 +192,10 @@ def test_pipeline_stage_wiring():
     )
     colocated_stages = {stage.name: stage for stage in colocated.stages}
     assert colocated_stages["preprocessing"].factory_args["device"] == "cuda:0"
+    assert (
+        colocated_stages["preprocessing"].factory_args["ref_audio_cache_max_items"]
+        == 1024
+    )
     assert colocated_stages["vocoder"].factory_args["device"] == "cuda:0"
 
 

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -325,6 +325,7 @@ def test_create_preprocessing_executor_env_toggle(monkeypatch):
     assert isinstance(
         rb._PREPROCESSING_CONTEXT.reference_encoder, stages.CachedReferenceEncoder
     )
+    assert rb._PREPROCESSING_CONTEXT.reference_encoder._cache.max_size == 1024
 
 
 def test_preprocess_and_result_adapter():


### PR DESCRIPTION

## Motivation

MOSS-TTS Local voice-cloning workloads can reuse the same reference audio many times across a benchmark or serving session. The current default `ref_audio_cache_max_items=256` is relatively small for the SeedTTS EN evaluation shape used here, which has 1088 requests and 666 unique reference audio files.

In the cache-only ablation on `main`, the 256-entry cache reached its item cap and continued evicting/re-encoding references. Raising the item cap to 1024 lets the cache hold all 666 unique references from this workload while keeping the existing `ref_audio_cache_max_bytes=64 MiB` limit unchanged.

## Modifications

1. `sglang_omni/models/moss_tts_local/config.py`
   - Raises the MOSS-TTS Local pipeline config default `ref_audio_cache_max_items` from `256` to `1024`.
   - Applies to both the default two-GPU config and the colocated config because both are built through `_stages(...)`.
   - Leaves `ref_audio_cache_max_bytes` unchanged at `64 * 1024 * 1024`.
   - Does not change the cache implementation, request path, env toggle, or explicit user overrides.

2. `tests/unit_test/moss_tts_local/test_pipeline.py`
   - Updates stage wiring coverage to assert that the default and colocated MOSS-TTS Local configs pass `ref_audio_cache_max_items=1024` to preprocessing.

## Related Issues

N/A

## Accuracy Test

**Setup:**

- Compared refs:
  - baseline: `main @ e94045e` with `ref_audio_cache_max_items=256`
  - intermediate: `main @ e94045e` with runtime override `stages.0.factory_args.ref_audio_cache_max_items=512`
  - candidate: `main @ e94045e` with runtime override `stages.0.factory_args.ref_audio_cache_max_items=1024`, equivalent to the proposed config default
- Model: `OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5`
- Config: `examples/configs/moss_tts_local.yaml`
- Dataset/eval: `zhaochenyang20/seed-tts-eval-arrow`, `lang=en`, 1088 samples / 666 unique audio files, `--ref-format references`, `--token-count auto`
- Hardware: `CUDA_VISIBLE_DEVICES=0,1`, 2x NVIDIA H100 80GB HBM3
- Topology: AR engine on logical `cuda:0`; codec/reference preprocessing and vocoder on logical `cuda:1`
- Concurrencies: `1` and `16`
- Quality eval: WER with `Qwen/Qwen3-ASR-1.7B`, ASR concurrency `32`, plus speaker similarity

All rows completed `1088/1088` TTS requests with zero failed requests. Quality evaluation completed for all cache settings at both concurrencies.

| concurrency | metric | cache=256 | cache=512 | cache=1024 |
| ---: | --- | ---: | ---: | ---: |
| 1 | WER corpus | 2.227% | 2.018% | 2.277% |
| 1 | speaker similarity | 64.997 | 65.287 | 65.316 |
| 16 | WER corpus | 2.361% | 2.738% | 2.738% |
| 16 | speaker similarity | 64.974 | 65.718 | 65.512 |

## Benchmark & Profiling

Same setup as described in the _Accuracy Test_ section. 

#### Concurrency 1

| Metric | cache=256 | cache=512 | 512 vs 256 | cache=1024 | 1024 vs 256 |
| --- | ---: | ---: | ---: | ---: | ---: |
| Samples | 1088 / 1088 | 1088 / 1088 | same | 1088 / 1088 | same |
| Failed | 0 | 0 | 0 | 0 | 0 |
| Throughput | 1.347 req/s | 1.320 req/s | -2.0% | 1.327 req/s | -1.5% |
| RTF mean | 0.1717 | 0.1751 | +2.0% | 0.1741 | +1.4% |
| RTF median | 0.1652 | 0.1702 | +3.0% | 0.1692 | +2.4% |
| RTF p95 | 0.2219 | 0.2133 | -3.9% | 0.2109 | -5.0% |
| RTF p99 | 0.2911 | 0.2805 | -3.6% | 0.2775 | -4.7% |
| Latency mean | 0.742 s | 0.758 s | +2.2% | 0.753 s | +1.5% |
| Latency median | 0.729 s | 0.750 s | +2.9% | 0.744 s | +2.1% |
| Latency p95 | 1.046 s | 1.038 s | -0.8% | 1.033 s | -1.2% |
| Latency p99 | 1.277 s | 1.237 s | -3.1% | 1.242 s | -2.7% |

#### Concurrency 16

| Metric | cache=256 | cache=512 | 512 vs 256 | cache=1024 | 1024 vs 256 |
| --- | ---: | ---: | ---: | ---: | ---: |
| Samples | 1088 / 1088 | 1088 / 1088 | same | 1088 / 1088 | same |
| Failed | 0 | 0 | 0 | 0 | 0 |
| Throughput | 6.777 req/s | 7.040 req/s | +3.9% | 8.946 req/s | +32.0% |
| RTF mean | 0.5644 | 0.5419 | -4.0% | 0.4224 | -25.2% |
| RTF median | 0.5316 | 0.5138 | -3.3% | 0.4034 | -24.1% |
| RTF p95 | 0.8377 | 0.7946 | -5.1% | 0.6000 | -28.4% |
| RTF p99 | 0.9657 | 0.8827 | -8.6% | 0.6554 | -32.1% |
| Latency mean | 2.350 s | 2.263 s | -3.7% | 1.778 s | -24.3% |
| Latency median | 2.343 s | 2.253 s | -3.8% | 1.766 s | -24.6% |
| Latency p95 | 2.808 s | 2.657 s | -5.4% | 2.162 s | -23.0% |
| Latency p99 | 3.091 s | 2.901 s | -6.1% | 2.471 s | -20.1% |

### Summary:

- At `c=16`, raising the cache item cap from 256 to 512 gives only a small QPS gain (`6.777 -> 7.040`, `+3.9%`) because 512 entries still cannot hold the 666 unique references in this workload.
- At `c=16`, raising the cap to 1024 improves global throughput from `6.777` to `8.946` QPS (`+32.0%`), while mean latency drops from `2.350s` to `1.778s` (`-24.3%`) and p95 latency drops from `2.808s` to `2.162s` (`-23.0%`).
- At `c=1`, throughput is effectively flat to slightly noisy across cache sizes: `1.347` QPS at 256, `1.320` QPS at 512, and `1.327` QPS at 1024.
- Cache logs explain the high-concurrency gain: the 256-entry run capped at `entries=256` and ended near `hits=609 misses=1234 merged=178`; the 512-entry run capped at `entries=512` and ended near `hits=598 misses=1193 merged=159`; the 1024-entry run held all 666 unique references and ended near `hits=1018 misses=666 entries=666`.
- The 512-entry cache used about `1.43 MiB`, and the 1024-entry cache used about `1.85 MiB` for this benchmark's cached reference entries, both well below the unchanged `64 MiB` byte cap.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Draft PRs are skipped even if labeled.
