### PR TITLE
encoder cuda graph for Moss TD

### DIFF
--- a/sglang_omni/models/moss_transcribe_diarize/encoder_cuda_graph.py
+++ b/sglang_omni/models/moss_transcribe_diarize/encoder_cuda_graph.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-chunk-count CUDA graph for the MOSS-TD Whisper encoder.
+
+The Whisper encoder is a fixed-shape, stateless pure function: input mel
+[num_chunks, num_mel_bins, input_feature_len] -> [num_chunks, encoder_len, d_model].
+
+Only the first dim (chunk count) varies, so we bucket over chunk count and pad
+up to the nearest captured bucket on replay.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+class WhisperEncoderCudaGraphRunner:
+    def __init__(
+        self,
+        encoder,
+        num_mel_bins: int,
+        input_feature_len: int,
+        min_free_gb: float = 3.0,
+        warmup_iters: int = 3,
+    ) -> None:
+        self._encoder = encoder
+        self._num_mel_bins = int(num_mel_bins)
+        self._input_feature_len = int(input_feature_len)
+        self._device = next(encoder.parameters()).device
+        self._dtype = next(encoder.parameters()).dtype
+        self._min_free_bytes = int(float(min_free_gb) * (1024**3))
+        self._warmup_iters = int(warmup_iters)
+        self._graphs: dict[int, tuple] = {}
+        self._pool = None
+        self._forward_batch = None
+
+    def _enough_free_vram(self) -> tuple[bool, int]:
+        free, _ = torch.cuda.mem_get_info(self._device)
+        return free >= self._min_free_bytes, free
+
+    def _warmup(self, static_feat, static_pos, forward_batch) -> None:
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            for _ in range(self._warmup_iters):
+                self._encoder(static_feat, static_pos, forward_batch)
+        torch.cuda.current_stream().wait_stream(stream)
+        torch.cuda.synchronize()
+
+    def _capture_bucket(self, c: int, encoder_len: int, forward_batch) -> None:
+        static_feat = torch.zeros(
+            c,
+            self._num_mel_bins,
+            self._input_feature_len,
+            device=self._device,
+            dtype=self._dtype,
+        )
+        static_pos = torch.arange(encoder_len, device=self._device, dtype=torch.long)
+        self._warmup(static_feat, static_pos, forward_batch)
+
+        if self._pool is None:
+            self._pool = torch.cuda.graph_pool_handle()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(
+            graph, pool=self._pool, capture_error_mode="thread_local"
+        ):
+            static_out = self._encoder(static_feat, static_pos, forward_batch)
+        self._graphs[c] = (graph, static_feat, static_pos, static_out)
+        logger.info(
+            "Captured MOSS-TD encoder CUDA graph chunks=%d -> out %s (%d cached)",
+            c,
+            tuple(static_out.shape),
+            len(self._graphs),
+        )
+
+    @torch.no_grad()
+    def capture(self, chunk_buckets, forward_batch=None) -> None:
+        """Capture one graph per chunk-count bucket, once, at warmup."""
+        self._forward_batch = forward_batch
+        encoder_len = (self._input_feature_len - 1) // 2 + 1
+
+        with torch.cuda.device(self._device):
+            for c in sorted(
+                {int(x) for x in chunk_buckets if int(x) >= 1}, reverse=True
+            ):
+                if c in self._graphs:
+                    continue
+                enough, free = self._enough_free_vram()
+                if not enough:
+                    logger.warning(
+                        "MOSS-TD encoder CUDA graph: free VRAM %.1fGB < %.1fGB "
+                        "headroom; skipping chunks=%d",
+                        free / 1024**3,
+                        self._min_free_bytes / 1024**3,
+                        c,
+                    )
+                    continue
+                try:
+                    self._capture_bucket(c, encoder_len, forward_batch)
+                except Exception as exc:
+                    logger.warning(
+                        "MOSS-TD encoder CUDA graph capture failed for chunks=%d: "
+                        "%s; will use a larger captured graph or eager",
+                        c,
+                        exc,
+                    )
+                    self._graphs.pop(c, None)
+
+    @torch.no_grad()
+    def run(self, input_features, encoder_position_ids, forward_batch):
+        """Replay the graph for [n, num_mel_bins, input_feature_len] features,
+        padding up to the nearest captured bucket. Falls back to eager if no
+        bucket fits or the input_feature_len differs from capture."""
+        n = input_features.shape[0]
+        chunk_bucket = min((c for c in self._graphs if c >= n), default=None)
+        if chunk_bucket is None or input_features.shape[-1] != self._input_feature_len:
+            return self._encoder(input_features, encoder_position_ids, forward_batch)
+        graph, static_feat, _static_pos, static_out = self._graphs[chunk_bucket]
+        static_feat[:n].copy_(input_features)
+        if n < chunk_bucket:
+            static_feat[n:].zero_()
+        graph.replay()
+        return static_out[:n].clone()

--- a/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
+++ b/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
@@ -24,6 +24,9 @@ from sglang.srt.models.qwen3 import Qwen3ForCausalLM
 from sglang.srt.models.whisper import WhisperEncoder
 from sglang.srt.utils import add_prefix
 
+from sglang_omni.models.moss_transcribe_diarize.encoder_cuda_graph import (
+    WhisperEncoderCudaGraphRunner,
+)
 from sglang_omni.models.moss_transcribe_diarize.hf_config import (
     MossTranscribeDiarizeConfig,
 )
@@ -87,6 +90,7 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
         )
         self.pattern = MultiModalityDataPaddingPatternMultimodalTokens()
         self._encoder_cache: Optional[StageOutputCache] = None
+        self._encoder_graph_runner = None
 
     def init_encoder_cache(self, max_bytes: int) -> None:
         self._encoder_cache = (
@@ -104,6 +108,25 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
 
     def pad_input_ids(self, input_ids: List[int], mm_inputs: MultimodalInputs):
         return self.pattern.pad_input_tokens(input_ids, mm_inputs)
+
+    def init_encoder_graphs(self, chunk_buckets, input_feature_len: int) -> None:
+        """Capture per-chunk-count CUDA graphs for the Whisper encoder.
+
+        Called from the stage factory after the model is on-device and CUDA
+        graphs are enabled. input_feature_len is the fixed length of the
+        encoder's input_features time axis for one 30s window
+        (WhisperFeatureExtractor.nb_max_frames).
+        """
+        buckets = [int(b) for b in (chunk_buckets or []) if int(b) >= 1]
+        if not buckets:
+            return
+        runner = WhisperEncoderCudaGraphRunner(
+            self.whisper_encoder,
+            num_mel_bins=int(self.config.audio_config.num_mel_bins),
+            input_feature_len=int(input_feature_len),
+        )
+        runner.capture(buckets)
+        self._encoder_graph_runner = runner
 
     def time_merge(self, features: torch.Tensor) -> torch.Tensor:
         batch_size, seq_len, hidden_size = features.shape
@@ -199,9 +222,14 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
             encoder_position_ids = torch.arange(
                 encoder_len, device=device, dtype=torch.long
             )
-            features = self.whisper_encoder(
-                batched_features, encoder_position_ids, forward_batch
-            )
+            if self._encoder_graph_runner is not None:
+                features = self._encoder_graph_runner.run(
+                    batched_features, encoder_position_ids, forward_batch
+                )
+            else:
+                features = self.whisper_encoder(
+                    batched_features, encoder_position_ids, forward_batch
+                )
 
             adaptor_dtype = next(self.vq_adaptor.parameters()).dtype
             merged = [

--- a/sglang_omni/models/moss_transcribe_diarize/stages.py
+++ b/sglang_omni/models/moss_transcribe_diarize/stages.py
@@ -31,6 +31,12 @@ from sglang_omni.scheduling.sglang_backend import (
     build_sglang_server_args,
 )
 
+# Note (yijiang): Dense buckets avoid CUDA-graph capture at padded sizes
+# we don't hit; pad-to-power-of-2 would tax a compute-bound encoder with
+# no cross-request batching yet.
+# Cap tuned to p99 audio duration ([1,8] covers up to ~4min)
+_DEFAULT_ENCODER_GRAPH_CHUNK_BUCKETS = list(range(1, 9))
+
 
 @contextmanager
 def _missing_additional_chat_templates_compat() -> Iterator[None]:
@@ -95,6 +101,7 @@ def create_sglang_moss_transcribe_diarize_executor(
     # note (yichi): async on by default for MOSS-TD; --decode-mode sync to opt out.
     enable_async_decode: bool = True,
     async_decode_min_batch_size: int = 2,
+    encoder_graph_chunk_buckets: list[int] | None = None,
     request_build_max_workers: int = 2,
     request_build_max_pending: int | None = 16,
     stream_emit_interval_s: float = 0.05,
@@ -156,6 +163,13 @@ def create_sglang_moss_transcribe_diarize_executor(
 
     if want_cuda_graph:
         model_worker.model_runner.init_device_graphs()
+        buckets = (
+            encoder_graph_chunk_buckets
+            if encoder_graph_chunk_buckets is not None
+            else _DEFAULT_ENCODER_GRAPH_CHUNK_BUCKETS
+        )
+        input_feature_len = int(processor.feature_extractor.nb_max_frames)
+        model_worker.model_runner.model.init_encoder_graphs(buckets, input_feature_len)
 
     init_mm_embedding_cache(mm_embedding_cache_size_bytes)
     model_worker.model_runner.model.init_encoder_cache(encoder_cache_size_bytes)

--- a/tests/unit_test/moss_transcribe_diarize/test_encoder_cuda_graph.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_encoder_cuda_graph.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the MOSS-TD Whisper encoder CUDA-graph runner."""
+
+from __future__ import annotations
+
+import ast
+import glob
+import inspect
+import os
+import textwrap
+
+import pytest
+import torch
+
+from sglang_omni.models.moss_transcribe_diarize.encoder_cuda_graph import (
+    WhisperEncoderCudaGraphRunner,
+)
+
+pytestmark = pytest.mark.gpu
+
+_HAS_CUDA = torch.cuda.is_available()
+
+_CKPT_GLOB = (
+    "/root/.cache/huggingface/hub/"
+    "models--OpenMOSS-Team--MOSS-Transcribe-Diarize/snapshots/*/"
+)
+
+_INPUT_FEATURE_LEN = 3000
+_CHUNK_BUCKETS = [1, 2, 4, 8, 16, 32]
+# Chunk counts exercised by the bit-identity test: exact bucket hits plus counts
+# that pad up to the next bucket (3->4, 5->8, 12->16, 20->32).
+_TEST_CHUNKS = [1, 2, 3, 4, 5, 8, 12, 16, 20, 32]
+
+
+def test_capture_uses_thread_local_error_mode():
+    source = textwrap.dedent(
+        inspect.getsource(WhisperEncoderCudaGraphRunner._capture_bucket)
+    )
+    tree = ast.parse(source)
+    graph_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "graph"
+        and isinstance(node.func.value, ast.Attribute)
+        and node.func.value.attr == "cuda"
+    ]
+    assert graph_calls, "encoder CUDA graph capture call not found"
+    assert any(
+        kw.arg == "capture_error_mode"
+        and isinstance(kw.value, ast.Constant)
+        and kw.value.value == "thread_local"
+        for call in graph_calls
+        for kw in call.keywords
+    ), "encoder CUDA graph capture must use thread-local error mode"
+
+
+@pytest.fixture(scope="module")
+def encoder_bundle():
+    """sglang WhisperEncoder built from the MOSS-TD checkpoint. sglang's encoder
+    uses TP-parallel layers, so a TP=1 group must exist before construction."""
+    if not _HAS_CUDA:
+        pytest.skip("needs CUDA")
+    snaps = glob.glob(_CKPT_GLOB)
+    if not snaps:
+        pytest.skip("MOSS-Transcribe-Diarize checkpoint snapshot not found")
+
+    from sglang.srt.distributed.parallel_state import (
+        init_distributed_environment,
+        initialize_model_parallel,
+        model_parallel_is_initialized,
+    )
+    from sglang.srt.models.whisper import WhisperEncoder
+    from transformers import AutoConfig
+
+    torch.cuda.set_device(0)
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29551")
+    if not torch.distributed.is_initialized():
+        init_distributed_environment(
+            world_size=1,
+            rank=0,
+            local_rank=0,
+            distributed_init_method=f"tcp://127.0.0.1:{os.environ['MASTER_PORT']}",
+            backend="nccl",
+        )
+    if not model_parallel_is_initialized():
+        initialize_model_parallel(tensor_model_parallel_size=1)
+
+    audio_config = AutoConfig.from_pretrained(
+        snaps[0], trust_remote_code=True
+    ).audio_config
+    encoder = WhisperEncoder(audio_config).cuda().to(torch.bfloat16).eval()
+    num_mel_bins = int(audio_config.num_mel_bins)
+    runner = WhisperEncoderCudaGraphRunner(encoder, num_mel_bins, _INPUT_FEATURE_LEN)
+    runner.capture(_CHUNK_BUCKETS)
+    return encoder, num_mel_bins, runner
+
+
+def _feat(num_mel_bins: int, n: int) -> torch.Tensor:
+    return torch.randn(
+        n, num_mel_bins, _INPUT_FEATURE_LEN, device="cuda", dtype=torch.bfloat16
+    )
+
+
+def _pos() -> torch.Tensor:
+    encoder_len = (_INPUT_FEATURE_LEN - 1) // 2 + 1
+    return torch.arange(encoder_len, device="cuda", dtype=torch.long)
+
+
+def test_some_graphs_captured(encoder_bundle):
+    _, _, runner = encoder_bundle
+    assert runner._graphs, "no encoder CUDA graphs captured (all fell back to eager)"
+    assert set(runner._graphs) == set(_CHUNK_BUCKETS)
+
+
+@pytest.mark.parametrize("n", _TEST_CHUNKS)
+def test_graph_bit_identical_to_eager(encoder_bundle, n):
+    """Graphed replay must equal eager bit-for-bit at the SAME batch size. When n
+    pads up to a larger bucket, we compare against eager run at that padded batch
+    (not batch n) to avoid batch sizes affecting kernel selections."""
+    encoder, num_mel_bins, runner = encoder_bundle
+    pos = _pos()
+    chunk_bucket = min(c for c in _CHUNK_BUCKETS if c >= n)
+    torch.manual_seed(100 + n)
+    feat = _feat(num_mel_bins, n)
+    feat_padded = torch.zeros(
+        chunk_bucket,
+        num_mel_bins,
+        _INPUT_FEATURE_LEN,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    feat_padded[:n] = feat
+    with torch.no_grad():
+        eager = encoder(feat_padded, pos, None)[:n]
+        graphed = runner.run(feat, pos, None)
+    assert torch.equal(eager, graphed), (
+        f"graph replay not bit-identical to same-batch eager (n={n}, "
+        f"bucket={chunk_bucket}): "
+        f"max|delta|={(eager.float() - graphed.float()).abs().max().item():.3e}"
+    )
+
+
+def test_over_largest_bucket_falls_back_to_eager(encoder_bundle):
+    """A chunk count above the largest captured bucket falls back to eager and
+    still matches a direct eager call."""
+    encoder, num_mel_bins, _ = encoder_bundle
+    runner = WhisperEncoderCudaGraphRunner(encoder, num_mel_bins, _INPUT_FEATURE_LEN)
+    runner.capture([1, 2])
+    feat = _feat(num_mel_bins, 5)
+    pos = _pos()
+    with torch.no_grad():
+        eager = encoder(feat, pos, None)
+        out = runner.run(feat, pos, None)
+    assert torch.equal(eager, out)
+
+
+def test_vram_guard_skips_capture(encoder_bundle):
+    """Below the configured VRAM headroom, capture is skipped (no graphs); forced
+    via an absurd min_free_gb."""
+    encoder, num_mel_bins, _ = encoder_bundle
+    runner = WhisperEncoderCudaGraphRunner(
+        encoder, num_mel_bins, _INPUT_FEATURE_LEN, min_free_gb=100000.0
+    )
+    runner.capture(_CHUNK_BUCKETS)
+    assert runner._graphs == {}, "VRAM guard must skip all captures"
+
+
+def test_capture_failure_falls_back_to_eager(encoder_bundle):
+    """A capture exception is caught per-bucket, that bucket dropped; run() then
+    falls back to eager, bit-identical to a direct eager call."""
+    encoder, num_mel_bins, _ = encoder_bundle
+    runner = WhisperEncoderCudaGraphRunner(encoder, num_mel_bins, _INPUT_FEATURE_LEN)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("simulated capture OOM")
+
+    runner._capture_bucket = boom
+    runner.capture(_CHUNK_BUCKETS)
+    assert runner._graphs == {}, "capture failures must be caught -> no graphs"
+
+    feat = _feat(num_mel_bins, 2)
+    pos = _pos()
+    with torch.no_grad():
+        eager = encoder(feat, pos, None)
+        out = runner.run(feat, pos, None)
+    assert torch.equal(eager, out)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Adds a per-chunk-count CUDA graph for the MOSS-Transcribe-Diarize Whisper encoder. The encoder is a fixed-shape, stateless pure function (`[num_chunks, num_mel_bins, input_feature_len]` → `[num_chunks, encoder_len, d_model]`). Only the batch dim (chunk count) varies, so we bucket over chunk count and pad up to the nearest captured bucket. 

## Modifications

 - `encoder_cuda_graph.py`: new `WhisperEncoderCudaGraphRunner` class. It captures one CUDA graph per chunk count, with warmup, a VRAM headroom check before each capture, and eager fallback if anything goes wrong.
  - `sglang_model.py`: `init_encoder_graphs()` builds the runner at startup, and the encoder now runs through it when a graph is available (otherwise fallback to eager).
  - `stages.py`: does the capture on startup; defaults to chunk counts `[1,2,4,8,16,32]`, which can be overridden with `encoder_graph_chunk_buckets`.

## Related Issues

Addresses the **M-PR4** (Encoder CUDA graph) item in #924. Continues #961

## Correctness

End-to-end (movies800, greedy, concurrency=1): 800/800 samples produce byte-identical `result_text` with vs without the encoder graph. The same eval run also shows all diarization metrics match exactly (speed metrics included below for reference):

  | metric | upstream | graph |
  |---|---|---|
  | cer | 6.55% | 6.55% |
  | cer_no_spk | 6.55% | 6.55% |
  | cp_cer | 12.96% | 12.96% |
  | cer_no_spk_cp_valid | 6.44% | 6.44% |
  | delta_cer | 6.52% | 6.52% |
  | cer_valid_samples | 784 | 784 |
  | cp_cer_valid_samples | 773 | 773 |
  | exact_matches | 23 | 23 |
  | failed_requests | 0 | 0 |
  | rtf_mean | 0.0202 | 0.0192 |
  | rtf_p95 | 0.0304 | 0.0290 |
  | throughput (req/s) | 4.653 | 4.948 |
  | latency_mean (s) | 0.215 | 0.202 |


## Benchmark & Profiling

Ran ASR CI stage 1 locally on **NVIDIA H100 80GB** (movies800, 2-worker router, c=16), 3 runs each, upstream vs this PR.

  **upstream (no encoder graph):**

  | run | CER | cpCER | CER-valid / cpCER-valid | RTF mean | RTF p95 | throughput |
  |---|---|---|---|---|---|---|
  | 1 | 6.73% | 12.90% | 784 / 773 | 0.0359 | 0.0577 | 42.6 |
  | 2 | 6.33% | 12.58% | 784 / 773 | 0.0353 | 0.0575 | 43.4 |
  | 3 | 6.38% | 12.66% | 784 / 773 | 0.0360 | 0.0592 | 42.5 |
  | **worst** | **6.73%** | **12.90%** | **784 / 773** | **0.0360** | **0.0592** | **42.5** |

  **this PR (encoder CUDA graph):**

  | run | CER | cpCER | CER-valid / cpCER-valid | RTF mean | RTF p95 | throughput |
  |---|---|---|---|---|---|---|
  | 1 | 6.35% | 12.53% | 784 / 773 | 0.0326 | 0.0520 | 46.7 |
  | 2 | 6.70% | 12.22% | 784 / 773 | 0.0333 | 0.0533 | 45.9 |
  | 3 | 6.53% | 12.93% | 784 / 773 | 0.0328 | 0.0529 | 46.2 |
  | **worst** | **6.70%** | **12.93%** | **784 / 773** | **0.0333** | **0.0533** | **45.9** |

Accuracy overlaps between the two (differences are within run-to-run concurrency  noise) — consistent with the encoder graph being bit-identical. RTF and throughput improve with non-overlapping ranges across the 3 runs. All runs pass the stage-1 gate.


## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
