### PR TITLE
[CI] Align Qwen3-Omni gates with H100 calibration report

### DIFF
--- a/tests/test_model/test_qwen3_omni_mmsu_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_ci.py
@@ -31,13 +31,13 @@ from tests.utils import MetricCheckCollector, apply_slack, assert_speed_threshol
 
 CONCURRENCY = 16
 
-MMSU_MIN_ACCURACY = 0.697
+MMSU_MIN_ACCURACY = 0.6925
 
 _MMSU_P95 = {
     16: {
-        "throughput_qps": 70.65,
-        "output_tok_per_req_s": 9.1,
-        "latency_mean_s": 0.226,
+        "throughput_qps": 66.12,
+        "output_tok_per_req_s": 8.6,
+        "latency_mean_s": 0.241,
     },
 }
 MMSU_THRESHOLDS = apply_slack(_MMSU_P95)

--- a/tests/test_model/test_qwen3_omni_mmsu_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_ci.py
@@ -31,13 +31,13 @@ from tests.utils import MetricCheckCollector, apply_slack, assert_speed_threshol
 
 CONCURRENCY = 16
 
-MMSU_MIN_ACCURACY = 0.6925
+MMSU_MIN_ACCURACY = 0.6965
 
 _MMSU_P95 = {
     16: {
-        "throughput_qps": 66.12,
-        "output_tok_per_req_s": 8.6,
-        "latency_mean_s": 0.241,
+        "throughput_qps": 59.377,
+        "output_tok_per_req_s": 7.7,
+        "latency_mean_s": 0.269,
     },
 }
 MMSU_THRESHOLDS = apply_slack(_MMSU_P95)

--- a/tests/test_model/test_qwen3_omni_mmsu_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_talker_ci.py
@@ -61,8 +61,8 @@ MMSU_TTS_PROMPT = (
     "Do not exceed 120 words in total."
 )
 
-MMSU_AUDIO_MIN_ACCURACY = 0.55
-MMSU_AUDIO_WER_BELOW_50_CORPUS_MAX = 0.0342
+MMSU_AUDIO_MIN_ACCURACY = 0.65
+MMSU_AUDIO_WER_BELOW_50_CORPUS_MAX = 0.0297
 MMSU_AUDIO_WER_BELOW_50_CORPUS_THRESHOLD = apply_wer_slack(
     MMSU_AUDIO_WER_BELOW_50_CORPUS_MAX
 )
@@ -70,10 +70,10 @@ MMSU_AUDIO_N_ABOVE_50_MAX = 0
 
 _MMSU_AUDIO_P95 = {
     16: {
-        "throughput_qps": 0.708,
-        "output_tok_per_req_s": 2.9,
-        "latency_mean_s": 20.942,
-        "rtf_mean": 1.1587,
+        "throughput_qps": 1.182,
+        "output_tok_per_req_s": 4.9,
+        "latency_mean_s": 12.466,
+        "rtf_mean": 0.6786,
     },
 }
 MMSU_AUDIO_THRESHOLDS = apply_slack(_MMSU_AUDIO_P95)

--- a/tests/test_model/test_qwen3_omni_mmsu_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_talker_ci.py
@@ -61,19 +61,19 @@ MMSU_TTS_PROMPT = (
     "Do not exceed 120 words in total."
 )
 
-MMSU_AUDIO_MIN_ACCURACY = 0.575
-MMSU_AUDIO_WER_BELOW_50_CORPUS_MAX = 0.0331
+MMSU_AUDIO_MIN_ACCURACY = 0.55
+MMSU_AUDIO_WER_BELOW_50_CORPUS_MAX = 0.0342
 MMSU_AUDIO_WER_BELOW_50_CORPUS_THRESHOLD = apply_wer_slack(
     MMSU_AUDIO_WER_BELOW_50_CORPUS_MAX
 )
-MMSU_AUDIO_N_ABOVE_50_MAX = 1.0
+MMSU_AUDIO_N_ABOVE_50_MAX = 0
 
 _MMSU_AUDIO_P95 = {
     16: {
-        "throughput_qps": 1.214,
-        "output_tok_per_req_s": 5.0,
-        "latency_mean_s": 12.476,
-        "rtf_mean": 0.6584,
+        "throughput_qps": 0.708,
+        "output_tok_per_req_s": 2.9,
+        "latency_mean_s": 20.942,
+        "rtf_mean": 1.1587,
     },
 }
 MMSU_AUDIO_THRESHOLDS = apply_slack(_MMSU_AUDIO_P95)

--- a/tests/test_model/test_qwen3_omni_tts_ci.py
+++ b/tests/test_model/test_qwen3_omni_tts_ci.py
@@ -61,9 +61,9 @@ WER_TIMEOUT = 600
 SIMILARITY_TIMEOUT = 600
 UTMOS_TIMEOUT = 600
 
-VC_WER_BELOW_50_CORPUS_MAX = 0.0213
+VC_WER_BELOW_50_CORPUS_MAX = 0.0284
 VC_WER_BELOW_50_CORPUS_THRESHOLD = apply_wer_slack(VC_WER_BELOW_50_CORPUS_MAX)
-VC_N_ABOVE_50_MAX = 0.0
+VC_N_ABOVE_50_MAX = 1
 # 60.0 mirrors the S2-Pro floor and is a placeholder until upstream issue
 # #483 is fixed; the hard assertion is currently disabled in
 # test_voice_cloning_similarity (see docstring there). PR #469 also collected
@@ -77,7 +77,7 @@ VC_N_ABOVE_50_MAX = 0.0
 VC_SIMILARITY_MEAN_MIN = 60.0
 # Calibrated from worst-of-5 full generate+score runs on SeedTTS-50 EN, H200 SXM.
 # worst-of-5 = 4.1924 · mean = 4.2575 · stdev = 0.0487
-VC_UTMOS_MEAN_REFERENCE = 4.2107
+VC_UTMOS_MEAN_REFERENCE = 4.2454
 VC_UTMOS_MEAN_MIN = apply_mos_slack(VC_UTMOS_MEAN_REFERENCE)
 
 # Strict worst-of-5 references from #1021's published 8xH100 calibration report.

--- a/tests/test_model/test_qwen3_omni_tts_ci.py
+++ b/tests/test_model/test_qwen3_omni_tts_ci.py
@@ -61,7 +61,7 @@ WER_TIMEOUT = 600
 SIMILARITY_TIMEOUT = 600
 UTMOS_TIMEOUT = 600
 
-VC_WER_BELOW_50_CORPUS_MAX = 0.0284
+VC_WER_BELOW_50_CORPUS_MAX = 0.0213
 VC_WER_BELOW_50_CORPUS_THRESHOLD = apply_wer_slack(VC_WER_BELOW_50_CORPUS_MAX)
 VC_N_ABOVE_50_MAX = 1
 # 60.0 mirrors the S2-Pro floor and is a placeholder until upstream issue
@@ -77,17 +77,17 @@ VC_N_ABOVE_50_MAX = 1
 VC_SIMILARITY_MEAN_MIN = 60.0
 # Calibrated from worst-of-5 full generate+score runs on SeedTTS-50 EN, H200 SXM.
 # worst-of-5 = 4.1924 · mean = 4.2575 · stdev = 0.0487
-VC_UTMOS_MEAN_REFERENCE = 4.2454
+VC_UTMOS_MEAN_REFERENCE = 4.2663
 VC_UTMOS_MEAN_MIN = apply_mos_slack(VC_UTMOS_MEAN_REFERENCE)
 
 # Strict worst-of-5 references from #1021's published 8xH100 calibration report.
 
 _VC_NON_STREAM_P95 = {
     16: {
-        "throughput_qps": 5.146,
-        "output_tok_per_req_s": 5.1,
-        "latency_mean_s": 2.869,
-        "rtf_mean": 0.9505,
+        "throughput_qps": 5.719,
+        "output_tok_per_req_s": 5.5,
+        "latency_mean_s": 2.647,
+        "rtf_mean": 0.9044,
     },
 }
 

--- a/tests/test_model/test_qwen3_omni_tts_ci.py
+++ b/tests/test_model/test_qwen3_omni_tts_ci.py
@@ -80,15 +80,15 @@ VC_SIMILARITY_MEAN_MIN = 60.0
 VC_UTMOS_MEAN_REFERENCE = 4.2107
 VC_UTMOS_MEAN_MIN = apply_mos_slack(VC_UTMOS_MEAN_REFERENCE)
 
-# Note (Chenyang): The thresholds for the throughput_qps of tests/test_model/test_qwen3_omni_tts_ci.py
-# are the most unstable metrics, so I drop it a lot.
+# Keep speed references tied to the 2xH100 CI runner; H200 calibration numbers
+# make these gates unattainable on the hardware that executes them.
 
 _VC_NON_STREAM_P95 = {
     16: {
-        "throughput_qps": 6.492,
-        "output_tok_per_req_s": 6.4,
-        "latency_mean_s": 2.29,
-        "rtf_mean": 0.7606,
+        "throughput_qps": 5.317,
+        "output_tok_per_req_s": 5.2,
+        "latency_mean_s": 2.803,
+        "rtf_mean": 0.8149,
     },
 }
 

--- a/tests/test_model/test_qwen3_omni_tts_ci.py
+++ b/tests/test_model/test_qwen3_omni_tts_ci.py
@@ -80,15 +80,14 @@ VC_SIMILARITY_MEAN_MIN = 60.0
 VC_UTMOS_MEAN_REFERENCE = 4.2107
 VC_UTMOS_MEAN_MIN = apply_mos_slack(VC_UTMOS_MEAN_REFERENCE)
 
-# Keep speed references tied to the 2xH100 CI runner; H200 calibration numbers
-# make these gates unattainable on the hardware that executes them.
+# Strict worst-of-5 references from #1021's published 8xH100 calibration report.
 
 _VC_NON_STREAM_P95 = {
     16: {
-        "throughput_qps": 5.317,
-        "output_tok_per_req_s": 5.2,
-        "latency_mean_s": 2.803,
-        "rtf_mean": 0.8149,
+        "throughput_qps": 5.146,
+        "output_tok_per_req_s": 5.1,
+        "latency_mean_s": 2.869,
+        "rtf_mean": 0.9505,
     },
 }
 

--- a/tests/test_model/test_qwen3_omni_videoamme_ci.py
+++ b/tests/test_model/test_qwen3_omni_videoamme_ci.py
@@ -31,13 +31,13 @@ from tests.utils import MetricCheckCollector, apply_slack, assert_speed_threshol
 CONCURRENCY = 16
 MAX_SAMPLES = 50
 
-VIDEOAMME_MIN_ACCURACY = 0.64
+VIDEOAMME_MIN_ACCURACY = 0.66
 
 _VIDEOAMME_P95 = {
     16: {
-        "throughput_qps": 1.793,
-        "output_tok_per_req_s": 5.9,
-        "latency_mean_s": 7.787,
+        "throughput_qps": 1.604,
+        "output_tok_per_req_s": 5.8,
+        "latency_mean_s": 8.572,
     },
 }
 VIDEOAMME_THRESHOLDS = apply_slack(_VIDEOAMME_P95)

--- a/tests/test_model/test_qwen3_omni_videoamme_ci.py
+++ b/tests/test_model/test_qwen3_omni_videoamme_ci.py
@@ -35,9 +35,9 @@ VIDEOAMME_MIN_ACCURACY = 0.64
 
 _VIDEOAMME_P95 = {
     16: {
-        "throughput_qps": 1.728,
-        "output_tok_per_req_s": 5.8,
-        "latency_mean_s": 8.054,
+        "throughput_qps": 1.793,
+        "output_tok_per_req_s": 5.9,
+        "latency_mean_s": 7.787,
     },
 }
 VIDEOAMME_THRESHOLDS = apply_slack(_VIDEOAMME_P95)

--- a/tests/test_model/test_qwen3_omni_videoamme_talker_tp2_ci.py
+++ b/tests/test_model/test_qwen3_omni_videoamme_talker_tp2_ci.py
@@ -49,7 +49,7 @@ MAX_TOKENS = 256
 ASR_DEVICE = "cuda:0"
 
 VIDEOAMME_TALKER_TP2_THINKER_TEXT_MIN_ACCURACY = 0.5
-VIDEOAMME_TALKER_TP2_WER_BELOW_50_CORPUS_MAX = 0.0399
+VIDEOAMME_TALKER_TP2_WER_BELOW_50_CORPUS_MAX = 0.0312
 VIDEOAMME_TALKER_TP2_WER_BELOW_50_CORPUS_THRESHOLD = apply_wer_slack(
     VIDEOAMME_TALKER_TP2_WER_BELOW_50_CORPUS_MAX
 )
@@ -57,10 +57,10 @@ VIDEOAMME_TALKER_TP2_N_ABOVE_50_MAX = 0.0
 
 _VIDEOAMME_TALKER_TP2_AUDIO_P95 = {
     16: {
-        "throughput_qps": 0.059,
+        "throughput_qps": 0.056,
         "output_tok_per_req_s": 0.3,
-        "latency_mean_s": 168.811,
-        "rtf_mean": 13.0958,
+        "latency_mean_s": 174.316,
+        "rtf_mean": 13.4381,
     },
 }
 VIDEOAMME_TALKER_TP2_THRESHOLDS = apply_slack(_VIDEOAMME_TALKER_TP2_AUDIO_P95)

--- a/tests/test_model/test_qwen3_omni_videoamme_talker_tp2_ci.py
+++ b/tests/test_model/test_qwen3_omni_videoamme_talker_tp2_ci.py
@@ -48,8 +48,8 @@ MAX_SAMPLES = 10
 MAX_TOKENS = 256
 ASR_DEVICE = "cuda:0"
 
-VIDEOAMME_TALKER_TP2_THINKER_TEXT_MIN_ACCURACY = 0.5
-VIDEOAMME_TALKER_TP2_WER_BELOW_50_CORPUS_MAX = 0.0312
+VIDEOAMME_TALKER_TP2_THINKER_TEXT_MIN_ACCURACY = 0.4
+VIDEOAMME_TALKER_TP2_WER_BELOW_50_CORPUS_MAX = 0.0196
 VIDEOAMME_TALKER_TP2_WER_BELOW_50_CORPUS_THRESHOLD = apply_wer_slack(
     VIDEOAMME_TALKER_TP2_WER_BELOW_50_CORPUS_MAX
 )
@@ -57,18 +57,13 @@ VIDEOAMME_TALKER_TP2_N_ABOVE_50_MAX = 0.0
 
 _VIDEOAMME_TALKER_TP2_AUDIO_P95 = {
     16: {
-        "throughput_qps": 0.056,
+        "throughput_qps": 0.062,
         "output_tok_per_req_s": 0.3,
-        "latency_mean_s": 174.316,
-        "rtf_mean": 13.4381,
+        "latency_mean_s": 160.352,
+        "rtf_mean": 12.3616,
     },
 }
 VIDEOAMME_TALKER_TP2_THRESHOLDS = apply_slack(_VIDEOAMME_TALKER_TP2_AUDIO_P95)
-
-# note (Yue Yin, Chenyang): 0.55-calibrated latency baseline (146.7 gate) is
-# unreachable on the #765 0.40 OOM-fix config (~148s); pin the gate to 155
-
-VIDEOAMME_TALKER_TP2_THRESHOLDS[16]["latency_mean_s_max"] = 155
 
 VIDEOAMME_TALKER_TP2_DATASET_LABEL = format_benchmark_dataset_label(
     dataset="videoamme-ci-50",

--- a/tests/test_model/test_qwen3_omni_videomme_ci.py
+++ b/tests/test_model/test_qwen3_omni_videomme_ci.py
@@ -36,9 +36,9 @@ VIDEOMME_MIN_ACCURACY = 0.56
 
 _VIDEOMME_P95 = {
     16: {
-        "throughput_qps": 1.169,
-        "output_tok_per_req_s": 9.3,
-        "latency_mean_s": 11.884,
+        "throughput_qps": 0.968,
+        "output_tok_per_req_s": 7.5,
+        "latency_mean_s": 14.602,
     },
 }
 VIDEOMME_THRESHOLDS = apply_slack(_VIDEOMME_P95)

--- a/tests/test_model/test_qwen3_omni_videomme_ci.py
+++ b/tests/test_model/test_qwen3_omni_videomme_ci.py
@@ -32,13 +32,13 @@ from tests.utils import MetricCheckCollector, apply_slack, assert_speed_threshol
 CONCURRENCY = 16
 MAX_SAMPLES = 50
 
-VIDEOMME_MIN_ACCURACY = 0.56
+VIDEOMME_MIN_ACCURACY = 0.58
 
 _VIDEOMME_P95 = {
     16: {
-        "throughput_qps": 0.968,
-        "output_tok_per_req_s": 7.5,
-        "latency_mean_s": 14.602,
+        "throughput_qps": 1.020,
+        "output_tok_per_req_s": 7.9,
+        "latency_mean_s": 13.908,
     },
 }
 VIDEOMME_THRESHOLDS = apply_slack(_VIDEOMME_P95)

--- a/tests/test_model/test_qwen3_omni_videomme_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_videomme_talker_ci.py
@@ -61,19 +61,19 @@ SHORT_ANSWER_PROMPT = (
     "'Answer: $LETTER'. Do not include step-by-step reasoning."
 )
 
-VIDEOMME_TALKER_THINKER_TEXT_MIN_ACCURACY = 0.55
-VIDEOMME_TALKER_WER_BELOW_50_CORPUS_MAX = 0.0493
+VIDEOMME_TALKER_THINKER_TEXT_MIN_ACCURACY = 0.60
+VIDEOMME_TALKER_WER_BELOW_50_CORPUS_MAX = 0.0483
 VIDEOMME_TALKER_WER_BELOW_50_CORPUS_THRESHOLD = apply_wer_slack(
     VIDEOMME_TALKER_WER_BELOW_50_CORPUS_MAX
 )
-VIDEOMME_TALKER_N_ABOVE_50_MAX = 2
+VIDEOMME_TALKER_N_ABOVE_50_MAX = 0
 
 _VIDEOMME_TALKER_AUDIO_P95 = {
     16: {
-        "throughput_qps": 0.843,
-        "output_tok_per_req_s": 3.4,
-        "latency_mean_s": 13.148,
-        "rtf_mean": 1.5726,
+        "throughput_qps": 0.881,
+        "output_tok_per_req_s": 3.2,
+        "latency_mean_s": 12.957,
+        "rtf_mean": 1.4203,
     },
 }
 VIDEOMME_TALKER_THRESHOLDS = apply_slack(_VIDEOMME_TALKER_AUDIO_P95)

--- a/tests/test_model/test_qwen3_omni_videomme_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_videomme_talker_ci.py
@@ -62,18 +62,18 @@ SHORT_ANSWER_PROMPT = (
 )
 
 VIDEOMME_TALKER_THINKER_TEXT_MIN_ACCURACY = 0.55
-VIDEOMME_TALKER_WER_BELOW_50_CORPUS_MAX = 0.0438
+VIDEOMME_TALKER_WER_BELOW_50_CORPUS_MAX = 0.0493
 VIDEOMME_TALKER_WER_BELOW_50_CORPUS_THRESHOLD = apply_wer_slack(
     VIDEOMME_TALKER_WER_BELOW_50_CORPUS_MAX
 )
-VIDEOMME_TALKER_N_ABOVE_50_MAX = 0
+VIDEOMME_TALKER_N_ABOVE_50_MAX = 2
 
 _VIDEOMME_TALKER_AUDIO_P95 = {
     16: {
-        "throughput_qps": 0.925,
-        "output_tok_per_req_s": 3.7,
-        "latency_mean_s": 12.702,
-        "rtf_mean": 1.3248,
+        "throughput_qps": 0.843,
+        "output_tok_per_req_s": 3.4,
+        "latency_mean_s": 13.148,
+        "rtf_mean": 1.5726,
     },
 }
 VIDEOMME_TALKER_THRESHOLDS = apply_slack(_VIDEOMME_TALKER_AUDIO_P95)


### PR DESCRIPTION
## Summary

- run 18 stages five times each and apply strict worst-of-5 references
- preserve MMMU/MMMU Talker values, which were recalibrated separately

## Why

The thresholds previously copied from #1021 did not match a fresh run of the current PR and environment. This PR now uses a new strict five-run calibration collected from the exact PR head.

## H100 calibration

- Host: `novita-h100`, 8× NVIDIA H100 80GB HBM3
- Image: `hongccc/sglang-omni:dev`
- Commit: `75f5e75216c0f6263da8f09dcae24c693de97612`
- Run: `/data/tune-runs/20260716T101437Z_pr1072/combined`
- Result: **STRICT + GIT: READY** — 18/18 stages, 5/5 complete samples per stage
- Reliability: no startup, OOM, timeout, or partial-result failures

| Stage | Before | Calibrated strict worst-of-5 |
|---|---|---|
| MMSU accuracy | 69.25% | **69.65%** |
| MMSU speed | 66.120 req/s · 8.6 tok/req-s · 0.241s latency | **59.377 req/s · 7.7 tok/req-s · 0.269s latency** |
| MMSU Talker accuracy/WER | 55.00% · 3.42% corpus WER · 0 samples >50% WER | **65.00% · 2.96% corpus WER · 0 samples >50% WER** |
| MMSU Talker speed | 0.708 req/s · 2.9 tok/req-s · 20.942s latency · 1.1587 RTF | **1.182 req/s · 4.9 tok/req-s · 12.466s latency · 0.6786 RTF** |
| TTS WER/UTMOS | 2.84% corpus WER · 1 sample >50% WER · 4.2454 UTMOS | **2.13% corpus WER · 1 sample >50% WER · 4.2663 UTMOS** |
| TTS speed | 5.146 req/s · 5.1 tok/req-s · 2.869s latency · 0.9505 RTF | **5.719 req/s · 5.5 tok/req-s · 2.647s latency · 0.9044 RTF** |
| VideoAMME accuracy | 64.00% | **66.00%** |
| VideoAMME speed | 1.793 req/s · 5.9 tok/req-s · 7.787s latency | **1.604 req/s · 5.8 tok/req-s · 8.572s latency** |
| VideoAMME Talker TP2 accuracy/WER | 50.00% · 3.12% corpus WER · 0 samples >50% WER | **40.00% · 1.95% corpus WER · 0 samples >50% WER** |
| VideoAMME Talker TP2 speed | 0.056 req/s · 0.3 tok/req-s · 174.316s latency (155s hard cap) · 13.4381 RTF | **0.062 req/s · 0.3 tok/req-s · 160.352s latency · 12.3616 RTF** |
| VideoMME accuracy | 56.00% | **58.00%** |
| VideoMME speed | 0.968 req/s · 7.5 tok/req-s · 14.602s latency | **1.020 req/s · 7.9 tok/req-s · 13.908s latency** |
| VideoMME Talker accuracy/WER | 55.00% · 4.93% corpus WER · 2 samples >50% WER | **60.00% · 4.82% corpus WER · 0 samples >50% WER** |
| VideoMME Talker speed | 0.843 req/s · 3.4 tok/req-s · 13.148s latency · 1.5726 RTF | **0.881 req/s · 3.2 tok/req-s · 12.957s latency · 1.4203 RTF** |

These are reference values. Existing `apply_slack`/WER/MOS slack derives the actual CI gates. The obsolete VideoAMME Talker `155s` hard cap was removed so the calibrated reference is effective.

## Validation

- `python -m pytest -q tests/unit_test/test_tune_ci_thresholds.py` (`7 passed`)
- `python -m compileall -q` on all changed Qwen3-Omni test modules
- `git diff --check`