### PR TITLE
[Perf]: MOSS-Transcribe-Diarize model Encoder `torch.compile`

### DIFF
--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -29,6 +29,18 @@ _ASYNC_DECODE_FACTORIES = frozenset(
 _QWEN_PARTIAL_START_TALKER_FACTORY = (
     "sglang_omni.models.qwen3_omni.stages.create_talker_ar_executor_from_config"
 )
+_MOSS_TD_ASR_ENCODER_COMPILE_FACTORIES = frozenset(
+    {
+        (
+            "sglang_omni.models.moss_transcribe_diarize.stages."
+            "create_sglang_moss_transcribe_diarize_executor"
+        ),
+        (
+            "sglang_omni.models.moss_transcribe_diarize.stages."
+            "create_moss_transcribe_diarize_executor"
+        ),
+    }
+)
 
 
 def launch_server(*args: object, **kwargs: object) -> object:
@@ -796,6 +808,7 @@ def _apply_stage_factory_args_override(
     updates: dict[str, object],
     reason: str,
     supported_factories: frozenset[str] | None = None,
+    supported_factories_description: str = "Higgs TTS and MOSS-TTS-Local",
     flag_name: str | None = None,
 ) -> None:
     matching_stages = _find_matching_stages(
@@ -807,9 +820,9 @@ def _apply_stage_factory_args_override(
         if supported_factories is not None and stage.factory not in supported_factories:
             display_flag = flag_name or reason
             raise typer.BadParameter(
-                f"{display_flag} currently supports only Higgs TTS and "
-                f"MOSS-TTS-Local; stage {stage.name!r} uses factory "
-                f"{stage.factory!r}"
+                f"{display_flag} currently supports only "
+                f"{supported_factories_description}; stage {stage.name!r} "
+                f"uses factory {stage.factory!r}"
             )
         factory_args = dict(stage.factory_args or {})
         factory_args.update(updates)
@@ -888,6 +901,36 @@ def apply_torch_compile_cli_overrides(
             mode=talker_mode,
             max_bs=talker_torch_compile_max_bs,
         )
+    return pipeline_config
+
+
+def apply_asr_encoder_torch_compile_cli_overrides(
+    pipeline_config: PipelineConfig,
+    *,
+    asr_encoder_torch_compile: str,
+    asr_encoder_torch_compile_mode: str | None,
+) -> PipelineConfig:
+    mode = _normalize_stage_toggle_mode(
+        "asr_encoder_torch_compile",
+        asr_encoder_torch_compile,
+    )
+    updates: dict[str, object] = {}
+    if mode != "default":
+        updates["encoder_torch_compile"] = mode == "on"
+    if asr_encoder_torch_compile_mode is not None:
+        updates["encoder_torch_compile_mode"] = asr_encoder_torch_compile_mode
+    if not updates:
+        return pipeline_config
+
+    _apply_stage_factory_args_override(
+        pipeline_config,
+        stage_name="asr",
+        updates=updates,
+        reason="ASR encoder torch.compile override",
+        supported_factories=_MOSS_TD_ASR_ENCODER_COMPILE_FACTORIES,
+        supported_factories_description="MOSS-Transcribe-Diarize ASR",
+        flag_name="--asr-encoder-torch-compile",
+    )
     return pipeline_config
 
 
@@ -1130,6 +1173,28 @@ def serve(
             help="Override torch_compile_max_bs for supported SGLang talker stage.",
         ),
     ] = None,
+    asr_encoder_torch_compile: Annotated[
+        str,
+        typer.Option(
+            "--asr-encoder-torch-compile",
+            "--asr_encoder_torch_compile",
+            help=(
+                "torch.compile mode for the MOSS-Transcribe-Diarize ASR "
+                "encoder: default|on|off."
+            ),
+        ),
+    ] = "default",
+    asr_encoder_torch_compile_mode: Annotated[
+        str | None,
+        typer.Option(
+            "--asr-encoder-torch-compile-mode",
+            "--asr_encoder_torch_compile_mode",
+            help=(
+                "Torch compile mode for the MOSS-Transcribe-Diarize ASR "
+                "encoder, e.g. max-autotune-no-cudagraphs."
+            ),
+        ),
+    ] = None,
     enable_realtime: Annotated[
         bool,
         typer.Option(
@@ -1258,6 +1323,11 @@ def serve(
         talker_torch_compile=talker_torch_compile,
         thinker_torch_compile_max_bs=thinker_torch_compile_max_bs,
         talker_torch_compile_max_bs=talker_torch_compile_max_bs,
+    )
+    merged_config = apply_asr_encoder_torch_compile_cli_overrides(
+        merged_config,
+        asr_encoder_torch_compile=asr_encoder_torch_compile,
+        asr_encoder_torch_compile_mode=asr_encoder_torch_compile_mode,
     )
     merged_config = apply_decode_mode_cli_overrides(
         merged_config,

--- a/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
+++ b/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
@@ -139,10 +139,12 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
             )
 
     def _audio_encoder_callable(self):
-        return self.__dict__.get("_compiled_whisper_encoder") or self.whisper_encoder
+        compiled = self.__dict__.get("_compiled_whisper_encoder")
+        return compiled if compiled is not None else self.whisper_encoder
 
     def _vq_adaptor_callable(self):
-        return self.__dict__.get("_compiled_vq_adaptor") or self.vq_adaptor
+        compiled = self.__dict__.get("_compiled_vq_adaptor")
+        return compiled if compiled is not None else self.vq_adaptor
 
     def get_audio_feature(
         self,

--- a/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
+++ b/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
@@ -83,6 +83,8 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
             prefix=add_prefix("model.language_model", prefix),
         )
         self.pattern = MultiModalityDataPaddingPatternMultimodalTokens()
+        self._compiled_whisper_encoder = None
+        self._compiled_vq_adaptor = None
 
     def get_input_embeddings(self):
         return self.language_model.get_input_embeddings()
@@ -97,6 +99,50 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
         return features[:, :trimmed_len, :].reshape(
             batch_size, trimmed_len // merge_size, hidden_size * merge_size
         )
+
+    def compile_audio_encoder(
+        self,
+        *,
+        mode: str,
+        dynamic: bool = True,
+        compile_adaptor: bool = False,
+    ) -> None:
+        """Compile tensor-only audio encoder hot paths.
+
+        Keep the original modules installed on the model so weight loading,
+        state dicts, and debugging still see the eager module tree. The compiled
+        callables are intentionally stored outside ``nn.Module`` registration.
+        """
+        from sglang.srt.model_executor.cuda_graph_runner import set_torch_compile_config
+
+        set_torch_compile_config()
+        logger.info(
+            "Compiling MOSS-TD WhisperEncoder (mode=%s, dynamic=%s)",
+            mode,
+            dynamic,
+        )
+        self.__dict__["_compiled_whisper_encoder"] = torch.compile(
+            self.whisper_encoder,
+            mode=mode,
+            dynamic=dynamic,
+        )
+        if compile_adaptor:
+            logger.info(
+                "Compiling MOSS-TD VQAdaptor (mode=%s, dynamic=%s)",
+                mode,
+                dynamic,
+            )
+            self.__dict__["_compiled_vq_adaptor"] = torch.compile(
+                self.vq_adaptor,
+                mode=mode,
+                dynamic=dynamic,
+            )
+
+    def _audio_encoder_callable(self):
+        return self.__dict__.get("_compiled_whisper_encoder") or self.whisper_encoder
+
+    def _vq_adaptor_callable(self):
+        return self.__dict__.get("_compiled_vq_adaptor") or self.vq_adaptor
 
     def get_audio_feature(
         self,
@@ -164,7 +210,7 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
         encoder_position_ids = torch.arange(
             encoder_len, device=device, dtype=torch.long
         )
-        features = self.whisper_encoder(
+        features = self._audio_encoder_callable()(
             batched_features, encoder_position_ids, forward_batch
         )
 
@@ -178,7 +224,7 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
             ).squeeze(0)
             for ids in audio_spans
         ]
-        return self.vq_adaptor(torch.cat(merged, dim=0))
+        return self._vq_adaptor_callable()(torch.cat(merged, dim=0))
 
     def forward(
         self,

--- a/sglang_omni/models/moss_transcribe_diarize/stages.py
+++ b/sglang_omni/models/moss_transcribe_diarize/stages.py
@@ -3,10 +3,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from contextlib import contextmanager
 import logging
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any
 

--- a/sglang_omni/models/moss_transcribe_diarize/stages.py
+++ b/sglang_omni/models/moss_transcribe_diarize/stages.py
@@ -165,7 +165,7 @@ def create_sglang_moss_transcribe_diarize_executor(
     enable_torch_compile: bool = False,
     encoder_torch_compile: bool = False,
     encoder_torch_compile_mode: str | None = None,
-    encoder_torch_compile_dynamic: bool = True,
+    encoder_torch_compile_dynamic: bool = False,
     encoder_torch_compile_warmup: bool = True,
     encoder_torch_compile_adaptor: bool = False,
     request_build_max_workers: int = 2,

--- a/sglang_omni/models/moss_transcribe_diarize/stages.py
+++ b/sglang_omni/models/moss_transcribe_diarize/stages.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import contextmanager
+import logging
+import os
+from types import SimpleNamespace
 from typing import Any
 
+import torch
 from sglang.srt.managers.mm_utils import init_mm_embedding_cache
 from transformers import AutoConfig, AutoProcessor, GenerationConfig
 
@@ -29,6 +33,8 @@ from sglang_omni.scheduling.sglang_backend import (
     SGLangOutputProcessor,
     build_sglang_server_args,
 )
+
+logger = logging.getLogger(__name__)
 
 # Note (yichi): Budget for long-form input and let the checkpoint window cap it.
 _LONG_FORM_PROMPT_TOKENS = 72000
@@ -83,6 +89,69 @@ def _default_max_new_tokens(model_path: str) -> int:
     return int(getattr(generation_config, "max_new_tokens", None) or 5120)
 
 
+def _resolve_encoder_torch_compile_mode(mode: str | None) -> str:
+    return mode or os.environ.get(
+        "SGLANG_TORCH_COMPILE_MODE",
+        "max-autotune-no-cudagraphs",
+    )
+
+
+def _torch_dtype_from_name(dtype: str | torch.dtype) -> torch.dtype:
+    if isinstance(dtype, torch.dtype):
+        return dtype
+    normalized = str(dtype).replace("torch.", "").lower()
+    if normalized in {"bfloat16", "bf16"}:
+        return torch.bfloat16
+    if normalized in {"float16", "half", "fp16"}:
+        return torch.float16
+    if normalized in {"float32", "float", "fp32"}:
+        return torch.float32
+    return torch.bfloat16
+
+
+def _warmup_moss_td_encoder_compile(
+    model: Any,
+    *,
+    device: str,
+    dtype: str | torch.dtype,
+) -> None:
+    compiled_encoder = getattr(model, "_compiled_whisper_encoder", None)
+    if compiled_encoder is None:
+        return
+
+    try:
+        first_param = next(model.whisper_encoder.parameters())
+        warmup_device = first_param.device
+        warmup_dtype = first_param.dtype
+    except (AttributeError, StopIteration):
+        warmup_device = torch.device(device)
+        warmup_dtype = _torch_dtype_from_name(dtype)
+
+    audio_config = model.config.audio_config
+    num_mel_bins = int(getattr(audio_config, "num_mel_bins", 80))
+    max_source_positions = int(getattr(audio_config, "max_source_positions", 1500))
+    num_frames = max(2, max_source_positions * 2)
+    input_features = torch.zeros(
+        (1, num_mel_bins, num_frames),
+        device=warmup_device,
+        dtype=warmup_dtype,
+    )
+    encoder_len = (input_features.shape[-1] - 1) // 2 + 1
+    encoder_position_ids = torch.arange(
+        encoder_len,
+        device=input_features.device,
+        dtype=torch.long,
+    )
+    fake_forward_batch = SimpleNamespace()
+
+    with torch.inference_mode():
+        compiled_encoder(input_features, encoder_position_ids, fake_forward_batch)
+    logger.info(
+        "Warmed up MOSS-TD encoder compile with input_features shape=%s",
+        tuple(input_features.shape),
+    )
+
+
 def create_sglang_moss_transcribe_diarize_executor(
     model_path: str,
     *,
@@ -94,6 +163,11 @@ def create_sglang_moss_transcribe_diarize_executor(
     mem_fraction_static: float | None = 0.80,
     mm_embedding_cache_size_bytes: int = 0,
     enable_torch_compile: bool = False,
+    encoder_torch_compile: bool = False,
+    encoder_torch_compile_mode: str | None = None,
+    encoder_torch_compile_dynamic: bool = True,
+    encoder_torch_compile_warmup: bool = True,
+    encoder_torch_compile_adaptor: bool = False,
     request_build_max_workers: int = 2,
     request_build_max_pending: int | None = 16,
     server_args_overrides: dict[str, Any] | None = None,
@@ -151,6 +225,17 @@ def create_sglang_moss_transcribe_diarize_executor(
         gpu_id,
         model_arch_override="MossTranscribeDiarizeForConditionalGeneration",
     )
+
+    if encoder_torch_compile:
+        model = model_worker.model_runner.model
+        compile_mode = _resolve_encoder_torch_compile_mode(encoder_torch_compile_mode)
+        model.compile_audio_encoder(
+            mode=compile_mode,
+            dynamic=encoder_torch_compile_dynamic,
+            compile_adaptor=encoder_torch_compile_adaptor,
+        )
+        if encoder_torch_compile_warmup:
+            _warmup_moss_td_encoder_compile(model, device=device, dtype=dtype)
 
     if want_cuda_graph:
         model_worker.model_runner.init_device_graphs()

--- a/tests/unit_test/moss_transcribe_diarize/test_encoder_compile.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_encoder_compile.py
@@ -1,0 +1,470 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+import typer
+
+from sglang_omni.cli.serve import apply_asr_encoder_torch_compile_cli_overrides
+from sglang_omni.config import PipelineConfig, StageConfig, resolve_stage_factory_args
+from sglang_omni.models.moss_transcribe_diarize.config import (
+    MossTranscribeDiarizePipelineConfig,
+)
+from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
+
+
+def _package(name: str) -> ModuleType:
+    module = ModuleType(name)
+    module.__path__ = []  # type: ignore[attr-defined]
+    return module
+
+
+def _install_fake_sglang_model_deps(monkeypatch: pytest.MonkeyPatch) -> None:
+    modules = {
+        "sglang": _package("sglang"),
+        "sglang.srt": _package("sglang.srt"),
+        "sglang.srt.layers": _package("sglang.srt.layers"),
+        "sglang.srt.layers.quantization": _package("sglang.srt.layers.quantization"),
+        "sglang.srt.layers.quantization.base_config": ModuleType(
+            "sglang.srt.layers.quantization.base_config"
+        ),
+        "sglang.srt.managers": _package("sglang.srt.managers"),
+        "sglang.srt.managers.mm_utils": ModuleType("sglang.srt.managers.mm_utils"),
+        "sglang.srt.managers.schedule_batch": ModuleType(
+            "sglang.srt.managers.schedule_batch"
+        ),
+        "sglang.srt.model_executor": _package("sglang.srt.model_executor"),
+        "sglang.srt.model_executor.forward_batch_info": ModuleType(
+            "sglang.srt.model_executor.forward_batch_info"
+        ),
+        "sglang.srt.model_loader": _package("sglang.srt.model_loader"),
+        "sglang.srt.model_loader.weight_utils": ModuleType(
+            "sglang.srt.model_loader.weight_utils"
+        ),
+        "sglang.srt.models": _package("sglang.srt.models"),
+        "sglang.srt.models.qwen3": ModuleType("sglang.srt.models.qwen3"),
+        "sglang.srt.models.whisper": ModuleType("sglang.srt.models.whisper"),
+        "sglang.srt.utils": ModuleType("sglang.srt.utils"),
+    }
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    modules["sglang.srt.layers.quantization.base_config"].QuantizationConfig = object
+    modules[
+        "sglang.srt.managers.mm_utils"
+    ].MultiModalityDataPaddingPatternMultimodalTokens = object
+    modules["sglang.srt.managers.mm_utils"].general_mm_embed_routine = (
+        lambda **kwargs: kwargs
+    )
+    modules["sglang.srt.managers.schedule_batch"].Modality = SimpleNamespace(
+        AUDIO="audio"
+    )
+    modules["sglang.srt.managers.schedule_batch"].MultimodalDataItem = object
+    modules["sglang.srt.managers.schedule_batch"].MultimodalInputs = object
+    modules["sglang.srt.model_executor.forward_batch_info"].ForwardBatch = object
+    modules["sglang.srt.model_loader.weight_utils"].default_weight_loader = (
+        lambda param, loaded_weight: None
+    )
+    modules["sglang.srt.models.qwen3"].Qwen3ForCausalLM = object
+    modules["sglang.srt.models.whisper"].WhisperEncoder = object
+    modules["sglang.srt.utils"].add_prefix = lambda name, prefix: f"{prefix}.{name}"
+
+    sys.modules.pop(
+        "sglang_omni.models.moss_transcribe_diarize.sglang_model",
+        None,
+    )
+
+
+def _install_fake_compile_config(monkeypatch: pytest.MonkeyPatch, calls: list[bool]):
+    cuda_graph_runner = ModuleType("sglang.srt.model_executor.cuda_graph_runner")
+    cuda_graph_runner.set_torch_compile_config = lambda: calls.append(True)
+    monkeypatch.setitem(
+        sys.modules,
+        "sglang.srt.model_executor.cuda_graph_runner",
+        cuda_graph_runner,
+    )
+
+
+def _import_sglang_model(monkeypatch: pytest.MonkeyPatch):
+    _install_fake_sglang_model_deps(monkeypatch)
+    return importlib.import_module(
+        "sglang_omni.models.moss_transcribe_diarize.sglang_model"
+    )
+
+
+def test_compile_audio_encoder_uses_torch_compile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sglang_model = _import_sglang_model(monkeypatch)
+    set_config_calls: list[bool] = []
+    _install_fake_compile_config(monkeypatch, set_config_calls)
+    compile_calls: list[tuple[object, str | None, bool | None]] = []
+
+    def fake_compile(target, *, mode=None, dynamic=None):
+        compile_calls.append((target, mode, dynamic))
+        return f"compiled-{len(compile_calls)}"
+
+    monkeypatch.setattr(torch, "compile", fake_compile)
+    model = SimpleNamespace(whisper_encoder=object(), vq_adaptor=object())
+
+    sglang_model.MossTranscribeDiarizeForConditionalGeneration.compile_audio_encoder(
+        model,
+        mode="reduce-overhead",
+        dynamic=True,
+        compile_adaptor=False,
+    )
+
+    assert set_config_calls == [True]
+    assert compile_calls == [(model.whisper_encoder, "reduce-overhead", True)]
+    assert model._compiled_whisper_encoder == "compiled-1"
+    assert getattr(model, "_compiled_vq_adaptor", None) is None
+
+
+def test_compile_audio_encoder_optionally_compiles_adaptor_and_encode_uses_compiled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sglang_model = _import_sglang_model(monkeypatch)
+    set_config_calls: list[bool] = []
+    _install_fake_compile_config(monkeypatch, set_config_calls)
+    compile_calls: list[tuple[object, str | None, bool | None]] = []
+
+    def fake_compile(target, *, mode=None, dynamic=None):
+        compile_calls.append((target, mode, dynamic))
+        return f"compiled-{len(compile_calls)}"
+
+    monkeypatch.setattr(torch, "compile", fake_compile)
+
+    class OriginalEncoder(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.param = torch.nn.Parameter(torch.zeros((), dtype=torch.float32))
+
+        def forward(self, *args, **kwargs):
+            raise AssertionError("eager encoder should not be called")
+
+    class OriginalAdaptor(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.param = torch.nn.Parameter(torch.zeros((), dtype=torch.float32))
+
+        def forward(self, *args, **kwargs):
+            raise AssertionError("eager adaptor should not be called")
+
+    model = SimpleNamespace(
+        whisper_encoder=OriginalEncoder(),
+        vq_adaptor=OriginalAdaptor(),
+    )
+    sglang_model.MossTranscribeDiarizeForConditionalGeneration.compile_audio_encoder(
+        model,
+        mode="max-autotune-no-cudagraphs",
+        dynamic=False,
+        compile_adaptor=True,
+    )
+    assert compile_calls == [
+        (model.whisper_encoder, "max-autotune-no-cudagraphs", False),
+        (model.vq_adaptor, "max-autotune-no-cudagraphs", False),
+    ]
+
+    encoder_calls: list[torch.Tensor] = []
+    adaptor_calls: list[torch.Tensor] = []
+
+    def compiled_encoder(input_features, encoder_position_ids, forward_batch):
+        del encoder_position_ids, forward_batch
+        encoder_calls.append(input_features)
+        return torch.arange(12, dtype=torch.float32).reshape(1, 4, 3)
+
+    def compiled_adaptor(features):
+        adaptor_calls.append(features)
+        return torch.ones((features.shape[0], 5), dtype=torch.float32)
+
+    model._compiled_whisper_encoder = compiled_encoder
+    model._compiled_vq_adaptor = compiled_adaptor
+    model.config = SimpleNamespace(audio_merge_size=2)
+    model_class = sglang_model.MossTranscribeDiarizeForConditionalGeneration
+    model.time_merge = lambda features: model_class.time_merge(
+        model,
+        features,
+    )
+    model._audio_encoder_callable = lambda: model_class._audio_encoder_callable(model)
+    model._vq_adaptor_callable = lambda: model_class._vq_adaptor_callable(model)
+    item = SimpleNamespace(
+        feature=torch.zeros((1, 80, 8), dtype=torch.float32),
+        audio_feature_lengths=torch.tensor([2]),
+        audio_chunk_mapping=torch.tensor([0]),
+    )
+
+    adapted = model_class.get_audio_feature(
+        model,
+        [item],
+        forward_batch=object(),
+    )
+
+    assert len(encoder_calls) == 1
+    assert len(adaptor_calls) == 1
+    assert adaptor_calls[0].shape == (2, 6)
+    assert adapted.shape == (2, 5)
+
+
+def _install_fake_stage_deps(monkeypatch: pytest.MonkeyPatch) -> None:
+    modules = {
+        "sglang": _package("sglang"),
+        "sglang.srt": _package("sglang.srt"),
+        "sglang.srt.managers": _package("sglang.srt.managers"),
+        "sglang.srt.managers.mm_utils": ModuleType("sglang.srt.managers.mm_utils"),
+        "sglang_omni.model_runner.base": ModuleType("sglang_omni.model_runner.base"),
+        "sglang_omni.models.moss_transcribe_diarize.request_builders": ModuleType(
+            "sglang_omni.models.moss_transcribe_diarize.request_builders"
+        ),
+        "sglang_omni.scheduling.bootstrap": ModuleType(
+            "sglang_omni.scheduling.bootstrap"
+        ),
+        "sglang_omni.scheduling.omni_scheduler": ModuleType(
+            "sglang_omni.scheduling.omni_scheduler"
+        ),
+        "sglang_omni.scheduling.sglang_backend": ModuleType(
+            "sglang_omni.scheduling.sglang_backend"
+        ),
+    }
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    modules["sglang.srt.managers.mm_utils"].init_mm_embedding_cache = lambda size: None
+    modules["sglang_omni.model_runner.base"].ModelRunner = (
+        lambda model_worker, output_proc: SimpleNamespace(
+            model_worker=model_worker,
+            output_proc=output_proc,
+        )
+    )
+    modules[
+        "sglang_omni.models.moss_transcribe_diarize.request_builders"
+    ].make_moss_transcribe_diarize_scheduler_adapters = lambda **kwargs: (
+        object(),
+        object(),
+    )
+    modules[
+        "sglang_omni.scheduling.bootstrap"
+    ].create_sglang_infrastructure_defer_cuda_graph = lambda *args, **kwargs: None
+
+    class FakeScheduler:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    modules["sglang_omni.scheduling.omni_scheduler"].OmniScheduler = FakeScheduler
+
+    backend = modules["sglang_omni.scheduling.sglang_backend"]
+    backend.SGLangOutputProcessor = lambda **kwargs: SimpleNamespace(**kwargs)
+
+    def fake_build_sglang_server_args(model_path, context_length, **kwargs):
+        return SimpleNamespace(
+            model_path=model_path,
+            context_length=context_length,
+            **kwargs,
+        )
+
+    backend.build_sglang_server_args = fake_build_sglang_server_args
+
+    sys.modules.pop("sglang_omni.models.moss_transcribe_diarize.stages", None)
+
+
+def _import_stages(monkeypatch: pytest.MonkeyPatch):
+    _install_fake_stage_deps(monkeypatch)
+    return importlib.import_module("sglang_omni.models.moss_transcribe_diarize.stages")
+
+
+def test_moss_td_stage_applies_encoder_compile_without_enabling_sglang_compile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stages = _import_stages(monkeypatch)
+    monkeypatch.setattr(
+        stages.AutoProcessor,
+        "from_pretrained",
+        staticmethod(lambda *args, **kwargs: SimpleNamespace(tokenizer=object())),
+    )
+    monkeypatch.setattr(stages, "_default_max_new_tokens", lambda model_path: 8)
+    monkeypatch.setattr(
+        stages,
+        "_default_context_length",
+        lambda model_path, max_new_tokens: 128,
+    )
+    monkeypatch.setattr(
+        stages,
+        "_warmup_moss_td_encoder_compile",
+        lambda *a, **k: None,
+    )
+    compile_calls: list[dict[str, object]] = []
+    init_graph_calls: list[bool] = []
+    infrastructure_enable_torch_compile: list[bool] = []
+
+    class FakeModel:
+        def compile_audio_encoder(self, **kwargs):
+            compile_calls.append(kwargs)
+
+    class FakeRunner:
+        def __init__(self, server_args):
+            self.server_args = server_args
+            self.model = FakeModel()
+
+        def init_device_graphs(self):
+            init_graph_calls.append(True)
+
+    class FakeWorker:
+        def __init__(self, server_args):
+            self.model_runner = FakeRunner(server_args)
+
+    def fake_create_sglang_infrastructure_defer_cuda_graph(
+        server_args,
+        gpu_id,
+        *,
+        model_arch_override,
+    ):
+        del gpu_id, model_arch_override
+        infrastructure_enable_torch_compile.append(server_args.enable_torch_compile)
+        return True, (
+            FakeWorker(server_args),
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            SimpleNamespace(),
+        )
+
+    monkeypatch.setattr(
+        stages,
+        "create_sglang_infrastructure_defer_cuda_graph",
+        fake_create_sglang_infrastructure_defer_cuda_graph,
+    )
+
+    scheduler = stages.create_sglang_moss_transcribe_diarize_executor(
+        "model",
+        device="cuda:0",
+        encoder_torch_compile=True,
+        encoder_torch_compile_mode="reduce-overhead",
+        encoder_torch_compile_dynamic=False,
+        encoder_torch_compile_warmup=False,
+        encoder_torch_compile_adaptor=True,
+    )
+
+    assert infrastructure_enable_torch_compile == [False]
+    assert compile_calls == [
+        {
+            "mode": "reduce-overhead",
+            "dynamic": False,
+            "compile_adaptor": True,
+        }
+    ]
+    assert init_graph_calls == [True]
+    assert scheduler.server_args.enable_torch_compile is False
+
+
+def test_moss_td_stage_skips_encoder_compile_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stages = _import_stages(monkeypatch)
+    monkeypatch.setattr(
+        stages.AutoProcessor,
+        "from_pretrained",
+        staticmethod(lambda *args, **kwargs: SimpleNamespace(tokenizer=object())),
+    )
+    monkeypatch.setattr(stages, "_default_max_new_tokens", lambda model_path: 8)
+    monkeypatch.setattr(
+        stages,
+        "_default_context_length",
+        lambda model_path, max_new_tokens: 128,
+    )
+    compile_calls: list[dict[str, object]] = []
+
+    class FakeModel:
+        def compile_audio_encoder(self, **kwargs):
+            compile_calls.append(kwargs)
+
+    class FakeRunner:
+        def __init__(self, server_args):
+            self.model = FakeModel()
+
+        def init_device_graphs(self):
+            raise AssertionError("CUDA graphs should be disabled in this fake")
+
+    def fake_create_sglang_infrastructure_defer_cuda_graph(
+        server_args,
+        gpu_id,
+        *,
+        model_arch_override,
+    ):
+        del gpu_id, model_arch_override
+        return False, (
+            SimpleNamespace(model_runner=FakeRunner(server_args)),
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            SimpleNamespace(),
+        )
+
+    monkeypatch.setattr(
+        stages,
+        "create_sglang_infrastructure_defer_cuda_graph",
+        fake_create_sglang_infrastructure_defer_cuda_graph,
+    )
+
+    stages.create_sglang_moss_transcribe_diarize_executor("model")
+
+    assert compile_calls == []
+
+
+def test_asr_encoder_torch_compile_cli_targets_moss_td_asr_stage() -> None:
+    config = MossTranscribeDiarizePipelineConfig(model_path="model")
+
+    apply_asr_encoder_torch_compile_cli_overrides(
+        config,
+        asr_encoder_torch_compile="on",
+        asr_encoder_torch_compile_mode="reduce-overhead",
+    )
+
+    asr_stage = next(stage for stage in config.stages if stage.name == "asr")
+    args = resolve_stage_factory_args(asr_stage, config)
+    assert args["encoder_torch_compile"] is True
+    assert args["encoder_torch_compile_mode"] == "reduce-overhead"
+
+
+def test_asr_encoder_torch_compile_rejects_unsupported_factory() -> None:
+    config = Qwen3ASRPipelineConfig(model_path="model")
+
+    with pytest.raises(
+        typer.BadParameter,
+        match="MOSS-Transcribe-Diarize ASR",
+    ):
+        apply_asr_encoder_torch_compile_cli_overrides(
+            config,
+            asr_encoder_torch_compile="on",
+            asr_encoder_torch_compile_mode=None,
+        )
+
+
+def test_asr_encoder_torch_compile_default_is_noop() -> None:
+    config = PipelineConfig(
+        model_path="model",
+        stages=[
+            StageConfig(
+                name="stage",
+                process="stage",
+                factory="tests.unit_test.fixtures.pipeline_fakes.dummy_factory",
+                terminal=True,
+            )
+        ],
+    )
+    before = config.model_dump()
+
+    apply_asr_encoder_torch_compile_cli_overrides(
+        config,
+        asr_encoder_torch_compile="default",
+        asr_encoder_torch_compile_mode=None,
+    )
+
+    assert config.model_dump() == before

--- a/tests/unit_test/moss_transcribe_diarize/test_encoder_compile.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_encoder_compile.py
@@ -173,17 +173,25 @@ def test_compile_audio_encoder_optionally_compiles_adaptor_and_encode_uses_compi
     encoder_calls: list[torch.Tensor] = []
     adaptor_calls: list[torch.Tensor] = []
 
-    def compiled_encoder(input_features, encoder_position_ids, forward_batch):
-        del encoder_position_ids, forward_batch
-        encoder_calls.append(input_features)
-        return torch.arange(12, dtype=torch.float32).reshape(1, 4, 3)
+    class CompiledEncoder:
+        def __bool__(self):
+            raise TypeError("compiled encoder should not be truth-tested")
 
-    def compiled_adaptor(features):
-        adaptor_calls.append(features)
-        return torch.ones((features.shape[0], 5), dtype=torch.float32)
+        def __call__(self, input_features, encoder_position_ids, forward_batch):
+            del encoder_position_ids, forward_batch
+            encoder_calls.append(input_features)
+            return torch.arange(12, dtype=torch.float32).reshape(1, 4, 3)
 
-    model._compiled_whisper_encoder = compiled_encoder
-    model._compiled_vq_adaptor = compiled_adaptor
+    class CompiledAdaptor:
+        def __bool__(self):
+            raise TypeError("compiled adaptor should not be truth-tested")
+
+        def __call__(self, features):
+            adaptor_calls.append(features)
+            return torch.ones((features.shape[0], 5), dtype=torch.float32)
+
+    model._compiled_whisper_encoder = CompiledEncoder()
+    model._compiled_vq_adaptor = CompiledAdaptor()
     model.config = SimpleNamespace(audio_merge_size=2)
     model_class = sglang_model.MossTranscribeDiarizeForConditionalGeneration
     model.time_merge = lambda features: model_class.time_merge(
@@ -360,6 +368,22 @@ def test_moss_td_stage_applies_encoder_compile_without_enabling_sglang_compile(
     ]
     assert init_graph_calls == [True]
     assert scheduler.server_args.enable_torch_compile is False
+
+
+def test_moss_td_stage_encoder_compile_defaults_are_e2e_safe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stages = _import_stages(monkeypatch)
+    monkeypatch.delenv("SGLANG_TORCH_COMPILE_MODE", raising=False)
+
+    assert stages._resolve_encoder_torch_compile_mode(None) == (
+        "max-autotune-no-cudagraphs"
+    )
+    assert stages._resolve_encoder_torch_compile_mode("reduce-overhead") == (
+        "reduce-overhead"
+    )
+    defaults = stages.create_sglang_moss_transcribe_diarize_executor.__kwdefaults__
+    assert defaults["encoder_torch_compile_dynamic"] is False
 
 
 def test_moss_td_stage_skips_encoder_compile_by_default(


### PR DESCRIPTION
## Motivation

#924

Add and evaluate optional `torch.compile` support for the MOSS Transcribe-Diarize ASR encoder path. The goal is to check whether compiling only the encoder can improve end-to-end latency without introducing other optimization changes.

## Modifications

- Add an encoder-only benchmark:
  - `benchmarks/eval/benchmark_moss_transcribe_diarize_encoder_compile.py`
- Document the benchmark method and measured e2e results.
- Use `max-autotune-no-cudagraphs` with `dynamic=False` as the recommended encoder compile configuration.
- Keep the benchmark scope limited to the Whisper encoder path compiled by `compile_audio_encoder`.
- Exclude VQ adaptor, language model, router/HTTP layer, cache, request preprocessing, concurrency tuning, and other service-side optimizations from the benchmark scope.

## Benchmark & Profiling

### Encoder-only benchmark

Environment:

- GPU: NVIDIA H800 PCIe, 80GB
- Model: `/root/models/MOSS-Transcribe-Diarize`
- Script: `benchmarks/eval/benchmark_moss_transcribe_diarize_encoder_compile.py`
- Config: `--frames 3000 --warmup 5 --iters 50`
- Compile mode: `max-autotune-no-cudagraphs`
- `dynamic=False`

| Mode | mean ms | p50 ms | p95 ms | speedup vs eager |
| --- | ---: | ---: | ---: | ---: |
| eager | 6.9335 | 6.3678 | 8.3071 | 1.0000x |
| `torch.compile:max-autotune-no-cudagraphs` | 5.1551 | 5.1053 | 5.1569 | 1.3450x |

The encoder hot path improves from `6.9335 ms` to `5.1551 ms` mean latency, about `1.345x` faster.

### E2E benchmark: short audio

Config:

- Audio: `results/query_to_cars_30s.wav`
- Total audio duration: `332.64s`
- Requests: `12`
- Concurrency: `1`
- Warmup: `1`

| Mode | success | throughput req/s | latency mean s | latency p50 s | latency p95 s |
| --- | ---: | ---: | ---: | ---: | ---: |
| encoder compile off | 12/12 | 5.3548 | 0.1864 | 0.1909 | 0.2199 |
| encoder compile on | 12/12 | 5.1996 | 0.1920 | 0.1969 | 0.2272 |

Short audio did not show an e2e gain:

- Mean latency: `+3.00%`
- Throughput: `-2.90%`

This indicates the short-audio workload is not dominated enough by the encoder path.

### E2E benchmark: long audio

Config:

- Audio: `results/query_to_cars_120s.wav`
- Per-request audio duration: `110.88s`
- Total audio duration: `443.52s`
- Requests: `4`
- Concurrency: `1`
- Warmup: `1`

| Mode | success | throughput req/s | latency mean s | latency p50 s | latency p95 s |
| --- | ---: | ---: | ---: | ---: | ---: |
| encoder compile off | 4/4 | 1.7085 | 0.5845 | 0.5975 | 0.7859 |
| encoder compile on | 4/4 | 1.8119 | 0.5509 | 0.5353 | 0.7997 |

Long audio showed a measurable e2e improvement:

- Mean latency: `-5.75%`
- Throughput: `+6.05%`
- Wall clock: `-5.71%`
- p50 latency: `-10.41%`
- p95 latency: `+1.76%`

The long-audio workload is more encoder-heavy, so encoder compile gives a visible e2e benefit.

### Compile mode selection

| Compile mode | Result | Decision |
| --- | --- | --- |
| `reduce-overhead` | Faster in microbenchmark, but unstable in e2e with output drift and a cudagraph-related assertion | Rejected |
| `max-autotune-no-cudagraphs`, `dynamic=False` | Encoder-only speedup and long-audio e2e improvement | Selected |
| `max-autotune-no-cudagraphs`, `dynamic=True` | No clear advantage over static shapes and higher first-real-input compile/autotune cost | Rejected |

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the `run-ci` label. Once labeled, every subsequent push re-triggers CI as long as the label remains. Use `/tag-and-rerun-ci higgs` or `/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even if labeled.

