### PR TITLE
[Refactor] T6: StageCapabilities vocabulary (#661)

### DIFF
--- a/sglang_omni/model_runner/sglang_model_runner.py
+++ b/sglang_omni/model_runner/sglang_model_runner.py
@@ -114,6 +114,13 @@ class SGLModelRunner(ModelRunner):
         except Exception as exc:
             logger.warning("sglang-omni: skipping Ming-Omni registration (%s)", exc)
 
+        try:
+            from sglang_omni.models.stage_capabilities import log_capability_table
+
+            log_capability_table()
+        except Exception as exc:
+            logger.warning("sglang-omni: capability table log skipped (%s)", exc)
+
     def _profile_available_bytes(self, pre_model_load_memory: float) -> int:
         """Profile KV-cache headroom for colocated SGLang AR stages.
 

--- a/sglang_omni/models/fishaudio_s2_pro/__init__.py
+++ b/sglang_omni/models/fishaudio_s2_pro/__init__.py
@@ -1,6 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 """FishAudio S2-Pro model support for sglang-omni."""
 
+from sglang_omni.models.stage_capabilities import StageCapabilities
+
 from . import config
 
-__all__ = ["config"]
+CAPABILITIES = StageCapabilities(
+    supports_cuda_graph=True,
+    supports_torch_compile=True,
+    supports_streaming_vocoder=True,
+    supports_reference_audio=True,
+)
+
+__all__ = ["config", "CAPABILITIES"]

--- a/sglang_omni/models/higgs_tts/__init__.py
+++ b/sglang_omni/models/higgs_tts/__init__.py
@@ -12,9 +12,19 @@ from __future__ import annotations
 
 from transformers import AutoConfig
 
+from sglang_omni.models.stage_capabilities import StageCapabilities
+
 from . import config
 from .hf_config import HiggsMultimodalQwen3Config
 
 AutoConfig.register("higgs_multimodal_qwen3", HiggsMultimodalQwen3Config)
 
-__all__ = ["config", "HiggsMultimodalQwen3Config"]
+CAPABILITIES = StageCapabilities(
+    supports_cuda_graph=True,
+    supports_async_decode=True,
+    supports_torch_compile=True,
+    supports_streaming_vocoder=True,
+    supports_reference_audio=True,
+)
+
+__all__ = ["config", "HiggsMultimodalQwen3Config", "CAPABILITIES"]

--- a/sglang_omni/models/moss_tts/__init__.py
+++ b/sglang_omni/models/moss_tts/__init__.py
@@ -1,2 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """MOSS-TTS support for SGLang Omni."""
+
+from sglang_omni.models.stage_capabilities import StageCapabilities
+
+CAPABILITIES = StageCapabilities(
+    supports_cuda_graph=True,
+    supports_reference_audio=True,
+)
+
+__all__ = ["CAPABILITIES"]

--- a/sglang_omni/models/moss_tts_local/__init__.py
+++ b/sglang_omni/models/moss_tts_local/__init__.py
@@ -1,2 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """MOSS-TTS Local (v1.5) pipeline package."""
+
+from sglang_omni.models.stage_capabilities import StageCapabilities
+
+CAPABILITIES = StageCapabilities(
+    supports_cuda_graph=True,
+    supports_async_decode=True,
+    supports_torch_compile=True,
+    supports_streaming_vocoder=True,
+    supports_reference_audio=True,
+)
+
+__all__ = ["CAPABILITIES"]

--- a/sglang_omni/models/qwen3_tts/__init__.py
+++ b/sglang_omni/models/qwen3_tts/__init__.py
@@ -1,6 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """Qwen3-TTS Base model support for sglang-omni."""
 
+from sglang_omni.models.stage_capabilities import StageCapabilities
+
 from . import config
 
-__all__ = ["config"]
+CAPABILITIES = StageCapabilities(
+    supports_cuda_graph=True,
+    supports_torch_compile=True,
+    supports_reference_audio=True,
+)
+
+__all__ = ["config", "CAPABILITIES"]

--- a/sglang_omni/models/stage_capabilities.py
+++ b/sglang_omni/models/stage_capabilities.py
@@ -33,7 +33,6 @@ class StageCapabilities:
     supports_torch_compile: bool = False
     supports_streaming_vocoder: bool = False
     supports_reference_audio: bool = False
-    supports_thinker_tp: bool = False
 
 
 def collect_capabilities(

--- a/sglang_omni/models/stage_capabilities.py
+++ b/sglang_omni/models/stage_capabilities.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Static per-model capability vocabulary (RFC #661, Template 6).
+
+Each model package exports a ``CAPABILITIES`` constant declaring which shared
+optimizations it supports. This is a *static* declaration ("this model supports
+this optimization under its default config"), not a runtime state ("this
+optimization is enabled right now"). Runtime gating lives in the model runner.
+
+The registry logs the full table at startup; a unit test asserts every
+in-scope model declares one, so the table cannot silently drift.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import pkgutil
+from dataclasses import dataclass, fields
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class StageCapabilities:
+    """Static per-model capability annotation.
+
+    All fields default to False. Override to True only for capabilities that
+    are verified and passing accuracy + perf CI.
+    """
+
+    supports_cuda_graph: bool = False
+    supports_async_decode: bool = False
+    supports_torch_compile: bool = False
+    supports_streaming_vocoder: bool = False
+    supports_reference_audio: bool = False
+    supports_thinker_tp: bool = False
+
+
+def collect_capabilities(
+    package_name: str = "sglang_omni.models",
+) -> dict[str, StageCapabilities]:
+    """Map model package short-name -> its declared ``CAPABILITIES``.
+
+    Enumerates the model subpackages and reads ``CAPABILITIES`` from each.
+    Packages that do not declare one (or fail to import) are skipped.
+    """
+    package = importlib.import_module(package_name)
+    table: dict[str, StageCapabilities] = {}
+    for _, name, ispkg in pkgutil.iter_modules(package.__path__, package_name + "."):
+        if not ispkg:
+            continue
+        short = name.rsplit(".", 1)[-1]
+        try:
+            module = importlib.import_module(name)
+        except Exception as exc:
+            logger.debug("Skipping %s while collecting capabilities: %s", name, exc)
+            continue
+        caps = getattr(module, "CAPABILITIES", None)
+        if isinstance(caps, StageCapabilities):
+            table[short] = caps
+    return table
+
+
+def format_capability_table(table: dict[str, StageCapabilities]) -> str:
+    flds = fields(StageCapabilities)
+    widths = [max(len(f.name) - len("supports_"), 3) + 2 for f in flds]
+    header = f"{'model':<18}" + "".join(
+        f"{f.name.replace('supports_', ''):<{w}}" for f, w in zip(flds, widths)
+    )
+    rows = [header]
+    for model, caps in sorted(table.items()):
+        cells = "".join(
+            f"{('yes' if getattr(caps, f.name) else '-'):<{w}}"
+            for f, w in zip(flds, widths)
+        )
+        rows.append(f"{model:<18}{cells}")
+    return "\n".join(rows)
+
+
+def log_capability_table() -> None:
+    table = collect_capabilities()
+    if table:
+        logger.info("Stage capability table:\n%s", format_capability_table(table))

--- a/sglang_omni/models/voxtral_tts/__init__.py
+++ b/sglang_omni/models/voxtral_tts/__init__.py
@@ -1,5 +1,12 @@
 """Voxtral-4B-TTS model support for sglang-omni."""
 
+from sglang_omni.models.stage_capabilities import StageCapabilities
+
 from . import config
 
-__all__ = ["config"]
+CAPABILITIES = StageCapabilities(
+    supports_cuda_graph=True,
+    supports_torch_compile=True,
+)
+
+__all__ = ["config", "CAPABILITIES"]

--- a/tests/unit_test/models/test_stage_capabilities.py
+++ b/tests/unit_test/models/test_stage_capabilities.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contract tests for the T6 stage capability vocabulary (RFC #661).
+
+CPU-only. A model whose optional runtime deps are missing in this environment
+is skipped (the codebase tolerates missing per-model deps, cf. PR #680); the
+presence guarantee is enforced in the full-dependency model CI.
+"""
+
+import dataclasses
+import importlib
+
+import pytest
+
+from sglang_omni.models.stage_capabilities import (
+    StageCapabilities,
+    collect_capabilities,
+    format_capability_table,
+)
+
+# In-scope TTS models that must declare CAPABILITIES.
+TTS_MODELS = [
+    "higgs_tts",
+    "moss_tts",
+    "moss_tts_local",
+    "qwen3_tts",
+    "fishaudio_s2_pro",
+    "voxtral_tts",
+]
+
+
+def _try_import(model):
+    try:
+        return importlib.import_module(f"sglang_omni.models.{model}"), None
+    except Exception as exc:  # optional dep missing in this env
+        return None, exc
+
+
+@pytest.mark.parametrize("model", TTS_MODELS)
+def test_model_declares_capabilities(model):
+    module, exc = _try_import(model)
+    if module is None:
+        pytest.skip(f"{model} cannot be imported in this env: {exc}")
+    caps = getattr(module, "CAPABILITIES", None)
+    assert caps is not None, f"{model} must export a CAPABILITIES constant"
+    assert isinstance(caps, StageCapabilities)
+
+
+def test_defaults_all_false():
+    caps = StageCapabilities()
+    for f in dataclasses.fields(StageCapabilities):
+        assert getattr(caps, f.name) is False, f"{f.name} should default to False"
+
+
+def test_capabilities_is_frozen():
+    caps = StageCapabilities()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        caps.supports_cuda_graph = True
+
+
+def test_collect_capabilities_covers_importable_models():
+    table = collect_capabilities()
+    assert table, "no model declared CAPABILITIES"
+    for model in TTS_MODELS:
+        module, _ = _try_import(model)
+        if module is None:
+            continue  # optional dep missing in this env; enforced in full CI
+        assert model in table, f"{model} imported but missing from collect_capabilities()"
+    rendered = format_capability_table(table)
+    assert "model" in rendered and "cuda_graph" in rendered


### PR DESCRIPTION
Implements Template 6 of #661 — a static, per-model capability vocabulary so CI can route by capability instead of hardcoded `if model_name == "...":` branches.

## What this adds
- `sglang_omni/models/stage_capabilities.py` — frozen `StageCapabilities` dataclass (five `supports_*` fields, all default `False`) + `collect_capabilities()` / `format_capability_table()` / `log_capability_table()`.
- A `CAPABILITIES` constant in each of the 6 in-scope TTS model `__init__.py`. Values reflect only merged/verified optimizations (matches the coverage matrix); in-progress and N/A stay `False`.
- Startup log of the capability table in `_register_omni_model` (degrades to a warning on failure).
- CPU-only contract test `tests/unit_test/models/test_stage_capabilities.py`: presence check + defaults-all-False + frozen.

Behavior-preserving — declarations + a startup log only, no runtime path change. ~100 LOC.

## Not done (intentionally out of scope)
- **Runtime-consistency warning** (RFC mechanism 3: warn when the runner reports a capability the static declaration denies). It needs T4's `cuda_graph_eligible()` hook, which does not exist yet — deferred to T4 so this PR does not pull in T4 surface.

## Gotcha found
- The presence check is **not unconditionally CPU-only**: importing some model packages (e.g. `higgs_tts`) transitively pulls heavy deps (`vllm`) absent in a bare env. Following the codebase's existing tolerance for missing per-model deps (#680), the test **skips** models it cannot import; the presence guarantee is enforced in the full-dependency model CI.

## Test
`pytest tests/unit_test/models/test_stage_capabilities.py` → **8 passed, 1 skipped** (higgs skipped — `vllm` absent locally). CPU, no GPU. Registry unchanged (17 archs).