### PR TITLE
[CI] Rerun latest failed workflow per event

### DIFF
--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -120,12 +120,24 @@ def handle_rerun_failed_ci(gh_repo, pr, comment, user_perms, react_on_success=Tr
 
     runs = gh_repo.get_workflow_runs(head_sha=head_sha)
 
+    rerun_candidates = [
+        run
+        for run in runs
+        if run.status == "completed" and run.conclusion in ("failure", "skipped")
+    ]
+    rerun_candidates.sort(key=lambda run: (run.created_at, run.id), reverse=True)
+
     rerun_count = 0
-    for run in runs:
-        if run.status != "completed":
+    seen_workflows = set()
+    for run in rerun_candidates:
+        workflow_key = (run.workflow_id, run.event)
+        if workflow_key in seen_workflows:
+            print(
+                f"Skipping older {run.conclusion} workflow: "
+                f"{run.name} (ID: {run.id})"
+            )
             continue
-        if run.conclusion not in ("failure", "skipped"):
-            continue
+        seen_workflows.add(workflow_key)
 
         print(f"Processing {run.conclusion} workflow: {run.name} (ID: {run.id})")
         try:


### PR DESCRIPTION
## Motivation

`/tag-and-rerun-ci` can find multiple completed failed/skipped workflow runs for the same PR head SHA. In Omni CI, rerunning duplicate `Omni CI` runs for the same PR can make them fight the workflow concurrency group and leave one attempt cancelled while another continues.

## Modifications

- Build the failed/skipped rerun candidate list before dispatching reruns.
- Sort candidates newest-first so the selected representative is deterministic instead of depending on API iteration order.
- Rerun only the latest candidate per `(workflow_id, event)` and skip older duplicates, while preserving the existing `skipped -> rerun()` and `failure -> rerun_failed_jobs()` behavior.

## Root Cause

The slash-command handler previously reran every completed failed/skipped workflow run for the PR head SHA. When two stale `Omni CI` pull-request runs existed for the same commit, both were rerun, and Omni CI's PR-level concurrency cancelled one of them.
