### PR TITLE
fix(playground): restrict filesystem browser root to prevent path traversal

### DIFF
--- a/playground/qwen-omni/app.py
+++ b/playground/qwen-omni/app.py
@@ -27,11 +27,25 @@ _MEDIA_SUFFIXES = {
 
 
 def _fs_root() -> Path:
-    """Filesystem root — always container root ``/``."""
-    return Path("/")
+    """Filesystem root for the playground file browser.
+
+    Configured via the SGLANG_OMNI_FS_ROOT environment variable and
+    defaults to /data. The value / is rejected: using the filesystem
+    root would make the containment check in :func:`_fs_resolve` vacuous
+    and expose the entire container filesystem via /v1/fs/* (CWE-22).
+    """
+    configured = os.environ.get("SGLANG_OMNI_FS_ROOT", "/data").strip() or "/data"
+    root = Path(configured).resolve()
+    if root == Path("/"):
+        raise RuntimeError(
+            "SGLANG_OMNI_FS_ROOT must not be '/'. Set it to a specific "
+            "directory (e.g. /data) to restrict the playground file browser."
+        )
+    return root
 
 
 def _fs_resolve(root: Path, raw_path: str | None) -> Path:
+    root = root.resolve()
     if raw_path is None or raw_path.strip() == "":
         candidate = root
     else:


### PR DESCRIPTION
## Motivation

`playground/qwen-omni/app.py` exposes a filesystem browser under `/v1/fs/list` and `/v1/fs/file`. The intended containment check restricts responses to files under a configured "root" directory, but `_fs_root()` unconditionally returns `Path("/")`:

```python
def _fs_root() -> Path:
    """Filesystem root — always container root ``/``."""
    return Path("/")
```

`_fs_resolve()` then calls `resolved.relative_to(root)` — but every absolute path is trivially "relative to" `/`, so the guard is a no-op. The endpoint has no authentication, and the app is launched with `uvicorn.run(app, host="0.0.0.0", port=args.port)`, so any client that can reach the playground port can read arbitrary files readable by the server process (CWE-22: Improper Limitation of a Pathname to a Restricted Directory).

## Modifications

`playground/qwen-omni/app.py` only (16 additions, 2 deletions):

- `_fs_root()` now reads `SGLANG_OMNI_FS_ROOT` from the environment, defaulting to `/data`, and resolves it to an absolute canonical path. It explicitly rejects `/` at startup with a clear `RuntimeError`, so an operator cannot accidentally re-introduce the vacuous check via environment configuration.
- `_fs_resolve()` calls `root.resolve()` before its containment check so symlink games at the configured root cannot bypass the `relative_to()` comparison downstream.

No other files are modified; the diff is intentionally minimal.

## Related Issues

None filed — reporting directly as a fix per the disclosure guidance for open-source projects.

## Security Analysis

**Affected file / functions:** `playground/qwen-omni/app.py` — `_fs_root()`, `_fs_resolve()`, and the two routes registered in `_register_filesystem()` (`GET /v1/fs/list`, `GET /v1/fs/file`).

**Data flow (pre-fix):**
1. Client sends `GET /v1/fs/file?path=/etc/passwd`.
2. Handler calls `root = _fs_root()` → `Path("/")`.
3. `_fs_resolve(root, "/etc/passwd")` builds an absolute `Path("/etc/passwd").resolve()`, then checks `resolved.relative_to(root)`. Because `root == Path("/")`, this succeeds for every absolute path.
4. Handler returns the file contents.

**Impact:** Unauthenticated read of any file the server process can access — e.g. `/etc/passwd`, container secrets mounted into the pod, model weights, `.env` files, `~/.ssh/*`, `/proc/self/environ` (which typically contains tokens and HF credentials passed to the runtime).

**Preconditions:** Network reachability to the playground port. Uvicorn binds `0.0.0.0`, so any environment where the port is exposed (developer workstation on a shared network, container in a cluster without a NetworkPolicy, cloud VM with a permissive security group) is exploitable. No credentials required.

**Fix rationale:** Reducing the root to `/data` (or an operator-chosen subtree) makes the existing `relative_to()` check meaningful again. Rejecting `/` at startup is a fail-loud guard against the same class of misconfiguration recurring via env var. Resolving `root` before the containment check prevents symlink-based escapes when the configured root itself contains links.

## Proof of Concept

Reproduce against a stock checkout of `main` (pre-fix):

```bash
# terminal 1: start the playground on any free port
python playground/qwen-omni/app.py --port 8765

# terminal 2: read an arbitrary file over the network
curl -s 'http://127.0.0.1:8765/v1/fs/file?path=/etc/passwd' | head
curl -s 'http://127.0.0.1:8765/v1/fs/file?path=/proc/self/environ' | tr '\0' '\n' | head
# directory listing also works:
curl -s 'http://127.0.0.1:8765/v1/fs/list?path=/root/.ssh'
```

After this patch, the same requests return a 4xx (path is outside `/data`) unless the operator explicitly opts in by setting `SGLANG_OMNI_FS_ROOT` to a directory that contains those files — and even then, only paths under that directory resolve.

## Accuracy Test

Not applicable — no model, kernel, or scheduling code is touched.

## Benchmark & Profiling

Not applicable — no hot-path changes.

## Testing

- Manual reproduction as above against `origin/main` confirmed unauthenticated read of `/etc/passwd`.
- After the patch, `_fs_root()` returns `PosixPath('/data')` by default; requests to `/v1/fs/file?path=/etc/passwd` are rejected by the existing `relative_to()` check in `_fs_resolve()`.
- Setting `SGLANG_OMNI_FS_ROOT=/` at startup now raises `RuntimeError` immediately, preventing accidental re-introduction of the bug.
- No existing tests reference `_fs_root`/`_fs_resolve`, so no test churn is introduced by this change.

## Adversarial review

Before submitting, I tried to disprove this: I checked whether the playground router mounts under any auth-gated `APIRouter` or middleware (it does not — `_register_filesystem(app)` attaches routes directly to the top-level `FastAPI` app with no `Depends(...)`), whether the app is intended as a demo that only listens on loopback (it binds `0.0.0.0` via `uvicorn.run`), and whether the containment check catches this via some other path (it does not — `relative_to(Path("/"))` succeeds for every absolute path). The preconditions (network access to the playground port) do not on their own grant filesystem read, so this is a genuine privilege escalation rather than a redundant finding.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests. — no dedicated test module exists for the playground FS endpoints; happy to add one on request.
- [x] Update documentation / docstrings / example tutorials as needed. — new docstring on `_fs_root()` documents the env var and the `/` rejection.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed. — not applicable.
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the `run-ci` label. This change does not touch any GPU or model code paths.