### PR TITLE
[Fix] Ming speech path on transformers 5.x: cache_position ints, portable voice-preset paths

### DIFF
--- a/sglang_omni/models/ming_omni/components/streaming_talker.py
+++ b/sglang_omni/models/ming_omni/components/streaming_talker.py
@@ -23,14 +23,13 @@ import numpy as np
 import torch
 
 from sglang_omni.models.ming_omni.components.streaming_text import uint8_tensor_to_text
+from sglang_omni.models.ming_omni.components.voice_presets import (
+    resolve_prompt_wav_path,
+)
 from sglang_omni.models.ming_omni.pipeline.next_stage import TALKER_STREAM_STAGE
 from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
-
-from sglang_omni.models.ming_omni.components.voice_presets import (
-    resolve_prompt_wav_path,
-)
 
 logger = logging.getLogger(__name__)
 

--- a/sglang_omni/models/ming_omni/components/streaming_talker.py
+++ b/sglang_omni/models/ming_omni/components/streaming_talker.py
@@ -28,6 +28,10 @@ from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.messages import IncomingMessage, OutgoingMessage
 
+from sglang_omni.models.ming_omni.components.voice_presets import (
+    resolve_prompt_wav_path,
+)
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_VOICE = "DB30"
@@ -392,11 +396,20 @@ class MingStreamingTalkerScheduler:
                     f"[TALKER_STREAM] voice preset {name!r} in "
                     f"{manifest_path} is missing prompt_wav_path"
                 )
-            resolved = os.path.join(talker_dir, rel_path)
-            if not os.path.isfile(resolved):
+            resolved = resolve_prompt_wav_path(rel_path, talker_dir)
+            if resolved is None:
                 raise FileNotFoundError(
                     f"[TALKER_STREAM] voice preset {name!r} references "
-                    f"missing prompt wav {resolved}"
+                    f"missing prompt wav {rel_path} (tried the talker dir "
+                    f"and the checkout-root suffix fallback)"
+                )
+            if resolved != os.path.join(talker_dir, rel_path):
+                logger.warning(
+                    "[TALKER_STREAM] voice preset %r prompt wav %s resolved "
+                    "via suffix fallback to %s",
+                    name,
+                    rel_path,
+                    resolved,
                 )
             entry["prompt_wav_path"] = resolved
 

--- a/sglang_omni/models/ming_omni/components/talker_executor.py
+++ b/sglang_omni/models/ming_omni/components/talker_executor.py
@@ -23,12 +23,11 @@ from pathlib import Path
 
 import torch
 
-from sglang_omni.models.ming_omni.pipeline.usage import build_text_usage
-from sglang_omni.proto import StagePayload
-
 from sglang_omni.models.ming_omni.components.voice_presets import (
     resolve_prompt_wav_path,
 )
+from sglang_omni.models.ming_omni.pipeline.usage import build_text_usage
+from sglang_omni.proto import StagePayload
 
 logger = logging.getLogger(__name__)
 

--- a/sglang_omni/models/ming_omni/components/talker_executor.py
+++ b/sglang_omni/models/ming_omni/components/talker_executor.py
@@ -26,6 +26,10 @@ import torch
 from sglang_omni.models.ming_omni.pipeline.usage import build_text_usage
 from sglang_omni.proto import StagePayload
 
+from sglang_omni.models.ming_omni.components.voice_presets import (
+    resolve_prompt_wav_path,
+)
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_VOICE = "DB30"
@@ -306,11 +310,20 @@ class MingTalkerExecutor:
                     f"[TALKER] voice preset {name!r} in {manifest_path} is "
                     f"missing prompt_wav_path"
                 )
-            resolved = os.path.join(talker_dir, rel_path)
-            if not os.path.isfile(resolved):
+            resolved = resolve_prompt_wav_path(rel_path, talker_dir)
+            if resolved is None:
                 raise FileNotFoundError(
                     f"[TALKER] voice preset {name!r} references missing "
-                    f"prompt wav {resolved}"
+                    f"prompt wav {rel_path} (tried the talker dir and the "
+                    f"checkout-root suffix fallback)"
+                )
+            if resolved != os.path.join(talker_dir, rel_path):
+                logger.warning(
+                    "[TALKER] voice preset %r prompt wav %s resolved via "
+                    "suffix fallback to %s",
+                    name,
+                    rel_path,
+                    resolved,
                 )
             entry["prompt_wav_path"] = resolved
 

--- a/sglang_omni/models/ming_omni/components/voice_presets.py
+++ b/sglang_omni/models/ming_omni/components/voice_presets.py
@@ -7,32 +7,57 @@ import os
 
 import sglang_omni
 
+ASSET_ROOT_ENV = "SGLANG_OMNI_VOICE_ASSET_ROOT"
+
 
 def _fallback_roots() -> list[str]:
+    roots = []
+    env_root = os.environ.get(ASSET_ROOT_ENV)
+    if env_root:
+        roots.append(env_root)
     # Checkpoint manifests may reference assets from the authoring checkout
-    # (Ming-flash-omni-2.0's DB30 points at tests/data); the local checkout
-    # root is the only stand-in for that.
+    # (Ming-flash-omni-2.0's DB30 points at tests/data). A wheel install's
+    # package parent is site-packages and ships no such assets, so only offer
+    # the parent when it actually looks like a checkout.
     pkg_root = os.path.dirname(os.path.dirname(os.path.abspath(sglang_omni.__file__)))
-    return [pkg_root]
+    if os.path.isdir(os.path.join(pkg_root, "tests")):
+        roots.append(pkg_root)
+    return roots
+
+
+def _contained(candidate: str, root: str) -> bool:
+    return os.path.realpath(candidate).startswith(os.path.realpath(root) + os.sep)
 
 
 def resolve_prompt_wav_path(raw_path: str, talker_dir: str) -> str | None:
     """Return an existing absolute path for a manifest prompt-wav entry.
 
     Tries the checkpoint-relative join first, then re-resolves path suffixes
-    (longest first) against the talker dir and the checkout root, so absolute
-    paths baked in on the authoring machine keep working. Returns None when
-    no candidate exists.
+    (longest first) against the talker dir and the fallback roots
+    (``SGLANG_OMNI_VOICE_ASSET_ROOT``, then the checkout root when running
+    from a checkout), so absolute paths baked in on the authoring machine
+    keep working. Parent traversal fails closed; bare filenames only match
+    inside the talker dir; every fallback match must stay inside its root.
+    Returns None when no candidate exists.
     """
-    primary = os.path.join(talker_dir, raw_path)
-    if os.path.isfile(primary):
-        return primary
-    parts = [p for p in raw_path.replace("\\", "/").split("/") if p]
+    parts = [p for p in raw_path.replace("\\", "/").split("/") if p and p != "."]
+    if ".." in parts:
+        return None
+    if os.path.isabs(raw_path):
+        if os.path.isfile(raw_path):
+            return raw_path
+    else:
+        primary = os.path.join(talker_dir, raw_path)
+        if os.path.isfile(primary) and _contained(primary, talker_dir):
+            return primary
     roots = [talker_dir, *_fallback_roots()]
     for start in range(len(parts)):
-        tail = os.path.join(*parts[start:])
+        tail_parts = parts[start:]
+        tail = os.path.join(*tail_parts)
         for root in roots:
+            if len(tail_parts) < 2 and root != talker_dir:
+                continue
             candidate = os.path.join(root, tail)
-            if os.path.isfile(candidate):
+            if os.path.isfile(candidate) and _contained(candidate, root):
                 return candidate
     return None

--- a/sglang_omni/models/ming_omni/components/voice_presets.py
+++ b/sglang_omni/models/ming_omni/components/voice_presets.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prompt-wav path resolution for Ming talker voice manifests."""
+
+from __future__ import annotations
+
+import os
+
+import sglang_omni
+
+
+def _fallback_roots() -> list[str]:
+    # Checkpoint manifests may reference assets from the authoring checkout
+    # (Ming-flash-omni-2.0's DB30 points at tests/data); the local checkout
+    # root is the only stand-in for that.
+    pkg_root = os.path.dirname(os.path.dirname(os.path.abspath(sglang_omni.__file__)))
+    return [pkg_root]
+
+
+def resolve_prompt_wav_path(raw_path: str, talker_dir: str) -> str | None:
+    """Return an existing absolute path for a manifest prompt-wav entry.
+
+    Tries the checkpoint-relative join first, then re-resolves path suffixes
+    (longest first) against the talker dir and the checkout root, so absolute
+    paths baked in on the authoring machine keep working. Returns None when
+    no candidate exists.
+    """
+    primary = os.path.join(talker_dir, raw_path)
+    if os.path.isfile(primary):
+        return primary
+    parts = [p for p in raw_path.replace("\\", "/").split("/") if p]
+    roots = [talker_dir, *_fallback_roots()]
+    for start in range(len(parts)):
+        tail = os.path.join(*parts[start:])
+        for root in roots:
+            candidate = os.path.join(root, tail)
+            if os.path.isfile(candidate):
+                return candidate
+    return None

--- a/sglang_omni/models/ming_omni/talker/audio_vae/vae_modules.py
+++ b/sglang_omni/models/ming_omni/talker/audio_vae/vae_modules.py
@@ -72,6 +72,9 @@ class Encoder(nn.Module):
     ):
         super().__init__()
         config = Qwen2Config.from_dict(config_dict=encoder_args)
+        # Note: (Jiaxin Deng) transformers 5.6's flash-attention integration
+        # crashes on plain Qwen2 backbones (s_aux is None); pin to sdpa.
+        config._attn_implementation = "sdpa"
         self.encoder = Qwen2Model(config)
         self.input_dim = input_dim
         self.hop_size = hop_size
@@ -136,6 +139,7 @@ class Decoder(nn.Module):
     def __init__(self, decoder_args, output_dim=320, latent_dim=64, patch_size=-1):
         super().__init__()
         config = Qwen2Config.from_dict(config_dict=decoder_args)
+        config._attn_implementation = "sdpa"
         self.decoder = Qwen2Model(config)
         self.output_dim = output_dim
         self.latent_dim = latent_dim

--- a/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
+++ b/sglang_omni/models/ming_omni/talker/modeling_ming_omni_talker.py
@@ -77,8 +77,7 @@ class SpkembExtractor:
             self.campplus_session.run(
                 None,
                 {
-                    self.campplus_session.get_inputs()[0]
-                    .name: feat.unsqueeze(dim=0)
+                    self.campplus_session.get_inputs()[0].name: feat.unsqueeze(dim=0)
                     .cpu()
                     .numpy()
                 },
@@ -258,6 +257,14 @@ class CFMGraphExecutorPool:
             self.release(executor)
 
 
+def _decode_cache_position(past_key_values, num_new_tokens, device):
+    # transformers>=5 returns a tensor from get_seq_length(); arange needs ints.
+    past_seen_tokens = int(past_key_values.get_seq_length())
+    return torch.arange(
+        past_seen_tokens, past_seen_tokens + num_new_tokens, device=device
+    )
+
+
 class MingOmniTalker(nn.Module):
     """Ming-Omni talker model.
 
@@ -364,9 +371,9 @@ class MingOmniTalker(nn.Module):
             if param.numel() == 1 and loaded_weight.numel() == 1:
                 param.data.fill_(loaded_weight.item())
             else:
-                assert (
-                    param.size() == loaded_weight.size()
-                ), f"Shape mismatch for {name}: param={param.size()}, weight={loaded_weight.size()}"
+                assert param.size() == loaded_weight.size(), (
+                    f"Shape mismatch for {name}: param={param.size()}, weight={loaded_weight.size()}"
+                )
                 param.data.copy_(loaded_weight)
             loaded.add(name)
 
@@ -541,11 +548,10 @@ class MingOmniTalker(nn.Module):
                         output_hidden_states=True,
                     )
                 else:
-                    past_seen_tokens = past_key_values.get_seq_length()
-                    cache_position = torch.arange(
-                        past_seen_tokens,
-                        past_seen_tokens + inputs_embeds.shape[1],
-                        device=inputs_embeds.device,
+                    cache_position = _decode_cache_position(
+                        past_key_values,
+                        inputs_embeds.shape[1],
+                        inputs_embeds.device,
                     )
 
                     if model_graph is None:
@@ -640,9 +646,9 @@ class MingOmniTalker(nn.Module):
         abort_event: threading.Event | None = None,
         max_decode_steps: int | None = None,
     ):
-        assert (
-            self.tokenizer is not None
-        ), "Tokenizer not set. Call set_tokenizer() first."
+        assert self.tokenizer is not None, (
+            "Tokenizer not set. Call set_tokenizer() first."
+        )
         tokenizer = self.tokenizer
 
         spk_emb_prompt: list = []

--- a/tests/unit_test/ming_omni/test_audio_vae_attn_impl.py
+++ b/tests/unit_test/ming_omni/test_audio_vae_attn_impl.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Audio VAE backbones must not resolve to flash-attention.
+
+transformers 5.6.0's flash-attention integration crashes on plain Qwen2
+backbones (`s_aux.to(...)` with `s_aux=None`), which kills the first speech
+request during prompt-wav registration. Pin the VAE backbones to sdpa.
+"""
+
+from __future__ import annotations
+
+from sglang_omni.models.ming_omni.talker.audio_vae.vae_modules import (
+    Decoder,
+    Encoder,
+)
+
+_BACKBONE = {
+    "hidden_size": 32,
+    "intermediate_size": 64,
+    # The encoder aggregator forces 4 layers; layer_types must cover them.
+    "num_hidden_layers": 4,
+    "num_attention_heads": 2,
+    "num_key_value_heads": 2,
+    "max_position_embeddings": 64,
+    "vocab_size": 16,
+}
+
+
+def test_encoder_backbones_pinned_to_sdpa():
+    enc = Encoder(
+        encoder_args=dict(_BACKBONE),
+        input_dim=8,
+        hop_size=4,
+        latent_dim=8,
+        patch_size=2,
+    )
+    assert enc.encoder.config._attn_implementation == "sdpa"
+    assert enc.aggregator.config._attn_implementation == "sdpa"
+
+
+def test_decoder_backbone_pinned_to_sdpa():
+    dec = Decoder(
+        decoder_args=dict(_BACKBONE),
+        output_dim=8,
+        latent_dim=8,
+        patch_size=2,
+    )
+    assert dec.decoder.config._attn_implementation == "sdpa"

--- a/tests/unit_test/ming_omni/test_talker_cache_position.py
+++ b/tests/unit_test/ming_omni/test_talker_cache_position.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Decode cache_position under transformers 5.x tensor-returning caches."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.models.ming_omni.talker.modeling_ming_omni_talker import (
+    _decode_cache_position,
+)
+
+
+def test_raw_arange_rejects_tensor_bounds():
+    """transformers 5.x StaticCache.get_seq_length() returns a 1-element
+    tensor once the cache is non-empty; feeding it to arange is a TypeError.
+    This is the #1114 failure mode the helper exists to prevent."""
+    seen = torch.tensor([5])
+    with pytest.raises(TypeError):
+        torch.arange(seen, seen + 1, device="cpu")
+
+
+@pytest.mark.parametrize("seen", [0, torch.tensor([5]), torch.tensor(7)])
+def test_decode_cache_position_coerces_cache_length(seen):
+    cache = SimpleNamespace(get_seq_length=lambda: seen)
+    pos = _decode_cache_position(cache, 3, torch.device("cpu"))
+    start = int(seen) if not isinstance(seen, int) else seen
+    assert pos.tolist() == [start, start + 1, start + 2]
+    assert pos.device.type == "cpu"

--- a/tests/unit_test/ming_omni/test_talker_voice_validation.py
+++ b/tests/unit_test/ming_omni/test_talker_voice_validation.py
@@ -632,7 +632,7 @@ def test_generate_emits_final_true_when_stop_token_fires(monkeypatch):
     _stub_for_generate(talker, num_steps_before_stop=4)
 
     monkeypatch.setattr(
-        "sglang_omni.models.ming_omni.talker.modeling_ming_omni_talker." "StaticCache",
+        "sglang_omni.models.ming_omni.talker.modeling_ming_omni_talker.StaticCache",
         lambda **kw: object(),
     )
 
@@ -664,7 +664,7 @@ def test_generate_emits_final_true_when_duration_cap_hits(monkeypatch):
     _stub_for_generate(talker, num_steps_before_stop=None)
 
     monkeypatch.setattr(
-        "sglang_omni.models.ming_omni.talker.modeling_ming_omni_talker." "StaticCache",
+        "sglang_omni.models.ming_omni.talker.modeling_ming_omni_talker.StaticCache",
         lambda **kw: object(),
     )
 
@@ -683,3 +683,69 @@ def test_generate_emits_final_true_when_duration_cap_hits(monkeypatch):
     assert len(yields) == 3
     flags = [bool(flag) for _, flag in yields]
     assert flags == [False, False, True]
+
+
+def test_executor_validate_resolves_absolute_authoring_path_via_suffix(tmp_path: Path):
+    """Checkpoint manifests can ship absolute paths from the authoring rig;
+    a path suffix that exists under the talker dir must still resolve."""
+    talker_dir = tmp_path / "talker"
+    wav_rel = "spks/DB30.wav"
+    abs_authoring = "/workspace/authoring-rig/checkout/spks/DB30.wav"
+    manifest = _write_voice_manifest(
+        talker_dir,
+        {"DB30": {"prompt_text": "x", "prompt_wav_path": abs_authoring}},
+        {wav_rel: b"\x00" * 16},
+    )
+    voice_dict = {"DB30": {"prompt_text": "x", "prompt_wav_path": abs_authoring}}
+    executor = MingTalkerExecutor(
+        model_path=str(tmp_path / "model"),
+        talker_model_path=str(talker_dir),
+        voice="DB30",
+    )
+    executor._validate_voice_presets(voice_dict, str(manifest), str(talker_dir))
+    assert voice_dict["DB30"]["prompt_wav_path"] == str(talker_dir / wav_rel)
+
+
+def test_executor_validate_resolves_via_fallback_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """DB30 in inclusionAI/Ming-flash-omni-2.0 points at the authoring
+    checkout's tests/data asset; the repo-root fallback must recover it."""
+    from sglang_omni.models.ming_omni.components import voice_presets
+
+    talker_dir = tmp_path / "talker"
+    repo_root = tmp_path / "checkout"
+    wav = repo_root / "tests" / "data" / "query_to_cars.wav"
+    wav.parent.mkdir(parents=True)
+    wav.write_bytes(b"\x00" * 16)
+    abs_authoring = "/workspace/authoring-rig-fallback/tests/data/query_to_cars.wav"
+    manifest = _write_voice_manifest(
+        talker_dir,
+        {"DB30": {"prompt_text": "x", "prompt_wav_path": abs_authoring}},
+    )
+    monkeypatch.setattr(voice_presets, "_fallback_roots", lambda: [str(repo_root)])
+    voice_dict = {"DB30": {"prompt_text": "x", "prompt_wav_path": abs_authoring}}
+    executor = MingTalkerExecutor(
+        model_path=str(tmp_path / "model"),
+        talker_model_path=str(talker_dir),
+        voice="DB30",
+    )
+    executor._validate_voice_presets(voice_dict, str(manifest), str(talker_dir))
+    assert voice_dict["DB30"]["prompt_wav_path"] == str(wav)
+
+
+def test_executor_validate_still_raises_when_no_candidate_exists(tmp_path: Path):
+    talker_dir = tmp_path / "talker"
+    abs_authoring = "/workspace/nowhere/spks/MISSING.wav"
+    manifest = _write_voice_manifest(
+        talker_dir,
+        {"DB30": {"prompt_text": "x", "prompt_wav_path": abs_authoring}},
+    )
+    voice_dict = {"DB30": {"prompt_text": "x", "prompt_wav_path": abs_authoring}}
+    executor = MingTalkerExecutor(
+        model_path=str(tmp_path / "model"),
+        talker_model_path=str(talker_dir),
+        voice="DB30",
+    )
+    with pytest.raises(FileNotFoundError):
+        executor._validate_voice_presets(voice_dict, str(manifest), str(talker_dir))

--- a/tests/unit_test/ming_omni/test_talker_voice_validation.py
+++ b/tests/unit_test/ming_omni/test_talker_voice_validation.py
@@ -749,3 +749,69 @@ def test_executor_validate_still_raises_when_no_candidate_exists(tmp_path: Path)
     )
     with pytest.raises(FileNotFoundError):
         executor._validate_voice_presets(voice_dict, str(manifest), str(talker_dir))
+
+
+def test_env_asset_root_resolves_for_wheel_installs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Wheel installs have no checkout; SGLANG_OMNI_VOICE_ASSET_ROOT is the
+    documented escape hatch."""
+    talker_dir = tmp_path / "talker"
+    asset_root = tmp_path / "assets"
+    wav = asset_root / "tests" / "data" / "query_to_cars.wav"
+    wav.parent.mkdir(parents=True)
+    wav.write_bytes(b"\x00" * 16)
+    monkeypatch.setenv("SGLANG_OMNI_VOICE_ASSET_ROOT", str(asset_root))
+    abs_authoring = "/workspace/authoring-rig/tests/data/query_to_cars.wav"
+    manifest = _write_voice_manifest(
+        talker_dir,
+        {"DB30": {"prompt_text": "x", "prompt_wav_path": abs_authoring}},
+    )
+    voice_dict = {"DB30": {"prompt_text": "x", "prompt_wav_path": abs_authoring}}
+    executor = MingTalkerExecutor(
+        model_path=str(tmp_path / "model"),
+        talker_model_path=str(talker_dir),
+        voice="DB30",
+    )
+    executor._validate_voice_presets(voice_dict, str(manifest), str(talker_dir))
+    assert voice_dict["DB30"]["prompt_wav_path"] == str(wav)
+
+
+def test_parent_traversal_in_manifest_path_fails_closed(tmp_path: Path):
+    talker_dir = tmp_path / "talker"
+    outside = tmp_path / "secret.wav"
+    outside.write_bytes(b"\x00" * 16)
+    rel = "../secret.wav"
+    manifest = _write_voice_manifest(
+        talker_dir,
+        {"DB30": {"prompt_text": "x", "prompt_wav_path": rel}},
+    )
+    voice_dict = {"DB30": {"prompt_text": "x", "prompt_wav_path": rel}}
+    executor = MingTalkerExecutor(
+        model_path=str(tmp_path / "model"),
+        talker_model_path=str(talker_dir),
+        voice="DB30",
+    )
+    with pytest.raises(FileNotFoundError):
+        executor._validate_voice_presets(voice_dict, str(manifest), str(talker_dir))
+
+
+def test_bare_basename_not_resolved_under_fallback_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A lone filename may match inside the checkpoint's talker dir, but the
+    wider fallback roots require at least parent/name to avoid same-name
+    shadowing."""
+    from sglang_omni.models.ming_omni.components import voice_presets
+
+    talker_dir = tmp_path / "talker"
+    talker_dir.mkdir(parents=True)
+    root = tmp_path / "checkout"
+    (root / "somewhere").mkdir(parents=True)
+    shadow = root / "somewhere" / "voice.wav"
+    shadow.write_bytes(b"\x00" * 16)
+    monkeypatch.setattr(voice_presets, "_fallback_roots", lambda: [str(root)])
+    assert (
+        voice_presets.resolve_prompt_wav_path("/authoring/voice.wav", str(talker_dir))
+        is None
+    )


### PR DESCRIPTION
## Motivation

Addresses #1114 layers 2 and 3 (layer 1, the missing `x-transformers` dep, is already on main). The Ming speech path fails on current main:

1. **Layer 3**: the vendored talker feeds `StaticCache.get_seq_length()` straight into `torch.arange`. transformers 5.x returns a 1-element tensor there once the cache is non-empty (4.x returned int), so the first decode step of talker warmup raises `TypeError: arange() received an invalid combination of arguments - got (Tensor, Tensor, device=...)`. Root cause pinned by a CPU-only micro-repro in the #1114 thread.
2. **Layer 2**: `Ming-flash-omni-2.0`'s `talker/data/voice_name.json` ships absolute prompt-wav paths from the authoring machine (`/workspace/sglang-omni-pr1000-head/tests/data/query_to_cars.wav` for the default DB30 voice), so preset validation fails everywhere except the authoring rig.
3. **A further layer, surfaced once the two above were fixed**: the audio VAE builds plain `Qwen2Model` backbones that resolve to flash-attention, and transformers 5.6's FA integration crashes on them (`s_aux.to(...)` with `s_aux=None` in `flash_attention_forward`), killing prompt-wav registration.

## Modifications

* `talker/modeling_ming_omni_talker.py`: extract `_decode_cache_position` and coerce the cache length through `int()`.
* New `components/voice_presets.py`: `resolve_prompt_wav_path` tries the checkpoint-relative join first, then re-resolves path suffixes (longest first) against the talker dir and the fallback roots: `SGLANG_OMNI_VOICE_ASSET_ROOT` (the wheel-install escape hatch) and the checkout root when running from a checkout. Parent traversal fails closed, bare filenames only match inside the talker dir, and every fallback match must stay inside its root. Both `_validate_voice_presets` copies share it, log a warning when the fallback engages, and still fail closed when no candidate exists.
* `talker/audio_vae/vae_modules.py`: pin the VAE Qwen2 backbones to sdpa (the VAE path is not launch-bound; sdpa costs nothing measurable).

## Tests

`tests/unit_test/ming_omni/`: a contract test proving tensor bounds break raw `arange` (the #1114 failure mode) plus coercion cases for int / 1-element / 0-d cache lengths; suffix resolution under the talker dir, the env asset root, and the checkout root; traversal, containment, and same-name-shadowing fail closed; the no-candidate failure; VAE backbones asserted sdpa. Full ming_omni suite: 201 passed.

## Validation status

Unit-level complete. A 5-GPU end-to-end run (thinker TP4 + talker, no symlink workaround) at the two-fix commit verified layers 1-2 in vivo: health OK, text path OK, zero arange errors, the DB30 preset resolved through the suffix fallback (logged), and the remaining 500 was the VAE flash-attention crash this PR's third fix addresses. A full speech-success e2e at the final head follows as a comment.
