### PR TITLE
[MOSS-TTS] Own audio tokenizer codec placement

### DIFF
--- a/docs/cookbook/moss_tts.md
+++ b/docs/cookbook/moss_tts.md
@@ -18,18 +18,26 @@ Architecturally, MOSS-TTS-v1.5 is the `delay-pattern` counterpart to [MOSS-TTS-L
 ## Prerequisites
 
 Install `sglang-omni` by following [Installation](../get_started/installation.md), then
-download the model (public, no token required):
+download the model and its audio-tokenizer codec (both public, no token required):
 
 ```bash
 hf download OpenMOSS-Team/MOSS-TTS-v1.5
+hf download OpenMOSS-Team/MOSS-Audio-Tokenizer
 ```
 
-The processor ships with the checkpoint, so no extra TTS package is needed. Decoding base64
-(data-URI) reference audio additionally requires `soundfile` (`uv pip install soundfile`).
+The text/chat-template processor ships with the MOSS-TTS checkpoint. The RVQ codec model
+implementation is owned by SGLang-Omni; `OpenMOSS-Team/MOSS-Audio-Tokenizer` is used only
+for `config.json` and safetensors weights by default, so those artifacts can be
+pre-downloaded, mirrored, or overridden through the stage `codec_model_path`. Decoding
+base64 (data-URI) reference audio additionally requires `soundfile`
+(`uv pip install soundfile`).
 
 ## Server Configuration
 
 The pipeline is `preprocessing → tts_engine → vocoder`.
+The default config places preprocessing and vocoder codec work on `cuda:0` with `float32`
+weights and falls back to CPU if CUDA is not available. To use a local or mirrored codec
+snapshot, set `codec_model_path` in the `preprocessing` and `vocoder` stage factory args.
 
 ```bash
 sgl-omni serve \

--- a/sglang_omni/models/moss_tts/audio_tokenizer.py
+++ b/sglang_omni/models/moss_tts/audio_tokenizer.py
@@ -1,0 +1,294 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Owned MOSS audio-tokenizer wrapper for MOSS-TTS Delay."""
+
+from __future__ import annotations
+
+import base64
+import io
+import logging
+import os
+from typing import Any
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MOSS_AUDIO_TOKENIZER = "OpenMOSS-Team/MOSS-Audio-Tokenizer"
+
+
+def _resolve_checkpoint(checkpoint: str) -> str:
+    if os.path.isdir(checkpoint):
+        return checkpoint
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(
+        checkpoint,
+        allow_patterns=(
+            "config.json",
+            "*.safetensors",
+            "*.safetensors.index.json",
+        ),
+    )
+
+
+def _torch_dtype(dtype: str | torch.dtype) -> torch.dtype:
+    return getattr(torch, dtype) if isinstance(dtype, str) else dtype
+
+
+class MossAudioTokenizer:
+    """Narrow encode/decode API around the upstream MOSS audio-tokenizer model."""
+
+    def __init__(
+        self,
+        model: Any,
+        *,
+        model_path: str,
+        checkpoint_dir: str,
+        device: str,
+        dtype: str | torch.dtype,
+    ) -> None:
+        self.model = model
+        self.model_path = model_path
+        self.checkpoint_dir = checkpoint_dir
+        self.device = str(device)
+        self.dtype = str(dtype)
+        try:
+            config = model.config
+        except AttributeError:
+            config = None
+        try:
+            self.sample_rate = int(config.sampling_rate)
+        except AttributeError:
+            self.sample_rate = 24000
+        try:
+            quantizer_kwargs = config.quantizer_kwargs or {}
+        except AttributeError:
+            quantizer_kwargs = {}
+        self.n_vq = int(quantizer_kwargs.get("num_quantizers", 32) or 32)
+
+    def encode_wavs(
+        self,
+        wav_list: list[torch.Tensor] | torch.Tensor,
+        sample_rate: int,
+        n_vq: int | None = None,
+    ) -> list[torch.Tensor]:
+        if isinstance(wav_list, torch.Tensor):
+            wav_list = [wav_list]
+        if not wav_list:
+            raise ValueError("wav_list must contain at least one waveform")
+
+        prepared: list[torch.Tensor] = []
+        target_sr = int(self.sample_rate)
+        resample = int(sample_rate) != target_sr
+        for wav in wav_list:
+            if wav.shape[0] > 1:
+                wav = wav.mean(dim=0, keepdim=True)
+            if resample:
+                import torchaudio
+
+                wav = torchaudio.functional.resample(
+                    waveform=wav,
+                    orig_freq=int(sample_rate),
+                    new_freq=target_sr,
+                )
+            prepared.append(self._loudness_normalize(wav.squeeze(0)).to(self.device))
+
+        try:
+            batch_encode = self.model.batch_encode
+        except AttributeError:
+            batch_encode = None
+        with torch.inference_mode():
+            if batch_encode is not None:
+                enc = batch_encode(prepared, num_quantizers=n_vq)
+                audio_codes = enc.audio_codes
+                audio_codes_lengths = enc.audio_codes_lengths
+            else:
+                max_len = max(int(wav.shape[-1]) for wav in prepared)
+                input_values = torch.zeros(
+                    len(prepared), 1, max_len, device=self.device, dtype=torch.float32
+                )
+                padding_mask = torch.zeros(
+                    len(prepared), max_len, device=self.device, dtype=torch.bool
+                )
+                for idx, wav in enumerate(prepared):
+                    this_len = int(wav.shape[-1])
+                    input_values[idx, 0, :this_len] = wav
+                    padding_mask[idx, :this_len] = True
+                enc = self.model.encode(
+                    input_values,
+                    padding_mask=padding_mask,
+                    num_quantizers=n_vq,
+                    return_dict=True,
+                )
+                audio_codes = enc.audio_codes
+                audio_codes_lengths = enc.audio_codes_lengths
+
+        if audio_codes is None or audio_codes_lengths is None:
+            raise RuntimeError(
+                "MOSS audio tokenizer encode returned empty audio_codes/audio_codes_lengths"
+            )
+
+        out: list[torch.Tensor] = []
+        for idx in range(int(audio_codes.shape[1])):
+            length = int(audio_codes_lengths[idx].item())
+            out.append(
+                audio_codes[:, idx, :length]
+                .transpose(0, 1)
+                .contiguous()
+                .to(torch.long)
+                .cpu()
+            )
+        return out
+
+    def encode_paths(
+        self,
+        paths: list[str] | str,
+        n_vq: int | None = None,
+    ) -> list[torch.Tensor]:
+        if isinstance(paths, str):
+            paths = [paths]
+        if not paths:
+            raise ValueError("paths must contain at least one audio path")
+
+        import torchaudio
+
+        wavs: list[torch.Tensor] = []
+        target_sr = int(self.sample_rate)
+        for path in paths:
+            wav, sample_rate = torchaudio.load(path)
+            if int(sample_rate) != target_sr:
+                wav = torchaudio.functional.resample(
+                    waveform=wav,
+                    orig_freq=int(sample_rate),
+                    new_freq=target_sr,
+                )
+            wavs.append(wav)
+        return self.encode_wavs(wavs, target_sr, n_vq=n_vq)
+
+    def encode_data_uri(self, ref_audio: str, n_vq: int | None = None) -> torch.Tensor:
+        from sglang_omni.models.moss_tts.request_builders import _DATA_URI_RE
+
+        match = _DATA_URI_RE.match(ref_audio)
+        if match is None:
+            raise ValueError(f"not a MOSS-TTS audio data URI: {ref_audio[:40]!r}")
+        try:
+            import soundfile as sf
+        except ImportError as exc:
+            raise RuntimeError(
+                "MOSS-TTS base64 reference audio requires soundfile to decode the data URI"
+            ) from exc
+
+        raw = base64.b64decode(match.group("data"))
+        audio, sample_rate = sf.read(io.BytesIO(raw), dtype="float32", always_2d=True)
+        wav = torch.from_numpy(audio.T)
+        return self.encode_wavs([wav], int(sample_rate), n_vq=n_vq)[0]
+
+    def decode_codes(
+        self,
+        codes_list: list[torch.Tensor] | torch.Tensor,
+    ) -> list[torch.Tensor]:
+        if isinstance(codes_list, torch.Tensor):
+            codes_list = [codes_list]
+        if not codes_list:
+            return []
+
+        transposed = [
+            codes.transpose(0, 1).contiguous().to(device=self.device, dtype=torch.long)
+            for codes in codes_list
+        ]
+        n_vq = int(transposed[0].shape[0])
+        max_t = max(int(codes.shape[1]) for codes in transposed)
+        audio_codes = torch.zeros(
+            n_vq, len(transposed), max_t, device=self.device, dtype=torch.long
+        )
+        padding_mask = torch.zeros(
+            len(transposed), max_t, device=self.device, dtype=torch.bool
+        )
+        for idx, codes in enumerate(transposed):
+            length = int(codes.shape[1])
+            audio_codes[:, idx, :length] = codes
+            padding_mask[idx, :length] = True
+
+        with torch.inference_mode():
+            decoded = self.model.decode(
+                audio_codes,
+                padding_mask=padding_mask,
+                return_dict=True,
+                chunk_duration=8,
+            )
+        audio = decoded.audio
+        audio_lengths = decoded.audio_lengths
+        if audio is None or audio_lengths is None:
+            raise RuntimeError(
+                "MOSS audio tokenizer decode returned empty audio/audio_lengths"
+            )
+
+        wavs: list[torch.Tensor] = []
+        for idx in range(int(audio.shape[0])):
+            length = int(audio_lengths[idx].item())
+            wavs.append(audio[idx, 0, :length].contiguous().to(torch.float32).cpu())
+        return wavs
+
+    @staticmethod
+    def _loudness_normalize(
+        wav: torch.Tensor,
+        target_dbfs: float = -20,
+        gain_range: tuple[float, float] = (-3.0, 3.0),
+    ) -> torch.Tensor:
+        wav = wav.to(torch.float32)
+        if wav.numel() == 0:
+            return wav
+        current_dbfs = 10.0 * torch.log10(torch.mean(wav**2) + 1e-9)
+        gain = float(target_dbfs - current_dbfs)
+        gain = max(gain_range[0], min(gain, gain_range[1]))
+        return wav * (10.0 ** (gain / 20.0))
+
+
+def load_moss_audio_tokenizer(
+    model_path: str = DEFAULT_MOSS_AUDIO_TOKENIZER,
+    *,
+    device: str = "cuda:0",
+    dtype: str | torch.dtype = "float32",
+) -> MossAudioTokenizer:
+    checkpoint_dir = _resolve_checkpoint(model_path)
+    logger.info(
+        "Loading MOSS audio tokenizer from %s on %s dtype=%s",
+        checkpoint_dir,
+        device,
+        dtype,
+    )
+    from sglang_omni.models.moss_tts.configuration_moss_audio_tokenizer import (
+        MossAudioTokenizerConfig,
+    )
+    from sglang_omni.models.moss_tts.modeling_moss_audio_tokenizer import (
+        MossAudioTokenizerModel,
+    )
+
+    config = MossAudioTokenizerConfig.from_pretrained(checkpoint_dir)
+    load_kwargs: dict[str, Any] = {
+        "config": config,
+        "local_files_only": True,
+    }
+    if str(device) != "cpu":
+        load_kwargs["torch_dtype"] = _torch_dtype(dtype)
+    model = MossAudioTokenizerModel.from_pretrained(checkpoint_dir, **load_kwargs)
+    try:
+        model.eval()
+    except AttributeError:
+        raise RuntimeError("MOSS audio tokenizer model does not implement eval()")
+    try:
+        move_model = model.to
+    except AttributeError:
+        raise RuntimeError("MOSS audio tokenizer model does not implement to()")
+    else:
+        kwargs: dict[str, Any] = {"device": device}
+        if str(device) != "cpu":
+            kwargs["dtype"] = _torch_dtype(dtype)
+        move_model(**kwargs)
+    return MossAudioTokenizer(
+        model,
+        model_path=model_path,
+        checkpoint_dir=checkpoint_dir,
+        device=device,
+        dtype=dtype,
+    )

--- a/sglang_omni/models/moss_tts/config.py
+++ b/sglang_omni/models/moss_tts/config.py
@@ -40,6 +40,7 @@ class MossTTSPipelineConfig(PipelineConfig):
             name="preprocessing",
             process="pipeline",
             factory=f"{_PKG}.stages.create_preprocessing_executor",
+            factory_args={"device": "cuda:0", "dtype": "float32"},
             next="tts_engine",
         ),
         StageConfig(

--- a/sglang_omni/models/moss_tts/config.py
+++ b/sglang_omni/models/moss_tts/config.py
@@ -8,6 +8,7 @@ from typing import ClassVar
 from sglang_omni.config import PipelineConfig, StageConfig
 
 _PKG = "sglang_omni.models.moss_tts"
+_DEFAULT_MOSS_AUDIO_TOKENIZER = "OpenMOSS-Team/MOSS-Audio-Tokenizer"
 
 
 class MossTTSPipelineConfig(PipelineConfig):
@@ -40,7 +41,12 @@ class MossTTSPipelineConfig(PipelineConfig):
             name="preprocessing",
             process="pipeline",
             factory=f"{_PKG}.stages.create_preprocessing_executor",
-            factory_args={"device": "cuda:0", "dtype": "float32"},
+            factory_args={
+                "codec_model_path": _DEFAULT_MOSS_AUDIO_TOKENIZER,
+                "device": "cuda:0",
+                "dtype": "float32",
+            },
+            gpu=0,
             next="tts_engine",
         ),
         StageConfig(
@@ -55,7 +61,10 @@ class MossTTSPipelineConfig(PipelineConfig):
             name="vocoder",
             process="pipeline",
             factory=f"{_PKG}.stages.create_vocoder_executor",
-            factory_args={"dtype": "float32"},
+            factory_args={
+                "codec_model_path": _DEFAULT_MOSS_AUDIO_TOKENIZER,
+                "dtype": "float32",
+            },
             gpu=0,
             terminal=True,
         ),

--- a/sglang_omni/models/moss_tts/configuration_moss_audio_tokenizer.py
+++ b/sglang_omni/models/moss_tts/configuration_moss_audio_tokenizer.py
@@ -1,0 +1,332 @@
+# coding=utf-8
+# Copyright 2026 OpenMOSS and the HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""MossAudioTokenizer model configuration"""
+
+from typing import Any
+
+from transformers.configuration_utils import PreTrainedConfig
+
+
+class MossAudioTokenizerConfig(PreTrainedConfig):
+    r"""
+    This is the configuration class to store the configuration of a [`MossAudioTokenizerModel`]. It is used to instantiate a
+    MossAudioTokenizer model according to the specified arguments, defining the model architecture.
+
+    Instantiating a configuration with the defaults will yield a similar configuration to that of the
+    [VoiceAgentGroup/moss_audio_tokenizer](https://huggingface.co/VoiceAgentGroup/moss_audio_tokenizer) architecture.
+
+    Configuration objects inherit from [`PreTrainedConfig`] and can be used to control the model outputs. Read the
+    documentation from [`PreTrainedConfig`] for more information.
+
+    Args:
+        sampling_rate (`int`, *optional*, defaults to 24000):
+            The sampling rate at which the audio waveform should be digitalized expressed in hertz (Hz).
+        downsample_rate (`int`, *optional*, defaults to 1920):
+            Total downsampling rate from waveform to tokens.
+        causal_transformer_context_duration (`float`, *optional*, defaults to 10.0):
+            Context duration in seconds for causal transformer.
+        encoder_kwargs (`list[dict]`, *optional*):
+            List of encoder module configurations. Each dict specifies a module type and its parameters.
+        decoder_kwargs (`list[dict]`, *optional*):
+            List of decoder module configurations in execution order.
+        quantizer_type (`str`, *optional*, defaults to `"rvq"`):
+            Quantizer type. Options include `"rvq"`, `"spec_rvq"`, `"rlfq"`, `"random_prefix_rlfq"`.
+        quantizer_kwargs (`dict`, *optional*):
+            Configuration for the quantizer including `input_dim`, `rvq_dim`, `output_dim`, `num_quantizers`,
+            `codebook_size`, and `codebook_dim`.
+
+    Example:
+
+    ```python
+    >>> from transformers import MossAudioTokenizerModel, MossAudioTokenizerConfig
+
+    >>> # Initializing a MossAudioTokenizer style configuration
+    >>> configuration = MossAudioTokenizerConfig()
+
+    >>> # Initializing a model (with random weights) from the configuration
+    >>> model = MossAudioTokenizerModel(configuration)
+
+    >>> # Accessing the model configuration
+    >>> configuration = model.config
+    ```
+    """
+
+    model_type = "moss-audio-tokenizer"
+
+    # Backward-compatible alias used by some checkpoints.
+    attribute_map = {"sample_rate": "sampling_rate"}
+
+    sampling_rate: int
+    downsample_rate: int
+    causal_transformer_context_duration: float
+    encoder_kwargs: list[dict[str, Any]]
+    decoder_kwargs: list[dict[str, Any]]
+    quantizer_type: str
+    quantizer_kwargs: dict[str, Any]
+
+    def __init__(
+        self,
+        version: str | None = None,
+        sampling_rate: int = 24000,
+        downsample_rate: int = 1920,
+        causal_transformer_context_duration: float = 10.0,
+        encoder_kwargs: list[dict[str, Any]] | None = None,
+        decoder_kwargs: list[dict[str, Any]] | None = None,
+        quantizer_type: str = "rlfq",
+        quantizer_kwargs: dict[str, Any] | None = None,
+        **kwargs,
+    ):
+        # Some checkpoints might include an incorrect/legacy `model_type` (e.g. "speech_tokenizer").
+        # We drop it to avoid overriding the class-level `model_type`.
+        kwargs.pop("model_type", None)
+
+        # `version` is accepted for compatibility but not used in modeling.
+        self.version = version
+        self.sampling_rate = sampling_rate
+        self.downsample_rate = downsample_rate
+        self.causal_transformer_context_duration = causal_transformer_context_duration
+        # Default encoder configuration
+        if encoder_kwargs is None:
+            encoder_kwargs = [
+                {
+                    "module_type": "PatchedPretransform",
+                    "patch_size": 240,
+                },
+                {
+                    "module_type": "Transformer",
+                    "input_dimension": 240,
+                    "output_dimension": 384,
+                    "d_model": 768,
+                    "num_heads": 12,
+                    "num_layers": 12,
+                    "dim_feedforward": 3072,
+                    "causal": True,
+                    "norm": "layer_norm",
+                    "positional_embedding": "rope",
+                    "max_period": 10000,
+                    "gating": "none",
+                    "layer_scale": 0.01,
+                    "conv_layout": True,
+                },
+                {
+                    "module_type": "PatchedPretransform",
+                    "patch_size": 2,
+                },
+                {
+                    "module_type": "Transformer",
+                    "input_dimension": 768,
+                    "output_dimension": 384,
+                    "d_model": 768,
+                    "num_heads": 12,
+                    "num_layers": 12,
+                    "dim_feedforward": 3072,
+                    "causal": True,
+                    "norm": "layer_norm",
+                    "positional_embedding": "rope",
+                    "max_period": 10000,
+                    "gating": "none",
+                    "layer_scale": 0.01,
+                    "conv_layout": True,
+                },
+                {
+                    "module_type": "PatchedPretransform",
+                    "patch_size": 2,
+                },
+                {
+                    "module_type": "Transformer",
+                    "input_dimension": 768,
+                    "output_dimension": 640,
+                    "d_model": 768,
+                    "num_heads": 12,
+                    "num_layers": 12,
+                    "dim_feedforward": 3072,
+                    "causal": True,
+                    "norm": "layer_norm",
+                    "positional_embedding": "rope",
+                    "max_period": 10000,
+                    "gating": "none",
+                    "layer_scale": 0.01,
+                    "conv_layout": True,
+                },
+                {
+                    "module_type": "PatchedPretransform",
+                    "patch_size": 2,
+                },
+                {
+                    "module_type": "Transformer",
+                    "input_dimension": 1280,
+                    "output_dimension": 768,
+                    "d_model": 1280,
+                    "num_heads": 20,
+                    "num_layers": 32,
+                    "dim_feedforward": 5120,
+                    "causal": True,
+                    "norm": "layer_norm",
+                    "positional_embedding": "rope",
+                    "max_period": 10000,
+                    "gating": "none",
+                    "layer_scale": 0.01,
+                    "conv_layout": True,
+                },
+            ]
+        self.encoder_kwargs = encoder_kwargs
+
+        # Default decoder configuration (execution order)
+        if decoder_kwargs is None:
+            decoder_kwargs = [
+                {
+                    "module_type": "Transformer",
+                    "input_dimension": 768,
+                    "output_dimension": 1280,
+                    "d_model": 1280,
+                    "num_heads": 20,
+                    "num_layers": 32,
+                    "dim_feedforward": 5120,
+                    "causal": True,
+                    "norm": "layer_norm",
+                    "positional_embedding": "rope",
+                    "max_period": 10000,
+                    "gating": "none",
+                    "layer_scale": 0.01,
+                    "conv_layout": True,
+                },
+                {
+                    "module_type": "PatchedPretransform",
+                    "patch_size": 2,
+                },
+                {
+                    "module_type": "Transformer",
+                    "input_dimension": 640,
+                    "output_dimension": 768,
+                    "d_model": 768,
+                    "num_heads": 12,
+                    "num_layers": 12,
+                    "dim_feedforward": 3072,
+                    "causal": True,
+                    "norm": "layer_norm",
+                    "positional_embedding": "rope",
+                    "max_period": 10000,
+                    "gating": "none",
+                    "layer_scale": 0.01,
+                    "conv_layout": True,
+                },
+                {
+                    "module_type": "PatchedPretransform",
+                    "patch_size": 2,
+                },
+                {
+                    "module_type": "Transformer",
+                    "input_dimension": 384,
+                    "output_dimension": 768,
+                    "d_model": 768,
+                    "num_heads": 12,
+                    "num_layers": 12,
+                    "dim_feedforward": 3072,
+                    "causal": True,
+                    "norm": "layer_norm",
+                    "positional_embedding": "rope",
+                    "max_period": 10000,
+                    "gating": "none",
+                    "layer_scale": 0.01,
+                    "conv_layout": True,
+                },
+                {
+                    "module_type": "PatchedPretransform",
+                    "patch_size": 2,
+                },
+                {
+                    "module_type": "Transformer",
+                    "input_dimension": 384,
+                    "output_dimension": 768,
+                    "d_model": 768,
+                    "num_heads": 12,
+                    "num_layers": 12,
+                    "dim_feedforward": 3072,
+                    "causal": True,
+                    "norm": "layer_norm",
+                    "positional_embedding": "rope",
+                    "max_period": 10000,
+                    "gating": "none",
+                    "layer_scale": 0.01,
+                    "conv_layout": True,
+                },
+                {
+                    "module_type": "PatchedPretransform",
+                    "patch_size": 2,
+                },
+                {
+                    "module_type": "Transformer",
+                    "input_dimension": 384,
+                    "output_dimension": 240,
+                    "d_model": 768,
+                    "num_heads": 12,
+                    "num_layers": 12,
+                    "dim_feedforward": 3072,
+                    "causal": True,
+                    "norm": "layer_norm",
+                    "positional_embedding": "rope",
+                    "max_period": 10000,
+                    "gating": "none",
+                    "layer_scale": 0.01,
+                    "conv_layout": True,
+                },
+                {
+                    "module_type": "PatchedPretransform",
+                    "patch_size": 240,
+                },
+            ]
+        self.decoder_kwargs = decoder_kwargs
+
+        # Default quantizer configuration
+        if quantizer_kwargs is None:
+            quantizer_kwargs = {
+                "input_dim": 768,
+                "rvq_dim": 512,
+                "output_dim": 768,
+                "num_quantizers": 32,
+                "codebook_size": 1024,
+                "codebook_dim": 8,
+                "quantizer_type": "rlfq",
+            }
+
+        # Handle quantizer_type from kwargs or config
+        kw_qtype = quantizer_kwargs.get("quantizer_type", None)
+        if kw_qtype is not None:
+            self.quantizer_type = kw_qtype
+        else:
+            self.quantizer_type = quantizer_type
+            quantizer_kwargs["quantizer_type"] = quantizer_type
+
+        self.quantizer_kwargs = quantizer_kwargs
+
+        super().__init__(**kwargs)
+
+    @property
+    def num_quantizers(self) -> int:
+        """Return the number of quantizers from quantizer_kwargs."""
+        return self.quantizer_kwargs.get("num_quantizers", 32)
+
+    @property
+    def codebook_size(self) -> int:
+        """Return the codebook size from quantizer_kwargs."""
+        return self.quantizer_kwargs.get("codebook_size", 4096)
+
+    @property
+    def frame_rate(self) -> float:
+        """Return the frame rate (tokens per second)."""
+        return self.sampling_rate / self.downsample_rate
+
+
+__all__ = ["MossAudioTokenizerConfig"]

--- a/sglang_omni/models/moss_tts/modeling_moss_audio_tokenizer.py
+++ b/sglang_omni/models/moss_tts/modeling_moss_audio_tokenizer.py
@@ -1,0 +1,2034 @@
+# Copyright 2026 OpenMOSS and the HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""PyTorch MossAudioTokenizer model."""
+
+from __future__ import annotations
+
+import copy
+import math
+from contextlib import ExitStack, contextmanager
+from dataclasses import dataclass
+from typing import cast
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+try:
+    from transformers.modeling_utils import PreTrainedAudioTokenizerBase
+except ImportError:
+    # Older Transformers releases do not expose the audio-tokenizer base.
+    from transformers.modeling_utils import (
+        PreTrainedModel as PreTrainedAudioTokenizerBase,
+    )
+
+from transformers.utils import ModelOutput
+
+from .configuration_moss_audio_tokenizer import MossAudioTokenizerConfig
+
+# =============================================================================
+# Output Classes
+# =============================================================================
+
+
+@dataclass
+class MossAudioTokenizerEncoderOutput(ModelOutput):
+    r"""
+    audio_codes (`torch.LongTensor` of shape `(num_quantizers, batch_size, sequence_length)`, *optional*):
+        Discrete audio codes computed using the encoder and quantizer.
+    audio_codes_lengths (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
+        Valid lengths for each sample's audio codes.
+    encoder_hidden_states (`torch.FloatTensor` of shape `(batch_size, hidden_size, sequence_length)`, *optional*):
+        Hidden states from the encoder before quantization.
+    """
+
+    audio_codes: torch.Tensor | None = None
+    audio_codes_lengths: torch.Tensor | None = None
+    encoder_hidden_states: torch.Tensor | None = None
+
+
+@dataclass
+class MossAudioTokenizerDecoderOutput(ModelOutput):
+    r"""
+    audio (`torch.FloatTensor` of shape `(batch_size, channels, sequence_length)`, *optional*):
+        Decoded audio waveform.
+    audio_lengths (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
+        Valid lengths for each sample's audio.
+    """
+
+    audio: torch.Tensor | None = None
+    audio_lengths: torch.Tensor | None = None
+
+
+@dataclass
+class MossAudioTokenizerOutput(ModelOutput):
+    r"""
+    audio (`torch.FloatTensor` of shape `(batch_size, channels, sequence_length)`, *optional*):
+        Decoded audio waveform.
+    audio_lengths (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
+        Valid lengths for each sample's audio.
+    audio_codes (`torch.LongTensor` of shape `(num_quantizers, batch_size, sequence_length)`, *optional*):
+        Discrete audio codes computed using the encoder and quantizer.
+    audio_codes_lengths (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
+        Valid lengths for each sample's audio codes.
+    """
+
+    audio: torch.Tensor | None = None
+    audio_lengths: torch.Tensor | None = None
+    audio_codes: torch.Tensor | None = None
+    audio_codes_lengths: torch.Tensor | None = None
+
+
+# =============================================================================
+# Streaming Module Base Classes
+# =============================================================================
+
+
+@dataclass
+class StreamingState:
+    """Base state for streaming modules."""
+
+    batch_size: int
+    device: torch.device
+
+    def __post_init__(self):
+        self.exec_mask = torch.ones(
+            self.batch_size, dtype=torch.bool, device=self.device
+        )
+
+    def set_exec_mask(self, exec_mask: torch.Tensor):
+        self.exec_mask[:] = exec_mask
+
+    def reset(self, reset_mask: torch.Tensor) -> None:
+        self.exec_mask[:] = torch.where(
+            reset_mask, torch.ones_like(self.exec_mask), self.exec_mask
+        )
+
+    def __enter__(self):
+        # ExitStack expects a context manager; returning self is conventional and useful for debugging.
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        pass
+
+
+class StreamingModule(nn.Module):
+    """Base class for streaming components."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._streaming_state: StreamingState | None = None
+        self._streaming_detached: bool = False
+        self._cached_children: list[tuple[str, StreamingModule]] | None = None
+
+    @property
+    def is_streaming(self):
+        return self._streaming_state is not None
+
+    def _apply_named_streaming(self, fn):
+        def _handle_module(prefix: str, module: nn.Module):
+            if isinstance(module, StreamingModule):
+                if module._streaming_detached and prefix != "":
+                    return
+                if self._cached_children is None:
+                    raise RuntimeError(
+                        "Internal error: _cached_children should be initialized before traversal."
+                    )
+                self._cached_children.append((prefix, module))
+            for name, child in module.named_children():
+                new_prefix = f"{prefix}.{name}" if prefix else name
+                _handle_module(new_prefix, child)
+
+        if self._cached_children is None:
+            self._cached_children = []
+            _handle_module("", self)
+        for name, child in self._cached_children:
+            fn(name, child)
+
+    def _start_streaming(self, batch_size: int, exit_stack: ExitStack):
+        def _start_streaming_fn(name: str, module: StreamingModule):
+            if module._streaming_state is not None:
+                raise RuntimeError(f"{name} is already streaming!")
+            state = module._init_streaming_state(batch_size)
+            exit_stack.enter_context(state)
+            module._streaming_state = state
+
+        self._apply_named_streaming(_start_streaming_fn)
+
+    def _stop_streaming(self) -> None:
+        def _stop_streaming_fn(name: str, module: StreamingModule):
+            module._streaming_state = None
+
+        self._apply_named_streaming(_stop_streaming_fn)
+
+    def _init_streaming_state(self, batch_size: int) -> StreamingState:
+        device = next(iter(self.parameters())).device
+        return StreamingState(batch_size, device)
+
+    def streaming(self, batch_size: int) -> ExitStack:
+        """Context manager to enter streaming mode."""
+        exit_stack = ExitStack()
+        self._start_streaming(batch_size, exit_stack)
+        exit_stack.callback(self._stop_streaming)
+        return exit_stack
+
+
+class StreamingContainer(StreamingModule):
+    """Container for streaming modules."""
+
+
+# =============================================================================
+# Normalization Layers
+# =============================================================================
+
+
+class MossAudioTokenizerRMSNorm(nn.Module):
+    """Root Mean Square Layer Normalization."""
+
+    def __init__(
+        self,
+        dim: int,
+        eps: float = 1e-5,
+        dtype: torch.dtype | None = None,
+        device=None,
+    ):
+        super().__init__()
+        self.eps = eps
+        self.dtype = dtype
+        self.alpha = nn.Parameter(
+            torch.full((1, 1, dim), 1.0, requires_grad=True, device=device, dtype=dtype)
+        )
+
+    def forward(self, x: torch.Tensor):
+        x_dtype = x.dtype
+        if self.dtype is not None:
+            x = x.to(self.dtype)
+        var = self.eps + torch.mean(x**2, dim=2, keepdim=True)
+        y = (x * (self.alpha.to(var) * torch.rsqrt(var))).to(x_dtype)
+        return y
+
+
+class MossAudioTokenizerLayerScale(nn.Module):
+    """Layer scale from Touvron et al. 2021."""
+
+    def __init__(
+        self,
+        channels: int,
+        init: float = 1e-4,
+        channel_last: bool = True,
+        device=None,
+        dtype=None,
+    ):
+        super().__init__()
+        self.channel_last = channel_last
+        self.scale = nn.Parameter(
+            torch.full(
+                (channels,), init, requires_grad=True, device=device, dtype=dtype
+            )
+        )
+
+    def forward(self, x: torch.Tensor):
+        if self.channel_last:
+            return self.scale * x
+        else:
+            return self.scale[:, None] * x
+
+
+def create_norm_fn(norm_type: str, dim: int, **kwargs) -> nn.Module:
+    """Create normalization module."""
+    if norm_type == "layer_norm":
+        return nn.LayerNorm(dim, eps=1e-5, **kwargs)
+    elif norm_type in {"rms_norm"}:
+        return MossAudioTokenizerRMSNorm(dim, eps=1e-5, **kwargs)
+    elif norm_type in {"rms_norm_f32"}:
+        kwargs.pop("dtype", None)
+        return MossAudioTokenizerRMSNorm(dim, eps=1e-8, dtype=torch.float, **kwargs)
+    else:
+        raise ValueError(f"Unknown norm type: {norm_type}")
+
+
+# =============================================================================
+# Rotary Position Embedding
+# =============================================================================
+
+
+def apply_rope(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    offset: torch.Tensor,
+    max_period: float = 10_000,
+    time_before_heads: bool = False,
+):
+    """Apply rotary position embedding."""
+    if time_before_heads:
+        B, T, H, D = q.shape
+    else:
+        B, H, T, D = q.shape
+    if k.shape != q.shape:
+        raise ValueError(
+            f"Expected k.shape == q.shape, got k={tuple(k.shape)} q={tuple(q.shape)}"
+        )
+    if D <= 0 or (D % 2) != 0:
+        raise ValueError(f"RoPE requires an even last dimension, got D={D}")
+
+    ds = torch.arange(D // 2, device=q.device, dtype=torch.float32)
+    freqs = torch.exp(ds * (-math.log(max_period) * 2 / D))
+    ts = offset.float().view(-1, 1) + torch.arange(
+        T, device=q.device, dtype=torch.float32
+    )
+
+    if time_before_heads:
+        ts = ts.view(B, -1, 1, 1)
+    else:
+        ts = ts.view(B, 1, -1, 1)
+
+    dims = q.shape[:-1]
+    q = q.view(*dims, D // 2, 2)
+    k = k.view(*dims, D // 2, 2)
+
+    qr, qi = q[..., 0].float(), q[..., 1].float()
+    kr, ki = k[..., 0].float(), k[..., 1].float()
+
+    rotr = torch.cos(freqs * ts)
+    roti = torch.sin(freqs * ts)
+
+    qor = qr * rotr - qi * roti
+    qoi = qr * roti + qi * rotr
+    kor = kr * rotr - ki * roti
+    koi = kr * roti + ki * rotr
+
+    dtype = q.dtype
+    qo = torch.stack([qor.to(dtype), qoi.to(dtype)], dim=-1)
+    ko = torch.stack([kor.to(dtype), koi.to(dtype)], dim=-1)
+
+    return qo.view(*dims, D), ko.view(*dims, D)
+
+
+class MossAudioTokenizerRotaryEmbedding(nn.Module):
+    """Rotary positional embedding (RoPE)."""
+
+    def __init__(self, max_period: float = 10000.0):
+        super().__init__()
+        self.max_period = max_period
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        offset: torch.Tensor,
+        time_before_heads: bool = False,
+    ):
+        return apply_rope(q, k, offset, self.max_period, time_before_heads)
+
+
+# =============================================================================
+# Gating Modules
+# =============================================================================
+
+
+class MossAudioTokenizerActivationGating(nn.Module):
+    """Gating FFN layer with activation."""
+
+    def __init__(self, dim: int, dim_feedforward: int, activation, **factory_kwargs):
+        super().__init__()
+        if dim_feedforward == 4 * dim:
+            hidden = (21 * dim) // 8
+        else:
+            hidden = (2 * dim_feedforward) // 3
+
+        self.linear_in = nn.Linear(dim, 2 * hidden, bias=False, **factory_kwargs)
+        self.linear_out = nn.Linear(hidden, dim, bias=False, **factory_kwargs)
+        self.activation = activation
+
+    def forward(self, x: torch.Tensor):
+        x = self.linear_in(x)
+        B, T, _ = x.shape
+        x = x.view(B, T, 2, -1)
+        x = self.activation(x[..., 0, :]) * x[..., 1, :]
+        x = self.linear_out(x)
+        return x
+
+
+def _get_activation(name: str):
+    if name in ["sigmoid", "tanh", "relu"]:
+        return getattr(torch, name)
+    elif name in ["leaky_relu", "elu", "gelu", "silu", "mish", "softsign"]:
+        return getattr(F, name)
+    elif name == "identity":
+        return nn.Identity()
+    else:
+        raise ValueError(f"Unknown activation {name}")
+
+
+def make_gating(
+    name: str, dim: int, dim_feedforward: int, **factory_kwargs
+) -> nn.Module:
+    return MossAudioTokenizerActivationGating(
+        dim, dim_feedforward, _get_activation(name), **factory_kwargs
+    )
+
+
+# =============================================================================
+# Positional Embeddings
+# =============================================================================
+
+
+def create_sin_embedding(
+    positions: torch.Tensor,
+    dim: int,
+    max_period: float = 10000,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Create sinusoidal positional embedding with shape [B, T, C]."""
+    if dim % 2 != 0:
+        raise ValueError(f"Sinusoidal embedding requires even dim, got dim={dim}")
+    half_dim = dim // 2
+    if half_dim <= 1:
+        raise ValueError(f"Sinusoidal embedding requires dim >= 4, got dim={dim}")
+    positions = positions.to(dtype)
+    adim = torch.arange(half_dim, device=positions.device, dtype=dtype).view(1, 1, -1)
+    max_period_tensor = torch.full([], max_period, device=positions.device, dtype=dtype)
+    phase = positions / (max_period_tensor ** (adim / (half_dim - 1)))
+    return torch.cat([torch.cos(phase), torch.sin(phase)], dim=-1)
+
+
+# =============================================================================
+# KV Cache for Attention
+# =============================================================================
+
+
+class KVCacheResult:
+    """Container for KV cache results that supports tuple unpacking."""
+
+    __slots__ = ("keys", "values", "positions")
+
+    def __init__(
+        self, keys: torch.Tensor, values: torch.Tensor, positions: torch.Tensor
+    ):
+        self.keys = keys
+        self.values = values
+        self.positions = positions
+
+    def __iter__(self):
+        """Allow unpacking as (keys, values, positions)."""
+        return iter((self.keys, self.values, self.positions))
+
+    @staticmethod
+    def from_kv(keys: torch.Tensor, values: torch.Tensor) -> KVCacheResult:
+        B, H, T, D = keys.shape
+        positions = torch.arange(T, device=keys.device, dtype=torch.long)
+        return KVCacheResult(keys, values, positions.expand(B, -1))
+
+
+class RingKVCache:
+    """Efficient streaming KVCache compatible with CUDA Graph."""
+
+    def __init__(
+        self,
+        batch_size: int,
+        num_heads: int,
+        dim_per_head: int,
+        capacity: int,
+        respect_exec_mask: bool = True,
+        device: torch.device = torch.device("cuda"),
+        dtype: torch.dtype = torch.bfloat16,
+    ):
+        self.capacity = capacity
+        self.cache = torch.zeros(
+            (2, batch_size, num_heads, capacity, dim_per_head),
+            device=device,
+            dtype=dtype,
+        )
+        self.respect_exec_mask = respect_exec_mask
+        if self.respect_exec_mask:
+            self.end_offset = torch.zeros(batch_size, device=device, dtype=torch.long)
+        else:
+            self.end_offset = torch.zeros(1, device=device, dtype=torch.long)
+
+    def reset(self, reset_mask: torch.Tensor) -> None:
+        self.end_offset[:] = torch.where(
+            reset_mask, torch.zeros_like(self.end_offset), self.end_offset
+        )
+
+    def complete(
+        self, k: torch.Tensor, v: torch.Tensor, exec_mask: torch.Tensor
+    ) -> KVCacheResult:
+        B, H, T, D = k.shape
+        if T <= 0:
+            raise ValueError(f"Expected T > 0, got T={T}")
+
+        indexes = torch.arange(
+            T, device=self.end_offset.device, dtype=self.end_offset.dtype
+        )
+        indexes = indexes + self.end_offset.view(-1, 1)
+        indexes = indexes % self.capacity
+
+        if self.respect_exec_mask:
+            this_indexes = indexes.view(B, 1, T, 1).expand(-1, H, T, D)
+            self.cache[0].scatter_(2, this_indexes, k)
+            self.cache[1].scatter_(2, this_indexes, v)
+        else:
+            self.cache[0].index_copy_(2, indexes[0], k)
+            self.cache[1].index_copy_(2, indexes[0], v)
+
+        keys = self.cache[0]
+        values = self.cache[1]
+
+        indexes = torch.arange(
+            self.capacity, device=self.end_offset.device, dtype=torch.long
+        )
+        last_offset = self.end_offset.view(-1, 1) + T - 1
+        end_index = last_offset % self.capacity
+        delta = indexes - end_index
+
+        positions = torch.where(
+            delta <= 0,
+            last_offset + delta,
+            last_offset + delta - self.capacity,
+        )
+
+        if self.respect_exec_mask:
+            self.end_offset[:] = torch.where(
+                exec_mask, self.end_offset + T, self.end_offset
+            )
+        else:
+            self.end_offset.add_(T)
+
+        invalid = indexes >= self.end_offset.view(-1, 1)
+        positions = torch.where(invalid, torch.full_like(positions, -1), positions)
+
+        return KVCacheResult(keys, values, positions)
+
+
+# =============================================================================
+# Multi-Head Attention
+# =============================================================================
+
+
+@dataclass
+class MHAState(StreamingState):
+    kv_cache: RingKVCache | None
+    offset: torch.Tensor
+    offset_cpu: int
+
+    def reset(self, reset_mask: torch.Tensor):
+        super().reset(reset_mask)
+        self.offset[:] = torch.where(
+            reset_mask, torch.zeros_like(self.offset), self.offset
+        )
+        if self.kv_cache is not None:
+            self.kv_cache.reset(reset_mask)
+        self.offset_cpu = 0
+
+
+def apply_weights_per_step(
+    modules: nn.ModuleList,
+    schedule: list[int] | None,
+    x: torch.Tensor,
+    offset: int | None,
+) -> torch.Tensor:
+    """Apply different weights for each time step."""
+    if len(modules) == 1:
+        return modules[0](x)
+
+    if offset is None:
+        raise ValueError(
+            "offset must be provided when using per-step weights (len(modules) > 1)."
+        )
+    ys = []
+    B, T, C = x.shape
+    for t in range(T):
+        module_index = t + offset
+        if schedule is not None:
+            if module_index >= len(schedule) or module_index < 0:
+                raise ValueError(
+                    f"weights_per_step_schedule is too short for module_index={module_index} (len={len(schedule)})."
+                )
+            module_index = schedule[module_index]
+        if module_index >= len(modules) or module_index < 0:
+            raise ValueError(
+                f"module_index={module_index} out of range for len(modules)={len(modules)}."
+            )
+        y = modules[module_index](x[:, t : t + 1])
+        ys.append(y)
+    return torch.cat(ys, 1)
+
+
+class MossAudioTokenizerMultiheadAttention(StreamingModule):
+    """Multi-head attention with streaming support."""
+
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        causal: bool = False,
+        context: int | None = None,
+        rope: MossAudioTokenizerRotaryEmbedding | None = None,
+        weights_per_step: int = 0,
+        weights_per_step_schedule: list[int] | None = None,
+        device=None,
+        dtype=None,
+    ):
+        super().__init__()
+        factory_kwargs = {"device": device, "dtype": dtype}
+
+        self.embed_dim = embed_dim
+        self.causal = causal
+        self.context = context
+        self.rope = rope
+        self.num_heads = num_heads
+        self.weights_per_step = weights_per_step
+        self.weights_per_step_schedule = weights_per_step_schedule
+
+        out_dim = 3 * embed_dim
+        mult = 1
+        if weights_per_step:
+            mult = (
+                max(weights_per_step_schedule) + 1
+                if weights_per_step_schedule
+                else weights_per_step
+            )
+        self.mult = mult
+
+        self.out_projs = nn.ModuleList(
+            [
+                nn.Linear(embed_dim, embed_dim, bias=False, **factory_kwargs)
+                for _ in range(mult)
+            ]
+        )
+        self.in_projs = nn.ModuleList(
+            [
+                nn.Linear(embed_dim, out_dim, bias=False, **factory_kwargs)
+                for _ in range(mult)
+            ]
+        )
+
+        self._register_load_state_dict_pre_hook(self._load_hook, with_module=True)
+
+    @staticmethod
+    def _load_hook(module, state_dict, prefix, *_):
+        mappings = {
+            "in_proj_weight": "in_projs.{i}.weight",
+            "in_proj.weight": "in_projs.{i}.weight",
+            "out_proj.weight": "out_projs.{i}.weight",
+        }
+        mult = module.mult
+        for suffix in ["", "_scb"]:
+            for source, target in mappings.items():
+                this_source = prefix + source + suffix
+                if this_source in state_dict:
+                    weight = state_dict[this_source]
+                    _, *OD = weight.shape
+                    weight = weight.view(mult, -1, *OD)
+                    for i in range(mult):
+                        state_dict[prefix + target.format(i=i) + suffix] = weight[i]
+                    state_dict.pop(this_source)
+
+    def _init_streaming_state(self, batch_size: int) -> MHAState:
+        in_proj = cast(nn.Linear, self.in_projs[0])
+        device = cast(torch.device, in_proj.weight.device)
+        dtype = cast(torch.dtype, in_proj.weight.dtype)
+
+        dim_per_head = self.embed_dim // self.num_heads
+        if self.context is None:
+            capacity = self.weights_per_step if self.weights_per_step else 1024
+        else:
+            capacity = self.context
+
+        kv_cache = RingKVCache(
+            batch_size,
+            self.num_heads,
+            dim_per_head,
+            capacity,
+            respect_exec_mask=not self.weights_per_step,
+            device=cast(torch.device, device),
+            dtype=cast(torch.dtype, dtype),
+        )
+        return MHAState(
+            batch_size,
+            cast(torch.device, device),
+            kv_cache,
+            offset=torch.zeros(
+                batch_size, device=cast(torch.device, device), dtype=torch.long
+            ),
+            offset_cpu=0,
+        )
+
+    def _complete_kv(self, k, v) -> KVCacheResult:
+        state = cast(MHAState | None, self._streaming_state)
+        if state is None:
+            return KVCacheResult.from_kv(k, v)
+        if state.kv_cache is None:
+            return KVCacheResult.from_kv(k, v)
+        return state.kv_cache.complete(k, v, state.exec_mask)
+
+    def forward(self, query: torch.Tensor, key: torch.Tensor, value: torch.Tensor):
+        state = cast(MHAState | None, self._streaming_state)
+        B, T = query.shape[:2]
+
+        if state is None:
+            offset = torch.zeros(B, device=query.device, dtype=torch.long)
+            offset_cpu = 0
+        else:
+            offset = state.offset
+            offset_cpu = state.offset_cpu
+
+        projected = apply_weights_per_step(
+            self.in_projs, self.weights_per_step_schedule, query, offset_cpu
+        )
+        dim_per_head = self.embed_dim // self.num_heads
+        projected = projected.reshape(B, T, 3, self.num_heads, dim_per_head).permute(
+            2, 0, 3, 1, 4
+        )
+        q, k, v = projected[0], projected[1], projected[2]
+
+        if self.rope:
+            q, k = self.rope(q, k, offset, time_before_heads=False)
+
+        k, v, pos_k = self._complete_kv(k, v)
+        pos_k = pos_k[:, None]
+
+        if self.causal:
+            pos_q = offset.view(-1, 1, 1) + torch.arange(
+                T, device=q.device, dtype=torch.long
+            ).view(-1, 1)
+            delta = pos_q - pos_k
+            attn_bias = (pos_k >= 0) & (delta >= 0)
+            if self.context is not None:
+                attn_bias = attn_bias & (delta < self.context)
+            attn_bias = attn_bias[:, None]
+        else:
+            attn_bias = None
+
+        x = F.scaled_dot_product_attention(q, k, v, attn_bias, dropout_p=0.0)
+        x = x.transpose(1, 2).reshape(B, T, self.embed_dim)
+        x = apply_weights_per_step(
+            self.out_projs, self.weights_per_step_schedule, x, offset_cpu
+        )
+
+        if state is not None:
+            state.offset[:] = torch.where(
+                state.exec_mask, state.offset + T, state.offset
+            )
+            state.offset_cpu += T
+        return x
+
+
+# =============================================================================
+# Transformer Layer
+# =============================================================================
+
+
+@dataclass
+class LayerState(StreamingState):
+    offset_cpu: int = 0
+
+    def reset(self, reset_mask: torch.Tensor):
+        super().reset(reset_mask)
+        self.offset_cpu = 0
+
+
+class MossAudioTokenizerTransformerLayer(StreamingModule):
+    """Transformer layer with streaming support."""
+
+    def __init__(
+        self,
+        d_model: int,
+        num_heads: int,
+        dim_feedforward: int = 2048,
+        causal: bool = False,
+        context: int | None = None,
+        rope: MossAudioTokenizerRotaryEmbedding | None = None,
+        norm: str = "layer_norm",
+        layer_scale: float | None = None,
+        gating: str = "none",
+        weights_per_step: int = 0,
+        weights_per_step_schedule: list[int] | None = None,
+        activation=F.gelu,
+        device=None,
+        dtype=None,
+    ):
+        super().__init__()
+        factory_kwargs = {"device": device, "dtype": dtype}
+
+        self.self_attn = MossAudioTokenizerMultiheadAttention(
+            embed_dim=d_model,
+            num_heads=num_heads,
+            causal=causal,
+            context=context,
+            rope=rope,
+            weights_per_step=weights_per_step,
+            weights_per_step_schedule=weights_per_step_schedule,
+            **factory_kwargs,
+        )
+        self.norm1 = create_norm_fn(norm, d_model, **factory_kwargs)
+        self.norm2 = create_norm_fn(norm, d_model, **factory_kwargs)
+
+        self.weights_per_step = weights_per_step
+        self.weights_per_step_schedule = weights_per_step_schedule
+        self.gating: nn.Module | nn.ModuleList | None = None
+        self.linear1: nn.Module | None = None
+        self.linear2: nn.Module | None = None
+        self.activation = activation
+
+        if gating == "none":
+            self.linear1 = nn.Linear(
+                d_model, dim_feedforward, bias=False, **factory_kwargs
+            )
+            self.linear2 = nn.Linear(
+                dim_feedforward, d_model, bias=False, **factory_kwargs
+            )
+        else:
+            if weights_per_step:
+                num_weights = (
+                    max(weights_per_step_schedule) + 1
+                    if weights_per_step_schedule
+                    else weights_per_step
+                )
+                dim_ff_list = (
+                    [dim_feedforward] * num_weights
+                    if isinstance(dim_feedforward, int)
+                    else dim_feedforward
+                )
+                self.gating = nn.ModuleList(
+                    [
+                        make_gating(gating, d_model, dim, **factory_kwargs)
+                        for dim in dim_ff_list
+                    ]
+                )
+            else:
+                self.gating = make_gating(
+                    gating, d_model, dim_feedforward, **factory_kwargs
+                )
+
+        if layer_scale is None:
+            self.layer_scale_1 = nn.Identity()
+            self.layer_scale_2 = nn.Identity()
+        else:
+            self.layer_scale_1 = MossAudioTokenizerLayerScale(
+                channels=d_model,
+                init=layer_scale,
+                channel_last=True,
+                **cast(dict[str, object], factory_kwargs),
+            )
+            self.layer_scale_2 = MossAudioTokenizerLayerScale(
+                channels=d_model,
+                init=layer_scale,
+                channel_last=True,
+                **cast(dict[str, object], factory_kwargs),
+            )
+
+    def _init_streaming_state(self, batch_size: int) -> LayerState:
+        device = next(iter(self.parameters())).device
+        return LayerState(batch_size, device, offset_cpu=0)
+
+    def _ff_block(self, x: torch.Tensor) -> torch.Tensor:
+        state = self._streaming_state
+        offset = state.offset_cpu if isinstance(state, LayerState) else 0
+
+        x_orig = x
+        x = self.norm2(x)
+
+        if self.gating is None:
+            assert self.linear1 is not None
+            assert self.linear2 is not None
+            update = self.linear2(self.activation(self.linear1(x)))
+        else:
+            if self.weights_per_step:
+                assert isinstance(self.gating, nn.ModuleList)
+                update = apply_weights_per_step(
+                    self.gating, self.weights_per_step_schedule, x, offset
+                )
+            else:
+                update = self.gating(x)
+        return x_orig.to(update) + self.layer_scale_2(update)
+
+    def _sa_block(self, x: torch.Tensor):
+        x_orig = x
+        x = self.norm1(x)
+        update = self.self_attn(x, x, x)
+        return x_orig.to(update) + self.layer_scale_1(update)
+
+    def forward(self, x: torch.Tensor):
+        x = self._sa_block(x)
+        x = self._ff_block(x)
+        state = self._streaming_state
+        if state is not None:
+            assert isinstance(state, LayerState)
+            state.offset_cpu += x.shape[1]
+        return x
+
+
+# =============================================================================
+# Streaming Transformer
+# =============================================================================
+
+
+@dataclass
+class TransformerState(StreamingState):
+    offsets: torch.Tensor
+
+    def reset(self, reset_mask: torch.Tensor):
+        super().reset(reset_mask)
+        self.offsets[:] = torch.where(
+            reset_mask, torch.zeros_like(self.offsets), self.offsets
+        )
+
+
+class MossAudioTokenizerTransformer(StreamingModule):
+    """Transformer with streaming/causal support."""
+
+    def __init__(
+        self,
+        d_model: int,
+        num_heads: int,
+        num_layers: int,
+        dim_feedforward: int = 2048,
+        causal: bool = False,
+        context: int | None = None,
+        positional_embedding: str = "sin",
+        max_period: float = 10_000,
+        positional_scale: float = 1.0,
+        device=None,
+        dtype=None,
+        **kwargs,
+    ):
+        super().__init__()
+        if d_model % num_heads != 0:
+            raise ValueError(
+                f"d_model must be divisible by num_heads, got d_model={d_model}, num_heads={num_heads}"
+            )
+
+        self.positional_embedding = positional_embedding
+        self.max_period = max_period
+        self.positional_scale = positional_scale
+
+        self.rope: MossAudioTokenizerRotaryEmbedding | None = None
+        if positional_embedding in {"rope", "sin_rope"}:
+            self.rope = MossAudioTokenizerRotaryEmbedding(max_period=max_period)
+
+        self.layers = nn.ModuleList()
+        for _ in range(num_layers):
+            self.layers.append(
+                MossAudioTokenizerTransformerLayer(
+                    d_model=d_model,
+                    num_heads=num_heads,
+                    dim_feedforward=dim_feedforward,
+                    causal=causal,
+                    context=context,
+                    rope=self.rope,
+                    device=device,
+                    dtype=dtype,
+                    **kwargs,
+                )
+            )
+
+    def _init_streaming_state(self, batch_size: int) -> TransformerState:
+        device = next(self.parameters()).device
+        return TransformerState(
+            batch_size,
+            device,
+            offsets=torch.zeros(batch_size, device=device, dtype=torch.long),
+        )
+
+    def forward(self, x: torch.Tensor, *args, **kwargs):
+        B, T, C = x.shape
+        state = self._streaming_state
+        offsets = (
+            torch.zeros(1, dtype=torch.long, device=x.device)
+            if state is None
+            else (
+                state.offsets
+                if isinstance(state, TransformerState)
+                else torch.zeros(1, dtype=torch.long, device=x.device)
+            )
+        )
+
+        if self.positional_embedding in {"sin", "sin_rope"}:
+            positions = torch.arange(T, device=x.device).view(1, -1, 1)
+            positions = positions + offsets.view(-1, 1, 1)
+            pos_emb = create_sin_embedding(
+                positions, C, max_period=self.max_period, dtype=x.dtype
+            )
+            x = x + self.positional_scale * pos_emb
+
+        for layer in self.layers:
+            x = layer(x, *args, **kwargs)
+
+        if state is not None:
+            assert isinstance(state, TransformerState)
+            state.offsets[:] = torch.where(
+                state.exec_mask, state.offsets + T, state.offsets
+            )
+        return x
+
+
+class MossAudioTokenizerProjectedTransformer(StreamingContainer):
+    """Transformer with input/output projections."""
+
+    def __init__(
+        self,
+        input_dimension: int,
+        output_dimension: int,
+        d_model: int,
+        *,
+        conv_layout: bool = False,
+        module_type: str,
+        **kwargs,
+    ):
+        super().__init__()
+        self.module_type = module_type
+        self.downsample_ratio: int = 1
+        self.input_dimension = input_dimension
+        self.output_dimension = output_dimension
+
+        self.input_proj = (
+            nn.Linear(input_dimension, d_model, bias=False)
+            if d_model != input_dimension
+            else nn.Identity()
+        )
+        self.transformer = MossAudioTokenizerTransformer(d_model=d_model, **kwargs)
+        self.conv_layout = conv_layout
+        self.output_proj = (
+            nn.Linear(d_model, output_dimension, bias=False)
+            if d_model != output_dimension
+            else nn.Identity()
+        )
+
+    def forward(self, x, input_lengths, *args, **kwargs):
+        x = self.input_proj(x.transpose(1, 2))  # (B, D, T) -> (B, T, D)
+        x = self.transformer(x, *args, **kwargs)
+        x = self.output_proj(x).transpose(1, 2)  # (B, T, D) -> (B, D, T)
+        return x, input_lengths
+
+
+# =============================================================================
+# Patched Pretransform Module
+# =============================================================================
+
+
+class MossAudioTokenizerPatchedPretransform(nn.Module):
+    """Patching module for downsampling/upsampling."""
+
+    def __init__(
+        self, patch_size: int, is_downsample: bool, module_type: str, **kwargs
+    ):
+        super().__init__()
+        self.patch_size = patch_size
+        self.downsample_ratio: int = patch_size
+        self.is_downsample = is_downsample
+        self.module_type = module_type
+
+    def encode(self, x, input_lengths):
+        b, d, _ = x.shape
+        h = self.patch_size
+        x = x.reshape(b, d, -1, h).permute(0, 1, 3, 2).reshape(b, d * h, -1)
+        # We pad the input waveform to a multiple of `downsample_rate` before applying the encoder.
+        # Use a ceil division to match that padding and avoid dropping the last (partially padded) frame.
+        output_lengths = input_lengths // self.patch_size
+        return x, output_lengths
+
+    def decode(self, x, input_lengths):
+        b, dh, length = x.shape
+        h = self.patch_size
+        d = dh // h
+        x = x.reshape(b, d, h, length).permute(0, 1, 3, 2).reshape(b, d, length * h)
+        output_lengths = input_lengths * self.patch_size
+        return x, output_lengths
+
+    def forward(self, x, input_lengths):
+        if self.is_downsample:
+            return self.encode(x, input_lengths)
+        else:
+            return self.decode(x, input_lengths)
+
+
+# =============================================================================
+# Vector Quantization
+# =============================================================================
+
+
+def WNConv1d(*args, **kwargs):
+    """Weight-normalized Conv1d."""
+    return nn.utils.parametrizations.weight_norm(nn.Conv1d(*args, **kwargs))
+
+
+class MossAudioTokenizerVectorQuantize(nn.Module):
+    """Single codebook vector quantization (inference only)."""
+
+    def __init__(
+        self,
+        input_dim: int,
+        codebook_size: int,
+        codebook_dim: int,
+        **kwargs,
+    ):
+        super().__init__()
+        self.input_dim = input_dim
+        self.codebook_size = codebook_size
+        self.codebook_dim = codebook_dim
+
+        if input_dim != codebook_dim:
+            self.in_proj = WNConv1d(input_dim, codebook_dim, kernel_size=1)
+            self.out_proj = WNConv1d(codebook_dim, input_dim, kernel_size=1)
+        else:
+            self.in_proj = nn.Identity()
+            self.out_proj = nn.Identity()
+
+        self.codebook = nn.Embedding(codebook_size, codebook_dim)
+
+    @torch.no_grad()
+    def forward(
+        self, z: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Args:
+            z: Input tensor of shape (B, D, T)
+        Returns:
+            z_q: Quantized tensor of shape (B, D, T)
+            indices: Code indices of shape (B, T)
+            z_e: Encoded tensor before quantization
+        """
+        z = z.float()
+        z_e = self.in_proj(z).float()
+
+        encodings = z_e.transpose(1, 2).reshape(-1, z_e.shape[1])
+
+        codebook_weight = self.codebook.weight
+        dist = (
+            encodings.pow(2).sum(1, keepdim=True)
+            - 2 * encodings @ codebook_weight.float().t()
+            + codebook_weight.float().pow(2).sum(1, keepdim=True).t()
+        )
+
+        indices = (-dist).max(1)[1]
+        indices = indices.reshape(z.size(0), -1)
+
+        z_q = self.decode_code(indices)
+        z_q = self.out_proj(z_q).float()
+
+        return z_q, indices, z_e
+
+    def decode_code(self, embed_id: torch.Tensor) -> torch.Tensor:
+        """Decode code indices to embeddings."""
+        return self.codebook(embed_id).transpose(1, 2).float()
+
+
+class MossAudioTokenizerLFQ(nn.Module):
+    """LFQ (inference-only) used by ResidualLFQ."""
+
+    def __init__(
+        self,
+        input_dim: int,
+        codebook_size: int,
+        codebook_dim: int,
+        **kwargs,
+    ):
+        super().__init__()
+        self.input_dim = input_dim
+        self.codebook_size = codebook_size
+        self.codebook_dim = codebook_dim
+
+        if self.input_dim != self.codebook_dim:
+            self.in_proj = WNConv1d(self.input_dim, self.codebook_dim, kernel_size=1)
+            self.out_proj = WNConv1d(self.codebook_dim, self.input_dim, kernel_size=1)
+        else:
+            self.in_proj = nn.Identity()
+            self.out_proj = nn.Identity()
+
+        self.codebook = nn.Embedding(codebook_size, codebook_dim)
+
+    @torch.no_grad()
+    def forward(
+        self, z: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Quantize z into codebook vectors."""
+        z = z.float()
+        z_e = self.in_proj(z).float()
+        z_q, indices = self.decode_latents(z_e)
+        z_q = (z_e + (z_q - z_e).detach()).float()
+        z_q = self.out_proj(z_q).float()
+        return z_q, indices, z_e
+
+    def embed_code(self, embed_id: torch.Tensor) -> torch.Tensor:
+        return F.embedding(embed_id, self.codebook.weight)
+
+    def decode_code_wo_out_proj(self, embed_id: torch.Tensor) -> torch.Tensor:
+        return self.embed_code(embed_id).transpose(1, 2)
+
+    def decode_code(self, embed_id: torch.Tensor) -> torch.Tensor:
+        z_q = self.decode_code_wo_out_proj(embed_id).float()
+        z_q = self.out_proj(z_q).float()
+        return z_q
+
+    def decode_latents(
+        self, latents: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Match training LFQ: L2-normalize then argmin squared distance."""
+        encodings = latents.transpose(1, 2).reshape(-1, latents.shape[1]).float()
+        codebook = self.codebook.weight.float()
+
+        encodings = F.normalize(encodings)
+        codebook = F.normalize(codebook)
+
+        dist = (
+            encodings.pow(2).sum(1, keepdim=True)
+            - 2 * encodings @ codebook.t()
+            + codebook.pow(2).sum(1, keepdim=True).t()
+        )
+        indices = (-dist).max(1)[1]
+        indices = indices.reshape(latents.size(0), -1)
+        z_q = self.decode_code_wo_out_proj(indices).float()
+        return z_q, indices
+
+
+class MossAudioTokenizerResidualVQ(nn.Module):
+    """Residual Vector Quantization (inference only)."""
+
+    def __init__(
+        self,
+        input_dim: int = 1024,
+        rvq_dim: int | None = None,
+        output_dim: int | None = None,
+        num_quantizers: int = 32,
+        codebook_size: int = 1024,
+        codebook_dim: int = 8,
+        **kwargs,
+    ):
+        super().__init__()
+        self.input_dim = input_dim
+        self.rvq_dim = rvq_dim or input_dim
+        self.output_dim = output_dim or input_dim
+        self.num_quantizers = num_quantizers
+        self.codebook_size = codebook_size
+        self.codebook_dim = codebook_dim
+
+        self.input_proj = (
+            WNConv1d(input_dim, self.rvq_dim, kernel_size=1)
+            if input_dim != self.rvq_dim
+            else nn.Identity()
+        )
+        self.output_proj = (
+            WNConv1d(self.rvq_dim, self.output_dim, kernel_size=1)
+            if self.rvq_dim != self.output_dim
+            else nn.Identity()
+        )
+
+        self.quantizers = nn.ModuleList(
+            [
+                MossAudioTokenizerVectorQuantize(
+                    input_dim=self.rvq_dim,
+                    codebook_size=codebook_size,
+                    codebook_dim=codebook_dim,
+                    **kwargs,
+                )
+                for _ in range(num_quantizers)
+            ]
+        )
+
+    @torch.no_grad()
+    def forward(
+        self,
+        z: torch.Tensor,
+        input_length: torch.Tensor,
+        n_quantizers: int | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        Args:
+            z: Input tensor of shape (B, D, T)
+            input_length: Valid lengths for each sample (B,)
+            n_quantizers: Number of quantizers to use
+        Returns:
+            quantized_out: Quantized output (B, D, T)
+            all_indices: All code indices (N, B, T)
+            output_length: Output lengths (B,)
+        """
+        z = self.input_proj(z)
+
+        batch_size, _, max_time = z.shape
+        mask = torch.arange(max_time, device=z.device).expand(
+            batch_size, max_time
+        ) < input_length.unsqueeze(1)
+
+        quantized_out = torch.zeros_like(z, dtype=torch.float32)
+        residual = z.clone().float()
+        all_indices = []
+
+        n_quantizers = n_quantizers or self.num_quantizers
+
+        for i, quantizer in enumerate(self.quantizers):
+            if i >= n_quantizers:
+                break
+
+            masked_residual = residual * mask.unsqueeze(1)
+            z_q_i, indices_i, _ = quantizer(masked_residual)
+
+            update_mask = mask.unsqueeze(1)
+            quantized_out = quantized_out + z_q_i * update_mask
+            residual = residual - z_q_i * update_mask
+            all_indices.append(indices_i)
+
+        all_indices = torch.stack(all_indices)  # (N, B, T)
+        quantized_out = self.output_proj(quantized_out)
+
+        return quantized_out, all_indices, input_length
+
+    def decode_codes(self, codes: torch.Tensor) -> torch.Tensor:
+        """Decode codes from multiple quantizers to embeddings."""
+        nq, B, T = codes.shape
+        emb = torch.zeros(B, self.rvq_dim, T, device=codes.device, dtype=torch.float32)
+
+        for i, quantizer in enumerate(self.quantizers[:nq]):
+            quantizer = cast(MossAudioTokenizerVectorQuantize, quantizer)
+            quantized_i = quantizer.decode_code(codes[i])
+            emb += quantized_i
+
+        emb = self.output_proj(emb)
+        return emb
+
+
+class MossAudioTokenizerResidualLFQ(nn.Module):
+    """Residual LFQ (inference only)."""
+
+    def __init__(
+        self,
+        input_dim: int = 1024,
+        rvq_dim: int | None = None,
+        output_dim: int | None = None,
+        num_quantizers: int = 32,
+        codebook_size: int = 1024,
+        codebook_dim: int = 8,
+        **kwargs,
+    ):
+        super().__init__()
+        self.input_dim = input_dim
+        self.rvq_dim = rvq_dim or input_dim
+        self.output_dim = output_dim or input_dim
+        self.num_quantizers = num_quantizers
+        self.codebook_size = codebook_size
+        self.codebook_dim = codebook_dim
+
+        self.input_proj = (
+            WNConv1d(input_dim, self.rvq_dim, kernel_size=1)
+            if input_dim != self.rvq_dim
+            else nn.Identity()
+        )
+        self.output_proj = (
+            WNConv1d(self.rvq_dim, self.output_dim, kernel_size=1)
+            if self.rvq_dim != self.output_dim
+            else nn.Identity()
+        )
+
+        self.quantizers = nn.ModuleList(
+            [
+                MossAudioTokenizerLFQ(
+                    input_dim=self.rvq_dim,
+                    codebook_size=codebook_size,
+                    codebook_dim=codebook_dim,
+                    **kwargs,
+                )
+                for _ in range(num_quantizers)
+            ]
+        )
+
+    @torch.no_grad()
+    def forward(
+        self,
+        z: torch.Tensor,
+        input_length: torch.Tensor,
+        n_quantizers: int | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Inference quantization."""
+        z = self.input_proj(z).float()
+
+        batch_size, _, max_time = z.shape
+        mask = torch.arange(max_time, device=z.device).expand(
+            batch_size, max_time
+        ) < input_length.unsqueeze(1)
+
+        quantized_out = torch.zeros_like(z, dtype=torch.float32)
+        residual = z.clone().float()
+        all_indices = []
+
+        n_quantizers = n_quantizers or self.num_quantizers
+        for i, quantizer in enumerate(self.quantizers):
+            if i >= n_quantizers:
+                break
+
+            masked_residual = residual * mask.unsqueeze(1)
+            z_q_i, indices_i, _ = quantizer(masked_residual)
+
+            update_mask = mask.unsqueeze(1)
+            quantized_out = quantized_out + z_q_i * update_mask
+            residual = residual - z_q_i * update_mask
+            all_indices.append(indices_i)
+
+        all_indices = (
+            torch.stack(all_indices)
+            if all_indices
+            else torch.empty(0, batch_size, max_time, device=z.device, dtype=torch.long)
+        )
+        quantized_out = self.output_proj(quantized_out)
+        return quantized_out, all_indices, input_length
+
+    def decode_codes(self, codes: torch.Tensor) -> torch.Tensor:
+        nq, B, T = codes.shape
+        emb = torch.zeros(B, self.rvq_dim, T, device=codes.device, dtype=torch.float32)
+        for i, quantizer in enumerate(self.quantizers[:nq]):
+            quantizer = cast(MossAudioTokenizerLFQ, quantizer)
+            emb += quantizer.decode_code(codes[i]).float()
+        emb = self.output_proj(emb)
+        return emb
+
+
+# =============================================================================
+# Main Model Classes
+# =============================================================================
+
+
+class MossAudioTokenizerPreTrainedModel(PreTrainedAudioTokenizerBase):
+    """Base class for MossAudioTokenizer models."""
+
+    config_class = MossAudioTokenizerConfig
+    base_model_prefix = ""
+    main_input_name = "input_values"
+    input_modalities = "audio"
+    supports_gradient_checkpointing = False
+    _no_split_modules = [
+        "MossAudioTokenizerTransformerLayer",
+        "MossAudioTokenizerResidualVQ",
+        "MossAudioTokenizerResidualLFQ",
+    ]
+
+
+class MossAudioTokenizerModel(MossAudioTokenizerPreTrainedModel):
+    """
+    MossAudioTokenizer model for audio tokenization and synthesis.
+
+    This model can encode audio waveforms into discrete tokens and decode
+    tokens back into audio waveforms.
+    """
+
+    def __init__(self, config: MossAudioTokenizerConfig):
+        super().__init__(config)
+
+        self.config = config
+        _ = config.version
+        self.sampling_rate = config.sampling_rate
+        self.downsample_rate = config.downsample_rate
+        self.causal_transformer_context_duration = (
+            config.causal_transformer_context_duration
+        )
+
+        # Build encoder
+        current_frame_rate: float = float(self.sampling_rate)
+        self.encoder = nn.ModuleList()
+
+        for encoder_kwargs_i in config.encoder_kwargs:
+            encoder_kwargs_i = dict(encoder_kwargs_i)  # Make a copy
+            if encoder_kwargs_i["module_type"] == "PatchedPretransform":
+                self.encoder.append(
+                    MossAudioTokenizerPatchedPretransform(
+                        **encoder_kwargs_i, is_downsample=True
+                    )
+                )
+            elif encoder_kwargs_i["module_type"] == "Transformer":
+                self.encoder.append(
+                    MossAudioTokenizerProjectedTransformer(
+                        **encoder_kwargs_i,
+                        context=int(
+                            current_frame_rate
+                            * self.causal_transformer_context_duration
+                        ),
+                    )
+                )
+            current_frame_rate /= self.encoder[-1].downsample_ratio
+
+        # Build quantizer
+        quantizer_kwargs = dict(config.quantizer_kwargs)
+        quantizer_type = quantizer_kwargs.get(
+            "quantizer_type", getattr(config, "quantizer_type", "rvq")
+        )
+        if quantizer_type in {"rvq", "spec_rvq"}:
+            self.quantizer = MossAudioTokenizerResidualVQ(**quantizer_kwargs)
+        elif quantizer_type in {"rlfq", "random_prefix_rlfq"}:
+            self.quantizer = MossAudioTokenizerResidualLFQ(**quantizer_kwargs)
+        else:
+            raise ValueError(f"Unsupported quantizer_type: {quantizer_type}")
+
+        # Build decoder
+        decoder_kwargs_list = copy.deepcopy(config.decoder_kwargs)
+        self.decoder = nn.ModuleList()
+
+        for decoder_kwargs_i in decoder_kwargs_list:
+            decoder_kwargs_i = dict(decoder_kwargs_i)
+            if decoder_kwargs_i["module_type"] == "PatchedPretransform":
+                self.decoder.append(
+                    MossAudioTokenizerPatchedPretransform(
+                        **decoder_kwargs_i, is_downsample=False
+                    )
+                )
+            elif decoder_kwargs_i["module_type"] == "Transformer":
+                self.decoder.append(
+                    MossAudioTokenizerProjectedTransformer(
+                        **decoder_kwargs_i,
+                        context=int(
+                            current_frame_rate
+                            * self.causal_transformer_context_duration
+                        ),
+                    )
+                )
+            current_frame_rate *= self.decoder[-1].downsample_ratio
+
+        self.post_init()
+
+    def _start_streaming(self, batch_size: int):
+        """Start streaming mode for all modules."""
+
+        def _start(module):
+            if isinstance(module, StreamingModule):
+                module._streaming_state = module._init_streaming_state(batch_size)
+
+        self.apply(_start)
+
+    def _stop_streaming(self):
+        """Stop streaming mode for all modules."""
+
+        def _stop(module):
+            if isinstance(module, StreamingModule):
+                module._streaming_state = None
+
+        self.apply(_stop)
+
+    @contextmanager
+    def streaming(self, batch_size: int = 1):
+        """Context manager for streaming mode."""
+        self._start_streaming(batch_size)
+        try:
+            yield
+        finally:
+            self._stop_streaming()
+
+    @torch.no_grad()
+    def batch_encode(
+        self, wav_list: list[torch.Tensor], num_quantizers: int | None = None
+    ) -> MossAudioTokenizerEncoderOutput:
+        """Batch encode a list of audio waveforms.
+
+        Args:
+            wav_list: List of audio tensors, each of shape `(num_samples,)`.
+            num_quantizers: Number of quantizers to use. By default, all quantizers are used.
+
+        Returns:
+            [`MossAudioTokenizerEncoderOutput`] with `audio_codes` and `audio_codes_lengths`.
+        """
+        if len(wav_list) == 0:
+            raise ValueError("`wav_list` must contain at least one waveform.")
+
+        device = wav_list[0].device
+        batch_size = len(wav_list)
+
+        max_length = max(wav.shape[-1] for wav in wav_list)
+        input_values = torch.zeros(batch_size, 1, max_length, device=device)
+        input_lengths = torch.zeros(batch_size, device=device, dtype=torch.long)
+
+        for i, wav in enumerate(wav_list):
+            input_values[i, 0, : wav.shape[-1]] = wav
+            input_lengths[i] = wav.shape[-1]
+
+        return self._encode_frame(
+            input_values, input_lengths, n_quantizers=num_quantizers
+        )
+
+    @torch.no_grad()
+    def batch_decode(
+        self, codes_list: list[torch.Tensor], num_quantizers: int | None = None
+    ) -> MossAudioTokenizerDecoderOutput:
+        """Batch decode a list of audio codes.
+
+        Args:
+            codes_list: List of audio code tensors, each of shape `(num_quantizers, codes_length)`.
+            num_quantizers: If provided, decode only the first `num_quantizers` quantizers from each element in
+                `codes_list`. If omitted, all elements in `codes_list` must have the same number of quantizers.
+
+        Returns:
+            [`MossAudioTokenizerDecoderOutput`] with `audio` and `audio_lengths`.
+        """
+        if len(codes_list) == 0:
+            raise ValueError("`codes_list` must contain at least one code tensor.")
+
+        batch_size = len(codes_list)
+        device = codes_list[0].device
+        nqs = [codes.shape[0] for codes in codes_list]
+        if num_quantizers is None:
+            num_quantizers = nqs[0]
+            if any(nq != num_quantizers for nq in nqs):
+                raise ValueError(
+                    "All elements in `codes_list` must have the same number of quantizers when `num_quantizers` is None. "
+                    "Pass `num_quantizers=...` to decode a common prefix."
+                )
+        else:
+            min_nq = min(nqs)
+            if min_nq < num_quantizers:
+                raise ValueError(
+                    "`num_quantizers` must be <= the number of quantizers for every element in `codes_list`. "
+                    f"Got num_quantizers={num_quantizers}, min(codes.shape[0])={min_nq}."
+                )
+        max_length = max(codes.shape[-1] for codes in codes_list)
+
+        audio_codes = torch.zeros(
+            num_quantizers, batch_size, max_length, device=device, dtype=torch.long
+        )
+        audio_codes_lengths = torch.zeros(batch_size, device=device, dtype=torch.long)
+
+        for i, codes in enumerate(codes_list):
+            codes = codes[:num_quantizers]
+            audio_codes[:, i, : codes.shape[-1]] = codes
+            audio_codes_lengths[i] = codes.shape[-1]
+
+        return self._decode_frame(audio_codes, audio_codes_lengths)
+
+    @torch.no_grad()
+    def _encode_frame(
+        self,
+        input_values: torch.Tensor,
+        input_lengths: torch.Tensor | None = None,
+        n_quantizers: int | None = None,
+    ) -> MossAudioTokenizerEncoderOutput:
+        """Tokenize audio waveform into discrete tokens."""
+        # Handle input shape
+        if input_values.dim() == 2:
+            input_values = input_values.unsqueeze(1)
+
+        B, _, T = input_values.shape
+        device = input_values.device
+
+        if input_lengths is None:
+            input_lengths = torch.full((B,), T, device=device, dtype=torch.long)
+
+        # Pad to multiple of downsample_rate
+        if T % self.downsample_rate != 0:
+            pad_length = self.downsample_rate - (T % self.downsample_rate)
+            input_values = F.pad(input_values, (0, pad_length))
+
+        # Encode
+        e, e_lengths = input_values, input_lengths
+        for encoder_module in self.encoder:
+            e, e_lengths = encoder_module(e, e_lengths)
+
+        # Quantize
+        quantizer = cast(
+            MossAudioTokenizerResidualVQ | MossAudioTokenizerResidualLFQ, self.quantizer
+        )
+        zq, audio_codes, audio_codes_lengths = quantizer(e, e_lengths, n_quantizers)
+
+        return MossAudioTokenizerEncoderOutput(
+            audio_codes=audio_codes,
+            audio_codes_lengths=audio_codes_lengths,
+            encoder_hidden_states=e,
+        )
+
+    @torch.no_grad()
+    def _decode_frame(
+        self,
+        codes: torch.Tensor,
+        codes_lengths: torch.Tensor | None = None,
+    ) -> MossAudioTokenizerDecoderOutput:
+        """Detokenize discrete tokens into audio waveform."""
+        nq, B, T = codes.shape
+        device = codes.device
+
+        if codes_lengths is None:
+            codes_lengths = torch.full((B,), T, device=device, dtype=torch.long)
+
+        # Decode from codes
+        quantizer = cast(
+            MossAudioTokenizerResidualVQ | MossAudioTokenizerResidualLFQ, self.quantizer
+        )
+        zq = quantizer.decode_codes(codes)
+
+        d, d_lengths = zq, codes_lengths
+        for decoder_module in self.decoder:
+            d, d_lengths = decoder_module(d, d_lengths)
+
+        return MossAudioTokenizerDecoderOutput(audio=d, audio_lengths=d_lengths)
+
+    def encode(  # type: ignore[override]
+        self,
+        input_values: torch.Tensor,
+        padding_mask: torch.Tensor | None = None,
+        num_quantizers: int | None = None,
+        return_dict: bool | None = None,
+        chunk_duration: float | None = None,
+    ):
+        """
+        Encodes the input audio waveform into discrete codes.
+
+        Args:
+            input_values (`torch.Tensor` of shape `(batch_size, channels, sequence_length)`):
+                Float values of the input audio waveform.
+            padding_mask (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
+                Mask to indicate valid audio samples.
+            num_quantizers (`int`, *optional*):
+                Number of quantizers to use. By default, all quantizers are used.
+            return_dict (`bool`, *optional*):
+                Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
+            chunk_duration (`float`, *optional*):
+                If provided, encode the input waveform in successive chunks of `chunk_duration` seconds while keeping a
+                streaming KV cache for the causal transformers.
+
+                `chunk_duration` must be <= `config.causal_transformer_context_duration`, and
+                `chunk_duration * config.sampling_rate` must be divisible by `config.downsample_rate`.
+
+        Returns:
+            `MossAudioTokenizerEncoderOutput` or tuple containing audio codes and lengths.
+        """
+        return_dict = (
+            return_dict if return_dict is not None else self.config.return_dict
+        )
+
+        # Handle input shape
+        if input_values.dim() == 2:
+            input_values = input_values.unsqueeze(1)
+
+        B, _, T = input_values.shape
+        device = input_values.device
+
+        if padding_mask is not None:
+            input_lengths = padding_mask.sum(dim=-1).long()
+        else:
+            input_lengths = torch.full((B,), T, device=device, dtype=torch.long)
+
+        if chunk_duration is None:
+            encoder_output = self._encode_frame(
+                input_values, input_lengths, num_quantizers
+            )
+        else:
+            if chunk_duration <= 0:
+                raise ValueError("`chunk_duration` must be > 0 when provided.")
+            if chunk_duration > self.causal_transformer_context_duration:
+                raise ValueError(
+                    "`chunk_duration` must be <= `config.causal_transformer_context_duration` "
+                    f"({self.causal_transformer_context_duration}), got {chunk_duration}."
+                )
+            if B != 1:
+                raise ValueError(
+                    "Streaming encode via `chunk_duration` currently only supports batch_size=1."
+                )
+
+            chunk_length = int(round(chunk_duration * self.sampling_rate))
+            if chunk_length <= 0:
+                raise ValueError(
+                    "`chunk_duration` is too small and results in chunk_length <= 0."
+                )
+            if chunk_length % self.downsample_rate != 0:
+                raise ValueError(
+                    "`chunk_duration * config.sampling_rate` must be divisible by `config.downsample_rate`. "
+                    f"Got chunk_length={chunk_length}, downsample_rate={self.downsample_rate}."
+                )
+
+            input_length = int(input_lengths[0].item())
+            if input_length <= chunk_length:
+                encoder_output = self._encode_frame(
+                    input_values[..., :input_length], input_lengths, num_quantizers
+                )
+            else:
+                codes_chunks: list[torch.Tensor] = []
+                hidden_chunks: list[torch.Tensor] = []
+
+                with ExitStack() as exit_stack:
+                    for encoder_module in self.encoder:
+                        if isinstance(encoder_module, StreamingModule):
+                            exit_stack.enter_context(
+                                encoder_module.streaming(batch_size=B)
+                            )
+
+                    for start_idx in range(0, input_length, chunk_length):
+                        input_length_i = min(chunk_length, input_length - start_idx)
+                        if input_length_i <= 0:
+                            break
+
+                        input_lengths_i = torch.tensor(
+                            [input_length_i], device=device, dtype=torch.long
+                        )
+                        input_values_i = input_values[
+                            ..., start_idx : start_idx + input_length_i
+                        ]
+                        result_i = self._encode_frame(
+                            input_values_i, input_lengths_i, num_quantizers
+                        )
+
+                        if (
+                            result_i.audio_codes is None
+                            or result_i.audio_codes_lengths is None
+                        ):
+                            raise RuntimeError(
+                                "Internal error: `_encode_frame` returned empty audio codes."
+                            )
+                        if result_i.encoder_hidden_states is None:
+                            raise RuntimeError(
+                                "Internal error: `_encode_frame` returned empty encoder hidden states."
+                            )
+
+                        codes_length_i = result_i.audio_codes_lengths
+                        codes_chunks.append(
+                            result_i.audio_codes[:, :, : codes_length_i[0]]
+                        )
+                        hidden_chunks.append(
+                            result_i.encoder_hidden_states[:, :, : codes_length_i[0]]
+                        )
+
+                audio_codes = torch.cat(codes_chunks, dim=-1)
+                encoder_hidden_states = torch.cat(hidden_chunks, dim=-1)
+                audio_codes_lengths = torch.tensor(
+                    [audio_codes.shape[-1]], device=device, dtype=torch.long
+                )
+                encoder_output = MossAudioTokenizerEncoderOutput(
+                    audio_codes=audio_codes,
+                    audio_codes_lengths=audio_codes_lengths,
+                    encoder_hidden_states=encoder_hidden_states,
+                )
+
+        if not return_dict:
+            assert encoder_output.audio_codes is not None
+            assert encoder_output.audio_codes_lengths is not None
+            return (
+                cast(torch.Tensor, encoder_output.audio_codes),
+                cast(torch.Tensor, encoder_output.audio_codes_lengths),
+            )
+        return encoder_output
+
+    def decode(  # type: ignore[override]
+        self,
+        audio_codes: torch.Tensor,
+        padding_mask: torch.Tensor | None = None,
+        return_dict: bool | None = None,
+        chunk_duration: float | None = None,
+        num_quantizers: int | None = None,
+    ):
+        """
+        Decodes the given codes into an output audio waveform.
+
+        Args:
+            audio_codes (`torch.LongTensor` of shape `(num_quantizers, batch_size, sequence_length)`):
+                Discrete code embeddings computed using `model.encode`.
+            padding_mask (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
+                Mask to indicate valid code positions.
+            return_dict (`bool`, *optional*):
+                Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
+            chunk_duration (`float`, *optional*):
+                If provided, decode the input codes in successive chunks of `chunk_duration` seconds while keeping a
+                streaming KV cache for the causal transformers.
+
+            num_quantizers (`int`, *optional*):
+                Number of quantizers to use. By default, all quantizers in `audio_codes` are used.
+
+                `chunk_duration` must be <= `config.causal_transformer_context_duration`, and
+                `chunk_duration * config.sampling_rate` must be divisible by `config.downsample_rate`.
+
+        Returns:
+            `MossAudioTokenizerDecoderOutput` or tuple containing decoded audio.
+        """
+        return_dict = (
+            return_dict if return_dict is not None else self.config.return_dict
+        )
+
+        if audio_codes.dim() == 2:
+            audio_codes = audio_codes.unsqueeze(1)  # nq, T -> nq, B=1, T
+
+        if num_quantizers is not None:
+            if num_quantizers > audio_codes.shape[0]:
+                raise ValueError(
+                    f"`num_quantizers` ({num_quantizers}) must be <= audio_codes.shape[0] ({audio_codes.shape[0]})."
+                )
+            audio_codes = audio_codes[:num_quantizers]
+
+        _, B, T = audio_codes.shape
+        device = audio_codes.device
+
+        if padding_mask is not None:
+            codes_lengths = padding_mask.sum(dim=-1).long()
+        else:
+            codes_lengths = torch.full((B,), T, device=device, dtype=torch.long)
+
+        if chunk_duration is None:
+            decoder_output = self._decode_frame(audio_codes, codes_lengths)
+        else:
+            if chunk_duration <= 0:
+                raise ValueError("`chunk_duration` must be > 0 when provided.")
+            if chunk_duration > self.causal_transformer_context_duration:
+                raise ValueError(
+                    "`chunk_duration` must be <= `config.causal_transformer_context_duration` "
+                    f"({self.causal_transformer_context_duration}), got {chunk_duration}."
+                )
+            if B != 1:
+                raise ValueError(
+                    "Streaming decode via `chunk_duration` currently only supports batch_size=1."
+                )
+
+            chunk_length = int(round(chunk_duration * self.sampling_rate))
+            if chunk_length <= 0:
+                raise ValueError(
+                    "`chunk_duration` is too small and results in chunk_length <= 0."
+                )
+            if chunk_length % self.downsample_rate != 0:
+                raise ValueError(
+                    "`chunk_duration * config.sampling_rate` must be divisible by `config.downsample_rate`. "
+                    f"Got chunk_length={chunk_length}, downsample_rate={self.downsample_rate}."
+                )
+
+            chunk_frame_length = chunk_length // self.downsample_rate
+            codes_length = int(codes_lengths[0].item())
+            if codes_length <= chunk_frame_length:
+                decoder_output = self._decode_frame(
+                    audio_codes[..., :codes_length], codes_lengths
+                )
+            else:
+                wav_chunks: list[torch.Tensor] = []
+                with ExitStack() as exit_stack:
+                    for decoder_module in self.decoder:
+                        if isinstance(decoder_module, StreamingModule):
+                            exit_stack.enter_context(
+                                decoder_module.streaming(batch_size=B)
+                            )
+
+                    for start_idx in range(0, codes_length, chunk_frame_length):
+                        codes_length_i = min(
+                            chunk_frame_length, codes_length - start_idx
+                        )
+                        if codes_length_i <= 0:
+                            break
+
+                        codes_lengths_i = torch.tensor(
+                            [codes_length_i], device=device, dtype=torch.long
+                        )
+                        codes_i = audio_codes[
+                            :, :, start_idx : start_idx + codes_length_i
+                        ]
+                        result_i = self._decode_frame(codes_i, codes_lengths_i)
+
+                        if result_i.audio is None or result_i.audio_lengths is None:
+                            raise RuntimeError(
+                                "Internal error: `_decode_frame` returned empty audio."
+                            )
+
+                        wav_chunks.append(
+                            result_i.audio[:, :, : result_i.audio_lengths[0]]
+                        )
+
+                wav = torch.cat(wav_chunks, dim=-1)
+                audio_lengths = torch.tensor(
+                    [wav.shape[-1]], device=device, dtype=torch.long
+                )
+                decoder_output = MossAudioTokenizerDecoderOutput(
+                    audio=wav, audio_lengths=audio_lengths
+                )
+
+        if not return_dict:
+            assert decoder_output.audio is not None
+            return (cast(torch.Tensor, decoder_output.audio),)
+        return decoder_output
+
+    def forward(
+        self,
+        input_values: torch.FloatTensor | None = None,
+        padding_mask: torch.BoolTensor | None = None,
+        audio_codes: torch.Tensor | None = None,
+        num_quantizers: int | None = None,
+        return_dict: bool | None = None,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None] | MossAudioTokenizerOutput:  # type: ignore[override]
+        r"""
+        input_values (`torch.FloatTensor` of shape `(batch_size, channels, sequence_length)`, *optional*):
+            Raw audio input converted to Float.
+        padding_mask (`torch.BoolTensor` of shape `(batch_size, sequence_length)`, *optional*):
+            Mask to avoid computing on padding token indices. Mask values selected in `[0, 1]`:
+            - 1 for tokens that are **not masked**,
+            - 0 for tokens that are **masked**.
+        audio_codes (`torch.LongTensor` of shape `(num_quantizers, batch_size, sequence_length)`, *optional*):
+            Discrete code embeddings computed using `model.encode`.
+        num_quantizers (`int`, *optional*):
+            Number of quantizers (codebooks) to use. By default, all quantizers are used.
+        return_dict (`bool`, *optional*):
+            Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
+
+        Examples:
+
+        ```python
+        >>> import torch
+        >>> from transformers import MossAudioTokenizerModel
+
+        >>> model = MossAudioTokenizerModel.from_pretrained("moss_audio_tokenizer-model")
+
+        >>> # Create dummy audio input
+        >>> audio = torch.randn(1, 1, 24000)  # 1 second of audio at 24kHz
+
+        >>> outputs = model(input_values=audio)
+        >>> audio_codes = outputs.audio_codes
+        >>> audio_values = outputs.audio
+        ```
+        """
+        return_dict = (
+            return_dict if return_dict is not None else self.config.return_dict
+        )
+
+        output_audio_codes: torch.Tensor | None = None
+        output_audio_codes_lengths: torch.Tensor | None = None
+        output_audio: torch.Tensor | None = None
+        output_audio_lengths: torch.Tensor | None = None
+        decoded_from_encoded_codes = False
+
+        # Encode if input_values provided
+        if input_values is not None:
+            encoder_output = self.encode(
+                input_values, padding_mask, num_quantizers, return_dict=True
+            )
+            encoder_output = cast(MossAudioTokenizerEncoderOutput, encoder_output)
+            output_audio_codes = encoder_output.audio_codes
+            output_audio_codes_lengths = encoder_output.audio_codes_lengths
+
+            # If codes not provided separately, use encoded codes for decoding
+            if audio_codes is None:
+                audio_codes = output_audio_codes
+                decoded_from_encoded_codes = True
+
+        # Decode if codes available
+        if audio_codes is not None:
+            # If we're decoding the codes we just produced, use the computed lengths so we don't decode padded garbage.
+            if decoded_from_encoded_codes and output_audio_codes_lengths is not None:
+                decoder_output = self._decode_frame(
+                    audio_codes, output_audio_codes_lengths
+                )
+            else:
+                decoder_output = self.decode(
+                    audio_codes,
+                    padding_mask=padding_mask,
+                    return_dict=True,
+                    num_quantizers=num_quantizers,
+                )
+                decoder_output = cast(MossAudioTokenizerDecoderOutput, decoder_output)
+            output_audio = decoder_output.audio
+            output_audio_lengths = decoder_output.audio_lengths
+
+        if not return_dict:
+            return (output_audio_codes, output_audio, output_audio_lengths)
+
+        return MossAudioTokenizerOutput(
+            audio=output_audio,
+            audio_lengths=output_audio_lengths,
+            audio_codes=output_audio_codes,
+            audio_codes_lengths=output_audio_codes_lengths,
+        )
+
+
+__all__ = ["MossAudioTokenizerModel", "MossAudioTokenizerPreTrainedModel"]

--- a/sglang_omni/models/moss_tts/request_builders.py
+++ b/sglang_omni/models/moss_tts/request_builders.py
@@ -109,6 +109,7 @@ class MossTTSPreparedRequest:
 @dataclass
 class MossTTSPreprocessingContext:
     processor: Any
+    audio_tokenizer: Any | None = None
 
 
 _PREPROCESSING_CONTEXT: MossTTSPreprocessingContext | None = None
@@ -121,12 +122,19 @@ _ABORTED_REQUESTS: set[str] = set()
 _PREPARED_REQUESTS_LOCK = threading.Lock()
 
 
-def set_moss_tts_preprocessing_context(*, processor: Any) -> None:
+def set_moss_tts_preprocessing_context(
+    *,
+    processor: Any,
+    audio_tokenizer: Any | None = None,
+) -> None:
     """Register the upstream MOSS processor used by preprocessing."""
 
     global _PREPROCESSING_CONTEXT
     with _PREPARED_REQUESTS_LOCK:
-        _PREPROCESSING_CONTEXT = MossTTSPreprocessingContext(processor=processor)
+        _PREPROCESSING_CONTEXT = MossTTSPreprocessingContext(
+            processor=processor,
+            audio_tokenizer=audio_tokenizer,
+        )
         _PREPARED_REQUESTS.clear()
         _INFLIGHT_REQUESTS.clear()
         _ABORTED_REQUESTS.clear()
@@ -398,14 +406,36 @@ def build_row_cache_key_ids(rows: torch.Tensor) -> list[int]:
     return key_ids
 
 
-def _reference_for_processor(processor: Any, ref_audio: Any | None) -> list[Any] | None:
+def _reference_for_processor(
+    processor: Any,
+    ref_audio: Any | None,
+    *,
+    audio_tokenizer: Any | None = None,
+) -> list[Any] | None:
+    del processor
     if ref_audio is None:
         return None
     if not isinstance(ref_audio, str):
         return [ref_audio]
     match = _DATA_URI_RE.match(ref_audio)
     if match is None:
-        return [ref_audio]
+        if audio_tokenizer is None:
+            raise RuntimeError(
+                "MOSS-TTS reference audio requires an initialized audio tokenizer"
+            )
+        return [audio_tokenizer.encode_paths([ref_audio])[0]]
+
+    if audio_tokenizer is None:
+        raise RuntimeError(
+            "MOSS-TTS data URI reference audio requires an initialized audio tokenizer"
+        )
+
+    try:
+        encode_data_uri = audio_tokenizer.encode_data_uri
+    except AttributeError:
+        encode_data_uri = None
+    if encode_data_uri is not None:
+        return [encode_data_uri(ref_audio)]
 
     try:
         import soundfile as sf
@@ -417,12 +447,20 @@ def _reference_for_processor(processor: Any, ref_audio: Any | None) -> list[Any]
     raw = base64.b64decode(match.group("data"))
     audio, sample_rate = sf.read(io.BytesIO(raw), dtype="float32", always_2d=True)
     wav = torch.from_numpy(audio.T)
-    codes = processor.encode_audios_from_wav([wav], int(sample_rate))[0]
-    return [codes]
+    return [audio_tokenizer.encode_wavs([wav], int(sample_rate))[0]]
 
 
-def _build_processor_message(processor: Any, state: MossTTSState) -> dict[str, Any]:
-    reference = _reference_for_processor(processor, state.ref_audio)
+def _build_processor_message(
+    processor: Any,
+    state: MossTTSState,
+    *,
+    audio_tokenizer: Any | None = None,
+) -> dict[str, Any]:
+    reference = _reference_for_processor(
+        processor,
+        state.ref_audio,
+        audio_tokenizer=audio_tokenizer,
+    )
     return processor.build_user_message(
         text=state.text,
         reference=reference,
@@ -436,9 +474,14 @@ def _prepare_moss_tts_request(
     payload: StagePayload,
     *,
     processor: Any,
+    audio_tokenizer: Any | None = None,
 ) -> MossTTSPreparedRequest:
     state = build_moss_tts_state(payload)
-    message = _build_processor_message(processor, state)
+    message = _build_processor_message(
+        processor,
+        state,
+        audio_tokenizer=audio_tokenizer,
+    )
     batch = processor([[message]], mode="generation")
     input_rows = batch["input_ids"]
     if input_rows.ndim != 3 or int(input_rows.shape[0]) != 1:
@@ -471,7 +514,11 @@ def preprocess_moss_tts_payload(payload: StagePayload) -> StagePayload:
         )
 
     try:
-        prepared = _prepare_moss_tts_request(payload, processor=context.processor)
+        prepared = _prepare_moss_tts_request(
+            payload,
+            processor=context.processor,
+            audio_tokenizer=context.audio_tokenizer,
+        )
     except BaseException:
         with _PREPARED_REQUESTS_LOCK:
             _INFLIGHT_REQUESTS.discard(rid)

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -93,18 +93,25 @@ def _load_moss_processor(
     return processor
 
 
+def _resolve_preprocessing_device(device: str) -> str:
+    if str(device).startswith("cuda") and not torch.cuda.is_available():
+        logger.warning(
+            "CUDA is unavailable; loading MOSS-TTS preprocessing processor on CPU"
+        )
+        return "cpu"
+    return device
+
+
 def create_preprocessing_executor(
-    model_path: str, *, max_concurrency: int = 8
+    model_path: str,
+    *,
+    max_concurrency: int = 8,
+    device: str = "cuda:0",
+    dtype: str = "float32",
 ) -> SimpleScheduler:
-    processor = _load_moss_processor(model_path, device="cpu", dtype="float32")
+    device = _resolve_preprocessing_device(device)
+    processor = _load_moss_processor(model_path, device=device, dtype=dtype)
     set_moss_tts_preprocessing_context(processor=processor)
-    # Preprocessing is CPU-heavy: every request tokenizes text and encodes the
-    # reference audio through the MOSS audio tokenizer. Serial execution
-    # (max_concurrency=1) lets the codec encode dominate wall-clock and starves
-    # the AR engine to batch size 1 (the dominant RTF cost). Run several in
-    # parallel — threads release the GIL during the torch codec forward — so the
-    # AR OmniScheduler receives a steady, batchable request stream. Mirrors the
-    # fishaudio_s2_pro preprocessing stage, which encodes references the same way.
     return SimpleScheduler(
         preprocess_moss_tts_payload,
         abort_callback=cleanup_prepared_moss_tts_request,

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -8,6 +8,10 @@ from typing import Any
 
 import torch
 
+from sglang_omni.models.moss_tts.audio_tokenizer import (
+    DEFAULT_MOSS_AUDIO_TOKENIZER,
+    load_moss_audio_tokenizer,
+)
 from sglang_omni.models.moss_tts.codec import split_moss_audio_segments
 from sglang_omni.models.moss_tts.hf_loading import (
     load_moss_processor_class,
@@ -34,9 +38,10 @@ from sglang_omni.utils.audio_payload import audio_waveform_payload
 logger = logging.getLogger(__name__)
 
 _MOSS_TTS_INSTALL_HINT = (
-    "MOSS-TTS support requires the upstream custom Transformers code. "
-    "Launch with trust_remote_code=True and make sure the checkpoint can load "
-    "OpenMOSS-Team/MOSS-Audio-Tokenizer."
+    "MOSS-TTS processor support requires the upstream custom Transformers code. "
+    "Launch the MOSS-TTS checkpoint with trust_remote_code=True. The codec "
+    "model implementation is local; make sure the codec config and safetensors "
+    "artifacts are available."
 )
 
 
@@ -52,8 +57,7 @@ def _torch_dtype(dtype: str | torch.dtype) -> torch.dtype:
     return getattr(torch, dtype) if isinstance(dtype, str) else dtype
 
 
-def _normalize_moss_processor_config(processor: Any) -> None:
-    model_config = getattr(processor, "model_config", None)
+def _normalize_moss_model_config(model_config: Any) -> None:
     if model_config is None:
         return
     audio_vocab_size = int(getattr(model_config, "audio_vocab_size", 1024) or 1024)
@@ -62,42 +66,61 @@ def _normalize_moss_processor_config(processor: Any) -> None:
             setattr(model_config, attr, default)
 
 
+def _normalize_moss_processor_config(processor: Any) -> None:
+    model_config = getattr(processor, "model_config", None)
+    _normalize_moss_model_config(model_config)
+
+
+def _load_moss_model_config(model_path: str) -> Any:
+    from transformers import AutoConfig
+
+    checkpoint_dir = resolve_moss_checkpoint(model_path)
+    with moss_transformers_processor_compat():
+        model_config = AutoConfig.from_pretrained(
+            checkpoint_dir,
+            trust_remote_code=True,
+        )
+    _normalize_moss_model_config(model_config)
+    return model_config
+
+
 def _load_moss_processor(
     model_path: str,
     *,
-    device: str = "cpu",
-    dtype: str | torch.dtype = "float32",
+    device: str | None = None,
+    dtype: str | torch.dtype | None = None,
 ) -> Any:
+    del device, dtype
     checkpoint_dir = resolve_moss_checkpoint(model_path)
-    logger.info(f"Loading MOSS-TTS processor from {checkpoint_dir} on {device}")
+    logger.info("Loading MOSS-TTS processor from %s without codec", checkpoint_dir)
     try:
+        from transformers import AutoConfig, AutoTokenizer
+
         with moss_transformers_processor_compat():
             processor_cls = load_moss_processor_class(checkpoint_dir)
-            processor = processor_cls.from_pretrained(
+            model_config = AutoConfig.from_pretrained(
                 checkpoint_dir,
                 trust_remote_code=True,
+            )
+            tokenizer = AutoTokenizer.from_pretrained(
+                checkpoint_dir,
+                trust_remote_code=True,
+            )
+            processor = processor_cls(
+                tokenizer=tokenizer,
+                audio_tokenizer=None,
+                model_config=model_config,
             )
     except Exception as exc:
         raise RuntimeError(_MOSS_TTS_INSTALL_HINT) from exc
 
     _normalize_moss_processor_config(processor)
-    audio_tokenizer = getattr(processor, "audio_tokenizer", None)
-    if audio_tokenizer is not None:
-        if hasattr(audio_tokenizer, "eval"):
-            audio_tokenizer.eval()
-        if hasattr(audio_tokenizer, "to"):
-            kwargs: dict[str, Any] = {"device": device}
-            if device != "cpu":
-                kwargs["dtype"] = _torch_dtype(dtype)
-            audio_tokenizer.to(**kwargs)
     return processor
 
 
-def _resolve_preprocessing_device(device: str) -> str:
+def _resolve_codec_device(device: str) -> str:
     if str(device).startswith("cuda") and not torch.cuda.is_available():
-        logger.warning(
-            "CUDA is unavailable; loading MOSS-TTS preprocessing processor on CPU"
-        )
+        logger.warning("CUDA is unavailable; loading MOSS audio tokenizer on CPU")
         return "cpu"
     return device
 
@@ -106,12 +129,24 @@ def create_preprocessing_executor(
     model_path: str,
     *,
     max_concurrency: int = 8,
+    codec_model_path: str = DEFAULT_MOSS_AUDIO_TOKENIZER,
     device: str = "cuda:0",
     dtype: str = "float32",
 ) -> SimpleScheduler:
-    device = _resolve_preprocessing_device(device)
-    processor = _load_moss_processor(model_path, device=device, dtype=dtype)
-    set_moss_tts_preprocessing_context(processor=processor)
+    processor = _load_moss_processor(model_path)
+    device = _resolve_codec_device(device)
+    audio_tokenizer = load_moss_audio_tokenizer(
+        codec_model_path,
+        device=device,
+        dtype=dtype,
+    )
+    set_moss_tts_preprocessing_context(
+        processor=processor,
+        audio_tokenizer=audio_tokenizer,
+    )
+    # Preprocessing tokenizes text and encodes reference audio through the MOSS
+    # audio tokenizer. Run several in parallel so the AR OmniScheduler receives
+    # a steady, batchable request stream.
     return SimpleScheduler(
         preprocess_moss_tts_payload,
         abort_callback=cleanup_prepared_moss_tts_request,
@@ -143,8 +178,9 @@ def create_tts_engine_executor(*args, **kwargs) -> Any:
 
 
 class _MossTTSVocoder(BatchVocoderBase):
-    def __init__(self, processor: Any, device: str) -> None:
-        self._processor = processor
+    def __init__(self, model_config: Any, audio_tokenizer: Any, device: str) -> None:
+        self._model_config = model_config
+        self._audio_tokenizer = audio_tokenizer
         self._device = device
 
     def prepare_item(self, payload: StagePayload) -> tuple[MossTTSState, torch.Tensor]:
@@ -162,21 +198,13 @@ class _MossTTSVocoder(BatchVocoderBase):
         delayed_codes: torch.Tensor,
     ) -> tuple[torch.Tensor, int]:
         delayed_codes = delayed_codes.to(device=self._device, dtype=torch.long)
-        audio_pad_code = int(
-            getattr(
-                getattr(self._processor, "model_config", None),
-                "audio_pad_code",
-                1024,
-            )
-        )
+        audio_pad_code = int(getattr(self._model_config, "audio_pad_code", 1024))
         segments = split_moss_audio_segments(
             delayed_codes,
             audio_pad_code=audio_pad_code,
             assistant_start_length=int(state.assistant_start_length),
         )
-        decoded = []
-        for segment in segments:
-            decoded.extend(self._processor.decode_audio_codes([segment]))
+        decoded = self._audio_tokenizer.decode_codes(segments)
         if not decoded:
             raise RuntimeError("MOSS-TTS vocoder decoded no audio segments")
         waveforms = [
@@ -184,14 +212,8 @@ class _MossTTSVocoder(BatchVocoderBase):
         ]
         waveform = torch.cat(waveforms, dim=0)
         sample_rate = int(
-            getattr(getattr(self._processor, "model_config", None), "sampling_rate", 0)
-            or getattr(
-                getattr(
-                    getattr(self._processor, "audio_tokenizer", None), "config", None
-                ),
-                "sampling_rate",
-                0,
-            )
+            getattr(self._audio_tokenizer, "sample_rate", 0)
+            or getattr(self._model_config, "sampling_rate", 0)
             or state.sample_rate
             or 24000
         )
@@ -227,15 +249,22 @@ def create_vocoder_executor(
     *,
     device: str = "cuda:0",
     gpu_id: int | None = None,
+    codec_model_path: str = DEFAULT_MOSS_AUDIO_TOKENIZER,
     dtype: str = "float32",
     max_batch_size: int = 8,
     max_batch_wait_ms: int = 2,
 ) -> SimpleScheduler:
     if gpu_id is not None:
         device = f"cuda:{gpu_id}"
-    processor = _load_moss_processor(model_path, device=device, dtype=dtype)
+    device = _resolve_codec_device(device)
+    model_config = _load_moss_model_config(model_path)
+    audio_tokenizer = load_moss_audio_tokenizer(
+        codec_model_path,
+        device=device,
+        dtype=dtype,
+    )
 
-    return _MossTTSVocoder(processor, device).build_scheduler(
+    return _MossTTSVocoder(model_config, audio_tokenizer, device).build_scheduler(
         max_batch_size=max_batch_size,
         max_batch_wait_ms=max_batch_wait_ms,
     )

--- a/tests/README.md
+++ b/tests/README.md
@@ -378,6 +378,8 @@ that happened to contain an older version of the test.
 
 - `unit_test/moss_tts/`: MOSS-TTS unit tests:
   - pipeline config and registry contracts
+  - explicit audio-tokenizer codec ownership, local modeling, artifact-only checkpoint
+    resolution, placement, and CPU fallback contracts
   - OmniScheduler-backed AR/vocoder stage factory wiring
   - request mapping for `ref_audio`, `references`, and `token_count`
   - preprocessing handoff and abort cleanup behavior

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -127,6 +127,10 @@ def test_moss_tts_config_and_registry_contracts() -> None:
     assert config.terminal_stages == ["vocoder"]
     assert config.gpu_placement == {"tts_engine": 0, "vocoder": 0}
     assert {stage.process for stage in config.stages} == {"pipeline"}
+    preprocessing = next(
+        stage for stage in config.stages if stage.name == "preprocessing"
+    )
+    assert preprocessing.factory_args == {"device": "cuda:0", "dtype": "float32"}
     assert config.supports_uploaded_voice_references() is True
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config("MossTTSDelayModel")
@@ -138,6 +142,31 @@ def test_moss_tts_config_and_registry_contracts() -> None:
     assert MossTTSPipelineConfig.talker_sglang_role_to_stage() == {
         "talker": "tts_engine"
     }
+
+
+def test_moss_preprocessing_executor_prefers_gpu_with_cpu_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    captured: list[tuple[str, str]] = []
+
+    def fake_load_processor(model_path, *, device, dtype):
+        assert model_path == "ckpt"
+        captured.append((device, dtype))
+        return object()
+
+    monkeypatch.setattr(stages, "_load_moss_processor", fake_load_processor)
+    try:
+        monkeypatch.setattr(stages.torch.cuda, "is_available", lambda: True)
+        stages.create_preprocessing_executor("ckpt")
+        assert captured[-1] == ("cuda:0", "float32")
+
+        monkeypatch.setattr(stages.torch.cuda, "is_available", lambda: False)
+        stages.create_preprocessing_executor("ckpt", device="cuda:1", dtype="bfloat16")
+        assert captured[-1] == ("cpu", "bfloat16")
+    finally:
+        clear_moss_tts_preprocessing_context()
 
 
 def test_moss_tts_engine_uses_auto_mem_fraction_by_default(monkeypatch) -> None:

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -19,6 +19,7 @@ from benchmarks.tasks.tts import (
     _handle_raw_pcm_streaming_response,
     estimate_moss_tts_duration_tokens,
 )
+from sglang_omni.config import build_stage_placement_plan
 from sglang_omni.models.moss_tts.codec import split_moss_audio_segments
 from sglang_omni.models.moss_tts.config import MossTTSPipelineConfig
 from sglang_omni.models.moss_tts.payload_types import MossTTSState
@@ -125,12 +126,20 @@ def test_moss_tts_config_and_registry_contracts() -> None:
         "vocoder",
     ]
     assert config.terminal_stages == ["vocoder"]
-    assert config.gpu_placement == {"tts_engine": 0, "vocoder": 0}
+    assert config.gpu_placement == {"preprocessing": 0, "tts_engine": 0, "vocoder": 0}
     assert {stage.process for stage in config.stages} == {"pipeline"}
-    preprocessing = next(
-        stage for stage in config.stages if stage.name == "preprocessing"
+    stages = {stage.name: stage for stage in config.stages}
+    assert stages["preprocessing"].factory_args == {
+        "codec_model_path": "OpenMOSS-Team/MOSS-Audio-Tokenizer",
+        "device": "cuda:0",
+        "dtype": "float32",
+    }
+    assert stages["vocoder"].factory_args["codec_model_path"] == (
+        "OpenMOSS-Team/MOSS-Audio-Tokenizer"
     )
-    assert preprocessing.factory_args == {"device": "cuda:0", "dtype": "float32"}
+    assert "gpu_id" not in stages["vocoder"].factory_args
+    placement = build_stage_placement_plan(config)
+    assert placement.stages["preprocessing"].gpu_ids == (0,)
     assert config.supports_uploaded_voice_references() is True
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config("MossTTSDelayModel")
@@ -144,29 +153,138 @@ def test_moss_tts_config_and_registry_contracts() -> None:
     }
 
 
-def test_moss_preprocessing_executor_prefers_gpu_with_cpu_fallback(
+def test_moss_preprocessing_executor_loads_owned_codec_with_cpu_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from sglang_omni.models.moss_tts import request_builders as rb
     from sglang_omni.models.moss_tts import stages
 
-    captured: list[tuple[str, str]] = []
+    captured: list[tuple[str, str, str]] = []
 
-    def fake_load_processor(model_path, *, device, dtype):
+    class FakeCodec:
+        sample_rate = 24000
+
+    def fake_load_processor(model_path):
         assert model_path == "ckpt"
-        captured.append((device, dtype))
         return object()
 
+    def fake_load_codec(codec_model_path, *, device, dtype):
+        captured.append((codec_model_path, device, dtype))
+        return FakeCodec()
+
     monkeypatch.setattr(stages, "_load_moss_processor", fake_load_processor)
+    monkeypatch.setattr(stages, "load_moss_audio_tokenizer", fake_load_codec)
     try:
         monkeypatch.setattr(stages.torch.cuda, "is_available", lambda: True)
         stages.create_preprocessing_executor("ckpt")
-        assert captured[-1] == ("cuda:0", "float32")
+        assert captured[-1] == (
+            "OpenMOSS-Team/MOSS-Audio-Tokenizer",
+            "cuda:0",
+            "float32",
+        )
+        assert rb._PREPROCESSING_CONTEXT.audio_tokenizer.sample_rate == 24000
 
         monkeypatch.setattr(stages.torch.cuda, "is_available", lambda: False)
-        stages.create_preprocessing_executor("ckpt", device="cuda:1", dtype="bfloat16")
-        assert captured[-1] == ("cpu", "bfloat16")
+        stages.create_preprocessing_executor(
+            "ckpt",
+            codec_model_path="codec-local",
+            device="cuda:1",
+            dtype="bfloat16",
+        )
+        assert captured[-1] == ("codec-local", "cpu", "bfloat16")
     finally:
         clear_moss_tts_preprocessing_context()
+
+
+def test_moss_audio_tokenizer_resolves_only_config_and_weight_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.moss_tts import audio_tokenizer
+
+    captured: dict[str, object] = {}
+    fake_hf = types.ModuleType("huggingface_hub")
+
+    def fake_snapshot_download(repo_id, **kwargs):
+        captured["repo_id"] = repo_id
+        captured.update(kwargs)
+        return "/tmp/moss-codec"
+
+    fake_hf.snapshot_download = fake_snapshot_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hf)
+
+    assert audio_tokenizer._resolve_checkpoint(
+        "OpenMOSS-Team/MOSS-Audio-Tokenizer"
+    ) == ("/tmp/moss-codec")
+    assert captured["repo_id"] == "OpenMOSS-Team/MOSS-Audio-Tokenizer"
+    assert captured["allow_patterns"] == (
+        "config.json",
+        "*.safetensors",
+        "*.safetensors.index.json",
+    )
+
+
+def test_moss_audio_tokenizer_loads_local_modeling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.moss_tts import audio_tokenizer
+    from sglang_omni.models.moss_tts.configuration_moss_audio_tokenizer import (
+        MossAudioTokenizerConfig,
+    )
+    from sglang_omni.models.moss_tts.modeling_moss_audio_tokenizer import (
+        MossAudioTokenizerModel,
+    )
+
+    captured: dict[str, object] = {}
+
+    class FakeConfig:
+        sampling_rate = 24000
+        quantizer_kwargs = {"num_quantizers": 32}
+
+    class FakeModel:
+        config = FakeConfig()
+
+        def eval(self):
+            captured["eval"] = True
+
+        def to(self, **kwargs):
+            captured["to"] = kwargs
+
+    def fake_config_from_pretrained(cls, checkpoint_dir):
+        del cls
+        captured["config_checkpoint_dir"] = checkpoint_dir
+        return FakeConfig()
+
+    def fake_model_from_pretrained(cls, checkpoint_dir, **kwargs):
+        del cls
+        captured["model_checkpoint_dir"] = checkpoint_dir
+        captured["model_kwargs"] = kwargs
+        return FakeModel()
+
+    monkeypatch.setattr(audio_tokenizer, "_resolve_checkpoint", lambda _: "/tmp/codec")
+    monkeypatch.setattr(
+        MossAudioTokenizerConfig,
+        "from_pretrained",
+        classmethod(fake_config_from_pretrained),
+    )
+    monkeypatch.setattr(
+        MossAudioTokenizerModel,
+        "from_pretrained",
+        classmethod(fake_model_from_pretrained),
+    )
+
+    tokenizer = audio_tokenizer.load_moss_audio_tokenizer(
+        "OpenMOSS-Team/MOSS-Audio-Tokenizer",
+        device="cpu",
+        dtype="float32",
+    )
+
+    assert tokenizer.checkpoint_dir == "/tmp/codec"
+    assert captured["config_checkpoint_dir"] == "/tmp/codec"
+    assert captured["model_checkpoint_dir"] == "/tmp/codec"
+    assert captured["model_kwargs"]["local_files_only"] is True
+    assert "trust_remote_code" not in captured["model_kwargs"]
+    assert captured["eval"] is True
+    assert captured["to"] == {"device": "cpu"}
 
 
 def test_moss_tts_engine_uses_auto_mem_fraction_by_default(monkeypatch) -> None:
@@ -326,18 +444,23 @@ def test_moss_tts_vocoder_uses_batch_base_path(monkeypatch: pytest.MonkeyPatch) 
 
     decoded_segments: list[list[list[int]]] = []
 
-    class FakeProcessor:
-        model_config = SimpleNamespace(audio_pad_code=1024, sampling_rate=16000)
+    class FakeCodec:
+        sample_rate = 16000
 
-        def decode_audio_codes(self, segments):
+        def decode_codes(self, segments):
             decoded_segments.extend(segment.tolist() for segment in segments)
             offset = float(len(decoded_segments) * 10)
             return [torch.tensor([offset, offset + 1], dtype=torch.float32)]
 
     monkeypatch.setattr(
         stages,
-        "_load_moss_processor",
-        lambda *args, **kwargs: FakeProcessor(),
+        "_load_moss_model_config",
+        lambda model_path: SimpleNamespace(audio_pad_code=1024, sampling_rate=16000),
+    )
+    monkeypatch.setattr(
+        stages,
+        "load_moss_audio_tokenizer",
+        lambda codec_model_path, *, device, dtype: FakeCodec(),
     )
 
     scheduler = stages.create_vocoder_executor(
@@ -623,9 +746,18 @@ def test_moss_preprocess_and_sglang_request_handoff(
                 )
             }
 
+    class FakeCodec:
+        def __init__(self) -> None:
+            self.paths = []
+
+        def encode_paths(self, paths):
+            self.paths.extend(paths)
+            return [torch.tensor([[7, 8], [9, 10]], dtype=torch.long)]
+
+    codec = FakeCodec()
     processor = FakeProcessor()
     payload = make_payload(
-        inputs="hello",
+        inputs={"text": "hello", "references": [{"audio_path": "ref.wav"}]},
         params={"max_new_tokens": 12},
         tts_params={"token_count": 80, "language": "en"},
     )
@@ -640,12 +772,17 @@ def test_moss_preprocess_and_sglang_request_handoff(
     )
 
     try:
-        set_moss_tts_preprocessing_context(processor=processor)
+        set_moss_tts_preprocessing_context(processor=processor, audio_tokenizer=codec)
         prepared_payload = preprocess_moss_tts_payload(payload)
         data = build_sglang_moss_tts_request(prepared_payload, model=model)
     finally:
         clear_moss_tts_preprocessing_context()
 
+    assert codec.paths == ["ref.wav"]
+    assert torch.equal(
+        processor.message_kwargs["reference"][0],
+        torch.tensor([[7, 8], [9, 10]], dtype=torch.long),
+    )
     assert processor.message_kwargs["tokens"] == 80
     assert processor.message_kwargs["language"] == "en"
     assert data.req._input_embeds_are_projected is True
@@ -964,6 +1101,63 @@ def test_moss_delay_codec_splits_non_pad_segments() -> None:
     assert [segment.tolist() for segment in segments] == [[[1, 3], [2, 4]]]
 
 
+def test_moss_vocoder_decodes_with_owned_codec(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.moss_tts import stages
+
+    class FakeCodec:
+        sample_rate = 16000
+
+        def __init__(self) -> None:
+            self.decoded_segments = None
+
+        def decode_codes(self, segments):
+            self.decoded_segments = [segment.clone() for segment in segments]
+            return [torch.tensor([0.25, -0.25, 0.5], dtype=torch.float32)]
+
+    codec = FakeCodec()
+
+    def fail_processor_load(*args, **kwargs):
+        raise AssertionError("vocoder must decode through the owned audio tokenizer")
+
+    monkeypatch.setattr(stages, "_load_moss_processor", fail_processor_load)
+    monkeypatch.setattr(
+        stages,
+        "_load_moss_model_config",
+        lambda model_path: SimpleNamespace(audio_pad_code=1024, sampling_rate=24000),
+    )
+    monkeypatch.setattr(
+        stages,
+        "load_moss_audio_tokenizer",
+        lambda codec_model_path, *, device, dtype: codec,
+    )
+
+    scheduler = stages.create_vocoder_executor("ckpt", gpu_id=0)
+    state = MossTTSState(
+        delayed_audio_codes=torch.tensor(
+            [[1, 1024], [2, 3], [1024, 4]],
+            dtype=torch.long,
+        ),
+        assistant_start_length=0,
+    )
+    result = asyncio.run(
+        scheduler._fn(
+            StagePayload(
+                request_id="decode",
+                request=OmniRequest(inputs="hello"),
+                data=state.to_dict(),
+            )
+        )
+    )
+
+    assert [segment.tolist() for segment in codec.decoded_segments] == [
+        [[1, 3], [2, 4]]
+    ]
+    assert result.data["sample_rate"] == 16000
+    assert result.data["modality"] == "audio"
+
+
 def test_moss_sample_tokens_uses_per_row_top_k() -> None:
     from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
 
@@ -1033,7 +1227,8 @@ def test_moss_preprocess_discards_handoff_after_abort(
 
     payload = make_payload(inputs="hello", request_id="abort-me")
 
-    def fake_prepare(pl, *, processor):
+    def fake_prepare(pl, *, processor, audio_tokenizer=None):
+        del audio_tokenizer
         # The abort fires while preprocessing is still running.
         rb.cleanup_prepared_moss_tts_request(pl.request_id)
         return rb.MossTTSPreparedRequest(
@@ -1106,7 +1301,8 @@ def test_moss_preprocess_pre_start_abort_does_not_block(
 ) -> None:
     from sglang_omni.models.moss_tts import request_builders as rb
 
-    def fake_prepare(pl, *, processor):
+    def fake_prepare(pl, *, processor, audio_tokenizer=None):
+        del audio_tokenizer
         return rb.MossTTSPreparedRequest(
             state=MossTTSState(),
             input_ids_list=[],


### PR DESCRIPTION
## Summary

- load the MOSS-TTS processor without the upstream processor-owned audio tokenizer
- add an owned `MossAudioTokenizer` wrapper for reference-audio encode and vocoder decode
- vendor the MOSS audio-tokenizer config/modeling implementation under `sglang_omni.models.moss_tts`; the HF codec repo is now used only for `config.json` and safetensors weights
- wire preprocessing and vocoder stages to load `OpenMOSS-Team/MOSS-Audio-Tokenizer` explicitly on GPU by default, with CPU fallback when CUDA is unavailable
- keep the request builder contract narrow: reference paths / data URIs are encoded by the owned codec before being passed to the MOSS processor
- add/update unit coverage and docs for the explicit codec ownership contract

## Why

Refs #860.

MOSS-TTS preprocessing previously reached through the upstream processor's internal `audio_tokenizer`. That made device placement implicit and left the expensive reference-audio codec encode path on CPU by default. This PR makes codec ownership explicit in sglang-omni: preprocessing owns encode, vocoder owns decode, and both stages can control codec checkpoint/device/dtype directly.

## Full SeedTTS E2E Validation

Environment:

- Model: `OpenMOSS-Team/MOSS-TTS-v1.5`
- Dataset: `zhaochenyang20/seed-tts-eval-arrow`
- Generate: `ref-format=references`, `token-count=auto`, warmup 10, concurrency 8, `max-running-requests=64`, `cuda-graph-max-bs=64`
- WER ASR: `Qwen/Qwen3-ASR-1.7B`, ASR concurrency 32
- Compared `origin/main@c00e6f9d` with PR head `40ed1a62`
- Runs below are serialized clean runs on the same container/GPU/port setup. A parallel attempt was discarded because two in-container `serve` instances share cleanup/process namespace and one cleanup killed the other pipeline.

Raw artifacts:

- PR EN: `/data/pr861-rebase-20260709/full_seedtts/pr_en`
- PR ZH: `/data/pr861-rebase-20260709/full_seedtts/pr_zh_seq`
- main EN: `/data/pr861-rebase-20260709/full_seedtts/main_en_seq`
- main ZH: `/data/pr861-rebase-20260709/full_seedtts/main_zh_seq`

### EN

| Metric | main | PR branch | Delta |
|---|---:|---:|---:|
| samples / failed | 1088 / 0 | 1088 / 0 | same |
| latency mean | 6.253s | 4.655s | -25.6% |
| latency p95 | 7.470s | 5.827s | -22.0% |
| RTF mean | 1.4692 | 1.0704 | -27.1% |
| throughput | 1.276 req/s | 1.717 req/s | +34.6% |
| audio throughput | 5.718 s/s | 7.690 s/s | +34.5% |
| WER corpus | 1.67% | 1.62% | -0.05 pp |
| WER excl. >50% samples | 1.30% | 1.37% | +0.067 pp |

### ZH

| Metric | main | PR branch | Delta |
|---|---:|---:|---:|
| samples / failed | 2020 / 0 | 2020 / 0 | same |
| latency mean | 6.823s | 5.374s | -21.2% |
| latency p95 | 7.723s | 6.341s | -17.9% |
| RTF mean | 1.2053 | 0.9388 | -22.1% |
| throughput | 1.170 req/s | 1.487 req/s | +27.1% |
| audio throughput | 6.761 s/s | 8.588 s/s | +27.0% |
| WER corpus | 1.02% | 1.09% | +0.069 pp |
| WER excl. >50% samples | 0.98% | 0.99% | +0.015 pp |

Result: full SeedTTS EN+ZH E2E completed with zero generation failures and zero WER skips. Compared with latest main on the same host/container, the PR branch improves generation throughput by +34.6% (EN) and +27.1% (ZH), lowers mean RTF by -27.1% (EN) and -22.1% (ZH), and keeps WER in the same low range.

Note: these are raw benchmark JSON comparisons from the same H100 container, not normalized `/data/perf-baselines` hook artifacts.

## Additional Validation

Final head: `40ed1a622861d087d2f987071d8ebf124e1fcd0d`
Base: `origin/main@c00e6f9d0b4116294eff40f673a2d7b386da3ec5`

- rebase onto latest `origin/main` completed and force-pushed with lease
- pre-commit during amend: autoflake, broken symlinks, whitespace, AST, private-key/debug checks, branch guard, isort, black-jupyter all passed
- local: `python -m py_compile` for changed MOSS-TTS modules/tests and `git diff --check` passed
- hyper01 container: `python -m py_compile` for changed MOSS-TTS modules/tests passed
- hyper01 container: `pytest tests/unit_test/moss_tts/test_pipeline.py -q` -> 35 passed, 20 warnings
- hyper01 container: `python -m ruff ...` could not run in this image because `ruff` is not installed (`No module named ruff`)
- full SeedTTS EN+ZH generation + ASR/WER as above

