### PR TITLE
[Perf][Higgs TTS] Keep decode-launch sampling params device-side; cache row indices across unchanged steps

### DIFF
--- a/sglang_omni/model_runner/base.py
+++ b/sglang_omni/model_runner/base.py
@@ -214,7 +214,7 @@ class ModelRunner:
         )
 
     def execute_resolve(
-        self, pending: "_PendingStep | None"
+        self, pending: "_PendingStep | None", skip_rids: set[str] | None = None
     ) -> ModelRunnerOutput | None:
         """Consume a launched decode step: wait on its event (non-blocking
         ``query()``, else ``synchronize()``), read its ``launch_buf`` (a device
@@ -222,6 +222,9 @@ class ModelRunner:
         (``post_decode_resolve``), then
         finalize sampling/output. Returns that step's ``ModelRunnerOutput``,
         or None if ``pending`` is None (first iteration / after a drain).
+
+        ``skip_rids``: caller-precomputed prior-step finished/retracted set
+        (same predicate as below); ``None`` computes it here.
         """
         if pending is None:
             return None
@@ -230,13 +233,15 @@ class ModelRunner:
         else:
             pending.event.synchronize()
             self._async_query_miss += 1
-        # Skip reqs finished or retracted in a prior (lagged) step so _finalize
-        # neither re-emits nor re-frees their KV (mirrors _resolve_and_process).
-        skip_rids = {
-            req.request_id
-            for req in pending.scheduler_output.requests
-            if req.data.req.finished() or self._req_is_retracted(req.data.req)
-        }
+        if skip_rids is None:
+            # Skip reqs finished or retracted in a prior (lagged) step so
+            # _finalize neither re-emits nor re-frees their KV (mirrors
+            # _resolve_and_process).
+            skip_rids = {
+                req.request_id
+                for req in pending.scheduler_output.requests
+                if req.data.req.finished() or self._req_is_retracted(req.data.req)
+            }
         self.post_decode_resolve(
             pending.launch_buf,
             pending.batch_result,

--- a/sglang_omni/models/higgs_tts/model.py
+++ b/sglang_omni/models/higgs_tts/model.py
@@ -168,6 +168,9 @@ class HiggsTTSModel(nn.Module):
         self._free_rows: list[int] = list(
             range(self._sampler_pool_max_running_requests)
         )
+        # Bumped on release: invalidates the runner's row-indices cache even
+        # if a released request id is later reused with a different row.
+        self._row_epoch = 0
         self._output_codes: dict[str, list[torch.Tensor]] = {}
         cg_device = self.backbone.model.embed_tokens.weight.device
         self._cg_row_indices = torch.zeros(
@@ -262,6 +265,7 @@ class HiggsTTSModel(nn.Module):
         row = self._rid_to_row.pop(req_id, None)
         if row is not None:
             self._free_rows.append(row)
+            self._row_epoch += 1
         self._output_codes.pop(req_id, None)
 
     def reset_request(self, req_id: str) -> None:

--- a/sglang_omni/models/higgs_tts/model_runner.py
+++ b/sglang_omni/models/higgs_tts/model_runner.py
@@ -17,7 +17,6 @@ import torch
 from sglang.srt.managers.schedule_batch import FINISH_MATCHED_TOKEN
 
 from sglang_omni.model_runner.base import ModelRunner
-from sglang_omni.models.higgs_tts.model import _flat_sampling_attr
 from sglang_omni.models.higgs_tts.sampler import K_MAX, selected_token_logprobs
 from sglang_omni.models.higgs_tts.text_tokenizer import AUDIO_PLACEHOLDER_ID
 from sglang_omni.models.higgs_tts.utils import EOC_ID
@@ -33,8 +32,24 @@ from sglang_omni.scheduling.streaming_vocoder import INITIAL_CODEC_CHUNK_FRAMES_
 logger = logging.getLogger(__name__)
 
 
+def _flat_nonempty(vals) -> torch.Tensor | None:
+    """Flatten a sampling attr to 1-D; empty behaves like absent (defaults)."""
+    if vals is None:
+        return None
+    t = torch.as_tensor(vals).reshape(-1)
+    return t if t.numel() else None
+
+
 class HiggsTTSModelRunner(ModelRunner):
     """ModelRunner for :class:`HiggsTTSModel`."""
+
+    # Decode row-indices cache, valid while (request-id list, padded bs, row
+    # epoch) is unchanged; the epoch guards the release + request-id-reuse
+    # case. Class-level defaults so fixtures built via object.__new__ inherit.
+    _rows_cache: torch.Tensor | None = None
+    _rows_cache_ids: list[str] | None = None
+    _rows_cache_bs: int = 0
+    _rows_cache_epoch: int = -1
 
     def __init__(self, tp_worker: Any, output_processor: Any) -> None:
         super().__init__(tp_worker, output_processor)
@@ -169,11 +184,26 @@ class HiggsTTSModelRunner(ModelRunner):
 
         model._sampler_pool.reset_row(model._padding_row)
 
-        rows_py: list[int] = [model.acquire_row(req.request_id) for req in requests]
-        rows_py.extend([model._padding_row] * (bs - n_real))
-        model._cg_row_indices[:bs] = torch.tensor(
-            rows_py, dtype=torch.long, device=model._cg_row_indices.device
-        )
+        req_ids = [req.request_id for req in requests]
+        epoch = model._row_epoch
+        if (
+            req_ids == self._rows_cache_ids
+            and bs == self._rows_cache_bs
+            and epoch == self._rows_cache_epoch
+        ):
+            # note (Jiaxin Deng): restore from the cached copy, not skip; the
+            # lookahead overrun guard below mutates _cg_row_indices in place.
+            model._cg_row_indices[:bs].copy_(self._rows_cache)
+        else:
+            rows_py: list[int] = [model.acquire_row(rid) for rid in req_ids]
+            rows_py.extend([model._padding_row] * (bs - n_real))
+            model._cg_row_indices[:bs] = torch.tensor(
+                rows_py, dtype=torch.long, device=model._cg_row_indices.device
+            )
+            self._rows_cache = model._cg_row_indices[:bs].clone()
+            self._rows_cache_ids = req_ids
+            self._rows_cache_bs = bs
+            self._rows_cache_epoch = epoch
 
         if self._async_enabled and is_lookahead and n_real > 0:
             # Async-lookahead overrun guard (GPU-side, no host sync): a request
@@ -194,23 +224,33 @@ class HiggsTTSModelRunner(ModelRunner):
                 done, torch.full_like(rows_t_real, model._padding_row), rows_t_real
             )
 
-        temps, top_ps, top_ks = self._extract_decode_sampling_params(
-            forward_batch, n_real
-        )
-        temps.extend([1.0] * (bs - n_real))
-        top_ps.extend([1.0] * (bs - n_real))
-        model._cg_temperature[:bs] = torch.tensor(
-            temps, dtype=torch.float32, device=model._cg_temperature.device
-        )
-        model._cg_top_p[:bs] = torch.tensor(
-            top_ps, dtype=torch.float32, device=model._cg_top_p.device
-        )
-
-        top_k_vals = [(tk if (tk is not None and tk > 0) else K_MAX) for tk in top_ks]
-        top_k_vals.extend([K_MAX] * (bs - n_real))
-        model._cg_top_k_buf[:bs] = torch.tensor(
-            top_k_vals, dtype=torch.long, device=model._cg_top_k_buf.device
-        )
+        # note (Jiaxin Deng): device-side copies only; a .cpu()/.tolist() here
+        # is a stream-syncing D2H on the per-step launch path.
+        sampling_info = getattr(forward_batch, "sampling_info", None)
+        temps = _flat_nonempty(getattr(sampling_info, "temperatures", None))
+        if temps is not None:
+            model._cg_temperature[:n_real].copy_(temps[:n_real])
+        else:
+            model._cg_temperature[:n_real].fill_(1.0)
+        top_ps = _flat_nonempty(getattr(sampling_info, "top_ps", None))
+        if top_ps is not None:
+            model._cg_top_p[:n_real].copy_(top_ps[:n_real])
+        else:
+            model._cg_top_p[:n_real].fill_(1.0)
+        top_ks = _flat_nonempty(getattr(sampling_info, "top_ks", None))
+        if top_ks is not None:
+            tks = top_ks[:n_real].to(torch.long)
+            # top_k outside (0, K_MAX) (incl. sglang's TOP_K_ALL sentinel for
+            # unspecified top_k) normalizes to K_MAX = no-op filter.
+            model._cg_top_k_buf[:n_real].copy_(
+                torch.where((tks > 0) & (tks < K_MAX), tks, torch.full_like(tks, K_MAX))
+            )
+        else:
+            model._cg_top_k_buf[:n_real].fill_(K_MAX)
+        if bs > n_real:
+            model._cg_temperature[n_real:bs].fill_(1.0)
+            model._cg_top_p[n_real:bs].fill_(1.0)
+            model._cg_top_k_buf[n_real:bs].fill_(K_MAX)
 
         rows_t = model._cg_row_indices[:bs]
         pool = model._sampler_pool
@@ -220,33 +260,6 @@ class HiggsTTSModelRunner(ModelRunner):
         model._cg_active_last_codes[:bs] = pool.last_codes[rows_t]
         model._cg_active_seeds[:bs] = pool.seeds[rows_t]
         model._cg_active_step_count[:bs] = pool.step_count[rows_t]
-
-    @staticmethod
-    def _extract_decode_sampling_params(forward_batch, n_real: int):
-        """Pull per-row temperature / top_p / top_k off sglang's
-        ``sampling_info`` with safe defaults. ``top_k`` values outside
-        ``(0, K_MAX)`` (including sglang's ``TOP_K_ALL`` sentinel for
-        unspecified top_k) are normalized to ``None`` — the downstream
-        buffer maps that to ``K_MAX`` = no-op filter.
-        """
-        sampling_info = getattr(forward_batch, "sampling_info", None)
-        if sampling_info is None or n_real == 0:
-            return ([1.0] * n_real, [1.0] * n_real, [None] * n_real)
-
-        temps_raw = _flat_sampling_attr(sampling_info, "temperatures") or [1.0] * n_real
-        top_ps_raw = _flat_sampling_attr(sampling_info, "top_ps") or [1.0] * n_real
-        top_ks_raw = _flat_sampling_attr(sampling_info, "top_ks")
-
-        temps = [float(t) for t in temps_raw[:n_real]]
-        top_ps = [float(t) for t in top_ps_raw[:n_real]]
-        if top_ks_raw is None:
-            top_ks: list[int | None] = [None] * n_real
-        else:
-            top_ks = [
-                int(t) if (t is not None and 0 < int(t) < K_MAX) else None
-                for t in top_ks_raw[:n_real]
-            ]
-        return temps, top_ps, top_ks
 
     def _collect_step_outputs_cg(
         self, result: Any, forward_batch: Any, requests: list

--- a/sglang_omni/models/higgs_tts/model_runner.py
+++ b/sglang_omni/models/higgs_tts/model_runner.py
@@ -226,18 +226,21 @@ class HiggsTTSModelRunner(ModelRunner):
 
         # note (Jiaxin Deng): device-side copies only; a .cpu()/.tolist() here
         # is a stream-syncing D2H on the per-step launch path.
-        sampling_info = getattr(forward_batch, "sampling_info", None)
-        temps = _flat_nonempty(getattr(sampling_info, "temperatures", None))
+        sampling_info = forward_batch.sampling_info
+        if sampling_info is None:
+            temps = top_ps = top_ks = None
+        else:
+            temps = _flat_nonempty(sampling_info.temperatures)
+            top_ps = _flat_nonempty(sampling_info.top_ps)
+            top_ks = _flat_nonempty(sampling_info.top_ks)
         if temps is not None:
             model._cg_temperature[:n_real].copy_(temps[:n_real])
         else:
             model._cg_temperature[:n_real].fill_(1.0)
-        top_ps = _flat_nonempty(getattr(sampling_info, "top_ps", None))
         if top_ps is not None:
             model._cg_top_p[:n_real].copy_(top_ps[:n_real])
         else:
             model._cg_top_p[:n_real].fill_(1.0)
-        top_ks = _flat_nonempty(getattr(sampling_info, "top_ks", None))
         if top_ks is not None:
             tks = top_ks[:n_real].to(torch.long)
             # top_k outside (0, K_MAX) (incl. sglang's TOP_K_ALL sentinel for

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -910,7 +910,9 @@ class OmniScheduler:
         pending_step = self._model_runner.execute_launch(sched_output)
         return sched_output, pending_step
 
-    def _run_batch_resolve(self, batch, sched_output, pending_step, skip_rids=()):
+    def _run_batch_resolve(
+        self, batch, sched_output, pending_step, skip_rids: set | None = None
+    ):
         """Async: resolve the given launched step (wait event, host collect),
         emit its stream chunks (except overrun reqs in ``skip_rids``), and
         return its GenerationBatchResult.
@@ -921,10 +923,12 @@ class OmniScheduler:
         """
         from sglang.srt.managers.scheduler import GenerationBatchResult
 
-        mr_output = self._model_runner.execute_resolve(pending_step)
+        mr_output = self._model_runner.execute_resolve(
+            pending_step, skip_rids=skip_rids
+        )
         if mr_output is None:
             return _FAILED_BATCH_RESULT
-        self._emit_stream_output(sched_output, mr_output, skip_rids=skip_rids)
+        self._emit_stream_output(sched_output, mr_output, skip_rids=skip_rids or ())
         return GenerationBatchResult(
             logits_output=None,
             next_token_ids=pending_step.batch_result.next_token_ids,

--- a/tests/unit_test/higgs_tts/test_row_sampling_params.py
+++ b/tests/unit_test/higgs_tts/test_row_sampling_params.py
@@ -1,0 +1,309 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Decode-launch host-traffic contract for HiggsTTSModelRunner.
+
+``_populate_cg_buffers`` runs at launch time while the previous step's forward
+is still in flight, so any ``.cpu()`` / ``.tolist()`` on sampling_info tensors
+is a stream-syncing D2H that serializes the async-decode overlap. These tests
+pin the contract: sampling params reach the CG buffers device-side (no host
+materialization), and the per-step row-indices rebuild is skipped when batch
+membership is unchanged.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.models.higgs_tts.model_runner import HiggsTTSModelRunner
+from sglang_omni.models.higgs_tts.sampler import K_MAX
+
+_POOL = 6
+_PAD = 5
+_NCB = 3
+
+
+class _NoHostReadbackTensor(torch.Tensor):
+    """Tensor whose host-materialization entry points fail the test."""
+
+    def cpu(self, *args, **kwargs):
+        raise RuntimeError("host readback (cpu) on the decode launch path")
+
+    def tolist(self):
+        raise RuntimeError("host readback (tolist) on the decode launch path")
+
+    def numpy(self, *args, **kwargs):
+        raise RuntimeError("host readback (numpy) on the decode launch path")
+
+    def item(self):
+        raise RuntimeError("host readback (item) on the decode launch path")
+
+    def __float__(self):
+        raise RuntimeError("host readback (float) on the decode launch path")
+
+    def __iter__(self):
+        raise RuntimeError("host readback (iter) on the decode launch path")
+
+    def to(self, *args, **kwargs):
+        if any(str(a) == "cpu" for a in args) or str(kwargs.get("device")) == "cpu":
+            raise RuntimeError("host readback (to cpu) on the decode launch path")
+        return super().to(*args, **kwargs)
+
+
+def _guarded(data, dtype):
+    return torch.tensor(data, dtype=dtype).as_subclass(_NoHostReadbackTensor)
+
+
+def _sampling_info(temps, top_ps, top_ks):
+    return SimpleNamespace(
+        temperatures=_guarded(temps, torch.float32).unsqueeze(-1),
+        top_ps=_guarded(top_ps, torch.float32),
+        top_ks=_guarded(top_ks, torch.long),
+    )
+
+
+def _make_runner(n_reqs=3):
+    pool = SimpleNamespace(
+        delay_count=torch.zeros(_POOL, dtype=torch.int32),
+        eoc_countdown=torch.full((_POOL,), -1, dtype=torch.int32),
+        generation_done=torch.zeros(_POOL, dtype=torch.bool),
+        last_codes=torch.zeros((_POOL, _NCB), dtype=torch.long),
+        seeds=torch.zeros(_POOL, dtype=torch.long),
+        step_count=torch.zeros(_POOL, dtype=torch.long),
+    )
+
+    def _pool_reset_row(row):
+        pool.delay_count[row] = 0
+        pool.eoc_countdown[row] = -1
+        pool.generation_done[row] = False
+        pool.last_codes[row].zero_()
+        pool.seeds[row] = 0
+        pool.step_count[row] = 0
+
+    pool.reset_row = _pool_reset_row
+
+    acquire_calls: list[str] = []
+    rid_to_row = {f"req{i}": i for i in range(n_reqs)}
+
+    def _acquire(rid):
+        acquire_calls.append(rid)
+        return rid_to_row[rid]
+
+    _make_runner.rid_to_row = rid_to_row
+
+    runner = object.__new__(HiggsTTSModelRunner)
+    runner._outbox = None
+    runner._vocoder_target = "vocoder"
+    runner._async_enabled = True
+    runner._staging_slot = 0
+    runner._host_staging_buffers = []
+    runner._logprob_host_buffers = None
+    runner._logprob_slot = 0
+    runner._async_query_hit = 0
+    runner._async_query_miss = 0
+    runner.model = SimpleNamespace(
+        _cg_row_indices=torch.zeros(_POOL, dtype=torch.long),
+        _cg_temperature=torch.ones(_POOL, dtype=torch.float32),
+        _cg_top_p=torch.ones(_POOL, dtype=torch.float32),
+        _cg_top_k_buf=torch.full((_POOL,), K_MAX, dtype=torch.long),
+        _cg_active_delay_count=torch.zeros(_POOL, dtype=torch.int32),
+        _cg_active_eoc_countdown=torch.zeros(_POOL, dtype=torch.int32),
+        _cg_active_generation_done=torch.zeros(_POOL, dtype=torch.bool),
+        _cg_active_last_codes=torch.zeros((_POOL, _NCB), dtype=torch.long),
+        _cg_active_seeds=torch.zeros(_POOL, dtype=torch.long),
+        _cg_active_step_count=torch.zeros(_POOL, dtype=torch.long),
+        _sampler_pool=pool,
+        _padding_row=_PAD,
+        _row_epoch=0,
+        acquire_row=_acquire,
+    )
+    reqs = [SimpleNamespace(request_id=f"req{i}") for i in range(n_reqs)]
+    return runner, reqs, acquire_calls
+
+
+def test_decode_populate_reads_sampling_info_device_side_only():
+    runner, reqs, _ = _make_runner()
+    # Poison the buffers so the padding-tail assertions can't pass vacuously.
+    runner.model._cg_temperature[:] = -9.0
+    runner.model._cg_top_p[:] = -9.0
+    runner.model._cg_top_k_buf[:] = -9
+    fb = SimpleNamespace(
+        batch_size=4,
+        sampling_info=_sampling_info([0.7, 1.3, 0.9], [0.95, 0.8, 1.0], [-1, 5, 0]),
+    )
+    runner._populate_cg_buffers(fb, reqs)
+    model = runner.model
+    assert torch.allclose(
+        model._cg_temperature[:3], torch.tensor([0.7, 1.3, 0.9], dtype=torch.float32)
+    )
+    assert torch.allclose(
+        model._cg_top_p[:3], torch.tensor([0.95, 0.8, 1.0], dtype=torch.float32)
+    )
+    # top_k outside (0, K_MAX) (sentinels -1 / 0) normalizes to K_MAX = no-op.
+    assert model._cg_top_k_buf[:4].tolist() == [K_MAX, 5, K_MAX, K_MAX]
+    # Padding slot (position 3 of bs=4) holds neutral values.
+    assert float(model._cg_temperature[3]) == 1.0
+    assert float(model._cg_top_p[3]) == 1.0
+
+
+def test_populate_without_sampling_info_uses_defaults():
+    runner, reqs, _ = _make_runner()
+    runner.model._cg_temperature[:] = 0.123
+    runner.model._cg_top_k_buf[:] = 7
+    fb = SimpleNamespace(batch_size=4, sampling_info=None)
+    runner._populate_cg_buffers(fb, reqs)
+    model = runner.model
+    assert model._cg_temperature[:4].tolist() == [1.0] * 4
+    assert model._cg_top_p[:4].tolist() == [1.0] * 4
+    assert model._cg_top_k_buf[:4].tolist() == [K_MAX] * 4
+
+
+def test_done_row_guard_keeps_position_params_but_padding_state():
+    """The lookahead overrun guard redirects a done row's STATE gathers to the
+    padding row; its sampling params still come from its batch position
+    (legacy behavior)."""
+    runner, reqs, _ = _make_runner()
+    pool = runner.model._sampler_pool
+    pool.generation_done[1] = True
+    pool.last_codes[1] = 42
+    fb = SimpleNamespace(
+        batch_size=3,
+        sampling_info=_sampling_info([0.7, 1.3, 0.9], [0.95, 0.8, 1.0], [7, 5, 2]),
+    )
+    runner._populate_cg_buffers(fb, reqs, is_lookahead=True)
+    model = runner.model
+    assert float(model._cg_temperature[1]) == pytest.approx(1.3)
+    assert int(model._cg_top_k_buf[1]) == 5
+    assert int(model._cg_row_indices[1]) == _PAD
+    # State gather went through the padding row (zeros), not row 1's 42s.
+    assert model._cg_active_last_codes[1].tolist() == [0, 0, 0]
+
+
+def test_rows_cache_skips_reacquire_on_unchanged_membership():
+    runner, reqs, acquire_calls = _make_runner()
+    fb = SimpleNamespace(
+        batch_size=4,
+        sampling_info=_sampling_info([0.7, 1.3, 0.9], [0.95, 0.8, 1.0], [7, 5, 2]),
+    )
+    runner._populate_cg_buffers(fb, reqs)
+    n_first = len(acquire_calls)
+    runner._populate_cg_buffers(fb, reqs)
+    assert len(acquire_calls) == n_first, "unchanged membership must not re-acquire"
+    assert runner.model._cg_row_indices[:4].tolist() == [0, 1, 2, _PAD]
+
+
+def test_rows_cache_restores_rows_mutated_by_guard():
+    """An overrun step mutates ``_cg_row_indices`` in place (done row ->
+    padding); the next populate with unchanged membership must restore the
+    true rows before applying its own guard."""
+    runner, reqs, _ = _make_runner()
+    fb = SimpleNamespace(
+        batch_size=3,
+        sampling_info=_sampling_info([0.7, 1.3, 0.9], [0.95, 0.8, 1.0], [7, 5, 2]),
+    )
+    runner._populate_cg_buffers(fb, reqs, is_lookahead=True)
+    pool = runner.model._sampler_pool
+    pool.generation_done[1] = True
+    runner._populate_cg_buffers(fb, reqs, is_lookahead=True)
+    assert int(runner.model._cg_row_indices[1]) == _PAD
+    pool.generation_done[1] = False
+    runner._populate_cg_buffers(fb, reqs, is_lookahead=True)
+    assert runner.model._cg_row_indices[:3].tolist() == [0, 1, 2]
+
+
+def test_rows_cache_invalidated_on_row_release_epoch():
+    """Same request-id list + bs can reappear after a row was released and
+    remapped (request-id reuse); the release-side epoch must invalidate the
+    cache so stale row mappings are never restored."""
+    runner, reqs, _ = _make_runner()
+    rid_to_row = _make_runner.rid_to_row
+    fb = SimpleNamespace(
+        batch_size=4,
+        sampling_info=_sampling_info([0.7, 1.3, 0.9], [0.95, 0.8, 1.0], [7, 5, 2]),
+    )
+    runner._populate_cg_buffers(fb, reqs)
+    assert runner.model._cg_row_indices[:3].tolist() == [0, 1, 2]
+    # req1's row is released and a same-named request later lands on row 4.
+    rid_to_row["req1"] = 4
+    runner.model._row_epoch += 1
+    runner._populate_cg_buffers(fb, reqs)
+    assert runner.model._cg_row_indices[:3].tolist() == [0, 4, 2]
+
+
+def test_empty_sampling_tensors_fall_back_to_defaults():
+    """Zero-length sampling attrs behave like absent ones. For temperatures /
+    top_ps this matches the removed path's falsy fallback; for top_ks the old
+    path raised a shape mismatch (unreachable in serving), defaults are the
+    deliberate replacement."""
+    runner, reqs, _ = _make_runner()
+    fb = SimpleNamespace(
+        batch_size=4,
+        sampling_info=SimpleNamespace(
+            temperatures=torch.zeros((0, 1), dtype=torch.float32),
+            top_ps=torch.zeros(0, dtype=torch.float32),
+            top_ks=torch.zeros(0, dtype=torch.long),
+        ),
+    )
+    runner._populate_cg_buffers(fb, reqs)
+    model = runner.model
+    assert model._cg_temperature[:4].tolist() == [1.0] * 4
+    assert model._cg_top_p[:4].tolist() == [1.0] * 4
+    assert model._cg_top_k_buf[:4].tolist() == [K_MAX] * 4
+
+
+def test_list_sampling_attrs_still_supported():
+    runner, reqs, _ = _make_runner()
+    fb = SimpleNamespace(
+        batch_size=3,
+        sampling_info=SimpleNamespace(
+            temperatures=[0.5, 0.6, 0.7], top_ps=[0.9, 0.8, 0.7], top_ks=[1, 2, 3]
+        ),
+    )
+    runner._populate_cg_buffers(fb, reqs)
+    assert torch.allclose(
+        runner.model._cg_temperature[:3],
+        torch.tensor([0.5, 0.6, 0.7], dtype=torch.float32),
+    )
+    assert runner.model._cg_top_k_buf[:3].tolist() == [1, 2, 3]
+
+
+def test_rows_cache_invalidated_on_membership_change():
+    runner, reqs, acquire_calls = _make_runner()
+    fb = SimpleNamespace(
+        batch_size=4,
+        sampling_info=_sampling_info([0.7, 1.3, 0.9], [0.95, 0.8, 1.0], [7, 5, 2]),
+    )
+    runner._populate_cg_buffers(fb, reqs)
+    survivors = [reqs[0], reqs[2]]
+    fb2 = SimpleNamespace(
+        batch_size=2,
+        sampling_info=_sampling_info([0.7, 0.9], [0.95, 1.0], [7, 2]),
+    )
+    n_before = len(acquire_calls)
+    runner._populate_cg_buffers(fb2, survivors)
+    assert len(acquire_calls) > n_before
+    assert runner.model._cg_row_indices[:2].tolist() == [0, 2]
+    assert torch.allclose(
+        runner.model._cg_temperature[:2],
+        torch.tensor([0.7, 0.9], dtype=torch.float32),
+    )
+
+
+def test_model_release_row_bumps_epoch():
+    """The model-side half of the cache invariant: release_row itself must
+    bump ``_row_epoch`` (mutation-kill for the bump in model.py)."""
+    from sglang_omni.models.higgs_tts.model import HiggsTTSModel
+
+    stub = SimpleNamespace(
+        _rid_to_row={"A": 3},
+        _free_rows=[],
+        _row_epoch=0,
+        _output_codes={},
+    )
+    HiggsTTSModel.release_row(stub, "A")
+    assert stub._row_epoch == 1
+    assert stub._free_rows == [3]
+    # Releasing an unknown id changes no mapping and must not bump.
+    HiggsTTSModel.release_row(stub, "ghost")
+    assert stub._row_epoch == 1

--- a/tests/unit_test/model_runner/test_async_resolve_skip_rids.py
+++ b/tests/unit_test/model_runner/test_async_resolve_skip_rids.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``execute_resolve`` accepts the caller's precomputed skip set.
+
+``_resolve_and_process`` already scans the lagged batch for finished/retracted
+requests; ``execute_resolve`` must reuse that set instead of re-running the
+same O(bs) ``finished()`` scan per step (and must keep computing it itself
+when no set is passed).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from sglang_omni.model_runner.base import ModelRunner
+
+
+class _StubRunner(ModelRunner):
+    def post_decode_resolve(
+        self, host_buf, result, forward_batch, schedule_batch, requests
+    ):
+        pass
+
+
+def _make_pending(finished_calls):
+    def _finished_probe(i):
+        def _finished():
+            finished_calls.append(i)
+            return False
+
+        return _finished
+
+    reqs = [
+        SimpleNamespace(
+            request_id=f"req{i}",
+            data=SimpleNamespace(
+                req=SimpleNamespace(finished=_finished_probe(i), is_retracted=False),
+                generation_steps=0,
+                extra_model_outputs={},
+            ),
+        )
+        for i in range(3)
+    ]
+    scheduler_output = SimpleNamespace(requests=reqs)
+    batch_result = SimpleNamespace(
+        next_token_ids=torch.zeros(3, dtype=torch.long),
+        logits_output=None,
+        can_run_cuda_graph=True,
+    )
+    return SimpleNamespace(
+        event=SimpleNamespace(query=lambda: True),
+        launch_buf=None,
+        scheduler_output=scheduler_output,
+        forward_batch=SimpleNamespace(batch_size=3),
+        schedule_batch=SimpleNamespace(is_prefill_only=False),
+        model_worker_batch=None,
+        batch_result=batch_result,
+    )
+
+
+def _make_runner():
+    outputs = {f"req{i}": SimpleNamespace(extra=None) for i in range(3)}
+    output_processor = SimpleNamespace(process=lambda result, sched_out: outputs)
+    tp_worker = SimpleNamespace(
+        gpu_id=0, model_runner=SimpleNamespace(model=SimpleNamespace())
+    )
+    return _StubRunner(tp_worker=tp_worker, output_processor=output_processor)
+
+
+def test_execute_resolve_uses_caller_skip_rids_without_rescan():
+    finished_calls: list[int] = []
+    runner = _make_runner()
+    pending = _make_pending(finished_calls)
+    out = runner.execute_resolve(pending, skip_rids={"req1"})
+    assert finished_calls == [], "caller-provided skip_rids must skip the rescan"
+    assert out is not None
+    # req1 was skipped: its generation_steps did not advance.
+    steps = [r.data.generation_steps for r in pending.scheduler_output.requests]
+    assert steps == [1, 0, 1]
+
+
+def test_execute_resolve_computes_skip_rids_when_not_passed():
+    finished_calls: list[int] = []
+    runner = _make_runner()
+    pending = _make_pending(finished_calls)
+    out = runner.execute_resolve(pending)
+    assert sorted(finished_calls) == [0, 1, 2]
+    assert out is not None
+    steps = [r.data.generation_steps for r in pending.scheduler_output.requests]
+    assert steps == [1, 1, 1]


### PR DESCRIPTION

## Motivation

Single-replica Higgs TTS serving is host-bound (#921). The per-step decode chain was measured at
~2.2 ms launch + ~1.3 ms collect at concurrency 96 on H100 (decomposition posted on #921); after
prefill admission coalescing (#1071) the decode chain becomes the dominant loop segment
(launch 43% / schedule 18% / resolve 17%).

Inside the launch half, `_populate_cg_buffers` rebuilt the CG sampling buffers from
`forward_batch.sampling_info` every decode step via `_flat_sampling_attr`, i.e.
`.detach().cpu().flatten().tolist()` x3 (temperatures / top_ps / top_ks) + three
`torch.tensor(list)` H2D uploads + one H2D for row indices. The `.cpu()` readbacks are
stream-syncing D2H issued at launch time, i.e. while the previous step's forward can still be
in flight on the same stream. In the measured host-bound c96 regime the previous forward is
usually already complete by then, so what this PR removes is the fixed per-step cost of the
host round trips (measured +2-3% e2e below, per-request latency unchanged); in regimes where
the GPU step is the laggard the same syncs would serialize the async-decode overlap directly.

## Modifications

1. Sampling params now reach `_cg_temperature/_cg_top_p/_cg_top_k_buf` via device-side
   `copy_`/`where` from `sampling_info`'s own tensors (top_k sentinel normalization included):
   no host materialization, no H2D on the decode hot path. For the production tensor path the
   values are bit-identical by construction (copied from the same tensors the old path read
   back); zero-length attrs now fall back to defaults like absent ones.
2. The device row-indices tensor is cached across steps keyed by (request-id list, padded batch
   size); rebuilt only on membership change. Restored by D2D copy (not skipped) because the
   lookahead overrun guard mutates `_cg_row_indices` in place. Row assignment per request id is
   stable: `acquire_row` is idempotent and rows are released only on terminal cleanup, which also
   changes membership.
3. `execute_resolve` accepts the caller's precomputed prior-step finished/retracted skip set
   (`_resolve_and_process` already computes it), removing a duplicate O(bs) `finished()` scan per
   step. Behavior with no caller-provided set is unchanged.

Cross-model surface: (3) touches `model_runner/base.py` shared by MOSS-TTS-Local and Qwen3-Omni
runners (optional param, default recomputes as before). MOSS / Qwen3 / scheduling unit suites
pass with failure sets identical by name to base a24654fa (pre-existing env failures only).

## Accuracy

Sampling-param values are copied from the same `sampling_info` tensors the removed path read
back, so sampled outputs are unchanged by construction. Unit tests pin: device-side-only reads
(host readback raises), top_k sentinel normalization, padding-row neutrality, guard/params
ordering, cache restore-after-guard, cache invalidation on membership change, skip_rids
threading semantics. [TODO: seed-tts WER A/B if requested]

## Benchmark [measured]

Rig: 1x H100 80 GB (novita), `bosonai/higgs-tts-3-4b`, seed-tts-eval EN voice clone (full set,
1088 requests/run), non-streaming, `--max-running-requests 96 --cuda-graph-max-bs 96
--decode-mode async`, closed-loop concurrency 96, server cores 0-15 / client cores 24-31 /
membind 0 on the card's NUMA node. Interleaved base/head rounds, fresh server per round, one
256-request warm run per server, host loadavg logged per run. One base round was discarded for
host-load contamination (loadavg >100 from a neighbor workload) and rerun windows were used
instead.

Runs containing a runaway generation (completion_tokens = 2048 cap, 81.6 s audio, EOC never
sampled; occurs in both arms with unseeded sampling, e.g. base r3 run1) extend wall-clock by
their ~20 s tail; they are listed with their runaway count and excluded from the headline mean.

| arm | QPS per run (runaways) | straggler-free mean | lat mean / p95 |
| --- | --- | ---: | --- |
| base a24654fa | 30.0, 28.8, 27.6 (1), 28.9 | **29.2** | 3.09-3.24 s / 4.28-4.61 s |
| head | 29.5, 24.8 (1), 30.5, 24.4 (1), 29.7, 24.7 (2) | **29.9 (+2.4%)** | 3.05-3.38 s / 4.25-4.61 s |

On main the decode chain is only ~13% of the event loop at c96 (prefill ~60% dominates until
#1071 lands), so the small headline delta is expected [inferred from the #921 decomposition];
per-request p50/p95 latency is unchanged. The stacked configuration below is where the launch
share (43% post-coalescing) makes the change visible.

### Stacked with prefill admission coalescing (K=16, T=140 ms) [measured]

Both arms + cherry-pick of 618426c2 (`sunao/prefill-pac`, conflict-resolved against a24654fa),
enabled via `runtime_overrides.tts_engine.prefill_coalesce_requests: 16 / wait_ms: 140`. One
head round was discarded for host-load contamination (loadavg >100) and rerun.

| arm | QPS per run (runaways) | straggler-free mean | lat p95 |
| --- | --- | ---: | --- |
| base + coalescing | 32.95, 26.9 (2), 30.2 (1), 30.1, 32.6*, 27.6* (1) | **31.9** | 3.79-4.12 s |
| head + coalescing | 32.2, 29.9 (1), 28.0 (1), 30.4, 28.5 (2), 29.9 (1) | **31.3 (parity)** | 3.74-4.54 s |

*loadavg 21-31 during the base round marked with an asterisk; all other listed runs at
loadavg < 10.

Read on the two tables together: the removed host round trips are worth +2-3% at c96 on this
rig and the change is latency-neutral; the stacked configuration shows parity within noise.
The remaining decode-chain host time sits in the upstream schedule bucket
(`update_running_batch`/`prepare_for_decode`, ~4.9 ms/iter per the #921 decomposition) and the
per-request collect loop; both are listed as follow-ups. Coalescing itself reproduced at
+5-8% QPS with clearly better p95 (3.8-4.1 s vs 4.3-4.6 s) on this rig, smaller than the +28%
on the #921 rig [measured].

Follow-ups (out of scope, measured on #921): the ~4.9 ms/iter `get_next_batch_to_run` schedule
bucket lives in upstream sglang (`filter_batch` rescans, `check_decode_mem`, `prepare_for_decode`);
`_decode_collect_host` per-row collect loop vectorization.
