### PR TITLE
[MOSS]: Use thread_local capture_error_mode for CUDA graph

### DIFF
--- a/sglang_omni/models/moss_tts_local/vocoder_cuda_graph.py
+++ b/sglang_omni/models/moss_tts_local/vocoder_cuda_graph.py
@@ -158,7 +158,9 @@ class MossVocoderCudaGraphRunner:
         if self._pool is None:
             self._pool = torch.cuda.graph_pool_handle()
         graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph, pool=self._pool):
+        with torch.cuda.graph(
+            graph, pool=self._pool, capture_error_mode="thread_local"
+        ):
             result = self._codec._decode_frame(static_codes, static_lengths)
             static_audio = result.audio
             static_audio_lengths = result.audio_lengths

--- a/tests/unit_test/moss_tts_local/test_vocoder_cuda_graph.py
+++ b/tests/unit_test/moss_tts_local/test_vocoder_cuda_graph.py
@@ -3,6 +3,10 @@
 
 from __future__ import annotations
 
+import ast
+import inspect
+import textwrap
+
 import pytest
 import torch
 
@@ -87,6 +91,36 @@ def test_some_graphs_captured(session_bundle):
     assert (
         captured
     ), "no codec-decode CUDA graphs captured (all shapes fell back to eager)"
+
+
+def test_cuda_graph_capture_uses_thread_local_error_mode():
+    from sglang_omni.models.moss_tts_local.vocoder_cuda_graph import (
+        MossVocoderCudaGraphRunner,
+    )
+
+    source = textwrap.dedent(
+        inspect.getsource(MossVocoderCudaGraphRunner._capture_frame_count)
+    )
+    tree = ast.parse(source)
+    graph_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "graph"
+        and isinstance(node.func.value, ast.Attribute)
+        and node.func.value.attr == "cuda"
+        and isinstance(node.func.value.value, ast.Name)
+        and node.func.value.value.id == "torch"
+    ]
+    assert graph_calls, "MOSS vocoder CUDA graph capture call not found"
+    assert any(
+        keyword.arg == "capture_error_mode"
+        and isinstance(keyword.value, ast.Constant)
+        and keyword.value.value == "thread_local"
+        for call in graph_calls
+        for keyword in call.keywords
+    ), "MOSS vocoder CUDA graph capture must use thread-local error mode"
 
 
 @pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA + real codec")


### PR DESCRIPTION
## Motivation

`MossVocoderCudaGraphRunner` captures CUDA graphs for vocoder execution, but graph capture can interact badly with other CUDA work in the same process if capture error handling is process-global. In colocated serving, this can make graph capture less isolated than intended: one thread/component entering CUDA graph capture can affect unrelated live serving work in the same CUDA process.

This PR makes the vocoder graph capture scope explicitly thread-local by passing `capture_error_mode="thread_local"` to `torch.cuda.graph(...)`. The goal is to keep CUDA graph capture error handling local to the runner thread and reduce cross-thread failure coupling during lazy or repeated graph capture.

## Modifications

* Update `MossVocoderCudaGraphRunner` to call `torch.cuda.graph(...)` with:

  ```python
  capture_error_mode="thread_local"
  ```

* Add a focused unit test that uses `inspect` and `ast` to parse the runner source and assert that the `torch.cuda.graph(...)` call includes the `capture_error_mode` keyword.

* Add the necessary test imports for source inspection and AST parsing.

## Related Issues

Fixes #825.

## Accuracy Test

pytest and pre-commit passed.

This PR does not change model weights, model architecture, kernels, vocoder numerics, or decoding logic. It only changes CUDA graph capture error-scope behavior and adds a source-level regression test.

## Benchmark & Profiling

Not applicable / not expected to affect steady-state performance.

The change only adds a keyword argument to CUDA graph capture setup. Runtime graph replay behavior should remain unchanged. The intended benefit is safer capture isolation in colocated serving, especially when graph capture can happen outside pure startup warmup.

## Checklist

* [x] Format your code according with pre-commit.
* [x] Add unit tests.
* [x] Update documentation / docstrings / example tutorials as needed.
* [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
* [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci moss` to select the MOSS TTS CI model. Draft PRs are skipped even if labeled.
