### PR TITLE
[TTS Refactor][M8] Model capabilities: Add static TTS model capability metadata

### DIFF
--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -199,12 +199,17 @@ class StageConfig(BaseModel):
 
 
 class PipelineConfig(BaseModel):
-    """Top-level pipeline configuration."""
+    """Top-level pipeline configuration.
+
+    Subclasses set ``requires_model_capabilities`` when their model package
+    must export static architecture-level capability metadata.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
     architecture: ClassVar[str | None] = None
     architecture_aliases: ClassVar[tuple[str, ...]] = ()
+    requires_model_capabilities: ClassVar[bool] = False
     tensor_parallel_disable_custom_all_reduce_stages: ClassVar[tuple[str, ...]] = ()
 
     model_path: str

--- a/sglang_omni/models/fishaudio_s2_pro/__init__.py
+++ b/sglang_omni/models/fishaudio_s2_pro/__init__.py
@@ -1,6 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """FishAudio S2-Pro model support for sglang-omni."""
 
+from sglang_omni.models.model_capabilities import ModelCapabilities
+
 from . import config
 
-__all__ = ["config"]
+CAPABILITIES = ModelCapabilities(
+    supports_reference_audio=True,
+    supports_batch_vocoder=True,
+    supports_streaming_vocoder=True,
+    supports_cuda_graph=True,
+    supports_torch_compile=True,
+)
+
+__all__ = ["CAPABILITIES", "config"]

--- a/sglang_omni/models/fishaudio_s2_pro/config.py
+++ b/sglang_omni/models/fishaudio_s2_pro/config.py
@@ -14,6 +14,7 @@ class S2ProPipelineConfig(PipelineConfig):
     """3-stage TTS pipeline: preprocessing → tts_engine → vocoder."""
 
     architecture: ClassVar[str] = "FishQwen3OmniForCausalLM"
+    requires_model_capabilities: ClassVar[bool] = True
 
     @classmethod
     def talker_sglang_role_to_stage(cls) -> dict[str, str]:

--- a/sglang_omni/models/higgs_tts/__init__.py
+++ b/sglang_omni/models/higgs_tts/__init__.py
@@ -12,9 +12,19 @@ from __future__ import annotations
 
 from transformers import AutoConfig
 
+from sglang_omni.models.model_capabilities import ModelCapabilities
+
 from . import config
 from .hf_config import HiggsMultimodalQwen3Config
 
 AutoConfig.register("higgs_multimodal_qwen3", HiggsMultimodalQwen3Config)
 
-__all__ = ["config", "HiggsMultimodalQwen3Config"]
+CAPABILITIES = ModelCapabilities(
+    supports_reference_audio=True,
+    supports_batch_vocoder=True,
+    supports_streaming_vocoder=True,
+    supports_cuda_graph=True,
+    supports_torch_compile=True,
+)
+
+__all__ = ["CAPABILITIES", "config", "HiggsMultimodalQwen3Config"]

--- a/sglang_omni/models/higgs_tts/config.py
+++ b/sglang_omni/models/higgs_tts/config.py
@@ -22,6 +22,7 @@ class HiggsTtsPipelineConfig(PipelineConfig):
     """
 
     architecture: ClassVar[str] = "HiggsMultimodalQwen3ForConditionalGeneration"
+    requires_model_capabilities: ClassVar[bool] = True
 
     @classmethod
     def generation_sglang_role_to_stage(cls) -> dict[str, str]:

--- a/sglang_omni/models/model_capabilities.py
+++ b/sglang_omni/models/model_capabilities.py
@@ -10,10 +10,24 @@ from types import ModuleType
 
 @dataclass(frozen=True)
 class ModelCapabilities:
-    """Static capability declaration for a TTS model architecture.
+    """Static capability declaration for a model architecture.
 
-    These flags describe what a model architecture can support, not what a
-    specific pipeline instance enables for a checkpoint or deployment.
+    These flags describe what a model architecture can support. Concrete
+    checkpoint and deployment policy stays with ``PipelineConfig`` methods. For
+    example, a Qwen3-TTS CustomVoice checkpoint can reject uploaded reference
+    audio even though the architecture declares reference-audio support.
+
+    Fields:
+    - supports_reference_audio: the architecture can condition on reference
+      audio when the selected checkpoint/deployment allows it.
+    - supports_batch_vocoder: the architecture can produce batched waveform
+      output.
+    - supports_streaming_vocoder: the architecture can stream vocoder output
+      before the full generation payload is complete.
+    - supports_cuda_graph: the architecture has a CUDA graph path.
+    - supports_torch_compile: the architecture has an owned ``torch.compile``
+      path, including codec, codebook, or frame-sampler compiles. This is not
+      limited to the generic SGLang ``enable_torch_compile`` server arg.
     """
 
     supports_reference_audio: bool

--- a/sglang_omni/models/model_capabilities.py
+++ b/sglang_omni/models/model_capabilities.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Capability declarations for model architectures."""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from types import ModuleType
+
+
+@dataclass(frozen=True)
+class ModelCapabilities:
+    """Static capability declaration for a TTS model architecture.
+
+    These flags describe what a model architecture can support, not what a
+    specific pipeline instance enables for a checkpoint or deployment.
+    """
+
+    supports_reference_audio: bool
+    supports_batch_vocoder: bool
+    supports_streaming_vocoder: bool
+    supports_cuda_graph: bool
+    supports_torch_compile: bool
+
+
+def get_model_capabilities(architecture: str) -> ModelCapabilities | None:
+    """Look up capabilities for a registered model architecture."""
+    module = _model_package_for_architecture(architecture)
+    if module is None:
+        return None
+    return _module_model_capabilities(module)
+
+
+def _model_package_for_architecture(architecture: str) -> ModuleType | None:
+    from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+
+    config_cls = PIPELINE_CONFIG_REGISTRY.configs.get(architecture)
+    if config_cls is None:
+        return None
+    package = config_cls.__module__.rsplit(".", 1)[0]
+    return importlib.import_module(package)
+
+
+def _module_model_capabilities(module: ModuleType) -> ModelCapabilities | None:
+    capabilities = getattr(module, "CAPABILITIES", None)
+    if capabilities is None:
+        return None
+    return _ensure_model_capabilities(
+        capabilities, f"{module.__name__}.CAPABILITIES"
+    )
+
+
+def _ensure_model_capabilities(
+    capabilities: object, source: str
+) -> ModelCapabilities:
+    if not isinstance(capabilities, ModelCapabilities):
+        raise TypeError(f"{source} must be a ModelCapabilities instance")
+    return capabilities
+
+
+__all__ = [
+    "ModelCapabilities",
+    "get_model_capabilities",
+]

--- a/sglang_omni/models/model_capabilities.py
+++ b/sglang_omni/models/model_capabilities.py
@@ -45,14 +45,10 @@ def _module_model_capabilities(module: ModuleType) -> ModelCapabilities | None:
     capabilities = getattr(module, "CAPABILITIES", None)
     if capabilities is None:
         return None
-    return _ensure_model_capabilities(
-        capabilities, f"{module.__name__}.CAPABILITIES"
-    )
+    return _ensure_model_capabilities(capabilities, f"{module.__name__}.CAPABILITIES")
 
 
-def _ensure_model_capabilities(
-    capabilities: object, source: str
-) -> ModelCapabilities:
+def _ensure_model_capabilities(capabilities: object, source: str) -> ModelCapabilities:
     if not isinstance(capabilities, ModelCapabilities):
         raise TypeError(f"{source} must be a ModelCapabilities instance")
     return capabilities

--- a/sglang_omni/models/moss_tts/__init__.py
+++ b/sglang_omni/models/moss_tts/__init__.py
@@ -1,2 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """MOSS-TTS support for SGLang Omni."""
+
+from sglang_omni.models.model_capabilities import ModelCapabilities
+
+CAPABILITIES = ModelCapabilities(
+    supports_reference_audio=True,
+    supports_batch_vocoder=True,
+    supports_streaming_vocoder=False,
+    supports_cuda_graph=True,
+    supports_torch_compile=False,
+)
+
+__all__ = ["CAPABILITIES"]

--- a/sglang_omni/models/moss_tts/config.py
+++ b/sglang_omni/models/moss_tts/config.py
@@ -14,6 +14,7 @@ class MossTTSPipelineConfig(PipelineConfig):
     """MOSS-TTS Delay pipeline: preprocessing -> AR engine -> vocoder."""
 
     architecture: ClassVar[str] = "MossTTSDelayModel"
+    requires_model_capabilities: ClassVar[bool] = True
     architecture_aliases: ClassVar[tuple[str, ...]] = (
         "MossTTSDelay",
         "MossTTSDelayForConditionalGeneration",

--- a/sglang_omni/models/moss_tts_local/__init__.py
+++ b/sglang_omni/models/moss_tts_local/__init__.py
@@ -1,2 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """MOSS-TTS Local (v1.5) pipeline package."""
+
+from sglang_omni.models.model_capabilities import ModelCapabilities
+
+CAPABILITIES = ModelCapabilities(
+    supports_reference_audio=True,
+    supports_batch_vocoder=True,
+    supports_streaming_vocoder=True,
+    supports_cuda_graph=True,
+    supports_torch_compile=False,
+)
+
+__all__ = ["CAPABILITIES"]

--- a/sglang_omni/models/moss_tts_local/__init__.py
+++ b/sglang_omni/models/moss_tts_local/__init__.py
@@ -8,7 +8,7 @@ CAPABILITIES = ModelCapabilities(
     supports_batch_vocoder=True,
     supports_streaming_vocoder=True,
     supports_cuda_graph=True,
-    supports_torch_compile=False,
+    supports_torch_compile=True,
 )
 
 __all__ = ["CAPABILITIES"]

--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -79,6 +79,7 @@ class MossTTSLocalPipelineConfig(PipelineConfig):
     """Single-GPU MOSS-TTS Local pipeline."""
 
     architecture: ClassVar[str] = "MossTTSLocalModel"
+    requires_model_capabilities: ClassVar[bool] = True
     architecture_aliases: ClassVar[tuple[str, ...]] = (
         "MossTTSLocal",
         "MossTTSLocalForConditionalGeneration",

--- a/sglang_omni/models/qwen3_tts/__init__.py
+++ b/sglang_omni/models/qwen3_tts/__init__.py
@@ -1,6 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """Qwen3-TTS Base model support for sglang-omni."""
 
+from sglang_omni.models.model_capabilities import ModelCapabilities
+
 from . import config
 
-__all__ = ["config"]
+CAPABILITIES = ModelCapabilities(
+    supports_reference_audio=True,
+    supports_batch_vocoder=True,
+    supports_streaming_vocoder=False,
+    supports_cuda_graph=True,
+    supports_torch_compile=True,
+)
+
+__all__ = ["CAPABILITIES", "config"]

--- a/sglang_omni/models/qwen3_tts/config.py
+++ b/sglang_omni/models/qwen3_tts/config.py
@@ -21,6 +21,7 @@ class Qwen3TTSPipelineConfig(PipelineConfig):
     """3-stage Qwen3-TTS Base pipeline: preprocessing -> engine -> vocoder."""
 
     architecture: ClassVar[str] = "Qwen3TTSForConditionalGeneration"
+    requires_model_capabilities: ClassVar[bool] = True
 
     @classmethod
     def generation_sglang_role_to_stage(cls) -> dict[str, str]:

--- a/sglang_omni/models/voxtral_tts/__init__.py
+++ b/sglang_omni/models/voxtral_tts/__init__.py
@@ -1,5 +1,15 @@
 """Voxtral-4B-TTS model support for sglang-omni."""
 
+from sglang_omni.models.model_capabilities import ModelCapabilities
+
 from . import config
 
-__all__ = ["config"]
+CAPABILITIES = ModelCapabilities(
+    supports_reference_audio=False,
+    supports_batch_vocoder=False,
+    supports_streaming_vocoder=False,
+    supports_cuda_graph=True,
+    supports_torch_compile=True,
+)
+
+__all__ = ["CAPABILITIES", "config"]

--- a/sglang_omni/models/voxtral_tts/config.py
+++ b/sglang_omni/models/voxtral_tts/config.py
@@ -17,6 +17,7 @@ _PKG = "sglang_omni.models.voxtral_tts.pipeline"
 
 class VoxtralTTSPipelineConfig(PipelineConfig):
     architecture: ClassVar[str] = "VoxtralTTSForConditionalGeneration"
+    requires_model_capabilities: ClassVar[bool] = True
 
     @classmethod
     def generation_sglang_role_to_stage(cls) -> dict[str, str]:

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -25,6 +25,7 @@ Export a config to JSON::
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import socket
@@ -38,6 +39,7 @@ from pydantic import BaseModel
 
 from sglang_omni.client import Client
 from sglang_omni.config import PipelineConfig
+from sglang_omni.models.model_capabilities import get_model_capabilities
 from sglang_omni.pipeline.mp_runner import MultiProcessPipelineRunner
 from sglang_omni.profiler.event_recorder import get_recorder as _get_event_recorder
 from sglang_omni.profiler.profiler_control import ProfilerControlClient
@@ -148,6 +150,38 @@ def _placement_log_summary(
             for gpu_id, gpu in placement_plan.gpus.items()
         },
     }
+
+
+def _model_capabilities_log_summary(
+    pipeline_config: PipelineConfig,
+) -> dict[str, Any] | None:
+    architecture = getattr(type(pipeline_config), "architecture", None)
+    if architecture is None:
+        return None
+    capabilities = get_model_capabilities(architecture)
+    if capabilities is None:
+        return None
+    return {
+        "architecture": architecture,
+        "reference_audio": capabilities.supports_reference_audio,
+        "batch_vocoder": capabilities.supports_batch_vocoder,
+        "streaming_vocoder": capabilities.supports_streaming_vocoder,
+        "cuda_graph": capabilities.supports_cuda_graph,
+        "torch_compile": capabilities.supports_torch_compile,
+    }
+
+
+def _log_model_capabilities(pipeline_config: PipelineConfig) -> None:
+    try:
+        summary = _model_capabilities_log_summary(pipeline_config)
+    except Exception:
+        logger.warning(
+            "Failed to resolve model capabilities for startup log",
+            exc_info=True,
+        )
+        return
+    if summary is not None:
+        logger.info("Model capabilities: %s", json.dumps(summary, sort_keys=True))
 
 
 class StartReq(BaseModel):
@@ -325,6 +359,7 @@ async def _run_server(
     logger.info(
         f"Resolved placement/topology plan: placement={placement_summary}",
     )
+    _log_model_capabilities(pipeline_config)
     logger.info(
         "Pipeline '%s' started (%d GPU(s))",
         pipeline_config.name,

--- a/tests/README.md
+++ b/tests/README.md
@@ -36,6 +36,8 @@ tests/
     │   ├── test_stage.py
     │   ├── test_stage_process_env.py
     │   └── test_stage_streaming.py
+    ├── models/
+    │   └── test_model_capabilities.py
     ├── qwen3_omni/
     │   ├── test_cli.py
     │   ├── test_code2wav.py
@@ -288,6 +290,9 @@ that happened to contain an older version of the test.
 - `unit_test/utils/`: Shared utility tests:
   - audio loading helpers for data URIs, file URIs, HTTP URLs, timeout fallback,
     and mono/channel preservation.
+- `unit_test/models/`: Model registry and cross-model contract tests:
+  - static TTS `ModelCapabilities` declarations, registry lookup, aliases, and
+    launcher startup logging.
 - `unit_test/qwen3_asr/`: Qwen3-ASR unit tests:
   - pipeline config and stage factory concurrency defaults
   - single-source audio token length formula used by both processor and

--- a/tests/unit_test/models/__init__.py
+++ b/tests/unit_test/models/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/unit_test/models/test_model_capabilities.py
+++ b/tests/unit_test/models/test_model_capabilities.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import importlib
+import sys
 from dataclasses import MISSING, FrozenInstanceError, fields
+from types import ModuleType
 
 import pytest
 
@@ -12,10 +14,6 @@ from sglang_omni.models.model_capabilities import (
     get_model_capabilities,
 )
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
-from sglang_omni.serve.launcher import (
-    _log_model_capabilities,
-    _model_capabilities_log_summary,
-)
 
 EXPECTED_TTS_CAPABILITIES = {
     "Qwen3TTSForConditionalGeneration": ModelCapabilities(
@@ -44,7 +42,7 @@ EXPECTED_TTS_CAPABILITIES = {
         supports_batch_vocoder=True,
         supports_streaming_vocoder=True,
         supports_cuda_graph=True,
-        supports_torch_compile=False,
+        supports_torch_compile=True,
     ),
     "FishQwen3OmniForCausalLM": ModelCapabilities(
         supports_reference_audio=True,
@@ -62,15 +60,6 @@ EXPECTED_TTS_CAPABILITIES = {
     ),
 }
 
-TTS_PACKAGE_NAMES = {
-    "fishaudio_s2_pro",
-    "higgs_tts",
-    "moss_tts",
-    "moss_tts_local",
-    "qwen3_tts",
-    "voxtral_tts",
-}
-
 
 def _package_for_architecture(architecture: str):
     config_cls = PIPELINE_CONFIG_REGISTRY.configs.get(architecture)
@@ -78,14 +67,21 @@ def _package_for_architecture(architecture: str):
     return importlib.import_module(config_cls.__module__.rsplit(".", 1)[0])
 
 
-def test_expected_tts_capabilities_cover_registered_tts_configs() -> None:
-    registered_tts_architectures = {
+def _capability_required_architectures() -> set[str]:
+    return {
         config_cls.architecture
-        for config_cls in PIPELINE_CONFIG_REGISTRY.configs.values()
-        if config_cls.__module__.split(".")[-2] in TTS_PACKAGE_NAMES
+        for config_cls in set(PIPELINE_CONFIG_REGISTRY.configs.values())
+        if getattr(config_cls, "requires_model_capabilities", False)
     }
 
-    assert registered_tts_architectures == set(EXPECTED_TTS_CAPABILITIES)
+
+def test_expected_capabilities_cover_registered_required_configs() -> None:
+    assert _capability_required_architectures() == set(EXPECTED_TTS_CAPABILITIES)
+
+
+def test_required_model_capability_configs_resolve_capabilities() -> None:
+    for architecture in sorted(_capability_required_architectures()):
+        assert get_model_capabilities(architecture) is not None
 
 
 def test_model_capabilities_are_frozen_and_explicit() -> None:
@@ -125,6 +121,29 @@ def test_get_model_capabilities_for_non_tts_and_unknown_architectures() -> None:
     assert get_model_capabilities("UnknownArchitecture") is None
 
 
+def test_get_model_capabilities_rejects_malformed_capabilities_export(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package_name = "tests.unit_test.models.fake_bad_capabilities"
+    fake_package = ModuleType(package_name)
+    fake_package.CAPABILITIES = object()
+
+    class FakeConfig:
+        pass
+
+    FakeConfig.__module__ = f"{package_name}.config"
+
+    monkeypatch.setitem(sys.modules, package_name, fake_package)
+    monkeypatch.setitem(
+        PIPELINE_CONFIG_REGISTRY.configs,
+        "MalformedCapabilitiesModel",
+        FakeConfig,
+    )
+
+    with pytest.raises(TypeError, match="must be a ModelCapabilities instance"):
+        get_model_capabilities("MalformedCapabilitiesModel")
+
+
 def test_get_model_capabilities_resolves_registered_alias() -> None:
     assert (
         get_model_capabilities("MossTTSDelay")
@@ -143,6 +162,8 @@ def test_model_capabilities_are_static_architecture_metadata() -> None:
 
 
 def test_launcher_model_capabilities_log_summary() -> None:
+    from sglang_omni.serve.launcher import _model_capabilities_log_summary
+
     config_cls = PIPELINE_CONFIG_REGISTRY.get_config("Qwen3TTSForConditionalGeneration")
     summary = _model_capabilities_log_summary(
         config_cls(model_path="Qwen/Qwen3-TTS-12Hz-0.6B-Base")
@@ -159,6 +180,8 @@ def test_launcher_model_capabilities_log_summary() -> None:
 
 
 def test_launcher_model_capabilities_log_summary_uses_static_architecture() -> None:
+    from sglang_omni.serve.launcher import _model_capabilities_log_summary
+
     config_cls = PIPELINE_CONFIG_REGISTRY.get_config("Qwen3TTSForConditionalGeneration")
     summary = _model_capabilities_log_summary(
         config_cls(model_path="Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice")
@@ -172,6 +195,8 @@ def test_launcher_model_capabilities_log_summary_uses_static_architecture() -> N
 def test_launcher_emits_model_capabilities_log(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    from sglang_omni.serve.launcher import _log_model_capabilities
+
     config_cls = PIPELINE_CONFIG_REGISTRY.get_config(
         "VoxtralTTSForConditionalGeneration"
     )
@@ -182,3 +207,21 @@ def test_launcher_emits_model_capabilities_log(
     assert '"architecture": "VoxtralTTSForConditionalGeneration"' in caplog.text
     assert '"reference_audio": false' in caplog.text
     assert '"batch_vocoder": false' in caplog.text
+
+
+def test_launcher_model_capabilities_warning_isolated(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from sglang_omni.serve import launcher
+
+    def fail_summary(_pipeline_config: object) -> None:
+        raise RuntimeError("capability lookup failed")
+
+    monkeypatch.setattr(launcher, "_model_capabilities_log_summary", fail_summary)
+    config_cls = PIPELINE_CONFIG_REGISTRY.get_config("Qwen3TTSForConditionalGeneration")
+
+    with caplog.at_level("WARNING", logger="sglang_omni.serve.launcher"):
+        launcher._log_model_capabilities(config_cls(model_path="dummy"))
+
+    assert "Failed to resolve model capabilities for startup log" in caplog.text

--- a/tests/unit_test/models/test_model_capabilities.py
+++ b/tests/unit_test/models/test_model_capabilities.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import FrozenInstanceError, MISSING, fields
+
+import pytest
+
+from sglang_omni.models.model_capabilities import (
+    ModelCapabilities,
+    get_model_capabilities,
+)
+from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
+from sglang_omni.serve.launcher import (
+    _log_model_capabilities,
+    _model_capabilities_log_summary,
+)
+
+EXPECTED_TTS_CAPABILITIES = {
+    "Qwen3TTSForConditionalGeneration": ModelCapabilities(
+        supports_reference_audio=True,
+        supports_batch_vocoder=True,
+        supports_streaming_vocoder=False,
+        supports_cuda_graph=True,
+        supports_torch_compile=True,
+    ),
+    "HiggsMultimodalQwen3ForConditionalGeneration": ModelCapabilities(
+        supports_reference_audio=True,
+        supports_batch_vocoder=True,
+        supports_streaming_vocoder=True,
+        supports_cuda_graph=True,
+        supports_torch_compile=True,
+    ),
+    "MossTTSDelayModel": ModelCapabilities(
+        supports_reference_audio=True,
+        supports_batch_vocoder=True,
+        supports_streaming_vocoder=False,
+        supports_cuda_graph=True,
+        supports_torch_compile=False,
+    ),
+    "MossTTSLocalModel": ModelCapabilities(
+        supports_reference_audio=True,
+        supports_batch_vocoder=True,
+        supports_streaming_vocoder=True,
+        supports_cuda_graph=True,
+        supports_torch_compile=False,
+    ),
+    "FishQwen3OmniForCausalLM": ModelCapabilities(
+        supports_reference_audio=True,
+        supports_batch_vocoder=True,
+        supports_streaming_vocoder=True,
+        supports_cuda_graph=True,
+        supports_torch_compile=True,
+    ),
+    "VoxtralTTSForConditionalGeneration": ModelCapabilities(
+        supports_reference_audio=False,
+        supports_batch_vocoder=False,
+        supports_streaming_vocoder=False,
+        supports_cuda_graph=True,
+        supports_torch_compile=True,
+    ),
+}
+
+TTS_PACKAGE_NAMES = {
+    "fishaudio_s2_pro",
+    "higgs_tts",
+    "moss_tts",
+    "moss_tts_local",
+    "qwen3_tts",
+    "voxtral_tts",
+}
+
+
+def _package_for_architecture(architecture: str):
+    config_cls = PIPELINE_CONFIG_REGISTRY.configs.get(architecture)
+    assert config_cls is not None, f"{architecture} is not registered"
+    return importlib.import_module(config_cls.__module__.rsplit(".", 1)[0])
+
+
+def test_expected_tts_capabilities_cover_registered_tts_configs() -> None:
+    registered_tts_architectures = {
+        config_cls.architecture
+        for config_cls in PIPELINE_CONFIG_REGISTRY.configs.values()
+        if config_cls.__module__.split(".")[-2] in TTS_PACKAGE_NAMES
+    }
+
+    assert registered_tts_architectures == set(EXPECTED_TTS_CAPABILITIES)
+
+
+def test_model_capabilities_are_frozen_and_explicit() -> None:
+    for field in fields(ModelCapabilities):
+        assert field.type in (bool, "bool")
+        assert field.default is MISSING
+        assert field.default_factory is MISSING
+
+    with pytest.raises(TypeError):
+        ModelCapabilities()
+
+    capabilities = next(iter(EXPECTED_TTS_CAPABILITIES.values()))
+    with pytest.raises(FrozenInstanceError):
+        capabilities.supports_reference_audio = False
+
+
+@pytest.mark.parametrize("architecture", EXPECTED_TTS_CAPABILITIES)
+def test_tts_model_package_exports_capabilities(architecture: str) -> None:
+    module = _package_for_architecture(architecture)
+    capabilities = getattr(module, "CAPABILITIES", None)
+
+    assert capabilities == EXPECTED_TTS_CAPABILITIES[architecture]
+    assert isinstance(capabilities, ModelCapabilities)
+    for field in fields(ModelCapabilities):
+        assert isinstance(getattr(capabilities, field.name), bool)
+
+
+@pytest.mark.parametrize("architecture", EXPECTED_TTS_CAPABILITIES)
+def test_get_model_capabilities_for_tts_architecture(architecture: str) -> None:
+    assert get_model_capabilities(architecture) == EXPECTED_TTS_CAPABILITIES[
+        architecture
+    ]
+
+
+def test_get_model_capabilities_for_non_tts_and_unknown_architectures() -> None:
+    assert get_model_capabilities("Qwen3OmniMoeForConditionalGeneration") is None
+    assert get_model_capabilities("UnknownArchitecture") is None
+
+
+def test_get_model_capabilities_resolves_registered_alias() -> None:
+    assert get_model_capabilities("MossTTSDelay") == EXPECTED_TTS_CAPABILITIES[
+        "MossTTSDelayModel"
+    ]
+
+
+def test_model_capabilities_are_static_architecture_metadata() -> None:
+    config_cls = PIPELINE_CONFIG_REGISTRY.get_config("Qwen3TTSForConditionalGeneration")
+    custom_config = config_cls(model_path="Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice")
+
+    capabilities = get_model_capabilities(config_cls.architecture)
+    assert capabilities is not None
+    assert capabilities.supports_reference_audio is True
+    assert custom_config.supports_uploaded_voice_references() is False
+
+
+def test_launcher_model_capabilities_log_summary() -> None:
+    config_cls = PIPELINE_CONFIG_REGISTRY.get_config("Qwen3TTSForConditionalGeneration")
+    summary = _model_capabilities_log_summary(
+        config_cls(model_path="Qwen/Qwen3-TTS-12Hz-0.6B-Base")
+    )
+
+    assert summary == {
+        "architecture": "Qwen3TTSForConditionalGeneration",
+        "reference_audio": True,
+        "batch_vocoder": True,
+        "streaming_vocoder": False,
+        "cuda_graph": True,
+        "torch_compile": True,
+    }
+
+
+def test_launcher_model_capabilities_log_summary_uses_static_architecture() -> None:
+    config_cls = PIPELINE_CONFIG_REGISTRY.get_config("Qwen3TTSForConditionalGeneration")
+    summary = _model_capabilities_log_summary(
+        config_cls(model_path="Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice")
+    )
+
+    assert summary is not None
+    assert summary["reference_audio"] is True
+    assert summary["batch_vocoder"] is True
+
+
+def test_launcher_emits_model_capabilities_log(caplog: pytest.LogCaptureFixture) -> None:
+    config_cls = PIPELINE_CONFIG_REGISTRY.get_config(
+        "VoxtralTTSForConditionalGeneration"
+    )
+    with caplog.at_level("INFO", logger="sglang_omni.serve.launcher"):
+        _log_model_capabilities(config_cls(model_path="dummy"))
+
+    assert "Model capabilities:" in caplog.text
+    assert '"architecture": "VoxtralTTSForConditionalGeneration"' in caplog.text
+    assert '"reference_audio": false' in caplog.text
+    assert '"batch_vocoder": false' in caplog.text

--- a/tests/unit_test/models/test_model_capabilities.py
+++ b/tests/unit_test/models/test_model_capabilities.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import importlib
-from dataclasses import FrozenInstanceError, MISSING, fields
+from dataclasses import MISSING, FrozenInstanceError, fields
 
 import pytest
 
@@ -115,9 +115,9 @@ def test_tts_model_package_exports_capabilities(architecture: str) -> None:
 
 @pytest.mark.parametrize("architecture", EXPECTED_TTS_CAPABILITIES)
 def test_get_model_capabilities_for_tts_architecture(architecture: str) -> None:
-    assert get_model_capabilities(architecture) == EXPECTED_TTS_CAPABILITIES[
-        architecture
-    ]
+    assert (
+        get_model_capabilities(architecture) == EXPECTED_TTS_CAPABILITIES[architecture]
+    )
 
 
 def test_get_model_capabilities_for_non_tts_and_unknown_architectures() -> None:
@@ -126,9 +126,10 @@ def test_get_model_capabilities_for_non_tts_and_unknown_architectures() -> None:
 
 
 def test_get_model_capabilities_resolves_registered_alias() -> None:
-    assert get_model_capabilities("MossTTSDelay") == EXPECTED_TTS_CAPABILITIES[
-        "MossTTSDelayModel"
-    ]
+    assert (
+        get_model_capabilities("MossTTSDelay")
+        == EXPECTED_TTS_CAPABILITIES["MossTTSDelayModel"]
+    )
 
 
 def test_model_capabilities_are_static_architecture_metadata() -> None:
@@ -168,7 +169,9 @@ def test_launcher_model_capabilities_log_summary_uses_static_architecture() -> N
     assert summary["batch_vocoder"] is True
 
 
-def test_launcher_emits_model_capabilities_log(caplog: pytest.LogCaptureFixture) -> None:
+def test_launcher_emits_model_capabilities_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     config_cls = PIPELINE_CONFIG_REGISTRY.get_config(
         "VoxtralTTSForConditionalGeneration"
     )


### PR DESCRIPTION
## Motivation
This PR implements the [M8 StageCapabilities](https://ljp2lkmtlez9.jp.larksuite.com/wiki/JkybwluLCiSRQXkb7Cije9tipQM?from=from_copylink) refactor as described in [SGLang-Omni-TTS-Refactor-RFC-v2](https://osgbw74w8zwb.sg.larksuite.com/docx/L3XId4GHYoJqSKxwXYqlXaBrgNd?from=from_copylink).

Introduce static, architecture-level TTS capability metadata so CI checks, developer documentation, and startup logs can query what each TTS model family supports without inspecting stage implementations or runtime-only pipeline state.

This is additive metadata. It does not route requests, change scheduler behavior, or replace instance-level `PipelineConfig` capability methods that can still depend on a specific checkpoint or deployment.

## Modifications

1. `sglang_omni/models/model_capabilities.py`
   - Adds the frozen `ModelCapabilities` dataclass with explicit boolean fields for reference audio, batch vocoder, streaming vocoder, CUDA graph support, and torch compile support.
   - Adds `get_model_capabilities(architecture)` to resolve a registered architecture through `PIPELINE_CONFIG_REGISTRY`, import its model package, and return its exported `CAPABILITIES`.
   - Returns `None` for unknown architectures or registered models without capability metadata, and raises a `TypeError` when a model exports a malformed `CAPABILITIES` value.

2. TTS model package `CAPABILITIES` exports
   - Adds `CAPABILITIES` constants to `qwen3_tts`, `higgs_tts`, `moss_tts`, `moss_tts_local`, `fishaudio_s2_pro`, and `voxtral_tts`.
   - Updates package `__all__` exports where needed so capability metadata is part of each model package's explicit public surface.
   - Covers the current TTS capability matrix for reference audio, batch vocoder, streaming vocoder, CUDA graph, and torch compile support.

3. `sglang_omni/serve/launcher.py`
   - Adds `_model_capabilities_log_summary(...)` to convert a loaded pipeline config into a compact capability summary.
   - Adds `_log_model_capabilities(...)` and emits a sorted JSON `Model capabilities:` startup log after placement/topology logging.
   - Wraps capability lookup failures in a warning so startup logging cannot break server launch.

4. Tests and documentation
   - Adds `tests/unit_test/models/test_model_capabilities.py` covering frozen/explicit dataclass fields, per-model exports, registry lookup, alias resolution, static architecture metadata semantics, non-TTS/unknown behavior, and launcher logging.
   - Adds `tests/unit_test/models/__init__.py` for the new unit test package.
   - Updates `tests/README.md` to document the new model registry/capability test area.

## Related Issues
N/A

## Accuracy Test

N/A

## Benchmark & Profiling

N/A

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the `run-ci` label. Once labeled, every subsequent push re-triggers CI as long as the label remains. Draft PRs are skipped even if labeled.
