### PR TITLE
feat(qwen3-omni): enable mixed-chunk by default on the thinker path (…

### DIFF
--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -943,7 +943,22 @@ def create_sglang_thinker_executor_from_config(
 ):
     """Returns OmniScheduler for thinker."""
 
-    overrides: dict[str, Any] = {"disable_cuda_graph": False}
+    # The thinker runs prefill XOR decode per scheduler step, so under
+    # concurrent streaming a large fraction of steps are prefill-only while
+    # in-flight decodes stall (measured on Qwen3-Omni-30B TP=2, 32 streams:
+    # ~98% of prefill steps had decode-ready reqs in running_batch passed over,
+    # ~18/step). Mixed-chunk folds those running decodes into the chunk-prefill
+    # (extend) step, restoring the decode duty cycle: +14% throughput and ~6%
+    # lower computation-aware latency at quality parity, with no low-concurrency
+    # regression and robustness to chunked_prefill_size (#760). Defaults here so
+    # the streaming-SST thinker path benefits out of the box; either key can be
+    # overridden via server_args_overrides (set enable_mixed_chunk=False to opt
+    # out). Note: mixed-chunk only engages when chunked_prefill_size > 0.
+    overrides: dict[str, Any] = {
+        "disable_cuda_graph": False,
+        "enable_mixed_chunk": True,
+        "chunked_prefill_size": 8192,
+    }
     if server_args_overrides:
         overrides.update(server_args_overrides)
     overrides["tp_size"] = tp_size

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -942,7 +942,7 @@ def create_sglang_thinker_executor_from_config(
     total_gpu_memory_fraction: float | None = None,
 ):
     """Returns OmniScheduler for thinker."""
-    # note (luojiaxuan)
+    # note: (luojiaxuan)
     # The thinker runs prefill XOR decode per scheduler step, so under
     # concurrent streaming a large fraction of steps are prefill-only while
     # in-flight decodes stall (measured on Qwen3-Omni-30B TP=2, 32 streams:

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -942,7 +942,7 @@ def create_sglang_thinker_executor_from_config(
     total_gpu_memory_fraction: float | None = None,
 ):
     """Returns OmniScheduler for thinker."""
-    # note: (luojiaxuan)
+    # note (luojiaxuan):
     # The thinker runs prefill XOR decode per scheduler step, so under
     # concurrent streaming a large fraction of steps are prefill-only while
     # in-flight decodes stall (measured on Qwen3-Omni-30B TP=2, 32 streams:

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -942,7 +942,7 @@ def create_sglang_thinker_executor_from_config(
     total_gpu_memory_fraction: float | None = None,
 ):
     """Returns OmniScheduler for thinker."""
-
+    # note (luojiaxuan)
     # The thinker runs prefill XOR decode per scheduler step, so under
     # concurrent streaming a large fraction of steps are prefill-only while
     # in-flight decodes stall (measured on Qwen3-Omni-30B TP=2, 32 streams:


### PR DESCRIPTION
### What

Default `enable_mixed_chunk=True` and `chunked_prefill_size=8192` for the
Qwen3-Omni thinker, set in `create_sglang_thinker_executor_from_config`
(`sglang_omni/models/qwen3_omni/stages.py`). Both stay overridable via
`server_args_overrides` (pass `enable_mixed_chunk=False` to opt out). One file,
+16/-1. Relates to #760.

### Why

The thinker scheduler advances **prefill XOR decode** per step. Under concurrent
streaming a large fraction of steps are prefill-only, and any in-flight decodes
just wait for that step to finish. This is a duty-cycle problem, not an
occupancy or arrival problem.

Measured on `Qwen3-Omni-30B-A3B-Instruct`, TP=2, 32 concurrent streaming-SST
sessions (env-gated scheduler probe):

- ~**98%** of pure-prefill steps had decode-ready requests in `running_batch`
  that were passed over (**~18 per step**) — i.e. the workload is *not*
  arrival-bound.
- decode advanced on only ~58% of scheduler iterations.

Mixed-chunk folds those running decodes into the chunk-prefill (extend) step,
restoring the decode duty cycle.

### Result (same-node A/B, en→zh ACL6060 streaming SimulEval)

| metric | baseline | mixed-chunk default | delta |
|---|---|---|---|
| throughput (seg/s) | ~8.1 | ~9.3 | **+14%** |
| StreamLAAL_CA (computation-aware) | ~2280 | ~2143 | **-6%** |
| BLEU | 32.1 | 32.1 | parity |
| pure-prefill steps stranding ready decodes | ~98% | **~0%** | — |

Hardened: holds under swapped A/B ordering (mixed-first), **no regression at
N=1 / N=8**, and robust across `chunked_prefill_size ∈ {4096, 8192, 16384}`
(flat ~9.2–9.3 seg/s; 8192 chosen as a safe default).

### Verifying the default actually engages (no CLI flag)

Launched the thinker with **no** mixed-chunk CLI flags so the *code default* is
the only source of the feature. Runtime confirms:

```
[thinker args] ... chunked_prefill_size=8192 ...
[prefill attribution] prefill_steps=161 with_ready_decodes=0 (0.0%) ...
```

vs. the prior baseline (no default, no flag): `chunked_prefill_size != 8192` and
~96–98% of prefill steps stranding ready decodes.

### Scope / risk

- Affects the **Qwen3-Omni** thinker only. ming-omni has its own
  `create_sglang_thinker_executor_from_config`; the talker is untouched.
- `cli/serve.py` and the qwen3-omni stage `factory_args` do not set these keys,
  so nothing clobbers the default; an explicit `server_args_overrides` (or a
  `--chunked-prefill-size` / `--enable-mixed-chunk` flag) still wins.
- Mixed-chunk only engages when `chunked_prefill_size > 0`. For short streaming
  prefills the chunk size is a no-op; for very long prefills, chunking at 8192
  is the standard recommended behavior.
