### PR TITLE
[Observability] Env-gated scheduler loop segment timer

### DIFF
--- a/sglang_omni/scheduling/loop_timer.py
+++ b/sglang_omni/scheduling/loop_timer.py
@@ -5,6 +5,10 @@ Enable with ``SGLANG_OMNI_LOOP_TIMER=1``; report interval via
 ``SGLANG_OMNI_LOOP_TIMER_INTERVAL_S`` (default 10). Emits one
 ``LOOP_TIMER {json}`` log line per interval with per-segment wall time,
 call count, and share of window wall time.
+
+An instance is owned by a single scheduler loop thread; it is not
+thread-safe. The injected ``clock`` must be monotonic. With the timer
+disabled the loops pay only a few local truthiness checks per iteration.
 """
 
 from __future__ import annotations
@@ -31,6 +35,9 @@ class LoopSegmentTimer:
         now = clock()
         self._t_report = now
         self._t0_window = now
+        # nan/inf would never report; <=0 would report every add(). Fail safe.
+        if not math.isfinite(interval_s) or interval_s <= 0:
+            interval_s = 10.0
         self._interval = interval_s
 
     def add(self, segment: str, dt: float) -> None:
@@ -63,8 +70,5 @@ def maybe_loop_timer() -> LoopSegmentTimer | None:
     try:
         interval = float(os.environ.get("SGLANG_OMNI_LOOP_TIMER_INTERVAL_S", "10"))
     except ValueError:
-        interval = 10.0
-    # nan/inf would never report; <=0 would report every add(). Fail safe.
-    if not math.isfinite(interval) or interval <= 0:
         interval = 10.0
     return LoopSegmentTimer(interval)

--- a/sglang_omni/scheduling/loop_timer.py
+++ b/sglang_omni/scheduling/loop_timer.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Env-gated scheduler event-loop segment timer (scan tooling).
+
+Enable with ``SGLANG_OMNI_LOOP_TIMER=1``; report interval via
+``SGLANG_OMNI_LOOP_TIMER_INTERVAL_S`` (default 10). Emits one
+``LOOP_TIMER {json}`` log line per interval with per-segment wall time,
+call count, and share of window wall time.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import time
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+
+class LoopSegmentTimer:
+    def __init__(
+        self,
+        interval_s: float = 10.0,
+        clock: Callable[[], float] = time.perf_counter,
+    ) -> None:
+        self._acc: dict[str, float] = {}
+        self._cnt: dict[str, int] = {}
+        self._clock = clock
+        now = clock()
+        self._t_report = now
+        self._t0_window = now
+        self._interval = interval_s
+
+    def add(self, segment: str, dt: float) -> None:
+        self._acc[segment] = self._acc.get(segment, 0.0) + dt
+        self._cnt[segment] = self._cnt.get(segment, 0) + 1
+        now = self._clock()
+        if now - self._t_report >= self._interval:
+            wall = max(now - self._t0_window, 1e-9)
+            payload = {
+                "wall_s": round(wall, 3),
+                "segments": {
+                    k: {
+                        "s": round(v, 4),
+                        "n": self._cnt[k],
+                        "share": round(v / wall, 4),
+                    }
+                    for k, v in sorted(self._acc.items())
+                },
+            }
+            logger.info("LOOP_TIMER %s", json.dumps(payload))
+            self._acc = {}
+            self._cnt = {}
+            self._t_report = now
+            self._t0_window = now
+
+
+def maybe_loop_timer() -> LoopSegmentTimer | None:
+    if os.environ.get("SGLANG_OMNI_LOOP_TIMER", "0") in ("", "0", "false", "False"):
+        return None
+    try:
+        interval = float(os.environ.get("SGLANG_OMNI_LOOP_TIMER_INTERVAL_S", "10"))
+    except ValueError:
+        interval = 10.0
+    # nan/inf would never report; <=0 would report every add(). Fail safe.
+    if not math.isfinite(interval) or interval <= 0:
+        interval = 10.0
+    return LoopSegmentTimer(interval)

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -1628,6 +1628,8 @@ class OmniScheduler:
             if self._engine_paused:
                 self._process_admin_requests()
                 time.sleep(0.001)
+                if _lt:
+                    _lt.add("paused", time.perf_counter() - _t)
                 continue
 
             batch = self.get_next_batch_to_run()
@@ -1849,6 +1851,8 @@ class OmniScheduler:
                 self._process_admin_requests()
                 self._resolve_pending_async()
                 time.sleep(0.001)
+                if _lt:
+                    _lt.add("paused", time.perf_counter() - _t)
                 continue
 
             if (
@@ -1887,6 +1891,8 @@ class OmniScheduler:
                     sched_output, pending_step = self._run_batch_launch(batch)
                 except Exception as exc:
                     self._handle_batch_failure(batch, exc)
+                    if _lt:
+                        _lt.add("launch", time.perf_counter() - _t)
                 else:
                     if _lt:
                         _now = time.perf_counter()

--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -97,6 +97,10 @@ class OmniScheduler:
         are defined directly on this class and take precedence.
     """
 
+    # Scan tooling (loop_timer.py), set in start(); class default keeps
+    # direct loop invocation (tests) working.
+    _loop_timer = None
+
     def __init__(
         self,
         tp_worker: Any,
@@ -1047,6 +1051,9 @@ class OmniScheduler:
             self._dirty_deferred_request_ids.add(request_id)
 
     def start(self) -> None:
+        from sglang_omni.scheduling.loop_timer import maybe_loop_timer
+
+        self._loop_timer = maybe_loop_timer()
         self._scheduler_thread_id = threading.get_ident()
         self._running = True
         try:
@@ -1608,10 +1615,16 @@ class OmniScheduler:
         # (which is mostly Python-side dispatch into many small CUDA kernels)
         # slows ~600x, dropping audio QPS from >10 to <0.5.
         while self._running:
+            _lt = self._loop_timer
+            _t = time.perf_counter() if _lt else 0.0
             self._process_admin_requests()
             recv_reqs = self.recv_requests()
             recv_reqs.extend(self._take_deferred_request_payloads())
             self.process_input_requests(recv_reqs)
+            if _lt:
+                _now = time.perf_counter()
+                _lt.add("recv", _now - _t)
+                _t = time.perf_counter()
             if self._engine_paused:
                 self._process_admin_requests()
                 time.sleep(0.001)
@@ -1619,14 +1632,27 @@ class OmniScheduler:
 
             batch = self.get_next_batch_to_run()
             self.cur_batch = batch
+            if _lt:
+                _now = time.perf_counter()
+                _lt.add("schedule", _now - _t)
+                _t = time.perf_counter()
 
             if batch:
                 result = self.run_batch(batch)
                 if result is not _FAILED_BATCH_RESULT:
                     self.process_batch_result(batch, result)
+                if _lt:
+                    _seg = (
+                        "sync_decode"
+                        if self._batch_is_decode(batch)
+                        else "sync_prefill"
+                    )
+                    _lt.add(_seg, time.perf_counter() - _t)
             else:
                 self.self_check_during_idle()
                 time.sleep(0.001)
+                if _lt:
+                    _lt.add("idle", time.perf_counter() - _t)
 
             self.last_batch = batch
             if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():
@@ -1809,10 +1835,16 @@ class OmniScheduler:
         decode first and run synchronously (the in-flight step is never stranded).
         """
         while self._running:
+            _lt = self._loop_timer
+            _t = time.perf_counter() if _lt else 0.0
             self._process_admin_requests()
             recv_reqs = self.recv_requests()
             recv_reqs.extend(self._take_deferred_request_payloads())
             self.process_input_requests(recv_reqs)
+            if _lt:
+                _now = time.perf_counter()
+                _lt.add("recv", _now - _t)
+                _t = time.perf_counter()
             if self._engine_paused:
                 self._process_admin_requests()
                 self._resolve_pending_async()
@@ -1828,9 +1860,17 @@ class OmniScheduler:
                 )
             ):
                 self._resolve_pending_async()
+                if _lt:
+                    _now = time.perf_counter()
+                    _lt.add("resolve_drain", _now - _t)
+                    _t = time.perf_counter()
 
             batch = self.get_next_batch_to_run()
             self.cur_batch = batch
+            if _lt:
+                _now = time.perf_counter()
+                _lt.add("schedule", _now - _t)
+                _t = time.perf_counter()
 
             # Route through sync when the runner's collect has a sync-only
             # fallback (default True for runners not overriding lookahead_eligible).
@@ -1848,6 +1888,10 @@ class OmniScheduler:
                 except Exception as exc:
                     self._handle_batch_failure(batch, exc)
                 else:
+                    if _lt:
+                        _now = time.perf_counter()
+                        _lt.add("launch", _now - _t)
+                        _t = time.perf_counter()
                     prev_pending = self._async_pending
                     self._async_pending = (batch.copy(), sched_output, pending_step)
                     if prev_pending is not None:
@@ -1856,6 +1900,8 @@ class OmniScheduler:
                             self._resolve_and_process(pb, ps, pstep)
                         except Exception as exc:
                             self._handle_batch_failure(pb, exc)
+                        if _lt:
+                            _lt.add("resolve", time.perf_counter() - _t)
             else:
                 # Fast path (low-concurrency decode below the threshold) +
                 # prefill + empty all land here: flush any in-flight lookahead
@@ -1874,13 +1920,26 @@ class OmniScheduler:
                     # KV). Fast-path analogue of the _resolve_and_process drop.
                     batch = self._drop_stale_overrun(batch)
                     self.cur_batch = batch
+                    if _lt:
+                        _now = time.perf_counter()
+                        _lt.add("resolve_drain", _now - _t)
+                        _t = time.perf_counter()
                 if batch:
                     result = self.run_batch(batch)
                     if result is not _FAILED_BATCH_RESULT:
                         self.process_batch_result(batch, result)
+                    if _lt:
+                        _seg = (
+                            "sync_decode"
+                            if self._batch_is_decode(batch)
+                            else "sync_prefill"
+                        )
+                        _lt.add(_seg, time.perf_counter() - _t)
                 else:
                     self.self_check_during_idle()
                     time.sleep(0.001)
+                    if _lt:
+                        _lt.add("idle", time.perf_counter() - _t)
 
             self.last_batch = batch
             if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():

--- a/tests/unit_test/scheduling/test_loop_timer.py
+++ b/tests/unit_test/scheduling/test_loop_timer.py
@@ -106,3 +106,19 @@ def test_invalid_interval_falls_back_to_default(monkeypatch, val):
     monkeypatch.setenv("SGLANG_OMNI_LOOP_TIMER_INTERVAL_S", val)
     t = maybe_loop_timer()
     assert t._interval == 10.0
+
+
+@pytest.mark.parametrize("bad", [0.0, -1.0, float("nan"), float("inf")])
+def test_direct_construction_invalid_interval_defaults(bad, caplog):
+    """0 would report on every add; nan/inf would never report. The class
+    itself (not just the env factory) falls back to the 10 s default."""
+    clock = _FakeClock()
+    t = LoopSegmentTimer(interval_s=bad, clock=clock)
+    with caplog.at_level(logging.INFO, logger="sglang_omni.scheduling.loop_timer"):
+        clock.t = 1.0
+        t.add("launch", 0.1)
+    assert _reports(caplog) == [], "invalid interval must behave like 10 s"
+    with caplog.at_level(logging.INFO, logger="sglang_omni.scheduling.loop_timer"):
+        clock.t = 11.0
+        t.add("launch", 0.1)
+    assert len(_reports(caplog)) == 1

--- a/tests/unit_test/scheduling/test_loop_timer.py
+++ b/tests/unit_test/scheduling/test_loop_timer.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Behavior of the env-gated scheduler loop segment timer."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from sglang_omni.scheduling.loop_timer import LoopSegmentTimer, maybe_loop_timer
+
+
+class _FakeClock:
+    """Deterministic monotonic clock advanced explicitly by the test."""
+
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def __call__(self) -> float:
+        return self.t
+
+
+def _reports(caplog):
+    out = []
+    for rec in caplog.records:
+        msg = rec.getMessage()
+        idx = msg.find("LOOP_TIMER ")
+        if idx >= 0:
+            out.append(json.loads(msg[idx + len("LOOP_TIMER ") :]))
+    return out
+
+
+def test_accumulates_within_a_window_without_reporting(caplog):
+    clock = _FakeClock()
+    t = LoopSegmentTimer(interval_s=10.0, clock=clock)
+    with caplog.at_level(logging.INFO, logger="sglang_omni.scheduling.loop_timer"):
+        clock.t = 1.0
+        t.add("launch", 0.1)
+        clock.t = 2.0
+        t.add("launch", 0.2)
+    assert _reports(caplog) == [], "must not report before the interval elapses"
+
+
+def test_reports_shares_and_counts_after_interval(caplog):
+    clock = _FakeClock()
+    t = LoopSegmentTimer(interval_s=10.0, clock=clock)
+    with caplog.at_level(logging.INFO, logger="sglang_omni.scheduling.loop_timer"):
+        clock.t = 4.0
+        t.add("launch", 4.0)
+        clock.t = 8.0
+        t.add("resolve", 2.0)
+        clock.t = 11.0  # crosses the 10 s interval
+        t.add("launch", 1.0)
+    reports = _reports(caplog)
+    assert len(reports) == 1
+    segs = reports[0]["segments"]
+    assert segs["launch"]["n"] == 2
+    assert segs["launch"]["s"] == pytest.approx(5.0)
+    assert segs["resolve"]["n"] == 1
+    # share is against window wall time (11 s), not summed segment time.
+    assert segs["launch"]["share"] == pytest.approx(5.0 / 11.0, abs=1e-3)
+
+
+def test_window_resets_after_report(caplog):
+    clock = _FakeClock()
+    t = LoopSegmentTimer(interval_s=10.0, clock=clock)
+    with caplog.at_level(logging.INFO, logger="sglang_omni.scheduling.loop_timer"):
+        clock.t = 11.0
+        t.add("launch", 1.0)  # first report fires, window resets to t=11
+        clock.t = 12.0
+        t.add("resolve", 0.5)
+        clock.t = 22.0
+        t.add("resolve", 0.5)  # second report
+    reports = _reports(caplog)
+    assert len(reports) == 2
+    # second window must not carry the first window's launch time.
+    assert "launch" not in reports[1]["segments"]
+    assert reports[1]["segments"]["resolve"]["n"] == 2
+
+
+def test_env_gate_off_by_default(monkeypatch):
+    monkeypatch.delenv("SGLANG_OMNI_LOOP_TIMER", raising=False)
+    assert maybe_loop_timer() is None
+
+
+@pytest.mark.parametrize("val", ["", "0", "false", "False"])
+def test_env_gate_falsy_values_disable(monkeypatch, val):
+    monkeypatch.setenv("SGLANG_OMNI_LOOP_TIMER", val)
+    assert maybe_loop_timer() is None
+
+
+def test_env_gate_on_returns_timer(monkeypatch):
+    monkeypatch.setenv("SGLANG_OMNI_LOOP_TIMER", "1")
+    monkeypatch.setenv("SGLANG_OMNI_LOOP_TIMER_INTERVAL_S", "5")
+    t = maybe_loop_timer()
+    assert isinstance(t, LoopSegmentTimer)
+    assert t._interval == 5.0
+
+
+@pytest.mark.parametrize("val", ["not-a-number", "NaN", "Infinity", "0", "-1", "-0.5"])
+def test_invalid_interval_falls_back_to_default(monkeypatch, val):
+    """Unparseable, non-finite, and non-positive intervals all fall back:
+    a nan/inf interval never reports; a <=0 interval reports every add()."""
+    monkeypatch.setenv("SGLANG_OMNI_LOOP_TIMER", "1")
+    monkeypatch.setenv("SGLANG_OMNI_LOOP_TIMER_INTERVAL_S", val)
+    t = maybe_loop_timer()
+    assert t._interval == 10.0


### PR DESCRIPTION
## Motivation

Single-replica omni serving is host-bound (#907, #921), so the question for any AR stage is
*which segment of the scheduler event loop is on the critical path*. Today there is no built-in
way to answer that: the loop has no per-segment timing, so every investigation on #921 has had to
add ad-hoc timers by hand (the `sunao/prefill-pac` branch shipped none; each profiling comment
re-derived segment shares from torch-profiler traces). This adds a small, off-by-default segment
timer to the shared `OmniScheduler` loops so the accounting is reproducible and model-agnostic.

## Modifications

* `sglang_omni/scheduling/loop_timer.py`: `LoopSegmentTimer` accumulates wall time + call count
  per named segment and, once per report interval, emits one `LOOP_TIMER {json}` line with each
  segment's time, count, and share of window wall time. Clock is injectable for testing.
* `sglang_omni/scheduling/omni_scheduler.py`: both hot loops (`_event_loop_async_decode`,
  `_event_loop_normal`) wrap their phases (recv / schedule / launch / resolve / resolve_drain /
  sync_prefill / sync_decode / idle) in `_lt.add(...)`. Gated on `self._loop_timer`, which is
  `None` unless `SGLANG_OMNI_LOOP_TIMER=1`. When off, each site is a single attribute load and a
  falsy branch, no `perf_counter` calls.

Enable: `SGLANG_OMNI_LOOP_TIMER=1` (interval via `SGLANG_OMNI_LOOP_TIMER_INTERVAL_S`, default 10 s).

## Tests

`tests/unit_test/scheduling/test_loop_timer.py`: accumulation within a window, report contents
(time/count/share against window wall, not summed segments), window reset after report, the env
gate (off by default, falsy values, bad interval fallback). Injected fake clock, no sleeps.

## Why it's worth landing (cross-model evidence) [measured]

Ran the timer across four families on one H100 (seed-tts EN / ASR sweep), taking the busiest 10 s
window per concurrency. It immediately separates the families by bottleneck:

| family | conc | loop dominant segment | SM% |
| --- | ---: | --- | ---: |
| Higgs TTS | 8 / 32 | launch 71% / 48% (4.0-4.5 ms/step) | 69 / 55 |
| MOSS-TTS-Local | 8 / 32 | launch 67% / 64% (7.8-8.1 ms/step) | 66 / 55 |
| Qwen3-ASR | 32 | sync prefill 83% | 31 |
| Fun-ASR | 32 | sync prefill 52% | 17 |

TTS is launch-bound (and MOSS's per-step launch is ~2x Higgs's, capping it at ~11 qps); ASR is
prefill-loop-bound with the GPU 3-5x idle. That is exactly the kind of routing the loop had no
way to show before. Overhead is one dict update per segment per iteration when enabled and nil
when off.
