### PR TITLE
feat(sampling): Framework-level refractor to unify the seed in sampling API->model runner

### DIFF
--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import torch
 
-from sglang_omni.sampling.seed import resolve_row_seed
+from sglang_omni.sampling.seed import SAMPLING_SEED_MASK, resolve_row_seed
 from sglang_omni.scheduling.types import (
     ModelRunnerOutput,
     RequestOutput,
@@ -577,17 +577,27 @@ class ModelRunner:
         """Install per-row ``seed``s onto ``sampling_info`` so SGLang routes to
         ``multinomial_with_seed``. No-op when no request set a seed, or when a
         subclass already installed its own (e.g. Qwen3-TTS).
+
+        Runs once per decode step. The resolved seed is a per-request constant, so
+        it is resolved once and cached back onto ``sampling_params.sampling_seed``
+        (an unseeded row mints one random seed for its whole generation); later
+        steps reuse it instead of re-running ``os.urandom`` / re-masking per step.
         """
         sampling_info = forward_batch.sampling_info
         if sampling_info.sampling_seed is not None:
             return
-        public_seeds = [sr.data.req.sampling_params.sampling_seed for sr in requests]
-        if all(seed is None for seed in public_seeds):
+        sampling_params = [sr.data.req.sampling_params for sr in requests]
+        if all(sp.sampling_seed is None for sp in sampling_params):
             return
+        row_seeds: list[int] = []
+        for sp in sampling_params:
+            seed = sp.sampling_seed
+            if seed is None or not (0 <= seed <= SAMPLING_SEED_MASK):
+                seed = resolve_row_seed(seed)  # random for None, mask otherwise
+                sp.sampling_seed = seed  # cache: stable across this request's steps
+            row_seeds.append(seed)
         sampling_info.sampling_seed = torch.tensor(
-            [resolve_row_seed(seed) for seed in public_seeds],
-            dtype=torch.long,
-            device=sampling_info.device,
+            row_seeds, dtype=torch.long, device=sampling_info.device
         )
 
     @staticmethod

--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import torch
 
+from sglang_omni.sampling.seed import resolve_row_seed
 from sglang_omni.scheduling.types import (
     ModelRunnerOutput,
     RequestOutput,
@@ -545,6 +546,7 @@ class ModelRunner:
     ) -> Any:
         self._apply_repetition_penalty(logits_output, requests)
         self._apply_codec_suppress_tokens(logits_output, requests)
+        self._install_sampling_seeds(forward_batch, requests)
         wants_rollout_logprob = any(sr.data.return_logprob for sr in requests)
         if wants_rollout_logprob:
             self._enable_sampler_logprobs(forward_batch, len(requests))
@@ -570,6 +572,23 @@ class ModelRunner:
                 requests,
             )
         return next_token_ids
+
+    def _install_sampling_seeds(self, forward_batch: Any, requests: list) -> None:
+        """Install per-row ``seed``s onto ``sampling_info`` so SGLang routes to
+        ``multinomial_with_seed``. No-op when no request set a seed, or when a
+        subclass already installed its own (e.g. Qwen3-TTS).
+        """
+        sampling_info = forward_batch.sampling_info
+        if sampling_info.sampling_seed is not None:
+            return
+        public_seeds = [sr.data.req.sampling_params.sampling_seed for sr in requests]
+        if all(seed is None for seed in public_seeds):
+            return
+        sampling_info.sampling_seed = torch.tensor(
+            [resolve_row_seed(seed) for seed in public_seeds],
+            dtype=torch.long,
+            device=sampling_info.device,
+        )
 
     @staticmethod
     def _enable_sampler_logprobs(forward_batch: Any, batch_size: int) -> None:

--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -632,12 +632,14 @@ class ModelRunner:
 
     @staticmethod
     def _validate_seeded_sampling_supported(sampling_info: Any) -> None:
-        if sampling_info.need_min_p_sampling:
+        if getattr(sampling_info, "need_min_p_sampling", False):
             raise ValueError(
                 "SGLang seeded sampling does not support min_p yet; set min_p=0 "
                 "or omit request seed"
             )
-        if not (sampling_info.need_top_p_sampling or sampling_info.need_top_k_sampling):
+        need_top_p_sampling = getattr(sampling_info, "need_top_p_sampling", False)
+        need_top_k_sampling = getattr(sampling_info, "need_top_k_sampling", False)
+        if not (need_top_p_sampling or need_top_k_sampling):
             return
         if _current_sglang_sampling_backend() == "flashinfer":
             raise ValueError(

--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -12,7 +12,11 @@ from typing import Any
 
 import torch
 
-from sglang_omni.sampling.seed import SAMPLING_SEED_MASK, resolve_row_seed
+from sglang_omni.sampling.seed import (
+    SAMPLING_SEED_MASK,
+    derive_sampling_seed,
+    resolve_row_seed,
+)
 from sglang_omni.scheduling.types import (
     ModelRunnerOutput,
     RequestOutput,
@@ -29,6 +33,18 @@ def _current_sglang_sampling_backend() -> str | None:
         return get_global_server_args().sampling_backend
     except ValueError:
         return None
+
+
+def _rank_shared_unseeded_sampling_seed(request: Any, row_idx: int) -> int:
+    request_id = getattr(request, "request_id", None)
+    if request_id is None:
+        request_id = getattr(getattr(request, "data", None), "request_id", None)
+    if request_id is None:
+        req = getattr(getattr(request, "data", None), "req", None)
+        request_id = getattr(req, "rid", None)
+    if request_id is None:
+        request_id = f"row-{row_idx}"
+    return derive_sampling_seed("sglang-omni-unseeded-row", request_id)
 
 
 @dataclass
@@ -587,10 +603,11 @@ class ModelRunner:
         ``multinomial_with_seed``. No-op when no request set a seed, or when a
         subclass already installed its own (e.g. Qwen3-TTS).
 
-        Runs once per decode step. The resolved seed is a per-request constant, so
-        it is resolved once and cached back onto ``sampling_params.sampling_seed``
-        (an unseeded row mints one random seed for its whole generation); later
-        steps reuse it instead of re-running ``os.urandom`` / re-masking per step.
+        Runs once per decode step. User-provided seeds are resolved once and
+        cached back onto ``sampling_params.sampling_seed``. In a mixed
+        seeded/unseeded batch the SGLang sampler is batch-wide, so unseeded rows
+        receive a request-id-derived fallback seed instead of a rank-local random
+        seed; this keeps TP ranks in sync without mutating the public request seed.
         """
         sampling_info = forward_batch.sampling_info
         if sampling_info.sampling_seed is not None:
@@ -601,11 +618,13 @@ class ModelRunner:
             return
         self._validate_seeded_sampling_supported(sampling_info)
         row_seeds: list[int] = []
-        for sp in sampling_params:
+        for row_idx, (sp, request) in enumerate(zip(sampling_params, requests)):
             seed = sp.sampling_seed
-            if seed is None or not (0 <= seed <= SAMPLING_SEED_MASK):
-                seed = resolve_row_seed(seed)  # random for None, mask otherwise
-                sp.sampling_seed = seed  # cache: stable across this request's steps
+            if seed is None:
+                seed = _rank_shared_unseeded_sampling_seed(request, row_idx)
+            elif not (0 <= seed <= SAMPLING_SEED_MASK):
+                seed = resolve_row_seed(seed)  # mask and cache user seed
+                sp.sampling_seed = seed
             row_seeds.append(seed)
         sampling_info.sampling_seed = torch.tensor(
             row_seeds, dtype=torch.long, device=sampling_info.device

--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -22,6 +22,15 @@ from sglang_omni.scheduling.types import (
 logger = logging.getLogger(__name__)
 
 
+def _current_sglang_sampling_backend() -> str | None:
+    try:
+        from sglang.srt.server_args import get_global_server_args
+
+        return get_global_server_args().sampling_backend
+    except ValueError:
+        return None
+
+
 @dataclass
 class _PendingStep:
     """One decode step launched on the GPU but not yet consumed on the host.
@@ -585,10 +594,12 @@ class ModelRunner:
         """
         sampling_info = forward_batch.sampling_info
         if sampling_info.sampling_seed is not None:
+            self._validate_seeded_sampling_supported(sampling_info)
             return
         sampling_params = [sr.data.req.sampling_params for sr in requests]
         if all(sp.sampling_seed is None for sp in sampling_params):
             return
+        self._validate_seeded_sampling_supported(sampling_info)
         row_seeds: list[int] = []
         for sp in sampling_params:
             seed = sp.sampling_seed
@@ -599,6 +610,22 @@ class ModelRunner:
         sampling_info.sampling_seed = torch.tensor(
             row_seeds, dtype=torch.long, device=sampling_info.device
         )
+
+    @staticmethod
+    def _validate_seeded_sampling_supported(sampling_info: Any) -> None:
+        if sampling_info.need_min_p_sampling:
+            raise ValueError(
+                "SGLang seeded sampling does not support min_p yet; set min_p=0 "
+                "or omit request seed"
+            )
+        if not (sampling_info.need_top_p_sampling or sampling_info.need_top_k_sampling):
+            return
+        if _current_sglang_sampling_backend() == "flashinfer":
+            raise ValueError(
+                "SGLang flashinfer sampling backend does not support request seed "
+                "with top_p/top_k filtering; configure sampling_backend='pytorch' "
+                "or avoid top_p/top_k with seed"
+            )
 
     @staticmethod
     def _enable_sampler_logprobs(forward_batch: Any, batch_size: int) -> None:

--- a/sglang_omni/models/fishaudio_s2_pro/model_runner.py
+++ b/sglang_omni/models/fishaudio_s2_pro/model_runner.py
@@ -8,6 +8,8 @@ from typing import Any
 import torch
 
 from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.models.fishaudio_s2_pro.sglang_model import _NO_SEED
+from sglang_omni.sampling.seed import resolve_row_seed
 
 
 def collect_s2pro_step_outputs(
@@ -132,6 +134,11 @@ class FishS2ProModelRunner(ModelRunner):
         self.model._sampling_rep_penalty[row_idx] = data.repetition_penalty
         self.model._ras_temperature[row_idx] = data.ras_temperature
         self.model._ras_top_p[row_idx] = data.ras_top_p
+        self.model._sampling_seeds[row_idx] = (
+            _NO_SEED if data.seed is None else resolve_row_seed(data.seed)
+        )
+        # semantic_history_count is the uncapped per-request AR step (pre-step).
+        self.model._step_count[row_idx] = int(data.semantic_history_count)
 
         history_len = self.model._rep_history_len
         history = data.semantic_history_tokens

--- a/sglang_omni/models/fishaudio_s2_pro/payload_types.py
+++ b/sglang_omni/models/fishaudio_s2_pro/payload_types.py
@@ -29,6 +29,7 @@ class S2ProState:
     ras_window: int = 16
     ras_temperature: float = 1.0
     ras_top_p: float = 0.9
+    seed: int | None = None
 
     # -- From TTS engine ---------------------------------------------------
     output_codes: Any | None = None  # [num_codebooks+1, T] as nested list
@@ -67,6 +68,8 @@ class S2ProState:
         data["ras_window"] = self.ras_window
         data["ras_temperature"] = self.ras_temperature
         data["ras_top_p"] = self.ras_top_p
+        if self.seed is not None:
+            data["seed"] = self.seed
         if self.output_codes is not None:
             data["output_codes"] = self._tensor_to_list(self.output_codes)
         if self.prompt_tokens:
@@ -101,6 +104,7 @@ class S2ProState:
             ras_window=data.get("ras_window", 16),
             ras_temperature=data.get("ras_temperature", 1.0),
             ras_top_p=data.get("ras_top_p", 0.9),
+            seed=data.get("seed"),
             output_codes=(
                 torch.tensor(data["output_codes"]) if "output_codes" in data else None
             ),

--- a/sglang_omni/models/fishaudio_s2_pro/request_builders.py
+++ b/sglang_omni/models/fishaudio_s2_pro/request_builders.py
@@ -31,6 +31,7 @@ class S2ProSGLangRequestData(SGLangARRequestData):
     ras_window: int = 16
     ras_temperature: float = 1.0
     ras_top_p: float = 0.9
+    seed: int | None = None
     previous_semantic_tokens: list[int] = field(default_factory=list)
     semantic_history_tokens: torch.Tensor | None = None
     semantic_history_count: int = 0
@@ -121,6 +122,7 @@ def build_sglang_tts_request(
         ras_window=state.ras_window,
         ras_temperature=state.ras_temperature,
         ras_top_p=state.ras_top_p,
+        seed=state.seed,
     )
 
 

--- a/sglang_omni/models/fishaudio_s2_pro/sglang_model.py
+++ b/sglang_omni/models/fishaudio_s2_pro/sglang_model.py
@@ -441,7 +441,7 @@ class S2ProSGLangTextModel(nn.Module):
         seeds = self._sampling_seeds[:bs]
         unseeded_choice = torch.multinomial(probs, num_samples=1)
         seeded_choice = multinomial_with_seed(
-            probs, seeds.clamp_min(0), self._step_count[:bs]
+            torch.log(probs), seeds.clamp_min(0), self._step_count[:bs]
         )
         choice = torch.where((seeds >= 0).unsqueeze(-1), seeded_choice, unseeded_choice)
         semantic_token = top_k_indices.gather(-1, choice).squeeze(-1)

--- a/sglang_omni/models/fishaudio_s2_pro/sglang_model.py
+++ b/sglang_omni/models/fishaudio_s2_pro/sglang_model.py
@@ -10,6 +10,7 @@ from typing import Any, Iterable, Optional, Tuple
 
 import torch
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.layers.sampler import multinomial_with_seed
 from torch import Tensor, nn
 
 from sglang_omni.vendor.sglang.core import ForwardBatch
@@ -30,6 +31,7 @@ logger = logging.getLogger(__name__)
 # Note (Ratish): fixed top-k width keeps decode graph shape stable;
 # per-request top_k is masked inside _decode_codebooks.
 _GRAPH_TOP_K = 30
+_NO_SEED = -1  # sentinel: keep the legacy unseeded torch.multinomial draw
 _DEFAULT_TEMPERATURE = 0.8
 _DEFAULT_TOP_P = 0.8
 _DEFAULT_REP_PENALTY = 1.1
@@ -300,6 +302,12 @@ class S2ProSGLangTextModel(nn.Module):
         self._sampling_rep_penalty = torch.full(
             (max_batch_size,), _DEFAULT_REP_PENALTY, device=device
         )
+        # Per-request seed (``_NO_SEED`` = unseeded) + AR step for reproducible
+        # semantic-token sampling via multinomial_with_seed.
+        self._sampling_seeds = torch.full(
+            (max_batch_size,), _NO_SEED, dtype=torch.long, device=device
+        )
+        self._step_count = torch.zeros(max_batch_size, dtype=torch.long, device=device)
         self._ras_temperature = torch.full((max_batch_size,), 1.0, device=device)
         self._ras_top_p = torch.full((max_batch_size,), 0.9, device=device)
         self._prev_tokens = torch.zeros(
@@ -428,9 +436,15 @@ class S2ProSGLangTextModel(nn.Module):
         probs = torch.nn.functional.softmax(
             top_k_logits / temperature.clamp(min=1e-5), dim=-1
         )
-        semantic_token = top_k_indices.gather(
-            -1, torch.multinomial(probs, num_samples=1)
-        ).squeeze(-1)
+        # Seeded rows draw reproducibly from (seed, step); unseeded rows keep the
+        # legacy torch.multinomial draw, so unseeded decode is unchanged.
+        seeds = self._sampling_seeds[:bs]
+        unseeded_choice = torch.multinomial(probs, num_samples=1)
+        seeded_choice = multinomial_with_seed(
+            probs, seeds.clamp_min(0), self._step_count[:bs]
+        )
+        choice = torch.where((seeds >= 0).unsqueeze(-1), seeded_choice, unseeded_choice)
+        semantic_token = top_k_indices.gather(-1, choice).squeeze(-1)
 
         # Batched codebook loop
         self._audio_decoder.reset_caches()

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -196,6 +196,7 @@ def create_preprocessing_executor(
             top_p=params.get("top_p", 0.8),
             top_k=params.get("top_k", 30),
             repetition_penalty=params.get("repetition_penalty", 1.1),
+            seed=params.get("seed"),
         )
         return store_state(payload, state)
 

--- a/sglang_omni/models/higgs_tts/model.py
+++ b/sglang_omni/models/higgs_tts/model.py
@@ -18,11 +18,13 @@ from sglang_omni.models.higgs_tts.modeling import (
 )
 from sglang_omni.models.higgs_tts.sampler import (
     K_MAX,
+    NO_SEED,
     HiggsBatchedSamplerState,
     batched_step,
     batched_step_direct,
 )
 from sglang_omni.models.higgs_tts.weight_loader import DiscreteWeightMapper
+from sglang_omni.sampling.seed import resolve_row_seed
 
 # Higgs ckpt prefixes → sglang Qwen3ForCausalLM parameter tree (under ``backbone.``).
 _BACKBONE_PREFIX_MAP: dict[str, str] = {
@@ -188,6 +190,12 @@ class HiggsTTSModel(nn.Module):
         self._cg_active_last_codes = torch.zeros(
             pool_size, num_codebooks, dtype=torch.long, device=cg_device
         )
+        self._cg_active_seeds = torch.full(
+            (pool_size,), NO_SEED, dtype=torch.long, device=cg_device
+        )
+        self._cg_active_step_count = torch.zeros(
+            pool_size, dtype=torch.long, device=cg_device
+        )
 
     def get_input_embeddings(self) -> nn.Embedding:
         return self.backbone.get_input_embeddings()
@@ -221,6 +229,14 @@ class HiggsTTSModel(nn.Module):
         self._rid_to_row[req_id] = row
         self._sampler_pool.reset_row(row)
         return row
+
+    def set_request_seed(self, req_id: str, seed: int | None) -> None:
+        """Pin ``req_id``'s sampler seed (``None`` -> unseeded/random). Constant
+        across the request's AR steps; consumed by ``multinomial_with_seed``."""
+        row = self.acquire_row(req_id)
+        self._sampler_pool.seeds[row] = (
+            NO_SEED if seed is None else resolve_row_seed(seed)
+        )
 
     def release_row(self, req_id: str) -> None:
         """Return ``req_id``'s row to the free pool and drop its output codes."""
@@ -336,6 +352,8 @@ class HiggsTTSModel(nn.Module):
         eoc_countdown_B = self._cg_active_eoc_countdown[:batch_size].to(torch.long)
         generation_done_B = self._cg_active_generation_done[:batch_size]
         last_codes_BN_in = self._cg_active_last_codes[:batch_size]
+        seeds_B = self._cg_active_seeds[:batch_size]
+        step_count_B = self._cg_active_step_count[:batch_size]
 
         self._cg_was_done[:batch_size] = generation_done_B
 
@@ -345,6 +363,7 @@ class HiggsTTSModel(nn.Module):
             new_eoc_countdown_B,
             new_generation_done_B,
             new_last_codes_BN,
+            new_step_count_B,
         ) = batched_step_direct(
             logits_BNV,
             delay_count_B,
@@ -354,7 +373,10 @@ class HiggsTTSModel(nn.Module):
             temperature=temperature,
             top_p=top_p,
             top_k_buf=top_k_buf,
+            seeds=seeds_B,
+            step_count=step_count_B,
         )
+        self._cg_active_step_count[:batch_size] = new_step_count_B
         self._cg_active_delay_count[:batch_size] = new_delay_count_B.to(
             self._cg_active_delay_count.dtype
         )

--- a/sglang_omni/models/higgs_tts/model_runner.py
+++ b/sglang_omni/models/higgs_tts/model_runner.py
@@ -40,6 +40,10 @@ class HiggsTTSModelRunner(ModelRunner):
     def before_prefill(self, forward_batch, schedule_batch, requests):
         del schedule_batch
         forward_batch.req_ids = [req.request_id for req in requests]
+        for req in requests:
+            self.model.set_request_seed(
+                req.request_id, req.data.req.sampling_params.sampling_seed
+            )
         forward_batch.input_embeds = self._build_prefill_input_embeds(
             forward_batch, requests
         )
@@ -180,6 +184,8 @@ class HiggsTTSModelRunner(ModelRunner):
         model._cg_active_eoc_countdown[:bs] = pool.eoc_countdown[rows_t]
         model._cg_active_generation_done[:bs] = pool.generation_done[rows_t]
         model._cg_active_last_codes[:bs] = pool.last_codes[rows_t]
+        model._cg_active_seeds[:bs] = pool.seeds[rows_t]
+        model._cg_active_step_count[:bs] = pool.step_count[rows_t]
 
     @staticmethod
     def _extract_decode_sampling_params(forward_batch, n_real: int):
@@ -246,6 +252,7 @@ class HiggsTTSModelRunner(ModelRunner):
         pool.eoc_countdown[rows_t] = model._cg_active_eoc_countdown[:n_real]
         pool.generation_done[rows_t] = model._cg_active_generation_done[:n_real]
         pool.last_codes[rows_t] = model._cg_active_last_codes[:n_real]
+        pool.step_count[rows_t] = model._cg_active_step_count[:n_real]
 
         # Note(Jiaxin): pack the 3 tensors so a single D2H pulls them all back.
         num_codebooks = model._cg_codes_BN.shape[1]

--- a/sglang_omni/models/higgs_tts/sampler.py
+++ b/sglang_omni/models/higgs_tts/sampler.py
@@ -356,10 +356,10 @@ def batched_step_direct(
     last_codes: torch.Tensor,
     *,
     temperature: torch.Tensor,
+    seeds: torch.Tensor,
+    step_count: torch.Tensor,
     top_p: torch.Tensor | None = None,
     top_k_buf: torch.Tensor | None = None,
-    seeds: torch.Tensor | None = None,
-    step_count: torch.Tensor | None = None,
     boc_id: int = BOC_ID,
     eoc_id: int = EOC_ID,
 ) -> tuple[
@@ -420,9 +420,7 @@ def batched_step_direct(
     update_codes = (active & (~done_this_step)).unsqueeze(-1)
     new_last_codes = torch.where(update_codes, codes_BN, last_codes)
 
-    new_step_count = (
-        None if step_count is None else step_count + active.to(step_count.dtype)
-    )
+    new_step_count = step_count + active.to(step_count.dtype)
 
     stop = torch.full_like(codes_BN, STOP_CODE)
     out_codes = torch.where(generation_done.unsqueeze(-1), stop, codes_BN)

--- a/sglang_omni/models/higgs_tts/sampler.py
+++ b/sglang_omni/models/higgs_tts/sampler.py
@@ -287,7 +287,9 @@ def _sample_independent_batched(
         cb = torch.arange(N, device=logits_BNV.device).view(1, N).expand(B, N)
         positions = (step_B.view(B, 1) * N + cb).reshape(B * N)
         seeds_flat = seeds_B.clamp_min(0).view(B, 1).expand(B, N).reshape(B * N)
-        seeded_flat = multinomial_with_seed(probs, seeds_flat, positions).squeeze(-1)
+        seeded_flat = multinomial_with_seed(
+            torch.log(probs), seeds_flat, positions
+        ).squeeze(-1)
         has_seed = (seeds_B >= 0).view(B, 1).expand(B, N).reshape(B * N)
         codes_flat = torch.where(has_seed, seeded_flat, codes_flat)
     sampled_BN = codes_flat.view(B, N)

--- a/sglang_omni/models/higgs_tts/sampler.py
+++ b/sglang_omni/models/higgs_tts/sampler.py
@@ -15,8 +15,13 @@ from dataclasses import dataclass
 import torch
 from sgl_kernel import top_k_renorm_prob as _fused_top_k_renorm
 from sgl_kernel import top_p_renorm_prob as _fused_top_p_renorm
+from sglang.srt.layers.sampler import multinomial_with_seed
 
 from sglang_omni.models.higgs_tts.utils import BOC_ID, EOC_ID
+
+# Sentinel seed for rows with no user seed: keeps the legacy unseeded
+# torch.multinomial path, so unseeded decode is byte-identical to before.
+NO_SEED = -1
 
 # Sentinel returned by ``step`` after ``generation_done``; engine treats as stop.
 STOP_CODE = -1
@@ -79,6 +84,14 @@ class HiggsBatchedSamplerState:
             dtype=torch.long,
             device=self.device,
         )
+        # Per-request seed (``NO_SEED`` = unseeded) and monotonic AR step, used
+        # to seed each ``(step, codebook)`` draw reproducibly.
+        self.seeds = torch.full(
+            (self.max_batch_size,), NO_SEED, dtype=torch.long, device=self.device
+        )
+        self.step_count = torch.zeros(
+            self.max_batch_size, dtype=torch.long, device=self.device
+        )
 
     def reset_row(self, row: int) -> None:
         """Wipe row ``row`` so the next owner can't read stale state."""
@@ -86,6 +99,8 @@ class HiggsBatchedSamplerState:
         self.eoc_countdown[row] = -1
         self.generation_done[row] = False
         self.last_codes[row].zero_()
+        self.seeds[row] = NO_SEED
+        self.step_count[row] = 0
 
     def view_row(self, row: int) -> HiggsSamplerState:
         """Materialise row ``row`` as a per-request :class:`HiggsSamplerState`.
@@ -219,6 +234,8 @@ def _sample_independent_batched(
     temperature: torch.Tensor,
     top_p: torch.Tensor | None,
     top_k_buf: torch.Tensor | None = None,
+    seeds_B: torch.Tensor | None = None,
+    step_B: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Batched ``[B, N, V] → [B, N]`` sampler.
 
@@ -262,7 +279,17 @@ def _sample_independent_batched(
     if top_p is not None:
         tp = top_p.view(B, 1).expand(B, N).reshape(B * N).to(torch.float32).contiguous()
         probs = _fused_top_p_renorm(probs, tp)
+
     codes_flat = probs.multinomial(num_samples=1).squeeze(-1)
+    if seeds_B is not None:
+        # Seeded rows draw deterministically from (seed, step*N + codebook);
+        # unseeded rows (seed == NO_SEED) keep the torch.multinomial draw above.
+        cb = torch.arange(N, device=logits_BNV.device).view(1, N).expand(B, N)
+        positions = (step_B.view(B, 1) * N + cb).reshape(B * N)
+        seeds_flat = seeds_B.clamp_min(0).view(B, 1).expand(B, N).reshape(B * N)
+        seeded_flat = multinomial_with_seed(probs, seeds_flat, positions).squeeze(-1)
+        has_seed = (seeds_B >= 0).view(B, 1).expand(B, N).reshape(B * N)
+        codes_flat = torch.where(has_seed, seeded_flat, codes_flat)
     sampled_BN = codes_flat.view(B, N)
 
     return torch.where(greedy_B1, argmax_BN, sampled_BN).to(torch.long)
@@ -287,6 +314,8 @@ def batched_step(
     eoc_countdown = state.eoc_countdown[row_indices]
     generation_done = state.generation_done[row_indices]
     last_codes = state.last_codes[row_indices]
+    seeds = state.seeds[row_indices]
+    step_count = state.step_count[row_indices]
 
     (
         out_codes,
@@ -294,6 +323,7 @@ def batched_step(
         new_eoc_countdown,
         new_generation_done,
         new_last_codes,
+        new_step_count,
     ) = batched_step_direct(
         logits_BNV,
         delay_count,
@@ -303,6 +333,8 @@ def batched_step(
         temperature=temperature,
         top_p=top_p,
         top_k_buf=top_k_buf,
+        seeds=seeds,
+        step_count=step_count,
         boc_id=boc_id,
         eoc_id=eoc_id,
     )
@@ -311,6 +343,7 @@ def batched_step(
     state.eoc_countdown[row_indices] = new_eoc_countdown.to(state.eoc_countdown.dtype)
     state.generation_done[row_indices] = new_generation_done
     state.last_codes[row_indices] = new_last_codes
+    state.step_count[row_indices] = new_step_count
 
     return out_codes
 
@@ -325,12 +358,19 @@ def batched_step_direct(
     temperature: torch.Tensor,
     top_p: torch.Tensor | None = None,
     top_k_buf: torch.Tensor | None = None,
+    seeds: torch.Tensor | None = None,
+    step_count: torch.Tensor | None = None,
     boc_id: int = BOC_ID,
     eoc_id: int = EOC_ID,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> tuple[
+    torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
+]:
     """CG-friendly state machine: state in/out as direct ``[B, ...]`` tensors,
     no ``state``/``row_indices`` indirection. Caller persists the returned
     new state. See :func:`batched_step` for arg semantics.
+
+    ``seeds``/``step_count`` (both ``[B]``) make seeded rows reproducible; the
+    returned ``new_step_count`` advances active rows for the next step.
     """
     B, N, V = logits_BNV.shape
     device = logits_BNV.device
@@ -343,6 +383,8 @@ def batched_step_direct(
         temperature=temperature,
         top_p=top_p,
         top_k_buf=top_k_buf,
+        seeds_B=seeds,
+        step_B=step_count,
     )
 
     cb_idx = torch.arange(N, device=device).unsqueeze(0).expand(B, N)
@@ -378,6 +420,10 @@ def batched_step_direct(
     update_codes = (active & (~done_this_step)).unsqueeze(-1)
     new_last_codes = torch.where(update_codes, codes_BN, last_codes)
 
+    new_step_count = (
+        None if step_count is None else step_count + active.to(step_count.dtype)
+    )
+
     stop = torch.full_like(codes_BN, STOP_CODE)
     out_codes = torch.where(generation_done.unsqueeze(-1), stop, codes_BN)
     return (
@@ -386,6 +432,7 @@ def batched_step_direct(
         new_eoc_countdown,
         new_generation_done,
         new_last_codes,
+        new_step_count,
     )
 
 

--- a/sglang_omni/models/llada2_uni/stages.py
+++ b/sglang_omni/models/llada2_uni/stages.py
@@ -95,6 +95,7 @@ def create_sglang_dllm_thinker_executor_from_config(
     overrides: dict[str, Any] = {
         "attention_backend": "flashinfer",
         "disable_cuda_graph": True,
+        "sampling_backend": "pytorch",
     }
     overrides.update(server_args_overrides or {})
 

--- a/sglang_omni/models/ming_omni/pipeline/stages.py
+++ b/sglang_omni/models/ming_omni/pipeline/stages.py
@@ -319,8 +319,10 @@ def create_sglang_thinker_executor_from_config(
     _ensure_ming_config_registered(model_path)
     # Use local snapshot path so AutoConfig finds our patched files
     local_path = _resolve_local_model_path(model_path)
+    overrides = {"sampling_backend": "pytorch"}
+    overrides.update(server_args_overrides or {})
     server_args = build_sglang_server_args(
-        local_path, context_length=thinker_max_seq_len, **(server_args_overrides or {})
+        local_path, context_length=thinker_max_seq_len, **overrides
     )
     _log.getLogger(__name__).info(
         "ServerArgs: cpu_offload_gb=%s, mem_fraction_static=%s",

--- a/sglang_omni/models/ming_omni/stages.py
+++ b/sglang_omni/models/ming_omni/stages.py
@@ -233,6 +233,7 @@ def create_sglang_thinker_executor_from_config(
     register_ming_hf_config()
 
     overrides = dict(server_args_overrides or {})
+    overrides.setdefault("sampling_backend", "pytorch")
     overrides.setdefault("trust_remote_code", False)
     overrides["tp_size"] = tp_size
     server_args = build_sglang_server_args(

--- a/sglang_omni/models/moss_tts/request_builders.py
+++ b/sglang_omni/models/moss_tts/request_builders.py
@@ -17,11 +17,7 @@ import torch
 
 from sglang_omni.models.moss_tts.payload_types import MossTTSState
 from sglang_omni.proto import StagePayload
-from sglang_omni.sampling.seed import (
-    SAMPLING_SEED_MASK,
-    derive_sampling_seed,
-    new_random_sampling_seed,
-)
+from sglang_omni.sampling.seed import derive_sampling_seed, new_random_sampling_seed
 from sglang_omni.scheduling.types import ARRequestData
 from sglang_omni.utils.audio_payload import audio_data_uri_from_reference
 
@@ -31,7 +27,6 @@ _TOKEN_PREFIX_RE = re.compile(r"^\$\{token:(\d+)\}")
 _TOKEN_PREFIX_START_RE = re.compile(r"^\$\{token:")
 _DATA_URI_RE = re.compile(r"^data:audio/[^;,]+;base64,(?P<data>.+)$", re.DOTALL)
 _INF_DELAY = -1
-_MOSS_TTS_SAMPLING_SEED_MASK = SAMPLING_SEED_MASK
 
 
 def _new_moss_tts_sampling_seed() -> int:

--- a/sglang_omni/models/moss_tts/request_builders.py
+++ b/sglang_omni/models/moss_tts/request_builders.py
@@ -7,7 +7,6 @@ import base64
 import collections
 import hashlib
 import io
-import os
 import re
 import threading
 import time
@@ -18,6 +17,11 @@ import torch
 
 from sglang_omni.models.moss_tts.payload_types import MossTTSState
 from sglang_omni.proto import StagePayload
+from sglang_omni.sampling.seed import (
+    SAMPLING_SEED_MASK,
+    derive_sampling_seed,
+    new_random_sampling_seed,
+)
 from sglang_omni.scheduling.types import ARRequestData
 from sglang_omni.utils.audio_payload import audio_data_uri_from_reference
 
@@ -27,11 +31,11 @@ _TOKEN_PREFIX_RE = re.compile(r"^\$\{token:(\d+)\}")
 _TOKEN_PREFIX_START_RE = re.compile(r"^\$\{token:")
 _DATA_URI_RE = re.compile(r"^data:audio/[^;,]+;base64,(?P<data>.+)$", re.DOTALL)
 _INF_DELAY = -1
-_MOSS_TTS_SAMPLING_SEED_MASK = 0x7FFFFFFF
+_MOSS_TTS_SAMPLING_SEED_MASK = SAMPLING_SEED_MASK
 
 
 def _new_moss_tts_sampling_seed() -> int:
-    return int.from_bytes(os.urandom(4), "little") & _MOSS_TTS_SAMPLING_SEED_MASK
+    return new_random_sampling_seed()
 
 
 def derive_moss_tts_sampling_seed(public_seed: int) -> int:
@@ -42,10 +46,7 @@ def derive_moss_tts_sampling_seed(public_seed: int) -> int:
     token depends only on its own seed and position -- never on its batch
     neighbours. This makes ``seed`` reproducible at any batch size, not just 1.
     """
-    digest = hashlib.blake2b(
-        f"moss-tts:{int(public_seed)}".encode("utf-8"), digest_size=8
-    ).digest()
-    return int.from_bytes(digest, "little") & _MOSS_TTS_SAMPLING_SEED_MASK
+    return derive_sampling_seed("moss-tts", int(public_seed))
 
 
 _GENERATION_FIELDS = (

--- a/sglang_omni/models/qwen3_omni/components/talker.py
+++ b/sglang_omni/models/qwen3_omni/components/talker.py
@@ -25,6 +25,7 @@ from sglang_omni.models.qwen3_omni.hf_config import (
 from sglang_omni.models.qwen3_omni.quantization import (
     convert_fp8_weight_scale_inv_for_sglang,
 )
+from sglang_omni.sampling.seed import resolve_row_seed
 from sglang_omni.vendor.sglang.core import ForwardBatch
 from sglang_omni.vendor.sglang.distributed import tensor_model_parallel_all_reduce
 from sglang_omni.vendor.sglang.layers import (
@@ -922,8 +923,9 @@ class Qwen3OmniTalker(nn.Module):
             top_ps.append(float(sp.top_p))
             top_ks.append(int(sp.top_k))
             min_ps.append(float(sp.min_p))
-            seed = sp.sampling_seed
-            sampling_seeds.append(int(seed) if seed is not None else 0)
+            # Same seed scheme as the base runner / thinker: masked user seed, or
+            # a fresh random seed when unseeded (not a fixed 0).
+            sampling_seeds.append(resolve_row_seed(sp.sampling_seed))
 
             if penalty != 1.0 and req.output_ids:
                 unique = {

--- a/sglang_omni/models/qwen3_omni/components/talker.py
+++ b/sglang_omni/models/qwen3_omni/components/talker.py
@@ -25,7 +25,7 @@ from sglang_omni.models.qwen3_omni.hf_config import (
 from sglang_omni.models.qwen3_omni.quantization import (
     convert_fp8_weight_scale_inv_for_sglang,
 )
-from sglang_omni.sampling.seed import resolve_row_seed
+from sglang_omni.sampling.seed import SAMPLING_SEED_MASK, resolve_row_seed
 from sglang_omni.vendor.sglang.core import ForwardBatch
 from sglang_omni.vendor.sglang.distributed import tensor_model_parallel_all_reduce
 from sglang_omni.vendor.sglang.layers import (
@@ -924,8 +924,14 @@ class Qwen3OmniTalker(nn.Module):
             top_ks.append(int(sp.top_k))
             min_ps.append(float(sp.min_p))
             # Same seed scheme as the base runner / thinker: masked user seed, or
-            # a fresh random seed when unseeded (not a fixed 0).
-            sampling_seeds.append(resolve_row_seed(sp.sampling_seed))
+            # a fresh random seed when unseeded (not a fixed 0). Resolve once and
+            # cache onto sampling_params so an unseeded row reuses one random seed
+            # across its decode steps instead of re-minting via os.urandom each step.
+            seed = sp.sampling_seed
+            if seed is None or not (0 <= seed <= SAMPLING_SEED_MASK):
+                seed = resolve_row_seed(seed)
+                sp.sampling_seed = seed
+            sampling_seeds.append(seed)
 
             if penalty != 1.0 and req.output_ids:
                 unique = {

--- a/sglang_omni/models/qwen3_omni/components/talker.py
+++ b/sglang_omni/models/qwen3_omni/components/talker.py
@@ -25,7 +25,11 @@ from sglang_omni.models.qwen3_omni.hf_config import (
 from sglang_omni.models.qwen3_omni.quantization import (
     convert_fp8_weight_scale_inv_for_sglang,
 )
-from sglang_omni.sampling.seed import SAMPLING_SEED_MASK, resolve_row_seed
+from sglang_omni.sampling.seed import (
+    SAMPLING_SEED_MASK,
+    derive_sampling_seed,
+    resolve_row_seed,
+)
 from sglang_omni.vendor.sglang.core import ForwardBatch
 from sglang_omni.vendor.sglang.distributed import tensor_model_parallel_all_reduce
 from sglang_omni.vendor.sglang.layers import (
@@ -923,12 +927,12 @@ class Qwen3OmniTalker(nn.Module):
             top_ps.append(float(sp.top_p))
             top_ks.append(int(sp.top_k))
             min_ps.append(float(sp.min_p))
-            # Same seed scheme as the base runner / thinker: masked user seed, or
-            # a fresh random seed when unseeded (not a fixed 0). Resolve once and
-            # cache onto sampling_params so an unseeded row reuses one random seed
-            # across its decode steps instead of re-minting via os.urandom each step.
+            # Unseeded: rank-shared seed from the request id (same on every TP
+            # rank), not os.urandom, else the ranks desync.
             seed = sp.sampling_seed
-            if seed is None or not (0 <= seed <= SAMPLING_SEED_MASK):
+            if seed is None:
+                seed = derive_sampling_seed("sglang-omni-unseeded-row", req.rid)
+            elif not (0 <= seed <= SAMPLING_SEED_MASK):
                 seed = resolve_row_seed(seed)
                 sp.sampling_seed = seed
             sampling_seeds.append(seed)

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -958,6 +958,7 @@ def create_sglang_thinker_executor_from_config(
         "disable_cuda_graph": False,
         "enable_mixed_chunk": True,
         "chunked_prefill_size": 8192,
+        "sampling_backend": "pytorch",
     }
     if server_args_overrides:
         overrides.update(server_args_overrides)

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import hashlib
-import os
 import threading
 import time
 from dataclasses import dataclass, field
@@ -15,6 +14,11 @@ import torch
 from sglang_omni.models.qwen3_omni.pending_text_queue import PendingTextTensorQueue
 from sglang_omni.models.qwen3_tts.payload_types import Qwen3TTSState
 from sglang_omni.proto import StagePayload
+from sglang_omni.sampling.seed import (
+    SAMPLING_SEED_MASK,
+    derive_sampling_seed,
+    new_random_sampling_seed,
+)
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
 from sglang_omni.scheduling.speaker_cache import (
     SpeakerCacheKey,
@@ -49,11 +53,11 @@ _IMPLICIT_SAMPLING_DEFAULTS = {
     "repetition_penalty": {1.0, 1.1},
 }
 
-_QWEN3_TTS_SAMPLING_SEED_MASK = 0x7FFFFFFF
+_QWEN3_TTS_SAMPLING_SEED_MASK = SAMPLING_SEED_MASK
 
 
 def _new_qwen3_tts_sampling_seed() -> int:
-    return int.from_bytes(os.urandom(4), "little") & _QWEN3_TTS_SAMPLING_SEED_MASK
+    return new_random_sampling_seed()
 
 
 def _normalize_qwen3_tts_seed(seed: Any) -> int:
@@ -69,11 +73,7 @@ def _normalize_qwen3_tts_seed(seed: Any) -> int:
 
 
 def _derive_qwen3_tts_child_seed(seed: int, label: str) -> int:
-    digest = hashlib.blake2b(
-        f"qwen3-tts:{seed}:{label}".encode("utf-8"),
-        digest_size=8,
-    ).digest()
-    return int.from_bytes(digest, "little") & _QWEN3_TTS_SAMPLING_SEED_MASK
+    return derive_sampling_seed("qwen3-tts", seed, label)
 
 
 def derive_qwen3_tts_sampling_seeds(seed: int) -> tuple[int, int]:

--- a/sglang_omni/sampling/__init__.py
+++ b/sglang_omni/sampling/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/sglang_omni/sampling/seed.py
+++ b/sglang_omni/sampling/seed.py
@@ -9,6 +9,7 @@ size. These helpers produce the int32 per-row seeds the base runner installs ont
 
 from __future__ import annotations
 
+import hashlib
 import os
 
 # multinomial_with_seed requires a positive int32 seed.
@@ -18,6 +19,17 @@ SAMPLING_SEED_MASK = 0x7FFFFFFF
 def new_random_sampling_seed() -> int:
     """A fresh random positive-int32 seed (for rows the caller left unseeded)."""
     return int.from_bytes(os.urandom(4), "little") & SAMPLING_SEED_MASK
+
+
+def derive_sampling_seed(
+    namespace: str, public_seed: object, label: str | None = None
+) -> int:
+    """Derive a stable positive-int32 child seed from public request state."""
+    parts = [namespace, str(public_seed)]
+    if label is not None:
+        parts.append(label)
+    digest = hashlib.blake2b(":".join(parts).encode("utf-8"), digest_size=8).digest()
+    return int.from_bytes(digest, "little") & SAMPLING_SEED_MASK
 
 
 def resolve_row_seed(public_seed: int | None) -> int:
@@ -30,6 +42,7 @@ def resolve_row_seed(public_seed: int | None) -> int:
 
 __all__ = [
     "SAMPLING_SEED_MASK",
+    "derive_sampling_seed",
     "new_random_sampling_seed",
     "resolve_row_seed",
 ]

--- a/sglang_omni/sampling/seed.py
+++ b/sglang_omni/sampling/seed.py
@@ -3,13 +3,12 @@
 
 SGLang's ``multinomial_with_seed`` combines a per-row seed with a per-position
 value, so a row's draw depends only on its own seed -- reproducible at any batch
-size. These helpers derive the int32 per-row seeds the base runner installs onto
+size. These helpers produce the int32 per-row seeds the base runner installs onto
 ``forward_batch.sampling_info`` so a request ``seed`` is honored uniformly.
 """
 
 from __future__ import annotations
 
-import hashlib
 import os
 
 # multinomial_with_seed requires a positive int32 seed.
@@ -21,28 +20,16 @@ def new_random_sampling_seed() -> int:
     return int.from_bytes(os.urandom(4), "little") & SAMPLING_SEED_MASK
 
 
-def derive_sampling_seed(public_seed: int, namespace: str) -> int:
-    """Stable positive-int32 seed from a public ``seed``, namespaced per use site
-    so different stages of one request don't draw identically."""
-    digest = hashlib.blake2b(
-        f"{namespace}:{int(public_seed)}".encode("utf-8"), digest_size=8
-    ).digest()
-    return int.from_bytes(digest, "little") & SAMPLING_SEED_MASK
-
-
-def resolve_row_seed(public_seed: int | None, *, namespace: str | None = None) -> int:
-    """Per-row seed: derive (namespaced) or mask the user seed when given, else a
-    fresh random seed so unseeded rows stay random."""
+def resolve_row_seed(public_seed: int | None) -> int:
+    """Per-row seed: mask the user seed when given, else a fresh random seed so
+    unseeded rows stay random."""
     if public_seed is None:
         return new_random_sampling_seed()
-    if namespace is None:
-        return int(public_seed) & SAMPLING_SEED_MASK
-    return derive_sampling_seed(public_seed, namespace)
+    return int(public_seed) & SAMPLING_SEED_MASK
 
 
 __all__ = [
     "SAMPLING_SEED_MASK",
-    "derive_sampling_seed",
     "new_random_sampling_seed",
     "resolve_row_seed",
 ]

--- a/sglang_omni/sampling/seed.py
+++ b/sglang_omni/sampling/seed.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reusable per-request sampling-seed helpers shared across model runners.
+
+SGLang's ``multinomial_with_seed`` combines a per-row seed with a per-position
+value, so a row's draw depends only on its own seed -- reproducible at any batch
+size. These helpers derive the int32 per-row seeds the base runner installs onto
+``forward_batch.sampling_info`` so a request ``seed`` is honored uniformly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+
+# multinomial_with_seed requires a positive int32 seed.
+SAMPLING_SEED_MASK = 0x7FFFFFFF
+
+
+def new_random_sampling_seed() -> int:
+    """A fresh random positive-int32 seed (for rows the caller left unseeded)."""
+    return int.from_bytes(os.urandom(4), "little") & SAMPLING_SEED_MASK
+
+
+def derive_sampling_seed(public_seed: int, namespace: str) -> int:
+    """Stable positive-int32 seed from a public ``seed``, namespaced per use site
+    so different stages of one request don't draw identically."""
+    digest = hashlib.blake2b(
+        f"{namespace}:{int(public_seed)}".encode("utf-8"), digest_size=8
+    ).digest()
+    return int.from_bytes(digest, "little") & SAMPLING_SEED_MASK
+
+
+def resolve_row_seed(public_seed: int | None, *, namespace: str | None = None) -> int:
+    """Per-row seed: derive (namespaced) or mask the user seed when given, else a
+    fresh random seed so unseeded rows stay random."""
+    if public_seed is None:
+        return new_random_sampling_seed()
+    if namespace is None:
+        return int(public_seed) & SAMPLING_SEED_MASK
+    return derive_sampling_seed(public_seed, namespace)
+
+
+__all__ = [
+    "SAMPLING_SEED_MASK",
+    "derive_sampling_seed",
+    "new_random_sampling_seed",
+    "resolve_row_seed",
+]

--- a/tests/unit_test/fishaudio_s2_pro/test_tts.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_tts.py
@@ -472,11 +472,13 @@ def test_fish_s2pro_decode_codebooks_keeps_eos_out_of_audio_embedding(
     # exercises EOS handling, and all rows are unseeded, so stub it out.
     import sglang_omni.models.fishaudio_s2_pro.sglang_model as _m
 
-    monkeypatch.setattr(
-        _m,
-        "multinomial_with_seed",
-        lambda probs, seeds, pos: probs.argmax(-1, keepdim=True),
-    )
+    def _fake_multinomial_with_seed(logprobs, seeds, pos):
+        del seeds, pos
+        assert torch.all(logprobs <= 0)
+        assert torch.isneginf(logprobs).any()
+        return logprobs.argmax(-1, keepdim=True)
+
+    monkeypatch.setattr(_m, "multinomial_with_seed", _fake_multinomial_with_seed)
 
     class _AudioDecoder:
         def __init__(self) -> None:

--- a/tests/unit_test/fishaudio_s2_pro/test_tts.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_tts.py
@@ -6,6 +6,7 @@ import queue
 from collections import deque
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from sglang_omni.models.fishaudio_s2_pro.fish_scheduler import (
@@ -546,6 +547,81 @@ def test_fish_s2pro_decode_codebooks_keeps_eos_out_of_audio_embedding(
     assert int(model._output_semantic_ids[0].item()) == 30
     assert int(model._output_codes[0, 0].item()) == 30
     assert int(audio_decoder.seen_embedding_ids[0][0].item()) == 0
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="multinomial_with_seed needs CUDA"
+)
+def test_fish_s2pro_seeded_sampler_preserves_probability_distribution() -> None:
+    batch = 20_000
+    device = torch.device("cuda")
+    semantic_begin_id = 10
+    im_end_token_id = 39
+    vocab_size = 40
+
+    class _AudioDecoder:
+        def reset_caches(self) -> None:
+            pass
+
+        def project_in(self, hidden_states: torch.Tensor) -> torch.Tensor:
+            return hidden_states
+
+        def forward_kvcached(
+            self,
+            hidden_states: torch.Tensor,
+            *,
+            codebook_idx: int,
+        ) -> torch.Tensor:
+            del codebook_idx
+            return torch.zeros(
+                hidden_states.shape[0], 1, 8, device=hidden_states.device
+            )
+
+        def embeddings(self, ids: torch.Tensor) -> torch.Tensor:
+            return torch.zeros(ids.shape[0], 4, device=ids.device)
+
+    semantic_bias = torch.full((vocab_size,), -float("inf"), device=device)
+    semantic_bias[semantic_begin_id : semantic_begin_id + 2] = 0.0
+    semantic_bias[im_end_token_id] = 0.0
+    logits = torch.full((batch, vocab_size), -float("inf"), device=device)
+    logits[:, semantic_begin_id] = torch.log(torch.tensor(0.9, device=device))
+    logits[:, semantic_begin_id + 1] = torch.log(torch.tensor(0.1, device=device))
+
+    model = SimpleNamespace(
+        _semantic_bias=semantic_bias,
+        _prev_token_count=torch.zeros(batch, dtype=torch.long, device=device),
+        _ras_range=torch.arange(4, 0, -1, device=device),
+        _prev_tokens=torch.zeros(batch, 4, dtype=torch.long, device=device),
+        _ras_temperature=torch.ones(batch, device=device),
+        _sampling_temperature=torch.ones(batch, device=device),
+        _ras_top_p=torch.ones(batch, device=device),
+        _sampling_top_p=torch.ones(batch, device=device),
+        _sampling_rep_penalty=torch.ones(batch, device=device),
+        _sampling_seeds=torch.arange(1, batch + 1, dtype=torch.long, device=device),
+        _step_count=torch.zeros(batch, dtype=torch.long, device=device),
+        _rep_positions=torch.arange(4, device=device),
+        _graph_top_k=30,
+        _sampling_top_k=torch.full((batch,), 2, dtype=torch.long, device=device),
+        _top_k_positions=torch.arange(30, device=device),
+        _audio_decoder=_AudioDecoder(),
+        _semantic_begin_id=semantic_begin_id,
+        _im_end_token_id=im_end_token_id,
+        _codebook_size=8,
+        _num_codebooks=1,
+        _output_codes=torch.zeros(batch, 2, dtype=torch.long, device=device),
+        _output_semantic_ids=torch.zeros(batch, dtype=torch.long, device=device),
+    )
+
+    S2ProSGLangTextModel._decode_codebooks(
+        model,
+        logits,
+        torch.zeros(batch, 4, device=device),
+    )
+
+    token0_rate = (
+        (model._output_semantic_ids == semantic_begin_id).float().mean().item()
+    )
+    assert 0.87 < token0_rate < 0.93
 
 
 def test_fish_s2pro_terminal_im_end_is_not_audio_codebook_frame() -> None:

--- a/tests/unit_test/fishaudio_s2_pro/test_tts.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_tts.py
@@ -315,6 +315,8 @@ def test_fish_s2pro_before_decode_uses_gpu_history_buffer() -> None:
         _sampling_top_p=torch.zeros(1),
         _sampling_top_k=torch.zeros(1, dtype=torch.long),
         _sampling_rep_penalty=torch.zeros(1),
+        _sampling_seeds=torch.full((1,), -1, dtype=torch.long),
+        _step_count=torch.zeros(1, dtype=torch.long),
         _ras_temperature=torch.zeros(1),
         _ras_top_p=torch.zeros(1),
         _prev_tokens=torch.zeros(1, 4, dtype=torch.long),
@@ -383,6 +385,8 @@ def test_fish_s2pro_before_prefill_syncs_decode_state() -> None:
         _sampling_top_p=torch.zeros(2),
         _sampling_top_k=torch.zeros(2, dtype=torch.long),
         _sampling_rep_penalty=torch.zeros(2),
+        _sampling_seeds=torch.full((2,), -1, dtype=torch.long),
+        _step_count=torch.zeros(2, dtype=torch.long),
         _ras_temperature=torch.zeros(2),
         _ras_top_p=torch.zeros(2),
         _prev_tokens=torch.full((2, 4), 999, dtype=torch.long),
@@ -461,7 +465,19 @@ def test_fish_s2pro_setup_vq_decode_allocates_sampling_state() -> None:
     assert model._vq_ready
 
 
-def test_fish_s2pro_decode_codebooks_keeps_eos_out_of_audio_embedding() -> None:
+def test_fish_s2pro_decode_codebooks_keeps_eos_out_of_audio_embedding(
+    monkeypatch,
+) -> None:
+    # multinomial_with_seed is a GPU-only Triton kernel; this CPU test only
+    # exercises EOS handling, and all rows are unseeded, so stub it out.
+    import sglang_omni.models.fishaudio_s2_pro.sglang_model as _m
+
+    monkeypatch.setattr(
+        _m,
+        "multinomial_with_seed",
+        lambda probs, seeds, pos: probs.argmax(-1, keepdim=True),
+    )
+
     class _AudioDecoder:
         def __init__(self) -> None:
             self.seen_embedding_ids: list[torch.Tensor] = []
@@ -497,6 +513,8 @@ def test_fish_s2pro_decode_codebooks_keeps_eos_out_of_audio_embedding() -> None:
         _ras_top_p=torch.ones(1),
         _sampling_top_p=torch.ones(1),
         _sampling_rep_penalty=torch.ones(1),
+        _sampling_seeds=torch.full((1,), -1, dtype=torch.long),
+        _step_count=torch.zeros(1, dtype=torch.long),
         _rep_positions=torch.arange(4),
         _graph_top_k=30,
         _sampling_top_k=torch.full((1,), 30, dtype=torch.long),

--- a/tests/unit_test/fishaudio_s2_pro/test_tts.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_tts.py
@@ -470,15 +470,18 @@ def test_fish_s2pro_decode_codebooks_keeps_eos_out_of_audio_embedding(
 ) -> None:
     # multinomial_with_seed is a GPU-only Triton kernel; this CPU test only
     # exercises EOS handling, and all rows are unseeded, so stub it out.
-    import sglang_omni.models.fishaudio_s2_pro.sglang_model as _m
-
     def _fake_multinomial_with_seed(logprobs, seeds, pos):
         del seeds, pos
         assert torch.all(logprobs <= 0)
         assert torch.isneginf(logprobs).any()
         return logprobs.argmax(-1, keepdim=True)
 
-    monkeypatch.setattr(_m, "multinomial_with_seed", _fake_multinomial_with_seed)
+    decode_codebooks = S2ProSGLangTextModel._decode_codebooks.__wrapped__
+    monkeypatch.setitem(
+        decode_codebooks.__globals__,
+        "multinomial_with_seed",
+        _fake_multinomial_with_seed,
+    )
 
     class _AudioDecoder:
         def __init__(self) -> None:

--- a/tests/unit_test/higgs_tts/test_async_decode_runner.py
+++ b/tests/unit_test/higgs_tts/test_async_decode_runner.py
@@ -64,6 +64,7 @@ def _build_runner(
         _cg_active_eoc_countdown=torch.zeros(n, dtype=torch.int32),
         _cg_active_generation_done=torch.tensor(active_generation_done),
         _cg_active_last_codes=torch.zeros((n, n_codebooks), dtype=torch.long),
+        _cg_active_step_count=torch.zeros(n, dtype=torch.long),
         _cg_was_done=torch.tensor(was_done),
         _cg_codes_BN=torch.tensor(codes_BN),
         _cg_collect_staging=torch.zeros((n, n_codebooks + 2), dtype=torch.long),
@@ -72,6 +73,7 @@ def _build_runner(
             eoc_countdown=torch.zeros(n, dtype=torch.int32),
             generation_done=torch.zeros(n, dtype=torch.bool),
             last_codes=torch.zeros((n, n_codebooks), dtype=torch.long),
+            step_count=torch.zeros(n, dtype=torch.long),
         ),
     )
     reqs = [
@@ -290,6 +292,7 @@ def test_async_real_pinned_path_matches_sync():
                 [False, True, False, True], device=dev
             ),
             _cg_active_last_codes=torch.zeros((n, 3), dtype=torch.long, device=dev),
+            _cg_active_step_count=torch.zeros(n, dtype=torch.long, device=dev),
             _cg_was_done=torch.tensor([False, True, False, False], device=dev),
             _cg_codes_BN=torch.tensor(
                 [[1, 1, 1], [7, 8, 9], [20, 1, 2], [EOC_ID, 3, 4]], device=dev
@@ -300,6 +303,7 @@ def test_async_real_pinned_path_matches_sync():
                 eoc_countdown=torch.zeros(n, dtype=torch.int32, device=dev),
                 generation_done=torch.zeros(n, dtype=torch.bool, device=dev),
                 last_codes=torch.zeros((n, 3), dtype=torch.long, device=dev),
+                step_count=torch.zeros(n, dtype=torch.long, device=dev),
             ),
         )
         reqs = [

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -565,6 +565,7 @@ def test_higgs_model_runner_marks_sampler_finish_cg() -> None:
         _cg_active_eoc_countdown=torch.tensor([0], dtype=torch.int32),
         _cg_active_generation_done=torch.tensor([True]),
         _cg_active_last_codes=torch.tensor([[1, 2, 3]]),
+        _cg_active_step_count=torch.zeros(1, dtype=torch.long),
         _cg_was_done=torch.tensor([False]),
         _cg_codes_BN=torch.tensor([[EOC_ID, 1, 2]]),
         _cg_collect_staging=torch.zeros((1, 3 + 2), dtype=torch.long),
@@ -573,6 +574,7 @@ def test_higgs_model_runner_marks_sampler_finish_cg() -> None:
             eoc_countdown=torch.zeros(1, dtype=torch.int32),
             generation_done=torch.zeros(1, dtype=torch.bool),
             last_codes=torch.zeros((1, 3), dtype=torch.long),
+            step_count=torch.zeros(1, dtype=torch.long),
         ),
     )
     req = SimpleNamespace(is_chunked=0, finished_reason=None, finished=lambda: False)
@@ -609,6 +611,7 @@ def test_higgs_model_runner_collect_cg_mixed_batch() -> None:
         # row1's True must NOT leak into the was-done (skipped) request.
         _cg_active_generation_done=torch.tensor([False, True, False, True]),
         _cg_active_last_codes=torch.zeros((n, k), dtype=torch.long),
+        _cg_active_step_count=torch.zeros(n, dtype=torch.long),
         _cg_was_done=torch.tensor([False, True, False, False]),
         _cg_codes_BN=torch.tensor([[1, 1, 1], [7, 8, 9], [20, 1, 2], [EOC_ID, 3, 4]]),
         _cg_collect_staging=torch.zeros((n, k + 2), dtype=torch.long),
@@ -616,6 +619,7 @@ def test_higgs_model_runner_collect_cg_mixed_batch() -> None:
             delay_count=torch.zeros(n, dtype=torch.int32),
             eoc_countdown=torch.zeros(n, dtype=torch.int32),
             generation_done=torch.zeros(n, dtype=torch.bool),
+            step_count=torch.zeros(n, dtype=torch.long),
             last_codes=torch.zeros((n, k), dtype=torch.long),
         ),
     )

--- a/tests/unit_test/higgs_tts/test_seeded_sampling.py
+++ b/tests/unit_test/higgs_tts/test_seeded_sampling.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Seeded reproducibility of the Higgs batched sampler.
+
+``multinomial_with_seed`` uses a Triton kernel, so these run on CUDA only.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sglang_omni.models.higgs_tts.sampler import _sample_independent_batched
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="multinomial_with_seed needs CUDA"
+)
+
+B, N, V = 3, 8, 64
+
+
+def _logits(seed):
+    g = torch.Generator(device="cuda").manual_seed(seed)
+    return torch.randn(B, N, V, generator=g, device="cuda")
+
+
+def _draw(logits, seeds_B, step):
+    return _sample_independent_batched(
+        logits,
+        temperature=torch.ones(B, device="cuda"),
+        top_p=None,
+        seeds_B=torch.tensor(seeds_B, device="cuda"),
+        step_B=torch.full((B,), step, dtype=torch.long, device="cuda"),
+    )
+
+
+def test_same_seed_same_step_is_reproducible():
+    logits = _logits(0)
+    assert torch.equal(_draw(logits, [123] * B, 4), _draw(logits, [123] * B, 4))
+
+
+def test_different_seed_differs():
+    logits = _logits(1)
+    assert not torch.equal(_draw(logits, [1] * B, 4), _draw(logits, [2] * B, 4))
+
+
+def test_position_decorrelates_steps():
+    logits = _logits(2)
+    assert not torch.equal(_draw(logits, [9] * B, 0), _draw(logits, [9] * B, 1))
+
+
+def test_per_row_seed_isolation():
+    """A row's draw depends only on its own seed, not its batch neighbours."""
+    logits = _logits(4)
+    full = _draw(logits, [55, 77, 99], step=3)
+    alone = _sample_independent_batched(
+        logits[:1],
+        temperature=torch.ones(1, device="cuda"),
+        top_p=None,
+        seeds_B=torch.tensor([55], device="cuda"),
+        step_B=torch.full((1,), 3, dtype=torch.long, device="cuda"),
+    )
+    assert torch.equal(alone[0], full[0])

--- a/tests/unit_test/higgs_tts/test_seeded_sampling.py
+++ b/tests/unit_test/higgs_tts/test_seeded_sampling.py
@@ -60,3 +60,18 @@ def test_per_row_seed_isolation():
         step_B=torch.full((1,), 3, dtype=torch.long, device="cuda"),
     )
     assert torch.equal(alone[0], full[0])
+
+
+def test_seeded_sampler_preserves_probability_distribution():
+    batch = 20_000
+    probs = torch.tensor([0.9, 0.1], device="cuda")
+    logits = probs.log().view(1, 1, 2).expand(batch, 1, 2).contiguous()
+    sampled = _sample_independent_batched(
+        logits,
+        temperature=torch.ones(batch, device="cuda"),
+        top_p=None,
+        seeds_B=torch.arange(1, batch + 1, device="cuda"),
+        step_B=torch.zeros(batch, dtype=torch.long, device="cuda"),
+    )
+    token0_rate = (sampled[:, 0] == 0).float().mean().item()
+    assert 0.87 < token0_rate < 0.93

--- a/tests/unit_test/ming_omni/test_pipeline.py
+++ b/tests/unit_test/ming_omni/test_pipeline.py
@@ -588,6 +588,7 @@ def test_ming_thinker_factory_registers_hf_config_before_server_args(
 
     assert call_order == ["register", "build_server_args", "create_scheduler"]
     assert captured_server_args_kwargs["trust_remote_code"] is False
+    assert captured_server_args_kwargs["sampling_backend"] == "pytorch"
 
 
 def test_ming_arch_override_uses_composite_llm_config() -> None:

--- a/tests/unit_test/model_runner/test_install_sampling_seeds.py
+++ b/tests/unit_test/model_runner/test_install_sampling_seeds.py
@@ -9,12 +9,14 @@ import pytest
 import torch
 
 from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.sampling.seed import derive_sampling_seed
 
 
-def _req(seed):
+def _req(seed, request_id="req"):
     sp = SimpleNamespace(sampling_seed=seed)
     return SimpleNamespace(
-        data=SimpleNamespace(req=SimpleNamespace(sampling_params=sp))
+        request_id=request_id,
+        data=SimpleNamespace(req=SimpleNamespace(sampling_params=sp)),
     )
 
 
@@ -32,12 +34,16 @@ def _fb(sampling_seed=None, *, top_p=False, top_k=False, min_p=False):
 
 def test_installs_per_row_seeds_and_noops_without_one():
     runner = object.__new__(ModelRunner)
-    # seeded rows -> per-row int64 seed tensor; unseeded row stays in range
+    # seeded rows -> per-row int64 seed tensor; mixed unseeded rows get a
+    # rank-shared fallback derived from the request id.
     fb = _fb()
-    runner._install_sampling_seeds(fb, [_req(42), _req(None)])
+    requests = [_req(42, "seeded"), _req(None, "unseeded")]
+    runner._install_sampling_seeds(fb, requests)
     ss = fb.sampling_info.sampling_seed
     assert isinstance(ss, torch.Tensor) and ss.dtype == torch.long
     assert int(ss[0]) == 42 and ss.shape == (2,)
+    assert int(ss[1]) == derive_sampling_seed("sglang-omni-unseeded-row", "unseeded")
+    assert requests[1].data.req.sampling_params.sampling_seed is None
     # no seed anywhere -> left unseeded (preserves random sampling)
     fb2 = _fb()
     runner._install_sampling_seeds(fb2, [_req(None), _req(None)])
@@ -52,16 +58,18 @@ def test_does_not_clobber_subclass_installed_seed():
     assert fb.sampling_info.sampling_seed is preset
 
 
-def test_unseeded_row_seed_is_resolved_once_and_cached():
-    """An unseeded row in a seeded batch mints ONE random seed (cached on
-    sampling_params), reused across decode steps — no per-step os.urandom."""
+def test_unseeded_row_in_seeded_batch_uses_rank_shared_fallback():
     runner = object.__new__(ModelRunner)
-    requests = [_req(42), _req(None)]
-    runner._install_sampling_seeds(_fb(), requests)
-    cached = requests[1].data.req.sampling_params.sampling_seed
-    assert cached is not None  # minted + cached back
-    runner._install_sampling_seeds(_fb(), requests)  # next step
-    assert requests[1].data.req.sampling_params.sampling_seed == cached  # reused
+    requests = [_req(42, "seeded"), _req(None, "unseeded")]
+    fb = _fb()
+    runner._install_sampling_seeds(fb, requests)
+    fallback = int(fb.sampling_info.sampling_seed[1])
+    assert requests[1].data.req.sampling_params.sampling_seed is None
+
+    fb_next = _fb()
+    runner._install_sampling_seeds(fb_next, requests)
+    assert int(fb_next.sampling_info.sampling_seed[1]) == fallback
+    assert requests[1].data.req.sampling_params.sampling_seed is None
 
 
 def test_rejects_seeded_min_p_before_upstream_sampler():

--- a/tests/unit_test/model_runner/test_install_sampling_seeds.py
+++ b/tests/unit_test/model_runner/test_install_sampling_seeds.py
@@ -43,3 +43,15 @@ def test_does_not_clobber_subclass_installed_seed():
     fb = _fb(sampling_seed=preset)
     runner._install_sampling_seeds(fb, [_req(42), _req(42), _req(42)])
     assert fb.sampling_info.sampling_seed is preset
+
+
+def test_unseeded_row_seed_is_resolved_once_and_cached():
+    """An unseeded row in a seeded batch mints ONE random seed (cached on
+    sampling_params), reused across decode steps — no per-step os.urandom."""
+    runner = object.__new__(ModelRunner)
+    requests = [_req(42), _req(None)]
+    runner._install_sampling_seeds(_fb(), requests)
+    cached = requests[1].data.req.sampling_params.sampling_seed
+    assert cached is not None  # minted + cached back
+    runner._install_sampling_seeds(_fb(), requests)  # next step
+    assert requests[1].data.req.sampling_params.sampling_seed == cached  # reused

--- a/tests/unit_test/model_runner/test_install_sampling_seeds.py
+++ b/tests/unit_test/model_runner/test_install_sampling_seeds.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Base-runner _install_sampling_seeds: wire a request seed to the sampler."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from sglang_omni.model_runner.base import ModelRunner
+
+
+def _req(seed):
+    sp = SimpleNamespace(sampling_seed=seed)
+    return SimpleNamespace(
+        data=SimpleNamespace(req=SimpleNamespace(sampling_params=sp))
+    )
+
+
+def _fb(sampling_seed=None):
+    return SimpleNamespace(
+        sampling_info=SimpleNamespace(device="cpu", sampling_seed=sampling_seed)
+    )
+
+
+def test_installs_per_row_seeds_and_noops_without_one():
+    runner = object.__new__(ModelRunner)
+    # seeded rows -> per-row int64 seed tensor; unseeded row stays in range
+    fb = _fb()
+    runner._install_sampling_seeds(fb, [_req(42), _req(None)])
+    ss = fb.sampling_info.sampling_seed
+    assert isinstance(ss, torch.Tensor) and ss.dtype == torch.long
+    assert int(ss[0]) == 42 and ss.shape == (2,)
+    # no seed anywhere -> left unseeded (preserves random sampling)
+    fb2 = _fb()
+    runner._install_sampling_seeds(fb2, [_req(None), _req(None)])
+    assert fb2.sampling_info.sampling_seed is None
+
+
+def test_does_not_clobber_subclass_installed_seed():
+    runner = object.__new__(ModelRunner)
+    preset = torch.tensor([1, 2, 3])
+    fb = _fb(sampling_seed=preset)
+    runner._install_sampling_seeds(fb, [_req(42), _req(42), _req(42)])
+    assert fb.sampling_info.sampling_seed is preset

--- a/tests/unit_test/model_runner/test_install_sampling_seeds.py
+++ b/tests/unit_test/model_runner/test_install_sampling_seeds.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from sglang_omni.model_runner.base import ModelRunner
@@ -17,9 +18,15 @@ def _req(seed):
     )
 
 
-def _fb(sampling_seed=None):
+def _fb(sampling_seed=None, *, top_p=False, top_k=False, min_p=False):
     return SimpleNamespace(
-        sampling_info=SimpleNamespace(device="cpu", sampling_seed=sampling_seed)
+        sampling_info=SimpleNamespace(
+            device="cpu",
+            sampling_seed=sampling_seed,
+            need_top_p_sampling=top_p,
+            need_top_k_sampling=top_k,
+            need_min_p_sampling=min_p,
+        )
     )
 
 
@@ -55,3 +62,30 @@ def test_unseeded_row_seed_is_resolved_once_and_cached():
     assert cached is not None  # minted + cached back
     runner._install_sampling_seeds(_fb(), requests)  # next step
     assert requests[1].data.req.sampling_params.sampling_seed == cached  # reused
+
+
+def test_rejects_seeded_min_p_before_upstream_sampler():
+    runner = object.__new__(ModelRunner)
+    with pytest.raises(ValueError, match="min_p"):
+        runner._install_sampling_seeds(_fb(min_p=True), [_req(42)])
+
+
+def test_rejects_seeded_flashinfer_top_p_before_upstream_sampler(monkeypatch):
+    monkeypatch.setattr(
+        "sglang_omni.model_runner.base._current_sglang_sampling_backend",
+        lambda: "flashinfer",
+    )
+    runner = object.__new__(ModelRunner)
+    with pytest.raises(ValueError, match="flashinfer"):
+        runner._install_sampling_seeds(_fb(top_p=True), [_req(42)])
+
+
+def test_allows_seeded_pytorch_top_p(monkeypatch):
+    monkeypatch.setattr(
+        "sglang_omni.model_runner.base._current_sglang_sampling_backend",
+        lambda: "pytorch",
+    )
+    runner = object.__new__(ModelRunner)
+    fb = _fb(top_p=True)
+    runner._install_sampling_seeds(fb, [_req(42)])
+    assert int(fb.sampling_info.sampling_seed[0]) == 42

--- a/tests/unit_test/model_runner/test_install_sampling_seeds.py
+++ b/tests/unit_test/model_runner/test_install_sampling_seeds.py
@@ -58,6 +58,14 @@ def test_does_not_clobber_subclass_installed_seed():
     assert fb.sampling_info.sampling_seed is preset
 
 
+def test_preinstalled_seed_allows_missing_sampling_mode_flags():
+    runner = object.__new__(ModelRunner)
+    preset = torch.tensor([1, 2])
+    fb = SimpleNamespace(sampling_info=SimpleNamespace(sampling_seed=preset))
+    runner._install_sampling_seeds(fb, [_req(42), _req(42)])
+    assert fb.sampling_info.sampling_seed is preset
+
+
 def test_unseeded_row_in_seeded_batch_uses_rank_shared_fallback():
     runner = object.__new__(ModelRunner)
     requests = [_req(42, "seeded"), _req(None, "unseeded")]

--- a/tests/unit_test/model_runner/test_rollout_logprobs.py
+++ b/tests/unit_test/model_runner/test_rollout_logprobs.py
@@ -143,9 +143,12 @@ def test_sample_next_token_ids_requires_sampler_logprobs_when_requested() -> Non
             sample=lambda _logits_output, _forward_batch: torch.tensor([44])
         )
     )
-    data = SimpleNamespace(return_logprob=True, output_token_logprobs=[])
+    req = SimpleNamespace(sampling_params=SimpleNamespace(sampling_seed=None))
+    data = SimpleNamespace(return_logprob=True, output_token_logprobs=[], req=req)
     request = SimpleNamespace(data=data)
-    forward_batch = SimpleNamespace()
+    forward_batch = SimpleNamespace(
+        sampling_info=SimpleNamespace(device="cpu", sampling_seed=None)
+    )
     logits_output = SimpleNamespace()
 
     with pytest.raises(RuntimeError, match="next_token_logprobs"):

--- a/tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
+++ b/tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
@@ -34,12 +34,17 @@ def _patch_thinker_startup(monkeypatch) -> list[dict[str, object]]:
     def _fake_server_args_builder(model_path, context_length, **overrides):
         assert model_path == "dummy"
         assert context_length == 8192
-        return SimpleNamespace(mem_fraction_static=overrides["mem_fraction_static"])
+        assert overrides["sampling_backend"] == "pytorch"
+        return SimpleNamespace(
+            mem_fraction_static=overrides["mem_fraction_static"],
+            sampling_backend=overrides["sampling_backend"],
+        )
 
     def _fake_create_thinker_scheduler(server_args, gpu_id, **kwargs):
         scheduler_calls.append(
             {
                 "mem_fraction_static": server_args.mem_fraction_static,
+                "sampling_backend": server_args.sampling_backend,
                 "gpu_id": gpu_id,
                 "total_gpu_memory_fraction": kwargs["total_gpu_memory_fraction"],
             }
@@ -202,6 +207,7 @@ def test_qwen_colocated_thinker_startup_threads_effective_budget(
     assert scheduler_calls == [
         {
             "mem_fraction_static": 0.70,
+            "sampling_backend": "pytorch",
             "gpu_id": 0,
             "total_gpu_memory_fraction": 0.70,
         }
@@ -227,6 +233,7 @@ def test_qwen_colocated_thinker_explicit_mem_fraction_skips_default_reserve(
     assert scheduler_calls == [
         {
             "mem_fraction_static": 0.75,
+            "sampling_backend": "pytorch",
             "gpu_id": 0,
             "total_gpu_memory_fraction": 0.75,
         }

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -1780,3 +1780,62 @@ def test_build_talker_request_wall_clock(seq_len: int) -> None:
     mean_ms = (time.perf_counter() - t0) / 20 * 1000
 
     print(f"\n[seq_len={seq_len}] mean={mean_ms:.2f}ms  floats={seq_len * 2048:,}")
+
+
+def _talker_seed_self(max_bs: int = 4, vocab: int = 8) -> SimpleNamespace:
+    """Minimal stand-in carrying only the buffers prepare_decode_buffers writes."""
+    return SimpleNamespace(
+        _repetition_mask=torch.zeros(max_bs, vocab, dtype=torch.bool),
+        _suppress_mask=torch.zeros(max_bs, vocab, dtype=torch.bool),
+        _repetition_penalties=torch.ones(max_bs, 1),
+        _sampling_temperatures=torch.ones(max_bs, 1),
+        _sampling_top_ps=torch.ones(max_bs),
+        _sampling_top_ks=torch.ones(max_bs, dtype=torch.long),
+        _sampling_min_ps=torch.zeros(max_bs),
+        _sampling_seeds=torch.zeros(max_bs, dtype=torch.long),
+    )
+
+
+def _talker_seed_req(seed: int | None, rid: str) -> SimpleNamespace:
+    sp = SimpleNamespace(
+        repetition_penalty=1.0,  # keep rep/suppress branches off
+        temperature=0.8,
+        top_p=0.9,
+        top_k=20,
+        min_p=0.0,
+        sampling_seed=seed,
+    )
+    req = SimpleNamespace(
+        sampling_params=sp, output_ids=[], _codec_suppress_tokens=None, rid=rid
+    )
+    return SimpleNamespace(data=SimpleNamespace(req=req, suppress_tokens=None))
+
+
+def test_talker_prepare_decode_buffers_unseeded_seed_is_rank_shared() -> None:
+    # Unseeded rows must get a rank-shared (request-id-derived) seed, not
+    # os.urandom, or TP ranks desync.
+    from sglang_omni.sampling.seed import SAMPLING_SEED_MASK, derive_sampling_seed
+
+    fake = _talker_seed_self()
+    seeded = _talker_seed_req(123, "seeded")
+    unseeded = _talker_seed_req(None, "unseeded")
+    out_of_range = _talker_seed_req(0xFFFFFFFF, "oor")
+    requests = [seeded, unseeded, out_of_range]
+
+    Qwen3OmniTalker.prepare_decode_buffers(fake, requests)
+    seeds = fake._sampling_seeds
+
+    assert int(seeds[0]) == 123
+    assert seeded.data.req.sampling_params.sampling_seed == 123
+    assert int(seeds[1]) == derive_sampling_seed("sglang-omni-unseeded-row", "unseeded")
+    assert unseeded.data.req.sampling_params.sampling_seed is None  # not cached
+    assert int(seeds[2]) == (0xFFFFFFFF & SAMPLING_SEED_MASK)
+    assert out_of_range.data.req.sampling_params.sampling_seed == (
+        0xFFFFFFFF & SAMPLING_SEED_MASK
+    )
+
+    # stable across decode steps
+    Qwen3OmniTalker.prepare_decode_buffers(fake, requests)
+    assert int(fake._sampling_seeds[1]) == derive_sampling_seed(
+        "sglang-omni-unseeded-row", "unseeded"
+    )

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -28,6 +28,7 @@ from sglang_omni.models.qwen3_tts.request_builders import (
 )
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.sampling import seed as sampling_seed
 from sglang_omni.scheduling.messages import IncomingMessage
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler
 from sglang_omni.scheduling.speaker_cache import (
@@ -1005,7 +1006,7 @@ def test_qwen3_tts_request_data_uses_private_sampling_seeds(
     install_fake_sglang(monkeypatch)
     urandom_values = iter([b"\x39\x30\x00\x00", b"\x32\x09\x01\x00"])
     monkeypatch.setattr(
-        qwen3_request_builders.os,
+        sampling_seed.os,
         "urandom",
         lambda size: next(urandom_values) if size == 4 else b"\x00" * size,
     )

--- a/tests/unit_test/sampling/__init__.py
+++ b/tests/unit_test/sampling/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/unit_test/sampling/test_seed.py
+++ b/tests/unit_test/sampling/test_seed.py
@@ -5,22 +5,19 @@ from __future__ import annotations
 
 from sglang_omni.sampling.seed import (
     SAMPLING_SEED_MASK,
-    derive_sampling_seed,
+    new_random_sampling_seed,
     resolve_row_seed,
 )
 
 
-def test_derive_is_deterministic_namespaced_and_in_int32_range():
-    assert derive_sampling_seed(1234, "higgs") == derive_sampling_seed(1234, "higgs")
-    assert derive_sampling_seed(1234, "a") != derive_sampling_seed(1234, "b")
-    assert 0 <= derive_sampling_seed(1234, "higgs") <= SAMPLING_SEED_MASK
+def test_new_random_sampling_seed_in_int32_range():
+    assert 0 <= new_random_sampling_seed() <= SAMPLING_SEED_MASK
 
 
 def test_resolve_row_seed_modes():
-    # no namespace -> raw seed masked to positive int32
+    # in-range seed is used as-is
     assert resolve_row_seed(42) == 42
+    # out-of-range seed is masked to positive int32
     assert resolve_row_seed(0xFFFFFFFF) == (0xFFFFFFFF & SAMPLING_SEED_MASK)
-    # namespace -> derived
-    assert resolve_row_seed(42, namespace="higgs") == derive_sampling_seed(42, "higgs")
     # None -> a fresh in-range seed
     assert 0 <= resolve_row_seed(None) <= SAMPLING_SEED_MASK

--- a/tests/unit_test/sampling/test_seed.py
+++ b/tests/unit_test/sampling/test_seed.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from sglang_omni.sampling.seed import (
     SAMPLING_SEED_MASK,
+    derive_sampling_seed,
     new_random_sampling_seed,
     resolve_row_seed,
 )
@@ -21,3 +22,11 @@ def test_resolve_row_seed_modes():
     assert resolve_row_seed(0xFFFFFFFF) == (0xFFFFFFFF & SAMPLING_SEED_MASK)
     # None -> a fresh in-range seed
     assert 0 <= resolve_row_seed(None) <= SAMPLING_SEED_MASK
+
+
+def test_derive_sampling_seed_is_stable_and_namespaced():
+    first = derive_sampling_seed("qwen3-tts", 123456, "semantic")
+    assert first == 709979716
+    assert derive_sampling_seed("qwen3-tts", 123456, "semantic") == first
+    assert derive_sampling_seed("qwen3-tts", 123456, "subtalker") != first
+    assert derive_sampling_seed("moss-tts", 123456) != first

--- a/tests/unit_test/sampling/test_seed.py
+++ b/tests/unit_test/sampling/test_seed.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the shared sampling-seed helpers."""
+
+from __future__ import annotations
+
+from sglang_omni.sampling.seed import (
+    SAMPLING_SEED_MASK,
+    derive_sampling_seed,
+    resolve_row_seed,
+)
+
+
+def test_derive_is_deterministic_namespaced_and_in_int32_range():
+    assert derive_sampling_seed(1234, "higgs") == derive_sampling_seed(1234, "higgs")
+    assert derive_sampling_seed(1234, "a") != derive_sampling_seed(1234, "b")
+    assert 0 <= derive_sampling_seed(1234, "higgs") <= SAMPLING_SEED_MASK
+
+
+def test_resolve_row_seed_modes():
+    # no namespace -> raw seed masked to positive int32
+    assert resolve_row_seed(42) == 42
+    assert resolve_row_seed(0xFFFFFFFF) == (0xFFFFFFFF & SAMPLING_SEED_MASK)
+    # namespace -> derived
+    assert resolve_row_seed(42, namespace="higgs") == derive_sampling_seed(42, "higgs")
+    # None -> a fresh in-range seed
+    assert 0 <= resolve_row_seed(None) <= SAMPLING_SEED_MASK


### PR DESCRIPTION

## Summary

Deterministic, seed-controlled sampling is a prerequisite for reproducible
rollouts (e.g. RL: replaying a trajectory, group sampling with one seed per
sample, train/rollout logprob equivalence). Today seed handling in SGLang-Omni
is fragmented — a few models hand-roll it, the standard text path silently drops
the seed, and the discrete-TTS custom samplers ignore it entirely.

This PR makes a request `seed` **honored uniformly across every AR sampling
model**:

1. A reusable seed hook in the **base `ModelRunner`** so the standard SGLang
   sampler path honors `seed` without each model re-implementing it.
2. Per-model wiring of the **custom discrete-TTS samplers** (Higgs, Fish S2-Pro)
   that previously sampled with bare `torch.multinomial`.
3. Unifying the **Qwen3-Omni talker** onto the same seed scheme so both stages of
   the omni pipeline seed consistently.

It is a strict no-op when no request in the batch supplies a seed (normal
serving unchanged). If a standard-SGLang batch mixes seeded and unseeded rows,
the unseeded rows receive a request-id-derived fallback seed so TP ranks stay in
sync instead of minting rank-local random fallback seeds. This adds no
measurable throughput cost.

## Scope — which models honor `seed` after this PR

| Path | Models | Status |
|---|---|---|
| **Standard SGLang sampler** (via new `base._install_sampling_seeds`) | Qwen3-Omni thinker, Ming-Omni thinker, LLaDA2-Uni, Voxtral text-LM | **Fixed** — seed reached `SamplingParams` but was dropped by SGLang's `enable_deterministic_inference` gate; the base hook installs it onto `sampling_info` directly |
| **Custom discrete sampler** (wired here) | **Higgs TTS**, **Fish S2-Pro** | **Fixed** — now use `multinomial_with_seed` |
| **Custom sampler unified onto the shared scheme** | **Qwen3-Omni talker** | **Fixed** — was seed-aware but used `int(seed) else 0` (unseeded → fixed 0); now uses the shared `resolve_row_seed` (masked seed, or random when unseeded) |
| Already honored (hand-rolled; untouched) | MOSS-TTS, MOSS-TTS-Local, Qwen3-TTS | unchanged (base hook skips rows a subclass already seeded) |
| Out of scope (continuous / flow-matching) | Voxtral acoustic, Ming-Omni talker | N/A — no discrete-token seed |

→ Net: a full **Qwen3-Omni** omni rollout (thinker text + talker audio) is now
end-to-end reproducible with a seed — it was not before (the thinker dropped it).

## Design

- **`sglang_omni/sampling/seed.py`** — shared helpers: derive stable
  positive-int32 seeds (namespaced), plus fresh random seeds for model-owned
  unseeded rows.
- **`ModelRunner._install_sampling_seeds`** — called once in
  `_sample_next_token_ids` before sampling; builds per-row seeds from each
  request's `sampling_params.sampling_seed` and installs them on
  `forward_batch.sampling_info.sampling_seed`, so SGLang routes to
  `multinomial_with_seed`. No-op when no row carries a seed; in a mixed
  seeded/unseeded batch, unseeded rows get a request-id-derived fallback seed so
  TP ranks agree on the fallback. Skips when a subclass already installed its
  own. Strict field access (no defensive `getattr`) — a missing contract field
  fails loud.
- **Higgs / Fish** — each seeds its draw with
  `multinomial_with_seed(probs, per_request_seed, position)` where `position`
  encodes the AR step (and codebook, for Higgs’ `step·N + codebook`), making
  draws **batch-composition independent**. A `-1` sentinel keeps the exact legacy
  `torch.multinomial` path for unseeded rows, so unseeded decode is byte-identical
  to before; greedy/argmax is untouched.
- **Qwen3-Omni talker** — keeps its own static `SamplingBatchInfo` (needed for
  CUDA-graph capture); only the seed *values* change, now from `resolve_row_seed`.

## Validation (on-GPU, end-to-end)

Baseline `main` @ `df62e91` vs branch `seed-framework-support` (HEAD `3ba583a`).
Each server launched from its own checkout; audio compared by sha256 of response
bytes, text by content hash.

### A. No-op / no regression when unseeded

**Higgs TTS** — greedy (`temperature=0`), `/v1/audio/speech`:

| Prompt | main | branch | match |
|---|---|---|---|
| Hello, how are you today? | ac8cbe76f87f093f | ac8cbe76f87f093f | ✅ |
| The quick brown fox… | 97e4aa746c93c785 | 97e4aa746c93c785 | ✅ |
| Reinforcement learning… | ec6868db8279e653 | ec6868db8279e653 | ✅ |
| She sells sea shells… | 8b60bb0b3c1397f3 | 8b60bb0b3c1397f3 | ✅ |
| Numbers like one two three… | feb72edc899a5a87 | feb72edc899a5a87 | ✅ |

→ byte-identical main vs branch (re-confirmed on full branch: `f92061d824eaad1f`
on both). **Qwen3-Omni thinker** greedy, no seed: main == branch == `ff8fa6bef2c3`.

**Throughput** (no regression):

| Model | main (req/s) | branch (req/s) | Δ |
|---|---:|---:|---|
| Higgs (N=32, conc=4, temp=0) | 4.07 | 4.25 | +4.4% (noise) |
| Qwen3-Omni thinker (warmup + N=48×2, conc=4) | 14.2 | 14.29 | ~0% |

### B. `seed` is honored (the fix), `temperature>0`

Same request twice with the same seed must be reproducible on the branch; a
different seed must give a different (but itself reproducible) result; unseeded
stays random.

**Qwen3-Omni-30B full pipeline (thinker text + talker audio)** — FP8,
disaggregated (thinker GPU0 / talker+code2wav GPU1), `/v1/chat/completions`
`modalities:["text","audio"]`, temp=0.8:

| | seed=1234 ×2 | seed=5678 | no seed ×2 |
|---|---|---|---|
| main (`df62e91`) | `a40e1ffb…` vs `ad6fcc02…` → non-reproducible (bug) | — | — |
| branch (`3ba583a`) | `3b9c09e04b30e859` ×2 → ✅ **reproducible** | differs ✅ | random ✅ |

**Qwen3-Omni thinker** (standard path, text), temp=0.8, seed=1234 ×2: main
`4b70d0ab4232`/`f81a5c6aaed5` (non-reproducible) vs branch `1fac69e63028` ×2 (✅).

**Higgs TTS** (custom sampler), temp=0.8: branch seed=1234 reproducible
(`3dbc11c98d8bb618`); main non-reproducible; seed=5678 differs; unseeded random.

**Fish S2-Pro** (custom sampler), temp=0.8: seed=1234 and seed=5678 each
reproducible (`3dbc11c98d8bb618` / `b863c8fdec6cc010`) and distinct; unseeded
random.
