### PR TITLE
[TTS Refactor][M4a] ReferenceEncodeService: base + FishAudio S2-Pro migration

### DIFF
--- a/docs/developer_reference/reference_encode_service.md
+++ b/docs/developer_reference/reference_encode_service.md
@@ -1,0 +1,125 @@
+# Reference Encode Service
+
+`ReferenceEncodeService` owns reusable mechanics for ad-hoc TTS reference
+encoding:
+
+- cache-keyed lookup;
+- byte-bounded LRU storage;
+- same-key single-flight while an encode is in progress;
+- failure propagation to waiters without caching failures;
+- artifact store/load conversion and caller-owned return values;
+- basic cache statistics.
+
+The service is for ad-hoc request references. Registered or uploaded voices
+continue to use `SpeakerArtifactCache`, because they have a different lifetime,
+key space, and invalidation path.
+
+## API Shape
+
+The implementation lives in `sglang_omni/scheduling/reference_encoder.py`.
+
+```python
+@dataclass(frozen=True)
+class ReferenceEncodeKey:
+    model_id: str
+    model_revision: str
+    encoder_id: str
+    encoder_config_hash: str
+    artifact_kind: str
+    input_key: str
+    options_key: str = ""
+
+
+class ReferenceEncodeHook(Generic[InputT, ArtifactT, StoredT]):
+    def normalize_input(self, raw_input: Any) -> InputT: ...
+    def cache_key(self, item: InputT) -> ReferenceEncodeKey | None: ...
+    def encode_one(self, item: InputT) -> ArtifactT: ...
+    def store_artifact(self, artifact: ArtifactT) -> StoredT: ...
+    def load_artifact(self, stored: StoredT) -> ArtifactT: ...
+    def revalidate(self, item: InputT, key: ReferenceEncodeKey) -> bool: ...
+
+
+class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
+    def get_or_encode(self, raw_input: Any, *, desc: str | None = None) -> ArtifactT: ...
+    def stats(self) -> dict[str, int]: ...
+```
+
+`ReferenceEncodeService` is synchronous and thread-first. Existing TTS
+preprocessing and encoder stages already run synchronous model code inside
+`SimpleScheduler` or `ThreadedSimpleScheduler`, so adding an async surface would
+force nested event-loop management without changing the underlying work.
+
+## Responsibility Split
+
+The service owns mechanics:
+
+- `_inflight` single-flight map;
+- `StageOutputCache` access under a service-owned lock;
+- cache insertion, byte budget, and LRU eviction;
+- follower waits, timeout handling, and exception fanout;
+- no-poison-on-failure behavior;
+- stats for hits, misses, merges, failures, uncacheable inputs, entries, bytes,
+  and evictions.
+
+The hook owns model semantics:
+
+- request-specific input normalization;
+- cacheability;
+- model/checkpoint/config key parts;
+- `encode_one`;
+- artifact device and dtype policy;
+- store/load conversion;
+- revalidation for mutable local files.
+
+## Cache-Key Contract
+
+`ReferenceEncodeKey` must include every input that can change the encoded
+artifact identity:
+
+- model family or checkpoint identity;
+- model or encoder revision;
+- encoder implementation and config hash;
+- artifact kind;
+- normalized reference content identity;
+- encode options that affect the artifact.
+
+Local reference files should use
+`reference_path_cache_key(path, trust_stat=False)` and revalidate before cache
+insert. Bytes and data-URI payloads should key by the bytes or original payload
+actually consumed by the model hook. Remote URLs should not be cached by URL
+string alone unless an upstream fetch layer has already materialized immutable
+content identity.
+
+## Artifact Policy
+
+Hooks should store cache-owned artifacts, usually detached CPU tensors or a
+small CPU dictionary of detached tensors. `load_artifact` must return a
+caller-owned object, commonly by cloning and moving to the expected dtype or
+device. The service enforces the byte budget on the stored representation.
+
+If a stored artifact is larger than `max_bytes`, the leader request and all
+same-key followers still receive a result, but the artifact is not inserted into
+the LRU.
+
+## Failure And Waiters
+
+For a cacheable key:
+
+1. Cache hits return `hook.load_artifact(stored)`.
+2. If another request is already encoding the same key, followers wait on the
+   leader future.
+3. The leader encodes once, stores the artifact representation, optionally
+   inserts it into the LRU, resolves waiters, and removes the in-flight entry.
+
+Leader failures are propagated to waiters and are not cached. The next request
+can retry as a new leader. A follower timeout does not remove the leader's
+in-flight entry.
+
+## M4a And M4b Boundary
+
+M4a is the production path: ad-hoc reference cache and same-key single-flight.
+
+M4b is profile-gated: different-key batch coalescing should only be added when
+M4a profiling shows reference encode remains a bottleneck and a model has a
+real `encode_batch` speedup. M4b must still apply M4a cache hits and same-key
+single-flight before enqueueing distinct cache-miss leaders into a batch.

--- a/docs/developer_reference/reference_encode_service.md
+++ b/docs/developer_reference/reference_encode_service.md
@@ -117,9 +117,12 @@ in-flight entry.
 
 ## M4a And M4b Boundary
 
-M4a is the production path: ad-hoc reference cache and same-key single-flight.
+This document covers **M4a only**: the ad-hoc reference cache and same-key
+single-flight that ships today.
 
-M4b is profile-gated: different-key batch coalescing should only be added when
-M4a profiling shows reference encode remains a bottleneck and a model has a
-real `encode_batch` speedup. M4b must still apply M4a cache hits and same-key
-single-flight before enqueueing distinct cache-miss leaders into a batch.
+**M4b (different-key batch coalescing) is not implemented and is a non-goal
+here**; it is described only to mark the scope boundary. If it is ever built, it
+would be justified only when M4a profiling shows reference encode remains a
+bottleneck and a model has a real `encode_batch` speedup, and it must still
+apply M4a cache hits and same-key single-flight before enqueueing distinct
+cache-miss leaders into a batch.

--- a/docs/developer_reference/reference_encode_service.md
+++ b/docs/developer_reference/reference_encode_service.md
@@ -121,8 +121,36 @@ This document covers **M4a only**: the ad-hoc reference cache and same-key
 single-flight that ships today.
 
 **M4b (different-key batch coalescing) is not implemented and is a non-goal
-here**; it is described only to mark the scope boundary. If it is ever built, it
-would be justified only when M4a profiling shows reference encode remains a
-bottleneck and a model has a real `encode_batch` speedup, and it must still
-apply M4a cache hits and same-key single-flight before enqueueing distinct
-cache-miss leaders into a batch.
+here**; it is described only to mark the scope boundary. Do not add M4b runtime
+code until profiling proves it is worth the extra scheduling surface.
+
+Before building M4b, run cold-cache workloads with different reference audio per
+request at concurrency 8 and 16 for FishAudio S2-Pro, Qwen3-TTS, and
+MOSS-TTS Local. Track preprocessing/reference-encode p50/p95, end-to-end TTFA
+and latency, throughput, cache hit/miss/merge counts, and GPU/CPU utilization.
+Build M4b for a model only if different-key reference encode remains a top
+bottleneck and batching gives at least 15% p95 latency reduction or 20%
+throughput improvement versus M4a.
+
+If M4b is built later, it should be an opt-in extension of
+`ReferenceEncodeService`, not the default path:
+
+- add explicit hook capability, for example `can_encode_batch()` defaulting to
+  `False`, and call `encode_batch(items)` only for hooks that opt in;
+- add service knobs such as `max_batch_size=1` and `max_batch_wait_ms=0`;
+- preserve M4a ordering: normalize input, compute cache key, check cache,
+  merge same-key inflight work, and only then enqueue distinct cache-miss
+  leaders for different-key batching;
+- use an internal queue that drains up to `max_batch_size` or
+  `max_batch_wait_ms`, calls one hook batch encode, and then stores,
+  revalidates, cache-inserts, and resolves each item independently;
+- on a batch failure, retry per item so one bad reference does not fail the
+  whole batch.
+
+Model rollout should stay evidence-driven. MOSS-TTS Local already has its own
+batched reference encoder and should not be migrated just to fit this generic
+surface. FishAudio S2-Pro is the first plausible candidate only if profiling
+shows real benefit; its batched path would decode/resample each reference, pad
+waveforms, call the codec once, and split outputs while preserving parity with
+`encode_one`. Qwen3-TTS should remain M4a-only unless the upstream wrapper
+exposes a safe batch primitive for `create_voice_clone_prompt`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -105,5 +105,6 @@ Supported Models
    developer_reference/pipeline.md
    developer_reference/config.md
    developer_reference/communication.md
+   developer_reference/reference_encode_service.md
    developer_reference/profiler.md
    developer_reference/rl_admin_control.md

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -14,6 +14,10 @@ from typing import Any
 import torch
 
 from sglang_omni.models.fishaudio_s2_pro.payload_types import S2ProState
+from sglang_omni.preprocessing.cache_key import hash_bytes as _hash_bytes
+from sglang_omni.preprocessing.cache_key import (
+    reference_path_cache_key as _reference_path_cache_key,
+)
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.pipeline_state import load_state as _load_pipeline_state
 from sglang_omni.scheduling.pipeline_state import store_state as _store_pipeline_state
@@ -21,10 +25,6 @@ from sglang_omni.scheduling.reference_encoder import (
     ReferenceEncodeHook,
     ReferenceEncodeKey,
     ReferenceEncodeService,
-)
-from sglang_omni.preprocessing.cache_key import (
-    hash_bytes as _hash_bytes,
-    reference_path_cache_key as _reference_path_cache_key,
 )
 from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoint
 
@@ -164,7 +164,9 @@ class _FishReferenceEncodeHook(
             if item.source_kind == "bytes":
                 audio, sr = audio_io.load_bytes(item.source)
             else:
-                audio, sr = audio_io.load_base64(item.media_type or "audio/wav", item.source)
+                audio, sr = audio_io.load_base64(
+                    item.media_type or "audio/wav", item.source
+                )
             audio_tensor = torch.from_numpy(audio).float().reshape(1, -1)
             return self._encode_reference_waveform(audio_tensor, int(sr))
         raise TypeError(f"unknown FishAudio reference source: {item.source_kind}")
@@ -175,9 +177,7 @@ class _FishReferenceEncodeHook(
     def load_artifact(self, stored: torch.Tensor) -> torch.Tensor:
         return stored.detach().clone().to(dtype=torch.long)
 
-    def revalidate(
-        self, item: _FishReferenceInput, key: ReferenceEncodeKey
-    ) -> bool:
+    def revalidate(self, item: _FishReferenceInput, key: ReferenceEncodeKey) -> bool:
         if item.source_kind != "path":
             return True
         return self._input_key(item) == key.input_key
@@ -193,9 +193,7 @@ class _FishReferenceEncodeHook(
             return f"base64:{media_type}:{_hash_bytes(payload)}"
         return None
 
-    def _encode_reference_waveform(
-        self, audio: torch.Tensor, sr: int
-    ) -> torch.Tensor:
+    def _encode_reference_waveform(self, audio: torch.Tensor, sr: int) -> torch.Tensor:
         import torchaudio
 
         if audio.shape[0] > 1:

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+from dataclasses import dataclass
 from typing import Any
 
 import torch
@@ -16,6 +17,15 @@ from sglang_omni.models.fishaudio_s2_pro.payload_types import S2ProState
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.pipeline_state import load_state as _load_pipeline_state
 from sglang_omni.scheduling.pipeline_state import store_state as _store_pipeline_state
+from sglang_omni.scheduling.reference_encoder import (
+    ReferenceEncodeHook,
+    ReferenceEncodeKey,
+    ReferenceEncodeService,
+)
+from sglang_omni.preprocessing.cache_key import (
+    hash_bytes as _hash_bytes,
+    reference_path_cache_key as _reference_path_cache_key,
+)
 from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoint
 
 logger = logging.getLogger(__name__)
@@ -87,6 +97,119 @@ def store_state(payload: StagePayload, state: S2ProState) -> StagePayload:
     return _store_pipeline_state(payload, state)
 
 
+@dataclass(frozen=True)
+class _FishReferenceInput:
+    source_kind: str
+    source: Any
+    media_type: str | None = None
+
+
+def _fish_reference_payload_is_supported(ref_data: dict[str, Any]) -> bool:
+    return (
+        ref_data.get("audio_path") is not None
+        or ref_data.get("bytes") is not None
+        or ref_data.get("base64") is not None
+        or ref_data.get("data") is not None
+    )
+
+
+class _FishReferenceEncodeHook(
+    ReferenceEncodeHook[_FishReferenceInput, torch.Tensor, torch.Tensor]
+):
+    def __init__(self, *, codec: Any, checkpoint_id: str) -> None:
+        self._codec = codec
+        self._checkpoint_id = str(checkpoint_id)
+        config = f"sample_rate:{int(codec.sample_rate)}"
+        self._encoder_config_hash = _hash_bytes(config.encode("utf-8"))
+
+    def normalize_input(self, raw_input: Any) -> _FishReferenceInput:
+        if not isinstance(raw_input, dict):
+            raise TypeError("FishAudio reference input must be a dict")
+        if raw_input.get("audio_path") is not None:
+            return _FishReferenceInput("path", str(raw_input["audio_path"]))
+        if raw_input.get("bytes") is not None:
+            return _FishReferenceInput("bytes", bytes(raw_input["bytes"]))
+        data = raw_input.get("base64") or raw_input.get("data")
+        if data is not None:
+            return _FishReferenceInput(
+                "base64",
+                data,
+                str(raw_input.get("media_type") or "audio/wav"),
+            )
+        raise ValueError("FishAudio reference input has no audio payload")
+
+    def cache_key(self, item: _FishReferenceInput) -> ReferenceEncodeKey | None:
+        input_key = self._input_key(item)
+        if input_key is None:
+            return None
+        return ReferenceEncodeKey(
+            model_id="fishaudio_s2_pro",
+            model_revision=self._checkpoint_id,
+            encoder_id="fishaudio_s2_pro_codec",
+            encoder_config_hash=self._encoder_config_hash,
+            artifact_kind="fishaudio_s2_pro_vq_codes",
+            input_key=input_key,
+        )
+
+    def encode_one(self, item: _FishReferenceInput) -> torch.Tensor:
+        if item.source_kind == "path":
+            import torchaudio
+
+            audio, sr = torchaudio.load(str(item.source))
+            return self._encode_reference_waveform(audio, int(sr))
+        if item.source_kind in ("bytes", "base64"):
+            from sglang_omni.preprocessing.audio import AudioMediaIO
+
+            audio_io = AudioMediaIO(target_sr=self._codec.sample_rate)
+            if item.source_kind == "bytes":
+                audio, sr = audio_io.load_bytes(item.source)
+            else:
+                audio, sr = audio_io.load_base64(item.media_type or "audio/wav", item.source)
+            audio_tensor = torch.from_numpy(audio).float().reshape(1, -1)
+            return self._encode_reference_waveform(audio_tensor, int(sr))
+        raise TypeError(f"unknown FishAudio reference source: {item.source_kind}")
+
+    def store_artifact(self, artifact: torch.Tensor) -> torch.Tensor:
+        return artifact.detach().to(device="cpu", dtype=torch.long).clone()
+
+    def load_artifact(self, stored: torch.Tensor) -> torch.Tensor:
+        return stored.detach().clone().to(dtype=torch.long)
+
+    def revalidate(
+        self, item: _FishReferenceInput, key: ReferenceEncodeKey
+    ) -> bool:
+        if item.source_kind != "path":
+            return True
+        return self._input_key(item) == key.input_key
+
+    def _input_key(self, item: _FishReferenceInput) -> str | None:
+        if item.source_kind == "path":
+            return _reference_path_cache_key(str(item.source), trust_stat=False)
+        if item.source_kind == "bytes":
+            return f"bytes:{_hash_bytes(item.source)}"
+        if item.source_kind == "base64":
+            payload = str(item.source).encode("utf-8")
+            media_type = item.media_type or "audio/wav"
+            return f"base64:{media_type}:{_hash_bytes(payload)}"
+        return None
+
+    def _encode_reference_waveform(
+        self, audio: torch.Tensor, sr: int
+    ) -> torch.Tensor:
+        import torchaudio
+
+        if audio.shape[0] > 1:
+            audio = audio.mean(0, keepdim=True)
+        audio = torchaudio.functional.resample(audio, sr, self._codec.sample_rate)
+        audios = audio.squeeze(0).unsqueeze(0)
+        audio_lengths = torch.tensor([audios.shape[1]], dtype=torch.long)
+        with torch.no_grad():
+            indices, _ = self._codec.encode(audios, audio_lengths)
+            if indices.ndim == 3:
+                indices = indices[0]
+        return indices.cpu()
+
+
 # ---------------------------------------------------------------------------
 # Preprocessing — returns callable
 # ---------------------------------------------------------------------------
@@ -112,43 +235,13 @@ def create_preprocessing_executor(
     tokenizer = PreTrainedTokenizerFast.from_pretrained(checkpoint_dir)
     adapter = S2ProTokenizerAdapter(tokenizer)
     codec = _load_codec(checkpoint_dir, "cpu")
-
-    def _encode_reference_waveform(audio: torch.Tensor, sr: int) -> torch.Tensor:
-        import torchaudio
-
-        if audio.shape[0] > 1:
-            audio = audio.mean(0, keepdim=True)
-        audio = torchaudio.functional.resample(audio, sr, codec.sample_rate)
-        audios = audio.squeeze(0).unsqueeze(0)
-        audio_lengths = torch.tensor([audios.shape[1]], dtype=torch.long)
-        with torch.no_grad():
-            indices, _ = codec.encode(audios, audio_lengths)
-            if indices.ndim == 3:
-                indices = indices[0]
-        return indices.cpu()
-
-    def _encode_reference_audio(audio_path: str) -> torch.Tensor:
-        import torchaudio
-
-        audio, sr = torchaudio.load(audio_path)
-        return _encode_reference_waveform(audio, int(sr))
-
-    def _encode_reference_data(ref_data: dict[str, Any]) -> torch.Tensor | None:
-        data = ref_data.get("base64") or ref_data.get("data")
-        if data is None and ref_data.get("bytes") is None:
-            return None
-
-        from sglang_omni.preprocessing.audio import AudioMediaIO
-
-        audio_io = AudioMediaIO(target_sr=codec.sample_rate)
-        if ref_data.get("bytes") is not None:
-            audio, sr = audio_io.load_bytes(ref_data["bytes"])
-        else:
-            audio, sr = audio_io.load_base64(
-                ref_data.get("media_type") or "audio/wav", data
-            )
-        audio_tensor = torch.from_numpy(audio).float().reshape(1, -1)
-        return _encode_reference_waveform(audio_tensor, int(sr))
+    reference_encode_service = ReferenceEncodeService(
+        _FishReferenceEncodeHook(codec=codec, checkpoint_id=checkpoint_dir),
+        max_items=256,
+        max_bytes=64 * 1024 * 1024,
+        timeout_s=130.0,
+        log_prefix="FishAudio S2-Pro",
+    )
 
     def _preprocess(payload: StagePayload) -> StagePayload:
         inputs = payload.request.inputs or {}
@@ -168,10 +261,11 @@ def create_preprocessing_executor(
                 vq_codes = ref_data.get("vq_codes")
                 if vq_codes is not None and not isinstance(vq_codes, torch.Tensor):
                     vq_codes = torch.tensor(vq_codes)
-                if vq_codes is None and ref_data.get("audio_path"):
-                    vq_codes = _encode_reference_audio(ref_data["audio_path"])
-                if vq_codes is None:
-                    vq_codes = _encode_reference_data(ref_data)
+                if vq_codes is None and _fish_reference_payload_is_supported(ref_data):
+                    vq_codes = reference_encode_service.get_or_encode(
+                        ref_data,
+                        desc="FishAudio S2-Pro reference",
+                    )
                 references.append(
                     Reference(
                         audio_bytes=b"",

--- a/sglang_omni/scheduling/reference_encoder.py
+++ b/sglang_omni/scheduling/reference_encoder.py
@@ -52,6 +52,7 @@ class ReferenceEncodeHook(Generic[InputT, ArtifactT, StoredT]):
         return True
 
     def encode_batch(self, items: list[InputT]) -> list[ArtifactT]:
+        """Reserved; ReferenceEncodeService does not call this until batching."""
         return [self.encode_one(item) for item in items]
 
 
@@ -92,7 +93,8 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
                 self._uncacheable += 1
             try:
                 return self._hook.encode_one(item)
-            except BaseException:
+            except BaseException as exc:
+                self._add_exception_note(exc, desc)
                 with self._lock:
                     self._failed += 1
                 raise
@@ -120,7 +122,11 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
         if follower_fut is not None:
             try:
                 stored = follower_fut.result(timeout=self._timeout_s)
-            except concurrent.futures.TimeoutError:
+            except concurrent.futures.TimeoutError as exc:
+                self._add_exception_note(exc, desc)
+                raise
+            except BaseException as exc:
+                self._add_exception_note(exc, desc)
                 raise
             return self._hook.load_artifact(stored)
 
@@ -140,6 +146,7 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
                     self._cache.put(cache_key, stored)
                 self._inflight.pop(cache_key, None)
         except BaseException as exc:
+            self._add_exception_note(exc, desc)
             with self._lock:
                 self._inflight.pop(cache_key, None)
                 self._failed += 1
@@ -161,6 +168,14 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
                 "failed": self._failed,
                 "uncacheable": self._uncacheable,
             }
+
+    @staticmethod
+    def _add_exception_note(exc: BaseException, desc: str | None) -> None:
+        if not desc:
+            return
+        add_note = getattr(exc, "add_note", None)
+        if callable(add_note):
+            add_note(f"Reference encode context: {desc}")
 
     def _maybe_log(self) -> None:
         if self._log_prefix is None:

--- a/sglang_omni/scheduling/reference_encoder.py
+++ b/sglang_omni/scheduling/reference_encoder.py
@@ -130,21 +130,26 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
             return self._hook.load_artifact(stored)
 
         assert leader_fut is not None
+        # revalidate() and cache.put() run inside the same guard as encode: any
+        # exception here must still drop the in-flight entry and fail the future,
+        # otherwise same-key followers block on a future that never resolves and
+        # every later request for this key re-follows a dead leader (permanent
+        # poison + timeout-length hangs). A hook's revalidate() may legitimately
+        # raise (e.g. a reference file mutated during the encode window).
         try:
             artifact = self._hook.encode_one(item)
             stored = self._hook.store_artifact(artifact)
+            should_cache = self._hook.revalidate(item, key)
+            with self._lock:
+                if should_cache:
+                    self._cache.put(cache_key, stored)
+                self._inflight.pop(cache_key, None)
         except BaseException as exc:
             with self._lock:
                 self._inflight.pop(cache_key, None)
                 self._failed += 1
             leader_fut.set_exception(exc)
             raise
-
-        should_cache = self._hook.revalidate(item, key)
-        with self._lock:
-            if should_cache:
-                self._cache.put(cache_key, stored)
-            self._inflight.pop(cache_key, None)
         leader_fut.set_result(stored)
         self._maybe_log()
         return self._hook.load_artifact(stored)

--- a/sglang_omni/scheduling/reference_encoder.py
+++ b/sglang_omni/scheduling/reference_encoder.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import logging
+import threading
+import time
+from dataclasses import asdict, dataclass
+from typing import Any, Generic, TypeVar
+
+from sglang_omni.scheduling.stage_cache import StageOutputCache
+
+logger = logging.getLogger(__name__)
+
+InputT = TypeVar("InputT")
+ArtifactT = TypeVar("ArtifactT")
+StoredT = TypeVar("StoredT")
+
+
+@dataclass(frozen=True)
+class ReferenceEncodeKey:
+    model_id: str
+    model_revision: str
+    encoder_id: str
+    encoder_config_hash: str
+    artifact_kind: str
+    input_key: str
+    options_key: str = ""
+
+    def to_string(self) -> str:
+        return json.dumps(asdict(self), sort_keys=True, separators=(",", ":"))
+
+
+class ReferenceEncodeHook(Generic[InputT, ArtifactT, StoredT]):
+    def normalize_input(self, raw_input: Any) -> InputT:
+        raise NotImplementedError
+
+    def cache_key(self, item: InputT) -> ReferenceEncodeKey | None:
+        raise NotImplementedError
+
+    def encode_one(self, item: InputT) -> ArtifactT:
+        raise NotImplementedError
+
+    def store_artifact(self, artifact: ArtifactT) -> StoredT:
+        raise NotImplementedError
+
+    def load_artifact(self, stored: StoredT) -> ArtifactT:
+        raise NotImplementedError
+
+    def revalidate(self, item: InputT, key: ReferenceEncodeKey) -> bool:
+        return True
+
+    def encode_batch(self, items: list[InputT]) -> list[ArtifactT]:
+        return [self.encode_one(item) for item in items]
+
+
+class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
+    _LOG_INTERVAL_S = 60.0
+
+    def __init__(
+        self,
+        hook: ReferenceEncodeHook[InputT, ArtifactT, StoredT],
+        *,
+        max_items: int | None = 256,
+        max_bytes: int | None = 64 * 1024 * 1024,
+        timeout_s: float = 130.0,
+        log_prefix: str | None = None,
+    ) -> None:
+        if max_items is not None and max_items < 1:
+            raise ValueError(f"max_items must be >= 1, got {max_items}")
+        if max_bytes is not None and max_bytes < 1:
+            raise ValueError(f"max_bytes must be >= 1, got {max_bytes}")
+        self._hook = hook
+        self._cache = StageOutputCache(max_size=max_items, max_bytes=max_bytes)
+        self._timeout_s = float(timeout_s)
+        self._log_prefix = log_prefix
+        self._lock = threading.Lock()
+        self._inflight: dict[str, concurrent.futures.Future[StoredT]] = {}
+        self._hits = 0
+        self._misses = 0
+        self._merged = 0
+        self._failed = 0
+        self._uncacheable = 0
+        self._last_log_time = 0.0
+
+    def get_or_encode(self, raw_input: Any, *, desc: str | None = None) -> ArtifactT:
+        item = self._hook.normalize_input(raw_input)
+        key = self._hook.cache_key(item)
+        if key is None:
+            with self._lock:
+                self._uncacheable += 1
+            try:
+                return self._hook.encode_one(item)
+            except BaseException:
+                with self._lock:
+                    self._failed += 1
+                raise
+
+        cache_key = key.to_string()
+        leader_fut: concurrent.futures.Future[StoredT] | None = None
+        follower_fut: concurrent.futures.Future[StoredT] | None = None
+        stored: StoredT | None = None
+        with self._lock:
+            stored = self._cache.get(cache_key)
+            if stored is not None:
+                self._hits += 1
+            elif cache_key in self._inflight:
+                self._merged += 1
+                follower_fut = self._inflight[cache_key]
+            else:
+                self._misses += 1
+                leader_fut = concurrent.futures.Future()
+                self._inflight[cache_key] = leader_fut
+
+        if stored is not None:
+            self._maybe_log()
+            return self._hook.load_artifact(stored)
+
+        if follower_fut is not None:
+            try:
+                stored = follower_fut.result(timeout=self._timeout_s)
+            except concurrent.futures.TimeoutError:
+                raise
+            except BaseException as cause:
+                label = desc or key.input_key
+                raise RuntimeError(
+                    f"reference encode failed for {label}: {cause}"
+                ) from cause
+            return self._hook.load_artifact(stored)
+
+        assert leader_fut is not None
+        try:
+            artifact = self._hook.encode_one(item)
+            stored = self._hook.store_artifact(artifact)
+        except BaseException as exc:
+            with self._lock:
+                self._inflight.pop(cache_key, None)
+                self._failed += 1
+            leader_fut.set_exception(exc)
+            raise
+
+        should_cache = self._hook.revalidate(item, key)
+        with self._lock:
+            if should_cache:
+                self._cache.put(cache_key, stored)
+            self._inflight.pop(cache_key, None)
+        leader_fut.set_result(stored)
+        self._maybe_log()
+        return self._hook.load_artifact(stored)
+
+    def stats(self) -> dict[str, int]:
+        with self._lock:
+            return {
+                "hits": self._hits,
+                "misses": self._misses,
+                "merged": self._merged,
+                "entries": len(self._cache),
+                "bytes": self._cache.current_bytes,
+                "evictions": self._cache.eviction_count,
+                "failed": self._failed,
+                "uncacheable": self._uncacheable,
+            }
+
+    def _maybe_log(self) -> None:
+        if self._log_prefix is None:
+            return
+        now = time.monotonic()
+        if now - self._last_log_time < self._LOG_INTERVAL_S:
+            return
+        with self._lock:
+            if now - self._last_log_time < self._LOG_INTERVAL_S:
+                return
+            self._last_log_time = now
+            stats = {
+                "hits": self._hits,
+                "misses": self._misses,
+                "merged": self._merged,
+                "entries": len(self._cache),
+                "bytes": self._cache.current_bytes,
+                "evictions": self._cache.eviction_count,
+                "failed": self._failed,
+                "uncacheable": self._uncacheable,
+            }
+        logger.info("%s reference encode stats: %s", self._log_prefix, stats)

--- a/sglang_omni/scheduling/reference_encoder.py
+++ b/sglang_omni/scheduling/reference_encoder.py
@@ -122,11 +122,6 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
                 stored = follower_fut.result(timeout=self._timeout_s)
             except concurrent.futures.TimeoutError:
                 raise
-            except BaseException as cause:
-                label = desc or key.input_key
-                raise RuntimeError(
-                    f"reference encode failed for {label}: {cause}"
-                ) from cause
             return self._hook.load_artifact(stored)
 
         assert leader_fut is not None

--- a/tests/README.md
+++ b/tests/README.md
@@ -100,7 +100,8 @@ tests/
     │   └── test_openai_api.py
     ├── scheduling/
     │   ├── test_engine_factory.py
-    │   └── test_pipeline_state.py
+    │   ├── test_pipeline_state.py
+    │   └── test_reference_encoder.py
     ├── fishaudio_s2_pro/
     │   ├── test_pipeline.py
     │   ├── test_streaming_vocoder.py
@@ -293,6 +294,9 @@ that happened to contain an older version of the test.
 - `unit_test/models/`: Model registry and cross-model contract tests:
   - static TTS `ModelCapabilities` declarations, registry lookup, aliases, and
     launcher startup logging.
+- `unit_test/scheduling/`: Shared scheduling-service unit tests:
+  - `ReferenceEncodeService` cache, same-key single-flight, timeout, failure,
+    and revalidation semantics.
 - `unit_test/qwen3_asr/`: Qwen3-ASR unit tests:
   - pipeline config and stage factory concurrency defaults
   - single-source audio token length formula used by both processor and

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -654,6 +654,62 @@ def test_fish_reference_encode_service_failure_does_not_poison(
     assert codec.calls == 2
 
 
+def test_fish_reference_path_mutation_returns_but_does_not_cache(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from sglang_omni.models.fishaudio_s2_pro.stages import _FishReferenceEncodeHook
+
+    ref_path = tmp_path / "ref.wav"
+    ref_path.write_bytes(b"version-a")
+
+    def load(path: str):
+        assert path == str(ref_path)
+        return torch.zeros((1, 8), dtype=torch.float32), 16000
+
+    monkeypatch.setitem(
+        sys.modules,
+        "torchaudio",
+        SimpleNamespace(
+            load=load,
+            functional=SimpleNamespace(
+                resample=lambda audio, sr, target_sr: audio,
+            ),
+        ),
+    )
+
+    class _Codec:
+        sample_rate = 16000
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def encode(self, audios: torch.Tensor, audio_lengths: torch.Tensor):
+            del audios, audio_lengths
+            self.calls += 1
+            if self.calls == 1:
+                ref_path.write_bytes(b"version-b")
+            return torch.tensor([[self.calls, self.calls + 1]], dtype=torch.long), None
+
+    codec = _Codec()
+    service = ReferenceEncodeService(
+        _FishReferenceEncodeHook(codec=codec, checkpoint_id="ckpt"),
+        max_items=16,
+        max_bytes=1024,
+    )
+
+    first = service.get_or_encode({"audio_path": str(ref_path)})
+    assert torch.equal(first, torch.tensor([[1, 2]], dtype=torch.long))
+    assert service.stats()["entries"] == 0
+
+    second = service.get_or_encode({"audio_path": str(ref_path)})
+    assert torch.equal(second, torch.tensor([[2, 3]], dtype=torch.long))
+    assert service.stats()["entries"] == 1
+
+    third = service.get_or_encode({"audio_path": str(ref_path)})
+    assert torch.equal(third, torch.tensor([[2, 3]], dtype=torch.long))
+    assert codec.calls == 2
+
+
 def test_decoder_forward_kvcached_obeys_compiled_batch_size_cap() -> None:
     from sglang_omni.models.fishaudio_s2_pro.fish_speech.models.text2semantic.modeling import (
         FishQwen3AudioDecoder,

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import importlib
 import sys
 import threading
-import time
 from types import ModuleType, SimpleNamespace
 
 import numpy as np
@@ -571,12 +570,21 @@ def test_fish_reference_encode_service_same_key_concurrent_merge(
     )
 
     codec = _Codec()
+    worker_count = 4
+    gate = threading.Barrier(worker_count)
+
+    class _GatedFishReferenceEncodeHook(_FishReferenceEncodeHook):
+        def normalize_input(self, raw_input):
+            item = super().normalize_input(raw_input)
+            gate.wait(timeout=5)
+            return item
+
     service = ReferenceEncodeService(
-        _FishReferenceEncodeHook(codec=codec, checkpoint_id="ckpt"),
+        _GatedFishReferenceEncodeHook(codec=codec, checkpoint_id="ckpt"),
         max_items=16,
         max_bytes=1024,
     )
-    results: list[torch.Tensor | None] = [None] * 4
+    results: list[torch.Tensor | None] = [None] * worker_count
     errors: list[Exception] = []
 
     def worker(index: int) -> None:
@@ -589,7 +597,6 @@ def test_fish_reference_encode_service_same_key_concurrent_merge(
     for thread in threads:
         thread.start()
     assert entered.wait(timeout=5)
-    time.sleep(0.05)
     release.set()
     for thread in threads:
         thread.join(timeout=5)

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -577,12 +577,12 @@ def test_fish_reference_encode_service_same_key_concurrent_merge(
         max_bytes=1024,
     )
     results: list[torch.Tensor | None] = [None] * 4
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
 
     def worker(index: int) -> None:
         try:
             results[index] = service.get_or_encode({"bytes": b"ref"})
-        except BaseException as exc:
+        except Exception as exc:
             errors.append(exc)
 
     threads = [threading.Thread(target=worker, args=(i,)) for i in range(len(results))]
@@ -597,9 +597,7 @@ def test_fish_reference_encode_service_same_key_concurrent_merge(
     assert not errors
     assert codec.calls == 1
     assert all(result is not None for result in results)
-    assert all(
-        torch.equal(result, torch.tensor([[1, 2, 3]])) for result in results
-    )
+    assert all(torch.equal(result, torch.tensor([[1, 2, 3]])) for result in results)
     assert service.stats()["merged"] == 3
 
 

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import importlib
 import sys
+import threading
+import time
 from types import ModuleType, SimpleNamespace
 
+import numpy as np
 import pytest
 import torch
 import typer
@@ -23,6 +26,7 @@ from sglang_omni.models.fishaudio_s2_pro.tokenizer import (
     Reference,
     S2ProTokenizerAdapter,
 )
+from sglang_omni.scheduling.reference_encoder import ReferenceEncodeService
 from tests.unit_test.fixtures.fish_fakes import (
     FakeFishTokenizer,
     make_s2pro_payload,
@@ -523,6 +527,133 @@ def test_s2pro_engine_validates_allocated_decode_buffers(
             text_buffer_bs=text_buffer_bs,
             audio_buffer_bs=audio_buffer_bs,
         )
+
+
+def test_fish_reference_encode_service_same_key_concurrent_merge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.fishaudio_s2_pro.stages import _FishReferenceEncodeHook
+    from sglang_omni.preprocessing import audio as audio_module
+
+    release = threading.Event()
+    entered = threading.Event()
+
+    class _AudioMediaIO:
+        def __init__(self, *, target_sr: int) -> None:
+            self.target_sr = target_sr
+
+        def load_bytes(self, payload: bytes):
+            assert payload == b"ref"
+            return np.zeros(12, dtype=np.float32), self.target_sr
+
+    class _Codec:
+        sample_rate = 16000
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def encode(self, audios: torch.Tensor, audio_lengths: torch.Tensor):
+            del audios, audio_lengths
+            entered.set()
+            assert release.wait(timeout=5)
+            self.calls += 1
+            return torch.tensor([[1, 2, 3]], dtype=torch.long), None
+
+    monkeypatch.setattr(audio_module, "AudioMediaIO", _AudioMediaIO)
+    monkeypatch.setitem(
+        sys.modules,
+        "torchaudio",
+        SimpleNamespace(
+            functional=SimpleNamespace(
+                resample=lambda audio, sr, target_sr: audio,
+            )
+        ),
+    )
+
+    codec = _Codec()
+    service = ReferenceEncodeService(
+        _FishReferenceEncodeHook(codec=codec, checkpoint_id="ckpt"),
+        max_items=16,
+        max_bytes=1024,
+    )
+    results: list[torch.Tensor | None] = [None] * 4
+    errors: list[BaseException] = []
+
+    def worker(index: int) -> None:
+        try:
+            results[index] = service.get_or_encode({"bytes": b"ref"})
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(len(results))]
+    for thread in threads:
+        thread.start()
+    assert entered.wait(timeout=5)
+    time.sleep(0.05)
+    release.set()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert not errors
+    assert codec.calls == 1
+    assert all(result is not None for result in results)
+    assert all(
+        torch.equal(result, torch.tensor([[1, 2, 3]])) for result in results
+    )
+    assert service.stats()["merged"] == 3
+
+
+def test_fish_reference_encode_service_failure_does_not_poison(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.fishaudio_s2_pro.stages import _FishReferenceEncodeHook
+    from sglang_omni.preprocessing import audio as audio_module
+
+    class _AudioMediaIO:
+        def __init__(self, *, target_sr: int) -> None:
+            self.target_sr = target_sr
+
+        def load_bytes(self, payload: bytes):
+            return np.zeros(8, dtype=np.float32), self.target_sr
+
+    class _Codec:
+        sample_rate = 16000
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def encode(self, audios: torch.Tensor, audio_lengths: torch.Tensor):
+            del audios, audio_lengths
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("transient")
+            return torch.tensor([[5, 6]], dtype=torch.long), None
+
+    monkeypatch.setattr(audio_module, "AudioMediaIO", _AudioMediaIO)
+    monkeypatch.setitem(
+        sys.modules,
+        "torchaudio",
+        SimpleNamespace(
+            functional=SimpleNamespace(
+                resample=lambda audio, sr, target_sr: audio,
+            )
+        ),
+    )
+
+    codec = _Codec()
+    service = ReferenceEncodeService(
+        _FishReferenceEncodeHook(codec=codec, checkpoint_id="ckpt"),
+        max_items=16,
+        max_bytes=1024,
+    )
+
+    with pytest.raises(RuntimeError, match="transient"):
+        service.get_or_encode({"bytes": b"ref"})
+    assert service.stats()["entries"] == 0
+
+    result = service.get_or_encode({"bytes": b"ref"})
+    assert torch.equal(result, torch.tensor([[5, 6]], dtype=torch.long))
+    assert codec.calls == 2
 
 
 def test_decoder_forward_kvcached_obeys_compiled_batch_size_cap() -> None:

--- a/tests/unit_test/scheduling/test_reference_encoder.py
+++ b/tests/unit_test/scheduling/test_reference_encoder.py
@@ -250,3 +250,68 @@ def test_stats_hits_misses_merged_entries_bytes() -> None:
     assert stats["merged"] == 0
     assert stats["entries"] == 1
     assert stats["bytes"] > 0
+
+
+def test_revalidate_exception_clears_inflight_and_does_not_poison() -> None:
+    # A hook whose revalidate() raises (e.g. reference file mutated mid-encode)
+    # must not strand the in-flight entry: the leader has to fail the future and
+    # drop the key so the next same-key request is a fresh leader, never a
+    # follower blocked on a dead future for the full timeout.
+    class _RaisingRevalidateHook(_TensorHook):
+        def revalidate(self, item: str, key: ReferenceEncodeKey) -> bool:
+            raise RuntimeError("revalidate boom")
+
+    hook = _RaisingRevalidateHook()
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024)
+
+    with pytest.raises(RuntimeError, match="revalidate boom"):
+        service.get_or_encode("k")
+    assert service.stats()["entries"] == 0
+    assert service.stats()["failed"] == 1
+    assert len(service._inflight) == 0
+
+    # New leader (not a stuck follower) -> encode runs again instead of hanging.
+    with pytest.raises(RuntimeError, match="revalidate boom"):
+        service.get_or_encode("k")
+    assert hook.calls["k"] == 2
+
+
+def test_revalidate_exception_propagates_to_followers_without_timeout() -> None:
+    # Concurrent same-key followers must receive the leader's failure promptly,
+    # not sit on follower_fut.result() until timeout_s.
+    release = threading.Event()
+    entered = threading.Event()
+
+    class _GatedRaisingHook(_TensorHook):
+        def encode_one(self, item: str) -> torch.Tensor:
+            entered.set()
+            assert release.wait(timeout=5)
+            return super().encode_one(item)
+
+        def revalidate(self, item: str, key: ReferenceEncodeKey) -> bool:
+            raise RuntimeError("revalidate boom")
+
+    hook = _GatedRaisingHook()
+    # Large timeout: if the key were poisoned, followers would block far past the
+    # join() below, leaving their threads alive and errors incomplete.
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024, timeout_s=30)
+    errors: list[Exception] = []
+
+    def worker() -> None:
+        try:
+            service.get_or_encode("k", desc="k")
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    assert entered.wait(timeout=5)
+    time.sleep(0.05)
+    release.set()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert len(errors) == 4
+    assert len(service._inflight) == 0

--- a/tests/unit_test/scheduling/test_reference_encoder.py
+++ b/tests/unit_test/scheduling/test_reference_encoder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import threading
+import time
 from collections import Counter
 from typing import Any
 
@@ -37,6 +38,19 @@ class _FirstWaveGate:
             return
         self._barrier.wait(timeout=5)
         self._done.set()
+
+
+def _wait_for_merged(
+    service: ReferenceEncodeService[Any, Any, Any],
+    expected: int,
+    timeout_s: float = 5.0,
+) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if service.stats()["merged"] >= expected:
+            return
+        time.sleep(0.001)
+    assert service.stats()["merged"] >= expected
 
 
 class _TensorHook(ReferenceEncodeHook[str, torch.Tensor, torch.Tensor]):
@@ -97,6 +111,7 @@ def test_same_key_concurrent_single_flight() -> None:
     for thread in threads:
         thread.start()
     assert entered.wait(timeout=5)
+    _wait_for_merged(service, worker_count - 1)
     release.set()
     for thread in threads:
         thread.join(timeout=5)
@@ -146,7 +161,8 @@ def test_key_none_bypasses_cache() -> None:
 def test_exception_propagates_to_all_waiters_and_does_not_poison() -> None:
     release = threading.Event()
     entered = threading.Event()
-    gate = _FirstWaveGate(4)
+    worker_count = 4
+    gate = _FirstWaveGate(worker_count)
 
     class _FlakyHook(_TensorHook):
         def normalize_input(self, raw_input: Any) -> str:
@@ -174,10 +190,11 @@ def test_exception_propagates_to_all_waiters_and_does_not_poison() -> None:
         except Exception as exc:
             errors.append(exc)
 
-    threads = [threading.Thread(target=worker) for _ in range(4)]
+    threads = [threading.Thread(target=worker) for _ in range(worker_count)]
     for thread in threads:
         thread.start()
     assert entered.wait(timeout=5)
+    _wait_for_merged(service, worker_count - 1)
     release.set()
     for thread in threads:
         thread.join(timeout=5)
@@ -307,7 +324,8 @@ def test_revalidate_exception_propagates_to_followers_without_timeout() -> None:
     # not sit on follower_fut.result() until timeout_s.
     release = threading.Event()
     entered = threading.Event()
-    gate = _FirstWaveGate(4)
+    worker_count = 4
+    gate = _FirstWaveGate(worker_count)
 
     class _GatedRaisingHook(_TensorHook):
         def normalize_input(self, raw_input: Any) -> str:
@@ -335,10 +353,11 @@ def test_revalidate_exception_propagates_to_followers_without_timeout() -> None:
         except Exception as exc:
             errors.append(exc)
 
-    threads = [threading.Thread(target=worker) for _ in range(4)]
+    threads = [threading.Thread(target=worker) for _ in range(worker_count)]
     for thread in threads:
         thread.start()
     assert entered.wait(timeout=5)
+    _wait_for_merged(service, worker_count - 1)
     release.set()
     for thread in threads:
         thread.join(timeout=5)

--- a/tests/unit_test/scheduling/test_reference_encoder.py
+++ b/tests/unit_test/scheduling/test_reference_encoder.py
@@ -161,6 +161,8 @@ def test_exception_propagates_to_all_waiters_and_does_not_poison() -> None:
         thread.join(timeout=5)
 
     assert len(errors) == 4
+    assert all(isinstance(error, ValueError) for error in errors)
+    assert all(str(error) == "boom" for error in errors)
     assert service.stats()["entries"] == 0
     result = service.get_or_encode("flaky")
     assert torch.equal(result, torch.tensor([9], dtype=torch.long))
@@ -314,4 +316,6 @@ def test_revalidate_exception_propagates_to_followers_without_timeout() -> None:
 
     assert all(not thread.is_alive() for thread in threads)
     assert len(errors) == 4
+    assert all(isinstance(error, RuntimeError) for error in errors)
+    assert all(str(error) == "revalidate boom" for error in errors)
     assert len(service._inflight) == 0

--- a/tests/unit_test/scheduling/test_reference_encoder.py
+++ b/tests/unit_test/scheduling/test_reference_encoder.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import concurrent.futures
 import threading
-import time
 from collections import Counter
 from typing import Any
 
@@ -26,6 +25,18 @@ def _key(name: str) -> ReferenceEncodeKey:
         artifact_kind="codes",
         input_key=name,
     )
+
+
+class _FirstWaveGate:
+    def __init__(self, count: int) -> None:
+        self._barrier = threading.Barrier(count)
+        self._done = threading.Event()
+
+    def wait(self) -> None:
+        if self._done.is_set():
+            return
+        self._barrier.wait(timeout=5)
+        self._done.set()
 
 
 class _TensorHook(ReferenceEncodeHook[str, torch.Tensor, torch.Tensor]):
@@ -57,8 +68,15 @@ class _TensorHook(ReferenceEncodeHook[str, torch.Tensor, torch.Tensor]):
 def test_same_key_concurrent_single_flight() -> None:
     release = threading.Event()
     entered = threading.Event()
+    worker_count = 8
+    gate = _FirstWaveGate(worker_count)
 
     class _GatedHook(_TensorHook):
+        def normalize_input(self, raw_input: Any) -> str:
+            item = super().normalize_input(raw_input)
+            gate.wait()
+            return item
+
         def encode_one(self, item: str) -> torch.Tensor:
             entered.set()
             assert release.wait(timeout=5)
@@ -66,7 +84,7 @@ def test_same_key_concurrent_single_flight() -> None:
 
     hook = _GatedHook()
     service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024)
-    results: list[torch.Tensor | None] = [None] * 8
+    results: list[torch.Tensor | None] = [None] * worker_count
     errors: list[Exception] = []
 
     def worker(index: int) -> None:
@@ -79,7 +97,6 @@ def test_same_key_concurrent_single_flight() -> None:
     for thread in threads:
         thread.start()
     assert entered.wait(timeout=5)
-    time.sleep(0.05)
     release.set()
     for thread in threads:
         thread.join(timeout=5)
@@ -129,8 +146,14 @@ def test_key_none_bypasses_cache() -> None:
 def test_exception_propagates_to_all_waiters_and_does_not_poison() -> None:
     release = threading.Event()
     entered = threading.Event()
+    gate = _FirstWaveGate(4)
 
     class _FlakyHook(_TensorHook):
+        def normalize_input(self, raw_input: Any) -> str:
+            item = super().normalize_input(raw_input)
+            gate.wait()
+            return item
+
         def encode_one(self, item: str) -> torch.Tensor:
             with self.lock:
                 self.calls[item] += 1
@@ -155,7 +178,6 @@ def test_exception_propagates_to_all_waiters_and_does_not_poison() -> None:
     for thread in threads:
         thread.start()
     assert entered.wait(timeout=5)
-    time.sleep(0.05)
     release.set()
     for thread in threads:
         thread.join(timeout=5)
@@ -163,6 +185,8 @@ def test_exception_propagates_to_all_waiters_and_does_not_poison() -> None:
     assert len(errors) == 4
     assert all(isinstance(error, ValueError) for error in errors)
     assert all(str(error) == "boom" for error in errors)
+    if hasattr(errors[0], "__notes__"):
+        assert "Reference encode context: flaky" in errors[0].__notes__
     assert service.stats()["entries"] == 0
     result = service.get_or_encode("flaky")
     assert torch.equal(result, torch.tensor([9], dtype=torch.long))
@@ -283,8 +307,14 @@ def test_revalidate_exception_propagates_to_followers_without_timeout() -> None:
     # not sit on follower_fut.result() until timeout_s.
     release = threading.Event()
     entered = threading.Event()
+    gate = _FirstWaveGate(4)
 
     class _GatedRaisingHook(_TensorHook):
+        def normalize_input(self, raw_input: Any) -> str:
+            item = super().normalize_input(raw_input)
+            gate.wait()
+            return item
+
         def encode_one(self, item: str) -> torch.Tensor:
             entered.set()
             assert release.wait(timeout=5)
@@ -309,7 +339,6 @@ def test_revalidate_exception_propagates_to_followers_without_timeout() -> None:
     for thread in threads:
         thread.start()
     assert entered.wait(timeout=5)
-    time.sleep(0.05)
     release.set()
     for thread in threads:
         thread.join(timeout=5)

--- a/tests/unit_test/scheduling/test_reference_encoder.py
+++ b/tests/unit_test/scheduling/test_reference_encoder.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import concurrent.futures
+import threading
+import time
+from collections import Counter
+from typing import Any
+
+import pytest
+import torch
+
+from sglang_omni.scheduling.reference_encoder import (
+    ReferenceEncodeHook,
+    ReferenceEncodeKey,
+    ReferenceEncodeService,
+)
+
+
+def _key(name: str) -> ReferenceEncodeKey:
+    return ReferenceEncodeKey(
+        model_id="test",
+        model_revision="rev",
+        encoder_id="encoder",
+        encoder_config_hash="cfg",
+        artifact_kind="codes",
+        input_key=name,
+    )
+
+
+class _TensorHook(ReferenceEncodeHook[str, torch.Tensor, torch.Tensor]):
+    def __init__(self) -> None:
+        self.calls: Counter[str] = Counter()
+        self.lock = threading.Lock()
+
+    def normalize_input(self, raw_input: Any) -> str:
+        return str(raw_input)
+
+    def cache_key(self, item: str) -> ReferenceEncodeKey | None:
+        if item.startswith("uncacheable"):
+            return None
+        return _key(item)
+
+    def encode_one(self, item: str) -> torch.Tensor:
+        with self.lock:
+            self.calls[item] += 1
+        value = sum(ord(ch) for ch in item) % 127
+        return torch.full((2,), value, dtype=torch.long)
+
+    def store_artifact(self, artifact: torch.Tensor) -> torch.Tensor:
+        return artifact.detach().to("cpu").clone()
+
+    def load_artifact(self, stored: torch.Tensor) -> torch.Tensor:
+        return stored.detach().clone().to(dtype=torch.long)
+
+
+def test_same_key_concurrent_single_flight() -> None:
+    release = threading.Event()
+    entered = threading.Event()
+
+    class _GatedHook(_TensorHook):
+        def encode_one(self, item: str) -> torch.Tensor:
+            entered.set()
+            assert release.wait(timeout=5)
+            return super().encode_one(item)
+
+    hook = _GatedHook()
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024)
+    results: list[torch.Tensor | None] = [None] * 8
+    errors: list[BaseException] = []
+
+    def worker(index: int) -> None:
+        try:
+            results[index] = service.get_or_encode("same")
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(len(results))]
+    for thread in threads:
+        thread.start()
+    assert entered.wait(timeout=5)
+    time.sleep(0.05)
+    release.set()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert not errors
+    assert hook.calls["same"] == 1
+    assert all(result is not None for result in results)
+    first = results[0]
+    assert first is not None
+    assert all(torch.equal(first, result) for result in results if result is not None)
+    assert len({result.data_ptr() for result in results if result is not None}) == 8
+    stats = service.stats()
+    assert stats["misses"] == 1
+    assert stats["merged"] == 7
+    assert stats["hits"] == 0
+    assert stats["entries"] == 1
+
+
+def test_cache_hit_returns_loaded_artifact() -> None:
+    hook = _TensorHook()
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024)
+
+    first = service.get_or_encode("hit")
+    first.fill_(-1)
+    second = service.get_or_encode("hit")
+
+    assert hook.calls["hit"] == 1
+    assert torch.all(second >= 0)
+    assert first.data_ptr() != second.data_ptr()
+    assert service.stats()["hits"] == 1
+
+
+def test_key_none_bypasses_cache() -> None:
+    hook = _TensorHook()
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024)
+
+    service.get_or_encode("uncacheable-a")
+    service.get_or_encode("uncacheable-a")
+
+    assert hook.calls["uncacheable-a"] == 2
+    stats = service.stats()
+    assert stats["uncacheable"] == 2
+    assert stats["misses"] == 0
+    assert stats["entries"] == 0
+
+
+def test_exception_propagates_to_all_waiters_and_does_not_poison() -> None:
+    release = threading.Event()
+    entered = threading.Event()
+
+    class _FlakyHook(_TensorHook):
+        def encode_one(self, item: str) -> torch.Tensor:
+            with self.lock:
+                self.calls[item] += 1
+                call = self.calls[item]
+            entered.set()
+            assert release.wait(timeout=5)
+            if call == 1:
+                raise ValueError("boom")
+            return torch.tensor([9], dtype=torch.long)
+
+    hook = _FlakyHook()
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024)
+    errors: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            service.get_or_encode("flaky", desc="flaky")
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    assert entered.wait(timeout=5)
+    time.sleep(0.05)
+    release.set()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert len(errors) == 4
+    assert service.stats()["entries"] == 0
+    result = service.get_or_encode("flaky")
+    assert torch.equal(result, torch.tensor([9], dtype=torch.long))
+    assert hook.calls["flaky"] == 2
+
+
+def test_artifact_larger_than_budget_is_returned_but_not_cached() -> None:
+    hook = _TensorHook()
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=1)
+
+    first = service.get_or_encode("large")
+    second = service.get_or_encode("large")
+
+    assert torch.equal(first, second)
+    assert hook.calls["large"] == 2
+    assert service.stats()["entries"] == 0
+
+
+def test_lru_eviction_respects_max_bytes() -> None:
+    hook = _TensorHook()
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=16)
+
+    service.get_or_encode("a")
+    service.get_or_encode("b")
+    service.get_or_encode("b")
+    service.get_or_encode("a")
+
+    assert hook.calls["b"] == 1
+    assert hook.calls["a"] == 2
+    assert service.stats()["evictions"] >= 1
+
+
+def test_revalidate_false_returns_but_does_not_cache() -> None:
+    class _NoCacheHook(_TensorHook):
+        def revalidate(self, item: str, key: ReferenceEncodeKey) -> bool:
+            return False
+
+    hook = _NoCacheHook()
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024)
+
+    service.get_or_encode("changed")
+    service.get_or_encode("changed")
+
+    assert hook.calls["changed"] == 2
+    assert service.stats()["entries"] == 0
+
+
+def test_follower_timeout_does_not_remove_leader_inflight() -> None:
+    release = threading.Event()
+    entered = threading.Event()
+
+    class _SlowHook(_TensorHook):
+        def encode_one(self, item: str) -> torch.Tensor:
+            entered.set()
+            assert release.wait(timeout=5)
+            return super().encode_one(item)
+
+    hook = _SlowHook()
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024, timeout_s=0.01)
+    leader_result: list[torch.Tensor] = []
+
+    leader = threading.Thread(
+        target=lambda: leader_result.append(service.get_or_encode("slow"))
+    )
+    leader.start()
+    assert entered.wait(timeout=5)
+    with pytest.raises(concurrent.futures.TimeoutError):
+        service.get_or_encode("slow")
+    release.set()
+    leader.join(timeout=5)
+
+    assert len(leader_result) == 1
+    assert hook.calls["slow"] == 1
+    assert torch.equal(service.get_or_encode("slow"), leader_result[0])
+
+
+def test_stats_hits_misses_merged_entries_bytes() -> None:
+    hook = _TensorHook()
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024)
+
+    service.get_or_encode("stats")
+    service.get_or_encode("stats")
+    stats = service.stats()
+
+    assert stats["hits"] == 1
+    assert stats["misses"] == 1
+    assert stats["merged"] == 0
+    assert stats["entries"] == 1
+    assert stats["bytes"] > 0

--- a/tests/unit_test/scheduling/test_reference_encoder.py
+++ b/tests/unit_test/scheduling/test_reference_encoder.py
@@ -67,12 +67,12 @@ def test_same_key_concurrent_single_flight() -> None:
     hook = _GatedHook()
     service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024)
     results: list[torch.Tensor | None] = [None] * 8
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
 
     def worker(index: int) -> None:
         try:
             results[index] = service.get_or_encode("same")
-        except BaseException as exc:
+        except Exception as exc:
             errors.append(exc)
 
     threads = [threading.Thread(target=worker, args=(i,)) for i in range(len(results))]
@@ -143,12 +143,12 @@ def test_exception_propagates_to_all_waiters_and_does_not_poison() -> None:
 
     hook = _FlakyHook()
     service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024)
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
 
     def worker() -> None:
         try:
             service.get_or_encode("flaky", desc="flaky")
-        except BaseException as exc:
+        except Exception as exc:
             errors.append(exc)
 
     threads = [threading.Thread(target=worker) for _ in range(4)]


### PR DESCRIPTION
## Motivation

M4a extracts the reusable mechanics for ad-hoc TTS reference encoding: cache-keyed lookup, byte-bounded LRU storage, same-key single-flight, no-poison failure handling, and caller-owned artifact loading. FishAudio S2-Pro is the first production migration because its threaded preprocessing path can currently duplicate same-key reference encodes.

## Module doc

- Lark design: https://osgbw74w8zwb.sg.larksuite.com/docx/PM8Ed39XAoHkLoxguvHlFiO5ghc
- Repo API doc: `docs/developer_reference/reference_encode_service.md`

## Issue

- #925

## Behavior class

Yellow. Output artifacts should remain equivalent, but same-key concurrent ad-hoc references now share one in-flight encode and successful artifacts may be served from a bounded cache.

## Old path deletion

Replaces FishAudio S2-Pro's inline ad-hoc reference helpers in `sglang_omni/models/fishaudio_s2_pro/stages.py`:

- `_encode_reference_waveform(...)`
- `_encode_reference_audio(...)`
- `_encode_reference_data(...)`

The codec/waveform semantics moved into the Fish-specific hook; no M4b batch coalescing is introduced.

## Modifications

- Adds `sglang_omni/scheduling/reference_encoder.py` with `ReferenceEncodeKey`, `ReferenceEncodeHook`, and synchronous `ReferenceEncodeService`.
- Adds the developer API doc and links it from the docs index.
- Wires FishAudio S2-Pro supported ad-hoc reference payloads through the shared service while keeping model-specific normalization, keying, codec encode, and artifact policy local.

## Contract tests

- [x] `tests/unit_test/scheduling/test_reference_encoder.py::test_same_key_concurrent_single_flight`
- [x] `tests/unit_test/scheduling/test_reference_encoder.py::test_cache_hit_returns_loaded_artifact`
- [x] `tests/unit_test/scheduling/test_reference_encoder.py::test_key_none_bypasses_cache`
- [x] `tests/unit_test/scheduling/test_reference_encoder.py::test_exception_propagates_to_all_waiters_and_does_not_poison`
- [x] `tests/unit_test/scheduling/test_reference_encoder.py::test_artifact_larger_than_budget_is_returned_but_not_cached`
- [x] `tests/unit_test/scheduling/test_reference_encoder.py::test_lru_eviction_respects_max_bytes`
- [x] `tests/unit_test/scheduling/test_reference_encoder.py::test_revalidate_false_returns_but_does_not_cache`
- [x] `tests/unit_test/scheduling/test_reference_encoder.py::test_follower_timeout_does_not_remove_leader_inflight`
- [x] `tests/unit_test/scheduling/test_reference_encoder.py::test_stats_hits_misses_merged_entries_bytes`
- [x] `tests/unit_test/fishaudio_s2_pro/test_pipeline.py::test_fish_reference_encode_service_same_key_concurrent_merge`
- [x] `tests/unit_test/fishaudio_s2_pro/test_pipeline.py::test_fish_reference_encode_service_failure_does_not_poison`

## Accuracy / perf gate

Latest-head CI has been opened and pinned to the MOSS TTS selector with [`/tag-and-rerun-ci moss`](https://github.com/sgl-project/sglang-omni/pull/926#issuecomment-4895581328). Current latest-head run is [Omni CI 28808960302](https://github.com/sgl-project/sglang-omni/actions/runs/28808960302) at `32873e8`; `omni-ci-gate` passed and `setup - omni venv` is queued on the self-hosted H100 runner.

Note: this PR changes FishAudio S2-Pro reference encode code, but the repo's slash-command TTS CI selector currently supports only `higgs` and `moss`. The earlier `/tag-and-rerun-ci fishaudio` comment added `run-ci` but did not pin a FishAudio-specific gate.

Historical completed GPU CI data for this PR:

| SHA | Run | TTS selector | Overall | Notes |
|---|---|---|---|---|
| `a5bb89d` | [28754562352](https://github.com/sgl-project/sglang-omni/actions/runs/28754562352) | `moss` | Passed | Full Omni CI passed: PR Test, ASR, MOSS TTS, and Qwen3-Omni stages 1-10. |
| `ea84ddd` | [28803077375](https://github.com/sgl-project/sglang-omni/actions/runs/28803077375) | `moss` | Failed after TTS | PR Test, ASR, and MOSS TTS passed; later `Qwen3-Omni CI / stage 3 - MMMU accuracy + speed` failed. Superseded by latest head. |
| `32873e8` | [28808960302](https://github.com/sgl-project/sglang-omni/actions/runs/28808960302) | `moss` | Running | Triggered for latest head; queued at setup. |

MOSS TTS CI, SeedTTS voice-clone workload (`references`, concurrency 16):

| SHA / run | Mode | Completed | QPS | Latency mean / p95 | RTF mean / p95 | Extra |
|---|---|---:|---:|---:|---:|---|
| `a5bb89d` / [28754562352](https://github.com/sgl-project/sglang-omni/actions/runs/28754562352) | non-stream | 1088/1088 | 12.930 | 1.232s / 1.659s | 0.2907 / 0.4115 | audio throughput 56.911 s/s |
| `a5bb89d` / [28754562352](https://github.com/sgl-project/sglang-omni/actions/runs/28754562352) | stream | 1088/1088 | 8.881 | 1.793s / 2.370s | 0.4202 / 0.5742 | TTFA mean/p95 0.6785s / 1.1207s; inter-chunk mean/p95 0.1039s / 0.3203s |
| `ea84ddd` / [28803077375](https://github.com/sgl-project/sglang-omni/actions/runs/28803077375) | non-stream | 1088/1088 | 12.415 | 1.282s / 1.719s | 0.3031 / 0.4392 | audio throughput 54.643 s/s |
| `ea84ddd` / [28803077375](https://github.com/sgl-project/sglang-omni/actions/runs/28803077375) | stream | 1088/1088 | 8.722 | 1.826s / 2.444s | 0.4278 / 0.5786 | TTFA mean/p95 0.7129s / 1.1528s; inter-chunk mean/p95 0.1048s / 0.3231s |

Qwen3-ASR SeedTTS WER sanity for generated/evaluated audio:

| SHA / run | Evaluated | Corpus WER | ASR throughput | ASR latency mean / p95 | ASR RTF mean / p95 |
|---|---:|---:|---:|---:|---:|
| `a5bb89d` / [28754562352](https://github.com/sgl-project/sglang-omni/actions/runs/28754562352) | 1088/1088 | 1.271% | 98.079 samples/s | 0.324s / 0.437s | 0.0703 / 0.0989 |
| `ea84ddd` / [28803077375](https://github.com/sgl-project/sglang-omni/actions/runs/28803077375) | 1088/1088 | 1.218% | 100.376 samples/s | 0.316s / 0.429s | 0.0685 / 0.0968 |

## Resolved comments

- #661: keep PRs small and mark behavior-changing/yellow semantics explicitly.
- #809: do not revive the closed conflicting branch; redo the extraction on current `main` and keep MOSS-local batching out of M4a.
- M4 design: reuse existing cache-key utilities, keep registered voice cache separate, and do not introduce M4b or M7 in the FishAudio migration.

## Validation

- [x] `python3 -m py_compile sglang_omni/scheduling/reference_encoder.py sglang_omni/models/fishaudio_s2_pro/stages.py tests/unit_test/scheduling/test_reference_encoder.py tests/unit_test/fishaudio_s2_pro/test_pipeline.py`
- [x] `git diff --check`
- [ ] `python3 -m pytest tests/unit_test/scheduling/test_reference_encoder.py tests/unit_test/fishaudio_s2_pro/test_pipeline.py -q` (blocked locally: available Python environments lack `torch` and `pytest`)
- [x] Latest-head non-GPU checks at `32873e8`: CodeQL Analyze (javascript-typescript/python), Docs Check, Lint, Test Layout, and Omni CI gate passed.
- [ ] Latest-head Omni CI: [run 28808960302](https://github.com/sgl-project/sglang-omni/actions/runs/28808960302) opened/pinned to `moss`, currently queued at `setup - omni venv`.
- [x] Historical full Omni CI: [run 28754562352](https://github.com/sgl-project/sglang-omni/actions/runs/28754562352) passed at `a5bb89d`; detailed data in Accuracy / perf gate.
- [x] Intermediate Omni CI: [run 28803077375](https://github.com/sgl-project/sglang-omni/actions/runs/28803077375) passed PR Test, ASR, and MOSS TTS at `ea84ddd`, then failed later in Qwen3-Omni MMMU; superseded by latest head.

## Checklist

- [ ] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the `run-ci` label. Once labeled, every subsequent push to a PR targeting `main` re-triggers CI as long as the label remains. Current repo-supported TTS selectors are `higgs` and `moss`; use the `run-higgs` / `run-moss` labels or `workflow_dispatch` input `tts_ci_model=higgs|moss` to pin the TTS gate. Draft PRs are skipped even if labeled.

