### PR TITLE
[TTS Refactor][M4a] ReferenceEncodeService: Qwen3-TTS taxonomy migration

### DIFF
--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -22,6 +22,8 @@ _PKG = "sglang_omni.models.moss_tts_local"
 _COLOCATED_TOTAL_GPU_MEMORY_FRACTION = 0.90
 _COLOCATED_CODEC_MEM_RESERVE = 0.15
 _AR_MEM_FRACTION_STATIC = 0.85
+_REF_AUDIO_CACHE_MAX_ITEMS = 8192
+_REF_AUDIO_CACHE_MAX_BYTES = 64 * 1024 * 1024
 
 
 def _stages(*, codec_device: str, colocated: bool) -> list[StageConfig]:
@@ -44,12 +46,7 @@ def _stages(*, codec_device: str, colocated: bool) -> list[StageConfig]:
             name="preprocessing",
             process="pipeline",
             factory=f"{_PKG}.stages.create_preprocessing_executor",
-            factory_args={
-                "device": codec_device,
-                "ref_audio_cache": True,
-                "ref_audio_cache_max_items": 8192,
-                "ref_audio_cache_max_bytes": 64 * 1024 * 1024,
-            },
+            factory_args={"device": codec_device},
             gpu=0,
             next="tts_engine",
         ),
@@ -107,9 +104,22 @@ class MossTTSLocalPipelineConfig(PipelineConfig):
     cuda_graph: bool = True
     cuda_graph_frames: list[int] | None = None
     cuda_graph_min_free_gb: float = 3.0
+    ref_audio_cache: bool = True
+    ref_audio_cache_max_items: int = _REF_AUDIO_CACHE_MAX_ITEMS
+    ref_audio_cache_max_bytes: int = _REF_AUDIO_CACHE_MAX_BYTES
 
     def model_post_init(self, __context: Any = None) -> None:
         super().model_post_init(__context)
+        if self.ref_audio_cache_max_items < 1:
+            raise ValueError(
+                "ref_audio_cache_max_items must be >= 1; got "
+                f"{self.ref_audio_cache_max_items}"
+            )
+        if self.ref_audio_cache_max_bytes < 1:
+            raise ValueError(
+                "ref_audio_cache_max_bytes must be >= 1; got "
+                f"{self.ref_audio_cache_max_bytes}"
+            )
         if self.cuda_graph_min_free_gb < 0:
             raise ValueError(
                 "cuda_graph_min_free_gb must be >= 0 (0 disables the VRAM headroom "
@@ -127,6 +137,14 @@ class MossTTSLocalPipelineConfig(PipelineConfig):
                     f"cuda_graph_frames entries must be positive ints (>= 1); got {invalid}"
                 )
         for stage in self.stages:
+            if stage.factory.endswith("create_preprocessing_executor"):
+                stage.factory_args.setdefault("ref_audio_cache", self.ref_audio_cache)
+                stage.factory_args.setdefault(
+                    "ref_audio_cache_max_items", self.ref_audio_cache_max_items
+                )
+                stage.factory_args.setdefault(
+                    "ref_audio_cache_max_bytes", self.ref_audio_cache_max_bytes
+                )
             if stage.factory.endswith("create_vocoder_executor"):
                 stage.factory_args.setdefault("cuda_graph", self.cuda_graph)
                 stage.factory_args.setdefault(

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -445,7 +445,7 @@ class _MossLocalReferenceEncodeHook(
     ) -> bool:
         if item.source_kind != "path":
             return True
-        return self._input_key(item) == key.input_key
+        return _reference_path_cache_key(item.source) == key.input_key
 
     def _input_key(self, item: _MossLocalReferenceInput) -> str | None:
         if item.source_kind == "path":

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -7,10 +7,8 @@ import base64
 import concurrent.futures
 import io
 import logging
-import os
 import queue
 import threading
-import time
 from dataclasses import dataclass
 from typing import Any, TypeAlias
 
@@ -41,8 +39,12 @@ from sglang_omni.preprocessing.cache_key import hash_bytes as _hash_bytes
 from sglang_omni.preprocessing.cache_key import (
     reference_path_cache_key as _reference_path_cache_key,
 )
+from sglang_omni.scheduling.reference_encoder import (
+    ReferenceEncodeHook,
+    ReferenceEncodeKey,
+    ReferenceEncodeService,
+)
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
-from sglang_omni.scheduling.stage_cache import StageOutputCache
 
 logger = logging.getLogger(__name__)
 
@@ -381,172 +383,114 @@ class _BatchedReferenceEncoder:
         return results
 
 
-class CachedReferenceEncoder:
-    """Content-addressed LRU cache + single-flight dedup in front of _BatchedReferenceEncoder.
+@dataclass(frozen=True)
+class _MossLocalReferenceInput:
+    source_kind: str
+    source: str
+    raw: bytes | None = None
 
-    Every path (miss, hit, follower) returns an independent CPU long tensor, so
-    downstream sees one device/dtype regardless of cache temperature.
-    Stores codes as int32 on CPU (lossless for codebook values in [0, 1023]).
-    """
 
-    # Cadence for the periodic stats log; class attr so it is easy to tune.
-    LOG_INTERVAL_S = 60.0
-
+class _MossLocalReferenceEncodeHook(
+    ReferenceEncodeHook[_MossLocalReferenceInput, torch.Tensor, torch.Tensor]
+):
     def __init__(
         self,
         encoder: _BatchedReferenceEncoder,
         *,
-        max_items: int = 256,
-        max_bytes: int = 64 * 1024 * 1024,
+        n_vq: int,
     ) -> None:
-        # Fail fast on non-positive capacities: a negative max_items makes
-        # StageOutputCache evict from an empty dict and KeyError at request time.
-        if max_items < 1:
-            raise ValueError(f"ref_audio_cache_max_items must be >= 1, got {max_items}")
-        if max_bytes < 1:
-            raise ValueError(f"ref_audio_cache_max_bytes must be >= 1, got {max_bytes}")
         self._encoder = encoder
-        self._cache = StageOutputCache(
-            max_size=max_items,
-            max_bytes=max_bytes,
-            cache_device="cpu",
+        self._n_vq = int(n_vq)
+        self._encoder_config_hash = _hash_bytes(f"n_vq:{self._n_vq}".encode("utf-8"))
+
+    def normalize_input(self, raw_input: Any) -> _MossLocalReferenceInput:
+        if isinstance(raw_input, _MossLocalReferenceInput):
+            return raw_input
+        return _MossLocalReferenceInput("path", str(raw_input))
+
+    def cache_key(self, item: _MossLocalReferenceInput) -> ReferenceEncodeKey | None:
+        input_key = self._input_key(item)
+        if input_key is None:
+            return None
+        return ReferenceEncodeKey(
+            model_id="moss_tts_local",
+            model_revision="local_audio_tokenizer",
+            encoder_id="moss_tts_local_audio_tokenizer",
+            encoder_config_hash=self._encoder_config_hash,
+            artifact_kind="moss_tts_local_reference_codes",
+            input_key=input_key,
         )
-        self._lock = threading.Lock()
-        self._inflight: dict[str, concurrent.futures.Future] = {}
-        self._hits = 0
-        self._misses = 0
-        self._merged = 0
-        self._last_log_time: float = 0.0
+
+    def encode_one(self, item: _MossLocalReferenceInput) -> torch.Tensor:
+        if item.source_kind == "path":
+            return self._encoder.encode(item.source)
+        if item.source_kind == "data_uri":
+            raw = item.raw
+            if raw is None:
+                raw = _BatchedReferenceEncoder._data_uri_audio_bytes(item.source)
+            wav, sample_rate = _BatchedReferenceEncoder._decode_data_uri_audio(raw)
+            return self._encoder.encode_wav(wav, sample_rate)
+        raise TypeError(f"unknown MOSS-local reference source: {item.source_kind}")
+
+    def store_artifact(self, artifact: torch.Tensor) -> torch.Tensor:
+        return artifact.detach().to("cpu", dtype=torch.int32).clone()
+
+    def load_artifact(self, stored: torch.Tensor) -> torch.Tensor:
+        return stored.detach().clone().to(torch.long)
+
+    def revalidate(
+        self,
+        item: _MossLocalReferenceInput,
+        key: ReferenceEncodeKey,
+    ) -> bool:
+        if item.source_kind != "path":
+            return True
+        return self._input_key(item) == key.input_key
+
+    def _input_key(self, item: _MossLocalReferenceInput) -> str | None:
+        if item.source_kind == "path":
+            _BatchedReferenceEncoder._check_reference_duration(item.source)
+            return _reference_path_cache_key(item.source)
+        if item.source_kind == "data_uri":
+            raw = item.raw
+            if raw is None:
+                raw = _BatchedReferenceEncoder._data_uri_audio_bytes(item.source)
+            return f"bytes:{_hash_bytes(raw)}"
+        return None
+
+
+class _MossLocalReferenceEncoder:
+    def __init__(
+        self,
+        encoder: _BatchedReferenceEncoder,
+        *,
+        n_vq: int,
+        max_items: int,
+        max_bytes: int,
+    ) -> None:
+        self._service = ReferenceEncodeService(
+            _MossLocalReferenceEncodeHook(encoder, n_vq=n_vq),
+            max_items=max_items,
+            max_bytes=max_bytes,
+            timeout_s=_BatchedReferenceEncoder.ENCODE_TIMEOUT_S + 10,
+            log_prefix="MOSS-TTS Local ref cache",
+        )
 
     def encode(self, path: str) -> torch.Tensor:
-        path = str(path)
-        # Note(Jiaxin): duration gate runs first — a >100 s ref must never reach
-        # the cache or the inflight dict.
-        _BatchedReferenceEncoder._check_reference_duration(path)
-        # trust_stat left False (review feedback): keep the sentinel byte-read so a
-        # same-size+mtime+ctime overwrite cannot stale-hit. The flag stays available
-        # in reference_path_cache_key for deployments that guarantee immutable refs.
-        key = _reference_path_cache_key(path)
-        if key is None:
-            return self._encoder.encode(path)  # uncacheable (URL/missing) -> bypass
-        return self._cached_encode(
-            key,
-            lambda: self._encoder.encode(path),
-            desc=repr(path),
-            # TOCTOU re-stat: skip the put if the file changed during the encode.
-            revalidate=lambda: _reference_path_cache_key(path) == key,
-        )
-
-    def _cached_encode(
-        self, key: str, encode_fn, *, desc: str, revalidate=None
-    ) -> torch.Tensor:
-        """Single-flight skeleton shared by encode() and encode_data_uri().
-
-        All paths return an independent CPU long tensor. revalidate(), if given,
-        is evaluated outside the lock and gates the put (TOCTOU guard for file
-        paths).
-        """
-        leader_fut: concurrent.futures.Future | None = None
-        follower_fut: concurrent.futures.Future | None = None
-
-        with self._lock:
-            stored = self._cache.get(key)
-            if stored is not None:
-                self._hits += 1
-            elif key in self._inflight:
-                self._merged += 1
-                follower_fut = self._inflight[key]
-            else:
-                self._misses += 1
-                leader_fut = concurrent.futures.Future()
-                self._inflight[key] = leader_fut
-
-        if stored is not None:
-            # Note(Jiaxin): clone on hit so callers can't mutate the shared entry.
-            self._maybe_log()
-            return stored.clone().to(torch.long)
-
-        if follower_fut is not None:
-            # Note(Jiaxin): each follower raises a FRESH RuntimeError — sharing one
-            # exception instance lets concurrent re-raises corrupt its traceback
-            # (same lesson as _BatchedReferenceEncoder._worker).
-            timeout = _BatchedReferenceEncoder.ENCODE_TIMEOUT_S + 10
-            try:
-                stored = follower_fut.result(timeout=timeout)
-            except Exception as cause:
-                raise RuntimeError(
-                    f"reference encode failed for {desc}: {cause}"
-                ) from cause
-            return stored.clone().to(torch.long)
-
-        assert leader_fut is not None
-        try:
-            result = encode_fn()
-        except BaseException as exc:
-            with self._lock:
-                self._inflight.pop(key, None)
-            leader_fut.set_exception(exc)
-            raise
-
-        do_put = revalidate() if revalidate is not None else True
-        stored = result.detach().to("cpu", dtype=torch.int32)
-        with self._lock:
-            if do_put:
-                self._cache.put(key, stored)
-            self._inflight.pop(key, None)
-        leader_fut.set_result(stored)
-        self._maybe_log()
-        # CPU long like the hit path.
-        return stored.to(torch.long)
-
-    def _maybe_log(self) -> None:
-        now = time.monotonic()
-        if now - self._last_log_time < self.LOG_INTERVAL_S:
-            return
-        with self._lock:
-            if now - self._last_log_time < self.LOG_INTERVAL_S:
-                return
-            self._last_log_time = now
-            snapshot = (
-                self._hits,
-                self._misses,
-                self._merged,
-                len(self._cache._cache),
-                self._cache.current_bytes,
-            )
-        logger.info(
-            "MOSS-TTS Local ref cache: hits=%d misses=%d merged=%d entries=%d bytes=%d",
-            *snapshot,
+        return self._service.get_or_encode(
+            _MossLocalReferenceInput("path", str(path)),
+            desc=repr(str(path)),
         )
 
     def encode_data_uri(self, ref_audio: str) -> torch.Tensor:
-        """Cache-aware encode for data-URI refs through the same LRU + single-flight
-        as file paths (adds the duration check _reference_for_processor lacks).
-
-        Note(Jiaxin): file: and bytes: keyspaces never collide — the two decode
-        chains differ, so codes aren't guaranteed identical for the "same" audio.
-        """
         raw = _BatchedReferenceEncoder._data_uri_audio_bytes(ref_audio)
-        key = f"bytes:{_hash_bytes(raw)}"
+        return self._service.get_or_encode(
+            _MossLocalReferenceInput("data_uri", str(ref_audio), raw),
+            desc="data-URI",
+        )
 
-        def _encode() -> torch.Tensor:
-            # Note(Jiaxin): the duration check runs inside the leader (not before
-            # inflight registration like the file path) so concurrent same-payload
-            # requests share one sf.read of a potentially large decoded buffer.
-            wav, sample_rate = _BatchedReferenceEncoder._decode_data_uri_audio(raw)
-            return self._encoder.encode_wav(wav, sample_rate)
-
-        return self._cached_encode(key, _encode, desc="data-URI")
-
-    def stats(self) -> dict:
-        with self._lock:
-            return {
-                "hits": self._hits,
-                "misses": self._misses,
-                "merged": self._merged,
-                "entries": len(self._cache._cache),
-                "bytes": self._cache.current_bytes,
-            }
+    def stats(self) -> dict[str, int]:
+        return self._service.stats()
 
 
 def create_preprocessing_executor(
@@ -562,17 +506,6 @@ def create_preprocessing_executor(
     ref_audio_cache_max_items: int = 8192,
     ref_audio_cache_max_bytes: int = 64 * 1024 * 1024,
 ) -> SimpleScheduler:
-    # MOSS_REF_AUDIO_CACHE=0 disables the cache at startup (ops kill switch / A-B
-    # toggle) without a config edit; unset => kwarg default.
-    env_toggle = os.environ.get("MOSS_REF_AUDIO_CACHE")
-    if env_toggle is not None:
-        ref_audio_cache = env_toggle.strip().lower() not in (
-            "0",
-            "false",
-            "no",
-            "off",
-            "",
-        )
     device = _resolve_codec_device(device, gpu_id)
     processor = _load_moss_tts_local_processor(model_path)
     audio_tokenizer = load_moss_tts_local_audio_tokenizer(
@@ -586,8 +519,9 @@ def create_preprocessing_executor(
         max_batch_wait_ms=encode_batch_wait_ms,
     )
     if ref_audio_cache:
-        reference_encoder = CachedReferenceEncoder(
+        reference_encoder = _MossLocalReferenceEncoder(
             reference_encoder,
+            n_vq=int(processor.model_config.n_vq),
             max_items=ref_audio_cache_max_items,
             max_bytes=ref_audio_cache_max_bytes,
         )

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -7,6 +7,7 @@ import base64
 import concurrent.futures
 import io
 import logging
+import os
 import queue
 import threading
 from dataclasses import dataclass
@@ -506,6 +507,17 @@ def create_preprocessing_executor(
     ref_audio_cache_max_items: int = 8192,
     ref_audio_cache_max_bytes: int = 64 * 1024 * 1024,
 ) -> SimpleScheduler:
+    # MOSS_REF_AUDIO_CACHE=0 disables the cache at startup (ops kill switch / A-B
+    # toggle) without a config edit; unset => kwarg/config default.
+    env_toggle = os.environ.get("MOSS_REF_AUDIO_CACHE")
+    if env_toggle is not None:
+        ref_audio_cache = env_toggle.strip().lower() not in (
+            "0",
+            "false",
+            "no",
+            "off",
+            "",
+        )
     device = _resolve_codec_device(device, gpu_id)
     processor = _load_moss_tts_local_processor(model_path)
     audio_tokenizer = load_moss_tts_local_audio_tokenizer(

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -465,8 +465,8 @@ class _MossLocalReferenceEncoder:
         encoder: _BatchedReferenceEncoder,
         *,
         n_vq: int,
-        max_items: int,
-        max_bytes: int,
+        max_items: int | None = 256,
+        max_bytes: int | None = 64 * 1024 * 1024,
     ) -> None:
         self._service = ReferenceEncodeService(
             _MossLocalReferenceEncodeHook(encoder, n_vq=n_vq),

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -133,7 +133,6 @@ class Qwen3TTSPreparedRequest:
 class Qwen3TTSPreprocessingContext:
     model: Any
     wrapper: Any
-    adhoc_reference_service: ReferenceEncodeService | None = None
 
 
 _PREPROCESSING_CONTEXT: Qwen3TTSPreprocessingContext | None = None
@@ -148,11 +147,10 @@ def set_qwen3_tts_preprocessing_context(*, model: Any, wrapper: Any) -> None:
 
     global _PREPROCESSING_CONTEXT
     with _PREPARED_REQUESTS_LOCK:
-        service = _get_qwen3_tts_adhoc_reference_service_locked(model, wrapper)
+        _get_qwen3_tts_adhoc_reference_service_locked(model, wrapper)
         _PREPROCESSING_CONTEXT = Qwen3TTSPreprocessingContext(
             model=model,
             wrapper=wrapper,
-            adhoc_reference_service=service,
         )
         _PREPARED_REQUESTS.clear()
 

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import threading
 import time
 from dataclasses import dataclass, field
@@ -20,9 +21,18 @@ from sglang_omni.sampling.seed import (
     new_random_sampling_seed,
 )
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
+from sglang_omni.scheduling.reference_encoder import (
+    ReferenceEncodeHook,
+    ReferenceEncodeKey,
+    ReferenceEncodeService,
+)
 from sglang_omni.scheduling.speaker_cache import (
     SpeakerCacheKey,
     get_speaker_artifact_cache,
+)
+from sglang_omni.preprocessing.cache_key import (
+    hash_bytes as _hash_bytes,
+    reference_path_cache_key as _reference_path_cache_key,
 )
 from sglang_omni.utils.audio_payload import audio_data_uri_from_reference
 
@@ -123,10 +133,13 @@ class Qwen3TTSPreparedRequest:
 class Qwen3TTSPreprocessingContext:
     model: Any
     wrapper: Any
+    adhoc_reference_service: ReferenceEncodeService | None = None
 
 
 _PREPROCESSING_CONTEXT: Qwen3TTSPreprocessingContext | None = None
 _PREPARED_REQUESTS: dict[str, Qwen3TTSPreparedRequest] = {}
+_ADHOC_REFERENCE_SERVICE: ReferenceEncodeService | None = None
+_ADHOC_REFERENCE_SERVICE_OWNER: tuple[int, int] | None = None
 _PREPARED_REQUESTS_LOCK = threading.Lock()
 
 
@@ -135,9 +148,11 @@ def set_qwen3_tts_preprocessing_context(*, model: Any, wrapper: Any) -> None:
 
     global _PREPROCESSING_CONTEXT
     with _PREPARED_REQUESTS_LOCK:
+        service = _get_qwen3_tts_adhoc_reference_service_locked(model, wrapper)
         _PREPROCESSING_CONTEXT = Qwen3TTSPreprocessingContext(
             model=model,
             wrapper=wrapper,
+            adhoc_reference_service=service,
         )
         _PREPARED_REQUESTS.clear()
 
@@ -145,9 +160,12 @@ def set_qwen3_tts_preprocessing_context(*, model: Any, wrapper: Any) -> None:
 def clear_qwen3_tts_preprocessing_context() -> None:
     """Clear Qwen3-TTS preprocessing globals, mainly for tests and reloads."""
 
+    global _ADHOC_REFERENCE_SERVICE, _ADHOC_REFERENCE_SERVICE_OWNER
     global _PREPROCESSING_CONTEXT
     with _PREPARED_REQUESTS_LOCK:
         _PREPROCESSING_CONTEXT = None
+        _ADHOC_REFERENCE_SERVICE = None
+        _ADHOC_REFERENCE_SERVICE_OWNER = None
         _PREPARED_REQUESTS.clear()
 
 
@@ -546,6 +564,171 @@ def _qwen3_tts_voice_prompt_from_cache(
     return prompt, str(ref_text) if ref_text is not None else None
 
 
+@dataclass(frozen=True)
+class _Qwen3TTSAdhocReferenceInput:
+    ref_audio: Any
+    ref_text: str | None
+    x_vector_only_mode: bool
+
+
+class _Qwen3TTSAdhocReferenceHook(
+    ReferenceEncodeHook[
+        _Qwen3TTSAdhocReferenceInput,
+        tuple[dict[str, Any], str | None],
+        dict[str, Any],
+    ]
+):
+    def __init__(self, *, model: Any, wrapper: Any) -> None:
+        self._model = model
+        self._wrapper = wrapper
+        self._model_revision = _qwen3_tts_model_revision(model, wrapper)
+        self._encoder_config_hash = _qwen3_tts_encoder_config_hash(model, wrapper)
+
+    def normalize_input(self, raw_input: Any) -> _Qwen3TTSAdhocReferenceInput:
+        if isinstance(raw_input, _Qwen3TTSAdhocReferenceInput):
+            return raw_input
+        if not isinstance(raw_input, Qwen3TTSState):
+            raise TypeError("Qwen3-TTS ad-hoc reference input must be a state")
+        return _Qwen3TTSAdhocReferenceInput(
+            ref_audio=raw_input.ref_audio,
+            ref_text=raw_input.ref_text,
+            x_vector_only_mode=raw_input.x_vector_only_mode,
+        )
+
+    def cache_key(
+        self, item: _Qwen3TTSAdhocReferenceInput
+    ) -> ReferenceEncodeKey | None:
+        input_key = _qwen3_tts_ref_audio_input_key(item.ref_audio)
+        if input_key is None:
+            return None
+        options_key = json.dumps(
+            {
+                "ref_text": item.ref_text,
+                "x_vector_only_mode": bool(item.x_vector_only_mode),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return ReferenceEncodeKey(
+            model_id="qwen3_tts",
+            model_revision=self._model_revision,
+            encoder_id="qwen3_tts_voice_clone_prompt",
+            encoder_config_hash=self._encoder_config_hash,
+            artifact_kind="qwen3_tts_voice_clone_prompt_adhoc",
+            input_key=input_key,
+            options_key=options_key,
+        )
+
+    def encode_one(
+        self, item: _Qwen3TTSAdhocReferenceInput
+    ) -> tuple[dict[str, Any], str | None]:
+        with torch.no_grad():
+            prompt_items = self._wrapper.create_voice_clone_prompt(
+                ref_audio=item.ref_audio,
+                ref_text=item.ref_text,
+                x_vector_only_mode=item.x_vector_only_mode,
+            )
+        if len(prompt_items) != 1:
+            raise ValueError("Qwen3-TTS expects exactly one voice-clone prompt")
+        voice_clone_prompt = self._wrapper._prompt_items_to_voice_clone_prompt(
+            prompt_items
+        )
+        return voice_clone_prompt, prompt_items[0].ref_text
+
+    def store_artifact(self, artifact: tuple[dict[str, Any], str | None]) -> dict:
+        voice_clone_prompt, ref_text = artifact
+        return _cacheable_qwen3_tts_voice_prompt(
+            voice_clone_prompt,
+            ref_text=ref_text,
+        )
+
+    def load_artifact(
+        self, stored: dict[str, Any]
+    ) -> tuple[dict[str, Any], str | None]:
+        cached_prompt = _qwen3_tts_voice_prompt_from_cache(stored)
+        if cached_prompt is None:
+            raise RuntimeError("Qwen3-TTS ad-hoc reference cache entry is invalid")
+        return cached_prompt
+
+    def revalidate(
+        self,
+        item: _Qwen3TTSAdhocReferenceInput,
+        key: ReferenceEncodeKey,
+    ) -> bool:
+        current_key = _qwen3_tts_ref_audio_input_key(item.ref_audio)
+        return current_key == key.input_key
+
+
+def _qwen3_tts_ref_audio_input_key(ref_audio: Any) -> str | None:
+    if isinstance(ref_audio, str):
+        if ref_audio.startswith("data:"):
+            return f"data:{_hash_bytes(ref_audio.encode('utf-8'))}"
+        return _reference_path_cache_key(ref_audio, trust_stat=False)
+    if isinstance(ref_audio, bytes | bytearray | memoryview):
+        return f"bytes:{_hash_bytes(ref_audio)}"
+    if isinstance(ref_audio, dict):
+        data_uri = audio_data_uri_from_reference(ref_audio)
+        if data_uri is not None:
+            return f"data:{_hash_bytes(data_uri.encode('utf-8'))}"
+    return None
+
+
+def _qwen3_tts_model_revision(model: Any, wrapper: Any) -> str:
+    processor = getattr(wrapper, "processor", None)
+    candidates = (
+        getattr(model, "name_or_path", None),
+        getattr(getattr(model, "config", None), "_name_or_path", None),
+        getattr(getattr(model, "config", None), "name_or_path", None),
+        getattr(processor, "name_or_path", None),
+        getattr(processor, "_name_or_path", None),
+    )
+    for candidate in candidates:
+        if candidate:
+            return str(candidate)
+    return type(model).__module__ + "." + type(model).__qualname__
+
+
+def _qwen3_tts_encoder_config_hash(model: Any, wrapper: Any) -> str:
+    processor = getattr(wrapper, "processor", None)
+    parts = [
+        type(model).__module__ + "." + type(model).__qualname__,
+        type(wrapper).__module__ + "." + type(wrapper).__qualname__,
+        type(processor).__module__ + "." + type(processor).__qualname__,
+        str(getattr(processor, "name_or_path", "")),
+        str(getattr(processor, "_name_or_path", "")),
+    ]
+    return _hash_bytes("|".join(parts).encode("utf-8"))
+
+
+def _get_qwen3_tts_adhoc_reference_service_locked(
+    model: Any,
+    wrapper: Any,
+) -> ReferenceEncodeService:
+    global _ADHOC_REFERENCE_SERVICE, _ADHOC_REFERENCE_SERVICE_OWNER
+    owner = (id(model), id(wrapper))
+    if (
+        _ADHOC_REFERENCE_SERVICE is None
+        or _ADHOC_REFERENCE_SERVICE_OWNER != owner
+    ):
+        _ADHOC_REFERENCE_SERVICE = ReferenceEncodeService(
+            _Qwen3TTSAdhocReferenceHook(model=model, wrapper=wrapper),
+            max_items=256,
+            max_bytes=64 * 1024 * 1024,
+            timeout_s=130.0,
+            log_prefix="Qwen3-TTS ad-hoc reference",
+        )
+        _ADHOC_REFERENCE_SERVICE_OWNER = owner
+    return _ADHOC_REFERENCE_SERVICE
+
+
+def _get_qwen3_tts_adhoc_reference_service(
+    model: Any,
+    wrapper: Any,
+) -> ReferenceEncodeService:
+    with _PREPARED_REQUESTS_LOCK:
+        return _get_qwen3_tts_adhoc_reference_service_locked(model, wrapper)
+
+
 def _normalized_model_type(model: Any) -> str:
     model_type = getattr(model, "tts_model_type", None)
     if model_type is None:
@@ -597,6 +780,12 @@ def _prepare_qwen3_tts_base_request(
     )
     if cached_prompt is not None:
         voice_clone_prompt, ref_text = cached_prompt
+    elif cache_key is None:
+        reference_service = _get_qwen3_tts_adhoc_reference_service(model, wrapper)
+        voice_clone_prompt, ref_text = reference_service.get_or_encode(
+            state,
+            desc="Qwen3-TTS ad-hoc reference",
+        )
     else:
         with torch.no_grad():
             prompt_items = wrapper.create_voice_clone_prompt(
@@ -608,14 +797,13 @@ def _prepare_qwen3_tts_base_request(
             raise ValueError("Qwen3-TTS expects exactly one voice-clone prompt")
         voice_clone_prompt = wrapper._prompt_items_to_voice_clone_prompt(prompt_items)
         ref_text = prompt_items[0].ref_text
-        if cache_key is not None:
-            speaker_cache.put(
-                cache_key,
-                _cacheable_qwen3_tts_voice_prompt(
-                    voice_clone_prompt,
-                    ref_text=ref_text,
-                ),
-            )
+        speaker_cache.put(
+            cache_key,
+            _cacheable_qwen3_tts_voice_prompt(
+                voice_clone_prompt,
+                ref_text=ref_text,
+            ),
+        )
 
     input_id = wrapper._tokenize_texts([wrapper._build_assistant_text(state.text)])[0]
     ref_id = (

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -14,25 +14,25 @@ import torch
 
 from sglang_omni.models.qwen3_omni.pending_text_queue import PendingTextTensorQueue
 from sglang_omni.models.qwen3_tts.payload_types import Qwen3TTSState
+from sglang_omni.preprocessing.cache_key import hash_bytes as _hash_bytes
+from sglang_omni.preprocessing.cache_key import (
+    reference_path_cache_key as _reference_path_cache_key,
+)
 from sglang_omni.proto import StagePayload
 from sglang_omni.sampling.seed import (
     SAMPLING_SEED_MASK,
     derive_sampling_seed,
     new_random_sampling_seed,
 )
-from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
 from sglang_omni.scheduling.reference_encoder import (
     ReferenceEncodeHook,
     ReferenceEncodeKey,
     ReferenceEncodeService,
 )
+from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
 from sglang_omni.scheduling.speaker_cache import (
     SpeakerCacheKey,
     get_speaker_artifact_cache,
-)
-from sglang_omni.preprocessing.cache_key import (
-    hash_bytes as _hash_bytes,
-    reference_path_cache_key as _reference_path_cache_key,
 )
 from sglang_omni.utils.audio_payload import audio_data_uri_from_reference
 
@@ -706,10 +706,7 @@ def _get_qwen3_tts_adhoc_reference_service_locked(
 ) -> ReferenceEncodeService:
     global _ADHOC_REFERENCE_SERVICE, _ADHOC_REFERENCE_SERVICE_OWNER
     owner = (id(model), id(wrapper))
-    if (
-        _ADHOC_REFERENCE_SERVICE is None
-        or _ADHOC_REFERENCE_SERVICE_OWNER != owner
-    ):
+    if _ADHOC_REFERENCE_SERVICE is None or _ADHOC_REFERENCE_SERVICE_OWNER != owner:
         _ADHOC_REFERENCE_SERVICE = ReferenceEncodeService(
             _Qwen3TTSAdhocReferenceHook(model=model, wrapper=wrapper),
             max_items=256,

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -137,9 +137,9 @@ class Qwen3TTSPreprocessingContext:
 
 _PREPROCESSING_CONTEXT: Qwen3TTSPreprocessingContext | None = None
 _PREPARED_REQUESTS: dict[str, Qwen3TTSPreparedRequest] = {}
-_ADHOC_REFERENCE_SERVICE_ENTRY: tuple[
-    tuple[int, int], ReferenceEncodeService
-] | None = None
+_ADHOC_REFERENCE_SERVICE_ENTRY: (
+    tuple[tuple[int, int], ReferenceEncodeService] | None
+) = None
 _PREPARED_REQUESTS_LOCK = threading.Lock()
 
 

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -137,8 +137,9 @@ class Qwen3TTSPreprocessingContext:
 
 _PREPROCESSING_CONTEXT: Qwen3TTSPreprocessingContext | None = None
 _PREPARED_REQUESTS: dict[str, Qwen3TTSPreparedRequest] = {}
-_ADHOC_REFERENCE_SERVICE: ReferenceEncodeService | None = None
-_ADHOC_REFERENCE_SERVICE_OWNER: tuple[int, int] | None = None
+_ADHOC_REFERENCE_SERVICE_ENTRY: tuple[
+    tuple[int, int], ReferenceEncodeService
+] | None = None
 _PREPARED_REQUESTS_LOCK = threading.Lock()
 
 
@@ -158,12 +159,11 @@ def set_qwen3_tts_preprocessing_context(*, model: Any, wrapper: Any) -> None:
 def clear_qwen3_tts_preprocessing_context() -> None:
     """Clear Qwen3-TTS preprocessing globals, mainly for tests and reloads."""
 
-    global _ADHOC_REFERENCE_SERVICE, _ADHOC_REFERENCE_SERVICE_OWNER
+    global _ADHOC_REFERENCE_SERVICE_ENTRY
     global _PREPROCESSING_CONTEXT
     with _PREPARED_REQUESTS_LOCK:
         _PREPROCESSING_CONTEXT = None
-        _ADHOC_REFERENCE_SERVICE = None
-        _ADHOC_REFERENCE_SERVICE_OWNER = None
+        _ADHOC_REFERENCE_SERVICE_ENTRY = None
         _PREPARED_REQUESTS.clear()
 
 
@@ -702,18 +702,20 @@ def _get_qwen3_tts_adhoc_reference_service_locked(
     model: Any,
     wrapper: Any,
 ) -> ReferenceEncodeService:
-    global _ADHOC_REFERENCE_SERVICE, _ADHOC_REFERENCE_SERVICE_OWNER
+    global _ADHOC_REFERENCE_SERVICE_ENTRY
     owner = (id(model), id(wrapper))
-    if _ADHOC_REFERENCE_SERVICE is None or _ADHOC_REFERENCE_SERVICE_OWNER != owner:
-        _ADHOC_REFERENCE_SERVICE = ReferenceEncodeService(
+    entry = _ADHOC_REFERENCE_SERVICE_ENTRY
+    if entry is None or entry[0] != owner:
+        service = ReferenceEncodeService(
             _Qwen3TTSAdhocReferenceHook(model=model, wrapper=wrapper),
             max_items=256,
             max_bytes=64 * 1024 * 1024,
             timeout_s=130.0,
             log_prefix="Qwen3-TTS ad-hoc reference",
         )
-        _ADHOC_REFERENCE_SERVICE_OWNER = owner
-    return _ADHOC_REFERENCE_SERVICE
+        entry = (owner, service)
+        _ADHOC_REFERENCE_SERVICE_ENTRY = entry
+    return entry[1]
 
 
 def _get_qwen3_tts_adhoc_reference_service(

--- a/sglang_omni/scheduling/reference_encoder.py
+++ b/sglang_omni/scheduling/reference_encoder.py
@@ -56,6 +56,18 @@ class ReferenceEncodeHook(Generic[InputT, ArtifactT, StoredT]):
         return [self.encode_one(item) for item in items]
 
 
+def _fresh_exception(exc: BaseException) -> BaseException:
+    try:
+        fresh = type(exc)(*getattr(exc, "args", ()))
+    except Exception:
+        fresh = RuntimeError(str(exc))
+    for note in getattr(exc, "__notes__", ()):
+        add_note = getattr(fresh, "add_note", None)
+        if callable(add_note):
+            add_note(note)
+    return fresh
+
+
 class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
     _LOG_INTERVAL_S = 60.0
 
@@ -127,7 +139,7 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
                 raise
             except BaseException as exc:
                 self._add_exception_note(exc, desc)
-                raise
+                raise _fresh_exception(exc) from exc
             return self._hook.load_artifact(stored)
 
         assert leader_fut is not None

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -746,7 +746,7 @@ def _payload(text: str = "hello") -> StagePayload:
     )
 
 
-def test_create_preprocessing_executor_env_toggle(monkeypatch):
+def test_create_preprocessing_executor_explicit_cache_toggle(monkeypatch):
     from sglang_omni.models.moss_tts_local import request_builders as rb
     from sglang_omni.models.moss_tts_local import stages
 
@@ -764,20 +764,20 @@ def test_create_preprocessing_executor_env_toggle(monkeypatch):
         lambda *a, **k: _FakeAudioTokenizer(),
     )
 
-    # MOSS_REF_AUDIO_CACHE=0 disables the wrapper at startup (kill switch).
-    monkeypatch.setenv("MOSS_REF_AUDIO_CACHE", "0")
-    stages.create_preprocessing_executor("model", device="cpu")
+    stages.create_preprocessing_executor(
+        "model",
+        device="cpu",
+        ref_audio_cache=False,
+    )
     assert not isinstance(
-        rb._PREPROCESSING_CONTEXT.reference_encoder, stages.CachedReferenceEncoder
+        rb._PREPROCESSING_CONTEXT.reference_encoder, stages._MossLocalReferenceEncoder
     )
 
-    # Unset -> kwarg default (True) -> wrapped.
-    monkeypatch.delenv("MOSS_REF_AUDIO_CACHE")
     stages.create_preprocessing_executor("model", device="cpu")
     assert isinstance(
-        rb._PREPROCESSING_CONTEXT.reference_encoder, stages.CachedReferenceEncoder
+        rb._PREPROCESSING_CONTEXT.reference_encoder, stages._MossLocalReferenceEncoder
     )
-    assert rb._PREPROCESSING_CONTEXT.reference_encoder._cache.max_size == 8192
+    assert rb._PREPROCESSING_CONTEXT.reference_encoder._service._cache.max_size == 8192
 
 
 def test_create_preprocessing_executor_uses_model_config_codec_path(monkeypatch):
@@ -1153,7 +1153,7 @@ def test_batched_reference_encoder_mixes_path_and_waveform_jobs():
     assert calls[0] == [2, 5]
 
 
-# CachedReferenceEncoder
+# _MossLocalReferenceEncoder
 
 
 def test_cached_reference_encoder_on_off_hit_bit_identical(tmp_path):
@@ -1165,7 +1165,7 @@ def test_cached_reference_encoder_on_off_hit_bit_identical(tmp_path):
     from sglang_omni.models.moss_tts_local.request_builders import (
         _prepare_moss_tts_local_request,
     )
-    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     ref_file = tmp_path / "ref.wav"
     ref_file.write_bytes(b"fake wav bytes for T5")
@@ -1222,8 +1222,10 @@ def test_cached_reference_encoder_on_off_hit_bit_identical(tmp_path):
     )
     assert encode_count == 1
 
-    # ON-miss: first call to CachedReferenceEncoder (cache empty)
-    cached_enc = CachedReferenceEncoder(fake_batched, max_items=256, max_bytes=64 << 20)
+    # ON-miss: first call to _MossLocalReferenceEncoder (cache empty)
+    cached_enc = _MossLocalReferenceEncoder(
+        fake_batched, n_vq=N_VQ, max_items=256, max_bytes=64 << 20
+    )
     encode_count = 0
     prepared_miss = _prepare_moss_tts_local_request(
         _ref_payload("t5-miss"), processor=processor, reference_encoder=cached_enc
@@ -1250,7 +1252,7 @@ def test_cached_reference_encoder_on_off_hit_bit_identical(tmp_path):
 
 def test_cached_reference_encoder_lru_eviction(tmp_path):
     """T3: LRU eviction by item count and by byte budget."""
-    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     encode_log = []
 
@@ -1260,7 +1262,9 @@ def test_cached_reference_encoder_lru_eviction(tmp_path):
             return torch.full((2, N_VQ), ord(path[-1]), dtype=torch.long)
 
     # --- item-count eviction: max_items=2, insert 3 ---
-    enc = CachedReferenceEncoder(_FakeBatched(), max_items=2, max_bytes=64 << 20)
+    enc = _MossLocalReferenceEncoder(
+        _FakeBatched(), n_vq=N_VQ, max_items=2, max_bytes=64 << 20
+    )
     files = [tmp_path / f"{c}.wav" for c in "abc"]
     for i, f in enumerate(files):
         f.write_bytes(bytes([i + 1]) * 16)  # distinct content → distinct cache keys
@@ -1276,7 +1280,9 @@ def test_cached_reference_encoder_lru_eviction(tmp_path):
 
     # --- byte-budget eviction: each entry is 2*12*4=96 bytes as int32 ---
     entry_bytes = 2 * N_VQ * 4  # int32
-    enc2 = CachedReferenceEncoder(_FakeBatched(), max_items=1000, max_bytes=entry_bytes)
+    enc2 = _MossLocalReferenceEncoder(
+        _FakeBatched(), n_vq=N_VQ, max_items=1000, max_bytes=entry_bytes
+    )
     f1, f2 = tmp_path / "d.wav", tmp_path / "e.wav"
     f1.write_bytes(b"y" * 16)
     f2.write_bytes(b"z" * 16)
@@ -1290,7 +1296,9 @@ def test_cached_reference_encoder_lru_eviction(tmp_path):
     assert len(encode_log) == 1
 
     # --- oversized entry is gracefully rejected, does not crash ---
-    enc3 = CachedReferenceEncoder(_FakeBatched(), max_items=10, max_bytes=1)
+    enc3 = _MossLocalReferenceEncoder(
+        _FakeBatched(), n_vq=N_VQ, max_items=10, max_bytes=1
+    )
     f3 = tmp_path / "big.wav"
     f3.write_bytes(b"big" * 16)
     result = enc3.encode(str(f3))
@@ -1299,18 +1307,18 @@ def test_cached_reference_encoder_lru_eviction(tmp_path):
 
 def test_cached_reference_encoder_rejects_nonpositive_capacity():
     """Negative/zero capacities fail fast at construction (P3, review)."""
-    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     class _FakeBatched:
         def encode(self, path: str) -> torch.Tensor:
             return torch.zeros((2, N_VQ), dtype=torch.long)
 
     with pytest.raises(ValueError, match="max_items"):
-        CachedReferenceEncoder(_FakeBatched(), max_items=-1)
+        _MossLocalReferenceEncoder(_FakeBatched(), n_vq=N_VQ, max_items=-1)
     with pytest.raises(ValueError, match="max_items"):
-        CachedReferenceEncoder(_FakeBatched(), max_items=0)
+        _MossLocalReferenceEncoder(_FakeBatched(), n_vq=N_VQ, max_items=0)
     with pytest.raises(ValueError, match="max_bytes"):
-        CachedReferenceEncoder(_FakeBatched(), max_bytes=0)
+        _MossLocalReferenceEncoder(_FakeBatched(), n_vq=N_VQ, max_bytes=0)
 
 
 def test_cached_reference_encoder_true_concurrency_dedup(tmp_path):
@@ -1319,7 +1327,7 @@ def test_cached_reference_encoder_true_concurrency_dedup(tmp_path):
     """
     import threading as _threading
 
-    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     ref = tmp_path / "ref.wav"
     ref.write_bytes(b"concurrent test")
@@ -1335,7 +1343,9 @@ def test_cached_reference_encoder_true_concurrency_dedup(tmp_path):
             return torch.full((5, N_VQ), 42, dtype=torch.long)
 
     N = 8
-    enc = CachedReferenceEncoder(_GatedBatched(), max_items=256, max_bytes=64 << 20)
+    enc = _MossLocalReferenceEncoder(
+        _GatedBatched(), n_vq=N_VQ, max_items=256, max_bytes=64 << 20
+    )
     results = [None] * N
     errors = []
 
@@ -1377,7 +1387,7 @@ def test_cached_reference_encoder_failure_does_not_poison(tmp_path):
     """
     import threading as _threading
 
-    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     ref = tmp_path / "flaky.wav"
     ref.write_bytes(b"flaky")
@@ -1394,7 +1404,9 @@ def test_cached_reference_encoder_failure_does_not_poison(tmp_path):
                 raise RuntimeError("transient encode failure")
             return torch.full((3, N_VQ), 7, dtype=torch.long)
 
-    enc = CachedReferenceEncoder(_FlakyBatched(), max_items=256, max_bytes=64 << 20)
+    enc = _MossLocalReferenceEncoder(
+        _FlakyBatched(), n_vq=N_VQ, max_items=256, max_bytes=64 << 20
+    )
     exc_results = [None, None]
 
     def fail_worker(idx):
@@ -1422,7 +1434,7 @@ def test_cached_reference_encoder_failure_does_not_poison(tmp_path):
     # Cache not poisoned
     assert enc.stats()["entries"] == 0
     # inflight cleared
-    assert len(enc._inflight) == 0
+    assert len(enc._service._inflight) == 0
 
     # Third request succeeds (new leader)
     gate.clear()
@@ -1434,7 +1446,7 @@ def test_cached_reference_encoder_failure_does_not_poison(tmp_path):
 
 def test_cached_reference_encoder_return_value_isolation(tmp_path):
     """T7: mutating the returned tensor does not corrupt the cached copy."""
-    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     ref = tmp_path / "iso.wav"
     ref.write_bytes(b"isolation test")
@@ -1443,7 +1455,9 @@ def test_cached_reference_encoder_return_value_isolation(tmp_path):
         def encode(self, path: str) -> torch.Tensor:
             return torch.full((4, N_VQ), 99, dtype=torch.long)
 
-    enc = CachedReferenceEncoder(_FakeBatched(), max_items=256, max_bytes=64 << 20)
+    enc = _MossLocalReferenceEncoder(
+        _FakeBatched(), n_vq=N_VQ, max_items=256, max_bytes=64 << 20
+    )
     enc.encode(str(ref))  # miss — populates cache
 
     hit1 = enc.encode(str(ref))  # first hit
@@ -1457,7 +1471,7 @@ def test_cached_reference_encoder_duration_gate(tmp_path, monkeypatch):
     """T8: references over 100 s are rejected before touching the cache."""
     torchaudio = pytest.importorskip("torchaudio")
 
-    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     ref = tmp_path / "long.wav"
     ref.write_bytes(b"fake long audio")
@@ -1476,16 +1490,18 @@ def test_cached_reference_encoder_duration_gate(tmp_path, monkeypatch):
 
     monkeypatch.setattr(torchaudio, "info", lambda path: _FakeInfo(), raising=False)
 
-    enc = CachedReferenceEncoder(_FakeBatched(), max_items=256, max_bytes=64 << 20)
+    enc = _MossLocalReferenceEncoder(
+        _FakeBatched(), n_vq=N_VQ, max_items=256, max_bytes=64 << 20
+    )
 
-    # _BatchedReferenceEncoder.encode checks duration before enqueuing; CachedReferenceEncoder
-    # calls through to the underlying encoder so the duration check still fires.
+    # _BatchedReferenceEncoder.encode checks duration before enqueuing;
+    # _MossLocalReferenceEncoder calls through so the duration check still fires.
     with pytest.raises(ValueError, match="100"):
         enc.encode(str(ref))
 
     assert encode_count == 0, "oversized reference must not reach the codec"
     assert enc.stats()["entries"] == 0
-    assert len(enc._inflight) == 0
+    assert len(enc._service._inflight) == 0
 
 
 # Data-URI reference path
@@ -1521,7 +1537,7 @@ def _make_wav_data_uri(
 
 def test_cached_reference_encoder_data_uri_hit_miss(tmp_path):
     """bytes: keyspace: same data-URI encoded twice -> one codec encode."""
-    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     pytest.importorskip("soundfile")
     data_uri, _ = _make_wav_data_uri()
@@ -1533,7 +1549,9 @@ def test_cached_reference_encoder_data_uri_hit_miss(tmp_path):
             wav_call_count += 1
             return torch.full((5, N_VQ), 42, dtype=torch.long)
 
-    enc = CachedReferenceEncoder(_FakeBatched(), max_items=256, max_bytes=64 << 20)
+    enc = _MossLocalReferenceEncoder(
+        _FakeBatched(), n_vq=N_VQ, max_items=256, max_bytes=64 << 20
+    )
     enc.encode_data_uri(data_uri)
     assert wav_call_count == 1, "first call must encode"
 
@@ -1575,7 +1593,7 @@ def test_uncached_data_uri_uses_reference_encoder():
 
 def test_cached_reference_encoder_file_bytes_keyspaces_do_not_collide(tmp_path):
     """file: and bytes: keys are independent; same-content file ≠ data-URI in cache."""
-    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     pytest.importorskip("soundfile")
     data_uri, raw = _make_wav_data_uri()
@@ -1597,7 +1615,9 @@ def test_cached_reference_encoder_file_bytes_keyspaces_do_not_collide(tmp_path):
             encode_count += 1
             return torch.full((5, N_VQ), 7, dtype=torch.long)
 
-    enc = CachedReferenceEncoder(_FakeBatched(), max_items=256, max_bytes=64 << 20)
+    enc = _MossLocalReferenceEncoder(
+        _FakeBatched(), n_vq=N_VQ, max_items=256, max_bytes=64 << 20
+    )
     enc.encode(str(ref_file))  # populates file: key
     enc.encode_data_uri(data_uri)  # must NOT hit file: entry
 
@@ -1611,7 +1631,7 @@ def test_cached_reference_encoder_data_uri_duration_gate():
     import base64
     import io
 
-    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     pytest.importorskip("soundfile")
     import soundfile as sf
@@ -1630,12 +1650,14 @@ def test_cached_reference_encoder_data_uri_duration_gate():
         def encode_wav(self, wav, sample_rate):
             return torch.zeros((5, N_VQ), dtype=torch.long)
 
-    enc = CachedReferenceEncoder(_FakeBatched(), max_items=256, max_bytes=64 << 20)
+    enc = _MossLocalReferenceEncoder(
+        _FakeBatched(), n_vq=N_VQ, max_items=256, max_bytes=64 << 20
+    )
     with pytest.raises(ValueError, match="100"):
         enc.encode_data_uri(uri)
 
     assert enc.stats()["entries"] == 0
-    assert len(enc._inflight) == 0
+    assert len(enc._service._inflight) == 0
 
 
 @pytest.mark.skipif(

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -1538,9 +1538,7 @@ def test_cached_reference_encoder_duration_gate(tmp_path, monkeypatch):
     assert len(enc._service._inflight) == 0
 
 
-def test_cached_reference_encoder_revalidate_skips_duration_gate(
-    tmp_path, monkeypatch
-):
+def test_cached_reference_encoder_revalidate_skips_duration_gate(tmp_path, monkeypatch):
     from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     ref = tmp_path / "ref.wav"

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -780,7 +780,7 @@ def _payload(text: str = "hello") -> StagePayload:
     )
 
 
-def test_create_preprocessing_executor_explicit_cache_toggle(monkeypatch):
+def test_create_preprocessing_executor_cache_toggles(monkeypatch):
     from sglang_omni.models.moss_tts_local import request_builders as rb
     from sglang_omni.models.moss_tts_local import stages
 
@@ -807,6 +807,13 @@ def test_create_preprocessing_executor_explicit_cache_toggle(monkeypatch):
         rb._PREPROCESSING_CONTEXT.reference_encoder, stages._MossLocalReferenceEncoder
     )
 
+    monkeypatch.setenv("MOSS_REF_AUDIO_CACHE", "0")
+    stages.create_preprocessing_executor("model", device="cpu")
+    assert not isinstance(
+        rb._PREPROCESSING_CONTEXT.reference_encoder, stages._MossLocalReferenceEncoder
+    )
+
+    monkeypatch.delenv("MOSS_REF_AUDIO_CACHE")
     stages.create_preprocessing_executor("model", device="cpu")
     assert isinstance(
         rb._PREPROCESSING_CONTEXT.reference_encoder, stages._MossLocalReferenceEncoder

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -395,6 +395,7 @@ def test_pipeline_stage_wiring():
     assert stages["preprocessing"].process == "pipeline"
     assert stages["preprocessing"].gpu == 0
     assert stages["preprocessing"].factory_args["device"] == "cuda:0"
+    assert stages["preprocessing"].factory_args["ref_audio_cache"] is True
     assert stages["preprocessing"].factory_args["ref_audio_cache_max_items"] == 8192
     assert config.supports_uploaded_voice_references() is True
     assert stages["tts_engine"].process == "pipeline"
@@ -431,6 +432,39 @@ def test_pipeline_stage_wiring():
     assert split_runtime.resources.total_gpu_memory_fraction is None
     assert split_runtime.sglang_server_args.mem_fraction_static == pytest.approx(0.85)
     assert split_stages["vocoder"].factory_args["device"] == "cuda:1"
+
+
+def test_pipeline_config_injects_reference_cache_factory_args():
+    config = MossTTSLocalPipelineConfig(
+        model_path="OpenMOSS-Team/moss-local-test",
+        ref_audio_cache=False,
+        ref_audio_cache_max_items=17,
+        ref_audio_cache_max_bytes=4096,
+    )
+    preprocessing = next(
+        stage
+        for stage in config.stages
+        if stage.factory.endswith("create_preprocessing_executor")
+    )
+
+    assert preprocessing.factory_args["ref_audio_cache"] is False
+    assert preprocessing.factory_args["ref_audio_cache_max_items"] == 17
+    assert preprocessing.factory_args["ref_audio_cache_max_bytes"] == 4096
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"ref_audio_cache_max_items": 0}, "ref_audio_cache_max_items"),
+        ({"ref_audio_cache_max_bytes": 0}, "ref_audio_cache_max_bytes"),
+    ],
+)
+def test_pipeline_config_rejects_invalid_reference_cache_settings(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        MossTTSLocalPipelineConfig(
+            model_path="OpenMOSS-Team/moss-local-test",
+            **kwargs,
+        )
 
 
 def _install_fake_moss_ar_factory(
@@ -1502,6 +1536,45 @@ def test_cached_reference_encoder_duration_gate(tmp_path, monkeypatch):
     assert encode_count == 0, "oversized reference must not reach the codec"
     assert enc.stats()["entries"] == 0
     assert len(enc._service._inflight) == 0
+
+
+def test_cached_reference_encoder_revalidate_skips_duration_gate(
+    tmp_path, monkeypatch
+):
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
+
+    ref = tmp_path / "ref.wav"
+    ref.write_bytes(b"revalidate reference")
+    info_calls = 0
+
+    class _FakeInfo:
+        num_frames = 48000
+        sample_rate = 48000
+
+    def info(path):
+        nonlocal info_calls
+        assert path == str(ref)
+        info_calls += 1
+        if info_calls > 1:
+            raise ValueError("duration gate should not run during revalidate")
+        return _FakeInfo()
+
+    monkeypatch.setitem(sys.modules, "torchaudio", types.SimpleNamespace(info=info))
+
+    class _FakeBatched:
+        def encode(self, path: str) -> torch.Tensor:
+            assert path == str(ref)
+            return torch.zeros((5, N_VQ), dtype=torch.long)
+
+    enc = _MossLocalReferenceEncoder(
+        _FakeBatched(), n_vq=N_VQ, max_items=256, max_bytes=64 << 20
+    )
+
+    result = enc.encode(str(ref))
+
+    assert torch.equal(result, torch.zeros((5, N_VQ), dtype=torch.long))
+    assert info_calls == 1
+    assert enc.stats()["entries"] == 1
 
 
 # Data-URI reference path

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -1455,7 +1455,7 @@ def test_qwen3_tts_preprocessing_abort_race_cleans_late_prepared_state(
     payload = make_payload(inputs="target")
     payload.request_id = request_id
     loop = asyncio.new_event_loop()
-    errors: list[BaseException] = []
+    errors: list[Exception] = []
 
     def run_compute() -> None:
         try:
@@ -1467,7 +1467,7 @@ def test_qwen3_tts_preprocessing_abort_race_cleans_late_prepared_state(
                 ),
                 loop,
             )
-        except BaseException as exc:
+        except Exception as exc:
             errors.append(exc)
 
     thread = threading.Thread(target=run_compute)

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -579,6 +579,193 @@ def test_qwen3_tts_uploaded_voice_clone_prompt_uses_shared_cache(
     assert calls == 3
 
 
+def test_qwen3_tts_adhoc_voice_clone_prompt_uses_reference_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = get_speaker_artifact_cache()
+    cache.clear()
+    qwen3_request_builders.clear_qwen3_tts_preprocessing_context()
+    calls = 0
+    data_uri = "data:audio/wav;base64,AAAA"
+
+    class FakePrompt:
+        def __init__(self, ref_text: str | None) -> None:
+            self.ref_text = ref_text
+
+    class FakeWrapper:
+        def create_voice_clone_prompt(self, **kwargs):
+            nonlocal calls
+            calls += 1
+            assert kwargs["ref_audio"] == data_uri
+            return [FakePrompt(kwargs["ref_text"])]
+
+        def _prompt_items_to_voice_clone_prompt(self, prompt_items):
+            return {
+                "ref_code": [torch.ones((1, 2), dtype=torch.long)],
+                "ref_spk_embedding": [torch.ones(4)],
+                "icl_mode": [True],
+            }
+
+        def _tokenize_texts(self, texts):
+            return [torch.arange(len(texts[0]), dtype=torch.long).unsqueeze(0)]
+
+        def _build_assistant_text(self, text):
+            return text
+
+        def _build_ref_text(self, text):
+            return text
+
+        def _merge_generate_kwargs(self, **kwargs):
+            return kwargs
+
+    class FakeModel:
+        device = torch.device("cpu")
+        root_config = SimpleNamespace(tts_pad_token_id=0)
+        model = SimpleNamespace(_feedback_buffer=torch.empty((1, 4)))
+
+        def build_voice_clone_inputs(self, **kwargs):
+            assert kwargs["voice_clone_prompt"]["icl_mode"] == [True]
+            return (
+                torch.ones((1, 2, 4)),
+                torch.ones((1, 2), dtype=torch.long),
+                torch.ones((1, 1, 4)),
+                None,
+            )
+
+        def get_text_embeddings(self):
+            return lambda ids: torch.ones((*ids.shape, 4), device=ids.device)
+
+        def text_projection(self, embeds):
+            return embeds
+
+    monkeypatch.setattr(
+        qwen3_request_builders,
+        "_build_qwen3_tts_pad_embed",
+        lambda model: torch.zeros(4),
+    )
+    model = FakeModel()
+    wrapper = FakeWrapper()
+
+    def make_adhoc_payload(**tts_params) -> StagePayload:
+        params = {
+            "ref_audio": data_uri,
+            "ref_text": "reference",
+        }
+        params.update(tts_params)
+        return make_payload(inputs="target", tts_params=params)
+
+    qwen3_request_builders._prepare_qwen3_tts_request(
+        make_adhoc_payload(),
+        model=model,
+        wrapper=wrapper,
+    )
+    qwen3_request_builders._prepare_qwen3_tts_request(
+        make_adhoc_payload(),
+        model=model,
+        wrapper=wrapper,
+    )
+    assert calls == 1
+    assert cache.stats()["entries"] == 0
+
+    qwen3_request_builders._prepare_qwen3_tts_request(
+        make_adhoc_payload(ref_text="different"),
+        model=model,
+        wrapper=wrapper,
+    )
+    qwen3_request_builders._prepare_qwen3_tts_request(
+        make_adhoc_payload(x_vector_only_mode=True),
+        model=model,
+        wrapper=wrapper,
+    )
+    assert calls == 3
+
+
+def test_qwen3_tts_adhoc_reference_failure_does_not_poison(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    qwen3_request_builders.clear_qwen3_tts_preprocessing_context()
+    data_uri = "data:audio/wav;base64,BBBB"
+
+    class FakePrompt:
+        ref_text = "reference"
+
+    class FakeWrapper:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def create_voice_clone_prompt(self, **kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("transient")
+            return [FakePrompt()]
+
+        def _prompt_items_to_voice_clone_prompt(self, prompt_items):
+            del prompt_items
+            return {
+                "ref_code": [torch.ones((1, 2), dtype=torch.long)],
+                "ref_spk_embedding": [torch.ones(4)],
+                "icl_mode": [True],
+            }
+
+        def _tokenize_texts(self, texts):
+            return [torch.arange(len(texts[0]), dtype=torch.long).unsqueeze(0)]
+
+        def _build_assistant_text(self, text):
+            return text
+
+        def _build_ref_text(self, text):
+            return text
+
+        def _merge_generate_kwargs(self, **kwargs):
+            return kwargs
+
+    class FakeModel:
+        device = torch.device("cpu")
+        root_config = SimpleNamespace(tts_pad_token_id=0)
+        model = SimpleNamespace(_feedback_buffer=torch.empty((1, 4)))
+
+        def build_voice_clone_inputs(self, **kwargs):
+            return (
+                torch.ones((1, 2, 4)),
+                torch.ones((1, 2), dtype=torch.long),
+                torch.ones((1, 1, 4)),
+                None,
+            )
+
+        def get_text_embeddings(self):
+            return lambda ids: torch.ones((*ids.shape, 4), device=ids.device)
+
+        def text_projection(self, embeds):
+            return embeds
+
+    monkeypatch.setattr(
+        qwen3_request_builders,
+        "_build_qwen3_tts_pad_embed",
+        lambda model: torch.zeros(4),
+    )
+
+    wrapper = FakeWrapper()
+    model = FakeModel()
+    payload = make_payload(
+        inputs="target",
+        tts_params={"ref_audio": data_uri, "ref_text": "reference"},
+    )
+
+    with pytest.raises(RuntimeError, match="transient"):
+        qwen3_request_builders._prepare_qwen3_tts_request(
+            payload,
+            model=model,
+            wrapper=wrapper,
+        )
+
+    qwen3_request_builders._prepare_qwen3_tts_request(
+        payload,
+        model=model,
+        wrapper=wrapper,
+    )
+    assert wrapper.calls == 2
+
+
 def test_qwen3_tts_uploaded_voice_x_vector_cache_omits_ref_code(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_test/scheduling/test_reference_encoder.py
+++ b/tests/unit_test/scheduling/test_reference_encoder.py
@@ -204,6 +204,7 @@ def test_exception_propagates_to_all_waiters_and_does_not_poison() -> None:
     assert all(str(error) == "boom" for error in errors)
     if hasattr(errors[0], "__notes__"):
         assert "Reference encode context: flaky" in errors[0].__notes__
+    assert len({id(error) for error in errors}) == len(errors)
     assert service.stats()["entries"] == 0
     result = service.get_or_encode("flaky")
     assert torch.equal(result, torch.tensor([9], dtype=torch.long))


### PR DESCRIPTION
## Motivation

Qwen3-TTS already separates uploaded voices through `SpeakerArtifactCache`, but ad-hoc `ref_audio` voice-clone prompts are recomputed on each request. This PR moves only the ad-hoc Base voice-clone prompt path onto M4a `ReferenceEncodeService` while preserving the registered/uploaded voice cache taxonomy.

## Module doc

- Lark design: https://osgbw74w8zwb.sg.larksuite.com/docx/PM8Ed39XAoHkLoxguvHlFiO5ghc
- Repo API doc: `docs/developer_reference/reference_encode_service.md`

## Issue

- #925

## Behavior class

Yellow. Output artifacts should remain equivalent, but repeated ad-hoc references can now hit the M4a cache or share an in-flight prompt build. Uploaded voice behavior remains on `SpeakerArtifactCache`.

## Old path deletion

Replaces the repeated ad-hoc `wrapper.create_voice_clone_prompt(...)` path in `sglang_omni/models/qwen3_tts/request_builders.py` for Base requests without `uploaded_voice_name` / `uploaded_voice_created_at`.

Uploaded voice prompt artifacts still use `_qwen3_tts_uploaded_voice_cache_key(...)` and `SpeakerArtifactCache`.

## Modifications

- Adds a Qwen3-TTS ad-hoc reference hook backed by `ReferenceEncodeService`.
- Keys ad-hoc artifacts by reference content identity, `ref_text`, `x_vector_only_mode`, model revision, and wrapper/processor identity.
- Reuses `_cacheable_qwen3_tts_voice_prompt(...)` and `_qwen3_tts_voice_prompt_from_cache(...)` for CPU-safe storage and caller-owned loads.
- Keeps remote or missing-path strings uncacheable unless they are materialized as data URIs or bytes-like inputs.

## Contract tests

- [x] `tests/unit_test/qwen3_tts/test_pipeline.py::test_qwen3_tts_uploaded_voice_clone_prompt_uses_shared_cache`
- [x] `tests/unit_test/qwen3_tts/test_pipeline.py::test_qwen3_tts_uploaded_voice_x_vector_cache_omits_ref_code`
- [x] `tests/unit_test/qwen3_tts/test_pipeline.py::test_qwen3_tts_adhoc_voice_clone_prompt_uses_reference_service`
- [x] `tests/unit_test/qwen3_tts/test_pipeline.py::test_qwen3_tts_adhoc_reference_failure_does_not_poison`
- [x] PR1 service contract tests remain the shared M4a contract coverage.

## Accuracy / perf gate

Rerun pending for latest head [#927@a22d236](https://github.com/sgl-project/sglang-omni/actions/runs/28754600725), pinned to the repo-supported `higgs` selector. An older run at `80f9464` passed unit tests after the follower-exception fix, but was cancelled by the latest push before ASR/TTS stages, so it is not a final perf gate.

| Model / selector | Mode | WER before -> after | QPS before -> after | Latency before -> after | RTF before -> after | Gate |
|---|---|---:|---:|---:|---:|---|
| Omni CI TTS (`higgs`) | non-stream | Pending latest head | Pending latest head | Pending latest head | Pending latest head | Pending |
| Omni CI TTS (`higgs`) | stream | Pending latest head | Pending latest head | Pending latest head | Pending latest head | Pending |

## Resolved comments

- #661: prove cache taxonomy instead of mixing registered voice and ad-hoc reference lifetimes.
- #809: keep Qwen3-TTS migration as a follow-up on the current M4 service, not the closed conflicting branch.
- M4 design: uploaded voice -> `SpeakerArtifactCache`; ad-hoc `ref_audio` -> `ReferenceEncodeService`.

## Validation

- [x] `python3 -m py_compile sglang_omni/scheduling/reference_encoder.py tests/unit_test/scheduling/test_reference_encoder.py sglang_omni/models/qwen3_tts/request_builders.py tests/unit_test/qwen3_tts/test_pipeline.py sglang_omni/models/moss_tts_local/stages.py tests/unit_test/moss_tts_local/test_pipeline.py`
- [x] `git diff --check`
- [ ] `python3 -m pytest tests/unit_test/qwen3_tts/test_pipeline.py tests/unit_test/scheduling/test_reference_encoder.py -q` (blocked locally: available Python environments lack `torch` and `pytest`)
- [ ] Omni CI TTS `higgs` accuracy/perf gate: [run 28754600725](https://github.com/sgl-project/sglang-omni/actions/runs/28754600725) pending latest head

## Checklist

- [ ] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the `run-ci` label. PRs targeting `main` re-trigger CI on each push while the label remains; this stacked PR is validated with `workflow_dispatch` because its base is #926. Current repo-supported TTS selectors are `higgs` and `moss`; use the `run-higgs` / `run-moss` labels or `workflow_dispatch` input `tts_ci_model=higgs|moss` to pin the TTS gate. Draft PRs are skipped even if labeled.
