### PR TITLE
perf(serve): gate thinker custom all-reduce on P2P/NVLink topology

### DIFF
--- a/examples/run_qwen3_omni_speech_server.py
+++ b/examples/run_qwen3_omni_speech_server.py
@@ -254,7 +254,7 @@ def _launch_speech_server(args: argparse.Namespace) -> None:
         Qwen3OmniSpeechPipelineConfig,
     )
     from sglang_omni.serve import launch_server
-    from sglang_omni.utils.gpu_compat import should_disable_thinker_custom_all_reduce
+    from sglang_omni.utils.gpu_compat import should_disable_custom_all_reduce_for_gpus
 
     for flag_name, value in (
         ("--mem-fraction-static", args.mem_fraction_static),
@@ -352,7 +352,7 @@ def _launch_speech_server(args: argparse.Namespace) -> None:
             config,
             stage_name="thinker",
             server_arg_updates={
-                "disable_custom_all_reduce": should_disable_thinker_custom_all_reduce(
+                "disable_custom_all_reduce": should_disable_custom_all_reduce_for_gpus(
                     thinker_gpu_ids
                 ),
             },

--- a/examples/run_qwen3_omni_speech_server.py
+++ b/examples/run_qwen3_omni_speech_server.py
@@ -254,6 +254,7 @@ def _launch_speech_server(args: argparse.Namespace) -> None:
         Qwen3OmniSpeechPipelineConfig,
     )
     from sglang_omni.serve import launch_server
+    from sglang_omni.utils.gpu_compat import should_disable_thinker_custom_all_reduce
 
     for flag_name, value in (
         ("--mem-fraction-static", args.mem_fraction_static),
@@ -350,7 +351,11 @@ def _launch_speech_server(args: argparse.Namespace) -> None:
         _apply_stage_factory_updates(
             config,
             stage_name="thinker",
-            server_arg_updates={"disable_custom_all_reduce": True},
+            server_arg_updates={
+                "disable_custom_all_reduce": should_disable_thinker_custom_all_reduce(
+                    thinker_gpu_ids
+                ),
+            },
         )
     else:
         if args.gpu_thinker_tp is not None:

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -12,6 +12,7 @@ from sglang_omni.preprocessing.resource_connector import (
     resolve_allowed_local_media_path,
 )
 from sglang_omni.serve.protocol import DEFAULT_TTS_BATCH_MAX_ITEMS
+from sglang_omni.utils.gpu_compat import should_disable_thinker_custom_all_reduce
 
 logger = logging.getLogger(__name__)
 
@@ -479,6 +480,40 @@ def _validate_colocated_gpu_override(
         )
 
 
+def _stage_tp_gpu_ids(stage: object) -> list[int]:
+    gpu = getattr(stage, "gpu", None)
+    if gpu is None:
+        return []
+    if isinstance(gpu, int):
+        return [gpu]
+    return [int(g) for g in gpu]
+
+
+def _gate_custom_all_reduce_on_topology(
+    stage: object,
+    updates: dict[str, object],
+) -> dict[str, object]:
+    """Relax a TP ``disable_custom_all_reduce=True`` override on capable topologies.
+
+    The config-level overrides disable custom all-reduce for every TP thinker.
+    Custom (P2P/NVLink) all-reduce is faster than NCCL and safe when the TP GPUs
+    form a P2P mesh, so re-enable it in that case; otherwise keep it disabled.
+    """
+    if updates.get("disable_custom_all_reduce") is not True:
+        return updates
+    gpu_ids = _stage_tp_gpu_ids(stage)
+    if should_disable_thinker_custom_all_reduce(gpu_ids):
+        return updates
+    refined = dict(updates)
+    refined["disable_custom_all_reduce"] = False
+    logger.info(
+        "Enabling custom all-reduce for stage '%s': GPUs %s form a P2P mesh",
+        getattr(stage, "name", "?"),
+        gpu_ids,
+    )
+    return refined
+
+
 def _apply_tensor_parallel_server_args_overrides(
     pipeline_config: PipelineConfig,
 ) -> None:
@@ -490,6 +525,7 @@ def _apply_tensor_parallel_server_args_overrides(
         )
         if not updates:
             continue
+        updates = _gate_custom_all_reduce_on_topology(stage, updates)
         _apply_stage_server_args_override(
             pipeline_config,
             stage_name=stage.name,

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -12,7 +12,7 @@ from sglang_omni.preprocessing.resource_connector import (
     resolve_allowed_local_media_path,
 )
 from sglang_omni.serve.protocol import DEFAULT_TTS_BATCH_MAX_ITEMS
-from sglang_omni.utils.gpu_compat import should_disable_thinker_custom_all_reduce
+from sglang_omni.utils.gpu_compat import should_disable_custom_all_reduce_for_gpus
 
 logger = logging.getLogger(__name__)
 
@@ -493,32 +493,26 @@ def _gate_custom_all_reduce_on_topology(
     stage: object,
     updates: dict[str, object],
     *,
-    disable_custom_all_reduce: bool | None = None,
+    gpu_ids: tuple[int, ...],
+    should_disable: bool,
 ) -> dict[str, object]:
-    """Relax a TP ``disable_custom_all_reduce=True`` override on capable topologies.
+    """Relax a TP ``disable_custom_all_reduce=True`` override on a P2P-capable topology.
 
     The config-level overrides disable custom all-reduce for every TP thinker.
     Custom (P2P/NVLink) all-reduce is faster than NCCL and safe when the TP GPUs
-    form a P2P mesh, so re-enable it in that case; otherwise keep it disabled.
-    SGLang still performs its own communicator support checks during worker
-    startup before using the custom all-reduce path.
+    form a P2P mesh, so re-enable it when the caller's topology probe confirms one
+    (``should_disable`` is False); otherwise keep it disabled. SGLang still performs
+    its own communicator support checks during worker startup before using the
+    custom all-reduce path.
     """
-    if updates.get("disable_custom_all_reduce") is not True:
-        return updates
-    gpu_ids = _stage_tp_gpu_ids(stage)
-    should_disable = (
-        should_disable_thinker_custom_all_reduce(gpu_ids)
-        if disable_custom_all_reduce is None
-        else disable_custom_all_reduce
-    )
-    if should_disable:
+    if updates.get("disable_custom_all_reduce") is not True or should_disable:
         return updates
     refined = dict(updates)
     refined["disable_custom_all_reduce"] = False
     logger.info(
         "Enabling custom all-reduce for stage '%s': GPUs %s form a P2P mesh",
         getattr(stage, "name", "?"),
-        gpu_ids,
+        list(gpu_ids),
     )
     return refined
 
@@ -542,12 +536,13 @@ def _apply_tensor_parallel_server_args_overrides(
             gpu_ids = tuple(_stage_tp_gpu_ids(stage))
             if gpu_ids not in topology_gated_custom_ar_cache:
                 topology_gated_custom_ar_cache[gpu_ids] = (
-                    should_disable_thinker_custom_all_reduce(gpu_ids)
+                    should_disable_custom_all_reduce_for_gpus(gpu_ids)
                 )
             updates = _gate_custom_all_reduce_on_topology(
                 stage,
                 updates,
-                disable_custom_all_reduce=topology_gated_custom_ar_cache[gpu_ids],
+                gpu_ids=gpu_ids,
+                should_disable=topology_gated_custom_ar_cache[gpu_ids],
             )
         _apply_stage_server_args_override(
             pipeline_config,

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -492,6 +492,8 @@ def _stage_tp_gpu_ids(stage: object) -> list[int]:
 def _gate_custom_all_reduce_on_topology(
     stage: object,
     updates: dict[str, object],
+    *,
+    disable_custom_all_reduce: bool | None = None,
 ) -> dict[str, object]:
     """Relax a TP ``disable_custom_all_reduce=True`` override on capable topologies.
 
@@ -504,7 +506,12 @@ def _gate_custom_all_reduce_on_topology(
     if updates.get("disable_custom_all_reduce") is not True:
         return updates
     gpu_ids = _stage_tp_gpu_ids(stage)
-    if should_disable_thinker_custom_all_reduce(gpu_ids):
+    should_disable = (
+        should_disable_thinker_custom_all_reduce(gpu_ids)
+        if disable_custom_all_reduce is None
+        else disable_custom_all_reduce
+    )
+    if should_disable:
         return updates
     refined = dict(updates)
     refined["disable_custom_all_reduce"] = False
@@ -523,6 +530,7 @@ def _apply_tensor_parallel_server_args_overrides(
     topology_gated_custom_ar_stages = (
         config_cls.topology_gated_custom_all_reduce_stages()
     )
+    topology_gated_custom_ar_cache: dict[tuple[int, ...], bool] = {}
     for stage in pipeline_config.stages:
         updates = config_cls.tensor_parallel_server_args_overrides(
             stage_name=stage.name,
@@ -531,7 +539,16 @@ def _apply_tensor_parallel_server_args_overrides(
         if not updates:
             continue
         if stage.name in topology_gated_custom_ar_stages:
-            updates = _gate_custom_all_reduce_on_topology(stage, updates)
+            gpu_ids = tuple(_stage_tp_gpu_ids(stage))
+            if gpu_ids not in topology_gated_custom_ar_cache:
+                topology_gated_custom_ar_cache[gpu_ids] = (
+                    should_disable_thinker_custom_all_reduce(gpu_ids)
+                )
+            updates = _gate_custom_all_reduce_on_topology(
+                stage,
+                updates,
+                disable_custom_all_reduce=topology_gated_custom_ar_cache[gpu_ids],
+            )
         _apply_stage_server_args_override(
             pipeline_config,
             stage_name=stage.name,

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -498,6 +498,8 @@ def _gate_custom_all_reduce_on_topology(
     The config-level overrides disable custom all-reduce for every TP thinker.
     Custom (P2P/NVLink) all-reduce is faster than NCCL and safe when the TP GPUs
     form a P2P mesh, so re-enable it in that case; otherwise keep it disabled.
+    SGLang still performs its own communicator support checks during worker
+    startup before using the custom all-reduce path.
     """
     if updates.get("disable_custom_all_reduce") is not True:
         return updates
@@ -518,6 +520,9 @@ def _apply_tensor_parallel_server_args_overrides(
     pipeline_config: PipelineConfig,
 ) -> None:
     config_cls = type(pipeline_config)
+    topology_gated_custom_ar_stages = (
+        config_cls.topology_gated_custom_all_reduce_stages()
+    )
     for stage in pipeline_config.stages:
         updates = config_cls.tensor_parallel_server_args_overrides(
             stage_name=stage.name,
@@ -525,7 +530,8 @@ def _apply_tensor_parallel_server_args_overrides(
         )
         if not updates:
             continue
-        updates = _gate_custom_all_reduce_on_topology(stage, updates)
+        if stage.name in topology_gated_custom_ar_stages:
+            updates = _gate_custom_all_reduce_on_topology(stage, updates)
         _apply_stage_server_args_override(
             pipeline_config,
             stage_name=stage.name,

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -282,6 +282,11 @@ class PipelineConfig(BaseModel):
             return {"disable_custom_all_reduce": True}
         return {}
 
+    @classmethod
+    def topology_gated_custom_all_reduce_stages(cls) -> set[str]:
+        """Stages whose TP custom all-reduce disable is topology-relaxable."""
+        return set()
+
     def requires_uploaded_voice_for_named_voice(self) -> bool:
         """Return whether non-default TTS voice names must be uploaded voices."""
         return False

--- a/sglang_omni/models/ming_omni/config.py
+++ b/sglang_omni/models/ming_omni/config.py
@@ -223,6 +223,10 @@ class _MingOmniBasePipelineConfig(PipelineConfig):
     def mem_fraction_role_to_stage(cls) -> dict[str, str]:
         return {"thinker": THINKER_STAGE}
 
+    @classmethod
+    def topology_gated_custom_all_reduce_stages(cls) -> set[str]:
+        return {THINKER_STAGE}
+
 
 class MingOmniPipelineConfig(_MingOmniBasePipelineConfig):
     """6-stage text pipeline."""

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -260,6 +260,10 @@ class _Qwen3OmniBasePipelineConfig(PipelineConfig):
         default_factory=lambda: dict(_DEEPGEMM_PRECOMPILE_ENV_DEFAULTS)
     )
 
+    @classmethod
+    def topology_gated_custom_all_reduce_stages(cls) -> set[str]:
+        return {THINKER_STAGE}
+
 
 class Qwen3OmniPipelineConfig(_Qwen3OmniBasePipelineConfig):
     """6-stage text-only pipeline."""

--- a/sglang_omni/utils/gpu_compat.py
+++ b/sglang_omni/utils/gpu_compat.py
@@ -176,8 +176,9 @@ def gpu_ids_support_p2p_mesh(
         return None
     status_ok = getattr(pynvml, "NVML_P2P_STATUS_OK", 0)
     read_index = getattr(pynvml, "NVML_P2P_CAPS_INDEX_READ", 0)
-    # nvidia-ml-py 13.595.45 ships a stray trailing comma (`= 0,`), making this
-    # constant a 1-tuple; nvmlDeviceGetP2PStatus needs a plain int.
+    # note (luojiaxuan): nvidia-ml-py 13.595.45 ships a stray trailing comma
+    # note (luojiaxuan): (`= 0,`), making this constant a 1-tuple;
+    # note (luojiaxuan): nvmlDeviceGetP2PStatus needs a plain int.
     if isinstance(read_index, tuple):
         read_index = read_index[0]
 

--- a/sglang_omni/utils/gpu_compat.py
+++ b/sglang_omni/utils/gpu_compat.py
@@ -210,7 +210,7 @@ def gpu_ids_support_p2p_mesh(
         _shutdown_nvml(pynvml)
 
 
-def should_disable_thinker_custom_all_reduce(
+def should_disable_custom_all_reduce_for_gpus(
     logical_gpu_ids: Sequence[int] | None,
     env: Mapping[str, str] | None = None,
 ) -> bool:

--- a/sglang_omni/utils/gpu_compat.py
+++ b/sglang_omni/utils/gpu_compat.py
@@ -177,8 +177,8 @@ def gpu_ids_support_p2p_mesh(
     status_ok = getattr(pynvml, "NVML_P2P_STATUS_OK", 0)
     read_index = getattr(pynvml, "NVML_P2P_CAPS_INDEX_READ", 0)
     # note (luojiaxuan): nvidia-ml-py 13.595.45 ships a stray trailing comma
-    # note (luojiaxuan): (`= 0,`), making this constant a 1-tuple;
-    # note (luojiaxuan): nvmlDeviceGetP2PStatus needs a plain int.
+    # (`= 0,`), making this constant a 1-tuple;
+    # nvmlDeviceGetP2PStatus needs a plain int.
     if isinstance(read_index, tuple):
         read_index = read_index[0]
 

--- a/sglang_omni/utils/gpu_compat.py
+++ b/sglang_omni/utils/gpu_compat.py
@@ -176,7 +176,9 @@ def gpu_ids_support_p2p_mesh(
         return None
     status_ok = getattr(pynvml, "NVML_P2P_STATUS_OK", 0)
     read_index = getattr(pynvml, "NVML_P2P_CAPS_INDEX_READ", 0)
-    if isinstance(read_index, tuple):  # some pynvml builds expose this as (0,)
+    # nvidia-ml-py 13.595.45 ships a stray trailing comma (`= 0,`), making this
+    # constant a 1-tuple; nvmlDeviceGetP2PStatus needs a plain int.
+    if isinstance(read_index, tuple):
         read_index = read_index[0]
 
     source_env = os.environ if env is None else env

--- a/sglang_omni/utils/gpu_compat.py
+++ b/sglang_omni/utils/gpu_compat.py
@@ -176,6 +176,8 @@ def gpu_ids_support_p2p_mesh(
         return None
     status_ok = getattr(pynvml, "NVML_P2P_STATUS_OK", 0)
     read_index = getattr(pynvml, "NVML_P2P_CAPS_INDEX_READ", 0)
+    if isinstance(read_index, tuple):  # some pynvml builds expose this as (0,)
+        read_index = read_index[0]
 
     source_env = os.environ if env is None else env
     visible_devices = parse_cuda_visible_devices(source_env.get("CUDA_VISIBLE_DEVICES"))
@@ -194,7 +196,12 @@ def gpu_ids_support_p2p_mesh(
                     return False
         return True
     except Exception as exc:
-        logger.debug("NVML P2P mesh query failed for gpus=%s: %s", ids, exc)
+        logger.warning(
+            "NVML P2P mesh query failed for gpus=%s: %s; "
+            "keeping custom all-reduce disabled",
+            ids,
+            exc,
+        )
         return None
     finally:
         _shutdown_nvml(pynvml)

--- a/sglang_omni/utils/gpu_compat.py
+++ b/sglang_omni/utils/gpu_compat.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import importlib
 import logging
 import os
-from collections.abc import Mapping, MutableMapping
+from collections.abc import Mapping, MutableMapping, Sequence
 
 from sglang_omni.utils.gpu_memory import (
     _get_device_handle,
@@ -146,3 +146,72 @@ def apply_gpu_compat_env_defaults(
         target_env[key] = value
         logger.info("Applied GPU compatibility env override: %s=%s", key, value)
     return overrides
+
+
+def gpu_ids_support_p2p_mesh(
+    logical_gpu_ids: Sequence[int],
+    env: Mapping[str, str] | None = None,
+) -> bool | None:
+    """Return whether the given logical GPUs form a full peer-to-peer mesh.
+
+    Custom (P2P/NVLink) all-reduce only works when every tensor-parallel rank can
+    directly access every other rank's memory. This queries NVML's pairwise P2P
+    status (so it does not create a CUDA context in the caller) for all ordered
+    pairs of the given logical GPU ids (resolved through ``CUDA_VISIBLE_DEVICES``).
+
+    Returns ``True`` only when every pair reports P2P-capable, ``False`` when any
+    pair is not, and ``None`` when the topology cannot be determined (pynvml
+    missing, NVML query error, or fewer than two distinct GPUs).
+    """
+    ids = list(dict.fromkeys(int(g) for g in logical_gpu_ids))
+    if len(ids) < 2:
+        return None
+
+    pynvml = _try_import_pynvml()
+    if pynvml is None:
+        return None
+
+    get_status = getattr(pynvml, "nvmlDeviceGetP2PStatus", None)
+    if get_status is None:
+        return None
+    status_ok = getattr(pynvml, "NVML_P2P_STATUS_OK", 0)
+    read_index = getattr(pynvml, "NVML_P2P_CAPS_INDEX_READ", 0)
+
+    source_env = os.environ if env is None else env
+    visible_devices = parse_cuda_visible_devices(source_env.get("CUDA_VISIBLE_DEVICES"))
+
+    try:
+        pynvml.nvmlInit()
+        handles = []
+        for logical_id in ids:
+            device_id = resolve_visible_device_id(logical_id, visible_devices)
+            handles.append(_get_device_handle(pynvml, device_id))
+        for i, handle_i in enumerate(handles):
+            for j, handle_j in enumerate(handles):
+                if i == j:
+                    continue
+                if get_status(handle_i, handle_j, read_index) != status_ok:
+                    return False
+        return True
+    except Exception as exc:
+        logger.debug("NVML P2P mesh query failed for gpus=%s: %s", ids, exc)
+        return None
+    finally:
+        _shutdown_nvml(pynvml)
+
+
+def should_disable_thinker_custom_all_reduce(
+    logical_gpu_ids: Sequence[int] | None,
+    env: Mapping[str, str] | None = None,
+) -> bool:
+    """Whether to disable SGLang custom all-reduce for a TP thinker.
+
+    Custom all-reduce requires a direct P2P mesh between the tensor-parallel GPUs;
+    on topologies without it (or that can't be confirmed) it must fall back to
+    NCCL. This returns ``True`` (disable) unless NVML confirms a full P2P mesh,
+    so the safe default is preserved and custom all-reduce is only enabled on
+    capable topologies (e.g. NVLink).
+    """
+    if not logical_gpu_ids:
+        return True
+    return gpu_ids_support_p2p_mesh(logical_gpu_ids, env) is not True

--- a/tests/unit_test/ming_omni/test_omni_serve.py
+++ b/tests/unit_test/ming_omni/test_omni_serve.py
@@ -209,6 +209,67 @@ def test_hard_custom_all_reduce_disable_is_not_topology_relaxed(
     )
 
 
+def test_topology_gated_custom_all_reduce_reuses_topology_decision(
+    monkeypatch,
+) -> None:
+    from sglang_omni.cli.serve import _apply_tensor_parallel_server_args_overrides
+
+    class TwoStageTopologyGatedConfig(PipelineConfig):
+        @classmethod
+        def tensor_parallel_server_args_overrides(
+            cls,
+            *,
+            stage_name: str,
+            tp_size: int,
+        ) -> dict[str, object]:
+            if stage_name in {"thinker", "encoder"} and tp_size > 1:
+                return {"disable_custom_all_reduce": True}
+            return {}
+
+        @classmethod
+        def topology_gated_custom_all_reduce_stages(cls) -> set[str]:
+            return {"thinker", "encoder"}
+
+    calls = []
+    monkeypatch.setattr(
+        "sglang_omni.cli.serve.should_disable_thinker_custom_all_reduce",
+        lambda gpu_ids: calls.append(tuple(gpu_ids)) or False,
+    )
+    config = TwoStageTopologyGatedConfig(
+        model_path="dummy",
+        stages=[
+            StageConfig(
+                name="thinker",
+                factory="tests.unit_test.fixtures.pipeline_fakes.dummy_factory",
+                gpu=[0, 1],
+                tp_size=2,
+                process="thinker",
+                terminal=True,
+            ),
+            StageConfig(
+                name="encoder",
+                factory="tests.unit_test.fixtures.pipeline_fakes.dummy_factory",
+                gpu=[0, 1],
+                tp_size=2,
+                process="encoder",
+                terminal=True,
+            ),
+        ],
+    )
+
+    _apply_tensor_parallel_server_args_overrides(config)
+
+    assert calls == [(0, 1)]
+    assert (
+        _server_args_overrides(config, "thinker")["disable_custom_all_reduce"]
+        is False
+    )
+    assert (
+        _server_args_overrides(config, "encoder")["disable_custom_all_reduce"]
+        is False
+    )
+
+
 def test_ming_cli_applies_image_encoder_tp_and_gpus() -> None:
     config = MingOmniPipelineConfig(model_path="dummy")
 

--- a/tests/unit_test/ming_omni/test_omni_serve.py
+++ b/tests/unit_test/ming_omni/test_omni_serve.py
@@ -122,7 +122,7 @@ def test_ming_text_variant_uses_text_image_pipeline(monkeypatch) -> None:
 
 def test_ming_cli_applies_tp_gpus_and_disable_custom_all_reduce(monkeypatch) -> None:
     monkeypatch.setattr(
-        "sglang_omni.cli.serve.should_disable_thinker_custom_all_reduce",
+        "sglang_omni.cli.serve.should_disable_custom_all_reduce_for_gpus",
         lambda *args, **kwargs: True,
     )
     config = MingOmniPipelineConfig(model_path="dummy")
@@ -145,7 +145,7 @@ def test_ming_cli_applies_tp_gpus_and_disable_custom_all_reduce(monkeypatch) -> 
 
 def test_ming_cli_enables_custom_all_reduce_on_p2p_mesh(monkeypatch) -> None:
     monkeypatch.setattr(
-        "sglang_omni.cli.serve.should_disable_thinker_custom_all_reduce",
+        "sglang_omni.cli.serve.should_disable_custom_all_reduce_for_gpus",
         lambda *args, **kwargs: False,
     )
     config = MingOmniPipelineConfig(model_path="dummy")
@@ -179,7 +179,7 @@ def test_hard_custom_all_reduce_disable_is_not_topology_relaxed(
             return {}
 
     monkeypatch.setattr(
-        "sglang_omni.cli.serve.should_disable_thinker_custom_all_reduce",
+        "sglang_omni.cli.serve.should_disable_custom_all_reduce_for_gpus",
         lambda *args, **kwargs: False,
     )
     config = HardDisableConfig(
@@ -232,7 +232,7 @@ def test_topology_gated_custom_all_reduce_reuses_topology_decision(
 
     calls = []
     monkeypatch.setattr(
-        "sglang_omni.cli.serve.should_disable_thinker_custom_all_reduce",
+        "sglang_omni.cli.serve.should_disable_custom_all_reduce_for_gpus",
         lambda gpu_ids: calls.append(tuple(gpu_ids)) or False,
     )
     config = TwoStageTopologyGatedConfig(

--- a/tests/unit_test/ming_omni/test_omni_serve.py
+++ b/tests/unit_test/ming_omni/test_omni_serve.py
@@ -120,7 +120,11 @@ def test_ming_text_variant_uses_text_image_pipeline(monkeypatch) -> None:
     assert config_manager.config.terminal_stages == ["decode"]
 
 
-def test_ming_cli_applies_tp_gpus_and_disable_custom_all_reduce() -> None:
+def test_ming_cli_applies_tp_gpus_and_disable_custom_all_reduce(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "sglang_omni.cli.serve.should_disable_thinker_custom_all_reduce",
+        lambda *args, **kwargs: True,
+    )
     config = MingOmniPipelineConfig(model_path="dummy")
 
     apply_parallelism_cli_overrides(
@@ -136,6 +140,26 @@ def test_ming_cli_applies_tp_gpus_and_disable_custom_all_reduce() -> None:
     assert thinker.gpu == [0, 1, 2, 3]
     assert (
         _server_args_overrides(config, "thinker")["disable_custom_all_reduce"] is True
+    )
+
+
+def test_ming_cli_enables_custom_all_reduce_on_p2p_mesh(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "sglang_omni.cli.serve.should_disable_thinker_custom_all_reduce",
+        lambda *args, **kwargs: False,
+    )
+    config = MingOmniPipelineConfig(model_path="dummy")
+
+    apply_parallelism_cli_overrides(
+        config,
+        thinker_tp_size=4,
+        thinker_gpus="0,1,2,3",
+        talker_gpu=None,
+        code2wav_gpu=None,
+    )
+
+    assert (
+        _server_args_overrides(config, "thinker")["disable_custom_all_reduce"] is False
     )
 
 

--- a/tests/unit_test/ming_omni/test_omni_serve.py
+++ b/tests/unit_test/ming_omni/test_omni_serve.py
@@ -336,7 +336,11 @@ def test_ming_cli_leaves_image_encoder_untouched_when_flags_omitted() -> None:
     assert image_encoder.gpu == before_gpu
 
 
-def test_ming_cli_applies_tp_server_args_for_config_mutated_tp() -> None:
+def test_ming_cli_applies_tp_server_args_for_config_mutated_tp(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "sglang_omni.cli.serve.should_disable_custom_all_reduce_for_gpus",
+        lambda *args, **kwargs: True,
+    )
     config = MingOmniPipelineConfig(model_path="dummy")
     thinker = _stage(config, "thinker")
     thinker.tp_size = 2
@@ -635,6 +639,11 @@ def test_registry_rejects_duplicate_architecture_aliases(tmp_path, monkeypatch) 
 
 
 def test_omni_serve_builds_ming_text_config_without_launching(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "sglang_omni.cli.serve.should_disable_custom_all_reduce_for_gpus",
+        lambda *args, **kwargs: True,
+    )
+
     from typer.testing import CliRunner
 
     from sglang_omni.cli import app
@@ -695,6 +704,11 @@ def test_omni_serve_builds_ming_text_config_without_launching(monkeypatch) -> No
 
 
 def test_omni_serve_builds_ming_speech_config_by_default(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "sglang_omni.cli.serve.should_disable_custom_all_reduce_for_gpus",
+        lambda *args, **kwargs: True,
+    )
+
     from typer.testing import CliRunner
 
     from sglang_omni.cli import app

--- a/tests/unit_test/ming_omni/test_omni_serve.py
+++ b/tests/unit_test/ming_omni/test_omni_serve.py
@@ -16,7 +16,7 @@ from sglang_omni.cli.serve import (
     apply_thinker_server_args_cli_overrides,
     apply_torch_compile_cli_overrides,
 )
-from sglang_omni.config import PipelineConfig
+from sglang_omni.config import PipelineConfig, StageConfig
 from sglang_omni.config.manager import ConfigManager
 from sglang_omni.models.ming_omni.config import (
     MingOmniPipelineConfig,
@@ -160,6 +160,52 @@ def test_ming_cli_enables_custom_all_reduce_on_p2p_mesh(monkeypatch) -> None:
 
     assert (
         _server_args_overrides(config, "thinker")["disable_custom_all_reduce"] is False
+    )
+
+
+def test_hard_custom_all_reduce_disable_is_not_topology_relaxed(
+    monkeypatch,
+) -> None:
+    class HardDisableConfig(PipelineConfig):
+        @classmethod
+        def tensor_parallel_server_args_overrides(
+            cls,
+            *,
+            stage_name: str,
+            tp_size: int,
+        ) -> dict[str, object]:
+            if stage_name == "thinker" and tp_size > 1:
+                return {"disable_custom_all_reduce": True}
+            return {}
+
+    monkeypatch.setattr(
+        "sglang_omni.cli.serve.should_disable_thinker_custom_all_reduce",
+        lambda *args, **kwargs: False,
+    )
+    config = HardDisableConfig(
+        model_path="dummy",
+        stages=[
+            StageConfig(
+                name="thinker",
+                factory="tests.unit_test.fixtures.pipeline_fakes.dummy_factory",
+                gpu=[0, 1],
+                tp_size=2,
+                process="thinker",
+                terminal=True,
+            )
+        ],
+    )
+
+    apply_parallelism_cli_overrides(
+        config,
+        thinker_tp_size=None,
+        thinker_gpus=None,
+        talker_gpu=None,
+        code2wav_gpu=None,
+    )
+
+    assert (
+        _server_args_overrides(config, "thinker")["disable_custom_all_reduce"] is True
     )
 
 

--- a/tests/unit_test/ming_omni/test_omni_serve.py
+++ b/tests/unit_test/ming_omni/test_omni_serve.py
@@ -261,12 +261,10 @@ def test_topology_gated_custom_all_reduce_reuses_topology_decision(
 
     assert calls == [(0, 1)]
     assert (
-        _server_args_overrides(config, "thinker")["disable_custom_all_reduce"]
-        is False
+        _server_args_overrides(config, "thinker")["disable_custom_all_reduce"] is False
     )
     assert (
-        _server_args_overrides(config, "encoder")["disable_custom_all_reduce"]
-        is False
+        _server_args_overrides(config, "encoder")["disable_custom_all_reduce"] is False
     )
 
 

--- a/tests/unit_test/pipeline/test_gpu_compat_custom_ar.py
+++ b/tests/unit_test/pipeline/test_gpu_compat_custom_ar.py
@@ -65,9 +65,7 @@ def test_should_disable_with_no_or_single_gpu(monkeypatch) -> None:
 def test_disabled_when_pynvml_unavailable(monkeypatch) -> None:
     _patch_pynvml(monkeypatch, None)
     assert gpu_compat.gpu_ids_support_p2p_mesh([0, 1], env={}) is None
-    assert (
-        gpu_compat.should_disable_thinker_custom_all_reduce([0, 1], env={}) is True
-    )
+    assert gpu_compat.should_disable_thinker_custom_all_reduce([0, 1], env={}) is True
 
 
 def test_enabled_on_full_p2p_mesh(monkeypatch) -> None:
@@ -101,6 +99,4 @@ def test_disabled_on_nvml_errors(monkeypatch) -> None:
 def test_disabled_when_p2p_status_api_missing(monkeypatch) -> None:
     _patch_pynvml(monkeypatch, _FakeP2PNVML(drop_status_fn=True))
     assert gpu_compat.gpu_ids_support_p2p_mesh([0, 1], env={}) is None
-    assert (
-        gpu_compat.should_disable_thinker_custom_all_reduce([0, 1], env={}) is True
-    )
+    assert gpu_compat.should_disable_thinker_custom_all_reduce([0, 1], env={}) is True

--- a/tests/unit_test/pipeline/test_gpu_compat_custom_ar.py
+++ b/tests/unit_test/pipeline/test_gpu_compat_custom_ar.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for topology-gated custom all-reduce detection in gpu_compat."""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+import sglang_omni.utils.gpu_compat as gpu_compat
+
+
+class _FakeP2PNVML(ModuleType):
+    """Minimal pynvml stub exposing only the P2P-status surface we query."""
+
+    NVML_P2P_STATUS_OK = 0
+    NVML_P2P_CAPS_INDEX_READ = 0
+
+    def __init__(
+        self,
+        *,
+        not_ok_pairs: set[tuple[int, int]] | None = None,
+        init_error: Exception | None = None,
+        query_error: Exception | None = None,
+        drop_status_fn: bool = False,
+    ) -> None:
+        super().__init__("pynvml")
+        self._not_ok_pairs = not_ok_pairs or set()
+        self._init_error = init_error
+        self._query_error = query_error
+        self.shutdown_called = False
+        if drop_status_fn:
+            # Simulate an old pynvml without the P2P-status API (instance attr
+            # shadows the class method so getattr(..., None) returns None).
+            self.nvmlDeviceGetP2PStatus = None
+
+    def nvmlInit(self) -> None:
+        if self._init_error is not None:
+            raise self._init_error
+
+    def nvmlShutdown(self) -> None:
+        self.shutdown_called = True
+
+    def nvmlDeviceGetHandleByIndex(self, device_id: int) -> int:
+        return device_id
+
+    def nvmlDeviceGetP2PStatus(self, handle_a: int, handle_b: int, _index: int) -> int:
+        if self._query_error is not None:
+            raise self._query_error
+        if (handle_a, handle_b) in self._not_ok_pairs:
+            return 1
+        return self.NVML_P2P_STATUS_OK
+
+
+def _patch_pynvml(monkeypatch, fake: ModuleType | None) -> None:
+    monkeypatch.setattr(gpu_compat, "_try_import_pynvml", lambda: fake)
+
+
+def test_should_disable_with_no_or_single_gpu(monkeypatch) -> None:
+    # NVML should never even be consulted for < 2 GPUs.
+    _patch_pynvml(monkeypatch, _FakeP2PNVML(not_ok_pairs={(0, 1)}))
+    assert gpu_compat.should_disable_thinker_custom_all_reduce(None, env={}) is True
+    assert gpu_compat.should_disable_thinker_custom_all_reduce([], env={}) is True
+    assert gpu_compat.should_disable_thinker_custom_all_reduce([0], env={}) is True
+
+
+def test_disabled_when_pynvml_unavailable(monkeypatch) -> None:
+    _patch_pynvml(monkeypatch, None)
+    assert gpu_compat.gpu_ids_support_p2p_mesh([0, 1], env={}) is None
+    assert (
+        gpu_compat.should_disable_thinker_custom_all_reduce([0, 1], env={}) is True
+    )
+
+
+def test_enabled_on_full_p2p_mesh(monkeypatch) -> None:
+    fake = _FakeP2PNVML()
+    _patch_pynvml(monkeypatch, fake)
+    assert gpu_compat.gpu_ids_support_p2p_mesh([0, 1, 2, 3], env={}) is True
+    assert (
+        gpu_compat.should_disable_thinker_custom_all_reduce([0, 1, 2, 3], env={})
+        is False
+    )
+    assert fake.shutdown_called is True
+
+
+def test_disabled_when_any_pair_lacks_p2p(monkeypatch) -> None:
+    _patch_pynvml(monkeypatch, _FakeP2PNVML(not_ok_pairs={(0, 3), (3, 0)}))
+    assert gpu_compat.gpu_ids_support_p2p_mesh([0, 1, 2, 3], env={}) is False
+    assert (
+        gpu_compat.should_disable_thinker_custom_all_reduce([0, 1, 2, 3], env={})
+        is True
+    )
+
+
+def test_disabled_on_nvml_errors(monkeypatch) -> None:
+    _patch_pynvml(monkeypatch, _FakeP2PNVML(init_error=RuntimeError("nvml init")))
+    assert gpu_compat.should_disable_thinker_custom_all_reduce([0, 1], env={}) is True
+
+    _patch_pynvml(monkeypatch, _FakeP2PNVML(query_error=RuntimeError("nvml query")))
+    assert gpu_compat.should_disable_thinker_custom_all_reduce([0, 1], env={}) is True
+
+
+def test_disabled_when_p2p_status_api_missing(monkeypatch) -> None:
+    _patch_pynvml(monkeypatch, _FakeP2PNVML(drop_status_fn=True))
+    assert gpu_compat.gpu_ids_support_p2p_mesh([0, 1], env={}) is None
+    assert (
+        gpu_compat.should_disable_thinker_custom_all_reduce([0, 1], env={}) is True
+    )

--- a/tests/unit_test/pipeline/test_gpu_compat_custom_ar.py
+++ b/tests/unit_test/pipeline/test_gpu_compat_custom_ar.py
@@ -54,15 +54,15 @@ def _patch_pynvml(monkeypatch, fake: ModuleType | None) -> None:
 
 def test_should_disable_with_no_or_single_gpu(monkeypatch) -> None:
     _patch_pynvml(monkeypatch, _FakeP2PNVML(not_ok_pairs={(0, 1)}))
-    assert gpu_compat.should_disable_thinker_custom_all_reduce(None, env={}) is True
-    assert gpu_compat.should_disable_thinker_custom_all_reduce([], env={}) is True
-    assert gpu_compat.should_disable_thinker_custom_all_reduce([0], env={}) is True
+    assert gpu_compat.should_disable_custom_all_reduce_for_gpus(None, env={}) is True
+    assert gpu_compat.should_disable_custom_all_reduce_for_gpus([], env={}) is True
+    assert gpu_compat.should_disable_custom_all_reduce_for_gpus([0], env={}) is True
 
 
 def test_disabled_when_pynvml_unavailable(monkeypatch) -> None:
     _patch_pynvml(monkeypatch, None)
     assert gpu_compat.gpu_ids_support_p2p_mesh([0, 1], env={}) is None
-    assert gpu_compat.should_disable_thinker_custom_all_reduce([0, 1], env={}) is True
+    assert gpu_compat.should_disable_custom_all_reduce_for_gpus([0, 1], env={}) is True
 
 
 def test_enabled_on_full_p2p_mesh(monkeypatch) -> None:
@@ -70,7 +70,7 @@ def test_enabled_on_full_p2p_mesh(monkeypatch) -> None:
     _patch_pynvml(monkeypatch, fake)
     assert gpu_compat.gpu_ids_support_p2p_mesh([0, 1, 2, 3], env={}) is True
     assert (
-        gpu_compat.should_disable_thinker_custom_all_reduce([0, 1, 2, 3], env={})
+        gpu_compat.should_disable_custom_all_reduce_for_gpus([0, 1, 2, 3], env={})
         is False
     )
     assert fake.shutdown_called is True
@@ -80,20 +80,20 @@ def test_disabled_when_any_pair_lacks_p2p(monkeypatch) -> None:
     _patch_pynvml(monkeypatch, _FakeP2PNVML(not_ok_pairs={(0, 3), (3, 0)}))
     assert gpu_compat.gpu_ids_support_p2p_mesh([0, 1, 2, 3], env={}) is False
     assert (
-        gpu_compat.should_disable_thinker_custom_all_reduce([0, 1, 2, 3], env={})
+        gpu_compat.should_disable_custom_all_reduce_for_gpus([0, 1, 2, 3], env={})
         is True
     )
 
 
 def test_disabled_on_nvml_errors(monkeypatch) -> None:
     _patch_pynvml(monkeypatch, _FakeP2PNVML(init_error=RuntimeError("nvml init")))
-    assert gpu_compat.should_disable_thinker_custom_all_reduce([0, 1], env={}) is True
+    assert gpu_compat.should_disable_custom_all_reduce_for_gpus([0, 1], env={}) is True
 
     _patch_pynvml(monkeypatch, _FakeP2PNVML(query_error=RuntimeError("nvml query")))
-    assert gpu_compat.should_disable_thinker_custom_all_reduce([0, 1], env={}) is True
+    assert gpu_compat.should_disable_custom_all_reduce_for_gpus([0, 1], env={}) is True
 
 
 def test_disabled_when_p2p_status_api_missing(monkeypatch) -> None:
     _patch_pynvml(monkeypatch, _FakeP2PNVML(drop_status_fn=True))
     assert gpu_compat.gpu_ids_support_p2p_mesh([0, 1], env={}) is None
-    assert gpu_compat.should_disable_thinker_custom_all_reduce([0, 1], env={}) is True
+    assert gpu_compat.should_disable_custom_all_reduce_for_gpus([0, 1], env={}) is True

--- a/tests/unit_test/pipeline/test_gpu_compat_custom_ar.py
+++ b/tests/unit_test/pipeline/test_gpu_compat_custom_ar.py
@@ -28,8 +28,6 @@ class _FakeP2PNVML(ModuleType):
         self._query_error = query_error
         self.shutdown_called = False
         if drop_status_fn:
-            # Simulate an old pynvml without the P2P-status API (instance attr
-            # shadows the class method so getattr(..., None) returns None).
             self.nvmlDeviceGetP2PStatus = None
 
     def nvmlInit(self) -> None:
@@ -55,7 +53,6 @@ def _patch_pynvml(monkeypatch, fake: ModuleType | None) -> None:
 
 
 def test_should_disable_with_no_or_single_gpu(monkeypatch) -> None:
-    # NVML should never even be consulted for < 2 GPUs.
     _patch_pynvml(monkeypatch, _FakeP2PNVML(not_ok_pairs={(0, 1)}))
     assert gpu_compat.should_disable_thinker_custom_all_reduce(None, env={}) is True
     assert gpu_compat.should_disable_thinker_custom_all_reduce([], env={}) is True

--- a/tests/unit_test/qwen3_omni/test_example_launcher.py
+++ b/tests/unit_test/qwen3_omni/test_example_launcher.py
@@ -97,7 +97,7 @@ def test_tp2_config_contract(mock_launch_server):
     """tp_size and parallelism.tp must stay in sync for TP=2."""
     args = _make_args(thinker_tp_size=2, gpu_thinker_tp="0,1")
     with patch(
-        "sglang_omni.utils.gpu_compat.should_disable_thinker_custom_all_reduce",
+        "sglang_omni.utils.gpu_compat.should_disable_custom_all_reduce_for_gpus",
         return_value=True,
     ):
         _launch_speech_server(args)
@@ -118,7 +118,7 @@ def test_tp2_enables_custom_all_reduce_on_p2p_mesh(mock_launch_server):
     """A P2P-capable (e.g. NVLink) TP thinker keeps custom all-reduce enabled."""
     args = _make_args(thinker_tp_size=2, gpu_thinker_tp="0,1")
     with patch(
-        "sglang_omni.utils.gpu_compat.should_disable_thinker_custom_all_reduce",
+        "sglang_omni.utils.gpu_compat.should_disable_custom_all_reduce_for_gpus",
         return_value=False,
     ):
         _launch_speech_server(args)

--- a/tests/unit_test/qwen3_omni/test_example_launcher.py
+++ b/tests/unit_test/qwen3_omni/test_example_launcher.py
@@ -96,7 +96,11 @@ def mock_launch_server():
 def test_tp2_config_contract(mock_launch_server):
     """tp_size and parallelism.tp must stay in sync for TP=2."""
     args = _make_args(thinker_tp_size=2, gpu_thinker_tp="0,1")
-    _launch_speech_server(args)
+    with patch(
+        "sglang_omni.utils.gpu_compat.should_disable_thinker_custom_all_reduce",
+        return_value=True,
+    ):
+        _launch_speech_server(args)
 
     config = mock_launch_server.call_args[0][0]
     thinker = _stage(config, "thinker")
@@ -107,6 +111,23 @@ def test_tp2_config_contract(mock_launch_server):
     assert (
         thinker.factory_args["server_args_overrides"]["disable_custom_all_reduce"]
         is True
+    )
+
+
+def test_tp2_enables_custom_all_reduce_on_p2p_mesh(mock_launch_server):
+    """A P2P-capable (e.g. NVLink) TP thinker keeps custom all-reduce enabled."""
+    args = _make_args(thinker_tp_size=2, gpu_thinker_tp="0,1")
+    with patch(
+        "sglang_omni.utils.gpu_compat.should_disable_thinker_custom_all_reduce",
+        return_value=False,
+    ):
+        _launch_speech_server(args)
+
+    config = mock_launch_server.call_args[0][0]
+    thinker = _stage(config, "thinker")
+    assert (
+        thinker.factory_args["server_args_overrides"]["disable_custom_all_reduce"]
+        is False
     )
 
 

--- a/tests/unit_test/qwen3_omni/test_pipeline.py
+++ b/tests/unit_test/qwen3_omni/test_pipeline.py
@@ -989,11 +989,15 @@ def test_thinker_tp_disable_custom_all_reduce_uses_shared_config_hook() -> None:
         ) == {"disable_custom_all_reduce": True}
 
 
-def test_qwen_cli_serve_applies_thinker_tp_override_to_server_args() -> None:
+def test_qwen_cli_serve_applies_thinker_tp_override_to_server_args(monkeypatch) -> None:
     """End-to-end: the CLI TP pass writes disable_custom_all_reduce into the
     thinker stage server args when TP>1 is configured (issue #760)."""
     from sglang_omni.cli.serve import _apply_tensor_parallel_server_args_overrides
 
+    monkeypatch.setattr(
+        "sglang_omni.cli.serve.should_disable_custom_all_reduce_for_gpus",
+        lambda *args, **kwargs: True,
+    )
     config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
     apply_parallelism_cli_overrides(
         config,

--- a/tests/unit_test/qwen3_omni/test_pipeline.py
+++ b/tests/unit_test/qwen3_omni/test_pipeline.py
@@ -1016,7 +1016,7 @@ def test_qwen_cli_serve_enables_custom_all_reduce_on_p2p_mesh(monkeypatch) -> No
     from sglang_omni.cli.serve import _apply_tensor_parallel_server_args_overrides
 
     monkeypatch.setattr(
-        "sglang_omni.cli.serve.should_disable_thinker_custom_all_reduce",
+        "sglang_omni.cli.serve.should_disable_custom_all_reduce_for_gpus",
         lambda *args, **kwargs: False,
     )
     config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")

--- a/tests/unit_test/qwen3_omni/test_pipeline.py
+++ b/tests/unit_test/qwen3_omni/test_pipeline.py
@@ -1030,8 +1030,7 @@ def test_qwen_cli_serve_enables_custom_all_reduce_on_p2p_mesh(monkeypatch) -> No
     _apply_tensor_parallel_server_args_overrides(config)
 
     assert (
-        _server_args_overrides(config, "thinker")["disable_custom_all_reduce"]
-        is False
+        _server_args_overrides(config, "thinker")["disable_custom_all_reduce"] is False
     )
 
 

--- a/tests/unit_test/qwen3_omni/test_pipeline.py
+++ b/tests/unit_test/qwen3_omni/test_pipeline.py
@@ -1012,6 +1012,29 @@ def test_qwen_cli_serve_applies_thinker_tp_override_to_server_args() -> None:
     )
 
 
+def test_qwen_cli_serve_enables_custom_all_reduce_on_p2p_mesh(monkeypatch) -> None:
+    from sglang_omni.cli.serve import _apply_tensor_parallel_server_args_overrides
+
+    monkeypatch.setattr(
+        "sglang_omni.cli.serve.should_disable_thinker_custom_all_reduce",
+        lambda *args, **kwargs: False,
+    )
+    config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+    apply_parallelism_cli_overrides(
+        config,
+        thinker_tp_size=2,
+        thinker_gpus="0,1",
+        talker_gpu=None,
+        code2wav_gpu=None,
+    )
+    _apply_tensor_parallel_server_args_overrides(config)
+
+    assert (
+        _server_args_overrides(config, "thinker")["disable_custom_all_reduce"]
+        is False
+    )
+
+
 def test_qwen_thinker_auto_path_applies_encoder_reserve() -> None:
     server_args = SimpleNamespace(mem_fraction_static=0.929)
 


### PR DESCRIPTION
## Summary
- The TP-thinker config path (`PipelineConfig.tensor_parallel_server_args_overrides`, e.g. Ming-Omni) and the Qwen3-Omni speech example launcher force `disable_custom_all_reduce=True` for **every** `tp_size>1` thinker. So tensor-parallel ranks always fall back to NCCL even on NVLink, where custom (P2P) all-reduce is faster.
- This gates the disable on the **actual GPU topology**: custom all-reduce stays disabled unless NVML confirms every TP GPU pair is P2P-capable (e.g. NVLink), in which case it is left enabled.
- Detection is **NVML-only (no CUDA context created in the coordinator)** and **conservative** -- any uncertainty (pynvml missing, query error, `<2` GPUs) preserves the safe disabled default, so CPU/CI behavior is unchanged.

## Why
Found during the #760 TP-concurrency investigation. A step-phase micro-profile showed the Qwen3-Omni thinker is GPU-forward-bound; the per-layer TP all-reduce runs every decode/prefill step, and forcing NCCL leaves NVLink performance on the table.

## Measurement
2x RTX A6000 NVLink (NV4), pure `Qwen3-Omni-30B-A3B-Instruct` TP=2 (no-RAG), 32 concurrent streaming sessions (ACL6060 en->zh), 3 runs/mode (server warm), identical harness:

| mode (N=32) | seg/s runs | mean | p50 RTT | BLEU |
|---|---|---|---|---|
| stock (NCCL) | 7.43 / 7.98 / 8.10 | 7.835 +/-0.293 | 867 ms | ~32.7 |
| custom-AR (NVLink) | 7.73 / 8.72 / 8.58 | **8.343 +/-0.440** | 830 ms | ~32.5 |

**+6.5% throughput, BLEU parity.**

## Changes
- `sglang_omni/utils/gpu_compat.py`: `gpu_ids_support_p2p_mesh()` (NVML pairwise P2P status, tri-state) + `should_disable_thinker_custom_all_reduce()`.
- `sglang_omni/cli/serve.py`: in `_apply_tensor_parallel_server_args_overrides`, relax a TP `disable_custom_all_reduce=True` to `False` when the stage GPUs form a P2P mesh.
- `examples/run_qwen3_omni_speech_server.py`: use the helper instead of hardcoding `True`.
- Tests: helper unit test (mock NVML), Ming serve-CLI gate (P2P on/off), Qwen3 example (P2P on/off).

## Scope / notes
- Default behavior is unchanged on non-P2P topologies and whenever NVML can't confirm a mesh.
- The standalone Ming example launchers (`examples/run_ming_omni_*.py`) still set the flag directly; they can adopt the same helper in a trivial follow-up.

## Test plan
- [x] `pytest tests/unit_test/pipeline/test_gpu_compat_custom_ar.py tests/unit_test/ming_omni/test_omni_serve.py tests/unit_test/qwen3_omni/test_example_launcher.py` -> 63 passed
- [ ] CI unit suite
