### PR TITLE
[CI] Let Omni CI inherit runner GPU assignment

### DIFF
--- a/.github/workflows/cleanup-pr-ci-home-on-close.yaml
+++ b/.github/workflows/cleanup-pr-ci-home-on-close.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 5
     container:
       image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
-      options: --rm -e NVIDIA_VISIBLE_DEVICES=6,7 -v /dev/shm:/dev/shm -v /data/omni-ci:/data/omni-ci
+      options: --rm -e NVIDIA_VISIBLE_DEVICES -v /dev/shm:/dev/shm -v /data/omni-ci:/data/omni-ci
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/omni-ci.yaml
+++ b/.github/workflows/omni-ci.yaml
@@ -123,7 +123,7 @@ jobs:
       image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
       options: >-
         --rm
-        -e NVIDIA_VISIBLE_DEVICES=6,7
+        -e NVIDIA_VISIBLE_DEVICES
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
         -v /data/cache/huggingface:/github/home/.cache/huggingface
@@ -295,7 +295,7 @@ jobs:
       image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
       options: >-
         --rm
-        -e NVIDIA_VISIBLE_DEVICES=6,7
+        -e NVIDIA_VISIBLE_DEVICES
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
         -v /data/cache/huggingface:/github/home/.cache/huggingface

--- a/.github/workflows/test-asr-ci.yaml
+++ b/.github/workflows/test-asr-ci.yaml
@@ -35,7 +35,7 @@ jobs:
       image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
       options: >-
         --rm
-        -e NVIDIA_VISIBLE_DEVICES=6,7
+        -e NVIDIA_VISIBLE_DEVICES
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
         -v /data/cache/huggingface:/github/home/.cache/huggingface
@@ -84,7 +84,7 @@ jobs:
       image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
       options: >-
         --rm
-        -e NVIDIA_VISIBLE_DEVICES=6,7
+        -e NVIDIA_VISIBLE_DEVICES
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
         -v /data/cache/huggingface:/github/home/.cache/huggingface

--- a/.github/workflows/test-qwen3-omni-ci.yaml
+++ b/.github/workflows/test-qwen3-omni-ci.yaml
@@ -37,7 +37,7 @@ jobs:
       image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
       options: >-
         --rm
-        -e NVIDIA_VISIBLE_DEVICES=6,7
+        -e NVIDIA_VISIBLE_DEVICES
         --cap-add=SYS_PTRACE
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
@@ -78,7 +78,7 @@ jobs:
       image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
       options: >-
         --rm
-        -e NVIDIA_VISIBLE_DEVICES=6,7
+        -e NVIDIA_VISIBLE_DEVICES
         --cap-add=SYS_PTRACE
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
@@ -136,7 +136,7 @@ jobs:
       image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
       options: >-
         --rm
-        -e NVIDIA_VISIBLE_DEVICES=6,7
+        -e NVIDIA_VISIBLE_DEVICES
         --cap-add=SYS_PTRACE
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
@@ -181,7 +181,7 @@ jobs:
       image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
       options: >-
         --rm
-        -e NVIDIA_VISIBLE_DEVICES=6,7
+        -e NVIDIA_VISIBLE_DEVICES
         --cap-add=SYS_PTRACE
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
@@ -226,7 +226,7 @@ jobs:
       image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
       options: >-
         --rm
-        -e NVIDIA_VISIBLE_DEVICES=6,7
+        -e NVIDIA_VISIBLE_DEVICES
         --cap-add=SYS_PTRACE
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
@@ -272,7 +272,7 @@ jobs:
       image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
       options: >-
         --rm
-        -e NVIDIA_VISIBLE_DEVICES=6,7
+        -e NVIDIA_VISIBLE_DEVICES
         --cap-add=SYS_PTRACE
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
@@ -317,7 +317,7 @@ jobs:
       image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
       options: >-
         --rm
-        -e NVIDIA_VISIBLE_DEVICES=6,7
+        -e NVIDIA_VISIBLE_DEVICES
         --cap-add=SYS_PTRACE
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
@@ -362,7 +362,7 @@ jobs:
       image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
       options: >-
         --rm
-        -e NVIDIA_VISIBLE_DEVICES=6,7
+        -e NVIDIA_VISIBLE_DEVICES
         --cap-add=SYS_PTRACE
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
@@ -407,7 +407,7 @@ jobs:
       image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
       options: >-
         --rm
-        -e NVIDIA_VISIBLE_DEVICES=6,7
+        -e NVIDIA_VISIBLE_DEVICES
         --cap-add=SYS_PTRACE
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
@@ -454,7 +454,7 @@ jobs:
       # processes; CAP_SYS_PTRACE is required (else every request 500s).
       options: >-
         --rm
-        -e NVIDIA_VISIBLE_DEVICES=6,7
+        -e NVIDIA_VISIBLE_DEVICES
         --cap-add=SYS_PTRACE
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci

--- a/.github/workflows/test-tts-ci.yaml
+++ b/.github/workflows/test-tts-ci.yaml
@@ -31,7 +31,7 @@ jobs:
       image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
       options: >-
         --rm
-        -e NVIDIA_VISIBLE_DEVICES=6,7
+        -e NVIDIA_VISIBLE_DEVICES
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
         -v /data/cache/huggingface:/github/home/.cache/huggingface
@@ -98,7 +98,7 @@ jobs:
       image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
       options: >-
         --rm
-        -e NVIDIA_VISIBLE_DEVICES=6,7
+        -e NVIDIA_VISIBLE_DEVICES
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
         -v /data/cache/huggingface:/github/home/.cache/huggingface
@@ -154,7 +154,7 @@ jobs:
       image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
       options: >-
         --rm
-        -e NVIDIA_VISIBLE_DEVICES=6,7
+        -e NVIDIA_VISIBLE_DEVICES
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
         -v /data/cache/huggingface:/github/home/.cache/huggingface

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
       image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
       options: >-
         --rm
-        -e NVIDIA_VISIBLE_DEVICES=6,7
+        -e NVIDIA_VISIBLE_DEVICES
         -v /dev/shm:/dev/shm
         -v /data/omni-ci:/data/omni-ci
         -v /data/cache/huggingface:/github/home/.cache/huggingface


### PR DESCRIPTION
This updates Omni CI jobs to inherit NVIDIA_VISIBLE_DEVICES from the assigned h100 self-hosted runner instead of hardcoding GPU 6,7 in the workflow container options.

The runner infra now assigns a fixed GPU pair to each h100 runner process. Keeping the workflow value inherited from the runner lets the existing baseline runner continue exposing GPU 6,7 while additional h100 runners can expose their own GPU pairs without changing the Omni CI workflow again.

This PR only changes workflow container options.