### PR TITLE
[Qwen3-Omni] Lazy TensorRef path for large inter-stage tensors (#797)

### DIFF
--- a/sglang_omni/models/qwen3_omni/merge.py
+++ b/sglang_omni/models/qwen3_omni/merge.py
@@ -12,6 +12,7 @@ from sglang_omni.models.qwen3_omni.payload_types import (
     Qwen3OmniPipelineState,
     ThinkerOutput,
 )
+from sglang_omni.pipeline.tensor_ref import is_tensor_ref_dict, tensor_ref_numel
 from sglang_omni.proto import StagePayload
 
 IMAGE_STAGE = "image_encoder"
@@ -26,8 +27,14 @@ def _cast_tensor(
     return value.to(dtype=dtype) if dtype is not None else value
 
 
-def _non_empty(tensor: torch.Tensor | None) -> bool:
-    return tensor is not None and tensor.numel() > 0
+def _non_empty(value: Any) -> bool:
+    if value is None:
+        return False
+    if is_tensor_ref_dict(value):
+        return tensor_ref_numel(value) > 0
+    if isinstance(value, torch.Tensor):
+        return value.numel() > 0
+    return False
 
 
 def merge_for_thinker(payloads: dict[str, StagePayload]) -> StagePayload:

--- a/sglang_omni/pipeline/relay_io.py
+++ b/sglang_omni/pipeline/relay_io.py
@@ -99,12 +99,6 @@ def restore_tensors(obj: Any, tensor_dict: dict[str, torch.Tensor]) -> Any:
         return obj
 
 
-# ---------------------------------------------------------------------------
-# Lazy TensorRef: externalize large allowlisted tensors instead of inlining
-# them into the payload buffer. Intermediate stages forward the small ref
-# dict untouched; only the declared consumer stage resolves it.
-# ---------------------------------------------------------------------------
-
 _BACKGROUND_REF_TASKS: set[asyncio.Task] = set()
 _LOGGED_REF_EDGES: set[tuple[str, str]] = set()
 
@@ -161,7 +155,6 @@ async def publish_tensor_ref(
         path=path,
         shape=tuple(tensor.shape),
         dtype=str(tensor.dtype),
-        device=str(tensor.device),
         nbytes=tensor.numel() * tensor.element_size(),
         blob_key=blob_key,
         blob_metadata=blob_metadata,

--- a/sglang_omni/pipeline/relay_io.py
+++ b/sglang_omni/pipeline/relay_io.py
@@ -8,16 +8,26 @@ Extracted from worker/data_plane.py and worker/runtime.py.
 """
 from __future__ import annotations
 
+import asyncio
 import base64
 import io
+import logging
 import pickle
 from multiprocessing.reduction import ForkingPickler
 from typing import Any
+from uuid import uuid4
 
 import torch
 
+from sglang_omni.pipeline.tensor_ref import (
+    TensorRef,
+    TensorRefPolicy,
+    is_tensor_ref_dict,
+)
 from sglang_omni.proto import DataReadyMessage, StagePayload
 from sglang_omni.relay.base import Relay
+
+logger = logging.getLogger(__name__)
 
 
 def _dtype_alignment(dtype: torch.dtype) -> int:
@@ -86,6 +96,247 @@ def restore_tensors(obj: Any, tensor_dict: dict[str, torch.Tensor]) -> Any:
 
 
 # ---------------------------------------------------------------------------
+# Lazy TensorRef: externalize large allowlisted tensors instead of inlining
+# them into the payload buffer. Intermediate stages forward the small ref
+# dict untouched; only the declared consumer stage resolves it.
+# ---------------------------------------------------------------------------
+
+_BACKGROUND_REF_TASKS: set[asyncio.Task] = set()
+_LOGGED_REF_EDGES: set[tuple[str, str]] = set()
+
+
+def _track_background_op(op: Any, ref_id: str) -> None:
+    async def _wait() -> None:
+        try:
+            await op.wait_for_completion()
+        except Exception:
+            logger.warning(
+                "tensor_ref relay op failed or timed out for %s", ref_id, exc_info=True
+            )
+
+    task = asyncio.create_task(_wait())
+    _BACKGROUND_REF_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_REF_TASKS.discard)
+
+
+async def publish_tensor_ref(
+    relay: Relay,
+    *,
+    request_id: str,
+    tensor: torch.Tensor,
+    path: str,
+    from_stage: str,
+    to_stage: str,
+    consumer_stage: str,
+) -> TensorRef:
+    """Externalize ``tensor`` to the relay and return a small reference to it.
+
+    The blob write is awaited (the bytes must be copied before this hop's
+    small envelope is sent), but its relay op is tracked in the background —
+    the consumer stage, not this hop, is the one that actually reads it.
+    """
+    edge = (from_stage, to_stage)
+    if edge not in _LOGGED_REF_EDGES:
+        _LOGGED_REF_EDGES.add(edge)
+        logger.info(
+            "tensor_ref active: externalizing %s (%.1f MiB) on edge %s->%s, "
+            "consumer=%s",
+            path,
+            tensor.numel() * tensor.element_size() / 1024**2,
+            from_stage,
+            to_stage,
+            consumer_stage,
+        )
+    blob_key = f"{request_id}:tensor_ref:{from_stage}:{to_stage}:{uuid4().hex}:{path}"
+    blob_metadata, op = await write_blob(relay, blob_key, tensor)
+    ref = TensorRef(
+        ref_id=blob_key,
+        request_id=request_id,
+        producer_stage=from_stage,
+        consumer_stage=consumer_stage,
+        path=path,
+        shape=tuple(tensor.shape),
+        dtype=str(tensor.dtype),
+        device=str(tensor.device),
+        nbytes=tensor.numel() * tensor.element_size(),
+        blob_key=blob_key,
+        blob_metadata=blob_metadata,
+    )
+    _track_background_op(op, ref.ref_id)
+    return ref
+
+
+async def extract_tensors_for_payload(
+    obj: Any,
+    *,
+    relay: Relay,
+    request_id: str,
+    from_stage: str | None,
+    to_stage: str | None,
+    tensor_ref_policy: TensorRefPolicy,
+    stats: dict[str, int],
+    path: str = "",
+) -> tuple[Any, dict[str, torch.Tensor]]:
+    """Like ``extract_tensors``, but allowlisted large tensors are published
+    as ``TensorRef`` dicts instead of being flattened into the relay buffer.
+    Leaves that are already a ``TensorRef`` dict are passed through as-is.
+    """
+    tensors: dict[str, torch.Tensor] = {}
+
+    if is_tensor_ref_dict(obj):
+        return obj, tensors
+
+    if isinstance(obj, torch.Tensor):
+        if tensor_ref_policy.should_externalize(path, obj):
+            ref = await publish_tensor_ref(
+                relay,
+                request_id=request_id,
+                tensor=obj,
+                path=path,
+                from_stage=from_stage or "",
+                to_stage=to_stage or "",
+                consumer_stage=tensor_ref_policy.consumer_stage,
+            )
+            stats["ref_count"] += 1
+            stats["ref_bytes"] += ref.nbytes
+            return ref.to_dict(), tensors
+
+        stats["inline_tensor_bytes"] += obj.numel() * obj.element_size()
+        placeholder = {
+            "_tensor_placeholder": path,
+            "shape": list(obj.shape),
+            "dtype": str(obj.dtype),
+            "device": str(obj.device),
+        }
+        tensors[path] = obj
+        return placeholder, tensors
+
+    elif isinstance(obj, dict):
+        new_dict = {}
+        for key, value in obj.items():
+            new_path = f"{path}.{key}" if path else key
+            new_value, sub_tensors = await extract_tensors_for_payload(
+                value,
+                relay=relay,
+                request_id=request_id,
+                from_stage=from_stage,
+                to_stage=to_stage,
+                tensor_ref_policy=tensor_ref_policy,
+                stats=stats,
+                path=new_path,
+            )
+            new_dict[key] = new_value
+            tensors.update(sub_tensors)
+        return new_dict, tensors
+
+    elif isinstance(obj, (list, tuple)):
+        new_list = []
+        for i, item in enumerate(obj):
+            new_path = f"{path}[{i}]"
+            new_item, sub_tensors = await extract_tensors_for_payload(
+                item,
+                relay=relay,
+                request_id=request_id,
+                from_stage=from_stage,
+                to_stage=to_stage,
+                tensor_ref_policy=tensor_ref_policy,
+                stats=stats,
+                path=new_path,
+            )
+            new_list.append(new_item)
+            tensors.update(sub_tensors)
+        return (type(obj)(new_list), tensors)
+
+    else:
+        return obj, tensors
+
+
+async def read_tensor_ref(relay: Relay, ref: TensorRef) -> torch.Tensor:
+    tensor = await read_blob(relay, ref.blob_key, ref.blob_metadata)
+    if tuple(tensor.shape) != ref.shape:
+        raise RuntimeError(
+            f"tensor_ref {ref.ref_id} shape mismatch: expected {ref.shape}, "
+            f"got {tuple(tensor.shape)}"
+        )
+    expected_dtype = getattr(torch, ref.dtype.replace("torch.", ""))
+    if tensor.dtype != expected_dtype:
+        raise RuntimeError(
+            f"tensor_ref {ref.ref_id} dtype mismatch: expected {ref.dtype}, "
+            f"got {tensor.dtype}"
+        )
+    return tensor
+
+
+async def materialize_tensor_refs(
+    relay: Relay,
+    obj: Any,
+    *,
+    current_stage: str,
+    materialize_all: bool = False,
+) -> Any:
+    """Recursively resolve ``TensorRef`` leaves whose ``consumer_stage``
+    matches ``current_stage`` (or all of them, if ``materialize_all``).
+    Refs belonging to a different consumer stage pass through unresolved.
+    """
+    if is_tensor_ref_dict(obj):
+        ref = TensorRef.from_dict(obj)
+        if materialize_all or ref.consumer_stage == current_stage:
+            return await read_tensor_ref(relay, ref)
+        return obj
+
+    # Containers are rebuilt only when a descendant ref was actually resolved;
+    # otherwise the original object is returned unchanged so ref-free payloads
+    # (every non-consumer stage) skip per-request container churn.
+    if isinstance(obj, dict):
+        new_dict = {}
+        changed = False
+        for key, value in obj.items():
+            new_value = await materialize_tensor_refs(
+                relay,
+                value,
+                current_stage=current_stage,
+                materialize_all=materialize_all,
+            )
+            changed = changed or new_value is not value
+            new_dict[key] = new_value
+        return new_dict if changed else obj
+
+    if isinstance(obj, (list, tuple)):
+        new_items = []
+        changed = False
+        for item in obj:
+            new_item = await materialize_tensor_refs(
+                relay,
+                item,
+                current_stage=current_stage,
+                materialize_all=materialize_all,
+            )
+            changed = changed or new_item is not item
+            new_items.append(new_item)
+        return type(obj)(new_items) if changed else obj
+
+    return obj
+
+
+async def materialize_payload_tensor_refs(
+    relay: Relay,
+    payload: StagePayload,
+    *,
+    current_stage: str,
+) -> StagePayload:
+    new_data = await materialize_tensor_refs(
+        relay, payload.data, current_stage=current_stage
+    )
+    if new_data is payload.data:
+        return payload
+    return StagePayload(
+        request_id=payload.request_id,
+        request=payload.request,
+        data=new_data,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Payload read/write (full StagePayload via relay)
 # ---------------------------------------------------------------------------
 
@@ -94,12 +345,30 @@ async def write_payload(
     relay: Relay,
     request_id: str,
     payload: StagePayload,
+    *,
+    from_stage: str | None = None,
+    to_stage: str | None = None,
+    tensor_ref_policy: TensorRefPolicy | None = None,
 ) -> tuple[dict[str, Any], Any]:
     """Write a StagePayload to relay. Returns (control_plane_metadata, relay_op)."""
     device = getattr(relay, "device", "cpu")
     transport_device = torch.device(device)
 
-    modified_data, tensor_dict = extract_tensors(payload.data)
+    stats: dict[str, int] | None = None
+    if tensor_ref_policy is not None:
+        stats = {"ref_count": 0, "ref_bytes": 0, "inline_tensor_bytes": 0}
+        modified_data, tensor_dict = await extract_tensors_for_payload(
+            payload.data,
+            relay=relay,
+            request_id=request_id,
+            from_stage=from_stage,
+            to_stage=to_stage,
+            tensor_ref_policy=tensor_ref_policy,
+            stats=stats,
+        )
+    else:
+        modified_data, tensor_dict = extract_tensors(payload.data)
+
     payload_no_tensors = StagePayload(
         request_id=payload.request_id,
         request=payload.request,
@@ -139,11 +408,14 @@ async def write_payload(
 
     op = await relay.put_async(all_tensors, request_id=request_id)
 
-    return {
+    metadata: dict[str, Any] = {
         "relay_info": op.metadata,
         "payload_pickle": base64.b64encode(metadata_bytes).decode("ascii"),
         "tensor_info": tensor_info,
-    }, op
+    }
+    if stats is not None:
+        metadata["tensor_ref_stats"] = stats
+    return metadata, op
 
 
 async def read_payload(

--- a/sglang_omni/pipeline/relay_io.py
+++ b/sglang_omni/pipeline/relay_io.py
@@ -281,9 +281,9 @@ async def materialize_tensor_refs(
             return await read_tensor_ref(relay, ref)
         return obj
 
-    # Containers are rebuilt only when a descendant ref was actually resolved;
-    # otherwise the original object is returned unchanged so ref-free payloads
-    # (every non-consumer stage) skip per-request container churn.
+    # note (luojiaxuan): Rebuild containers only when a descendant ref resolves;
+    # note (luojiaxuan): ref-free and non-consumer payloads keep object identity
+    # note (luojiaxuan): to skip per-request container churn.
     if isinstance(obj, dict):
         new_dict = {}
         changed = False

--- a/sglang_omni/pipeline/relay_io.py
+++ b/sglang_omni/pipeline/relay_io.py
@@ -38,6 +38,10 @@ def _pad_offset(offset: int, alignment: int) -> int:
     return (-offset) % alignment
 
 
+def _dtype_from_str(dtype_str: str) -> torch.dtype:
+    return getattr(torch, dtype_str.replace("torch.", ""))
+
+
 # ---------------------------------------------------------------------------
 # Tensor extraction / restoration (recursive, nested dicts/lists)
 # ---------------------------------------------------------------------------
@@ -258,7 +262,7 @@ async def read_tensor_ref(relay: Relay, ref: TensorRef) -> torch.Tensor:
             f"tensor_ref {ref.ref_id} shape mismatch: expected {ref.shape}, "
             f"got {tuple(tensor.shape)}"
         )
-    expected_dtype = getattr(torch, ref.dtype.replace("torch.", ""))
+    expected_dtype = _dtype_from_str(ref.dtype)
     if tensor.dtype != expected_dtype:
         raise RuntimeError(
             f"tensor_ref {ref.ref_id} dtype mismatch: expected {ref.dtype}, "
@@ -448,7 +452,7 @@ async def read_payload(
             offset = info["offset"]
             size = info["size"]
             tensor_bytes = recv_tensor[offset : offset + size]
-            dtype = getattr(torch, dtype_str.replace("torch.", ""))
+            dtype = _dtype_from_str(dtype_str)
             tensor = tensor_bytes.view(dtype).reshape(shape)
             tensor_dict[path] = tensor
 
@@ -514,7 +518,7 @@ async def read_blob(
     )
     await op.wait_for_completion()
 
-    dtype = getattr(torch, dtype_str.replace("torch.", ""))
+    dtype = _dtype_from_str(dtype_str)
     return recv_buf[offset:].view(dtype).reshape(shape)
 
 

--- a/sglang_omni/pipeline/relay_io.py
+++ b/sglang_omni/pipeline/relay_io.py
@@ -278,8 +278,8 @@ async def materialize_tensor_refs(
         return obj
 
     # note (luojiaxuan): Rebuild containers only when a descendant ref resolves;
-    # note (luojiaxuan): ref-free and non-consumer payloads keep object identity
-    # note (luojiaxuan): to skip per-request container churn.
+    # ref-free and non-consumer payloads keep object identity
+    # to skip per-request container churn.
     if isinstance(obj, dict):
         new_dict = {}
         changed = False

--- a/sglang_omni/pipeline/relay_io.py
+++ b/sglang_omni/pipeline/relay_io.py
@@ -103,6 +103,98 @@ _BACKGROUND_REF_TASKS: set[asyncio.Task] = set()
 _LOGGED_REF_EDGES: set[tuple[str, str]] = set()
 
 
+def collect_tensor_refs(obj: Any, seen: set[int] | None = None) -> list[TensorRef]:
+    """Collect unresolved TensorRef leaves from a nested payload."""
+    if obj is None:
+        return []
+    seen = set() if seen is None else seen
+    obj_id = id(obj)
+    if obj_id in seen:
+        return []
+    seen.add(obj_id)
+
+    if is_tensor_ref_dict(obj):
+        return [TensorRef.from_dict(obj)]
+    if isinstance(obj, dict):
+        refs: list[TensorRef] = []
+        for value in obj.values():
+            refs.extend(collect_tensor_refs(value, seen))
+        return refs
+    if isinstance(obj, (list, tuple, set, frozenset)):
+        refs = []
+        for value in obj:
+            refs.extend(collect_tensor_refs(value, seen))
+        return refs
+    return []
+
+
+def _release_shm_transfer(relay_info: dict[str, Any]) -> bool:
+    transfer_info = relay_info.get("transfer_info", {})
+    shm_name = (
+        transfer_info.get("shm_name") if isinstance(transfer_info, dict) else None
+    )
+    if not isinstance(shm_name, str) or not shm_name:
+        return False
+
+    from multiprocessing import shared_memory as _shm
+
+    try:
+        shm = _shm.SharedMemory(name=shm_name)
+    except FileNotFoundError:
+        return False
+    try:
+        shm.unlink()
+        return True
+    except FileNotFoundError:
+        return False
+    finally:
+        shm.close()
+
+
+def release_blob(relay: Relay, key: str, metadata: dict[str, Any]) -> bool:
+    """Best-effort release for a raw relay blob that will never be read."""
+    release_fn = getattr(relay, "release_blob", None)
+    if release_fn is not None:
+        release_fn(key, metadata)
+        return True
+
+    relay_info = metadata.get("relay_info", {})
+    if isinstance(relay_info, dict) and _release_shm_transfer(relay_info):
+        return True
+
+    storage = getattr(relay, "storage", None)
+    if isinstance(storage, dict) and key in storage:
+        storage.pop(key, None)
+        return True
+
+    return False
+
+
+def release_tensor_refs(relay: Relay, refs: list[TensorRef]) -> int:
+    """Release unresolved TensorRef blobs for requests that abort before consume."""
+    released = 0
+    seen: set[str] = set()
+    for ref in refs:
+        if ref.blob_key in seen:
+            continue
+        seen.add(ref.blob_key)
+        if release_blob(relay, ref.blob_key, ref.blob_metadata):
+            released += 1
+    return released
+
+
+def release_tensor_ref_blobs_from_metadata(
+    relay: Relay, metadata: dict[str, Any]
+) -> int:
+    if not isinstance(metadata, dict):
+        return 0
+    raw_refs = metadata.get("tensor_ref_blobs", [])
+    if not isinstance(raw_refs, list):
+        return 0
+    refs = [TensorRef.from_dict(item) for item in raw_refs if is_tensor_ref_dict(item)]
+    return release_tensor_refs(relay, refs)
+
+
 def _track_background_op(op: Any, ref_id: str) -> None:
     async def _wait() -> None:
         try:
@@ -406,6 +498,9 @@ async def write_payload(
         "payload_pickle": base64.b64encode(metadata_bytes).decode("ascii"),
         "tensor_info": tensor_info,
     }
+    tensor_ref_blobs = collect_tensor_refs(modified_data)
+    if tensor_ref_blobs:
+        metadata["tensor_ref_blobs"] = [ref.to_dict() for ref in tensor_ref_blobs]
     if stats is not None:
         metadata["tensor_ref_stats"] = stats
     return metadata, op

--- a/sglang_omni/pipeline/relay_io.py
+++ b/sglang_omni/pipeline/relay_io.py
@@ -137,13 +137,9 @@ async def publish_tensor_ref(
     if edge not in _LOGGED_REF_EDGES:
         _LOGGED_REF_EDGES.add(edge)
         logger.info(
-            "tensor_ref active: externalizing %s (%.1f MiB) on edge %s->%s, "
-            "consumer=%s",
-            path,
-            tensor.numel() * tensor.element_size() / 1024**2,
-            from_stage,
-            to_stage,
-            consumer_stage,
+            f"tensor_ref active: externalizing {path} "
+            f"({tensor.numel() * tensor.element_size() / 1024**2:.1f} MiB) "
+            f"on edge {from_stage}->{to_stage}, consumer={consumer_stage}"
         )
     blob_key = f"{request_id}:tensor_ref:{from_stage}:{to_stage}:{uuid4().hex}:{path}"
     blob_metadata, op = await write_blob(relay, blob_key, tensor)

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -661,9 +661,17 @@ class Stage:
             and getattr(self.scheduler, "requires_tp_work_fanout", False)
         ):
             # Fan out the *unresolved* payload before materializing any
-            # tensor refs below — followers materialize refs themselves,
-            # on their own relay/device, rather than receiving an already
-            # resolved large CUDA tensor over the cross-process work queue.
+            # tensor refs below, so a follower receives the small ref rather
+            # than an already-resolved large CUDA tensor over the work queue.
+            #
+            # CONTRACT: a TensorRef must be resolved exactly once per blob. The
+            # relay get is destructive (the SHM backend unlinks on read), so two
+            # ranks resolving the same ref would double-unlink. This holds today
+            # because the only ref consumer (thinker) runs OmniScheduler with
+            # requires_tp_work_fanout=False -- it never reaches this fanout, and
+            # materialize runs once on the leader. Do NOT enable a ref edge whose
+            # consumer is a requires_tp_work_fanout=True stage without making the
+            # relay read non-destructive / reference-counted first.
             self._tp_fanout.fanout_work(payload)
         payload_for_scheduler = payload
         if tensor_refs_enabled():

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -143,6 +143,7 @@ class Stage:
         self._first_stream_chunk_seen: set[str] = set()
         self._local_stream_targets: dict[str, set[str]] = {}
         self._nonlocal_stream_targets: dict[str, set[str]] = {}
+        self._unresolved_tensor_refs: dict[str, dict[str, Any]] = {}
         self._scheduler_thread: threading.Thread | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._scheduler_crash_error: BaseException | None = None
@@ -369,14 +370,17 @@ class Stage:
         payload: Any,
     ) -> None:
         if request_id in self._aborted:
+            self._release_payload_tensor_refs(payload)
             return
         self._active_requests.add(request_id)
         if self._stream_queue is not None and not self._stream_queue.has(request_id):
             self._stream_queue.open(request_id)
 
         if request_id in self._aborted:
+            self._release_payload_tensor_refs(payload)
             return
 
+        self._remember_payload_tensor_refs(request_id, payload)
         _emit_event(
             request_id=request_id,
             stage=self.name,
@@ -537,8 +541,11 @@ class Stage:
 
     async def _discard_payload_data(self, msg: DataReadyMessage) -> None:
         request_id = msg.request_id
+        payload = None
         try:
-            await relay_io.read_payload(self.relay, request_id, msg.shm_metadata)
+            payload = await relay_io.read_payload(
+                self.relay, request_id, msg.shm_metadata
+            )
         except Exception:
             logger.debug(
                 "Stage %s: failed to drain aborted payload for %s",
@@ -547,6 +554,12 @@ class Stage:
                 exc_info=True,
             )
             self.relay.cleanup(request_id)
+        finally:
+            relay_io.release_tensor_ref_blobs_from_metadata(
+                self.relay, msg.shm_metadata
+            )
+            if payload is not None:
+                self._release_payload_tensor_refs(payload)
 
     async def _discard_stream_chunk_data(self, msg: DataReadyMessage) -> None:
         if isinstance(msg.shm_metadata, dict) and msg.shm_metadata.get("_ipc"):
@@ -672,6 +685,7 @@ class Stage:
             payload_for_scheduler = await relay_io.materialize_payload_tensor_refs(
                 self.relay, payload, current_stage=self.name
             )
+            self._remember_payload_tensor_refs(request_id, payload_for_scheduler)
         self.scheduler.inbox.put(
             IncomingMessage(
                 request_id=request_id, type="new_request", data=payload_for_scheduler
@@ -1016,8 +1030,12 @@ class Stage:
             event_name="stage_hop_sent",
             metadata=hop_metadata,
         )
-        await self.control_plane.send_to_stage(target, endpoint, msg)
-        await op.wait_for_completion()
+        try:
+            await self.control_plane.send_to_stage(target, endpoint, msg)
+            await op.wait_for_completion()
+        except Exception:
+            relay_io.release_tensor_ref_blobs_from_metadata(self.relay, metadata)
+            raise
 
     @staticmethod
     def _is_isolated_projected_payload(
@@ -1278,6 +1296,7 @@ class Stage:
     async def _send_failure(self, request_id: str, error: str) -> None:
         self._record_aborted_request_id(request_id)
         if not self._owns_external_io:
+            self._release_tracked_tensor_refs(request_id)
             self._clear_request_state(request_id)
             raise RuntimeError(f"Follower stage {self.name} failed: {error}")
         await self.control_plane.send_complete(
@@ -1288,6 +1307,7 @@ class Stage:
                 error=error,
             )
         )
+        self._release_tracked_tensor_refs(request_id)
         self._clear_request_state(request_id)
 
     def _clear_request_state(self, request_id: str) -> None:
@@ -1303,6 +1323,7 @@ class Stage:
         self._first_stream_chunk_seen.discard(request_id)
         self._local_stream_targets.pop(request_id, None)
         self._nonlocal_stream_targets.pop(request_id, None)
+        self._unresolved_tensor_refs.pop(request_id, None)
 
     async def _handle_scheduler_crash(self, exc: BaseException) -> None:
         if self._scheduler_crash_error is not None:
@@ -1348,9 +1369,28 @@ class Stage:
 
     def _on_abort(self, request_id: str) -> None:
         self._record_aborted_request_id(request_id)
+        self._release_tracked_tensor_refs(request_id)
         self.relay.cleanup(request_id)
         self._clear_request_state(request_id)
         self.scheduler.abort(request_id)
+
+    def _remember_payload_tensor_refs(self, request_id: str, payload: Any) -> None:
+        data = getattr(payload, "data", payload)
+        refs = relay_io.collect_tensor_refs(data)
+        if refs:
+            self._unresolved_tensor_refs[request_id] = {
+                ref.blob_key: ref for ref in refs
+            }
+        else:
+            self._unresolved_tensor_refs.pop(request_id, None)
+
+    def _release_payload_tensor_refs(self, payload: Any) -> None:
+        data = getattr(payload, "data", payload)
+        relay_io.release_tensor_refs(self.relay, relay_io.collect_tensor_refs(data))
+
+    def _release_tracked_tensor_refs(self, request_id: str) -> None:
+        refs = list(self._unresolved_tensor_refs.pop(request_id, {}).values())
+        relay_io.release_tensor_refs(self.relay, refs)
 
     def _on_profiler_start(self, msg: ProfilerStartMessage) -> None:
         run_id = msg.run_id

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -661,11 +661,11 @@ class Stage:
             and getattr(self.scheduler, "requires_tp_work_fanout", False)
         ):
             # note (luojiaxuan): Fan out unresolved refs before materialization
-            # note (luojiaxuan): so followers receive small refs, not large CUDA
-            # note (luojiaxuan): tensors. TensorRef blobs are single-resolve
-            # note (luojiaxuan): because SHM get unlinks on read; do not enable
-            # note (luojiaxuan): refs for requires_tp_work_fanout=True consumers
-            # note (luojiaxuan): until blob reads are ref-counted/non-destructive.
+            # so followers receive small refs, not large CUDA
+            # tensors. TensorRef blobs are single-resolve
+            # because SHM get unlinks on read; do not enable
+            # refs for requires_tp_work_fanout=True consumers
+            # until blob reads are ref-counted/non-destructive.
             self._tp_fanout.fanout_work(payload)
         payload_for_scheduler = payload
         if tensor_refs_enabled():

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -20,6 +20,7 @@ from typing import Any, Callable, Literal
 from sglang_omni.pipeline import relay_io
 from sglang_omni.pipeline.stage.input import DirectInput, InputHandler
 from sglang_omni.pipeline.stage.stream_queue import StreamItem, StreamQueue
+from sglang_omni.pipeline.tensor_ref import TensorRefPolicy, tensor_refs_enabled
 from sglang_omni.pipeline.tp_control import TPLeaderFanout, TPWorkMessage
 from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.profiler.event_recorder import get_recorder as _get_recorder
@@ -659,9 +660,20 @@ class Stage:
             and self._tp_fanout is not None
             and getattr(self.scheduler, "requires_tp_work_fanout", False)
         ):
+            # Fan out the *unresolved* payload before materializing any
+            # tensor refs below — followers materialize refs themselves,
+            # on their own relay/device, rather than receiving an already
+            # resolved large CUDA tensor over the cross-process work queue.
             self._tp_fanout.fanout_work(payload)
+        payload_for_scheduler = payload
+        if tensor_refs_enabled():
+            payload_for_scheduler = await relay_io.materialize_payload_tensor_refs(
+                self.relay, payload, current_stage=self.name
+            )
         self.scheduler.inbox.put(
-            IncomingMessage(request_id=request_id, type="new_request", data=payload)
+            IncomingMessage(
+                request_id=request_id, type="new_request", data=payload_for_scheduler
+            )
         )
 
     async def _on_admin(self, msg: AdminMessage) -> None:
@@ -975,8 +987,16 @@ class Stage:
             )
             return
 
+        tensor_ref_policy = TensorRefPolicy.from_env(
+            from_stage=self.name, to_stage=target
+        )
         metadata, op = await relay_io.write_payload(
-            self.relay, request_id, projected_payload
+            self.relay,
+            request_id,
+            projected_payload,
+            from_stage=self.name,
+            to_stage=target,
+            tensor_ref_policy=tensor_ref_policy,
         )
         msg = DataReadyMessage(
             request_id=request_id,
@@ -984,11 +1004,15 @@ class Stage:
             to_stage=target,
             shm_metadata=metadata,
         )
+        hop_metadata: dict[str, Any] = {"to_stage": target}
+        tensor_ref_stats = metadata.get("tensor_ref_stats")
+        if tensor_ref_stats is not None:
+            hop_metadata.update(tensor_ref_stats)
         _emit_event(
             request_id=request_id,
             stage=self.name,
             event_name="stage_hop_sent",
-            metadata={"to_stage": target},
+            metadata=hop_metadata,
         )
         await self.control_plane.send_to_stage(target, endpoint, msg)
         await op.wait_for_completion()

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -660,18 +660,12 @@ class Stage:
             and self._tp_fanout is not None
             and getattr(self.scheduler, "requires_tp_work_fanout", False)
         ):
-            # Fan out the *unresolved* payload before materializing any
-            # tensor refs below, so a follower receives the small ref rather
-            # than an already-resolved large CUDA tensor over the work queue.
-            #
-            # CONTRACT: a TensorRef must be resolved exactly once per blob. The
-            # relay get is destructive (the SHM backend unlinks on read), so two
-            # ranks resolving the same ref would double-unlink. This holds today
-            # because the only ref consumer (thinker) runs OmniScheduler with
-            # requires_tp_work_fanout=False -- it never reaches this fanout, and
-            # materialize runs once on the leader. Do NOT enable a ref edge whose
-            # consumer is a requires_tp_work_fanout=True stage without making the
-            # relay read non-destructive / reference-counted first.
+            # note (luojiaxuan): Fan out unresolved refs before materialization
+            # note (luojiaxuan): so followers receive small refs, not large CUDA
+            # note (luojiaxuan): tensors. TensorRef blobs are single-resolve
+            # note (luojiaxuan): because SHM get unlinks on read; do not enable
+            # note (luojiaxuan): refs for requires_tp_work_fanout=True consumers
+            # note (luojiaxuan): until blob reads are ref-counted/non-destructive.
             self._tp_fanout.fanout_work(payload)
         payload_for_scheduler = payload
         if tensor_refs_enabled():

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -1378,11 +1378,8 @@ class Stage:
         data = getattr(payload, "data", payload)
         refs = relay_io.collect_tensor_refs(data)
         if refs:
-            self._unresolved_tensor_refs[request_id] = {
-                ref.blob_key: ref for ref in refs
-            }
-        else:
-            self._unresolved_tensor_refs.pop(request_id, None)
+            tracked = self._unresolved_tensor_refs.setdefault(request_id, {})
+            tracked.update({ref.blob_key: ref for ref in refs})
 
     def _release_payload_tensor_refs(self, payload: Any) -> None:
         data = getattr(payload, "data", payload)

--- a/sglang_omni/pipeline/tensor_ref.py
+++ b/sglang_omni/pipeline/tensor_ref.py
@@ -16,7 +16,7 @@ from typing import Any
 import torch
 
 TENSOR_REF_MARKER = "__sglang_omni_tensor_ref__"
-DEFAULT_TENSOR_REF_THRESHOLD_MB = 8.0
+DEFAULT_TENSOR_REF_THRESHOLD_MB = 2.0
 DEFAULT_TENSOR_REF_PATHS = (
     "video_embeds",
     "deepstack_visual_embeds_image",

--- a/sglang_omni/pipeline/tensor_ref.py
+++ b/sglang_omni/pipeline/tensor_ref.py
@@ -27,7 +27,6 @@ class TensorRef:
     path: str
     shape: tuple[int, ...]
     dtype: str
-    device: str
     nbytes: int
     blob_key: str
     blob_metadata: dict[str, Any]
@@ -43,7 +42,6 @@ class TensorRef:
             "path": self.path,
             "shape": list(self.shape),
             "dtype": self.dtype,
-            "device": self.device,
             "nbytes": self.nbytes,
             "blob_key": self.blob_key,
             "blob_metadata": self.blob_metadata,
@@ -60,7 +58,6 @@ class TensorRef:
             path=str(obj["path"]),
             shape=tuple(int(x) for x in obj["shape"]),
             dtype=str(obj["dtype"]),
-            device=str(obj["device"]),
             nbytes=int(obj["nbytes"]),
             blob_key=str(obj["blob_key"]),
             blob_metadata=dict(obj["blob_metadata"]),

--- a/sglang_omni/pipeline/tensor_ref.py
+++ b/sglang_omni/pipeline/tensor_ref.py
@@ -95,6 +95,13 @@ class TensorRefPolicy:
     path_allowlist: tuple[str, ...]
 
     def should_externalize(self, path: str, tensor: torch.Tensor) -> bool:
+        """Whether to externalize this tensor leaf as a TensorRef.
+
+        The allowlist matches the *leaf name* with any list index stripped
+        (``foo[0]`` -> ``foo``), so an allowlisted ``list[Tensor]`` (e.g.
+        deepstack embeds) is externalized element-by-element -- each list
+        element becomes its own blob / relay segment.
+        """
         leaf_name = path.rsplit(".", 1)[-1].split("[")[0]
         if leaf_name not in self.path_allowlist:
             return False

--- a/sglang_omni/pipeline/tensor_ref.py
+++ b/sglang_omni/pipeline/tensor_ref.py
@@ -16,6 +16,12 @@ from typing import Any
 import torch
 
 TENSOR_REF_MARKER = "__sglang_omni_tensor_ref__"
+DEFAULT_TENSOR_REF_THRESHOLD_MB = 8.0
+DEFAULT_TENSOR_REF_PATHS = (
+    "video_embeds",
+    "deepstack_visual_embeds_image",
+    "deepstack_visual_embeds_video",
+)
 
 
 @dataclass(frozen=True)
@@ -113,17 +119,24 @@ class TensorRefPolicy:
         consumer_stage = edges.get((from_stage, to_stage))
         if consumer_stage is None:
             return None
-        threshold_mb = float(os.environ.get("SGLANG_OMNI_TENSOR_REF_THRESHOLD_MB", "8"))
-        paths = os.environ.get(
-            "SGLANG_OMNI_TENSOR_REF_PATHS",
-            "video_embeds,deepstack_visual_embeds_image,deepstack_visual_embeds_video",
+        threshold_mb = float(
+            os.environ.get(
+                "SGLANG_OMNI_TENSOR_REF_THRESHOLD_MB",
+                str(DEFAULT_TENSOR_REF_THRESHOLD_MB),
+            )
+        )
+        raw_paths = os.environ.get("SGLANG_OMNI_TENSOR_REF_PATHS")
+        path_allowlist = (
+            tuple(p.strip() for p in raw_paths.split(",") if p.strip())
+            if raw_paths is not None
+            else DEFAULT_TENSOR_REF_PATHS
         )
         return cls(
             threshold_bytes=int(threshold_mb * 1024 * 1024),
             from_stage=from_stage,
             to_stage=to_stage,
             consumer_stage=consumer_stage,
-            path_allowlist=tuple(p.strip() for p in paths.split(",") if p.strip()),
+            path_allowlist=path_allowlist,
         )
 
 

--- a/sglang_omni/pipeline/tensor_ref.py
+++ b/sglang_omni/pipeline/tensor_ref.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lazy tensor handoff for large multimodal tensors crossing pipeline stages.
+
+A ``TensorRef`` stands in for a tensor that has been externalized to the
+relay rather than inlined into a ``StagePayload``. Intermediate stages that
+only forward the value (e.g. ``mm_aggregate``) never materialize it; only
+the declared ``consumer_stage`` resolves it back into a real tensor.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any
+
+import torch
+
+TENSOR_REF_MARKER = "__sglang_omni_tensor_ref__"
+
+
+@dataclass(frozen=True)
+class TensorRef:
+    ref_id: str
+    request_id: str
+    producer_stage: str
+    consumer_stage: str
+    path: str
+    shape: tuple[int, ...]
+    dtype: str
+    device: str
+    nbytes: int
+    blob_key: str
+    blob_metadata: dict[str, Any]
+    backend: str = "relay_lazy"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            TENSOR_REF_MARKER: True,
+            "ref_id": self.ref_id,
+            "request_id": self.request_id,
+            "producer_stage": self.producer_stage,
+            "consumer_stage": self.consumer_stage,
+            "path": self.path,
+            "shape": list(self.shape),
+            "dtype": self.dtype,
+            "device": self.device,
+            "nbytes": self.nbytes,
+            "blob_key": self.blob_key,
+            "blob_metadata": self.blob_metadata,
+            "backend": self.backend,
+        }
+
+    @classmethod
+    def from_dict(cls, obj: dict[str, Any]) -> "TensorRef":
+        return cls(
+            ref_id=str(obj["ref_id"]),
+            request_id=str(obj["request_id"]),
+            producer_stage=str(obj["producer_stage"]),
+            consumer_stage=str(obj["consumer_stage"]),
+            path=str(obj["path"]),
+            shape=tuple(int(x) for x in obj["shape"]),
+            dtype=str(obj["dtype"]),
+            device=str(obj["device"]),
+            nbytes=int(obj["nbytes"]),
+            blob_key=str(obj["blob_key"]),
+            blob_metadata=dict(obj["blob_metadata"]),
+            backend=str(obj.get("backend", "relay_lazy")),
+        )
+
+
+def tensor_refs_enabled() -> bool:
+    return os.environ.get("SGLANG_OMNI_ENABLE_TENSOR_REFS") == "1"
+
+
+def is_tensor_ref_dict(obj: Any) -> bool:
+    return isinstance(obj, dict) and obj.get(TENSOR_REF_MARKER) is True
+
+
+def tensor_ref_numel(obj: dict[str, Any] | TensorRef) -> int:
+    ref = TensorRef.from_dict(obj) if isinstance(obj, dict) else obj
+    numel = 1
+    for dim in ref.shape:
+        numel *= int(dim)
+    return numel
+
+
+@dataclass(frozen=True)
+class TensorRefPolicy:
+    """Per-edge policy controlling which tensor leaves get externalized."""
+
+    threshold_bytes: int
+    from_stage: str
+    to_stage: str
+    consumer_stage: str
+    path_allowlist: tuple[str, ...]
+
+    def should_externalize(self, path: str, tensor: torch.Tensor) -> bool:
+        leaf_name = path.rsplit(".", 1)[-1].split("[")[0]
+        if leaf_name not in self.path_allowlist:
+            return False
+        nbytes = tensor.numel() * tensor.element_size()
+        return nbytes >= self.threshold_bytes
+
+    @classmethod
+    def from_env(cls, *, from_stage: str, to_stage: str) -> "TensorRefPolicy | None":
+        if os.environ.get("SGLANG_OMNI_ENABLE_TENSOR_REFS") != "1":
+            return None
+        edges = _parse_edges(os.environ.get("SGLANG_OMNI_TENSOR_REF_EDGES", ""))
+        consumer_stage = edges.get((from_stage, to_stage))
+        if consumer_stage is None:
+            return None
+        threshold_mb = float(os.environ.get("SGLANG_OMNI_TENSOR_REF_THRESHOLD_MB", "8"))
+        paths = os.environ.get(
+            "SGLANG_OMNI_TENSOR_REF_PATHS",
+            "video_embeds,deepstack_visual_embeds_image,deepstack_visual_embeds_video",
+        )
+        return cls(
+            threshold_bytes=int(threshold_mb * 1024 * 1024),
+            from_stage=from_stage,
+            to_stage=to_stage,
+            consumer_stage=consumer_stage,
+            path_allowlist=tuple(p.strip() for p in paths.split(",") if p.strip()),
+        )
+
+
+@lru_cache(maxsize=1)
+def _parse_edges(raw: str) -> dict[tuple[str, str], str]:
+    edges: dict[tuple[str, str], str] = {}
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        parts = entry.split(":")
+        if len(parts) != 3:
+            continue
+        from_stage, to_stage, consumer_stage = (p.strip() for p in parts)
+        edges[(from_stage, to_stage)] = consumer_stage
+    return edges

--- a/tests/unit_test/fixtures/pipeline_fakes.py
+++ b/tests/unit_test/fixtures/pipeline_fakes.py
@@ -91,6 +91,27 @@ class FakeRelay:
         self.log.append("relay_close")
 
 
+class DestructiveFakeRelay(FakeRelay):
+    """FakeRelay whose ``get_async`` unlinks the blob after a single read,
+    modeling the SHM backend (``ShmGetOperation`` unlinks on read). A second
+    read of the same key fails -- so this exposes multi-consumer ref-resolve
+    bugs that the non-destructive ``FakeRelay`` cannot.
+    """
+
+    async def get_async(
+        self,
+        metadata: dict[str, Any],
+        dest_tensor: torch.Tensor,
+        request_id: str | None = None,
+    ) -> FakeOp:
+        key = str(metadata.get("key", request_id))
+        if key not in self.storage:
+            raise RuntimeError(f"relay blob {key} not found (already consumed)")
+        op = await super().get_async(metadata, dest_tensor, request_id=request_id)
+        del self.storage[key]
+        return op
+
+
 class FakeScheduler:
     def __init__(self, *, fail_start: BaseException | None = None):
         self.inbox: queue.Queue[IncomingMessage] = queue.Queue()

--- a/tests/unit_test/pipeline/test_stage.py
+++ b/tests/unit_test/pipeline/test_stage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import queue
 
 import pytest
 import torch
@@ -13,6 +14,8 @@ from sglang_omni.pipeline.local_dispatch import LocalStageDispatcher
 from sglang_omni.pipeline.stage.input import AggregatedInput
 from sglang_omni.pipeline.stage.stream_queue import StreamQueue
 from sglang_omni.pipeline.stage_workers import StageLaunchConfig, _construct_stage
+from sglang_omni.pipeline.tensor_ref import TensorRef, is_tensor_ref_dict
+from sglang_omni.pipeline.tp_control import TPLeaderFanout
 from sglang_omni.proto import DataReadyMessage
 from tests.unit_test.fixtures.pipeline_fakes import (
     EventLog,
@@ -270,6 +273,113 @@ def test_relay_payload_and_cross_gpu_stream_contracts() -> None:
         msg = control_plane.sent_to_stage[0][2]
         assert msg.shm_metadata["chunk_metadata"]["token_id"] == 1
         assert "hidden" in msg.shm_metadata["chunk_metadata_tensors"]
+
+    asyncio.run(_run())
+
+
+def test_stage_execute_fanouts_unresolved_payload_before_materializing_refs(
+    monkeypatch,
+) -> None:
+    """TP followers get the unresolved ref; the local scheduler gets the resolved tensor."""
+    monkeypatch.setenv("SGLANG_OMNI_ENABLE_TENSOR_REFS", "1")
+
+    async def _run() -> None:
+        relay = FakeRelay()
+        tensor = torch.arange(6, dtype=torch.float32)
+        blob_metadata, blob_op = await relay_io.write_blob(relay, "req-1:blob", tensor)
+        await blob_op.wait_for_completion()
+        ref = TensorRef(
+            ref_id="req-1:blob",
+            request_id="req-1",
+            producer_stage="image_encoder",
+            consumer_stage="thinker",
+            path="video_embeds",
+            shape=tuple(tensor.shape),
+            dtype=str(tensor.dtype),
+            device=str(tensor.device),
+            nbytes=tensor.numel() * tensor.element_size(),
+            blob_key="req-1:blob",
+            blob_metadata=blob_metadata,
+        )
+        payload = make_stage_payload(
+            request_id="req-1", data={"video_embeds": ref.to_dict()}
+        )
+
+        scheduler = FakeScheduler()
+        scheduler.requires_tp_work_fanout = True
+        follower_queue: queue.Queue = queue.Queue()
+        tp_fanout = TPLeaderFanout(
+            "thinker",
+            follower_work_queues=[follower_queue],
+            follower_abort_queues=[],
+        )
+        stage_obj = make_stage(
+            name="thinker",
+            role="leader",
+            scheduler=scheduler,
+            relay=relay,
+            tp_fanout=tp_fanout,
+        )
+
+        await stage_obj._execute(payload)
+
+        follower_msg = follower_queue.get_nowait()
+        assert is_tensor_ref_dict(follower_msg.data.data["video_embeds"])
+
+        scheduled = scheduler.inbox.get_nowait()
+        assert torch.equal(scheduled.data.data["video_embeds"], tensor)
+
+    asyncio.run(_run())
+
+
+def test_send_to_stage_does_not_block_on_externalized_tensor_ref_blob(
+    monkeypatch,
+) -> None:
+    """The small envelope op completes without waiting on the deferred blob op."""
+    monkeypatch.setenv("SGLANG_OMNI_ENABLE_TENSOR_REFS", "1")
+    monkeypatch.setenv(
+        "SGLANG_OMNI_TENSOR_REF_EDGES", "image_encoder:mm_aggregate:thinker"
+    )
+    monkeypatch.setenv("SGLANG_OMNI_TENSOR_REF_PATHS", "big")
+    monkeypatch.setenv("SGLANG_OMNI_TENSOR_REF_THRESHOLD_MB", "0")
+
+    async def _run() -> None:
+        gate = asyncio.Event()
+
+        class GatedRelay(FakeRelay):
+            async def put_async(self, tensor, request_id=None, dst_rank=None):
+                op = await super().put_async(
+                    tensor, request_id=request_id, dst_rank=dst_rank
+                )
+                if request_id and ":tensor_ref:" in request_id:
+                    real_wait = op.wait_for_completion
+
+                    async def gated_wait(timeout: float = 30.0):
+                        await gate.wait()
+                        await real_wait(timeout=timeout)
+
+                    op.wait_for_completion = gated_wait
+                return op
+
+        relay = GatedRelay()
+        stage_obj = make_stage(
+            name="image_encoder",
+            endpoints={"mm_aggregate": "inproc://mm"},
+            relay=relay,
+        )
+        payload = make_stage_payload(request_id="req-1", data={"big": torch.randn(4)})
+
+        await asyncio.wait_for(
+            stage_obj._send_to_stage("req-1", "mm_aggregate", payload),
+            timeout=1.0,
+        )
+
+        assert len(relay_io._BACKGROUND_REF_TASKS) == 1
+        task = next(iter(relay_io._BACKGROUND_REF_TASKS))
+        gate.set()
+        await asyncio.wait_for(task, timeout=1.0)
+        await asyncio.sleep(0)
+        assert relay_io._BACKGROUND_REF_TASKS == set()
 
     asyncio.run(_run())
 

--- a/tests/unit_test/pipeline/test_stage.py
+++ b/tests/unit_test/pipeline/test_stage.py
@@ -464,6 +464,80 @@ def test_stage_abort_releases_tracked_unresolved_tensor_ref_payload() -> None:
     asyncio.run(_run())
 
 
+def test_stage_abort_preserves_tracked_refs_across_ref_free_fanin(monkeypatch) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_ENABLE_TENSOR_REFS", "1")
+
+    async def _run() -> None:
+        relay = FakeRelay()
+        tensor = torch.arange(8, dtype=torch.float32)
+        blob_metadata, blob_op = await relay_io.write_blob(relay, "req-1:blob", tensor)
+        await blob_op.wait_for_completion()
+        ref = TensorRef(
+            ref_id="req-1:blob",
+            request_id="req-1",
+            producer_stage="image_encoder",
+            consumer_stage="thinker",
+            path="video_embeds",
+            shape=tuple(tensor.shape),
+            dtype=str(tensor.dtype),
+            nbytes=tensor.numel() * tensor.element_size(),
+            blob_key="req-1:blob",
+            blob_metadata=blob_metadata,
+        )
+
+        def _merge(payloads):
+            image_payload = payloads["image_encoder"]
+            return make_stage_payload(
+                request_id="req-1",
+                data={"video_embeds": image_payload.data["video_embeds"]},
+            )
+
+        stage_obj = make_stage(
+            name="mm_aggregate",
+            relay=relay,
+            input_handler=AggregatedInput({"image_encoder", "preprocessing"}, _merge),
+        )
+        started_materialize = asyncio.Event()
+        release_materialize = asyncio.Event()
+        original_materialize = relay_io.materialize_payload_tensor_refs
+
+        async def _blocking_materialize(relay_arg, payload, *, current_stage):
+            started_materialize.set()
+            await release_materialize.wait()
+            return await original_materialize(
+                relay_arg, payload, current_stage=current_stage
+            )
+
+        monkeypatch.setattr(
+            relay_io, "materialize_payload_tensor_refs", _blocking_materialize
+        )
+        await stage_obj._receive_payload_from_stage(
+            "req-1",
+            "image_encoder",
+            make_stage_payload(
+                request_id="req-1", data={"video_embeds": ref.to_dict()}
+            ),
+        )
+        assert "req-1:blob" in relay.storage
+
+        second_payload = asyncio.create_task(
+            stage_obj._receive_payload_from_stage(
+                "req-1",
+                "preprocessing",
+                make_stage_payload(request_id="req-1", data={"plain": 1}),
+            )
+        )
+        await asyncio.wait_for(started_materialize.wait(), timeout=2.0)
+
+        stage_obj._on_abort("req-1")
+        assert "req-1:blob" not in relay.storage
+
+        release_materialize.set()
+        await asyncio.wait_for(second_payload, timeout=2.0)
+
+    asyncio.run(_run())
+
+
 def test_stage_relay_read_failure_completes_with_error() -> None:
     """Preserves failure reporting when a stage cannot read its relay payload."""
 

--- a/tests/unit_test/pipeline/test_stage.py
+++ b/tests/unit_test/pipeline/test_stage.py
@@ -296,7 +296,6 @@ def test_stage_execute_fanouts_unresolved_payload_before_materializing_refs(
             path="video_embeds",
             shape=tuple(tensor.shape),
             dtype=str(tensor.dtype),
-            device=str(tensor.device),
             nbytes=tensor.numel() * tensor.element_size(),
             blob_key="req-1:blob",
             blob_metadata=blob_metadata,

--- a/tests/unit_test/pipeline/test_stage.py
+++ b/tests/unit_test/pipeline/test_stage.py
@@ -14,7 +14,11 @@ from sglang_omni.pipeline.local_dispatch import LocalStageDispatcher
 from sglang_omni.pipeline.stage.input import AggregatedInput
 from sglang_omni.pipeline.stage.stream_queue import StreamQueue
 from sglang_omni.pipeline.stage_workers import StageLaunchConfig, _construct_stage
-from sglang_omni.pipeline.tensor_ref import TensorRef, is_tensor_ref_dict
+from sglang_omni.pipeline.tensor_ref import (
+    TensorRef,
+    TensorRefPolicy,
+    is_tensor_ref_dict,
+)
 from sglang_omni.pipeline.tp_control import TPLeaderFanout
 from sglang_omni.proto import DataReadyMessage
 from tests.unit_test.fixtures.pipeline_fakes import (
@@ -379,6 +383,83 @@ def test_send_to_stage_does_not_block_on_externalized_tensor_ref_blob(
         await asyncio.wait_for(task, timeout=1.0)
         await asyncio.sleep(0)
         assert relay_io._BACKGROUND_REF_TASKS == set()
+
+    asyncio.run(_run())
+
+
+def test_stage_discards_aborted_tensor_ref_payload_releases_blob() -> None:
+    async def _run() -> None:
+        relay = FakeRelay()
+        tensor = torch.arange(8, dtype=torch.float32)
+        payload = make_stage_payload(request_id="req-1", data={"video_embeds": tensor})
+        policy = TensorRefPolicy(
+            threshold_bytes=1,
+            from_stage="image_encoder",
+            to_stage="mm_aggregate",
+            consumer_stage="thinker",
+            path_allowlist=("video_embeds",),
+        )
+        metadata, op = await relay_io.write_payload(
+            relay,
+            payload.request_id,
+            payload,
+            from_stage="image_encoder",
+            to_stage="mm_aggregate",
+            tensor_ref_policy=policy,
+        )
+        await op.wait_for_completion()
+        blob_key = metadata["tensor_ref_blobs"][0]["blob_key"]
+        assert blob_key in relay.storage
+
+        stage_obj = make_stage(name="mm_aggregate", relay=relay)
+        stage_obj._record_aborted_request_id("req-1")
+        await stage_obj._on_data_ready(
+            DataReadyMessage("req-1", "image_encoder", "mm_aggregate", metadata)
+        )
+
+        assert blob_key not in relay.storage
+
+        for task in list(relay_io._BACKGROUND_REF_TASKS):
+            await task
+
+    asyncio.run(_run())
+
+
+def test_stage_abort_releases_tracked_unresolved_tensor_ref_payload() -> None:
+    async def _run() -> None:
+        relay = FakeRelay()
+        tensor = torch.arange(8, dtype=torch.float32)
+        payload = make_stage_payload(request_id="req-1", data={"video_embeds": tensor})
+        policy = TensorRefPolicy(
+            threshold_bytes=1,
+            from_stage="image_encoder",
+            to_stage="mm_aggregate",
+            consumer_stage="thinker",
+            path_allowlist=("video_embeds",),
+        )
+        metadata, op = await relay_io.write_payload(
+            relay,
+            payload.request_id,
+            payload,
+            from_stage="image_encoder",
+            to_stage="mm_aggregate",
+            tensor_ref_policy=policy,
+        )
+        await op.wait_for_completion()
+        blob_key = metadata["tensor_ref_blobs"][0]["blob_key"]
+        mid_payload = await relay_io.read_payload(relay, payload.request_id, metadata)
+        assert blob_key in relay.storage
+
+        stage_obj = make_stage(name="mm_aggregate", relay=relay)
+        await stage_obj._receive_payload_from_stage(
+            "req-1", "image_encoder", mid_payload
+        )
+        stage_obj._on_abort("req-1")
+
+        assert blob_key not in relay.storage
+
+        for task in list(relay_io._BACKGROUND_REF_TASKS):
+            await task
 
     asyncio.run(_run())
 

--- a/tests/unit_test/pipeline/test_tensor_ref.py
+++ b/tests/unit_test/pipeline/test_tensor_ref.py
@@ -238,6 +238,46 @@ def test_write_payload_keeps_small_allowlisted_tensor_inline_with_policy() -> No
     asyncio.run(_run())
 
 
+def test_release_tensor_ref_blobs_from_metadata_drops_unconsumed_blob() -> None:
+    async def _run() -> None:
+        relay = FakeRelay()
+        tensor = torch.arange(8, dtype=torch.float32)
+        payload = make_stage_payload(
+            request_id="req-1",
+            data={"encoder_outs": {"image_encoder": {"video_embeds": tensor}}},
+        )
+        policy = TensorRefPolicy(
+            threshold_bytes=1,
+            from_stage="image_encoder",
+            to_stage="mm_aggregate",
+            consumer_stage="thinker",
+            path_allowlist=("video_embeds",),
+        )
+
+        metadata, op = await relay_io.write_payload(
+            relay,
+            payload.request_id,
+            payload,
+            from_stage="image_encoder",
+            to_stage="mm_aggregate",
+            tensor_ref_policy=policy,
+        )
+        await op.wait_for_completion()
+
+        ref_blob = metadata["tensor_ref_blobs"][0]
+        blob_key = ref_blob["blob_key"]
+        assert blob_key in relay.storage
+
+        released = relay_io.release_tensor_ref_blobs_from_metadata(relay, metadata)
+        assert released == 1
+        assert blob_key not in relay.storage
+
+        for task in list(relay_io._BACKGROUND_REF_TASKS):
+            await task
+
+    asyncio.run(_run())
+
+
 def test_destructive_relay_blob_read_is_single_use() -> None:
     """A blob read is destructive on the SHM backend (unlink-on-read): the first
     resolve succeeds, a second independent resolve of the same blob fails. This

--- a/tests/unit_test/pipeline/test_tensor_ref.py
+++ b/tests/unit_test/pipeline/test_tensor_ref.py
@@ -15,7 +15,11 @@ from sglang_omni.pipeline.tensor_ref import (
     tensor_ref_numel,
     tensor_refs_enabled,
 )
-from tests.unit_test.fixtures.pipeline_fakes import FakeRelay, make_stage_payload
+from tests.unit_test.fixtures.pipeline_fakes import (
+    DestructiveFakeRelay,
+    FakeRelay,
+    make_stage_payload,
+)
 
 
 def _make_ref(**overrides) -> TensorRef:
@@ -191,5 +195,30 @@ def test_write_payload_without_policy_is_unchanged() -> None:
         assert "tensor_ref_stats" not in metadata
         restored = await relay_io.read_payload(relay, payload.request_id, metadata)
         assert torch.equal(restored.data["x"], payload.data["x"])
+
+    asyncio.run(_run())
+
+
+def test_destructive_relay_blob_read_is_single_use() -> None:
+    """A blob read is destructive on the SHM backend (unlink-on-read): the first
+    resolve succeeds, a second independent resolve of the same blob fails. This
+    is why a TensorRef consumer MUST resolve exactly once -- the thinker
+    (OmniScheduler, requires_tp_work_fanout=False) resolves once on the leader;
+    a requires_tp_work_fanout=True consumer would double-unlink and crash.
+    """
+
+    async def _run() -> None:
+        relay = DestructiveFakeRelay()
+        tensor = torch.arange(8, dtype=torch.float32)
+        metadata, op = await relay_io.write_blob(relay, "req-1:blob", tensor)
+        await op.wait_for_completion()
+
+        # First (sole / leader) resolve succeeds.
+        first = await relay_io.read_blob(relay, "req-1:blob", metadata)
+        assert torch.equal(first, tensor)
+
+        # A second independent resolve of the same blob crashes.
+        with pytest.raises(RuntimeError):
+            await relay_io.read_blob(relay, "req-1:blob", metadata)
 
     asyncio.run(_run())

--- a/tests/unit_test/pipeline/test_tensor_ref.py
+++ b/tests/unit_test/pipeline/test_tensor_ref.py
@@ -31,7 +31,6 @@ def _make_ref(**overrides) -> TensorRef:
         path="encoder_outs.image_encoder.video_embeds",
         shape=(2, 3),
         dtype="torch.float32",
-        device="cuda:0",
         nbytes=24,
         blob_key="req-1:tensor_ref:image_encoder:mm_aggregate:abc:video_embeds",
         blob_metadata={"relay_info": {}, "tensor_shape": [2, 3]},

--- a/tests/unit_test/pipeline/test_tensor_ref.py
+++ b/tests/unit_test/pipeline/test_tensor_ref.py
@@ -63,8 +63,8 @@ def test_policy_should_externalize_respects_allowlist_and_threshold() -> None:
         consumer_stage="thinker",
         path_allowlist=("video_embeds",),
     )
-    big = torch.zeros(32, dtype=torch.float32)  # 128 bytes
-    small = torch.zeros(4, dtype=torch.float32)  # 16 bytes
+    big = torch.zeros(32, dtype=torch.float32)
+    small = torch.zeros(4, dtype=torch.float32)
 
     assert policy.should_externalize("encoder_outs.image_encoder.video_embeds", big)
     assert not policy.should_externalize(
@@ -131,7 +131,6 @@ async def _write_and_read_mid_payload(
     video_embeds = mid_payload.data["encoder_outs"]["image_encoder"]["video_embeds"]
     assert is_tensor_ref_dict(video_embeds)
 
-    # Let the deferred blob-publish op settle before reading it back.
     for task in list(relay_io._BACKGROUND_REF_TASKS):
         await task
 
@@ -168,7 +167,6 @@ def test_materialize_tensor_refs_materialize_all_overrides_consumer_stage() -> N
         tensor = torch.arange(8, dtype=torch.float32)
         mid_payload, original = await _write_and_read_mid_payload(relay, tensor)
 
-        # mm_aggregate is not the declared consumer, but materialize_all forces it.
         resolved_data = await relay_io.materialize_tensor_refs(
             relay,
             mid_payload.data,
@@ -212,11 +210,9 @@ def test_destructive_relay_blob_read_is_single_use() -> None:
         metadata, op = await relay_io.write_blob(relay, "req-1:blob", tensor)
         await op.wait_for_completion()
 
-        # First (sole / leader) resolve succeeds.
         first = await relay_io.read_blob(relay, "req-1:blob", metadata)
         assert torch.equal(first, tensor)
 
-        # A second independent resolve of the same blob crashes.
         with pytest.raises(RuntimeError):
             await relay_io.read_blob(relay, "req-1:blob", metadata)
 

--- a/tests/unit_test/pipeline/test_tensor_ref.py
+++ b/tests/unit_test/pipeline/test_tensor_ref.py
@@ -98,7 +98,8 @@ def test_policy_from_env_requires_declared_edge(monkeypatch) -> None:
     )
     assert policy is not None
     assert policy.consumer_stage == "thinker"
-    assert policy.threshold_bytes == int(DEFAULT_TENSOR_REF_THRESHOLD_MB * 1024 * 1024)
+    assert DEFAULT_TENSOR_REF_THRESHOLD_MB == 2.0
+    assert policy.threshold_bytes == 2 * 1024 * 1024
     assert policy.path_allowlist == DEFAULT_TENSOR_REF_PATHS
 
 

--- a/tests/unit_test/pipeline/test_tensor_ref.py
+++ b/tests/unit_test/pipeline/test_tensor_ref.py
@@ -9,6 +9,8 @@ import torch
 
 from sglang_omni.pipeline import relay_io
 from sglang_omni.pipeline.tensor_ref import (
+    DEFAULT_TENSOR_REF_PATHS,
+    DEFAULT_TENSOR_REF_THRESHOLD_MB,
     TensorRef,
     TensorRefPolicy,
     is_tensor_ref_dict,
@@ -96,8 +98,8 @@ def test_policy_from_env_requires_declared_edge(monkeypatch) -> None:
     )
     assert policy is not None
     assert policy.consumer_stage == "thinker"
-    assert policy.threshold_bytes == 8 * 1024 * 1024
-    assert "video_embeds" in policy.path_allowlist
+    assert policy.threshold_bytes == int(DEFAULT_TENSOR_REF_THRESHOLD_MB * 1024 * 1024)
+    assert policy.path_allowlist == DEFAULT_TENSOR_REF_PATHS
 
 
 async def _write_and_read_mid_payload(
@@ -192,6 +194,45 @@ def test_write_payload_without_policy_is_unchanged() -> None:
         assert "tensor_ref_stats" not in metadata
         restored = await relay_io.read_payload(relay, payload.request_id, metadata)
         assert torch.equal(restored.data["x"], payload.data["x"])
+
+    asyncio.run(_run())
+
+
+def test_write_payload_keeps_small_allowlisted_tensor_inline_with_policy() -> None:
+    async def _run() -> None:
+        relay = FakeRelay()
+        tensor = torch.arange(4, dtype=torch.float32)
+        payload = make_stage_payload(
+            request_id="req-1",
+            data={"encoder_outs": {"image_encoder": {"video_embeds": tensor}}},
+        )
+        policy = TensorRefPolicy(
+            threshold_bytes=tensor.numel() * tensor.element_size() + 1,
+            from_stage="image_encoder",
+            to_stage="mm_aggregate",
+            consumer_stage="thinker",
+            path_allowlist=("video_embeds",),
+        )
+
+        metadata, op = await relay_io.write_payload(
+            relay,
+            payload.request_id,
+            payload,
+            from_stage="image_encoder",
+            to_stage="mm_aggregate",
+            tensor_ref_policy=policy,
+        )
+        await op.wait_for_completion()
+
+        stats = metadata["tensor_ref_stats"]
+        assert stats["ref_count"] == 0
+        assert stats["ref_bytes"] == 0
+        assert stats["inline_tensor_bytes"] == tensor.numel() * tensor.element_size()
+
+        restored = await relay_io.read_payload(relay, payload.request_id, metadata)
+        value = restored.data["encoder_outs"]["image_encoder"]["video_embeds"]
+        assert torch.equal(value, tensor)
+        assert not is_tensor_ref_dict(value)
 
     asyncio.run(_run())
 

--- a/tests/unit_test/pipeline/test_tensor_ref.py
+++ b/tests/unit_test/pipeline/test_tensor_ref.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+import torch
+
+from sglang_omni.pipeline import relay_io
+from sglang_omni.pipeline.tensor_ref import (
+    TensorRef,
+    TensorRefPolicy,
+    is_tensor_ref_dict,
+    tensor_ref_numel,
+    tensor_refs_enabled,
+)
+from tests.unit_test.fixtures.pipeline_fakes import FakeRelay, make_stage_payload
+
+
+def _make_ref(**overrides) -> TensorRef:
+    defaults = dict(
+        ref_id="req-1:tensor_ref:image_encoder:mm_aggregate:abc:video_embeds",
+        request_id="req-1",
+        producer_stage="image_encoder",
+        consumer_stage="thinker",
+        path="encoder_outs.image_encoder.video_embeds",
+        shape=(2, 3),
+        dtype="torch.float32",
+        device="cuda:0",
+        nbytes=24,
+        blob_key="req-1:tensor_ref:image_encoder:mm_aggregate:abc:video_embeds",
+        blob_metadata={"relay_info": {}, "tensor_shape": [2, 3]},
+    )
+    defaults.update(overrides)
+    return TensorRef(**defaults)
+
+
+def test_tensor_ref_to_dict_from_dict_round_trip() -> None:
+    ref = _make_ref()
+    restored = TensorRef.from_dict(ref.to_dict())
+    assert restored == ref
+
+
+def test_is_tensor_ref_dict_and_numel() -> None:
+    ref = _make_ref()
+    ref_dict = ref.to_dict()
+    assert is_tensor_ref_dict(ref_dict)
+    assert not is_tensor_ref_dict({"shape": [1]})
+    assert not is_tensor_ref_dict(torch.zeros(1))
+    assert tensor_ref_numel(ref_dict) == 6
+    assert tensor_ref_numel(ref) == 6
+
+
+def test_policy_should_externalize_respects_allowlist_and_threshold() -> None:
+    policy = TensorRefPolicy(
+        threshold_bytes=64,
+        from_stage="image_encoder",
+        to_stage="mm_aggregate",
+        consumer_stage="thinker",
+        path_allowlist=("video_embeds",),
+    )
+    big = torch.zeros(32, dtype=torch.float32)  # 128 bytes
+    small = torch.zeros(4, dtype=torch.float32)  # 16 bytes
+
+    assert policy.should_externalize("encoder_outs.image_encoder.video_embeds", big)
+    assert not policy.should_externalize(
+        "encoder_outs.image_encoder.video_embeds", small
+    )
+    assert not policy.should_externalize("encoder_outs.image_encoder.image_embeds", big)
+
+
+def test_policy_from_env_disabled_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("SGLANG_OMNI_ENABLE_TENSOR_REFS", raising=False)
+    assert not tensor_refs_enabled()
+    assert (
+        TensorRefPolicy.from_env(from_stage="image_encoder", to_stage="mm_aggregate")
+        is None
+    )
+
+
+def test_policy_from_env_requires_declared_edge(monkeypatch) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_ENABLE_TENSOR_REFS", "1")
+    monkeypatch.setenv(
+        "SGLANG_OMNI_TENSOR_REF_EDGES", "image_encoder:mm_aggregate:thinker"
+    )
+    assert tensor_refs_enabled()
+    assert (
+        TensorRefPolicy.from_env(from_stage="mm_aggregate", to_stage="thinker") is None
+    )
+    policy = TensorRefPolicy.from_env(
+        from_stage="image_encoder", to_stage="mm_aggregate"
+    )
+    assert policy is not None
+    assert policy.consumer_stage == "thinker"
+    assert policy.threshold_bytes == 8 * 1024 * 1024
+    assert "video_embeds" in policy.path_allowlist
+
+
+async def _write_and_read_mid_payload(
+    relay: FakeRelay, tensor: torch.Tensor
+) -> tuple[relay_io.StagePayload, torch.Tensor]:
+    payload = make_stage_payload(
+        request_id="req-1",
+        data={"encoder_outs": {"image_encoder": {"video_embeds": tensor}}},
+    )
+    policy = TensorRefPolicy(
+        threshold_bytes=1,
+        from_stage="image_encoder",
+        to_stage="mm_aggregate",
+        consumer_stage="thinker",
+        path_allowlist=("video_embeds",),
+    )
+
+    metadata, op = await relay_io.write_payload(
+        relay,
+        payload.request_id,
+        payload,
+        from_stage="image_encoder",
+        to_stage="mm_aggregate",
+        tensor_ref_policy=policy,
+    )
+    await op.wait_for_completion()
+    assert metadata["tensor_ref_stats"]["ref_count"] == 1
+    assert metadata["tensor_ref_stats"]["ref_bytes"] == tensor.numel() * 4
+
+    mid_payload = await relay_io.read_payload(relay, payload.request_id, metadata)
+    video_embeds = mid_payload.data["encoder_outs"]["image_encoder"]["video_embeds"]
+    assert is_tensor_ref_dict(video_embeds)
+
+    # Let the deferred blob-publish op settle before reading it back.
+    for task in list(relay_io._BACKGROUND_REF_TASKS):
+        await task
+
+    return mid_payload, tensor
+
+
+@pytest.mark.parametrize(
+    "current_stage,expect_resolved", [("thinker", True), ("mm_aggregate", False)]
+)
+def test_materialize_payload_tensor_refs_resolves_only_for_consumer_stage(
+    current_stage, expect_resolved
+) -> None:
+    async def _run() -> None:
+        relay = FakeRelay()
+        tensor = torch.arange(8, dtype=torch.float32)
+        mid_payload, original = await _write_and_read_mid_payload(relay, tensor)
+
+        resolved_payload = await relay_io.materialize_payload_tensor_refs(
+            relay, mid_payload, current_stage=current_stage
+        )
+        value = resolved_payload.data["encoder_outs"]["image_encoder"]["video_embeds"]
+
+        if expect_resolved:
+            assert torch.equal(value, original)
+        else:
+            assert is_tensor_ref_dict(value)
+
+    asyncio.run(_run())
+
+
+def test_materialize_tensor_refs_materialize_all_overrides_consumer_stage() -> None:
+    async def _run() -> None:
+        relay = FakeRelay()
+        tensor = torch.arange(8, dtype=torch.float32)
+        mid_payload, original = await _write_and_read_mid_payload(relay, tensor)
+
+        # mm_aggregate is not the declared consumer, but materialize_all forces it.
+        resolved_data = await relay_io.materialize_tensor_refs(
+            relay,
+            mid_payload.data,
+            current_stage="mm_aggregate",
+            materialize_all=True,
+        )
+        value = resolved_data["encoder_outs"]["image_encoder"]["video_embeds"]
+        assert torch.equal(value, original)
+
+    asyncio.run(_run())
+
+
+def test_write_payload_without_policy_is_unchanged() -> None:
+    """Default call sites (no tensor_ref_policy) keep today's exact wire format."""
+
+    async def _run() -> None:
+        relay = FakeRelay()
+        payload = make_stage_payload(
+            request_id="req-1", data={"x": torch.arange(4, dtype=torch.float32)}
+        )
+        metadata, op = await relay_io.write_payload(relay, payload.request_id, payload)
+        await op.wait_for_completion()
+        assert "tensor_ref_stats" not in metadata
+        restored = await relay_io.read_payload(relay, payload.request_id, metadata)
+        assert torch.equal(restored.data["x"], payload.data["x"])
+
+    asyncio.run(_run())

--- a/tests/unit_test/qwen3_omni/test_pipeline.py
+++ b/tests/unit_test/qwen3_omni/test_pipeline.py
@@ -1133,7 +1133,6 @@ def test_qwen_merge_preserves_unresolved_video_tensor_ref() -> None:
         path="encoder_outs.image_encoder.video_embeds",
         shape=(4, 8),
         dtype="torch.bfloat16",
-        device="cuda:0",
         nbytes=4 * 8 * 2,
         blob_key="req-qwen:tensor_ref:image_encoder:mm_aggregate:abc:video_embeds",
         blob_metadata={"relay_info": {}, "tensor_shape": [4, 8]},

--- a/tests/unit_test/qwen3_omni/test_pipeline.py
+++ b/tests/unit_test/qwen3_omni/test_pipeline.py
@@ -43,6 +43,7 @@ from sglang_omni.models.qwen3_omni.request_builders import (
     resolve_mm_aggregate_wait_sources,
     resolve_preprocessing_next_stages,
 )
+from sglang_omni.pipeline.tensor_ref import TensorRef, is_tensor_ref_dict
 from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.scheduling.sglang_backend.server_args_builder import (
     apply_encoder_mem_reserve,
@@ -1120,6 +1121,38 @@ def test_qwen_mm_aggregate_keeps_lightweight_inputs_and_prunes_after_merge() -> 
         "video": "video:image-cache",
         "audio": "audio:audio-cache",
     }
+
+
+def test_qwen_merge_preserves_unresolved_video_tensor_ref() -> None:
+    """A lazily-externalized video_embeds ref survives merge unresolved."""
+    ref = TensorRef(
+        ref_id="req-qwen:tensor_ref:image_encoder:mm_aggregate:abc:video_embeds",
+        request_id="req-qwen",
+        producer_stage="image_encoder",
+        consumer_stage="thinker",
+        path="encoder_outs.image_encoder.video_embeds",
+        shape=(4, 8),
+        dtype="torch.bfloat16",
+        device="cuda:0",
+        nbytes=4 * 8 * 2,
+        blob_key="req-qwen:tensor_ref:image_encoder:mm_aggregate:abc:video_embeds",
+        blob_metadata={"relay_info": {}, "tensor_shape": [4, 8]},
+    )
+    image_state = Qwen3OmniPipelineState(
+        encoder_outs={"image_encoder": {"video_embeds": ref.to_dict()}}
+    )
+
+    merged = merge_for_thinker(
+        {
+            "preprocessing": make_qwen_payload(make_qwen_state()),
+            "image_encoder": make_qwen_payload(image_state),
+        }
+    )
+    merged_state = Qwen3OmniPipelineState.from_dict(merged.data)
+
+    video_embeds = merged_state.thinker_inputs["model_inputs"]["video_embeds"]
+    assert is_tensor_ref_dict(video_embeds)
+    assert video_embeds == ref.to_dict()
 
 
 def test_qwen_thinker_request_and_decode_contracts() -> None:

--- a/tests/unit_test/qwen3_omni/test_streaming.py
+++ b/tests/unit_test/qwen3_omni/test_streaming.py
@@ -654,6 +654,8 @@ def _bare_stage(*, is_terminal: bool, owns_io: bool = True) -> Stage:
     s._first_stream_chunk_seen = set()
     s._local_stream_targets = {}
     s._nonlocal_stream_targets = {}
+    s._unresolved_tensor_refs = {}
+    s.relay = SimpleNamespace()
     s.input_handler = SimpleNamespace(cancel=lambda request_id: None)
     s.scheduler = SimpleNamespace(abort=lambda request_id: None)
     s.control_plane = SimpleNamespace(completions=[])


### PR DESCRIPTION
## Motivation (#797)

Stage 11's latency is dominated by inter-stage **delivery** of the large video embeddings, not compute. Per the #797 investigation (Updates 7-8), the thinker idles ~140s with a full prefill queue while the video embeddings are **materialized at `mm_aggregate` and re-serialized to the thinker** over the relay — two full round-trips of the big tensor for a stage (`mm_aggregate`) that only forwards it.

## What this does

Adds an **env-gated lazy `TensorRef` path** for large allowlisted tensors:

- `image_encoder` publishes the tensor to the relay **once** and emits a small reference dict.
- `mm_aggregate` merges/forwards the ref **without materializing** it (the ref dict passes through the existing `write_payload`/`extract_tensors` untouched, since it has no tensor leaves).
- the `thinker` resolves the ref **once**, right before its scheduler.

Default behavior is **unchanged** unless `SGLANG_OMNI_ENABLE_TENSOR_REFS=1`.

```
SGLANG_OMNI_ENABLE_TENSOR_REFS=1
SGLANG_OMNI_TENSOR_REF_EDGES=image_encoder:mm_aggregate:thinker
SGLANG_OMNI_TENSOR_REF_THRESHOLD_MB=8
SGLANG_OMNI_TENSOR_REF_PATHS=video_embeds,deepstack_visual_embeds_image,deepstack_visual_embeds_video
```

## Implementation

- **`sglang_omni/pipeline/tensor_ref.py`** (new): `TensorRef` + env-driven `TensorRefPolicy` (`from_env` returns `None` — fully inert — unless enabled and the `(from,to)` edge is declared).
- **`relay_io.py`**: `write_payload` gains optional `from_stage/to_stage/tensor_ref_policy` (defaulted, so existing call sites are byte-for-byte unchanged); allowlisted large tensors are externalized via the existing `write_blob`, with the blob op tracked as a background task (the consumer stage, not this hop, reads it). `materialize_tensor_refs` resolves a ref only at its declared `consumer_stage` and is identity-preserving (ref-free payloads are returned as-is, no per-stage container churn).
- **`stage/runtime.py`**: `_execute` materializes refs **after** TP fanout (followers materialize on their own relay/device); `_send_to_stage` wires the per-edge policy and surfaces `tensor_ref_stats` into the `stage_hop_sent` trace event.
- **`qwen3_omni/merge.py`**: `_non_empty` recognizes `TensorRef` dicts as non-empty so `merge_for_thinker` keeps forwarding them.

## Results (Stage 11 Video-AMME Talker, FP8 thinker TP=2)

H100 2×GPU, SHM relay, 10 samples / concurrency 16, prompt-tokens-mean 14444 every run:

| TensorRef | latency_mean_s | accuracy | thinker stall |
|---|---|---|---|
| OFF (cold) | 160.7 | 0.50 | ~124 s |
| OFF (warm) | 179.3 | 0.50 | ~140 s |
| **ON** | **37.3** | 0.50 | none |
| **ON** | **36.2** | 0.50 | none |

**~4.5× lower `latency_mean_s`, accuracy unchanged.** Verified not a warm-cache artifact: both OFF runs (one cold, one warm) reproduce the #797 thinker stall (`#queue-req 9`, ~2 min of silence between the first request's prefill chunks); both ON runs eliminate it. Engagement confirmed in-log (`tensor_ref active: externalizing video_embeds (55.0 MiB) on edge image_encoder->mm_aggregate`).

## Tests

`tests/unit_test/pipeline/test_tensor_ref.py` (new) + additions to `test_stage.py` and `test_pipeline.py`: relay round-trip, consumer-stage gating, TP-fanout ordering (followers get the unresolved ref), deferred-blob-op is not awaited inline, and Qwen merge ref pass-through. Full `tests/unit_test` suite green (only pre-existing shared-host `/tmp` permission failures remain).

## Not in scope / known limits

- No default CUDA-IPC full-payload path (possible follow-up once lifecycle/release is in place).
- No active release-on-abort: an aborted in-flight ref leaks its SHM segment / self-heals its NIXL credit via timeout (accepted for v1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Acknowledgements

Thanks to @MelodyyyYin for the earlier exploration. Although that path was not merged, it helped rule out an incorrect optimization direction and shaped this final approach.

Co-authored-by: Melody Yin <melodyyin31@gmail.com>