### PR TITLE
Add fast path for WAV audio decoding

### DIFF
--- a/sglang_omni/utils/audio.py
+++ b/sglang_omni/utils/audio.py
@@ -31,6 +31,7 @@ def _try_fast_wav_decode(data: bytes, target_sample_rate: int) -> np.ndarray | N
         audio, sample_rate = _parse_wav_bytes(data)
     except ValueError:
         return None
+    audio = np.ascontiguousarray(audio, dtype=np.float32)
     if sample_rate == target_sample_rate:
         return audio
 
@@ -82,8 +83,8 @@ def load_audio(
             source = unquote(urlparse(source).path)
 
     if isinstance(source, bytes):
-        # Note (akazaakane): The pure-Python WAV parser avoids torchaudio decoder
-        # startup for common mono inputs without changing channel-preserving loads.
+        # Note (akazaakane): The direct WAV/NumPy path avoids torchaudio decoder
+        # startup when mono=True without changing channel-preserving loads.
         if mono and _is_riff_wav(source):
             fast = _try_fast_wav_decode(source, target_sample_rate)
             if fast is not None:

--- a/sglang_omni/utils/audio.py
+++ b/sglang_omni/utils/audio.py
@@ -23,15 +23,8 @@ def _is_riff_wav(data: bytes) -> bool:
 
 
 def _try_fast_wav_decode(data: bytes, target_sample_rate: int) -> np.ndarray | None:
-    """Decode PCM/IEEE-float WAV bytes without torchaudio's decoder init.
-
-    Returns None for anything the pure-Python parser doesn't support
-    (e.g. 24-bit PCM, ADPCM), so the caller falls back to torchaudio.load.
-    Resampling stays on torchaudio.functional.resample: it applies a
-    windowed-sinc lowpass, which np.interp-style linear resampling lacks,
-    so downsampling would alias.
-    """
-    # Local import: utils sits below preprocessing in the layering.
+    # Note (gaoyang): Keep unsupported WAV encodings on torchaudio so the fast
+    # path never narrows existing format coverage.
     from sglang_omni.preprocessing.audio import _parse_wav_bytes
 
     try:
@@ -40,6 +33,7 @@ def _try_fast_wav_decode(data: bytes, target_sample_rate: int) -> np.ndarray | N
         return None
     if sample_rate == target_sample_rate:
         return audio
+
     resampled = torchaudio.functional.resample(
         torch.from_numpy(audio), sample_rate, target_sample_rate
     )
@@ -88,9 +82,8 @@ def load_audio(
             source = unquote(urlparse(source).path)
 
     if isinstance(source, bytes):
-        # Fast path for PCM/float WAV bytes: skips torchaudio.load's
-        # per-call decoder initialization (~6 ms). _parse_wav_bytes
-        # downmixes to mono unconditionally, so only valid when mono=True.
+        # Note (akazaakane): The pure-Python WAV parser avoids torchaudio decoder
+        # startup for common mono inputs without changing channel-preserving loads.
         if mono and _is_riff_wav(source):
             fast = _try_fast_wav_decode(source, target_sample_rate)
             if fast is not None:

--- a/sglang_omni/utils/audio.py
+++ b/sglang_omni/utils/audio.py
@@ -23,7 +23,7 @@ def _is_riff_wav(data: bytes) -> bool:
 
 
 def _try_fast_wav_decode(data: bytes, target_sample_rate: int) -> np.ndarray | None:
-    # Note (gaoyang): Keep unsupported WAV encodings on torchaudio so the fast
+    # Note (akazaakane): Keep unsupported WAV encodings on torchaudio so the fast
     # path never narrows existing format coverage.
     from sglang_omni.preprocessing.audio import _parse_wav_bytes
 

--- a/sglang_omni/utils/audio.py
+++ b/sglang_omni/utils/audio.py
@@ -18,6 +18,34 @@ import torchaudio
 _DEFAULT_REQUEST_TIMEOUT = 5
 
 
+def _is_riff_wav(data: bytes) -> bool:
+    return len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WAVE"
+
+
+def _try_fast_wav_decode(data: bytes, target_sample_rate: int) -> np.ndarray | None:
+    """Decode PCM/IEEE-float WAV bytes without torchaudio's decoder init.
+
+    Returns None for anything the pure-Python parser doesn't support
+    (e.g. 24-bit PCM, ADPCM), so the caller falls back to torchaudio.load.
+    Resampling stays on torchaudio.functional.resample: it applies a
+    windowed-sinc lowpass, which np.interp-style linear resampling lacks,
+    so downsampling would alias.
+    """
+    # Local import: utils sits below preprocessing in the layering.
+    from sglang_omni.preprocessing.audio import _parse_wav_bytes
+
+    try:
+        audio, sample_rate = _parse_wav_bytes(data)
+    except ValueError:
+        return None
+    if sample_rate == target_sample_rate:
+        return audio
+    resampled = torchaudio.functional.resample(
+        torch.from_numpy(audio), sample_rate, target_sample_rate
+    )
+    return resampled.numpy()
+
+
 def decode_audio_data_uri(value: str) -> bytes | None:
     if not value.startswith("data:"):
         return None
@@ -60,6 +88,13 @@ def load_audio(
             source = unquote(urlparse(source).path)
 
     if isinstance(source, bytes):
+        # Fast path for PCM/float WAV bytes: skips torchaudio.load's
+        # per-call decoder initialization (~6 ms). _parse_wav_bytes
+        # downmixes to mono unconditionally, so only valid when mono=True.
+        if mono and _is_riff_wav(source):
+            fast = _try_fast_wav_decode(source, target_sample_rate)
+            if fast is not None:
+                return fast
         audio, sample_rate = torchaudio.load(io.BytesIO(source))
     elif isinstance(source, str):
         audio, sample_rate = torchaudio.load(source)

--- a/sglang_omni/utils/audio.py
+++ b/sglang_omni/utils/audio.py
@@ -32,6 +32,8 @@ def _try_fast_wav_decode(data: bytes, target_sample_rate: int) -> np.ndarray | N
     except ValueError:
         return None
     audio = np.ascontiguousarray(audio, dtype=np.float32)
+    if not audio.flags.writeable:
+        audio = audio.copy()
     if sample_rate == target_sample_rate:
         return audio
 

--- a/tests/unit_test/utils/test_audio.py
+++ b/tests/unit_test/utils/test_audio.py
@@ -123,7 +123,7 @@ def _sine_wav_bytes(
     samples = np.sin(2 * np.pi * 440.0 * t)
     if sampwidth == 2:
         frames = (samples * 32767).astype("<i2")
-    elif sampwidth == 3:  # 24-bit PCM, unsupported by the fast path
+    elif sampwidth == 3:
         i32 = (samples * 8388607).astype("<i4")
         frames = np.zeros(num_samples * 3, dtype=np.uint8)
         raw = i32.astype("<i4").tobytes()

--- a/tests/unit_test/utils/test_audio.py
+++ b/tests/unit_test/utils/test_audio.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import io
+import struct
 import wave
 
+import numpy as np
 import pybase64
 import pytest
 
@@ -108,3 +110,119 @@ def test_load_audio_uses_default_timeout_for_invalid_env(monkeypatch) -> None:
 
     assert samples.shape == (1600,)
     assert calls == [audio._DEFAULT_REQUEST_TIMEOUT]
+
+
+def _sine_wav_bytes(
+    sample_rate: int = 16000,
+    num_channels: int = 1,
+    duration_s: float = 0.1,
+    sampwidth: int = 2,
+) -> bytes:
+    num_samples = int(sample_rate * duration_s)
+    t = np.arange(num_samples) / sample_rate
+    samples = np.sin(2 * np.pi * 440.0 * t)
+    if sampwidth == 2:
+        frames = (samples * 32767).astype("<i2")
+    elif sampwidth == 3:  # 24-bit PCM, unsupported by the fast path
+        i32 = (samples * 8388607).astype("<i4")
+        frames = np.zeros(num_samples * 3, dtype=np.uint8)
+        raw = i32.astype("<i4").tobytes()
+        for i in range(num_samples):
+            frames[i * 3 : i * 3 + 3] = np.frombuffer(
+                raw[i * 4 : i * 4 + 3], dtype=np.uint8
+            )
+    else:
+        raise ValueError(sampwidth)
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav:
+        wav.setnchannels(num_channels)
+        wav.setsampwidth(sampwidth)
+        wav.setframerate(sample_rate)
+        if num_channels > 1:
+            interleaved = np.repeat(frames, num_channels) if sampwidth == 2 else frames
+            wav.writeframes(interleaved.tobytes())
+        else:
+            wav.writeframes(frames.tobytes())
+    return buffer.getvalue()
+
+
+def _float32_wav_bytes(sample_rate: int = 16000, num_samples: int = 1600) -> bytes:
+    t = np.arange(num_samples) / sample_rate
+    samples = np.sin(2 * np.pi * 440.0 * t).astype("<f4")
+    data = samples.tobytes()
+    fmt = struct.pack("<HHIIHH", 3, 1, sample_rate, sample_rate * 4, 4, 32)
+    body = b"WAVE" + b"fmt " + struct.pack("<I", len(fmt)) + fmt
+    body += b"data" + struct.pack("<I", len(data)) + data
+    return b"RIFF" + struct.pack("<I", len(body)) + body
+
+
+@pytest.mark.parametrize("sample_rate", [8000, 16000, 44100, 48000])
+def test_load_audio_fast_path_matches_torchaudio(monkeypatch, sample_rate) -> None:
+    wav = _sine_wav_bytes(sample_rate=sample_rate)
+
+    fast = load_audio(wav)
+
+    monkeypatch.setattr(audio, "_is_riff_wav", lambda data: False)
+    slow = load_audio(wav)
+
+    assert fast.dtype == slow.dtype == np.float32
+    assert fast.shape == slow.shape
+    np.testing.assert_allclose(fast, slow, atol=1e-6)
+
+
+def test_load_audio_fast_path_matches_torchaudio_stereo(monkeypatch) -> None:
+    wav = _sine_wav_bytes(num_channels=2)
+
+    fast = load_audio(wav)
+
+    monkeypatch.setattr(audio, "_is_riff_wav", lambda data: False)
+    slow = load_audio(wav)
+
+    np.testing.assert_allclose(fast, slow, atol=1e-6)
+
+
+def test_load_audio_fast_path_handles_float32_wav() -> None:
+    samples = load_audio(_float32_wav_bytes())
+
+    assert samples.shape == (1600,)
+    assert samples.dtype == np.float32
+
+
+def test_load_audio_fast_path_skips_torchaudio(monkeypatch) -> None:
+    def fail_load(*args, **kwargs):
+        raise AssertionError("torchaudio.load should not be called on the fast path")
+
+    monkeypatch.setattr(audio.torchaudio, "load", fail_load)
+
+    samples = load_audio(_sine_wav_bytes())
+
+    assert samples.shape == (1600,)
+
+
+def test_load_audio_fast_path_resamples(monkeypatch) -> None:
+    def fail_load(*args, **kwargs):
+        raise AssertionError("torchaudio.load should not be called on the fast path")
+
+    monkeypatch.setattr(audio.torchaudio, "load", fail_load)
+
+    samples = load_audio(_sine_wav_bytes(sample_rate=48000))
+
+    assert samples.shape == (1600,)
+
+
+def test_load_audio_falls_back_when_not_mono() -> None:
+    samples = load_audio(_sine_wav_bytes(num_channels=2), mono=False)
+
+    assert samples.shape == (2, 1600)
+
+
+def test_load_audio_falls_back_for_24bit_pcm() -> None:
+    samples = load_audio(_sine_wav_bytes(sampwidth=3))
+
+    assert samples.shape == (1600,)
+    assert samples.dtype == np.float32
+
+
+def test_load_audio_falls_back_for_non_wav_bytes() -> None:
+    assert audio._try_fast_wav_decode(b"\xffnot a wav" * 10, 16000) is None
+    assert not audio._is_riff_wav(b"ID3\x04" + b"\x00" * 20)

--- a/tests/unit_test/utils/test_audio.py
+++ b/tests/unit_test/utils/test_audio.py
@@ -186,6 +186,8 @@ def test_load_audio_fast_path_handles_float32_wav() -> None:
 
     assert samples.shape == (1600,)
     assert samples.dtype == np.float32
+    assert samples.flags.writeable
+    samples[0] = 0
 
 
 def test_load_audio_fast_path_skips_torchaudio(monkeypatch) -> None:


### PR DESCRIPTION


## Motivation
H100 ASR workload was measured as host-bound:

    GPU idle: approximately 94%
    Host CPU sensitivity: 0.69
    Audio decoding: approximately 69% of request-build time

A prototype fast path reduced common 16 kHz PCM WAV loading from approximately 6.10 ms to 0.03 ms

## Modifications

- Optimize audio loading for PCM/float WAV files by adding a direct WAV/NumPy fast path that avoids torchaudio’s per-call decoder initialization overhead of roughly 6 ms.
- The fast path is enabled as default. It reuses the existing WAV parser, converts the result to a writable float32 NumPy array, downmixes stereo input to mono when necessary, and uses torchaudio only for resampling. When mono=False, or when the WAV format is unsupported—such as 24-bit PCM—or parsing fails, loading falls back to torchaudio.
- This is a request-building optimization identified through follow-up profiling from #907. Issue #907 established that the workload is host-bound; deeper request-build profiling then identified audio decoding as a separate hotspot. This PR addresses only that hotspot. It does not change per-token scheduler synchronization, kernel-launch overhead, or the decode launch bubble.

## Related Issues

#1030 

## Benchmark & Profiling

This benchmark evaluates the end-to-end impact of adding a guarded PCM WAV fast path to `load_audio` for Qwen3-ASR request building.

The patch substantially reduces audio-loading and request-building overhead:

- Audio loading: **6.33 ms → 0.17 ms**
- Request building: **9.06 ms → 2.82 ms**
- Peak stable full-corpus throughput: **104.02 → 111.75 samples/s**
- Peak throughput improvement: **+7.43%**
- Full PCM corpus WER: **unchanged at 0.012107**
- FLAC fallback control: **+0.03%**, effectively unchanged

The benchmark confirms that supported PCM WAV requests use the fast path end to end and that unsupported formats continue through the existing fallback without a performance or quality regression.

---

## Test Configuration

### Server configuration

```text
model: Qwen/Qwen3-ASR-1.7B
GPU: 1 × NVIDIA H100
max_running_requests: 32
request_build_max_workers: 2
request_build_max_pending: 128
```

### Benchmark configuration

The benchmark used the SGLang-Omni ASR serving path through:

```text
/v1/audio/transcriptions
```

Each request included an actual audio file as multipart WAV or FLAC data.

For the full PCM benchmark:

```text
Dataset: SeedTTS English
Samples: 1088
Format: mono 16 kHz PCM16 WAV
Concurrencies: 32, 64, 96
Repeats: 3 per server startup
Independent startups: 2 per version
Valid repeats: 6 per version and concurrency
```

Run order:

```text
base_a → patch_a → patch_b → base_b
```

A 64-request warmup was run for every server startup.

All full PCM runs at concurrency 32, 64, and 96 completed with:

```text
skipped=0
```

---

# 1. Full PCM SeedTTS Benchmark

## Throughput

| Concurrency | Base QPS mean | Patch QPS mean | Change | Bootstrap 95% interval |
|---:|---:|---:|---:|---:|
| 32 | 88.85 | 92.02 | +3.57% | -20.14% to +32.35% |
| 64 | 104.02 | 111.75 | **+7.43%** | +5.68% to +9.29% |
| 96 | 101.95 | 106.95 | **+4.91%** | +1.63% to +8.21% |

Concurrency 64 was the peak stable operating point for both versions.

```text
Base peak:  104.02 samples/s
Patch peak: 111.75 samples/s
Change:      +7.43%
```

Concurrency 96 was slower than concurrency 64 for both versions, indicating that the server had already passed its optimal saturation point. Concurrency 128 was therefore not tested.

## Paired throughput changes

| Concurrency | Mean paired change | Paired range | Interpretation |
|---:|---:|---:|---|
| 32 | +2.95% | -4.47% to +6.97% | Inconclusive |
| 64 | **+7.46%** | **+4.66% to +10.17%** | Consistent improvement |
| 96 | **+4.92%** | **+0.60% to +8.47%** | Positive but below peak |

The strongest end-to-end result is therefore the concurrency-64 plateau.

---

## Quality

| Dataset | Base WER | Patch WER | Change |
|---|---:|---:|---:|
| Full PCM SeedTTS | 0.012107 | 0.012107 | None |

The patch produced no measurable WER regression.

All full PCM benchmark runs completed without skipped requests.

---

# 2. Fast-Path Instrumentation

The server recorded fast-path and fallback counters together with mean audio-loading and request-building latency.

The counts include both timed benchmark requests and the 64-request warmup for each server startup.

| Leg | Fast WAV hits | WAV fallbacks | Non-WAV fallbacks | Resample calls | Mean audio load | Mean request build |
|---|---:|---:|---:|---:|---:|---:|
| base_a | 0 | 9856 | 0 | 0 | 6.410 ms | 9.186 ms |
| base_b | 0 | 9856 | 0 | 0 | 6.240 ms | 8.935 ms |
| patch_a | 9856 | 0 | 0 | 0 | 0.168 ms | 2.864 ms |
| patch_b | 9856 | 0 | 0 | 0 | 0.177 ms | 2.767 ms |

## Aggregated latency

| Metric | Base mean | Patch mean | Reduction | Speedup |
|---|---:|---:|---:|---:|
| Audio loading | 6.325 ms | 0.173 ms | **97.3%** | **36.7×** |
| Request building | 9.061 ms | 2.816 ms | **68.9%** | **3.22×** |

Absolute request-building reduction:

```text
9.061 ms - 2.816 ms = 6.245 ms/request
```

The counters confirm that:

- Every supported PCM WAV request used the fast path on the patched branch.
- No patched PCM request fell back to `torchaudio.load`.
- The base branch used the existing WAV path for every request.
- No resampling occurred because all inputs were already mono 16 kHz PCM16 WAV.

This proves that the benchmark exercised the intended optimization end to end.

---

# 3. Short Homogeneous PCM Benchmark

A second benchmark was created from one 2.0-second mono 16 kHz PCM16 clip repeated 1024 times.

Dataset:

```text
/workspace/datasets/seedtts_short_pcm16_16k/meta.lst
```

## Results

| Concurrency | Base QPS | Patch QPS | Change |
|---:|---:|---:|---:|
| 32 | 157.47 | 202.36 | **+28.51%** |
| 64 | 267.38 | 246.49 | -7.81% |
| 96 | 114.87 | 111.10 | -3.28% |

## Interpretation

This test does not provide a stable saturated-throughput result.

The patch produced a large gain at concurrency 32, but the result reversed at concurrency 64 and both versions collapsed at concurrency 96.

Because every request used the same audio clip, the benchmark may interact with:

- identical audio fingerprints;
- multimodal caching;
- prefix or feature reuse;
- batching behavior;
- scheduler backpressure;
- request-shape homogeneity.

This benchmark confirms that lower request-building cost can materially improve some short-audio operating points, but it should not be used as the primary end-to-end acceptance result.

A stronger short-audio follow-up would use hundreds of distinct 1–3 second PCM clips rather than repeating the same waveform.

---

# 4. FLAC Fallback Control

A control benchmark was run with FLAC inputs to confirm that unsupported formats continue through the existing fallback path.

Configuration:

```text
Samples: 300
Concurrency: 64
Repeats: 3
request_build_max_pending: 128
```

## Results

| Format | Base QPS | Patch QPS | Change | WER | Skips |
|---|---:|---:|---:|---:|---:|
| FLAC | 95.74 | 95.77 | +0.03% | 0.012884 | 0 |

Patch counters:

```text
fast_wav_hits=0
non_wav_fallbacks=964
resample_calls=0
```

## Interpretation

The FLAC control behaved as expected:

- No FLAC request entered the PCM WAV fast path.
- All requests used the existing non-WAV fallback.
- Throughput was effectively unchanged.
- WER remained stable.
- No requests were skipped.

This isolates the performance gain to the PCM WAV fast path rather than an unrelated server or benchmark change.

---

# 5. Benchmark Robustness Changes

Local benchmark scaffolding was updated to make repeated performance runs more robust.

The changes were kept separate from the audio fast-path implementation.

## Changes

- Invalid repeats are marked with `valid_for_headline`.
- Aggregate statistics ignore invalid repeats.
- Missing or `None` metric values no longer crash aggregation.
- Failed or incomplete runs remain visible in the raw output but are excluded from headline means.

These changes prevent one failed repeat from corrupting the full benchmark summary.

---

# 6. End-to-End Interpretation

The optimization reduces audio-loading latency by approximately 6.15 ms per request:

```text
6.325 ms → 0.173 ms
```

It reduces total request-building latency by approximately 6.25 ms per request:

```text
9.061 ms → 2.816 ms
```

The local operation becomes approximately 37× faster, while the full request-builder stage becomes approximately 3.2× faster.

The end-to-end throughput gain is smaller because request building is only one component of the ASR pipeline. Other remaining costs include:

- feature extraction;
- scheduler processing;
- HTTP and multipart handling;
- model prefill;
- autoregressive decoding;
- output processing;
- batching and queue management.

Request building also runs with two workers and can overlap with GPU execution. Once the loader overhead is removed, the system shifts toward other bottlenecks.

The measured peak serving improvement of 7.43% is therefore consistent with the much larger local latency reduction.

---

# 7. Final Result

On one H100 with:

```text
request_build_max_workers=2
request_build_max_pending=128
max_running_requests=32
```

the PCM WAV fast path improved the full SeedTTS peak stable throughput at concurrency 64 from:

```text
104.02 → 111.75 samples/s
```

This is:

```text
+7.43%
```

At the same time:

```text
Audio loading:    6.33 ms → 0.17 ms
Request building: 9.06 ms → 2.82 ms
Corpus WER:       0.012107 → 0.012107
Skipped requests: 0
```

The FLAC fallback control remained unchanged:

```text
95.74 → 95.77 samples/s
```

## Recommended headline

> On one H100, the fast PCM WAV path reduced mean audio-loading latency from 6.33 ms to 0.17 ms and mean request-building latency from 9.06 ms to 2.82 ms. On the full PCM SeedTTS benchmark, peak stable Qwen3-ASR throughput improved from 104.02 to 111.75 samples/s at concurrency 64, a 7.43% gain. Corpus WER remained unchanged at 0.012107, all requests completed successfully, and a FLAC fallback control showed no throughput change.

## Conclusion

The benchmark demonstrates that the patch:

- materially reduces supported PCM WAV loading overhead;
- improves peak end-to-end ASR serving throughput;
- preserves transcription quality;
- preserves unsupported-format behavior;
- introduces no observable regression for FLAC inputs;
- produces its clearest benefit under saturated full-corpus serving conditions.

The defensible end-to-end throughput claim is **+7.43% at the peak stable concurrency**, rather than the earlier prototype estimate of approximately +45%.


## Checklist

- [x] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
