### PR TITLE
fix(client): correct GenerateRequest prompt type annotation

### DIFF
--- a/sglang_omni/client/types.py
+++ b/sglang_omni/client/types.py
@@ -84,7 +84,7 @@ class GenerateRequest:
 
     model: str | None = None
 
-    prompt: str | None = None
+    prompt: str | dict[str, Any] | None = None
     prompt_token_ids: list[int] | None = None
     messages: list[Message] | None = None
 


### PR DESCRIPTION

## Motivation

`GenerateRequest` is the shared client-level request model. Its `prompt` field is currently annotated as `str | None`, but existing entry points construct `GenerateRequest` with both text and structured dict payloads.

| API entry point | Populated `GenerateRequest` field | Actual `prompt` type |
| --- | --- | --- |
| `POST /v1/chat/completions` | `messages=[...]` | `None` |
| `POST /generate` with `messages` | `messages=[...]` | `None` |
| `POST /generate` with `input_ids` | `prompt_token_ids=[...]` | `None` |
| `POST /generate` with `prompt` | `prompt="<text>"` | `str` |
| `POST /v1/audio/speech` without references | `prompt="<text>"` | `str` |
| `POST /v1/audio/speech` with voice references | `prompt={"text": ..., "references": [...]}` | **`dict`** |
| `POST /v1/audio/transcriptions` | `prompt={"audio_bytes": ..., "filename": ..., "content_type": ...}` | **`dict`** |

The `/generate` endpoint intentionally continues to accept only a string `prompt`. The mismatch is at the shared client layer: reference-audio TTS and ASR transcription already use structured dict payloads.

`Client._extract_inputs()` already forwards `request.prompt` unchanged, so this is a type annotation correction rather than a runtime behavior change.

## Modifications

Widen `GenerateRequest.prompt` from `str | None` to `str | dict[str, Any] | None`.

This does not change runtime behavior or the public `/generate` API contract.
