### PR TITLE
[Qwen3-Omni Perf] Fix async drop-stale KV slot reslice for extend/mixed batches

### DIFF
--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -1842,12 +1842,45 @@ class OmniScheduler:
             return batch
         keep = [i for i, d in enumerate(drop) if not d]
         out_cache_loc = batch.out_cache_loc
-        self._free_overrun_step_slots(
-            out_cache_loc, [i for i, d in enumerate(drop) if d]
-        )
-        batch.filter_batch(keep_indices=keep)
-        if out_cache_loc is not None:
-            batch.out_cache_loc = out_cache_loc[keep]
+        forward_mode = getattr(batch, "forward_mode", None)
+        if forward_mode is not None and forward_mode.is_extend():
+            # extend/mixed: out_cache_loc/input_ids are per token (req i owns
+            # extend_lens[i] consecutive slots) and filter_batch only reslices
+            # the per-request fields, so handle the per-token ones here.
+            lens = batch.extend_lens
+            starts = [0] * len(lens)
+            for i in range(1, len(lens)):
+                starts[i] = starts[i - 1] + lens[i - 1]
+            drop_tokens = [
+                t
+                for i, d in enumerate(drop)
+                if d
+                for t in range(starts[i], starts[i] + lens[i])
+            ]
+            keep_tokens = [
+                t for i in keep for t in range(starts[i], starts[i] + lens[i])
+            ]
+            input_ids = batch.input_ids
+            prefix_lens = batch.prefix_lens
+            extend_logprob_start_lens = batch.extend_logprob_start_lens
+            self._free_overrun_step_slots(out_cache_loc, drop_tokens)
+            batch.filter_batch(keep_indices=keep)
+            batch.input_ids = input_ids[keep_tokens]
+            if out_cache_loc is not None:
+                batch.out_cache_loc = out_cache_loc[keep_tokens]
+            batch.extend_lens = [lens[i] for i in keep]
+            batch.extend_num_tokens = sum(batch.extend_lens)
+            batch.prefix_lens = [prefix_lens[i] for i in keep]
+            batch.extend_logprob_start_lens = [
+                extend_logprob_start_lens[i] for i in keep
+            ]
+        else:
+            self._free_overrun_step_slots(
+                out_cache_loc, [i for i, d in enumerate(drop) if d]
+            )
+            batch.filter_batch(keep_indices=keep)
+            if out_cache_loc is not None:
+                batch.out_cache_loc = out_cache_loc[keep]
         return batch if batch.reqs else None
 
     def _event_loop_async_decode(self) -> None:

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -1844,9 +1844,15 @@ class OmniScheduler:
         out_cache_loc = batch.out_cache_loc
         forward_mode = getattr(batch, "forward_mode", None)
         if forward_mode is not None and forward_mode.is_extend():
-            # extend/mixed: out_cache_loc/input_ids are per token (req i owns
-            # extend_lens[i] consecutive slots) and filter_batch only reslices
-            # the per-request fields, so handle the per-token ones here.
+            # Note:(Wenyao Gao) extend/mixed batches carry per-token fields
+            # (req i owns extend_lens[i] slots) that filter_batch leaves
+            # stale; reslice them here. The asserted fields are never
+            # populated on omni extend batches; trip instead of misslicing.
+            assert (
+                getattr(batch, "input_embeds", None) is None
+                and getattr(batch, "replace_embeds", None) is None
+                and getattr(batch, "token_type_ids", None) is None
+            ), "unhandled per-token field on drop-stale extend batch"
             lens = batch.extend_lens
             starts = [0] * len(lens)
             for i in range(1, len(lens)):
@@ -1863,6 +1869,7 @@ class OmniScheduler:
             input_ids = batch.input_ids
             prefix_lens = batch.prefix_lens
             extend_logprob_start_lens = batch.extend_logprob_start_lens
+            lp_token_ids = getattr(batch, "extend_input_logprob_token_ids", None)
             self._free_overrun_step_slots(out_cache_loc, drop_tokens)
             batch.filter_batch(keep_indices=keep)
             batch.input_ids = input_ids[keep_tokens]
@@ -1874,6 +1881,25 @@ class OmniScheduler:
             batch.extend_logprob_start_lens = [
                 extend_logprob_start_lens[i] for i in keep
             ]
+            if lp_token_ids is not None:
+                # Note:(Wenyao Gao) every req contributes a segment of
+                # lens[i] - start_lens[i] ids; not aligned with the token
+                # slices above.
+                if not batch.return_logprob:
+                    batch.extend_input_logprob_token_ids = None
+                else:
+                    lp_lens = [
+                        lens[i] - extend_logprob_start_lens[i] for i in range(len(lens))
+                    ]
+                    lp_starts = [0] * len(lp_lens)
+                    for i in range(1, len(lp_lens)):
+                        lp_starts[i] = lp_starts[i - 1] + lp_lens[i - 1]
+                    keep_lp_tokens = [
+                        t
+                        for i in keep
+                        for t in range(lp_starts[i], lp_starts[i] + lp_lens[i])
+                    ]
+                    batch.extend_input_logprob_token_ids = lp_token_ids[keep_lp_tokens]
         else:
             self._free_overrun_step_slots(
                 out_cache_loc, [i for i, d in enumerate(drop) if d]

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -1907,6 +1907,9 @@ class OmniScheduler:
             batch.filter_batch(keep_indices=keep)
             if out_cache_loc is not None:
                 batch.out_cache_loc = out_cache_loc[keep]
+        if batch.decoding_reqs:
+            kept_ids = {id(r) for r in batch.reqs}
+            batch.decoding_reqs = [r for r in batch.decoding_reqs if id(r) in kept_ids]
         return batch if batch.reqs else None
 
     def _event_loop_async_decode(self) -> None:

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,6 +30,7 @@ tests/
     │   └── test_audio.py
     ├── pipeline/
     │   ├── helpers.py
+    │   ├── test_async_decode.py
     │   ├── test_comm_engine_ack.py
     │   ├── test_comm_router.py
     │   ├── test_compile.py
@@ -317,6 +318,8 @@ that happened to contain an older version of the test.
   - scheduler batching
   - scheduler errors
   - scheduler concurrency
+  - async-decode drop-stale handling, including per-token field reslicing on
+    decode and extend/mixed batches
   - scheduler callable contracts, including sync wrappers and callable objects
     that return awaitables.
 - `unit_test/relay/`: Low-level data-plane relay tests:

--- a/tests/unit_test/pipeline/test_async_decode.py
+++ b/tests/unit_test/pipeline/test_async_decode.py
@@ -911,3 +911,72 @@ def test_drain_resolve_failure_calls_handle_batch_failure():
 
     assert failures == [(stranded_batch, RuntimeError, "drain boom")]
     assert s._async_pending is None
+
+
+# ---------------------------------------------------------------------------
+# _drop_stale_overrun on EXTEND/MIXED batches (#1023): out_cache_loc/input_ids
+# are per token (req i owns extend_lens[i] consecutive slots), not per request.
+# ---------------------------------------------------------------------------
+
+
+class _MixedBatch:
+    """Extend/mixed ScheduleBatch stub. filter_batch mirrors the real one:
+    per-request fields only, nulls out_cache_loc, leaves per-token fields and
+    the extend_* lists stale."""
+
+    def __init__(self, lens, done):
+        self.forward_mode = types.SimpleNamespace(
+            is_decode=lambda: False, is_extend=lambda: True
+        )
+        self.reqs = [types.SimpleNamespace(finished=lambda d=d: d) for d in done]
+        self.extend_lens = list(lens)
+        self.extend_num_tokens = sum(lens)
+        self.prefix_lens = [10 * (i + 1) for i in range(len(lens))]
+        self.extend_logprob_start_lens = [0] * len(lens)
+        self.out_cache_loc = torch.arange(100, 100 + sum(lens))
+        self.input_ids = torch.arange(sum(lens))
+
+    def filter_batch(self, keep_indices):
+        self.reqs = [self.reqs[i] for i in keep_indices]
+        self.out_cache_loc = None
+
+
+def _drop_stale_scheduler(freed):
+    s = OmniScheduler.__new__(OmniScheduler)
+    s.page_size = 1
+    s.server_args = types.SimpleNamespace(disable_radix_cache=False)
+    s.token_to_kv_pool_allocator = types.SimpleNamespace(
+        free=lambda t: freed.extend(t.tolist())
+    )
+    return s
+
+
+def test_drop_stale_overrun_mixed_reslices_per_token():
+    # mixed batch: extend req (3 tokens) + two folded decode reqs (1 token
+    # each, mix_with_running tail); the middle one finished on the lagged
+    # resolve.
+    freed = []
+    s = _drop_stale_scheduler(freed)
+    batch = _MixedBatch(lens=[3, 1, 1], done=[False, True, False])
+    out = s._drop_stale_overrun(batch)
+    assert out is batch
+    assert freed == [103]  # the dropped req's token slot, nothing else
+    assert out.out_cache_loc.tolist() == [100, 101, 102, 104]
+    assert out.input_ids.tolist() == [0, 1, 2, 4]
+    assert out.extend_lens == [3, 1]
+    assert out.extend_num_tokens == 4
+    assert out.prefix_lens == [10, 30]
+
+
+def test_drop_stale_overrun_extend_multitoken_drop():
+    # pure extend batch where the dropped req owned several token slots
+    freed = []
+    s = _drop_stale_scheduler(freed)
+    batch = _MixedBatch(lens=[2, 3], done=[True, False])
+    out = s._drop_stale_overrun(batch)
+    assert freed == [100, 101]
+    assert out.out_cache_loc.tolist() == [102, 103, 104]
+    assert out.input_ids.tolist() == [2, 3, 4]
+    assert out.extend_lens == [3]
+    assert out.extend_num_tokens == 3
+    assert out.prefix_lens == [20]

--- a/tests/unit_test/pipeline/test_async_decode.py
+++ b/tests/unit_test/pipeline/test_async_decode.py
@@ -913,32 +913,45 @@ def test_drain_resolve_failure_calls_handle_batch_failure():
     assert s._async_pending is None
 
 
-# ---------------------------------------------------------------------------
-# _drop_stale_overrun on EXTEND/MIXED batches (#1023): out_cache_loc/input_ids
-# are per token (req i owns extend_lens[i] consecutive slots), not per request.
-# ---------------------------------------------------------------------------
-
-
 class _MixedBatch:
-    """Extend/mixed ScheduleBatch stub. filter_batch mirrors the real one:
-    per-request fields only, nulls out_cache_loc, leaves per-token fields and
-    the extend_* lists stale."""
-
-    def __init__(self, lens, done):
+    def __init__(self, lens, done, lp_start_lens=None, logprob=None):
         self.forward_mode = types.SimpleNamespace(
             is_decode=lambda: False, is_extend=lambda: True
         )
-        self.reqs = [types.SimpleNamespace(finished=lambda d=d: d) for d in done]
+        logprob = logprob or [False] * len(lens)
+        self.reqs = [
+            types.SimpleNamespace(finished=lambda d=d: d, return_logprob=lp)
+            for d, lp in zip(done, logprob)
+        ]
         self.extend_lens = list(lens)
         self.extend_num_tokens = sum(lens)
         self.prefix_lens = [10 * (i + 1) for i in range(len(lens))]
-        self.extend_logprob_start_lens = [0] * len(lens)
+        self.extend_logprob_start_lens = (
+            list(lp_start_lens) if lp_start_lens else [0] * len(lens)
+        )
         self.out_cache_loc = torch.arange(100, 100 + sum(lens))
         self.input_ids = torch.arange(sum(lens))
+        self.input_embeds = None
+        self.replace_embeds = None
+        self.token_type_ids = None
+        self.return_logprob = any(logprob)
+        if self.return_logprob:
+            self.extend_input_logprob_token_ids = torch.tensor(
+                [
+                    100 * (i + 1) + k
+                    for i, (length, start) in enumerate(
+                        zip(self.extend_lens, self.extend_logprob_start_lens)
+                    )
+                    for k in range(length - start)
+                ]
+            )
+        else:
+            self.extend_input_logprob_token_ids = None
 
     def filter_batch(self, keep_indices):
         self.reqs = [self.reqs[i] for i in keep_indices]
         self.out_cache_loc = None
+        self.return_logprob = any(r.return_logprob for r in self.reqs)
 
 
 def _drop_stale_scheduler(freed):
@@ -952,24 +965,21 @@ def _drop_stale_scheduler(freed):
 
 
 def test_drop_stale_overrun_mixed_reslices_per_token():
-    # mixed batch: extend req (3 tokens) + two folded decode reqs (1 token
-    # each, mix_with_running tail); the middle one finished on the lagged
-    # resolve.
     freed = []
     s = _drop_stale_scheduler(freed)
     batch = _MixedBatch(lens=[3, 1, 1], done=[False, True, False])
     out = s._drop_stale_overrun(batch)
     assert out is batch
-    assert freed == [103]  # the dropped req's token slot, nothing else
+    assert freed == [103]
     assert out.out_cache_loc.tolist() == [100, 101, 102, 104]
     assert out.input_ids.tolist() == [0, 1, 2, 4]
     assert out.extend_lens == [3, 1]
     assert out.extend_num_tokens == 4
     assert out.prefix_lens == [10, 30]
+    assert out.extend_input_logprob_token_ids is None
 
 
 def test_drop_stale_overrun_extend_multitoken_drop():
-    # pure extend batch where the dropped req owned several token slots
     freed = []
     s = _drop_stale_scheduler(freed)
     batch = _MixedBatch(lens=[2, 3], done=[True, False])
@@ -980,3 +990,28 @@ def test_drop_stale_overrun_extend_multitoken_drop():
     assert out.extend_lens == [3]
     assert out.extend_num_tokens == 3
     assert out.prefix_lens == [20]
+
+
+def test_drop_stale_overrun_reslices_logprob_token_ids():
+    freed = []
+    s = _drop_stale_scheduler(freed)
+    batch = _MixedBatch(
+        lens=[3, 2, 2],
+        done=[False, True, False],
+        lp_start_lens=[1, 0, 2],
+        logprob=[True, True, True],
+    )
+    assert batch.extend_input_logprob_token_ids.tolist() == [100, 101, 200, 201]
+    out = s._drop_stale_overrun(batch)
+    assert out.extend_input_logprob_token_ids.tolist() == [100, 101]
+    assert out.extend_lens == [3, 2]
+    assert out.extend_logprob_start_lens == [1, 2]
+
+
+def test_drop_stale_overrun_drops_last_logprob_req():
+    freed = []
+    s = _drop_stale_scheduler(freed)
+    batch = _MixedBatch(lens=[2, 2], done=[True, False], logprob=[True, False])
+    out = s._drop_stale_overrun(batch)
+    assert out.return_logprob is False
+    assert out.extend_input_logprob_token_ids is None

--- a/tests/unit_test/pipeline/test_async_decode.py
+++ b/tests/unit_test/pipeline/test_async_decode.py
@@ -727,6 +727,7 @@ class _DFBatch:
     def __init__(self, reqs):
         self.reqs = list(reqs)
         self.out_cache_loc = torch.arange(100, 100 + len(reqs))
+        self.decoding_reqs = None
 
     def copy(self):
         return _DFBatch(self.reqs)
@@ -934,6 +935,7 @@ class _MixedBatch:
         self.input_embeds = None
         self.replace_embeds = None
         self.token_type_ids = None
+        self.decoding_reqs = None
         self.return_logprob = any(logprob)
         if self.return_logprob:
             self.extend_input_logprob_token_ids = torch.tensor(
@@ -1015,3 +1017,14 @@ def test_drop_stale_overrun_drops_last_logprob_req():
     out = s._drop_stale_overrun(batch)
     assert out.return_logprob is False
     assert out.extend_input_logprob_token_ids is None
+
+
+def test_drop_stale_overrun_filters_decoding_reqs():
+    # dropped folded-decode row must also be removed from decoding_reqs
+    freed = []
+    s = _drop_stale_scheduler(freed)
+    batch = _MixedBatch(lens=[3, 1, 1], done=[False, True, False])
+    batch.decoding_reqs = [batch.reqs[1], batch.reqs[2]]
+    live_decode = batch.reqs[2]
+    out = s._drop_stale_overrun(batch)
+    assert out.decoding_reqs == [live_decode]

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -363,6 +363,7 @@ def test_omni_scheduler_fast_path_drops_retracted_req() -> None:
         def __init__(self, reqs):
             self.reqs = reqs
             self.out_cache_loc = torch.arange(100, 100 + len(reqs))
+            self.decoding_reqs = None
 
         def filter_batch(self, keep_indices=None):
             captured["keep_indices"] = keep_indices


### PR DESCRIPTION
## Problem

Under asynchronous decode at c>=32, an extend/mixed prefill batch can reach the KV write with `out_cache_loc=None`, aborting the request server-side (~1/64 at c32 on the audited main revision `45582ff5`; CUDA illegal access and scheduler death on older deps).

<details>
<summary>Real traceback from the audited c32 run (revision 45582ff5)</summary>

```
2026-07-08 06:57:17,269 [ERROR] sglang_omni.scheduling.omni_scheduler: OmniScheduler batch failed for requests=['8689e71c-6028-4a89-8a2c-51a303551e84']
Traceback (most recent call last):
  File "/data/main-clean/sglang_omni/scheduling/omni_scheduler.py", line 815, in run_batch
    return self._run_batch(batch, pp_proxy_tensors)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/main-clean/sglang_omni/scheduling/omni_scheduler.py", line 837, in _run_batch
    mr_output = self._model_runner.execute(sched_output)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/main-clean/sglang_omni/model_runner/thinker_model_runner.py", line 64, in execute
    return super().execute(scheduler_output)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/main-clean/sglang_omni/model_runner/base.py", line 145, in execute
    batch_result = self._prepare_and_forward(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/main-clean/sglang_omni/model_runner/base.py", line 308, in _prepare_and_forward
    batch_result = self.custom_prefill_forward(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/main-clean/sglang_omni/model_runner/thinker_model_runner.py", line 86, in custom_prefill_forward
    return self._forward_with_omni_embeds(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/main-clean/sglang_omni/model_runner/thinker_model_runner.py", line 308, in _forward_with_omni_embeds
    hidden_states = outer.model(
                    ^^^^^^^^^^^^
  File "/data/main-clean/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1779, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/main-clean/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1790, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/main-clean/.venv/lib/python3.12/site-packages/sglang/srt/models/qwen3_vl_moe.py", line 115, in forward
    hidden_states, residual = layer(
                              ^^^^^^
  File "/data/main-clean/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1779, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/main-clean/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1790, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/main-clean/.venv/lib/python3.12/site-packages/sglang/srt/models/qwen3_moe.py", line 827, in forward
    hidden_states = self.self_attn(
                    ^^^^^^^^^^^^^^^
  File "/data/main-clean/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1779, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/main-clean/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1790, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/main-clean/.venv/lib/python3.12/site-packages/sglang/srt/models/qwen3_moe.py", line 716, in forward
    return self.forward_core(s)
           ^^^^^^^^^^^^^^^^^^^^
  File "/data/main-clean/.venv/lib/python3.12/site-packages/sglang/srt/models/qwen3_moe.py", line 695, in forward_core
    attn_output = self.attn(
                  ^^^^^^^^^^
  File "/data/main-clean/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1779, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/main-clean/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1790, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/main-clean/.venv/lib/python3.12/site-packages/sglang/srt/layers/radix_attention.py", line 138, in forward
    return forward_batch.attn_backend.forward(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/main-clean/.venv/lib/python3.12/site-packages/sglang/srt/layers/attention/base_attn_backend.py", line 124, in forward
    return self.forward_extend(
           ^^^^^^^^^^^^^^^^^^^^
  File "/data/main-clean/.venv/lib/python3.12/site-packages/sglang/srt/layers/attention/flashattention_backend.py", line 644, in forward_extend
    forward_batch.token_to_kv_pool.set_kv_buffer(
  File "/data/main-clean/.venv/lib/python3.12/site-packages/sglang/srt/mem_cache/memory_pool.py", line 1073, in set_kv_buffer
    _set_kv_buffer_impl(
  File "/data/main-clean/.venv/lib/python3.12/site-packages/sglang/srt/mem_cache/memory_pool.py", line 105, in _set_kv_buffer_impl
    return store_cache(
           ^^^^^^^^^^^^
  File "/data/main-clean/.venv/lib/python3.12/site-packages/torch/_ops.py", line 1269, in __call__
    return self._op(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/main-clean/.venv/lib/python3.12/site-packages/sglang/jit_kernel/kvcache.py", line 79, in store_cache
    module.store_cache(
  File "python/tvm_ffi/cython/function.pxi", line 929, in tvm_ffi.core.Function.__call__
TypeError: Mismatched type on argument #4 when calling: `store_cache(0: DLTensor*, 1: DLTensor*, 2: DLTensor*, 3: DLTensor*, 4: DLTensor*, 5: int) -> void`. Expected `DLTensor*` but got `None`
```

</details>

## Root cause

`_drop_stale_overrun` in the async decode loop filters EXTEND/MIXED batches with per-request semantics, but on those batches `out_cache_loc`/`input_ids` are per **token** (req `i` owns `extend_lens[i]` consecutive slots; `mix_with_running` appends folded decode reqs as extend-len-1 tails):

- At `45582ff5`: `filter_batch` nulls `out_cache_loc` with no restore — the loud `None` abort above.
- After #1010: the restore `out_cache_loc[keep]` indexes a per-token tensor with request indices — a length-mismatched KV write (silent slot corruption) instead of the loud `None`.
- `_free_overrun_step_slots(out_cache_loc, drop_indices)` likewise frees `out_cache_loc[req_index]`, i.e. another request's token slot on a mixed batch.

Full trace analysis: https://github.com/sgl-project/sglang-omni/issues/1023#issuecomment-4942392652

## Fix

In `_drop_stale_overrun`, extend/mixed batches now reslice the per-token fields (`out_cache_loc`, `input_ids`) by each kept request's extend-length segment, free exactly the dropped requests' token slots, and re-derive `extend_lens` / `extend_num_tokens` / `prefix_lens` / `extend_logprob_start_lens` (which `filter_batch` does not touch). Decode batches keep the #1010 per-request path unchanged.

## Validation

- Two regression tests (mixed batch dropping a folded-decode req; pure extend multi-token drop) fail on unfixed main, pass with the fix; `tests/unit_test/pipeline/` fully green (283 passed).
- E2E sweep (current main + fix, TP1 H100, warm-up discarded), zero failures across all rounds — 520/520 requests, of which 480 at c>=32 against the historical ~1/64 failure rate:

| round | c | n | ok | fail | out tok/s |
|---|---:|---:|---:|---:|---:|
| r1 | 1 | 8 | 8 | 0 | 182.9 |
| r1 | 16 | 32 | 32 | 0 | 1146.2 |
| r1 | 32 | 64 | 64 | 0 | 1408.1 |
| r1 | 48 | 96 | 96 | 0 | 1323.8 |
| r2 | 32 | 64 | 64 | 0 | 1438.5 |
| r2 | 48 | 96 | 96 | 0 | 1446.4 |
| r3 | 32 | 64 | 64 | 0 | 1301.4 |
| r3 | 48 | 96 | 96 | 0 | 1452.6 |

Part of #1022. Fixes #1023. Design basis: #1018 (item 1.1). Follow-up to #1010.
