### PR TITLE
Fix Fun-ASR integration review findings

### DIFF
--- a/docs/cookbook/fun_asr.md
+++ b/docs/cookbook/fun_asr.md
@@ -62,6 +62,7 @@ print(resp.json()["text"])
 | `language` | string | `en` | Language hint. `en`/`english`/`英文` transcribe to English; `zh`/`cn`/`chinese`/`中文` (or unset) transcribe to Chinese; other values pass through as the target language |
 | `response_format` | string | `json` | `json`, `verbose_json`, or `text` |
 | `temperature` | float | `0.0` | Sampling temperature; `0.0` (greedy) is the correct decoding mode for Fun-ASR-Nano and the default |
+| `max_new_tokens` | integer | duration-based | Generation budget scaled to the audio duration. Explicit values must be between 1 and 200 |
 
 ## Benchmarking
 
@@ -90,6 +91,8 @@ python -m benchmarks.eval.benchmark_asr_seedtts \
 ## Known Limitations
 
 - The endpoint accepts one uploaded file per request.
+- Each uploaded audio segment must be 30 seconds or shorter, matching the
+  official Fun-ASR VAD segment limit. Split longer recordings before upload.
 - `itn` and `hotwords` are supported by the model request builder but not
   exposed as form fields on the public transcription endpoint.
 - `prompt` is accepted by the HTTP endpoint for OpenAI compatibility, but

--- a/sglang_omni/models/fun_asr/__init__.py
+++ b/sglang_omni/models/fun_asr/__init__.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Author:
-# PoTaTo-Mika: https://github.com/PoTaTo-Mika
+
 """Fun-ASR model support for sglang-omni."""
 
 from . import config

--- a/sglang_omni/models/fun_asr/config.py
+++ b/sglang_omni/models/fun_asr/config.py
@@ -1,6 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-# Author:
-# PoTaTo-Mika: https://github.com/PoTaTo-Mika
 
 from __future__ import annotations
 
@@ -29,7 +27,9 @@ class FunASRPipelineConfig(PipelineConfig):
             factory_args={
                 "device": "cuda:0",
                 "max_running_requests": 32,
-                "max_new_tokens": 256,
+                "max_new_tokens": 200,
+                "request_build_max_workers": 2,
+                "request_build_max_pending": 16,
             },
             gpu=0,
             terminal=True,

--- a/sglang_omni/models/fun_asr/configuration_fun_asr.py
+++ b/sglang_omni/models/fun_asr/configuration_fun_asr.py
@@ -1,6 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-# Author:
-# PoTaTo-Mika: https://github.com/PoTaTo-Mika
 
 from __future__ import annotations
 
@@ -325,120 +323,73 @@ class FunAsrNanoProcessor:
         return inputs
 
 
-# ---------------------------------------------------------------------------
-# Config classes
-# ---------------------------------------------------------------------------
-
-
 class FunAsrNanoEncoderConfig(PretrainedConfig):
-    """SenseVoice-style SANM Conformer encoder hyperparameters.
-
-    Mirrors ``config.json`` ``audio_encoder_config``. The encoder itself
-    (``model.audio_encoder.*`` weights: encoders0/encoders/tp_encoders SANM
-    blocks + after_norm/tp_norm) is implemented in ``sglang_model.py``.
-    """
+    """SenseVoice SANM encoder configuration."""
 
     model_type = "fun_asr_nano_encoder"
 
     def __init__(
         self,
-        input_size: int = 560,
-        output_size: int = 512,
-        attention_heads: int = 4,
-        linear_units: int = 2048,
-        num_blocks: int = 50,
-        tp_blocks: int = 20,
+        num_mel_bins: int = 80,
+        num_stacked_frames: int = 7,
+        d_model: int = 512,
+        encoder_attention_heads: int = 4,
+        encoder_ffn_dim: int = 2048,
+        encoder_layers: int = 50,
+        num_timestamp_prediction_blocks: int = 20,
         kernel_size: int = 11,
-        sanm_shift: int = 0,
-        dropout_rate: float = 0.1,
-        attention_dropout_rate: float = 0.1,
-        positional_dropout_rate: float = 0.1,
-        initializer_range: float = 0.02,
+        dropout: float = 0.1,
+        attention_dropout: float = 0.1,
+        activation_dropout: float = 0.1,
+        activation_function: str = "relu",
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.input_size = input_size
-        self.output_size = output_size
-        self.attention_heads = attention_heads
-        self.linear_units = linear_units
-        self.num_blocks = num_blocks
-        self.tp_blocks = tp_blocks
+        self.num_mel_bins = num_mel_bins
+        self.num_stacked_frames = num_stacked_frames
+        self.d_model = d_model
+        self.encoder_attention_heads = encoder_attention_heads
+        self.encoder_ffn_dim = encoder_ffn_dim
+        self.encoder_layers = encoder_layers
+        self.num_timestamp_prediction_blocks = num_timestamp_prediction_blocks
         self.kernel_size = kernel_size
-        self.sanm_shift = sanm_shift
-        self.dropout_rate = dropout_rate
-        self.attention_dropout_rate = attention_dropout_rate
-        self.positional_dropout_rate = positional_dropout_rate
-        self.initializer_range = initializer_range
+        self.dropout = dropout
+        self.attention_dropout = attention_dropout
+        self.activation_dropout = activation_dropout
+        self.activation_function = activation_function
 
-
-class FunAsrNanoAdaptorConfig(PretrainedConfig):
-    """Low-frame-rate adaptor hyperparameters (``config.json`` top-level ``adaptor_*``)."""
-
-    model_type = "fun_asr_nano_adaptor"
-
-    def __init__(
-        self,
-        encoder_dim: int = 512,
-        llm_dim: int = 1024,
-        ffn_dim: int = 2048,
-        num_layers: int = 2,
-        attention_heads: int = 8,
-        downsample_rate: int = 1,
-        dropout_rate: float = 0.0,
-        use_low_frame_rate: bool = True,
-        **kwargs,
-    ):
-        super().__init__(**kwargs)
-        self.encoder_dim = encoder_dim
-        self.llm_dim = llm_dim
-        self.ffn_dim = ffn_dim
-        self.num_layers = num_layers
-        self.attention_heads = attention_heads
-        self.downsample_rate = downsample_rate
-        self.dropout_rate = dropout_rate
-        self.use_low_frame_rate = use_low_frame_rate
+    @property
+    def input_size(self) -> int:
+        return self.num_mel_bins * self.num_stacked_frames
 
 
 @register_customized_processor(FunAsrNanoProcessor)
 class FunAsrNanoConfig(PretrainedConfig):
-    """Top-level config for ``FunAsrNanoForConditionalGeneration``.
-
-    Matches the HF-adapted ``config.json`` shipped with Fun-ASR-Nano-2512:
-    ``audio_encoder_config`` (sub-config) + ``text_config`` (Qwen3) + top-level
-    ``adaptor_*`` fields + ``audio_token_index``. Note the HF checkpoint has NO
-    ``thinker_config`` wrapper (unlike Qwen3-ASR) — encoder/adaptor/text are
-    siblings under the top-level config.
-    """
+    """Configuration for the Fun-ASR-Nano checkpoint."""
 
     model_type = "fun_asr_nano"
     sub_configs: ClassVar[dict[str, Any]] = {
-        "audio_encoder_config": FunAsrNanoEncoderConfig,
+        "encoder_config": FunAsrNanoEncoderConfig,
     }
 
     def __init__(
         self,
-        audio_encoder_config=None,
+        encoder_config=None,
         text_config=None,
-        audio_token_index: int = 151646,
-        # Adaptor fields (top-level in config.json, prefixed adaptor_*)
-        adaptor_encoder_dim: int = 512,
-        adaptor_llm_dim: int = 1024,
-        adaptor_ffn_dim: int = 2048,
-        adaptor_num_layers: int = 2,
-        adaptor_attention_heads: int = 8,
-        adaptor_downsample_rate: int = 1,
-        adaptor_dropout_rate: float = 0.0,
-        use_low_frame_rate: bool = True,
+        audio_token_id: int = 151646,
+        adaptor_intermediate_size: int = 2048,
+        adaptor_num_hidden_layers: int = 2,
+        adaptor_num_attention_heads: int = 8,
+        activation_function: str = "relu",
+        initializer_range: float = 0.02,
+        tie_word_embeddings: bool = True,
         **kwargs,
     ):
-        # Resolve sub-configs BEFORE super().__init__: transformers 5.6 runs
-        # validate_token_ids inside __init__, which calls get_text_config() —
-        # so self.text_config must already exist when super() executes.
-        if isinstance(audio_encoder_config, dict):
-            audio_encoder_config = FunAsrNanoEncoderConfig(**audio_encoder_config)
-        elif audio_encoder_config is None:
-            audio_encoder_config = FunAsrNanoEncoderConfig()
-        self.audio_encoder_config = audio_encoder_config
+        if isinstance(encoder_config, dict):
+            encoder_config = FunAsrNanoEncoderConfig(**encoder_config)
+        elif encoder_config is None:
+            encoder_config = FunAsrNanoEncoderConfig()
+        self.encoder_config = encoder_config
 
         from transformers.models.qwen3.configuration_qwen3 import (
             Qwen3Config as HFQwen3Config,
@@ -449,29 +400,19 @@ class FunAsrNanoConfig(PretrainedConfig):
         elif text_config is None:
             text_config = HFQwen3Config()
         self.text_config = text_config
+        self.audio_token_id = audio_token_id
+        self.adaptor_intermediate_size = adaptor_intermediate_size
+        self.adaptor_num_hidden_layers = adaptor_num_hidden_layers
+        self.adaptor_num_attention_heads = adaptor_num_attention_heads
+        self.activation_function = activation_function
+        self.initializer_range = initializer_range
 
-        super().__init__(**kwargs)
-
-        # Adaptor config carried as a nested object for sglang_model.py.
-        self.adaptor_config = FunAsrNanoAdaptorConfig(
-            encoder_dim=adaptor_encoder_dim or self.audio_encoder_config.output_size,
-            llm_dim=adaptor_llm_dim or getattr(text_config, "hidden_size", 1024),
-            ffn_dim=adaptor_ffn_dim,
-            num_layers=adaptor_num_layers,
-            attention_heads=adaptor_attention_heads,
-            downsample_rate=adaptor_downsample_rate,
-            dropout_rate=adaptor_dropout_rate,
-            use_low_frame_rate=use_low_frame_rate,
+        super().__init__(
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
         )
 
-        # Audio placeholder token id (<|object_ref_start|>).
-        self.audio_token_index = audio_token_index
-
     def get_text_config(self, decoder: bool = False) -> PretrainedConfig:
-        # Called by transformers during super().__init__ validation and by
-        # sglang for context-length sizing. Guard against the brief window
-        # before self.text_config is assigned (should not trigger after the
-        # reorder above, but kept defensive).
         text_config = getattr(self, "text_config", None)
         if text_config is None:
             return self
@@ -480,12 +421,6 @@ class FunAsrNanoConfig(PretrainedConfig):
 
 AutoConfig.register("fun_asr_nano", FunAsrNanoConfig)
 AutoConfig.register("fun_asr_nano_encoder", FunAsrNanoEncoderConfig)
-AutoConfig.register("fun_asr_nano_adaptor", FunAsrNanoAdaptorConfig)
 
-# FunAsrNanoFeatureExtractor is a custom class (not a transformers built-in),
-# so AutoFeatureExtractor.from_pretrained — which stages.py uses to load the
-# feature extractor from preprocessor_config.json (feature_extractor_type=
-# "FunAsrNanoFeatureExtractor") — cannot resolve it without this registration.
-# The checkpoint ships no remote-code feature extractor (processor_config.json
-# only auto-maps AutoProcessor), so we register it ourselves.
+# note(LauraGPT): The checkpoint metadata names this local feature extractor.
 AutoFeatureExtractor.register("FunAsrNanoFeatureExtractor", FunAsrNanoFeatureExtractor)

--- a/sglang_omni/models/fun_asr/request_builders.py
+++ b/sglang_omni/models/fun_asr/request_builders.py
@@ -1,12 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-# Author:
-# PoTaTo-Mika: https://github.com/PoTaTo-Mika
 
 from __future__ import annotations
 
-import hashlib
-import io
 import logging
+import math
 import time
 from dataclasses import dataclass
 from typing import Any, Callable
@@ -23,6 +20,8 @@ from sglang.srt.sampling.sampling_params import SamplingParams
 
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
+from sglang_omni.utils.audio import audio_fingerprint, audio_fingerprint_int
+from sglang_omni.utils.audio import load_audio as _shared_load_audio
 
 from .tool_funcs.audio_lengths import fun_asr_low_frame_rate_length
 
@@ -30,6 +29,9 @@ logger = logging.getLogger(__name__)
 
 _SAMPLE_RATE = 16000
 _AUDIO_PAD = "<|object_ref_start|>"
+_MAX_AUDIO_DURATION_S = 30.0
+_MAX_GENERATION_TOKENS_AT_MAX_DURATION = 200
+_MIN_GENERATION_TOKENS = 16
 
 
 @dataclass
@@ -55,37 +57,39 @@ def _audio_source_from_payload(payload: StagePayload) -> Any:
     return inputs
 
 
-def load_audio(source: Any) -> np.ndarray:
-    """Load audio as a 1-D float32 numpy waveform at 16 kHz mono."""
-    import torchaudio
-
-    if isinstance(source, memoryview):
-        source = source.tobytes()
-    if isinstance(source, bytearray):
-        source = bytes(source)
-
-    if isinstance(source, bytes):
-        audio, sample_rate = torchaudio.load(io.BytesIO(source))
-    elif isinstance(source, str):
-        audio, sample_rate = torchaudio.load(source)
-    else:
-        raise ValueError(f"Unsupported Fun-ASR audio input: {type(source).__name__}")
-
-    if audio.ndim == 2 and audio.shape[0] > 1:
-        audio = audio.mean(dim=0, keepdim=True)
-    audio = audio.squeeze(0).to(torch.float32)
-    if sample_rate != _SAMPLE_RATE:
-        audio = torchaudio.functional.resample(audio, sample_rate, _SAMPLE_RATE)
-    return audio.cpu().numpy()
+def _load_audio(source: Any) -> np.ndarray:
+    return _shared_load_audio(
+        source,
+        source_name="Fun-ASR",
+        target_sample_rate=_SAMPLE_RATE,
+    )
 
 
-def _audio_fingerprint(audio: np.ndarray) -> str:
-    contiguous = np.ascontiguousarray(audio, dtype=np.float32)
-    return hashlib.blake2b(contiguous.tobytes(), digest_size=16).hexdigest()
+def _default_token_budget(audio_duration_s: float, max_new_tokens: int) -> int:
+    proportional = math.ceil(
+        audio_duration_s
+        / _MAX_AUDIO_DURATION_S
+        * _MAX_GENERATION_TOKENS_AT_MAX_DURATION
+    )
+    return min(max_new_tokens, max(_MIN_GENERATION_TOKENS, proportional))
 
 
-def _audio_fingerprint_int(fingerprint: str) -> int:
-    return int(fingerprint[:16], 16)
+def _request_token_budget(
+    params: dict[str, Any], audio_duration_s: float, max_new_tokens: int
+) -> int:
+    explicit = params.get("max_new_tokens")
+    if explicit is None:
+        return _default_token_budget(audio_duration_s, max_new_tokens)
+
+    try:
+        requested = int(explicit)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("max_new_tokens must be an integer") from exc
+    if requested < 1 or requested > max_new_tokens:
+        raise ValueError(
+            f"max_new_tokens must be between 1 and {max_new_tokens}, got {requested}"
+        )
+    return requested
 
 
 def _decode_token_ids(
@@ -145,15 +149,15 @@ def make_fun_asr_scheduler_adapters(
 ]:
     if feature_extractor is None:
         raise ValueError("Fun-ASR processor is missing a feature_extractor")
+    max_new_tokens = int(max_new_tokens)
+    if max_new_tokens < 1:
+        raise ValueError("max_new_tokens must be at least 1")
 
     audio_pad_token_id = int(tokenizer.convert_tokens_to_ids(_AUDIO_PAD))
     eos_token_id = int(tokenizer.eos_token_id)
     vocab_size = int(tokenizer.vocab_size)
 
     def _build_prompt_ids(num_audio_tokens: int, prompt_text: str) -> list[int]:
-        # ChatML per chat_template.jinja: system + user(text then N×audio
-        # placeholder) + assistant header. No <|audio_start|>/<|audio_end|>
-        # wrappers — the HF template emits <|object_ref_start|> bare.
         prompt = (
             f"<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n"
             f"<|im_start|>user\n"
@@ -165,9 +169,14 @@ def make_fun_asr_scheduler_adapters(
 
     def request_builder(payload: StagePayload) -> FunASRRequestData:
         params = payload.request.params or {}
-        audio = load_audio(_audio_source_from_payload(payload))
+        audio = _load_audio(_audio_source_from_payload(payload))
         audio_duration_s = float(len(audio) / _SAMPLE_RATE)
-        fingerprint = _audio_fingerprint(audio)
+        if audio_duration_s > _MAX_AUDIO_DURATION_S:
+            raise ValueError(
+                "Fun-ASR accepts audio up to 30.0 seconds because its official "
+                "VAD segment limit is 30 seconds; split longer audio before inference."
+            )
+        fingerprint = audio_fingerprint(audio)
 
         extracted = feature_extractor(
             audio,
@@ -198,7 +207,7 @@ def make_fun_asr_scheduler_adapters(
 
         audio_item = MultimodalDataItem(
             modality=Modality.AUDIO,
-            hash=_audio_fingerprint_int(fingerprint),
+            hash=audio_fingerprint_int(fingerprint),
             feature=features,
             model_specific_data={
                 "feature_attention_mask": feature_attention_mask,
@@ -230,7 +239,9 @@ def make_fun_asr_scheduler_adapters(
         mm_inputs.mrope_position_delta = torch.tensor([0], dtype=torch.long)
 
         temperature = float(params.get("temperature") or 0.0)
-        request_max_new_tokens = int(params.get("max_new_tokens") or max_new_tokens)
+        request_max_new_tokens = _request_token_budget(
+            params, audio_duration_s, max_new_tokens
+        )
         logger.debug(
             f"[fun-asr] sampling temp={temperature} "
             f"max_new_tokens={request_max_new_tokens} params={dict(params)}"
@@ -295,6 +306,5 @@ def make_fun_asr_scheduler_adapters(
 
 __all__ = [
     "FunASRRequestData",
-    "load_audio",
     "make_fun_asr_scheduler_adapters",
 ]

--- a/sglang_omni/models/fun_asr/sglang_model.py
+++ b/sglang_omni/models/fun_asr/sglang_model.py
@@ -84,7 +84,6 @@ class MultiHeadedAttentionSANM(nn.Module):
         self.dropout = nn.Dropout(p=dropout_rate)
 
     def forward_fsmn(self, v: torch.Tensor) -> torch.Tensor:
-        b, t, d = v.size()
         x = v.transpose(1, 2)  # (b, d, t)
         x = self.pad_fn(x)
         x = self.fsmn_block(x)

--- a/sglang_omni/models/fun_asr/sglang_model.py
+++ b/sglang_omni/models/fun_asr/sglang_model.py
@@ -1,6 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-# Author:
-# PoTaTo-Mika: https://github.com/PoTaTo-Mika
 
 from __future__ import annotations
 
@@ -24,16 +22,12 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.qwen3 import Qwen3ForCausalLM
 from sglang.srt.utils import add_prefix
+from transformers.activations import ACT2FN
 
 from .configuration_fun_asr import FunAsrNanoConfig
 from .tool_funcs.audio_lengths import fun_asr_low_frame_rate_length
 
 logger = logging.getLogger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# Positional encoding (funasr SinusoidalPositionEncoder, verbatim)
-# ---------------------------------------------------------------------------
 
 
 class SinusoidalPositionEncoder(nn.Module):
@@ -51,11 +45,6 @@ class SinusoidalPositionEncoder(nn.Module):
         return x + encoding
 
 
-# ---------------------------------------------------------------------------
-# SANM self-attention (funasr MultiHeadedAttentionSANM, verbatim)
-# ---------------------------------------------------------------------------
-
-
 class MultiHeadedAttentionSANM(nn.Module):
 
     def __init__(
@@ -64,55 +53,57 @@ class MultiHeadedAttentionSANM(nn.Module):
         in_feat: int,
         n_feat: int,
         dropout_rate: float,
-        kernel_size: int,
-        sanm_shfit: int = 0,
     ) -> None:
         super().__init__()
         assert n_feat % n_head == 0
         self.d_k = n_feat // n_head
         self.h = n_head
-        self.linear_out = nn.Linear(n_feat, n_feat)
-        self.linear_q_k_v = nn.Linear(in_feat, n_feat * 3)
-        self.fsmn_block = nn.Conv1d(
-            n_feat, n_feat, kernel_size, stride=1, padding=0, groups=n_feat, bias=False
-        )
-        left_padding = (kernel_size - 1) // 2
-        if sanm_shfit > 0:
-            left_padding = left_padding + sanm_shfit
-        right_padding = kernel_size - 1 - left_padding
-        self.pad_fn = nn.ConstantPad1d((left_padding, right_padding), 0.0)
+        self.q_proj = nn.Linear(in_feat, n_feat)
+        self.k_proj = nn.Linear(in_feat, n_feat)
+        self.v_proj = nn.Linear(in_feat, n_feat)
+        self.out_proj = nn.Linear(n_feat, n_feat)
         self.dropout = nn.Dropout(p=dropout_rate)
 
-    def forward_fsmn(self, v: torch.Tensor) -> torch.Tensor:
-        x = v.transpose(1, 2)  # (b, d, t)
-        x = self.pad_fn(x)
-        x = self.fsmn_block(x)
-        x = x.transpose(1, 2)  # (b, t, d)
-        x = x + v  # residual
-        x = self.dropout(x)
-        return x
-
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        b, t, d = x.size()
-        q_k_v = self.linear_q_k_v(x)
-        q, k, v = torch.split(q_k_v, int(self.h * self.d_k), dim=-1)
+        b, t, _ = x.size()
+        q = self.q_proj(x)
+        k = self.k_proj(x)
+        v = self.v_proj(x)
         q_h = q.view(b, t, self.h, self.d_k).transpose(1, 2)  # (b, h, t, dk)
         k_h = k.view(b, t, self.h, self.d_k).transpose(1, 2)
         v_h = v.view(b, t, self.h, self.d_k).transpose(1, 2)
 
-        fsmn_memory = self.forward_fsmn(v)
         q_h = q_h * (self.d_k**-0.5)
         scores = torch.matmul(q_h, k_h.transpose(-2, -1))  # (b, h, t, t)
         attn = torch.softmax(scores, dim=-1)
         p_attn = self.dropout(attn)
         x = torch.matmul(p_attn, v_h)  # (b, h, t, dk)
         x = x.transpose(1, 2).contiguous().view(b, -1, self.h * self.d_k)
-        return self.linear_out(x) + fsmn_memory
+        return self.out_proj(x)
 
 
-# ---------------------------------------------------------------------------
-# Encoder layer (funasr EncoderLayerSANM, verbatim)
-# ---------------------------------------------------------------------------
+class FunAsrNanoFSMN(nn.Module):
+
+    def __init__(self, size: int, kernel_size: int, dropout_rate: float) -> None:
+        super().__init__()
+        self.conv = nn.Conv1d(
+            size,
+            size,
+            kernel_size,
+            stride=1,
+            padding=0,
+            groups=size,
+            bias=False,
+        )
+        left_padding = (kernel_size - 1) // 2
+        right_padding = kernel_size - 1 - left_padding
+        self.pad = nn.ConstantPad1d((left_padding, right_padding), 0.0)
+        self.dropout = nn.Dropout(dropout_rate)
+
+    def forward(self, value_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.conv(self.pad(value_states.transpose(1, 2)))
+        hidden_states = hidden_states.transpose(1, 2) + value_states
+        return self.dropout(hidden_states)
 
 
 class EncoderLayerSANM(nn.Module):
@@ -121,45 +112,44 @@ class EncoderLayerSANM(nn.Module):
         self,
         in_size: int,
         size: int,
-        self_attn: MultiHeadedAttentionSANM,
-        feed_forward: "PositionwiseFeedForward",
+        attention_heads: int,
+        linear_units: int,
+        kernel_size: int,
         dropout_rate: float,
+        attention_dropout_rate: float,
+        activation_dropout_rate: float,
+        activation_function: str,
     ) -> None:
         super().__init__()
-        self.self_attn = self_attn
-        self.feed_forward = feed_forward
-        self.norm1 = nn.LayerNorm(in_size, eps=1e-5)
-        self.norm2 = nn.LayerNorm(size, eps=1e-5)
+        self.self_attn = MultiHeadedAttentionSANM(
+            attention_heads, in_size, size, attention_dropout_rate
+        )
+        self.self_attn_layer_norm = nn.LayerNorm(in_size, eps=1e-5)
+        self.final_layer_norm = nn.LayerNorm(size, eps=1e-5)
+        self.fc1 = nn.Linear(size, linear_units)
+        self.fc2 = nn.Linear(linear_units, size)
+        self.fsmn = FunAsrNanoFSMN(size, kernel_size, attention_dropout_rate)
         self.dropout = nn.Dropout(dropout_rate)
+        self.activation_dropout = nn.Dropout(activation_dropout_rate)
+        self.activation = ACT2FN[activation_function]
         self.in_size = in_size
         self.size = size
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         residual = x
-        x = self.norm1(x)
+        x = self.self_attn_layer_norm(x)
+        value_states = self.self_attn.v_proj(x)
+        x = self.dropout(self.self_attn(x) + self.fsmn(value_states))
         if self.in_size == self.size:
-            x = residual + self.dropout(self.self_attn(x))
-        else:
-            # Input projection block (560→512): no residual on attention.
-            x = self.dropout(self.self_attn(x))
+            x = residual + x
         residual = x
-        x = self.norm2(x)
-        x = residual + self.dropout(self.feed_forward(x))
+        x = self.final_layer_norm(x)
+        x = self.activation_dropout(self.activation(self.fc1(x)))
+        x = residual + self.dropout(self.fc2(x))
+        if x.dtype == torch.float16:
+            clamp_value = torch.finfo(x.dtype).max - 1000
+            x = torch.clamp(x, min=-clamp_value, max=clamp_value)
         return x
-
-
-class PositionwiseFeedForward(nn.Module):
-    """funasr PositionwiseFeedForward: w_2(relu(w_1(x)))."""
-
-    def __init__(self, idim: int, hidden_units: int, dropout_rate: float) -> None:
-        super().__init__()
-        self.w_1 = nn.Linear(idim, hidden_units)
-        self.w_2 = nn.Linear(hidden_units, idim)
-        self.dropout = nn.Dropout(dropout_rate)
-        self.activation = nn.ReLU()
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.w_2(self.dropout(self.activation(self.w_1(x))))
 
 
 class FunAsrNanoAudioEncoder(nn.Module):
@@ -173,89 +163,52 @@ class FunAsrNanoAudioEncoder(nn.Module):
         num_blocks: int = 50,
         tp_blocks: int = 20,
         kernel_size: int = 11,
-        sanm_shfit: int = 0,
         dropout_rate: float = 0.1,
         attention_dropout_rate: float = 0.1,
+        activation_dropout_rate: float = 0.1,
+        activation_function: str = "relu",
     ) -> None:
         super().__init__()
         self._output_size = output_size
         self.embed = SinusoidalPositionEncoder()
 
-        def make_attn(in_feat: int) -> MultiHeadedAttentionSANM:
-            return MultiHeadedAttentionSANM(
-                attention_heads,
-                in_feat,
+        def make_layer(in_size: int) -> EncoderLayerSANM:
+            return EncoderLayerSANM(
+                in_size,
                 output_size,
-                attention_dropout_rate,
+                attention_heads,
+                linear_units,
                 kernel_size,
-                sanm_shfit,
+                dropout_rate,
+                attention_dropout_rate,
+                activation_dropout_rate,
+                activation_function,
             )
 
-        def make_ffn() -> PositionwiseFeedForward:
-            return PositionwiseFeedForward(output_size, linear_units, dropout_rate)
-
-        # encoders0: 1 block, in_size=input_size (560) → output_size (512).
-        self.encoders0 = nn.ModuleList(
-            [
-                EncoderLayerSANM(
-                    input_size,
-                    output_size,
-                    make_attn(input_size),
-                    make_ffn(),
-                    dropout_rate,
-                )
-                for _ in range(1)
-            ]
+        self.stem = make_layer(input_size)
+        self.layers = nn.ModuleList(
+            [make_layer(output_size) for _ in range(num_blocks - 1)]
         )
-        # encoders: num_blocks-1 blocks, 512 → 512.
-        self.encoders = nn.ModuleList(
-            [
-                EncoderLayerSANM(
-                    output_size,
-                    output_size,
-                    make_attn(output_size),
-                    make_ffn(),
-                    dropout_rate,
-                )
-                for _ in range(num_blocks - 1)
-            ]
+        self.layer_norm = nn.LayerNorm(output_size, eps=1e-5)
+        self.timestamp_prediction_layers = nn.ModuleList(
+            [make_layer(output_size) for _ in range(tp_blocks)]
         )
-        self.tp_encoders = nn.ModuleList(
-            [
-                EncoderLayerSANM(
-                    output_size,
-                    output_size,
-                    make_attn(output_size),
-                    make_ffn(),
-                    dropout_rate,
-                )
-                for _ in range(tp_blocks)
-            ]
-        )
-        self.after_norm = nn.LayerNorm(output_size, eps=1e-5)
-        self.tp_norm = nn.LayerNorm(output_size, eps=1e-5)
+        self.timestamp_prediction_layer_norm = nn.LayerNorm(output_size, eps=1e-5)
 
     def output_size(self) -> int:
         return self._output_size
 
     def forward(self, xs: torch.Tensor) -> torch.Tensor:
-        # xs: [B, T, input_size]. Scale by sqrt(output_size) then add sinusoidal PE.
         xs = xs * (self._output_size**0.5)
         xs = self.embed(xs)
-        for layer in self.encoders0:
+        xs = self.stem(xs)
+        for layer in self.layers:
             xs = layer(xs)
-        for layer in self.encoders:
+        xs = self.layer_norm(xs)
+        for layer in self.timestamp_prediction_layers:
             xs = layer(xs)
-        xs = self.after_norm(xs)
-        for layer in self.tp_encoders:
-            xs = layer(xs)
-        xs = self.tp_norm(xs)
+        xs = self.timestamp_prediction_layer_norm(xs)
         return xs
-
-
-# ---------------------------------------------------------------------------
-# Adaptor (funasr Transformer adaptor, downsample_rate=1)
-# ---------------------------------------------------------------------------
 
 
 class MultiHeadedAttention(nn.Module):
@@ -270,24 +223,24 @@ class MultiHeadedAttention(nn.Module):
         assert n_feat % n_head == 0
         self.d_k = n_feat // n_head
         self.h = n_head
-        self.linear_q = nn.Linear(n_feat, n_feat)
-        self.linear_k = nn.Linear(n_feat, n_feat)
-        self.linear_v = nn.Linear(n_feat, n_feat)
-        self.linear_out = nn.Linear(n_feat, n_feat)
+        self.q_proj = nn.Linear(n_feat, n_feat)
+        self.k_proj = nn.Linear(n_feat, n_feat)
+        self.v_proj = nn.Linear(n_feat, n_feat)
+        self.out_proj = nn.Linear(n_feat, n_feat)
         self.dropout = nn.Dropout(p=dropout_rate)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         b, t, d = x.size()
-        q_h = self.linear_q(x).view(b, t, self.h, self.d_k).transpose(1, 2)
-        k_h = self.linear_k(x).view(b, t, self.h, self.d_k).transpose(1, 2)
-        v_h = self.linear_v(x).view(b, t, self.h, self.d_k).transpose(1, 2)
+        q_h = self.q_proj(x).view(b, t, self.h, self.d_k).transpose(1, 2)
+        k_h = self.k_proj(x).view(b, t, self.h, self.d_k).transpose(1, 2)
+        v_h = self.v_proj(x).view(b, t, self.h, self.d_k).transpose(1, 2)
         q_h = q_h * (self.d_k**-0.5)
         scores = torch.matmul(q_h, k_h.transpose(-2, -1))
         attn = torch.softmax(scores, dim=-1)
         p_attn = self.dropout(attn)
         x = torch.matmul(p_attn, v_h)
         x = x.transpose(1, 2).contiguous().view(b, -1, self.h * self.d_k)
-        return self.linear_out(x)
+        return self.out_proj(x)
 
 
 class AdaptorEncoderLayer(nn.Module):
@@ -296,23 +249,26 @@ class AdaptorEncoderLayer(nn.Module):
         self,
         size: int,
         self_attn: MultiHeadedAttention,
-        feed_forward: PositionwiseFeedForward,
+        feed_forward_dim: int,
         dropout_rate: float,
+        activation_function: str,
     ) -> None:
         super().__init__()
         self.self_attn = self_attn
-        self.feed_forward = feed_forward
-        self.norm1 = nn.LayerNorm(size, eps=1e-5)
-        self.norm2 = nn.LayerNorm(size, eps=1e-5)
+        self.self_attn_layer_norm = nn.LayerNorm(size, eps=1e-5)
+        self.final_layer_norm = nn.LayerNorm(size, eps=1e-5)
+        self.fc1 = nn.Linear(size, feed_forward_dim)
+        self.fc2 = nn.Linear(feed_forward_dim, size)
+        self.activation = ACT2FN[activation_function]
         self.dropout = nn.Dropout(dropout_rate)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         residual = x
-        x = self.norm1(x)
+        x = self.self_attn_layer_norm(x)
         x = residual + self.dropout(self.self_attn(x))
         residual = x
-        x = self.norm2(x)
-        x = residual + self.dropout(self.feed_forward(x))
+        x = self.final_layer_norm(x)
+        x = residual + self.dropout(self.fc2(self.activation(self.fc1(x))))
         return x
 
 
@@ -325,16 +281,15 @@ class FunAsrNanoAdaptor(nn.Module):
         ffn_dim: int = 2048,
         num_layers: int = 2,
         attention_heads: int = 8,
-        downsample_rate: int = 1,
         dropout_rate: float = 0.0,
+        activation_function: str = "relu",
     ) -> None:
         super().__init__()
         self.encoder_dim = encoder_dim
         self.llm_dim = llm_dim
-        self.k = downsample_rate
-        self.linear1 = nn.Linear(encoder_dim * self.k, ffn_dim)
-        self.relu = nn.ReLU()
-        self.linear2 = nn.Linear(ffn_dim, llm_dim)
+        self.linear_1 = nn.Linear(encoder_dim, ffn_dim)
+        self.act = ACT2FN[activation_function]
+        self.linear_2 = nn.Linear(ffn_dim, llm_dim)
 
         ffn_hidden = llm_dim // 4
         self.blocks = nn.ModuleList(
@@ -342,23 +297,21 @@ class FunAsrNanoAdaptor(nn.Module):
                 AdaptorEncoderLayer(
                     llm_dim,
                     MultiHeadedAttention(attention_heads, llm_dim, dropout_rate),
-                    PositionwiseFeedForward(llm_dim, ffn_hidden, dropout_rate),
+                    ffn_hidden,
                     dropout_rate,
+                    activation_function,
                 )
                 for _ in range(num_layers)
             ]
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = self.linear1(x)
-        x = self.relu(x)
-        x = self.linear2(x)
+        x = self.linear_1(x)
+        x = self.act(x)
+        x = self.linear_2(x)
         for block in self.blocks:
             x = block(x)
         return x
-
-
-# Final Model
 
 
 class FunAsrNanoForConditionalGeneration(nn.Module):
@@ -388,29 +341,29 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
     ) -> None:
         super().__init__()
         self.config = config
-        enc_cfg = config.audio_encoder_config
-        adp_cfg = config.adaptor_config
+        enc_cfg = config.encoder_config
 
-        self.audio_encoder = FunAsrNanoAudioEncoder(
+        self.audio_tower = FunAsrNanoAudioEncoder(
             input_size=enc_cfg.input_size,
-            output_size=enc_cfg.output_size,
-            attention_heads=enc_cfg.attention_heads,
-            linear_units=enc_cfg.linear_units,
-            num_blocks=enc_cfg.num_blocks,
-            tp_blocks=enc_cfg.tp_blocks,
+            output_size=enc_cfg.d_model,
+            attention_heads=enc_cfg.encoder_attention_heads,
+            linear_units=enc_cfg.encoder_ffn_dim,
+            num_blocks=enc_cfg.encoder_layers,
+            tp_blocks=enc_cfg.num_timestamp_prediction_blocks,
             kernel_size=enc_cfg.kernel_size,
-            sanm_shfit=enc_cfg.sanm_shift,
-            dropout_rate=enc_cfg.dropout_rate,
-            attention_dropout_rate=enc_cfg.attention_dropout_rate,
+            dropout_rate=enc_cfg.dropout,
+            attention_dropout_rate=enc_cfg.attention_dropout,
+            activation_dropout_rate=enc_cfg.activation_dropout,
+            activation_function=enc_cfg.activation_function,
         )
-        self.audio_adaptor = FunAsrNanoAdaptor(
-            encoder_dim=adp_cfg.encoder_dim,
-            llm_dim=adp_cfg.llm_dim,
-            ffn_dim=adp_cfg.ffn_dim,
-            num_layers=adp_cfg.num_layers,
-            attention_heads=adp_cfg.attention_heads,
-            downsample_rate=adp_cfg.downsample_rate,
-            dropout_rate=adp_cfg.dropout_rate,
+        self.multi_modal_projector = FunAsrNanoAdaptor(
+            encoder_dim=enc_cfg.d_model,
+            llm_dim=config.text_config.hidden_size,
+            ffn_dim=config.adaptor_intermediate_size,
+            num_layers=config.adaptor_num_hidden_layers,
+            attention_heads=config.adaptor_num_attention_heads,
+            dropout_rate=0.0,
+            activation_function=config.activation_function,
         )
         self.language_model = Qwen3ForCausalLM(
             config.text_config,
@@ -424,8 +377,8 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
 
     def get_audio_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
 
-        device = next(self.audio_encoder.parameters()).device
-        dtype = next(self.audio_encoder.parameters()).dtype
+        device = next(self.audio_tower.parameters()).device
+        dtype = next(self.audio_tower.parameters()).dtype
 
         embeddings: List[torch.Tensor] = []
         for item in items:
@@ -439,8 +392,8 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
                 feature = feature[:, :, :valid]
             # [1, 560, T] → [1, T, 560] (encoder expects [B, T, D]).
             xs = feature.permute(0, 2, 1).contiguous()
-            enc_out = self.audio_encoder(xs)  # [1, T, 512]
-            adp_out = self.audio_adaptor(enc_out)  # [1, T, 1024]
+            enc_out = self.audio_tower(xs)  # [1, T, 512]
+            adp_out = self.multi_modal_projector(enc_out)  # [1, T, 1024]
             t_lfr = adp_out.shape[1]
             num_tokens = int(fun_asr_low_frame_rate_length(t_lfr))
             num_tokens = max(num_tokens, 1)
@@ -478,6 +431,7 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
         params_dict = dict(self.named_parameters(remove_duplicate=False))
 
         for name, loaded_weight in weights:
+            checkpoint_name = name
             if "rotary_emb.inv_freq" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:
@@ -488,14 +442,20 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
             ):
                 continue
 
-            if name.startswith("model.audio_encoder."):
-                name = name.replace("model.audio_encoder.", "audio_encoder.", 1)
+            strict_multimodal = False
+            if name.startswith("model.audio_tower."):
+                name = name.replace("model.", "", 1)
                 is_llm = False
-            elif name.startswith("model.audio_adaptor."):
-                name = name.replace("model.audio_adaptor.", "audio_adaptor.", 1)
+                strict_multimodal = True
+            elif name.startswith("model.multi_modal_projector."):
+                name = name.replace("model.", "", 1)
                 is_llm = False
+                strict_multimodal = True
             elif name.startswith("model.language_model."):
                 name = name.replace("model.language_model.", "language_model.model.", 1)
+                is_llm = True
+            elif name == "lm_head.weight":
+                name = "language_model.lm_head.weight"
                 is_llm = True
             else:
                 is_llm = False
@@ -521,6 +481,11 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
             if name.endswith(".bias") and name not in params_dict:
                 continue
             if name not in params_dict:
+                if strict_multimodal:
+                    raise ValueError(
+                        f"Fun-ASR checkpoint weight {checkpoint_name} has no matching "
+                        f"model parameter ({name})"
+                    )
                 continue
             param = params_dict[name]
             weight_loader = getattr(param, "weight_loader", default_weight_loader)

--- a/sglang_omni/models/fun_asr/stages.py
+++ b/sglang_omni/models/fun_asr/stages.py
@@ -1,6 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-# Author:
-# PoTaTo-Mika: https://github.com/PoTaTo-Mika
 
 from __future__ import annotations
 
@@ -9,14 +7,20 @@ from typing import Any
 from sglang.srt.managers.mm_utils import init_mm_embedding_cache
 from transformers import AutoFeatureExtractor, AutoTokenizer
 
-# Imported for AutoConfig and AutoFeatureExtractor registration side effects.
+# note(LauraGPT): Auto* loading depends on these local registrations.
 import sglang_omni.models.fun_asr.configuration_fun_asr  # noqa: F401
 from sglang_omni.model_runner.base import ModelRunner
 from sglang_omni.models.fun_asr.request_builders import make_fun_asr_scheduler_adapters
 from sglang_omni.models.fun_asr.tool_funcs.audio_lengths import (
     fun_asr_low_frame_rate_length,
 )
-from sglang_omni.scheduling.bootstrap import create_sglang_infrastructure
+from sglang_omni.scheduling.bootstrap import (
+    create_sglang_infrastructure_defer_cuda_graph,
+)
+from sglang_omni.scheduling.generation_batch_policy import (
+    build_generation_batch_overrides,
+    validate_generation_batch_policy,
+)
 from sglang_omni.scheduling.omni_scheduler import OmniScheduler
 from sglang_omni.scheduling.sglang_backend import (
     SGLangOutputProcessor,
@@ -31,11 +35,13 @@ def create_sglang_fun_asr_executor(
     device: str = "cuda:0",
     dtype: str = "bfloat16",
     max_running_requests: int = 32,
-    max_new_tokens: int = 256,
+    max_new_tokens: int = 200,
     mem_fraction_static: float | None = None,
     mm_embedding_cache_size_bytes: int = 0,
     enable_torch_compile: bool = False,
     mm_attention_backend: str | None = None,
+    request_build_max_workers: int = 2,
+    request_build_max_pending: int | None = 16,
     server_args_overrides: dict[str, Any] | None = None,
 ):
 
@@ -52,27 +58,27 @@ def create_sglang_fun_asr_executor(
 
     prompt_overhead_tokens = 128
 
-    overrides: dict[str, Any] = {
+    defaults: dict[str, Any] = {
         "disable_cuda_graph": False,
         "disable_overlap_schedule": True,
         "enable_torch_compile": enable_torch_compile,
-        "torch_compile_max_bs": max_running_requests,
-        "cuda_graph_max_bs": max_running_requests,
         "mem_fraction_static": mem_fraction_static,
-        "max_running_requests": max_running_requests,
         "max_prefill_tokens": 4096,
         "chunked_prefill_size": 4096,
         "sampling_backend": "pytorch",
         "dtype": dtype,
     }
     if mm_attention_backend is not None:
-        overrides["mm_attention_backend"] = mm_attention_backend
+        defaults["mm_attention_backend"] = mm_attention_backend
     else:
         sm_version = get_visible_gpu_sm_version(gpu_id)
         if sm_version is not None and sm_version >= 100:
-            overrides["mm_attention_backend"] = "triton_attn"
-    if server_args_overrides:
-        overrides.update(server_args_overrides)
+            defaults["mm_attention_backend"] = "triton_attn"
+    overrides = build_generation_batch_overrides(
+        max_running_requests=max_running_requests,
+        server_args_overrides=server_args_overrides,
+        **defaults,
+    )
 
     server_args = build_sglang_server_args(
         model_path,
@@ -81,14 +87,12 @@ def create_sglang_fun_asr_executor(
         + prompt_overhead_tokens,
         **overrides,
     )
+    validate_generation_batch_policy(
+        model_name="Fun-ASR",
+        server_args=server_args,
+    )
 
-    # Temporarily disable CUDA graphs during infrastructure init (weights load +
-    # memory-pool sizing), then re-enable and capture graphs on the built model.
-    want_cuda_graph = not bool(getattr(server_args, "disable_cuda_graph", False))
-    if want_cuda_graph:
-        server_args.disable_cuda_graph = True
-
-    (
+    want_cuda_graph, (
         model_worker,
         tree_cache,
         req_to_token_pool,
@@ -96,14 +100,13 @@ def create_sglang_fun_asr_executor(
         prefill_mgr,
         decode_mgr,
         model_config,
-    ) = create_sglang_infrastructure(
+    ) = create_sglang_infrastructure_defer_cuda_graph(
         server_args,
         gpu_id,
         model_arch_override="FunAsrNanoForConditionalGeneration",
     )
 
     if want_cuda_graph:
-        server_args.disable_cuda_graph = False
         model_worker.model_runner.init_device_graphs()
 
     init_mm_embedding_cache(mm_embedding_cache_size_bytes)
@@ -131,6 +134,8 @@ def create_sglang_fun_asr_executor(
         model_runner=ModelRunner(model_worker, output_proc),
         request_builder=request_builder,
         result_adapter=result_adapter,
+        request_build_max_workers=request_build_max_workers,
+        request_build_max_pending=request_build_max_pending,
     )
 
 

--- a/sglang_omni/models/fun_asr/stages.py
+++ b/sglang_omni/models/fun_asr/stages.py
@@ -9,10 +9,9 @@ from typing import Any
 from sglang.srt.managers.mm_utils import init_mm_embedding_cache
 from transformers import AutoFeatureExtractor, AutoTokenizer
 
+# Imported for AutoConfig and AutoFeatureExtractor registration side effects.
+import sglang_omni.models.fun_asr.configuration_fun_asr  # noqa: F401
 from sglang_omni.model_runner.base import ModelRunner
-from sglang_omni.models.fun_asr.configuration_fun_asr import (  # noqa: F401 — registers fun_asr_nano AutoConfig + FunAsrNanoFeatureExtractor
-    FunAsrNanoConfig,
-)
 from sglang_omni.models.fun_asr.request_builders import make_fun_asr_scheduler_adapters
 from sglang_omni.models.fun_asr.tool_funcs.audio_lengths import (
     fun_asr_low_frame_rate_length,

--- a/sglang_omni/models/fun_asr/tool_funcs/__init__.py
+++ b/sglang_omni/models/fun_asr/tool_funcs/__init__.py
@@ -1,6 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-# Author:
-# PoTaTo-Mika: https://github.com/PoTaTo-Mika
 
 from .audio_lengths import (
     fun_asr_audio_token_lengths,

--- a/sglang_omni/models/fun_asr/tool_funcs/audio_lengths.py
+++ b/sglang_omni/models/fun_asr/tool_funcs/audio_lengths.py
@@ -8,7 +8,6 @@ from typing import Any
 
 import torch
 
-_LFR_M = 7
 _LFR_N = 6
 _LOW_FRAME_RATE_STAGES = 3
 

--- a/sglang_omni/models/fun_asr/tool_funcs/audio_lengths.py
+++ b/sglang_omni/models/fun_asr/tool_funcs/audio_lengths.py
@@ -1,6 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-# Author:
-# PoTaTo-Mika: https://github.com/PoTaTo-Mika
 
 from __future__ import annotations
 
@@ -13,31 +11,27 @@ _LOW_FRAME_RATE_STAGES = 3
 
 
 def fun_asr_lfr_length(mel_frames: int) -> int:
-
     return (mel_frames + _LFR_N - 1) // _LFR_N
 
 
 def fun_asr_low_frame_rate_length(lfr_frames: int) -> int:
-
     out = lfr_frames
     for _ in range(_LOW_FRAME_RATE_STAGES):
-        out = (out + 1) // 2  # ceil(out / 2)
+        out = (out + 1) // 2
     return out
 
 
 def fun_asr_audio_token_lengths(input_lengths: Any) -> torch.Tensor:
-
     if not isinstance(input_lengths, torch.Tensor):
         input_lengths = torch.tensor(input_lengths)
-    lfr_lengths = (input_lengths + _LFR_N - 1) // _LFR_N  # ceil(T / 6)
+    lfr_lengths = (input_lengths + _LFR_N - 1) // _LFR_N
     tokens = lfr_lengths
     for _ in range(_LOW_FRAME_RATE_STAGES):
-        tokens = (tokens + 1) // 2  # ceil(x / 2)
+        tokens = (tokens + 1) // 2
     return tokens
 
 
 def fun_asr_num_audio_tokens(num_mel_frames: int) -> int:
-    """Scalar wrapper for scheduler request construction."""
     return int(fun_asr_audio_token_lengths(num_mel_frames).item())
 
 

--- a/tests/unit_test/fun_asr/__init__.py
+++ b/tests/unit_test/fun_asr/__init__.py
@@ -1,3 +1,1 @@
 # SPDX-License-Identifier: Apache-2.0
-# Author:
-# PoTaTo-Mika: https://github.com/PoTaTo-Mika

--- a/tests/unit_test/fun_asr/test_configuration.py
+++ b/tests/unit_test/fun_asr/test_configuration.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from sglang_omni.models.fun_asr.configuration_fun_asr import FunAsrNanoConfig
+
+
+def test_fun_asr_config_uses_current_checkpoint_field_names() -> None:
+    config = FunAsrNanoConfig(
+        encoder_config={
+            "model_type": "fun_asr_nano_encoder",
+            "num_mel_bins": 40,
+            "num_stacked_frames": 3,
+            "d_model": 16,
+            "encoder_attention_heads": 2,
+            "encoder_ffn_dim": 32,
+            "encoder_layers": 3,
+            "num_timestamp_prediction_blocks": 1,
+            "kernel_size": 5,
+        },
+        text_config={
+            "model_type": "qwen3",
+            "hidden_size": 24,
+            "intermediate_size": 48,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 2,
+            "head_dim": 12,
+            "vocab_size": 128,
+        },
+        audio_token_id=123,
+        adaptor_intermediate_size=48,
+        adaptor_num_hidden_layers=1,
+        adaptor_num_attention_heads=2,
+        activation_function="relu",
+    )
+
+    assert config.encoder_config.input_size == 120
+    assert config.encoder_config.d_model == 16
+    assert config.encoder_config.encoder_layers == 3
+    assert config.text_config.hidden_size == 24
+    assert config.audio_token_id == 123
+    assert config.adaptor_intermediate_size == 48
+    assert config.adaptor_num_hidden_layers == 1
+    assert config.adaptor_num_attention_heads == 2
+    assert not hasattr(config, "adaptor_config")

--- a/tests/unit_test/fun_asr/test_model.py
+++ b/tests/unit_test/fun_asr/test_model.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from sglang_omni.models.fun_asr.sglang_model import (
+    FunAsrNanoAdaptor,
+    FunAsrNanoAudioEncoder,
+    FunAsrNanoForConditionalGeneration,
+)
+
+
+def test_fun_asr_audio_modules_match_current_checkpoint_parameter_names() -> None:
+    encoder = FunAsrNanoAudioEncoder(
+        input_size=8,
+        output_size=8,
+        attention_heads=2,
+        linear_units=16,
+        num_blocks=2,
+        tp_blocks=1,
+        kernel_size=3,
+    )
+    encoder_names = set(dict(encoder.named_parameters()))
+
+    assert "stem.self_attn.q_proj.weight" in encoder_names
+    assert "stem.self_attn.k_proj.weight" in encoder_names
+    assert "stem.self_attn.v_proj.weight" in encoder_names
+    assert "stem.self_attn.out_proj.weight" in encoder_names
+    assert "stem.fsmn.conv.weight" in encoder_names
+    assert "stem.fc1.weight" in encoder_names
+    assert "layers.0.self_attn_layer_norm.weight" in encoder_names
+    assert "layers.0.final_layer_norm.weight" in encoder_names
+    assert "layer_norm.weight" in encoder_names
+    assert "timestamp_prediction_layers.0.fc2.weight" in encoder_names
+    assert "timestamp_prediction_layer_norm.weight" in encoder_names
+
+    projector = FunAsrNanoAdaptor(
+        encoder_dim=8,
+        llm_dim=8,
+        ffn_dim=16,
+        num_layers=1,
+        attention_heads=2,
+    )
+    projector_names = set(dict(projector.named_parameters()))
+
+    assert "linear_1.weight" in projector_names
+    assert "linear_2.weight" in projector_names
+    assert "blocks.0.self_attn.q_proj.weight" in projector_names
+    assert "blocks.0.self_attn_layer_norm.weight" in projector_names
+    assert "blocks.0.fc1.weight" in projector_names
+    assert "blocks.0.final_layer_norm.weight" in projector_names
+
+
+def _weight_loader_target() -> FunAsrNanoForConditionalGeneration:
+    model = FunAsrNanoForConditionalGeneration.__new__(
+        FunAsrNanoForConditionalGeneration
+    )
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(
+        text_config=SimpleNamespace(tie_word_embeddings=False)
+    )
+    model.audio_tower = nn.Module()
+    model.audio_tower.layer_norm = nn.LayerNorm(2)
+    model.multi_modal_projector = nn.Module()
+    model.multi_modal_projector.linear_1 = nn.Linear(2, 2)
+    return model
+
+
+def test_fun_asr_weight_loader_loads_current_audio_prefixes() -> None:
+    model = _weight_loader_target()
+    expected = torch.tensor([2.0, 3.0])
+
+    model.load_weights([("model.audio_tower.layer_norm.weight", expected.clone())])
+
+    assert torch.equal(model.audio_tower.layer_norm.weight, expected)
+
+
+def test_fun_asr_weight_loader_rejects_unknown_audio_weights() -> None:
+    model = _weight_loader_target()
+
+    with pytest.raises(ValueError, match=r"model\.audio_tower\.missing\.weight"):
+        model.load_weights([("model.audio_tower.missing.weight", torch.ones(2))])

--- a/tests/unit_test/fun_asr/test_pipeline.py
+++ b/tests/unit_test/fun_asr/test_pipeline.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-# Author:
-# PoTaTo-Mika: https://github.com/PoTaTo-Mika
 
 from __future__ import annotations
 
 import inspect
+from types import SimpleNamespace
 
+import sglang_omni.models.fun_asr.stages as fun_asr_stages
 from sglang_omni.models.fun_asr.config import FunASRPipelineConfig
 from sglang_omni.models.fun_asr.stages import create_sglang_fun_asr_executor
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
@@ -21,6 +21,9 @@ def test_fun_asr_config_uses_batched_stage_with_32_running_requests() -> None:
     assert config.stages[0].factory.endswith("create_sglang_fun_asr_executor")
     assert config.stages[0].factory_args["device"] == "cuda:0"
     assert config.stages[0].factory_args["max_running_requests"] == 32
+    assert config.stages[0].factory_args["max_new_tokens"] == 200
+    assert config.stages[0].factory_args["request_build_max_workers"] == 2
+    assert config.stages[0].factory_args["request_build_max_pending"] == 16
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config("FunAsrNanoForConditionalGeneration")
         is FunASRPipelineConfig
@@ -31,6 +34,9 @@ def test_fun_asr_stage_default_allows_32_running_requests() -> None:
     signature = inspect.signature(create_sglang_fun_asr_executor)
 
     assert signature.parameters["max_running_requests"].default == 32
+    assert signature.parameters["max_new_tokens"].default == 200
+    assert signature.parameters["request_build_max_workers"].default == 2
+    assert signature.parameters["request_build_max_pending"].default == 16
 
 
 def test_fun_asr_stage_default_uses_auto_static_kv_budget() -> None:
@@ -49,3 +55,92 @@ def test_fun_asr_stage_default_disables_torch_compile() -> None:
     signature = inspect.signature(create_sglang_fun_asr_executor)
 
     assert signature.parameters["enable_torch_compile"].default is False
+
+
+def test_fun_asr_threads_generation_batch_and_request_build_policy(monkeypatch) -> None:
+    build_kwargs: dict[str, object] = {}
+    validations: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        fun_asr_stages.AutoTokenizer,
+        "from_pretrained",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        fun_asr_stages.AutoFeatureExtractor,
+        "from_pretrained",
+        lambda *args, **kwargs: SimpleNamespace(nb_max_frames=500),
+    )
+    monkeypatch.setattr(
+        fun_asr_stages,
+        "get_visible_gpu_sm_version",
+        lambda gpu_id: None,
+    )
+    monkeypatch.setattr(fun_asr_stages, "init_mm_embedding_cache", lambda size: None)
+    monkeypatch.setattr(
+        fun_asr_stages,
+        "make_fun_asr_scheduler_adapters",
+        lambda **kwargs: (object(), object()),
+    )
+    monkeypatch.setattr(fun_asr_stages, "ModelRunner", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        fun_asr_stages,
+        "SGLangOutputProcessor",
+        lambda **kwargs: object(),
+    )
+    monkeypatch.setattr(
+        fun_asr_stages,
+        "OmniScheduler",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    def _fake_server_args_builder(model_path, context_length, **overrides):
+        build_kwargs.update(overrides)
+        return SimpleNamespace(**overrides)
+
+    model_worker = SimpleNamespace(model_runner=SimpleNamespace(model=object()))
+    infrastructure = (
+        model_worker,
+        object(),
+        object(),
+        object(),
+        object(),
+        object(),
+        object(),
+    )
+
+    monkeypatch.setattr(
+        fun_asr_stages,
+        "build_sglang_server_args",
+        _fake_server_args_builder,
+    )
+    monkeypatch.setattr(
+        fun_asr_stages,
+        "create_sglang_infrastructure_defer_cuda_graph",
+        lambda *args, **kwargs: (False, infrastructure),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        fun_asr_stages,
+        "create_sglang_infrastructure",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("legacy bootstrap must not be used")
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        fun_asr_stages,
+        "validate_generation_batch_policy",
+        lambda **kwargs: validations.append(kwargs),
+        raising=False,
+    )
+
+    scheduler = fun_asr_stages.create_sglang_fun_asr_executor("dummy")
+
+    assert build_kwargs["cuda_graph_max_bs"] == 32
+    assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 12, 16, 24, 32]
+    assert validations == [
+        {"model_name": "Fun-ASR", "server_args": scheduler.server_args}
+    ]
+    assert scheduler.request_build_max_workers == 2
+    assert scheduler.request_build_max_pending == 16

--- a/tests/unit_test/fun_asr/test_request_builders.py
+++ b/tests/unit_test/fun_asr/test_request_builders.py
@@ -10,10 +10,6 @@ import numpy as np
 import torch
 
 import sglang_omni.models.fun_asr.request_builders as request_builders
-from sglang_omni.models.fun_asr.request_builders import (
-    FunASRRequestData,
-    make_fun_asr_scheduler_adapters,
-)
 from sglang_omni.models.fun_asr.tool_funcs.audio_lengths import (
     fun_asr_low_frame_rate_length,
 )
@@ -96,7 +92,7 @@ def test_fun_asr_request_builder_records_inclusive_audio_offsets(monkeypatch) ->
         "load_audio",
         lambda source: np.zeros(1600 * 3, dtype=np.float32),
     )
-    request_builder, _ = make_fun_asr_scheduler_adapters(
+    request_builder, _ = request_builders.make_fun_asr_scheduler_adapters(
         tokenizer=_FakeTokenizer(),
         max_new_tokens=32,
         feature_extractor=_feature_extractor(num_lfr_frames),
@@ -148,7 +144,7 @@ def test_fun_asr_request_builder_language_prompt(monkeypatch) -> None:
             captured["prompt_text"] = text
             return super().__call__(text, add_special_tokens=add_special_tokens)
 
-    request_builder, _ = make_fun_asr_scheduler_adapters(
+    request_builder, _ = request_builders.make_fun_asr_scheduler_adapters(
         tokenizer=_CapturingTokenizer(),
         max_new_tokens=16,
         feature_extractor=_feature_extractor(11),
@@ -166,7 +162,7 @@ def test_fun_asr_request_builder_language_prompt(monkeypatch) -> None:
 
 def test_fun_asr_result_adapter_decodes_transcript_directly() -> None:
     tokenizer = _FakeTokenizer()
-    _, result_adapter = make_fun_asr_scheduler_adapters(
+    _, result_adapter = request_builders.make_fun_asr_scheduler_adapters(
         tokenizer=tokenizer,
         max_new_tokens=32,
         feature_extractor=object(),
@@ -176,7 +172,7 @@ def test_fun_asr_result_adapter_decodes_transcript_directly() -> None:
         request=OmniRequest(inputs={}),
         data={},
     )
-    data = FunASRRequestData(
+    data = request_builders.FunASRRequestData(
         output_ids=[20, 21, 30],  # 你好 世界 <|im_end|>
         stage_payload=payload,
         language="zh",

--- a/tests/unit_test/fun_asr/test_request_builders.py
+++ b/tests/unit_test/fun_asr/test_request_builders.py
@@ -1,12 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-# Author:
-# PoTaTo-Mika: https://github.com/PoTaTo-Mika
 
 from __future__ import annotations
 
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 import torch
 
 import sglang_omni.models.fun_asr.request_builders as request_builders
@@ -89,7 +88,7 @@ def test_fun_asr_request_builder_records_inclusive_audio_offsets(monkeypatch) ->
 
     monkeypatch.setattr(
         request_builders,
-        "load_audio",
+        "_load_audio",
         lambda source: np.zeros(1600 * 3, dtype=np.float32),
     )
     request_builder, _ = request_builders.make_fun_asr_scheduler_adapters(
@@ -99,7 +98,9 @@ def test_fun_asr_request_builder_records_inclusive_audio_offsets(monkeypatch) ->
     )
     payload = StagePayload(
         request_id="req-fun-asr",
-        request=OmniRequest(inputs={"audio_bytes": b"wav"}),
+        request=OmniRequest(
+            inputs={"audio_bytes": b"wav"}, params={"max_new_tokens": 32}
+        ),
         data={},
     )
 
@@ -134,7 +135,7 @@ def test_fun_asr_request_builder_language_prompt(monkeypatch) -> None:
 
     monkeypatch.setattr(
         request_builders,
-        "load_audio",
+        "_load_audio",
         lambda source: np.zeros(1600, dtype=np.float32),
     )
     captured = {}
@@ -192,3 +193,94 @@ def test_fun_asr_result_adapter_decodes_transcript_directly() -> None:
         "skip_special_tokens": True,
         "clean_up_tokenization_spaces": False,
     }
+
+
+def test_fun_asr_load_audio_uses_shared_audio_utility(monkeypatch) -> None:
+    calls = []
+    expected = np.zeros(1600, dtype=np.float32)
+
+    def _shared(source, **kwargs):
+        calls.append((source, kwargs))
+        return expected
+
+    monkeypatch.setattr(request_builders, "_shared_load_audio", _shared)
+
+    actual = request_builders._load_audio(b"wav")
+
+    assert actual is expected
+    assert calls == [
+        (
+            b"wav",
+            {"source_name": "Fun-ASR", "target_sample_rate": 16000},
+        )
+    ]
+
+
+def test_fun_asr_request_builder_scales_default_token_budget(monkeypatch) -> None:
+    monkeypatch.setattr(
+        request_builders,
+        "_load_audio",
+        lambda source: np.zeros(16000 * 3, dtype=np.float32),
+    )
+    request_builder, _ = request_builders.make_fun_asr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=200,
+        feature_extractor=_feature_extractor(17),
+    )
+    payload = StagePayload(
+        request_id="req-fun-asr-budget",
+        request=OmniRequest(inputs={"audio_bytes": b"wav"}),
+        data={},
+    )
+
+    data = request_builder(payload)
+
+    assert data.req.sampling_params.max_new_tokens == 20
+    assert data.max_new_tokens == 20
+
+
+def test_fun_asr_request_builder_rejects_audio_over_vad_limit(monkeypatch) -> None:
+    monkeypatch.setattr(
+        request_builders,
+        "_load_audio",
+        lambda source: np.zeros(16000 * 30 + 1, dtype=np.float32),
+    )
+    request_builder, _ = request_builders.make_fun_asr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=200,
+        feature_extractor=_feature_extractor(17),
+    )
+    payload = StagePayload(
+        request_id="req-fun-asr-too-long",
+        request=OmniRequest(inputs={"audio_bytes": b"wav"}),
+        data={},
+    )
+
+    with pytest.raises(ValueError, match=r"30(?:\.0)? seconds.*VAD"):
+        request_builder(payload)
+
+
+def test_fun_asr_request_builder_rejects_explicit_token_budget_over_cap(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        request_builders,
+        "_load_audio",
+        lambda source: np.zeros(16000, dtype=np.float32),
+    )
+    request_builder, _ = request_builders.make_fun_asr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=200,
+        feature_extractor=_feature_extractor(17),
+    )
+    payload = StagePayload(
+        request_id="req-fun-asr-token-cap",
+        request=OmniRequest(
+            inputs={"audio_bytes": b"wav"},
+            params={"max_new_tokens": 201},
+        ),
+        data={},
+    )
+
+    with pytest.raises(ValueError, match=r"max_new_tokens.*200"):
+        request_builder(payload)


### PR DESCRIPTION
## Summary

This companion PR addresses the maintainer review on #1078:

- match the current FunAudioLLM/Fun-ASR-Nano-2512-hf native config and all model.audio_tower.* / model.multi_modal_projector.* tensor names
- reject unknown multimodal weights instead of silently dropping them
- reuse the shared audio and scheduling helpers, and parallelize request building
- enforce the official 30-second VAD segment limit and scale generation budgets by duration up to 200 tokens
- remove generated author/comment noise and document the request limits

## Validation

- pytest tests/unit_test/fun_asr -q -ra: 17 passed
- pre-commit on all 14 changed files: all hooks passed
- immutable Hub revision c0248ccb63cea44880b2f4ebc0f32b0241b7f8e8: 1,230 checkpoint tensors exactly match 1,230 model parameters, with no missing, extra, or shape-mismatched entries
- H100 FP32 parity against Transformers #46180: encoder max abs diff 1.43e-6; projector max abs diff 6.71e-4
- H100 full server smoke: /v1/audio/transcriptions returned "How many cars are there in the picture?" for tests/data/query_to_cars.wav