### PR TITLE
[Docs] Add same-GPU DP concept figures and common questions

### DIFF
--- a/docs/_static/image/same-gpu-dp-host-bound.svg
+++ b/docs/_static/image/same-gpu-dp-host-bound.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="430" viewBox="0 0 920 430" font-family="'Segoe UI',-apple-system,Roboto,Helvetica,Arial,sans-serif">
+  <rect width="920" height="430" fill="#f4f6f9"/>
+  <rect x="12" y="12" width="896" height="406" rx="16" fill="#ffffff" stroke="#e3e7ee"/>
+  <text x="40" y="56" font-size="20" font-weight="700" fill="#171b24">The bottleneck is the host, not the GPU</text>
+  <rect x="676" y="38" width="204" height="26" rx="13" fill="none" stroke="#12a394"/>
+  <text x="778" y="55" font-size="12.5" fill="#12a394" text-anchor="middle">Reader: CPU or GPU?</text>
+
+  <g transform="translate(48,64)">
+    <text x="0" y="56" font-size="13" fill="#5f6a79">CPU</text>
+    <text x="0" y="166" font-size="13" fill="#5f6a79">GPU</text>
+    <rect x="72" y="140" width="620" height="40" rx="7" fill="#ccd3dd"/>
+    <rect x="72"  y="44" width="124" height="40" rx="6" fill="#d5883a"/>
+    <rect x="232" y="44" width="124" height="40" rx="6" fill="#d5883a"/>
+    <rect x="392" y="44" width="124" height="40" rx="6" fill="#d5883a"/>
+    <rect x="552" y="44" width="124" height="40" rx="6" fill="#d5883a"/>
+    <rect x="192" y="140" width="16" height="40" rx="3" fill="#12a394"/>
+    <rect x="352" y="140" width="16" height="40" rx="3" fill="#12a394"/>
+    <rect x="512" y="140" width="16" height="40" rx="3" fill="#12a394"/>
+    <rect x="672" y="140" width="16" height="40" rx="3" fill="#12a394"/>
+    <path d="M196 84 L196 136" stroke="#5f6a79" stroke-width="1.4" marker-end="url(#a1)"/>
+    <path d="M356 84 L356 136" stroke="#5f6a79" stroke-width="1.4" marker-end="url(#a1)"/>
+    <path d="M516 84 L516 136" stroke="#5f6a79" stroke-width="1.4" marker-end="url(#a1)"/>
+    <path d="M676 84 L676 136" stroke="#5f6a79" stroke-width="1.4" marker-end="url(#a1)"/>
+    <text x="290" y="165" font-size="12" fill="#5f6a79" text-anchor="middle">idle · waiting on host</text>
+    <line x1="72" y1="200" x2="692" y2="200" stroke="#d7dce4"/>
+    <text x="72" y="218" font-size="12.5" fill="#5f6a79">GPU idle ≈71% between kernels · <tspan font-weight="700" fill="#171b24">SM Active ≈29%</tspan></text>
+    <text x="72" y="240" font-size="12.5" fill="#5f6a79">cut GPU clock ×0.455 → throughput ×0.90      ·      cut host CPU to ¼ → throughput ×0.31</text>
+  </g>
+
+  <g transform="translate(40,332)" font-size="12.5" fill="#5f6a79">
+    <rect x="0" y="0" width="13" height="13" rx="3" fill="#d5883a"/>
+    <text x="19" y="11">CPU busy (serial host work)</text>
+    <rect x="224" y="0" width="13" height="13" rx="3" fill="#12a394"/>
+    <text x="243" y="11">GPU kernel (≈3μs)</text>
+    <rect x="392" y="0" width="13" height="13" rx="3" fill="#ccd3dd"/>
+    <text x="411" y="11">GPU idle</text>
+  </g>
+  <text x="40" y="374" font-size="13" fill="#5f6a79">Each request's host work (scheduling, detok, sampling, output sync, stage handoff) runs serially in one process.</text>
+  <text x="40" y="398" font-size="13" fill="#5f6a79">Cutting GPU compute barely moves throughput; cutting host CPU drops it hard. The limit is the host (CPU) side.</text>
+
+  <defs><marker id="a1" markerWidth="7" markerHeight="7" refX="5" refY="3.2" orient="auto"><path d="M0 0 L6 3.2 L0 6 z" fill="#5f6a79"/></marker></defs>
+</svg>

--- a/docs/_static/image/same-gpu-dp-mps.svg
+++ b/docs/_static/image/same-gpu-dp-mps.svg
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="384" viewBox="0 0 920 384" font-family="'Segoe UI',-apple-system,Roboto,Helvetica,Arial,sans-serif">
+  <rect width="920" height="384" fill="#f4f6f9"/>
+  <rect x="12" y="12" width="896" height="360" rx="16" fill="#ffffff" stroke="#e3e7ee"/>
+  <text x="40" y="52" font-size="20" font-weight="700" fill="#171b24">More host chains + MPS fill the idle GPU</text>
+
+  <g transform="translate(56,58)">
+    <line x1="380" y1="22" x2="380" y2="186" stroke="#d7dce4" stroke-dasharray="4 5"/>
+    <text x="30" y="30" font-size="14" font-weight="700" fill="#171b24">1 replica</text>
+    <rect x="30" y="92" width="120" height="30" rx="6" fill="#d5883a"/>
+    <text x="90" y="112" font-size="12.5" fill="#ffffff" text-anchor="middle">host chain</text>
+    <path d="M150 107 L178 107" stroke="#5f6a79" stroke-width="1.5" marker-end="url(#a2)"/>
+    <rect x="184" y="44"  width="28" height="28" rx="4" fill="#12a394"/>
+    <rect x="252" y="44"  width="28" height="28" rx="4" fill="#12a394"/>
+    <rect x="218" y="78"  width="28" height="28" rx="4" fill="#12a394"/>
+    <rect x="286" y="112" width="28" height="28" rx="4" fill="#12a394"/>
+    <rect x="184" y="146" width="28" height="28" rx="4" fill="#12a394"/>
+    <rect x="218" y="44"  width="28" height="28" rx="4" fill="#ccd3dd"/>
+    <rect x="286" y="44"  width="28" height="28" rx="4" fill="#ccd3dd"/>
+    <rect x="184" y="78"  width="28" height="28" rx="4" fill="#ccd3dd"/>
+    <rect x="252" y="78"  width="28" height="28" rx="4" fill="#ccd3dd"/>
+    <rect x="286" y="78"  width="28" height="28" rx="4" fill="#ccd3dd"/>
+    <rect x="184" y="112" width="28" height="28" rx="4" fill="#ccd3dd"/>
+    <rect x="218" y="112" width="28" height="28" rx="4" fill="#ccd3dd"/>
+    <rect x="252" y="112" width="28" height="28" rx="4" fill="#ccd3dd"/>
+    <rect x="218" y="146" width="28" height="28" rx="4" fill="#ccd3dd"/>
+    <rect x="252" y="146" width="28" height="28" rx="4" fill="#ccd3dd"/>
+    <rect x="286" y="146" width="28" height="28" rx="4" fill="#ccd3dd"/>
+    <text x="184" y="196" font-size="12.5" fill="#5f6a79"><tspan fill="#171b24">SM Active ≈29%</tspan>, mostly idle</text>
+
+    <text x="410" y="30" font-size="14" font-weight="700" fill="#171b24">3 replicas + MPS</text>
+    <rect x="410" y="65" width="94" height="24" rx="5" fill="#d5883a"/>
+    <rect x="410" y="97" width="94" height="24" rx="5" fill="#d5883a"/>
+    <rect x="410" y="129" width="94" height="24" rx="5" fill="#d5883a"/>
+    <text x="457" y="81"  font-size="11" fill="#ffffff" text-anchor="middle">core block 1</text>
+    <text x="457" y="113" font-size="11" fill="#ffffff" text-anchor="middle">core block 2</text>
+    <text x="457" y="145" font-size="11" fill="#ffffff" text-anchor="middle">core block 3</text>
+    <path d="M504 77  L536 96"  stroke="#5f6a79" stroke-width="1.3" marker-end="url(#a2)"/>
+    <path d="M504 109 L536 109" stroke="#5f6a79" stroke-width="1.3" marker-end="url(#a2)"/>
+    <path d="M504 141 L536 122" stroke="#5f6a79" stroke-width="1.3" marker-end="url(#a2)"/>
+    <rect x="538" y="69" width="26" height="80" rx="5" fill="#12a394"/>
+    <text x="551" y="109" font-size="12" fill="#ffffff" text-anchor="middle" transform="rotate(-90 551 109)">MPS</text>
+    <path d="M564 109 L590 109" stroke="#5f6a79" stroke-width="1.5" marker-end="url(#a2)"/>
+    <rect x="596" y="44"  width="28" height="28" rx="4" fill="#12a394"/>
+    <rect x="630" y="44"  width="28" height="28" rx="4" fill="#3cae7f"/>
+    <rect x="664" y="44"  width="28" height="28" rx="4" fill="#2f8fb0"/>
+    <rect x="698" y="44"  width="28" height="28" rx="4" fill="#ccd3dd"/>
+    <rect x="596" y="78"  width="28" height="28" rx="4" fill="#3cae7f"/>
+    <rect x="630" y="78"  width="28" height="28" rx="4" fill="#2f8fb0"/>
+    <rect x="664" y="78"  width="28" height="28" rx="4" fill="#ccd3dd"/>
+    <rect x="698" y="78"  width="28" height="28" rx="4" fill="#12a394"/>
+    <rect x="596" y="112" width="28" height="28" rx="4" fill="#2f8fb0"/>
+    <rect x="630" y="112" width="28" height="28" rx="4" fill="#12a394"/>
+    <rect x="664" y="112" width="28" height="28" rx="4" fill="#3cae7f"/>
+    <rect x="698" y="112" width="28" height="28" rx="4" fill="#ccd3dd"/>
+    <rect x="596" y="146" width="28" height="28" rx="4" fill="#ccd3dd"/>
+    <rect x="630" y="146" width="28" height="28" rx="4" fill="#ccd3dd"/>
+    <rect x="664" y="146" width="28" height="28" rx="4" fill="#12a394"/>
+    <rect x="698" y="146" width="28" height="28" rx="4" fill="#ccd3dd"/>
+    <text x="596" y="196" font-size="12.5" fill="#5f6a79">more of the GPU is used</text>
+  </g>
+
+  <g transform="translate(40,296)" font-size="12.5" fill="#5f6a79">
+    <rect x="0" y="0" width="13" height="13" rx="3" fill="#12a394"/>
+    <text x="19" y="11">kernels from the replicas</text>
+    <rect x="196" y="0" width="13" height="13" rx="3" fill="#ccd3dd"/>
+    <text x="215" y="11">idle SM</text>
+    <rect x="290" y="0" width="13" height="13" rx="3" fill="#d5883a"/>
+    <text x="309" y="11">host chain (own cores)</text>
+  </g>
+  <text x="40" y="336" font-size="13" fill="#5f6a79">Each replica is a full serving process with its own cores, so it adds an independent host chain.</text>
+  <text x="40" y="358" font-size="13" fill="#5f6a79">Without MPS the processes only time-slice; MPS lets their kernels co-reside on the SMs and use the idle compute.</text>
+  <defs><marker id="a2" markerWidth="7" markerHeight="7" refX="5" refY="3.2" orient="auto"><path d="M0 0 L6 3.2 L0 6 z" fill="#5f6a79"/></marker></defs>
+</svg>

--- a/docs/_static/image/same-gpu-dp-vram.svg
+++ b/docs/_static/image/same-gpu-dp-vram.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="470" viewBox="0 0 920 470" font-family="'Segoe UI',-apple-system,Roboto,Helvetica,Arial,sans-serif">
+  <rect width="920" height="470" fill="#f4f6f9"/>
+  <rect x="12" y="12" width="896" height="446" rx="16" fill="#ffffff" stroke="#e3e7ee"/>
+  <text x="40" y="52" font-size="20" font-weight="700" fill="#171b24">The VRAM view: what DP costs, and what it buys</text>
+  <rect x="636" y="36" width="244" height="26" rx="13" fill="none" stroke="#12a394"/>
+  <text x="758" y="53" font-size="12.5" fill="#12a394" text-anchor="middle">Reader: why replicate weights?</text>
+
+  <g transform="translate(56,40)">
+    <text x="20" y="40" font-size="12.5" fill="#5f6a79">One 80 GB H100 · schematic, not to scale</text>
+
+    <text x="20" y="78" font-size="13" fill="#171b24" font-weight="700">1 replica</text>
+    <rect x="140" y="60" width="600" height="34" rx="6" fill="#eef1f5" stroke="#d7dce4"/>
+    <rect x="140" y="60" width="52"  height="34" rx="6" fill="#5b6b9a"/>
+    <rect x="192" y="60" width="330" height="34" fill="#deae54"/>
+    <text x="166" y="82" font-size="11" fill="#ffffff" text-anchor="middle">W</text>
+    <text x="357" y="82" font-size="12" fill="#4a3a12" text-anchor="middle">KV Cache (large)</text>
+    <text x="632" y="82" font-size="12" fill="#5f6a79" text-anchor="middle">free</text>
+    <text x="140" y="118" font-size="12" fill="#5f6a79">GPU compute used</text>
+    <rect x="270" y="106" width="300" height="14" rx="7" fill="#ccd3dd"/>
+    <rect x="270" y="106" width="87"  height="14" rx="7" fill="#12a394"/>
+    <text x="580" y="117" font-size="12" fill="#171b24">≈29%</text>
+
+    <text x="20" y="176" font-size="13" fill="#171b24" font-weight="700">3 replicas</text>
+    <rect x="140" y="158" width="600" height="34" rx="6" fill="#eef1f5" stroke="#d7dce4"/>
+    <rect x="140" y="158" width="52" height="34" rx="6" fill="#5b6b9a"/>
+    <rect x="192" y="158" width="52" height="34" fill="#5b6b9a"/>
+    <rect x="244" y="158" width="52" height="34" fill="#5b6b9a"/>
+    <rect x="296" y="158" width="128" height="34" fill="#deae54"/>
+    <rect x="424" y="158" width="86"  height="34" fill="#deae54"/>
+    <rect x="510" y="158" width="54"  height="34" fill="#deae54"/>
+    <text x="218" y="180" font-size="11" fill="#ffffff" text-anchor="middle">W ×3</text>
+    <text x="360" y="180" font-size="11" fill="#4a3a12" text-anchor="middle">KV 1</text>
+    <text x="467" y="180" font-size="11" fill="#4a3a12" text-anchor="middle">KV 2</text>
+    <text x="537" y="180" font-size="10" fill="#4a3a12" text-anchor="middle">KV 3</text>
+    <text x="652" y="180" font-size="12" fill="#5f6a79" text-anchor="middle">free</text>
+    <text x="296" y="210" font-size="11.5" fill="#5f6a79">per-replica KV tokens: 97,503 · 53,149 · 20,961</text>
+    <text x="140" y="238" font-size="12" fill="#5f6a79">GPU compute used</text>
+    <rect x="270" y="226" width="300" height="14" rx="7" fill="#ccd3dd"/>
+    <rect x="270" y="226" width="195" height="14" rx="7" fill="#12a394"/>
+    <text x="580" y="237" font-size="12" fill="#171b24">higher</text>
+
+    <line x1="20" y1="258" x2="740" y2="258" stroke="#d7dce4"/>
+    <text x="20" y="280" font-size="13" fill="#171b24">DP <tspan fill="#5f6a79">does not save VRAM</tspan>: it copies weights ×N and splits the KV pool, reclaiming the idle compute above.</text>
+  </g>
+
+  <g transform="translate(40,356)" font-size="12.5" fill="#5f6a79">
+    <rect x="0" y="0" width="13" height="13" rx="3" fill="#5b6b9a"/>
+    <text x="19" y="11">weights (replicated)</text>
+    <rect x="164" y="0" width="13" height="13" rx="3" fill="#deae54"/>
+    <text x="183" y="11">KV Cache (split, smaller each)</text>
+    <rect x="404" y="0" width="13" height="13" rx="3" fill="#12a394"/>
+    <text x="423" y="11">compute used</text>
+    <rect x="524" y="0" width="13" height="13" rx="3" fill="#ccd3dd"/>
+    <text x="543" y="11">idle</text>
+  </g>
+  <text x="40" y="392" font-size="13" fill="#5f6a79">A small model's weights are a modest slice of an 80 GB card, so two or three full replicas fit; each KV pool then gets smaller.</text>
+  <text x="40" y="414" font-size="13" fill="#5f6a79">It pays only when a tuned single replica was already leaving the GPU idle. On a compute-bound model</text>
+  <text x="40" y="436" font-size="13" fill="#5f6a79">(for example MOSS-TTS-Local at ≈81% util) the extra weight copies buy nothing.</text>
+</svg>

--- a/docs/basic_usage/mps_dp.md
+++ b/docs/basic_usage/mps_dp.md
@@ -6,6 +6,8 @@ A common data-parallel deployment assigns one GPU to each replica. When a tuned 
 
 Same-GPU data parallelism runs several complete serving replicas on one GPU and lets [CUDA MPS](https://docs.nvidia.com/deploy/mps/index.html) share the GPU between them. This is a conditional and ongoing optimization. We are excited to share it and call for the community to join the exploration.
 
+![Multiple host chains plus CUDA MPS filling the idle GPU](../_static/image/same-gpu-dp-mps.svg)
+
 ## Deploy
 
 The steps below are one continuous flow. We provide `examples/mps_dp/launch.sh` to manage the private MPS daemon and serving replicas for one run. It records replica processes, ports, and logs, starts replicas sequentially, verifies their KV capacity and MPS attachment, and tears down only the run it recorded. Detailed instructions are as follows:
@@ -34,6 +36,8 @@ The command above is the validated H100 Higgs DP3 recipe. The launcher uses thre
 The example leaves `--mem-fraction-static` unset and uses the model's existing default. Launching replicas sequentially avoids overlapping memory profiling and CUDA-graph capture during startup.
 
 Identical `--mem-fraction-static` flags do **not** mean identical KV capacity. `--mem-fraction-static` budgets model weights and the KV pool against the GPU memory available when each replica starts. Roughly, the profiled KV memory is the requested fraction of free memory measured before model loading, minus model and fixed runtime allocations. It is a per-replica budget, not an additive share of the card. Because replicas start sequentially, earlier ones have already reserved memory, so later ones see a smaller free pool and allocate fewer KV tokens even when every flag is the same (in one run, three sequential `mf=0.27` replicas received 97,503 / 53,149 / 20,961 KV tokens).
+
+![What same-GPU DP spends in VRAM and what it reclaims](../_static/image/same-gpu-dp-vram.svg)
 
 Memory profiling does not coordinate KV allocation across independent replica processes. For `N > 1`, the launcher therefore requires one common `MAX_TOTAL_TOKENS` value and passes it to every replica as `--max-total-tokens`. SGLang treats this value as an upper bound; the launcher rejects startup unless every replica resolves exactly that capacity. The cap is independent of the request-level `max_new_tokens` limit and does not distribute requests between replicas.
 
@@ -77,6 +81,8 @@ These commands and the token cap are from an 80 GB H100 with Higgs and are not f
 
 This recipe grew out of the serving profiling in [#907](https://github.com/sgl-project/sglang-omni/issues/907). Our profiling found substantial unused GPU capacity across several omni serving workloads, with strong host-dispatch-bound evidence in the tested ASR setup. From there we ran same-GPU DP experiments on [Higgs](https://sgl-project.github.io/sglang-omni/cookbook/higgs_tts.html) and [Moss](https://sgl-project.github.io/sglang-omni/cookbook/moss_tts_local.html) TTS models.
 
+![The bottleneck is host-side dispatch, not GPU compute](../_static/image/same-gpu-dp-host-bound.svg)
+
 | Experiment | GPU signal | Controlled observation | Result | Interpretation |
 |---|---|---|---|---|
 | ASR single replica | GPU timeline 94.3% idle | throughput 0.90x at SM clock 0.455x; 0.31x at host CPU near 0.25x | sensitive to CPU, not to GPU compute | strong host-dispatch-bound causal evidence in this ASR setup |
@@ -85,6 +91,16 @@ This recipe grew out of the serving profiling in [#907](https://github.com/sgl-p
 | Higgs DP with MPS | see the pinned case study in Evaluate | each replica saturated, MPS attachment confirmed | 1.4 to 2.1x nominal, repeated | MPS-enabled saturated runs produced the largest gains observed in the later pinned tests. |
 
 ASR is the strongest host-bound evidence. Higgs started as a gray zone but clearly leaves GPU headroom at a tuned single replica. Running several replicas as separate processes changes host execution, scheduling, and long-tail behavior, and it is not the same as enlarging one replica's batch. Without MPS the CUDA contexts mostly time-slice and recover only part of the idle; MPS lets kernels from different processes run concurrently when resources permit, and the later MPS-enabled saturated runs produced the largest gains observed in the pinned tests.
+
+## Common questions
+
+**Throughput has plateaued, so why is the GPU still idle?**
+
+Serving throughput depends on more than the GPU's peak compute. It also depends on how much parallel work a single replica exposes per step, how fast the host side handles scheduling and stage handoffs, and the request-length and batching distribution. A single Higgs replica can have a full request queue and still sit at about 29% SM Active; adding a second independent replica improves GPU idle and throughput together. So one process's serving path is not keeping the card fed, but the cause is not a single CPU function: multiple host execution paths, batching behavior, and a latency-bounded decode shape can all contribute.
+
+**Replicating the weights costs VRAM. What does that buy?**
+
+Same-GPU DP does not save VRAM; it spends more of it. It copies the weights per replica and gives each replica its own, smaller KV pool. What it buys is the otherwise idle compute, reclaimed. That trade pays off only when a tuned single replica leaves the GPU idle (so there are idle SMs to fill) and the model is small enough that its weights are a modest slice of the card, so two or three full replicas still fit. On a compute-bound model, or one too large to hold several weight copies, extra replicas buy little.
 
 ## Reproduce the results
 


### PR DESCRIPTION
## What

Follow-up to the same-GPU DP + CUDA MPS guide (merged in #986). Docs-only: adds three explanatory figures and a short **Common questions** section to `docs/basic_usage/same_gpu_dp.md`.

## Changes

* Three SVG concept figures under `docs/_static/image/`, embedded in the guide:
  * `same-gpu-dp-host-bound.svg`: the bottleneck is host-side dispatch, not GPU compute (the causal test and the idle-between-kernels timeline).
  * `same-gpu-dp-mps.svg`: several independent host chains plus CUDA MPS co-residing their kernels to fill the otherwise idle GPU.
  * `same-gpu-dp-vram.svg`: what same-GPU DP spends in VRAM (weights per replica, split KV pool) versus what it reclaims (idle compute).
* A **Common questions** section answering two questions the guide did not address directly: why a server that has plateaued on throughput can still leave the GPU idle, and what replicating the weights actually buys from a VRAM perspective.

## Notes

Figures use the measured pinned H100 / Higgs values already in the guide; no numbers or claims are changed. This only adds visuals and two conceptual Q&A. Sphinx build passes with no new warnings.
