### PR TITLE
Profile reference encode batch gate

### DIFF
--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -379,8 +379,14 @@ def _write_request_profile_report(
             "server-side event_dir."
         )
     if expect_reference_encode:
-        encode_count = sum(int(row.get("encode_count") or 0) for row in reference_rows)
-        if encode_count == 0:
+        successful_miss_count = sum(
+            min(
+                int(row.get("misses") or 0),
+                int(row.get("encode_count") or 0),
+            )
+            for row in reference_rows
+        )
+        if successful_miss_count == 0:
             raise RuntimeError(
                 "No successful reference encode misses were found in "
                 f"{event_dir!r}. For M4B gate runs, use a cold-cache workload "

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -374,8 +374,8 @@ def _write_request_profile_report(
     if expect_reference_encode and not reference_rows:
         raise RuntimeError(
             "No reference encode profile events were found in "
-            f"{event_dir!r}. For M4B gate runs, verify this model uses "
-            "ReferenceEncodeService and that the benchmark can read the "
+            f"{event_dir!r}. Verify this model uses ReferenceEncodeService "
+            "and that the benchmark can read the "
             "server-side event_dir."
         )
     if expect_reference_encode:
@@ -389,8 +389,8 @@ def _write_request_profile_report(
         if successful_miss_count == 0:
             raise RuntimeError(
                 "No successful reference encode misses were found in "
-                f"{event_dir!r}. For M4B gate runs, use a cold-cache workload "
-                "with different reference audio per request."
+                f"{event_dir!r}. Use a cold-cache workload with different "
+                "reference audio per request."
             )
     path = Path(report_path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -845,7 +845,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help=(
             "Fail if --profile-request-events produces no reference encode "
-            "breakdown. Use this for M4B gate runs."
+            "breakdown. Use this when validating reference encode coverage."
         ),
     )
     parser.add_argument(

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -256,6 +256,7 @@ class TtsSeedttsBenchmarkConfig:
     profile_run_id: str | None = None
     profile_event_dir: str | None = None
     profile_report_path: str | None = None
+    require_reference_encode_profile: bool = False
     # Transcribe phase
     lang: str = "en"
     device: str = "cuda:0"
@@ -313,6 +314,7 @@ def _build_results_config(
         "profile_run_id": config.profile_run_id,
         "profile_event_dir": config.profile_event_dir,
         "profile_report_path": config.profile_report_path,
+        "require_reference_encode_profile": config.require_reference_encode_profile,
     }
 
 
@@ -358,6 +360,7 @@ def _write_request_profile_report(
     event_dir: str,
     report_path: str,
     expect_events: bool = False,
+    expect_reference_encode: bool = False,
 ) -> dict:
     report = build_report(event_dir)
     if expect_events and int(report.get("request_count") or 0) == 0:
@@ -366,6 +369,13 @@ def _write_request_profile_report(
             f"{event_dir!r}. The benchmark host must be able to read the "
             "server-side event_dir; run the benchmark next to the server or "
             "pass a shared --profile-event-dir."
+        )
+    if expect_reference_encode and not report.get("reference_encode_breakdown"):
+        raise RuntimeError(
+            "No reference encode profile events were found in "
+            f"{event_dir!r}. For M4B gate runs, verify this model uses "
+            "ReferenceEncodeService and that the benchmark can read the "
+            "server-side event_dir."
         )
     path = Path(report_path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -446,6 +456,7 @@ async def run_tts_seedtts_benchmark(
             event_dir=profile_event_dir,
             report_path=profile_report_path,
             expect_events=bool(samples),
+            expect_reference_encode=config.require_reference_encode_profile,
         )
     else:
         outputs = await runner.run(samples, send_fn)
@@ -541,6 +552,7 @@ def _config_from_args(args: argparse.Namespace) -> TtsSeedttsBenchmarkConfig:
         profile_run_id=args.profile_run_id,
         profile_event_dir=args.profile_event_dir,
         profile_report_path=args.profile_report_path,
+        require_reference_encode_profile=args.require_reference_encode_profile,
         lang=args.lang,
         device=args.device,
         similarity_checkpoint=args.similarity_checkpoint,
@@ -808,6 +820,14 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--require-reference-encode-profile",
+        action="store_true",
+        help=(
+            "Fail if --profile-request-events produces no reference encode "
+            "breakdown. Use this for M4B gate runs."
+        ),
+    )
+    parser.add_argument(
         "--use-existing-server",
         action="store_true",
         help=(
@@ -855,6 +875,10 @@ def main() -> None:
         parser.error(
             "--use-existing-server currently requires --generate-only or "
             "--transcribe-only"
+        )
+    if args.require_reference_encode_profile and not args.profile_request_events:
+        parser.error(
+            "--require-reference-encode-profile requires --profile-request-events"
         )
     config = _config_from_args(args)
     wait_for_gpu_release = not args.skip_gpu_cleanup

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -363,6 +363,7 @@ def _write_request_profile_report(
     expect_reference_encode: bool = False,
 ) -> dict:
     report = build_report(event_dir)
+    reference_rows = report.get("reference_encode_breakdown") or []
     if expect_events and int(report.get("request_count") or 0) == 0:
         raise RuntimeError(
             "No request profile events were found in "
@@ -370,13 +371,21 @@ def _write_request_profile_report(
             "server-side event_dir; run the benchmark next to the server or "
             "pass a shared --profile-event-dir."
         )
-    if expect_reference_encode and not report.get("reference_encode_breakdown"):
+    if expect_reference_encode and not reference_rows:
         raise RuntimeError(
             "No reference encode profile events were found in "
             f"{event_dir!r}. For M4B gate runs, verify this model uses "
             "ReferenceEncodeService and that the benchmark can read the "
             "server-side event_dir."
         )
+    if expect_reference_encode:
+        encode_count = sum(int(row.get("encode_count") or 0) for row in reference_rows)
+        if encode_count == 0:
+            raise RuntimeError(
+                "No successful reference encode misses were found in "
+                f"{event_dir!r}. For M4B gate runs, use a cold-cache workload "
+                "with different reference audio per request."
+            )
     path = Path(report_path)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
@@ -390,6 +399,11 @@ async def run_tts_seedtts_benchmark(
 
     Returns a dict with keys: summary, per_request, config.
     """
+    if config.profile_request_events and config.warmup != 0:
+        raise ValueError(
+            "profile_request_events requires warmup=0 so warmup requests do "
+            "not populate the reference cache inside the profiling window"
+        )
     base_url = build_base_url(config)
     api_url = f"{base_url}/v1/audio/speech"
 
@@ -880,6 +894,8 @@ def main() -> None:
         parser.error(
             "--require-reference-encode-profile requires --profile-request-events"
         )
+    if args.profile_request_events and args.warmup != 0:
+        parser.error("--profile-request-events requires --warmup 0")
     config = _config_from_args(args)
     wait_for_gpu_release = not args.skip_gpu_cleanup
 

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -173,8 +173,10 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import logging
 import os
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -200,6 +202,7 @@ from benchmarks.tasks.tts import (
     save_generated_audio_metadata,
     save_speed_results,
 )
+from sglang_omni.profiler.views import build_report
 
 logging.basicConfig(
     level=logging.INFO,
@@ -249,6 +252,10 @@ class TtsSeedttsBenchmarkConfig:
     disable_tqdm: bool = False
     max_running_requests: int = 64
     cuda_graph_max_bs: int = 64
+    profile_request_events: bool = False
+    profile_run_id: str | None = None
+    profile_event_dir: str | None = None
+    profile_report_path: str | None = None
     # Transcribe phase
     lang: str = "en"
     device: str = "cuda:0"
@@ -302,7 +309,61 @@ def _build_results_config(
         "initial_codec_chunk_frames": config.initial_codec_chunk_frames,
         "max_running_requests": config.max_running_requests,
         "cuda_graph_max_bs": config.cuda_graph_max_bs,
+        "profile_request_events": config.profile_request_events,
+        "profile_run_id": config.profile_run_id,
+        "profile_event_dir": config.profile_event_dir,
+        "profile_report_path": config.profile_report_path,
     }
+
+
+async def _post_json(
+    session,
+    url: str,
+    payload: dict,
+) -> dict:
+    async with session.post(url, json=payload) as response:
+        body = await response.json()
+        response.raise_for_status()
+        return body
+
+
+async def _start_request_profile(
+    session,
+    base_url: str,
+    *,
+    run_id: str,
+    event_dir: str,
+) -> dict:
+    return await _post_json(
+        session,
+        f"{base_url}/start_request_profile",
+        {"run_id": run_id, "event_dir": event_dir},
+    )
+
+
+async def _stop_request_profile(
+    session,
+    base_url: str,
+    *,
+    run_id: str,
+) -> dict:
+    return await _post_json(
+        session,
+        f"{base_url}/stop_request_profile",
+        {"run_id": run_id},
+    )
+
+
+def _write_request_profile_report(
+    *,
+    event_dir: str,
+    report_path: str,
+) -> dict:
+    report = build_report(event_dir)
+    path = Path(report_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+    return report
 
 
 async def run_tts_seedtts_benchmark(
@@ -345,10 +406,49 @@ async def run_tts_seedtts_benchmark(
             disable_tqdm=config.disable_tqdm,
         )
     )
-    outputs = await runner.run(samples, send_fn)
+    profile_run_id = config.profile_run_id or f"tts-seedtts-{int(time.time())}"
+    profile_event_dir = config.profile_event_dir or str(
+        Path(config.output_dir, "request_profile_events").resolve()
+    )
+    profile_report_path = config.profile_report_path or str(
+        Path(config.output_dir, "request_profile_report.json").resolve()
+    )
+    profile_info = None
+    if config.profile_request_events:
+        import aiohttp
+
+        async with aiohttp.ClientSession() as session:
+            profile_info = await _start_request_profile(
+                session,
+                base_url,
+                run_id=profile_run_id,
+                event_dir=profile_event_dir,
+            )
+            try:
+                outputs = await runner.run(samples, send_fn)
+            finally:
+                try:
+                    await _stop_request_profile(
+                        session,
+                        base_url,
+                        run_id=profile_run_id,
+                    )
+                except Exception:
+                    logger.warning("failed to stop request profile", exc_info=True)
+        _write_request_profile_report(
+            event_dir=profile_event_dir,
+            report_path=profile_report_path,
+        )
+    else:
+        outputs = await runner.run(samples, send_fn)
 
     metrics = compute_speed_metrics(outputs, wall_clock_s=runner.wall_clock_s)
     results_config = _build_results_config(config, base_url=base_url)
+    if profile_info is not None:
+        results_config["profile_info"] = profile_info
+        results_config["profile_run_id"] = profile_run_id
+        results_config["profile_event_dir"] = profile_event_dir
+        results_config["profile_report_path"] = profile_report_path
     benchmark_results = build_speed_results(outputs, metrics, results_config)
     save_speed_results(outputs, metrics, results_config, config.output_dir)
     save_generated_audio_metadata(outputs, samples, config.output_dir)
@@ -429,6 +529,10 @@ def _config_from_args(args: argparse.Namespace) -> TtsSeedttsBenchmarkConfig:
         disable_tqdm=args.disable_tqdm,
         max_running_requests=args.max_running_requests,
         cuda_graph_max_bs=args.cuda_graph_max_bs,
+        profile_request_events=args.profile_request_events,
+        profile_run_id=args.profile_run_id,
+        profile_event_dir=args.profile_event_dir,
+        profile_report_path=args.profile_report_path,
         lang=args.lang,
         device=args.device,
         similarity_checkpoint=args.similarity_checkpoint,
@@ -661,6 +765,38 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             "running multiple benchmark processes in parallel on different "
             "GPUs; combine with CUDA_VISIBLE_DEVICES per worker and clean up "
             "each GPU once after the worker finishes."
+        ),
+    )
+    parser.add_argument(
+        "--profile-request-events",
+        action="store_true",
+        help=(
+            "Start /start_request_profile before generation and write a "
+            "request_profile_report.json with stage and reference-encode breakdowns."
+        ),
+    )
+    parser.add_argument(
+        "--profile-run-id",
+        type=str,
+        default=None,
+        help="Optional run_id for --profile-request-events.",
+    )
+    parser.add_argument(
+        "--profile-event-dir",
+        type=str,
+        default=None,
+        help=(
+            "Directory where server-side request profiler JSONL events are written. "
+            "Defaults to output-dir/request_profile_events."
+        ),
+    )
+    parser.add_argument(
+        "--profile-report-path",
+        type=str,
+        default=None,
+        help=(
+            "Output path for the generated request profile report. Defaults to "
+            "output-dir/request_profile_report.json."
         ),
     )
     parser.add_argument(

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -322,9 +322,8 @@ async def _post_json(
     payload: dict,
 ) -> dict:
     async with session.post(url, json=payload) as response:
-        body = await response.json()
         response.raise_for_status()
-        return body
+        return await response.json()
 
 
 async def _start_request_profile(
@@ -358,8 +357,16 @@ def _write_request_profile_report(
     *,
     event_dir: str,
     report_path: str,
+    expect_events: bool = False,
 ) -> dict:
     report = build_report(event_dir)
+    if expect_events and int(report.get("request_count") or 0) == 0:
+        raise RuntimeError(
+            "No request profile events were found in "
+            f"{event_dir!r}. The benchmark host must be able to read the "
+            "server-side event_dir; run the benchmark next to the server or "
+            "pass a shared --profile-event-dir."
+        )
     path = Path(report_path)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
@@ -438,6 +445,7 @@ async def run_tts_seedtts_benchmark(
         _write_request_profile_report(
             event_dir=profile_event_dir,
             report_path=profile_report_path,
+            expect_events=bool(samples),
         )
     else:
         outputs = await runner.run(samples, send_fn)

--- a/benchmarks/eval/benchmark_tts_seedtts.py
+++ b/benchmarks/eval/benchmark_tts_seedtts.py
@@ -472,12 +472,6 @@ async def run_tts_seedtts_benchmark(
                     )
                 except Exception:
                     logger.warning("failed to stop request profile", exc_info=True)
-        _write_request_profile_report(
-            event_dir=profile_event_dir,
-            report_path=profile_report_path,
-            expect_events=bool(samples),
-            expect_reference_encode=config.require_reference_encode_profile,
-        )
     else:
         outputs = await runner.run(samples, send_fn)
 
@@ -491,6 +485,13 @@ async def run_tts_seedtts_benchmark(
     benchmark_results = build_speed_results(outputs, metrics, results_config)
     save_speed_results(outputs, metrics, results_config, config.output_dir)
     save_generated_audio_metadata(outputs, samples, config.output_dir)
+    if config.profile_request_events:
+        _write_request_profile_report(
+            event_dir=profile_event_dir,
+            report_path=profile_report_path,
+            expect_events=bool(samples),
+            expect_reference_encode=config.require_reference_encode_profile,
+        )
     return benchmark_results
 
 

--- a/docs/design/07_simple_scheduler_batching.md
+++ b/docs/design/07_simple_scheduler_batching.md
@@ -1,0 +1,106 @@
+# 07_simple_scheduler_batching
+
+## SimpleScheduler Concurrent Batching
+
+Status: Draft
+
+Top-level module: M7
+
+Behavior level: Red
+
+Issue: TBD
+
+PR: TBD
+
+## Goal
+
+Support `max_concurrency > 1` together with `batch_compute_fn` when there is a
+real consumer and profiling evidence.
+
+## Scope
+
+- Queue-agnostic batch collection for `SimpleScheduler`.
+- Parity between the serial inbox path and the concurrent `async_inbox` path.
+- Ordering, cancellation, and error semantics for concurrent batches.
+- `max_batch_wait_ms`, `request_cost_fn`, and `max_batch_cost` behavior under
+  concurrent collection.
+
+## Non-scope
+
+- This is not a simple deletion of the current guard.
+- Do not mix this with T2 or T5 work.
+- Do not implement runtime scheduler changes without a consumer or profiling
+  evidence.
+
+## Contract
+
+The scheduler owns batch collection semantics. Call sites only declare
+`batch_compute_fn` and optional cost functions. They should not need stage-local
+queue logic to make concurrent batching correct.
+
+## Current State
+
+`SimpleScheduler` already supports serial local batching with `batch_compute_fn`
+when `max_concurrency=1`. It also supports concurrent non-batched execution with
+`max_concurrency > 1`.
+
+The combination is intentionally rejected today because the concurrent path
+bridges the blocking inbox into an internal `async_inbox` and then lets worker
+tasks claim individual messages. Removing the guard would make multiple workers
+race to form batches, which can break exclusive claim, FIFO expectations, cost
+accounting, and per-request error ownership.
+
+## Migration Plan
+
+1. Attach consumer or profile evidence. M4B is one possible consumer, but only
+   after reference-encode profiling shows different-key batching is useful.
+2. Write a design for the queue-agnostic collector and get it reviewed.
+3. Add contract tests first in an isolated red PR.
+4. Modify `SimpleScheduler` only after the contract is accepted.
+5. Keep the old `max_concurrency=1` batching behavior unchanged.
+
+## Candidate Design
+
+Use one collector owner per scheduler instance, not one collector per worker.
+The collector should read from the same source of truth for both serial and
+concurrent modes, form batches according to size, wait, and cost limits, and
+hand complete work items to workers.
+
+The collector should produce either a single-message work item or a batch work
+item. Workers run `compute_fn` for single items and `batch_compute_fn` for batch
+items. This preserves the call-site contract and keeps batching decisions inside
+the scheduler.
+
+Abort and error handling stay per request. A failed batch emits one error per
+claimed request. An aborted request is consumed before batch execution when
+possible, and after execution before result emission when the abort races with
+compute.
+
+## Contract Tests
+
+- Exclusive claim: each request is assigned to exactly one work item.
+- FIFO: batch formation preserves inbox order for eligible `new_request`
+  messages.
+- Exception propagation: a batch failure emits per-request errors for all
+  claimed requests.
+- Cancellation: aborted requests are not emitted as successes.
+- No busy loop: idle collectors and workers block or time out normally.
+- Wait parity: `max_batch_wait_ms` behaves the same in serial and concurrent
+  modes.
+- Cost parity: `request_cost_fn` and `max_batch_cost` split batches the same way
+  in serial and concurrent modes.
+- Non-request messages: non-`new_request` messages do not corrupt a pending
+  batch.
+
+## Open Decisions
+
+- Owner TBD: confirm whether this module already has a GitHub issue.
+- Owner TBD: migrate unresolved comments from the old RFC into this document.
+- Owner TBD: confirm the behavior class before opening the red PR.
+
+## Done
+
+- [ ] Consumer or profile evidence attached.
+- [ ] Queue-agnostic collector design approved.
+- [ ] Red PR isolated.
+- [ ] All concurrency invariants tested.

--- a/docs/design/simple_scheduler_batching.md
+++ b/docs/design/simple_scheduler_batching.md
@@ -1,10 +1,6 @@
-# 07_simple_scheduler_batching
-
-## SimpleScheduler Concurrent Batching
+# SimpleScheduler Concurrent Batching
 
 Status: Draft
-
-Top-level module: M7
 
 Behavior level: Red
 
@@ -28,7 +24,7 @@ real consumer and profiling evidence.
 ## Non-scope
 
 - This is not a simple deletion of the current guard.
-- Do not mix this with T2 or T5 work.
+- Do not mix this with unrelated transport or scheduler work.
 - Do not implement runtime scheduler changes without a consumer or profiling
   evidence.
 
@@ -52,10 +48,10 @@ accounting, and per-request error ownership.
 
 ## Migration Plan
 
-1. Attach consumer or profile evidence. M4B is one possible consumer, but only
-   after reference-encode profiling shows different-key batching is useful.
+1. Attach consumer or profile evidence. Different-key reference batching is one
+   possible consumer, but only after profiling shows the batched path is useful.
 2. Write a design for the queue-agnostic collector and get it reviewed.
-3. Add contract tests first in an isolated red PR.
+3. Add contract tests first in an isolated behavior PR.
 4. Modify `SimpleScheduler` only after the contract is accepted.
 5. Keep the old `max_concurrency=1` batching behavior unchanged.
 

--- a/docs/developer_reference/pipeline.md
+++ b/docs/developer_reference/pipeline.md
@@ -108,8 +108,8 @@ It supports a batch compute function for stages where local batching is
 useful. Today that local batching path is serial: `batch_compute_fn` is
 supported with `max_concurrency=1`, while `max_concurrency > 1` is only for
 non-batched `compute_fn` execution. Concurrent local batching is tracked by
-`docs/design/07_simple_scheduler_batching.md` and should only be implemented
-after a real consumer and profile evidence justify the extra scheduler surface.
+`docs/design/simple_scheduler_batching.md` and should only be implemented after
+a real consumer and profile evidence justify the extra scheduler surface.
 
 #### Code2WavScheduler
 

--- a/docs/developer_reference/pipeline.md
+++ b/docs/developer_reference/pipeline.md
@@ -105,7 +105,11 @@ inbox.get() -> compute function -> outbox.put(result or error)
 ```
 
 It supports a batch compute function for stages where local batching is
-useful.
+useful. Today that local batching path is serial: `batch_compute_fn` is
+supported with `max_concurrency=1`, while `max_concurrency > 1` is only for
+non-batched `compute_fn` execution. Concurrent local batching is tracked by
+`docs/design/07_simple_scheduler_batching.md` and should only be implemented
+after a real consumer and profile evidence justify the extra scheduler surface.
 
 #### Code2WavScheduler
 

--- a/docs/developer_reference/profiler.md
+++ b/docs/developer_reference/profiler.md
@@ -172,7 +172,8 @@ stream:
    not consume the opener of pair B.
 3. **Reference encode breakdown** — `ReferenceEncodeService` cache result
    counts (`hit`, `miss`, `merged`, `uncacheable`) plus leader encode and
-   same-key follower wait durations. Use this first when deciding whether
+   same-key follower wait durations. Encode latency percentiles include
+   successful encode attempts only. Use this first when deciding whether
    different-key reference encode batching is worth implementing.
 4. **Hop breakdown** — `stage_hop_sent` / `stage_input_received` and
    `stage_stream_chunk_sent` / `stage_stream_chunk_received` durations per
@@ -201,7 +202,8 @@ python -m benchmarks.eval.benchmark_tts_seedtts \
   --max-samples 64 \
   --output-dir results/m4b-gate-moss-local-c8 \
   --profile-request-events \
-  --profile-run-id m4b-gate-moss-local-c8
+  --profile-run-id m4b-gate-moss-local-c8 \
+  --require-reference-encode-profile
 ```
 
 ## Torch profiler

--- a/docs/developer_reference/profiler.md
+++ b/docs/developer_reference/profiler.md
@@ -175,6 +175,8 @@ stream:
    same-key follower wait durations. Encode latency percentiles include
    successful encode attempts only. Use this first when deciding whether
    different-key reference encode batching is worth implementing.
+   Uncacheable inputs have no cache key metadata, so they appear under the
+   unknown model and encoder bucket.
 4. **Hop breakdown** — `stage_hop_sent` / `stage_input_received` and
    `stage_stream_chunk_sent` / `stage_stream_chunk_received` durations per
    (source, destination, kind). Terminal stage stream chunks are paired the

--- a/docs/developer_reference/profiler.md
+++ b/docs/developer_reference/profiler.md
@@ -187,7 +187,9 @@ reconstructed even when each stage runs in its own process.
 For TTS reference-encode profiling, use the SeedTTS benchmark profile hook:
 run the benchmark where it can read the server-side event directory, or pass a
 shared `--profile-event-dir`. The benchmark fails if a non-empty run produces
-no readable request events.
+no readable request events. Profiling runs require `--warmup 0`; for M4B gate
+runs, `--require-reference-encode-profile` also requires at least one successful
+reference encode miss in the report.
 
 ```bash
 python -m benchmarks.eval.benchmark_tts_seedtts \

--- a/docs/developer_reference/profiler.md
+++ b/docs/developer_reference/profiler.md
@@ -176,7 +176,9 @@ stream:
    successful encode attempts only. Use this first when deciding whether
    different-key reference encode batching is worth implementing.
    Uncacheable inputs have no cache key metadata, so they appear under the
-   unknown model and encoder bucket.
+   unknown model and encoder bucket. The `failed` column counts per-request
+   reference encode failures, including same-key followers; it is not the same
+   as the service's leader-only `stats()["failed"]` counter.
 4. **Hop breakdown** — `stage_hop_sent` / `stage_input_received` and
    `stage_stream_chunk_sent` / `stage_stream_chunk_received` durations per
    (source, destination, kind). Terminal stage stream chunks are paired the
@@ -198,15 +200,13 @@ python -m benchmarks.eval.benchmark_tts_seedtts \
   --generate-only \
   --use-existing-server \
   --base-url http://localhost:8000 \
-  --model OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5 \
-  --ref-format references \
-  --token-count auto \
+  --model fishaudio/s2-pro \
   --warmup 0 \
   --concurrency 8 \
   --max-samples 64 \
-  --output-dir results/m4b-gate-moss-local-c8 \
+  --output-dir results/m4b-gate-fish-c8 \
   --profile-request-events \
-  --profile-run-id m4b-gate-moss-local-c8 \
+  --profile-run-id m4b-gate-fish-c8 \
   --require-reference-encode-profile
 ```
 

--- a/docs/developer_reference/profiler.md
+++ b/docs/developer_reference/profiler.md
@@ -73,6 +73,10 @@ Supporting events used for finer-grained breakdown:
 | Stage | `stage_hop_sent` | Payload `DataReadyMessage` sent to next stage |
 | Stage | `stage_stream_chunk_sent` | Each stream chunk (metadata `to_stage`, `chunk_id`, `modality`) |
 | Stage | `stage_stream_chunk_received` | Each stream chunk materialized and ready for the receiver scheduler, including coordinator terminal chunks |
+| Reference encode | `reference_encode_lookup` | Cache lookup result for `ReferenceEncodeService` (`hit`, `miss`, `merged`, or `uncacheable`) |
+| Reference encode | `reference_encode_start` / `reference_encode_end` | Leader encode interval for a cache miss or uncacheable item |
+| Reference encode | `reference_encode_wait_start` / `reference_encode_wait_end` | Same-key follower wait interval when a request merges onto an in-flight leader |
+| Reference encode | `reference_encode_failure` | Reference encode attempt failed, including encode, wait, store, or revalidate failures |
 | AR scheduler | `scheduler_queue_enter` | Built request entered the scheduler queue |
 | AR scheduler | `scheduler_first_emit` | First `stream_output_builder` emission per request |
 
@@ -155,7 +159,7 @@ python -m sglang_omni.profiler /tmp/profiles/demo-run/events --format table
 python -m sglang_omni.profiler /tmp/profiles/demo-run/events --format json --out report.json
 ```
 
-The CLI / `build_report` returns three views derived from the same event
+The CLI / `build_report` returns these views derived from the same event
 stream:
 
 1. **Timeline** — per-request event list with `t_rel_ms` anchored at
@@ -166,7 +170,11 @@ stream:
    against both `scheduler_first_emit` AND `stage_first_stream_chunk_sent`);
    every pair gets its own pending stack so a close event for pair A does
    not consume the opener of pair B.
-3. **Hop breakdown** — `stage_hop_sent` / `stage_input_received` and
+3. **Reference encode breakdown** — `ReferenceEncodeService` cache result
+   counts (`hit`, `miss`, `merged`, `uncacheable`) plus leader encode and
+   same-key follower wait durations. Use this first when deciding whether
+   different-key reference encode batching is worth implementing.
+4. **Hop breakdown** — `stage_hop_sent` / `stage_input_received` and
    `stage_stream_chunk_sent` / `stage_stream_chunk_received` durations per
    (source, destination, kind). Terminal stage stream chunks are paired the
    same way with destination `coordinator`.
@@ -174,6 +182,24 @@ stream:
 Hop pairs match across processes by `(request_id, source_stage, dest_stage,
 chunk_id?)`, so a single request's path through subprocesses can be
 reconstructed even when each stage runs in its own process.
+
+For TTS reference-encode profiling, use the SeedTTS benchmark profile hook:
+
+```bash
+python -m benchmarks.eval.benchmark_tts_seedtts \
+  --generate-only \
+  --use-existing-server \
+  --base-url http://localhost:8000 \
+  --model OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5 \
+  --ref-format references \
+  --token-count auto \
+  --warmup 0 \
+  --concurrency 8 \
+  --max-samples 64 \
+  --output-dir results/m4b-gate-moss-local-c8 \
+  --profile-request-events \
+  --profile-run-id m4b-gate-moss-local-c8
+```
 
 ## Torch profiler
 

--- a/docs/developer_reference/profiler.md
+++ b/docs/developer_reference/profiler.md
@@ -184,6 +184,9 @@ chunk_id?)`, so a single request's path through subprocesses can be
 reconstructed even when each stage runs in its own process.
 
 For TTS reference-encode profiling, use the SeedTTS benchmark profile hook:
+run the benchmark where it can read the server-side event directory, or pass a
+shared `--profile-event-dir`. The benchmark fails if a non-empty run produces
+no readable request events.
 
 ```bash
 python -m benchmarks.eval.benchmark_tts_seedtts \

--- a/docs/developer_reference/profiler.md
+++ b/docs/developer_reference/profiler.md
@@ -191,9 +191,9 @@ reconstructed even when each stage runs in its own process.
 For TTS reference-encode profiling, use the SeedTTS benchmark profile hook:
 run the benchmark where it can read the server-side event directory, or pass a
 shared `--profile-event-dir`. The benchmark fails if a non-empty run produces
-no readable request events. Profiling runs require `--warmup 0`; for M4B gate
-runs, `--require-reference-encode-profile` also requires at least one successful
-reference encode miss in the report.
+no readable request events. Profiling runs require `--warmup 0`; for reference
+batching gate runs, `--require-reference-encode-profile` also requires at least
+one successful reference encode miss in the report.
 
 ```bash
 python -m benchmarks.eval.benchmark_tts_seedtts \
@@ -204,9 +204,9 @@ python -m benchmarks.eval.benchmark_tts_seedtts \
   --warmup 0 \
   --concurrency 8 \
   --max-samples 64 \
-  --output-dir results/m4b-gate-fish-c8 \
+  --output-dir results/reference-batch-gate-fish-c8 \
   --profile-request-events \
-  --profile-run-id m4b-gate-fish-c8 \
+  --profile-run-id reference-batch-gate-fish-c8 \
   --require-reference-encode-profile
 ```
 

--- a/docs/developer_reference/reference_encode_service.md
+++ b/docs/developer_reference/reference_encode_service.md
@@ -123,39 +123,39 @@ Leader failures are propagated to waiters and are not cached. The next request
 can retry as a new leader. A follower timeout does not remove the leader's
 in-flight entry.
 
-## M4a And M4b Boundary
+## Cache And Batch Boundary
 
-This document covers **M4a only**: the ad-hoc reference cache and same-key
-single-flight that ships today.
+This document covers the ad-hoc reference cache and same-key single-flight that
+ship today.
 
-**M4b (different-key batch coalescing) is not implemented and is a non-goal
-here**; it is described only to mark the scope boundary. Do not add M4b runtime
-code until profiling proves it is worth the extra scheduling surface.
+Different-key batch coalescing is not implemented and is a non-goal here; it is
+described only to mark the scope boundary. Do not add runtime batching until
+profiling proves it is worth the extra scheduling surface.
 
-Before building M4b, run cold-cache workloads with different reference audio per
-request at concurrency 8 and 16 for FishAudio S2-Pro, Qwen3-TTS, and
-MOSS-TTS Local. Track preprocessing/reference-encode p50/p95, end-to-end TTFA
-and latency, throughput, cache hit/miss/merge counts, and GPU/CPU utilization.
-Use the SeedTTS benchmark with `--profile-request-events` so the profiler report
+Before building it, run cold-cache workloads with different reference audio per
+request at concurrency 8 and 16 for FishAudio S2-Pro, Qwen3-TTS, and MOSS-TTS
+Local. Track preprocessing/reference-encode p50/p95, end-to-end TTFA and
+latency, throughput, cache hit/miss/merge counts, and GPU/CPU utilization. Use
+the SeedTTS benchmark with `--profile-request-events` so the profiler report
 includes `reference_encode_breakdown`. Run the benchmark where it can read the
-server-side event directory, or pass a shared `--profile-event-dir`. For M4b
+server-side event directory, or pass a shared `--profile-event-dir`. For batch
 gate runs, also pass `--require-reference-encode-profile` so a run without
-successful reference encode miss events fails loudly. Profile gate runs must
-use `--warmup 0` so warmup requests do not populate the reference cache inside
-the profiling window. Uncacheable inputs still report encode time, but they do
-not count as M4b gate cache misses and appear in the unknown profiler bucket.
-Build M4b for a model only if different-key reference encode remains a top
+successful reference encode miss events fails loudly. Profile gate runs must use
+`--warmup 0` so warmup requests do not populate the reference cache inside the
+profiling window. Uncacheable inputs still report encode time, but they do not
+count as batch gate cache misses and appear in the unknown profiler bucket.
+Build different-key batching for a model only if reference encode remains a top
 bottleneck and batching gives at least 15% p95 latency reduction or 20%
-throughput improvement versus M4a.
+throughput improvement versus the cache plus same-key merge path.
 
-If M4b is built later, it should be an opt-in extension of
-`ReferenceEncodeService`, not the default path:
+If different-key reference batching is built later, it should be an opt-in
+extension of `ReferenceEncodeService`, not the default path:
 
 - add explicit hook capability, for example `can_encode_batch()` defaulting to
   `False`, and call `encode_batch(items)` only for hooks that opt in;
 - add service knobs such as `max_batch_size=1` and `max_batch_wait_ms=0`;
-- preserve M4a ordering: normalize input, compute cache key, check cache,
-  merge same-key inflight work, and only then enqueue distinct cache-miss
+- preserve cache-first ordering: normalize input, compute cache key, check
+  cache, merge same-key inflight work, and only then enqueue distinct cache-miss
   leaders for different-key batching;
 - use an internal queue that drains up to `max_batch_size` or
   `max_batch_wait_ms`, calls one hook batch encode, and then stores,
@@ -168,15 +168,16 @@ batched reference encoder and should not be migrated just to fit this generic
 surface. FishAudio S2-Pro is the first plausible candidate only if profiling
 shows real benefit; its batched path would decode/resample each reference, pad
 waveforms, call the codec once, and split outputs while preserving parity with
-`encode_one`. Qwen3-TTS should remain M4a-only unless the upstream wrapper
-exposes a safe batch primitive for `create_voice_clone_prompt`.
+`encode_one`. Qwen3-TTS should stay on cache plus same-key merge unless the
+upstream wrapper exposes a safe batch primitive for `create_voice_clone_prompt`.
 
-If M4b needs shared scheduler support instead of an internal service queue, use
-the M7 design in `docs/design/07_simple_scheduler_batching.md`. Do not remove
-the current `SimpleScheduler` guard as part of M4b profiling prep; M7 requires
-its own design review and red contract tests.
+If different-key reference batching needs shared scheduler support instead of an
+internal service queue, use the design in
+`docs/design/simple_scheduler_batching.md`. Do not remove the current
+`SimpleScheduler` guard as part of reference profiling prep; concurrent batching
+requires its own design review and behavior contract tests.
 
 When profiling MOSS-TTS Local anyway, keep the reference-audio cache enabled.
 The reported miss encode time includes its existing `_BatchedReferenceEncoder`
 queue and batch behavior, so compare it as evidence for whether any additional
-generic M4b surface is still needed, not as a clean no-batch baseline.
+generic batch surface is still needed, not as a clean no-batch baseline.

--- a/docs/developer_reference/reference_encode_service.md
+++ b/docs/developer_reference/reference_encode_service.md
@@ -140,7 +140,9 @@ Use the SeedTTS benchmark with `--profile-request-events` so the profiler report
 includes `reference_encode_breakdown`. Run the benchmark where it can read the
 server-side event directory, or pass a shared `--profile-event-dir`. For M4b
 gate runs, also pass `--require-reference-encode-profile` so a run without
-reference encode events fails loudly.
+successful reference encode miss events fails loudly. Profile gate runs must
+use `--warmup 0` so warmup requests do not populate the reference cache inside
+the profiling window.
 Build M4b for a model only if different-key reference encode remains a top
 bottleneck and batching gives at least 15% p95 latency reduction or 20%
 throughput improvement versus M4a.

--- a/docs/developer_reference/reference_encode_service.md
+++ b/docs/developer_reference/reference_encode_service.md
@@ -137,7 +137,8 @@ request at concurrency 8 and 16 for FishAudio S2-Pro, Qwen3-TTS, and
 MOSS-TTS Local. Track preprocessing/reference-encode p50/p95, end-to-end TTFA
 and latency, throughput, cache hit/miss/merge counts, and GPU/CPU utilization.
 Use the SeedTTS benchmark with `--profile-request-events` so the profiler report
-includes `reference_encode_breakdown`.
+includes `reference_encode_breakdown`. Run the benchmark where it can read the
+server-side event directory, or pass a shared `--profile-event-dir`.
 Build M4b for a model only if different-key reference encode remains a top
 bottleneck and batching gives at least 15% p95 latency reduction or 20%
 throughput improvement versus M4a.

--- a/docs/developer_reference/reference_encode_service.md
+++ b/docs/developer_reference/reference_encode_service.md
@@ -138,7 +138,9 @@ MOSS-TTS Local. Track preprocessing/reference-encode p50/p95, end-to-end TTFA
 and latency, throughput, cache hit/miss/merge counts, and GPU/CPU utilization.
 Use the SeedTTS benchmark with `--profile-request-events` so the profiler report
 includes `reference_encode_breakdown`. Run the benchmark where it can read the
-server-side event directory, or pass a shared `--profile-event-dir`.
+server-side event directory, or pass a shared `--profile-event-dir`. For M4b
+gate runs, also pass `--require-reference-encode-profile` so a run without
+reference encode events fails loudly.
 Build M4b for a model only if different-key reference encode remains a top
 bottleneck and batching gives at least 15% p95 latency reduction or 20%
 throughput improvement versus M4a.

--- a/docs/developer_reference/reference_encode_service.md
+++ b/docs/developer_reference/reference_encode_service.md
@@ -171,6 +171,11 @@ waveforms, call the codec once, and split outputs while preserving parity with
 `encode_one`. Qwen3-TTS should remain M4a-only unless the upstream wrapper
 exposes a safe batch primitive for `create_voice_clone_prompt`.
 
+If M4b needs shared scheduler support instead of an internal service queue, use
+the M7 design in `docs/design/07_simple_scheduler_batching.md`. Do not remove
+the current `SimpleScheduler` guard as part of M4b profiling prep; M7 requires
+its own design review and red contract tests.
+
 When profiling MOSS-TTS Local anyway, keep the reference-audio cache enabled.
 The reported miss encode time includes its existing `_BatchedReferenceEncoder`
 queue and batch behavior, so compare it as evidence for whether any additional

--- a/docs/developer_reference/reference_encode_service.md
+++ b/docs/developer_reference/reference_encode_service.md
@@ -170,3 +170,8 @@ shows real benefit; its batched path would decode/resample each reference, pad
 waveforms, call the codec once, and split outputs while preserving parity with
 `encode_one`. Qwen3-TTS should remain M4a-only unless the upstream wrapper
 exposes a safe batch primitive for `create_voice_clone_prompt`.
+
+When profiling MOSS-TTS Local anyway, keep the reference-audio cache enabled.
+The reported miss encode time includes its existing `_BatchedReferenceEncoder`
+queue and batch behavior, so compare it as evidence for whether any additional
+generic M4b surface is still needed, not as a clean no-batch baseline.

--- a/docs/developer_reference/reference_encode_service.md
+++ b/docs/developer_reference/reference_encode_service.md
@@ -8,7 +8,8 @@ encoding:
 - same-key single-flight while an encode is in progress;
 - failure propagation to waiters without caching failures;
 - artifact store/load conversion and caller-owned return values;
-- basic cache statistics.
+- basic cache statistics;
+- optional request-profiler events when callers pass a request id.
 
 The service is for ad-hoc request references. Registered or uploaded voices
 continue to use `SpeakerArtifactCache`, because they have a different lifetime,
@@ -40,7 +41,13 @@ class ReferenceEncodeHook(Generic[InputT, ArtifactT, StoredT]):
 
 
 class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
-    def get_or_encode(self, raw_input: Any, *, desc: str | None = None) -> ArtifactT: ...
+    def get_or_encode(
+        self,
+        raw_input: Any,
+        *,
+        desc: str | None = None,
+        request_id: str | None = None,
+    ) -> ArtifactT: ...
     def stats(self) -> dict[str, int]: ...
 ```
 
@@ -58,6 +65,7 @@ The service owns mechanics:
 - cache insertion, byte budget, and LRU eviction;
 - follower waits, timeout handling, and exception fanout;
 - no-poison-on-failure behavior;
+- request-profiler events for cache lookup, leader encode, follower wait, and failures;
 - stats for hits, misses, merges, failures, uncacheable inputs, entries, bytes,
   and evictions.
 
@@ -128,6 +136,8 @@ Before building M4b, run cold-cache workloads with different reference audio per
 request at concurrency 8 and 16 for FishAudio S2-Pro, Qwen3-TTS, and
 MOSS-TTS Local. Track preprocessing/reference-encode p50/p95, end-to-end TTFA
 and latency, throughput, cache hit/miss/merge counts, and GPU/CPU utilization.
+Use the SeedTTS benchmark with `--profile-request-events` so the profiler report
+includes `reference_encode_breakdown`.
 Build M4b for a model only if different-key reference encode remains a top
 bottleneck and batching gives at least 15% p95 latency reduction or 20%
 throughput improvement versus M4a.

--- a/docs/developer_reference/reference_encode_service.md
+++ b/docs/developer_reference/reference_encode_service.md
@@ -142,7 +142,8 @@ server-side event directory, or pass a shared `--profile-event-dir`. For M4b
 gate runs, also pass `--require-reference-encode-profile` so a run without
 successful reference encode miss events fails loudly. Profile gate runs must
 use `--warmup 0` so warmup requests do not populate the reference cache inside
-the profiling window.
+the profiling window. Uncacheable inputs still report encode time, but they do
+not count as M4b gate cache misses and appear in the unknown profiler bucket.
 Build M4b for a model only if different-key reference encode remains a top
 bottleneck and batching gives at least 15% p95 latency reduction or 20%
 throughput improvement versus M4a.

--- a/docs/developer_reference/tts_model_integration.md
+++ b/docs/developer_reference/tts_model_integration.md
@@ -154,7 +154,7 @@ Pick by responsibility:
 - `SimpleScheduler` - a single callable, optionally batched via
   `batch_compute_fn` when `max_concurrency=1`. Concurrent non-batched execution
   uses `max_concurrency > 1`; combining concurrency with local batching belongs
-  to the M7 design in `docs/design/07_simple_scheduler_batching.md`.
+  in `docs/design/simple_scheduler_batching.md`.
 - `OmniScheduler` - wraps SGLang's prefill/decode managers, KV cache, and
   request-limit machinery. Use it for AR generation.
 - A custom scheduler - when neither of the above fits (stateful streaming

--- a/docs/developer_reference/tts_model_integration.md
+++ b/docs/developer_reference/tts_model_integration.md
@@ -152,7 +152,9 @@ abort(request_id: str) -> None
 Pick by responsibility:
 
 - `SimpleScheduler` - a single callable, optionally batched via
-  `batch_compute_fn`. Right for preprocessing and most vocoders.
+  `batch_compute_fn` when `max_concurrency=1`. Concurrent non-batched execution
+  uses `max_concurrency > 1`; combining concurrency with local batching belongs
+  to the M7 design in `docs/design/07_simple_scheduler_batching.md`.
 - `OmniScheduler` - wraps SGLang's prefill/decode managers, KV cache, and
   request-limit machinery. Use it for AR generation.
 - A custom scheduler - when neither of the above fits (stateful streaming

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -263,6 +263,7 @@ def create_preprocessing_executor(
                     vq_codes = reference_encode_service.get_or_encode(
                         ref_data,
                         desc="FishAudio S2-Pro reference",
+                        request_id=payload.request_id,
                     )
                 references.append(
                     Reference(

--- a/sglang_omni/models/moss_tts_local/request_builders.py
+++ b/sglang_omni/models/moss_tts_local/request_builders.py
@@ -250,15 +250,19 @@ def _build_processor_message(
     processor: Any,
     state: MossTTSLocalState,
     reference_encoder: Any = None,
+    *,
+    request_id: str | None = None,
 ) -> dict[str, Any]:
     ref_audio = state.ref_audio
     if reference_encoder is not None and isinstance(ref_audio, str):
         if _DATA_URI_RE.match(ref_audio) is None:
             # File-path refs share one batched codec forward via the coalescer.
-            reference = [reference_encoder.encode(ref_audio)]
+            reference = [reference_encoder.encode(ref_audio, request_id=request_id)]
         else:
             # Data-URI refs through the same LRU (bytes: keyspace).
-            reference = [reference_encoder.encode_data_uri(ref_audio)]
+            reference = [
+                reference_encoder.encode_data_uri(ref_audio, request_id=request_id)
+            ]
     else:
         reference = _reference_for_processor(processor, ref_audio)
     return processor.build_user_message(
@@ -277,7 +281,12 @@ def _prepare_moss_tts_local_request(
     reference_encoder: Any = None,
 ) -> MossTTSLocalPreparedRequest:
     state = build_moss_tts_local_state(payload)
-    message = _build_processor_message(processor, state, reference_encoder)
+    message = _build_processor_message(
+        processor,
+        state,
+        reference_encoder,
+        request_id=payload.request_id,
+    )
     batch = processor([[message]], mode="generation")
     input_rows = batch["input_ids"]
     if input_rows.ndim != 3 or int(input_rows.shape[0]) != 1:

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -277,8 +277,9 @@ class _BatchedReferenceEncoder:
             )
         return torch.from_numpy(audio.T), int(sample_rate)
 
-    def encode(self, path: str) -> torch.Tensor:
+    def encode(self, path: str, *, request_id: str | None = None) -> torch.Tensor:
         """Encode one reference file; blocks until its batch completes."""
+        _ = request_id
         path = str(path)
         self._check_reference_duration(path)
         future: concurrent.futures.Future = concurrent.futures.Future()
@@ -290,7 +291,10 @@ class _BatchedReferenceEncoder:
         self._queue.put((_WaveformReferenceJob(wav, int(sample_rate)), future))
         return future.result(timeout=self.ENCODE_TIMEOUT_S)
 
-    def encode_data_uri(self, ref_audio: str) -> torch.Tensor:
+    def encode_data_uri(
+        self, ref_audio: str, *, request_id: str | None = None
+    ) -> torch.Tensor:
+        _ = request_id
         raw = self._data_uri_audio_bytes(ref_audio)
         wav, sample_rate = self._decode_data_uri_audio(raw)
         return self.encode_wav(wav, sample_rate)
@@ -477,17 +481,21 @@ class _MossLocalReferenceEncoder:
             log_prefix="MOSS-TTS Local ref cache",
         )
 
-    def encode(self, path: str) -> torch.Tensor:
+    def encode(self, path: str, *, request_id: str | None = None) -> torch.Tensor:
         return self._service.get_or_encode(
             _MossLocalReferenceInput("path", str(path)),
             desc=repr(str(path)),
+            request_id=request_id,
         )
 
-    def encode_data_uri(self, ref_audio: str) -> torch.Tensor:
+    def encode_data_uri(
+        self, ref_audio: str, *, request_id: str | None = None
+    ) -> torch.Tensor:
         raw = _BatchedReferenceEncoder._data_uri_audio_bytes(ref_audio)
         return self._service.get_or_encode(
             _MossLocalReferenceInput("data_uri", str(ref_audio), raw),
             desc="data-URI",
+            request_id=request_id,
         )
 
     def stats(self) -> dict[str, int]:

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -766,6 +766,7 @@ def _prepare_qwen3_tts_base_request(
     state: Qwen3TTSState,
     model: Any,
     wrapper: Any,
+    request_id: str | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
     speaker_cache = get_speaker_artifact_cache()
     cache_key = _qwen3_tts_uploaded_voice_cache_key(state)
@@ -782,6 +783,7 @@ def _prepare_qwen3_tts_base_request(
         voice_clone_prompt, ref_text = reference_service.get_or_encode(
             state,
             desc="Qwen3-TTS ad-hoc reference",
+            request_id=request_id,
         )
     else:
         with torch.no_grad():
@@ -875,6 +877,7 @@ def _prepare_qwen3_tts_request(
             state=state,
             model=model,
             wrapper=wrapper,
+            request_id=payload.request_id,
         )
     elif state.task_type == QWEN3_TTS_TASK_CUSTOM_VOICE:
         (

--- a/sglang_omni/profiler/__main__.py
+++ b/sglang_omni/profiler/__main__.py
@@ -49,6 +49,21 @@ def _main(argv: list[str] | None = None) -> int:
                 report["stage_breakdown"],
                 ["stage", "interval", "count", "total_ms", "avg_ms", "p95_ms"],
             )
+            + "\n## Reference encode breakdown\n"
+            + format_table(
+                report["reference_encode_breakdown"],
+                [
+                    "stage",
+                    "model_id",
+                    "lookups",
+                    "hits",
+                    "misses",
+                    "merged",
+                    "uncacheable",
+                    "encode_p95_ms",
+                    "wait_p95_ms",
+                ],
+            )
             + "\n## Hop breakdown\n"
             + format_table(
                 report["hop_breakdown"],

--- a/sglang_omni/profiler/views.py
+++ b/sglang_omni/profiler/views.py
@@ -407,7 +407,8 @@ def reference_encode_breakdown(
                 stack = pending.get(("wait", key))
                 if stack:
                     open_ns, _ = stack.pop(0)
-                    wait_durations[key].append((ts - open_ns) / 1e6)
+                    if md.get("result") not in ("error", "timeout"):
+                        wait_durations[key].append((ts - open_ns) / 1e6)
 
     keys = set(lookups) | set(encode_durations) | set(wait_durations) | set(failures)
     rows: list[ReferenceEncodeBreakdownRow] = []

--- a/sglang_omni/profiler/views.py
+++ b/sglang_omni/profiler/views.py
@@ -397,7 +397,8 @@ def reference_encode_breakdown(
                 stack = pending.get(("encode", key))
                 if stack:
                     open_ns, _ = stack.pop(0)
-                    encode_durations[key].append((ts - open_ns) / 1e6)
+                    if md.get("result") != "error":
+                        encode_durations[key].append((ts - open_ns) / 1e6)
             elif name == "reference_encode_failure":
                 failures[key] += 1
             elif name == "reference_encode_wait_start":

--- a/sglang_omni/profiler/views.py
+++ b/sglang_omni/profiler/views.py
@@ -278,7 +278,189 @@ def stage_breakdown(
 
 
 # ---------------------------------------------------------------------------
-# View 3: hop breakdown (stage_a -> stage_b)
+# View 3: reference encode breakdown
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ReferenceEncodeBreakdownRow:
+    stage: str
+    model_id: str
+    encoder_id: str
+    artifact_kind: str
+    lookups: int
+    hits: int
+    misses: int
+    merged: int
+    uncacheable: int
+    failed: int
+    encode_count: int
+    encode_total_ms: float
+    encode_avg_ms: float
+    encode_p50_ms: float
+    encode_p95_ms: float
+    encode_max_ms: float
+    wait_count: int
+    wait_total_ms: float
+    wait_avg_ms: float
+    wait_p50_ms: float
+    wait_p95_ms: float
+    wait_max_ms: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "stage": self.stage,
+            "model_id": self.model_id,
+            "encoder_id": self.encoder_id,
+            "artifact_kind": self.artifact_kind,
+            "lookups": self.lookups,
+            "hits": self.hits,
+            "misses": self.misses,
+            "merged": self.merged,
+            "uncacheable": self.uncacheable,
+            "failed": self.failed,
+            "encode_count": self.encode_count,
+            "encode_total_ms": round(self.encode_total_ms, 3),
+            "encode_avg_ms": round(self.encode_avg_ms, 3),
+            "encode_p50_ms": round(self.encode_p50_ms, 3),
+            "encode_p95_ms": round(self.encode_p95_ms, 3),
+            "encode_max_ms": round(self.encode_max_ms, 3),
+            "wait_count": self.wait_count,
+            "wait_total_ms": round(self.wait_total_ms, 3),
+            "wait_avg_ms": round(self.wait_avg_ms, 3),
+            "wait_p50_ms": round(self.wait_p50_ms, 3),
+            "wait_p95_ms": round(self.wait_p95_ms, 3),
+            "wait_max_ms": round(self.wait_max_ms, 3),
+        }
+
+
+def _reference_bucket_key(ev: dict[str, Any]) -> tuple[str, str, str, str]:
+    md = ev.get("metadata") or {}
+    return (
+        str(ev.get("stage") or "unknown"),
+        str(md.get("model_id") or "unknown"),
+        str(md.get("encoder_id") or "unknown"),
+        str(md.get("artifact_kind") or "unknown"),
+    )
+
+
+def _duration_stats(
+    values: list[float],
+) -> tuple[int, float, float, float, float, float]:
+    if not values:
+        return 0, 0.0, 0.0, 0.0, 0.0, 0.0
+    values.sort()
+    total = sum(values)
+    return (
+        len(values),
+        total,
+        total / len(values),
+        _percentile(values, 0.50),
+        _percentile(values, 0.95),
+        values[-1],
+    )
+
+
+def reference_encode_breakdown(
+    timelines: dict[str, RequestTimeline] | None = None,
+    *,
+    source: str | Path | Iterable[str | Path] | None = None,
+) -> list[ReferenceEncodeBreakdownRow]:
+    """Aggregate ReferenceEncodeService cache and timing events."""
+    if timelines is None:
+        if source is None:
+            raise ValueError("reference_encode_breakdown requires timelines or source")
+        timelines = reconstruct_timelines(source)
+
+    lookups: dict[tuple[str, str, str, str], dict[str, int]] = defaultdict(
+        lambda: defaultdict(int)
+    )
+    encode_durations: dict[tuple[str, str, str, str], list[float]] = defaultdict(list)
+    wait_durations: dict[tuple[str, str, str, str], list[float]] = defaultdict(list)
+    failures: dict[tuple[str, str, str, str], int] = defaultdict(int)
+
+    for tl in timelines.values():
+        pending: dict[
+            tuple[str, tuple[str, str, str, str]], list[tuple[int, dict[str, Any]]]
+        ] = defaultdict(list)
+        for ev in tl.events:
+            name = ev.get("event_name")
+            key = _reference_bucket_key(ev)
+            ts = int(ev.get("timestamp_ns", 0))
+            md = ev.get("metadata") or {}
+            if name == "reference_encode_lookup":
+                result = str(md.get("result") or "unknown")
+                lookups[key][result] += 1
+            elif name == "reference_encode_start":
+                pending[("encode", key)].append((ts, md))
+            elif name == "reference_encode_end":
+                stack = pending.get(("encode", key))
+                if stack:
+                    open_ns, _ = stack.pop(0)
+                    encode_durations[key].append((ts - open_ns) / 1e6)
+            elif name == "reference_encode_failure":
+                failures[key] += 1
+            elif name == "reference_encode_wait_start":
+                pending[("wait", key)].append((ts, md))
+            elif name == "reference_encode_wait_end":
+                stack = pending.get(("wait", key))
+                if stack:
+                    open_ns, _ = stack.pop(0)
+                    wait_durations[key].append((ts - open_ns) / 1e6)
+
+    keys = set(lookups) | set(encode_durations) | set(wait_durations) | set(failures)
+    rows: list[ReferenceEncodeBreakdownRow] = []
+    for key in keys:
+        stage, model_id, encoder_id, artifact_kind = key
+        lookup = lookups.get(key, {})
+        (
+            encode_count,
+            encode_total,
+            encode_avg,
+            encode_p50,
+            encode_p95,
+            encode_max,
+        ) = _duration_stats(encode_durations.get(key, []))
+        (
+            wait_count,
+            wait_total,
+            wait_avg,
+            wait_p50,
+            wait_p95,
+            wait_max,
+        ) = _duration_stats(wait_durations.get(key, []))
+        rows.append(
+            ReferenceEncodeBreakdownRow(
+                stage=stage,
+                model_id=model_id,
+                encoder_id=encoder_id,
+                artifact_kind=artifact_kind,
+                lookups=sum(lookup.values()),
+                hits=lookup.get("hit", 0),
+                misses=lookup.get("miss", 0),
+                merged=lookup.get("merged", 0),
+                uncacheable=lookup.get("uncacheable", 0),
+                failed=failures.get(key, 0),
+                encode_count=encode_count,
+                encode_total_ms=encode_total,
+                encode_avg_ms=encode_avg,
+                encode_p50_ms=encode_p50,
+                encode_p95_ms=encode_p95,
+                encode_max_ms=encode_max,
+                wait_count=wait_count,
+                wait_total_ms=wait_total,
+                wait_avg_ms=wait_avg,
+                wait_p50_ms=wait_p50,
+                wait_p95_ms=wait_p95,
+                wait_max_ms=wait_max,
+            )
+        )
+    rows.sort(key=lambda r: (-r.encode_total_ms, -r.wait_total_ms, r.stage))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# View 4: hop breakdown (stage_a -> stage_b)
 # ---------------------------------------------------------------------------
 
 
@@ -386,11 +568,14 @@ def hop_breakdown(
 
 
 def build_report(source: str | Path | Iterable[str | Path]) -> dict[str, Any]:
-    """Return all three views as a single dict for JSON serialization."""
+    """Return all profiler views as a single dict for JSON serialization."""
     timelines = reconstruct_timelines(source)
     return {
         "timelines": {rid: tl.to_relative() for rid, tl in timelines.items()},
         "stage_breakdown": [row.to_dict() for row in stage_breakdown(timelines)],
+        "reference_encode_breakdown": [
+            row.to_dict() for row in reference_encode_breakdown(timelines)
+        ],
         "hop_breakdown": [row.to_dict() for row in hop_breakdown(timelines)],
         "request_count": len(timelines),
     }

--- a/sglang_omni/scheduling/reference_encoder.py
+++ b/sglang_omni/scheduling/reference_encoder.py
@@ -9,6 +9,7 @@ import time
 from dataclasses import asdict, dataclass
 from typing import Any, Generic, TypeVar
 
+from sglang_omni.profiler.event_recorder import emit as _emit_profiler_event
 from sglang_omni.scheduling.stage_cache import StageOutputCache
 
 logger = logging.getLogger(__name__)
@@ -97,60 +98,194 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
         self._uncacheable = 0
         self._last_log_time = 0.0
 
-    def get_or_encode(self, raw_input: Any, *, desc: str | None = None) -> ArtifactT:
+    @staticmethod
+    def _event_metadata(
+        key: ReferenceEncodeKey | None,
+        **extra: Any,
+    ) -> dict[str, Any]:
+        metadata = {name: value for name, value in extra.items() if value is not None}
+        if key is not None:
+            metadata.update(
+                {
+                    "model_id": key.model_id,
+                    "encoder_id": key.encoder_id,
+                    "artifact_kind": key.artifact_kind,
+                }
+            )
+        return metadata
+
+    @staticmethod
+    def _emit_event(
+        request_id: str | None,
+        event_name: str,
+        *,
+        key: ReferenceEncodeKey | None = None,
+        **metadata: Any,
+    ) -> None:
+        if request_id is None:
+            return
+        _emit_profiler_event(
+            request_id=str(request_id),
+            stage=None,
+            event_name=event_name,
+            metadata=ReferenceEncodeService._event_metadata(key, **metadata),
+        )
+
+    def get_or_encode(
+        self,
+        raw_input: Any,
+        *,
+        desc: str | None = None,
+        request_id: str | None = None,
+    ) -> ArtifactT:
         item = self._hook.normalize_input(raw_input)
         key = self._hook.cache_key(item)
         if key is None:
             with self._lock:
                 self._uncacheable += 1
+            self._emit_event(
+                request_id,
+                "reference_encode_lookup",
+                result="uncacheable",
+            )
+            self._emit_event(
+                request_id,
+                "reference_encode_start",
+                result="uncacheable",
+            )
             try:
-                return self._hook.encode_one(item)
+                artifact = self._hook.encode_one(item)
             except BaseException as exc:
                 self._add_exception_note(exc, desc)
                 with self._lock:
                     self._failed += 1
+                self._emit_event(
+                    request_id,
+                    "reference_encode_end",
+                    result="error",
+                    error_type=type(exc).__name__,
+                )
+                self._emit_event(
+                    request_id,
+                    "reference_encode_failure",
+                    result="error",
+                    phase="encode",
+                    cacheable=False,
+                    error_type=type(exc).__name__,
+                )
                 raise
+            self._emit_event(
+                request_id,
+                "reference_encode_end",
+                result="success",
+                cacheable=False,
+            )
+            return artifact
 
         cache_key = key.to_string()
         leader_fut: concurrent.futures.Future[StoredT] | None = None
         follower_fut: concurrent.futures.Future[StoredT] | None = None
         stored: StoredT | None = None
+        lookup_result: str
         with self._lock:
             stored = self._cache.get(cache_key)
             if stored is not None:
                 self._hits += 1
+                lookup_result = "hit"
             elif cache_key in self._inflight:
                 self._merged += 1
                 follower_fut = self._inflight[cache_key]
+                lookup_result = "merged"
             else:
                 self._misses += 1
                 leader_fut = concurrent.futures.Future()
                 self._inflight[cache_key] = leader_fut
+                lookup_result = "miss"
+
+        self._emit_event(
+            request_id,
+            "reference_encode_lookup",
+            key=key,
+            result=lookup_result,
+        )
 
         if stored is not None:
             self._maybe_log()
             return self._hook.load_artifact(stored)
 
         if follower_fut is not None:
+            self._emit_event(
+                request_id,
+                "reference_encode_wait_start",
+                key=key,
+                result="merged",
+            )
             try:
                 stored = follower_fut.result(timeout=self._timeout_s)
             except concurrent.futures.TimeoutError as exc:
                 self._add_exception_note(exc, desc)
+                self._emit_event(
+                    request_id,
+                    "reference_encode_wait_end",
+                    key=key,
+                    result="timeout",
+                )
+                self._emit_event(
+                    request_id,
+                    "reference_encode_failure",
+                    key=key,
+                    result="timeout",
+                    phase="wait",
+                    error_type=type(exc).__name__,
+                )
                 raise
             except BaseException as exc:
                 self._add_exception_note(exc, desc)
+                self._emit_event(
+                    request_id,
+                    "reference_encode_wait_end",
+                    key=key,
+                    result="error",
+                    error_type=type(exc).__name__,
+                )
+                self._emit_event(
+                    request_id,
+                    "reference_encode_failure",
+                    key=key,
+                    result="error",
+                    phase="wait",
+                    error_type=type(exc).__name__,
+                )
                 raise _fresh_exception(exc) from exc
+            self._emit_event(
+                request_id,
+                "reference_encode_wait_end",
+                key=key,
+                result="success",
+            )
             return self._hook.load_artifact(stored)
 
         assert leader_fut is not None
-        # revalidate() and cache.put() run inside the same guard as encode: any
-        # exception here must still drop the in-flight entry and fail the future,
-        # otherwise same-key followers block on a future that never resolves and
-        # every later request for this key re-follows a dead leader (permanent
-        # poison + timeout-length hangs). A hook's revalidate() may legitimately
-        # raise (e.g. a reference file mutated during the encode window).
+        # note (luojiaxuan): revalidate and cache put share the encode guard.
+        # A failure must drop inflight and fail the future so same-key followers
+        # do not wait on a dead leader after a reference mutates mid-encode.
+        encode_event_closed = False
         try:
+            self._emit_event(
+                request_id,
+                "reference_encode_start",
+                key=key,
+                result="miss",
+            )
             artifact = self._hook.encode_one(item)
+            self._emit_event(
+                request_id,
+                "reference_encode_end",
+                key=key,
+                result="success",
+                cacheable=True,
+            )
+            encode_event_closed = True
             stored = self._hook.store_artifact(artifact)
             should_cache = self._hook.revalidate(item, key)
             with self._lock:
@@ -162,6 +297,22 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
             with self._lock:
                 self._inflight.pop(cache_key, None)
                 self._failed += 1
+            if not encode_event_closed:
+                self._emit_event(
+                    request_id,
+                    "reference_encode_end",
+                    key=key,
+                    result="error",
+                    error_type=type(exc).__name__,
+                )
+            self._emit_event(
+                request_id,
+                "reference_encode_failure",
+                key=key,
+                result="error",
+                phase="post_encode" if encode_event_closed else "encode",
+                error_type=type(exc).__name__,
+            )
             leader_fut.set_exception(exc)
             raise
         leader_fut.set_result(stored)

--- a/sglang_omni/scheduling/reference_encoder.py
+++ b/sglang_omni/scheduling/reference_encoder.py
@@ -9,10 +9,8 @@ import time
 from dataclasses import asdict, dataclass
 from typing import Any, Generic, TypeVar
 
-from sglang_omni.profiler.event_recorder import (
-    emit as _emit_profiler_event,
-    get_recorder as _get_event_recorder,
-)
+from sglang_omni.profiler.event_recorder import emit as _emit_profiler_event
+from sglang_omni.profiler.event_recorder import get_recorder as _get_event_recorder
 from sglang_omni.scheduling.stage_cache import StageOutputCache
 
 logger = logging.getLogger(__name__)

--- a/sglang_omni/scheduling/reference_encoder.py
+++ b/sglang_omni/scheduling/reference_encoder.py
@@ -9,7 +9,10 @@ import time
 from dataclasses import asdict, dataclass
 from typing import Any, Generic, TypeVar
 
-from sglang_omni.profiler.event_recorder import emit as _emit_profiler_event
+from sglang_omni.profiler.event_recorder import (
+    emit as _emit_profiler_event,
+    get_recorder as _get_event_recorder,
+)
 from sglang_omni.scheduling.stage_cache import StageOutputCache
 
 logger = logging.getLogger(__name__)
@@ -122,7 +125,7 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
         key: ReferenceEncodeKey | None = None,
         **metadata: Any,
     ) -> None:
-        if request_id is None:
+        if request_id is None or not _get_event_recorder().is_active():
             return
         _emit_profiler_event(
             request_id=str(request_id),

--- a/sglang_omni/scheduling/threaded_simple_scheduler.py
+++ b/sglang_omni/scheduling/threaded_simple_scheduler.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import inspect
 import logging
 import queue as _queue_mod
@@ -53,7 +54,8 @@ class ThreadedSimpleScheduler:
                 with self._lock:
                     if msg.request_id in self._aborted:
                         continue
-                    future = self._executor.submit(self._run_one, msg.data)
+                    context = contextvars.copy_context()
+                    future = self._executor.submit(context.run, self._run_one, msg.data)
                     self._pending[msg.request_id] = future
                 future.add_done_callback(
                     lambda fut, request_id=msg.request_id: self._finish(request_id, fut)

--- a/tests/unit_test/benchmarks/test_tts_seedtts_benchmark_config.py
+++ b/tests/unit_test/benchmarks/test_tts_seedtts_benchmark_config.py
@@ -44,3 +44,29 @@ def test_seedtts_benchmark_batch_args_are_independent() -> None:
     )
     assert results_config["max_running_requests"] == 32
     assert results_config["cuda_graph_max_bs"] == 128
+
+
+def test_seedtts_benchmark_profile_args_are_recorded() -> None:
+    config = _config_from_cli(
+        "--profile-request-events",
+        "--profile-run-id",
+        "m4b-gate",
+        "--profile-event-dir",
+        "/tmp/events",
+        "--profile-report-path",
+        "/tmp/report.json",
+    )
+
+    assert config.profile_request_events is True
+    assert config.profile_run_id == "m4b-gate"
+    assert config.profile_event_dir == "/tmp/events"
+    assert config.profile_report_path == "/tmp/report.json"
+
+    results_config = _build_results_config(
+        config,
+        base_url="http://localhost:8000",
+    )
+    assert results_config["profile_request_events"] is True
+    assert results_config["profile_run_id"] == "m4b-gate"
+    assert results_config["profile_event_dir"] == "/tmp/events"
+    assert results_config["profile_report_path"] == "/tmp/report.json"

--- a/tests/unit_test/benchmarks/test_tts_seedtts_benchmark_config.py
+++ b/tests/unit_test/benchmarks/test_tts_seedtts_benchmark_config.py
@@ -168,3 +168,51 @@ def test_seedtts_profile_report_can_require_successful_reference_encode(
             expect_events=True,
             expect_reference_encode=True,
         )
+
+
+def test_seedtts_profile_report_rejects_uncacheable_only_reference_encode(
+    tmp_path,
+) -> None:
+    event_dir = tmp_path / "events"
+    event_dir.mkdir()
+    events = [
+        {
+            "request_id": "r1",
+            "stage": "preprocessing",
+            "event_name": "reference_encode_lookup",
+            "timestamp_ns": 0,
+            "run_id": "run",
+            "pid": os.getpid(),
+            "metadata": {"result": "uncacheable"},
+        },
+        {
+            "request_id": "r1",
+            "stage": "preprocessing",
+            "event_name": "reference_encode_start",
+            "timestamp_ns": 1_000,
+            "run_id": "run",
+            "pid": os.getpid(),
+            "metadata": {"result": "uncacheable"},
+        },
+        {
+            "request_id": "r1",
+            "stage": "preprocessing",
+            "event_name": "reference_encode_end",
+            "timestamp_ns": 2_000,
+            "run_id": "run",
+            "pid": os.getpid(),
+            "metadata": {"result": "success"},
+        },
+    ]
+    (event_dir / "events_preprocessing_1.jsonl").write_text(
+        "".join(json.dumps(event) + "\n" for event in events),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="No successful reference encode misses"):
+        _write_request_profile_report(
+            event_dir=str(event_dir),
+            report_path=str(tmp_path / "report.json"),
+            expect_events=True,
+            expect_reference_encode=True,
+        )

--- a/tests/unit_test/benchmarks/test_tts_seedtts_benchmark_config.py
+++ b/tests/unit_test/benchmarks/test_tts_seedtts_benchmark_config.py
@@ -60,7 +60,7 @@ def test_seedtts_benchmark_profile_args_are_recorded() -> None:
         "--warmup",
         "0",
         "--profile-run-id",
-        "m4b-gate",
+        "reference-encode-gate",
         "--profile-event-dir",
         "/tmp/events",
         "--profile-report-path",
@@ -69,7 +69,7 @@ def test_seedtts_benchmark_profile_args_are_recorded() -> None:
     )
 
     assert config.profile_request_events is True
-    assert config.profile_run_id == "m4b-gate"
+    assert config.profile_run_id == "reference-encode-gate"
     assert config.profile_event_dir == "/tmp/events"
     assert config.profile_report_path == "/tmp/report.json"
     assert config.require_reference_encode_profile is True
@@ -80,7 +80,7 @@ def test_seedtts_benchmark_profile_args_are_recorded() -> None:
         base_url="http://localhost:8000",
     )
     assert results_config["profile_request_events"] is True
-    assert results_config["profile_run_id"] == "m4b-gate"
+    assert results_config["profile_run_id"] == "reference-encode-gate"
     assert results_config["profile_event_dir"] == "/tmp/events"
     assert results_config["profile_report_path"] == "/tmp/report.json"
     assert results_config["require_reference_encode_profile"] is True

--- a/tests/unit_test/benchmarks/test_tts_seedtts_benchmark_config.py
+++ b/tests/unit_test/benchmarks/test_tts_seedtts_benchmark_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 
@@ -11,6 +12,7 @@ from benchmarks.eval.benchmark_tts_seedtts import (
     _build_results_config,
     _config_from_args,
     _write_request_profile_report,
+    run_tts_seedtts_benchmark,
 )
 
 
@@ -55,6 +57,8 @@ def test_seedtts_benchmark_batch_args_are_independent() -> None:
 def test_seedtts_benchmark_profile_args_are_recorded() -> None:
     config = _config_from_cli(
         "--profile-request-events",
+        "--warmup",
+        "0",
         "--profile-run-id",
         "m4b-gate",
         "--profile-event-dir",
@@ -69,6 +73,7 @@ def test_seedtts_benchmark_profile_args_are_recorded() -> None:
     assert config.profile_event_dir == "/tmp/events"
     assert config.profile_report_path == "/tmp/report.json"
     assert config.require_reference_encode_profile is True
+    assert config.warmup == 0
 
     results_config = _build_results_config(
         config,
@@ -79,6 +84,18 @@ def test_seedtts_benchmark_profile_args_are_recorded() -> None:
     assert results_config["profile_event_dir"] == "/tmp/events"
     assert results_config["profile_report_path"] == "/tmp/report.json"
     assert results_config["require_reference_encode_profile"] is True
+
+
+def test_seedtts_profile_run_requires_zero_warmup() -> None:
+    config = TtsSeedttsBenchmarkConfig(
+        model="fishaudio/s2-pro",
+        meta="zhaochenyang20/seed-tts-eval-arrow",
+        profile_request_events=True,
+        warmup=1,
+    )
+
+    with pytest.raises(ValueError, match="warmup=0"):
+        asyncio.run(run_tts_seedtts_benchmark(config))
 
 
 def test_seedtts_profile_report_fails_when_events_are_missing(tmp_path) -> None:
@@ -112,6 +129,39 @@ def test_seedtts_profile_report_can_require_reference_encode_events(tmp_path) ->
     )
 
     with pytest.raises(RuntimeError, match="No reference encode profile events"):
+        _write_request_profile_report(
+            event_dir=str(event_dir),
+            report_path=str(tmp_path / "report.json"),
+            expect_events=True,
+            expect_reference_encode=True,
+        )
+
+
+def test_seedtts_profile_report_can_require_successful_reference_encode(
+    tmp_path,
+) -> None:
+    event_dir = tmp_path / "events"
+    event_dir.mkdir()
+    event = {
+        "request_id": "r1",
+        "stage": "preprocessing",
+        "event_name": "reference_encode_lookup",
+        "timestamp_ns": 0,
+        "run_id": "run",
+        "pid": os.getpid(),
+        "metadata": {
+            "model_id": "fish",
+            "encoder_id": "codec",
+            "artifact_kind": "codes",
+            "result": "hit",
+        },
+    }
+    (event_dir / "events_preprocessing_1.jsonl").write_text(
+        json.dumps(event) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="No successful reference encode misses"):
         _write_request_profile_report(
             event_dir=str(event_dir),
             report_path=str(tmp_path / "report.json"),

--- a/tests/unit_test/benchmarks/test_tts_seedtts_benchmark_config.py
+++ b/tests/unit_test/benchmarks/test_tts_seedtts_benchmark_config.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import pytest
+
 from benchmarks.eval.benchmark_tts_seedtts import (
     TtsSeedttsBenchmarkConfig,
     _build_arg_parser,
     _build_results_config,
     _config_from_args,
+    _write_request_profile_report,
 )
 
 
@@ -70,3 +73,16 @@ def test_seedtts_benchmark_profile_args_are_recorded() -> None:
     assert results_config["profile_run_id"] == "m4b-gate"
     assert results_config["profile_event_dir"] == "/tmp/events"
     assert results_config["profile_report_path"] == "/tmp/report.json"
+
+
+def test_seedtts_profile_report_fails_when_events_are_missing(tmp_path) -> None:
+    report_path = tmp_path / "report.json"
+
+    with pytest.raises(RuntimeError, match="No request profile events"):
+        _write_request_profile_report(
+            event_dir=str(tmp_path / "missing-events"),
+            report_path=str(report_path),
+            expect_events=True,
+        )
+
+    assert not report_path.exists()

--- a/tests/unit_test/benchmarks/test_tts_seedtts_benchmark_config.py
+++ b/tests/unit_test/benchmarks/test_tts_seedtts_benchmark_config.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+import os
+
 import pytest
 
 from benchmarks.eval.benchmark_tts_seedtts import (
@@ -58,12 +61,14 @@ def test_seedtts_benchmark_profile_args_are_recorded() -> None:
         "/tmp/events",
         "--profile-report-path",
         "/tmp/report.json",
+        "--require-reference-encode-profile",
     )
 
     assert config.profile_request_events is True
     assert config.profile_run_id == "m4b-gate"
     assert config.profile_event_dir == "/tmp/events"
     assert config.profile_report_path == "/tmp/report.json"
+    assert config.require_reference_encode_profile is True
 
     results_config = _build_results_config(
         config,
@@ -73,6 +78,7 @@ def test_seedtts_benchmark_profile_args_are_recorded() -> None:
     assert results_config["profile_run_id"] == "m4b-gate"
     assert results_config["profile_event_dir"] == "/tmp/events"
     assert results_config["profile_report_path"] == "/tmp/report.json"
+    assert results_config["require_reference_encode_profile"] is True
 
 
 def test_seedtts_profile_report_fails_when_events_are_missing(tmp_path) -> None:
@@ -86,3 +92,29 @@ def test_seedtts_profile_report_fails_when_events_are_missing(tmp_path) -> None:
         )
 
     assert not report_path.exists()
+
+
+def test_seedtts_profile_report_can_require_reference_encode_events(tmp_path) -> None:
+    event_dir = tmp_path / "events"
+    event_dir.mkdir()
+    event = {
+        "request_id": "r1",
+        "stage": "coordinator",
+        "event_name": "request_admission",
+        "timestamp_ns": 0,
+        "run_id": "run",
+        "pid": os.getpid(),
+        "metadata": {},
+    }
+    (event_dir / "events_coordinator_1.jsonl").write_text(
+        json.dumps(event) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="No reference encode profile events"):
+        _write_request_profile_report(
+            event_dir=str(event_dir),
+            report_path=str(tmp_path / "report.json"),
+            expect_events=True,
+            expect_reference_encode=True,
+        )

--- a/tests/unit_test/pipeline/test_simple_scheduler_concurrent.py
+++ b/tests/unit_test/pipeline/test_simple_scheduler_concurrent.py
@@ -41,6 +41,7 @@ def run_scheduler(
     This is a copy of tests.unit_test.pipeline.helpers.run_scheduler to avoid
     the torch transitive import in helpers.py.
     """
+
     def start() -> None:
         token = set_active_stage(active_stage) if active_stage is not None else None
         try:

--- a/tests/unit_test/pipeline/test_simple_scheduler_concurrent.py
+++ b/tests/unit_test/pipeline/test_simple_scheduler_concurrent.py
@@ -263,6 +263,28 @@ def test_default_max_concurrency_is_one_for_backcompat() -> None:
     assert [out.request_id for out in outputs] == ["req-1", "req-2"]
 
 
+def test_simple_scheduler_concurrent_propagates_active_stage_context() -> None:
+    seen_stages: list[str | None] = []
+    lock = threading.Lock()
+
+    def compute(payload: str) -> str:
+        with lock:
+            seen_stages.append(get_active_stage())
+        return payload.upper()
+
+    outputs = run_scheduler(
+        SimpleScheduler(compute, max_concurrency=2),
+        [IncomingMessage("req-stage", "new_request", "payload")],
+        output_count=1,
+        active_stage="preprocessing",
+    )
+
+    assert outputs[0].request_id == "req-stage"
+    assert outputs[0].type == "result"
+    assert outputs[0].data == "PAYLOAD"
+    assert seen_stages == ["preprocessing"]
+
+
 def test_threaded_simple_scheduler_propagates_active_stage_context() -> None:
     seen_stages: list[str | None] = []
     lock = threading.Lock()

--- a/tests/unit_test/pipeline/test_simple_scheduler_concurrent.py
+++ b/tests/unit_test/pipeline/test_simple_scheduler_concurrent.py
@@ -16,16 +16,23 @@ from typing import Any
 
 import pytest
 
+from sglang_omni.profiler.event_recorder import (
+    get_active_stage,
+    reset_active_stage,
+    set_active_stage,
+)
 from sglang_omni.scheduling.messages import IncomingMessage
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+from sglang_omni.scheduling.threaded_simple_scheduler import ThreadedSimpleScheduler
 
 
 def run_scheduler(
-    scheduler: SimpleScheduler,
+    scheduler: Any,
     messages: list[IncomingMessage],
     *,
     output_count: int,
     before_collect: Callable[[], None] | None = None,
+    active_stage: str | None = None,
 ) -> list[Any]:
     """Inlined copy of tests.unit_test.pipeline.helpers.run_scheduler to avoid
     the torch transitive import in helpers.py.
@@ -34,7 +41,14 @@ def run_scheduler(
     This is a copy of tests.unit_test.pipeline.helpers.run_scheduler to avoid
     the torch transitive import in helpers.py.
     """
-    thread = threading.Thread(target=scheduler.start, daemon=True)
+    def start() -> None:
+        token = set_active_stage(active_stage) if active_stage is not None else None
+        try:
+            scheduler.start()
+        finally:
+            reset_active_stage(token)
+
+    thread = threading.Thread(target=start, daemon=True)
     thread.start()
     try:
         for message in messages:
@@ -247,3 +261,25 @@ def test_default_max_concurrency_is_one_for_backcompat() -> None:
     )
 
     assert [out.request_id for out in outputs] == ["req-1", "req-2"]
+
+
+def test_threaded_simple_scheduler_propagates_active_stage_context() -> None:
+    seen_stages: list[str | None] = []
+    lock = threading.Lock()
+
+    def compute(payload: str) -> str:
+        with lock:
+            seen_stages.append(get_active_stage())
+        return payload.upper()
+
+    outputs = run_scheduler(
+        ThreadedSimpleScheduler(compute, max_concurrency=1),
+        [IncomingMessage("req-stage", "new_request", "payload")],
+        output_count=1,
+        active_stage="preprocessing",
+    )
+
+    assert outputs[0].request_id == "req-stage"
+    assert outputs[0].type == "result"
+    assert outputs[0].data == "PAYLOAD"
+    assert seen_stages == ["preprocessing"]

--- a/tests/unit_test/profiler/test_views.py
+++ b/tests/unit_test/profiler/test_views.py
@@ -490,6 +490,36 @@ def test_reference_encode_breakdown_counts_cache_and_durations(
             artifact_kind="codes",
             result="error",
         ),
+        _ev(
+            "r5",
+            "preprocessing",
+            "reference_encode_start",
+            7_000_000,
+            model_id="fish",
+            encoder_id="codec",
+            artifact_kind="codes",
+            result="miss",
+        ),
+        _ev(
+            "r5",
+            "preprocessing",
+            "reference_encode_end",
+            12_000_000,
+            model_id="fish",
+            encoder_id="codec",
+            artifact_kind="codes",
+            result="error",
+        ),
+        _ev(
+            "r5",
+            "preprocessing",
+            "reference_encode_failure",
+            12_000_000,
+            model_id="fish",
+            encoder_id="codec",
+            artifact_kind="codes",
+            result="error",
+        ),
     ]
     _write_events(tmp_path / "events_x.jsonl", events)
 
@@ -504,7 +534,8 @@ def test_reference_encode_breakdown_counts_cache_and_durations(
     assert row.encode_total_ms == 2.0
     assert row.wait_count == 1
     assert row.wait_total_ms == 1.0
-    assert row.failed == 1
+    assert row.wait_p95_ms == 1.0
+    assert row.failed == 2
 
     report = build_report(tmp_path)
     assert report["reference_encode_breakdown"][0]["encode_p95_ms"] == 2.0

--- a/tests/unit_test/profiler/test_views.py
+++ b/tests/unit_test/profiler/test_views.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from sglang_omni.profiler.views import (
     build_report,
     hop_breakdown,
+    reference_encode_breakdown,
     reconstruct_timelines,
     stage_breakdown,
 )
@@ -378,7 +379,7 @@ def test_stage_breakdown_uses_prefill_start_not_queue_enter(
     assert all("scheduler_queue_enter->" not in r.interval_name for r in rows)
 
 
-def test_build_report_returns_all_three_views(tmp_path: Path) -> None:
+def test_build_report_returns_all_views(tmp_path: Path) -> None:
     events = [
         _ev("r1", "coordinator", "request_admission", 0),
         _ev("r1", "encoder", "stage_input_received", 100, from_stage="coordinator"),
@@ -402,3 +403,108 @@ def test_build_report_returns_all_three_views(tmp_path: Path) -> None:
     assert any(
         r["src"] == "encoder" and r["dst"] == "thinker" for r in rep["hop_breakdown"]
     )
+    assert "reference_encode_breakdown" in rep
+
+
+def test_reference_encode_breakdown_counts_cache_and_durations(
+    tmp_path: Path,
+) -> None:
+    events = [
+        _ev(
+            "r1",
+            "preprocessing",
+            "reference_encode_lookup",
+            0,
+            model_id="fish",
+            encoder_id="codec",
+            artifact_kind="codes",
+            result="miss",
+        ),
+        _ev(
+            "r1",
+            "preprocessing",
+            "reference_encode_start",
+            1_000,
+            model_id="fish",
+            encoder_id="codec",
+            artifact_kind="codes",
+            result="miss",
+        ),
+        _ev(
+            "r1",
+            "preprocessing",
+            "reference_encode_end",
+            2_001_000,
+            model_id="fish",
+            encoder_id="codec",
+            artifact_kind="codes",
+            result="success",
+        ),
+        _ev(
+            "r2",
+            "preprocessing",
+            "reference_encode_lookup",
+            3_000_000,
+            model_id="fish",
+            encoder_id="codec",
+            artifact_kind="codes",
+            result="hit",
+        ),
+        _ev(
+            "r3",
+            "preprocessing",
+            "reference_encode_lookup",
+            4_000_000,
+            model_id="fish",
+            encoder_id="codec",
+            artifact_kind="codes",
+            result="merged",
+        ),
+        _ev(
+            "r3",
+            "preprocessing",
+            "reference_encode_wait_start",
+            4_100_000,
+            model_id="fish",
+            encoder_id="codec",
+            artifact_kind="codes",
+            result="merged",
+        ),
+        _ev(
+            "r3",
+            "preprocessing",
+            "reference_encode_wait_end",
+            5_100_000,
+            model_id="fish",
+            encoder_id="codec",
+            artifact_kind="codes",
+            result="success",
+        ),
+        _ev(
+            "r4",
+            "preprocessing",
+            "reference_encode_failure",
+            6_000_000,
+            model_id="fish",
+            encoder_id="codec",
+            artifact_kind="codes",
+            result="error",
+        ),
+    ]
+    _write_events(tmp_path / "events_x.jsonl", events)
+
+    rows = reference_encode_breakdown(source=tmp_path)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.lookups == 3
+    assert row.misses == 1
+    assert row.hits == 1
+    assert row.merged == 1
+    assert row.encode_count == 1
+    assert row.encode_total_ms == 2.0
+    assert row.wait_count == 1
+    assert row.wait_total_ms == 1.0
+    assert row.failed == 1
+
+    report = build_report(tmp_path)
+    assert report["reference_encode_breakdown"][0]["encode_p95_ms"] == 2.0

--- a/tests/unit_test/profiler/test_views.py
+++ b/tests/unit_test/profiler/test_views.py
@@ -10,8 +10,8 @@ from pathlib import Path
 from sglang_omni.profiler.views import (
     build_report,
     hop_breakdown,
-    reference_encode_breakdown,
     reconstruct_timelines,
+    reference_encode_breakdown,
     stage_breakdown,
 )
 
@@ -520,6 +520,36 @@ def test_reference_encode_breakdown_counts_cache_and_durations(
             artifact_kind="codes",
             result="error",
         ),
+        _ev(
+            "r6",
+            "preprocessing",
+            "reference_encode_wait_start",
+            13_000_000,
+            model_id="fish",
+            encoder_id="codec",
+            artifact_kind="codes",
+            result="merged",
+        ),
+        _ev(
+            "r6",
+            "preprocessing",
+            "reference_encode_wait_end",
+            143_000_000,
+            model_id="fish",
+            encoder_id="codec",
+            artifact_kind="codes",
+            result="timeout",
+        ),
+        _ev(
+            "r6",
+            "preprocessing",
+            "reference_encode_failure",
+            143_000_000,
+            model_id="fish",
+            encoder_id="codec",
+            artifact_kind="codes",
+            result="timeout",
+        ),
     ]
     _write_events(tmp_path / "events_x.jsonl", events)
 
@@ -535,7 +565,7 @@ def test_reference_encode_breakdown_counts_cache_and_durations(
     assert row.wait_count == 1
     assert row.wait_total_ms == 1.0
     assert row.wait_p95_ms == 1.0
-    assert row.failed == 2
+    assert row.failed == 3
 
     report = build_report(tmp_path)
     assert report["reference_encode_breakdown"][0]["encode_p95_ms"] == 2.0

--- a/tests/unit_test/scheduling/test_reference_encoder.py
+++ b/tests/unit_test/scheduling/test_reference_encoder.py
@@ -2,14 +2,22 @@
 from __future__ import annotations
 
 import concurrent.futures
+import json
 import threading
 import time
 from collections import Counter
+from pathlib import Path
 from typing import Any
 
 import pytest
 import torch
 
+from sglang_omni.profiler.event_recorder import (
+    get_recorder,
+    reset_active_stage,
+    set_active_stage,
+)
+from sglang_omni.profiler.views import reference_encode_breakdown
 from sglang_omni.scheduling.reference_encoder import (
     ReferenceEncodeHook,
     ReferenceEncodeKey,
@@ -51,6 +59,11 @@ def _wait_for_merged(
             return
         time.sleep(0.001)
     assert service.stats()["merged"] >= expected
+
+
+def _read_events(path: str) -> list[dict[str, Any]]:
+    with Path(path).open("r", encoding="utf-8") as fp:
+        return [json.loads(line) for line in fp if line.strip()]
 
 
 class _TensorHook(ReferenceEncodeHook[str, torch.Tensor, torch.Tensor]):
@@ -368,3 +381,40 @@ def test_revalidate_exception_propagates_to_followers_without_timeout() -> None:
     assert all(isinstance(error, RuntimeError) for error in errors)
     assert all(str(error) == "revalidate boom" for error in errors)
     assert len(service._inflight) == 0
+
+
+def test_reference_encode_profile_events_and_breakdown(tmp_path: Path) -> None:
+    rec = get_recorder()
+    if rec.is_active():
+        rec.stop()
+    token = set_active_stage("preprocessing")
+    path = rec.start(run_id="ref-test", event_dir=str(tmp_path), stage="preprocessing")
+    try:
+        hook = _TensorHook()
+        service = ReferenceEncodeService(hook, max_items=16, max_bytes=1024)
+
+        service.get_or_encode("profiled", request_id="r1")
+        service.get_or_encode("profiled", request_id="r2")
+        service.get_or_encode("uncacheable-profiled", request_id="r3")
+    finally:
+        rec.stop(run_id="ref-test")
+        reset_active_stage(token)
+
+    events = _read_events(path)
+    lookup_results = [
+        event["metadata"].get("result")
+        for event in events
+        if event["event_name"] == "reference_encode_lookup"
+    ]
+    assert lookup_results == ["miss", "hit", "uncacheable"]
+    assert all(event["stage"] == "preprocessing" for event in events)
+
+    rows = reference_encode_breakdown(source=tmp_path)
+    by_encoder = {row.encoder_id: row for row in rows}
+    row = by_encoder["encoder"]
+    assert row.lookups == 2
+    assert row.misses == 1
+    assert row.hits == 1
+    assert row.encode_count == 1
+    assert row.encode_total_ms >= 0.0
+    assert by_encoder["unknown"].uncacheable == 1


### PR DESCRIPTION
Summary

- Add request-level reference encode profiling for Fish, MOSS local, and Qwen3 TTS cache paths.
- Add reference encode breakdown to profiler report and CLI table.
- Add SeedTTS benchmark profile flags for reference batch gate runs, including fail-loud checks for missing request or reference encode events.
- Add docs/design/simple_scheduler_batching.md to record the SimpleScheduler concurrent batching boundary.
- Keep different-key reference batching and scheduler runtime changes unimplemented.

Profiling evidence

Host: hyper01, 1x H200 physical GPU 1. Branch commit: 197e14d. Model: fishaudio/s2-pro. All runs used warmup 0 and request profiling. Full artifacts are stored on hyper01.

| run | requests | ref lookups | misses | merged | hits | ref encode p95 ms | preprocessing p95 ms | tts p95 ms | vocoder p95 ms | latency p95 s | throughput qps |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Fish c=8, SeedTTS first 32, 20 unique refs | 32 | 32 | 20 | 12 | 0 | 8257.237 | 8771.237 | 4997.864 | 1066.737 | 12.14 | 0.947 |
| Fish c=16, SeedTTS first 32, 20 unique refs | 32 | 32 | 20 | 11 | 1 | 8406.635 | 13212.015 | 1192.675 | 374.75 | 14.298 | 1.25 |
| Fish c=16, local meta, 16 unique refs | 16 | 16 | 16 | 0 | 0 | 8857.482 | 15307.832 | 1300.829 | 612.896 | 16.132 | 0.952 |

Interpretation: Fish cold-cache reference encode dominates preprocessing. The all-unique c=16 run is the cleanest gate sample: 16 misses, 0 merged, ref encode p95 8857 ms, preprocessing p95 15308 ms, tts p95 1301 ms, vocoder p95 613 ms. This supported a small Fish-only prototype, not a runtime implementation.

Fish prototype evidence

Experimental PR: #1009. Branch commit: a6e30bc. Host: hyper01. Model: fishaudio/s2-pro. Workload: c=16, 64 requests, cold cache, 40 unique reference files, warmup 0, request profiling required.

| run | requests | misses | merged | hits | batches | batched items | ref encode p95 ms | latency p95 s | throughput qps |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| baseline cache plus same-key merge | 64 | 40 | 24 | 0 | 0 | 0 | 8507.316 | 14.625 | 1.197 |
| batch8 wait10 prototype | 64 | 40 | 23 | 1 | 12 | 37 | 46832.934 | 81.147 | 0.224 |

Conclusion: negative evidence. The padded Fish codec batch path regresses p95 latency and throughput, so this does not clear the gate for a formal Fish batching implementation.

CI TTS evidence

CI run 28964178379, attempt 2, head 197e14d, selected MOSS-local. TTS stage 1 non-streaming, stage 2 streaming, and stage 3 consistency all passed. Artifacts: tts-stage-nonstream-speed-results id 8180135093, tts-stage-stream-speed-results id 8180551466.

| ci run | model | stage | requests | concurrency | latency p95 s | rtf p95 | ttfc p95 s | throughput qps | artifact |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| 28964178379 attempt 2 | OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5 | non-streaming | 1088 | 16 | 1.720 | 0.4217 |  | 12.640 | 8180135093 |
| 28964178379 attempt 2 | OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5 | streaming | 1088 | 16 | 2.336 | 0.5503 | 1.1155 | 9.223 | 8180551466 |

This is clean end-to-end TTS CI evidence, not reference-encode breakdown. The CI speed stage currently writes speed_results.json only; reference encode breakdown comes from the request profiler artifacts above.

Validation

- python3 -m py_compile on touched Python files passed.
- git diff --check passed.
- Synthetic profiler build_report smoke passed.
- SimpleScheduler and ThreadedSimpleScheduler active-stage context smokes passed.
- Targeted pytest passed in a temporary Python 3.12 venv: 43 passed.
- Scheduler/profiler focused tests after the docs cleanup passed: 23 passed.
- Local docs build was not run because sphinx-build is not installed in this venv; GitHub docs CI is the source of truth for that check.
- Latest PR CI after the prior docs commit: lint, docs, test-layout, CodeQL JS, CodeQL Python, omni-ci-gate, setup, pick TTS model, ASR stages 1-2, TTS stages 1-3, and Qwen3 Omni stages 1-4 passed. PR Test / unit-test failed earlier in run 29005256799 before this docs-only cleanup.

Notes

- This PR is profiling prep plus SimpleScheduler concurrent batching boundary documentation only.
- SimpleScheduler concurrent batching still needs real consumer evidence, design review, and isolated behavior contract tests before scheduler runtime changes.
- Different-key reference batching should remain gated by cold-cache different-reference profiling before implementation.
