### PR TITLE
[Refactor] Quick-wins: Share reverse_delay_pattern (de-delay) util (#661)

### DIFF
--- a/sglang_omni/models/higgs_tts/utils.py
+++ b/sglang_omni/models/higgs_tts/utils.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Utilities shared across the Higgs TTS pipeline.
 
-- Delay pattern: :func:`apply_delay_pattern` / :func:`reverse_delay_pattern`
-  shift codebook ``c`` by ``c`` steps, BOC/EOC padding inside the codebook
-  vocab (ids 1024 / 1025 for the default 1026 vocab).
+- Delay pattern: :func:`apply_delay_pattern` shifts codebook ``c`` by ``c``
+  steps, BOC/EOC padding inside the codebook vocab (ids 1024 / 1025 for the
+  default 1026 vocab). The inverse lives in ``utils/delay_pattern.py``.
 - :func:`truncate_rope_to_bf16` matches sglang's fp32 RoPE cache to Higgs's
   bf16 training-time RoPE.
 - Stage helpers: checkpoint snapshot, codec cache, ref-codes coercion,
@@ -46,25 +46,6 @@ def apply_delay_pattern(codes_TN: torch.Tensor) -> torch.Tensor:
     for c in range(N):
         out[t_idx < c, c] = BOC_ID
         out[c : c + T, c] = codes_TN[:, c]
-    return out
-
-
-def reverse_delay_pattern(delayed_LN: torch.Tensor) -> torch.Tensor:
-    """``[L, N]`` delayed (L >= N) → ``[L - (N - 1), N]`` raw codes."""
-    if delayed_LN.ndim != 2:
-        raise ValueError(
-            f"delayed_LN must be 2-D [L, N], got shape {tuple(delayed_LN.shape)}"
-        )
-    L, N = delayed_LN.shape
-    T = L - (N - 1)
-    if T <= 0:
-        raise ValueError(
-            f"delayed_LN has L={L}, N={N}; need L >= N so at least one "
-            f"data row can be recovered."
-        )
-    out = torch.empty((T, N), device=delayed_LN.device, dtype=delayed_LN.dtype)
-    for c in range(N):
-        out[:, c] = delayed_LN[c : c + T, c]
     return out
 
 
@@ -154,7 +135,6 @@ __all__ = [
     "get_or_load_codec",
     "load_audio_to_24k",
     "resolve_checkpoint",
-    "reverse_delay_pattern",
     "to_codes_TN",
     "truncate_rope_to_bf16",
 ]

--- a/sglang_omni/models/higgs_tts/vocoder_scheduler.py
+++ b/sglang_omni/models/higgs_tts/vocoder_scheduler.py
@@ -10,7 +10,6 @@ import torch
 
 from sglang_omni.models.higgs_tts.audio_codec import HiggsAudioCodec
 from sglang_omni.models.higgs_tts.payload_types import HiggsTtsState
-from sglang_omni.models.higgs_tts.utils import reverse_delay_pattern
 from sglang_omni.models.tts_streaming import (
     INITIAL_CODEC_CHUNK_FRAMES_PARAM,
     resolve_initial_codec_chunk_frames,
@@ -20,6 +19,7 @@ from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.streaming_simple_scheduler import StreamingSimpleScheduler
 from sglang_omni.utils.audio_payload import audio_waveform_payload
+from sglang_omni.utils.delay_pattern import reverse_delay_pattern
 
 
 @dataclass

--- a/sglang_omni/models/moss_tts/codec.py
+++ b/sglang_omni/models/moss_tts/codec.py
@@ -7,25 +7,12 @@ from typing import Any
 
 import torch
 
+from sglang_omni.utils.delay_pattern import reverse_delay_pattern
+
 
 def apply_de_delay_pattern(delayed_codes: torch.Tensor) -> torch.Tensor:
     """Convert delayed RVQ rows back to normal ``[time, n_vq]`` codes."""
-
-    if delayed_codes.ndim != 2:
-        raise ValueError("MOSS-TTS delayed audio codes must be rank-2")
-    if delayed_codes.shape[0] < delayed_codes.shape[1]:
-        return delayed_codes.new_empty((0, delayed_codes.shape[1]))
-
-    tokens = delayed_codes.new_full(
-        (
-            delayed_codes.shape[0] - delayed_codes.shape[1] + 1,
-            delayed_codes.shape[1],
-        ),
-        0,
-    )
-    for idx in range(delayed_codes.shape[1]):
-        tokens[:, idx] = delayed_codes[idx : idx + tokens.shape[0], idx]
-    return tokens
+    return reverse_delay_pattern(delayed_codes, on_short="empty")
 
 
 def split_moss_audio_segments(

--- a/sglang_omni/utils/delay_pattern.py
+++ b/sglang_omni/utils/delay_pattern.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared delay-pattern transforms for multi-codebook TTS codecs."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import torch
+
+
+def reverse_delay_pattern(
+    delayed: torch.Tensor, *, on_short: Literal["raise", "empty"] = "raise"
+) -> torch.Tensor:
+    """Undo a codebook delay pattern: ``[L, N]`` (L >= N) -> ``[L - (N - 1), N]``.
+
+    Column ``c`` is read with a ``c``-row offset so the per-codebook delays line
+    back up. ``on_short`` controls the ``L < N`` case where no full data row can
+    be recovered: ``"raise"`` (default; Higgs) raises ``ValueError``; ``"empty"``
+    (MOSS) returns an empty ``[0, N]`` tensor.
+    """
+    if delayed.ndim != 2:
+        raise ValueError(
+            f"delayed must be 2-D [L, N], got shape {tuple(delayed.shape)}"
+        )
+    length, n = delayed.shape
+    rows = length - (n - 1)
+    if rows <= 0:
+        if on_short == "empty":
+            return delayed.new_empty((0, n))
+        raise ValueError(
+            f"delayed has L={length}, N={n}; need L >= N so at least one data "
+            f"row can be recovered."
+        )
+    out = torch.empty((rows, n), device=delayed.device, dtype=delayed.dtype)
+    for c in range(n):
+        out[:, c] = delayed[c : c + rows, c]
+    return out
+
+
+__all__ = ["reverse_delay_pattern"]

--- a/tests/unit_test/utils/test_delay_pattern.py
+++ b/tests/unit_test/utils/test_delay_pattern.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contract test for the shared ``reverse_delay_pattern`` util (RFC #661 quick win).
+
+Covers the de-delay round-trip and the two ``on_short`` policies that Higgs and
+MOSS rely on (raise vs return-empty). Needs torch; CPU only, no GPU.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sglang_omni.utils.delay_pattern import reverse_delay_pattern
+
+
+def _apply_delay(codes: torch.Tensor) -> torch.Tensor:
+    """Reference forward delay: ``[T, N]`` -> ``[T + N - 1, N]`` (column c offset by c)."""
+    t, n = codes.shape
+    out = torch.full((t + n - 1, n), -1, dtype=codes.dtype)
+    for c in range(n):
+        out[c : c + t, c] = codes[:, c]
+    return out
+
+
+def test_reverse_round_trips_the_forward_delay() -> None:
+    codes = torch.arange(12).reshape(4, 3)  # T=4, N=3
+    recovered = reverse_delay_pattern(_apply_delay(codes))
+    assert torch.equal(recovered, codes)
+
+
+def test_short_input_raises_by_default() -> None:
+    with pytest.raises(ValueError):
+        reverse_delay_pattern(torch.zeros(2, 3, dtype=torch.long))  # L=2 < N=3
+
+
+def test_short_input_returns_empty_when_requested() -> None:
+    out = reverse_delay_pattern(torch.zeros(2, 3, dtype=torch.long), on_short="empty")
+    assert out.shape == (0, 3)
+
+
+def test_non_2d_input_raises() -> None:
+    with pytest.raises(ValueError):
+        reverse_delay_pattern(torch.zeros(3, dtype=torch.long))


### PR DESCRIPTION
## Modifications

The logic moves into a new file `utils/delay_pattern.py`, shared by both models.

The two copies handled one edge case differently: when input length `L < N` (sequence shorter than the number of codebooks), higgs raises an exception while moss returns an empty tensor. The shared util preserves both via an `on_short="raise"|"empty"` parameter — higgs passes `raise`, moss passes `empty`, neither changes.

Forward delay stays model-specific. The reverse transform is identical across models (pure shift), but forward differs (pad tokens, state machines vary).

Three changes land it: higgs drops its local copy and imports the shared util; moss's `apply_de_delay_pattern` now delegates with `on_short="empty"`; a CPU-only contract test is added.

Out of scope: `resolve_checkpoint` / `_build_usage` — folded into task #807.

## Note !
This part is mentioned in the [lark docs](https://ylarkus3pw750a4b.usttp.larksuite.com/docx/XHA8dNxOhopLKdxqtDDuQTULtCd) Wave 1 as Quick wins, but in live tracking of #611 it is not mentioned.

## Related Issues

Part of #661

## Accuracy Test

N/A — behavior-preserving, code moves without changing computation. The only observable change is the `ValueError` message text in the short-input guard; the exception type is unchanged.

## Benchmark & Profiling

N/A — no hot-path change.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.