### PR TITLE
Prototype Fish reference encode batching

### DIFF
--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
+import torch.nn.functional as F
 
 from sglang_omni.models.fishaudio_s2_pro.payload_types import S2ProState
 from sglang_omni.preprocessing.cache_key import hash_bytes as _hash_bytes
@@ -152,11 +153,25 @@ class _FishReferenceEncodeHook(
         )
 
     def encode_one(self, item: _FishReferenceInput) -> torch.Tensor:
+        return self.encode_batch([item])[0]
+
+    def can_encode_batch(self) -> bool:
+        return True
+
+    def encode_batch(self, items: list[_FishReferenceInput]) -> list[torch.Tensor]:
+        if not items:
+            return []
+        waveforms = [self._load_reference_waveform(item) for item in items]
+        return self._encode_reference_waveforms(waveforms)
+
+    def _load_reference_waveform(
+        self, item: _FishReferenceInput
+    ) -> tuple[torch.Tensor, int]:
         if item.source_kind == "path":
             import torchaudio
 
             audio, sr = torchaudio.load(str(item.source))
-            return self._encode_reference_waveform(audio, int(sr))
+            return audio.float(), int(sr)
         if item.source_kind in ("bytes", "base64"):
             from sglang_omni.preprocessing.audio import AudioMediaIO
 
@@ -168,7 +183,7 @@ class _FishReferenceEncodeHook(
                     item.media_type or "audio/wav", item.source
                 )
             audio_tensor = torch.from_numpy(audio).float().reshape(1, -1)
-            return self._encode_reference_waveform(audio_tensor, int(sr))
+            return audio_tensor, int(sr)
         raise TypeError(f"unknown FishAudio reference source: {item.source_kind}")
 
     def store_artifact(self, artifact: torch.Tensor) -> torch.Tensor:
@@ -193,19 +208,47 @@ class _FishReferenceEncodeHook(
             return f"base64:{media_type}:{_hash_bytes(payload)}"
         return None
 
-    def _encode_reference_waveform(self, audio: torch.Tensor, sr: int) -> torch.Tensor:
+    def _encode_reference_waveforms(
+        self, waveforms: list[tuple[torch.Tensor, int]]
+    ) -> list[torch.Tensor]:
         import torchaudio
 
-        if audio.shape[0] > 1:
-            audio = audio.mean(0, keepdim=True)
-        audio = torchaudio.functional.resample(audio, sr, self._codec.sample_rate)
-        audios = audio.squeeze(0).unsqueeze(0)
-        audio_lengths = torch.tensor([audios.shape[1]], dtype=torch.long)
+        audio_rows: list[torch.Tensor] = []
+        lengths: list[int] = []
+        for audio, sr in waveforms:
+            if audio.shape[0] > 1:
+                audio = audio.mean(0, keepdim=True)
+            audio = torchaudio.functional.resample(audio, sr, self._codec.sample_rate)
+            row = audio.squeeze(0).contiguous().float()
+            audio_rows.append(row)
+            lengths.append(int(row.shape[0]))
+
+        max_len = max(lengths)
+        audios = torch.stack(
+            [F.pad(row, (0, max_len - row.shape[0])) for row in audio_rows]
+        )
+        audio_lengths = torch.tensor(lengths, dtype=torch.long)
         with torch.no_grad():
-            indices, _ = self._codec.encode(audios, audio_lengths)
-            if indices.ndim == 3:
-                indices = indices[0]
-        return indices.cpu()
+            indices, indices_lens = self._codec.encode(audios, audio_lengths)
+        if indices.ndim == 2 and len(waveforms) == 1:
+            indices = indices.unsqueeze(0)
+        if indices.shape[0] != len(waveforms):
+            raise ValueError(
+                "FishAudio codec returned batch "
+                f"{indices.shape[0]} for {len(waveforms)} inputs"
+            )
+        if indices_lens is None:
+            indices_lens = torch.full(
+                (len(waveforms),),
+                indices.shape[-1],
+                dtype=torch.long,
+                device=indices.device,
+            )
+        results = []
+        for item_indices, item_len in zip(indices, indices_lens):
+            length = int(item_len.item() if hasattr(item_len, "item") else item_len)
+            results.append(item_indices[..., :length].cpu())
+        return results
 
 
 # ---------------------------------------------------------------------------
@@ -217,6 +260,8 @@ def create_preprocessing_executor(
     model_path: str,
     *,
     max_concurrency: int = 8,
+    reference_encode_batch_size: int = 1,
+    reference_encode_batch_wait_ms: int = 0,
 ):
     """Returns a threaded scheduler for CPU-heavy preprocessing."""
     from sglang_omni.scheduling.threaded_simple_scheduler import ThreadedSimpleScheduler
@@ -239,6 +284,8 @@ def create_preprocessing_executor(
         max_bytes=64 * 1024 * 1024,
         timeout_s=130.0,
         log_prefix="FishAudio S2-Pro",
+        max_batch_size=reference_encode_batch_size,
+        max_batch_wait_ms=reference_encode_batch_wait_ms,
     )
 
     def _preprocess(payload: StagePayload) -> StagePayload:

--- a/sglang_omni/scheduling/reference_encoder.py
+++ b/sglang_omni/scheduling/reference_encoder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import concurrent.futures
 import json
 import logging
+import queue as _queue_mod
 import threading
 import time
 from dataclasses import asdict, dataclass
@@ -53,8 +54,10 @@ class ReferenceEncodeHook(Generic[InputT, ArtifactT, StoredT]):
     def revalidate(self, item: InputT, key: ReferenceEncodeKey) -> bool:
         return True
 
+    def can_encode_batch(self) -> bool:
+        return False
+
     def encode_batch(self, items: list[InputT]) -> list[ArtifactT]:
-        """Reserved; ReferenceEncodeService does not call this until batching."""
         return [self.encode_one(item) for item in items]
 
 
@@ -70,8 +73,19 @@ def _fresh_exception(exc: BaseException) -> BaseException:
     return fresh
 
 
+@dataclass
+class _BatchJob(Generic[InputT, StoredT]):
+    item: InputT
+    key: ReferenceEncodeKey
+    cache_key: str
+    future: concurrent.futures.Future[StoredT]
+    desc: str | None
+    request_id: str | None
+
+
 class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
     _LOG_INTERVAL_S = 60.0
+    _BATCH_STOP = object()
 
     def __init__(
         self,
@@ -81,15 +95,25 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
         max_bytes: int | None = 64 * 1024 * 1024,
         timeout_s: float = 130.0,
         log_prefix: str | None = None,
+        max_batch_size: int = 1,
+        max_batch_wait_ms: int = 0,
     ) -> None:
         if max_items is not None and max_items < 1:
             raise ValueError(f"max_items must be >= 1, got {max_items}")
         if max_bytes is not None and max_bytes < 1:
             raise ValueError(f"max_bytes must be >= 1, got {max_bytes}")
+        if max_batch_size < 1:
+            raise ValueError(f"max_batch_size must be >= 1, got {max_batch_size}")
+        if max_batch_wait_ms < 0:
+            raise ValueError(
+                f"max_batch_wait_ms must be >= 0, got {max_batch_wait_ms}"
+            )
         self._hook = hook
         self._cache = StageOutputCache(max_size=max_items, max_bytes=max_bytes)
         self._timeout_s = float(timeout_s)
         self._log_prefix = log_prefix
+        self._max_batch_size = int(max_batch_size)
+        self._max_batch_wait_s = float(max_batch_wait_ms) / 1000.0
         self._lock = threading.Lock()
         self._inflight: dict[str, concurrent.futures.Future[StoredT]] = {}
         self._hits = 0
@@ -97,7 +121,21 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
         self._merged = 0
         self._failed = 0
         self._uncacheable = 0
+        self._batches = 0
+        self._batched_items = 0
+        self._batch_fallbacks = 0
         self._last_log_time = 0.0
+        self._batch_enabled = self._max_batch_size > 1 and hook.can_encode_batch()
+        self._batch_queue: _queue_mod.Queue[Any] | None = None
+        self._batch_thread: threading.Thread | None = None
+        if self._batch_enabled:
+            self._batch_queue = _queue_mod.Queue()
+            self._batch_thread = threading.Thread(
+                target=self._batch_worker,
+                name="reference-encode-batch",
+                daemon=True,
+            )
+            self._batch_thread.start()
 
     @staticmethod
     def _event_metadata(
@@ -267,6 +305,16 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
             return self._hook.load_artifact(stored)
 
         assert leader_fut is not None
+        if self._batch_enabled:
+            return self._enqueue_batch_job(
+                item=item,
+                key=key,
+                cache_key=cache_key,
+                future=leader_fut,
+                desc=desc,
+                request_id=request_id,
+            )
+
         # note (luojiaxuan): revalidate and cache put share the encode guard.
         # A failure must drop inflight and fail the future so same-key followers
         # do not wait on a dead leader after a reference mutates mid-encode.
@@ -320,6 +368,152 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
         self._maybe_log()
         return self._hook.load_artifact(stored)
 
+    def _enqueue_batch_job(
+        self,
+        *,
+        item: InputT,
+        key: ReferenceEncodeKey,
+        cache_key: str,
+        future: concurrent.futures.Future[StoredT],
+        desc: str | None,
+        request_id: str | None,
+    ) -> ArtifactT:
+        assert self._batch_queue is not None
+        self._batch_queue.put(
+            _BatchJob(
+                item=item,
+                key=key,
+                cache_key=cache_key,
+                future=future,
+                desc=desc,
+                request_id=request_id,
+            )
+        )
+        try:
+            stored = future.result(timeout=self._timeout_s)
+        except BaseException as exc:
+            self._add_exception_note(exc, desc)
+            raise
+        self._maybe_log()
+        return self._hook.load_artifact(stored)
+
+    def _batch_worker(self) -> None:
+        assert self._batch_queue is not None
+        while True:
+            job = self._batch_queue.get()
+            if job is self._BATCH_STOP:
+                return
+            batch = [job]
+            deadline = time.monotonic() + self._max_batch_wait_s
+            while len(batch) < self._max_batch_size:
+                try:
+                    if self._max_batch_wait_s <= 0:
+                        next_job = self._batch_queue.get_nowait()
+                    else:
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            break
+                        next_job = self._batch_queue.get(timeout=remaining)
+                except _queue_mod.Empty:
+                    break
+                if next_job is self._BATCH_STOP:
+                    self._batch_queue.put(self._BATCH_STOP)
+                    break
+                batch.append(next_job)
+            self._run_batch_jobs(batch)
+
+    def _run_batch_jobs(self, batch: list[_BatchJob[InputT, StoredT]]) -> None:
+        for job in batch:
+            self._emit_event(
+                job.request_id,
+                "reference_encode_start",
+                key=job.key,
+                result="miss",
+            )
+        try:
+            artifacts = self._hook.encode_batch([job.item for job in batch])
+            if len(artifacts) != len(batch):
+                raise ValueError(
+                    "encode_batch returned "
+                    f"{len(artifacts)} results for {len(batch)} inputs"
+                )
+        except BaseException:
+            logger.warning(
+                "Reference encode batch failed; retrying each item",
+                exc_info=True,
+            )
+            with self._lock:
+                self._batch_fallbacks += 1
+            for job in batch:
+                self._run_batch_job_one(job)
+            return
+
+        with self._lock:
+            self._batches += 1
+            self._batched_items += len(batch)
+        for job, artifact in zip(batch, artifacts):
+            self._complete_batch_job(job, artifact)
+
+    def _run_batch_job_one(self, job: _BatchJob[InputT, StoredT]) -> None:
+        try:
+            artifact = self._hook.encode_one(job.item)
+        except BaseException as exc:
+            self._fail_batch_job(job, exc, phase="encode")
+            return
+        self._complete_batch_job(job, artifact)
+
+    def _complete_batch_job(
+        self,
+        job: _BatchJob[InputT, StoredT],
+        artifact: ArtifactT,
+    ) -> None:
+        try:
+            stored = self._hook.store_artifact(artifact)
+            should_cache = self._hook.revalidate(job.item, job.key)
+            with self._lock:
+                if should_cache:
+                    self._cache.put(job.cache_key, stored)
+                self._inflight.pop(job.cache_key, None)
+        except BaseException as exc:
+            self._fail_batch_job(job, exc, phase="post_encode")
+            return
+        self._emit_event(
+            job.request_id,
+            "reference_encode_end",
+            key=job.key,
+            result="success",
+            cacheable=True,
+        )
+        job.future.set_result(stored)
+
+    def _fail_batch_job(
+        self,
+        job: _BatchJob[InputT, StoredT],
+        exc: BaseException,
+        *,
+        phase: str,
+    ) -> None:
+        self._add_exception_note(exc, job.desc)
+        with self._lock:
+            self._inflight.pop(job.cache_key, None)
+            self._failed += 1
+        self._emit_event(
+            job.request_id,
+            "reference_encode_end",
+            key=job.key,
+            result="error",
+            error_type=type(exc).__name__,
+        )
+        self._emit_event(
+            job.request_id,
+            "reference_encode_failure",
+            key=job.key,
+            result="error",
+            phase=phase,
+            error_type=type(exc).__name__,
+        )
+        job.future.set_exception(exc)
+
     def stats(self) -> dict[str, int]:
         with self._lock:
             return {
@@ -331,6 +525,9 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
                 "evictions": self._cache.eviction_count,
                 "failed": self._failed,
                 "uncacheable": self._uncacheable,
+                "batches": self._batches,
+                "batched_items": self._batched_items,
+                "batch_fallbacks": self._batch_fallbacks,
             }
 
     @staticmethod
@@ -360,5 +557,14 @@ class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
                 "evictions": self._cache.eviction_count,
                 "failed": self._failed,
                 "uncacheable": self._uncacheable,
+                "batches": self._batches,
+                "batched_items": self._batched_items,
+                "batch_fallbacks": self._batch_fallbacks,
             }
         logger.info("%s reference encode stats: %s", self._log_prefix, stats)
+
+    def close(self) -> None:
+        if self._batch_queue is None or self._batch_thread is None:
+            return
+        self._batch_queue.put(self._BATCH_STOP)
+        self._batch_thread.join(timeout=1.0)

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -661,6 +661,70 @@ def test_fish_reference_encode_service_failure_does_not_poison(
     assert codec.calls == 2
 
 
+def test_fish_reference_encode_batch_pads_and_preserves_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from sglang_omni.models.fishaudio_s2_pro.stages import _FishReferenceEncodeHook
+    from sglang_omni.preprocessing import audio as audio_module
+
+    class _AudioMediaIO:
+        def __init__(self, *, target_sr: int) -> None:
+            self.target_sr = target_sr
+
+        def load_bytes(self, payload: bytes):
+            length = int(payload.decode("ascii"))
+            return np.arange(length, dtype=np.float32), self.target_sr
+
+    class _Codec:
+        sample_rate = 16000
+
+        def __init__(self) -> None:
+            self.calls = 0
+            self.audios: torch.Tensor | None = None
+            self.audio_lengths: torch.Tensor | None = None
+
+        def encode(self, audios: torch.Tensor, audio_lengths: torch.Tensor):
+            self.calls += 1
+            self.audios = audios.detach().clone()
+            self.audio_lengths = audio_lengths.detach().clone()
+            max_frames = int(torch.ceil(audio_lengths.float().max() / 4).item())
+            codes = torch.zeros((audios.shape[0], 2, max_frames), dtype=torch.long)
+            for row in range(audios.shape[0]):
+                codes[row, 0] = row + 1
+                codes[row, 1] = row + 11
+            lengths = torch.ceil(audio_lengths.float() / 4).long()
+            return codes, lengths
+
+    monkeypatch.setattr(audio_module, "AudioMediaIO", _AudioMediaIO)
+    monkeypatch.setitem(
+        sys.modules,
+        "torchaudio",
+        SimpleNamespace(
+            functional=SimpleNamespace(
+                resample=lambda audio, sr, target_sr: audio,
+            )
+        ),
+    )
+
+    codec = _Codec()
+    hook = _FishReferenceEncodeHook(codec=codec, checkpoint_id="ckpt")
+
+    results = hook.encode_batch(
+        [
+            hook.normalize_input({"bytes": b"8"}),
+            hook.normalize_input({"bytes": b"12"}),
+        ]
+    )
+
+    assert codec.calls == 1
+    assert codec.audios is not None
+    assert codec.audio_lengths is not None
+    assert codec.audios.shape == (2, 12)
+    assert torch.equal(codec.audio_lengths, torch.tensor([8, 12]))
+    assert torch.equal(results[0], torch.tensor([[1, 1], [11, 11]]))
+    assert torch.equal(results[1], torch.tensor([[2, 2, 2], [12, 12, 12]]))
+
+
 def test_fish_reference_path_mutation_returns_but_does_not_cache(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit_test/scheduling/test_reference_encoder.py
+++ b/tests/unit_test/scheduling/test_reference_encoder.py
@@ -92,6 +92,21 @@ class _TensorHook(ReferenceEncodeHook[str, torch.Tensor, torch.Tensor]):
         return stored.detach().clone().to(dtype=torch.long)
 
 
+class _BatchTensorHook(_TensorHook):
+    def __init__(self) -> None:
+        super().__init__()
+        self.batch_calls: list[list[str]] = []
+        self.batch_lock = threading.Lock()
+
+    def can_encode_batch(self) -> bool:
+        return True
+
+    def encode_batch(self, items: list[str]) -> list[torch.Tensor]:
+        with self.batch_lock:
+            self.batch_calls.append(list(items))
+        return [self.encode_one(item) for item in items]
+
+
 def test_same_key_concurrent_single_flight() -> None:
     release = threading.Event()
     entered = threading.Event()
@@ -155,6 +170,94 @@ def test_cache_hit_returns_loaded_artifact() -> None:
     assert torch.all(second >= 0)
     assert first.data_ptr() != second.data_ptr()
     assert service.stats()["hits"] == 1
+
+
+def test_different_keys_coalesce_when_hook_opts_in() -> None:
+    worker_count = 4
+    gate = _FirstWaveGate(worker_count)
+
+    class _GatedBatchHook(_BatchTensorHook):
+        def normalize_input(self, raw_input: Any) -> str:
+            item = super().normalize_input(raw_input)
+            gate.wait()
+            return item
+
+    hook = _GatedBatchHook()
+    service = ReferenceEncodeService(
+        hook,
+        max_items=16,
+        max_bytes=1024,
+        max_batch_size=worker_count,
+        max_batch_wait_ms=50,
+    )
+    results: list[torch.Tensor | None] = [None] * worker_count
+
+    def worker(index: int) -> None:
+        results[index] = service.get_or_encode(f"item-{index}")
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(worker_count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert all(not thread.is_alive() for thread in threads)
+    multi_item_calls = [call for call in hook.batch_calls if len(call) > 1]
+    assert len(multi_item_calls) == 1
+    assert set(multi_item_calls[0]) == {f"item-{i}" for i in range(worker_count)}
+    assert all(result is not None for result in results)
+    stats = service.stats()
+    assert stats["misses"] == worker_count
+    assert stats["batches"] == 1
+    assert stats["batched_items"] == worker_count
+    service.close()
+
+
+def test_batch_failure_retries_each_item() -> None:
+    worker_count = 3
+    gate = _FirstWaveGate(worker_count)
+
+    class _FallbackHook(_BatchTensorHook):
+        def normalize_input(self, raw_input: Any) -> str:
+            item = super().normalize_input(raw_input)
+            gate.wait()
+            return item
+
+        def encode_batch(self, items: list[str]) -> list[torch.Tensor]:
+            with self.batch_lock:
+                self.batch_calls.append(list(items))
+            raise RuntimeError("batch failed")
+
+    hook = _FallbackHook()
+    service = ReferenceEncodeService(
+        hook,
+        max_items=16,
+        max_bytes=1024,
+        max_batch_size=worker_count,
+        max_batch_wait_ms=50,
+    )
+    results: list[torch.Tensor | None] = [None] * worker_count
+
+    def worker(index: int) -> None:
+        results[index] = service.get_or_encode(f"fallback-{index}")
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(worker_count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert all(result is not None for result in results)
+    assert len(hook.batch_calls) == 1
+    assert set(hook.batch_calls[0]) == {
+        f"fallback-{i}" for i in range(worker_count)
+    }
+    assert hook.calls == Counter({f"fallback-{i}": 1 for i in range(worker_count)})
+    stats = service.stats()
+    assert stats["batch_fallbacks"] == 1
+    assert stats["failed"] == 0
+    service.close()
 
 
 def test_key_none_bypasses_cache() -> None:


### PR DESCRIPTION
Experimental Fish-only prototype. Do not merge.

Result:
Baseline c16, 64 samples, cold cache: latency p95 14.625s, throughput 1.197 qps, ref encode p95 8507.316 ms, misses 40, merged 24.
Batch8 wait10 c16: latency p95 81.147s, throughput 0.224 qps, ref encode p95 46832.934 ms, misses 40, merged 23, batches 12, batched_items 37.

Conclusion:
Negative evidence. Different-key Fish reference batching through padded codec.encode is much slower, so this should not become a formal Fish batching implementation.

Scheduler impact:
No SimpleScheduler runtime change needed. ReferenceEncodeService queue was enough for this experiment, and no real max_concurrency plus batch_compute_fn consumer showed up.

Artifacts:
Stored on hyper01.
