### PR TITLE
[Qwen3-Omni] Async decode (one-step lookahead) for the thinker text decode

### DIFF
--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -24,6 +24,8 @@ _ASYNC_DECODE_FACTORIES = frozenset(
     {
         "sglang_omni.models.higgs_tts.stages.create_sglang_tts_engine_executor",
         "sglang_omni.models.moss_tts_local.stages.create_sglang_tts_engine_executor",
+        "sglang_omni.models.qwen3_omni.stages."
+        "create_sglang_thinker_executor_from_config",
     }
 )
 _QWEN_PARTIAL_START_TALKER_FACTORY = (
@@ -842,14 +844,28 @@ def apply_decode_mode_cli_overrides(
         updates["async_decode_min_batch_size"] = int(async_lookahead_min_batch_size)
     if not updates:
         return pipeline_config
-    _apply_stage_factory_args_override(
-        pipeline_config,
-        stage_name="tts_engine",
-        updates=updates,
-        reason="decode mode override",
-        supported_factories=_ASYNC_DECODE_FACTORIES,
-        flag_name="--decode-mode/--async-lookahead-min-batch-size",
-    )
+    # note (jiaxin deng): resolve by factory so the override reaches whichever
+    # async-decode stage the pipeline has (tts_engine for Higgs/MOSS, thinker for
+    # Qwen3-Omni), instead of a single hardcoded stage name.
+    stage_names = [
+        stage.name
+        for stage in pipeline_config.stages
+        if stage.factory in _ASYNC_DECODE_FACTORIES
+    ]
+    if not stage_names:
+        raise typer.BadParameter(
+            "--decode-mode/--async-lookahead-min-batch-size is not supported by "
+            "this pipeline (no async-decode-capable stage)"
+        )
+    for stage_name in stage_names:
+        _apply_stage_factory_args_override(
+            pipeline_config,
+            stage_name=stage_name,
+            updates=updates,
+            reason="decode mode override",
+            supported_factories=_ASYNC_DECODE_FACTORIES,
+            flag_name="--decode-mode/--async-lookahead-min-batch-size",
+        )
     return pipeline_config
 
 

--- a/sglang_omni/model_runner/thinker_model_runner.py
+++ b/sglang_omni/model_runner/thinker_model_runner.py
@@ -325,26 +325,30 @@ class ThinkerModelRunner(ModelRunner):
         )
 
     def lookahead_eligible(self, batch: Any) -> bool:
-        """Route to sync where the one-step lag would diverge from sync. Speech /
-        hidden-capture batches: the captured-hidden side channel is per-forward, so
-        launch(N) overwrites it before resolve(N-1) reads it and the talker gets
-        mismatched hidden states. Sampling that reads the lagged output history
-        (repetition/presence/frequency penalty, min_new_tokens) or a fixed seed
-        also diverges; logit_bias / custom_params are routed conservatively.
-        return_logprob is routed to sync because the lookahead sampler skips the
-        base logprob-recording path.
+        """Route to sync where the one-step lag would diverge from sync. A request
+        that emits audio captures hidden states for the talker; the per-forward
+        _captured_aux_hidden_states side channel would be overwritten by a lookahead
+        launch(N) before resolve(N-1) collects it, so those requests route to sync
+        per batch. Sampling that reads the lagged output history (repetition /
+        presence / frequency penalty, min_new_tokens), a fixed seed, or
+        return_logprob (the lookahead sampler skips the base logprob path) also
+        diverges; logit_bias / custom_params are routed conservatively.
         """
-        # note (jiaxin deng): hidden-capture (speech/audio-output) batches must not
-        # use the lookahead; the _captured_aux_hidden_states side channel would be
-        # overwritten by launch(N) before resolve(N-1) collects it.
-        if self._text_model.layers_to_capture:
-            return False
+        from sglang_omni.models.qwen3_omni.request_builders import (
+            should_generate_audio_output,
+        )
+
         for req in batch.reqs:
-            # _omni_data is attached per request by OmniScheduler; guard the
-            # attribute access so a request data variant without the flag is
-            # simply treated as not requesting logprobs.
+            # note (jiaxin deng): fail closed if the request data is missing or None
+            # so a hidden-capture batch can never slip onto the async path.
             try:
-                needs_logprob = req._omni_data.return_logprob
+                data = req._omni_data
+            except AttributeError:
+                data = None
+            if data is None or should_generate_audio_output(data.stage_payload):
+                return False
+            try:
+                needs_logprob = data.return_logprob
             except AttributeError:
                 needs_logprob = False
             if needs_logprob:

--- a/sglang_omni/model_runner/thinker_model_runner.py
+++ b/sglang_omni/model_runner/thinker_model_runner.py
@@ -6,6 +6,7 @@ visual embeddings for Qwen3-Omni's thinker stage.
 """
 from __future__ import annotations
 
+import contextlib
 import logging
 from collections.abc import Callable
 from typing import Any
@@ -35,24 +36,36 @@ class ThinkerModelRunner(ModelRunner):
         self._outer_model = model.thinker
         self._text_model = self._outer_model.model
         self._embed_tokens = self._text_model.embed_tokens
+        self._th_host_bufs = None
+        self._th_slot = 0
 
         thinker_cfg = tp_worker.model_runner.model_config.hf_config.thinker_config
         self._image_token_id = thinker_cfg.image_token_id
         self._video_token_id = thinker_cfg.video_token_id
         self._audio_token_id = thinker_cfg.audio_token_id
 
+    @contextlib.contextmanager
+    def _text_only_capture_guard(self, requests: list[Any]):
+        # note (jiaxin deng): drop hidden-capture for an all-text batch, shared by
+        # sync execute() and async execute_launch so both take the same path.
+        capture_layers = self._text_model.layers_to_capture
+        if not (capture_layers and not self._batch_should_capture_hidden(requests)):
+            yield
+            return
+        saved_capture_layers = list(capture_layers)
+        self._text_model.layers_to_capture = []
+        try:
+            yield
+        finally:
+            self._text_model.layers_to_capture = saved_capture_layers
+
     def execute(self, scheduler_output: Any):
-        capture_layers = getattr(self._text_model, "layers_to_capture", None)
-        if capture_layers and not self._batch_should_capture_hidden(
-            scheduler_output.requests
-        ):
-            saved_capture_layers = list(capture_layers)
-            self._text_model.layers_to_capture = []
-            try:
-                return super().execute(scheduler_output)
-            finally:
-                self._text_model.layers_to_capture = saved_capture_layers
-        return super().execute(scheduler_output)
+        with self._text_only_capture_guard(scheduler_output.requests):
+            return super().execute(scheduler_output)
+
+    def execute_launch(self, scheduler_output: Any):
+        with self._text_only_capture_guard(scheduler_output.requests):
+            return super().execute_launch(scheduler_output)
 
     def _batch_should_capture_hidden(self, requests: list[Any]) -> bool:
         if self._should_capture_hidden is None:
@@ -310,3 +323,84 @@ class ThinkerModelRunner(ModelRunner):
         return GenerationBatchResult(
             logits_output=logits_output, can_run_cuda_graph=False
         )
+
+    def lookahead_eligible(self, batch: Any) -> bool:
+        """Route to sync where the one-step lag would diverge from sync. Speech /
+        hidden-capture batches: the captured-hidden side channel is per-forward, so
+        launch(N) overwrites it before resolve(N-1) reads it and the talker gets
+        mismatched hidden states. Sampling that reads the lagged output history
+        (repetition/presence/frequency penalty, min_new_tokens) or a fixed seed
+        also diverges; logit_bias / custom_params are routed conservatively.
+        return_logprob is routed to sync because the lookahead sampler skips the
+        base logprob-recording path.
+        """
+        # note (jiaxin deng): hidden-capture (speech/audio-output) batches must not
+        # use the lookahead; the _captured_aux_hidden_states side channel would be
+        # overwritten by launch(N) before resolve(N-1) collects it.
+        if self._text_model.layers_to_capture:
+            return False
+        for req in batch.reqs:
+            # _omni_data is attached per request by OmniScheduler; guard the
+            # attribute access so a request data variant without the flag is
+            # simply treated as not requesting logprobs.
+            try:
+                needs_logprob = req._omni_data.return_logprob
+            except AttributeError:
+                needs_logprob = False
+            if needs_logprob:
+                return False
+            sp = req.sampling_params
+            if (
+                sp.repetition_penalty != 1.0
+                or sp.presence_penalty != 0.0
+                or sp.frequency_penalty != 0.0
+                or sp.min_new_tokens > 0
+                or sp.sampling_seed is not None
+                or sp.logit_bias is not None
+                or sp.custom_params
+            ):
+                return False
+        return True
+
+    def _async_host_buf(self, like: torch.Tensor, n: int) -> torch.Tensor:
+        # note (jiaxin deng): two pinned buffers ping-ponged so resolve(N) reads
+        # one while launch(N+1) writes the other.
+        if self._th_host_bufs is None or self._th_host_bufs[0].shape[0] < n:
+            self._th_host_bufs = [
+                torch.empty(n, dtype=like.dtype, device="cpu", pin_memory=True)
+                for _ in range(2)
+            ]
+            self._th_slot = 0
+        buf = self._th_host_bufs[self._th_slot]
+        self._th_slot ^= 1
+        return buf
+
+    def _sample_lookahead(self, logits_output, forward_batch, requests):
+        # note (jiaxin deng): penalties never reach here (lookahead_eligible routes
+        # those batches to sync); only static suppress tokens are lag-safe.
+        self._apply_codec_suppress_tokens(logits_output, requests)
+        return self.tp_worker.model_runner.sample(logits_output, forward_batch)
+
+    def post_decode_launch(self, result, forward_batch, requests):
+        n = len(requests)
+        if n == 0:
+            return None
+        # note (jiaxin deng): the decode forward leaves next_token_ids None (sync
+        # samples in _finalize); set it here for the next-step input chain.
+        if result.next_token_ids is None:
+            result.next_token_ids = self._sample_lookahead(
+                result.logits_output, forward_batch, requests
+            )
+        nt = result.next_token_ids
+        host_buf = self._async_host_buf(nt, n)
+        host_buf[:n].copy_(nt[:n], non_blocking=True)
+        return host_buf
+
+    def post_decode_resolve(
+        self, launch_buf, result, forward_batch, schedule_batch, requests
+    ):
+        del forward_batch, schedule_batch
+        if len(requests) == 0 or launch_buf is None:
+            return
+        n = len(requests)
+        result.next_token_ids = launch_buf[:n].to(torch.long).clone()

--- a/sglang_omni/models/qwen3_omni/bootstrap.py
+++ b/sglang_omni/models/qwen3_omni/bootstrap.py
@@ -14,6 +14,8 @@ def create_thinker_scheduler(
     tp_rank: int = 0,
     nccl_port: int | None = None,
     total_gpu_memory_fraction: float | None = None,
+    enable_async_decode: bool = True,
+    async_decode_min_batch_size: int = 2,
 ):
     """Create the Qwen thinker scheduler."""
     from sglang.srt.utils.hf_transformers_utils import get_tokenizer
@@ -99,6 +101,8 @@ def create_thinker_scheduler(
         request_builder=request_builder,
         result_adapter=result_adapter,
         stream_output_builder=stream_output_builder,
+        enable_async_decode=enable_async_decode,
+        async_decode_min_batch_size=async_decode_min_batch_size,
     )
 
 

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -107,7 +107,8 @@ def _aggregate_stage(*, process: str, speech_enabled: bool = False) -> StageConf
 
 
 def _thinker_stage(*, gpu: int, speech_enabled: bool, process: str) -> StageConfig:
-    factory_args = {"thinker_max_seq_len": 8192}
+    # note (jiaxin deng): async decode defaults on; --decode-mode sync overrides it.
+    factory_args = {"thinker_max_seq_len": 8192, "enable_async_decode": True}
     if speech_enabled:
         factory_args["speech_enabled"] = True
     return StageConfig(

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -944,6 +944,8 @@ def create_sglang_thinker_executor_from_config(
     encoder_mem_reserve: float = 0.05,
     speech_enabled: bool = False,
     total_gpu_memory_fraction: float | None = None,
+    enable_async_decode: bool = True,
+    async_decode_min_batch_size: int = 2,
 ):
     """Returns OmniScheduler for thinker."""
     # note (luojiaxuan):
@@ -1026,6 +1028,8 @@ def create_sglang_thinker_executor_from_config(
         tp_rank=tp_rank,
         nccl_port=nccl_port,
         total_gpu_memory_fraction=effective_total_gpu_memory_fraction,
+        enable_async_decode=enable_async_decode,
+        async_decode_min_batch_size=async_decode_min_batch_size,
     )
     post_load_process_mem = get_process_gpu_memory_bytes(gpu_id)
     logger.info(

--- a/tests/unit_test/higgs_tts/test_cli_decode_mode.py
+++ b/tests/unit_test/higgs_tts/test_cli_decode_mode.py
@@ -85,9 +85,7 @@ def test_decode_mode_cli_invalid_mode_rejected():
 
 def test_decode_mode_cli_rejects_unsupported_config():
     config = Qwen3TTSPipelineConfig(model_path="dummy")
-    with pytest.raises(
-        typer.BadParameter, match="currently supports only Higgs TTS and MOSS-TTS-Local"
-    ):
+    with pytest.raises(typer.BadParameter, match="no async-decode-capable stage"):
         apply_decode_mode_cli_overrides(
             config, decode_mode="sync", async_lookahead_min_batch_size=None
         )
@@ -130,7 +128,7 @@ def test_async_lookahead_min_batch_size_without_tts_engine_fails_fast():
             )
         ],
     )
-    with pytest.raises(typer.BadParameter, match="tts_engine"):
+    with pytest.raises(typer.BadParameter, match="no async-decode-capable stage"):
         apply_decode_mode_cli_overrides(
             config, decode_mode=None, async_lookahead_min_batch_size=4
         )

--- a/tests/unit_test/qwen3_omni/test_thinker_async_decode_flag.py
+++ b/tests/unit_test/qwen3_omni/test_thinker_async_decode_flag.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The thinker stage defaults to async decode, and --decode-mode overrides it.
+
+Async decode is on by default (parity with Higgs); --decode-mode sync must route
+the override to the thinker stage (resolved by factory) and turn it off.
+"""
+from __future__ import annotations
+
+from sglang_omni.cli.serve import apply_decode_mode_cli_overrides
+from sglang_omni.models.qwen3_omni.config import Qwen3OmniPipelineConfig
+
+
+def _thinker_factory_args(cfg):
+    return next(s for s in cfg.stages if s.name == "thinker").factory_args
+
+
+def test_thinker_async_on_by_default():
+    cfg = Qwen3OmniPipelineConfig(model_path="dummy")
+    assert _thinker_factory_args(cfg)["enable_async_decode"] is True
+
+
+def test_decode_mode_sync_disables_thinker_async():
+    cfg = Qwen3OmniPipelineConfig(model_path="dummy")
+    apply_decode_mode_cli_overrides(
+        cfg, decode_mode="sync", async_lookahead_min_batch_size=None
+    )
+    assert _thinker_factory_args(cfg)["enable_async_decode"] is False
+
+
+def test_decode_mode_async_keeps_thinker_async():
+    cfg = Qwen3OmniPipelineConfig(model_path="dummy")
+    apply_decode_mode_cli_overrides(
+        cfg, decode_mode="async", async_lookahead_min_batch_size=None
+    )
+    assert _thinker_factory_args(cfg)["enable_async_decode"] is True

--- a/tests/unit_test/qwen3_omni/test_thinker_lookahead_eligible.py
+++ b/tests/unit_test/qwen3_omni/test_thinker_lookahead_eligible.py
@@ -1,21 +1,30 @@
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests for ThinkerModelRunner.lookahead_eligible.
 
-lookahead_eligible reads only per-batch/per-request flags (never other instance
-state), so it is exercised on a bare instance built with ``object.__new__`` with a
-stand-in text model and request objects.
+lookahead_eligible reads only per-request flags (never other instance state), so it
+is exercised on a bare instance built with ``object.__new__`` and stand-in requests.
+Audio-output detection (should_generate_audio_output) is stubbed on the stand-in
+stage_payload.
 """
 from __future__ import annotations
 
 import types
 
+import pytest
+
 from sglang_omni.model_runner.thinker_model_runner import ThinkerModelRunner
 
 
-def _runner(layers_to_capture=()) -> ThinkerModelRunner:
-    r = object.__new__(ThinkerModelRunner)
-    r._text_model = types.SimpleNamespace(layers_to_capture=list(layers_to_capture))
-    return r
+@pytest.fixture(autouse=True)
+def _stub_audio_output(monkeypatch):
+    monkeypatch.setattr(
+        "sglang_omni.models.qwen3_omni.request_builders.should_generate_audio_output",
+        lambda payload: payload == "audio",
+    )
+
+
+def _runner() -> ThinkerModelRunner:
+    return object.__new__(ThinkerModelRunner)
 
 
 def _sp(**kw):
@@ -32,10 +41,12 @@ def _sp(**kw):
     return types.SimpleNamespace(**d)
 
 
-def _req(return_logprob=False, **sp_kw):
+def _req(return_logprob=False, stage_payload="text", **sp_kw):
     return types.SimpleNamespace(
         sampling_params=_sp(**sp_kw),
-        _omni_data=types.SimpleNamespace(return_logprob=return_logprob),
+        _omni_data=types.SimpleNamespace(
+            return_logprob=return_logprob, stage_payload=stage_payload
+        ),
     )
 
 
@@ -51,16 +62,22 @@ def test_empty_batch_is_eligible():
     assert _runner().lookahead_eligible(_batch()) is True
 
 
-def test_hidden_capture_disables_lookahead():
-    # speech / audio-output server: capturing hidden layers routes to sync so the
-    # async launch cannot overwrite the captured-hidden side channel.
-    assert (
-        _runner(layers_to_capture=[0, 24]).lookahead_eligible(_batch(_req())) is False
-    )
+def test_audio_output_disables_lookahead():
+    # an audio-output request captures hidden for the talker -> route to sync.
+    assert _runner().lookahead_eligible(_batch(_req(stage_payload="audio"))) is False
 
 
 def test_return_logprob_disables_lookahead():
     assert _runner().lookahead_eligible(_batch(_req(return_logprob=True))) is False
+
+
+def test_missing_or_none_omni_data_falls_to_sync():
+    # request data missing or None cannot be inspected -> fail closed to sync
+    # (never raise, never let a possible hidden-capture batch onto async).
+    no_data = types.SimpleNamespace(sampling_params=_sp())
+    assert _runner().lookahead_eligible(_batch(no_data)) is False
+    none_data = types.SimpleNamespace(sampling_params=_sp(), _omni_data=None)
+    assert _runner().lookahead_eligible(_batch(none_data)) is False
 
 
 def test_each_gated_sampling_param_disables_lookahead():
@@ -77,5 +94,7 @@ def test_each_gated_sampling_param_disables_lookahead():
 
 
 def test_one_gated_request_disables_whole_batch():
-    batch = _batch(_req(), _req(repetition_penalty=1.3), _req())
-    assert _runner().lookahead_eligible(batch) is False
+    audio_mix = _batch(_req(), _req(stage_payload="audio"), _req())
+    assert _runner().lookahead_eligible(audio_mix) is False
+    param_mix = _batch(_req(), _req(repetition_penalty=1.3), _req())
+    assert _runner().lookahead_eligible(param_mix) is False

--- a/tests/unit_test/qwen3_omni/test_thinker_lookahead_eligible.py
+++ b/tests/unit_test/qwen3_omni/test_thinker_lookahead_eligible.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ThinkerModelRunner.lookahead_eligible.
+
+lookahead_eligible reads only per-batch/per-request flags (never other instance
+state), so it is exercised on a bare instance built with ``object.__new__`` with a
+stand-in text model and request objects.
+"""
+from __future__ import annotations
+
+import types
+
+from sglang_omni.model_runner.thinker_model_runner import ThinkerModelRunner
+
+
+def _runner(layers_to_capture=()) -> ThinkerModelRunner:
+    r = object.__new__(ThinkerModelRunner)
+    r._text_model = types.SimpleNamespace(layers_to_capture=list(layers_to_capture))
+    return r
+
+
+def _sp(**kw):
+    d = dict(
+        repetition_penalty=1.0,
+        presence_penalty=0.0,
+        frequency_penalty=0.0,
+        min_new_tokens=0,
+        sampling_seed=None,
+        logit_bias=None,
+        custom_params=None,
+    )
+    d.update(kw)
+    return types.SimpleNamespace(**d)
+
+
+def _req(return_logprob=False, **sp_kw):
+    return types.SimpleNamespace(
+        sampling_params=_sp(**sp_kw),
+        _omni_data=types.SimpleNamespace(return_logprob=return_logprob),
+    )
+
+
+def _batch(*reqs):
+    return types.SimpleNamespace(reqs=list(reqs))
+
+
+def test_plain_greedy_is_eligible():
+    assert _runner().lookahead_eligible(_batch(_req(), _req())) is True
+
+
+def test_empty_batch_is_eligible():
+    assert _runner().lookahead_eligible(_batch()) is True
+
+
+def test_hidden_capture_disables_lookahead():
+    # speech / audio-output server: capturing hidden layers routes to sync so the
+    # async launch cannot overwrite the captured-hidden side channel.
+    assert (
+        _runner(layers_to_capture=[0, 24]).lookahead_eligible(_batch(_req())) is False
+    )
+
+
+def test_return_logprob_disables_lookahead():
+    assert _runner().lookahead_eligible(_batch(_req(return_logprob=True))) is False
+
+
+def test_each_gated_sampling_param_disables_lookahead():
+    for kw in (
+        dict(repetition_penalty=1.3),
+        dict(presence_penalty=0.5),
+        dict(frequency_penalty=0.5),
+        dict(min_new_tokens=5),
+        dict(sampling_seed=42),
+        dict(logit_bias={1: 2.0}),
+        dict(custom_params={"x": 1}),
+    ):
+        assert _runner().lookahead_eligible(_batch(_req(**kw))) is False, kw
+
+
+def test_one_gated_request_disables_whole_batch():
+    batch = _batch(_req(), _req(repetition_penalty=1.3), _req())
+    assert _runner().lookahead_eligible(batch) is False


### PR DESCRIPTION
## Motivation

The Qwen3-Omni thinker decode loop is host-bound: a per-step `next_token_ids.tolist()` sync is roughly 90% of decode host time. This PR extends the omni async-decode one-step lookahead (#590, Higgs) to the thinker, overlapping that sync with the next step's GPU forward. Result: about +6-10% thinker text-decode throughput at concurrency 8-32, bit-identical to the synchronous path for greedy generation. Async is default-on for text decode; speech / hidden-capture, logprob, and history- or seed-dependent sampling automatically route to the synchronous path (see the gate below).

## Design

`post_decode_launch` samples `next_token_ids` on GPU and issues a non-blocking D2H copy into a pinned ping-pong buffer; `post_decode_resolve` reads it one step later, overlapping the next forward. Async is on by default (parity with Higgs); `--decode-mode sync` disables it, and batches below `async_decode_min_batch_size` (default 2) take the sync fast path.

The one-step lag is bit-identical only when nothing in the batch reads the lagged generated history, a fixed RNG seed, or the per-forward hidden-state side channel. `ThinkerModelRunner.lookahead_eligible` routes such batches to the synchronous path:

```text
route to sync if any request:
  captures hidden states (speech / audio output)   _captured_aux_hidden_states side channel is overwritten by launch(N) before resolve(N-1) reads it -> talker gets mismatched hidden
  sets repetition / presence / frequency_penalty    penalize the generated history
  sets min_new_tokens                               suppress EOS by generated-token count
  sets sampling_seed                                the overrun sample shifts the RNG draw order
  requests return_logprob                           the lookahead sampler skips the base logprob-recording path
  sets logit_bias / custom_params                   conservative; not proven lag-safe
```

Audited all 25 `SamplingParams` fields; these are the only history- or seed-dependent ones. Grammar (regex/ebnf/json_schema/structural_tag) is inert in the thinker (`grammar_backend=None`); shape params (temperature/top_k/top_p/min_p) apply identically to both paths via the shared `forward_batch`; the rest are finish conditions or detok formatting. Audio-output (hidden-capture) and return_logprob are detected per request via `should_generate_audio_output` on the request's `_omni_data`, so a text-output request on a speech-enabled server still takes the async path (only the audio-output requests route to sync).

## Modifications

- Add `post_decode_launch` / `post_decode_resolve` / `lookahead_eligible` to `ThinkerModelRunner`; share a `_text_only_capture_guard` between `execute` and the async launch for hidden-capture parity.
- Gate audio-output (hidden-capture) and `return_logprob` requests to sync per batch via `should_generate_audio_output` on `_omni_data`, alongside the history/seed-dependent sampling params; text-output requests on a speech-enabled server stay async.
- Thread `enable_async_decode` (default on) and `async_decode_min_batch_size` through `config` factory_args -> thinker stage executor -> `create_thinker_scheduler`.
- Resolve the `--decode-mode` override target by factory so it reaches the `thinker` stage (previously `tts_engine` only).
- Add unit coverage for the gate (each gated class -> sync, plain greedy -> async) and for default-on / `--decode-mode sync`.

## Validation

Rebased onto `origin/main` (`038612ac`); unit tests 6/6.

**Bit-identical (text decode): async signature == sync signature, verified on this commit (`12145110`, 2026-07-02), greedy temp=0, deterministic triplicate. The async side is confirmed to actually take the lookahead (launch count), and the penalty case is confirmed routed to sync (0 launches):**

| edge case | async == sync signature | async lookahead launches |
|---|---|---|
| plain greedy | `15800438b1352786` | 1248 |
| natural EOS + overrun + drain to bs<2 | `a23e8df1db732d50` | 384 |
| repetition_penalty 1.3 (routed to sync) | `a6084c4f13ea02e6` | 0 (sync) |

Absolute signatures differ from the pre-rebase reference due to setup; the async == sync invariant is the claim.

**Per-batch gate on a speech-enabled server (only audio-output routed to sync, text recovered to async):** instrumented the `_captured_aux_hidden_states` write and collect read and ran an interleaved text(async) + speech(sync) workload; across 39 speech forwards and 11 text-async forwards, all 21 fresh speech collects read their own forward's tensor and 0 fresh reads returned `None` (a sync batch's forward and collect are sequential in one scheduler iteration, so a text `None` write cannot land between them). Recovered text-decode throughput, colocated FP8 speech server, async vs sync:

| conc | async tok/s | sync tok/s | delta |
|---|---:|---:|---:|
| 8 | 710 | 704 | +0.9% |
| 16 | 1334 | 1177 | +13.3% |

Speech E2E on the same server stays at parity (async ≈ sync, 0 failed at c=8/16). The `out_cache_loc=None` prefill crash is specific to audio-output/hidden-capture batches, not multimodal input (an image-input / text-output request runs async without it), so multimodal-input text requests also take the async path.

**Thinker text-decode throughput (the win), FP8, H100 80GB SXM5, greedy, median of 3:**

| concurrency | sync tok/s | async tok/s | delta |
|---|---:|---:|---:|
| 1 | 182 | 183 | +0.4% |
| 8 | 1203 | 1282 | +6.5% |
| 16 | 2231 | 2464 | +10.4% |
| 32 | 2263 | 2467 | +9.0% |

**Speech E2E perf, `benchmark_omni_rollout_stress.py` (colocated Qwen3-Omni FP8, `--enable-audio`, full talker path), async vs sync, concurrency sweep:**

| conc | success (async / sync) | output tok/s (async / sync) | throughput req/s (async / sync) | p50 / p95 / p99 latency s (async \| sync) |
|---|---|---|---|---|
| 8 | 8/8, 8/8 / 8/8, 8/8 | 55.8-77.5 / 58.4-77.0 | 0.23-0.31 / 0.23-0.31 | 24.6-24.7/25.8-33.0/26.0-35.0 \| 24.1-24.9/26.0-31.7/26.1-34.2 |
| 16 | 16/16 / 16/16 | 83.7 / 91.5 | 0.328 / 0.359 | 39.5/47.4/48.5 \| 37.0/42.9/44.1 |
| 32 | 32/32 / 32/32 | 90.5 / 96.1 | 0.357 / 0.376 | 55.4/76.2/85.7 \| 62.3/81.6/83.9 |

0 failed requests across every condition. Run-to-run variance is large on this shared box (two c=8 reps of the same condition span tok/s 55.8-77.5, with neighbor-tenant contention and 25-85 s per-request latencies), so the async-vs-sync deltas at c=16/32 sit inside that noise band; async and sync are on par with no regression.

**Speech E2E quality (rollout_stress has no WER, so seedtts covers it), Qwen3-ASR-1.7B, 48 samples, 3 runs each:**

| | WER corpus (3 runs) | evaluated | >50% outliers |
|---|---|---|---|
| sync | 2.03% / 1.50% / 1.29% | 48/48 | 0 / 1 / 0 |
| async | 1.48% / 0.93% / 1.69% | 48/48 | 0 / 1 / 1 |

The WER ranges overlap and both sit at the reference level (~2.14% on H200 full-set); async is not degraded, so hidden-state capture is not misaligned.

Mechanism: on the async server, speech / audio-output batches take the sync path via the gate, so parity is expected and is exactly what confirms the gate routes them correctly. Without the gate, async speech crashes with `out_cache_loc=None` in the multimodal prefill (a pre-existing branch issue in how the async event loop builds the multimodal ForwardBatch, independent of this PR); the gate keeps speech off that path. Enabling async for speech in the future would first need that prefill fixed.

## Default / rollback

Async decode is default-on for text decode (the +6-10% win, bit-identical). Speech / hidden-capture, `return_logprob`, and history/seed-dependent sampling automatically route to sync via `lookahead_eligible`; single-request (bs < 2) decode also uses the sync fast path. `--decode-mode sync` disables async entirely. Correctness is covered by the bit-identical gate plus both speech E2E suites above.
