### PR TITLE
[Misc]: Use direct access for strict fields

### DIFF
--- a/examples/run_ming_omni_server.py
+++ b/examples/run_ming_omni_server.py
@@ -195,7 +195,7 @@ def _launch_text_server(args: argparse.Namespace) -> None:
         relay_backend=args.relay_backend,
     )
 
-    if getattr(args, "thinker_only", False):
+    if args.thinker_only:
         if args.gpu_audio_encoder is not None or args.gpu_image_encoder is not None:
             raise ValueError(
                 "--gpu-audio-encoder/--gpu-image-encoder cannot be used "
@@ -213,10 +213,10 @@ def _launch_text_server(args: argparse.Namespace) -> None:
         server_arg_updates["disable_custom_all_reduce"] = True
     if args.gpu_audio_encoder is not None:
         _set_stage_gpu(config, "audio_encoder", args.gpu_audio_encoder)
-    image_encoder_tp = getattr(args, "image_encoder_tp", 1)
+    image_encoder_tp = args.image_encoder_tp
     if image_encoder_tp < 1:
         raise ValueError("--image-encoder-tp must be >= 1")
-    if image_encoder_tp > 1 and getattr(args, "thinker_only", False):
+    if image_encoder_tp > 1 and args.thinker_only:
         raise ValueError("--thinker-only cannot be used with --image-encoder-tp > 1")
     if image_encoder_tp > 1:
         if args.gpu_image_encoder is None:

--- a/examples/run_ming_omni_speech.py
+++ b/examples/run_ming_omni_speech.py
@@ -180,7 +180,7 @@ def _save_audio(result: dict, output_path: str) -> None:
         if isinstance(payload, dict):
             data = payload
         else:
-            data = getattr(payload, "data", None)
+            data = payload.data
         if not isinstance(data, dict):
             continue
         waveform = data.get("audio_waveform")

--- a/examples/run_ming_omni_speech_server.py
+++ b/examples/run_ming_omni_speech_server.py
@@ -176,7 +176,7 @@ def _launch_speech_server(args: argparse.Namespace) -> None:
 
     _validate_fraction("--mem-fraction-static", args.mem_fraction_static)
 
-    if getattr(args, "enable_streaming_tts", False):
+    if args.enable_streaming_tts:
         config = MingOmniStreamingSpeechPipelineConfig(
             model_path=args.model_path,
             relay_backend=args.relay_backend,
@@ -204,7 +204,7 @@ def _launch_speech_server(args: argparse.Namespace) -> None:
         server_arg_updates["disable_custom_all_reduce"] = True
     if args.mem_fraction_static is not None:
         server_arg_updates["mem_fraction_static"] = args.mem_fraction_static
-    if getattr(args, "cpu_offload_gb", None) is not None:
+    if args.cpu_offload_gb is not None:
         server_arg_updates["cpu_offload_gb"] = args.cpu_offload_gb
     if server_arg_updates:
         _apply_stage_factory_updates(

--- a/examples/run_qwen3_omni_speech.py
+++ b/examples/run_qwen3_omni_speech.py
@@ -169,7 +169,10 @@ def _save_audio(result: dict, output_path: str) -> None:
     import numpy as np
 
     for stage_name, payload in result.items():
-        data = getattr(payload, "data", None)
+        if isinstance(payload, dict):
+            data = payload
+        else:
+            data = payload.data
         if not isinstance(data, dict):
             continue
         waveform = data.get("audio_waveform")

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -6,7 +6,7 @@ from typing import Annotated, Literal, NoReturn
 import typer
 import yaml
 
-from sglang_omni.config import PipelineConfig
+from sglang_omni.config import PipelineConfig, StageConfig
 from sglang_omni.config.manager import ConfigManager
 from sglang_omni.preprocessing.resource_connector import (
     resolve_allowed_local_media_path,
@@ -480,8 +480,8 @@ def _validate_colocated_gpu_override(
         )
 
 
-def _stage_tp_gpu_ids(stage: object) -> list[int]:
-    gpu = getattr(stage, "gpu", None)
+def _stage_tp_gpu_ids(stage: StageConfig) -> list[int]:
+    gpu = stage.gpu
     if gpu is None:
         return []
     if isinstance(gpu, int):
@@ -511,7 +511,7 @@ def _gate_custom_all_reduce_on_topology(
     refined["disable_custom_all_reduce"] = False
     logger.info(
         "Enabling custom all-reduce for stage '%s': GPUs %s form a P2P mesh",
-        getattr(stage, "name", "?"),
+        stage.name,
         list(gpu_ids),
     )
     return refined

--- a/sglang_omni/config/runtime.py
+++ b/sglang_omni/config/runtime.py
@@ -10,8 +10,6 @@ from typing import Any
 from sglang_omni.config.schema import PipelineConfig, StageConfig
 from sglang_omni.utils.imports import import_string
 
-_MAPPED_STAGE_RUNTIME_FIELDS = ("max_seq_len", "video_fps")
-
 
 def resolve_stage_factory_args(
     stage_cfg: StageConfig,
@@ -149,8 +147,7 @@ def _validate_runtime_sources(
         runtime_overrides,
     )
 
-    for field_name in _MAPPED_STAGE_RUNTIME_FIELDS:
-        value = getattr(stage_cfg.runtime, field_name)
+    for field_name, value in _mapped_stage_runtime_values(stage_cfg).items():
         if value is None:
             continue
         target_arg = stage_cfg.runtime_arg_map.get(field_name)
@@ -195,8 +192,7 @@ def _merge_factory_arg_overrides(
 def _apply_typed_runtime_args(args: dict[str, Any], stage_cfg: StageConfig) -> None:
     runtime = stage_cfg.runtime
 
-    for field_name in _MAPPED_STAGE_RUNTIME_FIELDS:
-        value = getattr(runtime, field_name)
+    for field_name, value in _mapped_stage_runtime_values(stage_cfg).items():
         if value is None:
             continue
         target_arg = stage_cfg.runtime_arg_map.get(field_name)
@@ -212,6 +208,14 @@ def _apply_typed_runtime_args(args: dict[str, Any], stage_cfg: StageConfig) -> N
         overrides = dict(args.get("server_args_overrides") or {})
         overrides["mem_fraction_static"] = mem_fraction_static
         args["server_args_overrides"] = overrides
+
+
+def _mapped_stage_runtime_values(stage_cfg: StageConfig) -> dict[str, Any]:
+    runtime = stage_cfg.runtime
+    return {
+        "max_seq_len": runtime.max_seq_len,
+        "video_fps": runtime.video_fps,
+    }
 
 
 def _resolve_primary_gpu_id(

--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -20,6 +20,7 @@ from sglang_omni.sampling.seed import (
 from sglang_omni.scheduling.types import (
     ModelRunnerOutput,
     RequestOutput,
+    SchedulerRequest,
     sampled_logprobs_to_list,
 )
 
@@ -35,15 +36,8 @@ def _current_sglang_sampling_backend() -> str | None:
         return None
 
 
-def _rank_shared_unseeded_sampling_seed(request: Any, row_idx: int) -> int:
-    request_id = getattr(request, "request_id", None)
-    if request_id is None:
-        request_id = getattr(getattr(request, "data", None), "request_id", None)
-    if request_id is None:
-        req = getattr(getattr(request, "data", None), "req", None)
-        request_id = getattr(req, "rid", None)
-    if request_id is None:
-        request_id = f"row-{row_idx}"
+def _rank_shared_unseeded_sampling_seed(request: SchedulerRequest, row_idx: int) -> int:
+    request_id = request.request_id or f"row-{row_idx}"
     return derive_sampling_seed("sglang-omni-unseeded-row", request_id)
 
 

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -222,11 +222,11 @@ class ModelWorker:
 
     def model_info(self) -> dict[str, Any]:
         return {
-            "model_path": getattr(self.server_args, "model_path", None),
-            "load_format": getattr(self.server_args, "load_format", None),
-            "weight_version": getattr(self.server_args, "weight_version", None),
+            "model_path": self.server_args.model_path,
+            "load_format": self.server_args.load_format,
+            "weight_version": self.server_args.weight_version,
             "tp_rank": self.tp_rank,
-            "tp_size": getattr(self.server_args, "tp_size", 1),
+            "tp_size": self.server_args.tp_size,
             "model_arch_override": self.model_arch_override,
             "supports_weight_update": hasattr(
                 self.model_runner, "update_weights_from_disk"
@@ -241,9 +241,7 @@ class ModelWorker:
         update = getattr(self.model_runner, "update_weights_from_disk", None)
         if update is None:
             return False, "model runner does not support update_weights_from_disk"
-        load_format = payload.get("load_format") or getattr(
-            self.server_args, "load_format", None
-        )
+        load_format = payload.get("load_format") or self.server_args.load_format
         success, message = update(
             model_path,
             load_format,
@@ -400,18 +398,16 @@ def _apply_model_worker_backend_policy(
     effective_quantization = _normalize_quantization(
         getattr(model_config, "quantization", None)
     )
-    server_quantization = _normalize_quantization(
-        getattr(server_args, "quantization", None)
-    )
+    server_quantization = _normalize_quantization(server_args.quantization)
     if server_quantization is not None:
         effective_quantization = server_quantization
 
-    moe_runner_backend = getattr(server_args, "moe_runner_backend", "auto")
+    moe_runner_backend = server_args.moe_runner_backend
     is_qwen3_omni_arch = model_arch_override in (
         "Qwen3OmniTalker",
         "Qwen3OmniThinkerForCausalLM",
     )
-    if is_qwen3_omni_arch and getattr(server_args, "ep_size", 1) != 1:
+    if is_qwen3_omni_arch and server_args.ep_size != 1:
         raise ValueError(
             "Qwen3-Omni ModelWorker does not support expert parallelism; "
             "use ep_size=1."
@@ -477,7 +473,7 @@ def _apply_model_worker_backend_policy(
         server_args.fp8_gemm_runner_backend = "triton"
         fp8_gemm_backend = server_args.fp8_gemm_runner_backend
 
-    server_quantization = getattr(server_args, "quantization", None)
+    server_quantization = server_args.quantization
     logger.info(
         f"Configured SGLang backend policy: arch={model_arch_override} "
         f"effective_quantization={effective_quantization} "

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -262,7 +262,7 @@ def create_sglang_tts_engine_executor(
         **overrides,
     )
     server_args.disable_overlap_schedule = True
-    if getattr(server_args, "attention_backend", None) is None:
+    if server_args.attention_backend is None:
         server_args.attention_backend = "fa3"
 
     want_cuda_graph, (
@@ -299,7 +299,7 @@ def create_sglang_tts_engine_executor(
         model_buffer_bs=_resolve_s2pro_model_buffer_bs(model_worker.model_runner.model),
     )
 
-    if bool(getattr(server_args, "enable_torch_compile", False)):
+    if bool(server_args.enable_torch_compile):
         _compile_s2pro_codebook_decoder(
             model_worker.model_runner.model,
             max_batch_size=server_args.torch_compile_max_bs,

--- a/sglang_omni/models/llada2_uni/components/preprocessor.py
+++ b/sglang_omni/models/llada2_uni/components/preprocessor.py
@@ -196,7 +196,7 @@ class LLaDA2Preprocessor:
 
     async def __call__(self, payload: StagePayload) -> StagePayload:
         request = payload.request
-        raw_inputs = request.inputs if hasattr(request, "inputs") else {}
+        raw_inputs = request.inputs
         if isinstance(raw_inputs, list):
             messages = raw_inputs
             raw_images, image_counts_per_msg = self._extract_raw_images(messages)

--- a/sglang_omni/models/ming_omni/bootstrap.py
+++ b/sglang_omni/models/ming_omni/bootstrap.py
@@ -24,7 +24,7 @@ def create_thinker_scheduler(
 ):
     if tp_size < 1:
         raise ValueError(f"tp_size must be >= 1, got {tp_size}")
-    if getattr(server_args, "tp_size", None) != tp_size:
+    if server_args.tp_size != tp_size:
         server_args.tp_size = tp_size
 
     from sglang_omni.model_runner.ming_thinker_model_runner import (

--- a/sglang_omni/models/ming_omni/components/preprocessor.py
+++ b/sglang_omni/models/ming_omni/components/preprocessor.py
@@ -321,7 +321,7 @@ class MingPreprocessor:
     async def __call__(self, payload: StagePayload) -> StagePayload:
         """Process a chat completion request into pipeline state."""
         request = payload.request
-        raw_inputs = request.inputs if hasattr(request, "inputs") else {}
+        raw_inputs = request.inputs
         if isinstance(raw_inputs, list):
             # OpenAI API passes messages list directly as inputs
             messages = raw_inputs

--- a/sglang_omni/models/ming_omni/components/streaming_detokenizer.py
+++ b/sglang_omni/models/ming_omni/components/streaming_detokenizer.py
@@ -31,7 +31,7 @@ from sglang_omni.models.ming_omni.pipeline.merge import decode_events
 from sglang_omni.models.ming_omni.pipeline.next_stage import THINKER_STAGE
 from sglang_omni.models.ming_omni.pipeline.state_io import load_state
 from sglang_omni.models.ming_omni.pipeline.usage import build_text_usage
-from sglang_omni.proto import StagePayload
+from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
 
 logger = logging.getLogger(__name__)
@@ -311,13 +311,13 @@ def _event_to_dict(event: Any) -> dict[str, Any]:
     }
 
 
-def text_output_requested(request: Any) -> bool:
+def text_output_requested(request: OmniRequest) -> bool:
     """Return True if text is among the requested output modalities.
 
     Reads ``request.metadata["output_modalities"]``; defaults to True when
     the field is absent (text is always produced unless explicitly excluded).
     """
-    metadata = getattr(request, "metadata", None)
+    metadata = request.metadata
     if not isinstance(metadata, dict):
         return True
     modalities = metadata.get("output_modalities")

--- a/sglang_omni/models/ming_omni/components/talker_executor.py
+++ b/sglang_omni/models/ming_omni/components/talker_executor.py
@@ -259,7 +259,7 @@ class MingTalkerExecutor:
 
     @staticmethod
     def _output_modalities(payload: StagePayload) -> set[str] | None:
-        metadata = getattr(payload.request, "metadata", None)
+        metadata = payload.request.metadata
         if not isinstance(metadata, dict):
             return None
         modalities = metadata.get("output_modalities")

--- a/sglang_omni/models/qwen3_omni/bootstrap.py
+++ b/sglang_omni/models/qwen3_omni/bootstrap.py
@@ -30,7 +30,7 @@ def create_thinker_scheduler(
 
     capture_hidden_layers = [0, 24] if speech_enabled else None
     capture_hidden = speech_enabled
-    want_cuda_graph = not bool(getattr(server_args, "disable_cuda_graph", False))
+    want_cuda_graph = not bool(server_args.disable_cuda_graph)
     defer_cuda_graph_capture = want_cuda_graph and capture_hidden
     if defer_cuda_graph_capture:
         server_args.enable_return_hidden_states = True

--- a/sglang_omni/models/qwen3_omni/request_builders.py
+++ b/sglang_omni/models/qwen3_omni/request_builders.py
@@ -49,7 +49,9 @@ def _resolve_seed(params: dict[str, Any]) -> int | None:
 
 
 def output_modalities(request: OmniRequest | None) -> set[str] | None:
-    metadata = getattr(request, "metadata", None)
+    if request is None:
+        return None
+    metadata = request.metadata
     if not isinstance(metadata, dict):
         return None
     modalities = metadata.get("output_modalities")

--- a/sglang_omni/models/qwen3_omni/talker_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/talker_scheduler.py
@@ -26,7 +26,7 @@ def configure_talker_server_args(
     re-enable graph capture after the model worker is constructed.
     """
 
-    want_cuda_graph = not bool(getattr(server_args, "disable_cuda_graph", False))
+    want_cuda_graph = not bool(server_args.disable_cuda_graph)
     if feedback_enabled:
         server_args.disable_overlap_schedule = True
         if want_cuda_graph:

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -234,7 +234,7 @@ def create_sglang_tts_engine_executor(
         generate_defaults=_load_qwen3_tts_generate_defaults(checkpoint_dir),
     )
     set_qwen3_tts_preprocessing_context(model=model, wrapper=wrapper)
-    if bool(getattr(server_args, "enable_torch_compile", False)):
+    if bool(server_args.enable_torch_compile):
         _compile_qwen3_tts_backbone(model)
         server_args.enable_torch_compile = False
     if want_cuda_graph:

--- a/sglang_omni/models/voxtral_tts/pipeline/stages.py
+++ b/sglang_omni/models/voxtral_tts/pipeline/stages.py
@@ -222,7 +222,7 @@ def create_generation_executor(
         **overrides,
     )
 
-    if getattr(server_args, "enable_torch_compile", False):
+    if server_args.enable_torch_compile:
         _enable_inductor_gemm_autotune()
 
     want_cuda_graph, (

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -425,7 +425,7 @@ def _run_process(
             if tasks:
                 await asyncio.gather(*tasks, return_exceptions=True)
             for stage in stages:
-                if getattr(stage, "_running", False):
+                if stage._running:
                     await stage.stop()
 
     asyncio.run(_start_and_run())

--- a/sglang_omni/scheduling/bootstrap.py
+++ b/sglang_omni/scheduling/bootstrap.py
@@ -54,7 +54,7 @@ def create_sglang_infrastructure(
         server_args.page_size,
     )
 
-    enable_overlap = not getattr(server_args, "disable_overlap_schedule", False)
+    enable_overlap = not server_args.disable_overlap_schedule
 
     prefill_mgr = PrefillManager(
         page_size=server_args.page_size,
@@ -112,7 +112,7 @@ def create_sglang_infrastructure_defer_cuda_graph(
     The caller finishes stage-specific decode setup, then runs
     init_device_graphs() only when this returns that CUDA graphs were requested.
     """
-    want_cuda_graph = not bool(getattr(server_args, "disable_cuda_graph", False))
+    want_cuda_graph = not bool(server_args.disable_cuda_graph)
     if want_cuda_graph:
         server_args.disable_cuda_graph = True
     try:

--- a/sglang_omni/scheduling/generation_batch_policy.py
+++ b/sglang_omni/scheduling/generation_batch_policy.py
@@ -76,23 +76,23 @@ def validate_generation_batch_policy(
 ) -> None:
     errors: list[str] = []
 
-    max_running_requests = _read_positive_int(
-        server_args,
+    max_running_requests = _validate_positive_int(
         "max_running_requests",
+        server_args.max_running_requests,
         errors,
     )
-    cuda_graph_enabled = not bool(getattr(server_args, "disable_cuda_graph", False))
+    cuda_graph_enabled = not bool(server_args.disable_cuda_graph)
 
     cuda_graph_max_bs: int | None = None
     cuda_graph_bs: tuple[int, ...] | None = None
     if cuda_graph_enabled:
-        cuda_graph_max_bs = _read_positive_int(
-            server_args,
+        cuda_graph_max_bs = _validate_positive_int(
             "cuda_graph_max_bs",
+            server_args.cuda_graph_max_bs,
             errors,
             required=True,
         )
-        cuda_graph_bs_value = getattr(server_args, "cuda_graph_bs", None)
+        cuda_graph_bs_value = server_args.cuda_graph_bs
         if cuda_graph_bs_value is None:
             errors.append("cuda_graph_bs must be explicit when CUDA graph is enabled")
         else:
@@ -115,10 +115,10 @@ def validate_generation_batch_policy(
                 f"({cuda_graph_max_bs} < {max_running_requests})"
             )
 
-    torch_compile_enabled = bool(getattr(server_args, "enable_torch_compile", False))
-    torch_compile_max_bs = _read_positive_int(
-        server_args,
+    torch_compile_enabled = bool(server_args.enable_torch_compile)
+    torch_compile_max_bs = _validate_positive_int(
         "torch_compile_max_bs",
+        server_args.torch_compile_max_bs,
         errors,
         required=torch_compile_enabled,
     )
@@ -153,14 +153,13 @@ def validate_generation_batch_policy(
         )
 
 
-def _read_positive_int(
-    obj: Any,
+def _validate_positive_int(
     field: str,
+    value: Any,
     errors: list[str],
     *,
     required: bool = True,
 ) -> int | None:
-    value = getattr(obj, field, None)
     if value is None:
         if required:
             errors.append(f"{field} must be explicit")

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -378,11 +378,11 @@ class OmniScheduler:
         self._prefill_start_done: set[str] = set()
 
     def _init_upstream_compat_flags(self, server_args: Any) -> None:
-        self.enable_hisparse = bool(getattr(server_args, "enable_hisparse", False))
+        self.enable_hisparse = bool(server_args.enable_hisparse)
         self.hisparse_coordinator = None
         self.enable_priority_preemption = bool(
-            getattr(server_args, "enable_priority_scheduling", False)
-            and not getattr(server_args, "disable_priority_preemption", False)
+            server_args.enable_priority_scheduling
+            and not server_args.disable_priority_preemption
         )
         # High-water mark, not a cap. Mirrors upstream Scheduler.__init__ (sglang/srt/managers/scheduler.py).
         self.max_prefill_bs = 0
@@ -934,13 +934,13 @@ class OmniScheduler:
             self._emit_request_error(req.rid, error)
             self.abort(req.rid, defer_running_cleanup=False)
 
-    def _emit_prefill_start_for_batch(self, batch: Any) -> None:
+    def _emit_prefill_start_for_batch(self, batch: ScheduleBatch) -> None:
         """Emit once when a request's first executable batch is selected."""
-        metadata = {}
-        for attr in ("is_prefill_only", "is_extend_in_batch"):
-            if hasattr(batch, attr):
-                metadata[attr] = bool(getattr(batch, attr))
-        for req in getattr(batch, "reqs", []) or []:
+        metadata = {
+            "is_prefill_only": bool(batch.is_prefill_only),
+            "is_extend_in_batch": bool(batch.is_extend_in_batch),
+        }
+        for req in batch.reqs:
             rid = req.rid
             if rid in self._prefill_start_done:
                 continue
@@ -970,7 +970,7 @@ class OmniScheduler:
             # Build result payload from the Req
             data = req._omni_data
             data.output_ids = list(req.output_ids)
-            data.weight_version = getattr(self.server_args, "weight_version", None)
+            data.weight_version = self.server_args.weight_version
             finished_reason = req.finished_reason
             data.finish_reason = (
                 finished_reason.to_json().get("type")
@@ -1199,9 +1199,9 @@ class OmniScheduler:
                 "running_batch_size": len(
                     getattr(self.running_batch, "reqs", []) or []
                 ),
-                "model_path": getattr(self.server_args, "model_path", None),
-                "load_format": getattr(self.server_args, "load_format", None),
-                "weight_version": getattr(self.server_args, "weight_version", None),
+                "model_path": self.server_args.model_path,
+                "load_format": self.server_args.load_format,
+                "weight_version": self.server_args.weight_version,
             }
         )
         return {"success": True, "message": "ok", "data": info}
@@ -1475,10 +1475,9 @@ class OmniScheduler:
         ):
             if batch is None:
                 continue
-            for req in getattr(batch, "reqs", []) or []:
-                rid = getattr(req, "rid", None)
-                if rid is not None and not req.finished():
-                    request_ids.add(rid)
+            for req in batch.reqs:
+                if req.rid is not None and not req.finished():
+                    request_ids.add(req.rid)
         return sorted(request_ids)
 
     def _can_update_active_requests(
@@ -1650,15 +1649,13 @@ class OmniScheduler:
                 self.self_check_during_busy()
 
     @staticmethod
-    def _batch_is_decode(batch) -> bool:
-        mode = getattr(batch, "forward_mode", None)
+    def _batch_is_decode(batch: ScheduleBatch) -> bool:
+        mode = batch.forward_mode
         if mode is None:
             return False
-        is_decode = getattr(mode, "is_decode", None)
-        if callable(is_decode):
-            return bool(is_decode())
-        is_extend = getattr(mode, "is_extend", None)
-        return (not bool(is_extend())) if callable(is_extend) else False
+        if mode.is_decode():
+            return True
+        return not bool(mode.is_extend())
 
     def _async_pending_batch(self):
         """The in-flight (launched, not yet resolved) decode batch, or None.
@@ -1837,7 +1834,7 @@ class OmniScheduler:
         for batch in (self.running_batch, self.cur_batch, self.last_batch):
             if batch is None:
                 continue
-            for req in getattr(batch, "reqs", ()):
+            for req in batch.reqs:
                 if req.rid == request_id:
                     return req._omni_data
         for req in self.waiting_queue:

--- a/sglang_omni/serve/speech_service.py
+++ b/sglang_omni/serve/speech_service.py
@@ -219,8 +219,9 @@ class SpeechRequestValidator:
         if request.language is not None:
             updates["language"] = _normalize_language(request.language)
 
-        for field_name in ("max_new_tokens", "token_count", "duration_tokens"):
-            _validate_positive_int(getattr(request, field_name), param=field_name)
+        _validate_positive_int(request.max_new_tokens, param="max_new_tokens")
+        _validate_positive_int(request.token_count, param="token_count")
+        _validate_positive_int(request.duration_tokens, param="duration_tokens")
         _validate_non_negative_int(
             request.initial_codec_chunk_frames,
             param=INITIAL_CODEC_CHUNK_FRAMES_PARAM,
@@ -502,8 +503,9 @@ class SpeechRequestValidator:
         )
         if batch.language is not None:
             _normalize_language(batch.language)
-        for field_name in ("max_new_tokens", "token_count", "duration_tokens"):
-            _validate_positive_int(getattr(batch, field_name), param=field_name)
+        _validate_positive_int(batch.max_new_tokens, param="max_new_tokens")
+        _validate_positive_int(batch.token_count, param="token_count")
+        _validate_positive_int(batch.duration_tokens, param="duration_tokens")
         _validate_non_negative_int(
             batch.initial_codec_chunk_frames,
             param=INITIAL_CODEC_CHUNK_FRAMES_PARAM,
@@ -625,16 +627,24 @@ class SpeechRequestValidator:
             )
             return reference.model_copy(update=updates)
 
-        for field_name in _REFERENCE_AUDIO_FIELDS:
-            value = getattr(reference, field_name)
-            if not isinstance(value, str):
-                continue
+        if isinstance(reference.audio_path, str):
             updates.update(
                 self._load_media_reference_descriptor(
-                    value, param=f"references.{field_name}"
+                    reference.audio_path, param="references.audio_path"
                 )
             )
-            break
+        elif isinstance(reference.ref_audio, str):
+            updates.update(
+                self._load_media_reference_descriptor(
+                    reference.ref_audio, param="references.ref_audio"
+                )
+            )
+        elif isinstance(reference.audio, str):
+            updates.update(
+                self._load_media_reference_descriptor(
+                    reference.audio, param="references.audio"
+                )
+            )
         return reference.model_copy(update=updates)
 
     def _load_media_reference_descriptor(

--- a/sglang_omni/utils/cuda_graph_batch_validator.py
+++ b/sglang_omni/utils/cuda_graph_batch_validator.py
@@ -286,7 +286,7 @@ def validate_stage(
         model = None
     model_cls = type(model).__name__ if model is not None else "unknown-model"
 
-    if bool(getattr(server_args, "disable_cuda_graph", False)):
+    if bool(server_args.disable_cuda_graph):
         return CudaGraphBatchReport(
             stage=f"{stage_name} ({model_cls})",
             max_running_requests=max_running_requests,

--- a/tests/unit_test/ming_omni/test_pipeline.py
+++ b/tests/unit_test/ming_omni/test_pipeline.py
@@ -117,6 +117,8 @@ def test_ming_speech_launcher_places_thinker_tp_and_talker(monkeypatch) -> None:
         gpu_talker=4,
         voice="DB30",
         mem_fraction_static=0.8,
+        cpu_offload_gb=None,
+        enable_streaming_tts=False,
         host="127.0.0.1",
         port=8000,
         model_name="ming-omni",

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -155,6 +155,7 @@ def test_moss_tts_engine_uses_auto_mem_fraction_by_default(monkeypatch) -> None:
             max_running_requests=kwargs["max_running_requests"],
             cuda_graph_max_bs=kwargs["cuda_graph_max_bs"],
             cuda_graph_bs=kwargs["cuda_graph_bs"],
+            enable_torch_compile=kwargs["enable_torch_compile"],
             torch_compile_max_bs=kwargs.get("torch_compile_max_bs"),
         )
 

--- a/tests/unit_test/pipeline/test_async_decode.py
+++ b/tests/unit_test/pipeline/test_async_decode.py
@@ -344,7 +344,10 @@ def test_batch_is_decode():
     )
     assert OmniScheduler._batch_is_decode(decode) is True
     assert OmniScheduler._batch_is_decode(extend) is False
-    assert OmniScheduler._batch_is_decode(types.SimpleNamespace()) is False  # no mode
+    assert (
+        OmniScheduler._batch_is_decode(types.SimpleNamespace(forward_mode=None))
+        is False
+    )
 
 
 def test_async_pending_batch_getattr_safe():

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -530,7 +530,7 @@ def test_omni_scheduler_distinguishes_queue_enter_from_prefill_start(
     assert "scheduler_prefill_start" not in names
     assert scheduler.waiting_queue == [req]
 
-    batch = SimpleNamespace(reqs=[req], is_prefill_only=True)
+    batch = SimpleNamespace(reqs=[req], is_prefill_only=True, is_extend_in_batch=False)
     scheduler._emit_prefill_start_for_batch(batch)
     scheduler._emit_prefill_start_for_batch(batch)
 
@@ -573,7 +573,9 @@ def test_omni_scheduler_initializes_upstream_queue_limit(monkeypatch) -> None:
         enable_mixed_chunk=False,
         schedule_policy="fcfs",
         enable_hierarchical_cache=False,
+        enable_hisparse=False,
         enable_priority_scheduling=False,
+        disable_priority_preemption=False,
         schedule_low_priority_values_first=False,
         priority_scheduling_preemption_threshold=0,
         schedule_conservativeness=1.0,

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -224,6 +224,8 @@ def test_omni_scheduler_run_batch_failure_emits_error_and_aborts(monkeypatch) ->
             ),
         ],
         batch_is_full=True,
+        is_prefill_only=True,
+        is_extend_in_batch=False,
     )
     scheduler.running_batch = batch
     scheduler.cur_batch = batch
@@ -267,6 +269,8 @@ def test_omni_scheduler_custom_runner_updates_next_input_ids() -> None:
             SimpleNamespace(rid="req-2", _omni_data=SimpleNamespace()),
         ],
         output_ids=None,
+        is_prefill_only=False,
+        is_extend_in_batch=False,
     )
 
     result = scheduler._run_batch(batch)
@@ -301,6 +305,8 @@ def test_omni_scheduler_custom_runner_advances_forward_ct() -> None:
         return SimpleNamespace(
             reqs=[SimpleNamespace(rid="r", _omni_data=SimpleNamespace())],
             output_ids=None,
+            is_prefill_only=False,
+            is_extend_in_batch=False,
         )
 
     scheduler._run_batch(_batch())

--- a/tests/unit_test/qwen3_omni/test_pipeline.py
+++ b/tests/unit_test/qwen3_omni/test_pipeline.py
@@ -638,7 +638,9 @@ def test_qwen_thinker_cuda_graph_capture_lifecycle(
     from sglang_omni.scheduling import bootstrap as scheduling_bootstrap
     from sglang_omni.scheduling import omni_scheduler, sglang_backend
 
-    server_args = SimpleNamespace(disable_cuda_graph=False)
+    server_args = SimpleNamespace(
+        disable_cuda_graph=False, enable_return_hidden_states=False
+    )
     infrastructure_saw_graph_disabled: list[bool] = []
     capture_hidden_layers_seen: list[list[int] | None] = []
     init_graph_calls = 0
@@ -712,7 +714,7 @@ def test_qwen_thinker_cuda_graph_capture_lifecycle(
     assert infrastructure_saw_graph_disabled == [expected_infrastructure_graph_disabled]
     assert capture_hidden_layers_seen == [expected_capture_hidden_layers]
     assert init_graph_calls == expected_init_graph_calls
-    assert getattr(server_args, "enable_return_hidden_states", False) is speech_enabled
+    assert server_args.enable_return_hidden_states is speech_enabled
     assert server_args.disable_cuda_graph is False
     assert scheduler.server_args is server_args
 

--- a/tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
+++ b/tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
@@ -257,6 +257,8 @@ def test_qwen_talker_ar_threads_explicit_generation_batch_policy(monkeypatch) ->
             max_running_requests=overrides["max_running_requests"],
             cuda_graph_max_bs=overrides["cuda_graph_max_bs"],
             cuda_graph_bs=overrides["cuda_graph_bs"],
+            disable_cuda_graph=overrides["disable_cuda_graph"],
+            enable_torch_compile=overrides.get("enable_torch_compile", False),
             torch_compile_max_bs=overrides["torch_compile_max_bs"],
         )
 
@@ -328,6 +330,8 @@ def test_talker_ar_default_running_batch_width_is_32(monkeypatch) -> None:
             max_running_requests=overrides["max_running_requests"],
             cuda_graph_max_bs=overrides["cuda_graph_max_bs"],
             cuda_graph_bs=overrides["cuda_graph_bs"],
+            disable_cuda_graph=overrides["disable_cuda_graph"],
+            enable_torch_compile=overrides.get("enable_torch_compile", False),
             torch_compile_max_bs=overrides["torch_compile_max_bs"],
         )
 


### PR DESCRIPTION
Summary: This PR replaces over-defensive `getattr`/`hasattr` usage with direct field access where local object contracts guarantee the field, using explicit type narrowing for supported mixed result shapes and leaving dynamic compatibility checks unchanged.

Change: Use direct access for strict local fields and update tests to model those contracts.
