### PR TITLE
feat(moss-td): opt-in torch.compile for the Whisper encoder

### DIFF
--- a/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
+++ b/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
@@ -72,6 +72,7 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
         super().__init__()
         self.config = config
         self.whisper_encoder = WhisperEncoder(config.audio_config, quant_config)
+        self.encoder_runner = self.whisper_encoder
         self.vq_adaptor = VQAdaptor(
             input_dim=config.adaptor_input_dim,
             hidden_size=config.text_config.hidden_size,
@@ -97,6 +98,21 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
         return features[:, :trimmed_len, :].reshape(
             batch_size, trimmed_len // merge_size, hidden_size * merge_size
         )
+
+    def compile_encoder(self, buckets: Tuple[int, ...] = (1, 2, 3, 4)) -> None:
+        from sglang.srt.model_executor.cuda_graph_runner import set_torch_compile_config
+
+        set_torch_compile_config()
+        self.encoder_runner = torch.compile(self.whisper_encoder, dynamic=False)
+        cfg = self.config.audio_config
+        p = next(self.whisper_encoder.parameters())
+        frames = int(cfg.max_source_positions) * 2
+        pos = torch.arange((frames - 1) // 2 + 1, device=p.device, dtype=torch.long)
+        for n in buckets:
+            feats = torch.zeros(
+                n, int(cfg.num_mel_bins), frames, device=p.device, dtype=p.dtype
+            )
+            self.encoder_runner(feats, pos, None)
 
     def get_audio_feature(
         self,
@@ -164,7 +180,7 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
         encoder_position_ids = torch.arange(
             encoder_len, device=device, dtype=torch.long
         )
-        features = self.whisper_encoder(
+        features = self.encoder_runner(
             batched_features, encoder_position_ids, forward_batch
         )
 

--- a/sglang_omni/models/moss_transcribe_diarize/stages.py
+++ b/sglang_omni/models/moss_transcribe_diarize/stages.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, Tuple
 
 from sglang.srt.managers.mm_utils import init_mm_embedding_cache
 from transformers import AutoConfig, AutoProcessor, GenerationConfig
@@ -94,6 +94,8 @@ def create_sglang_moss_transcribe_diarize_executor(
     mem_fraction_static: float | None = 0.80,
     mm_embedding_cache_size_bytes: int = 0,
     enable_torch_compile: bool = False,
+    encoder_torch_compile: bool = False,
+    encoder_compile_buckets: Tuple[int, ...] = (1, 2, 3, 4),
     request_build_max_workers: int = 2,
     request_build_max_pending: int | None = 16,
     server_args_overrides: dict[str, Any] | None = None,
@@ -151,6 +153,9 @@ def create_sglang_moss_transcribe_diarize_executor(
         gpu_id,
         model_arch_override="MossTranscribeDiarizeForConditionalGeneration",
     )
+
+    if encoder_torch_compile:
+        model_worker.model_runner.model.compile_encoder(encoder_compile_buckets)
 
     if want_cuda_graph:
         model_worker.model_runner.init_device_graphs()

--- a/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
@@ -6,6 +6,7 @@ import inspect
 
 import httpx
 import pytest
+import torch
 from huggingface_hub.errors import RepositoryNotFoundError
 
 from sglang_omni.models.moss_transcribe_diarize.config import (
@@ -56,6 +57,39 @@ def test_moss_transcribe_diarize_stage_reserves_encoder_headroom() -> None:
     assert signature.parameters["request_build_max_workers"].default == 2
     assert signature.parameters["request_build_max_pending"].default == 16
     assert signature.parameters["mm_embedding_cache_size_bytes"].default == 0
+
+
+def test_compile_encoder_swaps_runner_and_warms_each_bucket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+
+    from sglang_omni.models.moss_transcribe_diarize.sglang_model import (
+        MossTranscribeDiarizeForConditionalGeneration as Model,
+    )
+
+    monkeypatch.setattr(
+        "sglang.srt.model_executor.cuda_graph_runner.set_torch_compile_config",
+        lambda: None,
+        raising=False,
+    )
+    warmups: list[tuple[int, ...]] = []
+    runner = lambda feats, pos, forward_batch: warmups.append(tuple(feats.shape))
+    monkeypatch.setattr(torch, "compile", lambda module, dynamic: runner)
+
+    encoder = torch.nn.Linear(4, 4)
+    model = SimpleNamespace(
+        whisper_encoder=encoder,
+        encoder_runner=encoder,
+        config=SimpleNamespace(
+            audio_config=SimpleNamespace(max_source_positions=2, num_mel_bins=4)
+        ),
+    )
+
+    Model.compile_encoder(model, buckets=(1, 2))
+
+    assert model.encoder_runner is runner
+    assert len(warmups) == 2
 
 
 def _repo_not_found(url: str) -> RepositoryNotFoundError:


### PR DESCRIPTION
Opt-in `torch.compile(dynamic=False)` for the MOSS-Transcribe-Diarize Whisper encoder (#924), gated on a new `encoder_torch_compile` stage arg. `compile_encoder()` compiles the encoder and warms a contiguous `n_chunks` range (`encoder_compile_buckets`, default `(1,2,3,4)`) because `dynamic=False` compiles per exact shape. Off by default.

## Results

Test env: A100-40GB · bf16 · torch 2.11.0+cu130 · movies800 (96 samples) · greedy · fresh server per run · `mem_fraction_static=0.5`. Mean of 3 runs; all 96/96 completed.

| concurrency | eager qps | compile qps | Δ | eager lat (s) | compile lat (s) | CER (e→c) |
|---|---|---|---|---|---|---|
| 1  | 2.33  | 2.36  | +1.5% (noise) | 0.428 | 0.422 | 5.11 → 5.13 |
| 4  | 6.48  | 6.62  | +2.3% | 0.604 | 0.590 | 5.12 → 5.17 |
| 8  | 10.08 | 10.49 | +4.1% | 0.757 | 0.725 | 5.12 → 5.21 |
| 16 | 13.99 | 14.51 | +3.7% | 1.049 | 1.007 | 5.10 → 5.12 |

- Fairness: identical input (1366.3 s audio), output length matched within 0.3% (eager 17153–17221 chars, compile 17163–17197) → not a shorter-output artifact.