### PR TITLE
[TTS Refactor] Reduce reference encode hook boilerplate

### DIFF
--- a/docs/developer_reference/reference_encode_service.md
+++ b/docs/developer_reference/reference_encode_service.md
@@ -39,6 +39,24 @@ class ReferenceEncodeHook(Generic[InputT, ArtifactT, StoredT]):
     def revalidate(self, item: InputT, key: ReferenceEncodeKey) -> bool: ...
 
 
+class KeyedReferenceEncodeHook(ReferenceEncodeHook[InputT, ArtifactT, StoredT]):
+    model_id: str
+    model_revision: str
+    encoder_id: str
+    encoder_config_hash: str
+    artifact_kind: str
+
+    def input_key(self, item: InputT) -> str | None: ...
+    def options_key(self, item: InputT) -> str: ...
+
+
+class TensorReferenceEncodeHook(
+    KeyedReferenceEncodeHook[InputT, Tensor, Tensor]
+):
+    storage_dtype: torch.dtype | None
+    output_dtype: torch.dtype | None
+
+
 class ReferenceEncodeService(Generic[InputT, ArtifactT, StoredT]):
     def get_or_encode(self, raw_input: Any, *, desc: str | None = None) -> ArtifactT: ...
     def stats(self) -> dict[str, int]: ...
@@ -71,6 +89,15 @@ The hook owns model semantics:
 - store/load conversion;
 - revalidation for mutable local files.
 
+Hooks with structured identity should inherit `KeyedReferenceEncodeHook`. They
+provide key metadata, `input_key`, and `encode_one`, plus input normalization
+when the service does not already receive the typed item. The default builds
+`ReferenceEncodeKey` and rechecks input and option keys before insertion.
+Tensor-producing encoders should inherit `TensorReferenceEncodeHook`, which
+also stores a cache-owned CPU clone and returns a caller-owned clone in
+`output_dtype`. Structured artifacts such as nested prompt dictionaries keep
+their own store/load policy on top of `KeyedReferenceEncodeHook`.
+
 ## Cache-Key Contract
 
 `ReferenceEncodeKey` must include every input that can change the encoded
@@ -95,7 +122,9 @@ content identity.
 Hooks should store cache-owned artifacts, usually detached CPU tensors or a
 small CPU dictionary of detached tensors. `load_artifact` must return a
 caller-owned object, commonly by cloning and moving to the expected dtype or
-device. The service enforces the byte budget on the stored representation.
+device. `TensorReferenceEncodeHook` provides this policy through
+`storage_dtype` and `output_dtype`. The service enforces the byte budget on the
+stored representation.
 
 If a stored artifact is larger than `max_bytes`, the leader request and all
 same-key followers still receive a result, but the artifact is not inserted into

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -22,6 +22,7 @@ from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.pipeline_state import load_state as _load_pipeline_state
 from sglang_omni.scheduling.pipeline_state import store_state as _store_pipeline_state
 from sglang_omni.scheduling.reference_encoder import (
+    ReferenceEncodeKey,
     ReferenceEncodeService,
     TensorReferenceEncodeHook,
 )
@@ -184,6 +185,9 @@ class _FishReferenceEncodeHook(TensorReferenceEncodeHook[_FishReferenceInput]):
             audio_tensor = torch.from_numpy(audio).float().reshape(1, -1)
             return self._encode_reference_waveform(audio_tensor, int(sr))
         raise TypeError(f"unknown FishAudio reference source: {item.source_kind}")
+
+    def revalidate(self, item: _FishReferenceInput, key: ReferenceEncodeKey) -> bool:
+        return item.source_kind != "path" or self.input_key(item) == key.input_key
 
     def input_key(self, item: _FishReferenceInput) -> str | None:
         if item.source_kind == "path":

--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -22,9 +22,8 @@ from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.pipeline_state import load_state as _load_pipeline_state
 from sglang_omni.scheduling.pipeline_state import store_state as _store_pipeline_state
 from sglang_omni.scheduling.reference_encoder import (
-    ReferenceEncodeHook,
-    ReferenceEncodeKey,
     ReferenceEncodeService,
+    TensorReferenceEncodeHook,
 )
 from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoint
 
@@ -137,14 +136,18 @@ def _fish_reference_payload_is_supported(ref_data: dict[str, Any]) -> bool:
     )
 
 
-class _FishReferenceEncodeHook(
-    ReferenceEncodeHook[_FishReferenceInput, torch.Tensor, torch.Tensor]
-):
+class _FishReferenceEncodeHook(TensorReferenceEncodeHook[_FishReferenceInput]):
+    model_id = "fishaudio_s2_pro"
+    encoder_id = "fishaudio_s2_pro_codec"
+    artifact_kind = "fishaudio_s2_pro_vq_codes"
+    storage_dtype = torch.long
+    output_dtype = torch.long
+
     def __init__(self, *, codec: Any, checkpoint_id: str) -> None:
         self._codec = codec
-        self._checkpoint_id = str(checkpoint_id)
+        self.model_revision = str(checkpoint_id)
         config = f"sample_rate:{int(codec.sample_rate)}"
-        self._encoder_config_hash = _hash_bytes(config.encode("utf-8"))
+        self.encoder_config_hash = _hash_bytes(config.encode("utf-8"))
 
     def normalize_input(self, raw_input: Any) -> _FishReferenceInput:
         if not isinstance(raw_input, dict):
@@ -161,19 +164,6 @@ class _FishReferenceEncodeHook(
                 str(raw_input.get("media_type") or "audio/wav"),
             )
         raise ValueError("FishAudio reference input has no audio payload")
-
-    def cache_key(self, item: _FishReferenceInput) -> ReferenceEncodeKey | None:
-        input_key = self._input_key(item)
-        if input_key is None:
-            return None
-        return ReferenceEncodeKey(
-            model_id="fishaudio_s2_pro",
-            model_revision=self._checkpoint_id,
-            encoder_id="fishaudio_s2_pro_codec",
-            encoder_config_hash=self._encoder_config_hash,
-            artifact_kind="fishaudio_s2_pro_vq_codes",
-            input_key=input_key,
-        )
 
     def encode_one(self, item: _FishReferenceInput) -> torch.Tensor:
         if item.source_kind == "path":
@@ -195,18 +185,7 @@ class _FishReferenceEncodeHook(
             return self._encode_reference_waveform(audio_tensor, int(sr))
         raise TypeError(f"unknown FishAudio reference source: {item.source_kind}")
 
-    def store_artifact(self, artifact: torch.Tensor) -> torch.Tensor:
-        return artifact.detach().to(device="cpu", dtype=torch.long).clone()
-
-    def load_artifact(self, stored: torch.Tensor) -> torch.Tensor:
-        return stored.detach().clone().to(dtype=torch.long)
-
-    def revalidate(self, item: _FishReferenceInput, key: ReferenceEncodeKey) -> bool:
-        if item.source_kind != "path":
-            return True
-        return self._input_key(item) == key.input_key
-
-    def _input_key(self, item: _FishReferenceInput) -> str | None:
+    def input_key(self, item: _FishReferenceInput) -> str | None:
         if item.source_kind == "path":
             return _reference_path_cache_key(str(item.source), trust_stat=False)
         if item.source_kind == "bytes":

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -159,12 +159,7 @@ class _HiggsReferenceInput:
 
 
 class _HiggsReferenceEncodeHook(TensorReferenceEncodeHook[_HiggsReferenceInput]):
-    """M4a hook: delayed reference codes for a 24 kHz waveform.
-
-    Keys are waveform-content hashes (computed once in preprocessing), so
-    identical reference audio hits across request ids and source forms.
-    Waveform-content keys cannot go stale, so the default revalidate applies.
-    """
+    """Encode delayed 24 kHz reference codes keyed by waveform content."""
 
     model_revision = ""
     encoder_id = "higgs_codec_delayed"

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -57,9 +57,8 @@ from sglang_omni.preprocessing.cache_key import (
 )
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.reference_encoder import (
-    ReferenceEncodeHook,
-    ReferenceEncodeKey,
     ReferenceEncodeService,
+    TensorReferenceEncodeHook,
 )
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 from sglang_omni.scheduling.speaker_cache import (
@@ -159,9 +158,7 @@ class _HiggsReferenceInput:
         self.content_key = content_key
 
 
-class _HiggsReferenceEncodeHook(
-    ReferenceEncodeHook[_HiggsReferenceInput, torch.Tensor, torch.Tensor]
-):
+class _HiggsReferenceEncodeHook(TensorReferenceEncodeHook[_HiggsReferenceInput]):
     """M4a hook: delayed reference codes for a 24 kHz waveform.
 
     Keys are waveform-content hashes (computed once in preprocessing), so
@@ -169,25 +166,20 @@ class _HiggsReferenceEncodeHook(
     Waveform-content keys cannot go stale, so the default revalidate applies.
     """
 
+    model_revision = ""
+    encoder_id = "higgs_codec_delayed"
+    artifact_kind = "reference_codes"
+    storage_dtype = torch.int32
+    output_dtype = torch.long
+
     def __init__(self, codec: Any, *, num_codebooks: int, model_identity: str):
         self._codec = codec
         self._num_codebooks = int(num_codebooks)
-        self._model_identity = str(model_identity)
+        self.model_id = str(model_identity)
+        self.encoder_config_hash = f"nq{self._num_codebooks}"
 
-    def normalize_input(self, raw_input: Any) -> _HiggsReferenceInput:
-        return raw_input
-
-    def cache_key(self, item: _HiggsReferenceInput) -> ReferenceEncodeKey | None:
-        if item.content_key is None:
-            return None
-        return ReferenceEncodeKey(
-            model_id=self._model_identity,
-            model_revision="",
-            encoder_id="higgs_codec_delayed",
-            encoder_config_hash=f"nq{self._num_codebooks}",
-            artifact_kind="reference_codes",
-            input_key=item.content_key,
-        )
+    def input_key(self, item: _HiggsReferenceInput) -> str | None:
+        return item.content_key
 
     def encode_one(self, item: _HiggsReferenceInput) -> torch.Tensor:
         ref_codes_TN = self._codec.encode_reference(
@@ -199,12 +191,6 @@ class _HiggsReferenceEncodeHook(
                 f"{tuple(ref_codes_TN.shape)}"
             )
         return apply_delay_pattern(ref_codes_TN)
-
-    def store_artifact(self, artifact: torch.Tensor) -> torch.Tensor:
-        return artifact.detach().to("cpu", torch.int32)
-
-    def load_artifact(self, stored: torch.Tensor) -> torch.Tensor:
-        return stored.detach().clone().to(torch.long)
 
 
 def create_preprocessing_executor(

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -41,9 +41,9 @@ from sglang_omni.preprocessing.cache_key import (
     reference_path_cache_key as _reference_path_cache_key,
 )
 from sglang_omni.scheduling.reference_encoder import (
-    ReferenceEncodeHook,
     ReferenceEncodeKey,
     ReferenceEncodeService,
+    TensorReferenceEncodeHook,
 )
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 
@@ -392,8 +392,15 @@ class _MossLocalReferenceInput:
 
 
 class _MossLocalReferenceEncodeHook(
-    ReferenceEncodeHook[_MossLocalReferenceInput, torch.Tensor, torch.Tensor]
+    TensorReferenceEncodeHook[_MossLocalReferenceInput]
 ):
+    model_id = "moss_tts_local"
+    model_revision = "local_audio_tokenizer"
+    encoder_id = "moss_tts_local_audio_tokenizer"
+    artifact_kind = "moss_tts_local_reference_codes"
+    storage_dtype = torch.int32
+    output_dtype = torch.long
+
     def __init__(
         self,
         encoder: _BatchedReferenceEncoder,
@@ -402,25 +409,12 @@ class _MossLocalReferenceEncodeHook(
     ) -> None:
         self._encoder = encoder
         self._n_vq = int(n_vq)
-        self._encoder_config_hash = _hash_bytes(f"n_vq:{self._n_vq}".encode("utf-8"))
+        self.encoder_config_hash = _hash_bytes(f"n_vq:{self._n_vq}".encode("utf-8"))
 
     def normalize_input(self, raw_input: Any) -> _MossLocalReferenceInput:
         if isinstance(raw_input, _MossLocalReferenceInput):
             return raw_input
         return _MossLocalReferenceInput("path", str(raw_input))
-
-    def cache_key(self, item: _MossLocalReferenceInput) -> ReferenceEncodeKey | None:
-        input_key = self._input_key(item)
-        if input_key is None:
-            return None
-        return ReferenceEncodeKey(
-            model_id="moss_tts_local",
-            model_revision="local_audio_tokenizer",
-            encoder_id="moss_tts_local_audio_tokenizer",
-            encoder_config_hash=self._encoder_config_hash,
-            artifact_kind="moss_tts_local_reference_codes",
-            input_key=input_key,
-        )
 
     def encode_one(self, item: _MossLocalReferenceInput) -> torch.Tensor:
         if item.source_kind == "path":
@@ -433,22 +427,15 @@ class _MossLocalReferenceEncodeHook(
             return self._encoder.encode_wav(wav, sample_rate)
         raise TypeError(f"unknown MOSS-local reference source: {item.source_kind}")
 
-    def store_artifact(self, artifact: torch.Tensor) -> torch.Tensor:
-        return artifact.detach().to("cpu", dtype=torch.int32).clone()
-
-    def load_artifact(self, stored: torch.Tensor) -> torch.Tensor:
-        return stored.detach().clone().to(torch.long)
-
     def revalidate(
-        self,
-        item: _MossLocalReferenceInput,
-        key: ReferenceEncodeKey,
+        self, item: _MossLocalReferenceInput, key: ReferenceEncodeKey
     ) -> bool:
-        if item.source_kind != "path":
-            return True
-        return _reference_path_cache_key(item.source) == key.input_key
+        return (
+            item.source_kind != "path"
+            or _reference_path_cache_key(item.source) == key.input_key
+        )
 
-    def _input_key(self, item: _MossLocalReferenceInput) -> str | None:
+    def input_key(self, item: _MossLocalReferenceInput) -> str | None:
         if item.source_kind == "path":
             _BatchedReferenceEncoder._check_reference_duration(item.source)
             return _reference_path_cache_key(item.source)

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -25,8 +25,7 @@ from sglang_omni.sampling.seed import (
     new_random_sampling_seed,
 )
 from sglang_omni.scheduling.reference_encoder import (
-    ReferenceEncodeHook,
-    ReferenceEncodeKey,
+    KeyedReferenceEncodeHook,
     ReferenceEncodeService,
 )
 from sglang_omni.scheduling.sglang_backend import SGLangARRequestData
@@ -570,17 +569,21 @@ class _Qwen3TTSAdhocReferenceInput:
 
 
 class _Qwen3TTSAdhocReferenceHook(
-    ReferenceEncodeHook[
+    KeyedReferenceEncodeHook[
         _Qwen3TTSAdhocReferenceInput,
         tuple[dict[str, Any], str | None],
         dict[str, Any],
     ]
 ):
+    model_id = "qwen3_tts"
+    encoder_id = "qwen3_tts_voice_clone_prompt"
+    artifact_kind = "qwen3_tts_voice_clone_prompt_adhoc"
+
     def __init__(self, *, model: Any, wrapper: Any) -> None:
         self._model = model
         self._wrapper = wrapper
-        self._model_revision = _qwen3_tts_model_revision(model, wrapper)
-        self._encoder_config_hash = _qwen3_tts_encoder_config_hash(model, wrapper)
+        self.model_revision = _qwen3_tts_model_revision(model, wrapper)
+        self.encoder_config_hash = _qwen3_tts_encoder_config_hash(model, wrapper)
 
     def normalize_input(self, raw_input: Any) -> _Qwen3TTSAdhocReferenceInput:
         if isinstance(raw_input, _Qwen3TTSAdhocReferenceInput):
@@ -593,28 +596,17 @@ class _Qwen3TTSAdhocReferenceHook(
             x_vector_only_mode=raw_input.x_vector_only_mode,
         )
 
-    def cache_key(
-        self, item: _Qwen3TTSAdhocReferenceInput
-    ) -> ReferenceEncodeKey | None:
-        input_key = _qwen3_tts_ref_audio_input_key(item.ref_audio)
-        if input_key is None:
-            return None
-        options_key = json.dumps(
+    def input_key(self, item: _Qwen3TTSAdhocReferenceInput) -> str | None:
+        return _qwen3_tts_ref_audio_input_key(item.ref_audio)
+
+    def options_key(self, item: _Qwen3TTSAdhocReferenceInput) -> str:
+        return json.dumps(
             {
                 "ref_text": item.ref_text,
                 "x_vector_only_mode": bool(item.x_vector_only_mode),
             },
             sort_keys=True,
             separators=(",", ":"),
-        )
-        return ReferenceEncodeKey(
-            model_id="qwen3_tts",
-            model_revision=self._model_revision,
-            encoder_id="qwen3_tts_voice_clone_prompt",
-            encoder_config_hash=self._encoder_config_hash,
-            artifact_kind="qwen3_tts_voice_clone_prompt_adhoc",
-            input_key=input_key,
-            options_key=options_key,
         )
 
     def encode_one(
@@ -647,14 +639,6 @@ class _Qwen3TTSAdhocReferenceHook(
         if cached_prompt is None:
             raise RuntimeError("Qwen3-TTS ad-hoc reference cache entry is invalid")
         return cached_prompt
-
-    def revalidate(
-        self,
-        item: _Qwen3TTSAdhocReferenceInput,
-        key: ReferenceEncodeKey,
-    ) -> bool:
-        current_key = _qwen3_tts_ref_audio_input_key(item.ref_audio)
-        return current_key == key.input_key
 
 
 def _qwen3_tts_ref_audio_input_key(ref_audio: Any) -> str | None:

--- a/sglang_omni/scheduling/reference_encoder.py
+++ b/sglang_omni/scheduling/reference_encoder.py
@@ -7,7 +7,9 @@ import logging
 import threading
 import time
 from dataclasses import asdict, dataclass
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar, cast
+
+import torch
 
 from sglang_omni.scheduling.stage_cache import StageOutputCache
 
@@ -54,6 +56,60 @@ class ReferenceEncodeHook(Generic[InputT, ArtifactT, StoredT]):
     def encode_batch(self, items: list[InputT]) -> list[ArtifactT]:
         """Reserved; ReferenceEncodeService does not call this until batching."""
         return [self.encode_one(item) for item in items]
+
+
+class KeyedReferenceEncodeHook(ReferenceEncodeHook[InputT, ArtifactT, StoredT]):
+    """Defaults for hooks with structured identity and option keys."""
+
+    model_id: str
+    model_revision: str
+    encoder_id: str
+    encoder_config_hash: str
+    artifact_kind: str
+
+    def normalize_input(self, raw_input: Any) -> InputT:
+        return cast(InputT, raw_input)
+
+    def input_key(self, item: InputT) -> str | None:
+        raise NotImplementedError
+
+    def options_key(self, item: InputT) -> str:
+        return ""
+
+    def cache_key(self, item: InputT) -> ReferenceEncodeKey | None:
+        input_key = self.input_key(item)
+        if input_key is None:
+            return None
+        return ReferenceEncodeKey(
+            model_id=self.model_id,
+            model_revision=self.model_revision,
+            encoder_id=self.encoder_id,
+            encoder_config_hash=self.encoder_config_hash,
+            artifact_kind=self.artifact_kind,
+            input_key=input_key,
+            options_key=self.options_key(item),
+        )
+
+    def revalidate(self, item: InputT, key: ReferenceEncodeKey) -> bool:
+        return (
+            self.input_key(item) == key.input_key
+            and self.options_key(item) == key.options_key
+        )
+
+
+class TensorReferenceEncodeHook(
+    KeyedReferenceEncodeHook[InputT, torch.Tensor, torch.Tensor]
+):
+    """Defaults for reference encoders that cache CPU tensor artifacts."""
+
+    storage_dtype: torch.dtype | None = None
+    output_dtype: torch.dtype | None = None
+
+    def store_artifact(self, artifact: torch.Tensor) -> torch.Tensor:
+        return artifact.detach().to(device="cpu", dtype=self.storage_dtype, copy=True)
+
+    def load_artifact(self, stored: torch.Tensor) -> torch.Tensor:
+        return stored.detach().to(dtype=self.output_dtype, copy=True)
 
 
 def _fresh_exception(exc: BaseException) -> BaseException:

--- a/tests/unit_test/scheduling/test_reference_encoder.py
+++ b/tests/unit_test/scheduling/test_reference_encoder.py
@@ -11,21 +11,10 @@ import pytest
 import torch
 
 from sglang_omni.scheduling.reference_encoder import (
-    ReferenceEncodeHook,
     ReferenceEncodeKey,
     ReferenceEncodeService,
+    TensorReferenceEncodeHook,
 )
-
-
-def _key(name: str) -> ReferenceEncodeKey:
-    return ReferenceEncodeKey(
-        model_id="test",
-        model_revision="rev",
-        encoder_id="encoder",
-        encoder_config_hash="cfg",
-        artifact_kind="codes",
-        input_key=name,
-    )
 
 
 class _FirstWaveGate:
@@ -53,18 +42,23 @@ def _wait_for_merged(
     assert service.stats()["merged"] >= expected
 
 
-class _TensorHook(ReferenceEncodeHook[str, torch.Tensor, torch.Tensor]):
+class _TensorHook(TensorReferenceEncodeHook[str]):
+    model_id = "test"
+    model_revision = "rev"
+    encoder_id = "encoder"
+    encoder_config_hash = "cfg"
+    artifact_kind = "codes"
+    storage_dtype = torch.long
+    output_dtype = torch.long
+
     def __init__(self) -> None:
         self.calls: Counter[str] = Counter()
         self.lock = threading.Lock()
 
-    def normalize_input(self, raw_input: Any) -> str:
-        return str(raw_input)
-
-    def cache_key(self, item: str) -> ReferenceEncodeKey | None:
+    def input_key(self, item: str) -> str | None:
         if item.startswith("uncacheable"):
             return None
-        return _key(item)
+        return item
 
     def encode_one(self, item: str) -> torch.Tensor:
         with self.lock:
@@ -72,11 +66,41 @@ class _TensorHook(ReferenceEncodeHook[str, torch.Tensor, torch.Tensor]):
         value = sum(ord(ch) for ch in item) % 127
         return torch.full((2,), value, dtype=torch.long)
 
-    def store_artifact(self, artifact: torch.Tensor) -> torch.Tensor:
-        return artifact.detach().to("cpu").clone()
 
-    def load_artifact(self, stored: torch.Tensor) -> torch.Tensor:
-        return stored.detach().clone().to(dtype=torch.long)
+def test_tensor_hook_builds_key_and_owns_stored_and_loaded_tensors() -> None:
+    class _CompressedHook(_TensorHook):
+        storage_dtype = torch.int32
+        option = "v1"
+
+        def options_key(self, item: str) -> str:
+            return self.option
+
+    hook = _CompressedHook()
+    key = hook.cache_key("stable")
+    assert key is not None
+    assert key == ReferenceEncodeKey(
+        model_id="test",
+        model_revision="rev",
+        encoder_id="encoder",
+        encoder_config_hash="cfg",
+        artifact_kind="codes",
+        input_key="stable",
+        options_key="v1",
+    )
+    assert hook.revalidate("stable", key)
+    assert not hook.revalidate("changed", key)
+    hook.option = "v2"
+    assert not hook.revalidate("stable", key)
+
+    artifact = torch.tensor([1, 2], dtype=torch.long)
+    stored = hook.store_artifact(artifact)
+    loaded = hook.load_artifact(stored)
+    artifact.fill_(9)
+    stored.fill_(8)
+
+    assert stored.dtype == torch.int32
+    assert loaded.dtype == torch.long
+    assert torch.equal(loaded, torch.tensor([1, 2], dtype=torch.long))
 
 
 def test_same_key_concurrent_single_flight() -> None:

--- a/tests/unit_test/scheduling/test_reference_encoder.py
+++ b/tests/unit_test/scheduling/test_reference_encoder.py
@@ -102,6 +102,16 @@ def test_tensor_hook_builds_key_and_owns_stored_and_loaded_tensors() -> None:
     assert loaded.dtype == torch.long
     assert torch.equal(loaded, torch.tensor([1, 2], dtype=torch.long))
 
+    class _PreservingHook(_TensorHook):
+        storage_dtype = None
+        output_dtype = None
+
+    preserving_hook = _PreservingHook()
+    source = torch.tensor([1.5], dtype=torch.float32)
+    preserved = preserving_hook.load_artifact(preserving_hook.store_artifact(source))
+    assert preserved.dtype == torch.float32
+    assert preserved.data_ptr() != source.data_ptr()
+
 
 def test_same_key_concurrent_single_flight() -> None:
     release = threading.Event()


### PR DESCRIPTION
## Summary

- Add keyed and tensor hook defaults for shared key construction, revalidation, and tensor ownership/dtype policy.
- Migrate FishAudio S2-Pro, Higgs, MOSS-TTS Local, and Qwen3-TTS.
- Preserve MOSS one-time duration validation and Fish immutable-input revalidation fast paths.

## Result

Non-test, non-documentation Python: +111/-120, net -9.

The four model hooks shrink by 65 lines while the shared layer adds 56. Qwen structured prompt serialization remains model-specific.

## Verification

- 27 focused H100 tests passed.
- 13 shared scheduling tests passed locally.
- Pre-commit passed.
