### PR TITLE
[Perf] MOSS-TTS-Local: graph the packed vocoder and remove the per-step emit sync behind one load gate

### DIFF
--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -388,10 +388,9 @@ class MossTTSLocalModelRunner(ModelRunner):
         emit_indices = sorted(emit_set)
         if emit_indices:
             if fast_path and len(emit_indices) == batch_size:
-                # Steady-state decode step: every row emits, so the batch-order
-                # tensors are used as-is. Skips the index_select chain and the
-                # index tensor built from a host list, whose pageable H2D copy
-                # stream-syncs every step (24.6% of the serving loop at c32).
+                # Steady-state decode step: every row emits, so batch-order
+                # tensors are used as-is; a host-list index tensor's pageable
+                # H2D copy would stream-sync the launch queue every step.
                 emit_pool_rows = pool_rows
                 emit_row_t = row_t
                 emit_rows = rows

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -251,7 +251,6 @@ class MossTTSLocalModelRunner(ModelRunner):
         pool = self.model._state_pool
         batch_size = len(requests)
         num_channels = int(cfg.n_vq) + 1
-        publish_ar_decode_batch(batch_size)
 
         try:
             row_t = forward_batch.moss_pool_row_t
@@ -261,6 +260,9 @@ class MossTTSLocalModelRunner(ModelRunner):
                 requests
             )
         else:
+            # Decode steps only: a prefill collect must not stomp the load
+            # beacon with its small new-sequence count.
+            publish_ar_decode_batch(batch_size)
             try:
                 has_audio_repetition_penalty = (
                     forward_batch.moss_has_audio_repetition_penalty

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -12,6 +12,7 @@ from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
 from sglang_omni.models.moss_tts_local.radix_hash import gpu_radix_row_hash
 from sglang_omni.models.moss_tts_local.state_pool import MossTTSLocalDecodeJournal
 from sglang_omni.models.moss_tts_local.vocoder_cuda_graph import (
+    MOSSL_FRAME_GRAPH_MIN_AR_BATCH,
     mossl_frame_graph_enabled,
     publish_ar_decode_batch,
 )
@@ -365,7 +366,12 @@ class MossTTSLocalModelRunner(ModelRunner):
             )
             embeds = None
 
-        fast_path = mossl_frame_graph_enabled()
+        # Below the load threshold the legacy path (with its per-step stream
+        # sync) is kept deliberately: a deep launch queue makes the eager
+        # vocoder's host syncs pathological (see MOSSL_FRAME_GRAPH_MIN_AR_BATCH).
+        fast_path = (
+            mossl_frame_graph_enabled() and batch_size >= MOSSL_FRAME_GRAPH_MIN_AR_BATCH
+        )
         slot_id = int(cfg.audio_assistant_slot_token_id)
         end_id = int(cfg.audio_end_token_id)
         if fast_path:

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -446,6 +446,7 @@ class MossTTSLocalModelRunner(ModelRunner):
                 rids=[requests[i].request_id for i in emit_indices],
                 pool_rows=emit_pool_rows,
                 rows=emit_rows,
+                above_load_gate=fast_path,
             )
         # Always return rows so both the sync inline path and the async launch
         # publish next_token_ids; an all-chunked batch just attaches no journal.
@@ -684,6 +685,9 @@ class MossTTSLocalModelRunner(ModelRunner):
                     is_retracted = False
                 if (callable(finished_fn) and finished_fn()) or bool(is_retracted):
                     continue
+            # Latest live step wins: the finishing step's decision reaches the
+            # result payload for the vocode load gate.
+            sched_req.data.above_load_gate = journal.above_load_gate
             req_output = outputs[sched_req.request_id]
             if req_output.data is None or int(req_output.data) == end_id:
                 continue

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -11,6 +11,9 @@ from sglang_omni.model_runner.base import ModelRunner
 from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
 from sglang_omni.models.moss_tts_local.radix_hash import gpu_radix_row_hash
 from sglang_omni.models.moss_tts_local.state_pool import MossTTSLocalDecodeJournal
+from sglang_omni.models.moss_tts_local.vocoder_cuda_graph import (
+    mossl_frame_graph_enabled,
+)
 from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.types import RequestOutput
 
@@ -358,13 +361,21 @@ class MossTTSLocalModelRunner(ModelRunner):
             )
             embeds = None
 
+        fast_path = mossl_frame_graph_enabled()
         slot_id = int(cfg.audio_assistant_slot_token_id)
         end_id = int(cfg.audio_end_token_id)
-        next_text = torch.where(
-            stop_choice == 0,
-            torch.full((batch_size,), slot_id, dtype=torch.long, device=device),
-            torch.full((batch_size,), end_id, dtype=torch.long, device=device),
-        )
+        if fast_path:
+            next_text = torch.where(
+                stop_choice == 0,
+                self._token_scalar(slot_id, device),
+                self._token_scalar(end_id, device),
+            )
+        else:
+            next_text = torch.where(
+                stop_choice == 0,
+                torch.full((batch_size,), slot_id, dtype=torch.long, device=device),
+                torch.full((batch_size,), end_id, dtype=torch.long, device=device),
+            )
 
         rows = torch.empty((batch_size, num_channels), dtype=torch.long, device=device)
         rows[:, 0] = next_text
@@ -376,23 +387,38 @@ class MossTTSLocalModelRunner(ModelRunner):
             )
         emit_indices = sorted(emit_set)
         if emit_indices:
-            emit_index_t = torch.tensor(
-                emit_indices, dtype=torch.long, device=rows.device
-            )
-            emit_pool_rows = [pool_rows[i] for i in emit_indices]
-            emit_row_t = row_t[emit_index_t.to(device=row_t.device)]
-            emit_rows = rows.index_select(0, emit_index_t)
-            emit_steps = gen_steps.index_select(
-                0, emit_index_t.to(device=gen_steps.device)
-            )
+            if fast_path and len(emit_indices) == batch_size:
+                # Steady-state decode step: every row emits, so the batch-order
+                # tensors are used as-is. Skips the index_select chain and the
+                # index tensor built from a host list, whose pageable H2D copy
+                # stream-syncs every step (24.6% of the serving loop at c32).
+                emit_pool_rows = pool_rows
+                emit_row_t = row_t
+                emit_rows = rows
+                emit_steps = gen_steps
+                emit_next_text = next_text
+                emit_embeds = embeds
+            else:
+                emit_index_t = torch.tensor(
+                    emit_indices, dtype=torch.long, device=rows.device
+                )
+                emit_pool_rows = [pool_rows[i] for i in emit_indices]
+                emit_row_t = row_t[emit_index_t.to(device=row_t.device)]
+                emit_rows = rows.index_select(0, emit_index_t)
+                emit_steps = gen_steps.index_select(
+                    0, emit_index_t.to(device=gen_steps.device)
+                )
+                emit_next_text = next_text.index_select(
+                    0, emit_index_t.to(device=next_text.device)
+                )
+                emit_embeds = embeds.index_select(
+                    0, emit_index_t.to(device=embeds.device)
+                )
             pool.sampling_steps[emit_row_t] = (emit_steps + 1).to(
                 device=pool.sampling_steps.device, dtype=torch.int64
             )
             if has_audio_repetition_penalty:
-                keep_history = (
-                    next_text.index_select(0, emit_index_t.to(device=next_text.device))
-                    != end_id
-                )
+                keep_history = emit_next_text != end_id
                 emit_penalty_active = (
                     pool.audio_repetition_penalty[emit_row_t]
                     .to(device=keep_history.device)
@@ -403,7 +429,6 @@ class MossTTSLocalModelRunner(ModelRunner):
                     emit_row_t[keep_history.to(device=emit_row_t.device)],
                     emit_rows[keep_history.to(device=emit_rows.device)],
                 )
-            emit_embeds = embeds.index_select(0, emit_index_t.to(device=embeds.device))
             pool.feedback_embeds[emit_row_t] = emit_embeds.detach().to(
                 device=pool.feedback_embeds.device,
                 dtype=pool.feedback_embeds.dtype,
@@ -449,6 +474,20 @@ class MossTTSLocalModelRunner(ModelRunner):
         del forward_batch, schedule_batch, requests
         if launch_buf is not None and result is not None:
             result.next_token_ids = launch_buf
+
+    def _token_scalar(self, value: int, device: torch.device) -> torch.Tensor:
+        """Cached 0-dim device tensor for a token id (avoids two per-step
+        [batch]-sized fills feeding torch.where)."""
+        cache = getattr(self, "_token_scalar_cache", None)
+        if cache is None:
+            cache = {}
+            self._token_scalar_cache = cache
+        key = (int(value), device.type, device.index)
+        scalar = cache.get(key)
+        if scalar is None:
+            scalar = torch.full((), int(value), dtype=torch.long, device=device)
+            cache[key] = scalar
+        return scalar
 
     @staticmethod
     def _row_radix_token_ids(

--- a/sglang_omni/models/moss_tts_local/model_runner.py
+++ b/sglang_omni/models/moss_tts_local/model_runner.py
@@ -13,6 +13,7 @@ from sglang_omni.models.moss_tts_local.radix_hash import gpu_radix_row_hash
 from sglang_omni.models.moss_tts_local.state_pool import MossTTSLocalDecodeJournal
 from sglang_omni.models.moss_tts_local.vocoder_cuda_graph import (
     mossl_frame_graph_enabled,
+    publish_ar_decode_batch,
 )
 from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.types import RequestOutput
@@ -250,6 +251,7 @@ class MossTTSLocalModelRunner(ModelRunner):
         pool = self.model._state_pool
         batch_size = len(requests)
         num_channels = int(cfg.n_vq) + 1
+        publish_ar_decode_batch(batch_size)
 
         try:
             row_t = forward_batch.moss_pool_row_t

--- a/sglang_omni/models/moss_tts_local/payload_types.py
+++ b/sglang_omni/models/moss_tts_local/payload_types.py
@@ -45,3 +45,6 @@ class MossTTSLocalState(DeclarativeStateBase):
     token_count: int | None = wire(None, codec="opt_int")
     generation_kwargs: dict[str, Any] = wire(default_factory=dict, codec="dict")
     audio_codes: Any | None = wire(None, codec="tensor_cpu")
+    # Frame-graph load-gate decision of the last live decode step (vocode
+    # dispatch reads it; fail-closed default).
+    above_load_gate: bool = wire(False, emit="truthy", codec="bool")

--- a/sglang_omni/models/moss_tts_local/request_builders.py
+++ b/sglang_omni/models/moss_tts_local/request_builders.py
@@ -62,6 +62,8 @@ class MossTTSLocalSGLangRequestData(ARRequestData):
     sampling_seed: int = field(default_factory=_new_moss_tts_sampling_seed)
     engine_start_s: float = 0.0
     stream_metadata: dict[str, Any] | None = None
+    # Frame-graph load-gate decision of the request's last live decode step.
+    above_load_gate: bool = False
 
 
 @dataclass
@@ -419,6 +421,7 @@ def apply_sglang_moss_tts_local_result(
     state.prompt_tokens = len(data.input_ids) if data.input_ids is not None else 0
     state.completion_tokens = len(data.output_rows)
     state.engine_time_s = time.perf_counter() - data.engine_start_s
+    state.above_load_gate = bool(getattr(data, "above_load_gate", False))
     return StagePayload(
         request_id=payload.request_id,
         request=payload.request,

--- a/sglang_omni/models/moss_tts_local/state_pool.py
+++ b/sglang_omni/models/moss_tts_local/state_pool.py
@@ -306,7 +306,11 @@ class MossTTSLocalDecodeJournal:
         rids: list[str],
         pool_rows: list[int],
         rows: torch.Tensor,
+        above_load_gate: bool = False,
     ) -> None:
         self.rids = rids
         self.pool_rows = pool_rows
         self.rows = rows
+        # This step's frame-graph load-gate decision; rides to the request
+        # data so the vocode dispatch needs no global temporal state.
+        self.above_load_gate = above_load_gate

--- a/sglang_omni/models/moss_tts_local/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts_local/streaming_vocoder.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import threading
 from collections import Counter
 from dataclasses import dataclass, field
 from typing import Any, Mapping
@@ -17,6 +18,9 @@ from typing import Any, Mapping
 import torch
 
 from sglang_omni.models.moss_tts_local.payload_types import MossTTSLocalState
+from sglang_omni.models.moss_tts_local.vocoder_cuda_graph import (
+    mossl_frame_graph_enabled,
+)
 from sglang_omni.models.moss_tts_local.vocoder_decoder import MossTTSLocalVocoderDecoder
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.pipeline_state import build_usage
@@ -31,6 +35,9 @@ logger = logging.getLogger(__name__)
 
 _SOURCE_HINT = "MOSS-TTS Local"
 _SESSION_RESERVED_OFFLINE_SLOTS = 1
+# Frame-count buckets for the non-streaming decode CUDA graphs (utterances pad
+# up to the next bucket; longer ones decode eager).
+_NONSTREAM_GRAPH_FRAME_BUCKETS = (64, 96, 128, 160, 192, 224)
 
 
 class _CodecStreamSession:
@@ -400,6 +407,8 @@ class MossTTSLocalStreamingVocoderScheduler(
         self._n_vq = int(n_vq)
         self._session: _CodecStreamSession | None = None
         self._session_used_by_streaming = False
+        self._nonstream_cg_runner: Any | None = None
+        self._nonstream_cg_lock = threading.Lock()
         self._cuda_graph = bool(cuda_graph)
         self._cuda_graph_frames = (
             [int(t) for t in cuda_graph_frames] if cuda_graph_frames else None
@@ -696,6 +705,40 @@ class MossTTSLocalStreamingVocoderScheduler(
             logger.warning(
                 "MOSS vocoder CUDA graphs did not seal at startup (low VRAM); eager vocoder"
             )
+        self._warmup_nonstream_graphs()
+
+    def _warmup_nonstream_graphs(self) -> None:
+        if self._nonstream_cg_runner is not None or not mossl_frame_graph_enabled():
+            return
+        from sglang_omni.models.moss_tts_local.vocoder_cuda_graph import (
+            MossNonstreamVocoderGraphRunner,
+        )
+
+        batch_buckets = sorted(
+            {b for b in (1, 2, 4, 8) if b < self._max_batch_size}
+            | {self._max_batch_size}
+        )
+        runner = MossNonstreamVocoderGraphRunner(
+            self._codec,
+            self._nonstream_decoder,
+            n_vq=self._n_vq,
+            batch_buckets=batch_buckets,
+            frame_buckets=_NONSTREAM_GRAPH_FRAME_BUCKETS,
+            min_free_gb=self._cuda_graph_min_free_gb,
+        )
+        try:
+            runner.warmup()
+        except Exception:
+            logger.exception(
+                "MOSS nonstream vocoder CUDA-graph warmup failed; eager nonstream decode"
+            )
+            return
+        if runner.captured_keys():
+            self._nonstream_cg_runner = runner
+        else:
+            logger.warning(
+                "MOSS nonstream vocoder CUDA graphs did not capture; eager nonstream decode"
+            )
 
     def _ensure_slot(self, state: _LocalStreamState) -> None:
         if state.slot is None:
@@ -801,6 +844,13 @@ class MossTTSLocalStreamingVocoderScheduler(
             audio_codes[:, index, :length] = codes
             padding_mask[index, :length] = True
 
+        graphed = self._graphed_nonstream_decode(
+            audio_codes,
+            [int(codes.shape[1]) for codes in codes_channels_first],
+        )
+        if graphed is not None:
+            return graphed
+
         decoded = self._codec.decode(
             audio_codes,
             padding_mask=padding_mask,
@@ -819,6 +869,35 @@ class MossTTSLocalStreamingVocoderScheduler(
         return [
             audio_cpu[index, :, : int(lengths_cpu[index])].contiguous()
             for index in range(int(audio_cpu.shape[0]))
+        ]
+
+    def _graphed_nonstream_decode(
+        self,
+        audio_codes: torch.Tensor,
+        codes_lengths: list[int],
+    ) -> list[torch.Tensor] | None:
+        runner = self._nonstream_cg_runner
+        if runner is None or not mossl_frame_graph_enabled():
+            return None
+        try:
+            with self._nonstream_cg_lock:
+                out = runner.decode_padded(audio_codes, codes_lengths)
+                if out is None:
+                    return None
+                audio, audio_lengths = out
+                # One batched D2H inside the guard: an async replay error can
+                # surface here rather than in decode_padded.
+                audio_cpu = audio.detach().to("cpu", torch.float32)
+        except Exception:
+            self._nonstream_cg_runner = None
+            logger.exception(
+                "MOSS nonstream vocoder CUDA-graph replay failed; disabling, "
+                "serving eager from here"
+            )
+            raise
+        return [
+            audio_cpu[index, :, :length].contiguous()
+            for index, length in enumerate(audio_lengths)
         ]
 
     def _decode_codes_rows(self, codes_list: list[torch.Tensor]) -> list[torch.Tensor]:

--- a/sglang_omni/models/moss_tts_local/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts_local/streaming_vocoder.py
@@ -36,13 +36,19 @@ logger = logging.getLogger(__name__)
 
 _SOURCE_HINT = "MOSS-TTS Local"
 _SESSION_RESERVED_OFFLINE_SLOTS = 1
-# Frame-count buckets for the non-streaming decode CUDA graphs (utterances pad
-# up to the next bucket; longer ones decode eager). 12.5 fps codec: 240 = 19.2s.
-_NONSTREAM_GRAPH_FRAME_BUCKETS = (48, 80, 112, 144, 176, 208, 240)
+# Buckets for the non-streaming decode CUDA graphs, sized to the measured
+# production shapes (waves are ~always B=1, T~53 at 12.5 fps; 176 = 14s).
+# Larger shapes decode eager rather than paying pool VRAM for cold keys.
+_NONSTREAM_GRAPH_BATCH_BUCKETS = (1, 2)
+_NONSTREAM_GRAPH_FRAME_BUCKETS = (48, 80, 112, 144, 176)
 # Note: (Jiaxin Deng) load gate: the graphs trade T-bucket padding compute for
 # launch/GIL relief, which only pays when the AR loop is contended; measured
 # +10-14% qps at AR bs>=16 but -7% at bs~8 without the gate.
 _NONSTREAM_GRAPH_MIN_AR_BATCH = 12
+# Note: (Jiaxin Deng) eager decodes coexist with the graphs under the load
+# gate; captures must leave real allocator headroom (3.8GB free measured
+# pathological, 11.8GB healthy).
+_NONSTREAM_GRAPH_MIN_FREE_GB = 8.0
 
 
 class _CodecStreamSession:
@@ -720,8 +726,7 @@ class MossTTSLocalStreamingVocoderScheduler(
         )
 
         batch_buckets = sorted(
-            {b for b in (1, 2, 4, 8) if b < self._max_batch_size}
-            | {self._max_batch_size}
+            b for b in _NONSTREAM_GRAPH_BATCH_BUCKETS if b <= self._max_batch_size
         )
         runner = MossNonstreamVocoderGraphRunner(
             self._codec,
@@ -729,7 +734,9 @@ class MossTTSLocalStreamingVocoderScheduler(
             n_vq=self._n_vq,
             batch_buckets=batch_buckets,
             frame_buckets=_NONSTREAM_GRAPH_FRAME_BUCKETS,
-            min_free_gb=self._cuda_graph_min_free_gb,
+            min_free_gb=max(
+                self._cuda_graph_min_free_gb, _NONSTREAM_GRAPH_MIN_FREE_GB
+            ),
         )
         try:
             runner.warmup()

--- a/sglang_omni/models/moss_tts_local/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts_local/streaming_vocoder.py
@@ -824,7 +824,9 @@ class MossTTSLocalStreamingVocoderScheduler(
         return payload
 
     def _decode_codes_rows_nonstream(
-        self, codes_list: list[torch.Tensor]
+        self,
+        codes_list: list[torch.Tensor],
+        above_load_gate: bool | None = None,
     ) -> list[torch.Tensor]:
         n_vq = self._n_vq
         device = next(self._codec.parameters()).device
@@ -854,6 +856,7 @@ class MossTTSLocalStreamingVocoderScheduler(
         graphed = self._graphed_nonstream_decode(
             audio_codes,
             [int(codes.shape[1]) for codes in codes_channels_first],
+            above_load_gate=above_load_gate,
         )
         if graphed is not None:
             return graphed
@@ -882,11 +885,16 @@ class MossTTSLocalStreamingVocoderScheduler(
         self,
         audio_codes: torch.Tensor,
         codes_lengths: list[int],
+        above_load_gate: bool | None = None,
     ) -> list[torch.Tensor] | None:
         runner = self._nonstream_cg_runner
         if runner is None or not mossl_frame_graph_enabled():
             return None
-        if last_ar_decode_batch() < MOSSL_FRAME_GRAPH_MIN_AR_BATCH:
+        if above_load_gate is None:
+            # Heuristic beacon fallback, only for callers without a per-batch
+            # decision; the vocode wave normally carries its own flag.
+            above_load_gate = last_ar_decode_batch() >= MOSSL_FRAME_GRAPH_MIN_AR_BATCH
+        if not above_load_gate:
             return None
         try:
             with self._nonstream_cg_lock:
@@ -898,18 +906,24 @@ class MossTTSLocalStreamingVocoderScheduler(
                 # surface here rather than in decode_padded.
                 audio_cpu = audio.detach().to("cpu", torch.float32)
         except Exception:
+            # None -> the caller decodes this same batch eagerly inline, so
+            # the in-flight requests succeed; future calls stay eager.
             self._nonstream_cg_runner = None
             logger.exception(
-                "MOSS nonstream vocoder CUDA-graph replay failed; disabling, "
-                "serving eager from here"
+                "MOSS nonstream vocoder CUDA-graph replay failed; retrying "
+                "this batch eagerly and serving eager from here"
             )
-            raise
+            return None
         return [
             audio_cpu[index, :, :length].contiguous()
             for index, length in enumerate(audio_lengths)
         ]
 
-    def _decode_codes_rows(self, codes_list: list[torch.Tensor]) -> list[torch.Tensor]:
+    def _decode_codes_rows(
+        self,
+        codes_list: list[torch.Tensor],
+        above_load_gate: bool | None = None,
+    ) -> list[torch.Tensor]:
         """Decode ``[T, >=n_vq]`` row tensors to fp32 CPU waveforms."""
         with self._state_lock:
             self._close_idle_startup_session_locked()
@@ -920,7 +934,9 @@ class MossTTSLocalStreamingVocoderScheduler(
             original_decoder = self._codec.decoder
             self._codec.decoder = self._nonstream_decoder
             try:
-                return self._decode_codes_rows_nonstream(codes_list)
+                return self._decode_codes_rows_nonstream(
+                    codes_list, above_load_gate=above_load_gate
+                )
             finally:
                 self._codec.decoder = original_decoder
         channels_first = [
@@ -939,7 +955,17 @@ class MossTTSLocalStreamingVocoderScheduler(
     def _vocode_batch(self, payloads: list[StagePayload]) -> list[StagePayload]:
         prepared = [self._prepare_codes(payload) for payload in payloads]
         codes_list = [codes for _, codes in prepared if codes is not None]
-        decoded = iter(self._decode_codes_rows(codes_list)) if codes_list else iter(())
+        # Fail closed: one below-gate request keeps its whole wave eager.
+        wave_above_gate = all(
+            bool(state.above_load_gate)
+            for state, codes in prepared
+            if codes is not None
+        )
+        decoded = (
+            iter(self._decode_codes_rows(codes_list, above_load_gate=wave_above_gate))
+            if codes_list
+            else iter(())
+        )
         results = []
         for payload, (state, codes) in zip(payloads, prepared):
             if codes is None:

--- a/sglang_omni/models/moss_tts_local/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts_local/streaming_vocoder.py
@@ -36,8 +36,8 @@ logger = logging.getLogger(__name__)
 _SOURCE_HINT = "MOSS-TTS Local"
 _SESSION_RESERVED_OFFLINE_SLOTS = 1
 # Frame-count buckets for the non-streaming decode CUDA graphs (utterances pad
-# up to the next bucket; longer ones decode eager).
-_NONSTREAM_GRAPH_FRAME_BUCKETS = (64, 96, 128, 160, 192, 224)
+# up to the next bucket; longer ones decode eager). 12.5 fps codec: 240 = 19.2s.
+_NONSTREAM_GRAPH_FRAME_BUCKETS = (48, 80, 112, 144, 176, 208, 240)
 
 
 class _CodecStreamSession:

--- a/sglang_omni/models/moss_tts_local/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts_local/streaming_vocoder.py
@@ -734,9 +734,7 @@ class MossTTSLocalStreamingVocoderScheduler(
             n_vq=self._n_vq,
             batch_buckets=batch_buckets,
             frame_buckets=_NONSTREAM_GRAPH_FRAME_BUCKETS,
-            min_free_gb=max(
-                self._cuda_graph_min_free_gb, _NONSTREAM_GRAPH_MIN_FREE_GB
-            ),
+            min_free_gb=max(self._cuda_graph_min_free_gb, _NONSTREAM_GRAPH_MIN_FREE_GB),
         )
         try:
             runner.warmup()

--- a/sglang_omni/models/moss_tts_local/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts_local/streaming_vocoder.py
@@ -19,6 +19,7 @@ import torch
 
 from sglang_omni.models.moss_tts_local.payload_types import MossTTSLocalState
 from sglang_omni.models.moss_tts_local.vocoder_cuda_graph import (
+    MOSSL_FRAME_GRAPH_MIN_AR_BATCH,
     last_ar_decode_batch,
     mossl_frame_graph_enabled,
 )
@@ -41,10 +42,6 @@ _SESSION_RESERVED_OFFLINE_SLOTS = 1
 # Larger shapes decode eager rather than paying pool VRAM for cold keys.
 _NONSTREAM_GRAPH_BATCH_BUCKETS = (1, 2)
 _NONSTREAM_GRAPH_FRAME_BUCKETS = (48, 80, 112, 144, 176)
-# Note: (Jiaxin Deng) load gate: the graphs trade T-bucket padding compute for
-# launch/GIL relief, which only pays when the AR loop is contended; measured
-# +10-14% qps at AR bs>=16 but -7% at bs~8 without the gate.
-_NONSTREAM_GRAPH_MIN_AR_BATCH = 12
 # Note: (Jiaxin Deng) eager decodes coexist with the graphs under the load
 # gate; captures must leave real allocator headroom (3.8GB free measured
 # pathological, 11.8GB healthy).
@@ -889,7 +886,7 @@ class MossTTSLocalStreamingVocoderScheduler(
         runner = self._nonstream_cg_runner
         if runner is None or not mossl_frame_graph_enabled():
             return None
-        if last_ar_decode_batch() < _NONSTREAM_GRAPH_MIN_AR_BATCH:
+        if last_ar_decode_batch() < MOSSL_FRAME_GRAPH_MIN_AR_BATCH:
             return None
         try:
             with self._nonstream_cg_lock:

--- a/sglang_omni/models/moss_tts_local/streaming_vocoder.py
+++ b/sglang_omni/models/moss_tts_local/streaming_vocoder.py
@@ -19,6 +19,7 @@ import torch
 
 from sglang_omni.models.moss_tts_local.payload_types import MossTTSLocalState
 from sglang_omni.models.moss_tts_local.vocoder_cuda_graph import (
+    last_ar_decode_batch,
     mossl_frame_graph_enabled,
 )
 from sglang_omni.models.moss_tts_local.vocoder_decoder import MossTTSLocalVocoderDecoder
@@ -38,6 +39,10 @@ _SESSION_RESERVED_OFFLINE_SLOTS = 1
 # Frame-count buckets for the non-streaming decode CUDA graphs (utterances pad
 # up to the next bucket; longer ones decode eager). 12.5 fps codec: 240 = 19.2s.
 _NONSTREAM_GRAPH_FRAME_BUCKETS = (48, 80, 112, 144, 176, 208, 240)
+# Note: (Jiaxin Deng) load gate: the graphs trade T-bucket padding compute for
+# launch/GIL relief, which only pays when the AR loop is contended; measured
+# +10-14% qps at AR bs>=16 but -7% at bs~8 without the gate.
+_NONSTREAM_GRAPH_MIN_AR_BATCH = 12
 
 
 class _CodecStreamSession:
@@ -878,6 +883,8 @@ class MossTTSLocalStreamingVocoderScheduler(
     ) -> list[torch.Tensor] | None:
         runner = self._nonstream_cg_runner
         if runner is None or not mossl_frame_graph_enabled():
+            return None
+        if last_ar_decode_batch() < _NONSTREAM_GRAPH_MIN_AR_BATCH:
             return None
         try:
             with self._nonstream_cg_lock:

--- a/sglang_omni/models/moss_tts_local/vocoder_cuda_graph.py
+++ b/sglang_omni/models/moss_tts_local/vocoder_cuda_graph.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import Iterable
 from types import MethodType
 from typing import NamedTuple
@@ -13,6 +14,14 @@ import torch
 logger = logging.getLogger(__name__)
 
 _ATTN_ORIGINAL_UPDATE_CACHE_ATTR = "_sglang_omni_original_update_streaming_cache"
+
+MOSSL_FRAME_GRAPH_ENV = "SGLANG_OMNI_MOSSL_FRAME_GRAPH"
+_NONSTREAM_MAX_CAPTURE_FAILURES = 8
+
+
+def mossl_frame_graph_enabled() -> bool:
+    value = os.environ.get(MOSSL_FRAME_GRAPH_ENV, "1").strip().lower()
+    return value not in ("0", "false", "off")
 
 
 class _CapturedVocoderGraph(NamedTuple):
@@ -264,3 +273,246 @@ class MossVocoderCudaGraphRunner:
         entry.static_codes.copy_(codes_step)
         entry.graph.replay()
         return entry.static_audio, entry.static_audio_lengths
+
+
+class _CapturedNonstreamGraph(NamedTuple):
+    graph: torch.cuda.CUDAGraph
+    static_codes: torch.Tensor
+    static_audio: torch.Tensor
+    samples_per_frame: int
+
+
+class MossNonstreamVocoderGraphRunner:
+    """(B, T)-bucketed CUDA graphs over the packed non-streaming codec decode.
+
+    Captured at warmup with every sequence pinned to the bucket's dense length
+    (``assume_full_lengths``); the decode chain's only temporal mixing is causal
+    local attention, so tail/batch padding cannot reach the valid region — the
+    bit-identity gate in tests enforces this. Replay copies padded codes into
+    the static buffer and slices per-utterance audio by ``frames *
+    samples_per_frame`` (the length map is exactly linear; validated at
+    capture).
+    """
+
+    def __init__(
+        self,
+        codec,
+        nonstream_decoder,
+        *,
+        n_vq: int,
+        batch_buckets: Iterable[int],
+        frame_buckets: Iterable[int],
+        warmup_iters: int = 2,
+        min_free_gb: float = 3.0,
+    ) -> None:
+        self._codec = codec
+        self._nonstream_decoder = nonstream_decoder
+        self._n_vq = int(n_vq)
+        self._device = next(codec.parameters()).device
+        self._batch_buckets = sorted({int(b) for b in batch_buckets if int(b) >= 1})
+        self._frame_buckets = sorted({int(t) for t in frame_buckets if int(t) >= 1})
+        self._warmup_iters = int(warmup_iters)
+        self._min_free_bytes = int(float(min_free_gb) * (1024**3))
+        self._graphs: dict[tuple[int, int], _CapturedNonstreamGraph] = {}
+        # Note: (Jiaxin Deng) one shared mempool per batch bucket, captured
+        # largest-T first: growing a shared pool after a capture invalidates
+        # earlier graphs' addresses (streaming-runner lesson).
+        self._pools: dict[int, object] = {}
+        self._capture_failures = 0
+        self._disabled = False
+        self._sealed = False
+        self._graph_steps = 0
+        self._eager_misses = 0
+
+    def _enough_free_vram(self) -> tuple[bool, int]:
+        free, _ = torch.cuda.mem_get_info(self._device)
+        return free >= self._min_free_bytes, free
+
+    @torch.no_grad()
+    def _capture(self, batch_bucket: int, frame_bucket: int) -> None:
+        device = self._device
+        static_codes = torch.zeros(
+            self._n_vq, batch_bucket, frame_bucket, dtype=torch.long, device=device
+        )
+        static_lengths = torch.full(
+            (batch_bucket,), frame_bucket, dtype=torch.long, device=device
+        )
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        warmup_result = None
+        with torch.cuda.stream(stream):
+            for _ in range(self._warmup_iters):
+                warmup_result = self._codec._decode_frame(static_codes, static_lengths)
+        torch.cuda.current_stream().wait_stream(stream)
+        torch.cuda.synchronize()
+
+        # Validate the linear frame->sample map on the executed warmup result
+        # (capture only records, so the static outputs hold no values yet).
+        assert warmup_result is not None
+        warmup_lengths = warmup_result.audio_lengths
+        audio_len_max = int(warmup_lengths.max().item())
+        audio_len_min = int(warmup_lengths.min().item())
+        if (
+            audio_len_max != audio_len_min
+            or audio_len_max <= 0
+            or audio_len_max % frame_bucket != 0
+        ):
+            raise RuntimeError(
+                "MOSS nonstream vocoder length map is not uniformly linear: "
+                f"T={frame_bucket} -> audio_lengths in "
+                f"[{audio_len_min}, {audio_len_max}]"
+            )
+        samples_per_frame = audio_len_max // frame_bucket
+
+        pool = self._pools.get(batch_bucket)
+        if pool is None:
+            pool = torch.cuda.graph_pool_handle()
+            self._pools[batch_bucket] = pool
+        graph = torch.cuda.CUDAGraph()
+        try:
+            with torch.cuda.graph(
+                graph, pool=pool, capture_error_mode="thread_local"
+            ):
+                result = self._codec._decode_frame(static_codes, static_lengths)
+                static_audio = result.audio
+        except Exception:
+            try:
+                graph.reset()
+            except Exception:
+                pass
+            raise
+        self._graphs[(batch_bucket, frame_bucket)] = _CapturedNonstreamGraph(
+            graph=graph,
+            static_codes=static_codes,
+            static_audio=static_audio,
+            samples_per_frame=samples_per_frame,
+        )
+        logger.info(
+            "Captured MOSS nonstream vocoder CUDA graph B=%d T=%d -> audio %s "
+            "(%d cached)",
+            batch_bucket,
+            frame_bucket,
+            tuple(static_audio.shape),
+            len(self._graphs),
+        )
+
+    @torch.no_grad()
+    def warmup(self) -> None:
+        """Capture all (B, T) buckets once, then seal; failed/skipped keys fall
+        back to eager. Must run while the GPU is otherwise quiescent."""
+        if self._sealed:
+            logger.warning(
+                "MossNonstreamVocoderGraphRunner.warmup called after seal; ignoring"
+            )
+            return
+        original_decoder = self._codec.decoder
+        self._codec.decoder = self._nonstream_decoder
+        try:
+            with torch.cuda.device(self._device):
+                with self._nonstream_decoder.assume_full_lengths():
+                    for batch_bucket in sorted(self._batch_buckets, reverse=True):
+                        for frame_bucket in sorted(self._frame_buckets, reverse=True):
+                            if self._disabled:
+                                break
+                            enough, free = self._enough_free_vram()
+                            if not enough:
+                                logger.warning(
+                                    "MOSS nonstream vocoder CG: free VRAM %.1fGB < "
+                                    "%.1fGB headroom; skipping remaining captures",
+                                    free / 1024**3,
+                                    self._min_free_bytes / 1024**3,
+                                )
+                                self._sealed = True
+                                return
+                            try:
+                                self._capture(batch_bucket, frame_bucket)
+                            except Exception:
+                                self._capture_failures += 1
+                                logger.warning(
+                                    "MOSS nonstream vocoder CG capture failed for "
+                                    "B=%d T=%d (failure %d/%d); eager for this key",
+                                    batch_bucket,
+                                    frame_bucket,
+                                    self._capture_failures,
+                                    _NONSTREAM_MAX_CAPTURE_FAILURES,
+                                    exc_info=True,
+                                )
+                                if (
+                                    self._capture_failures
+                                    >= _NONSTREAM_MAX_CAPTURE_FAILURES
+                                ):
+                                    self._disabled = True
+                                    logger.warning(
+                                        "Disabling MOSS nonstream vocoder CUDA "
+                                        "graphs after %d capture failures",
+                                        self._capture_failures,
+                                    )
+                        if self._disabled:
+                            break
+        finally:
+            self._codec.decoder = original_decoder
+            self._sealed = True
+        logger.info(
+            "MOSS nonstream vocoder CUDA graphs sealed: %d keys %s",
+            len(self._graphs),
+            sorted(self._graphs.keys()),
+        )
+
+    def captured_keys(self) -> list[tuple[int, int]]:
+        return sorted(self._graphs.keys())
+
+    def _find_entry(
+        self, live_batch: int, live_frames: int
+    ) -> _CapturedNonstreamGraph | None:
+        for batch_bucket in self._batch_buckets:
+            if batch_bucket < live_batch:
+                continue
+            for frame_bucket in self._frame_buckets:
+                if frame_bucket < live_frames:
+                    continue
+                entry = self._graphs.get((batch_bucket, frame_bucket))
+                if entry is not None:
+                    return entry
+        return None
+
+    @torch.no_grad()
+    def decode_padded(
+        self,
+        padded_codes: torch.Tensor,
+        codes_lengths: list[int],
+    ) -> tuple[torch.Tensor, list[int]] | None:
+        """Replay a bucketed graph for ``[n_vq, B, T]`` zero-padded codes with
+        host-side per-utterance frame counts; ``None`` -> caller decodes eager.
+        Returns (static audio buffer sliced to live rows, per-utterance sample
+        counts); the caller must consume the audio before the next replay.
+        """
+        if self._disabled or not self._graphs:
+            return None
+        if not padded_codes.is_cuda:
+            return None
+        n_vq, live_batch, live_frames = padded_codes.shape
+        if n_vq != self._n_vq or live_batch == 0 or live_frames == 0:
+            return None
+        if len(codes_lengths) != live_batch:
+            return None
+        if torch.cuda.is_current_stream_capturing():
+            return None
+        entry = self._find_entry(live_batch, live_frames)
+        if entry is None:
+            self._eager_misses += 1
+            return None
+        with torch.cuda.device(self._device):
+            entry.static_codes.zero_()
+            entry.static_codes[:, :live_batch, :live_frames].copy_(padded_codes)
+            entry.graph.replay()
+        self._graph_steps += 1
+        if self._graph_steps % 500 == 0:
+            logger.info(
+                "MOSS nonstream vocoder CG: %d graphed decodes, %d eager misses",
+                self._graph_steps,
+                self._eager_misses,
+            )
+        audio_lengths = [
+            int(frames) * entry.samples_per_frame for frames in codes_lengths
+        ]
+        return entry.static_audio[:live_batch], audio_lengths

--- a/sglang_omni/models/moss_tts_local/vocoder_cuda_graph.py
+++ b/sglang_omni/models/moss_tts_local/vocoder_cuda_graph.py
@@ -286,10 +286,13 @@ class MossNonstreamVocoderGraphRunner:
     """(B, T)-bucketed CUDA graphs over the packed non-streaming codec decode.
 
     Captured at warmup with every sequence pinned to the bucket's dense length
-    (``assume_full_lengths``); the decode chain's only temporal mixing is causal
-    local attention, so tail/batch padding cannot reach the valid region — the
-    bit-identity gate in tests enforces this. Replay copies padded codes into
-    the static buffer and slices per-utterance audio by ``frames *
+    (``assume_full_lengths``). Replay is bit-identical to the same-geometry
+    eager decode (gated in tests). Note: (Jiaxin Deng) the eager ragged decode
+    is itself batch-composition-dependent at the bit level (varlen flash
+    geometry; measured max|delta| ~2e-2 between batch layouts of the same
+    utterance), so bucket padding stays within the pre-existing numerical
+    family rather than adding a new error mode. Replay copies padded codes
+    into the static buffer and slices per-utterance audio by ``frames *
     samples_per_frame`` (the length map is exactly linear; validated at
     capture).
     """
@@ -461,19 +464,25 @@ class MossNonstreamVocoderGraphRunner:
     def captured_keys(self) -> list[tuple[int, int]]:
         return sorted(self._graphs.keys())
 
-    def _find_entry(
+    def bucket_for(
         self, live_batch: int, live_frames: int
-    ) -> _CapturedNonstreamGraph | None:
+    ) -> tuple[int, int] | None:
+        """Smallest captured (batch, frames) bucket covering the live shape."""
         for batch_bucket in self._batch_buckets:
             if batch_bucket < live_batch:
                 continue
             for frame_bucket in self._frame_buckets:
                 if frame_bucket < live_frames:
                     continue
-                entry = self._graphs.get((batch_bucket, frame_bucket))
-                if entry is not None:
-                    return entry
+                if (batch_bucket, frame_bucket) in self._graphs:
+                    return (batch_bucket, frame_bucket)
         return None
+
+    def _find_entry(
+        self, live_batch: int, live_frames: int
+    ) -> _CapturedNonstreamGraph | None:
+        key = self.bucket_for(live_batch, live_frames)
+        return self._graphs[key] if key is not None else None
 
     @torch.no_grad()
     def decode_padded(

--- a/sglang_omni/models/moss_tts_local/vocoder_cuda_graph.py
+++ b/sglang_omni/models/moss_tts_local/vocoder_cuda_graph.py
@@ -436,7 +436,10 @@ class MossNonstreamVocoderGraphRunner:
         try:
             with torch.cuda.device(self._device):
                 with self._nonstream_decoder.assume_full_lengths():
-                    for batch_bucket in sorted(self._batch_buckets, reverse=True):
+                    # B ascending: a VRAM-budget stop keeps the small-B keys,
+                    # which carry ~all production hits. T stays largest-first
+                    # within each per-B shared pool (pool-growth rule).
+                    for batch_bucket in sorted(self._batch_buckets):
                         for frame_bucket in sorted(self._frame_buckets, reverse=True):
                             if self._disabled:
                                 break

--- a/sglang_omni/models/moss_tts_local/vocoder_cuda_graph.py
+++ b/sglang_omni/models/moss_tts_local/vocoder_cuda_graph.py
@@ -373,9 +373,7 @@ class MossNonstreamVocoderGraphRunner:
             self._pools[batch_bucket] = pool
         graph = torch.cuda.CUDAGraph()
         try:
-            with torch.cuda.graph(
-                graph, pool=pool, capture_error_mode="thread_local"
-            ):
+            with torch.cuda.graph(graph, pool=pool, capture_error_mode="thread_local"):
                 result = self._codec._decode_frame(static_codes, static_lengths)
                 static_audio = result.audio
         except Exception:
@@ -464,9 +462,7 @@ class MossNonstreamVocoderGraphRunner:
     def captured_keys(self) -> list[tuple[int, int]]:
         return sorted(self._graphs.keys())
 
-    def bucket_for(
-        self, live_batch: int, live_frames: int
-    ) -> tuple[int, int] | None:
+    def bucket_for(self, live_batch: int, live_frames: int) -> tuple[int, int] | None:
         """Smallest captured (batch, frames) bucket covering the live shape."""
         for batch_bucket in self._batch_buckets:
             if batch_bucket < live_batch:

--- a/sglang_omni/models/moss_tts_local/vocoder_cuda_graph.py
+++ b/sglang_omni/models/moss_tts_local/vocoder_cuda_graph.py
@@ -24,6 +24,31 @@ def mossl_frame_graph_enabled() -> bool:
     return value not in ("0", "false", "off")
 
 
+class _ArDecodeLoadBeacon:
+    """Latest AR decode batch size, published by the model runner every step.
+
+    The colocated vocoder thread reads it as the in-flight load signal for the
+    nonstream-graph gate. Note: (Jiaxin Deng) a split-process vocoder reads 0,
+    so its nonstream decode stays eager (safe, just ungraphed).
+    """
+
+    __slots__ = ("value",)
+
+    def __init__(self) -> None:
+        self.value = 0
+
+
+_ar_decode_load = _ArDecodeLoadBeacon()
+
+
+def publish_ar_decode_batch(batch_size: int) -> None:
+    _ar_decode_load.value = int(batch_size)
+
+
+def last_ar_decode_batch() -> int:
+    return _ar_decode_load.value
+
+
 class _CapturedVocoderGraph(NamedTuple):
     """One captured per-T graph and its static replay buffers (named to avoid positional unpack)."""
 

--- a/sglang_omni/models/moss_tts_local/vocoder_cuda_graph.py
+++ b/sglang_omni/models/moss_tts_local/vocoder_cuda_graph.py
@@ -509,13 +509,19 @@ class MossNonstreamVocoderGraphRunner:
         entry = self._find_entry(live_batch, live_frames)
         if entry is None:
             self._eager_misses += 1
+            if self._eager_misses <= 5:
+                logger.info(
+                    "MOSS nonstream vocoder CG miss: B=%d T=%d",
+                    live_batch,
+                    live_frames,
+                )
             return None
         with torch.cuda.device(self._device):
             entry.static_codes.zero_()
             entry.static_codes[:, :live_batch, :live_frames].copy_(padded_codes)
             entry.graph.replay()
         self._graph_steps += 1
-        if self._graph_steps % 500 == 0:
+        if self._graph_steps % 25 == 0:
             logger.info(
                 "MOSS nonstream vocoder CG: %d graphed decodes, %d eager misses",
                 self._graph_steps,

--- a/sglang_omni/models/moss_tts_local/vocoder_cuda_graph.py
+++ b/sglang_omni/models/moss_tts_local/vocoder_cuda_graph.py
@@ -17,6 +17,12 @@ _ATTN_ORIGINAL_UPDATE_CACHE_ATTR = "_sglang_omni_original_update_streaming_cache
 
 MOSSL_FRAME_GRAPH_ENV = "SGLANG_OMNI_MOSSL_FRAME_GRAPH"
 _NONSTREAM_MAX_CAPTURE_FAILURES = 8
+# Note: (Jiaxin Deng) one shared load threshold for the AR emit fast path and
+# the nonstream vocoder graphs: they must engage together. The fast path lets
+# the launch queue run deep, which the EAGER vocoder's ~13 per-utterance host
+# syncs each drain (measured stage-latency explosion); the graphed vocoder
+# syncs once. Below the threshold both stay off = the env-off code path.
+MOSSL_FRAME_GRAPH_MIN_AR_BATCH = 12
 
 
 def mossl_frame_graph_enabled() -> bool:

--- a/sglang_omni/models/moss_tts_local/vocoder_cuda_graph.py
+++ b/sglang_omni/models/moss_tts_local/vocoder_cuda_graph.py
@@ -463,15 +463,7 @@ class MossNonstreamVocoderGraphRunner:
                                 self._capture(batch_bucket, frame_bucket)
                             except Exception:
                                 self._capture_failures += 1
-                                logger.warning(
-                                    "MOSS nonstream vocoder CG capture failed for "
-                                    "B=%d T=%d (failure %d/%d); eager for this key",
-                                    batch_bucket,
-                                    frame_bucket,
-                                    self._capture_failures,
-                                    _NONSTREAM_MAX_CAPTURE_FAILURES,
-                                    exc_info=True,
-                                )
+                                self._log_capture_failure(batch_bucket, frame_bucket)
                                 if (
                                     self._capture_failures
                                     >= _NONSTREAM_MAX_CAPTURE_FAILURES
@@ -482,6 +474,29 @@ class MossNonstreamVocoderGraphRunner:
                                         "graphs after %d capture failures",
                                         self._capture_failures,
                                     )
+                                continue
+                            # Re-check AFTER the capture: one near the boundary
+                            # can eat into the promised eager headroom.
+                            enough_after, free_after = self._enough_free_vram()
+                            if not enough_after:
+                                entry = self._graphs.pop(
+                                    (batch_bucket, frame_bucket), None
+                                )
+                                if entry is not None:
+                                    try:
+                                        entry.graph.reset()
+                                    except Exception:
+                                        pass
+                                logger.warning(
+                                    "MOSS nonstream vocoder CG: capture B=%d T=%d "
+                                    "left free VRAM %.1fGB below the %.1fGB "
+                                    "reserve; rolled back, stopping captures",
+                                    batch_bucket,
+                                    frame_bucket,
+                                    free_after / 1024**3,
+                                    self._min_free_bytes / 1024**3,
+                                )
+                                return
                         if self._disabled:
                             break
         finally:
@@ -491,6 +506,17 @@ class MossNonstreamVocoderGraphRunner:
             "MOSS nonstream vocoder CUDA graphs sealed: %d keys %s",
             len(self._graphs),
             sorted(self._graphs.keys()),
+        )
+
+    def _log_capture_failure(self, batch_bucket: int, frame_bucket: int) -> None:
+        logger.warning(
+            "MOSS nonstream vocoder CG capture failed for "
+            "B=%d T=%d (failure %d/%d); eager for this key",
+            batch_bucket,
+            frame_bucket,
+            self._capture_failures,
+            _NONSTREAM_MAX_CAPTURE_FAILURES,
+            exc_info=True,
         )
 
     def captured_keys(self) -> list[tuple[int, int]]:

--- a/sglang_omni/models/moss_tts_local/vocoder_decoder.py
+++ b/sglang_omni/models/moss_tts_local/vocoder_decoder.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import importlib
 import math
 from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
 
@@ -561,6 +562,58 @@ class MossTTSLocalProjectedTransformer(nn.Module):
         self.output_proj = source.output_proj
         self.transformer = MossTTSLocalTransformer(source.transformer)
         self._position_ids_cache = _PositionIdsCache()
+        self._uniform_full_lengths = False
+        self._uniform_pack_cache: dict[tuple, tuple] = {}
+
+    def _uniform_pack_meta(
+        self, batch_size: int, max_seqlen: int, device: torch.device
+    ) -> tuple[torch.Tensor, torch.Tensor, _LocalCausalFlashPlan | None]:
+        key = (batch_size, max_seqlen, device.type, device.index)
+        meta = self._uniform_pack_cache.get(key)
+        if meta is None:
+            # Note: (Jiaxin Deng) built outside capture only: a cache miss during
+            # CUDA-graph capture host-syncs and aborts the capture -> eager.
+            positions = torch.arange(max_seqlen, device=device, dtype=torch.long)
+            position_ids = positions.repeat(batch_size)
+            cu_seqlens = torch.arange(
+                0,
+                (batch_size + 1) * max_seqlen,
+                max_seqlen,
+                device=device,
+                dtype=torch.int32,
+            )
+            first_attention = self.transformer.layers[0].self_attn
+            plan = None
+            if first_attention.causal and first_attention.context is not None:
+                plan = _build_local_causal_flash_plan(
+                    cu_seqlens,
+                    context=int(first_attention.context),
+                )
+            meta = (cu_seqlens, position_ids, plan)
+            self._uniform_pack_cache[key] = meta
+        return meta
+
+    def _forward_uniform_flash(
+        self,
+        x: torch.Tensor,
+        input_lengths: torch.Tensor,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        batch_size, max_seqlen, _ = x.shape
+        cu_seqlens, position_ids, local_flash_plan = self._uniform_pack_meta(
+            batch_size, max_seqlen, x.device
+        )
+        packed_x = x.reshape(batch_size * max_seqlen, x.shape[-1])
+        packed_x = self.transformer(
+            packed_x,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+            position_ids=position_ids,
+            input_lengths=input_lengths,
+            local_flash_plan=local_flash_plan,
+            **kwargs,
+        )
+        return packed_x.reshape(batch_size, max_seqlen, packed_x.shape[-1])
 
     def forward(
         self,
@@ -570,6 +623,11 @@ class MossTTSLocalProjectedTransformer(nn.Module):
     ) -> tuple[torch.Tensor, torch.Tensor]:
         x = self.input_proj(x.transpose(1, 2))
         backend = self.transformer.resolve_attention_implementation(x)
+        if backend == "flash_attention_2" and self._uniform_full_lengths and x.shape[1]:
+            # Every sequence is pinned to the dense length: no host reads, so
+            # the stack is CUDA-graph capturable.
+            x = self._forward_uniform_flash(x, input_lengths, **kwargs)
+            return self.output_proj(x).transpose(1, 2), input_lengths
         if backend == "flash_attention_2":
             batch_size, max_seqlen, _ = x.shape
             max_valid_seqlen = int(input_lengths.max().item()) if max_seqlen else 0
@@ -640,6 +698,24 @@ class MossTTSLocalVocoderDecoder(nn.Module):
             f"unsupported MOSS vocoder decoder stage {stage.__class__.__name__} "
             f"with module_type={module_type!r}"
         )
+
+    @contextmanager
+    def assume_full_lengths(self):
+        """Pin every sequence to its dense length across all transformer stages
+        (valid only when all input_lengths equal the padded time dimension)."""
+        transformer_stages = [
+            stage
+            for stage in self.stages
+            if isinstance(stage, MossTTSLocalProjectedTransformer)
+        ]
+        saved = [stage._uniform_full_lengths for stage in transformer_stages]
+        for stage in transformer_stages:
+            stage._uniform_full_lengths = True
+        try:
+            yield
+        finally:
+            for stage, value in zip(transformer_stages, saved):
+                stage._uniform_full_lengths = value
 
     def __iter__(self) -> Iterator[nn.Module]:
         return iter(self.stages)

--- a/tests/unit_test/moss_tts_local/test_frame_chain_graph.py
+++ b/tests/unit_test/moss_tts_local/test_frame_chain_graph.py
@@ -32,7 +32,9 @@ from sglang_omni.models.moss_tts_local.state_pool import (  # noqa: E402
 from sglang_omni.models.moss_tts_local.vocoder_cuda_graph import (  # noqa: E402
     MOSSL_FRAME_GRAPH_ENV,
     MossNonstreamVocoderGraphRunner,
+    last_ar_decode_batch,
     mossl_frame_graph_enabled,
+    publish_ar_decode_batch,
 )
 
 # ---------------------------------------------------------------------------
@@ -270,6 +272,67 @@ def test_mixed_chunked_batch_still_uses_index_fallback(
     monkeypatch.setattr(torch, "tensor", counting_tensor)
     runner._run_frame_decode(_result(batch_size), forward_batch, reqs)
     assert calls, "mixed batch should take the index-tensor fallback"
+
+
+def test_run_frame_decode_publishes_ar_batch_size():
+    """Every frame-decode step publishes its batch size to the load beacon the
+    vocoder gate reads (colocated process)."""
+    for batch_size in (1, 4):
+        runner = _make_runner(batch_size)
+        reqs = [_sched_req(f"r{i}") for i in range(batch_size)]
+        runner._run_frame_decode(_result(batch_size), types.SimpleNamespace(), reqs)
+        assert last_ar_decode_batch() == batch_size
+
+
+def _bare_scheduler():
+    import threading
+
+    from sglang_omni.models.moss_tts_local.streaming_vocoder import (
+        MossTTSLocalStreamingVocoderScheduler,
+    )
+
+    scheduler = MossTTSLocalStreamingVocoderScheduler.__new__(
+        MossTTSLocalStreamingVocoderScheduler
+    )
+    scheduler._nonstream_cg_lock = threading.Lock()
+    return scheduler
+
+
+def test_nonstream_gate_dispatch(monkeypatch: pytest.MonkeyPatch):
+    """Load-aware gate: below the AR-batch threshold the runner is not
+    consulted (eager, zero low-load regression by construction); at/above it
+    the graphs engage; the kill switch forces eager regardless of load."""
+    from sglang_omni.models.moss_tts_local.streaming_vocoder import (
+        _NONSTREAM_GRAPH_MIN_AR_BATCH,
+    )
+
+    scheduler = _bare_scheduler()
+    consulted: list = []
+
+    def fake_decode_padded(padded_codes, codes_lengths):
+        consulted.append((tuple(padded_codes.shape), list(codes_lengths)))
+        return torch.zeros(1, 2, 100), [40]
+
+    scheduler._nonstream_cg_runner = types.SimpleNamespace(
+        decode_padded=fake_decode_padded
+    )
+    codes = torch.zeros(N_VQ, 1, 10, dtype=torch.long)
+
+    monkeypatch.setenv(MOSSL_FRAME_GRAPH_ENV, "1")
+    publish_ar_decode_batch(_NONSTREAM_GRAPH_MIN_AR_BATCH - 1)
+    assert scheduler._graphed_nonstream_decode(codes, [10]) is None
+    assert not consulted, "below-threshold load must stay eager"
+
+    publish_ar_decode_batch(_NONSTREAM_GRAPH_MIN_AR_BATCH)
+    out = scheduler._graphed_nonstream_decode(codes, [10])
+    assert consulted, "at-threshold load must consult the graph runner"
+    assert out is not None and out[0].shape == (2, 40)
+
+    consulted.clear()
+    monkeypatch.setenv(MOSSL_FRAME_GRAPH_ENV, "0")
+    publish_ar_decode_batch(_NONSTREAM_GRAPH_MIN_AR_BATCH + 16)
+    assert scheduler._graphed_nonstream_decode(codes, [10]) is None
+    assert not consulted, "kill switch must force eager regardless of load"
 
 
 # ---------------------------------------------------------------------------
@@ -671,6 +734,7 @@ def test_scheduler_kill_switch_and_replay_failure(
     eager_ref = scheduler._decode_codes_rows([r.clone() for r in rows_list])
 
     scheduler._nonstream_cg_runner = graph_runner
+    publish_ar_decode_batch(32)  # open the load gate; the kill switch still wins
 
     # Env off: the runner must not be consulted.
     monkeypatch.setenv(MOSSL_FRAME_GRAPH_ENV, "0")

--- a/tests/unit_test/moss_tts_local/test_frame_chain_graph.py
+++ b/tests/unit_test/moss_tts_local/test_frame_chain_graph.py
@@ -35,7 +35,6 @@ from sglang_omni.models.moss_tts_local.vocoder_cuda_graph import (  # noqa: E402
     mossl_frame_graph_enabled,
 )
 
-
 # ---------------------------------------------------------------------------
 # Env switch
 # ---------------------------------------------------------------------------
@@ -182,9 +181,7 @@ def test_fast_path_bit_identical_to_legacy(
     assert torch.equal(legacy["journal_rows"], fast["journal_rows"])
     assert torch.equal(legacy["sampling_steps"], fast["sampling_steps"])
     assert torch.equal(legacy["feedback_embeds"], fast["feedback_embeds"])
-    assert torch.equal(
-        legacy["audio_token_presence"], fast["audio_token_presence"]
-    )
+    assert torch.equal(legacy["audio_token_presence"], fast["audio_token_presence"])
 
 
 @pytest.mark.parametrize("batch_size", [2, 4, 8, 16])
@@ -394,8 +391,7 @@ def _graphed(runner, codes_list):
     audio, audio_lengths = out
     audio_cpu = audio.detach().to("cpu", torch.float32)
     return [
-        audio_cpu[i, :, : audio_lengths[i]].contiguous()
-        for i in range(len(codes_list))
+        audio_cpu[i, :, : audio_lengths[i]].contiguous() for i in range(len(codes_list))
     ]
 
 
@@ -409,9 +405,7 @@ def _uniform_reference(codec, nonstream_decoder, codes_list, bucket):
     )
     for i, c in enumerate(codes_list):
         padded[:, i, : c.shape[1]] = c
-    lengths = torch.full(
-        (batch_bucket,), frame_bucket, device=device, dtype=torch.long
-    )
+    lengths = torch.full((batch_bucket,), frame_bucket, device=device, dtype=torch.long)
     original = codec.decoder
     codec.decoder = nonstream_decoder
     try:

--- a/tests/unit_test/moss_tts_local/test_frame_chain_graph.py
+++ b/tests/unit_test/moss_tts_local/test_frame_chain_graph.py
@@ -485,19 +485,26 @@ def test_geometry_delta_bounded_and_ragged_eager_not_batch_invariant(
     graphed = _graphed(graph_runner, [c24, c17])
     assert graphed is not None
     ragged = _eager_reference(codec, nonstream_decoder, [c24, c17])
-    graph_vs_ragged = max(
-        (graphed[i] - ragged[i]).abs().max().item() for i in range(2)
-    )
+
+    def _rms(x: torch.Tensor) -> float:
+        return float(x.float().pow(2).mean().sqrt())
+
+    for g in graphed:
+        assert torch.isfinite(g).all()
+    graph_vs_ragged_rms = max(_rms(graphed[i] - ragged[i]) for i in range(2))
 
     solo = _eager_reference(codec, nonstream_decoder, [c17])[0]
-    eager_vs_eager = (solo - ragged[1]).abs().max().item()
+    eager_vs_eager_rms = _rms(solo - ragged[1])
 
-    assert graph_vs_ragged <= 0.1, (
-        f"bucket-geometry delta unexpectedly large: {graph_vs_ragged:.3e}"
-    )
-    assert eager_vs_eager > 0.0, (
+    assert eager_vs_eager_rms > 0.0, (
         "ragged eager decode became batch-invariant; the same-geometry "
         "identity gate should be revisited against full ragged identity"
+    )
+    # Bucket padding must perturb no more than a small factor of the batch
+    # variance the eager decode already exhibits between layouts.
+    assert graph_vs_ragged_rms <= 5.0 * eager_vs_eager_rms, (
+        f"bucket-geometry delta rms {graph_vs_ragged_rms:.3e} exceeds 5x the "
+        f"eager batch-variance rms {eager_vs_eager_rms:.3e}"
     )
 
 
@@ -694,7 +701,8 @@ def test_scheduler_kill_switch_and_replay_failure(
     assert consulted, "env on must consult the nonstream graph runner"
     for a, b in zip(on_out, eager_ref):
         assert a.shape == b.shape
-        assert (a - b).abs().max().item() <= 0.1
+        assert torch.isfinite(a).all()
+        assert (a - b).abs().max().item() <= 0.5
 
     # Replay failure: disables the runner, raises, then serves eager.
     def boom(*args, **kwargs):

--- a/tests/unit_test/moss_tts_local/test_frame_chain_graph.py
+++ b/tests/unit_test/moss_tts_local/test_frame_chain_graph.py
@@ -361,6 +361,88 @@ def test_nonstream_gate_dispatch(monkeypatch: pytest.MonkeyPatch):
     assert not consulted, "kill switch must force eager regardless of load"
 
 
+def test_gate_decision_is_per_batch_not_beacon(monkeypatch: pytest.MonkeyPatch):
+    """The per-batch decision carried with the emitted rows must beat any
+    beacon residue: an above-gate batch stays graphed even if a smaller batch
+    published afterwards, and a below-gate batch never enters the graph path
+    regardless of a stale high beacon. The beacon is only the fallback for
+    callers without a per-batch decision."""
+    scheduler = _bare_scheduler()
+    consulted: list = []
+
+    def fake_decode_padded(padded_codes, codes_lengths):
+        consulted.append(1)
+        return torch.zeros(1, 2, 100), [40]
+
+    scheduler._nonstream_cg_runner = types.SimpleNamespace(
+        decode_padded=fake_decode_padded
+    )
+    codes = torch.zeros(N_VQ, 1, 10, dtype=torch.long)
+    monkeypatch.setenv(MOSSL_FRAME_GRAPH_ENV, "1")
+
+    # Above-gate batch with a smaller batch published in between: still graphed.
+    publish_ar_decode_batch(4)
+    out = scheduler._graphed_nonstream_decode(codes, [10], above_load_gate=True)
+    assert consulted and out is not None
+
+    # Below-gate batch with stale high beacon residue: never graphed.
+    consulted.clear()
+    publish_ar_decode_batch(32)
+    assert (
+        scheduler._graphed_nonstream_decode(codes, [10], above_load_gate=False) is None
+    )
+    assert not consulted
+
+    # No per-batch decision: beacon fallback applies (both directions).
+    publish_ar_decode_batch(32)
+    assert scheduler._graphed_nonstream_decode(codes, [10]) is not None
+    publish_ar_decode_batch(4)
+    assert scheduler._graphed_nonstream_decode(codes, [10]) is None
+
+
+def test_journal_and_request_data_carry_gate_flag(monkeypatch: pytest.MonkeyPatch):
+    """The AR step's gate decision rides the journal into the request data and
+    the result payload, so the vocode dispatch needs no global temporal state."""
+    from sglang_omni.models.moss_tts_local.payload_types import MossTTSLocalState
+    from sglang_omni.models.moss_tts_local.request_builders import (
+        MossTTSLocalSGLangRequestData,
+        apply_sglang_moss_tts_local_result,
+    )
+    from sglang_omni.proto import StagePayload
+
+    monkeypatch.setenv(MOSSL_FRAME_GRAPH_ENV, "1")
+
+    def _run(batch_size: int):
+        runner = _make_runner(batch_size)
+        reqs = [_sched_req(f"r{i}") for i in range(batch_size)]
+        result = _result(batch_size)
+        runner._run_frame_decode(result, types.SimpleNamespace(), reqs)
+        journal = result.moss_journal
+        runner.post_process_outputs(
+            result,
+            types.SimpleNamespace(requests=reqs),
+            {req.request_id: types.SimpleNamespace(data=0) for req in reqs},
+        )
+        return journal.above_load_gate, reqs
+
+    above, reqs = _run(16)
+    assert above is True
+    assert all(req.data.above_load_gate is True for req in reqs)
+
+    above, reqs = _run(4)
+    assert above is False
+    assert all(req.data.above_load_gate is False for req in reqs)
+
+    # Result adapter and wire round-trip.
+    data = MossTTSLocalSGLangRequestData(
+        stage_payload=StagePayload(request_id="r", request=None, data={}),
+        above_load_gate=True,
+    )
+    payload = apply_sglang_moss_tts_local_result(data.stage_payload, data)
+    assert MossTTSLocalState.from_dict(payload.data).above_load_gate is True
+    assert MossTTSLocalState.from_dict({}).above_load_gate is False
+
+
 # ---------------------------------------------------------------------------
 # Non-streaming vocoder CUDA graph (GPU + real codec)
 # ---------------------------------------------------------------------------
@@ -788,17 +870,119 @@ def test_scheduler_kill_switch_and_replay_failure(
         assert torch.isfinite(a).all()
         assert (a - b).abs().max().item() <= 0.5
 
-    # Replay failure: disables the runner, raises, then serves eager.
+    # A per-batch below-gate decision beats the open beacon on the real path.
+    consulted.clear()
+    below_out = scheduler._decode_codes_rows(
+        [r.clone() for r in rows_list], above_load_gate=False
+    )
+    assert not consulted, "below-gate batch must never enter the graph path"
+    for a, b in zip(below_out, eager_ref):
+        assert torch.equal(a, b)
+
+    # Replay failure: the SAME batch is retried eagerly inline (in-flight
+    # requests succeed, bit-identical), and the runner is disabled after.
     def boom(*args, **kwargs):
         raise RuntimeError("simulated replay failure")
 
     monkeypatch.setattr(graph_runner, "decode_padded", boom)
-    with pytest.raises(RuntimeError):
-        scheduler._decode_codes_rows([r.clone() for r in rows_list])
+    retried = scheduler._decode_codes_rows([r.clone() for r in rows_list])
     assert scheduler._nonstream_cg_runner is None
+    for a, b in zip(retried, eager_ref):
+        assert torch.equal(a, b)
     after = scheduler._decode_codes_rows([r.clone() for r in rows_list])
     for a, b in zip(after, eager_ref):
         assert torch.equal(a, b)
+
+
+@pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA + real codec")
+def test_post_capture_headroom_violation_rolls_back(codec_bundle, monkeypatch):
+    """A capture that eats into the promised free-VRAM reserve is rolled back:
+    the graph is reset, its key disabled, and capturing stops."""
+    codec, nonstream_decoder, _ = codec_bundle
+    runner = MossNonstreamVocoderGraphRunner(
+        codec,
+        nonstream_decoder,
+        n_vq=N_VQ,
+        batch_buckets=[1],
+        frame_buckets=[4, 8],
+    )
+    resets: list = []
+    original_reset = torch.cuda.CUDAGraph.reset
+
+    def spy_reset(self, *args, **kwargs):
+        resets.append(self)
+        return original_reset(self, *args, **kwargs)
+
+    monkeypatch.setattr(torch.cuda.CUDAGraph, "reset", spy_reset)
+
+    checks = {"n": 0}
+
+    def fake_headroom():
+        checks["n"] += 1
+        # Pre-capture check passes; the post-capture re-check reports the
+        # capture ate into the reserve.
+        return (checks["n"] % 2 == 1), 1 << 30
+
+    runner._enough_free_vram = fake_headroom
+    runner.warmup()
+    assert runner.captured_keys() == [], "violating capture must be rolled back"
+    assert resets, "rollback must release the graph via reset()"
+
+
+PROD_BATCH_BUCKETS = [1, 2]
+PROD_FRAME_BUCKETS = [144, 176]
+
+
+@pytest.fixture(scope="module")
+def prod_graph_runner(codec_bundle):
+    codec, nonstream_decoder, _ = codec_bundle
+    runner = MossNonstreamVocoderGraphRunner(
+        codec,
+        nonstream_decoder,
+        n_vq=N_VQ,
+        batch_buckets=PROD_BATCH_BUCKETS,
+        frame_buckets=PROD_FRAME_BUCKETS,
+    )
+    runner.warmup()
+    if not runner.captured_keys():
+        pytest.skip("no production-bucket graphs captured (low VRAM?)")
+    return runner
+
+
+@pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA + real codec")
+@pytest.mark.parametrize(
+    "lengths",
+    [
+        [144],  # exact production T bucket, crosses the 128-token query tile
+        [176],  # exact largest production T bucket
+        [150],  # tail-padded into T=176
+        [176, 130],  # ragged pair at B=2
+    ],
+    ids=["b1_t144_exact", "b1_t176_exact", "b1_t150_tailpad", "b2_ragged_prod"],
+)
+def test_prod_bucket_graph_bit_identical_same_geometry(
+    codec_bundle, prod_graph_runner, lengths
+):
+    """Same-geometry identity at the production frame buckets: T=144/176 span
+    multiple 128-token local-attention query tiles, which the small-T gates do
+    not exercise."""
+    codec, nonstream_decoder, vocab = codec_bundle
+    torch.manual_seed(sum(lengths) + 7)
+    codes_list = [
+        torch.randint(0, vocab, (N_VQ, t), device="cuda", dtype=torch.long)
+        for t in lengths
+    ]
+    bucket = prod_graph_runner.bucket_for(len(codes_list), max(lengths))
+    assert bucket is not None
+    graphed = _graphed(prod_graph_runner, codes_list)
+    assert graphed is not None
+    reference = _uniform_reference(codec, nonstream_decoder, codes_list, bucket)
+    for i in range(len(lengths)):
+        assert graphed[i].shape == reference[i].shape
+        assert torch.equal(graphed[i], reference[i]), (
+            f"utterance {i} not bit-identical at prod bucket {bucket}: "
+            f"max|delta|={(graphed[i] - reference[i]).abs().max().item():.3e}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit_test/moss_tts_local/test_frame_chain_graph.py
+++ b/tests/unit_test/moss_tts_local/test_frame_chain_graph.py
@@ -275,13 +275,31 @@ def test_mixed_chunked_batch_still_uses_index_fallback(
 
 
 def test_run_frame_decode_publishes_ar_batch_size():
-    """Every frame-decode step publishes its batch size to the load beacon the
-    vocoder gate reads (colocated process)."""
-    for batch_size in (1, 4):
+    """Decode steps publish their batch size to the load beacon the vocoder
+    gate reads; prefill collects (no staged pool rows) must not stomp it."""
+
+    def _decode_step(batch_size: int) -> None:
         runner = _make_runner(batch_size)
         reqs = [_sched_req(f"r{i}") for i in range(batch_size)]
-        runner._run_frame_decode(_result(batch_size), types.SimpleNamespace(), reqs)
-        assert last_ar_decode_batch() == batch_size
+        pool = runner.model._state_pool
+        row_t, pool_rows, has_penalty = pool.prepare_active_rows(reqs)
+        forward_batch = types.SimpleNamespace(
+            moss_pool_row_t=row_t,
+            moss_pool_rows=pool_rows,
+            moss_has_audio_repetition_penalty=has_penalty,
+        )
+        runner._run_frame_decode(_result(batch_size), forward_batch, reqs)
+
+    _decode_step(4)
+    assert last_ar_decode_batch() == 4
+
+    # Prefill-style collect (forward_batch without staged rows): no stomp.
+    runner = _make_runner(1)
+    runner._run_frame_decode(_result(1), types.SimpleNamespace(), [_sched_req("p0")])
+    assert last_ar_decode_batch() == 4
+
+    _decode_step(2)
+    assert last_ar_decode_batch() == 2
 
 
 def _bare_scheduler():

--- a/tests/unit_test/moss_tts_local/test_frame_chain_graph.py
+++ b/tests/unit_test/moss_tts_local/test_frame_chain_graph.py
@@ -208,12 +208,19 @@ def test_mixed_chunked_batch_matches_legacy(
     assert torch.equal(legacy["rows"], fast["rows"])
 
 
-def test_all_emit_path_builds_no_host_index_tensor(monkeypatch: pytest.MonkeyPatch):
-    """The steady-state decode step (every row emits) must not build an index
-    tensor from a host list: torch.tensor(list, device=...) is a pageable H2D
-    copy that stream-syncs, measured at 24.6% of the serving loop."""
+@pytest.mark.parametrize(
+    ("batch_size", "expect_fast"),
+    [(16, True), (4, False)],
+    ids=["at_load_threshold_fast", "below_threshold_legacy_sync"],
+)
+def test_all_emit_path_index_tensor_follows_load_gate(
+    monkeypatch: pytest.MonkeyPatch, batch_size: int, expect_fast: bool
+):
+    """At/above the load threshold the steady-state decode step must not build
+    an index tensor from a host list (a pageable H2D copy that stream-syncs,
+    measured at 24.6% of the serving loop); below it the legacy synced path is
+    kept deliberately (the deep launch queue starves the eager vocoder)."""
     monkeypatch.setenv(MOSSL_FRAME_GRAPH_ENV, "1")
-    batch_size = 4
     runner = _make_runner(batch_size)
     reqs = [_sched_req(f"r{i}") for i in range(batch_size)]
     pool = runner.model._state_pool
@@ -235,24 +242,25 @@ def test_all_emit_path_builds_no_host_index_tensor(monkeypatch: pytest.MonkeyPat
 
     monkeypatch.setattr(torch, "tensor", counting_tensor)
     runner._run_frame_decode(_result(batch_size), forward_batch, reqs)
-    assert not calls, (
-        "all-emit fast path must not call torch.tensor (host->device sync); "
-        f"saw {len(calls)} call(s)"
-    )
+    if expect_fast:
+        assert not calls, (
+            "all-emit fast path must not call torch.tensor (host->device "
+            f"sync); saw {len(calls)} call(s)"
+        )
+    else:
+        assert calls, "below-threshold load must keep the legacy synced path"
 
 
 def test_mixed_chunked_batch_still_uses_index_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Sanity for the counter above: the mixed emit case keeps the legacy
-    index-tensor path (so the fast-path counter is not vacuous)."""
+    """A mixed emit batch keeps the legacy index-tensor path even at/above the
+    load threshold (so the fast-path counter is not vacuous)."""
     monkeypatch.setenv(MOSSL_FRAME_GRAPH_ENV, "1")
-    batch_size = 3
+    batch_size = 16
     runner = _make_runner(batch_size)
-    reqs = [
-        _sched_req("r0"),
-        _sched_req("r1"),
-        _sched_req("r2", chunked=1),
+    reqs = [_sched_req(f"r{i}") for i in range(batch_size - 1)] + [
+        _sched_req(f"r{batch_size - 1}", chunked=1)
     ]
     pool = runner.model._state_pool
     row_t, pool_rows, has_penalty = pool.prepare_active_rows(reqs)
@@ -320,8 +328,8 @@ def test_nonstream_gate_dispatch(monkeypatch: pytest.MonkeyPatch):
     """Load-aware gate: below the AR-batch threshold the runner is not
     consulted (eager, zero low-load regression by construction); at/above it
     the graphs engage; the kill switch forces eager regardless of load."""
-    from sglang_omni.models.moss_tts_local.streaming_vocoder import (
-        _NONSTREAM_GRAPH_MIN_AR_BATCH,
+    from sglang_omni.models.moss_tts_local.vocoder_cuda_graph import (
+        MOSSL_FRAME_GRAPH_MIN_AR_BATCH as _NONSTREAM_GRAPH_MIN_AR_BATCH,
     )
 
     scheduler = _bare_scheduler()

--- a/tests/unit_test/moss_tts_local/test_frame_chain_graph.py
+++ b/tests/unit_test/moss_tts_local/test_frame_chain_graph.py
@@ -1,0 +1,643 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Gates for the MOSS-TTS-Local frame-chain fast path and the non-streaming
+vocoder CUDA graphs: bit-identity vs eager, capture safety, env kill switch,
+and the capture-failure fuse. GPU tests need the real MOSS-Audio-Tokenizer-v2.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+import types
+
+import pytest
+import torch
+
+CODEC_GLOB = (
+    "/root/.cache/huggingface/hub/"
+    "models--OpenMOSS-Team--MOSS-Audio-Tokenizer-v2/snapshots/*/"
+)
+N_VQ = 12
+_HAS_CUDA = torch.cuda.is_available()
+
+pytest.importorskip("sglang")
+
+from sglang_omni.models.moss_tts_local.model_runner import (  # noqa: E402
+    MossTTSLocalModelRunner,
+)
+from sglang_omni.models.moss_tts_local.state_pool import (  # noqa: E402
+    MossTTSLocalDecodeStatePool,
+)
+from sglang_omni.models.moss_tts_local.vocoder_cuda_graph import (  # noqa: E402
+    MOSSL_FRAME_GRAPH_ENV,
+    MossNonstreamVocoderGraphRunner,
+    mossl_frame_graph_enabled,
+)
+
+
+# ---------------------------------------------------------------------------
+# Env switch
+# ---------------------------------------------------------------------------
+
+
+def test_env_switch_parsing(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(MOSSL_FRAME_GRAPH_ENV, raising=False)
+    assert mossl_frame_graph_enabled() is True
+    for off in ("0", "false", "off", " 0 ", "FALSE"):
+        monkeypatch.setenv(MOSSL_FRAME_GRAPH_ENV, off)
+        assert mossl_frame_graph_enabled() is False
+    for on in ("1", "true", "on", ""):
+        monkeypatch.setenv(MOSSL_FRAME_GRAPH_ENV, on)
+        assert mossl_frame_graph_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# CPU harness for the model-runner frame decode (mirrors test_pipeline stubs)
+# ---------------------------------------------------------------------------
+
+_HIDDEN = 4
+_SLOT_ID = 1000
+_END_ID = 1001
+
+
+def _make_runner(batch_size: int):
+    weight = torch.zeros(max(batch_size, 2), _HIDDEN, dtype=torch.bfloat16)
+    model = types.SimpleNamespace(
+        _decode_input_embedding=types.SimpleNamespace(weight=weight),
+        _state_pool=None,
+        config=types.SimpleNamespace(
+            n_vq=N_VQ,
+            audio_assistant_slot_token_id=_SLOT_ID,
+            audio_end_token_id=_END_ID,
+        ),
+        frame_graph_max_bs=0,  # eager frame path
+        device=torch.device("cpu"),
+    )
+    pool = MossTTSLocalDecodeStatePool(model)
+    model._state_pool = pool
+    model.acquire_row = pool.acquire_row
+
+    def decode_frame(hidden, *, sample_text, sample_audio):
+        del sample_text, sample_audio
+        bs = hidden.shape[0]
+        # Deterministic, row-distinct codes; row i stops iff its hidden row is 1.
+        stops = hidden[:, 0].long().clamp(0, 1)
+        codes = (
+            torch.arange(bs, dtype=torch.long).view(bs, 1)
+            + torch.arange(N_VQ, dtype=torch.long).view(1, N_VQ)
+        ) % 1024
+        return stops, codes
+
+    model.decode_frame = decode_frame
+    model._prepare_multi_modal_inputs = lambda rows: (
+        rows.sum(dim=-1, keepdim=True).to(torch.bfloat16).expand(-1, _HIDDEN) + 3
+    ).contiguous()
+    runner = MossTTSLocalModelRunner.__new__(MossTTSLocalModelRunner)
+    runner.model = model
+    runner._outbox = None
+    return runner
+
+
+def _sched_req(rid: str, *, penalty: float = 1.0, chunked: int = 0):
+    data = types.SimpleNamespace(
+        req=types.SimpleNamespace(is_chunked=chunked),
+        text_temperature=1.0,
+        text_top_p=1.0,
+        text_top_k=50,
+        audio_temperature=1.0,
+        audio_top_p=1.0,
+        audio_top_k=50,
+        sampling_seed=0,
+        generation_steps=0,
+        sampling_steps=None,
+        audio_repetition_penalty=penalty,
+        output_rows=[],
+    )
+    return types.SimpleNamespace(request_id=rid, data=data)
+
+
+def _result(batch_size: int, stop_rows: set[int] = frozenset()):
+    hidden = torch.zeros(batch_size, _HIDDEN)
+    for row in stop_rows:
+        hidden[row, 0] = 1.0
+    return types.SimpleNamespace(
+        logits_output=types.SimpleNamespace(hidden_states=hidden)
+    )
+
+
+def _run_scenario(batch_size, *, stop_rows=frozenset(), penalties=None, chunked=None):
+    runner = _make_runner(batch_size)
+    penalties = penalties or [1.0] * batch_size
+    chunked = chunked or [0] * batch_size
+    reqs = [
+        _sched_req(f"r{i}", penalty=penalties[i], chunked=chunked[i])
+        for i in range(batch_size)
+    ]
+    result = _result(batch_size, stop_rows)
+    rows, end_id = runner._run_frame_decode(result, types.SimpleNamespace(), reqs)
+    pool = runner.model._state_pool
+    journal = getattr(result, "moss_journal", None)
+    return {
+        "rows": rows,
+        "end_id": end_id,
+        "journal_rids": journal.rids if journal is not None else None,
+        "journal_pool_rows": journal.pool_rows if journal is not None else None,
+        "journal_rows": journal.rows.clone() if journal is not None else None,
+        "sampling_steps": pool.sampling_steps.clone(),
+        "feedback_embeds": pool.feedback_embeds.clone(),
+        "audio_token_presence": pool.audio_token_presence.clone(),
+    }
+
+
+_SCENARIOS = {
+    "all_continue": {},
+    "stop_rows": {"stop_rows": {0}},
+    "rep_penalty_on": {"penalties_first": 1.3},
+    "rep_penalty_stop_mix": {"stop_rows": {0}, "penalties_first": 1.3},
+}
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
+@pytest.mark.parametrize("scenario", sorted(_SCENARIOS))
+def test_fast_path_bit_identical_to_legacy(
+    monkeypatch: pytest.MonkeyPatch, batch_size: int, scenario: str
+):
+    """The all-emit fast path (env on) must be bit-identical to the legacy
+    index_select path (env off): published rows, journal, and pool state."""
+    spec = _SCENARIOS[scenario]
+    kwargs: dict = {"stop_rows": spec.get("stop_rows", frozenset())}
+    if "penalties_first" in spec:
+        kwargs["penalties"] = [spec["penalties_first"]] + [1.0] * (batch_size - 1)
+
+    monkeypatch.setenv(MOSSL_FRAME_GRAPH_ENV, "0")
+    legacy = _run_scenario(batch_size, **kwargs)
+    monkeypatch.setenv(MOSSL_FRAME_GRAPH_ENV, "1")
+    fast = _run_scenario(batch_size, **kwargs)
+
+    assert torch.equal(legacy["rows"], fast["rows"])
+    assert legacy["end_id"] == fast["end_id"]
+    assert legacy["journal_rids"] == fast["journal_rids"]
+    assert legacy["journal_pool_rows"] == fast["journal_pool_rows"]
+    assert torch.equal(legacy["journal_rows"], fast["journal_rows"])
+    assert torch.equal(legacy["sampling_steps"], fast["sampling_steps"])
+    assert torch.equal(legacy["feedback_embeds"], fast["feedback_embeds"])
+    assert torch.equal(
+        legacy["audio_token_presence"], fast["audio_token_presence"]
+    )
+
+
+@pytest.mark.parametrize("batch_size", [2, 4, 8, 16])
+def test_mixed_chunked_batch_matches_legacy(
+    monkeypatch: pytest.MonkeyPatch, batch_size: int
+):
+    """A batch with a non-final chunked row (emit/no-emit mix) must keep the
+    legacy per-index behavior under the fast-path env: identical journal
+    (chunked row excluded) and pool state."""
+    chunked = [0] * batch_size
+    chunked[-1] = 2
+    monkeypatch.setenv(MOSSL_FRAME_GRAPH_ENV, "0")
+    legacy = _run_scenario(batch_size, chunked=chunked)
+    monkeypatch.setenv(MOSSL_FRAME_GRAPH_ENV, "1")
+    fast = _run_scenario(batch_size, chunked=chunked)
+
+    assert legacy["journal_rids"] == fast["journal_rids"]
+    assert f"r{batch_size - 1}" not in fast["journal_rids"]
+    assert torch.equal(legacy["journal_rows"], fast["journal_rows"])
+    assert torch.equal(legacy["sampling_steps"], fast["sampling_steps"])
+    assert torch.equal(legacy["feedback_embeds"], fast["feedback_embeds"])
+    assert torch.equal(legacy["rows"], fast["rows"])
+
+
+def test_all_emit_path_builds_no_host_index_tensor(monkeypatch: pytest.MonkeyPatch):
+    """The steady-state decode step (every row emits) must not build an index
+    tensor from a host list: torch.tensor(list, device=...) is a pageable H2D
+    copy that stream-syncs, measured at 24.6% of the serving loop."""
+    monkeypatch.setenv(MOSSL_FRAME_GRAPH_ENV, "1")
+    batch_size = 4
+    runner = _make_runner(batch_size)
+    reqs = [_sched_req(f"r{i}") for i in range(batch_size)]
+    pool = runner.model._state_pool
+    row_t, pool_rows, has_penalty = pool.prepare_active_rows(reqs)
+    forward_batch = types.SimpleNamespace(
+        moss_pool_row_t=row_t,
+        moss_pool_rows=pool_rows,
+        moss_has_audio_repetition_penalty=has_penalty,
+    )
+    # Warm any lazy one-time caches; only the steady-state step is asserted on.
+    runner._run_frame_decode(_result(batch_size), forward_batch, reqs)
+
+    calls: list = []
+    original_tensor = torch.tensor
+
+    def counting_tensor(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original_tensor(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "tensor", counting_tensor)
+    runner._run_frame_decode(_result(batch_size), forward_batch, reqs)
+    assert not calls, (
+        "all-emit fast path must not call torch.tensor (host->device sync); "
+        f"saw {len(calls)} call(s)"
+    )
+
+
+def test_mixed_chunked_batch_still_uses_index_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Sanity for the counter above: the mixed emit case keeps the legacy
+    index-tensor path (so the fast-path counter is not vacuous)."""
+    monkeypatch.setenv(MOSSL_FRAME_GRAPH_ENV, "1")
+    batch_size = 3
+    runner = _make_runner(batch_size)
+    reqs = [
+        _sched_req("r0"),
+        _sched_req("r1"),
+        _sched_req("r2", chunked=1),
+    ]
+    pool = runner.model._state_pool
+    row_t, pool_rows, has_penalty = pool.prepare_active_rows(reqs)
+    forward_batch = types.SimpleNamespace(
+        moss_pool_row_t=row_t,
+        moss_pool_rows=pool_rows,
+        moss_has_audio_repetition_penalty=has_penalty,
+    )
+
+    calls: list = []
+    original_tensor = torch.tensor
+
+    def counting_tensor(*args, **kwargs):
+        calls.append((args, kwargs))
+        return original_tensor(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "tensor", counting_tensor)
+    runner._run_frame_decode(_result(batch_size), forward_batch, reqs)
+    assert calls, "mixed batch should take the index-tensor fallback"
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming vocoder CUDA graph (GPU + real codec)
+# ---------------------------------------------------------------------------
+
+
+def test_nonstream_capture_uses_thread_local_error_mode():
+    source = textwrap.dedent(
+        inspect.getsource(MossNonstreamVocoderGraphRunner._capture)
+    )
+    tree = ast.parse(source)
+    graph_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "graph"
+        and isinstance(node.func.value, ast.Attribute)
+        and node.func.value.attr == "cuda"
+    ]
+    assert graph_calls, "nonstream vocoder CUDA graph capture call not found"
+    assert any(
+        keyword.arg == "capture_error_mode"
+        and isinstance(keyword.value, ast.Constant)
+        and keyword.value.value == "thread_local"
+        for call in graph_calls
+        for keyword in call.keywords
+    )
+
+
+BATCH_BUCKETS = [1, 2, 4]
+FRAME_BUCKETS = [12, 24]
+
+
+@pytest.fixture(scope="module")
+def codec_bundle():
+    import glob
+
+    from transformers import AutoModel
+
+    from sglang_omni.models.moss_tts_local.vocoder_decoder import (
+        MossTTSLocalVocoderDecoder,
+    )
+
+    snaps = glob.glob(CODEC_GLOB)
+    if not snaps:
+        pytest.skip("MOSS-Audio-Tokenizer-v2 codec snapshot not found")
+    codec = (
+        AutoModel.from_pretrained(snaps[0], trust_remote_code=True).to("cuda").eval()
+    )
+    nonstream_decoder = MossTTSLocalVocoderDecoder(codec.decoder)
+    vocab = 1024
+    return codec, nonstream_decoder, vocab
+
+
+@pytest.fixture(scope="module")
+def graph_runner(codec_bundle):
+    codec, nonstream_decoder, _ = codec_bundle
+    runner = MossNonstreamVocoderGraphRunner(
+        codec,
+        nonstream_decoder,
+        n_vq=N_VQ,
+        batch_buckets=BATCH_BUCKETS,
+        frame_buckets=FRAME_BUCKETS,
+    )
+    runner.warmup()
+    if not runner.captured_keys():
+        pytest.skip("no nonstream vocoder graphs captured (low VRAM?)")
+    return runner
+
+
+def _eager_reference(codec, nonstream_decoder, codes_list):
+    """The exact production eager path of _decode_codes_rows_nonstream."""
+    device = next(codec.parameters()).device
+    max_len = max(int(c.shape[1]) for c in codes_list)
+    audio_codes = torch.zeros(
+        N_VQ, len(codes_list), max_len, device=device, dtype=torch.long
+    )
+    padding_mask = torch.zeros(
+        len(codes_list), max_len, device=device, dtype=torch.bool
+    )
+    for i, c in enumerate(codes_list):
+        audio_codes[:, i, : c.shape[1]] = c
+        padding_mask[i, : c.shape[1]] = True
+    original = codec.decoder
+    codec.decoder = nonstream_decoder
+    try:
+        with torch.no_grad():
+            decoded = codec.decode(
+                audio_codes,
+                padding_mask=padding_mask,
+                num_quantizers=N_VQ,
+                return_dict=True,
+                chunk_duration=None,
+            )
+    finally:
+        codec.decoder = original
+    audio_cpu = decoded.audio.detach().to("cpu", torch.float32)
+    lengths_cpu = decoded.audio_lengths.detach().to("cpu")
+    return [
+        audio_cpu[i, :, : int(lengths_cpu[i])].contiguous()
+        for i in range(len(codes_list))
+    ]
+
+
+def _graphed(runner, codes_list):
+    device = runner._device
+    max_len = max(int(c.shape[1]) for c in codes_list)
+    padded = torch.zeros(
+        N_VQ, len(codes_list), max_len, device=device, dtype=torch.long
+    )
+    for i, c in enumerate(codes_list):
+        padded[:, i, : c.shape[1]] = c
+    lengths = [int(c.shape[1]) for c in codes_list]
+    out = runner.decode_padded(padded, lengths)
+    if out is None:
+        return None
+    audio, audio_lengths = out
+    audio_cpu = audio.detach().to("cpu", torch.float32)
+    return [
+        audio_cpu[i, :, : audio_lengths[i]].contiguous()
+        for i in range(len(codes_list))
+    ]
+
+
+@pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA + real codec")
+@pytest.mark.parametrize(
+    "lengths",
+    [
+        [12],  # exact frame bucket
+        [7],  # tail-padded within a bucket
+        [24, 17],  # ragged pair, exact batch bucket
+        [12, 9, 5],  # ragged triple -> padded batch bucket (B=4)
+        [24, 24, 24, 24],  # full bucket, uniform
+    ],
+    ids=["b1_exact", "b1_tailpad", "b2_ragged", "b3_padded_bucket", "b4_full"],
+)
+def test_nonstream_graph_bit_identical_to_eager(codec_bundle, graph_runner, lengths):
+    codec, nonstream_decoder, vocab = codec_bundle
+    torch.manual_seed(sum(lengths))
+    codes_list = [
+        torch.randint(0, vocab, (N_VQ, t), device="cuda", dtype=torch.long)
+        for t in lengths
+    ]
+    graphed = _graphed(graph_runner, codes_list)
+    assert graphed is not None, "expected a graph hit for this bucket"
+    eager = _eager_reference(codec, nonstream_decoder, codes_list)
+    for i in range(len(lengths)):
+        assert graphed[i].shape == eager[i].shape, (
+            f"utterance {i}: graphed {tuple(graphed[i].shape)} != "
+            f"eager {tuple(eager[i].shape)}"
+        )
+        assert torch.equal(graphed[i], eager[i]), (
+            f"utterance {i} not bit-identical: "
+            f"max|delta|={(graphed[i] - eager[i]).abs().max().item():.3e}"
+        )
+
+
+@pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA + real codec")
+def test_uniform_full_lengths_mode_bit_identical_to_default(codec_bundle):
+    """assume_full_lengths (the capture-mode pack) must match the default packed
+    path bit-for-bit when all lengths equal the dense length, and must restore
+    the default path on exit."""
+    codec, nonstream_decoder, vocab = codec_bundle
+    torch.manual_seed(7)
+    for batch_size, frames in ((1, 12), (3, 24)):
+        codes_list = [
+            torch.randint(0, vocab, (N_VQ, frames), device="cuda", dtype=torch.long)
+            for _ in range(batch_size)
+        ]
+        baseline = _eager_reference(codec, nonstream_decoder, codes_list)
+        with nonstream_decoder.assume_full_lengths():
+            uniform = _eager_reference(codec, nonstream_decoder, codes_list)
+        restored = _eager_reference(codec, nonstream_decoder, codes_list)
+        for i in range(batch_size):
+            assert torch.equal(uniform[i], baseline[i])
+            assert torch.equal(restored[i], baseline[i])
+
+
+@pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA + real codec")
+def test_oversize_shapes_fall_back_to_eager(graph_runner):
+    device = graph_runner._device
+    too_long = torch.zeros(N_VQ, 1, max(FRAME_BUCKETS) + 1, device=device).long()
+    assert graph_runner.decode_padded(too_long, [too_long.shape[2]]) is None
+    too_wide = torch.zeros(
+        N_VQ, max(BATCH_BUCKETS) + 1, FRAME_BUCKETS[0], device=device
+    ).long()
+    assert (
+        graph_runner.decode_padded(too_wide, [FRAME_BUCKETS[0]] * too_wide.shape[1])
+        is None
+    )
+
+
+class _NoHostReadbackTensor(torch.Tensor):
+    """Raises on any host readback so the replay dispatch is provably sync-free."""
+
+    def item(self):
+        raise AssertionError("host readback (.item) on replay dispatch")
+
+    def cpu(self, *args, **kwargs):
+        raise AssertionError("host readback (.cpu) on replay dispatch")
+
+    def tolist(self):
+        raise AssertionError("host readback (.tolist) on replay dispatch")
+
+    def numpy(self, *args, **kwargs):
+        raise AssertionError("host readback (.numpy) on replay dispatch")
+
+    def __bool__(self):
+        raise AssertionError("host readback (__bool__) on replay dispatch")
+
+    def __int__(self):
+        raise AssertionError("host readback (__int__) on replay dispatch")
+
+
+@pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA + real codec")
+def test_no_host_readback_on_replay_dispatch(graph_runner):
+    frames = FRAME_BUCKETS[0]
+    codes = torch.zeros(
+        N_VQ, 1, frames, device=graph_runner._device, dtype=torch.long
+    ).as_subclass(_NoHostReadbackTensor)
+    out = graph_runner.decode_padded(codes, [frames])
+    assert out is not None
+
+
+@pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA + real codec")
+def test_capture_failure_fuse_stops_after_max_failures(codec_bundle):
+    codec, nonstream_decoder, _ = codec_bundle
+    runner = MossNonstreamVocoderGraphRunner(
+        codec,
+        nonstream_decoder,
+        n_vq=N_VQ,
+        batch_buckets=[1, 2, 4],
+        frame_buckets=[4, 8, 16],  # 9 keys > 8-failure fuse
+    )
+    attempts: list = []
+
+    def boom(batch_bucket, frame_bucket):
+        attempts.append((batch_bucket, frame_bucket))
+        raise RuntimeError("simulated capture failure")
+
+    runner._capture = boom
+    runner.warmup()
+    assert runner.captured_keys() == []
+    assert len(attempts) == 8, "fuse must stop captures after 8 distinct failures"
+    codes = torch.zeros(N_VQ, 1, 4, device=next(codec.parameters()).device).long()
+    assert runner.decode_padded(codes, [4]) is None
+
+
+@pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA + real codec")
+def test_capture_failure_resets_graph_pool(codec_bundle, monkeypatch):
+    codec, nonstream_decoder, _ = codec_bundle
+    runner = MossNonstreamVocoderGraphRunner(
+        codec,
+        nonstream_decoder,
+        n_vq=N_VQ,
+        batch_buckets=[1],
+        frame_buckets=[4],
+    )
+    resets: list = []
+    original_reset = torch.cuda.CUDAGraph.reset
+
+    def spy_reset(self, *args, **kwargs):
+        resets.append(self)
+        return original_reset(self, *args, **kwargs)
+
+    monkeypatch.setattr(torch.cuda.CUDAGraph, "reset", spy_reset)
+
+    class _Boom(RuntimeError):
+        pass
+
+    original_frame = codec._decode_frame
+    calls = {"n": 0}
+
+    def failing_decode_frame(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] > 2:  # let warmup pass, fail inside capture
+            raise _Boom("simulated capture failure")
+        return original_frame(*args, **kwargs)
+
+    monkeypatch.setattr(codec, "_decode_frame", failing_decode_frame)
+    runner.warmup()
+    assert runner.captured_keys() == []
+    assert resets, "a failed capture must release its graph pool via reset()"
+
+
+@pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA + real codec")
+def test_vram_guard_skips_capture(codec_bundle):
+    codec, nonstream_decoder, _ = codec_bundle
+    runner = MossNonstreamVocoderGraphRunner(
+        codec,
+        nonstream_decoder,
+        n_vq=N_VQ,
+        batch_buckets=[1],
+        frame_buckets=[4],
+        min_free_gb=100000.0,
+    )
+    runner.warmup()
+    assert runner.captured_keys() == []
+
+
+@pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA + real codec")
+def test_scheduler_kill_switch_and_replay_failure(
+    codec_bundle, graph_runner, monkeypatch
+):
+    """Scheduler-level wiring: env off bypasses the runner entirely; a replay
+    failure disables the runner and serves eager afterwards, bit-identical."""
+    from sglang_omni.models.moss_tts_local.streaming_vocoder import (
+        MossTTSLocalStreamingVocoderScheduler,
+    )
+
+    codec, nonstream_decoder, vocab = codec_bundle
+    scheduler = MossTTSLocalStreamingVocoderScheduler(
+        codec,
+        n_vq=N_VQ,
+        sample_rate=48000,
+        cuda_graph=False,  # no streaming-session graphs; nonstream runner injected
+    )
+    scheduler._nonstream_decoder = nonstream_decoder
+    torch.manual_seed(11)
+    rows_list = [
+        torch.randint(0, vocab, (17, N_VQ), device="cuda", dtype=torch.long),
+        torch.randint(0, vocab, (12, N_VQ), device="cuda", dtype=torch.long),
+    ]
+    eager_ref = scheduler._decode_codes_rows([r.clone() for r in rows_list])
+
+    scheduler._nonstream_cg_runner = graph_runner
+
+    # Env off: the runner must not be consulted.
+    monkeypatch.setenv(MOSSL_FRAME_GRAPH_ENV, "0")
+    consulted: list = []
+    original_decode_padded = graph_runner.decode_padded
+
+    def spying_decode_padded(*args, **kwargs):
+        consulted.append(1)
+        return original_decode_padded(*args, **kwargs)
+
+    monkeypatch.setattr(graph_runner, "decode_padded", spying_decode_padded)
+    off_out = scheduler._decode_codes_rows([r.clone() for r in rows_list])
+    assert not consulted, "kill switch must bypass the nonstream graph runner"
+    for a, b in zip(off_out, eager_ref):
+        assert torch.equal(a, b)
+
+    # Env on: the runner is consulted and matches eager bit-for-bit.
+    monkeypatch.setenv(MOSSL_FRAME_GRAPH_ENV, "1")
+    on_out = scheduler._decode_codes_rows([r.clone() for r in rows_list])
+    assert consulted, "env on must consult the nonstream graph runner"
+    for a, b in zip(on_out, eager_ref):
+        assert torch.equal(a, b)
+
+    # Replay failure: disables the runner, raises, then serves eager.
+    def boom(*args, **kwargs):
+        raise RuntimeError("simulated replay failure")
+
+    monkeypatch.setattr(graph_runner, "decode_padded", boom)
+    with pytest.raises(RuntimeError):
+        scheduler._decode_codes_rows([r.clone() for r in rows_list])
+    assert scheduler._nonstream_cg_runner is None
+    after = scheduler._decode_codes_rows([r.clone() for r in rows_list])
+    for a, b in zip(after, eager_ref):
+        assert torch.equal(a, b)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/tests/unit_test/moss_tts_local/test_frame_chain_graph.py
+++ b/tests/unit_test/moss_tts_local/test_frame_chain_graph.py
@@ -399,6 +399,33 @@ def _graphed(runner, codes_list):
     ]
 
 
+def _uniform_reference(codec, nonstream_decoder, codes_list, bucket):
+    """Eager decode at the exact bucket geometry the graph replays: codes
+    zero-padded to (B_bucket, T_bucket), all lengths pinned to T_bucket."""
+    batch_bucket, frame_bucket = bucket
+    device = next(codec.parameters()).device
+    padded = torch.zeros(
+        N_VQ, batch_bucket, frame_bucket, device=device, dtype=torch.long
+    )
+    for i, c in enumerate(codes_list):
+        padded[:, i, : c.shape[1]] = c
+    lengths = torch.full(
+        (batch_bucket,), frame_bucket, device=device, dtype=torch.long
+    )
+    original = codec.decoder
+    codec.decoder = nonstream_decoder
+    try:
+        with torch.no_grad(), nonstream_decoder.assume_full_lengths():
+            result = codec._decode_frame(padded, lengths)
+    finally:
+        codec.decoder = original
+    audio_cpu = result.audio.detach().to("cpu", torch.float32)
+    return [
+        audio_cpu[i, :, : int(c.shape[1]) * 3840].contiguous()
+        for i, c in enumerate(codes_list)
+    ]
+
+
 @pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA + real codec")
 @pytest.mark.parametrize(
     "lengths",
@@ -411,25 +438,67 @@ def _graphed(runner, codes_list):
     ],
     ids=["b1_exact", "b1_tailpad", "b2_ragged", "b3_padded_bucket", "b4_full"],
 )
-def test_nonstream_graph_bit_identical_to_eager(codec_bundle, graph_runner, lengths):
+def test_nonstream_graph_bit_identical_to_same_geometry_eager(
+    codec_bundle, graph_runner, lengths
+):
+    """Replay must reproduce the eager decode it replaces (same bucket
+    geometry) bit-for-bit. Identity vs the RAGGED eager decode is not a
+    coherent gate: the eager varlen decode's bits already depend on batch
+    composition (see test_geometry_delta_bounded...)."""
     codec, nonstream_decoder, vocab = codec_bundle
     torch.manual_seed(sum(lengths))
     codes_list = [
         torch.randint(0, vocab, (N_VQ, t), device="cuda", dtype=torch.long)
         for t in lengths
     ]
+    bucket = graph_runner.bucket_for(len(codes_list), max(lengths))
+    assert bucket is not None, "expected a graph hit for this bucket"
     graphed = _graphed(graph_runner, codes_list)
-    assert graphed is not None, "expected a graph hit for this bucket"
-    eager = _eager_reference(codec, nonstream_decoder, codes_list)
+    assert graphed is not None
+    reference = _uniform_reference(codec, nonstream_decoder, codes_list, bucket)
     for i in range(len(lengths)):
-        assert graphed[i].shape == eager[i].shape, (
+        assert graphed[i].shape == reference[i].shape, (
             f"utterance {i}: graphed {tuple(graphed[i].shape)} != "
-            f"eager {tuple(eager[i].shape)}"
+            f"reference {tuple(reference[i].shape)}"
         )
-        assert torch.equal(graphed[i], eager[i]), (
-            f"utterance {i} not bit-identical: "
-            f"max|delta|={(graphed[i] - eager[i]).abs().max().item():.3e}"
+        assert torch.equal(graphed[i], reference[i]), (
+            f"utterance {i} not bit-identical to same-geometry eager: "
+            f"max|delta|={(graphed[i] - reference[i]).abs().max().item():.3e}"
         )
+
+
+@pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA + real codec")
+def test_geometry_delta_bounded_and_ragged_eager_not_batch_invariant(
+    codec_bundle, graph_runner
+):
+    """Two facts that justify the same-geometry identity gate above:
+    (1) the graphed (bucket-padded) output stays within a small bound of the
+    ragged eager output; (2) the ragged eager decode itself is NOT
+    batch-invariant at the bit level (same utterance, different neighbor ->
+    different bits), so bucket padding introduces no new error mode. If (2)
+    ever becomes exactly invariant, revisit the gate."""
+    codec, nonstream_decoder, vocab = codec_bundle
+    torch.manual_seed(4141)
+    c24 = torch.randint(0, vocab, (N_VQ, 24), device="cuda", dtype=torch.long)
+    c17 = torch.randint(0, vocab, (N_VQ, 17), device="cuda", dtype=torch.long)
+
+    graphed = _graphed(graph_runner, [c24, c17])
+    assert graphed is not None
+    ragged = _eager_reference(codec, nonstream_decoder, [c24, c17])
+    graph_vs_ragged = max(
+        (graphed[i] - ragged[i]).abs().max().item() for i in range(2)
+    )
+
+    solo = _eager_reference(codec, nonstream_decoder, [c17])[0]
+    eager_vs_eager = (solo - ragged[1]).abs().max().item()
+
+    assert graph_vs_ragged <= 0.1, (
+        f"bucket-geometry delta unexpectedly large: {graph_vs_ragged:.3e}"
+    )
+    assert eager_vs_eager > 0.0, (
+        "ragged eager decode became batch-invariant; the same-geometry "
+        "identity gate should be revisited against full ragged identity"
+    )
 
 
 @pytest.mark.skipif(not _HAS_CUDA, reason="needs CUDA + real codec")
@@ -617,12 +686,15 @@ def test_scheduler_kill_switch_and_replay_failure(
     for a, b in zip(off_out, eager_ref):
         assert torch.equal(a, b)
 
-    # Env on: the runner is consulted and matches eager bit-for-bit.
+    # Env on: the runner is consulted; output shape matches and the value
+    # stays within the bucket-geometry family (bit-identity vs ragged eager
+    # is not defined; see the geometry-delta test).
     monkeypatch.setenv(MOSSL_FRAME_GRAPH_ENV, "1")
     on_out = scheduler._decode_codes_rows([r.clone() for r in rows_list])
     assert consulted, "env on must consult the nonstream graph runner"
     for a, b in zip(on_out, eager_ref):
-        assert torch.equal(a, b)
+        assert a.shape == b.shape
+        assert (a - b).abs().max().item() <= 0.1
 
     # Replay failure: disables the runner, raises, then serves eager.
     def boom(*args, **kwargs):


### PR DESCRIPTION
## Motivation

MOSS-TTS-Local serving is host-bound: the event loop spends 64-67% in decode launch at 7.8-8.1 ms/step (loop-segment timer), capping a single replica at ~11 qps. A py-spy decomposition (18k samples, steady c32) shows where that goes: a hidden per-step H2D sync in the AR frame decode (`torch.tensor(emit_indices, device=cuda)`, 24.6% self) and the eager 92-layer non-streaming vocoder decode chain (46% inclusive, ~13 host syncs per utterance). The per-frame local-transformer chain itself is already CUDA-graphed on main (1.2% of samples).

## Modifications

* **All-emit fast path** in the AR frame decode (`model_runner.py`): the common all-rows-emit step skips the emit-index materialization and its stream sync; mixed emit/no-emit steps take the legacy path unchanged.
* **(B, T)-bucketed CUDA graphs over the packed non-streaming vocoder** (`vocoder_decoder.py`, new `vocoder_cuda_graph.py`): capture-safe `assume_full_lengths` pack mode, per-B shared pools captured largest-first, a VRAM guard that also re-checks headroom after each capture and rolls back a violating graph, an 8-distinct-failure fuse releasing pools via `CUDAGraph.reset()`, and replay-failure handling that decodes the in-flight batch eagerly inline before disabling the runner.
* **One per-batch load gate for both**: the gate decision is recorded at AR decode time and carried with the batch through the journal and state wire to the vocode dispatch (fail-closed; a wave is graphed only when all its payloads are gate-qualified). Both optimizations must engage together: the fast path deepens the launch queue, which turns the eager vocoder's per-utterance host syncs into a measured death spiral if gated independently. Threshold `MOSSL_FRAME_GRAPH_MIN_AR_BATCH = 12`; below it the code path is identical to baseline. Kill switch: `SGLANG_OMNI_MOSSL_FRAME_GRAPH=0`.

## Evidence (1x H100, seed-tts-eval EN, 256 samples per leg, fresh server per leg, loadavg logged)

Correctness: same-geometry bit-identity (`torch.equal` on rows, journal, pool state; feedback embeddings 0-ulp) across batch sizes 1/2/4/8/16 with repetition-penalty on/off, stop rows, and emit mixes; graphed vocoder replay `torch.equal` to same-geometry eager including the production frame buckets T=144/176 that cross the local-attention 128-token tile boundary. Note: main's own eager vocoder is not bit-stable across batch layouts (measured max delta 2.4e-2 for the same utterance), so cross-layout identity is unattainable in principle; quality is gated by WER instead. Full moss_tts_local suite: 246 passed.

End-to-end serving throughput (full pipeline through the HTTP endpoint, client-measured), ON vs OFF pairs at this head, under a busy shared host (1m loadavg 7-52 recorded per leg):

| pair | on (req/s) | off (req/s) | delta |
| --- | --- | --- | --- |
| c32, pair 1 | 9.641 | 8.940 | **+7.8%** |
| c32, pair 2 | 9.154 | 7.529 | **+21.6%** |
| c16, pair 1 | 8.773 | 8.612 | +1.9% |
| c16, pair 2 | 8.006 | 7.483 | +7.0% |
| c8 (2+2) | 6.658 | 6.614 | +0.7% (below the gate: baseline code path) |

ON won every pair, zero failures. On a calmer window (loadavg 10-19) the pre-hardening revision measured **+39.5% at c32 (mean latency -30%, p99 -28%)**; the hardened per-batch gate is strictly more conservative (ramp and drain-tail batches fail closed to eager), and host contention pushes the AR batch toward the threshold, so the busy-box magnitudes above are a floor. A quiet-window rerun will follow as a comment.

Quality: corpus WER at c8, 256 samples: **1.29% (on) vs 1.62% (off)**, no degradation (measured at the pre-hardening revision; the hardening changed dispatch only, not kernels, and same-geometry identity is re-proven at this head).

## Checklist

- [x] Format your code with `pre-commit run --all-files`
- [x] Add unit tests
