### PR TITLE
[CI] Add Ccyest to CI permissions

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -1,4 +1,9 @@
 {
+    "Ccyest": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "reason": "custom override"
+    },
     "Ratish1": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
@@ -15,11 +20,6 @@
         "reason": "custom override"
     },
     "zhaochenyang20": {
-        "can_tag_run_ci_label": true,
-        "can_rerun_failed_ci": true,
-        "reason": "custom override"
-    },
-    "Ccyest": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
         "reason": "custom override"

--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -18,5 +18,10 @@
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,
         "reason": "custom override"
+    },
+    "Ccyest": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "reason": "custom override"
     }
 }


### PR DESCRIPTION
## Summary
- Add `Ccyest` to `.github/CI_PERMISSIONS.json` with `can_tag_run_ci_label` and `can_rerun_failed_ci` permissions

## Test plan
- [ ] Verify `/tag-and-rerun-ci moss` works on a PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)