### PR TITLE
[Async]: Fix async decode stale batch KV slot ownership

### DIFF
--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -1788,8 +1788,13 @@ class OmniScheduler:
                 time.sleep(0.001)
                 continue
 
-            if self._async_pending is not None and (
-                self.chunked_req is not None or self.waiting_queue
+            if (
+                self._async_pending is not None
+                and self.is_mixed_chunk
+                and (
+                    self.chunked_req is not None
+                    or (self.waiting_queue and not self.running_batch.batch_is_full)
+                )
             ):
                 self._resolve_pending_async()
 

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -1758,10 +1758,13 @@ class OmniScheduler:
         if not any(drop):
             return batch
         keep = [i for i, d in enumerate(drop) if not d]
+        out_cache_loc = batch.out_cache_loc
         self._free_overrun_step_slots(
-            batch.out_cache_loc, [i for i, d in enumerate(drop) if d]
+            out_cache_loc, [i for i, d in enumerate(drop) if d]
         )
         batch.filter_batch(keep_indices=keep)
+        if out_cache_loc is not None:
+            batch.out_cache_loc = out_cache_loc[keep]
         return batch if batch.reqs else None
 
     def _event_loop_async_decode(self) -> None:
@@ -1784,6 +1787,11 @@ class OmniScheduler:
                 self._resolve_pending_async()
                 time.sleep(0.001)
                 continue
+
+            if self._async_pending is not None and (
+                self.chunked_req is not None or self.waiting_queue
+            ):
+                self._resolve_pending_async()
 
             batch = self.get_next_batch_to_run()
             self.cur_batch = batch

--- a/tests/unit_test/pipeline/test_async_decode.py
+++ b/tests/unit_test/pipeline/test_async_decode.py
@@ -521,6 +521,8 @@ def _new_scheduler_for_async_loop():
     s._admin_lock = threading.Lock()
     s._admin_queue = queue.Queue()
     s.chunked_req = None
+    s.is_mixed_chunk = False
+    s.running_batch = types.SimpleNamespace(batch_is_full=False)
     s.waiting_queue = []
     return s
 
@@ -605,25 +607,87 @@ def test_fast_path_threshold_four_routes_bs1_to_3_sync():
     assert events == ["sync", "launch", "resolve", "idle"]
 
 
-def test_async_pending_drains_before_waiting_prefill_is_scheduled():
+def test_async_pending_drains_before_mixed_prefill_is_built():
     events = []
     pending_batch = _FakeBatch(2)
     s = _scaffold_async_loop(
         async_pending=(pending_batch, "prev_sched", "prev_step"),
     )
+    s.is_mixed_chunk = True
     s.waiting_queue = [object()]
-    s.chunked_req = None
+    s._batch_is_decode = lambda batch: False
     s._resolve_and_process = lambda *args: events.append("resolve")
+    s.process_batch_result = lambda batch, result: None
+
+    def run_batch(batch):
+        events.append("prefill")
+        return object()
+
+    s.run_batch = run_batch
 
     def get_next_batch_to_run():
         events.append(("schedule", s._async_pending))
         s._running = False
-        return None
+        return _FakeBatch(1)
 
     s.get_next_batch_to_run = get_next_batch_to_run
     s._event_loop_async_decode()
 
-    assert events == ["resolve", ("schedule", None)]
+    assert events == ["resolve", ("schedule", None), "prefill"]
+
+
+def test_full_running_batch_keeps_lookahead_with_waiting_requests():
+    events = []
+    pending_batch = _FakeBatch(2)
+    pending = (pending_batch, "prev_sched", "prev_step")
+    s = _scaffold_async_loop(async_pending=pending)
+    s.is_mixed_chunk = True
+    s.running_batch.batch_is_full = True
+    s.waiting_queue = [object()]
+    s._resolve_and_process = lambda *args: events.append("resolve")
+
+    def launch(batch):
+        events.append("launch")
+        return "sched_output", "pending_step"
+
+    s._run_batch_launch = launch
+
+    def get_next_batch_to_run():
+        events.append(("schedule", s._async_pending is pending))
+        s._running = False
+        return _FakeBatch(2)
+
+    s.get_next_batch_to_run = get_next_batch_to_run
+    s._event_loop_async_decode()
+
+    assert events == [("schedule", True), "launch", "resolve"]
+
+
+def test_non_mixed_prefill_is_built_before_pending_decode_drains():
+    events = []
+    pending_batch = _FakeBatch(2)
+    pending = (pending_batch, "prev_sched", "prev_step")
+    s = _scaffold_async_loop(async_pending=pending)
+    s.waiting_queue = [object()]
+    s._batch_is_decode = lambda batch: False
+    s._resolve_and_process = lambda *args: events.append("resolve")
+    s.process_batch_result = lambda batch, result: None
+
+    def run_batch(batch):
+        events.append("prefill")
+        return object()
+
+    s.run_batch = run_batch
+
+    def get_next_batch_to_run():
+        events.append(("schedule", s._async_pending is pending))
+        s._running = False
+        return _FakeBatch(1)
+
+    s.get_next_batch_to_run = get_next_batch_to_run
+    s._event_loop_async_decode()
+
+    assert events == [("schedule", True), "resolve", "prefill"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_test/pipeline/test_async_decode.py
+++ b/tests/unit_test/pipeline/test_async_decode.py
@@ -511,9 +511,14 @@ class _FakeBatch:
     def __init__(self, n):
         # real ScheduleBatch.reqs are Reqs with .finished(); none finish here
         self.reqs = [types.SimpleNamespace(finished=lambda: False) for _ in range(n)]
+        self.out_cache_loc = torch.arange(n)
 
     def copy(self):
         return self
+
+    def filter_batch(self, keep_indices):
+        self.reqs = [self.reqs[i] for i in keep_indices]
+        self.out_cache_loc = None
 
 
 def _new_scheduler_for_async_loop():
@@ -522,7 +527,10 @@ def _new_scheduler_for_async_loop():
     s._admin_queue = queue.Queue()
     s.chunked_req = None
     s.is_mixed_chunk = False
+    s.page_size = 1
     s.running_batch = types.SimpleNamespace(batch_is_full=False)
+    s.server_args = types.SimpleNamespace(disable_radix_cache=False)
+    s.token_to_kv_pool_allocator = types.SimpleNamespace(free=lambda _: None)
     s.waiting_queue = []
     return s
 
@@ -759,10 +767,6 @@ def test_fast_path_does_not_double_free_req_finished_by_drain():
     s.self_check_during_idle = lambda: None
     s.self_check_during_busy = lambda: None
     s._run_batch_launch = lambda b: ("sched_output", "pending_step")
-    # the drain's _drop_stale_overrun consults the step-slot free gate
-    s.page_size = 1
-    s.server_args = types.SimpleNamespace(disable_radix_cache=False)
-    s.token_to_kv_pool_allocator = types.SimpleNamespace(free=lambda t: None)
     # real drain helper -> exercises the real fast-path ordering under test
     s._resolve_pending_async = OmniScheduler._resolve_pending_async.__get__(s)
 

--- a/tests/unit_test/pipeline/test_async_decode.py
+++ b/tests/unit_test/pipeline/test_async_decode.py
@@ -520,6 +520,8 @@ def _new_scheduler_for_async_loop():
     s = OmniScheduler.__new__(OmniScheduler)
     s._admin_lock = threading.Lock()
     s._admin_queue = queue.Queue()
+    s.chunked_req = None
+    s.waiting_queue = []
     return s
 
 
@@ -603,6 +605,27 @@ def test_fast_path_threshold_four_routes_bs1_to_3_sync():
     assert events == ["sync", "launch", "resolve", "idle"]
 
 
+def test_async_pending_drains_before_waiting_prefill_is_scheduled():
+    events = []
+    pending_batch = _FakeBatch(2)
+    s = _scaffold_async_loop(
+        async_pending=(pending_batch, "prev_sched", "prev_step"),
+    )
+    s.waiting_queue = [object()]
+    s.chunked_req = None
+    s._resolve_and_process = lambda *args: events.append("resolve")
+
+    def get_next_batch_to_run():
+        events.append(("schedule", s._async_pending))
+        s._running = False
+        return None
+
+    s.get_next_batch_to_run = get_next_batch_to_run
+    s._event_loop_async_decode()
+
+    assert events == ["resolve", ("schedule", None)]
+
+
 # ---------------------------------------------------------------------------
 # Stale-batch overrun regression: the fast-path `batch` is built (get_next_batch
 # _to_run, top of loop) BEFORE the in-flight lookahead step is drained. If the
@@ -630,7 +653,7 @@ class _DFBatch:
 
     def __init__(self, reqs):
         self.reqs = list(reqs)
-        self.out_cache_loc = None
+        self.out_cache_loc = torch.arange(100, 100 + len(reqs))
 
     def copy(self):
         return _DFBatch(self.reqs)
@@ -639,6 +662,7 @@ class _DFBatch:
         if keep_indices is None:
             keep_indices = [i for i, r in enumerate(self.reqs) if not r.finished()]
         self.reqs = [self.reqs[i] for i in keep_indices]
+        self.out_cache_loc = None
 
     def is_empty(self):
         return not self.reqs
@@ -673,6 +697,7 @@ def test_fast_path_does_not_double_free_req_finished_by_drain():
     # the drain's _drop_stale_overrun consults the step-slot free gate
     s.page_size = 1
     s.server_args = types.SimpleNamespace(disable_radix_cache=False)
+    s.token_to_kv_pool_allocator = types.SimpleNamespace(free=lambda t: None)
     # real drain helper -> exercises the real fast-path ordering under test
     s._resolve_pending_async = OmniScheduler._resolve_pending_async.__get__(s)
 

--- a/tests/unit_test/pipeline/test_async_decode.py
+++ b/tests/unit_test/pipeline/test_async_decode.py
@@ -607,14 +607,34 @@ def test_fast_path_threshold_four_routes_bs1_to_3_sync():
     assert events == ["sync", "launch", "resolve", "idle"]
 
 
-def test_async_pending_drains_before_mixed_prefill_is_built():
+@pytest.mark.parametrize(
+    (
+        "is_mixed_chunk",
+        "batch_is_full",
+        "prefill_source",
+        "has_pending_at_schedule",
+    ),
+    [
+        pytest.param(True, False, "waiting", False, id="mixed-waiting-prefill"),
+        pytest.param(False, False, "waiting", True, id="non-mixed-prefill"),
+        pytest.param(True, True, "chunked", False, id="mixed-chunked-prefill"),
+    ],
+)
+def test_pending_decode_drain_order_for_prefill(
+    is_mixed_chunk,
+    batch_is_full,
+    prefill_source,
+    has_pending_at_schedule,
+):
     events = []
+    pending_during_schedule = []
     pending_batch = _FakeBatch(2)
-    s = _scaffold_async_loop(
-        async_pending=(pending_batch, "prev_sched", "prev_step"),
-    )
-    s.is_mixed_chunk = True
-    s.waiting_queue = [object()]
+    pending = (pending_batch, "prev_sched", "prev_step")
+    s = _scaffold_async_loop(async_pending=pending)
+    s.is_mixed_chunk = is_mixed_chunk
+    s.running_batch.batch_is_full = batch_is_full
+    s.waiting_queue = [object()] if prefill_source == "waiting" else []
+    s.chunked_req = object() if prefill_source == "chunked" else None
     s._batch_is_decode = lambda batch: False
     s._resolve_and_process = lambda *args: events.append("resolve")
     s.process_batch_result = lambda batch, result: None
@@ -626,14 +646,22 @@ def test_async_pending_drains_before_mixed_prefill_is_built():
     s.run_batch = run_batch
 
     def get_next_batch_to_run():
-        events.append(("schedule", s._async_pending))
+        events.append("schedule")
+        pending_during_schedule.append(s._async_pending)
         s._running = False
         return _FakeBatch(1)
 
     s.get_next_batch_to_run = get_next_batch_to_run
     s._event_loop_async_decode()
 
-    assert events == ["resolve", ("schedule", None), "prefill"]
+    expected_events = (
+        ["schedule", "resolve", "prefill"]
+        if has_pending_at_schedule
+        else ["resolve", "schedule", "prefill"]
+    )
+    assert events == expected_events
+    expected_pending = pending if has_pending_at_schedule else None
+    assert pending_during_schedule[0] is expected_pending
 
 
 def test_full_running_batch_keeps_lookahead_with_waiting_requests():
@@ -661,33 +689,6 @@ def test_full_running_batch_keeps_lookahead_with_waiting_requests():
     s._event_loop_async_decode()
 
     assert events == [("schedule", True), "launch", "resolve"]
-
-
-def test_non_mixed_prefill_is_built_before_pending_decode_drains():
-    events = []
-    pending_batch = _FakeBatch(2)
-    pending = (pending_batch, "prev_sched", "prev_step")
-    s = _scaffold_async_loop(async_pending=pending)
-    s.waiting_queue = [object()]
-    s._batch_is_decode = lambda batch: False
-    s._resolve_and_process = lambda *args: events.append("resolve")
-    s.process_batch_result = lambda batch, result: None
-
-    def run_batch(batch):
-        events.append("prefill")
-        return object()
-
-    s.run_batch = run_batch
-
-    def get_next_batch_to_run():
-        events.append(("schedule", s._async_pending is pending))
-        s._running = False
-        return _FakeBatch(1)
-
-    s.get_next_batch_to_run = get_next_batch_to_run
-    s._event_loop_async_decode()
-
-    assert events == [("schedule", True), "resolve", "prefill"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -365,6 +365,7 @@ def test_omni_scheduler_fast_path_drops_retracted_req() -> None:
         def filter_batch(self, keep_indices=None):
             captured["keep_indices"] = keep_indices
             self.reqs = [self.reqs[i] for i in keep_indices]
+            self.out_cache_loc = None
 
     scheduler = object.__new__(OmniScheduler)
     scheduler.page_size = 1
@@ -379,6 +380,7 @@ def test_omni_scheduler_fast_path_drops_retracted_req() -> None:
     out = scheduler._drop_stale_overrun(FakeBatch([keep, retr]))
     assert captured["keep_indices"] == [0]
     assert [r.rid for r in out.reqs] == ["keep"]
+    assert out.out_cache_loc.tolist() == [100]
     assert freed == [101]
 
     # all dropped -> None so run_batch is skipped


### PR DESCRIPTION
## Summary

Fix Omni async decode stale-batch handling so an in-flight lookahead step is resolved before scheduling pending prefill/chunked work, and preserve decode `out_cache_loc` when stale decode rows are filtered after a pending-step drain.

This keeps the sync scheduler path unchanged and only touches the async decode event loop. The focused CPU regression coverage now checks that pending async work is drained before waiting prefill scheduling and that stale decode filtering keeps the prepared KV slot locations for surviving rows.

## Root Cause

The async decode loop could build the next batch with `get_next_batch_to_run()` while a previous lookahead decode step was still pending. If the pending step then finished or retracted a request, `_drop_stale_overrun()` filtered that already-prepared stale batch before forwarding it.

SGLang `ScheduleBatch.filter_batch()` intentionally clears `out_cache_loc`, because generic filtering invalidates the current forward allocation metadata. The async loop then forwarded the filtered batch without rebuilding it, so the backend could receive `out_cache_loc=None` as the KV-store indices. In the failing video workloads this surfaced downstream as `store_cache` receiving `None` for the DLTensor indices argument, followed by CUDA illegal memory access / thinker process abort.

The fix avoids prepared extend/mixed stale-batch surgery by draining pending async decode before prefill/chunked scheduling, and keeps the remaining stale-overrun filtering on the decode-shaped path where `out_cache_loc` is row-aligned and can be restored for kept rows.