### PR TITLE
[Qwen3-Omni Perf] Raise thinker max_running_requests default to 64

### DIFF
--- a/docs/basic_usage/qwen3_omni.md
+++ b/docs/basic_usage/qwen3_omni.md
@@ -232,6 +232,27 @@ python examples/run_omni.py qwen3-speech-server \
 the global value for that stage. Values must be greater than `0` and less than
 `1`.
 
+The thinker admits up to 64 running requests by default. Use the
+thinker-specific flag to lower or raise that limit in either text-only or
+speech mode:
+
+```bash
+sgl-omni serve \
+  --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
+  --thinker-max-running-requests 16
+```
+
+`--max-running-requests` continues to target the generation stage, which is the
+talker in the Qwen3-Omni speech pipeline. To configure the thinker through a
+pipeline YAML file instead, use the stage runtime override:
+
+```yaml
+runtime_overrides:
+  thinker:
+    server_args_overrides:
+      max_running_requests: 16
+```
+
 ## Single-GPU FP8 on H100/H20
 
 SGLang-Omni can also serve native FP8 Qwen3-Omni checkpoints. Native FP8 uses

--- a/sglang_omni/cli/serve.py
+++ b/sglang_omni/cli/serve.py
@@ -572,6 +572,7 @@ def apply_thinker_server_args_cli_overrides(
     *,
     cpu_offload_gb: int | None,
     quantization: str | None,
+    thinker_max_running_requests: int | None = None,
 ) -> PipelineConfig:
     updates: dict[str, object] = {}
     if cpu_offload_gb is not None:
@@ -583,6 +584,10 @@ def apply_thinker_server_args_cli_overrides(
         if not quantization:
             raise typer.BadParameter("--quantization must not be empty")
         updates["quantization"] = quantization
+    if thinker_max_running_requests is not None:
+        if thinker_max_running_requests < 1:
+            raise typer.BadParameter("--thinker-max-running-requests must be >= 1")
+        updates["max_running_requests"] = int(thinker_max_running_requests)
 
     if updates:
         _apply_stage_server_args_override(
@@ -1164,6 +1169,18 @@ def serve(
             ),
         ),
     ] = None,
+    thinker_max_running_requests: Annotated[
+        int | None,
+        typer.Option(
+            "--thinker-max-running-requests",
+            "--thinker_max_running_requests",
+            min=1,
+            help=(
+                "Override SGLang thinker stage max_running_requests. "
+                "Omit to use the pipeline config default."
+            ),
+        ),
+    ] = None,
     max_running_requests: Annotated[
         int | None,
         typer.Option(
@@ -1249,6 +1266,7 @@ def serve(
         merged_config,
         cpu_offload_gb=cpu_offload_gb,
         quantization=quantization,
+        thinker_max_running_requests=thinker_max_running_requests,
     )
     merged_config = apply_parallelism_cli_overrides(
         merged_config,

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -960,15 +960,14 @@ def create_sglang_thinker_executor_from_config(
     # the streaming-SST thinker path benefits out of the box; either key can be
     # overridden via server_args_overrides (set enable_mixed_chunk=False to opt
     # out). Note: mixed-chunk only engages when chunked_prefill_size > 0.
-    overrides: dict[str, Any] = {
-        "disable_cuda_graph": False,
-        "enable_mixed_chunk": True,
-        "chunked_prefill_size": 8192,
-        "max_running_requests": 64,
-        "sampling_backend": "pytorch",
-    }
-    if server_args_overrides:
-        overrides.update(server_args_overrides)
+    overrides = build_generation_batch_overrides(
+        max_running_requests=64,
+        server_args_overrides=server_args_overrides,
+        disable_cuda_graph=False,
+        enable_mixed_chunk=True,
+        chunked_prefill_size=8192,
+        sampling_backend="pytorch",
+    )
     overrides["tp_size"] = tp_size
     has_explicit_colocated_mem_fraction = (
         total_gpu_memory_fraction is not None
@@ -990,6 +989,10 @@ def create_sglang_thinker_executor_from_config(
         model_path,
         context_length=thinker_max_seq_len,
         **overrides,
+    )
+    validate_generation_batch_policy(
+        model_name="Qwen3-Omni thinker",
+        server_args=server_args,
     )
     if total_gpu_memory_fraction is None:
         encoder_reserve_applied = _apply_qwen_thinker_encoder_reserve(

--- a/sglang_omni/models/qwen3_omni/stages.py
+++ b/sglang_omni/models/qwen3_omni/stages.py
@@ -964,6 +964,7 @@ def create_sglang_thinker_executor_from_config(
         "disable_cuda_graph": False,
         "enable_mixed_chunk": True,
         "chunked_prefill_size": 8192,
+        "max_running_requests": 64,
         "sampling_backend": "pytorch",
     }
     if server_args_overrides:

--- a/tests/unit_test/qwen3_omni/test_cli.py
+++ b/tests/unit_test/qwen3_omni/test_cli.py
@@ -199,6 +199,43 @@ def test_cli_text_only_selects_text_variant(from_model_path, launch_server):
     launch_server.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    ("config_cls", "text_only"),
+    [
+        (Qwen3OmniPipelineConfig, True),
+        (Qwen3OmniSpeechPipelineConfig, False),
+    ],
+)
+@patch("sglang_omni.cli.serve.launch_server")
+@patch("sglang_omni.cli.serve.ConfigManager.from_model_path")
+def test_cli_thinker_max_running_requests_targets_thinker_in_both_variants(
+    from_model_path,
+    launch_server,
+    config_cls,
+    text_only,
+):
+    from_model_path.return_value = _DummyManager(config_cls(model_path="dummy"))
+
+    serve(
+        **_serve_kwargs(
+            text_only=text_only,
+            thinker_max_running_requests=16,
+        )
+    )
+
+    launched_config = launch_server.call_args.args[0]
+    thinker_overrides = _stage(launched_config, "thinker").factory_args[
+        "server_args_overrides"
+    ]
+    assert thinker_overrides["max_running_requests"] == 16
+    if isinstance(launched_config, Qwen3OmniSpeechPipelineConfig):
+        talker_overrides = _stage(launched_config, "talker_ar").factory_args.get(
+            "server_args_overrides",
+            {},
+        )
+        assert "max_running_requests" not in talker_overrides
+
+
 @patch("sglang_omni.cli.serve.launch_server")
 @patch("sglang_omni.cli.serve.ConfigManager.from_model_path")
 def test_cli_hides_merged_config_for_normal_info_launch(

--- a/tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
+++ b/tests/unit_test/qwen3_omni/test_sglang_ar_budget.py
@@ -39,6 +39,12 @@ def _patch_thinker_startup(monkeypatch) -> list[dict[str, object]]:
         return SimpleNamespace(
             mem_fraction_static=overrides["mem_fraction_static"],
             sampling_backend=overrides["sampling_backend"],
+            max_running_requests=overrides["max_running_requests"],
+            cuda_graph_max_bs=overrides["cuda_graph_max_bs"],
+            cuda_graph_bs=overrides["cuda_graph_bs"],
+            disable_cuda_graph=overrides["disable_cuda_graph"],
+            enable_torch_compile=overrides.get("enable_torch_compile", False),
+            torch_compile_max_bs=overrides["torch_compile_max_bs"],
         )
 
     def _fake_create_thinker_scheduler(server_args, gpu_id, **kwargs):
@@ -241,6 +247,78 @@ def test_qwen_colocated_thinker_explicit_mem_fraction_skips_default_reserve(
     ]
     assert "effective_total_gpu_memory_fraction=0.75" in caplog.text
     assert "encoder_mem_reserve=0.0" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("server_args_overrides", "expected_max_bs"),
+    [
+        (None, 64),
+        ({"max_running_requests": 16}, 16),
+    ],
+)
+def test_qwen_thinker_threads_explicit_generation_batch_policy(
+    monkeypatch,
+    server_args_overrides,
+    expected_max_bs,
+) -> None:
+    build_calls: list[dict[str, object]] = []
+    validation_calls: list[tuple[str, object]] = []
+    validate_generation_batch_policy = qwen_stages.validate_generation_batch_policy
+
+    def _fake_server_args_builder(model_path, context_length, **overrides):
+        assert model_path == "dummy"
+        assert context_length == 8192
+        build_calls.append(dict(overrides))
+        return SimpleNamespace(
+            mem_fraction_static=0.85,
+            max_running_requests=overrides["max_running_requests"],
+            cuda_graph_max_bs=overrides["cuda_graph_max_bs"],
+            cuda_graph_bs=overrides["cuda_graph_bs"],
+            disable_cuda_graph=overrides["disable_cuda_graph"],
+            enable_torch_compile=overrides.get("enable_torch_compile", False),
+            torch_compile_max_bs=overrides["torch_compile_max_bs"],
+        )
+
+    def _validate_generation_batch_policy(*, model_name, server_args):
+        validation_calls.append((model_name, server_args))
+        validate_generation_batch_policy(
+            model_name=model_name,
+            server_args=server_args,
+        )
+
+    monkeypatch.setattr(
+        qwen_stages,
+        "build_sglang_server_args",
+        _fake_server_args_builder,
+    )
+    monkeypatch.setattr(
+        qwen_stages,
+        "validate_generation_batch_policy",
+        _validate_generation_batch_policy,
+    )
+    monkeypatch.setattr(
+        qwen_stages,
+        "create_thinker_scheduler",
+        lambda *args, **kwargs: object(),
+    )
+    monkeypatch.setattr(qwen_stages, "avail_gpu_mem", lambda gpu_id: 90.0)
+    monkeypatch.setattr(
+        qwen_stages,
+        "get_process_gpu_memory_bytes",
+        lambda gpu_id: None,
+    )
+
+    qwen_stages.create_sglang_thinker_executor_from_config(
+        "dummy",
+        server_args_overrides=server_args_overrides,
+    )
+
+    assert build_calls[-1]["max_running_requests"] == expected_max_bs
+    assert build_calls[-1]["cuda_graph_max_bs"] == expected_max_bs
+    assert max(build_calls[-1]["cuda_graph_bs"]) == expected_max_bs
+    assert build_calls[-1]["torch_compile_max_bs"] == expected_max_bs
+    assert validation_calls[-1][0] == "Qwen3-Omni thinker"
+    assert validation_calls[-1][1].max_running_requests == expected_max_bs
 
 
 def test_qwen_talker_ar_threads_explicit_generation_batch_policy(monkeypatch) -> None:


### PR DESCRIPTION
## Motivation

The thinker inherits `max_running_requests=16` from `build_sglang_server_args` (`server_args_builder.py:16`). Under concurrent load this admission cap binds before GPU capacity: decode-ready requests queue outside the scheduler and TTFT grows with the queue. There is no CLI escape hatch — `--max-running-requests` maps to the generation role (talker_ar on the speech config, rejected on the text-only config) — so the thinker cap is effectively hardcoded. The talker already defaults to 32; the thinker is the only stage still at 16.

Part of the thinker serving work in #1022. Stacked on #1027 (first commit belongs to that PR).

## Modifications

One line: `max_running_requests=64` in the qwen3_omni thinker overrides (`create_sglang_thinker_executor_from_config`). Config-level `runtime.sglang_server_args.max_running_requests` still wins. The KV pool is sized by `mem_fraction_static`, so the cap adds no KV memory; the extra footprint is CUDA-graph capture at larger batch sizes.

## Benchmarking and Profiling

Baseline: main at bfcfabec. Text-only thinker, TP2, Qwen3-Omni-30B-A3B-Instruct, 96 prompts, 200 words in / 128 tokens out, seed 1234, streaming. H100 2x dedicated GPUs, mem-fraction 0.85. Output tok/s and TTFT p95 (s):

| conc | 16 (base) | 32 | 64 | TTFT p95 base | TTFT p95 @64 |
|------|-----------|------|------|------|------|
| 1  | 204  | 201  | 194  | 0.05 | 0.07 |
| 16 | 1449 | 1949 | 1906 | 0.22 | 0.21 |
| 32 | 2061 | 2514 | 2218 | 1.15 | 0.26 |
| 48 | 2052 | 2364 | 2303 | 2.18 | 0.35 |
| 64 | 2056 | 2333 | 2228 | 3.15 | 0.45 |

Throughput +8–12% at concurrency 32–64; TTFT p95 drops from seconds to under 0.5s (−78% to −86% at concurrency 48/64). Cap 32 peaks slightly higher on raw throughput but keeps 2s+ TTFT p95 once concurrency passes the cap. The thinker's first token gates every downstream stage in the streaming pipeline, so the default goes to 64.

OOM checks, all clean:

- H100 text-only TP2, mem-fraction 0.85: peak 73 GiB / 80 GiB through concurrency 64.
- H200 text-only TP2, mem-fraction 0.50 with ~60 GiB of unrelated resident memory per GPU: peak 117 GiB / 143 GiB. (Shared box, so throughput numbers there were noisy; the table uses the dedicated H100 runs.)
- Speech pipeline at the tightest supported layout (thinker TP2 + talker + code2wav, mem-fraction 0.55): 16/16 requests OK at cap 64, RTF p50 0.245.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
