### PR TITLE
[Deps] Add qwen-tts to project dependencies for Qwen3-TTS serving

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,8 @@ dependencies = [
     # Ming-Omni
     "diffusers==0.37.0",      # Align with sglang 0.5.12.post1 hard pin (diffusers==0.37.0)
     "x-transformers",          # Ming talker rotary embeddings
+    # Qwen3-TTS
+    "qwen-tts==0.1.1",        # Engine builder imports qwen_tts; pulls sox/onnxruntime it needs
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Motivation

`Qwen3TtsEngineBuilder` imports `qwen_tts` at generation-stage build (`sglang_omni/models/qwen3_tts/engine_builder.py`), but the package is not declared in `pyproject.toml`, so serving `Qwen3TTSPipelineConfig` on a fresh install fails at stage bring-up with `ModuleNotFoundError: qwen_tts`.

## Modifications

Add `qwen-tts==0.1.1` to the main dependency list (same placement as the S2-Pro and Ming-Omni serving deps). Its own metadata declares `sox`, `onnxruntime`, `accelerate` etc., so the rest of the Qwen3-TTS import chain comes transitively.

## Checklist

- [x] Format your code with `pre-commit run --all-files` (no Python changes)
- [x] Verified: `Qwen/Qwen3-TTS-12Hz-0.6B-Base` serves and completes seed-tts-eval runs on 1x H100 with exactly this package added on top of the current lockstep
