### PR TITLE
Optimize Qwen3-TTS predictor sampling hot path

### DIFF
--- a/sglang_omni/models/qwen3_tts/sampling_kernels.py
+++ b/sglang_omni/models/qwen3_tts/sampling_kernels.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Optional sampling kernels for Qwen3-TTS."""
+
+from __future__ import annotations
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:  # pragma: no cover - depends on runtime image
+    triton = None
+    tl = None
+
+
+if triton is not None:
+
+    @triton.jit
+    def _rotl32(x, r: tl.constexpr) -> tl.uint32:
+        x = x.to(tl.uint64)
+        return ((x << r) | (x >> (32 - r))) & 0xFFFFFFFF
+
+    @triton.jit
+    def _fmix32(h: tl.uint32) -> tl.uint32:
+        h ^= h >> 16
+        h = (h * 0x85EBCA6B) & 0xFFFFFFFF
+        h ^= h >> 13
+        h = (h * 0xC2B2AE35) & 0xFFFFFFFF
+        h ^= h >> 16
+        return h
+
+    @triton.jit
+    def _murmur3_mix(h: tl.uint32, k: tl.uint32) -> tl.uint32:
+        k = (k * 0xCC9E2D51) & 0xFFFFFFFF
+        k = _rotl32(k, 15)
+        k = (k * 0x1B873593) & 0xFFFFFFFF
+        h ^= k
+        h = _rotl32(h, 13)
+        h = (h * 5 + 0xE6546B64) & 0xFFFFFFFF
+        return h
+
+    @triton.jit
+    def _seeded_gumbel_sample_sorted_kernel(
+        probs,
+        sorted_idx,
+        seeds,
+        positions,
+        out,
+        num_cols: tl.constexpr,
+        probs_stride_b: tl.constexpr,
+        probs_stride_k: tl.constexpr,
+        idx_stride_b: tl.constexpr,
+        idx_stride_k: tl.constexpr,
+        block_size: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        offsets = tl.arange(0, block_size)
+        mask = offsets < num_cols
+
+        seed = tl.load(seeds + row).to(tl.uint64)
+        pos = tl.load(positions + row).to(tl.uint32)
+        col = offsets.to(tl.uint32)
+
+        h: tl.uint32 = 0
+        h = _murmur3_mix(h, (seed & 0xFFFFFFFF).to(tl.uint32))
+        h = _murmur3_mix(h, ((seed >> 32) & 0xFFFFFFFF).to(tl.uint32))
+        h = _murmur3_mix(h, pos)
+        h = _murmur3_mix(h, col)
+        h ^= 16
+        h = _fmix32(h)
+
+        u = h.to(tl.float64) / 4294967295.0
+        u = tl.maximum(u, 2.2250738585072014e-308)
+        gumbel = -tl.log(-tl.log(u))
+        weights = tl.load(
+            probs + row * probs_stride_b + offsets * probs_stride_k,
+            mask=mask,
+            other=-float("inf"),
+        ).to(tl.float64)
+        scores = tl.where(mask, weights + gumbel, -float("inf"))
+        max_score = tl.max(scores, axis=0)
+        candidates = tl.where(scores == max_score, offsets, num_cols)
+        rank = tl.min(candidates, axis=0)
+        token = tl.load(sorted_idx + row * idx_stride_b + rank * idx_stride_k)
+        tl.store(out + row, token)
+
+else:
+    _seeded_gumbel_sample_sorted_kernel = None
+
+
+def _next_power_of_2(value: int) -> int:
+    return 1 << (int(value) - 1).bit_length()
+
+
+def sample_from_sorted_probs_with_seed_small_k(
+    probs: torch.Tensor,
+    sorted_idx: torch.Tensor,
+    seeds: torch.Tensor,
+    positions: torch.Tensor,
+) -> torch.Tensor | None:
+    if (
+        _seeded_gumbel_sample_sorted_kernel is None
+        or not probs.is_cuda
+        or not sorted_idx.is_cuda
+        or not seeds.is_cuda
+        or not positions.is_cuda
+    ):
+        return None
+    if probs.ndim != 2 or sorted_idx.shape != probs.shape:
+        return None
+    if seeds.ndim != 1 or positions.ndim != 1:
+        return None
+    batch_size, num_cols = probs.shape
+    if batch_size == 0:
+        return torch.empty((0,), device=probs.device, dtype=torch.long)
+    if seeds.shape[0] != batch_size or positions.shape[0] != batch_size:
+        return None
+    if num_cols <= 0 or num_cols > 1024:
+        return None
+
+    block_size = _next_power_of_2(num_cols)
+    out = torch.empty((batch_size,), device=probs.device, dtype=torch.long)
+    _seeded_gumbel_sample_sorted_kernel[(batch_size,)](
+        probs,
+        sorted_idx,
+        seeds,
+        positions,
+        out,
+        int(num_cols),
+        probs.stride(0),
+        probs.stride(1),
+        sorted_idx.stride(0),
+        sorted_idx.stride(1),
+        block_size,
+    )
+    return out

--- a/sglang_omni/models/qwen3_tts/sglang_model.py
+++ b/sglang_omni/models/qwen3_tts/sglang_model.py
@@ -15,13 +15,15 @@ from sglang_omni.models.qwen3_omni.components.talker import (  # noqa: E501
     Qwen3OmniMoeTalkerDenseMLP,
     ResizeMLP,
     _bind_default_weight_loaders,
-    _repeat_kv,
 )
 from sglang_omni.models.qwen3_omni.components.thinker_model import (
     Qwen3OmniMoeThinkerTextAttention,
 )
 from sglang_omni.models.qwen3_tts.compat import (
     apply_qwen_tts_transformers_compatibility_patches,
+)
+from sglang_omni.models.qwen3_tts.sampling_kernels import (
+    sample_from_sorted_probs_with_seed_small_k,
 )
 from sglang_omni.vendor.sglang.core import ForwardBatch
 from sglang_omni.vendor.sglang.layers import ReplicatedLinear, RMSNorm
@@ -303,6 +305,11 @@ class Qwen3TTSTalker(nn.Module):
         cp_attn = cp_layers[0].self_attn
         self._predictor_positions = torch.arange(
             predictor_len, device=device, dtype=torch.long
+        )
+        self._predictor_position_rows = (
+            self._predictor_positions[:, None]
+            .expand(predictor_len, max_batch_size)
+            .contiguous()
         )
         self._predictor_k_cache = torch.zeros(
             len(cp_layers),
@@ -1122,15 +1129,7 @@ class Qwen3TTSTalker(nn.Module):
             keep_top_k = keep_all.unsqueeze(1) | (rank < top_ks.unsqueeze(1))
             sorted_scores = sorted_scores.masked_fill(~keep_top_k, -float("inf"))
 
-        sorted_probs = torch.softmax(sorted_scores, dim=-1)
         top_ps = self._sub_top_p_tensor.index_select(0, row_indices)
-        if self._sub_sampled_has_top_p:
-            active_top_p = (top_ps > 0.0) & (top_ps < 1.0)
-            cdf = torch.cumsum(sorted_probs, dim=-1)
-            remove = (cdf > top_ps.unsqueeze(1)) & active_top_p.unsqueeze(1)
-            remove[:, 0] = False
-            sorted_probs = sorted_probs.masked_fill(remove, 0.0)
-
         seeds = self._sub_sampling_seed_tensor.index_select(0, row_indices)
         sub_positions = (
             semantic_positions.to(device=logits.device, dtype=torch.long)
@@ -1138,6 +1137,24 @@ class Qwen3TTSTalker(nn.Module):
             + int(layer_idx)
             + 1
         )
+
+        sorted_probs = torch.softmax(sorted_scores, dim=-1)
+        if self._sub_sampled_has_top_p:
+            active_top_p = (top_ps > 0.0) & (top_ps < 1.0)
+            cdf = torch.cumsum(sorted_probs, dim=-1)
+            remove = (cdf > top_ps.unsqueeze(1)) & active_top_p.unsqueeze(1)
+            remove[:, 0] = False
+            sorted_probs = sorted_probs.masked_fill(remove, 0.0)
+
+        sampled = sample_from_sorted_probs_with_seed_small_k(
+            sorted_probs,
+            sorted_idx,
+            seeds,
+            sub_positions,
+        )
+        if sampled is not None:
+            return sampled.to(torch.long)
+
         sampled_rank = _sample_seeded_categorical(
             sorted_probs,
             seeds,
@@ -1154,9 +1171,7 @@ class Qwen3TTSTalker(nn.Module):
     ) -> torch.Tensor:
         hidden_states = token_embeds
         hidden_size = hidden_states.shape[-1]
-        positions = self._predictor_positions[cache_len : cache_len + 1].repeat(
-            batch_size
-        )
+        positions = self._predictor_position_rows[cache_len, :batch_size]
         for layer_idx, layer in enumerate(self.code_predictor.model.layers):
             residual = hidden_states
             normed = layer.input_layernorm(hidden_states.reshape(-1, hidden_size))
@@ -1223,15 +1238,22 @@ class Qwen3TTSTalker(nn.Module):
         layer_v_cache[:, :, cache_len : cache_len + 1, :].copy_(v)
         cached_k = layer_k_cache[:, :, : cache_len + 1, :]
         cached_v = layer_v_cache[:, :, : cache_len + 1, :]
-        groups = attn.num_heads // attn.num_kv_heads
-        cached_k = _repeat_kv(cached_k, groups)
-        cached_v = _repeat_kv(cached_v, groups)
-        attn_output = torch.nn.functional.scaled_dot_product_attention(
-            q,
-            cached_k,
-            cached_v,
-            is_causal=False,
-        )
+        num_kv_groups = attn.num_heads // attn.num_kv_heads
+        if num_kv_groups == 1:
+            attn_output = torch.nn.functional.scaled_dot_product_attention(
+                q,
+                cached_k,
+                cached_v,
+                is_causal=False,
+            )
+        else:
+            attn_output = torch.nn.functional.scaled_dot_product_attention(
+                q,
+                cached_k,
+                cached_v,
+                is_causal=False,
+                enable_gqa=True,
+            )
         attn_output = attn_output.transpose(1, 2).reshape(
             batch_size, attn.num_heads * attn.head_dim
         )

--- a/tests/unit_test/qwen3_tts/test_sampling_kernels.py
+++ b/tests/unit_test/qwen3_tts/test_sampling_kernels.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen3-TTS optional sampling kernels."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from sglang.srt.layers.sampler import multinomial_with_seed
+
+from sglang_omni.models.qwen3_tts.sampling_kernels import (
+    sample_from_sorted_probs_with_seed_small_k,
+)
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="Qwen3-TTS sampling kernel needs CUDA"
+)
+
+
+@pytest.mark.parametrize("batch_size,num_cols", [(1, 1), (3, 2), (7, 30), (16, 64)])
+def test_seeded_small_k_sampler_matches_sglang_multinomial(
+    batch_size: int, num_cols: int
+) -> None:
+    generator = torch.Generator(device="cuda").manual_seed(batch_size * 100 + num_cols)
+    probs = torch.rand(
+        batch_size,
+        num_cols,
+        generator=generator,
+        device="cuda",
+        dtype=torch.float32,
+    )
+    probs = probs / probs.sum(dim=1, keepdim=True)
+    sorted_idx = torch.randint(
+        0,
+        8192,
+        (batch_size, num_cols),
+        generator=generator,
+        device="cuda",
+        dtype=torch.long,
+    )
+    seeds = torch.arange(17, 17 + batch_size, device="cuda", dtype=torch.long)
+    positions = torch.arange(3, 3 + batch_size, device="cuda", dtype=torch.long)
+
+    sampled = sample_from_sorted_probs_with_seed_small_k(
+        probs, sorted_idx, seeds, positions
+    )
+    assert sampled is not None
+
+    sampled_rank = multinomial_with_seed(probs, seeds, positions).view(-1, 1)
+    expected = sorted_idx.gather(1, sampled_rank).view(-1)
+    assert torch.equal(sampled, expected)
+
+
+def test_seeded_small_k_sampler_falls_back_for_cpu() -> None:
+    probs = torch.ones((1, 2), dtype=torch.float32)
+    sorted_idx = torch.arange(2, dtype=torch.long).view(1, 2)
+    seeds = torch.ones((1,), dtype=torch.long)
+    positions = torch.zeros((1,), dtype=torch.long)
+
+    assert (
+        sample_from_sorted_probs_with_seed_small_k(probs, sorted_idx, seeds, positions)
+        is None
+    )


### PR DESCRIPTION
## Summary

- Avoid materializing repeated predictor KV tensors by using PyTorch SDPA GQA support when Q heads outnumber KV heads.
- Add an optional Triton small-k seeded sampler for Qwen3-TTS predictor sampling, with a fallback to the existing SGLang seeded multinomial path.
- Cache predictor position rows to remove per-token `repeat` allocation in the predictor loop.
- Keep the earlier copy/add Triton fusion attempt out of this PR because it benchmarked slower.

Fixes part of #870.

## Full Benchmark

B200, Qwen3-TTS 0.6B, SeedTTS EN full 1088-instance benchmark, c16 closed-loop, warmup=1, seed=1234, `max_running_requests=16`, `cuda_graph_max_bs=16`. Both runs used the same `hongccc/sglang-omni:dev` container, GPU7, benchmark harness, dataset, and ASR/WER pipeline.

| Metric | Full main baseline | This PR | Change |
| --- | ---: | ---: | ---: |
| Evaluated requests | 1088/1088 | 1088/1088 | unchanged |
| Failed requests | 0 | 0 | unchanged |
| WER corpus | 2.40% | 2.33% | -0.08 pp |
| Output throughput | 115.9 tok/s | 139.3 tok/s | +20.2% |
| Audio throughput | 9.274 audio-sec/s | 11.142 audio-sec/s | +20.1% |
| Throughput | 1.567 req/s | 1.883 req/s | +20.2% |
| Latency mean / median / p95 | 8.766 / 6.317 / 9.950 s | 7.594 / 5.551 / 8.823 s | mean -13.4% |
| RTF mean / median / p95 | 1.5810 / 1.5122 / 1.9013 | 1.3751 / 1.3443 / 1.6884 | mean -13.0% |
| Latency p99 | 145.556 s | 97.342 s | -33.1% |
| RTF p99 | 4.3561 | 2.1098 | -51.6% |

Result directories on the B200 machine:

- Main baseline: `/data/outputs/qwen3_tts_full_main_c16_b200_gpu7_0623_v2`
- This PR: `/data/outputs/qwen3_tts_full_pr_c16_b200_gpu7_0623_v2`

Main baseline commit: `3ba6b24`. This PR commit: `6c46c3b`.

## Iteration Benchmarks

Earlier H100 EN50/c16 runs were used only for iteration and are not the final performance claim. They showed the same direction, but the table above is the clean full 1088-instance benchmark.

## Validation

- `python3 -m py_compile sglang_omni/models/qwen3_tts/sglang_model.py sglang_omni/models/qwen3_tts/sampling_kernels.py tests/unit_test/qwen3_tts/test_sampling_kernels.py`
- H100 dev container: `CUDA_VISIBLE_DEVICES=0 pytest -q tests/unit_test/qwen3_tts/test_sampling_kernels.py`
  - `5 passed, 20 warnings in 7.49s`
- B200 full benchmark: 1088/1088 successful generation requests and 1088/1088 WER evaluation requests for both main and this PR.
