### PR TITLE
[Perf] MOSS-TTS: Add CUDA graph codec decoder

### DIFF
--- a/sglang_omni/models/moss_tts_local/codec_cuda_graph.py
+++ b/sglang_omni/models/moss_tts_local/codec_cuda_graph.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 import math
 import threading
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from types import MethodType, SimpleNamespace
 from typing import Any
 
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 
 codec_cuda_graph_capture_lock = threading.RLock()
 
-_ROPE_CACHE_POSITIONS = 65536
 _ROPE_CACHE_KEY_ATTR = "_sglang_omni_cuda_graph_rope_cache_key"
 _ROPE_CACHE_COS_ATTR = "_sglang_omni_cuda_graph_rope_cos"
 _ROPE_CACHE_SIN_ATTR = "_sglang_omni_cuda_graph_rope_sin"
@@ -75,28 +74,60 @@ def _decoder_rope_head_dims(codec: Any) -> dict[int, int]:
     return head_dims
 
 
+def _decoder_rope_position_multiplier(codec: Any) -> int:
+    """Max decoder sequence upsampling factor seen by any RoPE module."""
+
+    multiplier = 1
+    max_multiplier = 1
+    decoder = getattr(codec, "decoder", ())
+    for decoder_module in decoder:
+        modules = decoder_module.modules() if hasattr(decoder_module, "modules") else ()
+        for module in modules:
+            rope = getattr(module, "rope", None)
+            if rope is not None and hasattr(rope, "max_period"):
+                max_multiplier = max(max_multiplier, multiplier)
+        multiplier *= max(int(getattr(decoder_module, "downsample_ratio", 1) or 1), 1)
+    return max_multiplier
+
+
 def _ensure_rope_cache(
     rope: Any,
     *,
     device: torch.device,
     head_dim: int,
-    positions: int = _ROPE_CACHE_POSITIONS,
+    positions: int | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    cache_key = (str(device), int(head_dim), int(positions), float(rope.max_period))
-    if getattr(rope, _ROPE_CACHE_KEY_ATTR, None) != cache_key:
-        half_dim = int(head_dim) // 2
-        ds = torch.arange(half_dim, device=device, dtype=torch.float32)
-        freqs = torch.exp(ds * (-math.log(float(rope.max_period)) * 2 / int(head_dim)))
-        position_ids_f = torch.arange(positions, device=device, dtype=torch.float32)
-        phase = position_ids_f.view(-1, 1) * freqs.view(1, -1)
-        setattr(rope, _ROPE_CACHE_KEY_ATTR, cache_key)
-        setattr(rope, _ROPE_CACHE_COS_ATTR, torch.cos(phase))
-        setattr(rope, _ROPE_CACHE_SIN_ATTR, torch.sin(phase))
-        setattr(
-            rope,
-            _ROPE_CACHE_POS_ATTR,
-            torch.arange(positions, device=device, dtype=torch.long),
+    requested_positions = max(int(positions or 1), 1)
+    existing_key = getattr(rope, _ROPE_CACHE_KEY_ATTR, None)
+    if (
+        isinstance(existing_key, tuple)
+        and len(existing_key) == 4
+        and existing_key[0] == str(device)
+        and existing_key[1] == int(head_dim)
+        and int(existing_key[2]) >= requested_positions
+        and existing_key[3] == float(rope.max_period)
+    ):
+        return (
+            getattr(rope, _ROPE_CACHE_COS_ATTR),
+            getattr(rope, _ROPE_CACHE_SIN_ATTR),
+            getattr(rope, _ROPE_CACHE_POS_ATTR),
         )
+
+    positions = requested_positions
+    cache_key = (str(device), int(head_dim), int(positions), float(rope.max_period))
+    half_dim = int(head_dim) // 2
+    ds = torch.arange(half_dim, device=device, dtype=torch.float32)
+    freqs = torch.exp(ds * (-math.log(float(rope.max_period)) * 2 / int(head_dim)))
+    position_ids_f = torch.arange(positions, device=device, dtype=torch.float32)
+    phase = position_ids_f.view(-1, 1) * freqs.view(1, -1)
+    setattr(rope, _ROPE_CACHE_KEY_ATTR, cache_key)
+    setattr(rope, _ROPE_CACHE_COS_ATTR, torch.cos(phase))
+    setattr(rope, _ROPE_CACHE_SIN_ATTR, torch.sin(phase))
+    setattr(
+        rope,
+        _ROPE_CACHE_POS_ATTR,
+        torch.arange(positions, device=device, dtype=torch.long),
+    )
     return (
         getattr(rope, _ROPE_CACHE_COS_ATTR),
         getattr(rope, _ROPE_CACHE_SIN_ATTR),
@@ -126,6 +157,7 @@ def _cached_rope_forward(
         self,
         device=q.device,
         head_dim=head_dim,
+        positions=max(time_steps, 1),
     )
     positions = offset.to(device=q.device, dtype=torch.long).view(
         -1, 1
@@ -161,7 +193,9 @@ def _cached_rope_forward(
     return qo.view(*dims, head_dim), ko.view(*dims, head_dim)
 
 
-def patch_codec_rope_for_cuda_graph(codec: Any) -> None:
+def patch_codec_rope_for_cuda_graph(
+    codec: Any, *, cache_positions: int | None = None
+) -> None:
     """Make decoder RoPE graph-capturable by avoiding trig ops in capture."""
 
     try:
@@ -175,7 +209,27 @@ def patch_codec_rope_for_cuda_graph(codec: Any) -> None:
             rope.forward = MethodType(_cached_rope_forward, rope)
         head_dim = head_dims.get(id(rope))
         if head_dim is not None:
-            _ensure_rope_cache(rope, device=device, head_dim=head_dim)
+            _ensure_rope_cache(
+                rope,
+                device=device,
+                head_dim=head_dim,
+                positions=cache_positions,
+            )
+
+
+@contextmanager
+def _use_original_codec_rope(codec: Any):
+    restored: list[tuple[Any, Any]] = []
+    for rope in _decoder_rope_modules(codec):
+        original = getattr(rope, _ROPE_ORIGINAL_FORWARD_ATTR, None)
+        if callable(original):
+            restored.append((rope, rope.forward))
+            rope.forward = original
+    try:
+        yield
+    finally:
+        for rope, current_forward in restored:
+            rope.forward = current_forward
 
 
 def _cuda_graph_update_streaming_cache(
@@ -304,7 +358,7 @@ class AudioTokenizerDecoderCudaGraph:
     length buffers under a CUDA graph keyed by static shape.
     """
 
-    def __init__(self, codec: Any) -> None:
+    def __init__(self, codec: Any, *, max_audio_frames: int | None = None) -> None:
         if not codec_cuda_graph_supported(codec):
             raise RuntimeError(
                 "MOSS-TTS Local codec does not expose a CUDA graph-compatible "
@@ -312,7 +366,17 @@ class AudioTokenizerDecoderCudaGraph:
             )
         self._codec = codec
         set_codec_attention_backend_for_cuda_graph(codec)
-        patch_codec_rope_for_cuda_graph(codec)
+        rope_position_multiplier = _decoder_rope_position_multiplier(codec)
+        try:
+            max_audio_frames = int(max_audio_frames or 0)
+        except (TypeError, ValueError):
+            max_audio_frames = 0
+        self._rope_cache_limit = (
+            max_audio_frames * rope_position_multiplier
+            if max_audio_frames > 0
+            else None
+        )
+        patch_codec_rope_for_cuda_graph(codec, cache_positions=self._rope_cache_limit)
         patch_codec_attention_cache_for_cuda_graph(codec)
         self._cache: dict[
             tuple[Any, ...],
@@ -341,7 +405,7 @@ class AudioTokenizerDecoderCudaGraph:
         active_slots: tuple[int, ...] | None = None,
     ) -> Any:
         if self._disabled_reason is not None or codes.device.type != "cuda":
-            return self._codec._decode_frame(codes, code_lengths)
+            return self._decode_frame_eager(codes, code_lengths)
 
         try:
             return self._decode_frame_graphed(
@@ -363,10 +427,18 @@ class AudioTokenizerDecoderCudaGraph:
                 len(self._cache),
                 exc_info=True,
             )
-            return self._codec._decode_frame(codes, code_lengths)
+            return self._decode_frame_eager(codes, code_lengths)
 
     def close(self) -> None:
         self._cache.clear()
+
+    def _decode_frame_eager(
+        self,
+        codes: torch.Tensor,
+        code_lengths: torch.Tensor,
+    ) -> Any:
+        with _use_original_codec_rope(self._codec):
+            return self._codec._decode_frame(codes, code_lengths)
 
     def _decode_frame_graphed(
         self,

--- a/sglang_omni/models/moss_tts_local/codec_cuda_graph.py
+++ b/sglang_omni/models/moss_tts_local/codec_cuda_graph.py
@@ -1,0 +1,577 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CUDA graph replay for the MOSS-TTS Local audio-tokenizer decoder."""
+
+from __future__ import annotations
+
+import logging
+import math
+import threading
+from contextlib import nullcontext
+from types import MethodType, SimpleNamespace
+from typing import Any
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+codec_cuda_graph_capture_lock = threading.RLock()
+
+_ROPE_CACHE_POSITIONS = 65536
+_ROPE_CACHE_KEY_ATTR = "_sglang_omni_cuda_graph_rope_cache_key"
+_ROPE_CACHE_COS_ATTR = "_sglang_omni_cuda_graph_rope_cos"
+_ROPE_CACHE_SIN_ATTR = "_sglang_omni_cuda_graph_rope_sin"
+_ROPE_CACHE_POS_ATTR = "_sglang_omni_cuda_graph_rope_positions"
+_ROPE_ORIGINAL_FORWARD_ATTR = "_sglang_omni_original_rope_forward"
+_ATTN_ORIGINAL_UPDATE_CACHE_ATTR = "_sglang_omni_original_update_streaming_cache"
+
+_STATE_TENSOR_ATTRS = (
+    "exec_mask",
+    "offsets",
+    "offset",
+    "cached_keys",
+    "cached_values",
+    "cached_positions",
+    "_flash_cached_keys",
+    "_flash_cached_values",
+)
+_STATE_VALUE_ATTRS = ("offset_cpu",)
+
+
+def _decoder_attention_modules(codec: Any) -> list[Any]:
+    modules_by_id: dict[int, Any] = {}
+    decoder = getattr(codec, "decoder", ())
+    for decoder_module in decoder:
+        modules = decoder_module.modules() if hasattr(decoder_module, "modules") else ()
+        for module in modules:
+            if hasattr(module, "attention_implementation"):
+                modules_by_id.setdefault(id(module), module)
+    return list(modules_by_id.values())
+
+
+def _decoder_rope_modules(codec: Any) -> list[Any]:
+    modules_by_id: dict[int, Any] = {}
+    decoder = getattr(codec, "decoder", ())
+    for decoder_module in decoder:
+        modules = decoder_module.modules() if hasattr(decoder_module, "modules") else ()
+        for module in modules:
+            rope = getattr(module, "rope", None)
+            if rope is not None and hasattr(rope, "max_period"):
+                modules_by_id.setdefault(id(rope), rope)
+    return list(modules_by_id.values())
+
+
+def _decoder_rope_head_dims(codec: Any) -> dict[int, int]:
+    head_dims: dict[int, int] = {}
+    decoder = getattr(codec, "decoder", ())
+    for decoder_module in decoder:
+        modules = decoder_module.modules() if hasattr(decoder_module, "modules") else ()
+        for module in modules:
+            rope = getattr(module, "rope", None)
+            embed_dim = getattr(module, "embed_dim", None)
+            num_heads = getattr(module, "num_heads", None)
+            if rope is None or embed_dim is None or num_heads is None:
+                continue
+            head_dims[id(rope)] = int(embed_dim) // int(num_heads)
+    return head_dims
+
+
+def _ensure_rope_cache(
+    rope: Any,
+    *,
+    device: torch.device,
+    head_dim: int,
+    positions: int = _ROPE_CACHE_POSITIONS,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    cache_key = (str(device), int(head_dim), int(positions), float(rope.max_period))
+    if getattr(rope, _ROPE_CACHE_KEY_ATTR, None) != cache_key:
+        half_dim = int(head_dim) // 2
+        ds = torch.arange(half_dim, device=device, dtype=torch.float32)
+        freqs = torch.exp(ds * (-math.log(float(rope.max_period)) * 2 / int(head_dim)))
+        position_ids_f = torch.arange(positions, device=device, dtype=torch.float32)
+        phase = position_ids_f.view(-1, 1) * freqs.view(1, -1)
+        setattr(rope, _ROPE_CACHE_KEY_ATTR, cache_key)
+        setattr(rope, _ROPE_CACHE_COS_ATTR, torch.cos(phase))
+        setattr(rope, _ROPE_CACHE_SIN_ATTR, torch.sin(phase))
+        setattr(
+            rope,
+            _ROPE_CACHE_POS_ATTR,
+            torch.arange(positions, device=device, dtype=torch.long),
+        )
+    return (
+        getattr(rope, _ROPE_CACHE_COS_ATTR),
+        getattr(rope, _ROPE_CACHE_SIN_ATTR),
+        getattr(rope, _ROPE_CACHE_POS_ATTR),
+    )
+
+
+def _cached_rope_forward(
+    self: Any,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    offset: torch.Tensor,
+    time_before_heads: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if time_before_heads:
+        batch_size, time_steps, _, head_dim = q.shape
+    else:
+        batch_size, _, time_steps, head_dim = q.shape
+    if k.shape != q.shape:
+        raise ValueError(
+            f"Expected k.shape == q.shape, got k={tuple(k.shape)} q={tuple(q.shape)}"
+        )
+    if head_dim <= 0 or (head_dim % 2) != 0:
+        raise ValueError(f"RoPE requires an even last dimension, got D={head_dim}")
+
+    cos_cache, sin_cache, position_offsets = _ensure_rope_cache(
+        self,
+        device=q.device,
+        head_dim=head_dim,
+    )
+    positions = offset.to(device=q.device, dtype=torch.long).view(
+        -1, 1
+    ) + position_offsets[:time_steps].view(1, -1)
+    flat_positions = positions.reshape(-1)
+    rotr = cos_cache.index_select(0, flat_positions).view(
+        batch_size, time_steps, head_dim // 2
+    )
+    roti = sin_cache.index_select(0, flat_positions).view(
+        batch_size, time_steps, head_dim // 2
+    )
+    if time_before_heads:
+        rotr = rotr.view(batch_size, time_steps, 1, head_dim // 2)
+        roti = roti.view(batch_size, time_steps, 1, head_dim // 2)
+    else:
+        rotr = rotr.view(batch_size, 1, time_steps, head_dim // 2)
+        roti = roti.view(batch_size, 1, time_steps, head_dim // 2)
+
+    dims = q.shape[:-1]
+    q = q.view(*dims, head_dim // 2, 2)
+    k = k.view(*dims, head_dim // 2, 2)
+
+    qr, qi = q[..., 0].float(), q[..., 1].float()
+    kr, ki = k[..., 0].float(), k[..., 1].float()
+    qor = qr * rotr - qi * roti
+    qoi = qr * roti + qi * rotr
+    kor = kr * rotr - ki * roti
+    koi = kr * roti + ki * rotr
+
+    dtype = q.dtype
+    qo = torch.stack([qor.to(dtype), qoi.to(dtype)], dim=-1)
+    ko = torch.stack([kor.to(dtype), koi.to(dtype)], dim=-1)
+    return qo.view(*dims, head_dim), ko.view(*dims, head_dim)
+
+
+def patch_codec_rope_for_cuda_graph(codec: Any) -> None:
+    """Make decoder RoPE graph-capturable by avoiding trig ops in capture."""
+
+    try:
+        device = next(codec.parameters()).device
+    except Exception:
+        return
+    head_dims = _decoder_rope_head_dims(codec)
+    for rope in _decoder_rope_modules(codec):
+        if not hasattr(rope, _ROPE_ORIGINAL_FORWARD_ATTR):
+            setattr(rope, _ROPE_ORIGINAL_FORWARD_ATTR, rope.forward)
+            rope.forward = MethodType(_cached_rope_forward, rope)
+        head_dim = head_dims.get(id(rope))
+        if head_dim is not None:
+            _ensure_rope_cache(rope, device=device, head_dim=head_dim)
+
+
+def _cuda_graph_update_streaming_cache(
+    self: Any,
+    state: Any,
+    cached_k: torch.Tensor,
+    cached_v: torch.Tensor,
+    cached_pos: torch.Tensor,
+    k_all: torch.Tensor,
+    v_all: torch.Tensor,
+    pos_k: torch.Tensor,
+) -> None:
+    context = getattr(self, "context", None)
+    original = getattr(self, _ATTN_ORIGINAL_UPDATE_CACHE_ATTR, None)
+    if context is None:
+        if callable(original):
+            return original(state, cached_k, cached_v, cached_pos, k_all, v_all, pos_k)
+        raise RuntimeError("CUDA graph codec attention requires finite context")
+
+    state_cached_keys = getattr(state, "cached_keys", None)
+    state_cached_values = getattr(state, "cached_values", None)
+    state_cached_positions = getattr(state, "cached_positions", None)
+    if (
+        state_cached_keys is None
+        or state_cached_values is None
+        or state_cached_positions is None
+    ):
+        if callable(original):
+            return original(state, cached_k, cached_v, cached_pos, k_all, v_all, pos_k)
+        raise RuntimeError("CUDA graph codec attention cache is not initialized")
+
+    exec_mask = state.exec_mask.view(-1, 1, 1, 1)
+    exec_mask_pos = state.exec_mask.view(-1, 1)
+    new_cached_k = k_all[:, :, -int(context) :, :].contiguous()
+    new_cached_v = v_all[:, :, -int(context) :, :].contiguous()
+    new_cached_pos = pos_k[:, -int(context) :].contiguous()
+    state_cached_keys.copy_(torch.where(exec_mask, new_cached_k, cached_k))
+    state_cached_values.copy_(torch.where(exec_mask, new_cached_v, cached_v))
+    state_cached_positions.copy_(torch.where(exec_mask_pos, new_cached_pos, cached_pos))
+
+
+def patch_codec_attention_cache_for_cuda_graph(codec: Any) -> None:
+    """Keep streaming attention cache storage stable across graph replays."""
+
+    for module in _decoder_attention_modules(codec):
+        update_cache = getattr(module, "_update_streaming_cache", None)
+        if not callable(update_cache):
+            continue
+        if hasattr(module, _ATTN_ORIGINAL_UPDATE_CACHE_ATTR):
+            continue
+        setattr(module, _ATTN_ORIGINAL_UPDATE_CACHE_ATTR, update_cache)
+        module._update_streaming_cache = MethodType(
+            _cuda_graph_update_streaming_cache, module
+        )
+
+
+def _set_attention_implementation(module: Any, attention_implementation: str) -> None:
+    setter = getattr(module, "set_attention_implementation", None)
+    if callable(setter):
+        setter(attention_implementation)
+    else:
+        setattr(module, "attention_implementation", attention_implementation)
+
+
+def set_codec_attention_backend_for_cuda_graph(codec: Any) -> None:
+    """CUDA graph mode always uses the SDPA decoder attention path."""
+
+    setter = getattr(codec, "set_attention_implementation", None)
+    if callable(setter):
+        setter("sdpa")
+        return
+    for module in _decoder_attention_modules(codec):
+        _set_attention_implementation(module, "sdpa")
+
+
+def ensure_codec_decoder_cuda_graph_surface(codec: Any) -> None:
+    """Install the reference branch's decoder split if the HF codec lacks it."""
+
+    if hasattr(codec, "_decode_hidden_states"):
+        return
+    if not hasattr(codec, "decoder") or not hasattr(
+        codec, "_restore_channels_from_codec"
+    ):
+        return
+
+    def _decode_hidden_states(
+        self,
+        decoder_hidden_states: torch.Tensor,
+        codes_lengths: torch.Tensor,
+    ) -> Any:
+        autocast = (
+            self._codec_inference_autocast()
+            if hasattr(self, "_codec_inference_autocast")
+            else nullcontext()
+        )
+        with autocast:
+            audio, audio_lengths = decoder_hidden_states, codes_lengths
+            for decoder_module in self.decoder:
+                audio, audio_lengths = decoder_module(audio, audio_lengths)
+        audio, audio_lengths = self._restore_channels_from_codec(audio, audio_lengths)
+        return SimpleNamespace(audio=audio, audio_lengths=audio_lengths)
+
+    codec._decode_hidden_states = MethodType(_decode_hidden_states, codec)
+
+
+def codec_cuda_graph_supported(codec: Any) -> bool:
+    if not torch.cuda.is_available():
+        return False
+    if not hasattr(codec, "_decode_hidden_states"):
+        return False
+    quantizer = getattr(codec, "quantizer", None)
+    if quantizer is None or not hasattr(quantizer, "decode_codes"):
+        return False
+    try:
+        param = next(codec.parameters())
+    except Exception:
+        return False
+    return isinstance(param, torch.Tensor) and param.device.type == "cuda"
+
+
+class AudioTokenizerDecoderCudaGraph:
+    """Capture and replay the codec decoder while preserving streaming state.
+
+    The quantizer lookup stays eager because it is cheap and can handle changing
+    code values. The expensive decoder stack receives static hidden-state and
+    length buffers under a CUDA graph keyed by static shape.
+    """
+
+    def __init__(self, codec: Any) -> None:
+        if not codec_cuda_graph_supported(codec):
+            raise RuntimeError(
+                "MOSS-TTS Local codec does not expose a CUDA graph-compatible "
+                "decoder surface"
+            )
+        self._codec = codec
+        set_codec_attention_backend_for_cuda_graph(codec)
+        patch_codec_rope_for_cuda_graph(codec)
+        patch_codec_attention_cache_for_cuda_graph(codec)
+        self._cache: dict[
+            tuple[Any, ...],
+            tuple[
+                torch.cuda.CUDAGraph,
+                torch.Tensor,
+                torch.Tensor,
+                torch.Tensor,
+                torch.Tensor,
+            ],
+        ] = {}
+        self._disabled_reason: str | None = None
+        self._streaming_states_cache: list[Any] | None = None
+
+    @property
+    def disabled_reason(self) -> str | None:
+        return self._disabled_reason
+
+    def decode_frame(
+        self,
+        codes: torch.Tensor,
+        code_lengths: torch.Tensor,
+        *,
+        chunk_size: int,
+        advance_frames: int | None = None,
+        active_slots: tuple[int, ...] | None = None,
+    ) -> Any:
+        if self._disabled_reason is not None or codes.device.type != "cuda":
+            return self._codec._decode_frame(codes, code_lengths)
+
+        try:
+            return self._decode_frame_graphed(
+                codes,
+                code_lengths,
+                chunk_size=chunk_size,
+                advance_frames=advance_frames,
+                active_slots=active_slots,
+            )
+        except Exception as exc:
+            self._disabled_reason = str(exc)
+            logger.warning(
+                "MOSS-TTS Local audio-tokenizer CUDA graph capture disabled; "
+                "falling back to eager decoder: %s "
+                "(chunk_size=%s, active_slots=%s, cache_entries=%s)",
+                exc,
+                chunk_size,
+                active_slots,
+                len(self._cache),
+                exc_info=True,
+            )
+            return self._codec._decode_frame(codes, code_lengths)
+
+    def close(self) -> None:
+        self._cache.clear()
+
+    def _decode_frame_graphed(
+        self,
+        codes: torch.Tensor,
+        code_lengths: torch.Tensor,
+        *,
+        chunk_size: int,
+        advance_frames: int | None,
+        active_slots: tuple[int, ...] | None,
+    ) -> Any:
+        codec = self._codec
+        with torch.cuda.device(codes.device):
+            decoder_hidden_states = codec.quantizer.decode_codes(codes).float()
+            graph_key = (
+                str(codes.device),
+                tuple(decoder_hidden_states.shape),
+                str(decoder_hidden_states.dtype),
+                tuple(code_lengths.shape),
+                str(code_lengths.dtype),
+                getattr(codec, "compute_dtype_name", None),
+                int(chunk_size),
+            )
+
+            cached = self._cache.get(graph_key)
+            if cached is None:
+                cached = self._capture_graph(
+                    graph_key, decoder_hidden_states, code_lengths
+                )
+
+            graph, static_hidden, static_lengths, audio, audio_lengths = cached
+            static_hidden.copy_(decoder_hidden_states)
+            static_lengths.copy_(code_lengths)
+            graph.replay()
+            self._correct_streaming_offsets(
+                static_lengths,
+                chunk_size=int(chunk_size),
+                fallback_advance_frames=int(
+                    advance_frames if advance_frames is not None else chunk_size
+                ),
+            )
+            return SimpleNamespace(audio=audio, audio_lengths=audio_lengths)
+
+    def _capture_graph(
+        self,
+        graph_key: tuple[Any, ...],
+        decoder_hidden_states: torch.Tensor,
+        code_lengths: torch.Tensor,
+    ) -> tuple[
+        torch.cuda.CUDAGraph,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ]:
+        static_hidden = decoder_hidden_states.new_zeros(decoder_hidden_states.shape)
+        static_lengths = code_lengths.new_zeros(code_lengths.shape)
+        static_hidden.copy_(decoder_hidden_states)
+        static_lengths.copy_(code_lengths)
+
+        snapshots = self._snapshot_streaming_states()
+        try:
+            with codec_cuda_graph_capture_lock:
+                device = decoder_hidden_states.device
+                current_stream = torch.cuda.current_stream(device=device)
+                capture_stream = torch.cuda.Stream(device=device)
+                capture_stream.wait_stream(current_stream)
+                with torch.cuda.stream(capture_stream):
+                    _ = self._codec._decode_hidden_states(static_hidden, static_lengths)
+                capture_stream.synchronize()
+                self._restore_streaming_states(snapshots)
+                # Restore enqueues tensor copies on the caller's stream; graph
+                # capture must observe those copies before recording decoder ops.
+                capture_stream.wait_stream(current_stream)
+
+                with torch.cuda.device(device):
+                    cuda_graph = torch.cuda.CUDAGraph()
+                    with torch.cuda.graph(
+                        cuda_graph,
+                        stream=capture_stream,
+                        capture_error_mode="relaxed",
+                    ):
+                        decoder_output = self._codec._decode_hidden_states(
+                            static_hidden, static_lengths
+                        )
+                current_stream.wait_stream(capture_stream)
+            if decoder_output.audio is None or decoder_output.audio_lengths is None:
+                raise RuntimeError(
+                    "audio-tokenizer decoder graph capture returned empty audio"
+                )
+
+            captured = (
+                cuda_graph,
+                static_hidden,
+                static_lengths,
+                decoder_output.audio,
+                decoder_output.audio_lengths,
+            )
+            self._cache[graph_key] = captured
+
+            # Capture itself advances the codec streaming state. Restore here;
+            # the caller performs the first replay through the common path.
+            self._restore_streaming_states(snapshots)
+            return captured
+        except Exception:
+            self._restore_streaming_states(snapshots)
+            raise
+
+    def _collect_streaming_states(self) -> list[Any]:
+        states: list[Any] = []
+        decoder = getattr(self._codec, "decoder", ())
+        for decoder_module in decoder:
+            modules = (
+                decoder_module.modules() if hasattr(decoder_module, "modules") else ()
+            )
+            for module in modules:
+                state = getattr(module, "_streaming_state", None)
+                if state is not None:
+                    states.append(state)
+        return states
+
+    def _streaming_states(self) -> list[Any]:
+        if self._streaming_states_cache is None:
+            self._streaming_states_cache = self._collect_streaming_states()
+        return self._streaming_states_cache
+
+    def _snapshot_streaming_states(self) -> list[tuple[Any, dict[str, Any]]]:
+        snapshots: list[tuple[Any, dict[str, Any]]] = []
+        for state in self._streaming_states():
+            state_snapshot: dict[str, Any] = {}
+            for attr in _STATE_TENSOR_ATTRS:
+                if not hasattr(state, attr):
+                    continue
+                value = getattr(state, attr)
+                state_snapshot[attr] = (
+                    value.clone() if isinstance(value, torch.Tensor) else value
+                )
+            for attr in _STATE_VALUE_ATTRS:
+                if hasattr(state, attr):
+                    state_snapshot[attr] = getattr(state, attr)
+            snapshots.append((state, state_snapshot))
+        return snapshots
+
+    def _restore_streaming_states(
+        self, snapshots: list[tuple[Any, dict[str, Any]]]
+    ) -> None:
+        for state, state_snapshot in snapshots:
+            for attr, snapshot_value in state_snapshot.items():
+                current_value = getattr(state, attr, None)
+                if isinstance(snapshot_value, torch.Tensor):
+                    if (
+                        isinstance(current_value, torch.Tensor)
+                        and current_value.shape == snapshot_value.shape
+                        and current_value.dtype == snapshot_value.dtype
+                        and current_value.device == snapshot_value.device
+                    ):
+                        current_value.copy_(snapshot_value)
+                    else:
+                        setattr(state, attr, snapshot_value.clone())
+                elif snapshot_value is None and isinstance(current_value, torch.Tensor):
+                    if attr == "cached_positions":
+                        current_value.fill_(-1)
+                    else:
+                        current_value.zero_()
+                else:
+                    setattr(state, attr, snapshot_value)
+
+    def _correct_streaming_offsets(
+        self,
+        code_lengths: torch.Tensor,
+        *,
+        chunk_size: int,
+        fallback_advance_frames: int,
+    ) -> None:
+        for state in self._streaming_states():
+            corrected_tensor_offset = False
+            for attr in ("offset", "offsets"):
+                value = getattr(state, attr, None)
+                if (
+                    not isinstance(value, torch.Tensor)
+                    or value.ndim == 0
+                    or value.shape[0] != code_lengths.shape[0]
+                ):
+                    continue
+
+                lengths = code_lengths.to(
+                    device=value.device, dtype=value.dtype, non_blocking=True
+                )
+                exec_mask = getattr(state, "exec_mask", None)
+                if (
+                    isinstance(exec_mask, torch.Tensor)
+                    and exec_mask.ndim > 0
+                    and exec_mask.shape[0] == value.shape[0]
+                ):
+                    mask = exec_mask.to(
+                        device=value.device, dtype=torch.bool, non_blocking=True
+                    )
+                else:
+                    mask = lengths > 0
+                correction = lengths - int(chunk_size)
+                value.add_(torch.where(mask, correction, torch.zeros_like(correction)))
+                corrected_tensor_offset = True
+
+            if hasattr(state, "offset_cpu"):
+                # Older codec variants keep a scalar Python offset. They cannot
+                # represent per-slot lengths, so preserve the caller's uniform
+                # fallback behavior for those implementations.
+                if not corrected_tensor_offset:
+                    state.offset_cpu += int(fallback_advance_frames)

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -18,6 +18,10 @@ from sglang_omni.models.moss_tts.stages import (
     _moss_transformers_processor_compat,
     _resolve_checkpoint,
 )
+from sglang_omni.models.moss_tts_local.codec_cuda_graph import (
+    codec_cuda_graph_capture_lock,
+    ensure_codec_decoder_cuda_graph_surface,
+)
 from sglang_omni.models.moss_tts_local.payload_types import (
     moss_tts_local_special_token_defaults,
 )
@@ -76,7 +80,11 @@ def _resolve_codec_device(device: str | None, gpu_id: int | None) -> str:
     return "cuda:0"
 
 
-def _load_moss_tts_local_processor(model_path: str, *, device: str) -> Any:
+def _load_moss_tts_local_processor(
+    model_path: str,
+    *,
+    device: str,
+) -> Any:
     checkpoint_dir = _resolve_checkpoint(model_path)
     logger.info(
         "Loading MOSS-TTS Local processor from %s on %s", checkpoint_dir, device
@@ -94,6 +102,7 @@ def _load_moss_tts_local_processor(model_path: str, *, device: str) -> Any:
     _normalize_processor_config(processor)
     audio_tokenizer = getattr(processor, "audio_tokenizer", None)
     if audio_tokenizer is not None:
+        ensure_codec_decoder_cuda_graph_surface(audio_tokenizer)
         if hasattr(audio_tokenizer, "eval"):
             audio_tokenizer.eval()
         if hasattr(audio_tokenizer, "to"):
@@ -179,7 +188,8 @@ class _BatchedReferenceEncoder:
             unique_paths = list(dict.fromkeys(path for path, _ in batch))
             results: dict[str, Any] = {}
             try:
-                encoded = self._processor.encode_audios_from_path(unique_paths)
+                with codec_cuda_graph_capture_lock:
+                    encoded = self._processor.encode_audios_from_path(unique_paths)
                 results = dict(zip(unique_paths, encoded))
             except Exception:
                 logger.exception(
@@ -188,9 +198,10 @@ class _BatchedReferenceEncoder:
                 )
                 for path in unique_paths:
                     try:
-                        results[path] = self._processor.encode_audios_from_path([path])[
-                            0
-                        ]
+                        with codec_cuda_graph_capture_lock:
+                            results[path] = self._processor.encode_audios_from_path(
+                                [path]
+                            )[0]
                     except Exception as exc:
                         results[path] = exc
             for path, future in batch:
@@ -383,7 +394,8 @@ class CachedReferenceEncoder:
                     f"{_BatchedReferenceEncoder.MAX_REFERENCE_SECONDS:.0f}s"
                 )
             wav = torch.from_numpy(audio.T)
-            return processor.encode_audios_from_wav([wav], int(sample_rate))[0]
+            with codec_cuda_graph_capture_lock:
+                return processor.encode_audios_from_wav([wav], int(sample_rate))[0]
 
         return self._cached_encode(key, _encode, desc="data-URI")
 
@@ -576,6 +588,8 @@ def create_vocoder_executor(
     stream_slots: int = 8,
     stream_chunk_frames: int = 25,
     initial_chunk_frames: int = 5,
+    codec_cuda_graph: bool = True,
+    codec_cuda_graph_step_frames: list[int] | tuple[int, ...] | None = None,
 ) -> MossTTSLocalStreamingVocoderScheduler:
     device = _resolve_codec_device(device, gpu_id)
     processor = _load_moss_tts_local_processor(model_path, device=device)
@@ -586,4 +600,6 @@ def create_vocoder_executor(
         initial_chunk_frames=initial_chunk_frames,
         max_batch_size=max_batch_size,
         max_batch_wait_ms=max_batch_wait_ms,
+        use_cuda_graph=codec_cuda_graph,
+        cuda_graph_step_frames=codec_cuda_graph_step_frames,
     )

--- a/sglang_omni/models/moss_tts_local/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts_local/streaming_vocoder.py
@@ -15,13 +15,20 @@ requests take the pre-existing ``processor.decode_audio_codes`` path.
 
 from __future__ import annotations
 
+import bisect
 import contextlib
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 import torch
 
+from sglang_omni.models.moss_tts_local.codec_cuda_graph import (
+    AudioTokenizerDecoderCudaGraph,
+    codec_cuda_graph_supported,
+    ensure_codec_decoder_cuda_graph_surface,
+    set_codec_attention_backend_for_cuda_graph,
+)
 from sglang_omni.models.moss_tts_local.payload_types import MossTTSLocalState
 from sglang_omni.models.tts_streaming import (
     INITIAL_CODEC_CHUNK_FRAMES_PARAM,
@@ -36,6 +43,41 @@ from sglang_omni.utils.audio_payload import audio_waveform_payload
 logger = logging.getLogger(__name__)
 
 _SOURCE_HINT = "MOSS-TTS Local"
+
+
+def _default_cuda_graph_step_frames(max_step_frames: int) -> tuple[int, ...]:
+    """Mirror SGLang decode CUDA graph's sparse bucket schedule for step T."""
+
+    max_step_frames = int(max_step_frames)
+    if max_step_frames <= 0:
+        return ()
+    capture_frames = [1, 2, 4, 8, 12] + list(range(16, max_step_frames + 1, 8))
+    if max_step_frames not in capture_frames:
+        capture_frames.append(max_step_frames)
+    return tuple(
+        sorted({frame for frame in capture_frames if frame <= max_step_frames})
+    )
+
+
+def _normalize_cuda_graph_step_frames(
+    step_frames: Sequence[int] | None,
+    *,
+    initial_chunk_frames: int,
+    max_step_frames: int,
+    stream_chunk_frames: int,
+) -> tuple[int, ...]:
+    if step_frames is None:
+        values = list(_default_cuda_graph_step_frames(max_step_frames))
+    else:
+        values = [int(frame) for frame in step_frames]
+    values.extend(
+        [int(initial_chunk_frames), int(max_step_frames), int(stream_chunk_frames)]
+    )
+    return tuple(
+        sorted(
+            {int(frame) for frame in values if 0 < int(frame) <= int(max_step_frames)}
+        )
+    )
 
 
 def _resolve_sample_rate(processor: Any) -> int:
@@ -73,7 +115,15 @@ class _CodecStreamSession:
     scheduler loop thread.
     """
 
-    def __init__(self, codec: Any, *, stream_slots: int, offline_slots: int) -> None:
+    def __init__(
+        self,
+        codec: Any,
+        *,
+        stream_slots: int,
+        offline_slots: int,
+        use_cuda_graph: bool = False,
+        cuda_graph_step_frames: Sequence[int] = (),
+    ) -> None:
         self._codec = codec
         self._stream_slots = int(stream_slots)
         self._offline_slots = int(offline_slots)
@@ -82,8 +132,17 @@ class _CodecStreamSession:
         self._free_stream_slots = list(range(self._stream_slots))
         self._exit_stack = contextlib.ExitStack()
         self._closed = False
+        if use_cuda_graph:
+            set_codec_attention_backend_for_cuda_graph(codec)
         with torch.no_grad():
             self._exit_stack.enter_context(codec.streaming(self._batch_size))
+        self._cuda_graph_decoder: AudioTokenizerDecoderCudaGraph | None = None
+        if use_cuda_graph:
+            self._cuda_graph_decoder = AudioTokenizerDecoderCudaGraph(codec)
+        self._cuda_graph_step_frames = tuple(
+            sorted({int(frame) for frame in cuda_graph_step_frames if int(frame) > 0})
+        )
+        self._cuda_graph_warmed = False
 
     def acquire(self) -> int | None:
         if not self._free_stream_slots:
@@ -94,14 +153,93 @@ class _CodecStreamSession:
         if self._closed:
             return
         self._reset_slots([slot])
-        self._free_stream_slots.append(slot)
+        if slot < self._stream_slots:
+            self._free_stream_slots.append(slot)
 
     def close(self) -> None:
         if self._closed:
             return
         with torch.no_grad():
             self._exit_stack.close()
+        if self._cuda_graph_decoder is not None:
+            self._cuda_graph_decoder.close()
+            self._cuda_graph_decoder = None
         self._closed = True
+
+    def warmup_cuda_graphs(
+        self,
+        *,
+        n_vq: int,
+        stream_chunk_frames: int,
+        max_step_frames: int,
+    ) -> None:
+        if self._cuda_graph_decoder is None or self._cuda_graph_warmed:
+            return
+        if self._device.type != "cuda":
+            return
+        n_vq = int(n_vq)
+        graph_specs: list[tuple[int, tuple[int, ...]]] = []
+        if stream_chunk_frames > 0:
+            for n_active in range(1, self._stream_slots + 1):
+                start = self._stream_slots - n_active
+                graph_specs.append(
+                    (
+                        int(stream_chunk_frames),
+                        tuple(range(start, self._stream_slots)),
+                    )
+                )
+        active_offline_slots = tuple(
+            range(self._stream_slots, self._stream_slots + self._offline_slots)
+        )
+        for step_frames in self._cuda_graph_step_frames:
+            if step_frames <= 0 or step_frames > int(max_step_frames):
+                continue
+            graph_specs.append((int(step_frames), active_offline_slots))
+
+        for chunk_size, active_slots in graph_specs:
+            self._warmup_cuda_graph(n_vq, chunk_size, active_slots)
+        self._cuda_graph_warmed = True
+
+    def _warmup_cuda_graph(
+        self, n_vq: int, chunk_size: int, active_slots: tuple[int, ...]
+    ) -> None:
+        assert self._cuda_graph_decoder is not None
+        codes_step = torch.zeros(
+            n_vq,
+            self._batch_size,
+            chunk_size,
+            dtype=torch.long,
+            device=self._device,
+        )
+        codes_lengths = torch.zeros(
+            self._batch_size, dtype=torch.long, device=self._device
+        )
+        exec_mask = torch.zeros(self._batch_size, dtype=torch.bool, device=self._device)
+        for slot in active_slots:
+            codes_lengths[slot] = chunk_size
+            exec_mask[slot] = True
+        with torch.no_grad():
+            self._codec._set_streaming_exec_mask(exec_mask)
+            self._cuda_graph_decoder.decode_frame(
+                codes_step,
+                codes_lengths,
+                chunk_size=chunk_size,
+                advance_frames=chunk_size,
+                active_slots=active_slots,
+            )
+            self._reset_slots(list(active_slots))
+
+    def cuda_graph_bucket(self, step_t: int) -> int | None:
+        if self._cuda_graph_decoder is None:
+            return None
+        index = bisect.bisect_left(self._cuda_graph_step_frames, int(step_t))
+        if index >= len(self._cuda_graph_step_frames):
+            return None
+        return self._cuda_graph_step_frames[index]
+
+    def exact_cuda_graph_bucket(self, step_t: int) -> int | None:
+        bucket = self.cuda_graph_bucket(step_t)
+        return bucket if bucket == int(step_t) else None
 
     def _reset_slots(self, slots: list[int]) -> None:
         reset_mask = torch.zeros(
@@ -117,7 +255,14 @@ class _CodecStreamSession:
         with torch.no_grad():
             self._codec.apply(_reset)
 
-    def step(self, slot_codes: dict[int, torch.Tensor]) -> dict[int, torch.Tensor]:
+    def step(
+        self,
+        slot_codes: dict[int, torch.Tensor],
+        *,
+        use_cuda_graph: bool = True,
+        graph_step_frames: int | None = None,
+        final_step: bool = False,
+    ) -> dict[int, torch.Tensor]:
         """Advance the participating slots by one uniform-length step.
 
         ``slot_codes`` maps slot -> ``[n_vq, T]`` codes with the SAME ``T``
@@ -126,27 +271,47 @@ class _CodecStreamSession:
         """
         if not slot_codes:
             return {}
-        step_lengths = {int(codes.shape[1]) for codes in slot_codes.values()}
-        if len(step_lengths) != 1:
+        step_lengths_by_slot = {
+            int(slot): int(codes.shape[1]) for slot, codes in slot_codes.items()
+        }
+        step_lengths = set(step_lengths_by_slot.values())
+        if len(step_lengths) != 1 and not final_step:
             raise ValueError(
                 f"streaming step requires a uniform length, got {sorted(step_lengths)}"
             )
-        (step_t,) = step_lengths
+        step_t = max(step_lengths)
+        graph_t = int(graph_step_frames) if graph_step_frames is not None else step_t
+        if graph_t < step_t:
+            graph_t = step_t
+        if graph_t > step_t and not final_step:
+            graph_t = step_t
         n_vq = int(next(iter(slot_codes.values())).shape[0])
         codes_step = torch.zeros(
-            n_vq, self._batch_size, step_t, dtype=torch.long, device=self._device
+            n_vq, self._batch_size, graph_t, dtype=torch.long, device=self._device
         )
         codes_lengths = torch.zeros(
             self._batch_size, dtype=torch.long, device=self._device
         )
         exec_mask = torch.zeros(self._batch_size, dtype=torch.bool, device=self._device)
         for slot, codes in slot_codes.items():
-            codes_step[:, slot, :] = codes.to(device=self._device, dtype=torch.long)
-            codes_lengths[slot] = step_t
+            slot_step_t = step_lengths_by_slot[int(slot)]
+            codes_step[:, slot, :slot_step_t] = codes.to(
+                device=self._device, dtype=torch.long
+            )
+            codes_lengths[slot] = slot_step_t
             exec_mask[slot] = True
         with torch.no_grad():
             self._codec._set_streaming_exec_mask(exec_mask)
-            result = self._codec._decode_frame(codes_step, codes_lengths)
+            if self._cuda_graph_decoder is None or not use_cuda_graph:
+                result = self._codec._decode_frame(codes_step, codes_lengths)
+            else:
+                result = self._cuda_graph_decoder.decode_frame(
+                    codes_step,
+                    codes_lengths,
+                    chunk_size=graph_t,
+                    advance_frames=step_t,
+                    active_slots=tuple(sorted(slot_codes)),
+                )
         # One batched D2H per step, active slots only.
         slots = list(slot_codes)
         audio_cpu = result.audio[slots].detach().to("cpu", torch.float32)
@@ -172,6 +337,7 @@ class _CodecStreamSession:
             self._reset_slots(slots)
             cursors = [0] * len(wave)
             chunks: list[list[torch.Tensor]] = [[] for _ in wave]
+            graph_enabled = self._cuda_graph_decoder is not None
             while True:
                 remaining = [
                     int(codes.shape[1]) - cur for codes, cur in zip(wave, cursors)
@@ -179,6 +345,47 @@ class _CodecStreamSession:
                 positive = [r for r in remaining if r > 0]
                 if not positive:
                     break
+                if graph_enabled:
+                    if any(r > max_step_frames for r in positive):
+                        step_t = max_step_frames
+                        plan = {
+                            slots[i]: wave[i][:, cursors[i] : cursors[i] + step_t]
+                            for i, rem in enumerate(remaining)
+                            if rem >= step_t
+                        }
+                        decoded = self.step(
+                            plan,
+                            use_cuda_graph=True,
+                            graph_step_frames=self.exact_cuda_graph_bucket(step_t),
+                        )
+                        for i in range(len(wave)):
+                            if slots[i] in plan:
+                                chunks[i].append(decoded[slots[i]])
+                                cursors[i] += step_t
+                        continue
+
+                    final_groups: dict[int, dict[int, torch.Tensor]] = {}
+                    for i, rem in enumerate(remaining):
+                        if rem <= 0:
+                            continue
+                        bucket = self.cuda_graph_bucket(rem) or rem
+                        final_groups.setdefault(bucket, {})[slots[i]] = wave[i][
+                            :, cursors[i] : cursors[i] + rem
+                        ]
+                    for bucket, plan in sorted(final_groups.items()):
+                        decoded = self.step(
+                            plan,
+                            use_cuda_graph=True,
+                            graph_step_frames=bucket,
+                            final_step=True,
+                        )
+                        for i, rem in enumerate(remaining):
+                            if slots[i] in plan:
+                                chunks[i].append(decoded[slots[i]])
+                                cursors[i] += rem
+                        self._reset_slots(list(plan))
+                    break
+
                 if any(r >= max_step_frames for r in positive):
                     step_t = max_step_frames
                 else:
@@ -188,7 +395,7 @@ class _CodecStreamSession:
                     for i, rem in enumerate(remaining)
                     if rem >= step_t
                 }
-                decoded = self.step(plan)
+                decoded = self.step(plan, use_cuda_graph=False)
                 for i in range(len(wave)):
                     if slots[i] in plan:
                         chunks[i].append(decoded[slots[i]])
@@ -221,6 +428,8 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
         max_step_frames: int = 100,
         max_batch_size: int = 8,
         max_batch_wait_ms: int = 2,
+        use_cuda_graph: bool = True,
+        cuda_graph_step_frames: Sequence[int] | None = None,
     ) -> None:
         if stream_slots < 1:
             raise ValueError(f"stream_slots must be >= 1, got {stream_slots}")
@@ -246,16 +455,39 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
             )
         self._processor = processor
         self._codec = codec
+        ensure_codec_decoder_cuda_graph_surface(codec)
         self._stream_slots = int(stream_slots)
         self._stream_chunk_frames = int(stream_chunk_frames)
         self._default_initial_chunk_frames = max(
             0, min(int(initial_chunk_frames), int(stream_chunk_frames))
         )
         self._max_step_frames = int(max_step_frames)
+        self._cuda_graph_step_frames = _normalize_cuda_graph_step_frames(
+            cuda_graph_step_frames,
+            initial_chunk_frames=self._default_initial_chunk_frames,
+            max_step_frames=self._max_step_frames,
+            stream_chunk_frames=self._stream_chunk_frames,
+        )
         self._offline_slots = max(int(max_batch_size), 1)
         self._n_vq = int(processor.model_config.n_vq)
         self._sample_rate = _resolve_sample_rate(processor)
+        self._use_cuda_graph = bool(
+            use_cuda_graph and codec_cuda_graph_supported(codec)
+        )
+        if use_cuda_graph and not self._use_cuda_graph:
+            logger.info(
+                "MOSS-TTS Local audio-tokenizer CUDA graph is disabled: "
+                "codec is not CUDA graph compatible on this device"
+            )
+        elif self._use_cuda_graph:
+            set_codec_attention_backend_for_cuda_graph(codec)
+            logger.info(
+                "MOSS-TTS Local audio-tokenizer CUDA graph is enabled "
+                "(step_frames=%s)",
+                list(self._cuda_graph_step_frames),
+            )
         self._session: _CodecStreamSession | None = None
+        self._offline_session: _CodecStreamSession | None = None
         self._stream_states: dict[str, _LocalStreamState] = {}
         super().__init__(
             self._vocode,
@@ -266,6 +498,13 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
 
     def start(self) -> None:
         try:
+            if self._use_cuda_graph:
+                logger.info(
+                    "MOSS-TTS Local warming audio-tokenizer CUDA graphs before "
+                    "serving requests"
+                )
+                with self._state_lock:
+                    self._ensure_offline_session()
             super().start()
         finally:
             self._close_streaming_session()
@@ -279,6 +518,9 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
     def _close_streaming_session(self) -> None:
         with self._state_lock:
             self._stream_states.clear()
+            if self._offline_session is not None:
+                self._offline_session.close()
+                self._offline_session = None
             if self._session is not None:
                 self._session.close()
                 self._session = None
@@ -348,7 +590,19 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
                 step_t = min(len(state.pending), self._max_step_frames)
                 codes = torch.stack(state.pending[:step_t], dim=1)
                 del state.pending[:step_t]
-                audio_parts.append(session.step({state.slot: codes})[state.slot])
+                graph_step_frames = (
+                    session.cuda_graph_bucket(step_t)
+                    if not state.pending
+                    else session.exact_cuda_graph_bucket(step_t)
+                )
+                audio_parts.append(
+                    session.step(
+                        {state.slot: codes},
+                        use_cuda_graph=graph_step_frames is not None,
+                        graph_step_frames=graph_step_frames,
+                        final_step=not state.pending,
+                    )[state.slot]
+                )
             session.release(state.slot)
             state.slot = None
 
@@ -394,12 +648,40 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
 
     def _ensure_session(self) -> _CodecStreamSession:
         if self._session is None:
+            if self._offline_session is not None:
+                self._offline_session.close()
+                self._offline_session = None
             self._session = _CodecStreamSession(
                 self._codec,
                 stream_slots=self._stream_slots,
                 offline_slots=self._offline_slots,
+                use_cuda_graph=self._use_cuda_graph,
+                cuda_graph_step_frames=self._cuda_graph_step_frames,
+            )
+            self._session.warmup_cuda_graphs(
+                n_vq=self._n_vq,
+                stream_chunk_frames=self._stream_chunk_frames,
+                max_step_frames=self._max_step_frames,
             )
         return self._session
+
+    def _ensure_offline_session(self) -> _CodecStreamSession:
+        if self._session is not None:
+            return self._session
+        if self._offline_session is None:
+            self._offline_session = _CodecStreamSession(
+                self._codec,
+                stream_slots=0,
+                offline_slots=self._offline_slots,
+                use_cuda_graph=self._use_cuda_graph,
+                cuda_graph_step_frames=self._cuda_graph_step_frames,
+            )
+            self._offline_session.warmup_cuda_graphs(
+                n_vq=self._n_vq,
+                stream_chunk_frames=0,
+                max_step_frames=self._max_step_frames,
+            )
+        return self._offline_session
 
     def _ensure_slot(self, state: _LocalStreamState) -> None:
         if state.slot is None:
@@ -499,7 +781,14 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
             for _, state in participants:
                 plan[state.slot] = torch.stack(state.pending[:step_t], dim=1)
             try:
-                decoded = self._ensure_session().step(plan)
+                graph_step_frames = self._ensure_session().exact_cuda_graph_bucket(
+                    step_t
+                )
+                decoded = self._ensure_session().step(
+                    plan,
+                    use_cuda_graph=graph_step_frames is not None,
+                    graph_step_frames=graph_step_frames,
+                )
             except Exception as exc:
                 logger.exception(
                     "MOSS-TTS Local streaming decode step failed; aborting %d "
@@ -593,7 +882,7 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
 
     def _decode_codes_rows(self, codes_list: list[torch.Tensor]) -> list[torch.Tensor]:
         """Decode ``[T, >=n_vq]`` row tensors to fp32 CPU waveforms."""
-        if self._session is None:
+        if self._session is None and not self._use_cuda_graph:
             # Processor path opens its own streaming context; illegal once a
             # session is live.
             return [
@@ -606,7 +895,12 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
         # abort() resets slots under _state_lock from other threads; serialize
         # every session access on the same lock.
         with self._state_lock:
-            wavs = self._session.decode_offline(
+            session = (
+                self._session
+                if self._session is not None
+                else self._ensure_offline_session()
+            )
+            wavs = session.decode_offline(
                 channels_first, max_step_frames=self._max_step_frames
             )
         return [wav.detach().to("cpu", torch.float32).contiguous() for wav in wavs]

--- a/sglang_omni/models/moss_tts_local/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts_local/streaming_vocoder.py
@@ -23,6 +23,7 @@ from typing import Any, Mapping, Sequence
 
 import torch
 
+from sglang_omni.models.moss_tts.request_builders import MOSS_TTS_DEFAULT_MAX_NEW_TOKENS
 from sglang_omni.models.moss_tts_local.codec_cuda_graph import (
     AudioTokenizerDecoderCudaGraph,
     codec_cuda_graph_supported,
@@ -123,6 +124,7 @@ class _CodecStreamSession:
         offline_slots: int,
         use_cuda_graph: bool = False,
         cuda_graph_step_frames: Sequence[int] = (),
+        cuda_graph_max_audio_frames: int | None = None,
     ) -> None:
         self._codec = codec
         self._stream_slots = int(stream_slots)
@@ -138,7 +140,10 @@ class _CodecStreamSession:
             self._exit_stack.enter_context(codec.streaming(self._batch_size))
         self._cuda_graph_decoder: AudioTokenizerDecoderCudaGraph | None = None
         if use_cuda_graph:
-            self._cuda_graph_decoder = AudioTokenizerDecoderCudaGraph(codec)
+            self._cuda_graph_decoder = AudioTokenizerDecoderCudaGraph(
+                codec,
+                max_audio_frames=cuda_graph_max_audio_frames,
+            )
         self._cuda_graph_step_frames = tuple(
             sorted({int(frame) for frame in cuda_graph_step_frames if int(frame) > 0})
         )
@@ -284,7 +289,10 @@ class _CodecStreamSession:
         if graph_t < step_t:
             graph_t = step_t
         if graph_t > step_t and not final_step:
-            graph_t = step_t
+            raise AssertionError(
+                "CUDA graph bucket padding is only safe for terminal steps; "
+                "the caller must reset padded slots immediately after replay"
+            )
         n_vq = int(next(iter(slot_codes.values())).shape[0])
         codes_step = torch.zeros(
             n_vq, self._batch_size, graph_t, dtype=torch.long, device=self._device
@@ -471,6 +479,22 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
         self._offline_slots = max(int(max_batch_size), 1)
         self._n_vq = int(processor.model_config.n_vq)
         self._sample_rate = _resolve_sample_rate(processor)
+        autoregressive_model_config = getattr(
+            processor.model_config,
+            "qwen3_config",
+            getattr(processor.model_config, "language_config", None),
+        )
+        try:
+            max_audio_frames = int(
+                getattr(autoregressive_model_config, "max_position_embeddings", 0)
+            )
+        except (TypeError, ValueError):
+            max_audio_frames = 0
+        self._cuda_graph_max_audio_frames = (
+            max_audio_frames
+            if max_audio_frames > 0
+            else MOSS_TTS_DEFAULT_MAX_NEW_TOKENS
+        )
         self._use_cuda_graph = bool(
             use_cuda_graph and codec_cuda_graph_supported(codec)
         )
@@ -483,8 +507,9 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
             set_codec_attention_backend_for_cuda_graph(codec)
             logger.info(
                 "MOSS-TTS Local audio-tokenizer CUDA graph is enabled "
-                "(step_frames=%s)",
+                "(step_frames=%s, max_audio_frames=%s)",
                 list(self._cuda_graph_step_frames),
+                self._cuda_graph_max_audio_frames,
             )
         self._session: _CodecStreamSession | None = None
         self._offline_session: _CodecStreamSession | None = None
@@ -657,6 +682,7 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
                 offline_slots=self._offline_slots,
                 use_cuda_graph=self._use_cuda_graph,
                 cuda_graph_step_frames=self._cuda_graph_step_frames,
+                cuda_graph_max_audio_frames=self._cuda_graph_max_audio_frames,
             )
             self._session.warmup_cuda_graphs(
                 n_vq=self._n_vq,
@@ -675,6 +701,7 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
                 offline_slots=self._offline_slots,
                 use_cuda_graph=self._use_cuda_graph,
                 cuda_graph_step_frames=self._cuda_graph_step_frames,
+                cuda_graph_max_audio_frames=self._cuda_graph_max_audio_frames,
             )
             self._offline_session.warmup_cuda_graphs(
                 n_vq=self._n_vq,

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -999,6 +999,40 @@ def test_cached_reference_encoder_data_uri_hit_miss(tmp_path):
     assert stats["misses"] == 1
 
 
+def test_cached_reference_encoder_data_uri_uses_cuda_graph_capture_lock(monkeypatch):
+    from sglang_omni.models.moss_tts_local import stages
+    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+
+    data_uri, _ = _make_wav_data_uri()
+    lock_depth = 0
+    observed_lock_depths: list[int] = []
+
+    class _FakeLock:
+        def __enter__(self):
+            nonlocal lock_depth
+            lock_depth += 1
+
+        def __exit__(self, exc_type, exc, tb):
+            nonlocal lock_depth
+            lock_depth -= 1
+            return False
+
+    class _FakeProc:
+        def encode_audios_from_wav(self, wavs, sample_rate):
+            observed_lock_depths.append(lock_depth)
+            return [torch.full((5, N_VQ), 42, dtype=torch.long)]
+
+    monkeypatch.setattr(stages, "codec_cuda_graph_capture_lock", _FakeLock())
+
+    enc = CachedReferenceEncoder(
+        None, max_items=256, max_bytes=64 << 20  # type: ignore[arg-type]
+    )
+    enc.encode_data_uri(data_uri, processor=_FakeProc())
+
+    assert observed_lock_depths == [1]
+    assert lock_depth == 0
+
+
 def test_cached_reference_encoder_file_bytes_keyspaces_do_not_collide(tmp_path):
     """file: and bytes: keys are independent; same-content file ≠ data-URI in cache."""
     from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder

--- a/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
+++ b/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
@@ -13,6 +13,7 @@ codes — the property the v2 codec provides by construction.
 
 from __future__ import annotations
 
+import math
 import queue
 from contextlib import contextmanager
 from types import SimpleNamespace
@@ -23,7 +24,14 @@ import pytest
 import torch
 from torch import nn
 
-from sglang_omni.models.moss_tts_local import stages
+from sglang_omni.models.moss_tts_local import (
+    codec_cuda_graph,
+    stages,
+    streaming_vocoder,
+)
+from sglang_omni.models.moss_tts_local.codec_cuda_graph import (
+    ensure_codec_decoder_cuda_graph_surface,
+)
 from sglang_omni.models.moss_tts_local.payload_types import MossTTSLocalState
 from sglang_omni.models.moss_tts_local.request_builders import (
     build_moss_tts_local_stream_metadata,
@@ -138,6 +146,188 @@ class FakeProcessor:
         return wavs
 
 
+class _PatchableDecoder(nn.Module):
+    def forward(self, audio: torch.Tensor, lengths: torch.Tensor):
+        return audio + 1.0, lengths + 2
+
+
+class _PatchableCodec(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.decoder = nn.ModuleList([_PatchableDecoder()])
+
+    def _restore_channels_from_codec(self, audio: torch.Tensor, lengths: torch.Tensor):
+        return audio * 2.0, lengths + 1
+
+
+class _AttentionLeaf(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.attention_implementation = "flash_attention_2"
+
+    def set_attention_implementation(self, attention_implementation: str) -> None:
+        self.attention_implementation = attention_implementation
+
+
+class _AttentionParent(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.attention_implementation = "flash_attention_2"
+        self.child = _AttentionLeaf()
+
+    def set_attention_implementation(self, attention_implementation: str) -> None:
+        self.attention_implementation = attention_implementation
+        self.child.set_attention_implementation(attention_implementation)
+
+
+class _AttentionCodec(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.attention_implementation = "flash_attention_2"
+        self.set_calls: list[str] = []
+        self.dummy = nn.Parameter(torch.zeros(1))
+        self.decoder = nn.ModuleList([_AttentionParent()])
+
+    def set_attention_implementation(self, attention_implementation: str) -> None:
+        self.set_calls.append(attention_implementation)
+        self.attention_implementation = attention_implementation
+        for module in self.decoder:
+            module.set_attention_implementation(attention_implementation)
+
+
+class _TinyRotaryEmbedding(nn.Module):
+    def __init__(self, max_period: float = 10000.0) -> None:
+        super().__init__()
+        self.max_period = max_period
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        offset: torch.Tensor,
+        time_before_heads: bool = False,
+    ):
+        if time_before_heads:
+            batch_size, time_steps, _, head_dim = q.shape
+        else:
+            batch_size, _, time_steps, head_dim = q.shape
+        ds = torch.arange(head_dim // 2, device=q.device, dtype=torch.float32)
+        freqs = torch.exp(ds * (-math.log(self.max_period) * 2 / head_dim))
+        ts = offset.float().view(-1, 1) + torch.arange(
+            time_steps, device=q.device, dtype=torch.float32
+        )
+        if time_before_heads:
+            ts = ts.view(batch_size, -1, 1, 1)
+        else:
+            ts = ts.view(batch_size, 1, -1, 1)
+
+        dims = q.shape[:-1]
+        q = q.view(*dims, head_dim // 2, 2)
+        k = k.view(*dims, head_dim // 2, 2)
+        qr, qi = q[..., 0].float(), q[..., 1].float()
+        kr, ki = k[..., 0].float(), k[..., 1].float()
+        rotr = torch.cos(freqs * ts)
+        roti = torch.sin(freqs * ts)
+        qo = torch.stack(
+            [(qr * rotr - qi * roti).to(q.dtype), (qr * roti + qi * rotr).to(q.dtype)],
+            dim=-1,
+        )
+        ko = torch.stack(
+            [(kr * rotr - ki * roti).to(k.dtype), (kr * roti + ki * rotr).to(k.dtype)],
+            dim=-1,
+        )
+        return qo.view(*dims, head_dim), ko.view(*dims, head_dim)
+
+
+class _RopeAttention(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.embed_dim = 8
+        self.num_heads = 2
+        self.rope = _TinyRotaryEmbedding()
+
+
+class _RopeCodec(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.dummy = nn.Parameter(torch.zeros(1))
+        self.decoder = nn.ModuleList([_RopeAttention()])
+
+
+class _CacheState:
+    def __init__(self) -> None:
+        self.exec_mask = torch.tensor([True, False])
+        self.cached_keys = torch.tensor([[[[1.0], [2.0]]], [[[3.0], [4.0]]]])
+        self.cached_values = self.cached_keys + 10.0
+        self.cached_positions = torch.tensor([[0, 1], [2, 3]])
+
+
+class _CacheAttention(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.attention_implementation = "sdpa"
+        self.context = 2
+
+    def _update_streaming_cache(
+        self,
+        state,
+        cached_k,
+        cached_v,
+        cached_pos,
+        k_all,
+        v_all,
+        pos_k,
+    ) -> None:
+        exec_mask = state.exec_mask.view(-1, 1, 1, 1)
+        exec_mask_pos = state.exec_mask.view(-1, 1)
+        state.cached_keys = torch.where(exec_mask, k_all[:, :, -2:, :], cached_k)
+        state.cached_values = torch.where(exec_mask, v_all[:, :, -2:, :], cached_v)
+        state.cached_positions = torch.where(exec_mask_pos, pos_k[:, -2:], cached_pos)
+
+
+class _CacheCodec(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.decoder = nn.ModuleList([_CacheAttention()])
+
+
+class _StreamingStateModule(nn.Module):
+    def __init__(self, state: Any) -> None:
+        super().__init__()
+        self._streaming_state = state
+
+
+class _StreamingStateCodec(nn.Module):
+    def __init__(self, state: Any) -> None:
+        super().__init__()
+        self.dummy = nn.Parameter(torch.zeros(1))
+        self.decoder = nn.ModuleList([_StreamingStateModule(state)])
+
+
+class _FakeCudaGraphDecoder:
+    disabled_reason = None
+
+    def __init__(self, codec: FakeCodec) -> None:
+        self._codec = codec
+        self.calls: list[tuple[int, tuple[int, ...] | None]] = []
+
+    def decode_frame(
+        self,
+        codes: torch.Tensor,
+        code_lengths: torch.Tensor,
+        *,
+        chunk_size: int,
+        advance_frames: int | None = None,
+        active_slots: tuple[int, ...] | None = None,
+    ):
+        del advance_frames
+        self.calls.append((chunk_size, active_slots))
+        return self._codec._decode_frame(codes, code_lengths)
+
+    def close(self) -> None:
+        pass
+
+
 def reference_waveform(rows: torch.Tensor) -> torch.Tensor:
     """Stateless offline decode of [T, n_vq] codes rows."""
     codes = rows[:, :N_VQ]
@@ -157,7 +347,7 @@ def _make_scheduler(
     monkeypatch.setattr(
         stages,
         "_load_moss_tts_local_processor",
-        lambda model_path, *, device: processor,
+        lambda model_path, *, device, **_: processor,
     )
     scheduler = stages.create_vocoder_executor("fake-model", device="cpu", **kwargs)
     assert isinstance(scheduler, MossTTSLocalStreamingVocoderScheduler)
@@ -269,6 +459,135 @@ def test_stream_metadata_builder() -> None:
         "n_vq": 12,
         INITIAL_CODEC_CHUNK_FRAMES_PARAM: 3,
     }
+
+
+def test_cuda_graph_surface_patch_splits_decoder_hidden_states() -> None:
+    codec = _PatchableCodec()
+
+    ensure_codec_decoder_cuda_graph_surface(codec)
+
+    hidden = torch.zeros(2, 1, 3)
+    lengths = torch.tensor([3])
+    result = codec._decode_hidden_states(hidden, lengths)
+    torch.testing.assert_close(result.audio, torch.full_like(hidden, 2.0))
+    torch.testing.assert_close(result.audio_lengths, torch.tensor([6]))
+
+
+def test_cuda_graph_decoder_directly_sets_sdpa_attention(monkeypatch) -> None:
+    codec = _AttentionCodec()
+    parent = codec.decoder[0]
+    leaf = parent.child
+    monkeypatch.setattr(codec_cuda_graph, "codec_cuda_graph_supported", lambda _: True)
+
+    graph_decoder = codec_cuda_graph.AudioTokenizerDecoderCudaGraph(codec)
+
+    assert codec.set_calls == ["sdpa"]
+    assert codec.attention_implementation == "sdpa"
+    assert parent.attention_implementation == "sdpa"
+    assert leaf.attention_implementation == "sdpa"
+
+    graph_decoder.close()
+
+    assert codec.attention_implementation == "sdpa"
+    assert parent.attention_implementation == "sdpa"
+    assert leaf.attention_implementation == "sdpa"
+
+
+def test_cuda_graph_decoder_caches_streaming_states(monkeypatch) -> None:
+    initial_state = SimpleNamespace(offset=torch.tensor([0, 0]))
+    replacement_state = SimpleNamespace(offset=torch.tensor([1, 1]))
+    codec = _StreamingStateCodec(initial_state)
+    monkeypatch.setattr(codec_cuda_graph, "codec_cuda_graph_supported", lambda _: True)
+    graph_decoder = codec_cuda_graph.AudioTokenizerDecoderCudaGraph(codec)
+
+    states = graph_decoder._streaming_states()
+    codec.decoder[0]._streaming_state = replacement_state
+
+    assert graph_decoder._streaming_states() is states
+    assert graph_decoder._streaming_states() == [initial_state]
+
+
+def test_cuda_graph_rope_patch_matches_original() -> None:
+    codec = _RopeCodec()
+    rope = codec.decoder[0].rope
+    offset = torch.tensor([0, 3])
+    q = torch.randn(2, 2, 5, 4)
+    k = torch.randn(2, 2, 5, 4)
+    expected_q, expected_k = rope(q, k, offset, time_before_heads=False)
+
+    codec_cuda_graph.patch_codec_rope_for_cuda_graph(codec)
+
+    actual_q, actual_k = rope(q, k, offset, time_before_heads=False)
+    torch.testing.assert_close(actual_q, expected_q)
+    torch.testing.assert_close(actual_k, expected_k)
+    assert hasattr(rope, "_sglang_omni_original_rope_forward")
+
+    q_time_first = q.transpose(1, 2).contiguous()
+    k_time_first = k.transpose(1, 2).contiguous()
+    expected_q, expected_k = rope._sglang_omni_original_rope_forward(
+        q_time_first, k_time_first, offset, time_before_heads=True
+    )
+    actual_q, actual_k = rope(
+        q_time_first, k_time_first, offset, time_before_heads=True
+    )
+    torch.testing.assert_close(actual_q, expected_q)
+    torch.testing.assert_close(actual_k, expected_k)
+
+
+def test_cuda_graph_attention_cache_patch_keeps_storage_stable() -> None:
+    codec = _CacheCodec()
+    attention = codec.decoder[0]
+    state = _CacheState()
+    original_keys = state.cached_keys
+    original_values = state.cached_values
+    original_positions = state.cached_positions
+    cached_k = state.cached_keys.clone()
+    cached_v = state.cached_values.clone()
+    cached_pos = state.cached_positions.clone()
+    k_all = torch.tensor([[[[5.0], [6.0], [7.0]]], [[[8.0], [9.0], [10.0]]]])
+    v_all = k_all + 20.0
+    pos_k = torch.tensor([[4, 5, 6], [7, 8, 9]])
+
+    codec_cuda_graph.patch_codec_attention_cache_for_cuda_graph(codec)
+    attention._update_streaming_cache(
+        state, cached_k, cached_v, cached_pos, k_all, v_all, pos_k
+    )
+
+    assert state.cached_keys is original_keys
+    assert state.cached_values is original_values
+    assert state.cached_positions is original_positions
+    torch.testing.assert_close(
+        state.cached_keys, torch.tensor([[[[6.0], [7.0]]], [[[3.0], [4.0]]]])
+    )
+    torch.testing.assert_close(
+        state.cached_values, torch.tensor([[[[26.0], [27.0]]], [[[13.0], [14.0]]]])
+    )
+    torch.testing.assert_close(state.cached_positions, torch.tensor([[5, 6], [2, 3]]))
+    assert hasattr(attention, "_sglang_omni_original_update_streaming_cache")
+
+
+def test_cuda_graph_offset_correction_uses_real_code_lengths() -> None:
+    graph = object.__new__(codec_cuda_graph.AudioTokenizerDecoderCudaGraph)
+    offset_state = SimpleNamespace(
+        exec_mask=torch.tensor([True, True, False]),
+        offset=torch.tensor([18, 28, 30]),
+    )
+    offsets_state = SimpleNamespace(
+        exec_mask=torch.tensor([True, True, False]),
+        offsets=torch.tensor([108, 208, 300]),
+    )
+    cpu_state = SimpleNamespace(offset_cpu=11)
+    graph._streaming_states = lambda: [offset_state, offsets_state, cpu_state]
+
+    graph._correct_streaming_offsets(
+        torch.tensor([3, 5, 0]),
+        chunk_size=8,
+        fallback_advance_frames=5,
+    )
+
+    torch.testing.assert_close(offset_state.offset, torch.tensor([13, 25, 30]))
+    torch.testing.assert_close(offsets_state.offsets, torch.tensor([103, 205, 300]))
+    assert cpu_state.offset_cpu == 16
 
 
 def test_stream_concatenates_to_offline_decode(monkeypatch) -> None:
@@ -600,6 +919,81 @@ def test_done_without_chunks_decodes_payload_codes(monkeypatch) -> None:
         reference_waveform(rows[:, 1:]).numpy(),
     )
     assert [m.type for m in messages] == ["stream", "result"]
+
+
+def test_non_streaming_cuda_graph_mode_creates_offline_session(monkeypatch) -> None:
+    processor = FakeProcessor()
+    monkeypatch.setattr(streaming_vocoder, "codec_cuda_graph_supported", lambda _: True)
+    monkeypatch.setattr(
+        streaming_vocoder, "AudioTokenizerDecoderCudaGraph", _FakeCudaGraphDecoder
+    )
+    scheduler = _make_scheduler(monkeypatch, processor, max_batch_size=2)
+    rows = _rows(7, seed=51)
+
+    wavs = scheduler._decode_codes_rows([rows[:, 1:]])
+
+    assert scheduler._session is None
+    assert scheduler._offline_session is not None
+    assert processor.decode_calls == 0
+    np.testing.assert_array_equal(wavs[0].numpy(), reference_waveform(rows[:, 1:]))
+
+    _run_stream(scheduler, _rows(5, seed=53))
+    assert scheduler._session is not None
+    assert scheduler._offline_session is None
+    scheduler._close_streaming_session()
+
+
+def test_streaming_cuda_graph_captures_default_initial_chunk(monkeypatch) -> None:
+    processor = FakeProcessor()
+    monkeypatch.setattr(streaming_vocoder, "codec_cuda_graph_supported", lambda _: True)
+    monkeypatch.setattr(
+        streaming_vocoder, "AudioTokenizerDecoderCudaGraph", _FakeCudaGraphDecoder
+    )
+    scheduler = MossTTSLocalStreamingVocoderScheduler(
+        processor,
+        stream_chunk_frames=10,
+        initial_chunk_frames=5,
+        max_step_frames=10,
+        use_cuda_graph=True,
+    )
+
+    messages = _run_stream(scheduler, _rows(5, seed=54))
+
+    decoder = scheduler._session._cuda_graph_decoder
+    assert isinstance(decoder, _FakeCudaGraphDecoder)
+    assert scheduler._cuda_graph_step_frames == (1, 2, 4, 5, 8, 10)
+    assert decoder.calls == [(5, (7,))]
+    assert [m.type for m in messages] == ["stream", "result"]
+    scheduler._close_streaming_session()
+
+
+def test_offline_cuda_graph_pads_final_chunks_to_step_buckets(monkeypatch) -> None:
+    processor = FakeProcessor()
+    monkeypatch.setattr(streaming_vocoder, "codec_cuda_graph_supported", lambda _: True)
+    monkeypatch.setattr(
+        streaming_vocoder, "AudioTokenizerDecoderCudaGraph", _FakeCudaGraphDecoder
+    )
+    scheduler = MossTTSLocalStreamingVocoderScheduler(
+        processor,
+        stream_chunk_frames=5,
+        max_step_frames=5,
+        max_batch_size=2,
+        use_cuda_graph=True,
+    )
+    rows_long = _rows(8, seed=52)
+    rows_short = _rows(4, seed=53)
+
+    wavs = scheduler._decode_codes_rows([rows_long[:, 1:], rows_short[:, 1:]])
+
+    decoder = scheduler._offline_session._cuda_graph_decoder
+    assert isinstance(decoder, _FakeCudaGraphDecoder)
+    assert scheduler._cuda_graph_step_frames == (1, 2, 4, 5)
+    assert decoder.calls == [(5, (0,)), (4, (0, 1))]
+    np.testing.assert_array_equal(wavs[0].numpy(), reference_waveform(rows_long[:, 1:]))
+    np.testing.assert_array_equal(
+        wavs[1].numpy(), reference_waveform(rows_short[:, 1:])
+    )
+    scheduler._close_streaming_session()
 
 
 def test_abort_releases_slot(monkeypatch) -> None:

--- a/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
+++ b/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
@@ -254,6 +254,47 @@ class _RopeCodec(nn.Module):
         self.decoder = nn.ModuleList([_RopeAttention()])
 
 
+class _RopeDecodeCodec(_RopeCodec):
+    def _decode_frame(self, codes: torch.Tensor, code_lengths: torch.Tensor):
+        del code_lengths
+        batch = int(codes.shape[1])
+        q = torch.zeros(batch, 2, 1, 4)
+        k = torch.zeros_like(q)
+        offset = torch.zeros(batch, dtype=torch.long)
+        q_out, _ = self.decoder[0].rope(q, k, offset)
+        return SimpleNamespace(
+            audio=q_out.reshape(batch, 1, -1),
+            audio_lengths=torch.full((batch,), q_out[0].numel(), dtype=torch.long),
+        )
+
+
+class _UpsampleModule(nn.Module):
+    def __init__(self, ratio: int) -> None:
+        super().__init__()
+        self.downsample_ratio = int(ratio)
+
+
+class _MossV2ScaleRopeCodec(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.dummy = nn.Parameter(torch.zeros(1))
+        self.decoder = nn.ModuleList(
+            [
+                _RopeAttention(),
+                _UpsampleModule(2),
+                _RopeAttention(),
+                _UpsampleModule(2),
+                _RopeAttention(),
+                _UpsampleModule(2),
+                _RopeAttention(),
+                _UpsampleModule(2),
+                _RopeAttention(),
+                _UpsampleModule(2),
+                _RopeAttention(),
+            ]
+        )
+
+
 class _CacheState:
     def __init__(self) -> None:
         self.exec_mask = torch.tensor([True, False])
@@ -307,8 +348,11 @@ class _StreamingStateCodec(nn.Module):
 class _FakeCudaGraphDecoder:
     disabled_reason = None
 
-    def __init__(self, codec: FakeCodec) -> None:
+    def __init__(
+        self, codec: FakeCodec, *, max_audio_frames: int | None = None
+    ) -> None:
         self._codec = codec
+        self.max_audio_frames = max_audio_frames
         self.calls: list[tuple[int, tuple[int, ...] | None]] = []
 
     def decode_frame(
@@ -515,11 +559,11 @@ def test_cuda_graph_rope_patch_matches_original() -> None:
     k = torch.randn(2, 2, 5, 4)
     expected_q, expected_k = rope(q, k, offset, time_before_heads=False)
 
-    codec_cuda_graph.patch_codec_rope_for_cuda_graph(codec)
+    codec_cuda_graph.patch_codec_rope_for_cuda_graph(codec, cache_positions=8)
 
     actual_q, actual_k = rope(q, k, offset, time_before_heads=False)
-    torch.testing.assert_close(actual_q, expected_q)
-    torch.testing.assert_close(actual_k, expected_k)
+    assert torch.equal(actual_q, expected_q)
+    assert torch.equal(actual_k, expected_k)
     assert hasattr(rope, "_sglang_omni_original_rope_forward")
 
     q_time_first = q.transpose(1, 2).contiguous()
@@ -530,8 +574,57 @@ def test_cuda_graph_rope_patch_matches_original() -> None:
     actual_q, actual_k = rope(
         q_time_first, k_time_first, offset, time_before_heads=True
     )
-    torch.testing.assert_close(actual_q, expected_q)
-    torch.testing.assert_close(actual_k, expected_k)
+    assert torch.equal(actual_q, expected_q)
+    assert torch.equal(actual_k, expected_k)
+
+
+def test_cuda_graph_rope_cache_covers_default_moss_v2_decoder_scale(
+    monkeypatch,
+) -> None:
+    codec = _MossV2ScaleRopeCodec()
+    monkeypatch.setattr(codec_cuda_graph, "codec_cuda_graph_supported", lambda _: True)
+    graph_decoder = codec_cuda_graph.AudioTokenizerDecoderCudaGraph(
+        codec, max_audio_frames=4096
+    )
+
+    assert graph_decoder._rope_cache_limit == 131072
+    for decoder_module in (
+        codec.decoder[0],
+        codec.decoder[2],
+        codec.decoder[4],
+        codec.decoder[6],
+        codec.decoder[8],
+        codec.decoder[10],
+    ):
+        rope = decoder_module.rope
+        assert getattr(rope, "_sglang_omni_cuda_graph_rope_cos").shape[0] == 131072
+    graph_decoder.close()
+
+
+def test_cuda_graph_eager_fallback_uses_original_rope(monkeypatch) -> None:
+    codec = _RopeDecodeCodec()
+    monkeypatch.setattr(codec_cuda_graph, "codec_cuda_graph_supported", lambda _: True)
+    graph_decoder = codec_cuda_graph.AudioTokenizerDecoderCudaGraph(codec)
+    rope = codec.decoder[0].rope
+
+    def original_forward(q, k, offset, time_before_heads=False):
+        del offset, time_before_heads
+        return torch.full_like(q, 7.0), torch.full_like(k, 8.0)
+
+    setattr(rope, "_sglang_omni_original_rope_forward", original_forward)
+    graph_decoder._disabled_reason = "capture failed"
+
+    result = graph_decoder.decode_frame(
+        torch.zeros(1, 1, 1, dtype=torch.long),
+        torch.ones(1, dtype=torch.long),
+        chunk_size=1,
+    )
+
+    torch.testing.assert_close(result.audio, torch.full_like(result.audio, 7.0))
+    q = torch.zeros(1, 2, 1, 4)
+    k = torch.zeros_like(q)
+    q_out, _ = rope(q, k, torch.zeros(1, dtype=torch.long))
+    assert torch.equal(q_out, q)
 
 
 def test_cuda_graph_attention_cache_patch_keeps_storage_stable() -> None:
@@ -943,6 +1036,24 @@ def test_non_streaming_cuda_graph_mode_creates_offline_session(monkeypatch) -> N
     scheduler._close_streaming_session()
 
 
+def test_cuda_graph_uses_autoregressive_max_position_embeddings(monkeypatch) -> None:
+    processor = FakeProcessor()
+    processor.model_config.qwen3_config = SimpleNamespace(max_position_embeddings=32768)
+    monkeypatch.setattr(streaming_vocoder, "codec_cuda_graph_supported", lambda _: True)
+    monkeypatch.setattr(
+        streaming_vocoder, "AudioTokenizerDecoderCudaGraph", _FakeCudaGraphDecoder
+    )
+    scheduler = MossTTSLocalStreamingVocoderScheduler(processor, use_cuda_graph=True)
+
+    session = scheduler._ensure_offline_session()
+    decoder = session._cuda_graph_decoder
+
+    assert scheduler._cuda_graph_max_audio_frames == 32768
+    assert isinstance(decoder, _FakeCudaGraphDecoder)
+    assert decoder.max_audio_frames == 32768
+    scheduler._close_streaming_session()
+
+
 def test_streaming_cuda_graph_captures_default_initial_chunk(monkeypatch) -> None:
     processor = FakeProcessor()
     monkeypatch.setattr(streaming_vocoder, "codec_cuda_graph_supported", lambda _: True)
@@ -994,6 +1105,30 @@ def test_offline_cuda_graph_pads_final_chunks_to_step_buckets(monkeypatch) -> No
         wavs[1].numpy(), reference_waveform(rows_short[:, 1:])
     )
     scheduler._close_streaming_session()
+
+
+def test_cuda_graph_rejects_nonterminal_padded_step(monkeypatch) -> None:
+    processor = FakeProcessor()
+    monkeypatch.setattr(
+        streaming_vocoder, "AudioTokenizerDecoderCudaGraph", _FakeCudaGraphDecoder
+    )
+    session = streaming_vocoder._CodecStreamSession(
+        processor.audio_tokenizer,
+        stream_slots=0,
+        offline_slots=1,
+        use_cuda_graph=True,
+        cuda_graph_step_frames=(4,),
+    )
+    try:
+        with pytest.raises(AssertionError, match="terminal steps"):
+            session.step(
+                {0: torch.ones(N_VQ, 2, dtype=torch.long)},
+                use_cuda_graph=True,
+                graph_step_frames=4,
+                final_step=False,
+            )
+    finally:
+        session.close()
 
 
 def test_abort_releases_slot(monkeypatch) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
This pull request introduces support for CUDA Graphs in the MOSS-TTS Local streaming vocoder, aiming to improve inference efficiency and performance, especially for batch audio decoding on compatible CUDA devices. The changes add new options for enabling CUDA Graphs, implement logic to manage CUDA Graph warmup and execution, and ensure compatibility and fallback when CUDA Graphs are not available.

## Modifications
**CUDA Graphs Integration and Configuration:**

* Added support for CUDA Graphs in the streaming vocoder by introducing new parameters (`use_cuda_graph`, `cuda_graph_step_frames`) to the `create_vocoder_executor` and vocoder scheduler classes, allowing users to enable and configure CUDA Graph execution. [[1]](diffhunk://#diff-3fa7e30e7aba8595743c0ca045b50e50cf8131c8bb2ccdd4868f11e0ae583922R591-R592) [[2]](diffhunk://#diff-3fa7e30e7aba8595743c0ca045b50e50cf8131c8bb2ccdd4868f11e0ae583922R603-R604) [[3]](diffhunk://#diff-862eccdc1e989e72b58b23348d7e36787c0cb2f130015fb50665c8762e598314R431-R432)
* Implemented CUDA Graph warmup routines and step frame bucketization, including helper functions (`_default_cuda_graph_step_frames`, `_normalize_cuda_graph_step_frames`) to determine and normalize step frame schedules for graph capture. [[1]](diffhunk://#diff-862eccdc1e989e72b58b23348d7e36787c0cb2f130015fb50665c8762e598314R48-R82) [[2]](diffhunk://#diff-862eccdc1e989e72b58b23348d7e36787c0cb2f130015fb50665c8762e598314L76-R126)

**Codec and Session Management Enhancements:**

* Updated `_CodecStreamSession` to manage CUDA Graph decoder instances, warm up graphs for various chunk and slot configurations, and select the appropriate graph bucket for each decoding step. [[1]](diffhunk://#diff-862eccdc1e989e72b58b23348d7e36787c0cb2f130015fb50665c8762e598314L76-R126) [[2]](diffhunk://#diff-862eccdc1e989e72b58b23348d7e36787c0cb2f130015fb50665c8762e598314R156-R243)
* Modified the `step` and `decode_offline` methods to leverage CUDA Graphs when enabled, falling back to standard decoding otherwise, and optimizing batch decoding with graph bucket selection. [[1]](diffhunk://#diff-862eccdc1e989e72b58b23348d7e36787c0cb2f130015fb50665c8762e598314L120-R265) [[2]](diffhunk://#diff-862eccdc1e989e72b58b23348d7e36787c0cb2f130015fb50665c8762e598314R340-R388) [[3]](diffhunk://#diff-862eccdc1e989e72b58b23348d7e36787c0cb2f130015fb50665c8762e598314L191-R398)

**Thread Safety and Codec Compatibility:**

* Added locking and surface preparation for CUDA Graphs in codec operations to ensure thread safety and compatibility, including the use of `codec_cuda_graph_capture_lock` and `ensure_codec_decoder_cuda_graph_surface` in various processor and worker routines. [[1]](diffhunk://#diff-3fa7e30e7aba8595743c0ca045b50e50cf8131c8bb2ccdd4868f11e0ae583922R21-R24) [[2]](diffhunk://#diff-3fa7e30e7aba8595743c0ca045b50e50cf8131c8bb2ccdd4868f11e0ae583922R105) [[3]](diffhunk://#diff-3fa7e30e7aba8595743c0ca045b50e50cf8131c8bb2ccdd4868f11e0ae583922R191) [[4]](diffhunk://#diff-3fa7e30e7aba8595743c0ca045b50e50cf8131c8bb2ccdd4868f11e0ae583922L191-R204) [[5]](diffhunk://#diff-3fa7e30e7aba8595743c0ca045b50e50cf8131c8bb2ccdd4868f11e0ae583922R397) [[6]](diffhunk://#diff-862eccdc1e989e72b58b23348d7e36787c0cb2f130015fb50665c8762e598314R18-R31) [[7]](diffhunk://#diff-862eccdc1e989e72b58b23348d7e36787c0cb2f130015fb50665c8762e598314R458-R490)

**Usability and Logging Improvements:**

* Enhanced logging to inform users when CUDA Graphs are enabled, disabled, or being warmed up, and ensured proper fallback and informative messages when CUDA Graphs are not supported on the device. [[1]](diffhunk://#diff-862eccdc1e989e72b58b23348d7e36787c0cb2f130015fb50665c8762e598314R458-R490) [[2]](diffhunk://#diff-862eccdc1e989e72b58b23348d7e36787c0cb2f130015fb50665c8762e598314R501-R507)

These changes collectively improve the efficiency and flexibility of the MOSS-TTS Local streaming vocoder, particularly for users with CUDA Graph-compatible hardware.

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->
#801 

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->
WIP

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->
WIP

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Draft PRs are skipped even if labeled.
