### PR TITLE
[TTS Refactor] Adopt shared state serialization and checkpoint/config reuse for Ming-Omni-TTS

### DIFF
--- a/sglang_omni/models/ming_tts/audio_config.py
+++ b/sglang_omni/models/ming_tts/audio_config.py
@@ -8,43 +8,10 @@ from typing import Any
 
 from transformers import PretrainedConfig
 
+from sglang_omni.models.ming_omni.talker.audio_vae.configuration_audio_vae import (
+    AudioVAEconfig,
+)
 from sglang_omni.models.ming_tts.payload_types import MING_TTS_SAMPLE_RATE
-
-
-class AudioVAEconfig(PretrainedConfig):
-    """Config class matching the official AudioVAE checkpoint metadata."""
-
-    def __init__(
-        self,
-        sample_rate: int = 16000,
-        enc_kwargs: dict[str, Any] | None = None,
-        dec_kwargs: dict[str, Any] | None = None,
-        hifi_gan_disc_kwargs: dict[str, Any] | None = None,
-        spec_disc_kwargs: dict[str, Any] | None = None,
-        lambda_disc: float = 1.0,
-        lambda_mel_loss: float = 15.0,
-        lambda_adv: float = 1.0,
-        lambda_feat_match_loss: float = 1.0,
-        semantic_module_kwargs: dict[str, Any] | None = None,
-        lambda_semantic: float | None = 5.0,
-        init_method: str = "normal",
-        patch_size: int = -1,
-        **kwargs: Any,
-    ) -> None:
-        self.sample_rate = sample_rate
-        self.enc_kwargs = enc_kwargs
-        self.dec_kwargs = dec_kwargs
-        self.hifi_gan_disc_kwargs = hifi_gan_disc_kwargs
-        self.spec_disc_kwargs = spec_disc_kwargs
-        self.lambda_disc = lambda_disc
-        self.lambda_mel_loss = lambda_mel_loss
-        self.lambda_adv = lambda_adv
-        self.lambda_feat_match_loss = lambda_feat_match_loss
-        self.semantic_module_kwargs = semantic_module_kwargs
-        self.lambda_semantic = lambda_semantic
-        self.init_method = init_method
-        self.patch_size = patch_size
-        super().__init__(**kwargs)
 
 
 def resolve_ming_tts_audio_vae_config(

--- a/sglang_omni/models/ming_tts/audio_decode.py
+++ b/sglang_omni/models/ming_tts/audio_decode.py
@@ -13,7 +13,6 @@ from sglang_omni.models.ming_omni.talker.audio_vae.modeling_audio_vae import Aud
 from sglang_omni.models.ming_tts.audio_config import AudioVAEconfig
 from sglang_omni.models.ming_tts.payload_types import (
     MingTTSState,
-    decode_generated_latents,
     load_ming_tts_state,
     store_ming_tts_state,
 )
@@ -39,7 +38,7 @@ class MingAudioDecoder(torch.nn.Module):
         device: str | torch.device = "cuda:0",
         dtype: str | torch.dtype = "bfloat16",
     ) -> "MingAudioDecoder":
-        if audio_config.semantic_module_kwargs is not None:
+        if getattr(audio_config, "semantic_module_kwargs", None) is not None:
             raise ValueError(
                 "Ming-Omni-TTS serving currently uses the talker AudioVAE "
                 "encode/decode path and does not support semantic_module_kwargs"
@@ -152,11 +151,12 @@ class MingTTSBatchVocoder(BatchVocoderBase):
 
     def prepare_item(self, payload: StagePayload) -> tuple[MingTTSState, torch.Tensor]:
         state = load_ming_tts_state(payload)
-        latents = decode_generated_latents(
-            state,
-            device=self._decoder.device,
-            dtype=self._decoder.dtype,
-        )
+        latents = state.generated_latents
+        if latents is not None:
+            latents = latents.to(
+                device=self._decoder.device,
+                dtype=self._decoder.dtype,
+            )
         return state, latents
 
     def _decode_item(
@@ -187,9 +187,7 @@ class MingTTSBatchVocoder(BatchVocoderBase):
         state.sample_rate = int(sample_rate)
         state.duration_s = float(wav.numel() / int(sample_rate))
         if not self._keep_latents:
-            state.generated_latents_bytes = None
-            state.generated_latents_shape = None
-            state.generated_latents_dtype = None
+            state.generated_latents = None
 
         payload = store_ming_tts_state(payload, state)
         payload.data.update(

--- a/sglang_omni/models/ming_tts/engine_builder.py
+++ b/sglang_omni/models/ming_tts/engine_builder.py
@@ -64,11 +64,6 @@ class MingTtsEngineBuilder(TtsEngineBuilder):
         self.tokenizer: Any = None
         self._model_runner: Any = None
 
-    def resolve_checkpoint(self, model_path: str) -> str:
-        from sglang_omni.models.ming_tts import stages as ming_stages
-
-        return ming_stages._resolve_checkpoint(model_path)
-
     def pre_infra_setup(self, checkpoint_dir: str) -> None:
         from sglang_omni.models.ming_tts import stages as ming_stages
 

--- a/sglang_omni/models/ming_tts/engine_io.py
+++ b/sglang_omni/models/ming_tts/engine_io.py
@@ -11,7 +11,6 @@ import torch
 
 from sglang_omni.models.ming_tts.payload_types import (
     MingTTSState,
-    encode_generated_latents,
     load_ming_tts_state,
     store_ming_tts_state,
 )
@@ -85,7 +84,7 @@ def make_ming_tts_scheduler_adapters(
         sampling_params.verify(vocab_size)
 
         requires_projected_prefill = (
-            state.spk_emb_bytes is not None or state.prompt_latent_bytes is not None
+            state.spk_emb is not None or state.prompt_latent is not None
         )
 
         req_input_ids_list = input_ids_list
@@ -165,9 +164,7 @@ def make_ming_tts_scheduler_adapters(
             state.prompt_tokens = len(data.input_ids)
             state.completion_tokens = int(generated.shape[0])
             state.engine_time_s = time.perf_counter() - data.engine_start_s
-
-            for field_name, value in encode_generated_latents(generated).items():
-                setattr(state, field_name, value)
+            state.generated_latents = generated
 
             return store_ming_tts_state(payload, state)
         finally:

--- a/sglang_omni/models/ming_tts/model_runner.py
+++ b/sglang_omni/models/ming_tts/model_runner.py
@@ -11,10 +11,6 @@ import torch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 
 from sglang_omni.model_runner.base import ModelRunner
-from sglang_omni.models.ming_tts.payload_types import (
-    decode_prompt_latent,
-    decode_speaker_embedding,
-)
 from sglang_omni.models.ming_tts.sglang_model import MingTTSTailInputs
 
 
@@ -110,16 +106,12 @@ class MingTTSModelRunner(ModelRunner):
         weight = self.model._decode_input_embedding.weight
         device = weight.device
         dtype = weight.dtype
-        speaker_embedding = decode_speaker_embedding(
-            state,
-            device=device,
-            dtype=dtype,
-        )
-        prompt_latent = decode_prompt_latent(
-            state,
-            device=device,
-            dtype=torch.float32,
-        )
+        speaker_embedding = state.spk_emb
+        if speaker_embedding is not None:
+            speaker_embedding = speaker_embedding.to(device=device, dtype=dtype)
+        prompt_latent = state.prompt_latent
+        if prompt_latent is not None:
+            prompt_latent = prompt_latent.to(device=device, dtype=torch.float32)
         if prompt_latent is not None and prompt_latent.ndim == 2:
             prompt_latent = prompt_latent.unsqueeze(0)
 

--- a/sglang_omni/models/ming_tts/payload_types.py
+++ b/sglang_omni/models/ming_tts/payload_types.py
@@ -6,154 +6,27 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-import torch
-
 from sglang_omni.proto import StagePayload
-from sglang_omni.scheduling.pipeline_state import PipelineStateBase
+from sglang_omni.scheduling.pipeline_state import DeclarativeStateBase
 from sglang_omni.scheduling.pipeline_state import load_state as _load_pipeline_state
 from sglang_omni.scheduling.pipeline_state import store_state as _store_pipeline_state
+from sglang_omni.scheduling.pipeline_state import wire
 
 MING_TTS_SAMPLE_RATE = 44100
 MING_TTS_DEFAULT_MAX_DECODE_STEPS = 200
-MING_TTS_LATENT_TRANSPORT_DTYPE = "float32"
-MING_TTS_LATENT_TRANSPORT_VERSION = 1
-
-
-def encode_generated_latents(latents: Any) -> dict[str, Any]:
-    """Encode generated latent chunks as the cross-stage wire format."""
-
-    if not isinstance(latents, torch.Tensor):
-        latents = torch.as_tensor(latents)
-    latents = latents.detach().to(device="cpu", dtype=torch.float32).contiguous()
-    return {
-        "generated_latents_bytes": latents.numpy().tobytes(),
-        "generated_latents_shape": list(latents.shape),
-        "generated_latents_dtype": MING_TTS_LATENT_TRANSPORT_DTYPE,
-        "generated_latents_transport_version": MING_TTS_LATENT_TRANSPORT_VERSION,
-    }
-
-
-def decode_generated_latents(
-    data: "MingTTSState | dict[str, Any]",
-    *,
-    device: Any | None = None,
-    dtype: Any | None = None,
-) -> Any | None:
-    """Restore generated latent chunks from the cross-stage wire format."""
-
-    if isinstance(data, MingTTSState):
-        raw = data.generated_latents_bytes
-        shape = data.generated_latents_shape
-    else:
-        raw = data.get("generated_latents_bytes")
-        shape = data.get("generated_latents_shape")
-
-    return _decode_float_tensor(
-        raw,
-        shape,
-        device=device,
-        dtype=dtype,
-    )
-
-
-def encode_speaker_embedding(spk_emb: Any) -> dict[str, Any]:
-    """Encode raw CampPlus speaker embeddings for cross-stage transport."""
-
-    tensor = _encode_float_tensor(spk_emb)
-    return {
-        "spk_emb_bytes": tensor.numpy().tobytes(),
-        "spk_emb_shape": list(tensor.shape),
-        "spk_emb_dtype": MING_TTS_LATENT_TRANSPORT_DTYPE,
-    }
-
-
-def decode_speaker_embedding(
-    data: "MingTTSState | dict[str, Any]",
-    *,
-    device: Any | None = None,
-    dtype: Any | None = None,
-) -> Any | None:
-    """Restore raw CampPlus speaker embeddings from the state payload."""
-
-    if isinstance(data, MingTTSState):
-        raw = data.spk_emb_bytes
-        shape = data.spk_emb_shape
-    else:
-        raw = data.get("spk_emb_bytes")
-        shape = data.get("spk_emb_shape")
-    return _decode_float_tensor(
-        raw,
-        shape,
-        device=device,
-        dtype=dtype,
-    )
-
-
-def encode_prompt_latent(prompt_latent: Any) -> dict[str, Any]:
-    """Encode raw AudioVAE prompt latents for cross-stage transport."""
-
-    tensor = _encode_float_tensor(prompt_latent)
-    return {
-        "prompt_latent_bytes": tensor.numpy().tobytes(),
-        "prompt_latent_shape": list(tensor.shape),
-        "prompt_latent_dtype": MING_TTS_LATENT_TRANSPORT_DTYPE,
-    }
-
-
-def decode_prompt_latent(
-    data: "MingTTSState | dict[str, Any]",
-    *,
-    device: Any | None = None,
-    dtype: Any | None = None,
-) -> Any | None:
-    """Restore raw AudioVAE prompt latents from the state payload."""
-
-    if isinstance(data, MingTTSState):
-        raw = data.prompt_latent_bytes
-        shape = data.prompt_latent_shape
-    else:
-        raw = data.get("prompt_latent_bytes")
-        shape = data.get("prompt_latent_shape")
-    return _decode_float_tensor(
-        raw,
-        shape,
-        device=device,
-        dtype=dtype,
-    )
-
-
-def _encode_float_tensor(tensor: Any) -> Any:
-    if not isinstance(tensor, torch.Tensor):
-        tensor = torch.as_tensor(tensor)
-    return tensor.detach().to(device="cpu", dtype=torch.float32).contiguous()
-
-
-def _decode_float_tensor(
-    raw: Any,
-    shape: Any,
-    *,
-    device: Any | None,
-    dtype: Any | None,
-) -> Any | None:
-    if raw is None or shape is None:
-        return None
-    raw = bytes(raw)
-    dims = [int(dim) for dim in shape]
-    if len(raw) == 0:
-        # torch.frombuffer rejects empty buffers on torch >= 2.12; an empty
-        # latent stream (finish-before-first-chunk) is a supported payload.
-        tensor = torch.empty(dims, dtype=torch.float32)
-    else:
-        tensor = torch.frombuffer(raw, dtype=torch.float32).clone().reshape(dims)
-    if device is not None or dtype is not None:
-        tensor = tensor.to(device=device, dtype=dtype)
-    return tensor
 
 
 @dataclass
-class MingTTSState(PipelineStateBase):
-    """Per-request state for Ming-Omni-TTS generation."""
+class MingTTSState(DeclarativeStateBase):
+    """Per-request state for Ming-Omni-TTS generation.
 
+    Tensor fields transport as float32 {name}_bytes/_shape/_dtype triples via
+    the shared typed_tensor codec and restore to CPU float32 tensors.
+    """
+
+    sample_rate: int = MING_TTS_SAMPLE_RATE
+
+    # -- From preprocessing ------------------------------------------------
     text: str = ""
     prompt: str | None = None
     instructions: str | None = None
@@ -161,213 +34,31 @@ class MingTTSState(PipelineStateBase):
     voice: str | None = None
     ref_audio: Any | None = None
     ref_text: str | None = None
+    input_ids: list[int] | None = wire(None, codec="list")
+    max_decode_steps: int = wire(MING_TTS_DEFAULT_MAX_DECODE_STEPS, codec="int_or")
+    cfg: float = wire(2.0, codec="float")
+    sigma: float = wire(0.25, codec="float")
+    temperature: float = wire(0.0, codec="float")
 
-    input_ids: list[int] | None = None
+    # -- From reference encode ---------------------------------------------
     prompt_text: str | None = None
-    spk_token_positions: list[int] | None = None
-    spk_injection_positions: list[int] | None = None
-    audio_token_position: int | None = None
-    prompt_latent_start_position: int | None = None
-    prompt_latent_token_count: int = 0
+    spk_token_positions: list[int] | None = wire(None, codec="list")
+    spk_injection_positions: list[int] | None = wire(None, codec="list")
+    audio_token_position: int | None = wire(None, codec="opt_int")
+    prompt_latent_start_position: int | None = wire(None, codec="opt_int")
+    prompt_latent_token_count: int = wire(0, emit="truthy", codec="int")
+    spk_emb: Any | None = wire(None, codec="typed_tensor")
+    prompt_latent: Any | None = wire(None, codec="typed_tensor")
 
-    spk_emb_bytes: bytes | None = None
-    spk_emb_shape: list[int] | None = None
-    spk_emb_dtype: str | None = None
-    prompt_latent_bytes: bytes | None = None
-    prompt_latent_shape: list[int] | None = None
-    prompt_latent_dtype: str | None = None
-
-    max_decode_steps: int = MING_TTS_DEFAULT_MAX_DECODE_STEPS
-    cfg: float = 2.0
-    sigma: float = 0.25
-    temperature: float = 0.0
-
-    generated_latents_bytes: bytes | None = None
-    generated_latents_shape: list[int] | None = None
-    generated_latents_dtype: str | None = None
-    generated_latents_transport_version: int = MING_TTS_LATENT_TRANSPORT_VERSION
-    generated_last_chunk: list[bool] | None = None
-    stop_step: int | None = None
+    # -- From TTS engine ---------------------------------------------------
+    generated_latents: Any | None = wire(None, codec="typed_tensor")
+    generated_last_chunk: list[bool] | None = wire(None, codec="list")
+    stop_step: int | None = wire(None, codec="opt_int")
     finish_reason: str | None = None
-    prompt_tokens: int = 0
-    completion_tokens: int = 0
-    engine_time_s: float = 0.0
 
-    sample_rate: int = MING_TTS_SAMPLE_RATE
+    # -- From audio decode -------------------------------------------------
     duration_s: float | None = None
-    audio_decode_time_s: float = 0.0
-
-    def to_dict(self) -> dict[str, Any]:
-        data: dict[str, Any] = {
-            "text": self.text,
-            "max_decode_steps": int(self.max_decode_steps),
-            "cfg": float(self.cfg),
-            "sigma": float(self.sigma),
-            "temperature": float(self.temperature),
-            "sample_rate": int(self.sample_rate),
-        }
-        if self.prompt is not None:
-            data["prompt"] = self.prompt
-        if self.instructions is not None:
-            data["instructions"] = self.instructions
-        if self.language is not None:
-            data["language"] = self.language
-        if self.voice is not None:
-            data["voice"] = self.voice
-        if self.ref_audio is not None:
-            data["ref_audio"] = self.ref_audio
-        if self.ref_text is not None:
-            data["ref_text"] = self.ref_text
-        if self.input_ids is not None:
-            data["input_ids"] = list(self.input_ids)
-        if self.prompt_text is not None:
-            data["prompt_text"] = self.prompt_text
-        if self.spk_token_positions is not None:
-            data["spk_token_positions"] = list(self.spk_token_positions)
-        if self.spk_injection_positions is not None:
-            data["spk_injection_positions"] = list(self.spk_injection_positions)
-        if self.audio_token_position is not None:
-            data["audio_token_position"] = int(self.audio_token_position)
-        if self.prompt_latent_start_position is not None:
-            data["prompt_latent_start_position"] = int(
-                self.prompt_latent_start_position
-            )
-        if self.prompt_latent_token_count:
-            data["prompt_latent_token_count"] = int(self.prompt_latent_token_count)
-        if self.spk_emb_bytes is not None:
-            data["spk_emb_bytes"] = self.spk_emb_bytes
-            data["spk_emb_shape"] = list(self.spk_emb_shape or [])
-            data["spk_emb_dtype"] = self.spk_emb_dtype
-        if self.prompt_latent_bytes is not None:
-            data["prompt_latent_bytes"] = self.prompt_latent_bytes
-            data["prompt_latent_shape"] = list(self.prompt_latent_shape or [])
-            data["prompt_latent_dtype"] = self.prompt_latent_dtype
-        if self.generated_latents_bytes is not None:
-            data["generated_latents_bytes"] = self.generated_latents_bytes
-            data["generated_latents_shape"] = list(self.generated_latents_shape or [])
-            data["generated_latents_dtype"] = (
-                self.generated_latents_dtype or MING_TTS_LATENT_TRANSPORT_DTYPE
-            )
-            data["generated_latents_transport_version"] = int(
-                self.generated_latents_transport_version
-            )
-        if self.generated_last_chunk is not None:
-            data["generated_last_chunk"] = [
-                bool(item) for item in self.generated_last_chunk
-            ]
-        if self.stop_step is not None:
-            data["stop_step"] = int(self.stop_step)
-        if self.finish_reason is not None:
-            data["finish_reason"] = self.finish_reason
-        self.append_usage_fields(data)
-        if self.duration_s is not None:
-            data["duration_s"] = float(self.duration_s)
-        if self.audio_decode_time_s:
-            data["audio_decode_time_s"] = float(self.audio_decode_time_s)
-        return data
-
-    @classmethod
-    def from_dict(cls, data: Any) -> "MingTTSState":
-        def bytes_or_none(value: Any) -> bytes | None:
-            if value is None:
-                return None
-            return bytes(value)
-
-        def int_list_or_none(value: Any) -> list[int] | None:
-            if value is None:
-                return None
-            return [int(item) for item in value]
-
-        def int_or_default(value: Any, default: int) -> int:
-            return int(default if value is None else value)
-
-        def float_or_default(value: Any, default: float) -> float:
-            return float(default if value is None else value)
-
-        if not isinstance(data, dict):
-            data = {}
-        return cls(
-            text=str(data.get("text", "")),
-            prompt=data.get("prompt"),
-            instructions=data.get("instructions"),
-            language=data.get("language"),
-            voice=data.get("voice"),
-            ref_audio=data.get("ref_audio"),
-            ref_text=data.get("ref_text"),
-            input_ids=int_list_or_none(data.get("input_ids")),
-            prompt_text=data.get("prompt_text"),
-            spk_token_positions=int_list_or_none(data.get("spk_token_positions")),
-            spk_injection_positions=int_list_or_none(
-                data.get("spk_injection_positions")
-            ),
-            audio_token_position=(
-                int(data["audio_token_position"])
-                if data.get("audio_token_position") is not None
-                else None
-            ),
-            prompt_latent_start_position=(
-                int(data["prompt_latent_start_position"])
-                if data.get("prompt_latent_start_position") is not None
-                else None
-            ),
-            prompt_latent_token_count=int(
-                data.get("prompt_latent_token_count", 0) or 0
-            ),
-            spk_emb_bytes=bytes_or_none(data.get("spk_emb_bytes")),
-            spk_emb_shape=int_list_or_none(data.get("spk_emb_shape")),
-            spk_emb_dtype=data.get("spk_emb_dtype"),
-            prompt_latent_bytes=bytes_or_none(data.get("prompt_latent_bytes")),
-            prompt_latent_shape=int_list_or_none(data.get("prompt_latent_shape")),
-            prompt_latent_dtype=data.get("prompt_latent_dtype"),
-            max_decode_steps=int_or_default(
-                data.get("max_decode_steps"),
-                MING_TTS_DEFAULT_MAX_DECODE_STEPS,
-            ),
-            cfg=float_or_default(data.get("cfg"), 2.0),
-            sigma=float_or_default(data.get("sigma"), 0.25),
-            temperature=float_or_default(data.get("temperature"), 0.0),
-            generated_latents_bytes=bytes_or_none(data.get("generated_latents_bytes")),
-            generated_latents_shape=int_list_or_none(
-                data.get("generated_latents_shape")
-            ),
-            generated_latents_dtype=data.get("generated_latents_dtype"),
-            generated_latents_transport_version=int(
-                data.get(
-                    "generated_latents_transport_version",
-                    MING_TTS_LATENT_TRANSPORT_VERSION,
-                )
-                or MING_TTS_LATENT_TRANSPORT_VERSION
-            ),
-            generated_last_chunk=(
-                [bool(item) for item in data["generated_last_chunk"]]
-                if data.get("generated_last_chunk") is not None
-                else None
-            ),
-            stop_step=(
-                int(data["stop_step"]) if data.get("stop_step") is not None else None
-            ),
-            finish_reason=(
-                str(data["finish_reason"])
-                if data.get("finish_reason") is not None
-                else None
-            ),
-            prompt_tokens=int_or_default(data.get("prompt_tokens"), 0),
-            completion_tokens=int_or_default(data.get("completion_tokens"), 0),
-            engine_time_s=float_or_default(data.get("engine_time_s"), 0.0),
-            sample_rate=int_or_default(
-                data.get("sample_rate"),
-                MING_TTS_SAMPLE_RATE,
-            ),
-            duration_s=(
-                float(data["duration_s"])
-                if data.get("duration_s") is not None
-                else None
-            ),
-            audio_decode_time_s=float_or_default(
-                data.get("audio_decode_time_s"),
-                0.0,
-            ),
-        )
+    audio_decode_time_s: float = wire(0.0, emit="truthy", codec="float")
 
 
 def load_ming_tts_state(payload: StagePayload) -> MingTTSState:
@@ -380,16 +71,8 @@ def store_ming_tts_state(payload: StagePayload, state: MingTTSState) -> StagePay
 
 __all__ = [
     "MING_TTS_DEFAULT_MAX_DECODE_STEPS",
-    "MING_TTS_LATENT_TRANSPORT_DTYPE",
-    "MING_TTS_LATENT_TRANSPORT_VERSION",
     "MING_TTS_SAMPLE_RATE",
     "MingTTSState",
-    "decode_prompt_latent",
-    "decode_generated_latents",
-    "decode_speaker_embedding",
-    "encode_prompt_latent",
-    "encode_generated_latents",
-    "encode_speaker_embedding",
     "load_ming_tts_state",
     "store_ming_tts_state",
 ]

--- a/sglang_omni/models/ming_tts/reference_encode.py
+++ b/sglang_omni/models/ming_tts/reference_encode.py
@@ -199,9 +199,7 @@ class MingTTSReferenceEncoder:
         # note (luojiaxuan): keep artifacts on CPU float32 so the shared cache
         # never pins device memory and typed_tensor emits float32 unchanged.
         return {
-            "spk_emb": speaker_embedding.detach().to(
-                device="cpu", dtype=torch.float32
-            ),
+            "spk_emb": speaker_embedding.detach().to(device="cpu", dtype=torch.float32),
             "prompt_latent": prompt_latent.detach().to(
                 device="cpu", dtype=torch.float32
             ),

--- a/sglang_omni/models/ming_tts/reference_encode.py
+++ b/sglang_omni/models/ming_tts/reference_encode.py
@@ -16,8 +16,6 @@ from sglang_omni.models.ming_tts.audio_config import AudioVAEconfig
 from sglang_omni.models.ming_tts.audio_decode import MingAudioDecoder
 from sglang_omni.models.ming_tts.payload_types import (
     MING_TTS_SAMPLE_RATE,
-    encode_prompt_latent,
-    encode_speaker_embedding,
     load_ming_tts_state,
     store_ming_tts_state,
 )
@@ -198,11 +196,17 @@ class MingTTSReferenceEncoder:
         frames = int(prompt_latent.shape[1])
         speaker_embedding = self.speaker_encoder(speaker_waveform)
 
-        artifact: dict[str, Any] = {}
-        artifact.update(encode_speaker_embedding(speaker_embedding))
-        artifact.update(encode_prompt_latent(prompt_latent))
-        artifact["prompt_latent_token_count"] = frames // self.patch_size
-        return artifact
+        # note (luojiaxuan): keep artifacts on CPU float32 so the shared cache
+        # never pins device memory and typed_tensor emits float32 unchanged.
+        return {
+            "spk_emb": speaker_embedding.detach().to(
+                device="cpu", dtype=torch.float32
+            ),
+            "prompt_latent": prompt_latent.detach().to(
+                device="cpu", dtype=torch.float32
+            ),
+            "prompt_latent_token_count": frames // self.patch_size,
+        }
 
     def encode_payload(
         self,
@@ -221,12 +225,9 @@ class MingTTSReferenceEncoder:
         else:
             artifact = self._encode_reference(ref_audio)
 
-        prompt_latent_token_count = int(artifact["prompt_latent_token_count"])
-        for field_name, value in artifact.items():
-            if field_name == "prompt_latent_token_count":
-                continue
-            setattr(state, field_name, value)
-        state.prompt_latent_token_count = prompt_latent_token_count
+        state.spk_emb = artifact["spk_emb"]
+        state.prompt_latent = artifact["prompt_latent"]
+        state.prompt_latent_token_count = int(artifact["prompt_latent_token_count"])
         state.prompt_text = str(state.ref_text)
 
         plan = build_ming_tts_prompt(

--- a/sglang_omni/models/ming_tts/reference_encode.py
+++ b/sglang_omni/models/ming_tts/reference_encode.py
@@ -24,8 +24,7 @@ from sglang_omni.models.ming_tts.tokenizer import MingTTSTokenizerBundle
 from sglang_omni.preprocessing.cache_key import reference_path_cache_key
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.reference_encoder import (
-    ReferenceEncodeHook,
-    ReferenceEncodeKey,
+    KeyedReferenceEncodeHook,
     ReferenceEncodeService,
 )
 
@@ -61,7 +60,7 @@ class MingSpeakerEmbeddingExtractor:
         return torch.as_tensor(embedding.reshape(1, -1), dtype=torch.float32)
 
 
-class _MingTTSReferenceEncodeHook(ReferenceEncodeHook[str, dict, dict]):
+class _MingTTSReferenceEncodeHook(KeyedReferenceEncodeHook[str, dict, dict]):
     """M4a hook: cache (speaker embedding, prompt latent) per reference file.
 
     The artifact is the text-independent conditioning bundle; prompt build
@@ -69,39 +68,27 @@ class _MingTTSReferenceEncodeHook(ReferenceEncodeHook[str, dict, dict]):
     so a re-uploaded identical reference hits across request ids.
     """
 
+    model_revision = ""
+    encoder_id = "ming_audio_vae_campplus"
+    artifact_kind = "ref_conditioning"
+
     def __init__(self, encoder: "MingTTSReferenceEncoder", *, model_identity: str):
         self._encoder = encoder
-        self._model_identity = str(model_identity)
+        self.model_id = str(model_identity)
+        self.encoder_config_hash = (
+            f"sr{encoder.sample_rate}:patch{encoder.patch_size}:"
+            f"dtype{encoder._audio_vae_floating_dtype()}"
+        )
 
     def normalize_input(self, raw_input: Any) -> str:
         return str(raw_input)
 
-    def _input_key(self, item: str) -> str | None:
+    def input_key(self, item: str) -> str | None:
         # Full-content memoized hash; the sampled variant can collide for
         # same-size files that differ only in the middle (review on #858).
+        # None means unreadable input: bypass the cache and let encode_one
+        # raise the real error to the caller.
         return reference_path_cache_key(item, trust_stat=False)
-
-    def cache_key(self, item: str) -> ReferenceEncodeKey | None:
-        input_key = self._input_key(item)
-        if input_key is None:
-            # Unreadable input: bypass the cache and let encode_one raise the
-            # real error to the caller.
-            return None
-        encoder = self._encoder
-        return ReferenceEncodeKey(
-            model_id=self._model_identity,
-            model_revision="",
-            encoder_id="ming_audio_vae_campplus",
-            encoder_config_hash=(
-                f"sr{encoder.sample_rate}:patch{encoder.patch_size}:"
-                f"dtype{encoder._audio_vae_floating_dtype()}"
-            ),
-            artifact_kind="ref_conditioning",
-            input_key=input_key,
-        )
-
-    def revalidate(self, item: str, key: ReferenceEncodeKey) -> bool:
-        return self._input_key(item) == key.input_key
 
     def encode_one(self, item: str) -> dict:
         return self._encoder._encode_reference(item)

--- a/sglang_omni/models/ming_tts/stages.py
+++ b/sglang_omni/models/ming_tts/stages.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any
 
 from sglang_omni.models.ming_tts.audio_config import resolve_ming_tts_audio_vae_config
@@ -16,6 +15,7 @@ from sglang_omni.models.ming_tts.request_builders import preprocess_ming_tts_pay
 from sglang_omni.models.ming_tts.tokenizer import load_ming_tts_tokenizer
 from sglang_omni.models.ming_tts.weight_loading import load_ming_tts_audio_vae_weights
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
+from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoint
 
 logger = logging.getLogger(__name__)
 
@@ -238,14 +238,6 @@ def create_audio_decode_executor(
         max_batch_size=max_batch_size,
         max_batch_wait_ms=max_batch_wait_ms,
     )
-
-
-def _resolve_checkpoint(checkpoint: str) -> str:
-    if os.path.isdir(checkpoint):
-        return checkpoint
-    from huggingface_hub import snapshot_download
-
-    return snapshot_download(checkpoint)
 
 
 def _load_ming_tts_config(model_path: str) -> Any:

--- a/sglang_omni/models/ming_tts/weight_loading.py
+++ b/sglang_omni/models/ming_tts/weight_loading.py
@@ -261,13 +261,12 @@ def scan_ming_tts_weights(
 ) -> MingTTSWeightManifest:
     """Scan checkpoint metadata without materializing checkpoint tensors."""
 
-    resolved_path = Path(model_path).expanduser()
-    if not resolved_path.exists():
-        from huggingface_hub import snapshot_download
+    from sglang_omni.models.weight_loader import resolve_model_path
 
-        resolved_path = Path(
-            snapshot_download(str(model_path), local_files_only=local_files_only)
-        )
+    resolved_path = resolve_model_path(
+        str(model_path),
+        local_files_only=local_files_only,
+    )
 
     index_path = resolved_path / _INDEX_FILENAME
     if index_path.exists():

--- a/sglang_omni/models/qwen3_tts/engine_builder.py
+++ b/sglang_omni/models/qwen3_tts/engine_builder.py
@@ -26,7 +26,7 @@ class Qwen3TtsEngineBuilder(TtsEngineBuilder):
         if not hasattr(qwen_tts, "Qwen3TTSModel"):
             raise ImportError("qwen_tts does not expose Qwen3TTSModel")
 
-        return qwen3_stages._resolve_checkpoint(model_path)
+        return super().resolve_checkpoint(model_path)
 
     def pre_infra_setup(self, checkpoint_dir: str) -> None:
         del checkpoint_dir

--- a/sglang_omni/models/voxtral_tts/pipeline/stages.py
+++ b/sglang_omni/models/voxtral_tts/pipeline/stages.py
@@ -19,6 +19,7 @@ from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 from sglang_omni.scheduling.vocoder_base import BatchVocoderBase
 from sglang_omni.utils.audio_payload import audio_waveform_payload
+from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoint
 
 logger = logging.getLogger(__name__)
 
@@ -38,14 +39,6 @@ def _import_mistral_common_for_voxtral():
     except ImportError as exc:
         raise RuntimeError(_VOXTRAL_MISTRAL_COMMON_HINT) from exc
     return SpeechRequest, MistralTokenizer
-
-
-def _resolve_checkpoint(checkpoint: str) -> str:
-    if os.path.isdir(checkpoint):
-        return checkpoint
-    from huggingface_hub import snapshot_download
-
-    return snapshot_download(checkpoint)
 
 
 def _validate_voxtral_speech_params(

--- a/sglang_omni/scheduling/typed_tensor.py
+++ b/sglang_omni/scheduling/typed_tensor.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Exact bytes+dtype+shape round-trip for integer code tensors in pipeline state.
+"""Exact bytes+dtype+shape round-trip for code/latent tensors in pipeline state.
 
-Packs as {key}_bytes/_shape/_dtype (narrowest of uint16/int32), decodes to int64.
+Packs as {key}_bytes/_shape/_dtype. Integer tensors narrow to the smallest of
+uint16/int32 and decode to int64; floating tensors transport as float32 and
+decode to float32.
 
-Note(Chenchen Hong): use this when a code tensor must survive a control-plane
+Note(Chenchen Hong): use this when a tensor must survive a control-plane
 message, not just a relay hop. A field left in pipeline state reaches the
 terminal CompleteMessage, which control_plane.send_complete msgpack-packs and
 msgpack cannot pack a Tensor (it can pack bytes). Voxtral's audio_codes ends up
@@ -17,7 +19,7 @@ from typing import Any
 
 
 def encode_typed_tensor(value: Any, *, key: str) -> dict[str, Any]:
-    """Pack an integer code tensor as {key}_bytes/_shape/_dtype (merge into payload.data)."""
+    """Pack a tensor as {key}_bytes/_shape/_dtype (merge into payload.data)."""
     import numpy as np
 
     try:
@@ -26,9 +28,17 @@ def encode_typed_tensor(value: Any, *, key: str) -> dict[str, Any]:
         torch = None
 
     if torch is not None and isinstance(value, torch.Tensor):
-        value = value.detach().cpu().numpy()
+        # note (luojiaxuan): bfloat16 has no numpy dtype, so floating tensors
+        # convert to the float32 transport dtype while still torch-side.
+        if value.is_floating_point():
+            value = value.detach().to(device="cpu", dtype=torch.float32)
+        else:
+            value = value.detach().cpu()
+        value = value.numpy()
     array = np.asarray(value)
-    if array.size == 0:
+    if array.dtype.kind == "f":
+        array = array.astype(np.float32, copy=False)
+    elif array.size == 0:
         array = array.astype(np.uint16, copy=False)
     elif int(array.min()) >= 0 and int(array.max()) <= np.iinfo(np.uint16).max:
         array = array.astype(np.uint16, copy=False)
@@ -61,5 +71,8 @@ def decode_typed_tensor(
     if raw is None or shape is None:
         return None
     dtype = np.dtype(data.get(f"{key}_dtype", "uint16"))
-    array = np.frombuffer(raw, dtype=dtype).reshape(shape).astype(np.int64)
-    return torch.from_numpy(array)
+    array = np.frombuffer(raw, dtype=dtype).reshape(shape)
+    if array.dtype.kind == "f":
+        # astype copies, so the tensor never aliases the read-only buffer.
+        return torch.from_numpy(array.astype(array.dtype, copy=True))
+    return torch.from_numpy(array.astype(np.int64))

--- a/tests/unit_test/ming_tts/test_audio_decode.py
+++ b/tests/unit_test/ming_tts/test_audio_decode.py
@@ -9,10 +9,7 @@ from sglang_omni.models.ming_tts.audio_decode import (
     MingAudioDecoder,
     decode_ming_tts_audio_payload,
 )
-from sglang_omni.models.ming_tts.payload_types import (
-    MingTTSState,
-    encode_generated_latents,
-)
+from sglang_omni.models.ming_tts.payload_types import MingTTSState
 from sglang_omni.proto import OmniRequest, StagePayload
 
 
@@ -59,11 +56,8 @@ def test_ming_tts_audio_decode_accepts_empty_generated_latents() -> None:
         prompt_tokens=3,
         completion_tokens=0,
         generated_last_chunk=[],
+        generated_latents=torch.empty((0, 2, 3), dtype=torch.float32),
     )
-    for field_name, value in encode_generated_latents(
-        torch.empty((0, 2, 3), dtype=torch.float32)
-    ).items():
-        setattr(state, field_name, value)
     payload = StagePayload(
         request_id="req-ming-tts",
         request=OmniRequest(inputs="hello"),

--- a/tests/unit_test/ming_tts/test_engine_io.py
+++ b/tests/unit_test/ming_tts/test_engine_io.py
@@ -12,10 +12,7 @@ from sglang_omni.models.ming_tts.engine_io import (
     MingTTSSGLangRequestData,
     make_ming_tts_scheduler_adapters,
 )
-from sglang_omni.models.ming_tts.payload_types import (
-    MingTTSState,
-    decode_generated_latents,
-)
+from sglang_omni.models.ming_tts.payload_types import MingTTSState
 from sglang_omni.proto import OmniRequest, StagePayload
 
 
@@ -67,7 +64,7 @@ def test_ming_tts_result_adapter_serializes_empty_latent_output() -> None:
 
     payload = _result_adapter(reset_requests.append)(_request_data())
     restored = MingTTSState.from_dict(payload.data)
-    latents = decode_generated_latents(restored)
+    latents = restored.generated_latents
 
     assert latents is not None
     assert latents.shape == (0, 2, 3)
@@ -132,10 +129,10 @@ def test_ming_tts_result_adapter_resets_state_after_serialization_error(
 ) -> None:
     reset_requests = []
 
-    def fail_serialization(_):
+    def fail_serialization(*_args):
         raise RuntimeError("serialization failed")
 
-    monkeypatch.setattr(engine_io, "encode_generated_latents", fail_serialization)
+    monkeypatch.setattr(engine_io, "store_ming_tts_state", fail_serialization)
     data = _request_data(generated_latents=torch.ones(1, 2, 3))
 
     with pytest.raises(RuntimeError, match="serialization failed"):

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -2030,8 +2030,13 @@ def test_qwen3_tts_engine_applies_compat_overrides_and_reenables_cuda_graph(
     qwen_tts_module.Qwen3TTSModel = FakeQwen3TTSModel
     monkeypatch.setitem(sys.modules, "qwen_tts", qwen_tts_module)
 
+    from sglang_omni.scheduling import engine_factory
+
     monkeypatch.setattr(stages, "_register_qwen3_tts_hf_config", lambda: None)
     monkeypatch.setattr(stages, "_resolve_checkpoint", lambda model_path: model_path)
+    monkeypatch.setattr(
+        engine_factory, "_resolve_checkpoint", lambda model_path: model_path
+    )
     monkeypatch.setattr(
         stages,
         "_load_qwen3_tts_tokenizer",
@@ -2164,7 +2169,7 @@ def test_qwen3_tts_engine_probes_runtime_before_checkpoint_resolution(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from sglang_omni.models.qwen3_tts import engine_builder as engine_builder_mod
-    from sglang_omni.models.qwen3_tts import stages
+    from sglang_omni.scheduling import engine_factory
 
     checkpoint_resolutions: list[str] = []
 
@@ -2179,7 +2184,7 @@ def test_qwen3_tts_engine_probes_runtime_before_checkpoint_resolution(
             raise ImportError("missing qwen_tts")
         return original_import_module(name, package)
 
-    monkeypatch.setattr(stages, "_resolve_checkpoint", fake_resolve_checkpoint)
+    monkeypatch.setattr(engine_factory, "_resolve_checkpoint", fake_resolve_checkpoint)
     monkeypatch.setattr(
         engine_builder_mod.importlib, "import_module", fake_import_module
     )

--- a/tests/unit_test/scheduling/test_pipeline_state.py
+++ b/tests/unit_test/scheduling/test_pipeline_state.py
@@ -267,19 +267,16 @@ def test_tts_pipeline_state_round_trips_preserve_payload_fields() -> None:
                 audio_token_position=3,
                 prompt_latent_start_position=4,
                 prompt_latent_token_count=2,
-                spk_emb_bytes=b"\x00" * 8,
-                spk_emb_shape=[1, 2],
-                spk_emb_dtype="float32",
-                prompt_latent_bytes=b"\x00" * 8,
-                prompt_latent_shape=[1, 1, 2],
-                prompt_latent_dtype="float32",
+                spk_emb=torch.zeros(1, 2),
+                prompt_latent=torch.zeros(1, 1, 2),
                 max_decode_steps=16,
                 cfg=1.5,
                 sigma=0.2,
                 temperature=0.7,
-                generated_latents_bytes=b"\x00" * 16,
-                generated_latents_shape=[2, 1, 2],
-                generated_latents_dtype="float32",
+                generated_latents=torch.tensor(
+                    [[[0.5, -1.25]], [[2.0, 0.0]]],
+                    dtype=torch.float32,
+                ),
                 generated_last_chunk=[False, True],
                 stop_step=1,
                 finish_reason="stop",
@@ -405,6 +402,26 @@ def test_typed_tensor_picks_int32_for_large_values() -> None:
 
     assert data["audio_codes_dtype"] == "int32"
     assert decode_typed_tensor(data, key="audio_codes").tolist() == [[70000, 1]]
+
+
+def test_typed_tensor_float_round_trip_transports_as_float32() -> None:
+    latents = torch.tensor([[0.5, -1.25], [2.0, 0.0]], dtype=torch.bfloat16)
+
+    data = encode_typed_tensor(latents, key="latents")
+
+    assert data["latents_dtype"] == "float32"
+    restored = decode_typed_tensor(data, key="latents")
+    assert restored.dtype == torch.float32
+    assert restored.tolist() == [[0.5, -1.25], [2.0, 0.0]]
+
+
+def test_typed_tensor_empty_float_round_trip_keeps_shape() -> None:
+    data = encode_typed_tensor(torch.empty((0, 2, 3)), key="latents")
+
+    assert data["latents_dtype"] == "float32"
+    restored = decode_typed_tensor(data, key="latents")
+    assert restored.shape == (0, 2, 3)
+    assert restored.dtype == torch.float32
 
 
 def test_typed_tensor_legacy_list_fallback_and_missing() -> None:


### PR DESCRIPTION
## Motivation

Follow-up to #858: adopt the shared TTS surfaces that Ming-Omni-TTS still re-implemented locally, per the active roadmap item in #985.

## Modifications

1. **Declarative pipeline state (#1050 adoption).** `MingTTSState` moves from ~170 lines of hand-written `to_dict`/`from_dict` on `PipelineStateBase` to `DeclarativeStateBase` + `wire()` field specs, matching the other six TTS states.
2. **Shared typed-tensor transport for float latents.** `scheduling/typed_tensor.py` now also carries floating tensors (transported as float32; integer narrowing/decoding unchanged). `spk_emb`, `prompt_latent`, and `generated_latents` become tensor-valued state fields on `codec="typed_tensor"`, keeping the exact `{name}_bytes/_shape/_dtype` float32 wire keys. The Ming-local `encode_/decode_*` helper pairs are deleted; stages read and write tensors directly, and the reference-encode cache stores CPU float32 tensors through the same shared `StageOutputCache` accounting.
3. **Checkpoint resolution dedup.** `stages.py` reuses `utils.checkpoint.resolve_checkpoint` (the local byte-identical copy is deleted), the redundant `MingTtsEngineBuilder.resolve_checkpoint` override (identical to the `TtsEngineBuilder` default) is removed, and `weight_loading.scan_ming_tts_weights` reuses `models.weight_loader.resolve_model_path`.
4. **AudioVAEconfig consolidation.** `ming_tts/audio_config.py` drops its duplicate `AudioVAEconfig` class and reuses the vendored `ming_omni.talker.audio_vae` configuration; extra checkpoint keys flow through `PretrainedConfig` kwargs, and the single reader of `semantic_module_kwargs` now uses `getattr`.

5. **Same-theme checkpoint-resolution cleanup in Qwen3-TTS and Voxtral.** `Qwen3TtsEngineBuilder.resolve_checkpoint` keeps its qwen_tts runtime probe but delegates the final resolution to the shared `TtsEngineBuilder` default instead of reaching into `stages._resolve_checkpoint` (the two tests that intercepted resolution now patch `engine_factory._resolve_checkpoint`), and Voxtral's byte-identical local `_resolve_checkpoint` copy becomes an alias of `utils.checkpoint.resolve_checkpoint`.

Intentional wire cleanup: the `generated_latents_transport_version` payload key is dropped. It was written but never read anywhere, and the latent transport format is now owned by the shared typed-tensor codec.

## Behavior class

Output-equivalent refactor. Affected models: Ming-Omni-TTS (primary), plus behavior-identical checkpoint-resolution cleanup in Qwen3-TTS and Voxtral. The shared `typed_tensor` change is additive (float support); integer behavior is untouched and covered by the existing tests.

## Tests

- Shared round-trip contract test (`tests/unit_test/scheduling/test_pipeline_state.py`) updated to the tensor-field `MingTTSState`; it remains field-complete over the declarative layout.
- New shared typed-tensor float tests: bf16-to-float32 transport and empty-tensor round trip.
- Full `tests/unit_test` suite run in an sglang-omni container on an A6000 host: 2097 passed, 28 skipped. The 13 failures (ming_omni TP, pipeline IPC, router core, serve voices) fail identically on unmodified `main` in the same container and are unrelated environment gaps, not regressions from this change.
- After the Qwen3-TTS/Voxtral cleanup commit: `tests/unit_test/qwen3_tts`, `tests/unit_test/voxtral_tts`, and `tests/unit_test/scheduling/test_engine_factory.py` — 100 passed.

## Related Issues

Part of #985.
