### PR TITLE
[Refactor] T7: PreparedRequestQueue — parallel impl, consolidate with #903 (#661)

### DIFF
--- a/sglang_omni/models/moss_tts/request_builders.py
+++ b/sglang_omni/models/moss_tts/request_builders.py
@@ -8,7 +8,6 @@ import collections
 import hashlib
 import io
 import re
-import threading
 import time
 from dataclasses import dataclass, field
 from typing import Any
@@ -18,6 +17,7 @@ import torch
 from sglang_omni.models.moss_tts.payload_types import MossTTSState
 from sglang_omni.proto import StagePayload
 from sglang_omni.sampling.seed import derive_sampling_seed, new_random_sampling_seed
+from sglang_omni.scheduling.prepared_request_queue import PreparedRequestQueue
 from sglang_omni.scheduling.types import ARRequestData
 from sglang_omni.utils.audio_payload import audio_data_uri_from_reference
 
@@ -111,36 +111,21 @@ class MossTTSPreprocessingContext:
     processor: Any
 
 
-_PREPROCESSING_CONTEXT: MossTTSPreprocessingContext | None = None
-_PREPARED_REQUESTS: dict[str, MossTTSPreparedRequest] = {}
-# Request ids currently inside preprocess_moss_tts_payload.
-_INFLIGHT_REQUESTS: set[str] = set()
-# In-flight requests whose abort arrived before the handoff was published, so
-# compute drops the pending insert instead of leaking it into _PREPARED_REQUESTS.
-_ABORTED_REQUESTS: set[str] = set()
-_PREPARED_REQUESTS_LOCK = threading.Lock()
+_QUEUE: PreparedRequestQueue[MossTTSPreprocessingContext, MossTTSPreparedRequest] = (
+    PreparedRequestQueue()
+)
 
 
 def set_moss_tts_preprocessing_context(*, processor: Any) -> None:
     """Register the upstream MOSS processor used by preprocessing."""
 
-    global _PREPROCESSING_CONTEXT
-    with _PREPARED_REQUESTS_LOCK:
-        _PREPROCESSING_CONTEXT = MossTTSPreprocessingContext(processor=processor)
-        _PREPARED_REQUESTS.clear()
-        _INFLIGHT_REQUESTS.clear()
-        _ABORTED_REQUESTS.clear()
+    _QUEUE.set_context(MossTTSPreprocessingContext(processor=processor))
 
 
 def clear_moss_tts_preprocessing_context() -> None:
     """Clear MOSS-TTS preprocessing globals, mainly for tests and reloads."""
 
-    global _PREPROCESSING_CONTEXT
-    with _PREPARED_REQUESTS_LOCK:
-        _PREPROCESSING_CONTEXT = None
-        _PREPARED_REQUESTS.clear()
-        _INFLIGHT_REQUESTS.clear()
-        _ABORTED_REQUESTS.clear()
+    _QUEUE.clear_context()
 
 
 def cleanup_prepared_moss_tts_request(request_id: str) -> None:
@@ -151,12 +136,7 @@ def cleanup_prepared_moss_tts_request(request_id: str) -> None:
     leaves nothing behind.
     """
 
-    rid = str(request_id)
-    with _PREPARED_REQUESTS_LOCK:
-        if _PREPARED_REQUESTS.pop(rid, None) is not None:
-            return
-        if rid in _INFLIGHT_REQUESTS:
-            _ABORTED_REQUESTS.add(rid)
+    _QUEUE.abort(str(request_id))
 
 
 def pop_prepared_moss_tts_request(
@@ -166,8 +146,7 @@ def pop_prepared_moss_tts_request(
     marker = data.get(_MOSS_TTS_PREPARED_MARKER)
     if marker is None:
         return None
-    with _PREPARED_REQUESTS_LOCK:
-        prepared = _PREPARED_REQUESTS.pop(str(marker), None)
+    prepared = _QUEUE.pop(str(marker))
     if prepared is None:
         raise RuntimeError(
             "MOSS-TTS preprocessing state is missing for prepared payload "
@@ -460,10 +439,7 @@ def preprocess_moss_tts_payload(payload: StagePayload) -> StagePayload:
     """Run MOSS-TTS prompt/reference preprocessing outside the AR scheduler."""
 
     rid = str(payload.request_id)
-    with _PREPARED_REQUESTS_LOCK:
-        context = _PREPROCESSING_CONTEXT
-        if context is not None:
-            _INFLIGHT_REQUESTS.add(rid)
+    context = _QUEUE.begin(rid)
     if context is None:
         raise RuntimeError(
             "MOSS-TTS preprocessing context is not initialized; "
@@ -473,17 +449,9 @@ def preprocess_moss_tts_payload(payload: StagePayload) -> StagePayload:
     try:
         prepared = _prepare_moss_tts_request(payload, processor=context.processor)
     except BaseException:
-        with _PREPARED_REQUESTS_LOCK:
-            _INFLIGHT_REQUESTS.discard(rid)
-            _ABORTED_REQUESTS.discard(rid)
+        _QUEUE.fail_inflight(rid)
         raise
-    with _PREPARED_REQUESTS_LOCK:
-        _INFLIGHT_REQUESTS.discard(rid)
-        aborted = rid in _ABORTED_REQUESTS
-        _ABORTED_REQUESTS.discard(rid)
-        if not aborted:
-            # Aborted-while-preprocessing drops the handoff so it never lingers.
-            _PREPARED_REQUESTS[rid] = prepared
+    _QUEUE.publish(rid, prepared)
 
     data = prepared.state.to_dict()
     data[_MOSS_TTS_PREPARED_MARKER] = payload.request_id

--- a/sglang_omni/models/moss_tts_local/request_builders.py
+++ b/sglang_omni/models/moss_tts_local/request_builders.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import threading
 import time
 from dataclasses import dataclass, field
 from typing import Any
@@ -26,6 +25,7 @@ from sglang_omni.models.moss_tts.request_builders import (
 from sglang_omni.models.moss_tts_local.payload_types import MossTTSLocalState
 from sglang_omni.models.tts_streaming import INITIAL_CODEC_CHUNK_FRAMES_PARAM
 from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.prepared_request_queue import PreparedRequestQueue
 from sglang_omni.scheduling.types import ARRequestData
 
 _MOSS_TTS_LOCAL_PREPARED_MARKER = "_moss_tts_local_prepared_request"
@@ -83,43 +83,26 @@ class _PreprocessingContext:
     reference_encoder: Any = None
 
 
-_PREPROCESSING_CONTEXT: _PreprocessingContext | None = None
-_PREPARED_REQUESTS: dict[str, MossTTSLocalPreparedRequest] = {}
-_INFLIGHT_REQUESTS: set[str] = set()
-_ABORTED_REQUESTS: set[str] = set()
-_PREPARED_REQUESTS_LOCK = threading.Lock()
+_QUEUE: PreparedRequestQueue[_PreprocessingContext, MossTTSLocalPreparedRequest] = (
+    PreparedRequestQueue()
+)
 
 
 def set_moss_tts_local_preprocessing_context(
     *, processor: Any, reference_encoder: Any = None
 ) -> None:
-    global _PREPROCESSING_CONTEXT
-    with _PREPARED_REQUESTS_LOCK:
-        _PREPROCESSING_CONTEXT = _PreprocessingContext(
-            processor=processor, reference_encoder=reference_encoder
-        )
-        _PREPARED_REQUESTS.clear()
-        _INFLIGHT_REQUESTS.clear()
-        _ABORTED_REQUESTS.clear()
+    _QUEUE.set_context(
+        _PreprocessingContext(processor=processor, reference_encoder=reference_encoder)
+    )
 
 
 def clear_moss_tts_local_preprocessing_context() -> None:
-    global _PREPROCESSING_CONTEXT
-    with _PREPARED_REQUESTS_LOCK:
-        _PREPROCESSING_CONTEXT = None
-        _PREPARED_REQUESTS.clear()
-        _INFLIGHT_REQUESTS.clear()
-        _ABORTED_REQUESTS.clear()
+    _QUEUE.clear_context()
 
 
 def cleanup_prepared_moss_tts_local_request(request_id: str) -> None:
     """Drop any prepared handoff for an aborted request (see MOSS Delay)."""
-    rid = str(request_id)
-    with _PREPARED_REQUESTS_LOCK:
-        if _PREPARED_REQUESTS.pop(rid, None) is not None:
-            return
-        if rid in _INFLIGHT_REQUESTS:
-            _ABORTED_REQUESTS.add(rid)
+    _QUEUE.abort(str(request_id))
 
 
 def pop_prepared_moss_tts_local_request(
@@ -129,8 +112,7 @@ def pop_prepared_moss_tts_local_request(
     marker = data.get(_MOSS_TTS_LOCAL_PREPARED_MARKER)
     if marker is None:
         return None
-    with _PREPARED_REQUESTS_LOCK:
-        prepared = _PREPARED_REQUESTS.pop(str(marker), None)
+    prepared = _QUEUE.pop(str(marker))
     if prepared is None:
         raise RuntimeError(
             "MOSS-TTS Local preprocessing state is missing for prepared payload "
@@ -299,10 +281,7 @@ def preprocess_moss_tts_local_payload(payload: StagePayload) -> StagePayload:
     """Run prompt/reference preprocessing outside the AR scheduler."""
 
     rid = str(payload.request_id)
-    with _PREPARED_REQUESTS_LOCK:
-        context = _PREPROCESSING_CONTEXT
-        if context is not None:
-            _INFLIGHT_REQUESTS.add(rid)
+    context = _QUEUE.begin(rid)
     if context is None:
         raise RuntimeError(
             "MOSS-TTS Local preprocessing context is not initialized; "
@@ -316,16 +295,9 @@ def preprocess_moss_tts_local_payload(payload: StagePayload) -> StagePayload:
             reference_encoder=context.reference_encoder,
         )
     except BaseException:
-        with _PREPARED_REQUESTS_LOCK:
-            _INFLIGHT_REQUESTS.discard(rid)
-            _ABORTED_REQUESTS.discard(rid)
+        _QUEUE.fail_inflight(rid)
         raise
-    with _PREPARED_REQUESTS_LOCK:
-        _INFLIGHT_REQUESTS.discard(rid)
-        aborted = rid in _ABORTED_REQUESTS
-        _ABORTED_REQUESTS.discard(rid)
-        if not aborted:
-            _PREPARED_REQUESTS[rid] = prepared
+    _QUEUE.publish(rid, prepared)
 
     data = prepared.state.to_dict()
     data[_MOSS_TTS_LOCAL_PREPARED_MARKER] = payload.request_id

--- a/sglang_omni/scheduling/prepared_request_queue.py
+++ b/sglang_omni/scheduling/prepared_request_queue.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared preprocessing -> AR-engine handoff queue (RFC #661, Template 7).
+
+A process-wide tri-state registry — ``prepared`` (published, awaiting the AR
+scheduler), ``inflight`` (currently preprocessing), ``aborted`` (in-flight ids
+aborted before publish, so the pending insert is dropped) — plus the opaque
+per-model preprocessing ``context``. ``moss_tts`` and ``moss_tts_local`` used to
+duplicate these transitions line for line; only the context and payload type
+differ, so the registry is generic over both.
+
+It is correctness-critical: wrong abort-ordering either strands a GPU slot
+forever (ghost request) or publishes a handoff for an already-gone request.
+Every method holds ``lock`` for the whole transition. Pure-Python (no torch).
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Generic, TypeVar
+
+CtxT = TypeVar("CtxT")
+PrepT = TypeVar("PrepT")
+
+
+class PreparedRequestQueue(Generic[CtxT, PrepT]):
+    """Thread-safe tri-state handoff registry for preprocessing -> AR scheduler.
+
+    The attributes (``context`` / ``prepared`` / ``inflight`` / ``aborted`` /
+    ``lock``) are exposed for introspection; mutate them only through the methods
+    below, each of which holds ``lock`` for the whole transition.
+    """
+
+    def __init__(self) -> None:
+        self.context: CtxT | None = None
+        self.prepared: dict[str, PrepT] = {}
+        self.inflight: set[str] = set()
+        self.aborted: set[str] = set()
+        self.lock = threading.Lock()
+
+    def set_context(self, context: CtxT) -> None:
+        """Register the preprocessing context and reset the registry."""
+        with self.lock:
+            self.context = context
+            self.prepared.clear()
+            self.inflight.clear()
+            self.aborted.clear()
+
+    def clear_context(self) -> None:
+        """Drop the context and reset the registry (reloads and tests)."""
+        with self.lock:
+            self.context = None
+            self.prepared.clear()
+            self.inflight.clear()
+            self.aborted.clear()
+
+    def begin(self, request_id: str) -> CtxT | None:
+        """Read the context and, if present, mark ``request_id`` in flight.
+
+        The read and the in-flight insert happen under one lock so a concurrent
+        ``clear_context`` cannot strand a stale in-flight id.
+        """
+        with self.lock:
+            context = self.context
+            if context is not None:
+                self.inflight.add(request_id)
+            return context
+
+    def fail_inflight(self, request_id: str) -> None:
+        """Roll back an in-flight request whose preprocessing raised."""
+        with self.lock:
+            self.inflight.discard(request_id)
+            self.aborted.discard(request_id)
+
+    def publish(self, request_id: str, prepared: PrepT) -> bool:
+        """Publish a handoff unless the request was aborted mid-flight.
+
+        Returns ``True`` if stored, ``False`` if dropped because an abort arrived
+        while preprocessing was running.
+        """
+        with self.lock:
+            self.inflight.discard(request_id)
+            aborted = request_id in self.aborted
+            self.aborted.discard(request_id)
+            if not aborted:
+                self.prepared[request_id] = prepared
+            return not aborted
+
+    def abort(self, request_id: str) -> None:
+        """Drop a published handoff, or tombstone an in-flight one.
+
+        Only tombstone when preprocessing is actually in flight; an abort for a
+        request that is neither published nor in flight leaves nothing behind.
+        """
+        with self.lock:
+            if self.prepared.pop(request_id, None) is not None:
+                return
+            if request_id in self.inflight:
+                self.aborted.add(request_id)
+
+    def pop(self, request_id: str) -> PrepT | None:
+        """AR side: remove and return a published handoff, or ``None`` if absent."""
+        with self.lock:
+            return self.prepared.pop(request_id, None)
+
+
+__all__ = ["PreparedRequestQueue"]

--- a/sglang_omni/scheduling/prepared_request_queue.py
+++ b/sglang_omni/scheduling/prepared_request_queue.py
@@ -1,16 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Shared preprocessing -> AR-engine handoff queue (RFC #661, Template 7).
+"""Shared preprocessing -> AR-engine handoff queue.
 
-A process-wide tri-state registry — ``prepared`` (published, awaiting the AR
-scheduler), ``inflight`` (currently preprocessing), ``aborted`` (in-flight ids
-aborted before publish, so the pending insert is dropped) — plus the opaque
-per-model preprocessing ``context``. ``moss_tts`` and ``moss_tts_local`` used to
-duplicate these transitions line for line; only the context and payload type
-differ, so the registry is generic over both.
+A process-wide tri-state registry: prepared entries are published and awaiting
+the AR scheduler, inflight entries are still preprocessing, and aborted entries
+were cancelled before publish so the pending insert is dropped. The registry
+also tracks the opaque per-model preprocessing context. moss_tts and
+moss_tts_local used to duplicate these transitions line for line; only the
+context and payload type differ, so the registry is generic over both.
 
 It is correctness-critical: wrong abort-ordering either strands a GPU slot
 forever (ghost request) or publishes a handoff for an already-gone request.
-Every method holds ``lock`` for the whole transition. Pure-Python (no torch).
+Every method holds lock for the whole transition. Pure-Python (no torch).
 """
 
 from __future__ import annotations
@@ -25,9 +25,9 @@ PrepT = TypeVar("PrepT")
 class PreparedRequestQueue(Generic[CtxT, PrepT]):
     """Thread-safe tri-state handoff registry for preprocessing -> AR scheduler.
 
-    The attributes (``context`` / ``prepared`` / ``inflight`` / ``aborted`` /
-    ``lock``) are exposed for introspection; mutate them only through the methods
-    below, each of which holds ``lock`` for the whole transition.
+    The attributes context, prepared, inflight, aborted, and lock are exposed
+    for introspection; mutate them only through the methods below, each of which
+    holds lock for the whole transition.
     """
 
     def __init__(self) -> None:

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -939,9 +939,9 @@ def test_moss_preprocess_discards_handoff_after_abort(
     try:
         rb.set_moss_tts_preprocessing_context(processor=object())
         rb.preprocess_moss_tts_payload(payload)
-        with rb._PREPARED_REQUESTS_LOCK:
-            assert "abort-me" not in rb._PREPARED_REQUESTS
-            assert not rb._PREPARED_REQUESTS
+        with rb._QUEUE.lock:
+            assert "abort-me" not in rb._QUEUE.prepared
+            assert not rb._QUEUE.prepared
     finally:
         rb.clear_moss_tts_preprocessing_context()
 
@@ -1011,13 +1011,13 @@ def test_moss_preprocess_pre_start_abort_does_not_block(
         rb.set_moss_tts_preprocessing_context(processor=object())
         # Abort for a request that never started preprocessing: no tombstone.
         rb.cleanup_prepared_moss_tts_request("ghost")
-        with rb._PREPARED_REQUESTS_LOCK:
-            assert not rb._ABORTED_REQUESTS
+        with rb._QUEUE.lock:
+            assert not rb._QUEUE.aborted
         # The same id can still run a normal preprocess and publish its handoff.
         rb.preprocess_moss_tts_payload(make_payload(inputs="hello", request_id="ghost"))
-        with rb._PREPARED_REQUESTS_LOCK:
-            assert "ghost" in rb._PREPARED_REQUESTS
-            assert not rb._ABORTED_REQUESTS
-            assert not rb._INFLIGHT_REQUESTS
+        with rb._QUEUE.lock:
+            assert "ghost" in rb._QUEUE.prepared
+            assert not rb._QUEUE.aborted
+            assert not rb._QUEUE.inflight
     finally:
         rb.clear_moss_tts_preprocessing_context()

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -735,16 +735,16 @@ def test_create_preprocessing_executor_env_toggle(monkeypatch):
     monkeypatch.setenv("MOSS_REF_AUDIO_CACHE", "0")
     stages.create_preprocessing_executor("model", device="cpu")
     assert not isinstance(
-        rb._PREPROCESSING_CONTEXT.reference_encoder, stages.CachedReferenceEncoder
+        rb._QUEUE.context.reference_encoder, stages.CachedReferenceEncoder
     )
 
     # Unset -> kwarg default (True) -> wrapped.
     monkeypatch.delenv("MOSS_REF_AUDIO_CACHE")
     stages.create_preprocessing_executor("model", device="cpu")
     assert isinstance(
-        rb._PREPROCESSING_CONTEXT.reference_encoder, stages.CachedReferenceEncoder
+        rb._QUEUE.context.reference_encoder, stages.CachedReferenceEncoder
     )
-    assert rb._PREPROCESSING_CONTEXT.reference_encoder._cache.max_size == 8192
+    assert rb._QUEUE.context.reference_encoder._cache.max_size == 8192
 
 
 def test_create_preprocessing_executor_uses_model_config_codec_path(monkeypatch):

--- a/tests/unit_test/scheduling/__init__.py
+++ b/tests/unit_test/scheduling/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/unit_test/scheduling/test_prepared_request_queue.py
+++ b/tests/unit_test/scheduling/test_prepared_request_queue.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contract tests for the T7 PreparedRequestQueue (RFC #661, §13). CPU-only.
+
+The seven §13 scenarios plus a thread-storm: the queue exists only to be safe
+across the asyncio-preprocessing stage, the AR-engine thread, and the abort
+path, so a single concurrency test guards the property the others cannot.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from sglang_omni.scheduling.prepared_request_queue import PreparedRequestQueue
+
+
+def _active() -> PreparedRequestQueue:
+    q: PreparedRequestQueue = PreparedRequestQueue()
+    q.set_context(object())
+    return q
+
+
+def test_abort_while_inflight_makes_publish_drop() -> None:
+    q = _active()
+    q.begin("a")
+    q.abort("a")
+    assert "a" in q.aborted
+    assert q.publish("a", "PREP-a") is False
+    assert "a" not in q.prepared
+    assert "a" not in q.aborted
+
+
+def test_abort_after_publish_drops_the_prepared_entry() -> None:
+    q = _active()
+    q.begin("a")
+    assert q.publish("a", "PREP-a") is True
+    q.abort("a")
+    assert "a" not in q.prepared
+    assert "a" not in q.aborted
+
+
+def test_publish_then_pop_returns_the_payload() -> None:
+    q = _active()
+    q.begin("a")
+    q.publish("a", "PREP-a")
+    assert "a" not in q.inflight
+    assert q.pop("a") == "PREP-a"
+
+
+def test_abort_for_idle_id_is_a_noop() -> None:
+    q = _active()
+    q.abort("ghost")
+    assert not q.aborted
+    assert not q.inflight
+    assert not q.prepared
+
+
+def test_fail_inflight_leaves_nothing_behind() -> None:
+    q = _active()
+    q.begin("a")
+    q.fail_inflight("a")
+    assert not q.inflight
+    assert not q.aborted
+    assert "a" not in q.prepared
+
+
+def test_begin_clear_context_strands_no_stale_inflight() -> None:
+    q = _active()
+    q.begin("a")
+    q.publish("a", "PREP-a")
+    q.begin("b")
+    q.clear_context()
+    assert q.context is None
+    assert not q.prepared and not q.inflight and not q.aborted
+    # note (Xinhao Tan): with no context, begin is a no-op so no in-flight id is added
+    assert q.begin("c") is None
+    assert "c" not in q.inflight
+
+
+def test_pop_absent_id_returns_none() -> None:
+    q = _active()
+    assert q.pop("missing") is None
+
+
+def test_concurrent_handoffs_do_not_lose_or_cross_payloads() -> None:
+    q: PreparedRequestQueue = PreparedRequestQueue()
+    q.set_context(object())
+    n = 200
+    taken: dict[int, str] = {}
+    taken_lock = threading.Lock()
+    start = threading.Barrier(2)
+
+    def producer() -> None:
+        start.wait()
+        for i in range(n):
+            rid = str(i)
+            q.begin(rid)
+            q.publish(rid, f"PREP-{i}")
+
+    def consumer() -> None:
+        start.wait()
+        remaining = set(range(n))
+        while remaining:
+            for i in list(remaining):
+                prepared = q.pop(str(i))
+                if prepared is not None:
+                    with taken_lock:
+                        taken[i] = prepared
+                    remaining.discard(i)
+
+    threads = [threading.Thread(target=producer), threading.Thread(target=consumer)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert taken == {i: f"PREP-{i}" for i in range(n)}

--- a/tests/unit_test/scheduling/test_prepared_request_queue.py
+++ b/tests/unit_test/scheduling/test_prepared_request_queue.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Contract tests for the T7 PreparedRequestQueue (RFC #661, §13). CPU-only.
+"""Contract tests for PreparedRequestQueue. CPU-only.
 
-The seven §13 scenarios plus a thread-storm: the queue exists only to be safe
-across the asyncio-preprocessing stage, the AR-engine thread, and the abort
-path, so a single concurrency test guards the property the others cannot.
+These scenarios cover abort ordering, publish and pop behavior, context reset,
+and a thread storm across preprocessing, AR-engine handoff, and abort paths.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Motivation

RFC #661 Template 7. The tri-state preprocessing→AR-engine handoff — `prepared` / `inflight` / `aborted` + a lock + the per-model preprocessing context — is duplicated line for line across `moss_tts` and `moss_tts_local` (~80 LOC each). Per #661 (framework owns reusable mechanics; model dirs own model semantics), this extracts that shared machinery into one generic queue and migrates both models onto it.

Note: #903 (@MelodyyyYin) implements the same template. happy to defer to #903 with a `Co-authored-by` credit, or fold my addition (below) into it.

## Modifications

- New `sglang_omni/scheduling/prepared_request_queue.py`: generic `PreparedRequestQueue[CtxT, PrepT]` owning the tri-state + lock + the opaque per-model context. `begin()` reads the context and marks the request in-flight under one lock (preserves the original single-lock atomicity so a concurrent `clear_context` can't strand a stale in-flight id); `publish()` returns a non-observable `bool`; `abort` / `pop` / `fail_inflight` / `set_context` / `clear_context`.
- Migrated `moss_tts` and `moss_tts_local` `request_builders.py` to delegate to the queue; the duplicated per-model globals + lock are deleted in the same change. `stages.py` wiring (abort_callback / set-context) is unchanged.
- Updated both models' `test_pipeline.py` assertions to read `_QUEUE.*`.
- New CPU contract test: the seven §13 prepared/inflight/aborted scenarios plus a concurrency thread-storm.

## Related Issues

Part of #661 (Template 7). Overlaps with #903 (same template) — see Motivation.

## Accuracy Test

N/A — no model-side code (kernels / architecture / sampling) is touched. This is a behavior-preserving scheduling-layer refactor: the queue logic is line-for-line equivalent to the previous per-model code, and `publish()`'s `bool` return is non-observable (callers ignore it). Per-model Seed-TTS accuracy CI is the backstop.

## Benchmark & Profiling

N/A — no performance-relevant change. Same lock, same operations per request; one
shared class replaces two copies.

## Checklist

- [x] Format your code according with pre-commit. <!-- black + isort verified locally; run full pre-commit (ruff/autoflake) in the env before merge -->
- [x] Add unit tests. <!-- CPU contract test (7 scenarios + concurrency) + updated pipeline tests -->
- [ ] Update documentation / docstrings / example tutorials as needed. <!-- N/A -->
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed. <!-- N/A — behavior-preserving, no model code -->