### PR TITLE
chore: delete all filler and anonymous comments (#661)

### DIFF
--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -15,7 +15,6 @@ from sglang_omni.serve.protocol import DEFAULT_TTS_BATCH_MAX_ITEMS
 
 logger = logging.getLogger(__name__)
 
-
 _STAGE_TOGGLE_MODE = Literal["default", "on", "off"]
 _QWEN_COLOCATED_CONFIG_CLASS = "Qwen3OmniSpeechColocatedPipelineConfig"
 _DECODE_MODE = Literal["async", "sync"]
@@ -29,12 +28,10 @@ _QWEN_PARTIAL_START_TALKER_FACTORY = (
     "sglang_omni.models.qwen3_omni.stages.create_talker_ar_executor_from_config"
 )
 
-
 def launch_server(*args: object, **kwargs: object) -> object:
     from sglang_omni.serve.launcher import launch_server as _launch_server
 
     return _launch_server(*args, **kwargs)
-
 
 def _normalize_stage_toggle_mode(flag_name: str, value: str) -> _STAGE_TOGGLE_MODE:
     normalized = value.strip().lower()
@@ -42,13 +39,11 @@ def _normalize_stage_toggle_mode(flag_name: str, value: str) -> _STAGE_TOGGLE_MO
         raise typer.BadParameter(f"{flag_name} must be one of: default, on, off")
     return normalized  # type: ignore[return-value]
 
-
 def _normalize_decode_mode(value: str) -> _DECODE_MODE:
     normalized = value.strip().lower()
     if normalized not in {"async", "sync"}:
         raise typer.BadParameter("--decode-mode must be one of: async, sync")
     return normalized  # type: ignore[return-value]
-
 
 def _validate_colocate_cli_request(
     *,
@@ -63,19 +58,16 @@ def _validate_colocate_cli_request(
     if not config:
         raise typer.BadParameter("--colocate requires --config")
 
-
 def _validate_colocate_config(pipeline_config: PipelineConfig) -> None:
     if type(pipeline_config).__name__ != _QWEN_COLOCATED_CONFIG_CLASS:
         raise typer.BadParameter(
             f"--colocate requires a {_QWEN_COLOCATED_CONFIG_CLASS} config file"
         )
 
-
 def _should_print_merged_config(*, colocate: bool, log_level: str) -> bool:
     """Return whether to print the full resolved pipeline config."""
 
     return colocate or log_level.lower() == "debug"
-
 
 def _print_merged_config(pipeline_config: PipelineConfig) -> None:
     print("=" * 20, "Merged Configuration", "=" * 20)
@@ -88,7 +80,6 @@ def _print_merged_config(pipeline_config: PipelineConfig) -> None:
         )
     )
     print("=" * 50)
-
 
 def _find_matching_stages(
     pipeline_config: PipelineConfig,
@@ -105,7 +96,6 @@ def _find_matching_stages(
         )
     return matching_stages
 
-
 def _raise_unsupported_flag(
     pipeline_config: PipelineConfig,
     flag_name: str,
@@ -113,7 +103,6 @@ def _raise_unsupported_flag(
     raise typer.BadParameter(
         f"{flag_name} is not supported by {type(pipeline_config).__name__}"
     )
-
 
 def _resolve_talker_stage(
     pipeline_config: PipelineConfig,
@@ -125,7 +114,6 @@ def _resolve_talker_stage(
         _raise_unsupported_flag(pipeline_config, flag_name)
     return stage_name
 
-
 def _resolve_talker_sglang_stage(
     pipeline_config: PipelineConfig,
     *,
@@ -135,7 +123,6 @@ def _resolve_talker_sglang_stage(
     if stage_name is None:
         _raise_unsupported_flag(pipeline_config, flag_name)
     return stage_name
-
 
 def _apply_stage_server_args_override(
     pipeline_config: PipelineConfig,
@@ -170,7 +157,6 @@ def _apply_stage_server_args_override(
             if isinstance(runtime_server_args, dict):
                 runtime_server_args.update(updates)
 
-
 def _apply_stage_mem_fraction_override(
     pipeline_config: PipelineConfig,
     *,
@@ -184,7 +170,6 @@ def _apply_stage_mem_fraction_override(
     )
     for stage in matching_stages:
         stage.runtime.sglang_server_args.mem_fraction_static = value
-
 
 def _stage_has_explicit_mem_fraction_static(
     pipeline_config: PipelineConfig,
@@ -213,7 +198,6 @@ def _stage_has_explicit_mem_fraction_static(
     )
     return runtime_server_args_overrides.get("mem_fraction_static") is not None
 
-
 def _validate_mem_fraction_static(flag_name: str, value: float | None) -> float | None:
     if value is None:
         return None
@@ -221,14 +205,12 @@ def _validate_mem_fraction_static(flag_name: str, value: float | None) -> float 
         raise typer.BadParameter(f"{flag_name} must be > 0 and < 1, got {value}")
     return float(value)
 
-
 def _validate_encoder_mem_reserve(value: float | None) -> float | None:
     if value is None:
         return None
     if not 0.0 <= value < 1.0:
         raise typer.BadParameter("--encoder-mem-reserve must be in [0, 1)")
     return float(value)
-
 
 def _validate_allowed_local_media_path(value: str | None) -> str | None:
     if value is None:
@@ -238,7 +220,6 @@ def _validate_allowed_local_media_path(value: str | None) -> str | None:
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
 
-
 def _normalize_allowed_media_domains(values: list[str] | None) -> list[str]:
     domains: list[str] = []
     for value in values or []:
@@ -247,12 +228,10 @@ def _normalize_allowed_media_domains(values: list[str] | None) -> list[str]:
         )
     return domains
 
-
 def _validate_tts_batch_max_items(value: int) -> int:
     if value < 1:
         raise typer.BadParameter("tts batch max items must be greater than 0")
     return value
-
 
 def apply_mem_fraction_cli_overrides(
     pipeline_config: PipelineConfig,
@@ -306,8 +285,6 @@ def apply_mem_fraction_cli_overrides(
     }
     for role, stage_name in role_to_stage.items():
         role_value = role_values.get(role)
-        # Precedence: per-role flag wins over the global flag for this role;
-        # the global flag is the fallback when no per-role flag was given.
         final_value = role_value if role_value is not None else mem_fraction_static
         if final_value is not None:
             _apply_stage_mem_fraction_override(
@@ -316,7 +293,6 @@ def apply_mem_fraction_cli_overrides(
                 value=final_value,
             )
     return pipeline_config
-
 
 def apply_encoder_mem_reserve_cli_override(
     pipeline_config: PipelineConfig,
@@ -367,7 +343,6 @@ def apply_encoder_mem_reserve_cli_override(
             stage_runtime_overrides["encoder_mem_reserve"] = encoder_mem_reserve
     return pipeline_config
 
-
 def _parse_gpu_placement(flag_name: str, value: str) -> int | list[int]:
     text = value.strip()
     if not text:
@@ -415,7 +390,6 @@ def _parse_gpu_placement(flag_name: str, value: str) -> int | list[int]:
 
     return gpus[0] if len(gpus) == 1 else gpus
 
-
 def _validate_stage_parallelism_config(stage_name: str, tp_size: int, gpu) -> None:
     if tp_size < 1:
         raise typer.BadParameter(f"{stage_name}_tp_size must be >= 1")
@@ -438,7 +412,6 @@ def _validate_stage_parallelism_config(stage_name: str, tp_size: int, gpu) -> No
             f"{stage_name}_gpus must not contain duplicate GPU ids"
         )
 
-
 def _apply_stage_gpu_override(
     pipeline_config: PipelineConfig,
     *,
@@ -456,7 +429,6 @@ def _apply_stage_gpu_override(
     )
     for stage in matching_stages:
         stage.gpu = int(gpu)
-
 
 def _validate_colocated_gpu_override(
     pipeline_config: PipelineConfig,
@@ -478,7 +450,6 @@ def _validate_colocated_gpu_override(
             f"{flag_name} cannot move {stage_name} away from the colocated GPU"
         )
 
-
 def _apply_tensor_parallel_server_args_overrides(
     pipeline_config: PipelineConfig,
 ) -> None:
@@ -497,13 +468,11 @@ def _apply_tensor_parallel_server_args_overrides(
             reason=f"tensor parallel server args for {stage.name}",
         )
 
-
 def _validate_parallelism_config(pipeline_config: PipelineConfig) -> None:
     try:
         type(pipeline_config)(**pipeline_config.model_dump())
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
-
 
 def apply_thinker_server_args_cli_overrides(
     pipeline_config: PipelineConfig,
@@ -530,7 +499,6 @@ def apply_thinker_server_args_cli_overrides(
             reason="thinker SGLang ServerArgs override",
         )
     return pipeline_config
-
 
 def apply_parallelism_cli_overrides(
     pipeline_config: PipelineConfig,
@@ -631,7 +599,6 @@ def apply_parallelism_cli_overrides(
     _validate_parallelism_config(pipeline_config)
     return pipeline_config
 
-
 def _apply_stage_cuda_graph_override(
     pipeline_config: PipelineConfig,
     *,
@@ -647,7 +614,6 @@ def _apply_stage_cuda_graph_override(
         updates={"disable_cuda_graph": mode != "on"},
         reason=f"CUDA graph mode to {mode!r}",
     )
-
 
 def _apply_stage_torch_compile_override(
     pipeline_config: PipelineConfig,
@@ -674,7 +640,6 @@ def _apply_stage_torch_compile_override(
         reason=(f"torch compile settings (mode={mode!r}, max_bs={max_bs})"),
     )
 
-
 def apply_cuda_graph_cli_overrides(
     pipeline_config: PipelineConfig,
     *,
@@ -700,7 +665,6 @@ def apply_cuda_graph_cli_overrides(
             mode=talker_mode,
         )
     return pipeline_config
-
 
 def apply_partial_start_cli_overrides(
     pipeline_config: PipelineConfig,
@@ -734,7 +698,6 @@ def apply_partial_start_cli_overrides(
     )
     return pipeline_config
 
-
 def _apply_stage_factory_args_override(
     pipeline_config: PipelineConfig,
     *,
@@ -764,7 +727,6 @@ def _apply_stage_factory_args_override(
         stage_runtime_overrides = pipeline_config.runtime_overrides.get(stage.name)
         if isinstance(stage_runtime_overrides, dict):
             stage_runtime_overrides.update(updates)
-
 
 def apply_decode_mode_cli_overrides(
     pipeline_config: PipelineConfig,
@@ -797,7 +759,6 @@ def apply_decode_mode_cli_overrides(
         flag_name="--decode-mode/--async-lookahead-min-batch-size",
     )
     return pipeline_config
-
 
 def apply_torch_compile_cli_overrides(
     pipeline_config: PipelineConfig,
@@ -835,7 +796,6 @@ def apply_torch_compile_cli_overrides(
             max_bs=talker_torch_compile_max_bs,
         )
     return pipeline_config
-
 
 def serve(
     ctx: typer.Context,
@@ -1147,7 +1107,6 @@ def serve(
         text_only=text_only,
     )
 
-    # --- Resolve config ---
     if config:
         config_manager = ConfigManager.from_file(config)
     elif text_only:
@@ -1159,8 +1118,6 @@ def serve(
             raise typer.BadParameter("--model-path is required unless --config is set")
         config_manager = ConfigManager.from_model_path(model_path)
 
-    # we use ctx to capture the arguments that are used to modify the configuration on the fly
-    # we do expect the extra arguments to be pairs of names and values
     extra_args = config_manager.parse_extra_args(ctx.args)
     merged_config = config_manager.merge_config(extra_args)
     if model_path is not None:

--- a/sglang_omni/client/audio.py
+++ b/sglang_omni/client/audio.py
@@ -20,7 +20,6 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
-# Supported output formats and their MIME types
 FORMAT_MIME_TYPES: dict[str, str] = {
     "wav": "audio/wav",
     "mp3": "audio/mpeg",
@@ -30,10 +29,8 @@ FORMAT_MIME_TYPES: dict[str, str] = {
     "pcm": "audio/pcm",
 }
 
-# Default sample rate for generated audio
 DEFAULT_SAMPLE_RATE = 24000
 
-# Configurations for PyAV encoding
 PYAV_ENCODE_CONFIGS = {
     "opus": {
         "container": "ogg",
@@ -79,7 +76,6 @@ PYAV_ENCODE_CONFIGS = {
     },
 }
 
-
 @cache
 def audio_encoding_unavailable_reason(response_format: str) -> str | None:
     """Return why the requested response format cannot be encoded."""
@@ -106,7 +102,6 @@ def audio_encoding_unavailable_reason(response_format: str) -> str | None:
 
     return None
 
-
 def to_numpy(audio: Any) -> np.ndarray:
     """Convert audio data to a numpy float32 array.
 
@@ -119,7 +114,6 @@ def to_numpy(audio: Any) -> np.ndarray:
     if isinstance(audio, np.ndarray):
         return audio.astype(np.float32, copy=False)
 
-    # torch Tensor
     if hasattr(audio, "cpu") and hasattr(audio, "numpy"):
         arr = audio.detach().cpu().float().numpy()
         return arr.astype(np.float32, copy=False)
@@ -128,12 +122,10 @@ def to_numpy(audio: Any) -> np.ndarray:
         return np.array(audio, dtype=np.float32)
 
     if isinstance(audio, bytes):
-        # Assume 16-bit signed PCM
         arr = np.frombuffer(audio, dtype="<i2")
         return (arr.astype(np.float32) / 32768.0).astype(np.float32)
 
     raise TypeError(f"Unsupported audio type: {type(audio)}")
-
 
 def apply_speed(
     audio: np.ndarray, speed: float, sample_rate: int
@@ -150,18 +142,14 @@ def apply_speed(
     if speed == 1.0:
         return audio, sample_rate
 
-    # Speed up/slow down by changing the effective sample rate
-    # Then resample to the original rate
     new_length = max(int(round(len(audio) / speed)), 1)
     old_idx = np.arange(len(audio), dtype=np.float64)
     new_idx = np.linspace(0.0, len(audio) - 1, num=new_length, dtype=np.float64)
     resampled = np.interp(new_idx, old_idx, audio).astype(np.float32)
     return resampled, sample_rate
 
-
 def encode_wav(audio: np.ndarray, sample_rate: int) -> bytes:
     """Encode audio as a WAV file (16-bit PCM)."""
-    # Clamp to [-1, 1]
     audio = np.clip(audio, -1.0, 1.0)
     pcm = (audio * 32767.0).astype(np.int16)
     if pcm.ndim == 2:
@@ -177,13 +165,11 @@ def encode_wav(audio: np.ndarray, sample_rate: int) -> bytes:
     data_size = len(pcm_bytes)
 
     buf = io.BytesIO()
-    # RIFF header
     buf.write(b"RIFF")
     buf.write(struct.pack("<I", 36 + data_size))
     buf.write(b"WAVE")
-    # fmt chunk
     buf.write(b"fmt ")
-    buf.write(struct.pack("<I", 16))  # chunk size
+    buf.write(struct.pack("<I", 16))
     buf.write(
         struct.pack(
             "<HHIIHH",
@@ -195,13 +181,11 @@ def encode_wav(audio: np.ndarray, sample_rate: int) -> bytes:
             bits_per_sample,
         )
     )
-    # data chunk
     buf.write(b"data")
     buf.write(struct.pack("<I", data_size))
     buf.write(pcm_bytes)
 
     return buf.getvalue()
-
 
 def _resample_linear(audio: np.ndarray, orig_sr: int, target_sr: int) -> np.ndarray:
     if orig_sr == target_sr:
@@ -213,7 +197,6 @@ def _resample_linear(audio: np.ndarray, orig_sr: int, target_sr: int) -> np.ndar
     old_idx = np.arange(audio.shape[0], dtype=np.float64)
     new_idx = np.linspace(0.0, audio.shape[0] - 1, num=new_len, dtype=np.float64)
     return np.interp(new_idx, old_idx, audio).astype(np.float32)
-
 
 def _encode_with_pyav(
     audio: np.ndarray,
@@ -251,7 +234,6 @@ def _encode_with_pyav(
 
     stream.layout = "mono"
 
-    # FFmpeg expects float-planar (fltp) format for these codecs
     frame = av.AudioFrame.from_ndarray(
         audio.reshape(1, -1), format="fltp", layout="mono"
     )
@@ -266,7 +248,6 @@ def _encode_with_pyav(
     container.close()
     return buf.getvalue()
 
-
 def encode_pcm(audio: np.ndarray, sample_rate: int) -> bytes:
     """Encode audio as raw 16-bit PCM bytes."""
     audio = np.clip(audio, -1.0, 1.0)
@@ -274,7 +255,6 @@ def encode_pcm(audio: np.ndarray, sample_rate: int) -> bytes:
     if pcm.ndim == 2:
         pcm = np.ascontiguousarray(pcm.T)
     return pcm.tobytes()
-
 
 def select_audio_delta(
     audio_data: Any,
@@ -288,9 +268,6 @@ def select_audio_delta(
     if audio.ndim > 1:
         audio = audio.squeeze()
     if audio.ndim > 1:
-        # Streaming chunks are mono; downmix multi-channel payloads
-        # (e.g. the 48 kHz stereo MOSS-TTS Local codec) instead of
-        # silently dropping channels.
         channel_axis = 0 if audio.shape[0] < audio.shape[-1] else -1
         audio = audio.mean(axis=channel_axis).astype("float32")
 
@@ -300,7 +277,6 @@ def select_audio_delta(
     if total_samples <= emitted_samples:
         return None, emitted_samples
     return audio[emitted_samples:], total_samples
-
 
 def encode_audio(
     audio: Any,
@@ -415,7 +391,6 @@ def encode_audio(
         raise ValueError(f"Unsupported audio format: {response_format!r}")
     logger.warning("Unknown audio format '%s'; falling back to WAV", fmt)
     return encode_wav(arr, sample_rate), FORMAT_MIME_TYPES["wav"]
-
 
 def audio_to_base64(
     audio: Any,

--- a/sglang_omni/client/client.py
+++ b/sglang_omni/client/client.py
@@ -32,7 +32,6 @@ from sglang_omni.client.types import (
 from sglang_omni.pipeline.coordinator import Coordinator
 from sglang_omni.proto import OmniRequest, RequestState, StreamMessage
 
-
 class Client:
     """Internal client used by API adapters."""
 
@@ -45,10 +44,6 @@ class Client:
         self._coordinator = coordinator
         self._result_builder = result_builder or self._default_result_builder
         self._stream_builder = stream_builder or self._default_stream_builder
-
-    # ------------------------------------------------------------------
-    # Low-level generate (backward compatible)
-    # ------------------------------------------------------------------
 
     async def generate(
         self,
@@ -67,10 +62,6 @@ class Client:
 
         result = await self._coordinator.submit(req_id, omni_request)
         yield self._result_builder(req_id, result)
-
-    # ------------------------------------------------------------------
-    # High-level: non-streaming completion
-    # ------------------------------------------------------------------
 
     async def completion(
         self,
@@ -152,10 +143,6 @@ class Client:
             weight_version=weight_version,
         )
 
-    # ------------------------------------------------------------------
-    # High-level: streaming completion
-    # ------------------------------------------------------------------
-
     async def completion_stream(
         self,
         request: GenerateRequest,
@@ -186,10 +173,6 @@ class Client:
                 usage=chunk.usage,
                 stage_name=chunk.stage_name,
             )
-
-    # ------------------------------------------------------------------
-    # High-level: text-to-speech
-    # ------------------------------------------------------------------
 
     async def speech(
         self,
@@ -241,8 +224,6 @@ class Client:
             encode_audio, audio_data, **encode_kwargs
         )
 
-        # Derive actual format from MIME type (encode_audio may fall back
-        # to WAV if the requested codec is unavailable).
         actual_format = response_format
         for ext, mt in FORMAT_MIME_TYPES.items():
             if mt == mime_type:
@@ -256,10 +237,6 @@ class Client:
             sample_rate=sample_rate,
             usage=last_chunk.usage if last_chunk else None,
         )
-
-    # ------------------------------------------------------------------
-    # Other operations
-    # ------------------------------------------------------------------
 
     async def abort(
         self,
@@ -395,10 +372,6 @@ class Client:
             timeout_s=timeout_s,
         )
 
-    # ------------------------------------------------------------------
-    # Internals
-    # ------------------------------------------------------------------
-
     @staticmethod
     def _set_audio_data(chunk: GenerateChunk, data: dict[str, Any]) -> None:
         audio_data = data.get("audio_data") or data.get("audio")
@@ -456,8 +429,6 @@ class Client:
             result.request_id = request_id
             return result
         if isinstance(result, dict):
-            # Multi-terminal merged result, e.g. decode + code2wav/talker/
-            # talker_stream.
             audio_result = None
             if "decode" in result:
                 for audio_stage in ("code2wav", "talker", "talker_stream"):
@@ -586,7 +557,6 @@ class Client:
         chunk.text = str(data)
         return chunk
 
-
 def _extract_inputs(request: GenerateRequest) -> Any:
     choices = [
         request.prompt is not None,
@@ -603,16 +573,12 @@ def _extract_inputs(request: GenerateRequest) -> Any:
     if request.prompt_token_ids is not None:
         return list(request.prompt_token_ids)
 
-    # Build messages list
     messages = [msg.to_dict() for msg in request.messages or []]
 
-    # Check if we have audios, images, or videos in metadata
     audios = request.metadata.get("audios")
     images = request.metadata.get("images")
     videos = request.metadata.get("videos")
 
-    # If we have any media, return a dict with messages and media
-    # Otherwise, return just the messages list (for backward compatibility)
     if audios or images or videos:
         result = {"messages": messages}
         if images:
@@ -633,7 +599,6 @@ def _extract_inputs(request: GenerateRequest) -> Any:
                 result[key] = value
         return result
     return messages
-
 
 def _build_params(request: GenerateRequest) -> dict[str, Any]:
     params = request.sampling.to_dict()

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -7,7 +7,6 @@ from typing import Any, ClassVar, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-
 class RelayConfig(BaseModel):
     """Relay configuration for stage data transfer."""
 
@@ -19,14 +18,12 @@ class RelayConfig(BaseModel):
     world_size: int | None = None
     device: str = "cpu"
 
-
 class EndpointsConfig(BaseModel):
     """Endpoint allocation settings."""
 
     model_config = ConfigDict(extra="forbid")
 
     base_path: str = "/tmp/sglang_omni"
-
 
 class ParallelismConfig(BaseModel):
     """Supported parallelism for one logical stage."""
@@ -38,7 +35,6 @@ class ParallelismConfig(BaseModel):
     def model_post_init(self, __context: Any = None) -> None:
         if self.tp < 1:
             raise ValueError("parallelism.tp must be >= 1")
-
 
 class StageResourceConfig(BaseModel):
     """Placement-resource intent for one stage rank/process."""
@@ -61,7 +57,6 @@ class StageResourceConfig(BaseModel):
                 "runtime.resources.total_gpu_memory_fraction must be in (0, 1]"
             )
 
-
 class SGLangServerArgsConfig(BaseModel):
     """Typed subset of SGLang ServerArgs exposed through pipeline config."""
 
@@ -75,7 +70,6 @@ class SGLangServerArgsConfig(BaseModel):
             raise ValueError(
                 "runtime.sglang_server_args.mem_fraction_static must be in (0, 1)"
             )
-
 
 class StageRuntimeConfig(BaseModel):
     """Typed runtime intent for one stage.
@@ -100,7 +94,6 @@ class StageRuntimeConfig(BaseModel):
         if self.video_fps is not None and self.video_fps <= 0:
             raise ValueError("runtime.video_fps must be positive")
 
-
 class PlacementConfig(BaseModel):
     """Pipeline-level placement planning limits."""
 
@@ -115,7 +108,6 @@ class PlacementConfig(BaseModel):
             raise ValueError(
                 "placement.max_total_gpu_memory_fraction_per_gpu must be in (0, 1]"
             )
-
 
 class StageConfig(BaseModel):
     """Single pipeline stage configuration.
@@ -137,42 +129,33 @@ class StageConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    # --- Identity ---
     name: str
 
-    # --- Factory ---
     factory: str
     factory_args: dict[str, Any] = Field(default_factory=dict)
 
-    # --- Routing (set `next` for static routing or `terminal`) ---
     next: str | list[str] | None = None
     terminal: bool = False
     route_fn: str | None = None
 
-    # --- GPU / parallelism ---
     gpu: int | list[int] | None = None
     tp_size: int = 1
     parallelism: ParallelismConfig = Field(default_factory=ParallelismConfig)
     process: str | None = None
 
-    # --- Runtime intent ---
     runtime: StageRuntimeConfig = Field(default_factory=StageRuntimeConfig)
     runtime_arg_map: dict[str, str] = Field(default_factory=dict)
 
-    # --- Fan-in ---
     wait_for: list[str] | None = None
     wait_for_fn: str | None = None
     merge_fn: str | None = None
 
-    # --- Streaming ---
     stream_to: list[str] = Field(default_factory=list)
     stream_done_to_fn: str | None = None
     can_accept_stream_before_payload: bool = False
 
-    # --- Route-specific payload projection ---
     project_payload: dict[str, str] = Field(default_factory=dict)
 
-    # --- Relay (auto-inferred from gpu when None) ---
     relay: RelayConfig | None = None
 
     def model_post_init(self, __context: Any = None) -> None:
@@ -196,7 +179,6 @@ class StageConfig(BaseModel):
             parallelism_set and not tp_size_set and self.tp_size != self.parallelism.tp
         ):
             self.tp_size = self.parallelism.tp
-
 
 class PipelineConfig(BaseModel):
     """Top-level pipeline configuration."""
@@ -452,14 +434,12 @@ class PipelineConfig(BaseModel):
     def from_dict(data: dict[str, Any]) -> PipelineConfig:
         return PipelineConfig(**data)
 
-
 def _target_list(targets: str | list[str] | None) -> list[str]:
     if targets is None:
         return []
     if isinstance(targets, str):
         return [targets]
     return list(targets)
-
 
 def _stage_gpu_ids_for_fusion(stage: StageConfig) -> tuple[int, ...]:
     gpu = stage.gpu

--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -25,7 +25,6 @@ from sglang_omni.scheduling.types import (
 
 logger = logging.getLogger(__name__)
 
-
 def _current_sglang_sampling_backend() -> str | None:
     try:
         from sglang.srt.server_args import get_global_server_args
@@ -33,7 +32,6 @@ def _current_sglang_sampling_backend() -> str | None:
         return get_global_server_args().sampling_backend
     except ValueError:
         return None
-
 
 def _rank_shared_unseeded_sampling_seed(request: Any, row_idx: int) -> int:
     request_id = getattr(request, "request_id", None)
@@ -45,7 +43,6 @@ def _rank_shared_unseeded_sampling_seed(request: Any, row_idx: int) -> int:
     if request_id is None:
         request_id = f"row-{row_idx}"
     return derive_sampling_seed("sglang-omni-unseeded-row", request_id)
-
 
 @dataclass
 class _PendingStep:
@@ -66,15 +63,14 @@ class _PendingStep:
     launch(N+1) writes the other (design.md section 1.4).
     """
 
-    event: Any  # torch.cuda.Event, recorded after post_decode_launch publishes
-    launch_buf: Any  # post_decode_launch return: device snapshot or host staging
-    scheduler_output: Any  # this step's SchedulerOutput (routing + output proc)
-    forward_batch: Any  # for resolve-time finalize sampling
-    schedule_batch: Any  # to set .output_ids during resolve
-    model_worker_batch: Any  # for the prefill-only finalize branch (unused in decode)
-    batch_result: Any  # carries logits_output (device of next_token_ids)
-    n_real: int  # number of real (non-padding) rows this step
-
+    event: Any
+    launch_buf: Any
+    scheduler_output: Any
+    forward_batch: Any
+    schedule_batch: Any
+    model_worker_batch: Any
+    batch_result: Any
+    n_real: int
 
 class ModelRunner:
     """Base AR model runner.
@@ -90,15 +86,9 @@ class ModelRunner:
         self.device = torch.device(f"cuda:{tp_worker.gpu_id}")
         self.model = tp_worker.model_runner.model
 
-        # Async decode (one-step lookahead). Inert unless ``_async_enabled`` is set.
         self._async_enabled: bool = False
         self._staging_slot: int = 0
         self._host_staging_buffers: list[torch.Tensor] = []
-        # Observability: how often resolve found the launched step's event
-        # already done (no blocking) vs had to block on synchronize(). This
-        # counts whether the launched step's GPU work was published in time; it
-        # does NOT measure host-D2H overlap (only host-staging runners like Higgs
-        # overlap a host copy; the device-snapshot path does not).
         self._async_query_hit: int = 0
         self._async_query_miss: int = 0
 
@@ -192,16 +182,9 @@ class ModelRunner:
         launch_buf = self.post_decode_launch(
             batch_result, forward_batch, scheduler_output.requests
         )
-        # Publish this step's output token ids now (post_decode_launch set them
-        # from GPU state without a host sync) so the NEXT decode step's
-        # get_next_batch_to_run / prepare_for_decode can build its input_ids;
-        # under lookahead the host collect (resolve) lags by one step.
         if batch_result.next_token_ids is not None:
             schedule_batch.output_ids = batch_result.next_token_ids
         event = torch.cuda.Event()
-        # Recorded after post_decode_launch publishes this step, so
-        # event.query()==True means the launched step's GPU work is done and
-        # launch_buf is ready (design.md section 3).
         event.record()
         return _PendingStep(
             event=event,
@@ -231,8 +214,6 @@ class ModelRunner:
         else:
             pending.event.synchronize()
             self._async_query_miss += 1
-        # Skip reqs finished or retracted in a prior (lagged) step so _finalize
-        # neither re-emits nor re-frees their KV (mirrors _resolve_and_process).
         skip_rids = {
             req.request_id
             for req in pending.scheduler_output.requests
@@ -432,10 +413,6 @@ class ModelRunner:
             can_run_cuda_graph=bool(batch_result.can_run_cuda_graph),
         )
 
-    # ------------------------------------------------------------------
-    # Hooks — override in subclasses
-    # ------------------------------------------------------------------
-
     def before_prefill(
         self, forward_batch: Any, schedule_batch: Any, requests: list
     ) -> None:
@@ -558,10 +535,6 @@ class ModelRunner:
     ) -> Any | None:
         return None
 
-    # ------------------------------------------------------------------
-    # Shared logit processing
-    # ------------------------------------------------------------------
-
     def _sample_next_token_ids(
         self,
         logits_output: Any,
@@ -623,7 +596,7 @@ class ModelRunner:
             if seed is None:
                 seed = _rank_shared_unseeded_sampling_seed(request, row_idx)
             elif not (0 <= seed <= SAMPLING_SEED_MASK):
-                seed = resolve_row_seed(seed)  # mask and cache user seed
+                seed = resolve_row_seed(seed)
                 sp.sampling_seed = seed
             row_seeds.append(seed)
         sampling_info.sampling_seed = torch.tensor(

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -13,14 +13,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-
 @dataclass
 class ModelWorkerConfig:
     model_arch_override: str | None = None
     weight_prefix: str | None = None
     nccl_port: int | None = None
     total_gpu_memory_fraction: float | None = None
-
 
 _ARCH_CONFIG_MAP: dict[str, tuple[str, str | None]] = {
     "BailingMoeV2ForCausalLM": ("llm_config", None),
@@ -31,7 +29,6 @@ _ARCH_CONFIG_MAP: dict[str, tuple[str, str | None]] = {
     "MossTTSDelaySGLangModel": ("language_config", None),
     "MossTTSLocalSGLangModel": ("language_config", None),
 }
-
 
 class ModelWorker:
     def __init__(
@@ -322,9 +319,6 @@ class ModelWorker:
         shapes = payload.get("shapes")
         if names is None or dtypes is None or shapes is None:
             return False, "names, dtypes and shapes are required"
-        # Pydantic already guards type/None at the HTTP boundary; this length
-        # check is the one guard that matters — sglang zips names/dtypes/shapes
-        # and silently truncates to the shortest, under-broadcasting weights.
         name_count = len(names)
         dtype_count = len(dtypes)
         shape_count = len(shapes)
@@ -369,7 +363,6 @@ class ModelWorker:
         success, message = method(recv_req)
         return bool(success), str(message)
 
-
 def _resolve_nccl_port() -> int:
     master_port = os.environ.get("MASTER_PORT")
     if master_port:
@@ -381,14 +374,10 @@ def _resolve_nccl_port() -> int:
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             port = sock.getsockname()[1]
     except PermissionError:
-        # Some restricted CI / sandbox environments do not allow ephemeral socket
-        # binding during test-time configuration. Fall back to a stable default so
-        # callers still receive a valid NCCL port choice.
         port = 29500
 
     os.environ["MASTER_PORT"] = str(port)
     return port
-
 
 def _apply_model_worker_backend_policy(
     server_args: ServerArgs,
@@ -425,7 +414,6 @@ def _apply_model_worker_backend_policy(
         and moe_runner_backend == "auto"
     ):
         # Note:(Chenchen Hong) flashinfer_cutlass MoE deadlocks CUDA-graph
-        # capture on H20 (no H20 kernel coverage); triton captures cleanly there.
         server_args.moe_runner_backend = (
             "triton" if _is_h20_device() else "flashinfer_cutlass"
         )
@@ -472,8 +460,6 @@ def _apply_model_worker_backend_policy(
         and has_native_fp8_block_quant
         and fp8_gemm_backend in (None, "auto")
     ):
-        # Projected talker prefill has request-dependent FP8 dense GEMM shapes
-        # outside decode CUDA graph replay; DeepGEMM can otherwise JIT there.
         server_args.fp8_gemm_runner_backend = "triton"
         fp8_gemm_backend = server_args.fp8_gemm_runner_backend
 
@@ -487,12 +473,10 @@ def _apply_model_worker_backend_policy(
     )
     return effective_quantization
 
-
 def _normalize_quantization(value: object) -> str | None:
     if value is None:
         return None
     return str(value).lower()
-
 
 def _model_config_has_moe(model_config: ModelConfig) -> bool:
     config_to_check = getattr(model_config, "hf_text_config", None)
@@ -500,7 +484,6 @@ def _model_config_has_moe(model_config: ModelConfig) -> bool:
         hf_config = getattr(model_config, "hf_config", None)
         config_to_check = getattr(hf_config, "text_config", hf_config)
     return hasattr(config_to_check, "num_experts_per_tok")
-
 
 def _model_config_has_native_fp8_block_quant(model_config: ModelConfig) -> bool:
     quant_config = _get_hf_quantization_config(model_config)
@@ -512,7 +495,6 @@ def _model_config_has_native_fp8_block_quant(model_config: ModelConfig) -> bool:
         _normalize_quantization(quant_method) == "fp8" and weight_block_size is not None
     )
 
-
 def _get_hf_quantization_config(model_config: ModelConfig) -> object | None:
     hf_config = getattr(model_config, "hf_config", None)
     quant_config = getattr(hf_config, "quantization_config", None)
@@ -522,12 +504,10 @@ def _get_hf_quantization_config(model_config: ModelConfig) -> object | None:
     hf_text_config = getattr(model_config, "hf_text_config", None)
     return getattr(hf_text_config, "quantization_config", None)
 
-
 def _get_config_value(config: object, key: str) -> object | None:
     if isinstance(config, dict):
         return config.get(key)
     return getattr(config, key, None)
-
 
 def _is_h20_device() -> bool:
     """True only on NVIDIA H20 (word-boundary match so "H200" isn't caught)."""
@@ -542,7 +522,6 @@ def _is_h20_device() -> bool:
     except Exception:
         return False
 
-
 def _is_fp8_cutlass_moe_supported() -> bool:
     """Mirror pinned SGLang 0.5.12.post1 FP8 CUTLASS MoE assertions."""
     try:
@@ -554,7 +533,6 @@ def _is_fp8_cutlass_moe_supported() -> bool:
     return bool(
         cutlass_fp8_supported() and (is_sm90_supported() or is_sm100_supported())
     )
-
 
 def _initialize_model_worker_backend_globals(
     server_args: ServerArgs,

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -20,7 +20,6 @@ from sglang_omni.proto import StagePayload
 
 logger = logging.getLogger(__name__)
 
-
 def _compile_s2pro_codebook_decoder(model: Any, *, max_batch_size: int) -> None:
     """Compile Fast AR decoder layers while leaving sampling and loop control eager."""
     from sglang.srt.model_executor.cuda_graph_runner import set_torch_compile_config
@@ -49,14 +48,12 @@ def _compile_s2pro_codebook_decoder(model: Any, *, max_batch_size: int) -> None:
         max_batch_size,
     )
 
-
 def _resolve_checkpoint(checkpoint: str) -> str:
     if os.path.isdir(checkpoint):
         return checkpoint
     from huggingface_hub import snapshot_download
 
     return snapshot_download(checkpoint)
-
 
 def _load_codec(checkpoint_dir: str, device: str):
     from hydra.utils import instantiate
@@ -79,20 +76,12 @@ def _load_codec(checkpoint_dir: str, device: str):
     codec.eval().to(device)
     return codec
 
-
 def load_state(payload: StagePayload) -> S2ProState:
     return S2ProState.from_dict(payload.data)
-
 
 def store_state(payload: StagePayload, state: S2ProState) -> StagePayload:
     payload.data = state.to_dict()
     return payload
-
-
-# ---------------------------------------------------------------------------
-# Preprocessing — returns callable
-# ---------------------------------------------------------------------------
-
 
 def create_preprocessing_executor(
     model_path: str,
@@ -201,12 +190,6 @@ def create_preprocessing_executor(
         return store_state(payload, state)
 
     return ThreadedSimpleScheduler(_preprocess, max_concurrency=max_concurrency)
-
-
-# ---------------------------------------------------------------------------
-# TTS Engine — returns OmniScheduler
-# ---------------------------------------------------------------------------
-
 
 def create_sglang_tts_engine_executor(
     model_path: str,
@@ -327,12 +310,6 @@ def create_sglang_tts_engine_executor(
         max_new_tokens=max_new_tokens,
     )
     return scheduler
-
-
-# ---------------------------------------------------------------------------
-# Vocoder — returns callable
-# ---------------------------------------------------------------------------
-
 
 def create_vocoder_executor(
     model_path: str,

--- a/sglang_omni/models/higgs_tts/model_runner.py
+++ b/sglang_omni/models/higgs_tts/model_runner.py
@@ -25,7 +25,6 @@ from sglang_omni.scheduling.messages import OutgoingMessage
 
 logger = logging.getLogger(__name__)
 
-
 class HiggsTTSModelRunner(ModelRunner):
     """ModelRunner for :class:`HiggsTTSModel`."""
 
@@ -85,14 +84,6 @@ class HiggsTTSModelRunner(ModelRunner):
         staging = self._decode_pack_gpu(n_real)
         host_buf = self._next_host_staging(self.model._cg_collect_staging)
         host_buf[:n_real].copy_(staging[:n_real], non_blocking=True)
-        # Set next_token_ids (cb0) from GPU state now, with NO host sync, so the
-        # AR input chain (next step's input_ids = this step's output_ids) is
-        # available at launch — the host collect (post_decode_resolve) lags by
-        # one step under lookahead. For Higgs the decode input_ids is masked by
-        # _decode_step_embeds_cg (rows with codes use _cg_active_last_codes), so
-        # this only feeds the upstream bookkeeping. clamp>=0 keeps STOP_CODE(-1)
-        # rows in embed_tokens range; the host collect later overwrites with the
-        # skip-aware cb0 for output reporting.
         result.next_token_ids = (
             self.model._cg_codes_BN[:n_real, 0].clamp_min(0).to(torch.long).clone()
         )
@@ -142,18 +133,6 @@ class HiggsTTSModelRunner(ModelRunner):
         )
 
         if self._async_enabled and is_lookahead and n_real > 0:
-            # Async-lookahead overrun guard (GPU-side, no host sync): a request
-            # that finished via EOC at the prior step is still in this batch
-            # with pool.generation_done=True. Running the normal decode forward
-            # for such a done row trips a device-side gather assert, so route it
-            # to the reset padding row — its overrun output is discarded by the
-            # collect's finished()/was_done skip anyway. Length-finish rows have
-            # generation_done=False and are untouched.
-            #
-            # Only the lookahead launch path can carry such an overrun (the
-            # 1-wasted-step lag). On a fast-path (sync) decode step finished reqs
-            # are filtered out before the step, so no generation_done row is ever
-            # present and this gather+torch.where would be pure wasted GPU work.
             rows_t_real = model._cg_row_indices[:n_real]
             done = model._sampler_pool.generation_done[rows_t_real]
             model._cg_row_indices[:n_real] = torch.where(
@@ -232,7 +211,7 @@ class HiggsTTSModelRunner(ModelRunner):
                 f"forward_batch.batch_size ({bs}) < len(requests) ({n_real})"
             )
         staging = self._decode_pack_gpu(n_real)
-        combined_cpu = staging[:n_real].cpu()  # one blocking D2H (sync path)
+        combined_cpu = staging[:n_real].cpu()
         self._decode_collect_host(
             combined_cpu,
             result,
@@ -292,12 +271,6 @@ class HiggsTTSModelRunner(ModelRunner):
             if req.is_chunked > 0:
                 cb0_per_row.append(0)
                 continue
-            # Already finished in an earlier step? Skip its append. Under async
-            # lookahead the finished req gets one extra (wasted) forward before
-            # being dropped; this prevents leaking that overrun token. Catches
-            # length finishes too (which `_cg_was_done`, an EOC-only flag, does
-            # not). No-op for the sync path: a req is never finished() at its
-            # own collect (finish is set later, in process_batch_result).
             if req.finished():
                 cb0_per_row.append(0)
                 continue
@@ -414,6 +387,5 @@ class HiggsTTSModelRunner(ModelRunner):
                 metadata=metadata,
             )
         )
-
 
 __all__ = ["HiggsTTSModelRunner"]

--- a/sglang_omni/models/higgs_tts/payload_types.py
+++ b/sglang_omni/models/higgs_tts/payload_types.py
@@ -9,40 +9,35 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-
 @dataclass
 class HiggsTtsState:
     """Per-request state threaded through preprocessing → audio_encoder →
     tts_engine → vocoder. Fields populate lazily so a deserialised state is
     valid at any stage boundary."""
 
-    # preprocessing / audio_encoder
     prompt_token_ids: list[int] = field(default_factory=list)
     reference_codes_delayed: list[list[int]] | None = None
     target_text: str | None = None
     reference_text: str | None = None
-    reference_waveform: Any | None = None  # mono 24 kHz [1, 1, L] torch.Tensor
+    reference_waveform: Any | None = None
     reference_code_cache_key: str | None = None
     uploaded_voice_name: str | None = None
     uploaded_voice_created_at: int | None = None
 
     num_codebooks: int = 8
-    codebook_size: int = 1026  # 1024 data + <|boc|> + <|eoc|>
+    codebook_size: int = 1026
 
-    # generation params
     max_new_tokens: int = 2048
     temperature: float = 1.0
     top_p: float | None = None
     top_k: int | None = None
     seed: int | None = None
 
-    # tts_engine
     output_codes_delayed: list[list[int]] | None = None
     prompt_tokens: int = 0
     completion_tokens: int = 0
     engine_time_s: float = 0.0
 
-    # vocoder
     audio_samples: Any | None = None
     sample_rate: int = 24000
 
@@ -108,6 +103,5 @@ class HiggsTtsState:
             audio_samples=data.get("audio_samples"),
             sample_rate=data.get("sample_rate", 24000),
         )
-
 
 __all__ = ["HiggsTtsState"]

--- a/sglang_omni/models/higgs_tts/request_builders.py
+++ b/sglang_omni/models/higgs_tts/request_builders.py
@@ -17,7 +17,6 @@ from sglang_omni.models.tts_streaming import INITIAL_CODEC_CHUNK_FRAMES_PARAM
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
 
-
 @dataclass
 class HiggsSGLangRequestData(SGLangARRequestData):
     """Per-request state for the Higgs TTS scheduler."""
@@ -31,18 +30,14 @@ class HiggsSGLangRequestData(SGLangARRequestData):
     engine_start_s: float = 0.0
     stream_metadata: dict[str, Any] | None = None
 
-
 class _ResettableHiggsModel(Protocol):
     def reset_request(self, req_id: str) -> None: ...
-
 
 _HiggsRequestBuilder = Callable[[StagePayload], HiggsSGLangRequestData]
 _HiggsResultAdapter = Callable[[HiggsSGLangRequestData], StagePayload]
 
-
 def _perf_counter() -> float:
     return time.perf_counter()
-
 
 def _ref_audio_fingerprint(codes: list[list[int]] | None) -> str | None:
     """Stable hash of the full N-codebook ref-audio sequence.
@@ -63,7 +58,6 @@ def _ref_audio_fingerprint(codes: list[list[int]] | None) -> str | None:
             i += 2
     return hashlib.blake2b(bytes(buf), digest_size=16).hexdigest()
 
-
 def build_sglang_higgs_request(
     state: HiggsTtsState, *, request_id: str = ""
 ) -> HiggsSGLangRequestData:
@@ -81,14 +75,8 @@ def build_sglang_higgs_request(
     if state.seed is not None:
         sp_kwargs["sampling_seed"] = int(state.seed)
     sampling_params = SamplingParams(**sp_kwargs)
-    # tokenizer_manager.normalize() is bypassed in our custom pipeline;
-    # without it stop_strs / stop_regex_strs stay None and the upstream
-    # scheduler's check_finished trips on ``len(None)``.
     sampling_params.normalize(tokenizer=None)
 
-    # vocab_size = backbone text vocab so cb0 rides sglang's standard sampler path.
-    # extra_key namespaces the radix cache per ref-audio fingerprint so prompts
-    # sharing the -100 placeholder prefix can never cross-contaminate KV.
     req = Req(
         rid=request_id,
         origin_input_text="",
@@ -97,7 +85,6 @@ def build_sglang_higgs_request(
         vocab_size=151_936,
         extra_key=_ref_audio_fingerprint(state.reference_codes_delayed),
     )
-    # V1's prefill manager probes these attrs; absence triggers AttributeError.
     req._codec_suppress_tokens = None
     req._input_embeds_are_projected = False
 
@@ -112,7 +99,6 @@ def build_sglang_higgs_request(
         top_p=float(state.top_p) if state.top_p is not None else 1.0,
         top_k=int(state.top_k) if state.top_k is not None else -1,
     )
-
 
 def build_higgs_stream_metadata(
     payload: StagePayload, data: HiggsSGLangRequestData
@@ -144,7 +130,6 @@ def build_higgs_stream_metadata(
         ]
     return metadata
 
-
 def apply_higgs_result(state: HiggsTtsState, data: HiggsSGLangRequestData) -> None:
     if data.output_codes:
         codes = torch.stack(data.output_codes, dim=0).to(torch.long)
@@ -153,7 +138,6 @@ def apply_higgs_result(state: HiggsTtsState, data: HiggsSGLangRequestData) -> No
     else:
         state.output_codes_delayed = None
     state.prompt_tokens = len(data.input_ids)
-
 
 def make_higgs_scheduler_adapters(
     model: _ResettableHiggsModel,
@@ -195,7 +179,6 @@ def make_higgs_scheduler_adapters(
         )
 
     return request_builder, result_adapter
-
 
 __all__ = [
     "HiggsSGLangRequestData",

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -49,8 +49,6 @@ from sglang_omni.models.higgs_tts.vocoder_scheduler import (
     HiggsStreamingVocoderScheduler,
 )
 
-# _REF_PATH_HASH_MEMO is the shared memo object, re-exported so tests can
-# reset it; the underscored alias keeps this module's historical API.
 from sglang_omni.preprocessing.cache_key import _REF_PATH_HASH_MEMO  # noqa: F401
 from sglang_omni.preprocessing.cache_key import hash_bytes, hash_media_item
 from sglang_omni.preprocessing.cache_key import (
@@ -73,15 +71,11 @@ from sglang_omni.scheduling.threaded_simple_scheduler import ThreadedSimpleSched
 
 logger = logging.getLogger(__name__)
 
-
-# Codec runs at 75 Hz; chunked prefill of the multi-codebook prompt is unsafe
-# (sampler state machine has no rollback) so reject inputs past chunked_prefill_size.
 _MAX_REF_AUDIO_SEC = 100
 _REF_CODE_CACHE_MAX_ITEMS = 256
 _REF_CODE_CACHE_MAX_BYTES = 256 * 1024 * 1024
 _REF_WAVEFORM_CACHE_MAX_ITEMS = 256
 _REF_WAVEFORM_CACHE_MAX_BYTES = 512 * 1024 * 1024
-
 
 def _reference_audio_cache_key(reference_audio: Any) -> str | None:
     """Safe source key for preprocessing waveform-cache lookup."""
@@ -103,7 +97,6 @@ def _reference_audio_cache_key(reference_audio: Any) -> str | None:
     raw = base64.b64decode(encoded) if isinstance(encoded, str) else bytes(encoded)
     return hash_media_item(raw)
 
-
 def _reference_code_cache_key_from_waveform(
     waveform: torch.Tensor, sample_rate: int
 ) -> str:
@@ -115,7 +108,6 @@ def _reference_code_cache_key_from_waveform(
     wav = waveform.detach().cpu().contiguous().float()
     meta = f"sr:{int(sample_rate)}|shape:{tuple(wav.shape)}"
     return f"waveform:{meta}:{hash_bytes(wav.numpy().tobytes())}"
-
 
 def _uploaded_voice_cache_key(
     reference_audio: Any,
@@ -135,7 +127,6 @@ def _uploaded_voice_cache_key(
         artifact_kind=artifact_kind,
     )
 
-
 def _state_uploaded_voice_cache_key(
     state: HiggsTtsState,
     *,
@@ -149,7 +140,6 @@ def _state_uploaded_voice_cache_key(
         voice_version=int(state.uploaded_voice_created_at),
         artifact_kind=artifact_kind,
     )
-
 
 def create_preprocessing_executor(
     model_path: str,
@@ -171,7 +161,6 @@ def create_preprocessing_executor(
     raw = Tokenizer.from_file(os.path.join(checkpoint_dir, "tokenizer.json"))
     tokenizer = PreTrainedTokenizerFast(tokenizer_object=raw)
     adapter = HiggsTokenizerAdapter(tokenizer)
-    # Runs on a ThreadedSimpleScheduler pool for preprocessing;
     reference_waveform_cache = StageOutputCache(
         max_size=_REF_WAVEFORM_CACHE_MAX_ITEMS,
         max_bytes=_REF_WAVEFORM_CACHE_MAX_BYTES,
@@ -307,7 +296,6 @@ def create_preprocessing_executor(
 
     return ThreadedSimpleScheduler(_preprocess, max_concurrency=max_concurrency)
 
-
 def create_audio_encoder_executor(
     model_path: str,
     *,
@@ -333,8 +321,6 @@ def create_audio_encoder_executor(
     codec.encode_reference(
         torch.zeros(codec.SAMPLE_RATE), sample_rate=codec.SAMPLE_RATE
     )
-    # Single-threaded SimpleScheduler stage, so no lock needed. Cache a CPU
-    # tensor (not list[list[int]]) so StageOutputCache can byte-bound it.
     reference_code_cache = StageOutputCache(
         max_size=_REF_CODE_CACHE_MAX_ITEMS,
         max_bytes=_REF_CODE_CACHE_MAX_BYTES,
@@ -389,7 +375,6 @@ def create_audio_encoder_executor(
 
     return SimpleScheduler(_encode)
 
-
 def create_sglang_tts_engine_executor(
     model_path: str,
     *,
@@ -412,9 +397,6 @@ def create_sglang_tts_engine_executor(
         "max_running_requests": max_running_requests,
         "chunked_prefill_size": 8192,
         "dtype": "bfloat16",
-        # Radix cache is namespaced per ref-audio via Req.extra_key (set in
-        # build_sglang_higgs_request); shared -100 placeholder prefixes from
-        # different ref audios can't cross-contaminate the KV tree.
     }
     if server_args_overrides:
         overrides.update(server_args_overrides)
@@ -469,7 +451,6 @@ def create_sglang_tts_engine_executor(
     model_runner.set_stream_outbox(scheduler.outbox)
     return scheduler
 
-
 def create_vocoder_executor(
     model_path: str,
     *,
@@ -498,7 +479,6 @@ def create_vocoder_executor(
         stream_overlap_tokens=stream_overlap_tokens,
         stream_holdback_tokens=stream_holdback_tokens,
     )
-
 
 __all__ = [
     "create_audio_encoder_executor",

--- a/sglang_omni/models/higgs_tts/utils.py
+++ b/sglang_omni/models/higgs_tts/utils.py
@@ -24,13 +24,10 @@ from sglang_omni.preprocessing.audio import AudioMediaIO
 from sglang_omni.preprocessing.base import _is_url
 from sglang_omni.preprocessing.resource_connector import global_http_connection
 
-# Codec-vocab specials (inside the [N*V] codebook space, NOT the text vocab).
 BOC_ID = 1024
 EOC_ID = 1025
 
-# Shared between audio_encoder + vocoder; one codec load saves ~1 GB VRAM.
 _CODEC_CACHE: dict[tuple[str, str, str], HiggsAudioCodec] = {}
-
 
 def apply_delay_pattern(codes_TN: torch.Tensor) -> torch.Tensor:
     """``[T, N]`` raw codes → ``[T + N - 1, N]`` delayed, BOC/EOC padded."""
@@ -47,7 +44,6 @@ def apply_delay_pattern(codes_TN: torch.Tensor) -> torch.Tensor:
         out[t_idx < c, c] = BOC_ID
         out[c : c + T, c] = codes_TN[:, c]
     return out
-
 
 def reverse_delay_pattern(delayed_LN: torch.Tensor) -> torch.Tensor:
     """``[L, N]`` delayed (L >= N) → ``[L - (N - 1), N]`` raw codes."""
@@ -67,7 +63,6 @@ def reverse_delay_pattern(delayed_LN: torch.Tensor) -> torch.Tensor:
         out[:, c] = delayed_LN[c : c + T, c]
     return out
 
-
 def truncate_rope_to_bf16(model: torch.nn.Module) -> None:
     """bf16-truncate sglang's fp32 ``cos_sin_cache`` in-place (stored as fp32)
     to match Higgs's bf16 training-time RoPE.
@@ -78,13 +73,11 @@ def truncate_rope_to_bf16(model: torch.nn.Module) -> None:
             truncated = cache.to(torch.bfloat16).to(cache.dtype)
             cache.copy_(truncated)
 
-
 def resolve_checkpoint(checkpoint: str) -> str:
     """Local dir or HF repo id → local snapshot path."""
     if Path(checkpoint).is_dir():
         return checkpoint
     return snapshot_download(checkpoint)
-
 
 def get_or_load_codec(path: str, device: str, dtype: str) -> HiggsAudioCodec:
     """Process-wide cached :class:`HiggsAudioCodec` per (path, device, dtype)."""
@@ -98,7 +91,6 @@ def get_or_load_codec(path: str, device: str, dtype: str) -> HiggsAudioCodec:
     _CODEC_CACHE[key] = codec
     return codec
 
-
 def to_codes_TN(raw: Any, num_codebooks: int) -> torch.Tensor | None:
     """Coerce client-supplied ``reference_codes`` to a ``[T, N]`` int64 tensor."""
     if raw is None:
@@ -111,7 +103,6 @@ def to_codes_TN(raw: Any, num_codebooks: int) -> torch.Tensor | None:
             f"reference_codes must have shape [T, {num_codebooks}], got {tuple(t.shape)}"
         )
     return t.to(torch.long)
-
 
 def load_audio_to_24k(reference_audio: Any) -> tuple[np.ndarray, int]:
     """Load ``inputs["reference_audio"]`` as 24 kHz mono float32.
@@ -145,7 +136,6 @@ def load_audio_to_24k(reference_audio: Any) -> tuple[np.ndarray, int]:
             reference_audio.get("audio_path") or reference_audio["path"]
         )
     raise ValueError("reference_audio must include audio_path, path, bytes, or data")
-
 
 __all__ = [
     "BOC_ID",

--- a/sglang_omni/models/ming_omni/bootstrap.py
+++ b/sglang_omni/models/ming_omni/bootstrap.py
@@ -11,7 +11,6 @@ logger = logging.getLogger(__name__)
 
 StreamOutputBuilder = Callable[[str, Any, Any], list[Any]]
 
-
 def create_thinker_scheduler(
     server_args: Any,
     *,
@@ -105,7 +104,6 @@ def create_thinker_scheduler(
         stream_output_builder=stream_output_builder,
     )
 
-
 def make_thinker_scheduler_adapters(
     *,
     tokenizer: Any,
@@ -132,9 +130,6 @@ def make_thinker_scheduler_adapters(
         if not hasattr(input_ids, "to"):
             raise TypeError("prompt.input_ids must be a torch.Tensor")
 
-        # Per-content pad_value substitution to defeat SGLang radix prefix-cache
-        # aliasing across multimodal requests that share the same generic
-        # image/audio/video patch token id.
         thinker_inputs_early = state.thinker_inputs or {}
         media_cache_keys = thinker_inputs_early.get("media_cache_keys") or {}
         pad_values: dict[str, int] = {}
@@ -247,7 +242,6 @@ def make_thinker_scheduler_adapters(
 
     return request_builder, result_adapter
 
-
 def make_combined_stream_output_builder(
     *builders: StreamOutputBuilder,
 ) -> StreamOutputBuilder:
@@ -260,7 +254,6 @@ def make_combined_stream_output_builder(
         return messages
 
     return _build_stream_output
-
 
 def _select_stream_output_builder(
     enable_streaming_tts: bool,
@@ -277,7 +270,6 @@ def _select_stream_output_builder(
             ),
         )
     return make_text_stream_output_builder()
-
 
 def make_text_stream_output_builder(*, text_decode_stage: str = "decode"):
     """Per-token stream callback for text-only pipelines.
@@ -313,8 +305,6 @@ def make_text_stream_output_builder(*, text_decode_stage: str = "decode"):
         if not is_streaming:
             return []
 
-        # Only emit text deltas when text output is actually requested.
-        # Mirrors the output_modalities check in talker_executor.py.
         if not text_output_requested(stage_payload.request):
             return []
 
@@ -322,7 +312,6 @@ def make_text_stream_output_builder(*, text_decode_stage: str = "decode"):
             OutgoingMessage(
                 request_id=request_id,
                 type="stream",
-                # Wrap int — relay_io.write_blob is tensor-only.
                 data=torch.tensor([token_id], dtype=torch.long),
                 target=text_decode_stage,
                 metadata={"token_id": token_id},
@@ -330,7 +319,6 @@ def make_text_stream_output_builder(*, text_decode_stage: str = "decode"):
         ]
 
     return _build_stream_output
-
 
 def make_thinker_stream_output_builder(
     *,
@@ -353,9 +341,6 @@ def make_thinker_stream_output_builder(
 
     def _build_stream_output(request_id, req_data, req_output):
         req = getattr(req_data, "req", None)
-        # Suppress while chunked prefill is still consuming prompt tokens —
-        # prompt-side states could otherwise masquerade as the first
-        # assistant token and leak prompt content into TTS.
         if req is not None and int(getattr(req, "is_chunked", 0) or 0) > 0:
             return []
         if req_output.data is None or req is None:
@@ -366,8 +351,6 @@ def make_thinker_stream_output_builder(
         except (TypeError, ValueError):
             return []
 
-        # Per-request state lives on ``req`` so it is automatically GC'd when
-        # the SGLang scheduler drops the request.
         token_ids = getattr(req, "_ming_stream_token_ids", None)
         if token_ids is None:
             token_ids = []
@@ -382,14 +365,12 @@ def make_thinker_stream_output_builder(
             return []
 
         decoded = tokenizer.decode(token_ids, skip_special_tokens=True)
-        # Buffer until the trailing multi-byte char completes.
         if "\ufffd" in decoded:
             return []
 
         if decoded.startswith(emitted):
             delta = decoded[len(emitted) :]
         else:
-            # Defensive: detokenizer rewrote earlier text — re-emit full.
             delta = decoded
         if not delta:
             return []
@@ -400,13 +381,6 @@ def make_thinker_stream_output_builder(
             list(delta.encode("utf-8")),
             dtype=torch.uint8,
         )
-        # Only emit to the segmenter. The thinker is not a terminal stage,
-        # so it cannot send chunks directly to the coordinator via
-        # target=None — the runtime would fan that out to ``stream_to``
-        # peers, and the relay transport requires torch.Tensor payloads.
-        # Streaming text deltas to the client requires either a stream-
-        # aware decode stage or a dedicated text fan-out stage; left as a
-        # follow-up. Streaming audio still works via the talker_stream.
         return [
             OutgoingMessage(
                 request_id=request_id,
@@ -424,18 +398,15 @@ def make_thinker_stream_output_builder(
 
     return _build_stream_output
 
-
 def _torch_long():
     import torch
 
     return torch.long
 
-
 def _collect_eos_token_ids(tokenizer: Any) -> set[int] | None:
     """Match Ming V0: let the SGLang request stop only on tokenizer EOS."""
     eid = getattr(tokenizer, "eos_token_id", None)
     return {int(eid)} if isinstance(eid, int) and eid >= 0 else None
-
 
 def _stop_hits(output_ids: list[int], tokenizer: Any) -> list[int]:
     stop_ids = _collect_eos_token_ids(tokenizer) or set()

--- a/sglang_omni/models/ming_omni/components/streaming_detokenizer.py
+++ b/sglang_omni/models/ming_omni/components/streaming_detokenizer.py
@@ -39,17 +39,8 @@ logger = logging.getLogger(__name__)
 _DONE_SEEN_MAX = 10000
 _DONE_SEEN_EVICT_TO = 5000
 
-# The Stage runtime delivers abort(request_id) whenever a request fails or is
-# cancelled, which calls our abort() and removes the entry from _state. This
-# cap is a safety net against orphan entries if abort is ever lost (e.g. a
-# stream_chunk arrived before new_request, and the request was aborted before
-# new_request was delivered to the decode stage). Only entries idle for
-# _STATE_ORPHAN_IDLE_S are evicted: live streaming requests receive chunks
-# continuously, and done=True entries are awaiting an imminent new_request —
-# evicting either would drop tokens or hang an active request.
 _STATE_MAX = 10000
 _STATE_ORPHAN_IDLE_S = 300.0
-
 
 @dataclass
 class _RequestState:
@@ -57,7 +48,6 @@ class _RequestState:
     payload: StagePayload | None = None
     done: bool = False
     last_seen: float = 0.0
-
 
 class MingStreamingDetokenizeScheduler:
     """Stream-aware decode stage for Ming-Omni text-only pipelines.
@@ -81,8 +71,6 @@ class MingStreamingDetokenizeScheduler:
         self._running = False
         self._state: dict[str, _RequestState] = {}
         self._done_seen: OrderedDict[str, None] = OrderedDict()
-        # abort() runs on the stage's event-loop thread while start() runs on
-        # the scheduler thread; guards iteration/multi-op sections.
         self._state_lock = threading.Lock()
 
     def start(self) -> None:
@@ -149,8 +137,6 @@ class MingStreamingDetokenizeScheduler:
             )
 
     def _on_stream_chunk(self, request_id: str, item: Any) -> None:
-        # item is the StreamItem the runtime wraps around the thinker's
-        # torch.tensor([token_id], dtype=torch.long)
         data = item.data
         token_id = int(data.item()) if hasattr(data, "item") else int(data)
 
@@ -158,10 +144,6 @@ class MingStreamingDetokenizeScheduler:
         s.pending_tokens.append(token_id)
 
         candidate = self._tokenizer.decode(s.pending_tokens, skip_special_tokens=True)
-        # A trailing U+FFFD means an incomplete multi-byte UTF-8 char; hold
-        # until the next token. Interior U+FFFD (model emitting a literal
-        # replacement char) flushes normally — holding would stall streaming
-        # for the rest of the request.
         if candidate.endswith("�"):
             return
 
@@ -173,7 +155,7 @@ class MingStreamingDetokenizeScheduler:
             OutgoingMessage(
                 request_id=request_id,
                 type="stream",
-                target=None,  # terminal stream → Coordinator
+                target=None,
                 data={
                     "text": candidate,
                     "modality": "text",
@@ -186,8 +168,6 @@ class MingStreamingDetokenizeScheduler:
     def _on_stream_done(self, request_id: str) -> None:
         s = self._state.get(request_id)
         if s is None:
-            # Zero-token generation or late duplicate done — latch for
-            # _on_new_request to consume.
             self._done_seen[request_id] = None
             if len(self._done_seen) > _DONE_SEEN_MAX:
                 with self._state_lock:
@@ -214,7 +194,6 @@ class MingStreamingDetokenizeScheduler:
         if s is None or s.payload is None:
             return
 
-        # Flush any remaining pending tokens (e.g. truncated UTF-8 on max_tokens).
         if s.pending_tokens:
             leftover = self._tokenizer.decode(
                 s.pending_tokens, skip_special_tokens=True
@@ -282,11 +261,6 @@ class MingStreamingDetokenizeScheduler:
             result.update(final_event.payload)
             result.setdefault("modality", final_event.modality)
 
-        # Streaming clients already received the full output as per-token
-        # deltas; strip text from the terminal result to prevent
-        # double-sending. Must mirror the emission gate in
-        # make_text_stream_output_builder: when text output was not requested
-        # no deltas were ever emitted, so the final result keeps its text.
         if is_streaming and text_output_requested(payload.request):
             result.pop("text", None)
         elif "text" not in result:
@@ -301,7 +275,6 @@ class MingStreamingDetokenizeScheduler:
 
         return result
 
-
 def _event_to_dict(event: Any) -> dict[str, Any]:
     return {
         "type": event.type,
@@ -309,7 +282,6 @@ def _event_to_dict(event: Any) -> dict[str, Any]:
         "payload": dict(event.payload),
         "is_final": bool(event.is_final),
     }
-
 
 def text_output_requested(request: Any) -> bool:
     """Return True if text is among the requested output modalities.
@@ -329,7 +301,6 @@ def text_output_requested(request: Any) -> bool:
         return any(str(m).lower() == "text" for m in modalities)
     return True
 
-
 def _attach_decode_final_metadata(
     result: dict[str, Any],
     state: MingOmniPipelineState,
@@ -339,7 +310,6 @@ def _attach_decode_final_metadata(
     if finish_reason is not None:
         result.setdefault("finish_reason", finish_reason)
     result.setdefault("usage", build_text_usage(state, thinker_out))
-
 
 def create_ming_streaming_detokenize_scheduler(
     model_path: str,

--- a/sglang_omni/models/moss_tts/request_builders.py
+++ b/sglang_omni/models/moss_tts/request_builders.py
@@ -28,10 +28,8 @@ _TOKEN_PREFIX_START_RE = re.compile(r"^\$\{token:")
 _DATA_URI_RE = re.compile(r"^data:audio/[^;,]+;base64,(?P<data>.+)$", re.DOTALL)
 _INF_DELAY = -1
 
-
 def _new_moss_tts_sampling_seed() -> int:
     return new_random_sampling_seed()
-
 
 def derive_moss_tts_sampling_seed(public_seed: int) -> int:
     """Derive a stable per-request sampling seed from a public ``seed``.
@@ -42,7 +40,6 @@ def derive_moss_tts_sampling_seed(public_seed: int) -> int:
     neighbours. This makes ``seed`` reproducible at any batch size, not just 1.
     """
     return derive_sampling_seed("moss-tts", int(public_seed))
-
 
 _GENERATION_FIELDS = (
     "max_new_tokens",
@@ -58,7 +55,6 @@ _GENERATION_FIELDS = (
     "audio_top_k",
     "audio_repetition_penalty",
 )
-
 
 @dataclass
 class MossTTSSGLangRequestData(ARRequestData):
@@ -94,7 +90,6 @@ class MossTTSSGLangRequestData(ARRequestData):
     is_audio: bool = False
     engine_start_s: float = 0.0
 
-
 @dataclass
 class MossTTSPreparedRequest:
     """Heavy MOSS-TTS preprocessing output consumed by the AR scheduler."""
@@ -105,21 +100,15 @@ class MossTTSPreparedRequest:
     prompt_rows: torch.Tensor
     gen_kwargs: dict[str, Any]
 
-
 @dataclass
 class MossTTSPreprocessingContext:
     processor: Any
 
-
 _PREPROCESSING_CONTEXT: MossTTSPreprocessingContext | None = None
 _PREPARED_REQUESTS: dict[str, MossTTSPreparedRequest] = {}
-# Request ids currently inside preprocess_moss_tts_payload.
 _INFLIGHT_REQUESTS: set[str] = set()
-# In-flight requests whose abort arrived before the handoff was published, so
-# compute drops the pending insert instead of leaking it into _PREPARED_REQUESTS.
 _ABORTED_REQUESTS: set[str] = set()
 _PREPARED_REQUESTS_LOCK = threading.Lock()
-
 
 def set_moss_tts_preprocessing_context(*, processor: Any) -> None:
     """Register the upstream MOSS processor used by preprocessing."""
@@ -131,7 +120,6 @@ def set_moss_tts_preprocessing_context(*, processor: Any) -> None:
         _INFLIGHT_REQUESTS.clear()
         _ABORTED_REQUESTS.clear()
 
-
 def clear_moss_tts_preprocessing_context() -> None:
     """Clear MOSS-TTS preprocessing globals, mainly for tests and reloads."""
 
@@ -141,7 +129,6 @@ def clear_moss_tts_preprocessing_context() -> None:
         _PREPARED_REQUESTS.clear()
         _INFLIGHT_REQUESTS.clear()
         _ABORTED_REQUESTS.clear()
-
 
 def cleanup_prepared_moss_tts_request(request_id: str) -> None:
     """Drop any prepared MOSS-TTS handoff for an aborted request.
@@ -157,7 +144,6 @@ def cleanup_prepared_moss_tts_request(request_id: str) -> None:
             return
         if rid in _INFLIGHT_REQUESTS:
             _ABORTED_REQUESTS.add(rid)
-
 
 def pop_prepared_moss_tts_request(
     payload: StagePayload,
@@ -175,7 +161,6 @@ def pop_prepared_moss_tts_request(
         )
     return prepared
 
-
 def normalize_moss_tts_inputs(inputs: Any) -> tuple[str, list[dict[str, Any]]]:
     if isinstance(inputs, str):
         return inputs, []
@@ -187,7 +172,6 @@ def normalize_moss_tts_inputs(inputs: Any) -> tuple[str, list[dict[str, Any]]]:
             dict(reference) for reference in references if isinstance(reference, dict)
         ]
     return str(inputs) if inputs is not None else "", []
-
 
 def resolve_moss_reference(
     references: list[dict[str, Any]],
@@ -204,13 +188,11 @@ def resolve_moss_reference(
     ref_text = reference.get("text") or tts_params.get("ref_text")
     return ref_audio, str(ref_text) if ref_text is not None else None
 
-
 def _resolve_optional_text(value: Any) -> str | None:
     if value is None:
         return None
     text = str(value).strip()
     return text or None
-
 
 def _resolve_token_count(
     text: str,
@@ -247,7 +229,6 @@ def _resolve_token_count(
         raise ValueError("MOSS-TTS ${token:N} count must be a positive integer")
     return text, None
 
-
 def build_moss_tts_state(payload: StagePayload) -> MossTTSState:
     inputs = payload.request.inputs or {}
     params = payload.request.params or {}
@@ -278,7 +259,6 @@ def build_moss_tts_state(payload: StagePayload) -> MossTTSState:
         generation_kwargs=build_generation_kwargs(params, tts_params=tts_params),
     )
 
-
 def build_generation_kwargs(
     params: dict[str, Any],
     *,
@@ -303,8 +283,6 @@ def build_generation_kwargs(
     generation_kwargs: dict[str, Any] = {
         "max_new_tokens": max_new_tokens,
         # note (chenyang): the checkpoint's own generate() defaults; greedy
-        # (temperature=0) collapses the codec LM into copying the reference
-        # audio. Callers may override any field.
         "text_temperature": 1.5,
         "audio_temperature": 1.7,
         "text_top_p": 1.0,
@@ -356,7 +334,6 @@ def build_generation_kwargs(
     _validate_moss_tts_generation_kwargs(generation_kwargs)
     return generation_kwargs
 
-
 def _validate_moss_tts_generation_kwargs(kwargs: dict[str, Any]) -> None:
     """Validate public sampling fields (MOSS uses a custom sampler that bypasses
     SGLang's SamplingParams.verify), raising ValueError on out-of-range values."""
@@ -386,7 +363,6 @@ def _validate_moss_tts_generation_kwargs(kwargs: dict[str, Any]) -> None:
     ):
         raise ValueError(f"MOSS-TTS seed must be a non-negative integer, got {seed!r}")
 
-
 def build_row_cache_key_ids(rows: torch.Tensor) -> list[int]:
     """Build stable radix-cache token ids for MOSS multi-channel prompt rows."""
 
@@ -396,7 +372,6 @@ def build_row_cache_key_ids(rows: torch.Tensor) -> list[int]:
         digest = hashlib.blake2b(row.numpy().tobytes(), digest_size=8).digest()
         key_ids.append(int.from_bytes(digest, "little") & ((1 << 63) - 1))
     return key_ids
-
 
 def _reference_for_processor(processor: Any, ref_audio: Any | None) -> list[Any] | None:
     if ref_audio is None:
@@ -420,7 +395,6 @@ def _reference_for_processor(processor: Any, ref_audio: Any | None) -> list[Any]
     codes = processor.encode_audios_from_wav([wav], int(sample_rate))[0]
     return [codes]
 
-
 def _build_processor_message(processor: Any, state: MossTTSState) -> dict[str, Any]:
     reference = _reference_for_processor(processor, state.ref_audio)
     return processor.build_user_message(
@@ -430,7 +404,6 @@ def _build_processor_message(processor: Any, state: MossTTSState) -> dict[str, A
         tokens=state.token_count,
         language=state.language,
     )
-
 
 def _prepare_moss_tts_request(
     payload: StagePayload,
@@ -454,7 +427,6 @@ def _prepare_moss_tts_request(
         prompt_rows=prompt_rows,
         gen_kwargs=state.generation_kwargs,
     )
-
 
 def preprocess_moss_tts_payload(payload: StagePayload) -> StagePayload:
     """Run MOSS-TTS prompt/reference preprocessing outside the AR scheduler."""
@@ -482,7 +454,6 @@ def preprocess_moss_tts_payload(payload: StagePayload) -> StagePayload:
         aborted = rid in _ABORTED_REQUESTS
         _ABORTED_REQUESTS.discard(rid)
         if not aborted:
-            # Aborted-while-preprocessing drops the handoff so it never lingers.
             _PREPARED_REQUESTS[rid] = prepared
 
     data = prepared.state.to_dict()
@@ -491,13 +462,11 @@ def preprocess_moss_tts_payload(payload: StagePayload) -> StagePayload:
         request_id=payload.request_id, request=payload.request, data=data
     )
 
-
 def _last_equal(rows: torch.Tensor, value: int) -> int:
     matches = (rows[:, 0] == int(value)).nonzero(as_tuple=False).flatten()
     if matches.numel() == 0:
         return -1
     return int(matches[-1].item())
-
 
 def _resolve_audio_payload_bounds(
     rows: torch.Tensor, cfg: Any
@@ -535,7 +504,6 @@ def _resolve_audio_payload_bounds(
         return None
     return start, end
 
-
 def _initialize_generation_state(
     data: MossTTSSGLangRequestData,
     *,
@@ -558,7 +526,6 @@ def _initialize_generation_state(
     assistant_start_idx = max(0, min(assistant_start_idx, seq_len))
     data.assistant_prefix_rows = prompt_rows[assistant_start_idx:].detach().clone()
     data.state.assistant_start_length = int(data.assistant_prefix_rows.shape[0])
-
 
 def build_sglang_moss_tts_request(
     payload: StagePayload,
@@ -629,7 +596,6 @@ def build_sglang_moss_tts_request(
     data.stage_payload = payload
     return data
 
-
 def apply_sglang_moss_tts_result(
     payload: StagePayload,
     data: MossTTSSGLangRequestData,
@@ -673,7 +639,6 @@ def apply_sglang_moss_tts_result(
         request=payload.request,
         data=state.to_dict(),
     )
-
 
 def make_moss_tts_scheduler_adapters(*, model: Any):
     """Build StagePayload <-> SGLang request adapters for MOSS-TTS."""

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -14,7 +14,6 @@ from sglang_omni.models.moss_tts_local.state_pool import MossTTSLocalDecodeJourn
 from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.types import RequestOutput
 
-
 class MossTTSLocalModelRunner(ModelRunner):
     """Drives the per-frame local-transformer decode and feedback embeddings.
 
@@ -133,17 +132,8 @@ class MossTTSLocalModelRunner(ModelRunner):
             prefix_len = len(req.prefix_indices)
             pool = self.model._state_pool
             if data.output_rows:
-                # KV-pressure retraction re-prefills with an extend region
-                # spanning already-generated frames; their rows live in
-                # output_rows, not prompt_rows. The resumed prefill samples
-                # the next frame itself, superseding any feedback embedding
-                # stranded by the retraction.
                 generated = torch.stack(data.output_rows, dim=0)
                 rows = torch.cat([rows.to(generated.device), generated], dim=0)
-            # Realign the launch-side counter and clear the stranded pool row on
-            # any retraction re-prefill, including one retracted before it emitted
-            # a frame (empty output_rows). Both are no-ops for a fresh prefill:
-            # the counters are already aligned and no pool row is held.
             generation_steps = int(data.generation_steps)
             data.sampling_steps = generation_steps
             pool.reset_for_refill(sched_req.request_id, generation_steps)
@@ -217,7 +207,6 @@ class MossTTSLocalModelRunner(ModelRunner):
         if not requests:
             return
         rows, end_id = self._run_frame_decode(result, forward_batch, requests)
-        # Radix key is a capture-safe GPU hash: a device op, no host sync.
         next_text = rows[:, 0]
         next_token_ids = self._row_radix_token_ids(rows, next_text, end_id)
         result.next_token_ids = next_token_ids
@@ -280,9 +269,6 @@ class MossTTSLocalModelRunner(ModelRunner):
         audio_top_p = params["audio_top_p"]
         audio_top_k = params["audio_top_k"]
         sampling_seeds = params["seeds"]
-        # Advance the launch-side counter only for emitted rows; non-final
-        # chunked rows take a read-only position so a mid-prefill chunk's frame
-        # cannot shift the final chunk's sampling position off the no-chunk path.
         emit_set = {
             i
             for i, sched_req in enumerate(requests)
@@ -346,8 +332,6 @@ class MossTTSLocalModelRunner(ModelRunner):
                 seeds=sampling_seeds,
                 base_positions=gen_steps * num_channels,
             )
-            # The graph outputs are static buffers that the next replay (any
-            # later prefill or decode step) overwrites; snapshot what we keep.
             codes = codes.clone()
             embeds = feedback.clone()
         else:
@@ -413,8 +397,6 @@ class MossTTSLocalModelRunner(ModelRunner):
                 pool_rows=emit_pool_rows,
                 rows=emit_rows,
             )
-        # Always return rows so both the sync inline path and the async launch
-        # publish next_token_ids; an all-chunked batch just attaches no journal.
         return rows, end_id
 
     def post_decode_launch(self, result: Any, forward_batch: Any, requests: list):
@@ -589,10 +571,6 @@ class MossTTSLocalModelRunner(ModelRunner):
         scheduler_output: Any,
         outputs: dict[str, RequestOutput],
     ) -> None:
-        # The per-step journal is the single source of truth for output
-        # collection. A missing journal means no frame was produced this step
-        # (e.g. a prefill-only batch), which is the synchronous-baseline early
-        # return.
         try:
             journal = result.moss_journal
         except AttributeError:
@@ -621,9 +599,6 @@ class MossTTSLocalModelRunner(ModelRunner):
             )
         rows_cpu: torch.Tensor | None = None
         for i, sched_req in enumerate(expected_reqs):
-            # Overrun: a request finished or retracted in a PRIOR step is still
-            # in this lagged resolve batch; its wasted frame must not reach
-            # output_rows / the vocoder. No-op on the sync path.
             req = sched_req.data.req
             if req is not None:
                 try:
@@ -646,7 +621,6 @@ class MossTTSLocalModelRunner(ModelRunner):
             if self._outbox is None:
                 continue
             if rows_cpu is None:
-                # One D2H per step regardless of how many requests stream.
                 rows_cpu = journal.rows.detach().to("cpu", torch.long)
             self._outbox.put(
                 OutgoingMessage(

--- a/sglang_omni/models/moss_tts_local/request_builders.py
+++ b/sglang_omni/models/moss_tts_local/request_builders.py
@@ -29,7 +29,6 @@ from sglang_omni.scheduling.types import ARRequestData
 
 _MOSS_TTS_LOCAL_PREPARED_MARKER = "_moss_tts_local_prepared_request"
 
-
 @dataclass
 class MossTTSLocalSGLangRequestData(ARRequestData):
     """Scheduler-owned request state for MOSS-TTS Local."""
@@ -38,8 +37,6 @@ class MossTTSLocalSGLangRequestData(ARRequestData):
     req: Any = None
     synced: bool = False
     generation_steps: int = 0
-    # Launch-side seeded-sampling step counter (async decode): advances at launch
-    # while generation_steps moves at resolve. Floored so the sync path is unchanged.
     sampling_steps: int | None = None
     suppress_tokens: list[int] | None = None
     input_embeds_are_projected: bool = False
@@ -48,9 +45,6 @@ class MossTTSLocalSGLangRequestData(ARRequestData):
     model_config: Any = None
     prompt_rows: torch.Tensor | None = None
     output_rows: list[torch.Tensor] = field(default_factory=list)
-    # Checkpoint generate() defaults: the binary continue/stop head samples at
-    # plain temperature 1.0 while the audio channels use the model-card
-    # recommendation (1.7 / 0.8 / 25, repetition penalty off).
     text_temperature: float = 1.0
     text_top_p: float = 1.0
     text_top_k: int = 50
@@ -61,9 +55,7 @@ class MossTTSLocalSGLangRequestData(ARRequestData):
     seed: int | None = None
     sampling_seed: int = field(default_factory=_new_moss_tts_sampling_seed)
     engine_start_s: float = 0.0
-    # Non-None marks a streaming request.
     stream_metadata: dict[str, Any] | None = None
-
 
 @dataclass
 class MossTTSLocalPreparedRequest:
@@ -75,19 +67,16 @@ class MossTTSLocalPreparedRequest:
     prompt_rows: torch.Tensor
     gen_kwargs: dict[str, Any]
 
-
 @dataclass
 class _PreprocessingContext:
     processor: Any
     reference_encoder: Any = None
-
 
 _PREPROCESSING_CONTEXT: _PreprocessingContext | None = None
 _PREPARED_REQUESTS: dict[str, MossTTSLocalPreparedRequest] = {}
 _INFLIGHT_REQUESTS: set[str] = set()
 _ABORTED_REQUESTS: set[str] = set()
 _PREPARED_REQUESTS_LOCK = threading.Lock()
-
 
 def set_moss_tts_local_preprocessing_context(
     *, processor: Any, reference_encoder: Any = None
@@ -101,7 +90,6 @@ def set_moss_tts_local_preprocessing_context(
         _INFLIGHT_REQUESTS.clear()
         _ABORTED_REQUESTS.clear()
 
-
 def clear_moss_tts_local_preprocessing_context() -> None:
     global _PREPROCESSING_CONTEXT
     with _PREPARED_REQUESTS_LOCK:
@@ -109,7 +97,6 @@ def clear_moss_tts_local_preprocessing_context() -> None:
         _PREPARED_REQUESTS.clear()
         _INFLIGHT_REQUESTS.clear()
         _ABORTED_REQUESTS.clear()
-
 
 def cleanup_prepared_moss_tts_local_request(request_id: str) -> None:
     """Drop any prepared handoff for an aborted request (see MOSS Delay)."""
@@ -119,7 +106,6 @@ def cleanup_prepared_moss_tts_local_request(request_id: str) -> None:
             return
         if rid in _INFLIGHT_REQUESTS:
             _ABORTED_REQUESTS.add(rid)
-
 
 def pop_prepared_moss_tts_local_request(
     payload: StagePayload,
@@ -136,7 +122,6 @@ def pop_prepared_moss_tts_local_request(
             f"{marker!r}; the AR scheduler must not rebuild it"
         )
     return prepared
-
 
 def build_moss_tts_local_state(payload: StagePayload) -> MossTTSLocalState:
     inputs = payload.request.inputs or {}
@@ -168,7 +153,6 @@ def build_moss_tts_local_state(payload: StagePayload) -> MossTTSLocalState:
         generation_kwargs=build_generation_kwargs(params, tts_params=tts_params),
     )
 
-
 def build_generation_kwargs(
     params: dict[str, Any],
     *,
@@ -192,7 +176,6 @@ def build_generation_kwargs(
 
     generation_kwargs: dict[str, Any] = {
         "max_new_tokens": max_new_tokens,
-        # Checkpoint generate() / model-card defaults for v1.5.
         "text_temperature": 1.0,
         "audio_temperature": 1.7,
         "text_top_p": 1.0,
@@ -244,7 +227,6 @@ def build_generation_kwargs(
     _validate_moss_tts_generation_kwargs(generation_kwargs)
     return generation_kwargs
 
-
 def _build_processor_message(
     processor: Any,
     state: MossTTSLocalState,
@@ -255,10 +237,8 @@ def _build_processor_message(
     ref_audio = state.ref_audio
     if reference_encoder is not None and isinstance(ref_audio, str):
         if _DATA_URI_RE.match(ref_audio) is None:
-            # File-path refs share one batched codec forward via the coalescer.
             reference = [reference_encoder.encode(ref_audio)]
         elif hasattr(reference_encoder, "encode_data_uri"):
-            # Data-URI refs through the same LRU (bytes: keyspace).
             reference = [
                 reference_encoder.encode_data_uri(ref_audio, processor=processor)
             ]
@@ -273,7 +253,6 @@ def _build_processor_message(
         tokens=state.token_count,
         language=state.language,
     )
-
 
 def _prepare_moss_tts_local_request(
     payload: StagePayload,
@@ -298,7 +277,6 @@ def _prepare_moss_tts_local_request(
         prompt_rows=prompt_rows,
         gen_kwargs=state.generation_kwargs,
     )
-
 
 def preprocess_moss_tts_local_payload(payload: StagePayload) -> StagePayload:
     """Run prompt/reference preprocessing outside the AR scheduler."""
@@ -338,7 +316,6 @@ def preprocess_moss_tts_local_payload(payload: StagePayload) -> StagePayload:
         request_id=payload.request_id, request=payload.request, data=data
     )
 
-
 def build_moss_tts_local_stream_metadata(
     payload: StagePayload,
     *,
@@ -358,7 +335,6 @@ def build_moss_tts_local_stream_metadata(
             INITIAL_CODEC_CHUNK_FRAMES_PARAM
         ]
     return metadata
-
 
 def build_sglang_moss_tts_local_request(
     payload: StagePayload,
@@ -432,7 +408,6 @@ def build_sglang_moss_tts_local_request(
     data.stage_payload = payload
     return data
 
-
 def apply_sglang_moss_tts_local_result(
     payload: StagePayload,
     data: MossTTSLocalSGLangRequestData,
@@ -458,7 +433,6 @@ def apply_sglang_moss_tts_local_result(
         data=state.to_dict(),
     )
 
-
 def make_moss_tts_local_scheduler_adapters(*, model: Any):
     """Build StagePayload <-> SGLang request adapters for MOSS-TTS Local."""
 
@@ -469,8 +443,6 @@ def make_moss_tts_local_scheduler_adapters(*, model: Any):
         try:
             return apply_sglang_moss_tts_local_result(data.stage_payload, data)
         finally:
-            # Release the finished request's decode-state pool row (mirrors
-            # Higgs request_builders.py:186); recycles the row for a waiter.
             model.reset_request(data.stage_payload.request_id)
 
     return request_builder, result_adapter

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -45,17 +45,10 @@ _MOSS_TTS_LOCAL_INSTALL_HINT = (
     "OpenMOSS-Team/MOSS-Audio-Tokenizer-v2."
 )
 
-# NOTE: preprocessing and vocoder stages each load their own processor (and
-# ~4.3 GB bf16 codec instance): `model.streaming()` flips module-global codec
-# state, so a decode on a shared instance would corrupt a concurrent
-# reference encode (see streaming_vocoder.py).
-
-
 @dataclass(frozen=True)
 class _ArMemoryBudget:
     effective_total_gpu_memory_fraction: float | None
     applied_codec_mem_reserve: float
-
 
 def _apply_colocated_ar_memory_budget(
     overrides: dict[str, Any],
@@ -110,7 +103,6 @@ def _apply_colocated_ar_memory_budget(
         applied_codec_mem_reserve=applied_codec_mem_reserve,
     )
 
-
 def _normalize_processor_config(processor: Any) -> None:
     model_config = getattr(processor, "model_config", None)
     if model_config is None:
@@ -119,7 +111,6 @@ def _normalize_processor_config(processor: Any) -> None:
     for attr, default in moss_tts_local_special_token_defaults(audio_vocab_size):
         if getattr(model_config, attr, None) is None:
             setattr(model_config, attr, default)
-
 
 def _resolve_codec_device(device: str | None, gpu_id: int | None) -> str:
     """Pick the codec GPU for the preprocessing/vocoder stages.
@@ -135,7 +126,6 @@ def _resolve_codec_device(device: str | None, gpu_id: int | None) -> str:
     if gpu_id is not None:
         return f"cuda:{int(gpu_id)}"
     return "cuda:0"
-
 
 def _load_moss_tts_local_processor(model_path: str, *, device: str) -> Any:
     checkpoint_dir = _resolve_checkpoint(model_path)
@@ -158,12 +148,8 @@ def _load_moss_tts_local_processor(model_path: str, *, device: str) -> Any:
         if hasattr(audio_tokenizer, "eval"):
             audio_tokenizer.eval()
         if hasattr(audio_tokenizer, "to"):
-            # Device move only: the v2 codec manages its own dtypes (bf16
-            # encoder/decoder with an fp32 quantizer); a blanket dtype cast
-            # would corrupt the quantizer codebooks.
             audio_tokenizer.to(device)
     return processor
-
 
 class _BatchedReferenceEncoder:
     """Coalesces concurrent reference-audio encodes into batched codec calls.
@@ -176,11 +162,7 @@ class _BatchedReferenceEncoder:
     so one bad file only fails its own request.
     """
 
-    # Mirrors the Higgs reference-audio cap: bounds both encoder runtime and
-    # the batch-padding memory amplification.
     MAX_REFERENCE_SECONDS = 100.0
-    # An encode batch takes well under a second; a result this late means the
-    # worker died or wedged, so fail the request instead of hanging the slot.
     ENCODE_TIMEOUT_S = 120.0
 
     def __init__(
@@ -207,7 +189,7 @@ class _BatchedReferenceEncoder:
             info = torchaudio.info(path)
             duration = info.num_frames / max(int(info.sample_rate), 1)
         except Exception:
-            return  # unreadable files fail with a clearer error in the codec
+            return
         if duration > cls.MAX_REFERENCE_SECONDS:
             raise ValueError(
                 f"reference audio is {duration:.1f}s long; the limit is "
@@ -257,8 +239,6 @@ class _BatchedReferenceEncoder:
             for path, future in batch:
                 outcome = results.get(path)
                 if isinstance(outcome, Exception):
-                    # Fresh exception per future: a shared instance would be
-                    # mutated concurrently by every waiter's traceback raise.
                     future.set_exception(
                         RuntimeError(f"reference encode failed for {path}: {outcome}")
                     )
@@ -269,7 +249,6 @@ class _BatchedReferenceEncoder:
                 else:
                     future.set_result(outcome)
 
-
 class CachedReferenceEncoder:
     """Content-addressed LRU cache + single-flight dedup in front of _BatchedReferenceEncoder.
 
@@ -278,7 +257,6 @@ class CachedReferenceEncoder:
     Stores codes as int32 on CPU (lossless for codebook values in [0, 1023]).
     """
 
-    # Cadence for the periodic stats log; class attr so it is easy to tune.
     LOG_INTERVAL_S = 60.0
 
     def __init__(
@@ -288,8 +266,6 @@ class CachedReferenceEncoder:
         max_items: int = 256,
         max_bytes: int = 64 * 1024 * 1024,
     ) -> None:
-        # Fail fast on non-positive capacities: a negative max_items makes
-        # StageOutputCache evict from an empty dict and KeyError at request time.
         if max_items < 1:
             raise ValueError(f"ref_audio_cache_max_items must be >= 1, got {max_items}")
         if max_bytes < 1:
@@ -310,19 +286,14 @@ class CachedReferenceEncoder:
     def encode(self, path: str) -> torch.Tensor:
         path = str(path)
         # Note(Jiaxin): duration gate runs first — a >100 s ref must never reach
-        # the cache or the inflight dict.
         _BatchedReferenceEncoder._check_reference_duration(path)
-        # trust_stat left False (review feedback): keep the sentinel byte-read so a
-        # same-size+mtime+ctime overwrite cannot stale-hit. The flag stays available
-        # in reference_path_cache_key for deployments that guarantee immutable refs.
         key = _reference_path_cache_key(path)
         if key is None:
-            return self._encoder.encode(path)  # uncacheable (URL/missing) -> bypass
+            return self._encoder.encode(path)
         return self._cached_encode(
             key,
             lambda: self._encoder.encode(path),
             desc=repr(path),
-            # TOCTOU re-stat: skip the put if the file changed during the encode.
             revalidate=lambda: _reference_path_cache_key(path) == key,
         )
 
@@ -357,8 +328,6 @@ class CachedReferenceEncoder:
 
         if follower_fut is not None:
             # Note(Jiaxin): each follower raises a FRESH RuntimeError — sharing one
-            # exception instance lets concurrent re-raises corrupt its traceback
-            # (same lesson as _BatchedReferenceEncoder._worker).
             timeout = _BatchedReferenceEncoder.ENCODE_TIMEOUT_S + 10
             try:
                 stored = follower_fut.result(timeout=timeout)
@@ -385,7 +354,6 @@ class CachedReferenceEncoder:
             self._inflight.pop(key, None)
         leader_fut.set_result(stored)
         self._maybe_log()
-        # CPU long like the hit path.
         return stored.to(torch.long)
 
     def _maybe_log(self) -> None:
@@ -435,8 +403,6 @@ class CachedReferenceEncoder:
                 io.BytesIO(raw), dtype="float32", always_2d=True
             )
             # Note(Jiaxin): the duration check runs inside the leader (not before
-            # inflight registration like the file path) so concurrent same-payload
-            # requests share one sf.read of a potentially large decoded buffer.
             duration = audio.shape[0] / max(int(sample_rate), 1)
             if duration > _BatchedReferenceEncoder.MAX_REFERENCE_SECONDS:
                 raise ValueError(
@@ -458,7 +424,6 @@ class CachedReferenceEncoder:
                 "bytes": self._cache.current_bytes,
             }
 
-
 def create_preprocessing_executor(
     model_path: str,
     *,
@@ -471,8 +436,6 @@ def create_preprocessing_executor(
     ref_audio_cache_max_items: int = 8192,
     ref_audio_cache_max_bytes: int = 64 * 1024 * 1024,
 ) -> SimpleScheduler:
-    # MOSS_REF_AUDIO_CACHE=0 disables the cache at startup (ops kill switch / A-B
-    # toggle) without a config edit; unset => kwarg default.
     env_toggle = os.environ.get("MOSS_REF_AUDIO_CACHE")
     if env_toggle is not None:
         ref_audio_cache = env_toggle.strip().lower() not in (
@@ -498,15 +461,11 @@ def create_preprocessing_executor(
     set_moss_tts_local_preprocessing_context(
         processor=processor, reference_encoder=reference_encoder
     )
-    # Reference encoding runs through the ~1B-param causal codec encoder, so
-    # unlike MOSS Delay the audio tokenizer must live on the GPU; threads
-    # release the GIL during the codec forward, keeping the AR engine fed.
     return SimpleScheduler(
         preprocess_moss_tts_local_payload,
         abort_callback=cleanup_prepared_moss_tts_local_request,
         max_concurrency=max_concurrency,
     )
-
 
 def create_sglang_tts_engine_executor(
     model_path: str,
@@ -547,9 +506,6 @@ def create_sglang_tts_engine_executor(
         "trust_remote_code": True,
     }
     if total_gpu_memory_fraction is None:
-        # without a typed stage budget, this path cannot use process-scoped
-        # colocated profiling
-        # keep the legacy static fraction for split/custom deployments
         overrides["mem_fraction_static"] = 0.6 if torch.cuda.device_count() > 1 else 0.5
     if server_args_overrides:
         overrides.update(server_args_overrides)
@@ -613,9 +569,6 @@ def create_sglang_tts_engine_executor(
     model = model_worker.model_runner.model
     if want_cuda_graph:
         model_worker.model_runner.init_device_graphs()
-        # Also graph the per-frame local-transformer decode (1 + n_vq
-        # micro-steps and 13 seeded sampling passes per frame): eager it is
-        # kernel-launch-bound at ~22 ms/frame independent of batch size.
         model.init_frame_decode_graphs(
             list(overrides.get("cuda_graph_bs") or [1, 2, 4, 8, 16])
         )
@@ -630,8 +583,6 @@ def create_sglang_tts_engine_executor(
     )
 
     def abort_request(request_id: str) -> None:
-        # Drop any prepared handoff and release any held pool row; both are
-        # idempotent no-ops if the request never reached them.
         cleanup_prepared_moss_tts_local_request(request_id)
         model.reset_request(request_id)
 
@@ -655,10 +606,8 @@ def create_sglang_tts_engine_executor(
     model_runner.set_stream_outbox(scheduler.outbox)
     return scheduler
 
-
 def create_tts_engine_executor(*args, **kwargs) -> Any:
     return create_sglang_tts_engine_executor(*args, **kwargs)
-
 
 def create_vocoder_executor(
     model_path: str,
@@ -687,7 +636,5 @@ def create_vocoder_executor(
         cuda_graph_frames=cuda_graph_frames,
         cuda_graph_min_free_gb=cuda_graph_min_free_gb,
     )
-    # Capture graphs in the factory: it runs before the process is marked ready, so serving never
-    # races a half-captured graph. Same-process guarantee (each colocate/split stage warms its own).
     scheduler.warmup_now()
     return scheduler

--- a/sglang_omni/models/moss_tts_local/state_pool.py
+++ b/sglang_omni/models/moss_tts_local/state_pool.py
@@ -20,7 +20,6 @@ from typing import Any
 
 import torch
 
-
 class MossTTSLocalDecodeStatePool:
     """Row-indexed pool of next-step-critical decode state.
 
@@ -32,7 +31,6 @@ class MossTTSLocalDecodeStatePool:
     def __init__(self, model: Any) -> None:
         self.model = model
         weight = model._decode_input_embedding.weight
-        # P = max_running_requests + 1; the +1 is the reserved padding row.
         self.num_rows = int(weight.shape[0]) + 1
         self.padding_row = self.num_rows - 1
         self.hidden_size = int(weight.shape[1])
@@ -53,15 +51,12 @@ class MossTTSLocalDecodeStatePool:
         self.n_vq = int(n_vq or 12)
         self.audio_vocab_size = int(audio_vocab_size or 1024)
 
-        # Feedback embedding for the next decode step; bf16 matches the staging
-        # table dtype so before_decode's gather is a plain copy (#736).
         self.feedback_embeds = torch.zeros(
             self.num_rows,
             self.hidden_size,
             device=self.device,
             dtype=self.dtype,
         )
-        # Request-static sampling parameters / seed (written once at acquire).
         self.text_temp = torch.zeros(
             self.num_rows, device=self.device, dtype=torch.float32
         )
@@ -101,8 +96,6 @@ class MossTTSLocalDecodeStatePool:
         self._rid_to_row: dict[str, int] = {}
         self._params_written_rids: set[str] = set()
         self._audio_repetition_penalty_rows: set[int] = set()
-        # Real rows 0..P-2 are assignable; the padding row stays out of the
-        # free list so it is never handed to a request.
         self._free_rows: list[int] = list(range(self.padding_row))
 
     def acquire_row(self, rid: str) -> int:
@@ -288,7 +281,6 @@ class MossTTSLocalDecodeStatePool:
             pool_rows,
             has_audio_repetition_penalty,
         )
-
 
 class MossTTSLocalDecodeJournal:
     """Step-private record carrying the frame this step produced to collection.

--- a/sglang_omni/models/moss_tts_local/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts_local/streaming_vocoder.py
@@ -31,7 +31,6 @@ logger = logging.getLogger(__name__)
 
 _SOURCE_HINT = "MOSS-TTS Local"
 
-
 def _resolve_sample_rate(processor: Any) -> int:
     return int(
         getattr(getattr(processor, "model_config", None), "sampling_rate", 0)
@@ -42,7 +41,6 @@ def _resolve_sample_rate(processor: Any) -> int:
         )
         or 48000
     )
-
 
 def _build_usage(state: MossTTSLocalState) -> dict[str, Any] | None:
     if not (state.prompt_tokens or state.completion_tokens or state.engine_time_s):
@@ -55,7 +53,6 @@ def _build_usage(state: MossTTSLocalState) -> dict[str, Any] | None:
     if state.engine_time_s:
         usage["engine_time_s"] = round(float(state.engine_time_s), 6)
     return usage
-
 
 class _CodecStreamSession:
     """Persistent batched ``codec.streaming()`` session with slot bookkeeping (stream slots held by live requests; offline slots for non-streaming decodes). Scheduler-loop-thread only."""
@@ -72,14 +69,10 @@ class _CodecStreamSession:
         self._free_stream_slots = list(range(self._stream_slots))
         self._closed = False
         self._cg_runner: Any | None = None
-        # Capture is attempted at most once per session; a low-VRAM skip must not re-probe per step.
         self.warmup_attempted = False
-        # Per-T graph-vs-eager step counts for capture-hit-rate reporting (host-side, no GPU sync).
         self._cg_graph_t: Counter = Counter()
         self._cg_eager_t: Counter = Counter()
         self._cg_total_steps = 0
-        # Retain the streaming ExitStack so per-slot causal state lives across steps (closed in close());
-        # graph replay is kept bit-identical to this stateful decode by the in-place cache patch.
         self._exit_stack = contextlib.ExitStack()
         with torch.no_grad():
             self._exit_stack.enter_context(codec.streaming(self._batch_size))
@@ -97,12 +90,8 @@ class _CodecStreamSession:
             patch_codec_attention_cache_for_cuda_graph,
         )
 
-        # Patch the codec attention cache to an in-place write so the graph can capture it
-        # (bit-identical to eager).
         patch_codec_attention_cache_for_cuda_graph(self._codec)
         if self._cg_runner is None:
-            # Scheduler owns the capture shape range (max_frames = the largest T it asks for), rather
-            # than the runner keeping an independent default limit.
             self._cg_runner = MossVocoderCudaGraphRunner(
                 self._codec,
                 batch_size=self._batch_size,
@@ -113,19 +102,15 @@ class _CodecStreamSession:
         try:
             self._cg_runner.warmup(frames)
         except Exception:
-            # Drop a half-built runner on probe failure so serving stays on the eager path.
             self._cg_runner = None
             raise
         self._reset_slots(list(range(self._batch_size)))
         captured = self._cg_runner.captured_frames()
         if not captured:
-            # Nothing captured (low VRAM / all failed): drop the runner so serving does not pay a
-            # wasted decode_step probe every step only to fall back to eager.
             self._cg_runner = None
         return captured
 
     def has_cuda_graph_runner(self) -> bool:
-        # True only if the runner exists AND captured at least one graph.
         return bool(self._cg_runner and self._cg_runner.captured_frames())
 
     def captured_frames(self) -> list[int]:
@@ -219,13 +204,9 @@ class _CodecStreamSession:
                     self._codec._set_streaming_exec_mask(exec_mask)
                     result = self._codec._decode_frame(codes_step, codes_lengths)
                     audio, audio_lengths = result.audio, result.audio_lengths
-            # One batched D2H per step. A graph replay error can surface async HERE (not in
-            # decode_step), so materialization stays inside the replay guard.
             audio_cpu = audio[slots].detach().to("cpu", torch.float32)
             lengths_cpu = audio_lengths[slots].detach().to("cpu")
         except Exception:
-            # Graphed step failed (in decode_step or async on the D2H): disable the runner so future
-            # steps go eager; participants abort. An eager-path error does not disable it.
             if self._cg_runner is not None and (graph_failed or graphed is not None):
                 logger.exception(
                     "MOSS vocoder CUDA-graph replay failed (in decode_step or on output "
@@ -284,7 +265,6 @@ class _CodecStreamSession:
                 wavs.append(torch.cat(item_chunks, dim=-1))
         return wavs
 
-
 @dataclass
 class _LocalStreamState:
     slot: int | None = None
@@ -293,7 +273,6 @@ class _LocalStreamState:
     initial_chunk_frames: int = 0
     threshold: int = 0
     emitted_any: bool = False
-
 
 class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
     """Decode MOSS-TTS Local codec rows incrementally on the v2 codec."""
@@ -370,7 +349,6 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
         )
 
     def start(self) -> None:
-        # Graphs are captured in the factory (warmup_now) before this serving loop runs.
         try:
             super().start()
         finally:
@@ -389,8 +367,6 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
                 self._session.close()
                 self._session = None
             self._session_used_by_streaming = False
-
-    # --- Streaming hooks ---
 
     def is_streaming_payload(self, payload: StagePayload) -> bool:
         params = payload.request.params
@@ -427,7 +403,6 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
                 f"MOSS-TTS Local stream chunk must be a 1-D row with at least "
                 f"{n_vq + 1} channels (text + codes), got {tuple(row.shape)}"
             )
-        # Row layout matches output_rows: [text_token, code_0, ..., code_{n_vq-1}].
         state.pending.append(row[1 : 1 + n_vq])
         self._ensure_slot(state)
         self._pump_streams()
@@ -439,7 +414,6 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
 
         audio_parts: list[torch.Tensor] = []
         if state.slot is None and state.pending:
-            # Slot-starved: every frame is still buffered, decode offline.
             codes = torch.stack(state.pending, dim=1)
             state.pending = []
             audio_parts.extend(
@@ -493,8 +467,6 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
         if state is not None and state.slot is not None and self._session is not None:
             self._session.release(state.slot)
 
-    # --- Streaming internals ---
-
     def _ensure_session(self) -> _CodecStreamSession:
         if self._session is None:
             self._session = _CodecStreamSession(
@@ -519,10 +491,7 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
         """Step lengths T to capture (config ``cuda_graph_frames`` overrides). Default is a
         data-driven broad-exact set (see below); uncaptured T fall back to eager."""
         if self._cuda_graph_frames:
-            # Validated at config (>= 1) and __init__ (<= max_step_frames); use as configured.
             return sorted(set(self._cuda_graph_frames))
-        # Broad-exact small-T set (measured per-T serving frequency). The T=max_step_frames cap is
-        # excluded (biggest single graph, only ~1.04x offline-lane) to shrink the warmup VRAM peak.
         join_floor = max(
             1,
             min(self._default_initial_chunk_frames or 5, self._stream_chunk_frames),
@@ -544,8 +513,6 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
             self._default_initial_chunk_frames or join_floor,
             self._stream_chunk_frames,
         ]
-        # Clamp the generated default to the supported range (this is the auto-default, not user
-        # input; user-supplied frames are validated and rejected, never silently filtered).
         return sorted({t for t in frames if 1 <= t <= self._max_step_frames})
 
     def _codec_on_cuda(self) -> bool:
@@ -643,7 +610,6 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
             and params.get(INITIAL_CODEC_CHUNK_FRAMES_PARAM) is not None
         )
         if explicit:
-            # Explicit 0 opts out of a smaller first chunk.
             state.initial_chunk_frames = resolve_initial_codec_chunk_frames(
                 params,
                 steady_chunk_frames=self._stream_chunk_frames,
@@ -746,8 +712,6 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
             [codes], max_step_frames=self._max_step_frames
         )[0]
 
-    # --- Non-streaming path ---
-
     def _prepare_codes(
         self, payload: StagePayload
     ) -> tuple[MossTTSLocalState, torch.Tensor | None]:
@@ -756,7 +720,6 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
             raise RuntimeError("MOSS-TTS Local vocoder requires audio_codes")
         codes = torch.as_tensor(state.audio_codes, dtype=torch.long)
         if codes.numel() == 0:
-            # Emit no audio: only this request fails downstream, not the batch.
             return state, None
         return state, codes
 
@@ -766,7 +729,6 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
         state: MossTTSLocalState,
         wav: torch.Tensor,
     ) -> StagePayload:
-        # The v2 codec is natively stereo: keep [channels, samples] end to end.
         audio_payload = audio_waveform_payload(
             wav, source_hint=_SOURCE_HINT, keep_channels=True
         )
@@ -786,8 +748,6 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
         with self._state_lock:
             self._close_idle_startup_session_locked()
         if self._session is None:
-            # Processor path opens its own streaming context; illegal once a
-            # session is live.
             return [
                 torch.as_tensor(wav).detach().to("cpu")
                 for wav in self._processor.decode_audio_codes(codes_list)
@@ -795,8 +755,6 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
         channels_first = [
             codes[:, : self._n_vq].transpose(0, 1).contiguous() for codes in codes_list
         ]
-        # abort() resets slots under _state_lock from other threads; serialize
-        # every session access on the same lock.
         with self._state_lock:
             wavs = self._session.decode_offline(
                 channels_first, max_step_frames=self._max_step_frames
@@ -819,6 +777,5 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
 
     def _vocode(self, payload: StagePayload) -> StagePayload:
         return self._vocode_batch([payload])[0]
-
 
 __all__ = ["MossTTSLocalStreamingVocoderScheduler"]

--- a/sglang_omni/models/qwen3_omni/merge.py
+++ b/sglang_omni/models/qwen3_omni/merge.py
@@ -17,7 +17,6 @@ from sglang_omni.proto import StagePayload
 IMAGE_STAGE = "image_encoder"
 AUDIO_STAGE = "audio_encoder"
 
-
 def _cast_tensor(
     value: torch.Tensor | None, dtype: torch.dtype | None = None
 ) -> torch.Tensor | None:
@@ -25,10 +24,8 @@ def _cast_tensor(
         return None
     return value.to(dtype=dtype) if dtype is not None else value
 
-
 def _non_empty(tensor: torch.Tensor | None) -> bool:
     return tensor is not None and tensor.numel() > 0
-
 
 def merge_for_thinker(payloads: dict[str, StagePayload]) -> StagePayload:
     """Aggregate preprocessing + encoder outputs into thinker inputs."""
@@ -51,12 +48,9 @@ def merge_for_thinker(payloads: dict[str, StagePayload]) -> StagePayload:
     state.thinker_inputs = thinker_inputs
     state.encoder_inputs = {}
     _prune_preprocessing_for_thinker(state, encoder_outs)
-    # Encoder outputs have been consumed into thinker_inputs; keeping both
-    # doubles multimodal tensor payloads sent to the thinker.
     state.encoder_outs = {}
     base.data = state.to_dict()
     return base
-
 
 def build_thinker_inputs(
     state: Qwen3OmniPipelineState,
@@ -155,7 +149,6 @@ def build_thinker_inputs(
     if image_ck:
         media_cache_keys["image"] = f"image:{image_ck}"
         # Note (Xuesong): Image and video share the same encoder cache key, so prefix them
-        # differently to avoid hashed pad-value collisions across modalities.
         media_cache_keys["video"] = f"video:{image_ck}"
     if audio_ck:
         media_cache_keys["audio"] = f"audio:{audio_ck}"
@@ -164,7 +157,6 @@ def build_thinker_inputs(
     if media_cache_keys:
         result["media_cache_keys"] = media_cache_keys
     return result
-
 
 def _prune_preprocessing_for_thinker(
     state: Qwen3OmniPipelineState,
@@ -218,7 +210,6 @@ def _prune_preprocessing_for_thinker(
             "use_audio_in_video": use_audio_in_video,
         },
     }
-
 
 def decode_events(
     *,
@@ -275,7 +266,6 @@ def decode_events(
     decoded = tokenizer.decode(token_ids, skip_special_tokens=True)
     stream_state["text"] = decoded
 
-    # Skip incomplete multi-byte characters (replacement char).
     if "\ufffd" in decoded:
         return []
 

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -43,21 +43,17 @@ THINKER_STAGE = "thinker"
 
 logger = logging.getLogger(__name__)
 
-# Image-encoder batching budget; the multiplier accounts for transient activations.
 QWEN3_IMAGE_ENCODER_BATCH_BUDGET_BYTES = 10 * 1024**3
 QWEN3_IMAGE_ENCODER_ACTIVATION_MULTIPLIER = 5
 
-# CPU LRU cap for repeated-media encoder outputs.
 QWEN3_ENCODER_CACHE_MAX_BYTES = 4 * 1024**3
 QWEN3_ENCODER_CACHE_MAX_ENTRIES = 64
-
 
 @dataclass(frozen=True)
 class _ArMemoryContract:
     mem_fraction_static_pinned: bool
     effective_total_gpu_memory_fraction: float | None
     applied_encoder_mem_reserve: float
-
 
 def _apply_qwen_thinker_encoder_reserve(
     server_args: Any,
@@ -69,7 +65,6 @@ def _apply_qwen_thinker_encoder_reserve(
         return False
     apply_encoder_mem_reserve(server_args, encoder_mem_reserve)
     return True
-
 
 def _apply_colocated_ar_memory_contract(
     overrides: dict[str, Any],
@@ -125,7 +120,6 @@ def _apply_colocated_ar_memory_contract(
         applied_encoder_mem_reserve=applied_encoder_mem_reserve,
     )
 
-
 def _apply_colocated_encoder_mem_reserve(
     total_gpu_memory_fraction: float,
     encoder_mem_reserve: float,
@@ -147,15 +141,12 @@ def _apply_colocated_encoder_mem_reserve(
         )
     return round(effective_total_gpu_memory_fraction, 3)
 
-
 def load_state(payload: StagePayload) -> Qwen3OmniPipelineState:
     return Qwen3OmniPipelineState.from_dict(payload.data)
-
 
 def store_state(payload: StagePayload, state: Qwen3OmniPipelineState) -> StagePayload:
     payload.data = state.to_dict()
     return payload
-
 
 def _run_single_encoder_payload(
     payload: StagePayload,
@@ -188,7 +179,6 @@ def _run_single_encoder_payload(
     apply_encoder_result(state, stage_name=stage_name, result=result)
     return store_state(payload, state)
 
-
 def _image_request_is_batchable(request: Any) -> bool:
     if request.skip_result is not None:
         return False
@@ -204,7 +194,6 @@ def _image_request_is_batchable(request: Any) -> bool:
             return False
     return True
 
-
 def _split_visual_features(
     tensor: torch.Tensor | None,
     *,
@@ -215,7 +204,6 @@ def _split_visual_features(
         return None
     return tensor[start:end]
 
-
 def _split_visual_multiscale(
     tensors: list[torch.Tensor] | None,
     *,
@@ -225,7 +213,6 @@ def _split_visual_multiscale(
     if tensors is None:
         return None
     return [tensor[start:end] for tensor in tensors]
-
 
 def _create_image_encoder_request_cost_fn(model: Qwen3OmniImageEncoder):
     merge = int(model.spatial_merge_size) ** 2
@@ -251,12 +238,10 @@ def _create_image_encoder_request_cost_fn(model: Qwen3OmniImageEncoder):
 
     return _cost
 
-
 def _tensor_bytes(value: Any) -> int:
     if not isinstance(value, torch.Tensor):
         return 0
     return int(value.numel() * value.element_size())
-
 
 def _nested_tensor_bytes(value: Any) -> int:
     if isinstance(value, torch.Tensor):
@@ -267,11 +252,9 @@ def _nested_tensor_bytes(value: Any) -> int:
         return sum(_nested_tensor_bytes(item) for item in value)
     return 0
 
-
 def _encoder_cache_trace_enabled() -> bool:
     value = os.getenv("SGLANG_OMNI_TRACE_ENCODER_CACHE", "")
     return value.lower() not in ("", "0", "false", "no")
-
 
 def _short_cache_key(cache_key: str | None) -> str:
     if not cache_key:
@@ -279,7 +262,6 @@ def _short_cache_key(cache_key: str | None) -> str:
     if len(cache_key) <= 32:
         return cache_key
     return f"{cache_key[:16]}...{cache_key[-8:]}"
-
 
 def _trace_encoder_cache(
     stage_name: str,
@@ -306,7 +288,6 @@ def _trace_encoder_cache(
     if detail:
         parts.append(detail)
     logger.info("encoder_cache %s", " ".join(parts))
-
 
 def _lookup_cached_encoder_output(
     *,
@@ -337,7 +318,6 @@ def _lookup_cached_encoder_output(
     )
     return cached
 
-
 def _store_cached_encoder_output(
     *,
     request: Any,
@@ -358,12 +338,10 @@ def _store_cached_encoder_output(
         output_bytes=_nested_tensor_bytes(result),
     )
 
-
 def _grid_visual_tokens(grid: Any, merge: int) -> int:
     if not isinstance(grid, torch.Tensor) or grid.numel() == 0:
         return 0
     return int((grid.to(dtype=torch.long).prod(dim=-1) // merge).sum().item())
-
 
 def _batch_image_encoder_payloads(
     payloads: list[StagePayload],
@@ -570,7 +548,6 @@ def _batch_image_encoder_payloads(
 
     return [result for result in results if result is not None]
 
-
 def _audio_request_is_batchable(request: Any) -> bool:
     if request.skip_result is not None:
         return False
@@ -583,7 +560,6 @@ def _audio_request_is_batchable(request: Any) -> bool:
     return (lengths is None or isinstance(lengths, torch.Tensor)) and (
         mask is None or isinstance(mask, torch.Tensor)
     )
-
 
 def _normalize_audio_request_tensors(
     request: Any,
@@ -613,20 +589,17 @@ def _normalize_audio_request_tensors(
 
     return features, mask, lengths
 
-
 def _pad_audio_features(features: torch.Tensor, target_time: int) -> torch.Tensor:
     pad = target_time - int(features.shape[-1])
     if pad <= 0:
         return features
     return F.pad(features, (0, pad))
 
-
 def _pad_audio_mask(mask: torch.Tensor, target_time: int) -> torch.Tensor:
     pad = target_time - int(mask.shape[-1])
     if pad <= 0:
         return mask
     return F.pad(mask, (0, pad), value=False)
-
 
 def _batch_audio_encoder_payloads(
     payloads: list[StagePayload],
@@ -736,12 +709,6 @@ def _batch_audio_encoder_payloads(
 
     return [result for result in results if result is not None]
 
-
-# ---------------------------------------------------------------------------
-# Simple stages — return SimpleScheduler
-# ---------------------------------------------------------------------------
-
-
 def create_preprocessing_executor(
     model_path: str,
     *,
@@ -769,7 +736,6 @@ def create_preprocessing_executor(
 
     return SimpleScheduler(_preprocess)
 
-
 def create_aggregate_executor():
     from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
@@ -777,7 +743,6 @@ def create_aggregate_executor():
         return payload
 
     return SimpleScheduler(_identity)
-
 
 def create_image_encoder_executor(
     model_path: str,
@@ -839,8 +804,6 @@ def create_image_encoder_executor(
                     metadata={"modality": "image", "batch_size": len(payloads)},
                 )
 
-    # Preserve the calibrated image-encoder batching shape and add a small
-    # batch_wait so video benchmarks at concurrency=16 batch together.
     return SimpleScheduler(
         _encode,
         batch_compute_fn=_encode_batch,
@@ -849,7 +812,6 @@ def create_image_encoder_executor(
         request_cost_fn=_create_image_encoder_request_cost_fn(model),
         max_batch_cost=QWEN3_IMAGE_ENCODER_BATCH_BUDGET_BYTES,
     )
-
 
 def create_audio_encoder_executor(
     model_path: str,
@@ -918,15 +880,8 @@ def create_audio_encoder_executor(
         max_batch_wait_ms=50,
     )
 
-
 def create_decode_executor(model_path: str):
     return create_streaming_detokenize_scheduler(model_path)
-
-
-# ---------------------------------------------------------------------------
-# AR stages — return OmniScheduler
-# ---------------------------------------------------------------------------
-
 
 def create_sglang_thinker_executor_from_config(
     model_path: str,
@@ -943,17 +898,6 @@ def create_sglang_thinker_executor_from_config(
 ):
     """Returns OmniScheduler for thinker."""
     # note (luojiaxuan):
-    # The thinker runs prefill XOR decode per scheduler step, so under
-    # concurrent streaming a large fraction of steps are prefill-only while
-    # in-flight decodes stall (measured on Qwen3-Omni-30B TP=2, 32 streams:
-    # ~98% of prefill steps had decode-ready reqs in running_batch passed over,
-    # ~18/step). Mixed-chunk folds those running decodes into the chunk-prefill
-    # (extend) step, restoring the decode duty cycle: +14% throughput and ~6%
-    # lower computation-aware latency at quality parity, with no low-concurrency
-    # regression and robustness to chunked_prefill_size (#760). Defaults here so
-    # the streaming-SST thinker path benefits out of the box; either key can be
-    # overridden via server_args_overrides (set enable_mixed_chunk=False to opt
-    # out). Note: mixed-chunk only engages when chunked_prefill_size > 0.
     overrides: dict[str, Any] = {
         "disable_cuda_graph": False,
         "enable_mixed_chunk": True,
@@ -1038,7 +982,6 @@ def create_sglang_thinker_executor_from_config(
     )
     return scheduler
 
-
 def create_talker_ar_executor_from_config(
     model_path: str,
     *,
@@ -1059,13 +1002,7 @@ def create_talker_ar_executor_from_config(
     from sglang_omni.models.qwen3_omni.bootstrap import create_talker_scheduler
 
     # Note (Xuesong, Chenyang): cuda_graph defaults to ON for the talker
-    # after #384, which routed talker MoE through `self.experts` (FusedMoE)
-    # — the `fused_experts (full graph)` backend picked in #344. Caller can
-    # override via factory_args or the `--talker-cuda-graph off` CLI flag.
     # Note (Xuesong): pytorch backend works around an sglang upstream gap —
-    # Sampler.forward doesn't forward seed to flashinfer, so
-    # under cuda graph the captured RNG is boot-dependent and ~5% of prompts
-    # trigger degenerate AR loops (see #408). Revert once upstream lands.
     overrides: dict[str, Any] = {
         "disable_cuda_graph": False,
         "sampling_backend": "pytorch",

--- a/sglang_omni/pipeline/control_plane.py
+++ b/sglang_omni/pipeline/control_plane.py
@@ -37,17 +37,14 @@ ControlMessage = (
     | ProfilerStopMessage
 )
 
-
 def serialize_message(msg: ControlMessage) -> bytes:
     """Serialize a message to bytes."""
     return msgpack.packb(msg.to_dict(), use_bin_type=True)
-
 
 def deserialize_message(data: bytes) -> ControlMessage:
     """Deserialize bytes to a message."""
     d = msgpack.unpackb(data, raw=False)
     return parse_message(d)
-
 
 class ControlPlaneContext:
     """Shared ZMQ context for control plane."""
@@ -68,7 +65,6 @@ class ControlPlaneContext:
         if cls._context is not None:
             cls._context.term()
             cls._context = None
-
 
 class PushSocket:
     """Async PUSH socket for sending messages to a single destination."""
@@ -97,7 +93,6 @@ class PushSocket:
         if self._socket is not None:
             self._socket.close()
             self._socket = None
-
 
 class PullSocket:
     """Async PULL socket for receiving messages."""
@@ -143,7 +138,6 @@ class PullSocket:
             self._socket.close()
             self._socket = None
 
-
 class PubSocket:
     """Async PUB socket for broadcasting messages (e.g., abort)."""
 
@@ -156,7 +150,6 @@ class PubSocket:
         ctx = ControlPlaneContext.get()
         self._socket = ctx.socket(zmq.PUB)
         self._socket.bind(self.endpoint)
-        # Give subscribers time to connect
         await asyncio.sleep(0.1)
         logger.debug("PUB socket bound to %s", self.endpoint)
 
@@ -174,7 +167,6 @@ class PubSocket:
             self._socket.close()
             self._socket = None
 
-
 class SubSocket:
     """Async SUB socket for receiving broadcast messages."""
 
@@ -187,7 +179,7 @@ class SubSocket:
         ctx = ControlPlaneContext.get()
         self._socket = ctx.socket(zmq.SUB)
         self._socket.connect(self.endpoint)
-        self._socket.setsockopt(zmq.SUBSCRIBE, b"")  # Subscribe to all messages
+        self._socket.setsockopt(zmq.SUBSCRIBE, b"")
         logger.debug("SUB socket connected to %s", self.endpoint)
 
     async def recv(self) -> AbortMessage:
@@ -212,7 +204,6 @@ class SubSocket:
         if self._socket is not None:
             self._socket.close()
             self._socket = None
-
 
 class StageControlPlane:
     """Control plane interface for a Stage.
@@ -243,15 +234,12 @@ class StageControlPlane:
 
     async def start(self) -> None:
         """Initialize all sockets."""
-        # Socket to receive work
         self._recv_socket = PullSocket(self.recv_endpoint, bind=True)
         await self._recv_socket.start()
 
-        # Socket to send completions to coordinator
         self._coordinator_socket = PushSocket(self.coordinator_endpoint)
         await self._coordinator_socket.connect()
 
-        # Socket to receive abort broadcasts
         self._abort_socket = SubSocket(self.abort_endpoint)
         await self._abort_socket.connect()
 
@@ -335,7 +323,6 @@ class StageControlPlane:
             sock.close()
         self._next_stage_sockets.clear()
 
-
 class CoordinatorControlPlane:
     """Control plane interface for the Coordinator.
 
@@ -359,11 +346,9 @@ class CoordinatorControlPlane:
 
     async def start(self) -> None:
         """Initialize all sockets."""
-        # Socket to receive completions
         self._completion_socket = PullSocket(self.completion_endpoint, bind=True)
         await self._completion_socket.start()
 
-        # Socket to broadcast aborts
         self._abort_socket = PubSocket(self.abort_endpoint)
         await self._abort_socket.bind()
 

--- a/sglang_omni/pipeline/coordinator.py
+++ b/sglang_omni/pipeline/coordinator.py
@@ -29,14 +29,12 @@ from sglang_omni.proto import (
 
 logger = logging.getLogger(__name__)
 
-
 @dataclass
 class _AdminPendingOperation:
     expected_stages: set[str]
     action: str
     results: dict[str, AdminResult] = field(default_factory=dict)
     future: asyncio.Future | None = None
-
 
 class Coordinator:
     """Central coordinator for the multi-stage pipeline.
@@ -75,16 +73,13 @@ class Coordinator:
         self._terminal_stages_resolver = terminal_stages_resolver
         self._partial_results: dict[str, dict[str, Any]] = {}
 
-        # Control plane
         self.control_plane = CoordinatorControlPlane(
             completion_endpoint=completion_endpoint,
             abort_endpoint=abort_endpoint,
         )
 
-        # Stage registry
         self._stages: dict[str, StageInfo] = {}
 
-        # Request tracking
         self._requests: dict[str, RequestInfo] = {}
         self._completion_futures: dict[str, asyncio.Future] = {}
         self._stream_queues: dict[
@@ -93,7 +88,6 @@ class Coordinator:
         self._admin_ops: dict[str, _AdminPendingOperation] = {}
         self._admin_lock = asyncio.Lock()
 
-        # State
         self._running = False
         self._fatal_error: str | None = None
 
@@ -374,7 +368,6 @@ class Coordinator:
         if not isinstance(request, OmniRequest):
             request = OmniRequest(inputs=request)
 
-        # Track request
         self._requests[request_id] = RequestInfo(
             request_id=request_id,
             state=RequestState.PENDING,
@@ -382,7 +375,6 @@ class Coordinator:
             terminal_stages=self._resolve_terminal_stages(request),
         )
 
-        # Create future for completion
         loop = asyncio.get_running_loop()
         future: asyncio.Future = loop.create_future()
         self._completion_futures[request_id] = future
@@ -400,7 +392,6 @@ class Coordinator:
             metadata={"entry_stage": self.entry_stage},
         )
 
-        # Submit to entry stage
         entry_info = self._stages[self.entry_stage]
         await self.control_plane.submit_to_stage(
             self.entry_stage,
@@ -408,7 +399,6 @@ class Coordinator:
             SubmitMessage(request_id=request_id, data=payload),
         )
 
-        # Update state
         self._requests[request_id].state = RequestState.RUNNING
 
         logger.info(
@@ -438,13 +428,10 @@ class Coordinator:
         ):
             return False
 
-        # Broadcast abort to all stages
         await self.control_plane.broadcast_abort(AbortMessage(request_id=request_id))
 
-        # Update state
         info.state = RequestState.ABORTED
 
-        # Resolve future with error
         if request_id in self._completion_futures:
             self._completion_futures[request_id].set_exception(
                 asyncio.CancelledError(f"Request {request_id} aborted")
@@ -459,7 +446,6 @@ class Coordinator:
                 )
             )
 
-        # Cleanup request tracking
         self._requests.pop(request_id, None)
         self._partial_results.pop(request_id, None)
 
@@ -513,7 +499,6 @@ class Coordinator:
 
         info = self._requests[request_id]
 
-        # Fail-fast: any terminal failure -> fail entire request
         if not msg.success:
             info.state = RequestState.FAILED
             info.error = msg.error
@@ -541,7 +526,6 @@ class Coordinator:
             )
             return
 
-        # Single active terminal (original behavior) or no terminal_stages configured
         if len(expected_terminal_stages) <= 1:
             info.state = RequestState.COMPLETED
             info.result = msg.result
@@ -554,18 +538,15 @@ class Coordinator:
             self._requests.pop(request_id, None)
             return
 
-        # Multi-terminal: collect partial results
         partials = self._partial_results.setdefault(request_id, {})
         partials[msg.from_stage] = msg.result
 
-        # Forward stream completion per-stage
         if request_id in self._stream_queues:
             await self._stream_queues[request_id].put(msg)
 
         if set(partials) < expected_terminal_stages:
-            return  # still waiting
+            return
 
-        # All terminal stages done -> merge and resolve
         merged = dict(partials)
         self._partial_results.pop(request_id)
         info.state = RequestState.COMPLETED
@@ -718,12 +699,11 @@ class Coordinator:
             "request_states": state_counts,
         }
 
-
 async def run_coordinator(
     completion_endpoint: str,
     abort_endpoint: str,
     entry_stage: str,
-    stages: dict[str, str],  # name -> endpoint
+    stages: dict[str, str],
     terminal_stages: list[str] | None = None,
     terminal_stages_resolver: Callable[[OmniRequest], list[str] | None] | None = None,
 ) -> Coordinator:
@@ -747,11 +727,9 @@ async def run_coordinator(
         terminal_stages_resolver=terminal_stages_resolver,
     )
 
-    # Register stages
     for name, endpoint in stages.items():
         coordinator.register_stage(name, endpoint)
 
-    # Start
     await coordinator.start()
 
     return coordinator

--- a/sglang_omni/pipeline/relay_io.py
+++ b/sglang_omni/pipeline/relay_io.py
@@ -19,19 +19,11 @@ import torch
 from sglang_omni.proto import DataReadyMessage, StagePayload
 from sglang_omni.relay.base import Relay
 
-
 def _dtype_alignment(dtype: torch.dtype) -> int:
     return max(torch.empty((), dtype=dtype).element_size(), 1)
 
-
 def _pad_offset(offset: int, alignment: int) -> int:
     return (-offset) % alignment
-
-
-# ---------------------------------------------------------------------------
-# Tensor extraction / restoration (recursive, nested dicts/lists)
-# ---------------------------------------------------------------------------
-
 
 def extract_tensors(obj: Any, path: str = "") -> tuple[Any, dict[str, torch.Tensor]]:
     """Recursively extract tensors from nested structure, replacing with placeholders."""
@@ -68,7 +60,6 @@ def extract_tensors(obj: Any, path: str = "") -> tuple[Any, dict[str, torch.Tens
     else:
         return obj, tensors
 
-
 def restore_tensors(obj: Any, tensor_dict: dict[str, torch.Tensor]) -> Any:
     """Recursively restore tensors from placeholders."""
     if isinstance(obj, dict):
@@ -83,12 +74,6 @@ def restore_tensors(obj: Any, tensor_dict: dict[str, torch.Tensor]) -> Any:
         return type(obj)(restore_tensors(item, tensor_dict) for item in obj)
     else:
         return obj
-
-
-# ---------------------------------------------------------------------------
-# Payload read/write (full StagePayload via relay)
-# ---------------------------------------------------------------------------
-
 
 async def write_payload(
     relay: Relay,
@@ -145,7 +130,6 @@ async def write_payload(
         "tensor_info": tensor_info,
     }, op
 
-
 async def read_payload(
     relay: Relay,
     request_id: str,
@@ -189,12 +173,6 @@ async def read_payload(
     relay.cleanup(request_id)
     return payload
 
-
-# ---------------------------------------------------------------------------
-# Blob read/write (raw tensor via relay, for streaming chunks)
-# ---------------------------------------------------------------------------
-
-
 async def write_blob(
     relay: Relay,
     key: str,
@@ -222,7 +200,6 @@ async def write_blob(
     }
     return metadata, op
 
-
 async def read_blob(
     relay: Relay,
     key: str,
@@ -245,17 +222,10 @@ async def read_blob(
     dtype = getattr(torch, dtype_str.replace("torch.", ""))
     return recv_buf[offset:].view(dtype).reshape(shape)
 
-
-# ---------------------------------------------------------------------------
-# Stream chunk send
-# ---------------------------------------------------------------------------
-
 _IPC_INLINE_CPU_BYTES_LIMIT = 64 * 1024
-
 
 def _is_cuda_tensor(obj: Any) -> bool:
     return isinstance(obj, torch.Tensor) and obj.is_cuda
-
 
 def _contains_cuda_tensor(obj: Any) -> bool:
     if _is_cuda_tensor(obj):
@@ -267,7 +237,6 @@ def _contains_cuda_tensor(obj: Any) -> bool:
     if isinstance(obj, (list, tuple, set, frozenset)):
         return any(_contains_cuda_tensor(value) for value in obj)
     return False
-
 
 def _contains_cpu_tensor(obj: Any, seen: set[int] | None = None) -> bool:
     if obj is None:
@@ -285,7 +254,6 @@ def _contains_cpu_tensor(obj: Any, seen: set[int] | None = None) -> bool:
     if isinstance(obj, (list, tuple, set, frozenset)):
         return any(_contains_cpu_tensor(value, seen) for value in obj)
     return False
-
 
 def _inline_cpu_pickle_size(obj: Any, seen: set[int] | None = None) -> int:
     if obj is None:
@@ -311,7 +279,6 @@ def _inline_cpu_pickle_size(obj: Any, seen: set[int] | None = None) -> int:
     except Exception:
         return _IPC_INLINE_CPU_BYTES_LIMIT + 1
 
-
 def _should_use_cuda_ipc_stream_chunk(data: Any, metadata: dict | None) -> bool:
     if not _contains_cuda_tensor(data):
         return False
@@ -320,7 +287,6 @@ def _should_use_cuda_ipc_stream_chunk(data: Any, metadata: dict | None) -> bool:
     inline_size = _inline_cpu_pickle_size(data) + _inline_cpu_pickle_size(metadata)
     return inline_size <= _IPC_INLINE_CPU_BYTES_LIMIT
 
-
 def ipc_pickle(obj: Any) -> bytes:
     """Serialize via ForkingPickler only when CUDA IPC tensor handles are needed."""
     if not _contains_cuda_tensor(obj):
@@ -328,7 +294,6 @@ def ipc_pickle(obj: Any) -> bytes:
     buf = io.BytesIO()
     ForkingPickler(buf, 2).dump(obj)
     return buf.getvalue()
-
 
 def _serialize_ipc_metadata_value(value: Any) -> Any:
     if isinstance(value, torch.Tensor):
@@ -340,7 +305,6 @@ def _serialize_ipc_metadata_value(value: Any) -> Any:
     if isinstance(value, tuple):
         return {"_ipc_tuple": [_serialize_ipc_metadata_value(item) for item in value]}
     return value
-
 
 def serialize_ipc_chunk(
     data: Any,
@@ -354,7 +318,6 @@ def serialize_ipc_chunk(
 
     return ipc_metadata
 
-
 def deserialize_ipc_metadata(value: Any) -> Any:
     if isinstance(value, dict):
         if set(value) == {"_ipc_tensor"}:
@@ -365,7 +328,6 @@ def deserialize_ipc_metadata(value: Any) -> Any:
     if isinstance(value, list):
         return [deserialize_ipc_metadata(item) for item in value]
     return value
-
 
 async def send_stream_chunk(
     relay: Relay,
@@ -381,9 +343,6 @@ async def send_stream_chunk(
     same_gpu_targets: set[str] | None = None,
 ) -> None:
     """Send a streaming chunk to a downstream stage."""
-    # Keep CUDA IPC limited to CUDA-dominant chunks with no CPU tensors and only
-    # small inline Python metadata; otherwise the relay path keeps CPU-heavy
-    # pieces out of the IPC control-plane pickle.
     if (
         same_gpu_targets
         and target_stage in same_gpu_targets
@@ -434,9 +393,6 @@ async def send_stream_chunk(
                 }
             relay_metadata["chunk_metadata_tensors"] = metadata_refs
 
-    # Send control message FIRST — receiver starts reading immediately.
-    # NIXL credit deadlock avoidance: if we wait_for_completion before notifying,
-    # the receiver never starts reading, never triggers RDMA notification, deadlock.
     msg = DataReadyMessage(
         request_id=request_id,
         from_stage=from_stage,
@@ -448,7 +404,6 @@ async def send_stream_chunk(
 
     for pending_op in pending_ops:
         await pending_op.wait_for_completion()
-
 
 async def send_stream_signal(
     control_plane: Any,

--- a/sglang_omni/pipeline/runtime_config.py
+++ b/sglang_omni/pipeline/runtime_config.py
@@ -18,10 +18,8 @@ from sglang_omni.config.topology import ProcessTopologyPlan, build_process_topol
 
 logger = logging.getLogger(__name__)
 
-# PyZMQ checks the filesystem path after ``ipc://`` against this budget.
 _IPC_SUN_PATH_BUDGET = getattr(zmq, "IPC_PATH_MAX_LEN", 100)
 _TEMPFILE_RANDOM_SUFFIX_LEN = 8
-
 
 class IpcRuntimeDir:
     """Runtime-owned IPC directory for one pipeline instance."""
@@ -50,7 +48,6 @@ class IpcRuntimeDir:
         except OSError as exc:
             logger.warning("Failed to remove IPC runtime dir %s: %s", self.path, exc)
 
-
 @dataclass(frozen=True)
 class PipelineRuntimePrep:
     """Prepared stage, endpoint, placement, and topology state."""
@@ -63,7 +60,6 @@ class PipelineRuntimePrep:
     process_plan: ProcessTopologyPlan
     runtime_dir: IpcRuntimeDir
     runtime_dir_created_here: bool
-
 
 def create_ipc_runtime_dir(
     config: PipelineConfig,
@@ -87,7 +83,6 @@ def create_ipc_runtime_dir(
     dir_prefix = f"{namespace_prefix}-" if namespace_prefix else ""
     path = Path(tempfile.mkdtemp(prefix=dir_prefix, dir=base_root))
     return IpcRuntimeDir(path)
-
 
 def prepare_pipeline_runtime(
     config: PipelineConfig,
@@ -130,7 +125,6 @@ def prepare_pipeline_runtime(
         runtime_dir_created_here=runtime_dir_created_here,
     )
 
-
 def build_relay_config(
     stage_cfg: StageConfig,
     global_cfg: PipelineConfig,
@@ -166,7 +160,6 @@ def build_relay_config(
         "gpu_id": gpu_id,
     }
 
-
 def parse_gpu_id(device: str) -> int | None:
     if device == "cpu":
         return None
@@ -175,7 +168,6 @@ def parse_gpu_id(device: str) -> int | None:
     if device.startswith("cuda:"):
         return int(device.split(":", 1)[1])
     raise ValueError(f"Unsupported device string: {device}")
-
 
 def allocate_endpoints(
     *,
@@ -191,7 +183,6 @@ def allocate_endpoints(
     for stage in stages:
         endpoints[f"stage_{stage.name}"] = f"ipc://{base_dir}/stage_{stage.name}.sock"
     return endpoints
-
 
 def _truncate_ipc_namespace_prefix(
     namespace_prefix: str,
@@ -224,7 +215,6 @@ def _truncate_ipc_namespace_prefix(
         return ""
     return namespace_prefix[:max_prefix_len]
 
-
 def _validate_ipc_endpoint_budget(
     *,
     stages: list[StageConfig],
@@ -239,12 +229,10 @@ def _validate_ipc_endpoint_budget(
             path_len=path_len,
         )
 
-
 def _longest_endpoint_suffix_len(stages: list[StageConfig]) -> int:
     suffixes = [len("/completion.sock"), len("/abort.sock")]
     suffixes.extend(len(f"/stage_{stage.name}.sock") for stage in stages)
     return max(suffixes)
-
 
 def _ipc_dir_len(
     *,
@@ -256,7 +244,6 @@ def _ipc_dir_len(
     if namespace_prefix_len:
         dir_name_len += len("-")
     return len(str(base_root)) + len("/") + dir_name_len + endpoint_suffix_len
-
 
 def _raise_ipc_path_budget_error(
     *,

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -47,7 +47,6 @@ logger = logging.getLogger(__name__)
 GetNextFn = Callable[[str, Any], str | list[str] | None]
 GetStreamDoneTargetsFn = Callable[[str, Any], str | list[str] | None]
 
-
 class Stage:
     """IO shell for one pipeline stage.
 
@@ -106,7 +105,6 @@ class Stage:
         self._is_terminal = is_terminal
         self._owns_external_io = role in {"single", "leader"}
 
-        # --- Relay ---
         if relay is not None:
             self.relay = relay
         else:
@@ -132,13 +130,11 @@ class Stage:
                 recv_from_ranks=config.get("recv_from_ranks", []),
             )
 
-        # --- State ---
         self._running = False
         self._aborted: set[str] = set()
         self._active_requests: set[str] = set()
         self._stream_queue: StreamQueue | None = None
         self._stream_chunk_counters: dict[tuple[str, str], int] = {}
-        # Per-request: did we already emit the first stream-chunk event?
         self._first_stream_chunk_seen: set[str] = set()
         self._local_stream_targets: dict[str, set[str]] = {}
         self._nonlocal_stream_targets: dict[str, set[str]] = {}
@@ -154,12 +150,9 @@ class Stage:
         self._loop = asyncio.get_running_loop()
         self._running = True
 
-        # Start scheduler in dedicated thread
         if self.scheduler is not None:
 
             def _run_scheduler():
-                # Active-stage binding so ``emit(stage=None)`` from
-                # scheduler-thread descendants resolves to this stage.
                 _set_active_stage(self.name)
                 try:
                     if self.gpu_id is not None:
@@ -287,7 +280,7 @@ class Stage:
             metadata={"from_stage": "coordinator", "kind": "submit"},
         )
 
-        payload = msg.data  # StagePayload from coordinator
+        payload = msg.data
         await self._execute(payload)
 
     async def _on_data_ready(self, msg: DataReadyMessage) -> None:
@@ -299,7 +292,6 @@ class Stage:
         if self._stream_queue is not None and not self._stream_queue.has(request_id):
             self._stream_queue.open(request_id)
 
-        # Read payload from relay
         try:
             payload = await relay_io.read_payload(
                 self.relay, request_id, msg.shm_metadata
@@ -399,7 +391,6 @@ class Stage:
             return
         self._active_requests.add(request_id)
 
-        # Same-GPU CUDA IPC
         if isinstance(msg.shm_metadata, dict) and msg.shm_metadata.get("_ipc"):
             try:
                 item = self._deserialize_ipc_chunk(msg)
@@ -422,7 +413,6 @@ class Stage:
             await self._route_stream_item_or_fail(request_id, item)
             return
 
-        # Cross-GPU: relay
         blob_key = f"{request_id}:stream:{msg.from_stage}:{msg.to_stage}:{msg.chunk_id}"
         try:
             data = await relay_io.read_blob(self.relay, blob_key, msg.shm_metadata)
@@ -779,10 +769,6 @@ class Stage:
             role=self.role,
         )
 
-    # ------------------------------------------------------------------
-    # Outbox drain: scheduler results → route downstream
-    # ------------------------------------------------------------------
-
     async def _drain_outbox(self) -> None:
         if self._owns_external_io:
             await self._drain_outbox_external()
@@ -856,7 +842,6 @@ class Stage:
         if not self._owns_external_io:
             self._clear_request_state(request_id)
             return
-        # Send stream done to the active stream targets for this request.
         stream_targets = self._stream_targets
         if self.get_stream_done_targets is not None:
             resolved = self.get_stream_done_targets(request_id, result)
@@ -876,7 +861,6 @@ class Stage:
 
         next_stages = self.get_next(request_id, result)
         if next_stages is None:
-            # Terminal: notify coordinator
             _emit_event(
                 request_id=request_id,
                 stage=self.name,
@@ -1012,9 +996,6 @@ class Stage:
                 "projected local-object dispatch requires projectors to return "
                 f"StagePayload, got {type(projected_payload).__name__}"
             )
-        # A fan-out edge may use process-local dispatch only when projection
-        # gives the target its own mutable payload/data containers. Tensor leaves
-        # inside those containers may still be shared intentionally.
         if projected_payload.data is original_payload.data:
             return False
         return not Stage._shares_mutable_container(
@@ -1348,7 +1329,6 @@ class Stage:
                 )
 
     def _on_profiler_stop(self, msg: ProfilerStopMessage) -> None:
-        # run_id=None is a wildcard (stop whatever's active).
         if TorchProfiler.is_active() and (
             msg.run_id is None or TorchProfiler.get_active_run_id() == msg.run_id
         ):

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -29,7 +29,6 @@ from sglang_omni.utils.imports import import_string
 
 logger = logging.getLogger(__name__)
 
-
 @dataclass
 class StageLaunchConfig:
     """Resolved launch metadata for one logical stage instance.
@@ -42,7 +41,6 @@ class StageLaunchConfig:
     paths resolved by the child via :func:`import_string`.
     """
 
-    # Identity
     stage_name: str
     role: Literal["single", "leader", "follower"] = "single"
     tp_rank: int = 0
@@ -50,45 +48,36 @@ class StageLaunchConfig:
     gpu_id: int | None = None
     nccl_port: int | None = None
 
-    # Factory
     factory: str = ""
     factory_args: dict[str, Any] = field(default_factory=dict)
     env_defaults: dict[str, str] = field(default_factory=dict)
 
-    # Routing: static next stage(s)
     next_stages: str | list[str] | None = None
     route_fn: str | None = None
     is_terminal: bool = False
 
-    # Fan-in
     wait_for: list[str] | None = None
     wait_for_fn: str | None = None
     merge_fn: str | None = None
     project_payload: dict[str, str] = field(default_factory=dict)
 
-    # Relay
     relay_config: dict[str, Any] = field(default_factory=dict)
 
-    # Endpoints
     recv_endpoint: str = ""
     coordinator_endpoint: str = ""
     abort_endpoint: str = ""
     stage_endpoints: dict[str, str] = field(default_factory=dict)
 
-    # Stream wiring
     stream_targets: list[str] = field(default_factory=list)
     stream_done_to_fn: str | None = None
     same_gpu_targets: set[str] = field(default_factory=set)
     is_stream_receiver: bool = False
     can_accept_stream_before_payload: bool = False
 
-    # Same-process full payload wiring
     same_process_targets: set[str] = field(default_factory=set)
 
-    # Fusion name map
     name_map: dict[str, str] = field(default_factory=dict)
 
-    # TP internal control (leader -> followers)
     follower_work_queues: list[Any] = field(default_factory=list)
     follower_abort_queues: list[Any] = field(default_factory=list)
     follower_admin_result_queues: list[Any] = field(default_factory=list)
@@ -108,7 +97,6 @@ class StageLaunchConfig:
     def is_follower(self) -> bool:
         return self.role == "follower"
 
-
 @dataclass
 class StageWorkerProcessSpec:
     """Everything one OS process needs to run one or more stages."""
@@ -116,7 +104,6 @@ class StageWorkerProcessSpec:
     process_name: str
     stage_specs: list[StageLaunchConfig]
     gpu_id: int | None = None
-
 
 def _get_worker_process_env(spec: StageWorkerProcessSpec) -> dict[str, str]:
     """Return the spawn-time env overrides for *spec*.
@@ -136,7 +123,6 @@ def _get_worker_process_env(spec: StageWorkerProcessSpec) -> dict[str, str]:
             f"stage_specs={[s.stage_name for s in spec.stage_specs]}"
         )
     return get_stage_process_env(tp_stages[0])
-
 
 @contextmanager
 def _patched_spawn_env(spec: StageWorkerProcessSpec):
@@ -180,7 +166,6 @@ def _patched_spawn_env(spec: StageWorkerProcessSpec):
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = value
-
 
 class StageGroup:
     """Lifecycle manager for one or more OS processes in a topology group."""
@@ -353,7 +338,6 @@ class StageGroup:
             self._ready_events.clear()
             self._startup_error_channels.clear()
 
-
 def stage_process_main(
     spec: StageWorkerProcessSpec,
     ready_event: multiprocessing.Event,
@@ -377,7 +361,6 @@ def stage_process_main(
         if startup_error_channel is not None:
             startup_error_channel.put(traceback.format_exc())
         sys.exit(1)
-
 
 def _run_process(
     spec: StageWorkerProcessSpec,
@@ -429,7 +412,6 @@ def _run_process(
 
     asyncio.run(_start_and_run())
 
-
 def _construct_stage(
     spec: StageLaunchConfig,
     log: logging.Logger,
@@ -446,7 +428,6 @@ def _construct_stage(
         torch.cuda.set_device(int(gpu_id))
         log.info("Set current CUDA device to %s for stage %s", gpu_id, spec.stage_name)
 
-    # --- Build scheduler via factory ---
     log.info(
         "Building scheduler for %s (tp_rank=%d/%d) ...",
         spec.stage_name,
@@ -510,7 +491,6 @@ def _construct_stage(
             )
         return mapped_targets[0] if isinstance(targets, str) else mapped_targets
 
-    # --- Build routing ---
     if spec.is_terminal:
         get_next = lambda request_id, output: None
     elif spec.route_fn:
@@ -550,7 +530,6 @@ def _construct_stage(
     else:
         get_stream_done_targets = None
 
-    # --- Build input handler ---
     if spec.wait_for and spec.merge_fn:
         merge_fn = import_string(spec.merge_fn)
         sources = {spec.name_map.get(n, n) for n in spec.wait_for}
@@ -599,7 +578,6 @@ def _construct_stage(
             follower_admin_result_queues=spec.follower_admin_result_queues,
         )
 
-    # --- Construct Stage ---
     stage = Stage(
         name=spec.stage_name,
         role=spec.role,
@@ -626,7 +604,6 @@ def _construct_stage(
 
     return stage
 
-
 def _construct_scheduler(
     spec: StageLaunchConfig,
     gpu_id: int | None,
@@ -642,13 +619,11 @@ def _construct_scheduler(
         log.info(f"Acquired GPU startup lock for stage {spec.stage_name}: {lock_path}")
         return factory(**spec.factory_args)
 
-
 def _factory_args_use_cuda(factory_args: Mapping[str, Any]) -> bool:
     for value in factory_args.values():
         if isinstance(value, str) and value.startswith("cuda"):
             return True
     return False
-
 
 def get_stage_process_env(
     spec: StageLaunchConfig,
@@ -678,7 +653,6 @@ def get_stage_process_env(
         "SGLANG_ONE_VISIBLE_DEVICE_PER_PROCESS": "true",
         "SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK": "false",
     }
-
 
 def _prepare_cuda_environment(
     spec: StageLaunchConfig,
@@ -712,14 +686,12 @@ def _prepare_cuda_environment(
         mapped_gpu,
     )
 
-
 def _normalize_spec_gpu_id_to_local_device(spec: StageLaunchConfig) -> None:
     if "gpu_id" in spec.factory_args:
         spec.factory_args["gpu_id"] = 0
     if "gpu_id" in spec.relay_config:
         spec.relay_config["gpu_id"] = 0
     spec.gpu_id = 0
-
 
 def _process_name(spec: StageWorkerProcessSpec) -> str:
     if len(spec.stage_specs) > 1:
@@ -730,7 +702,6 @@ def _process_name(spec: StageWorkerProcessSpec) -> str:
     if stage_spec.role == "leader":
         return f"stage-{stage_spec.stage_name}-leader"
     return f"stage-{stage_spec.stage_name}-tp{stage_spec.tp_rank}-follower"
-
 
 def _close_queue(q: object) -> None:
     q.close()

--- a/sglang_omni/preprocessing/audio.py
+++ b/sglang_omni/preprocessing/audio.py
@@ -15,7 +15,6 @@ import torch
 
 from .base import MediaIO, _is_url
 
-
 def _decode_audio_bytes_av(data: bytes) -> tuple[np.ndarray, int]:
     """Decode audio bytes using PyAV (supports WebM/Opus, MP3, OGG, FLAC, etc.)."""
     import io
@@ -31,10 +30,8 @@ def _decode_audio_bytes_av(data: bytes) -> tuple[np.ndarray, int]:
         sample_rate = audio_stream.rate
         frames = []
         for frame in container.decode(audio_stream):
-            arr = frame.to_ndarray()  # shape varies by format
+            arr = frame.to_ndarray()
             if arr.ndim == 2:
-                # Planar formats (fltp, s16p, etc.): shape is (channels, samples)
-                # Average channels to mono
                 arr = arr.mean(axis=0)
             frames.append(arr.flatten().astype(np.float32))
     finally:
@@ -44,13 +41,11 @@ def _decode_audio_bytes_av(data: bytes) -> tuple[np.ndarray, int]:
         raise ValueError("No audio frames decoded")
 
     audio = np.concatenate(frames)
-    # Normalize integer formats to [-1, 1] float range
     if audio.max() > 1.0 or audio.min() < -1.0:
         peak = max(abs(audio.max()), abs(audio.min()))
         if peak > 0:
             audio = audio / peak
     return audio, int(sample_rate)
-
 
 def _parse_wav_bytes(data: bytes, source: str = "bytes") -> tuple[np.ndarray, int]:
     """Parse PCM/IEEE-float WAV from bytes without external deps."""
@@ -96,14 +91,14 @@ def _parse_wav_bytes(data: bytes, source: str = "bytes") -> tuple[np.ndarray, in
     if not data_bytes:
         raise ValueError(f"Missing data chunk in WAV: {source}")
 
-    if fmt_tag == 3:  # IEEE float
+    if fmt_tag == 3:
         if bits_per_sample == 32:
             audio = np.frombuffer(data_bytes, dtype="<f4")
         elif bits_per_sample == 64:
             audio = np.frombuffer(data_bytes, dtype="<f8").astype(np.float32)
         else:
             raise ValueError(f"Unsupported float WAV bit depth: {bits_per_sample}")
-    elif fmt_tag == 1:  # PCM
+    elif fmt_tag == 1:
         if bits_per_sample == 16:
             audio_i16 = np.frombuffer(data_bytes, dtype="<i2")
             audio = (audio_i16.astype(np.float32) / 32768.0).astype(np.float32)
@@ -123,13 +118,11 @@ def _parse_wav_bytes(data: bytes, source: str = "bytes") -> tuple[np.ndarray, in
 
     return audio.astype(np.float32, copy=False), int(sample_rate)
 
-
 def _read_wav_bytes(path: str) -> tuple[np.ndarray, int]:
     """Read PCM/IEEE-float WAV from file path without external deps."""
     with open(path, "rb") as f:
         data = f.read()
     return _parse_wav_bytes(data, source=path)
-
 
 def _resample_linear(audio: np.ndarray, orig_sr: int, target_sr: int) -> np.ndarray:
     if orig_sr == target_sr:
@@ -142,7 +135,6 @@ def _resample_linear(audio: np.ndarray, orig_sr: int, target_sr: int) -> np.ndar
     new_idx = np.linspace(0.0, audio.shape[0] - 1, num=new_len, dtype=np.float64)
     return np.interp(new_idx, old_idx, audio).astype(np.float32)
 
-
 def load_audio_path(path: str | Path, *, target_sr: int = 16000) -> np.ndarray:
     with open(path, "rb") as f:
         data = f.read()
@@ -151,7 +143,6 @@ def load_audio_path(path: str | Path, *, target_sr: int = 16000) -> np.ndarray:
     except ValueError:
         audio, sr = _decode_audio_bytes_av(data)
     return _resample_linear(audio, sr, target_sr)
-
 
 def pcm16_bytes_to_float32(
     data: bytes,
@@ -174,7 +165,6 @@ def pcm16_bytes_to_float32(
     if channels > 1:
         audio = audio.reshape(-1, channels).mean(axis=1).astype(np.float32)
     return _resample_linear(audio, source_sr, target_sr)
-
 
 class AudioMediaIO(MediaIO[tuple[npt.NDArray, float]]):
     """MediaIO implementation for audio files."""
@@ -218,7 +208,6 @@ class AudioMediaIO(MediaIO[tuple[npt.NDArray, float]]):
         resampled = _resample_linear(audio, sr, self.target_sr)
         return resampled, float(self.target_sr)
 
-
 async def ensure_audio_list_async(
     audios: Any,
     *,
@@ -240,45 +229,36 @@ async def ensure_audio_list_async(
         return []
     items = audios if isinstance(audios, list) else [audios]
 
-    # Import here to avoid circular dependency
     if resource_connector is None:
         from .resource_connector import get_global_resource_connector
 
         resource_connector = get_global_resource_connector()
 
-    # Collect coroutines for URL items
     coroutines: list[asyncio.Task[tuple[npt.NDArray, float]] | None] = []
     url_indices: list[int] = []
     normalized: list[Any] = []
 
-    # First pass: identify URL items and create coroutines
     for idx, item in enumerate(items):
         if isinstance(item, (str, Path)):
             if _is_url(item):
-                # Create coroutine for async URL fetching
                 coro = resource_connector.fetch_audio_async(
                     str(item), target_sr=target_sr
                 )
                 task = asyncio.create_task(coro)
                 coroutines.append(task)
                 url_indices.append(idx)
-                normalized.append(None)  # Placeholder
+                normalized.append(None)
             else:
-                # Local path - can be loaded synchronously
                 normalized.append(load_audio_path(item, target_sr=target_sr))
         else:
-            # Already processed (numpy array, etc.)
             normalized.append(item)
 
-    # Wait for all URL fetches to complete
     if coroutines:
         results = await asyncio.gather(*coroutines)
-        # Fill in the results at the correct indices (extract audio array, ignore sample rate)
         for url_idx, (audio, _) in zip(url_indices, results):
             normalized[url_idx] = audio
 
     return normalized
-
 
 def build_audio_mm_inputs(hf_inputs: dict[str, Any]) -> dict[str, Any]:
     """Extract standard audio tensors from HF processor outputs."""
@@ -295,7 +275,6 @@ def build_audio_mm_inputs(hf_inputs: dict[str, Any]) -> dict[str, Any]:
         "feature_attention_mask": feature_attention_mask,
         "audio_feature_lengths": audio_feature_lengths,
     }
-
 
 def compute_audio_cache_key(audios: Any) -> str | None:
     """Compute cache key from raw audio inputs (paths, numpy arrays).

--- a/sglang_omni/preprocessing/resource_connector.py
+++ b/sglang_omni/preprocessing/resource_connector.py
@@ -23,10 +23,8 @@ from .base import MediaIO
 _M = TypeVar("_M")
 _MAX_HTTP_REDIRECTS = 5
 
-# Global thread pool for CPU-bound tasks (decoding/resampling)
 global_thread_pool = ThreadPoolExecutor(max_workers=8)
 atexit.register(global_thread_pool.shutdown)
-
 
 class ResourceHTTPConnection:
     """Manages persistent HTTP clients for connection pooling."""
@@ -60,9 +58,7 @@ class ResourceHTTPConnection:
         if self._client:
             self._client.close()
 
-
 global_http_connection = ResourceHTTPConnection()
-
 
 def resolve_allowed_local_media_path(path: str | Path) -> Path:
     resolved = Path(path).expanduser().resolve()
@@ -70,20 +66,17 @@ def resolve_allowed_local_media_path(path: str | Path) -> Path:
         raise ValueError(f"allowed local media path must be a directory: {path}")
     return resolved
 
-
 def _next_redirect_url(response: httpx.Response) -> str:
     location = response.headers.get("location")
     if not location:
         raise ValueError("Redirect response is missing a Location header.")
     return str(response.url.join(location))
 
-
 def _response_media_type(response: httpx.Response) -> str | None:
     content_type = response.headers.get("content-type")
     if not content_type:
         return None
     return content_type.split(";", 1)[0].strip().lower() or None
-
 
 def _validate_response_length(
     response: httpx.Response, *, max_bytes: int | None
@@ -100,11 +93,9 @@ def _validate_response_length(
     if size > max_bytes:
         raise ValueError(f"Media URL response exceeds {max_bytes} bytes.")
 
-
 def _validate_downloaded_size(size: int, *, max_bytes: int | None) -> None:
     if max_bytes is not None and size > max_bytes:
         raise ValueError(f"Media URL response exceeds {max_bytes} bytes.")
-
 
 def _resolve_remote_addresses(
     hostname: str,
@@ -130,7 +121,6 @@ def _resolve_remote_addresses(
         raise ValueError(f"Could not resolve media URL hostname: {hostname}")
     return tuple(addresses)
 
-
 def _unsafe_remote_address_category(
     address: ipaddress.IPv4Address | ipaddress.IPv6Address,
 ) -> str | None:
@@ -148,14 +138,12 @@ def _unsafe_remote_address_category(
         return "unspecified"
     return None
 
-
 def _is_allowed_remote_domain(hostname: str, allowed_domain: str) -> bool:
     allowed_domain = allowed_domain.rstrip(".").lower()
     if allowed_domain.startswith("."):
         suffix = allowed_domain[1:]
         return hostname == suffix or hostname.endswith(allowed_domain)
     return hostname == allowed_domain
-
 
 def _read_limited_response_bytes(
     response: httpx.Response, *, max_bytes: int | None
@@ -171,7 +159,6 @@ def _read_limited_response_bytes(
         chunks.append(chunk)
     return b"".join(chunks)
 
-
 def _media_http_error(exc: httpx.HTTPError, url: str) -> ValueError:
     if isinstance(exc, httpx.HTTPStatusError):
         status_code = exc.response.status_code
@@ -179,7 +166,6 @@ def _media_http_error(exc: httpx.HTTPError, url: str) -> ValueError:
     if isinstance(exc, httpx.TimeoutException):
         return ValueError(f"Timed out loading media URL: {url}")
     return ValueError(f"Failed to load media URL {url}: {exc}")
-
 
 async def _read_limited_response_bytes_async(
     response: httpx.Response, *, max_bytes: int | None
@@ -194,7 +180,6 @@ async def _read_limited_response_bytes_async(
         _validate_downloaded_size(total, max_bytes=max_bytes)
         chunks.append(chunk)
     return b"".join(chunks)
-
 
 class MultiModalResourceConnector:
     """Connector for optimized multi-modal data loading."""
@@ -554,9 +539,7 @@ class MultiModalResourceConnector:
 
         return await self.load_resource_async(video_url, video_io, timeout=timeout)
 
-
 _global_connector: MultiModalResourceConnector | None = None
-
 
 def get_global_resource_connector() -> MultiModalResourceConnector:
     """Get or create the global resource connector."""

--- a/sglang_omni/proto/messages.py
+++ b/sglang_omni/proto/messages.py
@@ -7,7 +7,6 @@ from typing import Any
 from sglang_omni.proto.admin import AdminOperation, AdminResult
 from sglang_omni.proto.request import StagePayload
 
-
 @dataclass
 class DataReadyMessage:
     """Notify next stage that data is ready.
@@ -21,26 +20,21 @@ class DataReadyMessage:
     request_id: str
     from_stage: str
     to_stage: str
-    shm_metadata: Any  # Can be dict, SHMMetadata, or RdmaMetadata
+    shm_metadata: Any
     chunk_id: int | None = None
     is_done: bool = False
     error: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        # Handle different metadata types
         if isinstance(self.shm_metadata, dict):
-            # Simple dict (current NixlRelay format)
             metadata_dict = self.shm_metadata.copy()
-            metadata_dict["_type"] = "dict"  # Mark as simple dict
+            metadata_dict["_type"] = "dict"
         elif hasattr(self.shm_metadata, "to_dict"):
-            # SHMMetadata
             metadata_dict = self.shm_metadata.to_dict()
         elif hasattr(self.shm_metadata, "model_dump"):
-            # RdmaMetadata (Pydantic BaseModel)
             metadata_dict = self.shm_metadata.model_dump()
-            metadata_dict["_type"] = "RdmaMetadata"  # Mark as RdmaMetadata
+            metadata_dict["_type"] = "RdmaMetadata"
         else:
-            # Fallback: try to convert to dict
             metadata_dict = (
                 dict(self.shm_metadata)
                 if hasattr(self.shm_metadata, "__dict__")
@@ -66,15 +60,11 @@ class DataReadyMessage:
     def from_dict(cls, d: dict[str, Any]) -> "DataReadyMessage":
         metadata_dict = d["shm_metadata"]
 
-        # Determine metadata type based on _type field first
         metadata_type = metadata_dict.get("_type", "")
 
         if metadata_type == "dict" or "transfer_info" in metadata_dict:
-            # Simple dict format (current NixlRelay design)
-            # Remove _type marker if present
             metadata = {k: v for k, v in metadata_dict.items() if k != "_type"}
         elif metadata_type == "RdmaMetadata":
-            # Try to import RdmaMetadata if available
             try:
                 from sglang_omni.relay.operations.nixl import RdmaMetadata
 
@@ -85,19 +75,15 @@ class DataReadyMessage:
                 }
                 metadata = RdmaMetadata(**clean_dict)
             except (ImportError, Exception):
-                # Fallback to dict if RdmaMetadata not available
                 metadata = {k: v for k, v in metadata_dict.items() if k != "_type"}
         elif metadata_type == "SHMMetadata" or "shm_segments" in metadata_dict:
-            # Try to import SHMMetadata if available
             try:
                 from sglang_omni.relay.nixl import SHMMetadata
 
                 metadata = SHMMetadata.from_dict(metadata_dict)
             except (ImportError, Exception):
-                # Fallback to dict if SHMMetadata not available
                 metadata = {k: v for k, v in metadata_dict.items() if k != "_type"}
         elif "descriptors" in metadata_dict:
-            # Has descriptors but no _type - try RdmaMetadata first, fallback to dict
             try:
                 from sglang_omni.relay.operations.nixl import RdmaMetadata
 
@@ -108,10 +94,8 @@ class DataReadyMessage:
                 }
                 metadata = RdmaMetadata(**clean_dict)
             except (ImportError, Exception):
-                # Fallback to dict
                 metadata = {k: v for k, v in metadata_dict.items() if k != "_type"}
         else:
-            # Default: use as dict (for current NixlRelay)
             metadata = {k: v for k, v in metadata_dict.items() if k != "_type"}
 
         return cls(
@@ -123,7 +107,6 @@ class DataReadyMessage:
             is_done=d.get("is_done", False),
             error=d.get("error"),
         )
-
 
 @dataclass
 class AbortMessage:
@@ -137,7 +120,6 @@ class AbortMessage:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "AbortMessage":
         return cls(request_id=d["request_id"])
-
 
 @dataclass
 class CompleteMessage:
@@ -168,7 +150,6 @@ class CompleteMessage:
             result=d.get("result"),
             error=d.get("error"),
         )
-
 
 @dataclass
 class StreamMessage:
@@ -208,7 +189,6 @@ class StreamMessage:
             chunk_id=d.get("chunk_id"),
         )
 
-
 @dataclass
 class SubmitMessage:
     """Submit a new request to the entry stage."""
@@ -229,7 +209,6 @@ class SubmitMessage:
             data = StagePayload.from_dict(data)
         return cls(request_id=d["request_id"], data=data)
 
-
 @dataclass
 class ShutdownMessage:
     """Signal graceful shutdown to a stage."""
@@ -241,15 +220,14 @@ class ShutdownMessage:
     def from_dict(cls, d: dict[str, Any]) -> "ShutdownMessage":
         return cls()
 
-
 @dataclass
 class ProfilerStartMessage:
     """Profiler start for a stage."""
 
     run_id: str
-    trace_path_template: str  # e.g. "/tmp/profiles/{run_id}/{stage}/trace"
-    event_dir: str | None = None  # Per-stage JSONL event sink dir for request profiling
-    enable_torch: bool = True  # When False, only request-level events are captured
+    trace_path_template: str
+    event_dir: str | None = None
+    enable_torch: bool = True
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -269,7 +247,6 @@ class ProfilerStartMessage:
             enable_torch=bool(d.get("enable_torch", True)),
         )
 
-
 @dataclass
 class ProfilerStopMessage:
     """Profiler stop. ``run_id=None`` is a wildcard (stop active session)."""
@@ -282,7 +259,6 @@ class ProfilerStopMessage:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "ProfilerStopMessage":
         return cls(run_id=d.get("run_id"))
-
 
 @dataclass
 class AdminMessage:
@@ -297,7 +273,6 @@ class AdminMessage:
     def from_dict(cls, d: dict[str, Any]) -> "AdminMessage":
         return cls(operation=AdminOperation.from_dict(d["operation"]))
 
-
 @dataclass
 class AdminResultMessage:
     """Return an administrative result to the coordinator."""
@@ -310,7 +285,6 @@ class AdminResultMessage:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "AdminResultMessage":
         return cls(result=AdminResult.from_dict(d["result"]))
-
 
 def parse_message(
     d: dict[str, Any],

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -48,13 +48,11 @@ logger = logging.getLogger(__name__)
 
 _FAILED_BATCH_RESULT = object()
 
-
 class _NoOpSender:
     """Stub for send_to_detokenizer — stream_output handles emission."""
 
     def send_output(self, *args, **kwargs):
         pass
-
 
 class _NoOpGrammarManager:
     """Stub — OmniScheduler never uses constrained decoding."""
@@ -75,7 +73,6 @@ class _NoOpGrammarManager:
 
     def __len__(self) -> int:
         return 0
-
 
 class OmniScheduler:
     """Stage-facing scheduler for AR stages.
@@ -118,7 +115,6 @@ class OmniScheduler:
         self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
         self.requires_tp_work_fanout: bool = False
 
-        # --- Request builder: StagePayload → SGLangARRequestData ----------
         self._request_builder = request_builder
         self._result_adapter = result_adapter
         self._model_runner = model_runner
@@ -127,7 +123,6 @@ class OmniScheduler:
         self._stream_done_handler = stream_done_handler
         self._abort_callback = abort_callback
 
-        # --- Core scheduling state (read/written by upstream methods) -----
         self.server_args = server_args
         self.model_config = model_config
         self.gpu_id = tp_worker.gpu_id
@@ -141,19 +136,11 @@ class OmniScheduler:
         self.moe_ep_size = 1
         self.page_size = server_args.page_size
         self.enable_overlap = enable_overlap
-        # One-step-lookahead async decode (single stream + CUDA event). Only
-        # safe for model runners that implement post_decode_launch/resolve.
         self.enable_async_decode = enable_async_decode
-        # Below this decode batch size the lookahead is bypassed for a plain
-        # synchronous step: at low concurrency the per-step collect is too small
-        # to overlap, so the lookahead's fixed overhead is a net loss (the bs=1
-        # regression — see benchmark_results.md / stall_analysis.md). Default 2
-        # = only bs=1 takes the fast path.
         self.async_decode_min_batch_size = int(async_decode_min_batch_size)
         if model_runner is not None:
             model_runner._async_enabled = enable_async_decode
 
-        # Token / memory info (upstream reads from tp_worker.get_worker_info)
         mr = tp_worker.model_runner
         self.max_total_num_tokens = mr.max_total_num_tokens
         self.max_prefill_tokens = server_args.max_prefill_tokens
@@ -167,7 +154,6 @@ class OmniScheduler:
         self.random_seed = tp_worker.random_seed
         self.device = tp_worker.device
 
-        # Global server_args field upstream sets in its __init__
         from sglang.srt.server_args import get_global_server_args
 
         gsa = get_global_server_args()
@@ -177,25 +163,19 @@ class OmniScheduler:
                 1,
             )
 
-        # Workers
         self.tp_worker = tp_worker
         self.model_worker = tp_worker
 
-        # Cache / memory management
         self.tree_cache = tree_cache
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
         self.prefill_manager = prefill_manager
         self.decode_manager = decode_manager
 
-        # Batch state
         self.waiting_queue: list = []
         self.running_batch = ScheduleBatch(reqs=[], batch_is_full=False)
         self.cur_batch = None
         self.last_batch = None
-        # Async decode (one-step lookahead): the launched-but-not-resolved
-        # decode batch, or None. Tracked here (not just a loop local) so abort
-        # can reach the in-flight step. See _event_loop_async_decode.
         self._async_pending = None
         self.forward_ct = 0
         self.return_health_check_ct = 0
@@ -209,7 +189,6 @@ class OmniScheduler:
         self._scheduler_thread_id: int | None = None
         self._last_pause_mode: str | None = None
 
-        # Chunked prefill
         self.chunked_prefill_size = server_args.chunked_prefill_size
         if self.chunked_prefill_size <= 0:
             self.chunked_prefill_size = None
@@ -219,7 +198,6 @@ class OmniScheduler:
         )
         self.enable_dynamic_chunking = False
 
-        # Schedule policy
         from sglang.srt.managers.schedule_policy import SchedulePolicy
 
         self.schedule_policy = server_args.schedule_policy
@@ -253,7 +231,6 @@ class OmniScheduler:
         self.new_token_ratio = self.init_new_token_ratio
         self.prefill_delayer = None
 
-        # Feature flags (all disabled)
         self.enable_lora = False
         self.enable_pdmux = False
         self.enable_metrics = server_args.enable_metrics
@@ -271,7 +248,6 @@ class OmniScheduler:
         )
         self.current_scheduler_metrics_enabled = False
 
-        # Speculative decoding (disabled)
         try:
             from sglang.srt.managers.scheduler import DllmStagingReqs
         except ImportError:
@@ -287,7 +263,6 @@ class OmniScheduler:
         self.dllm_staging_reqs = DllmStagingReqs(dllm_config=None)
         self.draft_worker = None
 
-        # Subsystem stubs
         self.watchdog = None
         self.soft_watchdog = None
         self.recv_skipper = None
@@ -299,7 +274,6 @@ class OmniScheduler:
         self.require_mlp_sync = False
         self.abort_on_priority_when_disabled = False
 
-        # Disaggregation / hybrid (disabled)
         from sglang.srt.disaggregation.utils import DisaggregationMode
 
         self.disaggregation_mode = DisaggregationMode.NULL
@@ -309,7 +283,6 @@ class OmniScheduler:
         self.is_initializing = False
         self.truncation_align_size = None
 
-        # Attention parallelism / TP ownership
         self.attn_tp_rank = self.tp_rank
         self.attn_tp_size = self.tp_size
         self.attn_dp_rank = 0
@@ -321,7 +294,6 @@ class OmniScheduler:
         self.entry_rank = 0
         self.is_entry_rank = self.tp_rank == 0
 
-        # Misc
         self.metrics_collector = None
         self.pad_input_ids_func = None
         self.decode_mem_cache_buf_multiplier = 0
@@ -347,15 +319,10 @@ class OmniScheduler:
             getattr(server_args, "enable_priority_scheduling", False)
             and not getattr(server_args, "disable_priority_preemption", False)
         )
-        # High-water mark, not a cap. Mirrors upstream Scheduler.__init__ (sglang/srt/managers/scheduler.py).
         self.max_prefill_bs = 0
         self.use_ngram_embedding = False
         self.return_health_check_ipcs = []
         self.enable_overlap_mlx = False
-        # Upstream scheduler_runtime_checker_mixin._streaming_session_count
-        # iterates ``self.session_controller.sessions.values()`` during
-        # report_decode_stats. We don't host SGLang's interactive-session
-        # feature, so a stub with an empty sessions dict is sufficient.
         from types import SimpleNamespace
 
         self.session_controller = SimpleNamespace(sessions={})
@@ -375,10 +342,6 @@ class OmniScheduler:
 
     def self_check_during_busy(self) -> None:
         return None
-
-    # ------------------------------------------------------------------
-    # Composition: delegate missing attributes to the upstream class
-    # ------------------------------------------------------------------
 
     def __getattr__(self, name: str):
         """Look up methods on the upstream SGLang Scheduler class.
@@ -401,7 +364,6 @@ class OmniScheduler:
                 f"'{type(self).__name__}' has no attribute {name!r}"
             ) from None
 
-        # Bind unbound methods to this instance so they use our state
         if callable(attr):
             return types.MethodType(attr, self)
         return attr
@@ -640,16 +602,11 @@ class OmniScheduler:
         """
         self._emit_prefill_start_for_batch(batch)
         if self._model_runner is not None:
-            # Mirror upstream run_batch's per-forward counter: OmniScheduler
-            # overrides run_batch, so without this forward_ct stays 0 and
-            # SGLANG_TEST_RETRACT fires every step. Only the custom-runner path
-            # needs it (the fallback reaches upstream run_batch, which counts).
             self.forward_ct = getattr(self, "forward_ct", 0) + 1
             sched_output = self._build_sched_output(batch)
             mr_output = self._model_runner.execute(sched_output)
             self._emit_stream_output(sched_output, mr_output)
             return self._make_batch_result(batch, mr_output)
-        # Fallback: call upstream's run_batch (uses tp_worker directly)
         return _Upstream.run_batch(self, batch, pp_proxy_tensors)
 
     def _build_sched_output(self, batch):
@@ -691,8 +648,6 @@ class OmniScheduler:
 
     @staticmethod
     def _make_batch_result(batch, mr_output):
-        # process_batch_result reads .next_token_ids / .logits_output; the
-        # model runner already set batch.output_ids during execute/resolve.
         from sglang.srt.managers.scheduler import GenerationBatchResult
 
         next_token_ids = batch.output_ids
@@ -710,8 +665,6 @@ class OmniScheduler:
         payload), without waiting. Returns ``(sched_output, pending_step)``; the
         caller holds the pending step (launch-first keeps two steps in flight)."""
         self._emit_prefill_start_for_batch(batch)
-        # One forward per launch; mirror upstream run_batch's per-forward
-        # counter (the matching resolve does no forward, so it must not count).
         self.forward_ct = getattr(self, "forward_ct", 0) + 1
         sched_output = self._build_sched_output(batch)
         pending_step = self._model_runner.execute_launch(sched_output)
@@ -779,7 +732,6 @@ class OmniScheduler:
 
             rid = req.rid
 
-            # Build result payload from the Req
             data = req._omni_data
             data.output_ids = list(req.output_ids)
             data.weight_version = getattr(self.server_args, "weight_version", None)
@@ -1178,12 +1130,6 @@ class OmniScheduler:
                 "data": {"skipped": True, "unsupported": True},
             }
         # Note (Xuesong): init blocks on a NCCL/TCP rendezvous and runs on the
-        # scheduler serving thread (admin is drained inline in the event loop), so
-        # the serving loop is frozen until the trainer (rank 0) joins. sglang's
-        # init_weights_update_group exposes no timeout, so a missing trainer
-        # stalls inference up to NCCL's own timeout. Call this only in
-        # coordination with the trainer (the router takes the worker out of
-        # routing for the duration).
         with self._admin_lock:
             success, message = self.model_worker.init_weights_update_group(payload)
         return {
@@ -1344,11 +1290,6 @@ class OmniScheduler:
 
     def _event_loop_normal(self) -> None:
         # Note (Chenyang): yield the GIL when idle so co-located non-AR stages
-        # (encoders, preprocessor) running in sibling threads aren't starved
-        # of Python execution. Without this, in single-process mode the busy
-        # AR scheduler loop pins the GIL and the audio_encoder forward pass
-        # (which is mostly Python-side dispatch into many small CUDA kernels)
-        # slows ~600x, dropping audio QPS from >10 to <0.5.
         while self._running:
             self._process_admin_requests()
             recv_reqs = self.recv_requests()
@@ -1457,12 +1398,9 @@ class OmniScheduler:
         _mark_sampler_finished sets) must be KEPT so process_batch_result emits
         it — only reqs finished in a *prior* step are the overrun to drop.
         """
-        # A request retracted at step S is still in step S+1's lagged batch;
-        # drop it like a prior-step finish so its KV is not re-freed.
         pre_finished = [
             r.finished() or bool(getattr(r, "is_retracted", False)) for r in batch.reqs
         ]
-        # rids finished/retracted in a prior step (overrun): suppress their emit
         skip_rids = {batch.reqs[i].rid for i, was in enumerate(pre_finished) if was}
         result = self._run_batch_resolve(
             batch, sched_output, pending_step, skip_rids=skip_rids
@@ -1474,11 +1412,6 @@ class OmniScheduler:
             if result.next_token_ids is not None and keep:
                 idx = torch.tensor(keep, device=result.next_token_ids.device)
                 result.next_token_ids = result.next_token_ids[idx]
-            # Drop overrun reqs from the batch. NOT filter_batch(): batch is a
-            # ScheduleBatch.copy() which omits seq_lens (it carries only the
-            # fields process_batch_result needs). process_batch_result_decode
-            # zips batch.reqs with next_token_ids and uses Req attributes (not
-            # positional batch tensors), so trimming reqs in lockstep suffices.
             batch.reqs = [batch.reqs[i] for i in keep]
         if batch.reqs:
             self.process_batch_result(batch, result)
@@ -1538,8 +1471,6 @@ class OmniScheduler:
             batch = self.get_next_batch_to_run()
             self.cur_batch = batch
 
-            # Route through sync when the runner's collect has a sync-only
-            # fallback (default True for runners not overriding lookahead_eligible).
             runner = getattr(self, "_model_runner", None)
             use_lookahead = (
                 batch is not None
@@ -1563,21 +1494,8 @@ class OmniScheduler:
                         except Exception as exc:
                             self._handle_batch_failure(pb, exc)
             else:
-                # Fast path (low-concurrency decode below the threshold) +
-                # prefill + empty all land here: flush any in-flight lookahead
-                # step first (preserve ordering — this is also the bs>=2 -> bs=1
-                # drain transition), then run this batch synchronously. Bypassing
-                # the lookahead at bs=1 avoids its fixed per-step overhead, which
-                # at low concurrency has no overlap payoff (the bs=1 regression).
-                # Skip the drain call entirely in the common no-pending case (the
-                # bs=1 steady state) — _resolve_pending_async would just no-op.
                 if self._async_pending is not None:
                     self._resolve_pending_async()
-                    # Stale-batch overrun: `batch` was built (get_next_batch_to_run,
-                    # top of loop) BEFORE this drain, which can finish OR retract reqs
-                    # still present in it. Drop them before run_batch so they are not
-                    # forwarded/finalized a second time (double-free of already-freed
-                    # KV). Fast-path analogue of the _resolve_and_process drop.
                     batch = self._drop_stale_overrun(batch)
                     self.cur_batch = batch
                 if batch:
@@ -1605,7 +1523,6 @@ class OmniScheduler:
             self.inbox.put(msg)
 
     def _find_request_data(self, request_id: str) -> Any | None:
-        # Scan all batches a live req can sit in during prefill→decode handoff.
         for batch in (self.running_batch, self.cur_batch, self.last_batch):
             if batch is None:
                 continue
@@ -1636,7 +1553,6 @@ class OmniScheduler:
             req_data.stream_done = True
             return
         self._stream_done_handler(req_data)
-
 
 def _remove_from_batch(batch: Any, request_id: str) -> None:
     if batch is None:

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -52,11 +52,6 @@ from sglang_omni.utils.gpu_memory import (
 
 logger = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
-# Built-in pipeline registry
-# ---------------------------------------------------------------------------
-
-
 def _find_available_port(host: str, port: int) -> int:
     """Return *port* if available, otherwise find a free port and warn."""
     try:
@@ -72,16 +67,12 @@ def _find_available_port(host: str, port: int) -> int:
     logger.warning("Using port %d instead.", free_port)
     return free_port
 
-
 def _default_run_id() -> str:
     return time.strftime("run_%Y%m%d_%H%M%S")
-
 
 def _default_template(profiler_dir: str, run_id: str) -> str:
     return os.path.join(profiler_dir, run_id, "trace")
 
-
-# ---------------------------------------------------------------------------
 def _stage_runtime_log_summary(pipeline_config: PipelineConfig) -> dict[str, Any]:
     """Build stage placement and runtime budget fields for startup logs."""
 
@@ -98,7 +89,6 @@ def _stage_runtime_log_summary(pipeline_config: PipelineConfig) -> dict[str, Any
         }
     return summary
 
-
 def _format_gpu_device_info(info: GpuDeviceInfo) -> dict[str, Any]:
     return {
         "device_id": info.device_id,
@@ -109,7 +99,6 @@ def _format_gpu_device_info(info: GpuDeviceInfo) -> dict[str, Any]:
             else "unknown"
         ),
     }
-
 
 def _placement_log_summary(
     placement_plan,
@@ -149,7 +138,6 @@ def _placement_log_summary(
         },
     }
 
-
 class StartReq(BaseModel):
     run_id: str | None = None
     trace_path_template: str | None = None
@@ -157,19 +145,15 @@ class StartReq(BaseModel):
     event_dir: str | None = None
     enable_torch: bool = True
 
-
 class StopReq(BaseModel):
     run_id: str | None = None
-
 
 class StartRequestProfileReq(BaseModel):
     run_id: str | None = None
     event_dir: str | None = None
 
-
 def _default_event_dir(profiler_dir: str, run_id: str) -> str:
     return os.path.join(profiler_dir, run_id, "events")
-
 
 def _mount_profiler_routes(
     app, profiler_ctl: ProfilerControlClient, profiler_dir: str | None
@@ -263,7 +247,6 @@ def _mount_profiler_routes(
 
     @router.post("/stop_profile")
     async def stop(req: StopReq):
-        # run_id=None is a wildcard (stop whatever's active).
         run_id = req.run_id
         recorder = _get_event_recorder()
         active = recorder.active_run_id() if recorder.is_active() else None
@@ -285,7 +268,6 @@ def _mount_profiler_routes(
 
     app.include_router(router)
 
-
 async def _run_server(
     pipeline_config: PipelineConfig,
     *,
@@ -303,7 +285,6 @@ async def _run_server(
 
     This is the async entry point.  For a blocking call use :func:`launch_server`.
     """
-    # 0. Check port availability before loading models
     port = _find_available_port(host, port)
 
     mp_runner = MultiProcessPipelineRunner(pipeline_config)
@@ -311,9 +292,6 @@ async def _run_server(
     await mp_runner.start(timeout=startup_timeout)
     coordinator = mp_runner.coordinator
 
-    # Plans are resolved once inside ``mp_runner.start()`` (which applies
-    # stage fusion); read them back from the runner for logging rather than
-    # recomputing on the un-fused config.
     placement_plan = mp_runner.prep.placement_plan
     process_plan = mp_runner.prep.process_plan
     gpu_ids = set(placement_plan.gpus)
@@ -367,7 +345,6 @@ async def _run_server(
         await mp_runner.stop()
         logger.info("Pipeline stopped.")
 
-
 async def _serve_with_failure_watch(
     server: uvicorn.Server,
     runtime_watchers,
@@ -404,7 +381,6 @@ async def _serve_with_failure_watch(
         for task in watcher_tasks:
             if not task.done():
                 task.cancel()
-
 
 def launch_server(
     pipeline_config: PipelineConfig,

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -120,15 +120,12 @@ _BAD_REQUEST_MARKERS = (
     "Requested token count exceeds the model's maximum context length",
 )
 
-
 def _is_bad_request_error(exc: Exception) -> bool:
     message = str(exc)
     return any(marker in message for marker in _BAD_REQUEST_MARKERS)
 
-
 class _RequestBodyTooLarge(Exception):
     pass
-
 
 class VoiceUploadBodyLimitMiddleware:
     """Reject oversized voice uploads before Starlette parses multipart bodies."""
@@ -167,7 +164,6 @@ class VoiceUploadBodyLimitMiddleware:
             await self.app(scope, limited_receive, send)
         except _RequestBodyTooLarge:
             await _send_voice_upload_too_large(send, self.max_bytes)
-
 
 def create_app(
     client: Client,
@@ -216,7 +212,6 @@ def create_app(
         max_bytes=MAX_VOICE_UPLOAD_BODY_BYTES,
     )
 
-    # Store references in app state for access from route handlers
     app.state.client = client
     app.state.model_name = model_name or "sglang-omni"
     app.state.realtime_enabled = enable_realtime
@@ -235,7 +230,6 @@ def create_app(
 
     resolved_key = resolve_admin_api_key(admin_api_key)
 
-    # Register all routes
     register_favicon(app)
     _register_health(app)
     _register_models(app)
@@ -251,7 +245,6 @@ def create_app(
         _register_realtime(app)
 
     return app
-
 
 def _register_voices(app: FastAPI) -> None:
     @app.get("/v1/audio/voices")
@@ -302,7 +295,6 @@ def _register_voices(app: FastAPI) -> None:
             }
         )
 
-
 async def _read_voice_upload(audio_sample: UploadFile) -> bytes:
     audio_bytes = await audio_sample.read(MAX_VOICE_UPLOAD_BYTES + 1)
     if len(audio_bytes) > MAX_VOICE_UPLOAD_BYTES:
@@ -312,14 +304,12 @@ async def _read_voice_upload(audio_sample: UploadFile) -> bytes:
         )
     return audio_bytes
 
-
 def _is_voice_upload_scope(scope: dict[str, Any]) -> bool:
     return (
         scope.get("type") == "http"
         and scope.get("method") == "POST"
         and scope.get("path") == "/v1/audio/voices"
     )
-
 
 def _content_length(scope: dict[str, Any]) -> int | None:
     for name, value in scope.get("headers", ()):
@@ -330,7 +320,6 @@ def _content_length(scope: dict[str, Any]) -> int | None:
         except ValueError:
             return None
     return None
-
 
 async def _send_voice_upload_too_large(
     send: Callable[[dict[str, Any]], Awaitable[None]],
@@ -356,7 +345,6 @@ async def _send_voice_upload_too_large(
     )
     await send({"type": "http.response.body", "body": body})
 
-
 def _register_health(app: FastAPI) -> None:
     @app.get("/health")
     async def health() -> JSONResponse:
@@ -373,7 +361,6 @@ def _register_health(app: FastAPI) -> None:
             status_code=status_code,
         )
 
-
 def _register_models(app: FastAPI) -> None:
     @app.get("/v1/models")
     async def list_models() -> JSONResponse:
@@ -389,7 +376,6 @@ def _register_models(app: FastAPI) -> None:
             ]
         )
         return JSONResponse(content=model_list.model_dump())
-
 
 def _register_admin(app: FastAPI, admin_api_key: str | None = None) -> None:
     _auth = make_admin_auth_dependency(admin_api_key)
@@ -523,20 +509,16 @@ def _register_admin(app: FastAPI, admin_api_key: str | None = None) -> None:
             )
         )
 
-
 def _timeout_or_default(timeout_s: float | None, default: float) -> float:
     return default if timeout_s is None else timeout_s
 
-
 def _request_payload(req: AdminRequestBase) -> dict[str, Any]:
     return req.model_dump(exclude={"stages", "timeout_s"}, exclude_none=True)
-
 
 def _admin_response(result: dict[str, Any]) -> JSONResponse:
     if not result.get("success", False):
         raise HTTPException(status_code=400, detail=result)
     return JSONResponse(content=result)
-
 
 def _model_info_response(result: dict[str, Any]) -> JSONResponse:
     if not result.get("success", False):
@@ -560,7 +542,6 @@ def _model_info_response(result: dict[str, Any]) -> JSONResponse:
     )
     return JSONResponse(content=payload)
 
-
 def _extract_model_info_stage_data(result: dict[str, Any]) -> list[dict[str, Any]]:
     infos: list[dict[str, Any]] = []
     for item in result.get("results", []) or []:
@@ -576,7 +557,6 @@ def _extract_model_info_stage_data(result: dict[str, Any]) -> list[dict[str, Any
         stage_info.setdefault("success", item.get("success"))
         infos.append(stage_info)
     return infos
-
 
 def _common_model_info_value(
     result: dict[str, Any],
@@ -607,7 +587,6 @@ def _common_model_info_value(
         )
     return None
 
-
 def _register_chat_completions(app: FastAPI) -> None:
     @app.post("/v1/chat/completions")
     async def chat_completions(req: ChatCompletionRequest) -> Response:
@@ -621,7 +600,6 @@ def _register_chat_completions(app: FastAPI) -> None:
 
         gen_req = _build_chat_generate_request(req)
 
-        # Determine audio format from request
         audio_format = "wav"
         if req.audio and isinstance(req.audio, dict):
             audio_format = req.audio.get("format", "wav")
@@ -652,7 +630,6 @@ def _register_chat_completions(app: FastAPI) -> None:
             audio_format,
         )
 
-
 async def _chat_non_stream(
     client: Client,
     gen_req: GenerateRequest,
@@ -682,7 +659,6 @@ async def _chat_non_stream(
 
     requested_modalities = req.modalities or ["text"]
 
-    # Build message content
     message: dict[str, Any] = {"role": "assistant"}
 
     if "text" in requested_modalities and result.text:
@@ -698,7 +674,6 @@ async def _chat_non_stream(
     if "content" not in message and "audio" not in message:
         message["content"] = result.text
 
-    # Build usage
     usage = None
     if result.usage is not None:
         usage = UsageResponse(
@@ -723,7 +698,6 @@ async def _chat_non_stream(
 
     return JSONResponse(content=response.model_dump())
 
-
 async def _chat_stream(
     client: Client,
     gen_req: GenerateRequest,
@@ -745,9 +719,6 @@ async def _chat_stream(
         request_id=request_id,
         audio_format=audio_format,
     ):
-        # Capture finish info for the dedicated finish chunk after the loop.
-        # Some pipelines only emit a final aggregate chunk; do not drop its
-        # text/audio just because it already carries a finish reason.
         if chunk.finish_reason is not None:
             finish_reason = chunk.finish_reason
             if chunk.usage is not None:
@@ -771,18 +742,15 @@ async def _chat_stream(
         delta = ChatCompletionStreamDelta()
         emit = False
 
-        # Send role on first chunk
         if not role_sent:
             delta.role = "assistant"
             role_sent = True
             emit = True
 
-        # Text chunk
         if chunk.modality == "text" and chunk.text and "text" in requested_modalities:
             delta.content = chunk.text
             emit = True
 
-        # Audio chunk
         if (
             chunk.modality == "audio"
             and chunk.audio_b64 is not None
@@ -815,7 +783,6 @@ async def _chat_stream(
             choice.setdefault("finish_reason", None)
         yield f"data: {json.dumps(data)}\n\n"
 
-    # Finish chunk: empty delta + finish_reason.
     finish_resp = ChatCompletionStreamResponse(
         id=response_id,
         created=created,
@@ -836,17 +803,14 @@ async def _chat_stream(
 
     yield f"data: {STREAM_DONE_SENTINEL}\n\n"
 
-
 def _build_chat_generate_request(req: ChatCompletionRequest) -> GenerateRequest:
     """Convert a ChatCompletionRequest into a client GenerateRequest."""
-    # Parse stop sequences
     stop: list[str] = []
     if isinstance(req.stop, str):
         stop = [req.stop]
     elif isinstance(req.stop, list):
         stop = list(req.stop)
 
-    # Build sampling params
     sampling = SamplingParams(
         temperature=req.temperature if req.temperature is not None else 1.0,
         top_p=req.top_p if req.top_p is not None else 1.0,
@@ -860,20 +824,16 @@ def _build_chat_generate_request(req: ChatCompletionRequest) -> GenerateRequest:
         max_new_tokens=req.effective_max_tokens,
     )
 
-    # Convert messages
     messages = [Message(role=m.role, content=m.content) for m in req.messages]
 
-    # Determine output modalities
-    output_modalities = req.modalities or ["text"]  # e.g. ["text", "audio"]
+    output_modalities = req.modalities or ["text"]
 
-    # Build per-stage sampling overrides
     stage_sampling: dict[str, SamplingParams] | None = None
     if req.stage_sampling:
         stage_sampling = {}
         for stage_name, params_dict in req.stage_sampling.items():
             stage_sampling[stage_name] = SamplingParams(**params_dict)
 
-    # Extract audios, images, and videos from request
     audios: list[str] | None = None
     if req.audios:
         audios = req.audios
@@ -886,7 +846,6 @@ def _build_chat_generate_request(req: ChatCompletionRequest) -> GenerateRequest:
     if req.videos:
         videos = req.videos
 
-    # Merge audio config, audios, images, and videos into metadata
     metadata: dict[str, Any] = {}
     if req.audio:
         metadata["audio_config"] = req.audio
@@ -930,7 +889,6 @@ def _build_chat_generate_request(req: ChatCompletionRequest) -> GenerateRequest:
         output_modalities=output_modalities,
         metadata=metadata,
     )
-
 
 def _register_generate(app: FastAPI) -> None:
     @app.post("/generate")
@@ -976,7 +934,6 @@ def _register_generate(app: FastAPI) -> None:
         response = _build_generate_response(req, result, audio_format)
         return JSONResponse(content=response.model_dump())
 
-
 def _rollout_sampling_to_client(params: RolloutSamplingParams) -> SamplingParams:
     kwargs: dict[str, Any] = {
         key: value
@@ -999,7 +956,6 @@ def _rollout_sampling_to_client(params: RolloutSamplingParams) -> SamplingParams
     if "max_new_tokens" not in kwargs and params.max_tokens is not None:
         kwargs["max_new_tokens"] = params.max_tokens
     return SamplingParams(**kwargs)
-
 
 def _build_rollout_generate_request(req: RolloutGenerateRequest) -> GenerateRequest:
     """Convert a rollout GenerateRequest into a client GenerateRequest."""
@@ -1039,7 +995,6 @@ def _build_rollout_generate_request(req: RolloutGenerateRequest) -> GenerateRequ
         ),
         metadata=dict(req.metadata) if req.metadata else {},
     )
-
 
 def _build_generate_response(
     req: RolloutGenerateRequest,
@@ -1107,7 +1062,6 @@ def _build_generate_response(
     )
     return GenerateResponse(text=result.text, audio=audio, meta_info=meta_info)
 
-
 def _register_realtime(app: FastAPI) -> None:
     """Mount the OpenAI-compatible WebSocket Realtime endpoint."""
     from sglang_omni.serve.realtime import RealtimeSessionManager
@@ -1125,7 +1079,6 @@ def _register_realtime(app: FastAPI) -> None:
             await session.run()
         finally:
             await manager.close(session.session_id)
-
 
 def _register_speech(app: FastAPI) -> None:
     @app.post("/v1/audio/speech")
@@ -1203,7 +1156,6 @@ def _register_speech(app: FastAPI) -> None:
             headers=headers,
         )
 
-
 def _register_speech_batch(app: FastAPI) -> None:
     @app.post("/v1/audio/speech/batch")
     async def create_speech_batch(request: Request) -> JSONResponse:
@@ -1232,7 +1184,6 @@ def _register_speech_batch(app: FastAPI) -> None:
 
         response = SpeechBatchResponse.model_validate(response)
         return JSONResponse(content=response.model_dump(exclude_none=True))
-
 
 async def _create_speech_batch_with_disconnect_watch(
     request: Request,
@@ -1266,7 +1217,6 @@ async def _create_speech_batch_with_disconnect_watch(
         if not disconnect_task.done():
             await _cancel_task_bounded(disconnect_task)
 
-
 def _register_speech_ws(app: FastAPI) -> None:
     @app.websocket("/v1/audio/speech/stream")
     async def speech_stream(websocket: WebSocket) -> None:
@@ -1277,7 +1227,6 @@ def _register_speech_ws(app: FastAPI) -> None:
             speech_service=app.state.speech_service,
         )
         await session.run()
-
 
 def _speech_pcm_chunk_bytes(
     chunk: Any,
@@ -1300,7 +1249,6 @@ def _speech_pcm_chunk_bytes(
     if not audio_bytes:
         return None, emitted_samples, sample_rate
     return audio_bytes, emitted_samples, sample_rate
-
 
 async def _speech_audio_response(
     request: Request,
@@ -1409,7 +1357,6 @@ async def _speech_audio_response(
         },
     )
 
-
 async def _await_speech_response(
     request: Request,
     client: Client,
@@ -1452,7 +1399,6 @@ async def _await_speech_response(
         if not disconnect_task.done():
             await _cancel_task_bounded(disconnect_task)
 
-
 async def _cancel_task_bounded(task: asyncio.Task[Any]) -> None:
     task.cancel()
     done, _ = await asyncio.wait({task}, timeout=HTTP_DISCONNECT_CANCEL_TIMEOUT_S)
@@ -1460,7 +1406,6 @@ async def _cancel_task_bounded(task: asyncio.Task[Any]) -> None:
         await asyncio.gather(*done, return_exceptions=True)
     else:
         task.add_done_callback(_discard_cancelled_task_result)
-
 
 def _discard_cancelled_task_result(task: asyncio.Task[Any]) -> None:
     try:
@@ -1470,11 +1415,9 @@ def _discard_cancelled_task_result(task: asyncio.Task[Any]) -> None:
     except Exception:
         logger.debug("Cancelled request task finished with an error", exc_info=True)
 
-
 async def _wait_for_request_disconnect(request: Request) -> None:
     while not await request.is_disconnected():
         await asyncio.sleep(HTTP_DISCONNECT_POLL_INTERVAL_S)
-
 
 async def _close_async_iterator_if_supported(stream: AsyncIterator[Any]) -> None:
     try:
@@ -1482,7 +1425,6 @@ async def _close_async_iterator_if_supported(stream: AsyncIterator[Any]) -> None
     except AttributeError:
         return
     await close()
-
 
 async def _abort_and_close_speech_stream(
     client: Client,
@@ -1493,7 +1435,6 @@ async def _abort_and_close_speech_stream(
         await client.abort(request_id)
     finally:
         await _close_async_iterator_if_supported(stream)
-
 
 def _register_transcriptions(app: FastAPI) -> None:
     @app.post("/v1/audio/transcriptions")
@@ -1510,7 +1451,6 @@ def _register_transcriptions(app: FastAPI) -> None:
         request_id = f"transcription-{uuid.uuid4()}"
 
         # TODO(Ratish): add the same pre-parser body limit used by voice uploads
-        # once transcription upload limits are defined.
         audio_bytes = await file.read()
         if not audio_bytes:
             raise HTTPException(status_code=400, detail="Uploaded audio file is empty")
@@ -1546,7 +1486,6 @@ def _register_transcriptions(app: FastAPI) -> None:
                 ),
             )
         return JSONResponse(content=TranscriptionResponse(text=text).model_dump())
-
 
 def build_transcription_generate_request(
     *,

--- a/sglang_omni/serve/protocol.py
+++ b/sglang_omni/serve/protocol.py
@@ -7,14 +7,12 @@ from typing import Any
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
-
 class UsageResponse(BaseModel):
     """Token usage statistics."""
 
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
-
 
 class ChatMessage(BaseModel):
     """A single message in a chat conversation."""
@@ -25,15 +23,13 @@ class ChatMessage(BaseModel):
     tool_calls: list[dict[str, Any]] | None = None
     tool_call_id: str | None = None
 
-
 class ChatCompletionAudio(BaseModel):
     """Audio data returned in a chat completion response."""
 
     id: str
-    data: str  # base64-encoded audio
+    data: str
     expires_at: int | None = None
     transcript: str | None = None
-
 
 class ChatCompletionRequest(BaseModel):
     """OpenAI-compatible chat completion request."""
@@ -43,7 +39,6 @@ class ChatCompletionRequest(BaseModel):
     model: str | None = None
     messages: list[ChatMessage]
 
-    # Sampling parameters
     temperature: float | None = None
     top_p: float | None = None
     top_k: int | None = None
@@ -54,25 +49,16 @@ class ChatCompletionRequest(BaseModel):
     stop: str | list[str] | None = None
     seed: int | None = None
 
-    # Streaming
     stream: bool = False
 
-    # Multi-modal output control
-    modalities: list[str] | None = None  # e.g. ["text", "audio"]
+    modalities: list[str] | None = None
 
-    # Audio output configuration
-    audio: dict[str, Any] | None = None  # {"voice": "...", "format": "wav"}
+    audio: dict[str, Any] | None = None
 
-    # Audio input (sglang-omni extension)
-    # Can be a list of audio file paths (local paths or URLs)
     audios: list[str] | None = None
 
-    # Image input (sglang-omni extension)
-    # Can be a list of image file paths (local paths or URLs)
     images: list[str] | None = None
 
-    # Video input (sglang-omni extension)
-    # Can be a list of video file paths (local paths or URLs)
     videos: list[str] | None = None
     video_fps: float | None = None
     video_max_frames: int | None = None
@@ -80,18 +66,15 @@ class ChatCompletionRequest(BaseModel):
     video_max_pixels: int | None = None
     video_total_pixels: int | None = None
 
-    # Per-stage sampling overrides (sglang-omni specific)
     stage_sampling: dict[str, dict[str, Any]] | None = None
     stage_params: dict[str, dict[str, Any]] | None = None
 
-    # Talker-specific overrides for Qwen3-Omni speech output
     talker_temperature: float | None = None
     talker_top_p: float | None = None
     talker_top_k: int | None = None
     talker_repetition_penalty: float | None = None
     talker_max_new_tokens: int | None = None
 
-    # Misc
     request_id: str | None = None
     user: str | None = None
 
@@ -99,14 +82,12 @@ class ChatCompletionRequest(BaseModel):
     def effective_max_tokens(self) -> int | None:
         return self.max_completion_tokens or self.max_tokens
 
-
 class ChatCompletionChoice(BaseModel):
     """A single choice in a chat completion response."""
 
     index: int = 0
     message: dict[str, Any]
     finish_reason: str | None = "stop"
-
 
 class ChatCompletionResponse(BaseModel):
     """OpenAI-compatible chat completion response."""
@@ -118,7 +99,6 @@ class ChatCompletionResponse(BaseModel):
     choices: list[ChatCompletionChoice]
     usage: UsageResponse | None = None
 
-
 class ChatCompletionStreamDelta(BaseModel):
     """Delta content in a streaming chunk."""
 
@@ -126,14 +106,12 @@ class ChatCompletionStreamDelta(BaseModel):
     content: str | None = None
     audio: ChatCompletionAudio | None = None
 
-
 class ChatCompletionStreamChoice(BaseModel):
     """A single choice in a streaming chunk."""
 
     index: int = 0
     delta: ChatCompletionStreamDelta
     finish_reason: str | None = None
-
 
 class ChatCompletionStreamResponse(BaseModel):
     """OpenAI-compatible streaming chunk."""
@@ -144,7 +122,6 @@ class ChatCompletionStreamResponse(BaseModel):
     model: str
     choices: list[ChatCompletionStreamChoice]
     usage: UsageResponse | None = None
-
 
 class RolloutSamplingParams(BaseModel):
     """Typed sampling params for ``POST /generate``."""
@@ -162,13 +139,11 @@ class RolloutSamplingParams(BaseModel):
     max_new_tokens: int | None = Field(default=None, ge=1)
     max_tokens: int | None = Field(default=None, ge=1)
 
-
 class RolloutMessage(BaseModel):
     """Chat message for ``POST /generate`` (role and content required)."""
 
     role: str = Field(min_length=1)
     content: str | list[Any]
-
 
 class RolloutGenerateRequest(BaseModel):
     """Rollout request for ``POST /generate``; set exactly one of
@@ -197,13 +172,11 @@ class RolloutGenerateRequest(BaseModel):
     return_routed_experts: bool = False
     return_indexer_topk: bool = False
 
-
 class GenerateFinishReason(BaseModel):
     """Finish status for a rollout generation."""
 
     type: str
     length: int | None = None
-
 
 class GenerateAudio(BaseModel):
     """Audio payload for a rollout generation."""
@@ -212,7 +185,6 @@ class GenerateAudio(BaseModel):
     path: str | None = None
     format: str | None = None
     sample_rate: int | None = None
-
 
 class GenerateMetaInfo(BaseModel):
     """Rollout meta_info block."""
@@ -226,14 +198,12 @@ class GenerateMetaInfo(BaseModel):
     output_token_logprobs: list[Any] | None = None
     omni_rollout: dict[str, Any] | None = None
 
-
 class GenerateResponse(BaseModel):
     """Response body for ``POST /generate``."""
 
     text: str = ""
     audio: GenerateAudio | None = None
     meta_info: GenerateMetaInfo
-
 
 SUPPORTED_TTS_RESPONSE_FORMATS = frozenset({"wav", "mp3", "flac", "pcm", "aac", "opus"})
 SUPPORTED_TTS_LANGUAGES = frozenset(
@@ -256,7 +226,6 @@ TTS_SPEED_MIN = 0.25
 TTS_SPEED_MAX = 4.0
 DEFAULT_TTS_BATCH_MAX_ITEMS = 32
 
-
 class SpeechReference(BaseModel):
     """Reference item for voice cloning in /v1/audio/speech."""
 
@@ -268,7 +237,6 @@ class SpeechReference(BaseModel):
     text: str | None = None
     vq_codes: list[list[int]] | list[int] | None = None
 
-
 class CreateSpeechRequest(BaseModel):
     """OpenAI-compatible text-to-speech request.
 
@@ -278,7 +246,6 @@ class CreateSpeechRequest(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    # Standard OpenAI fields
     model: str | None = None
     input: str
     voice: str = Field(
@@ -289,21 +256,18 @@ class CreateSpeechRequest(BaseModel):
     speed: float = 1.0
     stream: bool = False
 
-    # Advanced TTS extensions
-    task_type: str | None = None  # e.g. "Base", "CustomVoice", "VoiceDesign"
+    task_type: str | None = None
     language: str | None = None
-    instructions: str | None = None  # style/emotion instructions
+    instructions: str | None = None
 
-    # Voice cloning parameters
-    ref_audio: str | None = None  # path or URL to reference audio
-    ref_text: str | None = None  # transcript of reference audio
-    references: list[SpeechReference] | None = None  # S2-Pro-style refs
+    ref_audio: str | None = None
+    ref_text: str | None = None
+    references: list[SpeechReference] | None = None
     x_vector_only_mode: bool | None = None
-    token_count: int | None = None  # MOSS-TTS duration token target
-    duration_tokens: int | None = None  # alias for token_count
+    token_count: int | None = None
+    duration_tokens: int | None = None
     initial_codec_chunk_frames: int | None = Field(default=None, ge=0)
 
-    # Generation parameters
     max_new_tokens: int | None = None
     temperature: float | None = None
     top_p: float | None = None
@@ -311,9 +275,7 @@ class CreateSpeechRequest(BaseModel):
     repetition_penalty: float | None = None
     seed: int | None = None
 
-    # Per-stage overrides (sglang-omni specific)
     stage_params: dict[str, dict[str, Any]] | None = None
-
 
 class SpeechBatchItem(BaseModel):
     """One item in a batch text-to-speech request."""
@@ -347,7 +309,6 @@ class SpeechBatchItem(BaseModel):
     seed: Any = None
     stage_params: Any = None
 
-
 class CreateSpeechBatchRequest(BaseModel):
     """Batch text-to-speech request with shared defaults and item overrides."""
 
@@ -380,7 +341,6 @@ class CreateSpeechBatchRequest(BaseModel):
     seed: int | None = None
     stage_params: dict[str, dict[str, Any]] | None = None
 
-
 class SpeechBatchResult(BaseModel):
     """One item result in a batch text-to-speech response."""
 
@@ -391,7 +351,6 @@ class SpeechBatchResult(BaseModel):
     media_type: str | None = None
     error: dict[str, Any] | None = None
 
-
 class SpeechBatchResponse(BaseModel):
     """Batch text-to-speech response preserving item order."""
 
@@ -400,7 +359,6 @@ class SpeechBatchResponse(BaseModel):
     total: int
     succeeded: int
     failed: int
-
 
 class SpeechStreamSessionConfig(BaseModel):
     """Configuration for /v1/audio/speech/stream WebSocket sessions."""
@@ -434,7 +392,6 @@ class SpeechStreamSessionConfig(BaseModel):
     seed: int | None = None
     stage_params: dict[str, dict[str, Any]] | None = None
 
-
 class UploadedVoiceMetadata(BaseModel):
     """Metadata returned for an uploaded TTS voice sample."""
 
@@ -446,7 +403,6 @@ class UploadedVoiceMetadata(BaseModel):
     ref_text: str | None = None
     speaker_description: str | None = None
 
-
 class VoiceListResponse(BaseModel):
     """Voice registry response for /v1/audio/voices."""
 
@@ -456,12 +412,10 @@ class VoiceListResponse(BaseModel):
         description="API-process uploaded-voice reference cache counters."
     )
 
-
 class TranscriptionResponse(BaseModel):
     """OpenAI-compatible transcription response."""
 
     text: str
-
 
 class ModelPermission(BaseModel):
     """Model permission info."""
@@ -471,7 +425,6 @@ class ModelPermission(BaseModel):
     allow_create_engine: bool = False
     allow_sampling: bool = True
     allow_logprobs: bool = True
-
 
 class ModelCard(BaseModel):
     """A single model entry."""
@@ -485,13 +438,11 @@ class ModelCard(BaseModel):
     )
     root: str | None = None
 
-
 class ModelList(BaseModel):
     """Response for GET /v1/models."""
 
     object: str = "list"
     data: list[ModelCard] = Field(default_factory=list)
-
 
 class AdminRequestBase(BaseModel):
     """Common admin request routing controls."""
@@ -499,14 +450,11 @@ class AdminRequestBase(BaseModel):
     stages: list[str] | None = None
     timeout_s: float | None = None
 
-
 class PauseGenerationRequest(AdminRequestBase):
     mode: str = "abort"
 
-
 class ContinueGenerationRequest(AdminRequestBase):
     torch_empty_cache: bool = True
-
 
 class UpdateWeightFromDiskRequest(AdminRequestBase):
     model_path: str
@@ -521,7 +469,6 @@ class UpdateWeightFromDiskRequest(AdminRequestBase):
     flush_cache: bool = True
     manifest: dict[str, Any] | None = None
 
-
 class UpdateWeightsFromTensorRequest(AdminRequestBase):
     serialized_named_tensors: list[Any] | None = None
     load_format: str | None = None
@@ -530,7 +477,6 @@ class UpdateWeightsFromTensorRequest(AdminRequestBase):
     weight_version: str | None = None
     disable_draft_model: bool | None = None
     torch_empty_cache: bool = False
-
 
 class UpdateWeightsFromDistributedRequest(AdminRequestBase):
     names: list[str]
@@ -543,7 +489,6 @@ class UpdateWeightsFromDistributedRequest(AdminRequestBase):
     load_format: str | None = None
     torch_empty_cache: bool = False
 
-
 class InitWeightsUpdateGroupRequest(AdminRequestBase):
     master_address: str
     master_port: int
@@ -552,10 +497,8 @@ class InitWeightsUpdateGroupRequest(AdminRequestBase):
     group_name: str = "weight_update_group"
     backend: str = "nccl"
 
-
 class DestroyWeightsUpdateGroupRequest(AdminRequestBase):
     group_name: str = "weight_update_group"
-
 
 class WeightsCheckerRequest(AdminRequestBase):
     action: str = "checksum"

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -31,7 +31,6 @@ MODEL_FAMILIES = {
     "voxtral": "vocoder",
 }
 
-
 class FaultInjectingCoordinator(Coordinator):
     """Inject a model-stage failure through the real Coordinator/Client path."""
 
@@ -84,10 +83,8 @@ class FaultInjectingCoordinator(Coordinator):
             modality=modality,
         )
 
-
 def _fault_client(model_name: str) -> Client:
     return Client(FaultInjectingCoordinator(MODEL_FAMILIES[model_name]))
-
 
 class SuccessfulSpeechClient:
     def __init__(self, *, sample_rate: int = 24000) -> None:
@@ -126,7 +123,6 @@ class SuccessfulSpeechClient:
             format=response_format,
         )
 
-
 class EmptyStreamingSpeechClient:
     def health(self) -> dict[str, Any]:
         return {"running": True}
@@ -140,7 +136,6 @@ class EmptyStreamingSpeechClient:
             sample_rate=24000,
             finish_reason="stop",
         )
-
 
 class EmptyDeltaStreamingSpeechClient:
     def health(self) -> dict[str, Any]:
@@ -163,7 +158,6 @@ class EmptyDeltaStreamingSpeechClient:
             finish_reason="stop",
         )
 
-
 class PrefetchedBlockingStreamingSpeechClient:
     def __init__(self) -> None:
         self.aborted: list[str] = []
@@ -185,7 +179,6 @@ class PrefetchedBlockingStreamingSpeechClient:
     async def abort(self, request_id: str) -> None:
         self.aborted.append(request_id)
 
-
 class BlockingFirstAudioStreamingSpeechClient:
     def __init__(self) -> None:
         self.started = asyncio.Event()
@@ -199,7 +192,6 @@ class BlockingFirstAudioStreamingSpeechClient:
 
     async def abort(self, request_id: str) -> None:
         self.aborted.append(request_id)
-
 
 class BlockingNonStreamingSpeechClient:
     def __init__(self) -> None:
@@ -225,7 +217,6 @@ class BlockingNonStreamingSpeechClient:
     async def abort(self, request_id: str) -> None:
         self.aborted.append(request_id)
 
-
 class DisconnectingRequest:
     def __init__(self) -> None:
         self.disconnected = asyncio.Event()
@@ -233,11 +224,9 @@ class DisconnectingRequest:
     async def is_disconnected(self) -> bool:
         return self.disconnected.is_set()
 
-
 class ConnectedRequest:
     async def is_disconnected(self) -> bool:
         return False
-
 
 class SuccessfulTranscriptionClient:
     def __init__(self) -> None:
@@ -258,7 +247,6 @@ class SuccessfulTranscriptionClient:
         del request_id, audio_format
         self.requests.append(request)
         return CompletionResult(request_id="transcription-1", text="hello world")
-
 
 class AdminClient:
     def __init__(self) -> None:
@@ -374,7 +362,6 @@ class AdminClient:
         self.calls.append(("weights_checker", payload or {}, stages, timeout_s))
         return {"success": True, "message": "ok", "results": []}
 
-
 @pytest.mark.parametrize("model_name", MODEL_FAMILIES)
 def test_non_streaming_http_faults_return_500(model_name: str) -> None:
     client = TestClient(create_app(_fault_client(model_name), model_name=model_name))
@@ -403,7 +390,6 @@ def test_non_streaming_http_faults_return_500(model_name: str) -> None:
     assert speech_resp.json()["error"]["type"] == "server_error"
     assert "cuda out of memory" in speech_resp.json()["error"]["message"]
 
-
 def test_speech_endpoint_rejects_invalid_request_with_openai_error() -> None:
     client = TestClient(create_app(SuccessfulSpeechClient(), model_name="tts"))
 
@@ -426,7 +412,6 @@ def test_speech_endpoint_rejects_invalid_request_with_openai_error() -> None:
         }
     }
 
-
 def test_speech_endpoint_returns_binary_audio() -> None:
     client = TestClient(create_app(SuccessfulSpeechClient(), model_name="tts"))
 
@@ -438,7 +423,6 @@ def test_speech_endpoint_returns_binary_audio() -> None:
     assert response.status_code == 200
     assert response.content == b"RIFF"
     assert response.headers["content-type"] == "audio/wav"
-
 
 def test_speech_endpoint_accepts_sdk_shaped_binary_request() -> None:
     speech_client = SuccessfulSpeechClient()
@@ -463,7 +447,6 @@ def test_speech_endpoint_accepts_sdk_shaped_binary_request() -> None:
     assert speech_client.speech_requests[0].model == "tts-1"
     assert speech_client.speech_requests[0].metadata["tts_params"]["voice"] == "alloy"
 
-
 def test_speech_endpoint_rejects_invalid_json_with_openai_error() -> None:
     client = TestClient(create_app(SuccessfulSpeechClient(), model_name="tts"))
 
@@ -477,7 +460,6 @@ def test_speech_endpoint_rejects_invalid_json_with_openai_error() -> None:
     assert response.json()["error"]["type"] == "BadRequestError"
     assert response.json()["error"]["code"] == 400
 
-
 def test_speech_endpoint_stream_without_audio_returns_error() -> None:
     client = TestClient(create_app(EmptyStreamingSpeechClient(), model_name="tts"))
 
@@ -490,7 +472,6 @@ def test_speech_endpoint_stream_without_audio_returns_error() -> None:
     assert response.json()["error"]["type"] == "server_error"
     assert "No audio output generated" in response.json()["error"]["message"]
 
-
 def test_speech_endpoint_stream_empty_delta_is_not_success() -> None:
     client = TestClient(create_app(EmptyDeltaStreamingSpeechClient(), model_name="tts"))
 
@@ -502,7 +483,6 @@ def test_speech_endpoint_stream_empty_delta_is_not_success() -> None:
     assert response.status_code == 500
     assert response.json()["error"]["type"] == "server_error"
     assert "No audio output generated" in response.json()["error"]["message"]
-
 
 def test_admin_routes_forward_to_client() -> None:
     admin = AdminClient()
@@ -555,7 +535,6 @@ def test_admin_routes_forward_to_client() -> None:
         ("weights_checker", {"action": "checksum"}, None, 120.0),
     ]
 
-
 def test_chat_stream_failure_closes_without_done_sentinel() -> None:
     chunks: list[str] = []
     client = _fault_client("qwen3-omni")
@@ -584,7 +563,6 @@ def test_chat_stream_failure_closes_without_done_sentinel() -> None:
     assert chunks
     assert all(chunk != "data: [DONE]\n\n" for chunk in chunks)
 
-
 def test_speech_stream_defaults_to_raw_pcm() -> None:
     client = TestClient(
         create_app(SuccessfulSpeechClient(), model_name="higgs-audio-v2")
@@ -606,7 +584,6 @@ def test_speech_stream_defaults_to_raw_pcm() -> None:
     assert response.headers["x-channels"] == "1"
     assert response.headers["x-bit-depth"] == "16"
     assert response.content == expected
-
 
 def test_speech_stream_headers_use_chunk_sample_rate() -> None:
     client = TestClient(
@@ -630,7 +607,6 @@ def test_speech_stream_headers_use_chunk_sample_rate() -> None:
     assert response.headers["x-bit-depth"] == "16"
     assert response.content == expected
 
-
 def test_raw_pcm_response_close_aborts_inner_speech_stream() -> None:
     async def _drive() -> None:
         client = PrefetchedBlockingStreamingSpeechClient()
@@ -647,7 +623,6 @@ def test_raw_pcm_response_close_aborts_inner_speech_stream() -> None:
         assert client.aborted == ["req-1"]
 
     asyncio.run(_drive())
-
 
 def test_raw_pcm_response_disconnect_before_first_chunk_aborts_request() -> None:
     async def _drive() -> None:
@@ -670,7 +645,6 @@ def test_raw_pcm_response_disconnect_before_first_chunk_aborts_request() -> None
 
     asyncio.run(_drive())
 
-
 def test_speech_stream_rejects_non_pcm_response_format() -> None:
     client = TestClient(
         create_app(SuccessfulSpeechClient(), model_name="higgs-audio-v2")
@@ -689,7 +663,6 @@ def test_speech_stream_rejects_non_pcm_response_format() -> None:
     assert "response_format" in response.text
     assert "pcm" in response.text.lower()
 
-
 def test_speech_request_carries_initial_codec_chunk_frames() -> None:
     req = CreateSpeechRequest(
         input="hello",
@@ -704,7 +677,6 @@ def test_speech_request_carries_initial_codec_chunk_frames() -> None:
 
     assert gen_req.extra_params["initial_codec_chunk_frames"] == 4
 
-
 def test_raw_pcm_speech_request_defaults_initial_codec_chunk_frames() -> None:
     req = CreateSpeechRequest(
         input="hello",
@@ -717,7 +689,6 @@ def test_raw_pcm_speech_request_defaults_initial_codec_chunk_frames() -> None:
     ).build_generate_request(req)
 
     assert gen_req.extra_params["initial_codec_chunk_frames"] == 1
-
 
 def test_raw_pcm_speech_request_respects_explicit_initial_zero() -> None:
     req = CreateSpeechRequest(
@@ -732,7 +703,6 @@ def test_raw_pcm_speech_request_respects_explicit_initial_zero() -> None:
     ).build_generate_request(req)
 
     assert gen_req.extra_params["initial_codec_chunk_frames"] == 0
-
 
 def test_speech_response_disconnect_aborts_active_request() -> None:
     async def _drive() -> None:
@@ -756,7 +726,6 @@ def test_speech_response_disconnect_aborts_active_request() -> None:
 
     asyncio.run(_drive())
 
-
 def test_speech_response_returns_when_disconnect_poll_is_false() -> None:
     async def _drive() -> None:
         result = await _await_speech_response(
@@ -770,7 +739,6 @@ def test_speech_response_returns_when_disconnect_poll_is_false() -> None:
         assert result.audio_bytes == b"RIFF"
 
     asyncio.run(_drive())
-
 
 def test_speech_request_records_explicit_generation_params() -> None:
     req = CreateSpeechRequest(
@@ -793,7 +761,6 @@ def test_speech_request_records_explicit_generation_params() -> None:
         "top_k",
     ]
 
-
 def test_speech_request_passes_streaming_control_fields() -> None:
     req = CreateSpeechRequest(
         input="hello",
@@ -812,7 +779,6 @@ def test_speech_request_passes_streaming_control_fields() -> None:
     assert tts_params["x_vector_only_mode"] is True
     assert tts_params["response_format"] == "pcm"
     assert gen_req.extra_params == {"initial_codec_chunk_frames": 8}
-
 
 def test_transcription_request_builds_asr_generate_request() -> None:
     gen_req = build_transcription_generate_request(
@@ -836,7 +802,6 @@ def test_transcription_request_builds_asr_generate_request() -> None:
     assert gen_req.output_modalities == ["text"]
     assert gen_req.stream is False
 
-
 def test_transcription_endpoint_returns_text_json() -> None:
     transcription_client = SuccessfulTranscriptionClient()
     client = TestClient(
@@ -857,7 +822,6 @@ def test_transcription_endpoint_returns_text_json() -> None:
     assert request.prompt["filename"] == "sample.wav"
     assert request.extra_params["language"] == "en"
 
-
 def test_speech_request_passes_moss_token_count() -> None:
     req = CreateSpeechRequest(input="hello", token_count=180)
 
@@ -866,11 +830,6 @@ def test_speech_request_passes_moss_token_count() -> None:
     )
 
     assert gen_req.metadata["tts_params"]["token_count"] == 180
-
-
-# ---------------------------------------------------------------------------
-# Admin auth tests
-# ---------------------------------------------------------------------------
 
 _ADMIN_PATHS_THAT_NEED_AUTH = [
     ("GET", "/model_info"),
@@ -888,14 +847,12 @@ _ADMIN_PATHS_THAT_NEED_AUTH = [
 
 _ADMIN_API_KEY = "secret-key"
 
-
 def _admin_headers(
     key: str = _ADMIN_API_KEY,
     *,
     scheme: str = "Bearer",
 ) -> dict[str, str]:
     return {"Authorization": f"{scheme} {key}"}
-
 
 def test_admin_routes_open_when_no_key_configured() -> None:
     """Without a key, all admin routes are accessible with no auth header."""
@@ -907,7 +864,6 @@ def test_admin_routes_open_when_no_key_configured() -> None:
 
     resp = client.post("/pause_generation", json={})
     assert resp.status_code == 200
-
 
 def test_admin_routes_require_bearer_token_when_key_configured() -> None:
     """When admin_api_key is set, requests without the header are rejected."""
@@ -923,7 +879,6 @@ def test_admin_routes_require_bearer_token_when_key_configured() -> None:
         ), f"{method} {path} should be 401, got {resp.status_code}"
         assert "WWW-Authenticate" in resp.headers
 
-
 def test_admin_routes_reject_wrong_bearer_token() -> None:
     admin = AdminClient()
     client = TestClient(
@@ -937,7 +892,6 @@ def test_admin_routes_reject_wrong_bearer_token() -> None:
         assert (
             resp.status_code == 403
         ), f"{method} {path} should be 403, got {resp.status_code}"
-
 
 def test_admin_routes_accept_correct_bearer_token() -> None:
     admin = AdminClient()
@@ -955,7 +909,6 @@ def test_admin_routes_accept_correct_bearer_token() -> None:
     )
     assert resp.status_code == 200
 
-
 def test_admin_routes_env_key_is_used_when_no_explicit_key(monkeypatch) -> None:
     monkeypatch.setenv("SGLANG_OMNI_ADMIN_KEY", "env-key")
     admin = AdminClient()
@@ -967,12 +920,6 @@ def test_admin_routes_env_key_is_used_when_no_explicit_key(monkeypatch) -> None:
     resp = client.get("/model_info", headers=_admin_headers("env-key"))
     assert resp.status_code == 200
 
-
-# ---------------------------------------------------------------------------
-# Stub endpoint 501 tests
-# ---------------------------------------------------------------------------
-
-
 def test_unimplemented_tensor_weight_update_returns_501() -> None:
     admin = AdminClient()
     client = TestClient(create_app(admin, model_name="qwen3-omni"))
@@ -981,7 +928,6 @@ def test_unimplemented_tensor_weight_update_returns_501() -> None:
     assert resp.status_code == 501
     assert resp.json()["error"]["code"] == "not_implemented"
     assert "update_weights_from_disk" in resp.json()["error"]["message"]
-
 
 def test_distributed_weight_update_routes_forward_to_client() -> None:
     admin = AdminClient()
@@ -1057,7 +1003,6 @@ def test_distributed_weight_update_routes_forward_to_client() -> None:
             0,
         ),
     ]
-
 
 def test_stub_endpoint_checks_auth_before_501() -> None:
     """Auth check fires before the tensor stub 501 body."""


### PR DESCRIPTION
LInk to issue #661.

  Applies the comment policy: a comment is either owner-attributed or deleted.

  - Deleted all filler comments (section dividers, step narration, restatements of obvious code)
  - Deleted all anonymous comments — per policy, unowned comments go regardless of content
  - Kept only already-attributed comments (`# Note:(Chenchen Hong)`, `# Note(Jiaxin):`, `# note (chenyang):`, `#
  TODO(Ratish):`)
  - 36 files, 617 comment lines removed
  - No logic changes — pure comment deletion