### PR TITLE
[MPS]: Add H100 and H200 MPS DP hardware profiles

### DIFF
--- a/docs/basic_usage/mps_dp.md
+++ b/docs/basic_usage/mps_dp.md
@@ -28,20 +28,28 @@ Pick a GPU that is idle, then find its NUMA node from the PCI bus id (drm card o
 2. **Launch the replicas.**
 
 ```bash
-CORE_BLOCKS="0-9 10-19 20-29" MAX_TOTAL_TOKENS=100000 bash examples/mps_dp/launch.sh up
+CONFIG=examples/mps_dp/configs/higgs_h100_dp3.yaml N=3 CORE_BLOCKS="0-9 10-19 20-29" bash examples/mps_dp/launch.sh up
 ```
 
-The command above is the validated H100 Higgs DP3 recipe. The launcher uses three replicas by default, resolves the GPU's NUMA node, assigns one local port per replica, starts a private MPS daemon, waits for each replica's health check before starting the next, and verifies MPS attachment. The CPU blocks are specific to the tested host; derive the correct blocks for your own CPU topology.
+The command above is the validated H100 Higgs DP3 recipe. For the validated H200 Higgs DP8 recipe, use:
 
-The example leaves `--mem-fraction-static` unset and uses the model's existing default. Launching replicas sequentially avoids overlapping memory profiling and CUDA-graph capture during startup.
+```bash
+CONFIG=examples/mps_dp/configs/higgs_h200_dp8.yaml N=8 CORE_BLOCKS="0-3 4-7 8-11 12-15 16-19 20-23 24-27 28-31" bash examples/mps_dp/launch.sh up
+```
+
+The pipeline config supplies the model and per-replica runtime settings. The launcher environment supplies host-local placement, including the GPU, replica count, and CPU blocks. The launcher resolves the GPU's NUMA node, assigns local ports automatically, starts a private MPS daemon, waits for each replica's health check before starting the next, and verifies MPS attachment. The CPU blocks above are specific to the tested hosts; derive the correct non-overlapping blocks for your own CPU topology.
+
+Both profiles set `mem_fraction_static` to `0.85`; `MF` can override it. When `CONFIG` is unset, the existing `MODEL` and `MAX_TOTAL_TOKENS` interface remains available. Launching replicas sequentially avoids overlapping memory profiling and CUDA-graph capture during startup.
 
 Identical `--mem-fraction-static` flags do **not** mean identical KV capacity. `--mem-fraction-static` budgets model weights and the KV pool against the GPU memory available when each replica starts. Roughly, the profiled KV memory is the requested fraction of free memory measured before model loading, minus model and fixed runtime allocations. It is a per-replica budget, not an additive share of the card. Because replicas start sequentially, earlier ones have already reserved memory, so later ones see a smaller free pool and allocate fewer KV tokens even when every flag is the same (in one run, three sequential `mf=0.27` replicas received 97,503 / 53,149 / 20,961 KV tokens).
 
 ![What same-GPU DP spends in VRAM and what it reclaims](../_static/image/same-gpu-dp-vram.svg)
 
-Memory profiling does not coordinate KV allocation across independent replica processes. For `N > 1`, the launcher therefore requires one common `MAX_TOTAL_TOKENS` value and passes it to every replica as `--max-total-tokens`. SGLang treats this value as an upper bound; the launcher rejects startup unless every replica resolves exactly that capacity. The cap is independent of the request-level `max_new_tokens` limit and does not distribute requests between replicas.
+Memory profiling does not coordinate KV allocation across independent replica processes. For `N > 1`, the launcher therefore requires one common `max_total_tokens` value, either from the pipeline config or from `MAX_TOTAL_TOKENS`. SGLang treats this value as an upper bound; the launcher rejects startup unless every replica resolves exactly that capacity. The cap applies independently to each replica; it is not divided across the pool. It is also independent of the request-level `max_new_tokens` limit and does not distribute requests between replicas.
 
-The validated H100 Higgs DP3 cap is `100000` tokens per replica. This value is a starting point for the tested configuration, not a universal hardware default. Recalculate the cap after changing the model, GPU, runtime, replica count, memory settings, or CUDA-graph settings. If a replica cannot allocate the common cap, lower it or reduce the replica count.
+The H100 Higgs DP3 profile uses `100000` tokens per replica. The H200 Higgs DP8 profile uses `30000` tokens per replica, preserving GPU memory headroom for non-KV runtime allocations, including the colocated audio encoder and vocoder. These values are specific to their configurations, not universal hardware defaults. Recalculate the cap after changing the model, GPU, runtime, replica count, memory settings, or CUDA-graph settings. If a replica cannot allocate the common cap, lower it or reduce the replica count.
+
+The H200 profile's `30000`-token KV pool is smaller than the worst-case demand from 64 requests each generating up to 2048 new tokens, even before accounting for input tokens. Therefore, `max_running_requests=64` is an admission ceiling rather than a guarantee that 64 long requests can decode concurrently. If the pool fills, SGLang retracts requests and returns them to the waiting queue until KV capacity becomes available.
 
 3. **Drive every replica to saturation.**
 
@@ -74,7 +82,7 @@ Setting up and tearing down MPS is more involved than running a single replica, 
 | DP2 + MPS, 2 x c64 | 31.5 to 37.7 qps | 1.4 to 1.7x |
 | DP3 + MPS, 3 x c64 | 39.9 to 46.9 qps | 1.8 to 2.1x |
 
-These commands and the token cap are from an 80 GB H100 with Higgs and are not fixed recommendations for other GPUs. On an H200 you would re-determine the replica count, common feasible token cap, CPU allocation, and saturation concurrency for that card. H200 may fit a larger KV budget or additional replicas, but this guide does not prescribe unverified values: repeat the sizing and saturation procedure and inspect every replica's actual allocation.
+The throughput results in the table and H100 case study are from an 80 GB H100 with Higgs. The H200 DP8 profile was validated separately on the full SeedTTS English dataset at concurrency 64 per replica. Re-evaluate replica count, CPU allocation, token capacity, and saturation concurrency before applying either profile to different hardware or workloads.
 
 
 ## How We Found This

--- a/examples/mps_dp/config.py
+++ b/examples/mps_dp/config.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Resolve launcher values from an SGLang Omni pipeline config."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import yaml
+
+from sglang_omni.config.manager import ConfigManager
+from sglang_omni.config.runtime import resolve_stage_static_factory_args
+
+
+def resolve_max_total_tokens(
+    config_path: str | Path,
+    max_total_tokens_override: int | None = None,
+    *,
+    require_single_sglang_engine: bool = False,
+) -> int | None:
+    """Return the effective generation-stage KV cap, or None when unpinned."""
+
+    pipeline_config = ConfigManager.from_file(str(config_path)).config
+    config_type = type(pipeline_config)
+    stage_name = config_type.generation_sglang_role_to_stage().get("generation")
+    if stage_name is None:
+        raise ValueError(f"{config_type.__name__} does not declare a generation stage")
+
+    sglang_stage_names = {
+        *config_type.mem_fraction_role_to_stage().values(),
+        *config_type.talker_sglang_role_to_stage().values(),
+        *config_type.generation_sglang_role_to_stage().values(),
+    }
+    if require_single_sglang_engine and sglang_stage_names != {stage_name}:
+        raise ValueError(
+            "KV verification requires CONFIG with one SGLang engine stage; "
+            f"found {sorted(sglang_stage_names)}"
+        )
+
+    stage = next(
+        (stage for stage in pipeline_config.stages if stage.name == stage_name),
+        None,
+    )
+    if stage is None:
+        raise ValueError(
+            f"generation stage {stage_name!r} is missing from the pipeline"
+        )
+
+    value = max_total_tokens_override
+    if value is None:
+        factory_args = resolve_stage_static_factory_args(stage, pipeline_config)
+        value = factory_args.get("server_args_overrides", {}).get("max_total_tokens")
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(
+            "the generation stage must define a positive integer max_total_tokens"
+        )
+    return value
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("config", help="SGLang Omni pipeline config")
+    parser.add_argument("--max-total-tokens", type=int)
+    parser.add_argument("--require-single-sglang-engine", action="store_true")
+    args = parser.parse_args()
+    try:
+        value = resolve_max_total_tokens(
+            args.config,
+            args.max_total_tokens,
+            require_single_sglang_engine=args.require_single_sglang_engine,
+        )
+        if value is not None:
+            print(value)
+    except (OSError, KeyError, ValueError, yaml.YAMLError) as exc:
+        parser.error(str(exc))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mps_dp/configs/higgs_h100_dp3.yaml
+++ b/examples/mps_dp/configs/higgs_h100_dp3.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# Validated on one 80 GB H100 with three same-GPU Higgs replicas.
+
+config_cls: HiggsTtsPipelineConfig
+name: higgs
+model_path: bosonai/higgs-tts-3-4b
+
+stage_overrides:
+  tts_engine:
+    runtime:
+      sglang_server_args:
+        mem_fraction_static: 0.85
+
+runtime_overrides:
+  tts_engine:
+    server_args_overrides:
+      max_total_tokens: 100000
+      max_running_requests: 64
+      cuda_graph_max_bs: 64

--- a/examples/mps_dp/configs/higgs_h200_dp8.yaml
+++ b/examples/mps_dp/configs/higgs_h200_dp8.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# Validated on one 141 GB H200 with eight same-GPU Higgs replicas.
+
+config_cls: HiggsTtsPipelineConfig
+name: higgs
+model_path: bosonai/higgs-tts-3-4b
+
+stage_overrides:
+  tts_engine:
+    runtime:
+      sglang_server_args:
+        mem_fraction_static: 0.85
+
+runtime_overrides:
+  tts_engine:
+    server_args_overrides:
+      max_total_tokens: 30000
+      max_running_requests: 64
+      cuda_graph_max_bs: 64

--- a/examples/mps_dp/launch.sh
+++ b/examples/mps_dp/launch.sh
@@ -4,6 +4,9 @@
 # This is a tested example, not a production process supervisor.
 #
 # Usage:
+#   CONFIG=examples/mps_dp/configs/higgs_h100_dp3.yaml GPU_ID=0 N=3 \
+#     CORE_BLOCKS="0-9 10-19 20-29" \
+#     bash examples/mps_dp/launch.sh up
 #   MODEL=bosonai/higgs-tts-3-4b GPU_ID=0 N=3 MAX_TOTAL_TOKENS=100000 \
 #     CORE_BLOCKS="0-9 10-19 20-29" \
 #     bash examples/mps_dp/launch.sh up
@@ -12,15 +15,23 @@
 #   bash examples/mps_dp/launch.sh down [RUN_ID]
 #
 # Environment for `up` (defaults in parentheses):
-#   MODEL (bosonai/higgs-tts-3-4b), MODEL_NAME (higgs), GPU_ID (0), N (3),
-#   BASE_PORT (8801),
+#   CONFIG: optional pipeline config. For N > 1, it must contain one SGLang
+#     engine stage so the launcher can identify that stage's KV log. When unset,
+#     MODEL is used.
+#   MODEL (bosonai/higgs-tts-3-4b; unavailable with CONFIG),
+#   MODEL_NAME (higgs without CONFIG; pipeline name with CONFIG), GPU_ID (0), N (3),
+#   BASE_PORT (8801), PYTHON_BIN (python),
 #   CORE_BLOCKS: N non-overlapping CPU blocks on the GPU's NUMA node, required.
 #   NUMA_NODE: explicit override when the PCI-derived NUMA node is unavailable.
-#   MAX_TOTAL_TOKENS: common positive --max-total-tokens cap; required for N > 1.
-#   MF: optional explicit --mem-fraction-static override (unset = Higgs default).
+#   MAX_TOTAL_TOKENS: optional common positive token-cap override. For N > 1,
+#     set it here or in CONFIG's generation-stage server arguments. The environment
+#     value takes precedence when both are set.
+#   MF: optional explicit --mem-fraction-static override (unset = pipeline default).
 set -euo pipefail
 
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 STATE_ROOT=${STATE_ROOT:-/tmp/sglang-omni-same-gpu-dp/$UID}
+PYTHON_BIN=${PYTHON_BIN:-python}
 CMD=${1:-}
 RUN_ARG=${2:-}
 HEALTH_TRIES=${HEALTH_TRIES:-50}
@@ -295,7 +306,8 @@ teardown_state() {
 }
 
 up() {
-  local model=${MODEL:-bosonai/higgs-tts-3-4b} model_name=${MODEL_NAME:-higgs}
+  local config=${CONFIG:-} model=${MODEL:-bosonai/higgs-tts-3-4b}
+  local model_name=${MODEL_NAME:-}
   local gpu=${GPU_ID:-0} n=${N:-3} base_port=${BASE_PORT:-8801} mf=${MF:-}
   [[ "$gpu" =~ ^[0-9]+$ ]] || die "GPU_ID must be a non-negative integer, got '$gpu'"
   [[ "$n" =~ ^[1-9][0-9]*$ ]] || die "N must be a positive integer, got '$n'"
@@ -312,14 +324,44 @@ up() {
   read -r -a blocks <<< "$CORE_BLOCKS"
   [ "${#blocks[@]}" = "$n" ] || die "CORE_BLOCKS must contain exactly $n blocks"
 
+  local serve_cmd=(sgl-omni serve) source_args=() model_name_args=()
   local extra_args=() mem_args=()
-  if [ "$n" -gt 1 ] && [ -z "${MAX_TOTAL_TOKENS:-}" ]; then
+  local expected_max_total_tokens=${MAX_TOTAL_TOKENS:-}
+  local model_path_manifest=$model
+  if [ -n "$config" ]; then
+    [ -z "${MODEL:-}" ] || die "MODEL cannot be combined with CONFIG"
+    [ -f "$config" ] || die "config file not found: $config"
+    config=$(cd -- "$(dirname -- "$config")" && pwd)/$(basename -- "$config")
+    serve_cmd=("$PYTHON_BIN" -m sglang_omni.cli serve)
+    source_args=(--config "$config")
+    model_path_manifest=from_config
+    if [ -n "$model_name" ]; then
+      model_name_args=(--model-name "$model_name")
+    fi
+    local config_resolver_args=("$config")
+    if [ -n "$expected_max_total_tokens" ]; then
+      config_resolver_args+=(--max-total-tokens "$expected_max_total_tokens")
+    fi
+    if [ "$n" -gt 1 ]; then
+      config_resolver_args+=(--require-single-sglang-engine)
+    fi
+    expected_max_total_tokens=$("$PYTHON_BIN" "$SCRIPT_DIR/config.py" \
+      "${config_resolver_args[@]}") \
+      || die "could not resolve max_total_tokens from $config"
+  else
+    source_args=(--model-path "$model")
+    model_name=${MODEL_NAME:-higgs}
+    model_name_args=(--model-name "$model_name")
+  fi
+  if [ "$n" -gt 1 ] && [ -z "$expected_max_total_tokens" ]; then
     die "MAX_TOTAL_TOKENS is required for N=$n so every replica has the same KV capacity"
   fi
+  if [ -n "$expected_max_total_tokens" ]; then
+    [[ "$expected_max_total_tokens" =~ ^[1-9][0-9]*$ ]] \
+      || die "max_total_tokens must be a positive integer, got '$expected_max_total_tokens'"
+  fi
   if [ -n "${MAX_TOTAL_TOKENS:-}" ]; then
-    [[ "$MAX_TOTAL_TOKENS" =~ ^[1-9][0-9]*$ ]] \
-      || die "MAX_TOTAL_TOKENS must be a positive integer, got '$MAX_TOTAL_TOKENS'"
-    extra_args+=(--max-total-tokens "$MAX_TOTAL_TOKENS")
+    extra_args+=(--max-total-tokens "$expected_max_total_tokens")
   fi
   if [ -n "$mf" ]; then
     mem_args+=(--mem-fraction-static "$mf")
@@ -358,10 +400,11 @@ up() {
   chmod 700 "$state/mps" "$state/mps/pipe" "$state/mps/log"
   {
     echo "run_id=$run"; echo "gpu_id=$gpu"; echo "gpu_uuid=$uuid"; echo "numa_node=$node"
-    echo "model=$model"; echo "model_name=$model_name"; echo "n=$n"
-    echo "mem_fraction_static=${mf:-default}"
+    echo "config=${config:-none}"; echo "model_path=$model_path_manifest"
+    echo "model_name=${model_name:-from_config}"; echo "n=$n"
+    echo "mem_fraction_static_cli_override=${mf:-none}"
     echo "base_port=$base_port"; echo "core_blocks=$CORE_BLOCKS"
-    echo "max_total_tokens=${MAX_TOTAL_TOKENS:-auto/profiled}"
+    echo "max_total_tokens=${expected_max_total_tokens:-auto/profiled}"
   } > "$state/manifest"
 
   export CUDA_MPS_PIPE_DIRECTORY=$state/mps/pipe CUDA_MPS_LOG_DIRECTORY=$state/mps/log
@@ -397,7 +440,7 @@ up() {
     # exactly this run's process trees.
     CUDA_VISIBLE_DEVICES="$uuid" \
     setsid numactl --cpunodebind="$node" --membind="$node" -C "${blocks[$i]}" \
-      sgl-omni serve --model-path "$model" --model-name "$model_name" \
+      "${serve_cmd[@]}" "${source_args[@]}" "${model_name_args[@]}" \
         "${mem_args[@]}" "${extra_args[@]}" \
         --host 127.0.0.1 --port "$port" > "$log" 2>&1 < /dev/null &
     pid=$!
@@ -421,15 +464,15 @@ up() {
       tail -n 8 "$log" >&2
       exit 1
     fi
-    echo "replica $i healthy on port $port (cores ${blocks[$i]}, mem fraction ${mf:-default})"
+    echo "replica $i healthy on port $port (cores ${blocks[$i]})"
     resolved_tokens=""
     resolved_tokens=$(grep -m1 -oE '#tokens:[[:space:]]*[0-9]+' "$log" \
       | grep -oE '[0-9]+$' || true)
     if [ "$n" -gt 1 ]; then
       [ -n "$resolved_tokens" ] \
         || die "replica $i is healthy but its resolved KV capacity is missing from $log"
-      [ "$resolved_tokens" = "$MAX_TOTAL_TOKENS" ] \
-        || die "replica $i resolved $resolved_tokens KV tokens; expected $MAX_TOTAL_TOKENS"
+      [ "$resolved_tokens" = "$expected_max_total_tokens" ] \
+        || die "replica $i resolved $resolved_tokens KV tokens; expected $expected_max_total_tokens"
     fi
     echo "replica $i KV #tokens: ${resolved_tokens:-not found}"
   done
@@ -440,7 +483,7 @@ up() {
     exit 1
   fi
   trap - EXIT
-  echo "up: $n replicas on GPU $gpu; token cap ${MAX_TOTAL_TOKENS:-auto/profiled}; state: $state"
+  echo "up: $n replicas on GPU $gpu; token cap ${expected_max_total_tokens:-auto/profiled}; state: $state"
   echo "tear down with: bash $0 down $run"
 }
 


### PR DESCRIPTION
## Motivation

Add reusable hardware profiles for the same-GPU Higgs DP + CUDA MPS launcher. The profiles keep equal KV sizing explicit while separating portable model/runtime settings from host-specific GPU and CPU placement.

## Modifications

- Allow `examples/mps_dp/launch.sh` to start replicas from an SGLang Omni pipeline config while preserving the existing environment-based interface.
- Resolve the generation stage's configured `max_total_tokens` through `ConfigManager` so the launcher can continue verifying the exact KV capacity of every replica.
- Add validated Higgs profiles for H100 DP3 (`100000` KV tokens per replica) and H200 DP8 (`30000` KV tokens per replica), both with `max_running_requests=64` and `cuda_graph_max_bs=64`.
- Document how pipeline configs, launcher placement settings, and per-replica KV caps interact.

## Related Issues

Related to #1066  #921

## Benchmark & Profiling

H200 DP8 + MPS, full SeedTTS English dataset, concurrency 64 per replica:

| Runs | Requests | Failed | Mean throughput | Mean p50 / p95 / p99 |
|---:|---:|---:|---:|---:|
| 3 | 26,112 / 26,112 | 0 | 68.415 req/s | 6.356 / 10.144 / 12.519 s |

All replicas resolved exactly `30000` KV tokens, all eight MPS clients attached, and the GPU returned to idle after every run.
