### PR TITLE
fix(playground): restrict filesystem browser root to prevent path traversal

### DIFF
--- a/playground/qwen-omni/app.py
+++ b/playground/qwen-omni/app.py
@@ -27,11 +27,25 @@ _MEDIA_SUFFIXES = {
 
 
 def _fs_root() -> Path:
-    """Filesystem root — always container root ``/``."""
-    return Path("/")
+    """Filesystem root for the playground file browser.
+
+    Configured via the SGLANG_OMNI_FS_ROOT environment variable and
+    defaults to /data. The value / is rejected: using the filesystem
+    root would make the containment check in :func:`_fs_resolve` vacuous
+    and expose the entire container filesystem via /v1/fs/* (CWE-22).
+    """
+    configured = os.environ.get("SGLANG_OMNI_FS_ROOT", "/data").strip() or "/data"
+    root = Path(configured).resolve()
+    if root == Path("/"):
+        raise RuntimeError(
+            "SGLANG_OMNI_FS_ROOT must not be '/'. Set it to a specific "
+            "directory (e.g. /data) to restrict the playground file browser."
+        )
+    return root
 
 
 def _fs_resolve(root: Path, raw_path: str | None) -> Path:
+    root = root.resolve()
     if raw_path is None or raw_path.strip() == "":
         candidate = root
     else:
@@ -166,7 +180,7 @@ _register_filesystem(app)
 _register_home(app)
 assert FRONTEND_DIR.is_dir(), "Frontend directory does not exist"
 app.mount("/", StaticFiles(directory=str(FRONTEND_DIR), html=True))
-logger.info("Serving playground UI from %s", FRONTEND_DIR)
+logger.info(f"Serving playground UI from {FRONTEND_DIR}")
 
 args = parse_args()
 uvicorn.run(app, host="0.0.0.0", port=args.port)


### PR DESCRIPTION
## Motivation

The Qwen-Omni playground app (`playground/qwen-omni/app.py`) exposes `/v1/fs/list` and `/v1/fs/file` endpoints intended to let the UI browse a demo dataset directory. However, `_fs_root()` currently hard-codes the root to `Path("/")`, which makes the containment check in `_fs_resolve()` (`resolved.relative_to(root)`) vacuously succeed for *any* absolute path on the container filesystem.

Combined with the fact that the playground is served by uvicorn bound to `0.0.0.0` and neither endpoint requires authentication, an unauthenticated network attacker who can reach the playground port can read arbitrary readable files inside the container — e.g. `/etc/passwd`, mounted secrets, SSH keys, `/proc/self/environ`, model weight paths, etc. This is a straightforward CWE-22 (Path Traversal) / arbitrary file read.

## Modifications

`playground/qwen-omni/app.py`:

- `_fs_root()` now reads `SGLANG_OMNI_FS_ROOT` (default `/data`), resolves it, and **rejects `/`** with a clear `RuntimeError` at startup — using the filesystem root would make the containment check meaningless.
- `_fs_resolve()` now calls `root.resolve()` before comparing, so symlinks or relative components in the configured root cannot be used to bypass the check.

The endpoints themselves are unchanged; the fix is entirely in the two helpers that define and enforce the browser sandbox. Diff is ~15 lines.

## Related Issues

None filed — reporting via PR per the project's public workflow.

## Security analysis

**Vulnerability:** CWE-22, arbitrary file read on the playground service.

**Data flow:** `raw_path` query parameter → `_fs_resolve(root=Path("/"), raw_path)` → `candidate = Path(raw_path)` (absolute paths are accepted as-is by `Path`) → `resolved = candidate.resolve()` → `resolved.relative_to(root)` where `root == Path("/")`, which succeeds for every absolute path → `FileResponse(resolved)` in `/v1/fs/file`, or directory listing in `/v1/fs/list`.

**Preconditions:**
- Network reachability to the playground port (uvicorn default bind is `0.0.0.0`).
- No authentication — the router has no `Depends(...)` gate and there is no app-level middleware on this app.

**Mitigations added:** After the fix, `root` defaults to `/data`, and `resolved.relative_to(root)` raises `ValueError` for paths outside that tree, which the endpoints already translate to HTTP errors. The `/` value is refused up-front so a misconfigured deployment cannot silently re-introduce the bug.

## Proof of concept

Against a stock playground instance (`python playground/qwen-omni/app.py` or the documented launch command), on the pre-fix `main`:

```bash
# Arbitrary file read — should not be reachable from a "file browser"
curl -s 'http://127.0.0.1:8000/v1/fs/file?path=/etc/passwd' | head
curl -s 'http://127.0.0.1:8000/v1/fs/file?path=/proc/self/environ'
curl -s 'http://127.0.0.1:8000/v1/fs/list?path=/root/.ssh'
```

Pre-fix these return file contents / directory listings. Post-fix, with the default `SGLANG_OMNI_FS_ROOT=/data`, they return an error because `/etc/passwd` is not under `/data`. Requests for paths inside `/data` continue to work as before.

Route existence check:

```
$ grep -n '/v1/fs/' playground/qwen-omni/app.py
89:    @app.get("/v1/fs/list")
142:    @app.get("/v1/fs/file")
```

## Testing

- Manually verified with `curl` that pre-fix, `/v1/fs/file?path=/etc/passwd` returns the file, and post-fix it is rejected.
- Verified that legitimate reads under the configured root (e.g. `/data/...`) still succeed.
- Verified `_fs_root()` raises at import/startup if `SGLANG_OMNI_FS_ROOT=/`, so misconfiguration fails loudly instead of silently reintroducing the traversal.

## Adversarial review

Before submitting we tried to disprove this: we checked whether the router mounts any auth dependency on the playground app, whether uvicorn is bound to loopback, and whether the endpoints do any second-layer containment we missed. None of those hold — the app builds a bare `FastAPI()` with no `dependencies=`, the documented launch binds `0.0.0.0`, and `_fs_resolve` is the only containment layer. The playground is a shipped, documented component of this serving runtime rather than a throwaway example, so the "just a demo" argument doesn't apply. We also confirmed the preconditions (network reach to the port) do not by themselves already give an attacker file read on the host, so this is not redundant with a pre-existing capability.

## Checklist

- [x] Format preserved (small, localized change).
- [x] Manual reproduction and fix verification performed.
- [x] Docstring on `_fs_root` updated to describe the new configuration knob and the rationale for rejecting `/`.
- [ ] No new unit tests added — the change is a one-file defensive hardening; happy to add tests if maintainers prefer.