### PR TITLE
Run Omni unit CI first and fix profiler route test

### DIFF
--- a/.github/scripts/prepare_omni_venv.sh
+++ b/.github/scripts/prepare_omni_venv.sh
@@ -34,11 +34,11 @@ if [ -f "${DEPS_HASH_FILE}" ] \
 fi
 
 if [ "${reuse_venv}" = true ]; then
-  echo "Reusing ${HOST} (pyproject.toml unchanged); refreshing editable install only"
+  echo "Reusing ${HOST} (pyproject.toml unchanged); refreshing editable install and dependency versions"
   rm -rf "./${VENV_NAME}"
   ln -sfn "${HOST}" "./${VENV_NAME}"
   source "${VENV_NAME}/bin/activate"
-  uv pip install -e .
+  uv pip install --upgrade -e .
   exit 0
 fi
 

--- a/.github/workflows/omni-ci.yaml
+++ b/.github/workflows/omni-ci.yaml
@@ -1,9 +1,9 @@
 name: Omni CI
 
 # DAG:
-#   preflight ──► setup ──► tts-ci ──► qwen3-omni-ci ──► pr-test
-#                    │          │              │              │
-#                    └──────────┴──────────────┴──────────────┴──► cleanup
+#   preflight ──► setup ──► pr-test ──► tts-ci ──► qwen3-omni-ci
+#                    │           │          │              │
+#                    └───────────┴──────────┴──────────────┴──► cleanup
 
 
 on:
@@ -129,8 +129,10 @@ jobs:
 
   tts-ci:
     name: TTS CI
-    needs: setup
-    if: needs.setup.result == 'success'
+    needs: [setup, pr-test]
+    if: >-
+      always() && !cancelled() &&
+      needs.setup.result == 'success'
     uses: ./.github/workflows/test-tts-ci.yaml
     secrets: inherit
 
@@ -145,9 +147,8 @@ jobs:
 
   pr-test:
     name: PR Test
-    needs: [setup, qwen3-omni-ci]
+    needs: setup
     if: >-
-      always() && !cancelled() &&
       needs.setup.result == 'success'
     uses: ./.github/workflows/test.yaml
     secrets: inherit

--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -14,8 +14,8 @@ env:
         && format('/github/home/pr-{0}', github.event.pull_request.number)
         || format('/github/home/run-{0}', github.run_id) }}
 
-# Invoked by omni-ci.yaml after TTS CI (second benchmark suite in the omni-ci
-# sequence: TTS → Qwen3-Omni → PR Test). Restores omni only.
+# Invoked by omni-ci.yaml after TTS CI (last benchmark suite in the omni-ci
+# sequence: PR Test → TTS → Qwen3-Omni). Restores omni only.
 
 jobs:
   stage-1-thinker:

--- a/.github/workflows/test-tts-ci.yaml
+++ b/.github/workflows/test-tts-ci.yaml
@@ -11,8 +11,8 @@ env:
   TTS_MODEL_PATH: boson-sglang/higgs-audio-v3-TTS-4B-grpo05200410999
   QWEN3_ASR_MODEL_PATH: Qwen/Qwen3-ASR-1.7B
 
-# Invoked by omni-ci.yaml after shared setup (first benchmark suite in the
-# omni-ci sequence: TTS → Qwen3-Omni → PR Test). Restores omni only.
+# Invoked by omni-ci.yaml after PR Test (second suite in the omni-ci sequence:
+# PR Test → TTS → Qwen3-Omni). Restores omni only.
 # DAG:
 #   stage-1-qwen3-asr            (independent)
 #   stage-2-non-streaming ──┐

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,8 +9,8 @@ env:
         && format('/github/home/pr-{0}', github.event.pull_request.number)
         || format('/github/home/run-{0}', github.run_id) }}
 
-# Invoked by omni-ci.yaml after Qwen3-Omni CI (last benchmark suite in the
-# omni-ci sequence: TTS → Qwen3-Omni → PR Test). Restores omni only.
+# Invoked by omni-ci.yaml after shared setup (first suite in the omni-ci
+# sequence: PR Test → TTS → Qwen3-Omni). Restores omni only.
 
 jobs:
   unit-test:

--- a/tests/unit_test/pipeline/test_ipc.py
+++ b/tests/unit_test/pipeline/test_ipc.py
@@ -387,8 +387,9 @@ async def _run_launcher_with_fake_runner(
     config: PipelineConfig,
     serve_mock: AsyncMock,
     monkeypatch: pytest.MonkeyPatch,
-) -> tuple[object, FastAPI]:
+) -> tuple[object, FastAPI, SimpleNamespace]:
     app = FastAPI()
+    profiler_calls = SimpleNamespace(starts=[], stops=[])
 
     from sglang_omni.serve import launcher
 
@@ -431,10 +432,10 @@ async def _run_launcher_with_fake_runner(
             del stage_control_endpoints
 
         async def broadcast_start(self, **kwargs) -> None:
-            del kwargs
+            profiler_calls.starts.append(kwargs)
 
         async def broadcast_stop(self, **kwargs) -> None:
-            del kwargs
+            profiler_calls.stops.append(kwargs)
 
     monkeypatch.setattr(launcher, "_find_available_port", lambda host, port: port)
     monkeypatch.setattr(launcher, "MultiProcessPipelineRunner", FakeRunner)
@@ -444,7 +445,7 @@ async def _run_launcher_with_fake_runner(
 
     await launcher._run_server(config, port=8000)
     assert runner_ref is not None
-    return runner_ref, app
+    return runner_ref, app, profiler_calls
 
 
 @pytest.mark.asyncio
@@ -455,7 +456,7 @@ async def test_launcher_uses_runner_and_mounts_profiler_routes(
     config = _make_config(tmp_path)
     server_serve = AsyncMock(return_value=None)
 
-    runner, app = await _run_launcher_with_fake_runner(
+    runner, app, profiler_calls = await _run_launcher_with_fake_runner(
         config=config,
         serve_mock=server_serve,
         monkeypatch=monkeypatch,
@@ -476,6 +477,10 @@ async def test_launcher_uses_runner_and_mounts_profiler_routes(
             stop_resp = client.post("/stop_profile", json={})
         assert start_resp.status_code == 200
         assert stop_resp.status_code == 200
+        assert profiler_calls.starts
+        assert profiler_calls.starts[0]["enable_torch"] is False
+        assert profiler_calls.starts[0]["event_dir"] == str(tmp_path / "events")
+        assert profiler_calls.stops == [{"run_id": None}]
     finally:
         rec = get_recorder()
         if rec.is_active():

--- a/tests/unit_test/pipeline/test_ipc.py
+++ b/tests/unit_test/pipeline/test_ipc.py
@@ -426,8 +426,19 @@ async def _run_launcher_with_fake_runner(
         async def wait_failed(self) -> None:
             await asyncio.Future()
 
+    class FakeProfilerControl:
+        def __init__(self, stage_control_endpoints: dict[str, str]) -> None:
+            del stage_control_endpoints
+
+        async def broadcast_start(self, **kwargs) -> None:
+            del kwargs
+
+        async def broadcast_stop(self, **kwargs) -> None:
+            del kwargs
+
     monkeypatch.setattr(launcher, "_find_available_port", lambda host, port: port)
     monkeypatch.setattr(launcher, "MultiProcessPipelineRunner", FakeRunner)
+    monkeypatch.setattr(launcher, "ProfilerControlClient", FakeProfilerControl)
     monkeypatch.setattr(launcher, "create_app", lambda *a, **k: app)
     monkeypatch.setattr(launcher.uvicorn.Server, "serve", serve_mock)
 
@@ -453,9 +464,22 @@ async def test_launcher_uses_runner_and_mounts_profiler_routes(
     assert runner.started
     assert runner.stopped
     server_serve.assert_awaited_once()
-    mounted_paths = {route.path for route in app.routes}
-    assert "/start_profile" in mounted_paths
-    assert "/stop_profile" in mounted_paths
+    try:
+        with TestClient(app) as client:
+            start_resp = client.post(
+                "/start_profile",
+                json={
+                    "enable_torch": False,
+                    "event_dir": str(tmp_path / "events"),
+                },
+            )
+            stop_resp = client.post("/stop_profile", json={})
+        assert start_resp.status_code == 200
+        assert stop_resp.status_code == 200
+    finally:
+        rec = get_recorder()
+        if rec.is_active():
+            rec.stop()
 
 
 def test_start_profile_request_only_mode_does_not_require_trace_template(


### PR DESCRIPTION
## Motivation

The current Omni CI failure comes from the profiler route test asserting FastAPI/Starlette route internals instead of the launcher contract. Newer FastAPI/Starlette can keep `include_router()` endpoints behind included-router entries, so walking only top-level `app.routes` is brittle.

This PR also moves the cheaper PR unit test suite before the TTS and Qwen3-Omni benchmark suites, and restores dependency refresh for reused Omni CI virtualenvs so cached PR environments do not keep stale compatible dependency versions indefinitely.

## Modifications

- Update `test_launcher_uses_runner_and_mounts_profiler_routes` to exercise `/start_profile` and `/stop_profile` through `TestClient` instead of inspecting `app.routes` object shape.
- Replace the real `ProfilerControlClient` in that launcher test with a minimal fake so endpoint dispatch is tested without opening IPC sockets.
- Reorder `omni-ci.yaml` from `setup -> TTS -> Qwen3-Omni -> PR Test` to `setup -> PR Test -> TTS -> Qwen3-Omni`, and update the workflow comments in the called workflows.
- Change the reused-venv path in `prepare_omni_venv.sh` to run `uv pip install --upgrade -e .`; the fresh-venv path remains `uv pip install -e .` because it already resolves from an empty environment.

## Root Cause

- The launcher mounts profiler endpoints through `app.include_router(router)`.
- With the package versions currently resolved in CI, `app.routes` may contain an included-router object rather than exposing every concrete profiler route at the top level.
- The old test asserted that incidental top-level route layout instead of making requests to the mounted endpoints.
- Separately, the reused CI env path refreshed only the editable install, so already-installed compatible dependencies could remain stale when `pyproject.toml` was unchanged.

## Accuracy Tests

- `bash -n .github/scripts/prepare_omni_venv.sh`
- `python3 -m py_compile tests/unit_test/pipeline/test_ipc.py`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "OK #{path}" }' .github/workflows/omni-ci.yaml .github/workflows/test.yaml .github/workflows/test-tts-ci.yaml .github/workflows/test-qwen3-omni-ci.yaml`
- `git diff --check upstream/main...HEAD`

## Speed Tests and Profiling

Not run. This changes CI ordering, CI dependency refresh behavior, and one unit test assertion path; it does not affect serving runtime behavior.

## Checklist

- [x] Format your code according to the contribution guide.
- [x] Add or update tests as needed.
- [x] Update documentation as needed.
- [x] Provide accuracy and speed results when the change affects them.
