### PR TITLE
[Feature] Enable calibrated FP8 KV cache for MOSS-Transcribe-Diarize

### DIFF
--- a/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
+++ b/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
@@ -417,5 +417,27 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
                     ),
                 )
 
+    def load_kv_cache_scales(self, quantization_param_path: str) -> None:
+        """Delegate FP8 KV scale loading to the Qwen3 decoder.
+
+        Note: (Jiaxin Deng) the upstream JSON loader assigns Python floats,
+        but the FA3 decode path calls .expand() on the scales; convert to
+        0-d tensors so fp8_e4m3 KV works instead of crashing at decode.
+        """
+        self.language_model.load_kv_cache_scales(quantization_param_path)
+        device = next(self.language_model.parameters()).device
+        for layer in self.language_model.model.layers:
+            attn = layer.self_attn.attn
+            if isinstance(attn.k_scale, float):
+                attn.k_scale_float = attn.k_scale
+                attn.k_scale = torch.tensor(
+                    attn.k_scale, dtype=torch.float32, device=device
+                )
+            if isinstance(attn.v_scale, float):
+                attn.v_scale_float = attn.v_scale
+                attn.v_scale = torch.tensor(
+                    attn.v_scale, dtype=torch.float32, device=device
+                )
+
 
 EntryClass = MossTranscribeDiarizeForConditionalGeneration

--- a/tests/unit_test/moss_transcribe_diarize/test_kv_cache_scales.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_kv_cache_scales.py
@@ -60,7 +60,11 @@ def test_delegates_and_converts_float_scales_to_tensors():
         assert isinstance(attn.k_scale, torch.Tensor) and attn.k_scale.ndim == 0
         assert isinstance(attn.v_scale, torch.Tensor) and attn.v_scale.ndim == 0
         assert attn.k_scale.dtype == torch.float32
+        assert attn.v_scale.dtype == torch.float32
+        assert attn.k_scale.device.type == "cpu"
+        assert attn.v_scale.device.type == "cpu"
         assert torch.isclose(attn.k_scale, torch.tensor(expected))
+        assert torch.isclose(attn.v_scale, torch.tensor(expected))
         assert attn.k_scale_float == expected
         assert attn.v_scale_float == expected
 
@@ -68,11 +72,12 @@ def test_delegates_and_converts_float_scales_to_tensors():
 def test_tensor_scales_pass_through_unconverted():
     fake = _fake_language_model(1)
     attn = fake.lm.model.layers[0].self_attn.attn
+    assigned: dict[str, torch.Tensor] = {}
 
     def load_with_tensors(path: str) -> None:
         fake.calls.append(path)
-        attn.k_scale = torch.tensor(0.5)
-        attn.v_scale = torch.tensor(0.5)
+        assigned["k"] = attn.k_scale = torch.tensor(0.5)
+        assigned["v"] = attn.v_scale = torch.tensor(0.5)
 
     fake.lm.load_kv_cache_scales = load_with_tensors
     inst = MossTranscribeDiarizeForConditionalGeneration.__new__(
@@ -82,4 +87,5 @@ def test_tensor_scales_pass_through_unconverted():
 
     inst.load_kv_cache_scales("/tmp/kv_scales.json")
 
-    assert attn.k_scale.ndim == 0 and attn.v_scale.ndim == 0
+    assert attn.k_scale is assigned["k"] and attn.v_scale is assigned["v"]
+    assert torch.isclose(attn.k_scale, torch.tensor(0.5))

--- a/tests/unit_test/moss_transcribe_diarize/test_kv_cache_scales.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_kv_cache_scales.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""load_kv_cache_scales delegation on the MTD entry class.
+
+sglang's model_runner calls ``load_kv_cache_scales`` on the EntryClass when
+``kv_cache_dtype=fp8_e4m3`` and ``quantization_param_path`` are set; without
+the method the server hard-fails at load. The upstream JSON loader also
+assigns Python floats to ``k_scale``/``v_scale``, while the FA3 decode path
+calls ``.expand()`` on them, so the delegation must convert to 0-d tensors.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from sglang_omni.models.moss_transcribe_diarize.sglang_model import (
+    MossTranscribeDiarizeForConditionalGeneration,
+)
+
+
+def _fake_language_model(n_layers: int) -> SimpleNamespace:
+    calls: list[str] = []
+    layers = []
+    for _ in range(n_layers):
+        attn = SimpleNamespace(
+            k_scale=None, v_scale=None, k_scale_float=None, v_scale_float=None
+        )
+        layers.append(SimpleNamespace(self_attn=SimpleNamespace(attn=attn)))
+
+    def load_kv_cache_scales(path: str) -> None:
+        calls.append(path)
+        # Mirror the upstream JSON loader: assigns plain Python floats.
+        for i, layer in enumerate(layers):
+            layer.self_attn.attn.k_scale = 0.01 * (i + 1)
+            layer.self_attn.attn.v_scale = 0.01 * (i + 1)
+
+    lm = SimpleNamespace(
+        load_kv_cache_scales=load_kv_cache_scales,
+        model=SimpleNamespace(layers=layers),
+        parameters=lambda: iter([torch.zeros(1)]),
+    )
+    return SimpleNamespace(lm=lm, calls=calls)
+
+
+def test_delegates_and_converts_float_scales_to_tensors():
+    fake = _fake_language_model(3)
+    inst = MossTranscribeDiarizeForConditionalGeneration.__new__(
+        MossTranscribeDiarizeForConditionalGeneration
+    )
+    inst.language_model = fake.lm
+
+    inst.load_kv_cache_scales("/tmp/kv_scales.json")
+
+    assert fake.calls == ["/tmp/kv_scales.json"]
+    for i, layer in enumerate(fake.lm.model.layers):
+        attn = layer.self_attn.attn
+        expected = 0.01 * (i + 1)
+        # FA3 calls .expand() on these; floats would crash at decode time.
+        assert isinstance(attn.k_scale, torch.Tensor) and attn.k_scale.ndim == 0
+        assert isinstance(attn.v_scale, torch.Tensor) and attn.v_scale.ndim == 0
+        assert attn.k_scale.dtype == torch.float32
+        assert torch.isclose(attn.k_scale, torch.tensor(expected))
+        assert attn.k_scale_float == expected
+        assert attn.v_scale_float == expected
+
+
+def test_tensor_scales_pass_through_unconverted():
+    fake = _fake_language_model(1)
+    attn = fake.lm.model.layers[0].self_attn.attn
+
+    def load_with_tensors(path: str) -> None:
+        fake.calls.append(path)
+        attn.k_scale = torch.tensor(0.5)
+        attn.v_scale = torch.tensor(0.5)
+
+    fake.lm.load_kv_cache_scales = load_with_tensors
+    inst = MossTranscribeDiarizeForConditionalGeneration.__new__(
+        MossTranscribeDiarizeForConditionalGeneration
+    )
+    inst.language_model = fake.lm
+
+    inst.load_kv_cache_scales("/tmp/kv_scales.json")
+
+    assert attn.k_scale.ndim == 0 and attn.v_scale.ndim == 0


### PR DESCRIPTION
## Motivation

MOSS-Transcribe-Diarize decode is KV-read-bound: contexts run ~33k tokens per request, raising the admission cap 16 -> 64 leaves throughput flat, and the per-step KV traffic scales with batch size (profiling in #921). The direct lever is cutting KV bytes, but `kv_cache_dtype: fp8_e4m3` is unusable for this model today, twice over:

1. sglang's model runner calls `load_kv_cache_scales` on the entry class when `quantization_param_path` is set; the MTD entry class lacks the method, so the server fails at load.
2. Without calibrated scales the e4m3 cast produces NaN, not saturation (measured K amax reaches 584 vs the e4m3 max of 448), and output degenerates to runaway garbage (CER 5.3 -> 1800+).

## Modifications

Add `load_kv_cache_scales` to `MossTranscribeDiarizeForConditionalGeneration`: delegate to the Qwen3 decoder (same pattern as the moss_tts entry classes), then convert the scales the upstream JSON loader assigns as Python floats into 0-d float32 tensors, because the FA3 decode path calls `.expand()` on them and crashes on floats.

Unit tests cover the delegation, the float-to-tensor conversion, and tensor pass-through.

## Usage

Record per-layer K/V amax over a short bf16 calibration run, write the vLLM-legacy scales JSON (`model_type: qwen3`, 28 layers, `scale = amax / 448 * margin`), then launch with:

```yaml
runtime_overrides:
  asr:
    server_args_overrides:
      kv_cache_dtype: fp8_e4m3
      quantization_param_path: /path/kv_scales.json
```

## Evidence (1x H100, movies800times)

* Startup gates [measured]: FA3 backend retained (`fp8_e5m2` silently demotes to triton, do not use it), `Loaded KV cache scaling factors from ...` logged.
* Quality preserved [measured]: cp_cer 13.42-13.66 across four 256-sample fp8 runs (c8 and c32) vs 13.51-13.77 for bf16 on the same sets; a same-100-sample paired smoke gives 15.44 (fp8) vs 16.15 (bf16). Uncalibrated fp8_e4m3 for contrast: cp_cer 1800+.
* Throughput: no claim in this PR. The KV pool doubles in capacity and per-step KV reads halve in bytes, but our A/B window was contention-noisy (within-arm spread ~2x from co-located jobs); a quiet-window ABAB will follow as a comment.

## Checklist

- [x] Format your code with `pre-commit run --all-files`
- [x] Add unit tests
