### PR TITLE
Add CUDA graph batch validator for SGLang generation stages (#836 W1)

### DIFF
--- a/sglang_omni/utils/cuda_graph_batch_validator.py
+++ b/sglang_omni/utils/cuda_graph_batch_validator.py
@@ -1,0 +1,432 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Validate CUDA graph batch coverage for SGLang-backed generation stages."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _BufferProbe:
+    """Per-model ``(label, fn)`` extractors reading the allocated buffer first dim."""
+
+    extractors: tuple[tuple[str, Callable[[Any], int]], ...]
+    note: str = ""
+
+
+_BUFFER_PROBES: dict[str, _BufferProbe] = {
+    "HiggsTTSModel": _BufferProbe(
+        (
+            ("_sampler_pool.seeds", lambda m: m._sampler_pool.seeds.shape[0]),
+            ("_cg_codes_BN", lambda m: m._cg_codes_BN.shape[0]),
+            ("_cg_active_last_codes", lambda m: m._cg_active_last_codes.shape[0]),
+        ),
+        note="sampler pool = max_running_requests + 1 (one reserved padding row)",
+    ),
+    "Qwen3TTSTalker": _BufferProbe(
+        (("_feedback_buffer", lambda m: m._feedback_buffer.shape[0]),)
+    ),
+    "MossTTSDelaySGLangModel": _BufferProbe(
+        (
+            (
+                "_decode_input_embedding.weight",
+                lambda m: m._decode_input_embedding.weight.shape[0],
+            ),
+        )
+    ),
+    "MossTTSLocalSGLangModel": _BufferProbe(
+        (
+            (
+                "_decode_input_embedding.weight",
+                lambda m: m._decode_input_embedding.weight.shape[0],
+            ),
+        )
+    ),
+    "S2ProSGLangTextModel": _BufferProbe(
+        (("_vq_codes", lambda m: m._vq_codes.shape[0]),),
+        note="allocated only after setup_vq_decode()",
+    ),
+    "VoxtralSGLangTTSModel": _BufferProbe(
+        (
+            (
+                "_decode_input_embed_buffer",
+                lambda m: m._decode_input_embed_buffer.shape[0],
+            ),
+        )
+    ),
+    "Qwen3OmniTalker": _BufferProbe(
+        (("_feedback_buffer", lambda m: m._feedback_buffer.shape[0]),)
+    ),
+}
+
+
+@dataclass(frozen=True)
+class CudaGraphBatchReport:
+    """Outcome of validating one stage's CUDA graph batch sizing."""
+
+    stage: str
+    max_running_requests: int | None
+    cuda_graph_max_bs: int | None
+    captured_bs: list[int] | None
+    request_slots: int | None
+    buffer_capacity: int | None
+    buffer_source: str | None
+    ok: bool
+    findings: list[str] = field(default_factory=list)
+
+    @property
+    def max_captured_bs(self) -> int | None:
+        return max(self.captured_bs) if self.captured_bs else None
+
+    def format(self) -> str:
+        """Render a human-readable multi-line report."""
+        lines = [f"Stage: {self.stage}"]
+        lines.append(
+            "  serving config:     "
+            f"max_running_requests={self.max_running_requests}, "
+            f"cuda_graph_max_bs={self.cuda_graph_max_bs}"
+        )
+        lines.append(
+            f"  captured graph bs:  {self.captured_bs} "
+            f"(max captured = {self.max_captured_bs})"
+        )
+        lines.append(f"  request slots:      {self.request_slots}")
+        lines.append(
+            f"  model-side buffers: {self.buffer_capacity} " f"[{self.buffer_source}]"
+        )
+        lines.append(f"  VERDICT: {'OK' if self.ok else 'MISMATCH'}")
+        for finding in self.findings:
+            lines.append(f"    - {finding}")
+        return "\n".join(lines)
+
+
+def evaluate_cuda_graph_batch_sizing(
+    *,
+    stage: str,
+    max_running_requests: int | None,
+    cuda_graph_max_bs: int | None,
+    captured_bs: list[int] | None,
+    request_slots: int | None,
+    buffer_capacity: int | None,
+    buffer_source: str | None = None,
+) -> CudaGraphBatchReport:
+    """Compare the three batch-size facts and produce a verdict."""
+    findings: list[str] = []
+    ok = True
+
+    captured = [b for b in (captured_bs or []) if b is not None]
+    max_captured = max(captured) if captured else None
+
+    if buffer_capacity is not None and max_captured is not None:
+        if max_captured > buffer_capacity:
+            ok = False
+            findings.append(
+                f"graphs captured up to bs={max_captured} but model-side "
+                f"buffer holds {buffer_capacity}; capture/replay above "
+                f"{buffer_capacity} overruns the model buffer."
+            )
+    elif buffer_capacity is None:
+        findings.append(
+            f"model-side buffer not read ({buffer_source}); validated serving "
+            f"config vs. captured sizes only."
+        )
+
+    if (
+        buffer_capacity is not None
+        and max_running_requests is not None
+        and buffer_capacity < max_running_requests
+    ):
+        ok = False
+        findings.append(
+            f"model-side buffer ({buffer_capacity}) is smaller than "
+            f"max_running_requests ({max_running_requests}); peak concurrency "
+            f"cannot be served."
+        )
+
+    if ok and not findings:
+        findings.append(
+            "captured sizes and model-side buffer track the serving config."
+        )
+
+    return CudaGraphBatchReport(
+        stage=stage,
+        max_running_requests=max_running_requests,
+        cuda_graph_max_bs=cuda_graph_max_bs,
+        captured_bs=captured or None,
+        request_slots=request_slots,
+        buffer_capacity=buffer_capacity,
+        buffer_source=buffer_source,
+        ok=ok,
+        findings=findings,
+    )
+
+
+def read_captured_bs(model_runner: object) -> list[int] | None:
+    """Read the actually-captured CUDA graph batch sizes, or None if absent."""
+    try:
+        captured = model_runner.graph_runner.capture_bs
+    except AttributeError:
+        logger.debug(
+            "cuda_graph_batch_validator: model_runner.graph_runner.capture_bs "
+            "missing (CUDA graphs disabled)."
+        )
+        return None
+    try:
+        sizes = sorted(int(b) for b in captured)
+    except (TypeError, ValueError):
+        logger.warning(
+            "cuda_graph_batch_validator: capture_bs is not an iterable of "
+            "ints (%r).",
+            captured,
+        )
+        return None
+    return sizes or None
+
+
+def read_model_buffer_capacity(model: object) -> tuple[int | None, str]:
+    """Return ``(min_capacity, source)`` over the model's registered buffers.
+
+    A model may register several per-request buffers; the safe capacity is the
+    smallest one, so all that resolve are read and the minimum is returned.
+    """
+    if model is None:
+        return None, "no model object on runner"
+
+    cls = type(model).__name__
+    probe = _BUFFER_PROBES.get(cls)
+    if probe is None:
+        return None, f"no buffer probe registered for model class {cls!r}"
+
+    candidates = [("model", model)]
+    try:
+        inner = model.model
+    except AttributeError:
+        inner = None
+    if inner is not None and inner is not model:
+        candidates.append(("model.model", inner))
+
+    smallest: int | None = None
+    source = ""
+    for where, obj in candidates:
+        for label, extract in probe.extractors:
+            try:
+                dim = int(extract(obj))
+            except (AttributeError, TypeError, ValueError, IndexError):
+                continue
+            if smallest is None or dim < smallest:
+                smallest = dim
+                source = f"{where}.{label}.shape[0]"
+
+    if smallest is None:
+        labels = ", ".join(label for label, _ in probe.extractors)
+        return None, (
+            f"model class {cls!r} registered but none of its buffers resolved "
+            f"({labels}); buffer may not be allocated yet"
+        )
+
+    if probe.note:
+        source += f" ({probe.note})"
+    return smallest, source
+
+
+def validate_stage(
+    stage_name: str,
+    model_runner: object,
+    *,
+    buffer_capacity: int | None = None,
+) -> CudaGraphBatchReport:
+    """Validate one SGLang-backed stage's batch sizing from its live runner."""
+    try:
+        server_args = model_runner.server_args
+        max_running_requests = server_args.max_running_requests
+        cuda_graph_max_bs = server_args.cuda_graph_max_bs
+    except AttributeError:
+        max_running_requests = None
+        cuda_graph_max_bs = None
+
+    try:
+        request_slots = model_runner.req_to_token_pool.size
+    except AttributeError:
+        request_slots = None
+
+    captured_bs = read_captured_bs(model_runner)
+
+    try:
+        model = model_runner.model
+    except AttributeError:
+        model = None
+    if buffer_capacity is None:
+        buffer_capacity, buffer_source = read_model_buffer_capacity(model)
+    else:
+        buffer_source = "caller-provided"
+
+    model_cls = type(model).__name__ if model is not None else "unknown-model"
+
+    return evaluate_cuda_graph_batch_sizing(
+        stage=f"{stage_name} ({model_cls})",
+        max_running_requests=max_running_requests,
+        cuda_graph_max_bs=cuda_graph_max_bs,
+        captured_bs=captured_bs,
+        request_slots=request_slots,
+        buffer_capacity=buffer_capacity,
+        buffer_source=buffer_source,
+    )
+
+
+_SGLANG_FACTORY_MARKERS = (
+    "create_sglang",
+    "_thinker_executor_from_config",
+    "_talker_ar_executor_from_config",
+    "create_generation_executor",
+)
+
+
+def sglang_stage_names(pipeline_config: object) -> list[str]:
+    """Return the names of stages whose factory is SGLang-backed."""
+    try:
+        stages = pipeline_config.stages or []
+    except AttributeError:
+        return []
+    names: list[str] = []
+    for stage in stages:
+        try:
+            name = stage.name
+            factory = stage.factory or ""
+        except AttributeError:
+            continue
+        if name and any(marker in factory for marker in _SGLANG_FACTORY_MARKERS):
+            names.append(name)
+    return names
+
+
+@dataclass(frozen=True)
+class CustomGraphReport:
+    """Frame-coverage report for a non-SGLang stage with its own CUDA graphs."""
+
+    stage: str
+    captured_frames: list[int] | None
+    slot_capacity: int | None
+    ok: bool = True
+    findings: list[str] = field(default_factory=list)
+
+    def format(self) -> str:
+        lines = [f"Stage: {self.stage} (custom graph)"]
+        lines.append(f"  captured frames (T): {self.captured_frames}")
+        lines.append(f"  slot capacity:       {self.slot_capacity}")
+        lines.append("  VERDICT: OK (coverage report)")
+        for finding in self.findings:
+            lines.append(f"    - {finding}")
+        return "\n".join(lines)
+
+
+@dataclass(frozen=True)
+class NoGraphReport:
+    """Report for a stage that has no CUDA graph to validate."""
+
+    stage: str
+    reason: str = ""
+    ok: bool = True
+
+    def format(self) -> str:
+        lines = [f"Stage: {self.stage} (no CUDA graph)"]
+        lines.append("  VERDICT: OK (no CUDA graph enabled; nothing to flag)")
+        if self.reason:
+            lines.append(f"    - {self.reason}")
+        return "\n".join(lines)
+
+
+def _read_custom_graph_report(
+    stage_name: str, scheduler: object
+) -> CustomGraphReport | None:
+    """Coverage report for the MOSS streaming vocoder, or None if not one."""
+    try:
+        session = scheduler._session
+        has_graph = session.has_cuda_graph_runner()
+    except AttributeError:
+        return None
+    if not has_graph:
+        return None
+
+    try:
+        captured = sorted(session.captured_frames())
+    except AttributeError:
+        captured = None
+    try:
+        slot_capacity = session._batch_size
+    except AttributeError:
+        slot_capacity = None
+
+    findings: list[str] = []
+    if captured:
+        findings.append(
+            f"captured {len(captured)} frame-size graph(s) up to T={max(captured)}; "
+            f"uncaptured frame sizes fall back to eager."
+        )
+    findings.append(
+        f"graphs are keyed by frame count T against a fixed slot pool "
+        f"({slot_capacity}); batch is bounded by the slot allocator, not by a "
+        f"serving max_running_requests, so the SGLang batch-overrun check does "
+        f"not apply here."
+    )
+    return CustomGraphReport(
+        stage=f"{stage_name} ({type(scheduler).__name__})",
+        captured_frames=captured,
+        slot_capacity=slot_capacity,
+        findings=findings,
+    )
+
+
+def _resolve_sglang_model_runner(scheduler: object) -> object | None:
+    """Return the SGLang ModelRunner from a scheduler, or None if non-SGLang."""
+    try:
+        return scheduler.tp_worker.model_runner
+    except AttributeError:
+        pass
+
+    try:
+        return scheduler._model_runner.tp_worker.model_runner
+    except AttributeError:
+        return None
+
+
+def validate_stage_scheduler(
+    stage_name: str,
+    scheduler: object,
+):
+    """Validate any stage from its scheduler; always returns a report."""
+    model_runner = _resolve_sglang_model_runner(scheduler)
+    if model_runner is not None:
+        if read_captured_bs(model_runner) is None:
+            try:
+                model = model_runner.model
+            except AttributeError:
+                model = None
+            model_cls = type(model).__name__ if model is not None else "unknown-model"
+            return NoGraphReport(
+                stage=f"{stage_name} ({model_cls})",
+                reason="SGLang stage with no captured CUDA graph "
+                "(cuda_graph disabled or capture skipped).",
+            )
+        return validate_stage(stage_name, model_runner)
+
+    custom = _read_custom_graph_report(stage_name, scheduler)
+    if custom is not None:
+        return custom
+
+    return NoGraphReport(
+        stage=f"{stage_name} ({type(scheduler).__name__})",
+        reason="stage captures no CUDA graphs.",
+    )
+
+
+def validate_stages(stage_schedulers):
+    """Validate every ``(stage_name, scheduler)`` pair; one report each."""
+    return [
+        validate_stage_scheduler(stage_name, scheduler)
+        for stage_name, scheduler in stage_schedulers
+    ]

--- a/tests/unit_test/model_runner/test_cuda_graph_batch_validator.py
+++ b/tests/unit_test/model_runner/test_cuda_graph_batch_validator.py
@@ -1,0 +1,499 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU unit tests for the CUDA graph batch validator (mocked objects, no GPU)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import sglang_omni.utils.cuda_graph_batch_validator as cgv
+from sglang_omni.utils.cuda_graph_batch_validator import (
+    CudaGraphBatchReport,
+    CustomGraphReport,
+    NoGraphReport,
+    evaluate_cuda_graph_batch_sizing,
+    read_captured_bs,
+    read_model_buffer_capacity,
+    sglang_stage_names,
+    validate_stage,
+    validate_stage_scheduler,
+    validate_stages,
+)
+
+
+class _FakeTensor:
+    """Minimal stand-in for a torch tensor exposing only ``.shape``."""
+
+    def __init__(self, first_dim: int):
+        self.shape = (first_dim, 8)
+
+
+def _fake_runner(
+    *,
+    model=None,
+    max_running_requests=64,
+    cuda_graph_max_bs=64,
+    capture_bs=None,
+    request_slots=64,
+    has_graph_runner=True,
+):
+    graph_runner = SimpleNamespace(capture_bs=capture_bs) if has_graph_runner else None
+    return SimpleNamespace(
+        server_args=SimpleNamespace(
+            max_running_requests=max_running_requests,
+            cuda_graph_max_bs=cuda_graph_max_bs,
+        ),
+        req_to_token_pool=SimpleNamespace(size=request_slots),
+        graph_runner=graph_runner,
+        model=model,
+    )
+
+
+# --- pure verdict logic ---------------------------------------------------
+
+
+def test_consistent_sizing_is_ok():
+    report = evaluate_cuda_graph_batch_sizing(
+        stage="tts_engine",
+        max_running_requests=64,
+        cuda_graph_max_bs=64,
+        captured_bs=[1, 2, 4, 8, 16, 32, 64],
+        request_slots=64,
+        buffer_capacity=65,
+    )
+    assert report.ok
+    assert report.max_captured_bs == 64
+
+
+def test_captured_exceeds_buffer_is_flagged():
+    report = evaluate_cuda_graph_batch_sizing(
+        stage="tts_engine",
+        max_running_requests=64,
+        cuda_graph_max_bs=128,
+        captured_bs=[1, 16, 64, 128],
+        request_slots=128,
+        buffer_capacity=65,
+    )
+    assert not report.ok
+    assert any("overruns the model buffer" in f for f in report.findings)
+
+
+def test_buffer_below_admission_limit_flagged():
+    report = evaluate_cuda_graph_batch_sizing(
+        stage="tts_engine",
+        max_running_requests=64,
+        cuda_graph_max_bs=64,
+        captured_bs=[1, 16, 32],
+        request_slots=64,
+        buffer_capacity=32,
+    )
+    assert not report.ok
+    assert any("cannot be served" in f for f in report.findings)
+
+
+def test_clamped_cap_is_not_a_failure():
+    report = evaluate_cuda_graph_batch_sizing(
+        stage="talker_ar",
+        max_running_requests=16,
+        cuda_graph_max_bs=64,
+        captured_bs=[1, 2, 4, 8, 16],
+        request_slots=16,
+        buffer_capacity=17,
+    )
+    assert report.ok
+    assert not any("clamped" in f for f in report.findings)
+
+
+def test_missing_buffer_validates_partial():
+    report = evaluate_cuda_graph_batch_sizing(
+        stage="voxtral_tts",
+        max_running_requests=16,
+        cuda_graph_max_bs=16,
+        captured_bs=[1, 8, 16],
+        request_slots=16,
+        buffer_capacity=None,
+        buffer_source="no buffer probe registered",
+    )
+    assert report.ok
+    assert any("model-side buffer not read" in f for f in report.findings)
+
+
+# --- captured-bs reader ---------------------------------------------------
+
+
+def test_read_captured_bs_sorts_and_ints():
+    runner = _fake_runner(capture_bs=[64, 1, 16, 4])
+    assert read_captured_bs(runner) == [1, 4, 16, 64]
+
+
+def test_read_captured_bs_missing_capture_returns_none():
+    runner = _fake_runner(has_graph_runner=True, capture_bs=None)
+    assert read_captured_bs(runner) is None
+
+
+def test_read_captured_bs_no_graph_runner_returns_none():
+    runner = _fake_runner(has_graph_runner=False)
+    assert read_captured_bs(runner) is None
+
+
+def test_read_captured_bs_malformed_element_degrades_to_none():
+    runner = _fake_runner(capture_bs=[1, 16, "auto"])
+    assert read_captured_bs(runner) is None
+
+
+def test_read_captured_bs_empty_list_is_none():
+    runner = _fake_runner(capture_bs=[])
+    assert read_captured_bs(runner) is None
+
+
+# --- model-side buffer reader ---------------------------------------------
+
+
+def _as_named(_unused, clsname, **attrs):
+    """Build an object whose ``type().__name__ == clsname`` carrying attrs."""
+    obj = type(clsname, (), {})()
+    for k, v in attrs.items():
+        setattr(obj, k, v)
+    return obj
+
+
+def test_read_buffer_higgs_sampler_pool():
+    model = _as_named(
+        None,
+        "HiggsTTSModel",
+        _sampler_pool=SimpleNamespace(seeds=_FakeTensor(65)),
+    )
+    cap, source = read_model_buffer_capacity(model)
+    assert cap == 65
+    assert "_sampler_pool.seeds.shape[0]" in source
+
+
+def test_read_buffer_returns_minimum_across_registered_buffers():
+    model = _as_named(
+        None,
+        "HiggsTTSModel",
+        _sampler_pool=SimpleNamespace(seeds=_FakeTensor(65)),
+        _cg_codes_BN=_FakeTensor(40),
+        _cg_active_last_codes=_FakeTensor(65),
+    )
+    cap, source = read_model_buffer_capacity(model)
+    assert cap == 40
+    assert "_cg_codes_BN.shape[0]" in source
+
+
+def test_read_buffer_qwen3_tts_feedback():
+    model = _as_named(None, "Qwen3TTSTalker", _feedback_buffer=_FakeTensor(64))
+    cap, source = read_model_buffer_capacity(model)
+    assert cap == 64
+    assert "_feedback_buffer.shape[0]" in source
+
+
+def test_read_buffer_inner_submodule_fallback():
+    inner = _as_named(None, "Inner", _feedback_buffer=_FakeTensor(32))
+    model = _as_named(None, "Qwen3OmniTalker", model=inner)
+    cap, source = read_model_buffer_capacity(model)
+    assert cap == 32
+    assert source.startswith("model.model.")
+
+
+def test_read_buffer_qwen3_omni_prefers_top_level_alias():
+    inner = _as_named(None, "TextModel", _feedback_buffer=_FakeTensor(48))
+    model = _as_named(
+        None, "Qwen3OmniTalker", model=inner, _feedback_buffer=inner._feedback_buffer
+    )
+    cap, source = read_model_buffer_capacity(model)
+    assert cap == 48
+    assert source == "model._feedback_buffer.shape[0]"
+
+
+def test_read_buffer_unregistered_model():
+    model = _as_named(None, "TotallyUnknownModel")
+    cap, source = read_model_buffer_capacity(model)
+    assert cap is None
+    assert "no buffer probe registered" in source
+
+
+def test_read_buffer_registered_but_unallocated():
+    model = _as_named(None, "S2ProSGLangTextModel")
+    cap, source = read_model_buffer_capacity(model)
+    assert cap is None
+    assert "none of its buffers resolved" in source
+
+
+def test_read_buffer_none_model():
+    cap, source = read_model_buffer_capacity(None)
+    assert cap is None
+    assert "no model object" in source
+
+
+# --- per-stage validation (auto buffer read) ------------------------------
+
+
+def test_validate_stage_auto_reads_buffer_and_passes():
+    model = _as_named(None, "Qwen3TTSTalker", _feedback_buffer=_FakeTensor(64))
+    runner = _fake_runner(model=model, capture_bs=[1, 2, 4, 8, 16, 32, 64])
+    report = validate_stage("tts_engine", runner)
+    assert report.buffer_capacity == 64
+    assert report.stage == "tts_engine (Qwen3TTSTalker)"
+    assert report.ok
+
+
+def test_validate_stage_detects_undersized_buffer_end_to_end():
+    model = _as_named(
+        None, "VoxtralSGLangTTSModel", _decode_input_embed_buffer=_FakeTensor(64)
+    )
+    runner = _fake_runner(
+        model=model,
+        max_running_requests=128,
+        cuda_graph_max_bs=128,
+        capture_bs=[1, 16, 64, 128],
+        request_slots=128,
+    )
+    report = validate_stage("tts_generation", runner)
+    assert report.buffer_capacity == 64
+    assert not report.ok
+    assert any("overruns the model buffer" in f for f in report.findings)
+
+
+def test_validate_stage_caller_override_buffer():
+    model = _as_named(None, "TotallyUnknownModel")
+    runner = _fake_runner(model=model, capture_bs=[1, 16, 64])
+    report = validate_stage("tts_engine", runner, buffer_capacity=65)
+    assert report.buffer_capacity == 65
+    assert report.buffer_source == "caller-provided"
+
+
+def test_validate_stage_unregistered_model_partial_report():
+    model = _as_named(None, "TotallyUnknownModel")
+    runner = _fake_runner(model=model, capture_bs=[1, 16, 64])
+    report = validate_stage("tts_engine", runner)
+    assert report.buffer_capacity is None
+    assert report.ok
+    assert any("model-side buffer not read" in f for f in report.findings)
+
+
+def test_validate_stage_names_the_stage():
+    model = _as_named(None, "Qwen3TTSTalker", _feedback_buffer=_FakeTensor(64))
+    runner = _fake_runner(model=model, capture_bs=[1, 16, 64])
+    out = validate_stage("talker_ar", runner).format()
+    assert "Stage: talker_ar (Qwen3TTSTalker)" in out
+    assert "VERDICT:" in out
+    assert "model-side buffers:" in out
+
+
+# --- per-stage enumeration -------------------------------------------------
+
+
+def _stage(name, factory):
+    return SimpleNamespace(name=name, factory=factory)
+
+
+def test_enumerate_single_sglang_stage_tts():
+    cfg = SimpleNamespace(
+        stages=[
+            _stage("preprocessing", "pkg.stages.create_preprocessing_executor"),
+            _stage("tts_engine", "pkg.stages.create_sglang_tts_engine_executor"),
+            _stage("vocoder", "pkg.stages.create_vocoder_executor"),
+        ]
+    )
+    assert sglang_stage_names(cfg) == ["tts_engine"]
+
+
+def test_enumerate_qwen3_omni_has_two_sglang_stages():
+    cfg = SimpleNamespace(
+        stages=[
+            _stage("preprocessing", "pkg.stages.create_preprocessing_executor"),
+            _stage("audio_encoder", "pkg.stages.create_audio_encoder_executor"),
+            _stage("thinker", "pkg.stages.create_sglang_thinker_executor_from_config"),
+            _stage("decode", "pkg.stages.create_decode_executor"),
+            _stage("talker_ar", "pkg.stages.create_talker_ar_executor_from_config"),
+            _stage(
+                "code2wav",
+                "pkg.components.code2wav_scheduler.create_code2wav_scheduler",
+            ),
+        ]
+    )
+    assert sglang_stage_names(cfg) == ["thinker", "talker_ar"]
+
+
+def test_enumerate_voxtral_generation_stage():
+    cfg = SimpleNamespace(
+        stages=[
+            _stage("preprocessing", "pkg.stages.create_preprocessing_executor"),
+            _stage("tts_generation", "pkg.pipeline.stages.create_generation_executor"),
+            _stage("vocoder", "pkg.stages.create_vocoder_executor"),
+        ]
+    )
+    assert sglang_stage_names(cfg) == ["tts_generation"]
+
+
+def test_enumerate_empty_when_no_sglang_stage():
+    cfg = SimpleNamespace(
+        stages=[
+            _stage("preprocessing", "pkg.stages.create_preprocessing_executor"),
+            _stage("vocoder", "pkg.stages.create_vocoder_executor"),
+        ]
+    )
+    assert sglang_stage_names(cfg) == []
+
+
+# --- runtime scheduler guard ----------------------------------------------
+
+
+def test_validate_scheduler_runs_for_sglang_stage():
+    model = _as_named(None, "Qwen3TTSTalker", _feedback_buffer=_FakeTensor(64))
+    runner = _fake_runner(model=model, capture_bs=[1, 16, 64])
+    scheduler = SimpleNamespace(tp_worker=SimpleNamespace(model_runner=runner))
+    report = validate_stage_scheduler("tts_engine", scheduler)
+    assert isinstance(report, CudaGraphBatchReport)
+    assert report.stage == "tts_engine (Qwen3TTSTalker)"
+
+
+def test_validate_scheduler_plain_stage_gets_no_graph_report():
+    scheduler = SimpleNamespace(process_one=lambda x: x)
+    report = validate_stage_scheduler("preprocessing", scheduler)
+    assert isinstance(report, NoGraphReport)
+    assert report.ok
+    assert "no CUDA graph" in report.format()
+
+
+def test_validate_scheduler_fish_wrapped_runner_resolves():
+    model = _as_named(None, "S2ProSGLangTextModel", _vq_codes=_FakeTensor(64))
+    runner = _fake_runner(model=model, capture_bs=[1, 16, 64])
+    fish_scheduler = type("FishScheduler", (), {})()
+    fish_scheduler._model_runner = SimpleNamespace(
+        tp_worker=SimpleNamespace(model_runner=runner)
+    )
+    report = validate_stage_scheduler("tts_engine", fish_scheduler)
+    assert isinstance(report, CudaGraphBatchReport)
+    assert report.buffer_capacity == 64
+    assert "S2ProSGLangTextModel" in report.stage
+
+
+def test_validate_scheduler_sglang_graphs_disabled_gets_no_graph_report():
+    model = _as_named(None, "Qwen3TTSTalker", _feedback_buffer=_FakeTensor(64))
+    runner = _fake_runner(model=model, capture_bs=None)
+    scheduler = SimpleNamespace(tp_worker=SimpleNamespace(model_runner=runner))
+    report = validate_stage_scheduler("tts_engine", scheduler)
+    assert isinstance(report, NoGraphReport)
+    assert "Qwen3TTSTalker" in report.stage
+    assert report.ok
+
+
+# --- custom-graph (non-SGLang) stage coverage -----------------------------
+
+
+def _fake_moss_vocoder_scheduler(*, captured, batch_size, has_runner=True):
+    session = SimpleNamespace(
+        has_cuda_graph_runner=lambda: has_runner,
+        captured_frames=lambda: list(captured),
+        _batch_size=batch_size,
+    )
+    sched = type("MossTTSLocalStreamingVocoderScheduler", (), {})()
+    sched._session = session
+    return sched
+
+
+def test_custom_graph_stage_reported():
+    sched = _fake_moss_vocoder_scheduler(captured=[100, 25, 5], batch_size=16)
+    report = validate_stage_scheduler("vocoder", sched)
+    assert isinstance(report, CustomGraphReport)
+    assert report.captured_frames == [5, 25, 100]
+    assert report.slot_capacity == 16
+    assert "vocoder (MossTTSLocalStreamingVocoderScheduler)" in report.format()
+    assert any("frame count T" in f for f in report.findings)
+
+
+def test_custom_graph_stage_no_capture_gets_no_graph_report():
+    sched = _fake_moss_vocoder_scheduler(captured=[], batch_size=16, has_runner=False)
+    report = validate_stage_scheduler("vocoder", sched)
+    assert isinstance(report, NoGraphReport)
+    assert report.ok
+
+
+def test_custom_graph_format_is_labeled():
+    sched = _fake_moss_vocoder_scheduler(captured=[1, 50], batch_size=8)
+    out = validate_stage_scheduler("vocoder", sched).format()
+    assert "custom graph" in out
+    assert "captured frames (T):" in out
+    assert "slot capacity:" in out
+
+
+# --- model-level driver: one independent report per stage -----------------
+
+
+def test_validate_stages_covers_every_stage_independently():
+    model = _as_named(None, "Qwen3TTSTalker", _feedback_buffer=_FakeTensor(64))
+    sglang_sched = SimpleNamespace(
+        tp_worker=SimpleNamespace(
+            model_runner=_fake_runner(model=model, capture_bs=[1, 16, 64])
+        )
+    )
+    preproc_sched = SimpleNamespace(process_one=lambda x: x)
+    vocoder_sched = _fake_moss_vocoder_scheduler(captured=[5, 50], batch_size=16)
+
+    reports = validate_stages(
+        [
+            ("preprocessing", preproc_sched),
+            ("tts_engine", sglang_sched),
+            ("vocoder", vocoder_sched),
+        ]
+    )
+
+    assert len(reports) == 3
+    assert isinstance(reports[0], NoGraphReport)
+    assert isinstance(reports[1], CudaGraphBatchReport)
+    assert isinstance(reports[2], CustomGraphReport)
+    assert all(hasattr(r, "ok") for r in reports)
+    assert "preprocessing" in reports[0].stage
+    assert "tts_engine" in reports[1].stage
+    assert "vocoder" in reports[2].stage
+
+
+def test_validate_stages_qwen3_omni_two_sglang_stages():
+    thinker_model = _as_named(None, "Qwen3OmniTalker", _feedback_buffer=_FakeTensor(16))
+    talker_model = _as_named(None, "Qwen3OmniTalker", _feedback_buffer=_FakeTensor(16))
+    thinker = SimpleNamespace(
+        tp_worker=SimpleNamespace(
+            model_runner=_fake_runner(
+                model=thinker_model,
+                max_running_requests=16,
+                cuda_graph_max_bs=16,
+                capture_bs=[1, 8, 16],
+                request_slots=16,
+            )
+        )
+    )
+    talker = SimpleNamespace(
+        tp_worker=SimpleNamespace(
+            model_runner=_fake_runner(
+                model=talker_model,
+                max_running_requests=16,
+                cuda_graph_max_bs=16,
+                capture_bs=[1, 8, 16],
+                request_slots=16,
+            )
+        )
+    )
+    reports = validate_stages([("thinker", thinker), ("talker_ar", talker)])
+    assert [type(r).__name__ for r in reports] == [
+        "CudaGraphBatchReport",
+        "CudaGraphBatchReport",
+    ]
+    assert "thinker" in reports[0].stage
+    assert "talker_ar" in reports[1].stage
+
+
+# --- probe registry covers every audited model ----------------------------
+
+
+def test_every_generation_model_has_a_probe():
+    expected = {
+        "HiggsTTSModel",
+        "Qwen3TTSTalker",
+        "MossTTSDelaySGLangModel",
+        "MossTTSLocalSGLangModel",
+        "S2ProSGLangTextModel",
+        "VoxtralSGLangTTSModel",
+        "Qwen3OmniTalker",
+    }
+    assert expected <= set(cgv._BUFFER_PROBES)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

CUDA-graph-backed generation stages have three batch-size facts that must agree but are set in three different places:
1. the serving config — `max_running_requests` / `cuda_graph_max_bs` on `server_args`
2. the batch sizes CUDA graph capture actually used (`graph_runner.capture_bs`)
3. the model's own per-request buffer size (e.g. the Higgs sampler pool, the Qwen3-TTS feedback buffer)

When (3) is sized from a stale assumption instead of the live serving config, a graph captured for a batch larger than the buffer overruns it. Raw throughput/RTF numbers can't reveal this — the three numbers live in different places and nothing reconciles them. This adds a small utility that reads all three from a running stage and flags a disagreement.

## Modifications

Adds `sglang_omni/utils/cuda_graph_batch_validator.py`. Given a running stage it produces one report with the three facts and a verdict.

How it works, per stage:
- **Effective capture coverage** — reads `model_runner.graph_runner.capture_bs` (the sizes capture actually used). This is fully generic: it touches only upstream SGLang attributes, so it works for *any* SGLang stage with no model-specific code.
- **Model-side buffer sizing** — reads the first dim of the model's actual allocated buffer tensor (not a value recomputed from config, so it catches a hard-coded buffer). The buffer lives under a different attribute per model, so this uses a small per-class registry (`_BUFFER_PROBES`) keyed on `type(model).__name__`. A model not in the registry is reported as "no buffer probe registered" — it still gets the capture-coverage check, just not the buffer comparison. Adding a new model is one registry line.
- **Verdict** — flags `MISMATCH` if capture exceeds the buffer, or if the buffer is smaller than `max_running_requests`; otherwise `OK`.

Validation is per stage. It checks each stage for an enabled CUDA graph and validates the ones that have it, noting "no CUDA graph" for the rest.

 ## Sample output
  
For a Higgs `tts_engine` stage launched with `cuda_graph_max_bs=128` while `max_running_requests=64`:

```
  Stage: tts_engine (HiggsTTSModel)
    serving config:     max_running_requests=64, cuda_graph_max_bs=128
    captured graph bs:  [1, 2, 4, 8, 12, 16, 24, 32, 40, 48, 56, 64] (max captured = 64)
    request slots:      64
    model-side buffers: 65 [model._sampler_pool.seeds.shape[0]]
    VERDICT: OK
      - captured sizes and model-side buffer track the serving config.
```

The requested `cuda_graph_max_bs=128` never took effect — capture was clamped to 64 by the request-slot count — which the report makes visible.

## Reusing it for CUDA graph tuning sweeps

A tuning sweep can call `validate_stage_scheduler` at stage startup and log the report alongside its throughput/RTF numbers, recording for each data point what was actually captured — e.g. surfacing when a requested `cuda_graph_max_bs` was silently clamped by `max_running_requests`.

## Related Issues

 Part of #836 (Workstream 1).

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
