### PR TITLE
Improve Qwen3-Omni thinker text-only decode throughput on H100

### DIFF
--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -7,6 +7,7 @@ pass, sampling, logit post-processing, and output extraction.
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from dataclasses import dataclass
 from typing import Any
@@ -26,6 +27,7 @@ from sglang_omni.scheduling.types import (
 from sglang_omni.utils.env import env_flag
 
 logger = logging.getLogger(__name__)
+_FORWARD_BATCH_MROPE_PATCH_LOCK = threading.Lock()
 
 
 def _current_sglang_sampling_backend() -> str | None:
@@ -112,6 +114,8 @@ class ModelRunner:
         self._mrope_patch_enabled: bool = self._build_profile_on or env_flag(
             "SGLANG_OMNI_FAST_MROPE_DECODE"
         )
+        if self._mrope_patch_enabled:
+            self._install_forward_batch_mrope_patch()
 
     def _next_host_staging(self, device_staging: torch.Tensor) -> torch.Tensor:
         """Return a pinned host staging buffer mirroring ``device_staging``'s
@@ -325,9 +329,6 @@ class ModelRunner:
             ForwardBatch,
         )
 
-        if bool(getattr(self, "_mrope_patch_enabled", False)):
-            self._patch_forward_batch_mrope(ForwardBatch)
-
         if self.device.type == "cuda":
             torch.cuda.set_device(self.device)
 
@@ -374,96 +375,106 @@ class ModelRunner:
             }
         return forward_batch, schedule_batch, model_worker_batch, is_prefill
 
+    def _install_forward_batch_mrope_patch(self) -> None:
+        from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+        self._patch_forward_batch_mrope(ForwardBatch)
+
     def _patch_forward_batch_mrope(self, forward_batch_cls: Any) -> None:
         """Install an env-gated text-decode MRoPE fast path and profiler hook."""
 
-        if getattr(forward_batch_cls, "_sglang_omni_mrope_patch", False):
-            if not getattr(
-                forward_batch_cls, "_sglang_omni_mrope_patch_reuse_logged", False
-            ):
-                logger.debug(
-                    "SGLang Omni MRoPE patch already installed on %s",
-                    getattr(forward_batch_cls, "__name__", forward_batch_cls),
-                )
-                forward_batch_cls._sglang_omni_mrope_patch_reuse_logged = True
-            return
-        if not hasattr(forward_batch_cls, "_compute_mrope_positions"):
-            if not getattr(
-                forward_batch_cls, "_sglang_omni_mrope_patch_missing_logged", False
-            ):
-                logger.warning(
-                    "SGLang Omni MRoPE patch requested but %s has no "
-                    "_compute_mrope_positions; skipping fast path/profile hook",
-                    getattr(forward_batch_cls, "__name__", forward_batch_cls),
-                )
-                forward_batch_cls._sglang_omni_mrope_patch_missing_logged = True
-            return
-
-        original = forward_batch_cls._compute_mrope_positions
-
-        def mrope_delta_is_zero(mm_input: Any) -> bool:
-            if mm_input is None:
-                return True
-            contains_mm_input = getattr(mm_input, "contains_mm_input", None)
-            if callable(contains_mm_input) and contains_mm_input():
-                return False
-            cached = getattr(mm_input, "_sglang_omni_zero_mrope_delta", None)
-            if cached is not None:
-                return bool(cached)
-            delta = getattr(mm_input, "mrope_position_delta", None)
-            if delta is None:
-                return False
-            if isinstance(delta, torch.Tensor):
-                if delta.device.type != "cpu":
-                    return False
-                is_zero = bool(delta.numel() > 0 and torch.all(delta == 0).item())
-            else:
-                try:
-                    is_zero = all(int(value) == 0 for value in delta)
-                except TypeError:
-                    is_zero = int(delta) == 0
-            try:
-                setattr(mm_input, "_sglang_omni_zero_mrope_delta", is_zero)
-            except Exception:
-                pass
-            return is_zero
-
-        def patched_mrope(forward_batch, model_runner, batch):
-            prof = env_flag("SGLANG_OMNI_BUILD_PROFILE")
-            fast = env_flag("SGLANG_OMNI_FAST_MROPE_DECODE")
-            t0 = time.perf_counter() if prof else 0.0
-            used_fast = False
-            try:
-                mm_inputs = getattr(batch, "multimodal_inputs", None)
-                text_only = mm_inputs is None or all(
-                    mrope_delta_is_zero(mm) for mm in mm_inputs
-                )
-                if (
-                    fast
-                    and text_only
-                    and forward_batch.forward_mode.is_decode()
-                    and forward_batch.positions is not None
-                    and getattr(forward_batch, "spec_info", None) is None
+        with _FORWARD_BATCH_MROPE_PATCH_LOCK:
+            if getattr(forward_batch_cls, "_sglang_omni_mrope_patch", False):
+                if not getattr(
+                    forward_batch_cls,
+                    "_sglang_omni_mrope_patch_reuse_logged",
+                    False,
                 ):
-                    positions = forward_batch.positions
-                    if positions.dtype != torch.int64:
-                        positions = positions.to(dtype=torch.int64)
-                    forward_batch.mrope_positions = (
-                        positions.reshape(1, -1).expand(3, -1).clone()
+                    logger.debug(
+                        "SGLang Omni MRoPE patch already installed on %s",
+                        getattr(forward_batch_cls, "__name__", forward_batch_cls),
                     )
-                    used_fast = True
-                    return None
-                return original(forward_batch, model_runner, batch)
-            finally:
-                if prof:
-                    forward_batch._sglang_omni_mrope_seconds = (
-                        time.perf_counter() - t0
+                    forward_batch_cls._sglang_omni_mrope_patch_reuse_logged = True
+                return
+            if not hasattr(forward_batch_cls, "_compute_mrope_positions"):
+                if not getattr(
+                    forward_batch_cls,
+                    "_sglang_omni_mrope_patch_missing_logged",
+                    False,
+                ):
+                    logger.warning(
+                        "SGLang Omni MRoPE patch requested but %s has no "
+                        "_compute_mrope_positions; skipping fast path/profile hook",
+                        getattr(forward_batch_cls, "__name__", forward_batch_cls),
                     )
-                    forward_batch._sglang_omni_mrope_fast = used_fast
+                    forward_batch_cls._sglang_omni_mrope_patch_missing_logged = True
+                return
 
-        forward_batch_cls._sglang_omni_orig_compute_mrope_positions = original
-        forward_batch_cls._compute_mrope_positions = patched_mrope
-        forward_batch_cls._sglang_omni_mrope_patch = True
+            original = forward_batch_cls._compute_mrope_positions
+
+            def mrope_delta_is_zero(mm_input: Any) -> bool:
+                if mm_input is None:
+                    return True
+                contains_mm_input = getattr(mm_input, "contains_mm_input", None)
+                if callable(contains_mm_input) and contains_mm_input():
+                    return False
+                cached = getattr(mm_input, "_sglang_omni_zero_mrope_delta", None)
+                if cached is not None:
+                    return bool(cached)
+                delta = getattr(mm_input, "mrope_position_delta", None)
+                if delta is None:
+                    return False
+                if isinstance(delta, torch.Tensor):
+                    if delta.device.type != "cpu":
+                        return False
+                    is_zero = bool(delta.numel() > 0 and torch.all(delta == 0).item())
+                else:
+                    try:
+                        is_zero = all(int(value) == 0 for value in delta)
+                    except TypeError:
+                        is_zero = int(delta) == 0
+                try:
+                    setattr(mm_input, "_sglang_omni_zero_mrope_delta", is_zero)
+                except Exception:
+                    pass
+                return is_zero
+
+            def patched_mrope(forward_batch, model_runner, batch):
+                prof = env_flag("SGLANG_OMNI_BUILD_PROFILE")
+                fast = env_flag("SGLANG_OMNI_FAST_MROPE_DECODE")
+                t0 = time.perf_counter() if prof else 0.0
+                used_fast = False
+                try:
+                    mm_inputs = getattr(batch, "multimodal_inputs", None)
+                    text_only = mm_inputs is None or all(
+                        mrope_delta_is_zero(mm) for mm in mm_inputs
+                    )
+                    if (
+                        fast
+                        and text_only
+                        and forward_batch.forward_mode.is_decode()
+                        and forward_batch.positions is not None
+                        and getattr(forward_batch, "spec_info", None) is None
+                    ):
+                        positions = forward_batch.positions
+                        if positions.dtype != torch.int64:
+                            positions = positions.to(dtype=torch.int64)
+                        forward_batch.mrope_positions = (
+                            positions.reshape(1, -1).expand(3, -1).clone()
+                        )
+                        used_fast = True
+                        return None
+                    return original(forward_batch, model_runner, batch)
+                finally:
+                    if prof:
+                        forward_batch._sglang_omni_mrope_seconds = (
+                            time.perf_counter() - t0
+                        )
+                        forward_batch._sglang_omni_mrope_fast = used_fast
+
+            forward_batch_cls._sglang_omni_orig_compute_mrope_positions = original
+            forward_batch_cls._compute_mrope_positions = patched_mrope
+            forward_batch_cls._sglang_omni_mrope_patch = True
 
     def _prepare_and_forward(
         self,

--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -7,6 +7,8 @@ pass, sampling, logit post-processing, and output extraction.
 from __future__ import annotations
 
 import logging
+import os
+import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -101,6 +103,16 @@ class ModelRunner:
         # overlap a host copy; the device-snapshot path does not).
         self._async_query_hit: int = 0
         self._async_query_miss: int = 0
+        self._phase_on: bool = bool(os.environ.get("SGLANG_OMNI_PHASE_PROFILE"))
+        self._phase_sync: bool = bool(os.environ.get("SGLANG_OMNI_PHASE_SYNC"))
+        self._last_phase: dict[str, Any] | None = None
+        self._build_profile_on: bool = bool(
+            os.environ.get("SGLANG_OMNI_BUILD_PROFILE")
+        )
+        self._last_build_phase: dict[str, float] | None = None
+        self._mrope_patch_enabled: bool = self._build_profile_on or bool(
+            os.environ.get("SGLANG_OMNI_FAST_MROPE_DECODE")
+        )
 
     def _next_host_staging(self, device_staging: torch.Tensor) -> torch.Tensor:
         """Return a pinned host staging buffer mirroring ``device_staging``'s
@@ -138,13 +150,22 @@ class ModelRunner:
         ``_finalize``) that ``execute_launch`` + ``execute_resolve`` also use,
         in the same order. Async decode splits this at the post-decode boundary.
         """
+        prof = bool(getattr(self, "_phase_on", False))
+        if prof:
+            self._last_phase = None
+            self._last_build_phase = None
+        t0 = time.perf_counter() if prof else 0.0
         built = self._build_forward_batch(scheduler_output)
         if built is None:
             return ModelRunnerOutput(outputs={}, req_ids=[], req_id_to_index={})
         forward_batch, schedule_batch, model_worker_batch, is_prefill = built
+        t1 = time.perf_counter() if prof else 0.0
         batch_result = self._prepare_and_forward(
             forward_batch, schedule_batch, scheduler_output.requests, is_prefill
         )
+        if prof and bool(getattr(self, "_phase_sync", False)):
+            torch.cuda.synchronize(self.device)
+        t2 = time.perf_counter() if prof else 0.0
         if is_prefill:
             self.post_prefill(
                 batch_result, forward_batch, schedule_batch, scheduler_output.requests
@@ -153,13 +174,24 @@ class ModelRunner:
             self.post_decode(
                 batch_result, forward_batch, schedule_batch, scheduler_output.requests
             )
-        return self._finalize(
+        t3 = time.perf_counter() if prof else 0.0
+        out = self._finalize(
             batch_result,
             forward_batch,
             schedule_batch,
             model_worker_batch,
             scheduler_output,
         )
+        if prof:
+            self._last_phase = {
+                "build": t1 - t0,
+                "forward": t2 - t1,
+                "post": t3 - t2,
+                "finalize": time.perf_counter() - t3,
+                "is_prefill": is_prefill,
+                "build_detail": self._last_build_phase,
+            }
+        return out
 
     def execute_launch(self, scheduler_output: Any) -> "_PendingStep | None":
         """Enqueue a decode step's forward + on-GPU sample, call
@@ -264,6 +296,9 @@ class ModelRunner:
             ForwardBatch,
         )
 
+        if bool(getattr(self, "_mrope_patch_enabled", False)):
+            self._patch_forward_batch_mrope(ForwardBatch)
+
         if self.device.type == "cuda":
             torch.cuda.set_device(self.device)
 
@@ -271,7 +306,10 @@ class ModelRunner:
         if schedule_batch is None:
             return None
 
+        prof = bool(getattr(self, "_build_profile_on", False))
+        t0 = time.perf_counter() if prof else 0.0
         model_worker_batch = schedule_batch.get_model_worker_batch()
+        t1 = time.perf_counter() if prof else 0.0
         is_prefill = bool(schedule_batch.forward_mode.is_extend())
 
         capture_hidden_mode = (
@@ -287,11 +325,70 @@ class ModelRunner:
             model_worker_batch.capture_hidden_mode = capture_hidden_mode
         elif self.output_processor._capture_hidden:
             model_worker_batch.capture_hidden_mode = CaptureHiddenMode.LAST
+        t2 = time.perf_counter() if prof else 0.0
 
         forward_batch = ForwardBatch.init_new(
             model_worker_batch, self.tp_worker.model_runner
         )
+        if prof:
+            t3 = time.perf_counter()
+            self._last_build_phase = {
+                "model_worker": t1 - t0,
+                "capture_hidden": t2 - t1,
+                "forward_batch": t3 - t2,
+                "mrope": float(
+                    getattr(forward_batch, "_sglang_omni_mrope_seconds", 0.0)
+                ),
+                "mrope_fast": float(
+                    bool(getattr(forward_batch, "_sglang_omni_mrope_fast", False))
+                ),
+            }
         return forward_batch, schedule_batch, model_worker_batch, is_prefill
+
+    def _patch_forward_batch_mrope(self, forward_batch_cls: Any) -> None:
+        """Install an env-gated text-decode MRoPE fast path and profiler hook."""
+
+        if getattr(forward_batch_cls, "_sglang_omni_mrope_patch", False):
+            return
+        if not hasattr(forward_batch_cls, "_compute_mrope_positions"):
+            return
+
+        original = forward_batch_cls._compute_mrope_positions
+
+        def patched_mrope(forward_batch, model_runner, batch):
+            prof = bool(os.environ.get("SGLANG_OMNI_BUILD_PROFILE"))
+            fast = bool(os.environ.get("SGLANG_OMNI_FAST_MROPE_DECODE"))
+            t0 = time.perf_counter() if prof else 0.0
+            used_fast = False
+            try:
+                mm_inputs = getattr(batch, "multimodal_inputs", None)
+                text_only = mm_inputs is None or all(mm is None for mm in mm_inputs)
+                if (
+                    fast
+                    and text_only
+                    and forward_batch.forward_mode.is_decode()
+                    and forward_batch.positions is not None
+                    and getattr(forward_batch, "spec_info", None) is None
+                ):
+                    positions = forward_batch.positions
+                    if positions.dtype != torch.int64:
+                        positions = positions.to(dtype=torch.int64)
+                    forward_batch.mrope_positions = (
+                        positions.reshape(1, -1).expand(3, -1).clone()
+                    )
+                    used_fast = True
+                    return None
+                return original(forward_batch, model_runner, batch)
+            finally:
+                if prof:
+                    forward_batch._sglang_omni_mrope_seconds = (
+                        time.perf_counter() - t0
+                    )
+                    forward_batch._sglang_omni_mrope_fast = used_fast
+
+        forward_batch_cls._sglang_omni_orig_compute_mrope_positions = original
+        forward_batch_cls._compute_mrope_positions = patched_mrope
+        forward_batch_cls._sglang_omni_mrope_patch = True
 
     def _prepare_and_forward(
         self,

--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -355,6 +355,33 @@ class ModelRunner:
 
         original = forward_batch_cls._compute_mrope_positions
 
+        def mrope_delta_is_zero(mm_input: Any) -> bool:
+            if mm_input is None:
+                return True
+            contains_mm_input = getattr(mm_input, "contains_mm_input", None)
+            if callable(contains_mm_input) and contains_mm_input():
+                return False
+            cached = getattr(mm_input, "_sglang_omni_zero_mrope_delta", None)
+            if cached is not None:
+                return bool(cached)
+            delta = getattr(mm_input, "mrope_position_delta", None)
+            if delta is None:
+                return False
+            if isinstance(delta, torch.Tensor):
+                if delta.device.type != "cpu":
+                    return False
+                is_zero = bool(delta.numel() > 0 and torch.all(delta == 0).item())
+            else:
+                try:
+                    is_zero = all(int(value) == 0 for value in delta)
+                except TypeError:
+                    is_zero = int(delta) == 0
+            try:
+                setattr(mm_input, "_sglang_omni_zero_mrope_delta", is_zero)
+            except Exception:
+                pass
+            return is_zero
+
         def patched_mrope(forward_batch, model_runner, batch):
             prof = bool(os.environ.get("SGLANG_OMNI_BUILD_PROFILE"))
             fast = bool(os.environ.get("SGLANG_OMNI_FAST_MROPE_DECODE"))
@@ -362,7 +389,9 @@ class ModelRunner:
             used_fast = False
             try:
                 mm_inputs = getattr(batch, "multimodal_inputs", None)
-                text_only = mm_inputs is None or all(mm is None for mm in mm_inputs)
+                text_only = mm_inputs is None or all(
+                    mrope_delta_is_zero(mm) for mm in mm_inputs
+                )
                 if (
                     fast
                     and text_only

--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -7,7 +7,6 @@ pass, sampling, logit post-processing, and output extraction.
 from __future__ import annotations
 
 import logging
-import os
 import time
 from dataclasses import dataclass
 from typing import Any
@@ -24,6 +23,7 @@ from sglang_omni.scheduling.types import (
     RequestOutput,
     sampled_logprobs_to_list,
 )
+from sglang_omni.utils.env import env_flag
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +76,7 @@ class _PendingStep:
     model_worker_batch: Any  # for the prefill-only finalize branch (unused in decode)
     batch_result: Any  # carries logits_output (device of next_token_ids)
     n_real: int  # number of real (non-padding) rows this step
+    phase: dict[str, Any] | None = None
 
 
 class ModelRunner:
@@ -103,15 +104,13 @@ class ModelRunner:
         # overlap a host copy; the device-snapshot path does not).
         self._async_query_hit: int = 0
         self._async_query_miss: int = 0
-        self._phase_on: bool = bool(os.environ.get("SGLANG_OMNI_PHASE_PROFILE"))
-        self._phase_sync: bool = bool(os.environ.get("SGLANG_OMNI_PHASE_SYNC"))
+        self._phase_on: bool = env_flag("SGLANG_OMNI_PHASE_PROFILE")
+        self._phase_sync: bool = env_flag("SGLANG_OMNI_PHASE_SYNC")
         self._last_phase: dict[str, Any] | None = None
-        self._build_profile_on: bool = bool(
-            os.environ.get("SGLANG_OMNI_BUILD_PROFILE")
-        )
+        self._build_profile_on: bool = env_flag("SGLANG_OMNI_BUILD_PROFILE")
         self._last_build_phase: dict[str, float] | None = None
-        self._mrope_patch_enabled: bool = self._build_profile_on or bool(
-            os.environ.get("SGLANG_OMNI_FAST_MROPE_DECODE")
+        self._mrope_patch_enabled: bool = self._build_profile_on or env_flag(
+            "SGLANG_OMNI_FAST_MROPE_DECODE"
         )
 
     def _next_host_staging(self, device_staging: torch.Tensor) -> torch.Tensor:
@@ -209,11 +208,17 @@ class ModelRunner:
         scheduling has two steps momentarily in flight: the just-launched step
         N and the not-yet-resolved step N-1.
         """
+        prof = bool(getattr(self, "_phase_on", False))
+        if prof:
+            self._last_phase = None
+            self._last_build_phase = None
+        t0 = time.perf_counter() if prof else 0.0
         built = self._build_forward_batch(scheduler_output)
         if built is None:
             return None
         forward_batch, schedule_batch, model_worker_batch, is_prefill = built
         assert not is_prefill, "async lookahead launch is decode-only"
+        t1 = time.perf_counter() if prof else 0.0
         batch_result = self._prepare_and_forward(
             forward_batch,
             schedule_batch,
@@ -221,8 +226,23 @@ class ModelRunner:
             is_prefill,
             is_lookahead=True,
         )
+        if prof and bool(getattr(self, "_phase_sync", False)):
+            torch.cuda.synchronize(self.device)
+        t2 = time.perf_counter() if prof else 0.0
         launch_buf = self.post_decode_launch(
             batch_result, forward_batch, scheduler_output.requests
+        )
+        t3 = time.perf_counter() if prof else 0.0
+        phase = (
+            {
+                "build": t1 - t0,
+                "forward": t2 - t1,
+                "post": t3 - t2,
+                "is_prefill": False,
+                "build_detail": self._last_build_phase,
+            }
+            if prof
+            else None
         )
         # Publish this step's output token ids now (post_decode_launch set them
         # from GPU state without a host sync) so the NEXT decode step's
@@ -244,6 +264,7 @@ class ModelRunner:
             model_worker_batch=model_worker_batch,
             batch_result=batch_result,
             n_real=len(scheduler_output.requests),
+            phase=phase,
         )
 
     def execute_resolve(
@@ -270,6 +291,7 @@ class ModelRunner:
             for req in pending.scheduler_output.requests
             if req.data.req.finished() or self._req_is_retracted(req.data.req)
         }
+        t_post0 = time.perf_counter() if pending.phase is not None else 0.0
         self.post_decode_resolve(
             pending.launch_buf,
             pending.batch_result,
@@ -277,7 +299,8 @@ class ModelRunner:
             pending.schedule_batch,
             pending.scheduler_output.requests,
         )
-        return self._finalize(
+        t_finalize0 = time.perf_counter() if pending.phase is not None else 0.0
+        out = self._finalize(
             pending.batch_result,
             pending.forward_batch,
             pending.schedule_batch,
@@ -286,6 +309,12 @@ class ModelRunner:
             set_output_ids=False,
             skip_rids=skip_rids,
         )
+        if pending.phase is not None:
+            phase = dict(pending.phase)
+            phase["post"] = phase["post"] + (t_finalize0 - t_post0)
+            phase["finalize"] = time.perf_counter() - t_finalize0
+            self._last_phase = phase
+        return out
 
     def _build_forward_batch(self, scheduler_output: Any):
         """Build the ForwardBatch + capture-hidden mode. Returns
@@ -349,8 +378,25 @@ class ModelRunner:
         """Install an env-gated text-decode MRoPE fast path and profiler hook."""
 
         if getattr(forward_batch_cls, "_sglang_omni_mrope_patch", False):
+            if not getattr(
+                forward_batch_cls, "_sglang_omni_mrope_patch_reuse_logged", False
+            ):
+                logger.debug(
+                    "SGLang Omni MRoPE patch already installed on %s",
+                    getattr(forward_batch_cls, "__name__", forward_batch_cls),
+                )
+                forward_batch_cls._sglang_omni_mrope_patch_reuse_logged = True
             return
         if not hasattr(forward_batch_cls, "_compute_mrope_positions"):
+            if not getattr(
+                forward_batch_cls, "_sglang_omni_mrope_patch_missing_logged", False
+            ):
+                logger.warning(
+                    "SGLang Omni MRoPE patch requested but %s has no "
+                    "_compute_mrope_positions; skipping fast path/profile hook",
+                    getattr(forward_batch_cls, "__name__", forward_batch_cls),
+                )
+                forward_batch_cls._sglang_omni_mrope_patch_missing_logged = True
             return
 
         original = forward_batch_cls._compute_mrope_positions
@@ -383,8 +429,8 @@ class ModelRunner:
             return is_zero
 
         def patched_mrope(forward_batch, model_runner, batch):
-            prof = bool(os.environ.get("SGLANG_OMNI_BUILD_PROFILE"))
-            fast = bool(os.environ.get("SGLANG_OMNI_FAST_MROPE_DECODE"))
+            prof = env_flag("SGLANG_OMNI_BUILD_PROFILE")
+            fast = env_flag("SGLANG_OMNI_FAST_MROPE_DECODE")
             t0 = time.perf_counter() if prof else 0.0
             used_fast = False
             try:

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -14,6 +14,7 @@ inheriting from ``SGLangScheduler``.
 from __future__ import annotations
 
 import logging
+import os
 import queue as _queue_mod
 import threading
 import time
@@ -840,6 +841,165 @@ class OmniScheduler:
         # Fallback: call upstream's run_batch (uses tp_worker directly)
         return _Upstream.run_batch(self, batch, pp_proxy_tensors)
 
+    def _phase_profile_on(self) -> bool:
+        on = getattr(self, "_phase_prof_on", None)
+        if on is None:
+            on = self._phase_prof_on = bool(
+                os.environ.get("SGLANG_OMNI_PHASE_PROFILE")
+            )
+            if on:
+                self._phase_interval = float(
+                    os.environ.get("SGLANG_OMNI_PHASE_PROFILE_INTERVAL", "5")
+                )
+                self._phase_last_log = time.perf_counter()
+                self._phase_acc = {
+                    "decode": self._new_phase_bucket(),
+                    "prefill": self._new_phase_bucket(),
+                }
+        return on
+
+    @staticmethod
+    def _new_phase_bucket() -> dict[str, Any]:
+        return {
+            "steps": 0,
+            "recv": 0.0,
+            "sched": 0.0,
+            "build": 0.0,
+            "forward": 0.0,
+            "post": 0.0,
+            "finalize": 0.0,
+            "stream": 0.0,
+            "proc": 0.0,
+            "build_model_worker": 0.0,
+            "build_capture_hidden": 0.0,
+            "build_forward_batch": 0.0,
+            "build_mrope": 0.0,
+            "build_mrope_fast": 0.0,
+            "fwd_by_bs": {},
+        }
+
+    @staticmethod
+    def _phase_ms(bucket: dict[str, Any], key: str) -> float:
+        return 1000.0 * bucket[key] / bucket["steps"] if bucket["steps"] else 0.0
+
+    def _record_step_phase(
+        self,
+        batch,
+        t0: float,
+        t1: float,
+        t2: float,
+        t3: float,
+        t4: float,
+    ) -> None:
+        recv = t1 - t0
+        sched = t2 - t1
+        run = t3 - t2
+        proc = t4 - t3
+        last_phase = getattr(self._model_runner, "_last_phase", None)
+        if last_phase is not None:
+            is_prefill = bool(last_phase["is_prefill"])
+            build = float(last_phase["build"])
+            forward = float(last_phase["forward"])
+            post = float(last_phase["post"])
+            finalize = float(last_phase["finalize"])
+            build_detail = last_phase.get("build_detail") or {}
+            stream = max(0.0, run - (build + forward + post + finalize))
+        else:
+            is_prefill = not self._batch_is_decode(batch)
+            build = forward = post = finalize = 0.0
+            build_detail = {}
+            stream = run
+
+        bucket = self._phase_acc["prefill" if is_prefill else "decode"]
+        bucket["steps"] += 1
+        bucket["recv"] += recv
+        bucket["sched"] += sched
+        bucket["build"] += build
+        bucket["forward"] += forward
+        bucket["post"] += post
+        bucket["finalize"] += finalize
+        bucket["stream"] += stream
+        bucket["proc"] += proc
+        bucket["build_model_worker"] += float(build_detail.get("model_worker", 0.0))
+        bucket["build_capture_hidden"] += float(
+            build_detail.get("capture_hidden", 0.0)
+        )
+        bucket["build_forward_batch"] += float(build_detail.get("forward_batch", 0.0))
+        bucket["build_mrope"] += float(build_detail.get("mrope", 0.0))
+        bucket["build_mrope_fast"] += float(build_detail.get("mrope_fast", 0.0))
+
+        try:
+            bs = len(batch.reqs)
+        except Exception:
+            bs = 0
+        fwd_by_bs = bucket["fwd_by_bs"].setdefault(bs, [0.0, 0])
+        fwd_by_bs[0] += forward
+        fwd_by_bs[1] += 1
+        if t4 - self._phase_last_log >= self._phase_interval:
+            self._log_step_phases()
+            self._phase_last_log = t4
+
+    def _log_step_phases(self) -> None:
+        for name in ("decode", "prefill"):
+            bucket = self._phase_acc[name]
+            if not bucket["steps"]:
+                continue
+            recv = self._phase_ms(bucket, "recv")
+            sched = self._phase_ms(bucket, "sched")
+            build = self._phase_ms(bucket, "build")
+            forward = self._phase_ms(bucket, "forward")
+            post = self._phase_ms(bucket, "post")
+            finalize = self._phase_ms(bucket, "finalize")
+            stream = self._phase_ms(bucket, "stream")
+            proc = self._phase_ms(bucket, "proc")
+            step = recv + sched + build + forward + post + finalize + stream + proc
+            logger.info(
+                "[step phases] %s steps=%d mean_ms step=%.2f | recv=%.2f "
+                "sched=%.2f build=%.2f forward=%.2f post=%.2f finalize=%.2f "
+                "stream=%.2f proc=%.2f | gpu=%.2f host_pre=%.2f host_post=%.2f",
+                name,
+                bucket["steps"],
+                step,
+                recv,
+                sched,
+                build,
+                forward,
+                post,
+                finalize,
+                stream,
+                proc,
+                forward,
+                recv + sched + build,
+                post + finalize + stream + proc,
+            )
+            if bucket["fwd_by_bs"]:
+                parts = " ".join(
+                    "%d:%.1fms(n=%d)" % (bs, 1000.0 * total / count, count)
+                    for bs, (total, count) in sorted(bucket["fwd_by_bs"].items())
+                    if count
+                )
+                logger.info("[fwd-by-bs] %s %s", name, parts)
+            build_detail = (
+                self._phase_ms(bucket, "build_model_worker")
+                + self._phase_ms(bucket, "build_capture_hidden")
+                + self._phase_ms(bucket, "build_forward_batch")
+            )
+            if build_detail > 0.0:
+                logger.info(
+                    "[build phases] %s steps=%d mean_ms model_worker=%.2f "
+                    "capture_hidden=%.2f forward_batch=%.2f "
+                    "mrope=%.2f mrope_fast=%d/%d other=%.2f",
+                    name,
+                    bucket["steps"],
+                    self._phase_ms(bucket, "build_model_worker"),
+                    self._phase_ms(bucket, "build_capture_hidden"),
+                    self._phase_ms(bucket, "build_forward_batch"),
+                    self._phase_ms(bucket, "build_mrope"),
+                    int(bucket.get("build_mrope_fast", 0.0)),
+                    bucket["steps"],
+                    max(0.0, build - build_detail),
+                )
+
     def _build_sched_output(self, batch):
         """Wrap a ScheduleBatch into the SchedulerOutput the model runner
         expects. Shared by the sync and async (launch) paths."""
@@ -1579,7 +1739,10 @@ class OmniScheduler:
         # slows ~600x, dropping audio QPS from >10 to <0.5.
         while self._running:
             self._process_admin_requests()
+            phase_prof = self._phase_profile_on()
+            t0 = time.perf_counter() if phase_prof else 0.0
             recv_reqs = self.recv_requests()
+            t1 = time.perf_counter() if phase_prof else 0.0
             recv_reqs.extend(self._take_deferred_request_payloads())
             self.process_input_requests(recv_reqs)
             if self._engine_paused:
@@ -1589,14 +1752,22 @@ class OmniScheduler:
 
             batch = self.get_next_batch_to_run()
             self.cur_batch = batch
+            t2 = time.perf_counter() if phase_prof else 0.0
+            phase_record = False
 
             if batch:
                 result = self.run_batch(batch)
+                t3 = time.perf_counter() if phase_prof else 0.0
                 if result is not _FAILED_BATCH_RESULT:
                     self.process_batch_result(batch, result)
+                    phase_record = True
             else:
                 self.self_check_during_idle()
                 time.sleep(0.001)
+                t3 = time.perf_counter() if phase_prof else 0.0
+            t4 = time.perf_counter() if phase_prof else 0.0
+            if phase_prof and phase_record:
+                self._record_step_phase(batch, t0, t1, t2, t3, t4)
 
             self.last_batch = batch
             if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():
@@ -1611,7 +1782,10 @@ class OmniScheduler:
 
         while self._running:
             self._process_admin_requests()
+            phase_prof = self._phase_profile_on()
+            t0 = time.perf_counter() if phase_prof else 0.0
             recv_reqs = self.recv_requests()
+            t1 = time.perf_counter() if phase_prof else 0.0
             recv_reqs.extend(self._take_deferred_request_payloads())
             self.process_input_requests(recv_reqs)
             if self._engine_paused:
@@ -1622,18 +1796,23 @@ class OmniScheduler:
             batch = self.get_next_batch_to_run()
             self.cur_batch = batch
             disable_overlap_for_batch = self.is_disable_overlap_for_batch(batch)
+            t2 = time.perf_counter() if phase_prof else 0.0
+            phase_record = False
 
             if disable_overlap_for_batch and self.result_queue:
                 pop_and_process()
 
             if batch:
                 batch_result = self.run_batch(batch)
+                t3 = time.perf_counter() if phase_prof else 0.0
                 if batch_result is not _FAILED_BATCH_RESULT:
                     self.result_queue.append((batch.copy(), batch_result))
+                    phase_record = True
                 else:
                     batch_result = None
             else:
                 batch_result = None
+                t3 = time.perf_counter() if phase_prof else 0.0
 
             if self.last_batch:
                 if not disable_overlap_for_batch and self.result_queue:
@@ -1644,6 +1823,9 @@ class OmniScheduler:
 
             if self.is_generation:
                 self.launch_batch_sample_if_needed(batch_result)
+            t4 = time.perf_counter() if phase_prof else 0.0
+            if phase_prof and phase_record:
+                self._record_step_phase(batch, t0, t1, t2, t3, t4)
 
             self.last_batch = batch
             if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -14,7 +14,6 @@ inheriting from ``SGLangScheduler``.
 from __future__ import annotations
 
 import logging
-import os
 import queue as _queue_mod
 import threading
 import time
@@ -46,6 +45,7 @@ from sglang_omni.proto.admin import (
     ADMIN_WEIGHTS_CHECKER,
 )
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
+from sglang_omni.utils.env import env_flag, env_float
 
 logger = logging.getLogger(__name__)
 
@@ -844,12 +844,10 @@ class OmniScheduler:
     def _phase_profile_on(self) -> bool:
         on = getattr(self, "_phase_prof_on", None)
         if on is None:
-            on = self._phase_prof_on = bool(
-                os.environ.get("SGLANG_OMNI_PHASE_PROFILE")
-            )
+            on = self._phase_prof_on = env_flag("SGLANG_OMNI_PHASE_PROFILE")
             if on:
-                self._phase_interval = float(
-                    os.environ.get("SGLANG_OMNI_PHASE_PROFILE_INTERVAL", "5")
+                self._phase_interval = env_float(
+                    "SGLANG_OMNI_PHASE_PROFILE_INTERVAL", default=5.0
                 )
                 self._phase_last_log = time.perf_counter()
                 self._phase_acc = {

--- a/sglang_omni/utils/env.py
+++ b/sglang_omni/utils/env.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import os
+
+_TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
+_FALSE_ENV_VALUES = {"0", "false", "no", "off", ""}
+
+
+def env_flag(name: str, *, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if normalized in _TRUE_ENV_VALUES:
+        return True
+    if normalized in _FALSE_ENV_VALUES:
+        return False
+    return default
+
+
+def env_float(name: str, *, default: float) -> float:
+    value = os.environ.get(name)
+    if value is None or value.strip() == "":
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default

--- a/tests/unit_test/model_runner/test_base_hooks.py
+++ b/tests/unit_test/model_runner/test_base_hooks.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import logging
 import sys
 import types
 from types import SimpleNamespace
@@ -9,6 +10,7 @@ import pytest
 import torch
 
 from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.utils.env import env_flag
 
 
 def _install_fake_forward_batch_module(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -61,7 +63,12 @@ def _scheduler_output(*, is_prefill: bool):
         output_ids=None,
         get_model_worker_batch=lambda: model_worker_batch,
     )
-    request_data = SimpleNamespace(generation_steps=0, extra_model_outputs={})
+    req_state = SimpleNamespace(finished=lambda: False, is_retracted=False)
+    request_data = SimpleNamespace(
+        generation_steps=0,
+        extra_model_outputs={},
+        req=req_state,
+    )
     request = SimpleNamespace(request_id="req-1", data=request_data)
     return SimpleNamespace(batch_data=schedule_batch, requests=[request])
 
@@ -101,6 +108,22 @@ def _runner(calls: list[str], *, custom_result):
             del result, forward_batch, schedule_batch, requests
             calls.append("post_decode")
 
+        def post_decode_launch(self, result, forward_batch, requests):
+            del result, forward_batch, requests
+            calls.append("post_decode_launch")
+            return "launch-buf"
+
+        def post_decode_resolve(
+            self,
+            launch_buf,
+            result,
+            forward_batch,
+            schedule_batch,
+            requests,
+        ):
+            del launch_buf, result, forward_batch, schedule_batch, requests
+            calls.append("post_decode_resolve")
+
     runner = object.__new__(RecordingRunner)
     runner.device = torch.device("cpu")
     runner.output_processor = SimpleNamespace(
@@ -123,7 +146,32 @@ def _runner(calls: list[str], *, custom_result):
         model_runner=object(),
         forward_batch_generation=standard_forward,
     )
+    runner._async_query_hit = 0
+    runner._async_query_miss = 0
+    runner._phase_on = False
+    runner._phase_sync = False
+    runner._last_phase = None
+    runner._build_profile_on = False
+    runner._last_build_phase = None
+    runner._mrope_patch_enabled = False
     return runner
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["0", "false", "False", "no", "off", ""],
+)
+def test_env_flag_false_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_PHASE_PROFILE", value)
+
+    assert env_flag("SGLANG_OMNI_PHASE_PROFILE") is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "True", "yes", "on"])
+def test_env_flag_true_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_PHASE_PROFILE", value)
+
+    assert env_flag("SGLANG_OMNI_PHASE_PROFILE") is True
 
 
 @pytest.mark.parametrize(
@@ -172,6 +220,58 @@ def test_execute_falls_back_to_standard_forward_after_before_hook(
     ]
     assert output.can_run_cuda_graph is False
     assert not hasattr(ModelRunner, "prepare_prefill")
+
+
+def test_async_resolve_records_phase(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_forward_batch_module(monkeypatch)
+
+    class FakeEvent:
+        def record(self) -> None:
+            return None
+
+        def query(self) -> bool:
+            return True
+
+        def synchronize(self) -> None:
+            raise AssertionError("query path should not synchronize")
+
+    monkeypatch.setattr(torch.cuda, "Event", FakeEvent)
+    calls: list[str] = []
+    custom_result = SimpleNamespace(
+        logits_output=None,
+        next_token_ids=torch.tensor([7]),
+        can_run_cuda_graph=True,
+    )
+    runner = _runner(calls, custom_result=custom_result)
+    runner._phase_on = True
+    runner._build_profile_on = True
+
+    pending = runner.execute_launch(_scheduler_output(is_prefill=False))
+
+    assert pending is not None
+    assert pending.phase is not None
+    assert runner._last_phase is None
+
+    output = runner.execute_resolve(pending)
+
+    assert output is not None
+    assert output.req_ids == ["req-1"]
+    assert runner._async_query_hit == 1
+    assert runner._last_phase is not None
+    assert runner._last_phase["is_prefill"] is False
+    assert {
+        "build",
+        "forward",
+        "post",
+        "finalize",
+        "build_detail",
+    } <= set(runner._last_phase)
+    assert calls == [
+        "before_decode",
+        "custom_decode",
+        "post_decode_launch",
+        "post_decode_resolve",
+    ]
 
 
 class _DecodeMode:
@@ -312,6 +412,19 @@ def test_mrope_fast_path_skips_multimodal(monkeypatch: pytest.MonkeyPatch) -> No
         forward_batch.mrope_positions,
         torch.full((3, 1), -1, dtype=torch.int64),
     )
+
+
+def test_mrope_patch_warns_when_hook_missing(caplog: pytest.LogCaptureFixture) -> None:
+    class ForwardBatch:
+        pass
+
+    runner = object.__new__(ModelRunner)
+
+    with caplog.at_level(logging.WARNING, logger="sglang_omni.model_runner.base"):
+        runner._patch_forward_batch_mrope(ForwardBatch)
+
+    assert "has no _compute_mrope_positions" in caplog.text
+    assert ForwardBatch._sglang_omni_mrope_patch_missing_logged is True
 
 
 def test_finalize_default_batch_generation_hook_calls_single_hook() -> None:

--- a/tests/unit_test/model_runner/test_base_hooks.py
+++ b/tests/unit_test/model_runner/test_base_hooks.py
@@ -174,6 +174,70 @@ def test_execute_falls_back_to_standard_forward_after_before_hook(
     assert not hasattr(ModelRunner, "prepare_prefill")
 
 
+class _DecodeMode:
+    def is_decode(self) -> bool:
+        return True
+
+
+def test_mrope_text_decode_fast_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_FAST_MROPE_DECODE", "1")
+    monkeypatch.setenv("SGLANG_OMNI_BUILD_PROFILE", "1")
+
+    class ForwardBatch:
+        def __init__(self) -> None:
+            self.forward_mode = _DecodeMode()
+            self.positions = torch.tensor([4, 7], dtype=torch.int32)
+            self.spec_info = None
+            self.mrope_positions = None
+
+        def _compute_mrope_positions(self, model_runner, batch):
+            del model_runner, batch
+            self.mrope_positions = torch.full((3, 2), -1, dtype=torch.int64)
+
+    runner = object.__new__(ModelRunner)
+    runner._patch_forward_batch_mrope(ForwardBatch)
+
+    forward_batch = ForwardBatch()
+    forward_batch._compute_mrope_positions(
+        object(),
+        SimpleNamespace(multimodal_inputs=[None, None]),
+    )
+
+    expected = torch.tensor([[4, 7], [4, 7], [4, 7]], dtype=torch.int64)
+    assert torch.equal(forward_batch.mrope_positions, expected)
+    assert forward_batch._sglang_omni_mrope_fast is True
+    assert forward_batch._sglang_omni_mrope_seconds >= 0.0
+
+
+def test_mrope_fast_path_skips_multimodal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_FAST_MROPE_DECODE", "1")
+
+    class ForwardBatch:
+        def __init__(self) -> None:
+            self.forward_mode = _DecodeMode()
+            self.positions = torch.tensor([4], dtype=torch.int32)
+            self.spec_info = None
+            self.mrope_positions = None
+
+        def _compute_mrope_positions(self, model_runner, batch):
+            del model_runner, batch
+            self.mrope_positions = torch.full((3, 1), -1, dtype=torch.int64)
+
+    runner = object.__new__(ModelRunner)
+    runner._patch_forward_batch_mrope(ForwardBatch)
+
+    forward_batch = ForwardBatch()
+    forward_batch._compute_mrope_positions(
+        object(),
+        SimpleNamespace(multimodal_inputs=[object()]),
+    )
+
+    assert torch.equal(
+        forward_batch.mrope_positions,
+        torch.full((3, 1), -1, dtype=torch.int64),
+    )
+
+
 def test_finalize_default_batch_generation_hook_calls_single_hook() -> None:
     calls: list[tuple[str, int]] = []
 

--- a/tests/unit_test/model_runner/test_base_hooks.py
+++ b/tests/unit_test/model_runner/test_base_hooks.py
@@ -427,6 +427,23 @@ def test_mrope_patch_warns_when_hook_missing(caplog: pytest.LogCaptureFixture) -
     assert ForwardBatch._sglang_omni_mrope_patch_missing_logged is True
 
 
+def test_mrope_patch_keeps_original_method_on_reentry() -> None:
+    class ForwardBatch:
+        def _compute_mrope_positions(self, model_runner, batch):
+            del model_runner, batch
+            return "original"
+
+    original = ForwardBatch._compute_mrope_positions
+    runner = object.__new__(ModelRunner)
+
+    runner._patch_forward_batch_mrope(ForwardBatch)
+    patched = ForwardBatch._compute_mrope_positions
+    runner._patch_forward_batch_mrope(ForwardBatch)
+
+    assert ForwardBatch._sglang_omni_orig_compute_mrope_positions is original
+    assert ForwardBatch._compute_mrope_positions is patched
+
+
 def test_finalize_default_batch_generation_hook_calls_single_hook() -> None:
     calls: list[tuple[str, int]] = []
 

--- a/tests/unit_test/model_runner/test_base_hooks.py
+++ b/tests/unit_test/model_runner/test_base_hooks.py
@@ -209,6 +209,82 @@ def test_mrope_text_decode_fast_path(monkeypatch: pytest.MonkeyPatch) -> None:
     assert forward_batch._sglang_omni_mrope_seconds >= 0.0
 
 
+def test_mrope_text_decode_fast_path_accepts_zero_delta_mm_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_FAST_MROPE_DECODE", "1")
+    monkeypatch.setenv("SGLANG_OMNI_BUILD_PROFILE", "1")
+
+    class ForwardBatch:
+        def __init__(self) -> None:
+            self.forward_mode = _DecodeMode()
+            self.positions = torch.tensor([8], dtype=torch.int64)
+            self.spec_info = None
+            self.mrope_positions = None
+
+        def _compute_mrope_positions(self, model_runner, batch):
+            del model_runner, batch
+            self.mrope_positions = torch.full((3, 1), -1, dtype=torch.int64)
+
+    mm_input = SimpleNamespace(
+        mrope_position_delta=torch.zeros((1, 1), dtype=torch.int64),
+        contains_mm_input=lambda: False,
+    )
+
+    runner = object.__new__(ModelRunner)
+    runner._patch_forward_batch_mrope(ForwardBatch)
+
+    forward_batch = ForwardBatch()
+    forward_batch._compute_mrope_positions(
+        object(),
+        SimpleNamespace(multimodal_inputs=[mm_input]),
+    )
+
+    assert torch.equal(
+        forward_batch.mrope_positions,
+        torch.tensor([[8], [8], [8]], dtype=torch.int64),
+    )
+    assert forward_batch._sglang_omni_mrope_fast is True
+
+
+def test_mrope_fast_path_skips_nonzero_delta_mm_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_FAST_MROPE_DECODE", "1")
+    monkeypatch.setenv("SGLANG_OMNI_BUILD_PROFILE", "1")
+
+    class ForwardBatch:
+        def __init__(self) -> None:
+            self.forward_mode = _DecodeMode()
+            self.positions = torch.tensor([8], dtype=torch.int64)
+            self.spec_info = None
+            self.mrope_positions = None
+
+        def _compute_mrope_positions(self, model_runner, batch):
+            del model_runner, batch
+            self.mrope_positions = torch.full((3, 1), -1, dtype=torch.int64)
+
+    mm_input = SimpleNamespace(
+        mrope_position_delta=torch.ones((1, 1), dtype=torch.int64),
+        contains_mm_input=lambda: False,
+    )
+
+    runner = object.__new__(ModelRunner)
+    runner._patch_forward_batch_mrope(ForwardBatch)
+
+    forward_batch = ForwardBatch()
+    forward_batch._compute_mrope_positions(
+        object(),
+        SimpleNamespace(multimodal_inputs=[mm_input]),
+    )
+
+    assert torch.equal(
+        forward_batch.mrope_positions,
+        torch.full((3, 1), -1, dtype=torch.int64),
+    )
+    assert forward_batch._sglang_omni_mrope_fast is False
+
+
 def test_mrope_fast_path_skips_multimodal(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("SGLANG_OMNI_FAST_MROPE_DECODE", "1")
 


### PR DESCRIPTION
## Summary

- Add env-gated per-step/build profiling for the Qwen3-Omni thinker decode path.
- Add an env-gated text-only decode MRoPE fast path that reuses decode positions instead of rebuilding/copying tiny CPU MRoPE tensors each step.
- Treat `MultimodalInputs(mm_items=[])` with zero `mrope_position_delta` as text-equivalent; nonzero delta and real multimodal inputs still use the original path.

## H100 Findings

Fixed-concurrency diagnostic result, before the full SLO-constrained throughput sweep:

- Setup: Qwen3-Omni thinker, BF16, TP=2, H100 GPU4/5 NV18, c32 text-only decode, `thinker_memory_fraction=mem_fraction_static=0.55`, CUDA graph hit rate 1.000.
- MRoPE text-only decode fast path:
  - Throughput: 3858.4 -> 4085.7 tok/s (+5.9%).
  - Step: 7.68 -> 7.30 ms.
  - Build: 0.61 -> 0.26 ms.
  - MRoPE: 0.37 -> 0.03 ms.
  - Forward stayed flat: ~6.45 -> ~6.43 ms.
- Companion custom all-reduce result is covered by #783, not reimplemented in this PR:
  - NCCL stable control: ~4034 tok/s.
  - custom-AR: 4440.6 tok/s mean / 4466.1 tok/s median (+10-11%).
  - Step/forward: ~7.31/6.45 ms -> ~6.68/5.85 ms.

## Metric Framing

The target metric should be SLO-constrained throughput, not raw tok/s or standalone latency. This PR contributes a low-risk host/build reduction that improves fixed-c32 decode throughput while preserving CUDA graph hit rate. The next benchmark should add p95 ITL/TTFT and a c16/c24/c32/c40/c48 sweep to report max sustainable tok/s under a fixed streaming latency budget.

## Validation

- `PYTHONPYCACHEPREFIX=/tmp/sglang-omni-pycache python3 -m py_compile sglang_omni/model_runner/base.py tests/unit_test/model_runner/test_base_hooks.py`
- `git diff --check`
- Container smoke test for MRoPE zero-delta/nonzero-delta behavior.
- H100 c32 A/B logs:
  - `/data/luojiaxuan/h100-host-scheduler-runs/20260617-mrope-ab2/`
  - `/data/luojiaxuan/h100-host-scheduler-runs/20260617-custom-ar-ab/`

Note: host-side `python3 -m pytest tests/unit_test/model_runner/test_base_hooks.py -q` could not run because `pytest` is not installed in the host Python environment.
