### PR TITLE
Fix MOSS local output collection without stream outbox

### DIFF
--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -26,6 +26,9 @@ class MossTTSLocalModelRunner(ModelRunner):
     CUDA-graph-replayable (decode input_ids are row indices).
     """
 
+    _outbox: Any | None = None
+    _vocoder_target = "vocoder"
+
     def __init__(self, tp_worker: Any, output_processor: Any):
         super().__init__(tp_worker, output_processor)
         self._outbox: Any | None = None
@@ -638,7 +641,9 @@ class MossTTSLocalModelRunner(ModelRunner):
                 continue
             sched_req.data.output_rows.append(journal.rows[i])
             stream_metadata = getattr(sched_req.data, "stream_metadata", None)
-            if self._outbox is None or stream_metadata is None:
+            if stream_metadata is None:
+                continue
+            if self._outbox is None:
                 continue
             if rows_cpu is None:
                 # One D2H per step regardless of how many requests stream.


### PR DESCRIPTION
## Motivation

Fix a MOSS-TTS Local unit-test regression where `post_process_outputs()` crashed with `AttributeError: 'MossTTSLocalModelRunner' object has no attribute '_outbox'` when tests construct the runner with `__new__`/`object.__new__`.

The output-row journal path is the primary model-runner contract. Streaming to the vocoder is an optional side effect layered on top of that contract, so missing stream outbox state must not block journal rows from being collected.

## Modifications

- Add class-level defaults for `MossTTSLocalModelRunner._outbox` and `_vocoder_target` so constructor-bypassed runner instances still have the same default no-stream state as fully constructed runners.
- Split the optional streaming checks in `post_process_outputs()`: append non-EOS journal rows to `output_rows`, then skip stream publication when `stream_metadata` is absent or no stream outbox is configured.
- Keep the existing production streaming path intact: `stages.py` still wires `model_runner.set_stream_outbox(scheduler.outbox)`, and streaming requests still publish `OutgoingMessage(type="stream", target="vocoder", ...)` when metadata and an outbox are present.

## Root Cause

- PR #753 added MOSS-TTS Local streaming by initializing `_outbox` in `__init__()` and reading `self._outbox` inside `post_process_outputs()`.
- Several MOSS-TTS Local unit tests intentionally instantiate `MossTTSLocalModelRunner` with `__new__`/`object.__new__` to exercise model-runner hooks without constructing the full SGLang worker stack.
- That made optional streaming state a hard requirement for output-row collection, even though `docs/developer_reference/pipeline.md` and `tts_model_integration.md` define streaming as scheduler outbox routing layered on top of the AR stage and `stream_to=["vocoder"]` configuration.
h.