### PR TITLE
[ASR] Default transcription requests to greedy decoding

### DIFF
--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -1608,8 +1608,9 @@ def build_transcription_generate_request(
         params["language"] = language
     if prompt is not None:
         params["prompt"] = prompt
-    if temperature is not None:
-        params["temperature"] = temperature
+    # note (aaron): the client layer fills in the SamplingParams default of 1.0
+    # when this key is absent. 0.0 (greedy) matches the OpenAI API, see issue #959.
+    params["temperature"] = temperature if temperature is not None else 0.0
 
     return GenerateRequest(
         model=model,

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -831,10 +831,28 @@ def test_transcription_request_builds_asr_generate_request() -> None:
         "filename": "sample.wav",
         "content_type": "audio/wav",
     }
-    assert gen_req.extra_params == {"task": "transcribe", "language": "en"}
+    assert gen_req.extra_params == {
+        "task": "transcribe",
+        "language": "en",
+        "temperature": 0.0,
+    }
     assert gen_req.metadata == {"task": "asr"}
     assert gen_req.output_modalities == ["text"]
     assert gen_req.stream is False
+
+
+def test_transcription_request_passes_explicit_temperature() -> None:
+    gen_req = build_transcription_generate_request(
+        audio_bytes=b"RIFF",
+        filename="sample.wav",
+        content_type="audio/wav",
+        model="openai/whisper-large-v3",
+        language="en",
+        prompt=None,
+        temperature=0.7,
+    )
+
+    assert gen_req.extra_params["temperature"] == 0.7
 
 
 def test_transcription_endpoint_returns_text_json() -> None:


### PR DESCRIPTION
## Motivation

/v1/audio/transcriptions decodes at an effective temperature of 1.0 when the request does not set one. The endpoint only forwards temperature when the form field is present, so the SamplingParams dataclass default of 1.0 reaches the model request. Output is sampled instead of greedy, which leaves only 114 of 800 val_800 outputs reproducible across identical runs and costs about 1 pp cer_no_spk. This is the largest accuracy contributor confirmed in #959. The OpenAI transcription API defaults temperature to 0 and the sglang reference implementation decodes greedily, so 0.0 matches both.

## Modifications

build_transcription_generate_request now always sets temperature in the extra params, defaulting to 0.0 when the request does not provide one. Explicit client values pass through unchanged. Updated the builder unit test and added one for the explicit passthrough.

## Related Issues

Addresses the temperature part of the accuracy divergence in #959. The residual gap to the issue's original numbers did not reproduce on current main and stays open there. Part of #924.

## Accuracy Test

A/B on val_800 with MOSS-Transcribe-Diarize, one H100, concurrency 16, fresh managed server per run, two reps per arm. CER cells show rep 1 / rep 2. Full details in https://github.com/sgl-project/sglang-omni/issues/959#issuecomment-4884981708

| arm | cer_no_spk | cp_cer | identical outputs across reps (of 800) |
|---|---|---|---|
| no temperature sent (effective 1.0) | 6.529 / 6.535 | 11.859 / 13.147 | 114 |
| temperature=0 | 5.481 / 5.484 | 11.496 / 11.500 | 792 |

Note the default arm measures 6.53, close to the CI harness 6.61, not the 8.06 to 8.41 in the original issue table, so the larger reported gap likely involves a different commit or serving config. A separate dtype A/B ruled out bf16 vs fp16 (0.03 pp).

## Benchmark & Profiling

No throughput impact expected from a decoding default change. The qps difference between the two arms was within cross-GPU noise (details in the linked comment). The throughput gap reported in #959 is structural and not touched by this PR.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.

cc @Ccyest
