### PR TITLE
[Qwen3-Omni Perf] Expose Talker partial-start threshold via CLI

### DIFF
--- a/docs/basic_usage/qwen3_omni.md
+++ b/docs/basic_usage/qwen3_omni.md
@@ -232,6 +232,24 @@ python examples/run_omni.py qwen3-speech-server \
 the global value for that stage. Values must be greater than `0` and less than
 `1`.
 
+To start the Qwen3-Omni Talker after the earliest supported three usable
+Thinker chunks, enable partial start and set its threshold explicitly:
+
+```bash
+sgl-omni serve \
+  --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
+  --config examples/configs/qwen3_omni_colocated_h100_bf16.yaml \
+  --colocate \
+  --talker-partial-start on \
+  --talker-partial-start-min-chunks 3 \
+  --port 8008
+```
+
+The minimum is three chunks because Talker prefill requires that layout.
+Supplying the threshold without `--talker-partial-start on` is rejected.
+This option does not change the default partial-start enablement of either
+the split or colocated topology.
+
 ## Single-GPU FP8 on H100/H20
 
 SGLang-Omni can also serve native FP8 Qwen3-Omni checkpoints. Native FP8 uses

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -1132,7 +1132,8 @@ def serve(
             "--talker-torch-compile",
             "--talker_torch_compile",
             help=(
-                "torch.compile mode for supported SGLang talker stage: default|on|off."
+                "torch.compile mode for supported SGLang talker stage: "
+                "default|on|off."
             ),
         ),
     ] = "default",

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -767,10 +767,23 @@ def apply_partial_start_cli_overrides(
     pipeline_config: PipelineConfig,
     *,
     talker_partial_start: str,
+    talker_partial_start_min_chunks: int | None = None,
 ) -> PipelineConfig:
     mode = _normalize_stage_toggle_mode("talker_partial_start", talker_partial_start)
-    if mode == "default":
+    if mode == "default" and talker_partial_start_min_chunks is None:
         return pipeline_config
+    if talker_partial_start_min_chunks is not None:
+        from sglang_omni.models.qwen3_omni.config import MIN_PARTIAL_START_CHUNKS
+
+        if mode != "on":
+            raise typer.BadParameter(
+                "--talker-partial-start-min-chunks requires --talker-partial-start on"
+            )
+        if talker_partial_start_min_chunks < MIN_PARTIAL_START_CHUNKS:
+            raise typer.BadParameter(
+                "--talker-partial-start-min-chunks must be >= "
+                f"{MIN_PARTIAL_START_CHUNKS}"
+            )
     stage_name = _resolve_talker_stage(
         pipeline_config,
         flag_name="--talker-partial-start",
@@ -786,11 +799,10 @@ def apply_partial_start_cli_overrides(
                 "--talker-partial-start currently supports only Qwen3-Omni "
                 f"talker; stage {stage.name!r} uses factory {stage.factory!r}"
             )
-    _apply_factory_args_updates(
-        pipeline_config,
-        matching_stages,
-        {"enable_partial_start": mode == "on"},
-    )
+    updates: dict[str, object] = {"enable_partial_start": mode == "on"}
+    if talker_partial_start_min_chunks is not None:
+        updates["partial_start_min_chunks"] = talker_partial_start_min_chunks
+    _apply_factory_args_updates(pipeline_config, matching_stages, updates)
     return pipeline_config
 
 
@@ -1094,6 +1106,18 @@ def serve(
             ),
         ),
     ] = "default",
+    talker_partial_start_min_chunks: Annotated[
+        int | None,
+        typer.Option(
+            "--talker-partial-start-min-chunks",
+            "--talker_partial_start_min_chunks",
+            help=(
+                "Start the Qwen3-Omni talker after this many usable thinker "
+                "chunks. Requires --talker-partial-start on. Omit to use the "
+                "pipeline default."
+            ),
+        ),
+    ] = None,
     thinker_torch_compile: Annotated[
         str,
         typer.Option(
@@ -1108,8 +1132,7 @@ def serve(
             "--talker-torch-compile",
             "--talker_torch_compile",
             help=(
-                "torch.compile mode for supported SGLang talker stage: "
-                "default|on|off."
+                "torch.compile mode for supported SGLang talker stage: default|on|off."
             ),
         ),
     ] = "default",
@@ -1300,6 +1323,7 @@ def serve(
     merged_config = apply_partial_start_cli_overrides(
         merged_config,
         talker_partial_start=talker_partial_start,
+        talker_partial_start_min_chunks=talker_partial_start_min_chunks,
     )
 
     if _should_print_merged_config(colocate=colocate, log_level=log_level):

--- a/tests/unit_test/qwen3_omni/test_cli.py
+++ b/tests/unit_test/qwen3_omni/test_cli.py
@@ -89,9 +89,9 @@ def _set_colocated_runtime(config: Qwen3OmniSpeechColocatedPipelineConfig) -> No
         "talker_ar": 0.35,
         "code2wav": 0.05,
     }.items():
-        _stage(
-            config, stage_name
-        ).runtime.resources.total_gpu_memory_fraction = fraction
+        _stage(config, stage_name).runtime.resources.total_gpu_memory_fraction = (
+            fraction
+        )
 
 
 @patch("sglang_omni.cli.serve.ConfigManager.from_model_path")

--- a/tests/unit_test/qwen3_omni/test_cli.py
+++ b/tests/unit_test/qwen3_omni/test_cli.py
@@ -469,3 +469,17 @@ def test_partial_start_cli_threshold_rejects_disabled_mode():
             talker_partial_start="off",
             talker_partial_start_min_chunks=5,
         )
+
+
+def test_partial_start_cli_threshold_rejects_default_mode():
+    config = Qwen3OmniSpeechColocatedPipelineConfig(model_path="dummy")
+
+    with pytest.raises(
+        typer.BadParameter,
+        match="requires --talker-partial-start on",
+    ):
+        apply_partial_start_cli_overrides(
+            config,
+            talker_partial_start="default",
+            talker_partial_start_min_chunks=5,
+        )

--- a/tests/unit_test/qwen3_omni/test_cli.py
+++ b/tests/unit_test/qwen3_omni/test_cli.py
@@ -67,6 +67,7 @@ def _serve_kwargs(**overrides):
         thinker_cuda_graph="default",
         talker_cuda_graph="default",
         talker_partial_start="default",
+        talker_partial_start_min_chunks=None,
         thinker_torch_compile="default",
         talker_torch_compile="default",
         thinker_torch_compile_max_bs=None,
@@ -88,9 +89,9 @@ def _set_colocated_runtime(config: Qwen3OmniSpeechColocatedPipelineConfig) -> No
         "talker_ar": 0.35,
         "code2wav": 0.05,
     }.items():
-        _stage(config, stage_name).runtime.resources.total_gpu_memory_fraction = (
-            fraction
-        )
+        _stage(
+            config, stage_name
+        ).runtime.resources.total_gpu_memory_fraction = fraction
 
 
 @patch("sglang_omni.cli.serve.ConfigManager.from_model_path")
@@ -377,17 +378,29 @@ def test_partial_start_default_is_on():
 def test_partial_start_cli_override_can_disable_and_enable():
     config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
 
-    apply_partial_start_cli_overrides(config, talker_partial_start="off")
+    apply_partial_start_cli_overrides(
+        config,
+        talker_partial_start="off",
+        talker_partial_start_min_chunks=None,
+    )
     talker = next(stage for stage in config.stages if stage.name == "talker_ar")
     assert resolve_stage_factory_args(talker, config)["enable_partial_start"] is False
 
-    apply_partial_start_cli_overrides(config, talker_partial_start="on")
+    apply_partial_start_cli_overrides(
+        config,
+        talker_partial_start="on",
+        talker_partial_start_min_chunks=None,
+    )
     assert resolve_stage_factory_args(talker, config)["enable_partial_start"] is True
 
 
 def test_partial_start_cli_default_preserves_config_default():
     config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
-    apply_partial_start_cli_overrides(config, talker_partial_start="default")
+    apply_partial_start_cli_overrides(
+        config,
+        talker_partial_start="default",
+        talker_partial_start_min_chunks=None,
+    )
     talker = next(stage for stage in config.stages if stage.name == "talker_ar")
     assert resolve_stage_factory_args(talker, config)["enable_partial_start"] is True
 
@@ -395,7 +408,11 @@ def test_partial_start_cli_default_preserves_config_default():
 def test_partial_start_cli_invalid_mode_rejected():
     config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
     with pytest.raises(typer.BadParameter):
-        apply_partial_start_cli_overrides(config, talker_partial_start="bogus")
+        apply_partial_start_cli_overrides(
+            config,
+            talker_partial_start="bogus",
+            talker_partial_start_min_chunks=None,
+        )
 
 
 def test_partial_start_cli_rejects_unsupported_config_with_stable_message():
@@ -404,4 +421,51 @@ def test_partial_start_cli_rejects_unsupported_config_with_stable_message():
         typer.BadParameter,
         match="--talker-partial-start is not supported by Qwen3OmniPipelineConfig",
     ):
-        apply_partial_start_cli_overrides(config, talker_partial_start="on")
+        apply_partial_start_cli_overrides(
+            config,
+            talker_partial_start="on",
+            talker_partial_start_min_chunks=None,
+        )
+
+
+def test_partial_start_cli_threshold_reaches_resolved_talker_args():
+    config = Qwen3OmniSpeechColocatedPipelineConfig(model_path="dummy")
+
+    apply_partial_start_cli_overrides(
+        config,
+        talker_partial_start="on",
+        talker_partial_start_min_chunks=8,
+    )
+
+    talker = next(stage for stage in config.stages if stage.name == "talker_ar")
+    talker_args = resolve_stage_factory_args(talker, config)
+    assert talker_args["enable_partial_start"] is True
+    assert talker_args["partial_start_min_chunks"] == 8
+
+
+def test_partial_start_cli_threshold_rejects_below_safe_floor():
+    config = Qwen3OmniSpeechColocatedPipelineConfig(model_path="dummy")
+
+    with pytest.raises(
+        typer.BadParameter,
+        match="--talker-partial-start-min-chunks must be >= 3",
+    ):
+        apply_partial_start_cli_overrides(
+            config,
+            talker_partial_start="on",
+            talker_partial_start_min_chunks=2,
+        )
+
+
+def test_partial_start_cli_threshold_rejects_disabled_mode():
+    config = Qwen3OmniSpeechColocatedPipelineConfig(model_path="dummy")
+
+    with pytest.raises(
+        typer.BadParameter,
+        match="requires --talker-partial-start on",
+    ):
+        apply_partial_start_cli_overrides(
+            config,
+            talker_partial_start="off",
+            talker_partial_start_min_chunks=5,
+        )


### PR DESCRIPTION
## Motivation

Qwen3-Omni already has a partial-start state machine for the Talker: it can begin prefill after a few usable Thinker chunks instead of waiting for the full Thinker output. The threshold is currently fixed (`partial_start_min_chunks=5` in the talker factory args) with no way to tune it from the CLI. Starting at the layout floor of three chunks gets first audio out earlier.

## Modifications

- `sglang_omni/cli/serve.py`: add `--talker-partial-start-min-chunks N` to `sgl-omni serve`. `apply_partial_start_cli_overrides` rejects the flag unless `--talker-partial-start on` is set, enforces `N >= MIN_PARTIAL_START_CHUNKS` (3, the Talker prefill layout floor), and propagates the value into resolved talker factory args.
- Topology defaults are untouched: split stays enabled at its existing threshold, colocated stays disabled unless explicitly turned on.
- `tests/unit_test/qwen3_omni/test_cli.py`: resolved-argument test through the real config resolution path, plus rejection tests for below-floor, `off`+threshold, and `default`+threshold.
- `docs/basic_usage/qwen3_omni.md`: launch example for threshold 3 on the colocated H100 BF16 config.

## Benchmarking and Profiling

H100 A/B, threshold 3 (candidate) vs threshold 5 (control): colocated BF16, fresh server per arm, alternating arm order, 8 warmup + 64 measured native-audio requests per arm, temperature 0, fixed seed.

Correctness: at concurrency 1, control vs candidate are bit-identical on every field — text, chunk count, chunk layout, PCM (8/8 each). The threshold changes only the streaming start schedule, not generated content.

| conc | pair | request/s | TTFA p50 |
|------|------|-----------|----------|
| c8   | 1    | −1.40%    | −7.11%   |
| c8   | 2    | −0.86%    | −29.34%  |
| c8   | 3    | +0.15%    | −3.98%   |
| c16  | 1    | −0.44%    | −4.28%   |
| c16  | 2    | +3.58%    | +2.54%   |
| c16  | 3    | −0.29%    | −3.60%   |

Read: throughput is neutral (arm means ~0%). TTFA improves consistently at c8 (−4% to −29%; magnitude depends on talker batch phase alignment) and is mixed at c16. This flag is therefore an explicit first-audio-latency tuning control, not a throughput optimization.

Methodology note: PCM is not bit-deterministic under concurrent batching — a server diverges from itself on ~3/8 requests at c8 (vocoder batch float effects, independent of this flag). Output exactness is therefore proven at c1, and text-exactness is enforced per pair at c8/c16.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [x] Add unit tests.
- [x] Update documentation.

https://claude.ai/code/session_011nbE2gg4u5gi7EbCVyymMp
