### PR TITLE
[CI Perf] Slim talker prefill projection

### DIFF
--- a/sglang_omni/models/qwen3_omni/components/talker_input.py
+++ b/sglang_omni/models/qwen3_omni/components/talker_input.py
@@ -176,6 +176,7 @@ def build_prefill_input(
     tts_pad_token_id: int,
     include_assistant_eos: bool = True,
     im_end_token_id: int | None = None,
+    include_user_context: bool = True,
 ) -> dict[str, torch.Tensor]:
     """Build full talker prefill input from thinker outputs.
 
@@ -214,6 +215,8 @@ def build_prefill_input(
         seg_mm_mask = multimodal_mask[start:end]
 
         if seg["role"] == "user":
+            if not include_user_context:
+                continue
             user_part = build_user_part(
                 thinker_embed=seg_embed,
                 thinker_hidden=seg_hidden,

--- a/sglang_omni/models/qwen3_omni/components/talker_prefill.py
+++ b/sglang_omni/models/qwen3_omni/components/talker_prefill.py
@@ -184,13 +184,17 @@ class TalkerPrefillBuilder:
         thinker_chunks: list[Any],
         *,
         thinker_done: bool,
+        include_user_context: bool = True,
     ) -> dict[str, Any]:
         if not thinker_chunks:
             raise ValueError("prompt prefill requires thinker chunks")
 
         state = Qwen3OmniPipelineState.from_dict(payload.data)
         prompt_ids, prompt_embed, prompt_hidden, prompt_model_inputs = (
-            self._reconstruct_prompt_states(state)
+            self._reconstruct_prompt_states(
+                state,
+                include_user_context=include_user_context,
+            )
         )
 
         assistant_token_ids = self.extract_chunk_token_ids(thinker_chunks)
@@ -237,6 +241,7 @@ class TalkerPrefillBuilder:
             tts_pad_token_id=self._tts_pad_token_id,
             include_assistant_eos=thinker_done,
             im_end_token_id=self._im_end_token_id,
+            include_user_context=include_user_context,
         )
 
         return {
@@ -247,7 +252,7 @@ class TalkerPrefillBuilder:
             ),
             "tts_pad_embed": tts_pad_embed[0].detach(),
             "tts_eos_embed": tts_eos_embed[0].detach(),
-            "prompt_model_inputs": prompt_model_inputs,
+            "prompt_model_inputs": prompt_model_inputs if include_user_context else {},
         }
 
     def append_text_chunk(self, req_data: Any, chunk: Any) -> None:
@@ -337,7 +342,10 @@ class TalkerPrefillBuilder:
         return PendingTextTensorQueue.from_tensor(tensor)
 
     def _reconstruct_prompt_states(
-        self, state: Qwen3OmniPipelineState
+        self,
+        state: Qwen3OmniPipelineState,
+        *,
+        include_user_context: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, dict[str, Any]]:
         prompt = state.prompt or {}
         prompt_input_ids = prompt["input_ids"]
@@ -347,6 +355,9 @@ class TalkerPrefillBuilder:
 
         prompt_embed = self._load_prompt_token_embeddings(prompt_ids)
         prompt_hidden = prompt_embed.clone()
+        if not include_user_context:
+            return prompt_ids, prompt_embed, prompt_hidden, {}
+
         prompt_model_inputs = self._prompt_model_inputs(state)
 
         merge_prompt_modality(

--- a/sglang_omni/models/qwen3_omni/request_builders.py
+++ b/sglang_omni/models/qwen3_omni/request_builders.py
@@ -34,6 +34,7 @@ DECODE_STAGE = "decode"
 TALKER_STAGE = "talker_ar"
 CODE2WAV_STAGE = "code2wav"
 MM_AGGREGATE_STAGE = "mm_aggregate"
+TALKER_PREFILL_USER_CONTEXT_PARAM = "talker_prefill_user_context"
 
 # Note(Chenchen Hong): PyTorch sampling_seed must fit a positive int32.
 MAX_INT32_POSITIVE = 0x7FFFFFFF
@@ -262,7 +263,7 @@ def project_mm_aggregate_to_talker_ar(payload: StagePayload) -> StagePayload:
     """Early-submit projection: ship prompt + thinker_inputs to the talker."""
     state = Qwen3OmniPipelineState.from_dict(payload.data)
     params = payload.request.params or {}
-    include_user_context = bool(params.get("talker_prefill_user_context", True))
+    include_user_context = bool(params.get(TALKER_PREFILL_USER_CONTEXT_PARAM, True))
     projected = Qwen3OmniPipelineState(
         prompt=dict(state.prompt) if isinstance(state.prompt, dict) else None,
         thinker_inputs=(
@@ -1072,7 +1073,7 @@ def _build_talker_request_data(
         )
     thinker_chunks = list(payload.prefetched_chunks)
     thinker_done = bool(payload.prefetched_stream_done)
-    include_user_context = bool(params.get("talker_prefill_user_context", True))
+    include_user_context = bool(params.get(TALKER_PREFILL_USER_CONTEXT_PARAM, True))
 
     if not thinker_chunks:
         raise RuntimeError(

--- a/sglang_omni/models/qwen3_omni/request_builders.py
+++ b/sglang_omni/models/qwen3_omni/request_builders.py
@@ -261,10 +261,14 @@ def project_encoder_to_mm_aggregate(payload: StagePayload) -> StagePayload:
 def project_mm_aggregate_to_talker_ar(payload: StagePayload) -> StagePayload:
     """Early-submit projection: ship prompt + thinker_inputs to the talker."""
     state = Qwen3OmniPipelineState.from_dict(payload.data)
+    params = payload.request.params or {}
+    include_user_context = bool(params.get("talker_prefill_user_context", True))
     projected = Qwen3OmniPipelineState(
         prompt=dict(state.prompt) if isinstance(state.prompt, dict) else None,
         thinker_inputs=(
-            dict(state.thinker_inputs) if isinstance(state.thinker_inputs, dict) else {}
+            dict(state.thinker_inputs)
+            if include_user_context and isinstance(state.thinker_inputs, dict)
+            else {}
         ),
     )
     return _payload_with_state(payload, projected)
@@ -1059,7 +1063,7 @@ def _build_talker_request_data(
     thinker_config: Any,
     resolve_sampling_config: Callable[[dict[str, Any]], dict[str, Any]],
 ) -> SGLangARRequestData:
-    params = payload.request.params
+    params = payload.request.params or {}
     sampling_cfg = resolve_sampling_config(params)
     if sampling_cfg.get("seed") is None:
         sampling_cfg["seed"] = (
@@ -1068,6 +1072,7 @@ def _build_talker_request_data(
         )
     thinker_chunks = list(payload.prefetched_chunks)
     thinker_done = bool(payload.prefetched_stream_done)
+    include_user_context = bool(params.get("talker_prefill_user_context", True))
 
     if not thinker_chunks:
         raise RuntimeError(
@@ -1079,6 +1084,7 @@ def _build_talker_request_data(
         payload,
         thinker_chunks,
         thinker_done=thinker_done,
+        include_user_context=include_user_context,
     )
     pending_text_queue = prompt_prefill["pending_text_queue"]
     pending_text_rows = len(pending_text_queue) if pending_text_queue is not None else 0

--- a/tests/unit_test/qwen3_omni/test_pipeline.py
+++ b/tests/unit_test/qwen3_omni/test_pipeline.py
@@ -35,6 +35,7 @@ from sglang_omni.models.qwen3_omni.config import (
 from sglang_omni.models.qwen3_omni.merge import decode_events, merge_for_thinker
 from sglang_omni.models.qwen3_omni.payload_types import Qwen3OmniPipelineState
 from sglang_omni.models.qwen3_omni.request_builders import (
+    TALKER_PREFILL_USER_CONTEXT_PARAM,
     apply_thinker_result,
     build_sglang_thinker_request,
     project_mm_aggregate_to_talker_ar,
@@ -229,7 +230,7 @@ def test_qwen_mm_aggregate_to_talker_projection_drops_context_when_disabled() ->
         request_id="req-1",
         request=OmniRequest(
             inputs="hi",
-            params={"talker_prefill_user_context": False},
+            params={TALKER_PREFILL_USER_CONTEXT_PARAM: False},
         ),
         data={
             "prompt": {"input_ids": torch.tensor([1, 2]), "prompt_text": "hi"},

--- a/tests/unit_test/qwen3_omni/test_pipeline.py
+++ b/tests/unit_test/qwen3_omni/test_pipeline.py
@@ -37,6 +37,7 @@ from sglang_omni.models.qwen3_omni.payload_types import Qwen3OmniPipelineState
 from sglang_omni.models.qwen3_omni.request_builders import (
     apply_thinker_result,
     build_sglang_thinker_request,
+    project_mm_aggregate_to_talker_ar,
     project_preprocessing_to_mm_aggregate,
     project_talker_to_code2wav,
     project_thinker_to_decode,
@@ -199,6 +200,55 @@ def test_qwen_thinker_to_decode_projection_drops_multimodal_tensors() -> None:
     assert state.thinker_out["extra_model_outputs"] == {}
     assert state.engine_outputs["thinker"]["output_ids"] == [3]
     assert state.engine_outputs["thinker"]["extra_model_outputs"] == {}
+
+
+def test_qwen_mm_aggregate_to_talker_projection_keeps_context_by_default() -> None:
+    video_embeds = torch.ones(2, 3)
+    payload = StagePayload(
+        request_id="req-1",
+        request=OmniRequest(inputs="hi"),
+        data={
+            "prompt": {"input_ids": torch.tensor([1, 2]), "prompt_text": "hi"},
+            "thinker_inputs": {
+                "model_inputs": {
+                    "video_embeds": video_embeds,
+                    "video_grid_thw": torch.tensor([[1, 2, 3]]),
+                }
+            },
+        },
+    )
+
+    projected = project_mm_aggregate_to_talker_ar(payload)
+    state = Qwen3OmniPipelineState.from_dict(projected.data)
+
+    assert state.thinker_inputs["model_inputs"]["video_embeds"] is video_embeds
+
+
+def test_qwen_mm_aggregate_to_talker_projection_drops_context_when_disabled() -> None:
+    payload = StagePayload(
+        request_id="req-1",
+        request=OmniRequest(
+            inputs="hi",
+            params={"talker_prefill_user_context": False},
+        ),
+        data={
+            "prompt": {"input_ids": torch.tensor([1, 2]), "prompt_text": "hi"},
+            "thinker_inputs": {
+                "model_inputs": {
+                    "audio_embeds": torch.ones(2, 3),
+                    "image_embeds": torch.ones(2, 3),
+                    "video_embeds": torch.ones(2, 3),
+                    "video_grid_thw": torch.tensor([[1, 2, 3]]),
+                }
+            },
+        },
+    )
+
+    projected = project_mm_aggregate_to_talker_ar(payload)
+    state = Qwen3OmniPipelineState.from_dict(projected.data)
+
+    assert state.prompt["prompt_text"] == "hi"
+    assert state.thinker_inputs == {}
 
 
 def test_qwen_thinker_to_decode_projection_isolates_stream_state() -> None:

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -25,7 +25,11 @@ from sglang_omni.models.qwen3_omni.pending_text_queue import (
     PendingTextTensorQueue,
     coerce_pending_text_queue,
 )
-from sglang_omni.models.qwen3_omni.request_builders import build_sglang_talker_request
+from sglang_omni.models.qwen3_omni.request_builders import (
+    TALKER_PREFILL_USER_CONTEXT_PARAM,
+    _build_talker_request_data,
+    build_sglang_talker_request,
+)
 from sglang_omni.models.qwen3_omni.talker_model_runner import QwenTalkerModelRunner
 from sglang_omni.models.qwen3_omni.talker_scheduler import (
     MIN_PARTIAL_START_CHUNKS,
@@ -737,10 +741,6 @@ def _drive_real_builder(
     request_id: str = "r0",
     request_params: dict[str, Any] | None = None,
 ) -> tuple[Any, dict[str, Any]]:
-    from sglang_omni.models.qwen3_omni.request_builders import (
-        _build_talker_request_data,
-    )
-
     captured: dict[str, Any] = {}
 
     class StubPrefillBuilder:
@@ -825,7 +825,7 @@ def test_real_builder_threads_user_context_prefill_flag() -> None:
     _, captured = _drive_real_builder(
         prefetched_chunks=[object()] * 5,
         prefetched_stream_done=False,
-        request_params={"talker_prefill_user_context": False},
+        request_params={TALKER_PREFILL_USER_CONTEXT_PARAM: False},
     )
 
     assert captured["build_prompt_prefill_include_user_context"] is False

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -15,8 +15,12 @@ from sglang_omni.models.qwen3_omni.components.talker import (
     Qwen3OmniTalker,
     _bind_default_weight_loaders,
 )
-from sglang_omni.models.qwen3_omni.components.talker_input import build_assistant_part
+from sglang_omni.models.qwen3_omni.components.talker_input import (
+    build_assistant_part,
+    build_prefill_input,
+)
 from sglang_omni.models.qwen3_omni.components.talker_prefill import TalkerPrefillBuilder
+from sglang_omni.models.qwen3_omni.payload_types import Qwen3OmniPipelineState
 from sglang_omni.models.qwen3_omni.pending_text_queue import (
     PendingTextTensorQueue,
     coerce_pending_text_queue,
@@ -226,6 +230,85 @@ def test_qwen_talker_assistant_part_handles_short_prefix() -> None:
         result["future_text_rows"],
         torch.tensor([[12.0, 13.0]], dtype=torch.float32),
     )
+
+
+def test_qwen_talker_prefill_can_skip_user_context() -> None:
+    """CI can avoid replaying long video/audio prompt rows through talker prefill."""
+    hidden_dim = 2
+    thinker_input_ids = torch.tensor([1, 2, 10, 11, 1, 3, 20, 21, 22], dtype=torch.long)
+    thinker_embed = torch.arange(
+        thinker_input_ids.numel() * hidden_dim,
+        dtype=torch.float32,
+    ).reshape(-1, hidden_dim)
+    thinker_hidden = thinker_embed + 100
+    multimodal_mask = torch.zeros(thinker_input_ids.numel(), dtype=torch.bool)
+    multimodal_mask[3] = True
+
+    def codec_embed_fn(token_ids: torch.Tensor) -> torch.Tensor:
+        return torch.zeros((token_ids.shape[0], hidden_dim), dtype=torch.float32)
+
+    common = dict(
+        thinker_embed=thinker_embed,
+        thinker_hidden=thinker_hidden,
+        thinker_input_ids=thinker_input_ids,
+        multimodal_mask=multimodal_mask,
+        text_projection=lambda tensor: tensor,
+        hidden_projection=lambda tensor: tensor + 1000,
+        codec_embed_fn=codec_embed_fn,
+        tts_bos_embed=torch.zeros((1, hidden_dim), dtype=torch.float32),
+        tts_eos_embed=torch.ones((1, hidden_dim), dtype=torch.float32),
+        tts_pad_embed=torch.full((1, hidden_dim), 7.0, dtype=torch.float32),
+        im_start_token_id=1,
+        system_token_id=0,
+        user_token_id=2,
+        assistant_token_id=3,
+        speaker_id=4,
+        codec_nothink_id=5,
+        codec_think_bos_id=6,
+        codec_think_eos_id=7,
+        codec_pad_id=8,
+        codec_bos_id=9,
+        tts_pad_token_id=99,
+        include_assistant_eos=True,
+        im_end_token_id=None,
+    )
+
+    with_user = build_prefill_input(**common)
+    without_user = build_prefill_input(**common, include_user_context=False)
+
+    assert with_user["input_embeds"].shape[0] == 13
+    assert without_user["input_embeds"].shape[0] == 9
+    assert without_user["input_ids"].tolist() == [99] * 9
+    assert torch.equal(
+        without_user["input_embeds"],
+        with_user["input_embeds"][-9:],
+    )
+
+
+def test_qwen_talker_prefill_skip_user_context_avoids_model_inputs() -> None:
+    builder = object.__new__(TalkerPrefillBuilder)
+    builder._load_prompt_token_embeddings = lambda ids: torch.ones(
+        (ids.numel(), 2),
+        dtype=torch.float32,
+    )
+
+    def fail_prompt_model_inputs(state):
+        del state
+        raise AssertionError("_prompt_model_inputs should not be read")
+
+    builder._prompt_model_inputs = fail_prompt_model_inputs
+    state = Qwen3OmniPipelineState(
+        prompt={"input_ids": torch.tensor([1, 2, 3], dtype=torch.long)}
+    )
+
+    prompt_ids, prompt_embed, prompt_hidden, prompt_model_inputs = (
+        builder._reconstruct_prompt_states(state, include_user_context=False)
+    )
+
+    assert prompt_ids.tolist() == [1, 2, 3]
+    assert torch.equal(prompt_embed, torch.ones((3, 2)))
+    assert torch.equal(prompt_hidden, torch.ones((3, 2)))
+    assert prompt_model_inputs == {}
 
 
 def test_qwen_talker_prefill_ignores_late_text_after_thinker_done() -> None:
@@ -667,9 +750,13 @@ def _drive_real_builder(
             thinker_chunks: list[Any],
             *,
             thinker_done: bool,
+            include_user_context: bool = True,
         ) -> dict[str, Any]:
             captured["build_prompt_prefill_thinker_done"] = thinker_done
             captured["build_prompt_prefill_chunk_count"] = len(thinker_chunks)
+            captured["build_prompt_prefill_include_user_context"] = (
+                include_user_context
+            )
             return {
                 "input_embeds": torch.zeros((9, 2), dtype=torch.float32),
                 "input_ids": torch.zeros((9,), dtype=torch.long),
@@ -731,6 +818,17 @@ def test_real_builder_threads_thinker_done_false_on_partial_path() -> None:
     )
     assert captured["build_prompt_prefill_thinker_done"] is False
     assert captured["talker_request_kwargs"]["thinker_chunks_done"] is False
+
+
+def test_real_builder_threads_user_context_prefill_flag() -> None:
+    """Request param can turn off long user/multimodal talker prefill."""
+    _, captured = _drive_real_builder(
+        prefetched_chunks=[object()] * 5,
+        prefetched_stream_done=False,
+        request_params={"talker_prefill_user_context": False},
+    )
+
+    assert captured["build_prompt_prefill_include_user_context"] is False
 
 
 def test_real_builder_threads_thinker_done_true_on_completed_stream() -> None:

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -360,7 +360,7 @@ def test_chunk_hidden_device_mismatch_resolved_before_stack() -> None:
         ),
     ]
 
-    # note (YueYin): .to() must happen per-chunk before torch.stack, not after
+    # note (luojiaxuan): .to() must happen per-chunk before torch.stack, not after
     result = torch.stack(
         [
             builder.chunk_layer_hidden_or_embed(c).to(


### PR DESCRIPTION
## Summary
- keep default talker early-submit behavior unchanged
- when `talker_prefill_user_context=false`, avoid sending `thinker_inputs` multimodal embeds from mm_aggregate to talker
- thread the request flag into talker prefill so the false path skips user-context replay and avoids reading prompt multimodal model inputs

## Validation
- `CUDA_HOME=/usr/local/cuda-13.0 python -m pytest tests/unit_test/qwen3_omni/test_pipeline.py tests/unit_test/qwen3_omni/test_talker.py -q`
- Combined with PR2 Stage 11 payload gate on H100 2x80GB, GPUs 2,3, `video_min_pixels=6272`, `video_max_pixels=6272`, `talker_prefill_user_context=false`:
  - `3 passed in 155.34s (0:02:35)`
  - accuracy `0.6000`, failed requests `0`, latency mean `46.912s`, RTF mean `3.3461`, prompt tokens mean `1132`
  - WER corpus `0.0098 (0.98%)`, >50% WER samples `0`

## Notes
This PR only changes the opt-in false path. Default speech/audio-output behavior remains unchanged. The Stage 11 CI path is enabled by PR2 sending `talker_prefill_user_context=false`.