### PR TITLE
[Benchmark] Extract WER outlier threshold into a named constant

### DIFF
--- a/benchmarks/metrics/wer.py
+++ b/benchmarks/metrics/wer.py
@@ -14,6 +14,9 @@ from benchmarks.metrics._format import (
     print_speed_metric_line,
 )
 
+# Mirrors ``_CER_ABOVE_50_FRACTION``; drives the ``*_50_*`` metric keys.
+_WER_ABOVE_50_FRACTION = 0.5
+
 
 @dataclass
 class SampleOutput:
@@ -73,8 +76,8 @@ def calculate_wer_metrics(outputs: list[SampleOutput], lang: str) -> dict:
         if o.audio_duration_s > 0 and o.latency_s > 0
     ]
 
-    n_above_50 = int(np.sum(wer_arr > 0.5))
-    ok_samples = [o for o in successes if o.wer <= 0.5]
+    n_above_50 = int(np.sum(wer_arr > _WER_ABOVE_50_FRACTION))
+    ok_samples = [o for o in successes if o.wer <= _WER_ABOVE_50_FRACTION]
     if ok_samples:
         ok_errors = sum(
             o.substitutions + o.deletions + o.insertions for o in ok_samples


### PR DESCRIPTION
## Motivation

`benchmarks/metrics/wer.py` hardcodes the `0.5` "high-error" cutoff inline
(`> 0.5` / `<= 0.5`) inside `calculate_wer_metrics`. The sibling module
`benchmarks/metrics/transcribe_diarize_metrics.py` already names the same cutoff
(`_CER_ABOVE_50_FRACTION = 0.5`) and its partition docstring notes that it
mirrors WER, so the WER side was the only place still using a bare literal.

## Modifications

- Extract the literal into a documented module-level constant
  `_WER_ABOVE_50_FRACTION = 0.5`, placed next to the imports (same location the
  diarize module puts `_CER_ABOVE_50_FRACTION`), and reference it from the two
  comparisons in `calculate_wer_metrics`.
- Pure refactor — **no behavior change**. The `">50%"` summary-table labels and
  the `*_50_*` metric keys are the module's public output schema and are left
  untouched on purpose.
- Add CPU-only unit tests for the two pure aggregators in this module
  (`calculate_wer_metrics`, `calculate_asr_speed_metrics`) under
  `tests/unit_test/benchmarks/`. They lock the existing behavior: corpus
  micro-average, per-sample distribution, the outlier partition and its exact
  boundary, failed-sample exclusion, RTF gating, divide-by-zero guards, and the
  `wall_time_s` throughput override. The boundary test derives its value from
  `_WER_ABOVE_50_FRACTION`, so it both proves the refactor is behavior-preserving
  and documents the constant's semantics. NumPy-only, no GPU or model — 12 tests.

## Related Issues

None.

## Accuracy Test

Not applicable — this does not touch model-side code. Metric values are
unchanged by construction; the added tests assert identical outputs.

## Benchmark & Profiling

Not applicable — no runtime/performance impact (constant folding of an
already-constant literal).

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
