### PR TITLE
[MOSS] Capture all streaming vocoder CUDA graph step lengths

### DIFF
--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -102,7 +102,7 @@ class MossTTSLocalPipelineConfig(PipelineConfig):
     )
 
     # Streaming-vocoder CUDA-graph knobs, injected into the vocoder factory by model_post_init.
-    # Default on, fail-safe to eager; cuda_graph_frames=None uses the built-in broad-exact set.
+    # Default on, fail-safe to eager; cuda_graph_frames=None captures exact T=1..stream_chunk.
     cuda_graph: bool = True
     cuda_graph_frames: list[int] | None = None
     cuda_graph_min_free_gb: float = 3.0

--- a/sglang_omni/models/moss_tts_local/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts_local/streaming_vocoder.py
@@ -512,37 +512,12 @@ class MossTTSLocalStreamingVocoderScheduler(StreamingSimpleScheduler):
             self._session = None
 
     def _cuda_graph_capture_frames(self) -> list[int]:
-        """Step lengths T to capture (config ``cuda_graph_frames`` overrides). Default is a
-        data-driven broad-exact set (see below); uncaptured T fall back to eager."""
+        """Step lengths T to capture. Config ``cuda_graph_frames`` overrides the default."""
         if self._cuda_graph_frames:
             # Validated at config (>= 1) and __init__ (<= max_step_frames); use as configured.
             return sorted(set(self._cuda_graph_frames))
-        # Broad-exact small-T set (measured per-T serving frequency). The T=max_step_frames cap is
-        # excluded (biggest single graph, only ~1.04x offline-lane) to shrink the warmup VRAM peak.
-        join_floor = max(
-            1,
-            min(self._default_initial_chunk_frames or 5, self._stream_chunk_frames),
-        )
-        frames = [
-            4,
-            5,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            20,
-            22,
-            24,
-            25,
-            join_floor,
-            self._default_initial_chunk_frames or join_floor,
-            self._stream_chunk_frames,
-        ]
-        # Clamp the generated default to the supported range (this is the auto-default, not user
-        # input; user-supplied frames are validated and rejected, never silently filtered).
-        return sorted({t for t in frames if 1 <= t <= self._max_step_frames})
+        max_frame = min(self._stream_chunk_frames, self._max_step_frames)
+        return list(range(1, max_frame + 1))
 
     def _codec_on_cuda(self) -> bool:
         try:

--- a/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
+++ b/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
@@ -982,6 +982,32 @@ def test_create_vocoder_executor_threads_cuda_graph_config(monkeypatch) -> None:
     assert scheduler2._cuda_graph_min_free_gb == 7.0
 
 
+def test_default_cuda_graph_frames_cover_stream_chunk_exactly(monkeypatch) -> None:
+    captured: list[list[int]] = []
+    monkeypatch.setattr(
+        MossTTSLocalStreamingVocoderScheduler, "_codec_on_cuda", lambda self: True
+    )
+
+    def fake_warmup(self, frames, *, min_free_gb: float = 3.0) -> list[int]:
+        self.warmup_attempted = True
+        captured.append(list(frames))
+        self._cg_runner = _FakeCudaGraphRunner(frames)
+        return self._cg_runner.captured_frames()
+
+    monkeypatch.setattr(_CodecStreamSession, "warmup_cuda_graph", fake_warmup)
+
+    scheduler = _make_scheduler(
+        monkeypatch,
+        FakeProcessor(),
+        stream_chunk_frames=4,
+        initial_chunk_frames=2,
+    )
+
+    assert captured == [[1, 2, 3, 4]]
+    assert scheduler._session is not None
+    assert scheduler._session.captured_frames() == [1, 2, 3, 4]
+
+
 def test_create_vocoder_executor_uses_separate_codec(monkeypatch) -> None:
     processor = FakeProcessor()
     codec = FakeCodec()


### PR DESCRIPTION
## Summary

This PR changes the default MOSS-TTS Local streaming vocoder CUDA graph capture set from a measured sparse set to exact coverage for every streaming step length from `T=1` through `stream_chunk_frames`.

The existing streaming vocoder CUDA graph path is already bit-identical for captured shapes because it captures one exact graph per step length and does not pad into larger buckets. The issue is coverage: the current default misses common small `T` values in the SeedTTS streaming workload, especially `T=1`, so many decode steps fall back to eager `_decode_frame`.

## Why

The previous default captured:

```text
T=[4, 5, 8, 9, 10, 11, 12, 13, 20, 22, 24, 25]
```

On the current MOSS-TTS Local streaming SeedTTS workload with `--token-count auto`, that only graphed `39.4%` of sampled decode steps. The remaining steps ran eager, which dominated TTFC, latency, and RTF.

The new default captures:

```text
T=[1, 2, 3, ..., 25]
```

for the default `stream_chunk_frames=25`. This keeps the same exact-shape CUDA graph semantics while covering the full normal streaming step range.

## Implementation

- Keep `cuda_graph_frames` as the explicit override.
- When `cuda_graph_frames=None`, capture every exact step length in `1..min(stream_chunk_frames, max_step_frames)`.
- Keep the existing low-VRAM guard and eager fallback behavior.
- Keep the no-padding invariant from the original CUDA graph implementation.
- Add a unit test that verifies the default capture set covers every exact streaming chunk length.

## Correctness

This does not introduce a new numerical path. It changes only which exact `T` shapes are warmed up for the existing graph replay path.

The CUDA graph runner still:

- captures one graph per exact `T`
- does not pad into bucketed shapes
- replays the same stateful codec decode path
- falls back to eager if capture fails or VRAM headroom is insufficient

GPU bit-identity was checked on the real codec path. The first attempt failed because the host could not build cuDNN SDPA execution plans during graph capture; rerunning with cuDNN SDPA disabled allowed graph capture and the bit-identity gate passed:

```text
15 passed
```

An additional default-shape identity harness compared graph replay against eager on the real codec for every `T=1..25` and active slot counts `1` and `8`:

```text
captured: all T=1..25
cases: 50
passed: 50
failed: 0
max_abs_overall: 0.0
```

Branches:

| branch | commit | output |
|---|---|---|
| `upstream/main` | `1ad75cc1` | `/data/moss_streaming_ab_upstream_main_c8` |
| `perf/moss-streaming-full-cg` | `2ac4d955` | `/data/moss_streaming_ab_full_cg_c8` |

## Results

| metric | upstream/main | this PR | delta | delta % |
|---|---:|---:|---:|---:|
| completed | 1088 | 1088 | 0 | 0.00% |
| failed | 0 | 0 | 0 |  |
| qps | 2.561 | 4.651 | +2.090 | +81.61% |
| rtf_mean | 0.7479 | 0.4014 | -0.3465 | -46.33% |
| rtf_p95 | 1.0991 | 0.5466 | -0.5525 | -50.27% |
| rtf_p99 | 1.2747 | 0.6776 | -0.5971 | -46.84% |
| latency_mean_s | 3.118 | 1.716 | -1.402 | -44.96% |
| latency_p95_s | 3.701 | 2.365 | -1.336 | -36.10% |
| latency_p99_s | 4.021 | 2.712 | -1.309 | -32.55% |
| audio_throughput_s_per_s | 11.272 | 20.470 | +9.198 | +81.60% |
| ttfc_mean_s | 2.3187 | 0.5251 | -1.7936 | -77.35% |
| audio_chunks_mean | 6.31 | 9.64 | +3.33 | +52.77% |
| WER corpus | 2.0347% | 2.2607% | +0.2261 pp | +11.11% |
| WER below 50 | 1.7057% | 1.7588% | +0.0531 pp | +3.11% |
| >50% WER outliers | 5 | 5 | 0 | 0.00% |
| UTMOS mean | 3.9642 | 3.9567 | -0.0075 | -0.19% |
| speaker similarity mean | 65.4003 | 65.4505 | +0.0502 | +0.08% |

## Graph Coverage

`upstream/main`:

```text
MOSS vocoder CUDA graphs captured at startup: T=[4, 5, 8, 9, 10, 11, 12, 13, 20, 22, 24, 25]
MOSS vocoder CG stats: 787/2000 steps graphed (39.4%); graph T={4: 13, 5: 74, 8: 63, 9: 61, 10: 44, 11: 44, 12: 65, 13: 32, 20: 57, 22: 65, 24: 99, 25: 170} eager T={1: 622, 2: 10, 3: 11, 6: 88, 7: 98, 14: 43, 15: 41, 16: 53, 17: 38, 18: 56, 19: 40, 21: 60, 23: 53}
```

This PR:

```text
MOSS vocoder CUDA graphs captured at startup: T=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
MOSS vocoder CG stats: 2000/2000 steps graphed (100.0%); graph T={1: 767, 2: 6, 3: 10, 4: 15, 5: 65, 6: 89, 7: 47, 8: 72, 9: 59, 10: 58, 11: 62, 12: 50, 13: 50, 14: 75, 15: 55, 16: 55, 17: 64, 18: 63, 19: 64, 20: 66, 21: 56, 22: 59, 23: 44, 24: 44, 25: 5} eager T={}
```

## Audio Integrity

| metric | upstream/main | this PR |
|---|---:|---:|
| wav files | 1088 | 1088 |
| read errors | 0 | 0 |
| silent / empty | 0 | 0 |
| clipped count | 35 | 40 |
| sample rate | 48000 for all | 48000 for all |
| channels | mono for all | mono for all |
| duration min / mean / max | 2.48 / 4.401 / 9.36s | 2.48 / 4.401 / 9.36s |
| >30s long files | 0 | 0 |

## Memory

| metric | upstream/main | this PR |
|---|---:|---:|
| before server | 4 MiB used / 81076 MiB free | 4 MiB used / 81076 MiB free |
| after health + graph capture | 69253 MiB used / 11827 MiB free | 69723 MiB used / 11357 MiB free |
| sampled peak during n200 | 70501 MiB used / 10579 MiB free | 70739 MiB used / 10341 MiB free |
| after stop | 4 MiB used / 81076 MiB free | 4 MiB used / 81076 MiB free |

Candidate memory cost:

- `+470 MiB` after startup graph capture
- `+238 MiB` sampled peak during n200 generation
- no VRAM guard trip, graph skip, OOM, or out-of-memory log lines observed

## Notes

- The WER corpus difference is small and the below-50 WER delta is `+0.053 pp`; outlier count is unchanged.
- UTMOS and speaker similarity remain effectively tied.
- The duration distribution is unchanged, and no silent, empty, missing, unreadable, or long-runaway outputs were observed.
- The speedup comes from eliminating eager streaming decode fallbacks, not from changing the codec math.
