### PR TITLE
[Qwen3]: Remove redundant Qwen3 Omni deepstack clone

### DIFF
--- a/sglang_omni/models/qwen3_omni/components/thinker_model.py
+++ b/sglang_omni/models/qwen3_omni/components/thinker_model.py
@@ -708,7 +708,7 @@ class Qwen3OmniMoeThinkerTextModel(nn.Module):
             visual_pos_masks = visual_pos_masks[..., 0]
         visual_pos_masks = visual_pos_masks.to(hidden_states.device)
         visual_embeds = visual_embeds.to(hidden_states.device, hidden_states.dtype)
-        local_this = hidden_states[visual_pos_masks, :].clone() + visual_embeds
+        local_this = hidden_states[visual_pos_masks, :] + visual_embeds
         hidden_states[visual_pos_masks, :] = local_this
         return hidden_states
 


### PR DESCRIPTION
Summary:
- Removes a redundant `.clone()` in the Qwen3-Omni thinker deepstack update.
- `hidden_states[visual_pos_masks, :]` uses boolean advanced indexing, which already materializes a temporary tensor before the out-of-place add with `visual_embeds`.
- This is a narrow cleanup only; it does not change routing, configuration, or public behavior.
