### PR TITLE
[CI]: Add luojiaxuan to CI permissions

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -9,6 +9,11 @@
         "can_rerun_failed_ci": true,
         "reason": "custom override"
     },
+    "luojiaxuan": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "reason": "custom override"
+    },
     "zhaochenyang20": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,


### PR DESCRIPTION
## Summary
- add `luojiaxuan` to `.github/CI_PERMISSIONS.json`
- grant `/tag-run-ci-label` and `/rerun-failed-ci` permissions

## Validation
- `python3 .github/update_ci_permission.py --sort-only`
- `python3 -m json.tool .github/CI_PERMISSIONS.json >/dev/null`