### PR TITLE
[Feature] Add Prometheus metrics endpoint for Omni API server

### DIFF
--- a/docs/developer_reference/main.md
+++ b/docs/developer_reference/main.md
@@ -20,6 +20,7 @@ HTTP API -> Client -> Coordinator -> Stage -> Scheduler -> ModelRunner -> model 
 | [Scheduler](./pipeline.md)        | Per-stage execution loop and failure propagation to stage outbox                       |
 | [ModelRunner](./pipeline.md)      | AR forward preparation, model forward dispatch, output extraction                      |
 | [Communication](./communication.md) | Control-plane messages and relay data transfer between stages                         |
+| [Metrics](./metrics.md)            | Optional Prometheus metrics for the Omni API/coordinator layer                        |
 | [TTS Integration](./tts_model_integration.md) | Checklist and lifecycle rules for adding TTS model families                         |
 
 Refer to the layer-specific document for specific design details.

--- a/docs/developer_reference/metrics.md
+++ b/docs/developer_reference/metrics.md
@@ -1,0 +1,32 @@
+# Prometheus Metrics
+
+SGLang-Omni can expose an optional Prometheus-compatible `/metrics` endpoint
+for the Omni API/coordinator layer.
+
+Start the server with:
+
+```bash
+sgl-omni serve ... --enable-metrics
+```
+
+Scrape:
+
+```bash
+curl http://localhost:8000/metrics
+```
+
+This endpoint currently exposes low-cardinality Omni API/coordinator metrics
+only. It does not enable, proxy, or aggregate underlying SGLang stage-level
+metrics.
+
+The endpoint intentionally does not expose request IDs, prompts, file paths,
+voice names, or arbitrary user input as Prometheus labels. HTTP request metrics
+also omit `model_name`; an Omni API server process serves one configured model,
+and Prometheus target labels such as `job` and `instance` should identify the
+scrape target.
+
+The HTTP duration histogram measures request handler duration. For streaming
+responses, it does not represent full end-to-end stream duration.
+
+For GPU and system metrics, use infrastructure exporters such as DCGM exporter,
+node exporter, cAdvisor, or kube-state-metrics.

--- a/docs/developer_reference/metrics.md
+++ b/docs/developer_reference/metrics.md
@@ -21,9 +21,8 @@ metrics.
 
 The endpoint intentionally does not expose request IDs, prompts, file paths,
 voice names, or arbitrary user input as Prometheus labels. HTTP request metrics
-also omit `model_name`; an Omni API server process serves one configured model,
-and Prometheus target labels such as `job` and `instance` should identify the
-scrape target.
+include the service-level `model_name` label so Kubernetes deployments with many
+Omni API server replicas can aggregate request rates and latency by model.
 
 The HTTP duration histogram measures request handler duration. For streaming
 responses, it does not represent full end-to-end stream duration.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -140,6 +140,7 @@ Supported Models
    developer_reference/config.md
    developer_reference/communication.md
    developer_reference/reference_encode_service.md
+   developer_reference/metrics.md
    developer_reference/profiler.md
    developer_reference/qwen3_asr_concurrency_profile.md
    developer_reference/rl_admin_control.md

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -1279,6 +1279,14 @@ def serve(
             help="Mount the OpenAI Realtime WebSocket endpoint at /v1/realtime.",
         ),
     ] = False,
+    enable_metrics: Annotated[
+        bool,
+        typer.Option(
+            "--enable-metrics",
+            "--enable_metrics",
+            help="Expose the Prometheus-compatible /metrics endpoint.",
+        ),
+    ] = False,
     decode_mode: Annotated[
         str | None,
         typer.Option(
@@ -1504,6 +1512,7 @@ def serve(
         model_name=model_name,
         log_level=log_level,
         enable_realtime=enable_realtime,
+        enable_metrics=enable_metrics,
         allowed_local_media_path=_validate_allowed_local_media_path(
             allowed_local_media_path
         ),

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -1284,7 +1284,11 @@ def serve(
         typer.Option(
             "--enable-metrics",
             "--enable_metrics",
-            help="Expose the Prometheus-compatible /metrics endpoint.",
+            help=(
+                "Expose the Omni API/coordinator Prometheus-compatible "
+                "/metrics endpoint. This does not enable or aggregate "
+                "underlying SGLang stage metrics."
+            ),
         ),
     ] = False,
     decode_mode: Annotated[

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -524,7 +524,9 @@ def launch_server(
             :class:`~sglang_omni.client.Client`.
         enable_realtime: If True, mount the WebSocket ``/v1/realtime``
             endpoint (OpenAI Realtime API).
-        enable_metrics: If True, expose the Prometheus ``/metrics`` endpoint.
+        enable_metrics: If True, expose the Omni API/coordinator Prometheus
+            ``/metrics`` endpoint. This does not enable or aggregate
+            underlying SGLang stage metrics.
         allowed_local_media_path: Directory allowed for ``file://`` media
             references in TTS requests.
         allowed_media_domains: Domains allowed for remote TTS reference audio.

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -372,6 +372,7 @@ async def _run_server(
     log_level: str = "info",
     client_kwargs: dict[str, Any] | None = None,
     enable_realtime: bool = False,
+    enable_metrics: bool = False,
     allowed_local_media_path: str | None = None,
     allowed_media_domains: list[str] | None = None,
     tts_batch_max_items: int = DEFAULT_TTS_BATCH_MAX_ITEMS,
@@ -432,6 +433,7 @@ async def _run_server(
             supports_realtime_audio_output=(
                 type(pipeline_config).code2wav_stage() is not None
             ),
+            enable_metrics=enable_metrics,
             allowed_local_media_path=allowed_local_media_path,
             allowed_media_domains=allowed_media_domains,
             tts_batch_max_items=tts_batch_max_items,
@@ -504,6 +506,7 @@ def launch_server(
     log_level: str = "info",
     client_kwargs: dict[str, Any] | None = None,
     enable_realtime: bool = False,
+    enable_metrics: bool = False,
     allowed_local_media_path: str | None = None,
     allowed_media_domains: list[str] | None = None,
     tts_batch_max_items: int = DEFAULT_TTS_BATCH_MAX_ITEMS,
@@ -521,6 +524,7 @@ def launch_server(
             :class:`~sglang_omni.client.Client`.
         enable_realtime: If True, mount the WebSocket ``/v1/realtime``
             endpoint (OpenAI Realtime API).
+        enable_metrics: If True, expose the Prometheus ``/metrics`` endpoint.
         allowed_local_media_path: Directory allowed for ``file://`` media
             references in TTS requests.
         allowed_media_domains: Domains allowed for remote TTS reference audio.
@@ -537,6 +541,7 @@ def launch_server(
             log_level=log_level,
             client_kwargs=client_kwargs,
             enable_realtime=enable_realtime,
+            enable_metrics=enable_metrics,
             allowed_local_media_path=allowed_local_media_path,
             allowed_media_domains=allowed_media_domains,
             tts_batch_max_items=tts_batch_max_items,

--- a/sglang_omni/serve/metrics.py
+++ b/sglang_omni/serve/metrics.py
@@ -43,7 +43,10 @@ GAUGE_FAMILIES = (
     MetricFamily(
         "sglang_omni_pipeline_tracked_requests",
         "gauge",
-        "Number of requests tracked by the Omni coordinator health snapshot.",
+        (
+            "Number of currently tracked requests according to the Omni "
+            "coordinator health snapshot."
+        ),
     ),
     MetricFamily(
         "sglang_omni_pipeline_pending_completions",
@@ -69,7 +72,11 @@ HTTP_REQUESTS_FAMILY = MetricFamily(
 HTTP_DURATION_FAMILY = MetricFamily(
     "sglang_omni_http_request_duration_seconds",
     "histogram",
-    "HTTP request handler duration in seconds for the Omni API server.",
+    (
+        "HTTP handler duration in seconds for the Omni API server. "
+        "For streaming responses, this does not represent full end-to-end "
+        "stream duration."
+    ),
 )
 METRIC_FAMILIES = (*GAUGE_FAMILIES, HTTP_REQUESTS_FAMILY, HTTP_DURATION_FAMILY)
 GAUGE_FAMILY_NAMES = frozenset(family.name for family in GAUGE_FAMILIES)
@@ -132,8 +139,10 @@ class OmniPrometheusMetrics:
                     {"model_name": self.model_name, "state": state_label},
                     state_value,
                 )
-        else:
+        elif "total_requests" in info:
             tracked_requests = _float_or_zero(info.get("total_requests"))
+        else:
+            tracked_requests = 0.0
 
         self._set_gauge(
             "sglang_omni_pipeline_tracked_requests",

--- a/sglang_omni/serve/metrics.py
+++ b/sglang_omni/serve/metrics.py
@@ -1,0 +1,329 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import math
+import time
+from collections import defaultdict
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import FastAPI, Request, Response
+
+PROMETHEUS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+DEFAULT_DURATION_BUCKETS = (
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+)
+
+
+@dataclass(frozen=True)
+class MetricFamily:
+    name: str
+    metric_type: str
+    help_text: str
+
+
+GAUGE_FAMILIES = (
+    MetricFamily(
+        "sglang_omni_pipeline_running",
+        "gauge",
+        "Whether the Omni coordinator reports the pipeline as running.",
+    ),
+    MetricFamily(
+        "sglang_omni_pipeline_tracked_requests",
+        "gauge",
+        "Number of requests tracked by the Omni coordinator health snapshot.",
+    ),
+    MetricFamily(
+        "sglang_omni_pipeline_pending_completions",
+        "gauge",
+        "Number of pending completions reported by the Omni coordinator.",
+    ),
+    MetricFamily(
+        "sglang_omni_request_states",
+        "gauge",
+        "Number of Omni requests by coordinator state.",
+    ),
+    MetricFamily(
+        "sglang_omni_stage_present",
+        "gauge",
+        "Whether a stage is present in the Omni coordinator health snapshot.",
+    ),
+)
+HTTP_REQUESTS_FAMILY = MetricFamily(
+    "sglang_omni_http_requests_total",
+    "counter",
+    "Total number of HTTP requests handled by the Omni API server.",
+)
+HTTP_DURATION_FAMILY = MetricFamily(
+    "sglang_omni_http_request_duration_seconds",
+    "histogram",
+    "HTTP request handler duration in seconds for the Omni API server.",
+)
+METRIC_FAMILIES = (*GAUGE_FAMILIES, HTTP_REQUESTS_FAMILY, HTTP_DURATION_FAMILY)
+GAUGE_FAMILY_NAMES = frozenset(family.name for family in GAUGE_FAMILIES)
+
+
+class OmniPrometheusMetrics:
+    """Small app-local Prometheus text renderer for the Omni API server."""
+
+    def __init__(
+        self,
+        model_name: str = "unknown",
+        *,
+        duration_buckets: tuple[float, ...] = DEFAULT_DURATION_BUCKETS,
+    ) -> None:
+        self.model_name = model_name or "unknown"
+        self.duration_buckets = tuple(
+            sorted(float(bucket) for bucket in duration_buckets)
+        )
+        self._gauges: dict[tuple[str, tuple[tuple[str, str], ...]], float] = {}
+        self._known_states: set[str] = set()
+        self._known_stages: set[str] = set()
+        self._http_requests_total: defaultdict[tuple[str, str, str], float] = defaultdict(
+            float
+        )
+        self._http_duration_count: defaultdict[tuple[str, str], float] = defaultdict(float)
+        self._http_duration_sum: defaultdict[tuple[str, str], float] = defaultdict(float)
+        self._http_duration_buckets: defaultdict[tuple[str, str, float], float] = (
+            defaultdict(float)
+        )
+
+    def update_from_health(self, info: Mapping[str, Any]) -> None:
+        model_labels = {"model_name": self.model_name}
+        self._set_gauge(
+            "sglang_omni_pipeline_running",
+            model_labels,
+            1.0 if info.get("running") else 0.0,
+        )
+        self._set_gauge(
+            "sglang_omni_pipeline_pending_completions",
+            model_labels,
+            _float_or_zero(info.get("pending_completions")),
+        )
+
+        request_states = info.get("request_states") or {}
+        if isinstance(request_states, Mapping):
+            tracked_requests = 0.0
+            for state in self._known_states:
+                self._set_gauge(
+                    "sglang_omni_request_states",
+                    {"model_name": self.model_name, "state": state},
+                    0.0,
+                )
+            for state, value in request_states.items():
+                state_label = str(state)
+                state_value = _float_or_zero(value)
+                tracked_requests += state_value
+                self._known_states.add(state_label)
+                self._set_gauge(
+                    "sglang_omni_request_states",
+                    {"model_name": self.model_name, "state": state_label},
+                    state_value,
+                )
+        else:
+            tracked_requests = _float_or_zero(info.get("total_requests"))
+
+        self._set_gauge(
+            "sglang_omni_pipeline_tracked_requests",
+            model_labels,
+            tracked_requests,
+        )
+
+        stages = info.get("stages") or []
+        if isinstance(stages, list):
+            for stage in self._known_stages:
+                self._set_gauge(
+                    "sglang_omni_stage_present",
+                    {"model_name": self.model_name, "stage": stage},
+                    0.0,
+                )
+            for stage in stages:
+                stage_label = str(stage)
+                self._known_stages.add(stage_label)
+                self._set_gauge(
+                    "sglang_omni_stage_present",
+                    {"model_name": self.model_name, "stage": stage_label},
+                    1.0,
+                )
+
+    def observe_http_request(
+        self,
+        *,
+        method: str,
+        route: str,
+        status: str,
+        duration_seconds: float,
+    ) -> None:
+        duration_seconds = max(float(duration_seconds), 0.0)
+        self._http_requests_total[(method, route, status)] += 1.0
+        self._http_duration_count[(method, route)] += 1.0
+        self._http_duration_sum[(method, route)] += duration_seconds
+        for bucket in self.duration_buckets:
+            if duration_seconds <= bucket:
+                self._http_duration_buckets[(method, route, bucket)] += 1.0
+
+    def render(self) -> Response:
+        return Response(
+            content=self.render_text(),
+            media_type=PROMETHEUS_CONTENT_TYPE,
+        )
+
+    def render_text(self) -> str:
+        lines: list[str] = []
+        for family in METRIC_FAMILIES:
+            lines.extend(_render_family_header(family))
+            lines.extend(self._render_family_samples(family.name))
+        return "\n".join(lines) + "\n"
+
+    def _set_gauge(self, name: str, labels: Mapping[str, str], value: float) -> None:
+        self._gauges[(name, _label_tuple(labels))] = float(value)
+
+    def _render_gauge_samples(self, name: str) -> list[str]:
+        samples = [
+            (labels, value)
+            for (sample_name, labels), value in self._gauges.items()
+            if sample_name == name
+        ]
+        return [
+            _render_sample(name, dict(labels), value)
+            for labels, value in sorted(samples, key=lambda item: item[0])
+        ]
+
+    def _render_family_samples(self, name: str) -> list[str]:
+        if name in GAUGE_FAMILY_NAMES:
+            return self._render_gauge_samples(name)
+        if name == HTTP_REQUESTS_FAMILY.name:
+            return self._render_http_request_samples()
+        if name == HTTP_DURATION_FAMILY.name:
+            return self._render_http_duration_samples()
+        raise AssertionError(f"unknown metric family: {name}")
+
+    def _render_http_request_samples(self) -> list[str]:
+        lines = []
+        for method, route, status in sorted(self._http_requests_total):
+            lines.append(
+                _render_sample(
+                    "sglang_omni_http_requests_total",
+                    {"method": method, "route": route, "status": status},
+                    self._http_requests_total[(method, route, status)],
+                )
+            )
+        return lines
+
+    def _render_http_duration_samples(self) -> list[str]:
+        lines = []
+        for method, route in sorted(self._http_duration_count):
+            base_labels = {"method": method, "route": route}
+            for bucket in self.duration_buckets:
+                lines.append(
+                    _render_sample(
+                        "sglang_omni_http_request_duration_seconds_bucket",
+                        {**base_labels, "le": _format_bucket(bucket)},
+                        self._http_duration_buckets[(method, route, bucket)],
+                    )
+                )
+            lines.append(
+                _render_sample(
+                    "sglang_omni_http_request_duration_seconds_bucket",
+                    {**base_labels, "le": "+Inf"},
+                    self._http_duration_count[(method, route)],
+                )
+            )
+            lines.append(
+                _render_sample(
+                    "sglang_omni_http_request_duration_seconds_count",
+                    base_labels,
+                    self._http_duration_count[(method, route)],
+                )
+            )
+            lines.append(
+                _render_sample(
+                    "sglang_omni_http_request_duration_seconds_sum",
+                    base_labels,
+                    self._http_duration_sum[(method, route)],
+                )
+            )
+        return lines
+
+
+def install_metrics_middleware(app: FastAPI) -> None:
+    @app.middleware("http")
+    async def prometheus_metrics_middleware(request: Request, call_next):
+        metrics: OmniPrometheusMetrics | None = getattr(app.state, "omni_metrics", None)
+        if metrics is None or request.url.path == "/metrics":
+            return await call_next(request)
+
+        start = time.perf_counter()
+        status = "500"
+        try:
+            response = await call_next(request)
+            status = str(response.status_code)
+            return response
+        finally:
+            route = request.scope.get("route")
+            route_path = getattr(route, "path", None) or "__unmatched__"
+            metrics.observe_http_request(
+                method=request.method,
+                route=route_path,
+                status=status,
+                duration_seconds=time.perf_counter() - start,
+            )
+
+
+def _render_family_header(family: MetricFamily) -> list[str]:
+    return [
+        f"# HELP {family.name} {family.help_text}",
+        f"# TYPE {family.name} {family.metric_type}",
+    ]
+
+
+def _render_sample(name: str, labels: Mapping[str, str], value: float) -> str:
+    rendered_labels = ",".join(
+        f'{key}="{_escape_label_value(value)}"'
+        for key, value in sorted(labels.items())
+    )
+    suffix = f"{{{rendered_labels}}}" if rendered_labels else ""
+    return f"{name}{suffix} {_format_value(value)}"
+
+
+def _label_tuple(labels: Mapping[str, str]) -> tuple[tuple[str, str], ...]:
+    return tuple(sorted((key, str(value)) for key, value in labels.items()))
+
+
+def _escape_label_value(value: str) -> str:
+    return str(value).replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
+
+
+def _float_or_zero(value: Any) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if math.isfinite(result):
+        return result
+    return 0.0
+
+
+def _format_bucket(value: float) -> str:
+    return f"{value:g}"
+
+
+def _format_value(value: float) -> str:
+    value = float(value)
+    if value == 0:
+        return "0.0"
+    if value.is_integer():
+        return f"{value:.1f}"
+    return f"{value:.17g}"

--- a/sglang_omni/serve/metrics.py
+++ b/sglang_omni/serve/metrics.py
@@ -98,11 +98,15 @@ class OmniPrometheusMetrics:
         self._gauges: dict[tuple[str, tuple[tuple[str, str], ...]], float] = {}
         self._known_states: set[str] = set()
         self._known_stages: set[str] = set()
-        self._http_requests_total: defaultdict[tuple[str, str, str], float] = defaultdict(
+        self._http_requests_total: defaultdict[tuple[str, str, str], float] = (
+            defaultdict(float)
+        )
+        self._http_duration_count: defaultdict[tuple[str, str], float] = defaultdict(
             float
         )
-        self._http_duration_count: defaultdict[tuple[str, str], float] = defaultdict(float)
-        self._http_duration_sum: defaultdict[tuple[str, str], float] = defaultdict(float)
+        self._http_duration_sum: defaultdict[tuple[str, str], float] = defaultdict(
+            float
+        )
         self._http_duration_buckets: defaultdict[tuple[str, str, float], float] = (
             defaultdict(float)
         )
@@ -225,7 +229,12 @@ class OmniPrometheusMetrics:
             lines.append(
                 _render_sample(
                     "sglang_omni_http_requests_total",
-                    {"method": method, "route": route, "status": status},
+                    {
+                        "method": method,
+                        "model_name": self.model_name,
+                        "route": route,
+                        "status": status,
+                    },
                     self._http_requests_total[(method, route, status)],
                 )
             )
@@ -234,7 +243,11 @@ class OmniPrometheusMetrics:
     def _render_http_duration_samples(self) -> list[str]:
         lines = []
         for method, route in sorted(self._http_duration_count):
-            base_labels = {"method": method, "route": route}
+            base_labels = {
+                "method": method,
+                "model_name": self.model_name,
+                "route": route,
+            }
             for bucket in self.duration_buckets:
                 lines.append(
                     _render_sample(
@@ -300,8 +313,7 @@ def _render_family_header(family: MetricFamily) -> list[str]:
 
 def _render_sample(name: str, labels: Mapping[str, str], value: float) -> str:
     rendered_labels = ",".join(
-        f'{key}="{_escape_label_value(value)}"'
-        for key, value in sorted(labels.items())
+        f'{key}="{_escape_label_value(value)}"' for key, value in sorted(labels.items())
     )
     suffix = f"{{{rendered_labels}}}" if rendered_labels else ""
     return f"{name}{suffix} {_format_value(value)}"

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -14,6 +14,7 @@ Provides the following endpoints:
 - GET  /v1/fs/list           — Browse filesystem directories
 - GET  /v1/fs/file           — Download a file
 - GET  /health               — Health check
+- GET  /metrics              — Prometheus metrics (when enabled)
 - WS   /v1/realtime          — OpenAI-compatible Realtime API (when enabled)
 """
 
@@ -65,6 +66,7 @@ from sglang_omni.http.favicon import register_favicon
 from sglang_omni.serve.generation_params import (
     record_explicit_generation_params as _record_explicit_generation_params,
 )
+from sglang_omni.serve.metrics import OmniPrometheusMetrics, install_metrics_middleware
 from sglang_omni.serve.openai_errors import (
     is_bad_request_error as _is_bad_request_error,
 )
@@ -186,6 +188,7 @@ def create_app(
     tts_batch_max_items: int = DEFAULT_TTS_BATCH_MAX_ITEMS,
     architectures: list[str] | None = None,
     audio_chunking: AudioChunkingConfig | None = None,
+    enable_metrics: bool = False,
 ) -> FastAPI:
     """Create a FastAPI application with OpenAI-compatible endpoints.
 
@@ -213,6 +216,8 @@ def create_app(
             ``/v1/audio/speech/batch``.
         audio_chunking: Long-audio chunking policy for ``/v1/audio/transcriptions``,
             declared by the pipeline config. None keeps chunking off.
+        enable_metrics: If True, expose a Prometheus-compatible ``/metrics``
+            endpoint and collect low-cardinality API metrics.
 
     Returns:
         Configured FastAPI application.
@@ -257,9 +262,14 @@ def create_app(
     )
 
     resolved_key = resolve_admin_api_key(admin_api_key)
+    if enable_metrics:
+        app.state.omni_metrics = OmniPrometheusMetrics(model_name=app.state.model_name)
+        install_metrics_middleware(app)
 
     # Register all routes
     register_favicon(app)
+    if enable_metrics:
+        _register_metrics(app)
     _register_health(app)
     _register_models(app)
     _register_admin(app, resolved_key)
@@ -382,6 +392,16 @@ async def _send_voice_upload_too_large(
         }
     )
     await send({"type": "http.response.body", "body": body})
+
+
+def _register_metrics(app: FastAPI) -> None:
+    @app.get("/metrics")
+    async def metrics() -> Response:
+        """Prometheus-compatible metrics endpoint."""
+        omni_metrics: OmniPrometheusMetrics = app.state.omni_metrics
+        client: Client = app.state.client
+        omni_metrics.update_from_health(client.health())
+        return omni_metrics.render()
 
 
 def _register_health(app: FastAPI) -> None:

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -395,7 +395,7 @@ async def _send_voice_upload_too_large(
 
 
 def _register_metrics(app: FastAPI) -> None:
-    @app.get("/metrics")
+    @app.get("/metrics", include_in_schema=False)
     async def metrics() -> Response:
         """Prometheus-compatible metrics endpoint."""
         omni_metrics: OmniPrometheusMetrics = app.state.omni_metrics

--- a/tests/unit_test/serve/test_metrics.py
+++ b/tests/unit_test/serve/test_metrics.py
@@ -215,3 +215,30 @@ def test_metrics_instances_do_not_share_state() -> None:
     assert 'model_name="second-model"' not in first_metrics
     assert 'model_name="second-model"' in second_metrics
     assert 'model_name="first-model"' not in second_metrics
+
+
+def test_rendered_metrics_are_parseable_when_prometheus_client_is_available() -> None:
+    prometheus_parser = pytest.importorskip("prometheus_client.parser")
+    metrics = OmniPrometheusMetrics(model_name="moss-tts-local-v15")
+
+    metrics.update_from_health(MetricsClient().health())
+    metrics.observe_http_request(
+        method="GET",
+        route="/health",
+        status="200",
+        duration_seconds=0.01,
+    )
+
+    families = list(
+        prometheus_parser.text_string_to_metric_families(metrics.render_text())
+    )
+    family_names = {family.name for family in families}
+    sample_names = {
+        sample.name
+        for family in families
+        for sample in getattr(family, "samples", ())
+    }
+
+    assert "sglang_omni_pipeline_running" in family_names
+    assert "sglang_omni_http_requests_total" in sample_names
+    assert "sglang_omni_http_request_duration_seconds_bucket" in sample_names

--- a/tests/unit_test/serve/test_metrics.py
+++ b/tests/unit_test/serve/test_metrics.py
@@ -67,8 +67,7 @@ def test_metrics_endpoint_renders_snapshot_when_enabled_and_api_importable() -> 
     assert resp.status_code == 200
     assert resp.headers["content-type"].startswith("text/plain")
     assert (
-        'sglang_omni_pipeline_running{model_name="moss-tts-local-v15"} 1.0'
-        in resp.text
+        'sglang_omni_pipeline_running{model_name="moss-tts-local-v15"} 1.0' in resp.text
     )
 
 
@@ -93,10 +92,7 @@ def test_coordinator_snapshot_gauges_reset_missing_state_and_stage() -> None:
     )
     text = metrics.render_text()
 
-    assert (
-        'sglang_omni_pipeline_running{model_name="moss-tts-local-v15"} 1.0'
-        in text
-    )
+    assert 'sglang_omni_pipeline_running{model_name="moss-tts-local-v15"} 1.0' in text
     assert (
         'sglang_omni_pipeline_tracked_requests{model_name="moss-tts-local-v15"} 1.0'
         in text
@@ -143,8 +139,8 @@ def test_histogram_buckets_are_cumulative() -> None:
     assert _http_duration_bucket(le="0.025") + " 1.0" in text
     assert _http_duration_bucket(le="+Inf") + " 1.0" in text
     assert (
-        'sglang_omni_http_request_duration_seconds_count{method="POST",route="/v1/audio/speech"} 1.0'
-        in text
+        'sglang_omni_http_request_duration_seconds_count{method="POST",'
+        'model_name="moss-tts-local-v15",route="/v1/audio/speech"} 1.0' in text
     )
 
 
@@ -188,16 +184,18 @@ def test_http_middleware_records_statuses_routes_and_skips_metrics_scrape() -> N
 
 def _http_duration_bucket(*, le: str) -> str:
     return (
-        'sglang_omni_http_request_duration_seconds_bucket{'
-        f'le="{le}",method="POST",route="/v1/audio/speech"'
+        "sglang_omni_http_request_duration_seconds_bucket{"
+        f'le="{le}",method="POST",model_name="moss-tts-local-v15",'
+        'route="/v1/audio/speech"'
         "}"
     )
 
 
 def _http_requests_total(*, route: str, status: str) -> str:
     return (
-        'sglang_omni_http_requests_total{'
-        f'method="GET",route="{route}",status="{status}"'
+        "sglang_omni_http_requests_total{"
+        f'method="GET",model_name="moss-tts-local-v15",route="{route}",'
+        f'status="{status}"'
         "}"
     )
 
@@ -234,9 +232,7 @@ def test_rendered_metrics_are_parseable_when_prometheus_client_is_available() ->
     )
     family_names = {family.name for family in families}
     sample_names = {
-        sample.name
-        for family in families
-        for sample in getattr(family, "samples", ())
+        sample.name for family in families for sample in getattr(family, "samples", ())
     }
 
     assert "sglang_omni_pipeline_running" in family_names

--- a/tests/unit_test/serve/test_metrics.py
+++ b/tests/unit_test/serve/test_metrics.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, Response
+from fastapi.testclient import TestClient
+
+from sglang_omni.serve.metrics import (
+    OmniPrometheusMetrics,
+    _render_sample,
+    install_metrics_middleware,
+)
+
+
+class MetricsClient:
+    def __init__(self, snapshots: list[dict[str, Any]] | None = None) -> None:
+        self.snapshots = snapshots or [
+            {
+                "running": True,
+                "stages": ["preprocess", "tts_engine"],
+                "entry_stage": "preprocess",
+                "total_requests": 3,
+                "pending_completions": 2,
+                "request_states": {"running": 2, "queued": 1},
+            }
+        ]
+        self.health_calls = 0
+
+    def health(self) -> dict[str, Any]:
+        index = min(self.health_calls, len(self.snapshots) - 1)
+        self.health_calls += 1
+        return self.snapshots[index]
+
+
+def create_metrics_app(*args: Any, **kwargs: Any):
+    pytest.importorskip("torch")
+    from sglang_omni.serve.openai_api import create_app
+
+    return create_app(*args, **kwargs)
+
+
+def test_metrics_endpoint_disabled_by_default_when_api_importable() -> None:
+    client = TestClient(
+        create_metrics_app(MetricsClient(), model_name="moss-tts-local-v15")
+    )
+
+    resp = client.get("/metrics")
+
+    assert resp.status_code == 404
+
+
+def test_metrics_endpoint_renders_snapshot_when_enabled_and_api_importable() -> None:
+    client_impl = MetricsClient()
+    client = TestClient(
+        create_metrics_app(
+            client_impl,
+            model_name="moss-tts-local-v15",
+            enable_metrics=True,
+        )
+    )
+
+    resp = client.get("/metrics")
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/plain")
+    assert (
+        'sglang_omni_pipeline_running{model_name="moss-tts-local-v15"} 1.0'
+        in resp.text
+    )
+
+
+def test_coordinator_snapshot_gauges_reset_missing_state_and_stage() -> None:
+    metrics = OmniPrometheusMetrics(model_name="moss-tts-local-v15")
+
+    metrics.update_from_health(
+        {
+            "running": True,
+            "stages": ["preprocess", "tts_engine"],
+            "pending_completions": 1,
+            "request_states": {"running": 1, "queued": 2},
+        }
+    )
+    metrics.update_from_health(
+        {
+            "running": True,
+            "stages": ["preprocess"],
+            "pending_completions": 0,
+            "request_states": {"running": 1},
+        }
+    )
+    text = metrics.render_text()
+
+    assert (
+        'sglang_omni_pipeline_running{model_name="moss-tts-local-v15"} 1.0'
+        in text
+    )
+    assert (
+        'sglang_omni_pipeline_tracked_requests{model_name="moss-tts-local-v15"} 1.0'
+        in text
+    )
+    assert (
+        'sglang_omni_pipeline_pending_completions{model_name="moss-tts-local-v15"} 0.0'
+        in text
+    )
+    assert (
+        'sglang_omni_request_states{model_name="moss-tts-local-v15",state="queued"} 0.0'
+        in text
+    )
+    assert (
+        'sglang_omni_stage_present{model_name="moss-tts-local-v15",stage="tts_engine"} 0.0'
+        in text
+    )
+
+
+def test_label_keys_are_sorted_and_values_are_escaped() -> None:
+    sample = _render_sample(
+        "sample_metric",
+        {"z_label": 'quote"slash\\newline\n', "a_label": "first"},
+        1,
+    )
+
+    assert (
+        sample
+        == 'sample_metric{a_label="first",z_label="quote\\"slash\\\\newline\\n"} 1.0'
+    )
+
+
+def test_histogram_buckets_are_cumulative() -> None:
+    metrics = OmniPrometheusMetrics(model_name="moss-tts-local-v15")
+
+    metrics.observe_http_request(
+        method="POST",
+        route="/v1/audio/speech",
+        status="200",
+        duration_seconds=0.02,
+    )
+    text = metrics.render_text()
+
+    assert _http_duration_bucket(le="0.01") + " 0.0" in text
+    assert _http_duration_bucket(le="0.025") + " 1.0" in text
+    assert _http_duration_bucket(le="+Inf") + " 1.0" in text
+    assert (
+        'sglang_omni_http_request_duration_seconds_count{method="POST",route="/v1/audio/speech"} 1.0'
+        in text
+    )
+
+
+def test_http_middleware_records_statuses_routes_and_skips_metrics_scrape() -> None:
+    app = FastAPI()
+    app.state.omni_metrics = OmniPrometheusMetrics(model_name="moss-tts-local-v15")
+    install_metrics_middleware(app)
+
+    @app.get("/ok")
+    async def ok() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.get("/bad")
+    async def bad() -> Response:
+        return Response(status_code=400)
+
+    @app.get("/boom")
+    async def boom() -> None:
+        raise RuntimeError("boom")
+
+    @app.get("/metrics")
+    async def metrics() -> Response:
+        return app.state.omni_metrics.render()
+
+    client = TestClient(app, raise_server_exceptions=False)
+
+    assert client.get("/ok").status_code == 200
+    assert client.get("/bad").status_code == 400
+    assert client.get("/boom").status_code == 500
+    assert client.get("/missing").status_code == 404
+    metrics_resp = client.get("/metrics")
+
+    assert metrics_resp.status_code == 200
+    text = metrics_resp.text
+    assert _http_requests_total(route="/ok", status="200") + " 1.0" in text
+    assert _http_requests_total(route="/bad", status="400") + " 1.0" in text
+    assert _http_requests_total(route="/boom", status="500") + " 1.0" in text
+    assert _http_requests_total(route="__unmatched__", status="404") + " 1.0" in text
+    assert 'route="/metrics"' not in text
+
+
+def _http_duration_bucket(*, le: str) -> str:
+    return (
+        'sglang_omni_http_request_duration_seconds_bucket{'
+        f'le="{le}",method="POST",route="/v1/audio/speech"'
+        "}"
+    )
+
+
+def _http_requests_total(*, route: str, status: str) -> str:
+    return (
+        'sglang_omni_http_requests_total{'
+        f'method="GET",route="{route}",status="{status}"'
+        "}"
+    )
+
+
+def test_metrics_instances_do_not_share_state() -> None:
+    first = OmniPrometheusMetrics(model_name="first-model")
+    second = OmniPrometheusMetrics(model_name="second-model")
+
+    first.update_from_health(MetricsClient().health())
+    second.update_from_health(MetricsClient().health())
+    first_metrics = first.render_text()
+    second_metrics = second.render_text()
+
+    assert 'model_name="first-model"' in first_metrics
+    assert 'model_name="second-model"' not in first_metrics
+    assert 'model_name="second-model"' in second_metrics
+    assert 'model_name="first-model"' not in second_metrics


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

SGLang-Omni currently exposes `/health`, but does not expose a Prometheus-compatible `/metrics` endpoint for the Omni API/coordinator layer.

SGLang core already documents `--enable-metrics` and `/metrics` for production monitoring. This PR adds a similar opt-in endpoint for the Omni API server, focused on low-cardinality API/coordinator metrics.

## Modifications

- Add `--enable-metrics` / `--enable_metrics` to `sgl-omni serve`.
- Add optional `GET /metrics` when metrics are enabled.
- Keep `GET /health` unchanged.
- Add an app-local Prometheus text renderer without adding a runtime `prometheus_client` dependency.
- Add low-cardinality coordinator gauges:
  - pipeline running
  - tracked requests
  - pending completions
  - request states
  - stage presence
- Add HTTP request count and handler-duration histogram metrics labeled by `model_name`, `method`, `route`, and status/bucket.
- Add documentation for the Omni API/coordinator metrics scope.
- Add unit tests for endpoint enablement, gauge reset behavior, label escaping/sorting, histogram buckets, middleware status/route labels, `/metrics` scrape exclusion, instance isolation, and optional Prometheus parser validation.
- Make `sglang_omni.serve.__init__` use lazy exports so importing `sglang_omni.serve.metrics` does not eagerly import the full API server/launcher stack.

This PR intentionally does not include GPU metrics, system metrics, DCGM replacement, OpenTelemetry tracing, request-level profiling, underlying SGLang stage metrics aggregation, full streaming lifecycle latency, or request ID / prompt / file path / voice name labels.

## Related Issues

Fixes #946

## Accuracy Test

N/A. This PR only adds observability plumbing and does not change model execution, sampling, request construction, or response generation.

## Benchmark & Profiling

N/A. The endpoint is disabled by default. When enabled, request middleware records low-cardinality counters/histograms and `/metrics` renders the current in-process snapshot.

Smoke tested with MOSS-TTS Local v1.5 on node56. The metrics endpoint exposed coordinator gauges, stage presence, HTTP request counters, and HTTP handler-duration histogram samples after successful and intentionally failed requests.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.

## Test Plan

- `uv run --no-project --with pytest --with fastapi --with httpx --with numpy --with pydantic --with pyzmq --with msgpack --with pyyaml --with soundfile --with uvicorn --with python-multipart --with prometheus-client python -m pytest tests/unit_test/serve/test_metrics.py -q`
- `python -m compileall -q sglang_omni/serve/metrics.py sglang_omni/serve/openai_api.py sglang_omni/serve/launcher.py sglang_omni/cli/serve.py sglang_omni/serve/__init__.py tests/unit_test/serve/test_metrics.py`
- `git diff --check`
- `uv run --no-project --with-requirements docs/requirements.txt sphinx-build -b html docs docs/_build/html`