### PR TITLE
ci: install zhon for Fun-ASR SeedTTS gate

### DIFF
--- a/.claude/skills/tune-ci-thresholds/models/asr/config.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/asr/config.yaml
@@ -3,18 +3,21 @@
 # CI DAG:
 #   stage-1-multi-speaker (MOSS-Transcribe-Diarize on movies800time + AISHELL4 long)
 #   -> stage-2-seedtts (Qwen3-ASR on SeedTTS EN)
+#   -> stage-3-fun-asr (Fun-ASR-Nano on SeedTTS EN and ZH)
 #
-# Both stages use the managed router with 2 single-GPU workers (DP=2).
+# All stages use the managed router with 2 single-GPU workers (DP=2).
 # Qwen3-ASR SeedTTS uses the ASR transcribe fan-out from tests.utils
 # (QWEN3_ASR_WER_CONCURRENCY = 32).
 name: asr
-description: "ASR CI (MOSS-TD multi-speaker + Qwen3-ASR SeedTTS)"
+description: "ASR CI (MOSS-TD multi-speaker + Qwen3-ASR SeedTTS + Fun-ASR SeedTTS)"
 hf_model_id: "OpenMOSS-Team/MOSS-Transcribe-Diarize"
 hf_model_ids_by_test:
   test_asr_ci_multi_speaker.py:
     - "OpenMOSS-Team/MOSS-Transcribe-Diarize"
   test_asr_ci_seedtts.py:
     - "Qwen/Qwen3-ASR-1.7B"
+  test_asr_ci_fun_asr.py:
+    - "FunAudioLLM/Fun-ASR-Nano-2512-hf"
 hf_datasets:
   - "zhaochenyang20/movies800time"
   - "zhaochenyang20/AISHELL4"
@@ -42,9 +45,11 @@ auto_env:
 gpus_per_test:
   test_asr_ci_multi_speaker.py: 2
   test_asr_ci_seedtts.py: 2
+  test_asr_ci_fun_asr.py: 2
 test_globs:
   - "tests/test_model/test_asr_ci_multi_speaker.py"
   - "tests/test_model/test_asr_ci_seedtts.py"
+  - "tests/test_model/test_asr_ci_fun_asr.py"
 extra_env: {}
 pytest_extra_args: {}
 stage_base_strip_prefix: "test_asr_ci_"
@@ -155,3 +160,32 @@ metric_sources:
       latency_p95_s: "speed.latency_p95_s"
       rtf_mean: "speed.rtf_mean"
       rtf_p95: "speed.rtf_p95"
+  test_asr_ci_fun_asr.py:
+    variants:
+      en:
+        constant_filter: "^FUN_ASR_(?!ZH_).*"
+        context_vars:
+          - SEEDTTS_FUN_ASR_EN_SAMPLES
+        json_file: "fun_asr_results.json"
+        sample_counts:
+          total: "summary.total_samples"
+          ok: "summary.evaluated"
+        paths:
+          corpus_wer: "summary.corpus_wer"
+          per_sample_wer_max: "summary.wer_per_sample_max"
+          throughput_qps: "speed.throughput_samples_per_s"
+          latency_mean_s: "speed.latency_mean_s"
+          latency_p95_s: "speed.latency_p95_s"
+          rtf_mean: "speed.rtf_mean"
+          rtf_p95: "speed.rtf_p95"
+      zh:
+        constant_filter: "^FUN_ASR_ZH_"
+        context_vars:
+          - SEEDTTS_FUN_ASR_ZH_SAMPLES
+        json_file: "fun_asr_zh_results.json"
+        sample_counts:
+          total: "summary.total_samples"
+          ok: "summary.evaluated"
+        paths:
+          corpus_wer: "summary.corpus_wer"
+          per_sample_wer_max: "summary.wer_per_sample_max"

--- a/.claude/skills/tune-ci-thresholds/models/asr/stages.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/asr/stages.yaml
@@ -617,3 +617,150 @@ seedtts_speed:
         scale: 1
         digits: 4
       status: OK
+fun_asr_en_wer:
+  test: tests/test_model/test_asr_ci_fun_asr.py
+  title: "FUN ASR EN Wer"
+  group: wer
+  extra_env: {}
+  context_vars:
+    - SEEDTTS_FUN_ASR_EN_SAMPLES
+  variant: "en"
+  test_file_sha256: 9017ecf0074a6b49ddac2337ae7dba1328913d418dbe70b058865132dd7837de
+  last_discovered_at: 2026-07-19T05:01:27Z
+  expected_samples: 1088
+  sample_counts:
+    total:
+      json_file: "fun_asr_results.json"
+      json_path: "summary.total_samples"
+    ok:
+      json_file: "fun_asr_results.json"
+      json_path: "summary.evaluated"
+  metrics:
+    corpus_wer:
+      source: "FUN_ASR_EN_CORPUS_WER_MAX"
+      json_file: "fun_asr_results.json"
+      json_path: "summary.corpus_wer"
+      worst: max
+      display:
+        label: "Corpus WER (%)"
+        scale: 100
+        digits: 2
+      status: OK
+    per_sample_wer_max:
+      source: "FUN_ASR_EN_SAMPLE_WER_MAX"
+      json_file: "fun_asr_results.json"
+      json_path: "summary.wer_per_sample_max"
+      worst: max
+      display:
+        label: "Max per-sample WER (%)"
+        scale: 100
+        digits: 2
+      status: OK
+fun_asr_en_speed:
+  test: tests/test_model/test_asr_ci_fun_asr.py
+  title: "FUN ASR EN Speed"
+  group: speed
+  extra_env: {}
+  context_vars:
+    - SEEDTTS_FUN_ASR_EN_SAMPLES
+  variant: "en"
+  test_file_sha256: 9017ecf0074a6b49ddac2337ae7dba1328913d418dbe70b058865132dd7837de
+  last_discovered_at: 2026-07-19T05:01:27Z
+  expected_samples: 1088
+  sample_counts:
+    total:
+      json_file: "fun_asr_results.json"
+      json_path: "summary.total_samples"
+    ok:
+      json_file: "fun_asr_results.json"
+      json_path: "summary.evaluated"
+  metrics:
+    throughput_qps:
+      source: "FUN_ASR_THROUGHPUT_MIN"
+      json_file: "fun_asr_results.json"
+      json_path: "speed.throughput_samples_per_s"
+      worst: min
+      display:
+        label: "Throughput (req/s)"
+        scale: 1
+        digits: 3
+      status: OK
+    latency_mean_s:
+      source: "FUN_ASR_LATENCY_MEAN_MAX_S"
+      json_file: "fun_asr_results.json"
+      json_path: "speed.latency_mean_s"
+      worst: max
+      display:
+        label: "Latency mean (s)"
+        scale: 1
+        digits: 3
+      status: OK
+    latency_p95_s:
+      source: "FUN_ASR_LATENCY_P95_MAX_S"
+      json_file: "fun_asr_results.json"
+      json_path: "speed.latency_p95_s"
+      worst: max
+      display:
+        label: "Latency p95 (s)"
+        scale: 1
+        digits: 3
+      status: OK
+    rtf_mean:
+      source: "FUN_ASR_RTF_MEAN_MAX"
+      json_file: "fun_asr_results.json"
+      json_path: "speed.rtf_mean"
+      worst: max
+      display:
+        label: "RTF mean"
+        scale: 1
+        digits: 4
+      status: OK
+    rtf_p95:
+      source: "FUN_ASR_RTF_P95_MAX"
+      json_file: "fun_asr_results.json"
+      json_path: "speed.rtf_p95"
+      worst: max
+      display:
+        label: "RTF p95"
+        scale: 1
+        digits: 4
+      status: OK
+fun_asr_zh_wer:
+  test: tests/test_model/test_asr_ci_fun_asr.py
+  title: "FUN ASR ZH Wer"
+  group: wer
+  extra_env: {}
+  context_vars:
+    - SEEDTTS_FUN_ASR_ZH_SAMPLES
+  variant: "zh"
+  test_file_sha256: 9017ecf0074a6b49ddac2337ae7dba1328913d418dbe70b058865132dd7837de
+  last_discovered_at: 2026-07-19T05:01:27Z
+  expected_samples: 2020
+  sample_counts:
+    total:
+      json_file: "fun_asr_zh_results.json"
+      json_path: "summary.total_samples"
+    ok:
+      json_file: "fun_asr_zh_results.json"
+      json_path: "summary.evaluated"
+  metrics:
+    corpus_wer:
+      source: "FUN_ASR_ZH_CORPUS_WER_MAX"
+      json_file: "fun_asr_zh_results.json"
+      json_path: "summary.corpus_wer"
+      worst: max
+      display:
+        label: "Corpus WER (%)"
+        scale: 100
+        digits: 2
+      status: OK
+    per_sample_wer_max:
+      source: "FUN_ASR_ZH_SAMPLE_WER_MAX"
+      json_file: "fun_asr_zh_results.json"
+      json_path: "summary.wer_per_sample_max"
+      worst: max
+      display:
+        label: "Max per-sample WER (%)"
+        scale: 100
+        digits: 2
+      status: OK

--- a/.github/scripts/prepare_omni_venv.sh
+++ b/.github/scripts/prepare_omni_venv.sh
@@ -52,6 +52,11 @@ if ! python -c "from whisper.normalizers import EnglishTextNormalizer" 2>/dev/nu
   uv pip install --force-reinstall --no-deps --no-cache openai-whisper==20250625
 fi
 
+if ! python -c "import zhon.hanzi" 2>/dev/null; then
+  echo "zhon missing from prepared venv, installing pinned dependency..."
+  uv pip install --force-reinstall --no-deps --no-cache zhon==2.1.1
+fi
+
 if ! bash "${SCRIPT_DIR}/validate_omni_venv_imports.sh" "${VENV_NAME}"; then
   exit 1
 fi

--- a/.github/scripts/validate_omni_venv_imports.sh
+++ b/.github/scripts/validate_omni_venv_imports.sh
@@ -25,6 +25,7 @@ import av
 import torch
 import transformers
 import sglang
+import zhon.hanzi
 from whisper.normalizers import EnglishTextNormalizer
 " 2>/dev/null; then
   echo "::error::${VENV_NAME} import probe failed at ${OMNI_CI_HOME}/${VENV_NAME}" >&2

--- a/.github/workflows/omni-ci.yaml
+++ b/.github/workflows/omni-ci.yaml
@@ -50,6 +50,7 @@ env:
   MOSS_TTS_MODEL_PATH: OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5
   QWEN3_ASR_MODEL_PATH: Qwen/Qwen3-ASR-1.7B
   MOSS_TRANSCRIBE_DIARIZE_MODEL_PATH: OpenMOSS-Team/MOSS-Transcribe-Diarize
+  FUN_ASR_MODEL_PATH: FunAudioLLM/Fun-ASR-Nano-2512-hf
 
 
 jobs:
@@ -166,7 +167,8 @@ jobs:
             "${QWEN3_ASR_MODEL_PATH}" \
             "${MOSS_TRANSCRIBE_DIARIZE_MODEL_PATH}" \
             "${TTS_MODEL_PATH}" \
-            "${MOSS_TTS_MODEL_PATH}"
+            "${MOSS_TTS_MODEL_PATH}" \
+            "${FUN_ASR_MODEL_PATH}"
 
       - name: Mark PR environment complete
         shell: bash

--- a/.github/workflows/test-asr-ci.yaml
+++ b/.github/workflows/test-asr-ci.yaml
@@ -21,10 +21,11 @@ env:
         || format('/data/omni-ci/run-{0}', github.run_id) }}
   MOSS_TRANSCRIBE_DIARIZE_MODEL_PATH: OpenMOSS-Team/MOSS-Transcribe-Diarize
   QWEN3_ASR_MODEL_PATH: Qwen/Qwen3-ASR-1.7B
+  FUN_ASR_MODEL_PATH: FunAudioLLM/Fun-ASR-Nano-2512-hf
 
 # Invoked by omni-ci.yaml after unit tests. Restores omni only.
 # DAG:
-#   stage-1-multi-speaker -> stage-2-seedtts
+#   stage-1-multi-speaker -> stage-2-seedtts -> stage-3-fun-asr
 
 jobs:
   stage-1-multi-speaker:
@@ -124,4 +125,56 @@ jobs:
             */qwen3_asr_results.json
           artifact-upload-name: asr-stage-seedtts-results
           artifact-upload-path: /tmp/**/qwen3_asr_results.json
+          summary-only: "true"
+
+  stage-3-fun-asr:
+    name: stage 3 - Fun-ASR SeedTTS
+    needs: stage-2-seedtts
+    if: always() && !cancelled()
+    runs-on: [self-hosted, h100]
+    timeout-minutes: 30
+    container:
+      image: crpi-n6adu6llixz83q37.cn-hangzhou.personal.cr.aliyuncs.com/hongccc/sglang-omni:dev
+      options: >-
+        --rm
+        -e NVIDIA_VISIBLE_DEVICES
+        -v /dev/shm:/dev/shm
+        -v /data/omni-ci:/data/omni-ci
+        -v /data/cache/huggingface:/github/home/.cache/huggingface
+        -v /data/cache/huggingface:/root/.cache/huggingface
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/omni-setup
+        with:
+          venv-name: omni
+
+      - name: Run Fun-ASR SeedTTS CI
+        shell: bash
+        run: |
+          source omni/bin/activate
+          export PYTHONPATH=$PWD
+          bash .github/scripts/run_flaky_pytest.sh \
+            pytest tests/test_model/test_asr_ci_fun_asr.py -v -s -x
+        env:
+          HF_ENDPOINT: https://huggingface.co
+          HF_HUB_DISABLE_XET: "1"
+          HF_HUB_ENABLE_HF_TRANSFER: "0"
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          FUN_ASR_MODEL_PATH: ${{ env.FUN_ASR_MODEL_PATH }}
+          TORCHINDUCTOR_CACHE_DIR: ${{ env.OMNI_CI_HOME }}/.torchinductor
+
+      - name: Post-stage cleanup
+        if: always()
+        uses: ./.github/actions/omni-post-stage
+        with:
+          stage-label: ASR stage 3 (Fun-ASR SeedTTS)
+          artifact-path-globs: |
+            */fun_asr_results.json
+            */fun_asr_zh_results.json
+          artifact-upload-name: asr-stage-fun-asr-results
+          artifact-upload-path: |
+            /tmp/**/fun_asr_results.json
+            /tmp/**/fun_asr_zh_results.json
           summary-only: "true"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -186,7 +186,7 @@ python -m benchmarks.eval.benchmark_omni_seedtts \
 | `eval/benchmark_omni_mmmu.py` | MMMU (VLM accuracy + speed) | Qwen3-Omni | `/v1/chat/completions` |
 | `eval/benchmark_omni_videomme.py` | Video-MME (video understanding) | Qwen3-Omni | `/v1/chat/completions` |
 | `eval/benchmark_omni_videoamme.py` | Video-AMME (video + audio question understanding) | Qwen3-Omni | `/v1/chat/completions` |
-| `eval/benchmark_asr_seedtts.py` | ASR concurrency scaling on SeedTTS EN | Qwen3-ASR, Fun-ASR | `/v1/audio/transcriptions` |
+| `eval/benchmark_asr_seedtts.py` | ASR concurrency scaling on SeedTTS EN/ZH | Qwen3-ASR, Fun-ASR | `/v1/audio/transcriptions` |
 
 See [tts_serving/README.md](tts_serving/README.md) for the TTS serving
 benchmark design, harness contract, scenario matrix, and Docker usage.

--- a/benchmarks/eval/benchmark_asr_seedtts.py
+++ b/benchmarks/eval/benchmark_asr_seedtts.py
@@ -54,6 +54,26 @@ Reference results on the full SeedTTS EN set (1088 clips, bf16, single RTX
 Both models saturated near concurrency 32. Fun-ASR completed every request at
 all measured levels; Qwen3-ASR skipped 72 requests at concurrency 64 on the
 single GPU. Audio duration was 4.69 s mean, 4.53 s median, and 8.81 s maximum.
+
+Reference results on a single H100 80 GB (bf16, DP=1, three repeats plus one
+discarded warmup per level):
+
+* Fun-ASR-Nano on the full SeedTTS EN set (1088 clips): 26.44 samples/s with
+  0.038 s mean latency at concurrency 1, saturating near 127.5 samples/s at
+  concurrency 16 through 32, with 0.0171 corpus WER at every level through 32.
+  The higher concurrency 64 figure counts completed samples only, after
+  request shedding.
+* Fun-ASR-Nano on the full SeedTTS ZH set (2020 clips): 167.4 samples/s at
+  concurrency 32 with 0.190 s mean latency and 0.0135 corpus WER at every
+  level through 32.
+* Qwen3-ASR-1.7B on the same GPU and EN set: 97.9 samples/s at concurrency 32
+  with 0.324 s mean latency and 0.0122 corpus WER. Fun-ASR-Nano was about 30
+  percent faster at saturation, and at concurrency 1 kept 0.038 s mean latency
+  versus 0.099 s for Qwen3-ASR, consistent with the 4080S comparison above.
+
+On the H100 both languages shed roughly 2 to 5 percent of requests at
+concurrency 64 with HTTP 500, because a single worker admits at most 16
+pending request builds. The full tables live in docs/cookbook/fun_asr.md.
 """
 
 from __future__ import annotations
@@ -69,6 +89,7 @@ import requests
 from benchmarks.dataset.prepare import DATASETS
 from benchmarks.dataset.seedtts import SampleInput, load_seedtts_samples
 from benchmarks.tasks.asr import (
+    FUN_ASR_MODEL_PATH,
     QWEN3_ASR_MODEL_PATH,
     build_asr_eval_results,
     run_asr_transcription,
@@ -269,7 +290,7 @@ def parse_args() -> argparse.Namespace:
         help=(
             "ASR model id served by the router. Defaults to "
             f"{QWEN3_ASR_MODEL_PATH}; use "
-            "FunAudioLLM/Fun-ASR-Nano-2512-hf for Fun-ASR-Nano."
+            f"{FUN_ASR_MODEL_PATH} for Fun-ASR-Nano."
         ),
     )
     parser.add_argument(

--- a/benchmarks/tasks/asr.py
+++ b/benchmarks/tasks/asr.py
@@ -48,6 +48,7 @@ OMNI_WHISPER_SAMPLE_RATE = 16000
 
 QWEN3_ASR_MODEL_PATH = "Qwen/Qwen3-ASR-1.7B"
 QWEN3_ASR_REQUEST_TIMEOUT_S = 300
+FUN_ASR_MODEL_PATH = "FunAudioLLM/Fun-ASR-Nano-2512-hf"
 # note (aaron): ASR transcription fan-out for WER, not TTS generation concurrency.
 DEFAULT_ASR_TRANSCRIBE_CONCURRENCY = 32
 # note (aaron): warmup requests sent before the timed window, per unit of concurrency.

--- a/docs/cookbook/fun_asr.md
+++ b/docs/cookbook/fun_asr.md
@@ -66,7 +66,7 @@ print(resp.json()["text"])
 
 ## Benchmarking
 
-SeedTTS EN concurrency/WER benchmarking for Fun-ASR-Nano lives in
+SeedTTS EN/ZH concurrency/WER benchmarking for Fun-ASR-Nano lives in
 `benchmarks/eval/benchmark_asr_seedtts.py`. Pass the Fun-ASR-Nano model
 path with `--model-path`.
 
@@ -87,6 +87,47 @@ python -m benchmarks.eval.benchmark_asr_seedtts \
   --model-path FunAudioLLM/Fun-ASR-Nano-2512-hf --port 8000 \
   --max-samples 20 --concurrencies 2 --repeats 1
 ```
+
+## Benchmark Results
+
+Measured on a single H100 80 GB (bf16, DP=1, default server settings)
+against the full SeedTTS sets. Each row is the mean of 3 runs with one
+discarded warmup pass per level. RTF is processing time divided by audio
+duration (lower is better). audio_s/s is seconds of audio transcribed per
+wall-clock second.
+
+SeedTTS EN (1088 clips, mean clip length 4.69 s). Corpus WER was 0.0171 at
+every level through concurrency 32:
+
+| Concurrency | Throughput (samples/s) | Mean latency (s) | p95 latency (s) | RTF mean | audio_s/s |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 26.44 | 0.038 | 0.047 | 0.0082 | 124 |
+| 2 | 42.55 | 0.047 | 0.058 | 0.0102 | 200 |
+| 4 | 62.35 | 0.064 | 0.088 | 0.0139 | 293 |
+| 8 | 90.24 | 0.088 | 0.121 | 0.0192 | 423 |
+| 16 | 127.46 | 0.125 | 0.167 | 0.0270 | 598 |
+| 32 | 127.44 | 0.249 | 0.334 | 0.0539 | 598 |
+| 64 | 137.98 | 0.453 | 0.542 | 0.0988 | 647 |
+
+SeedTTS ZH (2020 clips, mean clip length 4.68 s). Corpus WER, effectively
+character level after normalization, was 0.0135 at every level through
+concurrency 32:
+
+| Concurrency | Throughput (samples/s) | Mean latency (s) | p95 latency (s) | RTF mean | audio_s/s |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 26.96 | 0.037 | 0.048 | 0.0080 | 126 |
+| 2 | 45.97 | 0.043 | 0.056 | 0.0094 | 215 |
+| 4 | 58.28 | 0.069 | 0.093 | 0.0148 | 273 |
+| 8 | 79.76 | 0.100 | 0.138 | 0.0216 | 373 |
+| 16 | 138.23 | 0.116 | 0.160 | 0.0249 | 647 |
+| 32 | 167.42 | 0.190 | 0.264 | 0.0410 | 784 |
+| 64 | 165.75 | 0.381 | 0.475 | 0.0825 | 776 |
+
+At concurrency 64 a single worker rejects roughly 2 to 5 percent of
+requests with HTTP 500 by design, because the request-build backlog admits
+at most 16 pending builds per worker. Qwen3-ASR shows the same shedding
+behavior at this level. For higher client concurrency, serve behind the
+DP=2 managed router, matching the ASR CI topology.
 
 ## Known Limitations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "jiwer",
+    "zhon==2.1.1",
     "scipy>=1.10.0",
     "openai-whisper==20250625",
     # SeedTTS speaker similarity (WavLM-large SV head). The pip-installed

--- a/tests/test_model/test_asr_ci_fun_asr.py
+++ b/tests/test_model/test_asr_ci_fun_asr.py
@@ -1,0 +1,330 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SeedTTS ASR correctness CI for Fun-ASR-Nano.
+
+The test reuses the shared ASR SeedTTS harness against the SGLang Omni
+Fun-ASR router. The English split gates WER and speed at the calibrated
+concurrency. The Chinese split gates WER as well, since Fun-ASR-Nano targets
+multilingual and CJK transcription and a gate on English alone would miss
+regressions on its primary use case. Speed is gated on the English split
+only, because a second speed gate on the same topology would add flake
+surface without new signal.
+
+Author:
+Aaron Tian: https://github.com/db-ol
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from benchmarks.dataset.prepare import DATASETS
+from benchmarks.dataset.seedtts import SampleInput, load_seedtts_samples
+from benchmarks.eval.benchmark_asr_seedtts import (
+    FUN_ASR_MODEL_PATH,
+    run_asr_seedtts_once,
+)
+from benchmarks.metrics._format import format_benchmark_dataset_label
+from benchmarks.metrics.wer import print_asr_speed_summary, print_asr_wer_summary
+from benchmarks.tasks.asr import DEFAULT_ASR_TRANSCRIBE_CONCURRENCY
+from tests.test_model.omni_router_utils import (
+    ManagedRouterHandle,
+    launch_managed_router,
+    router_worker_traffic_guard,
+)
+from tests.utils import MetricCheckCollector, apply_wer_slack
+
+FUN_ASR_CI_MODEL_PATH = FUN_ASR_MODEL_PATH
+FUN_ASR_CONCURRENCY = DEFAULT_ASR_TRANSCRIBE_CONCURRENCY
+FUN_ASR_WARMUP_REQUESTS = FUN_ASR_CONCURRENCY * 2
+SEEDTTS_FUN_ASR_EN_SAMPLES = 1088
+SEEDTTS_FUN_ASR_ZH_SAMPLES = 2020
+SEEDTTS_ASR_DATASET_LABEL = format_benchmark_dataset_label(
+    dataset="seedtts",
+    repo_id=DATASETS["seedtts"],
+)
+
+# note (db-ol): WER references calibrated worst-of-5 on an idle 2x H100 80GB
+# DP=2 managed-router topology at concurrency 32 and confirmed identical on
+# the CI host. Speed references re-based to the CI host's worst-of-3
+# observation from the first stage-3 run, since its tail latency runs 8 to
+# 15 percent above the calibration box.
+FUN_ASR_EN_CORPUS_WER_MAX = 0.0171
+FUN_ASR_EN_SAMPLE_WER_MAX = 0.2857
+FUN_ASR_ZH_CORPUS_WER_MAX = 0.0136
+FUN_ASR_ZH_SAMPLE_WER_MAX = 0.8333
+FUN_ASR_THROUGHPUT_MIN = 58.14256776349853
+FUN_ASR_LATENCY_MEAN_MAX_S = 0.547
+FUN_ASR_LATENCY_P95_MAX_S = 0.809539619856514
+FUN_ASR_RTF_MEAN_MAX = 0.11876384088685976
+FUN_ASR_RTF_P95_MAX = 0.1815
+
+THRESHOLD_SLACK_HIGHER = 0.9
+THRESHOLD_SLACK_LOWER = 1.1
+
+FUN_ASR_EN_CORPUS_WER_THRESHOLD = apply_wer_slack(
+    FUN_ASR_EN_CORPUS_WER_MAX, THRESHOLD_SLACK_LOWER
+)
+FUN_ASR_EN_SAMPLE_WER_THRESHOLD = apply_wer_slack(
+    FUN_ASR_EN_SAMPLE_WER_MAX, THRESHOLD_SLACK_LOWER
+)
+FUN_ASR_ZH_CORPUS_WER_THRESHOLD = apply_wer_slack(
+    FUN_ASR_ZH_CORPUS_WER_MAX, THRESHOLD_SLACK_LOWER
+)
+FUN_ASR_ZH_SAMPLE_WER_THRESHOLD = apply_wer_slack(
+    FUN_ASR_ZH_SAMPLE_WER_MAX, THRESHOLD_SLACK_LOWER
+)
+FUN_ASR_THROUGHPUT_THRESHOLD = round(FUN_ASR_THROUGHPUT_MIN * THRESHOLD_SLACK_HIGHER, 3)
+FUN_ASR_LATENCY_MEAN_THRESHOLD_S = round(
+    FUN_ASR_LATENCY_MEAN_MAX_S * THRESHOLD_SLACK_LOWER, 3
+)
+FUN_ASR_LATENCY_P95_THRESHOLD_S = round(
+    FUN_ASR_LATENCY_P95_MAX_S * THRESHOLD_SLACK_LOWER, 3
+)
+FUN_ASR_RTF_MEAN_THRESHOLD = round(FUN_ASR_RTF_MEAN_MAX * THRESHOLD_SLACK_LOWER, 4)
+FUN_ASR_RTF_P95_THRESHOLD = round(FUN_ASR_RTF_P95_MAX * THRESHOLD_SLACK_LOWER, 4)
+STARTUP_TIMEOUT = 600
+
+
+def _require_cuda() -> None:
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for ASR correctness CI")
+
+
+@pytest.fixture(scope="module")
+def seedtts_en_samples() -> list[SampleInput]:
+    return load_seedtts_samples(
+        DATASETS["seedtts"],
+        max_samples=SEEDTTS_FUN_ASR_EN_SAMPLES,
+        split="en",
+    )
+
+
+@pytest.fixture(scope="module")
+def seedtts_zh_samples() -> list[SampleInput]:
+    return load_seedtts_samples(
+        DATASETS["seedtts"],
+        max_samples=SEEDTTS_FUN_ASR_ZH_SAMPLES,
+        split="zh",
+    )
+
+
+@pytest.fixture(scope="module")
+def asr_router_server(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> ManagedRouterHandle:
+    with launch_managed_router(
+        tmp_path_factory=tmp_path_factory,
+        model_path=FUN_ASR_CI_MODEL_PATH,
+        model_name=FUN_ASR_CI_MODEL_PATH,
+        worker_extra_args="",
+        wait_timeout=STARTUP_TIMEOUT,
+        log_prefix="fun_asr_router_logs",
+    ) as router:
+        yield router
+
+
+def _format_high_wer_sample(sample: dict) -> str:
+    return "\n".join(
+        [
+            f"sample_id={sample['id']}",
+            f"ref_text={sample['ref_text']!r}",
+            f"omni={sample['hyp_text']!r}",
+            f"sample_wer={sample['wer']:.4f}",
+            f"ref_norm={sample['ref_norm']!r}",
+            f"omni_norm={sample['hyp_norm']!r}",
+        ]
+    )
+
+
+def _collect_high_wer_samples(results: dict, threshold: float) -> list[str]:
+    return [
+        _format_high_wer_sample(sample)
+        for sample in results["per_sample"]
+        if sample["is_success"]
+        and sample["wer"] is not None
+        and sample["wer"] > threshold
+    ]
+
+
+@pytest.mark.benchmark
+def test_fun_asr_matches_seedtts_reference_text_en(
+    seedtts_en_samples: list[SampleInput],
+    asr_router_server: ManagedRouterHandle,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    _require_cuda()
+    checks = MetricCheckCollector("Fun-ASR EN correctness and speed")
+    checks.check(
+        len(seedtts_en_samples) == SEEDTTS_FUN_ASR_EN_SAMPLES,
+        f"Expected {SEEDTTS_FUN_ASR_EN_SAMPLES} SeedTTS samples, "
+        f"got {len(seedtts_en_samples)}",
+    )
+    if not seedtts_en_samples:
+        checks.assert_all()
+
+    with router_worker_traffic_guard(
+        asr_router_server,
+        label="Fun-ASR SeedTTS EN",
+    ) as router_guard:
+        results = asyncio.run(
+            run_asr_seedtts_once(
+                seedtts_en_samples,
+                host="127.0.0.1",
+                port=asr_router_server.port,
+                model_path=FUN_ASR_CI_MODEL_PATH,
+                lang="en",
+                concurrency=FUN_ASR_CONCURRENCY,
+                warmup=FUN_ASR_WARMUP_REQUESTS,
+                disable_tqdm=False,
+            )
+        )
+    summary = results["summary"]
+    speed = results["speed"]
+
+    high_wer_samples = _collect_high_wer_samples(
+        results, FUN_ASR_EN_SAMPLE_WER_THRESHOLD
+    )
+
+    print_asr_wer_summary(
+        summary, FUN_ASR_CI_MODEL_PATH, dataset=SEEDTTS_ASR_DATASET_LABEL
+    )
+    print_asr_speed_summary(
+        speed, FUN_ASR_CI_MODEL_PATH, dataset=SEEDTTS_ASR_DATASET_LABEL
+    )
+
+    results_path = tmp_path_factory.getbasetemp() / "fun_asr_results.json"
+    results_path.write_text(
+        json.dumps(
+            {
+                "summary": summary,
+                "speed": speed,
+                "router_ready_s": asr_router_server.router_ready_s,
+            },
+            indent=2,
+        )
+    )
+
+    corpus_wer = summary["corpus_wer"]
+    throughput_samples_per_s = speed["throughput_samples_per_s"]
+    latency_mean_s = speed["latency_mean_s"]
+    latency_p95_s = speed["latency_p95_s"]
+    rtf_mean = speed["rtf_mean"]
+    rtf_p95 = speed["rtf_p95"]
+
+    checks.check(
+        corpus_wer <= FUN_ASR_EN_CORPUS_WER_THRESHOLD,
+        f"Fun-ASR EN corpus WER {corpus_wer:.4f} exceeds "
+        f"{FUN_ASR_EN_CORPUS_WER_THRESHOLD:.4f}",
+    )
+    checks.check(
+        not high_wer_samples,
+        "Fun-ASR high-WER SeedTTS EN samples:\n" + "\n\n".join(high_wer_samples),
+    )
+    checks.check(
+        throughput_samples_per_s >= FUN_ASR_THROUGHPUT_THRESHOLD,
+        f"Fun-ASR throughput {throughput_samples_per_s:.3f} samples/s "
+        f"is below {FUN_ASR_THROUGHPUT_THRESHOLD:.3f}",
+    )
+    checks.check(
+        latency_mean_s <= FUN_ASR_LATENCY_MEAN_THRESHOLD_S,
+        f"Fun-ASR mean latency {latency_mean_s:.3f}s exceeds "
+        f"{FUN_ASR_LATENCY_MEAN_THRESHOLD_S:.3f}s",
+    )
+    checks.check(
+        latency_p95_s <= FUN_ASR_LATENCY_P95_THRESHOLD_S,
+        f"Fun-ASR p95 latency {latency_p95_s:.3f}s exceeds "
+        f"{FUN_ASR_LATENCY_P95_THRESHOLD_S:.3f}s",
+    )
+    checks.check(
+        rtf_mean <= FUN_ASR_RTF_MEAN_THRESHOLD,
+        f"Fun-ASR mean RTF {rtf_mean:.4f} exceeds " f"{FUN_ASR_RTF_MEAN_THRESHOLD:.4f}",
+    )
+    checks.check(
+        rtf_p95 <= FUN_ASR_RTF_P95_THRESHOLD,
+        f"Fun-ASR p95 RTF {rtf_p95:.4f} exceeds " f"{FUN_ASR_RTF_P95_THRESHOLD:.4f}",
+    )
+    router_guard.assert_served(
+        min_total_requests=len(seedtts_en_samples),
+        min_worker_share=0.40,
+    )
+    checks.assert_all()
+
+
+@pytest.mark.benchmark
+def test_fun_asr_matches_seedtts_reference_text_zh(
+    seedtts_zh_samples: list[SampleInput],
+    asr_router_server: ManagedRouterHandle,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    _require_cuda()
+    checks = MetricCheckCollector("Fun-ASR ZH correctness")
+    checks.check(
+        len(seedtts_zh_samples) == SEEDTTS_FUN_ASR_ZH_SAMPLES,
+        f"Expected {SEEDTTS_FUN_ASR_ZH_SAMPLES} SeedTTS samples, "
+        f"got {len(seedtts_zh_samples)}",
+    )
+    if not seedtts_zh_samples:
+        checks.assert_all()
+
+    with router_worker_traffic_guard(
+        asr_router_server,
+        label="Fun-ASR SeedTTS ZH",
+    ) as router_guard:
+        results = asyncio.run(
+            run_asr_seedtts_once(
+                seedtts_zh_samples,
+                host="127.0.0.1",
+                port=asr_router_server.port,
+                model_path=FUN_ASR_CI_MODEL_PATH,
+                lang="zh",
+                concurrency=FUN_ASR_CONCURRENCY,
+                warmup=FUN_ASR_WARMUP_REQUESTS,
+                disable_tqdm=False,
+            )
+        )
+    summary = results["summary"]
+    speed = results["speed"]
+
+    high_wer_samples = _collect_high_wer_samples(
+        results, FUN_ASR_ZH_SAMPLE_WER_THRESHOLD
+    )
+
+    print_asr_wer_summary(
+        summary, FUN_ASR_CI_MODEL_PATH, dataset=SEEDTTS_ASR_DATASET_LABEL
+    )
+    print_asr_speed_summary(
+        speed, FUN_ASR_CI_MODEL_PATH, dataset=SEEDTTS_ASR_DATASET_LABEL
+    )
+
+    results_path = tmp_path_factory.getbasetemp() / "fun_asr_zh_results.json"
+    results_path.write_text(
+        json.dumps(
+            {
+                "summary": summary,
+                "speed": speed,
+            },
+            indent=2,
+        )
+    )
+
+    corpus_wer = summary["corpus_wer"]
+
+    checks.check(
+        corpus_wer <= FUN_ASR_ZH_CORPUS_WER_THRESHOLD,
+        f"Fun-ASR ZH corpus WER {corpus_wer:.4f} exceeds "
+        f"{FUN_ASR_ZH_CORPUS_WER_THRESHOLD:.4f}",
+    )
+    checks.check(
+        not high_wer_samples,
+        "Fun-ASR high-WER SeedTTS ZH samples:\n" + "\n\n".join(high_wer_samples),
+    )
+    router_guard.assert_served(
+        min_total_requests=len(seedtts_zh_samples),
+        min_worker_share=0.40,
+    )
+    checks.assert_all()

--- a/tests/unit_test/benchmarks/test_dataset_regressions.py
+++ b/tests/unit_test/benchmarks/test_dataset_regressions.py
@@ -210,15 +210,18 @@ def test_tune_ci_threshold_asr_config_tracks_current_asr_ci_stages() -> None:
     assert config["test_globs"] == [
         "tests/test_model/test_asr_ci_multi_speaker.py",
         "tests/test_model/test_asr_ci_seedtts.py",
+        "tests/test_model/test_asr_ci_fun_asr.py",
     ]
     assert "tests/test_model/test_asr_ci.py" not in config["test_globs"]
     assert config["gpus_per_test"] == {
         "test_asr_ci_multi_speaker.py": 2,
         "test_asr_ci_seedtts.py": 2,
+        "test_asr_ci_fun_asr.py": 2,
     }
     assert config["hf_model_ids_by_test"] == {
         "test_asr_ci_multi_speaker.py": ["OpenMOSS-Team/MOSS-Transcribe-Diarize"],
         "test_asr_ci_seedtts.py": ["Qwen/Qwen3-ASR-1.7B"],
+        "test_asr_ci_fun_asr.py": ["FunAudioLLM/Fun-ASR-Nano-2512-hf"],
     }
     assert {
         "zhaochenyang20/movies800time",
@@ -229,6 +232,7 @@ def test_tune_ci_threshold_asr_config_tracks_current_asr_ci_stages() -> None:
     assert set(config["metric_sources"]) == {
         "test_asr_ci_multi_speaker.py",
         "test_asr_ci_seedtts.py",
+        "test_asr_ci_fun_asr.py",
     }
     assert (
         config["metric_sources"]["test_asr_ci_multi_speaker.py"]["json_file"]
@@ -252,6 +256,9 @@ def test_tune_ci_threshold_asr_config_tracks_current_asr_ci_stages() -> None:
         "multi_speaker_stream_speed",
         "seedtts_wer",
         "seedtts_speed",
+        "fun_asr_en_wer",
+        "fun_asr_en_speed",
+        "fun_asr_zh_wer",
     }
     assert stages["multi_speaker_diarization"]["test"] == (
         "tests/test_model/test_asr_ci_multi_speaker.py"
@@ -283,6 +290,14 @@ def test_tune_ci_threshold_asr_config_tracks_current_asr_ci_stages() -> None:
     )
     assert stages["seedtts_wer"]["test"] == "tests/test_model/test_asr_ci_seedtts.py"
     assert stages["seedtts_wer"]["expected_samples"] == 1088
+    assert stages["fun_asr_en_wer"]["test"] == "tests/test_model/test_asr_ci_fun_asr.py"
+    assert stages["fun_asr_en_wer"]["expected_samples"] == 1088
+    assert stages["fun_asr_zh_wer"]["expected_samples"] == 2020
+    assert (
+        stages["fun_asr_zh_wer"]["metrics"]["corpus_wer"]["json_file"]
+        == "fun_asr_zh_results.json"
+    )
+    assert "throughput_qps" in stages["fun_asr_en_speed"]["metrics"]
 
 
 def test_tune_ci_threshold_tts_config_no_longer_owns_asr_ci_stages() -> None:


### PR DESCRIPTION
## Summary
- add the Chinese punctuation dependency used by benchmarks.tasks.asr.normalize_text to pyproject.toml
- include zhon.hanzi in the reusable Omni venv import probe so old PR-scoped CI homes rebuild instead of silently reusing an environment that lacks zhon

## Why
#1093 stage 3 currently fails in the Fun-ASR SeedTTS ZH check with ModuleNotFoundError: No module named zhon. prepare_omni_venv.sh already has a fallback install, but reused venvs can pass the current import probe without zhon and skip the fresh prepare path.

## Validation
- python3 tomllib assertion: pyproject contains zhon==2.1.1
- bash -n .github/scripts/validate_omni_venv_imports.sh .github/scripts/prepare_omni_venv.sh .github/scripts/validate_omni_env_reusable.sh
- git diff --check
- isolated venv smoke: pip install zhon==2.1.1; import zhon.hanzi

Companion for #1093.