### PR TITLE
[Perf] Encoder CUDA graph for MOSS-TD

### DIFF
--- a/sglang_omni/models/moss_transcribe_diarize/encoder_cuda_graph.py
+++ b/sglang_omni/models/moss_transcribe_diarize/encoder_cuda_graph.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-chunk-count CUDA graph for the MOSS-TD Whisper encoder.
+
+The Whisper encoder is a fixed-shape, stateless pure function: input mel
+``[num_chunks, num_mel_bins, input_feature_len]`` -> ``[num_chunks, encoder_len, d_model]``.
+
+Only the first dim (chunk count) varies, so we bucket over chunk count and pad
+up to the nearest captured bucket on replay.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+class WhisperEncoderCudaGraphRunner:
+    def __init__(
+        self,
+        encoder,
+        num_mel_bins: int,
+        input_feature_len: int,
+        min_free_gb: float = 3.0,
+        warmup_iters: int = 3,
+    ) -> None:
+        self._encoder = encoder
+        self._num_mel_bins = int(num_mel_bins)
+        self._input_feature_len = int(input_feature_len)
+        self._device = next(encoder.parameters()).device
+        self._dtype = next(encoder.parameters()).dtype
+        self._min_free_bytes = int(float(min_free_gb) * (1024**3))
+        self._warmup_iters = int(warmup_iters)
+        self._graphs: dict[int, tuple] = {}
+        self._pool = None
+        self._forward_batch = None
+
+    def _enough_free_vram(self) -> tuple[bool, int]:
+        free, _ = torch.cuda.mem_get_info(self._device)
+        return free >= self._min_free_bytes, free
+
+    def _warmup(self, static_feat, static_pos, forward_batch) -> None:
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            for _ in range(self._warmup_iters):
+                self._encoder(static_feat, static_pos, forward_batch)
+        torch.cuda.current_stream().wait_stream(stream)
+        torch.cuda.synchronize()
+
+    def _capture_bucket(self, c: int, encoder_len: int, forward_batch) -> None:
+        static_feat = torch.zeros(
+            c,
+            self._num_mel_bins,
+            self._input_feature_len,
+            device=self._device,
+            dtype=self._dtype,
+        )
+        static_pos = torch.arange(encoder_len, device=self._device, dtype=torch.long)
+        self._warmup(static_feat, static_pos, forward_batch)
+
+        if self._pool is None:
+            self._pool = torch.cuda.graph_pool_handle()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(
+            graph, pool=self._pool, capture_error_mode="thread_local"
+        ):
+            static_out = self._encoder(static_feat, static_pos, forward_batch)
+        self._graphs[c] = (graph, static_feat, static_pos, static_out)
+        logger.info(
+            "Captured MOSS-TD encoder CUDA graph chunks=%d -> out %s (%d cached)",
+            c,
+            tuple(static_out.shape),
+            len(self._graphs),
+        )
+
+    @torch.no_grad()
+    def capture(self, chunk_buckets, forward_batch=None) -> None:
+        """Capture one graph per chunk-count bucket, once, at warmup."""
+        self._forward_batch = forward_batch
+        encoder_len = (self._input_feature_len - 1) // 2 + 1
+
+        with torch.cuda.device(self._device):
+            for c in sorted(
+                {int(x) for x in chunk_buckets if int(x) >= 1}, reverse=True
+            ):
+                if c in self._graphs:
+                    continue
+                enough, free = self._enough_free_vram()
+                if not enough:
+                    logger.warning(
+                        "MOSS-TD encoder CUDA graph: free VRAM %.1fGB < %.1fGB "
+                        "headroom; skipping chunks=%d+ (eager)",
+                        free / 1024**3,
+                        self._min_free_bytes / 1024**3,
+                        c,
+                    )
+                    break
+                try:
+                    self._capture_bucket(c, encoder_len, forward_batch)
+                except Exception as exc:
+                    logger.warning(
+                        "MOSS-TD encoder CUDA graph capture failed for chunks=%d: "
+                        "%s; will use eager for this size",
+                        c,
+                        exc,
+                    )
+                    self._graphs.pop(c, None)
+
+    @torch.no_grad()
+    def run(self, input_features, encoder_position_ids, forward_batch):
+        """Replay the graph for ``[n, num_mel_bins, input_feature_len]`` features,
+        padding up to the nearest captured bucket. Falls back to eager if no
+        bucket fits or the input_feature_len differs from capture."""
+        n = input_features.shape[0]
+        chunk_bucket = min((c for c in self._graphs if c >= n), default=None)
+        if chunk_bucket is None or input_features.shape[-1] != self._input_feature_len:
+            return self._encoder(input_features, encoder_position_ids, forward_batch)
+        graph, static_feat, _static_pos, static_out = self._graphs[chunk_bucket]
+        static_feat[:n].copy_(input_features)
+        if n < chunk_bucket:
+            static_feat[n:].zero_()
+        graph.replay()
+        return static_out[:n].clone()

--- a/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
+++ b/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
@@ -83,12 +83,36 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
             prefix=add_prefix("model.language_model", prefix),
         )
         self.pattern = MultiModalityDataPaddingPatternMultimodalTokens()
+        self._encoder_graph_runner = None
 
     def get_input_embeddings(self):
         return self.language_model.get_input_embeddings()
 
     def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
         return self.pattern.pad_input_tokens(input_ids, mm_inputs)
+
+    def init_encoder_graphs(self, chunk_buckets, input_feature_len: int) -> None:
+        """Capture per-chunk-count CUDA graphs for the Whisper encoder.
+
+        Called from the stage factory after the model is on-device and CUDA
+        graphs are enabled. ``input_feature_len`` is the fixed length of the
+        encoder's ``input_features`` time axis for one 30s window
+        (WhisperFeatureExtractor.nb_max_frames).
+        """
+        buckets = [int(b) for b in (chunk_buckets or []) if int(b) >= 1]
+        if not buckets:
+            return
+        from sglang_omni.models.moss_transcribe_diarize.encoder_cuda_graph import (
+            WhisperEncoderCudaGraphRunner,
+        )
+
+        runner = WhisperEncoderCudaGraphRunner(
+            self.whisper_encoder,
+            num_mel_bins=int(self.config.audio_config.num_mel_bins),
+            input_feature_len=int(input_feature_len),
+        )
+        runner.capture(buckets)
+        self._encoder_graph_runner = runner
 
     def time_merge(self, features: torch.Tensor) -> torch.Tensor:
         batch_size, seq_len, hidden_size = features.shape
@@ -145,11 +169,18 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
             device=input_features.device,
             dtype=torch.long,
         )
-        whisper_features = self.whisper_encoder(
-            input_features,
-            encoder_position_ids,
-            forward_batch,
-        )
+        if self._encoder_graph_runner is not None:
+            whisper_features = self._encoder_graph_runner.run(
+                input_features,
+                encoder_position_ids,
+                forward_batch,
+            )
+        else:
+            whisper_features = self.whisper_encoder(
+                input_features,
+                encoder_position_ids,
+                forward_batch,
+            )
 
         audio_feature_lengths_list = audio_feature_lengths.tolist()
         audio_chunk_mapping_list = audio_chunk_mapping.tolist()

--- a/sglang_omni/models/moss_transcribe_diarize/stages.py
+++ b/sglang_omni/models/moss_transcribe_diarize/stages.py
@@ -33,6 +33,12 @@ from sglang_omni.scheduling.sglang_backend import (
 # Note (yichi): Budget for long-form input and let the checkpoint window cap it.
 _LONG_FORM_PROMPT_TOKENS = 72000
 
+# Note (yijiang): Encoder CUDA-graph chunk-count buckets (1 chunk = one 30s audio
+# window). Chunk count depends on audio length (no config field to derive it
+# from). Larger counts will fall back to eager. Overridable via the
+# ``encoder_graph_chunk_buckets``.
+_DEFAULT_ENCODER_GRAPH_CHUNK_BUCKETS = [1, 2, 4, 8, 16, 32]
+
 
 @contextmanager
 def _missing_additional_chat_templates_compat() -> Iterator[None]:
@@ -94,6 +100,7 @@ def create_sglang_moss_transcribe_diarize_executor(
     mem_fraction_static: float | None = 0.80,
     mm_embedding_cache_size_bytes: int = 0,
     enable_torch_compile: bool = False,
+    encoder_graph_chunk_buckets: list[int] | None = None,
     request_build_max_workers: int = 2,
     request_build_max_pending: int | None = 16,
     server_args_overrides: dict[str, Any] | None = None,
@@ -154,6 +161,13 @@ def create_sglang_moss_transcribe_diarize_executor(
 
     if want_cuda_graph:
         model_worker.model_runner.init_device_graphs()
+        buckets = (
+            encoder_graph_chunk_buckets
+            if encoder_graph_chunk_buckets is not None
+            else _DEFAULT_ENCODER_GRAPH_CHUNK_BUCKETS
+        )
+        input_feature_len = int(processor.feature_extractor.nb_max_frames)
+        model_worker.model_runner.model.init_encoder_graphs(buckets, input_feature_len)
 
     init_mm_embedding_cache(mm_embedding_cache_size_bytes)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Adds a per-chunk-count CUDA graph for the MOSS-Transcribe-Diarize Whisper encoder. The encoder is a fixed-shape, stateless pure function (`[num_chunks, num_mel_bins, input_feature_len]` → `[num_chunks, encoder_len, d_model]`). Only the batch dim (chunk count) varies, so we bucket over chunk count and pad up to the nearest captured bucket. 

## Modifications

 - `encoder_cuda_graph.py`: new `WhisperEncoderCudaGraphRunner` class. It captures one CUDA graph per chunk count, with warmup, a VRAM headroom check before each capture, and eager fallback if anything goes wrong.
  - `sglang_model.py`: `init_encoder_graphs()` builds the runner at startup, and the encoder now runs through it when a graph is available (otherwise fallback to eager).
  - `stages.py`: does the capture on startup; defaults to chunk counts `[1,2,4,8,16,32]`, which can be overridden with `encoder_graph_chunk_buckets`.

## Related Issues

Addresses the **M-PR4** (Encoder CUDA graph) item in #924 

## Correctness

End-to-end (movies800, greedy, concurrency=1): 800/800 samples produce byte-identical `result_text` with vs without the encoder graph. The same eval run also shows all diarization metrics match exactly (speed metrics included below for reference):

  | metric | upstream | graph |
  |---|---|---|
  | cer | 6.55% | 6.55% |
  | cer_no_spk | 6.55% | 6.55% |
  | cp_cer | 12.96% | 12.96% |
  | cer_no_spk_cp_valid | 6.44% | 6.44% |
  | delta_cer | 6.52% | 6.52% |
  | cer_valid_samples | 784 | 784 |
  | cp_cer_valid_samples | 773 | 773 |
  | exact_matches | 23 | 23 |
  | failed_requests | 0 | 0 |
  | rtf_mean | 0.0202 | 0.0192 |
  | rtf_p95 | 0.0304 | 0.0290 |
  | throughput (req/s) | 4.653 | 4.948 |
  | latency_mean (s) | 0.215 | 0.202 |


## Benchmark & Profiling

Ran ASR CI stage 1 locally on **NVIDIA H100 80GB** (movies800, 2-worker router, c=16), 3 runs each, upstream vs this PR.

  **upstream (no encoder graph):**

  | run | CER | cpCER | CER-valid / cpCER-valid | RTF mean | RTF p95 | throughput |
  |---|---|---|---|---|---|---|
  | 1 | 6.73% | 12.90% | 784 / 773 | 0.0359 | 0.0577 | 42.6 |
  | 2 | 6.33% | 12.58% | 784 / 773 | 0.0353 | 0.0575 | 43.4 |
  | 3 | 6.38% | 12.66% | 784 / 773 | 0.0360 | 0.0592 | 42.5 |
  | **worst** | **6.73%** | **12.90%** | **784 / 773** | **0.0360** | **0.0592** | **42.5** |

  **this PR (encoder CUDA graph):**

  | run | CER | cpCER | CER-valid / cpCER-valid | RTF mean | RTF p95 | throughput |
  |---|---|---|---|---|---|---|
  | 1 | 6.35% | 12.53% | 784 / 773 | 0.0326 | 0.0520 | 46.7 |
  | 2 | 6.70% | 12.22% | 784 / 773 | 0.0333 | 0.0533 | 45.9 |
  | 3 | 6.53% | 12.93% | 784 / 773 | 0.0328 | 0.0529 | 46.2 |
  | **worst** | **6.70%** | **12.93%** | **784 / 773** | **0.0333** | **0.0533** | **45.9** |

Accuracy overlaps between the two (differences are within run-to-run concurrency  noise) — consistent with the encoder graph being bit-identical. RTF and throughput improve with non-overlapping ranges across the 3 runs. All runs pass the stage-1 gate.


## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
