### PR TITLE
[CI] Add Higgs TTS capacity probes: routed c96 and direct-worker c48 speed gates

### DIFF
--- a/.claude/skills/tune-ci-thresholds/models/tts/config.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/tts/config.yaml
@@ -101,8 +101,8 @@ metric_sources:
     # tts_nonstream_similarity.
     variants:
       nonstream:
-        # Higgs HIGGS_VC_* (not HIGGS_VC_STREAM_* / HIGGS_VC_NON_STREAM_HC_*);
-        # MOSS uses MOSS_VC_*. via calibration_presets.<preset>.constant_filter.
+        # Higgs HIGGS_VC_* (not HIGGS_VC_STREAM_*); MOSS uses MOSS_VC_*.
+        # via calibration_presets.<preset>.constant_filter in discover.
         constant_filter: "^HIGGS_VC_(?!STREAM_|NON_STREAM_HC_).*|^MOSS_VC_(?!STREAM_|NON_STREAM_HC_).*"
         json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
         sample_counts:
@@ -127,8 +127,19 @@ metric_sources:
           similarity_mean: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json::summary.speaker_similarity_mean"
           utmos_mean: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json::summary.utmos_mean"
       nonstream_hc:
-        constant_filter: "^HIGGS_VC_NON_STREAM_HC_.*$|^MOSS_VC_NON_STREAM_HC_.*$"
+        constant_filter: "^HIGGS_VC_NON_STREAM_HC_(?!DIRECT_).*$|^MOSS_VC_NON_STREAM_HC_(?!DIRECT_).*$"
         json_file: "test_voice_cloning_high_concur0/vc_nonstream_hc_c96/speed_results.json"
+        sample_counts:
+          total: "summary.total_requests"
+          ok: "summary.completed_requests"
+        paths:
+          throughput_qps: "summary.throughput_qps"
+          output_tok_per_req_s: "summary.output_tok_per_req_s"
+          latency_mean_s: "summary.latency_mean_s"
+          rtf_mean: "summary.rtf_mean"
+      nonstream_hc_direct:
+        constant_filter: "^HIGGS_VC_NON_STREAM_HC_DIRECT_.*$|^MOSS_VC_NON_STREAM_HC_DIRECT_.*$"
+        json_file: "test_voice_cloning_direct_work0/vc_nonstream_hc_direct_c48/speed_results.json"
         sample_counts:
           total: "summary.total_requests"
           ok: "summary.completed_requests"

--- a/.claude/skills/tune-ci-thresholds/models/tts/config.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/tts/config.yaml
@@ -101,9 +101,9 @@ metric_sources:
     # tts_nonstream_similarity.
     variants:
       nonstream:
-        # Higgs HIGGS_VC_* (not HIGGS_VC_STREAM_*); MOSS uses MOSS_VC_*.
-        # via calibration_presets.<preset>.constant_filter in discover.
-        constant_filter: "^HIGGS_VC_(?!STREAM_).*|^MOSS_VC_(?!STREAM_).*"
+        # Higgs HIGGS_VC_* (not HIGGS_VC_STREAM_* / HIGGS_VC_NON_STREAM_HC_*);
+        # MOSS uses MOSS_VC_*. via calibration_presets.<preset>.constant_filter.
+        constant_filter: "^HIGGS_VC_(?!STREAM_|NON_STREAM_HC_).*|^MOSS_VC_(?!STREAM_|NON_STREAM_HC_).*"
         json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
         sample_counts:
           total: "summary.total_requests"
@@ -126,6 +126,17 @@ metric_sources:
           corpus_wer: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json::summary.wer_corpus"
           similarity_mean: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json::summary.speaker_similarity_mean"
           utmos_mean: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json::summary.utmos_mean"
+      nonstream_hc:
+        constant_filter: "^HIGGS_VC_NON_STREAM_HC_.*$|^MOSS_VC_NON_STREAM_HC_.*$"
+        json_file: "test_voice_cloning_high_concur0/vc_nonstream_hc_c96/speed_results.json"
+        sample_counts:
+          total: "summary.total_requests"
+          ok: "summary.completed_requests"
+        paths:
+          throughput_qps: "summary.throughput_qps"
+          output_tok_per_req_s: "summary.output_tok_per_req_s"
+          latency_mean_s: "summary.latency_mean_s"
+          rtf_mean: "summary.rtf_mean"
       stream:
         constant_filter: "^HIGGS_VC_STREAM_.*$|^MOSS_VC_STREAM_.*$"
         json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"

--- a/.claude/skills/tune-ci-thresholds/models/tts/stages.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/tts/stages.yaml
@@ -12,11 +12,11 @@ tts_higgs_nonstream_wer:
   hf_model_ids:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d170f4686a2047346cb39782c69d1bd551af3cb14ef68fc770882d5e7f8b9af3
-  last_discovered_at: 2026-07-22T01:59:30Z
+  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
+  last_discovered_at: 2026-07-22T23:00:39Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e3965169163748bf61f8a169f32f96ffe154a2078ca08dcb4c756d595c6003e3
+  threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json"
@@ -48,11 +48,11 @@ tts_higgs_nonstream_similarity:
   hf_model_ids:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d170f4686a2047346cb39782c69d1bd551af3cb14ef68fc770882d5e7f8b9af3
-  last_discovered_at: 2026-07-22T01:59:30Z
+  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
+  last_discovered_at: 2026-07-22T23:00:39Z
   expected_samples: 50
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e3965169163748bf61f8a169f32f96ffe154a2078ca08dcb4c756d595c6003e3
+  threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
@@ -84,11 +84,11 @@ tts_higgs_nonstream_utmos:
   hf_model_ids:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d170f4686a2047346cb39782c69d1bd551af3cb14ef68fc770882d5e7f8b9af3
-  last_discovered_at: 2026-07-22T01:59:30Z
+  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
+  last_discovered_at: 2026-07-22T23:00:39Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e3965169163748bf61f8a169f32f96ffe154a2078ca08dcb4c756d595c6003e3
+  threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json"
@@ -120,11 +120,11 @@ tts_higgs_nonstream_speed:
   hf_model_ids:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d170f4686a2047346cb39782c69d1bd551af3cb14ef68fc770882d5e7f8b9af3
-  last_discovered_at: 2026-07-22T01:59:30Z
+  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
+  last_discovered_at: 2026-07-22T23:00:39Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e3965169163748bf61f8a169f32f96ffe154a2078ca08dcb4c756d595c6003e3
+  threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
@@ -186,11 +186,11 @@ tts_moss_nonstream_wer:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d170f4686a2047346cb39782c69d1bd551af3cb14ef68fc770882d5e7f8b9af3
-  last_discovered_at: 2026-07-22T01:59:30Z
+  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
+  last_discovered_at: 2026-07-22T23:00:39Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e3965169163748bf61f8a169f32f96ffe154a2078ca08dcb4c756d595c6003e3
+  threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/wer_results.json"
@@ -222,11 +222,11 @@ tts_moss_nonstream_similarity:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d170f4686a2047346cb39782c69d1bd551af3cb14ef68fc770882d5e7f8b9af3
-  last_discovered_at: 2026-07-22T01:59:30Z
+  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
+  last_discovered_at: 2026-07-22T23:00:39Z
   expected_samples: 50
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e3965169163748bf61f8a169f32f96ffe154a2078ca08dcb4c756d595c6003e3
+  threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/similarity_results.json"
@@ -258,11 +258,11 @@ tts_moss_nonstream_utmos:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d170f4686a2047346cb39782c69d1bd551af3cb14ef68fc770882d5e7f8b9af3
-  last_discovered_at: 2026-07-22T01:59:30Z
+  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
+  last_discovered_at: 2026-07-22T23:00:39Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e3965169163748bf61f8a169f32f96ffe154a2078ca08dcb4c756d595c6003e3
+  threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/utmos_results.json"
@@ -294,11 +294,11 @@ tts_moss_nonstream_speed:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d170f4686a2047346cb39782c69d1bd551af3cb14ef68fc770882d5e7f8b9af3
-  last_discovered_at: 2026-07-22T01:59:30Z
+  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
+  last_discovered_at: 2026-07-22T23:00:39Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e3965169163748bf61f8a169f32f96ffe154a2078ca08dcb4c756d595c6003e3
+  threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
   sample_counts:
     total:
       json_file: "test_voice_cloning_non_streami0/vc_nonstream_c16/speed_results.json"
@@ -347,6 +347,138 @@ tts_moss_nonstream_speed:
         scale: 1
         digits: 4
       status: OK
+tts_higgs_nonstream_hc_speed:
+  test: tests/test_model/test_tts_ci.py
+  title: "TTS HIGGS NONSTREAM_HC Speed"
+  group: speed
+  extra_env:
+    TTS_CI_MODEL: "higgs"
+  context_vars: []
+  variant: "nonstream_hc"
+  calibration_preset: "higgs"
+  gpus: 2
+  hf_model_ids:
+    - "bosonai/higgs-tts-3-4b"
+    - "Qwen/Qwen3-ASR-1.7B"
+  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
+  last_discovered_at: 2026-07-22T23:00:39Z
+  expected_samples: 1088
+  threshold_file: "tests/test_model/tts_ci_config.py"
+  threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
+  sample_counts:
+    total:
+      json_file: "test_voice_cloning_high_concur0/vc_nonstream_hc_c96/speed_results.json"
+      json_path: "summary.total_requests"
+    ok:
+      json_file: "test_voice_cloning_high_concur0/vc_nonstream_hc_c96/speed_results.json"
+      json_path: "summary.completed_requests"
+  metrics:
+    throughput_qps:
+      source: "_HIGGS_VC_NON_STREAM_HC_P95['throughput_qps']"
+      json_file: "test_voice_cloning_high_concur0/vc_nonstream_hc_c96/speed_results.json"
+      json_path: "summary.throughput_qps"
+      worst: min
+      display:
+        label: "Throughput (req/s)"
+        scale: 1
+        digits: 3
+      status: OK
+    output_tok_per_req_s:
+      source: "_HIGGS_VC_NON_STREAM_HC_P95['output_tok_per_req_s']"
+      json_file: "test_voice_cloning_high_concur0/vc_nonstream_hc_c96/speed_results.json"
+      json_path: "summary.output_tok_per_req_s"
+      worst: min
+      display:
+        label: "Output tok/req-s"
+        scale: 1
+        digits: 1
+      status: OK
+    latency_mean_s:
+      source: "_HIGGS_VC_NON_STREAM_HC_P95['latency_mean_s']"
+      json_file: "test_voice_cloning_high_concur0/vc_nonstream_hc_c96/speed_results.json"
+      json_path: "summary.latency_mean_s"
+      worst: max
+      display:
+        label: "Latency mean (s)"
+        scale: 1
+        digits: 3
+      status: OK
+    rtf_mean:
+      source: "_HIGGS_VC_NON_STREAM_HC_P95['rtf_mean']"
+      json_file: "test_voice_cloning_high_concur0/vc_nonstream_hc_c96/speed_results.json"
+      json_path: "summary.rtf_mean"
+      worst: max
+      display:
+        label: "RTF mean"
+        scale: 1
+        digits: 4
+      status: OK
+tts_higgs_nonstream_hc_direct_speed:
+  test: tests/test_model/test_tts_ci.py
+  title: "TTS HIGGS NONSTREAM_HC_DIRECT Speed"
+  group: speed
+  extra_env:
+    TTS_CI_MODEL: "higgs"
+  context_vars: []
+  variant: "nonstream_hc_direct"
+  calibration_preset: "higgs"
+  gpus: 2
+  hf_model_ids:
+    - "bosonai/higgs-tts-3-4b"
+    - "Qwen/Qwen3-ASR-1.7B"
+  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
+  last_discovered_at: 2026-07-22T23:00:39Z
+  expected_samples: 1088
+  threshold_file: "tests/test_model/tts_ci_config.py"
+  threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
+  sample_counts:
+    total:
+      json_file: "test_voice_cloning_direct_work0/vc_nonstream_hc_direct_c48/speed_results.json"
+      json_path: "summary.total_requests"
+    ok:
+      json_file: "test_voice_cloning_direct_work0/vc_nonstream_hc_direct_c48/speed_results.json"
+      json_path: "summary.completed_requests"
+  metrics:
+    throughput_qps:
+      source: "_HIGGS_VC_NON_STREAM_HC_DIRECT_P95['throughput_qps']"
+      json_file: "test_voice_cloning_direct_work0/vc_nonstream_hc_direct_c48/speed_results.json"
+      json_path: "summary.throughput_qps"
+      worst: min
+      display:
+        label: "Throughput (req/s)"
+        scale: 1
+        digits: 3
+      status: OK
+    output_tok_per_req_s:
+      source: "_HIGGS_VC_NON_STREAM_HC_DIRECT_P95['output_tok_per_req_s']"
+      json_file: "test_voice_cloning_direct_work0/vc_nonstream_hc_direct_c48/speed_results.json"
+      json_path: "summary.output_tok_per_req_s"
+      worst: min
+      display:
+        label: "Output tok/req-s"
+        scale: 1
+        digits: 1
+      status: OK
+    latency_mean_s:
+      source: "_HIGGS_VC_NON_STREAM_HC_DIRECT_P95['latency_mean_s']"
+      json_file: "test_voice_cloning_direct_work0/vc_nonstream_hc_direct_c48/speed_results.json"
+      json_path: "summary.latency_mean_s"
+      worst: max
+      display:
+        label: "Latency mean (s)"
+        scale: 1
+        digits: 3
+      status: OK
+    rtf_mean:
+      source: "_HIGGS_VC_NON_STREAM_HC_DIRECT_P95['rtf_mean']"
+      json_file: "test_voice_cloning_direct_work0/vc_nonstream_hc_direct_c48/speed_results.json"
+      json_path: "summary.rtf_mean"
+      worst: max
+      display:
+        label: "RTF mean"
+        scale: 1
+        digits: 4
+      status: OK
 tts_higgs_stream_wer:
   test: tests/test_model/test_tts_ci.py
   title: "TTS HIGGS STREAM Wer"
@@ -360,11 +492,11 @@ tts_higgs_stream_wer:
   hf_model_ids:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d170f4686a2047346cb39782c69d1bd551af3cb14ef68fc770882d5e7f8b9af3
-  last_discovered_at: 2026-07-22T01:59:30Z
+  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
+  last_discovered_at: 2026-07-22T23:00:39Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e3965169163748bf61f8a169f32f96ffe154a2078ca08dcb4c756d595c6003e3
+  threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/wer_results.json"
@@ -396,11 +528,11 @@ tts_higgs_stream_speed:
   hf_model_ids:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d170f4686a2047346cb39782c69d1bd551af3cb14ef68fc770882d5e7f8b9af3
-  last_discovered_at: 2026-07-22T01:59:30Z
+  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
+  last_discovered_at: 2026-07-22T23:00:39Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e3965169163748bf61f8a169f32f96ffe154a2078ca08dcb4c756d595c6003e3
+  threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"
@@ -452,11 +584,11 @@ tts_moss_stream_wer:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d170f4686a2047346cb39782c69d1bd551af3cb14ef68fc770882d5e7f8b9af3
-  last_discovered_at: 2026-07-22T01:59:30Z
+  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
+  last_discovered_at: 2026-07-22T23:00:39Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e3965169163748bf61f8a169f32f96ffe154a2078ca08dcb4c756d595c6003e3
+  threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/wer_results.json"
@@ -488,11 +620,11 @@ tts_moss_stream_speed:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: d170f4686a2047346cb39782c69d1bd551af3cb14ef68fc770882d5e7f8b9af3
-  last_discovered_at: 2026-07-22T01:59:30Z
+  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
+  last_discovered_at: 2026-07-22T23:00:39Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
-  threshold_file_sha256: e3965169163748bf61f8a169f32f96ffe154a2078ca08dcb4c756d595c6003e3
+  threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
   sample_counts:
     total:
       json_file: "test_voice_cloning_streaming0/vc_stream_c16/speed_results.json"

--- a/.claude/skills/tune-ci-thresholds/models/tts/stages.yaml
+++ b/.claude/skills/tune-ci-thresholds/models/tts/stages.yaml
@@ -12,8 +12,8 @@ tts_higgs_nonstream_wer:
   hf_model_ids:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
-  last_discovered_at: 2026-07-22T23:00:39Z
+  test_file_sha256: d30699419dbd99c0f0876142c0500ac87178f46f9e842258087fa9b3a4710623
+  last_discovered_at: 2026-07-26T16:29:14Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
   threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
@@ -48,8 +48,8 @@ tts_higgs_nonstream_similarity:
   hf_model_ids:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
-  last_discovered_at: 2026-07-22T23:00:39Z
+  test_file_sha256: d30699419dbd99c0f0876142c0500ac87178f46f9e842258087fa9b3a4710623
+  last_discovered_at: 2026-07-26T16:29:14Z
   expected_samples: 50
   threshold_file: "tests/test_model/tts_ci_config.py"
   threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
@@ -84,8 +84,8 @@ tts_higgs_nonstream_utmos:
   hf_model_ids:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
-  last_discovered_at: 2026-07-22T23:00:39Z
+  test_file_sha256: d30699419dbd99c0f0876142c0500ac87178f46f9e842258087fa9b3a4710623
+  last_discovered_at: 2026-07-26T16:29:14Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
   threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
@@ -120,8 +120,8 @@ tts_higgs_nonstream_speed:
   hf_model_ids:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
-  last_discovered_at: 2026-07-22T23:00:39Z
+  test_file_sha256: d30699419dbd99c0f0876142c0500ac87178f46f9e842258087fa9b3a4710623
+  last_discovered_at: 2026-07-26T16:29:14Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
   threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
@@ -186,8 +186,8 @@ tts_moss_nonstream_wer:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
-  last_discovered_at: 2026-07-22T23:00:39Z
+  test_file_sha256: d30699419dbd99c0f0876142c0500ac87178f46f9e842258087fa9b3a4710623
+  last_discovered_at: 2026-07-26T16:29:14Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
   threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
@@ -222,8 +222,8 @@ tts_moss_nonstream_similarity:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
-  last_discovered_at: 2026-07-22T23:00:39Z
+  test_file_sha256: d30699419dbd99c0f0876142c0500ac87178f46f9e842258087fa9b3a4710623
+  last_discovered_at: 2026-07-26T16:29:14Z
   expected_samples: 50
   threshold_file: "tests/test_model/tts_ci_config.py"
   threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
@@ -258,8 +258,8 @@ tts_moss_nonstream_utmos:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
-  last_discovered_at: 2026-07-22T23:00:39Z
+  test_file_sha256: d30699419dbd99c0f0876142c0500ac87178f46f9e842258087fa9b3a4710623
+  last_discovered_at: 2026-07-26T16:29:14Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
   threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
@@ -294,8 +294,8 @@ tts_moss_nonstream_speed:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
-  last_discovered_at: 2026-07-22T23:00:39Z
+  test_file_sha256: d30699419dbd99c0f0876142c0500ac87178f46f9e842258087fa9b3a4710623
+  last_discovered_at: 2026-07-26T16:29:14Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
   threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
@@ -360,8 +360,8 @@ tts_higgs_nonstream_hc_speed:
   hf_model_ids:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
-  last_discovered_at: 2026-07-22T23:00:39Z
+  test_file_sha256: d30699419dbd99c0f0876142c0500ac87178f46f9e842258087fa9b3a4710623
+  last_discovered_at: 2026-07-26T16:29:14Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
   threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
@@ -426,8 +426,8 @@ tts_higgs_nonstream_hc_direct_speed:
   hf_model_ids:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
-  last_discovered_at: 2026-07-22T23:00:39Z
+  test_file_sha256: d30699419dbd99c0f0876142c0500ac87178f46f9e842258087fa9b3a4710623
+  last_discovered_at: 2026-07-26T16:29:14Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
   threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
@@ -492,8 +492,8 @@ tts_higgs_stream_wer:
   hf_model_ids:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
-  last_discovered_at: 2026-07-22T23:00:39Z
+  test_file_sha256: d30699419dbd99c0f0876142c0500ac87178f46f9e842258087fa9b3a4710623
+  last_discovered_at: 2026-07-26T16:29:14Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
   threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
@@ -528,8 +528,8 @@ tts_higgs_stream_speed:
   hf_model_ids:
     - "bosonai/higgs-tts-3-4b"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
-  last_discovered_at: 2026-07-22T23:00:39Z
+  test_file_sha256: d30699419dbd99c0f0876142c0500ac87178f46f9e842258087fa9b3a4710623
+  last_discovered_at: 2026-07-26T16:29:14Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
   threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
@@ -584,8 +584,8 @@ tts_moss_stream_wer:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
-  last_discovered_at: 2026-07-22T23:00:39Z
+  test_file_sha256: d30699419dbd99c0f0876142c0500ac87178f46f9e842258087fa9b3a4710623
+  last_discovered_at: 2026-07-26T16:29:14Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
   threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827
@@ -620,8 +620,8 @@ tts_moss_stream_speed:
   hf_model_ids:
     - "OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5"
     - "Qwen/Qwen3-ASR-1.7B"
-  test_file_sha256: dafd14061895fb09dd95939f950d19bf612e1c9cada2fb7f92e75d4c8507ce4f
-  last_discovered_at: 2026-07-22T23:00:39Z
+  test_file_sha256: d30699419dbd99c0f0876142c0500ac87178f46f9e842258087fa9b3a4710623
+  last_discovered_at: 2026-07-26T16:29:14Z
   expected_samples: 1088
   threshold_file: "tests/test_model/tts_ci_config.py"
   threshold_file_sha256: 21882c65e65d7d790f85cbc7aea7bfff03b5484bafab1a366b125057d95c7827

--- a/tests/test_model/test_tts_ci.py
+++ b/tests/test_model/test_tts_ci.py
@@ -106,6 +106,10 @@ TTS_WORKER_EXTRA_ARGS = (
 SEEDTTS_EN_FULLSET_SAMPLES = 1088
 STREAMING_BENCHMARK_MAX_SAMPLES: int | None = None
 TTS_SIMILARITY_MAX_SAMPLES = 50
+# Note: (Jiaxin Deng) 96 client-side saturates both DP2 workers (48 each) so
+# capacity changes gate here; the c16 stage is latency-bound and cannot see them.
+TTS_HIGH_CONCURRENCY = 96
+TTS_HIGH_CONCURRENCY_MIN_WORKER_SHARE = 0.4
 
 # Note (chenyang): the RTF thresholds also includes the reference audio
 # processing time.
@@ -156,6 +160,7 @@ def _run_benchmark(
     concurrency: int,
     max_samples: int | None = None,
     stream: bool = False,
+    timeout_s: float | None = None,
 ) -> dict:
     benchmark_config = TtsSeedttsBenchmarkConfig(
         model=TTS_MODEL_PATH,
@@ -168,7 +173,10 @@ def _run_benchmark(
         ref_format=_PRESET.ref_format,
         token_count=_PRESET.token_count,
     )
-    speed_results = asyncio.run(run_tts_seedtts_benchmark(benchmark_config))
+    benchmark_coro = run_tts_seedtts_benchmark(benchmark_config)
+    if timeout_s is not None:
+        benchmark_coro = asyncio.wait_for(benchmark_coro, timeout_s)
+    speed_results = asyncio.run(benchmark_coro)
     _validate_speed_results_keys(speed_results)
     _print_saved_tts_speed_summary(
         output_dir,
@@ -524,6 +532,7 @@ def _assert_stage_used_all_router_workers(
     results: dict,
     label: str,
     collector: MetricCheckCollector | None = None,
+    min_worker_share: float | None = None,
 ) -> None:
     kwargs = {
         "port": router_server.port,
@@ -531,6 +540,8 @@ def _assert_stage_used_all_router_workers(
         "label": label,
         "min_total_requests": results["summary"]["completed_requests"],
     }
+    if min_worker_share is not None:
+        kwargs["min_worker_share"] = min_worker_share
     if collector is None:
         assert_workers_served_requests_since(**kwargs)
     else:
@@ -806,6 +817,78 @@ def test_voice_cloning_non_streaming(
             collector=checks,
         )
         checks.assert_all()
+
+
+@pytest.mark.tts_stage(TTS_STAGE_NONSTREAM)
+@pytest.mark.benchmark
+def test_voice_cloning_high_concurrency(
+    router_server: ManagedRouterHandle,
+    dataset_repo: str,
+    tmp_path: Path,
+) -> None:
+    hc_thresholds = _THRESHOLDS.non_stream_hc_speed
+    if hc_thresholds is None:
+        pytest.skip(
+            f"preset {_MODEL_NAME} has no high-concurrency speed thresholds"
+        )
+    _print_stage(
+        "TTS speed",
+        "non-streaming",
+        TTS_HIGH_CONCURRENCY,
+        "saturated-throughput probe",
+    )
+    output_dir = _resolve_stage_output_dir(
+        tmp_path, f"vc_nonstream_hc_c{TTS_HIGH_CONCURRENCY}"
+    )
+    label = f"TTS non-stream hc c{TTS_HIGH_CONCURRENCY}"
+    before_workers = router_get_json(router_server.port, "/workers")
+    checks = MetricCheckCollector(
+        f"TTS high-concurrency benchmark c{TTS_HIGH_CONCURRENCY}"
+    )
+    try:
+        results = _run_benchmark(
+            router_server.port,
+            dataset_repo,
+            output_dir,
+            concurrency=TTS_HIGH_CONCURRENCY,
+            timeout_s=BENCHMARK_TIMEOUT,
+        )
+        SPEED_OUTPUT_DIRS["non_stream"][TTS_HIGH_CONCURRENCY] = output_dir
+        _assert_full_seedtts_en_speed_results(
+            results,
+            label=label,
+            collector=checks,
+        )
+        _assert_stage_used_all_router_workers(
+            router_server=router_server,
+            before_workers=before_workers,
+            results=results,
+            label=label,
+            collector=checks,
+            min_worker_share=TTS_HIGH_CONCURRENCY_MIN_WORKER_SHARE,
+        )
+    except Exception:
+        print_router_diagnostics(router_server)
+        raise
+    summary, per_request = results["summary"], results["per_request"]
+    _assert_tts_audio_result_integrity(
+        summary,
+        per_request,
+        label=label,
+        collector=checks,
+    )
+    checks.check(
+        summary.get("failed_requests") == 0,
+        f"{label}: failed_requests={summary.get('failed_requests')}, expected 0",
+    )
+    if _PRESET.gate_thresholds:
+        assert_speed_thresholds(
+            summary,
+            hc_thresholds,
+            TTS_HIGH_CONCURRENCY,
+            collector=checks,
+        )
+    checks.assert_all()
 
 
 @pytest.mark.tts_stage(TTS_STAGE_STREAM)

--- a/tests/test_model/test_tts_ci.py
+++ b/tests/test_model/test_tts_ci.py
@@ -831,9 +831,7 @@ def test_voice_cloning_high_concurrency(
 ) -> None:
     hc_thresholds = _THRESHOLDS.non_stream_hc_speed
     if hc_thresholds is None:
-        pytest.skip(
-            f"preset {_MODEL_NAME} has no high-concurrency speed thresholds"
-        )
+        pytest.skip(f"preset {_MODEL_NAME} has no high-concurrency speed thresholds")
     _print_stage(
         "TTS speed",
         "non-streaming",
@@ -903,9 +901,7 @@ def test_voice_cloning_direct_worker_capacity(
 ) -> None:
     direct_thresholds = _THRESHOLDS.non_stream_hc_direct_speed
     if direct_thresholds is None:
-        pytest.skip(
-            f"preset {_MODEL_NAME} has no direct-worker capacity thresholds"
-        )
+        pytest.skip(f"preset {_MODEL_NAME} has no direct-worker capacity thresholds")
     _print_stage(
         "TTS speed",
         "non-streaming",

--- a/tests/test_model/test_tts_ci.py
+++ b/tests/test_model/test_tts_ci.py
@@ -110,6 +110,9 @@ TTS_SIMILARITY_MAX_SAMPLES = 50
 # capacity changes gate here; the c16 stage is latency-bound and cannot see them.
 TTS_HIGH_CONCURRENCY = 96
 TTS_HIGH_CONCURRENCY_MIN_WORKER_SHARE = 0.4
+# Note: (Jiaxin Deng) the direct-to-worker leg bypasses the router relay, which
+# saturates before the workers do; model-path capacity only gates here.
+TTS_DIRECT_WORKER_CONCURRENCY = 48
 
 # Note (chenyang): the RTF thresholds also includes the reference audio
 # processing time.
@@ -886,6 +889,69 @@ def test_voice_cloning_high_concurrency(
             summary,
             hc_thresholds,
             TTS_HIGH_CONCURRENCY,
+            collector=checks,
+        )
+    checks.assert_all()
+
+
+@pytest.mark.tts_stage(TTS_STAGE_NONSTREAM)
+@pytest.mark.benchmark
+def test_voice_cloning_direct_worker_capacity(
+    router_server: ManagedRouterHandle,
+    dataset_repo: str,
+    tmp_path: Path,
+) -> None:
+    direct_thresholds = _THRESHOLDS.non_stream_hc_direct_speed
+    if direct_thresholds is None:
+        pytest.skip(
+            f"preset {_MODEL_NAME} has no direct-worker capacity thresholds"
+        )
+    _print_stage(
+        "TTS speed",
+        "non-streaming",
+        TTS_DIRECT_WORKER_CONCURRENCY,
+        "direct-to-worker capacity probe (router bypassed)",
+    )
+    output_dir = _resolve_stage_output_dir(
+        tmp_path, f"vc_nonstream_hc_direct_c{TTS_DIRECT_WORKER_CONCURRENCY}"
+    )
+    label = f"TTS non-stream direct c{TTS_DIRECT_WORKER_CONCURRENCY}"
+    checks = MetricCheckCollector(
+        f"TTS direct-worker benchmark c{TTS_DIRECT_WORKER_CONCURRENCY}"
+    )
+    try:
+        results = _run_benchmark(
+            router_server.worker_ports[0],
+            dataset_repo,
+            output_dir,
+            concurrency=TTS_DIRECT_WORKER_CONCURRENCY,
+            timeout_s=BENCHMARK_TIMEOUT,
+        )
+        SPEED_OUTPUT_DIRS["non_stream"][TTS_DIRECT_WORKER_CONCURRENCY] = output_dir
+        _assert_full_seedtts_en_speed_results(
+            results,
+            label=label,
+            collector=checks,
+        )
+    except Exception:
+        print_router_diagnostics(router_server)
+        raise
+    summary, per_request = results["summary"], results["per_request"]
+    _assert_tts_audio_result_integrity(
+        summary,
+        per_request,
+        label=label,
+        collector=checks,
+    )
+    checks.check(
+        summary.get("failed_requests") == 0,
+        f"{label}: failed_requests={summary.get('failed_requests')}, expected 0",
+    )
+    if _PRESET.gate_thresholds:
+        assert_speed_thresholds(
+            summary,
+            direct_thresholds,
+            TTS_DIRECT_WORKER_CONCURRENCY,
             collector=checks,
         )
     checks.assert_all()

--- a/tests/test_model/tts_ci_config.py
+++ b/tests/test_model/tts_ci_config.py
@@ -29,6 +29,7 @@ class TtsCiThresholdPreset:
     stream_wer_corpus: float
     similarity_mean_min: float
     utmos_mean_min: float
+    non_stream_hc_speed: dict[int, dict[str, float]] | None = None
 
 
 @dataclass(frozen=True)
@@ -70,11 +71,23 @@ _HIGGS_VC_STREAM_P95 = {
     }
 }
 
+_HIGGS_VC_NON_STREAM_HC_P95 = {
+    96: {
+        "throughput_qps": 40.0,
+        "output_tok_per_req_s": 100.0,
+        "latency_mean_s": 3.5,
+        "rtf_mean": 0.6,
+    }
+}
+
 HIGGS_VC_NON_STREAM_THRESHOLDS = apply_slack(
     _HIGGS_VC_NON_STREAM_P95, THRESHOLD_SLACK_HIGHER, THRESHOLD_SLACK_LOWER
 )
 HIGGS_VC_STREAM_THRESHOLDS = apply_slack(
     _HIGGS_VC_STREAM_P95, THRESHOLD_SLACK_HIGHER, THRESHOLD_SLACK_LOWER
+)
+HIGGS_VC_NON_STREAM_HC_THRESHOLDS = apply_slack(
+    _HIGGS_VC_NON_STREAM_HC_P95, THRESHOLD_SLACK_HIGHER, THRESHOLD_SLACK_LOWER
 )
 
 
@@ -124,6 +137,7 @@ TTS_CI_PRESETS: dict[str, TtsCiPreset] = {
             stream_wer_corpus=HIGGS_VC_STREAM_WER_CORPUS_THRESHOLD,
             similarity_mean_min=HIGGS_VC_SIMILARITY_MEAN_MIN,
             utmos_mean_min=HIGGS_VC_UTMOS_MEAN_MIN,
+            non_stream_hc_speed=HIGGS_VC_NON_STREAM_HC_THRESHOLDS,
         ),
     ),
     "moss": TtsCiPreset(

--- a/tests/test_model/tts_ci_config.py
+++ b/tests/test_model/tts_ci_config.py
@@ -30,6 +30,7 @@ class TtsCiThresholdPreset:
     similarity_mean_min: float
     utmos_mean_min: float
     non_stream_hc_speed: dict[int, dict[str, float]] | None = None
+    non_stream_hc_direct_speed: dict[int, dict[str, float]] | None = None
 
 
 @dataclass(frozen=True)
@@ -73,10 +74,19 @@ _HIGGS_VC_STREAM_P95 = {
 
 _HIGGS_VC_NON_STREAM_HC_P95 = {
     96: {
-        "throughput_qps": 40.0,
-        "output_tok_per_req_s": 100.0,
-        "latency_mean_s": 3.5,
-        "rtf_mean": 0.6,
+        "throughput_qps": 34.091,
+        "output_tok_per_req_s": 72.0,
+        "latency_mean_s": 2.582,
+        "rtf_mean": 0.6423,
+    }
+}
+
+_HIGGS_VC_NON_STREAM_HC_DIRECT_P95 = {
+    48: {
+        "throughput_qps": 14.908,
+        "output_tok_per_req_s": 51.3,
+        "latency_mean_s": 2.908,
+        "rtf_mean": 0.71,
     }
 }
 
@@ -88,6 +98,9 @@ HIGGS_VC_STREAM_THRESHOLDS = apply_slack(
 )
 HIGGS_VC_NON_STREAM_HC_THRESHOLDS = apply_slack(
     _HIGGS_VC_NON_STREAM_HC_P95, THRESHOLD_SLACK_HIGHER, THRESHOLD_SLACK_LOWER
+)
+HIGGS_VC_NON_STREAM_HC_DIRECT_THRESHOLDS = apply_slack(
+    _HIGGS_VC_NON_STREAM_HC_DIRECT_P95, THRESHOLD_SLACK_HIGHER, THRESHOLD_SLACK_LOWER
 )
 
 
@@ -138,6 +151,7 @@ TTS_CI_PRESETS: dict[str, TtsCiPreset] = {
             similarity_mean_min=HIGGS_VC_SIMILARITY_MEAN_MIN,
             utmos_mean_min=HIGGS_VC_UTMOS_MEAN_MIN,
             non_stream_hc_speed=HIGGS_VC_NON_STREAM_HC_THRESHOLDS,
+            non_stream_hc_direct_speed=HIGGS_VC_NON_STREAM_HC_DIRECT_THRESHOLDS,
         ),
     ),
     "moss": TtsCiPreset(


### PR DESCRIPTION
## What

Adds two speed-only capacity probes to the Higgs TTS CI stage 1, closing the coverage gap where the c16 gate (throughput = 16 / latency, latency-bound) cannot see capacity changes at all:

* `test_voice_cloning_high_concurrency`: full 1088-sample nonstream run at client concurrency 96 through the router (48 per DP2 worker). Gates end-to-end system capacity.
* `test_voice_cloning_direct_worker_capacity`: same scope at concurrency 48 against worker 0 directly (under the default `max_running_requests` 64). Gates model-path capacity independent of the router, so a tripped gate is immediately attributable.

Both reuse the live stage-1 router (no extra server launch), assert full sample scope, zero failed requests, worker balance (routed leg, min share 0.4), and speed thresholds with the standard 0.75/1.25 slack. Preset-optional thresholds: Higgs is calibrated and gated; MOSS skips with an explicit reason until calibrated. Also gives `_run_benchmark` a real whole-benchmark timeout (`BENCHMARK_TIMEOUT` existed but was never applied) and a `min_worker_share` passthrough for the router balance check. Calibration tooling: two new variants in `models/tts/config.yaml` with disjoint constant filters; `stages.yaml` regenerated by `discover`.

## Calibration (measured)

Strict worst-of-5, `tune-ci-thresholds`, dedicated H100 pair, all 8 stages 5/5 strict with full sample scope and matching provenance.

| Leg | 5-run throughput (qps) | Worst-of-5 refs written |
|---|---|---|
| routed c96 | 34.09 / 41.16 / 41.40 / 35.63 / 37.74 | qps 34.091, tok 72.0, lat 2.582, rtf 0.6423 |
| direct c48 | 26.03 / 26.52 / 14.91 / 24.99 / 24.92 | qps 14.908, tok 51.3, lat 2.908, rtf 0.71 |

The direct-leg run 3 (14.91) is a shared-host contention window (the same run also hit the known streaming-flake mode and ran 35 percent slower end to end). It is retained per worst-of-N policy because CI runs on the same shared host and will see such windows; the resulting floor (gate 11.18 qps) is intentionally loose and only trips on severe model-path regressions. The other four runs sit within 6 percent of each other.

## Findings the probes surfaced (measured, pre/post #1071 pairs)

* At the shipped default serving config, #1071 is capacity-neutral at this scale: routed 32.6 pre vs 30.9 post; direct 23.5 pre vs 22.5 post (paired interleaved runs, differences within noise). Its published gains (48.5 to 99.3 qps) require the benchmark stack it was measured with (prefill coalescing enabled, cap=conc=96); coalescing is default-off. The probes gate the shipped defaults, which is what CI should do.
* The router relay costs roughly 30 percent of per-worker capacity at saturation (direct 22.5 to 26.5 qps per worker vs routed 15.4 to 20.7 per worker), consistent with the byte-proportional relay bottleneck analysis in the router work.

## Verification (measured)

* Post-apply validation observation on the calibrated constants: full higgs run, all 8 stages, pytest passed.
* Post-apply `apply-plan` reports `direction=equal` for all 8 HC metrics.
* Both discriminator pairs and the calibration ran the full 1088-sample scope per leg.

## Notes

* Rebased onto current main (includes #1133). If #1137 (similarity floor revert) merges first, only `stages.yaml` needs a mechanical `discover` refresh; this PR does not touch quality constants.
* CI stage 1 wall time grows by about 60 to 90 seconds (two extra generation passes, no extra WER/similarity/UTMOS).
* MOSS legs and a coalescing-enabled probe variant are natural follow-ups.
