### PR TITLE
[router] Fix in-flight counter leak on mid-stream upstream failure

### DIFF
--- a/sglang_omni_router/proxy.py
+++ b/sglang_omni_router/proxy.py
@@ -284,18 +284,25 @@ class ProxyHandler:
                     return
                 raise
             finally:
-                await upstream.aclose()
-                worker.decrement_active()
-                status_code = upstream.status_code if outcome == "completed" else None
-                worker.record_routed_request(status_code=status_code)
-                self._log_route_completion(
-                    worker=worker,
-                    path=path,
-                    metadata=metadata,
-                    status_code=upstream.status_code,
-                    outcome=outcome,
-                    start_time=start_time,
-                )
+                # Note (Jiaxin Deng): decrement the in-flight count (and record
+                # completion) even if aclose() raises on a broken mid-stream
+                # connection, otherwise least_request drifts permanently.
+                try:
+                    await upstream.aclose()
+                finally:
+                    worker.decrement_active()
+                    status_code = (
+                        upstream.status_code if outcome == "completed" else None
+                    )
+                    worker.record_routed_request(status_code=status_code)
+                    self._log_route_completion(
+                        worker=worker,
+                        path=path,
+                        metadata=metadata,
+                        status_code=upstream.status_code,
+                        outcome=outcome,
+                        start_time=start_time,
+                    )
 
         try:
             headers = filter_response_headers(upstream.headers, buffered=not stream)

--- a/tests/unit_test/router/test_app.py
+++ b/tests/unit_test/router/test_app.py
@@ -1125,6 +1125,43 @@ def test_streaming_failure_records_single_worker_failure() -> None:
     assert worker.state == "healthy"
 
 
+def test_streaming_inflight_count_decrements_even_if_aclose_raises() -> None:
+    class AcloseRaisingStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield b"data: chunk\n\n"
+            raise httpx.ReadError("stream boom")
+
+        async def aclose(self) -> None:
+            raise RuntimeError("aclose boom")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "healthy"}, request=request)
+        if request.url.path == "/v1/chat/completions":
+            return httpx.Response(
+                200,
+                stream=AcloseRaisingStream(),
+                headers={"content-type": "text/event-stream"},
+                request=request,
+            )
+        raise AssertionError(f"unexpected request path: {request.url.path}")
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    app = create_app(_router_config(), client=async_client)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        with client.stream(
+            "POST",
+            "/v1/chat/completions",
+            json={"model": "qwen3-omni", "stream": True},
+        ) as response:
+            b"".join(response.iter_bytes())
+
+    # Note (Jiaxin Deng): the in-flight count must decrement even though aclose()
+    # raised, otherwise it leaks and least_request drifts permanently.
+    assert all(worker.active_requests == 0 for worker in app.state.workers)
+
+
 # Streaming-relay semantics for the non-streaming path (Phase 0, #920): the relay
 # no longer buffers the full body, so failures after the status commits truncate,
 # and the response is chunked with a status-code-based worker error string.

--- a/tests/unit_test/router/test_app.py
+++ b/tests/unit_test/router/test_app.py
@@ -1160,6 +1160,11 @@ def test_streaming_inflight_count_decrements_even_if_aclose_raises() -> None:
     # Note (Jiaxin Deng): the in-flight count must decrement even though aclose()
     # raised, otherwise it leaks and least_request drifts permanently.
     assert all(worker.active_requests == 0 for worker in app.state.workers)
+    # Note (Jiaxin Deng): record_routed_request() runs in the same finally, so the
+    # broken stream is still booked as a routed failure rather than silently
+    # dropped; guards against a future change skipping the completion accounting.
+    assert sum(worker.routed_requests for worker in app.state.workers) == 1
+    assert sum(worker.failed_requests for worker in app.state.workers) == 1
 
 
 # Streaming-relay semantics for the non-streaming path (Phase 0, #920): the relay


### PR DESCRIPTION
## Summary
Pre-existing in-flight counter leak in the streaming relay, found while testing #920.

In `_forward_streaming`'s cleanup, `await upstream.aclose()` runs before `worker.decrement_active()`. If `aclose()` raises on a broken mid-stream connection (a real case when the upstream fails mid-body), `decrement_active()` and the completion recording are skipped, so the in-flight count is never decremented and `least_request` load balancing drifts permanently toward the affected worker.

## Fix
Wrap `aclose()` in a `try/finally` so `decrement_active()` and the completion recording always run, whether or not `aclose()` raises. `proxy.py` only.

## Test [measured]
`test_streaming_inflight_count_decrements_even_if_aclose_raises`: a mid-stream failure whose `aclose()` also raises. Fails on current main (the count leaks to 1), passes with the fix (0). Full router suite green.

## Note
Pre-existing on main, independent of #920. #920 unifies the two relay methods into `_forward_relay`, which inherits the same cleanup, so this fix and #920 overlap; whichever merges second rebases to carry the fix into `_forward_relay`.
