### PR TITLE
[MOSS]: Tune MOSS Local colocated AR memory budgeting

### DIFF
--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -11,13 +11,34 @@ from sglang_omni.config import (
     PipelineConfig,
     SGLangServerArgsConfig,
     StageConfig,
+    StageResourceConfig,
     StageRuntimeConfig,
 )
 
 _PKG = "sglang_omni.models.moss_tts_local"
+# Note (Ratish): in the default single-process topology preprocessing loads before AR, so its
+# codec memory is included by process-scoped SGLang accounting
+# the reserve is for the later vocoder codec instance and runtime headroom
+_COLOCATED_TOTAL_GPU_MEMORY_FRACTION = 0.90
+_COLOCATED_CODEC_MEM_RESERVE = 0.05
+_AR_MEM_FRACTION_STATIC = 0.85
 
 
-def _stages(*, codec_device: str) -> list[StageConfig]:
+def _stages(*, codec_device: str, colocated: bool) -> list[StageConfig]:
+    tts_engine_runtime = StageRuntimeConfig(
+        resources=StageResourceConfig(
+            total_gpu_memory_fraction=(
+                _COLOCATED_TOTAL_GPU_MEMORY_FRACTION if colocated else None
+            )
+        ),
+        sglang_server_args=SGLangServerArgsConfig(
+            mem_fraction_static=None if colocated else _AR_MEM_FRACTION_STATIC
+        ),
+    )
+    tts_engine_args = {"gpu_id": 0, "dtype": "bfloat16"}
+    if colocated:
+        tts_engine_args["codec_mem_reserve"] = _COLOCATED_CODEC_MEM_RESERVE
+
     return [
         StageConfig(
             name="preprocessing",
@@ -36,10 +57,8 @@ def _stages(*, codec_device: str) -> list[StageConfig]:
             name="tts_engine",
             process="pipeline",
             factory=f"{_PKG}.stages.create_sglang_tts_engine_executor",
-            factory_args={"gpu_id": 0, "dtype": "bfloat16"},
-            runtime=StageRuntimeConfig(
-                sglang_server_args=SGLangServerArgsConfig(mem_fraction_static=0.85),
-            ),
+            factory_args=tts_engine_args,
+            runtime=tts_engine_runtime,
             gpu=0,
             next="vocoder",
             stream_to=["vocoder"],
@@ -75,7 +94,7 @@ class MossTTSLocalPipelineConfig(PipelineConfig):
 
     model_path: str
     stages: list[StageConfig] = Field(
-        default_factory=lambda: _stages(codec_device="cuda:0")
+        default_factory=lambda: _stages(codec_device="cuda:0", colocated=True)
     )
 
     def supports_uploaded_voice_references(self) -> bool:
@@ -86,7 +105,7 @@ class MossTTSLocalColocatedPipelineConfig(MossTTSLocalPipelineConfig):
     """Backward-compatible alias for the default single-GPU pipeline."""
 
     stages: list[StageConfig] = Field(
-        default_factory=lambda: _stages(codec_device="cuda:0")
+        default_factory=lambda: _stages(codec_device="cuda:0", colocated=True)
     )
 
 
@@ -94,7 +113,7 @@ class MossTTSLocalSplitPipelineConfig(MossTTSLocalPipelineConfig):
     """Two-GPU variant that places codec work on the second visible GPU."""
 
     stages: list[StageConfig] = Field(
-        default_factory=lambda: _stages(codec_device="cuda:1")
+        default_factory=lambda: _stages(codec_device="cuda:1", colocated=False)
     )
 
 

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -9,6 +9,7 @@ import os
 import queue
 import threading
 import time
+from dataclasses import dataclass
 from typing import Any
 
 import torch
@@ -48,6 +49,66 @@ _MOSS_TTS_LOCAL_INSTALL_HINT = (
 # ~4.3 GB bf16 codec instance): `model.streaming()` flips module-global codec
 # state, so a decode on a shared instance would corrupt a concurrent
 # reference encode (see streaming_vocoder.py).
+
+
+@dataclass(frozen=True)
+class _ArMemoryBudget:
+    effective_total_gpu_memory_fraction: float | None
+    applied_codec_mem_reserve: float
+
+
+def _apply_colocated_ar_memory_budget(
+    overrides: dict[str, Any],
+    *,
+    total_gpu_memory_fraction: float | None,
+    codec_mem_reserve: float,
+) -> _ArMemoryBudget:
+    if total_gpu_memory_fraction is None:
+        return _ArMemoryBudget(
+            effective_total_gpu_memory_fraction=None,
+            applied_codec_mem_reserve=0.0,
+        )
+    if not 0.0 <= codec_mem_reserve < 1.0:
+        raise ValueError("codec_mem_reserve must be in [0, 1)")
+
+    effective_total_gpu_memory_fraction = round(
+        total_gpu_memory_fraction - codec_mem_reserve,
+        3,
+    )
+    if effective_total_gpu_memory_fraction < 0.1:
+        raise ValueError(
+            f"colocated total_gpu_memory_fraction {total_gpu_memory_fraction:.3f} "
+            f"minus codec_mem_reserve {codec_mem_reserve:.3f} = "
+            f"{effective_total_gpu_memory_fraction:.3f} is below the safe floor "
+            f"0.1; lower codec_mem_reserve or increase the tts_engine stage budget."
+        )
+
+    explicit_mem_fraction = overrides.get("mem_fraction_static")
+    applied_codec_mem_reserve = codec_mem_reserve
+    if explicit_mem_fraction is not None:
+        explicit_mem_fraction = float(explicit_mem_fraction)
+        if not 0.0 < explicit_mem_fraction < 1.0:
+            raise ValueError(
+                f"mem_fraction_static must be > 0 and < 1, got {explicit_mem_fraction}"
+            )
+        if explicit_mem_fraction > total_gpu_memory_fraction:
+            raise ValueError(
+                f"MOSS-TTS Local tts_engine mem_fraction_static cannot exceed "
+                f"runtime.resources.total_gpu_memory_fraction: "
+                f"{explicit_mem_fraction:.3f} > {total_gpu_memory_fraction:.3f}"
+            )
+        effective_total_gpu_memory_fraction = explicit_mem_fraction
+        applied_codec_mem_reserve = round(
+            total_gpu_memory_fraction - effective_total_gpu_memory_fraction,
+            3,
+        )
+    else:
+        overrides["mem_fraction_static"] = effective_total_gpu_memory_fraction
+
+    return _ArMemoryBudget(
+        effective_total_gpu_memory_fraction=effective_total_gpu_memory_fraction,
+        applied_codec_mem_reserve=applied_codec_mem_reserve,
+    )
 
 
 def _normalize_processor_config(processor: Any) -> None:
@@ -456,6 +517,8 @@ def create_sglang_tts_engine_executor(
     server_args_overrides: dict[str, Any] | None = None,
     enable_async_decode: bool = False,
     async_decode_min_batch_size: int = 2,
+    total_gpu_memory_fraction: float | None = None,
+    codec_mem_reserve: float = 0.0,
 ) -> Any:
     from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
     from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
@@ -479,15 +542,35 @@ def create_sglang_tts_engine_executor(
         "enable_torch_compile": False,
         "max_prefill_tokens": 8192,
         "max_running_requests": 16,
-        # Headroom for the two ~4.3 GB bf16 codec instances; back off further
-        # when everything co-locates on a single GPU.
-        "mem_fraction_static": 0.6 if torch.cuda.device_count() > 1 else 0.5,
         "sampling_backend": "pytorch",
         "torch_compile_max_bs": 16,
         "trust_remote_code": True,
     }
+    if total_gpu_memory_fraction is None:
+        # without a typed stage budget, this path cannot use process-scoped
+        # colocated profiling
+        # keep the legacy static fraction for split/custom deployments
+        overrides["mem_fraction_static"] = 0.6 if torch.cuda.device_count() > 1 else 0.5
     if server_args_overrides:
         overrides.update(server_args_overrides)
+    memory_budget = _apply_colocated_ar_memory_budget(
+        overrides,
+        total_gpu_memory_fraction=total_gpu_memory_fraction,
+        codec_mem_reserve=codec_mem_reserve,
+    )
+    profile_total_gpu_memory_fraction = (
+        memory_budget.effective_total_gpu_memory_fraction
+    )
+    if profile_total_gpu_memory_fraction is not None:
+        from sglang_omni.utils.gpu_memory import get_process_gpu_memory_bytes
+
+        if get_process_gpu_memory_bytes(gpu_id) is None:
+            logger.warning(
+                f"MOSS-TTS Local colocated process memory accounting is unavailable; "
+                f"falling back to upstream SGLang free-memory profiling. "
+                f"effective_total_gpu_memory_fraction={profile_total_gpu_memory_fraction}"
+            )
+            profile_total_gpu_memory_fraction = None
 
     server_args = build_sglang_server_args(
         checkpoint_dir,
@@ -498,6 +581,16 @@ def create_sglang_tts_engine_executor(
     want_cuda_graph = not bool(getattr(server_args, "disable_cuda_graph", False))
     if want_cuda_graph:
         server_args.disable_cuda_graph = True
+
+    logger.info(
+        f"MOSS-TTS Local SGLang startup: gpu_id={gpu_id} "
+        f"total_gpu_memory_fraction={total_gpu_memory_fraction} "
+        f"effective_total_gpu_memory_fraction="
+        f"{memory_budget.effective_total_gpu_memory_fraction} "
+        f"codec_mem_reserve={memory_budget.applied_codec_mem_reserve:.3f} "
+        f"mem_fraction_static={server_args.mem_fraction_static} "
+        f"profile_total_gpu_memory_fraction={profile_total_gpu_memory_fraction}"
+    )
 
     (
         model_worker,
@@ -511,6 +604,7 @@ def create_sglang_tts_engine_executor(
         server_args,
         gpu_id,
         model_arch_override="MossTTSLocalSGLangModel",
+        total_gpu_memory_fraction=profile_total_gpu_memory_fraction,
     )
 
     if want_cuda_graph:

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import struct
+import sys
+import types
 
 import numpy as np
 import pytest
@@ -166,6 +168,11 @@ def test_registry_resolves_local_architecture():
 
 def test_pipeline_stage_wiring():
     config = MossTTSLocalPipelineConfig(model_path="OpenMOSS-Team/moss-local-test")
+    assert [stage.name for stage in config.stages] == [
+        "preprocessing",
+        "tts_engine",
+        "vocoder",
+    ]
     stages = {stage.name: stage for stage in config.stages}
     assert set(stages) == {"preprocessing", "tts_engine", "vocoder"}
     assert stages["preprocessing"].next == "tts_engine"
@@ -181,9 +188,9 @@ def test_pipeline_stage_wiring():
     assert stages["tts_engine"].process == "pipeline"
     assert stages["tts_engine"].gpu == 0
     tts_engine_runtime = stages["tts_engine"].runtime
-    assert tts_engine_runtime.sglang_server_args.mem_fraction_static == pytest.approx(
-        0.85
-    )
+    assert tts_engine_runtime.resources.total_gpu_memory_fraction == pytest.approx(0.90)
+    assert tts_engine_runtime.sglang_server_args.mem_fraction_static is None
+    assert stages["tts_engine"].factory_args["codec_mem_reserve"] == pytest.approx(0.05)
     assert stages["vocoder"].process == "pipeline"
     assert stages["vocoder"].gpu == 0
     assert stages["vocoder"].factory_args["device"] == "cuda:0"
@@ -208,7 +215,185 @@ def test_pipeline_stage_wiring():
     split_stages = {stage.name: stage for stage in split.stages}
     assert split_stages["preprocessing"].factory_args["device"] == "cuda:1"
     assert split_stages["tts_engine"].factory_args["gpu_id"] == 0
+    split_runtime = split_stages["tts_engine"].runtime
+    assert split_runtime.resources.total_gpu_memory_fraction is None
+    assert split_runtime.sglang_server_args.mem_fraction_static == pytest.approx(0.85)
     assert split_stages["vocoder"].factory_args["device"] == "cuda:1"
+
+
+def _install_fake_moss_ar_factory(
+    monkeypatch,
+    *,
+    process_memory_bytes: int | None,
+):
+    pytest.importorskip("PIL")
+
+    from sglang_omni.models.moss_tts_local import stages
+    from sglang_omni.scheduling import bootstrap as scheduling_bootstrap
+    from sglang_omni.scheduling import omni_scheduler, sglang_backend
+    from sglang_omni.utils import gpu_memory as gpu_memory_utils
+
+    infrastructure_calls = []
+    process_memory_queries = []
+
+    def fake_build_sglang_server_args(model_path, context_length, **kwargs):
+        return types.SimpleNamespace(
+            model_path=model_path,
+            context_length=context_length,
+            **kwargs,
+        )
+
+    class FakeModelRunner:
+        model = object()
+
+    model_worker = types.SimpleNamespace(
+        model_runner=FakeModelRunner(),
+        model_config=types.SimpleNamespace(),
+    )
+
+    def fake_create_sglang_infrastructure(server_args, gpu_id, **kwargs):
+        infrastructure_calls.append(
+            {
+                "mem_fraction_static": server_args.mem_fraction_static,
+                "gpu_id": gpu_id,
+                "total_gpu_memory_fraction": kwargs.get("total_gpu_memory_fraction"),
+            }
+        )
+        return (
+            model_worker,
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            model_worker.model_config,
+        )
+
+    class FakeMossRunner:
+        def __init__(self, *args, **kwargs):
+            self.stream_outbox = None
+
+        def set_stream_outbox(self, outbox):
+            self.stream_outbox = outbox
+
+    class FakeScheduler:
+        def __init__(self, **kwargs):
+            self.outbox = object()
+            self.kwargs = kwargs
+
+    fake_runner_module = types.SimpleNamespace(MossTTSLocalModelRunner=FakeMossRunner)
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang_omni.models.moss_tts_local.model_runner",
+        fake_runner_module,
+    )
+    monkeypatch.setattr(
+        sglang_backend,
+        "build_sglang_server_args",
+        fake_build_sglang_server_args,
+    )
+    monkeypatch.setattr(
+        scheduling_bootstrap,
+        "create_sglang_infrastructure",
+        fake_create_sglang_infrastructure,
+    )
+    monkeypatch.setattr(
+        sglang_backend,
+        "SGLangOutputProcessor",
+        lambda **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        stages,
+        "make_moss_tts_local_scheduler_adapters",
+        lambda **kwargs: (object(), object()),
+    )
+    monkeypatch.setattr(stages, "_resolve_checkpoint", lambda model_path: model_path)
+    monkeypatch.setattr(omni_scheduler, "OmniScheduler", FakeScheduler)
+
+    def fake_get_process_gpu_memory_bytes(gpu_id):
+        process_memory_queries.append(gpu_id)
+        return process_memory_bytes
+
+    monkeypatch.setattr(
+        gpu_memory_utils,
+        "get_process_gpu_memory_bytes",
+        fake_get_process_gpu_memory_bytes,
+    )
+
+    return stages, infrastructure_calls, process_memory_queries
+
+
+def test_colocated_moss_ar_factory_threads_effective_budget(monkeypatch):
+    stages, infrastructure_calls, process_memory_queries = (
+        _install_fake_moss_ar_factory(
+            monkeypatch,
+            process_memory_bytes=1024,
+        )
+    )
+
+    stages.create_sglang_tts_engine_executor(
+        "dummy",
+        server_args_overrides={"disable_cuda_graph": True},
+        total_gpu_memory_fraction=0.90,
+        codec_mem_reserve=0.05,
+    )
+
+    assert infrastructure_calls == [
+        {
+            "mem_fraction_static": pytest.approx(0.85),
+            "gpu_id": 0,
+            "total_gpu_memory_fraction": pytest.approx(0.85),
+        }
+    ]
+    assert process_memory_queries == [0]
+
+
+def test_colocated_moss_ar_factory_uses_upstream_profile_without_process_accounting(
+    monkeypatch,
+):
+    stages, infrastructure_calls, process_memory_queries = (
+        _install_fake_moss_ar_factory(
+            monkeypatch,
+            process_memory_bytes=None,
+        )
+    )
+
+    stages.create_sglang_tts_engine_executor(
+        "dummy",
+        server_args_overrides={"disable_cuda_graph": True},
+        total_gpu_memory_fraction=0.90,
+        codec_mem_reserve=0.05,
+    )
+
+    assert infrastructure_calls == [
+        {
+            "mem_fraction_static": pytest.approx(0.85),
+            "gpu_id": 0,
+            "total_gpu_memory_fraction": None,
+        }
+    ]
+    assert process_memory_queries == [0]
+
+
+def test_colocated_moss_ar_factory_accepts_explicit_effective_budget():
+    pytest.importorskip("PIL")
+
+    from sglang_omni.models.moss_tts_local import stages
+
+    budget = stages._apply_colocated_ar_memory_budget(
+        {"mem_fraction_static": 0.70},
+        total_gpu_memory_fraction=0.90,
+        codec_mem_reserve=0.05,
+    )
+    assert budget.effective_total_gpu_memory_fraction == pytest.approx(0.70)
+    assert budget.applied_codec_mem_reserve == pytest.approx(0.20)
+
+    with pytest.raises(ValueError, match="cannot exceed"):
+        stages._apply_colocated_ar_memory_budget(
+            {"mem_fraction_static": 0.95},
+            total_gpu_memory_fraction=0.90,
+            codec_mem_reserve=0.05,
+        )
 
 
 def test_special_token_defaults_match_v15_checkpoint():
@@ -1600,4 +1785,5 @@ def test_async_decode_cli_accepts_moss_local():
     args = resolve_stage_factory_args(stage, config)
     assert args["enable_async_decode"] is True
     assert args["async_decode_min_batch_size"] == 4
-    assert args["server_args_overrides"]["mem_fraction_static"] == pytest.approx(0.85)
+    assert args["total_gpu_memory_fraction"] == pytest.approx(0.90)
+    assert args["codec_mem_reserve"] == pytest.approx(0.05)


### PR DESCRIPTION
## Motivation

MOSS Local runs preprocessing, AR, and vocoder in the default single-GPU pipeline. The AR stage needs a colocated memory budget that accounts for codec residency without falling back to the generic SGLang free-memory path used for non-colocated deployments.

This PR wires MOSS Local into the process-scoped `total_gpu_memory_fraction` path and keeps a small codec reserve for the later vocoder load/runtime headroom.

## Modifications

- Add explicit colocated MOSS Local AR memory budgeting in the default pipeline config:
  - `total_gpu_memory_fraction=0.90`
  - `codec_mem_reserve=0.05`
  - effective AR `mem_fraction_static=0.85`
- Keep the split/two-GPU MOSS Local config on the legacy static AR budget path.
- Thread the effective AR memory budget into `create_sglang_infrastructure(..., total_gpu_memory_fraction=...)` so SGLang uses process-scoped memory profiling when available.
- Fall back to upstream SGLang free-memory profiling if process-scoped GPU memory accounting is unavailable, instead of using an unsafe colocated budget in that environment.
- Preserve explicit `mem_fraction_static` overrides as explicit effective AR budgets, while validating that they do not exceed the stage `total_gpu_memory_fraction`.
- Add unit coverage for default/split pipeline wiring, effective budget forwarding, process-accounting fallback, and explicit effective budget validation.

## Speed and Accuracy

Benchmark setup: SeedTTS English, non-streaming, 1088 samples, concurrency 8, `ref-format=references`, `token-count=auto`, `seed=42`, `warmup=1`.

| Metric | `upstream/main` | This PR | Delta |
|---|---:|---:|---:|
| Throughput (req/s) | 4.772 | 5.199 | +0.427 (+8.9%) |
| RTF mean | 0.4014 | 0.3677 | -0.0337 (-8.4%) |
| RTF median | 0.3388 | 0.3392 | +0.0004 (+0.1%) |
| RTF p95 | 0.5908 | 0.5771 | -0.0137 (-2.3%) |
| RTF p99 | 0.8203 | 0.7234 | -0.0969 (-11.8%) |
| Latency mean (s) | 1.674 | 1.536 | -0.138 (-8.2%) |
| Latency median (s) | 1.471 | 1.482 | +0.011 (+0.7%) |
| Latency p95 (s) | 2.135 | 2.085 | -0.050 (-2.3%) |
| Latency p99 (s) | 3.131 | 2.660 | -0.471 (-15.0%) |
| Audio throughput (s/s) | 21.001 | 22.883 | +1.882 (+9.0%) |
| Output throughput (tok/s) | 262.5 | 286.0 | +23.5 (+9.0%) |
| Output tokens/request-s | 78.8 | 84.4 | +5.6 (+7.1%) |
| WER corpus | 2.29% | 2.08% | -0.21 pp |
| WER per-sample mean | 2.26% | 2.10% | -0.16 pp |
| WER per-sample p95 | 11.11% | 10.00% | -1.11 pp |
| WER corpus excl >50% | 1.59% | 1.47% | -0.12 pp |
| >50% WER samples | 8 | 7 | -1 |
