### PR TITLE
[CI] Recalibrate Qwen3-Omni speed gates for #869 (NVLink CUDA-IPC transport)

### DIFF
--- a/.claude/skills/tune-ci-thresholds/models/omni/stages.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/omni/stages.yaml
@@ -6,8 +6,8 @@ mmmu_accuracy:
   extra_env: {}
   context_vars:
     - CONCURRENCY
-  test_file_sha256: 076246df352b7e1ed18669ca2939f88e956d23111b76e446e8fb0dcb2ebf1fa0
-  last_discovered_at: 2026-07-14T20:32:38Z
+  test_file_sha256: dd99c94d21027246925b1b18642baaf418d4dbcc4337b2e79cc8c930592c8384
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 50
   sample_counts:
     total:
@@ -34,8 +34,8 @@ mmmu_speed:
   extra_env: {}
   context_vars:
     - CONCURRENCY
-  test_file_sha256: 076246df352b7e1ed18669ca2939f88e956d23111b76e446e8fb0dcb2ebf1fa0
-  last_discovered_at: 2026-07-14T20:32:38Z
+  test_file_sha256: dd99c94d21027246925b1b18642baaf418d4dbcc4337b2e79cc8c930592c8384
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 50
   sample_counts:
     total:
@@ -84,8 +84,8 @@ mmmu_talker_accuracy:
     - MAX_SAMPLES
     - MAX_TOKENS
     - CONCURRENCY
-  test_file_sha256: c59dcb6e1be3de451c1d1a28c08230b7dd53dec6cb4d8c617db30a44c5dbd90e
-  last_discovered_at: 2026-07-14T20:32:38Z
+  test_file_sha256: 8c365152e497c0f9c4a202a81da256f022cc186a6045c9f4457f43132d27fd47
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 20
   sample_counts:
     total:
@@ -114,8 +114,8 @@ mmmu_talker_wer:
     - MAX_SAMPLES
     - MAX_TOKENS
     - CONCURRENCY
-  test_file_sha256: c59dcb6e1be3de451c1d1a28c08230b7dd53dec6cb4d8c617db30a44c5dbd90e
-  last_discovered_at: 2026-07-14T20:32:38Z
+  test_file_sha256: 8c365152e497c0f9c4a202a81da256f022cc186a6045c9f4457f43132d27fd47
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 20
   sample_counts:
     total:
@@ -154,8 +154,8 @@ mmmu_talker_speed:
     - MAX_SAMPLES
     - MAX_TOKENS
     - CONCURRENCY
-  test_file_sha256: c59dcb6e1be3de451c1d1a28c08230b7dd53dec6cb4d8c617db30a44c5dbd90e
-  last_discovered_at: 2026-07-14T20:32:38Z
+  test_file_sha256: 8c365152e497c0f9c4a202a81da256f022cc186a6045c9f4457f43132d27fd47
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 20
   sample_counts:
     total:
@@ -212,8 +212,8 @@ mmsu_accuracy:
   extra_env: {}
   context_vars:
     - CONCURRENCY
-  test_file_sha256: 8d52ca6625a2894faf56136005b377da775c4d0663f62ad70f767b612c922cce
-  last_discovered_at: 2026-07-11T07:29:25Z
+  test_file_sha256: 0ed0afb4070e77af5040c2343d6627680ccb6e6386cb808bf4182ead9a0f233e
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 2000
   sample_counts:
     total:
@@ -240,8 +240,8 @@ mmsu_speed:
   extra_env: {}
   context_vars:
     - CONCURRENCY
-  test_file_sha256: 8d52ca6625a2894faf56136005b377da775c4d0663f62ad70f767b612c922cce
-  last_discovered_at: 2026-07-11T07:29:25Z
+  test_file_sha256: 0ed0afb4070e77af5040c2343d6627680ccb6e6386cb808bf4182ead9a0f233e
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 2000
   sample_counts:
     total:
@@ -290,8 +290,8 @@ mmsu_talker_accuracy:
     - MAX_SAMPLES
     - MAX_TOKENS
     - CONCURRENCY
-  test_file_sha256: 2bb3b914621f1c976f82e1ed482adcc83986f9102f50bad1b98bc78e3cab6994
-  last_discovered_at: 2026-07-11T07:29:25Z
+  test_file_sha256: aad4ccf862cb31e5a6f732310051cb85a6a3c9a89bc0fe1886993078df75135a
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 40
   sample_counts:
     total:
@@ -320,8 +320,8 @@ mmsu_talker_wer:
     - MAX_SAMPLES
     - MAX_TOKENS
     - CONCURRENCY
-  test_file_sha256: 2bb3b914621f1c976f82e1ed482adcc83986f9102f50bad1b98bc78e3cab6994
-  last_discovered_at: 2026-07-11T07:29:25Z
+  test_file_sha256: aad4ccf862cb31e5a6f732310051cb85a6a3c9a89bc0fe1886993078df75135a
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 40
   sample_counts:
     total:
@@ -360,8 +360,8 @@ mmsu_talker_speed:
     - MAX_SAMPLES
     - MAX_TOKENS
     - CONCURRENCY
-  test_file_sha256: 2bb3b914621f1c976f82e1ed482adcc83986f9102f50bad1b98bc78e3cab6994
-  last_discovered_at: 2026-07-11T07:29:25Z
+  test_file_sha256: aad4ccf862cb31e5a6f732310051cb85a6a3c9a89bc0fe1886993078df75135a
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 40
   sample_counts:
     total:
@@ -419,8 +419,8 @@ tts_wer:
   context_vars:
     - MAX_SAMPLES
     - CONCURRENCY
-  test_file_sha256: 1e58559fd23a12ea5bc9dbe870923c32089c2a77c0f10471020186744fbb6250
-  last_discovered_at: 2026-07-11T07:29:25Z
+  test_file_sha256: 21eac7bd86267332d8eae04d184a74a4b93e14d18268f6411789e42578a951d6
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 50
   sample_counts:
     total:
@@ -458,8 +458,8 @@ tts_utmos:
   context_vars:
     - MAX_SAMPLES
     - CONCURRENCY
-  test_file_sha256: 1e58559fd23a12ea5bc9dbe870923c32089c2a77c0f10471020186744fbb6250
-  last_discovered_at: 2026-07-11T07:29:25Z
+  test_file_sha256: 21eac7bd86267332d8eae04d184a74a4b93e14d18268f6411789e42578a951d6
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 50
   sample_counts:
     total:
@@ -487,8 +487,8 @@ tts_speed:
   context_vars:
     - MAX_SAMPLES
     - CONCURRENCY
-  test_file_sha256: 1e58559fd23a12ea5bc9dbe870923c32089c2a77c0f10471020186744fbb6250
-  last_discovered_at: 2026-07-11T07:29:25Z
+  test_file_sha256: 21eac7bd86267332d8eae04d184a74a4b93e14d18268f6411789e42578a951d6
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 50
   sample_counts:
     total:
@@ -546,8 +546,8 @@ videoamme_accuracy:
   context_vars:
     - MAX_SAMPLES
     - CONCURRENCY
-  test_file_sha256: 864d6ff0d3a8f9a1dac4ef549e8ba72fd28a43a707bf08ca00c5c7973058f619
-  last_discovered_at: 2026-07-11T07:29:25Z
+  test_file_sha256: 7c9083001ff412aec09b8ec6f3e380a1f56b61f47add787621b8824dfc5c3a39
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 50
   sample_counts:
     total:
@@ -575,8 +575,8 @@ videoamme_speed:
   context_vars:
     - MAX_SAMPLES
     - CONCURRENCY
-  test_file_sha256: 864d6ff0d3a8f9a1dac4ef549e8ba72fd28a43a707bf08ca00c5c7973058f619
-  last_discovered_at: 2026-07-11T07:29:25Z
+  test_file_sha256: 7c9083001ff412aec09b8ec6f3e380a1f56b61f47add787621b8824dfc5c3a39
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 50
   sample_counts:
     total:
@@ -626,8 +626,8 @@ videoamme_talker_tp2_accuracy:
     - MAX_SAMPLES
     - MAX_TOKENS
     - CONCURRENCY
-  test_file_sha256: 49cdd766b02f8669ada7cc78c5ba6477127425455e51579b28dd778ed29039be
-  last_discovered_at: 2026-07-11T07:29:25Z
+  test_file_sha256: b4452942923202e0dd19f1269c8a2aeb1f3ae2c89160acf310ae6ea3aa61695b
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 10
   sample_counts:
     total:
@@ -657,8 +657,8 @@ videoamme_talker_tp2_wer:
     - MAX_SAMPLES
     - MAX_TOKENS
     - CONCURRENCY
-  test_file_sha256: 49cdd766b02f8669ada7cc78c5ba6477127425455e51579b28dd778ed29039be
-  last_discovered_at: 2026-07-11T07:29:25Z
+  test_file_sha256: b4452942923202e0dd19f1269c8a2aeb1f3ae2c89160acf310ae6ea3aa61695b
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 10
   sample_counts:
     total:
@@ -698,8 +698,8 @@ videoamme_talker_tp2_speed:
     - MAX_SAMPLES
     - MAX_TOKENS
     - CONCURRENCY
-  test_file_sha256: 49cdd766b02f8669ada7cc78c5ba6477127425455e51579b28dd778ed29039be
-  last_discovered_at: 2026-07-11T07:29:25Z
+  test_file_sha256: b4452942923202e0dd19f1269c8a2aeb1f3ae2c89160acf310ae6ea3aa61695b
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 10
   sample_counts:
     total:
@@ -757,8 +757,8 @@ videomme_accuracy:
   context_vars:
     - MAX_SAMPLES
     - CONCURRENCY
-  test_file_sha256: 2b941d829db50054c8ba49eb1762812bdfd0169d4bab3c11eb839626d20716c0
-  last_discovered_at: 2026-07-11T07:29:25Z
+  test_file_sha256: f4e1f59087287df2e4015fe78079a472ae460b45acd09ce4af1ffca3b08104d8
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 50
   sample_counts:
     total:
@@ -786,8 +786,8 @@ videomme_speed:
   context_vars:
     - MAX_SAMPLES
     - CONCURRENCY
-  test_file_sha256: 2b941d829db50054c8ba49eb1762812bdfd0169d4bab3c11eb839626d20716c0
-  last_discovered_at: 2026-07-11T07:29:25Z
+  test_file_sha256: f4e1f59087287df2e4015fe78079a472ae460b45acd09ce4af1ffca3b08104d8
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 50
   sample_counts:
     total:
@@ -836,8 +836,8 @@ videomme_talker_accuracy:
     - MAX_SAMPLES
     - MAX_TOKENS
     - CONCURRENCY
-  test_file_sha256: 453d187341189d6522fa0dbc238edf65fd4868268565ff2c599bab29921d3166
-  last_discovered_at: 2026-07-11T07:29:25Z
+  test_file_sha256: b3475434614509b8fa02d35ca707d24677e40b3e6cbf16c3b07fcde5671bfadb
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 20
   sample_counts:
     total:
@@ -866,8 +866,8 @@ videomme_talker_wer:
     - MAX_SAMPLES
     - MAX_TOKENS
     - CONCURRENCY
-  test_file_sha256: 453d187341189d6522fa0dbc238edf65fd4868268565ff2c599bab29921d3166
-  last_discovered_at: 2026-07-11T07:29:25Z
+  test_file_sha256: b3475434614509b8fa02d35ca707d24677e40b3e6cbf16c3b07fcde5671bfadb
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 20
   sample_counts:
     total:
@@ -906,8 +906,8 @@ videomme_talker_speed:
     - MAX_SAMPLES
     - MAX_TOKENS
     - CONCURRENCY
-  test_file_sha256: 453d187341189d6522fa0dbc238edf65fd4868268565ff2c599bab29921d3166
-  last_discovered_at: 2026-07-11T07:29:25Z
+  test_file_sha256: b3475434614509b8fa02d35ca707d24677e40b3e6cbf16c3b07fcde5671bfadb
+  last_discovered_at: 2026-07-18T13:57:18Z
   expected_samples: 20
   sample_counts:
     total:

--- a/tests/test_model/test_qwen3_omni_mmmu_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmmu_ci.py
@@ -34,9 +34,9 @@ MMMU_MIN_ACCURACY = 0.62
 
 _MMMU_P95 = {
     16: {
-        "throughput_qps": 1.873,
-        "output_tok_per_req_s": 88.3,
-        "latency_mean_s": 7.629,
+        "throughput_qps": 2.219,
+        "output_tok_per_req_s": 95.4,
+        "latency_mean_s": 6.216,
     },
 }
 MMMU_THRESHOLDS = apply_slack(_MMMU_P95)

--- a/tests/test_model/test_qwen3_omni_mmmu_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmmu_talker_ci.py
@@ -70,10 +70,10 @@ MMMU_AUDIO_N_ABOVE_50_MAX = 6
 
 _MMMU_AUDIO_P95 = {
     16: {
-        "throughput_qps": 0.608,
-        "output_tok_per_req_s": 6.7,
-        "latency_mean_s": 20.901,
-        "rtf_mean": 0.5203,
+        "throughput_qps": 0.652,
+        "output_tok_per_req_s": 7.2,
+        "latency_mean_s": 19.357,
+        "rtf_mean": 0.4996,
     },
 }
 MMMU_AUDIO_THRESHOLDS = apply_slack(_MMMU_AUDIO_P95)

--- a/tests/test_model/test_qwen3_omni_mmsu_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_ci.py
@@ -35,9 +35,9 @@ MMSU_MIN_ACCURACY = 0.6965
 
 _MMSU_P95 = {
     16: {
-        "throughput_qps": 59.377,
-        "output_tok_per_req_s": 7.7,
-        "latency_mean_s": 0.269,
+        "throughput_qps": 63.703,
+        "output_tok_per_req_s": 8.3,
+        "latency_mean_s": 0.25,
     },
 }
 MMSU_THRESHOLDS = apply_slack(_MMSU_P95)

--- a/tests/test_model/test_qwen3_omni_mmsu_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_mmsu_talker_ci.py
@@ -70,10 +70,10 @@ MMSU_AUDIO_N_ABOVE_50_MAX = 0
 
 _MMSU_AUDIO_P95 = {
     16: {
-        "throughput_qps": 1.182,
+        "throughput_qps": 1.187,
         "output_tok_per_req_s": 4.9,
-        "latency_mean_s": 12.466,
-        "rtf_mean": 0.6786,
+        "latency_mean_s": 12.811,
+        "rtf_mean": 0.6805,
     },
 }
 MMSU_AUDIO_THRESHOLDS = apply_slack(_MMSU_AUDIO_P95)

--- a/tests/test_model/test_qwen3_omni_tts_ci.py
+++ b/tests/test_model/test_qwen3_omni_tts_ci.py
@@ -84,10 +84,10 @@ VC_UTMOS_MEAN_MIN = apply_mos_slack(VC_UTMOS_MEAN_REFERENCE)
 
 _VC_NON_STREAM_P95 = {
     16: {
-        "throughput_qps": 5.719,
-        "output_tok_per_req_s": 5.5,
-        "latency_mean_s": 2.647,
-        "rtf_mean": 0.9044,
+        "throughput_qps": 7.014,
+        "output_tok_per_req_s": 6.8,
+        "latency_mean_s": 2.153,
+        "rtf_mean": 0.6843,
     },
 }
 

--- a/tests/test_model/test_qwen3_omni_videoamme_ci.py
+++ b/tests/test_model/test_qwen3_omni_videoamme_ci.py
@@ -35,9 +35,9 @@ VIDEOAMME_MIN_ACCURACY = 0.66
 
 _VIDEOAMME_P95 = {
     16: {
-        "throughput_qps": 1.604,
-        "output_tok_per_req_s": 5.8,
-        "latency_mean_s": 8.572,
+        "throughput_qps": 1.676,
+        "output_tok_per_req_s": 6.0,
+        "latency_mean_s": 8.227,
     },
 }
 VIDEOAMME_THRESHOLDS = apply_slack(_VIDEOAMME_P95)

--- a/tests/test_model/test_qwen3_omni_videoamme_talker_tp2_ci.py
+++ b/tests/test_model/test_qwen3_omni_videoamme_talker_tp2_ci.py
@@ -57,10 +57,10 @@ VIDEOAMME_TALKER_TP2_N_ABOVE_50_MAX = 0.0
 
 _VIDEOAMME_TALKER_TP2_AUDIO_P95 = {
     16: {
-        "throughput_qps": 0.062,
-        "output_tok_per_req_s": 0.3,
-        "latency_mean_s": 160.352,
-        "rtf_mean": 12.3616,
+        "throughput_qps": 0.115,
+        "output_tok_per_req_s": 0.6,
+        "latency_mean_s": 83.996,
+        "rtf_mean": 5.9082,
     },
 }
 VIDEOAMME_TALKER_TP2_THRESHOLDS = apply_slack(_VIDEOAMME_TALKER_TP2_AUDIO_P95)

--- a/tests/test_model/test_qwen3_omni_videomme_ci.py
+++ b/tests/test_model/test_qwen3_omni_videomme_ci.py
@@ -36,9 +36,9 @@ VIDEOMME_MIN_ACCURACY = 0.58
 
 _VIDEOMME_P95 = {
     16: {
-        "throughput_qps": 1.020,
-        "output_tok_per_req_s": 7.9,
-        "latency_mean_s": 13.908,
+        "throughput_qps": 1.106,
+        "output_tok_per_req_s": 8.7,
+        "latency_mean_s": 12.682,
     },
 }
 VIDEOMME_THRESHOLDS = apply_slack(_VIDEOMME_P95)

--- a/tests/test_model/test_qwen3_omni_videomme_talker_ci.py
+++ b/tests/test_model/test_qwen3_omni_videomme_talker_ci.py
@@ -70,10 +70,10 @@ VIDEOMME_TALKER_N_ABOVE_50_MAX = 0
 
 _VIDEOMME_TALKER_AUDIO_P95 = {
     16: {
-        "throughput_qps": 0.881,
+        "throughput_qps": 0.908,
         "output_tok_per_req_s": 3.2,
-        "latency_mean_s": 12.957,
-        "rtf_mean": 1.4203,
+        "latency_mean_s": 13.154,
+        "rtf_mean": 1.5246,
     },
 }
 VIDEOMME_TALKER_THRESHOLDS = apply_slack(_VIDEOMME_TALKER_AUDIO_P95)


### PR DESCRIPTION
## Summary

Recalibrate Qwen3-Omni CI **speed** gates for **#869** (intra-node NVLink CUDA-IPC data plane + centralized transport). Strict worst-of-5 on 2×H100 at the post-#869 commit. Headline: `videoamme_talker_tp2` latency **160.35 → 83.996 s** — the NVLink transport payoff. **26 tightens, 4 loosens** (loosens are small residuals).

**Scope: speed metrics only.** #869 is a transport change (CUDA-IPC moves the same tensors over NVLink), so it cannot change model outputs — accuracy / WER / UTMOS are left at `main` (their movement this pass is sampling noise, and the no-slack accuracy gates would only get flakier if re-pinned to a 5-run worst).

## Method

Same skill/methodology as #1072 (`.claude/skills/tune-ci-thresholds`, strict worst-of-5; `apply_slack` derives the actual CI gates — only pre-slack references written here). 4 disjoint GPU-groups run concurrently (Mode B), one GPU-isolated container per pair (`0,1` / `2,3` / `4,5` / `6,7`), merged via `tune.py merge-runs`. All 23 stages `STRICT + GIT: READY` (5/5 complete, full sample scope). `stages.yaml` regenerated.

## H100 calibration

- **Host:** 2× NVIDIA H100 80GB HBM3, image `hongccc/sglang-omni:dev`
- **Commit:** `4b0055d9` (#869 merged) · sglang 0.5.12.post1 · torch 2.11.0
- **Run:** `20260718T113127Z` · ~51 min · **STRICT + GIT: READY, 23/23 stages**

## Cold-start outlier handling — worst-of-4 on 5 stages

Because all 4 GPU-groups were launched simultaneously, **run 1 of each stage caught cold-cache JIT + peak 4-group startup contention**. For 5 stages the run-1 latency sat 18-33% above the other 4 runs — a clear outlier that would inflate worst-of-5 with an artifact CI never sees (CI runs ≤3 concurrent). Those stages **drop run 1 and use worst-of-4**; every other stage keeps strict worst-of-5 (run 1 within normal spread — including `tp2`, whose worst is run 5, only 7% off worst-of-4).

| Stage (worst-of-4) | run 1 latency (dropped) | worst-of-4 (written) | gap |
|---|---|---|---|
| `mmmu_speed` | 8.284 | 6.216 | 33% |
| `videoamme_speed` | 10.857 | 8.227 | 32% |
| `mmsu_talker_speed` | 17.092 | 12.811 | 33% |
| `mmsu_speed` | 0.295 | 0.25 | 18% |
| `tts_speed` | 2.557 | 2.153 | 19% |

## Speed reference changes (pre-slack)

### Tightened (26)
| Stage | Metric | Old → New | basis |
|---|---|---|---|
| `mmmu_speed` | throughput_qps | 1.873 → **2.219** | worst-4 |
| `mmmu_speed` | output_tok_per_req_s | 88.3 → **95.4** | worst-4 |
| `mmmu_speed` | latency_mean_s | 7.629 → **6.216** | worst-4 |
| `mmmu_talker_speed` | throughput_qps | 0.608 → **0.652** | worst-5 |
| `mmmu_talker_speed` | output_tok_per_req_s | 6.7 → **7.2** | worst-5 |
| `mmmu_talker_speed` | latency_mean_s | 20.901 → **19.357** | worst-5 |
| `mmmu_talker_speed` | rtf_mean | 0.5203 → **0.4996** | worst-5 |
| `videomme_speed` | throughput_qps | 1.02 → **1.106** | worst-5 |
| `videomme_speed` | output_tok_per_req_s | 7.9 → **8.7** | worst-5 |
| `videomme_speed` | latency_mean_s | 13.908 → **12.682** | worst-5 |
| `videoamme_speed` | throughput_qps | 1.604 → **1.676** | worst-4 |
| `videoamme_speed` | output_tok_per_req_s | 5.8 → **6.0** | worst-4 |
| `videoamme_speed` | latency_mean_s | 8.572 → **8.227** | worst-4 |
| `mmsu_talker_speed` | throughput_qps | 1.182 → **1.187** | worst-4 |
| `mmsu_speed` | throughput_qps | 59.377 → **63.703** | worst-4 |
| `mmsu_speed` | output_tok_per_req_s | 7.7 → **8.3** | worst-4 |
| `mmsu_speed` | latency_mean_s | 0.269 → **0.25** | worst-4 |
| `tts_speed` | throughput_qps | 5.719 → **7.014** | worst-4 |
| `tts_speed` | output_tok_per_req_s | 5.5 → **6.8** | worst-4 |
| `tts_speed` | latency_mean_s | 2.647 → **2.153** | worst-4 |
| `tts_speed` | rtf_mean | 0.9044 → **0.6843** | worst-4 |
| `videomme_talker_speed` | throughput_qps | 0.881 → **0.908** | worst-5 |
| `videoamme_talker_tp2_speed` | throughput_qps | 0.062 → **0.115** | worst-5 |
| `videoamme_talker_tp2_speed` | output_tok_per_req_s | 0.3 → **0.6** | worst-5 |
| `videoamme_talker_tp2_speed` | latency_mean_s | 160.352 → **83.996** | worst-5 |
| `videoamme_talker_tp2_speed` | rtf_mean | 12.3616 → **5.9082** | worst-5 |

### Loosened (4)
| Stage | Metric | Old → New | basis |
|---|---|---|---|
| `mmsu_talker_speed` | latency_mean_s | 12.466 → **12.811** | worst-4 |
| `mmsu_talker_speed` | rtf_mean | 0.6786 → **0.6805** | worst-4 |
| `videomme_talker_speed` | latency_mean_s | 12.957 → **13.154** | worst-5 |
| `videomme_talker_speed` | rtf_mean | 1.4203 → **1.5246** | worst-5 |

## Validation

- `pytest tests/unit_test/test_tune_ci_thresholds.py` → **7 passed**
- accuracy/WER/UTMOS unchanged from `main`; `compileall` clean; `git diff --check` clean


---

<details>
<summary><b>Full calibration report — per-run tables (all 23 stages), operational reliability, provenance</b></summary>

# CI Threshold Observation Report

**Calibration commit:** `4b0055d9e09e670fda789009a97c8a5c43a0c5ab`
**Branch:** pr-1072
**Run directory:** `/data/tune-runs/20260718T113127Z/combined`
**Calibration started:** 2026-07-18T11:38:58Z
**Report generated:** 2026-07-18T12:37:29Z

## 1. MMMU Accuracy


| Run | Samples run | Samples ok | Acc (%) |
|-----|--------|--------|--------|
| 1 | 50 | 50 | 62.00 |
| 2 | 50 | 50 | 64.00 |
| 3 | 50 | 50 | 62.00 |
| 4 | 50 | 50 | 66.00 |
| 5 | 50 | 50 | 66.00 |
| **Worst-of-5** | — | — | **62.00** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Acc (%) | 62.00 | 64.00 | 62.00 | 66.00 | 4.00 | 2.00 | 0.031 | none |

Accuracy aggregate: 160/250; 95% Wilson CI 57.88%–69.70%.

## 2. MMMU Speed


| Run | Samples run | Samples ok | Throughput (req/s) | Output tok/req-s | Latency mean (s) |
|-----|--------|--------|--------|--------|--------|
| 1 | 50 | 50 | 1.528 | 74.8 | 8.284 |
| 2 | 50 | 50 | 2.219 | 98.7 | 6.035 |
| 3 | 50 | 50 | 2.234 | 97.4 | 6.216 |
| 4 | 50 | 50 | 2.322 | 97.4 | 5.758 |
| 5 | 50 | 50 | 2.278 | 95.4 | 5.623 |
| **Worst-of-5** | — | — | **1.528** | **74.8** | **8.284** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Throughput (req/s) | 1.528 | 2.234 | 1.528 | 2.322 | 0.794 | 0.331 | 0.157 | run1 |
| Output tok/req-s | 74.8 | 97.4 | 74.8 | 98.7 | 23.9 | 10.1 | 0.109 | run1 |
| Latency mean (s) | 8.284 | 6.035 | 5.623 | 8.284 | 2.661 | 1.088 | 0.170 | run1 |

## 3. MMMU TALKER Accuracy


| Run | Samples run | Samples ok | Acc (%) |
|-----|--------|--------|--------|
| 1 | 20 | 20 | 80.00 |
| 2 | 20 | 20 | 80.00 |
| 3 | 20 | 20 | 80.00 |
| 4 | 20 | 20 | 75.00 |
| 5 | 20 | 20 | 80.00 |
| **Worst-of-5** | — | — | **75.00** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Acc (%) | 75.00 | 80.00 | 75.00 | 80.00 | 5.00 | 2.24 | 0.028 | run4 |

Accuracy aggregate: 79/100; 95% Wilson CI 70.02%–85.83%.

## 4. MMMU TALKER Wer


| Run | Samples run | Samples ok | Corpus WER ≤50% (%) | Samples >50% WER |
|-----|--------|--------|--------|--------|
| 1 | 20 | 20 | 16.51 | 7 |
| 2 | 20 | 20 | 22.64 | 5 |
| 3 | 20 | 20 | 22.55 | 4 |
| 4 | 20 | 20 | 23.42 | 5 |
| 5 | 20 | 20 | 23.64 | 5 |
| **Worst-of-5** | — | — | **23.64** | **7** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Corpus WER ≤50% (%) | 23.64 | 22.64 | 16.51 | 23.64 | 7.12 | 2.97 | 0.136 | run1 |
| Samples >50% WER | 7 | 5 | 4 | 7 | 3 | 1 | 0.211 | run1, run3 |

## 5. MMMU TALKER Speed


| Run | Samples run | Samples ok | Throughput (req/s) | Output tok/req-s | Latency mean (s) | RTF mean |
|-----|--------|--------|--------|--------|--------|--------|
| 1 | 20 | 20 | 0.654 | 7.2 | 19.357 | 0.4996 |
| 2 | 20 | 20 | 0.658 | 7.2 | 19.235 | 0.4893 |
| 3 | 20 | 20 | 0.652 | 7.3 | 19.006 | 0.4874 |
| 4 | 20 | 20 | 0.657 | 7.4 | 18.701 | 0.4709 |
| 5 | 20 | 20 | 0.677 | 7.4 | 18.711 | 0.4846 |
| **Worst-of-5** | — | — | **0.652** | **7.2** | **19.357** | **0.4996** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Throughput (req/s) | 0.652 | 0.657 | 0.652 | 0.677 | 0.025 | 0.010 | 0.015 | run5 |
| Output tok/req-s | 7.2 | 7.3 | 7.2 | 7.4 | 0.2 | 0.1 | 0.014 | none |
| Latency mean (s) | 19.357 | 19.006 | 18.701 | 19.357 | 0.656 | 0.298 | 0.016 | none |
| RTF mean | 0.4996 | 0.4874 | 0.4709 | 0.4996 | 0.0287 | 0.0103 | 0.021 | run1, run4 |

## 6. VIDEOMME Accuracy


| Run | Samples run | Samples ok | Acc (%) |
|-----|--------|--------|--------|
| 1 | 50 | 50 | 56.00 |
| 2 | 50 | 50 | 58.00 |
| 3 | 50 | 50 | 60.00 |
| 4 | 50 | 50 | 60.00 |
| 5 | 50 | 50 | 60.00 |
| **Worst-of-5** | — | — | **56.00** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Acc (%) | 56.00 | 60.00 | 56.00 | 60.00 | 4.00 | 1.79 | 0.030 | none |

Accuracy aggregate: 147/250; 95% Wilson CI 52.61%–64.72%.

## 7. VIDEOMME Speed


| Run | Samples run | Samples ok | Throughput (req/s) | Output tok/req-s | Latency mean (s) |
|-----|--------|--------|--------|--------|--------|
| 1 | 50 | 50 | 1.106 | 8.7 | 12.682 |
| 2 | 50 | 50 | 1.125 | 9.0 | 12.276 |
| 3 | 50 | 50 | 1.175 | 9.3 | 11.919 |
| 4 | 50 | 50 | 1.188 | 9.3 | 11.742 |
| 5 | 50 | 50 | 1.134 | 8.8 | 12.329 |
| **Worst-of-5** | — | — | **1.106** | **8.7** | **12.682** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Throughput (req/s) | 1.106 | 1.134 | 1.106 | 1.188 | 0.082 | 0.035 | 0.030 | none |
| Output tok/req-s | 8.7 | 9.0 | 8.7 | 9.3 | 0.6 | 0.3 | 0.031 | none |
| Latency mean (s) | 12.682 | 12.276 | 11.742 | 12.682 | 0.940 | 0.368 | 0.030 | none |

## 8. VIDEOAMME Accuracy


| Run | Samples run | Samples ok | Acc (%) |
|-----|--------|--------|--------|
| 1 | 50 | 50 | 68.00 |
| 2 | 50 | 50 | 68.00 |
| 3 | 50 | 50 | 68.00 |
| 4 | 50 | 50 | 68.00 |
| 5 | 50 | 50 | 70.00 |
| **Worst-of-5** | — | — | **68.00** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Acc (%) | 68.00 | 68.00 | 68.00 | 70.00 | 2.00 | 0.89 | 0.013 | run5 |

Accuracy aggregate: 171/250; 95% Wilson CI 62.40%–73.85%.

## 9. VIDEOAMME Speed


| Run | Samples run | Samples ok | Throughput (req/s) | Output tok/req-s | Latency mean (s) |
|-----|--------|--------|--------|--------|--------|
| 1 | 50 | 50 | 1.360 | 4.6 | 10.857 |
| 2 | 50 | 50 | 1.701 | 6.1 | 8.020 |
| 3 | 50 | 50 | 1.676 | 6.0 | 8.227 |
| 4 | 50 | 50 | 1.925 | 6.9 | 7.146 |
| 5 | 50 | 50 | 1.716 | 6.2 | 7.975 |
| **Worst-of-5** | — | — | **1.360** | **4.6** | **10.857** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Throughput (req/s) | 1.360 | 1.701 | 1.360 | 1.925 | 0.565 | 0.203 | 0.121 | run1, run4 |
| Output tok/req-s | 4.6 | 6.1 | 4.6 | 6.9 | 2.3 | 0.8 | 0.141 | run1, run4 |
| Latency mean (s) | 10.857 | 8.020 | 7.146 | 10.857 | 3.711 | 1.410 | 0.167 | run1, run4 |

## 10. MMSU TALKER Accuracy


| Run | Samples run | Samples ok | Acc (%) |
|-----|--------|--------|--------|
| 1 | 40 | 40 | 67.50 |
| 2 | 40 | 40 | 65.00 |
| 3 | 40 | 40 | 67.50 |
| 4 | 40 | 40 | 65.00 |
| 5 | 40 | 40 | 67.50 |
| **Worst-of-5** | — | — | **65.00** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Acc (%) | 65.00 | 67.50 | 65.00 | 67.50 | 2.50 | 1.37 | 0.021 | none |

Accuracy aggregate: 133/200; 95% Wilson CI 59.70%–72.68%.

## 11. MMSU TALKER Wer


| Run | Samples run | Samples ok | Corpus WER ≤50% (%) | Samples >50% WER |
|-----|--------|--------|--------|--------|
| 1 | 40 | 40 | 2.25 | 0 |
| 2 | 40 | 40 | 1.54 | 0 |
| 3 | 40 | 40 | 1.69 | 0 |
| 4 | 40 | 40 | 2.27 | 1 |
| 5 | 40 | 40 | 1.70 | 2 |
| **Worst-of-5** | — | — | **2.27** | **2** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Corpus WER ≤50% (%) | 2.27 | 1.70 | 1.54 | 2.27 | 0.73 | 0.35 | 0.183 | none |
| Samples >50% WER | 2 | 0 | 0 | 2 | 2 | 1 | 1.491 | none |

## 12. MMSU TALKER Speed


| Run | Samples run | Samples ok | Throughput (req/s) | Output tok/req-s | Latency mean (s) | RTF mean |
|-----|--------|--------|--------|--------|--------|--------|
| 1 | 40 | 40 | 0.896 | 3.6 | 17.092 | 0.9203 |
| 2 | 40 | 40 | 1.220 | 4.9 | 12.395 | 0.6805 |
| 3 | 40 | 40 | 1.223 | 4.9 | 12.259 | 0.6548 |
| 4 | 40 | 40 | 1.187 | 5.0 | 12.811 | 0.6616 |
| 5 | 40 | 40 | 1.271 | 5.1 | 11.946 | 0.6281 |
| **Worst-of-5** | — | — | **0.896** | **3.6** | **17.092** | **0.9203** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Throughput (req/s) | 0.896 | 1.220 | 0.896 | 1.271 | 0.375 | 0.150 | 0.130 | run1 |
| Output tok/req-s | 3.6 | 4.9 | 3.6 | 5.1 | 1.5 | 0.6 | 0.132 | run1 |
| Latency mean (s) | 17.092 | 12.395 | 11.946 | 17.092 | 5.146 | 2.142 | 0.161 | run1 |
| RTF mean | 0.9203 | 0.6616 | 0.6281 | 0.9203 | 0.2922 | 0.1196 | 0.169 | run1 |

## 13. MMSU Accuracy


| Run | Samples run | Samples ok | Acc (%) |
|-----|--------|--------|--------|
| 1 | 2000 | 2000 | 70.15 |
| 2 | 2000 | 2000 | 69.50 |
| 3 | 2000 | 2000 | 70.10 |
| 4 | 2000 | 2000 | 70.45 |
| 5 | 2000 | 2000 | 70.35 |
| **Worst-of-5** | — | — | **69.50** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Acc (%) | 69.50 | 70.15 | 69.50 | 70.45 | 0.95 | 0.37 | 0.005 | run2 |

Accuracy aggregate: 7011/10000; 95% Wilson CI 69.21%–71.00%.

## 14. MMSU Speed


| Run | Samples run | Samples ok | Throughput (req/s) | Output tok/req-s | Latency mean (s) |
|-----|--------|--------|--------|--------|--------|
| 1 | 2000 | 2000 | 54.111 | 7.0 | 0.295 |
| 2 | 2000 | 2000 | 63.703 | 8.3 | 0.250 |
| 3 | 2000 | 2000 | 64.051 | 8.3 | 0.249 |
| 4 | 2000 | 2000 | 64.683 | 8.4 | 0.246 |
| 5 | 2000 | 2000 | 64.989 | 8.4 | 0.246 |
| **Worst-of-5** | — | — | **54.111** | **7.0** | **0.295** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Throughput (req/s) | 54.111 | 64.051 | 54.111 | 64.989 | 10.878 | 4.610 | 0.074 | run1 |
| Output tok/req-s | 7.0 | 8.3 | 7.0 | 8.4 | 1.4 | 0.6 | 0.075 | run1 |
| Latency mean (s) | 0.295 | 0.249 | 0.246 | 0.295 | 0.049 | 0.021 | 0.082 | run1 |

## 15. TTS Wer


| Run | Samples run | Samples ok | Corpus WER ≤50% (%) | Samples >50% WER |
|-----|--------|--------|--------|--------|
| 1 | 50 | 50 | 3.01 | 0 |
| 2 | 50 | 50 | 1.06 | 0 |
| 3 | 50 | 50 | 1.77 | 0 |
| 4 | 50 | 50 | 2.36 | 1 |
| 5 | 50 | 50 | 1.60 | 0 |
| **Worst-of-5** | — | — | **3.01** | **1** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Corpus WER ≤50% (%) | 3.01 | 1.77 | 1.06 | 3.01 | 1.95 | 0.75 | 0.382 | none |
| Samples >50% WER | 1 | 0 | 0 | 1 | 1 | 0 | 2.236 | run4 |

## 16. TTS Utmos


| Run | Samples run | Samples ok | UTMOS mean |
|-----|--------|--------|--------|
| 1 | 50 | 50 | 4.2856 |
| 2 | 50 | 50 | 4.2923 |
| 3 | 50 | 50 | 4.3296 |
| 4 | 50 | 50 | 4.3064 |
| 5 | 50 | 50 | 4.2815 |
| **Worst-of-5** | — | — | **4.2815** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| UTMOS mean | 4.2815 | 4.2923 | 4.2815 | 4.3296 | 0.0481 | 0.0195 | 0.005 | none |

## 17. TTS Speed


| Run | Samples run | Samples ok | Throughput (req/s) | Output tok/req-s | Latency mean (s) | RTF mean |
|-----|--------|--------|--------|--------|--------|--------|
| 1 | 50 | 50 | 5.954 | 5.7 | 2.557 | 0.8318 |
| 2 | 50 | 50 | 7.733 | 7.6 | 1.935 | 0.6300 |
| 3 | 50 | 50 | 7.831 | 7.6 | 1.922 | 0.6275 |
| 4 | 50 | 50 | 7.456 | 7.4 | 1.967 | 0.6351 |
| 5 | 50 | 50 | 7.014 | 6.8 | 2.153 | 0.6843 |
| **Worst-of-5** | — | — | **5.954** | **5.7** | **2.557** | **0.8318** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Throughput (req/s) | 5.954 | 7.456 | 5.954 | 7.831 | 1.877 | 0.764 | 0.106 | none |
| Output tok/req-s | 5.7 | 7.4 | 5.7 | 7.6 | 1.9 | 0.8 | 0.115 | none |
| Latency mean (s) | 2.557 | 1.967 | 1.922 | 2.557 | 0.635 | 0.268 | 0.127 | run1 |
| RTF mean | 0.8318 | 0.6351 | 0.6275 | 0.8318 | 0.2043 | 0.0871 | 0.128 | run1 |

## 18. VIDEOMME TALKER Accuracy


| Run | Samples run | Samples ok | Acc (%) |
|-----|--------|--------|--------|
| 1 | 20 | 20 | 60.00 |
| 2 | 20 | 20 | 65.00 |
| 3 | 20 | 20 | 65.00 |
| 4 | 20 | 20 | 60.00 |
| 5 | 20 | 20 | 60.00 |
| **Worst-of-5** | — | — | **60.00** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Acc (%) | 60.00 | 60.00 | 60.00 | 65.00 | 5.00 | 2.74 | 0.044 | none |

Accuracy aggregate: 62/100; 95% Wilson CI 52.21%–70.90%.

## 19. VIDEOMME TALKER Wer


| Run | Samples run | Samples ok | Corpus WER ≤50% (%) | Samples >50% WER |
|-----|--------|--------|--------|--------|
| 1 | 20 | 20 | 1.21 | 0 |
| 2 | 20 | 20 | 1.37 | 0 |
| 3 | 20 | 20 | 1.21 | 0 |
| 4 | 20 | 20 | 1.10 | 0 |
| 5 | 20 | 20 | 1.78 | 2 |
| **Worst-of-5** | — | — | **1.78** | **2** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Corpus WER ≤50% (%) | 1.78 | 1.21 | 1.10 | 1.78 | 0.68 | 0.27 | 0.200 | run5 |
| Samples >50% WER | 2 | 0 | 0 | 2 | 2 | 1 | 2.236 | run5 |

## 20. VIDEOMME TALKER Speed


| Run | Samples run | Samples ok | Throughput (req/s) | Output tok/req-s | Latency mean (s) | RTF mean |
|-----|--------|--------|--------|--------|--------|--------|
| 1 | 20 | 20 | 0.908 | 3.2 | 13.154 | 1.5246 |
| 2 | 20 | 20 | 0.921 | 3.3 | 12.805 | 1.2156 |
| 3 | 20 | 20 | 0.990 | 3.5 | 12.055 | 1.1093 |
| 4 | 20 | 20 | 0.962 | 3.4 | 11.931 | 1.3379 |
| 5 | 20 | 20 | 0.909 | 3.3 | 12.412 | 1.3280 |
| **Worst-of-5** | — | — | **0.908** | **3.2** | **13.154** | **1.5246** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Throughput (req/s) | 0.908 | 0.921 | 0.908 | 0.990 | 0.082 | 0.036 | 0.039 | none |
| Output tok/req-s | 3.2 | 3.3 | 3.2 | 3.5 | 0.3 | 0.1 | 0.034 | none |
| Latency mean (s) | 13.154 | 12.412 | 11.931 | 13.154 | 1.223 | 0.511 | 0.041 | none |
| RTF mean | 1.5246 | 1.3280 | 1.1093 | 1.5246 | 0.4153 | 0.1550 | 0.119 | run1 |

## 21. VIDEOAMME TALKER TP2 Accuracy


| Run | Samples run | Samples ok | Acc (%) |
|-----|--------|--------|--------|
| 1 | 10 | 10 | 60.00 |
| 2 | 10 | 10 | 50.00 |
| 3 | 10 | 10 | 40.00 |
| 4 | 10 | 10 | 50.00 |
| 5 | 10 | 10 | 50.00 |
| **Worst-of-5** | — | — | **40.00** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Acc (%) | 40.00 | 50.00 | 40.00 | 60.00 | 20.00 | 7.07 | 0.141 | run1, run3 |

Accuracy aggregate: 25/50; 95% Wilson CI 36.64%–63.36%.

## 22. VIDEOAMME TALKER TP2 Wer


| Run | Samples run | Samples ok | Corpus WER ≤50% (%) | Samples >50% WER |
|-----|--------|--------|--------|--------|
| 1 | 10 | 10 | 0.87 | 1 |
| 2 | 10 | 10 | 0.00 | 0 |
| 3 | 10 | 10 | 1.21 | 0 |
| 4 | 10 | 10 | 0.96 | 0 |
| 5 | 10 | 10 | 3.84 | 0 |
| **Worst-of-5** | — | — | **3.84** | **1** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Corpus WER ≤50% (%) | 3.84 | 0.96 | 0.00 | 3.84 | 3.84 | 1.45 | 1.052 | run2, run5 |
| Samples >50% WER | 1 | 0 | 0 | 1 | 1 | 0 | 2.236 | run1 |

## 23. VIDEOAMME TALKER TP2 Speed


| Run | Samples run | Samples ok | Throughput (req/s) | Output tok/req-s | Latency mean (s) | RTF mean |
|-----|--------|--------|--------|--------|--------|--------|
| 1 | 10 | 10 | 0.134 | 0.6 | 73.053 | 5.2502 |
| 2 | 10 | 10 | 0.139 | 0.7 | 70.464 | 4.9472 |
| 3 | 10 | 10 | 0.123 | 0.7 | 78.751 | 5.7574 |
| 4 | 10 | 10 | 0.133 | 0.7 | 74.439 | 5.1864 |
| 5 | 10 | 10 | 0.115 | 0.6 | 83.996 | 5.9082 |
| **Worst-of-5** | — | — | **0.115** | **0.6** | **83.996** | **5.9082** |

### Metric calibration

| Metric | Worst | Median | Min | Max | Range | Std | CV | Outliers |
|---|---:|---:|---:|---:|---:|---:|---:|---|
| Throughput (req/s) | 0.115 | 0.133 | 0.115 | 0.139 | 0.024 | 0.010 | 0.075 | none |
| Output tok/req-s | 0.6 | 0.7 | 0.6 | 0.7 | 0.1 | 0.1 | 0.083 | none |
| Latency mean (s) | 83.996 | 74.439 | 70.464 | 83.996 | 13.532 | 5.319 | 0.070 | none |
| RTF mean | 5.9082 | 5.2502 | 4.9472 | 5.9082 | 0.9610 | 0.4058 | 0.075 | none |

## Operational reliability

| Stage | Runs | Attempts | Retry successes | Failed attempts | Startup | OOM | Timeout | Partial |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| mmmu_accuracy | 5 | 5 | 0 | 1 | 0 | 0 | 0 | 0 |
| mmmu_speed | 5 | 5 | 0 | 1 | 0 | 0 | 0 | 0 |
| mmmu_talker_accuracy | 5 | 5 | 0 | 1 | 0 | 0 | 0 | 0 |
| mmmu_talker_wer | 5 | 5 | 0 | 1 | 0 | 0 | 0 | 0 |
| mmmu_talker_speed | 5 | 5 | 0 | 1 | 0 | 0 | 0 | 0 |
| videomme_accuracy | 5 | 5 | 0 | 1 | 0 | 0 | 0 | 0 |
| videomme_speed | 5 | 5 | 0 | 1 | 0 | 0 | 0 | 0 |
| videoamme_accuracy | 5 | 7 | 1 | 3 | 0 | 2 | 0 | 0 |
| videoamme_speed | 5 | 7 | 1 | 3 | 0 | 2 | 0 | 0 |
| mmsu_talker_accuracy | 5 | 5 | 0 | 3 | 0 | 0 | 0 | 0 |
| mmsu_talker_wer | 5 | 5 | 0 | 3 | 0 | 0 | 0 | 0 |
| mmsu_talker_speed | 5 | 5 | 0 | 3 | 0 | 0 | 0 | 0 |
| mmsu_accuracy | 5 | 5 | 0 | 1 | 0 | 0 | 0 | 0 |
| mmsu_speed | 5 | 5 | 0 | 1 | 0 | 0 | 0 | 0 |
| tts_wer | 5 | 5 | 0 | 1 | 0 | 0 | 0 | 0 |
| tts_utmos | 5 | 5 | 0 | 1 | 0 | 0 | 0 | 0 |
| tts_speed | 5 | 5 | 0 | 1 | 0 | 0 | 0 | 0 |
| videomme_talker_accuracy | 5 | 5 | 0 | 1 | 0 | 0 | 0 | 0 |
| videomme_talker_wer | 5 | 5 | 0 | 1 | 0 | 0 | 0 | 0 |
| videomme_talker_speed | 5 | 5 | 0 | 1 | 0 | 0 | 0 | 0 |
| videoamme_talker_tp2_accuracy | 5 | 5 | 0 | 2 | 0 | 0 | 0 | 0 |
| videoamme_talker_tp2_wer | 5 | 5 | 0 | 2 | 0 | 0 | 0 | 0 |
| videoamme_talker_tp2_speed | 5 | 5 | 0 | 2 | 0 | 0 | 0 | 0 |

## Provenance

- Model: omni
- Calibration commit: `4b0055d9e09e670fda789009a97c8a5c43a0c5ab`
- Branch: pr-1072 (dirty) — see `workspace.diff`
- Calibration started: 2026-07-18T11:38:58Z
- Venv Python: /github/home/calibration/omni/bin/python (flag)
- sglang 0.5.12.post1 · torch 2.11.0
- GPU: 2× NVIDIA H100 80GB HBM3
- GPU group: [0, 1]
- Environment comparability: core-pins-match; image-digest-unverified
- Container image digest: unverified
- Dependency freeze SHA256: None
- tune-ci-thresholds v0.7.0
- Report generated: 2026-07-18T12:37:29Z

</details>
