### PR TITLE
feat(comm): port TensorRef support to the Phase-0 data plane

### DIFF
--- a/sglang_omni/comm/data_ref.py
+++ b/sglang_omni/comm/data_ref.py
@@ -17,6 +17,7 @@ class TransportKind(str, Enum):
 
 class DataKind(str, Enum):
     STAGE_PAYLOAD = "stage_payload"
+    TENSOR_REF = "tensor_ref"
     STREAM_CHUNK = "stream_chunk"
     STREAM_METADATA_TENSOR = "stream_metadata_tensor"
     KV_PAGES = "kv_pages"

--- a/sglang_omni/comm/engine.py
+++ b/sglang_omni/comm/engine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import uuid
 from contextlib import suppress
 from typing import Any, Callable
 
@@ -11,8 +12,9 @@ import msgspec
 import torch
 
 from sglang_omni.comm import stage_io
-from sglang_omni.comm.data_ref import DataRef, TransportKind
+from sglang_omni.comm.data_ref import DataKind, DataRef, TransportKind
 from sglang_omni.comm.router import CommRouter
+from sglang_omni.comm.tensor_ref import TensorRef
 from sglang_omni.profiler.comm_trace import elapsed_ms as _comm_elapsed_ms
 from sglang_omni.profiler.comm_trace import emit as _comm_trace
 from sglang_omni.profiler.comm_trace import now_ns as _comm_now_ns
@@ -169,6 +171,46 @@ class CommEngine:
         data_ref: DataRef,
     ) -> StagePayload:
         return await stage_io.read_payload(relay, request_id, data_ref)
+
+    async def publish_tensor_ref(
+        self,
+        *,
+        relay: Relay,
+        request_id: str,
+        tensor: torch.Tensor,
+        transport: TransportKind,
+        producer_stage: str,
+        consumer_stage: str,
+        path: str,
+    ) -> TensorRef:
+        object_id = (
+            f"{request_id}:tensor_ref:{producer_stage}:{consumer_stage}:"
+            f"{uuid.uuid4().hex}"
+        )
+        data_ref, op = await stage_io.write_tensor(
+            relay,
+            object_id,
+            tensor,
+            transport=transport,
+            kind=DataKind.TENSOR_REF,
+            request_id=request_id,
+            from_stage=producer_stage,
+            to_stage=consumer_stage,
+        )
+        self._register_pending(data_ref.object_id, [op])
+        self._arm_pending(data_ref.object_id)
+        return TensorRef(
+            request_id=request_id,
+            producer_stage=producer_stage,
+            consumer_stage=consumer_stage,
+            path=path,
+            nbytes=tensor.numel() * tensor.element_size(),
+            data_ref=data_ref,
+        )
+
+    async def read_tensor_ref(self, ref: TensorRef) -> torch.Tensor:
+        relay = self.relay(ref.data_ref.transport)
+        return await stage_io.read_tensor(relay, ref.data_ref)
 
     async def send_stream_chunk(
         self,

--- a/sglang_omni/comm/stage_io.py
+++ b/sglang_omni/comm/stage_io.py
@@ -175,24 +175,7 @@ def is_direct_cuda_ipc_payload_ref(value: Any) -> bool:
 
 
 def deserialize_direct_cuda_ipc_payload(data_ref: dict[str, Any]) -> StagePayload:
-    if data_ref.get("_type") != _DIRECT_CUDA_IPC_PAYLOAD_TYPE:
-        raise ValueError("data_ref is not a direct CUDA IPC payload")
-    if data_ref.get("version") != 1:
-        raise ValueError(
-            f"unsupported direct CUDA IPC payload version {data_ref.get('version')!r}"
-        )
-    header_bytes = data_ref.get("header")
-    if not isinstance(header_bytes, bytes):
-        raise TypeError(
-            "direct CUDA IPC payload header must be bytes, got "
-            f"{type(header_bytes).__name__}"
-        )
-    header = pickle.loads(header_bytes)
-    if not isinstance(header, StagePayload):
-        raise TypeError(
-            "direct CUDA IPC payload header must decode to StagePayload, got "
-            f"{type(header).__name__}"
-        )
+    header = deserialize_direct_cuda_ipc_payload_header(data_ref)
     raw_tensors = data_ref.get("tensors")
     if not isinstance(raw_tensors, list):
         raise TypeError(
@@ -234,6 +217,30 @@ def deserialize_direct_cuda_ipc_payload(data_ref: dict[str, Any]) -> StagePayloa
         request=header.request,
         data=restore_tensors(header.data, tensors),
     )
+
+
+def deserialize_direct_cuda_ipc_payload_header(
+    data_ref: dict[str, Any]
+) -> StagePayload:
+    if data_ref.get("_type") != _DIRECT_CUDA_IPC_PAYLOAD_TYPE:
+        raise ValueError("data_ref is not a direct CUDA IPC payload")
+    if data_ref.get("version") != 1:
+        raise ValueError(
+            f"unsupported direct CUDA IPC payload version {data_ref.get('version')!r}"
+        )
+    header_bytes = data_ref.get("header")
+    if not isinstance(header_bytes, bytes):
+        raise TypeError(
+            "direct CUDA IPC payload header must be bytes, got "
+            f"{type(header_bytes).__name__}"
+        )
+    header = pickle.loads(header_bytes)
+    if not isinstance(header, StagePayload):
+        raise TypeError(
+            "direct CUDA IPC payload header must decode to StagePayload, got "
+            f"{type(header).__name__}"
+        )
+    return header
 
 
 def serialize_direct_cuda_ipc_stream_chunk(
@@ -334,11 +341,7 @@ async def read_payload(
     request_id: str,
     data_ref: DataRef,
 ) -> StagePayload:
-    if data_ref.kind is not DataKind.STAGE_PAYLOAD:
-        raise ValueError(f"expected stage_payload, got {data_ref.kind.value}")
-    if data_ref.header is None:
-        raise ValueError("stage_payload data_ref is missing header")
-    header = pickle.loads(base64.b64decode(data_ref.header))
+    header = deserialize_payload_header(data_ref)
     transfer_buf = await _read_transfer_buffer(relay, request_id, data_ref)
     tensors = {
         entry.path: _restore_tensor_device(
@@ -355,6 +358,20 @@ async def read_payload(
         request=header.request,
         data=restore_tensors(header.data, tensors),
     )
+
+
+def deserialize_payload_header(data_ref: DataRef) -> StagePayload:
+    if data_ref.kind is not DataKind.STAGE_PAYLOAD:
+        raise ValueError(f"expected stage_payload, got {data_ref.kind.value}")
+    if data_ref.header is None:
+        raise ValueError("stage_payload data_ref is missing header")
+    header = pickle.loads(base64.b64decode(data_ref.header))
+    if not isinstance(header, StagePayload):
+        raise TypeError(
+            "stage_payload data_ref header must decode to StagePayload, got "
+            f"{type(header).__name__}"
+        )
+    return header
 
 
 async def write_tensor(

--- a/sglang_omni/comm/tensor_ref.py
+++ b/sglang_omni/comm/tensor_ref.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lazy references for large tensors forwarded through pipeline stages."""
+from __future__ import annotations
+
+from typing import Any
+
+import msgspec
+
+from sglang_omni.comm.data_ref import DataKind, DataRef
+
+_TYPE = "TensorRef"
+_VERSION = 1
+
+
+class TensorRef(msgspec.Struct, frozen=True):
+    request_id: str
+    producer_stage: str
+    consumer_stage: str
+    path: str
+    nbytes: int
+    data_ref: DataRef
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "_type": _TYPE,
+            "version": _VERSION,
+            "request_id": self.request_id,
+            "producer_stage": self.producer_stage,
+            "consumer_stage": self.consumer_stage,
+            "path": self.path,
+            "nbytes": self.nbytes,
+            "data_ref": self.data_ref.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, value: dict[str, Any]) -> "TensorRef":
+        if _required(value, "_type", str) != _TYPE:
+            raise ValueError("value is not a tensor_ref")
+        version = _required(value, "version", int)
+        if version != _VERSION:
+            raise ValueError(f"unsupported TensorRef version {version}")
+        data_ref = DataRef.from_dict(_required(value, "data_ref", dict))
+        if data_ref.kind is not DataKind.TENSOR_REF:
+            raise ValueError(
+                f"tensor_ref data_ref kind must be tensor_ref, got "
+                f"{data_ref.kind.value}"
+            )
+        return cls(
+            request_id=_required(value, "request_id", str),
+            producer_stage=_required(value, "producer_stage", str),
+            consumer_stage=_required(value, "consumer_stage", str),
+            path=_required(value, "path", str),
+            nbytes=_required(value, "nbytes", int),
+            data_ref=data_ref,
+        )
+
+
+def is_tensor_ref(value: Any) -> bool:
+    return isinstance(value, dict) and value.get("_type") == _TYPE
+
+
+def collect_tensor_refs(value: Any, seen: set[int] | None = None) -> list[TensorRef]:
+    if value is None:
+        return []
+    seen = set() if seen is None else seen
+    value_id = id(value)
+    if value_id in seen:
+        return []
+    seen.add(value_id)
+    if is_tensor_ref(value):
+        return [TensorRef.from_dict(value)]
+    if isinstance(value, dict):
+        return [
+            ref for item in value.values() for ref in collect_tensor_refs(item, seen)
+        ]
+    if isinstance(value, (list, tuple)):
+        return [ref for item in value for ref in collect_tensor_refs(item, seen)]
+    return []
+
+
+def _required(value: dict[str, Any], key: str, expected: type) -> Any:
+    item = value[key]
+    if type(item) is not expected:
+        raise TypeError(f"tensor_ref {key} must be {expected.__name__}")
+    return item

--- a/sglang_omni/config/__init__.py
+++ b/sglang_omni/config/__init__.py
@@ -19,6 +19,7 @@ from sglang_omni.config.schema import (
     StageConfig,
     StageResourceConfig,
     StageRuntimeConfig,
+    TensorRefEdgeConfig,
 )
 from sglang_omni.config.topology import (
     ProcessGroupPlacement,
@@ -51,4 +52,5 @@ __all__ = [
     "PlacementConfig",
     "CommConfig",
     "EndpointsConfig",
+    "TensorRefEdgeConfig",
 ]

--- a/sglang_omni/config/schema.py
+++ b/sglang_omni/config/schema.py
@@ -27,6 +27,28 @@ class CommConfig(BaseModel):
     mooncake_device_name: str = ""
 
 
+class TensorRefEdgeConfig(BaseModel):
+    """Explicit lazy tensor handoff policy for one outgoing stage edge."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    consumer_stage: str
+    threshold_mb: float = 2.0
+    paths: tuple[str, ...]
+
+    def model_post_init(self, __context: Any = None) -> None:
+        if self.threshold_mb < 0:
+            raise ValueError("tensor_ref_edges threshold_mb must be non-negative")
+        self.consumer_stage = self.consumer_stage.strip()
+        if not self.consumer_stage:
+            raise ValueError("tensor_ref_edges consumer_stage must not be empty")
+        if not self.paths:
+            raise ValueError("tensor_ref_edges paths must not be empty")
+        self.paths = tuple(path.strip() for path in self.paths)
+        if any(not path for path in self.paths):
+            raise ValueError("tensor_ref_edges paths must not contain empty values")
+
+
 class EndpointsConfig(BaseModel):
     """Endpoint allocation settings."""
 
@@ -181,6 +203,9 @@ class StageConfig(BaseModel):
 
     # --- Route-specific payload projection ---
     project_payload: dict[str, str] = Field(default_factory=dict)
+
+    # --- Lazy tensor handoff ---
+    tensor_ref_edges: dict[str, TensorRefEdgeConfig] = Field(default_factory=dict)
 
     # --- Communication pool tuning ---
     comm: CommConfig | None = None
@@ -385,6 +410,23 @@ class PipelineConfig(BaseModel):
                 if t not in names:
                     raise ValueError(
                         f"Stage {s.name!r} project_payload references unknown stage {t!r}"
+                    )
+            route_targets = set(_target_list(s.next)) | set(s.stream_to)
+            for target, tensor_ref in s.tensor_ref_edges.items():
+                if target not in names:
+                    raise ValueError(
+                        f"Stage {s.name!r} tensor_ref_edges references unknown "
+                        f"target stage {target!r}"
+                    )
+                if target not in route_targets:
+                    raise ValueError(
+                        f"Stage {s.name!r} tensor_ref_edges target {target!r} is not "
+                        "a declared next or stream_to target"
+                    )
+                if tensor_ref.consumer_stage not in names:
+                    raise ValueError(
+                        f"Stage {s.name!r} tensor_ref_edges target {target!r} has "
+                        f"unknown consumer_stage {tensor_ref.consumer_stage!r}"
                     )
 
         for stage_name in self.runtime_overrides:

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -7,12 +7,23 @@ from typing import ClassVar
 
 from pydantic import Field
 
-from sglang_omni.config import PipelineConfig, PlacementConfig, StageConfig
+from sglang_omni.config import (
+    PipelineConfig,
+    PlacementConfig,
+    StageConfig,
+    TensorRefEdgeConfig,
+)
 
 _PKG = "sglang_omni.models.qwen3_omni"
 _PLACEMENT_POLICY = f"{_PKG}.placement.Qwen3OmniPlacementPolicy"
 THINKER_STAGE = "thinker"
 MIN_PARTIAL_START_CHUNKS = 3
+# The shared encoder config also serves speech pipelines, whose talker consumes
+# the main image/video embeds. Deepstack has one final consumer: the thinker.
+_VISUAL_DEEPSTACK_TENSOR_REF_PATHS = (
+    "encoder_outs.image_encoder.deepstack_visual_embeds_image",
+    "encoder_outs.image_encoder.deepstack_visual_embeds_video",
+)
 
 # SGLang reads this when DeepGEMM compile utilities are imported. Qwen AR
 # stages can first hit some dense FP8 shapes after readiness; disable all-M
@@ -58,6 +69,13 @@ def _image_encoder_stage(*, gpu: int, process: str) -> StageConfig:
         next="mm_aggregate",
         project_payload={
             "mm_aggregate": f"{_PKG}.request_builders.project_encoder_to_mm_aggregate"
+        },
+        tensor_ref_edges={
+            "mm_aggregate": TensorRefEdgeConfig(
+                consumer_stage=THINKER_STAGE,
+                threshold_mb=2.0,
+                paths=_VISUAL_DEEPSTACK_TENSOR_REF_PATHS,
+            )
         },
     )
 

--- a/sglang_omni/pipeline/mp_runner.py
+++ b/sglang_omni/pipeline/mp_runner.py
@@ -31,6 +31,7 @@ from sglang_omni.pipeline.runtime_config import (
     build_comm_config,
     prepare_pipeline_runtime,
 )
+from sglang_omni.pipeline.stage.tensor_ref import TensorRefPolicy
 from sglang_omni.pipeline.stage_workers import (
     StageGroup,
     StageLaunchConfig,
@@ -65,6 +66,11 @@ def _build_stage_groups(
         for target in scfg.stream_to:
             stream_receivers.add(target)
     stage_cfg_by_name = {stage.name: stage for stage in stages_cfg}
+    tensor_ref_consumer_stages = {
+        name_map.get(edge.consumer_stage, edge.consumer_stage)
+        for stage_cfg in stages_cfg
+        for edge in stage_cfg.tensor_ref_edges.values()
+    }
 
     nccl_port_counter = _NcclPortAllocator()
 
@@ -128,6 +134,11 @@ def _build_stage_groups(
             is_stream_receiver=stage_cfg.name in stream_receivers,
             can_accept_stream_before_payload=stage_cfg.can_accept_stream_before_payload,
             disable_direct_cuda_ipc_payload=stage_cfg.disable_direct_cuda_ipc_payload,
+            tensor_ref_policies=_build_tensor_ref_policies(stage_cfg, name_map),
+            resolve_tensor_refs=(
+                name_map.get(stage_cfg.name, stage_cfg.name)
+                in tensor_ref_consumer_stages
+            ),
             name_map=name_map,
         )
         if tp_size == 1:
@@ -180,6 +191,22 @@ def _build_stage_groups(
     groups.extend(tp_groups)
 
     return groups
+
+
+def _build_tensor_ref_policies(
+    stage_cfg: StageConfig,
+    name_map: dict[str, str],
+) -> dict[str, TensorRefPolicy]:
+    """Compile declarative tensor-reference edges for one launched stage."""
+    policies: dict[str, TensorRefPolicy] = {}
+    for raw_target, edge in stage_cfg.tensor_ref_edges.items():
+        target = name_map.get(raw_target, raw_target)
+        policies[target] = TensorRefPolicy(
+            threshold_bytes=int(edge.threshold_mb * 1024 * 1024),
+            consumer_stage=name_map.get(edge.consumer_stage, edge.consumer_stage),
+            paths=tuple(edge.paths),
+        )
+    return policies
 
 
 def _resolve_same_process_targets(

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -23,8 +23,10 @@ from sglang_omni.comm import stage_io
 from sglang_omni.comm.data_ref import DataRef
 from sglang_omni.comm.engine import CommEngine
 from sglang_omni.comm.router import CommRouter
+from sglang_omni.comm.tensor_ref import TensorRef, collect_tensor_refs, is_tensor_ref
 from sglang_omni.pipeline.stage.input import DirectInput, InputHandler
 from sglang_omni.pipeline.stage.stream_queue import StreamItem, StreamQueue
+from sglang_omni.pipeline.stage.tensor_ref import TensorRefPolicy
 from sglang_omni.pipeline.tp_control import TPLeaderFanout, TPWorkMessage
 from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.profiler.event_recorder import get_recorder as _get_recorder
@@ -98,6 +100,8 @@ class Stage:
         local_dispatcher: Any | None = None,
         can_accept_stream_before_payload: bool = False,
         disable_direct_cuda_ipc_payload: bool = False,
+        tensor_ref_policies: dict[str, TensorRefPolicy] | None = None,
+        resolve_tensor_refs: bool = False,
         tp_fanout: TPLeaderFanout | None = None,
         is_terminal: bool = False,
     ):
@@ -116,6 +120,8 @@ class Stage:
         self._local_dispatcher = local_dispatcher
         self._can_accept_stream_before_payload = can_accept_stream_before_payload
         self._disable_direct_cuda_ipc_payload = disable_direct_cuda_ipc_payload
+        self._tensor_ref_policies = tensor_ref_policies or {}
+        self._resolve_tensor_refs = resolve_tensor_refs
         self._tp_fanout = tp_fanout
         self._is_terminal = is_terminal
         self._owns_external_io = role in {"single", "leader"}
@@ -143,6 +149,7 @@ class Stage:
         self._first_stream_chunk_seen: set[str] = set()
         self._local_stream_targets: dict[str, set[str]] = {}
         self._nonlocal_stream_targets: dict[str, set[str]] = {}
+        self._unresolved_tensor_refs: dict[str, dict[str, TensorRef]] = {}
         self._receive_tasks: set[asyncio.Task] = set()
         self._receive_lane_tails: dict[tuple[str, str], asyncio.Future[None]] = {}
         self._scheduler_thread: threading.Thread | None = None
@@ -333,6 +340,9 @@ class Stage:
                 completion,
             )
         )
+        self._track_receive_task(task, label)
+
+    def _track_receive_task(self, task: asyncio.Task, label: str) -> None:
         self._receive_tasks.add(task)
         task.add_done_callback(self._receive_tasks.discard)
         task.add_done_callback(lambda done: self._on_background_task_done(done, label))
@@ -401,6 +411,15 @@ class Stage:
                     request_id,
                 )
                 await self._wait_for_receive_predecessor(predecessor)
+                with suppress(Exception):
+                    header = stage_io.deserialize_direct_cuda_ipc_payload_header(
+                        msg.data_ref
+                    )
+                    await self._send_tensor_ref_acks(
+                        collect_tensor_refs(header.data),
+                        success=False,
+                        error=_error_text(exc),
+                    )
                 await self._send_failure(
                     request_id, f"direct IPC payload deserialize failed: {exc}"
                 )
@@ -501,6 +520,7 @@ class Stage:
             event_name="stage_input_received",
             metadata={"from_stage": from_stage, "kind": "payload"},
         )
+        self._remember_tensor_refs(request_id, payload)
         merged = self.input_handler.receive(request_id, from_stage, payload)
         if merged is not None:
             _emit_event(
@@ -677,14 +697,36 @@ class Stage:
 
     async def _discard_payload_data(self, msg: DataReadyMessage) -> None:
         if stage_io.is_direct_cuda_ipc_payload_ref(msg.data_ref):
-            imported = stage_io.deserialize_direct_cuda_ipc_payload(msg.data_ref)
-            del imported
+            try:
+                payload = stage_io.deserialize_direct_cuda_ipc_payload(msg.data_ref)
+            except Exception as exc:
+                logger.debug(
+                    "Stage %s: failed to drain aborted direct IPC payload for %s",
+                    self.name,
+                    msg.request_id,
+                    exc_info=True,
+                )
+                with suppress(Exception):
+                    header = stage_io.deserialize_direct_cuda_ipc_payload_header(
+                        msg.data_ref
+                    )
+                    await self._send_tensor_ref_acks(
+                        collect_tensor_refs(header.data),
+                        success=False,
+                        error=_error_text(exc),
+                    )
+            else:
+                await self._send_tensor_ref_acks(
+                    collect_tensor_refs(payload.data),
+                    success=False,
+                    error="request aborted",
+                )
             return
         request_id = msg.request_id
         data_ref = self._data_ref_from_message(msg)
         relay = self._comm.relay(data_ref.transport)
         try:
-            await self._comm.read_payload(
+            payload = await self._comm.read_payload(
                 relay=relay,
                 request_id=request_id,
                 data_ref=data_ref,
@@ -699,9 +741,21 @@ class Stage:
             await self._send_data_ack(
                 msg, data_ref, success=False, error=_error_text(exc)
             )
+            with suppress(Exception):
+                header = stage_io.deserialize_payload_header(data_ref)
+                await self._send_tensor_ref_acks(
+                    collect_tensor_refs(header.data),
+                    success=False,
+                    error=_error_text(exc),
+                )
             self._comm.cleanup(request_id)
             return
         await self._send_data_ack(msg, data_ref, success=True)
+        await self._send_tensor_ref_acks(
+            collect_tensor_refs(payload.data),
+            success=False,
+            error="request aborted",
+        )
 
     async def _discard_stream_chunk_data(self, msg: DataReadyMessage) -> None:
         if stage_io.is_direct_cuda_ipc_stream_chunk_ref(msg.data_ref):
@@ -798,6 +852,8 @@ class Stage:
 
     async def _execute(self, payload: Any) -> None:
         request_id = payload.request_id
+        if self._resolve_tensor_refs and request_id in self._unresolved_tensor_refs:
+            payload = await self._materialize_tensor_refs(request_id, payload)
         _emit_event(
             request_id=request_id,
             stage=self.name,
@@ -812,6 +868,173 @@ class Stage:
         self.scheduler.inbox.put(
             IncomingMessage(request_id=request_id, type="new_request", data=payload)
         )
+
+    async def _externalize_tensor_refs(
+        self, payload: StagePayload, target: str
+    ) -> tuple[StagePayload, dict[str, int] | None]:
+        policy = self._tensor_ref_policies.get(target)
+        if policy is None:
+            return payload, None
+        transport, relay = self._comm.router.relay_for(policy.consumer_stage)
+        published_refs: list[TensorRef] = []
+
+        async def _visit(value: Any, path: str = "") -> Any:
+            if is_tensor_ref(value):
+                return value
+            if isinstance(value, torch.Tensor):
+                nbytes = value.numel() * value.element_size()
+                if not policy.should_externalize(path, nbytes):
+                    return value
+                ref = await self._comm.publish_tensor_ref(
+                    relay=relay,
+                    request_id=payload.request_id,
+                    tensor=value,
+                    transport=transport,
+                    producer_stage=self.name,
+                    consumer_stage=policy.consumer_stage,
+                    path=path,
+                )
+                published_refs.append(ref)
+                return ref.to_dict()
+            if isinstance(value, dict):
+                items: dict[Any, Any] = {}
+                changed = False
+                for key, item in value.items():
+                    externalized = await _visit(item, f"{path}.{key}" if path else key)
+                    changed = changed or externalized is not item
+                    items[key] = externalized
+                return items if changed else value
+            if isinstance(value, (list, tuple)):
+                items = []
+                changed = False
+                for idx, item in enumerate(value):
+                    externalized = await _visit(item, f"{path}[{idx}]")
+                    changed = changed or externalized is not item
+                    items.append(externalized)
+                return type(value)(items) if changed else value
+            return value
+
+        data = await _visit(payload.data)
+        if data is payload.data:
+            return payload, None
+        stats = {
+            "tensor_ref_count": len(published_refs),
+            "tensor_ref_bytes": sum(ref.nbytes for ref in published_refs),
+        }
+        return (
+            StagePayload(
+                request_id=payload.request_id,
+                request=payload.request,
+                data=data,
+            ),
+            stats,
+        )
+
+    def _remember_tensor_refs(self, request_id: str, payload: Any) -> None:
+        refs = [
+            ref
+            for ref in collect_tensor_refs(getattr(payload, "data", payload))
+            if ref.consumer_stage == self.name
+        ]
+        if refs:
+            tracked = self._unresolved_tensor_refs.setdefault(request_id, {})
+            tracked.update({ref.data_ref.object_id: ref for ref in refs})
+
+    async def _materialize_tensor_refs(
+        self, request_id: str, payload: StagePayload
+    ) -> StagePayload:
+        materialized: dict[str, torch.Tensor] = {}
+
+        async def _visit(value: Any) -> Any:
+            if is_tensor_ref(value):
+                ref = TensorRef.from_dict(value)
+                if ref.consumer_stage != self.name:
+                    return value
+                cached = materialized.get(ref.data_ref.object_id)
+                if cached is not None:
+                    return cached
+                try:
+                    tensor = await self._comm.read_tensor_ref(ref)
+                except Exception as exc:
+                    await self._send_tensor_ref_ack(
+                        ref, success=False, error=_error_text(exc)
+                    )
+                    raise
+                materialized[ref.data_ref.object_id] = tensor
+                await self._send_tensor_ref_ack(ref, success=True)
+                self._unresolved_tensor_refs.get(request_id, {}).pop(
+                    ref.data_ref.object_id, None
+                )
+                return tensor
+            if isinstance(value, dict):
+                items: dict[Any, Any] = {}
+                changed = False
+                for key, item in value.items():
+                    resolved = await _visit(item)
+                    changed = changed or resolved is not item
+                    items[key] = resolved
+                return items if changed else value
+            if isinstance(value, (list, tuple)):
+                items = []
+                changed = False
+                for item in value:
+                    resolved = await _visit(item)
+                    changed = changed or resolved is not item
+                    items.append(resolved)
+                return type(value)(items) if changed else value
+            return value
+
+        data = await _visit(payload.data)
+        if data is payload.data:
+            return payload
+        return StagePayload(
+            request_id=payload.request_id,
+            request=payload.request,
+            data=data,
+        )
+
+    async def _send_tensor_ref_ack(
+        self, ref: TensorRef, *, success: bool, error: str | None = None
+    ) -> None:
+        endpoint = self.endpoints.get(ref.producer_stage)
+        if endpoint is None:
+            raise RuntimeError(
+                f"Stage {self.name}: no endpoint configured for tensor_ref producer "
+                f"{ref.producer_stage!r}"
+            )
+        await self.control_plane.send_to_stage(
+            ref.producer_stage,
+            endpoint,
+            DataAckMessage(
+                request_id=ref.request_id,
+                from_stage=self.name,
+                to_stage=ref.producer_stage,
+                object_id=ref.data_ref.object_id,
+                success=success,
+                error=error,
+            ),
+        )
+
+    async def _fail_tensor_refs(self, request_id: str, error: str) -> None:
+        refs = list(self._unresolved_tensor_refs.pop(request_id, {}).values())
+        await self._send_tensor_ref_acks(refs, success=False, error=error)
+
+    async def _send_tensor_ref_acks(
+        self,
+        refs: list[TensorRef],
+        *,
+        success: bool,
+        error: str | None = None,
+    ) -> None:
+        seen: set[str] = set()
+        for ref in refs:
+            if ref.consumer_stage != self.name:
+                continue
+            if ref.data_ref.object_id in seen:
+                continue
+            seen.add(ref.data_ref.object_id)
+            with suppress(Exception):
+                await self._send_tensor_ref_ack(ref, success=success, error=error)
 
     async def _on_admin(self, msg: AdminMessage) -> None:
         operation = msg.operation
@@ -1129,6 +1352,10 @@ class Stage:
             )
             return
 
+        projected_payload, tensor_ref_stats = await self._externalize_tensor_refs(
+            projected_payload, target
+        )
+
         same_gpu_target = self._comm.router.is_same_gpu_target(target)
         if (
             not self._disable_direct_cuda_ipc_payload
@@ -1157,7 +1384,9 @@ class Stage:
                     request_id=request_id,
                     stage=self.name,
                     event_name="stage_hop_sent",
-                    metadata={"to_stage": target, "transport": "torch_cuda_ipc"},
+                    metadata=self._payload_hop_metadata(
+                        target, "torch_cuda_ipc", tensor_ref_stats
+                    ),
                 )
                 return
 
@@ -1178,8 +1407,21 @@ class Stage:
             request_id=request_id,
             stage=self.name,
             event_name="stage_hop_sent",
-            metadata={"to_stage": target, "transport": transport_kind.value},
+            metadata=self._payload_hop_metadata(
+                target, transport_kind.value, tensor_ref_stats
+            ),
         )
+
+    @staticmethod
+    def _payload_hop_metadata(
+        target: str,
+        transport: str,
+        tensor_ref_stats: dict[str, int] | None,
+    ) -> dict[str, Any]:
+        metadata: dict[str, Any] = {"to_stage": target, "transport": transport}
+        if tensor_ref_stats is not None:
+            metadata.update(tensor_ref_stats)
+        return metadata
 
     @staticmethod
     def _is_isolated_projected_payload(
@@ -1485,6 +1727,7 @@ class Stage:
 
     async def _send_failure(self, request_id: str, error: str) -> None:
         self._record_aborted_request_id(request_id)
+        await self._fail_tensor_refs(request_id, error)
         if not self._owns_external_io:
             self._clear_request_state(request_id)
             raise RuntimeError(f"Follower stage {self.name} failed: {error}")
@@ -1511,6 +1754,7 @@ class Stage:
         self._first_stream_chunk_seen.discard(request_id)
         self._local_stream_targets.pop(request_id, None)
         self._nonlocal_stream_targets.pop(request_id, None)
+        self._unresolved_tensor_refs.pop(request_id, None)
 
     async def _handle_scheduler_crash(self, exc: BaseException) -> None:
         if self._scheduler_crash_error is not None:
@@ -1556,9 +1800,18 @@ class Stage:
 
     def _on_abort(self, request_id: str) -> None:
         self._record_aborted_request_id(request_id)
+        refs = list(self._unresolved_tensor_refs.pop(request_id, {}).values())
+        if refs:
+            self._track_receive_task(
+                asyncio.create_task(self._ack_aborted_tensor_refs(refs)),
+                f"tensor refs abort {request_id}",
+            )
         self._comm.cleanup(request_id)
         self._clear_request_state(request_id)
         self.scheduler.abort(request_id)
+
+    async def _ack_aborted_tensor_refs(self, refs: list[TensorRef]) -> None:
+        await self._send_tensor_ref_acks(refs, success=False, error="request aborted")
 
     def _on_profiler_start(self, msg: ProfilerStartMessage) -> None:
         run_id = msg.run_id

--- a/sglang_omni/pipeline/stage/runtime.py
+++ b/sglang_omni/pipeline/stage/runtime.py
@@ -1366,6 +1366,8 @@ class Stage:
                 direct_ref = stage_io.serialize_direct_cuda_ipc_payload(
                     projected_payload
                 )
+            except ValueError:
+                pass
             except RuntimeError as exc:
                 if "received from another process" not in str(exc):
                     raise

--- a/sglang_omni/pipeline/stage/tensor_ref.py
+++ b/sglang_omni/pipeline/stage/tensor_ref.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime policy for externalizing tensors on one pipeline edge."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TensorRefPolicy:
+    threshold_bytes: int
+    consumer_stage: str
+    paths: tuple[str, ...]
+
+    def should_externalize(self, path: str, nbytes: int) -> bool:
+        matches_path = any(
+            path == configured_path or path.startswith(f"{configured_path}[")
+            for configured_path in self.paths
+        )
+        return matches_path and nbytes >= self.threshold_bytes

--- a/sglang_omni/pipeline/stage_workers.py
+++ b/sglang_omni/pipeline/stage_workers.py
@@ -21,6 +21,7 @@ from sglang_omni.pipeline.local_dispatch import LocalStageDispatcher
 from sglang_omni.pipeline.stage.input import AggregatedInput, DirectInput
 from sglang_omni.pipeline.stage.runtime import Stage
 from sglang_omni.pipeline.stage.stream_queue import StreamQueue
+from sglang_omni.pipeline.stage.tensor_ref import TensorRefPolicy
 from sglang_omni.pipeline.tp_control import TPFollowerControlPlane, TPLeaderFanout
 from sglang_omni.utils.gpu_compat import (
     apply_gpu_compat_env_defaults,
@@ -90,6 +91,8 @@ class StageLaunchConfig:
     is_stream_receiver: bool = False
     can_accept_stream_before_payload: bool = False
     disable_direct_cuda_ipc_payload: bool = False
+    tensor_ref_policies: dict[str, TensorRefPolicy] = field(default_factory=dict)
+    resolve_tensor_refs: bool = False
 
     # Same-process full payload wiring
     same_process_targets: set[str] = field(default_factory=set)
@@ -759,6 +762,8 @@ def _construct_stage(
         local_dispatcher=local_dispatcher,
         can_accept_stream_before_payload=spec.can_accept_stream_before_payload,
         disable_direct_cuda_ipc_payload=spec.disable_direct_cuda_ipc_payload,
+        tensor_ref_policies=spec.tensor_ref_policies,
+        resolve_tensor_refs=spec.resolve_tensor_refs,
         tp_fanout=tp_fanout,
         is_terminal=spec.is_terminal,
     )

--- a/tests/unit_test/fixtures/pipeline_fakes.py
+++ b/tests/unit_test/fixtures/pipeline_fakes.py
@@ -31,6 +31,7 @@ class FakeOp:
     def __init__(self, metadata: dict[str, Any], log: EventLog | None = None):
         self._metadata = metadata
         self.log = log or EventLog()
+        self.acked = False
         self.waited = False
         self.failed: BaseException | None = None
 
@@ -46,10 +47,12 @@ class FakeOp:
             raise self.failed
 
     def mark_receiver_done(self) -> None:
+        self.acked = True
         self.log.append("op_ack", self._metadata.get("key"))
 
     def mark_receiver_failed(self, exc: BaseException) -> None:
         self.failed = exc
+        self.log.append("op_fail", self._metadata.get("key"), str(exc))
 
 
 class FakeRelay:
@@ -57,6 +60,9 @@ class FakeRelay:
         self.device = device
         self.log = log or EventLog()
         self.storage: dict[str, torch.Tensor] = {}
+        self.ops: list[FakeOp] = []
+        self.receiver_ids: list[str | None] = []
+        self.get_calls = 0
         self.cleaned: list[str] = []
         self.closed = False
         self.fail_get: BaseException | None = None
@@ -68,15 +74,18 @@ class FakeRelay:
         dst_rank: int | None = None,
         receiver_id: str | None = None,
     ) -> FakeOp:
-        del dst_rank, receiver_id
+        del dst_rank
+        self.receiver_ids.append(receiver_id)
         key = str(request_id)
         stored = tensor.detach().clone()
         self.storage[key] = stored
         self.log.append("relay_put", key, int(stored.numel()))
-        return FakeOp(
+        op = FakeOp(
             {"transfer_info": {"size": int(stored.numel())}, "key": key},
             self.log,
         )
+        self.ops.append(op)
+        return op
 
     async def get_async(
         self,
@@ -84,6 +93,7 @@ class FakeRelay:
         dest_tensor: torch.Tensor,
         request_id: str | None = None,
     ) -> FakeOp:
+        self.get_calls += 1
         if self.fail_get is not None:
             raise self.fail_get
         key = str(metadata.get("key", request_id))
@@ -99,6 +109,15 @@ class FakeRelay:
     def close(self) -> None:
         self.closed = True
         self.log.append("relay_close")
+
+
+async def wait_until(predicate: Callable[[], bool], timeout: float = 1.0) -> None:
+    """Yield to background tasks until a test-visible condition becomes true."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not predicate():
+        if asyncio.get_running_loop().time() > deadline:
+            raise TimeoutError("condition was not met")
+        await asyncio.sleep(0)
 
 
 class DestructiveFakeRelay(FakeRelay):

--- a/tests/unit_test/pipeline/test_comm_engine_ack.py
+++ b/tests/unit_test/pipeline/test_comm_engine_ack.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
 
 import pytest
 import torch
@@ -13,89 +12,16 @@ from sglang_omni.comm.engine import CommEngine
 from sglang_omni.comm.router import CommRouter
 from sglang_omni.proto import DataAckMessage, DataReadyMessage
 from tests.unit_test.fixtures.pipeline_fakes import (
+    FakeRelay,
     RecordingStageControlPlane,
     make_stage_payload,
+    wait_until,
 )
-
-
-class _AckedOp:
-    def __init__(self, metadata: dict[str, Any]) -> None:
-        self._metadata = metadata
-        self.acked = False
-        self.waited = False
-        self.failed: BaseException | None = None
-
-    @property
-    def metadata(self) -> dict[str, Any]:
-        return self._metadata
-
-    def mark_receiver_done(self) -> None:
-        self.acked = True
-
-    def mark_receiver_failed(self, exc: BaseException) -> None:
-        self.failed = exc
-
-    async def wait_for_completion(self, timeout: float = 30.0) -> None:
-        del timeout
-        self.waited = True
-        if self.failed is not None:
-            raise self.failed
-        if not self.acked:
-            raise RuntimeError("waited before receiver ack")
-
-
-class _AckedRelay:
-    device = "cpu"
-
-    def __init__(self) -> None:
-        self.storage: dict[str, torch.Tensor] = {}
-        self.ops: list[_AckedOp] = []
-        self.receiver_ids: list[str | None] = []
-
-    async def put_async(
-        self,
-        tensor: torch.Tensor,
-        request_id: str | None = None,
-        dst_rank: int | None = None,
-        receiver_id: str | None = None,
-    ) -> _AckedOp:
-        del dst_rank
-        self.receiver_ids.append(receiver_id)
-        key = str(request_id)
-        self.storage[key] = tensor.detach().clone()
-        op = _AckedOp({"transfer_info": {"size": int(tensor.numel())}, "key": key})
-        self.ops.append(op)
-        return op
-
-    async def get_async(
-        self,
-        metadata: dict[str, Any],
-        dest_tensor: torch.Tensor,
-        request_id: str | None = None,
-    ) -> _AckedOp:
-        key = str(metadata.get("key", request_id))
-        stored = self.storage[key]
-        dest_tensor.reshape(-1)[: stored.numel()].copy_(stored.reshape(-1))
-        return _AckedOp(metadata)
-
-    def cleanup(self, request_id: str) -> None:
-        del request_id
-
-    def close(self) -> None:
-        pass
-
-
-async def _wait_until(predicate, timeout: float = 1.0) -> None:
-    deadline = asyncio.get_running_loop().time() + timeout
-    while not predicate():
-        if asyncio.get_running_loop().time() > deadline:
-            raise TimeoutError("condition was not met")
-        await asyncio.sleep(0)
 
 
 def test_comm_engine_releases_sender_op_after_data_ack() -> None:
     async def _run() -> None:
-        relay = _AckedRelay()
+        relay = FakeRelay()
         control_plane = RecordingStageControlPlane()
         engine = CommEngine(
             CommRouter(
@@ -135,7 +61,7 @@ def test_comm_engine_releases_sender_op_after_data_ack() -> None:
                 object_id=data_ref.object_id,
             )
         )
-        await _wait_until(lambda: op.waited)
+        await wait_until(lambda: op.waited)
         assert op.acked
 
     asyncio.run(_run())
@@ -163,7 +89,7 @@ def test_comm_engine_ignores_unknown_data_ack() -> None:
 
 def test_comm_engine_ignores_duplicate_data_ack() -> None:
     async def _run() -> None:
-        relay = _AckedRelay()
+        relay = FakeRelay()
         control_plane = RecordingStageControlPlane()
         engine = CommEngine(
             CommRouter(
@@ -194,7 +120,7 @@ def test_comm_engine_ignores_duplicate_data_ack() -> None:
         )
 
         engine.ack_transfer(ack)
-        await _wait_until(lambda: relay.ops[0].waited)
+        await wait_until(lambda: relay.ops[0].waited)
 
         engine.ack_transfer(ack)
 

--- a/tests/unit_test/pipeline/test_runtime_schema.py
+++ b/tests/unit_test/pipeline/test_runtime_schema.py
@@ -11,6 +11,7 @@ from sglang_omni.config import (
     StageConfig,
     StageResourceConfig,
     StageRuntimeConfig,
+    TensorRefEdgeConfig,
 )
 
 _FACTORY = "tests.unit_test.fixtures.pipeline_fakes.dummy_factory"
@@ -103,3 +104,90 @@ def test_pipeline_accepts_placement_config() -> None:
 def test_invalid_placement_limit_raises() -> None:
     with pytest.raises(ValueError, match="max_total_gpu_memory_fraction_per_gpu"):
         PlacementConfig(max_total_gpu_memory_fraction_per_gpu=1.1)
+
+
+def test_tensor_ref_edge_must_be_declared_route_target() -> None:
+    with pytest.raises(ValueError, match="not a declared next or stream_to target"):
+        PipelineConfig(
+            model_path="dummy",
+            stages=[
+                _stage(
+                    name="source",
+                    next="sink",
+                    terminal=False,
+                    tensor_ref_edges={
+                        "consumer": TensorRefEdgeConfig(
+                            consumer_stage="consumer",
+                            paths=("embeds",),
+                        )
+                    },
+                ),
+                _stage(name="sink"),
+                _stage(name="consumer"),
+            ],
+        )
+
+
+def test_tensor_ref_edge_allows_direct_forwarder_and_later_consumer() -> None:
+    config = PipelineConfig(
+        model_path="dummy",
+        stages=[
+            _stage(
+                name="source",
+                next="forwarder",
+                terminal=False,
+                tensor_ref_edges={
+                    "forwarder": TensorRefEdgeConfig(
+                        consumer_stage="consumer",
+                        paths=("embeds",),
+                    )
+                },
+            ),
+            _stage(name="forwarder", next="consumer", terminal=False),
+            _stage(name="consumer"),
+        ],
+    )
+
+    assert config.stages[0].tensor_ref_edges["forwarder"].consumer_stage == "consumer"
+
+
+def test_tensor_ref_edge_target_must_exist() -> None:
+    with pytest.raises(ValueError, match="references unknown target stage"):
+        PipelineConfig(
+            model_path="dummy",
+            stages=[
+                _stage(
+                    name="source",
+                    next="sink",
+                    terminal=False,
+                    tensor_ref_edges={
+                        "missing": TensorRefEdgeConfig(
+                            consumer_stage="sink",
+                            paths=("embeds",),
+                        )
+                    },
+                ),
+                _stage(name="sink"),
+            ],
+        )
+
+
+def test_tensor_ref_edge_consumer_must_exist() -> None:
+    with pytest.raises(ValueError, match="unknown consumer_stage"):
+        PipelineConfig(
+            model_path="dummy",
+            stages=[
+                _stage(
+                    name="source",
+                    next="sink",
+                    terminal=False,
+                    tensor_ref_edges={
+                        "sink": TensorRefEdgeConfig(
+                            consumer_stage="missing",
+                            paths=("embeds",),
+                        )
+                    },
+                ),
+                _stage(name="sink"),
+            ],
+        )

--- a/tests/unit_test/pipeline/test_stage.py
+++ b/tests/unit_test/pipeline/test_stage.py
@@ -1064,6 +1064,47 @@ def test_stage_uses_relay_when_direct_cuda_payload_is_reexported(monkeypatch) ->
     asyncio.run(_run())
 
 
+def test_stage_uses_relay_when_direct_cuda_payload_header_is_oversized(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(stage_io, "payload_has_cuda_tensor", lambda payload: True)
+    monkeypatch.setattr(
+        stage_io,
+        "extract_cuda_tensors",
+        lambda data: (data, {"gpu": torch.ones(1)}),
+    )
+
+    async def _run() -> None:
+        relay = FakeRelay()
+        control_plane = RecordingStageControlPlane()
+        sender = Stage(
+            name="mm_aggregate",
+            role="single",
+            get_next=lambda request_id, output: None,
+            gpu_id=0,
+            endpoints={"talker_ar": "inproc://talker"},
+            control_plane=control_plane,
+            relay=relay,
+            scheduler=FakeScheduler(),
+            gpu_stage_names={"talker_ar"},
+            stage_gpu_ids={"talker_ar": (0,)},
+        )
+
+        payload = make_stage_payload(
+            request_id="req-oversized-header",
+            data={"metadata": b"x" * 70_000, "tensor": torch.ones(1)},
+        )
+        await sender._send_to_stage("req-oversized-header", "talker_ar", payload)
+
+        target, endpoint, msg = control_plane.sent_to_stage[0]
+        assert target == "talker_ar"
+        assert endpoint == "inproc://talker"
+        assert msg.data_ref["_type"] == "DataRef"
+        assert relay.storage
+
+    asyncio.run(_run())
+
+
 def test_stage_receives_same_gpu_direct_cuda_ipc_payload(monkeypatch) -> None:
     payload = make_stage_payload(request_id="req-direct", data={"answer": 7})
     monkeypatch.setattr(

--- a/tests/unit_test/pipeline/test_tensor_ref.py
+++ b/tests/unit_test/pipeline/test_tensor_ref.py
@@ -1,0 +1,771 @@
+# SPDX-License-Identifier: Apache-2.0
+"""TensorRef protocol, policy, lifecycle, and observability contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import pickle
+
+import pytest
+import torch
+
+from sglang_omni.comm import stage_io
+from sglang_omni.comm.data_ref import (
+    BackendRef,
+    DataKind,
+    DataLayout,
+    DataRef,
+    TransportKind,
+)
+from sglang_omni.comm.engine import CommEngine
+from sglang_omni.comm.router import CommRouter
+from sglang_omni.comm.tensor_ref import TensorRef
+from sglang_omni.config.schema import StageConfig, TensorRefEdgeConfig
+from sglang_omni.pipeline.mp_runner import _build_tensor_ref_policies
+from sglang_omni.pipeline.stage.runtime import Stage
+from sglang_omni.pipeline.stage.tensor_ref import TensorRefPolicy
+from sglang_omni.proto import DataAckMessage, DataReadyMessage, StagePayload
+from tests.unit_test.fixtures.pipeline_fakes import (
+    FakeRelay,
+    FakeScheduler,
+    RecordingStageControlPlane,
+    make_stage_payload,
+    wait_until,
+)
+
+# ---------------------------------------------------------------------------
+# Test environment
+# ---------------------------------------------------------------------------
+
+
+def _make_stage(
+    name: str,
+    *,
+    relay: FakeRelay,
+    control_plane: RecordingStageControlPlane | None = None,
+    endpoints: dict[str, str] | None = None,
+    scheduler: FakeScheduler | None = None,
+    tensor_ref_policies: dict[str, TensorRefPolicy] | None = None,
+) -> Stage:
+    """Build only the Stage collaborators relevant to TensorRef tests."""
+    return Stage(
+        name=name,
+        role="single",
+        get_next=lambda *_: None,
+        gpu_id=None,
+        endpoints={} if endpoints is None else endpoints,
+        control_plane=(
+            RecordingStageControlPlane() if control_plane is None else control_plane
+        ),
+        relay=relay,
+        scheduler=scheduler,
+        tensor_ref_policies=tensor_ref_policies,
+    )
+
+
+def _policy(*paths: str, threshold_bytes: int = 1) -> TensorRefPolicy:
+    return TensorRefPolicy(
+        threshold_bytes=threshold_bytes,
+        consumer_stage="thinker",
+        paths=paths,
+    )
+
+
+def _make_tensor_ref(
+    *,
+    object_id: str = "tensor-ref-1",
+    path: str = "video_embeds",
+) -> TensorRef:
+    return TensorRef(
+        request_id="req-1",
+        producer_stage="encoder",
+        consumer_stage="thinker",
+        path=path,
+        nbytes=32,
+        data_ref=DataRef(
+            version=1,
+            kind=DataKind.TENSOR_REF,
+            object_id=object_id,
+            transport=TransportKind.SHM,
+            layout=DataLayout.RAW_TENSOR,
+            buffer=BackendRef(
+                transport=TransportKind.SHM,
+                info={"transfer_info": {"size": 32}},
+                length=32,
+            ),
+            shape=(8,),
+            dtype="torch.float32",
+            offset=0,
+        ),
+    )
+
+
+def _direct_payload_ref(payload: StagePayload) -> dict[str, object]:
+    return {
+        "_type": "TorchCudaIpcPayload",
+        "version": 1,
+        "header": pickle.dumps(payload),
+        "tensors": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# TensorRef wire protocol
+# ---------------------------------------------------------------------------
+
+
+def test_tensor_ref_uses_versioned_round_trip_wire_format() -> None:
+    """A valid descriptor keeps its identity across the public wire format."""
+    ref = _make_tensor_ref()
+
+    value = ref.to_dict()
+
+    assert value["_type"] == "TensorRef"
+    assert value["version"] == 1
+    assert TensorRef.from_dict(value) == ref
+
+
+def test_tensor_ref_rejects_wrong_protocol_version() -> None:
+    """The decoder rejects descriptors from an unsupported protocol version."""
+    value = _make_tensor_ref().to_dict()
+    value["version"] = 2
+
+    with pytest.raises(ValueError, match="unsupported TensorRef version"):
+        TensorRef.from_dict(value)
+
+
+def test_tensor_ref_rejects_non_tensor_data_ref() -> None:
+    """A TensorRef cannot wrap a DataRef for an ordinary Stage payload."""
+    value = _make_tensor_ref().to_dict()
+    value["data_ref"]["kind"] = DataKind.STAGE_PAYLOAD.value
+
+    with pytest.raises(ValueError, match="data_ref kind"):
+        TensorRef.from_dict(value)
+
+
+# ---------------------------------------------------------------------------
+# TensorRef policy and configuration
+# ---------------------------------------------------------------------------
+
+
+def test_tensor_ref_policy_is_compiled_from_stage_config() -> None:
+    """Compilation maps stage names and preserves the exact size/path boundary."""
+    stage_cfg = StageConfig(
+        name="encoder",
+        process="pipeline",
+        factory="tests.fake_factory",
+        next="aggregate",
+        tensor_ref_edges={
+            "aggregate": TensorRefEdgeConfig(
+                consumer_stage="thinker",
+                threshold_mb=1.0,
+                paths=("encoder_outs.image_encoder.video_embeds",),
+            )
+        },
+    )
+    name_map = {
+        "aggregate": "aggregate_fused",
+        "thinker": "thinker_fused",
+    }
+
+    policies = _build_tensor_ref_policies(stage_cfg, name_map)
+    policy = policies["aggregate_fused"]
+
+    assert set(policies) == {"aggregate_fused"}
+    assert policy.consumer_stage == "thinker_fused"
+    assert policy.threshold_bytes == 1024 * 1024
+    assert policy.should_externalize(
+        "encoder_outs.image_encoder.video_embeds", 1024 * 1024
+    )
+    assert not policy.should_externalize(
+        "encoder_outs.image_encoder.video_embeds", 1024 * 1024 - 1
+    )
+    assert not policy.should_externalize(
+        "encoder_outs.other_encoder.video_embeds", 1024 * 1024
+    )
+
+
+# ---------------------------------------------------------------------------
+# TensorRef lifecycle
+# ---------------------------------------------------------------------------
+
+# Publication: decide which tensors become references and retain their resources.
+
+
+def test_externalization_skips_nonmatching_tensor_without_side_effects() -> None:
+    """A non-allowlisted tensor stays inline and performs no Relay write."""
+
+    async def _run() -> None:
+        # Arrange: only video_embeds is eligible for externalization.
+        relay = FakeRelay()
+        producer = _make_stage(
+            "encoder",
+            relay=relay,
+            endpoints={"aggregate": "inproc://aggregate"},
+            tensor_ref_policies={"aggregate": _policy("video_embeds")},
+        )
+        tensor = torch.arange(8)
+        payload = make_stage_payload(request_id="req-1", data={"unrelated": tensor})
+
+        # Act: visit a payload without a matching path.
+        externalized, stats = await producer._externalize_tensor_refs(
+            payload, "aggregate"
+        )
+
+        # Assert: the original object and empty data-plane state are preserved.
+        assert externalized.data["unrelated"] is tensor
+        assert relay.ops == []
+        assert stats is None
+
+    asyncio.run(_run())
+
+
+def test_externalization_publishes_configured_nested_tensor_list() -> None:
+    """Runtime path construction joins list indices to the configured base path."""
+
+    async def _run() -> None:
+        # Arrange: the second tensor is exactly on the 16-byte threshold.
+        relay = FakeRelay()
+        configured_path = "encoder_outs.image_encoder.deepstack_visual_embeds_image"
+        producer = _make_stage(
+            "encoder",
+            relay=relay,
+            endpoints={"aggregate": "inproc://aggregate"},
+            tensor_ref_policies={
+                "aggregate": _policy(configured_path, threshold_bytes=16)
+            },
+        )
+        payload = make_stage_payload(
+            request_id="req-1",
+            data={
+                "encoder_outs": {
+                    "image_encoder": {
+                        "deepstack_visual_embeds_image": [
+                            torch.arange(8, dtype=torch.float32),
+                            torch.arange(4, dtype=torch.float32),
+                        ]
+                    }
+                }
+            },
+        )
+
+        # Act: externalize both configured list elements.
+        externalized, stats = await producer._externalize_tensor_refs(
+            payload, "aggregate"
+        )
+        values = externalized.data["encoder_outs"]["image_encoder"][
+            "deepstack_visual_embeds_image"
+        ]
+        refs = [TensorRef.from_dict(value) for value in values]
+
+        # Assert: paths and byte statistics describe the two physical tensors.
+        assert [ref.path for ref in refs] == [
+            f"{configured_path}[0]",
+            f"{configured_path}[1]",
+        ]
+        assert [ref.nbytes for ref in refs] == [32, 16]
+        assert stats == {"tensor_ref_count": 2, "tensor_ref_bytes": 48}
+
+        # Cleanup: complete the two publications created by this test.
+        for ref in refs:
+            producer._comm.ack_transfer(
+                DataAckMessage(
+                    request_id="req-1",
+                    from_stage="thinker",
+                    to_stage="encoder",
+                    object_id=ref.data_ref.object_id,
+                )
+            )
+        await wait_until(lambda: all(op.waited for op in relay.ops))
+
+    asyncio.run(_run())
+
+
+def test_published_tensor_ref_keeps_sender_operation_until_consumer_ack() -> None:
+    """Publication resources remain pending until the final consumer ACK arrives."""
+
+    async def _run() -> None:
+        # Arrange: publish one 8 x float32 tensor through the communication engine.
+        relay = FakeRelay()
+        engine = CommEngine(
+            CommRouter(
+                stage_name="encoder",
+                gpu_id=None,
+                same_process_targets=set(),
+                gpu_stage_names=set(),
+                comm_config={"ack_timeout_s": 1.0},
+                injected_relay=relay,
+            )
+        )
+        ref = await engine.publish_tensor_ref(
+            relay=relay,
+            request_id="req-1",
+            tensor=torch.arange(8, dtype=torch.float32),
+            transport=TransportKind.SHM,
+            producer_stage="encoder",
+            consumer_stage="thinker",
+            path="video_embeds",
+        )
+        op = relay.ops[0]
+
+        # Assert before ACK: nbytes is physical payload size and the op is retained.
+        assert ref.nbytes == 8 * 4
+        assert ref.data_ref.kind is DataKind.TENSOR_REF
+        assert op.acked is False
+        assert op.waited is False
+
+        # Act: deliver the final consumer's successful read acknowledgement.
+        engine.ack_transfer(
+            DataAckMessage(
+                request_id="req-1",
+                from_stage="thinker",
+                to_stage="encoder",
+                object_id=ref.data_ref.object_id,
+            )
+        )
+
+        # Assert after ACK: the Relay operation reaches its terminal state.
+        await wait_until(lambda: op.waited)
+        assert op.acked is True
+
+    asyncio.run(_run())
+
+
+# Materialization: only the declared consumer reads and acknowledges a reference.
+
+
+def test_consumer_materializes_tensor_ref_and_acks_original_producer() -> None:
+    """The final consumer restores tensor contents and ACKs the original producer."""
+
+    async def _run() -> None:
+        # Arrange: encoder publishes a ref that may pass through aggregate.
+        relay = FakeRelay()
+        producer = _make_stage(
+            "encoder",
+            relay=relay,
+            endpoints={"aggregate": "inproc://aggregate"},
+            tensor_ref_policies={"aggregate": _policy("video_embeds")},
+        )
+        expected = torch.arange(256)
+        forwarded, _ = await producer._externalize_tensor_refs(
+            make_stage_payload(request_id="req-1", data={"video_embeds": expected}),
+            "aggregate",
+        )
+        ref = TensorRef.from_dict(forwarded.data["video_embeds"])
+        consumer_control = RecordingStageControlPlane()
+        consumer = _make_stage(
+            "thinker",
+            relay=relay,
+            control_plane=consumer_control,
+            endpoints={"encoder": "inproc://encoder"},
+        )
+
+        # Act: thinker resolves the descriptor.
+        materialized = await consumer._materialize_tensor_refs("req-1", forwarded)
+
+        # Assert: data is correct and exactly one success ACK names the ref object.
+        assert torch.equal(materialized.data["video_embeds"], expected)
+        assert len(consumer_control.sent_to_stage) == 1
+        target, _, ack = consumer_control.sent_to_stage[0]
+        assert target == "encoder"
+        assert ack.object_id == ref.data_ref.object_id
+        assert ack.success is True
+
+        producer._comm.ack_transfer(ack)
+        await wait_until(lambda: relay.ops[0].waited)
+
+    asyncio.run(_run())
+
+
+def test_consumer_materializes_duplicate_tensor_ref_once() -> None:
+    """Repeated descriptors for one object share one read, tensor, and success ACK."""
+
+    async def _run() -> None:
+        # Arrange: two payload positions contain copies of the same descriptor.
+        relay = FakeRelay()
+        producer = _make_stage(
+            "encoder",
+            relay=relay,
+            endpoints={"aggregate": "inproc://aggregate"},
+            tensor_ref_policies={"aggregate": _policy("video_embeds")},
+        )
+        forwarded, _ = await producer._externalize_tensor_refs(
+            make_stage_payload(
+                request_id="req-1", data={"video_embeds": torch.arange(8)}
+            ),
+            "aggregate",
+        )
+        ref = forwarded.data["video_embeds"]
+        duplicated = make_stage_payload(
+            request_id="req-1", data={"left": ref, "right": dict(ref)}
+        )
+        consumer_control = RecordingStageControlPlane()
+        consumer = _make_stage(
+            "thinker",
+            relay=relay,
+            control_plane=consumer_control,
+            endpoints={"encoder": "inproc://encoder"},
+        )
+
+        # Act: materialize the payload containing duplicate descriptors.
+        materialized = await consumer._materialize_tensor_refs("req-1", duplicated)
+
+        # Assert: object_id is the deduplication key for the whole materialization.
+        assert relay.get_calls == 1
+        assert materialized.data["left"] is materialized.data["right"]
+        assert len(consumer_control.sent_to_stage) == 1
+
+        _, _, ack = consumer_control.sent_to_stage[0]
+        producer._comm.ack_transfer(ack)
+        await wait_until(lambda: relay.ops[0].waited)
+
+    asyncio.run(_run())
+
+
+def test_consumer_read_failure_sends_failed_ack_and_ends_sender_operation() -> None:
+    """A failed read becomes a failed ACK and terminates the producer resource."""
+
+    async def _run() -> None:
+        # Arrange: publish successfully, then fail the consumer's Relay read.
+        relay = FakeRelay()
+        producer = _make_stage(
+            "encoder",
+            relay=relay,
+            endpoints={"aggregate": "inproc://aggregate"},
+            tensor_ref_policies={"aggregate": _policy("video_embeds")},
+        )
+        forwarded, _ = await producer._externalize_tensor_refs(
+            make_stage_payload(
+                request_id="req-1", data={"video_embeds": torch.arange(8)}
+            ),
+            "aggregate",
+        )
+        ref = TensorRef.from_dict(forwarded.data["video_embeds"])
+        relay.fail_get = RuntimeError("read failed")
+        consumer_control = RecordingStageControlPlane()
+        consumer = _make_stage(
+            "thinker",
+            relay=relay,
+            control_plane=consumer_control,
+            endpoints={"encoder": "inproc://encoder"},
+        )
+
+        # Act: materialization fails at the data-plane read boundary.
+        with pytest.raises(RuntimeError, match="read failed"):
+            await consumer._materialize_tensor_refs("req-1", forwarded)
+
+        # Assert: the failed ACK identifies the same publication and releases it.
+        assert len(consumer_control.sent_to_stage) == 1
+        target, _, ack = consumer_control.sent_to_stage[0]
+        assert target == "encoder"
+        assert ack.object_id == ref.data_ref.object_id
+        assert ack.success is False
+        assert ack.error == "read failed"
+
+        producer._comm.ack_transfer(ack)
+        await wait_until(lambda: relay.ops[0].waited)
+        assert str(relay.ops[0].failed) == "read failed"
+
+    asyncio.run(_run())
+
+
+# Abort: only unresolved refs owned by the final consumer receive failed ACKs.
+
+
+def test_consumer_abort_fails_all_unresolved_tensor_refs_for_request() -> None:
+    """Request abort emits one failed ACK for every unresolved consumer ref."""
+
+    async def _run() -> None:
+        # Arrange: thinker has discovered two refs belonging to one request.
+        control = RecordingStageControlPlane()
+        scheduler = FakeScheduler()
+        consumer = _make_stage(
+            "thinker",
+            relay=FakeRelay(),
+            control_plane=control,
+            endpoints={"encoder": "inproc://encoder"},
+            scheduler=scheduler,
+        )
+        refs = [
+            _make_tensor_ref(object_id="tensor-ref-1", path="video_embeds[0]"),
+            _make_tensor_ref(object_id="tensor-ref-2", path="video_embeds[1]"),
+        ]
+        payload = make_stage_payload(
+            request_id="req-1", data={"video_embeds": [ref.to_dict() for ref in refs]}
+        )
+        consumer._remember_tensor_refs("req-1", payload)
+
+        # Act: abort the request before either ref is materialized.
+        consumer._on_abort("req-1")
+        await asyncio.gather(*list(consumer._receive_tasks))
+
+        # Assert: request work and both unresolved publications reach failure.
+        assert scheduler.aborted == ["req-1"]
+        tensor_acks = [message for _, _, message in control.sent_to_stage]
+        assert {ack.object_id for ack in tensor_acks} == {
+            ref.data_ref.object_id for ref in refs
+        }
+        assert all(ack.success is False for ack in tensor_acks)
+        assert all(ack.error == "request aborted" for ack in tensor_acks)
+
+    asyncio.run(_run())
+
+
+def test_aborted_non_consumer_does_not_ack_refs_in_relay_payload() -> None:
+    """A relay Stage drains and ACKs the payload but never ACKs forwarded refs."""
+
+    async def _run() -> None:
+        # Arrange: aggregate receives an already-aborted relay payload for thinker.
+        relay = FakeRelay()
+        ref = _make_tensor_ref()
+        payload = make_stage_payload(
+            request_id="req-1", data={"video_embeds": ref.to_dict()}
+        )
+        data_ref, _ = await stage_io.write_payload(
+            relay,
+            "req-1",
+            payload,
+            transport=TransportKind.SHM,
+            from_stage="encoder",
+            to_stage="aggregate",
+        )
+        control = RecordingStageControlPlane()
+        receiver = _make_stage(
+            "aggregate",
+            relay=relay,
+            control_plane=control,
+            endpoints={"encoder": "inproc://encoder"},
+        )
+        receiver._aborted.add("req-1")
+
+        # Act: discard the late payload rather than scheduling it.
+        await receiver._on_data_ready(
+            DataReadyMessage(
+                request_id="req-1",
+                from_stage="encoder",
+                to_stage="aggregate",
+                data_ref=data_ref.to_dict(),
+            )
+        )
+
+        # Assert: data is drained and only the outer payload object is ACKed.
+        acked_ids = {
+            message.object_id
+            for _, _, message in control.sent_to_stage
+            if isinstance(message, DataAckMessage)
+        }
+        assert relay.get_calls == 1
+        assert data_ref.object_id in acked_ids
+        assert ref.data_ref.object_id not in acked_ids
+
+    asyncio.run(_run())
+
+
+def test_aborted_non_consumer_does_not_ack_refs_in_direct_ipc_payload(
+    monkeypatch,
+) -> None:
+    """Direct-IPC discard consumes the payload without claiming consumer status."""
+    deserialize_calls = 0
+    deserialize = stage_io.deserialize_direct_cuda_ipc_payload
+
+    def _record_deserialize(data_ref):
+        nonlocal deserialize_calls
+        deserialize_calls += 1
+        return deserialize(data_ref)
+
+    monkeypatch.setattr(
+        stage_io, "deserialize_direct_cuda_ipc_payload", _record_deserialize
+    )
+
+    async def _run() -> None:
+        # Arrange: aggregate receives an inline descriptor intended for thinker.
+        ref = _make_tensor_ref()
+        payload = make_stage_payload(
+            request_id="req-1", data={"video_embeds": ref.to_dict()}
+        )
+        control = RecordingStageControlPlane()
+        receiver = _make_stage(
+            "aggregate",
+            relay=FakeRelay(),
+            control_plane=control,
+            endpoints={"encoder": "inproc://encoder"},
+        )
+        receiver._aborted.add("req-1")
+
+        # Act: discard the direct-IPC payload.
+        await receiver._on_data_ready(
+            DataReadyMessage(
+                request_id="req-1",
+                from_stage="encoder",
+                to_stage="aggregate",
+                data_ref=_direct_payload_ref(payload),
+            )
+        )
+
+        # Assert: the direct descriptor was consumed and no TensorRef was ACKed.
+        assert deserialize_calls == 1
+        assert not any(
+            isinstance(message, DataAckMessage)
+            and message.object_id == ref.data_ref.object_id
+            for _, _, message in control.sent_to_stage
+        )
+
+    asyncio.run(_run())
+
+
+def test_aborted_consumer_fails_refs_in_discarded_relay_payload() -> None:
+    """A late relay payload is drained before its final consumer fails its refs."""
+
+    async def _run() -> None:
+        # Arrange: thinker has already aborted when aggregate's payload arrives.
+        relay = FakeRelay()
+        ref = _make_tensor_ref()
+        payload = make_stage_payload(
+            request_id="req-1", data={"video_embeds": ref.to_dict()}
+        )
+        data_ref, _ = await stage_io.write_payload(
+            relay,
+            "req-1",
+            payload,
+            transport=TransportKind.SHM,
+            from_stage="aggregate",
+            to_stage="thinker",
+        )
+        control = RecordingStageControlPlane()
+        receiver = _make_stage(
+            "thinker",
+            relay=relay,
+            control_plane=control,
+            endpoints={
+                "aggregate": "inproc://aggregate",
+                "encoder": "inproc://encoder",
+            },
+        )
+        receiver._aborted.add("req-1")
+
+        # Act: discard the late relay payload.
+        await receiver._on_data_ready(
+            DataReadyMessage(
+                request_id="req-1",
+                from_stage="aggregate",
+                to_stage="thinker",
+                data_ref=data_ref.to_dict(),
+            )
+        )
+
+        # Assert: the outer payload succeeds, while the unresolved ref fails.
+        acks = {
+            message.object_id: message
+            for _, _, message in control.sent_to_stage
+            if isinstance(message, DataAckMessage)
+        }
+        assert acks[data_ref.object_id].success is True
+        assert acks[ref.data_ref.object_id].success is False
+        assert acks[ref.data_ref.object_id].error == "request aborted"
+
+    asyncio.run(_run())
+
+
+def test_aborted_consumer_fails_refs_in_discarded_direct_ipc_payload() -> None:
+    """A late direct-IPC payload lets the final consumer fail embedded refs."""
+
+    async def _run() -> None:
+        # Arrange: thinker has already aborted when an inline payload arrives.
+        ref = _make_tensor_ref()
+        payload = make_stage_payload(
+            request_id="req-1", data={"video_embeds": ref.to_dict()}
+        )
+        control = RecordingStageControlPlane()
+        receiver = _make_stage(
+            "thinker",
+            relay=FakeRelay(),
+            control_plane=control,
+            endpoints={"encoder": "inproc://encoder"},
+        )
+        receiver._aborted.add("req-1")
+
+        # Act: discard and inspect the direct-IPC payload.
+        await receiver._on_data_ready(
+            DataReadyMessage(
+                request_id="req-1",
+                from_stage="aggregate",
+                to_stage="thinker",
+                data_ref=_direct_payload_ref(payload),
+            )
+        )
+
+        # Assert: thinker sends one failed terminal ACK to encoder.
+        assert len(control.sent_to_stage) == 1
+        target, _, ack = control.sent_to_stage[0]
+        assert target == "encoder"
+        assert ack.object_id == ref.data_ref.object_id
+        assert ack.success is False
+        assert ack.error == "request aborted"
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# TensorRef observability
+# ---------------------------------------------------------------------------
+
+
+def test_tensor_ref_stats_are_attached_to_payload_hop(monkeypatch) -> None:
+    """A hop event reports the count and physical bytes externalized on that edge."""
+    events: list[dict] = []
+    monkeypatch.setattr(
+        "sglang_omni.pipeline.stage.runtime._emit_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+
+    async def _run() -> None:
+        # Arrange: one int64 tensor (8 x 8 bytes) is eligible on the edge.
+        relay = FakeRelay()
+        control = RecordingStageControlPlane()
+        producer = _make_stage(
+            "encoder",
+            relay=relay,
+            control_plane=control,
+            endpoints={"aggregate": "inproc://aggregate"},
+            tensor_ref_policies={"aggregate": _policy("video_embeds")},
+        )
+
+        # Act: send a payload through the normal Stage hop.
+        await producer._send_to_stage(
+            "req-1",
+            "aggregate",
+            make_stage_payload(
+                request_id="req-1", data={"video_embeds": torch.arange(8)}
+            ),
+            allow_local_object=False,
+        )
+
+        # Assert: observability reports bytes, not element count.
+        hop = next(event for event in events if event["event_name"] == "stage_hop_sent")
+        assert hop["metadata"]["tensor_ref_count"] == 1
+        assert hop["metadata"]["tensor_ref_bytes"] == 64
+
+        # Cleanup: ACK both the outer payload and its embedded TensorRef.
+        _, _, payload_message = control.sent_to_stage[0]
+        payload_ref = DataRef.from_dict(payload_message.data_ref)
+        forwarded = stage_io.deserialize_payload_header(payload_ref)
+        tensor_ref = TensorRef.from_dict(forwarded.data["video_embeds"])
+        producer._comm.ack_transfer(
+            DataAckMessage(
+                request_id="req-1",
+                from_stage="aggregate",
+                to_stage="encoder",
+                object_id=payload_ref.object_id,
+            )
+        )
+        producer._comm.ack_transfer(
+            DataAckMessage(
+                request_id="req-1",
+                from_stage="thinker",
+                to_stage="encoder",
+                object_id=tensor_ref.data_ref.object_id,
+            )
+        )
+        await wait_until(lambda: all(op.waited for op in relay.ops))
+
+    asyncio.run(_run())

--- a/tests/unit_test/qwen3_omni/test_tensor_ref.py
+++ b/tests/unit_test/qwen3_omni/test_tensor_ref.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen3-Omni TensorRef configuration and relay-merge contracts."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from sglang_omni.comm.data_ref import (
+    BackendRef,
+    DataKind,
+    DataLayout,
+    DataRef,
+    TransportKind,
+)
+from sglang_omni.comm.tensor_ref import TensorRef
+from sglang_omni.models.qwen3_omni.config import Qwen3OmniPipelineConfig
+from sglang_omni.models.qwen3_omni.merge import merge_for_thinker
+from sglang_omni.models.qwen3_omni.payload_types import Qwen3OmniPipelineState
+from tests.unit_test.fixtures.qwen_fakes import make_qwen_payload, make_qwen_state
+
+_TENSOR_REF_BYTES = 3 * 1024 * 1024
+
+
+def _visual_deepstack_ref(modality: str) -> TensorRef:
+    return TensorRef(
+        request_id="req-1",
+        producer_stage="image_encoder",
+        consumer_stage="thinker",
+        path=("encoder_outs.image_encoder." f"deepstack_visual_embeds_{modality}[0]"),
+        nbytes=_TENSOR_REF_BYTES,
+        data_ref=DataRef(
+            version=1,
+            kind=DataKind.TENSOR_REF,
+            object_id=f"tensor-ref-{modality}",
+            transport=TransportKind.SHM,
+            layout=DataLayout.RAW_TENSOR,
+            buffer=BackendRef(
+                transport=TransportKind.SHM,
+                info={"transfer_info": {"size": _TENSOR_REF_BYTES}},
+                length=_TENSOR_REF_BYTES,
+            ),
+            shape=(_TENSOR_REF_BYTES // 4,),
+            dtype="torch.float32",
+            offset=0,
+        ),
+    )
+
+
+def test_qwen_config_declares_visual_tensor_ref_edge() -> None:
+    config = Qwen3OmniPipelineConfig(model_path="model")
+    image_encoder = next(
+        stage for stage in config.stages if stage.name == "image_encoder"
+    )
+    edge = image_encoder.tensor_ref_edges["mm_aggregate"]
+
+    assert edge.consumer_stage == "thinker"
+    assert edge.threshold_mb == 2.0
+    assert edge.paths == (
+        "encoder_outs.image_encoder.deepstack_visual_embeds_image",
+        "encoder_outs.image_encoder.deepstack_visual_embeds_video",
+    )
+
+
+@pytest.mark.parametrize(
+    "deepstack_output_keys",
+    [
+        {"image": "deepstack_visual_embeds"},
+        {"video": "deepstack_visual_embeds"},
+        {
+            "image": "image_deepstack_visual_embeds",
+            "video": "video_deepstack_visual_embeds",
+        },
+    ],
+    ids=("image-only", "video-only", "image-and-video"),
+)
+def test_qwen_mm_aggregate_forwards_configured_deepstack_tensor_refs(
+    deepstack_output_keys: dict[str, str],
+) -> None:
+    refs = {
+        modality: _visual_deepstack_ref(modality) for modality in deepstack_output_keys
+    }
+    encoder_out: dict[str, object] = {}
+    for modality, ref in refs.items():
+        encoder_out[f"{modality}_embeds"] = torch.ones((1, 1))
+        encoder_out[f"deepstack_visual_embeds_{modality}"] = [ref.to_dict()]
+
+    preprocessing = make_qwen_payload(
+        make_qwen_state(mm_inputs={"image": {}}), request_id="req-1"
+    )
+    image_encoder = make_qwen_payload(
+        Qwen3OmniPipelineState(encoder_outs={"image_encoder": encoder_out}),
+        request_id="req-1",
+    )
+
+    merged = merge_for_thinker(
+        {"preprocessing": preprocessing, "image_encoder": image_encoder}
+    )
+    state = Qwen3OmniPipelineState.from_dict(merged.data)
+    model_inputs = state.thinker_inputs["model_inputs"]
+
+    assert {key for key in model_inputs if "deepstack" in key} == set(
+        deepstack_output_keys.values()
+    )
+    for modality, output_key in deepstack_output_keys.items():
+        assert model_inputs[output_key] == [refs[modality].to_dict()]


### PR DESCRIPTION
Stacked on #869. This PR targets `phase0-intra-node-nvlink-relay`; `main` remains unchanged until #869 lands.

## Context

TensorRef forwarding landed on `main` in #808, while #869 replaced the old `relay_io` path with the new `comm` / `stage_io` data plane. The need to reconcile them was identified in [this #869 review](https://github.com/sgl-project/sglang-omni/pull/869#discussion_r3521966803), and #941 retained “the TensorRef port” as a follow-up.

## Changes

- Add a versioned `TensorRef` backed by `DataRef(kind=tensor_ref)`.
- Add `StageConfig.tensor_ref_edges` configuration for paths, thresholds, and final consumers.
- Externalize only configured tensors at or above the threshold.
- Keep producer resources alive until the final consumer sends a success or failure ACK.
- Let intermediate stages forward references without reading or acknowledging them.
- Handle materialization, duplicate references, read failures, request failures, and aborts.
- Report TensorRef count and physical bytes in hop events.
- Fall back to the Relay selected by `CommRouter` when direct CUDA-IPC serialization is unavailable. This fixes the observed Qwen payload header of 165,440 bytes exceeding the 64 KiB direct-path limit.
- Enable Qwen3-Omni TensorRefs for visual deepstack tensors at or above 2 MiB on `image_encoder -> mm_aggregate -> thinker`.

In speech configurations, the main image/video embeddings stay on the ordinary payload path because the talker also consumes them. `merge.py` is unchanged because its existing merge logic already forwards nested TensorRef values without interpreting them.

## Relationship to #932

#932 implements per-edge TensorRef policies on its `main`-based `relay_io` path. This PR follows the same configuration and Qwen3-Omni policy design.

The data-plane implementations differ:

- #932 reuses #808's Relay blob representation; this PR uses #869's `DataRef`.
- #932 matches leaf field names; this PR matches complete payload paths.
- #932 uses the old Relay release lifecycle; this PR retains producer operations until final-consumer ACKs.
- Failure and abort cleanup are reported to the original producer through failed ACKs.

The #932 policy model is the design reference; its patch is not applied directly because it targets a different communication stack.

## Tests

### Unit tests

The tests added by this PR do not require a GPU.

```bash
python -m pytest -q \
  tests/unit_test/pipeline/test_tensor_ref.py \
  tests/unit_test/pipeline/test_comm_engine_ack.py \
  tests/unit_test/pipeline/test_runtime_schema.py \
  tests/unit_test/pipeline/test_stage.py \
  tests/unit_test/qwen3_omni/test_tensor_ref.py
```

Result: `76 passed`. Pre-commit passed on all changed files.

### Performance tests

Not included in this PR. Baseline and TensorRef performance comparisons will be added separately.

## Functional validation

Two one-request Qwen3-Omni smoke runs passed on commit `fbe129ef88c37554d325ceb8e9fa360a3ffb9084`:

- Cross-GPU TensorRef: `image_encoder` ran on logical GPU 1 and the final consumer `thinker` ran on logical GPU 0. All 3 TensorRefs, totaling 65,863,680 bytes, recorded `cuda_ipc_get_async` with `src_device=1` and `dst_device=0`.
- Same-GPU fallback: the same workload that produced a 165,440-byte direct header completed through the configured CUDA-IPC Relay fallback.

For the cross-GPU run, the published object-ID set matched both the consumer-read set and the producer-ACKed set. These are correctness checks, not performance results.

Related: #862, #808, #869, #932, #941
