### PR TITLE
[CI] Add long sequence support for MOSS-Transcribe-Diarize and evaluation script

### DIFF
--- a/.claude/skills/tune-ci-thresholds/AGENT-PRECHECK.md
+++ b/.claude/skills/tune-ci-thresholds/AGENT-PRECHECK.md
@@ -210,7 +210,7 @@ ls "$HF/hub" 2>/dev/null | rg -i 'qwen3|higgs|moss|movies800|seed-tts|video|mmmu
 Expected repos by model (precheck validates each):
 
 **`asr`:** models `OpenMOSS-Team/MOSS-Transcribe-Diarize`,
-`Qwen/Qwen3-ASR-1.7B`; datasets `zhaochenyang20/movies800`,
+`Qwen/Qwen3-ASR-1.7B`; datasets `zhaochenyang20/movies800time`,
 `zhaochenyang20/seed-tts-eval-arrow`.
 
 **`tts`:** models `bosonai/higgs-tts-3-4b`,

--- a/.claude/skills/tune-ci-thresholds/SKILL.md
+++ b/.claude/skills/tune-ci-thresholds/SKILL.md
@@ -666,7 +666,7 @@ Common ASR preset:
 python .claude/skills/tune-ci-thresholds/tune.py --model asr run \
   --stages ALL --repeats 5 --output-dir .tune-runs/<timestamp>_asr_all_r5
 
-# ASR stage 1 only (MOSS-Transcribe-Diarize on movies800):
+# ASR stage 1 only (MOSS-Transcribe-Diarize on movies800time):
 python .claude/skills/tune-ci-thresholds/tune.py --model asr run \
   --stages multi_speaker --repeats 5 --output-dir .tune-runs/<timestamp>_asr_multi_speaker_r5
 
@@ -695,16 +695,21 @@ uses `--stages ALL`; targeted reruns use `multi_speaker` or `seedtts`.
 
 | Stage key | Group | What gets written | Test constant(s) |
 |-----------|-------|-------------------|------------------|
-| `multi_speaker_diarization` | diarization | CER / cpCER / valid sample refs | `MOSS_TD_CER_*`, `MOSS_TD_CP_CER_*`, `MOSS_TD_DELTA_CER_*` |
+| `multi_speaker_diarization` | diarization | CER / cpCER / DER / valid sample refs | `MOSS_TD_CER_*`, `MOSS_TD_CP_CER_*`, `MOSS_TD_DELTA_CER_*`, `MOSS_TD_SPEAKER_TIMESTAMP_DER_PERCENT_REF` |
 | `multi_speaker_speed` | speed | throughput + latency + RTF P95 refs | `MOSS_TD_THROUGHPUT_QPS_MIN`, `MOSS_TD_LATENCY_*`, `MOSS_TD_RTF_*` |
 | `seedtts_wer` | wer | corpus + per-sample WER ref | `SEEDTTS_ASR_CORPUS_WER_MAX`, `SEEDTTS_ASR_SAMPLE_WER_MAX` |
 | `seedtts_speed` | speed | throughput + latency + RTF P95 refs | `QWEN3_ASR_THROUGHPUT_MIN`, `QWEN3_ASR_LATENCY_*`, `QWEN3_ASR_RTF_*` |
 
 Notes:
 - Stage 1 uses **`OpenMOSS-Team/MOSS-Transcribe-Diarize`** and dataset
-  **`zhaochenyang20/movies800`**. Strict audit expects
-  **`MOSS_TD_CI_SAMPLES`** samples; CER/cpCER metrics are already percentages
+  **`zhaochenyang20/movies800time`**. Strict audit expects
+  **`MOSS_TD_CI_SAMPLES`** samples; CER/cpCER/DER metrics are already percentages
   in the JSON, so display scale is **1**, not 100.
+- **DER (speaker-timestamp diarization error rate)** calibrates the reference
+  constant `MOSS_TD_SPEAKER_TIMESTAMP_DER_PERCENT_REF` (worst-of-N `max`); the
+  test derives `MOSS_TD_SPEAKER_TIMESTAMP_DER_PERCENT_MAX` via the slack helper.
+  Both start at `None`, so the DER gate is skipped (prints `[threshold pending]`)
+  until the first DER calibration fills in the reference.
 - Stage 2 uses **`Qwen/Qwen3-ASR-1.7B`** and dataset
   **`zhaochenyang20/seed-tts-eval-arrow`**. Strict audit expects
   **`SEEDTTS_ASR_CORRECTNESS_SAMPLES`** samples.

--- a/.claude/skills/tune-ci-thresholds/models/asr/config.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/asr/config.yaml
@@ -1,7 +1,7 @@
 # ASR CI threshold calibration (shared omni venv).
 #
 # CI DAG:
-#   stage-1-multi-speaker (MOSS-Transcribe-Diarize on movies800)
+#   stage-1-multi-speaker (MOSS-Transcribe-Diarize on movies800time)
 #   -> stage-2-seedtts (Qwen3-ASR on SeedTTS EN)
 #
 # Both stages use the managed router with 2 single-GPU workers (DP=2).
@@ -16,7 +16,7 @@ hf_model_ids_by_test:
   test_asr_ci_seedtts.py:
     - "Qwen/Qwen3-ASR-1.7B"
 hf_datasets:
-  - "zhaochenyang20/movies800"
+  - "zhaochenyang20/movies800time"
   - "zhaochenyang20/seed-tts-eval-arrow"
 omni_ci_home: "/github/home/calibration"
 default_venv_python:
@@ -59,6 +59,7 @@ metric_sources:
       cp_cer_percent: "diarization_metrics_percent.cp_cer"
       cer_no_spk_cp_valid_percent: "diarization_metrics_percent.cer_no_spk_cp_valid"
       delta_cer_percent: "diarization_metrics_percent.delta_cer"
+      speaker_timestamp_der_percent: "diarization_metrics_percent.speaker_timestamp_der"
       cer_valid_samples: "diarization_metrics_percent.cer_valid_samples"
       cp_cer_valid_samples: "diarization_metrics_percent.cp_cer_valid_samples"
       throughput_qps: "speed.throughput_qps"

--- a/.claude/skills/tune-ci-thresholds/models/asr/stages.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/asr/stages.yaml
@@ -6,8 +6,8 @@ multi_speaker_diarization:
   extra_env: {}
   context_vars:
     - MOSS_TD_CI_SAMPLES
-  test_file_sha256: 9c6033f50ddebe530ef44dbdf1e1ee81f55cfb1fdc49ce92acf89cfacab2c715
-  last_discovered_at: 2026-07-04T22:43:04Z
+  test_file_sha256: 83b8935eac43c2d0e610e94335fc901ecdc795275c93359fba1f3531f8d6f297
+  last_discovered_at: 2026-07-06T16:47:21Z
   expected_samples: 800
   sample_counts:
     total:
@@ -17,6 +17,16 @@ multi_speaker_diarization:
       json_file: "test_moss_transcribe_diarize_m0/moss_transcribe_diarize_results.json"
       json_path: "summary.evaluated"
   metrics:
+    speaker_timestamp_der_percent:
+      source: "MOSS_TD_SPEAKER_TIMESTAMP_DER_PERCENT_REF"
+      json_file: "test_moss_transcribe_diarize_m0/moss_transcribe_diarize_results.json"
+      json_path: "diarization_metrics_percent.speaker_timestamp_der"
+      worst: max
+      display:
+        label: "Speaker-timestamp DER (%)"
+        scale: 1
+        digits: 2
+      status: OK
     cer_valid_samples:
       source: "MOSS_TD_CER_VALID_SAMPLES_MIN"
       json_file: "test_moss_transcribe_diarize_m0/moss_transcribe_diarize_results.json"
@@ -94,8 +104,8 @@ multi_speaker_speed:
   extra_env: {}
   context_vars:
     - MOSS_TD_CI_SAMPLES
-  test_file_sha256: 9c6033f50ddebe530ef44dbdf1e1ee81f55cfb1fdc49ce92acf89cfacab2c715
-  last_discovered_at: 2026-07-04T22:43:04Z
+  test_file_sha256: 83b8935eac43c2d0e610e94335fc901ecdc795275c93359fba1f3531f8d6f297
+  last_discovered_at: 2026-07-06T16:47:21Z
   expected_samples: 800
   sample_counts:
     total:
@@ -162,8 +172,8 @@ seedtts_wer:
   extra_env: {}
   context_vars:
     - SEEDTTS_ASR_CORRECTNESS_SAMPLES
-  test_file_sha256: 9d7a0850681964214b398493b2c4bbafcdad2750ec98f31817426bb216857823
-  last_discovered_at: 2026-07-04T22:43:04Z
+  test_file_sha256: d13f9d994a9e349ad2d3e11004d4b4ea37eaeaa2a723213077c7034e749e5237
+  last_discovered_at: 2026-07-06T16:47:21Z
   expected_samples: 1088
   sample_counts:
     total:
@@ -200,8 +210,8 @@ seedtts_speed:
   extra_env: {}
   context_vars:
     - SEEDTTS_ASR_CORRECTNESS_SAMPLES
-  test_file_sha256: 9d7a0850681964214b398493b2c4bbafcdad2750ec98f31817426bb216857823
-  last_discovered_at: 2026-07-04T22:43:04Z
+  test_file_sha256: d13f9d994a9e349ad2d3e11004d4b4ea37eaeaa2a723213077c7034e749e5237
+  last_discovered_at: 2026-07-06T16:47:21Z
   expected_samples: 1088
   sample_counts:
     total:

--- a/.claude/skills/tune-ci-thresholds/tune.py
+++ b/.claude/skills/tune-ci-thresholds/tune.py
@@ -95,6 +95,7 @@ METRIC_SPECS = {
     "cp_cer_percent":       dict(worst="max", label="cpCER (%)",             digits=2, scale=1,   group="diarization"),
     "cer_no_spk_cp_valid_percent": dict(worst="max", label="CER no-spk cp-valid (%)", digits=2, scale=1, group="diarization"),
     "delta_cer_percent":    dict(worst="max", label="Delta CER (%)",         digits=2, scale=1,   group="diarization"),
+    "speaker_timestamp_der_percent": dict(worst="max", label="Speaker-timestamp DER (%)", digits=2, scale=1, group="diarization"),
     "cer_valid_samples":    dict(worst="min", label="CER valid samples",     digits=0, scale=1,   group="diarization"),
     "cp_cer_valid_samples": dict(worst="min", label="cpCER valid samples",   digits=0, scale=1,   group="diarization"),
     "throughput_qps":       dict(worst="min", label="Throughput (req/s)",    digits=3, scale=1,   group="speed"),
@@ -177,6 +178,10 @@ def match_metric(name, nested):
         return "cp_cer_percent"
     if "DELTA_CER_PERCENT_MAX" in name:
         return "delta_cer_percent"
+    # DER calibrates the reference constant (test derives the MAX via slack),
+    # so match the *_REF symbol; the computed *_MAX literal is left unmatched.
+    if "SPEAKER_TIMESTAMP_DER_PERCENT_REF" in name:
+        return "speaker_timestamp_der_percent"
     if "CP_CER_VALID_SAMPLES_MIN" in name:
         return "cp_cer_valid_samples"
     if "CER_VALID_SAMPLES_MIN" in name:

--- a/benchmarks/eval/eval_transcribe_diarize.py
+++ b/benchmarks/eval/eval_transcribe_diarize.py
@@ -458,7 +458,9 @@ def _format_float(section: str, key: str, value: float) -> float:
     if section == "summary":
         return round(value, 4)
     if section == "diarization_metrics_percent":
-        if key.endswith(("_seconds", "_false_alarm", "_missed_detection", "_confusion", "_collar")):
+        if key.endswith(
+            ("_seconds", "_false_alarm", "_missed_detection", "_confusion", "_collar")
+        ):
             return round(value, 4)
         return round(value, 2)
     if "rtf" in key:

--- a/benchmarks/eval/eval_transcribe_diarize.py
+++ b/benchmarks/eval/eval_transcribe_diarize.py
@@ -287,6 +287,7 @@ def main() -> int:
     print(f"  {'Concurrency:':<{SPEED_LABEL_WIDTH}} {args.concurrency}")
     print(f"  {'Output:':<{SPEED_LABEL_WIDTH}} {output_path}")
     print(f"{'=' * SPEED_LINE_WIDTH}")
+    print(_build_key_metrics_section(payload["diarization_metrics_percent"]))
     print(_build_metrics_section("summary", payload["summary"], SUMMARY_ORDER))
     print(_build_metrics_section("speed", payload["speed"], SPEED_ORDER))
     print(
@@ -436,6 +437,17 @@ def _build_metrics_section(
     return "\n".join(lines)
 
 
+def _build_key_metrics_section(metrics: Mapping[str, object]) -> str:
+    lines = ["\nkey_metrics", "-" * SPEED_LINE_WIDTH]
+    for key in KEY_METRICS_ORDER:
+        if key not in metrics:
+            continue
+        lines.append(
+            f"  {key + ':':<{SPEED_LABEL_WIDTH}} {_display_value('diarization_metrics_percent', key, metrics[key])}"
+        )
+    return "\n".join(lines)
+
+
 def _display_value(section: str, key: str, value: object) -> object:
     if isinstance(value, float):
         return _format_float(section, key, value)
@@ -446,6 +458,8 @@ def _format_float(section: str, key: str, value: float) -> float:
     if section == "summary":
         return round(value, 4)
     if section == "diarization_metrics_percent":
+        if key.endswith(("_seconds", "_false_alarm", "_missed_detection", "_confusion", "_collar")):
+            return round(value, 4)
         return round(value, 2)
     if "rtf" in key:
         return round(value, 4)

--- a/benchmarks/eval/eval_transcribe_diarize.py
+++ b/benchmarks/eval/eval_transcribe_diarize.py
@@ -99,9 +99,27 @@ DIARIZATION_METRICS_PERCENT_ORDER: Final[tuple[str, ...]] = (
     "cp_cer",
     "cer_no_spk_cp_valid",
     "delta_cer",
+    "speaker_timestamp_der",
+    "speaker_timestamp_der_collar",
+    "speaker_timestamp_der_valid_samples",
+    "speaker_timestamp_der_skipped",
+    "speaker_timestamp_der_skipped_parse_error",
+    "speaker_timestamp_der_skipped_no_ref_segments",
+    "speaker_timestamp_der_skipped_no_pred_segments",
+    "speaker_timestamp_der_compute_error",
+    "speaker_timestamp_der_total_seconds",
+    "speaker_timestamp_der_false_alarm",
+    "speaker_timestamp_der_missed_detection",
+    "speaker_timestamp_der_confusion",
     "cer_valid_samples",
     "cp_cer_valid_samples",
     "count",
+)
+KEY_METRICS_ORDER: Final[tuple[str, ...]] = (
+    "cer_no_spk",
+    "cp_cer",
+    "delta_cer",
+    "speaker_timestamp_der",
 )
 
 

--- a/benchmarks/eval/eval_transcribe_diarize.py
+++ b/benchmarks/eval/eval_transcribe_diarize.py
@@ -123,7 +123,12 @@ KEY_METRICS_ORDER: Final[tuple[str, ...]] = (
 )
 
 
-def make_send_fn(api_url: str, model_path: str, language: str | None) -> SendFn:
+def make_send_fn(
+    api_url: str,
+    model_path: str,
+    language: str | None,
+    max_new_tokens: int | None,
+) -> SendFn:
     async def send_fn(
         session: aiohttp.ClientSession,
         sample: Movies800Sample,
@@ -140,7 +145,13 @@ def make_send_fn(api_url: str, model_path: str, language: str | None) -> SendFn:
         try:
             async with session.post(
                 api_url,
-                data=_request_form(audio_bytes, audio_path, model_path, language),
+                data=_request_form(
+                    audio_bytes,
+                    audio_path,
+                    model_path,
+                    language,
+                    max_new_tokens,
+                ),
             ) as response:
                 if response.status != 200:
                     result.error = f"HTTP {response.status}: {await response.text()}"
@@ -174,6 +185,7 @@ async def run_eval(
     request_rate: float,
     disable_tqdm: bool,
     request_timeout_s: int,
+    max_new_tokens: int | None,
 ) -> tuple[list[RequestResult], float]:
     runner = BenchmarkRunner(
         RunConfig(
@@ -190,6 +202,7 @@ async def run_eval(
             api_url=f"{base_url}/v1/audio/transcriptions",
             model_path=model_path,
             language=language,
+            max_new_tokens=max_new_tokens,
         ),
     )
     return outputs, runner.wall_clock_s
@@ -223,7 +236,13 @@ def parse_args() -> argparse.Namespace:
         default=float("inf"),
         help="Requests per second (inf = send all at once).",
     )
-    parser.add_argument("--request-timeout-s", type=int, default=300)
+    parser.add_argument("--request-timeout-s", type=int, default=1800)
+    parser.add_argument(
+        "--max-new-tokens",
+        type=_positive_int,
+        default=None,
+        help="Optional max_new_tokens forwarded to /v1/audio/transcriptions.",
+    )
     parser.add_argument("--server-timeout-s", type=int, default=600)
     parser.add_argument("--max-samples", type=int, default=0)
     parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR)
@@ -324,6 +343,7 @@ def _run_with_or_without_server(
                 request_rate=args.request_rate,
                 disable_tqdm=args.disable_tqdm,
                 request_timeout_s=args.request_timeout_s,
+                max_new_tokens=args.max_new_tokens,
             )
         )
         payload = _build_payload(args, samples, outputs, wall_clock_s)
@@ -356,6 +376,7 @@ def _run_with_or_without_server(
                 request_rate=args.request_rate,
                 disable_tqdm=args.disable_tqdm,
                 request_timeout_s=args.request_timeout_s,
+                max_new_tokens=args.max_new_tokens,
             )
         )
         payload = _build_payload(args, samples, outputs, wall_clock_s)
@@ -381,6 +402,16 @@ def _server_cuda_graph_max_bs(args: argparse.Namespace) -> int:
     if args.cuda_graph_max_bs is not None:
         return args.cuda_graph_max_bs
     return _server_max_running_requests(args)
+
+
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("value must be a positive integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be a positive integer")
+    return parsed
 
 
 def _mem_fraction_static(value: str) -> float:
@@ -480,12 +511,15 @@ def _request_form(
     audio_path: Path,
     model_path: str,
     language: str | None,
+    max_new_tokens: int | None,
 ) -> aiohttp.FormData:
     form = aiohttp.FormData()
     form.add_field("model", model_path)
     form.add_field("response_format", "verbose_json")
     if language:
         form.add_field("language", language)
+    if max_new_tokens is not None:
+        form.add_field("max_new_tokens", str(max_new_tokens))
     form.add_field(
         "file",
         audio_bytes,

--- a/benchmarks/eval/eval_transcribe_diarize_long.py
+++ b/benchmarks/eval/eval_transcribe_diarize_long.py
@@ -1,0 +1,534 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MOSS-Transcribe-Diarize long-audio eval on AISHELL4.
+
+Usage:
+
+    python -m benchmarks.eval.eval_transcribe_diarize_long \
+        --max-concurrency 16 \
+        --output-dir results/moss_transcribe_diarize_aishell4_long
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import mimetypes
+import sys
+import time
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Final
+
+import aiohttp
+import soundfile
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from benchmarks.benchmarker.data import RequestResult
+from benchmarks.benchmarker.runner import BenchmarkRunner, RunConfig, SendFn
+from benchmarks.benchmarker.utils import (
+    managed_omni_server,
+    save_json_results,
+    wait_for_service,
+)
+from benchmarks.metrics._format import SPEED_LABEL_WIDTH, SPEED_LINE_WIDTH
+from benchmarks.tasks.transcribe_diarize import (
+    EvaluationPayload,
+    Movies800Sample,
+    build_evaluation_payload,
+    extract_prediction_text,
+    load_movies800_samples,
+)
+
+AISHELL4_REPO_ID: Final[str] = "zhaochenyang20/AISHELL4"
+MODEL_PATH: Final[str] = "OpenMOSS-Team/MOSS-Transcribe-Diarize"
+RESULTS_FILE: Final[str] = "transcribe_diarize_results.json"
+DEFAULT_OUTPUT_DIR: Final[str] = "results/moss_transcribe_diarize_aishell4_long"
+DEFAULT_SERVER_MEM_FRACTION_STATIC: Final[float] = 0.80
+SUMMARY_ORDER: Final[tuple[str, ...]] = (
+    "total_samples",
+    "evaluated",
+    "skipped",
+    "exact_matches",
+    "mismatches",
+    "exact_match_rate",
+)
+SPEED_ORDER: Final[tuple[str, ...]] = (
+    "total_requests",
+    "completed_requests",
+    "failed_requests",
+    "latency_mean_s",
+    "latency_median_s",
+    "latency_p95_s",
+    "latency_p99_s",
+    "audio_duration_mean_s",
+    "rtf_mean",
+    "rtf_median",
+    "rtf_p95",
+    "rtf_p99",
+    "throughput_qps",
+    "audio_throughput_s_per_s",
+    "output_throughput",
+    "output_tok_per_req_s",
+    "output_tokens_mean",
+    "output_tokens_total",
+    "prompt_tokens_mean",
+    "prompt_tokens_total",
+    "audio_ttfp_mean_s",
+    "audio_ttfp_median_s",
+    "audio_ttfp_p95_s",
+    "audio_ttfp_p99_s",
+    "text_ttft_mean_s",
+    "text_ttft_median_s",
+    "text_ttft_p95_s",
+    "text_ttft_p99_s",
+    "inter_chunk_mean_s",
+    "inter_chunk_p95_s",
+    "inter_chunk_p99_s",
+    "audio_chunks_mean",
+    "audio_chunks_p95",
+    "first_audio_payload_bytes_mean",
+    "first_audio_payload_bytes_p95",
+)
+DIARIZATION_METRICS_PERCENT_ORDER: Final[tuple[str, ...]] = (
+    "cer",
+    "cer_no_spk",
+    "cp_cer",
+    "cer_no_spk_cp_valid",
+    "delta_cer",
+    "speaker_timestamp_der",
+    "speaker_timestamp_der_collar",
+    "speaker_timestamp_der_valid_samples",
+    "speaker_timestamp_der_skipped",
+    "speaker_timestamp_der_skipped_parse_error",
+    "speaker_timestamp_der_skipped_no_ref_segments",
+    "speaker_timestamp_der_skipped_no_pred_segments",
+    "speaker_timestamp_der_compute_error",
+    "speaker_timestamp_der_total_seconds",
+    "speaker_timestamp_der_false_alarm",
+    "speaker_timestamp_der_missed_detection",
+    "speaker_timestamp_der_confusion",
+    "cer_valid_samples",
+    "cp_cer_valid_samples",
+    "count",
+)
+KEY_METRICS_ORDER: Final[tuple[str, ...]] = (
+    "cer_no_spk",
+    "cp_cer",
+    "delta_cer",
+    "speaker_timestamp_der",
+)
+
+
+def make_send_fn(
+    api_url: str,
+    model_path: str,
+    language: str | None,
+    max_new_tokens: int | None,
+) -> SendFn:
+    async def send_fn(
+        session: aiohttp.ClientSession,
+        sample: Movies800Sample,
+    ) -> RequestResult:
+        result = RequestResult(request_id=sample.sample_id)
+        audio_path = Path(sample.audio_path)
+        try:
+            audio_bytes = audio_path.read_bytes()
+        except OSError as exc:
+            result.error = str(exc)
+            return result
+        result.audio_duration_s = _audio_duration_s(audio_path)
+        start = time.perf_counter()
+        try:
+            async with session.post(
+                api_url,
+                data=_request_form(
+                    audio_bytes,
+                    audio_path,
+                    model_path,
+                    language,
+                    max_new_tokens,
+                ),
+            ) as response:
+                if response.status != 200:
+                    result.error = f"HTTP {response.status}: {await response.text()}"
+                else:
+                    result.text = extract_prediction_text(await response.json())
+                    result.is_success = True
+        except (
+            aiohttp.ClientError,
+            asyncio.TimeoutError,
+            json.JSONDecodeError,
+            ValueError,
+        ) as exc:
+            result.error = str(exc)
+        finally:
+            result.latency_s = time.perf_counter() - start
+        if result.is_success and result.audio_duration_s > 0:
+            result.rtf = result.latency_s / result.audio_duration_s
+        return result
+
+    return send_fn
+
+
+async def run_eval(
+    samples: list[Movies800Sample],
+    *,
+    base_url: str,
+    model_path: str,
+    language: str | None,
+    concurrency: int,
+    warmup: int,
+    request_rate: float,
+    disable_tqdm: bool,
+    request_timeout_s: int,
+    max_new_tokens: int | None,
+) -> tuple[list[RequestResult], float]:
+    runner = BenchmarkRunner(
+        RunConfig(
+            max_concurrency=concurrency,
+            request_rate=request_rate,
+            warmup=warmup,
+            disable_tqdm=disable_tqdm,
+            timeout_s=request_timeout_s,
+        )
+    )
+    outputs = await runner.run(
+        samples,
+        make_send_fn(
+            api_url=f"{base_url}/v1/audio/transcriptions",
+            model_path=model_path,
+            language=language,
+            max_new_tokens=max_new_tokens,
+        ),
+    )
+    return outputs, runner.wall_clock_s
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run MOSS-Transcribe-Diarize on AISHELL4 and compare outputs."
+    )
+    parser.add_argument("--repo-id", default=AISHELL4_REPO_ID)
+    parser.add_argument("--split", default="validation")
+    parser.add_argument("--audio-column", default="audio")
+    parser.add_argument("--expected-column", default="transcription")
+    parser.add_argument("--model-path", default=MODEL_PATH)
+    parser.add_argument("--base-url", default=None)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--language")
+    parser.add_argument(
+        "--concurrency",
+        "--max-concurrency",
+        dest="concurrency",
+        type=int,
+        default=16,
+        help="Maximum concurrent requests.",
+    )
+    parser.add_argument("--warmup", type=int, default=0)
+    parser.add_argument(
+        "--request-rate",
+        type=float,
+        default=float("inf"),
+        help="Requests per second (inf = send all at once).",
+    )
+    parser.add_argument("--request-timeout-s", type=int, default=1800)
+    parser.add_argument(
+        "--max-new-tokens",
+        type=_positive_int,
+        default=None,
+        help="Optional max_new_tokens forwarded to /v1/audio/transcriptions.",
+    )
+    parser.add_argument("--server-timeout-s", type=int, default=600)
+    parser.add_argument("--max-samples", type=int, default=0)
+    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--use-existing-server", action="store_true")
+    parser.add_argument("--disable-tqdm", action="store_true")
+    parser.add_argument(
+        "--max-running-requests",
+        type=int,
+        default=None,
+        help=(
+            "SGLang generation stage max_running_requests for the managed "
+            "server. Defaults to --concurrency."
+        ),
+    )
+    parser.add_argument(
+        "--cuda-graph-max-bs",
+        type=int,
+        default=None,
+        help=(
+            "SGLang generation stage cuda_graph_max_bs for the managed server. "
+            "Defaults to --max-running-requests."
+        ),
+    )
+    parser.add_argument(
+        "--mem-fraction-static",
+        type=_mem_fraction_static,
+        default=DEFAULT_SERVER_MEM_FRACTION_STATIC,
+        help=(
+            "SGLang static KV-cache memory fraction for the managed server. "
+            "MOSS-Transcribe-Diarize keeps headroom for the audio encoder by "
+            f"default ({DEFAULT_SERVER_MEM_FRACTION_STATIC})."
+        ),
+    )
+    parser.add_argument(
+        "--skip-gpu-cleanup",
+        action="store_true",
+        help="Do not run the shared GPU cleanup step after a managed server exits.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    try:
+        args = parse_args()
+        max_samples = args.max_samples if args.max_samples > 0 else sys.maxsize
+        samples = load_movies800_samples(
+            repo_id=args.repo_id,
+            split=args.split,
+            audio_column=args.audio_column,
+            expected_column=args.expected_column,
+            max_samples=max_samples,
+        )
+        payload, output_path = _run_with_or_without_server(args, samples)
+    except (FileNotFoundError, OSError, RuntimeError, TimeoutError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(f"\n{'=' * SPEED_LINE_WIDTH}")
+    print(f"{'ASR Eval Result':^{SPEED_LINE_WIDTH}}")
+    print(f"{'=' * SPEED_LINE_WIDTH}")
+    print(f"  {'Model:':<{SPEED_LABEL_WIDTH}} {args.model_path}")
+    print(f"  {'Concurrency:':<{SPEED_LABEL_WIDTH}} {args.concurrency}")
+    print(f"  {'Output:':<{SPEED_LABEL_WIDTH}} {output_path}")
+    print(f"{'=' * SPEED_LINE_WIDTH}")
+    print(_build_key_metrics_section(payload["diarization_metrics_percent"]))
+    print(_build_metrics_section("summary", payload["summary"], SUMMARY_ORDER))
+    print(_build_metrics_section("speed", payload["speed"], SPEED_ORDER))
+    print(
+        _build_metrics_section(
+            "diarization_metrics_percent",
+            payload["diarization_metrics_percent"],
+            DIARIZATION_METRICS_PERCENT_ORDER,
+        )
+    )
+    failed_requests = int(payload["speed"].get("failed_requests", 0) or 0)
+    if failed_requests:
+        print(
+            f"Evaluation failed: {failed_requests} request(s) failed.", file=sys.stderr
+        )
+        return 1
+    return 0
+
+
+def _run_with_or_without_server(
+    args: argparse.Namespace,
+    samples: list[Movies800Sample],
+) -> tuple[EvaluationPayload, str]:
+    base_url = _base_url(args)
+    if args.use_existing_server:
+        wait_for_service(base_url, timeout=args.server_timeout_s)
+        outputs, wall_clock_s = asyncio.run(
+            run_eval(
+                samples,
+                base_url=base_url,
+                model_path=args.model_path,
+                language=args.language,
+                concurrency=args.concurrency,
+                warmup=args.warmup,
+                request_rate=args.request_rate,
+                disable_tqdm=args.disable_tqdm,
+                request_timeout_s=args.request_timeout_s,
+                max_new_tokens=args.max_new_tokens,
+            )
+        )
+        payload = _build_payload(args, samples, outputs, wall_clock_s)
+        output_path = save_json_results(
+            json.loads(json.dumps(payload)),
+            args.output_dir,
+            RESULTS_FILE,
+        )
+        return payload, output_path
+    log_file = Path(args.output_dir) / "server_logs" / "asr_server.log"
+    with managed_omni_server(
+        model_path=args.model_path,
+        port=args.port,
+        host=args.host,
+        log_file=log_file,
+        max_running_requests=_server_max_running_requests(args),
+        cuda_graph_max_bs=_server_cuda_graph_max_bs(args),
+        mem_fraction_static=args.mem_fraction_static,
+        timeout=args.server_timeout_s,
+        wait_for_gpu_release=not args.skip_gpu_cleanup,
+    ):
+        outputs, wall_clock_s = asyncio.run(
+            run_eval(
+                samples,
+                base_url=base_url,
+                model_path=args.model_path,
+                language=args.language,
+                concurrency=args.concurrency,
+                warmup=args.warmup,
+                request_rate=args.request_rate,
+                disable_tqdm=args.disable_tqdm,
+                request_timeout_s=args.request_timeout_s,
+                max_new_tokens=args.max_new_tokens,
+            )
+        )
+        payload = _build_payload(args, samples, outputs, wall_clock_s)
+        output_path = save_json_results(
+            json.loads(json.dumps(payload)),
+            args.output_dir,
+            RESULTS_FILE,
+        )
+        return payload, output_path
+
+
+def _base_url(args: argparse.Namespace) -> str:
+    return (args.base_url or f"http://{args.host}:{args.port}").rstrip("/")
+
+
+def _server_max_running_requests(args: argparse.Namespace) -> int:
+    if args.max_running_requests is not None:
+        return args.max_running_requests
+    return args.concurrency
+
+
+def _server_cuda_graph_max_bs(args: argparse.Namespace) -> int:
+    if args.cuda_graph_max_bs is not None:
+        return args.cuda_graph_max_bs
+    return _server_max_running_requests(args)
+
+
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("value must be a positive integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be a positive integer")
+    return parsed
+
+
+def _mem_fraction_static(value: str) -> float:
+    try:
+        fraction = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "mem_fraction_static must be a float in (0, 1)"
+        ) from exc
+    if not 0.0 < fraction < 1.0:
+        raise argparse.ArgumentTypeError(
+            "mem_fraction_static must be a float in (0, 1)"
+        )
+    return fraction
+
+
+def _build_payload(
+    args: argparse.Namespace,
+    samples: list[Movies800Sample],
+    outputs: list[RequestResult],
+    wall_clock_s: float,
+) -> EvaluationPayload:
+    return build_evaluation_payload(
+        samples=samples,
+        outputs=outputs,
+        wall_clock_s=wall_clock_s,
+        model_path=args.model_path,
+        concurrency=args.concurrency,
+        repo_id=args.repo_id,
+        split=args.split,
+    )
+
+
+def _build_metrics_section(
+    title: str,
+    metrics: Mapping[str, object],
+    key_order: tuple[str, ...],
+) -> str:
+    lines = [f"\n{title}", "-" * SPEED_LINE_WIDTH]
+    seen_keys: set[str] = set()
+    for key in key_order:
+        if key not in metrics:
+            continue
+        seen_keys.add(key)
+        lines.append(
+            f"  {key + ':':<{SPEED_LABEL_WIDTH}} {_display_value(title, key, metrics[key])}"
+        )
+    for key in sorted(metrics):
+        if key in seen_keys:
+            continue
+        lines.append(
+            f"  {key + ':':<{SPEED_LABEL_WIDTH}} {_display_value(title, key, metrics[key])}"
+        )
+    return "\n".join(lines)
+
+
+def _build_key_metrics_section(metrics: Mapping[str, object]) -> str:
+    lines = ["\nkey_metrics", "-" * SPEED_LINE_WIDTH]
+    for key in KEY_METRICS_ORDER:
+        if key not in metrics:
+            continue
+        lines.append(
+            f"  {key + ':':<{SPEED_LABEL_WIDTH}} {_display_value('diarization_metrics_percent', key, metrics[key])}"
+        )
+    return "\n".join(lines)
+
+
+def _display_value(section: str, key: str, value: object) -> object:
+    if isinstance(value, float):
+        return _format_float(section, key, value)
+    return value
+
+
+def _format_float(section: str, key: str, value: float) -> float:
+    if section == "summary":
+        return round(value, 4)
+    if section == "diarization_metrics_percent":
+        if key.endswith(
+            ("_seconds", "_false_alarm", "_missed_detection", "_confusion", "_collar")
+        ):
+            return round(value, 4)
+        return round(value, 2)
+    if "rtf" in key:
+        return round(value, 4)
+    return round(value, 3)
+
+
+def _audio_duration_s(audio_path: Path) -> float:
+    try:
+        return float(soundfile.info(str(audio_path)).duration)
+    except RuntimeError:
+        return 0.0
+
+
+def _request_form(
+    audio_bytes: bytes,
+    audio_path: Path,
+    model_path: str,
+    language: str | None,
+    max_new_tokens: int | None,
+) -> aiohttp.FormData:
+    form = aiohttp.FormData()
+    form.add_field("model", model_path)
+    form.add_field("response_format", "verbose_json")
+    if language:
+        form.add_field("language", language)
+    if max_new_tokens is not None:
+        form.add_field("max_new_tokens", str(max_new_tokens))
+    form.add_field(
+        "file",
+        audio_bytes,
+        filename=audio_path.name,
+        content_type=mimetypes.guess_type(audio_path.name)[0]
+        or "application/octet-stream",
+    )
+    return form
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/eval/eval_transcribe_diarize_long.py
+++ b/benchmarks/eval/eval_transcribe_diarize_long.py
@@ -240,11 +240,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--max-new-tokens",
         type=_positive_int,
-        default=None,
+        default=65536,
         help="Optional max_new_tokens forwarded to /v1/audio/transcriptions.",
     )
     parser.add_argument("--server-timeout-s", type=int, default=600)
-    parser.add_argument("--max-samples", type=int, default=0)
+    parser.add_argument("--max-samples", type=int, default=20)
     parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR)
     parser.add_argument("--use-existing-server", action="store_true")
     parser.add_argument("--disable-tqdm", action="store_true")

--- a/benchmarks/metrics/transcribe_diarize_metrics.py
+++ b/benchmarks/metrics/transcribe_diarize_metrics.py
@@ -6,6 +6,7 @@ import re
 import unicodedata
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from typing import TypedDict
 
 import numpy as np
 from scipy.optimize import linear_sum_assignment
@@ -13,6 +14,8 @@ from scipy.optimize import linear_sum_assignment
 from benchmarks.metrics._format import SPEED_LABEL_WIDTH, SPEED_LINE_WIDTH
 
 TIMESTAMP_RE = re.compile(r"\[\d+(?:\.\d+)?\]")
+TIMESTAMP_TOKEN_RE = re.compile(r"^\d+(?:\.\d+)?$")
+SPEAKER_TOKEN_RE = re.compile(r"^S0*(\d+)$", re.IGNORECASE)
 SPEAKER_TAG_RE = re.compile(r"\[S0*(\d+)\]", re.IGNORECASE)
 SPEAKER_TAG_CANON_RE = re.compile(r"\[S\d+\]", re.IGNORECASE)
 BRACKET_EVENT_RE = re.compile(r"\[(?!S\d+\])[^]]+\]", re.IGNORECASE)
@@ -34,6 +37,15 @@ class DiarizationSampleMetric:
     cer_no_spk: float | None
     cp_cer: float | None
     cp_invalid_reason: str
+    speaker_timestamp_der_valid: bool
+    speaker_timestamp_der_invalid_reason: str
+    speaker_timestamp_ref_segments: int
+    speaker_timestamp_pred_segments: int
+    speaker_timestamp_der: float | None
+    speaker_timestamp_der_total_seconds: float
+    speaker_timestamp_der_false_alarm: float
+    speaker_timestamp_der_missed_detection: float
+    speaker_timestamp_der_confusion: float
 
 
 @dataclass(frozen=True, slots=True)
@@ -55,6 +67,56 @@ class DiarizationMetricsResult:
     metrics: dict[str, float | int | None]
     metrics_percent: dict[str, float | int | None]
     samples: list[DiarizationSampleMetric]
+
+
+@dataclass(frozen=True, slots=True)
+class _TimestampDerSample:
+    valid: bool
+    invalid_reason: str
+    ref_segments: int
+    pred_segments: int
+    der: float | None
+    total_seconds: float
+    false_alarm: float
+    missed_detection: float
+    confusion: float
+
+
+@dataclass(frozen=True, slots=True)
+class _TimestampDerAggregate:
+    overall_der: float | None
+    valid_samples: int
+    skipped: int
+    skipped_parse_error: int
+    skipped_no_ref_segments: int
+    skipped_no_pred_segments: int
+    compute_error: str
+    total_seconds: float
+    false_alarm: float
+    missed_detection: float
+    confusion: float
+    per_sample: list[_TimestampDerSample]
+
+
+class _TimestampDerDetail(TypedDict):
+    der: float | None
+    total: float
+    false_alarm: float
+    missed_detection: float
+    confusion: float
+
+
+class _TimestampDerSampleDetail(_TimestampDerDetail):
+    sample_index: int
+
+
+class _TimestampDerAggregateDetail(TypedDict):
+    overall_der: float | None
+    sample_details: list[_TimestampDerSampleDetail]
+    total: float
+    false_alarm: float
+    missed_detection: float
+    confusion: float
 
 
 def print_diarization_accuracy_summary(
@@ -79,19 +141,19 @@ def print_diarization_accuracy_summary(
     print(f"{'-' * line_width}")
     print(
         f"  {'Exact match rate:':<{label_width}} "
-        f"{summary['exact_match_rate']:.4f} ({summary['exact_match_rate'] * 100:.2f}%)"
+        f"{_as_float(summary, 'exact_match_rate'):.4f} ({_as_float(summary, 'exact_match_rate') * 100:.2f}%)"
     )
-    print(f"  {'CER:':<{label_width}} {_format_ratio(diarization_metrics.get('cer'))}")
+    print(f"  {'CER:':<{label_width}} {_format_ratio(_as_optional_number(diarization_metrics, 'cer'))}")
     print(
         f"  {'CER no speaker:':<{label_width}} "
-        f"{_format_ratio(diarization_metrics.get('cer_no_spk'))}"
+        f"{_format_ratio(_as_optional_number(diarization_metrics, 'cer_no_spk'))}"
     )
     print(
-        f"  {'cpCER:':<{label_width}} {_format_ratio(diarization_metrics.get('cp_cer'))}"
+        f"  {'cpCER:':<{label_width}} {_format_ratio(_as_optional_number(diarization_metrics, 'cp_cer'))}"
     )
     print(
         f"  {'Delta CER:':<{label_width}} "
-        f"{_format_ratio(diarization_metrics.get('delta_cer'))}"
+        f"{_format_ratio(_as_optional_number(diarization_metrics, 'delta_cer'))}"
     )
     print(
         f"  {'CER-valid samples:':<{label_width}} "
@@ -122,21 +184,21 @@ def print_diarization_speed_summary(
     print(f"{'-' * line_width}")
     print(
         f"  {'Throughput (req/s):':<{label_width}} "
-        f"{_format_decimal(speed.get('throughput_qps'), digits=3)}"
+        f"{_format_decimal(_as_optional_number(speed, 'throughput_qps'), digits=3)}"
     )
     print(
         f"  {'Latency mean / p95 (s):':<{label_width}} "
-        f"{_format_decimal(speed.get('latency_mean_s'), digits=3)} / "
-        f"{_format_decimal(speed.get('latency_p95_s'), digits=3)}"
+        f"{_format_decimal(_as_optional_number(speed, 'latency_mean_s'), digits=3)} / "
+        f"{_format_decimal(_as_optional_number(speed, 'latency_p95_s'), digits=3)}"
     )
     print(
         f"  {'RTF mean / p95:':<{label_width}} "
-        f"{_format_decimal(speed.get('rtf_mean'), digits=4)} / "
-        f"{_format_decimal(speed.get('rtf_p95'), digits=4)}"
+        f"{_format_decimal(_as_optional_number(speed, 'rtf_mean'), digits=4)} / "
+        f"{_format_decimal(_as_optional_number(speed, 'rtf_p95'), digits=4)}"
     )
     print(
         f"  {'Audio throughput (s/s):':<{label_width}} "
-        f"{_format_decimal(speed.get('audio_throughput_s_per_s'), digits=3)}"
+        f"{_format_decimal(_as_optional_number(speed, 'audio_throughput_s_per_s'), digits=3)}"
     )
     print(f"{'=' * line_width}")
 
@@ -144,11 +206,15 @@ def print_diarization_speed_summary(
 def compute_diarization_metrics(
     rows: Sequence[DiarizationRow],
 ) -> DiarizationMetricsResult:
+    timestamp_der = _compute_timestamp_der(
+        [(row.reference_text, row.prediction_text) for row in rows],
+        collar=0.0,
+    )
     sample_metrics: list[DiarizationSampleMetric] = []
     cer_stats: list[_CharStats] = []
     cp_stats: list[_CpCerStats] = []
     cer_stats_on_cp_valid: list[_CharStats] = []
-    for row in rows:
+    for row, timestamp_sample in zip(rows, timestamp_der.per_sample, strict=False):
         sample_cer_stats = _char_stats(
             clean_no_speaker(row.reference_text),
             clean_no_speaker(row.prediction_text),
@@ -170,6 +236,15 @@ def compute_diarization_metrics(
                 cer_no_spk=sample_cer_stats.cer,
                 cp_cer=sample_cp_stats.cer,
                 cp_invalid_reason=sample_cp_stats.invalid_reason,
+                speaker_timestamp_der_valid=timestamp_sample.valid,
+                speaker_timestamp_der_invalid_reason=timestamp_sample.invalid_reason,
+                speaker_timestamp_ref_segments=timestamp_sample.ref_segments,
+                speaker_timestamp_pred_segments=timestamp_sample.pred_segments,
+                speaker_timestamp_der=timestamp_sample.der,
+                speaker_timestamp_der_total_seconds=timestamp_sample.total_seconds,
+                speaker_timestamp_der_false_alarm=timestamp_sample.false_alarm,
+                speaker_timestamp_der_missed_detection=timestamp_sample.missed_detection,
+                speaker_timestamp_der_confusion=timestamp_sample.confusion,
             )
         )
 
@@ -187,13 +262,32 @@ def compute_diarization_metrics(
         "delta_cer": delta_cer,
         "cer_valid_samples": sum(1 for item in sample_metrics if item.cer_valid),
         "cp_cer_valid_samples": sum(1 for item in sample_metrics if item.cp_cer_valid),
+        "speaker_timestamp_der": timestamp_der.overall_der,
+        "speaker_timestamp_der_collar": 0.0,
+        "speaker_timestamp_der_valid_samples": timestamp_der.valid_samples,
+        "speaker_timestamp_der_skipped": timestamp_der.skipped,
+        "speaker_timestamp_der_skipped_parse_error": timestamp_der.skipped_parse_error,
+        "speaker_timestamp_der_skipped_no_ref_segments": timestamp_der.skipped_no_ref_segments,
+        "speaker_timestamp_der_skipped_no_pred_segments": timestamp_der.skipped_no_pred_segments,
+        "speaker_timestamp_der_compute_error": timestamp_der.compute_error,
+        "speaker_timestamp_der_total_seconds": timestamp_der.total_seconds,
+        "speaker_timestamp_der_false_alarm": timestamp_der.false_alarm,
+        "speaker_timestamp_der_missed_detection": timestamp_der.missed_detection,
+        "speaker_timestamp_der_confusion": timestamp_der.confusion,
         "count": len(sample_metrics),
     }
     metrics_percent = {
         key: (
             value * 100.0
             if key
-            in {"cer_no_spk", "cer", "cp_cer", "cer_no_spk_cp_valid", "delta_cer"}
+            in {
+                "cer_no_spk",
+                "cer",
+                "cp_cer",
+                "cer_no_spk_cp_valid",
+                "delta_cer",
+                "speaker_timestamp_der",
+            }
             and value is not None
             else value
         )
@@ -372,6 +466,22 @@ def _format_decimal(value: float | int | None, *, digits: int) -> str:
     return f"{float(value):.{digits}f}"
 
 
+def _as_float(metrics: Mapping[str, object], key: str) -> float:
+    value = metrics[key]
+    if not isinstance(value, int | float) or isinstance(value, bool):
+        raise TypeError(f"Metric {key!r} must be numeric, got {type(value).__name__}")
+    return float(value)
+
+
+def _as_optional_number(metrics: Mapping[str, object], key: str) -> float | int | None:
+    value = metrics.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, int | float) or isinstance(value, bool):
+        raise TypeError(f"Metric {key!r} must be numeric or None, got {type(value).__name__}")
+    return value
+
+
 def _levenshtein_distance(reference: str, prediction: str) -> int:
     previous_row = list(range(len(prediction) + 1))
     for reference_index, reference_character in enumerate(reference, start=1):
@@ -387,3 +497,381 @@ def _levenshtein_distance(reference: str, prediction: str) -> int:
             )
         previous_row = current_row
     return previous_row[-1]
+
+
+def _compute_timestamp_der(
+    rows: Sequence[tuple[str, str]],
+    *,
+    collar: float = 0.0,
+) -> _TimestampDerAggregate:
+    per_sample = [
+        _timestamp_der_validity(reference, prediction)
+        for reference, prediction in rows
+    ]
+    valid_items = [
+        (index, reference, prediction)
+        for index, ((reference, prediction), sample) in enumerate(
+            zip(rows, per_sample, strict=False)
+        )
+        if sample.valid
+    ]
+    overall_der: float | None = None
+    total_seconds = 0.0
+    false_alarm = 0.0
+    missed_detection = 0.0
+    confusion = 0.0
+    compute_error = ""
+    if valid_items:
+        try:
+            details = _timestamp_der_detail(
+                predictions=[prediction for _, _, prediction in valid_items],
+                references=[reference for _, reference, _ in valid_items],
+                collar=collar,
+            )
+            overall_der = details["overall_der"]
+            total_seconds = details["total"]
+            false_alarm = details["false_alarm"]
+            missed_detection = details["missed_detection"]
+            confusion = details["confusion"]
+            for (sample_index, _reference, _prediction), detail in zip(
+                valid_items,
+                details["sample_details"],
+                strict=False,
+            ):
+                sample = per_sample[sample_index]
+                per_sample[sample_index] = _TimestampDerSample(
+                    valid=sample.valid,
+                    invalid_reason=sample.invalid_reason,
+                    ref_segments=sample.ref_segments,
+                    pred_segments=sample.pred_segments,
+                    der=detail["der"],
+                    total_seconds=detail["total"],
+                    false_alarm=detail["false_alarm"],
+                    missed_detection=detail["missed_detection"],
+                    confusion=detail["confusion"],
+                )
+        except Exception as exc:
+            compute_error = str(exc)
+            for sample_index, _reference, _prediction in valid_items:
+                sample = per_sample[sample_index]
+                per_sample[sample_index] = _TimestampDerSample(
+                    valid=False,
+                    invalid_reason="der_compute_error",
+                    ref_segments=sample.ref_segments,
+                    pred_segments=sample.pred_segments,
+                    der=None,
+                    total_seconds=0.0,
+                    false_alarm=0.0,
+                    missed_detection=0.0,
+                    confusion=0.0,
+                )
+
+    return _TimestampDerAggregate(
+        overall_der=overall_der,
+        valid_samples=sum(1 for item in per_sample if item.valid),
+        skipped=sum(1 for item in per_sample if not item.valid),
+        skipped_parse_error=sum(
+            1 for item in per_sample if item.invalid_reason == "timestamp_parse_error"
+        ),
+        skipped_no_ref_segments=sum(
+            1
+            for item in per_sample
+            if item.invalid_reason == "no_ref_timestamped_speaker_segments"
+        ),
+        skipped_no_pred_segments=sum(
+            1
+            for item in per_sample
+            if item.invalid_reason == "no_pred_timestamped_speaker_segments"
+        ),
+        compute_error=compute_error,
+        total_seconds=total_seconds,
+        false_alarm=false_alarm,
+        missed_detection=missed_detection,
+        confusion=confusion,
+        per_sample=per_sample,
+    )
+
+
+def _timestamp_der_validity(reference: str, prediction: str) -> _TimestampDerSample:
+    try:
+        ref_segments = len(_parse_timestamped_speaker_segments(reference or ""))
+        pred_segments = len(_parse_timestamped_speaker_segments(prediction or ""))
+    except Exception:
+        return _TimestampDerSample(
+            valid=False,
+            invalid_reason="timestamp_parse_error",
+            ref_segments=0,
+            pred_segments=0,
+            der=None,
+            total_seconds=0.0,
+            false_alarm=0.0,
+            missed_detection=0.0,
+            confusion=0.0,
+        )
+    if ref_segments <= 0:
+        return _TimestampDerSample(
+            valid=False,
+            invalid_reason="no_ref_timestamped_speaker_segments",
+            ref_segments=ref_segments,
+            pred_segments=pred_segments,
+            der=None,
+            total_seconds=0.0,
+            false_alarm=0.0,
+            missed_detection=0.0,
+            confusion=0.0,
+        )
+    if pred_segments <= 0:
+        return _TimestampDerSample(
+            valid=False,
+            invalid_reason="no_pred_timestamped_speaker_segments",
+            ref_segments=ref_segments,
+            pred_segments=pred_segments,
+            der=None,
+            total_seconds=0.0,
+            false_alarm=0.0,
+            missed_detection=0.0,
+            confusion=0.0,
+        )
+    return _TimestampDerSample(
+        valid=True,
+        invalid_reason="",
+        ref_segments=ref_segments,
+        pred_segments=pred_segments,
+        der=None,
+        total_seconds=0.0,
+        false_alarm=0.0,
+        missed_detection=0.0,
+        confusion=0.0,
+    )
+
+
+def _parse_timestamped_speaker_segments(text: str) -> list[tuple[float, float, str]]:
+    tokens: list[tuple[str, float | str]] = []
+    for match in re.finditer(r"\[([^\]]+)\]", text or ""):
+        raw = match.group(1).strip()
+        if TIMESTAMP_TOKEN_RE.fullmatch(raw):
+            tokens.append(("time", float(raw)))
+            continue
+        speaker_match = SPEAKER_TOKEN_RE.fullmatch(raw)
+        if speaker_match:
+            tokens.append(("spk", f"[S{int(speaker_match.group(1))}]"))
+
+    segments: list[tuple[float, float, str]] = []
+    last_speaker: str | None = None
+    index = 0
+    token_count = len(tokens)
+    while index < token_count:
+        kind, value = tokens[index]
+        if kind != "time":
+            index += 1
+            continue
+        start = float(value)
+        next_index = index + 1
+        segment_speaker: str | None = None
+        while next_index < token_count and tokens[next_index][0] != "time":
+            if tokens[next_index][0] == "spk":
+                segment_speaker = str(tokens[next_index][1])
+            next_index += 1
+        if next_index >= token_count:
+            break
+        end = float(tokens[next_index][1])
+        speaker = segment_speaker or last_speaker
+        if speaker is not None and end > start:
+            segments.append((start, end, speaker))
+            last_speaker = speaker
+        index = next_index + 1
+    return segments
+
+
+def _timestamp_der_detail(
+    predictions: list[str],
+    references: list[str],
+    *,
+    collar: float,
+) -> _TimestampDerAggregateDetail:
+    sample_details: list[_TimestampDerSampleDetail] = []
+    total = 0.0
+    false_alarm = 0.0
+    missed_detection = 0.0
+    confusion = 0.0
+    for sample_index, (prediction, reference) in enumerate(
+        zip(predictions, references, strict=False)
+    ):
+        detail = _timestamp_der_one(reference, prediction, collar=collar)
+        sample_details.append(
+            {
+                "sample_index": sample_index,
+                "der": detail["der"],
+                "total": detail["total"],
+                "false_alarm": detail["false_alarm"],
+                "missed_detection": detail["missed_detection"],
+                "confusion": detail["confusion"],
+            }
+        )
+        total += detail["total"]
+        false_alarm += detail["false_alarm"]
+        missed_detection += detail["missed_detection"]
+        confusion += detail["confusion"]
+    errors = false_alarm + missed_detection + confusion
+    return {
+        "overall_der": errors / total if total > 0 else None,
+        "sample_details": sample_details,
+        "total": total,
+        "false_alarm": false_alarm,
+        "missed_detection": missed_detection,
+        "confusion": confusion,
+    }
+
+
+def _timestamp_der_one(
+    reference: str,
+    prediction: str,
+    *,
+    collar: float,
+) -> _TimestampDerDetail:
+    reference_segments = _parse_timestamped_speaker_segments(reference)
+    prediction_segments = _parse_timestamped_speaker_segments(prediction)
+    mapping = _best_hyp_to_ref_mapping(reference_segments, prediction_segments)
+    collar_regions = _reference_collar_regions(reference_segments, collar)
+    boundaries = sorted(
+        {
+            point
+            for start, end, _speaker in reference_segments + prediction_segments
+            for point in (start, end)
+        }
+        | {
+            point
+            for start, end in collar_regions
+            for point in (start, end)
+        }
+    )
+
+    total = 0.0
+    false_alarm = 0.0
+    missed_detection = 0.0
+    confusion = 0.0
+    for start, end in zip(boundaries, boundaries[1:], strict=False):
+        duration = end - start
+        if duration <= 0:
+            continue
+        midpoint = (start + end) / 2.0
+        if _inside_intervals(midpoint, collar_regions):
+            continue
+        reference_active = _active_speakers(reference_segments, start, end)
+        prediction_active_raw = _active_speakers(prediction_segments, start, end)
+        if not reference_active and not prediction_active_raw:
+            continue
+        prediction_active = {
+            mapping.get(speaker, f"__hyp_unmapped_{speaker}")
+            for speaker in prediction_active_raw
+        }
+        total += len(reference_active) * duration
+        false_alarm += (
+            max(0, len(prediction_active_raw) - len(reference_active)) * duration
+        )
+        missed_detection += (
+            max(0, len(reference_active) - len(prediction_active_raw)) * duration
+        )
+        confusion += max(
+            0,
+            min(len(reference_active), len(prediction_active_raw))
+            - len(reference_active & prediction_active),
+        ) * duration
+    errors = false_alarm + missed_detection + confusion
+    return {
+        "der": errors / total if total > 0 else None,
+        "total": total,
+        "false_alarm": false_alarm,
+        "missed_detection": missed_detection,
+        "confusion": confusion,
+    }
+
+
+def _best_hyp_to_ref_mapping(
+    reference_segments: list[tuple[float, float, str]],
+    prediction_segments: list[tuple[float, float, str]],
+) -> dict[str, str]:
+    reference_labels = sorted(
+        {segment[2] for segment in reference_segments}, key=_speaker_sort_key
+    )
+    prediction_labels = sorted(
+        {segment[2] for segment in prediction_segments}, key=_speaker_sort_key
+    )
+    if not reference_labels or not prediction_labels:
+        return {}
+    overlap = np.zeros((len(reference_labels), len(prediction_labels)), dtype=float)
+    reference_index = {
+        label: index for index, label in enumerate(reference_labels)
+    }
+    prediction_index = {
+        label: index for index, label in enumerate(prediction_labels)
+    }
+    for reference_segment in reference_segments:
+        for prediction_segment in prediction_segments:
+            duration = _segment_overlap(reference_segment, prediction_segment)
+            if duration > 0.0:
+                overlap[
+                    reference_index[reference_segment[2]],
+                    prediction_index[prediction_segment[2]],
+                ] += duration
+    row_indexes, column_indexes = linear_sum_assignment(-overlap)
+    return {
+        prediction_labels[column_index]: reference_labels[row_index]
+        for row_index, column_index in zip(row_indexes, column_indexes, strict=False)
+    }
+
+
+def _segment_overlap(
+    left: tuple[float, float, str],
+    right: tuple[float, float, str],
+) -> float:
+    return max(0.0, min(left[1], right[1]) - max(left[0], right[0]))
+
+
+def _speaker_sort_key(label: str) -> tuple[int, str]:
+    match = SPEAKER_TAG_RE.fullmatch(label)
+    return (int(match.group(1)), label) if match else (10**9, label)
+
+
+def _reference_collar_regions(
+    reference_segments: list[tuple[float, float, str]],
+    collar: float,
+) -> list[tuple[float, float]]:
+    if collar <= 0:
+        return []
+    intervals = []
+    for start, end, _speaker in reference_segments:
+        intervals.append((max(0.0, start - collar), start + collar))
+        intervals.append((max(0.0, end - collar), end + collar))
+    return _merge_intervals(intervals)
+
+
+def _merge_intervals(
+    intervals: list[tuple[float, float]],
+) -> list[tuple[float, float]]:
+    merged: list[tuple[float, float]] = []
+    for start, end in sorted((item for item in intervals if item[1] > item[0])):
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+        else:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+    return merged
+
+
+def _inside_intervals(
+    time_point: float,
+    intervals: list[tuple[float, float]],
+) -> bool:
+    return any(start <= time_point < end for start, end in intervals)
+
+
+def _active_speakers(
+    segments: list[tuple[float, float, str]],
+    start: float,
+    end: float,
+) -> set[str]:
+    return {
+        speaker
+        for segment_start, segment_end, speaker in segments
+        if segment_start < end and segment_end > start
+    }

--- a/benchmarks/metrics/transcribe_diarize_metrics.py
+++ b/benchmarks/metrics/transcribe_diarize_metrics.py
@@ -143,7 +143,9 @@ def print_diarization_accuracy_summary(
         f"  {'Exact match rate:':<{label_width}} "
         f"{_as_float(summary, 'exact_match_rate'):.4f} ({_as_float(summary, 'exact_match_rate') * 100:.2f}%)"
     )
-    print(f"  {'CER:':<{label_width}} {_format_ratio(_as_optional_number(diarization_metrics, 'cer'))}")
+    print(
+        f"  {'CER:':<{label_width}} {_format_ratio(_as_optional_number(diarization_metrics, 'cer'))}"
+    )
     print(
         f"  {'CER no speaker:':<{label_width}} "
         f"{_format_ratio(_as_optional_number(diarization_metrics, 'cer_no_spk'))}"
@@ -478,7 +480,9 @@ def _as_optional_number(metrics: Mapping[str, object], key: str) -> float | int 
     if value is None:
         return None
     if not isinstance(value, int | float) or isinstance(value, bool):
-        raise TypeError(f"Metric {key!r} must be numeric or None, got {type(value).__name__}")
+        raise TypeError(
+            f"Metric {key!r} must be numeric or None, got {type(value).__name__}"
+        )
     return value
 
 
@@ -505,8 +509,7 @@ def _compute_timestamp_der(
     collar: float = 0.0,
 ) -> _TimestampDerAggregate:
     per_sample = [
-        _timestamp_der_validity(reference, prediction)
-        for reference, prediction in rows
+        _timestamp_der_validity(reference, prediction) for reference, prediction in rows
     ]
     valid_items = [
         (index, reference, prediction)
@@ -739,11 +742,7 @@ def _timestamp_der_one(
             for start, end, _speaker in reference_segments + prediction_segments
             for point in (start, end)
         }
-        | {
-            point
-            for start, end in collar_regions
-            for point in (start, end)
-        }
+        | {point for start, end in collar_regions for point in (start, end)}
     )
 
     total = 0.0
@@ -772,11 +771,14 @@ def _timestamp_der_one(
         missed_detection += (
             max(0, len(reference_active) - len(prediction_active_raw)) * duration
         )
-        confusion += max(
-            0,
-            min(len(reference_active), len(prediction_active_raw))
-            - len(reference_active & prediction_active),
-        ) * duration
+        confusion += (
+            max(
+                0,
+                min(len(reference_active), len(prediction_active_raw))
+                - len(reference_active & prediction_active),
+            )
+            * duration
+        )
     errors = false_alarm + missed_detection + confusion
     return {
         "der": errors / total if total > 0 else None,
@@ -800,12 +802,8 @@ def _best_hyp_to_ref_mapping(
     if not reference_labels or not prediction_labels:
         return {}
     overlap = np.zeros((len(reference_labels), len(prediction_labels)), dtype=float)
-    reference_index = {
-        label: index for index, label in enumerate(reference_labels)
-    }
-    prediction_index = {
-        label: index for index, label in enumerate(prediction_labels)
-    }
+    reference_index = {label: index for index, label in enumerate(reference_labels)}
+    prediction_index = {label: index for index, label in enumerate(prediction_labels)}
     for reference_segment in reference_segments:
         for prediction_segment in prediction_segments:
             duration = _segment_overlap(reference_segment, prediction_segment)

--- a/benchmarks/tasks/transcribe_diarize.py
+++ b/benchmarks/tasks/transcribe_diarize.py
@@ -56,6 +56,15 @@ class PerSampleRecord(TypedDict):
     cer_valid: bool | None
     cp_cer_valid: bool | None
     cp_invalid_reason: str | None
+    speaker_timestamp_der_valid: bool | None
+    speaker_timestamp_der_invalid_reason: str | None
+    speaker_timestamp_ref_segments: int | None
+    speaker_timestamp_pred_segments: int | None
+    speaker_timestamp_der: float | None
+    speaker_timestamp_der_total_seconds: float | None
+    speaker_timestamp_der_false_alarm: float | None
+    speaker_timestamp_der_missed_detection: float | None
+    speaker_timestamp_der_confusion: float | None
 
 
 class EvaluationConfig(TypedDict):
@@ -130,6 +139,9 @@ def load_movies800_samples(
 
 
 def extract_prediction_text(payload: Mapping[str, JSONValue]) -> str:
+    text = payload.get("text")
+    if isinstance(text, str) and text.strip():
+        return text.strip()
     segments = payload.get("segments")
     if isinstance(segments, list):
         texts = [
@@ -139,7 +151,6 @@ def extract_prediction_text(payload: Mapping[str, JSONValue]) -> str:
         ]
         if texts:
             return " ".join(texts)
-    text = payload.get("text")
     if not isinstance(text, str):
         raise ValueError("Transcription response is missing a string 'text' field")
     return text.strip()
@@ -227,6 +238,51 @@ def build_evaluation_payload(
                 ),
                 "cp_invalid_reason": (
                     diarization_sample.cp_invalid_reason if diarization_sample else None
+                ),
+                "speaker_timestamp_der_valid": (
+                    diarization_sample.speaker_timestamp_der_valid
+                    if diarization_sample
+                    else None
+                ),
+                "speaker_timestamp_der_invalid_reason": (
+                    diarization_sample.speaker_timestamp_der_invalid_reason
+                    if diarization_sample
+                    else None
+                ),
+                "speaker_timestamp_ref_segments": (
+                    diarization_sample.speaker_timestamp_ref_segments
+                    if diarization_sample
+                    else None
+                ),
+                "speaker_timestamp_pred_segments": (
+                    diarization_sample.speaker_timestamp_pred_segments
+                    if diarization_sample
+                    else None
+                ),
+                "speaker_timestamp_der": (
+                    diarization_sample.speaker_timestamp_der
+                    if diarization_sample
+                    else None
+                ),
+                "speaker_timestamp_der_total_seconds": (
+                    diarization_sample.speaker_timestamp_der_total_seconds
+                    if diarization_sample
+                    else None
+                ),
+                "speaker_timestamp_der_false_alarm": (
+                    diarization_sample.speaker_timestamp_der_false_alarm
+                    if diarization_sample
+                    else None
+                ),
+                "speaker_timestamp_der_missed_detection": (
+                    diarization_sample.speaker_timestamp_der_missed_detection
+                    if diarization_sample
+                    else None
+                ),
+                "speaker_timestamp_der_confusion": (
+                    diarization_sample.speaker_timestamp_der_confusion
+                    if diarization_sample
+                    else None
                 ),
             }
         )

--- a/benchmarks/tasks/transcribe_diarize.py
+++ b/benchmarks/tasks/transcribe_diarize.py
@@ -19,7 +19,7 @@ from benchmarks.metrics.transcribe_diarize_metrics import (
     compute_diarization_metrics,
 )
 
-MOVIES800_REPO_ID: Final[str] = "zhaochenyang20/movies800"
+MOVIES800_REPO_ID: Final[str] = "zhaochenyang20/movies800time"
 EXPECTED_SAMPLE_COUNT: Final[int] = 800
 TIMESTAMP_RE: Final[re.Pattern[str]] = re.compile(r"\[\d+(?:\.\d+)?\]")
 SPEAKER_RE: Final[re.Pattern[str]] = re.compile(r"\[\s*s0*(\d+)\s*\]", re.IGNORECASE)

--- a/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
+++ b/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
@@ -159,26 +159,32 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
                 (0, hidden_size), device=adaptor_param.device, dtype=adaptor_param.dtype
             )
 
-        batched_features = torch.stack(chunks).to(device=device, dtype=encoder_dtype)
-        encoder_len = (batched_features.shape[-1] - 1) // 2 + 1
-        encoder_position_ids = torch.arange(
-            encoder_len, device=device, dtype=torch.long
-        )
-        features = self.whisper_encoder(
-            batched_features, encoder_position_ids, forward_batch
-        )
+        with torch.no_grad():
+            batched_features = torch.stack(chunks).to(
+                device=device, dtype=encoder_dtype
+            )
+            encoder_len = (batched_features.shape[-1] - 1) // 2 + 1
+            encoder_position_ids = torch.arange(
+                encoder_len, device=device, dtype=torch.long
+            )
+            features = self.whisper_encoder(
+                batched_features, encoder_position_ids, forward_batch
+            )
 
-        adaptor_dtype = next(self.vq_adaptor.parameters()).dtype
-        merged = [
-            self.time_merge(
-                torch.cat(
-                    [features[i : i + 1, : token_lens[i] * merge_size] for i in ids],
-                    dim=1,
-                ).to(dtype=adaptor_dtype)
-            ).squeeze(0)
-            for ids in audio_spans
-        ]
-        return self.vq_adaptor(torch.cat(merged, dim=0))
+            adaptor_dtype = next(self.vq_adaptor.parameters()).dtype
+            merged = [
+                self.time_merge(
+                    torch.cat(
+                        [
+                            features[i : i + 1, : token_lens[i] * merge_size]
+                            for i in ids
+                        ],
+                        dim=1,
+                    ).to(dtype=adaptor_dtype)
+                ).squeeze(0)
+                for ids in audio_spans
+            ]
+            return self.vq_adaptor(torch.cat(merged, dim=0))
 
     def forward(
         self,

--- a/sglang_omni/models/moss_transcribe_diarize/stages.py
+++ b/sglang_omni/models/moss_transcribe_diarize/stages.py
@@ -30,9 +30,6 @@ from sglang_omni.scheduling.sglang_backend import (
     build_sglang_server_args,
 )
 
-# Note (yichi): Budget for long-form input and let the checkpoint window cap it.
-_LONG_FORM_PROMPT_TOKENS = 72000
-
 
 @contextmanager
 def _missing_additional_chat_templates_compat() -> Iterator[None]:
@@ -68,11 +65,10 @@ def _missing_additional_chat_templates_compat() -> Iterator[None]:
             setattr(module, "list_repo_templates", original)
 
 
-def _default_context_length(model_path: str, max_new_tokens: int) -> int:
+def _default_context_length(model_path: str) -> int:
     config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
     text_config = getattr(config, "text_config", None)
-    max_positions = int(getattr(text_config, "max_position_embeddings", 40960))
-    return min(max_positions, _LONG_FORM_PROMPT_TOKENS + int(max_new_tokens))
+    return int(getattr(text_config, "max_position_embeddings", 131072))
 
 
 def _default_max_new_tokens(model_path: str) -> int:
@@ -112,7 +108,7 @@ def create_sglang_moss_transcribe_diarize_executor(
     resolved_context_length = (
         int(context_length)
         if context_length is not None
-        else _default_context_length(model_path, resolved_max_new_tokens)
+        else _default_context_length(model_path)
     )
 
     overrides = build_generation_batch_overrides(

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -1510,6 +1510,7 @@ def _register_transcriptions(app: FastAPI) -> None:
         prompt: str | None = Form(default=None),
         response_format: str = Form(default="json"),
         temperature: float | None = Form(default=None),
+        max_new_tokens: int | None = Form(default=None, ge=1),
     ) -> Response:
         client: Client = app.state.client
         default_model: str = app.state.model_name
@@ -1529,6 +1530,7 @@ def _register_transcriptions(app: FastAPI) -> None:
             language=language,
             prompt=prompt,
             temperature=temperature,
+            max_new_tokens=max_new_tokens,
         )
 
         try:
@@ -1602,6 +1604,7 @@ def build_transcription_generate_request(
     language: str | None,
     prompt: str | None,
     temperature: float | None,
+    max_new_tokens: int | None = None,
 ) -> GenerateRequest:
     params: dict[str, Any] = {"task": "transcribe"}
     if language is not None:
@@ -1611,6 +1614,8 @@ def build_transcription_generate_request(
     # note (aaron): the client layer fills in the SamplingParams default of 1.0
     # when this key is absent. 0.0 (greedy) matches the OpenAI API, see issue #959.
     params["temperature"] = temperature if temperature is not None else 0.0
+    if max_new_tokens is not None:
+        params["max_new_tokens"] = max_new_tokens
 
     return GenerateRequest(
         model=model,

--- a/tests/test_model/test_asr_ci_multi_speaker.py
+++ b/tests/test_model/test_asr_ci_multi_speaker.py
@@ -48,6 +48,9 @@ MOSS_TD_CER_NO_SPK_PERCENT_REF = 6.612385102255017
 MOSS_TD_CP_CER_PERCENT_REF = 13.0
 MOSS_TD_CER_NO_SPK_CP_VALID_PERCENT_REF = 6.51
 MOSS_TD_DELTA_CER_PERCENT_REF = 6.49
+# Speaker-timestamp DER (diarization error rate, already a percentage in the
+# result JSON). None until the first DER calibration fills in the reference.
+MOSS_TD_SPEAKER_TIMESTAMP_DER_PERCENT_REF: float | None = None
 MOSS_TD_CER_VALID_SAMPLES_MIN: int | None = 784
 MOSS_TD_CP_CER_VALID_SAMPLES_MIN: int | None = 773
 MOSS_TD_THROUGHPUT_QPS_REF = 33.761
@@ -73,6 +76,11 @@ MOSS_TD_CER_NO_SPK_CP_VALID_PERCENT_MAX: float | None = round(
 )
 MOSS_TD_DELTA_CER_PERCENT_MAX: float | None = round(
     MOSS_TD_DELTA_CER_PERCENT_REF * THRESHOLD_SLACK_LOWER, 4
+)
+MOSS_TD_SPEAKER_TIMESTAMP_DER_PERCENT_MAX: float | None = (
+    round(MOSS_TD_SPEAKER_TIMESTAMP_DER_PERCENT_REF * THRESHOLD_SLACK_LOWER, 4)
+    if MOSS_TD_SPEAKER_TIMESTAMP_DER_PERCENT_REF is not None
+    else None
 )
 MOSS_TD_THROUGHPUT_QPS_MIN: float | None = round(
     MOSS_TD_THROUGHPUT_QPS_REF * THRESHOLD_SLACK_HIGHER, 3
@@ -251,6 +259,13 @@ def test_moss_transcribe_diarize_movies800_multi_speaker(
         "delta_cer",
         diarization_percent.get("delta_cer"),
         MOSS_TD_DELTA_CER_PERCENT_MAX,
+        unit="%",
+    )
+    _check_optional_max(
+        checks,
+        "speaker_timestamp_der",
+        diarization_percent.get("speaker_timestamp_der"),
+        MOSS_TD_SPEAKER_TIMESTAMP_DER_PERCENT_MAX,
         unit="%",
     )
     _check_optional_min(

--- a/tests/unit_test/benchmarks/test_dataset_regressions.py
+++ b/tests/unit_test/benchmarks/test_dataset_regressions.py
@@ -221,7 +221,7 @@ def test_tune_ci_threshold_asr_config_tracks_current_asr_ci_stages() -> None:
         "test_asr_ci_seedtts.py": ["Qwen/Qwen3-ASR-1.7B"],
     }
     assert {
-        "zhaochenyang20/movies800",
+        "zhaochenyang20/movies800time",
         "zhaochenyang20/seed-tts-eval-arrow",
     }.issubset(config["hf_datasets"])
 

--- a/tests/unit_test/benchmarks/test_transcribe_diarize_metrics.py
+++ b/tests/unit_test/benchmarks/test_transcribe_diarize_metrics.py
@@ -55,3 +55,100 @@ def test_split_clean_by_speaker_preserves_spoken_event_words() -> None:
         "[S1]": "我笑了",
         "[S2]": "ilovemusic",
     }
+
+
+def test_compute_diarization_metrics_includes_timestamp_der_for_exact_match() -> None:
+    result = compute_diarization_metrics(
+        [
+            DiarizationRow(
+                sample_id="sample-1",
+                audio_path="/tmp/sample-1.wav",
+                reference_text="[0.00][S01]hello[1.00][1.00][S02]world[2.00]",
+                prediction_text="[0.00][S01]hello[1.00][1.00][S02]world[2.00]",
+            )
+        ]
+    )
+
+    assert result.metrics["speaker_timestamp_der"] == pytest.approx(0.0)
+    assert result.metrics["speaker_timestamp_der_valid_samples"] == 1
+    assert result.metrics["speaker_timestamp_der_skipped"] == 0
+    assert result.samples[0].speaker_timestamp_der_valid is True
+    assert result.samples[0].speaker_timestamp_der == pytest.approx(0.0)
+
+
+def test_compute_diarization_metrics_marks_missing_timestamp_prediction_invalid() -> None:
+    result = compute_diarization_metrics(
+        [
+            DiarizationRow(
+                sample_id="sample-1",
+                audio_path="/tmp/sample-1.wav",
+                reference_text="[0.00][S01]hello[1.00]",
+                prediction_text="[S01]hello",
+            )
+        ]
+    )
+
+    assert result.metrics["speaker_timestamp_der"] is None
+    assert result.metrics["speaker_timestamp_der_valid_samples"] == 0
+    assert result.metrics["speaker_timestamp_der_skipped_no_pred_segments"] == 1
+    assert result.samples[0].speaker_timestamp_der_valid is False
+    assert result.samples[0].speaker_timestamp_der_invalid_reason == "no_pred_timestamped_speaker_segments"
+
+
+def test_build_metrics_section_prints_timestamp_metrics() -> None:
+    module = _load_eval_module()
+
+    section = module._build_metrics_section(
+        "diarization_metrics_percent",
+        {
+            "speaker_timestamp_der": 12.3456,
+            "speaker_timestamp_der_valid_samples": 7,
+            "speaker_timestamp_der_skipped": 1,
+        },
+        (
+            "speaker_timestamp_der",
+            "speaker_timestamp_der_valid_samples",
+            "speaker_timestamp_der_skipped",
+        ),
+    )
+
+    assert "speaker_timestamp_der:" in section
+    assert "12.35" in section
+    assert "speaker_timestamp_der_valid_samples:" in section
+
+
+def test_build_key_metrics_section_prints_selected_metrics() -> None:
+    module = _load_eval_module()
+
+    section = module._build_key_metrics_section(
+        {
+            "cer_no_spk": 6.57,
+            "cp_cer": 14.42,
+            "delta_cer": 7.85,
+            "speaker_timestamp_der": 23.97,
+        }
+    )
+
+    assert "key_metrics" in section
+    assert "cer_no_spk:" in section
+    assert "6.57" in section
+    assert "cp_cer:" in section
+    assert "14.42" in section
+    assert "delta_cer:" in section
+    assert "7.85" in section
+    assert "speaker_timestamp_der:" in section
+    assert "23.97" in section
+
+
+def test_extract_prediction_text_prefers_top_level_text_for_timestamps() -> None:
+    from benchmarks.tasks.transcribe_diarize import extract_prediction_text
+
+    payload = {
+        "text": "[0.00][S01]hello[1.00][1.00][S02]world[2.00]",
+        "segments": [
+            {"text": "[S01]hello"},
+            {"text": "[S02]world"},
+        ],
+    }
+
+    assert extract_prediction_text(payload) == payload["text"]

--- a/tests/unit_test/benchmarks/test_transcribe_diarize_metrics.py
+++ b/tests/unit_test/benchmarks/test_transcribe_diarize_metrics.py
@@ -2,12 +2,36 @@
 
 from __future__ import annotations
 
+import importlib.util
+import sys
+from pathlib import Path
+
 import pytest
 
 from benchmarks.metrics.transcribe_diarize_metrics import (
     clean_no_speaker,
+    compute_diarization_metrics,
+    DiarizationRow,
     split_clean_by_speaker,
 )
+
+
+EVAL_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "benchmarks/eval/eval_transcribe_diarize.py"
+)
+
+
+def _load_eval_module():
+    spec = importlib.util.spec_from_file_location(
+        "eval_transcribe_diarize_entry",
+        EVAL_SCRIPT_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_test/benchmarks/test_transcribe_diarize_metrics.py
+++ b/tests/unit_test/benchmarks/test_transcribe_diarize_metrics.py
@@ -9,16 +9,14 @@ from pathlib import Path
 import pytest
 
 from benchmarks.metrics.transcribe_diarize_metrics import (
+    DiarizationRow,
     clean_no_speaker,
     compute_diarization_metrics,
-    DiarizationRow,
     split_clean_by_speaker,
 )
 
-
 EVAL_SCRIPT_PATH = (
-    Path(__file__).resolve().parents[3]
-    / "benchmarks/eval/eval_transcribe_diarize.py"
+    Path(__file__).resolve().parents[3] / "benchmarks/eval/eval_transcribe_diarize.py"
 )
 
 
@@ -76,7 +74,9 @@ def test_compute_diarization_metrics_includes_timestamp_der_for_exact_match() ->
     assert result.samples[0].speaker_timestamp_der == pytest.approx(0.0)
 
 
-def test_compute_diarization_metrics_marks_missing_timestamp_prediction_invalid() -> None:
+def test_compute_diarization_metrics_marks_missing_timestamp_prediction_invalid() -> (
+    None
+):
     result = compute_diarization_metrics(
         [
             DiarizationRow(
@@ -92,7 +92,10 @@ def test_compute_diarization_metrics_marks_missing_timestamp_prediction_invalid(
     assert result.metrics["speaker_timestamp_der_valid_samples"] == 0
     assert result.metrics["speaker_timestamp_der_skipped_no_pred_segments"] == 1
     assert result.samples[0].speaker_timestamp_der_valid is False
-    assert result.samples[0].speaker_timestamp_der_invalid_reason == "no_pred_timestamped_speaker_segments"
+    assert (
+        result.samples[0].speaker_timestamp_der_invalid_reason
+        == "no_pred_timestamped_speaker_segments"
+    )
 
 
 def test_build_metrics_section_prints_timestamp_metrics() -> None:

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -859,6 +859,24 @@ def test_transcription_request_passes_explicit_temperature() -> None:
     assert omni_req.params["temperature"] == 0.7
 
 
+def test_transcription_request_passes_explicit_max_new_tokens() -> None:
+    gen_req = build_transcription_generate_request(
+        audio_bytes=b"RIFF",
+        filename="sample.wav",
+        content_type="audio/wav",
+        model="OpenMOSS-Team/MOSS-Transcribe-Diarize",
+        language="en",
+        prompt=None,
+        temperature=None,
+        max_new_tokens=4096,
+    )
+
+    assert gen_req.model == "OpenMOSS-Team/MOSS-Transcribe-Diarize"
+    assert gen_req.extra_params["max_new_tokens"] == 4096
+    omni_req = Client._build_omni_request(gen_req)
+    assert omni_req.params["max_new_tokens"] == 4096
+
+
 def test_transcription_endpoint_returns_text_json() -> None:
     transcription_client = SuccessfulTranscriptionClient()
     client = TestClient(
@@ -878,6 +896,31 @@ def test_transcription_endpoint_returns_text_json() -> None:
     assert request.model == "openai/whisper-large-v3"
     assert request.prompt["filename"] == "sample.wav"
     assert request.extra_params["language"] == "en"
+
+
+def test_transcription_endpoint_passes_explicit_max_new_tokens() -> None:
+    transcription_client = SuccessfulTranscriptionClient()
+    client = TestClient(
+        create_app(
+            transcription_client,
+            model_name="OpenMOSS-Team/MOSS-Transcribe-Diarize",
+        )
+    )
+
+    response = client.post(
+        "/v1/audio/transcriptions",
+        data={
+            "model": "OpenMOSS-Team/MOSS-Transcribe-Diarize",
+            "max_new_tokens": "4096",
+        },
+        files={"file": ("sample.wav", b"RIFF", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert transcription_client.requests
+    request = transcription_client.requests[0]
+    assert request.model == "OpenMOSS-Team/MOSS-Transcribe-Diarize"
+    assert request.extra_params["max_new_tokens"] == 4096
 
 
 class DiarizationTranscriptionClient:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Add long-form ASR tests for audio durations of several tens of minutes to MOSS-Transcribe-Diarize to maintain performance.

## Modifications

1. Wrapped the encoder part with `torch.no_grad()`, which greatly reduces GPU memory usage during encoding and prevents out‑of‑memory (OOM) errors for long audio inputs.
2. Modified the OpenAI API's transcriptions interface to accept the `max_new_tokens` parameter required for long‑form audio.
3. Replaced the current manually concatenated context with the native `max_position_embeddings` from the model.
4. Added a `max_new_tokens` field in the eval script.
5. Added a dedicated eval script for long‑form audio processing.

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

### ASR Eval Result

**Model:** OpenMOSS-Team/MOSS-Transcribe-Diarize  
**Concurrency:** 16  
**Output:** `results/moss_transcribe_diarize_aishell4_long/transcribe_diarize_results.json`

---

### Key Metrics

| Metric | Value |
|--------|-------|
| cer_no_spk | 13.39 |
| cp_cer | 13.9 |
| delta_cer | 0.5 |
| speaker_timestamp_der | 11.33 |

---

### Summary

| Metric | Value |
|--------|-------|
| total_samples | 20 |
| evaluated | 20 |
| skipped | 0 |
| exact_matches | 0 |
| mismatches | 20 |
| exact_match_rate | 0.0 |

---

### Speed

| Metric | Value |
|--------|-------|
| total_requests | 20 |
| completed_requests | 20 |
| failed_requests | 0 |
| latency_mean_s | 611.399 |
| latency_median_s | 633.711 |
| latency_p95_s | 782.333 |
| latency_p99_s | 804.323 |
| audio_duration_mean_s | 2290.555 |
| rtf_mean | 0.2673 |
| rtf_median | 0.2757 |
| rtf_p95 | 0.3444 |
| rtf_p99 | 0.3456 |
| throughput_qps | 0.021 |
| audio_throughput_s_per_s | 48.209 |

---

### Diarization Metrics (Percent)

| Metric | Value |
|--------|-------|
| cer | 13.39 |
| cer_no_spk | 13.39 |
| cp_cer | 13.9 |
| cer_no_spk_cp_valid | 13.39 |
| delta_cer | 0.5 |
| speaker_timestamp_der | 11.33 |
| speaker_timestamp_der_collar | 0.0 |
| speaker_timestamp_der_valid_samples | 20 |
| speaker_timestamp_der_skipped | 0 |
| speaker_timestamp_der_skipped_parse_error | 0 |
| speaker_timestamp_der_skipped_no_ref_segments | 0 |
| speaker_timestamp_der_skipped_no_pred_segments | 0 |
| speaker_timestamp_der_compute_error | (empty) |
| speaker_timestamp_der_total_seconds | 43594.38 |
| speaker_timestamp_der_false_alarm | 1332.27 |
| speaker_timestamp_der_missed_detection | 2814.14 |
| speaker_timestamp_der_confusion | 793.69 |
| cer_valid_samples | 20 |
| cp_cer_valid_samples | 20 |
| count | 20 |

## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
