### PR TITLE
Add thinker local PD scheduler experiment

### DIFF
--- a/sglang_omni/environ.py
+++ b/sglang_omni/environ.py
@@ -97,6 +97,9 @@ class Environ:
     # logging
     SGLOMNI_LOG_LEVEL = EnvStr("INFO")
 
+    SGLANG_OMNI_ENABLE_THINKER_PD = EnvBool(False)
+    SGLANG_OMNI_THINKER_PD_READY_DECODE_LIMIT = EnvInt(32)
+
     def __new__(cls):
         # single instance
         if cls._instance is None:

--- a/sglang_omni/models/qwen3_omni/bootstrap.py
+++ b/sglang_omni/models/qwen3_omni/bootstrap.py
@@ -99,6 +99,7 @@ def create_thinker_scheduler(
         request_builder=request_builder,
         result_adapter=result_adapter,
         stream_output_builder=stream_output_builder,
+        stage_name="thinker",
     )
 
 

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -844,7 +844,12 @@ class OmniScheduler:
         ):
             ready_room = self._pd_ready_decode_limit - self._pd_ready_decode_req_count()
             if ready_room > 0:
-                return min(ready_room, self.req_to_token_pool.available_size())
+                decode_capacity = max(int(self.max_running_requests), 1)
+                return min(
+                    ready_room,
+                    decode_capacity,
+                    self.req_to_token_pool.available_size(),
+                )
         return _Upstream.get_num_allocatable_reqs(self, running_bs)
 
     def get_next_batch_to_run(self):

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -27,10 +27,12 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.dp_attention import compute_dp_attention_world_info
 from sglang.srt.managers.schedule_batch import FINISH_ABORT, ScheduleBatch
 from sglang.srt.managers.scheduler import Scheduler as _Upstream
+from sglang.srt.managers.scheduler import set_schedule_time_batch
 from sglang.srt.managers.scheduler import validate_input_length
 from sglang.srt.mem_cache.common import release_kv_cache
 from sglang.srt.utils import broadcast_pyobj
 
+from sglang_omni.environ import OMNIENV
 from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.profiler.event_recorder import get_active_stage as _get_active_stage
 from sglang_omni.proto.admin import (
@@ -112,6 +114,7 @@ class OmniScheduler:
         stream_chunk_handler: Callable | None = None,
         stream_done_handler: Callable | None = None,
         abort_callback: Callable[[str], None] | None = None,
+        stage_name: str | None = None,
         enable_overlap: bool = False,
         enable_async_decode: bool = False,
         async_decode_min_batch_size: int = 2,
@@ -130,6 +133,7 @@ class OmniScheduler:
         self._stream_chunk_handler = stream_chunk_handler
         self._stream_done_handler = stream_done_handler
         self._abort_callback = abort_callback
+        self.stage_name = stage_name
         self._request_admission_lock = threading.RLock()
         self.request_build_max_workers = max(1, int(request_build_max_workers))
         if self.request_build_max_workers > 1 and int(server_args.tp_size) > 1:
@@ -376,6 +380,29 @@ class OmniScheduler:
         self._dirty_deferred_request_ids: set[str] = set()
         self._first_emit_done: set[str] = set()
         self._prefill_start_done: set[str] = set()
+        self._pd_ready_decode_batches: deque[Any] = deque()
+        self._pd_prefill_admission_active = False
+        self._pd_ready_decode_limit = max(
+            1, int(OMNIENV.SGLANG_OMNI_THINKER_PD_READY_DECODE_LIMIT.get() or 1)
+        )
+        self._enable_thinker_pd = (
+            stage_name == "thinker"
+            and bool(OMNIENV.SGLANG_OMNI_ENABLE_THINKER_PD.get())
+            and not enable_overlap
+            and not enable_async_decode
+        )
+        if stage_name == "thinker" and bool(
+            OMNIENV.SGLANG_OMNI_ENABLE_THINKER_PD.get()
+        ) and not self._enable_thinker_pd:
+            logger.warning(
+                "Thinker local PD scheduler requested but disabled because "
+                "overlap/async decode is enabled"
+            )
+        if self._enable_thinker_pd:
+            logger.info(
+                "Thinker local PD scheduler enabled: ready_decode_limit=%s",
+                self._pd_ready_decode_limit,
+            )
 
     def _init_upstream_compat_flags(self, server_args: Any) -> None:
         self.enable_hisparse = bool(getattr(server_args, "enable_hisparse", False))
@@ -810,6 +837,170 @@ class OmniScheduler:
             )
         )
 
+    def get_num_allocatable_reqs(self, running_bs):
+        if (
+            getattr(self, "_enable_thinker_pd", False)
+            and getattr(self, "_pd_prefill_admission_active", False)
+        ):
+            ready_room = self._pd_ready_decode_limit - self._pd_ready_decode_req_count()
+            if ready_room > 0:
+                return min(ready_room, self.req_to_token_pool.available_size())
+        return _Upstream.get_num_allocatable_reqs(self, running_bs)
+
+    def get_next_batch_to_run(self):
+        if not getattr(self, "_enable_thinker_pd", False):
+            return _Upstream.get_next_batch_to_run(self)
+        return self._get_next_batch_to_run_local_pd()
+
+    def _get_next_batch_to_run_local_pd(self):
+        self._abort_on_waiting_timeout()
+        self._abort_on_running_timeout()
+
+        stashed_prefill = self._pd_stash_last_prefill_batch()
+
+        if self.running_batch.is_prefill_only:
+            self.running_batch.filter_batch()
+            if self.running_batch.is_empty():
+                self.running_batch.batch_is_full = False
+
+        ret = None
+        if self._pd_should_run_decode_before_prefill(stashed_prefill):
+            ret = self._pd_get_decode_batch()
+
+        new_batch = None
+        if ret is None and self._pd_can_schedule_prefill():
+            new_batch = self._pd_get_new_batch_prefill()
+
+        if new_batch is not None:
+            ret = new_batch
+        elif ret is None:
+            ret = self._pd_get_decode_batch()
+
+        ret = self.maybe_prepare_mlp_sync_batch(ret, need_sync=self.require_mlp_sync)
+        ret = self._maybe_prepare_ngram_embedding(ret)
+        if ret:
+            set_schedule_time_batch(ret)
+        return ret
+
+    def _pd_can_schedule_prefill(self) -> bool:
+        if not self._pd_waiting_or_chunked_prefill():
+            return False
+        return self._pd_ready_decode_req_count() < self._pd_ready_decode_limit
+
+    def _pd_should_run_decode_before_prefill(self, stashed_prefill: bool) -> bool:
+        if stashed_prefill:
+            return True
+        if self._pd_ready_decode_req_count() >= self._pd_ready_decode_limit:
+            return True
+        return self.running_batch.is_empty() and bool(self._pd_ready_decode_batches)
+
+    def _pd_get_decode_batch(self):
+        self._pd_admit_ready_decode_batches()
+        if self.running_batch.is_empty() or self.running_batch.is_prefill_only:
+            return None
+        self.running_batch = self.update_running_batch(self.running_batch)
+        return self.running_batch if not self.running_batch.is_empty() else None
+
+    def _pd_get_new_batch_prefill(self):
+        self._pd_prefill_admission_active = True
+        is_mixed_chunk = self.is_mixed_chunk
+        try:
+            self.running_batch.batch_is_full = False
+            self.is_mixed_chunk = False
+            return _Upstream.get_new_batch_prefill(self)
+        finally:
+            self.is_mixed_chunk = is_mixed_chunk
+            self._pd_prefill_admission_active = False
+
+    def _pd_waiting_or_chunked_prefill(self) -> bool:
+        return bool(self.waiting_queue) or self.chunked_req is not None
+
+    def _pd_ready_decode_req_count(self) -> int:
+        return sum(
+            batch.batch_size()
+            for batch in getattr(self, "_pd_ready_decode_batches", ())
+            if batch is not None
+        )
+
+    def _pd_stash_last_prefill_batch(self) -> bool:
+        last_batch = self.last_batch
+        if last_batch is None or not last_batch.forward_mode.is_extend():
+            return False
+        self.last_batch = None
+
+        chunked_req_to_exclude = set()
+        if self.chunked_req is not None:
+            chunked_req_to_exclude.add(self.chunked_req)
+            if getattr(self, "_chunked_req_scheduled_last_iter", False):
+                self.stash_chunked_request(self.chunked_req)
+        if last_batch.chunked_req is not None:
+            chunked_req_to_exclude.add(last_batch.chunked_req)
+
+        last_bs = last_batch.batch_size()
+        last_batch.filter_batch(chunked_req_to_exclude=list(chunked_req_to_exclude))
+        if last_batch.batch_size() < last_bs:
+            self.running_batch.batch_is_full = False
+        if last_batch.is_empty():
+            return False
+        self._pd_enqueue_ready_decode_batch(last_batch)
+        self.running_batch.batch_is_full = False
+        return True
+
+    def _pd_enqueue_ready_decode_batch(self, batch: ScheduleBatch) -> None:
+        self._pd_ready_decode_batches.append(batch)
+        queue_reqs = self._pd_ready_decode_req_count()
+        for req in batch.reqs:
+            _emit_event(
+                request_id=req.rid,
+                stage=None,
+                event_name="scheduler_pd_ready_decode_enter",
+                metadata={"ready_decode_reqs": queue_reqs},
+            )
+
+    def _pd_filter_running_batch_for_decode_slots(self) -> None:
+        if self.running_batch is None or self.running_batch.is_empty():
+            return
+        initial_bs = self.running_batch.batch_size()
+        self.running_batch.filter_batch(v1_spec_info_filtered=True)
+        if self.running_batch.is_empty():
+            self.running_batch.batch_is_full = False
+            return
+        if self.running_batch.batch_size() < initial_bs:
+            self.running_batch.batch_is_full = False
+
+    def _pd_decode_slots_available(self) -> int:
+        running_bs = 0 if self.running_batch is None else self.running_batch.batch_size()
+        return max(int(self.max_running_requests) - running_bs, 0)
+
+    def _pd_admit_ready_decode_batches(self) -> None:
+        if not self._pd_ready_decode_batches:
+            return
+
+        self._pd_filter_running_batch_for_decode_slots()
+        available = self._pd_decode_slots_available()
+        while self._pd_ready_decode_batches and available > 0:
+            batch = self._pd_ready_decode_batches[0]
+            batch_size = batch.batch_size()
+            if batch_size > available:
+                break
+            self._pd_ready_decode_batches.popleft()
+            if self.running_batch.is_empty():
+                self.running_batch = batch
+                self.running_batch.batch_is_full = False
+            else:
+                self.running_batch.merge_batch(batch)
+            available -= batch_size
+            ready_reqs = self._pd_ready_decode_req_count()
+            for req in batch.reqs:
+                _emit_event(
+                    request_id=req.rid,
+                    stage=None,
+                    event_name="scheduler_pd_decode_admit",
+                    metadata={"ready_decode_reqs": ready_reqs},
+                )
+        if self._pd_ready_decode_batches and available <= 0:
+            self.running_batch.batch_is_full = True
+
     def run_batch(self, batch, pp_proxy_tensors=None):
         try:
             return self._run_batch(batch, pp_proxy_tensors)
@@ -1094,6 +1285,7 @@ class OmniScheduler:
             _remove_from_batch(self.cur_batch, request_id)
             _remove_from_batch(self.last_batch, request_id)
             _remove_from_batch(self._async_pending_batch(), request_id)
+            self._remove_from_pd_ready_decode(request_id)
         self._drain_inbox_for_request(request_id)
 
     def admin(
@@ -1479,6 +1671,11 @@ class OmniScheduler:
                 rid = getattr(req, "rid", None)
                 if rid is not None and not req.finished():
                     request_ids.add(rid)
+        for batch in getattr(self, "_pd_ready_decode_batches", ()):
+            for req in getattr(batch, "reqs", []) or []:
+                rid = getattr(req, "rid", None)
+                if rid is not None and not req.finished():
+                    request_ids.add(rid)
         return sorted(request_ids)
 
     def _can_update_active_requests(
@@ -1560,6 +1757,12 @@ class OmniScheduler:
             if batch is None:
                 continue
             for req in batch.reqs:
+                if req.rid != request_id or id(req) in seen:
+                    continue
+                seen.add(id(req))
+                self._release_request_kv_cache(req)
+        for batch in getattr(self, "_pd_ready_decode_batches", ()):
+            for req in getattr(batch, "reqs", []) or []:
                 if req.rid != request_id or id(req) in seen:
                     continue
                 seen.add(id(req))
@@ -1832,6 +2035,17 @@ class OmniScheduler:
         for msg in retained:
             self.inbox.put(msg)
 
+    def _remove_from_pd_ready_decode(self, request_id: str) -> None:
+        ready_batches = getattr(self, "_pd_ready_decode_batches", None)
+        if not ready_batches:
+            return
+        retained = deque()
+        for batch in ready_batches:
+            _remove_from_batch(batch, request_id)
+            if batch is not None and getattr(batch, "reqs", None):
+                retained.append(batch)
+        self._pd_ready_decode_batches = retained
+
     def _find_request_data(self, request_id: str) -> Any | None:
         # Scan all batches a live req can sit in during prefill→decode handoff.
         for batch in (self.running_batch, self.cur_batch, self.last_batch):
@@ -1843,6 +2057,10 @@ class OmniScheduler:
         for req in self.waiting_queue:
             if req.rid == request_id:
                 return req._omni_data
+        for batch in getattr(self, "_pd_ready_decode_batches", ()):
+            for req in getattr(batch, "reqs", ()):
+                if req.rid == request_id:
+                    return req._omni_data
         return None
 
     @staticmethod

--- a/tests/unit_test/pipeline/test_thinker_pd_scheduler.py
+++ b/tests/unit_test/pipeline/test_thinker_pd_scheduler.py
@@ -150,6 +150,16 @@ def test_pd_allocatable_reqs_uses_ready_decode_room(monkeypatch):
     assert OmniScheduler.get_num_allocatable_reqs(scheduler, running_bs=4) == 7
 
 
+def test_pd_allocatable_reqs_never_builds_oversized_ready_decode_batch():
+    scheduler = _scheduler()
+    scheduler._pd_ready_decode_limit = 32
+    scheduler.max_running_requests = 4
+    scheduler.req_to_token_pool = _FakePool(available=32)
+    scheduler._pd_prefill_admission_active = True
+
+    assert OmniScheduler.get_num_allocatable_reqs(scheduler, running_bs=0) == 4
+
+
 def test_pd_prefill_admission_temporarily_disables_mixed_chunk(monkeypatch):
     scheduler = _scheduler()
     scheduler.is_mixed_chunk = True

--- a/tests/unit_test/pipeline/test_thinker_pd_scheduler.py
+++ b/tests/unit_test/pipeline/test_thinker_pd_scheduler.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from collections import deque
+from types import SimpleNamespace
+
+from sglang_omni.scheduling import omni_scheduler
+from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+
+
+class _FakeReq:
+    def __init__(self, rid: str, *, finished: bool = False):
+        self.rid = rid
+        self._finished = finished
+        self._omni_data = SimpleNamespace(request_id=rid)
+        self.req_pool_idx = None
+        self.mamba_pool_idx = None
+
+    def finished(self) -> bool:
+        return self._finished
+
+
+class _FakeMode:
+    def __init__(self, *, extend: bool):
+        self._extend = extend
+
+    def is_extend(self) -> bool:
+        return self._extend
+
+
+class _FakeBatch:
+    def __init__(self, reqs, *, extend: bool = True, batch_is_full: bool = False):
+        self.reqs = list(reqs)
+        self.forward_mode = _FakeMode(extend=extend)
+        self.batch_is_full = batch_is_full
+        self.chunked_req = None
+        self.is_prefill_only = False
+
+    def batch_size(self) -> int:
+        return len(self.reqs)
+
+    def is_empty(self) -> bool:
+        return not self.reqs
+
+    def filter_batch(self, chunked_req_to_exclude=None, keep_indices=None, **_kwargs):
+        if keep_indices is not None:
+            self.reqs = [self.reqs[i] for i in keep_indices]
+            return
+        excluded = set(chunked_req_to_exclude or [])
+        self.reqs = [
+            req for req in self.reqs if not req.finished() and req not in excluded
+        ]
+
+    def merge_batch(self, other) -> None:
+        self.reqs.extend(other.reqs)
+
+
+class _FakePool:
+    def __init__(self, available: int):
+        self._available = available
+
+    def available_size(self) -> int:
+        return self._available
+
+
+def _scheduler() -> OmniScheduler:
+    scheduler = object.__new__(OmniScheduler)
+    scheduler._pd_ready_decode_batches = deque()
+    scheduler._pd_ready_decode_limit = 4
+    scheduler._pd_prefill_admission_active = False
+    scheduler._enable_thinker_pd = True
+    scheduler.chunked_req = None
+    scheduler._chunked_req_scheduled_last_iter = False
+    scheduler.running_batch = _FakeBatch([], extend=False, batch_is_full=True)
+    scheduler.last_batch = None
+    scheduler.is_mixed_chunk = False
+    scheduler.max_running_requests = 4
+    scheduler.req_to_token_pool = _FakePool(available=16)
+    return scheduler
+
+
+def test_pd_stashes_prefill_batch_and_admits_to_decode(monkeypatch):
+    events = []
+    monkeypatch.setattr(
+        omni_scheduler,
+        "_emit_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+    scheduler = _scheduler()
+    reqs = [_FakeReq("r1"), _FakeReq("r2")]
+    scheduler.last_batch = _FakeBatch(reqs, extend=True)
+
+    assert OmniScheduler._pd_stash_last_prefill_batch(scheduler) is True
+
+    assert scheduler.running_batch.batch_is_full is False
+    assert scheduler.last_batch is None
+    assert OmniScheduler._pd_ready_decode_req_count(scheduler) == 2
+    assert [event["event_name"] for event in events] == [
+        "scheduler_pd_ready_decode_enter",
+        "scheduler_pd_ready_decode_enter",
+    ]
+
+    assert OmniScheduler._pd_stash_last_prefill_batch(scheduler) is False
+    assert OmniScheduler._pd_ready_decode_req_count(scheduler) == 2
+
+    OmniScheduler._pd_admit_ready_decode_batches(scheduler)
+
+    assert scheduler.running_batch.reqs == reqs
+    assert OmniScheduler._pd_ready_decode_req_count(scheduler) == 0
+    assert [event["event_name"] for event in events[-2:]] == [
+        "scheduler_pd_decode_admit",
+        "scheduler_pd_decode_admit",
+    ]
+
+
+def test_pd_does_not_overfill_decode_slots(monkeypatch):
+    monkeypatch.setattr(omni_scheduler, "_emit_event", lambda **_kwargs: None)
+    scheduler = _scheduler()
+    scheduler.running_batch = _FakeBatch(
+        [_FakeReq("active-1"), _FakeReq("active-2")],
+        extend=False,
+    )
+    scheduler._pd_ready_decode_batches.append(
+        _FakeBatch([_FakeReq("ready-1"), _FakeReq("ready-2"), _FakeReq("ready-3")])
+    )
+
+    OmniScheduler._pd_admit_ready_decode_batches(scheduler)
+
+    assert [req.rid for req in scheduler.running_batch.reqs] == [
+        "active-1",
+        "active-2",
+    ]
+    assert OmniScheduler._pd_ready_decode_req_count(scheduler) == 3
+
+
+def test_pd_allocatable_reqs_uses_ready_decode_room(monkeypatch):
+    scheduler = _scheduler()
+    scheduler._pd_ready_decode_batches.append(
+        _FakeBatch([_FakeReq("ready-1"), _FakeReq("ready-2")])
+    )
+    scheduler._pd_prefill_admission_active = True
+
+    assert OmniScheduler.get_num_allocatable_reqs(scheduler, running_bs=4) == 2
+
+    scheduler._pd_prefill_admission_active = False
+    monkeypatch.setattr(
+        omni_scheduler._Upstream,
+        "get_num_allocatable_reqs",
+        lambda _self, _running_bs: 7,
+    )
+    assert OmniScheduler.get_num_allocatable_reqs(scheduler, running_bs=4) == 7
+
+
+def test_pd_prefill_admission_temporarily_disables_mixed_chunk(monkeypatch):
+    scheduler = _scheduler()
+    scheduler.is_mixed_chunk = True
+    seen = []
+
+    def fake_get_new_batch_prefill(self):
+        seen.append((self._pd_prefill_admission_active, self.is_mixed_chunk))
+        return "new-batch"
+
+    monkeypatch.setattr(
+        omni_scheduler._Upstream,
+        "get_new_batch_prefill",
+        fake_get_new_batch_prefill,
+    )
+
+    assert OmniScheduler._pd_get_new_batch_prefill(scheduler) == "new-batch"
+    assert seen == [(True, False)]
+    assert scheduler.is_mixed_chunk is True
+    assert scheduler._pd_prefill_admission_active is False
+
+
+def test_pd_ready_decode_requests_participate_in_abort_lookup():
+    scheduler = _scheduler()
+    ready = _FakeReq("ready")
+    scheduler._pd_ready_decode_batches.append(_FakeBatch([ready]))
+    scheduler.waiting_queue = []
+    scheduler.cur_batch = None
+    scheduler.last_batch = None
+    scheduler._async_pending = None
+
+    assert OmniScheduler._find_request_data(scheduler, "ready") is ready._omni_data
+    assert OmniScheduler._active_request_ids(scheduler) == ["ready"]
+
+    OmniScheduler._remove_from_pd_ready_decode(scheduler, "ready")
+
+    assert OmniScheduler._pd_ready_decode_req_count(scheduler) == 0


### PR DESCRIPTION
## Summary

Refs #841.

This adds an env-gated thinker-only local prefill/decode scheduler experiment:
- `SGLANG_OMNI_ENABLE_THINKER_PD=1` enables the path; default behavior is unchanged.
- Prefilled thinker requests move into a ready-decode queue before being admitted back to decode.
- `SGLANG_OMNI_THINKER_PD_READY_DECODE_LIMIT` caps ready-decode pressure.
- PD profiler events make ready/admit timing visible.

The implementation is limited to the thinker stage and disables the local PD path when overlap/async decode is enabled.

## Rollout Stress Signal

Qwen3-Omni rollout stress, text-only, max_tokens=256, radix cache disabled.

| topology | config | N | p95 latency (s) | output tok/s | success |
|---|---|---:|---:|---:|---:|
| TP=2 | baseline | 16 | 5.017 | 808.0 | 16/16 |
| TP=2 | local PD | 16 | 4.202 | 954.6 | 16/16 |
| TP=2 | baseline | 32 | 8.699 | 923.5 | 32/32 |
| TP=2 | local PD | 32 | 7.718 | 1030.2 | 32/32 |
| TP=1 | baseline | 16 | 4.745 | 857.9 | 16/16 |
| TP=1 | local PD | 16 | 3.589 | 1129.8 | 16/16 |
| TP=1 | baseline | 32 | 7.657 | 1040.8 | 32/32 |
| TP=1 | local PD | 32 | 7.159 | 1111.1 | 32/32 |

N=32 p95 gains:
- TP=2: latency 8.699s -> 7.718s, output tok/s 923.5 -> 1030.2.
- TP=1: latency 7.657s -> 7.159s, output tok/s 1040.8 -> 1111.1.

## Tests

- `PYTHONPYCACHEPREFIX=/data/luojiaxuan/pd_probe/pycache python -m py_compile sglang_omni/environ.py sglang_omni/models/qwen3_omni/bootstrap.py sglang_omni/scheduling/omni_scheduler.py tests/unit_test/pipeline/test_thinker_pd_scheduler.py`
- `docker exec sglang-omni-luojiaxuan-pd-probe bash -lc 'cd /data/sglang-omni-thinker-pd && export PYTHONPATH=/data/sglang-omni-thinker-pd && python -m pytest tests/unit_test/pipeline/test_thinker_pd_scheduler.py -q'`
- Rollout stress TP=2 baseline/local-PD and TP=1 baseline/local-PD, as summarized above.
