### PR TITLE
[Bugfix] Avoid unretrieved completion-future errors for streaming requests

### DIFF
--- a/sglang_omni/pipeline/coordinator.py
+++ b/sglang_omni/pipeline/coordinator.py
@@ -127,9 +127,7 @@ class Coordinator:
         for request_id, info in list(self._requests.items()):
             info.state = RequestState.FAILED
             info.error = message
-            future = self._completion_futures.get(request_id)
-            if future is not None and not future.done():
-                future.set_exception(RuntimeError(message))
+            self._reject_completion_future(request_id, RuntimeError(message))
             queue = self._stream_queues.get(request_id)
             if queue is not None:
                 await queue.put(
@@ -418,6 +416,19 @@ class Coordinator:
             entry_info.control_endpoint,
         )
 
+    def _reject_completion_future(self, request_id: str, exc: BaseException) -> None:
+        # Note: (Akazaakane) Non-streaming callers await the completion future,
+        # so errors must be propagated with set_exception(). Streaming callers
+        # receive errors through the stream queue and never await that future;
+        # cancel it instead to avoid "Future exception was never retrieved".
+        future = self._completion_futures.get(request_id)
+        if future is None or future.done():
+            return
+        if request_id in self._stream_queues:
+            future.cancel()
+        else:
+            future.set_exception(exc)
+
     async def abort(self, request_id: str) -> bool:
         """Abort a request.
 
@@ -445,10 +456,9 @@ class Coordinator:
         info.state = RequestState.ABORTED
 
         # Resolve future with error
-        if request_id in self._completion_futures:
-            self._completion_futures[request_id].set_exception(
-                asyncio.CancelledError(f"Request {request_id} aborted")
-            )
+        self._reject_completion_future(
+            request_id, asyncio.CancelledError(f"Request {request_id} aborted")
+        )
         if request_id in self._stream_queues:
             await self._stream_queues[request_id].put(
                 CompleteMessage(
@@ -521,10 +531,9 @@ class Coordinator:
                 AbortMessage(request_id=request_id)
             )
             self._partial_results.pop(request_id, None)
-            if request_id in self._completion_futures:
-                future = self._completion_futures[request_id]
-                if not future.done():
-                    future.set_exception(RuntimeError(msg.error or "Unknown error"))
+            self._reject_completion_future(
+                request_id, RuntimeError(msg.error or "Unknown error")
+            )
             if request_id in self._stream_queues:
                 await self._stream_queues[request_id].put(msg)
             self._requests.pop(request_id, None)

--- a/tests/unit_test/pipeline/test_coordinator.py
+++ b/tests/unit_test/pipeline/test_coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 
 import pytest
 
@@ -304,5 +305,101 @@ def test_coordinator_fail_pending_requests_resolves_waiters() -> None:
             await future
         assert coordinator._requests == {}
         assert coordinator._partial_results == {}
+
+    asyncio.run(_run())
+
+
+async def _drive_stream_until_registered(coordinator: Coordinator, request_id: str):
+    """Start consuming a stream and return (task, error_sink, future) once the
+    request's completion future has been created."""
+    error_sink: list[str] = []
+
+    async def _consume() -> None:
+        try:
+            async for _msg in coordinator.stream(request_id, "hello"):
+                pass
+        except RuntimeError as exc:
+            error_sink.append(str(exc))
+
+    task = asyncio.create_task(_consume())
+    for _ in range(100):
+        if request_id in coordinator._completion_futures:
+            break
+        await asyncio.sleep(0)
+    future = coordinator._completion_futures[request_id]
+    return task, error_sink, future
+
+
+def test_coordinator_stream_abort_cancels_future_without_unretrieved_exception() -> None:
+    """Aborting a streaming request cancels its completion future instead of
+    setting an exception no one retrieves, so the event loop never reports a
+    'Future exception was never retrieved' error."""
+
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["decode"],
+        )
+        coordinator.control_plane = RecordingCoordinatorControlPlane()
+        coordinator.register_stage("preprocess", "inproc://preprocess")
+
+        loop = asyncio.get_running_loop()
+        handler_contexts: list = []
+        loop.set_exception_handler(
+            lambda _loop, context: handler_contexts.append(context)
+        )
+
+        task, error_sink, future = await _drive_stream_until_registered(
+            coordinator, "req-1"
+        )
+
+        assert await coordinator.abort("req-1") is True
+        await task
+
+        # Stream terminated via its queue; the future is cancelled rather than
+        # carrying an un-retrieved exception.
+        assert error_sink == ["aborted"]
+        assert future.cancelled() is True
+        assert "req-1" not in coordinator._completion_futures
+
+        # Dropping the future must not trip the loop's exception handler.
+        del future
+        gc.collect()
+        assert not any(
+            "never retrieved" in str(ctx.get("message", "")) for ctx in handler_contexts
+        )
+
+    asyncio.run(_run())
+
+
+def test_coordinator_stream_stage_failure_cancels_future() -> None:
+    """A stage failure on a streaming request cancels the completion future
+    (which the stream consumer never awaits) rather than setting an exception
+    that would be reported as never retrieved."""
+
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["decode"],
+        )
+        coordinator.control_plane = RecordingCoordinatorControlPlane()
+        coordinator.register_stage("preprocess", "inproc://preprocess")
+
+        task, error_sink, future = await _drive_stream_until_registered(
+            coordinator, "req-1"
+        )
+
+        await coordinator._handle_completion(
+            CompleteMessage("req-1", "decode", False, error="boom")
+        )
+        await task
+
+        assert error_sink == ["boom"]
+        assert future.cancelled() is True
+        assert "req-1" not in coordinator._completion_futures
 
     asyncio.run(_run())

--- a/tests/unit_test/pipeline/test_coordinator.py
+++ b/tests/unit_test/pipeline/test_coordinator.py
@@ -330,7 +330,9 @@ async def _drive_stream_until_registered(coordinator: Coordinator, request_id: s
     return task, error_sink, future
 
 
-def test_coordinator_stream_abort_cancels_future_without_unretrieved_exception() -> None:
+def test_coordinator_stream_abort_cancels_future_without_unretrieved_exception() -> (
+    None
+):
     """Aborting a streaming request cancels its completion future instead of
     setting an exception no one retrieves, so the event loop never reports a
     'Future exception was never retrieved' error."""

--- a/tests/unit_test/pipeline/test_coordinator.py
+++ b/tests/unit_test/pipeline/test_coordinator.py
@@ -358,7 +358,7 @@ def test_coordinator_stream_abort_cancels_future_without_unretrieved_exception()
         )
 
         assert await coordinator.abort("req-1") is True
-        await task
+        await asyncio.wait_for(task, timeout=1)
 
         # Stream terminated via its queue; the future is cancelled rather than
         # carrying an un-retrieved exception.
@@ -367,6 +367,46 @@ def test_coordinator_stream_abort_cancels_future_without_unretrieved_exception()
         assert "req-1" not in coordinator._completion_futures
 
         # Dropping the future must not trip the loop's exception handler.
+        del future
+        gc.collect()
+        assert not any(
+            "never retrieved" in str(ctx.get("message", "")) for ctx in handler_contexts
+        )
+
+    asyncio.run(_run())
+
+
+def test_coordinator_stream_fail_pending_requests_cancels_future() -> None:
+    """A coordinator failure reaches the stream without leaving an exception
+    on its unused completion future."""
+
+    async def _run() -> None:
+        coordinator = Coordinator(
+            "inproc://complete",
+            "inproc://abort",
+            entry_stage="preprocess",
+            terminal_stages=["decode"],
+        )
+        coordinator.control_plane = RecordingCoordinatorControlPlane()
+        coordinator.register_stage("preprocess", "inproc://preprocess")
+
+        loop = asyncio.get_running_loop()
+        handler_contexts: list = []
+        loop.set_exception_handler(
+            lambda _loop, context: handler_contexts.append(context)
+        )
+
+        task, error_sink, future = await _drive_stream_until_registered(
+            coordinator, "req-1"
+        )
+
+        await coordinator.fail_pending_requests(RuntimeError("stage died"))
+        await asyncio.wait_for(task, timeout=1)
+
+        assert error_sink == ["stage died"]
+        assert future.cancelled() is True
+        assert "req-1" not in coordinator._completion_futures
+
         del future
         gc.collect()
         assert not any(
@@ -398,7 +438,7 @@ def test_coordinator_stream_stage_failure_cancels_future() -> None:
         await coordinator._handle_completion(
             CompleteMessage("req-1", "decode", False, error="boom")
         )
-        await task
+        await asyncio.wait_for(task, timeout=1)
 
         assert error_sink == ["boom"]
         assert future.cancelled() is True


### PR DESCRIPTION
## Motivation

The coordinator creates a completion future for both non-streaming and streaming
requests.

Non-streaming callers await this future through `submit()`, so coordinator error
paths must propagate exceptions through it. Streaming callers instead receive
errors through the stream queue and never await the completion future.

Calling `future.set_exception(...)` for a streaming request therefore leaves an
exception that is never retrieved. When the future is released, asyncio may log:

```text
Future exception was never retrieved
````

This can occur when a streaming request is:

* explicitly aborted;
* failed because a pipeline stage returned an error;
* failed by `fail_pending_requests()` after a coordinator-level fatal error.

This issue becomes more visible when streaming API disconnects actively abort
backend requests, as implemented in #1080.

## Modifications

* Added `_reject_completion_future()` to resolve coordinator futures according
  to the request type:

  * non-streaming requests retain `set_exception(...)`, preserving `submit()`
    error propagation;
  * streaming requests cancel the unused completion future because their error
    is delivered through the stream queue.
* Applied the shared helper to:

  * `Coordinator.abort()`;
  * `Coordinator.fail_pending_requests()`;
  * the failure path in `Coordinator._handle_completion()`.
* Preserved the existing stream error messages and coordinator cleanup behavior.

## Related Issues

Related to #1080.

## Accuracy Test

N/A. This change only affects coordinator error handling and does not modify
model computation or generated output.

## Benchmark & Profiling

N/A. This change does not affect the inference hot path.

## Tests

Added coordinator-level regression coverage for:

* aborting a streaming request cancels its unused completion future;
* dropping the aborted future does not trigger the asyncio exception handler;
* a mid-stream stage failure cancels the unused completion future;
* streaming consumers still receive the original error through the stream queue.

Existing tests continue to verify that non-streaming callers receive the original
exception through the completion future, including stage failures,
`fail_pending_requests()`, and explicit aborts.

Validation:

```bash
pytest -q tests/unit_test/pipeline/test_coordinator.py
pre-commit run --all-files --show-diff-on-failure
```

## Checklist

* [x] Format your code according with pre-commit.
* [x] Add unit tests.
* [x] Update documentation / docstrings / example tutorials as needed.
* [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
* [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. This is a CPU-only coordinator lifecycle change; the targeted
unit test is listed above.

```
```
