### PR TITLE
[Higgs TTS] Rename _max_batch_size to _max_running_requests (#836 W2)

### DIFF
--- a/sglang_omni/models/higgs_tts/model.py
+++ b/sglang_omni/models/higgs_tts/model.py
@@ -156,16 +156,16 @@ class HiggsTTSModel(nn.Module):
                 self.multimodal_embedding.modality_embedding_0.weight
             )
 
-        self._max_batch_size = _resolve_max_running_requests()
-        pool_size = self._max_batch_size + 1
+        self._max_running_requests = _resolve_max_running_requests()
+        pool_size = self._max_running_requests + 1
         self._sampler_pool = HiggsBatchedSamplerState(
             max_batch_size=pool_size,
             num_codebooks=num_codebooks,
             device=self.backbone.model.embed_tokens.weight.device,
         )
-        self._padding_row = self._max_batch_size  # last row reserved
+        self._padding_row = self._max_running_requests  # last row reserved
         self._rid_to_row: dict[str, int] = {}
-        self._free_rows: list[int] = list(range(self._max_batch_size))
+        self._free_rows: list[int] = list(range(self._max_running_requests))
         self._output_codes: dict[str, list[torch.Tensor]] = {}
 
         cg_device = self.backbone.model.embed_tokens.weight.device
@@ -235,7 +235,7 @@ class HiggsTTSModel(nn.Module):
         if not self._free_rows:
             raise RuntimeError(
                 f"HiggsTTSModel sampler pool exhausted "
-                f"(max_running_requests={self._max_batch_size}); raise "
+                f"(max_running_requests={self._max_running_requests}); raise "
                 f"``max_running_requests`` or limit concurrent requests."
             )
         row = self._free_rows.pop()


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Workstream 2 of #836 (Higgs batch-naming cleanup). After #756, the Higgs model-side `self._max_batch_size` is resolved from the SGLang `max_running_requests` server-arg (via `_resolve_max_running_requests()`) and used only to size the sampler-pool row allocation. The name reads like an independent buffer-size choice when the value is actually slaved to the serving admission limit, so it no longer reflects its semantics.

## Modifications

Renamed `self._max_batch_size` → `self._max_running_requests` in `model.py` (5 references). After #756 this attribute holds the resolved `max_running_requests` and is used to size the sampler pool, so the old name no longer matched. Naming-only; no behavior change.

Per the W2 task, audited the batch-related names across `higgs_tts/`:
- Checked the stage-factory knobs (`max_running_requests`, `cuda_graph_max_bs`, `async_decode_min_batch_size`, `max_concurrency`, `vocoder_decode_batch_size`, `max_batch_wait_ms`), the model-side attributes in `model.py`, and the sampler/codec batch fields.
- All are accurate and live except `self._max_batch_size`, which #756 changed to hold the resolved `max_running_requests` (used to size the sampler pool) — the name no longer matched. That is the rename here. No other renames, and no stale params to remove (#756 already dropped the old constants and renamed the vocoder knob). `HiggsBatchedSamplerState.max_batch_size` is left as-is: there the value is the tensor allocation dimension, so the name is correct.

## Related Issues

Part of #836 (Workstream 2). Follows up #756.

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
