### PR TITLE
[Perf] Optimize Qwen3-Omni predictor hot path

### DIFF
--- a/examples/configs/qwen3_omni_colocated_h200_fused.yaml
+++ b/examples/configs/qwen3_omni_colocated_h200_fused.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# note (luojiaxuan): Opt-in H200 config for the S2S-faster fused
+# talker_ar/code2wav local-process edge.
+
+config_cls: Qwen3OmniSpeechColocatedPipelineConfig
+name: qwen3-omni-colocated-h200-fused
+model_path: Qwen/Qwen3-Omni-30B-A3B-Instruct
+relay_backend: shm
+fused_stages:
+  - [talker_ar, code2wav]
+
+stage_overrides:
+  image_encoder:
+    runtime:
+      resources:
+        total_gpu_memory_fraction: 0.017
+
+  audio_encoder:
+    runtime:
+      resources:
+        total_gpu_memory_fraction: 0.017
+
+  thinker:
+    runtime:
+      resources:
+        total_gpu_memory_fraction: 0.769
+
+  talker_ar:
+    runtime:
+      resources:
+        total_gpu_memory_fraction: 0.123
+
+  code2wav:
+    runtime:
+      resources:
+        total_gpu_memory_fraction: 0.014

--- a/examples/run_qwen3_omni_speech_server.py
+++ b/examples/run_qwen3_omni_speech_server.py
@@ -142,8 +142,8 @@ def parse_args() -> argparse.Namespace:
         action=argparse.BooleanOptionalAction,
         default=None,
         help=(
-            "Enable partial-prefix talker startup. Defaults to on for the "
-            "disaggregated speech topology and off for --colocated. Use "
+            "Enable partial-prefix talker startup. Defaults to the selected "
+            "speech pipeline config, currently on for both topologies. Use "
             "--no-enable-partial-start to disable."
         ),
     )
@@ -153,7 +153,7 @@ def parse_args() -> argparse.Namespace:
         default=5,
         help=(
             "Chunk-count threshold for partial-start (default 5). "
-            "Only consumed when --enable-partial-start is set; "
+            "Only consumed when partial-start is enabled; "
             "must be >= MIN_PARTIAL_START_CHUNKS (3)."
         ),
     )
@@ -262,20 +262,9 @@ def _launch_speech_server(args: argparse.Namespace) -> None:
     ):
         _validate_fraction(flag_name, value)
 
-    enable_partial_start = (
-        not args.colocated
-        if args.enable_partial_start is None
-        else bool(args.enable_partial_start)
+    requested_enable_partial_start = (
+        None if args.enable_partial_start is None else bool(args.enable_partial_start)
     )
-
-    if (
-        enable_partial_start
-        and args.partial_start_min_chunks < MIN_PARTIAL_START_CHUNKS
-    ):
-        raise ValueError(
-            f"--partial-start-min-chunks must be >= {MIN_PARTIAL_START_CHUNKS}, "
-            f"got {args.partial_start_min_chunks}"
-        )
 
     gpu_talker = (
         args.gpu_talker
@@ -409,18 +398,36 @@ def _launch_speech_server(args: argparse.Namespace) -> None:
             updates={"talker_max_seq_len": int(args.talker_max_seq_len)},
         )
 
-    talker_partial_start_updates: dict[str, object] = {
-        "enable_partial_start": enable_partial_start,
-    }
+    talker = next(stage for stage in config.stages if stage.name == "talker_ar")
+    if requested_enable_partial_start is None:
+        enable_partial_start = bool(
+            (talker.factory_args or {}).get("enable_partial_start", False)
+        )
+        talker_partial_start_updates: dict[str, object] = {}
+    else:
+        enable_partial_start = requested_enable_partial_start
+        talker_partial_start_updates = {
+            "enable_partial_start": enable_partial_start,
+        }
+
+    if (
+        enable_partial_start
+        and args.partial_start_min_chunks < MIN_PARTIAL_START_CHUNKS
+    ):
+        raise ValueError(
+            f"--partial-start-min-chunks must be >= {MIN_PARTIAL_START_CHUNKS}, "
+            f"got {args.partial_start_min_chunks}"
+        )
     if enable_partial_start:
         talker_partial_start_updates["partial_start_min_chunks"] = int(
             args.partial_start_min_chunks
         )
-    _apply_stage_factory_updates(
-        config,
-        stage_name="talker_ar",
-        updates=talker_partial_start_updates,
-    )
+    if talker_partial_start_updates:
+        _apply_stage_factory_updates(
+            config,
+            stage_name="talker_ar",
+            updates=talker_partial_start_updates,
+        )
 
     launch_server(
         config,

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -115,10 +115,15 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         max_batch_size: int = 16,
         max_batch_wait_ms: int = 1,
         enable_batched_decode: bool = True,
+        first_stream_chunk_size: int | None = None,
     ):
         self._model = model
         self._device = torch.device(device)
         self._stream_chunk_size = max(int(stream_chunk_size), 1)
+        self._first_stream_chunk_size = self._resolve_first_stream_chunk_size(
+            self._stream_chunk_size,
+            first_stream_chunk_size,
+        )
         self._left_context_size = max(int(left_context_size), 0)
         self._sample_rate = sample_rate
         self._codec_eos_token_id = codec_eos_token_id
@@ -138,6 +143,24 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         self._stream_enabled: dict[str, bool] = {}
         super().__init__(compute_fn=None)
         self._payloads = self._stream_payloads
+
+    @staticmethod
+    def _resolve_first_stream_chunk_size(
+        stream_chunk_size: int,
+        configured: int | None,
+    ) -> int:
+        env_value = os.getenv("SGLANG_OMNI_QWEN3_CODE2WAV_FIRST_CHUNK_SIZE")
+        if env_value is not None:
+            value = int(env_value)
+            if value <= 0:
+                return stream_chunk_size
+        elif configured is None:
+            value = min(stream_chunk_size, 8)
+        else:
+            value = int(configured)
+            if value <= 0:
+                return stream_chunk_size
+        return min(max(value, 1), stream_chunk_size)
 
     def is_streaming_payload(self, payload: StagePayload) -> bool:
         del payload
@@ -395,7 +418,8 @@ class Code2WavScheduler(StreamingSimpleScheduler):
             ready = end - start
             if ready <= 0:
                 continue
-            if ready < self._stream_chunk_size and request_id not in force_request_ids:
+            threshold = self._decode_ready_threshold(request_id)
+            if ready < threshold and request_id not in force_request_ids:
                 continue
             context = min(self._left_context_size, start)
             window = self._code_window(request_id, start - context, end)
@@ -512,9 +536,17 @@ class Code2WavScheduler(StreamingSimpleScheduler):
             ready = self._code_chunk_count(request_id) - self._emitted.get(
                 request_id, 0
             )
-            if ready >= self._stream_chunk_size:
+            if ready >= self._decode_ready_threshold(request_id):
                 count += 1
         return count
+
+    def _decode_ready_threshold(self, request_id: str) -> int:
+        if (
+            self._stream_enabled.get(request_id, False)
+            and self._emitted.get(request_id, 0) == 0
+        ):
+            return self._first_stream_chunk_size
+        return self._stream_chunk_size
 
     def _collect_more_stream_chunks(self) -> None:
         ready_count = self._ready_request_count()
@@ -605,6 +637,7 @@ def create_code2wav_scheduler(
     max_batch_size: int = 16,
     max_batch_wait_ms: int = 1,
     enable_batched_decode: bool = True,
+    first_stream_chunk_size: int | None = None,
 ):
     """Factory: returns Code2WavScheduler."""
     if gpu_id is not None:
@@ -618,4 +651,5 @@ def create_code2wav_scheduler(
         max_batch_size=max_batch_size,
         max_batch_wait_ms=max_batch_wait_ms,
         enable_batched_decode=enable_batched_decode,
+        first_stream_chunk_size=first_stream_chunk_size,
     )

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -4,9 +4,13 @@
 Receives codec code chunks via inbox (stream_chunk), accumulates them,
 runs vocoder incrementally, outputs final audio via outbox.
 """
+
 from __future__ import annotations
 
 import logging
+import queue as _queue_mod
+import time
+from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
@@ -20,6 +24,15 @@ from sglang_omni.scheduling.streaming_simple_scheduler import StreamingSimpleSch
 from sglang_omni.utils.audio_payload import audio_waveform_payload
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _DecodePlan:
+    request_id: str
+    start: int
+    end: int
+    trim: int
+    codes: torch.Tensor
 
 
 def load_code2wav_model(
@@ -61,6 +74,9 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         left_context_size: int = 25,
         sample_rate: int = 24000,
         codec_eos_token_id: int = 2150,
+        max_batch_size: int = 16,
+        max_batch_wait_ms: int = 1,
+        enable_batched_decode: bool = True,
     ):
         self._model = model
         self._device = torch.device(device)
@@ -69,6 +85,9 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         self._sample_rate = sample_rate
         self._codec_eos_token_id = codec_eos_token_id
         self._total_upsample = int(model.total_upsample)
+        self._decode_max_batch_size = max(int(max_batch_size), 1)
+        self._decode_max_batch_wait_s = max(float(max_batch_wait_ms), 0.0) / 1000.0
+        self._enable_batched_decode = bool(enable_batched_decode)
 
         # Per-request state
         self._code_chunks: dict[str, list[torch.Tensor]] = {}
@@ -112,6 +131,67 @@ class Code2WavScheduler(StreamingSimpleScheduler):
     def on_stream_chunk(
         self, request_id: str, chunk: StreamItem
     ) -> list[OutgoingMessage]:
+        self._append_stream_chunk(request_id, chunk)
+        if self._is_aborted(request_id):
+            return []
+        return self._decode_ready_requests(request_ids=[request_id])
+
+    def _handle_stream_chunk(self, request_id: str, item: Any) -> None:
+        if not isinstance(item, StreamItem):
+            raise TypeError(
+                f"{self.__class__.__name__} expected StreamItem for "
+                f"{request_id!r}, got {type(item).__name__}"
+            )
+        with self._state_lock:
+            self._append_stream_chunk(request_id, item)
+            if self._is_aborted(request_id):
+                return
+            if self._enable_batched_decode:
+                self._collect_more_stream_chunks()
+                messages = self._decode_ready_requests()
+            else:
+                messages = self._decode_ready_requests(request_ids=[request_id])
+            for out in messages:
+                if not self._is_aborted(out.request_id):
+                    self.outbox.put(out)
+
+    def _handle_stream_done(self, request_id: str) -> None:
+        with self._state_lock:
+            done_request_ids = [request_id]
+            if self._enable_batched_decode:
+                done_request_ids.extend(self._collect_more_stream_done())
+
+            ready_to_finalize: list[str] = []
+            for done_request_id in done_request_ids:
+                if done_request_id not in self._stream_payloads:
+                    if done_request_id in self._completed_non_streaming_request_ids:
+                        continue
+                    self._pending_done.add(done_request_id)
+                    continue
+                ready_to_finalize.append(done_request_id)
+
+            if not ready_to_finalize:
+                return
+
+            force_ids = set(ready_to_finalize)
+            request_ids = None if self._enable_batched_decode else ready_to_finalize
+            for out in self._decode_ready_requests(
+                force_request_ids=force_ids,
+                request_ids=request_ids,
+            ):
+                if not self._is_aborted(out.request_id):
+                    self.outbox.put(out)
+
+            for done_request_id in ready_to_finalize:
+                if self._is_aborted(done_request_id):
+                    continue
+                for out in self._finalize_request(done_request_id):
+                    if not self._is_aborted(out.request_id):
+                        self.outbox.put(out)
+                if not self._is_aborted(done_request_id):
+                    self._clear_request_state(done_request_id)
+
+    def _append_stream_chunk(self, request_id: str, chunk: StreamItem) -> None:
         self._ensure_request_state(request_id)
 
         # Latch the stream flag from talker's metadata once per request.
@@ -128,7 +208,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
                         "populate it."
                     ),
                 )
-                return []
+                return
             self._stream_enabled[request_id] = bool(meta["stream"])
 
         codes = chunk.data.to(device=self._device, dtype=torch.long)
@@ -146,20 +226,17 @@ class Code2WavScheduler(StreamingSimpleScheduler):
                 logger.debug(
                     "Code2Wav skip EOS req=%s codes=%s", request_id, codes.tolist()
                 )
-            return []
+            return
         self._code_chunks[request_id].append(codes)
-        ready = len(self._code_chunks[request_id]) - self._emitted[request_id]
-        if ready >= self._stream_chunk_size:
-            return self._decode_and_emit(request_id)
-        return []
 
     def on_stream_done(self, request_id: str) -> list[OutgoingMessage]:
-        # Decode remaining
-        chunks = self._code_chunks[request_id]
-        emitted = self._emitted[request_id]
         messages: list[OutgoingMessage] = []
-        if chunks and emitted < len(chunks):
-            messages.extend(self._decode_and_emit(request_id))
+        messages.extend(self._decode_ready_requests(force_request_ids={request_id}))
+        messages.extend(self._finalize_request(request_id))
+        return messages
+
+    def _finalize_request(self, request_id: str) -> list[OutgoingMessage]:
+        messages: list[OutgoingMessage] = []
 
         # Build final output
         audio_parts = self._audio_chunks.get(request_id, [])
@@ -203,61 +280,207 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         )
         return messages
 
-    def _decode_and_emit(self, request_id: str) -> list[OutgoingMessage]:
-        chunks = self._code_chunks[request_id]
-        start = self._emitted[request_id]
-        end = len(chunks)
-        audio = self._decode_incremental(request_id, chunks, start, end)
-        self._emitted[request_id] = end
+    def _decode_ready_requests(
+        self,
+        *,
+        force_request_ids: set[str] | None = None,
+        request_ids: list[str] | None = None,
+    ) -> list[OutgoingMessage]:
+        plans = self._build_decode_plans(
+            force_request_ids=force_request_ids or set(),
+            request_ids=request_ids,
+        )
+        if not plans:
+            return []
+
         messages: list[OutgoingMessage] = []
-        if audio.size > 0:
-            is_first = not self._audio_chunks[request_id]
-            self._audio_chunks[request_id].append(audio)
-            if is_first:
-                _emit_event(
-                    request_id=request_id,
-                    stage=None,
-                    event_name="code2wav_first_audio",
-                    metadata={"samples": int(audio.shape[0])},
-                )
-            if self._stream_enabled.get(request_id, True):
-                messages.append(
-                    OutgoingMessage(
-                        request_id=request_id,
-                        type="stream",
-                        target=None,
-                        data=self._build_audio_payload(audio),
-                        metadata={"modality": "audio"},
+        for group in self._group_decode_plans(plans):
+            for plan, audio in zip(group, self._decode_plan_batch(group)):
+                self._emitted[plan.request_id] = plan.end
+                if audio.size == 0:
+                    continue
+                is_first = not self._audio_chunks[plan.request_id]
+                self._audio_chunks[plan.request_id].append(audio)
+                if is_first:
+                    _emit_event(
+                        request_id=plan.request_id,
+                        stage=None,
+                        event_name="code2wav_first_audio",
+                        metadata={"samples": int(audio.shape[0])},
                     )
-                )
+                if self._stream_enabled.get(plan.request_id, True):
+                    messages.append(
+                        OutgoingMessage(
+                            request_id=plan.request_id,
+                            type="stream",
+                            target=None,
+                            data=self._build_audio_payload(audio),
+                            metadata={"modality": "audio"},
+                        )
+                    )
         return messages
 
-    def _decode_incremental(
-        self, request_id: str, code_chunks, start, end
-    ) -> np.ndarray:
-        if start >= end:
-            return np.zeros((0,), dtype=np.float32)
-        context = min(self._left_context_size, start)
-        window = torch.stack(code_chunks[start - context : end], dim=0)
-        codes = window.transpose(0, 1).unsqueeze(0)
+    def _build_decode_plans(
+        self,
+        *,
+        force_request_ids: set[str],
+        request_ids: list[str] | None,
+    ) -> list[_DecodePlan]:
+        plans: list[_DecodePlan] = []
+        candidate_ids = (
+            request_ids if request_ids is not None else list(self._code_chunks)
+        )
+        for request_id in candidate_ids:
+            if self._is_aborted(request_id):
+                continue
+            code_chunks = self._code_chunks.get(request_id)
+            if not code_chunks:
+                continue
+            start = self._emitted.get(request_id, 0)
+            end = len(code_chunks)
+            ready = end - start
+            if ready <= 0:
+                continue
+            if ready < self._stream_chunk_size and request_id not in force_request_ids:
+                continue
+            context = min(self._left_context_size, start)
+            window = torch.stack(code_chunks[start - context : end], dim=0)
+            codes = window.transpose(0, 1)
+            plans.append(
+                _DecodePlan(
+                    request_id=request_id,
+                    start=start,
+                    end=end,
+                    trim=context * self._total_upsample,
+                    codes=codes,
+                )
+            )
+        return plans
+
+    def _group_decode_plans(self, plans: list[_DecodePlan]) -> list[list[_DecodePlan]]:
+        if not self._enable_batched_decode:
+            return [[plan] for plan in plans]
+
+        grouped: dict[tuple[tuple[int, ...], int], list[_DecodePlan]] = {}
+        ordered_keys: list[tuple[tuple[int, ...], int]] = []
+        for plan in plans:
+            key = (tuple(plan.codes.shape), plan.trim)
+            if key not in grouped:
+                grouped[key] = []
+                ordered_keys.append(key)
+            grouped[key].append(plan)
+
+        batches: list[list[_DecodePlan]] = []
+        for key in ordered_keys:
+            group = grouped[key]
+            for start in range(0, len(group), self._decode_max_batch_size):
+                batches.append(group[start : start + self._decode_max_batch_size])
+        return batches
+
+    def _decode_plan_batch(self, plans: list[_DecodePlan]) -> list[np.ndarray]:
+        if not plans:
+            return []
+
+        codes = torch.stack([plan.codes for plan in plans], dim=0)
         with torch.no_grad():
             if self._device.type == "cuda":
                 torch.cuda.set_device(self._device)
             wav = self._model(codes)
-        trim = context * self._total_upsample
+        batch_size = len(plans)
+        if batch_size == 1:
+            wav = wav.reshape(1, -1)
+        elif int(wav.shape[0]) != batch_size:
+            raise RuntimeError(
+                "code2wav batched decode returned incompatible batch dimension: "
+                f"expected {batch_size}, got shape {tuple(wav.shape)}"
+            )
+        else:
+            wav = wav.reshape(batch_size, -1)
+
+        trim = plans[0].trim
         if trim:
-            wav = wav[..., trim:]
-        audio = wav.reshape(-1).detach().cpu().float().numpy().copy()
+            wav = wav[:, trim:]
+        audio_batch = wav.detach().to(device="cpu", dtype=torch.float32).numpy()
+        audio_parts = [audio_batch[i].copy() for i in range(batch_size)]
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
-                "Code2Wav decode window=%s start=%s end=%s trim=%s samples=%s",
+                "Code2Wav decode batch window=%s batch=%s start_end=%s trim=%s samples=%s",
                 tuple(codes.shape),
-                start,
-                end,
+                batch_size,
+                [(plan.start, plan.end) for plan in plans],
                 trim,
-                int(audio.shape[0]),
+                [int(audio.shape[0]) for audio in audio_parts],
             )
-        return audio
+        return audio_parts
+
+    def _has_ready_request(self) -> bool:
+        for request_id, chunks in self._code_chunks.items():
+            if self._is_aborted(request_id):
+                continue
+            ready = len(chunks) - self._emitted.get(request_id, 0)
+            if ready >= self._stream_chunk_size:
+                return True
+        return False
+
+    def _ready_request_count(self) -> int:
+        count = 0
+        for request_id, chunks in self._code_chunks.items():
+            if self._is_aborted(request_id):
+                continue
+            ready = len(chunks) - self._emitted.get(request_id, 0)
+            if ready >= self._stream_chunk_size:
+                count += 1
+        return count
+
+    def _collect_more_stream_chunks(self) -> None:
+        if self._decode_max_batch_size <= 1 or not self._has_ready_request():
+            return
+
+        deadline = time.monotonic() + self._decode_max_batch_wait_s
+        while self._ready_request_count() < self._decode_max_batch_size:
+            try:
+                msg = self.inbox.get_nowait()
+            except _queue_mod.Empty:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                try:
+                    msg = self.inbox.get(timeout=remaining)
+                except _queue_mod.Empty:
+                    break
+
+            if self._is_aborted(msg.request_id):
+                continue
+            if msg.type != "stream_chunk" or not isinstance(msg.data, StreamItem):
+                self._pending_messages.append(msg)
+                break
+            self._append_stream_chunk(msg.request_id, msg.data)
+
+    def _collect_more_stream_done(self) -> list[str]:
+        if self._decode_max_batch_size <= 1:
+            return []
+
+        request_ids: list[str] = []
+        deadline = time.monotonic() + self._decode_max_batch_wait_s
+        while len(request_ids) + 1 < self._decode_max_batch_size:
+            try:
+                msg = self.inbox.get_nowait()
+            except _queue_mod.Empty:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                try:
+                    msg = self.inbox.get(timeout=remaining)
+                except _queue_mod.Empty:
+                    break
+
+            if self._is_aborted(msg.request_id):
+                continue
+            if msg.type != "stream_done":
+                self._pending_messages.append(msg)
+                break
+            request_ids.append(msg.request_id)
+        return request_ids
 
     def _build_audio_payload(self, audio: np.ndarray) -> dict[str, Any]:
         return audio_waveform_payload(
@@ -276,6 +499,9 @@ def create_code2wav_scheduler(
     gpu_id: int | None = None,
     stream_chunk_size: int = 10,
     left_context_size: int = 25,
+    max_batch_size: int = 16,
+    max_batch_wait_ms: int = 1,
+    enable_batched_decode: bool = True,
 ):
     """Factory: returns Code2WavScheduler."""
     if gpu_id is not None:
@@ -286,4 +512,7 @@ def create_code2wav_scheduler(
         device=device,
         stream_chunk_size=stream_chunk_size,
         left_context_size=left_context_size,
+        max_batch_size=max_batch_size,
+        max_batch_wait_ms=max_batch_wait_ms,
+        enable_batched_decode=enable_batched_decode,
     )

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -8,6 +8,7 @@ runs vocoder incrementally, outputs final audio via outbox.
 from __future__ import annotations
 
 import logging
+import os
 import queue as _queue_mod
 import time
 from dataclasses import dataclass
@@ -33,6 +34,43 @@ class _DecodePlan:
     end: int
     trim: int
     codes: torch.Tensor
+
+
+@dataclass
+class _CodeTensorBuffer:
+    chunks: torch.Tensor | None = None
+    length: int = 0
+
+    def append(self, codes: torch.Tensor) -> None:
+        if self.chunks is None:
+            capacity = max(16, self.length + 1)
+            self.chunks = torch.empty(
+                (capacity, *codes.shape),
+                device=codes.device,
+                dtype=codes.dtype,
+            )
+        elif self.length >= int(self.chunks.shape[0]):
+            capacity = max(self.length + 1, int(self.chunks.shape[0]) * 2)
+            grown = torch.empty(
+                (capacity, *self.chunks.shape[1:]),
+                device=self.chunks.device,
+                dtype=self.chunks.dtype,
+            )
+            grown[: self.length].copy_(self.chunks[: self.length])
+            self.chunks = grown
+
+        if tuple(codes.shape) != tuple(self.chunks.shape[1:]):
+            raise RuntimeError(
+                "code2wav received inconsistent codec chunk shape: "
+                f"got {tuple(codes.shape)}, expected {tuple(self.chunks.shape[1:])}"
+            )
+        self.chunks[self.length].copy_(codes)
+        self.length += 1
+
+    def window(self, start: int, end: int) -> torch.Tensor:
+        if self.chunks is None:
+            raise RuntimeError("code2wav tensor buffer is empty")
+        return self.chunks[start:end]
 
 
 def load_code2wav_model(
@@ -88,9 +126,13 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         self._decode_max_batch_size = max(int(max_batch_size), 1)
         self._decode_max_batch_wait_s = max(float(max_batch_wait_ms), 0.0) / 1000.0
         self._enable_batched_decode = bool(enable_batched_decode)
+        self._enable_tensor_code_buffer = (
+            os.getenv("SGLANG_OMNI_QWEN3_CODE2WAV_TENSOR_BUFFER", "1") != "0"
+        )
 
         # Per-request state
         self._code_chunks: dict[str, list[torch.Tensor]] = {}
+        self._code_buffers: dict[str, _CodeTensorBuffer] = {}
         self._emitted: dict[str, int] = {}
         self._audio_chunks: dict[str, list[np.ndarray]] = {}
         self._stream_enabled: dict[str, bool] = {}
@@ -107,6 +149,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
 
     def clear_stream_state(self, request_id: str) -> None:
         self._code_chunks.pop(request_id, None)
+        self._code_buffers.pop(request_id, None)
         self._emitted.pop(request_id, None)
         self._audio_chunks.pop(request_id, None)
         self._stream_enabled.pop(request_id, None)
@@ -125,6 +168,8 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         if request_id in self._code_chunks:
             return
         self._code_chunks[request_id] = []
+        if self._enable_tensor_code_buffer:
+            self._code_buffers[request_id] = _CodeTensorBuffer()
         self._emitted[request_id] = 0
         self._audio_chunks[request_id] = []
 
@@ -227,7 +272,10 @@ class Code2WavScheduler(StreamingSimpleScheduler):
                     "Code2Wav skip EOS req=%s codes=%s", request_id, codes.tolist()
                 )
             return
-        self._code_chunks[request_id].append(codes)
+        if self._enable_tensor_code_buffer:
+            self._code_buffers[request_id].append(codes)
+        else:
+            self._code_chunks[request_id].append(codes)
 
     def on_stream_done(self, request_id: str) -> list[OutgoingMessage]:
         messages: list[OutgoingMessage] = []
@@ -252,7 +300,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
             logger.debug(
                 "Code2Wav finalize req=%s code_chunks=%s audio_parts=%s final_samples=%s",
                 request_id,
-                len(self._code_chunks[request_id]),
+                self._code_chunk_count(request_id),
                 len(audio_parts),
                 int(full_audio.shape[0]),
             )
@@ -266,7 +314,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
                 "sample_rate": self._sample_rate,
             }
         else:
-            final_data = self._build_audio_payload(full_audio)
+            final_data = self._build_audio_payload(full_audio, request_id=request_id)
         messages.append(
             OutgoingMessage(
                 request_id=request_id,
@@ -314,7 +362,10 @@ class Code2WavScheduler(StreamingSimpleScheduler):
                             request_id=plan.request_id,
                             type="stream",
                             target=None,
-                            data=self._build_audio_payload(audio),
+                            data=self._build_audio_payload(
+                                audio,
+                                request_id=plan.request_id,
+                            ),
                             metadata={"modality": "audio"},
                         )
                     )
@@ -330,21 +381,24 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         candidate_ids = (
             request_ids if request_ids is not None else list(self._code_chunks)
         )
+        start_ns = time.perf_counter_ns()
         for request_id in candidate_ids:
             if self._is_aborted(request_id):
                 continue
-            code_chunks = self._code_chunks.get(request_id)
-            if not code_chunks:
+            if request_id not in self._code_chunks:
+                continue
+            chunk_count = self._code_chunk_count(request_id)
+            if chunk_count <= 0:
                 continue
             start = self._emitted.get(request_id, 0)
-            end = len(code_chunks)
+            end = chunk_count
             ready = end - start
             if ready <= 0:
                 continue
             if ready < self._stream_chunk_size and request_id not in force_request_ids:
                 continue
             context = min(self._left_context_size, start)
-            window = torch.stack(code_chunks[start - context : end], dim=0)
+            window = self._code_window(request_id, start - context, end)
             codes = window.transpose(0, 1)
             plans.append(
                 _DecodePlan(
@@ -355,7 +409,32 @@ class Code2WavScheduler(StreamingSimpleScheduler):
                     codes=codes,
                 )
             )
+        if plans:
+            _emit_event(
+                request_id=plans[0].request_id,
+                stage=None,
+                event_name="code2wav_plan_build",
+                metadata={
+                    "plans": len(plans),
+                    "duration_us": (time.perf_counter_ns() - start_ns) / 1000.0,
+                    "tensor_buffer": self._enable_tensor_code_buffer,
+                },
+            )
         return plans
+
+    def _code_chunk_count(self, request_id: str) -> int:
+        if self._enable_tensor_code_buffer:
+            buffer = self._code_buffers.get(request_id)
+            return 0 if buffer is None else buffer.length
+        return len(self._code_chunks.get(request_id, ()))
+
+    def _code_window(self, request_id: str, start: int, end: int) -> torch.Tensor:
+        if self._enable_tensor_code_buffer:
+            buffer = self._code_buffers.get(request_id)
+            if buffer is None:
+                raise RuntimeError(f"code2wav missing tensor buffer for {request_id!r}")
+            return buffer.window(start, end)
+        return torch.stack(self._code_chunks[request_id][start:end], dim=0)
 
     def _group_decode_plans(self, plans: list[_DecodePlan]) -> list[list[_DecodePlan]]:
         if not self._enable_batched_decode:
@@ -381,6 +460,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         if not plans:
             return []
 
+        start_ns = time.perf_counter_ns()
         codes = torch.stack([plan.codes for plan in plans], dim=0)
         with torch.no_grad():
             if self._device.type == "cuda":
@@ -401,7 +481,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         if trim:
             wav = wav[:, trim:]
         audio_batch = wav.detach().to(device="cpu", dtype=torch.float32).numpy()
-        audio_parts = [audio_batch[i].copy() for i in range(batch_size)]
+        audio_parts = [audio_batch[i] for i in range(batch_size)]
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
                 "Code2Wav decode batch window=%s batch=%s start_end=%s trim=%s samples=%s",
@@ -411,14 +491,27 @@ class Code2WavScheduler(StreamingSimpleScheduler):
                 trim,
                 [int(audio.shape[0]) for audio in audio_parts],
             )
+        _emit_event(
+            request_id=plans[0].request_id,
+            stage=None,
+            event_name="code2wav_decode_batch",
+            metadata={
+                "batch_size": batch_size,
+                "window_shape": tuple(codes.shape),
+                "trim": trim,
+                "duration_us": (time.perf_counter_ns() - start_ns) / 1000.0,
+            },
+        )
         return audio_parts
 
     def _ready_request_count(self) -> int:
         count = 0
-        for request_id, chunks in self._code_chunks.items():
+        for request_id in self._code_chunks:
             if self._is_aborted(request_id):
                 continue
-            ready = len(chunks) - self._emitted.get(request_id, 0)
+            ready = self._code_chunk_count(request_id) - self._emitted.get(
+                request_id, 0
+            )
             if ready >= self._stream_chunk_size:
                 count += 1
         return count
@@ -475,13 +568,30 @@ class Code2WavScheduler(StreamingSimpleScheduler):
             request_ids.append(msg.request_id)
         return request_ids
 
-    def _build_audio_payload(self, audio: np.ndarray) -> dict[str, Any]:
-        return audio_waveform_payload(
+    def _build_audio_payload(
+        self,
+        audio: np.ndarray,
+        *,
+        request_id: str | None = None,
+    ) -> dict[str, Any]:
+        start_ns = time.perf_counter_ns()
+        payload = audio_waveform_payload(
             audio.astype(np.float32, copy=False),
             sample_rate=self._sample_rate,
             modality="audio",
             source_hint="Qwen3-Omni code2wav",
         )
+        if request_id is not None:
+            _emit_event(
+                request_id=request_id,
+                stage=None,
+                event_name="code2wav_audio_payload",
+                metadata={
+                    "samples": int(audio.shape[0]),
+                    "duration_us": (time.perf_counter_ns() - start_ns) / 1000.0,
+                },
+            )
+        return payload
 
 
 def create_code2wav_scheduler(

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -36,43 +36,6 @@ class _DecodePlan:
     codes: torch.Tensor
 
 
-@dataclass
-class _CodeTensorBuffer:
-    chunks: torch.Tensor | None = None
-    length: int = 0
-
-    def append(self, codes: torch.Tensor) -> None:
-        if self.chunks is None:
-            capacity = max(16, self.length + 1)
-            self.chunks = torch.empty(
-                (capacity, *codes.shape),
-                device=codes.device,
-                dtype=codes.dtype,
-            )
-        elif self.length >= int(self.chunks.shape[0]):
-            capacity = max(self.length + 1, int(self.chunks.shape[0]) * 2)
-            grown = torch.empty(
-                (capacity, *self.chunks.shape[1:]),
-                device=self.chunks.device,
-                dtype=self.chunks.dtype,
-            )
-            grown[: self.length].copy_(self.chunks[: self.length])
-            self.chunks = grown
-
-        if tuple(codes.shape) != tuple(self.chunks.shape[1:]):
-            raise RuntimeError(
-                "code2wav received inconsistent codec chunk shape: "
-                f"got {tuple(codes.shape)}, expected {tuple(self.chunks.shape[1:])}"
-            )
-        self.chunks[self.length].copy_(codes)
-        self.length += 1
-
-    def window(self, start: int, end: int) -> torch.Tensor:
-        if self.chunks is None:
-            raise RuntimeError("code2wav tensor buffer is empty")
-        return self.chunks[start:end]
-
-
 def load_code2wav_model(
     model_path: str, *, device: str = "cuda", dtype: str | None = None
 ):
@@ -109,58 +72,52 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         model: Any,
         device: str,
         stream_chunk_size: int = 10,
+        non_stream_chunk_size: int | None = None,
         left_context_size: int = 25,
         sample_rate: int = 24000,
         codec_eos_token_id: int = 2150,
         max_batch_size: int = 16,
         max_batch_wait_ms: int = 1,
         enable_batched_decode: bool = True,
-        first_stream_chunk_size: int | None = None,
     ):
         self._model = model
         self._device = torch.device(device)
         self._stream_chunk_size = max(int(stream_chunk_size), 1)
-        self._first_stream_chunk_size = self._resolve_first_stream_chunk_size(
-            self._stream_chunk_size,
-            first_stream_chunk_size,
+        env_non_stream_chunk_size = os.getenv(
+            "SGLANG_OMNI_QWEN3_CODE2WAV_NON_STREAM_CHUNK_SIZE"
         )
+        if env_non_stream_chunk_size is not None:
+            non_stream_chunk_size = int(env_non_stream_chunk_size)
+        self._non_stream_chunk_size = (
+            self._stream_chunk_size
+            if non_stream_chunk_size is None
+            else max(int(non_stream_chunk_size), 1)
+        )
+        env_left_context_size = os.getenv(
+            "SGLANG_OMNI_QWEN3_CODE2WAV_LEFT_CONTEXT_SIZE"
+        )
+        if env_left_context_size is not None:
+            left_context_size = int(env_left_context_size)
         self._left_context_size = max(int(left_context_size), 0)
         self._sample_rate = sample_rate
         self._codec_eos_token_id = codec_eos_token_id
         self._total_upsample = int(model.total_upsample)
         self._decode_max_batch_size = max(int(max_batch_size), 1)
+        env_batch_wait_ms = os.getenv(
+            "SGLANG_OMNI_QWEN3_CODE2WAV_MAX_BATCH_WAIT_MS"
+        )
+        if env_batch_wait_ms is not None:
+            max_batch_wait_ms = float(env_batch_wait_ms)
         self._decode_max_batch_wait_s = max(float(max_batch_wait_ms), 0.0) / 1000.0
         self._enable_batched_decode = bool(enable_batched_decode)
-        self._enable_tensor_code_buffer = (
-            os.getenv("SGLANG_OMNI_QWEN3_CODE2WAV_TENSOR_BUFFER", "1") != "0"
-        )
 
         # Per-request state
         self._code_chunks: dict[str, list[torch.Tensor]] = {}
-        self._code_buffers: dict[str, _CodeTensorBuffer] = {}
         self._emitted: dict[str, int] = {}
         self._audio_chunks: dict[str, list[np.ndarray]] = {}
         self._stream_enabled: dict[str, bool] = {}
         super().__init__(compute_fn=None)
         self._payloads = self._stream_payloads
-
-    @staticmethod
-    def _resolve_first_stream_chunk_size(
-        stream_chunk_size: int,
-        configured: int | None,
-    ) -> int:
-        env_value = os.getenv("SGLANG_OMNI_QWEN3_CODE2WAV_FIRST_CHUNK_SIZE")
-        if env_value is not None:
-            value = int(env_value)
-            if value <= 0:
-                return stream_chunk_size
-        elif configured is None:
-            value = min(stream_chunk_size, 8)
-        else:
-            value = int(configured)
-            if value <= 0:
-                return stream_chunk_size
-        return min(max(value, 1), stream_chunk_size)
 
     def is_streaming_payload(self, payload: StagePayload) -> bool:
         del payload
@@ -172,7 +129,6 @@ class Code2WavScheduler(StreamingSimpleScheduler):
 
     def clear_stream_state(self, request_id: str) -> None:
         self._code_chunks.pop(request_id, None)
-        self._code_buffers.pop(request_id, None)
         self._emitted.pop(request_id, None)
         self._audio_chunks.pop(request_id, None)
         self._stream_enabled.pop(request_id, None)
@@ -191,8 +147,6 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         if request_id in self._code_chunks:
             return
         self._code_chunks[request_id] = []
-        if self._enable_tensor_code_buffer:
-            self._code_buffers[request_id] = _CodeTensorBuffer()
         self._emitted[request_id] = 0
         self._audio_chunks[request_id] = []
 
@@ -295,10 +249,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
                     "Code2Wav skip EOS req=%s codes=%s", request_id, codes.tolist()
                 )
             return
-        if self._enable_tensor_code_buffer:
-            self._code_buffers[request_id].append(codes)
-        else:
-            self._code_chunks[request_id].append(codes)
+        self._code_chunks[request_id].append(codes)
 
     def on_stream_done(self, request_id: str) -> list[OutgoingMessage]:
         messages: list[OutgoingMessage] = []
@@ -323,7 +274,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
             logger.debug(
                 "Code2Wav finalize req=%s code_chunks=%s audio_parts=%s final_samples=%s",
                 request_id,
-                self._code_chunk_count(request_id),
+                len(self._code_chunks[request_id]),
                 len(audio_parts),
                 int(full_audio.shape[0]),
             )
@@ -337,7 +288,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
                 "sample_rate": self._sample_rate,
             }
         else:
-            final_data = self._build_audio_payload(full_audio, request_id=request_id)
+            final_data = self._build_audio_payload(full_audio)
         messages.append(
             OutgoingMessage(
                 request_id=request_id,
@@ -385,10 +336,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
                             request_id=plan.request_id,
                             type="stream",
                             target=None,
-                            data=self._build_audio_payload(
-                                audio,
-                                request_id=plan.request_id,
-                            ),
+                            data=self._build_audio_payload(audio),
                             metadata={"modality": "audio"},
                         )
                     )
@@ -404,25 +352,24 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         candidate_ids = (
             request_ids if request_ids is not None else list(self._code_chunks)
         )
-        start_ns = time.perf_counter_ns()
         for request_id in candidate_ids:
             if self._is_aborted(request_id):
                 continue
-            if request_id not in self._code_chunks:
-                continue
-            chunk_count = self._code_chunk_count(request_id)
-            if chunk_count <= 0:
+            code_chunks = self._code_chunks.get(request_id)
+            if not code_chunks:
                 continue
             start = self._emitted.get(request_id, 0)
-            end = chunk_count
+            end = len(code_chunks)
             ready = end - start
             if ready <= 0:
                 continue
-            threshold = self._decode_ready_threshold(request_id)
-            if ready < threshold and request_id not in force_request_ids:
+            if (
+                ready < self._decode_ready_threshold(request_id)
+                and request_id not in force_request_ids
+            ):
                 continue
             context = min(self._left_context_size, start)
-            window = self._code_window(request_id, start - context, end)
+            window = torch.stack(code_chunks[start - context : end], dim=0)
             codes = window.transpose(0, 1)
             plans.append(
                 _DecodePlan(
@@ -433,32 +380,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
                     codes=codes,
                 )
             )
-        if plans:
-            _emit_event(
-                request_id=plans[0].request_id,
-                stage=None,
-                event_name="code2wav_plan_build",
-                metadata={
-                    "plans": len(plans),
-                    "duration_us": (time.perf_counter_ns() - start_ns) / 1000.0,
-                    "tensor_buffer": self._enable_tensor_code_buffer,
-                },
-            )
         return plans
-
-    def _code_chunk_count(self, request_id: str) -> int:
-        if self._enable_tensor_code_buffer:
-            buffer = self._code_buffers.get(request_id)
-            return 0 if buffer is None else buffer.length
-        return len(self._code_chunks.get(request_id, ()))
-
-    def _code_window(self, request_id: str, start: int, end: int) -> torch.Tensor:
-        if self._enable_tensor_code_buffer:
-            buffer = self._code_buffers.get(request_id)
-            if buffer is None:
-                raise RuntimeError(f"code2wav missing tensor buffer for {request_id!r}")
-            return buffer.window(start, end)
-        return torch.stack(self._code_chunks[request_id][start:end], dim=0)
 
     def _group_decode_plans(self, plans: list[_DecodePlan]) -> list[list[_DecodePlan]]:
         if not self._enable_batched_decode:
@@ -484,7 +406,6 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         if not plans:
             return []
 
-        start_ns = time.perf_counter_ns()
         codes = torch.stack([plan.codes for plan in plans], dim=0)
         with torch.no_grad():
             if self._device.type == "cuda":
@@ -505,7 +426,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         if trim:
             wav = wav[:, trim:]
         audio_batch = wav.detach().to(device="cpu", dtype=torch.float32).numpy()
-        audio_parts = [audio_batch[i] for i in range(batch_size)]
+        audio_parts = [audio_batch[i].copy() for i in range(batch_size)]
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
                 "Code2Wav decode batch window=%s batch=%s start_end=%s trim=%s samples=%s",
@@ -515,37 +436,21 @@ class Code2WavScheduler(StreamingSimpleScheduler):
                 trim,
                 [int(audio.shape[0]) for audio in audio_parts],
             )
-        _emit_event(
-            request_id=plans[0].request_id,
-            stage=None,
-            event_name="code2wav_decode_batch",
-            metadata={
-                "batch_size": batch_size,
-                "window_shape": tuple(codes.shape),
-                "trim": trim,
-                "duration_us": (time.perf_counter_ns() - start_ns) / 1000.0,
-            },
-        )
         return audio_parts
 
     def _ready_request_count(self) -> int:
         count = 0
-        for request_id in self._code_chunks:
+        for request_id, chunks in self._code_chunks.items():
             if self._is_aborted(request_id):
                 continue
-            ready = self._code_chunk_count(request_id) - self._emitted.get(
-                request_id, 0
-            )
+            ready = len(chunks) - self._emitted.get(request_id, 0)
             if ready >= self._decode_ready_threshold(request_id):
                 count += 1
         return count
 
     def _decode_ready_threshold(self, request_id: str) -> int:
-        if (
-            self._stream_enabled.get(request_id, False)
-            and self._emitted.get(request_id, 0) == 0
-        ):
-            return self._first_stream_chunk_size
+        if not self._stream_enabled.get(request_id, True):
+            return self._non_stream_chunk_size
         return self._stream_chunk_size
 
     def _collect_more_stream_chunks(self) -> None:
@@ -600,30 +505,13 @@ class Code2WavScheduler(StreamingSimpleScheduler):
             request_ids.append(msg.request_id)
         return request_ids
 
-    def _build_audio_payload(
-        self,
-        audio: np.ndarray,
-        *,
-        request_id: str | None = None,
-    ) -> dict[str, Any]:
-        start_ns = time.perf_counter_ns()
-        payload = audio_waveform_payload(
+    def _build_audio_payload(self, audio: np.ndarray) -> dict[str, Any]:
+        return audio_waveform_payload(
             audio.astype(np.float32, copy=False),
             sample_rate=self._sample_rate,
             modality="audio",
             source_hint="Qwen3-Omni code2wav",
         )
-        if request_id is not None:
-            _emit_event(
-                request_id=request_id,
-                stage=None,
-                event_name="code2wav_audio_payload",
-                metadata={
-                    "samples": int(audio.shape[0]),
-                    "duration_us": (time.perf_counter_ns() - start_ns) / 1000.0,
-                },
-            )
-        return payload
 
 
 def create_code2wav_scheduler(
@@ -633,11 +521,11 @@ def create_code2wav_scheduler(
     dtype: str | None = None,
     gpu_id: int | None = None,
     stream_chunk_size: int = 10,
+    non_stream_chunk_size: int | None = None,
     left_context_size: int = 25,
     max_batch_size: int = 16,
     max_batch_wait_ms: int = 1,
     enable_batched_decode: bool = True,
-    first_stream_chunk_size: int | None = None,
 ):
     """Factory: returns Code2WavScheduler."""
     if gpu_id is not None:
@@ -647,9 +535,9 @@ def create_code2wav_scheduler(
         model,
         device=device,
         stream_chunk_size=stream_chunk_size,
+        non_stream_chunk_size=non_stream_chunk_size,
         left_context_size=left_context_size,
         max_batch_size=max_batch_size,
         max_batch_wait_ms=max_batch_wait_ms,
         enable_batched_decode=enable_batched_decode,
-        first_stream_chunk_size=first_stream_chunk_size,
     )

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -413,15 +413,6 @@ class Code2WavScheduler(StreamingSimpleScheduler):
             )
         return audio_parts
 
-    def _has_ready_request(self) -> bool:
-        for request_id, chunks in self._code_chunks.items():
-            if self._is_aborted(request_id):
-                continue
-            ready = len(chunks) - self._emitted.get(request_id, 0)
-            if ready >= self._stream_chunk_size:
-                return True
-        return False
-
     def _ready_request_count(self) -> int:
         count = 0
         for request_id, chunks in self._code_chunks.items():
@@ -433,11 +424,12 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         return count
 
     def _collect_more_stream_chunks(self) -> None:
-        if self._decode_max_batch_size <= 1 or not self._has_ready_request():
+        ready_count = self._ready_request_count()
+        if self._decode_max_batch_size <= 1 or ready_count == 0:
             return
 
         deadline = time.monotonic() + self._decode_max_batch_wait_s
-        while self._ready_request_count() < self._decode_max_batch_size:
+        while ready_count < self._decode_max_batch_size:
             try:
                 msg = self.inbox.get_nowait()
             except _queue_mod.Empty:
@@ -455,6 +447,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
                 self._pending_messages.append(msg)
                 break
             self._append_stream_chunk(msg.request_id, msg.data)
+            ready_count = self._ready_request_count()
 
     def _collect_more_stream_done(self) -> list[str]:
         if self._decode_max_batch_size <= 1:

--- a/sglang_omni/models/qwen3_omni/components/predictor_kernels.py
+++ b/sglang_omni/models/qwen3_omni/components/predictor_kernels.py
@@ -110,9 +110,7 @@ if has_triton_predictor_kernels():
         vocab_offsets = tl.arange(0, block_v)
         vocab_mask = vocab_offsets < vocab_size
         row_logits = tl.load(
-            logits
-            + row * logits_stride_b
-            + vocab_offsets * logits_stride_v,
+            logits + row * logits_stride_b + vocab_offsets * logits_stride_v,
             mask=vocab_mask,
             other=-float("inf"),
         )
@@ -173,9 +171,7 @@ def stage_initial_predictor_input_(
     if layer0_code.ndim != 1:
         raise ValueError(f"layer0_code must be 1D, got {tuple(layer0_code.shape)}")
     if talker_hidden.ndim != 2:
-        raise ValueError(
-            f"talker_hidden must be 2D, got {tuple(talker_hidden.shape)}"
-        )
+        raise ValueError(f"talker_hidden must be 2D, got {tuple(talker_hidden.shape)}")
     if predictor_input.ndim != 3:
         raise ValueError(
             f"predictor_input must be 3D, got {tuple(predictor_input.shape)}"

--- a/sglang_omni/models/qwen3_omni/components/predictor_kernels.py
+++ b/sglang_omni/models/qwen3_omni/components/predictor_kernels.py
@@ -1,0 +1,307 @@
+"""Optional Triton kernels for Qwen3-Omni talker code predictor."""
+
+from __future__ import annotations
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:  # pragma: no cover - exercised on CPU-only dev hosts.
+    triton = None
+    tl = None
+
+
+def has_triton_predictor_kernels() -> bool:
+    return triton is not None and tl is not None
+
+
+if has_triton_predictor_kernels():
+
+    @triton.jit
+    def _stage_initial_predictor_kernel(
+        layer0_code,
+        talker_hidden,
+        codec_weight,
+        predictor_input,
+        pos_codes,
+        pos_summed,
+        hidden_size: tl.constexpr,
+        layer0_code_stride_b: tl.constexpr,
+        talker_hidden_stride_b: tl.constexpr,
+        talker_hidden_stride_h: tl.constexpr,
+        codec_weight_stride_v: tl.constexpr,
+        codec_weight_stride_h: tl.constexpr,
+        predictor_input_stride_b: tl.constexpr,
+        predictor_input_stride_t: tl.constexpr,
+        predictor_input_stride_h: tl.constexpr,
+        pos_codes_stride_b: tl.constexpr,
+        pos_codes_stride_g: tl.constexpr,
+        pos_summed_stride_b: tl.constexpr,
+        pos_summed_stride_h: tl.constexpr,
+        block_h: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        offsets = tl.arange(0, block_h)
+        mask = offsets < hidden_size
+
+        code = tl.load(layer0_code + row * layer0_code_stride_b)
+        hidden = tl.load(
+            talker_hidden
+            + row * talker_hidden_stride_b
+            + offsets * talker_hidden_stride_h,
+            mask=mask,
+            other=0.0,
+        )
+        embed = tl.load(
+            codec_weight
+            + code * codec_weight_stride_v
+            + offsets * codec_weight_stride_h,
+            mask=mask,
+            other=0.0,
+        )
+
+        base = predictor_input + row * predictor_input_stride_b
+        tl.store(
+            base + offsets * predictor_input_stride_h,
+            hidden,
+            mask=mask,
+        )
+        tl.store(
+            base + predictor_input_stride_t + offsets * predictor_input_stride_h,
+            embed,
+            mask=mask,
+        )
+        tl.store(
+            pos_summed + row * pos_summed_stride_b + offsets * pos_summed_stride_h,
+            embed,
+            mask=mask,
+        )
+        tl.store(pos_codes + row * pos_codes_stride_b, code)
+
+    @triton.jit
+    def _sample_code_stage_predictor_kernel(
+        logits,
+        embedding_weight,
+        predictor_input,
+        pos_codes,
+        pos_summed,
+        vocab_size: tl.constexpr,
+        hidden_size: tl.constexpr,
+        logits_stride_b: tl.constexpr,
+        logits_stride_t: tl.constexpr,
+        logits_stride_v: tl.constexpr,
+        embedding_weight_stride_v: tl.constexpr,
+        embedding_weight_stride_h: tl.constexpr,
+        predictor_input_stride_b: tl.constexpr,
+        predictor_input_stride_t: tl.constexpr,
+        predictor_input_stride_h: tl.constexpr,
+        pos_codes_stride_b: tl.constexpr,
+        pos_codes_stride_g: tl.constexpr,
+        pos_summed_stride_b: tl.constexpr,
+        pos_summed_stride_h: tl.constexpr,
+        code_group: tl.constexpr,
+        input_slot: tl.constexpr,
+        block_v: tl.constexpr,
+        block_h: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+
+        vocab_offsets = tl.arange(0, block_v)
+        vocab_mask = vocab_offsets < vocab_size
+        row_logits = tl.load(
+            logits
+            + row * logits_stride_b
+            + vocab_offsets * logits_stride_v,
+            mask=vocab_mask,
+            other=-float("inf"),
+        )
+        max_val = tl.max(row_logits, axis=0)
+        first_max = tl.where(row_logits == max_val, vocab_offsets, block_v)
+        code = tl.min(first_max, axis=0)
+        tl.store(
+            pos_codes + row * pos_codes_stride_b + code_group * pos_codes_stride_g,
+            code,
+        )
+
+        hidden_offsets = tl.arange(0, block_h)
+        hidden_mask = hidden_offsets < hidden_size
+        embed = tl.load(
+            embedding_weight
+            + code * embedding_weight_stride_v
+            + hidden_offsets * embedding_weight_stride_h,
+            mask=hidden_mask,
+            other=0.0,
+        )
+        tl.store(
+            predictor_input
+            + row * predictor_input_stride_b
+            + input_slot * predictor_input_stride_t
+            + hidden_offsets * predictor_input_stride_h,
+            embed,
+            mask=hidden_mask,
+        )
+        old_sum = tl.load(
+            pos_summed
+            + row * pos_summed_stride_b
+            + hidden_offsets * pos_summed_stride_h,
+            mask=hidden_mask,
+            other=0.0,
+        )
+        tl.store(
+            pos_summed
+            + row * pos_summed_stride_b
+            + hidden_offsets * pos_summed_stride_h,
+            old_sum + embed,
+            mask=hidden_mask,
+        )
+
+
+def _can_launch(*tensors: torch.Tensor) -> bool:
+    return has_triton_predictor_kernels() and all(t.is_cuda for t in tensors)
+
+
+def stage_initial_predictor_input_(
+    *,
+    layer0_code: torch.Tensor,
+    talker_hidden: torch.Tensor,
+    codec_weight: torch.Tensor,
+    predictor_input: torch.Tensor,
+    pos_codes: torch.Tensor,
+    pos_summed: torch.Tensor,
+) -> bool:
+    if layer0_code.ndim != 1:
+        raise ValueError(f"layer0_code must be 1D, got {tuple(layer0_code.shape)}")
+    if talker_hidden.ndim != 2:
+        raise ValueError(
+            f"talker_hidden must be 2D, got {tuple(talker_hidden.shape)}"
+        )
+    if predictor_input.ndim != 3:
+        raise ValueError(
+            f"predictor_input must be 3D, got {tuple(predictor_input.shape)}"
+        )
+    if pos_codes.ndim != 2:
+        raise ValueError(f"pos_codes must be 2D, got {tuple(pos_codes.shape)}")
+    if pos_summed.ndim != 2:
+        raise ValueError(f"pos_summed must be 2D, got {tuple(pos_summed.shape)}")
+
+    batch_size, hidden_size = talker_hidden.shape
+    if batch_size == 0:
+        return True
+    if not _can_launch(
+        layer0_code,
+        talker_hidden,
+        codec_weight,
+        predictor_input,
+        pos_codes,
+        pos_summed,
+    ):
+        return False
+    if codec_weight.ndim != 2 or codec_weight.shape[1] != hidden_size:
+        return False
+    if predictor_input.shape[0] < batch_size or predictor_input.shape[2] != hidden_size:
+        return False
+    if pos_codes.shape[0] < batch_size or pos_codes.shape[1] < 1:
+        return False
+    if pos_summed.shape[0] < batch_size or pos_summed.shape[1] != hidden_size:
+        return False
+
+    block_h = triton.next_power_of_2(hidden_size)
+    _stage_initial_predictor_kernel[(batch_size,)](
+        layer0_code,
+        talker_hidden,
+        codec_weight,
+        predictor_input,
+        pos_codes,
+        pos_summed,
+        hidden_size,
+        layer0_code.stride(0),
+        talker_hidden.stride(0),
+        talker_hidden.stride(1),
+        codec_weight.stride(0),
+        codec_weight.stride(1),
+        predictor_input.stride(0),
+        predictor_input.stride(1),
+        predictor_input.stride(2),
+        pos_codes.stride(0),
+        pos_codes.stride(1),
+        pos_summed.stride(0),
+        pos_summed.stride(1),
+        block_h,
+        num_warps=8,
+    )
+    return True
+
+
+def sample_code_and_stage_(
+    *,
+    logits: torch.Tensor,
+    embedding_weight: torch.Tensor,
+    predictor_input: torch.Tensor,
+    pos_codes: torch.Tensor,
+    pos_summed: torch.Tensor,
+    layer_idx: int,
+) -> bool:
+    if logits.ndim != 3:
+        return False
+    if logits.shape[1] != 1:
+        return False
+    if embedding_weight.ndim != 2:
+        return False
+    if predictor_input.ndim != 3 or pos_codes.ndim != 2 or pos_summed.ndim != 2:
+        return False
+
+    batch_size, _, vocab_size = logits.shape
+    hidden_size = embedding_weight.shape[1]
+    code_group = layer_idx + 1
+    input_slot = layer_idx + 2
+    if batch_size == 0:
+        return True
+    if not _can_launch(
+        logits,
+        embedding_weight,
+        predictor_input,
+        pos_codes,
+        pos_summed,
+    ):
+        return False
+    if embedding_weight.shape[0] != vocab_size:
+        return False
+    if predictor_input.shape[0] < batch_size or predictor_input.shape[2] != hidden_size:
+        return False
+    if predictor_input.shape[1] <= input_slot:
+        return False
+    if pos_codes.shape[0] < batch_size or pos_codes.shape[1] <= code_group:
+        return False
+    if pos_summed.shape[0] < batch_size or pos_summed.shape[1] != hidden_size:
+        return False
+
+    block_v = triton.next_power_of_2(vocab_size)
+    block_h = triton.next_power_of_2(hidden_size)
+    _sample_code_stage_predictor_kernel[(batch_size,)](
+        logits,
+        embedding_weight,
+        predictor_input,
+        pos_codes,
+        pos_summed,
+        vocab_size,
+        hidden_size,
+        logits.stride(0),
+        logits.stride(1),
+        logits.stride(2),
+        embedding_weight.stride(0),
+        embedding_weight.stride(1),
+        predictor_input.stride(0),
+        predictor_input.stride(1),
+        predictor_input.stride(2),
+        pos_codes.stride(0),
+        pos_codes.stride(1),
+        pos_summed.stride(0),
+        pos_summed.stride(1),
+        code_group,
+        input_slot,
+        block_v,
+        block_h,
+        num_warps=8,
+    )
+    return True

--- a/sglang_omni/models/qwen3_omni/components/talker.py
+++ b/sglang_omni/models/qwen3_omni/components/talker.py
@@ -4,7 +4,6 @@ SGLang-native Talker model for Qwen3-Omni compatiable with hf formatting.
 
 from __future__ import annotations
 
-import os
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -909,10 +908,6 @@ class Qwen3OmniTalker(nn.Module):
             device=device,
             dtype=self.model.codec_embedding.weight.dtype,
         )
-        self._greedy_sample_fastpath_enabled = (
-            os.getenv("SGLANG_OMNI_QWEN3_GREEDY_SAMPLE_FASTPATH", "1") != "0"
-        )
-        self._decode_all_greedy = False
         _bind_default_weight_loaders(self)
         self._cached_params_dict = dict(self.named_parameters())
         self._sampler = None
@@ -955,7 +950,6 @@ class Qwen3OmniTalker(nn.Module):
         rep_toks: list[int] = []
         sup_rows: list[int] = []
         sup_toks: list[int] = []
-        all_greedy = True
 
         for row_idx, sched_req in enumerate(requests):
             data = sched_req.data
@@ -969,8 +963,6 @@ class Qwen3OmniTalker(nn.Module):
             top_ps.append(float(sp.top_p))
             top_ks.append(int(sp.top_k))
             min_ps.append(float(sp.min_p))
-            if temperature > 0.0:
-                all_greedy = False
             # Unseeded: rank-shared seed from the request id (same on every TP
             # rank), not os.urandom, else the ranks desync.
             seed = sp.sampling_seed
@@ -988,7 +980,6 @@ class Qwen3OmniTalker(nn.Module):
                     if 0 <= t < rep_vocab
                 }
                 if unique:
-                    all_greedy = False
                     rep_rows.extend([row_idx] * len(unique))
                     rep_toks.extend(unique)
 
@@ -1000,11 +991,8 @@ class Qwen3OmniTalker(nn.Module):
                     if 0 <= t < sup_vocab
                 ]
                 if valid_sup:
-                    all_greedy = False
                     sup_rows.extend([row_idx] * len(valid_sup))
                     sup_toks.extend(valid_sup)
-
-        self._decode_all_greedy = all_greedy
 
         rep_pen_dtype = self._repetition_penalties.dtype
         self._repetition_penalties[:batch_size, 0] = torch.tensor(
@@ -1174,13 +1162,6 @@ class Qwen3OmniTalker(nn.Module):
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         batch_size = logits.shape[0]
-        if getattr(self, "_greedy_sample_fastpath_enabled", True) and getattr(
-            self,
-            "_decode_all_greedy",
-            False,
-        ):
-            return torch.argmax(logits, dim=-1)
-
         logits = logits.clone()
 
         penalties = self._repetition_penalties[:batch_size].to(dtype=logits.dtype)

--- a/sglang_omni/models/qwen3_omni/components/talker.py
+++ b/sglang_omni/models/qwen3_omni/components/talker.py
@@ -18,6 +18,10 @@ from sglang_omni.models.qwen3_omni.components.thinker_model import (
     Qwen3OmniMoeThinkerTextDecoderLayer,
     Qwen3OmniMoeThinkerTextSparseMoeBlock,
 )
+from sglang_omni.models.qwen3_omni.components.predictor_kernels import (
+    sample_code_and_stage_,
+    stage_initial_predictor_input_,
+)
 from sglang_omni.models.qwen3_omni.hf_config import (
     Qwen3OmniMoeTalkerConfig,
     Qwen3OmniMoeTalkerTextConfig,
@@ -61,6 +65,38 @@ def _repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
         batch, num_kv_heads, n_rep, seq_len, head_dim
     )
     return hidden_states.reshape(batch, num_kv_heads * n_rep, seq_len, head_dim)
+
+
+def _scaled_dot_product_attention_gqa(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    is_causal: bool,
+) -> torch.Tensor:
+    num_kv_groups = q.shape[1] // k.shape[1]
+    if num_kv_groups == 1:
+        return torch.nn.functional.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            is_causal=is_causal,
+        )
+    try:
+        return torch.nn.functional.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            is_causal=is_causal,
+            enable_gqa=True,
+        )
+    except TypeError:
+        return torch.nn.functional.scaled_dot_product_attention(
+            q,
+            _repeat_kv(k, num_kv_groups),
+            _repeat_kv(v, num_kv_groups),
+            is_causal=is_causal,
+        )
 
 
 class ResizeMLP(nn.Module):
@@ -705,12 +741,8 @@ class Qwen3OmniMoeTalkerCodePredictor(nn.Module):
             1, 2
         )
 
-        num_kv_groups = attn.num_heads // attn.num_kv_heads
-        k = _repeat_kv(k, num_kv_groups)
-        v = _repeat_kv(v, num_kv_groups)
-
         # Use SDPA to match HF's attention computation
-        attn_output = torch.nn.functional.scaled_dot_product_attention(
+        attn_output = _scaled_dot_product_attention_gqa(
             q,
             k,
             v,
@@ -795,6 +827,9 @@ class Qwen3OmniTalker(nn.Module):
             predictor_len,
             device=device,
             dtype=torch.long,
+        )
+        self._predictor_position_rows = self._predictor_positions.unsqueeze(1).repeat(
+            1, max_batch_size
         )
         predictor_num_layers = len(self.code_predictor.model.layers)
         predictor_num_kv_heads = self.code_predictor.model.layers[
@@ -1237,8 +1272,6 @@ class Qwen3OmniTalker(nn.Module):
         num_groups = self.config.num_code_groups
         runtime_single_token = seq_len == 1
         if runtime_single_token:
-            self._output_codes[:batch_size].zero_()
-            self._output_embeds[:batch_size].zero_()
             result_codes = self._output_codes[:batch_size].unsqueeze(-1)
             summed_embeddings = self._output_embeds[:batch_size].unsqueeze(1)
         else:
@@ -1253,20 +1286,31 @@ class Qwen3OmniTalker(nn.Module):
                 device=predictor_input.device,
             )
 
+        codec_weight = self.get_input_embeddings().weight
         for pos in range(seq_len):
-            layer0_code = layer0_codes[:, pos : pos + 1]
-            layer0_embed = self.get_input_embeddings()(layer0_code).to(
-                dtype=predictor_input.dtype
-            )
+            layer0_code = layer0_codes[:, pos]
             pos_codes = result_codes[:, :, pos]
             pos_summed = summed_embeddings[:, pos, :]
-            pos_summed.zero_()
-            predictor_input[:, 0, :] = talker_hidden[:, pos, :].to(
-                dtype=predictor_input.dtype
+            staged = stage_initial_predictor_input_(
+                layer0_code=layer0_code,
+                talker_hidden=talker_hidden[:, pos, :],
+                codec_weight=codec_weight,
+                predictor_input=predictor_input,
+                pos_codes=pos_codes,
+                pos_summed=pos_summed,
             )
-            predictor_input[:, 1, :] = layer0_embed[:, 0, :]
-            pos_codes[:, 0].copy_(layer0_code[:, 0])
-            pos_summed.add_(layer0_embed[:, 0, :])
+            if not staged:
+                layer0_code_2d = layer0_code.unsqueeze(1)
+                layer0_embed = self.get_input_embeddings()(layer0_code_2d).to(
+                    dtype=predictor_input.dtype
+                )
+                pos_summed.zero_()
+                predictor_input[:, 0, :] = talker_hidden[:, pos, :].to(
+                    dtype=predictor_input.dtype
+                )
+                predictor_input[:, 1, :] = layer0_embed[:, 0, :]
+                pos_codes[:, 0].copy_(layer0_code)
+                pos_summed.add_(layer0_embed[:, 0, :])
 
             cache_len = 0
             self._predictor_forward_one_token(
@@ -1284,17 +1328,27 @@ class Qwen3OmniTalker(nn.Module):
 
             for layer_idx in range(num_groups - 1):
                 logits, _ = self.code_predictor.lm_head[layer_idx](last_hidden)
-                next_code = self._sample_code_predictor_token(logits)
-                pos_codes[:, layer_idx + 1].copy_(next_code[:, 0])
+                embedding = self.code_predictor.model.codec_embedding[layer_idx]
+                staged = sample_code_and_stage_(
+                    logits=logits,
+                    embedding_weight=embedding.weight,
+                    predictor_input=predictor_input,
+                    pos_codes=pos_codes,
+                    pos_summed=pos_summed,
+                    layer_idx=layer_idx,
+                )
+                if not staged:
+                    next_code = self._sample_code_predictor_token(logits)
+                    pos_codes[:, layer_idx + 1].copy_(next_code[:, 0])
 
-                new_embed = self.code_predictor.model.codec_embedding[layer_idx](
-                    next_code
-                ).to(dtype=predictor_input.dtype)
-                predictor_input[:, layer_idx + 2, :] = new_embed[:, 0, :]
-                pos_summed.add_(new_embed[:, 0, :])
+                    new_embed = embedding(next_code).to(dtype=predictor_input.dtype)
+                    predictor_input[:, layer_idx + 2, :] = new_embed[:, 0, :]
+                    pos_summed.add_(new_embed[:, 0, :])
                 if layer_idx < num_groups - 2:
                     last_hidden = self._predictor_forward_one_token(
-                        token_embeds=new_embed,
+                        token_embeds=predictor_input[
+                            :, layer_idx + 2 : layer_idx + 3, :
+                        ],
                         batch_size=batch_size,
                         cache_len=cache_len,
                     )
@@ -1312,9 +1366,7 @@ class Qwen3OmniTalker(nn.Module):
         """Process one predictor token against the cached prefix."""
         hidden_states = token_embeds
         hidden_size = hidden_states.shape[-1]
-        positions = self._predictor_positions[cache_len : cache_len + 1].repeat(
-            batch_size
-        )
+        positions = self._predictor_position_rows[cache_len, :batch_size]
 
         for layer_idx, layer in enumerate(self.code_predictor.model.layers):
             residual = hidden_states
@@ -1388,11 +1440,8 @@ class Qwen3OmniTalker(nn.Module):
 
         cached_k = layer_k_cache[:, :, : cache_len + 1, :]
         cached_v = layer_v_cache[:, :, : cache_len + 1, :]
-        num_kv_groups = attn.num_heads // attn.num_kv_heads
-        cached_k = _repeat_kv(cached_k, num_kv_groups)
-        cached_v = _repeat_kv(cached_v, num_kv_groups)
 
-        attn_output = torch.nn.functional.scaled_dot_product_attention(
+        attn_output = _scaled_dot_product_attention_gqa(
             q,
             cached_k,
             cached_v,

--- a/sglang_omni/models/qwen3_omni/components/talker.py
+++ b/sglang_omni/models/qwen3_omni/components/talker.py
@@ -4,6 +4,7 @@ SGLang-native Talker model for Qwen3-Omni compatiable with hf formatting.
 
 from __future__ import annotations
 
+import os
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -908,6 +909,10 @@ class Qwen3OmniTalker(nn.Module):
             device=device,
             dtype=self.model.codec_embedding.weight.dtype,
         )
+        self._greedy_sample_fastpath_enabled = (
+            os.getenv("SGLANG_OMNI_QWEN3_GREEDY_SAMPLE_FASTPATH", "1") != "0"
+        )
+        self._decode_all_greedy = False
         _bind_default_weight_loaders(self)
         self._cached_params_dict = dict(self.named_parameters())
         self._sampler = None
@@ -950,6 +955,7 @@ class Qwen3OmniTalker(nn.Module):
         rep_toks: list[int] = []
         sup_rows: list[int] = []
         sup_toks: list[int] = []
+        all_greedy = True
 
         for row_idx, sched_req in enumerate(requests):
             data = sched_req.data
@@ -957,11 +963,14 @@ class Qwen3OmniTalker(nn.Module):
             sp = req.sampling_params
 
             penalty = float(sp.repetition_penalty)
+            temperature = float(sp.temperature)
             rep_penalties.append(penalty)
-            temperatures.append(float(sp.temperature))
+            temperatures.append(temperature)
             top_ps.append(float(sp.top_p))
             top_ks.append(int(sp.top_k))
             min_ps.append(float(sp.min_p))
+            if temperature > 0.0:
+                all_greedy = False
             # Unseeded: rank-shared seed from the request id (same on every TP
             # rank), not os.urandom, else the ranks desync.
             seed = sp.sampling_seed
@@ -979,6 +988,7 @@ class Qwen3OmniTalker(nn.Module):
                     if 0 <= t < rep_vocab
                 }
                 if unique:
+                    all_greedy = False
                     rep_rows.extend([row_idx] * len(unique))
                     rep_toks.extend(unique)
 
@@ -990,8 +1000,11 @@ class Qwen3OmniTalker(nn.Module):
                     if 0 <= t < sup_vocab
                 ]
                 if valid_sup:
+                    all_greedy = False
                     sup_rows.extend([row_idx] * len(valid_sup))
                     sup_toks.extend(valid_sup)
+
+        self._decode_all_greedy = all_greedy
 
         rep_pen_dtype = self._repetition_penalties.dtype
         self._repetition_penalties[:batch_size, 0] = torch.tensor(
@@ -1161,6 +1174,13 @@ class Qwen3OmniTalker(nn.Module):
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         batch_size = logits.shape[0]
+        if getattr(self, "_greedy_sample_fastpath_enabled", True) and getattr(
+            self,
+            "_decode_all_greedy",
+            False,
+        ):
+            return torch.argmax(logits, dim=-1)
+
         logits = logits.clone()
 
         penalties = self._repetition_penalties[:batch_size].to(dtype=logits.dtype)

--- a/sglang_omni/models/qwen3_omni/components/talker.py
+++ b/sglang_omni/models/qwen3_omni/components/talker.py
@@ -14,14 +14,14 @@ from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.utils import add_prefix
 from torch import nn
 
+from sglang_omni.models.qwen3_omni.components.predictor_kernels import (
+    sample_code_and_stage_,
+    stage_initial_predictor_input_,
+)
 from sglang_omni.models.qwen3_omni.components.thinker_model import (
     Qwen3OmniMoeThinkerTextAttention,
     Qwen3OmniMoeThinkerTextDecoderLayer,
     Qwen3OmniMoeThinkerTextSparseMoeBlock,
-)
-from sglang_omni.models.qwen3_omni.components.predictor_kernels import (
-    sample_code_and_stage_,
-    stage_initial_predictor_input_,
 )
 from sglang_omni.models.qwen3_omni.hf_config import (
     Qwen3OmniMoeTalkerConfig,

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -24,7 +24,7 @@ _DEEPGEMM_PRECOMPILE_ENV_DEFAULTS = {"SGLANG_JIT_DEEPGEMM_PRECOMPILE": "0"}
 
 
 def _colocated_fused_stages() -> list[list[str]]:
-    if os.getenv("SGLANG_OMNI_QWEN3_FUSE_TALKER_CODE2WAV", "1") == "0":
+    if os.getenv("SGLANG_OMNI_QWEN3_FUSE_TALKER_CODE2WAV", "0") != "1":
         return []
     return [["talker_ar", "code2wav"]]
 

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import ClassVar
 
 from pydantic import Field
@@ -20,6 +21,12 @@ MIN_PARTIAL_START_CHUNKS = 3
 # FIXME (Ratish): Replace this with a bounded/pre-ready SGLang DeepGEMM compile
 # policy once that exists outside import-time environment globals.
 _DEEPGEMM_PRECOMPILE_ENV_DEFAULTS = {"SGLANG_JIT_DEEPGEMM_PRECOMPILE": "0"}
+
+
+def _colocated_fused_stages() -> list[list[str]]:
+    if os.getenv("SGLANG_OMNI_QWEN3_FUSE_TALKER_CODE2WAV", "1") == "0":
+        return []
+    return [["talker_ar", "code2wav"]]
 
 
 def _preprocessing_stage(*, process: str) -> StageConfig:
@@ -345,6 +352,7 @@ class Qwen3OmniSpeechColocatedPipelineConfig(Qwen3OmniSpeechPipelineConfig):
             enable_partial_start=False,
         )
     )
+    fused_stages: list[list[str]] = Field(default_factory=_colocated_fused_stages)
 
 
 EntryClass = Qwen3OmniSpeechPipelineConfig

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -192,7 +192,11 @@ def _code2wav_stage(*, gpu: int, process: str) -> StageConfig:
         name="code2wav",
         process=process,
         factory=f"{_PKG}.components.code2wav_scheduler.create_code2wav_scheduler",
-        factory_args={"device": "cuda"},
+        factory_args={
+            "device": "cuda",
+            "max_batch_wait_ms": 5,
+            "non_stream_chunk_size": 20,
+        },
         gpu=gpu,
         terminal=True,
         can_accept_stream_before_payload=True,
@@ -349,7 +353,7 @@ class Qwen3OmniSpeechColocatedPipelineConfig(Qwen3OmniSpeechPipelineConfig):
             thinker_gpu=0,
             talker_gpu=0,
             process_by_stage=_SPEECH_DEFAULT_PROCESSES,
-            enable_partial_start=False,
+            enable_partial_start=True,
         )
     )
     fused_stages: list[list[str]] = Field(default_factory=_colocated_fused_stages)

--- a/sglang_omni/models/qwen3_omni/talker_model_runner.py
+++ b/sglang_omni/models/qwen3_omni/talker_model_runner.py
@@ -3,15 +3,12 @@
 
 from __future__ import annotations
 
-import os
-import time
 from typing import Any
 
 import torch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 
 from sglang_omni.model_runner.base import ModelRunner
-from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.scheduling.messages import OutgoingMessage
 
 
@@ -30,9 +27,6 @@ class QwenTalkerModelRunner(ModelRunner):
         self._outbox = outbox
         self._code2wav_target = code2wav_target
         self._feedback_enabled = bool(feedback_enabled)
-        self._enable_batched_emit = (
-            os.getenv("SGLANG_OMNI_QWEN3_BATCH_TALKER_EMIT", "1") != "0"
-        )
 
     def execute(self, scheduler_output: Any):
         return super().execute(scheduler_output)
@@ -120,31 +114,10 @@ class QwenTalkerModelRunner(ModelRunner):
         schedule_batch: Any,
         requests: list,
     ) -> None:
-        batch_size = len(requests)
-        if batch_size == 0:
-            return
-
-        start_ns = time.perf_counter_ns()
-        enable_batched_emit = getattr(self, "_enable_batched_emit", True)
-        if enable_batched_emit:
-            code_rows = self.model._output_codes[:batch_size].detach().clone().unbind(0)
-            feedback_rows = (
-                self.model._output_embeds[:batch_size].detach().clone().unbind(0)
-            )
-        else:
-            code_rows = [
-                self.model._output_codes[idx].detach().clone()
-                for idx in range(batch_size)
-            ]
-            feedback_rows = [
-                self.model._output_embeds[idx].detach().clone()
-                for idx in range(batch_size)
-            ]
-
         for idx, sched_req in enumerate(requests):
             req = schedule_batch.reqs[idx]
-            code_chunk = code_rows[idx]
-            feedback_row = feedback_rows[idx]
+            code_chunk = self.model._output_codes[idx].detach().clone()
+            feedback_row = self.model._output_embeds[idx].detach().clone()
             # Tell code2wav whether to forward audio chunks to the Coordinator.
             stage_payload = sched_req.data.stage_payload
             is_streaming = bool(
@@ -161,16 +134,6 @@ class QwenTalkerModelRunner(ModelRunner):
                 )
             )
             sched_req.data.pending_feedback_queue.append(feedback_row)
-        _emit_event(
-            request_id=schedule_batch.reqs[0].rid,
-            stage=None,
-            event_name="talker_emit_code_feedback",
-            metadata={
-                "batch_size": batch_size,
-                "batched": enable_batched_emit,
-                "duration_us": (time.perf_counter_ns() - start_ns) / 1000.0,
-            },
-        )
 
     def sample_before_post_prefill(
         self, forward_batch: Any, schedule_batch: Any, requests: list
@@ -377,7 +340,6 @@ class QwenTalkerModelRunner(ModelRunner):
         if batch_size == 0:
             return
 
-        start_ns = time.perf_counter_ns()
         feedback_buffer = self.model._feedback_buffer
         feedback_mask = self.model._feedback_mask
         feedback_mask[:batch_size] = False
@@ -396,30 +358,10 @@ class QwenTalkerModelRunner(ModelRunner):
             rows.append(row_idx)
             embeds.append(combined)
         if rows:
+            rows_t = torch.tensor(rows, dtype=torch.long, device=feedback_buffer.device)
             embeds_stacked = torch.stack(embeds, dim=0)
-            if len(rows) == batch_size and rows[0] == 0 and rows[-1] == batch_size - 1:
-                feedback_buffer[:batch_size] = embeds_stacked
-                feedback_mask[:batch_size] = True
-            else:
-                rows_t = torch.tensor(
-                    rows,
-                    dtype=torch.long,
-                    device=feedback_buffer.device,
-                )
-                feedback_buffer[rows_t] = embeds_stacked
-                feedback_mask[rows_t] = True
-        _emit_event(
-            request_id=getattr(
-                getattr(requests[0].data, "req", None), "rid", "unknown"
-            ),
-            stage=None,
-            event_name="talker_feedback_buffer_write",
-            metadata={
-                "batch_size": batch_size,
-                "rows": len(rows),
-                "duration_us": (time.perf_counter_ns() - start_ns) / 1000.0,
-            },
-        )
+            feedback_buffer[rows_t] = embeds_stacked
+            feedback_mask[rows_t] = True
 
     @staticmethod
     def _data_has_next_decode_input(data: Any) -> bool:

--- a/sglang_omni/models/qwen3_omni/talker_model_runner.py
+++ b/sglang_omni/models/qwen3_omni/talker_model_runner.py
@@ -3,12 +3,15 @@
 
 from __future__ import annotations
 
+import os
+import time
 from typing import Any
 
 import torch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 
 from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.scheduling.messages import OutgoingMessage
 
 
@@ -27,6 +30,9 @@ class QwenTalkerModelRunner(ModelRunner):
         self._outbox = outbox
         self._code2wav_target = code2wav_target
         self._feedback_enabled = bool(feedback_enabled)
+        self._enable_batched_emit = (
+            os.getenv("SGLANG_OMNI_QWEN3_BATCH_TALKER_EMIT", "1") != "0"
+        )
 
     def execute(self, scheduler_output: Any):
         return super().execute(scheduler_output)
@@ -114,10 +120,31 @@ class QwenTalkerModelRunner(ModelRunner):
         schedule_batch: Any,
         requests: list,
     ) -> None:
+        batch_size = len(requests)
+        if batch_size == 0:
+            return
+
+        start_ns = time.perf_counter_ns()
+        enable_batched_emit = getattr(self, "_enable_batched_emit", True)
+        if enable_batched_emit:
+            code_rows = self.model._output_codes[:batch_size].detach().clone().unbind(0)
+            feedback_rows = (
+                self.model._output_embeds[:batch_size].detach().clone().unbind(0)
+            )
+        else:
+            code_rows = [
+                self.model._output_codes[idx].detach().clone()
+                for idx in range(batch_size)
+            ]
+            feedback_rows = [
+                self.model._output_embeds[idx].detach().clone()
+                for idx in range(batch_size)
+            ]
+
         for idx, sched_req in enumerate(requests):
             req = schedule_batch.reqs[idx]
-            code_chunk = self.model._output_codes[idx].detach().clone()
-            feedback_row = self.model._output_embeds[idx].detach().clone()
+            code_chunk = code_rows[idx]
+            feedback_row = feedback_rows[idx]
             # Tell code2wav whether to forward audio chunks to the Coordinator.
             stage_payload = sched_req.data.stage_payload
             is_streaming = bool(
@@ -134,6 +161,16 @@ class QwenTalkerModelRunner(ModelRunner):
                 )
             )
             sched_req.data.pending_feedback_queue.append(feedback_row)
+        _emit_event(
+            request_id=schedule_batch.reqs[0].rid,
+            stage=None,
+            event_name="talker_emit_code_feedback",
+            metadata={
+                "batch_size": batch_size,
+                "batched": enable_batched_emit,
+                "duration_us": (time.perf_counter_ns() - start_ns) / 1000.0,
+            },
+        )
 
     def sample_before_post_prefill(
         self, forward_batch: Any, schedule_batch: Any, requests: list
@@ -340,6 +377,7 @@ class QwenTalkerModelRunner(ModelRunner):
         if batch_size == 0:
             return
 
+        start_ns = time.perf_counter_ns()
         feedback_buffer = self.model._feedback_buffer
         feedback_mask = self.model._feedback_mask
         feedback_mask[:batch_size] = False
@@ -358,10 +396,28 @@ class QwenTalkerModelRunner(ModelRunner):
             rows.append(row_idx)
             embeds.append(combined)
         if rows:
-            rows_t = torch.tensor(rows, dtype=torch.long, device=feedback_buffer.device)
             embeds_stacked = torch.stack(embeds, dim=0)
-            feedback_buffer[rows_t] = embeds_stacked
-            feedback_mask[rows_t] = True
+            if len(rows) == batch_size and rows[0] == 0 and rows[-1] == batch_size - 1:
+                feedback_buffer[:batch_size] = embeds_stacked
+                feedback_mask[:batch_size] = True
+            else:
+                rows_t = torch.tensor(
+                    rows,
+                    dtype=torch.long,
+                    device=feedback_buffer.device,
+                )
+                feedback_buffer[rows_t] = embeds_stacked
+                feedback_mask[rows_t] = True
+        _emit_event(
+            request_id=getattr(getattr(requests[0].data, "req", None), "rid", "unknown"),
+            stage=None,
+            event_name="talker_feedback_buffer_write",
+            metadata={
+                "batch_size": batch_size,
+                "rows": len(rows),
+                "duration_us": (time.perf_counter_ns() - start_ns) / 1000.0,
+            },
+        )
 
     @staticmethod
     def _data_has_next_decode_input(data: Any) -> bool:

--- a/sglang_omni/models/qwen3_omni/talker_model_runner.py
+++ b/sglang_omni/models/qwen3_omni/talker_model_runner.py
@@ -409,7 +409,9 @@ class QwenTalkerModelRunner(ModelRunner):
                 feedback_buffer[rows_t] = embeds_stacked
                 feedback_mask[rows_t] = True
         _emit_event(
-            request_id=getattr(getattr(requests[0].data, "req", None), "rid", "unknown"),
+            request_id=getattr(
+                getattr(requests[0].data, "req", None), "rid", "unknown"
+            ),
             stage=None,
             event_name="talker_feedback_buffer_write",
             metadata={

--- a/sglang_omni/models/qwen3_omni/talker_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/talker_scheduler.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from collections import deque
 from typing import Any
 
@@ -48,6 +49,9 @@ class QwenTalkerScheduler(OmniScheduler):
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
+        env_min_chunks = os.getenv("SGLANG_OMNI_QWEN3_PARTIAL_START_MIN_CHUNKS")
+        if env_min_chunks is not None:
+            partial_start_min_chunks = int(env_min_chunks)
         if partial_start_min_chunks < MIN_PARTIAL_START_CHUNKS:
             raise ValueError(
                 f"partial_start_min_chunks must be >= {MIN_PARTIAL_START_CHUNKS}, "

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 import multiprocessing
 import socket
+import time
 from typing import Any
 
 from sglang_omni.config.placement import (
@@ -163,6 +164,37 @@ def _build_stage_groups(
     groups.extend(tp_groups)
 
     return groups
+
+
+def _pop_startup_batch(
+    groups: list[StageGroup],
+) -> tuple[list[StageGroup], list[StageGroup]]:
+    batch: list[StageGroup] = []
+    deferred: list[StageGroup] = []
+    used_gpu_ids: set[int] = set()
+    for group in groups:
+        gpu_ids = getattr(group, "gpu_ids", set())
+        if gpu_ids and used_gpu_ids.intersection(gpu_ids):
+            deferred.append(group)
+            continue
+        batch.append(group)
+        used_gpu_ids.update(gpu_ids)
+    return batch, deferred
+
+
+async def _spawn_and_wait_startup_batches(
+    groups: list[StageGroup],
+    ctx: multiprocessing.context.BaseContext,
+    timeout: float,
+) -> None:
+    pending = list(groups)
+    deadline = time.monotonic() + timeout
+    while pending:
+        batch, pending = _pop_startup_batch(pending)
+        for group in batch:
+            group.spawn(ctx)
+        remaining = max(0.0, deadline - time.monotonic())
+        await asyncio.gather(*(group.wait_ready(remaining) for group in batch))
 
 
 def _resolve_same_process_targets(
@@ -406,10 +438,7 @@ class MultiProcessPipelineRunner:
             if self._config.env_defaults:
                 env_names = ", ".join(sorted(self._config.env_defaults))
                 logger.info(f"Configured stage process env defaults: {env_names}")
-            for group in self._groups:
-                group.spawn(ctx)
-
-            await asyncio.gather(*(g.wait_ready(timeout) for g in self._groups))
+            await _spawn_and_wait_startup_batches(self._groups, ctx, timeout)
 
             for group in self._groups:
                 if group.any_dead():

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -205,6 +205,17 @@ class StageGroup:
         return len(self.process_specs)
 
     @property
+    def gpu_ids(self) -> set[int]:
+        ids: set[int] = set()
+        for process_spec in self.process_specs:
+            if process_spec.gpu_id is not None:
+                ids.add(int(process_spec.gpu_id))
+            for stage_spec in process_spec.stage_specs:
+                if stage_spec.gpu_id is not None:
+                    ids.add(int(stage_spec.gpu_id))
+        return ids
+
+    @property
     def specs(self) -> list[StageLaunchConfig]:
         return [
             stage_spec

--- a/sglang_omni/preprocessing/video.py
+++ b/sglang_omni/preprocessing/video.py
@@ -38,7 +38,6 @@ class _VideoDecodeCacheEntry:
 
 
 _video_decode_cache: OrderedDict[str, _VideoDecodeCacheEntry] = OrderedDict()
-_video_decode_cache_bytes = 0
 _video_decode_cache_lock = threading.Lock()
 
 
@@ -47,10 +46,8 @@ class VideoDecodeError(RuntimeError):
 
 
 def clear_video_decode_cache() -> None:
-    global _video_decode_cache_bytes
     with _video_decode_cache_lock:
         _video_decode_cache.clear()
-        _video_decode_cache_bytes = 0
 
 
 def _video_decode_cache_enabled() -> bool:
@@ -122,7 +119,6 @@ def _put_video_decode_cache(
     video: torch.Tensor,
     sample_fps: float,
 ) -> None:
-    global _video_decode_cache_bytes
     if key is None or not isinstance(video, torch.Tensor):
         return
     max_bytes = _video_decode_cache_max_bytes()
@@ -132,18 +128,16 @@ def _put_video_decode_cache(
     if nbytes <= 0 or nbytes > max_bytes:
         return
     with _video_decode_cache_lock:
-        old = _video_decode_cache.pop(key, None)
-        if old is not None:
-            _video_decode_cache_bytes -= old.nbytes
-        while _video_decode_cache and _video_decode_cache_bytes + nbytes > max_bytes:
+        _video_decode_cache.pop(key, None)
+        current_bytes = sum(entry.nbytes for entry in _video_decode_cache.values())
+        while _video_decode_cache and current_bytes + nbytes > max_bytes:
             _, evicted = _video_decode_cache.popitem(last=False)
-            _video_decode_cache_bytes -= evicted.nbytes
+            current_bytes -= evicted.nbytes
         _video_decode_cache[key] = _VideoDecodeCacheEntry(
             video=video,
             sample_fps=sample_fps,
             nbytes=nbytes,
         )
-        _video_decode_cache_bytes += nbytes
 
 
 class VideoMediaIO(MediaIO[tuple[torch.Tensor, float, Any | None]]):

--- a/sglang_omni/preprocessing/video.py
+++ b/sglang_omni/preprocessing/video.py
@@ -54,7 +54,7 @@ def clear_video_decode_cache() -> None:
 
 
 def _video_decode_cache_enabled() -> bool:
-    return os.getenv("SGLANG_OMNI_VIDEO_DECODE_CACHE", "1") != "0"
+    return os.getenv("SGLANG_OMNI_VIDEO_DECODE_CACHE", "0") == "1"
 
 
 def _video_decode_cache_max_bytes() -> int:

--- a/sglang_omni/preprocessing/video.py
+++ b/sglang_omni/preprocessing/video.py
@@ -6,7 +6,11 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
+import os
 import tempfile
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -23,9 +27,123 @@ from .resource_connector import global_thread_pool
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_VIDEO_DECODE_CACHE_BYTES = 8 * 1024 * 1024 * 1024
+
+
+@dataclass
+class _VideoDecodeCacheEntry:
+    video: torch.Tensor
+    sample_fps: float
+    nbytes: int
+
+
+_video_decode_cache: OrderedDict[str, _VideoDecodeCacheEntry] = OrderedDict()
+_video_decode_cache_bytes = 0
+_video_decode_cache_lock = threading.Lock()
+
 
 class VideoDecodeError(RuntimeError):
     """Raised when video decoding fails."""
+
+
+def clear_video_decode_cache() -> None:
+    global _video_decode_cache_bytes
+    with _video_decode_cache_lock:
+        _video_decode_cache.clear()
+        _video_decode_cache_bytes = 0
+
+
+def _video_decode_cache_enabled() -> bool:
+    return os.getenv("SGLANG_OMNI_VIDEO_DECODE_CACHE", "1") != "0"
+
+
+def _video_decode_cache_max_bytes() -> int:
+    raw = os.getenv("SGLANG_OMNI_VIDEO_DECODE_CACHE_MAX_BYTES")
+    if raw is None:
+        return _DEFAULT_VIDEO_DECODE_CACHE_BYTES
+    try:
+        return max(int(raw), 0)
+    except ValueError:
+        logger.warning(
+            "Invalid SGLANG_OMNI_VIDEO_DECODE_CACHE_MAX_BYTES=%r; disabling cache",
+            raw,
+        )
+        return 0
+
+
+def _should_cache_video_path(path: Path) -> bool:
+    if not _video_decode_cache_enabled():
+        return False
+    try:
+        path.resolve().relative_to(Path(tempfile.gettempdir()).resolve())
+    except OSError:
+        return False
+    except ValueError:
+        return True
+    return False
+
+
+def _video_decode_cache_key(
+    path: Path,
+    *,
+    fps: float | None,
+    max_frames: int | None,
+    min_pixels: int | None,
+    max_pixels: int | None,
+    total_pixels: int | None,
+) -> str | None:
+    if not _should_cache_video_path(path):
+        return None
+    try:
+        stat = path.stat()
+        resolved = path.resolve()
+    except OSError:
+        return None
+    return (
+        f"{resolved}|mtime_ns={stat.st_mtime_ns}|size={stat.st_size}"
+        f"|fps={fps}|max_frames={max_frames}|min_pixels={min_pixels}"
+        f"|max_pixels={max_pixels}|total_pixels={total_pixels}"
+    )
+
+
+def _get_video_decode_cache(key: str | None) -> tuple[torch.Tensor, float] | None:
+    if key is None:
+        return None
+    with _video_decode_cache_lock:
+        entry = _video_decode_cache.get(key)
+        if entry is None:
+            return None
+        _video_decode_cache.move_to_end(key)
+        return entry.video, entry.sample_fps
+
+
+def _put_video_decode_cache(
+    key: str | None,
+    video: torch.Tensor,
+    sample_fps: float,
+) -> None:
+    global _video_decode_cache_bytes
+    if key is None or not isinstance(video, torch.Tensor):
+        return
+    max_bytes = _video_decode_cache_max_bytes()
+    if max_bytes <= 0:
+        return
+    nbytes = int(video.numel() * video.element_size())
+    if nbytes <= 0 or nbytes > max_bytes:
+        return
+    with _video_decode_cache_lock:
+        old = _video_decode_cache.pop(key, None)
+        if old is not None:
+            _video_decode_cache_bytes -= old.nbytes
+        while _video_decode_cache and _video_decode_cache_bytes + nbytes > max_bytes:
+            _, evicted = _video_decode_cache.popitem(last=False)
+            _video_decode_cache_bytes -= evicted.nbytes
+        _video_decode_cache[key] = _VideoDecodeCacheEntry(
+            video=video,
+            sample_fps=sample_fps,
+            nbytes=nbytes,
+        )
+        _video_decode_cache_bytes += nbytes
 
 
 class VideoMediaIO(MediaIO[tuple[torch.Tensor, float, Any | None]]):
@@ -300,6 +418,66 @@ def _extract_audio_from_path(video_path: Path, target_sr: int) -> Any | None:
         return None
 
 
+def _unpack_video_reader_result(result: Any) -> tuple[torch.Tensor, float]:
+    if isinstance(result, tuple) and len(result) == 2:
+        video, sample_fps = result
+    elif isinstance(result, tuple) and len(result) == 3:
+        video, _metadata, sample_fps = result
+    else:
+        raise ValueError(
+            "Video reader must return (video, sample_fps) or "
+            "(video, metadata, sample_fps)"
+        )
+    if not isinstance(video, torch.Tensor):
+        raise TypeError(f"Video reader returned {type(video).__name__}, not Tensor")
+    return video, float(sample_fps)
+
+
+def _read_video_backend(
+    backend: str,
+    ele: dict[str, Any],
+) -> tuple[torch.Tensor, float]:
+    reader = qwen_vision.VIDEO_READER_BACKENDS[backend]
+    return _unpack_video_reader_result(reader(ele))
+
+
+def _image_resize_factor() -> int:
+    return int(getattr(qwen_vision, "IMAGE_FACTOR", 28))
+
+
+def _video_resize_budget(
+    ele: dict[str, Any],
+    *,
+    nframes: int,
+) -> tuple[int | None, int | None]:
+    min_pixels = ele.get("min_pixels", getattr(qwen_vision, "VIDEO_MIN_PIXELS", None))
+    total_pixels = ele.get(
+        "total_pixels",
+        getattr(qwen_vision, "VIDEO_TOTAL_PIXELS", None),
+    )
+    max_pixels_default = getattr(qwen_vision, "VIDEO_MAX_PIXELS", None)
+    frame_factor = getattr(qwen_vision, "FRAME_FACTOR", 2)
+
+    max_pixels = None
+    if total_pixels is not None:
+        max_pixels = total_pixels / nframes * frame_factor
+        if max_pixels_default is not None:
+            max_pixels = min(max_pixels_default, max_pixels)
+        if min_pixels is not None:
+            max_pixels = max(max_pixels, int(min_pixels * 1.05))
+
+    requested_max_pixels = ele.get("max_pixels", max_pixels)
+    if max_pixels is not None and requested_max_pixels is not None:
+        max_pixels = min(requested_max_pixels, max_pixels)
+    else:
+        max_pixels = requested_max_pixels
+
+    return (
+        int(min_pixels) if min_pixels is not None else None,
+        int(max_pixels) if max_pixels is not None else None,
+    )
+
+
 def load_video_path(
     path: str | Path,
     fps: float | None = None,
@@ -310,6 +488,18 @@ def load_video_path(
 ) -> tuple[torch.Tensor, float]:
     """Load a local video into a torch tensor (T, C, H, W) on CPU."""
     path = Path(path)
+    cache_key = _video_decode_cache_key(
+        path,
+        fps=fps,
+        max_frames=max_frames,
+        min_pixels=min_pixels,
+        max_pixels=max_pixels,
+        total_pixels=total_pixels,
+    )
+    cached = _get_video_decode_cache(cache_key)
+    if cached is not None:
+        return cached
+
     ele: dict[str, Any] = {"video": str(path)}
     if fps is not None:
         ele["fps"] = float(fps)
@@ -322,47 +512,42 @@ def load_video_path(
     if total_pixels is not None:
         ele["total_pixels"] = int(total_pixels)
     backend = qwen_vision.get_video_reader_backend()
-    try:
-        video, sample_fps = qwen_vision.VIDEO_READER_BACKENDS[backend](ele)
-    except Exception as backend_exc:
-        if backend == "torchvision":
-            raise VideoDecodeError(
-                f"Failed to decode video path={path}; torchvision failed with "
-                f"{type(backend_exc).__name__}: {backend_exc}"
-            ) from backend_exc
-        logger.warning("Video reader %s failed, falling back to torchvision", backend)
+    fallback_backends = [backend, "decord", "torchvision"]
+    errors: list[str] = []
+    for candidate in dict.fromkeys(fallback_backends):
+        if candidate not in qwen_vision.VIDEO_READER_BACKENDS:
+            continue
         try:
-            video, sample_fps = qwen_vision.VIDEO_READER_BACKENDS["torchvision"](ele)
-        except Exception as fallback_exc:
-            raise VideoDecodeError(
-                f"Failed to decode video path={path}; {backend} failed with "
-                f"{type(backend_exc).__name__}: {backend_exc}; "
-                f"torchvision failed with {type(fallback_exc).__name__}: "
-                f"{fallback_exc}"
-            ) from fallback_exc
+            video, sample_fps = _read_video_backend(candidate, ele)
+            if candidate != backend:
+                logger.warning(
+                    "Video reader %s failed for path=%s, used %s fallback",
+                    backend,
+                    path,
+                    candidate,
+                )
+            break
+        except Exception as exc:
+            errors.append(f"{candidate} failed with {type(exc).__name__}: {exc}")
+            continue
+    else:
+        raise VideoDecodeError(
+            f"Failed to decode video path={path}; " + "; ".join(errors)
+        )
     nframes, _, height, width = video.shape
-    min_pixels = ele.get("min_pixels", qwen_vision.VIDEO_MIN_PIXELS)
-    total_pixels = ele.get("total_pixels", qwen_vision.VIDEO_TOTAL_PIXELS)
-    max_pixels = max(
-        min(
-            qwen_vision.VIDEO_MAX_PIXELS,
-            total_pixels / nframes * qwen_vision.FRAME_FACTOR,
-        ),
-        int(min_pixels * 1.05),
-    )
-    max_pixels_supposed = ele.get("max_pixels", max_pixels)
-    max_pixels = min(max_pixels_supposed, max_pixels)
+    min_pixels, max_pixels = _video_resize_budget(ele, nframes=nframes)
+    image_factor = _image_resize_factor()
     if "resized_height" in ele and "resized_width" in ele:
         resized_height, resized_width = qwen_vision.smart_resize(
             ele["resized_height"],
             ele["resized_width"],
-            factor=qwen_vision.IMAGE_FACTOR,
+            factor=image_factor,
         )
     else:
         resized_height, resized_width = qwen_vision.smart_resize(
             height,
             width,
-            factor=qwen_vision.IMAGE_FACTOR,
+            factor=image_factor,
             min_pixels=min_pixels,
             max_pixels=max_pixels,
         )
@@ -372,6 +557,7 @@ def load_video_path(
         interpolation=InterpolationMode.BICUBIC,
         antialias=True,
     ).float()
+    _put_video_decode_cache(cache_key, video, sample_fps)
     return video, sample_fps
 
 

--- a/tests/unit_test/fixtures/qwen_fakes.py
+++ b/tests/unit_test/fixtures/qwen_fakes.py
@@ -161,5 +161,5 @@ class FakeCode2WavModel:
     def __call__(self, codes: torch.Tensor) -> torch.Tensor:
         self.calls.append(tuple(codes.shape))
         samples = int(codes.shape[-1]) * self.total_upsample
-        base = codes.to(dtype=torch.float32).sum().item()
+        base = codes.to(dtype=torch.float32).flatten(1).sum(dim=1).view(-1, 1, 1)
         return torch.arange(samples, dtype=torch.float32).view(1, 1, samples) + base

--- a/tests/unit_test/pipeline/test_ipc.py
+++ b/tests/unit_test/pipeline/test_ipc.py
@@ -280,6 +280,47 @@ async def test_mp_runner_cleans_spawned_groups_when_later_spawn_fails(
     assert list(tmp_path.iterdir()) == []
 
 
+def test_startup_batches_serialize_same_gpu_groups() -> None:
+    events: list[tuple[str, str]] = []
+
+    class FakeGroup:
+        def __init__(self, name: str, gpu_ids: set[int]) -> None:
+            self.name = name
+            self.gpu_ids = gpu_ids
+
+        def spawn(self, ctx) -> None:
+            del ctx
+            events.append(("spawn", self.name))
+
+        async def wait_ready(self, timeout: float) -> None:
+            assert timeout > 0
+            events.append(("ready", self.name))
+
+    asyncio.run(
+        mp_runner._spawn_and_wait_startup_batches(
+            [
+                FakeGroup("image_encoder", {0}),
+                FakeGroup("thinker", {0}),
+                FakeGroup("other_gpu", {1}),
+                FakeGroup("decode", set()),
+            ],
+            ctx=object(),
+            timeout=10,
+        )
+    )
+
+    assert events == [
+        ("spawn", "image_encoder"),
+        ("spawn", "other_gpu"),
+        ("spawn", "decode"),
+        ("ready", "image_encoder"),
+        ("ready", "other_gpu"),
+        ("ready", "decode"),
+        ("spawn", "thinker"),
+        ("ready", "thinker"),
+    ]
+
+
 @pytest.mark.asyncio
 async def test_mp_runner_startup_failure_includes_child_factory_traceback(
     tmp_path: Path,

--- a/tests/unit_test/preprocessing/test_video.py
+++ b/tests/unit_test/preprocessing/test_video.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from sglang_omni.preprocessing import video as video_utils  # noqa: E402
+
+
+def test_unpack_video_reader_result_accepts_new_qwen_vl_tuple() -> None:
+    frames = torch.zeros(2, 3, 4, 4)
+
+    video, sample_fps = video_utils._unpack_video_reader_result(
+        (frames, {"video_backend": "decord"}, 2.5)
+    )
+
+    assert video is frames
+    assert sample_fps == 2.5
+
+
+def test_load_video_path_falls_back_to_decord_tuple(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    video_utils.clear_video_decode_cache()
+    path = tmp_path / "sample.mp4"
+    path.write_bytes(b"not decoded by the mocked reader")
+    frames = torch.zeros(2, 3, 4, 4)
+    calls: list[str] = []
+
+    def fail_reader(ele):
+        calls.append("torchcodec")
+        raise ValueError("reader api mismatch")
+
+    def decord_reader(ele):
+        calls.append("decord")
+        return frames, {"video_backend": "decord"}, 2.0
+
+    monkeypatch.setattr(
+        video_utils.qwen_vision,
+        "get_video_reader_backend",
+        lambda: "torchcodec",
+    )
+    monkeypatch.setitem(
+        video_utils.qwen_vision.VIDEO_READER_BACKENDS,
+        "torchcodec",
+        fail_reader,
+    )
+    monkeypatch.setitem(
+        video_utils.qwen_vision.VIDEO_READER_BACKENDS,
+        "decord",
+        decord_reader,
+    )
+    monkeypatch.setattr(
+        video_utils.qwen_vision,
+        "smart_resize",
+        lambda height, width, **kwargs: (height, width),
+    )
+    monkeypatch.setattr(
+        video_utils.tv_f,
+        "resize",
+        lambda video, size, interpolation, antialias: video,
+    )
+
+    video, sample_fps = video_utils.load_video_path(path, fps=2)
+
+    assert calls == ["torchcodec", "decord"]
+    assert video is frames
+    assert sample_fps == 2.0
+    video_utils.clear_video_decode_cache()
+
+
+def test_load_video_path_reuses_local_decode_cache(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    video_utils.clear_video_decode_cache()
+    path = tmp_path / "sample.mp4"
+    path.write_bytes(b"stable local video")
+    frames = torch.zeros(2, 3, 4, 4)
+    calls = 0
+
+    def decord_reader(ele):
+        nonlocal calls
+        calls += 1
+        return frames, {"video_backend": "decord"}, 2.0
+
+    monkeypatch.setattr(
+        video_utils.tempfile,
+        "gettempdir",
+        lambda: str(tmp_path / "different-temp-root"),
+    )
+    monkeypatch.setenv("SGLANG_OMNI_VIDEO_DECODE_CACHE", "1")
+    monkeypatch.setenv("SGLANG_OMNI_VIDEO_DECODE_CACHE_MAX_BYTES", str(1024 * 1024))
+    monkeypatch.setattr(
+        video_utils.qwen_vision,
+        "get_video_reader_backend",
+        lambda: "decord",
+    )
+    monkeypatch.setitem(
+        video_utils.qwen_vision.VIDEO_READER_BACKENDS,
+        "decord",
+        decord_reader,
+    )
+    monkeypatch.setattr(
+        video_utils.qwen_vision,
+        "smart_resize",
+        lambda height, width, **kwargs: (height, width),
+    )
+    monkeypatch.setattr(
+        video_utils.tv_f,
+        "resize",
+        lambda video, size, interpolation, antialias: video,
+    )
+
+    first, first_fps = video_utils.load_video_path(path, fps=2)
+    second, second_fps = video_utils.load_video_path(path, fps=2)
+
+    assert calls == 1
+    assert first is second
+    assert first_fps == second_fps == 2.0
+    video_utils.clear_video_decode_cache()
+
+
+def test_load_video_path_does_not_cache_temp_files(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    video_utils.clear_video_decode_cache()
+    temp_root = tmp_path / "temp-root"
+    path = temp_root / "request" / "sample.mp4"
+    path.parent.mkdir(parents=True)
+    path.write_bytes(b"request scoped video")
+    frames = torch.zeros(2, 3, 4, 4)
+    calls = 0
+
+    def decord_reader(ele):
+        nonlocal calls
+        calls += 1
+        return frames.clone(), {"video_backend": "decord"}, 2.0
+
+    monkeypatch.setattr(video_utils.tempfile, "gettempdir", lambda: str(temp_root))
+    monkeypatch.setenv("SGLANG_OMNI_VIDEO_DECODE_CACHE", "1")
+    monkeypatch.setattr(
+        video_utils.qwen_vision,
+        "get_video_reader_backend",
+        lambda: "decord",
+    )
+    monkeypatch.setitem(
+        video_utils.qwen_vision.VIDEO_READER_BACKENDS,
+        "decord",
+        decord_reader,
+    )
+    monkeypatch.setattr(
+        video_utils.qwen_vision,
+        "smart_resize",
+        lambda height, width, **kwargs: (height, width),
+    )
+    monkeypatch.setattr(
+        video_utils.tv_f,
+        "resize",
+        lambda video, size, interpolation, antialias: video,
+    )
+
+    first, first_fps = video_utils.load_video_path(path, fps=2)
+    second, second_fps = video_utils.load_video_path(path, fps=2)
+
+    assert calls == 2
+    assert first is not second
+    assert first_fps == second_fps == 2.0
+    video_utils.clear_video_decode_cache()

--- a/tests/unit_test/preprocessing/test_video.py
+++ b/tests/unit_test/preprocessing/test_video.py
@@ -124,6 +124,57 @@ def test_load_video_path_reuses_local_decode_cache(
     video_utils.clear_video_decode_cache()
 
 
+def test_load_video_path_cache_is_opt_in_by_default(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    video_utils.clear_video_decode_cache()
+    path = tmp_path / "sample.mp4"
+    path.write_bytes(b"stable local video")
+    frames = torch.zeros(2, 3, 4, 4)
+    calls = 0
+
+    def decord_reader(ele):
+        nonlocal calls
+        calls += 1
+        return frames.clone(), {"video_backend": "decord"}, 2.0
+
+    monkeypatch.delenv("SGLANG_OMNI_VIDEO_DECODE_CACHE", raising=False)
+    monkeypatch.setattr(
+        video_utils.tempfile,
+        "gettempdir",
+        lambda: str(tmp_path / "different-temp-root"),
+    )
+    monkeypatch.setattr(
+        video_utils.qwen_vision,
+        "get_video_reader_backend",
+        lambda: "decord",
+    )
+    monkeypatch.setitem(
+        video_utils.qwen_vision.VIDEO_READER_BACKENDS,
+        "decord",
+        decord_reader,
+    )
+    monkeypatch.setattr(
+        video_utils.qwen_vision,
+        "smart_resize",
+        lambda height, width, **kwargs: (height, width),
+    )
+    monkeypatch.setattr(
+        video_utils.tv_f,
+        "resize",
+        lambda video, size, interpolation, antialias: video,
+    )
+
+    first, first_fps = video_utils.load_video_path(path, fps=2)
+    second, second_fps = video_utils.load_video_path(path, fps=2)
+
+    assert calls == 2
+    assert first is not second
+    assert first_fps == second_fps == 2.0
+    video_utils.clear_video_decode_cache()
+
+
 def test_load_video_path_does_not_cache_temp_files(
     monkeypatch,
     tmp_path,

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -156,6 +156,81 @@ def test_qwen_code2wav_batches_same_length_final_partials() -> None:
     assert model.calls == [(2, 2, 2), (1, 2, 1)]
 
 
+def test_qwen_code2wav_streaming_first_window_can_emit_early() -> None:
+    model = FakeCode2WavModel(total_upsample=2)
+    scheduler = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=4,
+        first_stream_chunk_size=2,
+        left_context_size=0,
+        sample_rate=24000,
+        max_batch_wait_ms=0,
+    )
+    _seed_payloads(scheduler, ["req-1"])
+
+    scheduler._on_chunk("req-1", _chunk(0, 1, 10, stream=True))
+    assert model.calls == []
+    scheduler._on_chunk("req-1", _chunk(1, 2, 20, stream=True))
+    assert model.calls == [(1, 2, 2)]
+
+    stream_messages = []
+    while not scheduler.outbox.empty():
+        stream_messages.append(scheduler.outbox.get_nowait())
+    assert any(message.type == "stream" for message in stream_messages)
+
+    for idx in range(2, 5):
+        scheduler._on_chunk("req-1", _chunk(idx, idx + 1, idx + 10, stream=True))
+    assert model.calls == [(1, 2, 2)]
+    scheduler._on_chunk("req-1", _chunk(5, 6, 15, stream=True))
+    assert model.calls == [(1, 2, 2), (1, 2, 4)]
+
+
+def test_qwen_code2wav_non_streaming_keeps_full_window_for_first_decode() -> None:
+    model = FakeCode2WavModel(total_upsample=2)
+    scheduler = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=4,
+        first_stream_chunk_size=2,
+        left_context_size=0,
+        sample_rate=24000,
+        max_batch_wait_ms=0,
+    )
+    _seed_payloads(scheduler, ["req-1"])
+
+    for idx in range(2):
+        scheduler._on_chunk("req-1", _chunk(idx, idx + 1, idx + 10, stream=False))
+    assert model.calls == []
+
+    for idx in range(2, 4):
+        scheduler._on_chunk("req-1", _chunk(idx, idx + 1, idx + 10, stream=False))
+    assert model.calls == [(1, 2, 4)]
+
+
+def test_qwen_code2wav_first_window_env_can_disable(monkeypatch) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_QWEN3_CODE2WAV_FIRST_CHUNK_SIZE", "0")
+    model = FakeCode2WavModel(total_upsample=2)
+    scheduler = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=4,
+        first_stream_chunk_size=2,
+        left_context_size=0,
+        sample_rate=24000,
+        max_batch_wait_ms=0,
+    )
+    _seed_payloads(scheduler, ["req-1"])
+
+    for idx in range(2):
+        scheduler._on_chunk("req-1", _chunk(idx, idx + 1, idx + 10, stream=True))
+    assert model.calls == []
+
+    for idx in range(2, 4):
+        scheduler._on_chunk("req-1", _chunk(idx, idx + 1, idx + 10, stream=True))
+    assert model.calls == [(1, 2, 4)]
+
+
 def test_qwen_code2wav_skips_eos_chunks_before_batching() -> None:
     model = FakeCode2WavModel(total_upsample=2)
     scheduler = Code2WavScheduler(

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -181,3 +181,79 @@ def test_qwen_code2wav_skips_eos_chunks_before_batching() -> None:
 
     assert model.calls == []
     assert scheduler._code_chunks["req-1"] == []
+
+
+def test_qwen_code2wav_tensor_buffer_builds_context_windows() -> None:
+    model = FakeCode2WavModel(total_upsample=2)
+    scheduler = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=10,
+        left_context_size=2,
+        sample_rate=24000,
+        max_batch_wait_ms=0,
+    )
+    _seed_payloads(scheduler, ["req-1"])
+
+    for idx in range(5):
+        scheduler._append_stream_chunk("req-1", _chunk(idx, idx + 1, idx + 10))
+    scheduler._emitted["req-1"] = 3
+
+    plans = scheduler._build_decode_plans(
+        force_request_ids={"req-1"},
+        request_ids=["req-1"],
+    )
+
+    assert len(plans) == 1
+    plan = plans[0]
+    assert plan.start == 3
+    assert plan.end == 5
+    assert plan.trim == 4
+    assert tuple(plan.codes.shape) == (2, 4)
+    assert torch.equal(plan.codes[0], torch.tensor([2, 3, 4, 5]))
+    assert torch.equal(plan.codes[1], torch.tensor([11, 12, 13, 14]))
+    assert scheduler._code_buffers["req-1"].length == 5
+    assert scheduler._code_chunks["req-1"] == []
+
+
+def test_qwen_code2wav_tensor_buffer_grows_without_losing_chunks() -> None:
+    scheduler = Code2WavScheduler(
+        FakeCode2WavModel(total_upsample=2),
+        device="cpu",
+        stream_chunk_size=64,
+        left_context_size=0,
+        sample_rate=24000,
+    )
+    _seed_payloads(scheduler, ["req-1"])
+
+    for idx in range(20):
+        scheduler._append_stream_chunk("req-1", _chunk(idx, idx + 1, idx + 100))
+
+    buffer = scheduler._code_buffers["req-1"]
+    assert buffer.length == 20
+    assert buffer.chunks is not None
+    assert int(buffer.chunks.shape[0]) >= 20
+    window = scheduler._code_window("req-1", 0, 20).transpose(0, 1)
+    assert torch.equal(window[0], torch.arange(1, 21))
+    assert torch.equal(window[1], torch.arange(100, 120))
+
+
+def test_qwen_code2wav_tensor_buffer_can_be_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_QWEN3_CODE2WAV_TENSOR_BUFFER", "0")
+    scheduler = Code2WavScheduler(
+        FakeCode2WavModel(total_upsample=2),
+        device="cpu",
+        stream_chunk_size=64,
+        left_context_size=0,
+        sample_rate=24000,
+    )
+    _seed_payloads(scheduler, ["req-1"])
+
+    scheduler._append_stream_chunk("req-1", _chunk(0, 1, 10))
+
+    assert scheduler._code_buffers == {}
+    assert len(scheduler._code_chunks["req-1"]) == 1
+    assert torch.equal(
+        scheduler._code_window("req-1", 0, 1).squeeze(0),
+        torch.tensor([1, 10]),
+    )

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -9,6 +9,7 @@ from sglang_omni.models.qwen3_omni.components.code2wav_scheduler import (
     Code2WavScheduler,
 )
 from sglang_omni.pipeline.stage.stream_queue import StreamItem
+from sglang_omni.scheduling.messages import IncomingMessage
 from tests.unit_test.fixtures.qwen_fakes import FakeCode2WavModel, make_qwen_payload
 
 
@@ -52,3 +53,131 @@ def test_qwen_code2wav_streams_incrementally_and_abort_clears_state() -> None:
     assert "req-2" not in scheduler._code_chunks
     assert "req-2" not in scheduler._payloads
     assert "req-2" not in scheduler._pending_done
+
+
+def _chunk(chunk_id: int, code_a: int, code_b: int, *, stream: bool = False):
+    return StreamItem(
+        chunk_id,
+        torch.tensor([code_a, code_b], dtype=torch.long),
+        "talker",
+        metadata={"stream": stream},
+    )
+
+
+def _seed_payloads(scheduler: Code2WavScheduler, request_ids: list[str]) -> None:
+    for request_id in request_ids:
+        scheduler._payloads[request_id] = make_qwen_payload(request_id=request_id)
+        scheduler._ensure_request_state(request_id)
+
+
+def _drain_final_audio(scheduler: Code2WavScheduler) -> dict[str, np.ndarray]:
+    audio_by_request: dict[str, np.ndarray] = {}
+    while not scheduler.outbox.empty():
+        message = scheduler.outbox.get_nowait()
+        if message.type != "result":
+            continue
+        audio_by_request[message.request_id] = np.frombuffer(
+            message.data.data["audio_waveform"], dtype=np.float32
+        )
+    return audio_by_request
+
+
+def test_qwen_code2wav_batches_ready_stream_windows_without_audio_changes() -> None:
+    batched_model = FakeCode2WavModel(total_upsample=2)
+    batched = Code2WavScheduler(
+        batched_model,
+        device="cpu",
+        stream_chunk_size=2,
+        left_context_size=0,
+        sample_rate=24000,
+        max_batch_wait_ms=0,
+    )
+    _seed_payloads(batched, ["req-1", "req-2"])
+
+    batched._on_chunk("req-1", _chunk(0, 1, 10))
+    batched._on_chunk("req-2", _chunk(0, 2, 20))
+    batched.inbox.put(IncomingMessage("req-2", "stream_chunk", _chunk(1, 4, 40)))
+    batched._on_chunk("req-1", _chunk(1, 3, 30))
+    batched._on_done("req-1")
+    batched._on_done("req-2")
+    batched_audio = _drain_final_audio(batched)
+
+    single_model = FakeCode2WavModel(total_upsample=2)
+    single = Code2WavScheduler(
+        single_model,
+        device="cpu",
+        stream_chunk_size=2,
+        left_context_size=0,
+        sample_rate=24000,
+        enable_batched_decode=False,
+    )
+    _seed_payloads(single, ["req-1", "req-2"])
+    for request_id, chunks in {
+        "req-1": [_chunk(0, 1, 10), _chunk(1, 3, 30)],
+        "req-2": [_chunk(0, 2, 20), _chunk(1, 4, 40)],
+    }.items():
+        for item in chunks:
+            single._on_chunk(request_id, item)
+        single._on_done(request_id)
+    single_audio = _drain_final_audio(single)
+
+    assert batched_model.calls == [(2, 2, 2)]
+    assert single_model.calls == [(1, 2, 2), (1, 2, 2)]
+    assert set(batched_audio) == {"req-1", "req-2"}
+    for request_id in batched_audio:
+        np.testing.assert_array_equal(
+            batched_audio[request_id], single_audio[request_id]
+        )
+
+
+def test_qwen_code2wav_batches_same_length_final_partials() -> None:
+    model = FakeCode2WavModel(total_upsample=2)
+    scheduler = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=10,
+        left_context_size=0,
+        sample_rate=24000,
+        max_batch_wait_ms=0,
+    )
+    _seed_payloads(scheduler, ["req-1", "req-2", "req-3"])
+
+    scheduler._on_chunk("req-1", _chunk(0, 1, 10))
+    scheduler._on_chunk("req-1", _chunk(1, 2, 20))
+    scheduler._on_chunk("req-2", _chunk(0, 3, 30))
+    scheduler._on_chunk("req-2", _chunk(1, 4, 40))
+    scheduler._on_chunk("req-3", _chunk(0, 5, 50))
+    scheduler.inbox.put(IncomingMessage("req-2", "stream_done"))
+    scheduler.inbox.put(IncomingMessage("req-3", "stream_done"))
+
+    scheduler._on_done("req-1")
+    _drain_final_audio(scheduler)
+
+    assert model.calls == [(2, 2, 2), (1, 2, 1)]
+
+
+def test_qwen_code2wav_skips_eos_chunks_before_batching() -> None:
+    model = FakeCode2WavModel(total_upsample=2)
+    scheduler = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=1,
+        left_context_size=0,
+        sample_rate=24000,
+        codec_eos_token_id=2150,
+        max_batch_wait_ms=0,
+    )
+    _seed_payloads(scheduler, ["req-1"])
+
+    scheduler._on_chunk(
+        "req-1",
+        StreamItem(
+            0,
+            torch.tensor([2150, 2150], dtype=torch.long),
+            "talker",
+            metadata={"stream": False},
+        ),
+    )
+
+    assert model.calls == []
+    assert scheduler._code_chunks["req-1"] == []

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -156,81 +156,6 @@ def test_qwen_code2wav_batches_same_length_final_partials() -> None:
     assert model.calls == [(2, 2, 2), (1, 2, 1)]
 
 
-def test_qwen_code2wav_streaming_first_window_can_emit_early() -> None:
-    model = FakeCode2WavModel(total_upsample=2)
-    scheduler = Code2WavScheduler(
-        model,
-        device="cpu",
-        stream_chunk_size=4,
-        first_stream_chunk_size=2,
-        left_context_size=0,
-        sample_rate=24000,
-        max_batch_wait_ms=0,
-    )
-    _seed_payloads(scheduler, ["req-1"])
-
-    scheduler._on_chunk("req-1", _chunk(0, 1, 10, stream=True))
-    assert model.calls == []
-    scheduler._on_chunk("req-1", _chunk(1, 2, 20, stream=True))
-    assert model.calls == [(1, 2, 2)]
-
-    stream_messages = []
-    while not scheduler.outbox.empty():
-        stream_messages.append(scheduler.outbox.get_nowait())
-    assert any(message.type == "stream" for message in stream_messages)
-
-    for idx in range(2, 5):
-        scheduler._on_chunk("req-1", _chunk(idx, idx + 1, idx + 10, stream=True))
-    assert model.calls == [(1, 2, 2)]
-    scheduler._on_chunk("req-1", _chunk(5, 6, 15, stream=True))
-    assert model.calls == [(1, 2, 2), (1, 2, 4)]
-
-
-def test_qwen_code2wav_non_streaming_keeps_full_window_for_first_decode() -> None:
-    model = FakeCode2WavModel(total_upsample=2)
-    scheduler = Code2WavScheduler(
-        model,
-        device="cpu",
-        stream_chunk_size=4,
-        first_stream_chunk_size=2,
-        left_context_size=0,
-        sample_rate=24000,
-        max_batch_wait_ms=0,
-    )
-    _seed_payloads(scheduler, ["req-1"])
-
-    for idx in range(2):
-        scheduler._on_chunk("req-1", _chunk(idx, idx + 1, idx + 10, stream=False))
-    assert model.calls == []
-
-    for idx in range(2, 4):
-        scheduler._on_chunk("req-1", _chunk(idx, idx + 1, idx + 10, stream=False))
-    assert model.calls == [(1, 2, 4)]
-
-
-def test_qwen_code2wav_first_window_env_can_disable(monkeypatch) -> None:
-    monkeypatch.setenv("SGLANG_OMNI_QWEN3_CODE2WAV_FIRST_CHUNK_SIZE", "0")
-    model = FakeCode2WavModel(total_upsample=2)
-    scheduler = Code2WavScheduler(
-        model,
-        device="cpu",
-        stream_chunk_size=4,
-        first_stream_chunk_size=2,
-        left_context_size=0,
-        sample_rate=24000,
-        max_batch_wait_ms=0,
-    )
-    _seed_payloads(scheduler, ["req-1"])
-
-    for idx in range(2):
-        scheduler._on_chunk("req-1", _chunk(idx, idx + 1, idx + 10, stream=True))
-    assert model.calls == []
-
-    for idx in range(2, 4):
-        scheduler._on_chunk("req-1", _chunk(idx, idx + 1, idx + 10, stream=True))
-    assert model.calls == [(1, 2, 4)]
-
-
 def test_qwen_code2wav_skips_eos_chunks_before_batching() -> None:
     model = FakeCode2WavModel(total_upsample=2)
     scheduler = Code2WavScheduler(
@@ -258,77 +183,78 @@ def test_qwen_code2wav_skips_eos_chunks_before_batching() -> None:
     assert scheduler._code_chunks["req-1"] == []
 
 
-def test_qwen_code2wav_tensor_buffer_builds_context_windows() -> None:
+def test_qwen_code2wav_batch_wait_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_QWEN3_CODE2WAV_MAX_BATCH_WAIT_MS", "7")
+    scheduler = Code2WavScheduler(
+        FakeCode2WavModel(total_upsample=2),
+        device="cpu",
+        stream_chunk_size=1,
+        left_context_size=0,
+        sample_rate=24000,
+        max_batch_wait_ms=0,
+    )
+
+    assert scheduler._decode_max_batch_wait_s == 0.007
+
+
+def test_qwen_code2wav_left_context_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_QWEN3_CODE2WAV_LEFT_CONTEXT_SIZE", "5")
+    scheduler = Code2WavScheduler(
+        FakeCode2WavModel(total_upsample=2),
+        device="cpu",
+        stream_chunk_size=1,
+        left_context_size=25,
+        sample_rate=24000,
+    )
+
+    assert scheduler._left_context_size == 5
+
+
+def test_qwen_code2wav_non_stream_chunk_size_env_keeps_streaming_threshold(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_QWEN3_CODE2WAV_NON_STREAM_CHUNK_SIZE", "3")
     model = FakeCode2WavModel(total_upsample=2)
     scheduler = Code2WavScheduler(
         model,
         device="cpu",
-        stream_chunk_size=10,
-        left_context_size=2,
+        stream_chunk_size=2,
+        left_context_size=0,
         sample_rate=24000,
         max_batch_wait_ms=0,
     )
-    _seed_payloads(scheduler, ["req-1"])
+    _seed_payloads(scheduler, ["non-stream", "stream"])
 
-    for idx in range(5):
-        scheduler._append_stream_chunk("req-1", _chunk(idx, idx + 1, idx + 10))
-    scheduler._emitted["req-1"] = 3
+    scheduler._on_chunk("non-stream", _chunk(0, 1, 10, stream=False))
+    scheduler._on_chunk("non-stream", _chunk(1, 2, 20, stream=False))
+    assert model.calls == []
 
-    plans = scheduler._build_decode_plans(
-        force_request_ids={"req-1"},
-        request_ids=["req-1"],
-    )
+    scheduler._on_chunk("stream", _chunk(0, 3, 30, stream=True))
+    scheduler._on_chunk("stream", _chunk(1, 4, 40, stream=True))
+    assert model.calls == [(1, 2, 2)]
 
-    assert len(plans) == 1
-    plan = plans[0]
-    assert plan.start == 3
-    assert plan.end == 5
-    assert plan.trim == 4
-    assert tuple(plan.codes.shape) == (2, 4)
-    assert torch.equal(plan.codes[0], torch.tensor([2, 3, 4, 5]))
-    assert torch.equal(plan.codes[1], torch.tensor([11, 12, 13, 14]))
-    assert scheduler._code_buffers["req-1"].length == 5
-    assert scheduler._code_chunks["req-1"] == []
+    scheduler._on_chunk("non-stream", _chunk(2, 5, 50, stream=False))
+    assert model.calls == [(1, 2, 2), (1, 2, 3)]
 
 
-def test_qwen_code2wav_tensor_buffer_grows_without_losing_chunks() -> None:
+def test_qwen_code2wav_non_stream_chunk_size_arg_and_env_override(monkeypatch) -> None:
     scheduler = Code2WavScheduler(
         FakeCode2WavModel(total_upsample=2),
         device="cpu",
-        stream_chunk_size=64,
+        stream_chunk_size=2,
+        non_stream_chunk_size=4,
         left_context_size=0,
         sample_rate=24000,
     )
-    _seed_payloads(scheduler, ["req-1"])
+    assert scheduler._non_stream_chunk_size == 4
 
-    for idx in range(20):
-        scheduler._append_stream_chunk("req-1", _chunk(idx, idx + 1, idx + 100))
-
-    buffer = scheduler._code_buffers["req-1"]
-    assert buffer.length == 20
-    assert buffer.chunks is not None
-    assert int(buffer.chunks.shape[0]) >= 20
-    window = scheduler._code_window("req-1", 0, 20).transpose(0, 1)
-    assert torch.equal(window[0], torch.arange(1, 21))
-    assert torch.equal(window[1], torch.arange(100, 120))
-
-
-def test_qwen_code2wav_tensor_buffer_can_be_disabled(monkeypatch) -> None:
-    monkeypatch.setenv("SGLANG_OMNI_QWEN3_CODE2WAV_TENSOR_BUFFER", "0")
+    monkeypatch.setenv("SGLANG_OMNI_QWEN3_CODE2WAV_NON_STREAM_CHUNK_SIZE", "6")
     scheduler = Code2WavScheduler(
         FakeCode2WavModel(total_upsample=2),
         device="cpu",
-        stream_chunk_size=64,
+        stream_chunk_size=2,
+        non_stream_chunk_size=4,
         left_context_size=0,
         sample_rate=24000,
     )
-    _seed_payloads(scheduler, ["req-1"])
-
-    scheduler._append_stream_chunk("req-1", _chunk(0, 1, 10))
-
-    assert scheduler._code_buffers == {}
-    assert len(scheduler._code_chunks["req-1"]) == 1
-    assert torch.equal(
-        scheduler._code_window("req-1", 0, 1).squeeze(0),
-        torch.tensor([1, 10]),
-    )
+    assert scheduler._non_stream_chunk_size == 6

--- a/tests/unit_test/qwen3_omni/test_colocation_config.py
+++ b/tests/unit_test/qwen3_omni/test_colocation_config.py
@@ -136,7 +136,9 @@ def test_colocated_config_places_talker_code2wav_local_edge_in_one_process() -> 
 
     assert talker.next == "code2wav"
     assert "code2wav" in talker.stream_to
-    assert topology.stage_to_process["talker_ar"] == topology.stage_to_process["code2wav"]
+    assert (
+        topology.stage_to_process["talker_ar"] == topology.stage_to_process["code2wav"]
+    )
 
 
 def test_colocated_talker_code2wav_fusion_can_be_disabled(monkeypatch) -> None:

--- a/tests/unit_test/qwen3_omni/test_colocation_config.py
+++ b/tests/unit_test/qwen3_omni/test_colocation_config.py
@@ -82,6 +82,7 @@ def test_colocated_topology_is_opt_in_and_uses_one_gpu() -> None:
 
     assert Variants["speech-colocated"] is Qwen3OmniSpeechColocatedPipelineConfig
     assert _stage(config, "talker_ar").factory_args["enable_partial_start"] is False
+    assert config.fused_stages == [["talker_ar", "code2wav"]]
     for stage_name in (
         "image_encoder",
         "audio_encoder",
@@ -110,9 +111,10 @@ def test_colocated_config_passes_with_explicit_budgets_without_ar_mem_fraction()
         "mm_aggregate",
         "thinker",
         "decode",
-        "talker_ar",
-        "code2wav",
+        "fused_talker_ar_code2wav",
     ]
+    assert topology.stage_to_process["talker_ar"] == "fused_talker_ar_code2wav"
+    assert topology.stage_to_process["code2wav"] == "fused_talker_ar_code2wav"
 
 
 def test_colocated_config_marks_same_gpu_stream_targets() -> None:
@@ -123,6 +125,31 @@ def test_colocated_config_marks_same_gpu_stream_targets() -> None:
 
     assert plan.same_gpu_stream_targets["thinker"] == frozenset({"talker_ar"})
     assert plan.same_gpu_stream_targets["talker_ar"] == frozenset({"code2wav"})
+
+
+def test_colocated_config_places_talker_code2wav_local_edge_in_one_process() -> None:
+    config = Qwen3OmniSpeechColocatedPipelineConfig(model_path="dummy")
+    _set_colocated_runtime(config)
+    placement = build_stage_placement_plan(config)
+    topology = build_process_topology_plan(config, placement)
+    talker = _stage(config, "talker_ar")
+
+    assert talker.next == "code2wav"
+    assert "code2wav" in talker.stream_to
+    assert topology.stage_to_process["talker_ar"] == topology.stage_to_process["code2wav"]
+
+
+def test_colocated_talker_code2wav_fusion_can_be_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_QWEN3_FUSE_TALKER_CODE2WAV", "0")
+    config = Qwen3OmniSpeechColocatedPipelineConfig(model_path="dummy")
+    _set_colocated_runtime(config)
+
+    placement = build_stage_placement_plan(config)
+    topology = build_process_topology_plan(config, placement)
+
+    assert config.fused_stages == []
+    assert topology.stage_to_process["talker_ar"] == "talker_ar"
+    assert topology.stage_to_process["code2wav"] == "code2wav"
 
 
 def test_default_speech_marks_only_talker_to_code2wav_same_gpu_stream() -> None:

--- a/tests/unit_test/qwen3_omni/test_colocation_config.py
+++ b/tests/unit_test/qwen3_omni/test_colocation_config.py
@@ -86,7 +86,9 @@ def test_colocated_topology_uses_one_gpu_without_default_fusion(
     config = Qwen3OmniSpeechColocatedPipelineConfig(model_path="dummy")
 
     assert Variants["speech-colocated"] is Qwen3OmniSpeechColocatedPipelineConfig
-    assert _stage(config, "talker_ar").factory_args["enable_partial_start"] is False
+    assert _stage(config, "talker_ar").factory_args["enable_partial_start"] is True
+    assert _stage(config, "code2wav").factory_args["max_batch_wait_ms"] == 5
+    assert _stage(config, "code2wav").factory_args["non_stream_chunk_size"] == 20
     assert config.fused_stages == []
     for stage_name in (
         "image_encoder",

--- a/tests/unit_test/qwen3_omni/test_colocation_config.py
+++ b/tests/unit_test/qwen3_omni/test_colocation_config.py
@@ -10,6 +10,8 @@ from sglang_omni.models.qwen3_omni.config import (
     Variants,
 )
 
+_FUSE_ENV = "SGLANG_OMNI_QWEN3_FUSE_TALKER_CODE2WAV"
+
 
 def _stage(config, name: str):
     return next(stage for stage in config.stages if stage.name == name)
@@ -77,12 +79,15 @@ def test_default_speech_topology_stays_disaggregated() -> None:
     ]
 
 
-def test_colocated_topology_is_opt_in_and_uses_one_gpu() -> None:
+def test_colocated_topology_uses_one_gpu_without_default_fusion(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv(_FUSE_ENV, raising=False)
     config = Qwen3OmniSpeechColocatedPipelineConfig(model_path="dummy")
 
     assert Variants["speech-colocated"] is Qwen3OmniSpeechColocatedPipelineConfig
     assert _stage(config, "talker_ar").factory_args["enable_partial_start"] is False
-    assert config.fused_stages == [["talker_ar", "code2wav"]]
+    assert config.fused_stages == []
     for stage_name in (
         "image_encoder",
         "audio_encoder",
@@ -111,10 +116,11 @@ def test_colocated_config_passes_with_explicit_budgets_without_ar_mem_fraction()
         "mm_aggregate",
         "thinker",
         "decode",
-        "fused_talker_ar_code2wav",
+        "talker_ar",
+        "code2wav",
     ]
-    assert topology.stage_to_process["talker_ar"] == "fused_talker_ar_code2wav"
-    assert topology.stage_to_process["code2wav"] == "fused_talker_ar_code2wav"
+    assert topology.stage_to_process["talker_ar"] == "talker_ar"
+    assert topology.stage_to_process["code2wav"] == "code2wav"
 
 
 def test_colocated_config_marks_same_gpu_stream_targets() -> None:
@@ -127,7 +133,10 @@ def test_colocated_config_marks_same_gpu_stream_targets() -> None:
     assert plan.same_gpu_stream_targets["talker_ar"] == frozenset({"code2wav"})
 
 
-def test_colocated_config_places_talker_code2wav_local_edge_in_one_process() -> None:
+def test_colocated_config_can_fuse_talker_code2wav_local_edge(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(_FUSE_ENV, "1")
     config = Qwen3OmniSpeechColocatedPipelineConfig(model_path="dummy")
     _set_colocated_runtime(config)
     placement = build_stage_placement_plan(config)
@@ -141,8 +150,8 @@ def test_colocated_config_places_talker_code2wav_local_edge_in_one_process() -> 
     )
 
 
-def test_colocated_talker_code2wav_fusion_can_be_disabled(monkeypatch) -> None:
-    monkeypatch.setenv("SGLANG_OMNI_QWEN3_FUSE_TALKER_CODE2WAV", "0")
+def test_colocated_talker_code2wav_fusion_is_default_off(monkeypatch) -> None:
+    monkeypatch.delenv(_FUSE_ENV, raising=False)
     config = Qwen3OmniSpeechColocatedPipelineConfig(model_path="dummy")
     _set_colocated_runtime(config)
 

--- a/tests/unit_test/qwen3_omni/test_config_manager.py
+++ b/tests/unit_test/qwen3_omni/test_config_manager.py
@@ -113,8 +113,7 @@ def test_qwen3_omni_h20_colocated_example_config_loads_and_plans() -> None:
         "mm_aggregate",
         "thinker",
         "decode",
-        "talker_ar",
-        "code2wav",
+        "fused_talker_ar_code2wav",
     ]
     assert (
         _stage(config, "thinker").runtime.sglang_server_args.mem_fraction_static is None

--- a/tests/unit_test/qwen3_omni/test_config_manager.py
+++ b/tests/unit_test/qwen3_omni/test_config_manager.py
@@ -92,7 +92,8 @@ def test_config_manager_rejects_trailing_key_without_value() -> None:
         )
 
 
-def test_qwen3_omni_h20_colocated_example_config_loads_and_plans() -> None:
+def test_qwen3_omni_h20_colocated_example_config_loads_and_plans(monkeypatch) -> None:
+    monkeypatch.delenv("SGLANG_OMNI_QWEN3_FUSE_TALKER_CODE2WAV", raising=False)
     config_path = _REPO_ROOT / "examples" / "configs" / "qwen3_omni_colocated_h20.yaml"
     config_text = config_path.read_text()
 
@@ -113,7 +114,8 @@ def test_qwen3_omni_h20_colocated_example_config_loads_and_plans() -> None:
         "mm_aggregate",
         "thinker",
         "decode",
-        "fused_talker_ar_code2wav",
+        "talker_ar",
+        "code2wav",
     ]
     assert (
         _stage(config, "thinker").runtime.sglang_server_args.mem_fraction_static is None
@@ -140,6 +142,30 @@ def test_qwen3_omni_h20_colocated_example_config_loads_and_plans() -> None:
         "talker_ar": 0,
         "code2wav": 0,
     }
+
+
+def test_qwen3_omni_h200_fused_example_config_loads_and_plans() -> None:
+    config_path = (
+        _REPO_ROOT / "examples" / "configs" / "qwen3_omni_colocated_h200_fused.yaml"
+    )
+
+    manager = ConfigManager.from_file(str(config_path))
+    config = manager.config
+    plan = build_stage_placement_plan(config)
+    topology = build_process_topology_plan(config, plan)
+
+    assert isinstance(config, Qwen3OmniSpeechColocatedPipelineConfig)
+    assert config.name == "qwen3-omni-colocated-h200-fused"
+    assert config.fused_stages == [["talker_ar", "code2wav"]]
+    assert [group.name for group in topology.groups] == [
+        "preprocessing",
+        "image_encoder",
+        "audio_encoder",
+        "mm_aggregate",
+        "thinker",
+        "decode",
+        "fused_talker_ar_code2wav",
+    ]
 
 
 def test_qwen3_omni_mmsu_example_config_uses_text_pipeline() -> None:

--- a/tests/unit_test/qwen3_omni/test_example_launcher.py
+++ b/tests/unit_test/qwen3_omni/test_example_launcher.py
@@ -172,14 +172,14 @@ def test_partial_start_defaults_on(mock_launch_server):
     assert talker.factory_args["enable_partial_start"] is True
 
 
-def test_partial_start_colocated_defaults_off(mock_launch_server):
+def test_partial_start_colocated_defaults_on(mock_launch_server):
     args = _make_args(colocated=True)
     _launch_speech_server(args)
 
     config = mock_launch_server.call_args[0][0]
     talker = _stage(config, "talker_ar")
 
-    assert talker.factory_args["enable_partial_start"] is False
+    assert talker.factory_args["enable_partial_start"] is True
 
 
 def test_partial_start_colocated_can_be_enabled(mock_launch_server):

--- a/tests/unit_test/qwen3_omni/test_predictor_kernels.py
+++ b/tests/unit_test/qwen3_omni/test_predictor_kernels.py
@@ -9,7 +9,6 @@ from sglang_omni.models.qwen3_omni.components.predictor_kernels import (
     stage_initial_predictor_input_,
 )
 
-
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="Qwen3-Omni predictor kernels require CUDA"
 )

--- a/tests/unit_test/qwen3_omni/test_predictor_kernels.py
+++ b/tests/unit_test/qwen3_omni/test_predictor_kernels.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from sglang_omni.models.qwen3_omni.components.predictor_kernels import (
+    sample_code_and_stage_,
+    stage_initial_predictor_input_,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="Qwen3-Omni predictor kernels require CUDA"
+)
+
+
+def _skip_without_triton(launched: bool) -> None:
+    if not launched:
+        pytest.skip("Triton predictor kernels are unavailable in this environment")
+
+
+def test_stage_initial_predictor_input_matches_torch_for_strided_views() -> None:
+    device = torch.device("cuda")
+    batch_size, seq_len, num_groups, vocab_size, hidden_size = 3, 2, 4, 11, 7
+
+    layer0_codes = torch.tensor(
+        [[1, 3], [4, 6], [8, 2]],
+        device=device,
+        dtype=torch.long,
+    )
+    talker_hidden = torch.randn(batch_size, seq_len, hidden_size, device=device)
+    codec_weight = torch.randn(vocab_size, hidden_size, device=device)
+    predictor_input = torch.full(
+        (batch_size, num_groups + 1, hidden_size),
+        -99.0,
+        device=device,
+    )
+    result_codes = torch.full(
+        (batch_size, num_groups, seq_len),
+        -1,
+        device=device,
+        dtype=torch.long,
+    )
+    summed_embeddings = torch.full(
+        (batch_size, seq_len, hidden_size),
+        -99.0,
+        device=device,
+    )
+
+    pos = 1
+    launched = stage_initial_predictor_input_(
+        layer0_code=layer0_codes[:, pos],
+        talker_hidden=talker_hidden[:, pos, :],
+        codec_weight=codec_weight,
+        predictor_input=predictor_input,
+        pos_codes=result_codes[:, :, pos],
+        pos_summed=summed_embeddings[:, pos, :],
+    )
+    _skip_without_triton(launched)
+    torch.cuda.synchronize()
+
+    expected_embed = codec_weight[layer0_codes[:, pos]]
+    assert torch.equal(result_codes[:, 0, pos], layer0_codes[:, pos])
+    torch.testing.assert_close(predictor_input[:, 0, :], talker_hidden[:, pos, :])
+    torch.testing.assert_close(predictor_input[:, 1, :], expected_embed)
+    torch.testing.assert_close(summed_embeddings[:, pos, :], expected_embed)
+
+
+def test_sample_code_and_stage_matches_torch_argmax_and_embedding() -> None:
+    device = torch.device("cuda")
+    batch_size, num_groups, vocab_size, hidden_size = 3, 5, 9, 6
+
+    logits = torch.full((batch_size, 1, vocab_size), -10.0, device=device)
+    logits[0, 0, 2] = 4.0
+    logits[0, 0, 3] = 4.0
+    logits[1, 0, 7] = 5.0
+    logits[2, 0, 0] = 6.0
+    embedding_weight = torch.randn(vocab_size, hidden_size, device=device)
+    predictor_input = torch.zeros(
+        batch_size,
+        num_groups + 1,
+        hidden_size,
+        device=device,
+    )
+    pos_codes = torch.full(
+        (batch_size, num_groups),
+        -1,
+        device=device,
+        dtype=torch.long,
+    )
+    pos_summed = torch.randn(batch_size, hidden_size, device=device)
+    expected_sum = pos_summed.clone()
+    layer_idx = 2
+
+    launched = sample_code_and_stage_(
+        logits=logits,
+        embedding_weight=embedding_weight,
+        predictor_input=predictor_input,
+        pos_codes=pos_codes,
+        pos_summed=pos_summed,
+        layer_idx=layer_idx,
+    )
+    _skip_without_triton(launched)
+    torch.cuda.synchronize()
+
+    expected_codes = torch.argmax(logits[:, -1, :], dim=-1)
+    expected_embed = embedding_weight[expected_codes]
+    assert torch.equal(pos_codes[:, layer_idx + 1], expected_codes)
+    torch.testing.assert_close(predictor_input[:, layer_idx + 2, :], expected_embed)
+    torch.testing.assert_close(pos_summed, expected_sum + expected_embed)

--- a/tests/unit_test/qwen3_omni/test_streaming.py
+++ b/tests/unit_test/qwen3_omni/test_streaming.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests for the Qwen3-Omni real-streaming path."""
+
 from __future__ import annotations
 
 import asyncio
@@ -508,9 +509,9 @@ class _FakeCode2Wav:
     total_upsample = 4
 
     def __call__(self, codes: torch.Tensor) -> torch.Tensor:
-        # codes: (1, codebooks, num_frames). Output shape (1, frames * upsample).
+        # codes: (batch, codebooks, num_frames). Output shape (batch, samples).
         n_frames = codes.shape[-1]
-        return torch.zeros(1, n_frames * self.total_upsample)
+        return torch.zeros(codes.shape[0], n_frames * self.total_upsample)
 
 
 def _make_code_chunk(metadata: dict | None) -> StreamItem:

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -1825,7 +1825,9 @@ def _talker_seed_req(
     req = SimpleNamespace(
         sampling_params=sp, output_ids=[], _codec_suppress_tokens=None, rid=rid
     )
-    return SimpleNamespace(data=SimpleNamespace(req=req, suppress_tokens=suppress_tokens))
+    return SimpleNamespace(
+        data=SimpleNamespace(req=req, suppress_tokens=suppress_tokens)
+    )
 
 
 def test_talker_prepare_decode_buffers_unseeded_seed_is_rank_shared() -> None:
@@ -1894,8 +1896,12 @@ def test_talker_emit_code_feedback_batches_clone_lifetime() -> None:
     second = outbox.get_nowait()
     assert torch.equal(first.data, torch.tensor([1, 2]))
     assert torch.equal(second.data, torch.tensor([3, 4]))
-    assert torch.equal(requests[0].data.pending_feedback_queue[0], torch.tensor([1.0, 2.0]))
-    assert torch.equal(requests[1].data.pending_feedback_queue[0], torch.tensor([3.0, 4.0]))
+    assert torch.equal(
+        requests[0].data.pending_feedback_queue[0], torch.tensor([1.0, 2.0])
+    )
+    assert torch.equal(
+        requests[1].data.pending_feedback_queue[0], torch.tensor([3.0, 4.0])
+    )
     assert first.metadata == {"stream": True}
     assert first.target == "code2wav"
 

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import queue
 import threading
 import time
 from collections import deque
@@ -501,6 +500,20 @@ def test_partial_rejects_min_chunks_below_layout_floor(monkeypatch) -> None:
             enable_partial_start=True,
             partial_start_min_chunks=MIN_PARTIAL_START_CHUNKS - 1,
         )
+
+
+def test_partial_min_chunks_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_QWEN3_PARTIAL_START_MIN_CHUNKS", "3")
+    monkeypatch.setattr(OmniScheduler, "__init__", lambda self, *a, **k: None)
+    live = QwenTalkerScheduler.__new__(QwenTalkerScheduler)
+
+    QwenTalkerScheduler.__init__(
+        live,
+        enable_partial_start=True,
+        partial_start_min_chunks=10,
+    )
+
+    assert live._partial_start_min_chunks == 3
 
 
 def test_partial_count_strips_only_trailing_im_end_chunk() -> None:
@@ -1801,33 +1814,28 @@ def _talker_seed_self(max_bs: int = 4, vocab: int = 8) -> SimpleNamespace:
         _sampling_top_ks=torch.ones(max_bs, dtype=torch.long),
         _sampling_min_ps=torch.zeros(max_bs),
         _sampling_seeds=torch.zeros(max_bs, dtype=torch.long),
-        _greedy_sample_fastpath_enabled=True,
-        _decode_all_greedy=False,
         _sampler=None,
     )
 
 
 def _talker_seed_req(
-    seed: int | None,
-    rid: str,
-    *,
-    temperature: float = 0.8,
-    suppress_tokens: list[int] | None = None,
+    seed: int | None, rid: str
 ) -> SimpleNamespace:
     sp = SimpleNamespace(
         repetition_penalty=1.0,  # keep rep/suppress branches off
-        temperature=temperature,
+        temperature=0.8,
         top_p=0.9,
         top_k=20,
         min_p=0.0,
         sampling_seed=seed,
     )
     req = SimpleNamespace(
-        sampling_params=sp, output_ids=[], _codec_suppress_tokens=None, rid=rid
+        sampling_params=sp,
+        output_ids=[],
+        _codec_suppress_tokens=None,
+        rid=rid,
     )
-    return SimpleNamespace(
-        data=SimpleNamespace(req=req, suppress_tokens=suppress_tokens)
-    )
+    return SimpleNamespace(data=SimpleNamespace(req=req, suppress_tokens=None))
 
 
 def test_talker_prepare_decode_buffers_unseeded_seed_is_rank_shared() -> None:
@@ -1858,82 +1866,3 @@ def test_talker_prepare_decode_buffers_unseeded_seed_is_rank_shared() -> None:
     assert int(fake._sampling_seeds[1]) == derive_sampling_seed(
         "sglang-omni-unseeded-row", "unseeded"
     )
-
-
-def test_talker_emit_code_feedback_batches_clone_lifetime() -> None:
-    outbox: queue.Queue = queue.Queue()
-    fake = SimpleNamespace(
-        _outbox=outbox,
-        _code2wav_target="code2wav",
-        _enable_batched_emit=True,
-        model=SimpleNamespace(
-            _output_codes=torch.tensor([[1, 2], [3, 4]], dtype=torch.long),
-            _output_embeds=torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
-        ),
-    )
-    schedule_batch = SimpleNamespace(
-        reqs=[SimpleNamespace(rid="req-1"), SimpleNamespace(rid="req-2")]
-    )
-    payload = SimpleNamespace(request=SimpleNamespace(params={"stream": True}))
-    requests = [
-        SimpleNamespace(
-            data=SimpleNamespace(stage_payload=payload, pending_feedback_queue=deque())
-        ),
-        SimpleNamespace(
-            data=SimpleNamespace(stage_payload=payload, pending_feedback_queue=deque())
-        ),
-    ]
-
-    QwenTalkerModelRunner._emit_code_chunks_and_feedback(
-        fake,
-        schedule_batch=schedule_batch,
-        requests=requests,
-    )
-    fake.model._output_codes.fill_(99)
-    fake.model._output_embeds.fill_(99.0)
-
-    first = outbox.get_nowait()
-    second = outbox.get_nowait()
-    assert torch.equal(first.data, torch.tensor([1, 2]))
-    assert torch.equal(second.data, torch.tensor([3, 4]))
-    assert torch.equal(
-        requests[0].data.pending_feedback_queue[0], torch.tensor([1.0, 2.0])
-    )
-    assert torch.equal(
-        requests[1].data.pending_feedback_queue[0], torch.tensor([3.0, 4.0])
-    )
-    assert first.metadata == {"stream": True}
-    assert first.target == "code2wav"
-
-
-def test_talker_decode_sampling_zero_temperature_uses_greedy_fastpath() -> None:
-    fake = _talker_seed_self(vocab=4)
-    requests = [
-        _talker_seed_req(None, "req-1", temperature=0.0),
-        _talker_seed_req(None, "req-2", temperature=0.0),
-    ]
-
-    Qwen3OmniTalker.prepare_decode_buffers(fake, requests)
-    sampled = Qwen3OmniTalker._sample_decode_tokens(
-        fake,
-        torch.tensor([[0.1, 5.0, 1.0, 2.0], [3.0, 0.5, 4.0, 1.0]]),
-        SimpleNamespace(positions=torch.arange(2)),
-    )
-
-    assert fake._decode_all_greedy is True
-    assert torch.equal(sampled, torch.tensor([1, 2]))
-
-
-def test_talker_decode_sampling_suppress_disables_greedy_fastpath() -> None:
-    fake = _talker_seed_self(vocab=4)
-    requests = [_talker_seed_req(None, "req-1", temperature=0.0, suppress_tokens=[1])]
-
-    Qwen3OmniTalker.prepare_decode_buffers(fake, requests)
-    sampled = Qwen3OmniTalker._sample_decode_tokens(
-        fake,
-        torch.tensor([[0.1, 5.0, 4.0, 2.0]]),
-        SimpleNamespace(positions=torch.arange(1)),
-    )
-
-    assert fake._decode_all_greedy is False
-    assert torch.equal(sampled, torch.tensor([2]))

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import queue
 import threading
 import time
 from collections import deque
@@ -1800,13 +1801,22 @@ def _talker_seed_self(max_bs: int = 4, vocab: int = 8) -> SimpleNamespace:
         _sampling_top_ks=torch.ones(max_bs, dtype=torch.long),
         _sampling_min_ps=torch.zeros(max_bs),
         _sampling_seeds=torch.zeros(max_bs, dtype=torch.long),
+        _greedy_sample_fastpath_enabled=True,
+        _decode_all_greedy=False,
+        _sampler=None,
     )
 
 
-def _talker_seed_req(seed: int | None, rid: str) -> SimpleNamespace:
+def _talker_seed_req(
+    seed: int | None,
+    rid: str,
+    *,
+    temperature: float = 0.8,
+    suppress_tokens: list[int] | None = None,
+) -> SimpleNamespace:
     sp = SimpleNamespace(
         repetition_penalty=1.0,  # keep rep/suppress branches off
-        temperature=0.8,
+        temperature=temperature,
         top_p=0.9,
         top_k=20,
         min_p=0.0,
@@ -1815,7 +1825,7 @@ def _talker_seed_req(seed: int | None, rid: str) -> SimpleNamespace:
     req = SimpleNamespace(
         sampling_params=sp, output_ids=[], _codec_suppress_tokens=None, rid=rid
     )
-    return SimpleNamespace(data=SimpleNamespace(req=req, suppress_tokens=None))
+    return SimpleNamespace(data=SimpleNamespace(req=req, suppress_tokens=suppress_tokens))
 
 
 def test_talker_prepare_decode_buffers_unseeded_seed_is_rank_shared() -> None:
@@ -1846,3 +1856,78 @@ def test_talker_prepare_decode_buffers_unseeded_seed_is_rank_shared() -> None:
     assert int(fake._sampling_seeds[1]) == derive_sampling_seed(
         "sglang-omni-unseeded-row", "unseeded"
     )
+
+
+def test_talker_emit_code_feedback_batches_clone_lifetime() -> None:
+    outbox: queue.Queue = queue.Queue()
+    fake = SimpleNamespace(
+        _outbox=outbox,
+        _code2wav_target="code2wav",
+        _enable_batched_emit=True,
+        model=SimpleNamespace(
+            _output_codes=torch.tensor([[1, 2], [3, 4]], dtype=torch.long),
+            _output_embeds=torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+        ),
+    )
+    schedule_batch = SimpleNamespace(
+        reqs=[SimpleNamespace(rid="req-1"), SimpleNamespace(rid="req-2")]
+    )
+    payload = SimpleNamespace(request=SimpleNamespace(params={"stream": True}))
+    requests = [
+        SimpleNamespace(
+            data=SimpleNamespace(stage_payload=payload, pending_feedback_queue=deque())
+        ),
+        SimpleNamespace(
+            data=SimpleNamespace(stage_payload=payload, pending_feedback_queue=deque())
+        ),
+    ]
+
+    QwenTalkerModelRunner._emit_code_chunks_and_feedback(
+        fake,
+        schedule_batch=schedule_batch,
+        requests=requests,
+    )
+    fake.model._output_codes.fill_(99)
+    fake.model._output_embeds.fill_(99.0)
+
+    first = outbox.get_nowait()
+    second = outbox.get_nowait()
+    assert torch.equal(first.data, torch.tensor([1, 2]))
+    assert torch.equal(second.data, torch.tensor([3, 4]))
+    assert torch.equal(requests[0].data.pending_feedback_queue[0], torch.tensor([1.0, 2.0]))
+    assert torch.equal(requests[1].data.pending_feedback_queue[0], torch.tensor([3.0, 4.0]))
+    assert first.metadata == {"stream": True}
+    assert first.target == "code2wav"
+
+
+def test_talker_decode_sampling_zero_temperature_uses_greedy_fastpath() -> None:
+    fake = _talker_seed_self(vocab=4)
+    requests = [
+        _talker_seed_req(None, "req-1", temperature=0.0),
+        _talker_seed_req(None, "req-2", temperature=0.0),
+    ]
+
+    Qwen3OmniTalker.prepare_decode_buffers(fake, requests)
+    sampled = Qwen3OmniTalker._sample_decode_tokens(
+        fake,
+        torch.tensor([[0.1, 5.0, 1.0, 2.0], [3.0, 0.5, 4.0, 1.0]]),
+        SimpleNamespace(positions=torch.arange(2)),
+    )
+
+    assert fake._decode_all_greedy is True
+    assert torch.equal(sampled, torch.tensor([1, 2]))
+
+
+def test_talker_decode_sampling_suppress_disables_greedy_fastpath() -> None:
+    fake = _talker_seed_self(vocab=4)
+    requests = [_talker_seed_req(None, "req-1", temperature=0.0, suppress_tokens=[1])]
+
+    Qwen3OmniTalker.prepare_decode_buffers(fake, requests)
+    sampled = Qwen3OmniTalker._sample_decode_tokens(
+        fake,
+        torch.tensor([[0.1, 5.0, 4.0, 2.0]]),
+        SimpleNamespace(positions=torch.arange(1)),
+    )
+
+    assert fake._decode_all_greedy is False
+    assert torch.equal(sampled, torch.tensor([2]))


### PR DESCRIPTION
## Summary

Optimize the Qwen3-Omni talker code predictor hot path with larger Triton fusion instead of small copy-only fusion.

Changes:
- Add optional Triton kernels for predictor input staging and code sampling/staging.
- Fuse `argmax logits -> code write -> embedding lookup -> predictor input write -> summed embedding update`.
- Fuse initial layer0 code embedding and predictor input staging.
- Use SDPA `enable_gqa=True` to avoid explicit KV repeat when available.
- Add CUDA unit coverage for the fused predictor kernels, including strided views and argmax tie behavior.

## Validation

Unit checks:
- `python3 -m py_compile sglang_omni/models/qwen3_omni/components/predictor_kernels.py sglang_omni/models/qwen3_omni/components/talker.py tests/unit_test/qwen3_omni/test_predictor_kernels.py`
- H100: `pytest -q tests/unit_test/qwen3_omni/test_predictor_kernels.py` -> 2 passed
- H100: `pytest -q tests/unit_test/qwen3_omni/test_talker.py` -> 63 passed

H100 benchmark, Qwen3-Omni SeedTTS EN full set, `temperature=0`, `max_concurrency=16`, `max_samples=1088`, voice clone enabled:

| Metric | Baseline | Patch | Change |
| --- | ---: | ---: | ---: |
| Completed | 1088/1088 | 1088/1088 | same |
| Throughput | 5.576 req/s | 5.696 req/s | +2.15% |
| Audio throughput | 20.226 audio-s/s | 20.507 audio-s/s | +1.39% |
| Output throughput | 79.5 tok/s | 81.2 tok/s | +2.14% |
| Latency mean | 2.864s | 2.805s | -2.06% |
| Latency p95 | 4.250s | 4.204s | -1.08% |
| Latency p99 | 5.100s | 4.731s | -7.24% |
| RTF mean | 0.8073 | 0.7965 | -1.34% |
| RTF p99 | 1.4234 | 1.3356 | -6.17% |
| WER corpus | 2.27% | 2.05% | -0.22 pp |
| >50% WER outliers | 5 | 2 | better |

Result dirs:
- Baseline: `/data/results/qwen3_omni_main_seedtts1088_c16_t0_gpu4_v1`
- Patch: `/data/results/qwen3_omni_large_fusion_seedtts1088_c16_t0_gpu4_v1`

Kernel microbench on H100:
- batch=16: stage fusion 1.85x, sample/stage fusion 1.89x
- batch=32: stage fusion 1.85x, sample/stage fusion 1.88x

## Notes

This targets the predictor staging/sample hot path. End-to-end speedup is modest on the full benchmark, suggesting the remaining Qwen3-Omni bottleneck is still broader scheduling/host/code2wav/runtime overhead rather than only this predictor fragment.
