### PR TITLE
[Ming]: Use thread_local capture_error_mode for CUDA graph

### DIFF
--- a/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
+++ b/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
@@ -190,7 +190,7 @@ class CFMGraphExecutor:
         # (execute) checks abort before _initialize_graph and on every replay.
         self.graph = torch.cuda.CUDAGraph()
         try:
-            with torch.cuda.graph(self.graph):
+            with torch.cuda.graph(self.graph, capture_error_mode="thread_local"):
                 self.gen_lat_placeholder = self.cfm.sample(
                     self.last_hidden_state_placeholder,
                     self.his_lat_placeholder,
@@ -558,7 +558,9 @@ class MingOmniTalker(nn.Module):
                         inputs_embeds_placeholder.copy_(inputs_embeds)
                         cache_position_placeholder.copy_(cache_position)
 
-                        with torch.cuda.graph(model_graph):
+                        with torch.cuda.graph(
+                            model_graph, capture_error_mode="thread_local"
+                        ):
                             outputs_placeholder = self.model(
                                 position_ids=position_ids_placeholder,
                                 cache_position=cache_position_placeholder,

--- a/tests/unit_test/ming_omni/test_talker_cuda_graph.py
+++ b/tests/unit_test/ming_omni/test_talker_cuda_graph.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ming talker CUDA graph source-level regression tests."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_TALKER_SOURCE = (
+    _REPO_ROOT
+    / "sglang_omni"
+    / "models"
+    / "ming_omni"
+    / "talker"
+    / "modeling_ming_omni_talker.py"
+)
+
+
+def _method_node(
+    tree: ast.Module, class_name: str, method_name: str
+) -> ast.FunctionDef:
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == method_name:
+                    return item
+    raise AssertionError(f"{class_name}.{method_name} not found")
+
+
+def _torch_cuda_graph_calls(node: ast.AST) -> list[ast.Call]:
+    return [
+        item
+        for item in ast.walk(node)
+        if isinstance(item, ast.Call)
+        and isinstance(item.func, ast.Attribute)
+        and item.func.attr == "graph"
+        and isinstance(item.func.value, ast.Attribute)
+        and item.func.value.attr == "cuda"
+        and isinstance(item.func.value.value, ast.Name)
+        and item.func.value.value.id == "torch"
+    ]
+
+
+def _has_thread_local_capture_error_mode(call: ast.Call) -> bool:
+    return any(
+        keyword.arg == "capture_error_mode"
+        and isinstance(keyword.value, ast.Constant)
+        and keyword.value.value == "thread_local"
+        for keyword in call.keywords
+    )
+
+
+def test_ming_lazy_cuda_graph_captures_use_thread_local_error_mode() -> None:
+    tree = ast.parse(_TALKER_SOURCE.read_text())
+    methods = [
+        ("CFMGraphExecutor", "_initialize_graph"),
+        ("MingOmniTalker", "generate"),
+    ]
+
+    for class_name, method_name in methods:
+        method = _method_node(tree, class_name, method_name)
+        graph_calls = _torch_cuda_graph_calls(method)
+        assert graph_calls, f"{class_name}.{method_name} CUDA graph capture not found"
+        assert all(
+            _has_thread_local_capture_error_mode(call) for call in graph_calls
+        ), (
+            f"{class_name}.{method_name} CUDA graph capture must use "
+            "thread-local error mode"
+        )

--- a/tests/unit_test/ming_omni/test_talker_cuda_graph.py
+++ b/tests/unit_test/ming_omni/test_talker_cuda_graph.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _TALKER_SOURCE = (
     _REPO_ROOT


### PR DESCRIPTION
## Motivation

This PR fixes the Ming instance of the CUDA graph capture issue described in #829. As @Ccyest point it out.

Ming Omni has model-local CUDA graph capture sites that can be reached from lazy/runtime paths, not only from guaranteed startup-only initialization. If those captures happen after serving has started, PyTorch’s default global CUDA graph capture error mode can make the capture sensitive to unrelated CUDA work from sibling serving threads in the same colocated process.

This is the same failure class discussed in #825 for the MOSS vocoder: a local CUDA graph capture should not be able to fail because another subsystem is doing unrelated CUDA work in the same process.

For Ming, the risky sites are:

- `CFMGraphExecutor._initialize_graph()`
- `MingOmniTalker.generate()`

Both can capture CUDA graphs when their local graph state has not yet been initialized. Using `capture_error_mode="thread_local"` makes these capture sites robust if they are reached during live serving.

## Modifications

This PR updates Ming’s local CUDA graph capture sites to explicitly use thread-local CUDA capture error handling:

- Pass `capture_error_mode="thread_local"` in `CFMGraphExecutor._initialize_graph()`.
- Pass `capture_error_mode="thread_local"` in `MingOmniTalker.generate()`.
- Add `tests/unit_test/ming_omni/test_talker_cuda_graph.py`.
- The new unit test parses the Ming talker source with `ast` / `inspect` and asserts that all local `torch.cuda.graph(...)` calls include `capture_error_mode="thread_local"`.

This keeps the fix scoped to Ming’s model-local lazy/live capture paths. It does not mechanically change startup-only graph initialization paths or SGLang-managed AR graph initialization.

## Related Issues

Closes #829.

Related to #825.

## Accuracy Test

This change only modifies CUDA graph capture error handling mode. It does not change model computation, graph replay logic, tensor values, sampling, or decoding behavior.

Expected accuracy impact: no output change.

Added regression coverage:

```bash
python -m pytest tests/unit_test/ming_omni/test_talker_cuda_graph.py
```
pytest and pre-commit passed.

## Benchmark & Profiling

Not applicable / not expected to affect steady-state performance.

The change only adds a keyword argument to CUDA graph capture setup. Runtime graph replay behavior should remain unchanged. The intended benefit is safer capture isolation in colocated serving, especially when graph capture can happen outside pure startup warmup.

## Checklist

* [x] Format your code according with pre-commit.
* [x] Add unit tests.
* [x] Update documentation / docstrings / example tutorials as needed.
* [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
* [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci moss` to select the MOSS TTS CI model. Draft PRs are skipped even if labeled.