### PR TITLE
[Perf][Higgs TTS] Prefill admission coalescing + out-of-process vocoder + compiled codec decode

### DIFF
--- a/sglang_omni/models/higgs_tts/config.py
+++ b/sglang_omni/models/higgs_tts/config.py
@@ -46,6 +46,9 @@ class HiggsTtsPipelineConfig(PipelineConfig):
             factory=f"{_PKG}.stages.create_audio_encoder_executor",
             factory_args={"device": "cuda"},
             gpu=0,
+            runtime=StageRuntimeConfig(
+                resources=StageResourceConfig(total_gpu_memory_fraction=0.03)
+            ),
             next="tts_engine",
         ),
         StageConfig(
@@ -58,15 +61,21 @@ class HiggsTtsPipelineConfig(PipelineConfig):
                 "enable_async_decode": True,
             },
             gpu=0,
+            runtime=StageRuntimeConfig(
+                resources=StageResourceConfig(total_gpu_memory_fraction=0.85)
+            ),
             next="vocoder",
             stream_to=["vocoder"],
         ),
         StageConfig(
             name="vocoder",
-            process="pipeline",
+            process="vocoder",
             factory=f"{_PKG}.stages.create_vocoder_executor",
-            factory_args={"device": "cuda"},
+            factory_args={"device": "cuda",  "compile_decode": True},
             gpu=0,
+            runtime=StageRuntimeConfig(
+                resources=StageResourceConfig(total_gpu_memory_fraction=0.10)
+            ),
             terminal=True,
             can_accept_stream_before_payload=True,
         ),

--- a/sglang_omni/models/higgs_tts/config.py
+++ b/sglang_omni/models/higgs_tts/config.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
-from sglang_omni.config import PipelineConfig, StageConfig
+from sglang_omni.config import (
+    PipelineConfig,
+    StageConfig,
+    StageResourceConfig,
+    StageRuntimeConfig,
+)
 
 _PKG = "sglang_omni.models.higgs_tts"
 

--- a/sglang_omni/models/higgs_tts/config.py
+++ b/sglang_omni/models/higgs_tts/config.py
@@ -71,7 +71,7 @@ class HiggsTtsPipelineConfig(PipelineConfig):
             name="vocoder",
             process="vocoder",
             factory=f"{_PKG}.stages.create_vocoder_executor",
-            factory_args={"device": "cuda",  "compile_decode": True},
+            factory_args={"device": "cuda", "compile_decode": True},
             gpu=0,
             runtime=StageRuntimeConfig(
                 resources=StageResourceConfig(total_gpu_memory_fraction=0.10)

--- a/sglang_omni/models/higgs_tts/engine_builder.py
+++ b/sglang_omni/models/higgs_tts/engine_builder.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib
+import os
 from typing import Any
 
 from sglang_omni.models.higgs_tts import request_builders
@@ -29,6 +30,8 @@ class HiggsTtsEngineBuilder(TtsEngineBuilder):
         async_decode_min_batch_size: int,
         stream_stride: int = DEFAULT_HIGGS_STREAM_STRIDE,
         stream_followup_stride: int = DEFAULT_HIGGS_STREAM_FOLLOWUP_STRIDE,
+        prefill_coalesce_requests: int = 0,
+        prefill_coalesce_wait_ms: float = 60.0,
     ) -> None:
         self.max_new_tokens = max_new_tokens
         self.max_running_requests = max_running_requests
@@ -37,6 +40,8 @@ class HiggsTtsEngineBuilder(TtsEngineBuilder):
         self.async_decode_min_batch_size = async_decode_min_batch_size
         self.stream_stride = stream_stride
         self.stream_followup_stride = stream_followup_stride
+        self.prefill_coalesce_requests = prefill_coalesce_requests
+        self.prefill_coalesce_wait_ms = prefill_coalesce_wait_ms
         self.model: Any | None = None
 
     def generation_defaults(
@@ -100,6 +105,8 @@ class HiggsTtsEngineBuilder(TtsEngineBuilder):
         return {
             "enable_async_decode": self.enable_async_decode,
             "async_decode_min_batch_size": self.async_decode_min_batch_size,
+            "prefill_coalesce_requests": self.prefill_coalesce_requests,
+            "prefill_coalesce_wait_ms": self.prefill_coalesce_wait_ms,
         }
 
     def post_scheduler_setup(self, scheduler: Any, model_runner: Any) -> None:

--- a/sglang_omni/models/higgs_tts/engine_builder.py
+++ b/sglang_omni/models/higgs_tts/engine_builder.py
@@ -31,6 +31,7 @@ class HiggsTtsEngineBuilder(TtsEngineBuilder):
         stream_followup_stride: int = DEFAULT_HIGGS_STREAM_FOLLOWUP_STRIDE,
         prefill_coalesce_requests: int = 0,
         prefill_coalesce_wait_ms: float = 60.0,
+        total_gpu_memory_fraction: float | None = None,
     ) -> None:
         self.max_new_tokens = max_new_tokens
         self.max_running_requests = max_running_requests
@@ -41,6 +42,7 @@ class HiggsTtsEngineBuilder(TtsEngineBuilder):
         self.stream_followup_stride = stream_followup_stride
         self.prefill_coalesce_requests = prefill_coalesce_requests
         self.prefill_coalesce_wait_ms = prefill_coalesce_wait_ms
+        self.total_gpu_memory_fraction = total_gpu_memory_fraction
         self.model: Any | None = None
 
     def generation_defaults(
@@ -57,7 +59,13 @@ class HiggsTtsEngineBuilder(TtsEngineBuilder):
             "max_running_requests": self.max_running_requests,
             "cuda_graph_max_bs": self.cuda_graph_max_bs,
             "disable_cuda_graph": False,
-            "mem_fraction_static": 0.85,
+            # The stage's runtime.resources.total_gpu_memory_fraction is the
+            # single source of truth when set; 0.85 only applies without one.
+            "mem_fraction_static": (
+                self.total_gpu_memory_fraction
+                if self.total_gpu_memory_fraction is not None
+                else 0.85
+            ),
             "chunked_prefill_size": 8192,
             "dtype": "bfloat16",
         }

--- a/sglang_omni/models/higgs_tts/engine_builder.py
+++ b/sglang_omni/models/higgs_tts/engine_builder.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib
+import logging
 from typing import Any
 
 from sglang_omni.models.higgs_tts import request_builders
@@ -13,6 +14,8 @@ from sglang_omni.models.higgs_tts.vocoder_scheduler import (
     DEFAULT_HIGGS_STREAM_STRIDE,
 )
 from sglang_omni.scheduling.engine_factory import TtsEngineBuilder
+
+logger = logging.getLogger(__name__)
 
 
 class HiggsTtsEngineBuilder(TtsEngineBuilder):
@@ -33,6 +36,13 @@ class HiggsTtsEngineBuilder(TtsEngineBuilder):
         prefill_coalesce_wait_ms: float = 60.0,
         total_gpu_memory_fraction: float | None = None,
     ) -> None:
+        if total_gpu_memory_fraction is not None and not (
+            0.0 < total_gpu_memory_fraction < 1.0
+        ):
+            raise ValueError(
+                "Higgs tts_engine total_gpu_memory_fraction must be in (0, 1): "
+                "it drives sglang mem_fraction_static, which requires < 1"
+            )
         self.max_new_tokens = max_new_tokens
         self.max_running_requests = max_running_requests
         self.cuda_graph_max_bs = cuda_graph_max_bs
@@ -67,6 +77,22 @@ class HiggsTtsEngineBuilder(TtsEngineBuilder):
             "chunked_prefill_size": 8192,
             "dtype": "bfloat16",
         }
+
+    def adjust_overrides(self, overrides: dict[str, Any]) -> None:
+        # Note: (Jiaxin Deng) an explicit mem_fraction_static override (e.g.
+        # --talker-mem-fraction-static) wins, but never silently.
+        expected = self.total_gpu_memory_fraction
+        if expected is None:
+            return
+        actual = overrides.get("mem_fraction_static")
+        if actual is not None and abs(actual - expected) <= 1e-9:
+            return
+        logger.warning(
+            "Higgs tts_engine mem_fraction_static=%s overrides the "
+            "placement-validated total_gpu_memory_fraction=%s",
+            actual,
+            expected,
+        )
 
     def customize_server_args(self, server_args: Any) -> None:
         server_args.disable_overlap_schedule = True

--- a/sglang_omni/models/higgs_tts/engine_builder.py
+++ b/sglang_omni/models/higgs_tts/engine_builder.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import importlib
-import os
 from typing import Any
 
 from sglang_omni.models.higgs_tts import request_builders

--- a/sglang_omni/models/higgs_tts/engine_builder.py
+++ b/sglang_omni/models/higgs_tts/engine_builder.py
@@ -59,8 +59,6 @@ class HiggsTtsEngineBuilder(TtsEngineBuilder):
             "max_running_requests": self.max_running_requests,
             "cuda_graph_max_bs": self.cuda_graph_max_bs,
             "disable_cuda_graph": False,
-            # The stage's runtime.resources.total_gpu_memory_fraction is the
-            # single source of truth when set; 0.85 only applies without one.
             "mem_fraction_static": (
                 self.total_gpu_memory_fraction
                 if self.total_gpu_memory_fraction is not None

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -517,7 +517,7 @@ def create_vocoder_executor(
                 dtype=torch.long,
                 device="cpu",
             )
-            # note (stephenkgli): Match serving's contiguous [T, N] layout and
+            # Note: (stephenkgli) match serving's contiguous [T, N] layout and
             # warm the zero-one-specialized batch and frame-count classes.
             for frame_count in _VOCODER_COMPILE_WARMUP_FRAME_COUNTS:
                 frame_codes_TN = warm_codes_TN[:frame_count]

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -79,6 +79,7 @@ _REF_CODE_CACHE_MAX_ITEMS = 256
 _REF_CODE_CACHE_MAX_BYTES = 256 * 1024 * 1024
 _REF_WAVEFORM_CACHE_MAX_ITEMS = 256
 _REF_WAVEFORM_CACHE_MAX_BYTES = 512 * 1024 * 1024
+_VOCODER_COMPILE_WARMUP_FRAME_COUNTS = (1, 8)
 
 
 def _reference_audio_cache_key(reference_audio: Any) -> str | None:
@@ -506,11 +507,20 @@ def create_vocoder_executor(
         eager_decode = codec.model.decode
         try:
             codec.model.decode = torch.compile(eager_decode, dynamic=True)
-            warm_codes = codec.encode_reference(
-                torch.zeros(codec.SAMPLE_RATE // 2), sample_rate=codec.SAMPLE_RATE
+            warm_codes_TN = torch.zeros(
+                (
+                    max(_VOCODER_COMPILE_WARMUP_FRAME_COUNTS),
+                    int(codec.model.config.num_quantizers),
+                ),
+                dtype=torch.long,
+                device="cpu",
             )
-            codec.decode(warm_codes)
-            codec.decode_batch([warm_codes[:8], warm_codes[:8]])
+            # note (stephenkgli): Match serving's contiguous [T, N] layout and
+            # warm the zero-one-specialized batch and frame-count classes.
+            for frame_count in _VOCODER_COMPILE_WARMUP_FRAME_COUNTS:
+                frame_codes_TN = warm_codes_TN[:frame_count]
+                codec.decode(frame_codes_TN)
+                codec.decode_batch([frame_codes_TN, frame_codes_TN])
         except Exception:
             logger.warning(
                 "torch.compile of the codec decode failed; falling back to the "

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -503,7 +503,24 @@ def create_vocoder_executor(
     checkpoint_dir = resolve_checkpoint(model_path)
     codec = get_or_load_codec(checkpoint_dir, device, dtype)
     if compile_decode:
-        codec.model.decode = torch.compile(codec.model.decode, dynamic=True)
+        eager_decode = codec.model.decode
+        try:
+            codec.model.decode = torch.compile(eager_decode, dynamic=True)
+            # torch.compile is lazy: warm it here so the first request does not
+            # stall the vocoder thread, and so an inductor failure degrades to
+            # eager at startup instead of erroring every request.
+            warm_codes = codec.encode_reference(
+                torch.zeros(codec.SAMPLE_RATE // 2), sample_rate=codec.SAMPLE_RATE
+            )
+            codec.decode(warm_codes)
+            codec.decode_batch([warm_codes[:8], warm_codes[:8]])
+        except Exception:
+            logger.warning(
+                "torch.compile of the codec decode failed; falling back to the "
+                "eager vocoder decode",
+                exc_info=True,
+            )
+            codec.model.decode = eager_decode
 
     return HiggsStreamingVocoderScheduler(
         codec,

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -506,9 +506,6 @@ def create_vocoder_executor(
         eager_decode = codec.model.decode
         try:
             codec.model.decode = torch.compile(eager_decode, dynamic=True)
-            # torch.compile is lazy: warm it here so the first request does not
-            # stall the vocoder thread, and so an inductor failure degrades to
-            # eager at startup instead of erroring every request.
             warm_codes = codec.encode_reference(
                 torch.zeros(codec.SAMPLE_RATE // 2), sample_rate=codec.SAMPLE_RATE
             )

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -460,6 +460,8 @@ def create_sglang_tts_engine_executor(
     async_decode_min_batch_size: int = 2,
     stream_stride: int = DEFAULT_HIGGS_STREAM_STRIDE,
     stream_followup_stride: int = DEFAULT_HIGGS_STREAM_FOLLOWUP_STRIDE,
+    prefill_coalesce_requests: int = 0,
+    prefill_coalesce_wait_ms: float = 60.0,
 ):
     """sglang-backed AR engine for Higgs TTS."""
     from sglang_omni.models.higgs_tts.engine_builder import HiggsTtsEngineBuilder
@@ -472,6 +474,8 @@ def create_sglang_tts_engine_executor(
         async_decode_min_batch_size=async_decode_min_batch_size,
         stream_stride=stream_stride,
         stream_followup_stride=stream_followup_stride,
+        prefill_coalesce_requests=prefill_coalesce_requests,
+        prefill_coalesce_wait_ms=prefill_coalesce_wait_ms,
     ).build(
         model_path,
         device=device,
@@ -490,6 +494,7 @@ def create_vocoder_executor(
     stream_followup_stride: int = DEFAULT_HIGGS_STREAM_FOLLOWUP_STRIDE,
     stream_overlap_tokens: int = 8,
     stream_holdback_tokens: int = 4,
+    compile_decode: bool = False,
 ):
     """Decode Higgs delayed codes to a mono 24 kHz waveform.
 
@@ -497,6 +502,8 @@ def create_vocoder_executor(
     """
     checkpoint_dir = resolve_checkpoint(model_path)
     codec = get_or_load_codec(checkpoint_dir, device, dtype)
+    if compile_decode:
+        codec.model.decode = torch.compile(codec.model.decode, dynamic=True)
 
     return HiggsStreamingVocoderScheduler(
         codec,

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -463,6 +463,7 @@ def create_sglang_tts_engine_executor(
     stream_followup_stride: int = DEFAULT_HIGGS_STREAM_FOLLOWUP_STRIDE,
     prefill_coalesce_requests: int = 0,
     prefill_coalesce_wait_ms: float = 60.0,
+    total_gpu_memory_fraction: float | None = None,
 ):
     """sglang-backed AR engine for Higgs TTS."""
     from sglang_omni.models.higgs_tts.engine_builder import HiggsTtsEngineBuilder
@@ -477,6 +478,7 @@ def create_sglang_tts_engine_executor(
         stream_followup_stride=stream_followup_stride,
         prefill_coalesce_requests=prefill_coalesce_requests,
         prefill_coalesce_wait_ms=prefill_coalesce_wait_ms,
+        total_gpu_memory_fraction=total_gpu_memory_fraction,
     ).build(
         model_path,
         device=device,

--- a/sglang_omni/models/higgs_tts/utils.py
+++ b/sglang_omni/models/higgs_tts/utils.py
@@ -29,8 +29,8 @@ from sglang_omni.utils.checkpoint import resolve_checkpoint
 BOC_ID = 1024
 EOC_ID = 1025
 
-# Note(maydomine): Per-process codec cache. audio_encoder and the vocoder now live in
-# separate processes, so each loads its own copy
+# Note: (maydomine) per-process cache: audio_encoder and the vocoder live in
+# separate processes, so each loads its own copy.
 _CODEC_CACHE: dict[tuple[str, str, str], HiggsAudioCodec] = {}
 
 

--- a/sglang_omni/models/higgs_tts/utils.py
+++ b/sglang_omni/models/higgs_tts/utils.py
@@ -29,7 +29,9 @@ from sglang_omni.utils.checkpoint import resolve_checkpoint
 BOC_ID = 1024
 EOC_ID = 1025
 
-# Shared between audio_encoder + vocoder; one codec load saves ~1 GB VRAM.
+# Per-process codec cache. audio_encoder and the vocoder now live in
+# separate processes, so each loads its own copy (~130 MB extra VRAM
+# measured); within a process the cache still dedupes loads.
 _CODEC_CACHE: dict[tuple[str, str, str], HiggsAudioCodec] = {}
 
 

--- a/sglang_omni/models/higgs_tts/utils.py
+++ b/sglang_omni/models/higgs_tts/utils.py
@@ -29,9 +29,8 @@ from sglang_omni.utils.checkpoint import resolve_checkpoint
 BOC_ID = 1024
 EOC_ID = 1025
 
-# Per-process codec cache. audio_encoder and the vocoder now live in
-# separate processes, so each loads its own copy (~130 MB extra VRAM
-# measured); within a process the cache still dedupes loads.
+# Note(maydomine): Per-process codec cache. audio_encoder and the vocoder now live in
+# separate processes, so each loads its own copy
 _CODEC_CACHE: dict[tuple[str, str, str], HiggsAudioCodec] = {}
 
 

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -839,8 +839,6 @@ class OmniScheduler:
         # oldest queued request, so partial admission or aborts never restart it.
         if self.prefill_coalesce_requests <= 1 or self.chunked_req is not None:
             return _Upstream.get_new_batch_prefill(self)
-        # With no decode work in flight the loop is idle, so holding prefill
-        # amortizes nothing and only costs TTFB.
         if self.running_batch is None or self.running_batch.is_empty():
             return _Upstream.get_new_batch_prefill(self)
         waiting = self.waiting_queue
@@ -851,8 +849,6 @@ class OmniScheduler:
         for req in waiting:
             t = getattr(req, "_coalesce_enqueue_t", None)
             if t is None:
-                # Stamp-on-miss: an unstamped request starts aging from first
-                # observation, guaranteeing release within the wait deadline.
                 t = req._coalesce_enqueue_t = now
             oldest = min(oldest, t)
         if now - oldest >= self.prefill_coalesce_wait_s:

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -195,7 +195,7 @@ class OmniScheduler:
         if model_runner is not None:
             model_runner._async_enabled = enable_async_decode
 
-        # Prefill admission coalescing: hold prefill until K requests are
+        # Note(maydomine): Prefill admission coalescing: hold prefill until K requests are
         # waiting or the oldest has waited T ms, amortizing the per-step host
         # cost (mostly batch-size-independent) over more requests. 0 = off.
         if int(prefill_coalesce_requests) > 1 and int(server_args.tp_size) > 1:

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -839,11 +839,22 @@ class OmniScheduler:
         # oldest queued request, so partial admission or aborts never restart it.
         if self.prefill_coalesce_requests <= 1 or self.chunked_req is not None:
             return _Upstream.get_new_batch_prefill(self)
+        # With no decode work in flight the loop is idle, so holding prefill
+        # amortizes nothing and only costs TTFB.
+        if self.running_batch is None or self.running_batch.is_empty():
+            return _Upstream.get_new_batch_prefill(self)
         waiting = self.waiting_queue
         if not waiting or len(waiting) >= self.prefill_coalesce_requests:
             return _Upstream.get_new_batch_prefill(self)
         now = time.perf_counter()
-        oldest = min(getattr(req, "_coalesce_enqueue_t", now) for req in waiting)
+        oldest = now
+        for req in waiting:
+            t = getattr(req, "_coalesce_enqueue_t", None)
+            if t is None:
+                # Stamp-on-miss: an unstamped request starts aging from first
+                # observation, guaranteeing release within the wait deadline.
+                t = req._coalesce_enqueue_t = now
+            oldest = min(oldest, t)
         if now - oldest >= self.prefill_coalesce_wait_s:
             return _Upstream.get_new_batch_prefill(self)
         return None

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -118,6 +118,8 @@ class OmniScheduler:
         enable_overlap: bool = False,
         enable_async_decode: bool = False,
         async_decode_min_batch_size: int = 2,
+        prefill_coalesce_requests: int = 0,
+        prefill_coalesce_wait_ms: float = 60.0,
         request_build_max_workers: int = 1,
         request_build_max_pending: int | None = None,
     ):
@@ -192,6 +194,13 @@ class OmniScheduler:
         self.async_decode_min_batch_size = int(async_decode_min_batch_size)
         if model_runner is not None:
             model_runner._async_enabled = enable_async_decode
+
+        # Prefill admission coalescing: hold prefill until K requests are
+        # waiting or the oldest has waited T ms, amortizing the per-step host
+        # cost (mostly batch-size-independent) over more requests. 0 = off.
+        self.prefill_coalesce_requests = int(prefill_coalesce_requests)
+        self.prefill_coalesce_wait_s = float(prefill_coalesce_wait_ms) / 1e3
+        self._prefill_coalesce_t0: float | None = None
 
         # Token / memory info (upstream reads from tp_worker.get_worker_info)
         mr = tp_worker.model_runner
@@ -813,6 +822,27 @@ class OmniScheduler:
                 data=error,
             )
         )
+
+    def get_new_batch_prefill(self):
+        # NOTE(maydomine): requests often arrive faster than they batch, so the
+        # loop burns its time on tiny prefill batches. Set coalesce_requests /
+        # wait_ms to hold admission until a batch is worth its fixed step cost.
+        if self.prefill_coalesce_requests <= 1 or self.chunked_req is not None:
+            return _Upstream.get_new_batch_prefill(self)
+        if not self.waiting_queue:
+            self._prefill_coalesce_t0 = None
+            return _Upstream.get_new_batch_prefill(self)
+        if len(self.waiting_queue) >= self.prefill_coalesce_requests:
+            self._prefill_coalesce_t0 = None
+            return _Upstream.get_new_batch_prefill(self)
+        now = time.perf_counter()
+        if self._prefill_coalesce_t0 is None:
+            self._prefill_coalesce_t0 = now
+            return None
+        if now - self._prefill_coalesce_t0 >= self.prefill_coalesce_wait_s:
+            self._prefill_coalesce_t0 = None
+            return _Upstream.get_new_batch_prefill(self)
+        return None
 
     def run_batch(self, batch, pp_proxy_tensors=None):
         try:

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -195,9 +195,8 @@ class OmniScheduler:
         if model_runner is not None:
             model_runner._async_enabled = enable_async_decode
 
-        # Note(maydomine): Prefill admission coalescing: hold prefill until K requests are
-        # waiting or the oldest has waited T ms, amortizing the per-step host
-        # cost (mostly batch-size-independent) over more requests. 0 = off.
+        # Note: (maydomine) coalescing gate: hold prefill until K requests wait
+        # or the oldest has waited T ms; 0 disables.
         if int(prefill_coalesce_requests) > 1 and int(server_args.tp_size) > 1:
             logger.warning(
                 "Prefill admission coalescing is disabled for "
@@ -833,10 +832,8 @@ class OmniScheduler:
         )
 
     def get_new_batch_prefill(self):
-        # NOTE(maydomine): requests often arrive faster than they batch, so the
-        # loop burns its time on tiny prefill batches. Hold admission until the
-        # batch is worth its fixed step cost; the deadline is measured from the
-        # oldest queued request, so partial admission or aborts never restart it.
+        # Note: (maydomine) batch prefill admissions to amortize the fixed step
+        # cost; the oldest-request deadline survives partial admission and aborts.
         if self.prefill_coalesce_requests <= 1 or self.chunked_req is not None:
             return _Upstream.get_new_batch_prefill(self)
         if self.running_batch is None or self.running_batch.is_empty():

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -198,6 +198,14 @@ class OmniScheduler:
         # Prefill admission coalescing: hold prefill until K requests are
         # waiting or the oldest has waited T ms, amortizing the per-step host
         # cost (mostly batch-size-independent) over more requests. 0 = off.
+        if int(prefill_coalesce_requests) > 1 and int(server_args.tp_size) > 1:
+            logger.warning(
+                "Prefill admission coalescing is disabled for "
+                f"tp_size={server_args.tp_size}: the wait deadline reads each "
+                "rank's local clock, so ranks could disagree on expiry and "
+                "break lockstep scheduling"
+            )
+            prefill_coalesce_requests = 0
         self.prefill_coalesce_requests = int(prefill_coalesce_requests)
         self.prefill_coalesce_wait_s = float(prefill_coalesce_wait_ms) / 1e3
 

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -200,7 +200,6 @@ class OmniScheduler:
         # cost (mostly batch-size-independent) over more requests. 0 = off.
         self.prefill_coalesce_requests = int(prefill_coalesce_requests)
         self.prefill_coalesce_wait_s = float(prefill_coalesce_wait_ms) / 1e3
-        self._prefill_coalesce_t0: float | None = None
 
         # Token / memory info (upstream reads from tp_worker.get_worker_info)
         mr = tp_worker.model_runner
@@ -734,6 +733,8 @@ class OmniScheduler:
                 stage=None,
                 event_name="scheduler_queue_enter",
             )
+            if not hasattr(req, "_coalesce_enqueue_t"):
+                req._coalesce_enqueue_t = time.perf_counter()
             self.waiting_queue.append(req)
 
         if request_admission_lock_held:
@@ -825,22 +826,17 @@ class OmniScheduler:
 
     def get_new_batch_prefill(self):
         # NOTE(maydomine): requests often arrive faster than they batch, so the
-        # loop burns its time on tiny prefill batches. Set coalesce_requests /
-        # wait_ms to hold admission until a batch is worth its fixed step cost.
+        # loop burns its time on tiny prefill batches. Hold admission until the
+        # batch is worth its fixed step cost; the deadline is measured from the
+        # oldest queued request, so partial admission or aborts never restart it.
         if self.prefill_coalesce_requests <= 1 or self.chunked_req is not None:
             return _Upstream.get_new_batch_prefill(self)
-        if not self.waiting_queue:
-            self._prefill_coalesce_t0 = None
-            return _Upstream.get_new_batch_prefill(self)
-        if len(self.waiting_queue) >= self.prefill_coalesce_requests:
-            self._prefill_coalesce_t0 = None
+        waiting = self.waiting_queue
+        if not waiting or len(waiting) >= self.prefill_coalesce_requests:
             return _Upstream.get_new_batch_prefill(self)
         now = time.perf_counter()
-        if self._prefill_coalesce_t0 is None:
-            self._prefill_coalesce_t0 = now
-            return None
-        if now - self._prefill_coalesce_t0 >= self.prefill_coalesce_wait_s:
-            self._prefill_coalesce_t0 = None
+        oldest = min(getattr(req, "_coalesce_enqueue_t", now) for req in waiting)
+        if now - oldest >= self.prefill_coalesce_wait_s:
             return _Upstream.get_new_batch_prefill(self)
         return None
 

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -271,14 +271,14 @@ def test_higgs_tts_engine_memory_budget_override_is_loud(caplog) -> None:
     builder = _make_higgs_builder(total_gpu_memory_fraction=0.8)
     assert builder.generation_defaults(dtype="bfloat16")["mem_fraction_static"] == 0.8
 
-    # Matching override (the no-CLI-flag path) stays silent.
+    # Note: (Jiaxin Deng) the matching no-CLI-flag path stays silent.
     with caplog.at_level(logging.WARNING):
         builder.adjust_overrides({"mem_fraction_static": 0.8})
         _make_higgs_builder().adjust_overrides({"mem_fraction_static": 0.9})
     assert not caplog.records
 
-    # A diverging override (e.g. --talker-mem-fraction-static) still wins, but
-    # warns instead of silently shadowing the placement-validated budget.
+    # Note: (Jiaxin Deng) a diverging override (e.g. --talker-mem-fraction-static)
+    # wins but warns instead of silently shadowing the placement budget.
     with caplog.at_level(logging.WARNING):
         builder.adjust_overrides({"mem_fraction_static": 0.3})
     assert any(

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import base64
+import logging
 import queue
 from types import SimpleNamespace
 from typing import Any
@@ -245,6 +246,44 @@ def test_higgs_tts_engine_abort_callback_requires_model() -> None:
     abort_callback("req-1")
 
     assert reset_calls == ["req-1"]
+
+
+def _make_higgs_builder(**kwargs):
+    from sglang_omni.models.higgs_tts.engine_builder import HiggsTtsEngineBuilder
+
+    return HiggsTtsEngineBuilder(
+        max_new_tokens=2048,
+        max_running_requests=64,
+        cuda_graph_max_bs=64,
+        enable_async_decode=False,
+        async_decode_min_batch_size=2,
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize("fraction", [0.0, 1.0, 1.2, -0.1])
+def test_higgs_tts_engine_rejects_out_of_range_memory_fraction(fraction) -> None:
+    with pytest.raises(ValueError, match="total_gpu_memory_fraction"):
+        _make_higgs_builder(total_gpu_memory_fraction=fraction)
+
+
+def test_higgs_tts_engine_memory_budget_override_is_loud(caplog) -> None:
+    builder = _make_higgs_builder(total_gpu_memory_fraction=0.8)
+    assert builder.generation_defaults(dtype="bfloat16")["mem_fraction_static"] == 0.8
+
+    # Matching override (the no-CLI-flag path) stays silent.
+    with caplog.at_level(logging.WARNING):
+        builder.adjust_overrides({"mem_fraction_static": 0.8})
+        _make_higgs_builder().adjust_overrides({"mem_fraction_static": 0.9})
+    assert not caplog.records
+
+    # A diverging override (e.g. --talker-mem-fraction-static) still wins, but
+    # warns instead of silently shadowing the placement-validated budget.
+    with caplog.at_level(logging.WARNING):
+        builder.adjust_overrides({"mem_fraction_static": 0.3})
+    assert any(
+        "total_gpu_memory_fraction" in record.message for record in caplog.records
+    )
 
 
 def test_higgs_reference_code_cache_key_round_trip() -> None:

--- a/tests/unit_test/scheduling/test_prefill_coalesce_gate.py
+++ b/tests/unit_test/scheduling/test_prefill_coalesce_gate.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Behavior tests for the prefill admission-coalescing gate.
+
+The gate holds prefill until ``prefill_coalesce_requests`` are waiting or the
+oldest has waited ``prefill_coalesce_wait_ms``; chunked prefill in flight and
+an empty queue pass straight through. Tested against a stub scheduler so no
+engine is needed — the upstream call is patched to a sentinel.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+pytest.importorskip("sglang")
+
+from sglang_omni.scheduling import omni_scheduler  # noqa: E402
+from sglang_omni.scheduling.omni_scheduler import OmniScheduler  # noqa: E402
+
+_UPSTREAM_BATCH = object()
+
+
+class _StubScheduler:
+    """The attribute surface get_new_batch_prefill touches."""
+
+    def __init__(self, *, coalesce_requests: int, wait_ms: float = 60.0) -> None:
+        self.prefill_coalesce_requests = coalesce_requests
+        self.prefill_coalesce_wait_s = wait_ms / 1e3
+        self._prefill_coalesce_t0: float | None = None
+        self.chunked_req = None
+        self.waiting_queue: list[object] = []
+
+    def get_new_batch_prefill(self):
+        return OmniScheduler.get_new_batch_prefill(self)
+
+
+@pytest.fixture()
+def upstream():
+    with mock.patch.object(
+        omni_scheduler._Upstream,
+        "get_new_batch_prefill",
+        return_value=_UPSTREAM_BATCH,
+    ) as patched:
+        yield patched
+
+
+def test_disabled_gate_passes_through(upstream):
+    sched = _StubScheduler(coalesce_requests=0)
+    sched.waiting_queue = [object()]
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+
+
+def test_chunked_prefill_bypasses_gate(upstream):
+    sched = _StubScheduler(coalesce_requests=8)
+    sched.waiting_queue = [object()]
+    sched.chunked_req = object()
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+
+
+def test_empty_queue_passes_through_and_resets_timer(upstream):
+    sched = _StubScheduler(coalesce_requests=8)
+    sched._prefill_coalesce_t0 = 123.0
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+    assert sched._prefill_coalesce_t0 is None
+
+
+def test_full_batch_passes_through_immediately(upstream):
+    sched = _StubScheduler(coalesce_requests=4)
+    sched.waiting_queue = [object()] * 4
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+    assert sched._prefill_coalesce_t0 is None
+
+
+def test_small_queue_is_held_until_deadline(upstream):
+    sched = _StubScheduler(coalesce_requests=8, wait_ms=60.0)
+    sched.waiting_queue = [object()] * 2
+    with mock.patch.object(omni_scheduler.time, "perf_counter") as clock:
+        clock.return_value = 100.0
+        assert sched.get_new_batch_prefill() is None  # arms the timer
+        assert sched._prefill_coalesce_t0 == 100.0
+
+        clock.return_value = 100.03  # inside the 60ms window
+        assert sched.get_new_batch_prefill() is None
+
+        clock.return_value = 100.07  # deadline expired
+        assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+        assert sched._prefill_coalesce_t0 is None
+    upstream.assert_called_once()
+
+
+def test_reaching_target_releases_before_deadline(upstream):
+    sched = _StubScheduler(coalesce_requests=3, wait_ms=60.0)
+    sched.waiting_queue = [object()]
+    with mock.patch.object(omni_scheduler.time, "perf_counter") as clock:
+        clock.return_value = 5.0
+        assert sched.get_new_batch_prefill() is None
+
+        sched.waiting_queue = [object()] * 3  # target reached, clock unchanged
+        assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+        assert sched._prefill_coalesce_t0 is None

--- a/tests/unit_test/scheduling/test_prefill_coalesce_gate.py
+++ b/tests/unit_test/scheduling/test_prefill_coalesce_gate.py
@@ -39,7 +39,6 @@ class _StubScheduler:
         self.prefill_coalesce_wait_s = wait_ms / 1e3
         self.chunked_req = None
         self.waiting_queue: list = []
-        # Decode work in flight by default; the idle-loop bypass has its own test.
         self.running_batch = SimpleNamespace(is_empty=lambda: False)
 
     def get_new_batch_prefill(self):
@@ -127,7 +126,7 @@ def test_abort_does_not_hand_newcomers_an_expired_deadline(upstream, clock):
 
 
 def test_idle_loop_bypasses_gate(upstream):
-    # No decode in flight: holding prefill amortizes nothing, only costs TTFB.
+    # Note(maydomine): No decode in flight: holding prefill amortizes nothing, only costs TTFB.
     sched = _StubScheduler(coalesce_requests=8)
     sched.waiting_queue = [_req(0.0)]
     sched.running_batch = None
@@ -138,7 +137,7 @@ def test_idle_loop_bypasses_gate(upstream):
 
 
 def test_unstamped_request_is_stamped_and_eventually_released(upstream, clock):
-    # Stamp-on-miss: held at first observation, then guaranteed release
+    # Note(maydomine): Stamp-on-miss: held at first observation, then guaranteed release
     # within the wait deadline (never a K-only unbounded hold).
     sched = _StubScheduler(coalesce_requests=8, wait_ms=60.0)
     clock.return_value = 200.0

--- a/tests/unit_test/scheduling/test_prefill_coalesce_gate.py
+++ b/tests/unit_test/scheduling/test_prefill_coalesce_gate.py
@@ -2,13 +2,17 @@
 """Behavior tests for the prefill admission-coalescing gate.
 
 The gate holds prefill until ``prefill_coalesce_requests`` are waiting or the
-oldest has waited ``prefill_coalesce_wait_ms``; chunked prefill in flight and
-an empty queue pass straight through. Tested against a stub scheduler so no
-engine is needed — the upstream call is patched to a sentinel.
+oldest queued request has waited ``prefill_coalesce_wait_ms``. The deadline is
+keyed on each request's enqueue time (``_coalesce_enqueue_t``), so partial
+upstream admission or an aborted request never restarts the window for the
+requests left behind. Chunked prefill in flight and an empty queue pass
+straight through. Tested against a stub scheduler with the upstream call
+patched to a sentinel.
 """
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -21,15 +25,20 @@ from sglang_omni.scheduling.omni_scheduler import OmniScheduler  # noqa: E402
 _UPSTREAM_BATCH = object()
 
 
+def _req(enqueue_t: float | None):
+    if enqueue_t is None:
+        return SimpleNamespace()
+    return SimpleNamespace(_coalesce_enqueue_t=enqueue_t)
+
+
 class _StubScheduler:
     """The attribute surface get_new_batch_prefill touches."""
 
     def __init__(self, *, coalesce_requests: int, wait_ms: float = 60.0) -> None:
         self.prefill_coalesce_requests = coalesce_requests
         self.prefill_coalesce_wait_s = wait_ms / 1e3
-        self._prefill_coalesce_t0: float | None = None
         self.chunked_req = None
-        self.waiting_queue: list[object] = []
+        self.waiting_queue: list = []
 
     def get_new_batch_prefill(self):
         return OmniScheduler.get_new_batch_prefill(self)
@@ -45,57 +54,78 @@ def upstream():
         yield patched
 
 
+@pytest.fixture()
+def clock():
+    with mock.patch.object(omni_scheduler.time, "perf_counter") as patched:
+        patched.return_value = 100.0
+        yield patched
+
+
 def test_disabled_gate_passes_through(upstream):
     sched = _StubScheduler(coalesce_requests=0)
-    sched.waiting_queue = [object()]
+    sched.waiting_queue = [_req(0.0)]
     assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
 
 
 def test_chunked_prefill_bypasses_gate(upstream):
     sched = _StubScheduler(coalesce_requests=8)
-    sched.waiting_queue = [object()]
+    sched.waiting_queue = [_req(0.0)]
     sched.chunked_req = object()
     assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
 
 
-def test_empty_queue_passes_through_and_resets_timer(upstream):
+def test_empty_queue_passes_through(upstream):
     sched = _StubScheduler(coalesce_requests=8)
-    sched._prefill_coalesce_t0 = 123.0
     assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
-    assert sched._prefill_coalesce_t0 is None
 
 
 def test_full_batch_passes_through_immediately(upstream):
     sched = _StubScheduler(coalesce_requests=4)
-    sched.waiting_queue = [object()] * 4
+    sched.waiting_queue = [_req(100.0)] * 4
     assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
-    assert sched._prefill_coalesce_t0 is None
 
 
-def test_small_queue_is_held_until_deadline(upstream):
+def test_small_queue_is_held_until_oldest_expires(upstream, clock):
     sched = _StubScheduler(coalesce_requests=8, wait_ms=60.0)
-    sched.waiting_queue = [object()] * 2
-    with mock.patch.object(omni_scheduler.time, "perf_counter") as clock:
-        clock.return_value = 100.0
-        assert sched.get_new_batch_prefill() is None  # arms the timer
-        assert sched._prefill_coalesce_t0 == 100.0
+    sched.waiting_queue = [_req(100.0), _req(100.01)]
 
-        clock.return_value = 100.03  # inside the 60ms window
-        assert sched.get_new_batch_prefill() is None
+    clock.return_value = 100.03  # oldest has waited 30ms of the 60ms window
+    assert sched.get_new_batch_prefill() is None
 
-        clock.return_value = 100.07  # deadline expired
-        assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
-        assert sched._prefill_coalesce_t0 is None
+    clock.return_value = 100.07  # oldest past the deadline
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
     upstream.assert_called_once()
 
 
-def test_reaching_target_releases_before_deadline(upstream):
+def test_reaching_target_releases_before_deadline(upstream, clock):
     sched = _StubScheduler(coalesce_requests=3, wait_ms=60.0)
-    sched.waiting_queue = [object()]
-    with mock.patch.object(omni_scheduler.time, "perf_counter") as clock:
-        clock.return_value = 5.0
-        assert sched.get_new_batch_prefill() is None
+    sched.waiting_queue = [_req(100.0)]
+    assert sched.get_new_batch_prefill() is None
 
-        sched.waiting_queue = [object()] * 3  # target reached, clock unchanged
-        assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
-        assert sched._prefill_coalesce_t0 is None
+    sched.waiting_queue = [_req(100.0)] * 3  # target reached, clock unchanged
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+
+
+def test_partial_admission_leftovers_keep_their_deadline(upstream, clock):
+    # Upstream admitted part of an expired wave; the leftovers still carry old
+    # enqueue times and must NOT re-wait a fresh window.
+    sched = _StubScheduler(coalesce_requests=8, wait_ms=60.0)
+    clock.return_value = 100.1
+    sched.waiting_queue = [_req(100.0), _req(100.02)]  # both past the deadline
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+
+
+def test_abort_does_not_hand_newcomers_an_expired_deadline(upstream, clock):
+    # The request that opened the window was aborted; a fresh arrival must
+    # wait its own window rather than inherit the nearly expired one.
+    sched = _StubScheduler(coalesce_requests=8, wait_ms=60.0)
+    clock.return_value = 100.1
+    sched.waiting_queue = [_req(100.09)]  # newcomer, 10ms old
+    assert sched.get_new_batch_prefill() is None
+
+
+def test_unstamped_request_is_treated_as_fresh(upstream, clock):
+    sched = _StubScheduler(coalesce_requests=8, wait_ms=60.0)
+    clock.return_value = 200.0
+    sched.waiting_queue = [_req(None)]
+    assert sched.get_new_batch_prefill() is None

--- a/tests/unit_test/scheduling/test_prefill_coalesce_gate.py
+++ b/tests/unit_test/scheduling/test_prefill_coalesce_gate.py
@@ -108,8 +108,8 @@ def test_reaching_target_releases_before_deadline(upstream, clock):
 
 
 def test_partial_admission_leftovers_keep_their_deadline(upstream, clock):
-    # Upstream admitted part of an expired wave; the leftovers still carry old
-    # enqueue times and must NOT re-wait a fresh window.
+    # Note: (maydomine) leftovers of a partially admitted wave keep their old
+    # stamps and must not re-wait a fresh window.
     sched = _StubScheduler(coalesce_requests=8, wait_ms=60.0)
     clock.return_value = 100.1
     sched.waiting_queue = [_req(100.0), _req(100.02)]  # both past the deadline
@@ -117,8 +117,8 @@ def test_partial_admission_leftovers_keep_their_deadline(upstream, clock):
 
 
 def test_abort_does_not_hand_newcomers_an_expired_deadline(upstream, clock):
-    # The request that opened the window was aborted; a fresh arrival must
-    # wait its own window rather than inherit the nearly expired one.
+    # Note: (maydomine) a fresh arrival after an abort waits its own window
+    # rather than inheriting the nearly expired one.
     sched = _StubScheduler(coalesce_requests=8, wait_ms=60.0)
     clock.return_value = 100.1
     sched.waiting_queue = [_req(100.09)]  # newcomer, 10ms old
@@ -126,7 +126,8 @@ def test_abort_does_not_hand_newcomers_an_expired_deadline(upstream, clock):
 
 
 def test_idle_loop_bypasses_gate(upstream):
-    # Note(maydomine): No decode in flight: holding prefill amortizes nothing, only costs TTFB.
+    # Note: (maydomine) no decode in flight: holding amortizes nothing, only
+    # costs TTFB.
     sched = _StubScheduler(coalesce_requests=8)
     sched.waiting_queue = [_req(0.0)]
     sched.running_batch = None
@@ -185,7 +186,7 @@ def test_newcomer_after_queue_drain_waits_its_own_window(upstream, clock):
 
 
 def test_unstamped_request_is_stamped_and_eventually_released(upstream, clock):
-    # Note(maydomine): Stamp-on-miss: held at first observation, then guaranteed release
+    # Note: (maydomine) stamp-on-miss: held at first observation, released
     # within the wait deadline (never a K-only unbounded hold).
     sched = _StubScheduler(coalesce_requests=8, wait_ms=60.0)
     clock.return_value = 200.0

--- a/tests/unit_test/scheduling/test_prefill_coalesce_gate.py
+++ b/tests/unit_test/scheduling/test_prefill_coalesce_gate.py
@@ -39,6 +39,8 @@ class _StubScheduler:
         self.prefill_coalesce_wait_s = wait_ms / 1e3
         self.chunked_req = None
         self.waiting_queue: list = []
+        # Decode work in flight by default; the idle-loop bypass has its own test.
+        self.running_batch = SimpleNamespace(is_empty=lambda: False)
 
     def get_new_batch_prefill(self):
         return OmniScheduler.get_new_batch_prefill(self)
@@ -124,8 +126,29 @@ def test_abort_does_not_hand_newcomers_an_expired_deadline(upstream, clock):
     assert sched.get_new_batch_prefill() is None
 
 
-def test_unstamped_request_is_treated_as_fresh(upstream, clock):
+def test_idle_loop_bypasses_gate(upstream):
+    # No decode in flight: holding prefill amortizes nothing, only costs TTFB.
+    sched = _StubScheduler(coalesce_requests=8)
+    sched.waiting_queue = [_req(0.0)]
+    sched.running_batch = None
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+
+    sched.running_batch = SimpleNamespace(is_empty=lambda: True)
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+
+
+def test_unstamped_request_is_stamped_and_eventually_released(upstream, clock):
+    # Stamp-on-miss: held at first observation, then guaranteed release
+    # within the wait deadline (never a K-only unbounded hold).
     sched = _StubScheduler(coalesce_requests=8, wait_ms=60.0)
     clock.return_value = 200.0
-    sched.waiting_queue = [_req(None)]
+    req = _req(None)
+    sched.waiting_queue = [req]
     assert sched.get_new_batch_prefill() is None
+    assert req._coalesce_enqueue_t == 200.0
+
+    clock.return_value = 200.03  # inside the window
+    assert sched.get_new_batch_prefill() is None
+
+    clock.return_value = 200.07  # past the deadline
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH

--- a/tests/unit_test/scheduling/test_prefill_coalesce_gate.py
+++ b/tests/unit_test/scheduling/test_prefill_coalesce_gate.py
@@ -136,6 +136,54 @@ def test_idle_loop_bypasses_gate(upstream):
     assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
 
 
+def test_real_partial_admission_cycle_releases_leftovers_immediately(clock):
+    # Note: (Jiaxin Deng) real admit cycle: upstream pops only the head of an
+    # expired wave; the leftover keeps its stamp and releases on the next pass.
+    def _admit_head(self):
+        self.waiting_queue.pop(0)
+        return _UPSTREAM_BATCH
+
+    sched = _StubScheduler(coalesce_requests=8, wait_ms=60.0)
+    clock.return_value = 100.07
+    leftover = _req(100.005)
+    sched.waiting_queue = [_req(100.0), leftover]
+    with mock.patch.object(
+        omni_scheduler._Upstream,
+        "get_new_batch_prefill",
+        autospec=True,
+        side_effect=_admit_head,
+    ) as patched:
+        assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+        assert sched.waiting_queue == [leftover]
+        assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+        assert patched.call_count == 2
+        assert sched.waiting_queue == []
+
+
+def test_newcomer_after_queue_drain_waits_its_own_window(upstream, clock):
+    # Note: (Jiaxin Deng) once the arming request leaves the queue (abort's
+    # queue filtering), a stamp-on-miss newcomer ages from its own arrival.
+    sched = _StubScheduler(coalesce_requests=8, wait_ms=60.0)
+    clock.return_value = 100.0
+    armer = _req(None)
+    sched.waiting_queue = [armer]
+    assert sched.get_new_batch_prefill() is None
+    assert armer._coalesce_enqueue_t == 100.0
+
+    clock.return_value = 100.059  # abort just before the armer's deadline
+    sched.waiting_queue.remove(armer)
+    newcomer = _req(None)
+    sched.waiting_queue.append(newcomer)
+    assert sched.get_new_batch_prefill() is None
+    assert newcomer._coalesce_enqueue_t == 100.059
+
+    clock.return_value = 100.07  # past the armer's window, inside the newcomer's
+    assert sched.get_new_batch_prefill() is None
+
+    clock.return_value = 100.12  # newcomer's own deadline expires
+    assert sched.get_new_batch_prefill() is _UPSTREAM_BATCH
+
+
 def test_unstamped_request_is_stamped_and_eventually_released(upstream, clock):
     # Note(maydomine): Stamp-on-miss: held at first observation, then guaranteed release
     # within the wait deadline (never a K-only unbounded hold).


### PR DESCRIPTION
## Motivation

Single-replica Higgs TTS serving is host-bound: the scheduler event loop saturates while the GPU idles at ~20% SM. Per-segment timing and NVTX profiling (full analysis on #921) attribute the loop time to three fixable costs:

1. **Synchronous prefill steps** ran at arrival granularity — 23 steps/s carrying only ~2 requests each, paying a ~25 ms mostly batch-size-independent host cost per step (60% of the loop).
2. **The DAC vocoder thread shared the scheduler process**: it contends for the GIL (prefill steps measured +38% slower while it is active) and its decode thread is the first component to saturate.
3. Vocoder per-chunk decode cost itself (17 ms in-process, 11.6 ms once isolated).

## Modifications

One commit, three stacked changes:

1. **Prefill admission coalescing** (`OmniScheduler.get_new_batch_prefill` gate): hold prefill until `prefill_coalesce_requests` are waiting or the oldest has waited `prefill_coalesce_wait_ms` (chunked prefill bypasses the gate; the deadline bounds added TTFB). Plumbed as Higgs stage factory args, default off.
2. **Vocoder in its own process** (`process="vocoder"` in the Higgs pipeline config): removes the GIL contention and gives the vocoder its own core. Sharing GPU 0 across process groups requires the explicit per-stage `total_gpu_memory_fraction` budgets added alongside (0.03 encoder / 0.85 engine / 0.10 vocoder).
3. **`torch.compile` on the codec decode** (`compile_decode` factory arg on the vocoder stage, following the audio-encoder precedent from #612; enabled by default in the Higgs pipeline config): 11.6 → 5.8 ms per chunk.

## Accuracy Test

Changes 1–2 alter scheduling and process placement only, not numerics; generated token streams are unaffected by construction. For the compiled decode path (change 3), the seed-tts-eval WER A/B is posted below: 1.005% -> 0.996% corpus WER (within noise, parity confirmed).

## Benchmark & Profiling

1× H100 80 GB, seed-tts-eval voice-clone (~157 prompt / ~115 output tokens), non-streaming, conc = cap, 90 s windows. Ladder measured on the rebased head (base includes #939/#1057); the cap sweep and DP tables below are from the pre-rebase head and will be refreshed with the #1037 recipe follow-up.

**Single replica ladder** (cap 96; re-measured on the rebased head, 2×90 s means; `QPS × lat ≈ 96` sanity-checked per row):

| config | QPS | lat mean / p95 | QPS×lat |
| --- | ---: | --- | ---: |
| main | 49.5 | 1.92 s / 6.0 s | 95.3 |
| + coalescing (K=32, T=300 ms) | 64.9 (+31%) | 1.50 s / 3.4 s | 97.7 |
| + vocoder own process | 85.1 (+31%) | 1.13 s / 3.1 s | 95.8 |
| + compiled decode | **99.7 (+17%)** | 0.96 s / 2.9 s | 95.6 |

**cap = conc sweep** (full stack; cap is now a real throughput/latency knob):

| cap | 96 | 128 | 160 | 192 | 224 | 256 | 288 | 320 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| QPS | 99.3 | 114.7 | **124.9** | 131.8 | 136.8 | 142.6 | 145.6 | 152.8 |
| p95 (s) | 3.0 | 3.5 | 4.0 | 4.4 | 5.5 | 5.8 | 7.2 | 6.2 |

Pareto knee at cap=160.

**Same-GPU DP × MPS** (3 replicas × cap 160, per-replica core slices):

| deployment | aggregate QPS | per-replica | lat mean |
| --- | ---: | ---: | --- |
| DP3 × MPS, old recipe (#921) | 124.4 | ~41 | — |
| **DP3 × MPS, this stack** | **323.5 / 330.9 → ~327** | ~109 (87% scaling) | 1.47 s |

56.3 GB used. One measurement caveat that becomes a follow-up: the KV pool is sized from free VRAM at boot, so same-GPU replicas end up with unequal pools (12.5 / 6.3 / 2.0 GB measured) and the last replica throttles to ~40% of its peers. The 327 number pins per-replica pools equal (54k tokens) via a measurement-time override; exposing an explicit KV budget knob lands with the #1037 recipe follow-up.

**Vocoder placement side-metrics** (review follow-up): idle boot VRAM +130 MiB for the separate codec process (69,883 vs 69,753 MiB); streaming TTFP (seed-tts-eval-50, conc 16, `--stream`) improves slightly out-of-process — mean 1.006 s / p95 2.00 s vs 1.089 s / 2.08 s in-process, i.e. the shm+ZMQ hop is repaid by the GIL relief.

Numbers re-validated on the review-fixed head (`0b6cdaa2`): 100.3 / 99.6 QPS at cap=conc=96.

Profiling method and full bottleneck decomposition (per-segment loop timers + NVTX under nsys, production rates) are documented on #921.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests (`tests/unit_test/scheduling/test_prefill_coalesce_gate.py`, incl. partial-admission and abort paths).
- [ ] Update documentation / docstrings / example tutorials as needed. *(recipe update for #1037 planned as follow-up)*
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.


