### PR TITLE
[Qwen3-Omni] Fix colocated launcher memory budgets

### DIFF
--- a/examples/launchers/qwen3_omni.py
+++ b/examples/launchers/qwen3_omni.py
@@ -58,6 +58,14 @@ Examples:
       --prompt "Read me a bedtime story." --output audio.wav
 """
 
+_DEFAULT_COLOCATED_MEMORY_BUDGETS = {
+    "image_encoder": 0.025,
+    "audio_encoder": 0.025,
+    "thinker": 0.75,
+    "talker_ar": 0.12,
+    "code2wav": 0.02,
+}
+
 
 def _parse_thinker_tp_gpu_list(spec: str, tp_size: int) -> list[int]:
     try:
@@ -84,7 +92,8 @@ def _resolve_speech_mem_fractions(
     global_mem_fraction_static: float | None,
     thinker_mem_fraction_static: float | None,
     talker_mem_fraction_static: float | None,
-) -> None:
+    typed_runtime: bool = False,
+) -> tuple[float | None, float | None]:
     values = (
         ("--mem-fraction-static", global_mem_fraction_static),
         ("--thinker-mem-fraction-static", thinker_mem_fraction_static),
@@ -102,18 +111,38 @@ def _resolve_speech_mem_fractions(
         if talker_mem_fraction_static is not None
         else global_mem_fraction_static
     )
-    if thinker_value is not None:
-        apply_stage_factory_updates(
-            config,
-            stage_name="thinker",
-            server_arg_updates={"mem_fraction_static": thinker_value},
-        )
-    if talker_value is not None:
-        apply_stage_factory_updates(
-            config,
-            stage_name="talker_ar",
-            server_arg_updates={"mem_fraction_static": talker_value},
-        )
+    for stage_name, value in (
+        ("thinker", thinker_value),
+        ("talker_ar", talker_value),
+    ):
+        if value is None:
+            continue
+        if typed_runtime:
+            stage = next(stage for stage in config.stages if stage.name == stage_name)
+            stage.runtime.sglang_server_args.mem_fraction_static = value
+        else:
+            apply_stage_factory_updates(
+                config,
+                stage_name=stage_name,
+                server_arg_updates={"mem_fraction_static": value},
+            )
+    return thinker_value, talker_value
+
+
+def _set_colocated_memory_budgets(
+    config: Any,
+    *,
+    thinker_mem_fraction_static: float | None,
+    talker_mem_fraction_static: float | None,
+) -> None:
+    budgets = dict(_DEFAULT_COLOCATED_MEMORY_BUDGETS)
+    if thinker_mem_fraction_static is not None:
+        budgets["thinker"] = thinker_mem_fraction_static
+    if talker_mem_fraction_static is not None:
+        budgets["talker_ar"] = talker_mem_fraction_static
+    for stage in config.stages:
+        if stage.name in budgets:
+            stage.runtime.resources.total_gpu_memory_fraction = budgets[stage.name]
 
 
 def _build_qwen_text_server_parser() -> argparse.ArgumentParser:
@@ -420,12 +449,19 @@ def launch_qwen_speech_server(args: argparse.Namespace) -> None:
 
     set_stage_gpu(config, "talker_ar", gpu_talker)
     set_stage_gpu(config, "code2wav", gpu_code2wav)
-    _resolve_speech_mem_fractions(
+    thinker_mem_fraction, talker_mem_fraction = _resolve_speech_mem_fractions(
         config,
         global_mem_fraction_static=args.mem_fraction_static,
         thinker_mem_fraction_static=args.thinker_mem_fraction_static,
         talker_mem_fraction_static=args.talker_mem_fraction_static,
+        typed_runtime=args.colocated,
     )
+    if args.colocated:
+        _set_colocated_memory_budgets(
+            config,
+            thinker_mem_fraction_static=thinker_mem_fraction,
+            talker_mem_fraction_static=talker_mem_fraction,
+        )
     if args.thinker_max_seq_len is not None:
         updates = {"thinker_max_seq_len": int(args.thinker_max_seq_len)}
         apply_stage_factory_updates(config, stage_name="thinker", updates=updates)

--- a/tests/unit_test/qwen3_omni/test_example_launcher.py
+++ b/tests/unit_test/qwen3_omni/test_example_launcher.py
@@ -16,6 +16,7 @@ from examples.launchers.qwen3_omni import _parse_thinker_tp_gpu_list
 from examples.launchers.qwen3_omni import (
     launch_qwen_speech_server as _launch_speech_server,
 )
+from sglang_omni.config import build_stage_placement_plan
 from sglang_omni.models.qwen3_omni.config import MIN_PARTIAL_START_CHUNKS
 
 _EXAMPLES_DIR = pathlib.Path(__file__).resolve().parents[3] / "examples"
@@ -465,6 +466,56 @@ def test_colocated_defaults_use_thinker_gpu_for_gpu_stages(mock_launch_server):
     assert _stage(config, "thinker").gpu == 0
     assert _stage(config, "talker_ar").gpu == 0
     assert _stage(config, "code2wav").gpu == 0
+
+
+def test_colocated_defaults_populate_typed_memory_budgets(mock_launch_server):
+    mock_launch_server.side_effect = lambda config, **_: build_stage_placement_plan(
+        config
+    )
+
+    _launch_speech_server(_make_args(colocated=True))
+
+    config = mock_launch_server.call_args[0][0]
+    budgets = {
+        stage_name: _stage(
+            config, stage_name
+        ).runtime.resources.total_gpu_memory_fraction
+        for stage_name in (
+            "image_encoder",
+            "audio_encoder",
+            "thinker",
+            "talker_ar",
+            "code2wav",
+        )
+    }
+    assert budgets == {
+        "image_encoder": pytest.approx(0.025),
+        "audio_encoder": pytest.approx(0.025),
+        "thinker": pytest.approx(0.75),
+        "talker_ar": pytest.approx(0.12),
+        "code2wav": pytest.approx(0.02),
+    }
+
+
+def test_colocated_mem_fractions_update_typed_budgets(mock_launch_server):
+    mock_launch_server.side_effect = lambda config, **_: build_stage_placement_plan(
+        config
+    )
+    args = _make_args(
+        colocated=True,
+        thinker_mem_fraction_static=0.55,
+        talker_mem_fraction_static=0.20,
+    )
+
+    _launch_speech_server(args)
+
+    config = mock_launch_server.call_args[0][0]
+    thinker = _stage(config, "thinker")
+    talker = _stage(config, "talker_ar")
+    assert thinker.runtime.resources.total_gpu_memory_fraction == pytest.approx(0.55)
+    assert thinker.runtime.sglang_server_args.mem_fraction_static == pytest.approx(0.55)
+    assert talker.runtime.resources.total_gpu_memory_fraction == pytest.approx(0.20)
+    assert talker.runtime.sglang_server_args.mem_fraction_static == pytest.approx(0.20)
 
 
 def test_colocated_rejects_conflicting_stage_gpu(mock_launch_server):

--- a/tests/unit_test/qwen3_omni/test_example_launcher.py
+++ b/tests/unit_test/qwen3_omni/test_example_launcher.py
@@ -495,6 +495,15 @@ def test_colocated_defaults_populate_typed_memory_budgets(mock_launch_server):
         "talker_ar": pytest.approx(0.12),
         "code2wav": pytest.approx(0.02),
     }
+    plan = build_stage_placement_plan(config)
+    assert plan.gpus[0].total_gpu_memory_fraction == pytest.approx(0.94)
+    assert (
+        _stage(config, "thinker").runtime.sglang_server_args.mem_fraction_static is None
+    )
+    assert (
+        _stage(config, "talker_ar").runtime.sglang_server_args.mem_fraction_static
+        is None
+    )
 
 
 def test_colocated_mem_fractions_update_typed_budgets(mock_launch_server):
@@ -516,6 +525,18 @@ def test_colocated_mem_fractions_update_typed_budgets(mock_launch_server):
     assert thinker.runtime.sglang_server_args.mem_fraction_static == pytest.approx(0.55)
     assert talker.runtime.resources.total_gpu_memory_fraction == pytest.approx(0.20)
     assert talker.runtime.sglang_server_args.mem_fraction_static == pytest.approx(0.20)
+
+
+def test_colocated_global_mem_fraction_rejects_overcommit(mock_launch_server):
+    mock_launch_server.side_effect = lambda config, **_: build_stage_placement_plan(
+        config
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="total_gpu_memory_fraction=1.070 exceeds placement limit 1.000",
+    ):
+        _launch_speech_server(_make_args(colocated=True, mem_fraction_static=0.5))
 
 
 def test_colocated_rejects_conflicting_stage_gpu(mock_launch_server):


### PR DESCRIPTION
Related to #985. Follow-up to #1070.

The qwen3-speech-server --colocated preset now applies the existing calibrated typed budgets before launch. Explicit AR memory overrides update the same typed budgets, and overcommitted values are rejected by placement.

Tests: 70 Qwen launcher and colocation tests passed. Black, isort, ruff, and diff checks passed.