### PR TITLE
fix(playground): restrict filesystem browser root to prevent path traversal

### DIFF
--- a/playground/qwen-omni/app.py
+++ b/playground/qwen-omni/app.py
@@ -27,26 +27,51 @@ _MEDIA_SUFFIXES = {
 
 
 def _fs_root() -> Path:
-    """Filesystem root — always container root ``/``."""
-    return Path("/")
+    """Filesystem root for the file browser.
+
+    Reads from ``SGLANG_OMNI_FS_ROOT`` (default: ``/data``).
+    Using ``/`` is intentionally forbidden — the file browser should
+    never expose the entire container filesystem.
+    """
+    raw = os.environ.get("SGLANG_OMNI_FS_ROOT", "/data")
+    root = Path(raw).resolve()
+    if root == Path("/"):
+        raise RuntimeError(
+            "SGLANG_OMNI_FS_ROOT must not be '/'. "
+            "Set it to a restricted directory such as /data or /workspace."
+        )
+    root.mkdir(parents=True, exist_ok=True)
+    return root
 
 
 def _fs_resolve(root: Path, raw_path: str | None) -> Path:
+    """Resolve *raw_path* to an absolute path confined under *root*.
+
+    Protects against path traversal (``../`` sequences, absolute paths
+    outside the root) **and** symlink escapes by resolving both the
+    candidate and the root, then checking containment.
+    """
+    resolved_root = root.resolve()
     if raw_path is None or raw_path.strip() == "":
-        candidate = root
+        return resolved_root
+
+    requested = Path(raw_path.strip())
+    # Always join relative to the root, even if the caller supplies an
+    # absolute path — this prevents ``/etc/shadow``-style access.
+    if requested.is_absolute():
+        candidate = requested.resolve()
     else:
-        requested = Path(raw_path.strip())
-        candidate = (
-            requested.resolve()
-            if requested.is_absolute()
-            else (root / requested).resolve()
-        )
+        candidate = (resolved_root / requested).resolve()
+
+    # Containment check: the resolved candidate must sit under the
+    # resolved root.  Because neither side is ``/``, this is a
+    # meaningful constraint.
     try:
-        candidate.relative_to(root)
+        candidate.relative_to(resolved_root)
     except ValueError:
         raise HTTPException(
             status_code=403,
-            detail=f"Path is outside allowed root: {root}",
+            detail=f"Path is outside allowed root: {resolved_root}",
         )
     return candidate
 

--- a/tests/test_cwe22_fs_traversal.py
+++ b/tests/test_cwe22_fs_traversal.py
@@ -1,0 +1,125 @@
+"""
+PoC / regression test for CWE-22 path traversal in playground/qwen-omni/app.py.
+
+The ``_fs_root()`` function returned ``Path("/")`` and the ``_fs_resolve()``
+guard ``candidate.relative_to(root)`` always passes when root is ``/``,
+allowing an unauthenticated caller to read arbitrary files and list arbitrary
+directories via the ``/v1/fs/file`` and ``/v1/fs/list`` endpoints.
+
+After the fix, _fs_root() must return a restricted directory, and requests
+outside that directory must be rejected with HTTP 403.
+"""
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers to set up a confined sandbox and import the patched app
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def sandbox(tmp_path: Path):
+    """Create a small sandbox directory with some files and subdirs."""
+    (tmp_path / "subdir").mkdir()
+    (tmp_path / "allowed.txt").write_text("hello")
+    (tmp_path / "subdir" / "nested.txt").write_text("nested content")
+    return tmp_path
+
+
+@pytest.fixture()
+def client(sandbox: Path, monkeypatch):
+    """
+    Patch the environment so _fs_root() resolves to the sandbox, then
+    import and build a TestClient around the app.
+    """
+    monkeypatch.setenv("SGLANG_OMNI_FS_ROOT", str(sandbox))
+
+    # Re-import the app module so _fs_root() picks up the env var.
+    import importlib
+    import sys
+
+    mod_name = "playground.qwen_omni_app_under_test"
+    if mod_name in sys.modules:
+        del sys.modules[mod_name]
+
+    # Load the actual module from its file path
+    import importlib.util
+
+    worktree = os.environ.get(
+        "WORKTREE",
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    )
+    spec = importlib.util.spec_from_file_location(
+        mod_name,
+        os.path.join(worktree, "playground", "qwen-omni", "app.py"),
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+
+    # Prevent uvicorn.run from actually starting a server at import time
+    import unittest.mock
+    with unittest.mock.patch("uvicorn.run"):
+        spec.loader.exec_module(mod)
+
+    return TestClient(mod.app, raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestPathTraversal:
+    """Requests outside the configured root MUST be rejected."""
+
+    def test_list_etc_rejected(self, client):
+        """GET /v1/fs/list?path=/etc must return 403."""
+        resp = client.get("/v1/fs/list", params={"path": "/etc"})
+        assert resp.status_code == 403, (
+            f"Expected 403 for /etc, got {resp.status_code}: {resp.text}"
+        )
+
+    def test_read_etc_passwd_rejected(self, client):
+        """GET /v1/fs/file?path=/etc/passwd must return 403."""
+        resp = client.get("/v1/fs/file", params={"path": "/etc/passwd"})
+        assert resp.status_code == 403, (
+            f"Expected 403 for /etc/passwd, got {resp.status_code}: {resp.text}"
+        )
+
+    def test_dotdot_traversal_rejected(self, client):
+        """GET /v1/fs/list?path=../../etc must return 403."""
+        resp = client.get("/v1/fs/list", params={"path": "../../etc"})
+        assert resp.status_code == 403, (
+            f"Expected 403 for ../../etc, got {resp.status_code}: {resp.text}"
+        )
+
+    def test_allowed_file_still_works(self, client, sandbox):
+        """A file inside the root should still be readable."""
+        resp = client.get("/v1/fs/file", params={"path": str(sandbox / "allowed.txt")})
+        assert resp.status_code == 200, (
+            f"Expected 200 for allowed file, got {resp.status_code}: {resp.text}"
+        )
+
+    def test_list_root_works(self, client, sandbox):
+        """Listing the root itself should succeed."""
+        resp = client.get("/v1/fs/list")
+        assert resp.status_code == 200, (
+            f"Expected 200 for root listing, got {resp.status_code}: {resp.text}"
+        )
+
+    def test_symlink_escape_rejected(self, client, sandbox):
+        """A symlink pointing outside the root must be filtered out."""
+        link = sandbox / "escape_link"
+        try:
+            link.symlink_to("/etc")
+        except OSError:
+            pytest.skip("Cannot create symlinks in this environment")
+
+        resp = client.get("/v1/fs/list", params={"path": str(link)})
+        assert resp.status_code == 403, (
+            f"Expected 403 for symlink escape, got {resp.status_code}: {resp.text}"
+        )

--- a/tests/test_cwe22_fs_traversal.py
+++ b/tests/test_cwe22_fs_traversal.py
@@ -9,8 +9,8 @@ directories via the ``/v1/fs/file`` and ``/v1/fs/list`` endpoints.
 After the fix, _fs_root() must return a restricted directory, and requests
 outside that directory must be rejected with HTTP 403.
 """
+import argparse
 import os
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -61,9 +61,14 @@ def client(sandbox: Path, monkeypatch):
     mod = importlib.util.module_from_spec(spec)
     sys.modules[mod_name] = mod
 
-    # Prevent uvicorn.run from actually starting a server at import time
+    # Prevent uvicorn.run from actually starting a server at import time,
+    # and prevent argparse from parsing pytest's CLI args.
     import unittest.mock
-    with unittest.mock.patch("uvicorn.run"):
+    with unittest.mock.patch("uvicorn.run"), \
+         unittest.mock.patch(
+             "argparse.ArgumentParser.parse_args",
+             return_value=argparse.Namespace(port=7860),
+         ):
         spec.loader.exec_module(mod)
 
     return TestClient(mod.app, raise_server_exceptions=False)


### PR DESCRIPTION
## Motivation

The file browser endpoints `/v1/fs/list` and `/v1/fs/file` in `playground/qwen-omni/app.py` are vulnerable to path traversal (CWE-22), allowing unauthenticated remote attackers to read any file and list any directory on the container filesystem.

The root cause: `_fs_root()` returns `Path("/")`, making the containment check `candidate.relative_to(Path("/"))` vacuously true — every absolute path on a Unix filesystem is "relative to" `/`. This means the guard intended to restrict access provides zero protection.

Combined with:
- No authentication on these endpoints
- CORS `allow_origins=["*"]`
- Server binds to `0.0.0.0`
- Recommended Docker deployment uses `--network host --privileged`

...any network client with access to port 7860 can read `/etc/shadow`, SSH keys, environment variables, model weights, or any other file the container process can access.

## Modifications

**`playground/qwen-omni/app.py`:**
- `_fs_root()` now reads from `SGLANG_OMNI_FS_ROOT` env var (default: `/data`) and explicitly rejects `/` as a root
- `_fs_resolve()` now resolves both root and candidate with `.resolve()` before the containment check, preventing symlink escapes and `../` traversal
- Absolute paths supplied by the caller are now checked for containment rather than blindly trusted

**`tests/test_cwe22_fs_traversal.py`** (new):
- Regression tests verifying that traversal attempts (`/etc/passwd`, `../../etc`, symlink escapes) return HTTP 403
- Verifies legitimate file access within the configured root still works

The fix is minimal and backward-compatible. Existing deployments that previously served files from `/` should set `SGLANG_OMNI_FS_ROOT` to their data directory (the default `/data` matches the typical Docker volume mount point).

## Related Issues

N/A — no existing issue tracks this vulnerability.

## Accuracy Test

Not applicable — this change affects only the playground file browser, not model inference.

## Benchmark & Profiling

Not applicable — no performance-sensitive code paths are modified.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

This PR modifies only Python code in `playground/qwen-omni/` and adds a test file. No GPU resources are required for testing.

---

## Security Details

### Vulnerability Summary

| Field | Value |
|-------|-------|
| CWE | CWE-22: Improper Limitation of a Pathname to a Restricted Directory |
| Severity | High |
| Affected file | `playground/qwen-omni/app.py` |
| Affected functions | `_fs_root()`, `_fs_resolve()` |
| Endpoints | `GET /v1/fs/list`, `GET /v1/fs/file` |
| Authentication | None required |

### Data Flow

1. Attacker sends `GET /v1/fs/file?path=/etc/shadow` to port 7860
2. `_fs_resolve(root=Path("/"), raw_path="/etc/shadow")` is called
3. `Path("/etc/shadow").resolve()` → `/etc/shadow`
4. Containment check: `Path("/etc/shadow").relative_to(Path("/"))` → succeeds (returns `"etc/shadow"`)
5. File is returned to the attacker via `FileResponse`

### Proof of Concept

```bash
# Start the playground (default configuration)
python playground/qwen-omni/app.py --port 7860

# Read /etc/passwd — should be blocked but isn't on the vulnerable version
curl -s "http://localhost:7860/v1/fs/file?path=/etc/passwd"

# List the entire filesystem root
curl -s "http://localhost:7860/v1/fs/list?path=/"

# Traverse from a relative path
curl -s "http://localhost:7860/v1/fs/list?path=../../../../../../etc"

# Read environment variables (may contain API keys/tokens)
curl -s "http://localhost:7860/v1/fs/file?path=/proc/self/environ"
```

On the **vulnerable** version, all of these return HTTP 200 with the file/directory contents. On the **fixed** version, they return HTTP 403 or a startup error if `SGLANG_OMNI_FS_ROOT=/` is attempted.

### Fix Rationale

The fundamental issue is that `relative_to(Path("/"))` is a no-op containment check — it passes for every absolute path. The fix:

1. Restricts the root to a meaningful subdirectory (`/data` by default)
2. Explicitly blocks `/` as a root value at startup
3. Resolves both paths with `.resolve()` before comparison (handles symlinks and `../`)
4. Makes the root configurable via environment variable for deployment flexibility

### Adversarial Review

Before submitting, we attempted to disprove this finding: we considered whether framework-level auth middleware, Docker network isolation, or the CORS configuration might prevent exploitation. They don't — the FastAPI app has no authentication dependencies on any router or endpoint, CORS `allow_origins=["*"]` permits cross-origin requests, and the recommended deployment binds to all interfaces with `--network host`. The `relative_to(Path("/"))` check is mathematically incapable of rejecting any valid absolute path.