### PR TITLE
[Fun-ASR] Add pad+mask batched audio encoding in get_audio_feature

### DIFF
--- a/sglang_omni/models/fun_asr/config.py
+++ b/sglang_omni/models/fun_asr/config.py
@@ -32,6 +32,8 @@ class FunASRPipelineConfig(PipelineConfig):
                 "enable_pre_lm_encoder": True,
                 "pre_lm_cache_max_entries": 4096,
                 "pre_lm_cache_size_bytes": 2 * 1024**3,
+                "pre_lm_max_batch_size": 8,
+                "pre_lm_max_batch_wait_ms": 4,
                 "request_build_max_workers": 8,
                 "request_build_max_pending": 16,
             },

--- a/sglang_omni/models/fun_asr/sglang_model.py
+++ b/sglang_omni/models/fun_asr/sglang_model.py
@@ -8,6 +8,7 @@ from typing import Any, Iterable, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.managers.mm_utils import (
     MultiModalityDataPaddingPatternMultimodalTokens,
@@ -28,6 +29,42 @@ from .configuration_fun_asr import FunAsrNanoConfig
 from .tool_funcs.audio_lengths import fun_asr_low_frame_rate_length
 
 logger = logging.getLogger(__name__)
+
+
+def _sanm_mask_from_lengths(
+    lengths: torch.Tensor, max_len: int, *, dtype: torch.dtype, device: torch.device
+) -> torch.Tensor:
+    # note (guozhihao): SenseVoice pad mask [B, 1, T], 1=valid.
+    idx = torch.arange(max_len, device=device).unsqueeze(0)
+    return (idx < lengths.unsqueeze(1)).to(dtype=dtype).unsqueeze(1)
+
+
+def _apply_time_mask(x: torch.Tensor, mask: Optional[torch.Tensor]) -> torch.Tensor:
+    if mask is None:
+        return x
+    return x * mask.transpose(1, 2)
+
+
+def _additive_key_pad_mask(mask: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    # note (guozhihao): SenseVoice [B, 1, T] (1=valid) -> SDPA additive [B, 1, 1, T].
+    return torch.zeros(
+        mask.shape[0], 1, 1, mask.shape[-1], device=mask.device, dtype=dtype
+    ).masked_fill(mask.unsqueeze(1).eq(0), torch.finfo(dtype).min)
+
+
+def _fused_qkv_project(
+    x: torch.Tensor,
+    q_proj: nn.Linear,
+    k_proj: nn.Linear,
+    v_proj: nn.Linear,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    # note (guozhihao): keep separate q/k/v Linears for HF checkpoint names;
+    # fuse into one GEMM at runtime.
+    weight = torch.cat([q_proj.weight, k_proj.weight, v_proj.weight], dim=0)
+    bias = None
+    if q_proj.bias is not None:
+        bias = torch.cat([q_proj.bias, k_proj.bias, v_proj.bias], dim=0)
+    return F.linear(x, weight, bias).chunk(3, dim=-1)
 
 
 class SinusoidalPositionEncoder(nn.Module):
@@ -62,24 +99,30 @@ class MultiHeadedAttentionSANM(nn.Module):
         self.k_proj = nn.Linear(in_feat, n_feat)
         self.v_proj = nn.Linear(in_feat, n_feat)
         self.out_proj = nn.Linear(n_feat, n_feat)
-        self.dropout = nn.Dropout(p=dropout_rate)
+        self.attn_dropout_p = float(dropout_rate)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, x: torch.Tensor, mask: Optional[torch.Tensor] = None
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # Returns (attn_out, v) so FSMN can reuse the same value projection.
         b, t, _ = x.size()
-        q = self.q_proj(x)
-        k = self.k_proj(x)
-        v = self.v_proj(x)
-        q_h = q.view(b, t, self.h, self.d_k).transpose(1, 2)  # (b, h, t, dk)
+        q, k, v = _fused_qkv_project(x, self.q_proj, self.k_proj, self.v_proj)
+        q_h = q.view(b, t, self.h, self.d_k).transpose(1, 2)
         k_h = k.view(b, t, self.h, self.d_k).transpose(1, 2)
         v_h = v.view(b, t, self.h, self.d_k).transpose(1, 2)
 
-        q_h = q_h * (self.d_k**-0.5)
-        scores = torch.matmul(q_h, k_h.transpose(-2, -1))  # (b, h, t, t)
-        attn = torch.softmax(scores, dim=-1)
-        p_attn = self.dropout(attn)
-        x = torch.matmul(p_attn, v_h)  # (b, h, t, dk)
-        x = x.transpose(1, 2).contiguous().view(b, -1, self.h * self.d_k)
-        return self.out_proj(x)
+        attn_mask = None if mask is None else _additive_key_pad_mask(mask, q.dtype)
+        dropout_p = self.attn_dropout_p if self.training else 0.0
+        out = F.scaled_dot_product_attention(
+            q_h,
+            k_h,
+            v_h,
+            attn_mask=attn_mask,
+            dropout_p=dropout_p,
+            is_causal=False,
+        )
+        out = out.transpose(1, 2).contiguous().view(b, t, self.h * self.d_k)
+        return self.out_proj(out), v
 
 
 class FunAsrNanoFSMN(nn.Module):
@@ -100,10 +143,16 @@ class FunAsrNanoFSMN(nn.Module):
         self.pad = nn.ConstantPad1d((left_padding, right_padding), 0.0)
         self.dropout = nn.Dropout(dropout_rate)
 
-    def forward(self, value_states: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, value_states: torch.Tensor, mask: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        # note (guozhihao): zero pad frames before/after the depthwise conv so
+        # kernel_size windows cannot leak padded values into valid frames.
+        value_states = _apply_time_mask(value_states, mask)
         hidden_states = self.conv(self.pad(value_states.transpose(1, 2)))
         hidden_states = hidden_states.transpose(1, 2) + value_states
-        return self.dropout(hidden_states)
+        hidden_states = self.dropout(hidden_states)
+        return _apply_time_mask(hidden_states, mask)
 
 
 class EncoderLayerSANM(nn.Module):
@@ -135,17 +184,22 @@ class EncoderLayerSANM(nn.Module):
         self.in_size = in_size
         self.size = size
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, x: torch.Tensor, mask: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
         residual = x
         x = self.self_attn_layer_norm(x)
-        value_states = self.self_attn.v_proj(x)
-        x = self.dropout(self.self_attn(x) + self.fsmn(value_states))
+        # note (guozhihao): attn returns v so FSMN does not recompute v_proj.
+        attn_out, value_states = self.self_attn(x, mask)
+        x = self.dropout(attn_out + self.fsmn(value_states, mask))
+        x = _apply_time_mask(x, mask)
         if self.in_size == self.size:
             x = residual + x
         residual = x
         x = self.final_layer_norm(x)
         x = self.activation_dropout(self.activation(self.fc1(x)))
         x = residual + self.dropout(self.fc2(x))
+        x = _apply_time_mask(x, mask)
         if x.dtype == torch.float16:
             clamp_value = torch.finfo(x.dtype).max - 1000
             x = torch.clamp(x, min=-clamp_value, max=clamp_value)
@@ -198,16 +252,20 @@ class FunAsrNanoAudioEncoder(nn.Module):
     def output_size(self) -> int:
         return self._output_size
 
-    def forward(self, xs: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, xs: torch.Tensor, mask: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
         xs = xs * (self._output_size**0.5)
         xs = self.embed(xs)
-        xs = self.stem(xs)
+        xs = self.stem(xs, mask)
         for layer in self.layers:
-            xs = layer(xs)
+            xs = layer(xs, mask)
         xs = self.layer_norm(xs)
+        xs = _apply_time_mask(xs, mask)
         for layer in self.timestamp_prediction_layers:
-            xs = layer(xs)
+            xs = layer(xs, mask)
         xs = self.timestamp_prediction_layer_norm(xs)
+        xs = _apply_time_mask(xs, mask)
         return xs
 
 
@@ -227,20 +285,29 @@ class MultiHeadedAttention(nn.Module):
         self.k_proj = nn.Linear(n_feat, n_feat)
         self.v_proj = nn.Linear(n_feat, n_feat)
         self.out_proj = nn.Linear(n_feat, n_feat)
-        self.dropout = nn.Dropout(p=dropout_rate)
+        self.attn_dropout_p = float(dropout_rate)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        b, t, d = x.size()
-        q_h = self.q_proj(x).view(b, t, self.h, self.d_k).transpose(1, 2)
-        k_h = self.k_proj(x).view(b, t, self.h, self.d_k).transpose(1, 2)
-        v_h = self.v_proj(x).view(b, t, self.h, self.d_k).transpose(1, 2)
-        q_h = q_h * (self.d_k**-0.5)
-        scores = torch.matmul(q_h, k_h.transpose(-2, -1))
-        attn = torch.softmax(scores, dim=-1)
-        p_attn = self.dropout(attn)
-        x = torch.matmul(p_attn, v_h)
-        x = x.transpose(1, 2).contiguous().view(b, -1, self.h * self.d_k)
-        return self.out_proj(x)
+    def forward(
+        self, x: torch.Tensor, mask: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        b, t, _ = x.size()
+        q, k, v = _fused_qkv_project(x, self.q_proj, self.k_proj, self.v_proj)
+        q_h = q.view(b, t, self.h, self.d_k).transpose(1, 2)
+        k_h = k.view(b, t, self.h, self.d_k).transpose(1, 2)
+        v_h = v.view(b, t, self.h, self.d_k).transpose(1, 2)
+
+        attn_mask = None if mask is None else _additive_key_pad_mask(mask, q.dtype)
+        dropout_p = self.attn_dropout_p if self.training else 0.0
+        out = F.scaled_dot_product_attention(
+            q_h,
+            k_h,
+            v_h,
+            attn_mask=attn_mask,
+            dropout_p=dropout_p,
+            is_causal=False,
+        )
+        out = out.transpose(1, 2).contiguous().view(b, t, self.h * self.d_k)
+        return self.out_proj(out)
 
 
 class AdaptorEncoderLayer(nn.Module):
@@ -262,14 +329,17 @@ class AdaptorEncoderLayer(nn.Module):
         self.activation = ACT2FN[activation_function]
         self.dropout = nn.Dropout(dropout_rate)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, x: torch.Tensor, mask: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
         residual = x
         x = self.self_attn_layer_norm(x)
-        x = residual + self.dropout(self.self_attn(x))
+        x = residual + self.dropout(self.self_attn(x, mask))
+        x = _apply_time_mask(x, mask)
         residual = x
         x = self.final_layer_norm(x)
         x = residual + self.dropout(self.fc2(self.activation(self.fc1(x))))
-        return x
+        return _apply_time_mask(x, mask)
 
 
 class FunAsrNanoAdaptor(nn.Module):
@@ -305,12 +375,15 @@ class FunAsrNanoAdaptor(nn.Module):
             ]
         )
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, x: torch.Tensor, mask: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
         x = self.linear_1(x)
         x = self.act(x)
         x = self.linear_2(x)
+        x = _apply_time_mask(x, mask)
         for block in self.blocks:
-            x = block(x)
+            x = block(x, mask)
         return x
 
 
@@ -376,28 +449,62 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
         return self.pattern.pad_input_tokens(input_ids, mm_inputs)
 
     def get_audio_feature(self, items: List[MultimodalDataItem]) -> torch.Tensor:
+        # note (guozhihao): pad+mask batch-encode to [sum_tokens, llm_dim] in order.
+        if not items:
+            raise ValueError(
+                "Fun-ASR get_audio_feature requires at least one audio item"
+            )
         device = next(self.audio_tower.parameters()).device
         dtype = next(self.audio_tower.parameters()).dtype
 
-        embeddings: List[torch.Tensor] = []
+        feats: List[torch.Tensor] = []
+        lengths: List[int] = []
         for item in items:
+            if item.feature is None:
+                raise ValueError(
+                    "Fun-ASR audio item is missing feature (input_features); "
+                    "cannot encode"
+                )
             feature = item.feature.to(device=device, dtype=dtype)
-            # feature: [1, input_size=560, T_padded] (LFR-stacked).
+            if feature.ndim != 3 or feature.shape[0] != 1:
+                raise ValueError(
+                    "Fun-ASR expects item.feature shaped [1, input_size, T], "
+                    f"got {tuple(feature.shape)}"
+                )
             mask = getattr(item, "feature_attention_mask", None)
             if mask is not None:
-                mask = mask.to(device=device)
-                valid = int(mask.sum().item())
-                # Single audio per item; take the first row's valid frames.
-                feature = feature[:, :, :valid]
-            # [1, 560, T] → [1, T, 560] (encoder expects [B, T, D]).
-            xs = feature.permute(0, 2, 1).contiguous()
-            enc_out = self.audio_tower(xs)  # [1, T, 512]
-            adp_out = self.multi_modal_projector(enc_out)  # [1, T, 1024]
-            t_lfr = adp_out.shape[1]
-            num_tokens = int(fun_asr_low_frame_rate_length(t_lfr))
-            num_tokens = max(num_tokens, 1)
-            embeddings.append(adp_out[0, :num_tokens, :])  # [num_tokens, 1024]
+                valid = int(mask.to(device=device).sum().item())
+            else:
+                valid = int(feature.shape[-1])
+            valid = max(valid, 1)
+            feats.append(feature[:, :, :valid])
+            lengths.append(valid)
 
+        batch_size = len(feats)
+        feat_dim = feats[0].shape[1]
+        t_max = max(lengths)
+        batched = feats[0].new_zeros(batch_size, feat_dim, t_max)
+        for i, (feat, length) in enumerate(zip(feats, lengths)):
+            batched[i, :, :length] = feat[0, :, :length]
+
+        xs = batched.permute(0, 2, 1).contiguous()  # [B, T_max, D]
+        ilens = torch.tensor(lengths, device=device, dtype=torch.long)
+        # note (guozhihao): skip masking for the common B=1 unpadded path so it
+        # stays bit-identical to the pre-batching encoder forward.
+        if batch_size == 1 and lengths[0] == t_max:
+            sanm_mask: Optional[torch.Tensor] = None
+        else:
+            sanm_mask = _sanm_mask_from_lengths(
+                ilens, t_max, dtype=xs.dtype, device=device
+            )
+
+        enc_out = self.audio_tower(xs, sanm_mask)
+        adp_out = self.multi_modal_projector(enc_out, sanm_mask)
+
+        embeddings: List[torch.Tensor] = []
+        for b, length in enumerate(lengths):
+            num_tokens = max(int(fun_asr_low_frame_rate_length(length)), 1)
+            embeddings.append(adp_out[b, :num_tokens, :])
         return torch.cat(embeddings, dim=0)
 
     def forward(

--- a/sglang_omni/models/fun_asr/sglang_model.py
+++ b/sglang_omni/models/fun_asr/sglang_model.py
@@ -487,9 +487,13 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
         for i, (feat, length) in enumerate(zip(feats, lengths)):
             batched[i, :, :length] = feat[0, :, :length]
 
-        xs = batched.permute(0, 2, 1).to(device=device, dtype=dtype, non_blocking=True)
+        xs = (
+            batched.permute(0, 2, 1)
+            .contiguous()
+            .to(device=device, dtype=dtype, non_blocking=True)
+        )
         # note (guozhihao): skip masking for the common B=1 unpadded path so it
-        # stays bit-identical to the pre-batching encoder forward.
+        # stays numerically equivalent to the unmasked encoder forward.
         if batch_size == 1 and lengths[0] == t_max:
             sanm_mask: Optional[torch.Tensor] = None
         else:

--- a/sglang_omni/models/fun_asr/sglang_model.py
+++ b/sglang_omni/models/fun_asr/sglang_model.py
@@ -465,7 +465,7 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
                     "Fun-ASR audio item is missing feature (input_features); "
                     "cannot encode"
                 )
-            feature = item.feature.to(device=device, dtype=dtype)
+            feature = item.feature
             if feature.ndim != 3 or feature.shape[0] != 1:
                 raise ValueError(
                     "Fun-ASR expects item.feature shaped [1, input_size, T], "
@@ -473,7 +473,7 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
                 )
             mask = getattr(item, "feature_attention_mask", None)
             if mask is not None:
-                valid = int(mask.to(device=device).sum().item())
+                valid = int(mask.sum().item())
             else:
                 valid = int(feature.shape[-1])
             valid = max(valid, 1)
@@ -487,13 +487,13 @@ class FunAsrNanoForConditionalGeneration(nn.Module):
         for i, (feat, length) in enumerate(zip(feats, lengths)):
             batched[i, :, :length] = feat[0, :, :length]
 
-        xs = batched.permute(0, 2, 1).contiguous()  # [B, T_max, D]
-        ilens = torch.tensor(lengths, device=device, dtype=torch.long)
+        xs = batched.permute(0, 2, 1).to(device=device, dtype=dtype, non_blocking=True)
         # note (guozhihao): skip masking for the common B=1 unpadded path so it
         # stays bit-identical to the pre-batching encoder forward.
         if batch_size == 1 and lengths[0] == t_max:
             sanm_mask: Optional[torch.Tensor] = None
         else:
+            ilens = torch.tensor(lengths, device=device, dtype=torch.long)
             sanm_mask = _sanm_mask_from_lengths(
                 ilens, t_max, dtype=xs.dtype, device=device
             )

--- a/sglang_omni/models/fun_asr/stages.py
+++ b/sglang_omni/models/fun_asr/stages.py
@@ -61,6 +61,8 @@ def _compile_fun_asr_audio_encoder(
 
     from sglang.srt.model_executor.cuda_graph_runner import set_torch_compile_config
 
+    from sglang_omni.models.fun_asr.sglang_model import _sanm_mask_from_lengths
+
     if warmup_lfr_frames < 2:
         # Note (wilsonzheng0327) Sizes 0/1 are always shape-specialized by
         # Dynamo; warming up with them would not build the symbolic-length graph.
@@ -81,16 +83,35 @@ def _compile_fun_asr_audio_encoder(
         # set, so a normal tensor here compiles a graph the service's
         # inference-mode tensors fail, forcing a full recompile on the first
         # real request
-        warmup = torch.zeros(
-            (1, int(warmup_lfr_frames), int(model.config.encoder_config.input_size)),
-            device=param.device,
-            dtype=param.dtype,
-        )
-        model.multi_modal_projector(model.audio_tower(warmup))
+        t = int(warmup_lfr_frames)
+        feat_dim = int(model.config.encoder_config.input_size)
+
+        # note(guozhihao-224): Dynamo specializes B=0/1 and mask=None vs tensor;
+        # B1/None + B1/mask + B2/mask cover the mask branch and the B>=2 dynamic graph.
+        for batch, with_mask in ((1, False), (1, True), (2, True)):
+            xs = (
+                torch.zeros(
+                    (batch, feat_dim, t), device=param.device, dtype=param.dtype
+                )
+                .permute(0, 2, 1)
+                .contiguous()
+            )
+            mask = (
+                _sanm_mask_from_lengths(
+                    torch.full((batch,), t, device=param.device, dtype=torch.long),
+                    t,
+                    dtype=param.dtype,
+                    device=param.device,
+                )
+                if with_mask
+                else None
+            )
+            model.multi_modal_projector(model.audio_tower(xs, mask), mask)
     logger.info(
         "Compiled Fun-ASR audio encoder + adaptor "
         "(dynamic=True, warmup_lfr_frames=%d, "
-        "warmup_inference_mode=%s)",
+        "warmup_inference_mode=%s, "
+        "signatures=B1/None+B1/mask+B2/mask)",
         warmup_lfr_frames,
         warmup_inference_mode,
     )

--- a/sglang_omni/models/fun_asr/stages.py
+++ b/sglang_omni/models/fun_asr/stages.py
@@ -119,6 +119,14 @@ def create_sglang_fun_asr_executor(
     request_build_max_pending: int | None = 16,
     server_args_overrides: dict[str, Any] | None = None,
 ):
+    if pre_lm_max_batch_size < 1:
+        raise ValueError(
+            f"pre_lm_max_batch_size must be >= 1, got {pre_lm_max_batch_size}"
+        )
+    if pre_lm_max_batch_wait_ms < 0:
+        raise ValueError(
+            f"pre_lm_max_batch_wait_ms must be >= 0, got {pre_lm_max_batch_wait_ms}"
+        )
 
     gpu_id = int(device.split(":")[-1]) if ":" in device else 0
 

--- a/sglang_omni/models/fun_asr/stages.py
+++ b/sglang_omni/models/fun_asr/stages.py
@@ -113,6 +113,8 @@ def create_sglang_fun_asr_executor(
     enable_pre_lm_encoder: bool = True,
     pre_lm_cache_max_entries: int = 4096,
     pre_lm_cache_size_bytes: int = 2 * 1024**3,
+    pre_lm_max_batch_size: int = 8,
+    pre_lm_max_batch_wait_ms: int = 4,
     request_build_max_workers: int = 8,
     request_build_max_pending: int | None = 16,
     server_args_overrides: dict[str, Any] | None = None,
@@ -212,6 +214,8 @@ def create_sglang_fun_asr_executor(
             ),
             cache_max_entries=pre_lm_cache_max_entries,
             cache_max_bytes=pre_lm_cache_size_bytes,
+            max_batch_size=pre_lm_max_batch_size,
+            max_batch_wait_ms=pre_lm_max_batch_wait_ms,
         )
 
     try:

--- a/tests/unit_test/fun_asr/test_encoder_compile.py
+++ b/tests/unit_test/fun_asr/test_encoder_compile.py
@@ -61,9 +61,9 @@ def test_compile_fun_asr_audio_encoder_compiles_forwards_with_dynamic_shapes(
     def _fake_compile(fn, dynamic=None):
         compile_calls.append({"fn": fn, "dynamic": dynamic})
 
-        def _wrapped(xs):
-            forward_shapes.append(tuple(xs.shape))
-            return fn(xs)
+        def _wrapped(xs, mask=None):
+            forward_shapes.append((tuple(xs.shape), mask is None))
+            return fn(xs, mask)
 
         return _wrapped
 
@@ -78,9 +78,16 @@ def test_compile_fun_asr_audio_encoder_compiles_forwards_with_dynamic_shapes(
     # intact — load_weights and weight updates match checkpoint names against
     # named_parameters, so no _orig_mod prefixes may appear.
     assert set(dict(model.audio_tower.named_parameters())) == tower_param_names
-    # Warmup ran through both compiled forwards: encoder input [1, T, 560-dim
-    # equivalent], then the encoder's output into the projector.
-    assert forward_shapes == [(1, 16, 8), (1, 16, 8)]
+    # Warmup covers serving signatures: B1/None, B1/mask, B2/mask
+    # (each through encoder then projector).
+    assert forward_shapes == [
+        ((1, 16, 8), True),
+        ((1, 16, 8), True),
+        ((1, 16, 8), False),
+        ((1, 16, 8), False),
+        ((2, 16, 8), False),
+        ((2, 16, 8), False),
+    ]
 
 
 def test_compile_fun_asr_audio_encoder_warmup_matches_service_grad_mode(
@@ -97,23 +104,24 @@ def test_compile_fun_asr_audio_encoder_warmup_matches_service_grad_mode(
     modes = []
 
     def _fake_compile(fn, dynamic=None):
-        def _wrapped(xs):
+        def _wrapped(xs, mask=None):
             modes.append((torch.is_inference_mode_enabled(), torch.is_inference(xs)))
-            return fn(xs)
+            return fn(xs, mask)
 
         return _wrapped
 
     monkeypatch.setattr(torch, "compile", _fake_compile)
 
     fun_asr_stages._compile_fun_asr_audio_encoder(model, warmup_lfr_frames=16)
-    assert modes == [(True, True), (True, True)]
+    # Three signatures × (encoder + projector).
+    assert modes == [(True, True)] * 6
 
     modes.clear()
     model = _tiny_model()
     fun_asr_stages._compile_fun_asr_audio_encoder(
         model, warmup_lfr_frames=16, warmup_inference_mode=False
     )
-    assert modes == [(False, False), (False, False)]
+    assert modes == [(False, False)] * 6
 
 
 def test_compile_fun_asr_audio_encoder_rejects_degenerate_warmup_length(

--- a/tests/unit_test/fun_asr/test_model.py
+++ b/tests/unit_test/fun_asr/test_model.py
@@ -7,11 +7,18 @@ from types import SimpleNamespace
 import pytest
 import torch
 import torch.nn as nn
+from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
 
 from sglang_omni.models.fun_asr.sglang_model import (
     FunAsrNanoAdaptor,
     FunAsrNanoAudioEncoder,
     FunAsrNanoForConditionalGeneration,
+    FunAsrNanoFSMN,
+    MultiHeadedAttentionSANM,
+    _sanm_mask_from_lengths,
+)
+from sglang_omni.models.fun_asr.tool_funcs.audio_lengths import (
+    fun_asr_low_frame_rate_length,
 )
 
 
@@ -93,7 +100,15 @@ def test_fun_asr_audio_feature_shape() -> None:
             super().__init__()
             self.anchor = nn.Parameter(torch.zeros(1))
 
-        def forward(self, value: torch.Tensor) -> torch.Tensor:
+        def forward(
+            self, value: torch.Tensor, mask: torch.Tensor | None = None
+        ) -> torch.Tensor:
+            return value
+
+    class _IdentityProjector(nn.Module):
+        def forward(
+            self, value: torch.Tensor, mask: torch.Tensor | None = None
+        ) -> torch.Tensor:
             return value
 
     model = FunAsrNanoForConditionalGeneration.__new__(
@@ -101,7 +116,7 @@ def test_fun_asr_audio_feature_shape() -> None:
     )
     nn.Module.__init__(model)
     model.audio_tower = _IdentityTower()
-    model.multi_modal_projector = nn.Identity()
+    model.multi_modal_projector = _IdentityProjector()
     item = SimpleNamespace(
         feature=torch.arange(68, dtype=torch.float32).reshape(1, 4, 17),
         feature_attention_mask=torch.ones(1, 17, dtype=torch.long),
@@ -110,3 +125,215 @@ def test_fun_asr_audio_feature_shape() -> None:
     embedding = model.get_audio_feature([item])
 
     assert embedding.shape == (3, 4)
+
+
+def _tiny_audio_mm_model() -> FunAsrNanoForConditionalGeneration:
+    """Encoder+adaptor only (no LLM) for get_audio_feature unit tests."""
+    model = FunAsrNanoForConditionalGeneration.__new__(
+        FunAsrNanoForConditionalGeneration
+    )
+    nn.Module.__init__(model)
+    model.audio_tower = FunAsrNanoAudioEncoder(
+        input_size=8,
+        output_size=8,
+        attention_heads=2,
+        linear_units=16,
+        num_blocks=2,
+        tp_blocks=1,
+        kernel_size=3,
+        dropout_rate=0.0,
+        attention_dropout_rate=0.0,
+        activation_dropout_rate=0.0,
+    )
+    model.multi_modal_projector = FunAsrNanoAdaptor(
+        encoder_dim=8,
+        llm_dim=8,
+        ffn_dim=16,
+        num_layers=1,
+        attention_heads=2,
+        dropout_rate=0.0,
+    )
+    model.eval()
+    return model
+
+
+def _audio_item(
+    feature: torch.Tensor, length: int, *, hash_id: int
+) -> MultimodalDataItem:
+    # feature: [1, D, T]; mask marks the first ``length`` frames valid.
+    t = feature.shape[-1]
+    mask = torch.zeros((1, t), dtype=torch.long)
+    mask[0, :length] = 1
+    return MultimodalDataItem(
+        modality=Modality.AUDIO,
+        hash=hash_id,
+        feature=feature,
+        model_specific_data={"feature_attention_mask": mask},
+    )
+
+
+def test_sanm_attention_mask_blocks_pad_keys() -> None:
+    torch.manual_seed(0)
+    attn = MultiHeadedAttentionSANM(n_head=2, in_feat=8, n_feat=8, dropout_rate=0.0)
+    attn.eval()
+    x = torch.randn(1, 4, 8).clone()
+    # note (guozhihao): corrupt the pad frame so missed key-masking would diverge.
+    x[0, 3] = 100.0
+    mask = torch.tensor([[[1.0, 1.0, 1.0, 0.0]]])
+    x_valid = x[:, :3].contiguous()
+
+    with torch.no_grad():
+        out_masked, v_masked = attn(x, mask)
+        out_valid, v_valid = attn(x_valid, mask=None)
+
+    assert torch.allclose(out_masked[:, :3], out_valid, atol=1e-5, rtol=1e-5)
+    assert torch.allclose(v_masked[:, :3], v_valid, atol=1e-5, rtol=1e-5)
+
+
+def test_sanm_fused_qkv_matches_separate_projections() -> None:
+    torch.manual_seed(4)
+    attn = MultiHeadedAttentionSANM(n_head=2, in_feat=8, n_feat=8, dropout_rate=0.0)
+    attn.eval()
+    x = torch.randn(2, 5, 8)
+    with torch.no_grad():
+        out, v = attn(x, mask=None)
+        v_ref = attn.v_proj(x)
+        q_ref = attn.q_proj(x)
+        k_ref = attn.k_proj(x)
+    assert torch.allclose(v, v_ref, atol=1e-5, rtol=1e-5)
+    # Fused path must still produce a usable attention output.
+    assert out.shape == x.shape
+    assert q_ref.shape == k_ref.shape == v_ref.shape
+
+
+def test_encoder_layer_runs_attention_once() -> None:
+    torch.manual_seed(5)
+    layer = FunAsrNanoAudioEncoder(
+        input_size=8,
+        output_size=8,
+        attention_heads=2,
+        linear_units=16,
+        num_blocks=1,
+        tp_blocks=0,
+        kernel_size=3,
+        dropout_rate=0.0,
+        attention_dropout_rate=0.0,
+        activation_dropout_rate=0.0,
+    ).stem
+    layer.eval()
+    calls = {"attn": 0}
+    original = layer.self_attn.forward
+
+    def _counting_attn(x, mask=None):
+        calls["attn"] += 1
+        return original(x, mask)
+
+    layer.self_attn.forward = _counting_attn  # type: ignore[method-assign]
+    with torch.no_grad():
+        layer(torch.randn(1, 6, 8), mask=None)
+    assert calls["attn"] == 1
+
+
+def test_fsmn_mask_zeros_pad_and_matches_unpadded() -> None:
+    torch.manual_seed(1)
+    fsmn = FunAsrNanoFSMN(size=4, kernel_size=3, dropout_rate=0.0)
+    fsmn.eval()
+    valid = torch.randn(1, 5, 4)
+    padded = torch.zeros(1, 8, 4)
+    padded[:, :5] = valid
+    padded[:, 5:] = 7.0
+    mask = _sanm_mask_from_lengths(
+        torch.tensor([5]), 8, dtype=valid.dtype, device=valid.device
+    )
+
+    with torch.no_grad():
+        out_serial = fsmn(valid, mask=None)
+        out_batched = fsmn(padded, mask=mask)
+
+    assert torch.allclose(out_serial, out_batched[:, :5], atol=1e-5, rtol=1e-5)
+    assert torch.allclose(out_batched[:, 5:], torch.zeros_like(out_batched[:, 5:]))
+
+
+def test_get_audio_feature_batched_matches_serial() -> None:
+    torch.manual_seed(2)
+    model = _tiny_audio_mm_model()
+
+    lengths = [5, 12, 8]
+    items = []
+    for i, length in enumerate(lengths):
+        feat = torch.randn(1, 8, length)
+        items.append(_audio_item(feat, length, hash_id=i + 1))
+
+    with torch.no_grad():
+        batched = model.get_audio_feature(items)
+        serial_parts = [model.get_audio_feature([item]) for item in items]
+        serial = torch.cat(serial_parts, dim=0)
+
+    expected_tokens = sum(
+        max(fun_asr_low_frame_rate_length(length), 1) for length in lengths
+    )
+    assert batched.shape == (expected_tokens, 8)
+    assert serial.shape == batched.shape
+    assert torch.allclose(batched, serial, atol=1e-5, rtol=1e-5)
+
+
+def test_get_audio_feature_batched_matches_serial_with_pre_padded_features() -> None:
+    """Right-padded features must use the mask length, not T."""
+    torch.manual_seed(3)
+    model = _tiny_audio_mm_model()
+
+    lengths = [6, 10]
+    t_max = 10
+    items = []
+    for i, length in enumerate(lengths):
+        feat = torch.zeros(1, 8, t_max)
+        feat[:, :, :length] = torch.randn(1, 8, length)
+        # note (guozhihao): garbage in the pad region catches a missing mask.
+        if length < t_max:
+            feat[:, :, length:] = 50.0
+        items.append(_audio_item(feat, length, hash_id=100 + i))
+
+    with torch.no_grad():
+        batched = model.get_audio_feature(items)
+        serial = torch.cat([model.get_audio_feature([item]) for item in items], dim=0)
+
+    assert batched.shape == serial.shape
+    assert torch.allclose(batched, serial, atol=1e-5, rtol=1e-5)
+
+
+def test_get_audio_feature_single_item_output_length() -> None:
+    model = _tiny_audio_mm_model()
+    length = 16
+    item = _audio_item(torch.randn(1, 8, length), length, hash_id=7)
+
+    with torch.no_grad():
+        out = model.get_audio_feature([item])
+
+    assert out.shape == (fun_asr_low_frame_rate_length(length), 8)
+
+
+def test_get_audio_feature_rejects_empty_items() -> None:
+    model = _tiny_audio_mm_model()
+    with pytest.raises(ValueError, match="at least one audio item"):
+        model.get_audio_feature([])
+
+
+def test_get_audio_feature_rejects_missing_feature() -> None:
+    model = _tiny_audio_mm_model()
+    item = MultimodalDataItem(modality=Modality.AUDIO, hash=1, feature=None)
+    with pytest.raises(ValueError, match="missing feature"):
+        model.get_audio_feature([item])
+
+
+def test_get_audio_feature_rejects_non_singleton_feature_batch() -> None:
+    model = _tiny_audio_mm_model()
+    item = MultimodalDataItem(
+        modality=Modality.AUDIO,
+        hash=2,
+        feature=torch.randn(2, 8, 4),
+        model_specific_data={
+            "feature_attention_mask": torch.ones((2, 4), dtype=torch.long),
+        },
+    )
+    with pytest.raises(ValueError, match=r"\[1, input_size, T\]"):
+        model.get_audio_feature([item])

--- a/tests/unit_test/fun_asr/test_pipeline.py
+++ b/tests/unit_test/fun_asr/test_pipeline.py
@@ -42,8 +42,30 @@ def test_fun_asr_stage_default_allows_32_running_requests() -> None:
     assert signature.parameters["enable_pre_lm_encoder"].default is True
     assert signature.parameters["pre_lm_cache_max_entries"].default == 4096
     assert signature.parameters["pre_lm_cache_size_bytes"].default == 2 * 1024**3
+    assert signature.parameters["pre_lm_max_batch_size"].default == 8
+    assert signature.parameters["pre_lm_max_batch_wait_ms"].default == 4
     assert signature.parameters["request_build_max_workers"].default == 8
     assert signature.parameters["request_build_max_pending"].default == 16
+
+
+@pytest.mark.parametrize(
+    ("batch_size", "wait_ms", "match"),
+    [
+        (0, 4, "pre_lm_max_batch_size"),
+        (-1, 4, "pre_lm_max_batch_size"),
+        (8, -1, "pre_lm_max_batch_wait_ms"),
+    ],
+)
+def test_fun_asr_stage_rejects_invalid_pre_lm_batch_knobs(
+    batch_size: int, wait_ms: int, match: str
+) -> None:
+    # Validation runs before any model/tokenizer load.
+    with pytest.raises(ValueError, match=match):
+        fun_asr_stages.create_sglang_fun_asr_executor(
+            "dummy",
+            pre_lm_max_batch_size=batch_size,
+            pre_lm_max_batch_wait_ms=wait_ms,
+        )
 
 
 def test_fun_asr_stage_default_uses_auto_static_kv_budget() -> None:


### PR DESCRIPTION
#924 ：F-PR5 encode kernel / prerequisite for F-PR5; throughput gated on F-PR3 (#1095).
## Summary
On top of F-PR3 (pre-LM encoder service + cache + single-flight), this adds a pad+mask batched encode path for Fun-ASR-Nano (F-PR5 kernel), plus SDPA / fused QKV / FSMN reuse of v.

With the default max_batch_wait_ms=4 and request_build_max_workers=8, observed avg B ≈ 2.7, so end-to-end gains vs PR3 alone are negligible.
After tuning batching/workers to sustain avg B ≥ 8, cold throughput vs PR3 alone improves by +56% at c=16 and +84% at c=32, with unchanged WER.

Also wires pre_lm_max_batch_size / pre_lm_max_batch_wait_ms through Fun-ASR stages/config (defaults remain 8 / 4) so high-concurrency cold deployments can increase coalescing explicitly.

## Motivation
- F-PR3 already moves encode before LM admission and can coalesce cross-request work, but get_audio_feature in PR3 still runs per-item forwards.

- True batched GEMM is F-PR5; this change adds a SenseVoice-style pad+mask kernel so the pre-LM service can do one encoder/adaptor forward when B>1.

- PR3’s default 8/4ms comes from review alignment with MOSS conventions (latency-first, small capped batches), not from pad+mask throughput tuning. request_build_max_workers=8 also caps concurrent encode_item enqueue, so avg B stays low.

## Modifications
- sglang_omni/models/fun_asr/sglang_model.py
   - Pad+mask: SenseVoice-style [B,1,T] through SANM / FSMN / Adaptor; get_audio_feature pads to T_max, runs one forward, then slices by fun_asr_low_frame_rate_length
   - Skip mask on the common B=1 unpadded path for parity with the old forward
   - SDPA + runtime fused QKV (keep separate q/k/v Linears for HF checkpoint names)
   - SANM attention returns (attn_out, v) so FSMN reuses v (no duplicate v_proj)
- sglang_omni/models/fun_asr/stages.py / config.py
   - New knobs: pre_lm_max_batch_size (default 8), pre_lm_max_batch_wait_ms (default 4)
- tests/unit_test/fun_asr/test_model.py: mask / batched≡serial / fused QKV / invalid-input coverage

## Benchmark
Setup: 1× H100 80GB, bf16, SeedTTS EN 1088 clips, --repeats 1, no warmup unless marked warm
### A. Default PR3 knobs (batch=8, wait=4ms, workers=8)
Observed avg B ≈ 2.6–2.8

Scenario | PR3 alone | PR3 + pad/SDPA | Δ thrpt
-- | -- | -- | --
Cold c=16 | 47.56/s · lat 0.335s · WER 0.0171 | 48.12/s · lat 0.330s · WER 0.0172 | +1.2%
Cold c=32 | 48.86/s · lat 0.647s · WER 0.0171 | 49.79/s · lat 0.636s · WER 0.0171 | +1.9%
Warm c=16 | 137.65/s · lat 0.116s · WER 0.0171 | 135.84/s · lat 0.117s · WER 0.0171 | ≈0

Takeaway: Batches are too small for pad+mask to matter; warm is cache-dominated.

### B. High-concurrency cold knobs (batch=16, wait=50ms, workers=32, pending=64)
Observed avg B ≈ 8–10

Scenario | avg B | PR3 alone | PR3 + pad/SDPA | Δ thrpt
-- | -- | -- | -- | --
Cold c=16 | ~7.5–8.9 | 47.88/s · lat 0.332s · WER 0.0171 | 74.94/s · lat 0.213s · WER 0.0171 | +56%
Cold c=32 | ~9.8 | 51.71/s · lat 0.612s · WER 0.0171 | 95.30/s · lat 0.332s · WER 0.0172 | +84%

Encoder wall time (c=32, ~500-item log checkpoint):

type | PR3 alone | PR3 + pad/SDPA
-- | -- | --
encoder_time_s | encoder_time_s | ~13.4s | ~5.8s (~2.3×)

### C. Ablation: larger wait without larger workers
batch=16, wait=50ms, workers=8 → avg B only ~4, with heavy wait tax:

Cold c=16 | thrpt | lat
-- | -- | --
PR3 alone | 21.86/s | 0.729s
PR3 + pad/SDPA | 24.98/s | 0.637s

Takeaway: Throughput drops vs defaults; request_build_max_workers must rise for avg B to grow.

### D. Encoder microbench (same SDPA kernel; pad vs serial)

Case | serial | batched | speedup
-- | -- | -- | --
B=1, T=80 | 20.4ms | 25.8ms | 0.79×
B=4 equal T=80 | 80.2ms | 25.9ms | 3.1×
B=8 var (Seed-like) | 163.0ms | 27.1ms | 6.0×

## Conclusions
- F-PR5 (pad+mask) belongs on top of F-PR3; gains show up on cold / cache-miss paths.
- Under default 4ms/8 + workers=8, e2e looks flat because coalescing is insufficient, not because the kernel is useless.
- Suggested high-concurrency cold config: pre_lm_max_batch_size=16, pre_lm_max_batch_wait_ms=50, request_build_max_workers=32 (lower wait if latency budget is tight).
- Do not make 50ms the global default: c=1 / light load pays the full collection window and hurts PR3’s low-latency profile; keep 8/4 as the latency-first default.
- WER stays aligned with PR3 alone / cookbook (~0.0171).

## Related
- Roadmap: [#924](https://github.com/sgl-project/sglang-omni/issues/924) (F-PR3 / F-PR5)
- Base: [#1095](https://github.com/sgl-project/sglang-omni/pull/1095) (8/4ms suggested by [WilsonZheng0327](https://github.com/sgl-project/sglang-omni/pull/1095#discussion_r3611779719) to follow MOSS)