### PR TITLE
[Refactor] Promote shared resolve_checkpoint() helper (#661)

### DIFF
--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -22,6 +22,7 @@ from sglang_omni.scheduling.generation_batch_policy import (
     sync_cuda_graph_bs_with_max_bs,
     validate_generation_batch_policy,
 )
+from sglang_omni.utils.hf import resolve_checkpoint
 
 logger = logging.getLogger(__name__)
 
@@ -60,14 +61,6 @@ def _resolve_s2pro_model_buffer_bs(model: Any) -> int:
         int(model.vq_decode_max_batch_size),
         int(model._audio_decoder.kv_cache_max_batch_size),
     )
-
-
-def _resolve_checkpoint(checkpoint: str) -> str:
-    if os.path.isdir(checkpoint):
-        return checkpoint
-    from huggingface_hub import snapshot_download
-
-    return snapshot_download(checkpoint)
 
 
 def _load_codec(checkpoint_dir: str, device: str):
@@ -114,7 +107,7 @@ def create_preprocessing_executor(
     """Returns a threaded scheduler for CPU-heavy preprocessing."""
     from sglang_omni.scheduling.threaded_simple_scheduler import ThreadedSimpleScheduler
 
-    checkpoint_dir = _resolve_checkpoint(model_path)
+    checkpoint_dir = resolve_checkpoint(model_path)
 
     from transformers import PreTrainedTokenizerFast
 
@@ -245,7 +238,7 @@ def create_sglang_tts_engine_executor(
         build_sglang_server_args,
     )
 
-    checkpoint_dir = _resolve_checkpoint(model_path)
+    checkpoint_dir = resolve_checkpoint(model_path)
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0
 
     patch_fish_config_for_sglang()
@@ -372,7 +365,7 @@ def create_vocoder_executor(
 
     if device is None:
         device = f"cuda:{gpu_id}" if gpu_id is not None else "cpu"
-    checkpoint_dir = _resolve_checkpoint(model_path)
+    checkpoint_dir = resolve_checkpoint(model_path)
     codec = _load_codec(checkpoint_dir, device)
 
     return S2ProVocoderScheduler(

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -27,6 +27,7 @@ from sglang_omni.scheduling.generation_batch_policy import (
 )
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 from sglang_omni.utils.audio_payload import audio_waveform_payload
+from sglang_omni.utils.hf import resolve_checkpoint
 
 logger = logging.getLogger(__name__)
 
@@ -46,14 +47,6 @@ def store_state(payload: StagePayload, state: Qwen3TTSState) -> StagePayload:
     return payload
 
 
-def _resolve_checkpoint(checkpoint: str) -> str:
-    if os.path.isdir(checkpoint):
-        return checkpoint
-    from huggingface_hub import snapshot_download
-
-    return snapshot_download(checkpoint)
-
-
 def _load_qwen3_tts_tokenizer(
     model_path: str,
     *,
@@ -67,7 +60,7 @@ def _load_qwen3_tts_tokenizer(
     except ImportError as exc:
         raise RuntimeError(_QWEN_TTS_INSTALL_HINT) from exc
 
-    checkpoint_dir = _resolve_checkpoint(model_path)
+    checkpoint_dir = resolve_checkpoint(model_path)
     tokenizer_path = os.path.join(checkpoint_dir, "speech_tokenizer")
     torch_dtype = getattr(torch, dtype) if isinstance(dtype, str) else dtype
     kwargs: dict[str, Any] = {
@@ -191,7 +184,7 @@ def create_sglang_tts_engine_executor(
     )
 
     _register_qwen3_tts_hf_config()
-    checkpoint_dir = _resolve_checkpoint(model_path)
+    checkpoint_dir = resolve_checkpoint(model_path)
     if gpu_id is not None:
         device = f"cuda:{gpu_id}"
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0

--- a/sglang_omni/utils/hf.py
+++ b/sglang_omni/utils/hf.py
@@ -20,6 +20,25 @@ except ImportError:
 from transformers.utils.hub import cached_file
 
 # ---------------------------------------------------------------------------
+# Checkpoint resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_checkpoint(checkpoint: str) -> str:
+    """Return a local checkpoint directory for a local path or HF repo id.
+
+    If ``checkpoint`` is an existing directory it is returned unchanged;
+    otherwise it is treated as a Hugging Face repo id, downloaded, and the
+    local snapshot path is returned.
+    """
+    if os.path.isdir(checkpoint):
+        return checkpoint
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(checkpoint)
+
+
+# ---------------------------------------------------------------------------
 # Architecture resolution helpers
 # ---------------------------------------------------------------------------
 

--- a/tests/unit_test/utils/test_resolve_checkpoint.py
+++ b/tests/unit_test/utils/test_resolve_checkpoint.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contract test for the shared ``resolve_checkpoint`` helper (RFC #661 quick win).
+
+CPU-only, no network: the local-directory branch is exercised directly and the
+download branch is checked with ``snapshot_download`` patched out.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from sglang_omni.utils.hf import resolve_checkpoint
+
+
+def test_existing_directory_is_returned_unchanged(tmp_path) -> None:
+    assert resolve_checkpoint(str(tmp_path)) == str(tmp_path)
+
+
+def test_repo_id_is_downloaded_via_snapshot_download() -> None:
+    with mock.patch(
+        "huggingface_hub.snapshot_download", return_value="/cache/snapshot"
+    ) as download:
+        resolved = resolve_checkpoint("org/some-model")
+
+    assert resolved == "/cache/snapshot"
+    download.assert_called_once_with("org/some-model")


### PR DESCRIPTION
## What this adds
- A shared `resolve_checkpoint()` in `sglang_omni/utils/hf.py` ("local dir or HF repo id → local path").
- Migrate the two verbatim inline copies (qwen3_tts, fishaudio_s2_pro) to it; delete the per-model defs.
- CPU-only contract test.

Behavior-preserving — the migrated helper is byte-for-byte equivalent; no model math / kernel / hot-path change. ~50 LOC.

## Not done (intentionally out of scope)
moss_tts / moss_tts_local (`resolve_moss_checkpoint`) and higgs_tts (`resolve_checkpoint` / `_resolve_ckpt_dir`) already keep their own module-local copies; folding them in is trivial but churns many call sites — kept as a follow-up to keep this PR small.

## Test
`pytest tests/unit_test/utils/test_resolve_checkpoint.py` — local-dir passthrough + repo-id download (snapshot_download mocked). CPU, no GPU.

Part of #661
