### PR TITLE
[MOSS-TTS Local] Fix split topology and batch stream transport

### DIFF
--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -24,9 +24,14 @@ _COLOCATED_CODEC_MEM_RESERVE = 0.15
 _AR_MEM_FRACTION_STATIC = 0.85
 _REF_AUDIO_CACHE_MAX_ITEMS = 8192
 _REF_AUDIO_CACHE_MAX_BYTES = 64 * 1024 * 1024
+_DEFAULT_STREAM_CHUNK_FRAMES = 25
+_DEFAULT_INITIAL_CHUNK_FRAMES = 1
 
 
 def _stages(*, codec_device: str, colocated: bool) -> list[StageConfig]:
+    codec_process = "pipeline" if colocated else "codec"
+    tts_engine_process = "pipeline" if colocated else "tts_engine"
+    codec_gpu = 0 if colocated else 1
     tts_engine_runtime = StageRuntimeConfig(
         resources=StageResourceConfig(
             total_gpu_memory_fraction=(
@@ -37,22 +42,29 @@ def _stages(*, codec_device: str, colocated: bool) -> list[StageConfig]:
             mem_fraction_static=None if colocated else _AR_MEM_FRACTION_STATIC
         ),
     )
-    tts_engine_args: dict[str, Any] = {"dtype": "bfloat16"}
+    tts_engine_args: dict[str, Any] = {
+        "dtype": "bfloat16",
+        "stream_chunk_frames": _DEFAULT_STREAM_CHUNK_FRAMES,
+        "initial_chunk_frames": _DEFAULT_INITIAL_CHUNK_FRAMES,
+    }
+    preprocessing_args: dict[str, Any] = {"device": codec_device}
     if colocated:
         tts_engine_args["codec_mem_reserve"] = _COLOCATED_CODEC_MEM_RESERVE
+    else:
+        preprocessing_args["inline_prepared_request"] = True
 
     return [
         StageConfig(
             name="preprocessing",
-            process="pipeline",
+            process=codec_process,
             factory=f"{_PKG}.stages.create_preprocessing_executor",
-            factory_args={"device": codec_device},
-            gpu=0,
+            factory_args=preprocessing_args,
+            gpu=codec_gpu,
             next="tts_engine",
         ),
         StageConfig(
             name="tts_engine",
-            process="pipeline",
+            process=tts_engine_process,
             factory=f"{_PKG}.stages.create_sglang_tts_engine_executor",
             factory_args=tts_engine_args,
             runtime=tts_engine_runtime,
@@ -62,10 +74,14 @@ def _stages(*, codec_device: str, colocated: bool) -> list[StageConfig]:
         ),
         StageConfig(
             name="vocoder",
-            process="pipeline",
+            process=codec_process,
             factory=f"{_PKG}.stages.create_vocoder_executor",
-            factory_args={"device": codec_device},
-            gpu=0,
+            factory_args={
+                "device": codec_device,
+                "stream_chunk_frames": _DEFAULT_STREAM_CHUNK_FRAMES,
+                "initial_chunk_frames": _DEFAULT_INITIAL_CHUNK_FRAMES,
+            },
+            gpu=codec_gpu,
             terminal=True,
             can_accept_stream_before_payload=True,
         ),
@@ -153,6 +169,31 @@ class MossTTSLocalPipelineConfig(PipelineConfig):
                 stage.factory_args.setdefault(
                     "cuda_graph_min_free_gb", self.cuda_graph_min_free_gb
                 )
+        vocoder = next(
+            (
+                stage
+                for stage in self.stages
+                if stage.factory.endswith("create_vocoder_executor")
+            ),
+            None,
+        )
+        tts_engine = next(
+            (
+                stage
+                for stage in self.stages
+                if stage.factory.endswith("create_sglang_tts_engine_executor")
+            ),
+            None,
+        )
+        if vocoder is not None and tts_engine is not None:
+            stream_chunk_frames = vocoder.factory_args.setdefault(
+                "stream_chunk_frames", _DEFAULT_STREAM_CHUNK_FRAMES
+            )
+            initial_chunk_frames = vocoder.factory_args.setdefault(
+                "initial_chunk_frames", _DEFAULT_INITIAL_CHUNK_FRAMES
+            )
+            tts_engine.factory_args["stream_chunk_frames"] = stream_chunk_frames
+            tts_engine.factory_args["initial_chunk_frames"] = initial_chunk_frames
 
     def supports_uploaded_voice_references(self) -> bool:
         return True
@@ -167,7 +208,7 @@ class MossTTSLocalColocatedPipelineConfig(MossTTSLocalPipelineConfig):
 
 
 class MossTTSLocalSplitPipelineConfig(MossTTSLocalPipelineConfig):
-    """Two-GPU variant that places codec work on the second visible GPU."""
+    """Two-process variant that places codec work on the second visible GPU."""
 
     stages: list[StageConfig] = Field(
         default_factory=lambda: _stages(codec_device="cuda:1", colocated=False)

--- a/sglang_omni/models/moss_tts_local/engine_builder.py
+++ b/sglang_omni/models/moss_tts_local/engine_builder.py
@@ -23,11 +23,15 @@ class MossTtsLocalEngineBuilder(TtsEngineBuilder):
         async_decode_min_batch_size: int,
         total_gpu_memory_fraction: float | None,
         codec_mem_reserve: float,
+        stream_chunk_frames: int = 25,
+        initial_chunk_frames: int = 1,
     ) -> None:
         self.enable_async_decode = enable_async_decode
         self.async_decode_min_batch_size = async_decode_min_batch_size
         self.total_gpu_memory_fraction = total_gpu_memory_fraction
         self.codec_mem_reserve = codec_mem_reserve
+        self.stream_chunk_frames = int(stream_chunk_frames)
+        self.initial_chunk_frames = int(initial_chunk_frames)
         self.memory_budget = moss_local_stages._ArMemoryBudget(
             effective_total_gpu_memory_fraction=None,
             applied_codec_mem_reserve=0.0,
@@ -123,7 +127,12 @@ class MossTtsLocalEngineBuilder(TtsEngineBuilder):
             "sglang_omni.models.moss_tts_local.model_runner"
         )
 
-        return model_runner_mod.MossTTSLocalModelRunner(model_worker, output_proc)
+        return model_runner_mod.MossTTSLocalModelRunner(
+            model_worker,
+            output_proc,
+            stream_chunk_frames=self.stream_chunk_frames,
+            initial_chunk_frames=self.initial_chunk_frames,
+        )
 
     def make_adapters(self, model: Any) -> tuple[Any, Any]:
         return request_builders.make_moss_tts_local_scheduler_adapters(model=model)

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -12,6 +12,10 @@ from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
 from sglang_omni.models.moss_tts_local.radix_hash import gpu_radix_row_hash
 from sglang_omni.models.moss_tts_local.state_pool import MossTTSLocalDecodeJournal
 from sglang_omni.scheduling.messages import OutgoingMessage
+from sglang_omni.scheduling.streaming_vocoder import (
+    INITIAL_CODEC_CHUNK_FRAMES_PARAM,
+    resolve_initial_codec_chunk_frames,
+)
 from sglang_omni.scheduling.types import RequestOutput
 
 
@@ -28,11 +32,28 @@ class MossTTSLocalModelRunner(ModelRunner):
 
     _outbox: Any | None = None
     _vocoder_target = "vocoder"
+    _stream_chunk_frames = 25
+    _default_initial_chunk_frames = 1
 
-    def __init__(self, tp_worker: Any, output_processor: Any):
+    def __init__(
+        self,
+        tp_worker: Any,
+        output_processor: Any,
+        *,
+        stream_chunk_frames: int = 25,
+        initial_chunk_frames: int = 1,
+    ):
         super().__init__(tp_worker, output_processor)
         self._outbox: Any | None = None
         self._vocoder_target = "vocoder"
+        if stream_chunk_frames < 1:
+            raise ValueError(
+                f"stream_chunk_frames must be >= 1, got {stream_chunk_frames}"
+            )
+        self._stream_chunk_frames = int(stream_chunk_frames)
+        self._default_initial_chunk_frames = max(
+            0, min(int(initial_chunk_frames), self._stream_chunk_frames)
+        )
 
     def set_stream_outbox(self, outbox: Any) -> None:
         self._outbox = outbox
@@ -619,7 +640,7 @@ class MossTTSLocalModelRunner(ModelRunner):
                 "MOSS-TTS Local journal/batch alignment broken: "
                 f"{journal.rids} != {expected_rids}"
             )
-        rows_cpu: torch.Tensor | None = None
+        stream_flushes: list[tuple[str, Any, list[torch.Tensor]]] = []
         for i, sched_req in enumerate(expected_reqs):
             # Overrun: a request finished or retracted in a PRIOR step is still
             # in this lagged resolve batch; its wasted frame must not reach
@@ -635,9 +656,17 @@ class MossTTSLocalModelRunner(ModelRunner):
                 except AttributeError:
                     is_retracted = False
                 if (callable(finished_fn) and finished_fn()) or bool(is_retracted):
+                    pending_rows = getattr(sched_req.data, "stream_pending_rows", None)
+                    if pending_rows:
+                        pending_rows.clear()
                     continue
             req_output = outputs[sched_req.request_id]
             if req_output.data is None or int(req_output.data) == end_id:
+                pending_rows = getattr(sched_req.data, "stream_pending_rows", None)
+                if pending_rows and self._outbox is not None:
+                    stream_flushes.append(
+                        (sched_req.request_id, sched_req.data, list(pending_rows))
+                    )
                 continue
             sched_req.data.output_rows.append(journal.rows[i])
             stream_metadata = getattr(sched_req.data, "stream_metadata", None)
@@ -645,15 +674,54 @@ class MossTTSLocalModelRunner(ModelRunner):
                 continue
             if self._outbox is None:
                 continue
-            if rows_cpu is None:
-                # One D2H per step regardless of how many requests stream.
-                rows_cpu = journal.rows.detach().to("cpu", torch.long)
+            pending_rows = sched_req.data.stream_pending_rows
+            pending_rows.append(journal.rows[i])
+            if len(pending_rows) >= self._stream_flush_threshold(sched_req.data):
+                stream_flushes.append(
+                    (sched_req.request_id, sched_req.data, list(pending_rows))
+                )
+
+        self._flush_stream_rows(stream_flushes)
+
+    def _stream_flush_threshold(self, data: Any) -> int:
+        if data.stream_first_chunk_sent:
+            return self._stream_chunk_frames
+        metadata = data.stream_metadata
+        if metadata.get(INITIAL_CODEC_CHUNK_FRAMES_PARAM) is not None:
+            initial_frames = resolve_initial_codec_chunk_frames(
+                metadata,
+                steady_chunk_frames=self._stream_chunk_frames,
+            )
+        else:
+            initial_frames = self._default_initial_chunk_frames
+        return initial_frames or self._stream_chunk_frames
+
+    def _flush_stream_rows(
+        self, flushes: list[tuple[str, Any, list[torch.Tensor]]]
+    ) -> None:
+        if not flushes or self._outbox is None:
+            return
+        lengths = [len(rows) for _, _, rows in flushes]
+        rows_cpu = (
+            torch.stack(
+                [row for _, _, rows in flushes for row in rows],
+                dim=0,
+            )
+            .detach()
+            .to("cpu", torch.long)
+        )
+        offset = 0
+        for (request_id, data, _), length in zip(flushes, lengths):
+            chunk = rows_cpu[offset : offset + length]
+            offset += length
+            data.stream_pending_rows.clear()
+            data.stream_first_chunk_sent = True
             self._outbox.put(
                 OutgoingMessage(
-                    request_id=sched_req.request_id,
+                    request_id=request_id,
                     type="stream",
                     target=self._vocoder_target,
-                    data=rows_cpu[i].clone(),
-                    metadata=stream_metadata,
+                    data=chunk,
+                    metadata=data.stream_metadata,
                 )
             )

--- a/sglang_omni/models/moss_tts_local/request_builders.py
+++ b/sglang_omni/models/moss_tts_local/request_builders.py
@@ -62,6 +62,8 @@ class MossTTSLocalSGLangRequestData(ARRequestData):
     sampling_seed: int = field(default_factory=_new_moss_tts_sampling_seed)
     engine_start_s: float = 0.0
     stream_metadata: dict[str, Any] | None = None
+    stream_pending_rows: list[torch.Tensor] = field(default_factory=list)
+    stream_first_chunk_sent: bool = False
 
 
 @dataclass
@@ -110,6 +112,29 @@ def pop_prepared_moss_tts_local_request(
     marker = data.get(_MOSS_TTS_LOCAL_PREPARED_MARKER)
     if marker is None:
         return None
+    if isinstance(marker, dict):
+        input_ids_list = marker.get("input_ids_list")
+        prompt_rows = marker.get("prompt_rows")
+        if (
+            str(marker.get("request_id")) != str(payload.request_id)
+            or not isinstance(input_ids_list, list)
+            or not isinstance(prompt_rows, torch.Tensor)
+            or prompt_rows.ndim != 2
+            or len(input_ids_list) != int(prompt_rows.shape[0])
+        ):
+            raise RuntimeError(
+                "MOSS-TTS Local inline preprocessing state is invalid for "
+                f"payload {payload.request_id!r}"
+            )
+        state = MossTTSLocalState.from_dict(data)
+        normalized_ids = [int(token_id) for token_id in input_ids_list]
+        return MossTTSLocalPreparedRequest(
+            state=state,
+            input_ids_list=normalized_ids,
+            input_ids=torch.tensor(normalized_ids, dtype=torch.long),
+            prompt_rows=prompt_rows.to(dtype=torch.long, device="cpu"),
+            gen_kwargs=dict(state.generation_kwargs),
+        )
     prepared = _QUEUE.pop(str(marker))
     if prepared is None:
         raise RuntimeError(
@@ -273,7 +298,9 @@ def _prepare_moss_tts_local_request(
     )
 
 
-def preprocess_moss_tts_local_payload(payload: StagePayload) -> StagePayload:
+def preprocess_moss_tts_local_payload(
+    payload: StagePayload, *, inline_prepared_request: bool = False
+) -> StagePayload:
     """Run prompt/reference preprocessing outside the AR scheduler."""
 
     rid = str(payload.request_id)
@@ -300,7 +327,16 @@ def preprocess_moss_tts_local_payload(payload: StagePayload) -> StagePayload:
 
     data = prepared.state.to_dict()
     if published:
-        data[_MOSS_TTS_LOCAL_PREPARED_MARKER] = payload.request_id
+        if inline_prepared_request:
+            prepared = _QUEUE.pop(rid)
+            if prepared is not None:
+                data[_MOSS_TTS_LOCAL_PREPARED_MARKER] = {
+                    "request_id": payload.request_id,
+                    "input_ids_list": prepared.input_ids_list,
+                    "prompt_rows": prepared.prompt_rows,
+                }
+        else:
+            data[_MOSS_TTS_LOCAL_PREPARED_MARKER] = payload.request_id
     return StagePayload(
         request_id=payload.request_id, request=payload.request, data=data
     )

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -11,6 +11,7 @@ import os
 import queue
 import threading
 from dataclasses import dataclass
+from functools import partial
 from typing import Any, TypeAlias
 
 import torch
@@ -506,6 +507,7 @@ def create_preprocessing_executor(
     ref_audio_cache: bool = True,
     ref_audio_cache_max_items: int = 8192,
     ref_audio_cache_max_bytes: int = 64 * 1024 * 1024,
+    inline_prepared_request: bool = False,
 ) -> SimpleScheduler:
     # MOSS_REF_AUDIO_CACHE=0 disables the cache at startup (ops kill switch / A-B
     # toggle) without a config edit; unset => kwarg/config default.
@@ -544,7 +546,10 @@ def create_preprocessing_executor(
     # unlike MOSS Delay the audio tokenizer must live on the GPU; threads
     # release the GIL during the codec forward, keeping the AR engine fed.
     return SimpleScheduler(
-        preprocess_moss_tts_local_payload,
+        partial(
+            preprocess_moss_tts_local_payload,
+            inline_prepared_request=inline_prepared_request,
+        ),
         abort_callback=cleanup_prepared_moss_tts_local_request,
         max_concurrency=max_concurrency,
     )
@@ -561,6 +566,8 @@ def create_sglang_tts_engine_executor(
     async_decode_min_batch_size: int = 2,
     total_gpu_memory_fraction: float | None = None,
     codec_mem_reserve: float = 0.0,
+    stream_chunk_frames: int = 25,
+    initial_chunk_frames: int = 1,
 ) -> Any:
     from sglang_omni.models.moss_tts_local.engine_builder import (
         MossTtsLocalEngineBuilder,
@@ -571,6 +578,8 @@ def create_sglang_tts_engine_executor(
         async_decode_min_batch_size=async_decode_min_batch_size,
         total_gpu_memory_fraction=total_gpu_memory_fraction,
         codec_mem_reserve=codec_mem_reserve,
+        stream_chunk_frames=stream_chunk_frames,
+        initial_chunk_frames=initial_chunk_frames,
     ).build(
         model_path,
         device=device,

--- a/sglang_omni/models/moss_tts_local/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts_local/streaming_vocoder.py
@@ -411,19 +411,24 @@ class MossTTSLocalStreamingVocoderScheduler(
         del request_id
         codes = codes.to(dtype=torch.long)
         n_vq = state.n_vq if state.n_vq is not None else self._n_vq
-        if codes.ndim != 1 or int(codes.shape[0]) < n_vq + 1:
-            raise ValueError(
-                f"MOSS-TTS Local stream chunk must be a 1-D row with at least "
-                f"{n_vq + 1} channels (text + codes), got {tuple(codes.shape)}"
-            )
-        # Row layout matches output_rows: [text_token, code_0, ..., code_{n_vq-1}].
-        return codes[1 : 1 + n_vq]
+        if codes.ndim == 1 and int(codes.shape[0]) >= n_vq + 1:
+            return codes[1 : 1 + n_vq]
+        if codes.ndim == 2 and int(codes.shape[1]) >= n_vq + 1:
+            return codes[:, 1 : 1 + n_vq]
+        raise ValueError(
+            "MOSS-TTS Local stream chunk must be a row or row batch with "
+            f"at least {n_vq + 1} channels (text + codes), got "
+            f"{tuple(codes.shape)}"
+        )
 
     def ingest(
         self, request_id: str, state: _LocalStreamState, codes: torch.Tensor
     ) -> None:
         del request_id
-        state.pending.append(codes)
+        if codes.ndim == 1:
+            state.pending.append(codes)
+        else:
+            state.pending.extend(codes.unbind(0))
         self._ensure_slot(state)
 
     def decode_delta(

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import queue
 import struct
 import sys
 import types
@@ -404,9 +405,13 @@ def test_pipeline_stage_wiring():
     assert tts_engine_runtime.resources.total_gpu_memory_fraction == pytest.approx(0.90)
     assert tts_engine_runtime.sglang_server_args.mem_fraction_static is None
     assert stages["tts_engine"].factory_args["codec_mem_reserve"] == pytest.approx(0.15)
+    assert stages["tts_engine"].factory_args["stream_chunk_frames"] == 25
+    assert stages["tts_engine"].factory_args["initial_chunk_frames"] == 1
     assert stages["vocoder"].process == "pipeline"
     assert stages["vocoder"].gpu == 0
     assert stages["vocoder"].factory_args["device"] == "cuda:0"
+    assert stages["vocoder"].factory_args["stream_chunk_frames"] == 25
+    assert stages["vocoder"].factory_args["initial_chunk_frames"] == 1
 
     placement = build_stage_placement_plan(config)
     assert placement.stages["tts_engine"].gpu_ids == (0,)
@@ -426,12 +431,36 @@ def test_pipeline_stage_wiring():
 
     split = MossTTSLocalSplitPipelineConfig(model_path="OpenMOSS-Team/moss-local-test")
     split_stages = {stage.name: stage for stage in split.stages}
+    assert split_stages["preprocessing"].process == "codec"
+    assert split_stages["preprocessing"].gpu == 1
     assert split_stages["preprocessing"].factory_args["device"] == "cuda:1"
+    assert split_stages["preprocessing"].factory_args["inline_prepared_request"]
+    assert split_stages["tts_engine"].process == "tts_engine"
     assert split_stages["tts_engine"].gpu == 0
     split_runtime = split_stages["tts_engine"].runtime
     assert split_runtime.resources.total_gpu_memory_fraction is None
     assert split_runtime.sglang_server_args.mem_fraction_static == pytest.approx(0.85)
+    assert split_stages["vocoder"].process == "codec"
+    assert split_stages["vocoder"].gpu == 1
     assert split_stages["vocoder"].factory_args["device"] == "cuda:1"
+
+
+def test_pipeline_config_syncs_stream_transport_with_vocoder_chunks():
+    stages = MossTTSLocalPipelineConfig(
+        model_path="OpenMOSS-Team/moss-local-test"
+    ).stages
+    vocoder = next(stage for stage in stages if stage.name == "vocoder")
+    vocoder.factory_args["stream_chunk_frames"] = 7
+    vocoder.factory_args["initial_chunk_frames"] = 3
+
+    config = MossTTSLocalPipelineConfig(
+        model_path="OpenMOSS-Team/moss-local-test",
+        stages=stages,
+    )
+    configured = {stage.name: stage for stage in config.stages}
+
+    assert configured["tts_engine"].factory_args["stream_chunk_frames"] == 7
+    assert configured["tts_engine"].factory_args["initial_chunk_frames"] == 3
 
 
 def test_pipeline_config_injects_reference_cache_factory_args():
@@ -877,6 +906,30 @@ def test_preprocess_and_result_adapter():
         assert result.data["prompt_tokens"] == prepared.prompt_rows.shape[0]
     finally:
         clear_moss_tts_local_preprocessing_context()
+
+
+def test_inline_preprocessing_handoff_survives_process_boundary():
+    from sglang_omni.models.moss_tts_local.request_builders import (
+        pop_prepared_moss_tts_local_request,
+    )
+
+    set_moss_tts_local_preprocessing_context(processor=_FakeProcessor())
+    payload = preprocess_moss_tts_local_payload(
+        _payload(), inline_prepared_request=True
+    )
+    marker = payload.data["_moss_tts_local_prepared_request"]
+    assert isinstance(marker, dict)
+
+    # An AR worker in another process has an empty process-local handoff queue.
+    clear_moss_tts_local_preprocessing_context()
+    prepared = pop_prepared_moss_tts_local_request(payload)
+
+    assert prepared is not None
+    assert prepared.input_ids.device.type == "cpu"
+    assert prepared.prompt_rows.device.type == "cpu"
+    assert prepared.input_ids_list == prepared.input_ids.tolist()
+    assert len(prepared.input_ids_list) == prepared.prompt_rows.shape[0]
+    assert prepared.state.text == "hello"
 
 
 def test_result_adapter_empty_generation():
@@ -1664,6 +1717,84 @@ def test_post_process_outputs_skips_chunked_rows():
 
     assert req_a.data.output_rows == [], "chunked row must not be appended"
     assert len(req_b.data.output_rows) == 1, "normal row must be appended"
+
+
+def test_post_process_batches_stream_rows_on_vocoder_boundaries():
+    pytest.importorskip("sglang")
+
+    from sglang_omni.models.moss_tts_local.model_runner import MossTTSLocalModelRunner
+    from sglang_omni.models.moss_tts_local.state_pool import MossTTSLocalDecodeJournal
+
+    runner = MossTTSLocalModelRunner.__new__(MossTTSLocalModelRunner)
+    runner.model = types.SimpleNamespace(
+        config=types.SimpleNamespace(audio_end_token_id=151670)
+    )
+    runner._outbox = queue.Queue()
+    runner._vocoder_target = "vocoder"
+    runner._stream_chunk_frames = 3
+    runner._default_initial_chunk_frames = 2
+
+    data = types.SimpleNamespace(
+        req=types.SimpleNamespace(
+            is_chunked=0,
+            is_retracted=False,
+            finished=lambda: False,
+        ),
+        output_rows=[],
+        stream_metadata={
+            "stream": True,
+            "initial_codec_chunk_frames": 1,
+        },
+        stream_pending_rows=[],
+        stream_first_chunk_sent=False,
+    )
+    sched_req = types.SimpleNamespace(request_id="rid", data=data)
+    sched_output = types.SimpleNamespace(requests=[sched_req])
+
+    def resolve_step(step: int, token: int = 1000) -> torch.Tensor:
+        row = torch.arange(N_VQ + 1, dtype=torch.long) + step * 100
+        result = types.SimpleNamespace(
+            moss_journal=MossTTSLocalDecodeJournal(
+                rids=["rid"], pool_rows=[0], rows=row.unsqueeze(0)
+            )
+        )
+        runner.post_process_outputs(
+            result,
+            sched_output,
+            {"rid": types.SimpleNamespace(data=token)},
+        )
+        return row
+
+    first = resolve_step(1)
+    first_message = runner._outbox.get_nowait()
+    assert first_message.request_id == "rid"
+    assert first_message.target == "vocoder"
+    assert first_message.data.shape == (1, N_VQ + 1)
+    torch.testing.assert_close(first_message.data, first.unsqueeze(0))
+
+    followup = [resolve_step(step) for step in (2, 3)]
+    with pytest.raises(queue.Empty):
+        runner._outbox.get_nowait()
+    followup.append(resolve_step(4))
+    followup_message = runner._outbox.get_nowait()
+    assert followup_message.data.shape == (3, N_VQ + 1)
+    torch.testing.assert_close(followup_message.data, torch.stack(followup))
+
+    tail = resolve_step(5)
+    with pytest.raises(queue.Empty):
+        runner._outbox.get_nowait()
+    resolve_step(6, token=151670)
+    tail_message = runner._outbox.get_nowait()
+    assert tail_message.data.shape == (1, N_VQ + 1)
+    torch.testing.assert_close(tail_message.data, tail.unsqueeze(0))
+    assert len(data.output_rows) == 5
+    assert data.stream_pending_rows == []
+
+    data.stream_first_chunk_sent = False
+    data.stream_metadata = {"stream": True, "initial_codec_chunk_frames": 0}
+    assert runner._stream_flush_threshold(data) == 3
+    data.stream_metadata = {"stream": True}
+    assert runner._stream_flush_threshold(data) == 2
 
 
 def test_finalize_skip_rids_selects_chunked_rows():

--- a/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
+++ b/tests/unit_test/moss_tts_local/test_streaming_vocoder.py
@@ -309,6 +309,24 @@ def _run_stream(
     return _drain(scheduler)
 
 
+def test_stream_accepts_batched_code_rows(monkeypatch) -> None:
+    processor = FakeProcessor()
+    scheduler = _make_scheduler(monkeypatch, processor, stream_chunk_frames=10)
+    rows = _rows(23, seed=17)
+    metadata = _metadata()
+
+    for chunk_id, chunk in enumerate((rows[:1], rows[1:11], rows[11:])):
+        scheduler._on_chunk("req", _stream_item(chunk, metadata, chunk_id))
+    scheduler._on_done("req")
+    scheduler._on_streaming_new_request("req", _terminal_payload(rows))
+
+    messages = _drain(scheduler)
+    np.testing.assert_array_equal(
+        _concat_stream_audio(messages, "req"),
+        reference_waveform(rows[:, 1:]).numpy(),
+    )
+
+
 def _decode_audio(data: dict[str, Any]) -> np.ndarray:
     assert data["audio_waveform_dtype"] == "float32"
     array = np.frombuffer(data["audio_waveform"], dtype=np.float32)


### PR DESCRIPTION
## Motivation

The existing `split` variant assigned codec work to `cuda:1`, but all three stages still shared the `pipeline` process. In practice, one process initialized the AR engine on GPU 0 and then the codec/vocoder on GPU 1; vocoder CUDA graph capture failed. Simply separating the stages also did not work because the prepared-request handoff used a process-local queue.

The streaming path had a second bottleneck: the AR runner copied and relayed one code row per decode step. Consumer-side coalescing from #892 can combine chunks that are already queued, but it cannot remove those producer-side D2H copies and relay messages.

## What this PR changes

- Make `MossTTSLocalSplitPipelineConfig` a real two-process topology:
  - `tts_engine` on GPU 0
  - `preprocessing` and `vocoder` in a codec process on GPU 1
- Carry the small CPU prepared-request state through `StagePayload` only for the cross-process variant; the default colocated path keeps the existing process-local handoff.
- Buffer generated code rows on the AR GPU and flush at the vocoder's decode boundaries:
  - first flush follows `initial_codec_chunk_frames`
  - steady-state flush follows `stream_chunk_frames`
  - EOS force-flushes the tail
- Flatten all requests due in the same scheduler step into one `torch.stack` and one D2H copy, then relay 2-D `[frames, channels]` chunks.
- Accept both legacy 1-D rows and new 2-D row batches in the MOSS-TTS Local streaming vocoder.

The default single-GPU topology and public API are unchanged; this adds no new flag.

## Why this is different from #892

#892 drains already-arrived messages in the vocoder inbox before pumping the codec. This PR reduces how many messages and D2H copies the producer creates in the first place. The two optimizations compose.

For 16 requests at concurrency 8, AR-to-vocoder stream messages dropped from **698 to 53 (-92.4%)**.

## Performance

Environment: 2x NVIDIA H200 for the split variant, streaming voice cloning, MOSS-TTS-Local-Transformer-v1.5, `token_count=auto`.

### Isolated batching delta on the same two-GPU split topology

| Workload | Split before | This PR | QPS | Mean latency | TTFC | RTF |
|---|---:|---:|---:|---:|---:|---:|
| c8, 64 requests | 7.771 | 8.282 | **+6.6%** | **-6.7%** | **-10.7%** | **-6.6%** |
| c16, 64 requests | 7.047 | 8.594 | **+22.0%** | **-18.8%** | **-18.1%** | **-19.2%** |

At c16, mean codec-GPU utilization rose from **55.0% to 69.5%** (p95 89.5%, max 93%). Three additional treatment repeats measured **8.692 / 9.019 / 8.818 QPS**, all with zero failures.

### Full SeedTTS EN scale-up comparison

This comparison intentionally measures the user-visible scale-up path: main's default 1x H200 topology versus this PR's 2x H200 split topology. It is not presented as a per-GPU efficiency comparison.

| Metric | main, 1x H200 | This PR, 2x H200 | Delta |
|---|---:|---:|---:|
| Requests | 1088/1088 | 1088/1088 | no failures |
| QPS | 5.889 | 8.436 | **+43.2%** |
| Mean latency | 2.705 s | 1.885 s | **-30.3%** |
| RTF | 0.6380 | 0.4514 | **-29.2%** |
| TTFC | 1.5576 s | 1.4094 s | **-9.5%** |

Both full runs used the same SeedTTS EN 1088 set, concurrency 16, streaming references, automatic duration tokens, and seed 42. The full A/B was collected on main `73905ed4`; the branch was subsequently rebased onto `1618b7ce`, whose intervening commits do not change the MOSS runtime. An exact latest-head smoke run completed 64/64 at c16 and measured **8.954 QPS**.

## Quality

One shared Qwen3-ASR-1.7B service transcribed both 1088-output sets:

| WER | main | This PR |
|---|---:|---:|
| Corpus WER | 1.968% | 2.110% |
| Corpus WER excluding >50% sample outliers | 1.622% | 1.641% |

The raw delta is +0.142 percentage points and is concentrated in two additional high-WER stochastic outliers; excluding the documented >50% outlier class, the delta is +0.020 points. All 1088 WAV formats matched; 1083/1088 shapes matched, with five stop-frame length differences expected from changed process/batch shapes under seeded sampling.

## Validation

- Rebased on `origin/main@1618b7ce`
- `pre-commit run --files ...`: all hooks passed
- `pytest tests/unit_test/moss_tts_local/test_pipeline.py tests/unit_test/moss_tts_local/test_streaming_vocoder.py tests/unit_test/moss_tts_local/test_state_pool.py -q`: **137 passed**
- Latest-head H200 E2E smoke: **64/64**, zero failures, **8.954 QPS** at c16

Related to #661. Conceptually orthogonal to the frame-decode kernel work in #762.
