### PR TITLE
[TTS Refactor][M4a] ReferenceEncodeService: MOSS-local cache cleanup

### DIFF
--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -471,8 +471,8 @@ class _MossLocalReferenceEncoder:
         encoder: _BatchedReferenceEncoder,
         *,
         n_vq: int,
-        max_items: int,
-        max_bytes: int,
+        max_items: int | None = 256,
+        max_bytes: int | None = 64 * 1024 * 1024,
     ) -> None:
         self._service = ReferenceEncodeService(
             _MossLocalReferenceEncodeHook(encoder, n_vq=n_vq),

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -10,7 +10,6 @@ import logging
 import os
 import queue
 import threading
-import time
 from dataclasses import dataclass
 from typing import Any, TypeAlias
 
@@ -46,8 +45,12 @@ from sglang_omni.scheduling.generation_batch_policy import (
     build_generation_batch_overrides,
     validate_generation_batch_policy,
 )
+from sglang_omni.scheduling.reference_encoder import (
+    ReferenceEncodeHook,
+    ReferenceEncodeKey,
+    ReferenceEncodeService,
+)
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
-from sglang_omni.scheduling.stage_cache import StageOutputCache
 
 logger = logging.getLogger(__name__)
 
@@ -386,172 +389,114 @@ class _BatchedReferenceEncoder:
         return results
 
 
-class CachedReferenceEncoder:
-    """Content-addressed LRU cache + single-flight dedup in front of _BatchedReferenceEncoder.
+@dataclass(frozen=True)
+class _MossLocalReferenceInput:
+    source_kind: str
+    source: str
+    raw: bytes | None = None
 
-    Every path (miss, hit, follower) returns an independent CPU long tensor, so
-    downstream sees one device/dtype regardless of cache temperature.
-    Stores codes as int32 on CPU (lossless for codebook values in [0, 1023]).
-    """
 
-    # Cadence for the periodic stats log; class attr so it is easy to tune.
-    LOG_INTERVAL_S = 60.0
-
+class _MossLocalReferenceEncodeHook(
+    ReferenceEncodeHook[_MossLocalReferenceInput, torch.Tensor, torch.Tensor]
+):
     def __init__(
         self,
         encoder: _BatchedReferenceEncoder,
         *,
-        max_items: int = 256,
-        max_bytes: int = 64 * 1024 * 1024,
+        n_vq: int,
     ) -> None:
-        # Fail fast on non-positive capacities: a negative max_items makes
-        # StageOutputCache evict from an empty dict and KeyError at request time.
-        if max_items < 1:
-            raise ValueError(f"ref_audio_cache_max_items must be >= 1, got {max_items}")
-        if max_bytes < 1:
-            raise ValueError(f"ref_audio_cache_max_bytes must be >= 1, got {max_bytes}")
         self._encoder = encoder
-        self._cache = StageOutputCache(
-            max_size=max_items,
-            max_bytes=max_bytes,
-            cache_device="cpu",
+        self._n_vq = int(n_vq)
+        self._encoder_config_hash = _hash_bytes(f"n_vq:{self._n_vq}".encode("utf-8"))
+
+    def normalize_input(self, raw_input: Any) -> _MossLocalReferenceInput:
+        if isinstance(raw_input, _MossLocalReferenceInput):
+            return raw_input
+        return _MossLocalReferenceInput("path", str(raw_input))
+
+    def cache_key(self, item: _MossLocalReferenceInput) -> ReferenceEncodeKey | None:
+        input_key = self._input_key(item)
+        if input_key is None:
+            return None
+        return ReferenceEncodeKey(
+            model_id="moss_tts_local",
+            model_revision="local_audio_tokenizer",
+            encoder_id="moss_tts_local_audio_tokenizer",
+            encoder_config_hash=self._encoder_config_hash,
+            artifact_kind="moss_tts_local_reference_codes",
+            input_key=input_key,
         )
-        self._lock = threading.Lock()
-        self._inflight: dict[str, concurrent.futures.Future] = {}
-        self._hits = 0
-        self._misses = 0
-        self._merged = 0
-        self._last_log_time: float = 0.0
+
+    def encode_one(self, item: _MossLocalReferenceInput) -> torch.Tensor:
+        if item.source_kind == "path":
+            return self._encoder.encode(item.source)
+        if item.source_kind == "data_uri":
+            raw = item.raw
+            if raw is None:
+                raw = _BatchedReferenceEncoder._data_uri_audio_bytes(item.source)
+            wav, sample_rate = _BatchedReferenceEncoder._decode_data_uri_audio(raw)
+            return self._encoder.encode_wav(wav, sample_rate)
+        raise TypeError(f"unknown MOSS-local reference source: {item.source_kind}")
+
+    def store_artifact(self, artifact: torch.Tensor) -> torch.Tensor:
+        return artifact.detach().to("cpu", dtype=torch.int32).clone()
+
+    def load_artifact(self, stored: torch.Tensor) -> torch.Tensor:
+        return stored.detach().clone().to(torch.long)
+
+    def revalidate(
+        self,
+        item: _MossLocalReferenceInput,
+        key: ReferenceEncodeKey,
+    ) -> bool:
+        if item.source_kind != "path":
+            return True
+        return self._input_key(item) == key.input_key
+
+    def _input_key(self, item: _MossLocalReferenceInput) -> str | None:
+        if item.source_kind == "path":
+            _BatchedReferenceEncoder._check_reference_duration(item.source)
+            return _reference_path_cache_key(item.source)
+        if item.source_kind == "data_uri":
+            raw = item.raw
+            if raw is None:
+                raw = _BatchedReferenceEncoder._data_uri_audio_bytes(item.source)
+            return f"bytes:{_hash_bytes(raw)}"
+        return None
+
+
+class _MossLocalReferenceEncoder:
+    def __init__(
+        self,
+        encoder: _BatchedReferenceEncoder,
+        *,
+        n_vq: int,
+        max_items: int,
+        max_bytes: int,
+    ) -> None:
+        self._service = ReferenceEncodeService(
+            _MossLocalReferenceEncodeHook(encoder, n_vq=n_vq),
+            max_items=max_items,
+            max_bytes=max_bytes,
+            timeout_s=_BatchedReferenceEncoder.ENCODE_TIMEOUT_S + 10,
+            log_prefix="MOSS-TTS Local ref cache",
+        )
 
     def encode(self, path: str) -> torch.Tensor:
-        path = str(path)
-        # Note(Jiaxin): duration gate runs first — a >100 s ref must never reach
-        # the cache or the inflight dict.
-        _BatchedReferenceEncoder._check_reference_duration(path)
-        # trust_stat left False (review feedback): keep the sentinel byte-read so a
-        # same-size+mtime+ctime overwrite cannot stale-hit. The flag stays available
-        # in reference_path_cache_key for deployments that guarantee immutable refs.
-        key = _reference_path_cache_key(path)
-        if key is None:
-            return self._encoder.encode(path)  # uncacheable (URL/missing) -> bypass
-        return self._cached_encode(
-            key,
-            lambda: self._encoder.encode(path),
-            desc=repr(path),
-            # TOCTOU re-stat: skip the put if the file changed during the encode.
-            revalidate=lambda: _reference_path_cache_key(path) == key,
-        )
-
-    def _cached_encode(
-        self, key: str, encode_fn, *, desc: str, revalidate=None
-    ) -> torch.Tensor:
-        """Single-flight skeleton shared by encode() and encode_data_uri().
-
-        All paths return an independent CPU long tensor. revalidate(), if given,
-        is evaluated outside the lock and gates the put (TOCTOU guard for file
-        paths).
-        """
-        leader_fut: concurrent.futures.Future | None = None
-        follower_fut: concurrent.futures.Future | None = None
-
-        with self._lock:
-            stored = self._cache.get(key)
-            if stored is not None:
-                self._hits += 1
-            elif key in self._inflight:
-                self._merged += 1
-                follower_fut = self._inflight[key]
-            else:
-                self._misses += 1
-                leader_fut = concurrent.futures.Future()
-                self._inflight[key] = leader_fut
-
-        if stored is not None:
-            # Note(Jiaxin): clone on hit so callers can't mutate the shared entry.
-            self._maybe_log()
-            return stored.clone().to(torch.long)
-
-        if follower_fut is not None:
-            # Note(Jiaxin): each follower raises a FRESH RuntimeError — sharing one
-            # exception instance lets concurrent re-raises corrupt its traceback
-            # (same lesson as _BatchedReferenceEncoder._worker).
-            timeout = _BatchedReferenceEncoder.ENCODE_TIMEOUT_S + 10
-            try:
-                stored = follower_fut.result(timeout=timeout)
-            except Exception as cause:
-                raise RuntimeError(
-                    f"reference encode failed for {desc}: {cause}"
-                ) from cause
-            return stored.clone().to(torch.long)
-
-        assert leader_fut is not None
-        try:
-            result = encode_fn()
-        except BaseException as exc:
-            with self._lock:
-                self._inflight.pop(key, None)
-            leader_fut.set_exception(exc)
-            raise
-
-        do_put = revalidate() if revalidate is not None else True
-        stored = result.detach().to("cpu", dtype=torch.int32)
-        with self._lock:
-            if do_put:
-                self._cache.put(key, stored)
-            self._inflight.pop(key, None)
-        leader_fut.set_result(stored)
-        self._maybe_log()
-        # CPU long like the hit path.
-        return stored.to(torch.long)
-
-    def _maybe_log(self) -> None:
-        now = time.monotonic()
-        if now - self._last_log_time < self.LOG_INTERVAL_S:
-            return
-        with self._lock:
-            if now - self._last_log_time < self.LOG_INTERVAL_S:
-                return
-            self._last_log_time = now
-            snapshot = (
-                self._hits,
-                self._misses,
-                self._merged,
-                len(self._cache._cache),
-                self._cache.current_bytes,
-            )
-        logger.info(
-            "MOSS-TTS Local ref cache: hits=%d misses=%d merged=%d entries=%d bytes=%d",
-            *snapshot,
+        return self._service.get_or_encode(
+            _MossLocalReferenceInput("path", str(path)),
+            desc=repr(str(path)),
         )
 
     def encode_data_uri(self, ref_audio: str) -> torch.Tensor:
-        """Cache-aware encode for data-URI refs through the same LRU + single-flight
-        as file paths (adds the duration check _reference_for_processor lacks).
-
-        Note(Jiaxin): file: and bytes: keyspaces never collide — the two decode
-        chains differ, so codes aren't guaranteed identical for the "same" audio.
-        """
         raw = _BatchedReferenceEncoder._data_uri_audio_bytes(ref_audio)
-        key = f"bytes:{_hash_bytes(raw)}"
+        return self._service.get_or_encode(
+            _MossLocalReferenceInput("data_uri", str(ref_audio), raw),
+            desc="data-URI",
+        )
 
-        def _encode() -> torch.Tensor:
-            # Note(Jiaxin): the duration check runs inside the leader (not before
-            # inflight registration like the file path) so concurrent same-payload
-            # requests share one sf.read of a potentially large decoded buffer.
-            wav, sample_rate = _BatchedReferenceEncoder._decode_data_uri_audio(raw)
-            return self._encoder.encode_wav(wav, sample_rate)
-
-        return self._cached_encode(key, _encode, desc="data-URI")
-
-    def stats(self) -> dict:
-        with self._lock:
-            return {
-                "hits": self._hits,
-                "misses": self._misses,
-                "merged": self._merged,
-                "entries": len(self._cache._cache),
-                "bytes": self._cache.current_bytes,
-            }
+    def stats(self) -> dict[str, int]:
+        return self._service.stats()
 
 
 def create_preprocessing_executor(
@@ -591,8 +536,9 @@ def create_preprocessing_executor(
         max_batch_wait_ms=encode_batch_wait_ms,
     )
     if ref_audio_cache:
-        reference_encoder = CachedReferenceEncoder(
+        reference_encoder = _MossLocalReferenceEncoder(
             reference_encoder,
+            n_vq=int(processor.model_config.n_vq),
             max_items=ref_audio_cache_max_items,
             max_bytes=ref_audio_cache_max_bytes,
         )

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -735,16 +735,16 @@ def test_create_preprocessing_executor_env_toggle(monkeypatch):
     monkeypatch.setenv("MOSS_REF_AUDIO_CACHE", "0")
     stages.create_preprocessing_executor("model", device="cpu")
     assert not isinstance(
-        rb._PREPROCESSING_CONTEXT.reference_encoder, stages.CachedReferenceEncoder
+        rb._PREPROCESSING_CONTEXT.reference_encoder, stages._MossLocalReferenceEncoder
     )
 
     # Unset -> kwarg default (True) -> wrapped.
     monkeypatch.delenv("MOSS_REF_AUDIO_CACHE")
     stages.create_preprocessing_executor("model", device="cpu")
     assert isinstance(
-        rb._PREPROCESSING_CONTEXT.reference_encoder, stages.CachedReferenceEncoder
+        rb._PREPROCESSING_CONTEXT.reference_encoder, stages._MossLocalReferenceEncoder
     )
-    assert rb._PREPROCESSING_CONTEXT.reference_encoder._cache.max_size == 8192
+    assert rb._PREPROCESSING_CONTEXT.reference_encoder._service._cache.max_size == 8192
 
 
 def test_create_preprocessing_executor_uses_model_config_codec_path(monkeypatch):
@@ -1120,7 +1120,7 @@ def test_batched_reference_encoder_mixes_path_and_waveform_jobs():
     assert calls[0] == [2, 5]
 
 
-# CachedReferenceEncoder
+# _MossLocalReferenceEncoder
 
 
 def test_cached_reference_encoder_on_off_hit_bit_identical(tmp_path):
@@ -1132,7 +1132,7 @@ def test_cached_reference_encoder_on_off_hit_bit_identical(tmp_path):
     from sglang_omni.models.moss_tts_local.request_builders import (
         _prepare_moss_tts_local_request,
     )
-    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     ref_file = tmp_path / "ref.wav"
     ref_file.write_bytes(b"fake wav bytes for T5")
@@ -1189,8 +1189,10 @@ def test_cached_reference_encoder_on_off_hit_bit_identical(tmp_path):
     )
     assert encode_count == 1
 
-    # ON-miss: first call to CachedReferenceEncoder (cache empty)
-    cached_enc = CachedReferenceEncoder(fake_batched, max_items=256, max_bytes=64 << 20)
+    # ON-miss: first call to _MossLocalReferenceEncoder (cache empty)
+    cached_enc = _MossLocalReferenceEncoder(
+        fake_batched, n_vq=N_VQ, max_items=256, max_bytes=64 << 20
+    )
     encode_count = 0
     prepared_miss = _prepare_moss_tts_local_request(
         _ref_payload("t5-miss"), processor=processor, reference_encoder=cached_enc
@@ -1217,7 +1219,7 @@ def test_cached_reference_encoder_on_off_hit_bit_identical(tmp_path):
 
 def test_cached_reference_encoder_lru_eviction(tmp_path):
     """T3: LRU eviction by item count and by byte budget."""
-    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     encode_log = []
 
@@ -1227,7 +1229,9 @@ def test_cached_reference_encoder_lru_eviction(tmp_path):
             return torch.full((2, N_VQ), ord(path[-1]), dtype=torch.long)
 
     # --- item-count eviction: max_items=2, insert 3 ---
-    enc = CachedReferenceEncoder(_FakeBatched(), max_items=2, max_bytes=64 << 20)
+    enc = _MossLocalReferenceEncoder(
+        _FakeBatched(), n_vq=N_VQ, max_items=2, max_bytes=64 << 20
+    )
     files = [tmp_path / f"{c}.wav" for c in "abc"]
     for i, f in enumerate(files):
         f.write_bytes(bytes([i + 1]) * 16)  # distinct content → distinct cache keys
@@ -1243,7 +1247,9 @@ def test_cached_reference_encoder_lru_eviction(tmp_path):
 
     # --- byte-budget eviction: each entry is 2*12*4=96 bytes as int32 ---
     entry_bytes = 2 * N_VQ * 4  # int32
-    enc2 = CachedReferenceEncoder(_FakeBatched(), max_items=1000, max_bytes=entry_bytes)
+    enc2 = _MossLocalReferenceEncoder(
+        _FakeBatched(), n_vq=N_VQ, max_items=1000, max_bytes=entry_bytes
+    )
     f1, f2 = tmp_path / "d.wav", tmp_path / "e.wav"
     f1.write_bytes(b"y" * 16)
     f2.write_bytes(b"z" * 16)
@@ -1257,7 +1263,9 @@ def test_cached_reference_encoder_lru_eviction(tmp_path):
     assert len(encode_log) == 1
 
     # --- oversized entry is gracefully rejected, does not crash ---
-    enc3 = CachedReferenceEncoder(_FakeBatched(), max_items=10, max_bytes=1)
+    enc3 = _MossLocalReferenceEncoder(
+        _FakeBatched(), n_vq=N_VQ, max_items=10, max_bytes=1
+    )
     f3 = tmp_path / "big.wav"
     f3.write_bytes(b"big" * 16)
     result = enc3.encode(str(f3))
@@ -1266,18 +1274,18 @@ def test_cached_reference_encoder_lru_eviction(tmp_path):
 
 def test_cached_reference_encoder_rejects_nonpositive_capacity():
     """Negative/zero capacities fail fast at construction (P3, review)."""
-    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     class _FakeBatched:
         def encode(self, path: str) -> torch.Tensor:
             return torch.zeros((2, N_VQ), dtype=torch.long)
 
     with pytest.raises(ValueError, match="max_items"):
-        CachedReferenceEncoder(_FakeBatched(), max_items=-1)
+        _MossLocalReferenceEncoder(_FakeBatched(), n_vq=N_VQ, max_items=-1)
     with pytest.raises(ValueError, match="max_items"):
-        CachedReferenceEncoder(_FakeBatched(), max_items=0)
+        _MossLocalReferenceEncoder(_FakeBatched(), n_vq=N_VQ, max_items=0)
     with pytest.raises(ValueError, match="max_bytes"):
-        CachedReferenceEncoder(_FakeBatched(), max_bytes=0)
+        _MossLocalReferenceEncoder(_FakeBatched(), n_vq=N_VQ, max_bytes=0)
 
 
 def test_cached_reference_encoder_true_concurrency_dedup(tmp_path):
@@ -1286,7 +1294,7 @@ def test_cached_reference_encoder_true_concurrency_dedup(tmp_path):
     """
     import threading as _threading
 
-    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     ref = tmp_path / "ref.wav"
     ref.write_bytes(b"concurrent test")
@@ -1302,7 +1310,9 @@ def test_cached_reference_encoder_true_concurrency_dedup(tmp_path):
             return torch.full((5, N_VQ), 42, dtype=torch.long)
 
     N = 8
-    enc = CachedReferenceEncoder(_GatedBatched(), max_items=256, max_bytes=64 << 20)
+    enc = _MossLocalReferenceEncoder(
+        _GatedBatched(), n_vq=N_VQ, max_items=256, max_bytes=64 << 20
+    )
     results = [None] * N
     errors = []
 
@@ -1344,7 +1354,7 @@ def test_cached_reference_encoder_failure_does_not_poison(tmp_path):
     """
     import threading as _threading
 
-    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     ref = tmp_path / "flaky.wav"
     ref.write_bytes(b"flaky")
@@ -1361,7 +1371,9 @@ def test_cached_reference_encoder_failure_does_not_poison(tmp_path):
                 raise RuntimeError("transient encode failure")
             return torch.full((3, N_VQ), 7, dtype=torch.long)
 
-    enc = CachedReferenceEncoder(_FlakyBatched(), max_items=256, max_bytes=64 << 20)
+    enc = _MossLocalReferenceEncoder(
+        _FlakyBatched(), n_vq=N_VQ, max_items=256, max_bytes=64 << 20
+    )
     exc_results = [None, None]
 
     def fail_worker(idx):
@@ -1389,7 +1401,7 @@ def test_cached_reference_encoder_failure_does_not_poison(tmp_path):
     # Cache not poisoned
     assert enc.stats()["entries"] == 0
     # inflight cleared
-    assert len(enc._inflight) == 0
+    assert len(enc._service._inflight) == 0
 
     # Third request succeeds (new leader)
     gate.clear()
@@ -1401,7 +1413,7 @@ def test_cached_reference_encoder_failure_does_not_poison(tmp_path):
 
 def test_cached_reference_encoder_return_value_isolation(tmp_path):
     """T7: mutating the returned tensor does not corrupt the cached copy."""
-    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     ref = tmp_path / "iso.wav"
     ref.write_bytes(b"isolation test")
@@ -1410,7 +1422,9 @@ def test_cached_reference_encoder_return_value_isolation(tmp_path):
         def encode(self, path: str) -> torch.Tensor:
             return torch.full((4, N_VQ), 99, dtype=torch.long)
 
-    enc = CachedReferenceEncoder(_FakeBatched(), max_items=256, max_bytes=64 << 20)
+    enc = _MossLocalReferenceEncoder(
+        _FakeBatched(), n_vq=N_VQ, max_items=256, max_bytes=64 << 20
+    )
     enc.encode(str(ref))  # miss — populates cache
 
     hit1 = enc.encode(str(ref))  # first hit
@@ -1424,7 +1438,7 @@ def test_cached_reference_encoder_duration_gate(tmp_path, monkeypatch):
     """T8: references over 100 s are rejected before touching the cache."""
     torchaudio = pytest.importorskip("torchaudio")
 
-    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     ref = tmp_path / "long.wav"
     ref.write_bytes(b"fake long audio")
@@ -1443,16 +1457,18 @@ def test_cached_reference_encoder_duration_gate(tmp_path, monkeypatch):
 
     monkeypatch.setattr(torchaudio, "info", lambda path: _FakeInfo(), raising=False)
 
-    enc = CachedReferenceEncoder(_FakeBatched(), max_items=256, max_bytes=64 << 20)
+    enc = _MossLocalReferenceEncoder(
+        _FakeBatched(), n_vq=N_VQ, max_items=256, max_bytes=64 << 20
+    )
 
-    # _BatchedReferenceEncoder.encode checks duration before enqueuing; CachedReferenceEncoder
-    # calls through to the underlying encoder so the duration check still fires.
+    # _BatchedReferenceEncoder.encode checks duration before enqueuing;
+    # _MossLocalReferenceEncoder calls through so the duration check still fires.
     with pytest.raises(ValueError, match="100"):
         enc.encode(str(ref))
 
     assert encode_count == 0, "oversized reference must not reach the codec"
     assert enc.stats()["entries"] == 0
-    assert len(enc._inflight) == 0
+    assert len(enc._service._inflight) == 0
 
 
 # Data-URI reference path
@@ -1488,7 +1504,7 @@ def _make_wav_data_uri(
 
 def test_cached_reference_encoder_data_uri_hit_miss(tmp_path):
     """bytes: keyspace: same data-URI encoded twice -> one codec encode."""
-    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     pytest.importorskip("soundfile")
     data_uri, _ = _make_wav_data_uri()
@@ -1500,7 +1516,9 @@ def test_cached_reference_encoder_data_uri_hit_miss(tmp_path):
             wav_call_count += 1
             return torch.full((5, N_VQ), 42, dtype=torch.long)
 
-    enc = CachedReferenceEncoder(_FakeBatched(), max_items=256, max_bytes=64 << 20)
+    enc = _MossLocalReferenceEncoder(
+        _FakeBatched(), n_vq=N_VQ, max_items=256, max_bytes=64 << 20
+    )
     enc.encode_data_uri(data_uri)
     assert wav_call_count == 1, "first call must encode"
 
@@ -1542,7 +1560,7 @@ def test_uncached_data_uri_uses_reference_encoder():
 
 def test_cached_reference_encoder_file_bytes_keyspaces_do_not_collide(tmp_path):
     """file: and bytes: keys are independent; same-content file ≠ data-URI in cache."""
-    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     pytest.importorskip("soundfile")
     data_uri, raw = _make_wav_data_uri()
@@ -1564,7 +1582,9 @@ def test_cached_reference_encoder_file_bytes_keyspaces_do_not_collide(tmp_path):
             encode_count += 1
             return torch.full((5, N_VQ), 7, dtype=torch.long)
 
-    enc = CachedReferenceEncoder(_FakeBatched(), max_items=256, max_bytes=64 << 20)
+    enc = _MossLocalReferenceEncoder(
+        _FakeBatched(), n_vq=N_VQ, max_items=256, max_bytes=64 << 20
+    )
     enc.encode(str(ref_file))  # populates file: key
     enc.encode_data_uri(data_uri)  # must NOT hit file: entry
 
@@ -1578,7 +1598,7 @@ def test_cached_reference_encoder_data_uri_duration_gate():
     import base64
     import io
 
-    from sglang_omni.models.moss_tts_local.stages import CachedReferenceEncoder
+    from sglang_omni.models.moss_tts_local.stages import _MossLocalReferenceEncoder
 
     pytest.importorskip("soundfile")
     import soundfile as sf
@@ -1597,12 +1617,14 @@ def test_cached_reference_encoder_data_uri_duration_gate():
         def encode_wav(self, wav, sample_rate):
             return torch.zeros((5, N_VQ), dtype=torch.long)
 
-    enc = CachedReferenceEncoder(_FakeBatched(), max_items=256, max_bytes=64 << 20)
+    enc = _MossLocalReferenceEncoder(
+        _FakeBatched(), n_vq=N_VQ, max_items=256, max_bytes=64 << 20
+    )
     with pytest.raises(ValueError, match="100"):
         enc.encode_data_uri(uri)
 
     assert enc.stats()["entries"] == 0
-    assert len(enc._inflight) == 0
+    assert len(enc._service._inflight) == 0
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Motivation

MOSS-local already had model-local LRU + same-key single-flight in `CachedReferenceEncoder`. M4a should own that reusable cache/single-flight/failure-propagation skeleton in `ReferenceEncodeService`, while MOSS-local keeps the model-specific codec semantics and different-key batch coalescing owner.

## Module doc

- Lark design: https://osgbw74w8zwb.sg.larksuite.com/docx/PM8Ed39XAoHkLoxguvHlFiO5ghc
- Repo API doc: `docs/developer_reference/reference_encode_service.md`

## Issue

- #925

## Behavior class

Yellow / preserving intent. MOSS-local should keep the same path and data-URI artifact behavior, but the cache/single-flight mechanics now come from the shared M4a service.

## Old path deletion

Removes the local `CachedReferenceEncoder` cache/single-flight wrapper from `sglang_omni/models/moss_tts_local/stages.py` and replaces it with `_MossLocalReferenceEncoder`, a thin model-local adapter over `ReferenceEncodeService`.

`_BatchedReferenceEncoder` remains model-local and remains the only owner of different-key batch coalescing in this PR.

## Modifications

- Adds `_MossLocalReferenceEncodeHook` for MOSS-local path and data-URI reference inputs.
- Stores CPU int32 reference codes and returns caller-owned CPU long tensors, matching the old wrapper intent.
- Keeps file duration gates, `reference_path_cache_key(...)` revalidation, and file/data-URI keyspace separation.
- Keeps `MOSS_REF_AUDIO_CACHE=0` behavior as the startup kill switch.

## Contract tests

- [x] `tests/unit_test/moss_tts_local/test_pipeline.py::test_cached_reference_encoder_on_off_hit_bit_identical`
- [x] `tests/unit_test/moss_tts_local/test_pipeline.py::test_cached_reference_encoder_lru_eviction`
- [x] `tests/unit_test/moss_tts_local/test_pipeline.py::test_cached_reference_encoder_rejects_nonpositive_capacity`
- [x] `tests/unit_test/moss_tts_local/test_pipeline.py::test_cached_reference_encoder_true_concurrency_dedup`
- [x] `tests/unit_test/moss_tts_local/test_pipeline.py::test_cached_reference_encoder_failure_does_not_poison`
- [x] `tests/unit_test/moss_tts_local/test_pipeline.py::test_cached_reference_encoder_return_value_isolation`
- [x] `tests/unit_test/moss_tts_local/test_pipeline.py::test_cached_reference_encoder_duration_gate`
- [x] `tests/unit_test/moss_tts_local/test_pipeline.py::test_cached_reference_encoder_data_uri_hit_miss`
- [x] `tests/unit_test/moss_tts_local/test_pipeline.py::test_cached_reference_encoder_file_bytes_keyspaces_do_not_collide`
- [x] `tests/unit_test/moss_tts_local/test_pipeline.py::test_cached_reference_encoder_data_uri_duration_gate`
- [x] PR1 service contract tests remain the shared M4a contract coverage.

## Accuracy / perf gate

Manual MOSS CI runs:
- Baseline: [Omni CI 28695860705](https://github.com/sgl-project/sglang-omni/actions/runs/28695860705), `workflow_dispatch`, ref `e8bc08f`, `tts_ci_model=moss`, SeedTTS EN full set, concurrency 16.
- After: [Omni CI 28694178241](https://github.com/sgl-project/sglang-omni/actions/runs/28694178241), `workflow_dispatch`, ref `1518ab6`, `tts_ci_model=moss`, SeedTTS EN full set, concurrency 16.

| Model | Mode | WER before -> after | QPS before -> after | Latency before -> after | RTF before -> after | Gate |
|---|---|---:|---:|---:|---:|---|
| MOSS-local | non-stream | 2.60% -> 2.25% | 12.183 -> 12.331 | 1.308s -> 1.292s | 0.3096 -> 0.3049 | Pass; accuracy and perf unchanged/slightly better |
| MOSS-local | stream | 2.32% -> 2.47% | 8.608 -> 8.763 | 1.848s -> 1.816s | 0.4329 -> 0.4257 | Pass; WER within noise/gate, perf slightly better |

M4b decision gate after this PR: collect M4a hit/miss/merged stats, reference encode wall time, E2E latency share, batch-size distribution, GPU utilization, and batch-size 2/4/8/16 speedup before implementing shared batch coalescing.

## Resolved comments

- #661: keep PRs under the review budget and avoid dual old/new paths.
- #809: redo the extraction on top of current `main`'s richer MOSS-local encoder; keep `_BatchedReferenceEncoder` model-local in M4a.
- M4 design: PR3 replaces only cache/single-flight; it does not introduce M4b shared batching or M7 scheduler changes.

## Validation

- [x] `python3 -m py_compile sglang_omni/models/moss_tts_local/stages.py tests/unit_test/moss_tts_local/test_pipeline.py`
- [x] `git diff --check`
- [ ] `python3 -m pytest tests/unit_test/moss_tts_local/test_pipeline.py tests/unit_test/scheduling/test_reference_encoder.py -q` (blocked locally: available Python environments lack `torch` and `pytest`)
- [x] SeedTTS MOSS-local stream/non-stream accuracy/perf gate
- [ ] M4b profiling decision

## Checklist

- [ ] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the `run-ci` label. Once labeled, every subsequent push re-triggers CI as long as the label remains. Use `/tag-and-rerun-ci moss` or the current repo-supported MOSS-local selector to run the gate. Draft PRs are skipped even if labeled.