### PR TITLE
[Perf] Increase MOSS-TTS Local reference audio cache item margin

### DIFF
--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -21,7 +21,7 @@ def _stages(*, codec_device: str) -> list[StageConfig]:
             factory_args={
                 "device": codec_device,
                 "ref_audio_cache": True,
-                "ref_audio_cache_max_items": 1024,
+                "ref_audio_cache_max_items": 8192,
                 "ref_audio_cache_max_bytes": 64 * 1024 * 1024,
             },
             gpu=0,

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -407,7 +407,7 @@ def create_preprocessing_executor(
     encode_batch_size: int = 8,
     encode_batch_wait_ms: int = 4,
     ref_audio_cache: bool = True,
-    ref_audio_cache_max_items: int = 1024,
+    ref_audio_cache_max_items: int = 8192,
     ref_audio_cache_max_bytes: int = 64 * 1024 * 1024,
 ) -> SimpleScheduler:
     # MOSS_REF_AUDIO_CACHE=0 disables the cache at startup (ops kill switch / A-B

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -175,7 +175,7 @@ def test_pipeline_stage_wiring():
     assert stages["preprocessing"].process == "pipeline"
     assert stages["preprocessing"].gpu == 0
     assert stages["preprocessing"].factory_args["device"] == "cuda:1"
-    assert stages["preprocessing"].factory_args["ref_audio_cache_max_items"] == 1024
+    assert stages["preprocessing"].factory_args["ref_audio_cache_max_items"] == 8192
     assert stages["tts_engine"].process == "pipeline"
     assert stages["tts_engine"].gpu == 0
     assert stages["vocoder"].process == "pipeline"
@@ -194,7 +194,7 @@ def test_pipeline_stage_wiring():
     assert colocated_stages["preprocessing"].factory_args["device"] == "cuda:0"
     assert (
         colocated_stages["preprocessing"].factory_args["ref_audio_cache_max_items"]
-        == 1024
+        == 8192
     )
     assert colocated_stages["vocoder"].factory_args["device"] == "cuda:0"
 
@@ -325,7 +325,7 @@ def test_create_preprocessing_executor_env_toggle(monkeypatch):
     assert isinstance(
         rb._PREPROCESSING_CONTEXT.reference_encoder, stages.CachedReferenceEncoder
     )
-    assert rb._PREPROCESSING_CONTEXT.reference_encoder._cache.max_size == 1024
+    assert rb._PREPROCESSING_CONTEXT.reference_encoder._cache.max_size == 8192
 
 
 def test_preprocess_and_result_adapter():


### PR DESCRIPTION

## Motivation

MOSS-TTS Local caches encoded reference audio as discrete codec token tensors, not waveforms or continuous features. In the SeedTTS EN workload used here, all 666 unique references occupy only about `1.85 MiB`, far below the existing `64 MiB` cache byte cap.

`main` already raises the default item cap to `1024`, which fixes the measured SeedTTS working set. This PR increases the default `ref_audio_cache_max_items` from `1024` to `8192` so the byte cap, rather than the item cap, remains the practical governor for larger voice-cloning workloads. The existing `ref_audio_cache_max_bytes=64 MiB` LRU limit is unchanged.

## Modifications

1. `sglang_omni/models/moss_tts_local/config.py`
   - Raises the MOSS-TTS Local pipeline config default `ref_audio_cache_max_items` from `1024` to `8192`.
   - Applies to both the default two-GPU config and the colocated config because both are built through `_stages(...)`.
   - Leaves `ref_audio_cache_max_bytes` unchanged at `64 * 1024 * 1024`.
   - Does not change the cache implementation, request path, env toggle, byte accounting, or explicit user overrides.

2. `sglang_omni/models/moss_tts_local/stages.py`
   - Updates the preprocessing executor default `ref_audio_cache_max_items` to `8192`, matching the pipeline config default.
   - Keeps the cache startup kill switch and byte-bounded LRU behavior unchanged.

3. `tests/unit_test/moss_tts_local/test_pipeline.py`
   - Updates stage wiring coverage to assert that default, colocated, and direct preprocessing construction paths use `ref_audio_cache_max_items=8192`.

## Related Issues

follow-up of https://github.com/sgl-project/sglang-omni/pull/778

## Accuracy Test

**Setup:**

- Compared refs:
  - baseline: `main @ 584a8b3` with `ref_audio_cache_max_items=1024`
  - candidate: `feat/moss-tts-local-ref-audio-cache-8192 @ a56f4e8` with `ref_audio_cache_max_items=8192`
- Model: `OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5`
- Config: `examples/configs/moss_tts_local.yaml`
- Dataset/eval: `zhaochenyang20/seed-tts-eval-arrow`, `lang=en`, 1088 samples / 666 unique reference audio files, `--ref-format references`, `--token-count auto`
- Hardware: `CUDA_VISIBLE_DEVICES=0,1`, 2x NVIDIA H100 80GB HBM3
- Topology: AR engine on logical `cuda:0`; codec/reference preprocessing and vocoder on logical `cuda:1`
- Concurrencies: `1` and `16`; warmup `8`

All rows completed `1088/1088` TTS requests with zero failed requests. Quality evaluation completed for both cache settings at both concurrencies.

| concurrency | metric | main cache=1024 | candidate cache=8192 |
| ---: | --- | ---: | ---: |
| 1 | WER corpus | 2.010% | 2.328% |
| 1 | speaker similarity | 65.197 | 65.214 |
| 16 | WER corpus | 2.780% | 2.386% |
| 16 | speaker similarity | 65.372 | 65.236 |

## Benchmark & Profiling

Same setup as described in the _Accuracy Test_ section. 

### 8192 vs current main 1024

| concurrency | metric | main cache=1024 | candidate cache=8192 | delta |
| ---: | --- | ---: | ---: | ---: |
| 1 | Audio throughput | 7.578 audio s/s | 7.626 audio s/s | +0.6% |
| 1 | Request throughput | 1.722 req/s | 1.733 req/s | +0.6% |
| 1 | Mean latency | 0.581 s | 0.577 s | -0.7% |
| 1 | P95 latency | 0.804 s | 0.805 s | +0.1% |
| 1 | Mean RTF | 0.1349 | 0.1340 | -0.7% |
| 16 | Audio throughput | 37.954 audio s/s | 38.370 audio s/s | +1.1% |
| 16 | Request throughput | 8.624 req/s | 8.718 req/s | +1.1% |
| 16 | Mean latency | 1.845 s | 1.825 s | -1.1% |
| 16 | P95 latency | 2.126 s | 2.115 s | -0.5% |
| 16 | Mean RTF | 0.4426 | 0.4380 | -1.0% |

### Cache behavior

Both `1024` and `8192` hold all 666 unique references in the SeedTTS EN workload, so the end-to-end benchmark is expected to be flat aside from normal run noise.

| variant | final cache entries | misses | bytes |
| --- | ---: | ---: | ---: |
| main cache=1024 | 666 | 666 | 1,850,592 |
| candidate cache=8192 | 666 | 666 | 1,850,592 |

### Summary:

- The current PR is intentionally a capacity-margin change: `8192` is performance-neutral against current `main` on SeedTTS EN because both `1024` and `8192` hold the full 666-reference working set.
- The unchanged `64 MiB` byte cap remains the hard cache budget. The measured 666 cached references use only `1.85 MiB`, so `max_items=8192` prevents premature item-count eviction on larger workloads while preserving bounded memory usage.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the `run-ci` label. Once labeled, every subsequent push re-triggers CI as long as the label remains. Draft PRs are skipped even if labeled.
