### PR TITLE
[Feat] Add session-aware media cache

### DIFF
--- a/docs/developer_reference/cache_plane.md
+++ b/docs/developer_reference/cache_plane.md
@@ -1,0 +1,91 @@
+# Cache Plane
+
+SGLang-Omni keeps cache ownership split across the layer that owns the bytes:
+upstream SGLang owns AR KV cache, relay owns transfer blobs, and model stages
+own model-specific artifacts such as encoder outputs or uploaded-speaker
+features. The cache plane is a model-neutral metadata layer over those owners.
+
+## What It Owns
+
+`sglang_omni.cache` records:
+
+- stable `CacheKey` identity: namespace, artifact kind, digest, model/version,
+  stage, and optional session
+- `CacheOwner`: stage/process/GPU/device metadata for locality decisions
+- `ArtifactHandle`: owner-specific pointer, such as a stage-output key
+- lifecycle metadata: size, timestamps, TTL, ready/building state, and pin count
+- local eviction, invalidation, and single-flight build coordination
+- session-to-owner bindings and owner affinity ranking for locality-aware routing
+
+It does not own tensor bytes, relay blobs, or SGLang KV blocks.
+
+## Current Integrations
+
+`StageOutputCache` can publish entries into a `LocalCachePlane` when constructed
+with a `cache_namespace`. Qwen3-Omni image and audio encoder output caches use
+this path, so repeated media outputs remain local to the stage cache while their
+owner and size metadata are visible through the cache plane.
+
+Qwen3-Omni preprocessing also keeps a small session media registry. When a
+request carries `metadata.session_id` and `metadata.reuse_session_media=true`,
+the preprocessor can reuse the previous media cache key for that session. If the
+cache plane shows the encoder artifact is still ready, preprocessing builds only
+the multimodal placeholder prompt and sends a cache-only encoder request. The
+encoder stage then reads the artifact from `StageOutputCache` instead of
+decoding pixels or rerunning the encoder. If the artifact has been evicted and
+raw media references are still retained, preprocessing falls back to the normal
+media path; otherwise the request must resend media.
+
+`SpeakerArtifactCache` uses the same metadata path for uploaded-speaker
+artifacts. It still stores artifacts in its bounded LRU and keeps the
+voice-level invalidation contract.
+
+## Application Scenario
+
+The high-value scenario is a multimodal chat session: a user uploads an image or
+video once, then asks several follow-up questions in the same session. The first
+turn builds the encoder output and publishes the artifact.
+Later turns can send only the new text plus:
+
+```json
+{
+  "metadata": {
+    "session_id": "conversation-123",
+    "reuse_session_media": true
+  }
+}
+```
+
+This avoids redundant image/video encoder work. For Qwen3-Omni, the session
+registry also keeps lightweight multimodal shape metadata such as
+`image_grid_thw`, so follow-up turns can skip media decoding while still
+expanding the correct placeholder tokens for M-RoPE and SGLang prefix/radix
+identity. The cache entry is the encoder artifact keyed by media content and
+preprocessing parameters, not the raw image bytes.
+
+## Locality API
+
+`LocalCachePlane.bind_session(session_id, owner)` records an explicit affinity
+between a logical session and the owner that should be preferred for follow-up
+work. Entries whose `CacheKey.session_id` is set also update that binding when
+they are published or registered as in-flight builds.
+
+`LocalCachePlane.rank_owners(selector, session_id=...)` returns `CacheAffinity`
+scores grouped by owner. This is the hook a scheduler or router can use to pick
+the worker/process/GPU with the best existing artifacts before falling back to
+normal load balancing. The current stage integrations publish metadata only; no
+scheduler route is changed by this API yet.
+
+## Boundaries
+
+The cache plane is intentionally thin:
+
+- Stage runtime does not branch on cache behavior.
+- Schedulers still own batching and request lifecycle.
+- Model code still decides whether an artifact is cacheable and how to compute
+  content identity.
+- SGLang radix/KV cache stays upstream-owned; the cache plane can observe or
+  route around it later, but does not mutate SGLang internals.
+
+Future distributed implementations should preserve the same schema and owner
+contract while replacing the local registry backend.

--- a/docs/developer_reference/main.md
+++ b/docs/developer_reference/main.md
@@ -20,6 +20,7 @@ HTTP API -> Client -> Coordinator -> Stage -> Scheduler -> ModelRunner -> model 
 | [Scheduler](./pipeline.md)        | Per-stage execution loop and failure propagation to stage outbox                       |
 | [ModelRunner](./pipeline.md)      | AR forward preparation, model forward dispatch, output extraction                      |
 | [Communication](./communication.md) | Control-plane messages and relay data transfer between stages                         |
+| [Cache Plane](./cache_plane.md)   | Cache metadata, owner locality, invalidation, and lifecycle registry                  |
 | [TTS Integration](./tts_model_integration.md) | Checklist and lifecycle rules for adding TTS model families                         |
 
 Refer to the layer-specific document for specific design details.
@@ -34,6 +35,7 @@ sglang_omni/
 |-- models/         # Model-specific configs, stages, request builders, modules
 |-- config/         # PipelineConfig, StageConfig, config manager, topology
 |-- relay/          # Data transfer backends
+|-- cache/          # Cache metadata plane and local artifact registry
 |-- serve/          # HTTP server and OpenAI-compatible API adapter
 |-- client/         # Internal client used by API adapters
 `-- proto/          # Request, payload, stage, and control-plane message types

--- a/sglang_omni/cache/__init__.py
+++ b/sglang_omni/cache/__init__.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from sglang_omni.cache.local import LocalCachePlane
+from sglang_omni.cache.schema import (
+    ArtifactHandle,
+    CacheAffinity,
+    CacheEntry,
+    CacheKey,
+    CacheLease,
+    CacheMeta,
+    CacheOwner,
+    CacheSelector,
+    CacheStats,
+)
+
+_GLOBAL_CACHE_PLANE = LocalCachePlane()
+
+
+def get_global_cache_plane() -> LocalCachePlane:
+    return _GLOBAL_CACHE_PLANE
+
+
+def reset_global_cache_plane() -> None:
+    _GLOBAL_CACHE_PLANE.clear()
+
+
+__all__ = [
+    "ArtifactHandle",
+    "CacheAffinity",
+    "CacheEntry",
+    "CacheKey",
+    "CacheLease",
+    "CacheMeta",
+    "CacheOwner",
+    "CacheSelector",
+    "CacheStats",
+    "LocalCachePlane",
+    "get_global_cache_plane",
+    "reset_global_cache_plane",
+]

--- a/sglang_omni/cache/local.py
+++ b/sglang_omni/cache/local.py
@@ -1,0 +1,463 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import threading
+import time
+from collections import OrderedDict
+
+from sglang_omni.cache.schema import (
+    ArtifactHandle,
+    CacheAffinity,
+    CacheEntry,
+    CacheKey,
+    CacheLease,
+    CacheMeta,
+    CacheOwner,
+    CacheSelector,
+    CacheStats,
+)
+
+
+class LocalCachePlane:
+    """In-process metadata registry for cacheable artifacts.
+
+    Owners keep the actual payload bytes. The plane records where entries live,
+    their approximate size, pin state, and readiness so higher layers can make
+    routing, invalidation, and observability decisions without taking over
+    tensor or SGLang KV ownership.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_entries: int | None = None,
+        max_bytes: int | None = None,
+        clock=time.monotonic,
+    ) -> None:
+        if max_entries is not None and max_entries <= 0:
+            raise ValueError("max_entries must be positive when set")
+        if max_bytes is not None and max_bytes <= 0:
+            raise ValueError("max_bytes must be positive when set")
+        self.max_entries = max_entries
+        self.max_bytes = max_bytes
+        self._clock = clock
+        self._entries: OrderedDict[CacheKey, CacheEntry] = OrderedDict()
+        self._conditions: dict[CacheKey, threading.Condition] = {}
+        self._session_owners: dict[str, CacheOwner] = {}
+        self._lock = threading.RLock()
+        self._hit_count = 0
+        self._miss_count = 0
+        self._eviction_count = 0
+        self._invalidation_count = 0
+
+    def publish(
+        self,
+        key: CacheKey,
+        handle: ArtifactHandle,
+        *,
+        owner: CacheOwner | None = None,
+        size_bytes: int = 0,
+        device: str | None = None,
+        dtype: str | None = None,
+        shape: tuple[int, ...] | None = None,
+        ttl_s: float | None = None,
+    ) -> CacheEntry:
+        now = self._clock()
+        owner = owner or CacheOwner()
+        meta = CacheMeta(
+            owner=owner,
+            size_bytes=int(size_bytes),
+            device=device,
+            dtype=dtype,
+            shape=shape,
+            created_at=now,
+            last_access_at=now,
+            ttl_s=ttl_s,
+            status="ready",
+        )
+        entry = CacheEntry(key=key, handle=handle, meta=meta)
+        with self._lock:
+            self._entries[key] = entry
+            self._entries.move_to_end(key)
+            if key.session_id is not None:
+                self._session_owners[key.session_id] = owner
+            self._notify_locked(key)
+            self._evict_over_budget_locked()
+            return self._entries.get(key, entry)
+
+    def start_build(
+        self,
+        key: CacheKey,
+        *,
+        owner: CacheOwner | None = None,
+        ttl_s: float | None = None,
+    ) -> bool:
+        """Register a single-flight build.
+
+        Returns True for the leader. Followers get False and can call
+        wait_ready(). Failed builds are removed, so a later caller can retry.
+        """
+
+        now = self._clock()
+        owner = owner or CacheOwner()
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is not None and not self._is_expired(entry, now):
+                self._entries.move_to_end(key)
+                return False
+            if entry is not None:
+                self._remove_locked(key)
+            meta = CacheMeta(
+                owner=owner,
+                created_at=now,
+                last_access_at=now,
+                ttl_s=ttl_s,
+                status="building",
+            )
+            self._entries[key] = CacheEntry(
+                key=key,
+                handle=ArtifactHandle(backend="building"),
+                meta=meta,
+            )
+            self._entries.move_to_end(key)
+            if key.session_id is not None:
+                self._session_owners[key.session_id] = owner
+            self._conditions.setdefault(key, threading.Condition(self._lock))
+            return True
+
+    def fail_build(self, key: CacheKey, error: BaseException | str) -> None:
+        del error
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is not None and entry.meta.status == "building":
+                self._remove_locked(key)
+            self._notify_locked(key)
+
+    def wait_ready(
+        self, key: CacheKey, timeout_s: float | None = None
+    ) -> CacheEntry | None:
+        deadline = None if timeout_s is None else self._clock() + timeout_s
+        with self._lock:
+            condition = self._conditions.setdefault(
+                key, threading.Condition(self._lock)
+            )
+            while True:
+                entry = self._entries.get(key)
+                if entry is None:
+                    return None
+                if self._is_expired(entry, self._clock()):
+                    self._remove_locked(key)
+                    self._notify_locked(key)
+                    return None
+                if entry.meta.status == "ready":
+                    self._entries.move_to_end(key)
+                    return entry
+                if entry.meta.status != "building":
+                    return None
+                if deadline is None:
+                    condition.wait()
+                    continue
+                remaining = deadline - self._clock()
+                if remaining <= 0:
+                    return None
+                condition.wait(remaining)
+
+    def lookup(self, key: CacheKey) -> CacheEntry | None:
+        with self._lock:
+            entry = self._entries.get(key)
+            now = self._clock()
+            if entry is None or self._is_expired(entry, now):
+                if entry is not None:
+                    self._remove_locked(key)
+                self._miss_count += 1
+                return None
+            if entry.meta.status != "ready":
+                self._miss_count += 1
+                return None
+            entry = CacheEntry(
+                key=entry.key, handle=entry.handle, meta=entry.meta.with_access(now)
+            )
+            self._entries[key] = entry
+            self._entries.move_to_end(key)
+            self._hit_count += 1
+            return entry
+
+    def peek(self, key: CacheKey) -> CacheEntry | None:
+        """Return a ready entry without updating hit/miss counters."""
+
+        with self._lock:
+            entry = self._entries.get(key)
+            now = self._clock()
+            if entry is None:
+                return None
+            if self._is_expired(entry, now):
+                self._remove_locked(key)
+                return None
+            if entry.meta.status != "ready":
+                return None
+            return entry
+
+    def record_miss(self, key: CacheKey) -> None:
+        del key
+        with self._lock:
+            self._miss_count += 1
+
+    def touch(self, key: CacheKey) -> None:
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                return
+            now = self._clock()
+            self._entries[key] = CacheEntry(
+                key=entry.key,
+                handle=entry.handle,
+                meta=entry.meta.with_access(now),
+            )
+            self._entries.move_to_end(key)
+
+    def pin(self, key: CacheKey, request_id: str) -> CacheLease | None:
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None or entry.meta.status != "ready":
+                return None
+            meta = entry.meta.with_ref_count(entry.meta.ref_count + 1)
+            self._entries[key] = CacheEntry(
+                key=entry.key, handle=entry.handle, meta=meta
+            )
+            self._entries.move_to_end(key)
+            return CacheLease(key=key, request_id=str(request_id))
+
+    def release(self, lease: CacheLease) -> None:
+        with self._lock:
+            entry = self._entries.get(lease.key)
+            if entry is None:
+                return
+            meta = entry.meta.with_ref_count(max(0, entry.meta.ref_count - 1))
+            self._entries[lease.key] = CacheEntry(
+                key=entry.key,
+                handle=entry.handle,
+                meta=meta,
+            )
+
+    def bind_session(self, session_id: str, owner: CacheOwner) -> None:
+        if not isinstance(session_id, str) or not session_id:
+            raise ValueError("session_id must be a non-empty string")
+        with self._lock:
+            self._session_owners[session_id] = owner
+
+    def unbind_session(self, session_id: str) -> bool:
+        if not isinstance(session_id, str) or not session_id:
+            raise ValueError("session_id must be a non-empty string")
+        with self._lock:
+            return self._session_owners.pop(session_id, None) is not None
+
+    def session_owner(self, session_id: str) -> CacheOwner | None:
+        if not isinstance(session_id, str) or not session_id:
+            raise ValueError("session_id must be a non-empty string")
+        with self._lock:
+            return self._session_owners.get(session_id)
+
+    def rank_owners(
+        self,
+        selector: CacheSelector | None = None,
+        *,
+        session_id: str | None = None,
+    ) -> list[CacheAffinity]:
+        selector = selector or CacheSelector()
+        affinity_session_id = session_id or selector.session_id
+        with self._lock:
+            scores: dict[CacheOwner, CacheAffinity] = {}
+            now = self._clock()
+            for key, entry in self._entries.items():
+                if entry.meta.status != "ready":
+                    continue
+                if self._is_expired(entry, now):
+                    continue
+                if not selector.matches(key):
+                    continue
+                affinity = scores.get(entry.meta.owner)
+                session_entry = (
+                    affinity_session_id is not None
+                    and key.session_id == affinity_session_id
+                )
+                scores[entry.meta.owner] = CacheAffinity(
+                    owner=entry.meta.owner,
+                    entry_count=(affinity.entry_count if affinity else 0) + 1,
+                    total_bytes=(affinity.total_bytes if affinity else 0)
+                    + entry.meta.size_bytes,
+                    session_entry_count=(
+                        affinity.session_entry_count if affinity else 0
+                    )
+                    + int(session_entry),
+                    bound_session=affinity.bound_session if affinity else False,
+                )
+
+            bound_owner = (
+                self._session_owners.get(affinity_session_id)
+                if affinity_session_id is not None
+                else None
+            )
+            if bound_owner is not None:
+                affinity = scores.get(bound_owner)
+                scores[bound_owner] = CacheAffinity(
+                    owner=bound_owner,
+                    entry_count=affinity.entry_count if affinity else 0,
+                    total_bytes=affinity.total_bytes if affinity else 0,
+                    session_entry_count=(
+                        affinity.session_entry_count if affinity else 0
+                    ),
+                    bound_session=True,
+                )
+
+            return sorted(
+                scores.values(),
+                key=lambda affinity: (
+                    not affinity.bound_session,
+                    -affinity.session_entry_count,
+                    -affinity.total_bytes,
+                    -affinity.entry_count,
+                    affinity.owner.host,
+                    affinity.owner.stage_name or "",
+                    affinity.owner.worker_id or "",
+                    affinity.owner.device or "",
+                ),
+            )
+
+    def remove(self, key: CacheKey) -> bool:
+        with self._lock:
+            if key not in self._entries:
+                return False
+            self._remove_locked(key)
+            self._notify_locked(key)
+            return True
+
+    def invalidate(
+        self,
+        selector: CacheSelector | None = None,
+        *,
+        include_pinned: bool = False,
+    ) -> int:
+        selector = selector or CacheSelector()
+        removed = 0
+        with self._lock:
+            for key, entry in list(self._entries.items()):
+                if not selector.matches(key):
+                    continue
+                if entry.meta.ref_count > 0 and not include_pinned:
+                    continue
+                self._remove_locked(key)
+                self._notify_locked(key)
+                removed += 1
+            if selector.session_id is not None and removed:
+                self._session_owners.pop(selector.session_id, None)
+            self._invalidation_count += removed
+        return removed
+
+    def evict(
+        self,
+        *,
+        max_entries: int | None = None,
+        max_bytes: int | None = None,
+        selector: CacheSelector | None = None,
+    ) -> list[CacheKey]:
+        if max_entries is not None and max_entries <= 0:
+            raise ValueError("max_entries must be positive when set")
+        if max_bytes is not None and max_bytes <= 0:
+            raise ValueError("max_bytes must be positive when set")
+        selector = selector or CacheSelector()
+        evicted: list[CacheKey] = []
+        with self._lock:
+            while self._over_budget_locked(max_entries, max_bytes):
+                victim = self._oldest_evictable_locked(selector)
+                if victim is None:
+                    break
+                self._remove_locked(victim)
+                self._notify_locked(victim)
+                evicted.append(victim)
+            self._eviction_count += len(evicted)
+        return evicted
+
+    def stats(self, selector: CacheSelector | None = None) -> CacheStats:
+        selector = selector or CacheSelector()
+        with self._lock:
+            entries = [
+                entry for key, entry in self._entries.items() if selector.matches(key)
+            ]
+            return CacheStats(
+                entries=len(entries),
+                ready_entries=sum(entry.meta.status == "ready" for entry in entries),
+                building_entries=sum(
+                    entry.meta.status == "building" for entry in entries
+                ),
+                pinned_entries=sum(entry.meta.ref_count > 0 for entry in entries),
+                total_bytes=sum(entry.meta.size_bytes for entry in entries),
+                hit_count=self._hit_count,
+                miss_count=self._miss_count,
+                eviction_count=self._eviction_count,
+                invalidation_count=self._invalidation_count,
+                session_bindings=self._session_binding_count_locked(selector),
+            )
+
+    def clear(self) -> None:
+        with self._lock:
+            keys = list(self._entries)
+            for key in keys:
+                self._notify_locked(key)
+            self._entries.clear()
+            self._conditions.clear()
+            self._session_owners.clear()
+
+    def _is_expired(self, entry: CacheEntry, now: float) -> bool:
+        ttl_s = entry.meta.ttl_s
+        return ttl_s is not None and now - entry.meta.created_at >= ttl_s
+
+    def _over_budget_locked(
+        self,
+        max_entries: int | None = None,
+        max_bytes: int | None = None,
+    ) -> bool:
+        entry_budget = max_entries if max_entries is not None else self.max_entries
+        byte_budget = max_bytes if max_bytes is not None else self.max_bytes
+        if entry_budget is not None and len(self._entries) > entry_budget:
+            return True
+        if byte_budget is not None and self._total_bytes_locked() > byte_budget:
+            return True
+        return False
+
+    def _evict_over_budget_locked(self) -> None:
+        evicted = 0
+        while self._over_budget_locked():
+            victim = self._oldest_evictable_locked(CacheSelector())
+            if victim is None:
+                break
+            self._remove_locked(victim)
+            self._notify_locked(victim)
+            evicted += 1
+        self._eviction_count += evicted
+
+    def _oldest_evictable_locked(self, selector: CacheSelector) -> CacheKey | None:
+        for key, entry in self._entries.items():
+            if not selector.matches(key):
+                continue
+            if entry.meta.status != "ready":
+                continue
+            if entry.meta.ref_count > 0:
+                continue
+            return key
+        return None
+
+    def _total_bytes_locked(self) -> int:
+        return sum(entry.meta.size_bytes for entry in self._entries.values())
+
+    def _remove_locked(self, key: CacheKey) -> None:
+        self._entries.pop(key, None)
+
+    def _session_binding_count_locked(self, selector: CacheSelector) -> int:
+        if selector.session_id is not None:
+            return int(selector.session_id in self._session_owners)
+        return len(self._session_owners)
+
+    def _notify_locked(self, key: CacheKey) -> None:
+        condition = self._conditions.get(key)
+        if condition is not None:
+            condition.notify_all()

--- a/sglang_omni/cache/schema.py
+++ b/sglang_omni/cache/schema.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import socket
+from dataclasses import dataclass, field, replace
+from typing import Any, Literal
+
+CacheStatus = Literal["building", "ready", "failed"]
+
+
+@dataclass(frozen=True)
+class CacheKey:
+    """Stable identity for a cacheable artifact.
+
+    The key describes content identity and routing dimensions only. The actual
+    tensor/object bytes stay owned by the stage cache, relay, or upstream
+    SGLang cache that produced them.
+    """
+
+    namespace: str
+    kind: str
+    digest: str
+    model_id: str | None = None
+    weight_version: str | None = None
+    processor_version: str | None = None
+    stage_name: str | None = None
+    session_id: str | None = None
+
+    def __post_init__(self) -> None:
+        for field_name in ("namespace", "kind", "digest"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"CacheKey.{field_name} must be a non-empty string")
+
+
+@dataclass(frozen=True)
+class CacheOwner:
+    """Where a cache entry is materialized."""
+
+    stage_name: str | None = None
+    process_id: int | None = None
+    worker_id: str | None = None
+    gpu_id: int | None = None
+    device: str | None = None
+    host: str = field(default_factory=socket.gethostname)
+
+
+@dataclass(frozen=True)
+class ArtifactHandle:
+    """Pointer to the owner-specific artifact storage."""
+
+    backend: str
+    ref: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.backend, str) or not self.backend:
+            raise ValueError("ArtifactHandle.backend must be a non-empty string")
+
+
+@dataclass(frozen=True)
+class CacheMeta:
+    owner: CacheOwner
+    size_bytes: int = 0
+    device: str | None = None
+    dtype: str | None = None
+    shape: tuple[int, ...] | None = None
+    created_at: float = 0.0
+    last_access_at: float = 0.0
+    ttl_s: float | None = None
+    ref_count: int = 0
+    status: CacheStatus = "ready"
+    error: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.size_bytes < 0:
+            raise ValueError("CacheMeta.size_bytes must be non-negative")
+        if self.ref_count < 0:
+            raise ValueError("CacheMeta.ref_count must be non-negative")
+        if self.ttl_s is not None and self.ttl_s <= 0:
+            raise ValueError("CacheMeta.ttl_s must be positive when set")
+
+    def with_access(self, timestamp: float) -> "CacheMeta":
+        return replace(self, last_access_at=timestamp)
+
+    def with_ref_count(self, ref_count: int) -> "CacheMeta":
+        return replace(self, ref_count=ref_count)
+
+
+@dataclass(frozen=True)
+class CacheEntry:
+    key: CacheKey
+    handle: ArtifactHandle
+    meta: CacheMeta
+
+
+@dataclass(frozen=True)
+class CacheLease:
+    key: CacheKey
+    request_id: str
+
+
+@dataclass(frozen=True)
+class CacheAffinity:
+    """Cache locality score for a materialized owner."""
+
+    owner: CacheOwner
+    entry_count: int = 0
+    total_bytes: int = 0
+    session_entry_count: int = 0
+    bound_session: bool = False
+
+    def __post_init__(self) -> None:
+        if self.entry_count < 0:
+            raise ValueError("CacheAffinity.entry_count must be non-negative")
+        if self.total_bytes < 0:
+            raise ValueError("CacheAffinity.total_bytes must be non-negative")
+        if self.session_entry_count < 0:
+            raise ValueError("CacheAffinity.session_entry_count must be non-negative")
+
+
+@dataclass(frozen=True)
+class CacheSelector:
+    namespace: str | None = None
+    kind: str | None = None
+    model_id: str | None = None
+    stage_name: str | None = None
+    session_id: str | None = None
+    keys: frozenset[CacheKey] | None = None
+
+    def matches(self, key: CacheKey) -> bool:
+        if self.keys is not None and key not in self.keys:
+            return False
+        if self.namespace is not None and key.namespace != self.namespace:
+            return False
+        if self.kind is not None and key.kind != self.kind:
+            return False
+        if self.model_id is not None and key.model_id != self.model_id:
+            return False
+        if self.stage_name is not None and key.stage_name != self.stage_name:
+            return False
+        if self.session_id is not None and key.session_id != self.session_id:
+            return False
+        return True
+
+
+@dataclass(frozen=True)
+class CacheStats:
+    entries: int
+    ready_entries: int
+    building_entries: int
+    pinned_entries: int
+    total_bytes: int
+    hit_count: int
+    miss_count: int
+    eviction_count: int
+    invalidation_count: int
+    session_bindings: int = 0

--- a/sglang_omni/models/qwen3_omni/components/preprocessor.py
+++ b/sglang_omni/models/qwen3_omni/components/preprocessor.py
@@ -13,8 +13,13 @@ from transformers.models.qwen3_omni_moe.processing_qwen3_omni_moe import (
     Qwen3OmniMoeProcessor,
 )
 
+from sglang_omni.cache import CacheKey, get_global_cache_plane
 from sglang_omni.models.qwen3_omni.payload_types import Qwen3OmniPipelineState
 from sglang_omni.models.qwen3_omni.request_builders import build_lightweight_mm_inputs
+from sglang_omni.models.qwen3_omni.session_media import (
+    SessionMediaEntry,
+    SessionMediaRegistry,
+)
 from sglang_omni.models.weight_loader import resolve_model_path
 from sglang_omni.preprocessing import (
     build_audio_mm_inputs,
@@ -67,6 +72,70 @@ def _contextualize_cache_key(base_key: str | None, **context: Any) -> str | None
         if value is not None:
             parts.append(f"{key}={value}")
     return "|".join(parts)
+
+
+def _has_media_refs(*values: Any) -> bool:
+    return any(value is not None and value != [] and value != () for value in values)
+
+
+def _metadata_or_input_value(
+    inputs: Any,
+    metadata: dict[str, Any],
+    key: str,
+) -> Any:
+    if key in metadata:
+        return metadata[key]
+    if isinstance(inputs, dict):
+        return inputs.get(key)
+    return None
+
+
+def _truthy_media_flag(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.lower() not in ("", "0", "false", "no", "none")
+    if isinstance(value, (list, tuple, set, dict)):
+        return bool(value)
+    return bool(value)
+
+
+def _session_id_from(inputs: Any, metadata: dict[str, Any]) -> str | None:
+    value = metadata.get("session_id")
+    if value is None and isinstance(inputs, dict):
+        value = inputs.get("session_id")
+    if value is None:
+        return None
+    value = str(value)
+    return value or None
+
+
+def _encoder_cache_ready(*, kind: str, cache_key: str, stage_name: str) -> bool:
+    entry = get_global_cache_plane().peek(
+        CacheKey(
+            namespace="qwen3_omni",
+            kind=kind,
+            digest=cache_key,
+            stage_name=stage_name,
+        )
+    )
+    return entry is not None
+
+
+def _metadata_cache_value(value: Any) -> Any:
+    if isinstance(value, torch.Tensor):
+        return value.detach().cpu()
+    if isinstance(value, dict):
+        return {key: _metadata_cache_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return type(value)(_metadata_cache_value(item) for item in value)
+    return value
+
+
+def _iter_metadata_rows(value: Any):
+    if value is None:
+        return iter([])
+    if isinstance(value, torch.Tensor):
+        return iter(value)
+    return iter(value)
 
 
 DEFAULT_THINKER_MAX_NEW_TOKENS = 2048
@@ -152,6 +221,7 @@ class Qwen3OmniPreprocessor:
         self.default_video_total_pixels = (
             int(video_total_pixels) if video_total_pixels is not None else None
         )
+        self.session_media = SessionMediaRegistry()
         self.model_dir = _resolve_local_model_dir(model_path)
         try:
             self.processor = Qwen3OmniMoeProcessor.from_pretrained(
@@ -284,36 +354,239 @@ class Qwen3OmniPreprocessor:
             },
         )
 
+    def _preprocess_cached_session_media(
+        self,
+        payload: StagePayload,
+        *,
+        messages: Any,
+        entry: SessionMediaEntry,
+    ) -> StagePayload | None:
+        encoder_inputs: dict[str, dict[str, Any]] = {}
+        if entry.image_cache_key:
+            if entry.num_images and entry.image_grid_thw is None:
+                return None
+            if entry.num_videos and entry.video_grid_thw is None:
+                return None
+            if not _encoder_cache_ready(
+                kind="image_encoder_output",
+                cache_key=entry.image_cache_key,
+                stage_name="image_encoder",
+            ):
+                return None
+            encoder_inputs["image_encoder"] = {
+                "cache_key": entry.image_cache_key,
+                "_active": True,
+                "_cache_only": True,
+            }
+        else:
+            encoder_inputs["image_encoder"] = {"_skip": True, "_result": {}}
+
+        if entry.audio_cache_key:
+            if entry.audio_placeholder_lengths is None:
+                return None
+            if not _encoder_cache_ready(
+                kind="audio_encoder_output",
+                cache_key=entry.audio_cache_key,
+                stage_name="audio_encoder",
+            ):
+                return None
+            encoder_inputs["audio_encoder"] = {
+                "cache_key": entry.audio_cache_key,
+                "_active": True,
+                "_cache_only": True,
+            }
+        else:
+            encoder_inputs["audio_encoder"] = {"_skip": True, "_result": {}}
+
+        if not any(
+            stage_inputs.get("_active") for stage_inputs in encoder_inputs.values()
+        ):
+            return None
+
+        messages_norm = normalize_messages(messages)
+        messages_mm = self._build_multimodal_messages(
+            messages_norm,
+            num_images=entry.num_images,
+            num_audios=entry.num_audios,
+            num_videos=entry.num_videos,
+        )
+        prompt_text = self.processor.apply_chat_template(
+            messages_mm,
+            add_generation_prompt=True,
+            tokenize=False,
+        )
+        tokenize_text = prompt_text
+        replace_tokens = getattr(
+            self.processor,
+            "replace_multimodal_special_tokens",
+            None,
+        )
+        if callable(replace_tokens):
+            tokenize_text = replace_tokens(
+                [prompt_text],
+                _iter_metadata_rows(entry.audio_placeholder_lengths),
+                _iter_metadata_rows(entry.image_grid_thw),
+                _iter_metadata_rows(entry.video_grid_thw),
+                video_second_per_grid=_iter_metadata_rows(entry.video_second_per_grid),
+                use_audio_in_video=bool(entry.use_audio_in_video),
+                position_id_per_seconds=entry.video_position_id_per_seconds,
+                seconds_per_chunk=entry.video_seconds_per_chunk,
+            )[0]
+        tokenized = self.tokenizer(
+            tokenize_text,
+            add_special_tokens=False,
+            return_tensors="pt",
+        )
+        input_ids = tokenized["input_ids"][0]
+        attention_mask = tokenized.get("attention_mask")
+        if isinstance(attention_mask, torch.Tensor):
+            attention_mask = attention_mask[0]
+        else:
+            attention_mask = torch.ones_like(input_ids)
+        validate_prompt_seq_len(
+            input_ids,
+            max_seq_len=self.max_seq_len,
+            max_new_tokens=payload.request.params.get(
+                "max_new_tokens", DEFAULT_THINKER_MAX_NEW_TOKENS
+            ),
+            request_id=payload.request_id,
+        )
+        return self._finalize_state(
+            payload,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            prompt_text=prompt_text,
+            full_mm_inputs={},
+            encoder_inputs=encoder_inputs,
+        )
+
     async def _call_impl(self, payload: StagePayload) -> StagePayload:
         inputs = payload.request.inputs
         if _is_pretokenized_prompt(inputs):
             return self._preprocess_pretokenized(payload, inputs)
-        if isinstance(inputs, dict):
-            messages = inputs.get("messages", [])
-            raw_images = inputs.get("images")
-            raw_videos = inputs.get("videos") or inputs.get("video")
-            raw_audios = inputs.get("audio") or inputs.get("audios")
-            audio_target_sr = int(inputs.get("audio_target_sr", 16000))
-            video_fps = inputs.get("video_fps", self.default_video_fps)
-            video_max_frames = inputs.get(
-                "video_max_frames",
-                self.default_video_max_frames,
+        metadata = payload.request.metadata
+        if not isinstance(metadata, dict):
+            metadata = {}
+        session_id = _session_id_from(inputs, metadata)
+        if session_id is not None and _truthy_media_flag(
+            _metadata_or_input_value(inputs, metadata, "clear_session_media")
+        ):
+            self.session_media.clear(session_id)
+        metadata_images = _metadata_or_input_value(inputs, metadata, "images")
+        metadata_videos = _metadata_or_input_value(
+            inputs, metadata, "videos"
+        ) or _metadata_or_input_value(inputs, metadata, "video")
+        metadata_audios = _metadata_or_input_value(
+            inputs, metadata, "audio"
+        ) or _metadata_or_input_value(inputs, metadata, "audios")
+        reuse_session_media = session_id is not None and _truthy_media_flag(
+            _metadata_or_input_value(inputs, metadata, "reuse_session_media")
+        )
+        if (
+            isinstance(inputs, dict)
+            or _has_media_refs(
+                metadata_images,
+                metadata_videos,
+                metadata_audios,
             )
-            video_min_pixels = inputs.get(
-                "video_min_pixels",
-                self.default_video_min_pixels,
+            or reuse_session_media
+        ):
+            messages = (
+                inputs.get("messages", []) if isinstance(inputs, dict) else inputs
             )
-            video_max_pixels = inputs.get(
-                "video_max_pixels",
-                self.default_video_max_pixels,
+            raw_images = metadata_images
+            raw_videos = metadata_videos
+            raw_audios = metadata_audios
+            reuse_entry: SessionMediaEntry | None = None
+            if reuse_session_media and not _has_media_refs(
+                raw_images, raw_videos, raw_audios
+            ):
+                reuse_entry = self.session_media.get(session_id)
+                if reuse_entry is not None:
+                    cached_payload = self._preprocess_cached_session_media(
+                        payload,
+                        messages=messages,
+                        entry=reuse_entry,
+                    )
+                    if cached_payload is not None:
+                        return cached_payload
+                    if not _has_media_refs(
+                        reuse_entry.raw_images,
+                        reuse_entry.raw_videos,
+                        reuse_entry.raw_audios,
+                    ):
+                        raise RuntimeError(
+                            "session media cache is not ready and the session "
+                            "does not retain raw media references; resend media"
+                        )
+                    raw_images = reuse_entry.raw_images
+                    raw_videos = reuse_entry.raw_videos
+                    raw_audios = reuse_entry.raw_audios
+            audio_target_sr_value = _metadata_or_input_value(
+                inputs, metadata, "audio_target_sr"
             )
-            video_total_pixels = inputs.get(
-                "video_total_pixels",
-                self.default_video_total_pixels,
+            audio_target_sr = int(
+                audio_target_sr_value if audio_target_sr_value is not None else 16000
             )
-            use_audio_in_video = inputs.get("use_audio_in_video")
-            video_seconds_per_chunk = inputs.get("video_seconds_per_chunk")
-            video_position_id_per_seconds = inputs.get("video_position_id_per_seconds")
+            if reuse_entry is not None:
+                audio_target_sr_value = _metadata_or_input_value(
+                    inputs, metadata, "audio_target_sr"
+                )
+                audio_target_sr = int(
+                    audio_target_sr_value
+                    if audio_target_sr_value is not None
+                    else reuse_entry.audio_target_sr
+                )
+            video_fps = _metadata_or_input_value(inputs, metadata, "video_fps")
+            if video_fps is None:
+                video_fps = self.default_video_fps
+            if reuse_entry is not None and video_fps is None:
+                video_fps = reuse_entry.video_fps
+            video_max_frames = _metadata_or_input_value(
+                inputs, metadata, "video_max_frames"
+            )
+            if video_max_frames is None:
+                video_max_frames = self.default_video_max_frames
+            if reuse_entry is not None and video_max_frames is None:
+                video_max_frames = reuse_entry.video_max_frames
+            video_min_pixels = _metadata_or_input_value(
+                inputs, metadata, "video_min_pixels"
+            )
+            if video_min_pixels is None:
+                video_min_pixels = self.default_video_min_pixels
+            if reuse_entry is not None and video_min_pixels is None:
+                video_min_pixels = reuse_entry.video_min_pixels
+            video_max_pixels = _metadata_or_input_value(
+                inputs, metadata, "video_max_pixels"
+            )
+            if video_max_pixels is None:
+                video_max_pixels = self.default_video_max_pixels
+            if reuse_entry is not None and video_max_pixels is None:
+                video_max_pixels = reuse_entry.video_max_pixels
+            video_total_pixels = _metadata_or_input_value(
+                inputs, metadata, "video_total_pixels"
+            )
+            if video_total_pixels is None:
+                video_total_pixels = self.default_video_total_pixels
+            if reuse_entry is not None and video_total_pixels is None:
+                video_total_pixels = reuse_entry.video_total_pixels
+            use_audio_in_video = _metadata_or_input_value(
+                inputs, metadata, "use_audio_in_video"
+            )
+            if reuse_entry is not None and use_audio_in_video is None:
+                use_audio_in_video = reuse_entry.use_audio_in_video
+            video_seconds_per_chunk = _metadata_or_input_value(
+                inputs, metadata, "video_seconds_per_chunk"
+            )
+            if reuse_entry is not None and video_seconds_per_chunk is None:
+                video_seconds_per_chunk = reuse_entry.video_seconds_per_chunk
+            video_position_id_per_seconds = _metadata_or_input_value(
+                inputs, metadata, "video_position_id_per_seconds"
+            )
+            if reuse_entry is not None and video_position_id_per_seconds is None:
+                video_position_id_per_seconds = (
+                    reuse_entry.video_position_id_per_seconds
+                )
             audio_from_video = False
             num_explicit_audios = 0
             resolved_video_fps = float(video_fps) if video_fps is not None else None
@@ -393,6 +666,9 @@ class Qwen3OmniPreprocessor:
                 audios = audios_result
         else:
             messages = inputs
+            raw_images = None
+            raw_videos = None
+            raw_audios = None
             images = []
             videos = []
             audios = []
@@ -545,6 +821,47 @@ class Qwen3OmniPreprocessor:
             )
         if contextualized_audio_cache_key:
             audio_encoder_inputs["cache_key"] = contextualized_audio_cache_key
+
+        if session_id is not None and _has_media_refs(
+            raw_images, raw_videos, raw_audios
+        ):
+            self.session_media.put(
+                session_id,
+                SessionMediaEntry(
+                    raw_images=raw_images,
+                    raw_videos=raw_videos,
+                    raw_audios=raw_audios,
+                    image_cache_key=combined_cache_key,
+                    audio_cache_key=contextualized_audio_cache_key,
+                    num_images=len(images),
+                    num_videos=len(videos),
+                    num_audios=num_audios_for_placeholder,
+                    image_grid_thw=_metadata_cache_value(
+                        full_mm_inputs["image"].get("image_grid_thw")
+                    ),
+                    video_grid_thw=_metadata_cache_value(
+                        full_mm_inputs["video"].get("video_grid_thw")
+                    ),
+                    video_second_per_grid=_metadata_cache_value(
+                        full_mm_inputs["video"].get("video_second_per_grid")
+                    ),
+                    audio_target_sr=audio_target_sr,
+                    video_fps=resolved_video_fps,
+                    video_max_frames=resolved_video_max_frames,
+                    video_min_pixels=resolved_video_min_pixels,
+                    video_max_pixels=resolved_video_max_pixels,
+                    video_total_pixels=resolved_video_total_pixels,
+                    use_audio_in_video=(
+                        bool(use_audio_in_video)
+                        if use_audio_in_video is not None
+                        else None
+                    ),
+                    video_seconds_per_chunk=resolved_video_seconds_per_chunk,
+                    video_position_id_per_seconds=(
+                        resolved_video_position_id_per_seconds
+                    ),
+                ),
+            )
 
         encoder_inputs: dict[str, dict[str, Any]] = {}
         image_encoder_inputs = {

--- a/sglang_omni/models/qwen3_omni/request_builders.py
+++ b/sglang_omni/models/qwen3_omni/request_builders.py
@@ -191,7 +191,9 @@ def build_encoder_request(
         )
     cache_key = inputs.get("cache_key")
     model_inputs = {
-        k: v for k, v in inputs.items() if k not in ("cache_key", "_active")
+        k: v
+        for k, v in inputs.items()
+        if k not in ("cache_key", "_active", "_cache_only")
     }
     return EncoderRequestData(
         model_inputs=model_inputs,
@@ -375,6 +377,8 @@ def _has_encoder_model_input(stage_name: str, stage_inputs: Any) -> bool:
         return False
     if stage_inputs.get("_active") is False:
         return False
+    if stage_inputs.get("_cache_only") and stage_inputs.get("cache_key") is not None:
+        return True
     if stage_name == IMAGE_STAGE:
         return (
             stage_inputs.get("pixel_values") is not None

--- a/sglang_omni/models/qwen3_omni/session_media.py
+++ b/sglang_omni/models/qwen3_omni/session_media.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+from threading import RLock
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SessionMediaEntry:
+    """Media references and cache keys retained for one logical session."""
+
+    raw_images: Any = None
+    raw_videos: Any = None
+    raw_audios: Any = None
+    image_cache_key: str | None = None
+    audio_cache_key: str | None = None
+    num_images: int = 0
+    num_videos: int = 0
+    num_audios: int = 0
+    image_grid_thw: Any = None
+    video_grid_thw: Any = None
+    video_second_per_grid: Any = None
+    audio_placeholder_lengths: Any = None
+    audio_target_sr: int = 16000
+    video_fps: float | None = None
+    video_max_frames: int | None = None
+    video_min_pixels: int | None = None
+    video_max_pixels: int | None = None
+    video_total_pixels: int | None = None
+    use_audio_in_video: bool | None = None
+    video_seconds_per_chunk: float | None = None
+    video_position_id_per_seconds: float | None = None
+
+    @property
+    def has_media(self) -> bool:
+        return bool(
+            self.raw_images
+            or self.raw_videos
+            or self.raw_audios
+            or self.image_cache_key
+            or self.audio_cache_key
+        )
+
+
+class SessionMediaRegistry:
+    """Small process-local LRU for session-scoped media reuse.
+
+    The registry keeps references and cache keys only. Heavy encoder artifacts
+    remain owned by StageOutputCache/cache plane entries.
+    """
+
+    def __init__(self, *, max_sessions: int = 1024) -> None:
+        if max_sessions <= 0:
+            raise ValueError("max_sessions must be positive")
+        self.max_sessions = int(max_sessions)
+        self._entries: OrderedDict[str, SessionMediaEntry] = OrderedDict()
+        self._lock = RLock()
+
+    def get(self, session_id: str) -> SessionMediaEntry | None:
+        _validate_session_id(session_id)
+        with self._lock:
+            entry = self._entries.get(session_id)
+            if entry is None:
+                return None
+            self._entries.move_to_end(session_id)
+            return entry
+
+    def put(self, session_id: str, entry: SessionMediaEntry) -> None:
+        _validate_session_id(session_id)
+        if not entry.has_media:
+            return
+        with self._lock:
+            self._entries[session_id] = entry
+            self._entries.move_to_end(session_id)
+            while len(self._entries) > self.max_sessions:
+                self._entries.popitem(last=False)
+
+    def clear(self, session_id: str) -> bool:
+        _validate_session_id(session_id)
+        with self._lock:
+            return self._entries.pop(session_id, None) is not None
+
+    def clear_all(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._entries)
+
+
+def _validate_session_id(session_id: str) -> None:
+    if not isinstance(session_id, str) or not session_id:
+        raise ValueError("session_id must be a non-empty string")

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -5,6 +5,7 @@ Each factory returns either:
 - A callable (compute_fn) for simple stages
 - An OmniScheduler for AR stages
 """
+
 from __future__ import annotations
 
 import logging
@@ -15,6 +16,7 @@ from typing import Any
 import torch
 import torch.nn.functional as F
 
+from sglang_omni.cache import CacheOwner
 from sglang_omni.models.qwen3_omni.bootstrap import create_thinker_scheduler
 from sglang_omni.models.qwen3_omni.components.audio_encoder import Qwen3OmniAudioEncoder
 from sglang_omni.models.qwen3_omni.components.image_encoder import Qwen3OmniImageEncoder
@@ -161,6 +163,16 @@ def store_state(payload: StagePayload, state: Qwen3OmniPipelineState) -> StagePa
     return payload
 
 
+def _payload_session_id(payload: StagePayload) -> str | None:
+    metadata = payload.request.metadata
+    if not isinstance(metadata, dict):
+        return None
+    session_id = metadata.get("session_id")
+    if session_id is None:
+        return None
+    return str(session_id)
+
+
 def _run_single_encoder_payload(
     payload: StagePayload,
     *,
@@ -178,25 +190,74 @@ def _run_single_encoder_payload(
             request_id=payload.request_id,
             stage_name=stage_name,
             cache=cache,
+            session_id=_payload_session_id(payload),
         )
         if result is None:
-            with torch.no_grad():
-                result = model(**request.model_inputs)
-            _store_cached_encoder_output(
+            if not request.model_inputs:
+                raise RuntimeError(
+                    f"{stage_name} cache-only request missed cache for key "
+                    f"{request.cache_key!r}; resend media or disable "
+                    "session media reuse"
+                )
+            result, computed = _compute_uncached_encoder_output(
                 request=request,
                 request_id=payload.request_id,
                 stage_name=stage_name,
+                model=model,
                 cache=cache,
-                result=result,
             )
+            if computed:
+                _store_cached_encoder_output(
+                    request=request,
+                    request_id=payload.request_id,
+                    stage_name=stage_name,
+                    cache=cache,
+                    result=result,
+                    session_id=_payload_session_id(payload),
+                )
     apply_encoder_result(state, stage_name=stage_name, result=result)
     return store_state(payload, state)
+
+
+def _compute_uncached_encoder_output(
+    *,
+    request: Any,
+    request_id: str,
+    stage_name: str,
+    model: Any,
+    cache: StageOutputCache | None,
+) -> tuple[Any, bool]:
+    build_leader = cache is None or request.cache_key is None
+    if cache is not None and request.cache_key is not None:
+        while True:
+            build_leader = cache.start_build(request.cache_key)
+            if build_leader:
+                break
+            result = cache.wait_ready(request.cache_key)
+            if result is not None:
+                _trace_encoder_cache(
+                    stage_name,
+                    "wait_hit",
+                    request_id=request_id,
+                    cache_key=request.cache_key,
+                    input_bytes=_nested_tensor_bytes(request.model_inputs),
+                    output_bytes=_nested_tensor_bytes(result),
+                )
+                return result, False
+    try:
+        with torch.no_grad():
+            return model(**request.model_inputs), True
+    except Exception as exc:
+        if build_leader and cache is not None and request.cache_key is not None:
+            cache.fail_build(request.cache_key, exc)
+        raise
 
 
 def _image_request_is_batchable(request: Any) -> bool:
     if request.skip_result is not None:
         return False
     input_dict = request.model_inputs
+    has_visual_tensor = False
     for key in (
         "pixel_values",
         "image_grid_thw",
@@ -206,7 +267,9 @@ def _image_request_is_batchable(request: Any) -> bool:
         value = input_dict.get(key)
         if value is not None and not isinstance(value, torch.Tensor):
             return False
-    return True
+        if key in ("pixel_values", "pixel_values_videos") and value is not None:
+            has_visual_tensor = True
+    return has_visual_tensor
 
 
 def _split_visual_features(
@@ -318,6 +381,7 @@ def _lookup_cached_encoder_output(
     request_id: str,
     stage_name: str,
     cache: StageOutputCache | None,
+    session_id: str | None = None,
 ) -> Any | None:
     if cache is None or request.cache_key is None:
         return None
@@ -339,6 +403,7 @@ def _lookup_cached_encoder_output(
         input_bytes=_nested_tensor_bytes(request.model_inputs),
         output_bytes=_nested_tensor_bytes(cached),
     )
+    cache.bind_session(session_id)
     return cached
 
 
@@ -349,10 +414,12 @@ def _store_cached_encoder_output(
     stage_name: str,
     cache: StageOutputCache | None,
     result: Any,
+    session_id: str | None = None,
 ) -> None:
     if cache is None or request.cache_key is None:
         return
     cache.put(request.cache_key, result)
+    cache.bind_session(session_id)
     _trace_encoder_cache(
         stage_name,
         "store",
@@ -398,6 +465,7 @@ def _batch_image_encoder_payloads(
             request_id=payload.request_id,
             stage_name=IMAGE_STAGE,
             cache=cache,
+            session_id=_payload_session_id(payload),
         )
         if cached is not None:
             apply_encoder_result(state, stage_name=IMAGE_STAGE, result=cached)
@@ -558,6 +626,7 @@ def _batch_image_encoder_payloads(
             stage_name=IMAGE_STAGE,
             cache=cache,
             result=stage_result,
+            session_id=_payload_session_id(meta["payload"]),
         )
         if request.cache_key is not None:
             computed_by_cache_key[request.cache_key] = stage_result
@@ -640,6 +709,9 @@ def _batch_audio_encoder_payloads(
 ) -> list[StagePayload]:
     results: list[StagePayload | None] = [None] * len(payloads)
     active: list[tuple[int, StagePayload, Any, Any]] = []
+    duplicate_waiters: dict[str, list[tuple[int, StagePayload, Any]]] = {}
+    active_cache_keys: set[str] = set()
+    active_cache_leaders: dict[str, str] = {}
 
     for idx, payload in enumerate(payloads):
         state = load_state(payload)
@@ -658,6 +730,7 @@ def _batch_audio_encoder_payloads(
             request_id=payload.request_id,
             stage_name=AUDIO_STAGE,
             cache=cache,
+            session_id=_payload_session_id(payload),
         )
         if cached is not None:
             apply_encoder_result(state, stage_name=AUDIO_STAGE, result=cached)
@@ -673,7 +746,23 @@ def _batch_audio_encoder_payloads(
             )
             continue
 
+        cache_key = request.cache_key
+        if cache_key is not None and cache_key in active_cache_keys:
+            duplicate_waiters.setdefault(cache_key, []).append((idx, payload, state))
+            _trace_encoder_cache(
+                AUDIO_STAGE,
+                "dedup_same_batch",
+                request_id=payload.request_id,
+                cache_key=cache_key,
+                input_bytes=_nested_tensor_bytes(request.model_inputs),
+                detail=f"leader={active_cache_leaders[cache_key]}",
+            )
+            continue
+
         active.append((idx, payload, state, request))
+        if cache_key is not None:
+            active_cache_keys.add(cache_key)
+            active_cache_leaders[cache_key] = payload.request_id
 
     if not active:
         return [result for result in results if result is not None]
@@ -715,6 +804,7 @@ def _batch_audio_encoder_payloads(
     embeds = combined["audio_embeds"]
     row_cursor = 0
     token_cursor = 0
+    computed_by_cache_key: dict[str, dict[str, Any]] = {}
     for item in normalized:
         row_end = row_cursor + item["count"]
         req_output_lengths = output_lengths[row_cursor:row_end]
@@ -732,11 +822,22 @@ def _batch_audio_encoder_payloads(
             stage_name=AUDIO_STAGE,
             cache=cache,
             result=stage_result,
+            session_id=_payload_session_id(item["payload"]),
         )
+        if item["request"].cache_key is not None:
+            computed_by_cache_key[item["request"].cache_key] = stage_result
         apply_encoder_result(item["state"], stage_name=AUDIO_STAGE, result=stage_result)
         results[item["idx"]] = store_state(item["payload"], item["state"])
         row_cursor = row_end
         token_cursor = token_end
+
+    for cache_key, waiters in duplicate_waiters.items():
+        stage_result = computed_by_cache_key.get(cache_key)
+        if stage_result is None:
+            continue
+        for idx, payload, state in waiters:
+            apply_encoder_result(state, stage_name=AUDIO_STAGE, result=stage_result)
+            results[idx] = store_state(payload, state)
 
     return [result for result in results if result is not None]
 
@@ -796,6 +897,9 @@ def create_image_encoder_executor(
         max_size=QWEN3_ENCODER_CACHE_MAX_ENTRIES,
         max_bytes=QWEN3_ENCODER_CACHE_MAX_BYTES,
         cache_device="cpu",
+        cache_namespace="qwen3_omni",
+        cache_kind="image_encoder_output",
+        cache_owner=CacheOwner(stage_name=IMAGE_STAGE, device=device),
     )
 
     def _encode(payload: StagePayload) -> StagePayload:
@@ -868,6 +972,9 @@ def create_audio_encoder_executor(
         max_size=QWEN3_ENCODER_CACHE_MAX_ENTRIES,
         max_bytes=QWEN3_ENCODER_CACHE_MAX_BYTES,
         cache_device="cpu",
+        cache_namespace="qwen3_omni",
+        cache_kind="audio_encoder_output",
+        cache_owner=CacheOwner(stage_name=AUDIO_STAGE, device=device),
     )
 
     def _encode(payload: StagePayload) -> StagePayload:

--- a/sglang_omni/scheduling/speaker_cache.py
+++ b/sglang_omni/scheduling/speaker_cache.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import numpy as np
 
+from sglang_omni.cache import CacheOwner, LocalCachePlane
 from sglang_omni.scheduling.stage_cache import StageOutputCache
 
 DEFAULT_SPEAKER_CACHE_BYTES = 512 * 1024 * 1024
@@ -29,13 +30,21 @@ class SpeakerCacheKey:
 class SpeakerArtifactCache:
     """Process-wide bounded LRU for voice features shared by TTS stages."""
 
-    def __init__(self, max_bytes: int = DEFAULT_SPEAKER_CACHE_BYTES) -> None:
+    def __init__(
+        self,
+        max_bytes: int = DEFAULT_SPEAKER_CACHE_BYTES,
+        cache_plane: LocalCachePlane | None = None,
+    ) -> None:
         if max_bytes <= 0:
             raise ValueError("speaker cache max_bytes must be positive")
         self.max_bytes = int(max_bytes)
         self._cache = StageOutputCache(
             max_bytes=self.max_bytes,
             size_fn=estimate_cache_bytes,
+            cache_plane=cache_plane,
+            cache_namespace="speaker_artifacts",
+            cache_kind="speaker_artifact",
+            cache_owner=CacheOwner(stage_name="speaker_artifacts"),
         )
         self._hit_count = 0
         self._miss_count = 0

--- a/sglang_omni/scheduling/stage_cache.py
+++ b/sglang_omni/scheduling/stage_cache.py
@@ -8,6 +8,15 @@ from typing import Any
 
 import torch
 
+from sglang_omni.cache import (
+    ArtifactHandle,
+    CacheKey,
+    CacheOwner,
+    CacheSelector,
+    LocalCachePlane,
+    get_global_cache_plane,
+)
+
 
 @dataclass
 class _CacheEntry:
@@ -47,7 +56,16 @@ class StageOutputCache:
         max_bytes: int | None = None,
         cache_device: torch.device | str | None = None,
         size_fn: Callable[[Any], int] | None = None,
+        cache_plane: LocalCachePlane | None = None,
+        cache_namespace: str | None = None,
+        cache_kind: str = "stage_output",
+        cache_owner: CacheOwner | None = None,
+        cache_ttl_s: float | None = None,
     ) -> None:
+        if max_size is not None and max_size <= 0:
+            raise ValueError("max_size must be positive when set")
+        if max_bytes is not None and max_bytes <= 0:
+            raise ValueError("max_bytes must be positive when set")
         if isinstance(cache_device, str):
             cache_device = torch.device(cache_device)
         self._cache: OrderedDict[str, _CacheEntry] = OrderedDict()
@@ -57,6 +75,15 @@ class StageOutputCache:
         self.current_bytes = 0
         self.eviction_count = 0
         self._size_fn = size_fn or _value_size_bytes
+        self._cache_namespace = cache_namespace
+        self._cache_kind = cache_kind
+        self._cache_owner = cache_owner or CacheOwner()
+        self._cache_ttl_s = cache_ttl_s
+        self._cache_plane = (
+            cache_plane
+            if cache_plane is not None
+            else (get_global_cache_plane() if cache_namespace is not None else None)
+        )
 
     def get(self, key: str | None) -> Any | None:
         if key is None:
@@ -64,8 +91,10 @@ class StageOutputCache:
         key = str(key)
         entry = self._cache.get(key)
         if entry is None:
+            self._record_plane_miss(key)
             return None
         self._cache.move_to_end(key)
+        self._touch_plane(key)
         return entry.data
 
     def put(self, key: str | None, data: Any) -> None:
@@ -76,6 +105,7 @@ class StageOutputCache:
         old_entry = self._cache.pop(key, None)
         if old_entry is not None:
             self.current_bytes -= old_entry.size_bytes
+            self._remove_plane_entry(key)
         if self.max_bytes is not None and size_bytes > self.max_bytes:
             return
         self._cache[key] = _CacheEntry(
@@ -84,9 +114,12 @@ class StageOutputCache:
         )
         self.current_bytes += size_bytes
         self._cache.move_to_end(key)
+        self._publish_plane_entry(key, size_bytes)
         self._evict_over_budget()
 
     def clear(self) -> None:
+        for key in list(self._cache):
+            self._remove_plane_entry(key)
         self._cache.clear()
         self.current_bytes = 0
 
@@ -97,21 +130,115 @@ class StageOutputCache:
                 continue
             entry = self._cache.pop(key)
             self.current_bytes -= entry.size_bytes
+            self._remove_plane_entry(key)
             removed += 1
         return removed
+
+    def bind_session(self, session_id: str | None) -> None:
+        if self._cache_plane is None or not session_id:
+            return
+        self._cache_plane.bind_session(str(session_id), self._cache_owner)
+
+    def start_build(self, key: str | None) -> bool:
+        plane_key = self._plane_key_or_none(key)
+        if plane_key is None:
+            return True
+        return self._cache_plane.start_build(
+            plane_key,
+            owner=self._cache_owner,
+            ttl_s=self._cache_ttl_s,
+        )
+
+    def wait_ready(self, key: str | None, timeout_s: float | None = None) -> Any | None:
+        plane_key = self._plane_key_or_none(key)
+        if plane_key is None:
+            return None
+        ready = self._cache_plane.wait_ready(plane_key, timeout_s=timeout_s)
+        if ready is None:
+            return None
+        cached = self.get(str(key))
+        if cached is None:
+            self._cache_plane.remove(plane_key)
+        return cached
+
+    def fail_build(self, key: str | None, error: BaseException | str) -> None:
+        plane_key = self._plane_key_or_none(key)
+        if plane_key is None:
+            return
+        self._cache_plane.fail_build(plane_key, error)
 
     def __len__(self) -> int:
         return len(self._cache)
 
     def _evict_over_budget(self) -> None:
         while self.max_size is not None and len(self._cache) > self.max_size:
-            _, entry = self._cache.popitem(last=False)
+            key, entry = self._cache.popitem(last=False)
             self.current_bytes -= entry.size_bytes
+            self._remove_plane_entry(key)
             self.eviction_count += 1
         while self.max_bytes is not None and self.current_bytes > self.max_bytes:
             if not self._cache:
                 self.current_bytes = 0
                 return
-            _, entry = self._cache.popitem(last=False)
+            key, entry = self._cache.popitem(last=False)
             self.current_bytes -= entry.size_bytes
+            self._remove_plane_entry(key)
             self.eviction_count += 1
+
+    def _plane_key(self, key: str) -> CacheKey | None:
+        if self._cache_plane is None or self._cache_namespace is None:
+            return None
+        return CacheKey(
+            namespace=self._cache_namespace,
+            kind=self._cache_kind,
+            digest=str(key),
+            stage_name=self._cache_owner.stage_name,
+        )
+
+    def _plane_key_or_none(self, key: str | None) -> CacheKey | None:
+        if key is None:
+            return None
+        return self._plane_key(str(key))
+
+    def _publish_plane_entry(self, key: str, size_bytes: int) -> None:
+        plane_key = self._plane_key(key)
+        if plane_key is None:
+            return
+        device = str(self.cache_device) if self.cache_device is not None else None
+        self._cache_plane.publish(
+            plane_key,
+            ArtifactHandle(backend="stage_output", ref={"key": key}),
+            owner=self._cache_owner,
+            size_bytes=size_bytes,
+            device=device,
+            ttl_s=self._cache_ttl_s,
+        )
+
+    def _remove_plane_entry(self, key: str) -> None:
+        plane_key = self._plane_key(key)
+        if plane_key is None:
+            return
+        self._cache_plane.remove(plane_key)
+
+    def _touch_plane(self, key: str) -> None:
+        plane_key = self._plane_key(key)
+        if plane_key is None:
+            return
+        self._cache_plane.lookup(plane_key)
+
+    def _record_plane_miss(self, key: str) -> None:
+        plane_key = self._plane_key(key)
+        if plane_key is None:
+            return
+        self._cache_plane.record_miss(plane_key)
+
+    def invalidate_plane_entries(self) -> int:
+        if self._cache_plane is None or self._cache_namespace is None:
+            return 0
+        return self._cache_plane.invalidate(
+            CacheSelector(
+                namespace=self._cache_namespace,
+                kind=self._cache_kind,
+                stage_name=self._cache_owner.stage_name,
+            )
+        )

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -886,8 +886,8 @@ def _build_chat_generate_request(req: ChatCompletionRequest) -> GenerateRequest:
     if req.videos:
         videos = req.videos
 
-    # Merge audio config, audios, images, and videos into metadata
-    metadata: dict[str, Any] = {}
+    # Merge request metadata, audio config, audios, images, and videos into metadata
+    metadata: dict[str, Any] = dict(req.metadata) if req.metadata else {}
     if req.audio:
         metadata["audio_config"] = req.audio
     if audios:

--- a/sglang_omni/serve/protocol.py
+++ b/sglang_omni/serve/protocol.py
@@ -94,6 +94,7 @@ class ChatCompletionRequest(BaseModel):
     # Misc
     request_id: str | None = None
     user: str | None = None
+    metadata: dict[str, Any] | None = None
 
     @property
     def effective_max_tokens(self) -> int | None:

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,6 +19,8 @@ tests/
     │   ├── fish_fakes.py
     │   ├── pipeline_fakes.py
     │   └── qwen_fakes.py
+    ├── cache/
+    │   └── test_cache_plane.py
     ├── pipeline/
     │   ├── helpers.py
     │   ├── test_compile.py

--- a/tests/unit_test/cache/__init__.py
+++ b/tests/unit_test/cache/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/unit_test/cache/test_cache_plane.py
+++ b/tests/unit_test/cache/test_cache_plane.py
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sglang_omni.cache import (
+    ArtifactHandle,
+    CacheKey,
+    CacheOwner,
+    CacheSelector,
+    LocalCachePlane,
+)
+from sglang_omni.scheduling.stage_cache import StageOutputCache
+
+
+def _key(digest: str, *, kind: str = "encoder_output") -> CacheKey:
+    return CacheKey(namespace="qwen3_omni", kind=kind, digest=digest)
+
+
+def _session_key(digest: str, session_id: str) -> CacheKey:
+    return CacheKey(
+        namespace="qwen3_omni",
+        kind="encoder_output",
+        digest=digest,
+        session_id=session_id,
+    )
+
+
+def test_local_cache_plane_tracks_owner_pin_and_eviction() -> None:
+    plane = LocalCachePlane(max_entries=2)
+    owner = CacheOwner(stage_name="image_encoder", gpu_id=0, device="cuda:0")
+
+    plane.publish(
+        _key("a"),
+        ArtifactHandle(backend="stage_output", ref={"key": "a"}),
+        owner=owner,
+        size_bytes=16,
+    )
+    plane.publish(
+        _key("b"),
+        ArtifactHandle(backend="stage_output", ref={"key": "b"}),
+        owner=owner,
+        size_bytes=16,
+    )
+
+    assert plane.lookup(_key("a")) is not None
+    lease = plane.pin(_key("a"), request_id="req-1")
+    assert lease is not None
+
+    plane.publish(
+        _key("c"),
+        ArtifactHandle(backend="stage_output", ref={"key": "c"}),
+        owner=owner,
+        size_bytes=16,
+    )
+
+    assert plane.lookup(_key("a")) is not None
+    assert plane.lookup(_key("b")) is None
+    assert plane.lookup(_key("c")) is not None
+    assert plane.stats().eviction_count == 1
+    assert plane.stats().pinned_entries == 1
+
+    plane.release(lease)
+    evicted = plane.evict(max_entries=1)
+
+    assert len(evicted) == 1
+    assert plane.stats().entries == 1
+    assert plane.stats().pinned_entries == 0
+
+
+def test_local_cache_plane_ranks_owners_for_session_locality() -> None:
+    plane = LocalCachePlane()
+    owner_a = CacheOwner(
+        stage_name="image_encoder",
+        worker_id="worker-a",
+        gpu_id=0,
+        device="cuda:0",
+    )
+    owner_b = CacheOwner(
+        stage_name="audio_encoder",
+        worker_id="worker-b",
+        gpu_id=1,
+        device="cuda:1",
+    )
+
+    plane.publish(
+        _session_key("image-a", "session-a"),
+        ArtifactHandle(backend="stage_output", ref={"key": "image-a"}),
+        owner=owner_a,
+        size_bytes=32,
+    )
+    plane.publish(
+        _session_key("audio-a", "session-a"),
+        ArtifactHandle(backend="stage_output", ref={"key": "audio-a"}),
+        owner=owner_a,
+        size_bytes=16,
+    )
+    plane.publish(
+        _session_key("image-b", "session-b"),
+        ArtifactHandle(backend="stage_output", ref={"key": "image-b"}),
+        owner=owner_b,
+        size_bytes=128,
+    )
+    plane.bind_session("session-a", owner_a)
+
+    ranked = plane.rank_owners(
+        CacheSelector(namespace="qwen3_omni"),
+        session_id="session-a",
+    )
+
+    assert ranked[0].owner == owner_a
+    assert ranked[0].bound_session
+    assert ranked[0].entry_count == 2
+    assert ranked[0].session_entry_count == 2
+    assert ranked[0].total_bytes == 48
+    assert plane.session_owner("session-a") == owner_a
+    assert plane.stats().session_bindings == 2
+
+    assert plane.unbind_session("session-a")
+    assert plane.session_owner("session-a") is None
+    assert plane.rank_owners(session_id="session-a")[0].owner == owner_a
+
+
+def test_local_cache_plane_singleflight_failure_does_not_poison_key() -> None:
+    plane = LocalCachePlane()
+    key = _key("build-me")
+
+    assert plane.start_build(key, owner=CacheOwner(stage_name="audio_encoder"))
+    assert not plane.start_build(key, owner=CacheOwner(stage_name="audio_encoder"))
+
+    plane.fail_build(key, RuntimeError("boom"))
+
+    assert plane.wait_ready(key, timeout_s=0.01) is None
+    assert plane.start_build(key, owner=CacheOwner(stage_name="audio_encoder"))
+
+    plane.publish(
+        key,
+        ArtifactHandle(backend="stage_output", ref={"key": "build-me"}),
+        owner=CacheOwner(stage_name="audio_encoder"),
+        size_bytes=8,
+    )
+
+    assert plane.wait_ready(key, timeout_s=0.01) is not None
+
+
+def test_local_cache_plane_peek_does_not_count_hit_or_miss() -> None:
+    plane = LocalCachePlane()
+    key = _key("peek-me")
+    plane.publish(key, ArtifactHandle(backend="stage_output", ref={"key": "peek-me"}))
+
+    assert plane.peek(key) is not None
+    assert plane.peek(_key("missing")) is None
+
+    stats = plane.stats()
+    assert stats.hit_count == 0
+    assert stats.miss_count == 0
+
+
+def test_stage_output_cache_registers_and_removes_plane_entries() -> None:
+    plane = LocalCachePlane()
+    owner = CacheOwner(stage_name="image_encoder", device="cuda")
+    cache = StageOutputCache(
+        max_size=1,
+        cache_plane=plane,
+        cache_namespace="qwen3_omni",
+        cache_kind="image_encoder_output",
+        cache_owner=owner,
+        cache_device="cpu",
+    )
+
+    cache.put("image-a", {"x": torch.ones(2, dtype=torch.float32)})
+    key_a = CacheKey(
+        namespace="qwen3_omni",
+        kind="image_encoder_output",
+        digest="image-a",
+        stage_name="image_encoder",
+    )
+    entry_a = plane.lookup(key_a)
+
+    assert entry_a is not None
+    assert entry_a.meta.owner.stage_name == "image_encoder"
+    assert entry_a.meta.device == "cpu"
+    assert entry_a.meta.size_bytes == 8
+    assert cache.get("image-a") is not None
+    assert plane.stats().hit_count == 2
+
+    cache.put("image-b", torch.ones(1, dtype=torch.float32))
+    key_b = CacheKey(
+        namespace="qwen3_omni",
+        kind="image_encoder_output",
+        digest="image-b",
+        stage_name="image_encoder",
+    )
+
+    assert cache.get("image-a") is None
+    assert plane.lookup(key_a) is None
+    assert plane.lookup(key_b) is not None
+
+    cache.clear()
+
+    assert plane.lookup(key_b) is None
+
+
+def test_stage_output_cache_singleflight_waits_for_ready_entry() -> None:
+    plane = LocalCachePlane()
+    cache = StageOutputCache(
+        cache_plane=plane,
+        cache_namespace="qwen3_omni",
+        cache_kind="image_encoder_output",
+        cache_owner=CacheOwner(stage_name="image_encoder"),
+    )
+    results: list[object | None] = []
+
+    assert cache.start_build("image-a")
+
+    import threading
+
+    waiter = threading.Thread(
+        target=lambda: results.append(cache.wait_ready("image-a", timeout_s=1.0))
+    )
+    waiter.start()
+    cache.put("image-a", {"x": torch.ones(1)})
+    waiter.join(timeout=1.0)
+
+    assert not waiter.is_alive()
+    assert len(results) == 1
+    assert results[0] is not None
+    assert plane.stats().ready_entries == 1
+
+
+def test_stage_output_cache_singleflight_failure_allows_retry() -> None:
+    plane = LocalCachePlane()
+    cache = StageOutputCache(
+        cache_plane=plane,
+        cache_namespace="qwen3_omni",
+        cache_kind="audio_encoder_output",
+        cache_owner=CacheOwner(stage_name="audio_encoder"),
+    )
+
+    assert cache.start_build("audio-a")
+    cache.fail_build("audio-a", RuntimeError("boom"))
+
+    assert cache.wait_ready("audio-a", timeout_s=0.01) is None
+    assert cache.start_build("audio-a")
+
+
+def test_stage_output_cache_rejects_invalid_budgets() -> None:
+    with pytest.raises(ValueError, match="max_size"):
+        StageOutputCache(max_size=0)
+    with pytest.raises(ValueError, match="max_bytes"):
+        StageOutputCache(max_bytes=0)
+
+
+def test_cache_selector_invalidates_matching_namespace() -> None:
+    plane = LocalCachePlane()
+    plane.publish(
+        _key("a", kind="image"),
+        ArtifactHandle(backend="stage_output", ref={"key": "a"}),
+    )
+    plane.publish(
+        _key("b", kind="audio"),
+        ArtifactHandle(backend="stage_output", ref={"key": "b"}),
+    )
+
+    removed = plane.invalidate(CacheSelector(namespace="qwen3_omni", kind="image"))
+
+    assert removed == 1
+    assert plane.lookup(_key("a", kind="image")) is None
+    assert plane.lookup(_key("b", kind="audio")) is not None

--- a/tests/unit_test/qwen3_omni/test_pipeline.py
+++ b/tests/unit_test/qwen3_omni/test_pipeline.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -10,6 +12,13 @@ import torch
 import typer
 
 import sglang_omni.models.qwen3_omni.stages as qwen_stages
+from sglang_omni.cache import (
+    ArtifactHandle,
+    CacheKey,
+    CacheOwner,
+    LocalCachePlane,
+    get_global_cache_plane,
+)
 from sglang_omni.cli.serve import (
     apply_encoder_mem_reserve_cli_override,
     apply_mem_fraction_cli_overrides,
@@ -36,6 +45,7 @@ from sglang_omni.models.qwen3_omni.merge import decode_events, merge_for_thinker
 from sglang_omni.models.qwen3_omni.payload_types import Qwen3OmniPipelineState
 from sglang_omni.models.qwen3_omni.request_builders import (
     apply_thinker_result,
+    build_encoder_request,
     build_sglang_thinker_request,
     project_preprocessing_to_mm_aggregate,
     project_talker_to_code2wav,
@@ -43,14 +53,20 @@ from sglang_omni.models.qwen3_omni.request_builders import (
     resolve_mm_aggregate_wait_sources,
     resolve_preprocessing_next_stages,
 )
+from sglang_omni.models.qwen3_omni.session_media import (
+    SessionMediaEntry,
+    SessionMediaRegistry,
+)
 from sglang_omni.pipeline.tensor_ref import TensorRef, is_tensor_ref_dict
 from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.scheduling.sglang_backend.server_args_builder import (
     apply_encoder_mem_reserve,
     build_sglang_server_args,
 )
+from sglang_omni.scheduling.stage_cache import StageOutputCache
 from sglang_omni.utils.imports import import_string
 from tests.unit_test.fixtures.qwen_fakes import (
+    FakeAudioEncoderModel,
     FakeQwenTokenizer,
     make_qwen_payload,
     make_qwen_state,
@@ -67,6 +83,112 @@ def _server_args_overrides(config: PipelineConfig, name: str) -> dict[str, objec
 
 def _runtime_mem_fraction_static(config, name: str) -> float | None:
     return _stage(config, name).runtime.sglang_server_args.mem_fraction_static
+
+
+class _FakeCachedMediaProcessor:
+    def __init__(self) -> None:
+        self.template_messages = None
+        self.called_multimodal_processor = False
+
+    def apply_chat_template(self, messages, **kwargs):
+        del kwargs
+        self.template_messages = messages
+        return "<image> describe"
+
+    def replace_multimodal_special_tokens(
+        self,
+        text,
+        audio_lengths,
+        image_grid_thw,
+        video_grid_thw,
+        video_second_per_grid,
+        use_audio_in_video,
+        position_id_per_seconds,
+        seconds_per_chunk,
+    ):
+        del (
+            audio_lengths,
+            video_grid_thw,
+            video_second_per_grid,
+            use_audio_in_video,
+            position_id_per_seconds,
+            seconds_per_chunk,
+        )
+        processed = []
+        for sample in text:
+            for grid in image_grid_thw:
+                sample = sample.replace(
+                    "<image>",
+                    "<image>" * int(grid.to(dtype=torch.long).prod().item()),
+                    1,
+                )
+            processed.append(sample)
+        return processed
+
+    def __call__(self, *args, **kwargs):
+        del args, kwargs
+        self.called_multimodal_processor = True
+        raise AssertionError("cached session media fast path should not decode media")
+
+
+class _FakeCachedMediaTokenizer:
+    def __call__(self, text, **kwargs):
+        del kwargs
+        token_count = max(1, text.count("<image>") + 1)
+        return {
+            "input_ids": torch.arange(token_count, dtype=torch.long).unsqueeze(0),
+            "attention_mask": torch.ones((1, token_count), dtype=torch.long),
+        }
+
+
+class _FakeMetadataMediaProcessor:
+    def __init__(self) -> None:
+        self.images = None
+
+    def apply_chat_template(self, messages, **kwargs):
+        del messages, kwargs
+        return "<image> describe"
+
+    def __call__(self, *, text, images, videos, audio, **kwargs):
+        del text, videos, audio, kwargs
+        self.images = images
+        return {
+            "input_ids": torch.tensor([[101, 102]], dtype=torch.long),
+            "attention_mask": torch.tensor([[1, 1]], dtype=torch.long),
+            "pixel_values": torch.ones((1, 3), dtype=torch.float32),
+            "image_grid_thw": torch.tensor([[1, 1, 1]], dtype=torch.long),
+        }
+
+
+def _fake_qwen_preprocessor_for_cached_media():
+    from sglang_omni.models.qwen3_omni.components.preprocessor import (
+        Qwen3OmniPreprocessor,
+    )
+
+    pre = object.__new__(Qwen3OmniPreprocessor)
+    pre.max_seq_len = None
+    pre.processor = _FakeCachedMediaProcessor()
+    pre.tokenizer = _FakeCachedMediaTokenizer()
+    pre.session_media = SessionMediaRegistry()
+    return pre
+
+
+def _fake_qwen_preprocessor_for_metadata_media():
+    from sglang_omni.models.qwen3_omni.components.preprocessor import (
+        Qwen3OmniPreprocessor,
+    )
+
+    pre = object.__new__(Qwen3OmniPreprocessor)
+    pre.max_seq_len = None
+    pre.default_video_fps = None
+    pre.default_video_max_frames = None
+    pre.default_video_min_pixels = None
+    pre.default_video_max_pixels = None
+    pre.default_video_total_pixels = None
+    pre.processor = _FakeMetadataMediaProcessor()
+    pre.tokenizer = _FakeCachedMediaTokenizer()
+    pre.session_media = SessionMediaRegistry()
+    return pre
 
 
 def test_qwen_pipeline_config_and_state_contracts() -> None:
@@ -279,6 +401,331 @@ def test_qwen_preprocess_pretokenized_builds_thinker_state_from_ids() -> None:
     assert state.prompt["attention_mask"].tolist() == [1, 1, 1]
     assert state.encoder_inputs["image_encoder"]["_skip"] is True
     assert state.encoder_inputs["audio_encoder"]["_skip"] is True
+
+
+def test_qwen_preprocessor_reuses_ready_session_media_without_decoding() -> None:
+    pre = _fake_qwen_preprocessor_for_cached_media()
+    cache_key = "image:session-media"
+    pre.session_media.put(
+        "session-1",
+        SessionMediaEntry(
+            raw_images=["tests/data/cars.jpg"],
+            image_cache_key=cache_key,
+            num_images=1,
+            image_grid_thw=torch.tensor([[1, 1, 2]], dtype=torch.long),
+        ),
+    )
+    get_global_cache_plane().publish(
+        CacheKey(
+            namespace="qwen3_omni",
+            kind="image_encoder_output",
+            digest=cache_key,
+            stage_name="image_encoder",
+        ),
+        ArtifactHandle(backend="stage_output", ref={"key": cache_key}),
+        owner=CacheOwner(stage_name="image_encoder", device="cuda:0"),
+        size_bytes=128,
+    )
+    payload = StagePayload(
+        request_id="req-session-media",
+        request=OmniRequest(
+            inputs={
+                "messages": [{"role": "user", "content": "What is in the picture?"}],
+            },
+            metadata={"session_id": "session-1", "reuse_session_media": True},
+        ),
+        data=None,
+    )
+
+    result = asyncio.run(pre._call_impl(payload))
+    state = Qwen3OmniPipelineState.from_dict(result.data)
+    image_inputs = state.encoder_inputs["image_encoder"]
+
+    assert pre.processor.called_multimodal_processor is False
+    assert image_inputs == {
+        "cache_key": cache_key,
+        "_active": True,
+        "_cache_only": True,
+    }
+    assert state.encoder_inputs["audio_encoder"]["_skip"] is True
+    assert state.prompt["input_ids"].numel() == 3
+    assert resolve_preprocessing_next_stages("req-session-media", result) == [
+        "image_encoder",
+        "mm_aggregate",
+    ]
+    encoder_request = build_encoder_request(state, stage_name="image_encoder")
+    assert encoder_request.cache_key == cache_key
+    assert encoder_request.model_inputs == {}
+
+
+def test_qwen_preprocessor_session_media_reuse_requires_ready_cache_or_raw_refs() -> (
+    None
+):
+    pre = _fake_qwen_preprocessor_for_cached_media()
+    pre.session_media.put(
+        "session-1",
+        SessionMediaEntry(image_cache_key="image:evicted", num_images=1),
+    )
+    payload = StagePayload(
+        request_id="req-session-media-miss",
+        request=OmniRequest(
+            inputs={
+                "messages": [{"role": "user", "content": "What is in the picture?"}],
+            },
+            metadata={"session_id": "session-1", "reuse_session_media": True},
+        ),
+        data=None,
+    )
+
+    with pytest.raises(RuntimeError, match="resend media"):
+        asyncio.run(pre._call_impl(payload))
+
+
+def test_qwen_preprocessor_reads_openai_metadata_media_for_message_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.qwen3_omni.components import preprocessor as pre_mod
+
+    async def fake_images(raw_images):
+        assert raw_images == ["tests/data/cars.jpg"]
+        return ["decoded-image"]
+
+    async def fake_videos(raw_videos, **kwargs):
+        del raw_videos, kwargs
+        return [], None, None
+
+    async def fake_audios(raw_audios, **kwargs):
+        del raw_audios, kwargs
+        return []
+
+    monkeypatch.setattr(pre_mod, "ensure_image_list_async", fake_images)
+    monkeypatch.setattr(pre_mod, "ensure_video_list_async", fake_videos)
+    monkeypatch.setattr(pre_mod, "ensure_audio_list_async", fake_audios)
+
+    pre = _fake_qwen_preprocessor_for_metadata_media()
+    payload = StagePayload(
+        request_id="req-openai-media",
+        request=OmniRequest(
+            inputs=[{"role": "user", "content": "What is in the image?"}],
+            metadata={
+                "session_id": "session-openai",
+                "images": ["tests/data/cars.jpg"],
+            },
+        ),
+        data=None,
+    )
+
+    result = asyncio.run(pre._call_impl(payload))
+    state = Qwen3OmniPipelineState.from_dict(result.data)
+    image_inputs = state.encoder_inputs["image_encoder"]
+    session_entry = pre.session_media.get("session-openai")
+
+    assert pre.processor.images == ["decoded-image"]
+    assert torch.equal(image_inputs["pixel_values"], torch.ones((1, 3)))
+    assert image_inputs["cache_key"].startswith("image:")
+    assert session_entry is not None
+    assert session_entry.raw_images == ["tests/data/cars.jpg"]
+    assert session_entry.num_images == 1
+
+
+def test_qwen_preprocessor_openai_session_reuse_falls_back_to_raw_refs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.qwen3_omni.components import preprocessor as pre_mod
+
+    async def fake_images(raw_images):
+        assert raw_images == ["tests/data/cars.jpg"]
+        return ["decoded-image"]
+
+    async def fake_videos(raw_videos, **kwargs):
+        del raw_videos, kwargs
+        return [], None, None
+
+    async def fake_audios(raw_audios, **kwargs):
+        del raw_audios, kwargs
+        return []
+
+    monkeypatch.setattr(pre_mod, "ensure_image_list_async", fake_images)
+    monkeypatch.setattr(pre_mod, "ensure_video_list_async", fake_videos)
+    monkeypatch.setattr(pre_mod, "ensure_audio_list_async", fake_audios)
+
+    pre = _fake_qwen_preprocessor_for_metadata_media()
+    pre.session_media.put(
+        "session-openai",
+        SessionMediaEntry(
+            raw_images=["tests/data/cars.jpg"],
+            image_cache_key="image:previous",
+            num_images=1,
+        ),
+    )
+    payload = StagePayload(
+        request_id="req-openai-reuse",
+        request=OmniRequest(
+            inputs=[{"role": "user", "content": "Answer again."}],
+            metadata={
+                "session_id": "session-openai",
+                "reuse_session_media": True,
+            },
+        ),
+        data=None,
+    )
+
+    result = asyncio.run(pre._call_impl(payload))
+    state = Qwen3OmniPipelineState.from_dict(result.data)
+    image_inputs = state.encoder_inputs["image_encoder"]
+
+    assert pre.processor.images == ["decoded-image"]
+    assert torch.equal(image_inputs["pixel_values"], torch.ones((1, 3)))
+    assert image_inputs["cache_key"].startswith("image:")
+
+
+def _encoder_payload(
+    *,
+    stage_name: str,
+    request_id: str,
+    cache_key: str,
+    inputs: dict[str, object],
+) -> StagePayload:
+    return make_qwen_payload(
+        make_qwen_state(
+            encoder_inputs={
+                stage_name: {
+                    "cache_key": cache_key,
+                    **inputs,
+                }
+            }
+        ),
+        request_id=request_id,
+    )
+
+
+def test_qwen_single_encoder_payload_singleflights_concurrent_cache_miss() -> None:
+    entered = threading.Event()
+    release = threading.Event()
+
+    class BlockingAudioModel:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def __call__(self, **kwargs):
+            del kwargs
+            self.calls += 1
+            entered.set()
+            assert release.wait(timeout=1.0)
+            return {
+                "audio_embeds": torch.ones((2, 2), dtype=torch.float32),
+                "audio_feature_lengths": torch.tensor([2], dtype=torch.long),
+                "audio_output_lengths": torch.tensor([2], dtype=torch.long),
+            }
+
+    cache = StageOutputCache(
+        cache_plane=LocalCachePlane(),
+        cache_namespace="qwen3_omni",
+        cache_kind="audio_encoder_output",
+        cache_owner=CacheOwner(stage_name="audio_encoder"),
+    )
+    model = BlockingAudioModel()
+    payloads = [
+        _encoder_payload(
+            stage_name="audio_encoder",
+            request_id="req-a",
+            cache_key="audio:shared",
+            inputs={
+                "input_features": torch.ones((1, 2, 3), dtype=torch.float32),
+                "audio_feature_lengths": torch.tensor([2], dtype=torch.long),
+            },
+        ),
+        _encoder_payload(
+            stage_name="audio_encoder",
+            request_id="req-b",
+            cache_key="audio:shared",
+            inputs={
+                "input_features": torch.ones((1, 2, 3), dtype=torch.float32),
+                "audio_feature_lengths": torch.tensor([2], dtype=torch.long),
+            },
+        ),
+    ]
+    results: list[StagePayload] = []
+    errors: list[BaseException] = []
+
+    def run(payload: StagePayload) -> None:
+        try:
+            results.append(
+                qwen_stages._run_single_encoder_payload(
+                    payload,
+                    stage_name="audio_encoder",
+                    model=model,
+                    cache=cache,
+                )
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    leader = threading.Thread(target=run, args=(payloads[0],))
+    follower = threading.Thread(target=run, args=(payloads[1],))
+    leader.start()
+    assert entered.wait(timeout=1.0)
+    follower.start()
+    release.set()
+    leader.join(timeout=1.0)
+    follower.join(timeout=1.0)
+
+    assert not leader.is_alive()
+    assert not follower.is_alive()
+    assert errors == []
+    assert len(results) == 2
+    assert model.calls == 1
+    for result in results:
+        state = Qwen3OmniPipelineState.from_dict(result.data)
+        assert torch.equal(
+            state.encoder_outs["audio_encoder"]["audio_embeds"],
+            torch.ones((2, 2), dtype=torch.float32),
+        )
+
+
+def test_qwen_audio_encoder_batch_dedups_duplicate_cache_keys() -> None:
+    model = FakeAudioEncoderModel()
+    cache = StageOutputCache(cache_device="cpu")
+    payloads = [
+        _encoder_payload(
+            stage_name="audio_encoder",
+            request_id="req-a",
+            cache_key="audio:duplicate",
+            inputs={
+                "input_features": torch.ones((1, 2, 3), dtype=torch.float32),
+                "audio_feature_lengths": torch.tensor([2], dtype=torch.long),
+            },
+        ),
+        _encoder_payload(
+            stage_name="audio_encoder",
+            request_id="req-b",
+            cache_key="audio:duplicate",
+            inputs={
+                "input_features": torch.ones((1, 2, 3), dtype=torch.float32),
+                "audio_feature_lengths": torch.tensor([2], dtype=torch.long),
+            },
+        ),
+    ]
+
+    results = qwen_stages._batch_audio_encoder_payloads(
+        payloads,
+        model=model,
+        cache=cache,
+    )
+
+    assert len(results) == 2
+    assert len(model.calls) == 1
+    for result in results:
+        state = Qwen3OmniPipelineState.from_dict(result.data)
+        audio_out = state.encoder_outs["audio_encoder"]
+        assert torch.equal(
+            audio_out["audio_embeds"],
+            torch.arange(4, dtype=torch.float32).reshape(2, 2),
+        )
+        assert torch.equal(
+            audio_out["audio_output_lengths"],
+            torch.tensor([2], dtype=torch.long),
+        )
 
 
 def test_qwen_talker_to_code2wav_projection_keeps_only_request_latch() -> None:

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -16,6 +16,7 @@ from sglang_omni.proto import CompleteMessage, OmniRequest, StreamMessage
 from sglang_omni.serve import create_app
 from sglang_omni.serve.openai_api import (
     _await_speech_response,
+    _build_chat_generate_request,
     _chat_stream,
     _speech_audio_response,
     build_transcription_generate_request,
@@ -140,6 +141,19 @@ class EmptyStreamingSpeechClient:
             sample_rate=24000,
             finish_reason="stop",
         )
+
+
+def test_chat_generate_request_preserves_session_media_metadata() -> None:
+    req = ChatCompletionRequest(
+        model="qwen3-omni",
+        messages=[{"role": "user", "content": "Follow up on the image."}],
+        metadata={"session_id": "session-1", "reuse_session_media": True},
+    )
+
+    generated = _build_chat_generate_request(req)
+
+    assert generated.metadata["session_id"] == "session-1"
+    assert generated.metadata["reuse_session_media"] is True
 
 
 class EmptyDeltaStreamingSpeechClient:

--- a/tests/unit_test/serve/test_speaker_cache.py
+++ b/tests/unit_test/serve/test_speaker_cache.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from sglang_omni.cache import CacheKey, LocalCachePlane
 from sglang_omni.scheduling.speaker_cache import SpeakerArtifactCache, SpeakerCacheKey
 
 
@@ -44,3 +45,26 @@ def test_speaker_cache_evicts_oldest_entry_under_memory_pressure() -> None:
     assert cache.get(first) is None
     assert cache.get(second) is not None
     assert cache.stats()["eviction_count"] == 1
+
+
+def test_speaker_cache_registers_artifacts_with_cache_plane() -> None:
+    plane = LocalCachePlane()
+    cache = SpeakerArtifactCache(max_bytes=1024, cache_plane=plane)
+    key = SpeakerCacheKey("higgs", "guide", 7, "reference_codes")
+
+    cache.put(key, np.arange(4, dtype=np.float32))
+    plane_key = CacheKey(
+        namespace="speaker_artifacts",
+        kind="speaker_artifact",
+        digest="higgs\x1fguide\x1f7\x1freference_codes",
+        stage_name="speaker_artifacts",
+    )
+
+    entry = plane.lookup(plane_key)
+
+    assert entry is not None
+    assert entry.meta.size_bytes == 16
+
+    cache.clear_voice("GUIDE")
+
+    assert plane.lookup(plane_key) is None


### PR DESCRIPTION
Closes #915.

## Summary

Add an SGLang-Omni-native cache path for repeated multimodal media reuse.

- add a model-neutral cache plane for cache metadata, owner locality, lifecycle, invalidation, stats, and single-flight build coordination
- wire `StageOutputCache` and uploaded-speaker artifacts into the cache plane
- add Qwen3-Omni session media reuse for follow-up turns via `metadata.session_id` and `metadata.reuse_session_media`
- preserve Qwen3-Omni placeholder expansion/M-RoPE correctness by caching lightweight media shape metadata, not raw image bytes
- deduplicate same-key audio/image encoder work in Qwen3-Omni hot paths
- pass OpenAI chat `metadata` through `/v1/chat/completions`

## Validation

Ran formatting, compile, diff, and affected unit tests:

- `python3 -m isort --check-only ...`
- `python3 -m black --check ...`
- `python3 -m compileall -q ...`
- `git diff --check`
- `pytest -q tests/unit_test/cache/test_cache_plane.py tests/unit_test/qwen3_omni/test_pipeline.py tests/unit_test/serve/test_speaker_cache.py tests/unit_test/serve/test_openai_api.py tests/unit_test/pipeline/test_scheduler.py::test_stage_output_cache_eviction_uses_lru_order tests/unit_test/pipeline/test_scheduler.py::test_stage_output_cache_tracks_bytes_and_detaches tests/unit_test/qwen3_tts/test_pipeline.py tests/unit_test/higgs_tts/test_pipeline.py`

Result: `203 passed, 20 warnings`.

## Experiment

Repeated-turn Qwen3-Omni image workload, measured from preprocessing through image encoder, N=8:

| Mode | Total | Warm avg | Cache stats |
| --- | ---: | ---: | --- |
| forced miss | 7673.96 ms | 902.69 ms | 8 misses, 0 hits |
| raw repeat | 1528.88 ms | 96.32 ms | 1 miss, 7 hits |
| session reuse | 931.37 ms | 11.00 ms | 1 miss, 7 hits |

Speedups:

- session reuse vs forced miss total: `8.24x`
- session reuse vs raw repeat total: `1.64x`
- session reuse warm path vs raw repeat warm path: `8.76x`

HTTP E2E through `/v1/chat/completions` also passed:

- first image turn: `miss -> store`, nonzero encoder input bytes
- follow-up turn 1: `hit`, `input_bytes=0`
- follow-up turn 2: `hit`, `input_bytes=0`
