### PR TITLE
[Model] Add CSM-1B (sesame/csm-1b) streaming TTS support

### DIFF
--- a/docs/basic_usage/tts.md
+++ b/docs/basic_usage/tts.md
@@ -1,6 +1,6 @@
 # TTS Model Usage
 
-This guide uses [Fish Speech S2-Pro](https://huggingface.co/fishaudio/s2-pro) as an example TTS (text-to-speech) model with SGLang-Omni and the OpenAI-compatible API. The same `/v1/audio/speech` endpoint also supports Voxtral TTS, Qwen3-TTS, and MOSS-TTS.
+This guide uses [Fish Speech S2-Pro](https://huggingface.co/fishaudio/s2-pro) as an example TTS (text-to-speech) model with SGLang-Omni and the OpenAI-compatible API. The same `/v1/audio/speech` endpoint also supports Voxtral TTS, Qwen3-TTS, MOSS-TTS, and CSM-1B.
 
 ## Prerequisites
 
@@ -28,6 +28,7 @@ uv pip install --no-deps qwen-tts==0.1.1
 | [Qwen3-TTS CustomVoice](../cookbook/qwen3_tts.md) | `examples/configs/qwen3_tts_0_6b_customvoice.yaml` | Text-only requests use the checkpoint speaker table. Missing `voice` defaults to `Vivian` |
 | [Qwen3-TTS VoiceDesign](../cookbook/qwen3_tts.md) | `examples/configs/qwen3_tts_1_7b_voicedesign.yaml` | Requires `task_type="VoiceDesign"` and non-empty `instructions`. No reference audio is required |
 | [MOSS-TTS](../cookbook/moss_tts.md) | `examples/configs/moss_tts.yaml` | Voice cloning via `ref_audio` or `references[0].audio_path` (+ `text`). Duration via `${token:N}` or `token_count`. Benchmark at `--max-concurrency 8` |
+| [CSM-1B](https://huggingface.co/sesame/csm-1b) | `examples/configs/csm_1b.yaml` | Plain TTS via `input` + `response_format` (`stream=true` for streaming PCM); single default speaker. `sesame/csm-1b` is gated, accept its license on HF first |
 
 ## Launch the Server
 
@@ -35,6 +36,15 @@ uv pip install --no-deps qwen-tts==0.1.1
 sgl-omni serve \
   --model-path fishaudio/s2-pro \
   --config examples/configs/s2pro_tts.yaml \
+  --port 8000
+```
+
+For CSM-1B:
+
+```bash
+sgl-omni serve \
+  --model-path sesame/csm-1b \
+  --config examples/configs/csm_1b.yaml \
   --port 8000
 ```
 

--- a/examples/configs/csm_1b.yaml
+++ b/examples/configs/csm_1b.yaml
@@ -1,0 +1,46 @@
+# CSM-1B (sesame/csm-1b) example config — sized for a 12 GB card (e.g. RTX 3060).
+#
+# runtime_overrides[<stage>] keys merge DIRECTLY as factory kwargs (NO
+# factory_args: nesting — config/runtime.py:28-31,125-139; a nested
+# factory_args key arrives as a bogus kwarg and TypeErrors at stage build).
+# server_args_overrides dicts deep-merge into the factory's own
+# (runtime.py:129-137). mem_fraction_static rides server_args_overrides only
+# while the typed runtime.sglang_server_args.mem_fraction_static is unset
+# (runtime.py:82-91) — we leave the typed field unset.
+#
+# budget @ mrr 8 (engineering arithmetic, NOT framework-enforced —
+# validate with a peak-VRAM smoke): backbone bf16 ~2.74 GB + cb0/depth
+# ~0.36 GB + Mimi fp32 ~0.4 GB + KV pool worst-case 512 MiB + CUDA ctx/torch
+# ~1.2 GB ≈ 5.6-6.0 GB total → ≥ 6 GB headroom on 12 GB. mem_fraction_static
+# 0.5 ≈ 2.9 GB KV pool ≈ 94k pooled positions (45× the mrr-8 worst case) —
+# deliberately low to leave Mimi, encoder activations, CG pool, and the
+# colocated stages outside SGLang's fence. The binding constraint on the
+# 3060 is COMPUTE (frame step < 80 ms RT), not VRAM.
+#
+# context_length is pinned to 2048 (the CSM hard model ceiling) inside the
+# tts_engine factory (stages.create_sglang_tts_engine_executor) — it is not a
+# YAML knob.
+#
+# Launch:
+#   sgl-omni serve --model-path sesame/csm-1b \
+#     --config examples/configs/csm_1b.yaml --port 8000
+config_cls: CsmTtsPipelineConfig
+model_path: sesame/csm-1b
+name: csm-1b
+runtime_overrides:
+  preprocessing:
+    max_concurrency: 8
+  audio_encoder:
+    max_batch_size: 4
+  tts_engine:
+    max_new_tokens: 125
+    enable_async_decode: false            # set true to enable async decode
+    server_args_overrides:
+      max_running_requests: 8
+      mem_fraction_static: 0.5
+      cuda_graph_max_bs: 8
+      disable_cuda_graph: true            # set false to enable CUDA graphs
+  vocoder:
+    stream_followup_stride: 6
+    stream_overlap_frames: 4
+    stream_holdback_frames: 2

--- a/sglang_omni/model_runner/sglang_model_runner.py
+++ b/sglang_omni/model_runner/sglang_model_runner.py
@@ -86,6 +86,7 @@ class SGLModelRunner(ModelRunner):
             "Qwen3OmniTalker": "sglang_omni.models.qwen3_omni.components.talker:Qwen3OmniTalker",
             "Qwen3OmniThinkerForCausalLM": "sglang_omni.models.qwen3_omni.components.sglang_thinker:Qwen3OmniThinkerForCausalLM",
             "HiggsMultimodalQwen3ForConditionalGeneration": "sglang_omni.models.higgs_tts.model:HiggsTTSModel",
+            "CsmForConditionalGeneration": "sglang_omni.models.csm_tts.model:CsmTTSModel",
             "Qwen3TTSTalker": "sglang_omni.models.qwen3_tts.sglang_model:Qwen3TTSTalker",
             "MossTTSDelaySGLangModel": "sglang_omni.models.moss_tts.sglang_model:MossTTSDelaySGLangModel",
             "MossTTSLocalSGLangModel": "sglang_omni.models.moss_tts_local.sglang_model:MossTTSLocalSGLangModel",

--- a/sglang_omni/models/csm_tts/__init__.py
+++ b/sglang_omni/models/csm_tts/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CSM-1B TTS model support for sglang-omni (``sesame/csm-1b``).
+
+Registers :class:`CsmTtsHfConfig` with ``transformers.AutoConfig`` under the
+NATIVE model type ``"csm"`` (``exist_ok=True`` overrides the in-process
+mapping; semantics + container check inR7), then imports
+``config`` so the pipeline registry pkgutil scan finds ``EntryClass``.
+
+This module (and ``config``) MUST stay sglang/CUDA-free — the registry scan
+silently skips packages whose import fails (contract). The sglang model
+class is registered in
+:meth:`sglang_omni.model_runner.sglang_model_runner.SGLModelRunner._register_omni_model`.
+"""
+
+from __future__ import annotations
+
+from transformers import AutoConfig
+
+from .hf_config import CsmTtsHfConfig
+
+AutoConfig.register("csm", CsmTtsHfConfig, exist_ok=True)
+
+from . import config  # noqa: E402  (must follow the AutoConfig override)
+
+__all__ = ["config", "CsmTtsHfConfig"]

--- a/sglang_omni/models/csm_tts/audio_codec.py
+++ b/sglang_omni/models/csm_tts/audio_codec.py
@@ -1,0 +1,401 @@
+# SPDX-License-Identifier: Apache-2.0
+# Wraps the Mimi neural audio codec via `transformers.MimiModel` (Apache-2.0; Kyutai Moshi/Mimi).
+"""Mimi codec wrapper for CSM — loaded from the SAME checkpoint's
+``codec_model.*`` subtree (one-artifact pattern; the engine's weight loader
+skips that subtree).
+
+fp32 BY DEFAULT (conv-transpose decode stability; bf16 opt-in). Mimi runs at
+24 kHz / 12.5 Hz ⇒ one frame = 80 ms = 1920 samples; 32 quantizers with
+2048-row codebooks — codes 2048/2049/2050 are OUT OF BOUNDS and must be
+clamped before any Mimi call (hard SIGSEGV-class hazard on some kernels,
+garbage on others).
+
+
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Callable
+
+import torch
+import torch.nn.functional as F
+from safetensors import safe_open
+
+logger = logging.getLogger(__name__)
+
+# Local copies of the CSM constants — utils.py imports THIS module, so this
+# module must not import utils (cycle).
+_NUM_CODEBOOKS = 32
+_MIMI_CODEBOOK_SIZE = 2048  # valid Mimi codes are [0, 2047]
+
+# Codec weights live under this prefix inside the CSM checkpoint shards.
+_CODEC_IN_CKPT_PREFIX = "codec_model."
+# CSM ships a NONSTANDARD index name (`transformers.safetensors.index.json`,
+# shards `transformers-0000x-of-00002.safetensors`).
+_SHARD_INDEX_CANDIDATES = (
+    "transformers.safetensors.index.json",
+    "model.safetensors.index.json",
+)
+
+
+def sanitize_for_mimi(codes: torch.Tensor) -> tuple[torch.Tensor, int]:
+    """Fence #2 of 3: count then ``codes.clamp_(0, 2047)``.
+
+    The clamp count is exported as a counter: under greedy/temp=0 runs
+    ``count == 0`` is a hard parity-gate assertion; under
+    sampling it is telemetry ONLY — the 2051-way heads can legally emit
+    2048-2050 with nonzero probability.
+
+    Args:
+        codes: int64 ``[F, 32]`` (any device).
+
+    Returns:
+        ``(clamped codes [F, 32], num_clamped int)``.
+    """
+    if codes.numel() == 0:
+        return codes, 0
+    num_clamped = int((codes >= _MIMI_CODEBOOK_SIZE).sum().item())
+    codes.clamp_(0, _MIMI_CODEBOOK_SIZE - 1)
+    return codes, num_clamped
+
+
+def trim_at_first_all_zero_frame(codes_F32: torch.Tensor) -> torch.Tensor:
+    """Fence #3 of 3: cut at the first frame whose ALL 32 codebooks
+    are 0 (HF cutoff semantics, generation_csm.py:471-477 — mirrors HF's
+    stop(31)/trim(32) inconsistency exactly: an EOS frame with cb31 != 0 IS
+    kept and decoded).
+
+    Args:
+        codes_F32: int ``[F, 32]``.
+
+    Returns:
+        ``codes_F32[:cutoff]`` (possibly 0 frames).
+    """
+    if codes_F32.numel() == 0:
+        return codes_F32
+    zero_frames = (codes_F32 == 0).all(dim=-1)
+    hits = torch.nonzero(zero_frames)
+    if hits.numel() == 0:
+        return codes_F32
+    return codes_F32[: int(hits[0].item())]
+
+
+def _load_codec_state_dict(checkpoint_dir: str) -> dict[str, torch.Tensor]:
+    """Pull all ``codec_model.*`` tensors out of the CSM checkpoint shards
+    into a state dict keyed by Mimi's own parameter names (prefix stripped)."""
+    shards: dict[str, list[str] | None] = {}
+    for index_name in _SHARD_INDEX_CANDIDATES:
+        index_path = os.path.join(checkpoint_dir, index_name)
+        if not os.path.isfile(index_path):
+            continue
+        with open(index_path) as f:
+            weight_map = json.load(f)["weight_map"]
+        for full_name, shard in weight_map.items():
+            if full_name.startswith(_CODEC_IN_CKPT_PREFIX):
+                shards.setdefault(shard, []).append(full_name)  # type: ignore[union-attr]
+        break
+    else:
+        # No index file: scan every shard in the dir for the prefix.
+        for name in sorted(os.listdir(checkpoint_dir)):
+            if name.endswith(".safetensors"):
+                shards[name] = None
+
+    state: dict[str, torch.Tensor] = {}
+    for shard, names in shards.items():
+        shard_path = os.path.join(checkpoint_dir, shard)
+        with safe_open(shard_path, framework="pt") as f:
+            keys = (
+                names
+                if names is not None
+                else [k for k in f.keys() if k.startswith(_CODEC_IN_CKPT_PREFIX)]
+            )
+            for full_name in keys:
+                state[full_name[len(_CODEC_IN_CKPT_PREFIX) :]] = f.get_tensor(full_name)
+    return state
+
+
+def _to_codes_B32F(codes_F32: torch.Tensor, device: torch.device) -> torch.Tensor:
+    """Validated ``[F, 32]`` → HF Mimi layout ``[1, 32, F]`` long on device."""
+    if codes_F32.ndim != 2 or codes_F32.shape[1] != _NUM_CODEBOOKS:
+        raise ValueError(
+            f"codes must be 2-D [F, {_NUM_CODEBOOKS}], got {tuple(codes_F32.shape)}"
+        )
+    return codes_F32.transpose(0, 1).unsqueeze(0).to(device=device, dtype=torch.long)
+
+
+class CsmMimiCodec:
+    """Wraps ``transformers.MimiModel`` for encode (audio_encoder stage) and
+    decode (vocoder stage). One process-wide instance per (path, device,
+    dtype) via :func:`sglang_omni.models.csm_tts.utils.get_or_load_codec`."""
+
+    SAMPLE_RATE = 24000
+    SAMPLES_PER_FRAME = 1920  # asserted from config sampling_rate / frame_rate
+
+    def __init__(self, model: Any, device: str, dtype: torch.dtype) -> None:
+        """Hold the realized ``MimiModel`` + device/dtype; assert
+        ``sampling_rate / frame_rate == 1920``."""
+        cfg = model.config
+        samples_per_frame = int(round(cfg.sampling_rate / cfg.frame_rate))
+        if (
+            int(cfg.sampling_rate) != self.SAMPLE_RATE
+            or samples_per_frame != self.SAMPLES_PER_FRAME
+        ):
+            raise ValueError(
+                f"Mimi config mismatch: sampling_rate={cfg.sampling_rate}, "
+                f"frame_rate={cfg.frame_rate} → {samples_per_frame} samples/frame; "
+                f"expected {self.SAMPLE_RATE} Hz / {self.SAMPLES_PER_FRAME}."
+            )
+        self.model = model
+        self.device = torch.device(device)
+        self.dtype = dtype
+        # Process-wide sanitize telemetry (fence #2); the vocoder additionally
+        # tracks per-request counts. Gate-able only at temp=0.
+        self.clamp_count = 0
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        checkpoint_dir: str,
+        device: str = "cuda",
+        dtype: torch.dtype = torch.float32,
+    ) -> "CsmMimiCodec":
+        """Build a ``MimiModel`` from the CSM checkpoint's ``codec_model.*``
+        tensors (NOT a separate kyutai repo download).
+
+        Returns:
+            :class:`CsmMimiCodec` on ``device`` in ``dtype`` (fp32 default).
+        """
+        from transformers import MimiConfig, MimiModel
+
+        config_path = os.path.join(checkpoint_dir, "config.json")
+        with open(config_path) as f:
+            csm_cfg = json.load(f)
+        codec_cfg = csm_cfg.get("codec_config")
+        if not isinstance(codec_cfg, dict):
+            raise ValueError(
+                f"{config_path} has no embedded codec_config dict; cannot "
+                "build the bundled Mimi codec."
+            )
+        codec_cfg = dict(codec_cfg)
+        for key in ("architectures", "torch_dtype", "transformers_version"):
+            codec_cfg.pop(key, None)
+        config = MimiConfig(**codec_cfg)
+        model = MimiModel(config).eval()
+
+        state = _load_codec_state_dict(checkpoint_dir)
+        if not state:
+            raise FileNotFoundError(
+                f"No codec weights found under {_CODEC_IN_CKPT_PREFIX!r} in "
+                f"{checkpoint_dir}; this checkpoint doesn't bundle Mimi."
+            )
+        missing, unexpected = model.load_state_dict(state, strict=False)
+        if unexpected:
+            raise RuntimeError(
+                f"Mimi codec load got {len(unexpected)} unexpected tensors "
+                f"(e.g. {unexpected[:3]}); checkpoint/transformers mismatch."
+            )
+        # Non-persistent buffers (rope inv_freq etc.) are regenerated at init;
+        # anything beyond that means a real architecture mismatch.
+        if len(missing) > len(state) // 2:
+            raise RuntimeError(
+                f"Mimi codec load is too sparse: {len(missing)} missing / "
+                f"{len(state)} loaded; embedded codec_config may be out of sync."
+            )
+        model = model.to(device=torch.device(device), dtype=dtype)
+        for p in model.parameters():
+            p.requires_grad_(False)
+        return cls(model, device=device, dtype=dtype)
+
+    @torch.no_grad()
+    def encode_reference(self, wav_11S: torch.Tensor, sample_rate: int) -> torch.Tensor:
+        """Encode one context waveform to Mimi codes.
+
+        Pads to >= 1 frame; transposes HF's ``[1, 32, F]`` output.
+
+        Args:
+            wav_11S: float32 ``[1, 1, S]`` mono.
+            sample_rate: must be 24000 (caller resamples).
+
+        Returns:
+            int64 ``[F, 32]``, values in ``[0, 2047]``.
+        """
+        if sample_rate != self.SAMPLE_RATE:
+            raise ValueError(
+                f"encode_reference expects {self.SAMPLE_RATE} Hz audio "
+                f"(caller resamples), got {sample_rate}"
+            )
+        wav = wav_11S
+        if wav.ndim == 1:
+            wav = wav.view(1, 1, -1)
+        elif wav.ndim == 2:
+            wav = wav.unsqueeze(0)
+        if wav.ndim != 3 or wav.shape[0] != 1 or wav.shape[1] != 1:
+            raise ValueError(
+                f"waveform must be mono [1, 1, S], got {tuple(wav_11S.shape)}"
+            )
+        if wav.shape[-1] < self.SAMPLES_PER_FRAME:
+            wav = F.pad(wav, (0, self.SAMPLES_PER_FRAME - wav.shape[-1]))
+        wav = wav.to(device=self.device, dtype=self.dtype)
+        codes_B32F = self.model.encode(wav).audio_codes
+        return codes_B32F.squeeze(0).transpose(0, 1).to(torch.long).cpu()
+
+    @torch.no_grad()
+    def decode(self, codes_F32: torch.Tensor) -> torch.Tensor:
+        """Decode a code matrix to a waveform (stateless path).
+
+        Transposes to ``[1, 32, F]``, applies the :func:`sanitize_for_mimi`
+        clamp guard, decodes.
+
+        Args:
+            codes_F32: int64 ``[F, 32]``.
+
+        Returns:
+            float32 ``[1, S]`` with ``S == F * 1920``.
+        """
+        # Clone so the caller's tensor is never mutated by the in-place clamp.
+        codes = codes_F32.detach().to(torch.long).clone()
+        codes = self._sanitize_counted(codes, "decode")
+        codes_B32F = _to_codes_B32F(codes, self.device)
+        wave = self.model.decode(codes_B32F).audio_values.squeeze(0)
+        return self._exact_frames(wave, int(codes.shape[0])).to(torch.float32).cpu()
+
+    @torch.no_grad()
+    def decode_batch(self, items: list[torch.Tensor]) -> list[torch.Tensor]:
+        """Bucketed batch decode (exact-frame-count buckets, higgs
+        ``_bucketed_batch`` copy) for the non-streaming path.
+
+        Args:
+            items: list of int64 ``[F_i, 32]``.
+
+        Returns:
+            list of float32 ``[1, S_i]`` aligned with the input order.
+        """
+
+        def _batch_fn(batch_items: list[torch.Tensor]) -> list[torch.Tensor]:
+            stacked = torch.stack(
+                [it.detach().to(torch.long) for it in batch_items]
+            )  # [B, F, 32]; stack copies, so the in-place clamp is safe
+            stacked = self._sanitize_counted(stacked, "decode_batch")
+            codes_B32F = stacked.transpose(1, 2).to(
+                device=self.device, dtype=torch.long
+            )
+            audio = self.model.decode(codes_B32F).audio_values  # [B, 1, S]
+            num_frames = int(stacked.shape[1])
+            return [
+                self._exact_frames(audio[j], num_frames).to(torch.float32).cpu()
+                for j in range(len(batch_items))
+            ]
+
+        return self._bucketed_batch(
+            items,
+            bucket_key_fn=lambda c: int(c.shape[0]),
+            single_fn=self.decode,
+            batch_fn=_batch_fn,
+            error_label="CSM Mimi decode_batch",
+        )
+
+    @torch.no_grad()
+    def streaming_decode(
+        self, codes_F32: torch.Tensor, past_key_values: Any | None
+    ) -> tuple[torch.Tensor, Any]:
+        """Stateful incremental decode wrapping
+        ``MimiModel.decode(..., decoder_past_key_values=...)``; the
+        per-request state object is OWNED by the vocoder scheduler and dropped
+        in ``clear_stream_state``. This stateful path is optional and not the
+        shipped default; the default vocoder uses stateless overlap-trim decode.
+
+        Args:
+            codes_F32: int64 ``[F_new, 32]`` delta frames.
+            past_key_values: Mimi decoder KV state or ``None`` on first call.
+
+        Returns:
+            ``(wave float32 [1, F_new * 1920], new past_key_values)``.
+        """
+        if past_key_values is None:
+            # Force the cache path (the bundled codec_config ships
+            # use_cache=False); only the decoder TRANSFORMER KV persists — the
+            # CNN/upsample ladder has no conv-state cache (HF docstring,
+            # modeling_mimi.py:1641-1643), hence the trailing-trim below.
+            from transformers.cache_utils import DynamicCache
+
+            past_key_values = DynamicCache()
+        codes = codes_F32.detach().to(torch.long).clone()
+        codes = self._sanitize_counted(codes, "streaming_decode")
+        codes_B32F = _to_codes_B32F(codes, self.device)
+        out = self.model.decode(codes_B32F, decoder_past_key_values=past_key_values)
+        wave = out.audio_values.squeeze(0)
+        num_frames = int(codes.shape[0])
+        expected = num_frames * self.SAMPLES_PER_FRAME
+        if wave.shape[-1] > expected:
+            wave = wave[..., :expected]  # CNN edge overrun; extra steps trimmed
+        return wave.to(torch.float32).cpu(), out.decoder_past_key_values
+
+    # --- internals ------------------------------------------------------------
+
+    def _sanitize_counted(self, codes: torch.Tensor, where: str) -> torch.Tensor:
+        codes, num_clamped = sanitize_for_mimi(codes)
+        if num_clamped:
+            self.clamp_count += num_clamped
+            logger.warning(
+                "CSM Mimi %s clamped %d OOB codes (>= %d); total=%d",
+                where,
+                num_clamped,
+                _MIMI_CODEBOOK_SIZE,
+                self.clamp_count,
+            )
+        return codes
+
+    def _exact_frames(self, wave: torch.Tensor, num_frames: int) -> torch.Tensor:
+        """Enforce the ``S == F * 1920`` contract the vocoder framing math
+        relies on (Mimi full decode is exact; spec)."""
+        expected = num_frames * self.SAMPLES_PER_FRAME
+        if wave.shape[-1] > expected:
+            return wave[..., :expected]
+        if wave.shape[-1] < expected:
+            raise RuntimeError(
+                f"Mimi decode returned {int(wave.shape[-1])} samples for "
+                f"{num_frames} frames; expected {expected}."
+            )
+        return wave
+
+    def _bucketed_batch(
+        self,
+        items: list[torch.Tensor],
+        *,
+        bucket_key_fn: Callable[[torch.Tensor], int],
+        single_fn: Callable[[torch.Tensor], torch.Tensor],
+        batch_fn: Callable[[list[torch.Tensor]], list[torch.Tensor]],
+        error_label: str,
+    ) -> list[torch.Tensor]:
+        """Run single_fn on singleton buckets and batch_fn on multi-item
+        buckets (higgs audio_codec._bucketed_batch copy)."""
+        if not items:
+            return []
+        if len(items) == 1:
+            return [single_fn(items[0])]
+
+        buckets: dict[int, list[int]] = {}
+        for i, item in enumerate(items):
+            buckets.setdefault(bucket_key_fn(item), []).append(i)
+
+        results: list[torch.Tensor | None] = [None] * len(items)
+        for indices in buckets.values():
+            if len(indices) == 1:
+                results[indices[0]] = single_fn(items[indices[0]])
+            else:
+                batch_results = batch_fn([items[i] for i in indices])
+                for idx, result in zip(indices, batch_results):
+                    results[idx] = result
+
+        out: list[torch.Tensor] = []
+        for i, result in enumerate(results):
+            if result is None:
+                raise RuntimeError(f"{error_label} did not produce result for item {i}")
+            out.append(result)
+        return out
+
+
+__all__ = ["CsmMimiCodec", "sanitize_for_mimi", "trim_at_first_all_zero_frame"]

--- a/sglang_omni/models/csm_tts/config.py
+++ b/sglang_omni/models/csm_tts/config.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# Pipeline config follows the sglang-omni TTS pipeline-config pattern (cf. Higgs / Qwen3-TTS).
+"""Pipeline configuration for CSM TTS (V1).
+
+MUST stay sglang/CUDA-free: ``import_pipeline_configs`` pkgutil-scans
+``sglang_omni/models/*`` and SILENTLY skips packages whose import fails — so
+this module never imports ``stages.py`` (the way higgs config.py:9 does); the
+concurrency constant is inlined instead.
+
+
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from sglang_omni.config import PipelineConfig, StageConfig
+
+_PKG = "sglang_omni.models.csm_tts"
+
+# Inlined (do NOT import stages.py — registry-silent-skip gotcha). Keep in
+# sync with stages.DEFAULT_MAX_CONCURRENCY.
+_DEFAULT_MAX_CONCURRENCY = 8
+
+
+class CsmTtsPipelineConfig(PipelineConfig):
+    """4-stage CSM TTS pipeline:
+    preprocessing → audio_encoder → tts_engine → vocoder.
+
+    Scheduler-visible AR step = one 80 ms frame (paged backbone forward →
+    cb0 sample → 31-step depth inner AR → 32-code frame → streamed to the
+    vocoder). Every non-terminal stage sets ``next=`` — schema validation
+    requires exactly one of ``next``/``terminal`` per stage
+    (config/schema.py:298-302).
+    """
+
+    architecture: ClassVar[str] = "CsmForConditionalGeneration"
+
+    model_path: str
+    stages: list[StageConfig] = [
+        StageConfig(
+            name="preprocessing",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_preprocessing_executor",
+            factory_args={"max_concurrency": _DEFAULT_MAX_CONCURRENCY},
+            next="audio_encoder",
+        ),
+        StageConfig(
+            name="audio_encoder",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_audio_encoder_executor",
+            factory_args={
+                "device": "cuda",
+                "max_batch_size": _DEFAULT_MAX_CONCURRENCY,
+            },
+            gpu=0,
+            next="tts_engine",
+        ),
+        # Engine-tuning defaults live in the FACTORY, not here (contract):
+        # stages.create_sglang_tts_engine_executor pins the 3060 budget from
+        # the VRAM table — context_length=2048, mem_fraction_static
+        # 0.5, cuda_graph_max_bs 8, dtype bfloat16, and disable_cuda_graph=
+        # True (eager is the correctness baseline; set False to enable CUDA graphs). The
+        # YAML's server_args_overrides deep-merge over those defaults.
+        StageConfig(
+            name="tts_engine",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_sglang_tts_engine_executor",
+            factory_args={
+                "device": "cuda",
+                "max_new_tokens": 125,  # frames (DEFAULT_MAX_FRAMES)
+                "enable_async_decode": False,  # set True to enable async decode
+                "server_args_overrides": {
+                    "max_running_requests": _DEFAULT_MAX_CONCURRENCY,
+                },
+            },
+            gpu=0,
+            next="vocoder",
+            stream_to=["vocoder"],
+        ),
+        StageConfig(
+            name="vocoder",
+            process="pipeline",
+            factory=f"{_PKG}.stages.create_vocoder_executor",
+            factory_args={
+                "device": "cuda",
+                "dtype": "float32",  # conv-transpose decode stability
+                "max_batch_size": _DEFAULT_MAX_CONCURRENCY,
+            },
+            gpu=0,
+            terminal=True,
+            can_accept_stream_before_payload=True,
+        ),
+    ]
+
+
+EntryClass = CsmTtsPipelineConfig

--- a/sglang_omni/models/csm_tts/hf_config.py
+++ b/sglang_omni/models/csm_tts/hf_config.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+# Builds on HuggingFace Transformers' CSM config (`transformers/models/csm`, Apache-2.0).
+"""HF config wrapper + synthetic sub-configs for CSM-1B (``sesame/csm-1b``).
+
+CSM's native ``transformers.CsmConfig`` stores the backbone fields FLAT (not as
+a nested ``text_config``) and its ``get_text_config()`` returns ``self`` with
+``vocab_size=2051`` — useless for SGLang's ``ModelConfig.from_server_args``,
+which reads head counts / hidden size / layers / vocab through
+``get_text_config()``. This module synthesizes a real ``LlamaConfig`` for the
+backbone and a small namespace config for the depth decoder.
+
+Must stay sglang/CUDA-free: imported by ``csm_tts/__init__.py`` during the
+registry pkgutil scan (contract).
+
+
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import transformers
+from transformers import CsmConfig, LlamaConfig
+
+# Pinned CSM-1B rope scaling (config.json:105-111 backbone, :80-86 depth);
+# also the fallback when a (test) config omits the fields.
+_BACKBONE_ROPE_SCALING: dict[str, Any] = {
+    "rope_type": "llama3",
+    "factor": 32.0,
+    "low_freq_factor": 0.125,
+    "high_freq_factor": 0.5,
+    "original_max_position_embeddings": 1024,
+}
+_DEPTH_ROPE_SCALING: dict[str, Any] = {
+    "rope_type": "llama3",
+    "factor": 32.0,
+    "low_freq_factor": 0.001953125,
+    "high_freq_factor": 0.0078125,
+    "original_max_position_embeddings": 16,
+}
+_DEFAULT_ROPE_THETA = 500000.0
+
+
+def _cfg_get(cfg: Any, name: str, default: Any) -> Any:
+    """Field read off a PretrainedConfig / SimpleNamespace / dict / None."""
+    if cfg is None:
+        value = None
+    elif isinstance(cfg, dict):
+        value = cfg.get(name)
+    else:
+        value = getattr(cfg, name, None)
+    return default if value is None else value
+
+
+def _rope_fields(
+    cfg: Any, default_scaling: dict[str, Any]
+) -> tuple[float, dict[str, Any]]:
+    """``(rope_theta, rope_scaling)`` from either layout: transformers<5
+    ``rope_theta`` + ``rope_scaling`` attrs (the checkpoint's serialized form)
+    or the v5 merged ``rope_parameters`` dict."""
+    theta = _cfg_get(cfg, "rope_theta", None)
+    scaling = _cfg_get(cfg, "rope_scaling", None)
+    if scaling is None:
+        params = _cfg_get(cfg, "rope_parameters", None)
+        if isinstance(params, dict):
+            theta = params.get("rope_theta", theta)
+            scaling = {k: v for k, v in params.items() if k != "rope_theta"}
+    scaling = dict(scaling) if scaling else dict(default_scaling)
+    scaling.setdefault("rope_type", "llama3")
+    return float(theta if theta is not None else _DEFAULT_ROPE_THETA), scaling
+
+
+def build_backbone_llama_config(csm_cfg: Any) -> LlamaConfig:
+    """Synthesize the SGLang-loadable backbone ``LlamaConfig``.
+
+    Reads the FLAT backbone fields off the HF ``CsmConfig`` and realizes:
+
+    - ``hidden_size=2048``, ``num_hidden_layers=16``, ``num_attention_heads=32``,
+      ``num_key_value_heads=8``, ``head_dim=64``, ``intermediate_size=8192``
+    - ``max_position_embeddings=2048`` (hard model ceiling)
+    - ``rope_theta=500000``,
+      ``rope_scaling={"rope_type": "llama3", "factor": 32.0,
+      "low_freq_factor": 0.125, "high_freq_factor": 0.5,
+      "original_max_position_embeddings": 1024}``
+    - ``vocab_size=128256`` (text vocab IS the backbone embedding)
+    - ``tie_word_embeddings=True`` — sglang ``LlamaForCausalLM``'s lm_head then
+      aliases ``embed_tokens``, avoiding a dead 525 MB bf16 text head that we
+      never use (cb0 comes from ``codebook0_head``, not the backbone lm_head).
+
+    Args:
+        csm_cfg: the (possibly wrapped) HF ``CsmConfig`` for ``sesame/csm-1b``.
+
+    Returns:
+        A concrete ``transformers.LlamaConfig``.
+    """
+    rope_theta, rope_scaling = _rope_fields(csm_cfg, _BACKBONE_ROPE_SCALING)
+    return LlamaConfig(
+        vocab_size=_cfg_get(csm_cfg, "text_vocab_size", 128256),
+        hidden_size=_cfg_get(csm_cfg, "hidden_size", 2048),
+        intermediate_size=_cfg_get(csm_cfg, "intermediate_size", 8192),
+        num_hidden_layers=_cfg_get(csm_cfg, "num_hidden_layers", 16),
+        num_attention_heads=_cfg_get(csm_cfg, "num_attention_heads", 32),
+        num_key_value_heads=_cfg_get(csm_cfg, "num_key_value_heads", 8),
+        head_dim=_cfg_get(csm_cfg, "head_dim", 64),
+        hidden_act=_cfg_get(csm_cfg, "hidden_act", "silu"),
+        max_position_embeddings=_cfg_get(csm_cfg, "max_position_embeddings", 2048),
+        rms_norm_eps=_cfg_get(csm_cfg, "rms_norm_eps", 1e-5),
+        rope_theta=rope_theta,
+        rope_scaling=rope_scaling,
+        attention_bias=_cfg_get(csm_cfg, "attention_bias", False),
+        attention_dropout=_cfg_get(csm_cfg, "attention_dropout", 0.0),
+        mlp_bias=_cfg_get(csm_cfg, "mlp_bias", False),
+        tie_word_embeddings=True,
+        bos_token_id=_cfg_get(csm_cfg, "bos_token_id", 128000),
+        eos_token_id=128001,  # <|end_of_text|>; cb0 ids (≤2050) can never collide
+        pad_token_id=_cfg_get(csm_cfg, "pad_token_id", 128002),
+    )
+
+
+def build_depth_decoder_config(csm_cfg: Any) -> SimpleNamespace:
+    """Synthesize the depth-decoder config namespace.
+
+    Depth decoder: 4 layers, ``hidden_size=1024``, 8 heads with EXPLICIT
+    ``head_dim=128`` (do not derive head_dim from hidden), 2 KV heads (GQA),
+    ``intermediate_size=8192`` (SwiGLU), ``max_position_embeddings=33`` (1
+    backbone hidden + 32 codebook positions), depth rope ``theta=500000``
+    llama3-scaled with ``factor=32.0``, ``low_freq_factor=0.001953125``,
+    ``high_freq_factor=0.0078125``, ``original_max_position_embeddings=16``.
+
+    Args:
+        csm_cfg: the HF ``CsmConfig``.
+
+    Returns:
+        ``SimpleNamespace`` (or ``PretrainedConfig``) consumed by
+        :class:`sglang_omni.models.csm_tts.modeling.CsmDepthDecoder`.
+    """
+    raw = _cfg_get(csm_cfg, "depth_decoder_config", None)
+    rope_theta, rope_scaling = _rope_fields(raw, _DEPTH_ROPE_SCALING)
+    return SimpleNamespace(
+        hidden_size=_cfg_get(raw, "hidden_size", 1024),
+        num_hidden_layers=_cfg_get(raw, "num_hidden_layers", 4),
+        num_attention_heads=_cfg_get(raw, "num_attention_heads", 8),
+        head_dim=_cfg_get(raw, "head_dim", 128),
+        num_key_value_heads=_cfg_get(raw, "num_key_value_heads", 2),
+        intermediate_size=_cfg_get(raw, "intermediate_size", 8192),
+        max_position_embeddings=_cfg_get(raw, "max_position_embeddings", 33),
+        backbone_hidden_size=_cfg_get(raw, "backbone_hidden_size", 2048),
+        vocab_size=_cfg_get(raw, "vocab_size", 2051),
+        num_codebooks=_cfg_get(raw, "num_codebooks", 32),
+        rms_norm_eps=_cfg_get(raw, "rms_norm_eps", 1e-5),
+        hidden_act=_cfg_get(raw, "hidden_act", "silu"),
+        attention_bias=_cfg_get(raw, "attention_bias", False),
+        mlp_bias=_cfg_get(raw, "mlp_bias", False),
+        rope_theta=rope_theta,
+        rope_scaling=rope_scaling,
+    )
+
+
+class CsmTtsHfConfig(CsmConfig):
+    """``CsmConfig`` subclass whose ``get_text_config()`` returns the realized
+    synthetic backbone ``LlamaConfig``.
+
+    Subclassing the native class keeps ``isinstance`` and field compatibility
+    for HF-side tooling, and inherits ``model_type="csm"`` so
+    ``AutoConfig.register("csm", ..., exist_ok=True)`` passes the model-type
+    consistency check (override semantics: ``_LazyConfigMapping._extra_content``
+    is consulted BEFORE the native mapping — the override wins in-process;
+    confirm in the container via ``AutoConfig.for_model("csm")``).
+
+    """
+
+    def get_text_config(self, decoder: bool = False) -> transformers.PretrainedConfig:
+        """Return the synthetic backbone ``LlamaConfig`` (NOT ``self``).
+
+        Native ``CsmConfig.get_text_config()`` would return ``self`` with
+        ``vocab_size=2051``; SGLang reads head counts / hidden / layers / vocab
+        through this hook, so it must see the 2048-hidden / 16-layer / 128256-
+        vocab backbone view.
+        """
+        del decoder
+        cached = self.__dict__.get("_csm_backbone_llama_config")
+        if cached is None:
+            cached = build_backbone_llama_config(self)
+            # Cached for object stability (callers may hold + mutate the
+            # returned reference, higgs pattern); stripped from serialization
+            # in to_dict() below.
+            self.__dict__["_csm_backbone_llama_config"] = cached
+        return cached
+
+    def to_dict(self) -> dict[str, Any]:
+        output = super().to_dict()
+        output.pop("_csm_backbone_llama_config", None)
+        return output
+
+
+__all__ = [
+    "CsmTtsHfConfig",
+    "build_backbone_llama_config",
+    "build_depth_decoder_config",
+]

--- a/sglang_omni/models/csm_tts/model.py
+++ b/sglang_omni/models/csm_tts/model.py
@@ -1,0 +1,594 @@
+# SPDX-License-Identifier: Apache-2.0
+# CSM-1B (sesame/csm-1b): an SGLang `LlamaForCausalLM` backbone + the CSM depth decoder
+# ported from HuggingFace Transformers `transformers/models/csm` (Apache-2.0), integrated via
+# the sglang-omni TTS model pattern (cf. Higgs / Qwen3-TTS).
+"""SGLang-integrated CSM-1B model: paged Llama backbone + cb0 head + dense
+depth decoder, with the 31-step depth loop INSIDE the scheduler-visible
+decode step (1 frame = 1 backbone position = 1 SGLang "token").
+
+Registered as ``CsmForConditionalGeneration`` in
+:meth:`sglang_omni.model_runner.sglang_model_runner.SGLModelRunner._register_omni_model`.
+
+The backbone runs under SGLang paged/varlen attention (composed
+``LlamaForCausalLM``) — no dense left-padded batch, which sidesteps the known
+bf16 B>=2 left-pad KV-corruption trap by construction.
+
+
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Tuple
+
+import torch
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.models.llama import LlamaForCausalLM
+from sglang.srt.utils import add_prefix
+from torch import nn
+
+from sglang_omni.models.csm_tts.hf_config import (
+    CsmTtsHfConfig,
+    build_backbone_llama_config,
+    build_depth_decoder_config,
+)
+from sglang_omni.models.csm_tts.modeling import CsmDepthDecoder, CsmFrameEmbedding
+from sglang_omni.models.csm_tts.sampler import (
+    K_MAX,
+    STAGING_WIDTH,
+    CsmBatchedSamplerState,
+    frame_finalize_direct,
+    sample_codes_batched,
+)
+from sglang_omni.models.csm_tts.utils import NUM_CODEBOOKS
+from sglang_omni.models.csm_tts.weight_loader import CsmWeightMapper
+
+_DEFAULT_MAX_BATCH_SIZE = 64
+
+
+@dataclass
+class CsmGenParams:
+    """Per-request generation params — TWO sampling sets:
+    cb0 rides SGLang's ``sampling_info``; the depth set is CSM-private
+    (defaults (0.9, 50), HF parity) and travels via ``req._omni_data``."""
+
+    temperature: float = 0.9
+    top_k: int = 50
+    top_p: float | None = None
+    depth_temperature: float = 0.9
+    depth_top_k: int = 50
+    seed: int | None = None
+
+
+def _flat_sampling_attr(sampling_info: Any, attr: str) -> list | None:
+    """Read a flat per-row attribute off SGLang's ``sampling_info`` (one D2H
+    per attribute; higgs pattern). Returns ``None`` when absent."""
+    val = getattr(sampling_info, attr, None)
+    if val is None:
+        return None
+    if hasattr(val, "cpu"):
+        return val.detach().cpu().flatten().tolist()
+    return list(val)
+
+
+def _normalize_top_k(top_k: Any) -> int:
+    """Map a raw top_k (incl. SGLang's TOP_K_ALL sentinel / -1 / 0 / huge) to
+    a valid filter width: values outside ``(0, K_MAX]`` become ``K_MAX``
+    (= no-op filter)."""
+    try:
+        k = int(top_k)
+    except (TypeError, ValueError):
+        return K_MAX
+    return k if 0 < k <= K_MAX else K_MAX
+
+
+class CsmTTSModel(nn.Module):
+    """CSM-1B for SGLang: ``backbone`` (paged LlamaForCausalLM, 16L/2048/
+    32h/8kv/hd64, ctx 2048, tie_word_embeddings=True so the never-used text
+    lm_head is free), ``frame_embedding`` ([65632, 2048] fused audio table),
+    ``codebook0_head`` (Linear 2048→2051, no bias — loaded from the ckpt's
+    ``lm_head.weight``), and ``depth_decoder`` (4L dense, slot-indexed static
+    KV ``[4, max_slots, 2, 33, 128]`` bf16).
+
+    Sampler pool: :class:`CsmBatchedSamplerState` with
+    ``pool_size = max_batch_size + 1`` (last row = padding row);
+    ``_rid_to_row`` / ``_free_rows`` / ``acquire_row`` / ``release_row`` /
+    ``reset_request`` follow higgs verbatim.
+
+    CG shadow buffers (pool-sized, sliced ``[:bs]`` in-graph):
+    ``_cg_row_indices`` (long), ``_cg_temperature`` / ``_cg_top_p`` (fp32),
+    ``_cg_top_k_buf`` (long, = K_MAX neutral), ``_cg_depth_temperature``
+    (fp32) + ``_cg_depth_top_k_buf`` (long) — the CSM-delta second param set,
+    ``_cg_codes_BN`` (long [P, 32]), ``_cg_collect_staging`` (long [P, 34] =
+    ``c0..c31 | was_done | generation_done``), ``_cg_was_done`` (bool),
+    ``_cg_active_generation_done`` (bool), ``_cg_active_last_codes``
+    (long [P, 32]).
+
+
+    """
+
+    def __init__(
+        self,
+        config: CsmTtsHfConfig,
+        quant_config: Any | None = None,
+        prefix: str = "",
+        max_batch_size: int = _DEFAULT_MAX_BATCH_SIZE,
+    ) -> None:
+        super().__init__()
+        self.config = config
+
+        self.backbone = LlamaForCausalLM(
+            build_backbone_llama_config(config),
+            quant_config=quant_config,
+            prefix=add_prefix("backbone", prefix),
+        )
+
+        depth_cfg = build_depth_decoder_config(config)
+        self._num_codebooks = int(depth_cfg.num_codebooks)
+        self._codebook_vocab = int(depth_cfg.vocab_size)
+        backbone_hidden = int(self.backbone.config.hidden_size)
+
+        self.frame_embedding = CsmFrameEmbedding(
+            num_codebooks=self._num_codebooks,
+            codebook_vocab=self._codebook_vocab,
+            hidden_size=backbone_hidden,
+        )
+        self.codebook0_head = nn.Linear(
+            backbone_hidden, self._codebook_vocab, bias=False
+        )
+
+        self._max_batch_size = int(max_batch_size)
+        pool_size = self._max_batch_size + 1
+        # frame_embedding is SHARED with the depth decoder (tied table);
+        # depth KV is slot-indexed so max_slots = pool_size covers any batch.
+        self.depth_decoder = CsmDepthDecoder(
+            depth_cfg, self.frame_embedding, max_slots=pool_size
+        )
+        # Loader-visible alias: the remap routes the checkpoint's
+        # ``depth_decoder.codebooks_head.weight`` to ``codebooks_head.weight``;
+        # registering the same module under this name makes that resolve
+        # without touching the mapper (same Parameter object).
+        self.codebooks_head = self.depth_decoder.codebooks_head
+
+        # Match backbone bf16 dtype (higgs "~1 ULP/step" note); buffers
+        # (rope cos/sin, mask, depth static KV) cast along with parameters.
+        backbone_dtype = self.backbone.model.embed_tokens.weight.dtype
+        self.frame_embedding.to(dtype=backbone_dtype)
+        self.codebook0_head.to(dtype=backbone_dtype)
+        self.depth_decoder.to(dtype=backbone_dtype)
+
+        device = self.backbone.model.embed_tokens.weight.device
+        self._sampler_pool = CsmBatchedSamplerState(pool_size, device=device)
+        self._padding_row = self._max_batch_size  # last row reserved
+        self._rid_to_row: dict[str, int] = {}
+        self._free_rows: list[int] = list(range(self._max_batch_size))
+        self._output_codes: dict[str, list[torch.Tensor]] = {}
+
+        self._cg_row_indices = torch.zeros(pool_size, dtype=torch.long, device=device)
+        self._cg_temperature = torch.ones(pool_size, dtype=torch.float32, device=device)
+        self._cg_top_p = torch.ones(pool_size, dtype=torch.float32, device=device)
+        self._cg_top_k_buf = torch.full(
+            (pool_size,), K_MAX, dtype=torch.long, device=device
+        )
+        # CSM delta vs higgs: second (depth-decoder-private) sampling set.
+        self._cg_depth_temperature = torch.ones(
+            pool_size, dtype=torch.float32, device=device
+        )
+        self._cg_depth_top_k_buf = torch.full(
+            (pool_size,), K_MAX, dtype=torch.long, device=device
+        )
+        self._cg_codes_BN = torch.zeros(
+            pool_size, NUM_CODEBOOKS, dtype=torch.long, device=device
+        )
+        # Packed D2H row: c0..c31 | was_done | generation_done.
+        self._cg_collect_staging = torch.zeros(
+            pool_size, STAGING_WIDTH, dtype=torch.long, device=device
+        )
+        self._cg_was_done = torch.zeros(pool_size, dtype=torch.bool, device=device)
+        self._cg_active_generation_done = torch.zeros(
+            pool_size, dtype=torch.bool, device=device
+        )
+        self._cg_active_last_codes = torch.zeros(
+            pool_size, NUM_CODEBOOKS, dtype=torch.long, device=device
+        )
+
+    def get_input_embeddings(self) -> nn.Embedding:
+        return self.backbone.get_input_embeddings()
+
+    @property
+    def num_codebooks(self) -> int:
+        return self._num_codebooks
+
+    @property
+    def codebook_vocab_size(self) -> int:
+        return self._codebook_vocab
+
+    # --- sampler-pool row lifecycle (higgs verbatim) -------------------------
+
+    def acquire_row(self, req_id: str) -> int:
+        """Bind ``req_id`` to a free pool row (reset on acquire). Returns row."""
+        row = self._rid_to_row.get(req_id)
+        if row is not None:
+            return row
+        if not self._free_rows:
+            raise RuntimeError(
+                f"CsmTTSModel sampler pool exhausted (max_batch_size="
+                f"{self._max_batch_size}); raise ``max_batch_size`` or limit "
+                f"concurrent requests."
+            )
+        row = self._free_rows.pop()
+        self._rid_to_row[req_id] = row
+        self._sampler_pool.reset_row(row)
+        return row
+
+    def release_row(self, req_id: str) -> None:
+        """Return the row bound to ``req_id`` to the free list (idempotent)."""
+        row = self._rid_to_row.pop(req_id, None)
+        if row is not None:
+            self._free_rows.append(row)
+        self._output_codes.pop(req_id, None)
+
+    def reset_request(self, req_id: str) -> None:
+        """Abort/result-adapter hook: release the sampler row + drop
+        ``_output_codes[req_id]`` (wired as ``OmniScheduler.abort_callback``)."""
+        self.release_row(req_id)
+
+    def get_output_codes(self, req_id: str) -> torch.Tensor:
+        """All frames emitted so far for ``req_id``.
+
+        Returns:
+            int64 CPU ``[F, 32]`` (includes the EOS frame — HF ``sequences``
+            parity; the vocoder never receives it).
+        """
+        codes = self._output_codes.get(req_id)
+        if not codes:
+            return torch.empty(0, self._num_codebooks, dtype=torch.long)
+        return torch.stack(codes, dim=0).to(torch.long).cpu()
+
+    # --- forward -------------------------------------------------------------
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: Any,
+        input_embeds: torch.Tensor | None = None,
+        **kwargs: Any,
+    ) -> LogitsProcessorOutput:
+        """One scheduler step.
+
+        Decode: ``input_embeds = _decode_step_embeds_cg(bs)``; prefill: the
+        runner supplies overlay embeds. Then ``hidden = self.backbone.model(
+        input_ids, positions, forward_batch, input_embeds)`` — SGLang's
+        LlamaModel applies the final RMSNorm (upstream llama.py:400), giving
+        the POST-norm hidden CSM's depth conditioning requires. Last-token
+        hidden via ``cumsum(extend_seq_lens) - 1`` on prefill. Then
+        ``decode_codebooks_batch_cg(hidden)`` (decode) or
+        ``decode_codebooks_batch(hidden, req_ids, gen_params)`` (prefill —
+        frame 0 IS sampled at prefill, like higgs).
+
+        Args:
+            input_ids: int64 ``[T_total]`` (decode: ``[bs]``).
+            positions: int64 ``[T_total]``.
+            forward_batch: SGLang ``ForwardBatch``.
+            input_embeds: optional ``[T_total, 2048]`` bf16 overlay.
+
+        Returns:
+            Dummy ``LogitsProcessorOutput(next_token_logits=zeros(bs,
+            vocab_size, fp32))``: cb0 is published via the runner, logit
+            processors run over zeros harmlessly.
+        """
+        is_decode = self._is_decode_step(forward_batch)
+
+        if is_decode:
+            input_embeds = self._decode_step_embeds_cg(int(input_ids.shape[0]))
+        else:
+            req_ids, gen_params = self._extract_batch_metadata(forward_batch)
+
+        hidden_states = self.backbone.model(
+            input_ids,
+            positions,
+            forward_batch,
+            input_embeds,
+        )
+
+        if (
+            not is_decode
+            and hasattr(forward_batch, "forward_mode")
+            and forward_batch.forward_mode.is_extend()
+            and getattr(forward_batch, "extend_seq_lens", None) is not None
+        ):
+            last_index = torch.cumsum(forward_batch.extend_seq_lens, dim=0) - 1
+            hidden_states_last = hidden_states[last_index]
+        else:
+            hidden_states_last = hidden_states
+            if hidden_states_last.ndim == 3:
+                hidden_states_last = hidden_states_last[:, -1, :]
+
+        if is_decode:
+            self.decode_codebooks_batch_cg(hidden_states_last)
+        else:
+            self.decode_codebooks_batch(hidden_states_last, req_ids, gen_params)
+
+        batch_size = hidden_states_last.shape[0]
+        text_logits_BV = torch.zeros(
+            (batch_size, self.backbone.config.vocab_size),
+            device=hidden_states_last.device,
+            dtype=torch.float32,
+        )
+        return LogitsProcessorOutput(
+            next_token_logits=text_logits_BV,
+            hidden_states=hidden_states_last,
+        )
+
+    def _decode_step_embeds_cg(self, bs: int) -> torch.Tensor:
+        """UNCONDITIONAL ``frame_embedding(_cg_active_last_codes[:bs])`` —
+        post-prefill a last frame always exists (no higgs ``delay_count>0``
+        text fallback; padding rows embed zeros-garbage that the collect
+        discards).
+
+        Returns:
+            bf16 ``[bs, 2048]``.
+        """
+        return self.frame_embedding(self._cg_active_last_codes[:bs])
+
+    @torch.no_grad()
+    def decode_codebooks_batch_cg(self, hidden_BD: torch.Tensor) -> torch.Tensor:
+        """CG decode tail: ``logits0 = codebook0_head(hidden).float()`` →
+        ``cb0 = sample_codes_batched(logits0, _cg_temperature, _cg_top_k_buf)``
+        → ``codes = depth_decoder.generate_frame(hidden, cb0,
+        _cg_depth_temperature, _cg_depth_top_k_buf, bs=bs)`` →
+        :func:`frame_finalize_direct` → write ``_cg_codes_BN`` /
+        ``_cg_was_done`` / ``_cg_active_*``. No host control flow, no D2H.
+
+        TODO: capture this whole tail (together with the backbone forward)
+        as one CUDA graph per batch size — eager-only for now.
+
+        Args:
+            hidden_BD: bf16 ``[bs, 2048]`` post-norm backbone hidden.
+
+        Returns:
+            int64 ``[bs, 32]`` finalized frame codes (STOP_CODE on frozen rows).
+        """
+        bs = int(hidden_BD.shape[0])
+
+        logits0 = self.codebook0_head(hidden_BD).to(torch.float32)
+        cb0_B = sample_codes_batched(
+            logits0,
+            self._cg_temperature[:bs],
+            self._cg_top_k_buf[:bs],
+            self._cg_top_p[:bs],
+        )
+        codes_B32 = self.depth_decoder.generate_frame(
+            hidden_BD,
+            cb0_B,
+            self._cg_depth_temperature,
+            self._cg_depth_top_k_buf,
+            bs=bs,
+        )
+
+        last_codes_in = self._cg_active_last_codes[:bs]
+        out_codes, new_done, was_done = frame_finalize_direct(
+            codes_B32, self._cg_active_generation_done[:bs]
+        )
+        self._cg_was_done[:bs] = was_done
+        self._cg_active_generation_done[:bs] = new_done
+        # Frozen rows keep their previous frame (raw sampled codes stay in
+        # embed range; STOP_CODE=-1 must never reach frame_embedding).
+        self._cg_active_last_codes[:bs] = torch.where(
+            was_done.unsqueeze(-1), last_codes_in, codes_B32
+        )
+        self._cg_codes_BN[:bs] = out_codes
+        return out_codes
+
+    @torch.no_grad()
+    def decode_codebooks_batch(
+        self,
+        hidden_BD: torch.Tensor,
+        req_ids: list[str],
+        gen_params: list[CsmGenParams],
+    ) -> torch.Tensor:
+        """Eager pool-indexed variant for PREFILL (rows via ``acquire_row``,
+        params from request data). Samples frame 0 (cb0 + full depth loop on
+        the last prompt position's hidden) and runs the SAME
+        :func:`frame_finalize_direct` EOS machine — frame-0 EOS is legal HF
+        behavior and empirically real for this checkpoint:
+        the runner then marks the request finished at prefill, emits NOTHING
+        to the vocoder, zero-decode lifecycle. Appends to
+        ``_output_codes[rid]``.
+
+        Args:
+            hidden_BD: bf16 ``[n_req, 2048]`` last-prompt-position hiddens.
+            req_ids: rids aligned with rows of ``hidden_BD``.
+            gen_params: per-request dual sampling param sets.
+
+        Returns:
+            int64 ``[n_req, 32]`` frame-0 codes.
+        """
+        batch_size = int(hidden_BD.shape[0])
+        if len(req_ids) != batch_size or len(gen_params) != batch_size:
+            raise ValueError(
+                f"batch size mismatch: hidden={batch_size}, "
+                f"req_ids={len(req_ids)}, gen_params={len(gen_params)}"
+            )
+        device = hidden_BD.device
+
+        logits0 = self.codebook0_head(hidden_BD).to(torch.float32)
+
+        row_indices = torch.tensor(
+            [self.acquire_row(rid) for rid in req_ids],
+            dtype=torch.long,
+            device=device,
+        )
+
+        temperature = torch.tensor(
+            [p.temperature for p in gen_params], dtype=torch.float32, device=device
+        )
+        has_top_p = any(p.top_p is not None for p in gen_params)
+        top_p = (
+            torch.tensor(
+                [p.top_p if p.top_p is not None else 1.0 for p in gen_params],
+                dtype=torch.float32,
+                device=device,
+            )
+            if has_top_p
+            else None
+        )
+        top_k_buf = torch.tensor(
+            [_normalize_top_k(p.top_k) for p in gen_params],
+            dtype=torch.long,
+            device=device,
+        )
+        depth_temperature = torch.tensor(
+            [p.depth_temperature for p in gen_params],
+            dtype=torch.float32,
+            device=device,
+        )
+        depth_top_k_buf = torch.tensor(
+            [_normalize_top_k(p.depth_top_k) for p in gen_params],
+            dtype=torch.long,
+            device=device,
+        )
+
+        cb0_B = sample_codes_batched(logits0, temperature, top_k_buf, top_p)
+        codes_B32 = self.depth_decoder.generate_frame(
+            hidden_BD, cb0_B, depth_temperature, depth_top_k_buf, bs=batch_size
+        )
+
+        pool = self._sampler_pool
+        out_codes, new_done, was_done = frame_finalize_direct(
+            codes_B32, pool.generation_done[row_indices]
+        )
+        pool.generation_done[row_indices] = new_done
+        pool.last_codes[row_indices] = torch.where(
+            was_done.unsqueeze(-1), pool.last_codes[row_indices], codes_B32
+        )
+        pool.frames_emitted[row_indices] += (~was_done).to(torch.int32)
+
+        # Note: one D2H per step to skip STOP-sentinel rows in the append loop
+        # (higgs pattern).
+        was_done_cpu = was_done.cpu().tolist()
+        out_codes = out_codes.detach().to(torch.long)
+        for b in range(batch_size):
+            if was_done_cpu[b]:
+                continue
+            self._output_codes.setdefault(req_ids[b], []).append(out_codes[b])
+
+        return out_codes
+
+    # --- batch metadata (prefill path) ----------------------------------------
+
+    @staticmethod
+    def _is_decode_step(forward_batch: Any) -> bool:
+        mode = getattr(forward_batch, "forward_mode", None)
+        if mode is None:
+            return False
+        is_decode = getattr(mode, "is_decode", None)
+        return bool(is_decode()) if callable(is_decode) else False
+
+    @staticmethod
+    def _infer_batch_size(forward_batch: Any) -> int:
+        seq_lens = getattr(forward_batch, "seq_lens", None)
+        if seq_lens is not None and hasattr(seq_lens, "shape"):
+            return int(seq_lens.shape[0])
+        return int(getattr(forward_batch, "batch_size", 1))
+
+    def _extract_batch_metadata(
+        self, forward_batch: Any
+    ) -> tuple[list[str], list[CsmGenParams]]:
+        req_ids_raw = getattr(forward_batch, "req_ids", None)
+        batch_size = self._infer_batch_size(forward_batch)
+        if req_ids_raw is None:
+            req_ids = [f"req-{i}" for i in range(batch_size)]
+        else:
+            req_ids = [str(r) for r in req_ids_raw]
+
+        sampling_info = getattr(forward_batch, "sampling_info", None)
+        # Depth params never ride sampling_info — the runner stamps them from
+        # ``req._omni_data`` in before_prefill.
+        depth_params = getattr(forward_batch, "csm_depth_params", None)
+        gen_params = self._gen_params_for_batch(sampling_info, depth_params, batch_size)
+        return req_ids, gen_params
+
+    @staticmethod
+    def _gen_params_for_batch(
+        sampling_info: Any,
+        depth_params: list[tuple[float, int]] | None,
+        batch_size: int,
+    ) -> list[CsmGenParams]:
+        """Per-row dual param sets: cb0 from ``sampling_info`` (one D2H per
+        attribute), depth from the runner-stamped list; HF defaults
+        (0.9, 50) for whichever side is absent."""
+        temps = top_ps = top_ks = None
+        if sampling_info is not None:
+            temps = _flat_sampling_attr(sampling_info, "temperatures")
+            top_ps = _flat_sampling_attr(sampling_info, "top_ps")
+            top_ks = _flat_sampling_attr(sampling_info, "top_ks")
+
+        params: list[CsmGenParams] = []
+        for b in range(batch_size):
+            p = CsmGenParams()
+            if temps is not None:
+                p.temperature = float(temps[b])
+            if top_ps is not None:
+                p.top_p = float(top_ps[b])
+            if top_ks is not None:
+                p.top_k = _normalize_top_k(top_ks[b])
+            if depth_params is not None and b < len(depth_params):
+                dt, dk = depth_params[b]
+                p.depth_temperature = float(dt)
+                p.depth_top_k = _normalize_top_k(dk)
+            params.append(p)
+        return params
+
+    # --- weights -------------------------------------------------------------
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> set[str]:
+        """Split the checkpoint stream per :class:`CsmWeightMapper`:
+        backbone names go through ``LlamaForCausalLM.load_weights`` (qkv /
+        gate_up stacking + tied-lm_head skip), own params are copied manually
+        with shape checks, everything cast to backbone bf16 on copy. The
+        mapper raises on any tensor outside the known census (strict
+        accounting; the depth tied-embed duplicate is a deliberate skip).
+
+        Returns:
+            Set of own (non-backbone) destination param names that received
+            a tensor.
+        """
+        mapper = CsmWeightMapper(
+            backbone_dtype=self.backbone.model.embed_tokens.weight.dtype
+        )
+
+        backbone_weights: list[Tuple[str, torch.Tensor]] = []
+        self_weights: list[Tuple[str, torch.Tensor]] = []
+        for name, tensor in weights:
+            mapped = mapper.map(name)  # raises ValueError on unexpected names
+            if mapped is None:
+                continue
+            if mapped.startswith("backbone."):
+                backbone_weights.append((mapped[len("backbone.") :], tensor))
+            else:
+                self_weights.append((mapped, tensor))
+
+        self.backbone.load_weights(iter(backbone_weights))
+
+        own_params = dict(self.named_parameters(remove_duplicate=False))
+        loaded: set[str] = set()
+        for name, tensor in self_weights:
+            param = own_params.get(name)
+            if param is None:
+                raise ValueError(
+                    f"CSM weight remap produced unknown destination {name!r}"
+                )
+            if param.shape != tensor.shape:
+                raise ValueError(
+                    f"Shape mismatch for {name}: expected {tuple(param.shape)}, "
+                    f"got {tuple(tensor.shape)}"
+                )
+            param.data.copy_(tensor.to(param.dtype))
+            loaded.add(name)
+
+        return loaded
+
+
+__all__ = ["CsmGenParams", "CsmTTSModel", "_flat_sampling_attr"]

--- a/sglang_omni/models/csm_tts/model_runner.py
+++ b/sglang_omni/models/csm_tts/model_runner.py
@@ -1,0 +1,545 @@
+# SPDX-License-Identifier: Apache-2.0
+# Follows the sglang-omni AR model-runner pattern (cf. Higgs).
+"""Frame-step ModelRunner for CSM TTS.
+
+The scheduler sees a normal one-token decode step (1 frame = 1 backbone
+position = 1 SGLang "token"); the 31-step depth loop runs inside
+``model.forward``'s decode branch. This runner owns everything
+OUTSIDE the (future) captured region: CG-buffer population, prefill embed
+overlay, the packed one-D2H-per-step collect, stream emission, and the
+async launch/resolve halves.
+
+Step anatomy (decode, sync path):
+
+1. ``before_decode → _populate_cg_buffers``: reset padding row; acquire rows;
+   lookahead-only GPU-side done-row reroute to the padding row (higgs guard
+   #1); fill cb0 sampling buffers from SGLang ``sampling_info`` via
+   ``_flat_sampling_attr``; fill DEPTH sampling buffers host-side from
+   ``req._omni_data`` (depth params never ride sampling_info); gather
+   ``pool.{generation_done, last_codes}[rows] → _cg_active_*[:bs]``.
+2. ``model.forward`` (see model.py).
+3. ``post_decode → _collect_step_outputs_cg``: ``_decode_pack_gpu`` (scatter
+   ``_cg_active_* → pool[rows]``; pack staging ``[P, 34]``) → ONE blocking
+   D2H ``staging[:n].cpu()`` → ``_decode_collect_host``.
+
+All three async overrun guards stay verbatim from higgs (padding-row reroute
+at launch; ``pre_finished`` snapshot + row drop in resolve; post-drain
+``filter_batch()``) — they protect the lookahead overlap, not the wind-down
+. Async stays OFF by default (``enable_async_decode=False`` in the
+stage factory; ``async_decode_min_batch_size=2`` — the measured bs=1
+regression); the launch/resolve halves below are implemented but dormant.
+
+
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from sglang.srt.managers.schedule_batch import FINISH_MATCHED_TOKEN
+
+from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.models.csm_tts.model import _flat_sampling_attr
+from sglang_omni.models.csm_tts.sampler import K_MAX
+from sglang_omni.models.csm_tts.utils import (
+    AUDIO_EOS_TOKEN_ID,
+    AUDIO_TOKEN_ID,
+    CODEBOOK_EOS,
+    NUM_CODEBOOKS,
+)
+from sglang_omni.scheduling.messages import OutgoingMessage
+
+__all__ = ["CsmTTSModelRunner"]
+
+
+class CsmTTSModelRunner(ModelRunner):
+    """ModelRunner for :class:`~sglang_omni.models.csm_tts.model.CsmTTSModel`."""
+
+    def __init__(self, tp_worker: Any, output_processor: Any) -> None:
+        super().__init__(tp_worker, output_processor)
+        self._outbox: Any | None = None
+        self._vocoder_target = "vocoder"
+
+    def set_stream_outbox(self, outbox: Any) -> None:
+        """Wire the OmniScheduler outbox used by :meth:`_emit_code_chunk`."""
+        self._outbox = outbox
+
+    # --- prefill --------------------------------------------------------------
+
+    def before_prefill(
+        self, forward_batch: Any, schedule_batch: Any, requests: list
+    ) -> None:
+        del schedule_batch
+        forward_batch.req_ids = [req.request_id for req in requests]
+        # Depth sampling params are CSM-private (never on sampling_info);
+        # stamp per-row (temperature, top_k) tuples so
+        # model._extract_batch_metadata can read them.
+        depth_temps, depth_top_ks = self._extract_depth_sampling_params(requests)
+        forward_batch.csm_depth_params = list(zip(depth_temps, depth_top_ks))
+        forward_batch.input_embeds = self._build_prefill_input_embeds(
+            forward_batch, requests
+        )
+
+    def post_prefill(
+        self, result: Any, forward_batch: Any, schedule_batch: Any, requests: list
+    ) -> None:
+        del forward_batch, schedule_batch
+        self._collect_step_outputs(result, requests)
+
+    def _build_prefill_input_embeds(
+        self, forward_batch: Any, requests: list
+    ) -> torch.Tensor | None:
+        """Prefill embed overlay.
+
+        ``embed_tokens`` of the token ids, then paste context-frame embeds at
+        the REAL-id ``AUDIO_TOKEN_ID`` (128002) positions (no -100 sentinel),
+        and give each ``AUDIO_EOS_TOKEN_ID`` (128003) position the
+        all-zeros-frame embed (HF ``_merge_input_ids_with_input_values``
+        parity, modeling_csm.py:877-885). ``num_ctx_codes_consumed`` keeps
+        the paste chunked-prefill-correct across ``chunked_prefill_size``
+        boundaries.
+
+        Returns:
+            bf16 ``[T_total, 2048]`` or ``None`` when no request in the batch
+            has context audio (every prompt id is then a real text token and
+            the backbone's own embedding is exact).
+        """
+        if not any(
+            getattr(sched_req.data, "context_codes", None) for sched_req in requests
+        ):
+            return None
+
+        input_ids = forward_batch.input_ids
+        device = input_ids.device
+        embed_tokens = self.model.backbone.model.embed_tokens
+        frame_embedding = self.model.frame_embedding
+
+        # All prompt ids are real in-vocab tokens (128002/128003 included) —
+        # no placeholder zeroing needed, the overlay simply overwrites rows.
+        text_embeds = embed_tokens(input_ids)
+        eos_frame_embed: torch.Tensor | None = None
+
+        offset = 0
+        for sched_req in requests:
+            data = sched_req.data
+            end = offset + int(data.req.extend_input_len)
+            chunk_ids = input_ids[offset:end]
+
+            audio_idx = (chunk_ids == AUDIO_TOKEN_ID).nonzero(as_tuple=True)[0]
+            n_placeholders = int(audio_idx.numel())
+            if n_placeholders > 0:
+                codes = self._concat_context_codes(data, device)
+                if codes is None:
+                    raise ValueError(
+                        f"request {sched_req.request_id}: prompt has "
+                        f"{n_placeholders} <|AUDIO|> placeholders but no "
+                        f"context_codes (prompt/codes mismatch)"
+                    )
+                consumed = int(data.num_ctx_codes_consumed)
+                if consumed + n_placeholders > codes.shape[0]:
+                    raise ValueError(
+                        f"request {sched_req.request_id}: placeholder count "
+                        f"overruns context codes ({consumed} consumed + "
+                        f"{n_placeholders} needed > {codes.shape[0]} frames — "
+                        f"off-by-one class)"
+                    )
+                with torch.no_grad():
+                    paste = frame_embedding(codes[consumed : consumed + n_placeholders])
+                text_embeds[audio_idx + offset] = paste.to(text_embeds.dtype)
+                data.num_ctx_codes_consumed = consumed + n_placeholders
+
+            eos_idx = (chunk_ids == AUDIO_EOS_TOKEN_ID).nonzero(as_tuple=True)[0]
+            if eos_idx.numel() > 0:
+                if eos_frame_embed is None:
+                    with torch.no_grad():
+                        eos_frame_embed = frame_embedding(
+                            torch.zeros(
+                                1, NUM_CODEBOOKS, dtype=torch.long, device=device
+                            )
+                        )
+                text_embeds[eos_idx + offset] = eos_frame_embed.to(text_embeds.dtype)
+
+            offset = end
+
+        return text_embeds
+
+    @staticmethod
+    def _concat_context_codes(data: Any, device: torch.device) -> torch.Tensor | None:
+        """Per-request context codes, all segments concatenated in prompt
+        order → int64 ``[F_total, 32]`` on ``device`` (placeholder spans
+        appear in the same order, so one cursor walks the whole matrix)."""
+        segments = getattr(data, "context_codes", None) or []
+        mats = []
+        for seg in segments:
+            t = seg if isinstance(seg, torch.Tensor) else torch.as_tensor(seg)
+            mats.append(t.reshape(-1, NUM_CODEBOOKS).to(torch.long))
+        if not mats:
+            return None
+        return torch.cat(mats, dim=0).to(device)
+
+    # --- decode (sync) ----------------------------------------------------------
+
+    def before_decode(
+        self,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list,
+        *,
+        is_lookahead: bool = False,
+    ) -> None:
+        del schedule_batch
+        forward_batch.req_ids = [req.request_id for req in requests]
+        self._populate_cg_buffers(forward_batch, requests, is_lookahead=is_lookahead)
+
+    def post_decode(
+        self, result: Any, forward_batch: Any, schedule_batch: Any, requests: list
+    ) -> None:
+        del schedule_batch
+        self._collect_step_outputs_cg(result, forward_batch, requests)
+
+    def _populate_cg_buffers(
+        self, forward_batch: Any, requests: list, *, is_lookahead: bool = False
+    ) -> None:
+        """Fill the model's CG buffers for one decode step (OUTSIDE any
+        captured region; step 1).
+
+        Padding rows (``batch_size > len(requests)``) point at the reserved
+        padding row, which is reset every step so it can't leak state into
+        real rows; their params are neutral (T=1, k=K_MAX).
+        """
+        model = self.model
+        bs = int(forward_batch.batch_size)
+        n_real = len(requests)
+        if bs < n_real:
+            raise ValueError(
+                f"forward_batch.batch_size ({bs}) < len(requests) ({n_real})"
+            )
+
+        model._sampler_pool.reset_row(model._padding_row)
+
+        rows_py: list[int] = [model.acquire_row(req.request_id) for req in requests]
+        rows_py.extend([model._padding_row] * (bs - n_real))
+        model._cg_row_indices[:bs] = torch.tensor(
+            rows_py, dtype=torch.long, device=model._cg_row_indices.device
+        )
+
+        if self._async_enabled and is_lookahead and n_real > 0:
+            # Async-lookahead overrun guard (GPU-side, no host sync): a request
+            # that EOS-finished at the prior step is still in this launched
+            # batch with pool.generation_done=True; reroute it to the reset
+            # padding row — its overrun output is discarded by the collect's
+            # finished()/was_done skip anyway. Sync steps never carry done
+            # rows, so this gather+where would be pure waste there.
+            rows_t_real = model._cg_row_indices[:n_real]
+            done = model._sampler_pool.generation_done[rows_t_real]
+            model._cg_row_indices[:n_real] = torch.where(
+                done, torch.full_like(rows_t_real, model._padding_row), rows_t_real
+            )
+
+        temps, top_ps, top_ks = self._extract_decode_sampling_params(
+            forward_batch, n_real
+        )
+        temps.extend([1.0] * (bs - n_real))
+        top_ps.extend([1.0] * (bs - n_real))
+        model._cg_temperature[:bs] = torch.tensor(
+            temps, dtype=torch.float32, device=model._cg_temperature.device
+        )
+        model._cg_top_p[:bs] = torch.tensor(
+            top_ps, dtype=torch.float32, device=model._cg_top_p.device
+        )
+        top_k_vals = [(tk if (tk is not None and tk > 0) else K_MAX) for tk in top_ks]
+        top_k_vals.extend([K_MAX] * (bs - n_real))
+        model._cg_top_k_buf[:bs] = torch.tensor(
+            top_k_vals, dtype=torch.long, device=model._cg_top_k_buf.device
+        )
+
+        # CSM delta vs higgs: depth-decoder sampling set, host-side from
+        # ``req._omni_data`` (= sched_req.data; step 1).
+        depth_temps, depth_top_ks = self._extract_depth_sampling_params(requests)
+        depth_temps.extend([1.0] * (bs - n_real))
+        depth_top_ks.extend([K_MAX] * (bs - n_real))
+        model._cg_depth_temperature[:bs] = torch.tensor(
+            depth_temps,
+            dtype=torch.float32,
+            device=model._cg_depth_temperature.device,
+        )
+        model._cg_depth_top_k_buf[:bs] = torch.tensor(
+            depth_top_ks, dtype=torch.long, device=model._cg_depth_top_k_buf.device
+        )
+
+        rows_t = model._cg_row_indices[:bs]
+        pool = model._sampler_pool
+        model._cg_active_generation_done[:bs] = pool.generation_done[rows_t]
+        model._cg_active_last_codes[:bs] = pool.last_codes[rows_t]
+
+    @staticmethod
+    def _extract_decode_sampling_params(forward_batch: Any, n_real: int) -> Any:
+        """cb0 (temperature, top_p, top_k) rows off SGLang's ``sampling_info``
+        with safe defaults (one D2H per attribute via ``_flat_sampling_attr``).
+        ``top_k`` values outside ``(0, K_MAX)`` (including SGLang's TOP_K_ALL
+        sentinel) normalize to ``None`` — the buffer maps that to ``K_MAX``
+        = no-op filter.
+
+        Returns:
+            ``(temps, top_ps, top_ks)`` host lists of length ``n_real``.
+        """
+        sampling_info = getattr(forward_batch, "sampling_info", None)
+        if sampling_info is None or n_real == 0:
+            return ([1.0] * n_real, [1.0] * n_real, [None] * n_real)
+
+        temps_raw = _flat_sampling_attr(sampling_info, "temperatures") or [1.0] * n_real
+        top_ps_raw = _flat_sampling_attr(sampling_info, "top_ps") or [1.0] * n_real
+        top_ks_raw = _flat_sampling_attr(sampling_info, "top_ks")
+
+        temps = [float(t) for t in temps_raw[:n_real]]
+        top_ps = [float(t) for t in top_ps_raw[:n_real]]
+        if top_ks_raw is None:
+            top_ks: list[int | None] = [None] * n_real
+        else:
+            top_ks = [
+                int(t) if (t is not None and 0 < int(t) <= K_MAX) else None
+                for t in top_ks_raw[:n_real]
+            ]
+        return temps, top_ps, top_ks
+
+    @staticmethod
+    def _extract_depth_sampling_params(requests: list) -> tuple[list[float], list[int]]:
+        """Depth (temperature, top_k) per request from ``sched_req.data``
+        (= ``req._omni_data``; defaults (0.9, 50) — HF parity)."""
+        depth_temps: list[float] = []
+        depth_top_ks: list[int] = []
+        for sched_req in requests:
+            data = sched_req.data
+            depth_temps.append(float(getattr(data, "depth_temperature", 0.9)))
+            dk = getattr(data, "depth_top_k", 50)
+            try:
+                dk = int(dk)
+            except (TypeError, ValueError):
+                dk = K_MAX
+            depth_top_ks.append(dk if 0 < dk <= K_MAX else K_MAX)
+        return depth_temps, depth_top_ks
+
+    def _collect_step_outputs_cg(
+        self, result: Any, forward_batch: Any, requests: list
+    ) -> None:
+        """Sync decode tail: ``_decode_pack_gpu(n)`` → ONE blocking D2H
+        ``staging[:n].cpu()`` → :meth:`_decode_collect_host` (step 3)."""
+        if len(requests) == 0:
+            return
+        n_real = len(requests)
+        bs = int(forward_batch.batch_size)
+        if bs < n_real:
+            raise ValueError(
+                f"forward_batch.batch_size ({bs}) < len(requests) ({n_real})"
+            )
+        staging = self._decode_pack_gpu(n_real)
+        combined_cpu = staging[:n_real].cpu()  # one blocking D2H (sync path)
+        self._decode_collect_host(
+            combined_cpu,
+            result,
+            requests,
+            next_token_device=result.logits_output.next_token_logits.device,
+        )
+
+    def _decode_pack_gpu(self, n_real: int) -> torch.Tensor:
+        """Scatter ``_cg_active_* → pool[rows]`` and pack the staging row
+        ``[codes_0..31 | was_done | generation_done]``. All GPU→GPU.
+
+        Returns:
+            int64 GPU staging buffer (full ``[P, 34]``; callers slice
+            ``[:n_real]``).
+        """
+        model = self.model
+        rows_t = model._cg_row_indices[:n_real]
+        pool = model._sampler_pool
+        pool.generation_done[rows_t] = model._cg_active_generation_done[:n_real]
+        pool.last_codes[rows_t] = model._cg_active_last_codes[:n_real]
+        # Bookkeeping only (nothing downstream reads it); under lookahead
+        # reroute duplicate padding-row indices make this last-write-wins,
+        # which is fine — the padding row is reset every step.
+        pool.frames_emitted[rows_t] += (~model._cg_was_done[:n_real]).to(torch.int32)
+
+        # Pack so a single D2H pulls codes + both flags (higgs pattern).
+        num_codebooks = model._cg_codes_BN.shape[1]
+        staging = model._cg_collect_staging
+        staging[:n_real, :num_codebooks] = model._cg_codes_BN[:n_real]
+        staging[:n_real, num_codebooks] = model._cg_was_done[:n_real]
+        staging[:n_real, num_codebooks + 1] = model._cg_active_generation_done[:n_real]
+        return staging
+
+    def _decode_collect_host(
+        self,
+        staging_host: torch.Tensor,
+        result: Any,
+        requests: list,
+        *,
+        next_token_device: torch.device | None = None,
+    ) -> None:
+        """Per-row host collect off the staged snapshot:
+        skip if ``req.is_chunked > 0`` / ``req.finished()`` / ``was_done``;
+        else append ``codes_32`` to ``data.output_frames``; if
+        ``generation_done``: :meth:`_mark_sampler_finished`, NO stream emit
+        (EOS frames never reach Mimi — fence #1 of 3); else
+        :meth:`_emit_code_chunk`; collect cb0 into ``result.next_token_ids``.
+
+        ``next_token_device`` is set on the sync path (those ids feed the next
+        step); the async resolve passes ``None`` (launch already published
+        GPU cb0, resolve only needs a CPU tensor for output processing).
+
+        Args:
+            staging_host: int64 CPU ``[n_real, 34]``.
+        """
+        model = self.model
+        num_codebooks = model._cg_codes_BN.shape[1]
+        codes_BN_cpu = staging_host[:, :num_codebooks]
+        was_done_cpu = staging_host[:, num_codebooks].bool().tolist()
+        gen_done_after_cpu = staging_host[:, num_codebooks + 1].bool().tolist()
+        cb0_per_row: list[int] = []
+        for b, sched_req in enumerate(requests):
+            data = sched_req.data
+            req = data.req
+            if req.is_chunked > 0:
+                cb0_per_row.append(0)
+                continue
+            # Already finished in an earlier step? Skip the append. Under
+            # async lookahead the finished req gets one extra (wasted) forward
+            # before being dropped; this prevents leaking that overrun frame.
+            # Catches length finishes too (which `was_done`, an EOS-only flag,
+            # does not). No-op on the sync path.
+            if req.finished():
+                cb0_per_row.append(0)
+                continue
+            if was_done_cpu[b]:
+                cb0_per_row.append(0)
+                continue
+            codes_32 = codes_BN_cpu[b].to(torch.long).clone()
+            data.output_frames.append(codes_32)
+            data.generation_done = bool(gen_done_after_cpu[b])
+            self._mark_sampler_finished(req, data.generation_done)
+            if not data.generation_done:
+                # EOS frames are recorded (HF `sequences` parity) but never
+                # streamed — fence #1 keeping codes >= 2048 away from Mimi.
+                self._emit_code_chunk(sched_req, codes_32)
+            cb0_per_row.append(int(codes_32[0].item()))
+
+        if next_token_device is None:
+            result.next_token_ids = torch.tensor(cb0_per_row, dtype=torch.long)
+        else:
+            result.next_token_ids = torch.tensor(
+                cb0_per_row, dtype=torch.long, device=next_token_device
+            )
+
+    def _collect_step_outputs(self, result: Any, requests: list) -> None:
+        """Prefill/eager collect (frame 0): same emission + finish rules as
+        the decode collect, including the frame-0-EOS zero-decode lifecycle; overwrites
+        ``result.next_token_ids`` with cb0 so the base runner skips its
+        text-vocab sampler."""
+        if len(requests) == 0:
+            return
+
+        model = self.model
+        cb0_per_row: list[int] = []
+        for sched_req in requests:
+            data = sched_req.data
+            req = data.req
+            rid = sched_req.request_id
+            row = model._rid_to_row.get(rid)
+            codes_log = model._output_codes.get(rid)
+            if req.is_chunked > 0 or row is None or not codes_log or req.finished():
+                cb0_per_row.append(0)
+                continue
+            codes_32 = codes_log[-1].detach().cpu().clone()
+            data.output_frames.append(codes_32)
+            data.generation_done = bool(model._sampler_pool.generation_done[row].item())
+            self._mark_sampler_finished(req, data.generation_done)
+            if not data.generation_done:
+                self._emit_code_chunk(sched_req, codes_32)
+            cb0_per_row.append(int(codes_32[0].item()))
+
+        result.next_token_ids = torch.tensor(
+            cb0_per_row,
+            dtype=torch.long,
+            device=result.logits_output.next_token_logits.device,
+        )
+
+    # --- decode (async halves; implemented but OFF by default) --------------------
+
+    def post_decode_launch(
+        self, result: Any, forward_batch: Any, requests: list
+    ) -> Any:
+        """Async GPU half: scatter + pack, ``copy_(non_blocking=True)`` into a
+        ping-pong pinned host buffer, and publish
+        ``result.next_token_ids = _cg_codes_BN[:n, 0].clamp_min(0)`` from GPU
+        state with NO host sync (clamp keeps STOP_CODE=-1 in embed range;
+        decode embeds read ``last_codes``, so this is bookkeeping only). Dormant by default (``enable_async_decode=False``).
+
+        Returns:
+            The pinned host buffer (the base runner records the CUDA event).
+        """
+        if len(requests) == 0:
+            return None
+        n_real = len(requests)
+        bs = int(forward_batch.batch_size)
+        if bs < n_real:
+            raise ValueError(
+                f"forward_batch.batch_size ({bs}) < len(requests) ({n_real})"
+            )
+        staging = self._decode_pack_gpu(n_real)
+        host_buf = self._next_host_staging(self.model._cg_collect_staging)
+        host_buf[:n_real].copy_(staging[:n_real], non_blocking=True)
+        result.next_token_ids = (
+            self.model._cg_codes_BN[:n_real, 0].clamp_min(0).to(torch.long).clone()
+        )
+        return host_buf
+
+    def post_decode_resolve(
+        self,
+        host_buf: Any,
+        result: Any,
+        forward_batch: Any,
+        schedule_batch: Any,
+        requests: list,
+    ) -> None:
+        """Async host half: run :meth:`_decode_collect_host` off the pinned
+        snapshot (the base runner's ``skip_rids``/``pre_finished`` machinery
+        plus the collect's own skips form the overrun guard)."""
+        del forward_batch, schedule_batch
+        if len(requests) == 0:
+            return
+        n_real = len(requests)
+        self._decode_collect_host(
+            host_buf[:n_real],
+            result,
+            requests,
+            next_token_device=None,
+        )
+
+    # --- emission / finish ------------------------------------------------------
+
+    def _emit_code_chunk(self, sched_req: Any, codes_32: torch.Tensor) -> None:
+        """Stream one frame to the vocoder:
+        ``OutgoingMessage(type="stream", target="vocoder", data=codes_32 CPU
+        int64 [32], metadata=stream_metadata)`` via the outbox. ``new_done``
+        rows are never emitted."""
+        if self._outbox is None:
+            return
+        metadata = sched_req.data.stream_metadata
+        if metadata is None:
+            return
+        self._outbox.put(
+            OutgoingMessage(
+                request_id=sched_req.request_id,
+                type="stream",
+                target=self._vocoder_target,
+                data=codes_32,
+                metadata=metadata,
+            )
+        )
+
+    @staticmethod
+    def _mark_sampler_finished(req: Any, generation_done: bool) -> None:
+        """Set ``FINISH_MATCHED_TOKEN(matched=CODEBOOK_EOS)`` (cb0 of the EOS
+        frame = 0) — upstream only needs *a* finish reason to fire KV release."""
+        if generation_done and req.finished_reason is None:
+            req.finished_reason = FINISH_MATCHED_TOKEN(CODEBOOK_EOS)

--- a/sglang_omni/models/csm_tts/modeling.py
+++ b/sglang_omni/models/csm_tts/modeling.py
@@ -1,0 +1,483 @@
+# SPDX-License-Identifier: Apache-2.0
+# CSM-1B architecture (frame embedding, codebooks head, dense depth decoder) ports the
+# reference implementation in HuggingFace Transformers `transformers/models/csm` (Apache-2.0).
+"""Framework-free torch modules for CSM-1B: frame embedding, codebooks head,
+dense depth decoder (4L, static 33-position KV, 31-step inner AR).
+
+These compose with an SGLang ``LlamaForCausalLM`` backbone in
+:class:`sglang_omni.models.csm_tts.model.CsmTTSModel`. Everything here is
+plain eager torch with static shapes, CUDA-graph-friendly (capture is not
+yet wired; eager by default): the 31-iteration host loop unrolls at capture
+with no data-dependent branches.
+
+
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from sglang_omni.models.csm_tts import sampler
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    """HF half-rotation rope application (modeling_csm.py:201-205). The HF
+    shards already carry the interleaved→half-rotated Q/K permutation
+    (convert_csm.py:61-67), so this is the matching apply."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def _llama3_scaled_inv_freq(
+    rope_theta: float, dim: int, rope_scaling: dict[str, Any]
+) -> torch.Tensor:
+    """llama3-scaled RoPE inverse frequencies, exact port of HF
+    ``modeling_rope_utils.py`` ``_compute_llama3_parameters`` (the
+    attention_factor for this rope type is 1.0, so cos/sin stay unscaled).
+    """
+    inv_freq = 1.0 / (
+        rope_theta
+        ** (torch.arange(0, dim, 2, dtype=torch.int64).to(torch.float32) / dim)
+    )
+    factor = float(rope_scaling["factor"])
+    low_freq_factor = float(rope_scaling["low_freq_factor"])
+    high_freq_factor = float(rope_scaling["high_freq_factor"])
+    old_context_len = float(rope_scaling["original_max_position_embeddings"])
+
+    low_freq_wavelen = old_context_len / low_freq_factor
+    high_freq_wavelen = old_context_len / high_freq_factor
+
+    wavelen = 2 * math.pi / inv_freq
+    inv_freq_llama = torch.where(
+        wavelen > low_freq_wavelen, inv_freq / factor, inv_freq
+    )
+    smooth_factor = (old_context_len / wavelen - low_freq_factor) / (
+        high_freq_factor - low_freq_factor
+    )
+    smoothed_inv_freq = (
+        1 - smooth_factor
+    ) * inv_freq_llama / factor + smooth_factor * inv_freq_llama
+    is_medium_freq = ~(wavelen < high_freq_wavelen) * ~(wavelen > low_freq_wavelen)
+    return torch.where(is_medium_freq, smoothed_inv_freq, inv_freq_llama)
+
+
+class CsmRMSNorm(nn.Module):
+    """HF-exact RMSNorm (modeling_csm.py:99-114): fp32 internal math, cast
+    back to the input dtype before the weight multiply."""
+
+    def __init__(self, hidden_size: int, eps: float = 1e-5) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+
+class CsmFrameEmbedding(nn.Module):
+    """Fused 32-codebook audio embedding: ONE ``weight [65632, 2048]`` table
+    (32 * 2051 rows; tied to the depth decoder's embed table).
+
+    Mirrors HF ``modeling_csm.py:655-666``: register
+    ``audio_tokens_offsets = arange(32) * 2051`` as a buffer.
+    """
+
+    def __init__(
+        self,
+        num_codebooks: int = 32,
+        codebook_vocab: int = 2051,
+        hidden_size: int = 2048,
+    ) -> None:
+        """Owns ``weight: nn.Parameter [num_codebooks * codebook_vocab, hidden_size]``
+        (= ``[65632, 2048]``, bf16 after model cast) and the int64
+        ``audio_tokens_offsets [32]`` buffer."""
+        super().__init__()
+        self.num_codebooks = num_codebooks
+        self.codebook_vocab = codebook_vocab
+        self.weight = nn.Parameter(
+            torch.empty(num_codebooks * codebook_vocab, hidden_size)
+        )
+        self.register_buffer(
+            "audio_tokens_offsets",
+            torch.arange(num_codebooks, dtype=torch.int64) * codebook_vocab,
+            persistent=False,
+        )
+
+    def forward(self, codes_B32: torch.Tensor) -> torch.Tensor:
+        """Frame embed: sum of per-codebook lookups.
+
+        ``F.embedding(codes_B32 + audio_tokens_offsets).sum(-2)``.
+
+        Args:
+            codes_B32: int64 ``[B, 32]``, values in ``[0, 2050]``.
+
+        Returns:
+            ``[B, 2048]`` (weight dtype, bf16 in the ship config).
+        """
+        return F.embedding(codes_B32 + self.audio_tokens_offsets, self.weight).sum(
+            dim=-2
+        )
+
+    def embed_codebook(self, codes_B: torch.Tensor, k: int) -> torch.Tensor:
+        """Single-codebook lookup at table offset ``k * 2051`` (depth-step
+        feedback: depth position ``p`` embeds the previous code with offset
+        ``(p - 1) * 2051``).
+
+        Args:
+            codes_B: int64 ``[B]``, values in ``[0, 2050]``.
+            k: codebook index in ``[0, 31]``.
+
+        Returns:
+            ``[B, 2048]`` (weight dtype).
+        """
+        return F.embedding(codes_B + k * self.codebook_vocab, self.weight)
+
+
+class CsmCodebooksHead(nn.Module):
+    """Per-depth-step output heads, ``weight [31, 1024, 2051]`` stored EXACTLY
+    in checkpoint layout. Head *k* predicts codebook *k+1*.
+
+    ⚠ Orientation trap: the forward is
+    ``h @ weight[step]`` (≡ ``F.linear(h, weight[step].T)``, HF
+    ``modeling_csm.py:528-536``). Do NOT "fix" shapes by re-storing the weight
+    as ``[31, 2051, 1024]`` — combined with loading the checkpoint tensor
+    ``(31, 1024, 2051)`` untransposed, that RUNS and produces garbage audio.
+    The tiny-config depth parity test pins this orientation and is a hard
+    correctness blocker.
+    """
+
+    def __init__(
+        self,
+        num_heads: int = 31,
+        hidden_size: int = 1024,
+        codebook_vocab: int = 2051,
+    ) -> None:
+        """Owns ``weight: nn.Parameter [31, 1024, 2051]`` (checkpoint layout)."""
+        super().__init__()
+        self.num_heads = num_heads
+        self.weight = nn.Parameter(torch.empty(num_heads, hidden_size, codebook_vocab))
+
+    def forward(self, h_BD: torch.Tensor, step: int) -> torch.Tensor:
+        """Logits for depth step ``step`` (predicting codebook ``step + 1``).
+
+        Args:
+            h_BD: ``[B, 1024]`` depth hidden (bf16).
+            step: head index in ``[0, 30]``.
+
+        Returns:
+            ``[B, 2051]`` logits in the WEIGHT dtype — caller casts to fp32
+            before sampling.
+        """
+        return h_BD @ self.weight[step]
+
+
+class _CsmDepthAttention(nn.Module):
+    """SDPA attention over the fixed 33-length static KV. Submodule names
+    (``{q,k,v,o}_proj``) match the checkpoint layer keys so the manual
+    weight copies stay 1:1."""
+
+    def __init__(self, depth_cfg: Any) -> None:
+        super().__init__()
+        self.num_heads = depth_cfg.num_attention_heads
+        self.num_kv_heads = depth_cfg.num_key_value_heads
+        self.head_dim = depth_cfg.head_dim
+        hidden = depth_cfg.hidden_size
+        bias = depth_cfg.attention_bias
+        self.q_proj = nn.Linear(hidden, self.num_heads * self.head_dim, bias=bias)
+        self.k_proj = nn.Linear(hidden, self.num_kv_heads * self.head_dim, bias=bias)
+        self.v_proj = nn.Linear(hidden, self.num_kv_heads * self.head_dim, bias=bias)
+        self.o_proj = nn.Linear(self.num_heads * self.head_dim, hidden, bias=bias)
+
+    def forward(
+        self,
+        hidden_BTD: torch.Tensor,
+        rope_cos: torch.Tensor,
+        rope_sin: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        write_pos: int,
+        attn_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        B, T, _ = hidden_BTD.shape
+        q = self.q_proj(hidden_BTD).view(B, T, self.num_heads, self.head_dim)
+        k = self.k_proj(hidden_BTD).view(B, T, self.num_kv_heads, self.head_dim)
+        v = self.v_proj(hidden_BTD).view(B, T, self.num_kv_heads, self.head_dim)
+        q = q.transpose(1, 2)
+        k = k.transpose(1, 2)
+        v = v.transpose(1, 2)
+
+        # HF casts cos/sin to the activation dtype before applying
+        # (modeling_csm.py:182, 209-231) — [T, head_dim] broadcasts over heads.
+        cos = rope_cos[write_pos : write_pos + T].to(q.dtype)
+        sin = rope_sin[write_pos : write_pos + T].to(q.dtype)
+        q = q * cos + _rotate_half(q) * sin
+        k = k * cos + _rotate_half(k) * sin
+
+        k_cache[:, :, write_pos : write_pos + T] = k
+        v_cache[:, :, write_pos : write_pos + T] = v
+
+        # GQA: kv head g serves q heads [g*rep, (g+1)*rep) — same ordering as
+        # HF repeat_kv (modeling_csm.py:234-243).
+        rep = self.num_heads // self.num_kv_heads
+        keys = k_cache.repeat_interleave(rep, dim=1)
+        vals = v_cache.repeat_interleave(rep, dim=1)
+        out = F.scaled_dot_product_attention(q, keys, vals, attn_mask=attn_mask)
+        out = out.transpose(1, 2).reshape(B, T, self.num_heads * self.head_dim)
+        return self.o_proj(out)
+
+
+class _CsmDepthMLP(nn.Module):
+    """SwiGLU MLP (1024 → 8192 → 1024); submodule names match checkpoint keys."""
+
+    def __init__(self, depth_cfg: Any) -> None:
+        super().__init__()
+        hidden = depth_cfg.hidden_size
+        inter = depth_cfg.intermediate_size
+        bias = depth_cfg.mlp_bias
+        self.gate_proj = nn.Linear(hidden, inter, bias=bias)
+        self.up_proj = nn.Linear(hidden, inter, bias=bias)
+        self.down_proj = nn.Linear(inter, hidden, bias=bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(F.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class CsmDepthDecoderLayer(nn.Module):
+    """One depth-decoder layer: RMSNorm → SDPA attention (8 heads, head_dim
+    128, 2 KV heads GQA, llama3-scaled rope) → RMSNorm → SwiGLU
+    (1024 → 8192 → 1024).
+
+    Attention is computed over the FIXED 33-length static KV with an additive
+    causal/length mask — shape-static (CG-ready); at 33 positions the
+    masked-full compute is cheaper than any varlen cleverness.
+    """
+
+    def __init__(self, depth_cfg: Any, layer_idx: int) -> None:
+        """Dense q/k/v/o + gate/up/down projections + 2 RMSNorms; no stacking
+        (own modules so the manual weight copies stay 1:1)."""
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.self_attn = _CsmDepthAttention(depth_cfg)
+        self.mlp = _CsmDepthMLP(depth_cfg)
+        self.input_layernorm = CsmRMSNorm(
+            depth_cfg.hidden_size, eps=depth_cfg.rms_norm_eps
+        )
+        self.post_attention_layernorm = CsmRMSNorm(
+            depth_cfg.hidden_size, eps=depth_cfg.rms_norm_eps
+        )
+
+    def forward(
+        self,
+        hidden_BTD: torch.Tensor,
+        rope_cos: torch.Tensor,
+        rope_sin: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        write_pos: int,
+        attn_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """One layer forward over the static 33-position KV.
+
+        Args:
+            hidden_BTD: ``[B, T, 1024]`` bf16; T == 2 on the len-2 "depth
+                prefill" (step 0+1), T == 1 thereafter.
+            rope_cos / rope_sin: precomputed ``[33, 128]`` fp32 cos/sin slices
+                for the positions being written.
+            k_cache / v_cache: this layer's static-KV slot views
+                ``[B, 2, 33, 128]`` bf16 (kv-heads-major), written in place at
+                ``write_pos``.
+            write_pos: first absolute depth position (0..32) being written.
+            attn_mask: additive ``[T, 33]`` (or broadcastable) fp mask encoding
+                causal + valid-length.
+
+        Returns:
+            ``[B, T, 1024]`` bf16.
+        """
+        residual = hidden_BTD
+        hidden = self.input_layernorm(hidden_BTD)
+        hidden = self.self_attn(
+            hidden, rope_cos, rope_sin, k_cache, v_cache, write_pos, attn_mask
+        )
+        hidden = residual + hidden
+
+        residual = hidden
+        hidden = self.post_attention_layernorm(hidden)
+        hidden = self.mlp(hidden)
+        return residual + hidden
+
+
+class CsmDepthDecoder(nn.Module):
+    """Dense depth decoder: 31-step inner AR per 80 ms frame.
+
+    Owns ``inputs_embeds_projector [1024, 2048]`` (Linear 2048→1024, no bias),
+    4 :class:`CsmDepthDecoderLayer`, final RMSNorm, a
+    :class:`CsmCodebooksHead`, precomputed 33-position rope cos/sin, and the
+    SLOT-INDEXED static KV ``k, v: [4, max_slots, 2, 33, 128]`` bf16.
+
+    Slot- (not pool-) indexed by design: the depth cache is
+    frame-local — reset at the start of every frame, dead by the end — so it
+    needs no per-request persistence and no rid→row gather/scatter; it lives
+    in CG-batch-slot order ``[:bs]``. "Reset per frame" = nothing at all: the
+    causal rows of the precomputed mask never look past ``write_pos + T - 1``,
+    so stale KV from the previous frame is unreachable (no memset, no length
+    scalar).
+    """
+
+    def __init__(
+        self,
+        depth_cfg: Any,
+        frame_embedding: CsmFrameEmbedding,
+        max_slots: int,
+    ) -> None:
+        """``frame_embedding`` is SHARED with the outer model (tied table);
+        ``max_slots`` sizes the static KV (= CG max batch size)."""
+        super().__init__()
+        self.config = depth_cfg
+        self.max_slots = max_slots
+        self.num_codebooks = depth_cfg.num_codebooks
+        self.frame_embedding = frame_embedding
+        self.inputs_embeds_projector = nn.Linear(
+            depth_cfg.backbone_hidden_size, depth_cfg.hidden_size, bias=False
+        )
+        self.layers = nn.ModuleList(
+            CsmDepthDecoderLayer(depth_cfg, i)
+            for i in range(depth_cfg.num_hidden_layers)
+        )
+        self.norm = CsmRMSNorm(depth_cfg.hidden_size, eps=depth_cfg.rms_norm_eps)
+        self.codebooks_head = CsmCodebooksHead(
+            depth_cfg.num_codebooks - 1, depth_cfg.hidden_size, depth_cfg.vocab_size
+        )
+
+        ctx = depth_cfg.max_position_embeddings  # 33
+        inv_freq = _llama3_scaled_inv_freq(
+            float(depth_cfg.rope_theta), depth_cfg.head_dim, depth_cfg.rope_scaling
+        )
+        freqs = torch.outer(torch.arange(ctx, dtype=torch.float32), inv_freq)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        self.register_buffer("rope_cos", emb.cos(), persistent=False)
+        self.register_buffer("rope_sin", emb.sin(), persistent=False)
+
+        # Additive causal mask over the full static window; row p hides every
+        # key slot > p, which is also what makes per-frame KV reset a no-op.
+        causal = torch.zeros(ctx, ctx, dtype=torch.float32)
+        causal.masked_fill_(
+            torch.ones(ctx, ctx, dtype=torch.bool).triu(1),
+            torch.finfo(torch.float32).min,
+        )
+        self.register_buffer("attn_mask_full", causal, persistent=False)
+
+        kv_shape = (
+            depth_cfg.num_hidden_layers,
+            max_slots,
+            depth_cfg.num_key_value_heads,
+            ctx,
+            depth_cfg.head_dim,
+        )
+        self.register_buffer("k_cache", torch.zeros(kv_shape), persistent=False)
+        self.register_buffer("v_cache", torch.zeros(kv_shape), persistent=False)
+
+    def _forward_step(
+        self,
+        embeds_BT2048: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        write_pos: int,
+    ) -> torch.Tensor:
+        """Project + run all layers for the T positions starting at
+        ``write_pos``; returns the post-final-norm hidden of the LAST position
+        ``[B, 1024]``."""
+        hidden = self.inputs_embeds_projector(embeds_BT2048)
+        T = hidden.shape[1]
+        mask = self.attn_mask_full[write_pos : write_pos + T].to(hidden.dtype)
+        for i, layer in enumerate(self.layers):
+            hidden = layer(
+                hidden,
+                self.rope_cos,
+                self.rope_sin,
+                k_cache[i],
+                v_cache[i],
+                write_pos,
+                mask,
+            )
+        return self.norm(hidden[:, -1])
+
+    def generate_frame(
+        self,
+        h_B2048: torch.Tensor,
+        cb0_B: torch.Tensor,
+        temps_B: torch.Tensor,
+        top_ks_B: torch.Tensor,
+        *,
+        bs: int,
+    ) -> torch.Tensor:
+        """Run the 31-step depth AR for one frame, batched across ``[:bs]``.
+
+        Step 0+1: forward ``[proj(h), proj(embed_codebook(cb0, 0))]`` (len-2
+        "depth prefill") → head ``W[0]`` → sample cb1. Then 30 more len-1
+        steps: position ``p`` embeds the previous code with table offset
+        ``(p - 1) * 2051``, head ``W[p - 1]`` samples ``cb_p`` — total 31
+        sampled codes; cb31 is never forwarded (HF parity). Fixed
+        31-iteration host loop, no data-dependent branches (CG-capturable as
+        one graph). Logits cast fp32 before sampling; per-row branchless
+        greedy/top-k via :func:`sampler.sample_codes_batched`.
+
+        Args:
+            h_B2048: ``[B, 2048]`` bf16 post-norm backbone hidden.
+            cb0_B: int64 ``[B]`` sampled codebook-0 codes.
+            temps_B: fp32 ``[B]`` depth temperatures (CSM-private param set).
+            top_ks_B: int64 ``[B]`` depth top-k buffer (K_MAX for neutral rows).
+            bs: live CG batch size (buffers are sliced ``[:bs]``).
+
+        Returns:
+            int64 ``[B, 32]`` — full frame ``[cb0 | cb1..cb31]``.
+        """
+        assert bs <= self.max_slots, f"bs={bs} exceeds depth KV slots {self.max_slots}"
+        assert h_B2048.shape[0] == bs and cb0_B.shape[0] == bs
+        temps = temps_B[:bs]
+        top_ks = top_ks_B[:bs]
+        k_cache = self.k_cache[:, :bs]
+        v_cache = self.v_cache[:, :bs]
+
+        # Depth prefill, positions 0+1: position 0 is the RAW 2048-dim backbone
+        # hidden (replaces the placeholder embedding, modeling_csm.py:480-481);
+        # position 1 is cb0 embedded with codebook table 0. Both then pass the
+        # 2048→1024 projector (modeling_csm.py:488).
+        embeds = torch.stack(
+            [h_B2048, self.frame_embedding.embed_codebook(cb0_B, 0)], dim=1
+        )
+        h_last = self._forward_step(embeds, k_cache, v_cache, write_pos=0)
+        prev = sampler.sample_codes_batched(
+            self.codebooks_head(h_last, 0).float(), temps, top_ks
+        )
+        codes = [cb0_B, prev]
+
+        # Positions 2..31: position p holds cb_{p-1} (table offset (p-1)*2051),
+        # head W[p-1] samples cb_p. cb31 (sampled at p=31) is never forwarded.
+        for p in range(2, self.num_codebooks):
+            embeds = self.frame_embedding.embed_codebook(prev, p - 1).unsqueeze(1)
+            h_last = self._forward_step(embeds, k_cache, v_cache, write_pos=p)
+            prev = sampler.sample_codes_batched(
+                self.codebooks_head(h_last, p - 1).float(), temps, top_ks
+            )
+            codes.append(prev)
+
+        return torch.stack(codes, dim=1)
+
+
+__all__ = [
+    "CsmCodebooksHead",
+    "CsmDepthDecoder",
+    "CsmDepthDecoderLayer",
+    "CsmFrameEmbedding",
+    "CsmRMSNorm",
+]

--- a/sglang_omni/models/csm_tts/payload_types.py
+++ b/sglang_omni/models/csm_tts/payload_types.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# Inter-stage state follows the sglang-omni TTS pipeline pattern; the EOS-frame semantics
+# mirror HuggingFace Transformers CSM (transformers/models/csm, Apache-2.0).
+"""Per-request pipeline state for CSM TTS — THE inter-stage wire schema.
+
+Carried between stages via :class:`sglang_omni.proto.StagePayload.data`.
+Fields populate lazily so a deserialised state is valid at any stage boundary.
+
+
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class CsmTtsState:
+    """State threaded through preprocessing → audio_encoder → tts_engine →
+    vocoder.
+
+    ``context`` entries are ``{speaker_id, text, codes_F32 | waveform}``;
+    ``context_codes`` holds one CPU int32 ``[F, 32]`` matrix per context
+    segment; ``num_ctx_codes_consumed`` is the chunked-prefill overlay cursor; ``max_new_tokens`` counts FRAMES (1 frame = 1 backbone
+    position, exactly like HF); ``output_frames`` is a list of ``[32]``
+    int rows and INCLUDES the EOS frame (HF ``sequences`` parity — the
+    vocoder never receives it).
+    """
+
+    # preprocessing
+    text: str | None = None
+    speaker_id: int = 0
+    context: list[dict[str, Any]] = field(default_factory=list)
+
+    # preprocessing / audio_encoder
+    prompt_ids: list[int] = field(default_factory=list)
+    context_codes: list[Any] | None = None  # per segment: CPU int32 [F, 32]
+    num_ctx_codes_consumed: int = 0
+
+    # generation params (dual sampling sets; HF defaults T=0.9 / top_k=50)
+    max_new_tokens: int = 125  # frames (DEFAULT_MAX_FRAMES)
+    temperature: float = 0.9
+    top_k: int = 50
+    top_p: float | None = None
+    depth_temperature: float = 0.9
+    depth_top_k: int = 50
+    seed: int | None = None
+    stream: bool = False
+
+    # tts_engine outputs
+    output_frames: list[Any] | None = None  # list of [32] int rows
+    prompt_tokens: int = 0
+    completion_frames: int = 0
+    engine_time_s: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise for ``StagePayload.data`` (sparse: omit None/empty;
+        higgs pattern)."""
+        data: dict[str, Any] = {
+            "speaker_id": self.speaker_id,
+            "prompt_ids": list(self.prompt_ids),
+            "max_new_tokens": self.max_new_tokens,
+            "temperature": self.temperature,
+            "top_k": self.top_k,
+            "depth_temperature": self.depth_temperature,
+            "depth_top_k": self.depth_top_k,
+        }
+        if self.text is not None:
+            data["text"] = self.text
+        if self.context:
+            data["context"] = self.context
+        if self.context_codes is not None:
+            data["context_codes"] = self.context_codes
+        if self.num_ctx_codes_consumed:
+            data["num_ctx_codes_consumed"] = self.num_ctx_codes_consumed
+        for key in ("top_p", "seed"):
+            value = getattr(self, key)
+            if value is not None:
+                data[key] = value
+        if self.stream:
+            data["stream"] = True
+        if self.output_frames is not None:
+            data["output_frames"] = self.output_frames
+        for key in ("prompt_tokens", "completion_frames", "engine_time_s"):
+            value = getattr(self, key)
+            if value:
+                data[key] = value
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "CsmTtsState":
+        """Rebuild from ``StagePayload.data`` produced by :meth:`to_dict`."""
+        return cls(
+            text=data.get("text"),
+            speaker_id=data.get("speaker_id", 0),
+            context=list(data.get("context", [])),
+            prompt_ids=list(data.get("prompt_ids", [])),
+            context_codes=data.get("context_codes"),
+            num_ctx_codes_consumed=data.get("num_ctx_codes_consumed", 0),
+            max_new_tokens=data.get("max_new_tokens", 125),
+            temperature=data.get("temperature", 0.9),
+            top_k=data.get("top_k", 50),
+            top_p=data.get("top_p"),
+            depth_temperature=data.get("depth_temperature", 0.9),
+            depth_top_k=data.get("depth_top_k", 50),
+            seed=data.get("seed"),
+            stream=data.get("stream", False),
+            output_frames=data.get("output_frames"),
+            prompt_tokens=data.get("prompt_tokens", 0),
+            completion_frames=data.get("completion_frames", 0),
+            engine_time_s=data.get("engine_time_s", 0.0),
+        )
+
+
+__all__ = ["CsmTtsState"]

--- a/sglang_omni/models/csm_tts/request_builders.py
+++ b/sglang_omni/models/csm_tts/request_builders.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+# Request construction + scheduler adapters follow the sglang-omni TTS pattern (cf. Higgs);
+# EOS-frame and radix-key semantics mirror HuggingFace Transformers CSM (Apache-2.0).
+"""SGLang request construction + scheduler adapters for CSM TTS.
+
+
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Protocol
+
+import torch
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.sampling.sampling_params import SamplingParams
+
+from sglang_omni.models.csm_tts.payload_types import CsmTtsState
+from sglang_omni.models.csm_tts.utils import (
+    BACKBONE_CTX,
+    CODEBOOK_VOCAB,
+    DEFAULT_MAX_FRAMES,
+    NUM_CODEBOOKS,
+    stack_frames,
+    to_codes_F32,
+)
+from sglang_omni.models.tts_streaming import INITIAL_CODEC_CHUNK_FRAMES_PARAM
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
+
+_TEXT_VOCAB_SIZE = 128_256
+
+
+@dataclass
+class CsmSGLangRequestData(SGLangARRequestData):
+    """Per-request state for the CSM TTS scheduler (engine-side mirror of
+    :class:`CsmTtsState` plus runtime bookkeeping)."""
+
+    context_codes: list[Any] | None = None  # CPU int32 [F, 32] per segment
+    num_ctx_codes_consumed: int = 0  # chunked-prefill overlay cursor
+    output_frames: list[torch.Tensor] = field(default_factory=list)
+    generation_done: bool = False
+    depth_temperature: float = 0.9
+    depth_top_k: int = 50
+    engine_start_s: float = 0.0
+    stream_metadata: dict[str, Any] | None = None
+
+
+class _ResettableCsmModel(Protocol):
+    def reset_request(self, req_id: str) -> None: ...
+
+
+_CsmRequestBuilder = Callable[[StagePayload], CsmSGLangRequestData]
+_CsmResultAdapter = Callable[[CsmSGLangRequestData], StagePayload]
+
+
+def _coerce_context_codes(state: CsmTtsState) -> list[torch.Tensor] | None:
+    """Engine-side coercion of per-segment context codes to CPU ``[F, 32]``
+    long tensors. By the time a request reaches the tts_engine every segment
+    MUST be encoded (the audio_encoder stage owns the raw-waveform path)."""
+    if state.context_codes is None:
+        return None
+    coerced: list[torch.Tensor] = []
+    for i, codes in enumerate(state.context_codes):
+        t = to_codes_F32(codes)
+        if t is None:
+            raise ValueError(
+                f"context segment {i} reached the tts_engine without encoded "
+                "codes; the audio_encoder stage must run first"
+            )
+        coerced.append(t.cpu())
+    return coerced
+
+
+def _context_fingerprint(state: CsmTtsState) -> str | None:
+    """blake2b-16 hex over ALL context-code matrices (2 bytes/code, range
+    0..2050) + speaker ids; ``None`` for context-free requests so they share
+    the radix subtree.
+
+    Required because different context audios share identical ``128002×F``
+    token prefixes — without ``Req.extra_key`` namespacing the radix tree
+    would share KV across different voices (higgs lesson, verbatim).
+
+    Returns:
+        Short hex digest or ``None``.
+    """
+    context_codes = _coerce_context_codes(state)
+    if not context_codes:
+        return None
+    h = hashlib.blake2b(digest_size=16)
+    for i, codes in enumerate(context_codes):
+        entry = state.context[i] if i < len(state.context) else {}
+        speaker = int(entry.get("speaker_id", entry.get("speaker", 0)) or 0)
+        h.update(f"|seg:{i}|spk:{speaker}|F:{int(codes.shape[0])}|".encode())
+        # 2 bytes/code (range 0..2050) so the hash is sensitive to every
+        # codebook of every frame, not just cb0 (higgs pattern).
+        flat = codes.reshape(-1).tolist()
+        buf = bytearray(2 * len(flat))
+        for j, c in enumerate(flat):
+            buf[2 * j] = c & 0xFF
+            buf[2 * j + 1] = (c >> 8) & 0xFF
+        h.update(bytes(buf))
+    return h.hexdigest()
+
+
+def build_sglang_csm_request(
+    state: CsmTtsState, *, request_id: str = ""
+) -> CsmSGLangRequestData:
+    """Build the SGLang ``Req`` + request data for one CSM TTS request.
+
+    Returns:
+        :class:`CsmSGLangRequestData`.
+    """
+    input_ids_list = [int(t) for t in state.prompt_ids]
+    if not input_ids_list:
+        raise ValueError(
+            "CSM request reached the tts_engine without prompt_ids; "
+            "preprocessing/audio_encoder must assemble the prompt first"
+        )
+    input_ids = torch.tensor(input_ids_list, dtype=torch.long)
+
+    # max_new_tokens counts FRAMES (1 frame = 1 backbone position, like HF).
+    sp_kwargs: dict[str, Any] = {
+        "max_new_tokens": int(state.max_new_tokens),
+        "temperature": float(state.temperature),
+    }
+    if state.top_p is not None:
+        sp_kwargs["top_p"] = float(state.top_p)
+    if state.top_k is not None:
+        sp_kwargs["top_k"] = int(state.top_k)
+    if state.seed is not None:
+        # The kwarg is ``sampling_seed``, NOT ``seed``.
+        sp_kwargs["sampling_seed"] = int(state.seed)
+    sampling_params = SamplingParams(**sp_kwargs)
+    # tokenizer_manager.normalize() is bypassed in our custom pipeline;
+    # without it stop_strs / stop_regex_strs stay None and the upstream
+    # scheduler's check_finished trips on ``len(None)``.
+    sampling_params.normalize(tokenizer=None)
+
+    context_codes = _coerce_context_codes(state)
+
+    # vocab_size = backbone TEXT vocab so cb0 (0..2050) rides sglang's
+    # standard token bookkeeping. extra_key namespaces the radix cache per
+    # context-audio fingerprint so prompts sharing the same 128002×F
+    # placeholder prefix can never cross-contaminate KV.
+    req = Req(
+        rid=request_id,
+        origin_input_text="",
+        origin_input_ids=input_ids_list,
+        sampling_params=sampling_params,
+        vocab_size=_TEXT_VOCAB_SIZE,
+        extra_key=_context_fingerprint(state),
+    )
+    # V1's prefill manager probes these attrs; absence triggers AttributeError.
+    req._codec_suppress_tokens = None
+    req._input_embeds_are_projected = False
+
+    return CsmSGLangRequestData(
+        input_ids=input_ids,
+        req=req,
+        context_codes=context_codes,
+        num_ctx_codes_consumed=int(state.num_ctx_codes_consumed),
+        max_new_tokens=int(state.max_new_tokens),
+        temperature=float(state.temperature),
+        top_p=float(state.top_p) if state.top_p is not None else 1.0,
+        top_k=int(state.top_k) if state.top_k is not None else -1,
+        depth_temperature=float(state.depth_temperature),
+        depth_top_k=int(state.depth_top_k),
+    )
+
+
+def build_csm_stream_metadata(
+    payload: StagePayload, data: CsmSGLangRequestData
+) -> dict[str, Any] | None:
+    """Stream metadata latched by the vocoder scheduler:
+    ``{modality: "audio_codes", stream: True, num_codebooks: 32,
+    codebook_size: 2051, [initial_codec_chunk_frames]}``.
+
+    Returns:
+        dict for streaming requests, ``None`` for non-streaming.
+    """
+    params = payload.request.params
+    if not isinstance(params, dict):
+        raise TypeError(
+            f"CSM request params must be a dict, got {type(params).__name__}"
+        )
+    if not bool(params.get("stream", False)):
+        return None
+
+    metadata: dict[str, Any] = {
+        "modality": "audio_codes",
+        "stream": True,
+        "num_codebooks": NUM_CODEBOOKS,
+        "codebook_size": CODEBOOK_VOCAB,
+    }
+    if params.get(INITIAL_CODEC_CHUNK_FRAMES_PARAM) is not None:
+        metadata[INITIAL_CODEC_CHUNK_FRAMES_PARAM] = params[
+            INITIAL_CODEC_CHUNK_FRAMES_PARAM
+        ]
+    return metadata
+
+
+def apply_csm_result(state: CsmTtsState, data: CsmSGLangRequestData) -> None:
+    """Write ``output_frames`` + usage (prompt_tokens, completion_frames,
+    engine_time_s) back into ``state``."""
+    if data.output_frames:
+        # [F, 32] incl. the EOS frame (HF ``sequences`` parity; the vocoder
+        # never received it).
+        codes = stack_frames([torch.as_tensor(f) for f in data.output_frames])
+        state.output_frames = codes.tolist()
+        state.completion_frames = int(codes.shape[0])
+    else:
+        state.output_frames = None
+        state.completion_frames = 0
+    state.prompt_tokens = len(data.input_ids)
+
+
+def make_csm_scheduler_adapters(
+    model: _ResettableCsmModel,
+    max_new_tokens_cap: int | None = DEFAULT_MAX_FRAMES,
+) -> tuple[_CsmRequestBuilder, _CsmResultAdapter]:
+    """Build the (request_builder, result_adapter) pair for ``OmniScheduler``.
+
+    request_builder: stamps ``engine_start_s`` / ``stage_payload`` /
+    ``stream_metadata`` and clamps ``max_new_tokens`` to
+    ``min(cap, BACKBONE_CTX - 1 - len(prompt_ids))`` — the scheduler's budget
+    is ``max_req_len = min(context_length - 1, max_total_num_tokens - 1)``
+    = 2047, NOT 2048 (omni_scheduler.py:150-153; clamping against 2048 admits
+    requests the admission check then rejects).
+
+    result_adapter: writes ``output_frames`` + usage into the state, calls
+    ``model.reset_request(rid)`` (frees the sampler row), returns a fresh
+    ``StagePayload``.
+
+    Returns:
+        ``(request_builder, result_adapter)``.
+    """
+
+    def request_builder(payload: StagePayload) -> CsmSGLangRequestData:
+        state = CsmTtsState.from_dict(payload.data)
+        frame_budget = BACKBONE_CTX - 1 - len(state.prompt_ids)
+        if frame_budget < 1:
+            raise ValueError(
+                f"prompt of {len(state.prompt_ids)} tokens leaves no frame "
+                f"budget (max_req_len is {BACKBONE_CTX - 1}); shorten the "
+                "text or context audio"
+            )
+        limit = (
+            frame_budget
+            if max_new_tokens_cap is None
+            else min(int(max_new_tokens_cap), frame_budget)
+        )
+        state.max_new_tokens = max(1, min(int(state.max_new_tokens), limit))
+        data = build_sglang_csm_request(state, request_id=payload.request_id)
+        data.engine_start_s = time.perf_counter()
+        data.stage_payload = payload
+        data.stream_metadata = build_csm_stream_metadata(payload, data)
+        return data
+
+    def result_adapter(data: CsmSGLangRequestData) -> StagePayload:
+        payload = data.stage_payload
+        state = CsmTtsState.from_dict(payload.data)
+        apply_csm_result(state, data)
+        if data.engine_start_s:
+            state.engine_time_s = time.perf_counter() - data.engine_start_s
+        model.reset_request(payload.request_id)
+        return StagePayload(
+            request_id=payload.request_id,
+            request=payload.request,
+            data=state.to_dict(),
+        )
+
+    return request_builder, result_adapter
+
+
+__all__ = [
+    "CsmSGLangRequestData",
+    "apply_csm_result",
+    "build_csm_stream_metadata",
+    "build_sglang_csm_request",
+    "make_csm_scheduler_adapters",
+]

--- a/sglang_omni/models/csm_tts/sampler.py
+++ b/sglang_omni/models/csm_tts/sampler.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+# Sampling / EOS semantics follow HuggingFace Transformers `transformers/models/csm` (Apache-2.0).
+"""Branchless batched sampling + EOS state machine for CSM.
+
+Simpler than higgs by design: CSM has no delay pattern and no EOC wind-down,
+so the three-phase higgs machine collapses to one transition
+(``eos_now = all(codes[:, :31] == 0)``; done rows freeze and emit
+``STOP_CODE``). Dual sampling param sets: cb0 (rides SGLang's sampling_info)
+and depth (CSM-private, from ``req._omni_data``).
+
+
+"""
+
+from __future__ import annotations
+
+import torch
+
+from sglang_omni.models.csm_tts.utils import (
+    CODEBOOK_EOS,
+    K_MAX,
+    NUM_CODEBOOKS,
+    STOP_CODE,
+)
+
+__all__ = [
+    "CsmBatchedSamplerState",
+    "K_MAX",
+    "STAGING_WIDTH",
+    "frame_finalize_direct",
+    "sample_codes_batched",
+    "step_reference",
+]
+
+# Greedy short-circuit threshold (higgs sampler.py parity).
+_GREEDY_TEMP_THRESHOLD = 1e-5
+
+# Packed D2H staging row layout: ``[c0..c31 | was_done |
+# generation_done]`` int64 — model.py allocates ``_cg_collect_staging
+# [P, STAGING_WIDTH]``; one blocking D2H per decode step pulls everything.
+STAGING_WIDTH = NUM_CODEBOOKS + 2
+
+
+class CsmBatchedSamplerState:
+    """Pool-row sampler state surviving across decode steps (higgs row
+    discipline: rows are acquired/released by rid while batch composition
+    changes under a fixed-shape CUDA graph).
+
+    Per row (pool size ``P``; last row = padding row):
+
+    - ``last_codes``: int64 ``[P, 32]`` — previous frame, feeds
+      ``CsmFrameEmbedding`` on the next decode step.
+    - ``generation_done``: bool ``[P]`` — EOS latched; row frozen.
+    - ``frames_emitted``: int32 ``[P]`` — frames appended so far.
+
+    No ``delay_count`` / ``eoc_countdown`` — CSM has neither.
+    """
+
+    def __init__(self, pool_size: int, device: torch.device | str = "cuda") -> None:
+        """Allocate ``last_codes [P, 32]`` int64, ``generation_done [P]`` bool,
+        ``frames_emitted [P]`` int32 on ``device``."""
+        self.pool_size = int(pool_size)
+        self.device = torch.device(device)
+        self.last_codes = torch.zeros(
+            self.pool_size, NUM_CODEBOOKS, dtype=torch.int64, device=self.device
+        )
+        self.generation_done = torch.zeros(
+            self.pool_size, dtype=torch.bool, device=self.device
+        )
+        self.frames_emitted = torch.zeros(
+            self.pool_size, dtype=torch.int32, device=self.device
+        )
+
+    def reset_row(self, row: int) -> None:
+        """Reset one pool row to the fresh-request state
+        (``last_codes=0``, ``generation_done=False``, ``frames_emitted=0``)."""
+        self.last_codes[row].zero_()
+        self.generation_done[row] = False
+        self.frames_emitted[row] = 0
+
+
+def sample_codes_batched(
+    logits_BV_fp32: torch.Tensor,
+    temperature_B: torch.Tensor,
+    top_k_buf_B: torch.Tensor,
+    top_p_B: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Branchless per-row greedy/top-k sampling (higgs
+    ``_sample_independent_batched`` with ``K_MAX=2051``).
+
+    Greedy rows (``temperature <= 1e-5`` or ``top_k == 1``) short-circuit
+    branchlessly to argmax over RAW logits; sampled rows use a fixed-shape
+    ``topk(K_MAX)`` + per-row k-th-value gather (CG-deterministic at temp=0).
+    Used for BOTH cb0 and every one of the 31 depth steps.
+
+    Args:
+        logits_BV_fp32: fp32 ``[B, 2051]`` (callers cast before this).
+        temperature_B: fp32 ``[B]``.
+        top_k_buf_B: int64 ``[B]`` (neutral rows carry ``K_MAX``).
+        top_p_B: optional fp32 ``[B]``.
+
+    Returns:
+        int64 ``[B]`` sampled codes in ``[0, 2050]``.
+    """
+    B = logits_BV_fp32.shape[0]
+
+    # Per-row greedy mask; argmax over RAW logits exactly like the higgs
+    # per-row reference. Selection is branchless (compute both, torch.where)
+    # because this runs inside the captured CUDA graph.
+    greedy_B = (temperature_B <= _GREEDY_TEMP_THRESHOLD) | (top_k_buf_B == 1)
+    argmax_B = logits_BV_fp32.argmax(dim=-1)
+
+    safe_temp = temperature_B.clamp(min=_GREEDY_TEMP_THRESHOLD).view(B, 1)
+    logits = logits_BV_fp32 / safe_temp
+
+    # Fixed-shape top-k: always topk(full width) + per-row k-th-value gather.
+    # K_MAX (= 2051) in production; clamped to the logits width so tiny-config
+    # tests run the same code path. Still
+    # shape-static under CUDA-graph capture (V is fixed per graph).
+    k_width = min(K_MAX, int(logits_BV_fp32.shape[-1]))
+    top_vals = logits.topk(k_width, dim=-1).values
+    k_idx = top_k_buf_B.view(B, 1).clamp(min=1, max=k_width) - 1
+    kth = top_vals.gather(-1, k_idx)
+    logits = torch.where(logits < kth, float("-inf"), logits)
+
+    if top_p_B is not None:
+        sorted_logits, sorted_indices = torch.sort(logits, descending=True, dim=-1)
+        cum_probs = sorted_logits.softmax(dim=-1).cumsum(dim=-1)
+        remove = cum_probs > top_p_B.view(B, 1)
+        # Shift right + force-keep top token so the highest-prob token never
+        # gets cut.
+        remove[..., 1:] = remove[..., :-1].clone()
+        remove[..., 0] = False
+        scatter = torch.zeros_like(remove)
+        scatter.scatter_(-1, sorted_indices, remove)
+        logits = torch.where(scatter, float("-inf"), logits)
+
+    probs = logits.softmax(dim=-1)
+    sampled_B = probs.multinomial(num_samples=1).squeeze(-1)
+
+    return torch.where(greedy_B, argmax_B, sampled_B).to(torch.long)
+
+
+def frame_finalize_direct(
+    codes_B32: torch.Tensor,
+    generation_done_B: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """The branchless EOS machine (single transition).
+
+    ``eos_now = (codes[:, :31] == CODEBOOK_EOS).all(-1)`` — cb31 EXCLUDED,
+    HF-exact (stop(31)/trim(32) inconsistency is mirrored downstream);
+    ``new_done = done | eos_now``; ``out_codes = where(was_done, STOP_CODE,
+    codes)``; done rows freeze. Runs on decode steps AND on the
+    prefill-sampled frame 0 (frame-0 EOS is legal + empirically real).
+
+    Args:
+        codes_B32: int64 ``[B, 32]`` freshly sampled frame.
+        generation_done_B: bool ``[B]`` done flags BEFORE this frame.
+
+    Returns:
+        ``(out_codes_B32 int64 [B, 32], new_done_B bool [B],
+        was_done_B bool [B])``.
+    """
+    # Clone: callers scatter new_done back into the same CG buffer this view
+    # came from; was_done must survive that write.
+    was_done_B = generation_done_B.clone()
+    eos_now_B = (codes_B32[:, : NUM_CODEBOOKS - 1] == CODEBOOK_EOS).all(dim=-1)
+    new_done_B = was_done_B | eos_now_B
+    stop = torch.full_like(codes_B32, STOP_CODE)
+    out_codes_B32 = torch.where(was_done_B.unsqueeze(-1), stop, codes_B32)
+    return out_codes_B32, new_done_B, was_done_B
+
+
+def step_reference(
+    codes_32: torch.Tensor,
+    generation_done: bool,
+) -> tuple[torch.Tensor, bool, bool]:
+    """Per-row eager mirror of :func:`frame_finalize_direct` for parity tests
+    (higgs pattern: tests assert per-row vs batched equality across
+    running / eos_now / done-freeze / mixed-batch phases).
+
+    Args:
+        codes_32: int64 ``[32]``.
+        generation_done: row done flag before this frame.
+
+    Returns:
+        ``(out_codes_32 int64 [32], new_done bool, was_done bool)``.
+    """
+    was_done = bool(generation_done)
+    if was_done:
+        return torch.full_like(codes_32, STOP_CODE), True, True
+    eos_now = bool((codes_32[: NUM_CODEBOOKS - 1] == CODEBOOK_EOS).all().item())
+    return codes_32.clone(), eos_now, False

--- a/sglang_omni/models/csm_tts/stages.py
+++ b/sglang_omni/models/csm_tts/stages.py
@@ -1,0 +1,598 @@
+# SPDX-License-Identifier: Apache-2.0
+# Follows the sglang-omni TTS stage pattern (cf. Higgs / Qwen3-TTS;
+# docs/developer_reference/tts_model_integration.md).
+"""Stage factories for the CSM TTS pipeline:
+``preprocessing → audio_encoder (Mimi encode, no-op fast path) → tts_engine →
+vocoder (Mimi decode)``.
+
+Referenced by dotted path from
+:class:`sglang_omni.models.csm_tts.config.CsmTtsPipelineConfig` — this module
+imports sglang and is therefore NEVER imported by ``config.py`` (the
+registry-silent-skip gotcha).
+
+
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import threading
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any
+
+import torch
+import torchaudio.functional as F_audio
+
+from sglang_omni.models.csm_tts.model_runner import CsmTTSModelRunner
+from sglang_omni.models.csm_tts.payload_types import CsmTtsState
+from sglang_omni.models.csm_tts.request_builders import make_csm_scheduler_adapters
+from sglang_omni.models.csm_tts.text_tokenizer import CsmPromptBuilder
+from sglang_omni.models.csm_tts.utils import (
+    BACKBONE_CTX,
+    DEFAULT_MAX_FRAMES,
+    FRAME_RATE,
+    NUM_CODEBOOKS,
+    SAMPLE_RATE,
+    get_or_load_codec,
+    load_audio_to_24k,
+    resolve_checkpoint,
+    to_codes_F32,
+)
+from sglang_omni.models.csm_tts.vocoder_scheduler import CsmStreamingVocoderScheduler
+from sglang_omni.preprocessing.cache_key import hash_bytes, hash_media_item
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
+from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+from sglang_omni.scheduling.sglang_backend import (
+    SGLangOutputProcessor,
+    build_sglang_server_args,
+)
+from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+from sglang_omni.scheduling.stage_cache import StageOutputCache
+from sglang_omni.scheduling.threaded_simple_scheduler import ThreadedSimpleScheduler
+
+logger = logging.getLogger(__name__)
+
+# The binding constraint on the 3060 is COMPUTE (frame step must beat 80 ms
+# real time), not VRAM — mrr/concurrency default to 8.
+DEFAULT_MAX_CONCURRENCY = 8
+
+# Context-audio budget guard: 60 s = 750 backbone positions at 12.5 Hz
+# (+1 <|audio_eos|> per segment); text capped ~1500 tokens after reserving
+# frames.
+MAX_CONTEXT_AUDIO_SECONDS = 60
+_MAX_CONTEXT_FRAMES = int(MAX_CONTEXT_AUDIO_SECONDS * FRAME_RATE)  # 750
+_MAX_TEXT_TOKENS = 1500
+
+# Three-tier context-audio caching (higgs copy): path-hash memo /
+# waveform LRU / encoded-codes LRU (as CPU int32 so the cache can byte-bound).
+_CTX_CODE_CACHE_MAX_ITEMS = 256
+_CTX_CODE_CACHE_MAX_BYTES = 256 * 1024 * 1024
+_CTX_WAVEFORM_CACHE_MAX_ITEMS = 256
+_CTX_WAVEFORM_CACHE_MAX_BYTES = 512 * 1024 * 1024
+_CTX_PATH_HASH_MEMO_MAX_ITEMS = 1024
+_CTX_PATH_HASH_SENTINEL_BYTES = 8192
+_CTX_PATH_HASH_MEMO: OrderedDict[str, tuple[str, str]] = OrderedDict()
+_CTX_PATH_HASH_MEMO_LOCK = threading.Lock()
+
+
+def _context_path_hash_memo_key(path: Path) -> tuple[str, int] | None:
+    try:
+        if not path.is_file():
+            return None
+        stat_result = path.stat()
+        memo_key = (
+            f"{path.resolve()}:"
+            f"{stat_result.st_size}:"
+            f"{stat_result.st_mtime_ns}:"
+            f"{stat_result.st_ctime_ns}"
+        )
+        return memo_key, int(stat_result.st_size)
+    except OSError:
+        return None
+
+
+def _context_path_sentinel(path: Path, file_size: int) -> str | None:
+    try:
+        chunk_size = min(_CTX_PATH_HASH_SENTINEL_BYTES, file_size)
+        with path.open("rb") as f:
+            chunks = [f.read(chunk_size)]
+            if file_size > _CTX_PATH_HASH_SENTINEL_BYTES:
+                middle_offset = max((file_size - chunk_size) // 2, 0)
+                f.seek(middle_offset)
+                chunks.append(f.read(chunk_size))
+            if file_size > 2 * _CTX_PATH_HASH_SENTINEL_BYTES:
+                f.seek(max(file_size - chunk_size, 0))
+                chunks.append(f.read(chunk_size))
+        return hash_bytes(b"".join(chunks) + f"|size:{file_size}".encode())
+    except OSError:
+        return None
+
+
+def _get_context_path_hash(memo_key: str, sentinel: str) -> str | None:
+    with _CTX_PATH_HASH_MEMO_LOCK:
+        cached = _CTX_PATH_HASH_MEMO.get(memo_key)
+        if cached is None:
+            return None
+        cached_sentinel, digest = cached
+        if cached_sentinel != sentinel:
+            _CTX_PATH_HASH_MEMO.pop(memo_key, None)
+            return None
+        _CTX_PATH_HASH_MEMO.move_to_end(memo_key)
+        return digest
+
+
+def _put_context_path_hash(memo_key: str, sentinel: str, digest: str) -> None:
+    with _CTX_PATH_HASH_MEMO_LOCK:
+        _CTX_PATH_HASH_MEMO[memo_key] = (sentinel, digest)
+        _CTX_PATH_HASH_MEMO.move_to_end(memo_key)
+        while len(_CTX_PATH_HASH_MEMO) > _CTX_PATH_HASH_MEMO_MAX_ITEMS:
+            _CTX_PATH_HASH_MEMO.popitem(last=False)
+
+
+def _context_path_cache_key(path_like: str | Path) -> str | None:
+    # Memoized full-content hash. The stat tuple avoids rereading stable local
+    # files while still invalidating normal and rapid same-size replacements.
+    path = Path(str(path_like)).expanduser()
+    memo = _context_path_hash_memo_key(path)
+    if memo is None:
+        return None
+    memo_key, file_size = memo
+    sentinel = _context_path_sentinel(path, file_size)
+    if sentinel is None:
+        return None
+    digest = _get_context_path_hash(memo_key, sentinel)
+    if digest is not None:
+        return f"file:{digest}"
+    try:
+        digest = hash_bytes(path.read_bytes())
+    except OSError:
+        return None
+    if _context_path_hash_memo_key(path) == memo:
+        _put_context_path_hash(memo_key, sentinel, digest)
+    return f"file:{digest}"
+
+
+def _context_audio_cache_key(context_audio: Any) -> str | None:
+    """Stable cache key for one context-audio input (higgs copy)."""
+    if isinstance(context_audio, (str, Path)):
+        return _context_path_cache_key(context_audio)
+    if not isinstance(context_audio, dict):
+        return None
+    path = context_audio.get("audio_path") or context_audio.get("path")
+    if path:
+        return _context_path_cache_key(path)
+    if "bytes" in context_audio:
+        data = context_audio["bytes"]
+        if isinstance(data, str):
+            data = data.encode()
+        return hash_media_item(data)
+    encoded = context_audio.get("base64") or context_audio.get("data")
+    if encoded is None:
+        return None
+    raw = base64.b64decode(encoded) if isinstance(encoded, str) else bytes(encoded)
+    return hash_media_item(raw)
+
+
+def _normalize_context_inputs(
+    inputs: dict[str, Any], default_speaker: int
+) -> list[dict[str, Any]]:
+    """``context`` list, or higgs-compatible ``references`` /
+    ``reference_audio``+``reference_text`` aliased into context segments."""
+    context = inputs.get("context")
+    if context:
+        if not isinstance(context, list):
+            raise TypeError(f"context must be a list, got {type(context).__name__}")
+        return [dict(seg) for seg in context]
+
+    segments: list[dict[str, Any]] = []
+    refs = inputs.get("references")
+    if refs and isinstance(refs, list):
+        for ref in refs:
+            if not isinstance(ref, dict):
+                continue
+            seg: dict[str, Any] = {
+                "speaker": ref.get("speaker", default_speaker),
+                "text": ref.get("text") or "",
+            }
+            if "bytes" in ref or "base64" in ref or "data" in ref:
+                seg["audio"] = ref
+            else:
+                seg["audio"] = ref.get("audio_path") or ref.get("path")
+            segments.append(seg)
+        return segments
+
+    reference_audio = inputs.get("reference_audio")
+    if reference_audio is not None:
+        segments.append(
+            {
+                "speaker": inputs.get("reference_speaker", default_speaker),
+                "text": inputs.get("reference_text") or "",
+                "audio": reference_audio,
+            }
+        )
+    return segments
+
+
+def create_preprocessing_executor(
+    model_path: str,
+    *,
+    max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
+) -> ThreadedSimpleScheduler:
+    """CPU preprocessing: parse inputs, tokenize, route the audio path.
+
+    Parses ``payload.request.inputs`` (str | dict with ``input|text``,
+    ``speaker``, ``context: [{text, speaker, audio|codes}]``,
+    higgs-compatible ``references`` aliasing). Three branches:
+
+    (a) pre-encoded codes → full prompt NOW (F = ``codes.shape[0]``);
+    (b) no context → prompt now;
+    (c) raw waveform → load/resample 24 kHz mono and DEFER prompt assembly to
+        the audio_encoder — the placeholder count must come from the actual
+        Mimi encode (kills the off-by-one class; do not optimize away).
+
+    Limits: context audio <= 60 s; text <= ~1500 tokens. Three-tier caching
+    copied from higgs (path-hash memo / waveform LRU / encoded-codes LRU as
+    CPU int32).
+
+    Returns:
+        ``ThreadedSimpleScheduler`` wrapping the preprocess fn.
+    """
+    checkpoint_dir = resolve_checkpoint(model_path)
+    builder = CsmPromptBuilder(checkpoint_dir)
+    waveform_cache = StageOutputCache(
+        max_size=_CTX_WAVEFORM_CACHE_MAX_ITEMS,
+        max_bytes=_CTX_WAVEFORM_CACHE_MAX_BYTES,
+    )
+    waveform_cache_lock = threading.Lock()
+
+    def _load_context_waveform(audio: Any) -> tuple[torch.Tensor, str | None]:
+        cache_key = _context_audio_cache_key(audio)
+        with waveform_cache_lock:
+            cached = waveform_cache.get(cache_key)
+        if cached is not None:
+            return cached.clone(), cache_key
+        waveform_np, sample_rate = load_audio_to_24k(audio)
+        wav = torch.from_numpy(waveform_np)
+        if sample_rate != SAMPLE_RATE:
+            wav = F_audio.resample(wav, sample_rate, SAMPLE_RATE)
+        if wav.shape[-1] > MAX_CONTEXT_AUDIO_SECONDS * SAMPLE_RATE:
+            raise ValueError(
+                f"context audio is too long ({wav.shape[-1] / SAMPLE_RATE:.1f}s); "
+                f"cap at {MAX_CONTEXT_AUDIO_SECONDS}s."
+            )
+        wav = wav.reshape(1, 1, -1).contiguous().float()
+        with waveform_cache_lock:
+            waveform_cache.put(cache_key, wav.clone())
+        return wav, cache_key
+
+    def _preprocess(payload: StagePayload) -> StagePayload:
+        inputs = payload.request.inputs or {}
+        params = payload.request.params or {}
+        if isinstance(inputs, str):
+            inputs = {"text": inputs}
+
+        text = inputs.get("input") or inputs.get("text") or ""
+        speaker_id = int(inputs.get("speaker", inputs.get("speaker_id", 0)) or 0)
+        text_tokens = builder.tokenize_segment_text(speaker_id, text)
+        if len(text_tokens) > _MAX_TEXT_TOKENS:
+            raise ValueError(
+                f"input text is too long ({len(text_tokens)} tokens); cap at "
+                f"{_MAX_TEXT_TOKENS} tokens after reserving frame budget."
+            )
+
+        context_entries: list[dict[str, Any]] = []
+        context_codes: list[torch.Tensor | None] = []
+        has_raw_audio = False
+        for seg in _normalize_context_inputs(inputs, speaker_id):
+            seg_speaker = int(
+                seg.get("speaker", seg.get("speaker_id", speaker_id)) or 0
+            )
+            seg_text = seg.get("text") or ""
+            entry: dict[str, Any] = {"speaker_id": seg_speaker, "text": seg_text}
+            codes = to_codes_F32(seg.get("codes"))
+            if codes is not None:
+                # (a) pre-encoded fast path: F is just codes.shape[0].
+                if codes.shape[0] > _MAX_CONTEXT_FRAMES:
+                    raise ValueError(
+                        f"context codes are too long ({int(codes.shape[0])} frames); "
+                        f"cap at {MAX_CONTEXT_AUDIO_SECONDS}s "
+                        f"(~{_MAX_CONTEXT_FRAMES} frames at {FRAME_RATE} Hz)."
+                    )
+                context_codes.append(codes.to(torch.int32).cpu())
+            else:
+                audio = seg.get("audio")
+                if audio is None:
+                    raise ValueError(
+                        "each context segment needs either pre-encoded 'codes' "
+                        "or raw 'audio'"
+                    )
+                # (c) raw waveform: defer prompt assembly to audio_encoder so
+                # the placeholder count comes from the ACTUAL encode.
+                wav, cache_key = _load_context_waveform(audio)
+                entry["waveform"] = wav
+                entry["cache_key"] = cache_key
+                context_codes.append(None)
+                has_raw_audio = True
+            context_entries.append(entry)
+
+        if has_raw_audio:
+            prompt_ids: list[int] = []  # assembled by audio_encoder
+        else:
+            prompt_ids, _spans = builder.build_prompt(
+                text=text,
+                speaker_id=speaker_id,
+                context=context_entries,
+                context_frame_counts=[
+                    int(c.shape[0]) for c in context_codes if c is not None
+                ],
+            )
+
+        max_new_tokens = params.get("max_new_tokens")
+        temperature = params.get("temperature")
+        top_k = params.get("top_k")
+        state = CsmTtsState(
+            text=text,
+            speaker_id=speaker_id,
+            context=context_entries,
+            prompt_ids=prompt_ids,
+            context_codes=context_codes if context_entries else None,
+            max_new_tokens=(
+                int(max_new_tokens) if max_new_tokens else DEFAULT_MAX_FRAMES
+            ),
+            temperature=float(temperature) if temperature is not None else 0.9,
+            top_k=int(top_k) if top_k is not None else 50,
+            top_p=params.get("top_p"),
+            depth_temperature=float(params.get("depth_temperature", 0.9)),
+            depth_top_k=int(params.get("depth_top_k", 50)),
+            seed=params.get("seed"),
+            stream=bool(params.get("stream", False)),
+        )
+        payload.data = state.to_dict()
+        return payload
+
+    return ThreadedSimpleScheduler(_preprocess, max_concurrency=max_concurrency)
+
+
+def create_audio_encoder_executor(
+    model_path: str,
+    *,
+    device: str = "cuda:0",
+    max_batch_size: int = DEFAULT_MAX_CONCURRENCY,
+    max_batch_wait_ms: int = 2,
+) -> SimpleScheduler:
+    """Mimi ENCODE stage (optional fast-path no-op).
+
+    No-op on the pre-encoded fast path; else ``codec.encode_reference`` →
+    ``[F, 32]`` → build the prompt with exactly F ``128002`` placeholders +
+    ``128003`` per segment → null the waveform. Startup warmup encode of 1 s
+    of zeros. Shares the process-wide Mimi via ``get_or_load_codec``.
+
+    Returns:
+        ``SimpleScheduler`` with batched encode.
+    """
+    checkpoint_dir = resolve_checkpoint(model_path)
+    builder = CsmPromptBuilder(checkpoint_dir)
+    codec = get_or_load_codec(checkpoint_dir, device, "float32")
+    # Warmup so the first request doesn't pay kernel autotune/lazy init.
+    codec.encode_reference(torch.zeros(1, 1, codec.SAMPLE_RATE), codec.SAMPLE_RATE)
+    # Single-threaded SimpleScheduler stage, so no lock needed. Cache CPU int32
+    # tensors so StageOutputCache can byte-bound them (higgs pattern).
+    code_cache = StageOutputCache(
+        max_size=_CTX_CODE_CACHE_MAX_ITEMS,
+        max_bytes=_CTX_CODE_CACHE_MAX_BYTES,
+        cache_device="cpu",
+    )
+
+    def _encode(payload: StagePayload) -> StagePayload:
+        state = CsmTtsState.from_dict(payload.data)
+        if state.prompt_ids:
+            return payload  # fast path: prompt already assembled upstream
+
+        context_codes = list(state.context_codes or [None] * len(state.context))
+        for i, entry in enumerate(state.context):
+            if context_codes[i] is not None:
+                continue
+            waveform = entry.get("waveform")
+            if waveform is None:
+                raise ValueError(
+                    f"context segment {i} has neither codes nor a loaded waveform"
+                )
+            cache_key = entry.get("cache_key")
+            codes = code_cache.get(cache_key)
+            if codes is None:
+                wav = torch.as_tensor(waveform, dtype=torch.float32)
+                codes_F32 = codec.encode_reference(wav, codec.SAMPLE_RATE)
+                if codes_F32.ndim != 2 or codes_F32.shape[1] != NUM_CODEBOOKS:
+                    raise ValueError(
+                        f"Mimi encode must return [F, {NUM_CODEBOOKS}], got "
+                        f"{tuple(codes_F32.shape)}"
+                    )
+                codes = codes_F32.to(torch.int32).cpu()
+                code_cache.put(cache_key, codes)
+            context_codes[i] = codes
+            entry.pop("waveform", None)
+            entry.pop("cache_key", None)
+
+        # F per segment from the ACTUAL encode (or codes.shape[0] on the
+        # pre-encoded segments) — never the closed-form estimate.
+        prompt_ids, _spans = builder.build_prompt(
+            text=state.text or "",
+            speaker_id=state.speaker_id,
+            context=state.context,
+            context_frame_counts=[int(c.shape[0]) for c in context_codes],
+        )
+        state.prompt_ids = prompt_ids
+        state.context_codes = context_codes
+        payload.data = state.to_dict()
+        return payload
+
+    return SimpleScheduler(
+        _encode,
+        max_batch_size=max_batch_size,
+        max_batch_wait_ms=max_batch_wait_ms,
+    )
+
+
+def create_sglang_tts_engine_executor(
+    model_path: str,
+    *,
+    device: str = "cuda:0",
+    max_new_tokens: int | None = DEFAULT_MAX_FRAMES,
+    server_args_overrides: dict[str, Any] | None = None,
+    enable_async_decode: bool = False,
+    async_decode_min_batch_size: int = 2,
+) -> OmniScheduler:
+    """SGLang-backed frame-AR engine (the-contract recipe).
+
+    Recipe: ``resolve_checkpoint`` →
+    ``build_sglang_server_args(checkpoint_dir, context_length=2048,
+    disable_cuda_graph=True (eager; set False to enable CUDA graphs), cuda_graph_max_bs=8,
+    mem_fraction_static=0.5, max_running_requests=8,
+    chunked_prefill_size=2048, dtype="bfloat16", **overrides)`` →
+    ``server_args.disable_overlap_schedule = True`` (contract-required) →
+    ``create_sglang_infrastructure`` → ``CsmTTSModelRunner(model_worker,
+    SGLangOutputProcessor(capture_hidden=False, ...))`` →
+    ``make_csm_scheduler_adapters`` → ``OmniScheduler(...,
+    abort_callback=model.reset_request)`` →
+    ``model_runner.set_stream_outbox(scheduler.outbox)``.
+
+    Deliberate deltas vs higgs: NO ``truncate_rope_to_bf16`` (CSM ckpt is
+    fp32-trained — leave SGLang's fp32 cos/sin cache alone); the
+    ``on_retract`` callable passed to bootstrap must ABORT with an actionable
+    error instead of silently re-prefilling (sampler pool has no rollback).
+
+    Returns:
+        Configured ``OmniScheduler``.
+    """
+    checkpoint_dir = resolve_checkpoint(model_path)
+    gpu_id = int(device.split(":")[-1]) if ":" in device else 0
+
+    overrides: dict[str, Any] = {
+        # Eager by default (correctness baseline); set disable_cuda_graph=False to enable CUDA graphs with
+        # the captured backbone+cb0+depth step.
+        "disable_cuda_graph": True,
+        "cuda_graph_max_bs": DEFAULT_MAX_CONCURRENCY,
+        "mem_fraction_static": 0.5,
+        "max_running_requests": DEFAULT_MAX_CONCURRENCY,
+        "chunked_prefill_size": 2048,
+        "dtype": "bfloat16",
+        # Radix cache is namespaced per context audio via Req.extra_key (set
+        # in build_sglang_csm_request); identical 128002xF placeholder
+        # prefixes from different voices can't cross-contaminate the KV tree.
+    }
+    if server_args_overrides:
+        overrides.update(server_args_overrides)
+
+    server_args = build_sglang_server_args(
+        checkpoint_dir,
+        context_length=BACKBONE_CTX,
+        **overrides,
+    )
+    server_args.disable_overlap_schedule = True
+
+    (
+        model_worker,
+        tree_cache,
+        req_to_token_pool,
+        token_to_kv_pool_allocator,
+        prefill_mgr,
+        decode_mgr,
+        model_config,
+    ) = create_sglang_infrastructure(server_args, gpu_id)
+
+    # NO truncate_rope_to_bf16 here: CSM is fp32-trained, the higgs
+    # bf16-training-parity rationale doesn't apply.
+
+    def _abort_on_retract(req: Any) -> None:
+        # retraction would replay the prompt and sample a NEW
+        # frame 0 while output_frames/the vocoder already consumed the old
+        # stream — the sampler pool has no rollback. Admission checks + the
+        # 45x-overprovisioned KV pool make this structurally unreachable;
+        # fail loudly if it ever fires.
+        raise RuntimeError(
+            "CSM tts_engine cannot retract request "
+            f"{getattr(req, 'rid', '<unknown>')!r}: the frame sampler/vocoder "
+            "stream has no rollback. Retraction means the KV "
+            "pool is overcommitted — raise mem_fraction_static or lower "
+            "max_running_requests."
+        )
+
+    decode_mgr.on_retract = _abort_on_retract
+
+    output_proc = SGLangOutputProcessor(
+        capture_hidden=False,
+        capture_hidden_layers=None,
+        model=model_worker.model_runner.model,
+    )
+    model_runner = CsmTTSModelRunner(model_worker, output_proc)
+    model = model_worker.model_runner.model
+    request_builder, result_adapter = make_csm_scheduler_adapters(
+        model,
+        max_new_tokens_cap=max_new_tokens,
+    )
+
+    scheduler = OmniScheduler(
+        tp_worker=model_worker,
+        tree_cache=tree_cache,
+        req_to_token_pool=req_to_token_pool,
+        token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+        server_args=server_args,
+        model_config=model_config,
+        prefill_manager=prefill_mgr,
+        decode_manager=decode_mgr,
+        model_runner=model_runner,
+        request_builder=request_builder,
+        result_adapter=result_adapter,
+        abort_callback=model.reset_request,
+        enable_async_decode=enable_async_decode,
+        async_decode_min_batch_size=async_decode_min_batch_size,
+    )
+    model_runner.set_stream_outbox(scheduler.outbox)
+    return scheduler
+
+
+def create_vocoder_executor(
+    model_path: str,
+    *,
+    device: str = "cuda:0",
+    dtype: str = "float32",
+    max_batch_size: int = DEFAULT_MAX_CONCURRENCY,
+    max_batch_wait_ms: int = 2,
+    stream_stride: int = 13,
+    stream_followup_stride: int = 6,
+    stream_overlap_frames: int = 4,
+    stream_holdback_frames: int = 2,
+) -> CsmStreamingVocoderScheduler:
+    """Mimi DECODE stage (fp32 default — conv-transpose stability).
+
+    ``resolve_checkpoint`` → ``get_or_load_codec`` (shared with the encoder)
+    → :class:`CsmStreamingVocoderScheduler` with the 12.5 Hz framing knobs.
+
+    Returns:
+        ``CsmStreamingVocoderScheduler``.
+    """
+    checkpoint_dir = resolve_checkpoint(model_path)
+    codec = get_or_load_codec(checkpoint_dir, device, dtype)
+
+    return CsmStreamingVocoderScheduler(
+        codec,
+        stream_stride=stream_stride,
+        stream_followup_stride=stream_followup_stride,
+        stream_overlap_frames=stream_overlap_frames,
+        stream_holdback_frames=stream_holdback_frames,
+        max_batch_size=max_batch_size,
+        max_batch_wait_ms=max_batch_wait_ms,
+    )
+
+
+__all__ = [
+    "DEFAULT_MAX_CONCURRENCY",
+    "MAX_CONTEXT_AUDIO_SECONDS",
+    "create_audio_encoder_executor",
+    "create_preprocessing_executor",
+    "create_sglang_tts_engine_executor",
+    "create_vocoder_executor",
+]

--- a/sglang_omni/models/csm_tts/text_tokenizer.py
+++ b/sglang_omni/models/csm_tts/text_tokenizer.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# Prompt assembly mirrors the sesame/csm-1b hub chat template and HuggingFace Transformers
+# CSM (transformers/models/csm, Apache-2.0); the raw-tokenizer load follows sglang-omni Higgs.
+"""CSM prompt assembly over the checkpoint's Llama-3 tokenizer.
+
+Mirrors the hub chat template EXACTLY (parity is hostage to token-exact
+prompt assembly):
+
+- per context message:
+  ``128000 ⊕ tok("[<spk>]<text>") ⊕ 128001 ⊕ 128002×F ⊕ 128003``
+- final (target) message:
+  ``128000 ⊕ tok("[<spk>]<text>") ⊕ 128001``
+
+``add_special_tokens=False`` everywhere; the speaker tag is LITERAL text
+``[0]``. Unlike higgs's ``-100`` sentinel, the ``<|AUDIO|>`` positions keep
+their REAL id 128002 (in-vocab) — no masking needed; the prefill overlay
+simply overwrites those embedding rows.
+
+The tokenizer is loaded from the raw ``tokenizer.json`` (higgs trick — dodges
+the transformers-v5 tokenizer-metadata incompatibility).
+
+
+"""
+
+from __future__ import annotations
+
+import os
+
+from tokenizers import Tokenizer
+from transformers import PreTrainedTokenizerFast
+
+from sglang_omni.models.csm_tts.utils import (
+    AUDIO_EOS_TOKEN_ID,
+    AUDIO_TOKEN_ID,
+    BOS,
+    EOT,
+)
+
+
+class CsmPromptBuilder:
+    """Token-exact CSM prompt builder."""
+
+    def __init__(self, checkpoint_dir: str) -> None:
+        """Load the Llama-3 tokenizer from ``<checkpoint_dir>/tokenizer.json``
+        via ``tokenizers.Tokenizer`` wrapped in ``PreTrainedTokenizerFast``
+        (higgs text_tokenizer pattern)."""
+        # transformers-v5 tokenizer-metadata dodge: bypass from_pretrained and
+        # load the raw tokenizer.json (higgs stages.py:198-200).
+        raw = Tokenizer.from_file(os.path.join(checkpoint_dir, "tokenizer.json"))
+        self._tok = PreTrainedTokenizerFast(tokenizer_object=raw)
+
+    @property
+    def tokenizer(self) -> PreTrainedTokenizerFast:
+        return self._tok
+
+    def build_prompt(
+        self,
+        *,
+        text: str,
+        speaker_id: int,
+        context: list[dict] | None = None,
+        context_frame_counts: list[int] | None = None,
+    ) -> tuple[list[int], list[tuple[int, int]]]:
+        """Assemble the full prompt id sequence + per-segment placeholder spans.
+
+        Args:
+            text: target utterance text.
+            speaker_id: speaker tag rendered as literal ``[<spk>]`` text.
+            context: ordered context segments ``{speaker_id, text}``.
+            context_frame_counts: F per context segment — MUST come from the
+                actual Mimi encode on the raw-waveform path (deferred prompt
+                assembly) or ``codes.shape[0]`` on the
+                pre-encoded fast path.
+
+        Returns:
+            ``(prompt_ids, placeholder_spans)`` where ``placeholder_spans`` is
+            one ``(start, length)`` per context segment covering its
+            ``128002×F`` run (the ``128003`` position immediately after gets
+            the all-zeros-frame embed at overlay time — HF
+            ``_merge_input_ids_with_input_values`` parity).
+        """
+        context = context or []
+        frame_counts = context_frame_counts or []
+        if len(frame_counts) != len(context):
+            raise ValueError(
+                f"context_frame_counts has {len(frame_counts)} entries for "
+                f"{len(context)} context segments"
+            )
+
+        prompt_ids: list[int] = []
+        placeholder_spans: list[tuple[int, int]] = []
+        for segment, num_frames in zip(context, frame_counts):
+            num_frames = int(num_frames)
+            if num_frames <= 0:
+                # Hub template: every non-final message must carry audio.
+                raise ValueError(
+                    f"context segment needs >= 1 audio frame, got {num_frames}"
+                )
+            prompt_ids.append(BOS)
+            prompt_ids.extend(
+                self.tokenize_segment_text(
+                    segment.get("speaker_id", 0), segment.get("text", "")
+                )
+            )
+            prompt_ids.append(EOT)
+            placeholder_spans.append((len(prompt_ids), num_frames))
+            prompt_ids.extend([AUDIO_TOKEN_ID] * num_frames)
+            prompt_ids.append(AUDIO_EOS_TOKEN_ID)
+
+        prompt_ids.append(BOS)
+        prompt_ids.extend(self.tokenize_segment_text(speaker_id, text))
+        prompt_ids.append(EOT)
+        return prompt_ids, placeholder_spans
+
+    def tokenize_segment_text(self, speaker_id: int, text: str) -> list[int]:
+        """``tok("[<spk>]<text>", add_special_tokens=False)`` — body tokens
+        only (no BOS/EOT framing).
+
+        Returns:
+            list[int] token ids in the 128256 text vocab.
+        """
+        return self._tok.encode(f"[{int(speaker_id)}]{text}", add_special_tokens=False)
+
+
+__all__ = [
+    "AUDIO_EOS_TOKEN_ID",
+    "AUDIO_TOKEN_ID",
+    "BOS",
+    "EOT",
+    "CsmPromptBuilder",
+]

--- a/sglang_omni/models/csm_tts/utils.py
+++ b/sglang_omni/models/csm_tts/utils.py
@@ -1,0 +1,290 @@
+# SPDX-License-Identifier: Apache-2.0
+# Shared CSM / Kyutai-Mimi constants and HF-Transformers-export staging; the 24 kHz audio
+# loader follows the sglang-omni Higgs loader. Mimi framing per transformers.MimiModel (Apache-2.0).
+"""Constants + stage helpers shared across the CSM TTS pipeline.
+
+Key facts:
+
+- Mimi: 24 kHz, 12.5 Hz frame rate ⇒ one frame = 80 ms = 1920 samples,
+  32 quantizers, codebook size 2048.
+- Audio vocab per codebook is 2051: valid Mimi codes 0..2047; specials
+  2048/2049/2050 must NEVER reach Mimi (``CODEBOOK_PAD=2050``).
+- EOS frame: codebooks 0..30 all == 0 (cb31 excluded); audio trim at the
+  first all-32-zero frame; default generation cap 125 frames.
+- **No delay-pattern helpers** — CSM has none (unlike higgs).
+
+
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from huggingface_hub import snapshot_download
+
+from sglang_omni.models.csm_tts.audio_codec import (
+    CsmMimiCodec,
+    trim_at_first_all_zero_frame,
+)
+from sglang_omni.preprocessing.audio import AudioMediaIO
+from sglang_omni.preprocessing.base import _is_url
+from sglang_omni.preprocessing.resource_connector import global_http_connection
+
+# --- CSM constants (real values, pinned by) -----------------------
+NUM_CODEBOOKS = 32
+CODEBOOK_VOCAB = 2051  # per-codebook logits width (2048 Mimi + 3 specials)
+MIMI_CODEBOOK_SIZE = 2048  # valid Mimi code range is [0, 2047]
+CODEBOOK_EOS = 0
+CODEBOOK_PAD = 2050
+STOP_CODE = -1  # frozen-row sentinel emitted after generation_done
+AUDIO_TOKEN_ID = 128002  # <|AUDIO|> — real in-vocab id (no -100 sentinel)
+AUDIO_EOS_TOKEN_ID = 128003  # <|audio_eos|>
+BOS = 128000
+EOT = 128001
+SAMPLE_RATE = 24000
+SAMPLES_PER_FRAME = 1920  # 24 kHz / 12.5 Hz
+FRAME_RATE = 12.5
+DEFAULT_MAX_FRAMES = 125
+BACKBONE_CTX = 2048
+K_MAX = 2051  # fixed-shape top-k width for the branchless sampler
+
+# Mimi encoder causal-conv ladder (HF processing_csm.py:57-60); the stride
+# product is 4*5*6*8*2 = 1920 = SAMPLES_PER_FRAME.
+_MIMI_KERNEL_SIZES = (7, 3, 1, 8, 3, 1, 10, 3, 1, 12, 3, 1, 16, 3, 4)
+_MIMI_STRIDES = (1, 1, 1, 4, 1, 1, 5, 1, 1, 6, 1, 1, 8, 1, 2)
+_MIMI_DILATIONS = (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
+
+# Shared between audio_encoder + vocoder; one Mimi load saves ~0.4 GB fp32.
+_CODEC_CACHE: dict[tuple[str, str, str], CsmMimiCodec] = {}
+
+
+def resolve_checkpoint(checkpoint: str) -> str:
+    """Local dir or HF repo id → local snapshot path, curated to the
+    HF-transformers export when the snapshot mixes checkpoint formats."""
+    if Path(checkpoint).is_dir():
+        snapshot = Path(checkpoint)
+    else:
+        snapshot = Path(snapshot_download(checkpoint))
+    return str(_stage_transformers_only_view(snapshot))
+
+
+_TF_INDEX_NAME = "transformers.safetensors.index.json"
+_TF_SHARD_PREFIX = "transformers-"
+
+
+def _stage_transformers_only_view(snapshot: Path) -> Path:
+    """Expose ONLY the HF-transformers export to the sglang weight loader.
+
+    The sesame/csm-1b snapshot can contain BOTH the orig-format
+    ``model.safetensors`` (un-permuted-RoPE Q/K — must never be read) and the ``transformers-*.safetensors`` shards. sglang's
+    ``DefaultModelLoader`` globs ``*.safetensors``, so a mixed snapshot feeds
+    orig-format tensors into the strict remap census (and would corrupt Q/K
+    if they were ever mapped). Stage a symlink view with the transformers
+    shards renamed to canonical ``model-0000i-of-0000n.safetensors`` plus a
+    rewritten ``model.safetensors.index.json`` so the loader's index filter
+    selects exactly the 538-tensor ship artifact. ``audio_codec.py`` falls
+    back to the rewritten index name, and tokenizer/config sidecars are
+    symlinked through unchanged.
+    """
+    tf_index = snapshot / _TF_INDEX_NAME
+    if not tf_index.exists():
+        return snapshot  # plain layout (e.g. a clean export dir): nothing to do
+    import hashlib
+    import json
+
+    view = (
+        Path.home()
+        / ".cache"
+        / "sglang_omni"
+        / "csm_tfview"
+        / hashlib.sha256(str(snapshot.resolve()).encode()).hexdigest()[:16]
+    )
+    view.mkdir(parents=True, exist_ok=True)
+
+    with open(tf_index) as f:
+        index = json.load(f)
+    rename = {
+        shard: (
+            "model-" + shard[len(_TF_SHARD_PREFIX) :]
+            if shard.startswith(_TF_SHARD_PREFIX)
+            else shard
+        )
+        for shard in sorted(set(index["weight_map"].values()))
+    }
+    index["weight_map"] = {k: rename[v] for k, v in index["weight_map"].items()}
+
+    def _link(dst: Path, src: Path) -> None:
+        if dst.is_symlink() or dst.exists():
+            dst.unlink()
+        dst.symlink_to(src.resolve())
+
+    for src_name, dst_name in rename.items():
+        _link(view / dst_name, snapshot / src_name)
+    for entry in snapshot.iterdir():
+        name = entry.name
+        if name == _TF_INDEX_NAME or name in rename:
+            continue
+        if name.endswith((".safetensors", ".bin", ".pt", ".pth")) or name in (
+            "model.safetensors.index.json",
+            "pytorch_model.bin.index.json",
+        ):
+            continue  # orig-format weights / stale indexes stay OUT of the view
+        _link(view / name, entry)
+    with open(view / "model.safetensors.index.json", "w") as f:
+        json.dump(index, f)
+    return view
+
+
+def get_or_load_codec(checkpoint_dir: str, device: str, dtype: str) -> CsmMimiCodec:
+    """Process-wide cached :class:`CsmMimiCodec` per ``(path, device, dtype)``.
+
+    One Mimi load serves both audio_encoder (encode) and vocoder (decode).
+
+    Returns:
+        ``CsmMimiCodec`` (fp32 by default — conv-transpose decode stability).
+    """
+    key = (str(checkpoint_dir), str(device), str(dtype))
+    cached = _CODEC_CACHE.get(key)
+    if cached is not None:
+        return cached
+    codec = CsmMimiCodec.from_pretrained(
+        checkpoint_dir, device=device, dtype=getattr(torch, dtype)
+    )
+    _CODEC_CACHE[key] = codec
+    return codec
+
+
+def encoded_audio_length(num_samples: int) -> int:
+    """Closed-form Mimi frame count for ``num_samples`` raw 24 kHz samples.
+
+    Port of HF ``processing_csm.py:93-129`` (causal-conv ladder ceil;
+    ≈ ``ceil(num_samples / 1920)``). Used ONLY for pre-encode budget /
+    admission estimates on raw waveforms — the pre-encoded fast path needs no
+    formula (F is just ``codes.shape[0]``), and the raw-waveform path defers
+    the actual placeholder count to the real Mimi encode so
+    prompts can never mismatch. Do NOT promote this estimate to prompt
+    assembly.
+
+    Returns:
+        int — number of 80 ms frames F.
+    """
+    cur_length = num_samples
+    for kernel_size, stride, dilation in zip(
+        _MIMI_KERNEL_SIZES, _MIMI_STRIDES, _MIMI_DILATIONS
+    ):
+        effective_kernel_size = (kernel_size - 1) * dilation + 1
+        padding_total = kernel_size - stride
+
+        n_frames = (cur_length - effective_kernel_size + padding_total) / stride + 1
+        n_frames = math.ceil(n_frames) - 1
+        ideal_length = n_frames * stride + kernel_size - padding_total
+        extra_padding = ideal_length - cur_length
+
+        # use_causal_conv=True: full padding on the left, extra on the right.
+        cur_length = cur_length + padding_total + extra_padding
+        cur_length = (cur_length - dilation * (kernel_size - 1) - 1) // stride + 1
+    return cur_length
+
+
+def to_codes_F32(obj: Any) -> torch.Tensor | None:
+    """Coerce client-supplied pre-encoded context codes to ``[F, 32]`` int64.
+
+    Accepts ``torch.Tensor`` / nested lists / numpy; ``None`` / empty → None.
+    Raises ``ValueError`` unless the result is 2-D with 32 columns.
+
+    Returns:
+        ``torch.LongTensor [F, 32]`` or ``None``.
+    """
+    if obj is None:
+        return None
+    t = obj if isinstance(obj, torch.Tensor) else torch.tensor(obj)
+    if t.numel() == 0:
+        return None
+    if t.ndim != 2 or t.shape[1] != NUM_CODEBOOKS:
+        raise ValueError(
+            f"context codes must have shape [F, {NUM_CODEBOOKS}], got {tuple(t.shape)}"
+        )
+    return t.to(torch.long)
+
+
+def stack_frames(frames: list[torch.Tensor]) -> torch.Tensor:
+    """Delay-free frame assembly: list of per-step int64 ``[32]`` rows →
+    ``[F, 32]`` code matrix (CSM has no delay pattern — rows stack as-is).
+
+    Returns:
+        ``torch.LongTensor [F, 32]`` (``[0, 32]`` for an empty list).
+    """
+    if not frames:
+        return torch.empty(0, NUM_CODEBOOKS, dtype=torch.long)
+    return torch.stack([f.reshape(NUM_CODEBOOKS).to(torch.long) for f in frames], dim=0)
+
+
+# NOTE: trim_at_first_all_zero_frame is defined ONCE in audio_codec.py (the
+# fence-#3 home) and re-exported here for stage-side callers.
+
+
+def load_audio_to_24k(reference_audio: Any) -> tuple[np.ndarray, int]:
+    """Load context audio as 24 kHz mono float32 (higgs loader copy).
+
+    Accepts local path, HTTP/HTTPS URL, or ``{audio_path|path|bytes|base64|
+    data}`` dict.
+
+    Returns:
+        ``(audio_float32 [S], sample_rate)`` — caller reshapes to ``[1, 1, S]``.
+    """
+    io = AudioMediaIO(target_sr=SAMPLE_RATE)
+
+    def _load_path_or_url(src: str | Path) -> tuple[np.ndarray, int]:
+        if isinstance(src, str) and _is_url(src):
+            response = global_http_connection.get_sync_client().get(src)
+            response.raise_for_status()
+            audio, sr = io.load_bytes(response.content)
+        else:
+            audio, sr = io.load_file(Path(src))
+        return np.asarray(audio, dtype=np.float32), int(sr)
+
+    if isinstance(reference_audio, (str, Path)):
+        return _load_path_or_url(reference_audio)
+
+    if "audio_path" in reference_audio or "path" in reference_audio:
+        return _load_path_or_url(
+            reference_audio.get("audio_path") or reference_audio["path"]
+        )
+    if "bytes" in reference_audio:
+        audio, sr = io.load_bytes(reference_audio["bytes"])
+        return np.asarray(audio, dtype=np.float32), int(sr)
+    media_type = reference_audio.get("media_type", "audio/wav")
+    data = reference_audio.get("base64") or reference_audio["data"]
+    audio, sr = io.load_base64(media_type, data)
+    return np.asarray(audio, dtype=np.float32), int(sr)
+
+
+__all__ = [
+    "AUDIO_EOS_TOKEN_ID",
+    "AUDIO_TOKEN_ID",
+    "BACKBONE_CTX",
+    "BOS",
+    "CODEBOOK_EOS",
+    "CODEBOOK_PAD",
+    "CODEBOOK_VOCAB",
+    "DEFAULT_MAX_FRAMES",
+    "EOT",
+    "FRAME_RATE",
+    "K_MAX",
+    "MIMI_CODEBOOK_SIZE",
+    "NUM_CODEBOOKS",
+    "SAMPLES_PER_FRAME",
+    "SAMPLE_RATE",
+    "STOP_CODE",
+    "encoded_audio_length",
+    "get_or_load_codec",
+    "load_audio_to_24k",
+    "resolve_checkpoint",
+    "stack_frames",
+    "to_codes_F32",
+    "trim_at_first_all_zero_frame",
+]

--- a/sglang_omni/models/csm_tts/vocoder_scheduler.py
+++ b/sglang_omni/models/csm_tts/vocoder_scheduler.py
@@ -1,0 +1,529 @@
+# SPDX-License-Identifier: Apache-2.0
+# Follows the sglang-omni Higgs `StreamingSimpleScheduler` streaming-vocoder pattern.
+"""Streaming vocoder stage for CSM — Mimi decode with overlap-trim seam
+handling at 12.5 Hz.
+
+Follows the higgs ``StreamingSimpleScheduler`` lifecycle exactly (latch
+contract, ``_pending_done`` buffering, abort → ``clear_stream_state``, slim
+terminal result). Key delta vs higgs: CSM has NO delay pattern,
+so ``raw_frames_available = len(rows)`` — frame 0 is decodable the moment it
+arrives (no ``rows - N + 1`` reversal warmup). One row = one ``[32]`` tensor
+= 80 ms = 1920 samples.
+
+Frame-math knobs at 12.5 Hz (starting points; a
+seam-audibility A/B over overlap ∈ {2, 4, 6}):
+
+- ``stream_stride=13`` (~1.04 s first decode; overridden to 1 by the
+  first-chunk knob on streaming paths)
+- ``stream_followup_stride=6`` (480 ms steady chunks)
+- ``stream_overlap_frames=4`` (320 ms re-decoded left context — Mimi's decode
+  path has no conv-state cache, edge frames differ per the HF docstring)
+- ``stream_holdback_frames=2`` (160 ms; never emit codec-edge frames
+  mid-stream; final flush emits all)
+
+Emission per delta: re-decode ``[emitted - overlap : available - holdback]``,
+trim ``overlap * 1920`` samples, emit exactly ``new_frames * 1920`` —
+seam-free without crossfade. This STATELESS overlap-trim decode is the default;
+the optional stateful ``decoder_past_key_values`` path is mutually exclusive with
+overlap re-decode and stays gated on an A/B.
+
+The three OOB fences: (1) engine never streams EOS/STOP frames;
+(2) ``sanitize_for_mimi`` clamp + counter on every matrix entering Mimi;
+(3) final flush / non-streaming trim at the first all-32-zero frame (HF
+cutoff semantics, generation_csm.py:471-477 — mirrors HF's stop(31)/trim(32)
+inconsistency exactly).
+
+
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+import torch
+
+from sglang_omni.models.csm_tts.audio_codec import (
+    CsmMimiCodec,
+    sanitize_for_mimi,
+    trim_at_first_all_zero_frame,
+)
+from sglang_omni.models.csm_tts.payload_types import CsmTtsState
+from sglang_omni.models.tts_streaming import (
+    INITIAL_CODEC_CHUNK_FRAMES_PARAM,
+    resolve_initial_codec_chunk_frames,
+)
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.messages import OutgoingMessage
+from sglang_omni.scheduling.streaming_simple_scheduler import StreamingSimpleScheduler
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["CsmStreamState", "CsmStreamingVocoderScheduler"]
+
+# Known CSM stream contract; used as the latch default when neither the
+# payload nor the chunk metadata carries the fields (CsmTtsState has no
+# num_codebooks/codebook_size fields — they're model constants).
+_NUM_CODEBOOKS = 32
+_CODEBOOK_VOCAB = 2051
+
+
+@dataclass
+class CsmStreamState:
+    """Per-request streaming state (dropped in ``clear_stream_state``)."""
+
+    rows: list[torch.Tensor] = field(default_factory=list)  # each int64 [32]
+    frames_emitted: int = 0
+    samples_emitted: int = 0
+    num_codebooks: int | None = None  # latched: 32
+    codebook_size: int | None = None  # latched: 2051
+    initial_codec_chunk_frames: int | None = None
+    clamp_count: int = 0  # sanitize_for_mimi telemetry (gate only at temp=0)
+    past_key_values: Any | None = None  # stateful path ONLY
+    done: bool = False
+
+
+class CsmStreamingVocoderScheduler(StreamingSimpleScheduler):
+    """Decode CSM code rows incrementally; batched final decode for the
+    non-streaming path (``_vocode_payloads`` + ``decode_batch``)."""
+
+    def __init__(
+        self,
+        codec: CsmMimiCodec,
+        *,
+        stream_stride: int = 13,
+        stream_followup_stride: int = 6,
+        stream_overlap_frames: int = 4,
+        stream_holdback_frames: int = 2,
+        max_batch_size: int = 8,
+        max_batch_wait_ms: int = 2,
+    ) -> None:
+        """Validate knobs, hold the shared :class:`CsmMimiCodec`, init the
+        per-request ``_stream_states`` dict, then ``super().__init__(
+        self._vocode_payload, batch_compute_fn=self._vocode_payloads,
+        max_batch_size=..., max_batch_wait_ms=...)`` (higgs ctor shape)."""
+        if stream_stride <= 0 or stream_followup_stride <= 0:
+            raise ValueError("stream_stride and stream_followup_stride must be > 0")
+        if stream_overlap_frames < 0:
+            raise ValueError("stream_overlap_frames must be >= 0")
+        if stream_holdback_frames < 0:
+            raise ValueError("stream_holdback_frames must be >= 0")
+
+        self._codec = codec
+        self._stream_stride = int(stream_stride)
+        self._stream_followup_stride = int(stream_followup_stride)
+        self._stream_overlap_frames = int(stream_overlap_frames)
+        self._stream_holdback_frames = int(stream_holdback_frames)
+        self._sample_rate = CsmMimiCodec.SAMPLE_RATE
+        self._samples_per_frame = CsmMimiCodec.SAMPLES_PER_FRAME
+        self._stream_states: dict[str, CsmStreamState] = {}
+        self._clamp_count_total = 0  # process-wide fence-#2 counter
+
+        super().__init__(
+            self._vocode_payload,
+            batch_compute_fn=self._vocode_payloads,
+            max_batch_size=max_batch_size,
+            max_batch_wait_ms=max_batch_wait_ms,
+        )
+
+    # --- StreamingSimpleScheduler hooks ---------------------------------------
+
+    def is_streaming_payload(self, payload: StagePayload) -> bool:
+        """``bool(payload.request.params.get("stream", False))``."""
+        params = payload.request.params
+        if not isinstance(params, dict):
+            raise TypeError(
+                f"CSM request params must be a dict, got {type(params).__name__}"
+            )
+        return bool(params.get("stream", False))
+
+    def on_streaming_new_request(self, request_id: str, payload: StagePayload) -> None:
+        """Latch the stream contract (``num_codebooks=32`` /
+        ``codebook_size=2051``) + ``initial_codec_chunk_frames`` from the
+        payload/params (higgs latch discipline; the stage runs with
+        ``can_accept_stream_before_payload=True``)."""
+        state = self._stream_states.setdefault(request_id, CsmStreamState())
+        data = payload.data if isinstance(payload.data, dict) else {}
+        self._latch_stream_contract(
+            request_id,
+            state,
+            num_codebooks=data.get(
+                "num_codebooks", state.num_codebooks or _NUM_CODEBOOKS
+            ),
+            codebook_size=data.get(
+                "codebook_size", state.codebook_size or _CODEBOOK_VOCAB
+            ),
+            source="payload",
+        )
+        params = (
+            payload.request.params if isinstance(payload.request.params, dict) else None
+        )
+        self._latch_initial_codec_chunk_frames_from_mapping(state, params)
+
+    def on_stream_chunk(self, request_id: str, item: Any) -> list[OutgoingMessage]:
+        """Append the ``[32]`` int64 row from ``item.data`` to the request's
+        ``rows`` and run :meth:`_decode_delta`.
+
+        Returns:
+            Zero or more audio-chunk ``OutgoingMessage``s (raw PCM payloads of
+            exactly ``new_frames * 1920`` samples each).
+        """
+        state = self._stream_states.setdefault(request_id, CsmStreamState())
+        self._latch_stream_metadata(request_id, state, item.metadata)
+
+        row = item.data
+        if not isinstance(row, torch.Tensor):
+            raise TypeError(
+                f"CSM stream chunk for {request_id!r} must carry a torch.Tensor, "
+                f"got {type(row).__name__}"
+            )
+        row = row.detach().to(device="cpu", dtype=torch.long).reshape(-1)
+        num_codebooks = state.num_codebooks or _NUM_CODEBOOKS
+        if int(row.shape[0]) != num_codebooks:
+            raise ValueError(
+                f"CSM stream chunk has {int(row.shape[0])} codebooks, "
+                f"expected {num_codebooks}"
+            )
+        state.rows.append(row)
+        return self._decode_delta(request_id, state)
+
+    def on_stream_done(self, request_id: str) -> list[OutgoingMessage]:
+        """Final flush (emit all held-back frames, trimmed at the first
+        all-32-zero frame — fence #3) + slim terminal result with usage
+        (prompt_tokens, completion_frames, engine_time_s). Zero-chunk streams
+        (frame-0 EOS) produce a well-formed empty/near-empty
+        audio response matching HF ``cutoff_idx=0``."""
+        payload = self._stream_payloads[request_id]
+        state = self._stream_states.setdefault(request_id, CsmStreamState())
+        messages = self._decode_delta(request_id, state, final=True)
+        if not messages and state.frames_emitted == 0:
+            # Zero-chunk stream (frame-0 EOS): fall back to the engine payload's
+            # output_frames with exact HF trim parity — empty when cb31 == 0,
+            # one 80 ms frame when cb31 != 0.
+            output = self._audio_payload_from_stage_payload(request_id, state, payload)
+            if output is not None:
+                messages.append(
+                    OutgoingMessage(
+                        request_id=request_id,
+                        type="stream",
+                        data=output,
+                        metadata={"modality": "audio"},
+                    )
+                )
+        state.done = True
+
+        final_data: dict[str, Any] = {
+            "modality": "audio",
+            "sample_rate": self._sample_rate,
+        }
+        usage = self._build_usage(CsmTtsState.from_dict(payload.data))
+        if usage is not None:
+            final_data["usage"] = usage
+        messages.append(
+            OutgoingMessage(
+                request_id=request_id,
+                type="result",
+                data=StagePayload(
+                    request_id=payload.request_id,
+                    request=payload.request,
+                    data=final_data,
+                ),
+            )
+        )
+        return messages
+
+    def clear_stream_state(self, request_id: str) -> None:
+        """Drop the per-request :class:`CsmStreamState` INCLUDING any Mimi
+        ``past_key_values`` — the cross-request state-leak guard (abort path
+        calls this too)."""
+        self._stream_states.pop(request_id, None)
+
+    # --- latch helpers ----------------------------------------------------------
+
+    def _latch_stream_metadata(
+        self,
+        request_id: str,
+        state: CsmStreamState,
+        metadata: dict[str, Any] | None,
+    ) -> None:
+        if not isinstance(metadata, dict):
+            # Engine chunks always carry stream_metadata; tolerate absence by
+            # falling back to the CSM constants (latched-once discipline kept).
+            self._latch_stream_contract(
+                request_id,
+                state,
+                num_codebooks=state.num_codebooks or _NUM_CODEBOOKS,
+                codebook_size=state.codebook_size or _CODEBOOK_VOCAB,
+                source="stream metadata defaults",
+            )
+            return
+        if metadata.get("modality") not in (None, "audio_codes"):
+            raise ValueError(
+                f"CSM stream chunk modality must be audio_codes, got "
+                f"{metadata.get('modality')!r}"
+            )
+        if metadata.get("stream") is not True:
+            raise RuntimeError(
+                f"CSM stream chunk for {request_id!r} must include "
+                "metadata['stream'] == True"
+            )
+        self._latch_stream_contract(
+            request_id,
+            state,
+            num_codebooks=metadata.get(
+                "num_codebooks", state.num_codebooks or _NUM_CODEBOOKS
+            ),
+            codebook_size=metadata.get(
+                "codebook_size", state.codebook_size or _CODEBOOK_VOCAB
+            ),
+            source="stream metadata",
+        )
+        if INITIAL_CODEC_CHUNK_FRAMES_PARAM in metadata:
+            self._latch_initial_codec_chunk_frames_from_mapping(state, metadata)
+
+    @staticmethod
+    def _latch_stream_contract(
+        request_id: str,
+        state: CsmStreamState,
+        *,
+        num_codebooks: Any,
+        codebook_size: Any,
+        source: str,
+    ) -> None:
+        try:
+            num_codebooks_i = int(num_codebooks)
+            codebook_size_i = int(codebook_size)
+        except (TypeError, ValueError) as exc:
+            raise TypeError(
+                f"CSM {source} for {request_id!r} must include integer "
+                "num_codebooks and codebook_size"
+            ) from exc
+        if num_codebooks_i != _NUM_CODEBOOKS or codebook_size_i != _CODEBOOK_VOCAB:
+            raise ValueError(
+                f"CSM {source} for {request_id!r} has invalid contract "
+                f"num_codebooks={num_codebooks_i}, codebook_size={codebook_size_i}; "
+                f"expected {_NUM_CODEBOOKS}/{_CODEBOOK_VOCAB}"
+            )
+        if state.num_codebooks is not None and state.num_codebooks != num_codebooks_i:
+            raise ValueError(
+                f"CSM stream num_codebooks changed for {request_id!r}: "
+                f"{state.num_codebooks} -> {num_codebooks_i}"
+            )
+        if state.codebook_size is not None and state.codebook_size != codebook_size_i:
+            raise ValueError(
+                f"CSM stream codebook_size changed for {request_id!r}: "
+                f"{state.codebook_size} -> {codebook_size_i}"
+            )
+        state.num_codebooks = num_codebooks_i
+        state.codebook_size = codebook_size_i
+
+    def _latch_initial_codec_chunk_frames_from_mapping(
+        self,
+        state: CsmStreamState,
+        params: Mapping[str, Any] | None,
+    ) -> None:
+        # No delay pattern: the steady first chunk IS stream_stride frames.
+        # Only overwrite when the mapping carries the key — chunks (and their
+        # metadata latch) may legally arrive BEFORE the engine payload.
+        if params is not None and INITIAL_CODEC_CHUNK_FRAMES_PARAM in params:
+            state.initial_codec_chunk_frames = resolve_initial_codec_chunk_frames(
+                params, steady_chunk_frames=self._stream_stride
+            )
+        elif state.initial_codec_chunk_frames is None:
+            state.initial_codec_chunk_frames = 0
+
+    # --- decode internals -------------------------------------------------------
+
+    def _decode_delta(
+        self, request_id: str, state: CsmStreamState, *, final: bool = False
+    ) -> list[OutgoingMessage]:
+        """Stateless overlap-trim incremental decode:
+        when enough new frames are available per stride/first-chunk knobs,
+        re-decode ``rows[emitted - overlap : available - holdback]`` through
+        :func:`sanitize_for_mimi` + ``codec.decode``, trim ``overlap * 1920``
+        leading samples, emit exactly ``new_frames * 1920``.
+
+        Returns:
+            Audio-chunk messages (possibly empty when below stride).
+        """
+        available = len(state.rows)
+        if available == 0:
+            return []
+
+        if final:
+            # Fence #3: never decode past the first all-32-zero frame.
+            rows_F32 = torch.stack(state.rows, dim=0)
+            emit_until = int(trim_at_first_all_zero_frame(rows_F32).shape[0])
+        else:
+            initial = state.initial_codec_chunk_frames or 0
+            has_emitted = state.frames_emitted > 0
+            if not has_emitted:
+                use_initial = 0 < initial < self._stream_stride
+                need = initial if use_initial else self._stream_stride
+                if available < need:
+                    return []
+                emit_until = (
+                    initial if use_initial else available - self._stream_holdback_frames
+                )
+            else:
+                need = (
+                    state.frames_emitted
+                    + self._stream_followup_stride
+                    + self._stream_holdback_frames
+                )
+                if available < need:
+                    return []
+                emit_until = available - self._stream_holdback_frames
+        if emit_until <= state.frames_emitted:
+            return []
+
+        window_start = max(0, state.frames_emitted - self._stream_overlap_frames)
+        codes = torch.stack(state.rows[window_start:emit_until], dim=0)  # fresh copy
+        codes, num_clamped = sanitize_for_mimi(codes)
+        if num_clamped:
+            state.clamp_count += num_clamped
+            self._clamp_count_total += num_clamped
+            logger.warning(
+                "CSM vocoder stream %s clamped %d OOB codes (fence #2 should "
+                "never fire at temp=0)",
+                request_id,
+                num_clamped,
+            )
+        audio = self._codec.decode(codes).reshape(-1)  # [decoded_frames * 1920]
+
+        trim_samples = (state.frames_emitted - window_start) * self._samples_per_frame
+        if final:
+            delta = audio[trim_samples:]
+        else:
+            new_frames = emit_until - state.frames_emitted
+            delta = audio[
+                trim_samples : trim_samples + new_frames * self._samples_per_frame
+            ]
+        delta = delta.contiguous()
+        if delta.numel() == 0:
+            return []
+
+        state.frames_emitted = emit_until
+        state.samples_emitted += int(delta.numel())
+        return [
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                data=self._audio_payload(delta, source_hint="CSM TTS streaming"),
+                metadata={"modality": "audio"},
+            )
+        ]
+
+    def _audio_payload_from_stage_payload(
+        self, request_id: str, state: CsmStreamState, payload: StagePayload
+    ) -> dict[str, Any] | None:
+        """Full-payload decode fallback for streams that never emitted —
+        exact HF trim semantics over ``state.output_frames`` (incl. the EOS
+        frame)."""
+        if not isinstance(payload.data, dict):
+            return None
+        codes = self._frames_to_codes(CsmTtsState.from_dict(payload.data).output_frames)
+        if codes is None:
+            return None
+        codes, num_clamped = sanitize_for_mimi(codes)
+        if num_clamped:
+            state.clamp_count += num_clamped
+            self._clamp_count_total += num_clamped
+            logger.warning(
+                "CSM vocoder fallback decode for %s clamped %d OOB codes",
+                request_id,
+                num_clamped,
+            )
+        return self._audio_payload(
+            self._codec.decode(codes), source_hint="CSM TTS streaming"
+        )
+
+    def _vocode_payload(self, payload: StagePayload) -> StagePayload:
+        """Non-streaming single decode (delegates to :meth:`_vocode_payloads`)."""
+        return self._vocode_payloads([payload])[0]
+
+    def _vocode_payloads(self, payloads: list[StagePayload]) -> list[StagePayload]:
+        """Non-streaming batch decode over ``state.output_frames`` via
+        ``codec.decode_batch`` (exact-frame-count buckets), trimming at the
+        first all-32-zero frame (exact HF trim parity — the EOS frame IS in
+        ``output_frames``)."""
+        items: list[tuple[CsmTtsState, torch.Tensor | None]] = []
+        for payload in payloads:
+            state = CsmTtsState.from_dict(payload.data)
+            codes = self._frames_to_codes(state.output_frames)
+            if codes is not None:
+                codes, num_clamped = sanitize_for_mimi(codes)
+                if num_clamped:
+                    self._clamp_count_total += num_clamped
+                    logger.warning(
+                        "CSM vocoder batch decode for %s clamped %d OOB codes",
+                        payload.request_id,
+                        num_clamped,
+                    )
+            items.append((state, codes))
+
+        valid = [(i, codes) for i, (_, codes) in enumerate(items) if codes is not None]
+        waveforms: list[torch.Tensor | None] = [None] * len(items)
+        if valid:
+            indices, codes_list = zip(*valid)
+            wavs = self._codec.decode_batch(list(codes_list))
+            if len(wavs) != len(valid):
+                raise RuntimeError(
+                    f"CSM vocoder decode_batch returned {len(wavs)} audios "
+                    f"for {len(valid)} requests"
+                )
+            for idx, wav in zip(indices, wavs):
+                waveforms[idx] = wav
+
+        results: list[StagePayload] = []
+        for payload, (state, _), waveform in zip(payloads, items, waveforms):
+            data = self._audio_payload(
+                waveform if waveform is not None else [],
+                source_hint="CSM TTS vocoder",
+            )
+            usage = self._build_usage(state)
+            if usage is not None:
+                data["usage"] = usage
+            payload.data = data
+            results.append(payload)
+        return results
+
+    @staticmethod
+    def _frames_to_codes(frames: list[Any] | None) -> torch.Tensor | None:
+        """``output_frames`` rows → trimmed int64 ``[F, 32]`` (or None when
+        nothing decodable remains — e.g. a frame-0 EOS with cb31 == 0)."""
+        if not frames:
+            return None
+        rows = [torch.as_tensor(row, dtype=torch.long).reshape(-1) for row in frames]
+        codes = torch.stack(rows, dim=0)
+        codes = trim_at_first_all_zero_frame(codes)
+        if codes.shape[0] == 0:
+            return None
+        return codes
+
+    def _audio_payload(self, audio: Any, *, source_hint: str) -> dict[str, Any]:
+        from sglang_omni.utils.audio_payload import audio_waveform_payload
+
+        return audio_waveform_payload(
+            audio,
+            sample_rate=self._sample_rate,
+            modality="audio",
+            source_hint=source_hint,
+        )
+
+    @staticmethod
+    def _build_usage(state: CsmTtsState) -> dict[str, Any] | None:
+        """Usage dict for the terminal result (prompt_tokens,
+        completion_frames, engine_time_s)."""
+        if not (state.prompt_tokens or state.completion_frames or state.engine_time_s):
+            return None
+        usage: dict[str, Any] = {
+            "prompt_tokens": state.prompt_tokens,
+            "completion_tokens": state.completion_frames,  # 1 frame = 1 token
+            "completion_frames": state.completion_frames,
+            "total_tokens": state.prompt_tokens + state.completion_frames,
+        }
+        if state.engine_time_s:
+            usage["engine_time_s"] = round(state.engine_time_s, 6)
+        return usage

--- a/sglang_omni/models/csm_tts/weight_loader.py
+++ b/sglang_omni/models/csm_tts/weight_loader.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# Remaps the HuggingFace Transformers CSM checkpoint export (transformers/models/csm,
+# Apache-2.0) onto the SGLang-integrated module names.
+"""Checkpoint weight-name remapping for CSM-1B.
+
+The ship artifact is the HF-transformers export: shards
+``transformers-00001-of-00002.safetensors`` / ``transformers-00002-of-00002
+.safetensors`` indexed by ``transformers.safetensors.index.json`` — 538
+tensors, ALL fp32 (cast to backbone bf16 on copy). NEVER read the orig-format
+``ckpt.pt`` / ``model.safetensors`` in the same repo: their Q/K are
+un-permuted-RoPE.
+
+Remap table:
+
+==============================================================  =====================================
+checkpoint name                                                 destination
+==============================================================  =====================================
+``embed_text_tokens.weight``                                    ``backbone.model.embed_tokens.weight``
+``backbone_model.embed_tokens.embed_audio_tokens.weight``       ``frame_embedding.weight``
+``backbone_model.layers.{i}.*``                                 ``backbone.model.layers.{i}.*``
+``backbone_model.norm.weight``                                  ``backbone.model.norm.weight``
+``lm_head.weight`` (shape ``[2051, 2048]``)                     ``codebook0_head.weight`` (NOT a text head!)
+``depth_decoder.model.inputs_embeds_projector.weight``          ``depth_decoder.inputs_embeds_projector.weight``
+``depth_decoder.model.layers.{0..3}.*``                         ``depth_decoder.layers.{i}.*`` (manual copies)
+``depth_decoder.model.norm.weight``                             depth final norm
+``depth_decoder.codebooks_head.weight``                         ``codebooks_head.weight``
+``depth_decoder.model.embed_tokens.weight``                     SKIP — tied alias of the audio table
+``codec_model.*``                                               SKIP — ``audio_codec.py`` loads that subtree
+==============================================================  =====================================
+
+The depth tied-embed duplicate IS present in the 538-tensor census (verified
+vs ``tf_index.json``) so the skip path ALWAYS fires; the zero-unexpected
+census counts it as deliberately-skipped, not missing. Llama
+qkv/gate_up stacking on the backbone side is handled by
+``LlamaForCausalLM.load_weights``; depth layers use their own dense modules
+(no stacking).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+_BACKBONE_LAYERS_PREFIX = "backbone_model.layers."
+_DEPTH_LAYERS_PREFIX = "depth_decoder.model.layers."
+
+# Exact-name routes (checkpoint name → destination).
+_EXACT_MAP: dict[str, str] = {
+    "embed_text_tokens.weight": "backbone.model.embed_tokens.weight",
+    "backbone_model.embed_tokens.embed_audio_tokens.weight": "frame_embedding.weight",
+    "backbone_model.norm.weight": "backbone.model.norm.weight",
+    # The checkpoint's lm_head IS the codebook-0 head [2051, 2048]; routing it
+    # to a text head would be catastrophic (the synthetic backbone config ties
+    # word embeddings precisely so no text lm_head exists to mis-load).
+    "lm_head.weight": "codebook0_head.weight",
+    "depth_decoder.model.inputs_embeds_projector.weight": (
+        "depth_decoder.inputs_embeds_projector.weight"
+    ),
+    "depth_decoder.model.norm.weight": "depth_decoder.norm.weight",
+    "depth_decoder.codebooks_head.weight": "codebooks_head.weight",
+}
+
+# Deliberate skips (checkpoint name/prefix → reason).
+_SKIP_EXACT: dict[str, str] = {
+    # Tied alias of frame_embedding.weight; present in the 538-tensor census,
+    # so this skip ALWAYS fires for the ship artifact.
+    "depth_decoder.model.embed_tokens.weight": "tied alias of the audio table",
+}
+_SKIP_PREFIXES: dict[str, str] = {
+    "codec_model.": "Mimi subtree; audio_codec.py loads it itself",
+}
+
+
+@dataclass(frozen=True)
+class CsmWeightMapper:
+    """Weight-name remapper for the CSM HF-transformers shards.
+
+    ``map`` routes each checkpoint tensor name to (dest_name | None-to-skip);
+    the model's ``load_weights`` splits the stream into backbone-vs-own params
+    and casts everything to ``backbone_dtype`` on copy.
+    """
+
+    backbone_dtype: torch.dtype = torch.bfloat16
+
+    def _route(self, name: str) -> tuple[str, str | None]:
+        """``("mapped", dest) | ("skipped", None) | ("unexpected", None)``."""
+        dest = _EXACT_MAP.get(name)
+        if dest is not None:
+            return "mapped", dest
+        if name.startswith(_BACKBONE_LAYERS_PREFIX):
+            return (
+                "mapped",
+                "backbone.model.layers." + name[len(_BACKBONE_LAYERS_PREFIX) :],
+            )
+        if name.startswith(_DEPTH_LAYERS_PREFIX):
+            return "mapped", "depth_decoder.layers." + name[len(_DEPTH_LAYERS_PREFIX) :]
+        if name in _SKIP_EXACT:
+            return "skipped", None
+        for prefix in _SKIP_PREFIXES:
+            if name.startswith(prefix):
+                return "skipped", None
+        return "unexpected", None
+
+    def map(self, name: str) -> str | None:
+        """Map a checkpoint tensor name to its destination name.
+
+        Args:
+            name: checkpoint key (e.g. ``"backbone_model.layers.3.self_attn.q_proj.weight"``).
+
+        Returns:
+            Destination parameter name, or ``None`` to deliberately skip
+            (``depth_decoder.model.embed_tokens.weight`` tied alias and the
+            whole ``codec_model.*`` subtree).
+
+        Raises:
+            ValueError: on any tensor name outside the known census — strict
+                accounting; never silently drop or misroute.
+        """
+        kind, dest = self._route(name)
+        if kind == "unexpected":
+            raise ValueError(
+                f"Unexpected checkpoint tensor {name!r}: not in the CSM remap "
+                f"table and not a deliberate skip"
+            )
+        return dest
+
+    def census(self, names: list[str]) -> dict[str, int]:
+        """Tensor census over all checkpoint keys.
+
+        Returns:
+            ``{"mapped": int, "skipped": int, "unexpected": int}`` — must be a
+            538/0-unexpected split for the ship artifact.
+        """
+        counts = {"mapped": 0, "skipped": 0, "unexpected": 0}
+        for name in names:
+            counts[self._route(name)[0]] += 1
+        return counts
+
+
+__all__ = ["CsmWeightMapper"]

--- a/tests/unit_test/csm_tts/__init__.py
+++ b/tests/unit_test/csm_tts/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/unit_test/csm_tts/conftest.py
+++ b/tests/unit_test/csm_tts/conftest.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU test harness for csm_tts (CPU-only sglang stub).
+
+When ``sglang`` is not installed (the CPU dev box), install a MINIMAL stub of
+the four upstream symbols the csm_tts engine-side modules import at module
+level, so ``request_builders`` / ``model_runner`` stay importable and their
+pure-logic seams (clamp math, fingerprinting, finish marking, embed overlay)
+are testable without a GPU. With real sglang present (container CI) the stub
+is never installed and the real classes are exercised.
+
+Stubbed contracts (kept 1:1 with the upstream call shapes used by csm_tts):
+
+- ``sglang.srt.managers.schedule_batch.Req`` — kwargs ctor, ``rid`` /
+  ``origin_input_ids`` / ``sampling_params`` / ``extra_key``; ``finished()``
+  derives from ``finished_reason``; ``is_chunked = 0``.
+- ``sglang.srt.managers.schedule_batch.FINISH_MATCHED_TOKEN`` — ``matched``.
+- ``sglang.srt.sampling.sampling_params.SamplingParams`` — kwargs incl.
+  ``sampling_seed``; ``normalize(tokenizer)`` sets ``stop_strs``.
+- ``sglang.srt.layers.logits_processor.LogitsProcessorOutput``.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+from typing import Any
+
+
+def _install_sglang_stub() -> None:
+    try:
+        import sglang.srt.managers.schedule_batch  # noqa: F401
+
+        return  # real sglang available — never stub
+    except ImportError:
+        pass
+
+    class FINISH_MATCHED_TOKEN:  # noqa: N801 — upstream name
+        def __init__(self, matched: Any) -> None:
+            self.matched = matched
+
+    class Req:
+        def __init__(
+            self,
+            rid: str = "",
+            origin_input_text: str = "",
+            origin_input_ids: list[int] | None = None,
+            sampling_params: Any = None,
+            vocab_size: int | None = None,
+            extra_key: str | None = None,
+            **kwargs: Any,
+        ) -> None:
+            self.rid = rid
+            self.origin_input_text = origin_input_text
+            self.origin_input_ids = list(origin_input_ids or [])
+            self.sampling_params = sampling_params
+            self.vocab_size = vocab_size
+            self.extra_key = extra_key
+            self.output_ids: list[int] = []
+            self.finished_reason: Any = None
+            self.is_chunked = 0
+
+        def finished(self) -> bool:
+            return self.finished_reason is not None
+
+    class SamplingParams:
+        def __init__(
+            self,
+            max_new_tokens: int = 128,
+            temperature: float = 1.0,
+            top_p: float = 1.0,
+            top_k: int = -1,
+            sampling_seed: int | None = None,
+            **kwargs: Any,
+        ) -> None:
+            self.max_new_tokens = max_new_tokens
+            self.temperature = temperature
+            self.top_p = top_p
+            self.top_k = top_k
+            self.sampling_seed = sampling_seed
+            self.stop_strs: Any = None
+            self.stop_regex_strs: Any = None
+
+        def normalize(self, tokenizer: Any) -> None:
+            del tokenizer
+            self.stop_strs = []
+            self.stop_regex_strs = []
+
+    class LogitsProcessorOutput:
+        def __init__(self, next_token_logits: Any = None, **kwargs: Any) -> None:
+            self.next_token_logits = next_token_logits
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    def _module(name: str, **attrs: Any) -> types.ModuleType:
+        mod = types.ModuleType(name)
+        mod.__path__ = []  # mark as package for submodule imports
+        for key, value in attrs.items():
+            setattr(mod, key, value)
+        sys.modules[name] = mod
+        return mod
+
+    class _Placeholder:
+        """Inert stand-in for upstream classes that csm_tts only references
+        through the sglang_backend package import chain (never constructed in
+        these CPU tests)."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+    _module("sglang")
+    _module("sglang.srt")
+
+    class _Env:
+        """Any ``envs.NAME.get()`` returns a falsy default."""
+
+        def __getattr__(self, name: str) -> Any:
+            return SimpleNamespace(get=lambda: False)
+
+    _module("sglang.srt.environ", envs=_Env())
+    _module("sglang.srt.managers")
+    _module(
+        "sglang.srt.managers.schedule_batch",
+        Req=Req,
+        ScheduleBatch=_Placeholder,
+        FINISH_MATCHED_TOKEN=FINISH_MATCHED_TOKEN,
+    )
+    _module("sglang.srt.managers.schedule_policy", PrefillAdder=_Placeholder)
+    _module("sglang.srt.mem_cache")
+    _module("sglang.srt.mem_cache.cache_init_params", CacheInitParams=_Placeholder)
+    _module("sglang.srt.mem_cache.radix_cache", RadixCache=_Placeholder)
+    _module("sglang.srt.server_args", ServerArgs=_Placeholder)
+    _module("sglang.srt.speculative")
+    _module(
+        "sglang.srt.speculative.spec_info",
+        SpeculativeAlgorithm=SimpleNamespace(NONE=None),
+    )
+    _module("sglang.srt.models")
+    _module("sglang.srt.models.llama", LlamaForCausalLM=_Placeholder)
+    _module(
+        "sglang.srt.utils",
+        add_prefix=lambda name, prefix: f"{prefix}.{name}" if prefix else name,
+    )
+    _module("sglang.srt.sampling")
+    _module("sglang.srt.sampling.sampling_params", SamplingParams=SamplingParams)
+    _module("sglang.srt.layers")
+    _module(
+        "sglang.srt.layers.logits_processor",
+        LogitsProcessorOutput=LogitsProcessorOutput,
+    )
+
+
+_install_sglang_stub()

--- a/tests/unit_test/csm_tts/test_async_decode_runner.py
+++ b/tests/unit_test/csm_tts/test_async_decode_runner.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Parity tests for CsmTTSModelRunner's async-decode (one-step lookahead) path.
+
+The async path splits the synchronous collect into two halves:
+
+  - ``post_decode_launch``  : GPU pack + non-blocking D2H into a pinned host
+                              buffer, plus a no-host-sync publish of
+                              ``result.next_token_ids`` from on-GPU codes.
+  - ``post_decode_resolve`` : host-side collect over the already-copied snapshot.
+
+Both halves must be semantically identical to the synchronous
+``_collect_step_outputs_cg``: for an identical initial CG-buffer state, they must
+produce the same ``data.output_frames`` / ``data.generation_done`` /
+``req.finished_reason`` / ``result.next_token_ids``.
+
+Async decode is dormant by default (``async_decode_min_batch_size=2``); these
+tests pin the parity contract so a future default-flip cannot silently change
+behavior. CPU-only: ``_next_host_staging`` allocates a ``pin_memory=True`` buffer
+(needs a CUDA context), so it is monkeypatched to a plain CPU buffer; a separate
+CUDA-guarded test exercises the real pinned path."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.models.csm_tts.model_runner import CsmTTSModelRunner
+from sglang_omni.models.csm_tts.utils import CODEBOOK_EOS, NUM_CODEBOOKS
+
+
+def _row(cb0: int) -> list[int]:
+    """A full 32-codebook frame with codebook-0 = ``cb0`` (rest = 1)."""
+    return [cb0] + [1] * (NUM_CODEBOOKS - 1)
+
+
+def _build_runner(
+    *,
+    codes_BN,
+    was_done,
+    active_generation_done,
+    is_chunked,
+    finished,
+    async_enabled=False,
+    device="cpu",
+):
+    """Fresh CsmTTSModelRunner over a SimpleNamespace model, mirroring the CG
+    fixtures. Each call returns an independent fixture: ``_decode_pack_gpu``
+    scatters shadow state back into the sampler pool, so sync-vs-async parity
+    must compare two independently seeded fixtures, never one model run twice."""
+    n = len(codes_BN)
+    runner = object.__new__(CsmTTSModelRunner)
+    runner._outbox = None
+    runner._vocoder_target = "vocoder"
+    runner._async_enabled = async_enabled
+    runner._staging_slot = 0
+    runner._host_staging_buffers = []
+    runner._async_query_hit = 0
+    runner._async_query_miss = 0
+    runner.model = SimpleNamespace(
+        _cg_row_indices=torch.arange(n, device=device),
+        _cg_active_generation_done=torch.tensor(active_generation_done, device=device),
+        _cg_active_last_codes=torch.zeros(
+            (n, NUM_CODEBOOKS), dtype=torch.long, device=device
+        ),
+        _cg_was_done=torch.tensor(was_done, device=device),
+        _cg_codes_BN=torch.tensor(codes_BN, dtype=torch.long, device=device),
+        _cg_collect_staging=torch.zeros(
+            (n, NUM_CODEBOOKS + 2), dtype=torch.long, device=device
+        ),
+        _sampler_pool=SimpleNamespace(
+            generation_done=torch.zeros(n, dtype=torch.bool, device=device),
+            last_codes=torch.zeros((n, NUM_CODEBOOKS), dtype=torch.long, device=device),
+            frames_emitted=torch.zeros(n, dtype=torch.int32, device=device),
+        ),
+    )
+    reqs = [
+        SimpleNamespace(
+            is_chunked=is_chunked[i], finished_reason=None, finished=finished[i]
+        )
+        for i in range(n)
+    ]
+    datas = [
+        SimpleNamespace(
+            req=reqs[i], output_frames=[], generation_done=False, stream_metadata=None
+        )
+        for i in range(n)
+    ]
+    sched = [SimpleNamespace(request_id=f"req{i}", data=datas[i]) for i in range(n)]
+    result = SimpleNamespace(
+        logits_output=SimpleNamespace(
+            next_token_logits=torch.zeros(n, 4, device=device)
+        )
+    )
+    forward_batch = SimpleNamespace(batch_size=n)
+    return runner, sched, result, forward_batch, reqs, datas
+
+
+def _snapshot(reqs, datas, result):
+    return {
+        "output_frames": [[c.tolist() for c in d.output_frames] for d in datas],
+        "generation_done": [d.generation_done for d in datas],
+        "finished_reason": [
+            None if r.finished_reason is None else r.finished_reason.matched
+            for r in reqs
+        ],
+        "next_token_ids": result.next_token_ids.tolist(),
+    }
+
+
+# 4-row mixed batch: row0 chunked, row1 was-done (skip), row2 active (not done),
+# row3 active newly-done (EOS this frame).
+_MIXED = dict(
+    codes_BN=[_row(1), _row(7), _row(20), _row(5)],
+    was_done=[False, True, False, False],
+    active_generation_done=[False, True, False, True],
+    is_chunked=[1, 0, 0, 0],
+    finished=[lambda: False] * 4,
+)
+
+
+def _patch_cpu_host_staging(monkeypatch):
+    monkeypatch.setattr(
+        CsmTTSModelRunner,
+        "_next_host_staging",
+        lambda self, dev_staging: torch.empty(
+            dev_staging.shape, dtype=dev_staging.dtype, device="cpu"
+        ),
+    )
+
+
+def _run_sync(**kw):
+    runner, sched, result, fb, reqs, datas = _build_runner(async_enabled=False, **kw)
+    runner._collect_step_outputs_cg(result, fb, sched)
+    return _snapshot(reqs, datas, result)
+
+
+def _run_async(monkeypatch, **kw):
+    runner, sched, result, fb, reqs, datas = _build_runner(async_enabled=True, **kw)
+    _patch_cpu_host_staging(monkeypatch)
+    host_buf = runner.post_decode_launch(result, fb, sched)
+    runner.post_decode_resolve(host_buf, result, fb, None, sched)
+    return _snapshot(reqs, datas, result)
+
+
+def test_async_matches_sync_mixed_batch(monkeypatch):
+    """Core parity: async (launch + resolve) == sync collect on a mixed batch."""
+    sync = _run_sync(**_MIXED)
+    asy = _run_async(monkeypatch, **_MIXED)
+    # Regression anchor on the sync path, independent of async.
+    assert sync["output_frames"] == [[], [], [_row(20)], [_row(5)]]
+    assert sync["generation_done"] == [False, False, False, True]
+    assert sync["finished_reason"] == [None, None, None, CODEBOOK_EOS]
+    assert sync["next_token_ids"] == [0, 0, 20, 5]
+    # Async must be byte-for-byte identical on all four outputs.
+    assert asy == sync
+
+
+def test_async_next_token_ids_published_at_launch(monkeypatch):
+    """post_decode_launch publishes next_token_ids from on-GPU codebook-0
+    (``_cg_codes_BN[:, 0].clamp_min(0)``) before resolve; clamp keeps a
+    STOP_CODE (-1) row in embed range."""
+    kw = dict(
+        codes_BN=[_row(5), [-1] * NUM_CODEBOOKS],
+        was_done=[False, True],
+        active_generation_done=[False, True],
+        is_chunked=[0, 0],
+        finished=[lambda: False, lambda: False],
+    )
+    runner, sched, result, fb, reqs, datas = _build_runner(async_enabled=True, **kw)
+    _patch_cpu_host_staging(monkeypatch)
+    runner.post_decode_launch(result, fb, sched)
+    assert result.next_token_ids.tolist() == [5, 0]
+    assert result.next_token_ids.dtype == torch.long
+
+
+def test_async_matches_sync_bs1_active(monkeypatch):
+    """Parity at bs=1 (the size the scheduler routes to the SYNC fast path);
+    the collect must still agree so a future default-flip is safe."""
+    kw = dict(
+        codes_BN=[_row(9)],
+        was_done=[False],
+        active_generation_done=[False],
+        is_chunked=[0],
+        finished=[lambda: False],
+    )
+    sync = _run_sync(**kw)
+    asy = _run_async(monkeypatch, **kw)
+    assert sync["output_frames"] == [[_row(9)]]
+    assert sync["next_token_ids"] == [9]
+    assert asy == sync
+
+
+def test_async_matches_sync_bs1_eos(monkeypatch):
+    """bs=1 finishing via EOS: generation_done + finish reason propagate
+    identically through the async path."""
+    kw = dict(
+        codes_BN=[_row(0)],
+        was_done=[False],
+        active_generation_done=[True],
+        is_chunked=[0],
+        finished=[lambda: False],
+    )
+    sync = _run_sync(**kw)
+    asy = _run_async(monkeypatch, **kw)
+    assert sync["generation_done"] == [True]
+    assert sync["finished_reason"] == [CODEBOOK_EOS]
+    assert asy == sync
+
+
+def _free_cuda_device(min_free_mib: int = 512):
+    if not torch.cuda.is_available():
+        return None
+    for i in range(torch.cuda.device_count()):
+        try:
+            free, _ = torch.cuda.mem_get_info(i)
+        except Exception:
+            continue
+        if free // (1024 * 1024) >= min_free_mib:
+            return f"cuda:{i}"
+    return None
+
+
+def test_async_real_pinned_path_matches_sync():
+    """CUDA-guarded: run the async path through the REAL pinned ``_next_host_staging``
+    (non-blocking D2H on a CUDA model) and confirm it still equals sync. Proves
+    the CPU monkeypatch above does not mask a pinned-path bug."""
+    dev = _free_cuda_device()
+    if dev is None:
+        pytest.skip("no CUDA device with free memory for the pinned D2H test")
+    torch.cuda.set_device(dev)
+    sync = _run_sync(device=dev, **_MIXED)
+
+    runner, sched, result, fb, reqs, datas = _build_runner(
+        async_enabled=True, device=dev, **_MIXED
+    )
+    host_buf = runner.post_decode_launch(result, fb, sched)
+    torch.cuda.synchronize()  # stand in for the base runner's recorded event
+    runner.post_decode_resolve(host_buf, result, fb, None, sched)
+    assert _snapshot(reqs, datas, result) == sync

--- a/tests/unit_test/csm_tts/test_modeling.py
+++ b/tests/unit_test/csm_tts/test_modeling.py
@@ -1,0 +1,318 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for csm_tts.modeling (CPU, no GPU, no sglang engine).
+
+ The depth-decoder greedy parity test vs HF pins the
+position/offset/head off-by-ones (the #1 bug class here) and the
+codebooks-head orientation before any GPU work — a hard correctness
+blocker.
+"""
+
+from __future__ import annotations
+
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from sglang_omni.models.csm_tts import modeling
+
+torch.manual_seed(0)
+
+# Real CSM-1B depth rope (config.json depth_decoder_config) — used
+# on BOTH sides of the HF parity test so our llama3-rope port is pinned too.
+_DEPTH_ROPE_SCALING = {
+    "rope_type": "llama3",
+    "factor": 32.0,
+    "low_freq_factor": 0.001953125,
+    "high_freq_factor": 0.0078125,
+    "original_max_position_embeddings": 16,
+}
+
+
+def _tiny_depth_cfg(
+    num_codebooks: int = 8,
+    vocab_size: int = 17,
+    hidden_size: int = 16,
+    backbone_hidden_size: int = 32,
+) -> SimpleNamespace:
+    """Tiny depth config — same field set as hf_config.build_depth_decoder_config."""
+    return SimpleNamespace(
+        hidden_size=hidden_size,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        head_dim=8,
+        num_key_value_heads=1,
+        intermediate_size=hidden_size * 2,
+        max_position_embeddings=33,
+        backbone_hidden_size=backbone_hidden_size,
+        vocab_size=vocab_size,
+        num_codebooks=num_codebooks,
+        rms_norm_eps=1e-5,
+        hidden_act="silu",
+        attention_bias=False,
+        mlp_bias=False,
+        rope_theta=500000.0,
+        rope_scaling=dict(_DEPTH_ROPE_SCALING),
+    )
+
+
+def _randomize(module: torch.nn.Module, std: float = 0.05) -> None:
+    with torch.no_grad():
+        for p in module.parameters():
+            p.normal_(0, std)
+
+
+def test_frame_embedding_matches_hand_rolled_reference() -> None:
+    """``CsmFrameEmbedding.forward(codes_B32)`` equals the hand-rolled
+    ``Σ_k embed[c_k + k*2051]`` over the one fused table (random weights,
+    fp32, exact)."""
+    fe = modeling.CsmFrameEmbedding(
+        num_codebooks=32, codebook_vocab=2051, hidden_size=64
+    )
+    _randomize(fe, std=0.02)
+    codes = torch.randint(0, 2051, (3, 32))
+    with torch.no_grad():
+        got = fe(codes)
+        ref = torch.stack(
+            [
+                sum(fe.weight[codes[b, k] + k * 2051] for k in range(32))
+                for b in range(3)
+            ]
+        )
+    assert got.shape == (3, 64)
+    assert torch.allclose(got, ref, atol=1e-5)
+
+
+def test_embed_codebook_offset_correctness() -> None:
+    """``embed_codebook(codes_B, k)`` reads rows at exactly ``codes + k*2051``
+    for every k in 0..31."""
+    fe = modeling.CsmFrameEmbedding(
+        num_codebooks=32, codebook_vocab=2051, hidden_size=8
+    )
+    _randomize(fe, std=0.02)
+    codes = torch.randint(0, 2051, (4,))
+    with torch.no_grad():
+        for k in range(32):
+            got = fe.embed_codebook(codes, k)
+            assert torch.equal(
+                got, fe.weight[codes + k * 2051]
+            ), f"offset wrong at k={k}"
+
+
+def test_codebooks_head_index_mapping_and_orientation() -> None:
+    """``CsmCodebooksHead`` head *k* predicts codebook *k+1*: ``forward(h, k)``
+    equals ``h @ weight[k]`` ≡ ``F.linear(h, weight[k].T)`` with the weight
+    kept in CHECKPOINT layout ``[31, hidden, vocab]`` (orientation trap,
+    review)."""
+    head = modeling.CsmCodebooksHead(num_heads=31, hidden_size=16, codebook_vocab=23)
+    _randomize(head, std=0.02)
+    assert head.weight.shape == (31, 16, 23)  # checkpoint layout, NOT transposed
+    h = torch.randn(5, 16)
+    with torch.no_grad():
+        for step in (0, 13, 30):
+            got = head(h, step)
+            assert got.shape == (5, 23)
+            assert torch.allclose(got, h @ head.weight[step], atol=1e-6)
+            assert torch.allclose(got, F.linear(h, head.weight[step].T), atol=1e-6)
+
+
+def test_generate_frame_shapes_with_random_weights() -> None:
+    """``generate_frame`` at random weights, greedy: shape ``[B, 32]`` int64,
+    values in ``[0, vocab)``, cb0 passes through unchanged, pool-sized param
+    buffers are sliced ``[:bs]``; poisoned depth KV cannot leak into a frame
+    (per-frame reset is structurally free)."""
+    cfg = _tiny_depth_cfg(num_codebooks=32, vocab_size=51)
+    fe = modeling.CsmFrameEmbedding(
+        cfg.num_codebooks, cfg.vocab_size, cfg.backbone_hidden_size
+    )
+    dd = modeling.CsmDepthDecoder(cfg, fe, max_slots=4)
+    _randomize(dd)
+    bs = 2
+    h = torch.randn(bs, cfg.backbone_hidden_size)
+    cb0 = torch.randint(0, cfg.vocab_size, (bs,))
+    temps = torch.zeros(4)  # pool-sized on purpose; greedy
+    topks = torch.full((4,), cfg.vocab_size, dtype=torch.long)
+    with torch.no_grad():
+        frame = dd.generate_frame(h, cb0, temps, topks, bs=bs)
+    assert frame.shape == (bs, 32)
+    assert frame.dtype == torch.int64
+    assert (frame >= 0).all() and (frame < cfg.vocab_size).all()
+    assert torch.equal(frame[:, 0], cb0)
+
+    with torch.no_grad():
+        dd.k_cache.copy_(torch.randn_like(dd.k_cache) * 50)
+        dd.v_cache.copy_(torch.randn_like(dd.v_cache) * 50)
+        frame2 = dd.generate_frame(h, cb0, temps, topks, bs=bs)
+    assert torch.equal(frame2, frame)
+
+
+def _dense_layer_reference(layer, x, rope_cos, rope_sin):
+    """Independent full-sequence reimplementation (no cache, naive attention)."""
+    attn = layer.self_attn
+    B, T, _ = x.shape
+    h = layer.input_layernorm(x)
+    q = attn.q_proj(h).view(B, T, attn.num_heads, attn.head_dim).transpose(1, 2)
+    k = attn.k_proj(h).view(B, T, attn.num_kv_heads, attn.head_dim).transpose(1, 2)
+    v = attn.v_proj(h).view(B, T, attn.num_kv_heads, attn.head_dim).transpose(1, 2)
+    cos, sin = rope_cos[:T], rope_sin[:T]
+    rot = modeling._rotate_half
+    q = q * cos + rot(q) * sin
+    k = k * cos + rot(k) * sin
+    rep = attn.num_heads // attn.num_kv_heads
+    k = k.repeat_interleave(rep, dim=1)
+    v = v.repeat_interleave(rep, dim=1)
+    scores = (q @ k.transpose(-1, -2)) / math.sqrt(attn.head_dim)
+    scores = scores + torch.full((T, T), float("-inf")).triu(1)
+    o = (scores.softmax(-1) @ v).transpose(1, 2).reshape(B, T, -1)
+    x = x + attn.o_proj(o)
+    return x + layer.mlp(layer.post_attention_layernorm(x))
+
+
+def test_incremental_static_kv_matches_dense_reference() -> None:
+    """The incremental 33-slot static-KV path equals an independent dense
+    full-recompute reference (pins KV indexing, rope positions, causal mask,
+    GQA mapping)."""
+    cfg = _tiny_depth_cfg()
+    fe = modeling.CsmFrameEmbedding(
+        cfg.num_codebooks, cfg.vocab_size, cfg.backbone_hidden_size
+    )
+    dd = modeling.CsmDepthDecoder(cfg, fe, max_slots=3)
+    _randomize(dd)
+    bs = 2
+    h = torch.randn(bs, cfg.backbone_hidden_size)
+    cb0 = torch.randint(0, cfg.vocab_size, (bs,))
+    temps = torch.zeros(3)
+    topks = torch.full((3,), cfg.vocab_size, dtype=torch.long)
+    with torch.no_grad():
+        frame = dd.generate_frame(h, cb0, temps, topks, bs=bs)
+
+        # Dense reference: re-run the whole prefix per step, no KV cache.
+        embeds = [h]
+        codes = [cb0]
+        prev = cb0
+        for p in range(1, cfg.num_codebooks):
+            embeds.append(dd.frame_embedding.embed_codebook(prev, p - 1))
+            x = dd.inputs_embeds_projector(torch.stack(embeds, dim=1))
+            for layer in dd.layers:
+                x = _dense_layer_reference(layer, x, dd.rope_cos, dd.rope_sin)
+            logits = dd.codebooks_head(dd.norm(x[:, -1]), p - 1).float()
+            prev = logits.argmax(-1)
+            codes.append(prev)
+        ref = torch.stack(codes, dim=1)
+    assert torch.equal(frame, ref)
+
+
+def test_depth_decoder_greedy_parity_vs_hf() -> None:
+    """Single-frame greedy parity vs HF ``CsmDepthDecoderForCausalLM`` (tiny
+       config, random weights, temp=0, both fp32, EXACT code match) — pins the
+    head orientation + the position/offset scheme + our llama3-rope port.
+       Hard correctness blocker."""
+    pytest.importorskip(
+        "transformers", reason="needs transformers >= 4.52 (native CSM)"
+    )
+    try:
+        from transformers.models.csm import CsmDepthDecoderConfig
+        from transformers.models.csm.modeling_csm import CsmDepthDecoderForCausalLM
+    except ImportError:
+        pytest.skip("installed transformers lacks the native CSM depth decoder")
+
+    torch.manual_seed(7)
+    cfg = _tiny_depth_cfg()
+    fe = modeling.CsmFrameEmbedding(
+        cfg.num_codebooks, cfg.vocab_size, cfg.backbone_hidden_size
+    )
+    dd = modeling.CsmDepthDecoder(cfg, fe, max_slots=4)
+    with torch.no_grad():
+        fe.weight.normal_(0, 0.05)
+    _randomize(dd)
+
+    hf_cfg = CsmDepthDecoderConfig(
+        num_codebooks=cfg.num_codebooks,
+        vocab_size=cfg.vocab_size,
+        backbone_hidden_size=cfg.backbone_hidden_size,
+        hidden_size=cfg.hidden_size,
+        intermediate_size=cfg.intermediate_size,
+        num_hidden_layers=cfg.num_hidden_layers,
+        num_attention_heads=cfg.num_attention_heads,
+        num_key_value_heads=cfg.num_key_value_heads,
+        head_dim=cfg.head_dim,
+        max_position_embeddings=cfg.max_position_embeddings,
+        rms_norm_eps=cfg.rms_norm_eps,
+        rope_theta=cfg.rope_theta,
+        rope_scaling=dict(cfg.rope_scaling),
+    )
+    hf = CsmDepthDecoderForCausalLM(hf_cfg).eval()
+
+    # Copy OUR random weights into the HF reference.
+    state = {
+        "model.embed_tokens.weight": fe.weight,
+        "model.inputs_embeds_projector.weight": dd.inputs_embeds_projector.weight,
+        "model.norm.weight": dd.norm.weight,
+        "codebooks_head.weight": dd.codebooks_head.weight,
+    }
+    for i, layer in enumerate(dd.layers):
+        pre = f"model.layers.{i}."
+        attn, mlp = layer.self_attn, layer.mlp
+        state[pre + "self_attn.q_proj.weight"] = attn.q_proj.weight
+        state[pre + "self_attn.k_proj.weight"] = attn.k_proj.weight
+        state[pre + "self_attn.v_proj.weight"] = attn.v_proj.weight
+        state[pre + "self_attn.o_proj.weight"] = attn.o_proj.weight
+        state[pre + "mlp.gate_proj.weight"] = mlp.gate_proj.weight
+        state[pre + "mlp.up_proj.weight"] = mlp.up_proj.weight
+        state[pre + "mlp.down_proj.weight"] = mlp.down_proj.weight
+        state[pre + "input_layernorm.weight"] = layer.input_layernorm.weight
+        state[pre + "post_attention_layernorm.weight"] = (
+            layer.post_attention_layernorm.weight
+        )
+    missing, unexpected = hf.load_state_dict(
+        {k: v.detach().clone() for k, v in state.items()}, strict=False
+    )
+    assert not unexpected, f"HF reference got unexpected tensors: {unexpected}"
+    assert all(
+        "rotary" in name or "inv_freq" in name for name in missing
+    ), f"HF reference is missing real weights: {missing}"
+
+    bs = 2
+    h = torch.randn(bs, cfg.backbone_hidden_size)
+    cb0 = torch.tensor([3, 11])
+    temps = torch.zeros(4)
+    topks = torch.full((4,), cfg.vocab_size, dtype=torch.long)
+    with torch.no_grad():
+        ours = dd.generate_frame(h, cb0, temps, topks, bs=bs)
+
+    # HF greedy drive: depth prefill [pos0=h, pos1=cb0] then 1-token steps.
+    # HF embeds position p with codebook-table offset clamp(p-1, 0) and head
+    # W[p-1] (modeling_csm.py CsmDepthDecoderModel.forward + CsmCodebooksHead).
+    # ``cache_position`` must be passed EXPLICITLY: the LM wrapper hands it to
+    # CsmCodebooksHead for head selection, and without it the head silently
+    # falls back to W[0] for every step (as HF's own generate path passes it).
+    with torch.no_grad():
+        ids = torch.stack([torch.zeros_like(cb0), cb0], dim=1)
+        out = hf(
+            input_ids=ids,
+            backbone_last_hidden_state=h,
+            use_cache=True,
+            logits_to_keep=1,
+            cache_position=torch.tensor([0, 1]),
+        )
+        past = out.past_key_values
+        prev = out.logits[:, -1].argmax(-1)
+        codes = [cb0, prev]
+        for p in range(2, cfg.num_codebooks):
+            out = hf(
+                input_ids=prev.unsqueeze(1),
+                past_key_values=past,
+                use_cache=True,
+                logits_to_keep=1,
+                cache_position=torch.tensor([p]),
+            )
+            past = out.past_key_values
+            prev = out.logits[:, -1].argmax(-1)
+            codes.append(prev)
+        ref = torch.stack(codes, dim=1)
+
+    assert torch.equal(
+        ours, ref
+    ), f"greedy depth divergence:\nours={ours.tolist()}\nhf  ={ref.tolist()}"

--- a/tests/unit_test/csm_tts/test_pipeline.py
+++ b/tests/unit_test/csm_tts/test_pipeline.py
@@ -1,0 +1,429 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pipeline-level unit tests for csm_tts (CPU, no GPU, no sglang engine —
+CPU-only sglang stub; the fixtures double as upstream API-drift
+tripwires perR5).
+
+
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from sglang_omni.models.csm_tts.audio_codec import (
+    CsmMimiCodec,
+    sanitize_for_mimi,
+    trim_at_first_all_zero_frame,
+)
+from sglang_omni.models.csm_tts.config import CsmTtsPipelineConfig
+from sglang_omni.models.csm_tts.text_tokenizer import (
+    AUDIO_EOS_TOKEN_ID,
+    AUDIO_TOKEN_ID,
+    BOS,
+    EOT,
+    CsmPromptBuilder,
+)
+from sglang_omni.models.csm_tts.vocoder_scheduler import CsmStreamingVocoderScheduler
+from sglang_omni.pipeline.stage.stream_queue import StreamItem
+
+SPF = CsmMimiCodec.SAMPLES_PER_FRAME  # 1920
+_STREAM_META = {
+    "modality": "audio_codes",
+    "stream": True,
+    "num_codebooks": 32,
+    "codebook_size": 2051,
+}
+
+
+def test_registry_smoke() -> None:
+    """``PIPELINE_CONFIG_REGISTRY.get_config("CsmForConditionalGeneration")``
+    resolves to ``CsmTtsPipelineConfig`` via the pkgutil scan — i.e. the
+    csm_tts ``__init__``/``config`` import chain stays sglang/CUDA-free
+    (contract; a silent registry skip would fail this)."""
+    from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+
+    config_cls = PIPELINE_CONFIG_REGISTRY.get_config("CsmForConditionalGeneration")
+    assert config_cls is CsmTtsPipelineConfig
+
+
+def test_config_topology() -> None:
+    """Stage topology: next= chain preprocessing→audio_encoder→tts_engine→
+    vocoder, ``tts_engine.stream_to=["vocoder"]``, vocoder ``terminal=True``
+    + ``can_accept_stream_before_payload=True``, all ``process="pipeline"``
+    (schema demands exactly one of next/terminal per stage)."""
+    config = CsmTtsPipelineConfig(model_path="fake-model")
+    stages = {stage.name: stage for stage in config.stages}
+
+    assert list(stages) == ["preprocessing", "audio_encoder", "tts_engine", "vocoder"]
+    assert stages["preprocessing"].next == "audio_encoder"
+    assert stages["audio_encoder"].next == "tts_engine"
+    assert stages["tts_engine"].next == "vocoder"
+    assert stages["tts_engine"].stream_to == ["vocoder"]
+    assert stages["vocoder"].terminal is True
+    assert stages["vocoder"].can_accept_stream_before_payload is True
+    assert all(stage.process == "pipeline" for stage in stages.values())
+    assert CsmTtsPipelineConfig.architecture == "CsmForConditionalGeneration"
+
+
+class _CharTokenizer:
+    """1 token per char, ids far outside the special range — structural
+    prompt-layout checks without the checkpoint tokenizer."""
+
+    def encode(self, text: str, add_special_tokens: bool = True) -> list[int]:
+        assert add_special_tokens is False  # hard requirement
+        return [200_000 + ord(c) for c in text]
+
+
+def test_prompt_builder_layout_matches_hub_chat_template() -> None:
+    """Structural layout per context message ``128000 ⊕ tok("[spk]text") ⊕
+    128001 ⊕ 128002×F ⊕ 128003`` and final message without audio framing;
+    spans cover exactly the 128002 runs. (Token-for-token golden fixtures
+    against the real checkpoint tokenizer are part of the container gate —
+    parity_csm_hf.py asserts prompt-token equality vs the HF processor.)"""
+    builder = CsmPromptBuilder.__new__(CsmPromptBuilder)
+    builder._tok = _CharTokenizer()
+
+    ids, spans = builder.build_prompt(
+        text="ok",
+        speaker_id=1,
+        context=[
+            {"speaker_id": 0, "text": "ab"},
+            {"speaker_id": 1, "text": "c"},
+        ],
+        context_frame_counts=[3, 2],
+    )
+    seg0 = builder.tokenize_segment_text(0, "ab")  # literal "[0]ab"
+    seg1 = builder.tokenize_segment_text(1, "c")
+    final = builder.tokenize_segment_text(1, "ok")
+    expected = (
+        [BOS]
+        + seg0
+        + [EOT]
+        + [AUDIO_TOKEN_ID] * 3
+        + [AUDIO_EOS_TOKEN_ID]
+        + [BOS]
+        + seg1
+        + [EOT]
+        + [AUDIO_TOKEN_ID] * 2
+        + [AUDIO_EOS_TOKEN_ID]
+        + [BOS]
+        + final
+        + [EOT]
+    )
+    assert ids == expected
+    assert spans == [
+        (1 + len(seg0) + 1, 3),
+        (len(seg0) + len(seg1) + 8, 2),
+    ]
+    for start, length in spans:
+        assert ids[start : start + length] == [AUDIO_TOKEN_ID] * length
+        assert ids[start + length] == AUDIO_EOS_TOKEN_ID
+
+    ids2, spans2 = builder.build_prompt(text="ok", speaker_id=0)
+    assert ids2 == [BOS] + builder.tokenize_segment_text(0, "ok") + [EOT]
+    assert spans2 == []
+
+    with pytest.raises(ValueError):
+        builder.build_prompt(
+            text="x",
+            speaker_id=0,
+            context=[{"speaker_id": 0, "text": "a"}],
+            context_frame_counts=[0],  # every non-final message carries audio
+        )
+    with pytest.raises(ValueError):
+        builder.build_prompt(
+            text="x",
+            speaker_id=0,
+            context=[{"speaker_id": 0, "text": "a"}],  # missing frame counts
+        )
+
+
+class _MockMimi:
+    """Identity-traceable decoder: a frame with codes[:, 0] == v decodes to
+    1920 samples all equal to float(v) — every emitted sample is traceable to
+    its source frame."""
+
+    SAMPLE_RATE = CsmMimiCodec.SAMPLE_RATE
+    SAMPLES_PER_FRAME = SPF
+
+    def __init__(self) -> None:
+        self.calls: list[torch.Tensor] = []
+
+    def decode(self, codes_F32: torch.Tensor) -> torch.Tensor:
+        assert codes_F32.ndim == 2 and codes_F32.shape[1] == 32
+        assert (
+            int(codes_F32.min()) >= 0 and int(codes_F32.max()) <= 2047
+        ), "OOB code reached Mimi — fence #2 failed"
+        self.calls.append(codes_F32.clone())
+        ids = codes_F32[:, 0].to(torch.float32)
+        return ids.repeat_interleave(SPF).reshape(1, -1)
+
+    def decode_batch(self, items: list[torch.Tensor]) -> list[torch.Tensor]:
+        return [self.decode(item) for item in items]
+
+
+def _row(value: int) -> torch.Tensor:
+    return torch.full((32,), value, dtype=torch.long)
+
+
+def _chunk_samples(message) -> np.ndarray:
+    data = message.data
+    assert data["modality"] == "audio"
+    assert data["sample_rate"] == 24000
+    samples = np.frombuffer(data["audio_waveform"], dtype=np.float32)
+    assert samples.size % SPF == 0, f"chunk not 1920-aligned: {samples.size}"
+    return samples
+
+
+def _run_stream(sched, rid, rows, extra_meta=None) -> list[np.ndarray]:
+    meta = dict(_STREAM_META)
+    if extra_meta:
+        meta.update(extra_meta)
+    chunks: list[np.ndarray] = []
+    for i, row in enumerate(rows):
+        msgs = sched.on_stream_chunk(rid, StreamItem(i, row, "tts_engine", meta))
+        chunks.extend(_chunk_samples(m) for m in msgs)
+    return chunks
+
+
+def _assert_gapless(chunks, ids) -> None:
+    got = np.concatenate(chunks) if chunks else np.zeros(0, dtype=np.float32)
+    want = np.repeat(np.asarray(list(ids), dtype=np.float32), SPF)
+    assert got.size == want.size, f"sample count {got.size} != {want.size}"
+    assert np.array_equal(got, want), "emitted samples not gapless/in-order"
+
+
+def test_vocoder_framing_math_default_strides() -> None:
+    """Delay-free framing at 12.5 Hz: first chunk at stride=13
+    rows emits 13-2(holdback)=11 frames, steady chunks of followup=6, the
+    overlap window is re-decoded then trimmed, final flush is gapless."""
+    mock = _MockMimi()
+    sched = CsmStreamingVocoderScheduler(mock)
+    rid = "req-default"
+    n_rows = 26
+    chunks = _run_stream(sched, rid, [_row(i + 1) for i in range(n_rows)])
+    state = sched._stream_states[rid]
+
+    assert chunks and chunks[0].size == 11 * SPF
+    assert chunks[1].size == 6 * SPF and chunks[2].size == 6 * SPF
+    # 2nd decode window starts at emitted - overlap = 11 - 4 → frame id 8...
+    assert int(mock.calls[1][0, 0]) == 8
+    # ...but the re-decoded overlap is trimmed: chunk 2 starts at id 12.
+    assert chunks[1][0] == 12.0
+
+    final = sched._decode_delta(rid, state, final=True)
+    chunks.extend(_chunk_samples(m) for m in final)
+    assert state.frames_emitted == n_rows
+    _assert_gapless(chunks, range(1, n_rows + 1))
+
+    sched.clear_stream_state(rid)
+    assert rid not in sched._stream_states
+
+
+def test_vocoder_initial_chunk_knob_ttfa_path() -> None:
+    """``initial_codec_chunk_frames=1`` → exactly 1 frame after row 1 (the
+    TTFA knob), then gapless through the final flush."""
+    mock = _MockMimi()
+    sched = CsmStreamingVocoderScheduler(mock)
+    rid = "req-initial"
+    chunks = _run_stream(
+        sched,
+        rid,
+        [_row(i + 1) for i in range(20)],
+        extra_meta={"initial_codec_chunk_frames": 1},
+    )
+    state = sched._stream_states[rid]
+    assert state.initial_codec_chunk_frames == 1
+    assert chunks[0].size == 1 * SPF and chunks[0][0] == 1.0
+    assert int(mock.calls[0].shape[0]) == 1
+
+    final = sched._decode_delta(rid, state, final=True)
+    chunks.extend(_chunk_samples(m) for m in final)
+    _assert_gapless(chunks, range(1, 21))
+
+
+def test_vocoder_trim_and_clamp_fences() -> None:
+    """Fences #2/#3: the final flush trims at the first
+    all-32-zero frame (tail never reaches Mimi); a cb31!=0 EOS frame is KEPT
+    by the trim (HF stop(31)/trim(32) split); OOB codes 2048-2050 are counted
+    then clamped."""
+    # trim helper semantics
+    frames = torch.stack([_row(3), _row(7), _row(0), _row(9)])
+    assert trim_at_first_all_zero_frame(frames).shape[0] == 2
+    eos_cb31 = torch.tensor([[0] * 31 + [5]], dtype=torch.long)
+    assert trim_at_first_all_zero_frame(eos_cb31).shape[0] == 1
+    assert CsmStreamingVocoderScheduler._frames_to_codes([[0] * 32]) is None
+    kept = CsmStreamingVocoderScheduler._frames_to_codes([[0] * 31 + [5]])
+    assert kept is not None and kept.shape[0] == 1
+
+    # sanitize counts then clamps; valid codes untouched
+    bad = torch.tensor([[2048, 2049, 2050, 5, 0] + [1] * 27], dtype=torch.long)
+    clamped, count = sanitize_for_mimi(bad.clone())
+    assert count == 3
+    assert int(clamped.max()) <= 2047 and int(clamped.min()) >= 0
+    assert clamped[0, 3] == 5 and clamped[0, 4] == 0
+
+    # streamed: all-zero frame cuts the final flush; bad row clamp counted
+    mock = _MockMimi()
+    sched = CsmStreamingVocoderScheduler(mock)
+    rid = "req-trim"
+    rows = [_row(i + 1) for i in range(24)] + [_row(0), _row(99)]
+    chunks = _run_stream(sched, rid, rows)
+    state = sched._stream_states[rid]
+    final = sched._decode_delta(rid, state, final=True)
+    chunks.extend(_chunk_samples(m) for m in final)
+    assert state.frames_emitted == 24
+    _assert_gapless(chunks, range(1, 25))
+
+    mock = _MockMimi()
+    sched = CsmStreamingVocoderScheduler(mock)
+    rid = "req-clamp"
+    rows = [_row(i + 1) for i in range(12)]
+    bad_row = _row(7)
+    bad_row[0:3] = torch.tensor([2048, 2049, 2050])
+    rows.append(bad_row)  # 13th row triggers the first decode (bad row held back)
+    _run_stream(sched, rid, rows)
+    state = sched._stream_states[rid]
+    assert state.clamp_count == 0  # held-back row not decoded mid-stream
+    sched._decode_delta(rid, state, final=True)
+    assert state.clamp_count == 3
+    assert sched._clamp_count_total == 3
+
+
+def _overlay_fixture():
+    """Runner + fake model with traceable embeddings for the prefill overlay."""
+    from sglang_omni.models.csm_tts.model_runner import CsmTTSModelRunner
+
+    dim = 4
+
+    def embed_tokens(ids: torch.Tensor) -> torch.Tensor:
+        return ids.to(torch.float32).unsqueeze(-1).repeat(1, dim)
+
+    def frame_embedding(codes: torch.Tensor) -> torch.Tensor:
+        # traceable: negative sum of the frame's codes
+        return -codes.to(torch.float32).sum(dim=-1, keepdim=True).repeat(1, dim)
+
+    fake_model = SimpleNamespace(
+        backbone=SimpleNamespace(model=SimpleNamespace(embed_tokens=embed_tokens)),
+        frame_embedding=frame_embedding,
+    )
+    tp_worker = SimpleNamespace(
+        gpu_id=0, model_runner=SimpleNamespace(model=fake_model)
+    )
+    runner = CsmTTSModelRunner(tp_worker, output_processor=None)
+    return runner, frame_embedding, embed_tokens
+
+
+def test_prefill_overlay_paste_positions() -> None:
+    """Overlay pastes context-frame embeds at real-id 128002 positions, the
+    all-zeros-frame embed at 128003 (HF ``_merge_input_ids_with_input_values``
+    parity), leaves text rows on the backbone embedding, and returns None for
+    batches with no context audio."""
+    runner, frame_embedding, embed_tokens = _overlay_fixture()
+
+    codes = torch.randint(1, 2048, (3, 32), dtype=torch.long)
+    prompt = (
+        [BOS, 200_065, EOT]
+        + [AUDIO_TOKEN_ID] * 3
+        + [AUDIO_EOS_TOKEN_ID]
+        + [BOS, 200_066, EOT]
+    )
+    input_ids = torch.tensor(prompt, dtype=torch.long)
+    data = SimpleNamespace(
+        req=SimpleNamespace(extend_input_len=len(prompt)),
+        context_codes=[codes],
+        num_ctx_codes_consumed=0,
+    )
+    forward_batch = SimpleNamespace(input_ids=input_ids)
+    requests = [SimpleNamespace(request_id="r0", data=data)]
+
+    embeds = runner._build_prefill_input_embeds(forward_batch, requests)
+    assert embeds is not None and embeds.shape == (len(prompt), 4)
+
+    expected_paste = frame_embedding(codes)
+    assert torch.equal(embeds[3:6], expected_paste)  # 128002 run
+    eos_embed = frame_embedding(torch.zeros(1, 32, dtype=torch.long))
+    assert torch.equal(embeds[6], eos_embed[0])  # 128003 → all-zeros frame
+    text_positions = [0, 1, 2, 7, 8, 9]
+    assert torch.equal(embeds[text_positions], embed_tokens(input_ids[text_positions]))
+    assert data.num_ctx_codes_consumed == 3
+
+    # no context audio in the batch → None (backbone embedding is exact)
+    data_no_ctx = SimpleNamespace(
+        req=SimpleNamespace(extend_input_len=3),
+        context_codes=None,
+        num_ctx_codes_consumed=0,
+    )
+    none_embeds = runner._build_prefill_input_embeds(
+        SimpleNamespace(input_ids=torch.tensor([BOS, 200_065, EOT])),
+        [SimpleNamespace(request_id="r1", data=data_no_ctx)],
+    )
+    assert none_embeds is None
+
+
+def test_prefill_overlay_chunked_cursor() -> None:
+    """``num_ctx_codes_consumed`` keeps the paste chunked-prefill-correct:
+    a placeholder run split across two extend chunks consumes the code matrix
+    sequentially; overrunning the codes raises (off-by-one
+    class)."""
+    runner, frame_embedding, _ = _overlay_fixture()
+
+    codes = torch.randint(1, 2048, (5, 32), dtype=torch.long)
+    data = SimpleNamespace(
+        req=SimpleNamespace(extend_input_len=3),
+        context_codes=[codes],
+        num_ctx_codes_consumed=0,
+    )
+
+    # chunk 1: first 3 placeholders
+    chunk1 = torch.tensor([AUDIO_TOKEN_ID] * 3, dtype=torch.long)
+    embeds1 = runner._build_prefill_input_embeds(
+        SimpleNamespace(input_ids=chunk1),
+        [SimpleNamespace(request_id="r0", data=data)],
+    )
+    assert torch.equal(embeds1, frame_embedding(codes[:3]))
+    assert data.num_ctx_codes_consumed == 3
+
+    # chunk 2: remaining 2 placeholders + audio_eos
+    chunk2 = torch.tensor([AUDIO_TOKEN_ID] * 2 + [AUDIO_EOS_TOKEN_ID], dtype=torch.long)
+    embeds2 = runner._build_prefill_input_embeds(
+        SimpleNamespace(input_ids=chunk2),
+        [SimpleNamespace(request_id="r0", data=data)],
+    )
+    assert torch.equal(embeds2[:2], frame_embedding(codes[3:5]))
+    assert data.num_ctx_codes_consumed == 5
+
+    # a further placeholder would overrun the code matrix → loud error
+    data.req.extend_input_len = 1
+    with pytest.raises(ValueError, match="overruns context codes"):
+        runner._build_prefill_input_embeds(
+            SimpleNamespace(input_ids=torch.tensor([AUDIO_TOKEN_ID])),
+            [SimpleNamespace(request_id="r0", data=data)],
+        )
+
+    # placeholders without any context codes → loud error (prompt mismatch)
+    data_missing = SimpleNamespace(
+        req=SimpleNamespace(extend_input_len=1),
+        context_codes=[],
+        num_ctx_codes_consumed=0,
+    )
+    # NB: the batch must contain at least one request WITH context codes for
+    # the overlay to run at all; pair the broken request with a healthy one.
+    healthy = SimpleNamespace(
+        req=SimpleNamespace(extend_input_len=1),
+        context_codes=[codes],
+        num_ctx_codes_consumed=0,
+    )
+    ids = torch.tensor([AUDIO_TOKEN_ID, AUDIO_TOKEN_ID], dtype=torch.long)
+    with pytest.raises(ValueError, match="no context_codes"):
+        runner._build_prefill_input_embeds(
+            SimpleNamespace(input_ids=ids),
+            [
+                SimpleNamespace(request_id="r-h", data=healthy),
+                SimpleNamespace(request_id="r-m", data=data_missing),
+            ],
+        )

--- a/tests/unit_test/csm_tts/test_request_builders.py
+++ b/tests/unit_test/csm_tts/test_request_builders.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for csm_tts.request_builders (CPU; sglang stubbed via conftest
+on machines without it).
+
+
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.models.csm_tts import request_builders
+from sglang_omni.models.csm_tts.payload_types import CsmTtsState
+from sglang_omni.models.csm_tts.utils import BACKBONE_CTX
+from sglang_omni.proto import OmniRequest, StagePayload
+
+
+def _state(prompt_len: int = 8, **kwargs) -> CsmTtsState:
+    return CsmTtsState(text="hi", prompt_ids=list(range(1, prompt_len + 1)), **kwargs)
+
+
+def _payload(
+    state: CsmTtsState, rid: str = "req-1", params: dict | None = None
+) -> StagePayload:
+    return StagePayload(
+        request_id=rid,
+        request=OmniRequest(inputs={}, params=params or {}),
+        data=state.to_dict(),
+    )
+
+
+def test_sampling_params_normalize_called_and_seed_kwarg(monkeypatch) -> None:
+    """``sampling_params.normalize(tokenizer=None)`` is invoked (stop_strs
+    crash upstream otherwise) and the seed rides the ``sampling_seed`` kwarg,
+    NOT ``seed``."""
+    init_kwargs: list[dict] = []
+    normalize_calls: list = []
+    real_cls = request_builders.SamplingParams
+
+    class SpyParams(real_cls):
+        def __init__(self, **kwargs):
+            init_kwargs.append(dict(kwargs))
+            super().__init__(**kwargs)
+
+        def normalize(self, tokenizer):
+            normalize_calls.append(tokenizer)
+            return super().normalize(tokenizer)
+
+    monkeypatch.setattr(request_builders, "SamplingParams", SpyParams)
+    state = _state(seed=42, max_new_tokens=10, temperature=0.7, top_k=50)
+    data = request_builders.build_sglang_csm_request(state, request_id="r1")
+
+    assert normalize_calls == [None]
+    kwargs = init_kwargs[0]
+    assert kwargs["sampling_seed"] == 42
+    assert "seed" not in kwargs
+    assert kwargs["max_new_tokens"] == 10
+    assert kwargs["temperature"] == pytest.approx(0.7)
+    assert kwargs["top_k"] == 50
+
+    assert data.req.rid == "r1"
+    # V1 prefill-manager probe attrs (absence → AttributeError upstream).
+    assert data.req._codec_suppress_tokens is None
+    assert data.req._input_embeds_are_projected is False
+    # Depth set is CSM-private and never rides SamplingParams.
+    assert "depth_temperature" not in kwargs
+    assert data.depth_temperature == pytest.approx(0.9)
+    assert data.depth_top_k == 50
+
+
+def test_empty_prompt_rejected() -> None:
+    with pytest.raises(ValueError, match="prompt_ids"):
+        request_builders.build_sglang_csm_request(
+            CsmTtsState(text="x", prompt_ids=[]), request_id="r0"
+        )
+
+
+def test_max_new_tokens_clamp_vs_ctx_budget() -> None:
+    """Clamp is ``min(cap, BACKBONE_CTX - 1 - len(prompt_ids))`` — against
+    max_req_len = 2047, NOT 2048; zero budget raises an
+    actionable error."""
+    model = SimpleNamespace(reset_request=lambda rid: None)
+
+    # cap binds for short prompts
+    rb_cap, _ = request_builders.make_csm_scheduler_adapters(
+        model, max_new_tokens_cap=125
+    )
+    data = rb_cap(_payload(_state(prompt_len=10, max_new_tokens=4096)))
+    assert data.max_new_tokens == 125
+    assert data.req.sampling_params.max_new_tokens == 125
+
+    # context budget binds near the ceiling: 2047 - len(prompt_ids)
+    rb_unc, _ = request_builders.make_csm_scheduler_adapters(
+        model, max_new_tokens_cap=None
+    )
+    data = rb_unc(_payload(_state(prompt_len=BACKBONE_CTX - 50, max_new_tokens=4096)))
+    assert data.max_new_tokens == 49  # 2047 - 1998, NOT 50
+
+    # a prompt of 2047 tokens leaves no frame budget at all
+    with pytest.raises(ValueError, match="frame budget"):
+        rb_unc(_payload(_state(prompt_len=BACKBONE_CTX - 1)))
+
+
+def test_result_adapter_writes_usage_and_resets() -> None:
+    resets: list[str] = []
+    model = SimpleNamespace(reset_request=resets.append)
+    rb, ra = request_builders.make_csm_scheduler_adapters(model)
+    data = rb(_payload(_state(prompt_len=5, max_new_tokens=10), rid="req-x"))
+    data.output_frames.append(torch.arange(32, dtype=torch.long))
+
+    out = ra(data)
+
+    assert resets == ["req-x"]
+    state = CsmTtsState.from_dict(out.data)
+    assert state.completion_frames == 1
+    assert state.prompt_tokens == 5
+    assert state.output_frames == [list(range(32))]
+    assert state.engine_time_s > 0
+
+
+def test_stream_metadata_only_for_streaming_requests() -> None:
+    state = _state()
+    streaming = _payload(
+        state, params={"stream": True, "initial_codec_chunk_frames": 1}
+    )
+    metadata = request_builders.build_csm_stream_metadata(streaming, None)
+    assert metadata == {
+        "modality": "audio_codes",
+        "stream": True,
+        "num_codebooks": 32,
+        "codebook_size": 2051,
+        "initial_codec_chunk_frames": 1,
+    }
+    assert request_builders.build_csm_stream_metadata(_payload(state), None) is None
+
+
+def test_context_fingerprint_sensitivity() -> None:
+    """Any context code or speaker change → new extra_key; no context →
+    None (shared radix subtree) — the voice cross-contamination guard."""
+    torch.manual_seed(3)
+    codes = torch.randint(0, 2048, (4, 32), dtype=torch.int32)
+
+    def state_for(context_codes, speaker=0):
+        return CsmTtsState(
+            text="x",
+            prompt_ids=[1],
+            context=[{"speaker_id": speaker, "text": "a"}],
+            context_codes=context_codes,
+        )
+
+    base_fp = request_builders._context_fingerprint(state_for([codes]))
+    assert base_fp is not None
+
+    changed = codes.clone()
+    changed[2, 31] += 1  # a single code in a single frame
+    assert request_builders._context_fingerprint(state_for([changed])) != base_fp
+
+    assert (
+        request_builders._context_fingerprint(state_for([codes], speaker=1)) != base_fp
+    )
+
+    # same inputs → same key (radix reuse), no context → None
+    assert request_builders._context_fingerprint(state_for([codes])) == base_fp
+    assert (
+        request_builders._context_fingerprint(CsmTtsState(text="x", prompt_ids=[1]))
+        is None
+    )

--- a/tests/unit_test/csm_tts/test_sampler.py
+++ b/tests/unit_test/csm_tts/test_sampler.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for csm_tts.sampler (CPU, no GPU) plus the
+frame-0-EOS zero-decode lifecycle at the runner level (sglang stubbed
+via conftest on machines without it)."""
+
+from __future__ import annotations
+
+import queue
+from types import SimpleNamespace
+
+import torch
+
+from sglang_omni.models.csm_tts import sampler
+from sglang_omni.models.csm_tts.utils import (
+    CODEBOOK_EOS,
+    K_MAX,
+    NUM_CODEBOOKS,
+    STOP_CODE,
+)
+
+torch.manual_seed(0)
+
+
+def test_step_reference_vs_frame_finalize_direct_parity() -> None:
+    """Per-row ``step_reference`` vs batched ``frame_finalize_direct`` across
+    phases: running / eos_now / done-freeze / mixed batch."""
+    for trial in range(50):
+        bsz = int(torch.randint(1, 9, ()).item())
+        codes = torch.randint(0, 2051, (bsz, 32), dtype=torch.int64)
+        for r in range(bsz):
+            mode = r % 4
+            if mode == 1:
+                codes[r] = 0  # all-32-zero EOS
+            elif mode == 2:
+                codes[r] = 0
+                codes[r, 31] = int(torch.randint(1, 2048, ()).item())  # cb31-only
+        done = torch.rand(bsz) < 0.4
+        b_out, b_new, b_was = sampler.frame_finalize_direct(codes, done)
+        for r in range(bsz):
+            r_out, r_new, r_was = sampler.step_reference(codes[r], bool(done[r]))
+            assert torch.equal(b_out[r], r_out), f"codes trial {trial} row {r}"
+            assert bool(b_new[r]) == r_new, f"new_done trial {trial} row {r}"
+            assert bool(b_was[r]) == r_was, f"was_done trial {trial} row {r}"
+
+
+def test_eos_uses_cb0_to_cb30_only() -> None:
+    """EOS covers codebooks 0..30 only — a frame with cb0..30 == 0 and
+    cb31 != 0 STILL stops (HF-exact stop(31) semantics); any nonzero inside
+    cb0..30 does not."""
+    not_done = torch.zeros(4, dtype=torch.bool)
+    codes = torch.zeros(4, 32, dtype=torch.int64)
+    codes[1, 31] = 7  # EOS despite cb31 != 0
+    codes[2, 5] = 9  # NOT EOS (cb5 nonzero)
+    codes[3] = torch.arange(1, 33)  # NOT EOS
+    out, new_done, was_done = sampler.frame_finalize_direct(codes, not_done)
+    assert new_done.tolist() == [True, True, False, False]
+    assert was_done.tolist() == [False] * 4
+    # Non-frozen rows pass codes through — the EOS frame itself is recorded
+    # (HF ``sequences`` parity; the vocoder never receives it).
+    assert torch.equal(out, codes)
+
+
+def test_stop_sentinel_freeze() -> None:
+    """Done rows emit STOP_CODE=-1 and stay frozen on subsequent frames; the
+    ``was_done`` snapshot survives the caller scattering ``new_done`` back
+    into the same buffer."""
+    done = torch.tensor([True, True, False])
+    codes = torch.randint(1, 2048, (3, 32), dtype=torch.int64)
+    out, new_done, was_done = sampler.frame_finalize_direct(codes, done)
+    assert (out[:2] == STOP_CODE).all()
+    assert torch.equal(out[2], codes[2])
+    assert new_done.tolist() == [True, True, False]
+    assert was_done.tolist() == [True, True, False]
+
+    # all-zero frame finishes the running row; frozen rows stay frozen
+    out, new_done, _ = sampler.frame_finalize_direct(
+        torch.zeros(3, 32, dtype=torch.int64), new_done
+    )
+    assert new_done.tolist() == [True, True, True]
+    assert (out[:2] == STOP_CODE).all() and (out[2] == 0).all()
+
+    # was_done must not alias the live done buffer (model.py scatters into it)
+    buf = torch.tensor([False, True])
+    _, nd, wd = sampler.frame_finalize_direct(
+        torch.zeros(2, 32, dtype=torch.int64), buf
+    )
+    buf.copy_(nd)
+    assert wd.tolist() == [False, True]
+
+
+def test_greedy_short_circuit_determinism() -> None:
+    """temp=0 / top_k=1 rows short-circuit branchlessly to argmax over RAW
+    logits — bitwise deterministic across calls, immune to top_p."""
+    B = 5
+    zeros_t = torch.zeros(B)
+    neutral_k = torch.full((B,), K_MAX, dtype=torch.int64)
+    for step in range(32):  # cb0 + 31 depth steps
+        logits = torch.randn(B, K_MAX, dtype=torch.float32) * 4.0
+        out = sampler.sample_codes_batched(logits, zeros_t, neutral_k)
+        assert torch.equal(out, logits.argmax(dim=-1)), f"step {step}"
+        assert out.dtype == torch.int64
+
+    logits = torch.randn(B, K_MAX)
+    a = sampler.sample_codes_batched(logits, zeros_t, neutral_k)
+    b = sampler.sample_codes_batched(logits, zeros_t, neutral_k)
+    assert torch.equal(a, b)
+
+    # top_k == 1 at temp > 0 also short-circuits to argmax
+    hot_t = torch.full((B,), 0.9)
+    one_k = torch.ones(B, dtype=torch.int64)
+    out = sampler.sample_codes_batched(logits, hot_t, one_k)
+    assert torch.equal(out, logits.argmax(dim=-1))
+
+    # greedy rows unaffected by a tight top_p
+    out = sampler.sample_codes_batched(
+        logits, zeros_t, neutral_k, torch.full((B,), 0.1)
+    )
+    assert torch.equal(out, logits.argmax(dim=-1))
+
+
+def test_fixed_shape_topk_filter_vs_naive() -> None:
+    """Fixed-shape ``topk(K_MAX)`` + per-row k-th-value gather keeps sampled
+    codes inside each row's naive top-k support for mixed per-row k; greedy
+    rows in the same batch still equal argmax."""
+    B = 5
+    logits = torch.randn(B, K_MAX, dtype=torch.float32) * 4.0
+    mix_t = torch.tensor([0.0, 0.9, 0.0, 0.9, 0.9])
+    mix_k = torch.tensor([K_MAX, 50, 1, 50, 7], dtype=torch.int64)
+    for _ in range(20):
+        out = sampler.sample_codes_batched(logits, mix_t, mix_k)
+        assert torch.equal(out[[0, 2]], logits.argmax(dim=-1)[[0, 2]])
+        for r, k in ((1, 50), (3, 50), (4, 7)):
+            scaled = logits[r] / 0.9
+            kth = scaled.topk(k).values[-1]
+            assert scaled[out[r]] >= kth, f"row {r} escaped top-{k} support"
+        assert ((out >= 0) & (out < K_MAX)).all()
+
+
+def test_sampler_state_pool_reset_row_and_staging_width() -> None:
+    """Pool-row state shapes/dtypes + ``reset_row`` + the packed D2H staging
+    width contract."""
+    pool = sampler.CsmBatchedSamplerState(4, device="cpu")
+    assert pool.last_codes.shape == (4, NUM_CODEBOOKS)
+    assert pool.last_codes.dtype == torch.int64
+    assert pool.generation_done.dtype == torch.bool
+    assert pool.frames_emitted.dtype == torch.int32
+    pool.last_codes[1] = 5
+    pool.generation_done[1] = True
+    pool.frames_emitted[1] = 99
+    pool.reset_row(1)
+    assert (pool.last_codes[1] == 0).all()
+    assert not bool(pool.generation_done[1])
+    assert int(pool.frames_emitted[1]) == 0
+    assert sampler.STAGING_WIDTH == NUM_CODEBOOKS + 2 == 34
+
+
+class _FakeReq:
+    def __init__(self) -> None:
+        self.is_chunked = 0
+        self.finished_reason = None
+        self.output_ids: list[int] = []
+
+    def finished(self) -> bool:
+        return self.finished_reason is not None
+
+
+def test_forced_frame0_eos_zero_decode_lifecycle() -> None:
+    """A frame-0 EOS sampled AT PREFILL finishes the
+    request at prefill — the EOS frame is recorded in ``output_frames`` (HF
+    ``sequences`` parity), a finish reason is set (KV release trigger), and
+    NOTHING is emitted to the vocoder. A sibling non-EOS request in the same
+    collect IS streamed (proves the empty outbox is not vacuous)."""
+    from sglang_omni.models.csm_tts.model_runner import CsmTTSModelRunner
+
+    eos_frame = torch.zeros(NUM_CODEBOOKS, dtype=torch.long)
+    eos_frame[31] = 7  # cb31 excluded from the EOS check
+    normal_frame = torch.arange(1, NUM_CODEBOOKS + 1, dtype=torch.long)
+
+    fake_model = SimpleNamespace(
+        _rid_to_row={"r-eos": 0, "r-run": 1},
+        _output_codes={"r-eos": [eos_frame], "r-run": [normal_frame]},
+        _sampler_pool=SimpleNamespace(generation_done=torch.tensor([True, False])),
+    )
+    tp_worker = SimpleNamespace(
+        gpu_id=0, model_runner=SimpleNamespace(model=fake_model)
+    )
+    runner = CsmTTSModelRunner(tp_worker, output_processor=None)
+    outbox: queue.Queue = queue.Queue()
+    runner.set_stream_outbox(outbox)
+
+    metadata = {"modality": "audio_codes", "stream": True}
+    reqs = []
+    datas = []
+    for rid in ("r-eos", "r-run"):
+        req = _FakeReq()
+        data = SimpleNamespace(
+            req=req,
+            output_frames=[],
+            stream_metadata=metadata,
+            generation_done=False,
+        )
+        reqs.append(SimpleNamespace(request_id=rid, data=data))
+        datas.append(data)
+
+    result = SimpleNamespace(
+        logits_output=SimpleNamespace(next_token_logits=torch.zeros(2, 4)),
+        next_token_ids=None,
+    )
+    runner._collect_step_outputs(result, reqs)
+
+    eos_data, run_data = datas
+    # EOS frame recorded but the request finishes at prefill...
+    assert len(eos_data.output_frames) == 1
+    assert torch.equal(eos_data.output_frames[0], eos_frame)
+    assert eos_data.generation_done is True
+    assert eos_data.req.finished_reason is not None
+    assert eos_data.req.finished_reason.matched == CODEBOOK_EOS
+    # ...while the running request keeps going and streams its frame.
+    assert run_data.generation_done is False
+    assert run_data.req.finished_reason is None
+
+    emitted = []
+    while not outbox.empty():
+        emitted.append(outbox.get_nowait())
+    assert [m.request_id for m in emitted] == ["r-run"]  # EOS never streamed
+    assert emitted[0].target == "vocoder"
+    assert torch.equal(emitted[0].data, normal_frame)
+
+    # cb0 published per row (EOS row contributes its cb0 = 0)
+    assert result.next_token_ids.tolist() == [0, 1]
+
+
+def test_top_p_nucleus_keeps_top_token_and_excludes_tail() -> None:
+    """On sampled rows (temperature>0, top_k=K_MAX) the top_p filter keeps the
+    highest-prob token and never samples from the excluded low-prob tail."""
+    torch.manual_seed(1234)
+    V, B = 16, 4
+    temp = torch.ones(B)
+    topk = torch.full((B,), K_MAX, dtype=torch.long)
+    # (a) one dominant token + tiny p -> nucleus collapses to the argmax.
+    logits = torch.full((B, V), -10.0)
+    logits[:, 3] = 10.0
+    top_p = torch.full((B,), 0.5)
+    for _ in range(64):
+        out = sampler.sample_codes_batched(logits, temp, topk, top_p)
+        assert torch.all(out == 3), out.tolist()
+    # (b) flat top-3 (logit 10) over a -10 tail -> samples stay within {0,1,2}.
+    logits = torch.full((B, V), -10.0)
+    logits[:, :3] = 10.0
+    top_p = torch.full((B,), 0.9)
+    seen: set[int] = set()
+    for _ in range(200):
+        out = sampler.sample_codes_batched(logits, temp, topk, top_p)
+        seen.update(out.tolist())
+    assert seen and all(t < 3 for t in seen), f"tail token sampled: {sorted(seen)}"

--- a/tests/unit_test/csm_tts/test_weight_loader.py
+++ b/tests/unit_test/csm_tts/test_weight_loader.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for CsmWeightMapper, the HF-transformers shard name remap.
+
+The mapper guards documented traps: the checkpoint ``lm_head.weight`` is the
+codebook-0 head (NOT a text head); the depth tied-embed duplicate and the whole
+``codec_model.*`` subtree are deliberate skips; any tensor outside the census is
+a hard error. CPU-only (no sglang, no GPU)."""
+
+from __future__ import annotations
+
+import pytest
+
+from sglang_omni.models.csm_tts.weight_loader import CsmWeightMapper
+
+
+def test_exact_map_routes() -> None:
+    m = CsmWeightMapper()
+    assert m.map("embed_text_tokens.weight") == "backbone.model.embed_tokens.weight"
+    assert (
+        m.map("backbone_model.embed_tokens.embed_audio_tokens.weight")
+        == "frame_embedding.weight"
+    )
+    assert m.map("backbone_model.norm.weight") == "backbone.model.norm.weight"
+    # The checkpoint lm_head IS the codebook-0 head, never a text head.
+    assert m.map("lm_head.weight") == "codebook0_head.weight"
+    assert m.map("depth_decoder.codebooks_head.weight") == "codebooks_head.weight"
+    assert m.map("depth_decoder.model.norm.weight") == "depth_decoder.norm.weight"
+    assert (
+        m.map("depth_decoder.model.inputs_embeds_projector.weight")
+        == "depth_decoder.inputs_embeds_projector.weight"
+    )
+
+
+def test_prefix_routes() -> None:
+    m = CsmWeightMapper()
+    assert (
+        m.map("backbone_model.layers.3.self_attn.q_proj.weight")
+        == "backbone.model.layers.3.self_attn.q_proj.weight"
+    )
+    assert (
+        m.map("depth_decoder.model.layers.0.mlp.gate_proj.weight")
+        == "depth_decoder.layers.0.mlp.gate_proj.weight"
+    )
+
+
+def test_deliberate_skips_map_to_none() -> None:
+    m = CsmWeightMapper()
+    # Tied alias of the audio table (present in the 538-tensor census).
+    assert m.map("depth_decoder.model.embed_tokens.weight") is None
+    # The Mimi codec subtree is loaded by audio_codec.py, not here.
+    assert m.map("codec_model.encoder.layers.0.conv.weight") is None
+
+
+def test_unexpected_name_raises() -> None:
+    m = CsmWeightMapper()
+    with pytest.raises(ValueError):
+        m.map("totally.unknown.tensor")
+
+
+def test_census_zero_unexpected() -> None:
+    m = CsmWeightMapper()
+    names = [
+        "embed_text_tokens.weight",
+        "lm_head.weight",
+        "backbone_model.embed_tokens.embed_audio_tokens.weight",
+        "backbone_model.norm.weight",
+        "backbone_model.layers.0.self_attn.q_proj.weight",
+        "depth_decoder.model.inputs_embeds_projector.weight",
+        "depth_decoder.model.norm.weight",
+        "depth_decoder.codebooks_head.weight",
+        "depth_decoder.model.layers.0.mlp.gate_proj.weight",
+        "depth_decoder.model.embed_tokens.weight",  # skip: tied alias
+        "codec_model.encoder.conv.weight",  # skip: codec subtree
+    ]
+    census = m.census(names)
+    assert census["unexpected"] == 0
+    assert census["skipped"] >= 2
+    assert census["mapped"] >= 8
+    assert census["mapped"] + census["skipped"] == len(names)


### PR DESCRIPTION
Closes #799.

## Motivation

Adds end-to-end support for Sesame **CSM-1B** ([sesame/csm-1b](https://huggingface.co/sesame/csm-1b), Apache-2.0): a Llama-3.2-1B backbone that emits one frame per autoregressive step, a 31-step depth decoder over 32 Kyutai Mimi RVQ codebooks, and the Mimi vocoder. It is a popular, natural-sounding 1B conversational model that until now had only the reference repo and single-stream community forks, with no production batching or streaming.

## Design

Standard 3-stage Omni TTS pipeline, following the existing Higgs TTS layout (#428):

`preprocessing → tts_engine (OmniScheduler: paged KV, continuous batching, abort) → vocoder (streaming Mimi)`

- **Model** (`sglang_omni/models/csm_tts/`): the backbone composes SGLang's `LlamaForCausalLM` under paged/varlen attention; the 31-step depth decoder runs inside the scheduler-visible decode step. The codebooks head, frame embedding, sampler, Mimi codec wrapper, and weight remap are framework-free torch ported from HuggingFace Transformers `transformers/models/csm` and `transformers.MimiModel`.
- **Runner / scheduling**: `CsmTTSModelRunner` reuses the `ModelRunner` sync-decode collect and async-decode hooks (`post_decode_launch` / `post_decode_resolve`); the sampler-pool row discipline and CG-buffer population mirror the Higgs runner.
- **State / handoff**: `CsmTtsState` flows preprocessing → engine → vocoder via `StagePayload`.
- **Registration**: one line in `_register_omni_model` (`CsmForConditionalGeneration` → `csm_tts.model:CsmTTSModel`), auto-discovered via `EntryClass` + `architecture`.

The new codec piece is a Kyutai **Mimi** vocoder stage (RVQ at 12.5 Hz, 24 kHz mono), which appears to be the first Mimi backend in the repo and is reusable by other Mimi-based models. It slots into the existing TTS abstraction; it is not a new one.

## Scope

Minimal and additive: 26 files, registry is one line. Optimizations (CUDA-graph capture, depth-loop batching, async decode) are intentionally left as follow-ups to keep this first PR small. Async decode is implemented but off by default.

## Validation (RTX 3060, 12 GB)

- **Lint**: `pre-commit run --all-files` clean (autoflake + isort + black 24.10.0 + file hooks).
- **Unit tests**: 38 passed, 2 skipped (GPU-free). Covers HF-greedy depth bit-parity, the weight-remap census (the `lm_head`-is-codebook0 trap), async-decode sync-vs-async parity, top_p nucleus filtering, the EOS machine, and the out-of-bounds clamp fences.
- **End to end**: boots and serves `/v1/audio/speech` in streaming and non-streaming, single and concurrent (continuous batching confirmed to 8). A capped request returns a full clip (480000 PCM bytes, 125 frames at 24 kHz).

## Run

```bash
sgl-omni serve --model-path sesame/csm-1b --config examples/configs/csm_1b.yaml --port 8000
```

## Notes for reviewers

- `sesame/csm-1b` is gated; accept its license on HF before pulling weights.
- The example config is sized for a 12 GB card (eager, `mem_fraction_static 0.5`); flip the CUDA-graph and async-decode knobs once the optimization follow-ups land.
