### PR TITLE
[Bugfix] Abort backend inference when a streaming response ends early

### DIFF
--- a/sglang_omni/client/client.py
+++ b/sglang_omni/client/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from contextlib import aclosing
 from dataclasses import replace
 from typing import Any, AsyncIterator, Callable
 
@@ -58,11 +59,13 @@ class Client:
         req_id = request_id or str(uuid.uuid4())
         omni_request = self._build_omni_request(request)
         if request.stream:
-            async for msg in self._coordinator.stream(req_id, omni_request):
-                if isinstance(msg, StreamMessage):
-                    yield self._stream_builder(req_id, msg)
-                else:
-                    yield self._result_builder(req_id, msg.result)
+            coordinator_stream = self._coordinator.stream(req_id, omni_request)
+            async with aclosing(coordinator_stream):
+                async for msg in coordinator_stream:
+                    if isinstance(msg, StreamMessage):
+                        yield self._stream_builder(req_id, msg)
+                    else:
+                        yield self._result_builder(req_id, msg.result)
             return
 
         result = await self._coordinator.submit(req_id, omni_request)
@@ -169,31 +172,33 @@ class Client:
         need to touch numpy / raw bytes.
         """
         streamed_text = ""
-        async for chunk in self.generate(request, request_id=request_id):
-            audio_b64: str | None = None
-            if chunk.modality == "audio" and chunk.audio_data is not None:
-                audio_b64 = audio_to_base64(
-                    chunk.audio_data,
-                    sample_rate=chunk.sample_rate or DEFAULT_SAMPLE_RATE,
-                    output_format=audio_format,
+        generate_stream = self.generate(request, request_id=request_id)
+        async with aclosing(generate_stream):
+            async for chunk in generate_stream:
+                audio_b64: str | None = None
+                if chunk.modality == "audio" and chunk.audio_data is not None:
+                    audio_b64 = audio_to_base64(
+                        chunk.audio_data,
+                        sample_rate=chunk.sample_rate or DEFAULT_SAMPLE_RATE,
+                        output_format=audio_format,
+                    )
+
+                text = chunk.text
+                if chunk.modality == "text" and text:
+                    if chunk.finish_reason is None:
+                        streamed_text += text
+                    elif streamed_text and text.startswith(streamed_text):
+                        text = text[len(streamed_text) :] or None
+
+                yield CompletionStreamChunk(
+                    request_id=request_id,
+                    text=text,
+                    modality=chunk.modality,
+                    audio_b64=audio_b64,
+                    finish_reason=chunk.finish_reason,
+                    usage=chunk.usage,
+                    stage_name=chunk.stage_name,
                 )
-
-            text = chunk.text
-            if chunk.modality == "text" and text:
-                if chunk.finish_reason is None:
-                    streamed_text += text
-                elif streamed_text and text.startswith(streamed_text):
-                    text = text[len(streamed_text) :] or None
-
-            yield CompletionStreamChunk(
-                request_id=request_id,
-                text=text,
-                modality=chunk.modality,
-                audio_b64=audio_b64,
-                finish_reason=chunk.finish_reason,
-                usage=chunk.usage,
-                stage_name=chunk.stage_name,
-            )
 
     # ------------------------------------------------------------------
     # High-level: text-to-speech

--- a/sglang_omni/pipeline/coordinator.py
+++ b/sglang_omni/pipeline/coordinator.py
@@ -90,6 +90,9 @@ class Coordinator:
         self._stream_queues: dict[
             str, asyncio.Queue[CompleteMessage | StreamMessage]
         ] = {}
+        # Abort messages carry only the request ID. A strongly held task keeps
+        # local admission closed and lets the broadcast survive caller cancellation.
+        self._abort_tasks: dict[str, asyncio.Task[bool]] = {}
         self._admin_ops: dict[str, _AdminPendingOperation] = {}
         self._admin_lock = asyncio.Lock()
 
@@ -322,20 +325,21 @@ class Coordinator:
             result = await future
             return result
         finally:
-            self._completion_futures.pop(request_id, None)
+            if self._completion_futures.get(request_id) is future:
+                self._completion_futures.pop(request_id, None)
 
     async def stream(
         self, request_id: str, request: OmniRequest | Any
     ) -> AsyncIterator[CompleteMessage | StreamMessage]:
         """Submit a request and yield stream events until completion."""
-        if request_id in self._stream_queues:
-            raise ValueError(f"Request {request_id} already streaming")
-
         queue: asyncio.Queue[CompleteMessage | StreamMessage] = asyncio.Queue()
-        self._stream_queues[request_id] = queue
+        admitted_request: RequestInfo | None = None
+        completion_future: asyncio.Future | None = None
 
         try:
-            await self._submit_request(request_id, request)
+            await self._submit_request(request_id, request, stream_queue=queue)
+            admitted_request = self._requests.get(request_id)
+            completion_future = self._completion_futures.get(request_id)
             expected_terminal_stages = self._expected_terminal_stages(request_id)
 
             completed_stages: set[str] = set()
@@ -354,27 +358,42 @@ class Coordinator:
                 else:
                     yield msg
         finally:
+            if self._stream_queues.get(request_id) is queue:
+                if admitted_request is None:
+                    admitted_request = self._requests.get(request_id)
+                if completion_future is None:
+                    completion_future = self._completion_futures.get(request_id)
             try:
-                if request_id in self._requests:
+                if (
+                    admitted_request is not None
+                    and self._requests.get(request_id) is admitted_request
+                ):
                     try:
                         await self.abort(request_id)
                     except Exception:
-                        logger.warning(
-                            "Failed to abort request %s after stream interruption",
-                            request_id,
-                            exc_info=True,
-                        )
+                        # The coordinator-owned abort task logs its own failure.
+                        # Do not replace the exception already leaving the stream.
+                        pass
             finally:
-                self._stream_queues.pop(request_id, None)
-                self._completion_futures.pop(request_id, None)
+                if self._stream_queues.get(request_id) is queue:
+                    self._stream_queues.pop(request_id, None)
+                if (
+                    completion_future is not None
+                    and self._completion_futures.get(request_id) is completion_future
+                ):
+                    self._completion_futures.pop(request_id, None)
 
     async def _submit_request(
-        self, request_id: str, request: OmniRequest | Any
+        self,
+        request_id: str,
+        request: OmniRequest | Any,
+        *,
+        stream_queue: asyncio.Queue[CompleteMessage | StreamMessage] | None = None,
     ) -> None:
         """Submit a request without waiting for completion."""
         if self._fatal_error is not None:
             raise RuntimeError(self._fatal_error)
-        if request_id in self._requests:
+        if self._request_id_is_reserved(request_id):
             raise ValueError(f"Request {request_id} already exists")
 
         if self.entry_stage not in self._stages:
@@ -395,6 +414,8 @@ class Coordinator:
         loop = asyncio.get_running_loop()
         future: asyncio.Future = loop.create_future()
         self._completion_futures[request_id] = future
+        if stream_queue is not None:
+            self._stream_queues[request_id] = stream_queue
 
         payload = StagePayload(
             request_id=request_id,
@@ -418,7 +439,9 @@ class Coordinator:
         )
 
         # Update state
-        self._requests[request_id].state = RequestState.RUNNING
+        info = self._requests.get(request_id)
+        if info is not None:
+            info.state = RequestState.RUNNING
 
         logger.info(
             "Coordinator submitted req=%s to %s at %s",
@@ -427,15 +450,43 @@ class Coordinator:
             entry_info.control_endpoint,
         )
 
-    def _reject_completion_future(self, request_id: str, exc: BaseException) -> None:
+    def _request_id_is_reserved(self, request_id: str) -> bool:
+        """Return whether any coordinator owner still holds this request ID."""
+        return (
+            request_id in self._requests
+            or request_id in self._completion_futures
+            or request_id in self._stream_queues
+            or request_id in self._abort_tasks
+        )
+
+    def _reject_completion_future(
+        self,
+        request_id: str,
+        exc: BaseException,
+        *,
+        expected_future: asyncio.Future | None = None,
+        expected_stream_queue: (
+            asyncio.Queue[CompleteMessage | StreamMessage] | None
+        ) = None,
+    ) -> None:
         # Note: (Akazaakane) Non-streaming callers await the completion future,
         # so errors must be propagated with set_exception(). Streaming callers
         # receive errors through the stream queue and never await that future;
         # cancel it instead to avoid "Future exception was never retrieved".
         future = self._completion_futures.get(request_id)
+        if expected_future is not None and future is not expected_future:
+            return
         if future is None or future.done():
             return
-        if request_id in self._stream_queues:
+        is_stream = (
+            request_id in self._stream_queues
+            if expected_future is None
+            else (
+                expected_stream_queue is not None
+                and self._stream_queues.get(request_id) is expected_stream_queue
+            )
+        )
+        if is_stream:
             future.cancel()
         else:
             future.set_exception(exc)
@@ -449,10 +500,14 @@ class Coordinator:
         Returns:
             True if aborted, False if not found
         """
-        if request_id not in self._requests:
+        abort_task = self._abort_tasks.get(request_id)
+        if abort_task is not None:
+            return await asyncio.shield(abort_task)
+
+        info = self._requests.get(request_id)
+        if info is None:
             return False
 
-        info = self._requests[request_id]
         if info.state in (
             RequestState.COMPLETED,
             RequestState.FAILED,
@@ -460,18 +515,48 @@ class Coordinator:
         ):
             return False
 
-        # Broadcast abort to all stages
+        completion_future = self._completion_futures.get(request_id)
+        stream_queue = self._stream_queues.get(request_id)
+        abort_task = asyncio.create_task(
+            self._run_abort(
+                request_id,
+                info,
+                completion_future,
+                stream_queue,
+            ),
+            name=f"coordinator-abort-{request_id}",
+        )
+        self._abort_tasks[request_id] = abort_task
+        abort_task.add_done_callback(
+            lambda done, rid=request_id: self._on_abort_task_done(rid, done)
+        )
+        return await asyncio.shield(abort_task)
+
+    async def _run_abort(
+        self,
+        request_id: str,
+        info: RequestInfo,
+        completion_future: asyncio.Future | None,
+        stream_queue: asyncio.Queue[CompleteMessage | StreamMessage] | None,
+    ) -> bool:
         await self.control_plane.broadcast_abort(AbortMessage(request_id=request_id))
 
-        # Update state
-        info.state = RequestState.ABORTED
+        if self._requests.get(request_id) is not info:
+            return False
 
-        # Resolve future with error
-        self._reject_completion_future(
-            request_id, asyncio.CancelledError(f"Request {request_id} aborted")
-        )
-        if request_id in self._stream_queues:
-            await self._stream_queues[request_id].put(
+        info.state = RequestState.ABORTED
+        if completion_future is not None:
+            self._reject_completion_future(
+                request_id,
+                asyncio.CancelledError(f"Request {request_id} aborted"),
+                expected_future=completion_future,
+                expected_stream_queue=stream_queue,
+            )
+        if (
+            stream_queue is not None
+            and self._stream_queues.get(request_id) is stream_queue
+        ):
+            await stream_queue.put(
                 CompleteMessage(
                     request_id=request_id,
                     from_stage="coordinator",
@@ -480,12 +565,30 @@ class Coordinator:
                 )
             )
 
-        # Cleanup request tracking
-        self._requests.pop(request_id, None)
-        self._partial_results.pop(request_id, None)
+        if self._requests.get(request_id) is info:
+            self._requests.pop(request_id, None)
+            self._partial_results.pop(request_id, None)
 
         logger.info("Coordinator aborted req=%s", request_id)
         return True
+
+    def _on_abort_task_done(
+        self,
+        request_id: str,
+        task: asyncio.Task[bool],
+    ) -> None:
+        if self._abort_tasks.get(request_id) is task:
+            self._abort_tasks.pop(request_id, None)
+        if task.cancelled():
+            logger.warning("Coordinator abort task cancelled for req=%s", request_id)
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.warning(
+                "Failed to abort request %s",
+                request_id,
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
 
     async def run_completion_loop(self) -> None:
         """Run the completion receiving loop.

--- a/sglang_omni/pipeline/coordinator.py
+++ b/sglang_omni/pipeline/coordinator.py
@@ -354,8 +354,19 @@ class Coordinator:
                 else:
                     yield msg
         finally:
-            self._stream_queues.pop(request_id, None)
-            self._completion_futures.pop(request_id, None)
+            try:
+                if request_id in self._requests:
+                    try:
+                        await self.abort(request_id)
+                    except Exception:
+                        logger.warning(
+                            "Failed to abort request %s after stream interruption",
+                            request_id,
+                            exc_info=True,
+                        )
+            finally:
+                self._stream_queues.pop(request_id, None)
+                self._completion_futures.pop(request_id, None)
 
     async def _submit_request(
         self, request_id: str, request: OmniRequest | Any

--- a/sglang_omni/pipeline/coordinator.py
+++ b/sglang_omni/pipeline/coordinator.py
@@ -325,21 +325,16 @@ class Coordinator:
             result = await future
             return result
         finally:
-            if self._completion_futures.get(request_id) is future:
-                self._completion_futures.pop(request_id, None)
+            self._completion_futures.pop(request_id, None)
 
     async def stream(
         self, request_id: str, request: OmniRequest | Any
     ) -> AsyncIterator[CompleteMessage | StreamMessage]:
         """Submit a request and yield stream events until completion."""
         queue: asyncio.Queue[CompleteMessage | StreamMessage] = asyncio.Queue()
-        admitted_request: RequestInfo | None = None
-        completion_future: asyncio.Future | None = None
 
         try:
             await self._submit_request(request_id, request, stream_queue=queue)
-            admitted_request = self._requests.get(request_id)
-            completion_future = self._completion_futures.get(request_id)
             expected_terminal_stages = self._expected_terminal_stages(request_id)
 
             completed_stages: set[str] = set()
@@ -359,29 +354,18 @@ class Coordinator:
                     yield msg
         finally:
             if self._stream_queues.get(request_id) is queue:
-                if admitted_request is None:
-                    admitted_request = self._requests.get(request_id)
-                if completion_future is None:
-                    completion_future = self._completion_futures.get(request_id)
-            try:
-                if (
-                    admitted_request is not None
-                    and self._requests.get(request_id) is admitted_request
-                ):
-                    try:
-                        await self.abort(request_id)
-                    except Exception:
-                        # The coordinator-owned abort task logs its own failure.
-                        # Do not replace the exception already leaving the stream.
-                        pass
-            finally:
-                if self._stream_queues.get(request_id) is queue:
-                    self._stream_queues.pop(request_id, None)
-                if (
-                    completion_future is not None
-                    and self._completion_futures.get(request_id) is completion_future
-                ):
-                    self._completion_futures.pop(request_id, None)
+                try:
+                    if request_id in self._requests:
+                        try:
+                            await self.abort(request_id)
+                        except Exception:
+                            # The coordinator-owned abort task logs its own failure.
+                            # Do not replace the exception already leaving the stream.
+                            pass
+                finally:
+                    if self._stream_queues.get(request_id) is queue:
+                        self._stream_queues.pop(request_id, None)
+                        self._completion_futures.pop(request_id, None)
 
     async def _submit_request(
         self,
@@ -463,30 +447,15 @@ class Coordinator:
         self,
         request_id: str,
         exc: BaseException,
-        *,
-        expected_future: asyncio.Future | None = None,
-        expected_stream_queue: (
-            asyncio.Queue[CompleteMessage | StreamMessage] | None
-        ) = None,
     ) -> None:
         # Note: (Akazaakane) Non-streaming callers await the completion future,
         # so errors must be propagated with set_exception(). Streaming callers
         # receive errors through the stream queue and never await that future;
         # cancel it instead to avoid "Future exception was never retrieved".
         future = self._completion_futures.get(request_id)
-        if expected_future is not None and future is not expected_future:
-            return
         if future is None or future.done():
             return
-        is_stream = (
-            request_id in self._stream_queues
-            if expected_future is None
-            else (
-                expected_stream_queue is not None
-                and self._stream_queues.get(request_id) is expected_stream_queue
-            )
-        )
-        if is_stream:
+        if request_id in self._stream_queues:
             future.cancel()
         else:
             future.set_exception(exc)
@@ -515,15 +484,8 @@ class Coordinator:
         ):
             return False
 
-        completion_future = self._completion_futures.get(request_id)
-        stream_queue = self._stream_queues.get(request_id)
         abort_task = asyncio.create_task(
-            self._run_abort(
-                request_id,
-                info,
-                completion_future,
-                stream_queue,
-            ),
+            self._run_abort(request_id),
             name=f"coordinator-abort-{request_id}",
         )
         self._abort_tasks[request_id] = abort_task
@@ -535,27 +497,19 @@ class Coordinator:
     async def _run_abort(
         self,
         request_id: str,
-        info: RequestInfo,
-        completion_future: asyncio.Future | None,
-        stream_queue: asyncio.Queue[CompleteMessage | StreamMessage] | None,
     ) -> bool:
         await self.control_plane.broadcast_abort(AbortMessage(request_id=request_id))
 
-        if self._requests.get(request_id) is not info:
+        info = self._requests.get(request_id)
+        if info is None:
             return False
 
         info.state = RequestState.ABORTED
-        if completion_future is not None:
-            self._reject_completion_future(
-                request_id,
-                asyncio.CancelledError(f"Request {request_id} aborted"),
-                expected_future=completion_future,
-                expected_stream_queue=stream_queue,
-            )
-        if (
-            stream_queue is not None
-            and self._stream_queues.get(request_id) is stream_queue
-        ):
+        self._reject_completion_future(
+            request_id, asyncio.CancelledError(f"Request {request_id} aborted")
+        )
+        stream_queue = self._stream_queues.get(request_id)
+        if stream_queue is not None:
             await stream_queue.put(
                 CompleteMessage(
                     request_id=request_id,
@@ -565,9 +519,8 @@ class Coordinator:
                 )
             )
 
-        if self._requests.get(request_id) is info:
-            self._requests.pop(request_id, None)
-            self._partial_results.pop(request_id, None)
+        self._requests.pop(request_id, None)
+        self._partial_results.pop(request_id, None)
 
         logger.info("Coordinator aborted req=%s", request_id)
         return True

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -26,7 +26,7 @@ import math
 import time
 import uuid
 from collections.abc import Awaitable, Callable
-from contextlib import suppress
+from contextlib import aclosing, suppress
 from typing import Any, AsyncIterator
 
 from fastapi import (
@@ -46,6 +46,7 @@ from fastapi.responses import (
     Response,
     StreamingResponse,
 )
+from starlette.types import Receive, Scope, Send
 
 from sglang_omni.client import (
     Client,
@@ -138,6 +139,29 @@ def _is_bad_request_error(exc: Exception) -> bool:
 
 class _RequestBodyTooLarge(Exception):
     pass
+
+
+class _ClosableStreamingResponse(StreamingResponse):
+    """Close the response body iterator at the ASGI ownership boundary."""
+
+    async def __call__(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        try:
+            await super().__call__(scope, receive, send)
+        finally:
+            await self._close_body_iterator()
+
+    async def _close_body_iterator(self) -> None:
+        try:
+            await _close_async_iterator_if_supported(self.body_iterator)
+        except asyncio.CancelledError:
+            logger.warning("Cancelled while closing streaming response body")
+        except Exception:
+            logger.warning("Failed to close streaming response body", exc_info=True)
 
 
 class VoiceUploadBodyLimitMiddleware:
@@ -650,7 +674,7 @@ def _register_chat_completions(app: FastAPI) -> None:
             audio_format = req.audio.get("format", "wav")
 
         if req.stream:
-            return StreamingResponse(
+            return _ClosableStreamingResponse(
                 _chat_stream(
                     client,
                     gen_req,
@@ -756,87 +780,93 @@ async def _chat_stream(
     model: str,
     req: ChatCompletionRequest,
     audio_format: str,
-):
+) -> AsyncIterator[str]:
     """Streaming chat completion generator (yields SSE events)."""
     role_sent = False
     requested_modalities = req.modalities or ["text"]
     finish_reason: str | None = None
     final_usage: UsageResponse | None = None
 
-    async for chunk in client.completion_stream(
+    chunk_stream = client.completion_stream(
         gen_req,
         request_id=request_id,
         audio_format=audio_format,
-    ):
-        # Capture finish info for the dedicated finish chunk after the loop.
-        # Some pipelines only emit a final aggregate chunk; do not drop its
-        # text/audio just because it already carries a finish reason.
-        if chunk.finish_reason is not None:
-            finish_reason = chunk.finish_reason
-            if chunk.usage is not None:
-                final_usage = UsageResponse(
-                    prompt_tokens=chunk.usage.prompt_tokens or 0,
-                    completion_tokens=chunk.usage.completion_tokens or 0,
-                    total_tokens=chunk.usage.total_tokens or 0,
+    )
+    async with aclosing(chunk_stream):
+        async for chunk in chunk_stream:
+            # Capture finish info for the dedicated finish chunk after the loop.
+            # Some pipelines only emit a final aggregate chunk; do not drop its
+            # text/audio just because it already carries a finish reason.
+            if chunk.finish_reason is not None:
+                finish_reason = chunk.finish_reason
+                if chunk.usage is not None:
+                    final_usage = UsageResponse(
+                        prompt_tokens=chunk.usage.prompt_tokens or 0,
+                        completion_tokens=chunk.usage.completion_tokens or 0,
+                        total_tokens=chunk.usage.total_tokens or 0,
+                    )
+                has_payload = (
+                    chunk.modality == "text"
+                    and bool(chunk.text)
+                    and "text" in requested_modalities
+                ) or (
+                    chunk.modality == "audio"
+                    and chunk.audio_b64 is not None
+                    and "audio" in requested_modalities
                 )
-            has_payload = (
+                if not has_payload:
+                    continue
+
+            delta = ChatCompletionStreamDelta()
+            emit = False
+
+            # Send role on first chunk
+            if not role_sent:
+                delta.role = "assistant"
+                role_sent = True
+                emit = True
+
+            # Text chunk
+            if (
                 chunk.modality == "text"
-                and bool(chunk.text)
+                and chunk.text
                 and "text" in requested_modalities
-            ) or (
+            ):
+                delta.content = chunk.text
+                emit = True
+
+            # Audio chunk
+            if (
                 chunk.modality == "audio"
                 and chunk.audio_b64 is not None
                 and "audio" in requested_modalities
-            )
-            if not has_payload:
+            ):
+                delta.audio = ChatCompletionAudio(
+                    id=f"audio-{request_id}",
+                    data=chunk.audio_b64,
+                )
+                emit = True
+
+            if not emit:
                 continue
 
-        delta = ChatCompletionStreamDelta()
-        emit = False
-
-        # Send role on first chunk
-        if not role_sent:
-            delta.role = "assistant"
-            role_sent = True
-            emit = True
-
-        # Text chunk
-        if chunk.modality == "text" and chunk.text and "text" in requested_modalities:
-            delta.content = chunk.text
-            emit = True
-
-        # Audio chunk
-        if (
-            chunk.modality == "audio"
-            and chunk.audio_b64 is not None
-            and "audio" in requested_modalities
-        ):
-            delta.audio = ChatCompletionAudio(
-                id=f"audio-{request_id}",
-                data=chunk.audio_b64,
+            stream_resp = ChatCompletionStreamResponse(
+                id=response_id,
+                created=created,
+                model=model,
+                choices=[
+                    ChatCompletionStreamChoice(
+                        index=0,
+                        delta=delta,
+                        finish_reason=None,
+                    )
+                ],
             )
-            emit = True
 
-        if not emit:
-            continue
-
-        stream_resp = ChatCompletionStreamResponse(
-            id=response_id,
-            created=created,
-            model=model,
-            choices=[
-                ChatCompletionStreamChoice(
-                    index=0,
-                    delta=delta,
-                    finish_reason=None,
-                )
-            ],
-        )
-
-        data = stream_resp.model_dump(exclude_none=True)
-        for choice in data.get("choices", []):
-            choice.setdefault("finish_reason", None)
-        yield f"data: {json.dumps(data)}\n\n"
+            data = stream_resp.model_dump(exclude_none=True)
+            for choice in data.get("choices", []):
+                choice.setdefault("finish_reason", None)
+            yield f"data: {json.dumps(data)}\n\n"
 
     # Finish chunk: empty delta + finish_reason.
     finish_resp = ChatCompletionStreamResponse(
@@ -1599,7 +1629,7 @@ def _register_transcriptions(app: FastAPI) -> None:
             )
             adapter = resolve_adapter(getattr(app.state, "architectures", None))
             duration_s = _probe_audio_duration(audio_bytes)
-            return StreamingResponse(
+            return _ClosableStreamingResponse(
                 _transcription_stream(
                     client,
                     gen_req,
@@ -1684,15 +1714,17 @@ async def _transcription_stream(
     post-processed transcript.
     """
     final_text: str | None = None
+    chunk_stream = client.generate(gen_req, request_id=request_id)
     try:
-        async for chunk in client.generate(gen_req, request_id=request_id):
-            if chunk.finish_reason is not None:
-                if isinstance(chunk.text, str) and chunk.text:
-                    final_text = chunk.text
-                continue
-            if chunk.modality == "text" and chunk.text:
-                event = TranscriptionTextDeltaEvent(delta=chunk.text)
-                yield f"data: {event.model_dump_json(exclude_none=True)}\n\n"
+        async with aclosing(chunk_stream):
+            async for chunk in chunk_stream:
+                if chunk.finish_reason is not None:
+                    if isinstance(chunk.text, str) and chunk.text:
+                        final_text = chunk.text
+                    continue
+                if chunk.modality == "text" and chunk.text:
+                    event = TranscriptionTextDeltaEvent(delta=chunk.text)
+                    yield f"data: {event.model_dump_json(exclude_none=True)}\n\n"
     except Exception as exc:
         logger.exception("Error streaming transcription for request %s", request_id)
         payload = {"type": "error", "error": {"message": str(exc)}}

--- a/tests/unit_test/pipeline/test_coordinator.py
+++ b/tests/unit_test/pipeline/test_coordinator.py
@@ -478,7 +478,7 @@ def test_duplicate_stream_preserves_existing_non_stream_request() -> None:
     asyncio.run(_run())
 
 
-def test_completed_stream_reserves_request_id_until_owner_closes() -> None:
+def test_completed_stream_keeps_request_id_reserved_until_owner_closes() -> None:
     async def _run() -> None:
         coordinator = Coordinator(
             "inproc://complete",
@@ -513,11 +513,6 @@ def test_completed_stream_reserves_request_id_until_owner_closes() -> None:
         await stream.aclose()
         assert "req-1" not in coordinator._completion_futures
         assert "req-1" not in coordinator._stream_queues
-
-        await coordinator._submit_request("req-1", "replacement")
-        replacement = coordinator._requests["req-1"]
-        assert replacement is not None
-        assert await coordinator.abort("req-1") is True
 
     asyncio.run(_run())
 
@@ -578,9 +573,6 @@ def test_stream_abort_reserves_request_id_while_broadcast_is_in_flight() -> None
         assert coordinator._abort_tasks == {}
         assert coordinator._completion_futures == {}
         assert coordinator._stream_queues == {}
-
-        await coordinator._submit_request("req-1", "replacement")
-        assert await coordinator.abort("req-1") is True
 
     asyncio.run(_run())
 

--- a/tests/unit_test/pipeline/test_coordinator.py
+++ b/tests/unit_test/pipeline/test_coordinator.py
@@ -330,6 +330,131 @@ async def _drive_stream_until_registered(coordinator: Coordinator, request_id: s
     return task, error_sink, future
 
 
+def test_coordinator_stream_early_close_aborts_and_cleans_state() -> None:
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["decode"],
+        )
+        control_plane = RecordingCoordinatorControlPlane()
+        coordinator.control_plane = control_plane
+        coordinator.register_stage("preprocess", "inproc://preprocess")
+
+        stream = coordinator.stream("req-1", OmniRequest(inputs="hello"))
+        first_chunk = asyncio.create_task(anext(stream))
+        for _ in range(100):
+            if "req-1" in coordinator._stream_queues:
+                break
+            await asyncio.sleep(0)
+        await coordinator._handle_stream(
+            StreamMessage(
+                request_id="req-1",
+                from_stage="decode",
+                chunk={"text": "hello"},
+                modality="text",
+            )
+        )
+        await first_chunk
+        await stream.aclose()
+
+        assert [msg.request_id for msg in control_plane.aborts] == ["req-1"]
+        assert "req-1" not in coordinator._requests
+        assert "req-1" not in coordinator._stream_queues
+        assert "req-1" not in coordinator._completion_futures
+
+    asyncio.run(_run())
+
+
+def test_coordinator_stream_natural_completion_does_not_abort() -> None:
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["decode"],
+        )
+        control_plane = RecordingCoordinatorControlPlane()
+        coordinator.control_plane = control_plane
+        coordinator.register_stage("preprocess", "inproc://preprocess")
+
+        async def _consume() -> list[CompleteMessage | StreamMessage]:
+            return [
+                message
+                async for message in coordinator.stream(
+                    "req-1", OmniRequest(inputs="hello")
+                )
+            ]
+
+        task = asyncio.create_task(_consume())
+        for _ in range(100):
+            if "req-1" in coordinator._requests:
+                break
+            await asyncio.sleep(0)
+        await coordinator._handle_completion(
+            CompleteMessage(
+                request_id="req-1",
+                from_stage="decode",
+                success=True,
+                result={"text": "hello"},
+            )
+        )
+        messages = await task
+
+        assert len(messages) == 1
+        assert control_plane.aborts == []
+        assert "req-1" not in coordinator._requests
+        assert "req-1" not in coordinator._stream_queues
+        assert "req-1" not in coordinator._completion_futures
+
+    asyncio.run(_run())
+
+
+def test_coordinator_stream_abort_failure_is_logged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class FailingAbortControlPlane(RecordingCoordinatorControlPlane):
+        async def broadcast_abort(self, msg) -> None:
+            self.aborts.append(msg)
+            raise RuntimeError("abort transport unavailable")
+
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["decode"],
+        )
+        control_plane = FailingAbortControlPlane()
+        coordinator.control_plane = control_plane
+        coordinator.register_stage("preprocess", "inproc://preprocess")
+
+        stream = coordinator.stream("req-1", OmniRequest(inputs="hello"))
+        first_chunk = asyncio.create_task(anext(stream))
+        for _ in range(100):
+            if "req-1" in coordinator._stream_queues:
+                break
+            await asyncio.sleep(0)
+        await coordinator._handle_stream(
+            StreamMessage(
+                request_id="req-1",
+                from_stage="decode",
+                chunk={"text": "hello"},
+                modality="text",
+            )
+        )
+        await first_chunk
+        await stream.aclose()
+
+        assert "req-1" not in coordinator._stream_queues
+        assert "req-1" not in coordinator._completion_futures
+
+    with caplog.at_level("WARNING"):
+        asyncio.run(_run())
+    assert "Failed to abort request req-1 after stream interruption" in caplog.text
+
+
 def test_coordinator_stream_abort_cancels_future_without_unretrieved_exception() -> (
     None
 ):

--- a/tests/unit_test/pipeline/test_coordinator.py
+++ b/tests/unit_test/pipeline/test_coordinator.py
@@ -367,6 +367,41 @@ def test_coordinator_stream_early_close_aborts_and_cleans_state() -> None:
     asyncio.run(_run())
 
 
+def test_stream_close_after_one_terminal_aborts_remaining_terminal_work() -> None:
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["decode", "code2wav"],
+        )
+        control_plane = RecordingCoordinatorControlPlane()
+        coordinator.control_plane = control_plane
+        coordinator.register_stage("preprocess", "inproc://preprocess")
+
+        stream = coordinator.stream("req-1", "hello")
+        first_terminal = asyncio.create_task(anext(stream))
+        for _ in range(100):
+            if "req-1" in coordinator._requests:
+                break
+            await asyncio.sleep(0)
+        await coordinator._handle_completion(
+            CompleteMessage("req-1", "decode", True, result={"text": "done"})
+        )
+        assert (await first_terminal).from_stage == "decode"
+        assert coordinator._partial_results["req-1"] == {"decode": {"text": "done"}}
+
+        await stream.aclose()
+
+        assert [msg.request_id for msg in control_plane.aborts] == ["req-1"]
+        assert coordinator._requests == {}
+        assert coordinator._partial_results == {}
+        assert coordinator._completion_futures == {}
+        assert coordinator._stream_queues == {}
+
+    asyncio.run(_run())
+
+
 def test_coordinator_stream_natural_completion_does_not_abort() -> None:
     async def _run() -> None:
         coordinator = Coordinator(
@@ -407,6 +442,176 @@ def test_coordinator_stream_natural_completion_does_not_abort() -> None:
         assert "req-1" not in coordinator._requests
         assert "req-1" not in coordinator._stream_queues
         assert "req-1" not in coordinator._completion_futures
+
+    asyncio.run(_run())
+
+
+def test_duplicate_stream_preserves_existing_non_stream_request() -> None:
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["decode"],
+        )
+        control_plane = RecordingCoordinatorControlPlane()
+        coordinator.control_plane = control_plane
+        coordinator.register_stage("preprocess", "inproc://preprocess")
+
+        await coordinator._submit_request("req-1", "original")
+        original_request = coordinator._requests["req-1"]
+        original_future = coordinator._completion_futures["req-1"]
+
+        duplicate = coordinator.stream("req-1", "duplicate")
+        with pytest.raises(ValueError, match="already exists"):
+            await anext(duplicate)
+
+        assert coordinator._requests["req-1"] is original_request
+        assert coordinator._completion_futures["req-1"] is original_future
+        assert "req-1" not in coordinator._stream_queues
+        assert control_plane.aborts == []
+
+        assert await coordinator.abort("req-1") is True
+        with pytest.raises(asyncio.CancelledError):
+            await original_future
+
+    asyncio.run(_run())
+
+
+def test_completed_stream_reserves_request_id_until_owner_closes() -> None:
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["decode"],
+        )
+        control_plane = RecordingCoordinatorControlPlane()
+        coordinator.control_plane = control_plane
+        coordinator.register_stage("preprocess", "inproc://preprocess")
+
+        stream = coordinator.stream("req-1", "original")
+        terminal_event = asyncio.create_task(anext(stream))
+        for _ in range(100):
+            if "req-1" in coordinator._requests:
+                break
+            await asyncio.sleep(0)
+        await coordinator._handle_completion(
+            CompleteMessage("req-1", "decode", True, result={"text": "done"})
+        )
+        assert (await terminal_event).result == {"text": "done"}
+
+        old_future = coordinator._completion_futures["req-1"]
+        old_queue = coordinator._stream_queues["req-1"]
+        assert "req-1" not in coordinator._requests
+
+        with pytest.raises(ValueError, match="already exists"):
+            await coordinator._submit_request("req-1", "replacement")
+        assert coordinator._completion_futures["req-1"] is old_future
+        assert coordinator._stream_queues["req-1"] is old_queue
+
+        await stream.aclose()
+        assert "req-1" not in coordinator._completion_futures
+        assert "req-1" not in coordinator._stream_queues
+
+        await coordinator._submit_request("req-1", "replacement")
+        replacement = coordinator._requests["req-1"]
+        assert replacement is not None
+        assert await coordinator.abort("req-1") is True
+
+    asyncio.run(_run())
+
+
+def test_stream_abort_reserves_request_id_while_broadcast_is_in_flight() -> None:
+    class BlockingAbortControlPlane(RecordingCoordinatorControlPlane):
+        def __init__(self) -> None:
+            super().__init__()
+            self.abort_started = asyncio.Event()
+            self.release_abort = asyncio.Event()
+
+        async def broadcast_abort(self, msg) -> None:
+            self.aborts.append(msg)
+            self.abort_started.set()
+            await self.release_abort.wait()
+
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["decode"],
+        )
+        control_plane = BlockingAbortControlPlane()
+        coordinator.control_plane = control_plane
+        coordinator.register_stage("preprocess", "inproc://preprocess")
+
+        stream = coordinator.stream("req-1", "original")
+        first_chunk = asyncio.create_task(anext(stream))
+        for _ in range(100):
+            if "req-1" in coordinator._requests:
+                break
+            await asyncio.sleep(0)
+        await coordinator._handle_stream(
+            StreamMessage(
+                request_id="req-1",
+                from_stage="decode",
+                chunk={"text": "partial"},
+                modality="text",
+            )
+        )
+        await first_chunk
+
+        close_task = asyncio.create_task(stream.aclose())
+        await control_plane.abort_started.wait()
+
+        await coordinator._handle_completion(
+            CompleteMessage("req-1", "decode", True, result={"text": "done"})
+        )
+        assert "req-1" not in coordinator._requests
+        assert "req-1" in coordinator._abort_tasks
+
+        with pytest.raises(ValueError, match="already exists"):
+            await coordinator._submit_request("req-1", "replacement")
+
+        control_plane.release_abort.set()
+        await close_task
+        assert coordinator._abort_tasks == {}
+        assert coordinator._completion_futures == {}
+        assert coordinator._stream_queues == {}
+
+        await coordinator._submit_request("req-1", "replacement")
+        assert await coordinator.abort("req-1") is True
+
+    asyncio.run(_run())
+
+
+def test_stream_cancellation_is_preserved_after_abort_cleanup() -> None:
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["decode"],
+        )
+        control_plane = RecordingCoordinatorControlPlane()
+        coordinator.control_plane = control_plane
+        coordinator.register_stage("preprocess", "inproc://preprocess")
+
+        next_event = asyncio.create_task(anext(coordinator.stream("req-1", "hello")))
+        for _ in range(100):
+            if "req-1" in coordinator._requests:
+                break
+            await asyncio.sleep(0)
+
+        next_event.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await next_event
+
+        assert [msg.request_id for msg in control_plane.aborts] == ["req-1"]
+        assert coordinator._requests == {}
+        assert coordinator._completion_futures == {}
+        assert coordinator._stream_queues == {}
+        assert coordinator._abort_tasks == {}
 
     asyncio.run(_run())
 
@@ -452,7 +657,7 @@ def test_coordinator_stream_abort_failure_is_logged(
 
     with caplog.at_level("WARNING"):
         asyncio.run(_run())
-    assert "Failed to abort request req-1 after stream interruption" in caplog.text
+    assert "Failed to abort request req-1" in caplog.text
 
 
 def test_coordinator_stream_abort_cancels_future_without_unretrieved_exception() -> (

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -24,7 +24,9 @@ from sglang_omni.serve.openai_api import (
     _await_speech_response,
     _build_chat_generate_request,
     _chat_stream,
+    _ClosableStreamingResponse,
     _speech_audio_response,
+    _transcription_stream,
     build_transcription_generate_request,
 )
 from sglang_omni.serve.protocol import ChatCompletionRequest, CreateSpeechRequest
@@ -267,6 +269,24 @@ class SuccessfulTranscriptionClient:
         del request_id, audio_format
         self.requests.append(request)
         return CompletionResult(request_id="transcription-1", text="hello world")
+
+
+class _IdentityTranscriptionAdapter:
+    def postprocess_text(self, text: str) -> str:
+        return text
+
+
+def _streaming_client() -> tuple[Client, Coordinator, RecordingCoordinatorControlPlane]:
+    coordinator = Coordinator(
+        "inproc://complete",
+        "inproc://abort",
+        entry_stage="preprocess",
+        terminal_stages=["decode"],
+    )
+    control_plane = RecordingCoordinatorControlPlane()
+    coordinator.control_plane = control_plane
+    coordinator.register_stage("preprocess", "inproc://preprocess")
+    return Client(coordinator), coordinator, control_plane
 
 
 class AdminClient:
@@ -643,6 +663,149 @@ def test_chat_stream_failure_closes_without_done_sentinel() -> None:
 
     assert chunks
     assert all(chunk != "data: [DONE]\n\n" for chunk in chunks)
+
+
+def test_chat_asgi_send_failure_aborts_backend_and_cleans_state() -> None:
+    async def _run() -> None:
+        client, coordinator, control_plane = _streaming_client()
+        request_id = "req-asgi-disconnect"
+        request = ChatCompletionRequest(
+            model="qwen3-omni",
+            messages=[{"role": "user", "content": "hello"}],
+            stream=True,
+        )
+        response = _ClosableStreamingResponse(
+            _chat_stream(
+                client=client,
+                gen_req=GenerateRequest(
+                    model="qwen3-omni", prompt="hello", stream=True
+                ),
+                request_id=request_id,
+                response_id=f"chatcmpl-{request_id}",
+                created=0,
+                model="qwen3-omni",
+                req=request,
+                audio_format="wav",
+            ),
+            media_type="text/event-stream",
+        )
+
+        body_ready = asyncio.Event()
+
+        async def send(message: dict[str, Any]) -> None:
+            if message["type"] != "http.response.body":
+                return
+            body_ready.set()
+            raise RuntimeError("client vanished during body send")
+
+        async def receive() -> dict[str, Any]:
+            await asyncio.Event().wait()
+            return {"type": "http.disconnect"}
+
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.4"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/v1/chat/completions",
+            "raw_path": b"/v1/chat/completions",
+            "query_string": b"",
+            "root_path": "",
+            "headers": [],
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+        }
+        response_task = asyncio.create_task(response(scope, receive, send))
+        for _ in range(100):
+            if request_id in coordinator._stream_queues:
+                break
+            await asyncio.sleep(0)
+        await coordinator._handle_stream(
+            StreamMessage(
+                request_id=request_id,
+                from_stage="decode",
+                chunk={"text": "hello", "modality": "text"},
+                modality="text",
+            )
+        )
+
+        await body_ready.wait()
+        with pytest.raises(RuntimeError, match="client vanished during body send"):
+            await response_task
+        assert [msg.request_id for msg in control_plane.aborts] == [request_id]
+        assert request_id not in coordinator._requests
+        assert request_id not in coordinator._stream_queues
+        assert request_id not in coordinator._completion_futures
+
+    asyncio.run(_run())
+
+
+def test_client_completion_stream_close_reaches_coordinator_owner() -> None:
+    async def _run() -> None:
+        client, coordinator, control_plane = _streaming_client()
+        request_id = "req-client-close"
+        stream = client.completion_stream(
+            GenerateRequest(model="qwen3-omni", prompt="hello", stream=True),
+            request_id=request_id,
+        )
+        first_chunk = asyncio.create_task(anext(stream))
+        for _ in range(100):
+            if request_id in coordinator._stream_queues:
+                break
+            await asyncio.sleep(0)
+        await coordinator._handle_stream(
+            StreamMessage(
+                request_id=request_id,
+                from_stage="decode",
+                chunk={"text": "hello", "modality": "text"},
+                modality="text",
+            )
+        )
+        await first_chunk
+        await stream.aclose()
+
+        assert [msg.request_id for msg in control_plane.aborts] == [request_id]
+        assert request_id not in coordinator._requests
+        assert request_id not in coordinator._stream_queues
+        assert request_id not in coordinator._completion_futures
+
+    asyncio.run(_run())
+
+
+def test_transcription_stream_close_reaches_coordinator_owner() -> None:
+    async def _run() -> None:
+        client, coordinator, control_plane = _streaming_client()
+        request_id = "req-transcription-close"
+        stream = _transcription_stream(
+            client,
+            GenerateRequest(model="whisper", prompt="hello", stream=True),
+            request_id=request_id,
+            adapter=_IdentityTranscriptionAdapter(),
+            duration_s=1.0,
+        )
+        first_event = asyncio.create_task(anext(stream))
+        for _ in range(100):
+            if request_id in coordinator._stream_queues:
+                break
+            await asyncio.sleep(0)
+        await coordinator._handle_stream(
+            StreamMessage(
+                request_id=request_id,
+                from_stage="decode",
+                chunk={"text": "hello", "modality": "text"},
+                modality="text",
+            )
+        )
+        await first_event
+        await stream.aclose()
+
+        assert [msg.request_id for msg in control_plane.aborts] == [request_id]
+        assert request_id not in coordinator._requests
+        assert request_id not in coordinator._stream_queues
+        assert request_id not in coordinator._completion_futures
+
+    asyncio.run(_run())
 
 
 def test_chat_request_omits_explicit_params_when_sampling_omitted() -> None:

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -57,9 +57,17 @@ class FaultInjectingCoordinator(Coordinator):
         self.register_stage("preprocess", "inproc://preprocess")
 
     async def _submit_request(
-        self, request_id: str, request: OmniRequest | Any
+        self,
+        request_id: str,
+        request: OmniRequest | Any,
+        *,
+        stream_queue: asyncio.Queue[CompleteMessage | StreamMessage] | None = None,
     ) -> None:
-        await super()._submit_request(request_id, request)
+        await super()._submit_request(
+            request_id,
+            request,
+            stream_queue=stream_queue,
+        )
         if not isinstance(request, OmniRequest):
             request = OmniRequest(inputs=request)
         if bool(request.params.get("stream", False)):
@@ -276,17 +284,53 @@ class _IdentityTranscriptionAdapter:
         return text
 
 
-def _streaming_client() -> tuple[Client, Coordinator, RecordingCoordinatorControlPlane]:
+class _BlockingAbortControlPlane(RecordingCoordinatorControlPlane):
+    def __init__(self) -> None:
+        super().__init__()
+        self.abort_started = asyncio.Event()
+        self.release_abort = asyncio.Event()
+        self.abort_cancelled = False
+
+    async def broadcast_abort(self, msg: Any) -> None:
+        self.aborts.append(msg)
+        self.abort_started.set()
+        try:
+            await self.release_abort.wait()
+        except asyncio.CancelledError:
+            self.abort_cancelled = True
+            raise
+
+
+def _streaming_client(
+    control_plane: RecordingCoordinatorControlPlane | None = None,
+) -> tuple[Client, Coordinator, RecordingCoordinatorControlPlane]:
     coordinator = Coordinator(
         "inproc://complete",
         "inproc://abort",
         entry_stage="preprocess",
         terminal_stages=["decode"],
     )
-    control_plane = RecordingCoordinatorControlPlane()
+    control_plane = control_plane or RecordingCoordinatorControlPlane()
     coordinator.control_plane = control_plane
     coordinator.register_stage("preprocess", "inproc://preprocess")
     return Client(coordinator), coordinator, control_plane
+
+
+def _http_scope(*, path: str, spec_version: str) -> dict[str, Any]:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": spec_version},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "root_path": "",
+        "headers": [],
+        "server": ("testserver", 80),
+        "client": ("testclient", 50000),
+    }
 
 
 class AdminClient:
@@ -702,20 +746,7 @@ def test_chat_asgi_send_failure_aborts_backend_and_cleans_state() -> None:
             await asyncio.Event().wait()
             return {"type": "http.disconnect"}
 
-        scope = {
-            "type": "http",
-            "asgi": {"version": "3.0", "spec_version": "2.4"},
-            "http_version": "1.1",
-            "method": "POST",
-            "scheme": "http",
-            "path": "/v1/chat/completions",
-            "raw_path": b"/v1/chat/completions",
-            "query_string": b"",
-            "root_path": "",
-            "headers": [],
-            "server": ("testserver", 80),
-            "client": ("testclient", 50000),
-        }
+        scope = _http_scope(path="/v1/chat/completions", spec_version="2.4")
         response_task = asyncio.create_task(response(scope, receive, send))
         for _ in range(100):
             if request_id in coordinator._stream_queues:
@@ -733,6 +764,149 @@ def test_chat_asgi_send_failure_aborts_backend_and_cleans_state() -> None:
         await body_ready.wait()
         with pytest.raises(RuntimeError, match="client vanished during body send"):
             await response_task
+        assert [msg.request_id for msg in control_plane.aborts] == [request_id]
+        assert request_id not in coordinator._requests
+        assert request_id not in coordinator._stream_queues
+        assert request_id not in coordinator._completion_futures
+
+    asyncio.run(_run())
+
+
+def test_chat_asgi_receive_disconnect_aborts_backend_and_cleans_state() -> None:
+    async def _run() -> None:
+        blocking_control_plane = _BlockingAbortControlPlane()
+        client, coordinator, control_plane = _streaming_client(blocking_control_plane)
+        request_id = "req-asgi-receive-disconnect"
+        request = ChatCompletionRequest(
+            model="qwen3-omni",
+            messages=[{"role": "user", "content": "hello"}],
+            stream=True,
+        )
+        response = _ClosableStreamingResponse(
+            _chat_stream(
+                client=client,
+                gen_req=GenerateRequest(
+                    model="qwen3-omni", prompt="hello", stream=True
+                ),
+                request_id=request_id,
+                response_id=f"chatcmpl-{request_id}",
+                created=0,
+                model="qwen3-omni",
+                req=request,
+                audio_format="wav",
+            ),
+            media_type="text/event-stream",
+        )
+
+        first_body_sent = asyncio.Event()
+        disconnected = asyncio.Event()
+
+        async def send(message: dict[str, Any]) -> None:
+            if message["type"] == "http.response.body" and message.get("body"):
+                first_body_sent.set()
+
+        async def receive() -> dict[str, Any]:
+            await disconnected.wait()
+            return {"type": "http.disconnect"}
+
+        response_task = asyncio.create_task(
+            response(
+                _http_scope(
+                    path="/v1/chat/completions",
+                    spec_version="2.3",
+                ),
+                receive,
+                send,
+            )
+        )
+        for _ in range(100):
+            if request_id in coordinator._stream_queues:
+                break
+            await asyncio.sleep(0)
+        await coordinator._handle_stream(
+            StreamMessage(
+                request_id=request_id,
+                from_stage="decode",
+                chunk={"text": "hello", "modality": "text"},
+                modality="text",
+            )
+        )
+
+        await first_body_sent.wait()
+        disconnected.set()
+        await blocking_control_plane.abort_started.wait()
+        await asyncio.wait_for(response_task, timeout=1)
+
+        assert [msg.request_id for msg in control_plane.aborts] == [request_id]
+        assert blocking_control_plane.abort_cancelled is False
+        abort_task = coordinator._abort_tasks[request_id]
+        assert request_id in coordinator._requests
+        assert request_id not in coordinator._stream_queues
+        assert request_id not in coordinator._completion_futures
+
+        blocking_control_plane.release_abort.set()
+        assert await asyncio.wait_for(asyncio.shield(abort_task), timeout=1) is True
+        await asyncio.sleep(0)
+
+        assert request_id not in coordinator._requests
+        assert request_id not in coordinator._stream_queues
+        assert request_id not in coordinator._completion_futures
+        assert request_id not in coordinator._abort_tasks
+
+    asyncio.run(_run())
+
+
+def test_chat_asgi_task_cancellation_aborts_backend_and_stays_cancelled() -> None:
+    async def _run() -> None:
+        client, coordinator, control_plane = _streaming_client()
+        request_id = "req-asgi-cancelled"
+        request = ChatCompletionRequest(
+            model="qwen3-omni",
+            messages=[{"role": "user", "content": "hello"}],
+            stream=True,
+        )
+        response = _ClosableStreamingResponse(
+            _chat_stream(
+                client=client,
+                gen_req=GenerateRequest(
+                    model="qwen3-omni", prompt="hello", stream=True
+                ),
+                request_id=request_id,
+                response_id=f"chatcmpl-{request_id}",
+                created=0,
+                model="qwen3-omni",
+                req=request,
+                audio_format="wav",
+            ),
+            media_type="text/event-stream",
+        )
+
+        async def send(_message: dict[str, Any]) -> None:
+            return
+
+        async def receive() -> dict[str, Any]:
+            await asyncio.Event().wait()
+            return {"type": "http.disconnect"}
+
+        response_task = asyncio.create_task(
+            response(
+                _http_scope(
+                    path="/v1/chat/completions",
+                    spec_version="2.4",
+                ),
+                receive,
+                send,
+            )
+        )
+        for _ in range(100):
+            if request_id in coordinator._stream_queues:
+                break
+            await asyncio.sleep(0)
+
+        response_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await response_task
+
         assert [msg.request_id for msg in control_plane.aborts] == [request_id]
         assert request_id not in coordinator._requests
         assert request_id not in coordinator._stream_queues


### PR DESCRIPTION
## Motivation

Streaming Chat Completions and Audio Transcriptions did not abort backend inference when their SSE response ended early, so the backend kept generating for a response that could no longer be delivered, holding GPU compute, KV cache, and scheduler capacity until the request finished on its own.

Affected endpoints:

* `POST /v1/chat/completions`
* `POST /v1/audio/transcriptions`

Starlette pulls a chunk from the response body iterator and then calls `send()` outside that generator, so a failed or cancelled `send()` leaves the SSE formatter suspended at its `yield` and never runs cleanup written inside it. Closing the outer generator is not sufficient either, because it does not deterministically close the nested generators underneath:

```text
response body iterator
  -> Chat / ASR formatter
    -> Client.completion_stream()
      -> Client.generate()
        -> Coordinator.stream()
```

A failing `send()` does not prove the client disconnected deliberately; Starlette maps any `OSError` to `ClientDisconnect`, and the same failure can come from a connection reset, a proxy timeout, or server shutdown. Cleanup therefore triggers on "this response can no longer be delivered" rather than on a specific disconnect cause.

## Modifications

* Add `_ClosableStreamingResponse`, which closes the response body iterator at the ASGI ownership boundary, covering `send()` failures, cancellation, and normal exit. Cleanup failures are logged and never mask the original exception.
* Use `contextlib.aclosing()` in `Client.generate()`, `Client.completion_stream()`, and both SSE formatters so closure cascades deterministically down to the coordinator.
* Abort in `Coordinator.stream()` when it exits while the request is still non-terminal. The coordinator submits and tracks the request, so it owns abort policy; Chat and ASR only format events and close their client stream.
* Skip the abort when the request is no longer in the active table, so normal completion sends none and `_submit_request()` failures before registration send none.
* Log abort failures with `logger.warning(..., exc_info=True)` instead of suppressing them, and always release the stream queue and completion future.

`Coordinator.abort()` is unchanged, and the TTS streaming path is untouched because it already managed this lifecycle correctly. Existing explicit `client.abort()` callers still broadcast exactly once, since `abort()` returns early once the request is no longer active.

## Related Issues

N/A

## Accuracy Test

N/A. This change does not modify model computation, sampling behavior, or generated output.

## Benchmark & Profiling

N/A. This is a request-lifecycle and resource-cleanup fix.

## Tests

Added deterministic CPU-only regression tests, with no ZMQ or CUDA:

* `test_chat_asgi_send_failure_aborts_backend_and_cleans_state` drives `StreamingResponse.__call__` with a failing body send, so the failure happens outside the formatter generator.
* `test_client_completion_stream_close_reaches_coordinator_owner` and `test_transcription_stream_close_reaches_coordinator_owner` close a real client stream and assert the abort reaches the coordinator.
* `test_coordinator_stream_early_close_aborts_and_cleans_state` asserts the abort broadcast and cleanup of `_requests`, `_stream_queues`, and `_completion_futures`.
* `test_coordinator_stream_natural_completion_does_not_abort` asserts no abort is sent.
* `test_coordinator_stream_abort_failure_is_logged` asserts a failing abort is logged and still releases coordinator state.

Verified separately that the original `send()` failure is preserved and that cancellation semantics are unchanged, including the case where the abort must await while the request task is already cancelled.

Validation commands:

```bash
pytest -q tests/unit_test/client/test_completion_rollout.py tests/unit_test/pipeline/test_coordinator.py tests/unit_test/serve/test_openai_api.py
pre-commit run --files sglang_omni/client/client.py sglang_omni/pipeline/coordinator.py sglang_omni/serve/openai_api.py tests/unit_test/pipeline/test_coordinator.py tests/unit_test/serve/test_openai_api.py
```

Results:

```text
pytest: 76 passed
pre-commit: all hooks passed
```

## Checklist

* [x] Format the code according to pre-commit.
* [x] Add unit tests.
* [x] Update documentation / docstrings / example tutorials as needed.
* [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
