### PR TITLE
[bigfix] Ming-Omni Streaming TTS all-segment overlap bugfix 

### DIFF
--- a/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
+++ b/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
@@ -942,7 +942,17 @@ class MingOmniTalker(nn.Module):
                             stream=True,
                             last_chunk=last_chunk,
                         )
-                        yield {"tts_speech": this_tts_speech.cpu()}
+                        (
+                            this_tts_speech,
+                            self.sil_holder_cache[this_uuid],
+                        ) = self.silence_holder(
+                            this_tts_speech,
+                            audio_detokenizer.config.sample_rate,
+                            self.sil_holder_cache[this_uuid],
+                            last_chunk,
+                        )
+                        if this_tts_speech.numel() > 0:
+                            yield {"tts_speech": this_tts_speech.cpu()}
                 else:
                     future.result()
                     this_tts_speech_token = self.tts_speech_token_dict[this_uuid]

--- a/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
+++ b/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
@@ -1231,17 +1231,24 @@ class MingOmniTalker(nn.Module):
 
         for text_ori in text_list:
             length = len(text_ori)
-            previous_segment_positions = [
-                position
+            previous_segment_items = [
+                (key, position)
                 for key, position in cache_position.items()
                 if isinstance(key, int)
             ]
-            if not previous_segment_positions:
+            segment_key = (
+                max(key for key, _ in previous_segment_items) + 1
+                if previous_segment_items
+                else 0
+            )
+            if not previous_segment_items:
                 segment_start_idx = 0
             else:
-                segment_start_idx = previous_segment_positions[-1][1] + 1
+                segment_start_idx = max(
+                    position[1] for _, position in previous_segment_items
+                ) + 1
             segment_end_idx = segment_start_idx + length - 1
-            cache_position.update({count: (segment_start_idx, segment_end_idx)})
+            cache_position.update({segment_key: (segment_start_idx, segment_end_idx)})
 
             if not is_chinese(text_ori):
                 text = normalize_numbers(text_ori)
@@ -1306,7 +1313,7 @@ class MingOmniTalker(nn.Module):
                     )
                     next_start_idx = this_end_idx + 1
                     cache_position.update(
-                        {f"{count}_{idx}": (this_start_idx, this_end_idx)}
+                        {f"{segment_key}_{idx}": (this_start_idx, this_end_idx)}
                     )
                     rel_start_idx = this_start_idx - segment_start_idx
                     rel_end_idx = this_end_idx - segment_start_idx
@@ -1319,12 +1326,17 @@ class MingOmniTalker(nn.Module):
                     yield (
                         tts_speech,
                         this_text_ori,
-                        cache_position[f"{count}_{idx}"],
+                        cache_position[f"{segment_key}_{idx}"],
                         this_dura * 1000,
                     )
                 else:
                     all_wavs.append(tts_speech)
-                    yield tts_speech, text_ori, cache_position[count], this_dura * 1000
+                    yield (
+                        tts_speech,
+                        text_ori,
+                        cache_position[segment_key],
+                        this_dura * 1000,
+                    )
 
     def omni_audio_generation(
         self,

--- a/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
+++ b/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
@@ -1231,11 +1231,17 @@ class MingOmniTalker(nn.Module):
 
         for text_ori in text_list:
             length = len(text_ori)
-            if len(cache_position) == 0:
-                cache_position.update({count: (0, length - 1)})
+            previous_segment_positions = [
+                position
+                for key, position in cache_position.items()
+                if isinstance(key, int)
+            ]
+            if not previous_segment_positions:
+                segment_start_idx = 0
             else:
-                end_idx = list(cache_position.values())[-1][1] + 1
-                cache_position.update({count: (end_idx, end_idx + length - 1)})
+                segment_start_idx = previous_segment_positions[-1][1] + 1
+            segment_end_idx = segment_start_idx + length - 1
+            cache_position.update({count: (segment_start_idx, segment_end_idx)})
 
             if not is_chinese(text_ori):
                 text = normalize_numbers(text_ori)
@@ -1248,8 +1254,9 @@ class MingOmniTalker(nn.Module):
             if text and text[0] == "\uff0c":
                 text = text[1:]
 
-            use_stream = stream and (count == 0)
+            use_stream = stream
             all_wavs: list = []
+            next_start_idx = segment_start_idx
 
             segment_max_decode_steps = self.duration_capped_steps(
                 text_len=len(text),
@@ -1289,26 +1296,24 @@ class MingOmniTalker(nn.Module):
                     tts_speech.shape[-1] / audio_detokenizer.config.sample_rate
                 )
                 if use_stream:
-                    if idx == 0:
-                        this_start_idx = 0
-                        this_end_idx = min(math.ceil(this_dura * wds_lg), length) - 1
-                    else:
-                        this_start_idx = min(
-                            list(cache_position.values())[-1][1] + 1, length - 1
+                    this_start_idx = min(next_start_idx, segment_end_idx)
+                    this_end_idx = (
+                        min(
+                            math.ceil(this_dura * wds_lg) + this_start_idx,
+                            segment_end_idx + 1,
                         )
-                        this_end_idx = (
-                            min(
-                                (math.ceil(this_dura * wds_lg) + this_start_idx), length
-                            )
-                            - 1
-                        )
+                        - 1
+                    )
+                    next_start_idx = this_end_idx + 1
                     cache_position.update(
                         {f"{count}_{idx}": (this_start_idx, this_end_idx)}
                     )
+                    rel_start_idx = this_start_idx - segment_start_idx
+                    rel_end_idx = this_end_idx - segment_start_idx
                     this_text_ori = (
                         ""
                         if this_start_idx == this_end_idx
-                        else text_ori[this_start_idx : this_end_idx + 1]
+                        else text_ori[rel_start_idx : rel_end_idx + 1]
                     )
                     all_wavs.append(tts_speech)
                     yield (

--- a/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
+++ b/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
@@ -1244,9 +1244,9 @@ class MingOmniTalker(nn.Module):
             if not previous_segment_items:
                 segment_start_idx = 0
             else:
-                segment_start_idx = max(
-                    position[1] for _, position in previous_segment_items
-                ) + 1
+                segment_start_idx = (
+                    max(position[1] for _, position in previous_segment_items) + 1
+                )
             segment_end_idx = segment_start_idx + length - 1
             cache_position.update({segment_key: (segment_start_idx, segment_end_idx)})
 

--- a/tests/unit_test/ming_omni/test_talker_voice_validation.py
+++ b/tests/unit_test/ming_omni/test_talker_voice_validation.py
@@ -294,12 +294,13 @@ def test_process_segment_streams_every_internal_segment():
     talker = object.__new__(MingOmniTalker)
     talker.normalizer = SimpleNamespace(normalize=lambda text: text)
     talker.patch_size = 2
-    detok = _fake_detokenizer(sample_rate=10)
+    detok = _fake_detokenizer(sample_rate=100)
     recorded_stream_flags = []
 
     def fake_tts_job(**kwargs):
         recorded_stream_flags.append(kwargs["stream"])
-        yield {"tts_speech": _torch.zeros(10, dtype=_torch.float32)}
+        for _ in range(4):
+            yield {"tts_speech": _torch.zeros(1, 10, dtype=_torch.float32)}
 
     talker.tts_job = fake_tts_job
     cache_position = {}
@@ -344,11 +345,108 @@ def test_process_segment_streams_every_internal_segment():
     )
 
     assert recorded_stream_flags == [True, True]
-    assert first_outputs[0][2] == (0, len("First segment.") - 1)
-    assert second_outputs[0][2] == (
+    assert len(first_outputs) == 4
+    assert len(second_outputs) == 4
+    assert cache_position[0] == (0, len("First segment.") - 1)
+    assert cache_position[1] == (
         len("First segment."),
         len("First segment.") + len("Second segment.") - 1,
     )
+    assert "0_0" in cache_position
+    assert "0_3" in cache_position
+    assert "1_0" in cache_position
+    assert "1_3" in cache_position
+    assert first_outputs[0][2][0] == 0
+    assert second_outputs[0][2][0] == len("First segment.")
+
+
+def test_tts_job_stream_applies_silence_holder(monkeypatch):
+    import threading as _threading
+
+    import torch as _torch
+
+    import sglang_omni.models.ming_omni.talker.modeling_ming_omni_talker as talker_mod
+
+    class _NullStream:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    class _DoneFuture:
+        def done(self):
+            return True
+
+        def exception(self):
+            return None
+
+        def result(self):
+            return None
+
+        def cancel(self):
+            return False
+
+    class _FakeExecutor:
+        def submit(self, fn, *args, **kwargs):
+            token_queue = kwargs["token_queue"]
+            token_queue.put((_torch.ones(1, 1), False))
+            token_queue.put((_torch.ones(1, 1), True))
+            token_queue.put(talker_mod._TOKEN_DONE)
+            return _DoneFuture()
+
+    monkeypatch.setattr(_torch.cuda, "stream", lambda s: _NullStream())
+    monkeypatch.setattr(_torch.cuda, "Stream", lambda device=None: object())
+    monkeypatch.setattr(_torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(
+        MingOmniTalker,
+        "device",
+        property(lambda self: "cpu"),
+        raising=False,
+    )
+
+    talker = object.__new__(MingOmniTalker)
+    talker.executor = _FakeExecutor()
+    talker.lock = _threading.Lock()
+    talker.tts_speech_token_dict = {}
+    talker.llm_end_dict = {}
+    talker.vae_cache = {}
+    talker.sil_holder_cache = {}
+    token2wav_last_chunks = []
+    silence_holder_last_chunks = []
+
+    def fake_token2wav(**kwargs):
+        token2wav_last_chunks.append(kwargs["last_chunk"])
+        return _torch.ones(1, 10, dtype=_torch.float32), kwargs["cache"]
+
+    def fake_silence_holder(speech, sample_rate, sil_cache, last_chunk):
+        silence_holder_last_chunks.append(last_chunk)
+        if not last_chunk:
+            return _torch.zeros(0, dtype=speech.dtype), {"held": True}
+        return speech * 2, {"held": False}
+
+    talker.token2wav = fake_token2wav
+    talker.silence_holder = fake_silence_holder
+
+    outputs = list(
+        MingOmniTalker.tts_job(
+            talker,
+            prompt=None,
+            text="hello",
+            spk_emb=None,
+            instruction=None,
+            audio_detokenizer=_fake_detokenizer(sample_rate=100),
+            prompt_text=None,
+            prompt_wav_lat=None,
+            prompt_wav_emb=None,
+            stream=True,
+        )
+    )
+
+    assert token2wav_last_chunks == [False, True]
+    assert silence_holder_last_chunks == [False, True]
+    assert len(outputs) == 1
+    assert _torch.equal(outputs[0]["tts_speech"], _torch.full((1, 10), 2.0))
 
 
 def test_process_segment_uses_distinct_cache_keys_for_cut_fragments(monkeypatch):

--- a/tests/unit_test/ming_omni/test_talker_voice_validation.py
+++ b/tests/unit_test/ming_omni/test_talker_voice_validation.py
@@ -353,6 +353,7 @@ def test_process_segment_streams_every_internal_segment():
 
 def test_process_segment_uses_distinct_cache_keys_for_cut_fragments(monkeypatch):
     import torch as _torch
+
     import sglang_omni.models.ming_omni.talker.modeling_ming_omni_talker as talker_mod
 
     talker = object.__new__(MingOmniTalker)

--- a/tests/unit_test/ming_omni/test_talker_voice_validation.py
+++ b/tests/unit_test/ming_omni/test_talker_voice_validation.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -286,6 +287,72 @@ def _fake_detokenizer(sample_rate=44100, vae_patch_size=4, hop_size=480):
     encoder = SimpleNamespace(patch_size=vae_patch_size, hop_size=hop_size)
     config = SimpleNamespace(sample_rate=sample_rate)
     return SimpleNamespace(encoder=encoder, config=config)
+
+
+def test_process_segment_streams_every_internal_segment():
+    import torch as _torch
+
+    talker = object.__new__(MingOmniTalker)
+    talker.normalizer = SimpleNamespace(normalize=lambda text: text)
+    talker.patch_size = 2
+    detok = _fake_detokenizer(sample_rate=10)
+    recorded_stream_flags = []
+
+    def fake_tts_job(**kwargs):
+        recorded_stream_flags.append(kwargs["stream"])
+        yield {"tts_speech": _torch.zeros(10, dtype=_torch.float32)}
+
+    talker.tts_job = fake_tts_job
+    cache_position = {}
+
+    first_outputs = list(
+        MingOmniTalker._process_segment(
+            talker,
+            "First segment.",
+            prompt=None,
+            instruction=None,
+            spk_emb=None,
+            audio_detokenizer=detok,
+            prompt_text=None,
+            prompt_wav_lat=None,
+            prompt_wav_emb=None,
+            stream=True,
+            count=0,
+            cache_position=cache_position,
+            max_length=50,
+            wds_lg_zh=6.07,
+            wds_lg_en=16,
+        )
+    )
+    second_outputs = list(
+        MingOmniTalker._process_segment(
+            talker,
+            "Second segment.",
+            prompt=None,
+            instruction=None,
+            spk_emb=None,
+            audio_detokenizer=detok,
+            prompt_text=None,
+            prompt_wav_lat=None,
+            prompt_wav_emb=None,
+            stream=True,
+            count=1,
+            cache_position=cache_position,
+            max_length=50,
+            wds_lg_zh=6.07,
+            wds_lg_en=16,
+        )
+    )
+
+    assert recorded_stream_flags == [True, True]
+    assert first_outputs[0][2] == (0, len("First segment.") - 1)
+    assert second_outputs[0][2] == (
+        len("First segment."),
+        len("First segment.") + len("Second segment.") - 1,
+    )
+    assert "stream and (count == 0)" not in inspect.getsource(
+        MingOmniTalker._process_segment
+    )
 
 
 def test_duration_capped_steps_short_text_uses_floor():

--- a/tests/unit_test/ming_omni/test_talker_voice_validation.py
+++ b/tests/unit_test/ming_omni/test_talker_voice_validation.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import inspect
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -350,9 +349,57 @@ def test_process_segment_streams_every_internal_segment():
         len("First segment."),
         len("First segment.") + len("Second segment.") - 1,
     )
-    assert "stream and (count == 0)" not in inspect.getsource(
-        MingOmniTalker._process_segment
+
+
+def test_process_segment_uses_distinct_cache_keys_for_cut_fragments(monkeypatch):
+    import torch as _torch
+    import sglang_omni.models.ming_omni.talker.modeling_ming_omni_talker as talker_mod
+
+    talker = object.__new__(MingOmniTalker)
+    talker.normalizer = SimpleNamespace(normalize=lambda text: text)
+    talker.patch_size = 2
+    detok = _fake_detokenizer(sample_rate=10)
+    recorded_stream_flags = []
+
+    def fake_tts_job(**kwargs):
+        recorded_stream_flags.append(kwargs["stream"])
+        yield {"tts_speech": _torch.zeros(10, dtype=_torch.float32)}
+
+    monkeypatch.setattr(
+        talker_mod,
+        "cut_text_by_semantic_length",
+        lambda text, max_length: {"fragments": ["Alpha.", "Beta."]},
     )
+    talker.tts_job = fake_tts_job
+    cache_position = {}
+
+    outputs = list(
+        MingOmniTalker._process_segment(
+            talker,
+            "Alpha. Beta.",
+            prompt=None,
+            instruction=None,
+            spk_emb=None,
+            audio_detokenizer=detok,
+            prompt_text=None,
+            prompt_wav_lat=None,
+            prompt_wav_emb=None,
+            stream=True,
+            count=0,
+            cache_position=cache_position,
+            max_length=50,
+            wds_lg_zh=6.07,
+            wds_lg_en=16,
+        )
+    )
+
+    assert recorded_stream_flags == [True, True]
+    assert outputs[0][2] == (0, len("Alpha.") - 1)
+    assert outputs[1][2] == (len("Alpha."), len("Alpha.") + len("Beta.") - 1)
+    assert cache_position[0] == (0, len("Alpha.") - 1)
+    assert cache_position[1] == (len("Alpha."), len("Alpha.") + len("Beta.") - 1)
+    assert cache_position["0_0"] == outputs[0][2]
+    assert cache_position["1_0"] == outputs[1][2]
 
 
 def test_duration_capped_steps_short_text_uses_floor():


### PR DESCRIPTION
## Motivation

Ming-Omni streaming TTS currently only enables token-level streaming / vocoder overlap for the first internal TTS segment.

In `MingOmniTalker._process_segment`, the current logic is:

```python
use_stream = stream and (count == 0)
```

So when stream=True, only count == 0 goes through the streaming tts_job path. Later segments use stream=False, which waits for the full talker token generation to finish and then runs token2wav once. This means only the first segment overlaps talker token generation with vocoder decoding; subsequent segments regress to serial AR/talker → vocoder execution.

This is inconsistent with the intent of streaming TTS. The streaming talker scheduler forwards stream=True into omni_audio_generation, and its output path is already capable of emitting multiple audio chunks per request/segment.

## Modifications

Enable streaming for every segment (use_stream = stream) and refactor segment indexing logic. Compute segment_start_idx/segment_end_idx from prior integer keys in cache_position instead of relying on list(values()) ordering; introduce next_start_idx to track subsegment boundaries and clamp per-chunk start/end to the segment end. Update cache_position keys for subchunks to "{count}_{idx}" and slice text using indices relative to the segment start. Add a unit test (test_process_segment_streams_every_internal_segment) that verifies streaming flags and cache positions for consecutive segments.


## Related Issues

#254 

## Accuracy Test

<html><head></head><body><div _ngcontent-ng-c1753873157="" class="markdown markdown-main-panel enable-luminous-fast-follows stronger enable-updated-hr-color" style="--animation-duration: 400ms; --fade-animation-function: ease-out; font-family: Google Sans Text, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;" id="model-response-message-contentr_39045eccd90b86a7" aria-live="polite" aria-busy="false" dir="ltr"><p data-path-to-node="0" style="font-family: Google Sans Text, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">Ran the one-GPU PR-vs-main smoke on 1*H100 GPU.</p><p data-path-to-node="1" style="font-family: Google Sans Text, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">This was a targeted Ming streaming overlap smoke, not the standard SeedTTS benchmark. It imports the real <code data-path-to-node="1" data-index-in-node="106" style="font-family: Google Sans Text, sans-serif !important; line-height: 1.15 !important; margin-top: 0px !important;">MingOmniTalker._process_segment</code> from each branch, forces 3 internal segments, and simulates AR/vocoder timing so segment 1+ serial-vs-streaming behavior is measurable.</p>

Branch | stream flags | chunks by segment | total mean | segment gap mean
-- | -- | -- | -- | --
origin/main | [true, false, false] | {0: 4, 1: 1, 2: 1} | 922.1 ms | 435.9 ms
pr-866 | [true, true, true] | {0: 4, 1: 4, 2: 4} | 602.6 ms | 201.1 ms


## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
