### PR TITLE
[Qwen3]: Defer non-streaming Code2Wav audio materialization

### DIFF
--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -173,11 +173,14 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         full_audio = None if stream_enabled else self._concat_audio_parts(audio_parts)
         payload = self._payloads[request_id]
         if logger.isEnabledFor(logging.DEBUG):
+            emitted_samples = sum(self._audio_numel(part) for part in audio_parts)
             logger.debug(
-                "Code2Wav finalize req=%s code_chunks=%s audio_parts=%s final_samples=%s",
+                "Code2Wav finalize req=%s code_chunks=%s audio_parts=%s "
+                "emitted_samples=%s final_payload_samples=%s",
                 request_id,
                 len(self._code_chunks[request_id]),
                 len(audio_parts),
+                emitted_samples,
                 0 if full_audio is None else self._audio_numel(full_audio),
             )
         # Streaming clients already received per-chunk audio; final result is

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -73,7 +73,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         # Per-request state
         self._code_chunks: dict[str, list[torch.Tensor]] = {}
         self._emitted: dict[str, int] = {}
-        self._audio_chunks: dict[str, list[np.ndarray]] = {}
+        self._audio_chunks: dict[str, list[np.ndarray | torch.Tensor]] = {}
         self._stream_enabled: dict[str, bool] = {}
         super().__init__(compute_fn=None)
         self._payloads = self._stream_payloads
@@ -169,7 +169,8 @@ class Code2WavScheduler(StreamingSimpleScheduler):
                 RuntimeError(f"code2wav produced no audio for {request_id!r}"),
             )
             return []
-        full_audio = np.concatenate(audio_parts).astype(np.float32, copy=False)
+        stream_enabled = self._stream_enabled.get(request_id, False)
+        full_audio = None if stream_enabled else self._concat_audio_parts(audio_parts)
         payload = self._payloads[request_id]
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
@@ -177,18 +178,19 @@ class Code2WavScheduler(StreamingSimpleScheduler):
                 request_id,
                 len(self._code_chunks[request_id]),
                 len(audio_parts),
-                int(full_audio.shape[0]),
+                0 if full_audio is None else self._audio_numel(full_audio),
             )
         # Streaming clients already received per-chunk audio; final result is
         # metadata-only to avoid IPC-ing full audio that the HTTP layer drops.
         # Default False so missing latch falls back to non-streaming (safe:
         # may waste bandwidth, never starves a non-streaming client).
-        if self._stream_enabled.get(request_id, False):
+        if stream_enabled:
             final_data: dict[str, Any] = {
                 "modality": "audio",
                 "sample_rate": self._sample_rate,
             }
         else:
+            assert full_audio is not None
             final_data = self._build_audio_payload(full_audio)
         messages.append(
             OutgoingMessage(
@@ -207,10 +209,17 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         chunks = self._code_chunks[request_id]
         start = self._emitted[request_id]
         end = len(chunks)
-        audio = self._decode_incremental(request_id, chunks, start, end)
+        stream_enabled = self._stream_enabled.get(request_id, True)
+        audio = self._decode_incremental(
+            request_id,
+            chunks,
+            start,
+            end,
+            to_numpy=stream_enabled,
+        )
         self._emitted[request_id] = end
         messages: list[OutgoingMessage] = []
-        if audio.size > 0:
+        if self._audio_numel(audio) > 0:
             is_first = not self._audio_chunks[request_id]
             self._audio_chunks[request_id].append(audio)
             if is_first:
@@ -218,9 +227,9 @@ class Code2WavScheduler(StreamingSimpleScheduler):
                     request_id=request_id,
                     stage=None,
                     event_name="code2wav_first_audio",
-                    metadata={"samples": int(audio.shape[0])},
+                    metadata={"samples": self._audio_numel(audio)},
                 )
-            if self._stream_enabled.get(request_id, True):
+            if stream_enabled:
                 messages.append(
                     OutgoingMessage(
                         request_id=request_id,
@@ -233,10 +242,16 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         return messages
 
     def _decode_incremental(
-        self, request_id: str, code_chunks, start, end
-    ) -> np.ndarray:
+        self,
+        request_id: str,
+        code_chunks,
+        start,
+        end,
+        *,
+        to_numpy: bool,
+    ) -> np.ndarray | torch.Tensor:
         if start >= end:
-            return np.zeros((0,), dtype=np.float32)
+            return np.zeros((0,), dtype=np.float32) if to_numpy else torch.empty(0)
         context = min(self._left_context_size, start)
         window = torch.stack(code_chunks[start - context : end], dim=0)
         codes = window.transpose(0, 1).unsqueeze(0)
@@ -247,7 +262,14 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         trim = context * self._total_upsample
         if trim:
             wav = wav[..., trim:]
-        audio = wav.reshape(-1).detach().cpu().float().numpy().copy()
+        audio_tensor = wav.reshape(-1).detach()
+        audio: np.ndarray | torch.Tensor
+        if to_numpy:
+            audio = audio_tensor.cpu().float().numpy().copy()
+        else:
+            if trim:
+                audio_tensor = audio_tensor.clone()
+            audio = audio_tensor
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
                 "Code2Wav decode window=%s start=%s end=%s trim=%s samples=%s",
@@ -255,17 +277,32 @@ class Code2WavScheduler(StreamingSimpleScheduler):
                 start,
                 end,
                 trim,
-                int(audio.shape[0]),
+                self._audio_numel(audio),
             )
         return audio
 
-    def _build_audio_payload(self, audio: np.ndarray) -> dict[str, Any]:
+    def _build_audio_payload(self, audio: np.ndarray | torch.Tensor) -> dict[str, Any]:
+        if isinstance(audio, torch.Tensor):
+            audio = audio.detach().cpu().float().numpy()
         return audio_waveform_payload(
             audio.astype(np.float32, copy=False),
             sample_rate=self._sample_rate,
             modality="audio",
             source_hint="Qwen3-Omni code2wav",
         )
+
+    @staticmethod
+    def _audio_numel(audio: np.ndarray | torch.Tensor) -> int:
+        if isinstance(audio, torch.Tensor):
+            return int(audio.numel())
+        return int(audio.size)
+
+    @staticmethod
+    def _concat_audio_parts(
+        audio_parts: list[np.ndarray | torch.Tensor],
+    ) -> torch.Tensor:
+        assert all(isinstance(part, torch.Tensor) for part in audio_parts)
+        return torch.cat(audio_parts, dim=0)
 
 
 def create_code2wav_scheduler(


### PR DESCRIPTION
## Motivation

This PR reduces CPU/GPU transfer work in the Qwen3-Omni Code2Wav scheduler for non-streaming TTS responses.

Before this change, each decoded Code2Wav window was immediately materialized as CPU float32 NumPy, even when the request was non-streaming and the client would only receive the final audio. The scheduler then concatenated those NumPy chunks at request completion.

After this change, streaming behavior is unchanged, but non-streaming requests keep decoded audio windows as detached torch tensors and build the final audio payload once at request completion.

## Modifications

Streaming requests are intentionally unchanged because streaming clients need each audio chunk immediately:

```text
decoded window tensor -> CPU float32 NumPy -> emit stream audio chunk
```

Non-streaming requests before:

```text
decoded window tensor -> CPU float32 NumPy per window -> np.concatenate -> payload
```

Non-streaming requests after:

```text
decoded window tensor -> keep detached tensor per window -> torch.cat -> payload
```

The change is a data-materialization cleanup. It does not change prompt construction, thinker generation, talker codec-token generation, vocoder inputs, window boundaries, left-context trimming, sample rate, or payload schema.

The final implementation also keeps the memory behavior bounded:

- Trimmed non-streaming tensor views are compacted before retention so the scheduler does not pin pre-trim backing storage until request finalization.
- Final tensor serialization copies to CPU before float32 conversion, avoiding a full fp32 temporary on GPU for fp16/bf16 Code2Wav outputs.

## Accuracy Tests

For the exact changed operation, an external local materialization probe held decoded vocoder tensors fixed and compared the old per-window NumPy materialization against the new final tensor materialization. It passed with byte-identical `audio_waveform` payloads for float32, float16, bfloat16, single-chunk, multi-chunk, and non-contiguous tensor cases.

Observed CUDA proof output:

```text
PASS float32_many_chunks: dtype=torch.float32 chunks=5 samples=4745
PASS float16_many_chunks: dtype=torch.float16 chunks=4 samples=2339
PASS bfloat16_many_chunks: dtype=torch.bfloat16 chunks=4 samples=4426
PASS float32_single_chunk: dtype=torch.float32 chunks=1 samples=8192
PASS float32_noncontiguous: dtype=torch.float32 chunks=3 samples=4369
PASS: old and new non-streaming Code2Wav payload bytes are identical
```

Focused unit result:

```text
1 passed
```

WER was evaluated with `Qwen/Qwen3-ASR-1.7B` on both generated output dirs.

| Metric | PR | Main `d7e62b0e` |
| --- | ---: | ---: |
| generated completed / failed | 1088 / 0 | 1088 / 0 |
| WER corpus | 2.11% | 2.65% |
| WER excl. >50% | 1.94% | 1.91% |
| >50% WER samples | 2 | 3 |
| WER sample mean | 2.28% | 2.86% |
| WER sample p95 | 14.29% | 13.04% |
| WER sample max | 214.29% | 842.86% |

ASR speed:

| Metric | PR | Main |
| --- | ---: | ---: |
| ASR evaluated / total | 1088 / 1088 | 1088 / 1088 |
| ASR skipped | 0 | 0 |
| ASR latency mean | 0.604s | 0.582s |
| ASR throughput | 52.75 samples/s | 54.78 samples/s |

## Speed Tests and Profiling

Full SeedTTS EN voice-clone A/B compared.

| Metric | PR | Main `d7e62b0e` | Delta |
| --- | ---: | ---: | ---: |
| completed / failed | 1088 / 0 | 1088 / 0 | same |
| throughput qps | 5.376 | 5.237 | +2.7% |
| rtf_mean | 0.8275 | 0.8410 | -1.6% |
| latency mean | 2.968s | 3.048s | -2.6% |
| latency p95 | 4.376s | 4.448s | -1.6% |
| latency p99 | 5.230s | 5.472s | -4.4% |
| audio throughput | 19.722 s/s | 19.537 s/s | +0.9% |
| output throughput | 76.6 tok/s | 74.6 tok/s | +2.7% |
| output tokens total | 15503 | 15500 | +3 tokens |


## Checklist

- [x] Format code according to the contribution guide.
- [x] Add or update tests as needed.
- [ ] Update documentation as needed.
- [x] Provide accuracy and speed results when the change affects them.
