### PR TITLE
[TTS Refactor][M4a] ReferenceEncodeService: base service (standalone)

### DIFF
--- a/docs/developer_reference/reference_encode_service.md
+++ b/docs/developer_reference/reference_encode_service.md
@@ -1,0 +1,125 @@
+# Reference Encode Service
+
+`ReferenceEncodeService` owns reusable mechanics for ad-hoc TTS reference
+encoding:
+
+- cache-keyed lookup;
+- byte-bounded LRU storage;
+- same-key single-flight while an encode is in progress;
+- failure propagation to waiters without caching failures;
+- artifact store/load conversion and caller-owned return values;
+- basic cache statistics.
+
+The service is for ad-hoc request references. Registered or uploaded voices
+continue to use `SpeakerArtifactCache`, because they have a different lifetime,
+key space, and invalidation path.
+
+## API Shape
+
+The implementation lives in `sglang_omni/scheduling/reference_encoder.py`.
+
+```python
+@dataclass(frozen=True)
+class ReferenceEncodeKey:
+    model_id: str
+    model_revision: str
+    encoder_id: str
+    encoder_config_hash: str
+    artifact_kind: str
+    input_key: str
+    options_key: str = ""
+
+
+class ReferenceEncodeHook(Generic[InputT, ArtifactT, StoredT]):
+    def normalize_input(self, raw_input: Any) -> InputT: ...
+    def cache_key(self, item: InputT) -> ReferenceEncodeKey | None: ...
+    def encode_one(self, item: InputT) -> ArtifactT: ...
+    def store_artifact(self, artifact: ArtifactT) -> StoredT: ...
+    def load_artifact(self, stored: StoredT) -> ArtifactT: ...
+    def revalidate(self, item: InputT, key: ReferenceEncodeKey) -> bool: ...
+
+
+class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
+    def get_or_encode(self, raw_input: Any, *, desc: str | None = None) -> ArtifactT: ...
+    def stats(self) -> dict[str, int]: ...
+```
+
+`ReferenceEncodeService` is synchronous and thread-first. Existing TTS
+preprocessing and encoder stages already run synchronous model code inside
+`SimpleScheduler` or `ThreadedSimpleScheduler`, so adding an async surface would
+force nested event-loop management without changing the underlying work.
+
+## Responsibility Split
+
+The service owns mechanics:
+
+- `_inflight` single-flight map;
+- `StageOutputCache` access under a service-owned lock;
+- cache insertion, byte budget, and LRU eviction;
+- follower waits, timeout handling, and exception fanout;
+- no-poison-on-failure behavior;
+- stats for hits, misses, merges, failures, uncacheable inputs, entries, bytes,
+  and evictions.
+
+The hook owns model semantics:
+
+- request-specific input normalization;
+- cacheability;
+- model/checkpoint/config key parts;
+- `encode_one`;
+- artifact device and dtype policy;
+- store/load conversion;
+- revalidation for mutable local files.
+
+## Cache-Key Contract
+
+`ReferenceEncodeKey` must include every input that can change the encoded
+artifact identity:
+
+- model family or checkpoint identity;
+- model or encoder revision;
+- encoder implementation and config hash;
+- artifact kind;
+- normalized reference content identity;
+- encode options that affect the artifact.
+
+Local reference files should use
+`reference_path_cache_key(path, trust_stat=False)` and revalidate before cache
+insert. Bytes and data-URI payloads should key by the bytes or original payload
+actually consumed by the model hook. Remote URLs should not be cached by URL
+string alone unless an upstream fetch layer has already materialized immutable
+content identity.
+
+## Artifact Policy
+
+Hooks should store cache-owned artifacts, usually detached CPU tensors or a
+small CPU dictionary of detached tensors. `load_artifact` must return a
+caller-owned object, commonly by cloning and moving to the expected dtype or
+device. The service enforces the byte budget on the stored representation.
+
+If a stored artifact is larger than `max_bytes`, the leader request and all
+same-key followers still receive a result, but the artifact is not inserted into
+the LRU.
+
+## Failure And Waiters
+
+For a cacheable key:
+
+1. Cache hits return `hook.load_artifact(stored)`.
+2. If another request is already encoding the same key, followers wait on the
+   leader future.
+3. The leader encodes once, stores the artifact representation, optionally
+   inserts it into the LRU, resolves waiters, and removes the in-flight entry.
+
+Leader failures are propagated to waiters and are not cached. The next request
+can retry as a new leader. A follower timeout does not remove the leader's
+in-flight entry.
+
+## M4a And M4b Boundary
+
+M4a is the production path: ad-hoc reference cache and same-key single-flight.
+
+M4b is profile-gated: different-key batch coalescing should only be added when
+M4a profiling shows reference encode remains a bottleneck and a model has a
+real `encode_batch` speedup. M4b must still apply M4a cache hits and same-key
+single-flight before enqueueing distinct cache-miss leaders into a batch.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -105,5 +105,6 @@ Supported Models
    developer_reference/pipeline.md
    developer_reference/config.md
    developer_reference/communication.md
+   developer_reference/reference_encode_service.md
    developer_reference/profiler.md
    developer_reference/rl_admin_control.md

--- a/sglang_omni/scheduling/reference_encoder.py
+++ b/sglang_omni/scheduling/reference_encoder.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import logging
+import threading
+import time
+from dataclasses import asdict, dataclass
+from typing import Any, Generic, TypeVar
+
+from sglang_omni.scheduling.stage_cache import StageOutputCache
+
+logger = logging.getLogger(__name__)
+
+InputT = TypeVar("InputT")
+ArtifactT = TypeVar("ArtifactT")
+StoredT = TypeVar("StoredT")
+
+
+@dataclass(frozen=True)
+class ReferenceEncodeKey:
+    model_id: str
+    model_revision: str
+    encoder_id: str
+    encoder_config_hash: str
+    artifact_kind: str
+    input_key: str
+    options_key: str = ""
+
+    def to_string(self) -> str:
+        return json.dumps(asdict(self), sort_keys=True, separators=(",", ":"))
+
+
+class ReferenceEncodeHook(Generic[InputT, ArtifactT, StoredT]):
+    def normalize_input(self, raw_input: Any) -> InputT:
+        raise NotImplementedError
+
+    def cache_key(self, item: InputT) -> ReferenceEncodeKey | None:
+        raise NotImplementedError
+
+    def encode_one(self, item: InputT) -> ArtifactT:
+        raise NotImplementedError
+
+    def store_artifact(self, artifact: ArtifactT) -> StoredT:
+        raise NotImplementedError
+
+    def load_artifact(self, stored: StoredT) -> ArtifactT:
+        raise NotImplementedError
+
+    def revalidate(self, item: InputT, key: ReferenceEncodeKey) -> bool:
+        return True
+
+    def encode_batch(self, items: list[InputT]) -> list[ArtifactT]:
+        return [self.encode_one(item) for item in items]
+
+
+class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
+    _LOG_INTERVAL_S = 60.0
+
+    def __init__(
+        self,
+        hook: ReferenceEncodeHook[InputT, ArtifactT, StoredT],
+        *,
+        max_items: int | None = 256,
+        max_bytes: int | None = 64 * 1024 * 1024,
+        timeout_s: float = 130.0,
+        log_prefix: str | None = None,
+    ) -> None:
+        if max_items is not None and max_items < 1:
+            raise ValueError(f"max_items must be >= 1, got {max_items}")
+        if max_bytes is not None and max_bytes < 1:
+            raise ValueError(f"max_bytes must be >= 1, got {max_bytes}")
+        self._hook = hook
+        self._cache = StageOutputCache(max_size=max_items, max_bytes=max_bytes)
+        self._timeout_s = float(timeout_s)
+        self._log_prefix = log_prefix
+        self._lock = threading.Lock()
+        self._inflight: dict[str, concurrent.futures.Future[StoredT]] = {}
+        self._hits = 0
+        self._misses = 0
+        self._merged = 0
+        self._failed = 0
+        self._uncacheable = 0
+        self._last_log_time = 0.0
+
+    def get_or_encode(self, raw_input: Any, *, desc: str | None = None) -> ArtifactT:
+        item = self._hook.normalize_input(raw_input)
+        key = self._hook.cache_key(item)
+        if key is None:
+            with self._lock:
+                self._uncacheable += 1
+            try:
+                return self._hook.encode_one(item)
+            except BaseException:
+                with self._lock:
+                    self._failed += 1
+                raise
+
+        cache_key = key.to_string()
+        leader_fut: concurrent.futures.Future[StoredT] | None = None
+        follower_fut: concurrent.futures.Future[StoredT] | None = None
+        stored: StoredT | None = None
+        with self._lock:
+            stored = self._cache.get(cache_key)
+            if stored is not None:
+                self._hits += 1
+            elif cache_key in self._inflight:
+                self._merged += 1
+                follower_fut = self._inflight[cache_key]
+            else:
+                self._misses += 1
+                leader_fut = concurrent.futures.Future()
+                self._inflight[cache_key] = leader_fut
+
+        if stored is not None:
+            self._maybe_log()
+            return self._hook.load_artifact(stored)
+
+        if follower_fut is not None:
+            try:
+                stored = follower_fut.result(timeout=self._timeout_s)
+            except concurrent.futures.TimeoutError:
+                raise
+            except BaseException as cause:
+                label = desc or key.input_key
+                raise RuntimeError(
+                    f"reference encode failed for {label}: {cause}"
+                ) from cause
+            return self._hook.load_artifact(stored)
+
+        assert leader_fut is not None
+        # revalidate() and cache.put() run inside the same guard as encode: any
+        # exception here must still drop the in-flight entry and fail the future,
+        # otherwise same-key followers block on a future that never resolves and
+        # every later request for this key re-follows a dead leader (permanent
+        # poison + timeout-length hangs). A hook's revalidate() may legitimately
+        # raise (e.g. a reference file mutated during the encode window).
+        try:
+            artifact = self._hook.encode_one(item)
+            stored = self._hook.store_artifact(artifact)
+            should_cache = self._hook.revalidate(item, key)
+            with self._lock:
+                if should_cache:
+                    self._cache.put(cache_key, stored)
+                self._inflight.pop(cache_key, None)
+        except BaseException as exc:
+            with self._lock:
+                self._inflight.pop(cache_key, None)
+                self._failed += 1
+            leader_fut.set_exception(exc)
+            raise
+        leader_fut.set_result(stored)
+        self._maybe_log()
+        return self._hook.load_artifact(stored)
+
+    def stats(self) -> dict[str, int]:
+        with self._lock:
+            return {
+                "hits": self._hits,
+                "misses": self._misses,
+                "merged": self._merged,
+                "entries": len(self._cache),
+                "bytes": self._cache.current_bytes,
+                "evictions": self._cache.eviction_count,
+                "failed": self._failed,
+                "uncacheable": self._uncacheable,
+            }
+
+    def _maybe_log(self) -> None:
+        if self._log_prefix is None:
+            return
+        now = time.monotonic()
+        if now - self._last_log_time < self._LOG_INTERVAL_S:
+            return
+        with self._lock:
+            if now - self._last_log_time < self._LOG_INTERVAL_S:
+                return
+            self._last_log_time = now
+            stats = {
+                "hits": self._hits,
+                "misses": self._misses,
+                "merged": self._merged,
+                "entries": len(self._cache),
+                "bytes": self._cache.current_bytes,
+                "evictions": self._cache.eviction_count,
+                "failed": self._failed,
+                "uncacheable": self._uncacheable,
+            }
+        logger.info("%s reference encode stats: %s", self._log_prefix, stats)

--- a/tests/unit_test/scheduling/test_reference_encoder.py
+++ b/tests/unit_test/scheduling/test_reference_encoder.py
@@ -1,0 +1,317 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import concurrent.futures
+import threading
+import time
+from collections import Counter
+from typing import Any
+
+import pytest
+import torch
+
+from sglang_omni.scheduling.reference_encoder import (
+    ReferenceEncodeHook,
+    ReferenceEncodeKey,
+    ReferenceEncodeService,
+)
+
+
+def _key(name: str) -> ReferenceEncodeKey:
+    return ReferenceEncodeKey(
+        model_id="test",
+        model_revision="rev",
+        encoder_id="encoder",
+        encoder_config_hash="cfg",
+        artifact_kind="codes",
+        input_key=name,
+    )
+
+
+class _TensorHook(ReferenceEncodeHook[str, torch.Tensor, torch.Tensor]):
+    def __init__(self) -> None:
+        self.calls: Counter[str] = Counter()
+        self.lock = threading.Lock()
+
+    def normalize_input(self, raw_input: Any) -> str:
+        return str(raw_input)
+
+    def cache_key(self, item: str) -> ReferenceEncodeKey | None:
+        if item.startswith("uncacheable"):
+            return None
+        return _key(item)
+
+    def encode_one(self, item: str) -> torch.Tensor:
+        with self.lock:
+            self.calls[item] += 1
+        value = sum(ord(ch) for ch in item) % 127
+        return torch.full((2,), value, dtype=torch.long)
+
+    def store_artifact(self, artifact: torch.Tensor) -> torch.Tensor:
+        return artifact.detach().to("cpu").clone()
+
+    def load_artifact(self, stored: torch.Tensor) -> torch.Tensor:
+        return stored.detach().clone().to(dtype=torch.long)
+
+
+def test_same_key_concurrent_single_flight() -> None:
+    release = threading.Event()
+    entered = threading.Event()
+
+    class _GatedHook(_TensorHook):
+        def encode_one(self, item: str) -> torch.Tensor:
+            entered.set()
+            assert release.wait(timeout=5)
+            return super().encode_one(item)
+
+    hook = _GatedHook()
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024)
+    results: list[torch.Tensor | None] = [None] * 8
+    errors: list[Exception] = []
+
+    def worker(index: int) -> None:
+        try:
+            results[index] = service.get_or_encode("same")
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(len(results))]
+    for thread in threads:
+        thread.start()
+    assert entered.wait(timeout=5)
+    time.sleep(0.05)
+    release.set()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert not errors
+    assert hook.calls["same"] == 1
+    assert all(result is not None for result in results)
+    first = results[0]
+    assert first is not None
+    assert all(torch.equal(first, result) for result in results if result is not None)
+    assert len({result.data_ptr() for result in results if result is not None}) == 8
+    stats = service.stats()
+    assert stats["misses"] == 1
+    assert stats["merged"] == 7
+    assert stats["hits"] == 0
+    assert stats["entries"] == 1
+
+
+def test_cache_hit_returns_loaded_artifact() -> None:
+    hook = _TensorHook()
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024)
+
+    first = service.get_or_encode("hit")
+    first.fill_(-1)
+    second = service.get_or_encode("hit")
+
+    assert hook.calls["hit"] == 1
+    assert torch.all(second >= 0)
+    assert first.data_ptr() != second.data_ptr()
+    assert service.stats()["hits"] == 1
+
+
+def test_key_none_bypasses_cache() -> None:
+    hook = _TensorHook()
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024)
+
+    service.get_or_encode("uncacheable-a")
+    service.get_or_encode("uncacheable-a")
+
+    assert hook.calls["uncacheable-a"] == 2
+    stats = service.stats()
+    assert stats["uncacheable"] == 2
+    assert stats["misses"] == 0
+    assert stats["entries"] == 0
+
+
+def test_exception_propagates_to_all_waiters_and_does_not_poison() -> None:
+    release = threading.Event()
+    entered = threading.Event()
+
+    class _FlakyHook(_TensorHook):
+        def encode_one(self, item: str) -> torch.Tensor:
+            with self.lock:
+                self.calls[item] += 1
+                call = self.calls[item]
+            entered.set()
+            assert release.wait(timeout=5)
+            if call == 1:
+                raise ValueError("boom")
+            return torch.tensor([9], dtype=torch.long)
+
+    hook = _FlakyHook()
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024)
+    errors: list[Exception] = []
+
+    def worker() -> None:
+        try:
+            service.get_or_encode("flaky", desc="flaky")
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    assert entered.wait(timeout=5)
+    time.sleep(0.05)
+    release.set()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert len(errors) == 4
+    assert service.stats()["entries"] == 0
+    result = service.get_or_encode("flaky")
+    assert torch.equal(result, torch.tensor([9], dtype=torch.long))
+    assert hook.calls["flaky"] == 2
+
+
+def test_artifact_larger_than_budget_is_returned_but_not_cached() -> None:
+    hook = _TensorHook()
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=1)
+
+    first = service.get_or_encode("large")
+    second = service.get_or_encode("large")
+
+    assert torch.equal(first, second)
+    assert hook.calls["large"] == 2
+    assert service.stats()["entries"] == 0
+
+
+def test_lru_eviction_respects_max_bytes() -> None:
+    hook = _TensorHook()
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=16)
+
+    service.get_or_encode("a")
+    service.get_or_encode("b")
+    service.get_or_encode("b")
+    service.get_or_encode("a")
+
+    assert hook.calls["b"] == 1
+    assert hook.calls["a"] == 2
+    assert service.stats()["evictions"] >= 1
+
+
+def test_revalidate_false_returns_but_does_not_cache() -> None:
+    class _NoCacheHook(_TensorHook):
+        def revalidate(self, item: str, key: ReferenceEncodeKey) -> bool:
+            return False
+
+    hook = _NoCacheHook()
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024)
+
+    service.get_or_encode("changed")
+    service.get_or_encode("changed")
+
+    assert hook.calls["changed"] == 2
+    assert service.stats()["entries"] == 0
+
+
+def test_follower_timeout_does_not_remove_leader_inflight() -> None:
+    release = threading.Event()
+    entered = threading.Event()
+
+    class _SlowHook(_TensorHook):
+        def encode_one(self, item: str) -> torch.Tensor:
+            entered.set()
+            assert release.wait(timeout=5)
+            return super().encode_one(item)
+
+    hook = _SlowHook()
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024, timeout_s=0.01)
+    leader_result: list[torch.Tensor] = []
+
+    leader = threading.Thread(
+        target=lambda: leader_result.append(service.get_or_encode("slow"))
+    )
+    leader.start()
+    assert entered.wait(timeout=5)
+    with pytest.raises(concurrent.futures.TimeoutError):
+        service.get_or_encode("slow")
+    release.set()
+    leader.join(timeout=5)
+
+    assert len(leader_result) == 1
+    assert hook.calls["slow"] == 1
+    assert torch.equal(service.get_or_encode("slow"), leader_result[0])
+
+
+def test_stats_hits_misses_merged_entries_bytes() -> None:
+    hook = _TensorHook()
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024)
+
+    service.get_or_encode("stats")
+    service.get_or_encode("stats")
+    stats = service.stats()
+
+    assert stats["hits"] == 1
+    assert stats["misses"] == 1
+    assert stats["merged"] == 0
+    assert stats["entries"] == 1
+    assert stats["bytes"] > 0
+
+
+def test_revalidate_exception_clears_inflight_and_does_not_poison() -> None:
+    # A hook whose revalidate() raises (e.g. reference file mutated mid-encode)
+    # must not strand the in-flight entry: the leader has to fail the future and
+    # drop the key so the next same-key request is a fresh leader, never a
+    # follower blocked on a dead future for the full timeout.
+    class _RaisingRevalidateHook(_TensorHook):
+        def revalidate(self, item: str, key: ReferenceEncodeKey) -> bool:
+            raise RuntimeError("revalidate boom")
+
+    hook = _RaisingRevalidateHook()
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024)
+
+    with pytest.raises(RuntimeError, match="revalidate boom"):
+        service.get_or_encode("k")
+    assert service.stats()["entries"] == 0
+    assert service.stats()["failed"] == 1
+    assert len(service._inflight) == 0
+
+    # New leader (not a stuck follower) -> encode runs again instead of hanging.
+    with pytest.raises(RuntimeError, match="revalidate boom"):
+        service.get_or_encode("k")
+    assert hook.calls["k"] == 2
+
+
+def test_revalidate_exception_propagates_to_followers_without_timeout() -> None:
+    # Concurrent same-key followers must receive the leader's failure promptly,
+    # not sit on follower_fut.result() until timeout_s.
+    release = threading.Event()
+    entered = threading.Event()
+
+    class _GatedRaisingHook(_TensorHook):
+        def encode_one(self, item: str) -> torch.Tensor:
+            entered.set()
+            assert release.wait(timeout=5)
+            return super().encode_one(item)
+
+        def revalidate(self, item: str, key: ReferenceEncodeKey) -> bool:
+            raise RuntimeError("revalidate boom")
+
+    hook = _GatedRaisingHook()
+    # Large timeout: if the key were poisoned, followers would block far past the
+    # join() below, leaving their threads alive and errors incomplete.
+    service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024, timeout_s=30)
+    errors: list[Exception] = []
+
+    def worker() -> None:
+        try:
+            service.get_or_encode("k", desc="k")
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    assert entered.wait(timeout=5)
+    time.sleep(0.05)
+    release.set()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert len(errors) == 4
+    assert len(service._inflight) == 0


### PR DESCRIPTION
## Motivation

Land the shared ad-hoc reference-encode service on `main` on its own, so each model migration (FishAudio #926, Qwen3-TTS #927, MOSS-local #930) can retarget `main` **independently** instead of stacking. Nothing depends on model code here, so this is the natural first thing to merge.

## Behavior class

Green. The service is **not wired into any model** in this PR — pure addition of an unused module + doc + tests. No runtime path changes, so no accuracy/throughput/latency impact and nothing for CI to gate yet. Perf gating happens per-migration when a model adopts the service.

## Modifications

- `sglang_omni/scheduling/reference_encoder.py`: `ReferenceEncodeKey`, `ReferenceEncodeHook`, synchronous `ReferenceEncodeService`. Owns mechanics only — cache-keyed lookup, byte-bounded LRU via `StageOutputCache`, same-key single-flight, no-poison failure fanout, caller-owned artifact load, basic stats. Model semantics (normalize/key/encode/store/load/revalidate) live in the caller's hook.
- Depends only on the existing `StageOutputCache`; no new deps.
- Developer reference doc + `docs/index.rst` toctree entry.

### Hang-safe leader path

The leader runs `revalidate()` and `cache.put()` inside the same `try/except` as `encode_one()`: any exception there still drops the in-flight entry and fails the future. Otherwise a raising `revalidate()` (e.g. a reference file mutated during the encode window) would leave same-key followers blocked on a future that never resolves — permanent poison + timeout-length hangs under concurrency.

## Contract tests

`tests/unit_test/scheduling/test_reference_encoder.py`: single-flight merge, cache hit, key-None bypass, exception-does-not-poison, over-budget-not-cached, LRU/byte-budget eviction, revalidate-false-not-cached, follower-timeout isolation, stats, and the two new `revalidate`-raises regression tests.

## Follow-ups (retarget onto this once merged)

- #926 FishAudio S2-Pro migration — drop the base-service files, keep only the Fish hook.
- #927 Qwen3-TTS migration — retarget `main`.
- #930 MOSS-local migration — retarget `main`; converge to a single MOSS PR (the env-var-free version) and drop the duplicate.

## Validation

- [x] `python3 -m py_compile sglang_omni/scheduling/reference_encoder.py tests/unit_test/scheduling/test_reference_encoder.py`
- [ ] `pytest tests/unit_test/scheduling/test_reference_encoder.py` — run in CI (local env lacks torch/pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)