### PR TITLE
[CI] Add per-sample ASR diagnostics and audio artifacts to TTS CI

### DIFF
--- a/.github/workflows/test-tts-ci.yaml
+++ b/.github/workflows/test-tts-ci.yaml
@@ -62,6 +62,17 @@ jobs:
           HF_TOKEN: ${{ secrets.BOSON_HF_TOKEN }}
           QWEN3_ASR_MODEL_PATH: ${{ env.QWEN3_ASR_MODEL_PATH }}
           TORCHINDUCTOR_CACHE_DIR: ${{ env.OMNI_CI_HOME }}/.torchinductor
+          QWEN3_ASR_RESULTS_DIR: ${{ env.OMNI_CI_HOME }}/qwen3-asr-results
+
+      - name: Upload Qwen3-ASR per-sample artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tts-stage1-asr-per-sample
+          path: ${{ env.OMNI_CI_HOME }}/qwen3-asr-results/qwen3_asr_results.json
+          if-no-files-found: warn
+          retention-days: 7
+          overwrite: true
 
       - name: Post-stage cleanup
         if: always()
@@ -122,6 +133,30 @@ jobs:
           retention-days: 7
           overwrite: true
 
+      - name: Upload non-streaming ASR debug artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tts-stage-nonstream-asr-debug
+          path: |
+            ${{ env.OMNI_CI_HOME }}/tts-stage-results/nonstream/**/asr_speed_results.json
+            ${{ env.OMNI_CI_HOME }}/tts-stage-results/nonstream/**/asr_speed_per_sample.json
+            ${{ env.OMNI_CI_HOME }}/tts-stage-results/nonstream/**/wer_results.json
+            ${{ env.OMNI_CI_HOME }}/tts-stage-results/nonstream/**/generated.json
+          if-no-files-found: warn
+          retention-days: 7
+          overwrite: true
+
+      - name: Upload non-streaming generated audio
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tts-stage-nonstream-audio
+          path: ${{ env.OMNI_CI_HOME }}/tts-stage-results/nonstream/**/audio/**
+          if-no-files-found: warn
+          retention-days: 7
+          overwrite: true
+
       - name: Post-stage cleanup
         if: always()
         uses: ./.github/actions/omni-post-stage
@@ -173,6 +208,30 @@ jobs:
           name: tts-stage-stream-speed-results
           path: ${{ env.OMNI_CI_HOME }}/tts-stage-results/stream/**/speed_results.json
           if-no-files-found: error
+          retention-days: 7
+          overwrite: true
+
+      - name: Upload streaming ASR debug artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tts-stage-stream-asr-debug
+          path: |
+            ${{ env.OMNI_CI_HOME }}/tts-stage-results/stream/**/asr_speed_results.json
+            ${{ env.OMNI_CI_HOME }}/tts-stage-results/stream/**/asr_speed_per_sample.json
+            ${{ env.OMNI_CI_HOME }}/tts-stage-results/stream/**/wer_results.json
+            ${{ env.OMNI_CI_HOME }}/tts-stage-results/stream/**/generated.json
+          if-no-files-found: warn
+          retention-days: 7
+          overwrite: true
+
+      - name: Upload streaming generated audio
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tts-stage-stream-audio
+          path: ${{ env.OMNI_CI_HOME }}/tts-stage-results/stream/**/audio/**
+          if-no-files-found: warn
           retention-days: 7
           overwrite: true
 

--- a/benchmarks/tasks/tts.py
+++ b/benchmarks/tasks/tts.py
@@ -1050,6 +1050,26 @@ def run_seedtts_transcribe(
 
     save_wer_results(outputs, wer_metrics, wer_config, config.output_dir)
     save_json_results(asr_metrics, config.output_dir, "asr_speed_results.json")
+    save_json_results(
+        [
+            {
+                "sample_id": o.sample_id,
+                "is_success": o.is_success,
+                "audio_duration_s": round(o.audio_duration_s, 4),
+                "asr_latency_s": round(o.asr_latency_s, 4),
+                "rtf": (
+                    round(o.asr_latency_s / o.audio_duration_s, 4)
+                    if o.audio_duration_s > 0
+                    else None
+                ),
+                "wer": round(o.wer, 6) if o.is_success else None,
+                "error": o.error or None,
+            }
+            for o in outputs
+        ],
+        config.output_dir,
+        "asr_speed_per_sample.json",
+    )
 
     return {
         "wer_summary": wer_metrics,

--- a/tests/test_model/test_qwen3_asr_ci.py
+++ b/tests/test_model/test_qwen3_asr_ci.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
+from pathlib import Path
 
 import pytest
 
@@ -166,8 +168,18 @@ def test_qwen3_asr_matches_seedtts_reference_text(
     print_asr_wer_summary(summary, QWEN3_ASR_CI_MODEL_PATH)
     print_asr_speed_summary(speed, QWEN3_ASR_CI_MODEL_PATH)
 
-    results_path = tmp_path_factory.getbasetemp() / "qwen3_asr_results.json"
-    results_path.write_text(json.dumps({"summary": summary, "speed": speed}, indent=2))
+    results_dir = os.environ.get("QWEN3_ASR_RESULTS_DIR")
+    if results_dir:
+        Path(results_dir).mkdir(parents=True, exist_ok=True)
+        results_path = Path(results_dir) / "qwen3_asr_results.json"
+    else:
+        results_path = tmp_path_factory.getbasetemp() / "qwen3_asr_results.json"
+    results_path.write_text(
+        json.dumps(
+            {"summary": summary, "speed": speed, "per_sample": results["per_sample"]},
+            indent=2,
+        )
+    )
 
     corpus_wer = summary["corpus_wer"]
     throughput_samples_per_s = speed["throughput_samples_per_s"]

--- a/tests/test_model/test_tts_ci.py
+++ b/tests/test_model/test_tts_ci.py
@@ -688,6 +688,9 @@ def similarity_checkpoint() -> str | None:
 @pytest.fixture(scope="module", autouse=True)
 def cleanup_generated_audio_fixture():
     yield
+    # keep generated audio in CI staging mode so the upload step can read it
+    if os.environ.get(TTS_STAGE_OUTPUT_ROOT_ENV):
+        return
     for output_dirs in SPEED_OUTPUT_DIRS.values():
         for output_dir in output_dirs.values():
             audio_dir = Path(output_dir) / "audio"


### PR DESCRIPTION
## Motivation

The TTS CI runs Qwen3-ASR across three stages but reports only aggregate ASR speed, and it deletes the generated audio after each stage. Issue #890 asks whether the stage-1 (reference audio) vs stage-2/3 (generated audio) throughput gap comes from a small number of bad generated clips. That cannot be checked today without the per-sample ASR timings or the audio, neither of which leaves the runner.

This is a temporary diagnostic to gather that data for #890. It does not change any threshold or workload. Once the cause is confirmed we plan to revert it or fold it into the actual fix, so it is not meant to live in the tree long term.

## Modifications

- `benchmarks/tasks/tts.py`: stage-2/3 transcription writes `asr_speed_per_sample.json` (per utterance `asr_latency_s`, `rtf`, `wer`, `audio_duration_s`, `is_success`) next to the existing aggregate `asr_speed_results.json`.
- `tests/test_model/test_qwen3_asr_ci.py`: stage-1 includes the `per_sample` rows it already computes in its results file, and writes the file under `QWEN3_ASR_RESULTS_DIR` when that variable is set. Behavior is unchanged when it is not.
- `tests/test_model/test_tts_ci.py`: the audio cleanup fixture keeps the generated audio in CI staging mode so the upload step can read it.
- `.github/workflows/test-tts-ci.yaml`: upload the per-sample JSONs, `wer_results.json`, `generated.json` and the generated audio as artifacts for all three stages. New uploads use `if-no-files-found: warn` so they never fail the run.

## Related Issues

Refs #890

## Accuracy Test

Not applicable. No model or kernel code is changed.

## Benchmark & Profiling

Not applicable. This only adds diagnostic artifacts and does not change the benchmark workload or thresholds.

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
