### PR TITLE
[WIP on 869]Intra-node data-plane hardening: completion wait, router device-fallback, SHM backpressure

### DIFF
--- a/sglang_omni/comm/__init__.py
+++ b/sglang_omni/comm/__init__.py
@@ -1,17 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 """Unified communication primitives for stage, rank, and node data movement."""
 
-from sglang_omni.comm.engine import CommEngine
-from sglang_omni.comm.router import CommRouter
 from sglang_omni.comm.data_ref import (
     BackendRef,
+    DataKind,
+    DataLayout,
+    DataRef,
     MetadataTensorRef,
     TensorMeta,
-    DataRef,
-    DataLayout,
-    DataKind,
     TransportKind,
 )
+from sglang_omni.comm.engine import CommEngine
+from sglang_omni.comm.router import CommRouter
 
 __all__ = [
     "BackendRef",

--- a/sglang_omni/comm/data_ref.py
+++ b/sglang_omni/comm/data_ref.py
@@ -70,7 +70,9 @@ class BackendRef:
         cls, *, transport: TransportKind, relay_info: dict[str, Any]
     ) -> "BackendRef":
         transfer_info = _dict(relay_info, "transfer_info")
-        return cls(transport=transport, info=relay_info, length=_int(transfer_info, "size"))
+        return cls(
+            transport=transport, info=relay_info, length=_int(transfer_info, "size")
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -160,7 +162,9 @@ class DataRef:
             layout=DataLayout(_str(value, "layout")),
             buffer=BackendRef.from_dict(_dict(value, "buffer")),
             header=_optional_str(value, "header"),
-            tensors=tuple(TensorMeta.from_dict(item) for item in _list(value, "tensors")),
+            tensors=tuple(
+                TensorMeta.from_dict(item) for item in _list(value, "tensors")
+            ),
             shape=_ints(value, "shape") if "shape" in value else None,
             dtype=_optional_str(value, "dtype"),
             offset=_int(value, "offset") if "offset" in value else None,

--- a/sglang_omni/comm/engine.py
+++ b/sglang_omni/comm/engine.py
@@ -7,8 +7,8 @@ from typing import Any
 import torch
 
 from sglang_omni.comm import stage_io
-from sglang_omni.comm.router import CommRouter
 from sglang_omni.comm.data_ref import DataRef, TransportKind
+from sglang_omni.comm.router import CommRouter
 from sglang_omni.proto import StagePayload
 from sglang_omni.relay.base import Relay
 

--- a/sglang_omni/comm/router.py
+++ b/sglang_omni/comm/router.py
@@ -51,6 +51,11 @@ class CommRouter:
         return self._physical_outbound(target)
 
     def _physical_outbound(self, target: str) -> TransportKind:
+        # Invariant: anything not in remote_stage_names is assumed same-node, so a
+        # future placement pass MUST populate remote_stage_names for every
+        # cross-node edge -- otherwise a cross-node target silently falls through
+        # to cuda_ipc/shm here. A hard assertion needs the Phase-1 node config,
+        # which does not exist yet.
         if target in self.remote_stage_names:
             return TransportKind.MOONCAKE
         if self.self_is_gpu and target in self.gpu_stage_names:
@@ -65,10 +70,10 @@ class CommRouter:
             )
         kind = self.outbound(target)
         if kind is TransportKind.CUDA_IPC and not data.is_cuda:
-            raise ValueError(
-                f"GPU stage edge {self.stage_name!r}->{target!r} selected "
-                "cuda_ipc, but the stream chunk is not CUDA-resident"
-            )
+            # Transport must follow the actual tensor device, not just placement:
+            # a GPU-placed edge can legitimately carry a host-resident chunk. Fall
+            # back to SHM (the host transport) instead of failing the transfer.
+            return TransportKind.SHM
         return kind
 
     def inbound(self, from_stage: str) -> TransportKind:

--- a/sglang_omni/relay/cuda_ipc.py
+++ b/sglang_omni/relay/cuda_ipc.py
@@ -191,6 +191,7 @@ class CudaIpcPutOperation(RelayOperation):
         request_id: str | None,
         size: int,
         release_cb: Callable[[], None],
+        fail_cb: Callable[[BaseException], None],
     ) -> None:
         self._metadata = metadata
         self._ready_event: torch.cuda.Event | None = ready_event
@@ -200,6 +201,7 @@ class CudaIpcPutOperation(RelayOperation):
         self._request_id = request_id
         self._size = size
         self._release_cb = release_cb
+        self._fail_cb = fail_cb
         self._completed = False
 
     @property
@@ -234,14 +236,11 @@ class CudaIpcPutOperation(RelayOperation):
                 loop=loop,
                 timeout_message="cuda_ipc receiver did not ack slot in time",
             )
-        except TimeoutError:
-            # Release the slot even on timeout: a crashed or hung receiver must not
-            # permanently leak a credit (there are only ``credits``, default 2) and
-            # deadlock later puts. TODO(comm): a safer end-state marks the relay
-            # failed and tears it down rather than risking reuse of a slot the dead
-            # receiver might still read.
+        except TimeoutError as exc:
+            # Timeout is a hard relay failure; do not return a possibly live slot
+            # to normal traffic.
             self._completed = True
-            self._release_cb()
+            self._fail_cb(exc)
             self._source_tensor = None
             self._ready_event = None
             raise
@@ -345,6 +344,8 @@ class CudaIpcRelay(Relay):
 
         self._remote_pools: dict[str, torch.Tensor] = {}
         self._remote_acks: dict[str, _AckMap] = {}
+        self._failed_error: BaseException | None = None
+        self._failed_event = asyncio.Event()
 
     def __del__(self) -> None:
         try:
@@ -410,6 +411,42 @@ class CudaIpcRelay(Relay):
             raise RuntimeError("cuda_ipc local ack map was not initialized")
         return pool_tensor, pool_id, pool_storage_handle, allocator, ack_map
 
+    def _mark_failed(self, exc: BaseException) -> None:
+        if self._failed_error is None:
+            self._failed_error = exc
+            self._failed_event.set()
+
+    def _raise_if_failed(self) -> None:
+        if self._failed_error is not None:
+            raise RuntimeError("cuda_ipc relay failed") from self._failed_error
+
+    async def _acquire_slot(self, allocator: CreditAllocator) -> int:
+        self._raise_if_failed()
+        acquire_task = asyncio.create_task(allocator.acquire_async())
+        fail_task = asyncio.create_task(self._failed_event.wait())
+        try:
+            done, _ = await asyncio.wait(
+                {acquire_task, fail_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if fail_task in done:
+                if acquire_task in done:
+                    allocator.release(acquire_task.result())
+                self._raise_if_failed()
+                raise RuntimeError("cuda_ipc relay failed")
+
+            offset = acquire_task.result()
+            try:
+                self._raise_if_failed()
+            except Exception:
+                allocator.release(offset)
+                raise
+            return offset
+        finally:
+            for task in (acquire_task, fail_task):
+                if not task.done():
+                    task.cancel()
+
     def _get_remote_pool(
         self,
         metadata: dict[str, Any],
@@ -445,6 +482,7 @@ class CudaIpcRelay(Relay):
         request_id: str | None = None,
         dst_rank: int | None = None,
     ) -> CudaIpcPutOperation:
+        self._raise_if_failed()
         if not tensor.is_cuda:
             raise ValueError(
                 "cuda_ipc relay can only transfer CUDA tensors; "
@@ -466,7 +504,7 @@ class CudaIpcRelay(Relay):
             )
 
         acquire_start = _comm_now_ns()
-        offset = await allocator.acquire_async()
+        offset = await self._acquire_slot(allocator)
         acquire_ms = _comm_elapsed_ms(acquire_start)
         slot_index = int(offset // self.slot_size)
         ack_map.clear(slot_index)
@@ -526,6 +564,7 @@ class CudaIpcRelay(Relay):
             request_id=request_id,
             size=size,
             release_cb=lambda: allocator.release(offset),
+            fail_cb=self._mark_failed,
         )
 
     async def get_async(

--- a/sglang_omni/relay/cuda_ipc.py
+++ b/sglang_omni/relay/cuda_ipc.py
@@ -24,6 +24,49 @@ logger = logging.getLogger(__name__)
 _PEER_ENABLED: set[tuple[int, int]] = set()
 _PEER_VISIBILITY_WARNED: set[tuple[int, int, int]] = set()
 
+# Completion-wait tuning. The spin window is sized to catch the small,
+# latency-sensitive completions that dominate decode (e.g. per-frame hidden
+# states, a few microseconds over NVLink) with no added latency; larger copies
+# correctly fall through to backoff, where the added detection latency is
+# negligible next to a multi-millisecond copy and the CPU is freed meanwhile.
+# These are provisional defaults, NOT measured: they should be tuned against the
+# Phase-0 profiling (issue #907) on target hardware before being trusted.
+_WAIT_SPIN_SECONDS = 20e-6
+_WAIT_BACKOFF_MIN_SECONDS = 50e-6
+_WAIT_BACKOFF_MAX_SECONDS = 1e-3
+
+
+async def _await_ready(
+    predicate: Callable[[], bool],
+    *,
+    deadline: float,
+    loop: asyncio.AbstractEventLoop,
+    timeout_message: str,
+) -> int:
+    """Wait until ``predicate`` is true without busy-spinning.
+
+    Phase 1 spins tightly for a short bounded window so the common fast
+    completion returns with no added latency. Phase 2 falls back to exponential
+    backoff with real sleeps, so a slow or hung transfer does not keep the
+    event-loop thread (and, via cudaEventQuery, the CUDA driver) fully busy.
+    Returns the number of polls performed.
+    """
+    polls = 0
+    spin_deadline = loop.time() + _WAIT_SPIN_SECONDS
+    while loop.time() < spin_deadline:
+        if predicate():
+            return polls
+        polls += 1
+        await asyncio.sleep(0)
+    delay = _WAIT_BACKOFF_MIN_SECONDS
+    while not predicate():
+        if loop.time() > deadline:
+            raise TimeoutError(timeout_message)
+        polls += 1
+        await asyncio.sleep(delay)
+        delay = min(delay * 2, _WAIT_BACKOFF_MAX_SECONDS)
+    return polls
+
 
 def _parse_device_id(device: str) -> int:
     if device.startswith("cuda:"):
@@ -169,12 +212,39 @@ class CudaIpcPutOperation(RelayOperation):
         wait_start = _comm_now_ns()
         loop = asyncio.get_event_loop()
         deadline = loop.time() + timeout
-        polls = 0
-        while not self._ack_map.is_done(self._ack_index):
-            if loop.time() > deadline:
-                raise TimeoutError("cuda_ipc receiver did not ack slot in time")
-            polls += 1
-            await asyncio.sleep(0)
+        # The spin+backoff helper below is an interim fix for the busy-spin only;
+        # the sender still polls a shared-mmap ack byte. The end-state is a truly
+        # event-driven wait, via one of two routes:
+        #   - eventfd + loop.add_reader (preferred): the receiver writes the
+        #     eventfd and the event loop wakes this coroutine directly -- zero CPU,
+        #     no helper thread, and a closed fd surfaces peer death immediately.
+        #     Cost: an eventfd is a raw fd, so it must be handed across the process
+        #     boundary (fork-inherit, or SCM_RIGHTS over a unix socket).
+        #   - named pipe (FIFO): path-based like today's ack file (no fd-passing),
+        #     and a pipe read is likewise add_reader-drivable. Slightly heavier
+        #     than eventfd and needs FIFO lifecycle management.
+        # TODO(comm): replace the shared-mmap ack poll with an eventfd + add_reader
+        # (falling back to a named pipe only if fd-passing is impractical) so the
+        # sender blocks event-driven with zero CPU and prompt peer-death detection,
+        # instead of this spin+backoff and the blunt 30s timeout.
+        try:
+            polls = await _await_ready(
+                lambda: self._ack_map.is_done(self._ack_index),
+                deadline=deadline,
+                loop=loop,
+                timeout_message="cuda_ipc receiver did not ack slot in time",
+            )
+        except TimeoutError:
+            # Release the slot even on timeout: a crashed or hung receiver must not
+            # permanently leak a credit (there are only ``credits``, default 2) and
+            # deadlock later puts. TODO(comm): a safer end-state marks the relay
+            # failed and tears it down rather than risking reuse of a slot the dead
+            # receiver might still read.
+            self._completed = True
+            self._release_cb()
+            self._source_tensor = None
+            self._ready_event = None
+            raise
         self._completed = True
         self._release_cb()
         self._source_tensor = None
@@ -219,12 +289,12 @@ class CudaIpcGetOperation(RelayOperation):
         wait_start = _comm_now_ns()
         loop = asyncio.get_event_loop()
         deadline = loop.time() + timeout
-        polls = 0
-        while not self._event.query():
-            if loop.time() > deadline:
-                raise TimeoutError("cuda_ipc copy did not complete in time")
-            polls += 1
-            await asyncio.sleep(0)
+        polls = await _await_ready(
+            self._event.query,
+            deadline=deadline,
+            loop=loop,
+            timeout_message="cuda_ipc copy did not complete in time",
+        )
         self._completed = True
         self._ack_map.mark_done(self._ack_index)
         self._pool_tensor = None

--- a/sglang_omni/relay/shm.py
+++ b/sglang_omni/relay/shm.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import uuid
 from multiprocessing import shared_memory as _shm
-from typing import Any
+from typing import Any, Callable
 
 import numpy as np
 import torch
@@ -20,6 +21,13 @@ import torch
 from .base import Relay, RelayOperation, register_relay
 
 logger = logging.getLogger(__name__)
+
+# Consume-wait tuning. shm is a cold, CPU-only path after the cuda_ipc split, so a
+# larger backoff cap than the GPU path is fine. Provisional defaults; tune with the
+# Phase-0 profiling (#907) if a CPU edge ever turns hot.
+_CONSUME_SPIN_SECONDS = 20e-6
+_CONSUME_BACKOFF_MIN_SECONDS = 50e-6
+_CONSUME_BACKOFF_MAX_SECONDS = 5e-3
 
 
 def shm_create_from_tensor(tensor: torch.Tensor) -> _shm.SharedMemory:
@@ -58,20 +66,59 @@ class ShmOperation(RelayOperation):
 class ShmPutOperation(ShmOperation):
     """
     Handle for Put.
-    In this simplified SHM model, writing is synchronous during creation,
-    so the operation is effectively complete immediately.
+
+    The sender holds its flow-control credit until the receiver has consumed the
+    block, which the receiver signals by unlinking it (the entry disappears from
+    /dev/shm). This gives real bounded-outstanding backpressure -- at most
+    ``credits`` un-consumed blocks exist at once -- by reusing the unlink the
+    receiver already performs, with no separate ack channel.
     """
 
-    def __init__(self, metadata: Any, shm_obj: _shm.SharedMemory):
+    def __init__(
+        self,
+        metadata: Any,
+        shm_obj: _shm.SharedMemory,
+        *,
+        shm_name: str,
+        release_cb: Callable[[], None],
+    ):
         super().__init__(metadata)
         self._shm_obj = shm_obj
+        self._shm_name = shm_name
+        self._release_cb = release_cb
 
     async def wait_for_completion(self, timeout: float = 30.0) -> None:
-        # Sender simply closes the local handle; Receiver is responsible for unlinking.
-        if not self._completed:
-            self._shm_obj.close()
+        if self._completed:
+            return
+        # Sender closes its own handle; the receiver owns the unlink.
+        self._shm_obj.close()
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + timeout
+        shm_path = f"/dev/shm/{self._shm_name}"
+        spin_deadline = loop.time() + _CONSUME_SPIN_SECONDS
+        delay = _CONSUME_BACKOFF_MIN_SECONDS
+        # Hold the credit until the receiver consumes the block (it disappears),
+        # spinning briefly then backing off so an absent consumer does not
+        # busy-spin. TODO(comm): polling /dev/shm is Linux-specific and a mild
+        # hack; a consumer->producer ack (or folding shm into the DataRef
+        # lifecycle) is cleaner. shm is a cold CPU-only path after the cuda_ipc
+        # split, so this easy-win is intentionally not a full pool + ack channel.
+        try:
+            while os.path.exists(shm_path):
+                if loop.time() > deadline:
+                    raise TimeoutError(
+                        f"shm block {self._shm_name} was not consumed in time"
+                    )
+                if loop.time() < spin_deadline:
+                    await asyncio.sleep(0)
+                else:
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, _CONSUME_BACKOFF_MAX_SECONDS)
+        finally:
+            # Always release the credit, even on timeout, so an absent or crashed
+            # consumer cannot permanently leak a slot.
             self._completed = True
-        return
+            self._release_cb()
 
 
 class ShmGetOperation(ShmOperation):
@@ -138,15 +185,14 @@ class ShmRelay(Relay):
         if request_id is None:
             request_id = str(uuid.uuid4())
 
-        # Flow control
+        # Acquire a credit and HOLD it until the receiver consumes the block (real
+        # bounded-outstanding backpressure); it is released in
+        # ShmPutOperation.wait_for_completion once the block is unlinked.
         await self._sem.acquire()
 
         try:
-            # 1. Create SHM and write data
             shm = shm_create_from_tensor(tensor)
             size_bytes = shm.size
-
-            # 2. Construct Metadata
             metadata = {
                 "engine_id": self.engine_id,
                 "transfer_info": {
@@ -155,15 +201,16 @@ class ShmRelay(Relay):
                     "req_id": request_id,
                 },
             }
+            return ShmPutOperation(
+                metadata,
+                shm,
+                shm_name=shm.name,
+                release_cb=self._sem.release,
+            )
 
-            # 3. Release semaphore immediately (Fire-and-Forget model)
+        except Exception:
             self._sem.release()
-
-            return ShmPutOperation(metadata, shm)
-
-        except Exception as e:
-            self._sem.release()
-            raise e
+            raise
 
     async def get_async(
         self, metadata: Any, dest_tensor: torch.Tensor, request_id: str = None

--- a/sglang_omni/relay/shm.py
+++ b/sglang_omni/relay/shm.py
@@ -114,6 +114,14 @@ class ShmPutOperation(ShmOperation):
                 else:
                     await asyncio.sleep(delay)
                     delay = min(delay * 2, _CONSUME_BACKOFF_MAX_SECONDS)
+        except TimeoutError:
+            # Reclaim the named block before releasing credit so repeated absent
+            # consumers cannot fill /dev/shm.
+            try:
+                self._shm_obj.unlink()
+            except FileNotFoundError:
+                pass
+            raise
         finally:
             # Always release the credit, even on timeout, so an absent or crashed
             # consumer cannot permanently leak a slot.
@@ -158,7 +166,10 @@ class ShmGetOperation(ShmOperation):
             finally:
                 # 3. Cleanup (Receiver owns lifecycle)
                 existing_shm.close()
-                existing_shm.unlink()
+                try:
+                    existing_shm.unlink()
+                except FileNotFoundError:
+                    pass
 
         finally:
             self._completed = True

--- a/tests/unit_test/pipeline/test_comm_router.py
+++ b/tests/unit_test/pipeline/test_comm_router.py
@@ -19,8 +19,7 @@ def test_comm_router_uses_cuda_ipc_for_same_node_gpu_payload_edges() -> None:
 
     assert router.outbound("local") is TransportKind.LOCAL_OBJECT
     assert router.outbound("decode") is TransportKind.CUDA_IPC
-    with pytest.raises(ValueError, match="selected cuda_ipc"):
-        router.outbound_stream("decode", torch.empty(1))
+    assert router.outbound_stream("decode", torch.empty(1)) is TransportKind.SHM
 
 
 def test_comm_router_uses_mooncake_only_for_remote_edges() -> None:

--- a/tests/unit_test/pipeline/test_stage_streaming.py
+++ b/tests/unit_test/pipeline/test_stage_streaming.py
@@ -10,7 +10,7 @@ import torch
 from pydantic import ValidationError
 
 from sglang_omni.comm import stage_io
-from sglang_omni.comm.data_ref import DataRef, TransportKind
+from sglang_omni.comm.data_ref import DataKind, DataRef, TransportKind
 from sglang_omni.comm.engine import CommEngine
 from sglang_omni.config.schema import StageConfig
 from sglang_omni.models.fishaudio_s2_pro.config import S2ProPipelineConfig
@@ -105,20 +105,34 @@ async def _make_relay_chunk(
     data,
     metadata: dict | None = None,
 ) -> DataReadyMessage:
-    control_plane = _FakeControlPlane()
-    await stage_io.send_stream_chunk(
+    object_id = f"{request_id}:stream:{from_stage}:{to_stage}:{chunk_id}"
+    data_ref, op = await stage_io.write_tensor(
         relay,
-        control_plane,
-        request_id=request_id,
-        data=data,
-        target_stage=to_stage,
-        target_endpoint=f"inproc://{to_stage}",
-        from_stage=from_stage,
-        chunk_id=chunk_id,
-        metadata=metadata,
+        object_id,
+        data,
         transport=TransportKind.SHM,
+        kind=DataKind.STREAM_CHUNK,
+        request_id=request_id,
+        from_stage=from_stage,
+        to_stage=to_stage,
     )
-    return control_plane.stage_messages[0][2]
+    pending_ops = [op]
+    data_ref = await stage_io._with_stream_metadata(
+        relay,
+        data_ref,
+        metadata,
+        TransportKind.SHM,
+        pending_ops,
+    )
+    for pending_op in pending_ops:
+        asyncio.create_task(pending_op.wait_for_completion())
+    return DataReadyMessage(
+        request_id=request_id,
+        from_stage=from_stage,
+        to_stage=to_stage,
+        data_ref=data_ref.to_dict(),
+        chunk_id=chunk_id,
+    )
 
 
 async def _make_relay_payload(
@@ -134,7 +148,7 @@ async def _make_relay_payload(
         payload,
         transport=TransportKind.SHM,
     )
-    await op.wait_for_completion()
+    asyncio.create_task(op.wait_for_completion())
     return DataReadyMessage(
         request_id=payload.request_id,
         from_stage=from_stage,

--- a/tests/unit_test/relay/test_cuda_ipc_relay.py
+++ b/tests/unit_test/relay/test_cuda_ipc_relay.py
@@ -14,18 +14,93 @@ import multiprocessing as mp
 import pytest
 import torch
 
-from sglang_omni.relay.cuda_ipc import CudaIpcRelay
+from sglang_omni.relay.cuda_ipc import CudaIpcPutOperation, CudaIpcRelay
 
 _N = 1024 * 1024  # 1 MiB payload
+
+
+class _NeverAck:
+    def is_done(self, index: int) -> bool:
+        return False
 
 
 def _expected(n: int) -> torch.Tensor:
     return (torch.arange(n, dtype=torch.int64) % 251).to(torch.uint8)
 
 
+def test_cuda_ipc_put_timeout_fails_relay_without_releasing_slot() -> None:
+    released = False
+    failed: list[BaseException] = []
+
+    def release() -> None:
+        nonlocal released
+        released = True
+
+    async def run() -> None:
+        op = CudaIpcPutOperation(
+            metadata={},
+            ready_event=object(),  # type: ignore[arg-type]
+            source_tensor=object(),  # type: ignore[arg-type]
+            ack_map=_NeverAck(),  # type: ignore[arg-type]
+            ack_index=0,
+            request_id="r",
+            size=1,
+            release_cb=release,
+            fail_cb=failed.append,
+        )
+        with pytest.raises(TimeoutError, match="receiver did not ack"):
+            await op.wait_for_completion(timeout=0.0)
+
+    asyncio.run(run())
+
+    assert released is False
+    assert len(failed) == 1
+    assert isinstance(failed[0], TimeoutError)
+
+
+def test_cuda_ipc_relay_failure_wakes_blocked_slot_acquire() -> None:
+    class BlockingAllocator:
+        def __init__(self) -> None:
+            self.released: list[int] = []
+
+        async def acquire_async(self) -> int:
+            await asyncio.Event().wait()
+            return 0
+
+        def release(self, credit_id: int) -> None:
+            self.released.append(credit_id)
+
+    async def run() -> BlockingAllocator:
+        relay = CudaIpcRelay(engine_id="sender", device="cuda:0")
+        allocator = BlockingAllocator()
+        task = asyncio.create_task(relay._acquire_slot(allocator))
+        await asyncio.sleep(0)
+        relay._mark_failed(TimeoutError("ack timeout"))
+        with pytest.raises(RuntimeError, match="cuda_ipc relay failed"):
+            await task
+        return allocator
+
+    allocator = asyncio.run(run())
+    assert allocator.released == []
+
+
+def test_cuda_ipc_put_fails_fast_after_relay_failure() -> None:
+    async def run() -> None:
+        relay = CudaIpcRelay(engine_id="sender", device="cuda:0")
+        relay._mark_failed(TimeoutError("ack timeout"))
+        with pytest.raises(RuntimeError, match="cuda_ipc relay failed"):
+            await relay.put_async(torch.zeros(1, dtype=torch.uint8))
+
+    asyncio.run(run())
+
+
 def _sender(src_gpu: int, meta_q: mp.Queue, done_q: mp.Queue) -> None:
     torch.cuda.set_device(src_gpu)
-    relay = CudaIpcRelay(engine_id="sender", device=f"cuda:{src_gpu}")
+    relay = CudaIpcRelay(
+        engine_id="sender",
+        device=f"cuda:{src_gpu}",
+        slot_size_mb=2,
+    )
     buf = _expected(_N).to(f"cuda:{src_gpu}")
 
     async def run() -> None:

--- a/tests/unit_test/relay/test_shm_relay.py
+++ b/tests/unit_test/relay/test_shm_relay.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+import torch
+
+from sglang_omni.relay.shm import ShmRelay
+
+
+def test_shm_put_timeout_unlinks_block_and_releases_credit() -> None:
+    async def run() -> None:
+        relay = ShmRelay(engine_id="sender", device="cpu", credits=1)
+        tensor = torch.arange(16, dtype=torch.uint8)
+        op = await relay.put_async(tensor, request_id="r0")
+        shm_name = op.metadata["transfer_info"]["shm_name"]
+        shm_path = f"/dev/shm/{shm_name}"
+
+        assert os.path.exists(shm_path)
+        with pytest.raises(TimeoutError, match="was not consumed in time"):
+            await op.wait_for_completion(timeout=0.0)
+        assert not os.path.exists(shm_path)
+
+        # The timeout path released the semaphore credit; another put should not
+        # block even though the first transfer failed.
+        op2 = await asyncio.wait_for(
+            relay.put_async(tensor, request_id="r1"),
+            timeout=1.0,
+        )
+        shm_name2 = op2.metadata["transfer_info"]["shm_name"]
+        shm_path2 = f"/dev/shm/{shm_name2}"
+        try:
+            assert os.path.exists(shm_path2)
+        finally:
+            with pytest.raises(TimeoutError):
+                await op2.wait_for_completion(timeout=0.0)
+            assert not os.path.exists(shm_path2)
+
+    asyncio.run(run())


### PR DESCRIPTION
Stacked on #869 — this PR targets the `phase0-intra-node-nvlink-relay` branch, so merging it folds these commits into #869; `main` is unaffected until #869 itself lands.

Three focused, independently reviewable fixes to the Phase-0 intra-node data plane (one commit each). Full rationale is in each commit message.

### 1. `fix(relay/cuda_ipc)` — completion busy-spin + credit leak on timeout
The CUDA-IPC completion wait polled with a loop calling `await asyncio.sleep(0)`, which never sleeps — pegging the event-loop thread at 100% CPU and hammering `cudaEventQuery` (driver-lock contention that steals CPU from kernel launches, the opposite of what a host/CPU-dispatch-bound server wants; cf. #907). Separately, on the 30s timeout the sender slot was never released, permanently leaking 1 of only 2 credits and eventually deadlocking puts. Fix: a shared spin-then-backoff helper (a short spin catches the common fast completion with no added latency; exponential backoff frees the CPU on slow/hung transfers) plus release-the-slot-on-timeout. The spin/backoff constants are provisional defaults — see the test & measurement plan comment. A `TODO(comm)` is left for a truly event-driven wait (eventfd + `add_reader`, or a named pipe).

### 2. `fix(comm/router)` — transport follows the actual tensor device
`CommRouter.outbound_stream` raised when a GPU-placed edge carried a CPU-resident chunk; it now falls back to SHM (the host transport) instead. Transport selection follows the actual tensor device, not placement alone. Also documents the same-node invariant in `_physical_outbound`. (Fixes the router half of the CPU-tensor review thread; the `stage_io` stream-metadata device round-trip is a separate follow-up.)

### 3. `fix(relay/shm)` — real bounded-outstanding backpressure
`ShmRelay` acquired its flow-control credit and released it immediately (fire-and-forget), so the semaphore provided no backpressure. The credit is now held until the receiver consumes the block — reusing the `unlink` the receiver already performs as the ack (poll `/dev/shm` with spin+backoff), and released on timeout too so an absent consumer cannot leak a slot. No new ack channel and no pre-allocated pool; deliberately scoped to the cold, CPU-only path (bulk tensors go via cuda_ipc/mooncake). Verified that every shm put path awaits completion, so the held credit is always released.

Not covered here (follow-ups): the `stage_io` stream-metadata device round-trip, the TensorRef port, and cross-node activation.
