### PR TITLE
[CI Perf] Trace stage relay payload IO

### DIFF
--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -174,6 +174,8 @@ class StageConfig(BaseModel):
 
     # --- Relay (auto-inferred from gpu when None) ---
     relay: RelayConfig | None = None
+    trace_stage_io: bool = False
+    trace_stage_io_sync: bool = False
 
     def model_post_init(self, __context: Any = None) -> None:
         fields_set = self.__pydantic_fields_set__

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -115,6 +115,8 @@ def _build_stage_groups(
             is_stream_receiver=stage_cfg.name in stream_receivers,
             can_accept_stream_before_payload=stage_cfg.can_accept_stream_before_payload,
             name_map=name_map,
+            trace_stage_io=stage_cfg.trace_stage_io,
+            trace_stage_io_sync=stage_cfg.trace_stage_io_sync,
         )
         if tp_size == 1:
             single_stage_specs[stage_cfg.name] = _build_single_stage_spec(

--- a/sglang_omni/pipeline/relay_io.py
+++ b/sglang_omni/pipeline/relay_io.py
@@ -13,6 +13,7 @@ import base64
 import io
 import logging
 import pickle
+import time
 from multiprocessing.reduction import ForkingPickler
 from typing import Any
 from uuid import uuid4
@@ -28,6 +29,38 @@ from sglang_omni.proto import DataReadyMessage, StagePayload
 from sglang_omni.relay.base import Relay
 
 logger = logging.getLogger(__name__)
+
+
+def _now_ns() -> int:
+    return time.perf_counter_ns()
+
+
+def _elapsed_ms(start_ns: int) -> float:
+    return round((time.perf_counter_ns() - start_ns) / 1e6, 3)
+
+
+def _maybe_sync_tensor(tensor: torch.Tensor, *, enabled: bool) -> None:
+    if not enabled or not tensor.is_cuda:
+        return
+    torch.cuda.synchronize(tensor.device)
+
+
+def _maybe_sync_device(device: torch.device, *, enabled: bool) -> None:
+    if not enabled or device.type != "cuda":
+        return
+    torch.cuda.synchronize(device)
+
+
+def _tensor_summary(path: str, tensor: torch.Tensor) -> dict[str, Any]:
+    return {
+        "path": path,
+        "shape": [int(dim) for dim in tensor.shape],
+        "dtype": str(tensor.dtype),
+        "device": str(tensor.device),
+        "numel": int(tensor.numel()),
+        "bytes": int(tensor.numel() * tensor.element_size()),
+        "contiguous": bool(tensor.is_contiguous()),
+    }
 
 
 def _dtype_alignment(dtype: torch.dtype) -> int:
@@ -434,11 +467,16 @@ async def write_payload(
     from_stage: str | None = None,
     to_stage: str | None = None,
     tensor_ref_policy: TensorRefPolicy | None = None,
+    trace_context: dict[str, Any] | None = None,
+    trace_sync: bool = False,
 ) -> tuple[dict[str, Any], Any]:
     """Write a StagePayload to relay. Returns (control_plane_metadata, relay_op)."""
     device = getattr(relay, "device", "cpu")
     transport_device = torch.device(device)
+    trace_enabled = trace_context is not None
+    timing: dict[str, float] = {}
 
+    start_ns = _now_ns()
     stats: dict[str, int] | None = None
     if tensor_ref_policy is not None:
         stats = {"ref_count": 0, "ref_bytes": 0, "inline_tensor_bytes": 0}
@@ -453,22 +491,49 @@ async def write_payload(
         )
     else:
         modified_data, tensor_dict = extract_tensors(payload.data)
+    if trace_enabled:
+        timing["extract_ms"] = _elapsed_ms(start_ns)
 
     payload_no_tensors = StagePayload(
         request_id=payload.request_id,
         request=payload.request,
         data=modified_data,
     )
+    start_ns = _now_ns()
     metadata_bytes = pickle.dumps(payload_no_tensors)
+    if trace_enabled:
+        timing["pickle_ms"] = _elapsed_ms(start_ns)
 
     if tensor_dict:
         tensor_buffers = []
         tensor_info = []
+        tensor_summaries = []
+        total_tensor_bytes = 0
         offset = 0
         for path, tensor in tensor_dict.items():
+            if trace_enabled:
+                summary = _tensor_summary(path, tensor)
+                tensor_summaries.append(summary)
+                total_tensor_bytes += int(summary["bytes"])
+                _maybe_sync_tensor(tensor, enabled=trace_sync)
+                start_ns = _now_ns()
             flat = tensor.contiguous().view(torch.uint8).reshape(-1)
+            if trace_enabled:
+                _maybe_sync_tensor(flat, enabled=trace_sync)
+                timing["contiguous_ms"] = timing.get("contiguous_ms", 0.0) + (
+                    (time.perf_counter_ns() - start_ns) / 1e6
+                )
             if flat.device != transport_device:
+                if trace_enabled:
+                    _maybe_sync_tensor(flat, enabled=trace_sync)
+                    start_ns = _now_ns()
                 flat = flat.to(device=transport_device)
+                if trace_enabled:
+                    _maybe_sync_tensor(flat, enabled=trace_sync)
+                    _maybe_sync_device(transport_device, enabled=trace_sync)
+                    timing["device_copy_ms"] = timing.get("device_copy_ms", 0.0) + (
+                        (time.perf_counter_ns() - start_ns) / 1e6
+                    )
             padding = _pad_offset(offset, _dtype_alignment(tensor.dtype))
             if padding:
                 tensor_buffers.append(
@@ -486,12 +551,39 @@ async def write_payload(
                 }
             )
             offset += flat.numel()
+        if trace_enabled:
+            _maybe_sync_device(transport_device, enabled=trace_sync)
+            start_ns = _now_ns()
         all_tensors = torch.cat(tensor_buffers)
+        if trace_enabled:
+            _maybe_sync_tensor(all_tensors, enabled=trace_sync)
+            timing["cat_ms"] = _elapsed_ms(start_ns)
     else:
         all_tensors = torch.zeros(1, dtype=torch.uint8, device=device)
         tensor_info = []
+        tensor_summaries = []
+        total_tensor_bytes = 0
+        if trace_enabled:
+            timing["cat_ms"] = 0.0
 
+    start_ns = _now_ns()
     op = await relay.put_async(all_tensors, request_id=request_id)
+    if trace_enabled:
+        timing["put_async_ms"] = _elapsed_ms(start_ns)
+        for key in ("contiguous_ms", "device_copy_ms"):
+            if key in timing:
+                timing[key] = round(timing[key], 3)
+        trace_context["payload_trace"] = {
+            "direction": "write",
+            "relay_device": str(device),
+            "transport_device": str(transport_device),
+            "tensor_count": len(tensor_summaries),
+            "tensor_bytes": total_tensor_bytes,
+            "tensor_payload_bytes": int(all_tensors.numel()),
+            "payload_pickle_bytes": len(metadata_bytes),
+            "tensors": tensor_summaries,
+            "timing_ms": timing,
+        }
 
     metadata: dict[str, Any] = {
         "relay_info": op.metadata,
@@ -510,25 +602,46 @@ async def read_payload(
     relay: Relay,
     request_id: str,
     metadata: dict[str, Any],
+    *,
+    trace_context: dict[str, Any] | None = None,
+    trace_sync: bool = False,
 ) -> StagePayload:
     """Read a StagePayload from relay using control_plane metadata."""
     device = getattr(relay, "device", "cpu")
+    trace_enabled = trace_context is not None
+    timing: dict[str, float] = {}
 
+    start_ns = _now_ns()
     payload_bytes = base64.b64decode(metadata["payload_pickle"])
     payload_no_tensors = pickle.loads(payload_bytes)
+    if trace_enabled:
+        timing["unpickle_ms"] = _elapsed_ms(start_ns)
 
     relay_info = metadata["relay_info"]
     tensor_info = metadata.get("tensor_info", [])
     tensor_dict = {}
 
     data_size = relay_info["transfer_info"]["size"]
+    start_ns = _now_ns()
     recv_tensor = torch.zeros(data_size, dtype=torch.uint8, device=device)
+    if trace_enabled:
+        timing["alloc_recv_ms"] = _elapsed_ms(start_ns)
+        _maybe_sync_tensor(recv_tensor, enabled=trace_sync)
+        start_ns = _now_ns()
     op = await relay.get_async(
         metadata=relay_info, dest_tensor=recv_tensor, request_id=request_id
     )
+    if trace_enabled:
+        timing["get_async_ms"] = _elapsed_ms(start_ns)
+        start_ns = _now_ns()
     await op.wait_for_completion()
+    if trace_enabled:
+        _maybe_sync_tensor(recv_tensor, enabled=trace_sync)
+        timing["get_wait_ms"] = _elapsed_ms(start_ns)
 
     if tensor_info:
+        if trace_enabled:
+            start_ns = _now_ns()
         for info in tensor_info:
             path = info["path"]
             shape = info["shape"]
@@ -539,8 +652,33 @@ async def read_payload(
             dtype = _dtype_from_str(dtype_str)
             tensor = tensor_bytes.view(dtype).reshape(shape)
             tensor_dict[path] = tensor
+        if trace_enabled:
+            timing["slice_restore_ms"] = _elapsed_ms(start_ns)
 
+    start_ns = _now_ns()
     restored_data = restore_tensors(payload_no_tensors.data, tensor_dict)
+    if trace_enabled:
+        timing["restore_ms"] = _elapsed_ms(start_ns)
+        trace_context["payload_trace"] = {
+            "direction": "read",
+            "relay_device": str(device),
+            "tensor_count": len(tensor_info),
+            "tensor_bytes": int(
+                sum(int(info.get("size", 0)) for info in tensor_info)
+            ),
+            "tensor_payload_bytes": int(data_size),
+            "payload_pickle_bytes": len(payload_bytes),
+            "tensors": [
+                {
+                    "path": info.get("path"),
+                    "shape": info.get("shape"),
+                    "dtype": info.get("dtype"),
+                    "bytes": int(info.get("size", 0)),
+                }
+                for info in tensor_info
+            ],
+            "timing_ms": timing,
+        }
     payload = StagePayload(
         request_id=payload_no_tensors.request_id,
         request=payload_no_tensors.request,

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import logging
 import os
 import queue as _queue_mod
 import threading
+import time
 from contextlib import suppress
 from typing import Any, Callable, Literal
 
@@ -44,9 +46,14 @@ from sglang_omni.relay.base import Relay, create_relay
 from sglang_omni.scheduling.messages import IncomingMessage
 
 logger = logging.getLogger(__name__)
+STAGE_IO_TRACE_EVENT = "stage_io_trace"
 
 GetNextFn = Callable[[str, Any], str | list[str] | None]
 GetStreamDoneTargetsFn = Callable[[str, Any], str | list[str] | None]
+
+
+def _elapsed_ms(start_ns: int) -> float:
+    return round((time.perf_counter_ns() - start_ns) / 1e6, 3)
 
 
 class Stage:
@@ -87,6 +94,8 @@ class Stage:
         can_accept_stream_before_payload: bool = False,
         tp_fanout: TPLeaderFanout | None = None,
         is_terminal: bool = False,
+        trace_stage_io: bool = False,
+        trace_stage_io_sync: bool = False,
     ):
         self.name = name
         self.role = role
@@ -106,6 +115,8 @@ class Stage:
         self._tp_fanout = tp_fanout
         self._is_terminal = is_terminal
         self._owns_external_io = role in {"single", "leader"}
+        self._trace_stage_io = trace_stage_io
+        self._trace_stage_io_sync = trace_stage_io_sync
 
         # --- Relay ---
         if relay is not None:
@@ -302,9 +313,18 @@ class Stage:
             self._stream_queue.open(request_id)
 
         # Read payload from relay
+        trace_context = self._make_stage_io_trace_context(
+            request_id=request_id,
+            from_stage=msg.from_stage,
+            to_stage=self.name,
+        )
         try:
             payload = await relay_io.read_payload(
-                self.relay, request_id, msg.shm_metadata
+                self.relay,
+                request_id,
+                msg.shm_metadata,
+                trace_context=trace_context,
+                trace_sync=self._trace_stage_io_sync,
             )
         except Exception as exc:
             logger.exception(
@@ -314,7 +334,12 @@ class Stage:
             await self._send_failure(request_id, f"relay read failed: {exc}")
             return
 
-        await self._receive_payload_from_stage(request_id, msg.from_stage, payload)
+        await self._receive_payload_from_stage(
+            request_id,
+            msg.from_stage,
+            payload,
+            trace_context=trace_context,
+        )
 
     async def receive_local_payload(
         self,
@@ -368,6 +393,7 @@ class Stage:
         request_id: str,
         from_stage: str,
         payload: Any,
+        trace_context: dict[str, Any] | None = None,
     ) -> None:
         if request_id in self._aborted:
             self._release_payload_tensor_refs(payload)
@@ -387,7 +413,16 @@ class Stage:
             event_name="stage_input_received",
             metadata={"from_stage": from_stage, "kind": "payload"},
         )
+        start_ns = time.perf_counter_ns()
         merged = self.input_handler.receive(request_id, from_stage, payload)
+        if trace_context is not None:
+            self._add_stage_io_timing(
+                trace_context,
+                "input_receive_ms",
+                _elapsed_ms(start_ns),
+            )
+            trace_context["aggregate_ready"] = merged is not None
+            self._emit_stage_io_trace(request_id, trace_context)
         if merged is not None:
             _emit_event(
                 request_id=request_id,
@@ -1006,6 +1041,11 @@ class Stage:
         tensor_ref_policy = TensorRefPolicy.from_env(
             from_stage=self.name, to_stage=target
         )
+        trace_context = self._make_stage_io_trace_context(
+            request_id=request_id,
+            from_stage=self.name,
+            to_stage=target,
+        )
         metadata, op = await relay_io.write_payload(
             self.relay,
             request_id,
@@ -1013,6 +1053,8 @@ class Stage:
             from_stage=self.name,
             to_stage=target,
             tensor_ref_policy=tensor_ref_policy,
+            trace_context=trace_context,
+            trace_sync=self._trace_stage_io_sync,
         )
         msg = DataReadyMessage(
             request_id=request_id,
@@ -1031,11 +1073,80 @@ class Stage:
             metadata=hop_metadata,
         )
         try:
+            start_ns = time.perf_counter_ns()
             await self.control_plane.send_to_stage(target, endpoint, msg)
+            if trace_context is not None:
+                self._add_stage_io_timing(
+                    trace_context,
+                    "control_plane_send_ms",
+                    _elapsed_ms(start_ns),
+                )
+            start_ns = time.perf_counter_ns()
             await op.wait_for_completion()
+            if trace_context is not None:
+                self._add_stage_io_timing(
+                    trace_context,
+                    "relay_op_wait_ms",
+                    _elapsed_ms(start_ns),
+                )
+                self._emit_stage_io_trace(request_id, trace_context)
         except Exception:
             relay_io.release_tensor_ref_blobs_from_metadata(self.relay, metadata)
             raise
+
+    def _make_stage_io_trace_context(
+        self,
+        *,
+        request_id: str,
+        from_stage: str,
+        to_stage: str,
+    ) -> dict[str, Any] | None:
+        if not self._trace_stage_io:
+            return None
+        return {
+            "request_id": request_id,
+            "from_stage": from_stage,
+            "to_stage": to_stage,
+            "edge": f"{from_stage}->{to_stage}",
+            "transport": "relay",
+        }
+
+    @staticmethod
+    def _add_stage_io_timing(
+        trace_context: dict[str, Any],
+        name: str,
+        value_ms: float,
+    ) -> None:
+        payload_trace = trace_context.setdefault("payload_trace", {})
+        timing = payload_trace.setdefault("timing_ms", {})
+        timing[name] = value_ms
+
+    def _emit_stage_io_trace(
+        self,
+        request_id: str,
+        trace_context: dict[str, Any],
+    ) -> None:
+        payload_trace = trace_context.get("payload_trace")
+        if not isinstance(payload_trace, dict):
+            return
+        metadata = {
+            key: value
+            for key, value in trace_context.items()
+            if key not in {"payload_trace", "request_id"}
+        }
+        metadata.update(payload_trace)
+        _emit_event(
+            request_id=request_id,
+            stage=self.name,
+            event_name=STAGE_IO_TRACE_EVENT,
+            metadata=metadata,
+        )
+        log_record = {"request_id": request_id, "stage": self.name, **metadata}
+        logger.info(
+            "%s %s",
+            STAGE_IO_TRACE_EVENT,
+            json.dumps(log_record, sort_keys=True, default=str),
+        )
 
     @staticmethod
     def _is_isolated_projected_payload(

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -70,6 +70,8 @@ class StageLaunchConfig:
 
     # Relay
     relay_config: dict[str, Any] = field(default_factory=dict)
+    trace_stage_io: bool = False
+    trace_stage_io_sync: bool = False
 
     # Endpoints
     recv_endpoint: str = ""
@@ -616,6 +618,8 @@ def _construct_stage(
         can_accept_stream_before_payload=spec.can_accept_stream_before_payload,
         tp_fanout=tp_fanout,
         is_terminal=spec.is_terminal,
+        trace_stage_io=spec.trace_stage_io,
+        trace_stage_io_sync=spec.trace_stage_io_sync,
     )
 
     if spec.is_stream_receiver:

--- a/tests/unit_test/pipeline/test_compile.py
+++ b/tests/unit_test/pipeline/test_compile.py
@@ -99,6 +99,8 @@ def test_runner_specs_wire_routes_overrides_aggregation_and_streams(tmp_path) ->
                 route_fn=fake_factory_path("identity_route"),
                 stream_to=["talker"],
                 stream_done_to_fn=fake_factory_path("identity_stream_targets"),
+                trace_stage_io=True,
+                trace_stage_io_sync=True,
             ),
             stage(
                 "aggregate",
@@ -133,6 +135,8 @@ def test_runner_specs_wire_routes_overrides_aggregation_and_streams(tmp_path) ->
     assert specs["thinker"].stream_done_to_fn == fake_factory_path(
         "identity_stream_targets"
     )
+    assert specs["thinker"].trace_stage_io
+    assert specs["thinker"].trace_stage_io_sync
     assert specs["aggregate"].wait_for == ["preprocess", "thinker"]
     assert specs["aggregate"].wait_for_fn == fake_factory_path("identity_wait_sources")
     assert specs["aggregate"].merge_fn == fake_factory_path("merge_payloads")

--- a/tests/unit_test/pipeline/test_stage.py
+++ b/tests/unit_test/pipeline/test_stage.py
@@ -11,6 +11,7 @@ import torch
 
 from sglang_omni.pipeline import relay_io
 from sglang_omni.pipeline.local_dispatch import LocalStageDispatcher
+from sglang_omni.pipeline.stage import runtime as stage_runtime
 from sglang_omni.pipeline.stage.input import AggregatedInput
 from sglang_omni.pipeline.stage.stream_queue import StreamQueue
 from sglang_omni.pipeline.stage_workers import StageLaunchConfig, _construct_stage
@@ -279,6 +280,146 @@ def test_relay_payload_and_cross_gpu_stream_contracts() -> None:
         assert "hidden" in msg.shm_metadata["chunk_metadata_tensors"]
 
     asyncio.run(_run())
+
+
+def test_stage_io_trace_disabled_by_default(monkeypatch, caplog) -> None:
+    """Stage IO tracing must stay silent unless explicitly enabled."""
+    events: list[dict] = []
+    monkeypatch.setattr(
+        "sglang_omni.pipeline.stage.runtime._emit_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+    caplog.set_level(logging.INFO, logger="sglang_omni.pipeline.stage.runtime")
+
+    async def _run() -> None:
+        relay = FakeRelay()
+        control_plane = RecordingStageControlPlane()
+        sender = make_stage(
+            name="image_encoder",
+            endpoints={"mm_aggregate": "inproc://mm_aggregate"},
+            relay=relay,
+            control_plane=control_plane,
+        )
+        await sender._send_to_stage(
+            "req-trace-off",
+            "mm_aggregate",
+            make_stage_payload(
+                request_id="req-trace-off",
+                data={
+                    "thinker_inputs": {
+                        "model_inputs": {
+                            "video_embeds": torch.ones(2, 3),
+                        }
+                    }
+                },
+            ),
+        )
+
+    asyncio.run(_run())
+
+    assert not any(
+        event["event_name"] == stage_runtime.STAGE_IO_TRACE_EVENT
+        for event in events
+    )
+    assert stage_runtime.STAGE_IO_TRACE_EVENT not in caplog.text
+
+
+def test_stage_io_trace_records_relay_payload_edges(monkeypatch, caplog) -> None:
+    """Trace relay write/read tensor volume and timing for one stage edge."""
+    events: list[dict] = []
+    monkeypatch.setattr(
+        "sglang_omni.pipeline.stage.runtime._emit_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+    caplog.set_level(logging.INFO, logger="sglang_omni.pipeline.stage.runtime")
+
+    async def _run() -> None:
+        relay = FakeRelay()
+        control_plane = RecordingStageControlPlane()
+        sender = make_stage(
+            name="image_encoder",
+            endpoints={"mm_aggregate": "inproc://mm_aggregate"},
+            relay=relay,
+            control_plane=control_plane,
+            trace_stage_io=True,
+        )
+        receiver_scheduler = FakeScheduler()
+        receiver = make_stage(
+            name="mm_aggregate",
+            relay=relay,
+            scheduler=receiver_scheduler,
+            trace_stage_io=True,
+        )
+        payload = make_stage_payload(
+            request_id="req-trace-on",
+            data={
+                "thinker_inputs": {
+                    "model_inputs": {
+                        "video_embeds": torch.ones(2, 3, dtype=torch.bfloat16),
+                        "video_grid_thw": torch.tensor([[1, 2, 3]]),
+                    }
+                }
+            },
+        )
+
+        await sender._send_to_stage("req-trace-on", "mm_aggregate", payload)
+        msg = control_plane.sent_to_stage[0][2]
+        await receiver._on_data_ready(msg)
+
+        queued = receiver_scheduler.inbox.get_nowait()
+        assert queued.type == "new_request"
+
+    asyncio.run(_run())
+
+    trace_events = [
+        event
+        for event in events
+        if event["event_name"] == stage_runtime.STAGE_IO_TRACE_EVENT
+    ]
+    assert len(trace_events) == 2
+
+    write_meta = next(
+        event["metadata"]
+        for event in trace_events
+        if event["metadata"]["direction"] == "write"
+    )
+    assert write_meta["edge"] == "image_encoder->mm_aggregate"
+    assert write_meta["tensor_count"] == 2
+    assert write_meta["tensor_bytes"] == 36
+    assert {
+        tensor["path"] for tensor in write_meta["tensors"]
+    } == {
+        "thinker_inputs.model_inputs.video_embeds",
+        "thinker_inputs.model_inputs.video_grid_thw",
+    }
+    for key in (
+        "extract_ms",
+        "pickle_ms",
+        "cat_ms",
+        "put_async_ms",
+        "control_plane_send_ms",
+        "relay_op_wait_ms",
+    ):
+        assert key in write_meta["timing_ms"]
+
+    read_meta = next(
+        event["metadata"]
+        for event in trace_events
+        if event["metadata"]["direction"] == "read"
+    )
+    assert read_meta["edge"] == "image_encoder->mm_aggregate"
+    assert read_meta["aggregate_ready"] is True
+    for key in (
+        "unpickle_ms",
+        "alloc_recv_ms",
+        "get_async_ms",
+        "get_wait_ms",
+        "restore_ms",
+        "input_receive_ms",
+    ):
+        assert key in read_meta["timing_ms"]
+
+    assert caplog.text.count(stage_runtime.STAGE_IO_TRACE_EVENT) == 2
 
 
 def test_stage_execute_fanouts_unresolved_payload_before_materializing_refs(


### PR DESCRIPTION
## Summary
- add explicit stage IO tracing via `StageConfig.trace_stage_io` / `trace_stage_io_sync`
- record relay payload tensor summaries and write/read timing for stage edges
- emit `stage_io_trace` profiler events and server log JSON lines while disabled by default

## Validation
- `python3 -m py_compile` on changed Python files
- focused pytest was not run locally because both available Python runtimes are missing `pytest`

## Notes
This is instrumentation only and does not change relay behavior unless tracing is enabled explicitly in pipeline config.

Tracked in #934.