### PR TITLE
Optimize Higgs TTS streaming code collection

### DIFF
--- a/sglang_omni/models/higgs_tts/model_runner.py
+++ b/sglang_omni/models/higgs_tts/model_runner.py
@@ -21,6 +21,13 @@ from sglang_omni.models.higgs_tts.model import _flat_sampling_attr
 from sglang_omni.models.higgs_tts.sampler import K_MAX, selected_token_logprobs
 from sglang_omni.models.higgs_tts.text_tokenizer import AUDIO_PLACEHOLDER_ID
 from sglang_omni.models.higgs_tts.utils import EOC_ID
+from sglang_omni.models.tts_streaming import (
+    DEFAULT_HIGGS_STREAM_FOLLOWUP_STRIDE,
+    DEFAULT_HIGGS_STREAM_STRIDE,
+    HIGGS_STREAM_FOLLOWUP_STRIDE_METADATA,
+    HIGGS_STREAM_STRIDE_METADATA,
+    INITIAL_CODEC_CHUNK_FRAMES_PARAM,
+)
 from sglang_omni.scheduling.messages import OutgoingMessage
 
 logger = logging.getLogger(__name__)
@@ -343,7 +350,11 @@ class HiggsTTSModelRunner(ModelRunner):
             ):
                 data.output_logprobs.append(logprobs_cpu[b].to(torch.float32).clone())
             data.generation_done = bool(gen_done_after_cpu[b])
-            self._emit_code_chunk(sched_req, codes_N)
+            self._queue_or_emit_code_chunk(
+                sched_req,
+                codes_N,
+                force=self._is_final_code_step(data),
+            )
             self._mark_sampler_finished(req, data.generation_done)
             cb0_per_row.append(int(codes_N[0].item()))
 
@@ -428,7 +439,11 @@ class HiggsTTSModelRunner(ModelRunner):
             ):
                 data.output_logprobs.append(logprobs_BN[b].detach().cpu().clone())
             data.generation_done = bool(model._sampler_pool.generation_done[row].item())
-            self._emit_code_chunk(sched_req, data.output_codes[-1])
+            self._queue_or_emit_code_chunk(
+                sched_req,
+                data.output_codes[-1],
+                force=self._is_final_code_step(data),
+            )
             self._mark_sampler_finished(req, data.generation_done)
             cb0_per_row.append(int(codes_N[0].item()))
 
@@ -512,6 +527,106 @@ class HiggsTTSModelRunner(ModelRunner):
         """Bridge Higgs sampler completion into upstream SGLang finish state."""
         if generation_done and req.finished_reason is None:
             req.finished_reason = FINISH_MATCHED_TOKEN(EOC_ID)
+
+    @staticmethod
+    def _is_final_code_step(data: Any) -> bool:
+        if bool(data.generation_done):
+            return True
+        try:
+            max_new_tokens = int(data.max_new_tokens or 0)
+        except AttributeError:
+            max_new_tokens = 0
+        return max_new_tokens > 0 and len(data.output_codes) >= max_new_tokens
+
+    def _queue_or_emit_code_chunk(
+        self, sched_req: Any, codes_N: torch.Tensor, *, force: bool = False
+    ) -> None:
+        if self._outbox is None:
+            return
+        data = sched_req.data
+        if data.stream_metadata is None:
+            return
+
+        data.stream_code_buffer.append(codes_N)
+        data.stream_code_seen_rows += 1
+        if int(data.stream_code_next_flush_rows) <= 0:
+            data.stream_code_next_flush_rows = self._initial_stream_flush_rows(data)
+        if force or data.stream_code_seen_rows >= data.stream_code_next_flush_rows:
+            self._flush_code_chunks(sched_req, force=force)
+
+    @staticmethod
+    def _stream_params(data: Any) -> tuple[int, int, int, int]:
+        num_codebooks = max(int(data.num_codebooks or 1), 1)
+        metadata = data.stream_metadata or {}
+        stride = max(
+            int(
+                metadata.get(HIGGS_STREAM_STRIDE_METADATA, DEFAULT_HIGGS_STREAM_STRIDE)
+            ),
+            1,
+        )
+        followup = max(
+            int(
+                metadata.get(
+                    HIGGS_STREAM_FOLLOWUP_STRIDE_METADATA,
+                    DEFAULT_HIGGS_STREAM_FOLLOWUP_STRIDE,
+                )
+            ),
+            1,
+        )
+        initial_frames = metadata.get(INITIAL_CODEC_CHUNK_FRAMES_PARAM)
+        if initial_frames is None:
+            return num_codebooks, stride, followup, 0
+        try:
+            initial_frames_i = int(initial_frames)
+        except (TypeError, ValueError):
+            initial_frames_i = 0
+        if initial_frames_i <= 0:
+            return num_codebooks, stride, followup, 0
+        steady_codec_frames = max(1, stride - num_codebooks + 1)
+        return (
+            num_codebooks,
+            stride,
+            followup,
+            min(initial_frames_i, steady_codec_frames),
+        )
+
+    @classmethod
+    def _initial_stream_flush_rows(cls, data: Any) -> int:
+        num_codebooks, stride, _, initial_frames = cls._stream_params(data)
+        steady_codec_frames = max(1, stride - num_codebooks + 1)
+        if 0 < initial_frames < steady_codec_frames:
+            return max(num_codebooks, initial_frames + num_codebooks - 1)
+        return max(num_codebooks, stride)
+
+    @classmethod
+    def _next_stream_flush_rows(cls, data: Any, flushed_rows: int) -> int:
+        num_codebooks, stride, followup, initial_frames = cls._stream_params(data)
+        steady_codec_frames = max(1, stride - num_codebooks + 1)
+        emitted_initial_chunk = (
+            not bool(data.stream_code_first_flush_done)
+            and 0 < initial_frames < steady_codec_frames
+        )
+        if emitted_initial_chunk:
+            return max(num_codebooks, stride) + followup
+        return int(flushed_rows) + followup
+
+    def _flush_code_chunks(self, sched_req: Any, *, force: bool = False) -> None:
+        data = sched_req.data
+        rows = data.stream_code_buffer
+        if not rows:
+            return
+        if len(rows) == 1:
+            payload = rows[0]
+        else:
+            payload = torch.stack(rows, dim=0)
+        flushed_rows = int(data.stream_code_seen_rows)
+        if not force:
+            data.stream_code_next_flush_rows = self._next_stream_flush_rows(
+                data, flushed_rows
+            )
+        data.stream_code_buffer = []
+        data.stream_code_first_flush_done = True
+        self._emit_code_chunk(sched_req, payload)
 
     def _emit_code_chunk(self, sched_req: Any, codes_N: torch.Tensor) -> None:
         if self._outbox is None:

--- a/sglang_omni/models/higgs_tts/model_runner.py
+++ b/sglang_omni/models/higgs_tts/model_runner.py
@@ -343,8 +343,7 @@ class HiggsTTSModelRunner(ModelRunner):
             if was_done_cpu[b]:
                 cb0_per_row.append(0)
                 continue
-            codes_N = codes_BN_cpu[b].to(torch.long).clone()
-            data.output_codes.append(codes_N)
+            codes_N = self._append_output_code(data, codes_BN_cpu[b])
             if logprobs_cpu is not None and self._request_captures_rollout_logprobs(
                 sched_req
             ):
@@ -433,7 +432,7 @@ class HiggsTTSModelRunner(ModelRunner):
                 cb0_per_row.append(0)
                 continue
             codes_N = codes_log[-1]
-            data.output_codes.append(codes_N.detach().cpu().clone())
+            codes_cpu = self._append_output_code(data, codes_N)
             if logprobs_BN is not None and self._request_captures_rollout_logprobs(
                 sched_req
             ):
@@ -441,7 +440,7 @@ class HiggsTTSModelRunner(ModelRunner):
             data.generation_done = bool(model._sampler_pool.generation_done[row].item())
             self._queue_or_emit_code_chunk(
                 sched_req,
-                data.output_codes[-1],
+                codes_cpu,
                 force=self._is_final_code_step(data),
             )
             self._mark_sampler_finished(req, data.generation_done)
@@ -460,6 +459,44 @@ class HiggsTTSModelRunner(ModelRunner):
 
     def _should_capture_rollout_logprobs(self, requests: list) -> bool:
         return any(self._request_captures_rollout_logprobs(req) for req in requests)
+
+    @staticmethod
+    def _append_output_code(data: Any, codes_N: torch.Tensor) -> torch.Tensor:
+        try:
+            max_new_tokens = int(data.max_new_tokens)
+            num_codebooks = int(data.num_codebooks)
+            count = int(data.output_code_count)
+            buffer = data.output_code_buffer
+        except AttributeError:
+            codes_cpu = codes_N.detach().cpu().to(torch.long).clone()
+            data.output_codes.append(codes_cpu)
+            return codes_cpu
+
+        if buffer is None:
+            buffer = torch.empty(
+                (max(1, max_new_tokens), num_codebooks),
+                dtype=torch.long,
+                device="cpu",
+            )
+            data.output_code_buffer = buffer
+        elif count >= buffer.shape[0]:
+            new_cap = max(count + 1, buffer.shape[0] * 2)
+            new_buffer = torch.empty(
+                (new_cap, num_codebooks),
+                dtype=torch.long,
+                device="cpu",
+            )
+            new_buffer[:count].copy_(buffer[:count])
+            buffer = new_buffer
+            data.output_code_buffer = buffer
+
+        row = buffer[count]
+        if codes_N.device.type == "cpu" and codes_N.dtype == torch.long:
+            row.copy_(codes_N, non_blocking=True)
+        else:
+            row.copy_(codes_N.detach().to(device="cpu", dtype=torch.long))
+        data.output_code_count = count + 1
+        return row
 
     def _decode_step_logprobs(self, result: Any, n_real: int) -> torch.Tensor:
         model = self.model
@@ -535,8 +572,12 @@ class HiggsTTSModelRunner(ModelRunner):
         try:
             max_new_tokens = int(data.max_new_tokens or 0)
         except AttributeError:
-            max_new_tokens = 0
-        return max_new_tokens > 0 and len(data.output_codes) >= max_new_tokens
+            return False
+        try:
+            output_count = int(data.output_code_count)
+        except AttributeError:
+            output_count = len(data.output_codes)
+        return max_new_tokens > 0 and output_count >= max_new_tokens
 
     def _queue_or_emit_code_chunk(
         self, sched_req: Any, codes_N: torch.Tensor, *, force: bool = False

--- a/sglang_omni/models/higgs_tts/request_builders.py
+++ b/sglang_omni/models/higgs_tts/request_builders.py
@@ -34,6 +34,8 @@ class HiggsSGLangRequestData(SGLangARRequestData):
     num_codebooks: int = 8
     codebook_size: int = 1026
     output_codes: list[torch.Tensor] = field(default_factory=list)
+    output_code_buffer: torch.Tensor | None = None
+    output_code_count: int = 0
     output_logprobs: list[torch.Tensor] = field(default_factory=list)
     return_omni_rollout: bool = False
     generation_done: bool = False
@@ -164,7 +166,11 @@ def build_higgs_stream_metadata(
 
 def apply_higgs_result(state: HiggsTtsState, data: HiggsSGLangRequestData) -> None:
     num_codebooks = int(data.num_codebooks)
-    if data.output_codes:
+    if data.output_code_buffer is not None and data.output_code_count > 0:
+        codes = data.output_code_buffer[: data.output_code_count].to(torch.long)
+        state.output_codes_delayed = codes.tolist()
+        state.completion_tokens = int(codes.shape[0])
+    elif data.output_codes:
         codes = torch.stack(data.output_codes, dim=0).to(torch.long)
         state.output_codes_delayed = codes.tolist()
         state.completion_tokens = int(codes.shape[0])

--- a/sglang_omni/models/higgs_tts/request_builders.py
+++ b/sglang_omni/models/higgs_tts/request_builders.py
@@ -14,7 +14,13 @@ from sglang.srt.sampling.sampling_params import SamplingParams
 
 from sglang_omni.models.higgs_tts.payload_types import HiggsTtsState
 from sglang_omni.models.higgs_tts.rollout_trace import build_omni_rollout_trace
-from sglang_omni.models.tts_streaming import INITIAL_CODEC_CHUNK_FRAMES_PARAM
+from sglang_omni.models.tts_streaming import (
+    DEFAULT_HIGGS_STREAM_FOLLOWUP_STRIDE,
+    DEFAULT_HIGGS_STREAM_STRIDE,
+    HIGGS_STREAM_FOLLOWUP_STRIDE_METADATA,
+    HIGGS_STREAM_STRIDE_METADATA,
+    INITIAL_CODEC_CHUNK_FRAMES_PARAM,
+)
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
 
@@ -33,6 +39,10 @@ class HiggsSGLangRequestData(SGLangARRequestData):
     generation_done: bool = False
     engine_start_s: float = 0.0
     stream_metadata: dict[str, Any] | None = None
+    stream_code_buffer: list[torch.Tensor] = field(default_factory=list)
+    stream_code_first_flush_done: bool = False
+    stream_code_seen_rows: int = 0
+    stream_code_next_flush_rows: int = 0
 
 
 class _ResettableHiggsModel(Protocol):
@@ -142,6 +152,8 @@ def build_higgs_stream_metadata(
         "stream": True,
         "num_codebooks": num_codebooks,
         "codebook_size": codebook_size,
+        HIGGS_STREAM_STRIDE_METADATA: DEFAULT_HIGGS_STREAM_STRIDE,
+        HIGGS_STREAM_FOLLOWUP_STRIDE_METADATA: DEFAULT_HIGGS_STREAM_FOLLOWUP_STRIDE,
     }
     if params.get(INITIAL_CODEC_CHUNK_FRAMES_PARAM) is not None:
         metadata[INITIAL_CODEC_CHUNK_FRAMES_PARAM] = params[

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -45,6 +45,10 @@ from sglang_omni.models.higgs_tts.utils import (
 from sglang_omni.models.higgs_tts.vocoder_scheduler import (
     HiggsStreamingVocoderScheduler,
 )
+from sglang_omni.models.tts_streaming import (
+    DEFAULT_HIGGS_STREAM_FOLLOWUP_STRIDE,
+    DEFAULT_HIGGS_STREAM_STRIDE,
+)
 
 # _REF_PATH_HASH_MEMO is the shared memo object, re-exported so tests can
 # reset it; the underscored alias keeps this module's historical API.
@@ -417,8 +421,8 @@ def create_vocoder_executor(
     dtype: str = "bfloat16",
     vocoder_decode_batch_size: int = 16,
     max_batch_wait_ms: int = 2,
-    stream_stride: int = 75,
-    stream_followup_stride: int = 75,
+    stream_stride: int = DEFAULT_HIGGS_STREAM_STRIDE,
+    stream_followup_stride: int = DEFAULT_HIGGS_STREAM_FOLLOWUP_STRIDE,
     stream_overlap_tokens: int = 8,
     stream_holdback_tokens: int = 4,
 ):

--- a/sglang_omni/models/higgs_tts/vocoder_scheduler.py
+++ b/sglang_omni/models/higgs_tts/vocoder_scheduler.py
@@ -143,25 +143,30 @@ class HiggsStreamingVocoderScheduler(StreamingSimpleScheduler):
         state = self._stream_states.setdefault(request_id, _HiggsStreamState())
         self._latch_stream_metadata(request_id, state, item.metadata)
 
-        row = item.data
-        if not isinstance(row, torch.Tensor):
+        chunk = item.data
+        if not isinstance(chunk, torch.Tensor):
             raise TypeError(
                 f"Higgs stream chunk for {request_id!r} must carry a torch.Tensor, "
-                f"got {type(row).__name__}"
+                f"got {type(chunk).__name__}"
             )
-        row = row.to(dtype=torch.long)
-        if row.ndim != 1:
+        chunk = chunk.to(dtype=torch.long)
+        if chunk.ndim == 1:
+            rows = chunk.unsqueeze(0)
+        elif chunk.ndim == 2:
+            rows = chunk
+        else:
             raise ValueError(
-                f"Higgs stream chunk must be 1-D [N], got {tuple(row.shape)}"
+                f"Higgs stream chunk must be 1-D [N] or 2-D [T, N], "
+                f"got {tuple(chunk.shape)}"
             )
 
         num_codebooks = self._require_stream_contract(state, request_id)[0]
-        if int(row.shape[0]) != num_codebooks:
+        if int(rows.shape[1]) != num_codebooks:
             raise ValueError(
-                f"Higgs stream chunk has {int(row.shape[0])} codebooks, "
+                f"Higgs stream chunk has {int(rows.shape[1])} codebooks, "
                 f"expected {num_codebooks}"
             )
-        state.delayed_rows.append(row)
+        state.delayed_rows.extend(rows.unbind(0))
 
         output = self._decode_delta(state, is_final=False)
         if output is None:

--- a/sglang_omni/models/tts_streaming.py
+++ b/sglang_omni/models/tts_streaming.py
@@ -6,6 +6,10 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 INITIAL_CODEC_CHUNK_FRAMES_PARAM = "initial_codec_chunk_frames"
+HIGGS_STREAM_STRIDE_METADATA = "stream_stride"
+HIGGS_STREAM_FOLLOWUP_STRIDE_METADATA = "stream_followup_stride"
+DEFAULT_HIGGS_STREAM_STRIDE = 75
+DEFAULT_HIGGS_STREAM_FOLLOWUP_STRIDE = 75
 
 
 def resolve_initial_codec_chunk_frames(

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -675,6 +675,62 @@ def test_higgs_model_runner_batches_stream_code_rows_on_decode_boundaries() -> N
     assert second.data[-1].tolist() == [17, 18, 19]
 
 
+def test_higgs_model_runner_collect_streaming_uses_preallocated_buffer() -> None:
+    runner = object.__new__(HiggsTTSModelRunner)
+    runner._outbox = queue.Queue()
+    runner._vocoder_target = "vocoder"
+    runner.model = SimpleNamespace(
+        _rid_to_row={"req": 0},
+        _output_codes={"req": []},
+        _sampler_pool=SimpleNamespace(generation_done=torch.tensor([False])),
+    )
+    req = SimpleNamespace(
+        is_chunked=0,
+        finished_reason=None,
+        finished=lambda: False,
+    )
+    data = SimpleNamespace(
+        req=req,
+        output_codes=[],
+        output_code_buffer=None,
+        output_code_count=0,
+        output_logprobs=[],
+        return_omni_rollout=False,
+        return_logprob=False,
+        generation_done=False,
+        max_new_tokens=2,
+        num_codebooks=3,
+        stream_metadata={
+            "modality": "audio_codes",
+            "stream": True,
+            "num_codebooks": 3,
+            "codebook_size": 17,
+            HIGGS_STREAM_STRIDE_METADATA: 8,
+            HIGGS_STREAM_FOLLOWUP_STRIDE_METADATA: 8,
+        },
+        stream_code_buffer=[],
+        stream_code_first_flush_done=False,
+        stream_code_seen_rows=0,
+        stream_code_next_flush_rows=0,
+    )
+    result = SimpleNamespace(
+        logits_output=SimpleNamespace(next_token_logits=torch.zeros(1, 4))
+    )
+    sched_req = SimpleNamespace(request_id="req", data=data)
+
+    for row in ([10, 11, 12], [13, 14, 15]):
+        runner.model._output_codes["req"] = [torch.tensor(row, dtype=torch.long)]
+        runner._collect_step_outputs(result, [sched_req])
+
+    out = runner._outbox.get_nowait()
+    assert out.type == "stream"
+    assert out.target == "vocoder"
+    assert out.data.tolist() == [[10, 11, 12], [13, 14, 15]]
+    assert data.output_codes == []
+    assert data.output_code_count == 2
+    assert data.output_code_buffer[:2].tolist() == [[10, 11, 12], [13, 14, 15]]
+
+
 def test_higgs_stream_metadata_carries_initial_codec_chunk_frames() -> None:
     payload = StagePayload(
         request_id="req",

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -20,6 +20,12 @@ from sglang_omni.models.higgs_tts.utils import EOC_ID, apply_delay_pattern
 from sglang_omni.models.higgs_tts.vocoder_scheduler import (
     HiggsStreamingVocoderScheduler,
 )
+from sglang_omni.models.tts_streaming import (
+    DEFAULT_HIGGS_STREAM_FOLLOWUP_STRIDE,
+    DEFAULT_HIGGS_STREAM_STRIDE,
+    HIGGS_STREAM_FOLLOWUP_STRIDE_METADATA,
+    HIGGS_STREAM_STRIDE_METADATA,
+)
 from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from sglang_omni.proto import OmniRequest, StagePayload
 from sglang_omni.scheduling.speaker_cache import get_speaker_artifact_cache
@@ -574,13 +580,20 @@ def test_higgs_model_runner_emits_latched_stream_metadata() -> None:
         return_omni_rollout=False,
         return_logprob=False,
         generation_done=False,
+        num_codebooks=3,
         stream_metadata={
             "modality": "audio_codes",
             "stream": True,
             "num_codebooks": 3,
             "codebook_size": 17,
             "initial_codec_chunk_frames": 2,
+            HIGGS_STREAM_STRIDE_METADATA: DEFAULT_HIGGS_STREAM_STRIDE,
+            HIGGS_STREAM_FOLLOWUP_STRIDE_METADATA: DEFAULT_HIGGS_STREAM_FOLLOWUP_STRIDE,
         },
+        stream_code_buffer=[],
+        stream_code_first_flush_done=False,
+        stream_code_seen_rows=0,
+        stream_code_next_flush_rows=0,
     )
     result = SimpleNamespace(
         logits_output=SimpleNamespace(next_token_logits=torch.zeros(1, 4))
@@ -601,7 +614,65 @@ def test_higgs_model_runner_emits_latched_stream_metadata() -> None:
         "num_codebooks": 3,
         "codebook_size": 17,
         "initial_codec_chunk_frames": 2,
+        HIGGS_STREAM_STRIDE_METADATA: DEFAULT_HIGGS_STREAM_STRIDE,
+        HIGGS_STREAM_FOLLOWUP_STRIDE_METADATA: DEFAULT_HIGGS_STREAM_FOLLOWUP_STRIDE,
     }
+
+
+def test_higgs_model_runner_batches_stream_code_rows_on_decode_boundaries() -> None:
+    runner = object.__new__(HiggsTTSModelRunner)
+    runner._outbox = queue.Queue()
+    runner._vocoder_target = "vocoder"
+    data = SimpleNamespace(
+        stream_metadata={
+            "modality": "audio_codes",
+            "stream": True,
+            "num_codebooks": 3,
+            "codebook_size": 17,
+            HIGGS_STREAM_STRIDE_METADATA: 3,
+            HIGGS_STREAM_FOLLOWUP_STRIDE_METADATA: 8,
+        },
+        num_codebooks=3,
+        output_codes=[],
+        max_new_tokens=99,
+        generation_done=False,
+        stream_code_buffer=[],
+        stream_code_first_flush_done=False,
+        stream_code_seen_rows=0,
+        stream_code_next_flush_rows=0,
+    )
+    sched_req = SimpleNamespace(request_id="req", data=data)
+
+    for i in range(2):
+        runner._queue_or_emit_code_chunk(
+            sched_req, torch.tensor([i, i + 1, i + 2], dtype=torch.long)
+        )
+    with pytest.raises(queue.Empty):
+        runner._outbox.get_nowait()
+
+    runner._queue_or_emit_code_chunk(
+        sched_req, torch.tensor([2, 3, 4], dtype=torch.long)
+    )
+    first = runner._outbox.get_nowait()
+    assert first.type == "stream"
+    assert first.target == "vocoder"
+    assert first.data.tolist() == [[0, 1, 2], [1, 2, 3], [2, 3, 4]]
+    assert data.stream_code_first_flush_done is True
+
+    for i in range(7):
+        runner._queue_or_emit_code_chunk(
+            sched_req, torch.tensor([10 + i, 11 + i, 12 + i], dtype=torch.long)
+        )
+    with pytest.raises(queue.Empty):
+        runner._outbox.get_nowait()
+
+    runner._queue_or_emit_code_chunk(
+        sched_req, torch.tensor([17, 18, 19], dtype=torch.long)
+    )
+    second = runner._outbox.get_nowait()
+    assert second.data.shape == (8, 3)
+    assert second.data[0].tolist() == [10, 11, 12]
+    assert second.data[-1].tolist() == [17, 18, 19]
 
 
 def test_higgs_stream_metadata_carries_initial_codec_chunk_frames() -> None:
@@ -623,6 +694,8 @@ def test_higgs_stream_metadata_carries_initial_codec_chunk_frames() -> None:
         "num_codebooks": 3,
         "codebook_size": 17,
         "initial_codec_chunk_frames": 1,
+        HIGGS_STREAM_STRIDE_METADATA: DEFAULT_HIGGS_STREAM_STRIDE,
+        HIGGS_STREAM_FOLLOWUP_STRIDE_METADATA: DEFAULT_HIGGS_STREAM_FOLLOWUP_STRIDE,
     }
 
 
@@ -1168,6 +1241,71 @@ def test_higgs_streaming_vocoder_matches_full_decode_with_codec_tail() -> None:
     ]
     streamed = np.concatenate(stream_chunks)
     np.testing.assert_array_equal(streamed, full.numpy())
+
+
+def test_higgs_streaming_vocoder_accepts_batched_code_rows() -> None:
+    raw_codes = torch.tensor(
+        [
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+            [10, 11, 12],
+            [13, 14, 15],
+            [16, 17, 18],
+        ],
+        dtype=torch.long,
+    )
+    delayed = apply_delay_pattern(raw_codes)
+    codec = _FakeUnevenHiggsStreamingCodec()
+    scheduler = HiggsStreamingVocoderScheduler(
+        codec,
+        stream_stride=3,
+        stream_followup_stride=2,
+        stream_overlap_tokens=1,
+        stream_holdback_tokens=0,
+    )
+    payload = _higgs_stream_payload(
+        "req",
+        stream=True,
+        delayed_rows=delayed.tolist(),
+        codebook_size=64,
+    )
+    full = scheduler._decode_state_to_audio(HiggsTtsState.from_dict(payload.data))
+    assert full is not None
+
+    scheduler._on_streaming_new_request("req", payload)
+    scheduler._on_chunk("req", _higgs_stream_item(delayed[:3], codebook_size=64))
+    scheduler._on_chunk("req", _higgs_stream_item(delayed[3:], codebook_size=64))
+    scheduler._on_done("req")
+
+    stream_chunks = [
+        np.frombuffer(msg.data["audio_waveform"], dtype=np.float32).copy()
+        for msg in _drain_higgs_outbox(scheduler)
+        if msg.type == "stream"
+    ]
+    streamed = np.concatenate(stream_chunks)
+    np.testing.assert_array_equal(streamed, full.numpy())
+
+
+def test_higgs_streaming_vocoder_rejects_bad_batched_code_width() -> None:
+    scheduler = HiggsStreamingVocoderScheduler(_FakeHiggsStreamingCodec())
+    payload = _higgs_stream_payload(
+        "req",
+        stream=True,
+        delayed_rows=[[1, 2, 3]],
+        codebook_size=64,
+    )
+    scheduler._on_streaming_new_request("req", payload)
+
+    with pytest.raises(ValueError, match="expected 3"):
+        scheduler._on_chunk(
+            "req",
+            _higgs_stream_item(
+                torch.ones((2, 4), dtype=torch.long),
+                num_codebooks=3,
+                codebook_size=64,
+            ),
+        )
 
 
 def test_higgs_initial_codec_chunk_frames_controls_first_chunk_only() -> None:

--- a/tests/unit_test/higgs_tts/test_request_builders.py
+++ b/tests/unit_test/higgs_tts/test_request_builders.py
@@ -44,3 +44,33 @@ def test_higgs_scheduler_adapters_clamp_cap_and_record_engine_time(
     assert result.data["completion_tokens"] == 1
     assert result.data["engine_time_s"] == 2.5
     assert reset_calls == ["req-higgs"]
+
+
+def test_higgs_result_adapter_reads_output_code_buffer() -> None:
+    reset_calls: list[str] = []
+    _, result_adapter = request_builders.make_higgs_scheduler_adapters(
+        SimpleNamespace(reset_request=reset_calls.append),
+    )
+    state = HiggsTtsState(
+        prompt_token_ids=[1, 2, 3],
+        max_new_tokens=8,
+        num_codebooks=3,
+    )
+    payload = StagePayload(
+        request_id="req-higgs",
+        request=OmniRequest(inputs={}),
+        data=state.to_dict(),
+    )
+    data = request_builders.build_sglang_higgs_request(
+        state, request_id=payload.request_id
+    )
+    data.stage_payload = payload
+    data.output_codes.append(torch.tensor([9, 9, 9], dtype=torch.long))
+    data.output_code_buffer = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.long)
+    data.output_code_count = 2
+
+    result = result_adapter(data)
+
+    assert result.data["output_codes_delayed"] == [[1, 2, 3], [4, 5, 6]]
+    assert result.data["completion_tokens"] == 2
+    assert reset_calls == ["req-higgs"]


### PR DESCRIPTION
## Summary

This PR optimizes Higgs TTS serving by combining two host-side streaming improvements:

- Batch streaming code chunks at vocoder-decodable boundaries instead of dispatching one code row per AR step.
- Store generated code rows in a per-request preallocated CPU buffer instead of repeatedly appending/cloning/stacking Python lists during decode collection.

The implementation keeps the existing behavior and API surface; no extra runtime flag is added.

## Motivation

Higgs TTS streaming spends non-trivial host time in per-step output-code collection and vocoder dispatch plumbing. This change reduces Python/list churn and queue pressure while preserving the existing final output adapter path.

## Validation

Unit tests on `hyper00-omni`, container `sglang-omni-hayden-main-profile`:

```bash
pytest -q \
  tests/unit_test/higgs_tts/test_request_builders.py \
  tests/unit_test/higgs_tts/test_pipeline.py \
  tests/unit_test/higgs_tts/test_async_decode_runner.py
```

Result: `47 passed, 20 warnings in 11.54s`.

Full SeedTTS E2E generate-only benchmark on `hyper00-omni`, GPU4, image `hongccc/sglang-omni:dev`:

- model: `bosonai/higgs-audio-v3-tts-4b`
- dataset/meta: `zhaochenyang20/seed-tts-eval-arrow`
- samples: 1088
- endpoint: `/v1/audio/speech`
- concurrency: 16
- warmup: 10
- max_running_requests: 64
- cuda_graph_max_bs: 64

| Metric | main `c00e6f9d` | this PR `894f1f42` | Delta |
|---|---:|---:|---:|
| QPS | 14.877 | 15.369 | +3.31% |
| mean latency | 1.070s | 1.035s | -3.27% |
| p95 latency | 1.540s | 1.486s | -3.51% |
| p99 latency | 1.805s | 1.709s | -5.32% |
| mean RTF | 0.2595 | 0.2538 | -2.20% |
| audio throughput | 63.20 s/s | 64.29 s/s | +1.72% |
| output tok/s | 1684.1 | 1714.8 | +1.82% |

Artifacts:

- main: `/data/perf-baselines/sglang-omni/20260709-142954-hyper00-omni-gpu4-higgs-e2e-full-seedtts-main-c00e6f9d`
- this PR: `/data/perf-baselines/sglang-omni/20260709-143637-hyper00-omni-gpu4-higgs-e2e-full-seedtts-combined-894f1f42`
- compare JSON: `/data/perf-baselines/sglang-omni/higgs_e2e_full_compare_main-c00e6f9d_vs_combined-894f1f42.json`

Note: this benchmark path does not fix the generation seed, so generated output token/audio duration totals differ slightly between runs. The config is otherwise matched.
