### PR TITLE
[bugfix]Cap max_new_tokens by audio duration

### DIFF
--- a/sglang_omni/models/moss_transcribe_diarize/request_builders.py
+++ b/sglang_omni/models/moss_transcribe_diarize/request_builders.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import re
 import time
 from dataclasses import dataclass
@@ -30,6 +31,9 @@ _AUDIO_PAD = "<|audio_pad|>"
 _AUDIO_START = "<|audio_start|>"
 _AUDIO_END = "<|audio_end|>"
 _SPECIAL_TOKEN_RE = re.compile(r"<\|(?:im_start|im_end|endoftext)\|>")
+_MOSS_TD_MAX_NEW_TOKENS_PER_AUDIO_SECOND = 20
+_MOSS_TD_MAX_NEW_TOKENS_SLACK = 64
+_MOSS_TD_MIN_MAX_NEW_TOKENS = 128
 # Note (yichi): MOSS-Transcribe-Diarize is an audio LLM: a Qwen3 text decoder
 # over Whisper audio embeddings, trained on a fixed transcribe+diarize
 # instruction with the timestamped/speaker-labelled transcript as the target
@@ -124,6 +128,35 @@ def _decode_token_ids(
 
 def postprocess_moss_transcribe_diarize_text(text: str) -> str:
     return _SPECIAL_TOKEN_RE.sub("", text).strip()
+
+
+def _duration_scaled_max_new_tokens(audio_duration_s: float) -> int | None:
+    if audio_duration_s <= 0:
+        return None
+    return max(
+        _MOSS_TD_MIN_MAX_NEW_TOKENS,
+        math.ceil(audio_duration_s * _MOSS_TD_MAX_NEW_TOKENS_PER_AUDIO_SECOND)
+        + _MOSS_TD_MAX_NEW_TOKENS_SLACK,
+    )
+
+
+def _resolve_request_max_new_tokens(
+    params: dict[str, Any],
+    *,
+    default_max_new_tokens: int,
+    audio_duration_s: float,
+) -> int:
+    explicit = params.get("max_new_tokens")
+    requested = int(explicit if explicit is not None else default_max_new_tokens)
+
+    # Preserve explicit caller overrides; cap only the default ASR path.
+    if explicit is not None:
+        return requested
+
+    duration_budget = _duration_scaled_max_new_tokens(audio_duration_s)
+    if duration_budget is None:
+        return requested
+    return min(requested, duration_budget)
 
 
 def _prompt_from_payload(payload: StagePayload, processor: Any) -> str:
@@ -249,7 +282,11 @@ def make_moss_transcribe_diarize_scheduler_adapters(
         )
 
         temperature = float(params.get("temperature") or 0.0)
-        request_max_new_tokens = int(params.get("max_new_tokens") or max_new_tokens)
+        request_max_new_tokens = _resolve_request_max_new_tokens(
+            params,
+            default_max_new_tokens=max_new_tokens,
+            audio_duration_s=audio_duration_s,
+        )
         sampling_params = SamplingParams(
             max_new_tokens=request_max_new_tokens,
             temperature=temperature,

--- a/tests/unit_test/moss_transcribe_diarize/test_request_builders.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_request_builders.py
@@ -12,6 +12,7 @@ import torch
 import sglang_omni.models.moss_transcribe_diarize.request_builders as request_builders
 from sglang_omni.models.moss_transcribe_diarize.request_builders import (
     DEFAULT_TRANSCRIBE_DIARIZE_PROMPT,
+    _resolve_request_max_new_tokens,
     make_moss_transcribe_diarize_scheduler_adapters,
 )
 from sglang_omni.proto import OmniRequest, StagePayload
@@ -106,6 +107,50 @@ def _request_builder(processor: FakeProcessor | None = None):
         max_new_tokens=32,
     )
     return request_builder
+
+
+def test_moss_td_duration_budget_caps_short_default_request() -> None:
+    assert (
+        _resolve_request_max_new_tokens(
+            {},
+            default_max_new_tokens=2048,
+            audio_duration_s=9.7,
+        )
+        == 258
+    )
+
+
+def test_moss_td_duration_budget_preserves_small_minimum() -> None:
+    assert (
+        _resolve_request_max_new_tokens(
+            {},
+            default_max_new_tokens=2048,
+            audio_duration_s=1.0,
+        )
+        == 128
+    )
+
+
+def test_moss_td_duration_budget_respects_explicit_max_new_tokens() -> None:
+    assert (
+        _resolve_request_max_new_tokens(
+            {"max_new_tokens": 2048},
+            default_max_new_tokens=512,
+            audio_duration_s=9.7,
+        )
+        == 2048
+    )
+
+
+def test_moss_td_duration_budget_does_not_raise_unknown_duration() -> None:
+    assert (
+        _resolve_request_max_new_tokens(
+            {},
+            default_max_new_tokens=2048,
+            audio_duration_s=0.0,
+        )
+        == 2048
+    )
 
 
 def test_request_builder_replaces_audio_tokens_with_item_pad_value() -> None:


### PR DESCRIPTION
## Summary

This PR adds a duration-scaled `max_new_tokens` stop-loss for the MOSS-Transcribe-Diarize ASR request builder.

It addresses the first action item in #975 : prevent a short pathological audio sample from consuming the full default generation cap when greedy decoding falls into a repeated transcript loop.

The change preserves the current greedy default and does not attempt to change decoding behavior or transcript quality. It only caps the default ASR generation budget based on input audio duration.

## Changes

* Added duration-scaled `max_new_tokens` logic in:

  `sglang_omni/models/moss_transcribe_diarize/request_builders.py`

* Applied the resolved cap when constructing MOSS-Transcribe-Diarize `SamplingParams`.

* Preserved explicit caller-provided `max_new_tokens`.

  * If the request sends `max_new_tokens`, that value is respected.
  * If the request does not send it, the duration-scaled default cap is applied.

## Validation

Validated on branch/commit:

```text
akaza-bugfix-tail-latency
22c8c6f
```

### Single-sample pathological probe

Input:

```text
val_000280.flac
temperature=0
```

Result:

```text
request builder cap: max_new_tokens=258
first probe latency: 7.01s
warm probe latency: 0.57s
```

The output still repeats `Ha ha ...`, but it now stops at the duration-scaled cap instead of running to the full 2048-token default cap.

### Temperature=1 control

```text
latency: 0.293s
```

The transcript terminates normally with `Oops.`

### Full stage-1 ASR CI

Command ran on GPUs 4,5 with a local cached model snapshot.

```text
800/800 completed
0 failed
throughput: 44.390 req/s
latency mean / p95: 0.358 / 0.838s
test result: 1 passed in 45.85s
```

## Notes

This is a stop-loss fix only.

It does not fix the repeated transcript content itself. That should be handled separately by the later loop-mitigation items from #975, such as evaluating repetition penalty or other decode-time safeguards.

The CI/eval request path does not send explicit `max_new_tokens`, so the duration-scaled cap applies there. Explicit caller overrides are intentionally preserved.


## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
