### PR TITLE
[Ming-Omni] Make mm_aggregate a pure relay and enable the video_embeds TensorRef edge

### DIFF
--- a/benchmarks/eval/benchmark_omni_mmmu.py
+++ b/benchmarks/eval/benchmark_omni_mmmu.py
@@ -84,7 +84,7 @@ from benchmarks.dataset.mmmu import load_mmmu_samples
 from benchmarks.metrics.mmmu import compute_mmmu_metrics, print_mmmu_accuracy_summary
 from benchmarks.metrics.performance import compute_speed_metrics, print_speed_summary
 from benchmarks.metrics.wer import print_wer_summary
-from benchmarks.tasks.tts import (
+from benchmarks.tasks.asr import (
     DEFAULT_ASR_TRANSCRIBE_CONCURRENCY,
     compute_text_audio_consistency,
 )

--- a/benchmarks/eval/benchmark_omni_mmsu.py
+++ b/benchmarks/eval/benchmark_omni_mmsu.py
@@ -107,14 +107,14 @@ from benchmarks.dataset.mmsu import MmsuSample, load_mmsu_samples
 from benchmarks.metrics.mmsu import compute_mmsu_metrics, print_mmsu_summary
 from benchmarks.metrics.performance import compute_speed_metrics
 from benchmarks.metrics.wer import print_wer_summary
+from benchmarks.tasks.asr import (
+    DEFAULT_ASR_TRANSCRIBE_CONCURRENCY,
+    compute_text_audio_consistency,
+)
 from benchmarks.tasks.audio_understanding import (
     build_mmsu_results,
     make_mmsu_send_fn,
     save_mmsu_results,
-)
-from benchmarks.tasks.tts import (
-    DEFAULT_ASR_TRANSCRIBE_CONCURRENCY,
-    compute_text_audio_consistency,
 )
 
 logging.basicConfig(

--- a/benchmarks/eval/benchmark_omni_seedtts.py
+++ b/benchmarks/eval/benchmark_omni_seedtts.py
@@ -154,9 +154,11 @@ from benchmarks.metrics.performance import (
     compute_speed_metrics,
     print_speed_summary,
 )
-from benchmarks.tasks.tts import (
+from benchmarks.tasks.asr import (
     DEFAULT_ASR_TRANSCRIBE_CONCURRENCY,
     QWEN3_ASR_MODEL_PATH,
+)
+from benchmarks.tasks.tts import (
     VoiceCloneOmni,
     build_base_url,
     run_seedtts_similarity,

--- a/benchmarks/eval/benchmark_omni_videomme.py
+++ b/benchmarks/eval/benchmark_omni_videomme.py
@@ -85,7 +85,7 @@ from benchmarks.metrics.video import (
     print_videomme_accuracy_summary,
 )
 from benchmarks.metrics.wer import print_wer_summary
-from benchmarks.tasks.tts import (
+from benchmarks.tasks.asr import (
     DEFAULT_ASR_TRANSCRIBE_CONCURRENCY,
     compute_text_audio_consistency,
 )

--- a/benchmarks/eval/benchmark_qwen3_asr_concurrency.py
+++ b/benchmarks/eval/benchmark_qwen3_asr_concurrency.py
@@ -11,11 +11,11 @@ decide the right ASR fan-out for SeedTTS EN transcription / WER workloads.
 This script transcribes the SeedTTS *reference* clips directly (no TTS
 generation step), so it isolates ASR behavior from TTS.
 
-``run_asr_transcription`` + ``build_asr_eval_results`` are the shared
-transcription/scoring path; the Qwen3-ASR correctness gate
-(``tests/test_model/test_qwen3_asr_ci.py``) imports them so the gate is just
-this benchmark run plus thresholds. Both reuse the benchmark framework
-abstractions (``BenchmarkRunner``, ``benchmarks.metrics``).
+This file is the executable CLI wrapper: the shared transcription/scoring
+layer (run_asr_transcription and build_asr_eval_results) lives in
+benchmarks.tasks.asr and is imported here and by the Qwen3-ASR correctness
+gate (tests/test_model/test_qwen3_asr_ci.py), so the gate is just this
+benchmark run plus thresholds.
 
 Usage:
 
@@ -46,201 +46,18 @@ import asyncio
 import json
 import os
 import statistics
-import time
 
-import aiohttp
 import requests
-from jiwer import process_words
 
-from benchmarks.benchmarker.data import RequestResult
-from benchmarks.benchmarker.runner import BenchmarkRunner, RunConfig, SendFn
-from benchmarks.benchmarker.utils import get_wav_duration
 from benchmarks.dataset.prepare import DATASETS
-from benchmarks.dataset.seedtts import SampleInput, load_seedtts_samples
-from benchmarks.metrics.performance import compute_speed_metrics
-from benchmarks.metrics.wer import calculate_asr_speed_metrics, calculate_wer_metrics
-from benchmarks.tasks.tts import (
-    DEFAULT_ASR_TRANSCRIBE_CONCURRENCY,
-    QWEN3_ASR_MAX_NEW_TOKENS,
+from benchmarks.dataset.seedtts import load_seedtts_samples
+from benchmarks.tasks.asr import (
     QWEN3_ASR_MODEL_PATH,
-    QWEN3_ASR_REQUEST_TIMEOUT_S,
-    SampleOutput,
-    normalize_text,
+    build_asr_eval_results,
+    run_asr_transcription,
 )
 
 DEFAULT_CONCURRENCIES = "1,2,4,8,16,32,64"
-
-
-def make_asr_send_fn(
-    model_name: str,
-    api_url: str,
-    *,
-    lang: str = "en",
-    max_new_tokens: int = QWEN3_ASR_MAX_NEW_TOKENS,
-) -> SendFn:
-    """Return a *send_fn(session, sample) -> RequestResult* that transcribes one
-    SeedTTS reference clip via the Omni ``/v1/audio/transcriptions`` endpoint.
-
-    Note: do NOT send temperature=0 — Qwen3-ASR degenerates under pure greedy
-    (the server bumps it to 0.01). ``language`` selects the forced prefix.
-    """
-
-    async def send_fn(
-        session: aiohttp.ClientSession, sample: SampleInput
-    ) -> RequestResult:
-        result = RequestResult(request_id=sample.sample_id)
-        try:
-            with open(sample.ref_audio, "rb") as audio_file:
-                audio_bytes = audio_file.read()
-        except OSError as exc:
-            result.error = str(exc)
-            return result
-        result.audio_duration_s = get_wav_duration(audio_bytes)
-
-        form = aiohttp.FormData()
-        form.add_field("model", model_name)
-        form.add_field("language", "en" if lang == "en" else lang)
-        form.add_field("response_format", "json")
-        form.add_field("max_new_tokens", str(max_new_tokens))
-        form.add_field(
-            "file",
-            audio_bytes,
-            filename=os.path.basename(sample.ref_audio),
-            content_type="audio/wav",
-        )
-
-        start_time = time.perf_counter()
-        try:
-            async with session.post(api_url, data=form) as response:
-                if response.status != 200:
-                    result.error = f"HTTP {response.status}: {await response.text()}"
-                else:
-                    payload = await response.json()
-                    result.text = str(payload.get("text", ""))
-                    result.is_success = True
-        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
-            result.error = str(exc)
-        finally:
-            result.latency_s = time.perf_counter() - start_time
-        if result.is_success and result.audio_duration_s > 0:
-            result.rtf = result.latency_s / result.audio_duration_s
-        return result
-
-    return send_fn
-
-
-async def run_asr_transcription(
-    samples: list[SampleInput],
-    *,
-    host: str = "127.0.0.1",
-    port: int,
-    model_path: str = QWEN3_ASR_MODEL_PATH,
-    lang: str = "en",
-    concurrency: int = DEFAULT_ASR_TRANSCRIBE_CONCURRENCY,
-    warmup: int = 0,
-    request_timeout_s: int = QWEN3_ASR_REQUEST_TIMEOUT_S,
-    disable_tqdm: bool = True,
-) -> tuple[list[RequestResult], float]:
-    """Transcribe ``samples`` against a running ASR router at one concurrency.
-
-    Returns ``(outputs, wall_clock_s)`` via the shared ``BenchmarkRunner``.
-    """
-    api_url = f"http://{host}:{port}/v1/audio/transcriptions"
-    send_fn = make_asr_send_fn(model_path, api_url, lang=lang)
-    runner = BenchmarkRunner(
-        RunConfig(
-            max_concurrency=concurrency,
-            warmup=warmup,
-            disable_tqdm=disable_tqdm,
-            timeout_s=request_timeout_s,
-        )
-    )
-    outputs = await runner.run(samples, send_fn)
-    return outputs, runner.wall_clock_s
-
-
-def build_asr_eval_results(
-    samples: list[SampleInput],
-    outputs: list[RequestResult],
-    wall_clock_s: float,
-    lang: str,
-    *,
-    model_path: str = QWEN3_ASR_MODEL_PATH,
-    concurrency: int = DEFAULT_ASR_TRANSCRIBE_CONCURRENCY,
-) -> dict:
-    """Score transcriptions and assemble WER + speed metrics.
-
-    Returns ``{"summary": wer, "speed": speed, "per_sample": [...]}`` with the
-    exact ``summary.*`` / ``speed.*`` keys the Qwen3-ASR gate writes and the
-    tune-ci-thresholds config reads. WER/speed reuse ``benchmarks.metrics``.
-    """
-    result_by_id = {result.request_id: result for result in outputs}
-    sample_outputs: list[SampleOutput] = []
-    per_sample: list[dict] = []
-    for sample in samples:
-        result = result_by_id.get(sample.sample_id)
-        output = SampleOutput(
-            sample_id=sample.sample_id,
-            target_text=sample.ref_text,
-        )
-        if result is None or not result.is_success:
-            output.error = (result.error if result else "") or "No transcription"
-        else:
-            output.latency_s = result.latency_s
-            output.asr_latency_s = result.latency_s
-            output.audio_duration_s = result.audio_duration_s
-            output.whisper_text = result.text
-            output.ref_norm = normalize_text(sample.ref_text, lang)
-            output.hyp_norm = normalize_text(result.text, lang)
-            if output.ref_norm:
-                measures = process_words(output.ref_norm, output.hyp_norm)
-                output.wer = measures.wer
-                output.substitutions = measures.substitutions
-                output.deletions = measures.deletions
-                output.insertions = measures.insertions
-                output.hits = measures.hits
-                output.is_success = True
-            else:
-                output.error = "Empty reference after normalization"
-        sample_outputs.append(output)
-        per_sample.append(
-            {
-                "id": output.sample_id,
-                "is_success": output.is_success,
-                "wer": output.wer if output.is_success else None,
-                "ref_text": output.target_text,
-                "hyp_text": output.whisper_text,
-                "ref_norm": output.ref_norm,
-                "hyp_norm": output.hyp_norm,
-                "audio_duration_s": output.audio_duration_s,
-                "latency_s": output.latency_s,
-                "error": output.error,
-            }
-        )
-
-    wer_summary = calculate_wer_metrics(sample_outputs, lang)
-    # note (Yue Yin): gate + tune-ci-thresholds read summary.corpus_wer
-    wer_summary["corpus_wer"] = wer_summary["wer_corpus"]
-
-    asr_speed = calculate_asr_speed_metrics(sample_outputs, wall_time_s=wall_clock_s)
-    # note (Yue Yin): compute_speed_metrics supplies rtf_p95 (the asr metrics omit it)
-    perf = compute_speed_metrics(outputs, wall_clock_s=wall_clock_s)
-    speed = {
-        **asr_speed,
-        "asr_model": model_path,
-        "asr_concurrency": concurrency,
-        "asr_rtf_p95": perf.get("rtf_p95"),
-        # note (Yue Yin): plain calibration keys read by tune-ci-thresholds + gate
-        "throughput_samples_per_s": asr_speed["asr_throughput_samples_per_s"],
-        "latency_mean_s": asr_speed["asr_latency_mean_s"],
-        "latency_median_s": asr_speed["asr_latency_median_s"],
-        "latency_p95_s": asr_speed["asr_latency_p95_s"],
-        "latency_p99_s": asr_speed["asr_latency_p99_s"],
-        "rtf_mean": asr_speed["asr_rtf_mean"],
-        "rtf_median": asr_speed["asr_rtf_median"],
-        "rtf_p95": perf.get("rtf_p95"),
-    }
-    return {"summary": wer_summary, "speed": speed, "per_sample": per_sample}
 
 
 def _fetch_worker_snapshot(host: str, port: int) -> dict | None:

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -186,10 +186,12 @@ from benchmarks.metrics.performance import (
     compute_speed_metrics,
     print_speed_summary,
 )
-from benchmarks.tasks.tts import (
+from benchmarks.tasks.asr import (
     DEFAULT_ASR_TRANSCRIBE_CONCURRENCY,
-    MOSS_TTS_TOKEN_COUNT_AUTO,
     QWEN3_ASR_MODEL_PATH,
+)
+from benchmarks.tasks.tts import (
+    MOSS_TTS_TOKEN_COUNT_AUTO,
     build_base_url,
     make_tts_send_fn,
     run_seedtts_similarity,

--- a/benchmarks/metrics/wer.py
+++ b/benchmarks/metrics/wer.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
 
 import numpy as np
 
@@ -13,11 +13,27 @@ from benchmarks.metrics._format import (
     print_speed_metric_line,
 )
 
-if TYPE_CHECKING:
-    from benchmarks.tasks.tts import SampleOutput
+
+@dataclass
+class SampleOutput:
+    sample_id: str = ""
+    target_text: str = ""
+    whisper_text: str = ""
+    ref_norm: str = ""
+    hyp_norm: str = ""
+    wer: float = 0.0
+    substitutions: int = 0
+    deletions: int = 0
+    insertions: int = 0
+    hits: int = 0
+    audio_duration_s: float = 0.0
+    latency_s: float = 0.0
+    asr_latency_s: float = 0.0
+    is_success: bool = False
+    error: str = ""
 
 
-def calculate_wer_metrics(outputs: list["SampleOutput"], lang: str) -> dict:
+def calculate_wer_metrics(outputs: list[SampleOutput], lang: str) -> dict:
     """Compute corpus-level WER metrics from per-sample outputs."""
     successes = [o for o in outputs if o.is_success]
     if not successes:
@@ -210,7 +226,7 @@ def print_asr_wer_summary(metrics: dict, model_name: str) -> None:
 
 
 def calculate_asr_speed_metrics(
-    outputs: list["SampleOutput"],
+    outputs: list[SampleOutput],
     *,
     wall_time_s: float | None = None,
 ) -> dict:

--- a/benchmarks/tasks/asr.py
+++ b/benchmarks/tasks/asr.py
@@ -1,0 +1,587 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared ASR task layer: transcription, WER scoring, and ASR speed assembly.
+
+Owns the ASR/WER primitives shared by the standalone ASR benchmark
+(benchmarks/eval/benchmark_qwen3_asr_concurrency.py), the Qwen3-ASR CI gate
+(tests/test_model/test_qwen3_asr_ci.py), the TTS WER stage
+(benchmarks.tasks.tts.run_seedtts_transcribe), and the talker WER paths.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import functools
+import io
+import logging
+import os
+import string
+import time
+import wave
+
+import aiohttp
+import requests
+import torch
+from jiwer import process_words
+
+from benchmarks.benchmarker.data import RequestResult
+from benchmarks.benchmarker.runner import BenchmarkRunner, RunConfig, SendFn
+from benchmarks.benchmarker.utils import get_wav_duration
+from benchmarks.dataset.seedtts import SampleInput
+from benchmarks.metrics.performance import compute_speed_metrics
+from benchmarks.metrics.wer import (
+    SampleOutput,
+    calculate_asr_speed_metrics,
+    calculate_wer_metrics,
+)
+
+logger = logging.getLogger(__name__)
+
+OMNI_WHISPER_MODEL_PATH = "openai/whisper-large-v3"
+OMNI_WHISPER_REQUEST_TIMEOUT_S = 300
+# note (aaron): the Whisper encoder accepts at most ~30 s per request
+# (nb_max_frames=3000). The transformers pipeline uses chunk_length_s=30 and
+# long talker audio mirrors that.
+OMNI_WHISPER_CHUNK_LENGTH_S = 30
+OMNI_WHISPER_CHUNK_STRIDE_S = 25
+OMNI_WHISPER_SAMPLE_RATE = 16000
+
+QWEN3_ASR_MODEL_PATH = "Qwen/Qwen3-ASR-1.7B"
+QWEN3_ASR_REQUEST_TIMEOUT_S = 300
+# note (aaron): ASR transcription fan-out for WER, not TTS generation concurrency.
+DEFAULT_ASR_TRANSCRIBE_CONCURRENCY = 32
+# note (aaron): warmup requests sent before the timed window, per unit of concurrency.
+ASR_WARMUP_MULTIPLIER = 2
+
+
+@functools.lru_cache(maxsize=1)
+def _get_en_normalizer():
+    """Lazy-load the required English WER normalizer from openai-whisper."""
+    try:
+        from whisper.normalizers import EnglishTextNormalizer
+    except ImportError as exc:
+        raise RuntimeError(
+            "English WER requires openai-whisper "
+            "(whisper.normalizers.EnglishTextNormalizer). "
+            "Install pinned deps with uv pip install -e ."
+        ) from exc
+
+    return EnglishTextNormalizer()
+
+
+def normalize_text(text: str, lang: str) -> str:
+    if lang == "zh":
+        from zhon.hanzi import punctuation as zh_punct
+
+        all_punct = zh_punct + string.punctuation
+        for ch in all_punct:
+            if ch == "'":
+                continue
+            text = text.replace(ch, "")
+        text = text.replace(" ", "").replace("\u3000", "").strip()
+        text = " ".join(list(text))
+        return text
+
+    normalizer = _get_en_normalizer()
+    return normalizer(text)
+
+
+def _load_wav_mono_16k(wav_path: str) -> torch.Tensor:
+    import torchaudio
+
+    audio, sample_rate = torchaudio.load(wav_path)
+    if audio.ndim == 2 and audio.shape[0] > 1:
+        audio = audio.mean(dim=0, keepdim=True)
+    audio = audio.squeeze(0).to(torch.float32)
+    if sample_rate != OMNI_WHISPER_SAMPLE_RATE:
+        audio = torchaudio.functional.resample(
+            audio, sample_rate, OMNI_WHISPER_SAMPLE_RATE
+        )
+    return audio
+
+
+def _wav_bytes_from_mono_16k(audio: torch.Tensor) -> bytes:
+    pcm16 = (audio.clamp(-1.0, 1.0) * 32767.0).to(torch.int16).cpu()
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(OMNI_WHISPER_SAMPLE_RATE)
+        wav_file.writeframes(pcm16.numpy().tobytes())
+    return buffer.getvalue()
+
+
+def _post_omni_whisper_transcription(
+    asr: dict,
+    audio_bytes: bytes,
+    filename: str,
+    lang: str,
+) -> str:
+    response = requests.post(
+        f"http://127.0.0.1:{asr['router_port']}/v1/audio/transcriptions",
+        data={
+            "model": asr["model_path"],
+            "language": "en" if lang == "en" else lang,
+            "temperature": "0",
+        },
+        files={
+            "file": (
+                filename,
+                audio_bytes,
+                "audio/wav",
+            )
+        },
+        timeout=OMNI_WHISPER_REQUEST_TIMEOUT_S,
+        proxies={"http": None, "https": None},
+    )
+    response.raise_for_status()
+    return str(response.json()["text"])
+
+
+def _transcribe_omni_whisper(asr: dict, wav_path: str, lang: str) -> str:
+    audio = _load_wav_mono_16k(wav_path)
+    duration_s = float(audio.shape[0]) / OMNI_WHISPER_SAMPLE_RATE
+    if duration_s <= OMNI_WHISPER_CHUNK_LENGTH_S:
+        with open(wav_path, "rb") as audio_file:
+            return _post_omni_whisper_transcription(
+                asr,
+                audio_file.read(),
+                os.path.basename(wav_path),
+                lang,
+            )
+
+    chunk_samples = OMNI_WHISPER_CHUNK_LENGTH_S * OMNI_WHISPER_SAMPLE_RATE
+    stride_samples = OMNI_WHISPER_CHUNK_STRIDE_S * OMNI_WHISPER_SAMPLE_RATE
+    chunk_texts: list[str] = []
+    for start in range(0, int(audio.shape[0]), stride_samples):
+        chunk = audio[start : start + chunk_samples]
+        if chunk.numel() == 0:
+            break
+        chunk_bytes = _wav_bytes_from_mono_16k(chunk)
+        chunk_texts.append(
+            _post_omni_whisper_transcription(
+                asr,
+                chunk_bytes,
+                f"{os.path.basename(wav_path)}.chunk{start // stride_samples}.wav",
+                lang,
+            ).strip()
+        )
+        if start + chunk_samples >= audio.shape[0]:
+            break
+    return " ".join(text for text in chunk_texts if text)
+
+
+def load_omni_whisper_asr(
+    router_port: int,
+    model_path: str = OMNI_WHISPER_MODEL_PATH,
+) -> dict:
+    """Return an ASR handle that transcribes via SGLang Omni Whisper router."""
+    return {
+        "type": "omni_whisper",
+        "router_port": router_port,
+        "model_path": model_path,
+    }
+
+
+def load_qwen3_asr(
+    router_port: int,
+    model_path: str = QWEN3_ASR_MODEL_PATH,
+) -> dict:
+    """Return an ASR handle that transcribes via a Qwen3-ASR sglang-omni router."""
+    return {
+        "type": "qwen3_asr",
+        "router_port": router_port,
+        "model_path": model_path,
+    }
+
+
+def _is_whisper_asr_model(model_path: str) -> bool:
+    return "whisper" in model_path.lower()
+
+
+def load_router_asr(
+    router_port: int,
+    model_path: str = QWEN3_ASR_MODEL_PATH,
+) -> dict:
+    """Return an ASR handle backed by a running SGLang Omni ASR server."""
+    if _is_whisper_asr_model(model_path):
+        return load_omni_whisper_asr(router_port, model_path=model_path)
+    return load_qwen3_asr(router_port, model_path=model_path)
+
+
+def _transcribe_qwen3_asr(asr: dict, wav_path: str, lang: str) -> str:
+    """Transcribe one wav via the Qwen3-ASR server's /v1/audio/transcriptions.
+
+    Note: do not send temperature=0 because Qwen3-ASR degenerates under pure
+    greedy (the server bumps it to 0.01). The language field selects the
+    forced prefix. max_new_tokens comes from the Qwen3 ASR pipeline config.
+    """
+    with open(wav_path, "rb") as audio_file:
+        response = requests.post(
+            f"http://127.0.0.1:{asr['router_port']}/v1/audio/transcriptions",
+            data={
+                "model": asr["model_path"],
+                "language": "en" if lang == "en" else lang,
+                "response_format": "json",
+            },
+            files={"file": (os.path.basename(wav_path), audio_file, "audio/wav")},
+            timeout=QWEN3_ASR_REQUEST_TIMEOUT_S,
+            proxies={"http": None, "https": None},
+        )
+    response.raise_for_status()
+    return str(response.json()["text"])
+
+
+def _resolve_asr_backend(
+    lang: str,
+    asr_device: str,
+    *,
+    asr_router_port: int | None = None,
+    asr_model_path: str = QWEN3_ASR_MODEL_PATH,
+    generation_mode: str | None = None,
+) -> dict:
+    if asr_router_port is not None:
+        return load_router_asr(asr_router_port, model_path=asr_model_path)
+    return load_asr_model(lang, asr_device, generation_mode)
+
+
+def load_asr_model(lang: str, device: str, generation_mode: str | None = None):
+    """Legacy local ASR entry point.
+
+    WER now runs through SGLang Omni's OpenAI-compatible transcription endpoint.
+    Start an ASR server with sglang_omni.cli serve and pass its port instead
+    of loading local ASR backends in-process.
+    """
+    mode_suffix = f" for {generation_mode} generation" if generation_mode else ""
+    del device
+    if lang not in {"en", "zh"}:
+        raise ValueError(f"Unsupported language: {lang}")
+    raise ValueError(
+        "WER transcription requires a running SGLang Omni ASR server"
+        f"{mode_suffix}. Start Qwen3-ASR (default "
+        f"{QWEN3_ASR_MODEL_PATH}) or {OMNI_WHISPER_MODEL_PATH} and pass "
+        "asr_router_port."
+    )
+
+
+def transcribe(asr: dict, wav_path: str, lang: str, device: str) -> str:
+    if asr["type"] == "qwen3_asr":
+        return _transcribe_qwen3_asr(asr, wav_path, lang)
+    if asr["type"] == "omni_whisper":
+        return _transcribe_omni_whisper(asr, wav_path, lang)
+    raise ValueError(f"Unknown ASR type: {asr['type']}")
+
+
+def apply_wer(output: SampleOutput, hyp_text: str, lang: str) -> SampleOutput:
+    """Fill output with normalized texts and per-sample WER fields."""
+    output.whisper_text = hyp_text
+    output.ref_norm = normalize_text(output.target_text, lang)
+    output.hyp_norm = normalize_text(hyp_text, lang)
+    if not output.ref_norm:
+        output.error = "Empty reference after normalization"
+        return output
+    measures = process_words(output.ref_norm, output.hyp_norm)
+    output.wer = measures.wer
+    output.substitutions = measures.substitutions
+    output.deletions = measures.deletions
+    output.insertions = measures.insertions
+    output.hits = measures.hits
+    output.is_success = True
+    return output
+
+
+def transcribe_and_compute_wer(
+    output: SampleOutput,
+    wav_path: str,
+    asr: dict,
+    lang: str,
+    device: str,
+) -> SampleOutput:
+    """Transcribe audio and compute per-sample WER metrics."""
+    try:
+        hyp_text = transcribe(asr, wav_path, lang, device)
+    except Exception as exc:
+        output.error = f"Transcription failed: {exc}"
+        logger.error(f"[{output.sample_id}] {output.error}")
+        return output
+    return apply_wer(output, hyp_text, lang)
+
+
+def make_asr_send_fn(
+    model_name: str,
+    api_url: str,
+    lang: str = "en",
+) -> SendFn:
+    """Return a send_fn(session, sample) -> RequestResult that transcribes one
+    SeedTTS reference clip via the Omni /v1/audio/transcriptions endpoint.
+
+    Note: do not send temperature=0 because Qwen3-ASR degenerates under pure
+    greedy (the server bumps it to 0.01). The language field selects the
+    forced prefix. max_new_tokens comes from the Qwen3 ASR pipeline config.
+    """
+
+    async def send_fn(
+        session: aiohttp.ClientSession, sample: SampleInput
+    ) -> RequestResult:
+        result = RequestResult(request_id=sample.sample_id)
+        try:
+            with open(sample.ref_audio, "rb") as audio_file:
+                audio_bytes = audio_file.read()
+        except OSError as exc:
+            result.error = str(exc)
+            return result
+        result.audio_duration_s = get_wav_duration(audio_bytes)
+
+        form = aiohttp.FormData()
+        form.add_field("model", model_name)
+        form.add_field("language", "en" if lang == "en" else lang)
+        form.add_field("response_format", "json")
+        form.add_field(
+            "file",
+            audio_bytes,
+            filename=os.path.basename(sample.ref_audio),
+            content_type="audio/wav",
+        )
+
+        start_time = time.perf_counter()
+        try:
+            async with session.post(api_url, data=form) as response:
+                if response.status != 200:
+                    result.error = f"HTTP {response.status}: {await response.text()}"
+                else:
+                    payload = await response.json()
+                    result.text = str(payload.get("text", ""))
+                    result.is_success = True
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            result.error = str(exc)
+        finally:
+            result.latency_s = time.perf_counter() - start_time
+        if result.is_success and result.audio_duration_s > 0:
+            result.rtf = result.latency_s / result.audio_duration_s
+        return result
+
+    return send_fn
+
+
+async def run_asr_transcription(
+    samples: list[SampleInput],
+    *,
+    host: str = "127.0.0.1",
+    port: int,
+    model_path: str = QWEN3_ASR_MODEL_PATH,
+    lang: str = "en",
+    concurrency: int = DEFAULT_ASR_TRANSCRIBE_CONCURRENCY,
+    warmup: int = 0,
+    request_timeout_s: int = QWEN3_ASR_REQUEST_TIMEOUT_S,
+    disable_tqdm: bool = True,
+) -> tuple[list[RequestResult], float]:
+    """Transcribe samples against a running ASR router at one concurrency.
+
+    Returns (outputs, wall_clock_s) via the shared BenchmarkRunner.
+    """
+    api_url = f"http://{host}:{port}/v1/audio/transcriptions"
+    send_fn = make_asr_send_fn(model_path, api_url, lang=lang)
+    runner = BenchmarkRunner(
+        RunConfig(
+            max_concurrency=concurrency,
+            warmup=warmup,
+            disable_tqdm=disable_tqdm,
+            timeout_s=request_timeout_s,
+        )
+    )
+    outputs = await runner.run(samples, send_fn)
+    return outputs, runner.wall_clock_s
+
+
+def build_asr_eval_results(
+    samples: list[SampleInput],
+    outputs: list[RequestResult],
+    wall_clock_s: float,
+    lang: str,
+    *,
+    model_path: str = QWEN3_ASR_MODEL_PATH,
+    concurrency: int = DEFAULT_ASR_TRANSCRIBE_CONCURRENCY,
+) -> dict:
+    """Score transcriptions and assemble WER + speed metrics.
+
+    Returns {"summary": wer, "speed": speed, "per_sample": [...]} with the
+    exact summary.* and speed.* keys the Qwen3-ASR gate writes and the
+    tune-ci-thresholds config reads. WER/speed reuse benchmarks.metrics.
+    """
+    result_by_id = {result.request_id: result for result in outputs}
+    sample_outputs: list[SampleOutput] = []
+    per_sample: list[dict] = []
+    for sample in samples:
+        result = result_by_id.get(sample.sample_id)
+        output = SampleOutput(
+            sample_id=sample.sample_id,
+            target_text=sample.ref_text,
+        )
+        if result is None or not result.is_success:
+            output.error = (result.error if result else "") or "No transcription"
+        else:
+            output.latency_s = result.latency_s
+            output.asr_latency_s = result.latency_s
+            output.audio_duration_s = result.audio_duration_s
+            output = apply_wer(output, result.text, lang)
+        sample_outputs.append(output)
+        per_sample.append(
+            {
+                "id": output.sample_id,
+                "is_success": output.is_success,
+                "wer": output.wer if output.is_success else None,
+                "ref_text": output.target_text,
+                "hyp_text": output.whisper_text,
+                "ref_norm": output.ref_norm,
+                "hyp_norm": output.hyp_norm,
+                "audio_duration_s": output.audio_duration_s,
+                "latency_s": output.latency_s,
+                "error": output.error,
+            }
+        )
+
+    wer_summary = calculate_wer_metrics(sample_outputs, lang)
+    # note (Yue Yin): gate + tune-ci-thresholds read summary.corpus_wer
+    wer_summary["corpus_wer"] = wer_summary["wer_corpus"]
+
+    asr_speed = calculate_asr_speed_metrics(sample_outputs, wall_time_s=wall_clock_s)
+    # note (Yue Yin): compute_speed_metrics supplies rtf_p95 (the asr metrics omit it)
+    perf = compute_speed_metrics(outputs, wall_clock_s=wall_clock_s)
+    speed = {
+        **asr_speed,
+        "asr_model": model_path,
+        "asr_concurrency": concurrency,
+        "asr_rtf_p95": perf.get("rtf_p95"),
+        # note (Yue Yin): plain calibration keys read by tune-ci-thresholds + gate
+        "throughput_samples_per_s": asr_speed["asr_throughput_samples_per_s"],
+        "latency_mean_s": asr_speed["asr_latency_mean_s"],
+        "latency_median_s": asr_speed["asr_latency_median_s"],
+        "latency_p95_s": asr_speed["asr_latency_p95_s"],
+        "latency_p99_s": asr_speed["asr_latency_p99_s"],
+        "rtf_mean": asr_speed["asr_rtf_mean"],
+        "rtf_median": asr_speed["asr_rtf_median"],
+        "rtf_p95": perf.get("rtf_p95"),
+    }
+    return {"summary": wer_summary, "speed": speed, "per_sample": per_sample}
+
+
+def compute_text_audio_consistency(
+    request_results: list[RequestResult],
+    lang: str,
+    asr_device: str,
+    *,
+    asr_router_port: int | None = None,
+    asr_model_path: str = QWEN3_ASR_MODEL_PATH,
+    asr_concurrency: int = DEFAULT_ASR_TRANSCRIBE_CONCURRENCY,
+) -> dict:
+    """WER between each request's text output (ref) and ASR-transcribed audio (hyp)."""
+    asr = _resolve_asr_backend(
+        lang,
+        asr_device,
+        asr_router_port=asr_router_port,
+        asr_model_path=asr_model_path,
+    )
+
+    outputs_by_idx: list[SampleOutput | None] = [None] * len(request_results)
+    pending: list[tuple[int, RequestResult, SampleOutput]] = []
+    for idx, result in enumerate(request_results):
+        ref_text = " ".join(result.text.split())
+        out = SampleOutput(
+            sample_id=result.request_id,
+            target_text=ref_text,
+            latency_s=result.latency_s,
+            audio_duration_s=result.audio_duration_s,
+        )
+        if not result.is_success or not result.wav_path:
+            out.error = result.error or "No audio in response"
+            outputs_by_idx[idx] = out
+            continue
+        pending.append((idx, result, out))
+
+    def _transcribe_pending(
+        result: RequestResult,
+        output: SampleOutput,
+    ) -> SampleOutput:
+        asr_t0 = time.perf_counter()
+        output = transcribe_and_compute_wer(
+            output,
+            result.wav_path,
+            asr,
+            lang,
+            asr_device,
+        )
+        output.asr_latency_s = time.perf_counter() - asr_t0
+        return output
+
+    asr_concurrency = max(1, int(asr_concurrency))
+    if asr_concurrency == 1:
+        for idx, result, output in pending:
+            outputs_by_idx[idx] = _transcribe_pending(result, output)
+    else:
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=asr_concurrency,
+        ) as executor:
+            future_to_idx = {
+                executor.submit(_transcribe_pending, result, output): idx
+                for idx, result, output in pending
+            }
+            for future in concurrent.futures.as_completed(future_to_idx):
+                outputs_by_idx[future_to_idx[future]] = future.result()
+
+    outputs = [output for output in outputs_by_idx if output is not None]
+
+    per_sample = [
+        {
+            "id": o.sample_id,
+            "is_success": o.is_success,
+            "wer": o.wer if o.is_success else None,
+            "ref_text": o.target_text[:100],
+            "hyp_text": o.whisper_text[:100],
+            "ref_norm": o.ref_norm,
+            "hyp_norm": o.hyp_norm,
+            "audio_duration_s": o.audio_duration_s,
+            "error": o.error,
+        }
+        for o in outputs
+    ]
+    return {"summary": calculate_wer_metrics(outputs, lang), "per_sample": per_sample}
+
+
+def compute_text_audio_consistency_from_records(
+    per_sample: list[dict],
+    lang: str,
+    asr_device: str,
+    *,
+    audio_dir: str | None = None,
+    sample_id_key: str = "sample_id",
+    text_key: str = "raw_response",
+    asr_router_port: int | None = None,
+    asr_model_path: str = QWEN3_ASR_MODEL_PATH,
+    asr_concurrency: int = DEFAULT_ASR_TRANSCRIBE_CONCURRENCY,
+) -> dict:
+    """Compute WER from saved eval records after the inference server is stopped."""
+    request_results: list[RequestResult] = []
+    for record in per_sample:
+        sample_id = record.get(sample_id_key)
+        wav_path = record.get("wav_path") or ""
+        if not wav_path and audio_dir and sample_id:
+            wav_path = os.path.join(audio_dir, f"{sample_id}.wav")
+        request_results.append(
+            RequestResult(
+                request_id=str(sample_id or ""),
+                text=str(record.get(text_key) or ""),
+                is_success=bool(record.get("is_success")),
+                latency_s=float(record.get("latency_s") or 0),
+                audio_duration_s=float(record.get("audio_duration_s") or 0),
+                wav_path=wav_path,
+                error=str(record.get("error") or ""),
+            )
+        )
+    return compute_text_audio_consistency(
+        request_results,
+        lang,
+        asr_device,
+        asr_router_port=asr_router_port,
+        asr_model_path=asr_model_path,
+        asr_concurrency=asr_concurrency,
+    )

--- a/benchmarks/tasks/tts.py
+++ b/benchmarks/tasks/tts.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-"""TTS task utilities: voice-clone API clients, ASR evaluation, and HTTP send functions.
+"""TTS task utilities: voice-clone API clients, seed-tts eval stages, and HTTP send functions.
+
+ASR transcription and WER scoring live in benchmarks.tasks.asr. This module
+maps generated audio into ASR samples and reuses that layer.
 
 Replaces tasks/tts_speed.py and tasks/voice_clone.py.
 """
@@ -9,25 +12,19 @@ from __future__ import annotations
 import asyncio
 import base64
 import binascii
-import concurrent.futures
 import csv
-import functools
 import io
 import json
 import logging
 import os
-import string
 import time
 import wave
-from dataclasses import dataclass
 from typing import AsyncIterator, Protocol
 
 import aiohttp
 import numpy as np
-import requests
 import soundfile as sf
 import torch
-from jiwer import process_words
 from tqdm import tqdm
 
 from benchmarks.benchmarker.data import RequestResult
@@ -49,10 +46,17 @@ from benchmarks.metrics.speaker_similarity_assets import (
     ensure_speaker_similarity_assets,
 )
 from benchmarks.metrics.wer import (
+    SampleOutput,
     calculate_asr_speed_metrics,
     calculate_wer_metrics,
     print_asr_speed_summary,
     print_wer_summary,
+)
+from benchmarks.tasks.asr import (
+    ASR_WARMUP_MULTIPLIER,
+    apply_wer,
+    run_asr_transcription,
+    transcribe_and_compute_wer,
 )
 
 logger = logging.getLogger(__name__)
@@ -67,421 +71,8 @@ UTMOS_BATCH_SIZE = 8
 
 
 # ---------------------------------------------------------------------------
-# ASR / WER utilities
+# WER result persistence
 # ---------------------------------------------------------------------------
-
-
-@dataclass
-class SampleOutput:
-    sample_id: str = ""
-    target_text: str = ""
-    whisper_text: str = ""
-    ref_norm: str = ""
-    hyp_norm: str = ""
-    wer: float = 0.0
-    substitutions: int = 0
-    deletions: int = 0
-    insertions: int = 0
-    hits: int = 0
-    audio_duration_s: float = 0.0
-    latency_s: float = 0.0
-    asr_latency_s: float = 0.0
-    is_success: bool = False
-    error: str = ""
-
-
-@functools.lru_cache(maxsize=1)
-def _get_en_normalizer():
-    """Lazy-load the required English WER normalizer from openai-whisper."""
-    try:
-        from whisper.normalizers import EnglishTextNormalizer
-    except ImportError as exc:
-        raise RuntimeError(
-            "English WER requires openai-whisper "
-            "(whisper.normalizers.EnglishTextNormalizer). "
-            "Install pinned deps with `uv pip install -e .`."
-        ) from exc
-
-    return EnglishTextNormalizer()
-
-
-def normalize_text(text: str, lang: str) -> str:
-    if lang == "zh":
-        from zhon.hanzi import punctuation as zh_punct
-
-        all_punct = zh_punct + string.punctuation
-        for ch in all_punct:
-            if ch == "'":
-                continue
-            text = text.replace(ch, "")
-        text = text.replace(" ", "").replace("\u3000", "").strip()
-        text = " ".join(list(text))
-        return text
-
-    normalizer = _get_en_normalizer()
-    return normalizer(text)
-
-
-OMNI_WHISPER_MODEL_PATH = "openai/whisper-large-v3"
-OMNI_WHISPER_REQUEST_TIMEOUT_S = 300
-# Whisper encoder accepts at most ~30 s per request (nb_max_frames=3000).
-# transformers pipeline uses chunk_length_s=30; mirror that for long talker audio.
-OMNI_WHISPER_CHUNK_LENGTH_S = 30
-OMNI_WHISPER_CHUNK_STRIDE_S = 25
-OMNI_WHISPER_SAMPLE_RATE = 16000
-
-
-def _load_wav_mono_16k(wav_path: str) -> torch.Tensor:
-    import torchaudio
-
-    audio, sample_rate = torchaudio.load(wav_path)
-    if audio.ndim == 2 and audio.shape[0] > 1:
-        audio = audio.mean(dim=0, keepdim=True)
-    audio = audio.squeeze(0).to(torch.float32)
-    if sample_rate != OMNI_WHISPER_SAMPLE_RATE:
-        audio = torchaudio.functional.resample(
-            audio, sample_rate, OMNI_WHISPER_SAMPLE_RATE
-        )
-    return audio
-
-
-def _wav_bytes_from_mono_16k(audio: torch.Tensor) -> bytes:
-    pcm16 = (audio.clamp(-1.0, 1.0) * 32767.0).to(torch.int16).cpu()
-    buffer = io.BytesIO()
-    with wave.open(buffer, "wb") as wav_file:
-        wav_file.setnchannels(1)
-        wav_file.setsampwidth(2)
-        wav_file.setframerate(OMNI_WHISPER_SAMPLE_RATE)
-        wav_file.writeframes(pcm16.numpy().tobytes())
-    return buffer.getvalue()
-
-
-def _post_omni_whisper_transcription(
-    asr: dict,
-    audio_bytes: bytes,
-    filename: str,
-    lang: str,
-) -> str:
-    response = requests.post(
-        f"http://127.0.0.1:{asr['router_port']}/v1/audio/transcriptions",
-        data={
-            "model": asr["model_path"],
-            "language": "en" if lang == "en" else lang,
-            "temperature": "0",
-        },
-        files={
-            "file": (
-                filename,
-                audio_bytes,
-                "audio/wav",
-            )
-        },
-        timeout=OMNI_WHISPER_REQUEST_TIMEOUT_S,
-        proxies={"http": None, "https": None},
-    )
-    response.raise_for_status()
-    return str(response.json()["text"])
-
-
-def _transcribe_omni_whisper(asr: dict, wav_path: str, lang: str) -> str:
-    audio = _load_wav_mono_16k(wav_path)
-    duration_s = float(audio.shape[0]) / OMNI_WHISPER_SAMPLE_RATE
-    if duration_s <= OMNI_WHISPER_CHUNK_LENGTH_S:
-        with open(wav_path, "rb") as audio_file:
-            return _post_omni_whisper_transcription(
-                asr,
-                audio_file.read(),
-                os.path.basename(wav_path),
-                lang,
-            )
-
-    chunk_samples = OMNI_WHISPER_CHUNK_LENGTH_S * OMNI_WHISPER_SAMPLE_RATE
-    stride_samples = OMNI_WHISPER_CHUNK_STRIDE_S * OMNI_WHISPER_SAMPLE_RATE
-    chunk_texts: list[str] = []
-    for start in range(0, int(audio.shape[0]), stride_samples):
-        chunk = audio[start : start + chunk_samples]
-        if chunk.numel() == 0:
-            break
-        chunk_bytes = _wav_bytes_from_mono_16k(chunk)
-        chunk_texts.append(
-            _post_omni_whisper_transcription(
-                asr,
-                chunk_bytes,
-                f"{os.path.basename(wav_path)}.chunk{start // stride_samples}.wav",
-                lang,
-            ).strip()
-        )
-        if start + chunk_samples >= audio.shape[0]:
-            break
-    return " ".join(text for text in chunk_texts if text)
-
-
-def load_omni_whisper_asr(
-    router_port: int,
-    *,
-    model_path: str = OMNI_WHISPER_MODEL_PATH,
-) -> dict:
-    """Return an ASR handle that transcribes via SGLang Omni Whisper router."""
-    return {
-        "type": "omni_whisper",
-        "router_port": router_port,
-        "model_path": model_path,
-    }
-
-
-QWEN3_ASR_MODEL_PATH = os.getenv("QWEN3_ASR_MODEL_PATH", "Qwen/Qwen3-ASR-1.7B")
-QWEN3_ASR_REQUEST_TIMEOUT_S = 300
-QWEN3_ASR_MAX_NEW_TOKENS = int(os.getenv("QWEN3_ASR_MAX_NEW_TOKENS", "128"))
-# ASR transcription fan-out for WER, not TTS generation concurrency.
-DEFAULT_ASR_TRANSCRIBE_CONCURRENCY = int(
-    os.getenv("QWEN3_ASR_CONCURRENCY", os.getenv("SEEDTTS_ASR_CONCURRENCY", "32"))
-)
-
-
-def load_qwen3_asr(
-    router_port: int,
-    *,
-    model_path: str = QWEN3_ASR_MODEL_PATH,
-) -> dict:
-    """Return an ASR handle that transcribes via a Qwen3-ASR sglang-omni router."""
-    return {
-        "type": "qwen3_asr",
-        "router_port": router_port,
-        "model_path": model_path,
-    }
-
-
-def _is_whisper_asr_model(model_path: str) -> bool:
-    return "whisper" in model_path.lower()
-
-
-def load_router_asr(
-    router_port: int,
-    *,
-    model_path: str = QWEN3_ASR_MODEL_PATH,
-) -> dict:
-    """Return an ASR handle backed by a running SGLang Omni ASR server."""
-    if _is_whisper_asr_model(model_path):
-        return load_omni_whisper_asr(router_port, model_path=model_path)
-    return load_qwen3_asr(router_port, model_path=model_path)
-
-
-def _transcribe_qwen3_asr(asr: dict, wav_path: str, lang: str) -> str:
-    """Transcribe one wav via the Qwen3-ASR server's /v1/audio/transcriptions.
-
-    Note: do NOT send temperature=0 — Qwen3-ASR degenerates under pure greedy
-    (the server bumps it to 0.01). ``language`` selects the forced prefix.
-    """
-    with open(wav_path, "rb") as audio_file:
-        response = requests.post(
-            f"http://127.0.0.1:{asr['router_port']}/v1/audio/transcriptions",
-            data={
-                "model": asr["model_path"],
-                "language": "en" if lang == "en" else lang,
-                "response_format": "json",
-                "max_new_tokens": str(QWEN3_ASR_MAX_NEW_TOKENS),
-            },
-            files={"file": (os.path.basename(wav_path), audio_file, "audio/wav")},
-            timeout=QWEN3_ASR_REQUEST_TIMEOUT_S,
-            proxies={"http": None, "https": None},
-        )
-    response.raise_for_status()
-    return str(response.json()["text"])
-
-
-def _resolve_asr_backend(
-    lang: str,
-    asr_device: str,
-    *,
-    asr_router_port: int | None = None,
-    asr_model_path: str = QWEN3_ASR_MODEL_PATH,
-    generation_mode: str | None = None,
-) -> dict:
-    if asr_router_port is not None:
-        return load_router_asr(asr_router_port, model_path=asr_model_path)
-    return load_asr_model(lang, asr_device, generation_mode)
-
-
-def load_asr_model(lang: str, device: str, generation_mode: str | None = None):
-    """Legacy local ASR entry point.
-
-    WER now runs through SGLang Omni's OpenAI-compatible transcription endpoint.
-    Start an ASR server with ``sglang_omni.cli serve`` and pass its port instead
-    of loading local ASR backends in-process.
-    """
-    mode_suffix = f" for {generation_mode} generation" if generation_mode else ""
-    del device
-    if lang not in {"en", "zh"}:
-        raise ValueError(f"Unsupported language: {lang}")
-    raise ValueError(
-        "WER transcription requires a running SGLang Omni ASR server"
-        f"{mode_suffix}. Start Qwen3-ASR (default "
-        f"{QWEN3_ASR_MODEL_PATH}) or {OMNI_WHISPER_MODEL_PATH} and pass "
-        "asr_router_port."
-    )
-
-
-def transcribe(asr: dict, wav_path: str, lang: str, device: str) -> str:
-    if asr["type"] == "qwen3_asr":
-        return _transcribe_qwen3_asr(asr, wav_path, lang)
-    if asr["type"] == "omni_whisper":
-        return _transcribe_omni_whisper(asr, wav_path, lang)
-    raise ValueError(f"Unknown ASR type: {asr['type']}")
-
-
-def transcribe_and_compute_wer(
-    output: SampleOutput,
-    wav_path: str,
-    asr: dict,
-    lang: str,
-    device: str,
-) -> SampleOutput:
-    """Transcribe audio and compute per-sample WER metrics."""
-    try:
-        hyp_text = transcribe(asr, wav_path, lang, device)
-    except Exception as exc:
-        output.error = f"Transcription failed: {exc}"
-        logger.error(f"[{output.sample_id}] {output.error}")
-        return output
-
-    output.whisper_text = hyp_text
-    output.ref_norm = normalize_text(output.target_text, lang)
-    output.hyp_norm = normalize_text(hyp_text, lang)
-
-    if not output.ref_norm:
-        output.error = "Empty reference after normalization"
-        return output
-
-    measures = process_words(output.ref_norm, output.hyp_norm)
-    output.wer = measures.wer
-    output.substitutions = measures.substitutions
-    output.deletions = measures.deletions
-    output.insertions = measures.insertions
-    output.hits = measures.hits
-    output.is_success = True
-    return output
-
-
-def compute_text_audio_consistency(
-    request_results: list[RequestResult],
-    lang: str,
-    asr_device: str,
-    *,
-    asr_router_port: int | None = None,
-    asr_model_path: str = QWEN3_ASR_MODEL_PATH,
-    asr_concurrency: int = DEFAULT_ASR_TRANSCRIBE_CONCURRENCY,
-) -> dict:
-    """WER between each request's text output (ref) and ASR-transcribed audio (hyp)."""
-    asr = _resolve_asr_backend(
-        lang,
-        asr_device,
-        asr_router_port=asr_router_port,
-        asr_model_path=asr_model_path,
-    )
-
-    outputs_by_idx: list[SampleOutput | None] = [None] * len(request_results)
-    pending: list[tuple[int, RequestResult, SampleOutput]] = []
-    for idx, result in enumerate(request_results):
-        ref_text = " ".join(result.text.split())
-        out = SampleOutput(
-            sample_id=result.request_id,
-            target_text=ref_text,
-            latency_s=result.latency_s,
-            audio_duration_s=result.audio_duration_s,
-        )
-        if not result.is_success or not result.wav_path:
-            out.error = result.error or "No audio in response"
-            outputs_by_idx[idx] = out
-            continue
-        pending.append((idx, result, out))
-
-    def _transcribe_pending(
-        result: RequestResult,
-        output: SampleOutput,
-    ) -> SampleOutput:
-        asr_t0 = time.perf_counter()
-        output = transcribe_and_compute_wer(
-            output,
-            result.wav_path,
-            asr,
-            lang,
-            asr_device,
-        )
-        output.asr_latency_s = time.perf_counter() - asr_t0
-        return output
-
-    asr_concurrency = max(1, int(asr_concurrency))
-    if asr_concurrency == 1:
-        for idx, result, output in pending:
-            outputs_by_idx[idx] = _transcribe_pending(result, output)
-    else:
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=asr_concurrency,
-        ) as executor:
-            future_to_idx = {
-                executor.submit(_transcribe_pending, result, output): idx
-                for idx, result, output in pending
-            }
-            for future in concurrent.futures.as_completed(future_to_idx):
-                outputs_by_idx[future_to_idx[future]] = future.result()
-
-    outputs = [output for output in outputs_by_idx if output is not None]
-
-    per_sample = [
-        {
-            "id": o.sample_id,
-            "is_success": o.is_success,
-            "wer": o.wer if o.is_success else None,
-            "ref_text": o.target_text[:100],
-            "hyp_text": o.whisper_text[:100],
-            "ref_norm": o.ref_norm,
-            "hyp_norm": o.hyp_norm,
-            "audio_duration_s": o.audio_duration_s,
-            "error": o.error,
-        }
-        for o in outputs
-    ]
-    return {"summary": calculate_wer_metrics(outputs, lang), "per_sample": per_sample}
-
-
-def compute_text_audio_consistency_from_records(
-    per_sample: list[dict],
-    lang: str,
-    asr_device: str,
-    *,
-    audio_dir: str | None = None,
-    sample_id_key: str = "sample_id",
-    text_key: str = "raw_response",
-    asr_router_port: int | None = None,
-    asr_model_path: str = QWEN3_ASR_MODEL_PATH,
-    asr_concurrency: int = DEFAULT_ASR_TRANSCRIBE_CONCURRENCY,
-) -> dict:
-    """Compute WER from saved eval records after the inference server is stopped."""
-    request_results: list[RequestResult] = []
-    for record in per_sample:
-        sample_id = record.get(sample_id_key)
-        wav_path = record.get("wav_path") or ""
-        if not wav_path and audio_dir and sample_id:
-            wav_path = os.path.join(audio_dir, f"{sample_id}.wav")
-        request_results.append(
-            RequestResult(
-                request_id=str(sample_id or ""),
-                text=str(record.get(text_key) or ""),
-                is_success=bool(record.get("is_success")),
-                latency_s=float(record.get("latency_s") or 0),
-                audio_duration_s=float(record.get("audio_duration_s") or 0),
-                wav_path=wav_path,
-                error=str(record.get("error") or ""),
-            )
-        )
-    return compute_text_audio_consistency(
-        request_results,
-        lang,
-        asr_device,
-        asr_router_port=asr_router_port,
-        asr_model_path=asr_model_path,
-        asr_concurrency=asr_concurrency,
-    )
 
 
 def save_wer_results(
@@ -888,36 +479,6 @@ def build_base_url(config: ServerEndpointConfig) -> str:
     return config.base_url or f"http://{config.host}:{config.port}"
 
 
-def _transcribe_one_entry(
-    entry: dict,
-    asr: dict,
-    lang: str,
-    device: str,
-) -> SampleOutput:
-    """Transcribe a single ``generated.json`` entry and compute its WER."""
-    output = SampleOutput(
-        sample_id=entry["sample_id"],
-        target_text=entry["target_text"],
-    )
-    if not entry.get("is_success", False):
-        output.error = f"Generation failed: {entry.get('error', 'unknown')}"
-        return output
-
-    output.latency_s = entry.get("latency_s", 0.0)
-    output.audio_duration_s = entry.get("audio_duration_s", 0.0)
-    asr_t0 = time.perf_counter()
-    output = transcribe_and_compute_wer(output, entry["wav_path"], asr, lang, device)
-    output.asr_latency_s = time.perf_counter() - asr_t0
-    return output
-
-
-def _resolve_asr_concurrency(config: SeedttsTranscribeConfig) -> int:
-    value = getattr(config, "asr_concurrency", DEFAULT_ASR_TRANSCRIBE_CONCURRENCY)
-    if value is None:
-        value = 1
-    return max(1, int(value))
-
-
 def _log_transcribe_result(
     *,
     idx: int,
@@ -937,13 +498,72 @@ def _log_transcribe_result(
             )
         return
 
-    # Only warn for post-generation transcription failures; generation
-    # failures are surfaced at speed-benchmark time and already logged.
+    # note (aaron): only warn for post-generation transcription failures.
+    # Generation failures are surfaced at speed-benchmark time and already logged.
     if entry.get("is_success", False):
         logger.warning(
             f"[{idx + 1}/{total}] Transcription failed: "
             f"{entry['sample_id']} -- {output.error}",
         )
+
+
+def _transcribe_generated_via_runner(
+    generated: list[dict],
+    router_port: int,
+    model_path: str,
+    lang: str,
+    concurrency: int,
+    *,
+    log_per_sample: bool = False,
+) -> tuple[list[SampleOutput], float]:
+    done = [e for e in generated if e.get("is_success", False)]
+    samples = [
+        SampleInput(
+            sample_id=e["sample_id"],
+            ref_text=e["target_text"],
+            ref_audio=e["wav_path"],
+            target_text=e["target_text"],
+        )
+        for e in done
+    ]
+    results, wall_s = asyncio.run(
+        run_asr_transcription(
+            samples,
+            port=router_port,
+            model_path=model_path,
+            lang=lang,
+            concurrency=concurrency,
+            warmup=concurrency * ASR_WARMUP_MULTIPLIER,
+        )
+    )
+    result_by_id = {r.request_id: r for r in results}
+    outputs: list[SampleOutput] = []
+    total = len(generated)
+    for idx, e in enumerate(generated):
+        output = SampleOutput(
+            sample_id=e["sample_id"], target_text=e.get("target_text", "")
+        )
+        output.latency_s = e.get("latency_s", 0.0)
+        output.audio_duration_s = e.get("audio_duration_s", 0.0)
+        if not e.get("is_success", False):
+            output.error = f"Generation failed: {e.get('error', 'unknown')}"
+            outputs.append(output)
+            continue
+        result = result_by_id.get(e["sample_id"])
+        if result is None or not result.is_success:
+            output.error = (result.error if result else "") or "No transcription"
+        else:
+            output.asr_latency_s = result.latency_s
+            output = apply_wer(output, result.text, lang)
+        _log_transcribe_result(
+            idx=idx,
+            total=total,
+            entry=e,
+            output=output,
+            log_per_sample=log_per_sample,
+        )
+        outputs.append(output)
+    return outputs, wall_s
 
 
 def run_seedtts_transcribe(
@@ -970,63 +590,16 @@ def run_seedtts_transcribe(
         generated: list[dict] = json.load(f)
     logger.info(f"Loaded {len(generated)} entries from {generated_path}")
 
-    asr_model_path = getattr(config, "asr_model_path", QWEN3_ASR_MODEL_PATH)
-    asr = _resolve_asr_backend(
+    asr_model_path = config.asr_model_path
+    asr_concurrency = max(1, int(config.asr_concurrency))
+    outputs, asr_wall_time_s = _transcribe_generated_via_runner(
+        generated,
+        asr_router_port,
+        asr_model_path,
         config.lang,
-        config.device,
-        asr_router_port=asr_router_port,
-        asr_model_path=asr_model_path,
-        generation_mode=generation_mode,
+        asr_concurrency,
+        log_per_sample=log_per_sample,
     )
-
-    tqdm_desc = (
-        f"Transcribing ({config.lang})" if not generation_mode else "WER transcribe"
-    )
-    asr_concurrency = _resolve_asr_concurrency(config)
-    outputs_by_idx: list[SampleOutput | None] = [None] * len(generated)
-    asr_wall_start_s = time.perf_counter()
-    if asr_concurrency == 1:
-        for idx, entry in enumerate(tqdm(generated, desc=tqdm_desc)):
-            output = _transcribe_one_entry(entry, asr, config.lang, config.device)
-            outputs_by_idx[idx] = output
-            _log_transcribe_result(
-                idx=idx,
-                total=len(generated),
-                entry=entry,
-                output=output,
-                log_per_sample=log_per_sample,
-            )
-    else:
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=asr_concurrency,
-        ) as executor:
-            future_to_idx = {
-                executor.submit(
-                    _transcribe_one_entry,
-                    entry,
-                    asr,
-                    config.lang,
-                    config.device,
-                ): idx
-                for idx, entry in enumerate(generated)
-            }
-            with tqdm(total=len(generated), desc=tqdm_desc) as progress:
-                for future in concurrent.futures.as_completed(future_to_idx):
-                    idx = future_to_idx[future]
-                    entry = generated[idx]
-                    output = future.result()
-                    outputs_by_idx[idx] = output
-                    _log_transcribe_result(
-                        idx=idx,
-                        total=len(generated),
-                        entry=entry,
-                        output=output,
-                        log_per_sample=log_per_sample,
-                    )
-                    progress.update(1)
-
-    asr_wall_time_s = time.perf_counter() - asr_wall_start_s
-    outputs = [output for output in outputs_by_idx if output is not None]
 
     wer_metrics = calculate_wer_metrics(outputs, config.lang)
     asr_metrics = calculate_asr_speed_metrics(outputs, wall_time_s=asr_wall_time_s)

--- a/examples/run_ming_omni_server.py
+++ b/examples/run_ming_omni_server.py
@@ -195,7 +195,7 @@ def _launch_text_server(args: argparse.Namespace) -> None:
         relay_backend=args.relay_backend,
     )
 
-    if getattr(args, "thinker_only", False):
+    if args.thinker_only:
         if args.gpu_audio_encoder is not None or args.gpu_image_encoder is not None:
             raise ValueError(
                 "--gpu-audio-encoder/--gpu-image-encoder cannot be used "
@@ -213,10 +213,10 @@ def _launch_text_server(args: argparse.Namespace) -> None:
         server_arg_updates["disable_custom_all_reduce"] = True
     if args.gpu_audio_encoder is not None:
         _set_stage_gpu(config, "audio_encoder", args.gpu_audio_encoder)
-    image_encoder_tp = getattr(args, "image_encoder_tp", 1)
+    image_encoder_tp = args.image_encoder_tp
     if image_encoder_tp < 1:
         raise ValueError("--image-encoder-tp must be >= 1")
-    if image_encoder_tp > 1 and getattr(args, "thinker_only", False):
+    if image_encoder_tp > 1 and args.thinker_only:
         raise ValueError("--thinker-only cannot be used with --image-encoder-tp > 1")
     if image_encoder_tp > 1:
         if args.gpu_image_encoder is None:

--- a/examples/run_ming_omni_speech.py
+++ b/examples/run_ming_omni_speech.py
@@ -180,7 +180,7 @@ def _save_audio(result: dict, output_path: str) -> None:
         if isinstance(payload, dict):
             data = payload
         else:
-            data = getattr(payload, "data", None)
+            data = payload.data
         if not isinstance(data, dict):
             continue
         waveform = data.get("audio_waveform")

--- a/examples/run_ming_omni_speech.py
+++ b/examples/run_ming_omni_speech.py
@@ -159,7 +159,7 @@ async def main_async(args: argparse.Namespace) -> None:
             timeout=args.timeout,
         )
         duration = time.time() - t0
-        logger.info("Pipeline completed in %.2fs", duration)
+        logger.info(f"Pipeline completed in {duration:.2f}s")
 
         if args.output and isinstance(result, dict):
             _save_audio(result, args.output)

--- a/examples/run_ming_omni_speech_server.py
+++ b/examples/run_ming_omni_speech_server.py
@@ -176,7 +176,7 @@ def _launch_speech_server(args: argparse.Namespace) -> None:
 
     _validate_fraction("--mem-fraction-static", args.mem_fraction_static)
 
-    if getattr(args, "enable_streaming_tts", False):
+    if args.enable_streaming_tts:
         config = MingOmniStreamingSpeechPipelineConfig(
             model_path=args.model_path,
             relay_backend=args.relay_backend,
@@ -204,7 +204,7 @@ def _launch_speech_server(args: argparse.Namespace) -> None:
         server_arg_updates["disable_custom_all_reduce"] = True
     if args.mem_fraction_static is not None:
         server_arg_updates["mem_fraction_static"] = args.mem_fraction_static
-    if getattr(args, "cpu_offload_gb", None) is not None:
+    if args.cpu_offload_gb is not None:
         server_arg_updates["cpu_offload_gb"] = args.cpu_offload_gb
     if server_arg_updates:
         _apply_stage_factory_updates(

--- a/examples/run_qwen3_omni_speech.py
+++ b/examples/run_qwen3_omni_speech.py
@@ -169,7 +169,10 @@ def _save_audio(result: dict, output_path: str) -> None:
     import numpy as np
 
     for stage_name, payload in result.items():
-        data = getattr(payload, "data", None)
+        if isinstance(payload, dict):
+            data = payload
+        else:
+            data = payload.data
         if not isinstance(data, dict):
             continue
         waveform = data.get("audio_waveform")

--- a/examples/run_qwen3_omni_speech.py
+++ b/examples/run_qwen3_omni_speech.py
@@ -152,7 +152,7 @@ async def main_async(args: argparse.Namespace) -> None:
             timeout=args.timeout,
         )
         duration = time.time() - t0
-        logger.info("Pipeline completed in %.2fs", duration)
+        logger.info(f"Pipeline completed in {duration:.2f}s")
 
         # Extract and save audio if requested
         if args.output and isinstance(result, dict):

--- a/playground/qwen-omni/app.py
+++ b/playground/qwen-omni/app.py
@@ -166,7 +166,7 @@ _register_filesystem(app)
 _register_home(app)
 assert FRONTEND_DIR.is_dir(), "Frontend directory does not exist"
 app.mount("/", StaticFiles(directory=str(FRONTEND_DIR), html=True))
-logger.info("Serving playground UI from %s", FRONTEND_DIR)
+logger.info(f"Serving playground UI from {FRONTEND_DIR}")
 
 args = parse_args()
 uvicorn.run(app, host="0.0.0.0", port=args.port)

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -6,7 +6,7 @@ from typing import Annotated, Literal, NoReturn
 import typer
 import yaml
 
-from sglang_omni.config import PipelineConfig
+from sglang_omni.config import PipelineConfig, StageConfig
 from sglang_omni.config.manager import ConfigManager
 from sglang_omni.preprocessing.resource_connector import (
     resolve_allowed_local_media_path,
@@ -480,8 +480,8 @@ def _validate_colocated_gpu_override(
         )
 
 
-def _stage_tp_gpu_ids(stage: object) -> list[int]:
-    gpu = getattr(stage, "gpu", None)
+def _stage_tp_gpu_ids(stage: StageConfig) -> list[int]:
+    gpu = stage.gpu
     if gpu is None:
         return []
     if isinstance(gpu, int):
@@ -511,7 +511,7 @@ def _gate_custom_all_reduce_on_topology(
     refined["disable_custom_all_reduce"] = False
     logger.info(
         "Enabling custom all-reduce for stage '%s': GPUs %s form a P2P mesh",
-        getattr(stage, "name", "?"),
+        stage.name,
         list(gpu_ids),
     )
     return refined

--- a/sglang_omni/client/audio.py
+++ b/sglang_omni/client/audio.py
@@ -381,7 +381,7 @@ def encode_audio(
             if not allow_format_fallback:
                 raise ValueError(f"pydub is required to encode response_format={fmt!r}")
             logger.warning(
-                "pydub not installed; falling back to WAV for %s request", fmt
+                f"pydub not installed; falling back to WAV for {fmt} request"
             )
             return encode_wav(arr, sample_rate), FORMAT_MIME_TYPES["wav"]
         except Exception as exc:
@@ -390,7 +390,7 @@ def encode_audio(
                     f"Failed to encode response_format={fmt!r}: {exc}"
                 ) from exc
             logger.warning(
-                "Failed to encode %s; falling back to WAV", fmt, exc_info=True
+                f"Failed to encode {fmt}; falling back to WAV", exc_info=True
             )
             return encode_wav(arr, sample_rate), FORMAT_MIME_TYPES["wav"]
 
@@ -413,7 +413,7 @@ def encode_audio(
 
     if not allow_format_fallback:
         raise ValueError(f"Unsupported audio format: {response_format!r}")
-    logger.warning("Unknown audio format '%s'; falling back to WAV", fmt)
+    logger.warning(f"Unknown audio format '{fmt}'; falling back to WAV")
     return encode_wav(arr, sample_rate), FORMAT_MIME_TYPES["wav"]
 
 

--- a/sglang_omni/config/__init__.py
+++ b/sglang_omni/config/__init__.py
@@ -19,6 +19,7 @@ from sglang_omni.config.schema import (
     StageConfig,
     StageResourceConfig,
     StageRuntimeConfig,
+    TensorRefEdgeConfig,
 )
 from sglang_omni.config.topology import (
     ProcessGroupPlacement,
@@ -51,4 +52,5 @@ __all__ = [
     "PlacementConfig",
     "RelayConfig",
     "EndpointsConfig",
+    "TensorRefEdgeConfig",
 ]

--- a/sglang_omni/config/runtime.py
+++ b/sglang_omni/config/runtime.py
@@ -10,8 +10,6 @@ from typing import Any
 from sglang_omni.config.schema import PipelineConfig, StageConfig
 from sglang_omni.utils.imports import import_string
 
-_MAPPED_STAGE_RUNTIME_FIELDS = ("max_seq_len", "video_fps")
-
 
 def resolve_stage_factory_args(
     stage_cfg: StageConfig,
@@ -149,8 +147,7 @@ def _validate_runtime_sources(
         runtime_overrides,
     )
 
-    for field_name in _MAPPED_STAGE_RUNTIME_FIELDS:
-        value = getattr(stage_cfg.runtime, field_name)
+    for field_name, value in _mapped_stage_runtime_values(stage_cfg).items():
         if value is None:
             continue
         target_arg = stage_cfg.runtime_arg_map.get(field_name)
@@ -195,8 +192,7 @@ def _merge_factory_arg_overrides(
 def _apply_typed_runtime_args(args: dict[str, Any], stage_cfg: StageConfig) -> None:
     runtime = stage_cfg.runtime
 
-    for field_name in _MAPPED_STAGE_RUNTIME_FIELDS:
-        value = getattr(runtime, field_name)
+    for field_name, value in _mapped_stage_runtime_values(stage_cfg).items():
         if value is None:
             continue
         target_arg = stage_cfg.runtime_arg_map.get(field_name)
@@ -212,6 +208,14 @@ def _apply_typed_runtime_args(args: dict[str, Any], stage_cfg: StageConfig) -> N
         overrides = dict(args.get("server_args_overrides") or {})
         overrides["mem_fraction_static"] = mem_fraction_static
         args["server_args_overrides"] = overrides
+
+
+def _mapped_stage_runtime_values(stage_cfg: StageConfig) -> dict[str, Any]:
+    runtime = stage_cfg.runtime
+    return {
+        "max_seq_len": runtime.max_seq_len,
+        "video_fps": runtime.video_fps,
+    }
 
 
 def _resolve_primary_gpu_id(

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -20,6 +20,28 @@ class RelayConfig(BaseModel):
     device: str = "cpu"
 
 
+class TensorRefEdgeConfig(BaseModel):
+    """Explicit lazy tensor handoff policy for one outgoing stage edge."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    consumer_stage: str
+    threshold_mb: float = 2.0
+    paths: tuple[str, ...]
+
+    def model_post_init(self, __context: Any = None) -> None:
+        if self.threshold_mb < 0:
+            raise ValueError("tensor_ref_edges threshold_mb must be non-negative")
+        if not self.consumer_stage.strip():
+            raise ValueError("tensor_ref_edges consumer_stage must not be empty")
+        if not self.paths:
+            raise ValueError("tensor_ref_edges paths must not be empty")
+        cleaned = tuple(path.strip() for path in self.paths)
+        if any(not path for path in cleaned):
+            raise ValueError("tensor_ref_edges paths must not contain empty values")
+        self.paths = cleaned
+
+
 class EndpointsConfig(BaseModel):
     """Endpoint allocation settings."""
 
@@ -174,6 +196,7 @@ class StageConfig(BaseModel):
 
     # --- Relay (auto-inferred from gpu when None) ---
     relay: RelayConfig | None = None
+    tensor_ref_edges: dict[str, TensorRefEdgeConfig] = Field(default_factory=dict)
 
     def model_post_init(self, __context: Any = None) -> None:
         fields_set = self.__pydantic_fields_set__
@@ -370,6 +393,23 @@ class PipelineConfig(BaseModel):
                 if t not in names:
                     raise ValueError(
                         f"Stage {s.name!r} project_payload references unknown stage {t!r}"
+                    )
+            route_targets = set(_target_list(s.next)) | set(s.stream_to)
+            for t, tensor_ref in s.tensor_ref_edges.items():
+                if t not in names:
+                    raise ValueError(
+                        f"Stage {s.name!r} tensor_ref_edges references unknown "
+                        f"target stage {t!r}"
+                    )
+                if t not in route_targets:
+                    raise ValueError(
+                        f"Stage {s.name!r} tensor_ref_edges target {t!r} is not "
+                        "a declared next or stream_to target"
+                    )
+                if tensor_ref.consumer_stage not in names:
+                    raise ValueError(
+                        f"Stage {s.name!r} tensor_ref_edges target {t!r} has "
+                        f"unknown consumer_stage {tensor_ref.consumer_stage!r}"
                     )
 
         for stage_name in self.runtime_overrides:

--- a/sglang_omni/model_runner/_sglang_qwen3_vl_patches.py
+++ b/sglang_omni/model_runner/_sglang_qwen3_vl_patches.py
@@ -216,8 +216,7 @@ def apply_qwen3_vl_hf_parity_patches() -> None:
         setattr(Qwen3VLMoeVisionModel, _PATCHED_FLAG, True)
 
     logger.info(
-        "Applied rot_pos_emb HF-parity patch to %s.%s "
-        "(see sglang-omni issue #434 for context).",
-        Qwen3VLMoeVisionModel.__module__,
-        Qwen3VLMoeVisionModel.__name__,
+        f"Applied rot_pos_emb HF-parity patch to "
+        f"{Qwen3VLMoeVisionModel.__module__}.{Qwen3VLMoeVisionModel.__name__} "
+        f"(see sglang-omni issue #434 for context).",
     )

--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -20,6 +20,7 @@ from sglang_omni.sampling.seed import (
 from sglang_omni.scheduling.types import (
     ModelRunnerOutput,
     RequestOutput,
+    SchedulerRequest,
     sampled_logprobs_to_list,
 )
 
@@ -35,15 +36,8 @@ def _current_sglang_sampling_backend() -> str | None:
         return None
 
 
-def _rank_shared_unseeded_sampling_seed(request: Any, row_idx: int) -> int:
-    request_id = getattr(request, "request_id", None)
-    if request_id is None:
-        request_id = getattr(getattr(request, "data", None), "request_id", None)
-    if request_id is None:
-        req = getattr(getattr(request, "data", None), "req", None)
-        request_id = getattr(req, "rid", None)
-    if request_id is None:
-        request_id = f"row-{row_idx}"
+def _rank_shared_unseeded_sampling_seed(request: SchedulerRequest, row_idx: int) -> int:
+    request_id = request.request_id or f"row-{row_idx}"
     return derive_sampling_seed("sglang-omni-unseeded-row", request_id)
 
 

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -222,11 +222,11 @@ class ModelWorker:
 
     def model_info(self) -> dict[str, Any]:
         return {
-            "model_path": getattr(self.server_args, "model_path", None),
-            "load_format": getattr(self.server_args, "load_format", None),
-            "weight_version": getattr(self.server_args, "weight_version", None),
+            "model_path": self.server_args.model_path,
+            "load_format": self.server_args.load_format,
+            "weight_version": self.server_args.weight_version,
             "tp_rank": self.tp_rank,
-            "tp_size": getattr(self.server_args, "tp_size", 1),
+            "tp_size": self.server_args.tp_size,
             "model_arch_override": self.model_arch_override,
             "supports_weight_update": hasattr(
                 self.model_runner, "update_weights_from_disk"
@@ -241,9 +241,7 @@ class ModelWorker:
         update = getattr(self.model_runner, "update_weights_from_disk", None)
         if update is None:
             return False, "model runner does not support update_weights_from_disk"
-        load_format = payload.get("load_format") or getattr(
-            self.server_args, "load_format", None
-        )
+        load_format = payload.get("load_format") or self.server_args.load_format
         success, message = update(
             model_path,
             load_format,
@@ -400,18 +398,16 @@ def _apply_model_worker_backend_policy(
     effective_quantization = _normalize_quantization(
         getattr(model_config, "quantization", None)
     )
-    server_quantization = _normalize_quantization(
-        getattr(server_args, "quantization", None)
-    )
+    server_quantization = _normalize_quantization(server_args.quantization)
     if server_quantization is not None:
         effective_quantization = server_quantization
 
-    moe_runner_backend = getattr(server_args, "moe_runner_backend", "auto")
+    moe_runner_backend = server_args.moe_runner_backend
     is_qwen3_omni_arch = model_arch_override in (
         "Qwen3OmniTalker",
         "Qwen3OmniThinkerForCausalLM",
     )
-    if is_qwen3_omni_arch and getattr(server_args, "ep_size", 1) != 1:
+    if is_qwen3_omni_arch and server_args.ep_size != 1:
         raise ValueError(
             "Qwen3-Omni ModelWorker does not support expert parallelism; "
             "use ep_size=1."
@@ -477,7 +473,7 @@ def _apply_model_worker_backend_policy(
         server_args.fp8_gemm_runner_backend = "triton"
         fp8_gemm_backend = server_args.fp8_gemm_runner_backend
 
-    server_quantization = getattr(server_args, "quantization", None)
+    server_quantization = server_args.quantization
     logger.info(
         f"Configured SGLang backend policy: arch={model_arch_override} "
         f"effective_quantization={effective_quantization} "

--- a/sglang_omni/model_runner/sglang_model_runner.py
+++ b/sglang_omni/model_runner/sglang_model_runner.py
@@ -101,7 +101,7 @@ class SGLModelRunner(ModelRunner):
                     importlib.import_module(module_path), attr
                 )
             except Exception as exc:
-                logger.warning("sglang-omni: skipping model %s (%s)", arch, exc)
+                logger.warning(f"sglang-omni: skipping model {arch} ({exc})")
 
         try:
             from sglang_omni.models.ming_omni.registration import (
@@ -112,7 +112,7 @@ class SGLModelRunner(ModelRunner):
             register_ming_hf_config()
             register_ming_model_registry()
         except Exception as exc:
-            logger.warning("sglang-omni: skipping Ming-Omni registration (%s)", exc)
+            logger.warning(f"sglang-omni: skipping Ming-Omni registration ({exc})")
 
     def _profile_available_bytes(self, pre_model_load_memory: float) -> int:
         """Profile KV-cache headroom for colocated SGLang AR stages.

--- a/sglang_omni/models/fishaudio_s2_pro/bootstrap.py
+++ b/sglang_omni/models/fishaudio_s2_pro/bootstrap.py
@@ -97,7 +97,7 @@ def load_audio_decoder(
         FishQwen3OmniForCausalLM,
     )
 
-    logger.info("Loading Fish audio decoder from %s", checkpoint_dir)
+    logger.info(f"Loading Fish audio decoder from {checkpoint_dir}")
     start = time.perf_counter()
 
     config = FishQwen3OmniConfig.from_pretrained(checkpoint_dir)

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -262,7 +262,7 @@ def create_sglang_tts_engine_executor(
         **overrides,
     )
     server_args.disable_overlap_schedule = True
-    if getattr(server_args, "attention_backend", None) is None:
+    if server_args.attention_backend is None:
         server_args.attention_backend = "fa3"
 
     want_cuda_graph, (
@@ -299,7 +299,7 @@ def create_sglang_tts_engine_executor(
         model_buffer_bs=_resolve_s2pro_model_buffer_bs(model_worker.model_runner.model),
     )
 
-    if bool(getattr(server_args, "enable_torch_compile", False)):
+    if bool(server_args.enable_torch_compile):
         _compile_s2pro_codebook_decoder(
             model_worker.model_runner.model,
             max_batch_size=server_args.torch_compile_max_bs,

--- a/sglang_omni/models/llada2_uni/components/preprocessor.py
+++ b/sglang_omni/models/llada2_uni/components/preprocessor.py
@@ -196,7 +196,7 @@ class LLaDA2Preprocessor:
 
     async def __call__(self, payload: StagePayload) -> StagePayload:
         request = payload.request
-        raw_inputs = request.inputs if hasattr(request, "inputs") else {}
+        raw_inputs = request.inputs
         if isinstance(raw_inputs, list):
             messages = raw_inputs
             raw_images, image_counts_per_msg = self._extract_raw_images(messages)

--- a/sglang_omni/models/ming_omni/bootstrap.py
+++ b/sglang_omni/models/ming_omni/bootstrap.py
@@ -24,7 +24,7 @@ def create_thinker_scheduler(
 ):
     if tp_size < 1:
         raise ValueError(f"tp_size must be >= 1, got {tp_size}")
-    if getattr(server_args, "tp_size", None) != tp_size:
+    if server_args.tp_size != tp_size:
         server_args.tp_size = tp_size
 
     from sglang_omni.model_runner.ming_thinker_model_runner import (

--- a/sglang_omni/models/ming_omni/components/audio_encoder.py
+++ b/sglang_omni/models/ming_omni/components/audio_encoder.py
@@ -109,7 +109,7 @@ class MingAudioEncoder(nn.Module):
 
     def _load_weights(self) -> None:
         """Load audio tower and projection weights from checkpoint."""
-        logger.info("Loading Ming audio encoder weights from %s", self._model_path)
+        logger.info(f"Loading Ming audio encoder weights from {self._model_path}")
         load_module(
             self.audio_tower,
             self._model_path,

--- a/sglang_omni/models/ming_omni/components/preprocessor.py
+++ b/sglang_omni/models/ming_omni/components/preprocessor.py
@@ -321,7 +321,7 @@ class MingPreprocessor:
     async def __call__(self, payload: StagePayload) -> StagePayload:
         """Process a chat completion request into pipeline state."""
         request = payload.request
-        raw_inputs = request.inputs if hasattr(request, "inputs") else {}
+        raw_inputs = request.inputs
         if isinstance(raw_inputs, list):
             # OpenAI API passes messages list directly as inputs
             messages = raw_inputs

--- a/sglang_omni/models/ming_omni/components/streaming_detokenizer.py
+++ b/sglang_omni/models/ming_omni/components/streaming_detokenizer.py
@@ -31,7 +31,7 @@ from sglang_omni.models.ming_omni.pipeline.merge import decode_events
 from sglang_omni.models.ming_omni.pipeline.next_stage import THINKER_STAGE
 from sglang_omni.models.ming_omni.pipeline.state_io import load_state
 from sglang_omni.models.ming_omni.pipeline.usage import build_text_usage
-from sglang_omni.proto import StagePayload
+from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
 
 logger = logging.getLogger(__name__)
@@ -311,13 +311,13 @@ def _event_to_dict(event: Any) -> dict[str, Any]:
     }
 
 
-def text_output_requested(request: Any) -> bool:
+def text_output_requested(request: OmniRequest) -> bool:
     """Return True if text is among the requested output modalities.
 
     Reads ``request.metadata["output_modalities"]``; defaults to True when
     the field is absent (text is always produced unless explicitly excluded).
     """
-    metadata = getattr(request, "metadata", None)
+    metadata = request.metadata
     if not isinstance(metadata, dict):
         return True
     modalities = metadata.get("output_modalities")

--- a/sglang_omni/models/ming_omni/components/talker_executor.py
+++ b/sglang_omni/models/ming_omni/components/talker_executor.py
@@ -259,7 +259,7 @@ class MingTalkerExecutor:
 
     @staticmethod
     def _output_modalities(payload: StagePayload) -> set[str] | None:
-        metadata = getattr(payload.request, "metadata", None)
+        metadata = payload.request.metadata
         if not isinstance(metadata, dict):
             return None
         modalities = metadata.get("output_modalities")

--- a/sglang_omni/models/ming_omni/config.py
+++ b/sglang_omni/models/ming_omni/config.py
@@ -7,7 +7,12 @@ from typing import Any, ClassVar
 
 from pydantic import Field
 
-from sglang_omni.config.schema import PipelineConfig, PlacementConfig, StageConfig
+from sglang_omni.config.schema import (
+    PipelineConfig,
+    PlacementConfig,
+    StageConfig,
+    TensorRefEdgeConfig,
+)
 from sglang_omni.models.ming_omni.pipeline.next_stage import (
     AGGREGATE_STAGE,
     AUDIO_STAGE,
@@ -87,6 +92,12 @@ def _image_encoder_stage(
         next=AGGREGATE_STAGE,
         project_payload={
             AGGREGATE_STAGE: f"{_PKG}.stages.project_encoder_to_mm_aggregate"
+        },
+        tensor_ref_edges={
+            AGGREGATE_STAGE: TensorRefEdgeConfig(
+                consumer_stage=THINKER_STAGE,
+                paths=("video_embeds",),
+            )
         },
     )
 

--- a/sglang_omni/models/ming_omni/pipeline/merge.py
+++ b/sglang_omni/models/ming_omni/pipeline/merge.py
@@ -13,22 +13,28 @@ from sglang_omni.models.ming_omni.io import (
     ThinkerOutput,
 )
 from sglang_omni.models.ming_omni.pipeline.next_stage import AUDIO_STAGE, IMAGE_STAGE
+from sglang_omni.pipeline.tensor_ref import is_tensor_ref_dict, tensor_ref_numel
 from sglang_omni.proto import StagePayload
 
 
-def _as_tensor(value: Any, dtype: torch.dtype | None = None) -> torch.Tensor | None:
+def flatten_embed_batch_dims(result: dict[str, Any]) -> dict[str, Any]:
+    """Producer-side [B, T', H] -> [T', H] so mm_aggregate forwards opaquely."""
+    out = dict(result)
+    for key in ("audio_embeds", "image_embeds", "video_embeds"):
+        value = out.get(key)
+        if isinstance(value, torch.Tensor) and value.dim() == 3:
+            out[key] = value.squeeze(0)
+    return out
+
+
+def _non_empty(value: Any) -> bool:
     if value is None:
-        return None
+        return False
+    if is_tensor_ref_dict(value):
+        return tensor_ref_numel(value) > 0
     if isinstance(value, torch.Tensor):
-        return value.to(dtype=dtype) if dtype is not None else value
-    try:
-        return torch.as_tensor(value, dtype=dtype)
-    except Exception:
-        return None
-
-
-def _non_empty(tensor: torch.Tensor | None) -> bool:
-    return isinstance(tensor, torch.Tensor) and tensor.numel() > 0
+        return value.numel() > 0
+    return False
 
 
 def merge_for_thinker(payloads: dict[str, StagePayload]) -> StagePayload:
@@ -81,39 +87,19 @@ def build_thinker_inputs(
         encoder_outs.get(IMAGE_STAGE, {}) if isinstance(encoder_outs, dict) else {}
     )
 
-    audio_embeds = (
-        _as_tensor(audio_out.get("audio_embeds"))
-        if isinstance(audio_out, dict)
-        else None
-    )
-    image_embeds = (
-        _as_tensor(image_out.get("image_embeds"))
-        if isinstance(image_out, dict)
-        else None
-    )
-    video_embeds = (
-        _as_tensor(image_out.get("video_embeds"))
-        if isinstance(image_out, dict)
-        else None
-    )
+    audio_embeds = audio_out.get("audio_embeds")
+    image_embeds = image_out.get("image_embeds")
+    video_embeds = image_out.get("video_embeds")
 
     thinker_model_inputs: dict[str, Any] = {}
 
     if _non_empty(audio_embeds):
-        # Flatten: [B, T', H] -> [T', H] (remove batch dim for SGLang injection)
-        if audio_embeds.dim() == 3:
-            audio_embeds = audio_embeds.squeeze(0)
         thinker_model_inputs["audio_embeds"] = audio_embeds
 
     if _non_empty(image_embeds):
-        # Flatten: [B, T', H] -> [T', H] if needed
-        if image_embeds.dim() == 3:
-            image_embeds = image_embeds.squeeze(0)
         thinker_model_inputs["image_embeds"] = image_embeds
 
     if _non_empty(video_embeds):
-        if video_embeds.dim() == 3:
-            video_embeds = video_embeds.squeeze(0)
         thinker_model_inputs["video_embeds"] = video_embeds
 
     media_cache_keys: dict[str, str] = {}

--- a/sglang_omni/models/ming_omni/stages.py
+++ b/sglang_omni/models/ming_omni/stages.py
@@ -149,6 +149,7 @@ def create_audio_encoder_executor(
     dtype: str | None = None,
 ):
     from sglang_omni.models.ming_omni.components.audio_encoder import MingAudioEncoder
+    from sglang_omni.models.ming_omni.pipeline.merge import flatten_embed_batch_dims
     from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
     model = MingAudioEncoder(model_path=model_path, device=device, dtype=dtype)
@@ -165,7 +166,9 @@ def create_audio_encoder_executor(
             _meta = {"cache_key", "audio_placeholder_loc_lens"}
             model_inputs = {k: v for k, v in inputs.items() if k not in _meta}
             result = model(**model_inputs)
-        state.encoder_outs[AUDIO_STAGE] = result if isinstance(result, dict) else {}
+        state.encoder_outs[AUDIO_STAGE] = (
+            flatten_embed_batch_dims(result) if isinstance(result, dict) else {}
+        )
         state.engine_outputs[AUDIO_STAGE] = state.encoder_outs[AUDIO_STAGE]
         payload.data = state.to_dict()
         return payload
@@ -183,6 +186,7 @@ def create_image_encoder_executor(
     nccl_port: int | None = None,
 ):
     from sglang_omni.models.ming_omni.components.image_encoder import MingImageEncoder
+    from sglang_omni.models.ming_omni.pipeline.merge import flatten_embed_batch_dims
     from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
     model = MingImageEncoder(
@@ -205,7 +209,9 @@ def create_image_encoder_executor(
         else:
             model_inputs = {k: v for k, v in inputs.items() if k != "cache_key"}
             result = model(**model_inputs)
-        state.encoder_outs[IMAGE_STAGE] = result if isinstance(result, dict) else {}
+        state.encoder_outs[IMAGE_STAGE] = (
+            flatten_embed_batch_dims(result) if isinstance(result, dict) else {}
+        )
         state.engine_outputs[IMAGE_STAGE] = state.encoder_outs[IMAGE_STAGE]
         payload.data = state.to_dict()
         return payload

--- a/sglang_omni/models/moss_tts/sglang_model.py
+++ b/sglang_omni/models/moss_tts/sglang_model.py
@@ -437,7 +437,7 @@ class MossTTSDelaySGLangModel(torch.nn.Module):
             if param is not None:
                 self._load_param(param, loaded_weight)
             else:
-                logger.warning("MOSS-TTS parameter %s not found", original_name)
+                logger.warning(f"MOSS-TTS parameter {original_name} not found")
 
     @staticmethod
     def _map_audio_embedding_name(name: str) -> str | None:

--- a/sglang_omni/models/moss_tts/stages.py
+++ b/sglang_omni/models/moss_tts/stages.py
@@ -73,7 +73,7 @@ def _load_moss_processor(
     dtype: str | torch.dtype = "float32",
 ) -> Any:
     checkpoint_dir = resolve_moss_checkpoint(model_path)
-    logger.info("Loading MOSS-TTS processor from %s on %s", checkpoint_dir, device)
+    logger.info(f"Loading MOSS-TTS processor from {checkpoint_dir} on {device}")
     try:
         with moss_transformers_processor_compat():
             processor_cls = load_moss_processor_class(checkpoint_dir)

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -672,7 +672,7 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
                     self._load_param(param, loaded_weight)
                 else:
                     logger.warning(
-                        "MOSS-TTS Local parameter %s not found", original_name
+                        f"MOSS-TTS Local parameter {original_name} not found"
                     )
                 continue
 
@@ -706,7 +706,7 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             if param is not None:
                 self._load_param(param, loaded_weight)
             else:
-                logger.warning("MOSS-TTS Local parameter %s not found", original_name)
+                logger.warning(f"MOSS-TTS Local parameter {original_name} not found")
 
         self._zero_audio_pad_rows()
 

--- a/sglang_omni/models/qwen3_asr/config.py
+++ b/sglang_omni/models/qwen3_asr/config.py
@@ -25,6 +25,7 @@ class Qwen3ASRPipelineConfig(PipelineConfig):
             factory_args={
                 "device": "cuda:0",
                 "max_running_requests": 32,
+                "max_new_tokens": 128,
                 "request_build_max_workers": 2,
                 "request_build_max_pending": 16,
             },

--- a/sglang_omni/models/qwen3_omni/bootstrap.py
+++ b/sglang_omni/models/qwen3_omni/bootstrap.py
@@ -30,7 +30,7 @@ def create_thinker_scheduler(
 
     capture_hidden_layers = [0, 24] if speech_enabled else None
     capture_hidden = speech_enabled
-    want_cuda_graph = not bool(getattr(server_args, "disable_cuda_graph", False))
+    want_cuda_graph = not bool(server_args.disable_cuda_graph)
     defer_cuda_graph_capture = want_cuda_graph and capture_hidden
     if defer_cuda_graph_capture:
         server_args.enable_return_hidden_states = True

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -7,12 +7,22 @@ from typing import ClassVar
 
 from pydantic import Field
 
-from sglang_omni.config import PipelineConfig, PlacementConfig, StageConfig
+from sglang_omni.config import (
+    PipelineConfig,
+    PlacementConfig,
+    StageConfig,
+    TensorRefEdgeConfig,
+)
 
 _PKG = "sglang_omni.models.qwen3_omni"
 _PLACEMENT_POLICY = f"{_PKG}.placement.Qwen3OmniPlacementPolicy"
 THINKER_STAGE = "thinker"
 MIN_PARTIAL_START_CHUNKS = 3
+_VISUAL_TENSOR_REF_PATHS = (
+    "video_embeds",
+    "deepstack_visual_embeds_image",
+    "deepstack_visual_embeds_video",
+)
 
 # SGLang reads this when DeepGEMM compile utilities are imported. Qwen AR
 # stages can first hit some dense FP8 shapes after readiness; disable all-M
@@ -58,6 +68,13 @@ def _image_encoder_stage(*, gpu: int, process: str) -> StageConfig:
         next="mm_aggregate",
         project_payload={
             "mm_aggregate": f"{_PKG}.request_builders.project_encoder_to_mm_aggregate"
+        },
+        tensor_ref_edges={
+            "mm_aggregate": TensorRefEdgeConfig(
+                consumer_stage="thinker",
+                threshold_mb=2.0,
+                paths=_VISUAL_TENSOR_REF_PATHS,
+            )
         },
     )
 

--- a/sglang_omni/models/qwen3_omni/request_builders.py
+++ b/sglang_omni/models/qwen3_omni/request_builders.py
@@ -49,7 +49,9 @@ def _resolve_seed(params: dict[str, Any]) -> int | None:
 
 
 def output_modalities(request: OmniRequest | None) -> set[str] | None:
-    metadata = getattr(request, "metadata", None)
+    if request is None:
+        return None
+    metadata = request.metadata
     if not isinstance(metadata, dict):
         return None
     modalities = metadata.get("output_modalities")

--- a/sglang_omni/models/qwen3_omni/talker_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/talker_scheduler.py
@@ -26,7 +26,7 @@ def configure_talker_server_args(
     re-enable graph capture after the model worker is constructed.
     """
 
-    want_cuda_graph = not bool(getattr(server_args, "disable_cuda_graph", False))
+    want_cuda_graph = not bool(server_args.disable_cuda_graph)
     if feedback_enabled:
         server_args.disable_overlap_schedule = True
         if want_cuda_graph:

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -234,7 +234,7 @@ def create_sglang_tts_engine_executor(
         generate_defaults=_load_qwen3_tts_generate_defaults(checkpoint_dir),
     )
     set_qwen3_tts_preprocessing_context(model=model, wrapper=wrapper)
-    if bool(getattr(server_args, "enable_torch_compile", False)):
+    if bool(server_args.enable_torch_compile):
         _compile_qwen3_tts_backbone(model)
         server_args.enable_torch_compile = False
     if want_cuda_graph:

--- a/sglang_omni/models/voxtral_tts/acoustic_transformer.py
+++ b/sglang_omni/models/voxtral_tts/acoustic_transformer.py
@@ -339,9 +339,7 @@ class FlowMatchingAudioTransformer(nn.Module):
         params_dict = dict(self.named_parameters())
         name, loaded_weight = weight
         if name not in params_dict:
-            logger.warning(
-                "%s not found in FlowMatchingAudioTransformer (UNUSED)", name
-            )
+            logger.warning(f"{name} not found in FlowMatchingAudioTransformer (UNUSED)")
             return name
         param = params_dict[name]
         weight_loader = getattr(param, "weight_loader", default_weight_loader)

--- a/sglang_omni/models/voxtral_tts/audio_tokenizer.py
+++ b/sglang_omni/models/voxtral_tts/audio_tokenizer.py
@@ -674,7 +674,7 @@ class VoxtralTTSAudioTokenizer(nn.Module):
                 self.quantizer.semantic_codebook.embedding_sum = loaded_weight
                 return name
             else:
-                logger.warning("Weight %s not found in audio tokenizer", name)
+                logger.warning(f"Weight {name} not found in audio tokenizer")
                 return name
         param = params_dict[name]
         param.data.copy_(loaded_weight)

--- a/sglang_omni/models/voxtral_tts/pipeline/stages.py
+++ b/sglang_omni/models/voxtral_tts/pipeline/stages.py
@@ -222,7 +222,7 @@ def create_generation_executor(
         **overrides,
     )
 
-    if getattr(server_args, "enable_torch_compile", False):
+    if server_args.enable_torch_compile:
         _enable_inductor_gemm_autotune()
 
     want_cuda_graph, (

--- a/sglang_omni/models/voxtral_tts/voxtral_tts_audio_generation.py
+++ b/sglang_omni/models/voxtral_tts/voxtral_tts_audio_generation.py
@@ -573,7 +573,7 @@ class VoxtralTTSAudioGeneration(nn.Module):
         config = VoxtralModelConfig.from_model_path(checkpoint_dir)
         audio_args = asdict(config.audio_model_args)
 
-        logger.info("Loading model from %s …", checkpoint_dir)
+        logger.info(f"Loading model from {checkpoint_dir} …")
         t0 = time.perf_counter()
         mem0 = torch.cuda.memory_allocated(device) if device.startswith("cuda") else 0
 

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -123,7 +123,8 @@ def _build_stage_groups(
             name_map=name_map,
             tensor_ref_policies=_build_tensor_ref_policies(stage_cfg, name_map),
             resolve_tensor_refs=(
-                name_map.get(stage_cfg.name, stage_cfg.name) in tensor_ref_consumer_stages
+                name_map.get(stage_cfg.name, stage_cfg.name)
+                in tensor_ref_consumer_stages
             ),
         )
         if tp_size == 1:

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -36,6 +36,7 @@ from sglang_omni.pipeline.stage_workers import (
     StageLaunchConfig,
     StageWorkerProcessSpec,
 )
+from sglang_omni.pipeline.tensor_ref import TensorRefPolicy
 from sglang_omni.utils.imports import import_string
 
 logger = logging.getLogger(__name__)
@@ -65,6 +66,11 @@ def _build_stage_groups(
         for target in scfg.stream_to:
             stream_receivers.add(target)
     stage_cfg_by_name = {stage.name: stage for stage in stages_cfg}
+    tensor_ref_consumer_stages = {
+        name_map.get(edge.consumer_stage, edge.consumer_stage)
+        for stage in stages_cfg
+        for edge in stage.tensor_ref_edges.values()
+    }
 
     nccl_port_counter = _NcclPortAllocator()
 
@@ -115,6 +121,10 @@ def _build_stage_groups(
             is_stream_receiver=stage_cfg.name in stream_receivers,
             can_accept_stream_before_payload=stage_cfg.can_accept_stream_before_payload,
             name_map=name_map,
+            tensor_ref_policies=_build_tensor_ref_policies(stage_cfg, name_map),
+            resolve_tensor_refs=(
+                name_map.get(stage_cfg.name, stage_cfg.name) in tensor_ref_consumer_stages
+            ),
         )
         if tp_size == 1:
             single_stage_specs[stage_cfg.name] = _build_single_stage_spec(
@@ -166,6 +176,24 @@ def _build_stage_groups(
     groups.extend(tp_groups)
 
     return groups
+
+
+def _build_tensor_ref_policies(
+    stage_cfg: StageConfig,
+    name_map: dict[str, str],
+) -> dict[str, TensorRefPolicy]:
+    policies: dict[str, TensorRefPolicy] = {}
+    from_stage = name_map.get(stage_cfg.name, stage_cfg.name)
+    for raw_target, edge in stage_cfg.tensor_ref_edges.items():
+        target = name_map.get(raw_target, raw_target)
+        policies[target] = TensorRefPolicy(
+            threshold_bytes=int(edge.threshold_mb * 1024 * 1024),
+            from_stage=from_stage,
+            to_stage=target,
+            consumer_stage=name_map.get(edge.consumer_stage, edge.consumer_stage),
+            path_allowlist=tuple(edge.paths),
+        )
+    return policies
 
 
 def _resolve_same_process_targets(

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -20,7 +20,7 @@ from typing import Any, Callable, Literal
 from sglang_omni.pipeline import relay_io
 from sglang_omni.pipeline.stage.input import DirectInput, InputHandler
 from sglang_omni.pipeline.stage.stream_queue import StreamItem, StreamQueue
-from sglang_omni.pipeline.tensor_ref import TensorRefPolicy, tensor_refs_enabled
+from sglang_omni.pipeline.tensor_ref import TensorRefPolicy
 from sglang_omni.pipeline.tp_control import TPLeaderFanout, TPWorkMessage
 from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.profiler.event_recorder import get_recorder as _get_recorder
@@ -87,6 +87,8 @@ class Stage:
         can_accept_stream_before_payload: bool = False,
         tp_fanout: TPLeaderFanout | None = None,
         is_terminal: bool = False,
+        tensor_ref_policies: dict[str, TensorRefPolicy] | None = None,
+        resolve_tensor_refs: bool = False,
     ):
         self.name = name
         self.role = role
@@ -106,6 +108,8 @@ class Stage:
         self._tp_fanout = tp_fanout
         self._is_terminal = is_terminal
         self._owns_external_io = role in {"single", "leader"}
+        self._tensor_ref_policies = tensor_ref_policies or {}
+        self._resolve_tensor_refs = resolve_tensor_refs
 
         # --- Relay ---
         if relay is not None:
@@ -301,10 +305,11 @@ class Stage:
         if self._stream_queue is not None and not self._stream_queue.has(request_id):
             self._stream_queue.open(request_id)
 
-        # Read payload from relay
         try:
             payload = await relay_io.read_payload(
-                self.relay, request_id, msg.shm_metadata
+                self.relay,
+                request_id,
+                msg.shm_metadata,
             )
         except Exception as exc:
             logger.exception(
@@ -314,7 +319,11 @@ class Stage:
             await self._send_failure(request_id, f"relay read failed: {exc}")
             return
 
-        await self._receive_payload_from_stage(request_id, msg.from_stage, payload)
+        await self._receive_payload_from_stage(
+            request_id,
+            msg.from_stage,
+            payload,
+        )
 
     async def receive_local_payload(
         self,
@@ -681,7 +690,7 @@ class Stage:
             # until blob reads are ref-counted/non-destructive.
             self._tp_fanout.fanout_work(payload)
         payload_for_scheduler = payload
-        if tensor_refs_enabled():
+        if self._resolve_tensor_refs:
             payload_for_scheduler = await relay_io.materialize_payload_tensor_refs(
                 self.relay, payload, current_stage=self.name
             )
@@ -1003,9 +1012,7 @@ class Stage:
             )
             return
 
-        tensor_ref_policy = TensorRefPolicy.from_env(
-            from_stage=self.name, to_stage=target
-        )
+        tensor_ref_policy = self._tensor_ref_policies.get(target)
         metadata, op = await relay_io.write_payload(
             self.relay,
             request_id,

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -20,6 +20,7 @@ from sglang_omni.pipeline.local_dispatch import LocalStageDispatcher
 from sglang_omni.pipeline.stage.input import AggregatedInput, DirectInput
 from sglang_omni.pipeline.stage.runtime import Stage
 from sglang_omni.pipeline.stage.stream_queue import StreamQueue
+from sglang_omni.pipeline.tensor_ref import TensorRefPolicy
 from sglang_omni.pipeline.tp_control import TPFollowerControlPlane, TPLeaderFanout
 from sglang_omni.utils.gpu_compat import (
     apply_gpu_compat_env_defaults,
@@ -70,6 +71,8 @@ class StageLaunchConfig:
 
     # Relay
     relay_config: dict[str, Any] = field(default_factory=dict)
+    tensor_ref_policies: dict[str, TensorRefPolicy] = field(default_factory=dict)
+    resolve_tensor_refs: bool = False
 
     # Endpoints
     recv_endpoint: str = ""
@@ -616,6 +619,8 @@ def _construct_stage(
         can_accept_stream_before_payload=spec.can_accept_stream_before_payload,
         tp_fanout=tp_fanout,
         is_terminal=spec.is_terminal,
+        tensor_ref_policies=spec.tensor_ref_policies,
+        resolve_tensor_refs=spec.resolve_tensor_refs,
     )
 
     if spec.is_stream_receiver:

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -428,7 +428,7 @@ def _run_process(
             if tasks:
                 await asyncio.gather(*tasks, return_exceptions=True)
             for stage in stages:
-                if getattr(stage, "_running", False):
+                if stage._running:
                     await stage.stop()
 
     asyncio.run(_start_and_run())

--- a/sglang_omni/pipeline/tensor_ref.py
+++ b/sglang_omni/pipeline/tensor_ref.py
@@ -8,9 +8,7 @@ the declared ``consumer_stage`` resolves it back into a real tensor.
 """
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
-from functools import lru_cache
 from typing import Any
 
 import torch
@@ -71,10 +69,6 @@ class TensorRef:
         )
 
 
-def tensor_refs_enabled() -> bool:
-    return os.environ.get("SGLANG_OMNI_ENABLE_TENSOR_REFS") == "1"
-
-
 def is_tensor_ref_dict(obj: Any) -> bool:
     return isinstance(obj, dict) and obj.get(TENSOR_REF_MARKER) is True
 
@@ -110,46 +104,3 @@ class TensorRefPolicy:
             return False
         nbytes = tensor.numel() * tensor.element_size()
         return nbytes >= self.threshold_bytes
-
-    @classmethod
-    def from_env(cls, *, from_stage: str, to_stage: str) -> "TensorRefPolicy | None":
-        if os.environ.get("SGLANG_OMNI_ENABLE_TENSOR_REFS") != "1":
-            return None
-        edges = _parse_edges(os.environ.get("SGLANG_OMNI_TENSOR_REF_EDGES", ""))
-        consumer_stage = edges.get((from_stage, to_stage))
-        if consumer_stage is None:
-            return None
-        threshold_mb = float(
-            os.environ.get(
-                "SGLANG_OMNI_TENSOR_REF_THRESHOLD_MB",
-                str(DEFAULT_TENSOR_REF_THRESHOLD_MB),
-            )
-        )
-        raw_paths = os.environ.get("SGLANG_OMNI_TENSOR_REF_PATHS")
-        path_allowlist = (
-            tuple(p.strip() for p in raw_paths.split(",") if p.strip())
-            if raw_paths is not None
-            else DEFAULT_TENSOR_REF_PATHS
-        )
-        return cls(
-            threshold_bytes=int(threshold_mb * 1024 * 1024),
-            from_stage=from_stage,
-            to_stage=to_stage,
-            consumer_stage=consumer_stage,
-            path_allowlist=path_allowlist,
-        )
-
-
-@lru_cache(maxsize=1)
-def _parse_edges(raw: str) -> dict[tuple[str, str], str]:
-    edges: dict[tuple[str, str], str] = {}
-    for entry in raw.split(","):
-        entry = entry.strip()
-        if not entry:
-            continue
-        parts = entry.split(":")
-        if len(parts) != 3:
-            continue
-        from_stage, to_stage, consumer_stage = (p.strip() for p in parts)
-        edges[(from_stage, to_stage)] = consumer_stage
-    return edges

--- a/sglang_omni/scheduling/bootstrap.py
+++ b/sglang_omni/scheduling/bootstrap.py
@@ -54,7 +54,7 @@ def create_sglang_infrastructure(
         server_args.page_size,
     )
 
-    enable_overlap = not getattr(server_args, "disable_overlap_schedule", False)
+    enable_overlap = not server_args.disable_overlap_schedule
 
     prefill_mgr = PrefillManager(
         page_size=server_args.page_size,
@@ -112,7 +112,7 @@ def create_sglang_infrastructure_defer_cuda_graph(
     The caller finishes stage-specific decode setup, then runs
     init_device_graphs() only when this returns that CUDA graphs were requested.
     """
-    want_cuda_graph = not bool(getattr(server_args, "disable_cuda_graph", False))
+    want_cuda_graph = not bool(server_args.disable_cuda_graph)
     if want_cuda_graph:
         server_args.disable_cuda_graph = True
     try:

--- a/sglang_omni/scheduling/generation_batch_policy.py
+++ b/sglang_omni/scheduling/generation_batch_policy.py
@@ -76,23 +76,23 @@ def validate_generation_batch_policy(
 ) -> None:
     errors: list[str] = []
 
-    max_running_requests = _read_positive_int(
-        server_args,
+    max_running_requests = _validate_positive_int(
         "max_running_requests",
+        server_args.max_running_requests,
         errors,
     )
-    cuda_graph_enabled = not bool(getattr(server_args, "disable_cuda_graph", False))
+    cuda_graph_enabled = not bool(server_args.disable_cuda_graph)
 
     cuda_graph_max_bs: int | None = None
     cuda_graph_bs: tuple[int, ...] | None = None
     if cuda_graph_enabled:
-        cuda_graph_max_bs = _read_positive_int(
-            server_args,
+        cuda_graph_max_bs = _validate_positive_int(
             "cuda_graph_max_bs",
+            server_args.cuda_graph_max_bs,
             errors,
             required=True,
         )
-        cuda_graph_bs_value = getattr(server_args, "cuda_graph_bs", None)
+        cuda_graph_bs_value = server_args.cuda_graph_bs
         if cuda_graph_bs_value is None:
             errors.append("cuda_graph_bs must be explicit when CUDA graph is enabled")
         else:
@@ -115,10 +115,10 @@ def validate_generation_batch_policy(
                 f"({cuda_graph_max_bs} < {max_running_requests})"
             )
 
-    torch_compile_enabled = bool(getattr(server_args, "enable_torch_compile", False))
-    torch_compile_max_bs = _read_positive_int(
-        server_args,
+    torch_compile_enabled = bool(server_args.enable_torch_compile)
+    torch_compile_max_bs = _validate_positive_int(
         "torch_compile_max_bs",
+        server_args.torch_compile_max_bs,
         errors,
         required=torch_compile_enabled,
     )
@@ -153,14 +153,13 @@ def validate_generation_batch_policy(
         )
 
 
-def _read_positive_int(
-    obj: Any,
+def _validate_positive_int(
     field: str,
+    value: Any,
     errors: list[str],
     *,
     required: bool = True,
 ) -> int | None:
-    value = getattr(obj, field, None)
     if value is None:
         if required:
             errors.append(f"{field} must be explicit")

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -378,11 +378,11 @@ class OmniScheduler:
         self._prefill_start_done: set[str] = set()
 
     def _init_upstream_compat_flags(self, server_args: Any) -> None:
-        self.enable_hisparse = bool(getattr(server_args, "enable_hisparse", False))
+        self.enable_hisparse = bool(server_args.enable_hisparse)
         self.hisparse_coordinator = None
         self.enable_priority_preemption = bool(
-            getattr(server_args, "enable_priority_scheduling", False)
-            and not getattr(server_args, "disable_priority_preemption", False)
+            server_args.enable_priority_scheduling
+            and not server_args.disable_priority_preemption
         )
         # High-water mark, not a cap. Mirrors upstream Scheduler.__init__ (sglang/srt/managers/scheduler.py).
         self.max_prefill_bs = 0
@@ -934,13 +934,13 @@ class OmniScheduler:
             self._emit_request_error(req.rid, error)
             self.abort(req.rid, defer_running_cleanup=False)
 
-    def _emit_prefill_start_for_batch(self, batch: Any) -> None:
+    def _emit_prefill_start_for_batch(self, batch: ScheduleBatch) -> None:
         """Emit once when a request's first executable batch is selected."""
-        metadata = {}
-        for attr in ("is_prefill_only", "is_extend_in_batch"):
-            if hasattr(batch, attr):
-                metadata[attr] = bool(getattr(batch, attr))
-        for req in getattr(batch, "reqs", []) or []:
+        metadata = {
+            "is_prefill_only": bool(batch.is_prefill_only),
+            "is_extend_in_batch": bool(batch.is_extend_in_batch),
+        }
+        for req in batch.reqs:
             rid = req.rid
             if rid in self._prefill_start_done:
                 continue
@@ -970,7 +970,7 @@ class OmniScheduler:
             # Build result payload from the Req
             data = req._omni_data
             data.output_ids = list(req.output_ids)
-            data.weight_version = getattr(self.server_args, "weight_version", None)
+            data.weight_version = self.server_args.weight_version
             finished_reason = req.finished_reason
             data.finish_reason = (
                 finished_reason.to_json().get("type")
@@ -1199,9 +1199,9 @@ class OmniScheduler:
                 "running_batch_size": len(
                     getattr(self.running_batch, "reqs", []) or []
                 ),
-                "model_path": getattr(self.server_args, "model_path", None),
-                "load_format": getattr(self.server_args, "load_format", None),
-                "weight_version": getattr(self.server_args, "weight_version", None),
+                "model_path": self.server_args.model_path,
+                "load_format": self.server_args.load_format,
+                "weight_version": self.server_args.weight_version,
             }
         )
         return {"success": True, "message": "ok", "data": info}
@@ -1475,10 +1475,9 @@ class OmniScheduler:
         ):
             if batch is None:
                 continue
-            for req in getattr(batch, "reqs", []) or []:
-                rid = getattr(req, "rid", None)
-                if rid is not None and not req.finished():
-                    request_ids.add(rid)
+            for req in batch.reqs:
+                if req.rid is not None and not req.finished():
+                    request_ids.add(req.rid)
         return sorted(request_ids)
 
     def _can_update_active_requests(
@@ -1650,15 +1649,13 @@ class OmniScheduler:
                 self.self_check_during_busy()
 
     @staticmethod
-    def _batch_is_decode(batch) -> bool:
-        mode = getattr(batch, "forward_mode", None)
+    def _batch_is_decode(batch: ScheduleBatch) -> bool:
+        mode = batch.forward_mode
         if mode is None:
             return False
-        is_decode = getattr(mode, "is_decode", None)
-        if callable(is_decode):
-            return bool(is_decode())
-        is_extend = getattr(mode, "is_extend", None)
-        return (not bool(is_extend())) if callable(is_extend) else False
+        if mode.is_decode():
+            return True
+        return not bool(mode.is_extend())
 
     def _async_pending_batch(self):
         """The in-flight (launched, not yet resolved) decode batch, or None.
@@ -1837,7 +1834,7 @@ class OmniScheduler:
         for batch in (self.running_batch, self.cur_batch, self.last_batch):
             if batch is None:
                 continue
-            for req in getattr(batch, "reqs", ()):
+            for req in batch.reqs:
                 if req.rid == request_id:
                     return req._omni_data
         for req in self.waiting_queue:

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -65,11 +65,11 @@ def _find_available_port(host: str, port: int) -> int:
             return port
     except OSError:
         pass
-    logger.warning("Port %d is already in use on %s.", port, host)
+    logger.warning(f"Port {port} is already in use on {host}.")
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind((host, 0))
         free_port = s.getsockname()[1]
-    logger.warning("Using port %d instead.", free_port)
+    logger.warning(f"Using port {free_port} instead.")
     return free_port
 
 
@@ -323,8 +323,7 @@ async def _run_server(
         pipeline_config,
     )
     logger.info(
-        "Resolved placement/topology plan: placement=%s",
-        placement_summary,
+        f"Resolved placement/topology plan: placement={placement_summary}",
     )
     logger.info(
         "Pipeline '%s' started (%d GPU(s))",

--- a/sglang_omni/serve/realtime/manager.py
+++ b/sglang_omni/serve/realtime/manager.py
@@ -23,14 +23,14 @@ class RealtimeSessionManager:
             model_name=self.model_name,
         )
         self.sessions[session.session_id] = session
-        logger.info("Realtime session opened: %s", session.session_id)
+        logger.info(f"Realtime session opened: {session.session_id}")
         return session
 
     async def close(self, session_id: str) -> None:
         session = self.sessions[session_id]
         await session.teardown()
         del self.sessions[session_id]
-        logger.info("Realtime session closed: %s", session_id)
+        logger.info(f"Realtime session closed: {session_id}")
 
     def active_sessions(self) -> list[str]:
         return list(self.sessions.keys())

--- a/sglang_omni/serve/speech_service.py
+++ b/sglang_omni/serve/speech_service.py
@@ -219,8 +219,9 @@ class SpeechRequestValidator:
         if request.language is not None:
             updates["language"] = _normalize_language(request.language)
 
-        for field_name in ("max_new_tokens", "token_count", "duration_tokens"):
-            _validate_positive_int(getattr(request, field_name), param=field_name)
+        _validate_positive_int(request.max_new_tokens, param="max_new_tokens")
+        _validate_positive_int(request.token_count, param="token_count")
+        _validate_positive_int(request.duration_tokens, param="duration_tokens")
         _validate_non_negative_int(
             request.initial_codec_chunk_frames,
             param=INITIAL_CODEC_CHUNK_FRAMES_PARAM,
@@ -502,8 +503,9 @@ class SpeechRequestValidator:
         )
         if batch.language is not None:
             _normalize_language(batch.language)
-        for field_name in ("max_new_tokens", "token_count", "duration_tokens"):
-            _validate_positive_int(getattr(batch, field_name), param=field_name)
+        _validate_positive_int(batch.max_new_tokens, param="max_new_tokens")
+        _validate_positive_int(batch.token_count, param="token_count")
+        _validate_positive_int(batch.duration_tokens, param="duration_tokens")
         _validate_non_negative_int(
             batch.initial_codec_chunk_frames,
             param=INITIAL_CODEC_CHUNK_FRAMES_PARAM,
@@ -625,16 +627,24 @@ class SpeechRequestValidator:
             )
             return reference.model_copy(update=updates)
 
-        for field_name in _REFERENCE_AUDIO_FIELDS:
-            value = getattr(reference, field_name)
-            if not isinstance(value, str):
-                continue
+        if isinstance(reference.audio_path, str):
             updates.update(
                 self._load_media_reference_descriptor(
-                    value, param=f"references.{field_name}"
+                    reference.audio_path, param="references.audio_path"
                 )
             )
-            break
+        elif isinstance(reference.ref_audio, str):
+            updates.update(
+                self._load_media_reference_descriptor(
+                    reference.ref_audio, param="references.ref_audio"
+                )
+            )
+        elif isinstance(reference.audio, str):
+            updates.update(
+                self._load_media_reference_descriptor(
+                    reference.audio, param="references.audio"
+                )
+            )
         return reference.model_copy(update=updates)
 
     def _load_media_reference_descriptor(

--- a/sglang_omni/serve/speech_voices.py
+++ b/sglang_omni/serve/speech_voices.py
@@ -293,7 +293,7 @@ class SpeakerSampleStore:
         try:
             safe_open = _safetensors_safe_open()
         except SpeechAPIError as exc:
-            logger.warning("%s; uploaded voices will not be restored", exc.message)
+            logger.warning(f"{exc.message}; uploaded voices will not be restored")
             return
         candidates: list[UploadedVoice] = []
         for path in sorted(self.root_dir.glob("*.safetensors")):
@@ -301,28 +301,24 @@ class SpeakerSampleStore:
                 with safe_open(str(path), framework="np") as handle:
                     metadata = dict(handle.metadata() or {})
             except Exception as exc:
-                logger.warning("Skipping unreadable voice file %s: %s", path, exc)
+                logger.warning(f"Skipping unreadable voice file {path}: {exc}")
                 continue
             try:
                 voice = _voice_from_metadata(metadata, path)
             except SpeechAPIError as exc:
-                logger.warning("Skipping invalid voice metadata %s: %s", path, exc)
+                logger.warning(f"Skipping invalid voice metadata {path}: {exc}")
                 continue
             candidates.append(voice)
         candidates.sort(key=lambda voice: voice.created_at, reverse=True)
         for voice in candidates:
             if voice.normalized_name in restored:
                 logger.warning(
-                    "Skipping duplicate restored voice %s for name %s",
-                    voice.file_path,
-                    voice.normalized_name,
+                    f"Skipping duplicate restored voice {voice.file_path} for name {voice.normalized_name}",
                 )
                 continue
             if len(restored) >= self.max_uploaded:
                 logger.warning(
-                    "Skipping restored voice %s because SPEAKER_MAX_UPLOADED=%d",
-                    voice.file_path,
-                    self.max_uploaded,
+                    f"Skipping restored voice {voice.file_path} because SPEAKER_MAX_UPLOADED={self.max_uploaded}",
                 )
                 continue
             restored[voice.normalized_name] = voice
@@ -382,7 +378,7 @@ def _speaker_max_uploaded_from_env() -> int:
     try:
         return int(value)
     except ValueError:
-        logger.warning("Invalid SPEAKER_MAX_UPLOADED=%r; using default", value)
+        logger.warning(f"Invalid SPEAKER_MAX_UPLOADED={value!r}; using default")
         return DEFAULT_SPEAKER_MAX_UPLOADED
 
 

--- a/sglang_omni/utils/cuda_graph_batch_validator.py
+++ b/sglang_omni/utils/cuda_graph_batch_validator.py
@@ -284,7 +284,7 @@ def validate_stage(
         model = None
     model_cls = type(model).__name__ if model is not None else "unknown-model"
 
-    if bool(getattr(server_args, "disable_cuda_graph", False)):
+    if bool(server_args.disable_cuda_graph):
         return CudaGraphBatchReport(
             stage=f"{stage_name} ({model_cls})",
             max_running_requests=max_running_requests,

--- a/sglang_omni/utils/cuda_graph_batch_validator.py
+++ b/sglang_omni/utils/cuda_graph_batch_validator.py
@@ -210,9 +210,7 @@ def read_captured_bs(model_runner: object) -> list[int] | None:
         sizes = sorted(int(b) for b in captured)
     except (TypeError, ValueError):
         logger.warning(
-            "cuda_graph_batch_validator: capture_bs is not an iterable of "
-            "ints (%r).",
-            captured,
+            f"cuda_graph_batch_validator: capture_bs is not an iterable of ints ({captured!r}).",
         )
         return None
     return sizes or None

--- a/sglang_omni/utils/gpu_compat.py
+++ b/sglang_omni/utils/gpu_compat.py
@@ -144,7 +144,7 @@ def apply_gpu_compat_env_defaults(
     overrides = get_gpu_compat_env_defaults(target_env)
     for key, value in overrides.items():
         target_env[key] = value
-        logger.info("Applied GPU compatibility env override: %s=%s", key, value)
+        logger.info(f"Applied GPU compatibility env override: {key}={value}")
     return overrides
 
 
@@ -200,10 +200,7 @@ def gpu_ids_support_p2p_mesh(
         return True
     except Exception as exc:
         logger.warning(
-            "NVML P2P mesh query failed for gpus=%s: %s; "
-            "keeping custom all-reduce disabled",
-            ids,
-            exc,
+            f"NVML P2P mesh query failed for gpus={ids}: {exc}; keeping custom all-reduce disabled",
         )
         return None
     finally:

--- a/tests/test_model/test_qwen3_asr_ci.py
+++ b/tests/test_model/test_qwen3_asr_ci.py
@@ -19,12 +19,12 @@ import pytest
 
 from benchmarks.dataset.prepare import DATASETS
 from benchmarks.dataset.seedtts import SampleInput, load_seedtts_samples
-from benchmarks.eval.benchmark_qwen3_asr_concurrency import (
+from benchmarks.metrics.wer import print_asr_speed_summary, print_asr_wer_summary
+from benchmarks.tasks.asr import (
+    QWEN3_ASR_MODEL_PATH,
     build_asr_eval_results,
     run_asr_transcription,
 )
-from benchmarks.metrics.wer import print_asr_speed_summary, print_asr_wer_summary
-from benchmarks.tasks.tts import QWEN3_ASR_MODEL_PATH
 from tests.test_model.omni_router_utils import (
     ManagedRouterHandle,
     launch_managed_router,

--- a/tests/test_model/test_qwen3_omni_mmmu_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmmu_talker_ci.py
@@ -31,7 +31,7 @@ from benchmarks.eval.benchmark_omni_mmmu import MMMUEvalConfig, run_mmmu_eval
 from benchmarks.metrics.mmmu import print_mmmu_accuracy_summary
 from benchmarks.metrics.performance import print_speed_summary
 from benchmarks.metrics.wer import print_wer_summary
-from benchmarks.tasks.tts import compute_text_audio_consistency_from_records
+from benchmarks.tasks.asr import compute_text_audio_consistency_from_records
 from tests.test_model.omni_router_utils import (
     ManagedRouterHandle,
     router_worker_traffic_guard,

--- a/tests/test_model/test_qwen3_omni_mmsu_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_talker_ci.py
@@ -31,7 +31,7 @@ from benchmarks.dataset.prepare import DATASETS
 from benchmarks.eval.benchmark_omni_mmsu import run as run_mmsu
 from benchmarks.metrics.mmsu import print_mmsu_summary
 from benchmarks.metrics.wer import print_wer_summary
-from benchmarks.tasks.tts import compute_text_audio_consistency_from_records
+from benchmarks.tasks.asr import compute_text_audio_consistency_from_records
 from tests.test_model.omni_router_utils import (
     ManagedRouterHandle,
     router_worker_traffic_guard,

--- a/tests/test_model/test_qwen3_omni_videoamme_talker_tp2_ci.py
+++ b/tests/test_model/test_qwen3_omni_videoamme_talker_tp2_ci.py
@@ -27,7 +27,7 @@ from benchmarks.eval.benchmark_omni_videomme import VideoEvalConfig
 from benchmarks.metrics.performance import print_speed_summary
 from benchmarks.metrics.video import print_videomme_accuracy_summary
 from benchmarks.metrics.wer import print_wer_summary
-from benchmarks.tasks.tts import compute_text_audio_consistency_from_records
+from benchmarks.tasks.asr import compute_text_audio_consistency_from_records
 from tests.test_model.omni_router_utils import ManagedRouterHandle
 from tests.utils import (
     QWEN3_ASR_WER_CONCURRENCY,

--- a/tests/test_model/test_qwen3_omni_videomme_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_videomme_talker_ci.py
@@ -35,7 +35,7 @@ from benchmarks.eval.benchmark_omni_videomme import VideoEvalConfig, run_video_e
 from benchmarks.metrics.performance import print_speed_summary
 from benchmarks.metrics.video import print_videomme_accuracy_summary
 from benchmarks.metrics.wer import print_wer_summary
-from benchmarks.tasks.tts import compute_text_audio_consistency_from_records
+from benchmarks.tasks.asr import compute_text_audio_consistency_from_records
 from tests.test_model.omni_router_utils import (
     ManagedRouterHandle,
     router_worker_traffic_guard,

--- a/tests/unit_test/ming_omni/test_pipeline.py
+++ b/tests/unit_test/ming_omni/test_pipeline.py
@@ -117,6 +117,8 @@ def test_ming_speech_launcher_places_thinker_tp_and_talker(monkeypatch) -> None:
         gpu_talker=4,
         voice="DB30",
         mem_fraction_static=0.8,
+        cpu_offload_gb=None,
+        enable_streaming_tts=False,
         host="127.0.0.1",
         port=8000,
         model_name="ming-omni",

--- a/tests/unit_test/ming_omni/test_pipeline.py
+++ b/tests/unit_test/ming_omni/test_pipeline.py
@@ -867,6 +867,45 @@ def test_ming_audio_executor_flattens_embed_batch_dim(monkeypatch) -> None:
     assert tuple(audio_embeds.shape) == (4, 8)
 
 
+def test_ming_image_executor_flattens_embed_batch_dims(monkeypatch) -> None:
+    """Image/video embeds leave the producer flat, ready for TensorRef edges."""
+    import torch
+
+    from sglang_omni.models.ming_omni.io import MingOmniPipelineState
+    from sglang_omni.models.ming_omni.pipeline.next_stage import IMAGE_STAGE
+    from sglang_omni.models.ming_omni.stages import create_image_encoder_executor
+    from sglang_omni.proto import StagePayload
+
+    class FakeEncoder:
+        def __init__(self, **kwargs):
+            pass
+
+        def __call__(self, **kwargs):
+            return {
+                "image_embeds": torch.randn(1, 4, 8),
+                "video_embeds": torch.randn(1, 12, 8),
+            }
+
+    fake_mod = ModuleType("sglang_omni.models.ming_omni.components.image_encoder")
+    fake_mod.MingImageEncoder = FakeEncoder
+    monkeypatch.setitem(
+        sys.modules, "sglang_omni.models.ming_omni.components.image_encoder", fake_mod
+    )
+    scheduler = create_image_encoder_executor("dummy")
+
+    state = MingOmniPipelineState(
+        encoder_inputs={IMAGE_STAGE: {"pixel_values_videos": torch.randn(2, 4)}},
+    )
+    payload = StagePayload(request_id="req-1", request=None, data=state.to_dict())
+
+    out = scheduler._fn(payload)
+    out_state = MingOmniPipelineState.from_dict(out.data)
+
+    outs = out_state.encoder_outs[IMAGE_STAGE]
+    assert tuple(outs["image_embeds"].shape) == (4, 8)
+    assert tuple(outs["video_embeds"].shape) == (12, 8)
+
+
 def test_compute_video_cache_key_changes_with_decode_params() -> None:
     """Different fps/max_frames/pixel limits must produce distinct cache keys.
 

--- a/tests/unit_test/ming_omni/test_pipeline.py
+++ b/tests/unit_test/ming_omni/test_pipeline.py
@@ -806,6 +806,67 @@ def test_ming_merge_extracts_video_embeds_into_thinker_inputs() -> None:
     assert result["media_cache_keys"]["video"] == "video:img:abc|vid:def"
 
 
+def test_ming_merge_preserves_unresolved_video_tensor_ref() -> None:
+    """A lazily-externalized video_embeds ref must survive merge unresolved."""
+    from sglang_omni.models.ming_omni.io import MingOmniPipelineState
+    from sglang_omni.models.ming_omni.pipeline.merge import build_thinker_inputs
+    from sglang_omni.models.ming_omni.pipeline.next_stage import IMAGE_STAGE
+    from sglang_omni.pipeline.tensor_ref import TensorRef, is_tensor_ref_dict
+
+    ref = TensorRef(
+        ref_id="req-ming:tensor_ref:image_encoder:mm_aggregate:abc:video_embeds",
+        request_id="req-ming",
+        producer_stage="image_encoder",
+        consumer_stage="thinker",
+        path="encoder_outs.image_encoder.video_embeds",
+        shape=(12, 8),
+        dtype="torch.bfloat16",
+        nbytes=12 * 8 * 2,
+        blob_key="req-ming:tensor_ref:image_encoder:mm_aggregate:abc:video_embeds",
+        blob_metadata={"relay_info": {}, "tensor_shape": [12, 8]},
+    )
+    state = MingOmniPipelineState()
+    encoder_outs = {IMAGE_STAGE: {"video_embeds": ref.to_dict()}}
+
+    result = build_thinker_inputs(state, encoder_outs)
+
+    video_embeds = result["model_inputs"]["video_embeds"]
+    assert is_tensor_ref_dict(video_embeds)
+    assert video_embeds == ref.to_dict()
+
+
+def test_ming_audio_executor_flattens_embed_batch_dim(monkeypatch) -> None:
+    """Producer emits flat [T', H] embeds so mm_aggregate stays a pure relay."""
+    import torch
+
+    from sglang_omni.models.ming_omni.components import audio_encoder as audio_mod
+    from sglang_omni.models.ming_omni.io import MingOmniPipelineState
+    from sglang_omni.models.ming_omni.pipeline.next_stage import AUDIO_STAGE
+    from sglang_omni.models.ming_omni.stages import create_audio_encoder_executor
+    from sglang_omni.proto import StagePayload
+
+    class FakeEncoder:
+        def __init__(self, **kwargs):
+            pass
+
+        def __call__(self, **kwargs):
+            return {"audio_embeds": torch.randn(1, 4, 8)}
+
+    monkeypatch.setattr(audio_mod, "MingAudioEncoder", FakeEncoder)
+    scheduler = create_audio_encoder_executor("dummy")
+
+    state = MingOmniPipelineState(
+        encoder_inputs={AUDIO_STAGE: {"audio_feats": torch.randn(1, 4, 16)}},
+    )
+    payload = StagePayload(request_id="req-1", request=None, data=state.to_dict())
+
+    out = scheduler._fn(payload)
+    out_state = MingOmniPipelineState.from_dict(out.data)
+
+    audio_embeds = out_state.encoder_outs[AUDIO_STAGE]["audio_embeds"]
+    assert tuple(audio_embeds.shape) == (4, 8)
+
+
 def test_compute_video_cache_key_changes_with_decode_params() -> None:
     """Different fps/max_frames/pixel limits must produce distinct cache keys.
 

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -155,6 +155,7 @@ def test_moss_tts_engine_uses_auto_mem_fraction_by_default(monkeypatch) -> None:
             max_running_requests=kwargs["max_running_requests"],
             cuda_graph_max_bs=kwargs["cuda_graph_max_bs"],
             cuda_graph_bs=kwargs["cuda_graph_bs"],
+            enable_torch_compile=kwargs["enable_torch_compile"],
             torch_compile_max_bs=kwargs.get("torch_compile_max_bs"),
         )
 

--- a/tests/unit_test/pipeline/test_async_decode.py
+++ b/tests/unit_test/pipeline/test_async_decode.py
@@ -344,7 +344,10 @@ def test_batch_is_decode():
     )
     assert OmniScheduler._batch_is_decode(decode) is True
     assert OmniScheduler._batch_is_decode(extend) is False
-    assert OmniScheduler._batch_is_decode(types.SimpleNamespace()) is False  # no mode
+    assert (
+        OmniScheduler._batch_is_decode(types.SimpleNamespace(forward_mode=None))
+        is False
+    )
 
 
 def test_async_pending_batch_getattr_safe():

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -224,6 +224,8 @@ def test_omni_scheduler_run_batch_failure_emits_error_and_aborts(monkeypatch) ->
             ),
         ],
         batch_is_full=True,
+        is_prefill_only=True,
+        is_extend_in_batch=False,
     )
     scheduler.running_batch = batch
     scheduler.cur_batch = batch
@@ -267,6 +269,8 @@ def test_omni_scheduler_custom_runner_updates_next_input_ids() -> None:
             SimpleNamespace(rid="req-2", _omni_data=SimpleNamespace()),
         ],
         output_ids=None,
+        is_prefill_only=False,
+        is_extend_in_batch=False,
     )
 
     result = scheduler._run_batch(batch)
@@ -301,6 +305,8 @@ def test_omni_scheduler_custom_runner_advances_forward_ct() -> None:
         return SimpleNamespace(
             reqs=[SimpleNamespace(rid="r", _omni_data=SimpleNamespace())],
             output_ids=None,
+            is_prefill_only=False,
+            is_extend_in_batch=False,
         )
 
     scheduler._run_batch(_batch())
@@ -530,7 +536,7 @@ def test_omni_scheduler_distinguishes_queue_enter_from_prefill_start(
     assert "scheduler_prefill_start" not in names
     assert scheduler.waiting_queue == [req]
 
-    batch = SimpleNamespace(reqs=[req], is_prefill_only=True)
+    batch = SimpleNamespace(reqs=[req], is_prefill_only=True, is_extend_in_batch=False)
     scheduler._emit_prefill_start_for_batch(batch)
     scheduler._emit_prefill_start_for_batch(batch)
 
@@ -573,7 +579,9 @@ def test_omni_scheduler_initializes_upstream_queue_limit(monkeypatch) -> None:
         enable_mixed_chunk=False,
         schedule_policy="fcfs",
         enable_hierarchical_cache=False,
+        enable_hisparse=False,
         enable_priority_scheduling=False,
+        disable_priority_preemption=False,
         schedule_low_priority_values_first=False,
         priority_scheduling_preemption_threshold=0,
         schedule_conservativeness=1.0,

--- a/tests/unit_test/pipeline/test_stage.py
+++ b/tests/unit_test/pipeline/test_stage.py
@@ -283,6 +283,7 @@ def test_relay_payload_and_cross_gpu_stream_contracts() -> None:
 
 def test_stage_execute_fanouts_unresolved_payload_before_materializing_refs() -> None:
     """TP followers get the unresolved ref; the local scheduler gets the resolved tensor."""
+
     async def _run() -> None:
         relay = FakeRelay()
         tensor = torch.arange(6, dtype=torch.float32)
@@ -334,6 +335,7 @@ def test_stage_execute_fanouts_unresolved_payload_before_materializing_refs() ->
 
 def test_send_to_stage_does_not_block_on_externalized_tensor_ref_blob() -> None:
     """The small envelope op completes without waiting on the deferred blob op."""
+
     async def _run() -> None:
         gate = asyncio.Event()
 

--- a/tests/unit_test/pipeline/test_stage.py
+++ b/tests/unit_test/pipeline/test_stage.py
@@ -281,12 +281,8 @@ def test_relay_payload_and_cross_gpu_stream_contracts() -> None:
     asyncio.run(_run())
 
 
-def test_stage_execute_fanouts_unresolved_payload_before_materializing_refs(
-    monkeypatch,
-) -> None:
+def test_stage_execute_fanouts_unresolved_payload_before_materializing_refs() -> None:
     """TP followers get the unresolved ref; the local scheduler gets the resolved tensor."""
-    monkeypatch.setenv("SGLANG_OMNI_ENABLE_TENSOR_REFS", "1")
-
     async def _run() -> None:
         relay = FakeRelay()
         tensor = torch.arange(6, dtype=torch.float32)
@@ -322,6 +318,7 @@ def test_stage_execute_fanouts_unresolved_payload_before_materializing_refs(
             scheduler=scheduler,
             relay=relay,
             tp_fanout=tp_fanout,
+            resolve_tensor_refs=True,
         )
 
         await stage_obj._execute(payload)
@@ -335,17 +332,8 @@ def test_stage_execute_fanouts_unresolved_payload_before_materializing_refs(
     asyncio.run(_run())
 
 
-def test_send_to_stage_does_not_block_on_externalized_tensor_ref_blob(
-    monkeypatch,
-) -> None:
+def test_send_to_stage_does_not_block_on_externalized_tensor_ref_blob() -> None:
     """The small envelope op completes without waiting on the deferred blob op."""
-    monkeypatch.setenv("SGLANG_OMNI_ENABLE_TENSOR_REFS", "1")
-    monkeypatch.setenv(
-        "SGLANG_OMNI_TENSOR_REF_EDGES", "image_encoder:mm_aggregate:thinker"
-    )
-    monkeypatch.setenv("SGLANG_OMNI_TENSOR_REF_PATHS", "big")
-    monkeypatch.setenv("SGLANG_OMNI_TENSOR_REF_THRESHOLD_MB", "0")
-
     async def _run() -> None:
         gate = asyncio.Event()
 
@@ -365,10 +353,18 @@ def test_send_to_stage_does_not_block_on_externalized_tensor_ref_blob(
                 return op
 
         relay = GatedRelay()
+        policy = TensorRefPolicy(
+            threshold_bytes=0,
+            from_stage="image_encoder",
+            to_stage="mm_aggregate",
+            consumer_stage="thinker",
+            path_allowlist=("big",),
+        )
         stage_obj = make_stage(
             name="image_encoder",
             endpoints={"mm_aggregate": "inproc://mm"},
             relay=relay,
+            tensor_ref_policies={"mm_aggregate": policy},
         )
         payload = make_stage_payload(request_id="req-1", data={"big": torch.randn(4)})
 
@@ -465,8 +461,6 @@ def test_stage_abort_releases_tracked_unresolved_tensor_ref_payload() -> None:
 
 
 def test_stage_abort_preserves_tracked_refs_across_ref_free_fanin(monkeypatch) -> None:
-    monkeypatch.setenv("SGLANG_OMNI_ENABLE_TENSOR_REFS", "1")
-
     async def _run() -> None:
         relay = FakeRelay()
         tensor = torch.arange(8, dtype=torch.float32)
@@ -496,6 +490,7 @@ def test_stage_abort_preserves_tracked_refs_across_ref_free_fanin(monkeypatch) -
             name="mm_aggregate",
             relay=relay,
             input_handler=AggregatedInput({"image_encoder", "preprocessing"}, _merge),
+            resolve_tensor_refs=True,
         )
         started_materialize = asyncio.Event()
         release_materialize = asyncio.Event()

--- a/tests/unit_test/pipeline/test_tensor_ref.py
+++ b/tests/unit_test/pipeline/test_tensor_ref.py
@@ -7,7 +7,9 @@ import asyncio
 import pytest
 import torch
 
+from sglang_omni.config import StageConfig, TensorRefEdgeConfig
 from sglang_omni.pipeline import relay_io
+from sglang_omni.pipeline.mp_runner import _build_tensor_ref_policies
 from sglang_omni.pipeline.tensor_ref import (
     DEFAULT_TENSOR_REF_PATHS,
     DEFAULT_TENSOR_REF_THRESHOLD_MB,
@@ -15,11 +17,11 @@ from sglang_omni.pipeline.tensor_ref import (
     TensorRefPolicy,
     is_tensor_ref_dict,
     tensor_ref_numel,
-    tensor_refs_enabled,
 )
 from tests.unit_test.fixtures.pipeline_fakes import (
     DestructiveFakeRelay,
     FakeRelay,
+    fake_factory_path,
     make_stage_payload,
 )
 
@@ -75,28 +77,26 @@ def test_policy_should_externalize_respects_allowlist_and_threshold() -> None:
     assert not policy.should_externalize("encoder_outs.image_encoder.image_embeds", big)
 
 
-def test_policy_from_env_disabled_by_default(monkeypatch) -> None:
-    monkeypatch.delenv("SGLANG_OMNI_ENABLE_TENSOR_REFS", raising=False)
-    assert not tensor_refs_enabled()
-    assert (
-        TensorRefPolicy.from_env(from_stage="image_encoder", to_stage="mm_aggregate")
-        is None
+def test_explicit_stage_config_builds_tensor_ref_policy() -> None:
+    stage_cfg = StageConfig(
+        name="image_encoder",
+        process="pipeline",
+        factory=fake_factory_path("make_scheduler"),
+        next="mm_aggregate",
+        tensor_ref_edges={
+            "mm_aggregate": TensorRefEdgeConfig(
+                consumer_stage="thinker",
+                threshold_mb=DEFAULT_TENSOR_REF_THRESHOLD_MB,
+                paths=DEFAULT_TENSOR_REF_PATHS,
+            )
+        },
     )
 
+    policies = _build_tensor_ref_policies(stage_cfg, {})
+    policy = policies["mm_aggregate"]
 
-def test_policy_from_env_requires_declared_edge(monkeypatch) -> None:
-    monkeypatch.setenv("SGLANG_OMNI_ENABLE_TENSOR_REFS", "1")
-    monkeypatch.setenv(
-        "SGLANG_OMNI_TENSOR_REF_EDGES", "image_encoder:mm_aggregate:thinker"
-    )
-    assert tensor_refs_enabled()
-    assert (
-        TensorRefPolicy.from_env(from_stage="mm_aggregate", to_stage="thinker") is None
-    )
-    policy = TensorRefPolicy.from_env(
-        from_stage="image_encoder", to_stage="mm_aggregate"
-    )
-    assert policy is not None
+    assert policy.from_stage == "image_encoder"
+    assert policy.to_stage == "mm_aggregate"
     assert policy.consumer_stage == "thinker"
     assert DEFAULT_TENSOR_REF_THRESHOLD_MB == 2.0
     assert policy.threshold_bytes == 2 * 1024 * 1024

--- a/tests/unit_test/qwen3_omni/test_pipeline.py
+++ b/tests/unit_test/qwen3_omni/test_pipeline.py
@@ -92,6 +92,7 @@ def test_qwen_pipeline_config_and_state_contracts() -> None:
     speech_talker = _stage(speech_config, "talker_ar")
     text_thinker = _stage(text_config, "thinker")
     preprocessing = _stage(speech_config, "preprocessing")
+    image_encoder = _stage(speech_config, "image_encoder")
     aggregate = _stage(speech_config, "mm_aggregate")
     # Speech-mode thinker streams hidden states to talker_ar AND text-token
     # ids to decode (for the streaming detokenizer); text-mode thinker
@@ -108,6 +109,14 @@ def test_qwen_pipeline_config_and_state_contracts() -> None:
     )
     assert aggregate.route_fn == (
         f"{request_builders_path}.resolve_mm_aggregate_next_stages"
+    )
+    tensor_ref = image_encoder.tensor_ref_edges["mm_aggregate"]
+    assert tensor_ref.consumer_stage == "thinker"
+    assert tensor_ref.threshold_mb == 2.0
+    assert tensor_ref.paths == (
+        "video_embeds",
+        "deepstack_visual_embeds_image",
+        "deepstack_visual_embeds_video",
     )
     assert speech_thinker.stream_to == ["talker_ar", "decode"]
     assert speech_thinker.route_fn == (

--- a/tests/unit_test/qwen3_omni/test_pipeline.py
+++ b/tests/unit_test/qwen3_omni/test_pipeline.py
@@ -647,7 +647,9 @@ def test_qwen_thinker_cuda_graph_capture_lifecycle(
     from sglang_omni.scheduling import bootstrap as scheduling_bootstrap
     from sglang_omni.scheduling import omni_scheduler, sglang_backend
 
-    server_args = SimpleNamespace(disable_cuda_graph=False)
+    server_args = SimpleNamespace(
+        disable_cuda_graph=False, enable_return_hidden_states=False
+    )
     infrastructure_saw_graph_disabled: list[bool] = []
     capture_hidden_layers_seen: list[list[int] | None] = []
     init_graph_calls = 0
@@ -721,7 +723,7 @@ def test_qwen_thinker_cuda_graph_capture_lifecycle(
     assert infrastructure_saw_graph_disabled == [expected_infrastructure_graph_disabled]
     assert capture_hidden_layers_seen == [expected_capture_hidden_layers]
     assert init_graph_calls == expected_init_graph_calls
-    assert getattr(server_args, "enable_return_hidden_states", False) is speech_enabled
+    assert server_args.enable_return_hidden_states is speech_enabled
     assert server_args.disable_cuda_graph is False
     assert scheduler.server_args is server_args
 

--- a/tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
+++ b/tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
@@ -257,6 +257,8 @@ def test_qwen_talker_ar_threads_explicit_generation_batch_policy(monkeypatch) ->
             max_running_requests=overrides["max_running_requests"],
             cuda_graph_max_bs=overrides["cuda_graph_max_bs"],
             cuda_graph_bs=overrides["cuda_graph_bs"],
+            disable_cuda_graph=overrides["disable_cuda_graph"],
+            enable_torch_compile=overrides.get("enable_torch_compile", False),
             torch_compile_max_bs=overrides["torch_compile_max_bs"],
         )
 
@@ -328,6 +330,8 @@ def test_talker_ar_default_running_batch_width_is_32(monkeypatch) -> None:
             max_running_requests=overrides["max_running_requests"],
             cuda_graph_max_bs=overrides["cuda_graph_max_bs"],
             cuda_graph_bs=overrides["cuda_graph_bs"],
+            disable_cuda_graph=overrides["disable_cuda_graph"],
+            enable_torch_compile=overrides.get("enable_torch_compile", False),
             torch_compile_max_bs=overrides["torch_compile_max_bs"],
         )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from benchmarks.benchmarker import utils as benchmark_utils
-from benchmarks.tasks.tts import (
+from benchmarks.tasks.asr import (
     DEFAULT_ASR_TRANSCRIBE_CONCURRENCY,
     QWEN3_ASR_MODEL_PATH,
 )


### PR DESCRIPTION
> [!NOTE]
> Stacked on #932 (branch rebased onto `luojiaxuan/tensor-ref-explicit-policy`), merge order 932 -> 935. Until #932 lands, the diff below includes its commits — review the top 3 commits (`[Ming-Omni] ...`).

## Motivation

`merge_for_thinker` in `sglang_omni/models/ming_omni/pipeline/merge.py` transforms embeds at `mm_aggregate` (`_as_tensor` + `dim()`/`squeeze(0)`), so Ming cannot join the TensorRef path (#808). Worse, an unresolved `TensorRef` reaching the merge is silently dropped — `_as_tensor` swallows the `torch.as_tensor(ref_dict)` exception and returns `None`, deleting `video_embeds` from thinker inputs with no error; masked today only because TensorRef is off by default.

## Modifications

- `pipeline/merge.py`: `_non_empty` recognizes TensorRef dicts via shape metadata (same pattern #808 added to the qwen3 merge); embeds forwarded untouched; `_as_tensor` removed.
- `stages.py`: audio/image encoder executors flatten `[B, T', H] -> [T', H]` at the producer (`flatten_embed_batch_dims`), before `write_payload` externalizes the tensor — `mm_aggregate` becomes a pure relay; no COW semantics needed for Ming.
- `config.py`: declare the Ming TensorRef edge via #932's `TensorRefEdgeConfig` — `image_encoder -> mm_aggregate`, consumer `thinker`, `paths=("video_embeds",)` (video only for now, matching the qwen3 scope; image/audio can follow once #803 trace data justifies them).
- `tests/unit_test/ming_omni/test_pipeline.py`: regression test that an unresolved `video_embeds` ref survives merge (fails on the pre-fix code with `KeyError: 'model_inputs'`), plus producer-flatten tests for the audio and image executors.

## Related Issues

Ming rollout step of #934. Builds on #808. Stacked on #932.

## Accuracy Test

Behavior-neutral with refs off: the squeeze moves from `mm_aggregate` to the producer, thinker inputs are identical. Unit tests (run on #932's branch + these commits):

```
$ pytest tests/unit_test/ming_omni/test_pipeline.py tests/unit_test/pipeline/test_tensor_ref.py -q
38 passed
```

Ming has no GPU CI stage, so before merge I will run a manual refs-on E2E on a GPU box and post output-parity + latency results here.

## Benchmark & Profiling

Numbers will come from the manual E2E above; #808 measured 160-179s -> 36-37s (~4.5x) on the equivalent qwen3 stage 11 video path.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
