### PR TITLE
[TTS] Validate generation batch policies (#836 W1)

### DIFF
--- a/sglang_omni/models/fishaudio_s2_pro/fish_speech/models/text2semantic/modeling.py
+++ b/sglang_omni/models/fishaudio_s2_pro/fish_speech/models/text2semantic/modeling.py
@@ -1006,6 +1006,15 @@ class FishQwen3AudioDecoder(PreTrainedModel):
             persistent=False,
         )
 
+    @property
+    def kv_cache_max_batch_size(self) -> int:
+        if not self.layers:
+            raise RuntimeError("Audio decoder layers are not initialized")
+        kv_cache = self.layers[0].attention.kv_cache
+        if kv_cache is None:
+            raise RuntimeError("Audio decoder KV cache is not initialized")
+        return int(kv_cache.k_cache.shape[0])
+
     def reset_caches(self):
         """Reset all KV caches to zeros."""
         for layer in self.layers:

--- a/sglang_omni/models/fishaudio_s2_pro/sglang_model.py
+++ b/sglang_omni/models/fishaudio_s2_pro/sglang_model.py
@@ -323,6 +323,12 @@ class S2ProSGLangTextModel(nn.Module):
 
         self._vq_ready = True
 
+    @property
+    def vq_decode_max_batch_size(self) -> int:
+        if not self._vq_ready:
+            raise RuntimeError("VQ decode buffers are not initialized")
+        return int(self._vq_codes.shape[0])
+
     def forward(
         self,
         input_ids: Tensor,

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -18,7 +18,7 @@ from sglang_omni.models.fishaudio_s2_pro.request_builders import (
 )
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.generation_batch_policy import (
-    build_power_of_two_cuda_graph_bs,
+    build_default_cuda_graph_bs,
     sync_cuda_graph_bs_with_max_bs,
     validate_generation_batch_policy,
 )
@@ -251,7 +251,7 @@ def create_sglang_tts_engine_executor(
     patch_fish_config_for_sglang()
 
     overrides: dict[str, Any] = {
-        "cuda_graph_bs": build_power_of_two_cuda_graph_bs(64),
+        "cuda_graph_bs": build_default_cuda_graph_bs(64),
         "cuda_graph_max_bs": 64,
         "disable_cuda_graph": False,
         "mem_fraction_static": 0.85,

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -55,6 +55,13 @@ def _compile_s2pro_codebook_decoder(model: Any, *, max_batch_size: int) -> None:
     )
 
 
+def _resolve_s2pro_model_buffer_bs(model: Any) -> int:
+    return min(
+        int(model.vq_decode_max_batch_size),
+        int(model._audio_decoder.kv_cache_max_batch_size),
+    )
+
+
 def _resolve_checkpoint(checkpoint: str) -> str:
     if os.path.isdir(checkpoint):
         return checkpoint
@@ -252,7 +259,7 @@ def create_sglang_tts_engine_executor(
         "chunked_prefill_size": 8192,
         "dtype": "bfloat16",
         "enable_torch_compile": True,
-        "torch_compile_max_bs": 16,
+        "torch_compile_max_bs": 64,
         "random_seed": int.from_bytes(os.urandom(4), "little") & 0x7FFFFFFF,
     }
     if server_args_overrides:
@@ -306,8 +313,7 @@ def create_sglang_tts_engine_executor(
     validate_generation_batch_policy(
         model_name="FishAudio S2-Pro",
         server_args=server_args,
-        model_buffer_bs=server_args.max_running_requests,
-        allow_partial_torch_compile_coverage=True,
+        model_buffer_bs=_resolve_s2pro_model_buffer_bs(model_worker.model_runner.model),
     )
 
     if bool(getattr(server_args, "enable_torch_compile", False)):

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -17,6 +17,10 @@ from sglang_omni.models.fishaudio_s2_pro.request_builders import (
     make_tts_scheduler_adapters,
 )
 from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.generation_batch_policy import (
+    build_power_of_two_cuda_graph_bs,
+    sync_cuda_graph_bs_with_max_bs,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -239,6 +243,8 @@ def create_sglang_tts_engine_executor(
     patch_fish_config_for_sglang()
 
     overrides: dict[str, Any] = {
+        "cuda_graph_bs": build_power_of_two_cuda_graph_bs(64),
+        "cuda_graph_max_bs": 64,
         "disable_cuda_graph": False,
         "mem_fraction_static": 0.85,
         "max_running_requests": 64,
@@ -250,6 +256,7 @@ def create_sglang_tts_engine_executor(
     }
     if server_args_overrides:
         overrides.update(server_args_overrides)
+        sync_cuda_graph_bs_with_max_bs(overrides, server_args_overrides)
 
     server_args = build_sglang_server_args(
         checkpoint_dir,

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -20,6 +20,7 @@ from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.generation_batch_policy import (
     build_power_of_two_cuda_graph_bs,
     sync_cuda_graph_bs_with_max_bs,
+    validate_generation_batch_policy,
 )
 
 logger = logging.getLogger(__name__)
@@ -301,6 +302,12 @@ def create_sglang_tts_engine_executor(
         num_codebooks=num_codebooks,
         codebook_size=codebook_size,
         ras_window=ras_window,
+    )
+    validate_generation_batch_policy(
+        model_name="FishAudio S2-Pro",
+        server_args=server_args,
+        model_buffer_bs=server_args.max_running_requests,
+        allow_partial_torch_compile_coverage=True,
     )
 
     if bool(getattr(server_args, "enable_torch_compile", False)):

--- a/sglang_omni/models/higgs_tts/model.py
+++ b/sglang_omni/models/higgs_tts/model.py
@@ -227,6 +227,10 @@ class HiggsTTSModel(nn.Module):
     def codebook_vocab_size(self) -> int:
         return self._codebook_vocab_size
 
+    @property
+    def sampler_pool_max_running_requests(self) -> int:
+        return self._max_batch_size
+
     def acquire_row(self, req_id: str) -> int:
         """Allocate or look up the sampler-pool row for ``req_id``. Idempotent."""
         row = self._rid_to_row.get(req_id)

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -58,6 +58,9 @@ from sglang_omni.preprocessing.cache_key import (
 )
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
+from sglang_omni.scheduling.generation_batch_policy import (
+    validate_generation_batch_policy,
+)
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler
 from sglang_omni.scheduling.sglang_backend import (
     SGLangOutputProcessor,
@@ -436,15 +439,21 @@ def create_sglang_tts_engine_executor(
         model_config,
     ) = create_sglang_infrastructure(server_args, gpu_id)
 
-    truncate_rope_to_bf16(model_worker.model_runner.model)
+    model = model_worker.model_runner.model
+    truncate_rope_to_bf16(model)
+    validate_generation_batch_policy(
+        model_name="Higgs TTS",
+        server_args=server_args,
+        model_buffer_bs=getattr(model, "_max_batch_size", None),
+        require_cuda_graph_bs=False,
+    )
 
     output_proc = SGLangOutputProcessor(
         capture_hidden=False,
         capture_hidden_layers=None,
-        model=model_worker.model_runner.model,
+        model=model,
     )
     model_runner = HiggsTTSModelRunner(model_worker, output_proc)
-    model = model_worker.model_runner.model
     request_builder, result_adapter = make_higgs_scheduler_adapters(
         model,
         max_new_tokens_cap=max_new_tokens,

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -59,7 +59,7 @@ from sglang_omni.preprocessing.cache_key import (
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
 from sglang_omni.scheduling.generation_batch_policy import (
-    build_power_of_two_cuda_graph_bs,
+    build_default_cuda_graph_bs,
     sync_cuda_graph_bs_with_max_bs,
     validate_generation_batch_policy,
 )
@@ -412,7 +412,7 @@ def create_sglang_tts_engine_executor(
 
     overrides: dict[str, Any] = {
         "disable_cuda_graph": False,
-        "cuda_graph_bs": build_power_of_two_cuda_graph_bs(cuda_graph_max_bs),
+        "cuda_graph_bs": build_default_cuda_graph_bs(cuda_graph_max_bs),
         "cuda_graph_max_bs": cuda_graph_max_bs,
         "mem_fraction_static": 0.85,
         "max_running_requests": max_running_requests,

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -59,6 +59,8 @@ from sglang_omni.preprocessing.cache_key import (
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
 from sglang_omni.scheduling.generation_batch_policy import (
+    build_power_of_two_cuda_graph_bs,
+    sync_cuda_graph_bs_with_max_bs,
     validate_generation_batch_policy,
 )
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler
@@ -410,6 +412,7 @@ def create_sglang_tts_engine_executor(
 
     overrides: dict[str, Any] = {
         "disable_cuda_graph": False,
+        "cuda_graph_bs": build_power_of_two_cuda_graph_bs(cuda_graph_max_bs),
         "cuda_graph_max_bs": cuda_graph_max_bs,
         "mem_fraction_static": 0.85,
         "max_running_requests": max_running_requests,
@@ -421,6 +424,7 @@ def create_sglang_tts_engine_executor(
     }
     if server_args_overrides:
         overrides.update(server_args_overrides)
+        sync_cuda_graph_bs_with_max_bs(overrides, server_args_overrides)
 
     server_args = build_sglang_server_args(
         checkpoint_dir,
@@ -444,8 +448,7 @@ def create_sglang_tts_engine_executor(
     validate_generation_batch_policy(
         model_name="Higgs TTS",
         server_args=server_args,
-        model_buffer_bs=getattr(model, "_max_batch_size", None),
-        require_cuda_graph_bs=False,
+        model_buffer_bs=model.sampler_pool_max_running_requests,
     )
 
     output_proc = SGLangOutputProcessor(

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -23,6 +23,10 @@ from sglang_omni.models.moss_tts.request_builders import (
     set_moss_tts_preprocessing_context,
 )
 from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.generation_batch_policy import (
+    sync_cuda_graph_bs_with_max_bs,
+    validate_generation_batch_policy,
+)
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 from sglang_omni.utils.audio_payload import audio_waveform_payload
 
@@ -239,6 +243,7 @@ def create_sglang_tts_engine_executor(
     }
     if server_args_overrides:
         overrides.update(server_args_overrides)
+        sync_cuda_graph_bs_with_max_bs(overrides, server_args_overrides)
 
     server_args = build_sglang_server_args(
         checkpoint_dir,
@@ -266,6 +271,11 @@ def create_sglang_tts_engine_executor(
 
     if want_cuda_graph:
         server_args.disable_cuda_graph = False
+
+    validate_generation_batch_policy(
+        model_name="MOSS-TTS",
+        server_args=server_args,
+    )
 
     model = model_worker.model_runner.model
     if want_cuda_graph:

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -24,7 +24,7 @@ from sglang_omni.models.moss_tts.request_builders import (
 )
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.generation_batch_policy import (
-    build_power_of_two_cuda_graph_bs,
+    build_default_cuda_graph_bs,
     sync_cuda_graph_bs_with_max_bs,
     validate_generation_batch_policy,
 )
@@ -231,7 +231,7 @@ def create_sglang_tts_engine_executor(
 
     overrides: dict[str, Any] = {
         "dtype": dtype,
-        "cuda_graph_bs": build_power_of_two_cuda_graph_bs(16),
+        "cuda_graph_bs": build_default_cuda_graph_bs(16),
         "cuda_graph_max_bs": 16,
         "disable_cuda_graph": False,
         "disable_overlap_schedule": True,

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -24,6 +24,7 @@ from sglang_omni.models.moss_tts.request_builders import (
 )
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.generation_batch_policy import (
+    build_power_of_two_cuda_graph_bs,
     sync_cuda_graph_bs_with_max_bs,
     validate_generation_batch_policy,
 )
@@ -230,7 +231,7 @@ def create_sglang_tts_engine_executor(
 
     overrides: dict[str, Any] = {
         "dtype": dtype,
-        "cuda_graph_bs": [1, 2, 4, 8, 16],
+        "cuda_graph_bs": build_power_of_two_cuda_graph_bs(16),
         "cuda_graph_max_bs": 16,
         "disable_cuda_graph": False,
         "disable_overlap_schedule": True,

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -35,6 +35,7 @@ from sglang_omni.preprocessing.cache_key import (
     reference_path_cache_key as _reference_path_cache_key,
 )
 from sglang_omni.scheduling.generation_batch_policy import (
+    build_power_of_two_cuda_graph_bs,
     sync_cuda_graph_bs_with_max_bs,
     validate_generation_batch_policy,
 )
@@ -539,7 +540,7 @@ def create_sglang_tts_engine_executor(
 
     overrides: dict[str, Any] = {
         "dtype": dtype,
-        "cuda_graph_bs": [1, 2, 4, 8, 16],
+        "cuda_graph_bs": build_power_of_two_cuda_graph_bs(16),
         "cuda_graph_max_bs": 16,
         "disable_cuda_graph": False,
         "disable_overlap_schedule": True,

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -35,7 +35,7 @@ from sglang_omni.preprocessing.cache_key import (
     reference_path_cache_key as _reference_path_cache_key,
 )
 from sglang_omni.scheduling.generation_batch_policy import (
-    build_power_of_two_cuda_graph_bs,
+    build_default_cuda_graph_bs,
     sync_cuda_graph_bs_with_max_bs,
     validate_generation_batch_policy,
 )
@@ -540,7 +540,7 @@ def create_sglang_tts_engine_executor(
 
     overrides: dict[str, Any] = {
         "dtype": dtype,
-        "cuda_graph_bs": build_power_of_two_cuda_graph_bs(16),
+        "cuda_graph_bs": build_default_cuda_graph_bs(16),
         "cuda_graph_max_bs": 16,
         "disable_cuda_graph": False,
         "disable_overlap_schedule": True,
@@ -628,7 +628,10 @@ def create_sglang_tts_engine_executor(
         # micro-steps and 13 seeded sampling passes per frame): eager it is
         # kernel-launch-bound at ~22 ms/frame independent of batch size.
         model.init_frame_decode_graphs(
-            list(overrides.get("cuda_graph_bs") or [1, 2, 4, 8, 16])
+            list(
+                overrides.get("cuda_graph_bs")
+                or build_default_cuda_graph_bs(int(overrides["cuda_graph_max_bs"]))
+            )
         )
 
     output_proc = SGLangOutputProcessor(

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -34,6 +34,10 @@ from sglang_omni.models.moss_tts_local.streaming_vocoder import (
 from sglang_omni.preprocessing.cache_key import (
     reference_path_cache_key as _reference_path_cache_key,
 )
+from sglang_omni.scheduling.generation_batch_policy import (
+    sync_cuda_graph_bs_with_max_bs,
+    validate_generation_batch_policy,
+)
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 from sglang_omni.scheduling.stage_cache import StageOutputCache
 
@@ -553,6 +557,7 @@ def create_sglang_tts_engine_executor(
         overrides["mem_fraction_static"] = 0.6 if torch.cuda.device_count() > 1 else 0.5
     if server_args_overrides:
         overrides.update(server_args_overrides)
+        sync_cuda_graph_bs_with_max_bs(overrides, server_args_overrides)
     memory_budget = _apply_colocated_ar_memory_budget(
         overrides,
         total_gpu_memory_fraction=total_gpu_memory_fraction,
@@ -609,6 +614,11 @@ def create_sglang_tts_engine_executor(
 
     if want_cuda_graph:
         server_args.disable_cuda_graph = False
+
+    validate_generation_batch_policy(
+        model_name="MOSS-TTS Local",
+        server_args=server_args,
+    )
 
     model = model_worker.model_runner.model
     if want_cuda_graph:

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -30,7 +30,7 @@ from sglang_omni.models.qwen3_omni.request_builders import (
 from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.generation_batch_policy import (
-    build_power_of_two_cuda_graph_bs,
+    build_default_cuda_graph_bs,
     sync_cuda_graph_bs_with_max_bs,
     validate_generation_batch_policy,
 )
@@ -1072,7 +1072,7 @@ def create_talker_ar_executor_from_config(
     # under cuda graph the captured RNG is boot-dependent and ~5% of prompts
     # trigger degenerate AR loops (see #408). Revert once upstream lands.
     overrides: dict[str, Any] = {
-        "cuda_graph_bs": build_power_of_two_cuda_graph_bs(16),
+        "cuda_graph_bs": build_default_cuda_graph_bs(16),
         "cuda_graph_max_bs": 16,
         "disable_cuda_graph": False,
         "max_running_requests": 16,

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -32,6 +32,7 @@ from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.generation_batch_policy import (
     build_power_of_two_cuda_graph_bs,
     sync_cuda_graph_bs_with_max_bs,
+    validate_generation_batch_policy,
 )
 from sglang_omni.scheduling.sglang_backend import (
     apply_encoder_mem_reserve,
@@ -1091,6 +1092,10 @@ def create_talker_ar_executor_from_config(
         model_path,
         context_length=talker_max_seq_len,
         **overrides,
+    )
+    validate_generation_batch_policy(
+        model_name="Qwen3-Omni talker_ar",
+        server_args=server_args,
     )
     pre_load_avail_mem = avail_gpu_mem(gpu_id)
     pre_load_process_mem = get_process_gpu_memory_bytes(gpu_id)

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -29,6 +29,10 @@ from sglang_omni.models.qwen3_omni.request_builders import (
 )
 from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.generation_batch_policy import (
+    build_power_of_two_cuda_graph_bs,
+    sync_cuda_graph_bs_with_max_bs,
+)
 from sglang_omni.scheduling.sglang_backend import (
     apply_encoder_mem_reserve,
     build_sglang_server_args,
@@ -1067,11 +1071,16 @@ def create_talker_ar_executor_from_config(
     # under cuda graph the captured RNG is boot-dependent and ~5% of prompts
     # trigger degenerate AR loops (see #408). Revert once upstream lands.
     overrides: dict[str, Any] = {
+        "cuda_graph_bs": build_power_of_two_cuda_graph_bs(16),
+        "cuda_graph_max_bs": 16,
         "disable_cuda_graph": False,
+        "max_running_requests": 16,
         "sampling_backend": "pytorch",
+        "torch_compile_max_bs": 16,
     }
     if server_args_overrides:
         overrides.update(server_args_overrides)
+        sync_cuda_graph_bs_with_max_bs(overrides, server_args_overrides)
     overrides["tp_size"] = tp_size
     _apply_colocated_ar_memory_contract(
         overrides,

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -21,7 +21,7 @@ from sglang_omni.models.qwen3_tts.request_builders import (
 )
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.generation_batch_policy import (
-    build_power_of_two_cuda_graph_bs,
+    build_default_cuda_graph_bs,
     sync_cuda_graph_bs_with_max_bs,
     validate_generation_batch_policy,
 )
@@ -197,7 +197,7 @@ def create_sglang_tts_engine_executor(
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0
 
     overrides: dict[str, Any] = {
-        "cuda_graph_bs": build_power_of_two_cuda_graph_bs(16),
+        "cuda_graph_bs": build_default_cuda_graph_bs(16),
         "cuda_graph_max_bs": 16,
         "dtype": dtype,
         "disable_cuda_graph": False,

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -23,6 +23,7 @@ from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.generation_batch_policy import (
     build_power_of_two_cuda_graph_bs,
     sync_cuda_graph_bs_with_max_bs,
+    validate_generation_batch_policy,
 )
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 from sglang_omni.utils.audio_payload import audio_waveform_payload
@@ -239,6 +240,11 @@ def create_sglang_tts_engine_executor(
 
     if want_cuda_graph:
         server_args.disable_cuda_graph = False
+
+    validate_generation_batch_policy(
+        model_name="Qwen3-TTS",
+        server_args=server_args,
+    )
 
     model = model_worker.model_runner.model
     speech_tokenizer = _load_qwen3_tts_tokenizer(

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -20,6 +20,10 @@ from sglang_omni.models.qwen3_tts.request_builders import (
     set_qwen3_tts_preprocessing_context,
 )
 from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.generation_batch_policy import (
+    build_power_of_two_cuda_graph_bs,
+    sync_cuda_graph_bs_with_max_bs,
+)
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 from sglang_omni.utils.audio_payload import audio_waveform_payload
 
@@ -192,6 +196,8 @@ def create_sglang_tts_engine_executor(
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0
 
     overrides: dict[str, Any] = {
+        "cuda_graph_bs": build_power_of_two_cuda_graph_bs(16),
+        "cuda_graph_max_bs": 16,
         "dtype": dtype,
         "disable_cuda_graph": False,
         "disable_overlap_schedule": True,
@@ -205,6 +211,7 @@ def create_sglang_tts_engine_executor(
     }
     if server_args_overrides:
         overrides.update(server_args_overrides)
+        sync_cuda_graph_bs_with_max_bs(overrides, server_args_overrides)
 
     server_args = build_sglang_server_args(
         checkpoint_dir,

--- a/sglang_omni/models/voxtral_tts/pipeline/stages.py
+++ b/sglang_omni/models/voxtral_tts/pipeline/stages.py
@@ -19,6 +19,7 @@ from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.generation_batch_policy import (
     build_power_of_two_cuda_graph_bs,
     sync_cuda_graph_bs_with_max_bs,
+    validate_generation_batch_policy,
 )
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 from sglang_omni.utils.audio_payload import audio_waveform_payload
@@ -244,6 +245,11 @@ def create_generation_executor(
 
     if want_cuda_graph:
         server_args.disable_cuda_graph = False
+
+    validate_generation_batch_policy(
+        model_name="Voxtral TTS",
+        server_args=server_args,
+    )
 
     voice_embeddings = _load_voxtral_voice_embeddings(checkpoint_dir, device)
     model = model_worker.model_runner.model

--- a/sglang_omni/models/voxtral_tts/pipeline/stages.py
+++ b/sglang_omni/models/voxtral_tts/pipeline/stages.py
@@ -17,7 +17,7 @@ from sglang_omni.models.voxtral_tts.io import VoxtralTTSState
 from sglang_omni.models.voxtral_tts.pipeline.state_io import load_state, store_state
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.generation_batch_policy import (
-    build_power_of_two_cuda_graph_bs,
+    build_default_cuda_graph_bs,
     sync_cuda_graph_bs_with_max_bs,
     validate_generation_batch_policy,
 )
@@ -203,7 +203,7 @@ def create_generation_executor(
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0
 
     overrides: dict[str, Any] = {
-        "cuda_graph_bs": build_power_of_two_cuda_graph_bs(16),
+        "cuda_graph_bs": build_default_cuda_graph_bs(16),
         "cuda_graph_max_bs": 16,
         "dtype": "bfloat16",
         "disable_cuda_graph": False,

--- a/sglang_omni/models/voxtral_tts/pipeline/stages.py
+++ b/sglang_omni/models/voxtral_tts/pipeline/stages.py
@@ -16,6 +16,10 @@ import torch
 from sglang_omni.models.voxtral_tts.io import VoxtralTTSState
 from sglang_omni.models.voxtral_tts.pipeline.state_io import load_state, store_state
 from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.generation_batch_policy import (
+    build_power_of_two_cuda_graph_bs,
+    sync_cuda_graph_bs_with_max_bs,
+)
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 from sglang_omni.utils.audio_payload import audio_waveform_payload
 
@@ -198,6 +202,8 @@ def create_generation_executor(
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0
 
     overrides: dict[str, Any] = {
+        "cuda_graph_bs": build_power_of_two_cuda_graph_bs(16),
+        "cuda_graph_max_bs": 16,
         "dtype": "bfloat16",
         "disable_cuda_graph": False,
         "disable_overlap_schedule": True,
@@ -211,6 +217,7 @@ def create_generation_executor(
     }
     if server_args_overrides:
         overrides.update(server_args_overrides)
+        sync_cuda_graph_bs_with_max_bs(overrides, server_args_overrides)
 
     server_args = build_sglang_server_args(
         checkpoint_dir,

--- a/sglang_omni/scheduling/generation_batch_policy.py
+++ b/sglang_omni/scheduling/generation_batch_policy.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Generation-stage batch policy helpers for SGLang-backed stages."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class GenerationBatchPolicyReport:
+    model_name: str
+    max_running_requests: int
+    cuda_graph_enabled: bool
+    cuda_graph_max_bs: int | None
+    cuda_graph_bs: tuple[int, ...] | None
+    torch_compile_max_bs: int | None
+    model_buffer_bs: int | None
+
+
+def build_power_of_two_cuda_graph_bs(max_bs: int) -> list[int]:
+    max_bs = int(max_bs)
+    if max_bs < 1:
+        raise ValueError("max_bs must be >= 1")
+
+    values: list[int] = []
+    bs = 1
+    while bs < max_bs:
+        values.append(bs)
+        bs *= 2
+    values.append(max_bs)
+    return values
+
+
+def sync_cuda_graph_bs_with_max_bs(
+    overrides: dict[str, Any],
+    server_args_overrides: dict[str, Any] | None,
+) -> None:
+    if not server_args_overrides:
+        return
+    if (
+        "cuda_graph_max_bs" in server_args_overrides
+        and "cuda_graph_bs" not in server_args_overrides
+    ):
+        overrides["cuda_graph_bs"] = build_power_of_two_cuda_graph_bs(
+            int(overrides["cuda_graph_max_bs"])
+        )
+
+
+def validate_generation_batch_policy(
+    *,
+    model_name: str,
+    server_args: Any,
+    model_buffer_bs: int | None = None,
+    allow_partial_cuda_graph_coverage: bool = False,
+    allow_partial_torch_compile_coverage: bool = False,
+    require_cuda_graph_bs: bool = True,
+    require_full_cuda_graph_coverage: bool = True,
+    require_full_torch_compile_coverage: bool = True,
+) -> GenerationBatchPolicyReport:
+    errors: list[str] = []
+
+    max_running_requests = _read_positive_int(
+        server_args,
+        "max_running_requests",
+        errors,
+    )
+    cuda_graph_enabled = not bool(getattr(server_args, "disable_cuda_graph", False))
+
+    cuda_graph_max_bs: int | None = None
+    cuda_graph_bs: tuple[int, ...] | None = None
+    if cuda_graph_enabled:
+        cuda_graph_max_bs = _read_positive_int(
+            server_args,
+            "cuda_graph_max_bs",
+            errors,
+            required=True,
+        )
+        cuda_graph_bs_value = getattr(server_args, "cuda_graph_bs", None)
+        if cuda_graph_bs_value is None:
+            if require_cuda_graph_bs:
+                errors.append("cuda_graph_bs must be explicit when CUDA graph is enabled")
+        else:
+            cuda_graph_bs = _normalize_cuda_graph_bs(cuda_graph_bs_value, errors)
+
+        if cuda_graph_max_bs is not None and cuda_graph_bs is not None:
+            if max(cuda_graph_bs) != cuda_graph_max_bs:
+                errors.append(
+                    "max(cuda_graph_bs) must match cuda_graph_max_bs "
+                    f"({max(cuda_graph_bs)} != {cuda_graph_max_bs})"
+                )
+
+        if (
+            require_full_cuda_graph_coverage
+            and not allow_partial_cuda_graph_coverage
+            and max_running_requests is not None
+            and cuda_graph_max_bs is not None
+            and cuda_graph_max_bs < max_running_requests
+        ):
+            errors.append(
+                "cuda_graph_max_bs must cover max_running_requests "
+                f"({cuda_graph_max_bs} < {max_running_requests})"
+            )
+
+    torch_compile_max_bs = _read_positive_int(
+        server_args,
+        "torch_compile_max_bs",
+        errors,
+        required=False,
+    )
+    if (
+        require_full_torch_compile_coverage
+        and not allow_partial_torch_compile_coverage
+        and max_running_requests is not None
+        and torch_compile_max_bs is not None
+        and torch_compile_max_bs < max_running_requests
+    ):
+        errors.append(
+            "torch_compile_max_bs must cover max_running_requests "
+            f"({torch_compile_max_bs} < {max_running_requests})"
+        )
+
+    normalized_model_buffer_bs: int | None = None
+    if model_buffer_bs is not None:
+        normalized_model_buffer_bs = int(model_buffer_bs)
+        if normalized_model_buffer_bs < 1:
+            errors.append("model_buffer_bs must be >= 1")
+        if (
+            max_running_requests is not None
+            and normalized_model_buffer_bs < max_running_requests
+        ):
+            errors.append(
+                "model_buffer_bs must cover max_running_requests "
+                f"({normalized_model_buffer_bs} < {max_running_requests})"
+            )
+
+    if errors:
+        raise ValueError(
+            f"{model_name} invalid generation batch policy: " + "; ".join(errors)
+        )
+
+    assert max_running_requests is not None
+    return GenerationBatchPolicyReport(
+        model_name=model_name,
+        max_running_requests=max_running_requests,
+        cuda_graph_enabled=cuda_graph_enabled,
+        cuda_graph_max_bs=cuda_graph_max_bs,
+        cuda_graph_bs=cuda_graph_bs,
+        torch_compile_max_bs=torch_compile_max_bs,
+        model_buffer_bs=normalized_model_buffer_bs,
+    )
+
+
+def _read_positive_int(
+    obj: Any,
+    field: str,
+    errors: list[str],
+    *,
+    required: bool = True,
+) -> int | None:
+    value = getattr(obj, field, None)
+    if value is None:
+        if required:
+            errors.append(f"{field} must be explicit")
+        return None
+    try:
+        normalized = int(value)
+    except (TypeError, ValueError):
+        errors.append(f"{field} must be an integer")
+        return None
+    if normalized < 1:
+        errors.append(f"{field} must be >= 1")
+        return None
+    return normalized
+
+
+def _normalize_cuda_graph_bs(
+    value: Iterable[Any],
+    errors: list[str],
+) -> tuple[int, ...] | None:
+    if isinstance(value, (str, bytes)):
+        errors.append("cuda_graph_bs must be a sequence of positive integers")
+        return None
+
+    try:
+        normalized = tuple(int(item) for item in value)
+    except (TypeError, ValueError):
+        errors.append("cuda_graph_bs must be a sequence of positive integers")
+        return None
+
+    if not normalized:
+        errors.append("cuda_graph_bs must be non-empty")
+        return None
+    if any(item < 1 for item in normalized):
+        errors.append("cuda_graph_bs values must be >= 1")
+        return None
+    if tuple(sorted(set(normalized))) != normalized:
+        errors.append("cuda_graph_bs must be strictly increasing")
+        return None
+    return normalized

--- a/sglang_omni/scheduling/generation_batch_policy.py
+++ b/sglang_omni/scheduling/generation_batch_policy.py
@@ -20,17 +20,18 @@ class GenerationBatchPolicyReport:
     model_buffer_bs: int | None
 
 
-def build_power_of_two_cuda_graph_bs(max_bs: int) -> list[int]:
+def build_default_cuda_graph_bs(max_bs: int) -> list[int]:
     max_bs = int(max_bs)
     if max_bs < 1:
         raise ValueError("max_bs must be >= 1")
 
-    values: list[int] = []
-    bs = 1
-    while bs < max_bs:
-        values.append(bs)
-        bs *= 2
-    values.append(max_bs)
+    values = [1, 2, 4, 8, 12]
+    values.extend(range(16, 257, 8))
+    values.extend(range(272, 512, 16))
+    values.extend(range(512, max_bs + 1, 32))
+    values = [bs for bs in values if bs <= max_bs]
+    if not values or values[-1] != max_bs:
+        values.append(max_bs)
     return values
 
 
@@ -44,7 +45,7 @@ def sync_cuda_graph_bs_with_max_bs(
         "cuda_graph_max_bs" in server_args_overrides
         and "cuda_graph_bs" not in server_args_overrides
     ):
-        overrides["cuda_graph_bs"] = build_power_of_two_cuda_graph_bs(
+        overrides["cuda_graph_bs"] = build_default_cuda_graph_bs(
             int(overrides["cuda_graph_max_bs"])
         )
 

--- a/sglang_omni/scheduling/generation_batch_policy.py
+++ b/sglang_omni/scheduling/generation_batch_policy.py
@@ -15,6 +15,7 @@ class GenerationBatchPolicyReport:
     cuda_graph_enabled: bool
     cuda_graph_max_bs: int | None
     cuda_graph_bs: tuple[int, ...] | None
+    torch_compile_enabled: bool
     torch_compile_max_bs: int | None
     model_buffer_bs: int | None
 
@@ -53,11 +54,6 @@ def validate_generation_batch_policy(
     model_name: str,
     server_args: Any,
     model_buffer_bs: int | None = None,
-    allow_partial_cuda_graph_coverage: bool = False,
-    allow_partial_torch_compile_coverage: bool = False,
-    require_cuda_graph_bs: bool = True,
-    require_full_cuda_graph_coverage: bool = True,
-    require_full_torch_compile_coverage: bool = True,
 ) -> GenerationBatchPolicyReport:
     errors: list[str] = []
 
@@ -79,8 +75,7 @@ def validate_generation_batch_policy(
         )
         cuda_graph_bs_value = getattr(server_args, "cuda_graph_bs", None)
         if cuda_graph_bs_value is None:
-            if require_cuda_graph_bs:
-                errors.append("cuda_graph_bs must be explicit when CUDA graph is enabled")
+            errors.append("cuda_graph_bs must be explicit when CUDA graph is enabled")
         else:
             cuda_graph_bs = _normalize_cuda_graph_bs(cuda_graph_bs_value, errors)
 
@@ -92,9 +87,7 @@ def validate_generation_batch_policy(
                 )
 
         if (
-            require_full_cuda_graph_coverage
-            and not allow_partial_cuda_graph_coverage
-            and max_running_requests is not None
+            max_running_requests is not None
             and cuda_graph_max_bs is not None
             and cuda_graph_max_bs < max_running_requests
         ):
@@ -103,15 +96,15 @@ def validate_generation_batch_policy(
                 f"({cuda_graph_max_bs} < {max_running_requests})"
             )
 
+    torch_compile_enabled = bool(getattr(server_args, "enable_torch_compile", False))
     torch_compile_max_bs = _read_positive_int(
         server_args,
         "torch_compile_max_bs",
         errors,
-        required=False,
+        required=torch_compile_enabled,
     )
     if (
-        require_full_torch_compile_coverage
-        and not allow_partial_torch_compile_coverage
+        torch_compile_enabled
         and max_running_requests is not None
         and torch_compile_max_bs is not None
         and torch_compile_max_bs < max_running_requests
@@ -147,6 +140,7 @@ def validate_generation_batch_policy(
         cuda_graph_enabled=cuda_graph_enabled,
         cuda_graph_max_bs=cuda_graph_max_bs,
         cuda_graph_bs=cuda_graph_bs,
+        torch_compile_enabled=torch_compile_enabled,
         torch_compile_max_bs=torch_compile_max_bs,
         model_buffer_bs=normalized_model_buffer_bs,
     )

--- a/tests/README.md
+++ b/tests/README.md
@@ -86,6 +86,7 @@ tests/
     │   ├── test_stop_run_id.py
     │   └── test_views.py
     ├── serve/
+    │   ├── test_generation_batch_policy.py
     │   ├── test_generation_server_args.py
     │   └── test_openai_api.py
     ├── fishaudio_s2_pro/

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -282,9 +282,12 @@ def test_s2pro_compile_helper_targets_forward_kvcached(
     assert audio_decoder._compiled_forward_kvcached_max_bs == 2
 
 
-def test_s2pro_engine_disables_generic_compile_after_local_compile(
+def _run_s2pro_engine_with_fake_buffers(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
+    *,
+    text_buffer_bs: int = 64,
+    audio_buffer_bs: int = 64,
+) -> SimpleNamespace:
     stages = importlib.import_module("sglang_omni.models.fishaudio_s2_pro.stages")
     monkeypatch.setattr(stages, "_resolve_checkpoint", lambda model_path: model_path)
 
@@ -300,7 +303,7 @@ def test_s2pro_engine_disables_generic_compile_after_local_compile(
 
         def init_device_graphs(self) -> None:
             assert self.server_args.enable_torch_compile is False
-            assert self.server_args.torch_compile_max_bs == 16
+            assert self.server_args.torch_compile_max_bs == 64
             init_graph_calls.append(True)
 
     class _FakeWorker:
@@ -311,12 +314,20 @@ def test_s2pro_engine_disables_generic_compile_after_local_compile(
     fake_bootstrap.patch_fish_config_for_sglang = lambda: None
     fake_bootstrap.truncate_rope_to_bf16 = lambda model: None
     fake_bootstrap.load_audio_decoder = lambda checkpoint_dir, device: (
-        SimpleNamespace(),
+        SimpleNamespace(kv_cache_max_batch_size=-1),
         10,
         4096,
         FakeFishTokenizer(),
     )
-    fake_bootstrap.bootstrap_text_model_for_decode = lambda **kwargs: None
+
+    def fake_bootstrap_text_model_for_decode(**kwargs: object) -> None:
+        text_model = kwargs["text_model"]
+        audio_decoder = kwargs["audio_decoder"]
+        text_model.vq_decode_max_batch_size = text_buffer_bs
+        text_model._audio_decoder = audio_decoder
+        audio_decoder.kv_cache_max_batch_size = audio_buffer_bs
+
+    fake_bootstrap.bootstrap_text_model_for_decode = fake_bootstrap_text_model_for_decode
 
     def fake_build_sglang_server_args(
         model_path: str,
@@ -412,20 +423,60 @@ def test_s2pro_engine_disables_generic_compile_after_local_compile(
     monkeypatch.setattr(stages, "_compile_s2pro_codebook_decoder", fake_compile)
 
     scheduler = stages.create_sglang_tts_engine_executor("model", device="cuda:0")
+    return SimpleNamespace(
+        scheduler=scheduler,
+        build_kwargs=build_kwargs,
+        infrastructure_saw_graph_disabled=infrastructure_saw_graph_disabled,
+        compile_calls=compile_calls,
+        init_graph_calls=init_graph_calls,
+    )
+
+
+def test_s2pro_engine_disables_generic_compile_after_local_compile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = _run_s2pro_engine_with_fake_buffers(monkeypatch)
+    scheduler = result.scheduler
+    build_kwargs = result.build_kwargs
 
     assert build_kwargs["enable_torch_compile"] is True
     assert build_kwargs["max_running_requests"] == 64
     assert build_kwargs["cuda_graph_max_bs"] == 64
     assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 16, 32, 64]
-    assert build_kwargs["torch_compile_max_bs"] == 16
-    assert infrastructure_saw_graph_disabled == [True]
-    assert compile_calls == [(scheduler.model_runner.args[0].model_runner.model, 16)]
-    assert init_graph_calls == [True]
+    assert build_kwargs["torch_compile_max_bs"] == 64
+    assert result.infrastructure_saw_graph_disabled == [True]
+    assert result.compile_calls == [
+        (scheduler.model_runner.args[0].model_runner.model, 64)
+    ]
+    assert result.init_graph_calls == [True]
     assert scheduler.server_args.disable_cuda_graph is False
     assert scheduler.server_args.enable_torch_compile is False
     assert scheduler.server_args.cuda_graph_max_bs == 64
     assert scheduler.server_args.cuda_graph_bs == [1, 2, 4, 8, 16, 32, 64]
-    assert scheduler.server_args.torch_compile_max_bs == 16
+    assert scheduler.server_args.torch_compile_max_bs == 64
+
+
+@pytest.mark.parametrize(
+    "text_buffer_bs,audio_buffer_bs",
+    [
+        (32, 64),
+        (64, 32),
+    ],
+)
+def test_s2pro_engine_validates_allocated_decode_buffers(
+    monkeypatch: pytest.MonkeyPatch,
+    text_buffer_bs: int,
+    audio_buffer_bs: int,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match="model_buffer_bs must cover max_running_requests",
+    ):
+        _run_s2pro_engine_with_fake_buffers(
+            monkeypatch,
+            text_buffer_bs=text_buffer_bs,
+            audio_buffer_bs=audio_buffer_bs,
+        )
 
 
 def test_decoder_forward_kvcached_obeys_compiled_batch_size_cap() -> None:

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -442,7 +442,20 @@ def test_s2pro_engine_disables_generic_compile_after_local_compile(
     assert build_kwargs["enable_torch_compile"] is True
     assert build_kwargs["max_running_requests"] == 64
     assert build_kwargs["cuda_graph_max_bs"] == 64
-    assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 16, 32, 64]
+    assert build_kwargs["cuda_graph_bs"] == [
+        1,
+        2,
+        4,
+        8,
+        12,
+        16,
+        24,
+        32,
+        40,
+        48,
+        56,
+        64,
+    ]
     assert build_kwargs["torch_compile_max_bs"] == 64
     assert result.infrastructure_saw_graph_disabled == [True]
     assert result.compile_calls == [
@@ -452,7 +465,20 @@ def test_s2pro_engine_disables_generic_compile_after_local_compile(
     assert scheduler.server_args.disable_cuda_graph is False
     assert scheduler.server_args.enable_torch_compile is False
     assert scheduler.server_args.cuda_graph_max_bs == 64
-    assert scheduler.server_args.cuda_graph_bs == [1, 2, 4, 8, 16, 32, 64]
+    assert scheduler.server_args.cuda_graph_bs == [
+        1,
+        2,
+        4,
+        8,
+        12,
+        16,
+        24,
+        32,
+        40,
+        48,
+        56,
+        64,
+    ]
     assert scheduler.server_args.torch_compile_max_bs == 64
 
 

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -327,7 +327,9 @@ def _run_s2pro_engine_with_fake_buffers(
         text_model._audio_decoder = audio_decoder
         audio_decoder.kv_cache_max_batch_size = audio_buffer_bs
 
-    fake_bootstrap.bootstrap_text_model_for_decode = fake_bootstrap_text_model_for_decode
+    fake_bootstrap.bootstrap_text_model_for_decode = (
+        fake_bootstrap_text_model_for_decode
+    )
 
     def fake_build_sglang_server_args(
         model_path: str,

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -330,6 +330,8 @@ def test_s2pro_engine_disables_generic_compile_after_local_compile(
             enable_torch_compile=kwargs["enable_torch_compile"],
             torch_compile_max_bs=kwargs["torch_compile_max_bs"],
             max_running_requests=kwargs["max_running_requests"],
+            cuda_graph_max_bs=kwargs["cuda_graph_max_bs"],
+            cuda_graph_bs=kwargs["cuda_graph_bs"],
             page_size=1,
             chunked_prefill_size=kwargs["chunked_prefill_size"],
             max_prefill_tokens=16384,
@@ -412,12 +414,17 @@ def test_s2pro_engine_disables_generic_compile_after_local_compile(
     scheduler = stages.create_sglang_tts_engine_executor("model", device="cuda:0")
 
     assert build_kwargs["enable_torch_compile"] is True
+    assert build_kwargs["max_running_requests"] == 64
+    assert build_kwargs["cuda_graph_max_bs"] == 64
+    assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 16, 32, 64]
     assert build_kwargs["torch_compile_max_bs"] == 16
     assert infrastructure_saw_graph_disabled == [True]
     assert compile_calls == [(scheduler.model_runner.args[0].model_runner.model, 16)]
     assert init_graph_calls == [True]
     assert scheduler.server_args.disable_cuda_graph is False
     assert scheduler.server_args.enable_torch_compile is False
+    assert scheduler.server_args.cuda_graph_max_bs == 64
+    assert scheduler.server_args.cuda_graph_bs == [1, 2, 4, 8, 16, 32, 64]
     assert scheduler.server_args.torch_compile_max_bs == 16
 
 

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -38,6 +38,8 @@ def test_higgs_tts_engine_enables_cuda_graph_by_default(monkeypatch) -> None:
         server_args = SimpleNamespace(
             disable_cuda_graph=overrides["disable_cuda_graph"],
             disable_overlap_schedule=False,
+            max_running_requests=overrides["max_running_requests"],
+            cuda_graph_max_bs=overrides["cuda_graph_max_bs"],
         )
         captured["checkpoint_dir"] = checkpoint_dir
         captured["context_length"] = context_length
@@ -47,7 +49,10 @@ def test_higgs_tts_engine_enables_cuda_graph_by_default(monkeypatch) -> None:
 
     def fake_create_sglang_infrastructure(server_args, gpu_id):
         captured["gpu_id"] = gpu_id
-        model = SimpleNamespace(reset_request=lambda _request_id: None)
+        model = SimpleNamespace(
+            _max_batch_size=64,
+            reset_request=lambda _request_id: None,
+        )
         return (
             SimpleNamespace(model_runner=SimpleNamespace(model=model)),
             object(),

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -112,7 +112,20 @@ def test_higgs_tts_engine_enables_cuda_graph_by_default(monkeypatch) -> None:
     assert captured["context_length"] == 4096
     assert captured["gpu_id"] == 0
     assert captured["overrides"]["disable_cuda_graph"] is False
-    assert captured["overrides"]["cuda_graph_bs"] == [1, 2, 4, 8, 16, 32, 64]
+    assert captured["overrides"]["cuda_graph_bs"] == [
+        1,
+        2,
+        4,
+        8,
+        12,
+        16,
+        24,
+        32,
+        40,
+        48,
+        56,
+        64,
+    ]
     assert captured["overrides"]["cuda_graph_max_bs"] == 64
     assert captured["overrides"]["max_running_requests"] == 64
     assert captured["server_args"].disable_overlap_schedule is True

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -38,8 +38,11 @@ def test_higgs_tts_engine_enables_cuda_graph_by_default(monkeypatch) -> None:
         server_args = SimpleNamespace(
             disable_cuda_graph=overrides["disable_cuda_graph"],
             disable_overlap_schedule=False,
+            enable_torch_compile=False,
             max_running_requests=overrides["max_running_requests"],
             cuda_graph_max_bs=overrides["cuda_graph_max_bs"],
+            cuda_graph_bs=overrides["cuda_graph_bs"],
+            torch_compile_max_bs=32,
         )
         captured["checkpoint_dir"] = checkpoint_dir
         captured["context_length"] = context_length
@@ -50,7 +53,7 @@ def test_higgs_tts_engine_enables_cuda_graph_by_default(monkeypatch) -> None:
     def fake_create_sglang_infrastructure(server_args, gpu_id):
         captured["gpu_id"] = gpu_id
         model = SimpleNamespace(
-            _max_batch_size=64,
+            sampler_pool_max_running_requests=64,
             reset_request=lambda _request_id: None,
         )
         return (
@@ -109,9 +112,12 @@ def test_higgs_tts_engine_enables_cuda_graph_by_default(monkeypatch) -> None:
     assert captured["context_length"] == 4096
     assert captured["gpu_id"] == 0
     assert captured["overrides"]["disable_cuda_graph"] is False
+    assert captured["overrides"]["cuda_graph_bs"] == [1, 2, 4, 8, 16, 32, 64]
     assert captured["overrides"]["cuda_graph_max_bs"] == 64
     assert captured["overrides"]["max_running_requests"] == 64
     assert captured["server_args"].disable_overlap_schedule is True
+    assert captured["server_args"].enable_torch_compile is False
+    assert captured["server_args"].torch_compile_max_bs == 32
     assert captured["adapter_kwargs"] == {"max_new_tokens_cap": 2048}
     assert (
         captured["stream_outbox"]

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -152,6 +152,10 @@ def test_moss_tts_engine_uses_auto_mem_fraction_by_default(monkeypatch) -> None:
         return SimpleNamespace(
             disable_cuda_graph=kwargs["disable_cuda_graph"],
             disable_overlap_schedule=False,
+            max_running_requests=kwargs["max_running_requests"],
+            cuda_graph_max_bs=kwargs["cuda_graph_max_bs"],
+            cuda_graph_bs=kwargs["cuda_graph_bs"],
+            torch_compile_max_bs=kwargs.get("torch_compile_max_bs"),
         )
 
     def fake_create_sglang_infrastructure(

--- a/tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
+++ b/tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
@@ -10,6 +10,7 @@ from sglang.srt.model_executor.model_runner_kv_cache_mixin import (
 )
 
 import sglang_omni.model_runner.sglang_model_runner as runner_mod
+import sglang_omni.models.qwen3_omni.bootstrap as qwen_bootstrap
 import sglang_omni.models.qwen3_omni.stages as qwen_stages
 
 
@@ -240,3 +241,77 @@ def test_qwen_colocated_thinker_explicit_mem_fraction_skips_default_reserve(
     ]
     assert "effective_total_gpu_memory_fraction=0.75" in caplog.text
     assert "encoder_mem_reserve=0.0" in caplog.text
+
+
+def test_qwen_talker_ar_threads_explicit_generation_batch_policy(monkeypatch) -> None:
+    build_calls: list[dict[str, object]] = []
+    scheduler_calls: list[dict[str, object]] = []
+
+    def _fake_server_args_builder(model_path, context_length, **overrides):
+        assert model_path == "dummy"
+        assert context_length == 4096
+        build_calls.append(dict(overrides))
+        return SimpleNamespace(
+            mem_fraction_static=0.55,
+            sampling_backend=overrides["sampling_backend"],
+            max_running_requests=overrides["max_running_requests"],
+            cuda_graph_max_bs=overrides["cuda_graph_max_bs"],
+            cuda_graph_bs=overrides["cuda_graph_bs"],
+            torch_compile_max_bs=overrides["torch_compile_max_bs"],
+        )
+
+    def _fake_create_talker_scheduler(server_args, gpu_id, **kwargs):
+        scheduler_calls.append(
+            {
+                "gpu_id": gpu_id,
+                "sampling_backend": server_args.sampling_backend,
+                "max_running_requests": server_args.max_running_requests,
+                "cuda_graph_max_bs": server_args.cuda_graph_max_bs,
+                "cuda_graph_bs": server_args.cuda_graph_bs,
+                "torch_compile_max_bs": server_args.torch_compile_max_bs,
+                "weight_prefix": kwargs["weight_prefix"],
+            }
+        )
+        return object()
+
+    monkeypatch.setattr(
+        qwen_stages,
+        "build_sglang_server_args",
+        _fake_server_args_builder,
+    )
+    monkeypatch.setattr(
+        qwen_bootstrap,
+        "create_talker_scheduler",
+        _fake_create_talker_scheduler,
+    )
+    monkeypatch.setattr(qwen_stages, "avail_gpu_mem", lambda gpu_id: 90.0)
+    monkeypatch.setattr(
+        qwen_stages,
+        "get_process_gpu_memory_bytes",
+        lambda gpu_id: None,
+    )
+
+    qwen_stages.create_talker_ar_executor_from_config("dummy")
+
+    assert build_calls == [
+        {
+            "cuda_graph_bs": [1, 2, 4, 8, 16],
+            "cuda_graph_max_bs": 16,
+            "disable_cuda_graph": False,
+            "max_running_requests": 16,
+            "sampling_backend": "pytorch",
+            "torch_compile_max_bs": 16,
+            "tp_size": 1,
+        }
+    ]
+    assert scheduler_calls == [
+        {
+            "gpu_id": 0,
+            "sampling_backend": "pytorch",
+            "max_running_requests": 16,
+            "cuda_graph_max_bs": 16,
+            "cuda_graph_bs": [1, 2, 4, 8, 16],
+            "torch_compile_max_bs": 16,
+            "weight_prefix": "talker.",
+        }
+    ]

--- a/tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
+++ b/tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
@@ -295,7 +295,7 @@ def test_qwen_talker_ar_threads_explicit_generation_batch_policy(monkeypatch) ->
 
     assert build_calls == [
         {
-            "cuda_graph_bs": [1, 2, 4, 8, 16],
+            "cuda_graph_bs": [1, 2, 4, 8, 12, 16],
             "cuda_graph_max_bs": 16,
             "disable_cuda_graph": False,
             "max_running_requests": 16,
@@ -310,7 +310,7 @@ def test_qwen_talker_ar_threads_explicit_generation_batch_policy(monkeypatch) ->
             "sampling_backend": "pytorch",
             "max_running_requests": 16,
             "cuda_graph_max_bs": 16,
-            "cuda_graph_bs": [1, 2, 4, 8, 16],
+            "cuda_graph_bs": [1, 2, 4, 8, 12, 16],
             "torch_compile_max_bs": 16,
             "weight_prefix": "talker.",
         }

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -1991,6 +1991,8 @@ def test_qwen3_tts_engine_applies_compat_overrides_and_reenables_cuda_graph(
             chunked_prefill_size=0,
             max_prefill_tokens=kwargs["max_prefill_tokens"],
             max_running_requests=kwargs["max_running_requests"],
+            cuda_graph_max_bs=kwargs["cuda_graph_max_bs"],
+            cuda_graph_bs=kwargs["cuda_graph_bs"],
             torch_compile_max_bs=kwargs["torch_compile_max_bs"],
         )
 
@@ -2044,6 +2046,8 @@ def test_qwen3_tts_engine_applies_compat_overrides_and_reenables_cuda_graph(
     assert build_kwargs["sampling_backend"] == "pytorch"
     assert build_kwargs["mem_fraction_static"] == 0.7
     assert build_kwargs["max_running_requests"] == 2
+    assert build_kwargs["cuda_graph_max_bs"] == 16
+    assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 16]
     assert build_kwargs["torch_compile_max_bs"] == 16
 
     def target():
@@ -2073,5 +2077,7 @@ def test_qwen3_tts_engine_applies_compat_overrides_and_reenables_cuda_graph(
     assert init_graph_calls == [True]
     assert scheduler.server_args.disable_cuda_graph is False
     assert scheduler.server_args.enable_torch_compile is False
+    assert scheduler.server_args.cuda_graph_max_bs == 16
+    assert scheduler.server_args.cuda_graph_bs == [1, 2, 4, 8, 16]
     assert scheduler.server_args.torch_compile_max_bs == 16
     clear_qwen3_tts_preprocessing_context()

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -2047,7 +2047,7 @@ def test_qwen3_tts_engine_applies_compat_overrides_and_reenables_cuda_graph(
     assert build_kwargs["mem_fraction_static"] == 0.7
     assert build_kwargs["max_running_requests"] == 2
     assert build_kwargs["cuda_graph_max_bs"] == 16
-    assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 16]
+    assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 12, 16]
     assert build_kwargs["torch_compile_max_bs"] == 16
 
     def target():
@@ -2078,6 +2078,6 @@ def test_qwen3_tts_engine_applies_compat_overrides_and_reenables_cuda_graph(
     assert scheduler.server_args.disable_cuda_graph is False
     assert scheduler.server_args.enable_torch_compile is False
     assert scheduler.server_args.cuda_graph_max_bs == 16
-    assert scheduler.server_args.cuda_graph_bs == [1, 2, 4, 8, 16]
+    assert scheduler.server_args.cuda_graph_bs == [1, 2, 4, 8, 12, 16]
     assert scheduler.server_args.torch_compile_max_bs == 16
     clear_qwen3_tts_preprocessing_context()

--- a/tests/unit_test/serve/test_generation_batch_policy.py
+++ b/tests/unit_test/serve/test_generation_batch_policy.py
@@ -20,6 +20,7 @@ def _server_args(**overrides: object) -> SimpleNamespace:
         "disable_cuda_graph": False,
         "cuda_graph_max_bs": 16,
         "cuda_graph_bs": [1, 2, 4, 8, 16],
+        "enable_torch_compile": True,
         "torch_compile_max_bs": 16,
     }
     values.update(overrides)
@@ -43,6 +44,7 @@ def test_validate_generation_batch_policy_reports_explicit_full_policy() -> None
     assert report.cuda_graph_enabled is True
     assert report.cuda_graph_max_bs == 16
     assert report.cuda_graph_bs == (1, 2, 4, 8, 16)
+    assert report.torch_compile_enabled is True
     assert report.torch_compile_max_bs == 16
     assert report.model_buffer_bs == 16
 
@@ -63,8 +65,8 @@ def test_validate_generation_batch_policy_rejects_mismatched_cuda_graph_max() ->
         )
 
 
-def test_validate_generation_batch_policy_requires_compile_coverage_or_exception() -> None:
-    partial_compile = _server_args(
+def test_validate_generation_batch_policy_requires_enabled_compile_coverage() -> None:
+    undercovered_compile = _server_args(
         max_running_requests=64,
         cuda_graph_max_bs=64,
         cuda_graph_bs=[1, 2, 4, 8, 16, 32, 64],
@@ -73,14 +75,22 @@ def test_validate_generation_batch_policy_requires_compile_coverage_or_exception
     with pytest.raises(ValueError, match="torch_compile_max_bs must cover"):
         validate_generation_batch_policy(
             model_name="test-model",
-            server_args=partial_compile,
+            server_args=undercovered_compile,
         )
 
+
+def test_validate_generation_batch_policy_ignores_disabled_compile_cap() -> None:
     report = validate_generation_batch_policy(
         model_name="test-model",
-        server_args=partial_compile,
-        allow_partial_torch_compile_coverage=True,
+        server_args=_server_args(
+            max_running_requests=64,
+            cuda_graph_max_bs=64,
+            cuda_graph_bs=[1, 2, 4, 8, 16, 32, 64],
+            enable_torch_compile=False,
+            torch_compile_max_bs=16,
+        ),
     )
+    assert report.torch_compile_enabled is False
     assert report.torch_compile_max_bs == 16
 
 

--- a/tests/unit_test/serve/test_generation_batch_policy.py
+++ b/tests/unit_test/serve/test_generation_batch_policy.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Generation-stage batch policy validation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from sglang_omni.scheduling.generation_batch_policy import (
+    build_power_of_two_cuda_graph_bs,
+    sync_cuda_graph_bs_with_max_bs,
+    validate_generation_batch_policy,
+)
+
+
+def _server_args(**overrides: object) -> SimpleNamespace:
+    values: dict[str, object] = {
+        "max_running_requests": 16,
+        "disable_cuda_graph": False,
+        "cuda_graph_max_bs": 16,
+        "cuda_graph_bs": [1, 2, 4, 8, 16],
+        "torch_compile_max_bs": 16,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_power_of_two_cuda_graph_bs_includes_requested_max() -> None:
+    assert build_power_of_two_cuda_graph_bs(1) == [1]
+    assert build_power_of_two_cuda_graph_bs(16) == [1, 2, 4, 8, 16]
+    assert build_power_of_two_cuda_graph_bs(24) == [1, 2, 4, 8, 16, 24]
+
+
+def test_validate_generation_batch_policy_reports_explicit_full_policy() -> None:
+    report = validate_generation_batch_policy(
+        model_name="test-model",
+        server_args=_server_args(),
+        model_buffer_bs=16,
+    )
+
+    assert report.max_running_requests == 16
+    assert report.cuda_graph_enabled is True
+    assert report.cuda_graph_max_bs == 16
+    assert report.cuda_graph_bs == (1, 2, 4, 8, 16)
+    assert report.torch_compile_max_bs == 16
+    assert report.model_buffer_bs == 16
+
+
+def test_validate_generation_batch_policy_rejects_implicit_cuda_graph_bs() -> None:
+    with pytest.raises(ValueError, match="cuda_graph_bs must be explicit"):
+        validate_generation_batch_policy(
+            model_name="test-model",
+            server_args=_server_args(cuda_graph_bs=None),
+        )
+
+
+def test_validate_generation_batch_policy_rejects_mismatched_cuda_graph_max() -> None:
+    with pytest.raises(ValueError, match=r"max\(cuda_graph_bs\) must match"):
+        validate_generation_batch_policy(
+            model_name="test-model",
+            server_args=_server_args(cuda_graph_max_bs=32),
+        )
+
+
+def test_validate_generation_batch_policy_requires_compile_coverage_or_exception() -> None:
+    partial_compile = _server_args(
+        max_running_requests=64,
+        cuda_graph_max_bs=64,
+        cuda_graph_bs=[1, 2, 4, 8, 16, 32, 64],
+        torch_compile_max_bs=16,
+    )
+    with pytest.raises(ValueError, match="torch_compile_max_bs must cover"):
+        validate_generation_batch_policy(
+            model_name="test-model",
+            server_args=partial_compile,
+        )
+
+    report = validate_generation_batch_policy(
+        model_name="test-model",
+        server_args=partial_compile,
+        allow_partial_torch_compile_coverage=True,
+    )
+    assert report.torch_compile_max_bs == 16
+
+
+def test_validate_generation_batch_policy_rejects_under_sized_model_buffer() -> None:
+    with pytest.raises(ValueError, match="model_buffer_bs must cover"):
+        validate_generation_batch_policy(
+            model_name="test-model",
+            server_args=_server_args(max_running_requests=4),
+            model_buffer_bs=2,
+        )
+
+
+def test_sync_cuda_graph_bs_with_max_bs_preserves_explicit_list() -> None:
+    overrides: dict[str, object] = {
+        "cuda_graph_max_bs": 16,
+        "cuda_graph_bs": [1, 2, 4, 8, 16],
+    }
+    server_args_overrides = {"cuda_graph_max_bs": 32, "cuda_graph_bs": [1, 4, 32]}
+    overrides.update(server_args_overrides)
+    sync_cuda_graph_bs_with_max_bs(overrides, server_args_overrides)
+    assert overrides["cuda_graph_bs"] == [1, 4, 32]
+
+
+def test_sync_cuda_graph_bs_with_max_bs_fills_missing_list() -> None:
+    overrides: dict[str, object] = {"cuda_graph_max_bs": 32}
+    sync_cuda_graph_bs_with_max_bs(overrides, {"cuda_graph_max_bs": 32})
+    assert overrides["cuda_graph_bs"] == [1, 2, 4, 8, 16, 32]

--- a/tests/unit_test/serve/test_generation_batch_policy.py
+++ b/tests/unit_test/serve/test_generation_batch_policy.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from sglang_omni.scheduling.generation_batch_policy import (
-    build_power_of_two_cuda_graph_bs,
+    build_default_cuda_graph_bs,
     sync_cuda_graph_bs_with_max_bs,
     validate_generation_batch_policy,
 )
@@ -19,7 +19,7 @@ def _server_args(**overrides: object) -> SimpleNamespace:
         "max_running_requests": 16,
         "disable_cuda_graph": False,
         "cuda_graph_max_bs": 16,
-        "cuda_graph_bs": [1, 2, 4, 8, 16],
+        "cuda_graph_bs": [1, 2, 4, 8, 12, 16],
         "enable_torch_compile": True,
         "torch_compile_max_bs": 16,
     }
@@ -27,10 +27,24 @@ def _server_args(**overrides: object) -> SimpleNamespace:
     return SimpleNamespace(**values)
 
 
-def test_power_of_two_cuda_graph_bs_includes_requested_max() -> None:
-    assert build_power_of_two_cuda_graph_bs(1) == [1]
-    assert build_power_of_two_cuda_graph_bs(16) == [1, 2, 4, 8, 16]
-    assert build_power_of_two_cuda_graph_bs(24) == [1, 2, 4, 8, 16, 24]
+def test_default_cuda_graph_bs_matches_sglang_normal_buckets() -> None:
+    assert build_default_cuda_graph_bs(1) == [1]
+    assert build_default_cuda_graph_bs(16) == [1, 2, 4, 8, 12, 16]
+    assert build_default_cuda_graph_bs(24) == [1, 2, 4, 8, 12, 16, 24]
+    assert build_default_cuda_graph_bs(64) == [
+        1,
+        2,
+        4,
+        8,
+        12,
+        16,
+        24,
+        32,
+        40,
+        48,
+        56,
+        64,
+    ]
 
 
 def test_validate_generation_batch_policy_reports_explicit_full_policy() -> None:
@@ -43,7 +57,7 @@ def test_validate_generation_batch_policy_reports_explicit_full_policy() -> None
     assert report.max_running_requests == 16
     assert report.cuda_graph_enabled is True
     assert report.cuda_graph_max_bs == 16
-    assert report.cuda_graph_bs == (1, 2, 4, 8, 16)
+    assert report.cuda_graph_bs == (1, 2, 4, 8, 12, 16)
     assert report.torch_compile_enabled is True
     assert report.torch_compile_max_bs == 16
     assert report.model_buffer_bs == 16
@@ -69,7 +83,7 @@ def test_validate_generation_batch_policy_requires_enabled_compile_coverage() ->
     undercovered_compile = _server_args(
         max_running_requests=64,
         cuda_graph_max_bs=64,
-        cuda_graph_bs=[1, 2, 4, 8, 16, 32, 64],
+        cuda_graph_bs=[1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64],
         torch_compile_max_bs=16,
     )
     with pytest.raises(ValueError, match="torch_compile_max_bs must cover"):
@@ -85,7 +99,7 @@ def test_validate_generation_batch_policy_ignores_disabled_compile_cap() -> None
         server_args=_server_args(
             max_running_requests=64,
             cuda_graph_max_bs=64,
-            cuda_graph_bs=[1, 2, 4, 8, 16, 32, 64],
+            cuda_graph_bs=[1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64],
             enable_torch_compile=False,
             torch_compile_max_bs=16,
         ),
@@ -106,7 +120,7 @@ def test_validate_generation_batch_policy_rejects_under_sized_model_buffer() -> 
 def test_sync_cuda_graph_bs_with_max_bs_preserves_explicit_list() -> None:
     overrides: dict[str, object] = {
         "cuda_graph_max_bs": 16,
-        "cuda_graph_bs": [1, 2, 4, 8, 16],
+        "cuda_graph_bs": [1, 2, 4, 8, 12, 16],
     }
     server_args_overrides = {"cuda_graph_max_bs": 32, "cuda_graph_bs": [1, 4, 32]}
     overrides.update(server_args_overrides)
@@ -117,4 +131,4 @@ def test_sync_cuda_graph_bs_with_max_bs_preserves_explicit_list() -> None:
 def test_sync_cuda_graph_bs_with_max_bs_fills_missing_list() -> None:
     overrides: dict[str, object] = {"cuda_graph_max_bs": 32}
     sync_cuda_graph_bs_with_max_bs(overrides, {"cuda_graph_max_bs": 32})
-    assert overrides["cuda_graph_bs"] == [1, 2, 4, 8, 16, 32]
+    assert overrides["cuda_graph_bs"] == [1, 2, 4, 8, 12, 16, 24, 32]

--- a/tests/unit_test/voxtral_tts/test_pipeline.py
+++ b/tests/unit_test/voxtral_tts/test_pipeline.py
@@ -502,14 +502,14 @@ def test_voxtral_generation_reenables_cuda_graph_after_bootstrap(
     assert build_kwargs["enable_torch_compile"] is True
     assert build_kwargs["sampling_backend"] == "pytorch"
     assert build_kwargs["cuda_graph_max_bs"] == 16
-    assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 16]
+    assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 12, 16]
     assert build_kwargs["torch_compile_max_bs"] == 16
     assert infrastructure_saw_graph_disabled == [True]
     assert init_graph_calls == [True]
     assert scheduler.server_args.disable_cuda_graph is False
     assert scheduler.server_args.enable_torch_compile is True
     assert scheduler.server_args.cuda_graph_max_bs == 16
-    assert scheduler.server_args.cuda_graph_bs == [1, 2, 4, 8, 16]
+    assert scheduler.server_args.cuda_graph_bs == [1, 2, 4, 8, 12, 16]
     assert scheduler.server_args.torch_compile_max_bs == 16
 
 

--- a/tests/unit_test/voxtral_tts/test_pipeline.py
+++ b/tests/unit_test/voxtral_tts/test_pipeline.py
@@ -452,6 +452,8 @@ def test_voxtral_generation_reenables_cuda_graph_after_bootstrap(
             chunked_prefill_size=0,
             max_prefill_tokens=kwargs["max_prefill_tokens"],
             max_running_requests=kwargs["max_running_requests"],
+            cuda_graph_max_bs=kwargs["cuda_graph_max_bs"],
+            cuda_graph_bs=kwargs["cuda_graph_bs"],
             torch_compile_max_bs=kwargs["torch_compile_max_bs"],
         )
 
@@ -499,11 +501,15 @@ def test_voxtral_generation_reenables_cuda_graph_after_bootstrap(
     assert build_kwargs["disable_cuda_graph"] is False
     assert build_kwargs["enable_torch_compile"] is True
     assert build_kwargs["sampling_backend"] == "pytorch"
+    assert build_kwargs["cuda_graph_max_bs"] == 16
+    assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 16]
     assert build_kwargs["torch_compile_max_bs"] == 16
     assert infrastructure_saw_graph_disabled == [True]
     assert init_graph_calls == [True]
     assert scheduler.server_args.disable_cuda_graph is False
     assert scheduler.server_args.enable_torch_compile is True
+    assert scheduler.server_args.cuda_graph_max_bs == 16
+    assert scheduler.server_args.cuda_graph_bs == [1, 2, 4, 8, 16]
     assert scheduler.server_args.torch_compile_max_bs == 16
 
 


### PR DESCRIPTION
## Summary

Addresses Workstream 1 from #836.

- Add a reusable generation batch policy report/validator for SGLang-backed generation stages.
- Standardize explicit CUDA graph batch policy construction and override syncing for generation stages.
- Use explicit CUDA graph batch lists that match SGLang's normal default capture buckets, so validation does not narrow graph coverage.
- Remove the old partial/require validation knobs: CUDA graph now requires explicit `cuda_graph_bs` and full `max_running_requests` coverage when enabled.
- Enforce `torch_compile_max_bs` coverage only when `enable_torch_compile=True`; S2-Pro now uses 64/64/64 for `max_running_requests`, `cuda_graph_max_bs`, and `torch_compile_max_bs`.
- Validate model-side batch buffers for Higgs TTS and FishAudio S2-Pro using explicit model properties / allocated buffer capacity.

## TTS Coverage

Covered models/stages: Higgs TTS, MOSS-TTS, MOSS-TTS Local, Qwen3-TTS, Voxtral TTS, FishAudio S2-Pro, and Qwen3-Omni talker AR.

## Validation

- `python -m pytest tests/unit_test/serve/test_generation_batch_policy.py tests/unit_test/higgs_tts/test_pipeline.py tests/unit_test/fishaudio_s2_pro/test_pipeline.py tests/unit_test/moss_tts/test_pipeline.py tests/unit_test/moss_tts_local/test_pipeline.py tests/unit_test/qwen3_tts/test_pipeline.py tests/unit_test/voxtral_tts/test_pipeline.py tests/unit_test/qwen3_omni/test_sglang_ar_budget.py -q` -> 233 passed
- `git diff --check` -> passed

Generation-only benchmark comparison, same H100 GPU/container. Baseline is `origin/main` at `8a41fc4`; PR is `f2a886c`. Suspicious/noisy rows were repeated to 3 total runs. For repeated rows, values are median (min-max), and delta uses medians. Qwen3-TTS baseline uses a rerun to replace the original outlier run1.

| Model | Samples / concurrency | Runs | PR req/s | Baseline req/s | Req delta | PR audio s/s | Baseline audio s/s | Audio delta | PR latency mean (s) | Baseline latency mean (s) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Higgs TTS | 1088 / 16 | 1 | 15.473 | 15.410 | +0.4% | 64.928 | 64.527 | +0.6% | 1.028 | 1.032 |
| FishAudio S2-Pro | 256 / 64 | 3 | 1.268 (1.259-1.338) | 1.320 (1.303-1.384) | -3.9% | 4.792 (4.761-5.069) | 4.990 (4.916-5.235) | -4.0% | 44.929 (42.551-45.151) | 43.178 (41.108-43.686) |
| MOSS-TTS | 256 / 16 | 3 | 3.933 (3.854-4.021) | 3.864 (3.521-4.051) | +1.8% | 17.044 (16.707-17.416) | 16.753 (15.260-17.522) | +1.7% | 3.996 (3.908-4.081) | 4.066 (3.885-4.479) |
| Voxtral TTS | 50 / 16 | 3 | 7.453 (7.325-7.637) | 7.321 (5.918-7.731) | +1.8% | 39.615 (39.354-41.008) | 39.169 (31.274-42.132) | +1.1% | 1.960 (1.877-1.999) | 2.005 (1.844-2.472) |
| Qwen3-TTS 0.6B | 50 / 16 | 3 | 2.537 (2.466-2.554) | 2.606 (2.562-2.628) | -2.6% | 10.091 (9.752-10.550) | 10.591 (10.461-10.858) | -4.7% | 5.398 (5.346-5.554) | 5.444 (5.181-5.462) |

Notes:
- S2-Pro startup confirmed PR Fast AR compile `max_batch_size=64` and CUDA graph batches `[1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64]`. Baseline compiled Fast AR with `max_batch_size=16` and the same CUDA graph buckets.
- Qwen3-TTS baseline original run1 was retested and excluded from the table because it generated many more output tokens (`4542`) and had p99 latency `47.441s`. The rerun normalized to `2509` output tokens, `2.606` req/s, and p99 latency `10.527s`.
- Voxtral had a single-run baseline outlier. After repeats, the large single-run speedup is not stable, so this PR does not claim it as a real gain.
- Artifact roots: `/data/sglang-omni-profile-runs/pr843-bench-defaultcg-20260621`, `/data/sglang-omni-profile-runs/pr843-baseline-main-20260621`, and `/data/sglang-omni-profile-runs/pr843-repeat-20260621`.
