### PR TITLE
[MOSS] Decouple MOSS-TTS Local codec from processor

### DIFF
--- a/sglang_omni/models/moss_tts/hf_loading.py
+++ b/sglang_omni/models/moss_tts/hf_loading.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared Hugging Face loading helpers for MOSS TTS models."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+
+def resolve_moss_checkpoint(checkpoint: str) -> str:
+    """Return a local checkpoint directory for a local path or HF repo id."""
+    if os.path.isdir(checkpoint):
+        return checkpoint
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(checkpoint)
+
+
+@contextmanager
+def moss_transformers_processor_compat() -> Iterator[None]:
+    """Scope Transformers API-drift patches to MOSS processor/code loading."""
+    import transformers.configuration_utils as configuration_utils
+    from transformers import PreTrainedModel, processing_utils
+
+    missing = object()
+    undo: list[tuple[str, Any, str, Any]] = []
+
+    def patch_attr(obj: Any, name: str, value: Any) -> None:
+        undo.append(("attr", obj, name, getattr(obj, name, missing)))
+        setattr(obj, name, value)
+
+    def patch_item(mapping: dict, key: str, value: Any) -> None:
+        undo.append(("item", mapping, key, mapping.get(key, missing)))
+        mapping[key] = value
+
+    try:
+        if not hasattr(configuration_utils, "PreTrainedConfig"):
+            patch_attr(
+                configuration_utils,
+                "PreTrainedConfig",
+                configuration_utils.PretrainedConfig,
+            )
+        auto_mapping = getattr(processing_utils, "AUTO_TO_BASE_CLASS_MAPPING", None)
+        if isinstance(auto_mapping, dict):
+            if "AutoModel" not in auto_mapping:
+                patch_item(auto_mapping, "AutoModel", "PreTrainedModel")
+            if not hasattr(processing_utils, "MODALITY_TO_BASE_CLASS_MAPPING"):
+                patch_attr(
+                    processing_utils, "MODALITY_TO_BASE_CLASS_MAPPING", auto_mapping
+                )
+        if hasattr(processing_utils, "PreTrainedAudioTokenizerBase"):
+            patch_attr(
+                processing_utils, "PreTrainedAudioTokenizerBase", PreTrainedModel
+            )
+        yield
+    finally:
+        for kind, obj, key, old in reversed(undo):
+            if kind == "attr":
+                if old is missing:
+                    if hasattr(obj, key):
+                        delattr(obj, key)
+                else:
+                    setattr(obj, key, old)
+            elif old is missing:
+                obj.pop(key, None)
+            else:
+                obj[key] = old
+
+
+def load_moss_processor_class(checkpoint_dir: str) -> type:
+    from transformers.dynamic_module_utils import get_class_from_dynamic_module
+
+    processor_config_path = os.path.join(checkpoint_dir, "processor_config.json")
+    with open(processor_config_path, encoding="utf-8") as f:
+        processor_config = json.load(f)
+
+    class_ref = (processor_config.get("auto_map") or {}).get("AutoProcessor")
+    if not class_ref:
+        raise RuntimeError("MOSS-TTS processor_config.json lacks AutoProcessor map")
+
+    processor_cls = get_class_from_dynamic_module(class_ref, checkpoint_dir)
+    if list(getattr(processor_cls, "attributes", [])) == [
+        "feature_extractor",
+        "tokenizer",
+    ]:
+        processor_cls.attributes = ["tokenizer"]
+    return processor_cls

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -3,15 +3,17 @@
 
 from __future__ import annotations
 
-import json
 import logging
-import os
-from contextlib import contextmanager
 from typing import Any
 
 import torch
 
 from sglang_omni.models.moss_tts.codec import split_moss_audio_segments
+from sglang_omni.models.moss_tts.hf_loading import (
+    load_moss_processor_class,
+    moss_transformers_processor_compat,
+    resolve_moss_checkpoint,
+)
 from sglang_omni.models.moss_tts.payload_types import (
     MossTTSState,
     moss_tts_special_token_defaults,
@@ -49,90 +51,8 @@ def store_state(payload: StagePayload, state: MossTTSState) -> StagePayload:
     return payload
 
 
-def _resolve_checkpoint(checkpoint: str) -> str:
-    if os.path.isdir(checkpoint):
-        return checkpoint
-    from huggingface_hub import snapshot_download
-
-    return snapshot_download(checkpoint)
-
-
 def _torch_dtype(dtype: str | torch.dtype) -> torch.dtype:
     return getattr(torch, dtype) if isinstance(dtype, str) else dtype
-
-
-@contextmanager
-def _moss_transformers_processor_compat():
-    """Scope load-time Transformers API-drift patches to the MOSS processor load
-    (renamed PreTrainedConfig, the audio-tokenizer modality mapping, and
-    PreTrainedAudioTokenizerBase), restoring the globals afterwards so they don't
-    leak into unrelated models."""
-    import transformers.configuration_utils as configuration_utils
-    from transformers import PreTrainedModel, processing_utils
-
-    missing = object()
-    undo: list[tuple[str, Any, str, Any]] = []
-
-    def patch_attr(obj: Any, name: str, value: Any) -> None:
-        undo.append(("attr", obj, name, getattr(obj, name, missing)))
-        setattr(obj, name, value)
-
-    def patch_item(mapping: dict, key: str, value: Any) -> None:
-        undo.append(("item", mapping, key, mapping.get(key, missing)))
-        mapping[key] = value
-
-    try:
-        if not hasattr(configuration_utils, "PreTrainedConfig"):
-            patch_attr(
-                configuration_utils,
-                "PreTrainedConfig",
-                configuration_utils.PretrainedConfig,
-            )
-        auto_mapping = getattr(processing_utils, "AUTO_TO_BASE_CLASS_MAPPING", None)
-        if isinstance(auto_mapping, dict):
-            if "AutoModel" not in auto_mapping:
-                patch_item(auto_mapping, "AutoModel", "PreTrainedModel")
-            if not hasattr(processing_utils, "MODALITY_TO_BASE_CLASS_MAPPING"):
-                patch_attr(
-                    processing_utils, "MODALITY_TO_BASE_CLASS_MAPPING", auto_mapping
-                )
-        if hasattr(processing_utils, "PreTrainedAudioTokenizerBase"):
-            patch_attr(
-                processing_utils, "PreTrainedAudioTokenizerBase", PreTrainedModel
-            )
-        yield
-    finally:
-        for kind, obj, key, old in reversed(undo):
-            if kind == "attr":
-                if old is missing:
-                    if hasattr(obj, key):
-                        delattr(obj, key)
-                else:
-                    setattr(obj, key, old)
-            elif old is missing:
-                obj.pop(key, None)
-            else:
-                obj[key] = old
-
-
-def _load_moss_processor_class(checkpoint_dir: str) -> type:
-    from transformers.dynamic_module_utils import get_class_from_dynamic_module
-
-    processor_config_path = os.path.join(checkpoint_dir, "processor_config.json")
-    with open(processor_config_path, encoding="utf-8") as f:
-        processor_config = json.load(f)
-
-    class_ref = (processor_config.get("auto_map") or {}).get("AutoProcessor")
-    if not class_ref:
-        raise RuntimeError("MOSS-TTS processor_config.json lacks AutoProcessor map")
-
-    processor_cls = get_class_from_dynamic_module(class_ref, checkpoint_dir)
-    if list(getattr(processor_cls, "attributes", [])) == [
-        "feature_extractor",
-        "tokenizer",
-    ]:
-        processor_cls.attributes = ["tokenizer"]
-    return processor_cls
 
 
 def _normalize_moss_processor_config(processor: Any) -> None:
@@ -151,11 +71,11 @@ def _load_moss_processor(
     device: str = "cpu",
     dtype: str | torch.dtype = "float32",
 ) -> Any:
-    checkpoint_dir = _resolve_checkpoint(model_path)
+    checkpoint_dir = resolve_moss_checkpoint(model_path)
     logger.info("Loading MOSS-TTS processor from %s on %s", checkpoint_dir, device)
     try:
-        with _moss_transformers_processor_compat():
-            processor_cls = _load_moss_processor_class(checkpoint_dir)
+        with moss_transformers_processor_compat():
+            processor_cls = load_moss_processor_class(checkpoint_dir)
             processor = processor_cls.from_pretrained(
                 checkpoint_dir,
                 trust_remote_code=True,
@@ -224,7 +144,7 @@ def create_sglang_tts_engine_executor(
         build_sglang_server_args,
     )
 
-    checkpoint_dir = _resolve_checkpoint(model_path)
+    checkpoint_dir = resolve_moss_checkpoint(model_path)
     if gpu_id is not None:
         device = f"cuda:{gpu_id}"
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0

--- a/sglang_omni/models/moss_tts_local/audio_tokenizer.py
+++ b/sglang_omni/models/moss_tts_local/audio_tokenizer.py
@@ -131,6 +131,7 @@ class MossTTSLocalAudioTokenizer:
 
     @staticmethod
     def _loudness_normalize(wav: torch.Tensor) -> torch.Tensor:
+        wav = wav.to(torch.float32)
         if wav.numel() == 0:
             return wav
         current_dbfs = 10.0 * torch.log10(torch.mean(wav**2) + 1e-9)

--- a/sglang_omni/models/moss_tts_local/audio_tokenizer.py
+++ b/sglang_omni/models/moss_tts_local/audio_tokenizer.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Owned MOSS-Audio-Tokenizer-v2 loader for MOSS-TTS Local."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import torch
+
+from sglang_omni.models.moss_tts.stages import (
+    _moss_transformers_processor_compat,
+    _resolve_checkpoint,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MOSS_TTS_LOCAL_AUDIO_TOKENIZER = "OpenMOSS-Team/MOSS-Audio-Tokenizer-v2"
+_LOUDNESS_TARGET_DBFS = -20.0
+_LOUDNESS_GAIN_MIN_DB = -3.0
+_LOUDNESS_GAIN_MAX_DB = 3.0
+
+
+class MossTTSLocalAudioTokenizer:
+    """Narrow encode API plus owned access to the upstream v2 codec model."""
+
+    def __init__(
+        self,
+        model: Any,
+        *,
+        device: str,
+    ) -> None:
+        self.model = model
+        self.device = str(device)
+        config = model.config
+        self.sample_rate = int(config.sampling_rate)
+        self.number_channels = int(config.number_channels)
+
+    def encode_paths(
+        self,
+        paths: list[str],
+        *,
+        num_quantizers: int,
+    ) -> list[torch.Tensor]:
+        if not paths:
+            raise ValueError("paths must contain at least one audio path")
+        return self.encode_waveforms(
+            self.load_paths(paths),
+            num_quantizers=num_quantizers,
+        )
+
+    def load_paths(self, paths: list[str]) -> list[tuple[torch.Tensor, int]]:
+        import torchaudio
+
+        waveforms = []
+        for path in paths:
+            wav, sample_rate = torchaudio.load(path)
+            if int(sample_rate) != self.sample_rate:
+                wav = torchaudio.functional.resample(
+                    waveform=wav,
+                    orig_freq=int(sample_rate),
+                    new_freq=self.sample_rate,
+                )
+            waveforms.append((wav, self.sample_rate))
+        return waveforms
+
+    def encode_wavs(
+        self,
+        wavs: list[torch.Tensor],
+        sample_rate: int,
+        *,
+        num_quantizers: int,
+    ) -> list[torch.Tensor]:
+        return self.encode_waveforms(
+            [(wav, int(sample_rate)) for wav in wavs],
+            num_quantizers=num_quantizers,
+        )
+
+    def encode_waveforms(
+        self,
+        waveforms: list[tuple[torch.Tensor, int]],
+        *,
+        num_quantizers: int,
+    ) -> list[torch.Tensor]:
+        if not waveforms:
+            raise ValueError("waveforms must contain at least one waveform")
+        prepared = [
+            self._prepare_waveform(wav, sample_rate) for wav, sample_rate in waveforms
+        ]
+
+        with torch.inference_mode():
+            encoded = self.model.batch_encode(
+                prepared,
+                num_quantizers=int(num_quantizers),
+            )
+        audio_codes = encoded.audio_codes
+        audio_codes_lengths = encoded.audio_codes_lengths
+        if audio_codes is None or audio_codes_lengths is None:
+            raise RuntimeError(
+                "MOSS-TTS Local audio tokenizer encode returned empty "
+                "audio_codes/audio_codes_lengths"
+            )
+        codes_cpu = audio_codes.detach().to("cpu", torch.long)
+        lengths_cpu = audio_codes_lengths.detach().to("cpu")
+        return [
+            codes_cpu[:, index, : int(lengths_cpu[index])].transpose(0, 1).contiguous()
+            for index in range(int(codes_cpu.shape[1]))
+        ]
+
+    def _prepare_waveform(self, wav: torch.Tensor, sample_rate: int) -> torch.Tensor:
+        if wav.ndim == 1:
+            wav = wav.unsqueeze(0)
+        if wav.shape[0] == 1:
+            wav = wav.repeat(self.number_channels, 1)
+        elif wav.shape[0] > self.number_channels:
+            wav = wav[: self.number_channels]
+        if wav.shape[0] != self.number_channels:
+            raise ValueError(
+                f"expected {self.number_channels} audio channels, got {wav.shape[0]}"
+            )
+        if int(sample_rate) != self.sample_rate:
+            import torchaudio
+
+            wav = torchaudio.functional.resample(
+                waveform=wav,
+                orig_freq=int(sample_rate),
+                new_freq=self.sample_rate,
+            )
+        wav = self._loudness_normalize(wav)
+        return wav.to(device=self.device, dtype=torch.float32)
+
+    @staticmethod
+    def _loudness_normalize(wav: torch.Tensor) -> torch.Tensor:
+        if wav.numel() == 0:
+            return wav
+        current_dbfs = 10.0 * torch.log10(torch.mean(wav**2) + 1e-9)
+        gain = float(_LOUDNESS_TARGET_DBFS - current_dbfs)
+        gain = max(_LOUDNESS_GAIN_MIN_DB, min(gain, _LOUDNESS_GAIN_MAX_DB))
+        return wav * (10.0 ** (gain / 20.0))
+
+
+def load_moss_tts_local_audio_tokenizer(
+    model_path: str = DEFAULT_MOSS_TTS_LOCAL_AUDIO_TOKENIZER,
+    *,
+    device: str = "cuda:0",
+) -> MossTTSLocalAudioTokenizer:
+    checkpoint_dir = _resolve_checkpoint(model_path)
+    logger.info(
+        f"Loading MOSS-TTS Local audio tokenizer from {checkpoint_dir} on {device}"
+    )
+    try:
+        from transformers import AutoModel
+
+        with _moss_transformers_processor_compat():
+            model = AutoModel.from_pretrained(
+                checkpoint_dir,
+                trust_remote_code=True,
+            )
+    except Exception as exc:
+        raise RuntimeError(
+            "MOSS-TTS Local support requires OpenMOSS-Team/MOSS-Audio-Tokenizer-v2"
+        ) from exc
+    model.eval()
+    model.to(device)
+    return MossTTSLocalAudioTokenizer(
+        model,
+        device=device,
+    )

--- a/sglang_omni/models/moss_tts_local/audio_tokenizer.py
+++ b/sglang_omni/models/moss_tts_local/audio_tokenizer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Owned MOSS-Audio-Tokenizer-v2 loader for MOSS-TTS Local."""
+"""MOSS-Audio-Tokenizer-v2 codec loader for MOSS-TTS Local."""
 
 from __future__ import annotations
 
@@ -8,9 +8,9 @@ from typing import Any
 
 import torch
 
-from sglang_omni.models.moss_tts.stages import (
-    _moss_transformers_processor_compat,
-    _resolve_checkpoint,
+from sglang_omni.models.moss_tts.hf_loading import (
+    moss_transformers_processor_compat,
+    resolve_moss_checkpoint,
 )
 
 logger = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ _LOUDNESS_GAIN_MAX_DB = 3.0
 
 
 class MossTTSLocalAudioTokenizer:
-    """Narrow encode API plus owned access to the upstream v2 codec model."""
+    """Encode wrapper around a separately loaded MOSS-Audio-Tokenizer-v2 model."""
 
     def __init__(
         self,
@@ -144,14 +144,14 @@ def load_moss_tts_local_audio_tokenizer(
     *,
     device: str = "cuda:0",
 ) -> MossTTSLocalAudioTokenizer:
-    checkpoint_dir = _resolve_checkpoint(model_path)
+    checkpoint_dir = resolve_moss_checkpoint(model_path)
     logger.info(
         f"Loading MOSS-TTS Local audio tokenizer from {checkpoint_dir} on {device}"
     )
     try:
         from transformers import AutoModel
 
-        with _moss_transformers_processor_compat():
+        with moss_transformers_processor_compat():
             model = AutoModel.from_pretrained(
                 checkpoint_dir,
                 trust_remote_code=True,

--- a/sglang_omni/models/moss_tts_local/audio_tokenizer.py
+++ b/sglang_omni/models/moss_tts_local/audio_tokenizer.py
@@ -16,6 +16,7 @@ from sglang_omni.models.moss_tts.hf_loading import (
 logger = logging.getLogger(__name__)
 
 DEFAULT_MOSS_TTS_LOCAL_AUDIO_TOKENIZER = "OpenMOSS-Team/MOSS-Audio-Tokenizer-v2"
+_REFERENCE_CHANNELS = 2
 _LOUDNESS_TARGET_DBFS = -20.0
 _LOUDNESS_GAIN_MIN_DB = -3.0
 _LOUDNESS_GAIN_MAX_DB = 3.0
@@ -34,7 +35,6 @@ class MossTTSLocalAudioTokenizer:
         self.device = str(device)
         config = model.config
         self.sample_rate = int(config.sampling_rate)
-        self.number_channels = int(config.number_channels)
 
     def encode_paths(
         self,
@@ -111,12 +111,12 @@ class MossTTSLocalAudioTokenizer:
         if wav.ndim == 1:
             wav = wav.unsqueeze(0)
         if wav.shape[0] == 1:
-            wav = wav.repeat(self.number_channels, 1)
-        elif wav.shape[0] > self.number_channels:
-            wav = wav[: self.number_channels]
-        if wav.shape[0] != self.number_channels:
+            wav = wav.repeat(_REFERENCE_CHANNELS, 1)
+        elif wav.shape[0] > _REFERENCE_CHANNELS:
+            wav = wav[:_REFERENCE_CHANNELS]
+        if wav.shape[0] != _REFERENCE_CHANNELS:
             raise ValueError(
-                f"expected {self.number_channels} audio channels, got {wav.shape[0]}"
+                f"expected {_REFERENCE_CHANNELS} audio channels, got {wav.shape[0]}"
             )
         if int(sample_rate) != self.sample_rate:
             import torchaudio
@@ -156,6 +156,7 @@ def load_moss_tts_local_audio_tokenizer(
             model = AutoModel.from_pretrained(
                 checkpoint_dir,
                 trust_remote_code=True,
+                codec_weight_dtype="bf16",
             )
     except Exception as exc:
         raise RuntimeError(

--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -46,6 +46,11 @@ def _stages(*, codec_device: str, colocated: bool) -> list[StageConfig]:
             factory=f"{_PKG}.stages.create_preprocessing_executor",
             factory_args={
                 "device": codec_device,
+                # MOSS-Audio-Tokenizer-v2 reference encode is batch-shape sensitive:
+                # the same file can produce different discrete prompt codes when
+                # encoded alone versus with unrelated refs. Keep default serving
+                # deterministic; cache/single-flight still deduplicates identical refs.
+                "encode_batch_size": 1,
                 "ref_audio_cache": True,
                 "ref_audio_cache_max_items": 8192,
                 "ref_audio_cache_max_bytes": 64 * 1024 * 1024,

--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -46,11 +46,6 @@ def _stages(*, codec_device: str, colocated: bool) -> list[StageConfig]:
             factory=f"{_PKG}.stages.create_preprocessing_executor",
             factory_args={
                 "device": codec_device,
-                # MOSS-Audio-Tokenizer-v2 reference encode is batch-shape sensitive:
-                # the same file can produce different discrete prompt codes when
-                # encoded alone versus with unrelated refs. Keep default serving
-                # deterministic; cache/single-flight still deduplicates identical refs.
-                "encode_batch_size": 1,
                 "ref_audio_cache": True,
                 "ref_audio_cache_max_items": 8192,
                 "ref_audio_cache_max_bytes": 64 * 1024 * 1024,

--- a/sglang_omni/models/moss_tts_local/request_builders.py
+++ b/sglang_omni/models/moss_tts_local/request_builders.py
@@ -11,6 +11,7 @@ from typing import Any
 import torch
 
 from sglang_omni.models.moss_tts.request_builders import (
+    _DATA_URI_RE,
     MOSS_TTS_DEFAULT_MAX_NEW_TOKENS,
     _new_moss_tts_sampling_seed,
     _reference_for_processor,
@@ -250,20 +251,14 @@ def _build_processor_message(
     state: MossTTSLocalState,
     reference_encoder: Any = None,
 ) -> dict[str, Any]:
-    from sglang_omni.models.moss_tts.request_builders import _DATA_URI_RE
-
     ref_audio = state.ref_audio
     if reference_encoder is not None and isinstance(ref_audio, str):
         if _DATA_URI_RE.match(ref_audio) is None:
             # File-path refs share one batched codec forward via the coalescer.
             reference = [reference_encoder.encode(ref_audio)]
-        elif hasattr(reference_encoder, "encode_data_uri"):
-            # Data-URI refs through the same LRU (bytes: keyspace).
-            reference = [
-                reference_encoder.encode_data_uri(ref_audio, processor=processor)
-            ]
         else:
-            reference = _reference_for_processor(processor, ref_audio)
+            # Data-URI refs through the same LRU (bytes: keyspace).
+            reference = [reference_encoder.encode_data_uri(ref_audio)]
     else:
         reference = _reference_for_processor(processor, ref_audio)
     return processor.build_user_message(

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -12,16 +12,16 @@ import queue
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypeAlias
 
 import torch
 
-from sglang_omni.models.moss_tts.request_builders import _DATA_URI_RE
-from sglang_omni.models.moss_tts.stages import (
-    _load_moss_processor_class,
-    _moss_transformers_processor_compat,
-    _resolve_checkpoint,
+from sglang_omni.models.moss_tts.hf_loading import (
+    load_moss_processor_class,
+    moss_transformers_processor_compat,
+    resolve_moss_checkpoint,
 )
+from sglang_omni.models.moss_tts.request_builders import _DATA_URI_RE
 from sglang_omni.models.moss_tts_local.audio_tokenizer import (
     DEFAULT_MOSS_TTS_LOCAL_AUDIO_TOKENIZER,
     load_moss_tts_local_audio_tokenizer,
@@ -81,7 +81,7 @@ class _WaveformReferenceJob:
     sample_rate: int
 
 
-_ReferenceEncodeJob = _PathReferenceJob | _WaveformReferenceJob
+_ReferenceEncodeJob: TypeAlias = _PathReferenceJob | _WaveformReferenceJob
 
 
 def _data_uri_audio_bytes(ref_audio: str) -> bytes:
@@ -92,18 +92,13 @@ def _data_uri_audio_bytes(ref_audio: str) -> bytes:
 
 
 def _decode_data_uri_audio(raw: bytes) -> tuple[torch.Tensor, int]:
-    try:
-        import soundfile as sf
-    except ImportError as exc:
-        raise RuntimeError(
-            "MOSS-TTS Local base64 reference audio requires soundfile"
-        ) from exc
+    import soundfile as sf
 
     audio, sample_rate = sf.read(io.BytesIO(raw), dtype="float32", always_2d=True)
     duration = audio.shape[0] / max(int(sample_rate), 1)
     if duration > _MAX_REFERENCE_SECONDS:
         raise ValueError(
-            f"reference audio is {duration:.1f}s long; the limit is "
+            f"reference audio is {duration:.1f}s long, limit is "
             f"{_MAX_REFERENCE_SECONDS:.0f}s"
         )
     return torch.from_numpy(audio.T), int(sample_rate)
@@ -190,13 +185,13 @@ def _resolve_codec_device(device: str | None, gpu_id: int | None) -> str:
 
 
 def _load_moss_tts_local_processor(model_path: str) -> Any:
-    checkpoint_dir = _resolve_checkpoint(model_path)
+    checkpoint_dir = resolve_moss_checkpoint(model_path)
     logger.info(f"Loading MOSS-TTS Local processor from {checkpoint_dir} without codec")
     try:
         from transformers import AutoConfig, AutoTokenizer
 
-        with _moss_transformers_processor_compat():
-            processor_cls = _load_moss_processor_class(checkpoint_dir)
+        with moss_transformers_processor_compat():
+            processor_cls = load_moss_processor_class(checkpoint_dir)
             model_config = AutoConfig.from_pretrained(
                 checkpoint_dir,
                 trust_remote_code=True,
@@ -266,7 +261,7 @@ class _BatchedReferenceEncoder:
             return  # unreadable files fail with a clearer error in the codec
         if duration > cls.MAX_REFERENCE_SECONDS:
             raise ValueError(
-                f"reference audio is {duration:.1f}s long; the limit is "
+                f"reference audio is {duration:.1f}s long, limit is "
                 f"{cls.MAX_REFERENCE_SECONDS:.0f}s"
             )
 
@@ -619,7 +614,7 @@ def create_sglang_tts_engine_executor(
         build_sglang_server_args,
     )
 
-    checkpoint_dir = _resolve_checkpoint(model_path)
+    checkpoint_dir = resolve_moss_checkpoint(model_path)
     if gpu_id is not None:
         device = f"cuda:{gpu_id}"
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -562,7 +562,7 @@ def create_preprocessing_executor(
     gpu_id: int | None = None,
     codec_model_path: str | None = None,
     max_concurrency: int = 16,
-    encode_batch_size: int = 8,
+    encode_batch_size: int = 1,
     encode_batch_wait_ms: int = 4,
     ref_audio_cache: bool = True,
     ref_audio_cache_max_items: int = 8192,

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -562,7 +562,7 @@ def create_preprocessing_executor(
     gpu_id: int | None = None,
     codec_model_path: str | None = None,
     max_concurrency: int = 16,
-    encode_batch_size: int = 1,
+    encode_batch_size: int = 8,
     encode_batch_wait_ms: int = 4,
     ref_audio_cache: bool = True,
     ref_audio_cache_max_items: int = 8192,

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -212,6 +212,22 @@ def _load_moss_tts_local_processor(model_path: str) -> Any:
     return processor
 
 
+def _resolve_audio_tokenizer_model_path(
+    processor: Any,
+    codec_model_path: str | None,
+) -> str:
+    if codec_model_path is not None:
+        return codec_model_path
+    return str(
+        getattr(
+            processor.model_config,
+            "audio_tokenizer_name_or_path",
+            DEFAULT_MOSS_TTS_LOCAL_AUDIO_TOKENIZER,
+        )
+        or DEFAULT_MOSS_TTS_LOCAL_AUDIO_TOKENIZER
+    )
+
+
 class _BatchedReferenceEncoder:
     """Coalesces concurrent reference-audio encodes into batched codec calls.
 
@@ -544,7 +560,7 @@ def create_preprocessing_executor(
     *,
     device: str | None = None,
     gpu_id: int | None = None,
-    codec_model_path: str = DEFAULT_MOSS_TTS_LOCAL_AUDIO_TOKENIZER,
+    codec_model_path: str | None = None,
     max_concurrency: int = 16,
     encode_batch_size: int = 8,
     encode_batch_wait_ms: int = 4,
@@ -566,7 +582,7 @@ def create_preprocessing_executor(
     device = _resolve_codec_device(device, gpu_id)
     processor = _load_moss_tts_local_processor(model_path)
     audio_tokenizer = load_moss_tts_local_audio_tokenizer(
-        codec_model_path,
+        _resolve_audio_tokenizer_model_path(processor, codec_model_path),
         device=device,
     )
     reference_encoder: Any = _BatchedReferenceEncoder(
@@ -760,7 +776,7 @@ def create_vocoder_executor(
     *,
     device: str | None = None,
     gpu_id: int | None = None,
-    codec_model_path: str = DEFAULT_MOSS_TTS_LOCAL_AUDIO_TOKENIZER,
+    codec_model_path: str | None = None,
     max_batch_size: int = 8,
     max_batch_wait_ms: int = 2,
     stream_slots: int = 8,
@@ -773,7 +789,7 @@ def create_vocoder_executor(
     device = _resolve_codec_device(device, gpu_id)
     processor = _load_moss_tts_local_processor(model_path)
     audio_tokenizer = load_moss_tts_local_audio_tokenizer(
-        codec_model_path,
+        _resolve_audio_tokenizer_model_path(processor, codec_model_path),
         device=device,
     )
     scheduler = MossTTSLocalStreamingVocoderScheduler(

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+import base64
 import concurrent.futures
+import io
 import logging
 import os
 import queue
@@ -14,10 +16,15 @@ from typing import Any
 
 import torch
 
+from sglang_omni.models.moss_tts.request_builders import _DATA_URI_RE
 from sglang_omni.models.moss_tts.stages import (
     _load_moss_processor_class,
     _moss_transformers_processor_compat,
     _resolve_checkpoint,
+)
+from sglang_omni.models.moss_tts_local.audio_tokenizer import (
+    DEFAULT_MOSS_TTS_LOCAL_AUDIO_TOKENIZER,
+    load_moss_tts_local_audio_tokenizer,
 )
 from sglang_omni.models.moss_tts_local.payload_types import (
     moss_tts_local_special_token_defaults,
@@ -31,6 +38,7 @@ from sglang_omni.models.moss_tts_local.request_builders import (
 from sglang_omni.models.moss_tts_local.streaming_vocoder import (
     MossTTSLocalStreamingVocoderScheduler,
 )
+from sglang_omni.preprocessing.cache_key import hash_bytes as _hash_bytes
 from sglang_omni.preprocessing.cache_key import (
     reference_path_cache_key as _reference_path_cache_key,
 )
@@ -49,17 +57,56 @@ _MOSS_TTS_LOCAL_INSTALL_HINT = (
     "Launch with trust_remote_code=True and make sure the checkpoint can load "
     "OpenMOSS-Team/MOSS-Audio-Tokenizer-v2."
 )
+_MAX_REFERENCE_SECONDS = 100.0
 
-# NOTE: preprocessing and vocoder stages each load their own processor (and
-# ~4.3 GB bf16 codec instance): `model.streaming()` flips module-global codec
-# state, so a decode on a shared instance would corrupt a concurrent
-# reference encode (see streaming_vocoder.py).
+# NOTE: preprocessing and vocoder stages each load their own codec instance:
+# `model.streaming()` flips codec state, so a decode on a shared instance would
+# corrupt a concurrent reference encode (see streaming_vocoder.py).
 
 
 @dataclass(frozen=True)
 class _ArMemoryBudget:
     effective_total_gpu_memory_fraction: float | None
     applied_codec_mem_reserve: float
+
+
+@dataclass(frozen=True)
+class _PathReferenceJob:
+    path: str
+
+
+@dataclass(frozen=True)
+class _WaveformReferenceJob:
+    wav: torch.Tensor
+    sample_rate: int
+
+
+_ReferenceEncodeJob = _PathReferenceJob | _WaveformReferenceJob
+
+
+def _data_uri_audio_bytes(ref_audio: str) -> bytes:
+    match = _DATA_URI_RE.match(ref_audio)
+    if match is None:
+        raise ValueError(f"encode_data_uri: not a data URI ({ref_audio[:40]!r}...)")
+    return base64.b64decode(match.group("data"))
+
+
+def _decode_data_uri_audio(raw: bytes) -> tuple[torch.Tensor, int]:
+    try:
+        import soundfile as sf
+    except ImportError as exc:
+        raise RuntimeError(
+            "MOSS-TTS Local base64 reference audio requires soundfile"
+        ) from exc
+
+    audio, sample_rate = sf.read(io.BytesIO(raw), dtype="float32", always_2d=True)
+    duration = audio.shape[0] / max(int(sample_rate), 1)
+    if duration > _MAX_REFERENCE_SECONDS:
+        raise ValueError(
+            f"reference audio is {duration:.1f}s long; the limit is "
+            f"{_MAX_REFERENCE_SECONDS:.0f}s"
+        )
+    return torch.from_numpy(audio.T), int(sample_rate)
 
 
 def _apply_colocated_ar_memory_budget(
@@ -142,31 +189,31 @@ def _resolve_codec_device(device: str | None, gpu_id: int | None) -> str:
     return "cuda:0"
 
 
-def _load_moss_tts_local_processor(model_path: str, *, device: str) -> Any:
+def _load_moss_tts_local_processor(model_path: str) -> Any:
     checkpoint_dir = _resolve_checkpoint(model_path)
-    logger.info(
-        "Loading MOSS-TTS Local processor from %s on %s", checkpoint_dir, device
-    )
+    logger.info(f"Loading MOSS-TTS Local processor from {checkpoint_dir} without codec")
     try:
+        from transformers import AutoConfig, AutoTokenizer
+
         with _moss_transformers_processor_compat():
             processor_cls = _load_moss_processor_class(checkpoint_dir)
-            processor = processor_cls.from_pretrained(
+            model_config = AutoConfig.from_pretrained(
                 checkpoint_dir,
                 trust_remote_code=True,
+            )
+            tokenizer = AutoTokenizer.from_pretrained(
+                checkpoint_dir,
+                trust_remote_code=True,
+            )
+            processor = processor_cls(
+                tokenizer=tokenizer,
+                audio_tokenizer=None,
+                model_config=model_config,
             )
     except Exception as exc:
         raise RuntimeError(_MOSS_TTS_LOCAL_INSTALL_HINT) from exc
 
     _normalize_processor_config(processor)
-    audio_tokenizer = getattr(processor, "audio_tokenizer", None)
-    if audio_tokenizer is not None:
-        if hasattr(audio_tokenizer, "eval"):
-            audio_tokenizer.eval()
-        if hasattr(audio_tokenizer, "to"):
-            # Device move only: the v2 codec manages its own dtypes (bf16
-            # encoder/decoder with an fp32 quantizer); a blanket dtype cast
-            # would corrupt the quantizer codebooks.
-            audio_tokenizer.to(device)
     return processor
 
 
@@ -183,22 +230,26 @@ class _BatchedReferenceEncoder:
 
     # Mirrors the Higgs reference-audio cap: bounds both encoder runtime and
     # the batch-padding memory amplification.
-    MAX_REFERENCE_SECONDS = 100.0
+    MAX_REFERENCE_SECONDS = _MAX_REFERENCE_SECONDS
     # An encode batch takes well under a second; a result this late means the
     # worker died or wedged, so fail the request instead of hanging the slot.
     ENCODE_TIMEOUT_S = 120.0
 
     def __init__(
         self,
-        processor: Any,
+        audio_tokenizer: Any,
         *,
+        n_vq: int,
         max_batch_size: int = 8,
         max_batch_wait_ms: int = 4,
     ) -> None:
-        self._processor = processor
+        self._audio_tokenizer = audio_tokenizer
+        self._n_vq = int(n_vq)
         self._max_batch_size = max(int(max_batch_size), 1)
         self._max_wait_s = max(float(max_batch_wait_ms), 0.0) / 1000.0
-        self._queue: queue.Queue[tuple[str, concurrent.futures.Future]] = queue.Queue()
+        self._queue: queue.Queue[
+            tuple[_ReferenceEncodeJob, concurrent.futures.Future]
+        ] = queue.Queue()
         self._thread = threading.Thread(
             target=self._worker, name="moss-local-ref-encode", daemon=True
         )
@@ -224,10 +275,21 @@ class _BatchedReferenceEncoder:
         path = str(path)
         self._check_reference_duration(path)
         future: concurrent.futures.Future = concurrent.futures.Future()
-        self._queue.put((path, future))
+        self._queue.put((_PathReferenceJob(path), future))
         return future.result(timeout=self.ENCODE_TIMEOUT_S)
 
-    def _drain_batch(self) -> list[tuple[str, concurrent.futures.Future]]:
+    def encode_wav(self, wav: torch.Tensor, sample_rate: int) -> torch.Tensor:
+        future: concurrent.futures.Future = concurrent.futures.Future()
+        self._queue.put((_WaveformReferenceJob(wav, int(sample_rate)), future))
+        return future.result(timeout=self.ENCODE_TIMEOUT_S)
+
+    def encode_data_uri(self, ref_audio: str) -> torch.Tensor:
+        wav, sample_rate = _decode_data_uri_audio(_data_uri_audio_bytes(ref_audio))
+        return self.encode_wav(wav, sample_rate)
+
+    def _drain_batch(
+        self,
+    ) -> list[tuple[_ReferenceEncodeJob, concurrent.futures.Future]]:
         batch = [self._queue.get()]
         while len(batch) < self._max_batch_size:
             try:
@@ -242,37 +304,76 @@ class _BatchedReferenceEncoder:
     def _worker(self) -> None:
         while True:
             batch = self._drain_batch()
-            unique_paths = list(dict.fromkeys(path for path, _ in batch))
-            results: dict[str, Any] = {}
-            try:
-                encoded = self._processor.encode_audios_from_path(unique_paths)
-                results = dict(zip(unique_paths, encoded))
-            except Exception:
-                logger.exception(
-                    "MOSS-TTS Local batched reference encode failed; "
-                    "retrying per item"
-                )
-                for path in unique_paths:
-                    try:
-                        results[path] = self._processor.encode_audios_from_path([path])[
-                            0
-                        ]
-                    except Exception as exc:
-                        results[path] = exc
-            for path, future in batch:
-                outcome = results.get(path)
+            results = self._encode_batch(batch)
+            for index, (_, future) in enumerate(batch):
+                outcome = results.get(index)
                 if isinstance(outcome, Exception):
                     # Fresh exception per future: a shared instance would be
                     # mutated concurrently by every waiter's traceback raise.
                     future.set_exception(
-                        RuntimeError(f"reference encode failed for {path}: {outcome}")
+                        RuntimeError(f"reference encode failed: {outcome}")
                     )
                 elif outcome is None:
                     future.set_exception(
-                        RuntimeError(f"reference encode produced no codes: {path}")
+                        RuntimeError("reference encode produced no codes")
                     )
                 else:
                     future.set_result(outcome)
+
+    def _encode_batch(
+        self, batch: list[tuple[_ReferenceEncodeJob, concurrent.futures.Future]]
+    ) -> dict[int, Any]:
+        results: dict[int, Any] = {}
+        path_to_indices: dict[str, list[int]] = {}
+        waveforms: list[tuple[torch.Tensor, int]] = []
+        waveform_indices: list[int] = []
+        for index, (job, _) in enumerate(batch):
+            if isinstance(job, _PathReferenceJob):
+                path_to_indices.setdefault(job.path, []).append(index)
+            elif isinstance(job, _WaveformReferenceJob):
+                waveform_indices.append(index)
+                waveforms.append((job.wav, job.sample_rate))
+            else:
+                raise TypeError(f"unknown reference encode job: {type(job).__name__}")
+
+        unique_paths = list(path_to_indices)
+        try:
+            path_waveforms = (
+                self._audio_tokenizer.load_paths(unique_paths) if unique_paths else []
+            )
+            encoded = self._audio_tokenizer.encode_waveforms(
+                path_waveforms + waveforms,
+                num_quantizers=self._n_vq,
+            )
+            path_count = len(unique_paths)
+            for path, codes in zip(unique_paths, encoded[:path_count]):
+                for index in path_to_indices[path]:
+                    results[index] = codes
+            for index, codes in zip(waveform_indices, encoded[path_count:]):
+                results[index] = codes
+        except Exception:
+            logger.exception(
+                "MOSS-TTS Local batched reference encode failed; retrying per item"
+            )
+            for path, indices in path_to_indices.items():
+                try:
+                    codes = self._audio_tokenizer.encode_paths(
+                        [path],
+                        num_quantizers=self._n_vq,
+                    )[0]
+                except Exception as exc:
+                    codes = exc
+                for index in indices:
+                    results[index] = codes
+            for index, waveform in zip(waveform_indices, waveforms):
+                try:
+                    results[index] = self._audio_tokenizer.encode_waveforms(
+                        [waveform],
+                        num_quantizers=self._n_vq,
+                    )[0]
+                except Exception as exc:
+                    results[index] = exc
+        return results
 
 
 class CachedReferenceEncoder:
@@ -413,43 +514,22 @@ class CachedReferenceEncoder:
             *snapshot,
         )
 
-    def encode_data_uri(self, ref_audio: str, *, processor: Any) -> torch.Tensor:
+    def encode_data_uri(self, ref_audio: str) -> torch.Tensor:
         """Cache-aware encode for data-URI refs through the same LRU + single-flight
         as file paths (adds the duration check _reference_for_processor lacks).
 
         Note(Jiaxin): file: and bytes: keyspaces never collide — the two decode
         chains differ, so codes aren't guaranteed identical for the "same" audio.
         """
-        import base64
-        import io
-
-        from sglang_omni.models.moss_tts.request_builders import _DATA_URI_RE
-        from sglang_omni.preprocessing.cache_key import hash_bytes as _hash_bytes
-
-        match = _DATA_URI_RE.match(ref_audio)
-        if match is None:
-            raise ValueError(f"encode_data_uri: not a data URI ({ref_audio[:40]!r}...)")
-
-        raw = base64.b64decode(match.group("data"))
+        raw = _data_uri_audio_bytes(ref_audio)
         key = f"bytes:{_hash_bytes(raw)}"
 
         def _encode() -> torch.Tensor:
-            import soundfile as sf
-
-            audio, sample_rate = sf.read(
-                io.BytesIO(raw), dtype="float32", always_2d=True
-            )
             # Note(Jiaxin): the duration check runs inside the leader (not before
             # inflight registration like the file path) so concurrent same-payload
             # requests share one sf.read of a potentially large decoded buffer.
-            duration = audio.shape[0] / max(int(sample_rate), 1)
-            if duration > _BatchedReferenceEncoder.MAX_REFERENCE_SECONDS:
-                raise ValueError(
-                    f"reference audio is {duration:.1f}s long; the limit is "
-                    f"{_BatchedReferenceEncoder.MAX_REFERENCE_SECONDS:.0f}s"
-                )
-            wav = torch.from_numpy(audio.T)
-            return processor.encode_audios_from_wav([wav], int(sample_rate))[0]
+            wav, sample_rate = _decode_data_uri_audio(raw)
+            return self._encoder.encode_wav(wav, sample_rate)
 
         return self._cached_encode(key, _encode, desc="data-URI")
 
@@ -469,6 +549,7 @@ def create_preprocessing_executor(
     *,
     device: str | None = None,
     gpu_id: int | None = None,
+    codec_model_path: str = DEFAULT_MOSS_TTS_LOCAL_AUDIO_TOKENIZER,
     max_concurrency: int = 16,
     encode_batch_size: int = 8,
     encode_batch_wait_ms: int = 4,
@@ -488,9 +569,14 @@ def create_preprocessing_executor(
             "",
         )
     device = _resolve_codec_device(device, gpu_id)
-    processor = _load_moss_tts_local_processor(model_path, device=device)
+    processor = _load_moss_tts_local_processor(model_path)
+    audio_tokenizer = load_moss_tts_local_audio_tokenizer(
+        codec_model_path,
+        device=device,
+    )
     reference_encoder: Any = _BatchedReferenceEncoder(
-        processor,
+        audio_tokenizer,
+        n_vq=int(processor.model_config.n_vq),
         max_batch_size=encode_batch_size,
         max_batch_wait_ms=encode_batch_wait_ms,
     )
@@ -679,6 +765,7 @@ def create_vocoder_executor(
     *,
     device: str | None = None,
     gpu_id: int | None = None,
+    codec_model_path: str = DEFAULT_MOSS_TTS_LOCAL_AUDIO_TOKENIZER,
     max_batch_size: int = 8,
     max_batch_wait_ms: int = 2,
     stream_slots: int = 8,
@@ -689,9 +776,15 @@ def create_vocoder_executor(
     cuda_graph_min_free_gb: float = 3.0,
 ) -> MossTTSLocalStreamingVocoderScheduler:
     device = _resolve_codec_device(device, gpu_id)
-    processor = _load_moss_tts_local_processor(model_path, device=device)
+    processor = _load_moss_tts_local_processor(model_path)
+    audio_tokenizer = load_moss_tts_local_audio_tokenizer(
+        codec_model_path,
+        device=device,
+    )
     scheduler = MossTTSLocalStreamingVocoderScheduler(
-        processor,
+        audio_tokenizer.model,
+        n_vq=int(processor.model_config.n_vq),
+        sample_rate=audio_tokenizer.sample_rate,
         stream_slots=stream_slots,
         stream_chunk_frames=stream_chunk_frames,
         initial_chunk_frames=initial_chunk_frames,

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -84,26 +84,6 @@ class _WaveformReferenceJob:
 _ReferenceEncodeJob: TypeAlias = _PathReferenceJob | _WaveformReferenceJob
 
 
-def _data_uri_audio_bytes(ref_audio: str) -> bytes:
-    match = _DATA_URI_RE.match(ref_audio)
-    if match is None:
-        raise ValueError(f"encode_data_uri: not a data URI ({ref_audio[:40]!r}...)")
-    return base64.b64decode(match.group("data"))
-
-
-def _decode_data_uri_audio(raw: bytes) -> tuple[torch.Tensor, int]:
-    import soundfile as sf
-
-    audio, sample_rate = sf.read(io.BytesIO(raw), dtype="float32", always_2d=True)
-    duration = audio.shape[0] / max(int(sample_rate), 1)
-    if duration > _MAX_REFERENCE_SECONDS:
-        raise ValueError(
-            f"reference audio is {duration:.1f}s long, limit is "
-            f"{_MAX_REFERENCE_SECONDS:.0f}s"
-        )
-    return torch.from_numpy(audio.T), int(sample_rate)
-
-
 def _apply_colocated_ar_memory_budget(
     overrides: dict[str, Any],
     *,
@@ -224,7 +204,6 @@ def _resolve_audio_tokenizer_model_path(
             "audio_tokenizer_name_or_path",
             DEFAULT_MOSS_TTS_LOCAL_AUDIO_TOKENIZER,
         )
-        or DEFAULT_MOSS_TTS_LOCAL_AUDIO_TOKENIZER
     )
 
 
@@ -281,6 +260,26 @@ class _BatchedReferenceEncoder:
                 f"{cls.MAX_REFERENCE_SECONDS:.0f}s"
             )
 
+    @staticmethod
+    def _data_uri_audio_bytes(ref_audio: str) -> bytes:
+        match = _DATA_URI_RE.match(ref_audio)
+        if match is None:
+            raise ValueError(f"encode_data_uri: not a data URI ({ref_audio[:40]!r}...)")
+        return base64.b64decode(match.group("data"))
+
+    @staticmethod
+    def _decode_data_uri_audio(raw: bytes) -> tuple[torch.Tensor, int]:
+        import soundfile as sf
+
+        audio, sample_rate = sf.read(io.BytesIO(raw), dtype="float32", always_2d=True)
+        duration = audio.shape[0] / max(int(sample_rate), 1)
+        if duration > _BatchedReferenceEncoder.MAX_REFERENCE_SECONDS:
+            raise ValueError(
+                f"reference audio is {duration:.1f}s long, limit is "
+                f"{_BatchedReferenceEncoder.MAX_REFERENCE_SECONDS:.0f}s"
+            )
+        return torch.from_numpy(audio.T), int(sample_rate)
+
     def encode(self, path: str) -> torch.Tensor:
         """Encode one reference file; blocks until its batch completes."""
         path = str(path)
@@ -295,7 +294,8 @@ class _BatchedReferenceEncoder:
         return future.result(timeout=self.ENCODE_TIMEOUT_S)
 
     def encode_data_uri(self, ref_audio: str) -> torch.Tensor:
-        wav, sample_rate = _decode_data_uri_audio(_data_uri_audio_bytes(ref_audio))
+        raw = self._data_uri_audio_bytes(ref_audio)
+        wav, sample_rate = self._decode_data_uri_audio(raw)
         return self.encode_wav(wav, sample_rate)
 
     def _drain_batch(
@@ -532,14 +532,14 @@ class CachedReferenceEncoder:
         Note(Jiaxin): file: and bytes: keyspaces never collide — the two decode
         chains differ, so codes aren't guaranteed identical for the "same" audio.
         """
-        raw = _data_uri_audio_bytes(ref_audio)
+        raw = _BatchedReferenceEncoder._data_uri_audio_bytes(ref_audio)
         key = f"bytes:{_hash_bytes(raw)}"
 
         def _encode() -> torch.Tensor:
             # Note(Jiaxin): the duration check runs inside the leader (not before
             # inflight registration like the file path) so concurrent same-payload
             # requests share one sf.read of a potentially large decoded buffer.
-            wav, sample_rate = _decode_data_uri_audio(raw)
+            wav, sample_rate = _BatchedReferenceEncoder._decode_data_uri_audio(raw)
             return self._encoder.encode_wav(wav, sample_rate)
 
         return self._cached_encode(key, _encode, desc="data-URI")

--- a/sglang_omni/models/moss_tts_local/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts_local/streaming_vocoder.py
@@ -239,8 +239,8 @@ class _CodecStreamSession:
     def decode_offline(
         self, codes_list: list[torch.Tensor], *, max_step_frames: int
     ) -> list[torch.Tensor]:
-        """Decode complete utterances ``[n_vq, T]`` via the offline lane, replaying the codec's
-        chunked ``batch_decode`` so output matches ``processor.decode_audio_codes``."""
+        """Decode complete utterances ``[n_vq, T]`` through offline slots in the
+        persistent codec session."""
         wavs: list[torch.Tensor] = []
         for wave_start in range(0, len(codes_list), self._offline_slots):
             wave = codes_list[wave_start : wave_start + self._offline_slots]

--- a/sglang_omni/models/moss_tts_local/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts_local/streaming_vocoder.py
@@ -33,18 +33,6 @@ logger = logging.getLogger(__name__)
 _SOURCE_HINT = "MOSS-TTS Local"
 
 
-def _resolve_sample_rate(processor: Any) -> int:
-    return int(
-        getattr(getattr(processor, "model_config", None), "sampling_rate", 0)
-        or getattr(
-            getattr(getattr(processor, "audio_tokenizer", None), "config", None),
-            "sampling_rate",
-            0,
-        )
-        or 48000
-    )
-
-
 def _build_usage(state: MossTTSLocalState) -> dict[str, Any] | None:
     if not (state.prompt_tokens or state.completion_tokens or state.engine_time_s):
         return None
@@ -301,8 +289,10 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
 
     def __init__(
         self,
-        processor: Any,
+        codec: Any,
         *,
+        n_vq: int,
+        sample_rate: int,
         stream_slots: int = 8,
         stream_chunk_frames: int = 25,
         initial_chunk_frames: int = 5,
@@ -319,11 +309,6 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
             raise ValueError(
                 "stream_chunk_frames must be in (0, max_step_frames], got "
                 f"{stream_chunk_frames} (max_step_frames={max_step_frames})"
-            )
-        codec = getattr(processor, "audio_tokenizer", None)
-        if codec is None:
-            raise RuntimeError(
-                "MOSS-TTS Local vocoder requires processor.audio_tokenizer"
             )
         missing = [
             name
@@ -354,8 +339,8 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
         )
         self._max_step_frames = int(max_step_frames)
         self._offline_slots = max(int(max_batch_size), 1)
-        self._n_vq = int(processor.model_config.n_vq)
-        self._sample_rate = _resolve_sample_rate(processor)
+        self._n_vq = int(n_vq)
+        self._sample_rate = int(sample_rate)
         self._session: _CodecStreamSession | None = None
         self._session_used_by_streaming = False
         self._cuda_graph = bool(cuda_graph)
@@ -848,8 +833,6 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
             # The processor helper forces chunk_duration=8 and enters the
             # tokenizer streaming loop. This decoder is non-streaming, so it must
             # run through the tokenizer's full-sequence decode path.
-            # TODO(Ratish): Load and own the non-streaming codec directly so this
-            # path does not need to swap the processor-owned decoder at call time.
             original_decoder = self._codec.decoder
             self._codec.decoder = self._nonstream_decoder
             try:

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -199,7 +199,9 @@ def test_moss_tts_engine_uses_auto_mem_fraction_by_default(monkeypatch) -> None:
     )
     fake_model_runner_module.MossTTSModelRunner = FakeMossTTSModelRunner
 
-    monkeypatch.setattr(stages, "_resolve_checkpoint", lambda model_path: model_path)
+    monkeypatch.setattr(
+        stages, "resolve_moss_checkpoint", lambda model_path: model_path
+    )
     monkeypatch.setattr(
         stages,
         "make_moss_tts_scheduler_adapters",

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -395,6 +395,7 @@ def test_pipeline_stage_wiring():
     assert stages["preprocessing"].process == "pipeline"
     assert stages["preprocessing"].gpu == 0
     assert stages["preprocessing"].factory_args["device"] == "cuda:0"
+    assert stages["preprocessing"].factory_args["encode_batch_size"] == 1
     assert stages["preprocessing"].factory_args["ref_audio_cache_max_items"] == 8192
     assert config.supports_uploaded_voice_references() is True
     assert stages["tts_engine"].process == "pipeline"
@@ -417,6 +418,7 @@ def test_pipeline_stage_wiring():
     )
     colocated_stages = {stage.name: stage for stage in colocated.stages}
     assert colocated_stages["preprocessing"].factory_args["device"] == "cuda:0"
+    assert colocated_stages["preprocessing"].factory_args["encode_batch_size"] == 1
     assert (
         colocated_stages["preprocessing"].factory_args["ref_audio_cache_max_items"]
         == 8192
@@ -426,6 +428,7 @@ def test_pipeline_stage_wiring():
     split = MossTTSLocalSplitPipelineConfig(model_path="OpenMOSS-Team/moss-local-test")
     split_stages = {stage.name: stage for stage in split.stages}
     assert split_stages["preprocessing"].factory_args["device"] == "cuda:1"
+    assert split_stages["preprocessing"].factory_args["encode_batch_size"] == 1
     assert split_stages["tts_engine"].factory_args["gpu_id"] == 0
     split_runtime = split_stages["tts_engine"].runtime
     assert split_runtime.resources.total_gpu_memory_fraction is None

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -675,6 +675,38 @@ def test_create_preprocessing_executor_env_toggle(monkeypatch):
     assert rb._PREPROCESSING_CONTEXT.reference_encoder._cache.max_size == 8192
 
 
+def test_create_preprocessing_executor_uses_model_config_codec_path(monkeypatch):
+    from sglang_omni.models.moss_tts_local import stages
+
+    class _FakeAudioTokenizer:
+        def encode_paths(self, paths, *, num_quantizers):
+            return []
+
+    processor = _FakeProcessor()
+    processor.model_config = types.SimpleNamespace(
+        n_vq=N_VQ,
+        audio_tokenizer_name_or_path="codec-from-model-config",
+    )
+    loaded_codec_paths = []
+
+    def fake_load_audio_tokenizer(model_path, *, device):
+        loaded_codec_paths.append(model_path)
+        return _FakeAudioTokenizer()
+
+    monkeypatch.setattr(
+        stages, "_load_moss_tts_local_processor", lambda model_path: processor
+    )
+    monkeypatch.setattr(
+        stages,
+        "load_moss_tts_local_audio_tokenizer",
+        fake_load_audio_tokenizer,
+    )
+
+    stages.create_preprocessing_executor("model", device="cpu")
+
+    assert loaded_codec_paths == ["codec-from-model-config"]
+
+
 def test_preprocess_and_result_adapter():
     set_moss_tts_local_preprocessing_context(processor=_FakeProcessor())
     try:

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -12,6 +12,7 @@ import torch
 
 from sglang_omni.client.audio import encode_audio, encode_wav
 from sglang_omni.config.placement import build_stage_placement_plan
+from sglang_omni.models.moss_tts_local.audio_tokenizer import MossTTSLocalAudioTokenizer
 from sglang_omni.models.moss_tts_local.config import (
     MossTTSLocalColocatedPipelineConfig,
     MossTTSLocalPipelineConfig,
@@ -39,6 +40,36 @@ from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.utils.audio_payload import audio_waveform_payload
 
 N_VQ = 12
+
+
+class _FakeEncodedAudio:
+    def __init__(self, audio_codes: torch.Tensor, audio_codes_lengths: torch.Tensor):
+        self.audio_codes = audio_codes
+        self.audio_codes_lengths = audio_codes_lengths
+
+
+class _FakeAudioTokenizerModel:
+    def __init__(self) -> None:
+        self.config = types.SimpleNamespace(sampling_rate=48000, number_channels=2)
+        self.calls: list[tuple[list[torch.Tensor], int]] = []
+
+    def batch_encode(self, wavs: list[torch.Tensor], *, num_quantizers: int):
+        assert all(wav.ndim == 2 and wav.shape[0] == 2 for wav in wavs)
+        self.calls.append((wavs, int(num_quantizers)))
+        max_len = max(int(wav.shape[-1]) for wav in wavs)
+        audio_codes = torch.zeros(num_quantizers, len(wavs), max_len, dtype=torch.long)
+        audio_codes_lengths = torch.tensor(
+            [int(wav.shape[-1]) for wav in wavs], dtype=torch.long
+        )
+        for index, wav in enumerate(wavs):
+            length = int(wav.shape[-1])
+            base = int(wav[0, 0].item()) if wav.numel() else 0
+            audio_codes[:, index, :length] = (
+                torch.arange(num_quantizers, dtype=torch.long).view(-1, 1)
+                + base
+                + torch.arange(length, dtype=torch.long).view(1, -1)
+            )
+        return _FakeEncodedAudio(audio_codes, audio_codes_lengths)
 
 
 # ---------------------------------------------------------------------------
@@ -151,6 +182,121 @@ def test_local_transformer_rejects_out_of_range_position():
 def test_rotate_half_interleaved_matches_upstream():
     x = torch.randn(5, 4, 8)
     torch.testing.assert_close(_rotate_half_interleaved(x), _hf_rotate_half(x))
+
+
+# ---------------------------------------------------------------------------
+# Owned audio tokenizer wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_owned_audio_tokenizer_returns_row_major_trimmed_codes():
+    model = _FakeAudioTokenizerModel()
+    tokenizer = MossTTSLocalAudioTokenizer(model, device="cpu")
+    wavs = [
+        torch.full((1, 3), 10.0),
+        torch.full((1, 5), 20.0),
+    ]
+
+    encoded = tokenizer.encode_wavs(wavs, 48000, num_quantizers=N_VQ)
+
+    assert len(model.calls) == 1
+    assert model.calls[0][1] == N_VQ
+    assert [tuple(wav.shape) for wav in model.calls[0][0]] == [(2, 3), (2, 5)]
+    assert [tuple(codes.shape) for codes in encoded] == [(3, N_VQ), (5, N_VQ)]
+
+
+def test_owned_audio_tokenizer_batches_mixed_sample_rates(monkeypatch):
+    model = _FakeAudioTokenizerModel()
+    tokenizer = MossTTSLocalAudioTokenizer(model, device="cpu")
+    resample_calls = []
+
+    def fake_load(path):
+        if path == "ref-16k.wav":
+            return torch.full((1, 4), 16.0), 16000
+        return torch.full((1, 6), 48.0), 48000
+
+    def fake_resample(waveform, *, orig_freq, new_freq):
+        resample_calls.append((orig_freq, new_freq))
+        return waveform + 1
+
+    monkeypatch.setitem(
+        sys.modules,
+        "torchaudio",
+        types.SimpleNamespace(
+            load=fake_load,
+            functional=types.SimpleNamespace(resample=fake_resample),
+        ),
+    )
+
+    encoded = tokenizer.encode_paths(
+        ["ref-16k.wav", "ref-48k.wav"],
+        num_quantizers=N_VQ,
+    )
+
+    assert len(model.calls) == 1
+    assert resample_calls == [(16000, 48000)]
+    assert [tuple(wav.shape) for wav in model.calls[0][0]] == [(2, 4), (2, 6)]
+    assert [tuple(codes.shape) for codes in encoded] == [(4, N_VQ), (6, N_VQ)]
+
+
+def test_owned_audio_tokenizer_path_resamples_before_channel_fold(monkeypatch):
+    model = _FakeAudioTokenizerModel()
+    tokenizer = MossTTSLocalAudioTokenizer(model, device="cpu")
+    observed_resample_shapes = []
+
+    def fake_load(path):
+        return torch.stack([torch.ones(4), torch.full((4,), 3.0)]), 16000
+
+    def fake_resample(waveform, *, orig_freq, new_freq):
+        observed_resample_shapes.append(tuple(waveform.shape))
+        return waveform
+
+    monkeypatch.setitem(
+        sys.modules,
+        "torchaudio",
+        types.SimpleNamespace(
+            load=fake_load,
+            functional=types.SimpleNamespace(resample=fake_resample),
+        ),
+    )
+
+    tokenizer.encode_paths(["ref.wav"], num_quantizers=N_VQ)
+
+    assert observed_resample_shapes == [(2, 4)]
+    scale = 10.0 ** (-3.0 / 20.0)
+    expected = torch.stack([torch.ones(4), torch.full((4,), 3.0)]) * scale
+    torch.testing.assert_close(model.calls[0][0][0], expected)
+
+
+def test_owned_audio_tokenizer_matches_processor_waveform_prep_for_stereo():
+    model = _FakeAudioTokenizerModel()
+    tokenizer = MossTTSLocalAudioTokenizer(model, device="cpu")
+    stereo = torch.stack(
+        [torch.full((4,), 1.0), torch.full((4,), 3.0)],
+        dim=0,
+    )
+
+    tokenizer.encode_wavs([stereo], 48000, num_quantizers=N_VQ)
+
+    prepared = model.calls[0][0][0]
+    expected = stereo * (10.0 ** (-3.0 / 20.0))
+    torch.testing.assert_close(prepared, expected)
+
+
+def test_owned_audio_tokenizer_matches_processor_waveform_prep_for_mono_and_extra_channels():
+    model = _FakeAudioTokenizerModel()
+    tokenizer = MossTTSLocalAudioTokenizer(model, device="cpu")
+    mono = torch.full((1, 4), 2.0)
+    three_channel = torch.stack(
+        [torch.full((4,), 1.0), torch.full((4,), 3.0), torch.full((4,), 5.0)],
+        dim=0,
+    )
+
+    tokenizer.encode_wavs([mono, three_channel], 48000, num_quantizers=N_VQ)
+
+    scale = 10.0 ** (-3.0 / 20.0)
+    torch.testing.assert_close(model.calls[0][0][0], mono.repeat(2, 1) * scale)
+    torch.testing.assert_close(model.calls[0][0][1], three_channel[:2] * scale)
 
 
 # ---------------------------------------------------------------------------
@@ -478,6 +624,8 @@ def test_build_state_token_count_and_language():
 class _FakeProcessor:
     """Builds deterministic [1, T, 13] rows from the message text length."""
 
+    model_config = type("_FakeModelConfig", (), {"n_vq": N_VQ})()
+
     @staticmethod
     def build_user_message(**kwargs):
         return dict(kwargs, role="user")
@@ -505,8 +653,18 @@ def test_create_preprocessing_executor_env_toggle(monkeypatch):
     from sglang_omni.models.moss_tts_local import request_builders as rb
     from sglang_omni.models.moss_tts_local import stages
 
+    class _FakeAudioTokenizer:
+        def encode_paths(self, paths, *, num_quantizers):
+            assert num_quantizers == N_VQ
+            return []
+
     monkeypatch.setattr(
         stages, "_load_moss_tts_local_processor", lambda *a, **k: _FakeProcessor()
+    )
+    monkeypatch.setattr(
+        stages,
+        "load_moss_tts_local_audio_tokenizer",
+        lambda *a, **k: _FakeAudioTokenizer(),
     )
 
     # MOSS_REF_AUDIO_CACHE=0 disables the wrapper at startup (kill switch).
@@ -762,18 +920,32 @@ def test_batched_reference_encoder_coalesces_and_isolates_errors():
 
     calls = []
 
-    class _FakeCodecProcessor:
-        def encode_audios_from_path(self, paths):
-            calls.append(list(paths))
+    class _FakeAudioTokenizer:
+        def load_paths(self, paths):
+            return [(torch.full((1, len(path)), len(path)), 48000) for path in paths]
+
+        def encode_waveforms(self, waveforms, *, num_quantizers):
+            assert num_quantizers == N_VQ
+            calls.append([int(wav.shape[-1]) for wav, _ in waveforms])
             out = []
-            for p in paths:
-                if "bad" in p:
-                    raise RuntimeError(f"cannot read {p}")
-                out.append(torch.full((4, N_VQ), len(p), dtype=torch.long))
+            for wav, _ in waveforms:
+                length = int(wav.shape[-1])
+                if length == 4:
+                    raise RuntimeError("cannot encode bad reference")
+                out.append(torch.full((4, N_VQ), length, dtype=torch.long))
             return out
 
+        def encode_paths(self, paths, *, num_quantizers):
+            return self.encode_waveforms(
+                self.load_paths(paths),
+                num_quantizers=num_quantizers,
+            )
+
     encoder = _BatchedReferenceEncoder(
-        _FakeCodecProcessor(), max_batch_size=4, max_batch_wait_ms=20
+        _FakeAudioTokenizer(),
+        n_vq=N_VQ,
+        max_batch_size=4,
+        max_batch_wait_ms=20,
     )
     results = {}
 
@@ -794,6 +966,64 @@ def test_batched_reference_encoder_coalesces_and_isolates_errors():
     assert results["bbb"].shape == (4, N_VQ) and int(results["bbb"][0, 0]) == 3
     # The failing batch retried per item; good items still succeeded.
     assert any(len(c) > 1 for c in calls) or len(calls) >= 3
+
+
+def test_batched_reference_encoder_mixes_path_and_waveform_jobs():
+    import threading
+
+    from sglang_omni.models.moss_tts_local.stages import _BatchedReferenceEncoder
+
+    calls = []
+
+    class _FakeAudioTokenizer:
+        def load_paths(self, paths):
+            return [(torch.full((1, len(path)), len(path)), 48000) for path in paths]
+
+        def encode_waveforms(self, waveforms, *, num_quantizers):
+            assert num_quantizers == N_VQ
+            calls.append([int(wav.shape[-1]) for wav, _ in waveforms])
+            return [
+                torch.full((int(wav.shape[-1]), N_VQ), int(wav.shape[-1]))
+                for wav, _ in waveforms
+            ]
+
+    encoder = _BatchedReferenceEncoder(
+        _FakeAudioTokenizer(),
+        n_vq=N_VQ,
+        max_batch_size=2,
+        max_batch_wait_ms=100,
+    )
+    results = {}
+    errors = []
+    barrier = threading.Barrier(2)
+
+    def encode_path():
+        try:
+            barrier.wait(timeout=5)
+            results["path"] = encoder.encode("aa")
+        except Exception as exc:
+            errors.append(exc)
+
+    def encode_wav():
+        try:
+            barrier.wait(timeout=5)
+            results["wav"] = encoder.encode_wav(torch.full((1, 5), 5), 48000)
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=encode_path),
+        threading.Thread(target=encode_wav),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not errors
+    assert int(results["path"][0, 0]) == 2
+    assert int(results["wav"][0, 0]) == 5
+    assert calls[0] == [2, 5]
 
 
 # ---------------------------------------------------------------------------
@@ -1100,7 +1330,7 @@ def test_cached_reference_encoder_return_value_isolation(tmp_path):
 
 def test_cached_reference_encoder_duration_gate(tmp_path, monkeypatch):
     """T8: references over 100 s are rejected before touching the cache."""
-    import torchaudio
+    torchaudio = pytest.importorskip("torchaudio")
 
     from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
 
@@ -1167,26 +1397,24 @@ def _make_wav_data_uri(
 
 
 def test_cached_reference_encoder_data_uri_hit_miss(tmp_path):
-    """bytes: keyspace: same data-URI encoded twice → 1 encode_audios_from_wav call."""
+    """bytes: keyspace: same data-URI encoded twice -> one owned-codec encode."""
     from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
 
+    pytest.importorskip("soundfile")
     data_uri, _ = _make_wav_data_uri()
     wav_call_count = 0
 
-    class _FakeProc:
-        def encode_audios_from_wav(self, wavs, sample_rate):
+    class _FakeBatched:
+        def encode_wav(self, wav, sample_rate):
             nonlocal wav_call_count
             wav_call_count += 1
-            return [torch.full((5, N_VQ), 42, dtype=torch.long)]
+            return torch.full((5, N_VQ), 42, dtype=torch.long)
 
-    enc = CachedReferenceEncoder(
-        None, max_items=256, max_bytes=64 << 20  # type: ignore[arg-type]
-    )
-    proc = _FakeProc()
-    enc.encode_data_uri(data_uri, processor=proc)
+    enc = CachedReferenceEncoder(_FakeBatched(), max_items=256, max_bytes=64 << 20)
+    enc.encode_data_uri(data_uri)
     assert wav_call_count == 1, "first call must encode"
 
-    result2 = enc.encode_data_uri(data_uri, processor=proc)
+    result2 = enc.encode_data_uri(data_uri)
     assert wav_call_count == 1, "second call must hit cache"
     assert torch.equal(result2, torch.full((5, N_VQ), 42, dtype=torch.long))
 
@@ -1195,10 +1423,38 @@ def test_cached_reference_encoder_data_uri_hit_miss(tmp_path):
     assert stats["misses"] == 1
 
 
+def test_uncached_data_uri_uses_owned_reference_encoder():
+    from sglang_omni.models.moss_tts_local.request_builders import (
+        _build_processor_message,
+    )
+    from sglang_omni.models.moss_tts_local.stages import _BatchedReferenceEncoder
+
+    pytest.importorskip("soundfile")
+    data_uri, _ = _make_wav_data_uri()
+    model = _FakeAudioTokenizerModel()
+    tokenizer = MossTTSLocalAudioTokenizer(model, device="cpu")
+    reference_encoder = _BatchedReferenceEncoder(
+        tokenizer,
+        n_vq=N_VQ,
+        max_batch_size=4,
+        max_batch_wait_ms=20,
+    )
+    processor = _FakeProcessor()
+    state = MossTTSLocalState(text="hello", ref_audio=data_uri)
+
+    message = _build_processor_message(processor, state, reference_encoder)
+
+    assert len(model.calls) == 1
+    assert model.calls[0][1] == N_VQ
+    assert len(message["reference"]) == 1
+    assert message["reference"][0].shape[1] == N_VQ
+
+
 def test_cached_reference_encoder_file_bytes_keyspaces_do_not_collide(tmp_path):
     """file: and bytes: keys are independent; same-content file ≠ data-URI in cache."""
     from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
 
+    pytest.importorskip("soundfile")
     data_uri, raw = _make_wav_data_uri()
 
     # Write the same raw bytes as a file
@@ -1213,13 +1469,14 @@ def test_cached_reference_encoder_file_bytes_keyspaces_do_not_collide(tmp_path):
             encode_count += 1
             return torch.full((5, N_VQ), 7, dtype=torch.long)
 
-    class _FakeProc:
-        def encode_audios_from_wav(self, wavs, sample_rate):
-            return [torch.full((5, N_VQ), 7, dtype=torch.long)]
+        def encode_wav(self, wav, sample_rate):
+            nonlocal encode_count
+            encode_count += 1
+            return torch.full((5, N_VQ), 7, dtype=torch.long)
 
     enc = CachedReferenceEncoder(_FakeBatched(), max_items=256, max_bytes=64 << 20)
     enc.encode(str(ref_file))  # populates file: key
-    enc.encode_data_uri(data_uri, processor=_FakeProc())  # must NOT hit file: entry
+    enc.encode_data_uri(data_uri)  # must NOT hit file: entry
 
     assert (
         enc.stats()["misses"] == 2
@@ -1246,16 +1503,13 @@ def test_cached_reference_encoder_data_uri_duration_gate():
     raw = buf.getvalue()
     uri = f"data:audio/wav;base64,{base64.b64encode(raw).decode()}"
 
-    enc = CachedReferenceEncoder(
-        None, max_items=256, max_bytes=64 << 20  # type: ignore[arg-type]
-    )
+    class _FakeBatched:
+        def encode_wav(self, wav, sample_rate):
+            return torch.zeros((5, N_VQ), dtype=torch.long)
 
-    class _FakeProc:
-        def encode_audios_from_wav(self, wavs, sr):
-            return [torch.zeros((5, N_VQ), dtype=torch.long)]
-
+    enc = CachedReferenceEncoder(_FakeBatched(), max_items=256, max_bytes=64 << 20)
     with pytest.raises(ValueError, match="100"):
-        enc.encode_data_uri(uri, processor=_FakeProc())
+        enc.encode_data_uri(uri)
 
     assert enc.stats()["entries"] == 0
     assert len(enc._inflight) == 0

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -395,7 +395,6 @@ def test_pipeline_stage_wiring():
     assert stages["preprocessing"].process == "pipeline"
     assert stages["preprocessing"].gpu == 0
     assert stages["preprocessing"].factory_args["device"] == "cuda:0"
-    assert stages["preprocessing"].factory_args["encode_batch_size"] == 1
     assert stages["preprocessing"].factory_args["ref_audio_cache_max_items"] == 8192
     assert config.supports_uploaded_voice_references() is True
     assert stages["tts_engine"].process == "pipeline"
@@ -418,7 +417,6 @@ def test_pipeline_stage_wiring():
     )
     colocated_stages = {stage.name: stage for stage in colocated.stages}
     assert colocated_stages["preprocessing"].factory_args["device"] == "cuda:0"
-    assert colocated_stages["preprocessing"].factory_args["encode_batch_size"] == 1
     assert (
         colocated_stages["preprocessing"].factory_args["ref_audio_cache_max_items"]
         == 8192
@@ -428,7 +426,6 @@ def test_pipeline_stage_wiring():
     split = MossTTSLocalSplitPipelineConfig(model_path="OpenMOSS-Team/moss-local-test")
     split_stages = {stage.name: stage for stage in split.stages}
     assert split_stages["preprocessing"].factory_args["device"] == "cuda:1"
-    assert split_stages["preprocessing"].factory_args["encode_batch_size"] == 1
     assert split_stages["tts_engine"].factory_args["gpu_id"] == 0
     split_runtime = split_stages["tts_engine"].runtime
     assert split_runtime.resources.total_gpu_memory_fraction is None

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -241,7 +241,7 @@ def test_audio_tokenizer_path_resamples_before_channel_fold(monkeypatch):
     observed_resample_shapes = []
 
     def fake_load(path):
-        return torch.stack([torch.ones(4), torch.full((4,), 3.0)]), 16000
+        return torch.ones(1, 4), 16000
 
     def fake_resample(waveform, *, orig_freq, new_freq):
         observed_resample_shapes.append(tuple(waveform.shape))
@@ -258,9 +258,9 @@ def test_audio_tokenizer_path_resamples_before_channel_fold(monkeypatch):
 
     tokenizer.encode_paths(["ref.wav"], num_quantizers=N_VQ)
 
-    assert observed_resample_shapes == [(2, 4)]
+    assert observed_resample_shapes == [(1, 4)]
     scale = 10.0 ** (-3.0 / 20.0)
-    expected = torch.stack([torch.ones(4), torch.full((4,), 3.0)]) * scale
+    expected = torch.ones(1, 4).repeat(2, 1) * scale
     torch.testing.assert_close(model.calls[0][0][0], expected)
 
 
@@ -293,6 +293,78 @@ def test_audio_tokenizer_matches_processor_waveform_prep_for_mono_and_extra_chan
     scale = 10.0 ** (-3.0 / 20.0)
     torch.testing.assert_close(model.calls[0][0][0], mono.repeat(2, 1) * scale)
     torch.testing.assert_close(model.calls[0][0][1], three_channel[:2] * scale)
+
+
+def test_audio_tokenizer_reference_encode_uses_processor_stereo_contract():
+    model = _FakeAudioTokenizerModel()
+    model.config.number_channels = 1
+    tokenizer = MossTTSLocalAudioTokenizer(model, device="cpu")
+    mono = torch.full((1, 4), 2.0)
+
+    tokenizer.encode_wavs([mono], 48000, num_quantizers=N_VQ)
+
+    scale = 10.0 ** (-3.0 / 20.0)
+    torch.testing.assert_close(model.calls[0][0][0], mono.repeat(2, 1) * scale)
+
+
+def test_audio_tokenizer_loader_matches_processor_codec_weight_dtype(monkeypatch):
+    from contextlib import nullcontext
+
+    from sglang_omni.models.moss_tts_local import audio_tokenizer as audio_tokenizer_mod
+    from sglang_omni.models.moss_tts_local.audio_tokenizer import (
+        load_moss_tts_local_audio_tokenizer,
+    )
+
+    class _FakeLoadedCodec(_FakeAudioTokenizerModel):
+        def __init__(self):
+            super().__init__()
+            self.eval_called = False
+            self.to_device = None
+
+        def eval(self):
+            self.eval_called = True
+            return self
+
+        def to(self, device):
+            self.to_device = device
+            return self
+
+    loaded_kwargs = {}
+    loaded_model = _FakeLoadedCodec()
+
+    class _FakeAutoModel:
+        @staticmethod
+        def from_pretrained(model_path, **kwargs):
+            loaded_kwargs["model_path"] = model_path
+            loaded_kwargs.update(kwargs)
+            return loaded_model
+
+    monkeypatch.setattr(
+        audio_tokenizer_mod,
+        "resolve_moss_checkpoint",
+        lambda model_path: f"/resolved/{model_path}",
+    )
+    monkeypatch.setattr(
+        audio_tokenizer_mod,
+        "moss_transformers_processor_compat",
+        nullcontext,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "transformers",
+        types.SimpleNamespace(AutoModel=_FakeAutoModel),
+    )
+
+    tokenizer = load_moss_tts_local_audio_tokenizer("codec", device="cuda:7")
+
+    assert tokenizer.model is loaded_model
+    assert loaded_model.eval_called
+    assert loaded_model.to_device == "cuda:7"
+    assert loaded_kwargs == {
+        "model_path": "/resolved/codec",
+        "trust_remote_code": True,
+        "codec_weight_dtype": "bf16",
+    }
 
 
 # Registry / config

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -72,9 +72,7 @@ class _FakeAudioTokenizerModel:
         return _FakeEncodedAudio(audio_codes, audio_codes_lengths)
 
 
-# ---------------------------------------------------------------------------
 # Local transformer numerics
-# ---------------------------------------------------------------------------
 
 
 def _hf_rotate_half(hidden_states: torch.Tensor) -> torch.Tensor:
@@ -184,12 +182,10 @@ def test_rotate_half_interleaved_matches_upstream():
     torch.testing.assert_close(_rotate_half_interleaved(x), _hf_rotate_half(x))
 
 
-# ---------------------------------------------------------------------------
-# Owned audio tokenizer wrapper
-# ---------------------------------------------------------------------------
+# MOSS-Audio-Tokenizer-v2 wrapper
 
 
-def test_owned_audio_tokenizer_returns_row_major_trimmed_codes():
+def test_audio_tokenizer_returns_row_major_trimmed_codes():
     model = _FakeAudioTokenizerModel()
     tokenizer = MossTTSLocalAudioTokenizer(model, device="cpu")
     wavs = [
@@ -205,7 +201,7 @@ def test_owned_audio_tokenizer_returns_row_major_trimmed_codes():
     assert [tuple(codes.shape) for codes in encoded] == [(3, N_VQ), (5, N_VQ)]
 
 
-def test_owned_audio_tokenizer_batches_mixed_sample_rates(monkeypatch):
+def test_audio_tokenizer_batches_mixed_sample_rates(monkeypatch):
     model = _FakeAudioTokenizerModel()
     tokenizer = MossTTSLocalAudioTokenizer(model, device="cpu")
     resample_calls = []
@@ -239,7 +235,7 @@ def test_owned_audio_tokenizer_batches_mixed_sample_rates(monkeypatch):
     assert [tuple(codes.shape) for codes in encoded] == [(4, N_VQ), (6, N_VQ)]
 
 
-def test_owned_audio_tokenizer_path_resamples_before_channel_fold(monkeypatch):
+def test_audio_tokenizer_path_resamples_before_channel_fold(monkeypatch):
     model = _FakeAudioTokenizerModel()
     tokenizer = MossTTSLocalAudioTokenizer(model, device="cpu")
     observed_resample_shapes = []
@@ -268,7 +264,7 @@ def test_owned_audio_tokenizer_path_resamples_before_channel_fold(monkeypatch):
     torch.testing.assert_close(model.calls[0][0][0], expected)
 
 
-def test_owned_audio_tokenizer_matches_processor_waveform_prep_for_stereo():
+def test_audio_tokenizer_matches_processor_waveform_prep_for_stereo():
     model = _FakeAudioTokenizerModel()
     tokenizer = MossTTSLocalAudioTokenizer(model, device="cpu")
     stereo = torch.stack(
@@ -283,7 +279,7 @@ def test_owned_audio_tokenizer_matches_processor_waveform_prep_for_stereo():
     torch.testing.assert_close(prepared, expected)
 
 
-def test_owned_audio_tokenizer_matches_processor_waveform_prep_for_mono_and_extra_channels():
+def test_audio_tokenizer_matches_processor_waveform_prep_for_mono_and_extra_channels():
     model = _FakeAudioTokenizerModel()
     tokenizer = MossTTSLocalAudioTokenizer(model, device="cpu")
     mono = torch.full((1, 4), 2.0)
@@ -299,9 +295,7 @@ def test_owned_audio_tokenizer_matches_processor_waveform_prep_for_mono_and_extr
     torch.testing.assert_close(model.calls[0][0][1], three_channel[:2] * scale)
 
 
-# ---------------------------------------------------------------------------
 # Registry / config
-# ---------------------------------------------------------------------------
 
 
 def test_registry_resolves_local_architecture():
@@ -453,7 +447,9 @@ def _install_fake_moss_ar_factory(
         "make_moss_tts_local_scheduler_adapters",
         lambda **kwargs: (object(), object()),
     )
-    monkeypatch.setattr(stages, "_resolve_checkpoint", lambda model_path: model_path)
+    monkeypatch.setattr(
+        stages, "resolve_moss_checkpoint", lambda model_path: model_path
+    )
     monkeypatch.setattr(omni_scheduler, "OmniScheduler", FakeScheduler)
 
     def fake_get_process_gpu_memory_bytes(gpu_id):
@@ -551,9 +547,7 @@ def test_special_token_defaults_match_v15_checkpoint():
     assert defaults["audio_pad_code"] == 1024
 
 
-# ---------------------------------------------------------------------------
 # Generation kwargs / state
-# ---------------------------------------------------------------------------
 
 
 def test_build_generation_kwargs_defaults():
@@ -616,9 +610,7 @@ def test_build_state_token_count_and_language():
     assert state.language == "English"
 
 
-# ---------------------------------------------------------------------------
 # Preprocessing handoff + result adapter
-# ---------------------------------------------------------------------------
 
 
 class _FakeProcessor:
@@ -738,9 +730,7 @@ def test_result_adapter_empty_generation():
     assert codes.shape == (0, N_VQ)
 
 
-# ---------------------------------------------------------------------------
 # Repetition penalty parity
-# ---------------------------------------------------------------------------
 
 
 def test_audio_repetition_penalty_mask_matches_upstream_semantics():
@@ -1026,9 +1016,7 @@ def test_batched_reference_encoder_mixes_path_and_waveform_jobs():
     assert calls[0] == [2, 5]
 
 
-# ---------------------------------------------------------------------------
-# CachedReferenceEncoder  (T3–T9)
-# ---------------------------------------------------------------------------
+# CachedReferenceEncoder
 
 
 def test_cached_reference_encoder_on_off_hit_bit_identical(tmp_path):
@@ -1363,9 +1351,7 @@ def test_cached_reference_encoder_duration_gate(tmp_path, monkeypatch):
     assert len(enc._inflight) == 0
 
 
-# ---------------------------------------------------------------------------
-# Data-URI path (commit 4): bytes: keyspace + duration check
-# ---------------------------------------------------------------------------
+# Data-URI reference path
 
 
 def _make_wav_data_uri(
@@ -1397,7 +1383,7 @@ def _make_wav_data_uri(
 
 
 def test_cached_reference_encoder_data_uri_hit_miss(tmp_path):
-    """bytes: keyspace: same data-URI encoded twice -> one owned-codec encode."""
+    """bytes: keyspace: same data-URI encoded twice -> one codec encode."""
     from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
 
     pytest.importorskip("soundfile")
@@ -1423,7 +1409,7 @@ def test_cached_reference_encoder_data_uri_hit_miss(tmp_path):
     assert stats["misses"] == 1
 
 
-def test_uncached_data_uri_uses_owned_reference_encoder():
+def test_uncached_data_uri_uses_reference_encoder():
     from sglang_omni.models.moss_tts_local.request_builders import (
         _build_processor_message,
     )
@@ -1555,9 +1541,7 @@ def test_branchless_sampler_matches_eager_sampler():
     torch.testing.assert_close(eager, branchless)
 
 
-# ---------------------------------------------------------------------------
 # Stereo audio payload + encoding
-# ---------------------------------------------------------------------------
 
 
 def test_audio_waveform_payload_keeps_stereo_shape():

--- a/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
+++ b/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
@@ -982,23 +982,23 @@ def test_create_vocoder_executor_threads_cuda_graph_config(monkeypatch) -> None:
     assert scheduler2._cuda_graph_min_free_gb == 7.0
 
 
-def test_create_vocoder_executor_uses_owned_codec(monkeypatch) -> None:
+def test_create_vocoder_executor_uses_separate_codec(monkeypatch) -> None:
     processor = FakeProcessor()
-    owned_codec = FakeCodec()
-    _patch_vocoder_factory_loaders(monkeypatch, processor, owned_codec)
+    codec = FakeCodec()
+    _patch_vocoder_factory_loaders(monkeypatch, processor, codec)
 
     scheduler = stages.create_vocoder_executor("fake-model", device="cpu")
 
-    assert scheduler._codec is owned_codec
+    assert scheduler._codec is codec
     assert scheduler._codec is not processor.audio_tokenizer
 
     rows = _rows(7, seed=98)
-    (result,) = scheduler._vocode_batch([_offline_payload(rows, "owned")])
+    (result,) = scheduler._vocode_batch([_offline_payload(rows, "separate-codec")])
 
     assert processor.decode_calls == 0
     assert processor.audio_tokenizer.decode_calls == 0
-    assert owned_codec.decode_calls == 1
-    assert owned_codec.decode_decoders == [scheduler._nonstream_decoder]
+    assert codec.decode_calls == 1
+    assert codec.decode_decoders == [scheduler._nonstream_decoder]
     np.testing.assert_array_equal(
         _decode_audio(result.data), reference_waveform(rows[:, 1:]).numpy()
     )

--- a/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
+++ b/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
@@ -1004,6 +1004,32 @@ def test_create_vocoder_executor_uses_separate_codec(monkeypatch) -> None:
     )
 
 
+def test_create_vocoder_executor_uses_model_config_codec_path(monkeypatch) -> None:
+    processor = FakeProcessor()
+    processor.model_config.audio_tokenizer_name_or_path = "codec-from-model-config"
+    codec = FakeCodec()
+    loaded_codec_paths = []
+
+    def fake_load_audio_tokenizer(model_path, *, device):
+        loaded_codec_paths.append(model_path)
+        return SimpleNamespace(model=codec, sample_rate=SAMPLE_RATE)
+
+    monkeypatch.setattr(
+        stages,
+        "_load_moss_tts_local_processor",
+        lambda model_path: processor,
+    )
+    monkeypatch.setattr(
+        stages,
+        "load_moss_tts_local_audio_tokenizer",
+        fake_load_audio_tokenizer,
+    )
+
+    stages.create_vocoder_executor("fake-model", device="cpu")
+
+    assert loaded_codec_paths == ["codec-from-model-config"]
+
+
 def test_pipeline_config_injects_cuda_graph_into_vocoder_factory_args() -> None:
     from sglang_omni.models.moss_tts_local.config import (
         MossTTSLocalPipelineConfig,

--- a/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
+++ b/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
@@ -198,14 +198,30 @@ def reference_waveform(rows: torch.Tensor) -> torch.Tensor:
 def _make_scheduler(
     monkeypatch: pytest.MonkeyPatch, processor: FakeProcessor, **kwargs: int
 ) -> MossTTSLocalStreamingVocoderScheduler:
-    monkeypatch.setattr(
-        stages,
-        "_load_moss_tts_local_processor",
-        lambda model_path, *, device: processor,
-    )
+    _patch_vocoder_factory_loaders(monkeypatch, processor, processor.audio_tokenizer)
     scheduler = stages.create_vocoder_executor("fake-model", device="cpu", **kwargs)
     assert isinstance(scheduler, MossTTSLocalStreamingVocoderScheduler)
     return scheduler
+
+
+def _patch_vocoder_factory_loaders(
+    monkeypatch: pytest.MonkeyPatch,
+    processor: FakeProcessor,
+    codec: FakeCodec,
+) -> None:
+    monkeypatch.setattr(
+        stages,
+        "_load_moss_tts_local_processor",
+        lambda model_path: processor,
+    )
+    monkeypatch.setattr(
+        stages,
+        "load_moss_tts_local_audio_tokenizer",
+        lambda model_path, *, device: SimpleNamespace(
+            model=codec,
+            sample_rate=SAMPLE_RATE,
+        ),
+    )
 
 
 def _rows(frames: int, *, seed: int) -> torch.Tensor:
@@ -689,19 +705,19 @@ def test_non_streaming_path_ignores_idle_startup_session(monkeypatch) -> None:
     scheduler = _make_scheduler(monkeypatch, processor)
     scheduler._ensure_session()
     assert scheduler._session is not None
-    assert processor.audio_tokenizer._streaming_state is not None
+    assert scheduler._codec._streaming_state is not None
 
     rows = _rows(11, seed=59)
-    original_decoder = processor.audio_tokenizer.decoder
+    original_decoder = scheduler._codec.decoder
     (result,) = scheduler._vocode_batch([_offline_payload(rows, "r1")])
 
     assert processor.decode_calls == 0
-    assert processor.audio_tokenizer.decode_calls == 1
-    assert processor.audio_tokenizer.decode_chunk_durations == [None]
-    assert processor.audio_tokenizer.decode_decoders == [scheduler._nonstream_decoder]
-    assert processor.audio_tokenizer.decoder is original_decoder
+    assert scheduler._codec.decode_calls == 1
+    assert scheduler._codec.decode_chunk_durations == [None]
+    assert scheduler._codec.decode_decoders == [scheduler._nonstream_decoder]
+    assert scheduler._codec.decoder is original_decoder
     assert scheduler._session is None
-    assert processor.audio_tokenizer._streaming_state is None
+    assert scheduler._codec._streaming_state is None
     np.testing.assert_array_equal(
         _decode_audio(result.data), reference_waveform(rows[:, 1:]).numpy()
     )
@@ -715,7 +731,7 @@ def test_non_streaming_empty_audio_codes_skip_decode(monkeypatch) -> None:
     (result,) = scheduler._vocode_batch([_offline_payload(rows, "empty")])
 
     assert processor.decode_calls == 0
-    assert processor.audio_tokenizer.decode_calls == 0
+    assert scheduler._codec.decode_calls == 0
     assert "audio_codes" not in result.data
     assert "audio_waveform" not in result.data
 
@@ -726,7 +742,7 @@ def test_non_streaming_path_with_and_without_live_session(monkeypatch) -> None:
 
     rows_1 = _rows(101, seed=60)
     rows_2 = _rows(4, seed=61)
-    original_decoder = processor.audio_tokenizer.decoder
+    original_decoder = scheduler._codec.decoder
 
     # Before any stream: use the full-sequence tokenizer path with the packed
     # non-streaming decoder installed.
@@ -734,10 +750,10 @@ def test_non_streaming_path_with_and_without_live_session(monkeypatch) -> None:
         [_offline_payload(rows_1, "r1"), _offline_payload(rows_2, "r2")]
     )
     assert processor.decode_calls == 0
-    assert processor.audio_tokenizer.decode_calls == 1
-    assert processor.audio_tokenizer.decode_chunk_durations == [None]
-    assert processor.audio_tokenizer.decode_decoders == [scheduler._nonstream_decoder]
-    assert processor.audio_tokenizer.decoder is original_decoder
+    assert scheduler._codec.decode_calls == 1
+    assert scheduler._codec.decode_chunk_durations == [None]
+    assert scheduler._codec.decode_decoders == [scheduler._nonstream_decoder]
+    assert scheduler._codec.decoder is original_decoder
     waves_before = [_decode_audio(result.data) for result in results]
     for result in results:
         assert result.data["sample_rate"] == SAMPLE_RATE
@@ -755,7 +771,7 @@ def test_non_streaming_path_with_and_without_live_session(monkeypatch) -> None:
         [_offline_payload(rows_1, "r3"), _offline_payload(rows_2, "r4")]
     )
     assert processor.decode_calls == 0
-    assert processor.audio_tokenizer.decode_calls == 1
+    assert scheduler._codec.decode_calls == 1
     waves_after = [_decode_audio(result.data) for result in results]
     for before, after in zip(waves_before, waves_after):
         np.testing.assert_array_equal(before, after)
@@ -769,7 +785,9 @@ def test_offline_lane_waves_split_across_slots(monkeypatch) -> None:
     processor = FakeProcessor()
     # Constructed directly: max_step_frames is not a factory knob.
     scheduler = MossTTSLocalStreamingVocoderScheduler(
-        processor,
+        processor.audio_tokenizer,
+        n_vq=N_VQ,
+        sample_rate=SAMPLE_RATE,
         max_batch_size=2,
         max_step_frames=3,
         stream_chunk_frames=3,
@@ -798,20 +816,20 @@ def test_stop_closes_persistent_streaming_session(monkeypatch) -> None:
     scheduler = _make_scheduler(monkeypatch, processor)
     scheduler._on_chunk("req", _stream_item(_rows(1, seed=74)[0], _metadata()))
     assert scheduler._session is not None
-    assert processor.audio_tokenizer._streaming_state is not None
+    assert scheduler._codec._streaming_state is not None
 
     scheduler.stop()
 
     assert scheduler._session is None
     assert scheduler._stream_states == {}
-    assert processor.audio_tokenizer._streaming_state is None
+    assert scheduler._codec._streaming_state is None
 
     # Reusing the same codec instance after stop must be able to open a fresh
     # streaming context instead of tripping the codec's nested-session guard.
     restarted = _make_scheduler(monkeypatch, processor)
     restarted._on_chunk("req2", _stream_item(_rows(1, seed=75)[0], _metadata()))
     assert restarted._session is not None
-    assert processor.audio_tokenizer._streaming_state is not None
+    assert restarted._codec._streaming_state is not None
     restarted.stop()
 
 
@@ -964,6 +982,28 @@ def test_create_vocoder_executor_threads_cuda_graph_config(monkeypatch) -> None:
     assert scheduler2._cuda_graph_min_free_gb == 7.0
 
 
+def test_create_vocoder_executor_uses_owned_codec(monkeypatch) -> None:
+    processor = FakeProcessor()
+    owned_codec = FakeCodec()
+    _patch_vocoder_factory_loaders(monkeypatch, processor, owned_codec)
+
+    scheduler = stages.create_vocoder_executor("fake-model", device="cpu")
+
+    assert scheduler._codec is owned_codec
+    assert scheduler._codec is not processor.audio_tokenizer
+
+    rows = _rows(7, seed=98)
+    (result,) = scheduler._vocode_batch([_offline_payload(rows, "owned")])
+
+    assert processor.decode_calls == 0
+    assert processor.audio_tokenizer.decode_calls == 0
+    assert owned_codec.decode_calls == 1
+    assert owned_codec.decode_decoders == [scheduler._nonstream_decoder]
+    np.testing.assert_array_equal(
+        _decode_audio(result.data), reference_waveform(rows[:, 1:]).numpy()
+    )
+
+
 def test_pipeline_config_injects_cuda_graph_into_vocoder_factory_args() -> None:
     from sglang_omni.models.moss_tts_local.config import (
         MossTTSLocalPipelineConfig,
@@ -1016,7 +1056,11 @@ def test_scheduler_rejects_frame_above_max_step(monkeypatch) -> None:
     # do not silently drop it.
     with pytest.raises(ValueError, match="exceed max_step_frames"):
         MossTTSLocalStreamingVocoderScheduler(
-            FakeProcessor(), max_step_frames=25, cuda_graph_frames=[5, 100]
+            FakeCodec(),
+            n_vq=N_VQ,
+            sample_rate=SAMPLE_RATE,
+            max_step_frames=25,
+            cuda_graph_frames=[5, 100],
         )
 
 


### PR DESCRIPTION
## Motivation

MOSS-TTS Local preprocessing and vocoder stages previously reached through the Hugging Face processor-owned `audio_tokenizer`. This keeps the codec load and processor state coupled, which makes the local codec path harder to reason about and harder to optimize independently.

This PR loads the MOSS-Audio-Tokenizer-v2 codec as an owned component for MOSS-TTS Local while keeping the processor responsible for text/config handling.

## Modifications

- Add an owned `MossTTSLocalAudioTokenizer` wrapper that loads `OpenMOSS-Team/MOSS-Audio-Tokenizer-v2`, prepares reference waveforms with the upstream channel/resample/loudness semantics, and exposes a narrow encode API.
- Load the MOSS-TTS Local processor without constructing its codec, then load the codec separately for preprocessing and vocoder stages.
- Route reference file paths and data-URI references through the owned codec encoder with the existing batching/cache path.
- Pass the owned codec model directly into the streaming vocoder scheduler instead of deriving it from `processor.audio_tokenizer`.
- Add unit coverage for owned codec loading, waveform preparation, batched reference encoding, data-URI handling, and vocoder executor construction.

## Validation

Unit gate:

```text
115 passed, 20 warnings
```

Full SeedTTS EN, `--max-concurrency 8`:

| metric | value |
|---|---:|
| completed / failed | `1088 / 0` |
| WER evaluated / skipped | `1088 / 0` |
| throughput_qps | `7.138` |
| rtf_mean / p95 / p99 | `0.2637 / 0.3794 / 0.4389` |
| latency mean / p95 / p99 | `1.119s / 1.530s / 1.717s` |
| output throughput | `392.5 tok/s` |
| output tokens total | `59832` |
| WER corpus | `2.28%` |
| WER below 50 | `1.83%` |
| >50% WER outliers | `5` |
| UTMOS mean | `3.9542` |
| speaker similarity mean | `65.1585` |

Audio integrity:

| check | value |
|---|---:|
| files | `1088` |
| missing | `0` |
| read errors | `0` |
| silent / zero-peak | `0` |
| empty | `0` |
| sample rate | `48000` for all |
| channels | stereo for all |
| duration min / mean / max | `1.68s / 4.399s / 9.36s` |
| full-scale clipped sample count | `20` |

