### PR TITLE
[Qwen3-ASR] Auto-scale decode batch caps to GPU memory

### DIFF
--- a/sglang_omni/models/qwen3_asr/config.py
+++ b/sglang_omni/models/qwen3_asr/config.py
@@ -24,10 +24,13 @@ class Qwen3ASRPipelineConfig(PipelineConfig):
             factory=f"{_PKG}.stages.create_sglang_qwen3_asr_executor",
             factory_args={
                 "device": "cuda:0",
-                "max_running_requests": 32,
+                # "auto" -> tier max_running_requests + request_build_max_pending
+                # to the GPU's total memory (see auto_generation_batch_caps);
+                # small / CI-class GPUs keep the historical 32 / 16.
+                "max_running_requests": "auto",
                 "max_new_tokens": 128,
                 "request_build_max_workers": 2,
-                "request_build_max_pending": 16,
+                "request_build_max_pending": "auto",
             },
             gpu=0,
             terminal=True,

--- a/sglang_omni/models/qwen3_asr/stages.py
+++ b/sglang_omni/models/qwen3_asr/stages.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from sglang.srt.managers.mm_utils import init_mm_embedding_cache
@@ -16,6 +17,7 @@ from sglang_omni.scheduling.bootstrap import (
     create_sglang_infrastructure_defer_cuda_graph,
 )
 from sglang_omni.scheduling.generation_batch_policy import (
+    auto_generation_batch_caps,
     build_generation_batch_overrides,
     validate_generation_batch_policy,
 )
@@ -25,6 +27,47 @@ from sglang_omni.scheduling.sglang_backend import (
     build_sglang_server_args,
 )
 from sglang_omni.utils.gpu_compat import get_visible_gpu_sm_version
+from sglang_omni.utils.gpu_memory import format_bytes_gib, get_gpu_device_info
+
+logger = logging.getLogger(__name__)
+
+_AUTO = "auto"
+
+
+def _resolve_generation_batch_caps(
+    gpu_id: int,
+    max_running_requests: int | str,
+    request_build_max_pending: int | str | None,
+) -> tuple[int, int | None]:
+    """Resolve ``"auto"`` generation-batch caps from the GPU's total memory.
+
+    Explicit integer values pass through untouched; ``"auto"`` triggers the
+    memory-tiered defaults (see ``auto_generation_batch_caps``). The GPU is
+    queried at most once, only when something is actually ``"auto"``.
+    """
+    auto_mrr: int | None = None
+    auto_backlog: int | None = None
+    if _AUTO in (max_running_requests, request_build_max_pending):
+        info = get_gpu_device_info(gpu_id)
+        auto_mrr, auto_backlog = auto_generation_batch_caps(info.total_memory_bytes)
+        logger.info(
+            "Qwen3-ASR auto batch caps: gpu=%s (%s) -> "
+            "max_running_requests=%s, request_build_max_pending=%s",
+            gpu_id,
+            format_bytes_gib(info.total_memory_bytes),
+            auto_mrr,
+            auto_backlog,
+        )
+
+    if max_running_requests == _AUTO:
+        max_running_requests = auto_mrr
+    if request_build_max_pending == _AUTO:
+        request_build_max_pending = auto_backlog
+
+    resolved_pending = (
+        None if request_build_max_pending is None else int(request_build_max_pending)
+    )
+    return int(max_running_requests), resolved_pending
 
 
 def create_sglang_qwen3_asr_executor(
@@ -32,18 +75,22 @@ def create_sglang_qwen3_asr_executor(
     *,
     device: str = "cuda:0",
     dtype: str = "float16",
-    max_running_requests: int = 32,
+    max_running_requests: int | str = "auto",
     max_new_tokens: int = 256,
     mem_fraction_static: float | None = None,
     mm_embedding_cache_size_bytes: int = 0,
     enable_torch_compile: bool = False,
     mm_attention_backend: str | None = None,
     request_build_max_workers: int = 2,
-    request_build_max_pending: int | None = 16,
+    request_build_max_pending: int | str | None = "auto",
     server_args_overrides: dict[str, Any] | None = None,
 ):
 
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0
+
+    max_running_requests, request_build_max_pending = _resolve_generation_batch_caps(
+        gpu_id, max_running_requests, request_build_max_pending
+    )
 
     tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
     feature_extractor = AutoFeatureExtractor.from_pretrained(

--- a/sglang_omni/scheduling/generation_batch_policy.py
+++ b/sglang_omni/scheduling/generation_batch_policy.py
@@ -24,6 +24,39 @@ def build_default_cuda_graph_bs(max_bs: int) -> list[int]:
     return values
 
 
+_GIB = 1024**3
+
+# max_running_requests also drives cuda_graph_max_bs (see
+# build_generation_batch_overrides), so a larger cap raises CUDA-graph capture
+# VRAM. The tiers therefore key off *total* GPU memory and keep the historical
+# (32, 16) as the floor: small / CI-class GPUs stay byte-for-byte unchanged,
+# while big GPUs -- which otherwise leave KV headroom idle -- get a decode batch
+# cap that uses it (and a proportionally larger request-build backlog so bursts
+# are not rejected before they can be built). Thresholds are in GiB.
+_AUTO_BATCH_CAP_TIERS: tuple[tuple[float, int, int], ...] = (
+    (70.0, 128, 256),  # H100/H200/A100-80G and larger
+    (40.0, 64, 128),  # A100-40G, L40/L40S/A6000-48G
+)
+_AUTO_BATCH_CAP_FLOOR: tuple[int, int] = (32, 16)
+
+
+def auto_generation_batch_caps(
+    total_memory_bytes: int | None,
+) -> tuple[int, int]:
+    """Pick ``(max_running_requests, request_build_max_pending)`` for a GPU.
+
+    Returns the historical ``(32, 16)`` floor when total memory is unknown or
+    small, so auto-scaling is a no-op on small / CI-class GPUs. Bigger GPUs get
+    a larger decode batch and a proportionally larger build backlog.
+    """
+    if total_memory_bytes is not None and total_memory_bytes > 0:
+        total_gib = total_memory_bytes / _GIB
+        for threshold_gib, max_running_requests, backlog in _AUTO_BATCH_CAP_TIERS:
+            if total_gib >= threshold_gib:
+                return max_running_requests, backlog
+    return _AUTO_BATCH_CAP_FLOOR
+
+
 def build_generation_batch_overrides(
     *,
     max_running_requests: int,

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -11,7 +11,7 @@ from sglang_omni.models.qwen3_asr.stages import create_sglang_qwen3_asr_executor
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
 
 
-def test_qwen3_asr_config_uses_batched_stage_with_32_running_requests() -> None:
+def test_qwen3_asr_config_uses_batched_stage_with_auto_batch_caps() -> None:
     config = Qwen3ASRPipelineConfig(model_path="Qwen/Qwen3-ASR-1.7B")
 
     assert config.entry_stage == "asr"
@@ -20,9 +20,10 @@ def test_qwen3_asr_config_uses_batched_stage_with_32_running_requests() -> None:
     assert config.gpu_placement == {"asr": 0}
     assert config.stages[0].factory.endswith("create_sglang_qwen3_asr_executor")
     assert config.stages[0].factory_args["device"] == "cuda:0"
-    assert config.stages[0].factory_args["max_running_requests"] == 32
+    # Batch caps auto-tier to the GPU's total memory (small GPUs keep 32 / 16).
+    assert config.stages[0].factory_args["max_running_requests"] == "auto"
     assert config.stages[0].factory_args["request_build_max_workers"] == 2
-    assert config.stages[0].factory_args["request_build_max_pending"] == 16
+    assert config.stages[0].factory_args["request_build_max_pending"] == "auto"
     assert "request_build_max_backlog" not in config.stages[0].factory_args
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config("Qwen3ASRForConditionalGeneration")
@@ -30,12 +31,12 @@ def test_qwen3_asr_config_uses_batched_stage_with_32_running_requests() -> None:
     )
 
 
-def test_qwen3_asr_stage_default_allows_32_running_requests() -> None:
+def test_qwen3_asr_stage_defaults_to_auto_batch_caps() -> None:
     signature = inspect.signature(create_sglang_qwen3_asr_executor)
 
-    assert signature.parameters["max_running_requests"].default == 32
+    assert signature.parameters["max_running_requests"].default == "auto"
     assert signature.parameters["request_build_max_workers"].default == 2
-    assert signature.parameters["request_build_max_pending"].default == 16
+    assert signature.parameters["request_build_max_pending"].default == "auto"
     assert "request_build_max_backlog" not in signature.parameters
 
 
@@ -74,6 +75,14 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
         qwen3_asr_stages,
         "get_visible_gpu_sm_version",
         lambda gpu_id: None,
+    )
+    # Force the "auto" batch caps to the small-GPU floor (32 / 16) so the
+    # cuda_graph_max_bs assertions below are deterministic regardless of the
+    # host GPU the unit tests happen to run on.
+    monkeypatch.setattr(
+        qwen3_asr_stages,
+        "get_gpu_device_info",
+        lambda gpu_id: SimpleNamespace(total_memory_bytes=None),
     )
     monkeypatch.setattr(qwen3_asr_stages, "init_mm_embedding_cache", lambda size: None)
     monkeypatch.setattr(
@@ -128,3 +137,89 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
 
     assert build_kwargs["cuda_graph_max_bs"] == 32
     assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 12, 16, 24, 32]
+
+
+def test_qwen3_asr_auto_batch_caps_scale_on_large_gpu(monkeypatch) -> None:
+    build_kwargs: dict[str, object] = {}
+    scheduler_kwargs: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        qwen3_asr_stages.AutoTokenizer,
+        "from_pretrained",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        qwen3_asr_stages.AutoFeatureExtractor,
+        "from_pretrained",
+        lambda *args, **kwargs: SimpleNamespace(nb_max_frames=3000),
+    )
+    monkeypatch.setattr(
+        qwen3_asr_stages,
+        "get_visible_gpu_sm_version",
+        lambda gpu_id: None,
+    )
+    # An 80 GiB GPU (H100-class) must lift the auto caps to 128 / 256, and that
+    # must flow through to cuda_graph_max_bs and the scheduler's build backlog.
+    monkeypatch.setattr(
+        qwen3_asr_stages,
+        "get_gpu_device_info",
+        lambda gpu_id: SimpleNamespace(total_memory_bytes=80 * (1024**3)),
+    )
+    monkeypatch.setattr(qwen3_asr_stages, "init_mm_embedding_cache", lambda size: None)
+    monkeypatch.setattr(
+        qwen3_asr_stages,
+        "make_qwen3_asr_scheduler_adapters",
+        lambda **kwargs: (object(), object()),
+    )
+    monkeypatch.setattr(
+        qwen3_asr_stages,
+        "ModelRunner",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        qwen3_asr_stages,
+        "SGLangOutputProcessor",
+        lambda **kwargs: object(),
+    )
+
+    def _capture_scheduler(**kwargs):
+        scheduler_kwargs.update(kwargs)
+        return SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(qwen3_asr_stages, "OmniScheduler", _capture_scheduler)
+
+    def _fake_server_args_builder(model_path, context_length, **overrides):
+        build_kwargs.update(overrides)
+        return SimpleNamespace(**overrides)
+
+    def _fake_create_infrastructure(server_args, gpu_id, **kwargs):
+        model_worker = SimpleNamespace(model_runner=SimpleNamespace(model=object()))
+        return False, (
+            model_worker,
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+            object(),
+        )
+
+    monkeypatch.setattr(
+        qwen3_asr_stages,
+        "build_sglang_server_args",
+        _fake_server_args_builder,
+    )
+    monkeypatch.setattr(
+        qwen3_asr_stages,
+        "create_sglang_infrastructure_defer_cuda_graph",
+        _fake_create_infrastructure,
+    )
+
+    qwen3_asr_stages.create_sglang_qwen3_asr_executor("dummy")
+
+    assert build_kwargs["max_running_requests"] == 128
+    assert build_kwargs["cuda_graph_max_bs"] == 128
+    assert max(build_kwargs["cuda_graph_bs"]) == 128
+    # request_build_max_workers stays at its conservative default (GIL headroom).
+    assert scheduler_kwargs["request_build_max_workers"] == 2
+    assert scheduler_kwargs["request_build_max_pending"] == 256

--- a/tests/unit_test/serve/test_generation_batch_policy.py
+++ b/tests/unit_test/serve/test_generation_batch_policy.py
@@ -8,10 +8,13 @@ from types import SimpleNamespace
 import pytest
 
 from sglang_omni.scheduling.generation_batch_policy import (
+    auto_generation_batch_caps,
     build_default_cuda_graph_bs,
     build_generation_batch_overrides,
     validate_generation_batch_policy,
 )
+
+_GIB = 1024**3
 
 
 def _server_args(**overrides: object) -> SimpleNamespace:
@@ -25,6 +28,33 @@ def _server_args(**overrides: object) -> SimpleNamespace:
     }
     values.update(overrides)
     return SimpleNamespace(**values)
+
+
+@pytest.mark.parametrize(
+    ("total_gib", "expected"),
+    [
+        (80, (128, 256)),  # H100/A100-80G
+        (141, (128, 256)),  # H200
+        (70, (128, 256)),  # tier boundary (inclusive)
+        (48, (64, 128)),  # L40S/A6000
+        (40, (64, 128)),  # A100-40G, tier boundary (inclusive)
+        (39.9, (32, 16)),  # just below 40G -> floor
+        (24, (32, 16)),  # A10/L4/consumer
+        (16, (32, 16)),  # T4
+    ],
+)
+def test_auto_generation_batch_caps_tiers_by_memory(
+    total_gib: float, expected: tuple[int, int]
+) -> None:
+    assert auto_generation_batch_caps(int(total_gib * _GIB)) == expected
+
+
+def test_auto_generation_batch_caps_falls_back_to_floor_when_unknown() -> None:
+    # NVML/torch may be unable to report memory (returns None); a zero/negative
+    # reading is equally untrustworthy. Both must yield the unchanged default.
+    assert auto_generation_batch_caps(None) == (32, 16)
+    assert auto_generation_batch_caps(0) == (32, 16)
+    assert auto_generation_batch_caps(-1) == (32, 16)
 
 
 def test_default_cuda_graph_bs_matches_sglang_normal_buckets() -> None:


### PR DESCRIPTION
## Motivation

Qwen3-ASR sets `max_running_requests=32` and `request_build_max_pending=16` as fixed constants regardless of GPU. On an H100 this caps the decode batch well below the available KV headroom (scheduler logs report `token usage: 0.00`), and once transcription concurrency exceeds the 16-slot build backlog the overflow is rejected with HTTP 500s. Single-worker throughput therefore plateaus and starts dropping requests as concurrency rises, instead of scaling into the idle GPU. #885 removed the synchronous request-build bottleneck; this PR addresses the remaining static batch and backlog caps.

## Modifications

- Add `auto_generation_batch_caps()` in `generation_batch_policy.py`: tiers `(max_running_requests, request_build_max_pending)` by total GPU memory — `>= 70 GiB -> (128, 256)`, `>= 40 GiB -> (64, 128)`, otherwise the historical `(32, 16)`.
- Resolve an `"auto"` sentinel in the Qwen3-ASR stage from `gpu_memory.get_gpu_device_info` (NVML first, torch fallback, `None`-safe -> floor); explicit integer values still pass through unchanged.
- Default Qwen3-ASR `max_running_requests` and `request_build_max_pending` to `"auto"`.
- Keep `request_build_max_workers=2`. Raising it to `4` de-serializes builds further but regressed concurrency `16` / `32` by 7–12% from GIL contention.
- `max_running_requests` also drives `cuda_graph_max_bs`, so tiering by total memory keeps small / CI-class GPUs byte-for-byte unchanged and avoids CUDA-graph capture OOM on small cards.
- Add unit coverage for the tiers, the `None` / non-positive floor, the `"auto"` defaults, and end-to-end wiring of the large-GPU tier into `cuda_graph_max_bs` and the scheduler backlog.

## Related Issues

Related to https://github.com/sgl-project/sglang-omni/issues/831

## Accuracy Test

WER on SeedTTS English, `600` samples, ASR concurrency `32`, H100 80GB. Corpus WER is unchanged and no samples are dropped:

| Config | Corpus WER (2 repeats) | Skipped |
| --- | --- | --- |
| Baseline (`32` / `16`) | `0.0132`, `0.0132` | `0`, `0` |
| Auto (`128` / `256`) | `0.0132`, `0.0132` | `0`, `0` |

## Benchmark & Profiling

Hardware: `NVIDIA H100 80GB PCIe`, single worker
ASR model: `Qwen/Qwen3-ASR-1.7B`
Samples: `600`
Repeats: `2`
Auto config resolves on this GPU to `max_running_requests=128`, `request_build_max_pending=256`.

```bash
# baseline
sgl-omni serve --model-path Qwen/Qwen3-ASR-1.7B --host 0.0.0.0 --port 8000 \
  stages.0.factory_args.max_running_requests=32 \
  stages.0.factory_args.request_build_max_pending=16

# after (default; "auto" tiers to the GPU)
sgl-omni serve --model-path Qwen/Qwen3-ASR-1.7B --host 0.0.0.0 --port 8000

python -m benchmarks.eval.benchmark_asr_seedtts --host 127.0.0.1 --port 8000 \
  --max-samples 600 --concurrencies 16,32,48,64,96 --repeats 2 --warmup
```

Mean throughput over 2 warm repeats:

| Concurrency | Baseline, samples/s | Auto, samples/s | Baseline skipped | Auto skipped |
| --- | ---: | ---: | ---: | ---: |
| 16 | `40.83` | `38.77` | `0` | `0` |
| 32 | `51.00` | `55.67` | `0` | `0` |
| 64 | `40.77` | `78.21` | `55`–`70` | `0` |
| 96 | — | `76.19` | — | `0` |

Baseline throughput does not rise past concurrency ~`32` — beyond the 16-slot backlog it returns HTTP 500s rather than batching — while the auto caps scale to ~`78` samples/s with no dropped requests and unchanged corpus WER.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
