### PR TITLE
[Perf] Isolate Fish S2-Pro reference encoding from GPU stages

### DIFF
--- a/sglang_omni/models/fishaudio_s2_pro/config.py
+++ b/sglang_omni/models/fishaudio_s2_pro/config.py
@@ -28,7 +28,7 @@ class S2ProPipelineConfig(PipelineConfig):
     stages: list[StageConfig] = [
         StageConfig(
             name="preprocessing",
-            process="pipeline",
+            process="preprocessing",
             factory=f"{_PKG}.stages.create_preprocessing_executor",
             next="tts_engine",
         ),

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -30,6 +30,27 @@ from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoi
 
 logger = logging.getLogger(__name__)
 
+_MAX_PREPROCESSING_INTRAOP_THREADS = 8
+
+
+def _configure_preprocessing_threads(worker_count: int) -> int:
+    if "OMP_NUM_THREADS" in os.environ:
+        return torch.get_num_threads()
+
+    cpu_count = (
+        len(os.sched_getaffinity(0))
+        if hasattr(os, "sched_getaffinity")
+        else (os.cpu_count() or 1)
+    )
+    # Requests already fan out across worker threads; bound the shared intra-op
+    # pool so reference encoding cannot starve the GPU pipeline process.
+    intraop_threads = min(
+        max(cpu_count // worker_count, 1),
+        _MAX_PREPROCESSING_INTRAOP_THREADS,
+    )
+    torch.set_num_threads(intraop_threads)
+    return intraop_threads
+
 
 def _compile_s2pro_codebook_decoder(model: Any, *, max_batch_size: int) -> None:
     """Compile Fast AR decoder layers while leaving sampling and loop control eager."""
@@ -216,6 +237,13 @@ def create_preprocessing_executor(
     """Returns a threaded scheduler for CPU-heavy preprocessing."""
     from sglang_omni.scheduling.threaded_simple_scheduler import ThreadedSimpleScheduler
 
+    worker_count = max(int(max_concurrency), 1)
+    intraop_threads = _configure_preprocessing_threads(worker_count)
+    logger.info(
+        "Fish preprocessing uses %d workers, %d shared intra-op threads",
+        worker_count,
+        intraop_threads,
+    )
     checkpoint_dir = _resolve_checkpoint(model_path)
 
     from transformers import PreTrainedTokenizerFast
@@ -285,7 +313,7 @@ def create_preprocessing_executor(
         )
         return store_state(payload, state)
 
-    return ThreadedSimpleScheduler(_preprocess, max_concurrency=max_concurrency)
+    return ThreadedSimpleScheduler(_preprocess, max_concurrency=worker_count)
 
 
 def create_sglang_tts_engine_executor(

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -53,6 +53,11 @@ def test_fish_config_state_and_tokenizer_prompt_contracts() -> None:
         "tts_engine",
         "vocoder",
     ]
+    assert [stage.process for stage in config.stages] == [
+        "preprocessing",
+        "pipeline",
+        "pipeline",
+    ]
     assert config.terminal_stages == ["vocoder"]
     assert config.gpu_placement == {"tts_engine": 0, "vocoder": 0}
     assert config.supports_uploaded_voice_references() is True
@@ -89,6 +94,49 @@ def test_fish_config_state_and_tokenizer_prompt_contracts() -> None:
     assert prompt["vq_mask_tokens"].sum().item() == 2
     assert torch.equal(prompt["vq_parts"][0], torch.tensor([[0, 1], [10, 11]]))
     assert any("<|speaker:alice|>target" in text for text in tokenizer.encoded_texts)
+
+
+@pytest.mark.parametrize(
+    "cpu_count,expected_intraop_threads",
+    [(4, 1), (32, 4), (224, 8)],
+)
+def test_fish_preprocessing_uses_bounded_cpu_threads(
+    monkeypatch: pytest.MonkeyPatch,
+    cpu_count: int,
+    expected_intraop_threads: int,
+) -> None:
+    stages = importlib.import_module("sglang_omni.models.fishaudio_s2_pro.stages")
+
+    monkeypatch.delenv("OMP_NUM_THREADS", raising=False)
+    monkeypatch.setattr(
+        stages.os,
+        "sched_getaffinity",
+        lambda _pid: set(range(cpu_count)),
+        raising=False,
+    )
+    configured_threads: list[int] = []
+    monkeypatch.setattr(stages.torch, "set_num_threads", configured_threads.append)
+
+    intraop_threads = stages._configure_preprocessing_threads(worker_count=8)
+
+    assert configured_threads == [expected_intraop_threads]
+    assert intraop_threads == expected_intraop_threads
+
+
+def test_fish_preprocessing_preserves_operator_thread_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stages = importlib.import_module("sglang_omni.models.fishaudio_s2_pro.stages")
+
+    monkeypatch.setenv("OMP_NUM_THREADS", "3")
+    monkeypatch.setattr(stages.torch, "get_num_threads", lambda: 3)
+    configured_threads: list[int] = []
+    monkeypatch.setattr(stages.torch, "set_num_threads", configured_threads.append)
+
+    intraop_threads = stages._configure_preprocessing_threads(worker_count=8)
+
+    assert configured_threads == []
+    assert intraop_threads == 3
 
 
 def test_fish_tts_request_and_result_adapters_preserve_tensor_contracts() -> None:


### PR DESCRIPTION
## Summary

- move Fish S2-Pro's CPU-only reference preprocessing into its own process
- bound the shared PyTorch intra-op pool from the process CPU affinity and the existing preprocessing concurrency
- preserve an explicit `OMP_NUM_THREADS` operator override
- keep `tts_engine` and `vocoder` colocated on the same GPU; no extra GPU or user-facing flag

## Motivation

The current topology runs CPU reference encoding in the same OS process as the GPU TTS engine and vocoder. With concurrent cold references, the CPU codec's native thread pool delays GPU scheduling instead of overlapping with it.

A stage trace on latest main showed:

| Stage | Mean | p95 |
| --- | ---: | ---: |
| preprocessing | 5.236 s | 7.460 s |
| tts_engine | 1.175 s | - |
| vocoder | 0.199 s | - |

Preprocessing accounted for 79.2% of measured stage residence, while scheduler queue p95 was only 31.6 ms. After isolation, preprocessing fell to 0.915 s mean / 1.248 s p95; the added preprocessing-to-TTS IPC hop was 12.9 ms mean / 29.1 ms p95.

## H200 benchmark

- base: `1618b7ce26f5ea464e849cfcd943c0e429a711a6`
- image: `hongccc/sglang-omni:dev`
- hardware: one H200, same GPU for main and this branch
- workload: 128 distinct SeedTTS voice-cloning references, streaming, `max_new_tokens=2048`, concurrency 16
- two 20-request warmups used a disjoint reference set, so the measured references were cold
- 128/128 requests completed with zero failures in both runs

| Metric | main | this PR | Delta |
| --- | ---: | ---: | ---: |
| QPS | 1.383 | 3.297 | **+138.4%** |
| Mean latency | 11.093 s | 4.724 s | **-57.4%** |
| Mean RTF | 2.7773 | 1.1624 | **-58.2%** |
| Mean TTFC | 9.8960 s | 2.9896 s | **-69.8%** |

At concurrency 8, a separate cold-reference run improved QPS from 1.363 to 2.883 (+111.5%).

### Warm-cache control

I repeated the same 128 references after populating the in-process cache. This checks that the extra process hop does not regress the common fixed-speaker path.

| Metric | main | this PR | Delta |
| --- | ---: | ---: | ---: |
| QPS | 4.674 | 4.669 | -0.1% |
| Mean latency | 3.313 s | 3.332 s | +0.6% |
| Mean RTF | 0.7980 | 0.8050 | +0.9% |
| Mean TTFC | 0.9350 s | 0.8978 s | -4.0% |

The warm-cache path is effectively unchanged.

## Resource tradeoffs

One-second `nvidia-smi dmon` samples during the cold c16 run showed GPU nonzero-SM duty cycle rising from 72.5% to 88.9%, and all-sample mean SM utilization from 50.9% to 55.1%. The optimization keeps the GPU fed rather than changing model compute.

The separate process costs about 2.0 GiB additional host RSS and increases total server threads from 700 to 808. Sampled peak GPU FB usage was about 2.1 GiB higher under the faster run, while model load, KV pool, and post-CUDA-graph available-memory logs were identical. A 4/8/28 intra-op thread sweep selected 8 as the best throughput/resource point; an explicit `OMP_NUM_THREADS` remains authoritative.

## Validation

- `pytest -q tests/unit_test/fishaudio_s2_pro` (63 passed)
- pre-commit on all three changed files
- cold-reference and warm-cache end-to-end SeedTTS A/B on the server described above