### PR TITLE
[CI] Add timestamp diarization metrics for MOSS-Transcribe-Diarize and highlight key outputs

### DIFF
--- a/benchmarks/eval/eval_transcribe_diarize.py
+++ b/benchmarks/eval/eval_transcribe_diarize.py
@@ -458,7 +458,9 @@ def _format_float(section: str, key: str, value: float) -> float:
     if section == "summary":
         return round(value, 4)
     if section == "diarization_metrics_percent":
-        if key.endswith(("_seconds", "_false_alarm", "_missed_detection", "_confusion", "_collar")):
+        if key.endswith(
+            ("_seconds", "_false_alarm", "_missed_detection", "_confusion", "_collar")
+        ):
             return round(value, 4)
         return round(value, 2)
     if "rtf" in key:

--- a/benchmarks/eval/eval_transcribe_diarize.py
+++ b/benchmarks/eval/eval_transcribe_diarize.py
@@ -287,6 +287,7 @@ def main() -> int:
     print(f"  {'Concurrency:':<{SPEED_LABEL_WIDTH}} {args.concurrency}")
     print(f"  {'Output:':<{SPEED_LABEL_WIDTH}} {output_path}")
     print(f"{'=' * SPEED_LINE_WIDTH}")
+    print(_build_key_metrics_section(payload["diarization_metrics_percent"]))
     print(_build_metrics_section("summary", payload["summary"], SUMMARY_ORDER))
     print(_build_metrics_section("speed", payload["speed"], SPEED_ORDER))
     print(
@@ -436,6 +437,17 @@ def _build_metrics_section(
     return "\n".join(lines)
 
 
+def _build_key_metrics_section(metrics: Mapping[str, object]) -> str:
+    lines = ["\nkey_metrics", "-" * SPEED_LINE_WIDTH]
+    for key in KEY_METRICS_ORDER:
+        if key not in metrics:
+            continue
+        lines.append(
+            f"  {key + ':':<{SPEED_LABEL_WIDTH}} {_display_value('diarization_metrics_percent', key, metrics[key])}"
+        )
+    return "\n".join(lines)
+
+
 def _display_value(section: str, key: str, value: object) -> object:
     if isinstance(value, float):
         return _format_float(section, key, value)
@@ -446,6 +458,8 @@ def _format_float(section: str, key: str, value: float) -> float:
     if section == "summary":
         return round(value, 4)
     if section == "diarization_metrics_percent":
+        if key.endswith(("_seconds", "_false_alarm", "_missed_detection", "_confusion", "_collar")):
+            return round(value, 4)
         return round(value, 2)
     if "rtf" in key:
         return round(value, 4)

--- a/benchmarks/eval/eval_transcribe_diarize.py
+++ b/benchmarks/eval/eval_transcribe_diarize.py
@@ -99,9 +99,27 @@ DIARIZATION_METRICS_PERCENT_ORDER: Final[tuple[str, ...]] = (
     "cp_cer",
     "cer_no_spk_cp_valid",
     "delta_cer",
+    "speaker_timestamp_der",
+    "speaker_timestamp_der_collar",
+    "speaker_timestamp_der_valid_samples",
+    "speaker_timestamp_der_skipped",
+    "speaker_timestamp_der_skipped_parse_error",
+    "speaker_timestamp_der_skipped_no_ref_segments",
+    "speaker_timestamp_der_skipped_no_pred_segments",
+    "speaker_timestamp_der_compute_error",
+    "speaker_timestamp_der_total_seconds",
+    "speaker_timestamp_der_false_alarm",
+    "speaker_timestamp_der_missed_detection",
+    "speaker_timestamp_der_confusion",
     "cer_valid_samples",
     "cp_cer_valid_samples",
     "count",
+)
+KEY_METRICS_ORDER: Final[tuple[str, ...]] = (
+    "cer_no_spk",
+    "cp_cer",
+    "delta_cer",
+    "speaker_timestamp_der",
 )
 
 

--- a/benchmarks/metrics/transcribe_diarize_metrics.py
+++ b/benchmarks/metrics/transcribe_diarize_metrics.py
@@ -6,6 +6,7 @@ import re
 import unicodedata
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from typing import TypedDict
 
 import numpy as np
 from scipy.optimize import linear_sum_assignment
@@ -13,6 +14,8 @@ from scipy.optimize import linear_sum_assignment
 from benchmarks.metrics._format import SPEED_LABEL_WIDTH, SPEED_LINE_WIDTH
 
 TIMESTAMP_RE = re.compile(r"\[\d+(?:\.\d+)?\]")
+TIMESTAMP_TOKEN_RE = re.compile(r"^\d+(?:\.\d+)?$")
+SPEAKER_TOKEN_RE = re.compile(r"^S0*(\d+)$", re.IGNORECASE)
 SPEAKER_TAG_RE = re.compile(r"\[S0*(\d+)\]", re.IGNORECASE)
 SPEAKER_TAG_CANON_RE = re.compile(r"\[S\d+\]", re.IGNORECASE)
 BRACKET_EVENT_RE = re.compile(r"\[(?!S\d+\])[^]]+\]", re.IGNORECASE)
@@ -34,6 +37,15 @@ class DiarizationSampleMetric:
     cer_no_spk: float | None
     cp_cer: float | None
     cp_invalid_reason: str
+    speaker_timestamp_der_valid: bool
+    speaker_timestamp_der_invalid_reason: str
+    speaker_timestamp_ref_segments: int
+    speaker_timestamp_pred_segments: int
+    speaker_timestamp_der: float | None
+    speaker_timestamp_der_total_seconds: float
+    speaker_timestamp_der_false_alarm: float
+    speaker_timestamp_der_missed_detection: float
+    speaker_timestamp_der_confusion: float
 
 
 @dataclass(frozen=True, slots=True)
@@ -55,6 +67,56 @@ class DiarizationMetricsResult:
     metrics: dict[str, float | int | None]
     metrics_percent: dict[str, float | int | None]
     samples: list[DiarizationSampleMetric]
+
+
+@dataclass(frozen=True, slots=True)
+class _TimestampDerSample:
+    valid: bool
+    invalid_reason: str
+    ref_segments: int
+    pred_segments: int
+    der: float | None
+    total_seconds: float
+    false_alarm: float
+    missed_detection: float
+    confusion: float
+
+
+@dataclass(frozen=True, slots=True)
+class _TimestampDerAggregate:
+    overall_der: float | None
+    valid_samples: int
+    skipped: int
+    skipped_parse_error: int
+    skipped_no_ref_segments: int
+    skipped_no_pred_segments: int
+    compute_error: str
+    total_seconds: float
+    false_alarm: float
+    missed_detection: float
+    confusion: float
+    per_sample: list[_TimestampDerSample]
+
+
+class _TimestampDerDetail(TypedDict):
+    der: float | None
+    total: float
+    false_alarm: float
+    missed_detection: float
+    confusion: float
+
+
+class _TimestampDerSampleDetail(_TimestampDerDetail):
+    sample_index: int
+
+
+class _TimestampDerAggregateDetail(TypedDict):
+    overall_der: float | None
+    sample_details: list[_TimestampDerSampleDetail]
+    total: float
+    false_alarm: float
+    missed_detection: float
+    confusion: float
 
 
 def print_diarization_accuracy_summary(
@@ -79,19 +141,19 @@ def print_diarization_accuracy_summary(
     print(f"{'-' * line_width}")
     print(
         f"  {'Exact match rate:':<{label_width}} "
-        f"{summary['exact_match_rate']:.4f} ({summary['exact_match_rate'] * 100:.2f}%)"
+        f"{_as_float(summary, 'exact_match_rate'):.4f} ({_as_float(summary, 'exact_match_rate') * 100:.2f}%)"
     )
-    print(f"  {'CER:':<{label_width}} {_format_ratio(diarization_metrics.get('cer'))}")
+    print(f"  {'CER:':<{label_width}} {_format_ratio(_as_optional_number(diarization_metrics, 'cer'))}")
     print(
         f"  {'CER no speaker:':<{label_width}} "
-        f"{_format_ratio(diarization_metrics.get('cer_no_spk'))}"
+        f"{_format_ratio(_as_optional_number(diarization_metrics, 'cer_no_spk'))}"
     )
     print(
-        f"  {'cpCER:':<{label_width}} {_format_ratio(diarization_metrics.get('cp_cer'))}"
+        f"  {'cpCER:':<{label_width}} {_format_ratio(_as_optional_number(diarization_metrics, 'cp_cer'))}"
     )
     print(
         f"  {'Delta CER:':<{label_width}} "
-        f"{_format_ratio(diarization_metrics.get('delta_cer'))}"
+        f"{_format_ratio(_as_optional_number(diarization_metrics, 'delta_cer'))}"
     )
     print(
         f"  {'CER-valid samples:':<{label_width}} "
@@ -122,21 +184,21 @@ def print_diarization_speed_summary(
     print(f"{'-' * line_width}")
     print(
         f"  {'Throughput (req/s):':<{label_width}} "
-        f"{_format_decimal(speed.get('throughput_qps'), digits=3)}"
+        f"{_format_decimal(_as_optional_number(speed, 'throughput_qps'), digits=3)}"
     )
     print(
         f"  {'Latency mean / p95 (s):':<{label_width}} "
-        f"{_format_decimal(speed.get('latency_mean_s'), digits=3)} / "
-        f"{_format_decimal(speed.get('latency_p95_s'), digits=3)}"
+        f"{_format_decimal(_as_optional_number(speed, 'latency_mean_s'), digits=3)} / "
+        f"{_format_decimal(_as_optional_number(speed, 'latency_p95_s'), digits=3)}"
     )
     print(
         f"  {'RTF mean / p95:':<{label_width}} "
-        f"{_format_decimal(speed.get('rtf_mean'), digits=4)} / "
-        f"{_format_decimal(speed.get('rtf_p95'), digits=4)}"
+        f"{_format_decimal(_as_optional_number(speed, 'rtf_mean'), digits=4)} / "
+        f"{_format_decimal(_as_optional_number(speed, 'rtf_p95'), digits=4)}"
     )
     print(
         f"  {'Audio throughput (s/s):':<{label_width}} "
-        f"{_format_decimal(speed.get('audio_throughput_s_per_s'), digits=3)}"
+        f"{_format_decimal(_as_optional_number(speed, 'audio_throughput_s_per_s'), digits=3)}"
     )
     print(f"{'=' * line_width}")
 
@@ -144,11 +206,15 @@ def print_diarization_speed_summary(
 def compute_diarization_metrics(
     rows: Sequence[DiarizationRow],
 ) -> DiarizationMetricsResult:
+    timestamp_der = _compute_timestamp_der(
+        [(row.reference_text, row.prediction_text) for row in rows],
+        collar=0.0,
+    )
     sample_metrics: list[DiarizationSampleMetric] = []
     cer_stats: list[_CharStats] = []
     cp_stats: list[_CpCerStats] = []
     cer_stats_on_cp_valid: list[_CharStats] = []
-    for row in rows:
+    for row, timestamp_sample in zip(rows, timestamp_der.per_sample, strict=False):
         sample_cer_stats = _char_stats(
             clean_no_speaker(row.reference_text),
             clean_no_speaker(row.prediction_text),
@@ -170,6 +236,15 @@ def compute_diarization_metrics(
                 cer_no_spk=sample_cer_stats.cer,
                 cp_cer=sample_cp_stats.cer,
                 cp_invalid_reason=sample_cp_stats.invalid_reason,
+                speaker_timestamp_der_valid=timestamp_sample.valid,
+                speaker_timestamp_der_invalid_reason=timestamp_sample.invalid_reason,
+                speaker_timestamp_ref_segments=timestamp_sample.ref_segments,
+                speaker_timestamp_pred_segments=timestamp_sample.pred_segments,
+                speaker_timestamp_der=timestamp_sample.der,
+                speaker_timestamp_der_total_seconds=timestamp_sample.total_seconds,
+                speaker_timestamp_der_false_alarm=timestamp_sample.false_alarm,
+                speaker_timestamp_der_missed_detection=timestamp_sample.missed_detection,
+                speaker_timestamp_der_confusion=timestamp_sample.confusion,
             )
         )
 
@@ -187,13 +262,32 @@ def compute_diarization_metrics(
         "delta_cer": delta_cer,
         "cer_valid_samples": sum(1 for item in sample_metrics if item.cer_valid),
         "cp_cer_valid_samples": sum(1 for item in sample_metrics if item.cp_cer_valid),
+        "speaker_timestamp_der": timestamp_der.overall_der,
+        "speaker_timestamp_der_collar": 0.0,
+        "speaker_timestamp_der_valid_samples": timestamp_der.valid_samples,
+        "speaker_timestamp_der_skipped": timestamp_der.skipped,
+        "speaker_timestamp_der_skipped_parse_error": timestamp_der.skipped_parse_error,
+        "speaker_timestamp_der_skipped_no_ref_segments": timestamp_der.skipped_no_ref_segments,
+        "speaker_timestamp_der_skipped_no_pred_segments": timestamp_der.skipped_no_pred_segments,
+        "speaker_timestamp_der_compute_error": timestamp_der.compute_error,
+        "speaker_timestamp_der_total_seconds": timestamp_der.total_seconds,
+        "speaker_timestamp_der_false_alarm": timestamp_der.false_alarm,
+        "speaker_timestamp_der_missed_detection": timestamp_der.missed_detection,
+        "speaker_timestamp_der_confusion": timestamp_der.confusion,
         "count": len(sample_metrics),
     }
     metrics_percent = {
         key: (
             value * 100.0
             if key
-            in {"cer_no_spk", "cer", "cp_cer", "cer_no_spk_cp_valid", "delta_cer"}
+            in {
+                "cer_no_spk",
+                "cer",
+                "cp_cer",
+                "cer_no_spk_cp_valid",
+                "delta_cer",
+                "speaker_timestamp_der",
+            }
             and value is not None
             else value
         )
@@ -372,6 +466,22 @@ def _format_decimal(value: float | int | None, *, digits: int) -> str:
     return f"{float(value):.{digits}f}"
 
 
+def _as_float(metrics: Mapping[str, object], key: str) -> float:
+    value = metrics[key]
+    if not isinstance(value, int | float) or isinstance(value, bool):
+        raise TypeError(f"Metric {key!r} must be numeric, got {type(value).__name__}")
+    return float(value)
+
+
+def _as_optional_number(metrics: Mapping[str, object], key: str) -> float | int | None:
+    value = metrics.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, int | float) or isinstance(value, bool):
+        raise TypeError(f"Metric {key!r} must be numeric or None, got {type(value).__name__}")
+    return value
+
+
 def _levenshtein_distance(reference: str, prediction: str) -> int:
     previous_row = list(range(len(prediction) + 1))
     for reference_index, reference_character in enumerate(reference, start=1):
@@ -387,3 +497,381 @@ def _levenshtein_distance(reference: str, prediction: str) -> int:
             )
         previous_row = current_row
     return previous_row[-1]
+
+
+def _compute_timestamp_der(
+    rows: Sequence[tuple[str, str]],
+    *,
+    collar: float = 0.0,
+) -> _TimestampDerAggregate:
+    per_sample = [
+        _timestamp_der_validity(reference, prediction)
+        for reference, prediction in rows
+    ]
+    valid_items = [
+        (index, reference, prediction)
+        for index, ((reference, prediction), sample) in enumerate(
+            zip(rows, per_sample, strict=False)
+        )
+        if sample.valid
+    ]
+    overall_der: float | None = None
+    total_seconds = 0.0
+    false_alarm = 0.0
+    missed_detection = 0.0
+    confusion = 0.0
+    compute_error = ""
+    if valid_items:
+        try:
+            details = _timestamp_der_detail(
+                predictions=[prediction for _, _, prediction in valid_items],
+                references=[reference for _, reference, _ in valid_items],
+                collar=collar,
+            )
+            overall_der = details["overall_der"]
+            total_seconds = details["total"]
+            false_alarm = details["false_alarm"]
+            missed_detection = details["missed_detection"]
+            confusion = details["confusion"]
+            for (sample_index, _reference, _prediction), detail in zip(
+                valid_items,
+                details["sample_details"],
+                strict=False,
+            ):
+                sample = per_sample[sample_index]
+                per_sample[sample_index] = _TimestampDerSample(
+                    valid=sample.valid,
+                    invalid_reason=sample.invalid_reason,
+                    ref_segments=sample.ref_segments,
+                    pred_segments=sample.pred_segments,
+                    der=detail["der"],
+                    total_seconds=detail["total"],
+                    false_alarm=detail["false_alarm"],
+                    missed_detection=detail["missed_detection"],
+                    confusion=detail["confusion"],
+                )
+        except Exception as exc:
+            compute_error = str(exc)
+            for sample_index, _reference, _prediction in valid_items:
+                sample = per_sample[sample_index]
+                per_sample[sample_index] = _TimestampDerSample(
+                    valid=False,
+                    invalid_reason="der_compute_error",
+                    ref_segments=sample.ref_segments,
+                    pred_segments=sample.pred_segments,
+                    der=None,
+                    total_seconds=0.0,
+                    false_alarm=0.0,
+                    missed_detection=0.0,
+                    confusion=0.0,
+                )
+
+    return _TimestampDerAggregate(
+        overall_der=overall_der,
+        valid_samples=sum(1 for item in per_sample if item.valid),
+        skipped=sum(1 for item in per_sample if not item.valid),
+        skipped_parse_error=sum(
+            1 for item in per_sample if item.invalid_reason == "timestamp_parse_error"
+        ),
+        skipped_no_ref_segments=sum(
+            1
+            for item in per_sample
+            if item.invalid_reason == "no_ref_timestamped_speaker_segments"
+        ),
+        skipped_no_pred_segments=sum(
+            1
+            for item in per_sample
+            if item.invalid_reason == "no_pred_timestamped_speaker_segments"
+        ),
+        compute_error=compute_error,
+        total_seconds=total_seconds,
+        false_alarm=false_alarm,
+        missed_detection=missed_detection,
+        confusion=confusion,
+        per_sample=per_sample,
+    )
+
+
+def _timestamp_der_validity(reference: str, prediction: str) -> _TimestampDerSample:
+    try:
+        ref_segments = len(_parse_timestamped_speaker_segments(reference or ""))
+        pred_segments = len(_parse_timestamped_speaker_segments(prediction or ""))
+    except Exception:
+        return _TimestampDerSample(
+            valid=False,
+            invalid_reason="timestamp_parse_error",
+            ref_segments=0,
+            pred_segments=0,
+            der=None,
+            total_seconds=0.0,
+            false_alarm=0.0,
+            missed_detection=0.0,
+            confusion=0.0,
+        )
+    if ref_segments <= 0:
+        return _TimestampDerSample(
+            valid=False,
+            invalid_reason="no_ref_timestamped_speaker_segments",
+            ref_segments=ref_segments,
+            pred_segments=pred_segments,
+            der=None,
+            total_seconds=0.0,
+            false_alarm=0.0,
+            missed_detection=0.0,
+            confusion=0.0,
+        )
+    if pred_segments <= 0:
+        return _TimestampDerSample(
+            valid=False,
+            invalid_reason="no_pred_timestamped_speaker_segments",
+            ref_segments=ref_segments,
+            pred_segments=pred_segments,
+            der=None,
+            total_seconds=0.0,
+            false_alarm=0.0,
+            missed_detection=0.0,
+            confusion=0.0,
+        )
+    return _TimestampDerSample(
+        valid=True,
+        invalid_reason="",
+        ref_segments=ref_segments,
+        pred_segments=pred_segments,
+        der=None,
+        total_seconds=0.0,
+        false_alarm=0.0,
+        missed_detection=0.0,
+        confusion=0.0,
+    )
+
+
+def _parse_timestamped_speaker_segments(text: str) -> list[tuple[float, float, str]]:
+    tokens: list[tuple[str, float | str]] = []
+    for match in re.finditer(r"\[([^\]]+)\]", text or ""):
+        raw = match.group(1).strip()
+        if TIMESTAMP_TOKEN_RE.fullmatch(raw):
+            tokens.append(("time", float(raw)))
+            continue
+        speaker_match = SPEAKER_TOKEN_RE.fullmatch(raw)
+        if speaker_match:
+            tokens.append(("spk", f"[S{int(speaker_match.group(1))}]"))
+
+    segments: list[tuple[float, float, str]] = []
+    last_speaker: str | None = None
+    index = 0
+    token_count = len(tokens)
+    while index < token_count:
+        kind, value = tokens[index]
+        if kind != "time":
+            index += 1
+            continue
+        start = float(value)
+        next_index = index + 1
+        segment_speaker: str | None = None
+        while next_index < token_count and tokens[next_index][0] != "time":
+            if tokens[next_index][0] == "spk":
+                segment_speaker = str(tokens[next_index][1])
+            next_index += 1
+        if next_index >= token_count:
+            break
+        end = float(tokens[next_index][1])
+        speaker = segment_speaker or last_speaker
+        if speaker is not None and end > start:
+            segments.append((start, end, speaker))
+            last_speaker = speaker
+        index = next_index + 1
+    return segments
+
+
+def _timestamp_der_detail(
+    predictions: list[str],
+    references: list[str],
+    *,
+    collar: float,
+) -> _TimestampDerAggregateDetail:
+    sample_details: list[_TimestampDerSampleDetail] = []
+    total = 0.0
+    false_alarm = 0.0
+    missed_detection = 0.0
+    confusion = 0.0
+    for sample_index, (prediction, reference) in enumerate(
+        zip(predictions, references, strict=False)
+    ):
+        detail = _timestamp_der_one(reference, prediction, collar=collar)
+        sample_details.append(
+            {
+                "sample_index": sample_index,
+                "der": detail["der"],
+                "total": detail["total"],
+                "false_alarm": detail["false_alarm"],
+                "missed_detection": detail["missed_detection"],
+                "confusion": detail["confusion"],
+            }
+        )
+        total += detail["total"]
+        false_alarm += detail["false_alarm"]
+        missed_detection += detail["missed_detection"]
+        confusion += detail["confusion"]
+    errors = false_alarm + missed_detection + confusion
+    return {
+        "overall_der": errors / total if total > 0 else None,
+        "sample_details": sample_details,
+        "total": total,
+        "false_alarm": false_alarm,
+        "missed_detection": missed_detection,
+        "confusion": confusion,
+    }
+
+
+def _timestamp_der_one(
+    reference: str,
+    prediction: str,
+    *,
+    collar: float,
+) -> _TimestampDerDetail:
+    reference_segments = _parse_timestamped_speaker_segments(reference)
+    prediction_segments = _parse_timestamped_speaker_segments(prediction)
+    mapping = _best_hyp_to_ref_mapping(reference_segments, prediction_segments)
+    collar_regions = _reference_collar_regions(reference_segments, collar)
+    boundaries = sorted(
+        {
+            point
+            for start, end, _speaker in reference_segments + prediction_segments
+            for point in (start, end)
+        }
+        | {
+            point
+            for start, end in collar_regions
+            for point in (start, end)
+        }
+    )
+
+    total = 0.0
+    false_alarm = 0.0
+    missed_detection = 0.0
+    confusion = 0.0
+    for start, end in zip(boundaries, boundaries[1:], strict=False):
+        duration = end - start
+        if duration <= 0:
+            continue
+        midpoint = (start + end) / 2.0
+        if _inside_intervals(midpoint, collar_regions):
+            continue
+        reference_active = _active_speakers(reference_segments, start, end)
+        prediction_active_raw = _active_speakers(prediction_segments, start, end)
+        if not reference_active and not prediction_active_raw:
+            continue
+        prediction_active = {
+            mapping.get(speaker, f"__hyp_unmapped_{speaker}")
+            for speaker in prediction_active_raw
+        }
+        total += len(reference_active) * duration
+        false_alarm += (
+            max(0, len(prediction_active_raw) - len(reference_active)) * duration
+        )
+        missed_detection += (
+            max(0, len(reference_active) - len(prediction_active_raw)) * duration
+        )
+        confusion += max(
+            0,
+            min(len(reference_active), len(prediction_active_raw))
+            - len(reference_active & prediction_active),
+        ) * duration
+    errors = false_alarm + missed_detection + confusion
+    return {
+        "der": errors / total if total > 0 else None,
+        "total": total,
+        "false_alarm": false_alarm,
+        "missed_detection": missed_detection,
+        "confusion": confusion,
+    }
+
+
+def _best_hyp_to_ref_mapping(
+    reference_segments: list[tuple[float, float, str]],
+    prediction_segments: list[tuple[float, float, str]],
+) -> dict[str, str]:
+    reference_labels = sorted(
+        {segment[2] for segment in reference_segments}, key=_speaker_sort_key
+    )
+    prediction_labels = sorted(
+        {segment[2] for segment in prediction_segments}, key=_speaker_sort_key
+    )
+    if not reference_labels or not prediction_labels:
+        return {}
+    overlap = np.zeros((len(reference_labels), len(prediction_labels)), dtype=float)
+    reference_index = {
+        label: index for index, label in enumerate(reference_labels)
+    }
+    prediction_index = {
+        label: index for index, label in enumerate(prediction_labels)
+    }
+    for reference_segment in reference_segments:
+        for prediction_segment in prediction_segments:
+            duration = _segment_overlap(reference_segment, prediction_segment)
+            if duration > 0.0:
+                overlap[
+                    reference_index[reference_segment[2]],
+                    prediction_index[prediction_segment[2]],
+                ] += duration
+    row_indexes, column_indexes = linear_sum_assignment(-overlap)
+    return {
+        prediction_labels[column_index]: reference_labels[row_index]
+        for row_index, column_index in zip(row_indexes, column_indexes, strict=False)
+    }
+
+
+def _segment_overlap(
+    left: tuple[float, float, str],
+    right: tuple[float, float, str],
+) -> float:
+    return max(0.0, min(left[1], right[1]) - max(left[0], right[0]))
+
+
+def _speaker_sort_key(label: str) -> tuple[int, str]:
+    match = SPEAKER_TAG_RE.fullmatch(label)
+    return (int(match.group(1)), label) if match else (10**9, label)
+
+
+def _reference_collar_regions(
+    reference_segments: list[tuple[float, float, str]],
+    collar: float,
+) -> list[tuple[float, float]]:
+    if collar <= 0:
+        return []
+    intervals = []
+    for start, end, _speaker in reference_segments:
+        intervals.append((max(0.0, start - collar), start + collar))
+        intervals.append((max(0.0, end - collar), end + collar))
+    return _merge_intervals(intervals)
+
+
+def _merge_intervals(
+    intervals: list[tuple[float, float]],
+) -> list[tuple[float, float]]:
+    merged: list[tuple[float, float]] = []
+    for start, end in sorted((item for item in intervals if item[1] > item[0])):
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+        else:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+    return merged
+
+
+def _inside_intervals(
+    time_point: float,
+    intervals: list[tuple[float, float]],
+) -> bool:
+    return any(start <= time_point < end for start, end in intervals)
+
+
+def _active_speakers(
+    segments: list[tuple[float, float, str]],
+    start: float,
+    end: float,
+) -> set[str]:
+    return {
+        speaker
+        for segment_start, segment_end, speaker in segments
+        if segment_start < end and segment_end > start
+    }

--- a/benchmarks/metrics/transcribe_diarize_metrics.py
+++ b/benchmarks/metrics/transcribe_diarize_metrics.py
@@ -143,7 +143,9 @@ def print_diarization_accuracy_summary(
         f"  {'Exact match rate:':<{label_width}} "
         f"{_as_float(summary, 'exact_match_rate'):.4f} ({_as_float(summary, 'exact_match_rate') * 100:.2f}%)"
     )
-    print(f"  {'CER:':<{label_width}} {_format_ratio(_as_optional_number(diarization_metrics, 'cer'))}")
+    print(
+        f"  {'CER:':<{label_width}} {_format_ratio(_as_optional_number(diarization_metrics, 'cer'))}"
+    )
     print(
         f"  {'CER no speaker:':<{label_width}} "
         f"{_format_ratio(_as_optional_number(diarization_metrics, 'cer_no_spk'))}"
@@ -478,7 +480,9 @@ def _as_optional_number(metrics: Mapping[str, object], key: str) -> float | int 
     if value is None:
         return None
     if not isinstance(value, int | float) or isinstance(value, bool):
-        raise TypeError(f"Metric {key!r} must be numeric or None, got {type(value).__name__}")
+        raise TypeError(
+            f"Metric {key!r} must be numeric or None, got {type(value).__name__}"
+        )
     return value
 
 
@@ -505,8 +509,7 @@ def _compute_timestamp_der(
     collar: float = 0.0,
 ) -> _TimestampDerAggregate:
     per_sample = [
-        _timestamp_der_validity(reference, prediction)
-        for reference, prediction in rows
+        _timestamp_der_validity(reference, prediction) for reference, prediction in rows
     ]
     valid_items = [
         (index, reference, prediction)
@@ -739,11 +742,7 @@ def _timestamp_der_one(
             for start, end, _speaker in reference_segments + prediction_segments
             for point in (start, end)
         }
-        | {
-            point
-            for start, end in collar_regions
-            for point in (start, end)
-        }
+        | {point for start, end in collar_regions for point in (start, end)}
     )
 
     total = 0.0
@@ -772,11 +771,14 @@ def _timestamp_der_one(
         missed_detection += (
             max(0, len(reference_active) - len(prediction_active_raw)) * duration
         )
-        confusion += max(
-            0,
-            min(len(reference_active), len(prediction_active_raw))
-            - len(reference_active & prediction_active),
-        ) * duration
+        confusion += (
+            max(
+                0,
+                min(len(reference_active), len(prediction_active_raw))
+                - len(reference_active & prediction_active),
+            )
+            * duration
+        )
     errors = false_alarm + missed_detection + confusion
     return {
         "der": errors / total if total > 0 else None,
@@ -800,12 +802,8 @@ def _best_hyp_to_ref_mapping(
     if not reference_labels or not prediction_labels:
         return {}
     overlap = np.zeros((len(reference_labels), len(prediction_labels)), dtype=float)
-    reference_index = {
-        label: index for index, label in enumerate(reference_labels)
-    }
-    prediction_index = {
-        label: index for index, label in enumerate(prediction_labels)
-    }
+    reference_index = {label: index for index, label in enumerate(reference_labels)}
+    prediction_index = {label: index for index, label in enumerate(prediction_labels)}
     for reference_segment in reference_segments:
         for prediction_segment in prediction_segments:
             duration = _segment_overlap(reference_segment, prediction_segment)

--- a/benchmarks/tasks/transcribe_diarize.py
+++ b/benchmarks/tasks/transcribe_diarize.py
@@ -56,6 +56,15 @@ class PerSampleRecord(TypedDict):
     cer_valid: bool | None
     cp_cer_valid: bool | None
     cp_invalid_reason: str | None
+    speaker_timestamp_der_valid: bool | None
+    speaker_timestamp_der_invalid_reason: str | None
+    speaker_timestamp_ref_segments: int | None
+    speaker_timestamp_pred_segments: int | None
+    speaker_timestamp_der: float | None
+    speaker_timestamp_der_total_seconds: float | None
+    speaker_timestamp_der_false_alarm: float | None
+    speaker_timestamp_der_missed_detection: float | None
+    speaker_timestamp_der_confusion: float | None
 
 
 class EvaluationConfig(TypedDict):
@@ -130,6 +139,9 @@ def load_movies800_samples(
 
 
 def extract_prediction_text(payload: Mapping[str, JSONValue]) -> str:
+    text = payload.get("text")
+    if isinstance(text, str) and text.strip():
+        return text.strip()
     segments = payload.get("segments")
     if isinstance(segments, list):
         texts = [
@@ -139,7 +151,6 @@ def extract_prediction_text(payload: Mapping[str, JSONValue]) -> str:
         ]
         if texts:
             return " ".join(texts)
-    text = payload.get("text")
     if not isinstance(text, str):
         raise ValueError("Transcription response is missing a string 'text' field")
     return text.strip()
@@ -227,6 +238,51 @@ def build_evaluation_payload(
                 ),
                 "cp_invalid_reason": (
                     diarization_sample.cp_invalid_reason if diarization_sample else None
+                ),
+                "speaker_timestamp_der_valid": (
+                    diarization_sample.speaker_timestamp_der_valid
+                    if diarization_sample
+                    else None
+                ),
+                "speaker_timestamp_der_invalid_reason": (
+                    diarization_sample.speaker_timestamp_der_invalid_reason
+                    if diarization_sample
+                    else None
+                ),
+                "speaker_timestamp_ref_segments": (
+                    diarization_sample.speaker_timestamp_ref_segments
+                    if diarization_sample
+                    else None
+                ),
+                "speaker_timestamp_pred_segments": (
+                    diarization_sample.speaker_timestamp_pred_segments
+                    if diarization_sample
+                    else None
+                ),
+                "speaker_timestamp_der": (
+                    diarization_sample.speaker_timestamp_der
+                    if diarization_sample
+                    else None
+                ),
+                "speaker_timestamp_der_total_seconds": (
+                    diarization_sample.speaker_timestamp_der_total_seconds
+                    if diarization_sample
+                    else None
+                ),
+                "speaker_timestamp_der_false_alarm": (
+                    diarization_sample.speaker_timestamp_der_false_alarm
+                    if diarization_sample
+                    else None
+                ),
+                "speaker_timestamp_der_missed_detection": (
+                    diarization_sample.speaker_timestamp_der_missed_detection
+                    if diarization_sample
+                    else None
+                ),
+                "speaker_timestamp_der_confusion": (
+                    diarization_sample.speaker_timestamp_der_confusion
+                    if diarization_sample
+                    else None
                 ),
             }
         )

--- a/benchmarks/tasks/transcribe_diarize.py
+++ b/benchmarks/tasks/transcribe_diarize.py
@@ -19,7 +19,7 @@ from benchmarks.metrics.transcribe_diarize_metrics import (
     compute_diarization_metrics,
 )
 
-MOVIES800_REPO_ID: Final[str] = "zhaochenyang20/movies800"
+MOVIES800_REPO_ID: Final[str] = "zhaochenyang20/movies800time"
 EXPECTED_SAMPLE_COUNT: Final[int] = 800
 TIMESTAMP_RE: Final[re.Pattern[str]] = re.compile(r"\[\d+(?:\.\d+)?\]")
 SPEAKER_RE: Final[re.Pattern[str]] = re.compile(r"\[\s*s0*(\d+)\s*\]", re.IGNORECASE)

--- a/tests/unit_test/benchmarks/test_dataset_regressions.py
+++ b/tests/unit_test/benchmarks/test_dataset_regressions.py
@@ -221,7 +221,7 @@ def test_tune_ci_threshold_asr_config_tracks_current_asr_ci_stages() -> None:
         "test_asr_ci_seedtts.py": ["Qwen/Qwen3-ASR-1.7B"],
     }
     assert {
-        "zhaochenyang20/movies800",
+        "zhaochenyang20/movies800time",
         "zhaochenyang20/seed-tts-eval-arrow",
     }.issubset(config["hf_datasets"])
 

--- a/tests/unit_test/benchmarks/test_transcribe_diarize_metrics.py
+++ b/tests/unit_test/benchmarks/test_transcribe_diarize_metrics.py
@@ -55,3 +55,100 @@ def test_split_clean_by_speaker_preserves_spoken_event_words() -> None:
         "[S1]": "我笑了",
         "[S2]": "ilovemusic",
     }
+
+
+def test_compute_diarization_metrics_includes_timestamp_der_for_exact_match() -> None:
+    result = compute_diarization_metrics(
+        [
+            DiarizationRow(
+                sample_id="sample-1",
+                audio_path="/tmp/sample-1.wav",
+                reference_text="[0.00][S01]hello[1.00][1.00][S02]world[2.00]",
+                prediction_text="[0.00][S01]hello[1.00][1.00][S02]world[2.00]",
+            )
+        ]
+    )
+
+    assert result.metrics["speaker_timestamp_der"] == pytest.approx(0.0)
+    assert result.metrics["speaker_timestamp_der_valid_samples"] == 1
+    assert result.metrics["speaker_timestamp_der_skipped"] == 0
+    assert result.samples[0].speaker_timestamp_der_valid is True
+    assert result.samples[0].speaker_timestamp_der == pytest.approx(0.0)
+
+
+def test_compute_diarization_metrics_marks_missing_timestamp_prediction_invalid() -> None:
+    result = compute_diarization_metrics(
+        [
+            DiarizationRow(
+                sample_id="sample-1",
+                audio_path="/tmp/sample-1.wav",
+                reference_text="[0.00][S01]hello[1.00]",
+                prediction_text="[S01]hello",
+            )
+        ]
+    )
+
+    assert result.metrics["speaker_timestamp_der"] is None
+    assert result.metrics["speaker_timestamp_der_valid_samples"] == 0
+    assert result.metrics["speaker_timestamp_der_skipped_no_pred_segments"] == 1
+    assert result.samples[0].speaker_timestamp_der_valid is False
+    assert result.samples[0].speaker_timestamp_der_invalid_reason == "no_pred_timestamped_speaker_segments"
+
+
+def test_build_metrics_section_prints_timestamp_metrics() -> None:
+    module = _load_eval_module()
+
+    section = module._build_metrics_section(
+        "diarization_metrics_percent",
+        {
+            "speaker_timestamp_der": 12.3456,
+            "speaker_timestamp_der_valid_samples": 7,
+            "speaker_timestamp_der_skipped": 1,
+        },
+        (
+            "speaker_timestamp_der",
+            "speaker_timestamp_der_valid_samples",
+            "speaker_timestamp_der_skipped",
+        ),
+    )
+
+    assert "speaker_timestamp_der:" in section
+    assert "12.35" in section
+    assert "speaker_timestamp_der_valid_samples:" in section
+
+
+def test_build_key_metrics_section_prints_selected_metrics() -> None:
+    module = _load_eval_module()
+
+    section = module._build_key_metrics_section(
+        {
+            "cer_no_spk": 6.57,
+            "cp_cer": 14.42,
+            "delta_cer": 7.85,
+            "speaker_timestamp_der": 23.97,
+        }
+    )
+
+    assert "key_metrics" in section
+    assert "cer_no_spk:" in section
+    assert "6.57" in section
+    assert "cp_cer:" in section
+    assert "14.42" in section
+    assert "delta_cer:" in section
+    assert "7.85" in section
+    assert "speaker_timestamp_der:" in section
+    assert "23.97" in section
+
+
+def test_extract_prediction_text_prefers_top_level_text_for_timestamps() -> None:
+    from benchmarks.tasks.transcribe_diarize import extract_prediction_text
+
+    payload = {
+        "text": "[0.00][S01]hello[1.00][1.00][S02]world[2.00]",
+        "segments": [
+            {"text": "[S01]hello"},
+            {"text": "[S02]world"},
+        ],
+    }
+
+    assert extract_prediction_text(payload) == payload["text"]

--- a/tests/unit_test/benchmarks/test_transcribe_diarize_metrics.py
+++ b/tests/unit_test/benchmarks/test_transcribe_diarize_metrics.py
@@ -2,12 +2,36 @@
 
 from __future__ import annotations
 
+import importlib.util
+import sys
+from pathlib import Path
+
 import pytest
 
 from benchmarks.metrics.transcribe_diarize_metrics import (
     clean_no_speaker,
+    compute_diarization_metrics,
+    DiarizationRow,
     split_clean_by_speaker,
 )
+
+
+EVAL_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "benchmarks/eval/eval_transcribe_diarize.py"
+)
+
+
+def _load_eval_module():
+    spec = importlib.util.spec_from_file_location(
+        "eval_transcribe_diarize_entry",
+        EVAL_SCRIPT_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_test/benchmarks/test_transcribe_diarize_metrics.py
+++ b/tests/unit_test/benchmarks/test_transcribe_diarize_metrics.py
@@ -9,16 +9,14 @@ from pathlib import Path
 import pytest
 
 from benchmarks.metrics.transcribe_diarize_metrics import (
+    DiarizationRow,
     clean_no_speaker,
     compute_diarization_metrics,
-    DiarizationRow,
     split_clean_by_speaker,
 )
 
-
 EVAL_SCRIPT_PATH = (
-    Path(__file__).resolve().parents[3]
-    / "benchmarks/eval/eval_transcribe_diarize.py"
+    Path(__file__).resolve().parents[3] / "benchmarks/eval/eval_transcribe_diarize.py"
 )
 
 
@@ -76,7 +74,9 @@ def test_compute_diarization_metrics_includes_timestamp_der_for_exact_match() ->
     assert result.samples[0].speaker_timestamp_der == pytest.approx(0.0)
 
 
-def test_compute_diarization_metrics_marks_missing_timestamp_prediction_invalid() -> None:
+def test_compute_diarization_metrics_marks_missing_timestamp_prediction_invalid() -> (
+    None
+):
     result = compute_diarization_metrics(
         [
             DiarizationRow(
@@ -92,7 +92,10 @@ def test_compute_diarization_metrics_marks_missing_timestamp_prediction_invalid(
     assert result.metrics["speaker_timestamp_der_valid_samples"] == 0
     assert result.metrics["speaker_timestamp_der_skipped_no_pred_segments"] == 1
     assert result.samples[0].speaker_timestamp_der_valid is False
-    assert result.samples[0].speaker_timestamp_der_invalid_reason == "no_pred_timestamped_speaker_segments"
+    assert (
+        result.samples[0].speaker_timestamp_der_invalid_reason
+        == "no_pred_timestamped_speaker_segments"
+    )
 
 
 def test_build_metrics_section_prints_timestamp_metrics() -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

This pull request introduces support for speaker timestamp Diarization Error Rate (DER) metrics in both the diarization evaluation and reporting pipeline. It adds new fields to the data model, updates the evaluation logic to compute and report these metrics, and enhances the output formatting to highlight key metrics. Comprehensive tests are also added to ensure correct behavior.

## Modifications

**Speaker timestamp DER metric support:**

* Added new speaker timestamp DER-related fields (e.g., `speaker_timestamp_der`, `speaker_timestamp_der_valid`, etc.) to the `PerSampleRecord` data structure and included them in the evaluation payload. [[1]](diffhunk://#diff-87b184dce93fb3e9a186c78515baec45fd3b43949a822c6431fbb9f0d85eb3dcR59-R67) [[2]](diffhunk://#diff-87b184dce93fb3e9a186c78515baec45fd3b43949a822c6431fbb9f0d85eb3dcR242-R286)
* Updated the diarization metrics computation to include speaker timestamp DER and its validity, and adjusted logic to handle missing or invalid predictions.

**Evaluation output and formatting improvements:**

* Introduced a `KEY_METRICS_ORDER` and a `_build_key_metrics_section` function to print a dedicated key metrics section in the evaluation output, including the new DER metrics. [[1]](diffhunk://#diff-9b09118fe1a270bad491b3583719f8c0a84e27f86840e693eb50771a65049248R102-R123) [[2]](diffhunk://#diff-9b09118fe1a270bad491b3583719f8c0a84e27f86840e693eb50771a65049248R440-R450) [[3]](diffhunk://#diff-9b09118fe1a270bad491b3583719f8c0a84e27f86840e693eb50771a65049248R290)
* Improved float formatting in `_format_float` for diarization metrics, rounding seconds and error counts to four decimals and others to two.

**Bug fixes and test enhancements:**

* Updated `extract_prediction_text` to prefer the top-level `"text"` field if present, improving handling of timestamped predictions. [[1]](diffhunk://#diff-87b184dce93fb3e9a186c78515baec45fd3b43949a822c6431fbb9f0d85eb3dcR142-R144) [[2]](diffhunk://#diff-87b184dce93fb3e9a186c78515baec45fd3b43949a822c6431fbb9f0d85eb3dcL142)
* Added unit tests for new DER metrics computation, reporting, and output formatting, including dynamic loading and invocation of the evaluation script. [[1]](diffhunk://#diff-619bd031b35c0b9968414b384dc25ee5851b2f8f0afd577fe870a6fee216d07aR5-R33) [[2]](diffhunk://#diff-619bd031b35c0b9968414b384dc25ee5851b2f8f0afd577fe870a6fee216d07aR56-R157)

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

| Metric | Value |
|---|---:|
| cer_no_spk | 6.684 ± 0.184 (2.75%) |
| cp_cer | 14.338 ± 0.612 (4.27%) |
| delta_cer | 7.656 ± 0.487 (6.36%) |
| speaker_timestamp_der | 23.948 ± 0.492 (2.05%) |


## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
