### PR TITLE
Support MOSS-Transcribe-Diarize model

### DIFF
--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -203,6 +203,7 @@ class PipelineConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    architecture: ClassVar[str | None] = None
     architecture_aliases: ClassVar[tuple[str, ...]] = ()
     tensor_parallel_disable_custom_all_reduce_stages: ClassVar[tuple[str, ...]] = ()
 

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -30,6 +30,7 @@ _ARCH_CONFIG_MAP: dict[str, tuple[str, str | None]] = {
     "Qwen3TTSTalker": ("talker_config", None),
     "MossTTSDelaySGLangModel": ("language_config", None),
     "MossTTSLocalSGLangModel": ("language_config", None),
+    "MossTranscribeDiarizeForConditionalGeneration": ("text_config", None),
 }
 
 

--- a/sglang_omni/model_runner/sglang_model_runner.py
+++ b/sglang_omni/model_runner/sglang_model_runner.py
@@ -89,6 +89,7 @@ class SGLModelRunner(ModelRunner):
             "Qwen3TTSTalker": "sglang_omni.models.qwen3_tts.sglang_model:Qwen3TTSTalker",
             "MossTTSDelaySGLangModel": "sglang_omni.models.moss_tts.sglang_model:MossTTSDelaySGLangModel",
             "MossTTSLocalSGLangModel": "sglang_omni.models.moss_tts_local.sglang_model:MossTTSLocalSGLangModel",
+            "MossTranscribeDiarizeForConditionalGeneration": "sglang_omni.models.moss_transcribe_diarize.sglang_model:MossTranscribeDiarizeForConditionalGeneration",
             "VoxtralSGLangTTSModel": "sglang_omni.models.voxtral_tts.sglang_model:VoxtralSGLangTTSModel",
             "LLaDA2MoeModelLM": "sglang_omni.models.llada2_uni.components.thinker:LLaDA2MoeModelLM",
             "WhisperForConditionalGeneration": "sglang_omni.models.whisper_asr.sglang_model:WhisperForConditionalGeneration",

--- a/sglang_omni/models/moss_transcribe_diarize/__init__.py
+++ b/sglang_omni/models/moss_transcribe_diarize/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MOSS-Transcribe-Diarize model support."""

--- a/sglang_omni/models/moss_transcribe_diarize/config.py
+++ b/sglang_omni/models/moss_transcribe_diarize/config.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pipeline configuration for MOSS-Transcribe-Diarize."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from sglang_omni.config import PipelineConfig, StageConfig
+from sglang_omni.models.moss_transcribe_diarize import (  # noqa: F401
+    hf_config as _hf_config,
+)
+
+_PKG = "sglang_omni.models.moss_transcribe_diarize"
+
+
+class MossTranscribeDiarizePipelineConfig(PipelineConfig):
+    """Single-stage batched ASR/diarization pipeline for MOSS-TD checkpoints."""
+
+    architecture: ClassVar[str] = "MossTranscribeDiarizeForConditionalGeneration"
+
+    model_path: str
+    entry_stage: str = "asr"
+    stages: list[StageConfig] = [
+        StageConfig(
+            name="asr",
+            process="asr",
+            factory=f"{_PKG}.stages.create_sglang_moss_transcribe_diarize_executor",
+            factory_args={
+                "device": "cuda:0",
+                "max_running_requests": 16,
+                "request_build_max_workers": 2,
+                "request_build_max_pending": 16,
+            },
+            gpu=0,
+            terminal=True,
+        )
+    ]
+
+
+EntryClass = MossTranscribeDiarizePipelineConfig

--- a/sglang_omni/models/moss_transcribe_diarize/hf_config.py
+++ b/sglang_omni/models/moss_transcribe_diarize/hf_config.py
@@ -59,7 +59,7 @@ class MossTranscribeDiarizeConfig(PretrainedConfig):
             audio_config = self.sub_configs["audio_config"](**audio_config)
 
         text_config.tie_word_embeddings = tie_word_embeddings
-        if not getattr(text_config, "layer_types", None):
+        if not text_config.layer_types:
             text_config.layer_types = ["full_attention"] * text_config.num_hidden_layers
 
         self.text_config = text_config
@@ -70,9 +70,6 @@ class MossTranscribeDiarizeConfig(PretrainedConfig):
             adaptor_input_dim or audio_config.d_model * audio_merge_size
         )
         super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)
-
-    def get_text_config(self, decoder=False) -> PretrainedConfig:
-        return self.text_config
 
 
 AutoConfig.register(

--- a/sglang_omni/models/moss_transcribe_diarize/hf_config.py
+++ b/sglang_omni/models/moss_transcribe_diarize/hf_config.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HF config shim for MOSS-Transcribe-Diarize."""
+
+from __future__ import annotations
+
+from transformers import AutoConfig, PretrainedConfig
+from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
+from transformers.models.whisper.configuration_whisper import WhisperConfig
+
+
+class MossTranscribeDiarizeConfig(PretrainedConfig):
+    model_type = "moss_transcribe_diarize"
+    sub_configs = {"text_config": Qwen3Config, "audio_config": WhisperConfig}
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        text_config=None,
+        audio_config=None,
+        audio_token_id: int = 151671,
+        audio_merge_size: int = 4,
+        adaptor_input_dim: int | None = None,
+        tie_word_embeddings: bool = True,
+        **kwargs,
+    ):
+        if text_config is None:
+            text_config = Qwen3Config(
+                vocab_size=151936,
+                hidden_size=1024,
+                intermediate_size=3072,
+                num_hidden_layers=28,
+                num_attention_heads=16,
+                num_key_value_heads=8,
+                head_dim=128,
+                max_position_embeddings=40960,
+                tie_word_embeddings=tie_word_embeddings,
+                rope_theta=1_000_000.0,
+                layer_types=["full_attention"] * 28,
+            )
+        elif isinstance(text_config, dict):
+            text_config = self.sub_configs["text_config"](**text_config)
+
+        if audio_config is None:
+            audio_config = WhisperConfig(
+                num_mel_bins=80,
+                d_model=1024,
+                encoder_layers=24,
+                encoder_attention_heads=16,
+                encoder_ffn_dim=4096,
+                max_source_positions=1500,
+                dropout=0.0,
+                attention_dropout=0.0,
+                activation_dropout=0.0,
+                activation_function="gelu",
+                encoder_layerdrop=0.0,
+                scale_embedding=False,
+            )
+        elif isinstance(audio_config, dict):
+            audio_config = self.sub_configs["audio_config"](**audio_config)
+
+        text_config.tie_word_embeddings = tie_word_embeddings
+        if not getattr(text_config, "layer_types", None):
+            text_config.layer_types = ["full_attention"] * text_config.num_hidden_layers
+
+        self.text_config = text_config
+        self.audio_config = audio_config
+        self.audio_token_id = audio_token_id
+        self.audio_merge_size = audio_merge_size
+        self.adaptor_input_dim = (
+            adaptor_input_dim or audio_config.d_model * audio_merge_size
+        )
+        super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)
+
+    def get_text_config(self, decoder=False) -> PretrainedConfig:
+        return self.text_config
+
+
+AutoConfig.register(
+    "moss_transcribe_diarize", MossTranscribeDiarizeConfig, exist_ok=True
+)

--- a/sglang_omni/models/moss_transcribe_diarize/request_builders.py
+++ b/sglang_omni/models/moss_transcribe_diarize/request_builders.py
@@ -14,6 +14,7 @@ from typing import Any, Callable
 
 import numpy as np
 import torch
+import torchaudio
 from sglang.srt.managers.schedule_batch import (
     Modality,
     MultimodalDataItem,
@@ -32,6 +33,10 @@ _AUDIO_PAD = "<|audio_pad|>"
 _AUDIO_START = "<|audio_start|>"
 _AUDIO_END = "<|audio_end|>"
 _SPECIAL_TOKEN_RE = re.compile(r"<\|(?:im_start|im_end|endoftext)\|>")
+# MOSS-Transcribe-Diarize is an audio LLM: a Qwen3 text decoder over Whisper
+# audio embeddings, trained on a fixed transcribe+diarize instruction with the
+# timestamped/speaker-labelled transcript as the target output. This is the
+# default instruction used when a request does not supply its own prompt.
 DEFAULT_TRANSCRIBE_DIARIZE_PROMPT = (
     "请将音频转写为文本，每一段需以起始时间戳和说话人编号"
     "（[S01]、[S02]、[S03]…）开头，正文为对应的语音内容，"
@@ -52,7 +57,8 @@ def _only_audio(value: Any) -> Any:
     if isinstance(value, (list, tuple)):
         if len(value) != 1:
             raise ValueError(
-                "MOSS-Transcribe-Diarize supports exactly one audio per request"
+                "MOSS-Transcribe-Diarize supports exactly one audio per request, "
+                f"got {len(value)} items"
             )
         return value[0]
     return value
@@ -104,8 +110,6 @@ def _decode_data_uri(value: str) -> bytes | None:
 
 
 def load_audio(source: Any) -> np.ndarray:
-    import torchaudio
-
     if isinstance(source, dict):
         if source.get("data") is not None:
             source = source["data"]
@@ -144,8 +148,7 @@ def load_audio(source: Any) -> np.ndarray:
         sample_rate = _SAMPLE_RATE
     else:
         raise ValueError(
-            "Unsupported MOSS-Transcribe-Diarize audio input: "
-            f"{type(source).__name__}"
+            f"Unsupported MOSS-Transcribe-Diarize audio input: {type(source).__name__}"
         )
 
     if audio.ndim == 1:
@@ -243,7 +246,6 @@ def _contiguous_offsets(input_ids: list[int], token_id: int) -> list[tuple[int, 
 
 
 def make_moss_transcribe_diarize_scheduler_adapters(
-    *,
     processor: Any,
     tokenizer: Any,
     max_new_tokens: int,

--- a/sglang_omni/models/moss_transcribe_diarize/request_builders.py
+++ b/sglang_omni/models/moss_transcribe_diarize/request_builders.py
@@ -371,11 +371,7 @@ def make_moss_transcribe_diarize_scheduler_adapters(
                 "asr_latency_s": engine_time_s,
                 "prompt_tokens": len(data.prompt_token_ids or []),
                 "completion_tokens": len(output_ids),
-                "usage": {
-                    "engine_time_s": engine_time_s,
-                    "prompt_tokens": len(data.prompt_token_ids or []),
-                    "completion_tokens": len(output_ids),
-                },
+                "usage": {"engine_time_s": engine_time_s},
                 "finish_reason": data.finish_reason,
                 "weight_version": getattr(data, "weight_version", None),
                 "modality": "text",

--- a/sglang_omni/models/moss_transcribe_diarize/request_builders.py
+++ b/sglang_omni/models/moss_transcribe_diarize/request_builders.py
@@ -33,10 +33,10 @@ _AUDIO_PAD = "<|audio_pad|>"
 _AUDIO_START = "<|audio_start|>"
 _AUDIO_END = "<|audio_end|>"
 _SPECIAL_TOKEN_RE = re.compile(r"<\|(?:im_start|im_end|endoftext)\|>")
-# MOSS-Transcribe-Diarize is an audio LLM: a Qwen3 text decoder over Whisper
-# audio embeddings, trained on a fixed transcribe+diarize instruction with the
-# timestamped/speaker-labelled transcript as the target output. This is the
-# default instruction used when a request does not supply its own prompt.
+# Note (yichi): MOSS-Transcribe-Diarize is an audio LLM: a Qwen3 text decoder
+# over Whisper audio embeddings, trained on a fixed transcribe+diarize
+# instruction with the timestamped/speaker-labelled transcript as the target
+# output. This is the default instruction used when a request supplies no prompt.
 DEFAULT_TRANSCRIBE_DIARIZE_PROMPT = (
     "请将音频转写为文本，每一段需以起始时间戳和说话人编号"
     "（[S01]、[S02]、[S03]…）开头，正文为对应的语音内容，"

--- a/sglang_omni/models/moss_transcribe_diarize/request_builders.py
+++ b/sglang_omni/models/moss_transcribe_diarize/request_builders.py
@@ -1,0 +1,394 @@
+# SPDX-License-Identifier: Apache-2.0
+"""StagePayload <-> SGLang request adapters for MOSS-Transcribe-Diarize."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import logging
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import numpy as np
+import torch
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+    Req,
+)
+from sglang.srt.sampling.sampling_params import SamplingParams
+
+from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
+
+logger = logging.getLogger(__name__)
+
+_SAMPLE_RATE = 16000
+_AUDIO_PAD = "<|audio_pad|>"
+_AUDIO_START = "<|audio_start|>"
+_AUDIO_END = "<|audio_end|>"
+_SPECIAL_TOKEN_RE = re.compile(r"<\|(?:im_start|im_end|endoftext)\|>")
+DEFAULT_TRANSCRIBE_DIARIZE_PROMPT = (
+    "请将音频转写为文本，每一段需以起始时间戳和说话人编号"
+    "（[S01]、[S02]、[S03]…）开头，正文为对应的语音内容，"
+    "并在段末标注结束时间戳，以清晰标明该段语音范围。"
+)
+
+
+@dataclass
+class MossTranscribeDiarizeRequestData(SGLangARRequestData):
+    prompt_token_ids: list[int] | None = None
+    output_ids: list[int] | None = None
+    audio_duration_s: float = 0.0
+    language: str = "auto"
+    engine_start_s: float = 0.0
+
+
+def _only_audio(value: Any) -> Any:
+    if isinstance(value, (list, tuple)):
+        if len(value) != 1:
+            raise ValueError(
+                "MOSS-Transcribe-Diarize supports exactly one audio per request"
+            )
+        return value[0]
+    return value
+
+
+def _audio_source_from_payload(payload: StagePayload) -> Any:
+    inputs = payload.request.inputs
+    if isinstance(inputs, dict):
+        for key in ("audio_bytes", "bytes", "file", "audio_data"):
+            value = inputs.get(key)
+            if value is not None:
+                return value
+        value = inputs.get("audios")
+        if value is not None:
+            return _only_audio(value)
+        for key in ("audio_path", "path", "url"):
+            value = inputs.get(key)
+            if value is not None:
+                return value
+
+    metadata = payload.request.metadata or {}
+    value = metadata.get("audios")
+    if value is not None:
+        return _only_audio(value)
+    for key in ("audio_data", "audio"):
+        value = metadata.get(key)
+        if value is not None:
+            return value
+    return inputs
+
+
+def _has_metadata_audio_source(payload: StagePayload) -> bool:
+    metadata = payload.request.metadata or {}
+    return any(
+        metadata.get(key) is not None for key in ("audios", "audio_data", "audio")
+    )
+
+
+def _decode_data_uri(value: str) -> bytes | None:
+    if not value.startswith("data:"):
+        return None
+    _, _, payload = value.partition(",")
+    if not payload:
+        return None
+    try:
+        return base64.b64decode(payload)
+    except Exception as exc:
+        raise ValueError("Invalid base64 audio data URI") from exc
+
+
+def load_audio(source: Any) -> np.ndarray:
+    import torchaudio
+
+    if isinstance(source, dict):
+        if source.get("data") is not None:
+            source = source["data"]
+        elif source.get("path") is not None:
+            source = source["path"]
+        elif source.get("url") is not None:
+            source = source["url"]
+
+    if isinstance(source, memoryview):
+        source = source.tobytes()
+    if isinstance(source, bytearray):
+        source = bytes(source)
+    if isinstance(source, str):
+        decoded = _decode_data_uri(source)
+        if decoded is not None:
+            source = decoded
+    if isinstance(source, (list, tuple)):
+        try:
+            source = np.asarray(source, dtype=np.float32)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "MOSS-Transcribe-Diarize audio_data must be a single numeric waveform"
+            ) from exc
+
+    if isinstance(source, bytes):
+        audio, sample_rate = torchaudio.load(io.BytesIO(source))
+    elif isinstance(source, str):
+        audio, sample_rate = torchaudio.load(source)
+    elif isinstance(source, np.ndarray):
+        if source.size == 0:
+            raise ValueError("MOSS-Transcribe-Diarize audio input is empty")
+        audio = torch.from_numpy(source)
+        sample_rate = _SAMPLE_RATE
+    elif torch.is_tensor(source):
+        audio = source
+        sample_rate = _SAMPLE_RATE
+    else:
+        raise ValueError(
+            "Unsupported MOSS-Transcribe-Diarize audio input: "
+            f"{type(source).__name__}"
+        )
+
+    if audio.ndim == 1:
+        audio = audio.unsqueeze(0)
+    if audio.ndim == 2 and audio.shape[0] > 1:
+        audio = audio.mean(dim=0, keepdim=True)
+    audio = audio.squeeze(0).to(torch.float32)
+    if sample_rate != _SAMPLE_RATE:
+        audio = torchaudio.functional.resample(audio, sample_rate, _SAMPLE_RATE)
+    return audio.cpu().numpy()
+
+
+def _audio_fingerprint(audio: np.ndarray) -> str:
+    contiguous = np.ascontiguousarray(audio, dtype=np.float32)
+    return hashlib.blake2b(contiguous.tobytes(), digest_size=16).hexdigest()
+
+
+def _audio_fingerprint_int(fingerprint: str) -> int:
+    return int(fingerprint[:16], 16)
+
+
+def _decode_token_ids(
+    tokenizer: Any, token_ids: list[int], *, skip_special_tokens: bool
+) -> str:
+    try:
+        return tokenizer.decode(
+            token_ids,
+            skip_special_tokens=skip_special_tokens,
+            clean_up_tokenization_spaces=False,
+        )
+    except TypeError:
+        return tokenizer.decode(token_ids, skip_special_tokens=skip_special_tokens)
+
+
+def postprocess_moss_transcribe_diarize_text(text: str) -> str:
+    return _SPECIAL_TOKEN_RE.sub("", text).strip()
+
+
+def _prompt_from_payload(payload: StagePayload, processor: Any) -> str:
+    inputs = payload.request.inputs
+    params = payload.request.params or {}
+
+    if isinstance(inputs, dict) and "messages" in inputs:
+        return processor.apply_chat_template(
+            inputs["messages"],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+
+    input_text: Any = params.get("prompt")
+    if isinstance(inputs, dict):
+        input_text = inputs.get("prompt", inputs.get("text", input_text))
+    elif isinstance(inputs, str) and _has_metadata_audio_source(payload):
+        input_text = inputs
+
+    if isinstance(input_text, list):
+        input_text = processor.tokenizer.decode(input_text)
+    input_text = input_text or ""
+    if _AUDIO_PAD in input_text:
+        return str(input_text)
+
+    if not str(input_text).strip():
+        input_text = DEFAULT_TRANSCRIBE_DIARIZE_PROMPT
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "audio", "audio": ""},
+                {"type": "text", "text": str(input_text)},
+            ],
+        }
+    ]
+    return processor.apply_chat_template(
+        messages,
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+
+
+def _contiguous_offsets(input_ids: list[int], token_id: int) -> list[tuple[int, int]]:
+    offsets: list[tuple[int, int]] = []
+    start: int | None = None
+    for idx, value in enumerate(input_ids):
+        if value == token_id:
+            if start is None:
+                start = idx
+            continue
+        if start is not None:
+            offsets.append((start, idx - 1))
+            start = None
+    if start is not None:
+        offsets.append((start, len(input_ids) - 1))
+    return offsets
+
+
+def make_moss_transcribe_diarize_scheduler_adapters(
+    *,
+    processor: Any,
+    tokenizer: Any,
+    max_new_tokens: int,
+) -> tuple[
+    Callable[[StagePayload], MossTranscribeDiarizeRequestData],
+    Callable[[Any], StagePayload],
+]:
+    audio_token_id = int(
+        getattr(processor, "audio_token_id", None)
+        or tokenizer.convert_tokens_to_ids(_AUDIO_PAD)
+    )
+    audio_start_id = int(tokenizer.convert_tokens_to_ids(_AUDIO_START))
+    audio_end_id = int(tokenizer.convert_tokens_to_ids(_AUDIO_END))
+    eos_token_id = int(tokenizer.eos_token_id)
+    vocab_size = int(tokenizer.vocab_size)
+
+    def request_builder(payload: StagePayload) -> MossTranscribeDiarizeRequestData:
+        params = payload.request.params or {}
+        audio = load_audio(_audio_source_from_payload(payload))
+        audio_duration_s = float(len(audio) / _SAMPLE_RATE)
+        fingerprint = _audio_fingerprint(audio)
+        prompt = _prompt_from_payload(payload, processor)
+
+        encoded = processor(
+            text=prompt,
+            audio=audio,
+            return_tensors="pt",
+            max_length=int(params.get("max_length") or 131072),
+        )
+        input_ids = encoded["input_ids"][0].tolist()
+        features = encoded["input_features"]
+        audio_feature_lengths = encoded["audio_feature_lengths"]
+        audio_chunk_mapping = encoded["audio_chunk_mapping"]
+
+        offsets = _contiguous_offsets(input_ids, audio_token_id)
+        if not offsets:
+            raise ValueError("MOSS-Transcribe-Diarize prompt has no audio tokens")
+
+        audio_item = MultimodalDataItem(
+            modality=Modality.AUDIO,
+            hash=_audio_fingerprint_int(fingerprint),
+            feature=features,
+            model_specific_data={
+                "audio_feature_lengths": audio_feature_lengths,
+                "audio_chunk_mapping": audio_chunk_mapping,
+            },
+        )
+        audio_item.set_pad_value()
+        audio_item.offsets = offsets
+
+        padded_input_ids = [
+            audio_item.pad_value if token_id == audio_token_id else token_id
+            for token_id in input_ids
+        ]
+
+        mm_inputs = MultimodalInputs(
+            mm_items=[audio_item],
+            num_image_tokens=int(audio_feature_lengths.sum().item()),
+            audio_token_id=audio_token_id,
+            audio_start_id=audio_start_id,
+            audio_end_id=audio_end_id,
+        )
+
+        temperature = float(params.get("temperature") or 0.0)
+        request_max_new_tokens = int(params.get("max_new_tokens") or max_new_tokens)
+        sampling_params = SamplingParams(
+            max_new_tokens=request_max_new_tokens,
+            temperature=temperature,
+            top_p=float(params.get("top_p") or 1.0),
+            stop_token_ids=[eos_token_id],
+        )
+        sampling_params.normalize(tokenizer=None)
+
+        req = Req(
+            rid=payload.request_id,
+            origin_input_text="",
+            origin_input_ids=padded_input_ids,
+            sampling_params=sampling_params,
+            vocab_size=vocab_size,
+            extra_key=fingerprint,
+        )
+        req.multimodal_inputs = mm_inputs
+        req._codec_suppress_tokens = None
+
+        logger.debug(
+            "[moss-td] prompt_tokens=%d audio_tokens=%d chunks=%d duration=%.3fs",
+            len(padded_input_ids),
+            sum(end - start + 1 for start, end in offsets),
+            int(audio_feature_lengths.numel()),
+            audio_duration_s,
+        )
+
+        return MossTranscribeDiarizeRequestData(
+            input_ids=torch.tensor(padded_input_ids, dtype=torch.long),
+            req=req,
+            prompt_token_ids=padded_input_ids,
+            max_new_tokens=request_max_new_tokens,
+            temperature=temperature,
+            audio_duration_s=audio_duration_s,
+            language=str(params.get("language") or "auto"),
+            engine_start_s=time.perf_counter(),
+            stage_payload=payload,
+        )
+
+    def result_adapter(data: MossTranscribeDiarizeRequestData) -> StagePayload:
+        payload = data.stage_payload
+        output_ids = list(data.output_ids or [])
+        raw_text = _decode_token_ids(
+            tokenizer,
+            output_ids,
+            skip_special_tokens=False,
+        )
+        text = postprocess_moss_transcribe_diarize_text(raw_text)
+        engine_time_s = (
+            time.perf_counter() - data.engine_start_s if data.engine_start_s else 0.0
+        )
+        return StagePayload(
+            request_id=payload.request_id,
+            request=payload.request,
+            data={
+                "text": text,
+                "token_ids": output_ids,
+                "language": data.language,
+                "duration_s": data.audio_duration_s,
+                "asr_latency_s": engine_time_s,
+                "prompt_tokens": len(data.prompt_token_ids or []),
+                "completion_tokens": len(output_ids),
+                "usage": {
+                    "engine_time_s": engine_time_s,
+                    "prompt_tokens": len(data.prompt_token_ids or []),
+                    "completion_tokens": len(output_ids),
+                },
+                "finish_reason": data.finish_reason,
+                "weight_version": getattr(data, "weight_version", None),
+                "modality": "text",
+            },
+        )
+
+    return request_builder, result_adapter
+
+
+__all__ = [
+    "DEFAULT_TRANSCRIBE_DIARIZE_PROMPT",
+    "MossTranscribeDiarizeRequestData",
+    "load_audio",
+    "make_moss_transcribe_diarize_scheduler_adapters",
+    "postprocess_moss_transcribe_diarize_text",
+]

--- a/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
+++ b/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
@@ -1,0 +1,312 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SGLang-native MOSS-Transcribe-Diarize model."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.managers.mm_utils import (
+    MultiModalityDataPaddingPatternMultimodalTokens,
+    general_mm_embed_routine,
+)
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.models.qwen3 import Qwen3ForCausalLM
+from sglang.srt.models.whisper import WhisperEncoder
+from sglang.srt.utils import add_prefix
+
+from sglang_omni.models.moss_transcribe_diarize.hf_config import (
+    MossTranscribeDiarizeConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class VQAdaptor(nn.Module):
+    def __init__(self, input_dim: int, hidden_size: int, norm_eps: float = 1e-6):
+        super().__init__()
+        self.layers = nn.Sequential(
+            nn.Linear(input_dim, hidden_size, bias=True),
+            nn.SiLU(),
+            nn.Linear(hidden_size, hidden_size, bias=True),
+            nn.LayerNorm(hidden_size, eps=norm_eps, bias=True),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.layers(x)
+
+
+class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
+    default_bitsandbytes_target_modules = [
+        ".gate_proj.",
+        ".down_proj.",
+        ".up_proj.",
+        ".q_proj.",
+        ".k_proj.",
+        ".v_proj.",
+        ".o_proj.",
+    ]
+    bitsandbytes_stacked_params_mapping = {
+        "q_proj": ("qkv_proj", 0),
+        "k_proj": ("qkv_proj", 1),
+        "v_proj": ("qkv_proj", 2),
+        "gate_proj": ("gate_up_proj", 0),
+        "up_proj": ("gate_up_proj", 1),
+    }
+
+    def __init__(
+        self,
+        config: MossTranscribeDiarizeConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.whisper_encoder = WhisperEncoder(config.audio_config, quant_config)
+        self.vq_adaptor = VQAdaptor(
+            input_dim=config.adaptor_input_dim,
+            hidden_size=config.text_config.hidden_size,
+            norm_eps=config.text_config.rms_norm_eps,
+        )
+        self.language_model = Qwen3ForCausalLM(
+            config.text_config,
+            quant_config,
+            prefix=add_prefix("model.language_model", prefix),
+        )
+        self.pattern = MultiModalityDataPaddingPatternMultimodalTokens()
+
+    def get_input_embeddings(self):
+        return self.language_model.get_input_embeddings()
+
+    def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
+        return self.pattern.pad_input_tokens(input_ids, mm_inputs)
+
+    def time_merge(self, features: torch.Tensor) -> torch.Tensor:
+        batch_size, seq_len, hidden_size = features.shape
+        merge_size = int(self.config.audio_merge_size)
+        trimmed_len = (seq_len // merge_size) * merge_size
+        return features[:, :trimmed_len, :].reshape(
+            batch_size, trimmed_len // merge_size, hidden_size * merge_size
+        )
+
+    def _encode_one_audio_item(
+        self,
+        item: MultimodalDataItem,
+        forward_batch: ForwardBatch,
+    ) -> list[torch.Tensor]:
+        if item.feature is None:
+            raise ValueError(
+                "MOSS-Transcribe-Diarize audio item is missing input_features."
+            )
+
+        device = next(self.whisper_encoder.parameters()).device
+        encoder_dtype = next(self.whisper_encoder.parameters()).dtype
+        input_features = item.feature.to(device=device, dtype=encoder_dtype)
+
+        audio_feature_lengths = getattr(item, "audio_feature_lengths", None)
+        if audio_feature_lengths is None:
+            raise ValueError(
+                "MOSS-Transcribe-Diarize audio item is missing audio_feature_lengths."
+            )
+        audio_feature_lengths = audio_feature_lengths.to(device="cpu", dtype=torch.long)
+        if audio_feature_lengths.numel() != input_features.shape[0]:
+            raise ValueError(
+                "audio_feature_lengths must contain one length per input_features "
+                f"chunk: got {audio_feature_lengths.numel()} lengths for "
+                f"{input_features.shape[0]} chunks."
+            )
+
+        audio_chunk_mapping = getattr(item, "audio_chunk_mapping", None)
+        if audio_chunk_mapping is None:
+            audio_chunk_mapping = torch.zeros(
+                input_features.shape[0], dtype=torch.long, device="cpu"
+            )
+        else:
+            audio_chunk_mapping = audio_chunk_mapping.to(device="cpu", dtype=torch.long)
+        if audio_chunk_mapping.numel() != input_features.shape[0]:
+            raise ValueError(
+                "audio_chunk_mapping must contain one sample index per input_features "
+                f"chunk: got {audio_chunk_mapping.numel()} indices for "
+                f"{input_features.shape[0]} chunks."
+            )
+
+        encoder_len = input_features.shape[-1] // 2
+        encoder_position_ids = torch.arange(
+            encoder_len,
+            device=input_features.device,
+            dtype=torch.long,
+        )
+        whisper_features = self.whisper_encoder(
+            input_features,
+            encoder_position_ids,
+            forward_batch,
+        )
+
+        audio_feature_lengths_list = audio_feature_lengths.tolist()
+        audio_chunk_mapping_list = audio_chunk_mapping.tolist()
+        num_audios = (
+            max(audio_chunk_mapping_list) + 1 if audio_chunk_mapping_list else 0
+        )
+        per_audio_chunks = [[] for _ in range(num_audios)]
+        merge_size = int(self.config.audio_merge_size)
+        for chunk_idx, token_len in enumerate(audio_feature_lengths_list):
+            sample_idx = audio_chunk_mapping_list[chunk_idx]
+            per_audio_chunks[sample_idx].append(
+                whisper_features[
+                    chunk_idx : chunk_idx + 1, : int(token_len) * merge_size
+                ]
+            )
+
+        adapted = []
+        adaptor_dtype = next(self.vq_adaptor.parameters()).dtype
+        for parts in per_audio_chunks:
+            if not parts:
+                continue
+            feat = torch.cat(parts, dim=1).to(dtype=adaptor_dtype)
+            merged = self.time_merge(feat)
+            adapted.append(self.vq_adaptor(merged).squeeze(0))
+        return adapted
+
+    def get_audio_feature(
+        self,
+        items: List[MultimodalDataItem],
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        audio_embeds = []
+        for item in items:
+            audio_embeds.extend(self._encode_one_audio_item(item, forward_batch))
+        if not audio_embeds:
+            hidden_size = self.config.text_config.hidden_size
+            device = next(self.vq_adaptor.parameters()).device
+            dtype = next(self.vq_adaptor.parameters()).dtype
+            return torch.empty((0, hidden_size), device=device, dtype=dtype)
+        return torch.cat(audio_embeds, dim=0)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        return general_mm_embed_routine(
+            input_ids=input_ids,
+            forward_batch=forward_batch,
+            language_model=self.language_model,
+            data_embedding_funcs={
+                Modality.AUDIO: lambda items: self.get_audio_feature(
+                    items,
+                    forward_batch,
+                ),
+            },
+            positions=positions,
+        )
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        stacked_params_mapping = [
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+        whisper_stacked_params_mapping = [
+            ("self_attn.qkv_proj", "self_attn.q_proj", "q"),
+            ("self_attn.qkv_proj", "self_attn.k_proj", "k"),
+            ("self_attn.qkv_proj", "self_attn.v_proj", "v"),
+        ]
+        params_dict = dict(self.named_parameters(remove_duplicate=False))
+
+        def load_one(name: str, loaded_weight: torch.Tensor):
+            original_name = name
+            if "rotary_emb.inv_freq" in name:
+                return
+            if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:
+                return
+
+            if name == "lm_head.weight":
+                name = "language_model.lm_head.weight"
+            elif name.startswith("model.language_model."):
+                name = "language_model.model." + name[len("model.language_model.") :]
+            elif name.startswith("model.whisper_encoder."):
+                name = "whisper_encoder." + name[len("model.whisper_encoder.") :]
+            elif name.startswith("model.vq_adaptor."):
+                name = "vq_adaptor." + name[len("model.vq_adaptor.") :]
+
+            if (
+                name == "language_model.model.embed_tokens.weight"
+                and self.config.text_config.tie_word_embeddings
+                and "language_model.lm_head.weight" in params_dict
+            ):
+                param = params_dict["language_model.lm_head.weight"]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+
+            handled = False
+            if name.startswith("whisper_encoder."):
+                for param_name, weight_name, shard_id in whisper_stacked_params_mapping:
+                    if weight_name not in name:
+                        continue
+                    mapped_name = name.replace(weight_name, param_name)
+                    if mapped_name.endswith(".bias") and mapped_name not in params_dict:
+                        handled = True
+                        break
+                    if mapped_name in params_dict:
+                        param = params_dict[mapped_name]
+                        param.weight_loader(param, loaded_weight, shard_id)
+                        handled = True
+                    break
+
+            if name.startswith("language_model."):
+                for param_name, weight_name, shard_id in stacked_params_mapping:
+                    if weight_name not in name:
+                        continue
+                    mapped_name = name.replace(weight_name, param_name)
+                    if mapped_name.endswith(".bias") and mapped_name not in params_dict:
+                        handled = True
+                        break
+                    if mapped_name in params_dict:
+                        param = params_dict[mapped_name]
+                        param.weight_loader(param, loaded_weight, shard_id)
+                        handled = True
+                    break
+
+            if handled:
+                return
+
+            if name.endswith(".bias") and name not in params_dict:
+                return
+
+            if name in params_dict:
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+            else:
+                logger.debug("Skipping weight: %s -> %s", original_name, name)
+
+        for name, loaded_weight in weights:
+            load_one(name, loaded_weight)
+            if (
+                name.startswith("model.whisper_encoder.layers.")
+                and ".self_attn.k_proj.weight" in name
+            ):
+                load_one(
+                    name.replace(".k_proj.weight", ".k_proj.bias"),
+                    torch.zeros(
+                        loaded_weight.shape[0],
+                        dtype=loaded_weight.dtype,
+                        device=loaded_weight.device,
+                    ),
+                )
+
+
+EntryClass = MossTranscribeDiarizeForConditionalGeneration

--- a/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
+++ b/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
@@ -139,7 +139,7 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
                 f"{input_features.shape[0]} chunks."
             )
 
-        encoder_len = input_features.shape[-1] // 2
+        encoder_len = (input_features.shape[-1] - 1) // 2 + 1
         encoder_position_ids = torch.arange(
             encoder_len,
             device=input_features.device,

--- a/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
+++ b/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
@@ -291,7 +291,7 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
             else:
-                logger.debug("Skipping weight: %s -> %s", original_name, name)
+                logger.debug(f"Skipping weight: {original_name} -> {name}")
 
         for name, loaded_weight in weights:
             load_one(name, loaded_weight)

--- a/sglang_omni/models/moss_transcribe_diarize/stages.py
+++ b/sglang_omni/models/moss_transcribe_diarize/stages.py
@@ -28,12 +28,15 @@ from sglang_omni.scheduling.sglang_backend import (
     build_sglang_server_args,
 )
 
+# Note (yichi): Budget for long-form input and let the checkpoint window cap it.
+_LONG_FORM_PROMPT_TOKENS = 72000
+
 
 def _default_context_length(model_path: str, max_new_tokens: int) -> int:
     config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
     text_config = getattr(config, "text_config", None)
     max_positions = int(getattr(text_config, "max_position_embeddings", 40960))
-    return min(max_positions, max(8192, int(max_new_tokens) + 4096))
+    return min(max_positions, _LONG_FORM_PROMPT_TOKENS + int(max_new_tokens))
 
 
 def _default_max_new_tokens(model_path: str) -> int:

--- a/sglang_omni/models/moss_transcribe_diarize/stages.py
+++ b/sglang_omni/models/moss_transcribe_diarize/stages.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stage factory for SGLang-backed MOSS-Transcribe-Diarize inference."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sglang.srt.managers.mm_utils import init_mm_embedding_cache
+from transformers import AutoConfig, AutoProcessor, GenerationConfig
+
+from sglang_omni.model_runner.base import ModelRunner
+from sglang_omni.models.moss_transcribe_diarize import (  # noqa: F401
+    hf_config as _hf_config,
+)
+from sglang_omni.models.moss_transcribe_diarize.request_builders import (
+    make_moss_transcribe_diarize_scheduler_adapters,
+)
+from sglang_omni.scheduling.bootstrap import (
+    create_sglang_infrastructure_defer_cuda_graph,
+)
+from sglang_omni.scheduling.generation_batch_policy import (
+    build_generation_batch_overrides,
+    validate_generation_batch_policy,
+)
+from sglang_omni.scheduling.omni_scheduler import OmniScheduler
+from sglang_omni.scheduling.sglang_backend import (
+    SGLangOutputProcessor,
+    build_sglang_server_args,
+)
+
+
+def _default_context_length(model_path: str, max_new_tokens: int) -> int:
+    config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+    text_config = getattr(config, "text_config", None)
+    max_positions = int(getattr(text_config, "max_position_embeddings", 40960))
+    return min(max_positions, max(8192, int(max_new_tokens) + 4096))
+
+
+def _default_max_new_tokens(model_path: str) -> int:
+    try:
+        generation_config = GenerationConfig.from_pretrained(model_path)
+    except Exception:
+        return 5120
+    return int(getattr(generation_config, "max_new_tokens", None) or 5120)
+
+
+def create_sglang_moss_transcribe_diarize_executor(
+    model_path: str,
+    *,
+    device: str = "cuda:0",
+    dtype: str = "bfloat16",
+    max_running_requests: int = 16,
+    max_new_tokens: int | None = None,
+    context_length: int | None = None,
+    mem_fraction_static: float | None = None,
+    mm_embedding_cache_size_bytes: int = 0,
+    enable_torch_compile: bool = False,
+    request_build_max_workers: int = 2,
+    request_build_max_pending: int | None = 16,
+    server_args_overrides: dict[str, Any] | None = None,
+):
+    gpu_id = int(device.split(":")[-1]) if ":" in device else 0
+
+    processor = AutoProcessor.from_pretrained(model_path, trust_remote_code=True)
+    tokenizer = processor.tokenizer
+
+    resolved_max_new_tokens = (
+        int(max_new_tokens)
+        if max_new_tokens is not None
+        else _default_max_new_tokens(model_path)
+    )
+    resolved_context_length = (
+        int(context_length)
+        if context_length is not None
+        else _default_context_length(model_path, resolved_max_new_tokens)
+    )
+
+    overrides = build_generation_batch_overrides(
+        max_running_requests=max_running_requests,
+        server_args_overrides=server_args_overrides,
+        disable_cuda_graph=False,
+        disable_overlap_schedule=True,
+        enable_torch_compile=enable_torch_compile,
+        mem_fraction_static=mem_fraction_static,
+        max_prefill_tokens=4096,
+        chunked_prefill_size=4096,
+        sampling_backend="pytorch",
+        dtype=dtype,
+    )
+
+    server_args = build_sglang_server_args(
+        model_path,
+        context_length=resolved_context_length,
+        **overrides,
+    )
+    validate_generation_batch_policy(
+        model_name="MOSS-Transcribe-Diarize",
+        server_args=server_args,
+    )
+
+    want_cuda_graph, (
+        model_worker,
+        tree_cache,
+        req_to_token_pool,
+        token_to_kv_pool_allocator,
+        prefill_mgr,
+        decode_mgr,
+        model_config,
+    ) = create_sglang_infrastructure_defer_cuda_graph(
+        server_args,
+        gpu_id,
+        model_arch_override="MossTranscribeDiarizeForConditionalGeneration",
+    )
+
+    if want_cuda_graph:
+        model_worker.model_runner.init_device_graphs()
+
+    init_mm_embedding_cache(mm_embedding_cache_size_bytes)
+
+    output_proc = SGLangOutputProcessor(
+        capture_hidden=False,
+        capture_hidden_layers=None,
+        model=model_worker.model_runner.model,
+    )
+    request_builder, result_adapter = make_moss_transcribe_diarize_scheduler_adapters(
+        processor=processor,
+        tokenizer=tokenizer,
+        max_new_tokens=resolved_max_new_tokens,
+    )
+
+    return OmniScheduler(
+        tp_worker=model_worker,
+        tree_cache=tree_cache,
+        req_to_token_pool=req_to_token_pool,
+        token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+        server_args=server_args,
+        model_config=model_config,
+        prefill_manager=prefill_mgr,
+        decode_manager=decode_mgr,
+        model_runner=ModelRunner(model_worker, output_proc),
+        request_builder=request_builder,
+        result_adapter=result_adapter,
+        request_build_max_workers=request_build_max_workers,
+        request_build_max_pending=request_build_max_pending,
+    )
+
+
+def create_moss_transcribe_diarize_executor(*args, **kwargs):
+    return create_sglang_moss_transcribe_diarize_executor(*args, **kwargs)
+
+
+__all__ = [
+    "create_sglang_moss_transcribe_diarize_executor",
+    "create_moss_transcribe_diarize_executor",
+]

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -348,6 +348,7 @@ async def _run_server(
             allowed_local_media_path=allowed_local_media_path,
             allowed_media_domains=allowed_media_domains,
             tts_batch_max_items=tts_batch_max_items,
+            architectures=[pipeline_config.architecture],
         )
         profiler_dir = os.environ.get("SGLANG_TORCH_PROFILER_DIR")
         profiler_ctl = ProfilerControlClient(mp_runner.stage_control_endpoints)

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -19,8 +19,10 @@ Provides the following endpoints:
 from __future__ import annotations
 
 import asyncio
+import io
 import json
 import logging
+import math
 import time
 import uuid
 from collections.abc import Awaitable, Callable
@@ -89,6 +91,7 @@ from sglang_omni.serve.protocol import (
     RolloutSamplingParams,
     SpeechBatchResponse,
     TranscriptionResponse,
+    TranscriptionUsage,
     UpdateWeightFromDiskRequest,
     UpdateWeightsFromDistributedRequest,
     UsageResponse,
@@ -105,6 +108,7 @@ from sglang_omni.serve.speech_errors import (
 from sglang_omni.serve.speech_service import SpeechRequestValidator
 from sglang_omni.serve.speech_voices import MAX_VOICE_UPLOAD_BYTES, SpeakerSampleStore
 from sglang_omni.serve.speech_ws import SpeechWebSocketSession
+from sglang_omni.serve.transcription_adapters import resolve_adapter
 
 logger = logging.getLogger(__name__)
 STREAM_DONE_SENTINEL = "[DONE]"
@@ -180,6 +184,7 @@ def create_app(
     allowed_media_domains: list[str] | None = None,
     admin_api_key: str | None = None,
     tts_batch_max_items: int = DEFAULT_TTS_BATCH_MAX_ITEMS,
+    architectures: list[str] | None = None,
 ) -> FastAPI:
     """Create a FastAPI application with OpenAI-compatible endpoints.
 
@@ -219,6 +224,7 @@ def create_app(
     # Store references in app state for access from route handlers
     app.state.client = client
     app.state.model_name = model_name or "sglang-omni"
+    app.state.architectures = [a for a in (architectures or []) if a]
     app.state.realtime_enabled = enable_realtime
     app.state.speaker_sample_store = SpeakerSampleStore()
     app.state.speech_service = SpeechRequestValidator(
@@ -1146,7 +1152,7 @@ def _register_speech(app: FastAPI) -> None:
                 reference_descriptors=prepared.reference_descriptors,
                 uploaded_voice=prepared.uploaded_voice,
             )
-        except json.JSONDecodeError as exc:
+        except json.JSONDecodeError:
             return speech_error_response(
                 bad_request("speech request body must be valid JSON")
             )
@@ -1545,7 +1551,46 @@ def _register_transcriptions(app: FastAPI) -> None:
                     f"{response_format!r}"
                 ),
             )
-        return JSONResponse(content=TranscriptionResponse(text=text).model_dump())
+
+        adapter = resolve_adapter(getattr(app.state, "architectures", None))
+        text = adapter.postprocess_text(text)
+        duration_s = _probe_audio_duration(audio_bytes)
+        usage = (
+            TranscriptionUsage(seconds=math.ceil(duration_s))
+            if duration_s > 0
+            else None
+        )
+        if normalized_response_format == "verbose_json":
+            response = adapter.build_verbose_response(
+                text=text,
+                language=language,
+                audio_duration_s=duration_s,
+            )
+            response.usage = usage
+            return JSONResponse(content=response.model_dump(exclude_none=True))
+        return JSONResponse(
+            content=TranscriptionResponse(text=text, usage=usage).model_dump(
+                exclude_none=True
+            )
+        )
+
+
+def _probe_audio_duration(audio_bytes: bytes) -> float:
+    """Best-effort audio duration (seconds) from raw upload bytes.
+
+    Uses ``soundfile.info`` (metadata only, no full decode; torchaudio removed
+    its ``info`` API in 2.x). Returns 0.0 if the duration cannot be
+    determined; callers treat 0.0 as "unknown".
+    """
+    try:
+        import soundfile as sf
+
+        info = sf.info(io.BytesIO(audio_bytes))
+        if info.samplerate:
+            return max(info.frames / float(info.samplerate), 0.0)
+    except (RuntimeError, ValueError):
+        logger.debug("Could not probe audio duration", exc_info=True)
+    return 0.0
 
 
 def build_transcription_generate_request(

--- a/sglang_omni/serve/protocol.py
+++ b/sglang_omni/serve/protocol.py
@@ -457,10 +457,38 @@ class VoiceListResponse(BaseModel):
     )
 
 
+class TranscriptionUsage(BaseModel):
+    """Duration-based usage info for a transcription response."""
+
+    type: str = "duration"
+    seconds: int
+
+
 class TranscriptionResponse(BaseModel):
     """OpenAI-compatible transcription response."""
 
     text: str
+    usage: TranscriptionUsage | None = None
+
+
+class TranscriptionSegment(BaseModel):
+    """A transcript segment with timestamps (OpenAI verbose_json)."""
+
+    id: int
+    start: float
+    end: float
+    text: str
+
+
+class TranscriptionVerboseResponse(BaseModel):
+    """OpenAI-compatible ``verbose_json`` transcription response."""
+
+    task: str = "transcribe"
+    language: str | None = None
+    duration: float | None = None
+    text: str
+    segments: list[TranscriptionSegment] = Field(default_factory=list)
+    usage: TranscriptionUsage | None = None
 
 
 class ModelPermission(BaseModel):

--- a/sglang_omni/serve/transcription_adapters/__init__.py
+++ b/sglang_omni/serve/transcription_adapters/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Transcription output adapters (verbose_json segment building).
+
+Importing this package registers all built-in adapters.
+"""
+
+from __future__ import annotations
+
+# Imported for its registration side effect (@register_transcription_adapter).
+from sglang_omni.serve.transcription_adapters import (  # noqa: F401
+    moss_transcribe_diarize,
+)
+from sglang_omni.serve.transcription_adapters.base import (
+    TranscriptionAdapter,
+    register_transcription_adapter,
+    resolve_adapter,
+)
+
+__all__ = [
+    "TranscriptionAdapter",
+    "register_transcription_adapter",
+    "resolve_adapter",
+]

--- a/sglang_omni/serve/transcription_adapters/base.py
+++ b/sglang_omni/serve/transcription_adapters/base.py
@@ -85,8 +85,8 @@ def register_transcription_adapter(
     """Class decorator registering a TranscriptionAdapter under key.
 
     key is matched as a substring against the model's HF architectures at
-    resolve time (e.g. "MossTranscribeDiarize" matches
-    "MossTranscribeDiarizeForConditionalGeneration").
+    resolve time (e.g. MossTranscribeDiarize matches
+    MossTranscribeDiarizeForConditionalGeneration).
     """
 
     def decorator(cls: type[TranscriptionAdapter]) -> type[TranscriptionAdapter]:

--- a/sglang_omni/serve/transcription_adapters/base.py
+++ b/sglang_omni/serve/transcription_adapters/base.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Model-specific transcription output adapters.
+
+Ported from the upstream SGLang ``transcription_adapters`` pattern: subclass
+:class:`TranscriptionAdapter`, decorate with
+``@register_transcription_adapter("Key")``, and the ``/v1/audio/transcriptions``
+handler resolves the right adapter by matching *Key* as a substring against the
+served model's HF ``architectures``.
+
+Only the pieces the omni HTTP layer needs are kept: markup post-processing and
+``verbose_json`` segment building. Sampling / prompt construction already live
+in each model's pipeline (``stages.py`` / ``request_builders.py``), so they are
+intentionally not part of this interface.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from sglang_omni.serve.protocol import (
+    TranscriptionSegment,
+    TranscriptionVerboseResponse,
+)
+
+
+class TranscriptionAdapter(ABC):
+    """Abstract base for model-specific transcription output handling."""
+
+    def postprocess_text(self, text: str) -> str:
+        """Strip model-specific markers from the decoded text.
+
+        Default is an identity pass-through; override for models that emit
+        special-token or diarization syntax.
+        """
+        return text
+
+    @abstractmethod
+    def build_verbose_response(
+        self,
+        *,
+        text: str,
+        language: str | None,
+        audio_duration_s: float,
+    ) -> TranscriptionVerboseResponse:
+        """Build a ``verbose_json`` response with segments / timestamps."""
+
+
+class DefaultTranscriptionAdapter(TranscriptionAdapter):
+    """Fallback: emit the whole transcript as a single segment."""
+
+    def build_verbose_response(
+        self,
+        *,
+        text: str,
+        language: str | None,
+        audio_duration_s: float,
+    ) -> TranscriptionVerboseResponse:
+        text = text.strip()
+        segments = (
+            [
+                TranscriptionSegment(
+                    id=0,
+                    start=0.0,
+                    end=round(max(float(audio_duration_s), 0.0), 2),
+                    text=text,
+                )
+            ]
+            if text
+            else []
+        )
+        return TranscriptionVerboseResponse(
+            language=language,
+            duration=round(max(float(audio_duration_s), 0.0), 2),
+            text=text,
+            segments=segments,
+        )
+
+
+_ADAPTER_REGISTRY: dict[str, type[TranscriptionAdapter]] = {}
+_DEFAULT_ADAPTER_KEY = "__default__"
+_ADAPTER_REGISTRY[_DEFAULT_ADAPTER_KEY] = DefaultTranscriptionAdapter
+
+
+def register_transcription_adapter(key: str):
+    """Class decorator registering a :class:`TranscriptionAdapter` under *key*.
+
+    *key* is matched as a substring against the model's HF ``architectures``
+    at resolve time (e.g. ``"MossTranscribeDiarize"`` matches
+    ``"MossTranscribeDiarizeForConditionalGeneration"``).
+    """
+
+    def decorator(cls: type[TranscriptionAdapter]) -> type[TranscriptionAdapter]:
+        _ADAPTER_REGISTRY[key] = cls
+        return cls
+
+    return decorator
+
+
+def resolve_adapter(architectures: list[str] | None) -> TranscriptionAdapter:
+    """Pick an adapter by matching architecture names against the registry."""
+    for arch in architectures or []:
+        if not arch:
+            continue
+        for key, adapter_cls in _ADAPTER_REGISTRY.items():
+            if key != _DEFAULT_ADAPTER_KEY and key in arch:
+                return adapter_cls()
+    return _ADAPTER_REGISTRY[_DEFAULT_ADAPTER_KEY]()

--- a/sglang_omni/serve/transcription_adapters/base.py
+++ b/sglang_omni/serve/transcription_adapters/base.py
@@ -1,21 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 """Model-specific transcription output adapters.
 
-Ported from the upstream SGLang ``transcription_adapters`` pattern: subclass
-:class:`TranscriptionAdapter`, decorate with
-``@register_transcription_adapter("Key")``, and the ``/v1/audio/transcriptions``
-handler resolves the right adapter by matching *Key* as a substring against the
-served model's HF ``architectures``.
+Ported from the upstream SGLang transcription_adapters pattern: subclass
+TranscriptionAdapter, decorate with register_transcription_adapter("Key"), and
+the /v1/audio/transcriptions handler resolves the right adapter by matching Key
+as a substring against the served model's HF architectures.
 
 Only the pieces the omni HTTP layer needs are kept: markup post-processing and
-``verbose_json`` segment building. Sampling / prompt construction already live
-in each model's pipeline (``stages.py`` / ``request_builders.py``), so they are
+verbose_json segment building. Sampling / prompt construction already live in
+each model's pipeline (stages.py / request_builders.py), so they are
 intentionally not part of this interface.
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 
 from sglang_omni.serve.protocol import (
     TranscriptionSegment,
@@ -37,12 +37,11 @@ class TranscriptionAdapter(ABC):
     @abstractmethod
     def build_verbose_response(
         self,
-        *,
         text: str,
         language: str | None,
         audio_duration_s: float,
     ) -> TranscriptionVerboseResponse:
-        """Build a ``verbose_json`` response with segments / timestamps."""
+        """Build a verbose_json response with segments / timestamps."""
 
 
 class DefaultTranscriptionAdapter(TranscriptionAdapter):
@@ -50,7 +49,6 @@ class DefaultTranscriptionAdapter(TranscriptionAdapter):
 
     def build_verbose_response(
         self,
-        *,
         text: str,
         language: str | None,
         audio_duration_s: float,
@@ -81,12 +79,14 @@ _DEFAULT_ADAPTER_KEY = "__default__"
 _ADAPTER_REGISTRY[_DEFAULT_ADAPTER_KEY] = DefaultTranscriptionAdapter
 
 
-def register_transcription_adapter(key: str):
-    """Class decorator registering a :class:`TranscriptionAdapter` under *key*.
+def register_transcription_adapter(
+    key: str,
+) -> Callable[[type[TranscriptionAdapter]], type[TranscriptionAdapter]]:
+    """Class decorator registering a TranscriptionAdapter under key.
 
-    *key* is matched as a substring against the model's HF ``architectures``
-    at resolve time (e.g. ``"MossTranscribeDiarize"`` matches
-    ``"MossTranscribeDiarizeForConditionalGeneration"``).
+    key is matched as a substring against the model's HF architectures at
+    resolve time (e.g. "MossTranscribeDiarize" matches
+    "MossTranscribeDiarizeForConditionalGeneration").
     """
 
     def decorator(cls: type[TranscriptionAdapter]) -> type[TranscriptionAdapter]:

--- a/sglang_omni/serve/transcription_adapters/moss_transcribe_diarize.py
+++ b/sglang_omni/serve/transcription_adapters/moss_transcribe_diarize.py
@@ -36,7 +36,6 @@ class MossTranscribeDiarizeAdapter(TranscriptionAdapter):
 
     def build_verbose_response(
         self,
-        *,
         text: str,
         language: str | None,
         audio_duration_s: float,

--- a/sglang_omni/serve/transcription_adapters/moss_transcribe_diarize.py
+++ b/sglang_omni/serve/transcription_adapters/moss_transcribe_diarize.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """verbose_json adapter for MOSS-Transcribe-Diarize.
 
-The model emits ``[start][S01] text [end]`` segments (speaker labels +
-timestamps). This adapter parses that markup into OpenAI ``verbose_json``
+The model emits [start][S01] text [end] segments (speaker labels +
+timestamps). This adapter parses that markup into OpenAI verbose_json
 segments. The segment regex is ported from the upstream SGLang adapter.
 """
 

--- a/sglang_omni/serve/transcription_adapters/moss_transcribe_diarize.py
+++ b/sglang_omni/serve/transcription_adapters/moss_transcribe_diarize.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+"""verbose_json adapter for MOSS-Transcribe-Diarize.
+
+The model emits ``[start][S01] text [end]`` segments (speaker labels +
+timestamps). This adapter parses that markup into OpenAI ``verbose_json``
+segments. The segment regex is ported from the upstream SGLang adapter.
+"""
+
+from __future__ import annotations
+
+import re
+
+from sglang_omni.serve.protocol import (
+    TranscriptionSegment,
+    TranscriptionVerboseResponse,
+)
+from sglang_omni.serve.transcription_adapters.base import (
+    TranscriptionAdapter,
+    register_transcription_adapter,
+)
+
+_SPECIAL_TOKEN_RE = re.compile(r"<\|(?:im_start|im_end|endoftext)\|>")
+_SEGMENT_RE = re.compile(
+    r"\[(?P<start>\d+(?:\.\d+)?)\]\s*\[(?P<speaker>S\d{2,})\]"
+    r"(?P<text>.*?)"
+    r"\s*\[(?P<end>\d+(?:\.\d+)?)\]"
+    r"(?=\s*(?:\[\d+(?:\.\d+)?\]\s*\[S\d{2,}\]|$))",
+    re.DOTALL,
+)
+
+
+@register_transcription_adapter("MossTranscribeDiarize")
+class MossTranscribeDiarizeAdapter(TranscriptionAdapter):
+    def postprocess_text(self, text: str) -> str:
+        return _SPECIAL_TOKEN_RE.sub("", text).strip()
+
+    def build_verbose_response(
+        self,
+        *,
+        text: str,
+        language: str | None,
+        audio_duration_s: float,
+    ) -> TranscriptionVerboseResponse:
+        segments = self._parse_segments(text)
+        if not segments:
+            segments = self._build_fallback_segments(text, audio_duration_s)
+        duration = (
+            round(float(audio_duration_s), 2)
+            if audio_duration_s > 0
+            else max((seg.end for seg in segments), default=0.0)
+        )
+        return TranscriptionVerboseResponse(
+            language=language,
+            duration=round(duration, 2),
+            text=text,
+            segments=segments,
+        )
+
+    @staticmethod
+    def _parse_segments(text: str) -> list[TranscriptionSegment]:
+        segments: list[TranscriptionSegment] = []
+        for segment_id, match in enumerate(_SEGMENT_RE.finditer(text)):
+            speaker = match.group("speaker")
+            body = match.group("text").strip()
+            segment_text = f"[{speaker}]{body}" if body else f"[{speaker}]"
+            segments.append(
+                TranscriptionSegment(
+                    id=segment_id,
+                    start=round(float(match.group("start")), 2),
+                    end=round(float(match.group("end")), 2),
+                    text=segment_text,
+                )
+            )
+        return segments
+
+    @staticmethod
+    def _build_fallback_segments(
+        text: str, audio_duration_s: float
+    ) -> list[TranscriptionSegment]:
+        text = text.strip()
+        if not text:
+            return []
+        if not re.match(r"^\[S\d{2,}\]", text):
+            text = f"[S01]{text}"
+        return [
+            TranscriptionSegment(
+                id=0,
+                start=0.0,
+                end=round(max(float(audio_duration_s), 0.0), 2),
+                text=text,
+            )
+        ]

--- a/tests/README.md
+++ b/tests/README.md
@@ -62,6 +62,9 @@ tests/
     ├── qwen3_asr/
     │   ├── test_pipeline.py
     │   └── test_request_builders.py
+    ├── moss_transcribe_diarize/
+    │   ├── test_request_builders.py
+    │   └── test_transcription_adapter.py
     ├── qwen3_tts/
     │   └── test_pipeline.py
     ├── higgs_tts/
@@ -276,6 +279,11 @@ that happened to contain an older version of the test.
     request builder paths
   - token-level result adapter marker handling, avoiding decode/encode
     text round-trips for byte-level BPE output.
+- `unit_test/moss_transcribe_diarize/`: MOSS-Transcribe-Diarize unit tests:
+  - request builder audio-source resolution, single-audio enforcement, audio
+    token padding, and default transcribe+diarize prompt injection
+  - verbose_json transcription adapter: architecture-based resolution, special
+    token stripping, and speaker/timestamp segment parsing with fallback.
 - `unit_test/qwen3_omni/` Qwen3-Omni unit tests:
 
   - public CLI/config behavior

--- a/tests/unit_test/moss_transcribe_diarize/test_request_builders.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_request_builders.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+import sglang_omni.models.moss_transcribe_diarize.request_builders as request_builders
+from sglang_omni.models.moss_transcribe_diarize.request_builders import (
+    DEFAULT_TRANSCRIBE_DIARIZE_PROMPT,
+    make_moss_transcribe_diarize_scheduler_adapters,
+)
+from sglang_omni.proto import OmniRequest, StagePayload
+
+
+class FakeTokenizer:
+    vocab_size = 200000
+    eos_token_id = 151645
+
+    def __init__(self) -> None:
+        self._ids = {
+            "<|audio_start|>": 151669,
+            "<|audio_pad|>": 151671,
+            "<|audio_end|>": 151670,
+        }
+
+    def convert_tokens_to_ids(self, token: str) -> int:
+        return self._ids[token]
+
+    def decode(self, token_ids, **kwargs) -> str:
+        del kwargs
+        return "".join(str(token_id) for token_id in token_ids)
+
+
+class FakeProcessor:
+    audio_token_id = 151671
+
+    def __init__(self) -> None:
+        self.tokenizer = FakeTokenizer()
+        self.messages = None
+
+    def apply_chat_template(
+        self, messages, *, tokenize: bool, add_generation_prompt: bool
+    ):
+        del tokenize, add_generation_prompt
+        self.messages = messages
+        return "<|im_start|>user\n<|audio_start|><|audio_pad|><|audio_end|>prompt"
+
+    def __call__(self, *, text: str, audio, return_tensors: str, max_length: int):
+        del text, audio, return_tensors, max_length
+        return {
+            "input_ids": torch.tensor(
+                [[10, 151669, 151671, 151671, 20, 151671, 151670, 11]],
+                dtype=torch.long,
+            ),
+            "input_features": torch.zeros((1, 80, 3000), dtype=torch.float32),
+            "audio_feature_lengths": torch.tensor([3], dtype=torch.long),
+            "audio_chunk_mapping": torch.tensor([0], dtype=torch.long),
+        }
+
+
+def _payload(prompt: str | None = None) -> StagePayload:
+    params = {"prompt": prompt} if prompt is not None else {}
+    return StagePayload(
+        request_id="req-1",
+        request=OmniRequest(
+            inputs={"audio_data": np.zeros(1600, dtype=np.float32)},
+            params=params,
+            metadata={"model": "moss-transcribe-diarize"},
+        ),
+        data={},
+    )
+
+
+def _payload_with_inputs(inputs, *, metadata: dict | None = None) -> StagePayload:
+    return StagePayload(
+        request_id="req-1",
+        request=OmniRequest(
+            inputs=inputs,
+            params={},
+            metadata=metadata or {"model": "moss-transcribe-diarize"},
+        ),
+        data={},
+    )
+
+
+def _request_builder(processor: FakeProcessor | None = None):
+    processor = processor or FakeProcessor()
+    request_builder, _ = make_moss_transcribe_diarize_scheduler_adapters(
+        processor=processor,
+        tokenizer=processor.tokenizer,
+        max_new_tokens=32,
+    )
+    return request_builder
+
+
+def test_request_builder_replaces_audio_tokens_with_item_pad_value() -> None:
+    processor = FakeProcessor()
+    request_builder = _request_builder(processor)
+
+    data = request_builder(_payload())
+
+    input_ids = data.input_ids.tolist()
+    audio_token_id = processor.audio_token_id
+    assert audio_token_id not in input_ids
+    audio_item = data.req.multimodal_inputs.mm_items[0]
+    assert audio_item.offsets == [(2, 3), (5, 5)]
+    assert input_ids[2] == audio_item.pad_value
+    assert input_ids[3] == audio_item.pad_value
+    assert input_ids[5] == audio_item.pad_value
+    assert input_ids[4] == 20
+    assert data.req.sampling_params.max_new_tokens == 32
+
+
+def test_request_builder_uses_default_prompt_for_empty_transcription_prompt() -> None:
+    processor = FakeProcessor()
+    request_builder = _request_builder(processor)
+
+    request_builder(_payload(prompt=""))
+
+    assert processor.messages is not None
+    assert (
+        processor.messages[0]["content"][1]["text"] == DEFAULT_TRANSCRIBE_DIARIZE_PROMPT
+    )
+
+
+def test_request_builder_preserves_audio_data_sample_list_as_one_waveform() -> None:
+    request_builder = _request_builder()
+
+    data = request_builder(_payload_with_inputs({"audio_data": [0.0, 0.1, -0.1, 0.0]}))
+
+    assert data.audio_duration_s == 4 / 16000
+    assert len(data.req.multimodal_inputs.mm_items) == 1
+
+
+def test_request_builder_accepts_single_audio_from_audios_list() -> None:
+    request_builder = _request_builder()
+
+    data = request_builder(
+        _payload_with_inputs({"audios": [np.zeros(1600, dtype=np.float32)]})
+    )
+
+    assert data.audio_duration_s == 0.1
+    assert len(data.req.multimodal_inputs.mm_items) == 1
+
+
+def test_request_builder_rejects_multiple_audios() -> None:
+    request_builder = _request_builder()
+
+    with pytest.raises(ValueError, match="exactly one audio"):
+        request_builder(
+            _payload_with_inputs(
+                {"audios": [np.zeros(1600, dtype=np.float32), np.zeros(1600)]}
+            )
+        )
+
+
+def test_request_builder_uses_default_prompt_for_bare_string_audio_source(
+    monkeypatch,
+) -> None:
+    processor = FakeProcessor()
+    request_builder = _request_builder(processor)
+    monkeypatch.setattr(
+        request_builders,
+        "load_audio",
+        lambda source: np.zeros(1600, dtype=np.float32),
+    )
+
+    request_builder(_payload_with_inputs("/tmp/audio.wav"))
+
+    assert processor.messages is not None
+    assert (
+        processor.messages[0]["content"][1]["text"] == DEFAULT_TRANSCRIBE_DIARIZE_PROMPT
+    )
+
+
+def test_request_builder_uses_string_prompt_when_audio_is_supplied_separately() -> None:
+    processor = FakeProcessor()
+    request_builder = _request_builder(processor)
+
+    request_builder(
+        _payload_with_inputs(
+            "custom diarization prompt",
+            metadata={
+                "model": "moss-transcribe-diarize",
+                "audios": [np.zeros(1600, dtype=np.float32)],
+            },
+        )
+    )
+
+    assert processor.messages is not None
+    assert processor.messages[0]["content"][1]["text"] == "custom diarization prompt"

--- a/tests/unit_test/moss_transcribe_diarize/test_transcription_adapter.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_transcription_adapter.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the MOSS-Transcribe-Diarize verbose_json adapter."""
+
+from __future__ import annotations
+
+from sglang_omni.serve.transcription_adapters import resolve_adapter
+from sglang_omni.serve.transcription_adapters.base import DefaultTranscriptionAdapter
+from sglang_omni.serve.transcription_adapters.moss_transcribe_diarize import (
+    MossTranscribeDiarizeAdapter,
+)
+
+
+def _moss_adapter() -> MossTranscribeDiarizeAdapter:
+    return MossTranscribeDiarizeAdapter()
+
+
+def test_resolve_adapter_matches_moss_architecture() -> None:
+    adapter = resolve_adapter(["MossTranscribeDiarizeForConditionalGeneration"])
+    assert isinstance(adapter, MossTranscribeDiarizeAdapter)
+
+
+def test_resolve_adapter_falls_back_to_default() -> None:
+    assert isinstance(resolve_adapter(["SomethingElse"]), DefaultTranscriptionAdapter)
+    assert isinstance(resolve_adapter([]), DefaultTranscriptionAdapter)
+    assert isinstance(resolve_adapter(None), DefaultTranscriptionAdapter)
+
+
+def test_postprocess_strips_special_tokens_only() -> None:
+    adapter = _moss_adapter()
+    raw = "<|im_start|>[0.12][S01] hello[3.27]<|im_end|>"
+    assert adapter.postprocess_text(raw) == "[0.12][S01] hello[3.27]"
+
+
+def test_parse_single_segment() -> None:
+    adapter = _moss_adapter()
+    text = "[0.12][S01] We asked over twenty different people.[3.27]"
+    resp = adapter.build_verbose_response(
+        text=text, language="en", audio_duration_s=3.3
+    )
+    assert len(resp.segments) == 1
+    seg = resp.segments[0]
+    assert seg.id == 0
+    assert seg.start == 0.12
+    assert seg.end == 3.27
+    assert seg.text == "[S01]We asked over twenty different people."
+    assert resp.duration == 3.3
+    assert resp.language == "en"
+
+
+def test_parse_multi_speaker_segments() -> None:
+    adapter = _moss_adapter()
+    text = "[0.00][S01] Hello there.[1.20][1.30][S02] How are you.[3.00]"
+    resp = adapter.build_verbose_response(
+        text=text, language=None, audio_duration_s=3.0
+    )
+    assert [(s.id, s.start, s.end) for s in resp.segments] == [
+        (0, 0.0, 1.2),
+        (1, 1.3, 3.0),
+    ]
+    assert resp.segments[0].text == "[S01]Hello there."
+    assert resp.segments[1].text == "[S02]How are you."
+    assert resp.language is None
+
+
+def test_fallback_when_no_markup() -> None:
+    adapter = _moss_adapter()
+    resp = adapter.build_verbose_response(
+        text="plain transcript no markers", language="en", audio_duration_s=4.5
+    )
+    assert len(resp.segments) == 1
+    seg = resp.segments[0]
+    assert seg.start == 0.0
+    assert seg.end == 4.5
+    assert seg.text == "[S01]plain transcript no markers"
+    assert resp.duration == 4.5
+
+
+def test_empty_text_yields_no_segments() -> None:
+    adapter = _moss_adapter()
+    resp = adapter.build_verbose_response(
+        text="   ", language="en", audio_duration_s=2.0
+    )
+    assert resp.segments == []
+
+
+def test_default_adapter_single_segment() -> None:
+    adapter = DefaultTranscriptionAdapter()
+    resp = adapter.build_verbose_response(
+        text="hello world", language=None, audio_duration_s=1.5
+    )
+    assert len(resp.segments) == 1
+    assert resp.segments[0].text == "hello world"
+    assert resp.segments[0].end == 1.5

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -858,6 +858,96 @@ def test_transcription_endpoint_returns_text_json() -> None:
     assert request.extra_params["language"] == "en"
 
 
+class DiarizationTranscriptionClient:
+    """Stub returning MOSS-style diarized markup for verbose_json tests."""
+
+    async def completion(self, request, *, request_id, audio_format="wav"):
+        from sglang_omni.client.types import CompletionResult
+
+        del request, request_id, audio_format
+        return CompletionResult(
+            request_id="transcription-1",
+            text="[0.00][S01] hello there.[1.20][1.30][S02] bye.[3.00]",
+        )
+
+
+def test_transcription_verbose_json_returns_diarized_segments() -> None:
+    client = TestClient(
+        create_app(
+            DiarizationTranscriptionClient(),
+            model_name="moss-transcribe-diarize",
+            architectures=["MossTranscribeDiarizeForConditionalGeneration"],
+        )
+    )
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        data={"model": "moss-transcribe-diarize", "response_format": "verbose_json"},
+        files={"file": ("sample.wav", b"RIFF", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["task"] == "transcribe"
+    assert [(s["id"], s["start"], s["end"], s["text"]) for s in body["segments"]] == [
+        (0, 0.0, 1.2, "[S01]hello there."),
+        (1, 1.3, 3.0, "[S02]bye."),
+    ]
+
+
+def test_transcription_verbose_json_falls_back_for_plain_text() -> None:
+    client = TestClient(
+        create_app(
+            SuccessfulTranscriptionClient(),
+            model_name="moss-transcribe-diarize",
+            architectures=["MossTranscribeDiarizeForConditionalGeneration"],
+        )
+    )
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        data={"model": "moss-transcribe-diarize", "response_format": "verbose_json"},
+        files={"file": ("sample.wav", b"RIFF", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["segments"]) == 1
+    assert body["segments"][0]["text"] == "[S01]hello world"
+
+
+def _wav_bytes(duration_s: float, sample_rate: int = 16000) -> bytes:
+    import io
+
+    import numpy as np
+    import soundfile as sf
+
+    samples = np.zeros(int(duration_s * sample_rate), dtype=np.float32)
+    buf = io.BytesIO()
+    sf.write(buf, samples, sample_rate, format="WAV")
+    return buf.getvalue()
+
+
+def test_transcription_probes_duration_from_real_wav() -> None:
+    client = TestClient(
+        create_app(
+            DiarizationTranscriptionClient(),
+            model_name="moss-transcribe-diarize",
+            architectures=["MossTranscribeDiarizeForConditionalGeneration"],
+        )
+    )
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        data={"model": "moss-transcribe-diarize", "response_format": "verbose_json"},
+        files={"file": ("sample.wav", _wav_bytes(3.5), "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["usage"] == {"type": "duration", "seconds": 4}
+
+
 def test_speech_request_passes_moss_token_count() -> None:
     req = CreateSpeechRequest(input="hello", token_count=180)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
This pull request adds support for the [MOSS-Transcribe-Diarize](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize) model, which is a multi-modal model for audio transcription and speaker diarization. This model supports accepting a single audio input of up to approximately 90 minutes in length, and directly generates structured transcription results with timestamps and speaker labels.

The changes include registering the new model, providing configuration and request builder logic, and integrating with the scheduler.

## Modifications
**MOSS-Transcribe-Diarize model integration:**

* Registered the new `MossTranscribeDiarizeForConditionalGeneration` model in the model worker config and model runner, making it available for use. [[1]](diffhunk://#diff-7db93c2d9981f5076d6a0a24990328db56ff25eb8def7f742c16e3191aadf14dR33) [[2]](diffhunk://#diff-559d0e3adb5619c2e9f1333a644afac8b7ab4356c0e9ac59ec4d0309cfba7794R92)
* Added the `sglang_omni/models/moss_transcribe_diarize/config.py` file, defining the pipeline configuration for the MOSS-Transcribe-Diarize model, including its entry stage and batching parameters.
* Implemented a HuggingFace-compatible config class in `sglang_omni/models/moss_transcribe_diarize/hf_config.py` to describe the model architecture, including text and audio sub-configs.
* Added request builder and result adapter logic in `sglang_omni/models/moss_transcribe_diarize/request_builders.py`, handling audio input processing, prompt construction, and output postprocessing for the scheduler.

**Project structure and metadata:**

* Added an `__init__.py` file to the model directory with license and module docstring.

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
