### PR TITLE
Add RL refit admin API alias

### DIFF
--- a/docs/developer_reference/rl_admin_control.md
+++ b/docs/developer_reference/rl_admin_control.md
@@ -31,6 +31,7 @@ The worker server supports:
 - `GET|POST /model_info`
 - `POST /pause_generation`
 - `POST /continue_generation`
+- `POST /refit`
 - `POST /update_weights_from_disk`
 - `POST /update_weights_from_tensor`
 - `POST /init_weights_update_group`
@@ -38,6 +39,8 @@ The worker server supports:
 - `POST /update_weights_from_distributed`
 - `GET|POST /weights_checker`
 
+`/refit` is a Miles/UniRL-friendly alias for the from-disk refit path and has
+the same request and response contract as `/update_weights_from_disk`.
 `/update_weights_from_disk` is the primary implemented update path. It pauses
 the target scheduler, optionally aborts active requests, calls the underlying
 SGLang model runner update method, optionally flushes cache, and resumes unless
@@ -85,6 +88,10 @@ indefinitely. If distributed group initialization fails or times out, the target
 worker remains disabled until an operator explicitly re-enables it after
 recovery.
 
+The router exposes `POST /refit` with the same disk-refit body. It broadcasts the
+request to worker `POST /refit` routes, disables target workers while the update
+is in flight, and serializes it through the same admin update lock.
+
 ## Weight Checker
 
 `/weights_checker` supports `snapshot`, `reset_tensors`, `compare`, and
@@ -92,3 +99,23 @@ recovery.
 name, dtype, shape, and raw bytes, then derives a per-rank checksum from the
 sorted tensor digests. Full-model SHA256 checks block inference on that worker
 until the digest completes.
+
+## Refit Validation
+
+Use the focused unit tests for CPU-safe contract checks:
+
+```bash
+pytest tests/unit_test/model_runner/test_weight_checker.py -q
+pytest tests/unit_test/serve/test_openai_api.py -q
+pytest tests/unit_test/router/test_app.py -q
+```
+
+Use the GPU end-to-end test to measure refit efficiency on the production path:
+
+```bash
+pytest tests/test_model/test_rl_distributed_weight_update.py -s
+```
+
+The E2E test launches an instruct server, refits it to a base checkpoint over the
+distributed refit path, prints the measured update latency, and compares SHA256
+digests against a reference base-loaded server.

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -420,8 +420,7 @@ def _register_admin(app: FastAPI, admin_api_key: str | None = None) -> None:
             )
         )
 
-    @app.post("/update_weights_from_disk", dependencies=[Depends(_auth)])
-    async def update_weights_from_disk(
+    async def _update_weights_from_disk_response(
         req: UpdateWeightFromDiskRequest,
     ) -> JSONResponse:
         client: Client = app.state.client
@@ -433,6 +432,16 @@ def _register_admin(app: FastAPI, admin_api_key: str | None = None) -> None:
                 timeout_s=_timeout_or_default(req.timeout_s, 120.0),
             )
         )
+
+    @app.post("/update_weights_from_disk", dependencies=[Depends(_auth)])
+    async def update_weights_from_disk(
+        req: UpdateWeightFromDiskRequest,
+    ) -> JSONResponse:
+        return await _update_weights_from_disk_response(req)
+
+    @app.post("/refit", dependencies=[Depends(_auth)])
+    async def refit(req: UpdateWeightFromDiskRequest) -> JSONResponse:
+        return await _update_weights_from_disk_response(req)
 
     @app.post("/update_weights_from_tensor", dependencies=[Depends(_auth)])
     async def update_weights_from_tensor(

--- a/sglang_omni_router/app.py
+++ b/sglang_omni_router/app.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 
 _ADMIN_UPDATE_PATHS = {
     "/pause_generation",
+    "/refit",
     "/update_weights_from_disk",
     "/update_weights_from_distributed",
     "/init_weights_update_group",
@@ -332,6 +333,10 @@ def register_routes(
             request,
             "/update_weights_from_disk",
         )
+
+    @app.post("/refit", dependencies=[Depends(_auth)])
+    async def refit(request: Request) -> JSONResponse:
+        return await _broadcast_admin_request(app, request, "/refit")
 
     @app.post("/update_weights_from_tensor", dependencies=[Depends(_auth)])
     async def update_weights_from_tensor(request: Request) -> JSONResponse:

--- a/tests/README.md
+++ b/tests/README.md
@@ -190,9 +190,11 @@ Relevant model CI ownership:
 - `test_rl_distributed_weight_update.py`: launches a Higgs TTS worker on one GPU
   and a rank-0 trainer subprocess on another GPU, initializes the distributed
   weight-update group, broadcasts base-model body weights, verifies the
-  `tts_engine` checksum changes, destroys the update group, and checks the
-  server still serves audio. It is skipped unless two GPUs and the required
-  Higgs base checkpoint are already available in the Hugging Face cache.
+  `tts_engine` checksum changes against a base-loaded reference, prints measured
+  refit latency for efficiency tracking, destroys the update group, and checks
+  the server still serves audio. It is skipped unless two GPUs and the required
+  Higgs base/instruct checkpoints are already available in the Hugging Face
+  cache.
 - CLI flags `--s2pro-stage {nonstream,stream,consistency,all}` and
   `--concurrency {1,2,4,8,16,all}`: scope an S2-Pro CI sweep without editing
   source.
@@ -355,10 +357,12 @@ that happened to contain an older version of the test.
   - worker metadata and health-state contracts
   - request routing, proxying, and streaming relay
   - worker selection policy behavior
+  - RL admin/refit broadcast and worker-isolation behavior
   - managed launcher command construction and cleanup.
 
 - `unit_test/serve/`: In-process serving API unit tests:
   - OpenAI-compatible request/response behavior
+  - RL admin/refit request validation and client forwarding
   - streaming response framing and failure semantics.
 
 - `unit_test/fishaudio_s2_pro/`: FishAudio S2-Pro unit tests:

--- a/tests/unit_test/model_runner/test_weight_checker.py
+++ b/tests/unit_test/model_runner/test_weight_checker.py
@@ -124,6 +124,71 @@ def test_model_worker_update_weights_from_disk_updates_visible_model_info() -> N
     assert runner.model_config.model_path == "/tmp/new-model"
 
 
+def test_disk_refit_replaces_instruct_weights_with_base_sha256() -> None:
+    instruct_model = torch.nn.Sequential(
+        torch.nn.Linear(3, 4, bias=False),
+        torch.nn.Linear(4, 2, bias=False),
+    )
+    base_model = torch.nn.Sequential(
+        torch.nn.Linear(3, 4, bias=False),
+        torch.nn.Linear(4, 2, bias=False),
+    )
+    with torch.no_grad():
+        for tensor in instruct_model.parameters():
+            tensor.fill_(0.25)
+        for tensor in base_model.parameters():
+            tensor.fill_(1.5)
+
+    def checksum(model: torch.nn.Module) -> str:
+        return StrictWeightChecker(SimpleNamespace(model=model)).run("checksum")[
+            "per_gpu_checksum"
+        ]
+
+    base_checksum = checksum(base_model)
+    assert checksum(instruct_model) != base_checksum
+
+    def update_weights_from_disk(
+        model_path: str,
+        load_format: str | None,
+        *,
+        recapture_cuda_graph: bool,
+    ) -> tuple[bool, str]:
+        assert model_path == "/tmp/base-model"
+        assert load_format == "safetensors"
+        assert recapture_cuda_graph is False
+        instruct_model.load_state_dict(base_model.state_dict())
+        return True, "refit complete"
+
+    runner = SimpleNamespace(
+        model=instruct_model,
+        server_args=SimpleNamespace(model_path="/tmp/instruct-model"),
+        model_config=SimpleNamespace(model_path="/tmp/instruct-model"),
+        update_weights_from_disk=update_weights_from_disk,
+    )
+    worker = object.__new__(ModelWorker)
+    worker.server_args = SimpleNamespace(
+        model_path="/tmp/instruct-model",
+        load_format="auto",
+        weight_version="instruct",
+    )
+    worker.model_runner = runner
+
+    success, message = ModelWorker.update_weights_from_disk(
+        worker,
+        {
+            "model_path": "/tmp/base-model",
+            "load_format": "safetensors",
+            "weight_version": "base-v1",
+        },
+    )
+
+    assert success is True
+    assert message == "refit complete"
+    assert checksum(instruct_model) == base_checksum
+    assert worker.server_args.model_path == "/tmp/base-model"
+    assert worker.server_args.weight_version == "base-v1"
+
+
 def test_model_worker_init_weights_update_group_passes_positional_args() -> None:
     calls: list[tuple[Any, ...]] = []
 

--- a/tests/unit_test/router/test_app.py
+++ b/tests/unit_test/router/test_app.py
@@ -1753,6 +1753,7 @@ _ROUTER_ADMIN_PATHS = [
     ("POST", "/model_info"),
     ("POST", "/pause_generation"),
     ("POST", "/continue_generation"),
+    ("POST", "/refit"),
     ("POST", "/update_weights_from_disk"),
     ("POST", "/update_weights_from_tensor"),
     ("POST", "/update_weights_from_distributed"),
@@ -1876,6 +1877,57 @@ def test_router_unimplemented_tensor_weight_update_returns_501() -> None:
         resp = client.post("/update_weights_from_tensor", json={})
     assert resp.status_code == 501
     assert resp.json()["error"]["code"] == "not_implemented"
+
+
+def test_router_refit_broadcasts_with_worker_isolation() -> None:
+    seen_paths: list[str] = []
+    disabled_during_refit: list[bool] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "healthy"}, request=request)
+        seen_paths.append(request.url.path)
+        disabled_during_refit.append(app.state.workers[0].disabled)
+        if request.url.path == "/refit":
+            return httpx.Response(
+                200,
+                json={
+                    "success": True,
+                    "message": "ok",
+                    "results": [
+                        {
+                            "stage": "decode",
+                            "success": True,
+                            "data": {
+                                "model_path": "/tmp/base-model",
+                                "weight_version": "base-v1",
+                            },
+                        }
+                    ],
+                },
+                request=request,
+            )
+        raise AssertionError(f"unexpected request path: {request.url.path}")
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(
+        _router_config(worker_configs=[WorkerConfig(url="http://worker-a:8101")]),
+        client=async_client,
+    )
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/refit",
+            json={"model_path": "/tmp/base-model", "weight_version": "base-v1"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["path"] == "/refit"
+    assert seen_paths == ["/refit"]
+    assert disabled_during_refit == [True]
+    assert app.state.workers[0].disabled is False
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -507,6 +507,14 @@ def test_admin_routes_forward_to_client() -> None:
             "abort_all_requests": True,
         },
     )
+    refit = client.post(
+        "/refit",
+        json={
+            "model_path": "/tmp/base-model",
+            "weight_version": "base-v1",
+            "timeout_s": 7,
+        },
+    )
     checksum = client.post("/weights_checker", json={"action": "checksum"})
 
     assert info.status_code == 200
@@ -516,6 +524,7 @@ def test_admin_routes_forward_to_client() -> None:
     assert info.json()["stages"][0]["stage"] == "decode"
     assert pause.status_code == 200
     assert update.status_code == 200
+    assert refit.status_code == 200
     assert checksum.status_code == 200
     assert admin.calls == [
         ("model_info", {}, None, 30.0),
@@ -536,6 +545,22 @@ def test_admin_routes_forward_to_client() -> None:
             },
             None,
             120.0,
+        ),
+        (
+            "update_weights_from_disk",
+            {
+                "model_path": "/tmp/base-model",
+                "abort_all_requests": False,
+                "weight_version": "base-v1",
+                "is_async": False,
+                "torch_empty_cache": False,
+                "keep_pause": False,
+                "recapture_cuda_graph": False,
+                "token_step": 0,
+                "flush_cache": True,
+            },
+            None,
+            7,
         ),
         ("weights_checker", {"action": "checksum"}, None, 120.0),
     ]
@@ -839,6 +864,7 @@ _ADMIN_PATHS_THAT_NEED_AUTH = [
     ("POST", "/model_info"),
     ("POST", "/pause_generation"),
     ("POST", "/continue_generation"),
+    ("POST", "/refit"),
     ("POST", "/update_weights_from_disk"),
     ("POST", "/update_weights_from_tensor"),
     ("POST", "/update_weights_from_distributed"),
@@ -943,6 +969,16 @@ def test_unimplemented_tensor_weight_update_returns_501() -> None:
     assert resp.status_code == 501
     assert resp.json()["error"]["code"] == "not_implemented"
     assert "update_weights_from_disk" in resp.json()["error"]["message"]
+
+
+def test_refit_requires_model_path() -> None:
+    admin = AdminClient()
+    client = TestClient(create_app(admin, model_name="qwen3-omni"))
+
+    resp = client.post("/refit", json={})
+
+    assert resp.status_code == 422
+    assert admin.calls == []
 
 
 def test_distributed_weight_update_routes_forward_to_client() -> None:


### PR DESCRIPTION
## Summary

Adds a Miles/UniRL-friendly `POST /refit` admin alias for the existing from-disk weight update path.

- Worker serve API accepts `/refit` with the same request contract as `/update_weights_from_disk`
- External router broadcasts `/refit` through the admin update lock and worker isolation path
- Adds focused SHA256 refit coverage that loads fake instruct weights, refits to fake base weights, and verifies the strict checksum matches
- Updates RL admin docs and the test catalog with refit validation guidance

## Validation

- Remote container: `novita-h100-omni`, container `sglang-omni-hayden-rl`
- `python -m compileall -q sglang_omni/serve/openai_api.py sglang_omni_router/app.py tests/unit_test/serve/test_openai_api.py tests/unit_test/router/test_app.py tests/unit_test/model_runner/test_weight_checker.py`
- `CUDA_VISIBLE_DEVICES=0 pytest tests/unit_test/model_runner/test_weight_checker.py tests/unit_test/serve/test_openai_api.py tests/unit_test/router/test_app.py -q` -> `109 passed in 3.63s`
- `pytest tests/test_model/test_rl_distributed_weight_update.py -s -q -vv --tb=short` -> `1 skipped in 0.09s` because the container does not have the Higgs base/instruct checkpoints cached (`base None`, `instruct None`)
- Local pre-commit hooks run by `git commit` passed

## Notes

The new route is intentionally conservative: `/refit` is an alias for disk refit metadata over the admin control plane. Bulk tensors/checkpoints remain on disk or the distributed data plane.
