### PR TITLE
refactor(moss-td): fold per-item encoder loop into a single forward in get_audio_feature

### DIFF
--- a/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
+++ b/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
@@ -98,98 +98,87 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
             batch_size, trimmed_len // merge_size, hidden_size * merge_size
         )
 
-    def _encode_one_audio_item(
-        self,
-        item: MultimodalDataItem,
-        forward_batch: ForwardBatch,
-    ) -> list[torch.Tensor]:
-        if item.feature is None:
-            raise ValueError(
-                "MOSS-Transcribe-Diarize audio item is missing input_features."
-            )
-
-        device = next(self.whisper_encoder.parameters()).device
-        encoder_dtype = next(self.whisper_encoder.parameters()).dtype
-        input_features = item.feature.to(device=device, dtype=encoder_dtype)
-
-        audio_feature_lengths = getattr(item, "audio_feature_lengths", None)
-        if audio_feature_lengths is None:
-            raise ValueError(
-                "MOSS-Transcribe-Diarize audio item is missing audio_feature_lengths."
-            )
-        audio_feature_lengths = audio_feature_lengths.to(device="cpu", dtype=torch.long)
-        if audio_feature_lengths.numel() != input_features.shape[0]:
-            raise ValueError(
-                "audio_feature_lengths must contain one length per input_features "
-                f"chunk: got {audio_feature_lengths.numel()} lengths for "
-                f"{input_features.shape[0]} chunks."
-            )
-
-        audio_chunk_mapping = getattr(item, "audio_chunk_mapping", None)
-        if audio_chunk_mapping is None:
-            audio_chunk_mapping = torch.zeros(
-                input_features.shape[0], dtype=torch.long, device="cpu"
-            )
-        else:
-            audio_chunk_mapping = audio_chunk_mapping.to(device="cpu", dtype=torch.long)
-        if audio_chunk_mapping.numel() != input_features.shape[0]:
-            raise ValueError(
-                "audio_chunk_mapping must contain one sample index per input_features "
-                f"chunk: got {audio_chunk_mapping.numel()} indices for "
-                f"{input_features.shape[0]} chunks."
-            )
-
-        encoder_len = (input_features.shape[-1] - 1) // 2 + 1
-        encoder_position_ids = torch.arange(
-            encoder_len,
-            device=input_features.device,
-            dtype=torch.long,
-        )
-        whisper_features = self.whisper_encoder(
-            input_features,
-            encoder_position_ids,
-            forward_batch,
-        )
-
-        audio_feature_lengths_list = audio_feature_lengths.tolist()
-        audio_chunk_mapping_list = audio_chunk_mapping.tolist()
-        num_audios = (
-            max(audio_chunk_mapping_list) + 1 if audio_chunk_mapping_list else 0
-        )
-        per_audio_chunks = [[] for _ in range(num_audios)]
-        merge_size = int(self.config.audio_merge_size)
-        for chunk_idx, token_len in enumerate(audio_feature_lengths_list):
-            sample_idx = audio_chunk_mapping_list[chunk_idx]
-            per_audio_chunks[sample_idx].append(
-                whisper_features[
-                    chunk_idx : chunk_idx + 1, : int(token_len) * merge_size
-                ]
-            )
-
-        adapted = []
-        adaptor_dtype = next(self.vq_adaptor.parameters()).dtype
-        for parts in per_audio_chunks:
-            if not parts:
-                continue
-            feat = torch.cat(parts, dim=1).to(dtype=adaptor_dtype)
-            merged = self.time_merge(feat)
-            adapted.append(self.vq_adaptor(merged).squeeze(0))
-        return adapted
-
     def get_audio_feature(
         self,
         items: List[MultimodalDataItem],
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
-        audio_embeds = []
+        # NOTE: sglang's mm dispatch calls this per request, so len(items) is always 1 today.
+        merge_size = int(self.config.audio_merge_size)
+        device = next(self.whisper_encoder.parameters()).device
+        encoder_dtype = next(self.whisper_encoder.parameters()).dtype
+
+        chunks: list[torch.Tensor] = []
+        token_lens: list[int] = []
+        audio_spans: list[list[int]] = []
         for item in items:
-            audio_embeds.extend(self._encode_one_audio_item(item, forward_batch))
-        if not audio_embeds:
+            if item.feature is None:
+                raise ValueError(
+                    "MOSS-Transcribe-Diarize audio item is missing input_features."
+                )
+            input_features = item.feature
+            num_chunks = input_features.shape[0]
+
+            feature_lengths = getattr(item, "audio_feature_lengths", None)
+            if feature_lengths is None:
+                raise ValueError(
+                    "MOSS-Transcribe-Diarize audio item is missing audio_feature_lengths."
+                )
+            feature_lengths = feature_lengths.to(device="cpu", dtype=torch.long)
+            if feature_lengths.numel() != num_chunks:
+                raise ValueError(
+                    "audio_feature_lengths must contain one length per input_features "
+                    f"chunk: got {feature_lengths.numel()} lengths for {num_chunks} chunks."
+                )
+
+            chunk_mapping = getattr(item, "audio_chunk_mapping", None)
+            if chunk_mapping is None:
+                chunk_mapping = torch.zeros(num_chunks, dtype=torch.long)
+            else:
+                chunk_mapping = chunk_mapping.to(device="cpu", dtype=torch.long)
+            if chunk_mapping.numel() != num_chunks:
+                raise ValueError(
+                    "audio_chunk_mapping must contain one sample index per input_features "
+                    f"chunk: got {chunk_mapping.numel()} indices for {num_chunks} chunks."
+                )
+            feature_lengths = feature_lengths.tolist()
+            chunk_mapping = chunk_mapping.tolist()
+
+            num_audios = max(chunk_mapping) + 1 if chunk_mapping else 0
+            per_audio: list[list[int]] = [[] for _ in range(num_audios)]
+            for chunk_idx, token_len in enumerate(feature_lengths):
+                per_audio[chunk_mapping[chunk_idx]].append(len(chunks))
+                chunks.append(input_features[chunk_idx])
+                token_lens.append(int(token_len))
+            audio_spans.extend(ids for ids in per_audio if ids)
+
+        if not chunks:
             hidden_size = self.config.text_config.hidden_size
-            device = next(self.vq_adaptor.parameters()).device
-            dtype = next(self.vq_adaptor.parameters()).dtype
-            return torch.empty((0, hidden_size), device=device, dtype=dtype)
-        return torch.cat(audio_embeds, dim=0)
+            adaptor_param = next(self.vq_adaptor.parameters())
+            return torch.empty(
+                (0, hidden_size), device=adaptor_param.device, dtype=adaptor_param.dtype
+            )
+
+        batched_features = torch.stack(chunks).to(device=device, dtype=encoder_dtype)
+        encoder_len = (batched_features.shape[-1] - 1) // 2 + 1
+        encoder_position_ids = torch.arange(
+            encoder_len, device=device, dtype=torch.long
+        )
+        features = self.whisper_encoder(
+            batched_features, encoder_position_ids, forward_batch
+        )
+
+        adaptor_dtype = next(self.vq_adaptor.parameters()).dtype
+        merged = [
+            self.time_merge(
+                torch.cat(
+                    [features[i : i + 1, : token_lens[i] * merge_size] for i in ids],
+                    dim=1,
+                ).to(dtype=adaptor_dtype)
+            ).squeeze(0)
+            for ids in audio_spans
+        ]
+        return self.vq_adaptor(torch.cat(merged, dim=0))
 
     def forward(
         self,


### PR DESCRIPTION
Addresses the **M-PR6 (batched inference)** item in #924.

## What

Replace the per-item encode loop in `get_audio_feature` with a single batched `whisper_encoder` forward (stack all chunks → one pass → reassemble per audio), matching the pattern in `whisper_asr` / `qwen3_asr`.

## Accuracy — no regression

movies800, A100-40GB bf16, 3 runs each @ concurrency 8:

| metric | baseline | this PR |
|---|---|---|
| CER (%) | 6.54 / 6.52 / 6.12 | 6.51 / 6.40 / 6.58 |
| cp_CER (%) | 12.34 / 13.03 / 11.70 | 12.68 / 13.02 / 12.97 |

This PR stays inside the baseline run-to-run band.

## The batching doesn't actually engage today

- **Observed** (profiled @ concurrency 16): `get_audio_feature` always receives a single item (`items=1`), even when the LLM prefill batches up to 14 sequences — so it degenerates to the per-item path (identical GPU time).
- **Root cause** ([upstream](https://github.com/sgl-project/sglang/blob/3a679459e5d3ed15838cbe8726944c4e52b8e103/python/sglang/srt/managers/mm_utils.py#L650)): `mm_utils._get_chunked_prefill_embedding` loops per request (`embedding_items[items_size[i]:items_size[i+1]]`) and calls the embedder once per request. `qwen3_asr` shares this dispatch; `whisper_asr` uses its own `forward`.
- **Encoder cost** (single-request trace): ~13 ms encoder vs ~1–2 s of LLM decode, and the batch speedup is ~1.3× (measured, saturates by batch 16) — so even if engaged the end-to-end effect is minimal.

## Next steps (needs a call)

1. **Merge as cleanup** — aligns with `whisper_asr`/`qwen3_asr`, −14 lines; code comment notes `items` is always 1.
2. **Close** — runtime no-op.
3. **Enable in sglang core** — hoist encode out of the per-request loop in `_get_chunked_prefill_embedding`, flag-gated. Better as a general upstream option benchmarked on an encoder-bound model.

Leaning (1) or (2) — opening for maintainers to call.

