### PR TITLE
Gate TTS voice-copy on paired similarity margin

### DIFF
--- a/.claude/skills/tune-ci-thresholds/AGENT-PRECHECK.md
+++ b/.claude/skills/tune-ci-thresholds/AGENT-PRECHECK.md
@@ -208,7 +208,7 @@ ls "$HF/hub" 2>/dev/null | rg -i 'qwen3|higgs|seed-tts|video|mmmu|mmsu|marksverd
 
 Expected repos by model (precheck validates each):
 
-**`tts`:** models `boson-sglang/higgs-audio-v3-TTS-4B-grpo05200410999`,
+**`tts`:** models `bosonai/higgs-audio-v3-tts-4b`,
 `Qwen/Qwen3-ASR-1.7B`; dataset `zhaochenyang20/seed-tts-eval-arrow`.
 
 **`qwen3-omni-v1` (adds):** models `Qwen/Qwen3-Omni-30B-A3B-Instruct`,

--- a/.claude/skills/tune-ci-thresholds/models/qwen3-omni-v1/config.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/qwen3-omni-v1/config.yaml
@@ -210,6 +210,9 @@ metric_sources:
       wer:
         total: "vc_nonstream0/wer_results.json::summary.total_samples"
         ok: "vc_nonstream0/wer_results.json::summary.evaluated"
+      similarity:
+        total: "vc_nonstream0/voice_copy_margin_results.json::summary.total_samples"
+        ok: "vc_nonstream0/voice_copy_margin_results.json::summary.evaluated"
       utmos:
         total: "vc_nonstream0/utmos_results.json::summary.total_samples"
         ok: "vc_nonstream0/utmos_results.json::summary.evaluated"
@@ -224,4 +227,5 @@ metric_sources:
       per_sample_wer_max: "vc_nonstream0/wer_results.json::summary.wer_per_sample_max"
       wer_below_50_corpus: "vc_nonstream0/wer_results.json::summary.wer_below_50_corpus"
       n_above_50: "vc_nonstream0/wer_results.json::summary.n_above_50_pct_wer"
+      similarity_margin: "vc_nonstream0/voice_copy_margin_results.json::summary.speaker_similarity_margin_mean"
       utmos_mean: "vc_nonstream0/utmos_results.json::summary.utmos_mean"

--- a/.claude/skills/tune-ci-thresholds/models/qwen3-omni-v1/stages.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/qwen3-omni-v1/stages.yaml
@@ -417,9 +417,8 @@ tts_wer:
   group: wer
   extra_env: {}
   context_vars:
-    - MAX_SAMPLES
     - CONCURRENCY
-  test_file_sha256: f118b29d905975eb11c2c83cd5ed90bdf94d04b5c267b36d1f924ac8d7c4c909
+  test_file_sha256: 0190ac8527e0d28dd444b05b708738c95d8fbbdca372e6a02d9e7503a7a5f1dc
   last_discovered_at: 2026-06-27T11:49:15Z
   expected_samples: 50
   sample_counts:
@@ -450,15 +449,42 @@ tts_wer:
         scale: 1
         digits: 0
       status: OK
+tts_similarity:
+  test: tests/test_model/test_qwen3_omni_tts_ci.py
+  title: "TTS Similarity"
+  group: similarity
+  extra_env: {}
+  context_vars:
+    - CONCURRENCY
+  test_file_sha256: 0190ac8527e0d28dd444b05b708738c95d8fbbdca372e6a02d9e7503a7a5f1dc
+  last_discovered_at: 2026-06-27T11:49:15Z
+  expected_samples: 20
+  sample_counts:
+    total:
+      json_file: "vc_nonstream0/voice_copy_margin_results.json"
+      json_path: "summary.total_samples"
+    ok:
+      json_file: "vc_nonstream0/voice_copy_margin_results.json"
+      json_path: "summary.evaluated"
+  metrics:
+    similarity_margin:
+      source: "VC_SIMILARITY_MARGIN_MIN"
+      json_file: "vc_nonstream0/voice_copy_margin_results.json"
+      json_path: "summary.speaker_similarity_margin_mean"
+      worst: min
+      display:
+        label: "Speaker sim margin"
+        scale: 1
+        digits: 4
+      status: OK
 tts_utmos:
   test: tests/test_model/test_qwen3_omni_tts_ci.py
   title: "TTS Utmos"
   group: utmos
   extra_env: {}
   context_vars:
-    - MAX_SAMPLES
     - CONCURRENCY
-  test_file_sha256: f118b29d905975eb11c2c83cd5ed90bdf94d04b5c267b36d1f924ac8d7c4c909
+  test_file_sha256: 0190ac8527e0d28dd444b05b708738c95d8fbbdca372e6a02d9e7503a7a5f1dc
   last_discovered_at: 2026-06-27T11:49:15Z
   expected_samples: 50
   sample_counts:
@@ -485,9 +511,8 @@ tts_speed:
   group: speed
   extra_env: {}
   context_vars:
-    - MAX_SAMPLES
     - CONCURRENCY
-  test_file_sha256: f118b29d905975eb11c2c83cd5ed90bdf94d04b5c267b36d1f924ac8d7c4c909
+  test_file_sha256: 0190ac8527e0d28dd444b05b708738c95d8fbbdca372e6a02d9e7503a7a5f1dc
   last_discovered_at: 2026-06-27T11:49:15Z
   expected_samples: 50
   sample_counts:

--- a/.claude/skills/tune-ci-thresholds/models/tts/config.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/tts/config.yaml
@@ -20,7 +20,7 @@
 #   STREAMING_BENCHMARK_MAX_SAMPLES = None  (full SeedTTS EN set for streaming)
 # - Voice-clone artifacts live under per-variant dirs in pytest tmp_path:
 #   vc_nonstream_c16/ and vc_stream_c16/ (speed_results.json, wer_results.json,
-#   similarity_results.json and utmos_results.json for nonstream).
+#   voice_copy_margin_results.json and utmos_results.json for nonstream).
 # - WER thresholds are corpus-level only; each TTS preset has its own symbol
 #   namespace in tts_ci_config.py (Higgs: HIGGS_VC_* / _HIGGS_VC_*; MOSS:
 #   MOSS_VC_* / _MOSS_VC_*). Per-sample WER caps and generation failure
@@ -137,8 +137,8 @@ metric_sources:
             total: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json::summary.total_samples"
             ok: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json::summary.evaluated"
           similarity:
-            total: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json::summary.total_samples"
-            ok: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json::summary.evaluated"
+            total: "test_voice_cloning_non_streami0/vc_nonstream_c16/voice_copy_margin_results.json::summary.total_samples"
+            ok: "test_voice_cloning_non_streami0/vc_nonstream_c16/voice_copy_margin_results.json::summary.evaluated"
           utmos:
             total: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json::summary.total_samples"
             ok: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json::summary.evaluated"
@@ -148,7 +148,7 @@ metric_sources:
           latency_mean_s: "summary.latency_mean_s"
           rtf_mean: "summary.rtf_mean"
           corpus_wer: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json::summary.wer_corpus"
-          similarity_mean: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json::summary.speaker_similarity_mean"
+          similarity_margin: "test_voice_cloning_non_streami0/vc_nonstream_c16/voice_copy_margin_results.json::summary.speaker_similarity_margin_mean"
           utmos_mean: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json::summary.utmos_mean"
       stream:
         constant_filter: "^HIGGS_VC_STREAM_.*$|^MOSS_VC_STREAM_.*$"

--- a/.claude/skills/tune-ci-thresholds/models/tts/config.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/tts/config.yaml
@@ -37,12 +37,12 @@
 #   weights are already present in the configured HF cache.
 name: tts
 description: "TTS CI (Qwen3-ASR + Higgs/MOSS SeedTTS EN)"
-hf_model_id: "boson-sglang/higgs-audio-v3-TTS-4B-grpo05200410999"
+hf_model_id: "bosonai/higgs-audio-v3-tts-4b"
 hf_model_ids_by_test:
   test_qwen3_asr_ci.py:
     - "Qwen/Qwen3-ASR-1.7B"
   test_tts_ci.py:
-    - "boson-sglang/higgs-audio-v3-TTS-4B-grpo05200410999"
+    - "bosonai/higgs-audio-v3-tts-4b"
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
 hf_datasets:
@@ -107,7 +107,7 @@ metric_sources:
         # discover: only Higgs HIGGS_VC_* constants (never MOSS_VC_*)
         constant_filter: "^HIGGS_VC_"
         hf_model_ids:
-          - "boson-sglang/higgs-audio-v3-TTS-4B-grpo05200410999"
+          - "bosonai/higgs-audio-v3-tts-4b"
           - "Qwen/Qwen3-ASR-1.7B"
       moss:
         extra_env:

--- a/.claude/skills/tune-ci-thresholds/models/tts/stages.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/tts/stages.yaml
@@ -118,11 +118,11 @@ tts_higgs_nonstream_wer:
   hf_model_ids:
     - "bosonai/higgs-audio-v3-tts-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: 7152ca23fd4963c64ca3e1a6ba3c027e0a5416203e8890eec0a7a68dbfbddd97
+  test_file_sha256: 3cce551489af28e58279e7469842965dab19a8db079a057b890a5b00b5054c9f
   last_discovered_at: 2026-06-27T17:42:01Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: c875e225655cafe55028fbdabfe9e760e643fc468b04abf732a3e0c7d40710d3
+  threshold_file_sha256: 91f84233f90a630b01cca2ddba43460bdc7f86ede83188c29d20cc171846aaa9
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json"
@@ -154,26 +154,26 @@ tts_higgs_nonstream_similarity:
   hf_model_ids:
     - "bosonai/higgs-audio-v3-tts-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: 7152ca23fd4963c64ca3e1a6ba3c027e0a5416203e8890eec0a7a68dbfbddd97
+  test_file_sha256: 3cce551489af28e58279e7469842965dab19a8db079a057b890a5b00b5054c9f
   last_discovered_at: 2026-06-27T17:42:01Z
   expected_samples: 50
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: c875e225655cafe55028fbdabfe9e760e643fc468b04abf732a3e0c7d40710d3
+  threshold_file_sha256: 91f84233f90a630b01cca2ddba43460bdc7f86ede83188c29d20cc171846aaa9
   sample_counts:
     total:
-      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/voice_copy_margin_results.json"
       json_path: "summary.total_samples"
     ok:
-      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/voice_copy_margin_results.json"
       json_path: "summary.evaluated"
   metrics:
-    similarity_mean:
-      source: "HIGGS_VC_SIMILARITY_MEAN_MIN"
-      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
-      json_path: "summary.speaker_similarity_mean"
+    similarity_margin:
+      source: "HIGGS_VC_SIMILARITY_MARGIN_MIN"
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/voice_copy_margin_results.json"
+      json_path: "summary.speaker_similarity_margin_mean"
       worst: min
       display:
-        label: "Speaker sim mean"
+        label: "Speaker sim margin"
         scale: 1
         digits: 4
       status: OK
@@ -190,11 +190,11 @@ tts_higgs_nonstream_utmos:
   hf_model_ids:
     - "bosonai/higgs-audio-v3-tts-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: 7152ca23fd4963c64ca3e1a6ba3c027e0a5416203e8890eec0a7a68dbfbddd97
+  test_file_sha256: 3cce551489af28e58279e7469842965dab19a8db079a057b890a5b00b5054c9f
   last_discovered_at: 2026-06-27T17:42:01Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: c875e225655cafe55028fbdabfe9e760e643fc468b04abf732a3e0c7d40710d3
+  threshold_file_sha256: 91f84233f90a630b01cca2ddba43460bdc7f86ede83188c29d20cc171846aaa9
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json"
@@ -226,11 +226,11 @@ tts_higgs_nonstream_speed:
   hf_model_ids:
     - "bosonai/higgs-audio-v3-tts-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: 7152ca23fd4963c64ca3e1a6ba3c027e0a5416203e8890eec0a7a68dbfbddd97
+  test_file_sha256: 3cce551489af28e58279e7469842965dab19a8db079a057b890a5b00b5054c9f
   last_discovered_at: 2026-06-27T17:42:01Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: c875e225655cafe55028fbdabfe9e760e643fc468b04abf732a3e0c7d40710d3
+  threshold_file_sha256: 91f84233f90a630b01cca2ddba43460bdc7f86ede83188c29d20cc171846aaa9
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
@@ -292,11 +292,11 @@ tts_moss_nonstream_wer:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: 7152ca23fd4963c64ca3e1a6ba3c027e0a5416203e8890eec0a7a68dbfbddd97
+  test_file_sha256: 3cce551489af28e58279e7469842965dab19a8db079a057b890a5b00b5054c9f
   last_discovered_at: 2026-06-27T17:42:01Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: c875e225655cafe55028fbdabfe9e760e643fc468b04abf732a3e0c7d40710d3
+  threshold_file_sha256: 91f84233f90a630b01cca2ddba43460bdc7f86ede83188c29d20cc171846aaa9
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json"
@@ -328,26 +328,26 @@ tts_moss_nonstream_similarity:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: 7152ca23fd4963c64ca3e1a6ba3c027e0a5416203e8890eec0a7a68dbfbddd97
+  test_file_sha256: 3cce551489af28e58279e7469842965dab19a8db079a057b890a5b00b5054c9f
   last_discovered_at: 2026-06-27T17:42:01Z
   expected_samples: 50
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: c875e225655cafe55028fbdabfe9e760e643fc468b04abf732a3e0c7d40710d3
+  threshold_file_sha256: 91f84233f90a630b01cca2ddba43460bdc7f86ede83188c29d20cc171846aaa9
   sample_counts:
     total:
-      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/voice_copy_margin_results.json"
       json_path: "summary.total_samples"
     ok:
-      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/voice_copy_margin_results.json"
       json_path: "summary.evaluated"
   metrics:
-    similarity_mean:
-      source: "MOSS_VC_SIMILARITY_MEAN_MIN"
-      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
-      json_path: "summary.speaker_similarity_mean"
+    similarity_margin:
+      source: "MOSS_VC_SIMILARITY_MARGIN_MIN"
+      json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/voice_copy_margin_results.json"
+      json_path: "summary.speaker_similarity_margin_mean"
       worst: min
       display:
-        label: "Speaker sim mean"
+        label: "Speaker sim margin"
         scale: 1
         digits: 4
       status: OK
@@ -364,11 +364,11 @@ tts_moss_nonstream_utmos:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: 7152ca23fd4963c64ca3e1a6ba3c027e0a5416203e8890eec0a7a68dbfbddd97
+  test_file_sha256: 3cce551489af28e58279e7469842965dab19a8db079a057b890a5b00b5054c9f
   last_discovered_at: 2026-06-27T17:42:01Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: c875e225655cafe55028fbdabfe9e760e643fc468b04abf732a3e0c7d40710d3
+  threshold_file_sha256: 91f84233f90a630b01cca2ddba43460bdc7f86ede83188c29d20cc171846aaa9
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json"
@@ -400,11 +400,11 @@ tts_moss_nonstream_speed:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: 7152ca23fd4963c64ca3e1a6ba3c027e0a5416203e8890eec0a7a68dbfbddd97
+  test_file_sha256: 3cce551489af28e58279e7469842965dab19a8db079a057b890a5b00b5054c9f
   last_discovered_at: 2026-06-27T17:42:01Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: c875e225655cafe55028fbdabfe9e760e643fc468b04abf732a3e0c7d40710d3
+  threshold_file_sha256: 91f84233f90a630b01cca2ddba43460bdc7f86ede83188c29d20cc171846aaa9
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
@@ -466,11 +466,11 @@ tts_higgs_stream_wer:
   hf_model_ids:
     - "bosonai/higgs-audio-v3-tts-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: 7152ca23fd4963c64ca3e1a6ba3c027e0a5416203e8890eec0a7a68dbfbddd97
+  test_file_sha256: 3cce551489af28e58279e7469842965dab19a8db079a057b890a5b00b5054c9f
   last_discovered_at: 2026-06-27T17:42:01Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: c875e225655cafe55028fbdabfe9e760e643fc468b04abf732a3e0c7d40710d3
+  threshold_file_sha256: 91f84233f90a630b01cca2ddba43460bdc7f86ede83188c29d20cc171846aaa9
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/wer_results.json"
@@ -502,11 +502,11 @@ tts_higgs_stream_speed:
   hf_model_ids:
     - "bosonai/higgs-audio-v3-tts-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: 7152ca23fd4963c64ca3e1a6ba3c027e0a5416203e8890eec0a7a68dbfbddd97
+  test_file_sha256: 3cce551489af28e58279e7469842965dab19a8db079a057b890a5b00b5054c9f
   last_discovered_at: 2026-06-27T17:42:01Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: c875e225655cafe55028fbdabfe9e760e643fc468b04abf732a3e0c7d40710d3
+  threshold_file_sha256: 91f84233f90a630b01cca2ddba43460bdc7f86ede83188c29d20cc171846aaa9
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"
@@ -558,11 +558,11 @@ tts_moss_stream_wer:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: 7152ca23fd4963c64ca3e1a6ba3c027e0a5416203e8890eec0a7a68dbfbddd97
+  test_file_sha256: 3cce551489af28e58279e7469842965dab19a8db079a057b890a5b00b5054c9f
   last_discovered_at: 2026-06-27T17:42:01Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: c875e225655cafe55028fbdabfe9e760e643fc468b04abf732a3e0c7d40710d3
+  threshold_file_sha256: 91f84233f90a630b01cca2ddba43460bdc7f86ede83188c29d20cc171846aaa9
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/wer_results.json"
@@ -594,11 +594,11 @@ tts_moss_stream_speed:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: 7152ca23fd4963c64ca3e1a6ba3c027e0a5416203e8890eec0a7a68dbfbddd97
+  test_file_sha256: 3cce551489af28e58279e7469842965dab19a8db079a057b890a5b00b5054c9f
   last_discovered_at: 2026-06-27T17:42:01Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: c875e225655cafe55028fbdabfe9e760e643fc468b04abf732a3e0c7d40710d3
+  threshold_file_sha256: 91f84233f90a630b01cca2ddba43460bdc7f86ede83188c29d20cc171846aaa9
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"

--- a/.claude/skills/tune-ci-thresholds/models/tts/stages.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/tts/stages.yaml
@@ -116,7 +116,7 @@ tts_higgs_nonstream_wer:
   calibration_preset: "higgs"
   gpus: 2
   hf_model_ids:
-    - "boson-sglang/higgs-audio-v3-TTS-4B-grpo05200410999"
+    - "bosonai/higgs-audio-v3-tts-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 7152ca23fd4963c64ca3e1a6ba3c027e0a5416203e8890eec0a7a68dbfbddd97
   last_discovered_at: 2026-06-27T17:42:01Z
@@ -152,7 +152,7 @@ tts_higgs_nonstream_similarity:
   calibration_preset: "higgs"
   gpus: 2
   hf_model_ids:
-    - "boson-sglang/higgs-audio-v3-TTS-4B-grpo05200410999"
+    - "bosonai/higgs-audio-v3-tts-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 7152ca23fd4963c64ca3e1a6ba3c027e0a5416203e8890eec0a7a68dbfbddd97
   last_discovered_at: 2026-06-27T17:42:01Z
@@ -188,7 +188,7 @@ tts_higgs_nonstream_utmos:
   calibration_preset: "higgs"
   gpus: 2
   hf_model_ids:
-    - "boson-sglang/higgs-audio-v3-TTS-4B-grpo05200410999"
+    - "bosonai/higgs-audio-v3-tts-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 7152ca23fd4963c64ca3e1a6ba3c027e0a5416203e8890eec0a7a68dbfbddd97
   last_discovered_at: 2026-06-27T17:42:01Z
@@ -224,7 +224,7 @@ tts_higgs_nonstream_speed:
   calibration_preset: "higgs"
   gpus: 2
   hf_model_ids:
-    - "boson-sglang/higgs-audio-v3-TTS-4B-grpo05200410999"
+    - "bosonai/higgs-audio-v3-tts-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 7152ca23fd4963c64ca3e1a6ba3c027e0a5416203e8890eec0a7a68dbfbddd97
   last_discovered_at: 2026-06-27T17:42:01Z
@@ -464,7 +464,7 @@ tts_higgs_stream_wer:
   calibration_preset: "higgs"
   gpus: 2
   hf_model_ids:
-    - "boson-sglang/higgs-audio-v3-TTS-4B-grpo05200410999"
+    - "bosonai/higgs-audio-v3-tts-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 7152ca23fd4963c64ca3e1a6ba3c027e0a5416203e8890eec0a7a68dbfbddd97
   last_discovered_at: 2026-06-27T17:42:01Z
@@ -500,7 +500,7 @@ tts_higgs_stream_speed:
   calibration_preset: "higgs"
   gpus: 2
   hf_model_ids:
-    - "boson-sglang/higgs-audio-v3-TTS-4B-grpo05200410999"
+    - "bosonai/higgs-audio-v3-tts-4b"
     - "Qwen/Qwen3-ASR-1.7B"
   test_file_sha256: 7152ca23fd4963c64ca3e1a6ba3c027e0a5416203e8890eec0a7a68dbfbddd97
   last_discovered_at: 2026-06-27T17:42:01Z

--- a/.claude/skills/tune-ci-thresholds/tune.py
+++ b/.claude/skills/tune-ci-thresholds/tune.py
@@ -100,6 +100,7 @@ METRIC_SPECS = {
     "rtf_p95":              dict(worst="max", label="RTF p95",               digits=4, scale=1,   group="speed"),
     "failed_requests":      dict(worst="max", label="Failed requests",       digits=0, scale=1,   group="reliability"),
     "similarity_mean":      dict(worst="min", label="Speaker sim mean",      digits=4, scale=1,   group="similarity"),
+    "similarity_margin":    dict(worst="min", label="Speaker sim margin",    digits=4, scale=1,   group="similarity"),
     "utmos_mean":           dict(worst="min", label="UTMOS mean",            digits=4, scale=1,   group="utmos"),
 }
 _NESTED = {
@@ -145,6 +146,7 @@ _BENCHMARK_PATH_OVERRIDES = {
 _TTS_FIXED_PRESETS = frozenset({
     "SEEDTTS_EN_FULLSET_SAMPLES",
     "TTS_SIMILARITY_MAX_SAMPLES",
+    "SIMILARITY_MARGIN_MAX_SAMPLES",
     "STREAMING_BENCHMARK_MAX_SAMPLES",
 })
 
@@ -162,6 +164,8 @@ def match_metric(name, nested):
     if "N_ABOVE_50_MAX" in name: return "n_above_50"
     if name == "TTS_MAX_FAILED_REQUESTS" or "MAX_FAILED_REQUESTS" in name:
         return "failed_requests"
+    if "SIMILARITY_MARGIN" in name and name.endswith("_MIN"):
+        return "similarity_margin"
     if "SIMILARITY" in name and name.endswith("_MIN"):
         return "similarity_mean"
     if "UTMOS" in name and name.endswith("_REFERENCE"):
@@ -1110,12 +1114,20 @@ def _expected_samples(
     context_vars: list[str] | None,
 ) -> int | None:
     """Resolve CI sample scope from test-file constants (written to stages.yaml)."""
-    for const_name in context_vars or []:
-        value = _int_constant(tree, const_name)
-        if isinstance(value, int):
-            return value
     if group == "similarity":
-        value = _int_constant(tree, "TTS_SIMILARITY_MAX_SAMPLES")
+        for name in ("SIMILARITY_MARGIN_MAX_SAMPLES", "TTS_SIMILARITY_MAX_SAMPLES"):
+            value = _int_constant(tree, name)
+            if isinstance(value, int):
+                return value
+    if group in ("wer", "speed", "utmos"):
+        for name in ("MAX_SAMPLES", "SEEDTTS_EN_FULLSET_SAMPLES"):
+            value = _int_constant(tree, name)
+            if isinstance(value, int):
+                return value
+    for const_name in context_vars or []:
+        if "CONCURRENCY" in const_name:
+            continue
+        value = _int_constant(tree, const_name)
         if isinstance(value, int):
             return value
     if variant == "stream":
@@ -1125,10 +1137,6 @@ def _expected_samples(
         fullset = _int_constant(tree, "SEEDTTS_EN_FULLSET_SAMPLES")
         if isinstance(fullset, int):
             return fullset
-    if group in ("wer", "speed", "utmos"):
-        value = _int_constant(tree, "SEEDTTS_EN_FULLSET_SAMPLES")
-        if isinstance(value, int):
-            return value
     value = _int_constant(tree, "SEEDTTS_ASR_CORRECTNESS_SAMPLES")
     if isinstance(value, int):
         return value

--- a/benchmarks/metrics/voice_copy_margin.py
+++ b/benchmarks/metrics/voice_copy_margin.py
@@ -6,11 +6,12 @@ from __future__ import annotations
 import json
 import os
 
-
 VOICE_COPY_MARGIN_RESULTS_FILENAME = "voice_copy_margin_results.json"
 
 
-def _index_similarity_rows(results: dict, label: str) -> tuple[dict[str, dict], list[str]]:
+def _index_similarity_rows(
+    results: dict, label: str
+) -> tuple[dict[str, dict], list[str]]:
     rows = results.get("per_sample")
     if not isinstance(rows, list):
         raise ValueError(f"{label} similarity results must contain a per_sample list")

--- a/benchmarks/metrics/voice_copy_margin.py
+++ b/benchmarks/metrics/voice_copy_margin.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Paired speaker-similarity margin utilities for voice-copy benchmarks."""
+
+from __future__ import annotations
+
+import json
+import os
+
+
+VOICE_COPY_MARGIN_RESULTS_FILENAME = "voice_copy_margin_results.json"
+
+
+def _index_similarity_rows(results: dict, label: str) -> tuple[dict[str, dict], list[str]]:
+    rows = results.get("per_sample")
+    if not isinstance(rows, list):
+        raise ValueError(f"{label} similarity results must contain a per_sample list")
+
+    indexed: dict[str, dict] = {}
+    ordered_ids: list[str] = []
+    for idx, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise ValueError(f"{label} per_sample[{idx}] must be an object")
+        sample_id = row.get("id") or row.get("sample_id")
+        if not isinstance(sample_id, str) or not sample_id:
+            raise ValueError(f"{label} per_sample[{idx}] is missing a sample id")
+        if sample_id in indexed:
+            raise ValueError(
+                f"{label} similarity results contain duplicate id {sample_id}"
+            )
+        indexed[sample_id] = row
+        ordered_ids.append(sample_id)
+    return indexed, ordered_ids
+
+
+def _speaker_similarity_score(row: dict | None, label: str) -> tuple[float | None, str]:
+    if row is None:
+        return None, f"{label} row missing"
+    score = row.get("speaker_similarity")
+    if row.get("is_success") is not True:
+        return None, str(row.get("error") or f"{label} similarity row failed")
+    if isinstance(score, bool) or not isinstance(score, (int, float)):
+        return None, f"{label} speaker_similarity missing"
+    return float(score), ""
+
+
+def _save_json_results(results: dict, output_dir: str, filename: str) -> str:
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, filename)
+    with open(path, "w") as f:
+        json.dump(results, f, indent=2, ensure_ascii=False)
+    return path
+
+
+def compute_seedtts_voice_copy_margin(
+    copy_similarity_results: dict,
+    no_copy_similarity_results: dict,
+    *,
+    output_dir: str | None = None,
+) -> dict:
+    """Compute paired SeedTTS voice-copy similarity margin by sample id."""
+    copy_by_id, ordered_ids = _index_similarity_rows(
+        copy_similarity_results, "voice-copy"
+    )
+    no_copy_by_id, no_copy_ordered_ids = _index_similarity_rows(
+        no_copy_similarity_results, "no-copy"
+    )
+    for sample_id in no_copy_ordered_ids:
+        if sample_id not in copy_by_id:
+            ordered_ids.append(sample_id)
+
+    margins: list[float] = []
+    copy_scores: list[float] = []
+    no_copy_scores: list[float] = []
+    per_sample: list[dict] = []
+
+    for sample_id in ordered_ids:
+        copy_row = copy_by_id.get(sample_id)
+        no_copy_row = no_copy_by_id.get(sample_id)
+        copy_score, copy_error = _speaker_similarity_score(copy_row, "voice-copy")
+        no_copy_score, no_copy_error = _speaker_similarity_score(no_copy_row, "no-copy")
+
+        base_row = {
+            "id": sample_id,
+            "ref_audio": (copy_row or no_copy_row or {}).get("ref_audio"),
+            "copy_wav_path": (copy_row or {}).get("wav_path"),
+            "no_copy_wav_path": (no_copy_row or {}).get("wav_path"),
+            "copy_similarity": copy_score,
+            "no_copy_similarity": no_copy_score,
+        }
+        if copy_score is None or no_copy_score is None:
+            errors = [error for error in (copy_error, no_copy_error) if error]
+            per_sample.append(
+                {
+                    **base_row,
+                    "speaker_similarity_margin": None,
+                    "is_success": False,
+                    "error": "; ".join(errors),
+                }
+            )
+            continue
+
+        margin = copy_score - no_copy_score
+        margins.append(margin)
+        copy_scores.append(copy_score)
+        no_copy_scores.append(no_copy_score)
+        per_sample.append(
+            {
+                **base_row,
+                "speaker_similarity_margin": margin,
+                "is_success": True,
+                "error": None,
+            }
+        )
+
+    if not margins:
+        raise RuntimeError(
+            "SeedTTS voice-copy margin: no paired scoreable samples "
+            f"({len(per_sample)} skipped)."
+        )
+
+    summary = {
+        "speaker_similarity_copy_mean": sum(copy_scores) / len(copy_scores),
+        "speaker_similarity_no_copy_mean": sum(no_copy_scores) / len(no_copy_scores),
+        "speaker_similarity_margin_mean": sum(margins) / len(margins),
+        "speaker_similarity_margin_min": min(margins),
+        "speaker_similarity_margin_max": max(margins),
+        "total_samples": len(per_sample),
+        "evaluated": len(margins),
+        "skipped": len(per_sample) - len(margins),
+    }
+    results = {
+        "summary": summary,
+        "config": {
+            "copy_total_samples": copy_similarity_results.get("summary", {}).get(
+                "total_samples"
+            ),
+            "no_copy_total_samples": no_copy_similarity_results.get("summary", {}).get(
+                "total_samples"
+            ),
+        },
+        "per_sample": per_sample,
+    }
+    if output_dir is not None:
+        _save_json_results(results, output_dir, VOICE_COPY_MARGIN_RESULTS_FILENAME)
+    return results

--- a/benchmarks/tasks/tts.py
+++ b/benchmarks/tasks/tts.py
@@ -563,6 +563,7 @@ class SeedttsSimilarityConfig(Protocol):
     meta: str
     lang: str
     output_dir: str
+    max_samples: int | None
     device: str
     similarity_checkpoint: str | None
 

--- a/tests/test_model/test_qwen3_omni_tts_ci.py
+++ b/tests/test_model/test_qwen3_omni_tts_ci.py
@@ -24,6 +24,7 @@ from benchmarks.eval.benchmark_omni_seedtts import (
     run_omni_seedtts_benchmark,
 )
 from benchmarks.metrics.performance import print_speed_summary
+from benchmarks.metrics.voice_copy_margin import compute_seedtts_voice_copy_margin
 from benchmarks.metrics.wer import print_wer_summary
 from tests.test_model.omni_router_utils import (
     ManagedRouterHandle,
@@ -51,6 +52,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 CONCURRENCY = 16
 MAX_SAMPLES = 50
+SIMILARITY_MARGIN_MAX_SAMPLES = 20
 # Optional user override: a path to a custom fine-tuned WavLM checkpoint.
 # When unset, the bootstrapper in benchmarks.metrics.speaker_similarity_assets
 # auto-downloads the official weights into the shared cache directory.
@@ -74,6 +76,10 @@ VC_N_ABOVE_50_MAX = 0.0
 # five with the standard slack margin. See the "Speaker similarity
 # calibration" section of the PR description for the per-run numbers.
 VC_SIMILARITY_MEAN_MIN = 60.0
+# note (luojiaxuan): This is intentionally a margin floor, not a naked
+# similarity floor. tune-ci-thresholds should overwrite it from strict
+# worst-of-5 calibration once the CI-repro run is available.
+VC_SIMILARITY_MARGIN_MIN = 0.0
 # Calibrated from worst-of-5 full generate+score runs on SeedTTS-50 EN, H200 SXM.
 # worst-of-5 = 4.1924 · mean = 4.2575 · stdev = 0.0487
 VC_UTMOS_MEAN_REFERENCE = 4.2388
@@ -108,15 +114,18 @@ def _run_benchmark(
     port: int,
     meta: str,
     output_dir: str,
+    *,
+    voice_clone: bool = True,
+    max_samples: int = MAX_SAMPLES,
 ) -> dict:
     config = OmniSeedttsBenchmarkConfig(
         model="qwen3-omni",
         port=port,
         meta=meta,
         output_dir=output_dir,
-        max_samples=MAX_SAMPLES,
+        max_samples=max_samples,
         max_concurrency=CONCURRENCY,
-        voice_clone=True,
+        voice_clone=voice_clone,
     )
     speed_results = asyncio.run(run_omni_seedtts_benchmark(config))
     assert (
@@ -183,6 +192,7 @@ def _run_similarity(
     output_dir: str,
     checkpoint_path: str | None,
     *,
+    max_samples: int | None = None,
     device: str = "cuda:0",
 ) -> dict:
     """Compute SeedTTS speaker similarity in CI (mirrors WER subprocess pattern)."""
@@ -202,6 +212,8 @@ def _run_similarity(
     ]
     if checkpoint_path is not None:
         cmd += ["--similarity-checkpoint", checkpoint_path]
+    if max_samples is not None:
+        cmd += ["--max-samples", str(max_samples)]
 
     env = no_proxy_env()
     existing = env.get("PYTHONPATH", "")
@@ -350,6 +362,7 @@ class _SpeedArtifacts:
     """
 
     output_dir: str
+    no_copy_output_dir: str
     summary: dict
     per_request: list
 
@@ -362,6 +375,7 @@ def speed_artifacts(
 ) -> _SpeedArtifacts:
     """Run the speed benchmark once and expose its artifacts."""
     output_dir = str(tmp_path_factory.mktemp("vc_nonstream"))
+    no_copy_output_dir = str(tmp_path_factory.mktemp("vc_nocopy"))
     try:
         workers = router_get_json(qwen3_omni_bf16_colocated_server.port, "/workers")
         print_worker_snapshot("initial /workers snapshot", workers)
@@ -377,11 +391,20 @@ def speed_artifacts(
             dataset_repo,
             output_dir,
         )
+        no_copy_results = _run_benchmark(
+            qwen3_omni_router_server.port,
+            dataset_repo,
+            no_copy_output_dir,
+            voice_clone=False,
+            max_samples=SIMILARITY_MARGIN_MAX_SAMPLES,
+        )
+        assert no_copy_results.get("per_request"), "No-copy margin run produced no rows"
     except Exception:
         print_router_diagnostics(qwen3_omni_bf16_colocated_server)
         raise
     return _SpeedArtifacts(
         output_dir=output_dir,
+        no_copy_output_dir=no_copy_output_dir,
         summary=results["summary"],
         per_request=results["per_request"],
     )
@@ -448,7 +471,7 @@ def test_voice_cloning_non_streaming(
             "router worker traffic",
             assert_workers_served_requests,
             final_workers,
-            min_total_requests=MAX_SAMPLES,
+            min_total_requests=MAX_SAMPLES + SIMILARITY_MARGIN_MAX_SAMPLES,
         )
         checks.assert_all()
     except Exception:
@@ -482,45 +505,52 @@ def test_voice_cloning_wer(
 @pytest.mark.benchmark
 def test_voice_cloning_similarity(
     wer_audio_dir: str,
+    speed_artifacts: _SpeedArtifacts,
     dataset_repo: str,
     similarity_checkpoint: str | None,
 ) -> None:
-    """Speaker similarity for Qwen3-Omni voice-clone output.
-
-    Quality gating against ``VC_SIMILARITY_MEAN_MIN`` is intentionally
-    DISABLED while upstream issue sgl-project/sglang-omni#483 is open:
-    Qwen3-Omni currently emits a default voice (multimodal prompt
-    features do not reach talker prefill ``input_embeds``), so a
-    50-sample EN dry-run measures SIM mean ~3 vs ~64 for S2-Pro on the
-    same samples.
-
-    The test still runs and persists ``similarity_results.json`` so the
-    metric tracks longitudinally and will catch the day #483 is fixed.
-    Once #483 lands, swap the structural assert below back to
-    ``_assert_similarity_results(results, VC_SIMILARITY_MEAN_MIN)``.
-    """
-    results = _run_similarity(
+    """Gate voice-copy quality by paired similarity margin over no-copy."""
+    copy_results = _run_similarity(
         dataset_repo,
         wer_audio_dir,
         similarity_checkpoint,
+        max_samples=SIMILARITY_MARGIN_MAX_SAMPLES,
     )
-    # Structural sanity only — quality gate disabled per docstring above.
-    # `skipped == 0` is a structural assertion (generation succeeded and WAVs
-    # are on disk), not a voice-quality gate, so it stays enabled even while
-    # #483 keeps the similarity-mean assertion soft.
-    summary = results.get("summary", {})
-    checks = MetricCheckCollector("Qwen3-Omni speaker similarity structure")
+    no_copy_results = _run_similarity(
+        dataset_repo,
+        speed_artifacts.no_copy_output_dir,
+        similarity_checkpoint,
+        max_samples=SIMILARITY_MARGIN_MAX_SAMPLES,
+    )
+    margin_results = compute_seedtts_voice_copy_margin(
+        copy_results,
+        no_copy_results,
+        output_dir=wer_audio_dir,
+    )
+
+    summary = margin_results.get("summary", {})
+    checks = MetricCheckCollector("Qwen3-Omni voice-copy similarity margin")
     checks.check(
-        summary.get("speaker_similarity_mean") is not None,
-        "Missing speaker_similarity_mean in summary",
+        summary.get("evaluated") == SIMILARITY_MARGIN_MAX_SAMPLES,
+        f"similarity margin evaluated {summary.get('evaluated')} samples "
+        f"!= {SIMILARITY_MARGIN_MAX_SAMPLES}",
     )
     checks.check(
-        bool(results.get("per_sample")),
-        "Expected per-sample speaker similarity results",
+        summary.get("skipped") == 0,
+        f"similarity margin skipped {summary.get('skipped')} samples != 0",
     )
+    margin_mean = summary.get("speaker_similarity_margin_mean")
+    if margin_mean is None:
+        checks.fail("Missing speaker_similarity_margin_mean in summary")
+    else:
+        checks.check(
+            margin_mean >= VC_SIMILARITY_MARGIN_MIN,
+            f"speaker_similarity_margin_mean {margin_mean:.4f} "
+            f"< threshold {VC_SIMILARITY_MARGIN_MIN:.4f}",
+        )
     checks.check(
-        summary.get("skipped", 0) == 0,
-        f"speaker similarity: {summary.get('skipped')} skipped samples != 0",
+        bool(margin_results.get("per_sample")),
+        "Expected per-sample voice-copy margin results",
     )
     checks.assert_all()
 

--- a/tests/test_model/test_qwen3_omni_tts_ci.py
+++ b/tests/test_model/test_qwen3_omni_tts_ci.py
@@ -77,9 +77,10 @@ VC_N_ABOVE_50_MAX = 0.0
 # calibration" section of the PR description for the per-run numbers.
 VC_SIMILARITY_MEAN_MIN = 60.0
 # note (luojiaxuan): This is intentionally a margin floor, not a naked
-# similarity floor. tune-ci-thresholds should overwrite it from strict
-# worst-of-5 calibration once the CI-repro run is available.
-VC_SIMILARITY_MARGIN_MIN = 0.0
+# similarity floor. H200 worst-of-5 on SeedTTS-50 EN first 20 was negative
+# (worst=-1.7332, mean=-1.3416), so this is only a regression floor and not
+# evidence that voice-copy is better than no-copy.
+VC_SIMILARITY_MARGIN_MIN = -1.7333
 # Calibrated from worst-of-5 full generate+score runs on SeedTTS-50 EN, H200 SXM.
 # worst-of-5 = 4.1924 · mean = 4.2575 · stdev = 0.0487
 VC_UTMOS_MEAN_REFERENCE = 4.2388

--- a/tests/test_model/test_tts_ci.py
+++ b/tests/test_model/test_tts_ci.py
@@ -69,6 +69,7 @@ from tests.utils import (
 
 PER_REQUEST_STORE: dict[str, list[dict]] = {}
 SPEED_OUTPUT_DIRS: dict[str, dict[int, str]] = {"non_stream": {}, "stream": {}}
+NO_COPY_OUTPUT_DIRS: dict[int, str] = {}
 
 
 _MODEL_NAME, _TTS_CI_PRESET = select_tts_ci_preset()
@@ -144,6 +145,7 @@ def _run_benchmark(
     concurrency: int,
     max_samples: int | None = None,
     stream: bool = False,
+    voice_clone: bool = True,
 ) -> dict:
     benchmark_config = TtsSeedttsBenchmarkConfig(
         model=TTS_MODEL_PATH,
@@ -153,6 +155,7 @@ def _run_benchmark(
         concurrency=concurrency,
         max_samples=max_samples,
         stream=stream,
+        voice_clone=voice_clone,
         ref_format=_PRESET.ref_format,
         token_count=_PRESET.token_count,
     )
@@ -285,30 +288,143 @@ def _run_similarity(
     return similarity_results
 
 
-def _assert_similarity_results(
+def _similarity_rows_by_id(results: dict) -> dict[str, float]:
+    rows: dict[str, float] = {}
+    for row in results.get("per_sample") or []:
+        sample_id = row.get("id")
+        similarity = row.get("speaker_similarity")
+        if row.get("is_success") is True and sample_id and similarity is not None:
+            rows[str(sample_id)] = float(similarity)
+    return rows
+
+
+def _build_voice_copy_margin_results(
+    copy_results: dict,
+    no_copy_results: dict,
+) -> dict:
+    copy_rows = _similarity_rows_by_id(copy_results)
+    no_copy_rows = _similarity_rows_by_id(no_copy_results)
+    shared_ids = sorted(set(copy_rows) & set(no_copy_rows))
+    per_sample = [
+        {
+            "id": sample_id,
+            "copy_similarity": copy_rows[sample_id],
+            "no_copy_similarity": no_copy_rows[sample_id],
+            "speaker_similarity_margin": copy_rows[sample_id]
+            - no_copy_rows[sample_id],
+        }
+        for sample_id in shared_ids
+    ]
+
+    copy_summary = copy_results.get("summary") or {}
+    no_copy_summary = no_copy_results.get("summary") or {}
+    total_samples = max(
+        int(copy_summary.get("total_samples") or 0),
+        int(no_copy_summary.get("total_samples") or 0),
+        len(copy_rows),
+        len(no_copy_rows),
+    )
+    skipped = total_samples - len(per_sample)
+    margin_scores = [row["speaker_similarity_margin"] for row in per_sample]
+    copy_scores = [row["copy_similarity"] for row in per_sample]
+    no_copy_scores = [row["no_copy_similarity"] for row in per_sample]
+    summary = {
+        "speaker_similarity_copy_mean": (
+            sum(copy_scores) / len(copy_scores) if copy_scores else None
+        ),
+        "speaker_similarity_no_copy_mean": (
+            sum(no_copy_scores) / len(no_copy_scores) if no_copy_scores else None
+        ),
+        "speaker_similarity_margin_mean": (
+            sum(margin_scores) / len(margin_scores) if margin_scores else None
+        ),
+        "total_samples": total_samples,
+        "evaluated": len(per_sample),
+        "skipped": skipped,
+        "copy_evaluated": copy_summary.get("evaluated"),
+        "copy_skipped": copy_summary.get("skipped"),
+        "no_copy_evaluated": no_copy_summary.get("evaluated"),
+        "no_copy_skipped": no_copy_summary.get("skipped"),
+        "missing_from_copy": sorted(set(no_copy_rows) - set(copy_rows)),
+        "missing_from_no_copy": sorted(set(copy_rows) - set(no_copy_rows)),
+    }
+    return {"summary": summary, "per_sample": per_sample}
+
+
+def _save_voice_copy_margin_results(output_dir: str, results: dict) -> dict:
+    output_path = Path(output_dir) / "voice_copy_margin_results.json"
+    with output_path.open("w", encoding="utf-8") as f:
+        json.dump(results, f, indent=2, ensure_ascii=False)
+    return results
+
+
+def _assert_similarity_margin_results(
     results: dict,
-    min_mean: float,
+    min_margin: float,
     *,
+    expected_samples: int,
     collector: MetricCheckCollector | None = None,
 ) -> None:
-    checks = collector or MetricCheckCollector("speaker similarity")
-    summary = results["summary"]
-    per_sample = results["per_sample"]
-    checks.check(bool(per_sample), "Expected per-sample speaker similarity results")
+    checks = collector or MetricCheckCollector("speaker similarity margin")
+    summary = results.get("summary") or {}
     checks.check(
-        summary.get("skipped", 0) == 0,
-        f"speaker similarity: {summary.get('skipped')} skipped samples != 0",
+        summary.get("evaluated") == expected_samples,
+        f"speaker similarity margin: evaluated={summary.get('evaluated')}, "
+        f"expected {expected_samples}",
     )
-    mean = summary.get("speaker_similarity_mean")
+    checks.check(
+        summary.get("skipped") == 0,
+        f"speaker similarity margin: skipped={summary.get('skipped')} != 0",
+    )
+    mean = summary.get("speaker_similarity_margin_mean")
     if mean is None:
-        checks.fail("Missing speaker_similarity_mean in summary")
+        checks.fail("Missing speaker_similarity_margin_mean in summary")
     else:
         checks.check(
-            mean >= min_mean,
-            f"speaker_similarity_mean {mean:.4f} < threshold {min_mean:.4f}",
+            mean >= min_margin,
+            f"speaker_similarity_margin_mean {mean:.4f} < threshold {min_margin:.4f}",
         )
     if collector is None:
         checks.assert_all()
+
+
+@pytest.mark.tts_stage(TTS_STAGE_NONSTREAM)
+def test_voice_copy_margin_results_pair_by_sample_id() -> None:
+    copy_results = {
+        "summary": {"total_samples": 3, "evaluated": 2, "skipped": 1},
+        "per_sample": [
+            {"id": "sample-a", "speaker_similarity": 70.0, "is_success": True},
+            {"id": "sample-b", "speaker_similarity": 50.0, "is_success": True},
+            {"id": "sample-c", "speaker_similarity": None, "is_success": False},
+        ],
+    }
+    no_copy_results = {
+        "summary": {"total_samples": 3, "evaluated": 2, "skipped": 1},
+        "per_sample": [
+            {"id": "sample-b", "speaker_similarity": 5.0, "is_success": True},
+            {"id": "sample-d", "speaker_similarity": 7.0, "is_success": True},
+            {"id": "sample-c", "speaker_similarity": None, "is_success": False},
+        ],
+    }
+
+    results = _build_voice_copy_margin_results(copy_results, no_copy_results)
+
+    assert results["summary"]["speaker_similarity_copy_mean"] == 50.0
+    assert results["summary"]["speaker_similarity_no_copy_mean"] == 5.0
+    assert results["summary"]["speaker_similarity_margin_mean"] == 45.0
+    assert results["summary"]["total_samples"] == 3
+    assert results["summary"]["evaluated"] == 1
+    assert results["summary"]["skipped"] == 2
+    assert results["summary"]["missing_from_copy"] == ["sample-d"]
+    assert results["summary"]["missing_from_no_copy"] == ["sample-a"]
+    assert results["per_sample"] == [
+        {
+            "id": "sample-b",
+            "copy_similarity": 50.0,
+            "no_copy_similarity": 5.0,
+            "speaker_similarity_margin": 45.0,
+        }
+    ]
 
 
 def _run_utmos(output_dir: str, *, device: str = "cuda:0") -> dict:
@@ -380,6 +496,16 @@ def _load_speed_results(results_path: Path) -> dict:
         speed_results = json.load(f)
     _validate_speed_results_keys(speed_results)
     return speed_results
+
+
+def _resolve_no_copy_output_dir(concurrency: int, copy_output_dir: str) -> str | None:
+    output_dir = NO_COPY_OUTPUT_DIRS.get(concurrency)
+    if output_dir is not None:
+        return output_dir
+    candidate = Path(copy_output_dir).parent / f"vc_nonstream_no_copy_c{concurrency}"
+    if (candidate / "generated.json").exists():
+        return str(candidate)
+    return None
 
 
 def _assert_tts_audio_result_integrity(
@@ -693,6 +819,10 @@ def cleanup_generated_audio_fixture():
             audio_dir = Path(output_dir) / "audio"
             if audio_dir.exists():
                 shutil.rmtree(audio_dir)
+    for output_dir in NO_COPY_OUTPUT_DIRS.values():
+        audio_dir = Path(output_dir) / "audio"
+        if audio_dir.exists():
+            shutil.rmtree(audio_dir)
 
 
 @pytest.fixture(scope="module")
@@ -793,6 +923,39 @@ def test_voice_cloning_non_streaming(
             results=results,
             collector=checks,
         )
+        _print_stage(
+            "TTS no-copy",
+            "non-streaming",
+            concurrency,
+            f"generate {TTS_SIMILARITY_MAX_SAMPLES} WAVs for voice-copy margin",
+        )
+        no_copy_output_dir = _resolve_stage_output_dir(
+            tmp_path, f"vc_nonstream_no_copy_c{concurrency}"
+        )
+        try:
+            no_copy_results = _run_benchmark(
+                router_server.port,
+                dataset_repo,
+                no_copy_output_dir,
+                concurrency=concurrency,
+                max_samples=TTS_SIMILARITY_MAX_SAMPLES,
+                voice_clone=False,
+            )
+        except Exception:
+            print_router_diagnostics(router_server)
+            raise
+        _assert_tts_audio_result_integrity(
+            no_copy_results["summary"],
+            no_copy_results["per_request"],
+            label=f"TTS no-copy non-stream c{concurrency}",
+            collector=checks,
+        )
+        checks.check(
+            len(no_copy_results["per_request"]) == TTS_SIMILARITY_MAX_SAMPLES,
+            f"TTS no-copy non-stream c{concurrency}: generated "
+            f"{len(no_copy_results['per_request'])}/{TTS_SIMILARITY_MAX_SAMPLES}",
+        )
+        NO_COPY_OUTPUT_DIRS[concurrency] = no_copy_output_dir
         checks.assert_all()
 
 
@@ -927,17 +1090,37 @@ def test_voice_cloning_similarity(
             "SIM",
             "non-streaming",
             concurrency,
-            "score speed-stage WAVs",
+            "score voice-copy and no-copy WAVs",
         )
-        results = _run_similarity(
+        copy_output_dir = wer_input_dirs["non_stream"][concurrency]
+        no_copy_output_dir = _resolve_no_copy_output_dir(concurrency, copy_output_dir)
+        if no_copy_output_dir is None:
+            checks.fail(
+                f"TTS no-copy non-streaming output missing for concurrency {concurrency}"
+            )
+            continue
+        copy_results = _run_similarity(
             dataset_repo,
-            wer_input_dirs["non_stream"][concurrency],
+            copy_output_dir,
             similarity_checkpoint,
             max_samples=TTS_SIMILARITY_MAX_SAMPLES,
         )
+        no_copy_results = _run_similarity(
+            dataset_repo,
+            no_copy_output_dir,
+            similarity_checkpoint,
+            max_samples=TTS_SIMILARITY_MAX_SAMPLES,
+        )
+        margin_results = _save_voice_copy_margin_results(
+            copy_output_dir,
+            _build_voice_copy_margin_results(copy_results, no_copy_results),
+        )
         if _PRESET.gate_thresholds:
-            _assert_similarity_results(
-                results, _THRESHOLDS.similarity_mean_min, collector=checks
+            _assert_similarity_margin_results(
+                margin_results,
+                _THRESHOLDS.similarity_margin_min,
+                expected_samples=TTS_SIMILARITY_MAX_SAMPLES,
+                collector=checks,
             )
     checks.assert_all()
 

--- a/tests/test_model/test_tts_ci.py
+++ b/tests/test_model/test_tts_ci.py
@@ -310,8 +310,7 @@ def _build_voice_copy_margin_results(
             "id": sample_id,
             "copy_similarity": copy_rows[sample_id],
             "no_copy_similarity": no_copy_rows[sample_id],
-            "speaker_similarity_margin": copy_rows[sample_id]
-            - no_copy_rows[sample_id],
+            "speaker_similarity_margin": copy_rows[sample_id] - no_copy_rows[sample_id],
         }
         for sample_id in shared_ids
     ]

--- a/tests/test_model/tts_ci_config.py
+++ b/tests/test_model/tts_ci_config.py
@@ -115,7 +115,7 @@ MOSS_VC_STREAM_THRESHOLDS = apply_slack(
 TTS_CI_PRESETS: dict[str, TtsCiPreset] = {
     "higgs": TtsCiPreset(
         model=TtsCiModelPreset(
-            model_path="boson-sglang/higgs-audio-v3-TTS-4B-grpo05200410999",
+            model_path="bosonai/higgs-audio-v3-tts-4b",
         ),
         thresholds=TtsCiThresholdPreset(
             non_stream_speed=HIGGS_VC_NON_STREAM_THRESHOLDS,

--- a/tests/test_model/tts_ci_config.py
+++ b/tests/test_model/tts_ci_config.py
@@ -27,7 +27,7 @@ class TtsCiThresholdPreset:
     stream_speed: dict[int, dict[str, float]]
     wer_corpus: float
     stream_wer_corpus: float
-    similarity_mean_min: float
+    similarity_margin_min: float
     utmos_mean_min: float
 
 
@@ -49,7 +49,7 @@ HIGGS_VC_WER_MAX_CORPUS = 0.0123
 HIGGS_VC_WER_CORPUS_THRESHOLD = apply_wer_slack(HIGGS_VC_WER_MAX_CORPUS)
 HIGGS_VC_STREAM_WER_MAX_CORPUS = 0.0131
 HIGGS_VC_STREAM_WER_CORPUS_THRESHOLD = apply_wer_slack(HIGGS_VC_STREAM_WER_MAX_CORPUS)
-HIGGS_VC_SIMILARITY_MEAN_MIN = 66.590424118042
+HIGGS_VC_SIMILARITY_MARGIN_MIN = 60.636281912326815
 HIGGS_VC_UTMOS_MEAN_REFERENCE = 4.1453
 HIGGS_VC_UTMOS_MEAN_MIN = apply_mos_slack(HIGGS_VC_UTMOS_MEAN_REFERENCE)
 
@@ -83,7 +83,7 @@ MOSS_VC_WER_MAX_CORPUS = 0.0257
 MOSS_VC_WER_CORPUS_THRESHOLD = apply_wer_slack(MOSS_VC_WER_MAX_CORPUS)
 MOSS_VC_STREAM_WER_MAX_CORPUS = 0.0246
 MOSS_VC_STREAM_WER_CORPUS_THRESHOLD = apply_wer_slack(MOSS_VC_STREAM_WER_MAX_CORPUS)
-MOSS_VC_SIMILARITY_MEAN_MIN = 63.716178512573244
+MOSS_VC_SIMILARITY_MARGIN_MIN = 54.81295958429575
 MOSS_VC_UTMOS_MEAN_REFERENCE = 3.955
 MOSS_VC_UTMOS_MEAN_MIN = apply_mos_slack(MOSS_VC_UTMOS_MEAN_REFERENCE)
 
@@ -122,7 +122,7 @@ TTS_CI_PRESETS: dict[str, TtsCiPreset] = {
             stream_speed=HIGGS_VC_STREAM_THRESHOLDS,
             wer_corpus=HIGGS_VC_WER_CORPUS_THRESHOLD,
             stream_wer_corpus=HIGGS_VC_STREAM_WER_CORPUS_THRESHOLD,
-            similarity_mean_min=HIGGS_VC_SIMILARITY_MEAN_MIN,
+            similarity_margin_min=HIGGS_VC_SIMILARITY_MARGIN_MIN,
             utmos_mean_min=HIGGS_VC_UTMOS_MEAN_MIN,
         ),
     ),
@@ -138,7 +138,7 @@ TTS_CI_PRESETS: dict[str, TtsCiPreset] = {
             stream_speed=MOSS_VC_STREAM_THRESHOLDS,
             wer_corpus=MOSS_VC_WER_CORPUS_THRESHOLD,
             stream_wer_corpus=MOSS_VC_STREAM_WER_CORPUS_THRESHOLD,
-            similarity_mean_min=MOSS_VC_SIMILARITY_MEAN_MIN,
+            similarity_margin_min=MOSS_VC_SIMILARITY_MARGIN_MIN,
             utmos_mean_min=MOSS_VC_UTMOS_MEAN_MIN,
         ),
     ),

--- a/tests/unit_test/benchmarks/test_seedtts_voice_copy_margin.py
+++ b/tests/unit_test/benchmarks/test_seedtts_voice_copy_margin.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from benchmarks.metrics.voice_copy_margin import compute_seedtts_voice_copy_margin
+
+
+def _similarity_results(rows: list[dict]) -> dict:
+    evaluated = sum(1 for row in rows if row.get("is_success"))
+    return {
+        "summary": {
+            "total_samples": len(rows),
+            "evaluated": evaluated,
+            "skipped": len(rows) - evaluated,
+        },
+        "per_sample": rows,
+    }
+
+
+def _row(sample_id: str, score: float | None, *, success: bool = True) -> dict:
+    return {
+        "id": sample_id,
+        "ref_audio": f"/ref/{sample_id}.wav",
+        "wav_path": f"/gen/{sample_id}.wav",
+        "speaker_similarity": score,
+        "is_success": success,
+        "error": None if success else "failed",
+    }
+
+
+def test_seedtts_voice_copy_margin_pairs_by_sample_id(tmp_path: Path) -> None:
+    copy_results = _similarity_results([_row("b", 0.62), _row("a", 0.81)])
+    no_copy_results = _similarity_results([_row("a", 0.51), _row("b", 0.40)])
+
+    results = compute_seedtts_voice_copy_margin(
+        copy_results,
+        no_copy_results,
+        output_dir=str(tmp_path),
+    )
+
+    summary = results["summary"]
+    assert summary["speaker_similarity_copy_mean"] == pytest.approx(0.715)
+    assert summary["speaker_similarity_no_copy_mean"] == pytest.approx(0.455)
+    assert summary["speaker_similarity_margin_mean"] == pytest.approx(0.26)
+    assert summary["evaluated"] == 2
+    assert summary["skipped"] == 0
+    assert [row["id"] for row in results["per_sample"]] == ["b", "a"]
+
+    saved = tmp_path / "voice_copy_margin_results.json"
+    assert saved.exists()
+    assert json.loads(saved.read_text())["summary"] == summary
+
+
+def test_seedtts_voice_copy_margin_records_missing_and_failed_rows() -> None:
+    copy_results = _similarity_results(
+        [
+            _row("a", 0.80),
+            _row("b", None, success=False),
+            _row("c", 0.75),
+        ]
+    )
+    no_copy_results = _similarity_results([_row("a", 0.50), _row("b", 0.40)])
+
+    results = compute_seedtts_voice_copy_margin(copy_results, no_copy_results)
+
+    summary = results["summary"]
+    assert summary["speaker_similarity_margin_mean"] == pytest.approx(0.30)
+    assert summary["evaluated"] == 1
+    assert summary["skipped"] == 2
+    skipped = [row for row in results["per_sample"] if not row["is_success"]]
+    assert {row["id"] for row in skipped} == {"b", "c"}
+    assert any("no-copy row missing" in row["error"] for row in skipped)
+
+
+def _load_tune_module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / ".claude/skills/tune-ci-thresholds/tune.py"
+    )
+    spec = importlib.util.spec_from_file_location("tune_ci_thresholds", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_tune_ci_thresholds_discovers_similarity_margin_before_mean() -> None:
+    tune = _load_tune_module()
+
+    assert tune.match_metric("VC_SIMILARITY_MARGIN_MIN", None) == "similarity_margin"
+    assert tune.match_metric("VC_SIMILARITY_MEAN_MIN", None) == "similarity_mean"
+    assert tune.METRIC_SPECS["similarity_margin"]["worst"] == "min"


### PR DESCRIPTION
Closes #895.

Summary:
- Gate TTS voice-copy quality on paired SeedTTS speaker-similarity margin, not raw copy similarity.
- Generate a no-copy first-50-sample baseline in the nonstream TTS stage for margin scoring only.
- Write `voice_copy_margin_results.json` and register `similarity_margin` in calibration config.

H200 calibration, first 50 SeedTTS EN samples, worst-of-5:
- Higgs: margins 61.6709, 62.8018, 60.6363, 64.8855, 62.4343; threshold 60.636281912326815.
- MOSS: margins 57.5851, 58.8682, 58.1238, 58.9385, 54.8130; threshold 54.81295958429575.

Tests:
- `python3 -m py_compile tests/test_model/test_tts_ci.py tests/test_model/tts_ci_config.py .claude/skills/tune-ci-thresholds/tune.py`
- `python3 -m pytest tests/test_model/test_tts_ci.py::test_voice_copy_margin_results_pair_by_sample_id -q` in H200 container
- `python3 .claude/skills/tune-ci-thresholds/tune.py --model tts discover --output .claude/skills/tune-ci-thresholds/models/tts/stages.yaml`
