### PR TITLE
[TTS Refactor][T5b] StreamingVocoderBase: Higgs migration

### DIFF
--- a/sglang_omni/models/higgs_tts/vocoder_scheduler.py
+++ b/sglang_omni/models/higgs_tts/vocoder_scheduler.py
@@ -10,13 +10,11 @@ import torch
 
 from sglang_omni.models.higgs_tts.audio_codec import HiggsAudioCodec
 from sglang_omni.models.higgs_tts.payload_types import HiggsTtsState
-from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from sglang_omni.proto import StagePayload
-from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.pipeline_state import build_usage
-from sglang_omni.scheduling.streaming_simple_scheduler import StreamingSimpleScheduler
 from sglang_omni.scheduling.streaming_vocoder import (
     INITIAL_CODEC_CHUNK_FRAMES_PARAM,
+    StreamingVocoderBase,
     resolve_initial_codec_chunk_frames,
 )
 from sglang_omni.utils.audio_payload import audio_waveform_payload
@@ -28,13 +26,12 @@ class _HiggsStreamState:
     delayed_rows: list[torch.Tensor] = field(default_factory=list)
     emitted_raw_frames: int = 0
     next_decode_rows: int = 0
-    has_emitted: bool = False
     num_codebooks: int | None = None
     codebook_size: int | None = None
     initial_codec_chunk_frames: int = 0
 
 
-class HiggsStreamingVocoderScheduler(StreamingSimpleScheduler):
+class HiggsStreamingVocoderScheduler(StreamingVocoderBase[_HiggsStreamState, None]):
     """Decode Higgs codec rows incrementally, with batched final decode."""
 
     def __init__(
@@ -60,188 +57,64 @@ class HiggsStreamingVocoderScheduler(StreamingSimpleScheduler):
         self._stream_followup_stride = int(stream_followup_stride)
         self._stream_overlap_tokens = int(stream_overlap_tokens)
         self._stream_holdback_tokens = int(stream_holdback_tokens)
-        self._sample_rate = HiggsAudioCodec.SAMPLE_RATE
-        self._stream_states: dict[str, _HiggsStreamState] = {}
         self._samples_per_frame = self._resolve_samples_per_frame(codec)
 
         super().__init__(
             self._vocode_payload,
             batch_compute_fn=self._vocode_payloads,
+            sample_rate=HiggsAudioCodec.SAMPLE_RATE,
+            stream_source_hint="Higgs",
             max_batch_size=max_batch_size,
             max_batch_wait_ms=max_batch_wait_ms,
         )
 
-    def is_streaming_payload(self, payload: StagePayload) -> bool:
-        params = payload.request.params
-        if not isinstance(params, dict):
-            raise TypeError(
-                f"Higgs request params must be a dict, got {type(params).__name__}"
-            )
-        return bool(params.get("stream", False))
+    def create_stream_state(self, request_id: str) -> _HiggsStreamState:
+        del request_id
+        return _HiggsStreamState()
 
-    def on_streaming_new_request(self, request_id: str, payload: StagePayload) -> None:
-        stream_state = self._stream_states.setdefault(request_id, _HiggsStreamState())
-        if not isinstance(payload.data, dict):
-            raise TypeError(
-                f"Higgs streaming payload for {request_id!r} must be a dict, "
-                f"got {type(payload.data).__name__}"
-            )
-        missing = [
-            key for key in ("num_codebooks", "codebook_size") if key not in payload.data
-        ]
-        if not missing:
-            self._latch_stream_contract(
-                request_id,
-                stream_state,
-                num_codebooks=payload.data["num_codebooks"],
-                codebook_size=payload.data["codebook_size"],
-                source="payload",
-            )
-            self._latch_initial_codec_chunk_frames_from_mapping(
-                payload.request_id,
-                stream_state,
-                (
-                    payload.request.params
-                    if isinstance(payload.request.params, dict)
-                    else None
-                ),
-            )
-            return
-        if (
-            stream_state.num_codebooks is not None
-            and stream_state.codebook_size is not None
-        ):
-            self._latch_stream_contract(
-                request_id,
-                stream_state,
-                num_codebooks=payload.data.get(
-                    "num_codebooks", stream_state.num_codebooks
-                ),
-                codebook_size=payload.data.get(
-                    "codebook_size", stream_state.codebook_size
-                ),
-                source="payload",
-            )
-            self._latch_initial_codec_chunk_frames_from_mapping(
-                payload.request_id,
-                stream_state,
-                (
-                    payload.request.params
-                    if isinstance(payload.request.params, dict)
-                    else None
-                ),
-            )
-            return
-        raise RuntimeError(
-            f"Higgs streaming payload for {request_id!r} is missing fields: "
-            f"{', '.join(missing)}"
-        )
-
-    def on_stream_chunk(
-        self, request_id: str, item: StreamItem
-    ) -> list[OutgoingMessage]:
-        state = self._stream_states.setdefault(request_id, _HiggsStreamState())
-        self._latch_stream_metadata(request_id, state, item.metadata)
-
-        row = item.data
-        if not isinstance(row, torch.Tensor):
-            raise TypeError(
-                f"Higgs stream chunk for {request_id!r} must carry a torch.Tensor, "
-                f"got {type(row).__name__}"
-            )
-        row = row.to(dtype=torch.long)
-        if row.ndim != 1:
-            raise ValueError(
-                f"Higgs stream chunk must be 1-D [N], got {tuple(row.shape)}"
-            )
-
-        num_codebooks = self._require_stream_contract(state, request_id)[0]
-        if int(row.shape[0]) != num_codebooks:
-            raise ValueError(
-                f"Higgs stream chunk has {int(row.shape[0])} codebooks, "
-                f"expected {num_codebooks}"
-            )
-        state.delayed_rows.append(row)
-
-        output = self._decode_delta(state, is_final=False)
-        if output is None:
-            return []
-        return [
-            OutgoingMessage(
-                request_id=request_id,
-                type="stream",
-                data=output,
-                metadata={"modality": "audio"},
-            )
-        ]
-
-    def on_stream_done(self, request_id: str) -> list[OutgoingMessage]:
-        payload = self._stream_payloads[request_id]
-        state = self._stream_states.setdefault(request_id, _HiggsStreamState())
-        output = self._decode_delta(state, is_final=True)
-        if output is None and not state.has_emitted:
-            output = self._audio_payload_from_stage_payload(payload)
-
-        messages: list[OutgoingMessage] = []
-        if output is not None:
-            messages.append(
-                OutgoingMessage(
-                    request_id=request_id,
-                    type="stream",
-                    data=output,
-                    metadata={"modality": "audio"},
-                )
-            )
-
-        final_data: dict[str, Any] = {
-            "modality": "audio",
-            "sample_rate": self._sample_rate,
-        }
-        final_state = HiggsTtsState.from_dict(payload.data)
-        usage = build_usage(final_state)
-        if usage is not None:
-            final_data["usage"] = usage
-        if final_state.omni_rollout is not None:
-            final_data["omni_rollout"] = final_state.omni_rollout
-        messages.append(
-            OutgoingMessage(
-                request_id=request_id,
-                type="result",
-                data=StagePayload(
-                    request_id=payload.request_id,
-                    request=payload.request,
-                    data=final_data,
-                ),
-            )
-        )
-        return messages
-
-    def clear_stream_state(self, request_id: str) -> None:
-        self._stream_states.pop(request_id, None)
-
-    def _latch_stream_metadata(
+    def latch_stream_contract(
         self,
         request_id: str,
         state: _HiggsStreamState,
-        metadata: dict[str, Any] | None,
+        source: StagePayload | Mapping[str, Any],
+        *,
+        origin: str,
     ) -> None:
-        if not isinstance(metadata, dict):
-            if state.num_codebooks is None or state.codebook_size is None:
-                raise RuntimeError(
-                    f"Higgs stream chunk for {request_id!r} is missing metadata "
-                    "with num_codebooks and codebook_size"
+        if origin == "payload":
+            payload = source
+            if not isinstance(payload.data, dict):
+                raise TypeError(
+                    f"Higgs streaming payload for {request_id!r} must be a dict, "
+                    f"got {type(payload.data).__name__}"
                 )
+            missing = [
+                key
+                for key in ("num_codebooks", "codebook_size")
+                if key not in payload.data
+            ]
+            if missing and (state.num_codebooks is None or state.codebook_size is None):
+                raise RuntimeError(
+                    f"Higgs streaming payload for {request_id!r} is missing fields: "
+                    f"{', '.join(missing)}"
+                )
+            self._latch_contract_values(
+                request_id,
+                state,
+                num_codebooks=payload.data.get("num_codebooks", state.num_codebooks),
+                codebook_size=payload.data.get("codebook_size", state.codebook_size),
+                source=origin,
+            )
+            self._latch_initial_codec_chunk_frames_from_mapping(
+                request_id,
+                state,
+                (
+                    payload.request.params
+                    if isinstance(payload.request.params, dict)
+                    else None
+                ),
+            )
             return
-        if metadata.get("modality") not in (None, "audio_codes"):
-            raise ValueError(
-                f"Higgs stream chunk modality must be audio_codes, got "
-                f"{metadata.get('modality')!r}"
-            )
-        if metadata.get("stream") is not True:
-            raise RuntimeError(
-                f"Higgs stream chunk for {request_id!r} must include "
-                "metadata['stream'] == True"
-            )
+        metadata: Mapping[str, Any] = source
         missing = [
             key for key in ("num_codebooks", "codebook_size") if key not in metadata
         ]
@@ -251,12 +124,12 @@ class HiggsStreamingVocoderScheduler(StreamingSimpleScheduler):
                 f"{', '.join(missing)}"
             )
         if "num_codebooks" in metadata and "codebook_size" in metadata:
-            self._latch_stream_contract(
+            self._latch_contract_values(
                 request_id,
                 state,
                 num_codebooks=metadata["num_codebooks"],
                 codebook_size=metadata["codebook_size"],
-                source="stream metadata",
+                source=origin,
             )
         if INITIAL_CODEC_CHUNK_FRAMES_PARAM in metadata:
             self._latch_initial_codec_chunk_frames_from_mapping(
@@ -265,69 +138,31 @@ class HiggsStreamingVocoderScheduler(StreamingSimpleScheduler):
                 metadata,
             )
 
-    @staticmethod
-    def _latch_stream_contract(
-        request_id: str,
-        state: _HiggsStreamState,
-        *,
-        num_codebooks: Any,
-        codebook_size: Any,
-        source: str,
+    def validate_chunk(
+        self, request_id: str, state: _HiggsStreamState, codes: torch.Tensor
+    ) -> torch.Tensor:
+        row = codes.to(dtype=torch.long)
+        if row.ndim != 1:
+            raise ValueError(
+                f"Higgs stream chunk must be 1-D [N], got {tuple(row.shape)}"
+            )
+        num_codebooks = self._require_stream_contract(state, request_id)[0]
+        if int(row.shape[0]) != num_codebooks:
+            raise ValueError(
+                f"Higgs stream chunk has {int(row.shape[0])} codebooks, "
+                f"expected {num_codebooks}"
+            )
+        return row
+
+    def ingest(
+        self, request_id: str, state: _HiggsStreamState, codes: torch.Tensor
     ) -> None:
-        try:
-            num_codebooks_i = int(num_codebooks)
-            codebook_size_i = int(codebook_size)
-        except (TypeError, ValueError) as exc:
-            raise TypeError(
-                f"Higgs {source} for {request_id!r} must include integer "
-                "num_codebooks and codebook_size"
-            ) from exc
-        if num_codebooks_i <= 0 or codebook_size_i <= 2:
-            raise ValueError(
-                f"Higgs {source} for {request_id!r} has invalid "
-                f"num_codebooks={num_codebooks_i}, codebook_size={codebook_size_i}"
-            )
-        if state.num_codebooks is not None and state.num_codebooks != num_codebooks_i:
-            raise ValueError(
-                f"Higgs stream num_codebooks changed for {request_id!r}: "
-                f"{state.num_codebooks} -> {num_codebooks_i}"
-            )
-        if state.codebook_size is not None and state.codebook_size != codebook_size_i:
-            raise ValueError(
-                f"Higgs stream codebook_size changed for {request_id!r}: "
-                f"{state.codebook_size} -> {codebook_size_i}"
-            )
-        state.num_codebooks = num_codebooks_i
-        state.codebook_size = codebook_size_i
+        del request_id
+        state.delayed_rows.append(codes)
 
-    def _latch_initial_codec_chunk_frames_from_mapping(
-        self,
-        request_id: str,
-        state: _HiggsStreamState,
-        params: Mapping[str, Any] | None,
-    ) -> None:
-        num_codebooks, _ = self._require_stream_contract(state, request_id)
-        steady_codec_frames = max(1, self._stream_stride - num_codebooks + 1)
-        state.initial_codec_chunk_frames = resolve_initial_codec_chunk_frames(
-            params,
-            steady_chunk_frames=steady_codec_frames,
-        )
-
-    @staticmethod
-    def _require_stream_contract(
-        state: _HiggsStreamState,
-        request_id: str,
-    ) -> tuple[int, int]:
-        if state.num_codebooks is None or state.codebook_size is None:
-            raise RuntimeError(
-                f"Higgs stream contract for {request_id!r} is missing "
-                "num_codebooks or codebook_size"
-            )
-        return state.num_codebooks, state.codebook_size
-
-    def _decode_delta(
-        self, state: _HiggsStreamState, *, is_final: bool
-    ) -> dict[str, Any] | None:
+    def decode_delta(
+        self, request_id: str, state: _HiggsStreamState, *, is_final: bool
+    ) -> torch.Tensor | None:
         delayed_count = len(state.delayed_rows)
         if delayed_count == 0:
             return None
@@ -340,7 +175,7 @@ class HiggsStreamingVocoderScheduler(StreamingSimpleScheduler):
         use_initial_chunk = (
             state.initial_codec_chunk_frames > 0
             and state.initial_codec_chunk_frames < steady_codec_frames
-            and not state.has_emitted
+            and not self._stream_has_emitted(request_id)
         )
         first_decode_rows = max(
             num_codebooks,
@@ -400,13 +235,98 @@ class HiggsStreamingVocoderScheduler(StreamingSimpleScheduler):
             num_codebooks=num_codebooks,
             emitted_initial_chunk=use_initial_chunk and not is_final,
         )
-        state.has_emitted = True
+        return delta
+
+    def stream_payload(self, request_id: str, waveform: torch.Tensor) -> dict[str, Any]:
+        del request_id
         return audio_waveform_payload(
-            delta,
+            waveform,
             sample_rate=self._sample_rate,
             modality="audio",
             source_hint="Higgs TTS streaming",
         )
+
+    def fallback_full_decode(
+        self, request_id: str, payload: StagePayload, state: _HiggsStreamState
+    ) -> torch.Tensor | None:
+        del request_id, state
+        return self._decode_state_to_audio(HiggsTtsState.from_dict(payload.data))
+
+    def final_result_data(
+        self, request_id: str, payload: StagePayload, state: _HiggsStreamState
+    ) -> dict[str, Any]:
+        del request_id, state
+        final_data: dict[str, Any] = {
+            "modality": "audio",
+            "sample_rate": self._sample_rate,
+        }
+        final_state = HiggsTtsState.from_dict(payload.data)
+        usage = build_usage(final_state)
+        if usage is not None:
+            final_data["usage"] = usage
+        if final_state.omni_rollout is not None:
+            final_data["omni_rollout"] = final_state.omni_rollout
+        return final_data
+
+    @staticmethod
+    def _latch_contract_values(
+        request_id: str,
+        state: _HiggsStreamState,
+        *,
+        num_codebooks: Any,
+        codebook_size: Any,
+        source: str,
+    ) -> None:
+        try:
+            num_codebooks_i = int(num_codebooks)
+            codebook_size_i = int(codebook_size)
+        except (TypeError, ValueError) as exc:
+            raise TypeError(
+                f"Higgs {source} for {request_id!r} must include integer "
+                "num_codebooks and codebook_size"
+            ) from exc
+        if num_codebooks_i <= 0 or codebook_size_i <= 2:
+            raise ValueError(
+                f"Higgs {source} for {request_id!r} has invalid "
+                f"num_codebooks={num_codebooks_i}, codebook_size={codebook_size_i}"
+            )
+        if state.num_codebooks is not None and state.num_codebooks != num_codebooks_i:
+            raise ValueError(
+                f"Higgs stream num_codebooks changed for {request_id!r}: "
+                f"{state.num_codebooks} -> {num_codebooks_i}"
+            )
+        if state.codebook_size is not None and state.codebook_size != codebook_size_i:
+            raise ValueError(
+                f"Higgs stream codebook_size changed for {request_id!r}: "
+                f"{state.codebook_size} -> {codebook_size_i}"
+            )
+        state.num_codebooks = num_codebooks_i
+        state.codebook_size = codebook_size_i
+
+    def _latch_initial_codec_chunk_frames_from_mapping(
+        self,
+        request_id: str,
+        state: _HiggsStreamState,
+        params: Mapping[str, Any] | None,
+    ) -> None:
+        num_codebooks, _ = self._require_stream_contract(state, request_id)
+        steady_codec_frames = max(1, self._stream_stride - num_codebooks + 1)
+        state.initial_codec_chunk_frames = resolve_initial_codec_chunk_frames(
+            params,
+            steady_chunk_frames=steady_codec_frames,
+        )
+
+    @staticmethod
+    def _require_stream_contract(
+        state: _HiggsStreamState,
+        request_id: str,
+    ) -> tuple[int, int]:
+        if state.num_codebooks is None or state.codebook_size is None:
+            raise RuntimeError(
+                f"Higgs stream contract for {request_id!r} is missing "
+                "num_codebooks or codebook_size"
+            )
+        return state.num_codebooks, state.codebook_size
 
     def _next_decode_rows_after_emit(
         self,
@@ -420,20 +340,6 @@ class HiggsStreamingVocoderScheduler(StreamingSimpleScheduler):
                 max(num_codebooks, self._stream_stride) + self._stream_followup_stride
             )
         return delayed_count + self._stream_followup_stride
-
-    def _audio_payload_from_stage_payload(
-        self, payload: StagePayload
-    ) -> dict[str, Any] | None:
-        state = HiggsTtsState.from_dict(payload.data)
-        audio = self._decode_state_to_audio(state)
-        if audio is None:
-            return None
-        return audio_waveform_payload(
-            audio,
-            sample_rate=self._sample_rate,
-            modality="audio",
-            source_hint="Higgs TTS streaming",
-        )
 
     def _vocode_payload(self, payload: StagePayload) -> StagePayload:
         return self._vocode_payloads([payload])[0]

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -1257,6 +1257,42 @@ def test_higgs_initial_chunk_resumes_after_followup_boundary() -> None:
     assert len(second_streams) == 1
 
 
+def test_higgs_stream_contract_change_rejects_chunk_without_buffering() -> None:
+    scheduler = HiggsStreamingVocoderScheduler(_FakeHiggsStreamingCodec())
+    payload = _higgs_stream_payload("req", stream=True, delayed_rows=[[1, 2, 3]])
+    scheduler._on_streaming_new_request("req", payload)
+
+    row = torch.tensor([1, 2, 3], dtype=torch.long)
+    with pytest.raises(ValueError, match="num_codebooks changed for"):
+        scheduler._on_chunk("req", _higgs_stream_item(row, num_codebooks=4))
+    with pytest.raises(ValueError, match="codebook_size changed for"):
+        scheduler._on_chunk("req", _higgs_stream_item(row, codebook_size=21))
+    assert scheduler._stream_states["req"].delayed_rows == []
+
+
+def test_higgs_stream_contract_requires_integer_values() -> None:
+    scheduler = HiggsStreamingVocoderScheduler(_FakeHiggsStreamingCodec())
+    payload = _higgs_stream_payload("req", stream=True, delayed_rows=[[1, 2, 3]])
+    scheduler._on_streaming_new_request("req", payload)
+
+    item = _higgs_stream_item(torch.tensor([1, 2, 3], dtype=torch.long))
+    item.metadata["num_codebooks"] = "three"
+    with pytest.raises(TypeError, match="must include integer"):
+        scheduler._on_chunk("req", item)
+    assert scheduler._stream_states["req"].delayed_rows == []
+
+
+def test_higgs_streaming_payload_missing_contract_fields_errors() -> None:
+    scheduler = HiggsStreamingVocoderScheduler(_FakeHiggsStreamingCodec())
+    payload = StagePayload(
+        request_id="req",
+        request=OmniRequest(inputs="", params={"stream": True}),
+        data={},
+    )
+    with pytest.raises(RuntimeError, match="is missing fields"):
+        scheduler._on_streaming_new_request("req", payload)
+
+
 def _drain_higgs_outbox(
     scheduler: HiggsStreamingVocoderScheduler,
 ) -> list:


### PR DESCRIPTION
Stacked on #936 (this diff includes its commits until it merges) — review scope here is the Higgs commit only.

Second T5b migration from #661, on top of #936's `StreamingVocoderBase`: Higgs moves onto the base with no base changes — the hook surface validated on MOSS-local absorbed the simpler request-local streamer as-is. `StreamingVocoderBase` is the streaming sibling of T5a's `BatchVocoderBase` (`scheduling/vocoder_base.py`, merged via #940); this PR touches only the streaming path.

One file of production code changes: `higgs_tts/vocoder_scheduler.py` (−241/+147). The duplicated lifecycle (state registry, stream gate, chunk scaffold, done sequencing, nothing-emitted fallback, abort/late-chunk handling) is deleted; delay-pattern cursor math (`raw = rows − num_codebooks + 1`), holdback/overlap re-decode with exact hop-length trimming, contract latching content, the metadata-only terminal result and the non-streaming batch-decode path stay model-owned and verbatim (the latter is T5a territory: it migrates onto `BatchVocoderBase` separately, not here). No coalescing. `stages.py` wiring unchanged (same constructor surface). Client-visible strings preserved via `stream_source_hint="Higgs"`, with one theoretical exception (None-metadata chunk after a payload-latched contract now errors; unreachable from the only producer — `_emit_code_chunk` always attaches the metadata dict).

Behavior class: Green (output-equivalent). Old path deleted in this PR; no dual path.

Tests: all 34 pre-existing higgs pipeline tests pass unmodified (none deleted — each covers model-owned math, not base scaffold); added latch-immutability cases that previously had no model-level coverage. Base contract suite unchanged.

Full SeedTTS-EN gate (complete en split, c=16, DP1, no router, 1x H100, `--max-running-requests 64 --cuda-graph-max-bs 64`), bosonai/higgs-audio-v3-tts-4b, main @ 1cb04ad vs this branch:

| Model / config | Split | WER / CER | Speaker SIM | Samples | Failed / skipped | Throughput | rtf_mean |
|---|---|---|---|---|---|---|---|
| main, non-stream | en | 0.95% | 67.15 | 1088/1088 | 0 / 0 | 14.93 req/s | 0.256 |
| **this PR, non-stream** | en | 1.17% (1.09% excl. 1 outlier >50%) | 67.29 | 1088/1088 | 0 / 0 | 15.35 req/s | 0.251 |
| main, stream | en | 1.18% | 67.18 | 1088/1088 | 0 / 0 | 14.04 req/s | 0.269 |
| **this PR, stream** | en | 1.05% | 67.22 | 1088/1088 | 0 / 0 | 14.03 req/s | 0.273 |

Streaming TTFP mean/p95: 0.211/0.417 s (main) vs 0.212/0.409 s (this PR). WER deltas are sampling noise (server-default temperature; note main-vs-main spread 0.95↔1.18 across modes); SIM/throughput/RTF/TTFP flat.