### PR TITLE
Extract Qwen3-ASR mel at true audio length instead of padding to 3000 mel frames

### DIFF
--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -171,10 +171,10 @@ def make_qwen3_asr_scheduler_adapters(
         audio_duration_s = float(len(audio) / _SAMPLE_RATE)
         fingerprint = _audio_fingerprint(audio)
 
-        # note (Jeffro Qu): unlike Whisper's default 30s window, here we pad the mel to the clip's true length. 
+        # note (Jeffro Qu): unlike Whisper's default 30s window, here we pad the mel to the clip's true length.
         # WhisperFeatureExtractor defaults to padding="max_length", padding every clip to nb_max_frames=3000 (~30s),
-        # so a short clip pays the full 30s of mel FFT on silence. 
-        # This is safefor Qwen3-ASR because its encoder is variable-length and keeps only the
+        # so a short clip pays the full 30s of mel FFT on silence.
+        # This is safe for Qwen3-ASR because its encoder is variable-length and keeps only the
         # valid frames via feature_attention_mask; vanilla Whisper's fixed-length encoder would instead break on padding="longest" (see ref: transformers#26241).
         # refs:
         #  https://github.com/huggingface/transformers/blob/main/src/transformers/models/whisper/feature_extraction_whisper.py

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -194,8 +194,8 @@ def make_qwen3_asr_scheduler_adapters(
             feature_attention_mask = torch.ones(
                 (features.shape[0], features.shape[-1]), dtype=torch.long
             )
-        # get_audio_feature uses the mask to select valid frames; its no-mask
-        # branch transposes wrong, so the mask path must be taken.
+        # note (Jeffro Qu): get_audio_feature uses the mask to select valid
+        # frames; its no-mask branch transposes wrong, so the mask path must be taken.
         num_mel_frames = int(feature_attention_mask.sum().item())
         num_audio_tokens = int(qwen3_asr_num_audio_tokens(num_mel_frames))
         logger.debug(

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -171,22 +171,31 @@ def make_qwen3_asr_scheduler_adapters(
         audio_duration_s = float(len(audio) / _SAMPLE_RATE)
         fingerprint = _audio_fingerprint(audio)
 
+        # note (Jeffro Qu): unlike Whisper's default 30s window, here we pad the mel to the clip's true length. 
+        # WhisperFeatureExtractor defaults to padding="max_length", padding every clip to nb_max_frames=3000 (~30s),
+        # so a short clip pays the full 30s of mel FFT on silence. 
+        # This is safefor Qwen3-ASR because its encoder is variable-length and keeps only the
+        # valid frames via feature_attention_mask; vanilla Whisper's fixed-length encoder would instead break on padding="longest" (see ref: transformers#26241).
+        # refs:
+        #  https://github.com/huggingface/transformers/blob/main/src/transformers/models/whisper/feature_extraction_whisper.py
+        #  https://github.com/huggingface/transformers/issues/26241
         extracted = feature_extractor(
             audio,
             sampling_rate=_SAMPLE_RATE,
             return_tensors="pt",
             return_attention_mask=True,
+            padding="longest",
+            truncation=True,
         )
-        features = extracted.input_features  # 128, 3000
+        features = extracted.input_features  # [128, true_frames] (<= 3000)
         feature_attention_mask = getattr(extracted, "attention_mask", None)
         if feature_attention_mask is None:
             # WhisperFeatureExtractor normally returns one; fall back to all-valid.
             feature_attention_mask = torch.ones(
                 (features.shape[0], features.shape[-1]), dtype=torch.long
             )
-        # Keep the full padded mel; the model's get_audio_feature uses the mask
-        # to select valid frames. Its no-mask branch transposes wrong, so the
-        # mask path must be taken.
+        # get_audio_feature uses the mask to select valid frames; its no-mask
+        # branch transposes wrong, so the mask path must be taken.
         num_mel_frames = int(feature_attention_mask.sum().item())
         num_audio_tokens = int(qwen3_asr_num_audio_tokens(num_mel_frames))
         logger.debug(
@@ -283,7 +292,7 @@ def make_qwen3_asr_scheduler_adapters(
         # is not an identity transform for all whitespace/Unicode transcripts.
         raw = _decode_token_ids(tokenizer, output_ids, skip_special_tokens=False)
         logger.debug(
-            f"[qwen3-asr] n_out={len(output_ids)} ids={output_ids[:40]} " f"raw={raw!r}"
+            f"[qwen3-asr] n_out={len(output_ids)} ids={output_ids[:40]} raw={raw!r}"
         )
         asr_text_idx = _find_subsequence(output_ids, asr_text_token_ids)
         transcript_ids = (


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Qwen3-ASR reuses Whisper's feature extractor, which pads every audio clip to 30s (3000 mel frames) before computing the mel spectrogram. SeedTTS clips are only ~4–7s, so most of that CPU mel/FFT work runs on silence.

Profiling the c=32 path shows per-request preprocessing (request_build, ~28ms) is a big chunk of wall-clock and runs serially before the GPU (https://github.com/sgl-project/sglang-omni/issues/831#issuecomment-4756457401). But Qwen3-ASR's audio encoder is variable-length and already drops the padded frames via feature_attention_mask, so the 30s padding is pure waste.

## Modifications

Extract the mel at the clip's true length instead of padding to 30s

## Related Issues

#831

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

### Results (single H200, DP=1, SeedTTS EN **1088**, c=32 ×3 repeats)

#### End-to-end benchmark

| metric | before | after | Δ |
|---|---|---|---|
| throughput (samples/s) | 22.43 | 27.88 | **+24.3%** |
| wall mean (s) | 48.52 | 39.04 | −19.5% |
| latency mean (s) | 1.416 | 1.144 | −19.2% |
| latency p95 (s) | 1.925 | 1.546 | −19.7% |
| rtf mean | 0.3064 | 0.2474 | −19.3% |
| corpus WER (mean of 3) | 0.01297 | 0.01310 | unchanged (noise) |
| skipped | 0 | 0 | — |

WER per-repeat:
before: 0.0129/0.0128/0.0132; after: 0.0138/0.0127/0.0128.

#### Stage breakdown (mechanism)

| interval | before avg | after avg | Δ |
|---|---|---|---|
| `scheduler_request_build_start→end` | 27.9 ms | 18.5 ms | **−34%** |
| `scheduler_request_build_start→end` p95 | 37.6 ms | 27.0 ms | −28% |
| `stage_input_received→stage_complete` (end-to-end, incl. queue) | 1561 ms | 1285 ms | −18% |

---

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
