### PR TITLE
[Docs] Fix MOSS-TTS-Local streaming command format

### DIFF
--- a/docs/cookbook/moss_tts_local.md
+++ b/docs/cookbook/moss_tts_local.md
@@ -126,8 +126,8 @@ Reference encodes are cached (LRU) and coalesced into batched codec calls, so re
 
 ### Streaming
 
-Set `"stream": true` and `"response_format": "pcm"` to receive raw 48 kHz mono PCM
-chunks in real time. Pipe the stream through `ffmpeg` when you want a playable WAV file:
+Set `"stream": true`, `"response_format": "pcm"`, and `"stream_format": "audio"` to receive raw
+48 kHz mono PCM chunks in real time. Pipe the stream through `ffmpeg` when you want a playable WAV file:
 
 ```bash
 curl -N -X POST http://localhost:8000/v1/audio/speech \
@@ -137,7 +137,8 @@ curl -N -X POST http://localhost:8000/v1/audio/speech \
     "ref_audio": "https://huggingface.co/datasets/zhaochenyang20/seed-tts-eval-mini/resolve/main/en/prompt-wavs/common_voice_en_10119832.wav",
     "ref_text": "We asked over twenty different people, and they all said it was his.",
     "stream": true,
-    "response_format": "pcm"
+    "response_format": "pcm",
+    "stream_format": "audio"
   }' \
   | ffmpeg -f s16le -ar 48000 -ac 1 -i pipe:0 output_stream.wav
 ```
@@ -197,6 +198,7 @@ curl -X POST http://localhost:8000/v1/audio/speech \
 | `references` | `null` | Reference clip for cloning; each item has `audio_path` and `text` |
 | `ref_audio` / `ref_text` | `null` | Shorthand for `references[0].audio_path` / `references[0].text` |
 | `stream` | `false` | Stream raw PCM audio chunks (with `response_format: pcm`) |
+| `stream_format` | `sse` | Set to `audio` when piping raw PCM bytes directly into an audio decoder |
 | `language` | `null` | Optional target-language hint; omit to let the model infer |
 | `instructions` | `null` | Optional free-text style directive |
 | `token_count` / `duration_tokens` | `null` | Target duration in codec frames; must be `> 0` |


### PR DESCRIPTION
## Motivation

The MOSS-TTS-Local cookbook streaming example pipes the response directly into `ffmpeg -f s16le`. Manual verification showed that omitting `"stream_format": "audio"` can produce noise-like WAV output and can trigger
ffmpeg PCM decode errors, even when the command exits successfully.

## Modifications

1. `docs/cookbook/moss_tts_local.md`
   - Updates the Streaming section to require `"stream": true`, `"response_format": "pcm"`, and `"stream_format": "audio"` for the raw PCM pipe-to-ffmpeg command.
   - Adds `"stream_format": "audio"` to the copy-paste curl JSON payload.
   - Documents `stream_format` in the generation parameter table for users who pipe raw PCM bytes directly into an audio decoder.

## Related Issues

N/A

## Accuracy Test
N/A

## Benchmark & Profiling
N/A 

**Setup:**

- Baseline: `upstream/main @ 3d8b2a2`
- Candidate: `fix/moss-tts-local-stream-format-audio @ ba24e69`
- Model: `OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5`
- Server: `CUDA_VISIBLE_DEVICES=0,1 /data/.venv/bin/sgl-omni serve --model-path OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5 --port 8000 --log-level info`
- Hardware: NVIDIA H100 80GB GPUs

| Variant | Runs | ffmpeg result | WAV stats |
| --- | --- | --- | --- |
| Without `stream_format` | 2 | One run logged `Invalid PCM packet` and `Decoding error`; both commands exited `0` | `mean_abs=0.595037` and `0.592171`, noise-like |
| With `"stream_format": "audio"` | 2 | No ffmpeg decode errors | `mean_abs=0.066221` and `0.061892`, speech-like |

### Summary:
The cookbook command should include `"stream_format": "audio"` when piping raw PCM streaming output into ffmpeg.

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the `run-ci` label. Once labeled, every subsequent push re-triggers CI as long as the label remains. Draft PRs are skipped even if labeled.