### PR TITLE
docs: fix MOSS-TTS cookbook parameter surface

### DIFF
--- a/docs/cookbook/moss_tts.md
+++ b/docs/cookbook/moss_tts.md
@@ -116,7 +116,7 @@ curl -N -X POST http://localhost:8000/v1/audio/speech \
 
 MOSS-TTS conditions on a target **duration token count** (codec frames; a larger count yields
 longer audio). Set it with an inline `${token:N}` prefix on `input` (stripped before synthesis),
-or with a `token_count` (alias `duration_tokens` / `tokens`) parameter. The count must be a
+or with a `token_count` (alias `duration_tokens`) parameter. The count must be a
 positive integer.
 
 ```json
@@ -129,7 +129,7 @@ sample with `--token-count auto`.
 ### Text Markup, Style, and Language
 
 Inline text markup that the model understands (for example `[pause Xs]`, pinyin, and IPA) is
-passed through unchanged. An optional `instructions` (alias `instruct`) field carries a
+passed through unchanged. An optional `instructions` field carries a
 free-text style directive, and an optional `language` hint biases the target language (omit it
 to let the model infer from the text):
 
@@ -151,8 +151,8 @@ to let the model infer from the text):
 | `ref_audio` / `ref_text` | `null` | Shorthand for `references[0].audio_path` / `references[0].text` |
 | `stream` | `false` | Stream raw PCM audio chunks |
 | `language` | `null` | Optional target-language hint; omit to let the model infer |
-| `instructions` / `instruct` | `null` | Optional free-text style directive |
-| `token_count` / `duration_tokens` / `tokens` | `null` | Target duration in codec frames; must be `> 0` |
+| `instructions` | `null` | Optional free-text style directive |
+| `token_count` / `duration_tokens` | `null` | Target duration in codec frames; must be `> 0` |
 | `max_new_tokens` | `4096` | Maximum generated frames; an explicit value must be `> 0` |
 | `temperature` | `1.5` text / `1.7` audio | Sampling temperature; a single `temperature` overrides both channels |
 | `top_p` | `1.0` text / `0.8` audio | Top-p sampling; a single `top_p` overrides both channels |
@@ -160,9 +160,8 @@ to let the model infer from the text):
 | `repetition_penalty` | `1.0` | Audio repetition penalty |
 | `seed` | `null` | Non-negative integer; see [Seed Reproducibility](#seed-reproducibility) |
 
-The per-channel fields (`text_temperature`, `audio_temperature`, `text_top_p`, `audio_top_p`,
-`text_top_k`, `audio_top_k`, `audio_repetition_penalty`) are also accepted and take precedence
-over the single-value aliases.
+The two default values are the model's separate text-channel and audio-channel sampling settings;
+a single `temperature`, `top_p`, or `top_k` applies to both.
 
 ## Seed Reproducibility
 


### PR DESCRIPTION
### Title

docs: fix MOSS-TTS cookbook parameter surface

### Body

**Problem**

`docs/cookbook/moss_tts.md` documents request parameters that the `/v1/audio/speech` endpoint does
not actually accept. Since #659 the endpoint validates the request body against
`CreateSpeechRequest` (`sglang_omni/serve/protocol.py`); Pydantic uses the default
`extra='ignore'`, so any undeclared field is silently dropped before it can reach the model.

The cookbook lists three parameters that never take effect through the HTTP API:

- **`tokens`** as an alias for `token_count` — `CreateSpeechRequest` declares only `token_count`
  and `duration_tokens`.
- **`instruct`** as an alias for `instructions` — only `instructions` is declared.
- The **per-channel sampling fields** (`text_temperature`, `audio_temperature`, `text_top_p`,
  `audio_top_p`, `text_top_k`, `audio_top_k`, `audio_repetition_penalty`), described as "also
  accepted and take precedence" — none are declared on `CreateSpeechRequest`, and
  `speech_service._build_tts_params` only forwards the single-valued `temperature` / `top_p` /
  `top_k` / `repetition_penalty`. (The request builders can read per-channel values, but the HTTP
  layer never populates them.)

**Fix (docs only)**

- Drop the `tokens` and `instruct` aliases; keep `token_count` / `duration_tokens` and
  `instructions`.
- Replace the per-channel note with an accurate statement: the two default values are the model's
  text-channel and audio-channel sampling settings, and a single `temperature` / `top_p` / `top_k`
  applies to both (which `_build_tts_params` + the request builder's `explicit_generation_params`
  path do support).

**Scope**

Single file, documentation only — no code or behavior change.
