### PR TITLE
[RL] Preserve multimodal inputs and fix Higgs rollout semantics

### DIFF
--- a/sglang_omni/client/client.py
+++ b/sglang_omni/client/client.py
@@ -615,23 +615,31 @@ def _extract_inputs(request: GenerateRequest) -> Any:
             "GenerateRequest requires exactly one input: "
             "prompt, prompt_token_ids, or messages."
         )
+    # Media is model input, not request metadata. Keep metadata fallbacks for
+    # existing chat-completion callers while /generate migrates to typed fields.
+    audios = request.audios or request.metadata.get("audios")
+    images = request.images or request.metadata.get("images")
+    videos = request.videos or request.metadata.get("videos")
+    has_media = bool(audios or images or videos)
+
     if request.prompt is not None:
+        if has_media:
+            raise ValueError(
+                "prompt with media is not supported; use messages or prompt_token_ids"
+            )
         return request.prompt
+
     if request.prompt_token_ids is not None:
-        return list(request.prompt_token_ids)
-
-    # Build messages list
-    messages = [msg.to_dict() for msg in request.messages or []]
-
-    # Check if we have audios, images, or videos in metadata
-    audios = request.metadata.get("audios")
-    images = request.metadata.get("images")
-    videos = request.metadata.get("videos")
-
-    # If we have any media, return a dict with messages and media
-    # Otherwise, return just the messages list (for backward compatibility)
-    if audios or images or videos:
+        if not has_media:
+            return list(request.prompt_token_ids)
+        result: dict[str, Any] = {"input_ids": list(request.prompt_token_ids)}
+    else:
+        messages = [msg.to_dict() for msg in request.messages or []]
+        if not has_media:
+            return messages
         result = {"messages": messages}
+
+    if has_media:
         if images:
             result["images"] = images
         if audios:
@@ -645,11 +653,14 @@ def _extract_inputs(request: GenerateRequest) -> Any:
             "video_max_pixels",
             "video_total_pixels",
         ):
-            value = request.metadata.get(key)
+            value = getattr(request, key)
+            if value is None:
+                value = request.metadata.get(key)
             if value is not None:
                 result[key] = value
         return result
-    return messages
+
+    raise AssertionError("unreachable input shape")
 
 
 def _build_params(request: GenerateRequest) -> dict[str, Any]:

--- a/sglang_omni/client/client.py
+++ b/sglang_omni/client/client.py
@@ -142,6 +142,8 @@ class Client:
                 id=f"audio-{request_id}",
                 data=audio_b64,
                 transcript=full_text if full_text else None,
+                format=audio_format,
+                sample_rate=sample_rate or DEFAULT_SAMPLE_RATE,
             )
 
         return CompletionResult(

--- a/sglang_omni/client/client.py
+++ b/sglang_omni/client/client.py
@@ -646,16 +646,16 @@ def _extract_inputs(request: GenerateRequest) -> Any:
             result["audios"] = audios
         if videos:
             result["videos"] = videos
-        for key in (
-            "video_fps",
-            "video_max_frames",
-            "video_min_pixels",
-            "video_max_pixels",
-            "video_total_pixels",
+        for key, typed_value in (
+            ("video_fps", request.video_fps),
+            ("video_max_frames", request.video_max_frames),
+            ("video_min_pixels", request.video_min_pixels),
+            ("video_max_pixels", request.video_max_pixels),
+            ("video_total_pixels", request.video_total_pixels),
         ):
-            value = getattr(request, key)
-            if value is None:
-                value = request.metadata.get(key)
+            value = (
+                typed_value if typed_value is not None else request.metadata.get(key)
+            )
             if value is not None:
                 result[key] = value
         return result

--- a/sglang_omni/client/types.py
+++ b/sglang_omni/client/types.py
@@ -97,6 +97,14 @@ class GenerateRequest:
 
     # Multi-modal support
     output_modalities: list[str] | None = None
+    images: list[str] | None = None
+    audios: list[str] | None = None
+    videos: list[str] | None = None
+    video_fps: float | None = None
+    video_max_frames: int | None = None
+    video_min_pixels: int | None = None
+    video_max_pixels: int | None = None
+    video_total_pixels: int | None = None
 
     metadata: dict[str, Any] = field(default_factory=dict)
 
@@ -117,6 +125,14 @@ class GenerateRequest:
             "stream": self.stream,
             "max_tokens": self.max_tokens,
             "output_modalities": self.output_modalities,
+            "images": self.images,
+            "audios": self.audios,
+            "videos": self.videos,
+            "video_fps": self.video_fps,
+            "video_max_frames": self.video_max_frames,
+            "video_min_pixels": self.video_min_pixels,
+            "video_max_pixels": self.video_max_pixels,
+            "video_total_pixels": self.video_total_pixels,
             "metadata": dict(self.metadata),
         }
 

--- a/sglang_omni/client/types.py
+++ b/sglang_omni/client/types.py
@@ -207,6 +207,8 @@ class CompletionAudio:
     id: str
     data: str  # base64
     transcript: str | None = None
+    format: str = "wav"
+    sample_rate: int | None = None
 
 
 @dataclass

--- a/sglang_omni/model_runner/model_worker.py
+++ b/sglang_omni/model_runner/model_worker.py
@@ -14,6 +14,31 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _nccl_version_string() -> str:
+    import torch
+
+    version = torch.cuda.nccl.version()
+    if isinstance(version, tuple):
+        return ".".join(str(part) for part in version)
+    return str(version)
+
+
+def _distributed_weight_update_transport(model_runner: Any) -> dict[str, Any] | None:
+    required_methods = (
+        "init_weights_update_group",
+        "update_weights_from_distributed",
+        "destroy_weights_update_group",
+    )
+    if not all(hasattr(model_runner, method) for method in required_methods):
+        return None
+    return {
+        "protocol_version": 1,
+        "backend": "nccl",
+        "nccl_version": _nccl_version_string(),
+        "nccl_cumem_enable": os.environ.get("NCCL_CUMEM_ENABLE", "default"),
+    }
+
+
 @dataclass
 class ModelWorkerConfig:
     model_arch_override: str | None = None
@@ -222,6 +247,9 @@ class ModelWorker:
         return batch_result
 
     def model_info(self) -> dict[str, Any]:
+        distributed_weight_update = _distributed_weight_update_transport(
+            self.model_runner
+        )
         return {
             "model_path": self.server_args.model_path,
             "load_format": self.server_args.load_format,
@@ -232,6 +260,10 @@ class ModelWorker:
             "supports_weight_update": hasattr(
                 self.model_runner, "update_weights_from_disk"
             ),
+            "supports_distributed_weight_update": (
+                distributed_weight_update is not None
+            ),
+            "distributed_weight_update": distributed_weight_update,
             "supports_weight_checker": True,
         }
 

--- a/sglang_omni/models/higgs_tts/config.py
+++ b/sglang_omni/models/higgs_tts/config.py
@@ -25,6 +25,10 @@ class HiggsTtsPipelineConfig(PipelineConfig):
     requires_model_capabilities: ClassVar[bool] = True
 
     @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"talker": "tts_engine"}
+
+    @classmethod
     def generation_sglang_role_to_stage(cls) -> dict[str, str]:
         return {"generation": "tts_engine"}
 

--- a/sglang_omni/models/higgs_tts/model.py
+++ b/sglang_omni/models/higgs_tts/model.py
@@ -169,6 +169,7 @@ class HiggsTTSModel(nn.Module):
             range(self._sampler_pool_max_running_requests)
         )
         self._output_codes: dict[str, list[torch.Tensor]] = {}
+        self._output_action_masks: dict[str, list[torch.Tensor]] = {}
         cg_device = self.backbone.model.embed_tokens.weight.device
         self._cg_row_indices = torch.zeros(
             pool_size, dtype=torch.long, device=cg_device
@@ -186,9 +187,12 @@ class HiggsTTSModel(nn.Module):
         self._cg_codes_BN = torch.zeros(
             pool_size, num_codebooks, dtype=torch.long, device=cg_device
         )
-        # Note(Jiaxin): Packs codes_BN | was_done | active_generation_done into one buffer.
+        self._cg_action_mask_BN = torch.zeros(
+            pool_size, num_codebooks, dtype=torch.bool, device=cg_device
+        )
+        # Packs codes | action mask | was_done | generation_done for one D2H copy.
         self._cg_collect_staging = torch.zeros(
-            pool_size, num_codebooks + 2, dtype=torch.long, device=cg_device
+            pool_size, 2 * num_codebooks + 2, dtype=torch.long, device=cg_device
         )
         self._cg_was_done = torch.zeros(pool_size, dtype=torch.bool, device=cg_device)
 
@@ -263,6 +267,7 @@ class HiggsTTSModel(nn.Module):
         if row is not None:
             self._free_rows.append(row)
         self._output_codes.pop(req_id, None)
+        self._output_action_masks.pop(req_id, None)
 
     def reset_request(self, req_id: str) -> None:
         self.release_row(req_id)
@@ -344,6 +349,9 @@ class HiggsTTSModel(nn.Module):
             if was_done_cpu[b]:
                 continue
             self._output_codes.setdefault(req_ids[b], []).append(codes_BN[b])
+            self._output_action_masks.setdefault(req_ids[b], []).append(
+                self._sampler_pool.last_action_mask[row_indices[b]].clone()
+            )
 
         text_vocab_size = self.backbone.config.vocab_size
         return torch.zeros(
@@ -383,6 +391,7 @@ class HiggsTTSModel(nn.Module):
             new_generation_done_B,
             new_last_codes_BN,
             new_step_count_B,
+            action_mask_BN,
         ) = batched_step_direct(
             logits_BNV,
             delay_count_B,
@@ -405,6 +414,7 @@ class HiggsTTSModel(nn.Module):
         self._cg_active_generation_done[:batch_size] = new_generation_done_B
         self._cg_active_last_codes[:batch_size] = new_last_codes_BN
         self._cg_codes_BN[:batch_size] = codes_BN
+        self._cg_action_mask_BN[:batch_size] = action_mask_BN
 
         text_vocab_size = self.backbone.config.vocab_size
         return torch.zeros(

--- a/sglang_omni/models/higgs_tts/model_runner.py
+++ b/sglang_omni/models/higgs_tts/model_runner.py
@@ -289,14 +289,20 @@ class HiggsTTSModelRunner(ModelRunner):
         pool.eoc_countdown[rows_t] = model._cg_active_eoc_countdown[:n_real]
         pool.generation_done[rows_t] = model._cg_active_generation_done[:n_real]
         pool.last_codes[rows_t] = model._cg_active_last_codes[:n_real]
+        pool.last_action_mask[rows_t] = model._cg_action_mask_BN[:n_real]
         pool.step_count[rows_t] = model._cg_active_step_count[:n_real]
 
-        # Note(Jiaxin): pack the 3 tensors so a single D2H pulls them all back.
+        # Pack codes, action masks, and terminal flags into one D2H transfer.
         num_codebooks = model._cg_codes_BN.shape[1]
         staging = model._cg_collect_staging
         staging[:n_real, :num_codebooks] = model._cg_codes_BN[:n_real]
-        staging[:n_real, num_codebooks] = model._cg_was_done[:n_real]
-        staging[:n_real, num_codebooks + 1] = model._cg_active_generation_done[:n_real]
+        staging[:n_real, num_codebooks : 2 * num_codebooks] = model._cg_action_mask_BN[
+            :n_real
+        ]
+        staging[:n_real, 2 * num_codebooks] = model._cg_was_done[:n_real]
+        staging[:n_real, 2 * num_codebooks + 1] = model._cg_active_generation_done[
+            :n_real
+        ]
         return staging
 
     def _decode_collect_host(
@@ -321,8 +327,9 @@ class HiggsTTSModelRunner(ModelRunner):
         model = self.model
         num_codebooks = model._cg_codes_BN.shape[1]
         codes_BN_cpu = combined_cpu[:, :num_codebooks]
-        was_done_cpu = combined_cpu[:, num_codebooks].bool().tolist()
-        gen_done_after_cpu = combined_cpu[:, num_codebooks + 1].bool().tolist()
+        action_mask_BN_cpu = combined_cpu[:, num_codebooks : 2 * num_codebooks].bool()
+        was_done_cpu = combined_cpu[:, 2 * num_codebooks].bool().tolist()
+        gen_done_after_cpu = combined_cpu[:, 2 * num_codebooks + 1].bool().tolist()
         cb0_per_row: list[int] = []
         for b, sched_req in enumerate(requests):
             data = sched_req.data
@@ -343,12 +350,18 @@ class HiggsTTSModelRunner(ModelRunner):
                 cb0_per_row.append(0)
                 continue
             codes_N = codes_BN_cpu[b].to(torch.long).clone()
+            action_mask_N = action_mask_BN_cpu[b].clone()
             data.output_codes.append(codes_N)
+            data.output_action_masks.append(action_mask_N)
             if logprobs_cpu is not None and self._request_captures_rollout_logprobs(
                 sched_req
             ):
                 data.output_logprobs.append(
-                    logprobs_cpu[b, :num_codebooks].to(torch.float32).clone()
+                    torch.where(
+                        action_mask_N,
+                        logprobs_cpu[b, :num_codebooks].to(torch.float32),
+                        torch.zeros(num_codebooks, dtype=torch.float32),
+                    )
                 )
                 data.output_token_logprobs.append(
                     [
@@ -434,16 +447,32 @@ class HiggsTTSModelRunner(ModelRunner):
             rid = sched_req.request_id
             row = model._rid_to_row.get(rid)
             codes_log = model._output_codes.get(rid)
-            if req.is_chunked > 0 or row is None or not codes_log or req.finished():
+            action_mask_log = model._output_action_masks.get(rid)
+            if (
+                req.is_chunked > 0
+                or row is None
+                or not codes_log
+                or not action_mask_log
+                or req.finished()
+            ):
                 cb0_per_row.append(0)
                 continue
             codes_N = codes_log[-1]
+            action_mask_N = action_mask_log[-1]
             data.output_codes.append(codes_N.detach().cpu().clone())
+            data.output_action_masks.append(action_mask_N.detach().cpu().clone())
             if logprob_bundle is not None and self._request_captures_rollout_logprobs(
                 sched_req
             ):
                 data.output_logprobs.append(
-                    logprob_bundle[b, : model._num_codebooks].detach().cpu().clone()
+                    torch.where(
+                        action_mask_N,
+                        logprob_bundle[b, : model._num_codebooks],
+                        torch.zeros_like(logprob_bundle[b, : model._num_codebooks]),
+                    )
+                    .detach()
+                    .cpu()
+                    .clone()
                 )
                 data.output_token_logprobs.append(
                     [

--- a/sglang_omni/models/higgs_tts/payload_types.py
+++ b/sglang_omni/models/higgs_tts/payload_types.py
@@ -48,6 +48,7 @@ class HiggsTtsState(PipelineStateBase):
     output_codes_delayed: list[list[int]] | None = None
     output_token_logprobs: list[Any] | None = None
     omni_rollout: dict[str, Any] | None = None
+    weight_version: str | None = None
 
     # vocoder
     audio_samples: Any | None = None
@@ -87,6 +88,8 @@ class HiggsTtsState(PipelineStateBase):
             data["output_token_logprobs"] = self.output_token_logprobs
         if self.omni_rollout is not None:
             data["omni_rollout"] = self.omni_rollout
+        if self.weight_version is not None:
+            data["weight_version"] = self.weight_version
         self.append_usage_fields(data)
         if self.audio_samples is not None:
             data["audio_samples"] = self.audio_samples
@@ -116,6 +119,7 @@ class HiggsTtsState(PipelineStateBase):
             output_codes_delayed=data.get("output_codes_delayed"),
             output_token_logprobs=data.get("output_token_logprobs"),
             omni_rollout=data.get("omni_rollout"),
+            weight_version=data.get("weight_version"),
             prompt_tokens=data.get("prompt_tokens", 0),
             completion_tokens=data.get("completion_tokens", 0),
             engine_time_s=data.get("engine_time_s", 0.0),

--- a/sglang_omni/models/higgs_tts/request_builders.py
+++ b/sglang_omni/models/higgs_tts/request_builders.py
@@ -28,6 +28,7 @@ class HiggsSGLangRequestData(SGLangARRequestData):
     num_codebooks: int = 8
     codebook_size: int = 1026
     output_codes: list[torch.Tensor] = field(default_factory=list)
+    output_action_masks: list[torch.Tensor] = field(default_factory=list)
     output_logprobs: list[torch.Tensor] = field(default_factory=list)
     output_token_logprobs: list[list[float | int]] = field(default_factory=list)
     return_omni_rollout: bool = False
@@ -71,6 +72,8 @@ def _ref_audio_fingerprint(codes: list[list[int]] | None) -> str | None:
 def build_sglang_higgs_request(
     state: HiggsTtsState, *, request_id: str = ""
 ) -> HiggsSGLangRequestData:
+    if state.return_omni_rollout and not state.return_logprob:
+        raise ValueError("Higgs return_omni_rollout=true requires return_logprob=true")
     input_ids_list = list(state.prompt_token_ids)
     input_ids = torch.tensor(input_ids_list, dtype=torch.long)
 
@@ -170,7 +173,17 @@ def apply_higgs_result(state: HiggsTtsState, data: HiggsSGLangRequestData) -> No
                 f"does not match codes shape {tuple(codes.shape)}"
             )
 
-    raw_token_logprobs = getattr(data, "output_token_logprobs", None)
+    if data.output_action_masks:
+        action_mask = torch.stack(data.output_action_masks, dim=0).to(torch.bool)
+        if action_mask.shape != codes.shape:
+            raise ValueError(
+                f"Higgs rollout action-mask shape {tuple(action_mask.shape)} "
+                f"does not match codes shape {tuple(codes.shape)}"
+            )
+    else:
+        action_mask = torch.empty_like(codes, dtype=torch.bool)
+
+    raw_token_logprobs = data.output_token_logprobs
     if data.return_logprob and raw_token_logprobs is not None:
         if len(raw_token_logprobs) != int(codes.shape[0]):
             raise ValueError(
@@ -202,11 +215,16 @@ def apply_higgs_result(state: HiggsTtsState, data: HiggsSGLangRequestData) -> No
         state.output_token_logprobs = None
 
     if data.return_omni_rollout:
+        if not data.output_action_masks or delayed_logprobs is None:
+            raise ValueError(
+                "Higgs structured rollout is missing aligned action masks or policy logprobs"
+            )
         state.omni_rollout = build_omni_rollout_trace(
             codes,
             num_codebooks=num_codebooks,
             codebook_vocab_size=int(data.codebook_size),
-            delayed_logprobs=delayed_logprobs,
+            policy_logprobs=delayed_logprobs,
+            action_mask=action_mask,
         )
     state.prompt_tokens = len(data.input_ids)
 

--- a/sglang_omni/models/higgs_tts/request_builders.py
+++ b/sglang_omni/models/higgs_tts/request_builders.py
@@ -226,6 +226,7 @@ def apply_higgs_result(state: HiggsTtsState, data: HiggsSGLangRequestData) -> No
             policy_logprobs=delayed_logprobs,
             action_mask=action_mask,
         )
+    state.weight_version = data.weight_version
     state.prompt_tokens = len(data.input_ids)
 
 

--- a/sglang_omni/models/higgs_tts/rollout_trace.py
+++ b/sglang_omni/models/higgs_tts/rollout_trace.py
@@ -1,8 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Serialize a Higgs rollout (delayed codes + logprobs) into the
-``meta_info.omni_rollout`` schema (issue #780 §1.1.1): one ``higgs_codes``
-discrete action stream with actions, logprobs, and the trainable-action mask.
-"""
+"""Build the version-2 structured Higgs rollout trace."""
 
 from __future__ import annotations
 
@@ -10,9 +7,9 @@ from typing import Any
 
 import torch
 
-from sglang_omni.models.higgs_tts.utils import delay_pattern_action_mask
+from sglang_omni.models.higgs_tts.utils import delay_pattern_codec_content_mask
 
-OMNI_ROLLOUT_VERSION = 1
+OMNI_ROLLOUT_VERSION = 2
 
 
 def build_omni_rollout_trace(
@@ -20,21 +17,13 @@ def build_omni_rollout_trace(
     *,
     num_codebooks: int,
     codebook_vocab_size: int,
-    delayed_logprobs: torch.Tensor | None = None,
+    policy_logprobs: torch.Tensor,
+    action_mask: torch.Tensor,
     model_family: str = "higgs_tts",
     stage: str = "tts_engine",
     stream_name: str = "higgs_codes",
 ) -> dict[str, Any]:
-    """Build the ``meta_info.omni_rollout`` dict from a delayed ``[L, N]`` code
-    matrix and aligned ``[L, N]`` selected-action logprobs (``None`` if not
-    requested).
-
-    The logprob contract is the sampler's canonical Higgs RL signal: fp32
-    selected-action values from full-vocab ``log_softmax(logits / T)`` at the
-    sampled code. Greedy rows (``temperature ~= 0`` or ``top_k == 1``) use raw
-    logits. Raises ``ValueError`` on shape disagreement or a non-finite logprob
-    at a trainable action position.
-    """
+    """Validate and serialize aligned sampled actions, masks, and logprobs."""
     if delayed_codes.ndim != 2:
         raise ValueError(
             f"delayed_codes must be 2-D [L, N], got shape {tuple(delayed_codes.shape)}"
@@ -45,51 +34,51 @@ def build_omni_rollout_trace(
             f"delayed_codes has {N} codebooks but num_codebooks={num_codebooks}"
         )
 
-    action_mask = delay_pattern_action_mask(delayed_codes)  # [L, N] bool
+    if tuple(action_mask.shape) != (L, N):
+        raise ValueError(
+            f"action_mask shape {tuple(action_mask.shape)} != codes shape {(L, N)}"
+        )
+    if tuple(policy_logprobs.shape) != (L, N):
+        raise ValueError(
+            f"policy_logprobs shape {tuple(policy_logprobs.shape)} != "
+            f"codes shape {(L, N)}"
+        )
+    action_mask = action_mask.to(torch.bool)
+    if delayed_codes.numel() and not bool(
+        ((delayed_codes >= 0) & (delayed_codes < codebook_vocab_size)).all()
+    ):
+        raise ValueError("Higgs rollout action is outside the codebook vocabulary")
+    action_logprobs = policy_logprobs[action_mask]
+    if action_logprobs.numel() and not bool(torch.isfinite(action_logprobs).all()):
+        raise ValueError("non-finite policy logprob at a sampled action position")
 
-    if delayed_logprobs is not None:
-        if tuple(delayed_logprobs.shape) != (L, N):
-            raise ValueError(
-                f"delayed_logprobs shape {tuple(delayed_logprobs.shape)} != "
-                f"codes shape {(L, N)}"
-            )
-        # Every trainable action must carry a finite logprob.
-        action_logprobs = delayed_logprobs[action_mask]
-        if action_logprobs.numel() and not bool(torch.isfinite(action_logprobs).all()):
-            raise ValueError(
-                "non-finite logprob at a trainable action position; "
-                "rollout logprob capture is inconsistent with the action mask"
-            )
+    policy_logprobs = torch.where(
+        action_mask,
+        policy_logprobs.to(torch.float32),
+        torch.zeros_like(policy_logprobs, dtype=torch.float32),
+    )
+    codec_content_mask = delay_pattern_codec_content_mask(delayed_codes)
 
     stream: dict[str, Any] = {
         "name": stream_name,
         "stage": stage,
         "modality": "audio",
-        "action_type": "discrete",
-        "layout": "codebook_2d",
-        "flatten_order": "time_major",
+        "action_type": "multi_discrete",
+        "layout": "time_codebook",
         "shape": [int(L), int(N)],
         "vocab_size": int(codebook_vocab_size),
         "actions": delayed_codes.to(torch.long).tolist(),
-        "logprobs": (
-            delayed_logprobs.to(torch.float32).tolist()
-            if delayed_logprobs is not None
-            else None
-        ),
-        "action_mask": action_mask.to(torch.int64).tolist(),
-        # Omitted: action_mask==0 already marks every non-trainable position.
-        "deterministic_mask": None,
+        "policy_logprobs": policy_logprobs.tolist(),
+        "action_mask": action_mask.tolist(),
+        "codec_content_mask": codec_content_mask.tolist(),
         "channel_ids": list(range(N)),
-        "channel_roles": [f"codebook_{c}" for c in range(N)],
     }
 
     return {
         "version": OMNI_ROLLOUT_VERSION,
         "model_family": model_family,
-        "stages": [stage],
         "total_action_count": int(action_mask.sum().item()),
         "action_streams": [stream],
-        "non_action_outputs": [],
     }
 
 

--- a/sglang_omni/models/higgs_tts/sampler.py
+++ b/sglang_omni/models/higgs_tts/sampler.py
@@ -37,6 +37,7 @@ class HiggsSamplerState:
     eoc_countdown: int | None = None
     generation_done: bool = False
     last_codes: torch.Tensor | None = None
+    last_action_mask: torch.Tensor | None = None
 
 
 class HiggsBatchedSamplerState:
@@ -46,7 +47,7 @@ class HiggsBatchedSamplerState:
 
     - ``delay_count[i]``: how many AR steps row ``i`` has produced so far.
       While ``delay_count < num_codebooks`` we're in the delay window.
-    - ``eoc_countdown[i]``: ``-1`` when cb0 hasn't emitted EOC yet, else
+    - ``eoc_countdown[i]``: ``-1`` before an active codebook emits EOC, else
       remaining wind-down steps. Once it hits ``0`` we set
       ``generation_done[i] = True``.
     - ``generation_done[i]``: terminal flag; the model runner reads this
@@ -79,6 +80,12 @@ class HiggsBatchedSamplerState:
             dtype=torch.long,
             device=self.device,
         )
+        self.last_action_mask = torch.zeros(
+            self.max_batch_size,
+            self.num_codebooks,
+            dtype=torch.bool,
+            device=self.device,
+        )
         # Per-request seed (``NO_SEED`` = unseeded) and monotonic AR step, used
         # to seed each ``(step, codebook)`` draw reproducibly.
         self.seeds = torch.full(
@@ -94,6 +101,7 @@ class HiggsBatchedSamplerState:
         self.eoc_countdown[row] = -1
         self.generation_done[row] = False
         self.last_codes[row].zero_()
+        self.last_action_mask[row].zero_()
         self.seeds[row] = NO_SEED
         self.step_count[row] = 0
 
@@ -109,6 +117,7 @@ class HiggsBatchedSamplerState:
             eoc_countdown=None if eoc < 0 else eoc,
             generation_done=bool(self.generation_done[row].item()),
             last_codes=None if delay == 0 else self.last_codes[row],
+            last_action_mask=None if delay == 0 else self.last_action_mask[row],
         )
 
     def write_row(self, row: int, state: HiggsSamplerState) -> None:
@@ -120,6 +129,10 @@ class HiggsBatchedSamplerState:
         self.generation_done[row] = state.generation_done
         if state.last_codes is not None:
             self.last_codes[row].copy_(state.last_codes.to(self.last_codes.dtype))
+        if state.last_action_mask is not None:
+            self.last_action_mask[row].copy_(
+                state.last_action_mask.to(self.last_action_mask.dtype)
+            )
 
 
 _GREEDY_TEMP_THRESHOLD = 1e-5
@@ -188,29 +201,56 @@ def step(
         )
 
     if state.generation_done:
+        state.last_action_mask = torch.zeros(
+            N, dtype=torch.bool, device=logits_NV.device
+        )
         return torch.full((N,), STOP_CODE, dtype=torch.long, device=logits_NV.device)
 
-    codes_N = _sample_independent(
+    sampled_N = _sample_independent(
         logits_NV,
         temperature=temperature,
         top_p=top_p,
         top_k=top_k,
     ).to(torch.long)
 
-    if state.delay_count < N:
-        next_cb = state.delay_count + 1
-        if next_cb < N:
-            codes_N[next_cb:] = boc_id
-        state.delay_count += 1
-    elif state.eoc_countdown is not None:
+    codes_N = sampled_N.clone()
+    cb_idx = torch.arange(N, device=logits_NV.device)
+    delay_forced = (state.delay_count < N) & (cb_idx > state.delay_count)
+
+    if state.eoc_countdown is not None:
+        # If EOC first appeared at codebook k, the next row has completed
+        # codebooks 0..k. Each wind-down row grows that forced-EOC prefix by one.
+        eoc_through = N - 1 - state.eoc_countdown
+        eoc_forced = cb_idx <= eoc_through
+        codes_N[delay_forced] = boc_id
+        codes_N[eoc_forced] = eoc_id
+        action_mask_N = ~(delay_forced | eoc_forced)
+
         state.eoc_countdown -= 1
         if state.eoc_countdown <= 0:
             state.generation_done = True
-    elif int(codes_N[0].item()) == eoc_id:
-        if N <= 2:
-            state.generation_done = True
+    else:
+        sampled_mask = ~delay_forced
+        codes_N[delay_forced] = boc_id
+        eoc_positions = (sampled_N == eoc_id) & sampled_mask
+        if bool(eoc_positions.any()):
+            first_eoc = int(eoc_positions.nonzero(as_tuple=False)[0].item())
+            forced_prefix = cb_idx < first_eoc
+            codes_N[forced_prefix] = eoc_id
+            action_mask_N = sampled_mask & ~forced_prefix
+
+            # Local codec tensors have length T + N - 1. An EOC at codebook k
+            # therefore needs N-k-2 subsequent rows (the EOC row is included).
+            state.eoc_countdown = max(N - first_eoc - 2, 0)
+            if state.eoc_countdown == 0:
+                state.generation_done = True
         else:
-            state.eoc_countdown = N - 2
+            action_mask_N = sampled_mask
+
+    if state.delay_count < N:
+        state.delay_count += 1
+
+    state.last_action_mask = action_mask_N.clone()
 
     if not state.generation_done:
         state.last_codes = codes_N.clone()
@@ -341,6 +381,7 @@ def batched_step(
         new_generation_done,
         new_last_codes,
         new_step_count,
+        action_mask_BN,
     ) = batched_step_direct(
         logits_BNV,
         delay_count,
@@ -360,6 +401,7 @@ def batched_step(
     state.eoc_countdown[row_indices] = new_eoc_countdown.to(state.eoc_countdown.dtype)
     state.generation_done[row_indices] = new_generation_done
     state.last_codes[row_indices] = new_last_codes
+    state.last_action_mask[row_indices] = action_mask_BN
     state.step_count[row_indices] = new_step_count
 
     return out_codes
@@ -386,6 +428,7 @@ def batched_step_direct(
     torch.Tensor,
     torch.Tensor,
     torch.Tensor,
+    torch.Tensor,
 ]:
     """CG-friendly state machine: state in/out as direct ``[B, ...]`` tensors,
     no ``state``/``row_indices`` indirection. Caller persists the returned
@@ -400,7 +443,7 @@ def batched_step_direct(
     delay_count = delay_count.to(torch.long)
     eoc_countdown = eoc_countdown.to(torch.long)
 
-    codes_BN = _sample_independent_batched(
+    sampled_BN = _sample_independent_batched(
         logits_BNV,
         temperature=temperature,
         top_p=top_p,
@@ -408,34 +451,55 @@ def batched_step_direct(
         seeds_B=seeds,
         step_B=step_count,
     )
-    cb_idx = torch.arange(N, device=device).unsqueeze(0).expand(B, N)
-    in_delay = (delay_count < N).unsqueeze(-1)
-    delay_mask = in_delay & (cb_idx > delay_count.unsqueeze(-1))
-    codes_BN = torch.where(delay_mask, torch.full_like(codes_BN, boc_id), codes_BN)
-
     active = ~generation_done
-    in_delay_active = active & (delay_count < N)
-    in_winddown_active = active & (eoc_countdown >= 0) & (~in_delay_active)
-    cb0_eoc_now_active = (
-        active & (~in_delay_active) & (~in_winddown_active) & (codes_BN[:, 0] == eoc_id)
+    cb_idx = torch.arange(N, device=device).unsqueeze(0).expand(B, N)
+    delay_forced = (
+        active.unsqueeze(-1)
+        & (delay_count < N).unsqueeze(-1)
+        & (cb_idx > delay_count.unsqueeze(-1))
+    )
+    in_winddown_active = active & (eoc_countdown >= 0)
+    normal_active = active & ~in_winddown_active
+    normal_sampled_mask = normal_active.unsqueeze(-1) & ~delay_forced
+
+    eoc_candidates = normal_sampled_mask & (sampled_BN == eoc_id)
+    first_eoc_idx = torch.where(
+        eoc_candidates, cb_idx, torch.full_like(cb_idx, N)
+    ).amin(dim=1)
+    eoc_now_active = first_eoc_idx < N
+    termination_prefix = eoc_now_active.unsqueeze(-1) & (
+        cb_idx < first_eoc_idx.unsqueeze(-1)
     )
 
-    new_delay_count = torch.where(in_delay_active, delay_count + 1, delay_count)
+    winddown_eoc_through = N - 1 - eoc_countdown
+    winddown_eoc_forced = in_winddown_active.unsqueeze(-1) & (
+        cb_idx <= winddown_eoc_through.unsqueeze(-1)
+    )
 
-    if N > 2:
-        new_eoc_countdown = torch.where(
-            cb0_eoc_now_active,
-            torch.full_like(eoc_countdown, N - 2),
-            torch.where(in_winddown_active, eoc_countdown - 1, eoc_countdown),
-        )
-        done_this_step = in_winddown_active & (new_eoc_countdown <= 0)
-    else:
-        new_eoc_countdown = torch.where(
-            in_winddown_active, eoc_countdown - 1, eoc_countdown
-        )
-        done_this_step = cb0_eoc_now_active | (
-            in_winddown_active & (new_eoc_countdown <= 0)
-        )
+    codes_BN = torch.where(
+        delay_forced, torch.full_like(sampled_BN, boc_id), sampled_BN
+    )
+    codes_BN = torch.where(
+        termination_prefix | winddown_eoc_forced,
+        torch.full_like(codes_BN, eoc_id),
+        codes_BN,
+    )
+    action_mask_BN = (normal_sampled_mask & ~termination_prefix) | (
+        in_winddown_active.unsqueeze(-1) & ~delay_forced & ~winddown_eoc_forced
+    )
+
+    advance_delay = active & (delay_count < N)
+    new_delay_count = torch.where(advance_delay, delay_count + 1, delay_count)
+
+    remaining_after_eoc = (N - first_eoc_idx - 2).clamp_min(0)
+    new_eoc_countdown = torch.where(
+        eoc_now_active,
+        remaining_after_eoc,
+        torch.where(in_winddown_active, eoc_countdown - 1, eoc_countdown),
+    )
+    done_this_step = (eoc_now_active & (remaining_after_eoc <= 0)) | (
+        in_winddown_active & (new_eoc_countdown <= 0)
+    )
     new_generation_done = generation_done | done_this_step
 
     update_codes = (active & (~done_this_step)).unsqueeze(-1)
@@ -445,6 +509,7 @@ def batched_step_direct(
 
     stop = torch.full_like(codes_BN, STOP_CODE)
     out_codes = torch.where(generation_done.unsqueeze(-1), stop, codes_BN)
+    action_mask_BN = action_mask_BN & active.unsqueeze(-1)
     return (
         out_codes,
         new_delay_count,
@@ -452,6 +517,7 @@ def batched_step_direct(
         new_generation_done,
         new_last_codes,
         new_step_count,
+        action_mask_BN,
     )
 
 

--- a/sglang_omni/models/higgs_tts/utils.py
+++ b/sglang_omni/models/higgs_tts/utils.py
@@ -50,12 +50,12 @@ def apply_delay_pattern(codes_TN: torch.Tensor) -> torch.Tensor:
     return out
 
 
-def delay_pattern_action_mask(
-    delayed_LN: torch.Tensor,
-    *,
-    eoc_id: int = EOC_ID,
-) -> torch.Tensor:
-    """``[L, N]`` boolean mask: ``True`` at trainable real-audio actions."""
+def delay_pattern_codec_content_mask(delayed_LN: torch.Tensor) -> torch.Tensor:
+    """Mark delayed cells that de-delay into aligned codec frames.
+
+    This is codec geometry, not an RL action mask. Sampling records the action
+    mask before forced BOC/EOC values overwrite model samples.
+    """
     if delayed_LN.ndim != 2:
         raise ValueError(
             f"delayed_LN must be 2-D [L, N], got shape {tuple(delayed_LN.shape)}"
@@ -63,8 +63,7 @@ def delay_pattern_action_mask(
     L, N = delayed_LN.shape
     device = delayed_LN.device
 
-    cb0_eoc_rows = (delayed_LN[:, 0] == eoc_id).nonzero(as_tuple=False)
-    t_raw = int(cb0_eoc_rows[0].item()) if cb0_eoc_rows.numel() > 0 else L
+    t_raw = max(L - (N - 1), 0)
 
     r = torch.arange(L, device=device).unsqueeze(1)  # [L, 1]
     c = torch.arange(N, device=device).unsqueeze(0)  # [1, N]
@@ -147,7 +146,7 @@ __all__ = [
     "BOC_ID",
     "EOC_ID",
     "apply_delay_pattern",
-    "delay_pattern_action_mask",
+    "delay_pattern_codec_content_mask",
     "get_or_load_codec",
     "load_audio_to_24k",
     "resolve_checkpoint",

--- a/sglang_omni/models/higgs_tts/vocoder_scheduler.py
+++ b/sglang_omni/models/higgs_tts/vocoder_scheduler.py
@@ -207,6 +207,8 @@ class HiggsStreamingVocoderScheduler(StreamingSimpleScheduler):
             final_data["output_codebook_tokens"] = final_state.output_codes_delayed
         if final_state.omni_rollout is not None:
             final_data["omni_rollout"] = final_state.omni_rollout
+        if final_state.weight_version is not None:
+            final_data["weight_version"] = final_state.weight_version
         messages.append(
             OutgoingMessage(
                 request_id=request_id,
@@ -499,6 +501,8 @@ class HiggsStreamingVocoderScheduler(StreamingSimpleScheduler):
             data["output_codebook_tokens"] = state.output_codes_delayed
         if state.omni_rollout is not None:
             data["omni_rollout"] = state.omni_rollout
+        if state.weight_version is not None:
+            data["weight_version"] = state.weight_version
         payload.data = data
         return payload
 

--- a/sglang_omni/models/qwen3_asr/config.py
+++ b/sglang_omni/models/qwen3_asr/config.py
@@ -15,6 +15,14 @@ class Qwen3ASRPipelineConfig(PipelineConfig):
 
     architecture: ClassVar[str] = "Qwen3ASRForConditionalGeneration"
 
+    @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"asr": "asr"}
+
+    @classmethod
+    def generation_sglang_role_to_stage(cls) -> dict[str, str]:
+        return {"generation": "asr"}
+
     model_path: str
     entry_stage: str = "asr"
     stages: list[StageConfig] = [

--- a/sglang_omni/models/qwen3_omni/components/preprocessor.py
+++ b/sglang_omni/models/qwen3_omni/components/preprocessor.py
@@ -123,16 +123,13 @@ def _is_pretokenized_prompt(inputs: Any) -> bool:
     )
 
 
-def _media_token_id(processor: Any, modality: str) -> int | None:
+def _media_token_ids(processor: Any) -> dict[str, int]:
     tokenizer = processor.tokenizer
-    token_id = getattr(tokenizer, f"{modality}_token_id", None)
-    if token_id is not None:
-        return int(token_id)
-    token = getattr(processor, f"{modality}_token", None)
-    if token is None:
-        return None
-    resolved = tokenizer.convert_tokens_to_ids(token)
-    return int(resolved) if resolved is not None else None
+    return {
+        "image": int(tokenizer.convert_tokens_to_ids(processor.image_token)),
+        "audio": int(tokenizer.convert_tokens_to_ids(processor.audio_token)),
+        "video": int(tokenizer.convert_tokens_to_ids(processor.video_token)),
+    }
 
 
 def _validate_pretokenized_media_tokens(
@@ -141,10 +138,7 @@ def _validate_pretokenized_media_tokens(
     processed_input_ids: torch.Tensor,
 ) -> None:
     """Require caller-provided ids to reserve every derived media embedding slot."""
-    for modality in ("image", "audio", "video"):
-        token_id = _media_token_id(processor, modality)
-        if token_id is None:
-            continue
+    for modality, token_id in _media_token_ids(processor).items():
         provided_count = int((provided_input_ids == token_id).sum().item())
         processed_count = int((processed_input_ids == token_id).sum().item())
         if provided_count != processed_count:

--- a/sglang_omni/models/qwen3_omni/components/preprocessor.py
+++ b/sglang_omni/models/qwen3_omni/components/preprocessor.py
@@ -123,6 +123,37 @@ def _is_pretokenized_prompt(inputs: Any) -> bool:
     )
 
 
+def _media_token_id(processor: Any, modality: str) -> int | None:
+    tokenizer = processor.tokenizer
+    token_id = getattr(tokenizer, f"{modality}_token_id", None)
+    if token_id is not None:
+        return int(token_id)
+    token = getattr(processor, f"{modality}_token", None)
+    if token is None:
+        return None
+    resolved = tokenizer.convert_tokens_to_ids(token)
+    return int(resolved) if resolved is not None else None
+
+
+def _validate_pretokenized_media_tokens(
+    processor: Any,
+    provided_input_ids: torch.Tensor,
+    processed_input_ids: torch.Tensor,
+) -> None:
+    """Require caller-provided ids to reserve every derived media embedding slot."""
+    for modality in ("image", "audio", "video"):
+        token_id = _media_token_id(processor, modality)
+        if token_id is None:
+            continue
+        provided_count = int((provided_input_ids == token_id).sum().item())
+        processed_count = int((processed_input_ids == token_id).sum().item())
+        if provided_count != processed_count:
+            raise ValueError(
+                f"Pretokenized {modality} token count {provided_count} does not "
+                f"match processed media token count {processed_count}"
+            )
+
+
 class Qwen3OmniPreprocessor:
     """CPU-side preprocessing and tokenization using the HF processor."""
 
@@ -288,7 +319,14 @@ class Qwen3OmniPreprocessor:
         inputs = payload.request.inputs
         if _is_pretokenized_prompt(inputs):
             return self._preprocess_pretokenized(payload, inputs)
+
+        pretokenized_ids: list[int] | None = None
         if isinstance(inputs, dict):
+            raw_input_ids = inputs.get("input_ids")
+            if raw_input_ids is not None:
+                if not _is_pretokenized_prompt(raw_input_ids):
+                    raise ValueError("input_ids must be a non-empty list of integers")
+                pretokenized_ids = list(raw_input_ids)
             messages = inputs.get("messages", [])
             raw_images = inputs.get("images")
             raw_videos = inputs.get("videos") or inputs.get("video")
@@ -391,6 +429,9 @@ class Qwen3OmniPreprocessor:
                     audios = audios_result
             else:
                 audios = audios_result
+
+            if pretokenized_ids is not None and not (images or videos or audios):
+                return self._preprocess_pretokenized(payload, pretokenized_ids)
         else:
             messages = inputs
             images = []
@@ -418,6 +459,13 @@ class Qwen3OmniPreprocessor:
             resolved_video_total_pixels = None
             resolved_video_seconds_per_chunk = None
             resolved_video_position_id_per_seconds = None
+
+        # Pretokenized requests do not need their original conversation for
+        # tokenization. A synthetic user message lets the HF processor derive
+        # media tensors and expected placeholder counts; its token ids are then
+        # discarded in favor of the caller-provided ids below.
+        if pretokenized_ids is not None and not messages:
+            messages = [{"role": "user", "content": ""}]
 
         messages_norm = normalize_messages(messages)
         # Insert placeholders:
@@ -478,12 +526,23 @@ class Qwen3OmniPreprocessor:
             **processor_kwargs,
         )
 
-        input_ids = hf_inputs["input_ids"][0]
-        attention_mask = hf_inputs.get("attention_mask")
-        if isinstance(attention_mask, torch.Tensor):
-            attention_mask = attention_mask[0]
-        else:
+        processed_input_ids = hf_inputs["input_ids"][0]
+        if pretokenized_ids is not None:
+            input_ids = torch.tensor(pretokenized_ids, dtype=torch.long)
+            _validate_pretokenized_media_tokens(
+                self.processor,
+                input_ids,
+                processed_input_ids,
+            )
             attention_mask = torch.ones_like(input_ids)
+            prompt_text = ""
+        else:
+            input_ids = processed_input_ids
+            attention_mask = hf_inputs.get("attention_mask")
+            if isinstance(attention_mask, torch.Tensor):
+                attention_mask = attention_mask[0]
+            else:
+                attention_mask = torch.ones_like(input_ids)
 
         validate_prompt_seq_len(
             input_ids,

--- a/sglang_omni/proto/admin.py
+++ b/sglang_omni/proto/admin.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 ADMIN_MODEL_INFO = "model_info"
+ADMIN_FLUSH_CACHE = "flush_cache"
 ADMIN_PAUSE_GENERATION = "pause_generation"
 ADMIN_CONTINUE_GENERATION = "continue_generation"
 ADMIN_UPDATE_WEIGHTS_FROM_DISK = "update_weights_from_disk"

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -36,6 +36,7 @@ from sglang_omni.profiler.event_recorder import get_active_stage as _get_active_
 from sglang_omni.proto.admin import (
     ADMIN_CONTINUE_GENERATION,
     ADMIN_DESTROY_WEIGHTS_UPDATE_GROUP,
+    ADMIN_FLUSH_CACHE,
     ADMIN_INIT_WEIGHTS_UPDATE_GROUP,
     ADMIN_MODEL_INFO,
     ADMIN_PAUSE_GENERATION,
@@ -1153,6 +1154,8 @@ class OmniScheduler:
         payload = dict(payload or {})
         if action == ADMIN_MODEL_INFO:
             return self._admin_model_info()
+        if action == ADMIN_FLUSH_CACHE:
+            return self._admin_flush_cache()
         if action == ADMIN_PAUSE_GENERATION:
             return self._admin_pause_generation(payload)
         if action == ADMIN_CONTINUE_GENERATION:
@@ -1205,6 +1208,16 @@ class OmniScheduler:
             }
         )
         return {"success": True, "message": "ok", "data": info}
+
+    def _admin_flush_cache(self) -> dict[str, Any]:
+        with self._admin_lock:
+            success = bool(self.flush_cache())
+        return {
+            "success": success,
+            "message": "cache flushed" if success else "cache flush failed",
+            "data": {"flush_cache": success},
+            "error": None if success else "cache flush failed",
+        }
 
     def _admin_pause_generation(self, payload: dict[str, Any]) -> dict[str, Any]:
         mode = str(payload.get("mode") or "abort")

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -365,8 +365,7 @@ async def _send_voice_upload_too_large(
 
 
 def _register_health(app: FastAPI) -> None:
-    @app.get("/health")
-    async def health() -> JSONResponse:
+    async def health_response() -> JSONResponse:
         """Health check endpoint (includes filesystem browse info)."""
         client: Client = app.state.client
         info = client.health()
@@ -379,6 +378,9 @@ def _register_health(app: FastAPI) -> None:
             },
             status_code=status_code,
         )
+
+    app.add_api_route("/health", health_response, methods=["GET"])
+    app.add_api_route("/health_generate", health_response, methods=["GET"])
 
 
 def _register_models(app: FastAPI) -> None:
@@ -438,6 +440,31 @@ def _register_admin(app: FastAPI, admin_api_key: str | None = None) -> None:
                 stages=req.stages,
                 timeout_s=_timeout_or_default(req.timeout_s, 60.0),
             )
+        )
+
+    @app.get("/flush_cache", dependencies=[Depends(_auth)])
+    async def flush_cache() -> JSONResponse:
+        client: Client = app.state.client
+        return _admin_response(await client.admin("flush_cache", timeout_s=60.0))
+
+    @app.post("/begin_weight_update", dependencies=[Depends(_auth)])
+    async def begin_weight_update() -> JSONResponse:
+        return JSONResponse(
+            content={
+                "success": True,
+                "message": "Omni weight updates are atomic per update request",
+                "data": {"session_required": False},
+            }
+        )
+
+    @app.post("/end_weight_update", dependencies=[Depends(_auth)])
+    async def end_weight_update() -> JSONResponse:
+        return JSONResponse(
+            content={
+                "success": True,
+                "message": "Omni weight update request completed atomically",
+                "data": {"session_required": False},
+            }
         )
 
     @app.post("/update_weights_from_disk", dependencies=[Depends(_auth)])

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -989,6 +989,7 @@ def _register_generate(app: FastAPI) -> None:
                 status_code=400,
                 detail="stream=true is not supported by /generate yet",
             )
+        _validate_structured_rollout_sampling(req)
 
         request_id = str(uuid.uuid4())
         audio_format = "wav"
@@ -1012,8 +1013,48 @@ def _register_generate(app: FastAPI) -> None:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-        response = _build_generate_response(req, result, audio_format)
+        try:
+            response = _build_generate_response(req, result, audio_format)
+        except HTTPException:
+            raise
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=500,
+                detail=f"backend returned an invalid structured rollout: {exc}",
+            ) from exc
         return JSONResponse(content=response.model_dump())
+
+
+def _validate_structured_rollout_sampling(req: RolloutGenerateRequest) -> None:
+    """Keep policy and behavior logprobs identical for the initial v2 trace."""
+    if not req.return_omni_rollout:
+        return
+    if not req.return_logprob:
+        raise HTTPException(
+            status_code=400,
+            detail="return_omni_rollout=true requires return_logprob=true",
+        )
+
+    profiles = [("sampling_params", req.sampling_params)]
+    if req.stage_sampling is not None:
+        profiles.extend(req.stage_sampling.items())
+    for name, params in profiles:
+        invalid: list[str] = []
+        if params.temperature is not None and params.temperature != 1.0:
+            invalid.append("temperature must be 1.0")
+        if params.top_p is not None and params.top_p != 1.0:
+            invalid.append("top_p must be 1.0")
+        if params.top_k is not None and params.top_k > 0:
+            invalid.append("top_k must be absent or non-positive")
+        if params.min_p is not None and params.min_p != 0.0:
+            invalid.append("min_p must be 0.0")
+        if params.repetition_penalty is not None and params.repetition_penalty != 1.0:
+            invalid.append("repetition_penalty must be 1.0")
+        if invalid:
+            raise HTTPException(
+                status_code=400,
+                detail=f"structured rollout {name}: " + "; ".join(invalid),
+            )
 
 
 def _rollout_sampling_to_client(params: RolloutSamplingParams) -> SamplingParams:
@@ -1143,7 +1184,11 @@ def _build_generate_response(
         )
     audio: GenerateAudio | None = None
     if result.audio is not None:
-        audio = GenerateAudio(data=result.audio.data, format=audio_format)
+        audio = GenerateAudio(
+            data=result.audio.data,
+            format=result.audio.format or audio_format,
+            sample_rate=result.audio.sample_rate,
+        )
 
     meta_info = GenerateMetaInfo(
         finish_reason=finish_reason,
@@ -1157,6 +1202,45 @@ def _build_generate_response(
         output_codebook_tokens=result.output_codebook_tokens,
         omni_rollout=result.omni_rollout if req.return_omni_rollout else None,
     )
+    if meta_info.omni_rollout is not None:
+        first_stream = meta_info.omni_rollout.action_streams[0]
+        if completion_tokens != first_stream.shape[0]:
+            raise HTTPException(
+                status_code=500,
+                detail="completion_tokens does not match structured action length",
+            )
+        if (
+            result.output_codebook_tokens is not None
+            and result.output_codebook_tokens != first_stream.actions
+        ):
+            raise HTTPException(
+                status_code=500,
+                detail="output_codebook_tokens does not match structured actions",
+            )
+        structured_audio = any(
+            stream.modality == "audio"
+            for stream in meta_info.omni_rollout.action_streams
+        )
+        if structured_audio:
+            if first_stream.shape[0] == 0:
+                raise HTTPException(
+                    status_code=500,
+                    detail="structured audio rollout contains no emitted action rows",
+                )
+            if (
+                result.audio is None
+                or not result.audio.data
+                or result.audio.format != "wav"
+                or result.audio.sample_rate is None
+                or result.audio.sample_rate <= 0
+            ):
+                raise HTTPException(
+                    status_code=500,
+                    detail=(
+                        "structured audio rollout requires a nonempty WAV waveform "
+                        "with a positive sample_rate"
+                    ),
+                )
     return GenerateResponse(text=result.text, audio=audio, meta_info=meta_info)
 
 

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -1080,6 +1080,14 @@ def _build_rollout_generate_request(req: RolloutGenerateRequest) -> GenerateRequ
         output_modalities=(
             req.output_modalities if req.output_modalities is not None else ["text"]
         ),
+        images=req.images,
+        audios=req.audios,
+        videos=req.videos,
+        video_fps=req.video_fps,
+        video_max_frames=req.video_max_frames,
+        video_min_pixels=req.video_min_pixels,
+        video_max_pixels=req.video_max_pixels,
+        video_total_pixels=req.video_total_pixels,
         metadata=metadata,
     )
 

--- a/sglang_omni/serve/protocol.py
+++ b/sglang_omni/serve/protocol.py
@@ -174,7 +174,7 @@ class RolloutGenerateRequest(BaseModel):
     """Rollout request for ``POST /generate``; set exactly one of
     ``input_ids``, ``prompt``, ``messages``."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
     model: str | None = None
 
@@ -189,6 +189,27 @@ class RolloutGenerateRequest(BaseModel):
     stage_sampling: dict[str, RolloutSamplingParams] | None = None
     stage_params: dict[str, dict[str, Any]] | None = None
     output_modalities: list[str] | None = None
+
+    # Canonical media names match ChatCompletionRequest and the internal
+    # preprocessors. The *_data aliases keep existing Miles/SGLang payloads
+    # wire-compatible while callers migrate to the canonical names.
+    images: list[str] | None = Field(
+        default=None,
+        validation_alias=AliasChoices("images", "image_data"),
+    )
+    audios: list[str] | None = Field(
+        default=None,
+        validation_alias=AliasChoices("audios", "audio_data"),
+    )
+    videos: list[str] | None = Field(
+        default=None,
+        validation_alias=AliasChoices("videos", "video_data"),
+    )
+    video_fps: float | None = None
+    video_max_frames: int | None = None
+    video_min_pixels: int | None = None
+    video_max_pixels: int | None = None
+    video_total_pixels: int | None = None
 
     metadata: dict[str, Any] | None = None
 

--- a/sglang_omni/serve/protocol.py
+++ b/sglang_omni/serve/protocol.py
@@ -3,9 +3,19 @@
 
 from __future__ import annotations
 
-from typing import Any
+import math
+from typing import Any, Literal
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    model_validator,
+)
 
 
 class UsageResponse(BaseModel):
@@ -235,6 +245,82 @@ class GenerateAudio(BaseModel):
     sample_rate: int | None = None
 
 
+class MultiDiscreteActionStream(BaseModel):
+    """One aligned time-by-codebook policy action stream."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    stage: str
+    modality: str
+    action_type: Literal["multi_discrete"]
+    layout: Literal["time_codebook"]
+    shape: list[StrictInt]
+    vocab_size: StrictInt = Field(gt=0)
+    actions: list[list[StrictInt]]
+    policy_logprobs: list[list[StrictFloat]]
+    action_mask: list[list[StrictBool]]
+    codec_content_mask: list[list[StrictBool]] | None = None
+    channel_ids: list[StrictInt]
+
+    @model_validator(mode="after")
+    def validate_lattice(self) -> "MultiDiscreteActionStream":
+        if len(self.shape) != 2:
+            raise ValueError("action stream shape must be [time, codebooks]")
+        length, channels = self.shape
+        if length < 0 or channels <= 0:
+            raise ValueError("action stream dimensions must be non-negative")
+        if self.channel_ids != list(range(channels)):
+            raise ValueError("channel_ids must be the ordered codebook indices")
+
+        matrices = {
+            "actions": self.actions,
+            "policy_logprobs": self.policy_logprobs,
+            "action_mask": self.action_mask,
+        }
+        if self.codec_content_mask is not None:
+            matrices["codec_content_mask"] = self.codec_content_mask
+        for name, matrix in matrices.items():
+            if len(matrix) != length or any(len(row) != channels for row in matrix):
+                raise ValueError(f"{name} must have declared shape {self.shape}")
+
+        for row in range(length):
+            for channel in range(channels):
+                action = self.actions[row][channel]
+                logprob = self.policy_logprobs[row][channel]
+                sampled = self.action_mask[row][channel]
+                if action < 0 or action >= self.vocab_size:
+                    raise ValueError("action is outside the declared vocabulary")
+                if sampled and not math.isfinite(logprob):
+                    raise ValueError("sampled action has a non-finite policy logprob")
+                if not sampled and logprob != 0.0:
+                    raise ValueError("forced action policy logprob must be zero")
+        return self
+
+
+class OmniRolloutTrace(BaseModel):
+    """Versioned structured policy trace returned by ``POST /generate``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: Literal[2]
+    model_family: str
+    total_action_count: StrictInt = Field(ge=0)
+    action_streams: list[MultiDiscreteActionStream] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_action_count(self) -> "OmniRolloutTrace":
+        count = sum(
+            int(sampled)
+            for stream in self.action_streams
+            for row in stream.action_mask
+            for sampled in row
+        )
+        if count != self.total_action_count:
+            raise ValueError("total_action_count does not match action masks")
+        return self
+
+
 class GenerateMetaInfo(BaseModel):
     """Rollout meta_info block."""
 
@@ -246,7 +332,7 @@ class GenerateMetaInfo(BaseModel):
     request_metadata: dict[str, Any] | None = None
     output_token_logprobs: list[Any] | None = None
     output_codebook_tokens: list[Any] | None = None
-    omni_rollout: dict[str, Any] | None = None
+    omni_rollout: OmniRolloutTrace | None = None
 
 
 class GenerateResponse(BaseModel):

--- a/sglang_omni/utils/cuda_graph_batch_validator.py
+++ b/sglang_omni/utils/cuda_graph_batch_validator.py
@@ -24,6 +24,7 @@ _BUFFER_PROBES: dict[str, _BufferProbe] = {
         (
             ("_sampler_pool.seeds", lambda m: m._sampler_pool.seeds.shape[0]),
             ("_cg_codes_BN", lambda m: m._cg_codes_BN.shape[0]),
+            ("_cg_action_mask_BN", lambda m: m._cg_action_mask_BN.shape[0]),
             ("_cg_active_last_codes", lambda m: m._cg_active_last_codes.shape[0]),
         ),
         note="sampler pool = max_running_requests + 1 (one reserved padding row)",

--- a/tests/unit_test/client/test_completion_rollout.py
+++ b/tests/unit_test/client/test_completion_rollout.py
@@ -21,6 +21,17 @@ class _SubmitStubCoordinator:
         return self._result
 
 
+class _CapturingSubmitCoordinator(_SubmitStubCoordinator):
+    def __init__(self, result: Any) -> None:
+        super().__init__(result)
+        self.request = None
+
+    async def submit(self, request_id: str, omni_request: Any) -> Any:
+        del request_id
+        self.request = omni_request
+        return self._result
+
+
 class _StreamStubCoordinator:
     """Streaming coordinator stub: yields the given StreamMessages in order."""
 
@@ -51,6 +62,33 @@ def test_completion_surfaces_logprobs_and_weight_version() -> None:
     assert out.output_token_logprobs == [[-0.1, 11], [-0.2, 22], [-0.3, 33]]
     assert out.output_codebook_tokens == [[11, 1], [22, 2], [33, 3]]
     assert out.weight_version == "v7"
+
+
+def test_completion_combines_pretokenized_ids_and_media() -> None:
+    coordinator = _CapturingSubmitCoordinator({"text": "ok", "finish_reason": "stop"})
+    client = Client(coordinator)
+
+    asyncio.run(
+        client.completion(
+            GenerateRequest(
+                prompt_token_ids=[5, 6, 7],
+                images=["data:image/png;base64,SU1H"],
+                audios=["data:audio/wav;base64,QVVESU8="],
+                videos=["https://example.test/video.mp4"],
+                video_fps=2.0,
+                stream=False,
+            ),
+            request_id="r-mm",
+        )
+    )
+
+    assert coordinator.request.inputs == {
+        "input_ids": [5, 6, 7],
+        "images": ["data:image/png;base64,SU1H"],
+        "audios": ["data:audio/wav;base64,QVVESU8="],
+        "videos": ["https://example.test/video.mp4"],
+        "video_fps": 2.0,
+    }
 
 
 def test_completion_surfaces_omni_rollout() -> None:

--- a/tests/unit_test/higgs_tts/test_action_mask.py
+++ b/tests/unit_test/higgs_tts/test_action_mask.py
@@ -1,9 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for :func:`delay_pattern_action_mask` (RL trainable-action mask).
-
-The mask selects exactly the ``T x N`` real-audio parallelogram of a delayed code
-matrix -- the inverse geometry of :func:`apply_delay_pattern`. CPU-only.
-"""
+"""Codec-content geometry is deliberately separate from the RL action mask."""
 
 from __future__ import annotations
 
@@ -14,49 +10,42 @@ from sglang_omni.models.higgs_tts.utils import (
     BOC_ID,
     EOC_ID,
     apply_delay_pattern,
-    delay_pattern_action_mask,
+    delay_pattern_codec_content_mask,
 )
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
 
-@pytest.mark.parametrize("t_raw,n", [(1, 8), (3, 4), (10, 8), (5, 2), (1, 1), (20, 3)])
-def test_mask_is_inverse_of_apply_delay_pattern(t_raw: int, n: int):
-    """Mask == the non-BOC/EOC cells of a real delayed matrix == ``c<=r<c+T``."""
-    torch.manual_seed(t_raw * 100 + n)
-    raw_TN = torch.randint(0, 1024, (t_raw, n), device=DEVICE)  # real codes only
-    delayed = apply_delay_pattern(raw_TN)
-    assert delayed.shape == (t_raw + n - 1, n)
+@pytest.mark.parametrize("t_raw,n", [(1, 8), (3, 4), (10, 8), (5, 2), (1, 1)])
+def test_content_mask_inverts_complete_delay_pattern(t_raw: int, n: int):
+    raw = torch.randint(0, 1024, (t_raw, n), device=DEVICE)
+    delayed = apply_delay_pattern(raw)
 
-    mask = delay_pattern_action_mask(delayed)
+    mask = delay_pattern_codec_content_mask(delayed)
 
-    is_real = (delayed != BOC_ID) & (delayed != EOC_ID)
-    assert torch.equal(mask, is_real)
-    assert int(mask.sum().item()) == t_raw * n
+    assert torch.equal(mask, (delayed != BOC_ID) & (delayed != EOC_ID))
+    assert int(mask.sum()) == t_raw * n
 
 
-def test_T_recovered_from_cb0_eoc_only():
-    """``T`` comes from codebook 0's EOC, not an EOC appearing in another cb."""
-    n, t_raw = 4, 5
+def test_content_mask_depends_on_shape_not_special_token_values():
+    t_raw, n = 5, 4
     delayed = apply_delay_pattern(torch.randint(0, 1024, (t_raw, n), device=DEVICE))
-    delayed[1, 2] = EOC_ID  # spurious early EOC in cb2; cb0's EOC must still win
+    delayed[1, 1] = EOC_ID
+    delayed[3, 0] = BOC_ID
 
-    mask = delay_pattern_action_mask(delayed)
+    mask = delay_pattern_codec_content_mask(delayed)
+    rows = torch.arange(delayed.shape[0], device=DEVICE).unsqueeze(1)
+    channels = torch.arange(n, device=DEVICE).unsqueeze(0)
+    assert torch.equal(mask, (channels <= rows) & (rows < channels + t_raw))
 
-    r = torch.arange(delayed.shape[0], device=DEVICE).unsqueeze(1)
-    c = torch.arange(n, device=DEVICE).unsqueeze(0)
-    assert torch.equal(mask, (c <= r) & (r < c + t_raw))
 
+def test_length_truncation_only_marks_fully_dedelayable_rows():
+    length, n = 7, 4
+    delayed = torch.randint(0, 1024, (length, n), device=DEVICE)
+    t_raw = length - (n - 1)
 
-def test_no_cb0_eoc_means_T_equals_L():
-    """Length-truncated generation (cb0 never emits EOC) ⇒ ``T = L``."""
-    n, L = 3, 5
-    delayed = torch.randint(0, 1024, (L, n), device=DEVICE)
-    for c in range(n):
-        delayed[:c, c] = BOC_ID  # leading delay triangle, no EOC anywhere
+    mask = delay_pattern_codec_content_mask(delayed)
 
-    mask = delay_pattern_action_mask(delayed)
-
-    r = torch.arange(L, device=DEVICE).unsqueeze(1)
-    c = torch.arange(n, device=DEVICE).unsqueeze(0)
-    assert torch.equal(mask, c <= r)  # r < c + L always holds
+    rows = torch.arange(length, device=DEVICE).unsqueeze(1)
+    channels = torch.arange(n, device=DEVICE).unsqueeze(0)
+    assert torch.equal(mask, (channels <= rows) & (rows < channels + t_raw))

--- a/tests/unit_test/higgs_tts/test_async_decode_runner.py
+++ b/tests/unit_test/higgs_tts/test_async_decode_runner.py
@@ -29,6 +29,7 @@ import pytest
 import torch
 
 from sglang_omni.models.higgs_tts.model_runner import HiggsTTSModelRunner
+from sglang_omni.models.higgs_tts.sampler import K_MAX
 from sglang_omni.models.higgs_tts.utils import EOC_ID
 
 
@@ -41,6 +42,7 @@ def _build_runner(
     finished,
     async_enabled=False,
     n_codebooks=3,
+    action_mask_BN=None,
 ):
     """Build a HiggsTTSModelRunner over a SimpleNamespace model, mirroring
     test_pipeline.py's CG fixtures. Each call returns a FRESH, independent
@@ -49,6 +51,8 @@ def _build_runner(
     independent fixtures seeded identically, never one model run twice.
     """
     n = len(codes_BN)
+    if action_mask_BN is None:
+        action_mask_BN = [[True] * n_codebooks for _ in range(n)]
     runner = object.__new__(HiggsTTSModelRunner)
     runner._outbox = None
     runner._vocoder_target = "vocoder"
@@ -69,12 +73,14 @@ def _build_runner(
         _cg_active_step_count=torch.zeros(n, dtype=torch.long),
         _cg_was_done=torch.tensor(was_done),
         _cg_codes_BN=torch.tensor(codes_BN),
-        _cg_collect_staging=torch.zeros((n, n_codebooks + 2), dtype=torch.long),
+        _cg_action_mask_BN=torch.tensor(action_mask_BN, dtype=torch.bool),
+        _cg_collect_staging=torch.zeros((n, 2 * n_codebooks + 2), dtype=torch.long),
         _sampler_pool=SimpleNamespace(
             delay_count=torch.zeros(n, dtype=torch.int32),
             eoc_countdown=torch.zeros(n, dtype=torch.int32),
             generation_done=torch.zeros(n, dtype=torch.bool),
             last_codes=torch.zeros((n, n_codebooks), dtype=torch.long),
+            last_action_mask=torch.zeros((n, n_codebooks), dtype=torch.bool),
             step_count=torch.zeros(n, dtype=torch.long),
         ),
     )
@@ -88,7 +94,9 @@ def _build_runner(
         SimpleNamespace(
             req=reqs[i],
             output_codes=[],
+            output_action_masks=[],
             output_logprobs=[],
+            output_token_logprobs=[],
             return_omni_rollout=False,
             return_logprob=False,
             generation_done=False,
@@ -107,6 +115,11 @@ def _snapshot(reqs, datas, result):
     """Capture the four observable outputs for cross-path comparison."""
     return {
         "output_codes": [[c.tolist() for c in d.output_codes] for d in datas],
+        "output_action_masks": [
+            [m.tolist() for m in d.output_action_masks] for d in datas
+        ],
+        "output_logprobs": [[lp.tolist() for lp in d.output_logprobs] for d in datas],
+        "output_token_logprobs": [d.output_token_logprobs for d in datas],
         "generation_done": [d.generation_done for d in datas],
         "finished_reason": [
             None if r.finished_reason is None else r.finished_reason.to_json()
@@ -136,6 +149,11 @@ def _patch_cpu_host_staging(monkeypatch):
         HiggsTTSModelRunner,
         "_next_host_staging",
         lambda self, shape, dtype: torch.empty(tuple(shape), dtype=dtype, device="cpu"),
+    )
+    monkeypatch.setattr(
+        HiggsTTSModelRunner,
+        "_next_logprob_host_staging",
+        lambda self, device_buf: torch.empty_like(device_buf, device="cpu"),
     )
 
 
@@ -252,6 +270,61 @@ def test_async_matches_sync_bs1_eoc(monkeypatch):
     assert asy == sync
 
 
+def test_async_preserves_code_mask_logprob_request_association(monkeypatch):
+    """The integer and float D2H snapshots must stay aligned by request row."""
+    kwargs = dict(
+        codes_BN=[[2, 3, 4], [5, 6, 7]],
+        action_mask_BN=[[True, False, True], [False, True, False]],
+        was_done=[False, False],
+        active_generation_done=[False, False],
+        is_chunked=[0, 0],
+        finished=[lambda: False, lambda: False],
+    )
+    logits = torch.tensor(
+        [
+            [[0.0, 0.1, 2.0, 0.2, 0.3, 0.4, 0.5, 0.6]] * 3,
+            [[0.0, 0.1, 0.2, 0.3, 0.4, 2.0, 1.5, 1.0]] * 3,
+        ]
+    )
+
+    def configure(async_enabled: bool):
+        runner, sched, result, fb, reqs, datas = _build_runner(
+            async_enabled=async_enabled, **kwargs
+        )
+        runner.model._num_codebooks = 3
+        runner.model._cg_temperature = torch.ones(2)
+        runner.model._cg_top_k_buf = torch.full((2,), K_MAX, dtype=torch.long)
+        runner.model.modality_head = SimpleNamespace(generate=lambda hidden: logits)
+        result.logits_output.hidden_states = torch.zeros(2, 4)
+        for data in datas:
+            data.return_logprob = True
+            data.return_omni_rollout = True
+        return runner, sched, result, fb, reqs, datas
+
+    sync = configure(False)
+    sync[0]._collect_step_outputs_cg(sync[2], sync[3], sync[1])
+    sync_snapshot = _snapshot(sync[4], sync[5], sync[2])
+
+    async_case = configure(True)
+    _patch_cpu_host_staging(monkeypatch)
+    host = async_case[0].post_decode_launch(async_case[2], async_case[3], async_case[1])
+    async_case[0].post_decode_resolve(
+        host, async_case[2], async_case[3], None, async_case[1]
+    )
+    async_snapshot = _snapshot(async_case[4], async_case[5], async_case[2])
+
+    assert async_snapshot == sync_snapshot
+    assert sync_snapshot["output_action_masks"] == [
+        [[True, False, True]],
+        [[False, True, False]],
+    ]
+    assert sync_snapshot["output_logprobs"][0][0][1] == 0.0
+    assert sync_snapshot["output_logprobs"][1][0][0] == 0.0
+    assert sync_snapshot["output_logprobs"][1][0][2] == 0.0
+    assert sync_snapshot["output_token_logprobs"][0][0][1] == 2
+    assert sync_snapshot["output_token_logprobs"][1][0][1] == 5
+
+
 def _pick_free_cuda_device(min_free_mib: int = 512) -> str | None:
     """Return the first CUDA device with at least ``min_free_mib`` free, else
     None. Avoids OOM on shared boxes where some GPUs already host a server."""
@@ -306,12 +379,16 @@ def test_async_real_pinned_path_matches_sync():
             _cg_codes_BN=torch.tensor(
                 [[1, 1, 1], [7, 8, 9], [20, 1, 2], [EOC_ID, 3, 4]], device=dev
             ),
-            _cg_collect_staging=torch.zeros((n, 3 + 2), dtype=torch.long, device=dev),
+            _cg_action_mask_BN=torch.ones((n, 3), dtype=torch.bool, device=dev),
+            _cg_collect_staging=torch.zeros(
+                (n, 2 * 3 + 2), dtype=torch.long, device=dev
+            ),
             _sampler_pool=SimpleNamespace(
                 delay_count=torch.zeros(n, dtype=torch.int32, device=dev),
                 eoc_countdown=torch.zeros(n, dtype=torch.int32, device=dev),
                 generation_done=torch.zeros(n, dtype=torch.bool, device=dev),
                 last_codes=torch.zeros((n, 3), dtype=torch.long, device=dev),
+                last_action_mask=torch.zeros((n, 3), dtype=torch.bool, device=dev),
                 step_count=torch.zeros(n, dtype=torch.long, device=dev),
             ),
         )
@@ -323,7 +400,9 @@ def test_async_real_pinned_path_matches_sync():
             SimpleNamespace(
                 req=reqs[i],
                 output_codes=[],
+                output_action_masks=[],
                 output_logprobs=[],
+                output_token_logprobs=[],
                 return_omni_rollout=False,
                 return_logprob=False,
                 generation_done=False,

--- a/tests/unit_test/higgs_tts/test_batched_step.py
+++ b/tests/unit_test/higgs_tts/test_batched_step.py
@@ -15,6 +15,7 @@ from sglang_omni.models.higgs_tts.sampler import (
     K_MAX,
     STOP_CODE,
     HiggsBatchedSamplerState,
+    HiggsSamplerState,
     batched_step,
     step,
 )
@@ -60,6 +61,7 @@ def _snapshot_pool(pool: HiggsBatchedSamplerState) -> dict:
         "eoc_countdown": pool.eoc_countdown.clone(),
         "generation_done": pool.generation_done.clone(),
         "last_codes": pool.last_codes.clone(),
+        "last_action_mask": pool.last_action_mask.clone(),
     }
 
 
@@ -96,6 +98,9 @@ def test_batched_matches_per_row_delay_window():
 
         assert torch.equal(codes_pr, codes_bt), f"codes mismatch at t={t}"
         _assert_pools_equal(_snapshot_pool(pool_pr), _snapshot_pool(pool_bt))
+        if t < N:
+            expected = torch.arange(N, device=DEVICE) <= t
+            assert torch.equal(pool_bt.last_action_mask, expected.expand(B, N))
 
 
 # ---------------------------------------------------------------------------
@@ -138,6 +143,7 @@ def test_batched_matches_per_row_eoc_winddown():
         pool_pr.eoc_countdown,
         torch.full_like(pool_pr.eoc_countdown, N - 2),
     )
+    assert bool(pool_bt.last_action_mask[:, 0].all())
 
     # Phase 3: wind down through N-2 more steps until done.
     for k in range(N - 2):
@@ -189,6 +195,74 @@ def test_batched_done_row_returns_stop_and_freezes_state():
 
     # Row 1 should have advanced (delay window).
     assert int(pool.delay_count[1].item()) == 1
+    assert not bool(pool.last_action_mask[0].any())
+
+
+def test_later_codebook_eoc_forces_prefix_and_records_terminating_action():
+    """Lowest sampled EOC establishes the boundary; its own cell stays scored."""
+    n = 6
+    k = 2
+    pool = HiggsBatchedSamplerState(1, n, device=DEVICE)
+    pool.delay_count[0] = n
+    target = torch.arange(10, 10 + n, device=DEVICE).unsqueeze(0)
+    target[0, k] = EOC_ID
+    logits = torch.full((1, n, V), -10.0, device=DEVICE)
+    logits.scatter_(-1, target.unsqueeze(-1), 10.0)
+
+    codes = batched_step(
+        logits,
+        pool,
+        torch.tensor([0], device=DEVICE),
+        temperature=torch.ones(1, device=DEVICE),
+        top_k_buf=torch.ones(1, dtype=torch.long, device=DEVICE),
+    )
+
+    assert codes[0, :k].tolist() == [EOC_ID] * k
+    assert int(codes[0, k]) == EOC_ID
+    assert pool.last_action_mask[0].tolist() == [False, False, True, True, True, True]
+    assert int(pool.eoc_countdown[0]) == n - k - 2
+
+    next_target = torch.arange(20, 20 + n, device=DEVICE).unsqueeze(0)
+    next_logits = torch.full((1, n, V), -10.0, device=DEVICE)
+    next_logits.scatter_(-1, next_target.unsqueeze(-1), 10.0)
+    next_codes = batched_step(
+        next_logits,
+        pool,
+        torch.tensor([0], device=DEVICE),
+        temperature=torch.ones(1, device=DEVICE),
+        top_k_buf=torch.ones(1, dtype=torch.long, device=DEVICE),
+    )
+    assert next_codes[0, : k + 2].tolist() == [EOC_ID] * (k + 2)
+    assert pool.last_action_mask[0].tolist() == [
+        False,
+        False,
+        False,
+        False,
+        True,
+        True,
+    ]
+
+
+def test_early_eoc_preserves_local_delay_length_geometry():
+    """An EOC in the delay window defines T=row-k and still round-trips."""
+    n = 5
+    eoc_row = 2
+    eoc_codebook = 1
+    state = HiggsSamplerState(num_codebooks=n)
+    emitted = []
+    for row in range(20):
+        target = torch.arange(30, 30 + n, device=DEVICE)
+        if row == eoc_row:
+            target[eoc_codebook] = EOC_ID
+        logits = torch.full((n, V), -10.0, device=DEVICE)
+        logits.scatter_(-1, target.unsqueeze(-1), 10.0)
+        emitted.append(step(logits, state, top_k=1))
+        if state.generation_done:
+            break
+
+    expected_raw_length = eoc_row - eoc_codebook
+    assert len(emitted) - (n - 1) == expected_raw_length
+    assert bool(state.last_action_mask is not None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -524,6 +524,7 @@ def test_higgs_model_runner_marks_sampler_finish() -> None:
     runner.model = SimpleNamespace(
         _rid_to_row={"req": 0},
         _output_codes={"req": [torch.tensor([EOC_ID, 1, 2])]},
+        _output_action_masks={"req": [torch.tensor([True, True, True])]},
         _sampler_pool=SimpleNamespace(generation_done=torch.tensor([True])),
     )
     req = SimpleNamespace(
@@ -534,6 +535,7 @@ def test_higgs_model_runner_marks_sampler_finish() -> None:
     data = SimpleNamespace(
         req=req,
         output_codes=[],
+        output_action_masks=[],
         output_logprobs=[],
         return_omni_rollout=False,
         return_logprob=False,
@@ -560,6 +562,7 @@ def test_higgs_model_runner_emits_latched_stream_metadata() -> None:
     runner.model = SimpleNamespace(
         _rid_to_row={"req": 0},
         _output_codes={"req": [torch.tensor([EOC_ID, 1, 2])]},
+        _output_action_masks={"req": [torch.tensor([True, True, True])]},
         _sampler_pool=SimpleNamespace(generation_done=torch.tensor([True])),
     )
     req = SimpleNamespace(
@@ -570,6 +573,7 @@ def test_higgs_model_runner_emits_latched_stream_metadata() -> None:
     data = SimpleNamespace(
         req=req,
         output_codes=[],
+        output_action_masks=[],
         output_logprobs=[],
         return_omni_rollout=False,
         return_logprob=False,
@@ -639,12 +643,14 @@ def test_higgs_model_runner_marks_sampler_finish_cg() -> None:
         _cg_active_step_count=torch.zeros(1, dtype=torch.long),
         _cg_was_done=torch.tensor([False]),
         _cg_codes_BN=torch.tensor([[EOC_ID, 1, 2]]),
-        _cg_collect_staging=torch.zeros((1, 3 + 2), dtype=torch.long),
+        _cg_action_mask_BN=torch.ones((1, 3), dtype=torch.bool),
+        _cg_collect_staging=torch.zeros((1, 2 * 3 + 2), dtype=torch.long),
         _sampler_pool=SimpleNamespace(
             delay_count=torch.zeros(1, dtype=torch.int32),
             eoc_countdown=torch.zeros(1, dtype=torch.int32),
             generation_done=torch.zeros(1, dtype=torch.bool),
             last_codes=torch.zeros((1, 3), dtype=torch.long),
+            last_action_mask=torch.zeros((1, 3), dtype=torch.bool),
             step_count=torch.zeros(1, dtype=torch.long),
         ),
     )
@@ -652,6 +658,7 @@ def test_higgs_model_runner_marks_sampler_finish_cg() -> None:
     data = SimpleNamespace(
         req=req,
         output_codes=[],
+        output_action_masks=[],
         output_logprobs=[],
         return_omni_rollout=False,
         return_logprob=False,
@@ -692,13 +699,15 @@ def test_higgs_model_runner_collect_cg_mixed_batch() -> None:
         _cg_active_step_count=torch.zeros(n, dtype=torch.long),
         _cg_was_done=torch.tensor([False, True, False, False]),
         _cg_codes_BN=torch.tensor([[1, 1, 1], [7, 8, 9], [20, 1, 2], [EOC_ID, 3, 4]]),
-        _cg_collect_staging=torch.zeros((n, k + 2), dtype=torch.long),
+        _cg_action_mask_BN=torch.ones((n, k), dtype=torch.bool),
+        _cg_collect_staging=torch.zeros((n, 2 * k + 2), dtype=torch.long),
         _sampler_pool=SimpleNamespace(
             delay_count=torch.zeros(n, dtype=torch.int32),
             eoc_countdown=torch.zeros(n, dtype=torch.int32),
             generation_done=torch.zeros(n, dtype=torch.bool),
             step_count=torch.zeros(n, dtype=torch.long),
             last_codes=torch.zeros((n, k), dtype=torch.long),
+            last_action_mask=torch.zeros((n, k), dtype=torch.bool),
         ),
     )
     # row0 chunked, row1 was-done, row2 active (not done), row3 active (EOC done).
@@ -712,6 +721,7 @@ def test_higgs_model_runner_collect_cg_mixed_batch() -> None:
         SimpleNamespace(
             req=r,
             output_codes=[],
+            output_action_masks=[],
             output_logprobs=[],
             return_omni_rollout=False,
             return_logprob=False,
@@ -763,19 +773,22 @@ def test_higgs_model_runner_collects_rollout_logprobs_only_when_requested() -> N
         _cg_active_step_count=torch.zeros(n, dtype=torch.long),
         _cg_was_done=torch.tensor([False]),
         _cg_codes_BN=torch.tensor([[2, 3, 4]]),
-        _cg_collect_staging=torch.zeros((n, k + 2), dtype=torch.long),
+        _cg_action_mask_BN=torch.tensor([[True, False, True]]),
+        _cg_collect_staging=torch.zeros((n, 2 * k + 2), dtype=torch.long),
         _sampler_pool=SimpleNamespace(
             delay_count=torch.zeros(n, dtype=torch.int32),
             eoc_countdown=torch.zeros(n, dtype=torch.int32),
             generation_done=torch.zeros(n, dtype=torch.bool),
             step_count=torch.zeros(n, dtype=torch.long),
             last_codes=torch.zeros((n, k), dtype=torch.long),
+            last_action_mask=torch.zeros((n, k), dtype=torch.bool),
         ),
     )
     req = SimpleNamespace(is_chunked=0, finished_reason=None, finished=lambda: False)
     data = SimpleNamespace(
         req=req,
         output_codes=[],
+        output_action_masks=[],
         output_logprobs=[],
         output_token_logprobs=[],
         return_omni_rollout=True,
@@ -799,7 +812,9 @@ def test_higgs_model_runner_collects_rollout_logprobs_only_when_requested() -> N
         -1, torch.tensor([[[2], [3], [4]]])
     )
     assert len(data.output_logprobs) == 1
-    assert torch.allclose(data.output_logprobs[0], expected.squeeze(-1)[0])
+    expected_masked = expected.squeeze(-1)[0]
+    expected_masked[1] = 0.0
+    assert torch.allclose(data.output_logprobs[0], expected_masked)
     assert len(data.output_token_logprobs) == 1
     raw_cb0_logprob, cb0_token = data.output_token_logprobs[0]
     assert raw_cb0_logprob == pytest.approx(float(expected[0, 0, 0].item()))
@@ -813,6 +828,7 @@ def test_higgs_model_runner_skips_already_finished_eager_request() -> None:
     runner.model = SimpleNamespace(
         _rid_to_row={"req": 0},
         _output_codes={"req": [torch.tensor([EOC_ID, 1, 2])]},
+        _output_action_masks={"req": [torch.tensor([True, True, True])]},
         _sampler_pool=SimpleNamespace(generation_done=torch.tensor([True])),
     )
     req = SimpleNamespace(

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -29,6 +29,9 @@ def test_higgs_streaming_pipeline_routes_chunks_to_vocoder() -> None:
     config = HiggsTtsPipelineConfig(model_path="fake-model")
     stages_by_name = {stage.name: stage for stage in config.stages}
 
+    assert HiggsTtsPipelineConfig.mem_fraction_role_to_stage() == {
+        "talker": "tts_engine"
+    }
     assert stages_by_name["tts_engine"].stream_to == ["vocoder"]
     assert "server_args_overrides" not in stages_by_name["tts_engine"].factory_args
     assert stages_by_name["vocoder"].can_accept_stream_before_payload is True

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -900,6 +900,7 @@ def test_higgs_tts_vocoder_batches_decode_requests(
             prompt_tokens=5,
             completion_tokens=10,
             engine_time_s=0.5,
+            weight_version="7",
         ),
     )
     p2 = _make_payload(
@@ -917,6 +918,7 @@ def test_higgs_tts_vocoder_batches_decode_requests(
     assert audio.size > 0
     assert "audio_data" not in results[0].data
     assert results[0].data["usage"]["prompt_tokens"] == 5
+    assert results[0].data["weight_version"] == "7"
 
 
 def test_higgs_tts_vocoder_batch_handles_empty_items(

--- a/tests/unit_test/higgs_tts/test_rollout_serialization.py
+++ b/tests/unit_test/higgs_tts/test_rollout_serialization.py
@@ -37,6 +37,7 @@ def _fake_data(*, return_omni_rollout, return_logprob, t_raw=6):
         return_omni_rollout=return_omni_rollout,
         return_logprob=return_logprob,
         input_ids=list(range(5)),
+        weight_version="7",
     )
 
 
@@ -52,8 +53,10 @@ def test_omni_rollout_built_and_roundtrips():
     assert state.omni_rollout["version"] == 2
     assert state.omni_rollout["total_action_count"] == 6 * N + 1
     assert state.output_token_logprobs == data.output_token_logprobs
+    assert state.weight_version == "7"
     # Survives the StagePayload dict round-trip the client reads from.
     assert HiggsTtsState.from_dict(state.to_dict()).omni_rollout == state.omni_rollout
+    assert HiggsTtsState.from_dict(state.to_dict()).weight_version == "7"
     assert (
         HiggsTtsState.from_dict(state.to_dict()).output_token_logprobs
         == state.output_token_logprobs

--- a/tests/unit_test/higgs_tts/test_rollout_serialization.py
+++ b/tests/unit_test/higgs_tts/test_rollout_serialization.py
@@ -10,7 +10,10 @@ import torch
 
 from sglang_omni.models.higgs_tts.payload_types import HiggsTtsState
 from sglang_omni.models.higgs_tts.request_builders import apply_higgs_result
-from sglang_omni.models.higgs_tts.utils import apply_delay_pattern
+from sglang_omni.models.higgs_tts.utils import (
+    apply_delay_pattern,
+    delay_pattern_codec_content_mask,
+)
 
 N = 8
 V = 1026
@@ -22,8 +25,11 @@ def _fake_data(*, return_omni_rollout, return_logprob, t_raw=6):
         [float(-100.0 - i), int(code[0].item())]
         for i, code in enumerate(delayed.unbind(0))
     ]
+    action_mask = delay_pattern_codec_content_mask(delayed)
+    action_mask[t_raw, 0] = True
     return SimpleNamespace(
         output_codes=list(delayed.unbind(0)),
+        output_action_masks=list(action_mask.unbind(0)),
         output_logprobs=list(torch.randn(*delayed.shape).unbind(0)),
         output_token_logprobs=cb0_logprobs,
         num_codebooks=N,
@@ -42,8 +48,9 @@ def test_omni_rollout_built_and_roundtrips():
 
     stream = state.omni_rollout["action_streams"][0]
     assert stream["name"] == "higgs_codes"
-    assert stream["logprobs"] is not None
-    assert state.omni_rollout["total_action_count"] == 6 * N
+    assert stream["policy_logprobs"] is not None
+    assert state.omni_rollout["version"] == 2
+    assert state.omni_rollout["total_action_count"] == 6 * N + 1
     assert state.output_token_logprobs == data.output_token_logprobs
     # Survives the StagePayload dict round-trip the client reads from.
     assert HiggsTtsState.from_dict(state.to_dict()).omni_rollout == state.omni_rollout
@@ -62,13 +69,12 @@ def test_flag_gating():
     assert "omni_rollout" not in off.to_dict()
     assert off.output_token_logprobs is not None
 
-    # rollout but no logprob flag -> trace without logprobs.
+    # A structured rollout without full policy logprobs is invalid.
     no_lp = HiggsTtsState(num_codebooks=N, codebook_size=V)
-    apply_higgs_result(
-        no_lp, _fake_data(return_omni_rollout=True, return_logprob=False)
-    )
-    assert no_lp.omni_rollout["action_streams"][0]["logprobs"] is None
-    assert no_lp.output_token_logprobs is None
+    with pytest.raises(ValueError, match="missing aligned"):
+        apply_higgs_result(
+            no_lp, _fake_data(return_omni_rollout=True, return_logprob=False)
+        )
 
 
 def test_cb0_output_logprobs_do_not_require_omni_rollout():

--- a/tests/unit_test/higgs_tts/test_rollout_trace.py
+++ b/tests/unit_test/higgs_tts/test_rollout_trace.py
@@ -1,84 +1,106 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for :func:`build_omni_rollout_trace` (meta_info.omni_rollout builder).
-
-Mask geometry itself is covered by ``test_action_mask``; here we pin the schema /
-action count and the fail-loud input guards.
-"""
+"""Version-2 Higgs rollout trace validation and serialization."""
 
 from __future__ import annotations
 
 import pytest
 import torch
+from pydantic import ValidationError
 
 from sglang_omni.models.higgs_tts.rollout_trace import (
     OMNI_ROLLOUT_VERSION,
     build_omni_rollout_trace,
 )
-from sglang_omni.models.higgs_tts.utils import apply_delay_pattern
+from sglang_omni.models.higgs_tts.utils import (
+    apply_delay_pattern,
+    delay_pattern_codec_content_mask,
+)
+from sglang_omni.serve.protocol import OmniRolloutTrace
 
-DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 N = 8
 V = 1026
 
 
-def _delayed(t_raw: int, n: int = N) -> torch.Tensor:
-    return apply_delay_pattern(torch.randint(0, 1024, (t_raw, n), device=DEVICE))
+def _inputs(t_raw: int = 4):
+    codes = apply_delay_pattern(torch.randint(0, 1024, (t_raw, N)))
+    mask = delay_pattern_codec_content_mask(codes)
+    mask[t_raw, 0] = True  # sampled terminating EOC is an action, not content
+    logprobs = torch.randn(codes.shape)
+    return codes, mask, logprobs
 
 
-def test_schema_actions_logprobs_and_action_count():
-    torch.manual_seed(0)
-    t_raw = 10
-    delayed = _delayed(t_raw)
-    lp = torch.randn(*delayed.shape, device=DEVICE)
-
+def test_schema_uses_explicit_sample_time_mask():
+    codes, mask, logprobs = _inputs()
     trace = build_omni_rollout_trace(
-        delayed, num_codebooks=N, codebook_vocab_size=V, delayed_logprobs=lp
+        codes,
+        num_codebooks=N,
+        codebook_vocab_size=V,
+        policy_logprobs=logprobs,
+        action_mask=mask,
     )
 
-    assert trace["version"] == OMNI_ROLLOUT_VERSION
-    assert trace["model_family"] == "higgs_tts"
-    s = trace["action_streams"][0]
-    assert (s["name"], s["layout"], s["action_type"]) == (
-        "higgs_codes",
-        "codebook_2d",
-        "discrete",
+    parsed = OmniRolloutTrace.model_validate(trace)
+    assert parsed.version == OMNI_ROLLOUT_VERSION == 2
+    stream = trace["action_streams"][0]
+    assert (stream["action_type"], stream["layout"]) == (
+        "multi_discrete",
+        "time_codebook",
     )
-    assert s["shape"] == list(delayed.shape)
-    assert s["channel_ids"] == list(range(N))
-    # actions / logprobs serialize verbatim and aligned.
-    assert s["actions"] == delayed.to(torch.long).tolist()
-    assert torch.allclose(torch.tensor(s["logprobs"], device=DEVICE), lp, atol=1e-5)
-    # total_action_count == sum(mask) == T*N.
-    assert trace["total_action_count"] == sum(sum(row) for row in s["action_mask"])
-    assert trace["total_action_count"] == t_raw * N
+    assert stream["actions"] == codes.tolist()
+    assert stream["action_mask"] == mask.tolist()
+    assert (
+        stream["codec_content_mask"] == delay_pattern_codec_content_mask(codes).tolist()
+    )
+    assert trace["total_action_count"] == int(mask.sum())
+    serialized_lp = torch.tensor(stream["policy_logprobs"])
+    assert torch.all(serialized_lp[~mask] == 0)
+    assert torch.allclose(serialized_lp[mask], logprobs[mask])
 
 
-def test_input_guards():
-    delayed = _delayed(6)
-
+def test_input_guards_and_nonfinite_masking():
+    codes, mask, logprobs = _inputs()
+    kwargs = dict(
+        num_codebooks=N,
+        codebook_vocab_size=V,
+        policy_logprobs=logprobs,
+        action_mask=mask,
+    )
     with pytest.raises(ValueError, match="codebooks"):
-        build_omni_rollout_trace(delayed, num_codebooks=N + 1, codebook_vocab_size=V)
+        build_omni_rollout_trace(codes, **{**kwargs, "num_codebooks": N + 1})
+    with pytest.raises(ValueError, match="action_mask shape"):
+        build_omni_rollout_trace(codes, **{**kwargs, "action_mask": mask[:-1]})
+    with pytest.raises(ValueError, match="policy_logprobs shape"):
+        build_omni_rollout_trace(codes, **{**kwargs, "policy_logprobs": logprobs[:-1]})
 
-    with pytest.raises(ValueError, match="shape"):
-        build_omni_rollout_trace(
-            delayed,
-            num_codebooks=N,
-            codebook_vocab_size=V,
-            delayed_logprobs=torch.randn(delayed.shape[0] + 1, N, device=DEVICE),
-        )
-
-    # NaN on a real-action cell (3, 0) fails loud...
-    lp = torch.randn(*delayed.shape, device=DEVICE)
-    lp[3, 0] = float("nan")
+    row, channel = mask.nonzero()[0]
+    logprobs[row, channel] = float("nan")
     with pytest.raises(ValueError, match="non-finite"):
-        build_omni_rollout_trace(
-            delayed, num_codebooks=N, codebook_vocab_size=V, delayed_logprobs=lp
-        )
+        build_omni_rollout_trace(codes, **kwargs)
+    codes[0, 0] = V
+    with pytest.raises(ValueError, match="vocabulary"):
+        build_omni_rollout_trace(codes, **kwargs)
 
-    # ...but a non-finite value on a masked (BOC scaffolding) cell is harmless.
-    lp = torch.randn(*delayed.shape, device=DEVICE)
-    lp[0, N - 1] = float("-inf")
+
+def test_wire_schema_rejects_integer_masks_and_unknown_fields():
+    codes, mask, logprobs = _inputs()
     trace = build_omni_rollout_trace(
-        delayed, num_codebooks=N, codebook_vocab_size=V, delayed_logprobs=lp
+        codes,
+        num_codebooks=N,
+        codebook_vocab_size=V,
+        policy_logprobs=logprobs,
+        action_mask=mask,
     )
-    assert trace["total_action_count"] > 0
+    trace["action_streams"][0]["action_mask"][0][0] = 1
+    with pytest.raises(ValidationError):
+        OmniRolloutTrace.model_validate(trace)
+
+    trace = build_omni_rollout_trace(
+        codes,
+        num_codebooks=N,
+        codebook_vocab_size=V,
+        policy_logprobs=logprobs,
+        action_mask=mask,
+    )
+    trace["action_streams"][0]["unexpected"] = "must fail closed"
+    with pytest.raises(ValidationError):
+        OmniRolloutTrace.model_validate(trace)

--- a/tests/unit_test/model_runner/test_weight_checker.py
+++ b/tests/unit_test/model_runner/test_weight_checker.py
@@ -7,7 +7,10 @@ from typing import Any
 import pytest
 import torch
 
-from sglang_omni.model_runner.model_worker import ModelWorker
+from sglang_omni.model_runner.model_worker import (
+    ModelWorker,
+    _distributed_weight_update_transport,
+)
 from sglang_omni.model_runner.weight_checker import StrictWeightChecker, _tensor_bytes
 
 
@@ -69,6 +72,47 @@ def test_tensor_bytes_supports_float8_fallback_path() -> None:
 
     assert isinstance(raw, bytes)
     assert len(raw) == tensor.numel() * tensor.element_size()
+
+
+def test_distributed_weight_update_transport_advertises_process_nccl_mode(
+    monkeypatch,
+) -> None:
+    runner = SimpleNamespace(
+        init_weights_update_group=lambda: None,
+        update_weights_from_distributed=lambda: None,
+        destroy_weights_update_group=lambda: None,
+    )
+    monkeypatch.setenv("NCCL_CUMEM_ENABLE", "1")
+    monkeypatch.setattr(torch.cuda.nccl, "version", lambda: (2, 28, 9))
+
+    assert _distributed_weight_update_transport(runner) == {
+        "protocol_version": 1,
+        "backend": "nccl",
+        "nccl_version": "2.28.9",
+        "nccl_cumem_enable": "1",
+    }
+
+
+def test_distributed_weight_update_transport_reports_default_nccl_mode(
+    monkeypatch,
+) -> None:
+    runner = SimpleNamespace(
+        init_weights_update_group=lambda: None,
+        update_weights_from_distributed=lambda: None,
+        destroy_weights_update_group=lambda: None,
+    )
+    monkeypatch.delenv("NCCL_CUMEM_ENABLE", raising=False)
+    monkeypatch.setattr(torch.cuda.nccl, "version", lambda: (2, 28, 9))
+
+    assert _distributed_weight_update_transport(runner)["nccl_cumem_enable"] == (
+        "default"
+    )
+
+
+def test_distributed_weight_update_transport_requires_complete_refit_surface() -> None:
+    runner = SimpleNamespace(update_weights_from_distributed=lambda: None)
+
+    assert _distributed_weight_update_transport(runner) is None
 
 
 def test_model_worker_update_weights_from_disk_updates_visible_model_info() -> None:

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -23,6 +23,10 @@ def test_qwen3_asr_config_uses_batched_stage_with_32_running_requests() -> None:
     assert config.stages[0].factory_args["max_running_requests"] == 32
     assert config.stages[0].factory_args["request_build_max_workers"] == 2
     assert config.stages[0].factory_args["request_build_max_pending"] == 16
+    assert Qwen3ASRPipelineConfig.mem_fraction_role_to_stage() == {"asr": "asr"}
+    assert Qwen3ASRPipelineConfig.generation_sglang_role_to_stage() == {
+        "generation": "asr"
+    }
     assert "request_build_max_backlog" not in config.stages[0].factory_args
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config("Qwen3ASRForConditionalGeneration")

--- a/tests/unit_test/qwen3_omni/test_pipeline.py
+++ b/tests/unit_test/qwen3_omni/test_pipeline.py
@@ -287,12 +287,18 @@ def test_qwen_pretokenized_media_validates_placeholder_counts() -> None:
         _validate_pretokenized_media_tokens,
     )
 
+    tokenizer = SimpleNamespace(
+        convert_tokens_to_ids=lambda token: {
+            "<image>": 101,
+            "<audio>": 102,
+            "<video>": 103,
+        }[token]
+    )
     processor = SimpleNamespace(
-        tokenizer=SimpleNamespace(
-            image_token_id=101,
-            audio_token_id=102,
-            video_token_id=103,
-        )
+        tokenizer=tokenizer,
+        image_token="<image>",
+        audio_token="<audio>",
+        video_token="<video>",
     )
     processed = torch.tensor([101, 101, 102, 103, 103, 103])
 
@@ -316,12 +322,15 @@ def test_qwen_pretokenized_media_preserves_ids_and_builds_encoders(
     import sglang_omni.models.qwen3_omni.components.preprocessor as preprocessor_mod
 
     class _Tokenizer:
-        image_token_id = 101
-        audio_token_id = 102
-        video_token_id = 103
+        @staticmethod
+        def convert_tokens_to_ids(token):
+            return {"<image>": 101, "<audio>": 102, "<video>": 103}[token]
 
     class _Processor:
         tokenizer = _Tokenizer()
+        image_token = "<image>"
+        audio_token = "<audio>"
+        video_token = "<video>"
 
         def apply_chat_template(self, *args, **kwargs):
             del args, kwargs

--- a/tests/unit_test/qwen3_omni/test_pipeline.py
+++ b/tests/unit_test/qwen3_omni/test_pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 from types import SimpleNamespace
 
@@ -279,6 +280,119 @@ def test_qwen_preprocess_pretokenized_builds_thinker_state_from_ids() -> None:
     assert state.prompt["attention_mask"].tolist() == [1, 1, 1]
     assert state.encoder_inputs["image_encoder"]["_skip"] is True
     assert state.encoder_inputs["audio_encoder"]["_skip"] is True
+
+
+def test_qwen_pretokenized_media_validates_placeholder_counts() -> None:
+    from sglang_omni.models.qwen3_omni.components.preprocessor import (
+        _validate_pretokenized_media_tokens,
+    )
+
+    processor = SimpleNamespace(
+        tokenizer=SimpleNamespace(
+            image_token_id=101,
+            audio_token_id=102,
+            video_token_id=103,
+        )
+    )
+    processed = torch.tensor([101, 101, 102, 103, 103, 103])
+
+    _validate_pretokenized_media_tokens(
+        processor,
+        torch.tensor([7, 101, 101, 8, 102, 103, 103, 103]),
+        processed,
+    )
+
+    with pytest.raises(ValueError, match="audio token count"):
+        _validate_pretokenized_media_tokens(
+            processor,
+            torch.tensor([7, 101, 101, 8, 103, 103, 103]),
+            processed,
+        )
+
+
+def test_qwen_pretokenized_media_preserves_ids_and_builds_encoders(
+    monkeypatch,
+) -> None:
+    import sglang_omni.models.qwen3_omni.components.preprocessor as preprocessor_mod
+
+    class _Tokenizer:
+        image_token_id = 101
+        audio_token_id = 102
+        video_token_id = 103
+
+    class _Processor:
+        tokenizer = _Tokenizer()
+
+        def apply_chat_template(self, *args, **kwargs):
+            del args, kwargs
+            return "synthetic-media-prompt"
+
+        def __call__(self, **kwargs):
+            del kwargs
+            return {
+                "input_ids": torch.tensor([[101, 101, 102, 103, 103, 103]]),
+                "attention_mask": torch.ones((1, 6), dtype=torch.long),
+                "pixel_values": torch.ones((2, 3)),
+                "image_grid_thw": torch.tensor([[1, 2, 4]]),
+                "input_features": torch.ones((1, 4, 5)),
+                "feature_attention_mask": torch.ones((1, 5), dtype=torch.long),
+                "pixel_values_videos": torch.ones((3, 3)),
+                "video_grid_thw": torch.tensor([[1, 3, 4]]),
+                "video_second_per_grid": [0.5],
+            }
+
+    async def _images(raw):
+        return list(raw or [])
+
+    async def _audios(raw, *, target_sr):
+        del target_sr
+        return list(raw or [])
+
+    async def _videos(raw, **kwargs):
+        del kwargs
+        return list(raw or []), [2.0], []
+
+    monkeypatch.setattr(preprocessor_mod, "ensure_image_list_async", _images)
+    monkeypatch.setattr(preprocessor_mod, "ensure_audio_list_async", _audios)
+    monkeypatch.setattr(preprocessor_mod, "ensure_video_list_async", _videos)
+
+    pre = object.__new__(preprocessor_mod.Qwen3OmniPreprocessor)
+    pre.processor = _Processor()
+    pre.max_seq_len = None
+    pre.default_video_fps = None
+    pre.default_video_max_frames = None
+    pre.default_video_min_pixels = None
+    pre.default_video_max_pixels = None
+    pre.default_video_total_pixels = None
+    payload = StagePayload(
+        request_id="req-mm",
+        request=OmniRequest(
+            inputs={
+                "input_ids": [7, 101, 101, 102, 103, 103, 103, 8],
+                "images": ["image"],
+                "audios": ["audio"],
+                "videos": ["video"],
+            },
+            params={"max_new_tokens": 16},
+        ),
+        data={},
+    )
+
+    out = asyncio.run(pre._call_impl(payload))
+    state = Qwen3OmniPipelineState.from_dict(out.data)
+
+    assert state.prompt["input_ids"].tolist() == [
+        7,
+        101,
+        101,
+        102,
+        103,
+        103,
+        103,
+        8,
+    ]
+    assert state.encoder_inputs["image_encoder"].get("_skip") is not True
+    assert state.encoder_inputs["audio_encoder"].get("_skip") is not True
 
 
 def test_qwen_talker_to_code2wav_projection_keeps_only_request_latch() -> None:

--- a/tests/unit_test/serve/test_generate_rollout.py
+++ b/tests/unit_test/serve/test_generate_rollout.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
 from fastapi.testclient import TestClient
 
 from sglang_omni.client.types import (
@@ -50,6 +51,30 @@ def _text_result() -> CompletionResult:
         output_token_logprobs=[[-0.1, 11], [-0.2, 22]],
         weight_version="v3",
     )
+
+
+def _audio_trace() -> dict[str, Any]:
+    return {
+        "version": 2,
+        "model_family": "higgs_tts",
+        "total_action_count": 3,
+        "action_streams": [
+            {
+                "name": "higgs_codes",
+                "stage": "tts_engine",
+                "modality": "audio",
+                "action_type": "multi_discrete",
+                "layout": "time_codebook",
+                "shape": [2, 2],
+                "vocab_size": 1026,
+                "actions": [[10, 1024], [1025, 11]],
+                "policy_logprobs": [[-1.0, 0.0], [-2.0, -3.0]],
+                "action_mask": [[True, False], [True, True]],
+                "codec_content_mask": [[True, False], [False, True]],
+                "channel_ids": [0, 1],
+            }
+        ],
+    }
 
 
 def test_generate_returns_miles_meta_info() -> None:
@@ -160,13 +185,11 @@ def test_generate_rejects_empty_input_ids() -> None:
 def test_generate_returns_omni_rollout_when_present() -> None:
     result = _text_result()
     result.output_token_logprobs = None
-    result.omni_rollout = {
-        "version": 1,
-        "model_family": "qwen3_omni",
-        "stages": ["talker"],
-        "total_action_count": 1,
-        "action_streams": [],
-    }
+    result.output_codebook_tokens = [[10, 1024], [1025, 11]]
+    result.omni_rollout = _audio_trace()
+    result.audio = CompletionAudio(
+        id="a1", data="QUJD", format="wav", sample_rate=24000
+    )
     client = _RolloutClient(result)
     tc = TestClient(create_app(client, model_name="qwen3-omni"))
 
@@ -175,12 +198,76 @@ def test_generate_returns_omni_rollout_when_present() -> None:
         json={
             "prompt": "hi",
             "sampling_params": {},
+            "output_modalities": ["audio"],
             "return_omni_rollout": True,
         },
     )
 
     assert resp.status_code == 200
     assert resp.json()["meta_info"]["omni_rollout"] == result.omni_rollout
+    assert resp.json()["audio"]["sample_rate"] == 24000
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("temperature", 0.7, "temperature must be 1.0"),
+        ("top_p", 0.9, "top_p must be 1.0"),
+        ("top_k", 20, "top_k must be absent"),
+        ("min_p", 0.1, "min_p must be 0.0"),
+        ("repetition_penalty", 1.1, "repetition_penalty must be 1.0"),
+    ],
+)
+def test_generate_rejects_filtered_structured_rollout(
+    field: str, value: float, message: str
+) -> None:
+    client = _RolloutClient(_text_result())
+    tc = TestClient(create_app(client, model_name="higgs-audio"))
+
+    resp = tc.post(
+        "/generate",
+        json={
+            "prompt": "hi",
+            "sampling_params": {field: value},
+            "return_omni_rollout": True,
+        },
+    )
+
+    assert resp.status_code == 400
+    assert message in resp.text
+    assert client.requests == []
+
+
+def test_generate_rejects_structured_rollout_without_logprobs() -> None:
+    client = _RolloutClient(_text_result())
+    tc = TestClient(create_app(client, model_name="higgs-audio"))
+    resp = tc.post(
+        "/generate",
+        json={
+            "prompt": "hi",
+            "return_omni_rollout": True,
+            "return_logprob": False,
+        },
+    )
+    assert resp.status_code == 400
+    assert client.requests == []
+
+
+def test_generate_rejects_structured_audio_without_waveform() -> None:
+    result = _text_result()
+    result.output_token_logprobs = None
+    result.output_codebook_tokens = [[10, 1024], [1025, 11]]
+    result.omni_rollout = _audio_trace()
+    client = _RolloutClient(result)
+    tc = TestClient(create_app(client, model_name="higgs-audio"))
+
+    resp = tc.post(
+        "/generate",
+        json={"prompt": "hi", "return_omni_rollout": True},
+    )
+
+    assert resp.status_code == 500
+    assert "nonempty WAV" in resp.text
 
 
 def test_generate_omits_omni_rollout_when_not_requested() -> None:

--- a/tests/unit_test/serve/test_generate_rollout.py
+++ b/tests/unit_test/serve/test_generate_rollout.py
@@ -98,6 +98,48 @@ def test_generate_returns_codebook_tokens_when_present() -> None:
     assert resp.json()["meta_info"]["output_codebook_tokens"] == [[11, 1], [22, 2]]
 
 
+def test_generate_normalizes_media_aliases_with_input_ids() -> None:
+    client = _RolloutClient(_text_result())
+    tc = TestClient(create_app(client, model_name="qwen3-omni"))
+
+    resp = tc.post(
+        "/generate",
+        json={
+            "input_ids": [1, 2, 3],
+            "image_data": ["data:image/png;base64,SU1H"],
+            "audio_data": ["data:audio/wav;base64,QVVESU8="],
+            "video_data": ["https://example.test/video.mp4"],
+            "video_fps": 2.0,
+            "sampling_params": {"max_new_tokens": 2},
+        },
+    )
+
+    assert resp.status_code == 200
+    request = client.requests[0]
+    assert request.prompt_token_ids == [1, 2, 3]
+    assert request.images == ["data:image/png;base64,SU1H"]
+    assert request.audios == ["data:audio/wav;base64,QVVESU8="]
+    assert request.videos == ["https://example.test/video.mp4"]
+    assert request.video_fps == 2.0
+
+
+def test_generate_rejects_unknown_top_level_fields() -> None:
+    client = _RolloutClient(_text_result())
+    tc = TestClient(create_app(client, model_name="qwen3-omni"))
+
+    resp = tc.post(
+        "/generate",
+        json={
+            "input_ids": [1, 2, 3],
+            "sampling_params": {"max_new_tokens": 2},
+            "audoi_data": ["typo-must-not-be-dropped"],
+        },
+    )
+
+    assert resp.status_code == 422
+    assert client.requests == []
+
+
 def test_generate_rejects_empty_input_ids() -> None:
     client = _RolloutClient(_text_result())
     tc = TestClient(create_app(client, model_name="higgs-audio"))

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -1135,6 +1135,9 @@ _ADMIN_PATHS_THAT_NEED_AUTH = [
     ("POST", "/model_info"),
     ("POST", "/pause_generation"),
     ("POST", "/continue_generation"),
+    ("GET", "/flush_cache"),
+    ("POST", "/begin_weight_update"),
+    ("POST", "/end_weight_update"),
     ("POST", "/update_weights_from_disk"),
     ("POST", "/update_weights_from_tensor"),
     ("POST", "/update_weights_from_distributed"),
@@ -1165,6 +1168,21 @@ def test_admin_routes_open_when_no_key_configured() -> None:
 
     resp = client.post("/pause_generation", json={})
     assert resp.status_code == 200
+
+
+def test_sglang_compatibility_control_routes() -> None:
+    admin = AdminClient()
+    client = TestClient(create_app(admin, model_name="qwen3-omni"))
+
+    assert client.get("/health_generate").status_code == 200
+    flush = client.get("/flush_cache")
+    begin = client.post("/begin_weight_update", json={})
+    end = client.post("/end_weight_update", json={})
+
+    assert flush.status_code == 200
+    assert begin.json()["data"]["session_required"] is False
+    assert end.json()["data"]["session_required"] is False
+    assert admin.calls == [("flush_cache", {}, None, 60.0)]
 
 
 def test_admin_routes_require_bearer_token_when_key_configured() -> None:


### PR DESCRIPTION
## Summary

- preserve typed image, audio, and video inputs through `/generate`, including pretokenized placeholder validation
- correct Higgs delayed-code sampling so forced BOC/EOC cells are explicit and the sampled terminating EOC remains a policy action
- return a strict version-2 `[L, 8]` multi-discrete action stream with aligned float32 policy logprobs and action masks
- reject filtered structured sampling until behavior-distribution logprobs exist
- expose the health, cache-flush, weight-update session compatibility, and model-info controls required by an external Miles trainer
- advertise a versioned NCCL distributed-refit transport contract through stage-scoped model info
- allow global memory-fraction configuration for Higgs and Qwen3-ASR so TTS and reward inference can share one GPU

## Higgs contract

The structured stream contains `actions`, `policy_logprobs`, `action_mask`, and a separate `codec_content_mask`. Forced cells serialize with zero policy logprob. Miles reduces active codebook cells to one joint row logprob for GRPO; codebook-0 compatibility logprobs remain diagnostic only.

The local codec transform has `T + Q - 1` rows. If the first active EOC is at codebook `k`, this implementation emits `Q-k-2` subsequent rows, preserving the local delay/reverse-delay geometry.

## Validation

```text
latest control/config suite: 88 passed
original Higgs rollout suite: 174 passed
pre-commit over every changed file: passed
```

- a real H200 Higgs request returned a valid `[88, 8]` trace with 649 sampled cells, finite sampled logprobs, masked forced cells, and a non-silent 3.24-second 24 kHz WAV
- a real Qwen3-ASR server processed eight concurrent generated WAVs with stable result ordering
- Higgs and Qwen3-ASR ran together on one H200 using explicit memory fractions
- a Miles trainer refit all 399 policy tensors, advanced the server to version `2`, then completed a second eight-sample rollout using only version `2`
- post-update speech remained valid and was transcribed exactly by the colocated ASR server
- a live Higgs model-info request exposed protocol 1, NCCL 2.28.9, and CUMEM mode `default` through the complete coordinator/stage path

## Remaining precision work

The end-to-end functional RL gate passes. Exact SGLang/Megatron hidden-state and logprob parity, including Higgs-specific BF16 RoPE rounding and batch-invariant kernels, remains follow-up work and is not required for this naive one-device milestone.

Companion Miles draft: https://github.com/yxs/miles/pull/4

