### PR TITLE
[Qwen3-Omni] Capture talker predictor decode with CUDA graph

### DIFF
--- a/sglang_omni/models/qwen3_omni/components/talker.py
+++ b/sglang_omni/models/qwen3_omni/components/talker.py
@@ -103,24 +103,32 @@ class _PredictorDecodeGraph:
     @torch.no_grad()
     def _capture(self) -> None:
         device = self.layer0_codes.device
-        warmup_stream = torch.cuda.Stream(device=device)
-        current_stream = torch.cuda.current_stream(device=device)
-        warmup_stream.wait_stream(current_stream)
-        with torch.cuda.stream(warmup_stream):
-            for _ in range(2):
-                self.model._code_predictor_forward_incremental_eager(
-                    self.layer0_codes,
-                    self.talker_hidden,
-                )
-        current_stream.wait_stream(warmup_stream)
+        with torch.cuda.device(device):
+            warmup_stream = torch.cuda.Stream(device=device)
+            current_stream = torch.cuda.current_stream(device=device)
+            warmup_stream.wait_stream(current_stream)
+            with torch.cuda.stream(warmup_stream):
+                for _ in range(2):
+                    self.model._code_predictor_forward_incremental_eager(
+                        self.layer0_codes,
+                        self.talker_hidden,
+                    )
+            current_stream.wait_stream(warmup_stream)
 
-        with torch.cuda.graph(self.graph, capture_error_mode="thread_local"):
-            self.result_codes, self.summed_embeddings = (
-                self.model._code_predictor_forward_incremental_eager(
-                    self.layer0_codes,
-                    self.talker_hidden,
+            capture_stream = torch.cuda.Stream(device=device)
+            capture_stream.wait_stream(current_stream)
+            with torch.cuda.graph(
+                self.graph,
+                stream=capture_stream,
+                capture_error_mode="thread_local",
+            ):
+                self.result_codes, self.summed_embeddings = (
+                    self.model._code_predictor_forward_incremental_eager(
+                        self.layer0_codes,
+                        self.talker_hidden,
+                    )
                 )
-            )
+            current_stream.wait_stream(capture_stream)
 
         if self.result_codes is None or self.summed_embeddings is None:
             raise RuntimeError("Qwen3-Omni predictor CUDA graph captured no outputs")
@@ -131,9 +139,10 @@ class _PredictorDecodeGraph:
         layer0_codes: torch.Tensor,
         talker_hidden: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        self.layer0_codes.copy_(layer0_codes)
-        self.talker_hidden.copy_(talker_hidden)
-        self.graph.replay()
+        with torch.cuda.device(self.layer0_codes.device):
+            self.layer0_codes.copy_(layer0_codes)
+            self.talker_hidden.copy_(talker_hidden)
+            self.graph.replay()
         assert self.result_codes is not None
         assert self.summed_embeddings is not None
         return self.result_codes, self.summed_embeddings

--- a/sglang_omni/models/qwen3_omni/components/talker.py
+++ b/sglang_omni/models/qwen3_omni/components/talker.py
@@ -4,6 +4,7 @@ SGLang-native Talker model for Qwen3-Omni compatiable with hf formatting.
 
 from __future__ import annotations
 
+import logging
 from typing import Iterable, Optional, Tuple
 
 import torch
@@ -45,6 +46,8 @@ from sglang_omni.vendor.sglang.models import apply_qk_norm
 from sglang_omni.vendor.sglang.server_args import get_global_server_args
 from sglang_omni.vendor.sglang.utils import make_layers
 
+logger = logging.getLogger(__name__)
+
 
 def _bind_default_weight_loaders(module: nn.Module) -> None:
     for param in module.parameters():
@@ -61,6 +64,79 @@ def _repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
         batch, num_kv_heads, n_rep, seq_len, head_dim
     )
     return hidden_states.reshape(batch, num_kv_heads * n_rep, seq_len, head_dim)
+
+
+class _PredictorDecodeGraph:
+    """CUDA graph for one Qwen3-Omni predictor single-token decode bucket."""
+
+    def __init__(
+        self,
+        model: "Qwen3OmniTalker",
+        batch_size: int,
+        code_dtype: torch.dtype,
+    ) -> None:
+        self.model = model
+        self.batch_size = batch_size
+        self.code_dtype = code_dtype
+        device = model._predictor_input_buffer.device
+        hidden_size = model._predictor_input_buffer.shape[-1]
+        dtype = model._predictor_input_buffer.dtype
+
+        self.layer0_codes = torch.zeros(
+            batch_size,
+            1,
+            dtype=code_dtype,
+            device=device,
+        )
+        self.talker_hidden = torch.zeros(
+            batch_size,
+            1,
+            hidden_size,
+            dtype=dtype,
+            device=device,
+        )
+        self.graph = torch.cuda.CUDAGraph()
+        self.result_codes: torch.Tensor | None = None
+        self.summed_embeddings: torch.Tensor | None = None
+        self._capture()
+
+    @torch.no_grad()
+    def _capture(self) -> None:
+        device = self.layer0_codes.device
+        warmup_stream = torch.cuda.Stream(device=device)
+        current_stream = torch.cuda.current_stream(device=device)
+        warmup_stream.wait_stream(current_stream)
+        with torch.cuda.stream(warmup_stream):
+            for _ in range(2):
+                self.model._code_predictor_forward_incremental_eager(
+                    self.layer0_codes,
+                    self.talker_hidden,
+                )
+        current_stream.wait_stream(warmup_stream)
+
+        with torch.cuda.graph(self.graph, capture_error_mode="thread_local"):
+            self.result_codes, self.summed_embeddings = (
+                self.model._code_predictor_forward_incremental_eager(
+                    self.layer0_codes,
+                    self.talker_hidden,
+                )
+            )
+
+        if self.result_codes is None or self.summed_embeddings is None:
+            raise RuntimeError("Qwen3-Omni predictor CUDA graph captured no outputs")
+
+    @torch.no_grad()
+    def replay(
+        self,
+        layer0_codes: torch.Tensor,
+        talker_hidden: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        self.layer0_codes.copy_(layer0_codes)
+        self.talker_hidden.copy_(talker_hidden)
+        self.graph.replay()
+        assert self.result_codes is not None
+        assert self.summed_embeddings is not None
+        return self.result_codes, self.summed_embeddings
 
 
 class ResizeMLP(nn.Module):
@@ -873,6 +949,10 @@ class Qwen3OmniTalker(nn.Module):
             device=device,
             dtype=self.model.codec_embedding.weight.dtype,
         )
+        self._predictor_decode_graphs: dict[
+            tuple[int, torch.dtype], _PredictorDecodeGraph
+        ] = {}
+        self._predictor_decode_graph_disabled: set[tuple[int, torch.dtype]] = set()
         _bind_default_weight_loaders(self)
         self._cached_params_dict = dict(self.named_parameters())
         self._sampler = None
@@ -1220,6 +1300,97 @@ class Qwen3OmniTalker(nn.Module):
         talker_hidden: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Run the predictor one token at a time using a per-layer single-turn KV cache."""
+        if layer0_codes.ndim == 1:
+            layer0_codes = layer0_codes.unsqueeze(1)
+        if talker_hidden.ndim == 2:
+            talker_hidden = talker_hidden.unsqueeze(1)
+
+        batch_size, seq_len = layer0_codes.shape
+        if talker_hidden.shape[:2] != (batch_size, seq_len):
+            raise ValueError(
+                "talker_hidden shape must align with layer0_codes: "
+                f"{tuple(talker_hidden.shape)} vs {tuple(layer0_codes.shape)}"
+            )
+        if self._can_use_predictor_decode_graph(
+            layer0_codes=layer0_codes,
+            talker_hidden=talker_hidden,
+            seq_len=seq_len,
+        ):
+            graph_result = self._code_predictor_forward_single_token_graph(
+                layer0_codes=layer0_codes,
+                talker_hidden=talker_hidden,
+                batch_size=batch_size,
+                code_dtype=layer0_codes.dtype,
+            )
+            if graph_result is not None:
+                return graph_result
+
+        return self._code_predictor_forward_incremental_eager(
+            layer0_codes=layer0_codes,
+            talker_hidden=talker_hidden,
+        )
+
+    def _can_use_predictor_decode_graph(
+        self,
+        *,
+        layer0_codes: torch.Tensor,
+        talker_hidden: torch.Tensor,
+        seq_len: int,
+    ) -> bool:
+        if seq_len != 1:
+            return False
+        if layer0_codes.dtype not in (torch.int, torch.long):
+            return False
+        if not torch.cuda.is_available():
+            return False
+        if not layer0_codes.is_cuda or not talker_hidden.is_cuda:
+            return False
+        if torch.cuda.is_current_stream_capturing():
+            return False
+        return True
+
+    def _code_predictor_forward_single_token_graph(
+        self,
+        *,
+        layer0_codes: torch.Tensor,
+        talker_hidden: torch.Tensor,
+        batch_size: int,
+        code_dtype: torch.dtype,
+    ) -> Tuple[torch.Tensor, torch.Tensor] | None:
+        key = (batch_size, code_dtype)
+        if key in self._predictor_decode_graph_disabled:
+            return None
+
+        graph = self._predictor_decode_graphs.get(key)
+        if graph is None:
+            try:
+                graph = _PredictorDecodeGraph(self, batch_size, code_dtype)
+            except Exception:
+                self._predictor_decode_graph_disabled.add(key)
+                logger.warning(
+                    "Disabling Qwen3-Omni predictor CUDA graph for "
+                    "batch_size=%s dtype=%s",
+                    batch_size,
+                    code_dtype,
+                    exc_info=True,
+                )
+                return None
+            self._predictor_decode_graphs[key] = graph
+            logger.info(
+                "Captured Qwen3-Omni predictor CUDA graph for batch_size=%s "
+                "dtype=%s",
+                batch_size,
+                code_dtype,
+            )
+
+        return graph.replay(layer0_codes, talker_hidden)
+
+    def _code_predictor_forward_incremental_eager(
+        self,
+        layer0_codes: torch.Tensor,
+        talker_hidden: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Eager predictor implementation used for prefill and graph fallback."""
         if layer0_codes.ndim == 1:
             layer0_codes = layer0_codes.unsqueeze(1)
         if talker_hidden.ndim == 2:

--- a/sglang_omni/models/qwen3_omni/components/talker.py
+++ b/sglang_omni/models/qwen3_omni/components/talker.py
@@ -139,13 +139,26 @@ class _PredictorDecodeGraph:
         layer0_codes: torch.Tensor,
         talker_hidden: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        live_batch_size = layer0_codes.shape[0]
+        if live_batch_size > self.batch_size:
+            raise ValueError(
+                "Qwen3-Omni predictor CUDA graph bucket is too small: "
+                f"bucket={self.batch_size}, live={live_batch_size}"
+            )
+
         with torch.cuda.device(self.layer0_codes.device):
-            self.layer0_codes.copy_(layer0_codes)
-            self.talker_hidden.copy_(talker_hidden)
+            self.layer0_codes[:live_batch_size].copy_(layer0_codes)
+            self.talker_hidden[:live_batch_size].copy_(talker_hidden)
+            if live_batch_size < self.batch_size:
+                self.layer0_codes[live_batch_size:].zero_()
+                self.talker_hidden[live_batch_size:].zero_()
             self.graph.replay()
         assert self.result_codes is not None
         assert self.summed_embeddings is not None
-        return self.result_codes, self.summed_embeddings
+        return (
+            self.result_codes[:live_batch_size],
+            self.summed_embeddings[:live_batch_size],
+        )
 
 
 class ResizeMLP(nn.Module):
@@ -865,7 +878,8 @@ class Qwen3OmniTalker(nn.Module):
         device = self.model.codec_embedding.weight.device
         hidden_size = config.text_config.hidden_size
         predictor_len = config.num_code_groups + 1
-        max_batch_size = get_global_server_args().max_running_requests
+        server_args = get_global_server_args()
+        max_batch_size = server_args.max_running_requests
         self._cp_enabled = self.model._cp_enabled
         self._feedback_buffer = self.model._feedback_buffer
         self._feedback_mask = self.model._feedback_mask
@@ -957,6 +971,12 @@ class Qwen3OmniTalker(nn.Module):
             hidden_size,
             device=device,
             dtype=self.model.codec_embedding.weight.dtype,
+        )
+        self._predictor_decode_graph_batch_sizes = (
+            self._normalize_predictor_decode_graph_batch_sizes(
+                server_args,
+                max_batch_size=max_batch_size,
+            )
         )
         self._predictor_decode_graphs: dict[
             tuple[int, torch.dtype], _PredictorDecodeGraph
@@ -1358,6 +1378,33 @@ class Qwen3OmniTalker(nn.Module):
             return False
         return True
 
+    @staticmethod
+    def _normalize_predictor_decode_graph_batch_sizes(
+        server_args: object,
+        *,
+        max_batch_size: int,
+    ) -> tuple[int, ...]:
+        raw_batch_sizes = getattr(server_args, "cuda_graph_bs", None)
+        if raw_batch_sizes is None:
+            raw_batch_sizes = (max_batch_size,)
+
+        normalized = sorted(
+            {
+                int(batch_size)
+                for batch_size in raw_batch_sizes
+                if 1 <= int(batch_size) <= int(max_batch_size)
+            }
+        )
+        if not normalized or normalized[-1] < int(max_batch_size):
+            normalized.append(int(max_batch_size))
+        return tuple(normalized)
+
+    def _predictor_decode_graph_bucket_size(self, batch_size: int) -> int | None:
+        for bucket_size in self._predictor_decode_graph_batch_sizes:
+            if bucket_size >= batch_size:
+                return bucket_size
+        return None
+
     def _code_predictor_forward_single_token_graph(
         self,
         *,
@@ -1366,20 +1413,24 @@ class Qwen3OmniTalker(nn.Module):
         batch_size: int,
         code_dtype: torch.dtype,
     ) -> Tuple[torch.Tensor, torch.Tensor] | None:
-        key = (batch_size, code_dtype)
+        bucket_size = self._predictor_decode_graph_bucket_size(batch_size)
+        if bucket_size is None:
+            return None
+
+        key = (bucket_size, code_dtype)
         if key in self._predictor_decode_graph_disabled:
             return None
 
         graph = self._predictor_decode_graphs.get(key)
         if graph is None:
             try:
-                graph = _PredictorDecodeGraph(self, batch_size, code_dtype)
+                graph = _PredictorDecodeGraph(self, bucket_size, code_dtype)
             except Exception:
                 self._predictor_decode_graph_disabled.add(key)
                 logger.warning(
                     "Disabling Qwen3-Omni predictor CUDA graph for "
                     "batch_size=%s dtype=%s",
-                    batch_size,
+                    bucket_size,
                     code_dtype,
                     exc_info=True,
                 )
@@ -1388,7 +1439,7 @@ class Qwen3OmniTalker(nn.Module):
             logger.info(
                 "Captured Qwen3-Omni predictor CUDA graph for batch_size=%s "
                 "dtype=%s",
-                batch_size,
+                bucket_size,
                 code_dtype,
             )
 

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -540,6 +540,146 @@ def test_qwen_predictor_decode_graph_matches_eager(monkeypatch: pytest.MonkeyPat
     torch.testing.assert_close(graph_embeds, eager_embeds)
 
 
+class _TupleLinear(nn.Module):
+    def __init__(self, in_features: int, out_features: int) -> None:
+        super().__init__()
+        self.proj = nn.Linear(in_features, out_features, bias=False)
+
+    def forward(self, hidden_states: torch.Tensor):
+        return self.proj(hidden_states), None
+
+
+class _IdentityRotary(nn.Module):
+    def forward(
+        self,
+        positions: torch.Tensor,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        fused_set_kv_buffer_arg=None,
+    ):
+        del positions, fused_set_kv_buffer_arg
+        return q, k
+
+
+def _build_real_step_predictor_graph_talker(device: torch.device) -> Qwen3OmniTalker:
+    torch.manual_seed(1)
+    hidden_size = 8
+    num_heads = 2
+    num_kv_heads = 1
+    head_dim = 4
+    num_code_groups = 4
+    vocab_size = 16
+    max_batch_size = 4
+    predictor_len = num_code_groups + 1
+
+    talker = object.__new__(Qwen3OmniTalker)
+    talker.training = False
+    talker.config = SimpleNamespace(num_code_groups=num_code_groups)
+    talker._predictor_input_buffer = torch.zeros(
+        max_batch_size,
+        predictor_len,
+        hidden_size,
+        device=device,
+    )
+    talker._output_codes = torch.zeros(
+        max_batch_size,
+        num_code_groups,
+        dtype=torch.long,
+        device=device,
+    )
+    talker._output_embeds = torch.zeros(max_batch_size, hidden_size, device=device)
+    talker._predictor_positions = torch.arange(
+        predictor_len,
+        device=device,
+        dtype=torch.long,
+    )
+    talker._predictor_k_cache = torch.zeros(
+        1,
+        max_batch_size,
+        num_kv_heads,
+        predictor_len,
+        head_dim,
+        device=device,
+    )
+    talker._predictor_v_cache = torch.zeros_like(talker._predictor_k_cache)
+    talker._predictor_decode_graph_batch_sizes = (1, 2, 4)
+    talker._predictor_decode_graphs = {}
+    talker._predictor_decode_graph_disabled = set()
+
+    layer = SimpleNamespace(
+        input_layernorm=nn.Identity(),
+        post_attention_layernorm=nn.Identity(),
+        mlp=nn.Linear(hidden_size, hidden_size, bias=False).to(device),
+    )
+    layer.self_attn = SimpleNamespace(
+        q_size=num_heads * head_dim,
+        kv_size=num_kv_heads * head_dim,
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        q_norm=nn.Identity(),
+        k_norm=nn.Identity(),
+        alt_stream=None,
+        qkv_proj=_TupleLinear(hidden_size, (num_heads + 2 * num_kv_heads) * head_dim).to(
+            device
+        ),
+        o_proj=_TupleLinear(num_heads * head_dim, hidden_size).to(device),
+        rotary_emb=_IdentityRotary(),
+    )
+    talker.code_predictor = SimpleNamespace(
+        model=SimpleNamespace(
+            layers=[layer],
+            norm=nn.Identity(),
+            codec_embedding=nn.ModuleList(
+                [nn.Embedding(vocab_size, hidden_size).to(device) for _ in range(3)]
+            ),
+        ),
+        lm_head=nn.ModuleList(
+            [_TupleLinear(hidden_size, vocab_size).to(device) for _ in range(3)]
+        ),
+    )
+    layer0_embedding = nn.Embedding(vocab_size, hidden_size).to(device)
+    talker.get_input_embeddings = lambda: layer0_embedding
+    return talker
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="Qwen3-Omni predictor graph requires CUDA"
+)
+def test_qwen_predictor_decode_graph_covers_real_incremental_step(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Graph replay should exercise the real predictor step and KV cache path."""
+    monkeypatch.setattr(
+        talker_module,
+        "apply_qk_norm",
+        lambda q, k, **_: (q, k),
+    )
+
+    device = torch.device("cuda")
+    talker = _build_real_step_predictor_graph_talker(device)
+    layer0_codes = torch.tensor([[1], [7]], dtype=torch.int, device=device)
+    talker_hidden = torch.randn(2, 1, 8, device=device)
+
+    with torch.no_grad():
+        eager_codes, eager_embeds = talker._code_predictor_forward_incremental_eager(
+            layer0_codes,
+            talker_hidden,
+        )
+        eager_codes = eager_codes.clone()
+        eager_embeds = eager_embeds.clone()
+
+        graph_codes, graph_embeds = talker.code_predictor_forward(
+            layer0_codes,
+            talker_hidden,
+        )
+        torch.cuda.synchronize()
+
+    assert (2, torch.int) in talker._predictor_decode_graphs
+    torch.testing.assert_close(graph_codes, eager_codes)
+    torch.testing.assert_close(graph_embeds, eager_embeds)
+
+
 @pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.device_count() < 2,
     reason="requires two visible CUDA devices",

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -414,6 +414,7 @@ def _build_fake_predictor_graph_talker(device: torch.device) -> Qwen3OmniTalker:
     talker._output_embeds = torch.zeros(4, 8, device=device)
     talker._predictor_decode_graphs = {}
     talker._predictor_decode_graph_disabled = set()
+    talker._predictor_decode_graph_batch_sizes = (1, 2, 4)
     layer0_embedding = nn.Embedding(16, 8).to(device)
     talker.get_input_embeddings = lambda: layer0_embedding
     talker.code_predictor = SimpleNamespace(
@@ -435,6 +436,73 @@ def _build_fake_predictor_graph_talker(device: torch.device) -> Qwen3OmniTalker:
 
     talker._predictor_forward_one_token = fake_forward_one_token
     return talker
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="Qwen3-Omni predictor graph requires CUDA"
+)
+def test_qwen_predictor_decode_graph_uses_configured_batch_buckets(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Live exact batch sizes should reuse bounded predictor graph buckets."""
+
+    class RecordingPredictorDecodeGraph:
+        def __init__(
+            self,
+            model: Qwen3OmniTalker,
+            batch_size: int,
+            code_dtype: torch.dtype,
+        ) -> None:
+            self.batch_size = batch_size
+            self.code_dtype = code_dtype
+            self.hidden_size = model._predictor_input_buffer.shape[-1]
+            self.dtype = model._predictor_input_buffer.dtype
+
+        def replay(
+            self,
+            layer0_codes: torch.Tensor,
+            talker_hidden: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            live_batch_size = layer0_codes.shape[0]
+            assert live_batch_size <= self.batch_size
+            assert talker_hidden.shape[0] == live_batch_size
+            return (
+                torch.zeros(
+                    live_batch_size,
+                    4,
+                    1,
+                    dtype=torch.long,
+                    device=layer0_codes.device,
+                ),
+                torch.zeros(
+                    live_batch_size,
+                    1,
+                    self.hidden_size,
+                    dtype=self.dtype,
+                    device=talker_hidden.device,
+                ),
+            )
+
+    monkeypatch.setattr(
+        talker_module,
+        "_PredictorDecodeGraph",
+        RecordingPredictorDecodeGraph,
+    )
+
+    device = torch.device("cuda")
+    talker = _build_fake_predictor_graph_talker(device)
+    layer0_codes = torch.tensor([[1], [7], [3]], dtype=torch.int, device=device)
+    talker_hidden = torch.randn(3, 1, 8, device=device)
+
+    result_codes, result_embeds = talker.code_predictor_forward(
+        layer0_codes,
+        talker_hidden,
+    )
+
+    assert result_codes.shape == (3, 4, 1)
+    assert result_embeds.shape == (3, 1, 8)
+    assert (4, torch.int) in talker._predictor_decode_graphs
+    assert (3, torch.int) not in talker._predictor_decode_graphs
 
 
 @pytest.mark.skipif(

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import ast
 import threading
 import time
 from collections import deque
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 import torch
+from torch import nn
 
+import sglang_omni.models.qwen3_omni.components.talker as talker_module
 from sglang_omni.model_runner.thinker_model_runner import ThinkerModelRunner
 from sglang_omni.models.qwen3_omni.components.talker import (
     Qwen3OmniTalker,
@@ -356,6 +360,109 @@ def test_qwen_code_predictor_keeps_4d_logits_token_shape() -> None:
 
     assert sampled.shape == (1, 2)
     assert sampled.tolist() == [[2, 0]]
+
+
+def test_qwen_predictor_cuda_graph_capture_uses_thread_local_error_mode() -> None:
+    """Keeps lazy predictor graph capture scoped to this thread."""
+    source = (
+        Path(__file__).resolve().parents[3]
+        / "sglang_omni"
+        / "models"
+        / "qwen3_omni"
+        / "components"
+        / "talker.py"
+    )
+    tree = ast.parse(source.read_text())
+    graph_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "graph"
+        and isinstance(node.func.value, ast.Attribute)
+        and node.func.value.attr == "cuda"
+    ]
+
+    assert graph_calls
+    assert any(
+        any(
+            keyword.arg == "capture_error_mode"
+            and isinstance(keyword.value, ast.Constant)
+            and keyword.value.value == "thread_local"
+            for keyword in call.keywords
+        )
+        for call in graph_calls
+    )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="Qwen3-Omni predictor graph requires CUDA"
+)
+def test_qwen_predictor_decode_graph_matches_eager(monkeypatch: pytest.MonkeyPatch):
+    """Default graph replay matches eager predictor outputs for single-token decode."""
+    monkeypatch.setattr(
+        talker_module,
+        "get_global_server_args",
+        lambda: SimpleNamespace(max_running_requests=4),
+    )
+
+    class FakeLmHead(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.proj = nn.Linear(8, 16, bias=False)
+
+        def forward(self, hidden_states: torch.Tensor):
+            return self.proj(hidden_states), None
+
+    torch.manual_seed(0)
+    talker = object.__new__(Qwen3OmniTalker)
+    talker.training = False
+    talker.config = SimpleNamespace(num_code_groups=4)
+    talker._predictor_input_buffer = torch.zeros(4, 5, 8, device="cuda")
+    talker._output_codes = torch.zeros(4, 4, dtype=torch.long, device="cuda")
+    talker._output_embeds = torch.zeros(4, 8, device="cuda")
+    talker._predictor_decode_graphs = {}
+    talker._predictor_decode_graph_disabled = set()
+    layer0_embedding = nn.Embedding(16, 8).cuda()
+    talker.get_input_embeddings = lambda: layer0_embedding
+    talker.code_predictor = SimpleNamespace(
+        model=SimpleNamespace(
+            codec_embedding=nn.ModuleList(
+                [nn.Embedding(16, 8).cuda() for _ in range(3)]
+            )
+        ),
+        lm_head=nn.ModuleList([FakeLmHead().cuda() for _ in range(3)]),
+    )
+
+    def fake_forward_one_token(
+        *,
+        token_embeds: torch.Tensor,
+        batch_size: int,
+        cache_len: int,
+    ) -> torch.Tensor:
+        return token_embeds[:batch_size] + float(cache_len + 1)
+
+    talker._predictor_forward_one_token = fake_forward_one_token
+    layer0_codes = torch.tensor([[1], [7]], dtype=torch.int, device="cuda")
+    talker_hidden = torch.randn(2, 1, 8, device="cuda")
+
+    with torch.no_grad():
+        eager_codes, eager_embeds = talker._code_predictor_forward_incremental_eager(
+            layer0_codes,
+            talker_hidden,
+        )
+        eager_codes = eager_codes.clone()
+        eager_embeds = eager_embeds.clone()
+
+        graph_codes, graph_embeds = talker.code_predictor_forward(
+            layer0_codes,
+            talker_hidden,
+        )
+        torch.cuda.synchronize()
+
+    assert (2, torch.int) in talker._predictor_decode_graphs
+    torch.testing.assert_close(graph_codes, eager_codes)
+    torch.testing.assert_close(graph_embeds, eager_embeds)
 
 
 def _build_assistant_part_for_n_chunks(n: int) -> dict[str, torch.Tensor]:

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -395,43 +395,34 @@ def test_qwen_predictor_cuda_graph_capture_uses_thread_local_error_mode() -> Non
     )
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="Qwen3-Omni predictor graph requires CUDA"
-)
-def test_qwen_predictor_decode_graph_matches_eager(monkeypatch: pytest.MonkeyPatch):
-    """Default graph replay matches eager predictor outputs for single-token decode."""
-    monkeypatch.setattr(
-        talker_module,
-        "get_global_server_args",
-        lambda: SimpleNamespace(max_running_requests=4),
-    )
+class _FakePredictorLmHead(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.proj = nn.Linear(8, 16, bias=False)
 
-    class FakeLmHead(nn.Module):
-        def __init__(self) -> None:
-            super().__init__()
-            self.proj = nn.Linear(8, 16, bias=False)
+    def forward(self, hidden_states: torch.Tensor):
+        return self.proj(hidden_states), None
 
-        def forward(self, hidden_states: torch.Tensor):
-            return self.proj(hidden_states), None
 
+def _build_fake_predictor_graph_talker(device: torch.device) -> Qwen3OmniTalker:
     torch.manual_seed(0)
     talker = object.__new__(Qwen3OmniTalker)
     talker.training = False
     talker.config = SimpleNamespace(num_code_groups=4)
-    talker._predictor_input_buffer = torch.zeros(4, 5, 8, device="cuda")
-    talker._output_codes = torch.zeros(4, 4, dtype=torch.long, device="cuda")
-    talker._output_embeds = torch.zeros(4, 8, device="cuda")
+    talker._predictor_input_buffer = torch.zeros(4, 5, 8, device=device)
+    talker._output_codes = torch.zeros(4, 4, dtype=torch.long, device=device)
+    talker._output_embeds = torch.zeros(4, 8, device=device)
     talker._predictor_decode_graphs = {}
     talker._predictor_decode_graph_disabled = set()
-    layer0_embedding = nn.Embedding(16, 8).cuda()
+    layer0_embedding = nn.Embedding(16, 8).to(device)
     talker.get_input_embeddings = lambda: layer0_embedding
     talker.code_predictor = SimpleNamespace(
         model=SimpleNamespace(
             codec_embedding=nn.ModuleList(
-                [nn.Embedding(16, 8).cuda() for _ in range(3)]
+                [nn.Embedding(16, 8).to(device) for _ in range(3)]
             )
         ),
-        lm_head=nn.ModuleList([FakeLmHead().cuda() for _ in range(3)]),
+        lm_head=nn.ModuleList([_FakePredictorLmHead().to(device) for _ in range(3)]),
     )
 
     def fake_forward_one_token(
@@ -443,8 +434,24 @@ def test_qwen_predictor_decode_graph_matches_eager(monkeypatch: pytest.MonkeyPat
         return token_embeds[:batch_size] + float(cache_len + 1)
 
     talker._predictor_forward_one_token = fake_forward_one_token
-    layer0_codes = torch.tensor([[1], [7]], dtype=torch.int, device="cuda")
-    talker_hidden = torch.randn(2, 1, 8, device="cuda")
+    return talker
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="Qwen3-Omni predictor graph requires CUDA"
+)
+def test_qwen_predictor_decode_graph_matches_eager(monkeypatch: pytest.MonkeyPatch):
+    """Default graph replay matches eager predictor outputs for single-token decode."""
+    monkeypatch.setattr(
+        talker_module,
+        "get_global_server_args",
+        lambda: SimpleNamespace(max_running_requests=4),
+    )
+
+    device = torch.device("cuda")
+    talker = _build_fake_predictor_graph_talker(device)
+    layer0_codes = torch.tensor([[1], [7]], dtype=torch.int, device=device)
+    talker_hidden = torch.randn(2, 1, 8, device=device)
 
     with torch.no_grad():
         eager_codes, eager_embeds = talker._code_predictor_forward_incremental_eager(
@@ -460,6 +467,48 @@ def test_qwen_predictor_decode_graph_matches_eager(monkeypatch: pytest.MonkeyPat
         )
         torch.cuda.synchronize()
 
+    assert (2, torch.int) in talker._predictor_decode_graphs
+    torch.testing.assert_close(graph_codes, eager_codes)
+    torch.testing.assert_close(graph_embeds, eager_embeds)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+    reason="requires two visible CUDA devices",
+)
+def test_qwen_predictor_decode_graph_uses_tensor_device_when_current_device_differs(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Graph capture follows predictor tensors, not the process-current device."""
+    monkeypatch.setattr(
+        talker_module,
+        "get_global_server_args",
+        lambda: SimpleNamespace(max_running_requests=4),
+    )
+
+    torch.cuda.set_device(0)
+    device = torch.device("cuda:1")
+    talker = _build_fake_predictor_graph_talker(device)
+    layer0_codes = torch.tensor([[1], [7]], dtype=torch.int, device=device)
+    talker_hidden = torch.randn(2, 1, 8, device=device)
+
+    with torch.no_grad():
+        eager_codes, eager_embeds = talker._code_predictor_forward_incremental_eager(
+            layer0_codes,
+            talker_hidden,
+        )
+        eager_codes = eager_codes.clone()
+        eager_embeds = eager_embeds.clone()
+
+        torch.cuda.set_device(0)
+        assert torch.cuda.current_device() == 0
+        graph_codes, graph_embeds = talker.code_predictor_forward(
+            layer0_codes,
+            talker_hidden,
+        )
+        torch.cuda.synchronize(device)
+
+    assert torch.cuda.current_device() == 0
     assert (2, torch.int) in talker._predictor_decode_graphs
     torch.testing.assert_close(graph_codes, eager_codes)
     torch.testing.assert_close(graph_embeds, eager_embeds)

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -620,9 +620,9 @@ def _build_real_step_predictor_graph_talker(device: torch.device) -> Qwen3OmniTa
         q_norm=nn.Identity(),
         k_norm=nn.Identity(),
         alt_stream=None,
-        qkv_proj=_TupleLinear(hidden_size, (num_heads + 2 * num_kv_heads) * head_dim).to(
-            device
-        ),
+        qkv_proj=_TupleLinear(
+            hidden_size, (num_heads + 2 * num_kv_heads) * head_dim
+        ).to(device),
         o_proj=_TupleLinear(num_heads * head_dim, hidden_size).to(device),
         rotary_emb=_IdentityRotary(),
     )


### PR DESCRIPTION
## Summary

- Add a lazy per-`(batch_size, code_dtype)` CUDA graph cache for Qwen3-Omni talker predictor single-token decode.
- Keep eager fallback for prefill, CPU/non-CUDA inputs, unsupported token dtypes, active CUDA stream capture, and graph capture failures.
- Add unit coverage for `thread_local` capture mode and the serving-realistic `torch.int32` token id path.

## Motivation

Qwen3-Omni talker decode spends a meaningful fraction of time in the code predictor, which launches many small kernels for each generated audio token. Capturing the single-token predictor path amortizes Python/kernel launch overhead while preserving the existing eager implementation as the fallback.

The graph cache is dtype-aware because SGLang serving passes sampled token ids as `torch.int32`, while many local/unit paths use `torch.long`.

## Performance

Measured on `hyper00-omni`, H200 GPU 3, `hongccc/sglang-omni:dev`, SeedTTS-50 generate-only, `max_concurrency=4`, `warmup=10`, `max_samples=50`.

| Variant | QPS | Mean latency | Mean RTF |
| --- | ---: | ---: | ---: |
| main (`b09dc99`) | 2.605 | 1.514s | 0.4705 |
| predictor CUDA graph (`b09dc99` + patch) | 3.404 | 1.160s | 0.3466 |

This is +30.7% QPS and -23.4% mean latency in that run. The branch has since been rebased onto latest `origin/main` (`c00e6f9d`).

I also tested stacking `torch.compile` inside the manual CUDA graph. It worked, but only added ~1.6% QPS over the manual CUDA graph while adding roughly 2+ minutes of cold capture/compile startup across decode buckets, so this PR keeps the lower-risk manual graph path only.

## Validation

- Local: `py_compile`, `black --check`, `isort --check-only`, `git diff --check`
- Commit hooks: passed during commit
- H200 after rebase onto `origin/main`: `CUDA_VISIBLE_DEVICES=3 TMPDIR=/data/tmp pytest -q tests/unit_test/qwen3_omni/test_talker.py -k "code_predictor or cuda_graph_capture or predictor_decode_graph"`
  - `4 passed, 61 deselected`
