### PR TITLE
[Optimization ] Add stream output builder for MOSS-Transcribe-Diarize model

### DIFF
--- a/benchmarks/eval/eval_transcribe_diarize.py
+++ b/benchmarks/eval/eval_transcribe_diarize.py
@@ -105,7 +105,13 @@ DIARIZATION_METRICS_PERCENT_ORDER: Final[tuple[str, ...]] = (
 )
 
 
-def make_send_fn(api_url: str, model_path: str, language: str | None) -> SendFn:
+def make_send_fn(
+    api_url: str,
+    model_path: str,
+    language: str | None,
+    *,
+    stream: bool = False,
+) -> SendFn:
     async def send_fn(
         session: aiohttp.ClientSession,
         sample: Movies800Sample,
@@ -122,10 +128,17 @@ def make_send_fn(api_url: str, model_path: str, language: str | None) -> SendFn:
         try:
             async with session.post(
                 api_url,
-                data=_request_form(audio_bytes, audio_path, model_path, language),
+                data=_request_form(
+                    audio_bytes, audio_path, model_path, language, stream=stream
+                ),
             ) as response:
                 if response.status != 200:
                     result.error = f"HTTP {response.status}: {await response.text()}"
+                elif stream:
+                    result.text = await _consume_transcription_stream(
+                        response, result, start
+                    )
+                    result.is_success = True
                 else:
                     result.text = extract_prediction_text(await response.json())
                     result.is_success = True
@@ -145,6 +158,44 @@ def make_send_fn(api_url: str, model_path: str, language: str | None) -> SendFn:
     return send_fn
 
 
+async def _consume_transcription_stream(
+    response: aiohttp.ClientResponse,
+    result: RequestResult,
+    start: float,
+) -> str:
+    """Read the SSE transcription stream, filling streaming latency metrics.
+
+    Records ``text_ttft_s`` on the first ``transcript.text.delta`` and the
+    gaps between subsequent deltas in ``inter_chunk_s``. Returns the full
+    text from the terminal ``transcript.text.done`` event.
+    """
+    final_text: str | None = None
+    last_delta_t: float | None = None
+    async for raw_line in response.content:
+        line = raw_line.decode("utf-8").strip()
+        if not line.startswith("data: "):
+            continue
+        payload = line[len("data: ") :]
+        if payload == "[DONE]":
+            break
+        event = json.loads(payload)
+        event_type = event.get("type")
+        if event_type == "transcript.text.delta":
+            now = time.perf_counter()
+            if result.text_ttft_s is None:
+                result.text_ttft_s = now - start
+            elif last_delta_t is not None:
+                result.inter_chunk_s.append(now - last_delta_t)
+            last_delta_t = now
+        elif event_type == "transcript.text.done":
+            final_text = event.get("text")
+        elif event_type == "error":
+            raise ValueError(f"Stream error event: {event.get('error')}")
+    if not isinstance(final_text, str):
+        raise ValueError("Stream ended without a transcript.text.done event")
+    return final_text.strip()
+
+
 async def run_eval(
     samples: list[Movies800Sample],
     *,
@@ -156,6 +207,7 @@ async def run_eval(
     request_rate: float,
     disable_tqdm: bool,
     request_timeout_s: int,
+    stream: bool = False,
 ) -> tuple[list[RequestResult], float]:
     runner = BenchmarkRunner(
         RunConfig(
@@ -172,6 +224,7 @@ async def run_eval(
             api_url=f"{base_url}/v1/audio/transcriptions",
             model_path=model_path,
             language=language,
+            stream=stream,
         ),
     )
     return outputs, runner.wall_clock_s
@@ -211,6 +264,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR)
     parser.add_argument("--use-existing-server", action="store_true")
     parser.add_argument("--disable-tqdm", action="store_true")
+    parser.add_argument(
+        "--stream",
+        action="store_true",
+        help=(
+            "Use SSE streaming transcription (stream=true). Fills the "
+            "text_ttft_* and inter_chunk_* speed metrics; accuracy metrics "
+            "are computed on the final transcript as usual."
+        ),
+    )
     parser.add_argument(
         "--max-running-requests",
         type=int,
@@ -305,6 +367,7 @@ def _run_with_or_without_server(
                 request_rate=args.request_rate,
                 disable_tqdm=args.disable_tqdm,
                 request_timeout_s=args.request_timeout_s,
+                stream=args.stream,
             )
         )
         payload = _build_payload(args, samples, outputs, wall_clock_s)
@@ -337,6 +400,7 @@ def _run_with_or_without_server(
                 request_rate=args.request_rate,
                 disable_tqdm=args.disable_tqdm,
                 request_timeout_s=args.request_timeout_s,
+                stream=args.stream,
             )
         )
         payload = _build_payload(args, samples, outputs, wall_clock_s)
@@ -446,10 +510,18 @@ def _request_form(
     audio_path: Path,
     model_path: str,
     language: str | None,
+    *,
+    stream: bool = False,
 ) -> aiohttp.FormData:
     form = aiohttp.FormData()
     form.add_field("model", model_path)
-    form.add_field("response_format", "verbose_json")
+    if stream:
+        # verbose_json cannot stream; the plain text carries the same
+        # speaker/timestamp markup, which the metrics normalizer handles.
+        form.add_field("response_format", "json")
+        form.add_field("stream", "true")
+    else:
+        form.add_field("response_format", "verbose_json")
     if language:
         form.add_field("language", language)
     form.add_field(

--- a/sglang_omni/models/moss_transcribe_diarize/request_builders.py
+++ b/sglang_omni/models/moss_transcribe_diarize/request_builders.py
@@ -326,6 +326,7 @@ def make_moss_transcribe_diarize_scheduler_adapters(
 def make_moss_transcribe_diarize_stream_output_builder(
     tokenizer: Any,
     eos_token_id: int | None = None,
+    min_emit_interval_s: float = 0.0,
 ) -> Callable[[str, Any, Any], list[OutgoingMessage]]:
     """Per-token stream callback emitting partial transcription text deltas.
 
@@ -335,8 +336,20 @@ def make_moss_transcribe_diarize_stream_output_builder(
     runtime. Per-request state lives on ``req`` so it is GC'd with the
     request and survives retract/resume.
 
-    Incomplete UTF-8 sequences (trailing ``\\ufffd`` after decode) are
-    buffered until a later token completes them.
+    Incremental decode runs on the held pending-token buffer only (cleared on
+    every emit), which keeps per-step cost O(pending) instead of re-decoding
+    the full output each step. This is equality-safe for suffix-additive
+    tokenizers (byte-level BPE, as the Qwen3 backbone uses): concatenating
+    per-buffer decodes reproduces the full decode exactly. Incomplete UTF-8
+    sequences (trailing ``\\ufffd``) are held until a later token completes
+    them.
+
+    ``min_emit_interval_s`` rate-limits emission per request: tokens keep
+    accumulating in the pending buffer and are flushed as one delta once the
+    interval has elapsed since the last emit. The first delta and the EOS
+    flush are always immediate, so TTFT is unaffected. This bounds the
+    per-token message fan-out (outbox -> ZMQ -> coordinator -> SSE), which
+    otherwise costs measurable decode throughput at high concurrency.
     """
     resolved_eos = (
         int(eos_token_id)
@@ -370,31 +383,39 @@ def make_moss_transcribe_diarize_stream_output_builder(
         except (TypeError, ValueError):
             return []
 
-        token_ids = getattr(req, "_moss_stream_token_ids", None)
-        if token_ids is None:
-            token_ids = []
-            req._moss_stream_token_ids = token_ids
-        emitted = getattr(req, "_moss_stream_emitted_text", "")
+        pending = getattr(req, "_moss_stream_pending_ids", None)
+        if pending is None:
+            pending = []
+            req._moss_stream_pending_ids = pending
 
-        if resolved_eos is None or token_id != resolved_eos:
-            token_ids.append(token_id)
-        if not token_ids:
+        is_eos = resolved_eos is not None and token_id == resolved_eos
+        if not is_eos:
+            pending.append(token_id)
+        if not pending:
             return []
 
-        decoded = _decode_token_ids(tokenizer, token_ids, skip_special_tokens=True)
-        # Buffer until the trailing multi-byte char completes.
-        if decoded.endswith("\ufffd"):
+        # Rate-limit: hold tokens until the interval elapses. last_emit == 0.0
+        # means nothing was emitted yet — the first delta goes out immediately.
+        # EOS always flushes the remaining buffer.
+        now = time.perf_counter()
+        last_emit = float(getattr(req, "_moss_stream_last_emit_t", 0.0))
+        if (
+            not is_eos
+            and min_emit_interval_s > 0.0
+            and last_emit > 0.0
+            and (now - last_emit) < min_emit_interval_s
+        ):
             return []
 
-        if decoded.startswith(emitted):
-            delta = decoded[len(emitted) :]
-        else:
-            # Defensive: detokenizer rewrote earlier text — re-emit full.
-            delta = decoded
+        delta = _decode_token_ids(tokenizer, pending, skip_special_tokens=True)
+        # Hold until the trailing multi-byte char completes.
+        if delta.endswith("\ufffd"):
+            return []
+        pending.clear()
         if not delta:
             return []
 
-        req._moss_stream_emitted_text = decoded
+        req._moss_stream_last_emit_t = now
 
         return [
             OutgoingMessage(

--- a/sglang_omni/models/moss_transcribe_diarize/request_builders.py
+++ b/sglang_omni/models/moss_transcribe_diarize/request_builders.py
@@ -20,6 +20,7 @@ from sglang.srt.managers.schedule_batch import (
 from sglang.srt.sampling.sampling_params import SamplingParams
 
 from sglang_omni.proto import StagePayload
+from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
 from sglang_omni.utils.audio import audio_fingerprint, audio_fingerprint_int, load_audio
 
@@ -322,10 +323,101 @@ def make_moss_transcribe_diarize_scheduler_adapters(
     return request_builder, result_adapter
 
 
+def make_moss_transcribe_diarize_stream_output_builder(
+    tokenizer: Any,
+    eos_token_id: int | None = None,
+) -> Callable[[str, Any, Any], list[OutgoingMessage]]:
+    """Per-token stream callback emitting partial transcription text deltas.
+
+    OmniScheduler calls this on every decode step with the freshly sampled
+    token id. The MOSS-TD stage is terminal, so text deltas are emitted with
+    ``target=None`` and routed straight to the Coordinator by the stage
+    runtime. Per-request state lives on ``req`` so it is GC'd with the
+    request and survives retract/resume.
+
+    Incomplete UTF-8 sequences (trailing ``\\ufffd`` after decode) are
+    buffered until a later token completes them.
+    """
+    resolved_eos = (
+        int(eos_token_id)
+        if eos_token_id is not None
+        else (
+            int(tokenizer.eos_token_id)
+            if getattr(tokenizer, "eos_token_id", None) is not None
+            else None
+        )
+    )
+
+    def _build_stream_output(
+        request_id: str, req_data: Any, req_output: Any
+    ) -> list[OutgoingMessage]:
+        req = getattr(req_data, "req", None)
+        if req is None or req_output.data is None:
+            return []
+        # While chunked prefill is still consuming prompt tokens, suppress
+        # emission — prompt-side states would masquerade as output text.
+        if int(getattr(req, "is_chunked", 0) or 0) > 0:
+            return []
+
+        stage_payload = getattr(req_data, "stage_payload", None)
+        if stage_payload is None:
+            return []
+        if not bool((stage_payload.request.params or {}).get("stream", False)):
+            return []
+
+        try:
+            token_id = int(req_output.data)
+        except (TypeError, ValueError):
+            return []
+
+        token_ids = getattr(req, "_moss_stream_token_ids", None)
+        if token_ids is None:
+            token_ids = []
+            req._moss_stream_token_ids = token_ids
+        emitted = getattr(req, "_moss_stream_emitted_text", "")
+
+        if resolved_eos is None or token_id != resolved_eos:
+            token_ids.append(token_id)
+        if not token_ids:
+            return []
+
+        decoded = _decode_token_ids(tokenizer, token_ids, skip_special_tokens=True)
+        # Buffer until the trailing multi-byte char completes.
+        if decoded.endswith("\ufffd"):
+            return []
+
+        if decoded.startswith(emitted):
+            delta = decoded[len(emitted) :]
+        else:
+            # Defensive: detokenizer rewrote earlier text — re-emit full.
+            delta = decoded
+        if not delta:
+            return []
+
+        req._moss_stream_emitted_text = decoded
+
+        return [
+            OutgoingMessage(
+                request_id=request_id,
+                type="stream",
+                target=None,  # terminal stage → Coordinator
+                data={
+                    "text": delta,
+                    "modality": "text",
+                    "stage_name": "asr",
+                },
+                metadata={"modality": "text", "token_id": token_id},
+            )
+        ]
+
+    return _build_stream_output
+
+
 __all__ = [
     "DEFAULT_TRANSCRIBE_DIARIZE_PROMPT",
     "MossTranscribeDiarizeRequestData",
     "load_audio",
     "make_moss_transcribe_diarize_scheduler_adapters",
+    "make_moss_transcribe_diarize_stream_output_builder",
     "postprocess_moss_transcribe_diarize_text",
 ]

--- a/sglang_omni/models/moss_transcribe_diarize/stages.py
+++ b/sglang_omni/models/moss_transcribe_diarize/stages.py
@@ -16,6 +16,7 @@ from sglang_omni.models.moss_transcribe_diarize import (  # noqa: F401
 )
 from sglang_omni.models.moss_transcribe_diarize.request_builders import (
     make_moss_transcribe_diarize_scheduler_adapters,
+    make_moss_transcribe_diarize_stream_output_builder,
 )
 from sglang_omni.scheduling.bootstrap import (
     create_sglang_infrastructure_defer_cuda_graph,
@@ -167,6 +168,9 @@ def create_sglang_moss_transcribe_diarize_executor(
         tokenizer=tokenizer,
         max_new_tokens=resolved_max_new_tokens,
     )
+    stream_output_builder = make_moss_transcribe_diarize_stream_output_builder(
+        tokenizer=tokenizer,
+    )
 
     return OmniScheduler(
         tp_worker=model_worker,
@@ -180,6 +184,7 @@ def create_sglang_moss_transcribe_diarize_executor(
         model_runner=ModelRunner(model_worker, output_proc),
         request_builder=request_builder,
         result_adapter=result_adapter,
+        stream_output_builder=stream_output_builder,
         request_build_max_workers=request_build_max_workers,
         request_build_max_pending=request_build_max_pending,
     )

--- a/sglang_omni/models/moss_transcribe_diarize/stages.py
+++ b/sglang_omni/models/moss_transcribe_diarize/stages.py
@@ -97,6 +97,7 @@ def create_sglang_moss_transcribe_diarize_executor(
     enable_torch_compile: bool = False,
     request_build_max_workers: int = 2,
     request_build_max_pending: int | None = 16,
+    stream_emit_interval_s: float = 0.05,
     server_args_overrides: dict[str, Any] | None = None,
 ):
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0
@@ -170,6 +171,7 @@ def create_sglang_moss_transcribe_diarize_executor(
     )
     stream_output_builder = make_moss_transcribe_diarize_stream_output_builder(
         tokenizer=tokenizer,
+        min_emit_interval_s=stream_emit_interval_s,
     )
 
     return OmniScheduler(

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -91,6 +91,8 @@ from sglang_omni.serve.protocol import (
     RolloutSamplingParams,
     SpeechBatchResponse,
     TranscriptionResponse,
+    TranscriptionTextDeltaEvent,
+    TranscriptionTextDoneEvent,
     TranscriptionUsage,
     UpdateWeightFromDiskRequest,
     UpdateWeightsFromDistributedRequest,
@@ -1510,6 +1512,7 @@ def _register_transcriptions(app: FastAPI) -> None:
         prompt: str | None = Form(default=None),
         response_format: str = Form(default="json"),
         temperature: float | None = Form(default=None),
+        stream: bool = Form(default=False),
     ) -> Response:
         client: Client = app.state.client
         default_model: str = app.state.model_name
@@ -1520,6 +1523,45 @@ def _register_transcriptions(app: FastAPI) -> None:
         audio_bytes = await file.read()
         if not audio_bytes:
             raise HTTPException(status_code=400, detail="Uploaded audio file is empty")
+
+        normalized_response_format = response_format.strip().lower()
+        if stream:
+            # verbose_json needs the full text for segment parsing; only the
+            # plain-text formats can stream.
+            if normalized_response_format not in {"json", "text"}:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "stream=true supports only response_format 'json' or "
+                        f"'text', got {response_format!r}"
+                    ),
+                )
+            gen_req = build_transcription_generate_request(
+                audio_bytes=audio_bytes,
+                filename=file.filename,
+                content_type=file.content_type,
+                model=model or default_model,
+                language=language,
+                prompt=prompt,
+                temperature=temperature,
+                stream=True,
+            )
+            adapter = resolve_adapter(getattr(app.state, "architectures", None))
+            duration_s = _probe_audio_duration(audio_bytes)
+            return StreamingResponse(
+                _transcription_stream(
+                    client,
+                    gen_req,
+                    request_id=request_id,
+                    adapter=adapter,
+                    duration_s=duration_s,
+                ),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "X-Request-Id": request_id,
+                },
+            )
 
         gen_req = build_transcription_generate_request(
             audio_bytes=audio_bytes,
@@ -1540,7 +1582,6 @@ def _register_transcriptions(app: FastAPI) -> None:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
         text = result.text
-        normalized_response_format = response_format.strip().lower()
         if normalized_response_format == "text":
             return PlainTextResponse(text)
         if normalized_response_format not in {"json", "verbose_json"}:
@@ -1575,6 +1616,50 @@ def _register_transcriptions(app: FastAPI) -> None:
         )
 
 
+async def _transcription_stream(
+    client: Client,
+    gen_req: GenerateRequest,
+    *,
+    request_id: str,
+    adapter: Any,
+    duration_s: float,
+) -> AsyncIterator[str]:
+    """SSE generator for streaming transcriptions.
+
+    Emits OpenAI-style ``transcript.text.delta`` events for each partial text
+    chunk, then a terminal ``transcript.text.done`` event carrying the full
+    post-processed transcript.
+    """
+    final_text: str | None = None
+    try:
+        async for chunk in client.generate(gen_req, request_id=request_id):
+            if chunk.finish_reason is not None:
+                # Terminal aggregate result — capture the authoritative full
+                # text for the done event, do not re-emit it as a delta.
+                if isinstance(chunk.text, str) and chunk.text:
+                    final_text = chunk.text
+                continue
+            if chunk.modality == "text" and chunk.text:
+                event = TranscriptionTextDeltaEvent(delta=chunk.text)
+                yield f"data: {event.model_dump_json(exclude_none=True)}\n\n"
+    except Exception as exc:
+        # Headers are already sent; surface the failure as an SSE error event.
+        logger.exception(
+            "Error streaming transcription for request %s", request_id
+        )
+        payload = {"type": "error", "error": {"message": str(exc)}}
+        yield f"data: {json.dumps(payload)}\n\n"
+        return
+
+    text = adapter.postprocess_text(final_text or "")
+    usage = (
+        TranscriptionUsage(seconds=math.ceil(duration_s)) if duration_s > 0 else None
+    )
+    done_event = TranscriptionTextDoneEvent(text=text, usage=usage)
+    yield f"data: {done_event.model_dump_json(exclude_none=True)}\n\n"
+    yield f"data: {STREAM_DONE_SENTINEL}\n\n"
+
+
 def _probe_audio_duration(audio_bytes: bytes) -> float:
     """Best-effort audio duration (seconds) from raw upload bytes.
 
@@ -1602,6 +1687,7 @@ def build_transcription_generate_request(
     language: str | None,
     prompt: str | None,
     temperature: float | None,
+    stream: bool = False,
 ) -> GenerateRequest:
     params: dict[str, Any] = {"task": "transcribe"}
     if language is not None:
@@ -1619,7 +1705,7 @@ def build_transcription_generate_request(
             "content_type": content_type,
         },
         extra_params=params,
-        stream=False,
+        stream=stream,
         output_modalities=["text"],
         metadata={"task": "asr"},
     )

--- a/sglang_omni/serve/protocol.py
+++ b/sglang_omni/serve/protocol.py
@@ -491,6 +491,21 @@ class TranscriptionVerboseResponse(BaseModel):
     usage: TranscriptionUsage | None = None
 
 
+class TranscriptionTextDeltaEvent(BaseModel):
+    """OpenAI-compatible streaming transcription delta event (SSE)."""
+
+    type: str = "transcript.text.delta"
+    delta: str
+
+
+class TranscriptionTextDoneEvent(BaseModel):
+    """OpenAI-compatible streaming transcription terminal event (SSE)."""
+
+    type: str = "transcript.text.done"
+    text: str
+    usage: TranscriptionUsage | None = None
+
+
 class ModelPermission(BaseModel):
     """Model permission info."""
 

--- a/tests/unit_test/moss_transcribe_diarize/test_stream_output_builder.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_stream_output_builder.py
@@ -102,7 +102,7 @@ def test_silent_when_not_streaming():
 
     assert builder("req-1", rd, _make_req_output(1)) == []
     # No per-request state is created for non-streaming requests.
-    assert not hasattr(rd.req, "_moss_stream_token_ids")
+    assert not hasattr(rd.req, "_moss_stream_pending_ids")
 
 
 def test_silent_during_chunked_prefill():
@@ -209,8 +209,65 @@ def test_per_request_state_is_isolated():
     assert [m.data["text"] for m in out1] == ["A"]
     assert [m.data["text"] for m in out2] == ["B"]
     assert [m.data["text"] for m in out1b] == ["B"]
-    assert rd1.req._moss_stream_emitted_text == "AB"
-    assert rd2.req._moss_stream_emitted_text == "B"
+    # Emitted tokens leave the pending buffer; nothing lingers per request.
+    assert rd1.req._moss_stream_pending_ids == []
+    assert rd2.req._moss_stream_pending_ids == []
+
+
+# ---------------------------------------------------------------------------
+# Rate-limited (coalesced) emission
+# ---------------------------------------------------------------------------
+
+
+def _interval_builder(vocab: dict[int, bytes], interval_s: float):
+    return make_moss_transcribe_diarize_stream_output_builder(
+        tokenizer=_ByteTokenizer(vocab),
+        min_emit_interval_s=interval_s,
+    )
+
+
+def test_min_emit_interval_first_delta_is_immediate():
+    builder = _interval_builder({1: b"A"}, interval_s=3600.0)
+    rd = _make_req_data()
+
+    msgs = builder("r", rd, _make_req_output(1))
+    assert [m.data["text"] for m in msgs] == ["A"]
+
+
+def test_min_emit_interval_holds_then_eos_flushes():
+    """Tokens within the interval are held and flushed as one delta on EOS."""
+    builder = _interval_builder({1: b"A", 2: b"B", 3: b"C"}, interval_s=3600.0)
+    rd = _make_req_data()
+
+    assert [m.data["text"] for m in builder("r", rd, _make_req_output(1))] == ["A"]
+    # Interval has not elapsed: held.
+    assert builder("r", rd, _make_req_output(2)) == []
+    assert builder("r", rd, _make_req_output(3)) == []
+
+    msgs = builder("r", rd, _make_req_output(_EOS))
+    assert [m.data["text"] for m in msgs] == ["BC"]
+
+
+def test_min_emit_interval_elapsed_flushes_batch():
+    builder = _interval_builder({1: b"A", 2: b"B", 3: b"C"}, interval_s=0.01)
+    rd = _make_req_data()
+
+    assert [m.data["text"] for m in builder("r", rd, _make_req_output(1))] == ["A"]
+    assert builder("r", rd, _make_req_output(2)) == []
+
+    import time as _time
+
+    _time.sleep(0.02)
+    msgs = builder("r", rd, _make_req_output(3))
+    assert [m.data["text"] for m in msgs] == ["BC"]
+
+
+def test_eos_with_empty_pending_emits_nothing():
+    builder = _interval_builder({1: b"A"}, interval_s=3600.0)
+    rd = _make_req_data()
+
+    assert [m.data["text"] for m in builder("r", rd, _make_req_output(1))] == ["A"]
+    assert builder("r", rd, _make_req_output(_EOS)) == []
 
 
 def test_explicit_eos_token_id_overrides_tokenizer():

--- a/tests/unit_test/moss_transcribe_diarize/test_stream_output_builder.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_stream_output_builder.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for make_moss_transcribe_diarize_stream_output_builder.
+
+All tests run without a real MOSS-TD model — mock tokenizers are used. The
+builder is exercised exactly as OmniScheduler calls it: once per decode step
+with ``(request_id, req_data, req_output)``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from sglang_omni.models.moss_transcribe_diarize.request_builders import (
+    make_moss_transcribe_diarize_stream_output_builder,
+)
+from sglang_omni.proto import OmniRequest, StagePayload
+
+_EOS = 999
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+
+class _ByteTokenizer:
+    """Token id → fixed bytes; UTF-8 decode with errors='replace'."""
+
+    eos_token_id = _EOS
+
+    def __init__(
+        self,
+        vocab: dict[int, bytes],
+        special_token_ids: set[int] | None = None,
+    ):
+        self._vocab = vocab
+        self._special = special_token_ids or set()
+
+    def decode(
+        self,
+        ids,
+        skip_special_tokens: bool = False,
+        clean_up_tokenization_spaces: bool = False,
+    ) -> str:
+        chunks = [
+            self._vocab[tid]
+            for tid in ids
+            if not (skip_special_tokens and tid in self._special)
+        ]
+        return b"".join(chunks).decode("utf-8", errors="replace")
+
+
+def _make_req_data(*, stream: bool = True, is_chunked: int = 0) -> Any:
+    """Minimal req_data as OmniScheduler passes to stream_output_builder."""
+    stage_payload = StagePayload(
+        request_id="r",
+        request=OmniRequest(
+            inputs={"audio_bytes": b""},
+            params={"stream": stream},
+            metadata={},
+        ),
+        data={},
+    )
+    req = SimpleNamespace(is_chunked=is_chunked)
+    return SimpleNamespace(req=req, stage_payload=stage_payload)
+
+
+def _make_req_output(token_id: int | None) -> Any:
+    return SimpleNamespace(data=token_id)
+
+
+def _builder(vocab: dict[int, bytes], special: set[int] | None = None):
+    return make_moss_transcribe_diarize_stream_output_builder(
+        tokenizer=_ByteTokenizer(vocab, special_token_ids=special),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Emission gating
+# ---------------------------------------------------------------------------
+
+
+def test_emits_text_delta_when_streaming():
+    builder = _builder({1: b"[0.00]"})
+    rd = _make_req_data(stream=True)
+
+    msgs = builder("req-1", rd, _make_req_output(1))
+
+    assert len(msgs) == 1
+    msg = msgs[0]
+    assert msg.type == "stream"
+    assert msg.request_id == "req-1"
+    # target=None routes to the Coordinator (terminal stage).
+    assert msg.target is None
+    assert msg.data == {"text": "[0.00]", "modality": "text", "stage_name": "asr"}
+    assert msg.metadata == {"modality": "text", "token_id": 1}
+
+
+def test_silent_when_not_streaming():
+    builder = _builder({1: b"A"})
+    rd = _make_req_data(stream=False)
+
+    assert builder("req-1", rd, _make_req_output(1)) == []
+    # No per-request state is created for non-streaming requests.
+    assert not hasattr(rd.req, "_moss_stream_token_ids")
+
+
+def test_silent_during_chunked_prefill():
+    builder = _builder({1: b"A"})
+    rd = _make_req_data(stream=True, is_chunked=1)
+
+    assert builder("req-1", rd, _make_req_output(1)) == []
+
+    # Once chunked prefill completes, emission resumes.
+    rd.req.is_chunked = 0
+    msgs = builder("req-1", rd, _make_req_output(1))
+    assert [m.data["text"] for m in msgs] == ["A"]
+
+
+def test_silent_when_no_token_this_step():
+    builder = _builder({1: b"A"})
+    rd = _make_req_data(stream=True)
+
+    assert builder("req-1", rd, _make_req_output(None)) == []
+
+
+def test_silent_when_req_or_payload_missing():
+    builder = _builder({1: b"A"})
+
+    no_req = SimpleNamespace(req=None, stage_payload=None)
+    assert builder("req-1", no_req, _make_req_output(1)) == []
+
+    no_payload = SimpleNamespace(req=SimpleNamespace(is_chunked=0), stage_payload=None)
+    assert builder("req-1", no_payload, _make_req_output(1)) == []
+
+
+# ---------------------------------------------------------------------------
+# Incremental detokenization
+# ---------------------------------------------------------------------------
+
+
+def test_incremental_deltas_across_tokens():
+    builder = _builder({1: b"[S01]", 2: b" hello", 3: b" world"})
+    rd = _make_req_data()
+
+    deltas = []
+    for tid in (1, 2, 3):
+        for msg in builder("req-1", rd, _make_req_output(tid)):
+            deltas.append(msg.data["text"])
+
+    assert deltas == ["[S01]", " hello", " world"]
+
+
+def test_utf8_multibyte_hold_then_emit():
+    """A 3-byte CJK char split across 3 tokens must hold until complete."""
+    # "你" is U+4F60 → b'\xe4\xbd\xa0'. Split byte-per-token.
+    builder = _builder({1: b"\xe4", 2: b"\xbd", 3: b"\xa0", 4: b"ok"})
+    rd = _make_req_data()
+
+    assert builder("req-1", rd, _make_req_output(1)) == []
+    assert builder("req-1", rd, _make_req_output(2)) == []
+    msgs = builder("req-1", rd, _make_req_output(3))
+    assert [m.data["text"] for m in msgs] == ["你"]
+
+    msgs = builder("req-1", rd, _make_req_output(4))
+    assert [m.data["text"] for m in msgs] == ["ok"]
+
+
+def test_interior_replacement_char_does_not_stall_stream():
+    """Only a TRAILING U+FFFD is held; an interior one must flush normally."""
+    # 0x80 is a lone continuation byte → decodes to a permanent U+FFFD.
+    builder = _builder({1: b"\x80", 2: b"ok"})
+    rd = _make_req_data()
+
+    assert builder("req-1", rd, _make_req_output(1)) == []
+    msgs = builder("req-1", rd, _make_req_output(2))
+    assert [m.data["text"] for m in msgs] == ["\ufffdok"]
+
+
+def test_eos_token_emits_no_delta():
+    builder = _builder({1: b"hi", _EOS: b"<eos>"})
+    rd = _make_req_data()
+
+    msgs = builder("req-1", rd, _make_req_output(1))
+    assert [m.data["text"] for m in msgs] == ["hi"]
+    assert builder("req-1", rd, _make_req_output(_EOS)) == []
+
+
+def test_special_token_emits_no_delta():
+    """Tokens dropped by skip_special_tokens must not produce a chunk."""
+    builder = _builder({1: b"hi", 2: b"<|im_end|>"}, special={2})
+    rd = _make_req_data()
+
+    msgs = builder("req-1", rd, _make_req_output(1))
+    assert [m.data["text"] for m in msgs] == ["hi"]
+    assert builder("req-1", rd, _make_req_output(2)) == []
+
+
+def test_per_request_state_is_isolated():
+    """Concurrent requests keep independent token/text state on their req."""
+    builder = _builder({1: b"A", 2: b"B"})
+    rd1 = _make_req_data()
+    rd2 = _make_req_data()
+
+    out1 = builder("r1", rd1, _make_req_output(1))
+    out2 = builder("r2", rd2, _make_req_output(2))
+    out1b = builder("r1", rd1, _make_req_output(2))
+
+    assert [m.data["text"] for m in out1] == ["A"]
+    assert [m.data["text"] for m in out2] == ["B"]
+    assert [m.data["text"] for m in out1b] == ["B"]
+    assert rd1.req._moss_stream_emitted_text == "AB"
+    assert rd2.req._moss_stream_emitted_text == "B"
+
+
+def test_explicit_eos_token_id_overrides_tokenizer():
+    builder = make_moss_transcribe_diarize_stream_output_builder(
+        tokenizer=_ByteTokenizer({1: b"A", 7: b"<stop>"}),
+        eos_token_id=7,
+    )
+    rd = _make_req_data()
+
+    assert [m.data["text"] for m in builder("r", rd, _make_req_output(1))] == ["A"]
+    assert builder("r", rd, _make_req_output(7)) == []


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Wires stream_output_builder into OmniScheduler for MOSS-Transcribe-Diarize so partial transcription text is streamed as the LLM decodes, and exposes it end-to-end via an OpenAI-compatible SSE API. Especially valuable for long audio: first text now arrives in ~40 ms regardless of audio length.

## Related changes
**1. Model layer (request_builders.py, stages.py)**

New make_moss_transcribe_diarize_stream_output_builder: per-decode-step callback emitting text deltas as OutgoingMessage(type="stream"). 

Incremental detokenization: only the pending (un-emitted) token buffer is decoded each step — O(pending) instead of re-decoding the full output (O(n²) overall), which matters at max_new_tokens=5120.

Rate-limited emission via min_emit_interval_s (wired as stream_emit_interval_s=0.05 in the stage factory): deltas are coalesced into one message per interval; the first delta and the EOS flush are always immediate, so TTFT is unaffected. This bounds the per-token message fan-out (scheduler outbox → ZMQ → coordinator → SSE) that otherwise costs ~27% decode throughput at concurrency 8.

**2. API layer (protocol.py, openai_api.py)**

  /v1/audio/transcriptions now accepts stream=true and returns SSE transcript.text.delta / transcript.text.done events (OpenAI-compatible), terminated by data: [DONE]. The done event carries the post-processed full text and usage; non-streaming behavior is unchanged.


**3. Benchmark (eval_transcribe_diarize.py)**

  New --stream flag: consumes the SSE stream and reports text_ttft_{mean,median,p95,p99}_s (request → first delta) and inter_chunk_{mean,p95,p99}_s (gaps between deltas). Accuracy metrics are computed on the final transcript as usual.

## Related Issues
#924 

## Benchmark 

**- speed**

Metric | Non-stream 1 | Non-stream 2 | Non-stream 3 | Stream 1 | Stream 2 | Stream 3
-- | -- | -- | -- | -- | -- | --
throughput_qps | 24.177 | 24.035 | 23.949 | 22.847 | 22.989 | 23.293
audio_throughput_s_per_s | 279.772 | 278.128 | 277.129 | 264.378 | 266.027 | 269.540
latency_mean_s | 0.330 | 0.332 | 0.333 | 0.349 | 0.347 | 0.342
latency_median_s | 0.274 | 0.272 | 0.278 | 0.288 | 0.285 | 0.284
latency_p95_s | 0.747 | 0.774 | 0.757 | 0.782 | 0.803 | 0.788
latency_p99_s | 0.983 | 0.964 | 0.943 | 0.988 | 1.010 | 0.973
rtf_mean | 0.0316 | 0.0315 | 0.0320 | 0.0333 | 0.0332 | 0.0326
rtf_median | 0.0295 | 0.0296 | 0.0292 | 0.0308 | 0.0311 | 0.0309
rtf_p95 | 0.0508 | 0.0484 | 0.0504 | 0.0527 | 0.0528 | 0.0508
rtf_p99 | 0.0869 | 0.0767 | 0.1166 | 0.0836 | 0.1281 | 0.0797

- **Streaming-only metrics**

Metric | Stream 1 | Stream 2 | Stream 3
-- | -- | -- | --
text_ttft_mean_s | 0.041 | 0.043 | 0.040
text_ttft_median_s | 0.040 | 0.039 | 0.038
text_ttft_p95_s | 0.054 | 0.053 | 0.051
text_ttft_p99_s | 0.063 | 0.096 | 0.059
inter_chunk_mean_s | 0.050 | 0.050 | 0.050
inter_chunk_p95_s | 0.067 | 0.069 | 0.068
inter_chunk_p99_s | 0.083 | 0.084 | 0.081

- **Accuracy**(diarization metrics, %; 800/800 requests completed in every run, 0 failures)

Metric | Non-stream 1 | Non-stream 2 | Non-stream 3 | Stream 1 | Stream 2 | Stream 3
-- | -- | -- | -- | -- | -- | --
cer | 6.60 | 6.37 | 10.87¹ | 6.97 | 6.59 | 6.84
cp_cer | 13.00 | 13.44 | 17.83¹ | 13.17 | 12.48 | 13.66
cer_no_spk_cp_valid | 6.44 | 6.24 | 10.78¹ | 6.85 | 6.47 | 6.73
delta_cer | 6.56 | 7.19 | 7.05 | 6.32 | 6.01 | 6.93
exact_match_rate | 0.030 | 0.026 | 0.026 | 0.024 | 0.025 | 0.034

- **Takeaways**:

Steady-state streaming overhead is ~4% QPS (mean 23.04 vs 24.05) and +15 ms mean latency. 

TTFT is ~40 ms mean / ≤0.096 s p99, independent of audio length; non-streaming clients wait the full decode time for the first byte of text.

inter_chunk_mean_s sits exactly at the configured 50 ms coalescing window in all three runs with a tight tail (p99 ≤ 0.084 s) — steady delta cadence, no stalls. Set stream_emit_interval_s=0 to restore per-token emission.

Transcript quality is statistically identical across modes: deltas are presentation-only; the done event carries the same post-processed text as the non-streaming response.
