### PR TITLE
docs(moss-tts): document MOSS-TTS-Local variant in cookbook

### DIFF
--- a/docs/cookbook/moss_tts.md
+++ b/docs/cookbook/moss_tts.md
@@ -9,21 +9,40 @@ duration control, and the vocoder reconstructs 24 kHz speech. In SGLang-Omni it 
 `preprocessing → tts_engine → vocoder` pipeline and is served through the OpenAI-compatible
 `/v1/audio/speech` endpoint.
 
+SGLang-Omni serves two MOSS-TTS checkpoints:
+
+- **`MOSS-TTS-v1.5`** (default) — the delay-pattern model described above; a single-GPU
+  `preprocessing → tts_engine → vocoder` pipeline.
+- **`MOSS-TTS-Local-Transformer-v1.5`** — the "Local" variant, which pairs the Qwen3 backbone
+  with a local frame transformer and the `MOSS-Audio-Tokenizer-v2` codec (reconstructing **48 kHz**
+  speech). Its pipeline defaults to **two GPUs** (the ~1B-param codec runs on a second device so
+  it does not starve the AR engine). It exposes the same `/v1/audio/speech` request shape and
+  generation parameters as the delay model, so the synthesis examples below apply to both.
+
 ## Prerequisites
 
 Install `sglang-omni` by following [Installation](../get_started/installation.md), then
-download the model (public, no token required):
+download the checkpoint for the variant you want (both are public, no token required):
 
 ```bash
+# Delay model (single GPU)
 hf download OpenMOSS-Team/MOSS-TTS-v1.5
+
+# Local variant (defaults to two GPUs)
+hf download OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5
 ```
 
-The processor ships with the checkpoint, so no extra TTS package is needed. Decoding base64
-(data-URI) reference audio additionally requires `soundfile` (`uv pip install soundfile`).
+The processor ships with each checkpoint, so no extra TTS package is needed. The Local variant
+loads its codec (`OpenMOSS-Team/MOSS-Audio-Tokenizer-v2`) through the checkpoint's remote code,
+so launch it with `trust_remote_code` enabled. Decoding base64 (data-URI) reference audio
+additionally requires `soundfile` (`uv pip install soundfile`).
 
 ## Server Configuration
 
-The pipeline is `preprocessing → tts_engine → vocoder`.
+Both variants serve the same `preprocessing → tts_engine → vocoder` pipeline; pick the config
+that matches the checkpoint.
+
+### MOSS-TTS-v1.5 (delay model, single GPU)
 
 ```bash
 sgl-omni serve \
@@ -31,6 +50,22 @@ sgl-omni serve \
   --config examples/configs/moss_tts.yaml \
   --port 8000
 ```
+
+### MOSS-TTS-Local-Transformer-v1.5 (two GPUs)
+
+The Local config places the AR engine on `cuda:0` and the codec on `cuda:1`, so launch it on a
+host with at least two visible GPUs:
+
+```bash
+sgl-omni serve \
+  --model-path OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5 \
+  --config examples/configs/moss_tts_local.yaml \
+  --port 8000
+```
+
+To run the Local variant on a single GPU, colocate the codec with the AR engine by setting
+`config_cls: MossTTSLocalColocatedPipelineConfig` in a copy of `moss_tts_local.yaml` (this packs
+the codec and AR engine onto `cuda:0`, at the cost of throughput under concurrency).
 
 ## Synthesizing Speech
 


### PR DESCRIPTION
## Summary

Adds the **MOSS-TTS-Local-Transformer-v1.5** variant to the MOSS-TTS cookbook (`docs/cookbook/moss_tts.md`), which previously only documented the delay model (`MOSS-TTS-v1.5`).

### Prerequisites
- Distinguishes the two checkpoints (single-GPU delay model vs. two-GPU Local variant).
- Adds the `hf download OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5` command.
- Notes the codec (`MOSS-Audio-Tokenizer-v2`, 48 kHz output) is loaded via the checkpoint's remote code, so `trust_remote_code` must be enabled.

### Server Configuration
- Splits into two subsections, one per checkpoint.
- Documents the Local launch with `examples/configs/moss_tts_local.yaml` and its **two-GPU** default (AR engine on `cuda:0`, codec on `cuda:1`).
- Notes the single-GPU option via `config_cls: MossTTSLocalColocatedPipelineConfig`.

The request shape and generation parameters are identical to the delay model, so the existing synthesis examples apply to both variants. Note the output sample rate differs (Local 48 kHz vs. delay 24 kHz).

### Verified against the codebase
- Architecture (36-layer Qwen3 backbone + 1-layer frame-local transformer): `sglang_omni/models/moss_tts_local/sglang_model.py`.
- Two-GPU default (`codec_device="cuda:1"`) vs. colocated (`codec_device="cuda:0"`): `sglang_omni/models/moss_tts_local/config.py`.
- `config_cls: MossTTSLocalColocatedPipelineConfig` resolves via the `Variants` lookup in `sglang_omni/models/registry.py` (`get_config_cls_by_name`).
- 48 kHz output: `sglang_omni/models/moss_tts_local/payload_types.py` (`sample_rate = 48000`).