### PR TITLE
[CI] Restart latest Omni CI for targeted reruns

### DIFF
--- a/.github/workflows/slash-command-handler.yml
+++ b/.github/workflows/slash-command-handler.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install PyGithub requests
+          pip install PyGithub
 
       - name: Handle Slash Command
         env:

--- a/.github/workflows/slash-command-handler.yml
+++ b/.github/workflows/slash-command-handler.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install PyGithub
+          pip install PyGithub requests
 
       - name: Handle Slash Command
         env:

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -3,9 +3,13 @@ import os
 import sys
 import time
 
+import requests
 from github import Auth, Github
 
 PERMISSIONS_FILE_PATH = ".github/CI_PERMISSIONS.json"
+ACTIVE_WORKFLOW_STATUSES = {"queued", "in_progress", "waiting", "pending", "requested"}
+WORKFLOW_CANCEL_POLL_SECONDS = 5
+WORKFLOW_CANCEL_TIMEOUT_SECONDS = 120
 TTS_MODEL_LABELS = {
     "higgs": "run-higgs",
     "moss": "run-moss",
@@ -103,41 +107,155 @@ def handle_tag_run_ci(
     return True
 
 
-def handle_rerun_failed_ci(gh_repo, pr, comment, user_perms, react_on_success=True):
+def wait_for_workflow_run_completed(gh_repo, token, run_id):
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    url = f"https://api.github.com/repos/{gh_repo.full_name}/actions/runs/{run_id}"
+
+    deadline = time.time() + WORKFLOW_CANCEL_TIMEOUT_SECONDS
+    while time.time() < deadline:
+        response = requests.get(url, headers=headers, timeout=15)
+        if response.status_code != 200:
+            print(f"Failed to fetch workflow {run_id}: {response.status_code}")
+            return False
+        status = response.json().get("status")
+        if status == "completed":
+            return True
+        print(f"Waiting for workflow {run_id} to complete cancellation: {status}")
+        time.sleep(WORKFLOW_CANCEL_POLL_SECONDS)
+
+    print(f"Timed out waiting for workflow {run_id} to complete cancellation.")
+    return False
+
+
+def cancel_and_rerun_workflow(gh_repo, token, run):
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    run_url = f"https://api.github.com/repos/{gh_repo.full_name}/actions/runs/{run.id}"
+
+    print(f"Cancelling active workflow before full rerun: {run.name} (ID: {run.id})")
+    cancel_response = requests.post(f"{run_url}/cancel", headers=headers, timeout=15)
+    if cancel_response.status_code == 202:
+        if not wait_for_workflow_run_completed(gh_repo, token, run.id):
+            return False
+    elif cancel_response.status_code in (409, 422):
+        print(
+            f"Cancel returned {cancel_response.status_code}; "
+            "checking whether workflow already completed."
+        )
+        state_response = requests.get(run_url, headers=headers, timeout=15)
+        if (
+            state_response.status_code != 200
+            or state_response.json().get("status") != "completed"
+        ):
+            print(f"Workflow {run.id} is not ready for rerun after cancel response.")
+            return False
+    else:
+        print(
+            f"Failed to cancel workflow {run.id}: "
+            f"{cancel_response.status_code} {cancel_response.text}"
+        )
+        return False
+
+    rerun_response = requests.post(f"{run_url}/rerun", headers=headers, timeout=15)
+    if rerun_response.status_code not in (201, 202):
+        print(
+            f"Failed to rerun workflow {run.id}: "
+            f"{rerun_response.status_code} {rerun_response.text}"
+        )
+        return False
+    print(f"Triggered full rerun for workflow {run.name} (ID: {run.id}).")
+    return True
+
+
+def handle_rerun_failed_ci(
+    gh_repo,
+    pr,
+    comment,
+    user_perms,
+    react_on_success=True,
+    force_full_pull_request_workflow_names=None,
+    token=None,
+):
     """
     Handles the /rerun-failed-ci command.
     Reruns workflows with 'failure' or 'skipped' conclusions.
+    When force_full_pull_request_workflow_names is set, full-reruns the
+    latest matching pull_request workflow even if it is active or successful.
     Returns True if action was taken, False otherwise.
     """
     if not user_perms.get("can_rerun_failed_ci", False):
         print("Permission denied: can_rerun_failed_ci is false.")
         return False
 
-    print("Permission granted. Triggering rerun of failed or skipped workflows.")
+    if force_full_pull_request_workflow_names is None:
+        force_full_pull_request_workflow_names = set()
+
+    print("Permission granted. Triggering CI workflow reruns.")
 
     head_sha = pr.head.sha
     print(f"Checking workflows for commit: {head_sha}")
 
     runs = gh_repo.get_workflow_runs(head_sha=head_sha)
 
-    rerun_candidates = [
-        run
-        for run in runs
-        if run.status == "completed" and run.conclusion in ("failure", "skipped")
-    ]
-    rerun_candidates.sort(key=lambda run: (run.created_at, run.id), reverse=True)
-
-    rerun_count = 0
+    latest_runs = []
     seen_workflows = set()
-    for run in rerun_candidates:
+    for run in sorted(runs, key=lambda run: (run.created_at, run.id), reverse=True):
         workflow_key = (run.workflow_id, run.event)
         if workflow_key in seen_workflows:
+            continue
+        seen_workflows.add(workflow_key)
+        latest_runs.append(run)
+
+    rerun_count = 0
+    for run in latest_runs:
+        force_full_rerun = (
+            run.event == "pull_request"
+            and run.name in force_full_pull_request_workflow_names
+        )
+        if run.status in ACTIVE_WORKFLOW_STATUSES:
+            if not force_full_rerun:
+                print(
+                    f"Skipping latest workflow because it is still {run.status}: "
+                    f"{run.name} (ID: {run.id})"
+                )
+                continue
+            if not token:
+                print(f"Cannot restart active workflow without token: {run.id}")
+                continue
+            try:
+                if cancel_and_rerun_workflow(gh_repo, token, run):
+                    rerun_count += 1
+            except Exception as e:
+                print(f"Failed to restart active workflow {run.id}: {e}")
+            continue
+
+        if run.status != "completed":
             print(
-                f"Skipping older {run.conclusion} workflow: "
+                f"Skipping latest workflow because it is still {run.status}: "
                 f"{run.name} (ID: {run.id})"
             )
             continue
-        seen_workflows.add(workflow_key)
+        if force_full_rerun:
+            print(f"Processing full workflow rerun: {run.name} (ID: {run.id})")
+            try:
+                run.rerun()
+                rerun_count += 1
+            except Exception as e:
+                print(f"Failed to rerun workflow {run.id}: {e}")
+            continue
+        if run.conclusion not in ("failure", "skipped"):
+            print(
+                f"Skipping latest workflow with conclusion {run.conclusion}: "
+                f"{run.name} (ID: {run.id})"
+            )
+            continue
 
         print(f"Processing {run.conclusion} workflow: {run.name} (ID: {run.id})")
         try:
@@ -236,7 +354,15 @@ def main():
             time.sleep(5)
 
         rerun = handle_rerun_failed_ci(
-            repo, pr, comment, user_perms, react_on_success=False
+            repo,
+            pr,
+            comment,
+            user_perms,
+            react_on_success=False,
+            force_full_pull_request_workflow_names=(
+                {"Omni CI"} if tts_model_target else None
+            ),
+            token=token,
         )
 
         if tagged or rerun:

--- a/scripts/ci/utils/slash_command_handler.py
+++ b/scripts/ci/utils/slash_command_handler.py
@@ -3,13 +3,10 @@ import os
 import sys
 import time
 
-import requests
 from github import Auth, Github
+from github.GithubException import GithubException
 
 PERMISSIONS_FILE_PATH = ".github/CI_PERMISSIONS.json"
-ACTIVE_WORKFLOW_STATUSES = {"queued", "in_progress", "waiting", "pending", "requested"}
-WORKFLOW_CANCEL_POLL_SECONDS = 5
-WORKFLOW_CANCEL_TIMEOUT_SECONDS = 120
 TTS_MODEL_LABELS = {
     "higgs": "run-higgs",
     "moss": "run-moss",
@@ -68,10 +65,9 @@ def handle_tag_run_ci(
     The TTS model labels are mutually exclusive, so remove the opposite label
     before adding the selected one.
 
-    How fresh runs get dispatched: Omni CI workflows include `labeled` in
-    `on.pull_request.types`, so adding `run-ci` fires a new
-    `pull_request.labeled` event with the up-to-date label set in its
-    payload. This is the recovery mechanism for label-gated workflows.
+    The combined /tag-and-rerun-ci command restarts Omni CI after updating
+    labels, because labels added by GITHUB_TOKEN do not cascade-trigger a
+    new pull_request.labeled workflow run.
 
     Returns True if action was taken, False otherwise.
     """
@@ -107,70 +103,49 @@ def handle_tag_run_ci(
     return True
 
 
-def wait_for_workflow_run_completed(gh_repo, token, run_id):
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
-    url = f"https://api.github.com/repos/{gh_repo.full_name}/actions/runs/{run_id}"
-
-    deadline = time.time() + WORKFLOW_CANCEL_TIMEOUT_SECONDS
+def wait_for_workflow_run_completed(gh_repo, run_id):
+    deadline = time.time() + 120
     while time.time() < deadline:
-        response = requests.get(url, headers=headers, timeout=15)
-        if response.status_code != 200:
-            print(f"Failed to fetch workflow {run_id}: {response.status_code}")
-            return False
-        status = response.json().get("status")
-        if status == "completed":
+        latest_run = gh_repo.get_workflow_run(run_id)
+        if latest_run.status == "completed":
             return True
-        print(f"Waiting for workflow {run_id} to complete cancellation: {status}")
-        time.sleep(WORKFLOW_CANCEL_POLL_SECONDS)
+        print(
+            f"Waiting for workflow {run_id} to complete cancellation: "
+            f"{latest_run.status}"
+        )
+        time.sleep(5)
 
     print(f"Timed out waiting for workflow {run_id} to complete cancellation.")
     return False
 
 
-def cancel_and_rerun_workflow(gh_repo, token, run):
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
-    run_url = f"https://api.github.com/repos/{gh_repo.full_name}/actions/runs/{run.id}"
-
+def cancel_and_rerun_workflow(gh_repo, run):
     print(f"Cancelling active workflow before full rerun: {run.name} (ID: {run.id})")
-    cancel_response = requests.post(f"{run_url}/cancel", headers=headers, timeout=15)
-    if cancel_response.status_code == 202:
-        if not wait_for_workflow_run_completed(gh_repo, token, run.id):
-            return False
-    elif cancel_response.status_code in (409, 422):
-        print(
-            f"Cancel returned {cancel_response.status_code}; "
-            "checking whether workflow already completed."
-        )
-        state_response = requests.get(run_url, headers=headers, timeout=15)
-        if (
-            state_response.status_code != 200
-            or state_response.json().get("status") != "completed"
-        ):
-            print(f"Workflow {run.id} is not ready for rerun after cancel response.")
+    try:
+        cancelled = run.cancel()
+    except GithubException as e:
+        latest_run = gh_repo.get_workflow_run(run.id)
+        if latest_run.status != "completed":
+            print(f"Failed to cancel workflow {run.id}: {e}")
             return False
     else:
-        print(
-            f"Failed to cancel workflow {run.id}: "
-            f"{cancel_response.status_code} {cancel_response.text}"
-        )
+        if not cancelled:
+            print(f"Failed to cancel workflow {run.id}.")
+            return False
+
+    if not wait_for_workflow_run_completed(gh_repo, run.id):
         return False
 
-    rerun_response = requests.post(f"{run_url}/rerun", headers=headers, timeout=15)
-    if rerun_response.status_code not in (201, 202):
-        print(
-            f"Failed to rerun workflow {run.id}: "
-            f"{rerun_response.status_code} {rerun_response.text}"
-        )
+    latest_run = gh_repo.get_workflow_run(run.id)
+    try:
+        rerun_started = latest_run.rerun()
+    except GithubException as e:
+        print(f"Failed to rerun workflow {latest_run.id}: {e}")
         return False
-    print(f"Triggered full rerun for workflow {run.name} (ID: {run.id}).")
+    if not rerun_started:
+        print(f"Failed to rerun workflow {latest_run.id}.")
+        return False
+    print(f"Triggered full rerun for workflow {latest_run.name} (ID: {run.id}).")
     return True
 
 
@@ -180,22 +155,18 @@ def handle_rerun_failed_ci(
     comment,
     user_perms,
     react_on_success=True,
-    force_full_pull_request_workflow_names=None,
-    token=None,
+    force_full_omni_ci_rerun=False,
 ):
     """
     Handles the /rerun-failed-ci command.
     Reruns workflows with 'failure' or 'skipped' conclusions.
-    When force_full_pull_request_workflow_names is set, full-reruns the
-    latest matching pull_request workflow even if it is active or successful.
+    When force_full_omni_ci_rerun is set, full-reruns the latest Omni CI
+    pull_request workflow even if it is active or successful.
     Returns True if action was taken, False otherwise.
     """
     if not user_perms.get("can_rerun_failed_ci", False):
         print("Permission denied: can_rerun_failed_ci is false.")
         return False
-
-    if force_full_pull_request_workflow_names is None:
-        force_full_pull_request_workflow_names = set()
 
     print("Permission granted. Triggering CI workflow reruns.")
 
@@ -217,23 +188,18 @@ def handle_rerun_failed_ci(
     for run in latest_runs:
         force_full_rerun = (
             run.event == "pull_request"
-            and run.name in force_full_pull_request_workflow_names
+            and run.name == "Omni CI"
+            and force_full_omni_ci_rerun
         )
-        if run.status in ACTIVE_WORKFLOW_STATUSES:
+        if run.status in {"queued", "in_progress", "waiting", "pending", "requested"}:
             if not force_full_rerun:
                 print(
                     f"Skipping latest workflow because it is still {run.status}: "
                     f"{run.name} (ID: {run.id})"
                 )
                 continue
-            if not token:
-                print(f"Cannot restart active workflow without token: {run.id}")
-                continue
-            try:
-                if cancel_and_rerun_workflow(gh_repo, token, run):
-                    rerun_count += 1
-            except Exception as e:
-                print(f"Failed to restart active workflow {run.id}: {e}")
+            if cancel_and_rerun_workflow(gh_repo, run):
+                rerun_count += 1
             continue
 
         if run.status != "completed":
@@ -247,7 +213,7 @@ def handle_rerun_failed_ci(
             try:
                 run.rerun()
                 rerun_count += 1
-            except Exception as e:
+            except GithubException as e:
                 print(f"Failed to rerun workflow {run.id}: {e}")
             continue
         if run.conclusion not in ("failure", "skipped"):
@@ -359,10 +325,7 @@ def main():
             comment,
             user_perms,
             react_on_success=False,
-            force_full_pull_request_workflow_names=(
-                {"Omni CI"} if tts_model_target else None
-            ),
-            token=token,
+            force_full_omni_ci_rerun=tagged and tts_model_target is not None,
         )
 
         if tagged or rerun:


### PR DESCRIPTION
## Motivation

`/tag-and-rerun-ci moss` and `/tag-and-rerun-ci higgs` need to make the latest PR `Omni CI` run execute with the requested TTS target label. Labels added by the slash-command workflow use `GITHUB_TOKEN`, so we cannot rely on a new `pull_request.labeled` workflow run being created for the updated label set.

On PR #822, the command added `run-moss` but then reran an older failed `Omni CI` run while a newer PR `Omni CI` run already existed for the same head SHA. Omni's PR-level concurrency then cancelled the stale rerun, making the checks UI look like the command only cancelled CI.

## Modifications

- Select the latest workflow run per `(workflow_id, event)` before deciding what the slash handler can rerun, so older failed attempts are not rerun when a newer run exists.
- For targeted `/tag-and-rerun-ci moss|higgs`, full-rerun the latest PR `Omni CI` run so the runtime live-label fetch sees the selected TTS target.
- If the latest PR `Omni CI` run is queued or in progress, cancel it, wait for cancellation to complete, then trigger a full rerun of that same workflow run.
- Keep `/rerun-failed-ci` behavior scoped to latest completed `failure` or `skipped` runs, preserving `failure -> rerun_failed_jobs()` and `skipped -> rerun()`.
- Install `requests` explicitly for the slash-command workflow because the handler now uses GitHub REST endpoints directly for active-run cancel/rerun.

## Root Cause

The previous handler only considered completed failed/skipped workflow runs. That missed newer queued/in-progress runs for the same workflow/event, so it could rerun an older failed `Omni CI` attempt. It also had no active-run restart path for targeted TTS commands, even though the updated target label must be picked up by rerunning the workflow after labels are applied.
