### PR TITLE
[CI Perf] Use explicit TensorRef pipeline policies

### DIFF
--- a/sglang_omni/config/__init__.py
+++ b/sglang_omni/config/__init__.py
@@ -19,6 +19,7 @@ from sglang_omni.config.schema import (
     StageConfig,
     StageResourceConfig,
     StageRuntimeConfig,
+    TensorRefEdgeConfig,
 )
 from sglang_omni.config.topology import (
     ProcessGroupPlacement,
@@ -51,4 +52,5 @@ __all__ = [
     "PlacementConfig",
     "RelayConfig",
     "EndpointsConfig",
+    "TensorRefEdgeConfig",
 ]

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -20,6 +20,28 @@ class RelayConfig(BaseModel):
     device: str = "cpu"
 
 
+class TensorRefEdgeConfig(BaseModel):
+    """Explicit lazy tensor handoff policy for one outgoing stage edge."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    consumer_stage: str
+    threshold_mb: float = 2.0
+    paths: tuple[str, ...]
+
+    def model_post_init(self, __context: Any = None) -> None:
+        if self.threshold_mb < 0:
+            raise ValueError("tensor_ref_edges threshold_mb must be non-negative")
+        if not self.consumer_stage.strip():
+            raise ValueError("tensor_ref_edges consumer_stage must not be empty")
+        if not self.paths:
+            raise ValueError("tensor_ref_edges paths must not be empty")
+        cleaned = tuple(path.strip() for path in self.paths)
+        if any(not path for path in cleaned):
+            raise ValueError("tensor_ref_edges paths must not contain empty values")
+        self.paths = cleaned
+
+
 class EndpointsConfig(BaseModel):
     """Endpoint allocation settings."""
 
@@ -174,6 +196,7 @@ class StageConfig(BaseModel):
 
     # --- Relay (auto-inferred from gpu when None) ---
     relay: RelayConfig | None = None
+    tensor_ref_edges: dict[str, TensorRefEdgeConfig] = Field(default_factory=dict)
 
     def model_post_init(self, __context: Any = None) -> None:
         fields_set = self.__pydantic_fields_set__
@@ -370,6 +393,23 @@ class PipelineConfig(BaseModel):
                 if t not in names:
                     raise ValueError(
                         f"Stage {s.name!r} project_payload references unknown stage {t!r}"
+                    )
+            route_targets = set(_target_list(s.next)) | set(s.stream_to)
+            for t, tensor_ref in s.tensor_ref_edges.items():
+                if t not in names:
+                    raise ValueError(
+                        f"Stage {s.name!r} tensor_ref_edges references unknown "
+                        f"target stage {t!r}"
+                    )
+                if t not in route_targets:
+                    raise ValueError(
+                        f"Stage {s.name!r} tensor_ref_edges target {t!r} is not "
+                        "a declared next or stream_to target"
+                    )
+                if tensor_ref.consumer_stage not in names:
+                    raise ValueError(
+                        f"Stage {s.name!r} tensor_ref_edges target {t!r} has "
+                        f"unknown consumer_stage {tensor_ref.consumer_stage!r}"
                     )
 
         for stage_name in self.runtime_overrides:

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -7,12 +7,22 @@ from typing import ClassVar
 
 from pydantic import Field
 
-from sglang_omni.config import PipelineConfig, PlacementConfig, StageConfig
+from sglang_omni.config import (
+    PipelineConfig,
+    PlacementConfig,
+    StageConfig,
+    TensorRefEdgeConfig,
+)
 
 _PKG = "sglang_omni.models.qwen3_omni"
 _PLACEMENT_POLICY = f"{_PKG}.placement.Qwen3OmniPlacementPolicy"
 THINKER_STAGE = "thinker"
 MIN_PARTIAL_START_CHUNKS = 3
+_VISUAL_TENSOR_REF_PATHS = (
+    "video_embeds",
+    "deepstack_visual_embeds_image",
+    "deepstack_visual_embeds_video",
+)
 
 # SGLang reads this when DeepGEMM compile utilities are imported. Qwen AR
 # stages can first hit some dense FP8 shapes after readiness; disable all-M
@@ -58,6 +68,13 @@ def _image_encoder_stage(*, gpu: int, process: str) -> StageConfig:
         next="mm_aggregate",
         project_payload={
             "mm_aggregate": f"{_PKG}.request_builders.project_encoder_to_mm_aggregate"
+        },
+        tensor_ref_edges={
+            "mm_aggregate": TensorRefEdgeConfig(
+                consumer_stage="thinker",
+                threshold_mb=2.0,
+                paths=_VISUAL_TENSOR_REF_PATHS,
+            )
         },
     )
 

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -19,7 +19,6 @@ _PLACEMENT_POLICY = f"{_PKG}.placement.Qwen3OmniPlacementPolicy"
 THINKER_STAGE = "thinker"
 MIN_PARTIAL_START_CHUNKS = 3
 _VISUAL_TENSOR_REF_PATHS = (
-    "video_embeds",
     "deepstack_visual_embeds_image",
     "deepstack_visual_embeds_video",
 )

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -36,6 +36,7 @@ from sglang_omni.pipeline.stage_workers import (
     StageLaunchConfig,
     StageWorkerProcessSpec,
 )
+from sglang_omni.pipeline.tensor_ref import TensorRefPolicy
 from sglang_omni.utils.imports import import_string
 
 logger = logging.getLogger(__name__)
@@ -65,6 +66,11 @@ def _build_stage_groups(
         for target in scfg.stream_to:
             stream_receivers.add(target)
     stage_cfg_by_name = {stage.name: stage for stage in stages_cfg}
+    tensor_ref_consumer_stages = {
+        name_map.get(edge.consumer_stage, edge.consumer_stage)
+        for stage in stages_cfg
+        for edge in stage.tensor_ref_edges.values()
+    }
 
     nccl_port_counter = _NcclPortAllocator()
 
@@ -115,6 +121,10 @@ def _build_stage_groups(
             is_stream_receiver=stage_cfg.name in stream_receivers,
             can_accept_stream_before_payload=stage_cfg.can_accept_stream_before_payload,
             name_map=name_map,
+            tensor_ref_policies=_build_tensor_ref_policies(stage_cfg, name_map),
+            resolve_tensor_refs=(
+                name_map.get(stage_cfg.name, stage_cfg.name) in tensor_ref_consumer_stages
+            ),
         )
         if tp_size == 1:
             single_stage_specs[stage_cfg.name] = _build_single_stage_spec(
@@ -166,6 +176,24 @@ def _build_stage_groups(
     groups.extend(tp_groups)
 
     return groups
+
+
+def _build_tensor_ref_policies(
+    stage_cfg: StageConfig,
+    name_map: dict[str, str],
+) -> dict[str, TensorRefPolicy]:
+    policies: dict[str, TensorRefPolicy] = {}
+    from_stage = name_map.get(stage_cfg.name, stage_cfg.name)
+    for raw_target, edge in stage_cfg.tensor_ref_edges.items():
+        target = name_map.get(raw_target, raw_target)
+        policies[target] = TensorRefPolicy(
+            threshold_bytes=int(edge.threshold_mb * 1024 * 1024),
+            from_stage=from_stage,
+            to_stage=target,
+            consumer_stage=name_map.get(edge.consumer_stage, edge.consumer_stage),
+            path_allowlist=tuple(edge.paths),
+        )
+    return policies
 
 
 def _resolve_same_process_targets(

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -20,7 +20,7 @@ from typing import Any, Callable, Literal
 from sglang_omni.pipeline import relay_io
 from sglang_omni.pipeline.stage.input import DirectInput, InputHandler
 from sglang_omni.pipeline.stage.stream_queue import StreamItem, StreamQueue
-from sglang_omni.pipeline.tensor_ref import TensorRefPolicy, tensor_refs_enabled
+from sglang_omni.pipeline.tensor_ref import TensorRefPolicy
 from sglang_omni.pipeline.tp_control import TPLeaderFanout, TPWorkMessage
 from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.profiler.event_recorder import get_recorder as _get_recorder
@@ -87,6 +87,8 @@ class Stage:
         can_accept_stream_before_payload: bool = False,
         tp_fanout: TPLeaderFanout | None = None,
         is_terminal: bool = False,
+        tensor_ref_policies: dict[str, TensorRefPolicy] | None = None,
+        resolve_tensor_refs: bool = False,
     ):
         self.name = name
         self.role = role
@@ -106,6 +108,8 @@ class Stage:
         self._tp_fanout = tp_fanout
         self._is_terminal = is_terminal
         self._owns_external_io = role in {"single", "leader"}
+        self._tensor_ref_policies = tensor_ref_policies or {}
+        self._resolve_tensor_refs = resolve_tensor_refs
 
         # --- Relay ---
         if relay is not None:
@@ -301,10 +305,11 @@ class Stage:
         if self._stream_queue is not None and not self._stream_queue.has(request_id):
             self._stream_queue.open(request_id)
 
-        # Read payload from relay
         try:
             payload = await relay_io.read_payload(
-                self.relay, request_id, msg.shm_metadata
+                self.relay,
+                request_id,
+                msg.shm_metadata,
             )
         except Exception as exc:
             logger.exception(
@@ -314,7 +319,11 @@ class Stage:
             await self._send_failure(request_id, f"relay read failed: {exc}")
             return
 
-        await self._receive_payload_from_stage(request_id, msg.from_stage, payload)
+        await self._receive_payload_from_stage(
+            request_id,
+            msg.from_stage,
+            payload,
+        )
 
     async def receive_local_payload(
         self,
@@ -681,7 +690,7 @@ class Stage:
             # until blob reads are ref-counted/non-destructive.
             self._tp_fanout.fanout_work(payload)
         payload_for_scheduler = payload
-        if tensor_refs_enabled():
+        if self._resolve_tensor_refs:
             payload_for_scheduler = await relay_io.materialize_payload_tensor_refs(
                 self.relay, payload, current_stage=self.name
             )
@@ -1003,9 +1012,7 @@ class Stage:
             )
             return
 
-        tensor_ref_policy = TensorRefPolicy.from_env(
-            from_stage=self.name, to_stage=target
-        )
+        tensor_ref_policy = self._tensor_ref_policies.get(target)
         metadata, op = await relay_io.write_payload(
             self.relay,
             request_id,

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -20,6 +20,7 @@ from sglang_omni.pipeline.local_dispatch import LocalStageDispatcher
 from sglang_omni.pipeline.stage.input import AggregatedInput, DirectInput
 from sglang_omni.pipeline.stage.runtime import Stage
 from sglang_omni.pipeline.stage.stream_queue import StreamQueue
+from sglang_omni.pipeline.tensor_ref import TensorRefPolicy
 from sglang_omni.pipeline.tp_control import TPFollowerControlPlane, TPLeaderFanout
 from sglang_omni.utils.gpu_compat import (
     apply_gpu_compat_env_defaults,
@@ -70,6 +71,8 @@ class StageLaunchConfig:
 
     # Relay
     relay_config: dict[str, Any] = field(default_factory=dict)
+    tensor_ref_policies: dict[str, TensorRefPolicy] = field(default_factory=dict)
+    resolve_tensor_refs: bool = False
 
     # Endpoints
     recv_endpoint: str = ""
@@ -616,6 +619,8 @@ def _construct_stage(
         can_accept_stream_before_payload=spec.can_accept_stream_before_payload,
         tp_fanout=tp_fanout,
         is_terminal=spec.is_terminal,
+        tensor_ref_policies=spec.tensor_ref_policies,
+        resolve_tensor_refs=spec.resolve_tensor_refs,
     )
 
     if spec.is_stream_receiver:

--- a/sglang_omni/pipeline/tensor_ref.py
+++ b/sglang_omni/pipeline/tensor_ref.py
@@ -8,9 +8,7 @@ the declared ``consumer_stage`` resolves it back into a real tensor.
 """
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
-from functools import lru_cache
 from typing import Any
 
 import torch
@@ -71,10 +69,6 @@ class TensorRef:
         )
 
 
-def tensor_refs_enabled() -> bool:
-    return os.environ.get("SGLANG_OMNI_ENABLE_TENSOR_REFS") == "1"
-
-
 def is_tensor_ref_dict(obj: Any) -> bool:
     return isinstance(obj, dict) and obj.get(TENSOR_REF_MARKER) is True
 
@@ -110,46 +104,3 @@ class TensorRefPolicy:
             return False
         nbytes = tensor.numel() * tensor.element_size()
         return nbytes >= self.threshold_bytes
-
-    @classmethod
-    def from_env(cls, *, from_stage: str, to_stage: str) -> "TensorRefPolicy | None":
-        if os.environ.get("SGLANG_OMNI_ENABLE_TENSOR_REFS") != "1":
-            return None
-        edges = _parse_edges(os.environ.get("SGLANG_OMNI_TENSOR_REF_EDGES", ""))
-        consumer_stage = edges.get((from_stage, to_stage))
-        if consumer_stage is None:
-            return None
-        threshold_mb = float(
-            os.environ.get(
-                "SGLANG_OMNI_TENSOR_REF_THRESHOLD_MB",
-                str(DEFAULT_TENSOR_REF_THRESHOLD_MB),
-            )
-        )
-        raw_paths = os.environ.get("SGLANG_OMNI_TENSOR_REF_PATHS")
-        path_allowlist = (
-            tuple(p.strip() for p in raw_paths.split(",") if p.strip())
-            if raw_paths is not None
-            else DEFAULT_TENSOR_REF_PATHS
-        )
-        return cls(
-            threshold_bytes=int(threshold_mb * 1024 * 1024),
-            from_stage=from_stage,
-            to_stage=to_stage,
-            consumer_stage=consumer_stage,
-            path_allowlist=path_allowlist,
-        )
-
-
-@lru_cache(maxsize=1)
-def _parse_edges(raw: str) -> dict[tuple[str, str], str]:
-    edges: dict[tuple[str, str], str] = {}
-    for entry in raw.split(","):
-        entry = entry.strip()
-        if not entry:
-            continue
-        parts = entry.split(":")
-        if len(parts) != 3:
-            continue
-        from_stage, to_stage, consumer_stage = (p.strip() for p in parts)
-        edges[(from_stage, to_stage)] = consumer_stage
-    return edges

--- a/tests/unit_test/pipeline/test_stage.py
+++ b/tests/unit_test/pipeline/test_stage.py
@@ -281,12 +281,8 @@ def test_relay_payload_and_cross_gpu_stream_contracts() -> None:
     asyncio.run(_run())
 
 
-def test_stage_execute_fanouts_unresolved_payload_before_materializing_refs(
-    monkeypatch,
-) -> None:
+def test_stage_execute_fanouts_unresolved_payload_before_materializing_refs() -> None:
     """TP followers get the unresolved ref; the local scheduler gets the resolved tensor."""
-    monkeypatch.setenv("SGLANG_OMNI_ENABLE_TENSOR_REFS", "1")
-
     async def _run() -> None:
         relay = FakeRelay()
         tensor = torch.arange(6, dtype=torch.float32)
@@ -322,6 +318,7 @@ def test_stage_execute_fanouts_unresolved_payload_before_materializing_refs(
             scheduler=scheduler,
             relay=relay,
             tp_fanout=tp_fanout,
+            resolve_tensor_refs=True,
         )
 
         await stage_obj._execute(payload)
@@ -335,17 +332,8 @@ def test_stage_execute_fanouts_unresolved_payload_before_materializing_refs(
     asyncio.run(_run())
 
 
-def test_send_to_stage_does_not_block_on_externalized_tensor_ref_blob(
-    monkeypatch,
-) -> None:
+def test_send_to_stage_does_not_block_on_externalized_tensor_ref_blob() -> None:
     """The small envelope op completes without waiting on the deferred blob op."""
-    monkeypatch.setenv("SGLANG_OMNI_ENABLE_TENSOR_REFS", "1")
-    monkeypatch.setenv(
-        "SGLANG_OMNI_TENSOR_REF_EDGES", "image_encoder:mm_aggregate:thinker"
-    )
-    monkeypatch.setenv("SGLANG_OMNI_TENSOR_REF_PATHS", "big")
-    monkeypatch.setenv("SGLANG_OMNI_TENSOR_REF_THRESHOLD_MB", "0")
-
     async def _run() -> None:
         gate = asyncio.Event()
 
@@ -365,10 +353,18 @@ def test_send_to_stage_does_not_block_on_externalized_tensor_ref_blob(
                 return op
 
         relay = GatedRelay()
+        policy = TensorRefPolicy(
+            threshold_bytes=0,
+            from_stage="image_encoder",
+            to_stage="mm_aggregate",
+            consumer_stage="thinker",
+            path_allowlist=("big",),
+        )
         stage_obj = make_stage(
             name="image_encoder",
             endpoints={"mm_aggregate": "inproc://mm"},
             relay=relay,
+            tensor_ref_policies={"mm_aggregate": policy},
         )
         payload = make_stage_payload(request_id="req-1", data={"big": torch.randn(4)})
 
@@ -465,8 +461,6 @@ def test_stage_abort_releases_tracked_unresolved_tensor_ref_payload() -> None:
 
 
 def test_stage_abort_preserves_tracked_refs_across_ref_free_fanin(monkeypatch) -> None:
-    monkeypatch.setenv("SGLANG_OMNI_ENABLE_TENSOR_REFS", "1")
-
     async def _run() -> None:
         relay = FakeRelay()
         tensor = torch.arange(8, dtype=torch.float32)
@@ -496,6 +490,7 @@ def test_stage_abort_preserves_tracked_refs_across_ref_free_fanin(monkeypatch) -
             name="mm_aggregate",
             relay=relay,
             input_handler=AggregatedInput({"image_encoder", "preprocessing"}, _merge),
+            resolve_tensor_refs=True,
         )
         started_materialize = asyncio.Event()
         release_materialize = asyncio.Event()

--- a/tests/unit_test/pipeline/test_tensor_ref.py
+++ b/tests/unit_test/pipeline/test_tensor_ref.py
@@ -7,7 +7,9 @@ import asyncio
 import pytest
 import torch
 
+from sglang_omni.config import StageConfig, TensorRefEdgeConfig
 from sglang_omni.pipeline import relay_io
+from sglang_omni.pipeline.mp_runner import _build_tensor_ref_policies
 from sglang_omni.pipeline.tensor_ref import (
     DEFAULT_TENSOR_REF_PATHS,
     DEFAULT_TENSOR_REF_THRESHOLD_MB,
@@ -15,11 +17,11 @@ from sglang_omni.pipeline.tensor_ref import (
     TensorRefPolicy,
     is_tensor_ref_dict,
     tensor_ref_numel,
-    tensor_refs_enabled,
 )
 from tests.unit_test.fixtures.pipeline_fakes import (
     DestructiveFakeRelay,
     FakeRelay,
+    fake_factory_path,
     make_stage_payload,
 )
 
@@ -75,28 +77,26 @@ def test_policy_should_externalize_respects_allowlist_and_threshold() -> None:
     assert not policy.should_externalize("encoder_outs.image_encoder.image_embeds", big)
 
 
-def test_policy_from_env_disabled_by_default(monkeypatch) -> None:
-    monkeypatch.delenv("SGLANG_OMNI_ENABLE_TENSOR_REFS", raising=False)
-    assert not tensor_refs_enabled()
-    assert (
-        TensorRefPolicy.from_env(from_stage="image_encoder", to_stage="mm_aggregate")
-        is None
+def test_explicit_stage_config_builds_tensor_ref_policy() -> None:
+    stage_cfg = StageConfig(
+        name="image_encoder",
+        process="pipeline",
+        factory=fake_factory_path("make_scheduler"),
+        next="mm_aggregate",
+        tensor_ref_edges={
+            "mm_aggregate": TensorRefEdgeConfig(
+                consumer_stage="thinker",
+                threshold_mb=DEFAULT_TENSOR_REF_THRESHOLD_MB,
+                paths=DEFAULT_TENSOR_REF_PATHS,
+            )
+        },
     )
 
+    policies = _build_tensor_ref_policies(stage_cfg, {})
+    policy = policies["mm_aggregate"]
 
-def test_policy_from_env_requires_declared_edge(monkeypatch) -> None:
-    monkeypatch.setenv("SGLANG_OMNI_ENABLE_TENSOR_REFS", "1")
-    monkeypatch.setenv(
-        "SGLANG_OMNI_TENSOR_REF_EDGES", "image_encoder:mm_aggregate:thinker"
-    )
-    assert tensor_refs_enabled()
-    assert (
-        TensorRefPolicy.from_env(from_stage="mm_aggregate", to_stage="thinker") is None
-    )
-    policy = TensorRefPolicy.from_env(
-        from_stage="image_encoder", to_stage="mm_aggregate"
-    )
-    assert policy is not None
+    assert policy.from_stage == "image_encoder"
+    assert policy.to_stage == "mm_aggregate"
     assert policy.consumer_stage == "thinker"
     assert DEFAULT_TENSOR_REF_THRESHOLD_MB == 2.0
     assert policy.threshold_bytes == 2 * 1024 * 1024

--- a/tests/unit_test/qwen3_omni/test_pipeline.py
+++ b/tests/unit_test/qwen3_omni/test_pipeline.py
@@ -92,6 +92,7 @@ def test_qwen_pipeline_config_and_state_contracts() -> None:
     speech_talker = _stage(speech_config, "talker_ar")
     text_thinker = _stage(text_config, "thinker")
     preprocessing = _stage(speech_config, "preprocessing")
+    image_encoder = _stage(speech_config, "image_encoder")
     aggregate = _stage(speech_config, "mm_aggregate")
     # Speech-mode thinker streams hidden states to talker_ar AND text-token
     # ids to decode (for the streaming detokenizer); text-mode thinker
@@ -108,6 +109,14 @@ def test_qwen_pipeline_config_and_state_contracts() -> None:
     )
     assert aggregate.route_fn == (
         f"{request_builders_path}.resolve_mm_aggregate_next_stages"
+    )
+    tensor_ref = image_encoder.tensor_ref_edges["mm_aggregate"]
+    assert tensor_ref.consumer_stage == "thinker"
+    assert tensor_ref.threshold_mb == 2.0
+    assert tensor_ref.paths == (
+        "video_embeds",
+        "deepstack_visual_embeds_image",
+        "deepstack_visual_embeds_video",
     )
     assert speech_thinker.stream_to == ["talker_ar", "decode"]
     assert speech_thinker.route_fn == (

--- a/tests/unit_test/qwen3_omni/test_pipeline.py
+++ b/tests/unit_test/qwen3_omni/test_pipeline.py
@@ -114,7 +114,6 @@ def test_qwen_pipeline_config_and_state_contracts() -> None:
     assert tensor_ref.consumer_stage == "thinker"
     assert tensor_ref.threshold_mb == 2.0
     assert tensor_ref.paths == (
-        "video_embeds",
         "deepstack_visual_embeds_image",
         "deepstack_visual_embeds_video",
     )
@@ -1158,22 +1157,34 @@ def test_qwen_mm_aggregate_keeps_lightweight_inputs_and_prunes_after_merge() -> 
     }
 
 
-def test_qwen_merge_preserves_unresolved_video_tensor_ref() -> None:
-    """A lazily-externalized video_embeds ref survives merge unresolved."""
+def test_qwen_merge_preserves_unresolved_deepstack_tensor_ref() -> None:
+    """A lazily-externalized deepstack ref survives merge unresolved."""
     ref = TensorRef(
-        ref_id="req-qwen:tensor_ref:image_encoder:mm_aggregate:abc:video_embeds",
+        ref_id=(
+            "req-qwen:tensor_ref:image_encoder:mm_aggregate:abc:"
+            "deepstack_visual_embeds_video"
+        ),
         request_id="req-qwen",
         producer_stage="image_encoder",
         consumer_stage="thinker",
-        path="encoder_outs.image_encoder.video_embeds",
+        path="encoder_outs.image_encoder.deepstack_visual_embeds_video",
         shape=(4, 8),
         dtype="torch.bfloat16",
         nbytes=4 * 8 * 2,
-        blob_key="req-qwen:tensor_ref:image_encoder:mm_aggregate:abc:video_embeds",
+        blob_key=(
+            "req-qwen:tensor_ref:image_encoder:mm_aggregate:abc:"
+            "deepstack_visual_embeds_video"
+        ),
         blob_metadata={"relay_info": {}, "tensor_shape": [4, 8]},
     )
+    video_embeds = torch.ones((4, 8), dtype=torch.bfloat16)
     image_state = Qwen3OmniPipelineState(
-        encoder_outs={"image_encoder": {"video_embeds": ref.to_dict()}}
+        encoder_outs={
+            "image_encoder": {
+                "video_embeds": video_embeds,
+                "deepstack_visual_embeds_video": ref.to_dict(),
+            }
+        }
     )
 
     merged = merge_for_thinker(
@@ -1184,9 +1195,11 @@ def test_qwen_merge_preserves_unresolved_video_tensor_ref() -> None:
     )
     merged_state = Qwen3OmniPipelineState.from_dict(merged.data)
 
-    video_embeds = merged_state.thinker_inputs["model_inputs"]["video_embeds"]
-    assert is_tensor_ref_dict(video_embeds)
-    assert video_embeds == ref.to_dict()
+    model_inputs = merged_state.thinker_inputs["model_inputs"]
+    assert torch.equal(model_inputs["video_embeds"], video_embeds)
+    deepstack_embeds = model_inputs["deepstack_visual_embeds"]
+    assert is_tensor_ref_dict(deepstack_embeds)
+    assert deepstack_embeds == ref.to_dict()
 
 
 def test_qwen_thinker_request_and_decode_contracts() -> None:


### PR DESCRIPTION
## Summary
- remove TensorRef env gates and the from_env parser
- add explicit TensorRef edge policy config on StageConfig
- wire the Qwen image_encoder -> mm_aggregate TensorRef policy directly in pipeline config

## Tests
- python3 -m py_compile on changed Python files
- bundled Python Qwen config smoke for image_encoder TensorRef policy
- pytest not run locally: both available Python runtimes are missing pytest