### PR TITLE
T2a: reusable reference-audio encode (LRU + single-flight) + moss_local migration

### DIFF
--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -3,12 +3,8 @@
 
 from __future__ import annotations
 
-import concurrent.futures
 import logging
 import os
-import queue
-import threading
-import time
 from typing import Any
 
 import torch
@@ -33,8 +29,11 @@ from sglang_omni.models.moss_tts_local.streaming_vocoder import (
 from sglang_omni.preprocessing.cache_key import (
     reference_path_cache_key as _reference_path_cache_key,
 )
+from sglang_omni.scheduling.reference_encoder import (
+    BatchedReferenceEncoder as _SharedBatchedReferenceEncoder,
+)
+from sglang_omni.scheduling.reference_encoder import ReferenceEncodeCache
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
-from sglang_omni.scheduling.stage_cache import StageOutputCache
 
 logger = logging.getLogger(__name__)
 
@@ -130,13 +129,18 @@ class _BatchedReferenceEncoder:
         max_batch_wait_ms: int = 4,
     ) -> None:
         self._processor = processor
-        self._max_batch_size = max(int(max_batch_size), 1)
-        self._max_wait_s = max(float(max_batch_wait_ms), 0.0) / 1000.0
-        self._queue: queue.Queue[tuple[str, concurrent.futures.Future]] = queue.Queue()
-        self._thread = threading.Thread(
-            target=self._worker, name="moss-local-ref-encode", daemon=True
+        self._encoder = _SharedBatchedReferenceEncoder(
+            lambda paths: self._processor.encode_audios_from_path(paths),
+            single_encode_fn=lambda path: self._processor.encode_audios_from_path(
+                [path]
+            )[0],
+            validate_fn=self._check_reference_duration,
+            key_fn=str,
+            max_batch_size=max_batch_size,
+            max_batch_wait_ms=max_batch_wait_ms,
+            encode_timeout_s=self.ENCODE_TIMEOUT_S,
+            worker_name="moss-local-ref-encode",
         )
-        self._thread.start()
 
     @classmethod
     def _check_reference_duration(cls, path: str) -> None:
@@ -155,62 +159,11 @@ class _BatchedReferenceEncoder:
 
     def encode(self, path: str) -> torch.Tensor:
         """Encode one reference file; blocks until its batch completes."""
-        path = str(path)
-        self._check_reference_duration(path)
-        future: concurrent.futures.Future = concurrent.futures.Future()
-        self._queue.put((path, future))
-        return future.result(timeout=self.ENCODE_TIMEOUT_S)
-
-    def _drain_batch(self) -> list[tuple[str, concurrent.futures.Future]]:
-        batch = [self._queue.get()]
-        while len(batch) < self._max_batch_size:
-            try:
-                if self._max_wait_s > 0:
-                    batch.append(self._queue.get(timeout=self._max_wait_s))
-                else:
-                    batch.append(self._queue.get_nowait())
-            except queue.Empty:
-                break
-        return batch
-
-    def _worker(self) -> None:
-        while True:
-            batch = self._drain_batch()
-            unique_paths = list(dict.fromkeys(path for path, _ in batch))
-            results: dict[str, Any] = {}
-            try:
-                encoded = self._processor.encode_audios_from_path(unique_paths)
-                results = dict(zip(unique_paths, encoded))
-            except Exception:
-                logger.exception(
-                    "MOSS-TTS Local batched reference encode failed; "
-                    "retrying per item"
-                )
-                for path in unique_paths:
-                    try:
-                        results[path] = self._processor.encode_audios_from_path([path])[
-                            0
-                        ]
-                    except Exception as exc:
-                        results[path] = exc
-            for path, future in batch:
-                outcome = results.get(path)
-                if isinstance(outcome, Exception):
-                    # Fresh exception per future: a shared instance would be
-                    # mutated concurrently by every waiter's traceback raise.
-                    future.set_exception(
-                        RuntimeError(f"reference encode failed for {path}: {outcome}")
-                    )
-                elif outcome is None:
-                    future.set_exception(
-                        RuntimeError(f"reference encode produced no codes: {path}")
-                    )
-                else:
-                    future.set_result(outcome)
+        return self._encoder.encode(str(path))
 
 
 class CachedReferenceEncoder:
-    """Content-addressed LRU cache + single-flight dedup in front of _BatchedReferenceEncoder.
+    """Content-addressed LRU cache in front of _BatchedReferenceEncoder.
 
     Every path (miss, hit, follower) returns an independent CPU long tensor, so
     downstream sees one device/dtype regardless of cache temperature.
@@ -234,17 +187,27 @@ class CachedReferenceEncoder:
         if max_bytes < 1:
             raise ValueError(f"ref_audio_cache_max_bytes must be >= 1, got {max_bytes}")
         self._encoder = encoder
-        self._cache = StageOutputCache(
-            max_size=max_items,
+        self._store = ReferenceEncodeCache(
+            max_items=max_items,
             max_bytes=max_bytes,
             cache_device="cpu",
+            store_fn=self._store_codes,
+            load_fn=self._load_codes,
+            timeout_s=_BatchedReferenceEncoder.ENCODE_TIMEOUT_S + 10,
+            log_interval_s=self.LOG_INTERVAL_S,
+            log_prefix="MOSS-TTS Local ref cache",
         )
-        self._lock = threading.Lock()
-        self._inflight: dict[str, concurrent.futures.Future] = {}
-        self._hits = 0
-        self._misses = 0
-        self._merged = 0
-        self._last_log_time: float = 0.0
+        # Compatibility for existing tests and debugging probes.
+        self._cache = self._store.cache
+        self._inflight = self._store.inflight
+
+    @staticmethod
+    def _store_codes(result: torch.Tensor) -> torch.Tensor:
+        return result.detach().to("cpu", dtype=torch.int32)
+
+    @staticmethod
+    def _load_codes(stored: torch.Tensor) -> torch.Tensor:
+        return stored.clone().to(torch.long)
 
     def encode(self, path: str) -> torch.Tensor:
         path = str(path)
@@ -274,77 +237,11 @@ class CachedReferenceEncoder:
         is evaluated outside the lock and gates the put (TOCTOU guard for file
         paths).
         """
-        leader_fut: concurrent.futures.Future | None = None
-        follower_fut: concurrent.futures.Future | None = None
-
-        with self._lock:
-            stored = self._cache.get(key)
-            if stored is not None:
-                self._hits += 1
-            elif key in self._inflight:
-                self._merged += 1
-                follower_fut = self._inflight[key]
-            else:
-                self._misses += 1
-                leader_fut = concurrent.futures.Future()
-                self._inflight[key] = leader_fut
-
-        if stored is not None:
-            # Note(Jiaxin): clone on hit so callers can't mutate the shared entry.
-            self._maybe_log()
-            return stored.clone().to(torch.long)
-
-        if follower_fut is not None:
-            # Note(Jiaxin): each follower raises a FRESH RuntimeError — sharing one
-            # exception instance lets concurrent re-raises corrupt its traceback
-            # (same lesson as _BatchedReferenceEncoder._worker).
-            timeout = _BatchedReferenceEncoder.ENCODE_TIMEOUT_S + 10
-            try:
-                stored = follower_fut.result(timeout=timeout)
-            except Exception as cause:
-                raise RuntimeError(
-                    f"reference encode failed for {desc}: {cause}"
-                ) from cause
-            return stored.clone().to(torch.long)
-
-        assert leader_fut is not None
-        try:
-            result = encode_fn()
-        except BaseException as exc:
-            with self._lock:
-                self._inflight.pop(key, None)
-            leader_fut.set_exception(exc)
-            raise
-
-        do_put = revalidate() if revalidate is not None else True
-        stored = result.detach().to("cpu", dtype=torch.int32)
-        with self._lock:
-            if do_put:
-                self._cache.put(key, stored)
-            self._inflight.pop(key, None)
-        leader_fut.set_result(stored)
-        self._maybe_log()
-        # CPU long like the hit path.
-        return stored.to(torch.long)
-
-    def _maybe_log(self) -> None:
-        now = time.monotonic()
-        if now - self._last_log_time < self.LOG_INTERVAL_S:
-            return
-        with self._lock:
-            if now - self._last_log_time < self.LOG_INTERVAL_S:
-                return
-            self._last_log_time = now
-            snapshot = (
-                self._hits,
-                self._misses,
-                self._merged,
-                len(self._cache._cache),
-                self._cache.current_bytes,
-            )
-        logger.info(
-            "MOSS-TTS Local ref cache: hits=%d misses=%d merged=%d entries=%d bytes=%d",
-            *snapshot,
+        return self._store.get_or_encode(
+            key,
+            encode_fn,
+            desc=desc,
+            revalidate=revalidate,
         )
 
     def encode_data_uri(self, ref_audio: str, *, processor: Any) -> torch.Tensor:
@@ -388,14 +285,7 @@ class CachedReferenceEncoder:
         return self._cached_encode(key, _encode, desc="data-URI")
 
     def stats(self) -> dict:
-        with self._lock:
-            return {
-                "hits": self._hits,
-                "misses": self._misses,
-                "merged": self._merged,
-                "entries": len(self._cache._cache),
-                "bytes": self._cache.current_bytes,
-            }
+        return self._store.stats()
 
 
 def create_preprocessing_executor(

--- a/sglang_omni/scheduling/reference_encoder.py
+++ b/sglang_omni/scheduling/reference_encoder.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import concurrent.futures
+import logging
+import queue
+import threading
+import time
+from collections.abc import Callable, Hashable, Sequence
+from typing import Any, Generic, TypeVar
+
+import torch
+
+from sglang_omni.scheduling.stage_cache import StageOutputCache
+
+InputT = TypeVar("InputT")
+OutputT = TypeVar("OutputT")
+StoredT = TypeVar("StoredT")
+
+logger = logging.getLogger(__name__)
+
+
+def _identity(value: Any) -> Any:
+    return value
+
+
+def _clone_tensor_values(value: Any) -> Any:
+    if isinstance(value, torch.Tensor):
+        return value.clone()
+    if isinstance(value, dict):
+        return {key: _clone_tensor_values(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return type(value)(_clone_tensor_values(item) for item in value)
+    return value
+
+
+class BatchedReferenceEncoder(Generic[InputT, OutputT]):
+    """Coalesce concurrent reference encodes into one batched worker call."""
+
+    def __init__(
+        self,
+        batch_encode_fn: Callable[[list[InputT]], Sequence[OutputT]],
+        *,
+        single_encode_fn: Callable[[InputT], OutputT] | None = None,
+        validate_fn: Callable[[InputT], None] | None = None,
+        key_fn: Callable[[InputT], Hashable] | None = None,
+        max_batch_size: int = 8,
+        max_batch_wait_ms: int = 4,
+        encode_timeout_s: float = 120.0,
+        worker_name: str = "reference-encode",
+    ) -> None:
+        self._batch_encode_fn = batch_encode_fn
+        self._single_encode_fn = single_encode_fn
+        self._validate_fn = validate_fn
+        self._key_fn = key_fn or (lambda item: item)  # type: ignore[return-value]
+        self._max_batch_size = max(int(max_batch_size), 1)
+        self._max_wait_s = max(float(max_batch_wait_ms), 0.0) / 1000.0
+        self._encode_timeout_s = float(encode_timeout_s)
+        self._queue: queue.Queue[tuple[InputT, concurrent.futures.Future[OutputT]]] = (
+            queue.Queue()
+        )
+        self._thread = threading.Thread(
+            target=self._worker, name=worker_name, daemon=True
+        )
+        self._thread.start()
+
+    def encode(self, item: InputT) -> OutputT:
+        if self._validate_fn is not None:
+            self._validate_fn(item)
+        future: concurrent.futures.Future[OutputT] = concurrent.futures.Future()
+        self._queue.put((item, future))
+        return future.result(timeout=self._encode_timeout_s)
+
+    def _drain_batch(
+        self,
+    ) -> list[tuple[InputT, concurrent.futures.Future[OutputT]]]:
+        batch = [self._queue.get()]
+        while len(batch) < self._max_batch_size:
+            try:
+                if self._max_wait_s > 0:
+                    batch.append(self._queue.get(timeout=self._max_wait_s))
+                else:
+                    batch.append(self._queue.get_nowait())
+            except queue.Empty:
+                break
+        return batch
+
+    def _worker(self) -> None:
+        while True:
+            batch = self._drain_batch()
+            unique_items: list[InputT] = []
+            unique_keys: list[Hashable] = []
+            seen: set[Hashable] = set()
+            for item, _ in batch:
+                key = self._key_fn(item)
+                if key in seen:
+                    continue
+                seen.add(key)
+                unique_items.append(item)
+                unique_keys.append(key)
+
+            results: dict[Hashable, OutputT | BaseException] = {}
+            try:
+                encoded = list(self._batch_encode_fn(unique_items))
+                if len(encoded) != len(unique_items):
+                    raise RuntimeError(
+                        "batched reference encode returned "
+                        f"{len(encoded)} results for {len(unique_items)} inputs"
+                    )
+                results = dict(zip(unique_keys, encoded))
+            except Exception:
+                logger.exception("Batched reference encode failed; retrying per item")
+                for key, item in zip(unique_keys, unique_items):
+                    try:
+                        results[key] = self._encode_single(item)
+                    except Exception as exc:
+                        results[key] = exc
+
+            for item, future in batch:
+                key = self._key_fn(item)
+                outcome = results.get(key)
+                if isinstance(outcome, BaseException):
+                    future.set_exception(
+                        RuntimeError(f"reference encode failed for {item}: {outcome}")
+                    )
+                elif outcome is None:
+                    future.set_exception(
+                        RuntimeError(f"reference encode produced no result: {item}")
+                    )
+                else:
+                    future.set_result(outcome)
+
+    def _encode_single(self, item: InputT) -> OutputT:
+        if self._single_encode_fn is not None:
+            return self._single_encode_fn(item)
+        encoded = list(self._batch_encode_fn([item]))
+        if len(encoded) != 1:
+            raise RuntimeError(
+                "single reference encode returned "
+                f"{len(encoded)} results for 1 input"
+            )
+        return encoded[0]
+
+
+class ReferenceEncodeCache(Generic[StoredT]):
+    """Content-addressed LRU cache with single-flight miss coalescing."""
+
+    def __init__(
+        self,
+        *,
+        max_items: int | None = 256,
+        max_bytes: int | None = 64 * 1024 * 1024,
+        cache_device: torch.device | str | None = "cpu",
+        size_fn: Callable[[Any], int] | None = None,
+        store_fn: Callable[[Any], StoredT] | None = None,
+        load_fn: Callable[[StoredT], Any] | None = None,
+        timeout_s: float = 130.0,
+        log_interval_s: float | None = None,
+        log_prefix: str | None = None,
+    ) -> None:
+        if max_items is not None and max_items < 1:
+            raise ValueError(f"max_items must be >= 1, got {max_items}")
+        if max_bytes is not None and max_bytes < 1:
+            raise ValueError(f"max_bytes must be >= 1, got {max_bytes}")
+        self._cache = StageOutputCache(
+            max_size=max_items,
+            max_bytes=max_bytes,
+            cache_device=cache_device,
+            size_fn=size_fn,
+        )
+        self._lock = threading.Lock()
+        self._inflight: dict[str, concurrent.futures.Future[StoredT]] = {}
+        self._store_fn = store_fn or _identity
+        self._load_fn = load_fn or _clone_tensor_values
+        self._timeout_s = float(timeout_s)
+        self._log_interval_s = log_interval_s
+        self._log_prefix = log_prefix
+        self._hits = 0
+        self._misses = 0
+        self._merged = 0
+        self._last_log_time = 0.0
+
+    @property
+    def cache(self) -> StageOutputCache:
+        return self._cache
+
+    @property
+    def inflight(self) -> dict[str, concurrent.futures.Future[StoredT]]:
+        return self._inflight
+
+    def get_or_encode(
+        self,
+        key: str | None,
+        encode_fn: Callable[[], Any],
+        *,
+        desc: str,
+        revalidate: Callable[[], bool] | None = None,
+    ) -> Any:
+        if key is None:
+            return self._load_fn(self._store_fn(encode_fn()))
+
+        key = str(key)
+        stored: StoredT | None = None
+        leader_fut: concurrent.futures.Future[StoredT] | None = None
+        follower_fut: concurrent.futures.Future[StoredT] | None = None
+
+        with self._lock:
+            stored = self._cache.get(key)
+            if stored is not None:
+                self._hits += 1
+            elif key in self._inflight:
+                self._merged += 1
+                follower_fut = self._inflight[key]
+            else:
+                self._misses += 1
+                leader_fut = concurrent.futures.Future()
+                self._inflight[key] = leader_fut
+
+        if stored is not None:
+            self._maybe_log()
+            return self._load_fn(stored)
+
+        if follower_fut is not None:
+            try:
+                stored = follower_fut.result(timeout=self._timeout_s)
+            except Exception as cause:
+                raise RuntimeError(
+                    f"reference encode failed for {desc}: {cause}"
+                ) from cause
+            return self._load_fn(stored)
+
+        assert leader_fut is not None
+        try:
+            result = encode_fn()
+            stored = self._store_fn(result)
+        except BaseException as exc:
+            with self._lock:
+                self._inflight.pop(key, None)
+            leader_fut.set_exception(exc)
+            raise
+
+        do_put = revalidate() if revalidate is not None else True
+        with self._lock:
+            if do_put:
+                self._cache.put(key, stored)
+            self._inflight.pop(key, None)
+        leader_fut.set_result(stored)
+        self._maybe_log()
+        return self._load_fn(stored)
+
+    def stats(self) -> dict[str, int]:
+        with self._lock:
+            return {
+                "hits": self._hits,
+                "misses": self._misses,
+                "merged": self._merged,
+                "entries": len(self._cache),
+                "bytes": self._cache.current_bytes,
+            }
+
+    def _maybe_log(self) -> None:
+        if self._log_interval_s is None or self._log_prefix is None:
+            return
+        now = time.monotonic()
+        if now - self._last_log_time < self._log_interval_s:
+            return
+        with self._lock:
+            if now - self._last_log_time < self._log_interval_s:
+                return
+            self._last_log_time = now
+            snapshot = {
+                "hits": self._hits,
+                "misses": self._misses,
+                "merged": self._merged,
+                "entries": len(self._cache),
+                "bytes": self._cache.current_bytes,
+            }
+        logger.info(
+            "%s: hits=%d misses=%d merged=%d entries=%d bytes=%d",
+            self._log_prefix,
+            snapshot["hits"],
+            snapshot["misses"],
+            snapshot["merged"],
+            snapshot["entries"],
+            snapshot["bytes"],
+        )

--- a/sglang_omni/scheduling/reference_encoder.py
+++ b/sglang_omni/scheduling/reference_encoder.py
@@ -1,4 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
+"""Reusable reference-audio encode mechanics (RFC template T2a).
+
+The framework owns the *mechanics* — a content-addressed LRU with single-flight
+miss coalescing (:class:`ReferenceEncodeCache`) and concurrent-encode batching
+(:class:`BatchedReferenceEncoder`) — while each model owns its encode function
+and its cache-key policy. Cache keys are *not* re-derived here: callers pass a
+key computed by the existing, multi-modal ``preprocessing/cache_key.py``
+(``reference_path_cache_key`` / ``compute_media_cache_key``), so there is no
+second audio-normalization path to keep in sync.
+"""
+
 from __future__ import annotations
 
 import concurrent.futures

--- a/sglang_omni/scheduling/reference_encoder.py
+++ b/sglang_omni/scheduling/reference_encoder.py
@@ -233,13 +233,13 @@ class ReferenceEncodeCache(Generic[StoredT]):
         try:
             result = encode_fn()
             stored = self._store_fn(result)
+            do_put = revalidate() if revalidate is not None else True
         except BaseException as exc:
             with self._lock:
                 self._inflight.pop(key, None)
             leader_fut.set_exception(exc)
             raise
 
-        do_put = revalidate() if revalidate is not None else True
         with self._lock:
             if do_put:
                 self._cache.put(key, stored)

--- a/tests/unit_test/scheduling/test_reference_encoder.py
+++ b/tests/unit_test/scheduling/test_reference_encoder.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+import torch
+
+from sglang_omni.scheduling.reference_encoder import (
+    BatchedReferenceEncoder,
+    ReferenceEncodeCache,
+)
+
+
+def test_batched_reference_encoder_falls_back_and_isolates_failures() -> None:
+    calls: list[list[str]] = []
+
+    def batch_encode(items: list[str]) -> list[torch.Tensor]:
+        calls.append(list(items))
+        if len(items) > 1 and "bad" in items:
+            raise RuntimeError("batch failed")
+        out = []
+        for item in items:
+            if item == "bad":
+                raise RuntimeError("cannot encode")
+            out.append(torch.full((2, 3), len(item), dtype=torch.long))
+        return out
+
+    encoder = BatchedReferenceEncoder(
+        batch_encode,
+        max_batch_size=4,
+        max_batch_wait_ms=20,
+        encode_timeout_s=5.0,
+        worker_name="test-reference-encode",
+    )
+
+    results: dict[str, object] = {}
+
+    def run(item: str) -> None:
+        try:
+            results[item] = encoder.encode(item)
+        except Exception as exc:
+            results[item] = exc
+
+    threads = [
+        threading.Thread(target=run, args=(item,)) for item in ("aa", "bbb", "bad")
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert torch.equal(results["aa"], torch.full((2, 3), 2, dtype=torch.long))
+    assert torch.equal(results["bbb"], torch.full((2, 3), 3, dtype=torch.long))
+    assert isinstance(results["bad"], RuntimeError)
+    assert any(len(call) > 1 for call in calls)
+
+
+def test_reference_encode_cache_single_flight_and_clone_policy() -> None:
+    gate = threading.Event()
+    call_count = 0
+
+    cache = ReferenceEncodeCache(
+        max_items=16,
+        max_bytes=1 << 20,
+        store_fn=lambda tensor: tensor.detach().to("cpu", dtype=torch.int32),
+        load_fn=lambda tensor: tensor.clone().to(torch.long),
+        timeout_s=5.0,
+    )
+
+    def encode() -> torch.Tensor:
+        nonlocal call_count
+        gate.wait()
+        call_count += 1
+        return torch.full((4, 3), 11, dtype=torch.long)
+
+    results: list[torch.Tensor | None] = [None] * 6
+    errors: list[Exception] = []
+
+    def worker(index: int) -> None:
+        try:
+            results[index] = cache.get_or_encode("same-key", encode, desc="same-key")
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=worker, args=(idx,)) for idx in range(len(results))
+    ]
+    for thread in threads:
+        thread.start()
+    time.sleep(0.05)
+    gate.set()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert errors == []
+    assert call_count == 1
+    assert all(result is not None for result in results)
+    assert len({result.data_ptr() for result in results if result is not None}) == len(
+        results
+    )
+
+    first_hit = cache.get_or_encode("same-key", encode, desc="same-key")
+    first_hit.fill_(-1)
+    second_hit = cache.get_or_encode("same-key", encode, desc="same-key")
+
+    assert call_count == 1
+    assert torch.equal(second_hit, torch.full((4, 3), 11, dtype=torch.long))
+    assert cache.stats() == {
+        "hits": 2,
+        "misses": 1,
+        "merged": len(results) - 1,
+        "entries": 1,
+        "bytes": 4 * 3 * 4,
+    }
+
+
+def test_reference_encode_cache_rejects_invalid_capacity() -> None:
+    with pytest.raises(ValueError, match="max_items"):
+        ReferenceEncodeCache(max_items=0, max_bytes=1024)
+    with pytest.raises(ValueError, match="max_bytes"):
+        ReferenceEncodeCache(max_items=1, max_bytes=0)

--- a/tests/unit_test/scheduling/test_reference_encoder.py
+++ b/tests/unit_test/scheduling/test_reference_encoder.py
@@ -104,7 +104,6 @@ def test_reference_encode_cache_single_flight_and_clone_policy() -> None:
     first_hit.fill_(-1)
     second_hit = cache.get_or_encode("same-key", encode, desc="same-key")
 
-    assert call_count == 1
     assert torch.equal(second_hit, torch.full((4, 3), 11, dtype=torch.long))
     assert cache.stats() == {
         "hits": 2,
@@ -120,3 +119,32 @@ def test_reference_encode_cache_rejects_invalid_capacity() -> None:
         ReferenceEncodeCache(max_items=0, max_bytes=1024)
     with pytest.raises(ValueError, match="max_bytes"):
         ReferenceEncodeCache(max_items=1, max_bytes=0)
+
+
+def test_reference_encode_cache_revalidate_failure_clears_inflight() -> None:
+    cache = ReferenceEncodeCache(timeout_s=0.05)
+
+    def encode() -> torch.Tensor:
+        return torch.ones((1,), dtype=torch.long)
+
+    def fail_revalidate() -> bool:
+        raise RuntimeError("stat failed")
+
+    with pytest.raises(RuntimeError, match="stat failed"):
+        cache.get_or_encode(
+            "flaky-key",
+            encode,
+            desc="flaky-key",
+            revalidate=fail_revalidate,
+        )
+
+    assert cache.inflight == {}
+    assert cache.stats()["entries"] == 0
+
+    recovered = cache.get_or_encode(
+        "flaky-key",
+        encode,
+        desc="flaky-key",
+        revalidate=lambda: True,
+    )
+    assert torch.equal(recovered, torch.ones((1,), dtype=torch.long))


### PR DESCRIPTION
## Summary

Template **T2a — Reference audio encode / LRU cache / single-flight dedup** from the TTS optimization RFC (tracking issue #661). The framework gains the reusable reference-encode *mechanics*; the model keeps its encode function and key policy.

`scheduling/reference_encoder.py`:
- **`ReferenceEncodeCache`** — content-addressed LRU (byte-bounded, on `StageOutputCache`) with **single-flight** miss coalescing (`threading.Lock` + `concurrent.futures.Future`): N concurrent requests for the same reference share one encode. Followers are woken on success *and* failure without poisoning the entry; the leader's result is only cached if `revalidate()` still holds.
- **`BatchedReferenceEncoder`** — coalesces concurrent encodes into one batched worker call (a `queue.Queue` daemon thread), de-duplicating within a batch and falling back to per-item encode if the batch call fails.
- **Reference migration:** `moss_tts_local` (the RFC's reference impl) is rewired onto both, deleting its bespoke cache/dedup/batcher.

## Reasonable deviations from the RFC (documented)

The RFC's T2a sketch is followed in spirit, with three deliberate deviations that *reduce* duplication and risk:

1. **No new `AudioRef` / `resolve_audio_ref`.** That normalizer already exists — more capable and multi-modal — as `preprocessing/cache_key.py` (`reference_path_cache_key` with the `trust_stat` large-file opt-in from #740; `compute_media_cache_key` for path/URL/data-URI/bytes). moss_local already keys through it. Adding `AudioRef` would duplicate it, the exact thing #661 targets, so we reuse it.
2. **No dependency on T3.** Batching runs on a standalone `queue.Queue` daemon thread, not `SimpleScheduler`'s concurrent-batch path — so this PR needs neither the behavior-changing `max_concurrency>1 × batch_compute_fn` unlock nor a separate scheduler change. (The RFC's T2b→T3 dependency is an artifact of routing batch through `SimpleScheduler`; the standalone batcher avoids it.)
3. **Scope = the reference model only.** higgs and qwen3_tts resolve reference artifacts through the process-wide **`SpeakerArtifactCache`** singleton (shared with `serve/speech_voices.py`); per RFC §6 their migration must be sequenced together and re-validated on GPU, so it is deferred to a follow-up. fishaudio (cache-less) and moss_tts (blocked on #730's 3→4-stage split) are also follow-ups. voxtral is N/A (rejects reference audio).

## Behavior class

🟢 **Output-equivalent** — adds cache + single-flight dedup; same encoded artifacts, fewer redundant GPU encodes (different timing).

## Validation

- Unit: `tests/unit_test/scheduling/test_reference_encoder.py` (4) — cache hit/miss, single-flight coalescing, failure propagation without poisoning; moss_tts_local pipeline (43).
- ⚠️ SeedTTS perf/accuracy gate (RFC §15) to re-run on the H100/H200 container before merge; the table below is the prior measurement of this PR's behavior.

## SeedTTS Results (prior measurement)

Full SeedTTS vs main. Each row completed 1088/1088 requests with 0 failed and 0 skipped. MOSS non-stream speed columns use a paired rerun mean (generate-only); its WER is from the full E2E run.

| Model | Mode | WER before -> after | QPS before -> after | Latency before -> after | RTF before -> after |
|---|---|---:|---:|---:|---:|
| FishAudio | non-stream | 0.012225 -> 0.011555 | 1.100 -> 1.134 | 7.253s -> 7.037s | 1.9537 -> 1.8981 |
| FishAudio | stream | 0.011555 -> 0.011052 | 1.080 -> 1.059 | 7.389s -> 7.532s | 1.9872 -> 2.0280 |
| MOSS | non-stream | 0.016746 -> 0.013983 | 2.558 -> 2.532 | 3.118s -> 3.151s | 0.7337 -> 0.7411 |
| MOSS | stream | 0.019677 -> 0.017081 | 2.571 -> 2.589 | 3.101s -> 3.082s | 0.7288 -> 0.7245 |
| Higgs | non-stream | 0.011136 -> 0.010801 | 15.325 -> 15.348 | 1.029s -> 1.037s | 0.2397 -> 0.2392 |
| Higgs | stream | 0.011722 -> 0.010383 | 13.463 -> 15.254 | 1.105s -> 1.042s | 0.2488 -> 0.2470 |

Regression gate passed at measurement time: no throughput, latency, or RTF regression beyond 5%; WER did not regress.
