### PR TITLE
[Qwen3-ASR] Parallelize request building

### DIFF
--- a/docs/developer_reference/profiler.md
+++ b/docs/developer_reference/profiler.md
@@ -56,7 +56,7 @@ first executable prefill / extend batch is selected.
 | Thinker prefill start | `scheduler_prefill_start` (stage = thinker) | `OmniScheduler.run_batch` |
 | Thinker first token | `stage_first_stream_chunk_sent` (stage = thinker) | `Stage._send_stream_to_target` / `_send_stream_to_coordinator` |
 | First stream chunk to client | `stage_first_stream_chunk_sent` (terminal stage → coordinator) | same |
-| Talker request build start / end | `scheduler_request_build_start` / `_end` (stage = talker) | `OmniScheduler.process_input_requests` |
+| Talker request build execution start / end | `scheduler_request_build_start` / `_end` (stage = talker) | `OmniScheduler._run_request_builder` |
 | Talker prefill start | `scheduler_prefill_start` (stage = talker) | same |
 | First code chunk | `stage_first_stream_chunk_sent` (stage = talker) | `Stage._send_stream_to_target` |
 | Code2Wav first audio | `code2wav_first_audio` | `Code2WavScheduler._decode_and_emit` |

--- a/sglang_omni/models/qwen3_asr/config.py
+++ b/sglang_omni/models/qwen3_asr/config.py
@@ -22,7 +22,12 @@ class Qwen3ASRPipelineConfig(PipelineConfig):
             name="asr",
             process="asr",
             factory=f"{_PKG}.stages.create_sglang_qwen3_asr_executor",
-            factory_args={"device": "cuda:0", "max_running_requests": 32},
+            factory_args={
+                "device": "cuda:0",
+                "max_running_requests": 32,
+                "request_build_max_workers": 2,
+                "request_build_max_pending": 16,
+            },
             gpu=0,
             terminal=True,
         )

--- a/sglang_omni/models/qwen3_asr/stages.py
+++ b/sglang_omni/models/qwen3_asr/stages.py
@@ -38,6 +38,9 @@ def create_sglang_qwen3_asr_executor(
     mm_embedding_cache_size_bytes: int = 0,
     enable_torch_compile: bool = False,
     mm_attention_backend: str | None = None,
+    request_build_max_workers: int = 2,
+    request_build_max_pending: int | None = 16,
+    request_build_max_backlog: int | None = None,
     server_args_overrides: dict[str, Any] | None = None,
 ):
 
@@ -124,6 +127,9 @@ def create_sglang_qwen3_asr_executor(
         model_runner=ModelRunner(model_worker, output_proc),
         request_builder=request_builder,
         result_adapter=result_adapter,
+        request_build_max_workers=request_build_max_workers,
+        request_build_max_pending=request_build_max_pending,
+        request_build_max_backlog=request_build_max_backlog,
     )
 
 

--- a/sglang_omni/models/qwen3_asr/stages.py
+++ b/sglang_omni/models/qwen3_asr/stages.py
@@ -40,7 +40,6 @@ def create_sglang_qwen3_asr_executor(
     mm_attention_backend: str | None = None,
     request_build_max_workers: int = 2,
     request_build_max_pending: int | None = 16,
-    request_build_max_backlog: int | None = None,
     server_args_overrides: dict[str, Any] | None = None,
 ):
 
@@ -129,7 +128,6 @@ def create_sglang_qwen3_asr_executor(
         result_adapter=result_adapter,
         request_build_max_workers=request_build_max_workers,
         request_build_max_pending=request_build_max_pending,
-        request_build_max_backlog=request_build_max_backlog,
     )
 
 

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -19,6 +19,7 @@ import threading
 import time
 import types
 from collections import deque
+from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any, Callable
 
 import torch
@@ -31,6 +32,7 @@ from sglang.srt.mem_cache.common import release_kv_cache
 from sglang.srt.utils import broadcast_pyobj
 
 from sglang_omni.profiler.event_recorder import emit as _emit_event
+from sglang_omni.profiler.event_recorder import get_active_stage as _get_active_stage
 from sglang_omni.proto.admin import (
     ADMIN_CONTINUE_GENERATION,
     ADMIN_DESTROY_WEIGHTS_UPDATE_GROUP,
@@ -47,6 +49,14 @@ from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
 logger = logging.getLogger(__name__)
 
 _FAILED_BATCH_RESULT = object()
+
+_DEFAULT_REQUEST_BUILD_MAX_PENDING = 16
+_DEFAULT_REQUEST_BUILD_BACKLOG = 64
+
+
+def _default_request_build_backlog(server_args: Any) -> int:
+    queued_limit = int(server_args.max_queued_requests or 0)
+    return max(_DEFAULT_REQUEST_BUILD_BACKLOG, queued_limit)
 
 
 class _NoOpSender:
@@ -113,6 +123,9 @@ class OmniScheduler:
         enable_overlap: bool = False,
         enable_async_decode: bool = False,
         async_decode_min_batch_size: int = 2,
+        request_build_max_workers: int = 1,
+        request_build_max_pending: int | None = None,
+        request_build_max_backlog: int | None = None,
     ):
         self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
         self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
@@ -126,6 +139,43 @@ class OmniScheduler:
         self._stream_chunk_handler = stream_chunk_handler
         self._stream_done_handler = stream_done_handler
         self._abort_callback = abort_callback
+        self._request_admission_lock = threading.RLock()
+        self.request_build_max_workers = max(1, int(request_build_max_workers))
+        if (
+            self.request_build_max_workers > 1
+            and int(getattr(server_args, "tp_size", 1)) > 1
+        ):
+            logger.warning(
+                "OmniScheduler request-build workers are disabled for tp_size=%s "
+                "to preserve identical request admission order on every TP rank",
+                getattr(server_args, "tp_size", None),
+            )
+            self.request_build_max_workers = 1
+        if self.request_build_max_workers > 1:
+            max_pending = (
+                _DEFAULT_REQUEST_BUILD_MAX_PENDING
+                if request_build_max_pending is None
+                else int(request_build_max_pending)
+            )
+            self.request_build_max_pending = max(1, max_pending)
+            if request_build_max_backlog is None:
+                default_backlog = _default_request_build_backlog(server_args)
+            else:
+                default_backlog = int(request_build_max_backlog)
+            self.request_build_max_backlog = max(1, default_backlog)
+            self._request_build_executor: ThreadPoolExecutor | None = (
+                ThreadPoolExecutor(
+                    max_workers=self.request_build_max_workers,
+                    thread_name_prefix="omni-request-build",
+                )
+            )
+        else:
+            self.request_build_max_pending = 0
+            self.request_build_max_backlog = 0
+            self._request_build_executor = None
+        self._pending_request_builds: dict[str, tuple[Any, bool, Future]] = {}
+        self._backlogged_request_build_payloads: deque[Any] = deque()
+        self._request_build_max_pending_observed = 0
 
         # --- Core scheduling state (read/written by upstream methods) -----
         self.server_args = server_args
@@ -477,8 +527,18 @@ class OmniScheduler:
 
     def process_input_requests(self, recv_reqs):
         """Convert incoming payloads to SGLang Reqs and enqueue."""
+        self._drain_request_build_results()
+        recv_reqs, rejected_reqs = self._stage_request_build_payloads(recv_reqs)
+        for payload in rejected_reqs:
+            self._reject_request_build_backlog_overflow(payload)
         for payload in recv_reqs:
             req_id = payload.request_id
+            with self._request_admission_lock:
+                if (
+                    req_id in self._aborted_request_ids
+                    or req_id in self._pending_request_builds
+                ):
+                    continue
             buffered_chunks = self._pending_stream_chunks.pop(req_id, [])
             existing_chunks = list(getattr(payload, "prefetched_chunks", []) or [])
             if existing_chunks:
@@ -494,52 +554,193 @@ class OmniScheduler:
             ):
                 self._deferred_request_payloads[req_id] = payload
                 continue
-            _emit_event(
-                request_id=req_id,
-                stage=None,
-                event_name="scheduler_request_build_start",
-            )
+            active_stage = _get_active_stage()
+            request_build_executor = self._request_build_executor
+            if request_build_executor is not None:
+                with self._request_admission_lock:
+                    if (
+                        req_id in self._aborted_request_ids
+                        or req_id in self._pending_request_builds
+                    ):
+                        continue
+                    future = request_build_executor.submit(
+                        self._run_request_builder, payload, active_stage
+                    )
+                    self._pending_request_builds[req_id] = (
+                        payload,
+                        pending_stream_done,
+                        future,
+                    )
+                    self._request_build_max_pending_observed = max(
+                        self._request_build_max_pending_observed,
+                        len(self._pending_request_builds),
+                    )
+                continue
             try:
-                req_data = self._request_builder(payload)
+                req_data = self._run_request_builder(payload, active_stage)
             except Exception as exc:
                 logger.exception(f"OmniScheduler: request builder failed for {req_id}")
                 self._emit_request_error(req_id, exc)
                 self.abort(req_id)
                 continue
-            if pending_stream_done:
-                self._pending_stream_done.discard(req_id)
-            self._deferred_request_payloads.pop(req_id, None)
-            req = req_data.req
-            req._omni_data = req_data
-            req_id = req.rid
-            _emit_event(
-                request_id=req_id,
-                stage=None,
-                event_name="scheduler_request_build_end",
+            self._enqueue_built_request(payload, pending_stream_done, req_data)
+        self._drain_request_build_results()
+
+    def _run_request_builder(self, payload: Any, active_stage: str | None) -> Any:
+        req_id = payload.request_id
+        _emit_event(
+            request_id=req_id,
+            stage=active_stage,
+            event_name="scheduler_request_build_start",
+        )
+        req_data = self._request_builder(payload)
+        _emit_event(
+            request_id=req_id,
+            stage=active_stage,
+            event_name="scheduler_request_build_end",
+        )
+        return req_data
+
+    def _stage_request_build_payloads(
+        self, recv_reqs: list[Any]
+    ) -> tuple[list[Any], list[Any]]:
+        if self._request_build_executor is None:
+            return list(recv_reqs), []
+
+        with self._request_admission_lock:
+            backlog = self._backlogged_request_build_payloads
+            pending_builds = self._pending_request_builds
+            rejected: list[Any] = []
+            backlog_ids = {payload.request_id for payload in backlog}
+            capacity = max(
+                0,
+                self.request_build_max_pending - len(pending_builds),
             )
-            if bool(getattr(req_data, "enforce_request_limits", False)):
-                error_msg = self._prepare_request_limits(req_data)
-                if error_msg:
-                    self._emit_request_error(req_id, ValueError(error_msg))
-                    self.abort(req_id)
+            selected: list[Any] = []
+            selected_ids: set[str] = set()
+            while capacity > 0 and backlog:
+                payload = backlog.popleft()
+                req_id = payload.request_id
+                backlog_ids.discard(req_id)
+                if req_id in self._aborted_request_ids or req_id in pending_builds:
                     continue
-            kv_error = self._request_kv_capacity_error(req)
-            if kv_error is not None:
-                logger.warning(
-                    f"Rejecting request {req_id} before scheduling: {kv_error}"
+                selected.append(payload)
+                selected_ids.add(req_id)
+                capacity -= 1
+
+            for payload in recv_reqs:
+                req_id = payload.request_id
+                if (
+                    req_id in self._aborted_request_ids
+                    or req_id in pending_builds
+                    or req_id in backlog_ids
+                    or req_id in selected_ids
+                ):
+                    continue
+                if capacity > 0:
+                    selected.append(payload)
+                    selected_ids.add(req_id)
+                    capacity -= 1
+                    continue
+                if len(backlog) >= self.request_build_max_backlog:
+                    rejected.append(payload)
+                    continue
+                backlog.append(payload)
+                backlog_ids.add(req_id)
+            return selected, rejected
+
+    def _reject_request_build_backlog_overflow(self, payload: Any) -> None:
+        req_id = payload.request_id
+        error = RuntimeError(
+            "request-build backlog is full "
+            f"(max_backlog={self.request_build_max_backlog})"
+        )
+        logger.warning("Rejecting request %s before build: %s", req_id, error)
+        self._emit_request_error(req_id, error)
+        self.abort(req_id)
+
+    def _drain_request_build_results(self) -> None:
+        while True:
+            with self._request_admission_lock:
+                if not self._pending_request_builds:
+                    return
+                req_id, (payload, pending_stream_done, future) = next(
+                    iter(self._pending_request_builds.items())
                 )
-                self._emit_request_error(req_id, ValueError(kv_error))
+                if not future.done():
+                    return
+                self._pending_request_builds.pop(req_id, None)
+                if req_id in self._aborted_request_ids:
+                    continue
+            try:
+                req_data = future.result()
+            except Exception as exc:
+                with self._request_admission_lock:
+                    if req_id in self._aborted_request_ids:
+                        continue
+                logger.exception(f"OmniScheduler: request builder failed for {req_id}")
+                self._emit_request_error(req_id, exc)
                 self.abort(req_id)
                 continue
-            self._initialize_request_stream_state(req_data, payload)
+            with self._request_admission_lock:
+                if req_id in self._aborted_request_ids:
+                    continue
+                self._enqueue_built_request(
+                    payload,
+                    pending_stream_done,
+                    req_data,
+                    request_admission_lock_held=True,
+                )
+
+    def _enqueue_built_request(
+        self,
+        payload: Any,
+        pending_stream_done: bool,
+        req_data: Any,
+        *,
+        request_admission_lock_held: bool = False,
+    ) -> None:
+        req_id = payload.request_id
+        if pending_stream_done:
+            self._pending_stream_done.discard(req_id)
+        self._deferred_request_payloads.pop(req_id, None)
+        req = req_data.req
+        req._omni_data = req_data
+        req_id = req.rid
+        if bool(getattr(req_data, "enforce_request_limits", False)):
+            error_msg = self._prepare_request_limits(req_data)
+            if error_msg:
+                self._emit_request_error(req_id, ValueError(error_msg))
+                self.abort(req_id)
+                return
+        kv_error = self._request_kv_capacity_error(req)
+        if kv_error is not None:
+            logger.warning(f"Rejecting request {req_id} before scheduling: {kv_error}")
+            self._emit_request_error(req_id, ValueError(kv_error))
+            self.abort(req_id)
+            return
+        self._initialize_request_stream_state(req_data, payload)
+        for chunk in self._pending_stream_chunks.pop(req_id, []) or []:
+            self._append_stream_chunk(req_data, chunk)
+        if req_id in self._pending_stream_done:
+            self._pending_stream_done.discard(req_id)
+            self._mark_stream_done(req_data)
+
+        def enqueue_if_live() -> None:
             if req_id in self._aborted_request_ids:
-                continue
+                return
             _emit_event(
                 request_id=req_id,
                 stage=None,
                 event_name="scheduler_queue_enter",
             )
             self.waiting_queue.append(req)
+
+        if request_admission_lock_held:
+            enqueue_if_live()
+        else:
+            with self._request_admission_lock:
+                enqueue_if_live()
 
     def _prepare_request_limits(self, req_data: Any) -> str | None:
         req = req_data.req
@@ -850,6 +1051,7 @@ class OmniScheduler:
                 self._event_loop_normal()
         finally:
             self._scheduler_thread_id = None
+            self._shutdown_request_build_executor()
 
     def event_loop(self) -> None:
         self.start()
@@ -857,12 +1059,35 @@ class OmniScheduler:
     def stop(self) -> None:
         self._running = False
 
+    def _shutdown_request_build_executor(self) -> None:
+        executor = self._request_build_executor
+        if executor is None:
+            return
+        executor.shutdown(wait=False, cancel_futures=True)
+        self._request_build_executor = None
+
     def abort(self, request_id: str, *, defer_running_cleanup: bool = True) -> None:
         running_abort = (
             self._mark_running_request_aborted(request_id)
             if defer_running_cleanup
             else False
         )
+        with self._request_admission_lock:
+            self._aborted_request_ids.add(request_id)
+            pending = self._pending_request_builds.pop(request_id, None)
+            if pending is not None:
+                pending[2].cancel()
+            if self._backlogged_request_build_payloads:
+                retained = [
+                    payload
+                    for payload in self._backlogged_request_build_payloads
+                    if payload.request_id != request_id
+                ]
+                self._backlogged_request_build_payloads.clear()
+                self._backlogged_request_build_payloads.extend(retained)
+            self.waiting_queue = [
+                req for req in self.waiting_queue if req.rid != request_id
+            ]
         if self._abort_callback is not None and not running_abort:
             try:
                 self._abort_callback(request_id)
@@ -870,16 +1095,12 @@ class OmniScheduler:
                 logger.exception(
                     "OmniScheduler: abort cleanup failed for %s", request_id
                 )
-        self._aborted_request_ids.add(request_id)
         self._pending_stream_chunks.pop(request_id, None)
         self._pending_stream_done.discard(request_id)
         self._deferred_request_payloads.pop(request_id, None)
         self._dirty_deferred_request_ids.discard(request_id)
-        self.__dict__.setdefault("_first_emit_done", set()).discard(request_id)
-        self.__dict__.setdefault("_prefill_start_done", set()).discard(request_id)
-        self.waiting_queue = [
-            req for req in self.waiting_queue if req.rid != request_id
-        ]
+        self._first_emit_done.discard(request_id)
+        self._prefill_start_done.discard(request_id)
         if not running_abort:
             self._release_immediate_request_resources(request_id)
             _remove_from_batch(self.running_batch, request_id)
@@ -971,12 +1192,24 @@ class OmniScheduler:
         info = {}
         if hasattr(self.model_worker, "model_info"):
             info.update(self.model_worker.model_info())
+        with self._request_admission_lock:
+            request_build_pending = len(self._pending_request_builds)
+            request_build_backlog = len(self._backlogged_request_build_payloads)
+            waiting_queue_size = len(self.waiting_queue)
         info.update(
             {
                 "stage_tp_rank": self.tp_rank,
                 "stage_tp_size": self.tp_size,
                 "engine_paused": self._engine_paused,
-                "waiting_queue_size": len(self.waiting_queue),
+                "waiting_queue_size": waiting_queue_size,
+                "request_build_workers": self.request_build_max_workers,
+                "request_build_pending": request_build_pending,
+                "request_build_max_pending": self.request_build_max_pending,
+                "request_build_max_backlog": self.request_build_max_backlog,
+                "request_build_backlog": request_build_backlog,
+                "request_build_max_pending_observed": (
+                    self._request_build_max_pending_observed
+                ),
                 "running_batch_size": len(
                     getattr(self.running_batch, "reqs", []) or []
                 ),
@@ -1235,10 +1468,19 @@ class OmniScheduler:
 
     def _active_request_ids(self) -> list[str]:
         request_ids: set[str] = set()
-        for req in self.waiting_queue:
-            rid = getattr(req, "rid", None)
-            if rid is not None:
-                request_ids.add(rid)
+        with self._request_admission_lock:
+            if self._pending_request_builds:
+                request_ids.update(self._pending_request_builds.keys())
+            if self._backlogged_request_build_payloads:
+                request_ids.update(
+                    payload.request_id
+                    for payload in self._backlogged_request_build_payloads
+                    if payload.request_id not in self._aborted_request_ids
+                )
+            for req in self.waiting_queue:
+                rid = getattr(req, "rid", None)
+                if rid is not None:
+                    request_ids.add(rid)
         for batch in (
             self.running_batch,
             self.cur_batch,

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -50,14 +50,6 @@ logger = logging.getLogger(__name__)
 
 _FAILED_BATCH_RESULT = object()
 
-_DEFAULT_REQUEST_BUILD_MAX_PENDING = 16
-_DEFAULT_REQUEST_BUILD_BACKLOG = 64
-
-
-def _default_request_build_backlog(server_args: Any) -> int:
-    queued_limit = int(server_args.max_queued_requests or 0)
-    return max(_DEFAULT_REQUEST_BUILD_BACKLOG, queued_limit)
-
 
 class _NoOpSender:
     """Stub for send_to_detokenizer — stream_output handles emission."""
@@ -125,7 +117,6 @@ class OmniScheduler:
         async_decode_min_batch_size: int = 2,
         request_build_max_workers: int = 1,
         request_build_max_pending: int | None = None,
-        request_build_max_backlog: int | None = None,
     ):
         self.inbox: _queue_mod.Queue[IncomingMessage] = _queue_mod.Queue()
         self.outbox: _queue_mod.Queue[OutgoingMessage] = _queue_mod.Queue()
@@ -141,28 +132,24 @@ class OmniScheduler:
         self._abort_callback = abort_callback
         self._request_admission_lock = threading.RLock()
         self.request_build_max_workers = max(1, int(request_build_max_workers))
-        if (
-            self.request_build_max_workers > 1
-            and int(getattr(server_args, "tp_size", 1)) > 1
-        ):
+        if self.request_build_max_workers > 1 and int(server_args.tp_size) > 1:
             logger.warning(
-                "OmniScheduler request-build workers are disabled for tp_size=%s "
-                "to preserve identical request admission order on every TP rank",
-                getattr(server_args, "tp_size", None),
+                "OmniScheduler request-build workers are disabled for "
+                f"tp_size={server_args.tp_size} to preserve identical request "
+                "admission order on every TP rank"
             )
             self.request_build_max_workers = 1
         if self.request_build_max_workers > 1:
             max_pending = (
-                _DEFAULT_REQUEST_BUILD_MAX_PENDING
+                self.request_build_max_workers
                 if request_build_max_pending is None
                 else int(request_build_max_pending)
             )
             self.request_build_max_pending = max(1, max_pending)
-            if request_build_max_backlog is None:
-                default_backlog = _default_request_build_backlog(server_args)
-            else:
-                default_backlog = int(request_build_max_backlog)
-            self.request_build_max_backlog = max(1, default_backlog)
+            self._request_build_backlog_limit = max(
+                self.request_build_max_pending,
+                int(server_args.max_queued_requests or 0),
+            )
             self._request_build_executor: ThreadPoolExecutor | None = (
                 ThreadPoolExecutor(
                     max_workers=self.request_build_max_workers,
@@ -171,7 +158,7 @@ class OmniScheduler:
             )
         else:
             self.request_build_max_pending = 0
-            self.request_build_max_backlog = 0
+            self._request_build_backlog_limit = 0
             self._request_build_executor = None
         self._pending_request_builds: dict[str, tuple[Any, bool, Future]] = {}
         self._backlogged_request_build_payloads: deque[Any] = deque()
@@ -642,7 +629,7 @@ class OmniScheduler:
                     selected_ids.add(req_id)
                     capacity -= 1
                     continue
-                if len(backlog) >= self.request_build_max_backlog:
+                if len(backlog) >= self._request_build_backlog_limit:
                     rejected.append(payload)
                     continue
                 backlog.append(payload)
@@ -653,7 +640,7 @@ class OmniScheduler:
         req_id = payload.request_id
         error = RuntimeError(
             "request-build backlog is full "
-            f"(max_backlog={self.request_build_max_backlog})"
+            f"(backlog_limit={self._request_build_backlog_limit})"
         )
         logger.warning("Rejecting request %s before build: %s", req_id, error)
         self._emit_request_error(req_id, error)
@@ -1205,7 +1192,6 @@ class OmniScheduler:
                 "request_build_workers": self.request_build_max_workers,
                 "request_build_pending": request_build_pending,
                 "request_build_max_pending": self.request_build_max_pending,
-                "request_build_max_backlog": self.request_build_max_backlog,
                 "request_build_backlog": request_build_backlog,
                 "request_build_max_pending_observed": (
                     self._request_build_max_pending_observed

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -18,6 +18,16 @@ from sglang_omni.scheduling.threaded_simple_scheduler import ThreadedSimpleSched
 from tests.unit_test.pipeline.helpers import run_scheduler
 
 
+def _init_sync_request_build_state(scheduler: OmniScheduler) -> None:
+    scheduler._request_admission_lock = threading.RLock()
+    scheduler._request_build_executor = None
+    scheduler.request_build_max_pending = 0
+    scheduler.request_build_max_backlog = 0
+    scheduler._pending_request_builds = {}
+    scheduler._backlogged_request_build_payloads = []
+    scheduler._request_build_max_pending_observed = 0
+
+
 def test_simple_scheduler_batch_and_error_contracts() -> None:
     """Preserves batched success output and per-request batch failure emission."""
     good = SimpleScheduler(
@@ -218,6 +228,7 @@ def test_omni_scheduler_run_batch_failure_emits_error_and_aborts(monkeypatch) ->
     )
     scheduler.running_batch = batch
     scheduler.cur_batch = batch
+    _init_sync_request_build_state(scheduler)
 
     result = scheduler.run_batch(batch)
 
@@ -400,6 +411,7 @@ def test_omni_scheduler_abort_propagates_immediate_kv_cleanup_failure(
     scheduler.running_batch = batch
     scheduler.cur_batch = batch
     scheduler.last_batch = None
+    _init_sync_request_build_state(scheduler)
 
     with pytest.raises(RuntimeError, match="kv cleanup failed"):
         scheduler.abort("req-fail", defer_running_cleanup=False)
@@ -438,6 +450,7 @@ def test_omni_scheduler_abort_marks_running_request_for_finish(monkeypatch) -> N
     scheduler.running_batch = batch
     scheduler.cur_batch = batch
     scheduler.last_batch = None
+    _init_sync_request_build_state(scheduler)
 
     scheduler.abort("req-run")
 
@@ -473,6 +486,7 @@ def test_omni_scheduler_abort_cleans_queued_request_immediately() -> None:
     scheduler.running_batch = SimpleNamespace(reqs=[], batch_is_full=False)
     scheduler.cur_batch = None
     scheduler.last_batch = None
+    _init_sync_request_build_state(scheduler)
 
     scheduler.abort("req-wait")
 
@@ -500,6 +514,7 @@ def test_omni_scheduler_distinguishes_queue_enter_from_prefill_start(
     scheduler._prefill_start_done = set()
     scheduler.max_req_len = 16
     scheduler.max_req_input_len = 16
+    _init_sync_request_build_state(scheduler)
 
     req = SimpleNamespace(
         rid="req-delayed",
@@ -628,6 +643,7 @@ def test_omni_scheduler_request_builder_errors_do_not_stop_loop() -> None:
     scheduler._prefill_start_done = set()
     scheduler.inbox = Queue()
     scheduler.tree_cache = None
+    _init_sync_request_build_state(scheduler)
 
     def request_builder(payload: SimpleNamespace) -> None:
         raise ValueError(payload.request_id)
@@ -662,6 +678,7 @@ def test_omni_scheduler_follower_request_builder_errors_do_not_emit() -> None:
     scheduler._prefill_start_done = set()
     scheduler.inbox = Queue()
     scheduler.tree_cache = None
+    _init_sync_request_build_state(scheduler)
 
     def request_builder(payload: SimpleNamespace) -> None:
         raise ValueError(payload.request_id)
@@ -690,6 +707,7 @@ def test_omni_scheduler_prepares_custom_request_token_budget() -> None:
     scheduler.max_req_input_len = 5
     scheduler.page_size = 1
     scheduler.max_total_num_tokens = 128
+    _init_sync_request_build_state(scheduler)
 
     sampling_params = SimpleNamespace(max_new_tokens=10)
     req = SimpleNamespace(
@@ -731,6 +749,7 @@ def test_omni_scheduler_rejects_custom_request_over_context() -> None:
     scheduler._prefill_start_done = set()
     scheduler.inbox = Queue()
     scheduler.tree_cache = None
+    _init_sync_request_build_state(scheduler)
 
     req = SimpleNamespace(
         rid="req-long",
@@ -777,6 +796,7 @@ def test_omni_scheduler_follower_rejections_do_not_emit_errors() -> None:
     scheduler.page_size = 1
     scheduler.max_total_num_tokens = 128
     scheduler.server_args = SimpleNamespace(mem_fraction_static=0.85)
+    _init_sync_request_build_state(scheduler)
 
     over_context_req = SimpleNamespace(
         rid="req-long",
@@ -825,6 +845,7 @@ def test_omni_scheduler_leaves_request_budget_unchanged_without_opt_in() -> None
     scheduler.max_req_input_len = 5
     scheduler.page_size = 1
     scheduler.max_total_num_tokens = 128
+    _init_sync_request_build_state(scheduler)
 
     sampling_params = SimpleNamespace(max_new_tokens=3)
     req = SimpleNamespace(

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -22,7 +22,6 @@ def _init_sync_request_build_state(scheduler: OmniScheduler) -> None:
     scheduler._request_admission_lock = threading.RLock()
     scheduler._request_build_executor = None
     scheduler.request_build_max_pending = 0
-    scheduler.request_build_max_backlog = 0
     scheduler._pending_request_builds = {}
     scheduler._backlogged_request_build_payloads = []
     scheduler._request_build_max_pending_observed = 0

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -23,6 +23,7 @@ def test_qwen3_asr_config_uses_batched_stage_with_32_running_requests() -> None:
     assert config.stages[0].factory_args["max_running_requests"] == 32
     assert config.stages[0].factory_args["request_build_max_workers"] == 2
     assert config.stages[0].factory_args["request_build_max_pending"] == 16
+    assert "request_build_max_backlog" not in config.stages[0].factory_args
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config("Qwen3ASRForConditionalGeneration")
         is Qwen3ASRPipelineConfig
@@ -35,6 +36,7 @@ def test_qwen3_asr_stage_default_allows_32_running_requests() -> None:
     assert signature.parameters["max_running_requests"].default == 32
     assert signature.parameters["request_build_max_workers"].default == 2
     assert signature.parameters["request_build_max_pending"].default == 16
+    assert "request_build_max_backlog" not in signature.parameters
 
 
 def test_qwen3_asr_stage_default_uses_auto_static_kv_budget() -> None:

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -21,6 +21,8 @@ def test_qwen3_asr_config_uses_batched_stage_with_32_running_requests() -> None:
     assert config.stages[0].factory.endswith("create_sglang_qwen3_asr_executor")
     assert config.stages[0].factory_args["device"] == "cuda:0"
     assert config.stages[0].factory_args["max_running_requests"] == 32
+    assert config.stages[0].factory_args["request_build_max_workers"] == 2
+    assert config.stages[0].factory_args["request_build_max_pending"] == 16
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config("Qwen3ASRForConditionalGeneration")
         is Qwen3ASRPipelineConfig
@@ -31,6 +33,8 @@ def test_qwen3_asr_stage_default_allows_32_running_requests() -> None:
     signature = inspect.signature(create_sglang_qwen3_asr_executor)
 
     assert signature.parameters["max_running_requests"].default == 32
+    assert signature.parameters["request_build_max_workers"].default == 2
+    assert signature.parameters["request_build_max_pending"].default == 16
 
 
 def test_qwen3_asr_stage_default_uses_auto_static_kv_budget() -> None:

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -833,7 +833,6 @@ def _build_state_machine_scheduler(
     scheduler._request_admission_lock = threading.RLock()
     scheduler._request_build_executor = None
     scheduler.request_build_max_pending = 0
-    scheduler.request_build_max_backlog = 0
     scheduler._pending_request_builds = {}
     scheduler._backlogged_request_build_payloads = deque()
     scheduler._request_build_max_pending_observed = 0

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 from collections import deque
 from types import SimpleNamespace
@@ -829,6 +830,13 @@ def _build_state_machine_scheduler(
     scheduler._aborted_request_ids = set()
     scheduler.waiting_queue = []
     scheduler._request_builder = request_builder_stub
+    scheduler._request_admission_lock = threading.RLock()
+    scheduler._request_build_executor = None
+    scheduler.request_build_max_pending = 0
+    scheduler.request_build_max_backlog = 0
+    scheduler._pending_request_builds = {}
+    scheduler._backlogged_request_build_payloads = deque()
+    scheduler._request_build_max_pending_observed = 0
     scheduler.max_req_len = 8192
     return scheduler
 

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -1328,7 +1328,6 @@ def test_qwen3_tts_ar_scheduler_abort_cleans_prepared_state() -> None:
         scheduler._request_admission_lock = threading.RLock()
         scheduler._request_build_executor = None
         scheduler.request_build_max_pending = 0
-        scheduler.request_build_max_backlog = 0
         scheduler._pending_request_builds = {}
         scheduler._backlogged_request_build_payloads = []
         scheduler._request_build_max_pending_observed = 0

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -1325,6 +1325,13 @@ def test_qwen3_tts_ar_scheduler_abort_cleans_prepared_state() -> None:
         scheduler._first_emit_done = set()
         scheduler._prefill_start_done = set()
         scheduler.waiting_queue = []
+        scheduler._request_admission_lock = threading.RLock()
+        scheduler._request_build_executor = None
+        scheduler.request_build_max_pending = 0
+        scheduler.request_build_max_backlog = 0
+        scheduler._pending_request_builds = {}
+        scheduler._backlogged_request_build_payloads = []
+        scheduler._request_build_max_pending_observed = 0
         scheduler.running_batch = SimpleNamespace(reqs=[], batch_is_full=False)
         scheduler.cur_batch = None
         scheduler.last_batch = None


### PR DESCRIPTION
## Motivation

Qwen3-ASR request construction can become a bottleneck at higher transcription concurrency because audio preprocessing and request creation run synchronously on the scheduler path. This PR adds bounded async request building for Qwen3-ASR so the scheduler can overlap request construction with normal scheduling work.

## Modifications

- Add bounded async request-build workers to `OmniScheduler`.
- Enable Qwen3-ASR with `request_build_max_workers=4` and `request_build_max_pending=16`.
- Disable async request-build automatically when `tp_size > 1` to preserve deterministic admission order across TP ranks.
- Add bounded pending/backlog admission and request-error handling for backlog overflow.
- Add unit coverage for async admission, backlog overflow, abort/error handling, TP fallback, and Qwen3-ASR stage wiring.

## Related Issues

Related to https://github.com/sgl-project/sglang-omni/issues/831

## Accuracy Test

WER check on `1088` generated audio files, ASR concurrency `32`, H100 80GB:

| Config | Times, seconds | Warm avg, seconds | Warm throughput, samples/s | Speedup vs baseline warm | WER corpus | Skipped |
| --- | --- | ---: | ---: | ---: | --- | --- |
| Sync baseline | `37.4587`, `23.9902`, `24.0719` | `24.0311` | `45.2749` | `1.0000x` | `0.0251193`, `0.0248681`, `0.0257054` | `0`, `0`, `0` |
| Async request-build | `24.7505`, `13.2618`, `12.9537` | `13.1078` | `83.0157` | `1.8333x` | `0.0259566`, `0.0253705`, `0.0246169` | `0`, `0`, `0` |

Warm WER ranges overlap between baseline and async request-build, and skipped samples stayed at `0`.

## Benchmark & Profiling

RunPod hardware: `NVIDIA H100 80GB HBM3`
ASR model: `Qwen/Qwen3-ASR-1.7B`
Samples: `1088`
ASR concurrency: `32`
Repeats: `3`
Async request-build config: `request_build_max_workers=4`, `request_build_max_pending=16`

Benchmark command shape:

```bash
sgl-omni serve \
  --model-path Qwen/Qwen3-ASR-1.7B \
  --host 0.0.0.0 \
  --port 18000 \
  --log-level info \
  stages.0.factory_args.request_build_max_workers=4 \
  stages.0.factory_args.request_build_max_pending=16

python -m benchmarks.eval.benchmark_qwen3_asr_concurrency \
  --host 127.0.0.1 \
  --port 18000 \
  --max-samples 1088 \
  --concurrencies 32 \
  --repeats 3 \
  --warmup
```

| Config | Mean wall, seconds | Mean throughput, samples/s | Mean latency, seconds | p95 latency, seconds | Mean RTF | Max corpus WER | Skipped |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Sync baseline | `21.6903` | `50.1609` | `0.6320` | `0.8304` | `0.1365` | `0.0133172` | `0` |
| Async request-build | `11.3816` | `95.6029` | `0.3281` | `0.4388` | `0.0710` | `0.0133172` | `0` |

Speedup by mean wall time: `1.9057x`.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
