### PR TITLE
[router] Stream proxied responses instead of buffering (Phase 0 of #907 router optimization)

### DIFF
--- a/sglang_omni_router/proxy.py
+++ b/sglang_omni_router/proxy.py
@@ -61,6 +61,14 @@ WORKER_REQUEST_FAILURE_STATUS_CODES = {
     HTTPStatus.GATEWAY_TIMEOUT.value,
 }
 
+# Note (Jiaxin Deng): terminal SSE event injected when an event-stream relay
+# fails mid-body, so the client gets a valid error frame (fields mirror the
+# worker's OpenAI error envelope) instead of a silently truncated stream.
+_SSE_UPSTREAM_ERROR_EVENT = (
+    b'data: {"error": {"message": "upstream stream failed before completion", '
+    b'"type": "upstream_error", "param": null, "code": 502}}\n\n'
+)
+
 
 class PayloadTooLargeError(ValueError):
     pass
@@ -198,9 +206,9 @@ class ProxyHandler:
         metadata: RouteMetadata,
         worker: Worker,
     ) -> Response:
-        # Note (Jiaxin Deng): stream the upstream response through instead of
-        # buffering the whole body; a mid-stream failure after a 2xx now
-        # truncates the response rather than returning 502.
+        # Note (Jiaxin Deng): stream through instead of buffering. A mid-stream
+        # failure after a 2xx cannot become a 502; SSE (text/event-stream) bodies
+        # get a terminal error event, other bodies (audio, JSON) truncate.
         stream = metadata.stream
         start_time = time.perf_counter()
         upstream_request = self._client.build_request(
@@ -256,6 +264,10 @@ class ProxyHandler:
                 error=f"status={upstream.status_code}",
             )
 
+        is_event_stream = (upstream.headers.get("content-type") or "").startswith(
+            "text/event-stream"
+        )
+
         async def iter_bytes():
             outcome = _response_outcome(upstream.status_code)
             try:
@@ -267,6 +279,9 @@ class ProxyHandler:
             except httpx.HTTPError as exc:
                 outcome = "stream_error"
                 record_worker_failure_once(error=type(exc).__name__)
+                if is_event_stream:
+                    yield _SSE_UPSTREAM_ERROR_EVENT
+                    return
                 raise
             finally:
                 await upstream.aclose()

--- a/sglang_omni_router/proxy.py
+++ b/sglang_omni_router/proxy.py
@@ -188,11 +188,9 @@ class ProxyHandler:
                 content={"error": {"message": "no eligible upstream"}},
             )
 
-        if metadata.stream:
-            return await self._forward_streaming(request, path, body, metadata, worker)
-        return await self._forward_non_streaming(request, path, body, metadata, worker)
+        return await self._forward_relay(request, path, body, metadata, worker)
 
-    async def _forward_non_streaming(
+    async def _forward_relay(
         self,
         request: Request,
         path: str,
@@ -200,70 +198,10 @@ class ProxyHandler:
         metadata: RouteMetadata,
         worker: Worker,
     ) -> Response:
-        with worker.request_guard():
-            start_time = time.perf_counter()
-            upstream_url = build_upstream_url(worker, path, request)
-            request_headers = filter_request_headers(request)
-            try:
-                response = await self._client.request(
-                    request.method,
-                    upstream_url,
-                    content=body,
-                    headers=request_headers,
-                )
-            except httpx.HTTPError as exc:
-                worker.record_routed_request()
-                self._record_worker_request_failure(
-                    worker,
-                    error=type(exc).__name__,
-                )
-                self._log_route_completion(
-                    worker=worker,
-                    path=path,
-                    metadata=metadata,
-                    status_code=502,
-                    outcome="upstream_error",
-                    start_time=start_time,
-                )
-                return JSONResponse(
-                    status_code=502,
-                    content={"error": {"message": "upstream request failed"}},
-                    headers=self._diagnostic_headers(worker, metadata),
-                )
-
-            if response.status_code in WORKER_REQUEST_FAILURE_STATUS_CODES:
-                self._record_worker_request_failure(
-                    worker,
-                    status_code=response.status_code,
-                    error=_response_error(response),
-                )
-            worker.record_routed_request(status_code=response.status_code)
-            outcome = _response_outcome(response.status_code)
-            self._log_route_completion(
-                worker=worker,
-                path=path,
-                metadata=metadata,
-                status_code=response.status_code,
-                outcome=outcome,
-                start_time=start_time,
-            )
-            headers = filter_response_headers(response.headers, buffered=True)
-            headers.update(self._diagnostic_headers(worker, metadata))
-            return Response(
-                content=response.content,
-                status_code=response.status_code,
-                headers=headers,
-                media_type=response.headers.get("content-type"),
-            )
-
-    async def _forward_streaming(
-        self,
-        request: Request,
-        path: str,
-        body: bytes,
-        metadata: RouteMetadata,
-        worker: Worker,
-    ) -> StreamingResponse | JSONResponse:
+        # Note (Jiaxin Deng): stream the upstream response through instead of
+        # buffering the whole body; a mid-stream failure after a 2xx now
+        # truncates the response rather than returning 502.
+        stream = metadata.stream
         start_time = time.perf_counter()
         upstream_request = self._client.build_request(
             request.method,
@@ -345,17 +283,22 @@ class ProxyHandler:
                 )
 
         try:
-            headers = filter_response_headers(upstream.headers)
+            headers = filter_response_headers(upstream.headers, buffered=not stream)
             headers.update(self._diagnostic_headers(worker, metadata))
         except Exception:
             await upstream.aclose()
             worker.decrement_active()
             raise
+        media_type = (
+            upstream.headers.get("content-type", "text/event-stream")
+            if stream
+            else upstream.headers.get("content-type")
+        )
         return StreamingResponse(
             iter_bytes(),
             status_code=upstream.status_code,
             headers=headers,
-            media_type=upstream.headers.get("content-type", "text/event-stream"),
+            media_type=media_type,
         )
 
     def _diagnostic_headers(
@@ -445,11 +388,6 @@ async def _read_body_with_limit(request: Request, max_size: int) -> bytes:
             raise PayloadTooLargeError
         chunks.append(chunk)
     return b"".join(chunks)
-
-
-def _response_error(response: httpx.Response) -> str:
-    content = response.content[:512].decode("utf-8", errors="replace")
-    return content or f"status={response.status_code}"
 
 
 def _response_outcome(status_code: int) -> str:

--- a/tests/unit_test/router/test_app.py
+++ b/tests/unit_test/router/test_app.py
@@ -1334,6 +1334,48 @@ def test_non_sse_midstream_failure_is_not_injected_with_error_event() -> None:
     assert all(worker.active_requests == 0 for worker in app.state.workers)
 
 
+def test_active_requests_held_across_body_relay_then_released() -> None:
+    # Note (Jiaxin Deng): recording active_requests at each yield proves the
+    # count is held while the body is still relaying (0 if released early), 0 after.
+    app_holder: list[FastAPI] = []
+    observed_during_relay: list[int] = []
+
+    class ObservingStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            worker = app_holder[0].state.workers[0]
+            observed_during_relay.append(worker.active_requests)
+            yield b"chunk-1"
+            observed_during_relay.append(worker.active_requests)
+            yield b"chunk-2"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "healthy"}, request=request)
+        if request.url.path == "/v1/audio/speech":
+            return httpx.Response(
+                200,
+                stream=ObservingStream(),
+                headers={"content-type": "audio/wav"},
+                request=request,
+            )
+        raise AssertionError(f"unexpected request path: {request.url.path}")
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(
+        _router_config(worker_configs=[WorkerConfig(url="http://worker-a:8101")]),
+        client=async_client,
+    )
+    app_holder.append(app)
+
+    with TestClient(app) as client:
+        response = client.post("/v1/audio/speech", json={"model": "qwen3-omni"})
+
+    assert response.status_code == 200
+    assert response.content == b"chunk-1chunk-2"
+    assert observed_during_relay == [1, 1]
+    assert all(worker.active_requests == 0 for worker in app.state.workers)
+
+
 def test_least_request_avoids_worker_with_active_stream_load() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path == "/health":

--- a/tests/unit_test/router/test_app.py
+++ b/tests/unit_test/router/test_app.py
@@ -1070,14 +1070,14 @@ def test_streaming_upstream_error_cleans_active_count() -> None:
     app = create_app(_router_config(), client=async_client)
 
     with TestClient(app) as client:
-        with pytest.raises(httpx.ReadError, match="stream boom"):
-            with client.stream(
-                "POST",
-                "/v1/chat/completions",
-                json={"model": "qwen3-omni", "stream": True},
-            ) as response:
-                b"".join(response.iter_bytes())
+        with client.stream(
+            "POST",
+            "/v1/chat/completions",
+            json={"model": "qwen3-omni", "stream": True},
+        ) as response:
+            body = b"".join(response.iter_bytes())
 
+    assert b"upstream_error" in body
     assert all(worker.active_requests == 0 for worker in app.state.workers)
 
 
@@ -1109,14 +1109,14 @@ def test_streaming_failure_records_single_worker_failure() -> None:
     )
 
     with TestClient(app) as client:
-        with pytest.raises(httpx.ReadError, match="stream boom"):
-            with client.stream(
-                "POST",
-                "/v1/chat/completions",
-                json={"model": "qwen3-omni", "stream": True},
-            ) as response:
-                b"".join(response.iter_bytes())
+        with client.stream(
+            "POST",
+            "/v1/chat/completions",
+            json={"model": "qwen3-omni", "stream": True},
+        ) as response:
+            body = b"".join(response.iter_bytes())
 
+    assert b"upstream_error" in body
     worker = app.state.workers[0]
     assert worker.routed_requests == 1
     assert worker.successful_requests == 0
@@ -1152,8 +1152,6 @@ def test_non_streaming_midstream_failure_truncates_instead_of_502() -> None:
     app = create_app(_router_config(), client=async_client)
 
     with TestClient(app) as client:
-        # 2xx status/headers commit before the body, so a mid-body failure
-        # truncates the stream (surfaced as ReadError) instead of a buffered 502.
         with pytest.raises(httpx.ReadError, match="body boom"):
             with client.stream(
                 "POST",
@@ -1187,10 +1185,9 @@ def test_non_streaming_error_status_relays_full_body_not_truncated() -> None:
             "/v1/chat/completions", json={"model": "qwen3-omni", "messages": []}
         )
 
-    # An error status whose body is fully received relays cleanly (the boundary:
-    # only a failure after the body starts truncates). Connect-time failures
-    # still return the router 502, pinned by
-    # test_upstream_request_failure_returns_502_and_cleans_active_count.
+    # Note (Jiaxin Deng): a complete error-status body relays cleanly (only a
+    # failure after the body starts truncates); the connect-time 502 boundary is
+    # pinned by test_upstream_request_failure_returns_502_and_cleans_active_count.
     assert response.status_code == 502
     assert response.json() == {"error": "upstream declined"}
     assert all(worker.active_requests == 0 for worker in app.state.workers)
@@ -1225,8 +1222,8 @@ def test_worker_failure_last_error_uses_status_code_not_body() -> None:
 
     assert response.status_code == 503
     worker = app.state.workers[0]
-    # Recorded as the status code, not a snippet of the (non-empty) response body,
-    # since the streaming relay cannot read the body without consuming it.
+    # Note (Jiaxin Deng): recorded as the status code, not a snippet of the
+    # (non-empty) body, since the streaming relay cannot read it without consuming.
     assert worker.last_error == "status=503"
 
 
@@ -1257,6 +1254,84 @@ def test_relayed_response_has_no_content_length_header() -> None:
     assert response.status_code == 200
     assert response.content == b'{"ok": true}'
     assert "content-length" not in {key.lower() for key in response.headers}
+
+
+def test_sse_terminal_error_event_appended_after_prior_events() -> None:
+    class BrokenStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield b'data: {"i": 1}\n\n'
+            yield b'data: {"i": 2}\n\n'
+            yield b'data: {"i": 3}\n\n'
+            raise httpx.ReadError("sse boom")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "healthy"}, request=request)
+        if request.url.path == "/v1/chat/completions":
+            return httpx.Response(
+                200,
+                stream=BrokenStream(),
+                headers={"content-type": "text/event-stream"},
+                request=request,
+            )
+        raise AssertionError(f"unexpected request path: {request.url.path}")
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(_router_config(), client=async_client)
+
+    with TestClient(app) as client:
+        with client.stream(
+            "POST",
+            "/v1/chat/completions",
+            json={"model": "qwen3-omni", "stream": True},
+        ) as response:
+            assert response.status_code == 200
+            body = b"".join(response.iter_bytes())
+
+    assert (
+        body.index(b'{"i": 1}')
+        < body.index(b'{"i": 2}')
+        < body.index(b'{"i": 3}')
+        < body.index(b"upstream_error")
+    )
+    assert body.count(b"data: ") == 4  # 3 upstream events + 1 terminal error event
+    assert all(worker.active_requests == 0 for worker in app.state.workers)
+
+
+def test_non_sse_midstream_failure_is_not_injected_with_error_event() -> None:
+    class BrokenStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield b"RIFF....partial-wav"
+            raise httpx.ReadError("audio boom")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "healthy"}, request=request)
+        if request.url.path == "/v1/audio/speech":
+            return httpx.Response(
+                200,
+                stream=BrokenStream(),
+                headers={"content-type": "audio/wav"},
+                request=request,
+            )
+        raise AssertionError(f"unexpected request path: {request.url.path}")
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(_router_config(), client=async_client)
+
+    with TestClient(app) as client:
+        # Note (Jiaxin Deng): a non-SSE body truncates (ReadError propagates); if
+        # the SSE error event were wrongly injected, it would end cleanly instead.
+        with pytest.raises(httpx.ReadError, match="audio boom"):
+            with client.stream(
+                "POST",
+                "/v1/audio/speech",
+                json={"model": "qwen3-omni"},
+            ) as response:
+                assert response.status_code == 200
+                b"".join(response.iter_bytes())
+
+    assert all(worker.active_requests == 0 for worker in app.state.workers)
 
 
 def test_least_request_avoids_worker_with_active_stream_load() -> None:

--- a/tests/unit_test/router/test_app.py
+++ b/tests/unit_test/router/test_app.py
@@ -1125,6 +1125,140 @@ def test_streaming_failure_records_single_worker_failure() -> None:
     assert worker.state == "healthy"
 
 
+# Streaming-relay semantics for the non-streaming path (Phase 0, #920): the relay
+# no longer buffers the full body, so failures after the status commits truncate,
+# and the response is chunked with a status-code-based worker error string.
+
+
+def test_non_streaming_midstream_failure_truncates_instead_of_502() -> None:
+    class BrokenStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield b'{"partial": true'
+            raise httpx.ReadError("body boom")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "healthy"}, request=request)
+        if request.url.path == "/v1/chat/completions":
+            return httpx.Response(
+                200,
+                stream=BrokenStream(),
+                headers={"content-type": "application/json"},
+                request=request,
+            )
+        raise AssertionError(f"unexpected request path: {request.url.path}")
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(_router_config(), client=async_client)
+
+    with TestClient(app) as client:
+        # 2xx status/headers commit before the body, so a mid-body failure
+        # truncates the stream (surfaced as ReadError) instead of a buffered 502.
+        with pytest.raises(httpx.ReadError, match="body boom"):
+            with client.stream(
+                "POST",
+                "/v1/chat/completions",
+                json={"model": "qwen3-omni", "messages": []},
+            ) as response:
+                assert response.status_code == 200
+                b"".join(response.iter_bytes())
+
+    assert all(worker.active_requests == 0 for worker in app.state.workers)
+
+
+def test_non_streaming_error_status_relays_full_body_not_truncated() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "healthy"}, request=request)
+        if request.url.path == "/v1/chat/completions":
+            return httpx.Response(
+                502,
+                content=b'{"error": "upstream declined"}',
+                headers={"content-type": "application/json"},
+                request=request,
+            )
+        raise AssertionError(f"unexpected request path: {request.url.path}")
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(_router_config(), client=async_client)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/chat/completions", json={"model": "qwen3-omni", "messages": []}
+        )
+
+    # An error status whose body is fully received relays cleanly (the boundary:
+    # only a failure after the body starts truncates). Connect-time failures
+    # still return the router 502, pinned by
+    # test_upstream_request_failure_returns_502_and_cleans_active_count.
+    assert response.status_code == 502
+    assert response.json() == {"error": "upstream declined"}
+    assert all(worker.active_requests == 0 for worker in app.state.workers)
+
+
+def test_worker_failure_last_error_uses_status_code_not_body() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "healthy"}, request=request)
+        if request.url.path == "/v1/chat/completions":
+            return httpx.Response(
+                503,
+                content=b'{"detail": "scheduler overloaded, retry later"}',
+                headers={"content-type": "application/json"},
+                request=request,
+            )
+        raise AssertionError(f"unexpected request path: {request.url.path}")
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(
+        _router_config(
+            health_failure_threshold=2,
+            worker_configs=[WorkerConfig(url="http://worker-a:8101")],
+        ),
+        client=async_client,
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/chat/completions", json={"model": "qwen3-omni", "messages": []}
+        )
+
+    assert response.status_code == 503
+    worker = app.state.workers[0]
+    # Recorded as the status code, not a snippet of the (non-empty) response body,
+    # since the streaming relay cannot read the body without consuming it.
+    assert worker.last_error == "status=503"
+
+
+def test_relayed_response_has_no_content_length_header() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "healthy"}, request=request)
+        if request.url.path == "/v1/chat/completions":
+            return httpx.Response(
+                200,
+                content=b'{"ok": true}',
+                headers={
+                    "content-type": "application/json",
+                    "content-length": "12",
+                },
+                request=request,
+            )
+        raise AssertionError(f"unexpected request path: {request.url.path}")
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(_router_config(), client=async_client)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/chat/completions", json={"model": "qwen3-omni", "messages": []}
+        )
+
+    assert response.status_code == 200
+    assert response.content == b'{"ok": true}'
+    assert "content-length" not in {key.lower() for key in response.headers}
+
+
 def test_least_request_avoids_worker_with_active_stream_load() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path == "/health":


### PR DESCRIPTION
## Motivation
Part of the #907 router optimization. The single-process router saturates one CPU core; profiling shows the cap is two parts: ~73% fixed per-request overhead (asyncio + httpx + FastAPI, which caps ~820 qps even with trivial responses) plus ~27% byte-proportional relay at 300 KB (rising with audio length). This PR removes the byte-growth half by not buffering the response body; the fixed-overhead half is addressed separately by the multi-process work (Phase 1). The two are decoupled, so this lands on its own.

## Change
Merge `_forward_non_streaming` and `_forward_streaming` into one streaming `_forward_relay`, so the router no longer materializes the full (base64 audio) response body on its event loop. `proxy.py` only, +13/-75 (net -62 lines; also drops the now-unused `_response_error` helper).

## Results [all measured]
* 117/117 router unit tests pass (offline httpx `MockTransport` suite: opaque forwarding, failure/retryable-status paths, header stripping, `active_requests` lifecycle, capability routing, admin, health, SSE streaming).
* A/B at router-core saturation (100% CPU, mock upstream), buffered baseline vs this streaming change:

  | response size | throughput | peak RSS |
  |---|---|---|
  | 300 KB | +2.4% | -35% (108 -> 70 MB) |
  | 1.5 MB | +22% | -78% (519 -> 112 MB) |

  The throughput win grows with audio size (the buffer + join cost is size-proportional); the memory win is large. The one-shot mock understates the real streaming-worker benefit (TTFB and memory under load).

## Semantic changes (please sign off)
* A mid-stream upstream failure **after** a 2xx status now truncates the streamed response instead of returning 502. This is inherent to streaming (status and headers commit before the body starts). Connect-time and pre-body failures still return a clean 502 JSON, unchanged.
* Non-streaming responses now use chunked transfer-encoding (no `content-length` header). Transparent to standard HTTP clients; inherent to relaying a body of unknown length without buffering it.
* For a worker-failure status code, the recorded `worker.last_error` is now `status=NNN` instead of a response-body snippet, since the streaming path cannot read the body without consuming it. (No behavior change for callers; observability only.)

