### PR TITLE
[Benchmark] Validate Qwen3-ASR 1.7B on RTX 4090

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -187,6 +187,7 @@ python -m benchmarks.eval.benchmark_omni_seedtts \
 | `eval/benchmark_omni_videomme.py` | Video-MME (video understanding) | Qwen3-Omni | `/v1/chat/completions` |
 | `eval/benchmark_omni_videoamme.py` | Video-AMME (video + audio question understanding) | Qwen3-Omni | `/v1/chat/completions` |
 | `eval/benchmark_asr_seedtts.py` | ASR concurrency scaling on SeedTTS EN/ZH | Qwen3-ASR, Fun-ASR | `/v1/audio/transcriptions` |
+| `eval/benchmark_asr_stability.py` | ASR functional paths and sustained mixed-load soak | Qwen3-ASR | `/v1/audio/transcriptions` |
 
 See [tts_serving/README.md](tts_serving/README.md) for the TTS serving
 benchmark design, harness contract, scenario matrix, and Docker usage.
@@ -211,6 +212,11 @@ transcribes the SeedTTS *reference* clips directly against a running Qwen3-ASR
 or Fun-ASR router and reports WER + speed + per-worker routing balance per
 concurrency level. Use it to measure how ASR concurrency affects throughput,
 latency, and WER for a given workload.
+
+`benchmark_asr_stability.py` validates basic EN/ZH requests, SSE consistency,
+stream cancellation/reconnect, empty/corrupt inputs, audio immediately below
+and above the former 30-second preprocessing boundary, memory retention, and a
+configurable mixed-concurrency soak. Its default duration is 30 minutes.
 
 Both `*_seedtts.py` scripts also support speech quality and similarity evaluation via UTMOS and WavLM speaker verification metrics. Running with `--utmos-only` or `--similarity-only` loads the respective pre-trained predictor and computes scores on the previously generated audio in the output directory without requiring the TTS/ASR servers to be running.
 

--- a/benchmarks/dataset/prepare.py
+++ b/benchmarks/dataset/prepare.py
@@ -23,8 +23,11 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+SEEDTTS_DATASET_ID = "zhaochenyang20/seed-tts-eval-arrow"
+SEEDTTS_DATASET_REVISION = "27f4c1adee83b5b29b7c4b375f6b976324bda308"
+
 DATASETS: dict[str, str] = {
-    "seedtts": "zhaochenyang20/seed-tts-eval-arrow",
+    "seedtts": SEEDTTS_DATASET_ID,
     "seedtts-mini": "zhaochenyang20/seed-tts-eval-mini-arrow",
     "seedtts-50": "zhaochenyang20/seed-tts-eval-50-arrow",
     "mmmu": "MMMU/MMMU",
@@ -40,22 +43,46 @@ DATASETS: dict[str, str] = {
     "videoamme-ci-50": "zhaochenyang20/Video_AMME_ci",
 }
 
+DATASET_REVISIONS: dict[str, str] = {
+    "seedtts": SEEDTTS_DATASET_REVISION,
+}
 
-def download_dataset(repo_id: str, *, quiet: bool = False) -> None:
+
+def download_dataset(
+    repo_id: str,
+    *,
+    revision: str | None = None,
+    quiet: bool = False,
+) -> None:
     """Pre-warm the HuggingFace ``datasets`` cache for *repo_id*."""
     from datasets import get_dataset_config_names, load_dataset
     from huggingface_hub import hf_hub_download
 
+    revision_kwargs = {"revision": revision} if revision else {}
     if not quiet:
-        logger.info(f"Pre-warming HuggingFace cache for {repo_id} ...")
+        logger.info(
+            "Pre-warming HuggingFace cache for %s revision=%s ...",
+            repo_id,
+            revision or "default",
+        )
 
     if repo_id == "MMMU/MMMU":
-        config_names = get_dataset_config_names(repo_id)
+        config_names = get_dataset_config_names(repo_id, **revision_kwargs)
         for config_name in config_names:
-            load_dataset(repo_id, config_name, split="validation")
+            load_dataset(
+                repo_id,
+                config_name,
+                split="validation",
+                **revision_kwargs,
+            )
     elif repo_id == "BoJack/MMAR":
-        load_dataset(repo_id)
-        hf_hub_download(repo_id, "mmar-audio.tar.gz", repo_type="dataset")
+        load_dataset(repo_id, **revision_kwargs)
+        hf_hub_download(
+            repo_id,
+            "mmar-audio.tar.gz",
+            repo_type="dataset",
+            **revision_kwargs,
+        )
     elif repo_id.startswith("lmms-lab/mmau:"):
         dataset_id, split = repo_id.split(":", 1)
         load_dataset(
@@ -63,9 +90,10 @@ def download_dataset(repo_id: str, *, quiet: bool = False) -> None:
             split=split,
             data_files={split: f"data/{split}-*.parquet"},
             verification_mode="no_checks",
+            **revision_kwargs,
         )
     else:
-        load_dataset(repo_id)
+        load_dataset(repo_id, **revision_kwargs)
 
     if not quiet:
         logger.info(f"Dataset {repo_id} cached.")
@@ -79,10 +107,16 @@ def main() -> None:
         default="seedtts",
         help="Dataset to download.",
     )
+    parser.add_argument(
+        "--revision",
+        default=None,
+        help="Dataset revision; known evaluation datasets use a pinned default.",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)
-    download_dataset(DATASETS[args.dataset])
+    revision = args.revision or DATASET_REVISIONS.get(args.dataset)
+    download_dataset(DATASETS[args.dataset], revision=revision)
 
 
 if __name__ == "__main__":

--- a/benchmarks/dataset/seedtts.py
+++ b/benchmarks/dataset/seedtts.py
@@ -35,7 +35,7 @@ class SampleInput:
     target_text: str
 
 
-_STAGED_CACHE: dict[tuple[str, str, int | None], list[SampleInput]] = {}
+_STAGED_CACHE: dict[tuple[str, str, str | None, int | None], list[SampleInput]] = {}
 
 
 def _resolve_staged_audio_path(
@@ -80,6 +80,7 @@ def load_seedtts_samples(
     max_samples: int | None = None,
     *,
     split: str = "en",
+    revision: str | None = None,
 ) -> list[SampleInput]:
     """Load SeedTTS evaluation samples.
 
@@ -91,7 +92,7 @@ def load_seedtts_samples(
     """
     if os.path.isfile(source) or source.endswith(".lst"):
         return _load_from_meta_lst(source, max_samples)
-    return _load_from_arrow(source, split, max_samples)
+    return _load_from_arrow(source, split, revision, max_samples)
 
 
 def _load_from_meta_lst(path: str, max_samples: int | None) -> list[SampleInput]:
@@ -123,22 +124,31 @@ def _load_from_meta_lst(path: str, max_samples: int | None) -> list[SampleInput]
 
 
 def _load_from_arrow(
-    repo_id: str, split: str, max_samples: int | None
+    repo_id: str,
+    split: str,
+    revision: str | None,
+    max_samples: int | None,
 ) -> list[SampleInput]:
     """Load from a HuggingFace Arrow/Parquet dataset repo."""
-    full_cache_key = (repo_id, split, None)
+    full_cache_key = (repo_id, split, revision, None)
     if full_cache_key in _STAGED_CACHE:
         samples = _STAGED_CACHE[full_cache_key]
         return samples[:max_samples] if max_samples is not None else list(samples)
 
-    cache_key = (repo_id, split, max_samples)
+    cache_key = (repo_id, split, revision, max_samples)
     if cache_key in _STAGED_CACHE:
         return list(_STAGED_CACHE[cache_key])
 
     from datasets import Audio, load_dataset
 
-    logger.info("Loading %s split=%s from HuggingFace ...", repo_id, split)
-    ds = load_dataset(repo_id, split=split)
+    logger.info(
+        "Loading %s split=%s revision=%s from HuggingFace ...",
+        repo_id,
+        split,
+        revision or "default",
+    )
+    load_kwargs = {"revision": revision} if revision else {}
+    ds = load_dataset(repo_id, split=split, **load_kwargs)
 
     missing = _REQUIRED_COLUMNS - set(ds.column_names)
     if missing:

--- a/benchmarks/eval/benchmark_asr_seedtts.py
+++ b/benchmarks/eval/benchmark_asr_seedtts.py
@@ -13,22 +13,24 @@ Usage:
     # Download the test set once:
     python -m benchmarks.dataset.prepare --dataset seedtts
 
-    # Launch Qwen3-ASR behind the router, matching ASR CI
-    python -m sglang_omni_router.serve \
-        --host 0.0.0.0 \
-        --port 8000 \
-        --launcher-config examples/configs/qwen3_asr_router.yaml \
-        --policy least_request \
-        --health-success-threshold 1 \
-        --health-failure-threshold 2 \
-        --health-check-interval-secs 2 \
-        --log-level info
+    # Launch the validated single-RTX-4090 profile
+    sgl-omni serve \
+        --config examples/configs/qwen3_asr_rtx4090.yaml \
+        --port 8000
 
     # Sweep the issue's matrix (3 repeats each) over the full SeedTTS EN set:
     python -m benchmarks.eval.benchmark_asr_seedtts \
         --port 8000 \
         --concurrencies 1,2,4,8,16,32,64 \
-        --repeats 3
+        --repeats 3 --warmup \
+        --dataset-revision 27f4c1adee83b5b29b7c4b375f6b976324bda308 \
+        --model-revision 7278e1e70fe206f11671096ffdd38061171dd6e5 \
+        --dtype bfloat16 \
+        --attention-backend flashinfer \
+        --mm-attention-backend triton_attn \
+        --cuda-graph --no-torch-compile \
+        --max-running-requests 16 \
+        --mem-fraction-static 0.65
 
     # Quick local smoke on a 20-sample subset:
     python -m benchmarks.eval.benchmark_asr_seedtts \
@@ -41,7 +43,19 @@ Usage:
         --port 8000 --model-path FunAudioLLM/Fun-ASR-Nano-2512-hf \
         --concurrencies 1,2,4,8,16,32,64 --repeats 3 --warmup
 
-Reference results on the full SeedTTS EN set (1088 clips, bf16, single RTX
+Validated RTX 4090 24 GB results (bf16, DP=1, max-running-requests=16,
+CUDA Graph through 16, three repeats plus one warmup per level):
+
+* SeedTTS EN corpus WER was 0.0120-0.0123. Throughput was 10.53 samples/s at
+  concurrency 1, 45.10 at concurrency 8, and 65.43 at concurrency 16.
+* SeedTTS ZH corpus CER was 0.0062. Throughput was 11.67 samples/s at
+  concurrency 1, 55.21 at concurrency 8, and 79.53 at concurrency 16.
+* Concurrency 32 completed without skips but queued above the 16-request
+  admission limit, so it did not improve EN throughput.
+* The 30-minute mixed soak completed 78,418 requests without unexpected errors;
+  peak sampled GPU memory was 17,990 MiB.
+
+Earlier reference results on the full SeedTTS EN set (1088 clips, bf16, single RTX
 4080 SUPER 32 GB, DP=1, three repeats plus one discarded warmup per level):
 
 * At concurrency 32, Qwen3-ASR-1.7B reached 55.07 samples/s with 0.577 s mean
@@ -86,8 +100,15 @@ import statistics
 
 import requests
 
-from benchmarks.dataset.prepare import DATASETS
+from benchmarks.dataset.prepare import (
+    DATASETS,
+    SEEDTTS_DATASET_REVISION,
+)
 from benchmarks.dataset.seedtts import SampleInput, load_seedtts_samples
+from benchmarks.runtime_metrics import (
+    ResourceMonitor,
+    collect_benchmark_provenance,
+)
 from benchmarks.tasks.asr import (
     FUN_ASR_MODEL_PATH,
     QWEN3_ASR_MODEL_PATH,
@@ -96,6 +117,7 @@ from benchmarks.tasks.asr import (
 )
 
 DEFAULT_CONCURRENCIES = "1,2,4,8,16,32,64"
+DEFAULT_MODEL_REVISION = "7278e1e70fe206f11671096ffdd38061171dd6e5"
 
 
 def _fetch_worker_snapshot(host: str, port: int) -> dict | None:
@@ -175,14 +197,32 @@ async def run_asr_seedtts_once(
 
 
 async def _run_repeat(args, samples, concurrency: int, repeat: int) -> dict:
-    benchmark_result = await run_asr_seedtts_once(
-        samples,
-        host=args.host,
-        port=args.port,
-        model_path=args.model_path,
-        lang=args.lang,
-        concurrency=concurrency,
+    monitor = (
+        None
+        if args.disable_resource_monitor
+        else ResourceMonitor(
+            gpu_index=args.gpu_index,
+            interval_s=args.monitor_interval_s,
+        ).start()
     )
+    try:
+        benchmark_result = await run_asr_seedtts_once(
+            samples,
+            host=args.host,
+            port=args.port,
+            model_path=args.model_path,
+            lang=args.lang,
+            concurrency=concurrency,
+        )
+    finally:
+        resources = (
+            monitor.stop()
+            if monitor is not None
+            else {
+                "available": False,
+                "error": "resource monitoring disabled",
+            }
+        )
     summary = benchmark_result["summary"]
     speed = benchmark_result["speed"]
     return {
@@ -191,6 +231,7 @@ async def _run_repeat(args, samples, concurrency: int, repeat: int) -> dict:
         "evaluated": summary["evaluated"],
         "total": summary["total_samples"],
         "skipped": summary["skipped"],
+        "errors": summary["skipped"],
         "corpus_wer": summary["corpus_wer"],
         "per_sample_wer_max": summary["wer_per_sample_max"],
         "wall_clock_s": benchmark_result["wall_clock_s"],
@@ -201,6 +242,7 @@ async def _run_repeat(args, samples, concurrency: int, repeat: int) -> dict:
         "rtf_mean": speed["rtf_mean"],
         "rtf_p95": speed["rtf_p95"],
         "worker": benchmark_result["worker"],
+        "resources": resources,
     }
 
 
@@ -215,12 +257,33 @@ def _aggregate(repeats: list[dict]) -> dict:
             "max": max(values),
         }
 
+    def _resource_metric(*path: str) -> dict | None:
+        values: list[float] = []
+        for repeat in repeats:
+            current = repeat.get("resources")
+            for key in path:
+                if not isinstance(current, dict):
+                    current = None
+                    break
+                current = current.get(key)
+            if isinstance(current, (int, float)):
+                values.append(float(current))
+        if not values:
+            return None
+        return {
+            "per_repeat": values,
+            "mean": statistics.mean(values),
+            "min": min(values),
+            "max": max(values),
+        }
+
     return {
         "concurrency": repeats[0]["concurrency"],
         "repeats": len(repeats),
         "evaluated": repeats[0]["evaluated"],
         "total": repeats[0]["total"],
         "skipped": repeats[0]["skipped"],
+        "errors": _stat("errors"),
         "corpus_wer": _stat("corpus_wer"),
         "per_sample_wer_max": _stat("per_sample_wer_max"),
         "wall_clock_s": _stat("wall_clock_s"),
@@ -230,6 +293,29 @@ def _aggregate(repeats: list[dict]) -> dict:
         "latency_p99_s": _stat("latency_p99_s"),
         "rtf_mean": _stat("rtf_mean"),
         "rtf_p95": _stat("rtf_p95"),
+        "resources": {
+            "gpu_memory_used_peak_mib": _resource_metric(
+                "gpu_memory_used_mib", "max"
+            ),
+            "gpu_memory_used_steady_mib": _resource_metric(
+                "gpu_memory_used_mib", "steady_mean"
+            ),
+            "gpu_process_memory_peak_mib": _resource_metric(
+                "gpu_process_memory_mib", "max"
+            ),
+            "power_peak_w": _resource_metric("power_w", "max"),
+            "system_cpu_peak_percent": _resource_metric(
+                "system_cpu_percent", "max"
+            ),
+            "gpu_process_cpu_peak_percent": _resource_metric(
+                "gpu_process_cpu_percent", "max"
+            ),
+            "monitor_errors": [
+                repeat["resources"].get("error")
+                for repeat in repeats
+                if repeat.get("resources", {}).get("error")
+            ],
+        },
         "per_repeat": repeats,
     }
 
@@ -294,6 +380,80 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--model-revision",
+        default=None,
+        help=(
+            "Resolved model revision used by the running server. The pinned "
+            "Qwen3-ASR revision is used when its default model path is selected."
+        ),
+    )
+    parser.add_argument(
+        "--dataset-revision",
+        default=SEEDTTS_DATASET_REVISION,
+        help="Pinned HuggingFace SeedTTS dataset revision.",
+    )
+    parser.add_argument(
+        "--dtype",
+        default=None,
+        help="Served dtype recorded as provenance (for example, bfloat16).",
+    )
+    parser.add_argument(
+        "--attention-backend",
+        default=None,
+        help="Selected language-model attention backend recorded as provenance.",
+    )
+    parser.add_argument(
+        "--mm-attention-backend",
+        default=None,
+        help="Selected multimodal attention backend recorded as provenance.",
+    )
+    parser.add_argument(
+        "--cuda-graph",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Whether the server uses CUDA Graphs, recorded as provenance.",
+    )
+    parser.add_argument(
+        "--torch-compile",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Whether the server uses torch.compile, recorded as provenance.",
+    )
+    parser.add_argument(
+        "--max-running-requests",
+        type=int,
+        default=None,
+        help="Server admission limit recorded as provenance.",
+    )
+    parser.add_argument(
+        "--mem-fraction-static",
+        type=float,
+        default=None,
+        help="Server static-memory fraction recorded as provenance.",
+    )
+    parser.add_argument(
+        "--launch-command",
+        default=os.environ.get("SGLANG_OMNI_BENCHMARK_LAUNCH_COMMAND"),
+        help="Exact server launch command stored in the result JSON.",
+    )
+    parser.add_argument(
+        "--gpu-index",
+        type=int,
+        default=0,
+        help="Logical local GPU index sampled for memory, utilization, and power.",
+    )
+    parser.add_argument(
+        "--monitor-interval-s",
+        type=float,
+        default=0.2,
+        help="Resource monitor sampling interval.",
+    )
+    parser.add_argument(
+        "--disable-resource-monitor",
+        action="store_true",
+        help="Disable local GPU/CPU resource sampling.",
+    )
+    parser.add_argument(
         "--warmup",
         action="store_true",
         help="Run one discarded warmup pass before timing each concurrency.",
@@ -343,8 +503,16 @@ def main() -> None:
     args = parse_args()
     concurrencies = [int(c) for c in args.concurrencies.split(",") if c.strip()]
     max_samples = args.max_samples if args.max_samples > 0 else None
+    model_revision = args.model_revision
+    if model_revision is None and args.model_path == QWEN3_ASR_MODEL_PATH:
+        model_revision = DEFAULT_MODEL_REVISION
 
-    samples = load_seedtts_samples(args.meta, max_samples=max_samples, split=args.lang)
+    samples = load_seedtts_samples(
+        args.meta,
+        max_samples=max_samples,
+        split=args.lang,
+        revision=args.dataset_revision,
+    )
     print(
         f"Loaded {len(samples)} SeedTTS {args.lang} samples; "
         f"sweeping concurrency={concurrencies} x {args.repeats} repeats "
@@ -354,17 +522,43 @@ def main() -> None:
     aggregates = asyncio.run(_sweep(args, samples, concurrencies))
     _print_table(aggregates)
 
+    server_config = {
+        "dtype": args.dtype,
+        "attention_backend": args.attention_backend,
+        "mm_attention_backend": args.mm_attention_backend,
+        "cuda_graph": args.cuda_graph,
+        "torch_compile": args.torch_compile,
+        "max_running_requests": args.max_running_requests,
+        "mem_fraction_static": args.mem_fraction_static,
+    }
     payload = {
+        "schema_version": 2,
+        "provenance": collect_benchmark_provenance(
+            model_id=args.model_path,
+            model_revision=model_revision,
+            dataset_id=args.meta,
+            dataset_revision=args.dataset_revision,
+            launch_command=args.launch_command,
+            server_config=server_config,
+        ),
         "config": {
             "host": args.host,
             "port": args.port,
             "meta": args.meta,
             "lang": args.lang,
             "model_path": args.model_path,
+            "model_revision": model_revision,
+            "dataset_revision": args.dataset_revision,
             "num_samples": len(samples),
             "concurrencies": concurrencies,
             "repeats": args.repeats,
             "warmup": args.warmup,
+            "server": server_config,
+            "resource_monitor": {
+                "enabled": not args.disable_resource_monitor,
+                "gpu_index": args.gpu_index,
+                "interval_s": args.monitor_interval_s,
+            },
         },
         "results": aggregates,
     }

--- a/benchmarks/eval/benchmark_asr_stability.py
+++ b/benchmarks/eval/benchmark_asr_stability.py
@@ -1,0 +1,573 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Functional and sustained-load validation for an ASR transcription server."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import io
+import json
+import os
+import random
+import statistics
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+import numpy as np
+import soundfile as sf
+
+from benchmarks.dataset.prepare import DATASETS, SEEDTTS_DATASET_REVISION
+from benchmarks.dataset.seedtts import SampleInput, load_seedtts_samples
+from benchmarks.runtime_metrics import ResourceMonitor, collect_benchmark_provenance
+
+MODEL_ID = "Qwen/Qwen3-ASR-1.7B"
+MODEL_REVISION = "7278e1e70fe206f11671096ffdd38061171dd6e5"
+SAMPLE_RATE = 16000
+
+
+@dataclass(frozen=True)
+class PreparedSample:
+    sample_id: str
+    language: str
+    audio_bytes: bytes
+    duration_s: float
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--model-path", default=MODEL_ID)
+    parser.add_argument("--model-revision", default=MODEL_REVISION)
+    parser.add_argument("--meta", default=DATASETS["seedtts"])
+    parser.add_argument("--dataset-revision", default=SEEDTTS_DATASET_REVISION)
+    parser.add_argument("--duration-s", type=float, default=1800.0)
+    parser.add_argument("--concurrencies", default="1,4,8,16")
+    parser.add_argument("--samples-per-language", type=int, default=20)
+    parser.add_argument("--request-timeout-s", type=float, default=60.0)
+    parser.add_argument("--gpu-index", type=int, default=0)
+    parser.add_argument("--monitor-interval-s", type=float, default=0.2)
+    parser.add_argument("--launch-command", default=None)
+    parser.add_argument("--output", default="asr_stability_results.json")
+    return parser.parse_args()
+
+
+async def main_async(args: argparse.Namespace) -> dict[str, Any]:
+    if args.duration_s <= 0:
+        raise ValueError("--duration-s must be > 0")
+    concurrencies = [
+        int(value) for value in args.concurrencies.split(",") if value.strip()
+    ]
+    if not concurrencies or any(value < 1 for value in concurrencies):
+        raise ValueError("--concurrencies must contain positive integers")
+
+    samples = _load_prepared_samples(args)
+    timeout = aiohttp.ClientTimeout(total=args.request_timeout_s)
+    connector = aiohttp.TCPConnector(limit=max(concurrencies) + 8)
+    resource_monitor = ResourceMonitor(
+        gpu_index=args.gpu_index,
+        interval_s=args.monitor_interval_s,
+    ).start()
+    memory_checkpoints: list[dict[str, Any]] = [
+        _memory_checkpoint("before_functional", args.gpu_index)
+    ]
+
+    async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
+        functional = await _run_functional_checks(session, args, samples)
+        memory_checkpoints.append(
+            _memory_checkpoint("after_functional", args.gpu_index)
+        )
+        stages, chaos = await _run_soak(
+            session,
+            args,
+            samples,
+            concurrencies=concurrencies,
+        )
+        memory_checkpoints.append(_memory_checkpoint("after_soak", args.gpu_index))
+        await asyncio.sleep(5)
+        memory_checkpoints.append(_memory_checkpoint("after_cooldown", args.gpu_index))
+        health_status = await _health_status(session, args)
+
+    resources = resource_monitor.stop()
+    unexpected_errors = sum(stage["unexpected_errors"] for stage in stages)
+    passed = (
+        all(check["passed"] for check in functional)
+        and unexpected_errors == 0
+        and all(event["passed"] for event in chaos)
+        and health_status == 200
+    )
+    return {
+        "schema_version": 1,
+        "passed": passed,
+        "provenance": collect_benchmark_provenance(
+            model_id=args.model_path,
+            model_revision=args.model_revision,
+            dataset_id=args.meta,
+            dataset_revision=args.dataset_revision,
+            launch_command=args.launch_command,
+            server_config={
+                "dtype": "bfloat16",
+                "attention_backend": "flashinfer",
+                "mm_attention_backend": "triton_attn",
+                "cuda_graph": True,
+                "torch_compile": False,
+                "max_running_requests": 16,
+                "mem_fraction_static": 0.65,
+            },
+        ),
+        "config": {
+            "host": args.host,
+            "port": args.port,
+            "duration_s": args.duration_s,
+            "concurrencies": concurrencies,
+            "samples_per_language": args.samples_per_language,
+            "seed": 123,
+        },
+        "functional": functional,
+        "soak_stages": stages,
+        "chaos_events": chaos,
+        "resources": resources,
+        "memory_checkpoints": memory_checkpoints,
+        "final_health_status": health_status,
+        "unexpected_errors": unexpected_errors,
+    }
+
+
+def _load_prepared_samples(args: argparse.Namespace) -> list[PreparedSample]:
+    prepared: list[PreparedSample] = []
+    for language in ("en", "zh"):
+        loaded = load_seedtts_samples(
+            args.meta,
+            max_samples=args.samples_per_language,
+            split=language,
+            revision=args.dataset_revision,
+        )
+        prepared.extend(_prepare_sample(sample, language) for sample in loaded)
+    if not prepared:
+        raise RuntimeError("No SeedTTS samples were loaded")
+    return prepared
+
+
+def _prepare_sample(sample: SampleInput, language: str) -> PreparedSample:
+    audio_bytes = Path(sample.ref_audio).read_bytes()
+    return PreparedSample(
+        sample_id=sample.sample_id,
+        language=language,
+        audio_bytes=audio_bytes,
+        duration_s=_duration_s(audio_bytes),
+    )
+
+
+async def _run_functional_checks(
+    session: aiohttp.ClientSession,
+    args: argparse.Namespace,
+    samples: list[PreparedSample],
+) -> list[dict[str, Any]]:
+    en_sample = next(sample for sample in samples if sample.language == "en")
+    zh_sample = next(sample for sample in samples if sample.language == "zh")
+    checks: list[dict[str, Any]] = []
+
+    en_result = await _post_transcription(session, args, en_sample)
+    checks.append(_expect_success("basic_en", en_result))
+    zh_result = await _post_transcription(session, args, zh_sample)
+    checks.append(_expect_success("basic_zh", zh_result))
+
+    stream_result = await _post_streaming_transcription(session, args, en_sample)
+    checks.append(
+        {
+            "name": "streaming_consistency",
+            "passed": (
+                stream_result["status"] == 200
+                and stream_result["done"]
+                and stream_result["text"] == en_result["text"]
+            ),
+            "status": stream_result["status"],
+            "stream_text": stream_result["text"],
+            "non_stream_text": en_result["text"],
+            "events": stream_result["events"],
+        }
+    )
+
+    cancellation = await _cancel_stream(session, args, en_sample)
+    await asyncio.sleep(0.5)
+    reconnect = await _post_streaming_transcription(session, args, en_sample)
+    checks.append(
+        {
+            "name": "stream_cancel_and_reconnect",
+            "passed": (
+                cancellation["status"] == 200
+                and cancellation["received_event"]
+                and reconnect["done"]
+            ),
+            "cancel": cancellation,
+            "reconnect_status": reconnect["status"],
+        }
+    )
+
+    checks.append(
+        _expect_status(
+            "empty_audio",
+            await _post_raw_audio(session, args, b"", "empty.wav", "en"),
+            400,
+        )
+    )
+    checks.append(
+        _expect_status(
+            "corrupt_audio",
+            await _post_raw_audio(
+                session,
+                args,
+                b"not-an-audio-file",
+                "corrupt.wav",
+                "en",
+            ),
+            400,
+        )
+    )
+
+    below_30s = _resize_wav(en_sample.audio_bytes, 29.9)
+    below_30s_result = await _post_raw_audio(
+        session,
+        args,
+        below_30s,
+        "below-30s.wav",
+        "en",
+    )
+    checks.append(_expect_success("below_30s_audio", below_30s_result))
+
+    beyond_30s = _resize_wav(en_sample.audio_bytes, 30.1)
+    beyond_30s_result = await _post_raw_audio(
+        session,
+        args,
+        beyond_30s,
+        "beyond-30s.wav",
+        "en",
+    )
+    checks.append(_expect_success("beyond_30s_audio", beyond_30s_result))
+    return checks
+
+
+async def _run_soak(
+    session: aiohttp.ClientSession,
+    args: argparse.Namespace,
+    samples: list[PreparedSample],
+    *,
+    concurrencies: list[int],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    randomizer = random.Random(123)
+    stage_duration_s = args.duration_s / len(concurrencies)
+    stages: list[dict[str, Any]] = []
+    chaos_events: list[dict[str, Any]] = []
+    for concurrency in concurrencies:
+        deadline = time.monotonic() + stage_duration_s
+        counters = {
+            "requests": 0,
+            "successes": 0,
+            "unexpected_errors": 0,
+            "en": 0,
+            "zh": 0,
+        }
+        latencies: list[float] = []
+
+        async def worker(worker_id: int) -> None:
+            index = worker_id
+            while time.monotonic() < deadline:
+                sample = samples[index % len(samples)]
+                index += concurrency
+                result = await _post_transcription(session, args, sample)
+                counters["requests"] += 1
+                counters[sample.language] += 1
+                latencies.append(result["latency_s"])
+                if result["status"] == 200 and result["text"]:
+                    counters["successes"] += 1
+                else:
+                    counters["unexpected_errors"] += 1
+
+        async def chaos_worker() -> None:
+            event_number = 0
+            while time.monotonic() < deadline:
+                await asyncio.sleep(min(30.0, max(0.0, deadline - time.monotonic())))
+                if time.monotonic() >= deadline:
+                    break
+                sample = randomizer.choice(samples)
+                if event_number % 2 == 0:
+                    result = await _post_raw_audio(
+                        session,
+                        args,
+                        b"invalid",
+                        "intentional-corrupt.wav",
+                        sample.language,
+                    )
+                    chaos_events.append(
+                        {
+                            "stage_concurrency": concurrency,
+                            "kind": "malformed",
+                            "status": result["status"],
+                            "passed": result["status"] == 400,
+                        }
+                    )
+                else:
+                    result = await _cancel_stream(session, args, sample)
+                    reconnect = await _post_streaming_transcription(
+                        session, args, sample
+                    )
+                    chaos_events.append(
+                        {
+                            "stage_concurrency": concurrency,
+                            "kind": "cancel_reconnect",
+                            "status": result["status"],
+                            "passed": (
+                                result["status"] == 200
+                                and result["received_event"]
+                                and reconnect["done"]
+                            ),
+                        }
+                    )
+                event_number += 1
+
+        started = time.monotonic()
+        await asyncio.gather(
+            *(worker(worker_id) for worker_id in range(concurrency)),
+            chaos_worker(),
+        )
+        stages.append(
+            {
+                "concurrency": concurrency,
+                "duration_s": time.monotonic() - started,
+                **counters,
+                "throughput_requests_per_s": counters["successes"]
+                / max(time.monotonic() - started, 1e-9),
+                "latency_mean_s": statistics.mean(latencies) if latencies else None,
+                "latency_p95_s": _percentile(latencies, 95),
+                "memory": _memory_checkpoint(
+                    f"after_concurrency_{concurrency}",
+                    args.gpu_index,
+                ),
+            }
+        )
+    return stages, chaos_events
+
+
+async def _post_transcription(
+    session: aiohttp.ClientSession,
+    args: argparse.Namespace,
+    sample: PreparedSample,
+) -> dict[str, Any]:
+    return await _post_raw_audio(
+        session,
+        args,
+        sample.audio_bytes,
+        f"{sample.sample_id}.wav",
+        sample.language,
+    )
+
+
+async def _post_raw_audio(
+    session: aiohttp.ClientSession,
+    args: argparse.Namespace,
+    audio_bytes: bytes,
+    filename: str,
+    language: str,
+) -> dict[str, Any]:
+    form = aiohttp.FormData()
+    form.add_field("model", args.model_path)
+    form.add_field("language", language)
+    form.add_field("response_format", "json")
+    form.add_field(
+        "file",
+        audio_bytes,
+        filename=filename,
+        content_type="audio/wav",
+    )
+    started = time.perf_counter()
+    async with session.post(_url(args), data=form) as response:
+        body = await response.text()
+        text = ""
+        if response.status == 200:
+            try:
+                text = str(json.loads(body).get("text", ""))
+            except json.JSONDecodeError:
+                pass
+        return {
+            "status": response.status,
+            "text": text,
+            "body": body[:500],
+            "latency_s": time.perf_counter() - started,
+        }
+
+
+async def _post_streaming_transcription(
+    session: aiohttp.ClientSession,
+    args: argparse.Namespace,
+    sample: PreparedSample,
+) -> dict[str, Any]:
+    form = _stream_form(args, sample)
+    events: list[dict[str, Any]] = []
+    async with session.post(_url(args), data=form) as response:
+        async for raw_line in response.content:
+            line = raw_line.decode(errors="replace").strip()
+            if not line.startswith("data:"):
+                continue
+            payload = line[5:].strip()
+            if payload == "[DONE]":
+                break
+            try:
+                events.append(json.loads(payload))
+            except json.JSONDecodeError:
+                continue
+    done_events = [
+        event for event in events if event.get("type") == "transcript.text.done"
+    ]
+    return {
+        "status": response.status,
+        "events": len(events),
+        "done": bool(done_events),
+        "text": str(done_events[-1].get("text", "")) if done_events else "",
+    }
+
+
+async def _cancel_stream(
+    session: aiohttp.ClientSession,
+    args: argparse.Namespace,
+    sample: PreparedSample,
+) -> dict[str, Any]:
+    response = await session.post(_url(args), data=_stream_form(args, sample))
+    first_line = ""
+    try:
+        first_line = (
+            await asyncio.wait_for(response.content.readline(), timeout=10)
+        ).decode(errors="replace")
+    finally:
+        status = response.status
+        response.close()
+    return {
+        "status": status,
+        "received_event": first_line.startswith("data:"),
+    }
+
+
+def _stream_form(args: argparse.Namespace, sample: PreparedSample) -> aiohttp.FormData:
+    form = aiohttp.FormData()
+    form.add_field("model", args.model_path)
+    form.add_field("language", sample.language)
+    form.add_field("response_format", "json")
+    form.add_field("stream", "true")
+    form.add_field(
+        "file",
+        sample.audio_bytes,
+        filename=f"{sample.sample_id}.wav",
+        content_type="audio/wav",
+    )
+    return form
+
+
+async def _health_status(
+    session: aiohttp.ClientSession,
+    args: argparse.Namespace,
+) -> int:
+    async with session.get(f"http://{args.host}:{args.port}/health") as response:
+        await response.read()
+        return response.status
+
+
+def _expect_success(name: str, result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": name,
+        "passed": result["status"] == 200 and bool(result["text"]),
+        **result,
+    }
+
+
+def _expect_status(
+    name: str,
+    result: dict[str, Any],
+    expected_status: int,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "passed": result["status"] == expected_status,
+        "expected_status": expected_status,
+        **result,
+    }
+
+
+def _resize_wav(audio_bytes: bytes, duration_s: float) -> bytes:
+    audio, sample_rate = sf.read(io.BytesIO(audio_bytes), dtype="float32")
+    if audio.ndim == 2:
+        audio = audio.mean(axis=1)
+    target_samples = round(duration_s * SAMPLE_RATE)
+    if sample_rate != SAMPLE_RATE:
+        old_positions = np.linspace(0.0, 1.0, num=len(audio), endpoint=False)
+        new_length = round(len(audio) * SAMPLE_RATE / sample_rate)
+        new_positions = np.linspace(0.0, 1.0, num=new_length, endpoint=False)
+        audio = np.interp(new_positions, old_positions, audio).astype(np.float32)
+    repeats = max(1, (target_samples + len(audio) - 1) // len(audio))
+    resized = np.tile(audio, repeats)[:target_samples]
+    buffer = io.BytesIO()
+    sf.write(buffer, resized, SAMPLE_RATE, format="WAV", subtype="PCM_16")
+    return buffer.getvalue()
+
+
+def _duration_s(audio_bytes: bytes) -> float:
+    info = sf.info(io.BytesIO(audio_bytes))
+    return info.frames / float(info.samplerate)
+
+
+def _percentile(values: list[float], percentile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = min(
+        len(ordered) - 1,
+        max(0, round((percentile / 100.0) * (len(ordered) - 1))),
+    )
+    return ordered[index]
+
+
+def _memory_checkpoint(label: str, gpu_index: int) -> dict[str, Any]:
+    output = _command(
+        "nvidia-smi",
+        f"--id={gpu_index}",
+        "--query-gpu=memory.used,memory.free,power.draw,utilization.gpu",
+        "--format=csv,noheader,nounits",
+    )
+    return {
+        "label": label,
+        "monotonic_s": time.monotonic(),
+        "nvidia_smi_csv": output,
+    }
+
+
+def _command(*args: str) -> str | None:
+    try:
+        return subprocess.run(
+            args,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return None
+
+
+def _url(args: argparse.Namespace) -> str:
+    return f"http://{args.host}:{args.port}/v1/audio/transcriptions"
+
+
+def main() -> None:
+    args = parse_args()
+    result = asyncio.run(main_async(args))
+    output = Path(os.path.abspath(args.output))
+    output.write_text(json.dumps(result, indent=2) + "\n")
+    print(json.dumps({"passed": result["passed"], "output": str(output)}, indent=2))
+    if not result["passed"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/runtime_metrics.py
+++ b/benchmarks/runtime_metrics.py
@@ -1,0 +1,393 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Best-effort provenance and host-resource sampling for local benchmarks."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import json
+import os
+import platform
+import subprocess
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ResourceSample:
+    elapsed_s: float
+    gpu_memory_used_mib: float
+    gpu_memory_free_mib: float
+    gpu_process_memory_mib: float
+    gpu_util_percent: float | None
+    power_w: float | None
+    system_cpu_percent: float | None
+    gpu_process_cpu_percent: float | None
+    gpu_process_pids: tuple[int, ...]
+
+
+class ResourceMonitor:
+    """Sample one local GPU and its compute processes in a background thread."""
+
+    def __init__(self, gpu_index: int = 0, interval_s: float = 0.2) -> None:
+        if gpu_index < 0:
+            raise ValueError("gpu_index must be >= 0")
+        if interval_s <= 0:
+            raise ValueError("interval_s must be > 0")
+        self.gpu_index = gpu_index
+        self.interval_s = interval_s
+        self.samples: list[ResourceSample] = []
+        self.error: str | None = None
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._started_at = 0.0
+        self._pynvml: Any = None
+        self._handle: Any = None
+        self._psutil: Any = None
+        self._processes: dict[int, Any] = {}
+
+    def start(self) -> "ResourceMonitor":
+        try:
+            import psutil
+            import pynvml
+
+            pynvml.nvmlInit()
+            self._pynvml = pynvml
+            self._psutil = psutil
+            self._handle = _resolve_nvml_handle(pynvml, self.gpu_index)
+            psutil.cpu_percent(interval=None)
+        except Exception as exc:
+            self.error = f"{type(exc).__name__}: {exc}"
+            self._shutdown_nvml()
+            return self
+
+        self._started_at = time.perf_counter()
+        self._sample_once()
+        self._thread = threading.Thread(
+            target=self._run,
+            name=f"benchmark-resource-monitor-gpu{self.gpu_index}",
+            daemon=True,
+        )
+        self._thread.start()
+        return self
+
+    def stop(self) -> dict[str, Any]:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=max(5.0, self.interval_s * 5))
+        if self._handle is not None:
+            self._sample_once()
+        self._shutdown_nvml()
+        return summarize_resource_samples(
+            self.samples,
+            interval_s=self.interval_s,
+            error=self.error,
+        )
+
+    def _run(self) -> None:
+        while not self._stop_event.wait(self.interval_s):
+            self._sample_once()
+
+    def _sample_once(self) -> None:
+        try:
+            pynvml = self._pynvml
+            memory = pynvml.nvmlDeviceGetMemoryInfo(self._handle)
+            process_memory_bytes = 0
+            process_pids: set[int] = set()
+            for process in _nvml_compute_processes(pynvml, self._handle):
+                process_pids.add(int(process.pid))
+                used = getattr(process, "usedGpuMemory", 0)
+                if isinstance(used, int) and 0 <= used < 2**63:
+                    process_memory_bytes += used
+
+            utilization = _best_effort(
+                lambda: float(
+                    pynvml.nvmlDeviceGetUtilizationRates(self._handle).gpu
+                )
+            )
+            power_w = _best_effort(
+                lambda: float(pynvml.nvmlDeviceGetPowerUsage(self._handle)) / 1000.0
+            )
+            system_cpu = _best_effort(
+                lambda: float(self._psutil.cpu_percent(interval=None))
+            )
+            process_cpu = self._gpu_process_cpu_percent(process_pids)
+            self.samples.append(
+                ResourceSample(
+                    elapsed_s=time.perf_counter() - self._started_at,
+                    gpu_memory_used_mib=float(memory.used) / (1024**2),
+                    gpu_memory_free_mib=float(memory.free) / (1024**2),
+                    gpu_process_memory_mib=float(process_memory_bytes) / (1024**2),
+                    gpu_util_percent=utilization,
+                    power_w=power_w,
+                    system_cpu_percent=system_cpu,
+                    gpu_process_cpu_percent=process_cpu,
+                    gpu_process_pids=tuple(sorted(process_pids)),
+                )
+            )
+        except Exception as exc:
+            if self.error is None:
+                self.error = f"{type(exc).__name__}: {exc}"
+
+    def _gpu_process_cpu_percent(self, pids: set[int]) -> float | None:
+        if self._psutil is None:
+            return None
+        total = 0.0
+        observed = False
+        for pid in pids:
+            try:
+                process = self._processes.get(pid)
+                if process is None:
+                    process = self._psutil.Process(pid)
+                    self._processes[pid] = process
+                total += float(process.cpu_percent(interval=None))
+                observed = True
+            except (self._psutil.NoSuchProcess, self._psutil.AccessDenied):
+                self._processes.pop(pid, None)
+        return total if observed else None
+
+    def _shutdown_nvml(self) -> None:
+        if self._pynvml is None:
+            return
+        try:
+            self._pynvml.nvmlShutdown()
+        except Exception:
+            pass
+        self._pynvml = None
+        self._handle = None
+
+
+def summarize_resource_samples(
+    samples: list[ResourceSample],
+    *,
+    interval_s: float,
+    error: str | None = None,
+) -> dict[str, Any]:
+    if not samples:
+        return {
+            "available": False,
+            "sample_interval_s": interval_s,
+            "samples": 0,
+            "error": error,
+        }
+
+    steady_count = max(1, min(len(samples), round(5.0 / interval_s)))
+    steady = samples[-steady_count:]
+    return {
+        "available": True,
+        "sample_interval_s": interval_s,
+        "samples": len(samples),
+        "duration_s": samples[-1].elapsed_s,
+        "gpu_memory_used_mib": _series_summary(
+            [sample.gpu_memory_used_mib for sample in samples],
+            steady=[sample.gpu_memory_used_mib for sample in steady],
+        ),
+        "gpu_memory_free_mib": _series_summary(
+            [sample.gpu_memory_free_mib for sample in samples],
+            steady=[sample.gpu_memory_free_mib for sample in steady],
+        ),
+        "gpu_process_memory_mib": _series_summary(
+            [sample.gpu_process_memory_mib for sample in samples],
+            steady=[sample.gpu_process_memory_mib for sample in steady],
+        ),
+        "gpu_util_percent": _optional_series_summary(
+            [sample.gpu_util_percent for sample in samples]
+        ),
+        "power_w": _optional_series_summary([sample.power_w for sample in samples]),
+        "system_cpu_percent": _optional_series_summary(
+            [sample.system_cpu_percent for sample in samples]
+        ),
+        "gpu_process_cpu_percent": _optional_series_summary(
+            [sample.gpu_process_cpu_percent for sample in samples]
+        ),
+        "gpu_process_pids": sorted(
+            {
+                pid
+                for sample in samples
+                for pid in sample.gpu_process_pids
+            }
+        ),
+        "error": error,
+    }
+
+
+def collect_benchmark_provenance(
+    *,
+    model_id: str,
+    model_revision: str | None,
+    dataset_id: str,
+    dataset_revision: str | None,
+    launch_command: str | None,
+    server_config: dict[str, Any],
+) -> dict[str, Any]:
+    packages = {
+        dist.metadata.get("Name", "unknown"): dist.version
+        for dist in importlib.metadata.distributions()
+    }
+    package_payload = json.dumps(packages, sort_keys=True, separators=(",", ":"))
+
+    try:
+        import torch
+
+        torch_cuda = torch.version.cuda
+        cudnn_version = torch.backends.cudnn.version()
+    except Exception:
+        torch_cuda = None
+        cudnn_version = None
+
+    return {
+        "schema_version": 1,
+        "repository": {
+            "commit": _command("git", "rev-parse", "HEAD"),
+            "branch": _command("git", "branch", "--show-current"),
+            "dirty": bool(_command("git", "status", "--porcelain")),
+        },
+        "host": {
+            "platform": platform.platform(),
+            "cpu_model": _first_prefixed_line("/proc/cpuinfo", "model name"),
+            "logical_cpus": os.cpu_count(),
+            "memory_total_kib": _first_prefixed_line("/proc/meminfo", "MemTotal"),
+        },
+        "gpu": {
+            "nvidia_smi_csv": _command(
+                "nvidia-smi",
+                "--query-gpu=index,name,uuid,memory.total,driver_version,pstate,"
+                "power.limit,clocks.sm,clocks.mem,compute_cap",
+                "--format=csv,noheader,nounits",
+            ),
+            "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
+            "torch_cuda_build": torch_cuda,
+            "cudnn_version": cudnn_version,
+        },
+        "packages": {
+            name: _package_version(name)
+            for name in (
+                "torch",
+                "sglang",
+                "sglang-omni",
+                "transformers",
+                "flash-attn-4",
+                "flashinfer-python",
+                "sglang-kernel",
+            )
+        },
+        "dependency_freeze_sha256": hashlib.sha256(
+            package_payload.encode()
+        ).hexdigest(),
+        "artifacts": {
+            "model_id": model_id,
+            "model_revision": model_revision,
+            "dataset_id": dataset_id,
+            "dataset_revision": dataset_revision,
+        },
+        "launch_command": launch_command,
+        "server_config": server_config,
+        "normalization": {
+            "en": "whisper.normalizers.EnglishTextNormalizer",
+            "zh": "strip zhon+ASCII punctuation, remove spaces, score characters",
+        },
+    }
+
+
+def _resolve_nvml_handle(pynvml: Any, logical_gpu_index: int):
+    visible = [
+        token.strip()
+        for token in os.environ.get("CUDA_VISIBLE_DEVICES", "").split(",")
+        if token.strip()
+    ]
+    device: int | str = logical_gpu_index
+    if visible:
+        if logical_gpu_index >= len(visible):
+            raise ValueError(
+                f"logical GPU {logical_gpu_index} is not in CUDA_VISIBLE_DEVICES"
+            )
+        token = visible[logical_gpu_index]
+        device = int(token) if token.isdigit() else token
+    if isinstance(device, int):
+        return pynvml.nvmlDeviceGetHandleByIndex(device)
+    return pynvml.nvmlDeviceGetHandleByUUID(device.encode())
+
+
+def _nvml_compute_processes(pynvml: Any, handle: Any) -> list[Any]:
+    processes: dict[int, Any] = {}
+    for getter_name in (
+        "nvmlDeviceGetComputeRunningProcesses",
+        "nvmlDeviceGetGraphicsRunningProcesses",
+    ):
+        getter = getattr(pynvml, getter_name, None)
+        if getter is None:
+            continue
+        try:
+            for process in getter(handle):
+                processes[int(process.pid)] = process
+        except Exception:
+            continue
+    return list(processes.values())
+
+
+def _series_summary(values: list[float], *, steady: list[float]) -> dict[str, float]:
+    return {
+        "min": min(values),
+        "max": max(values),
+        "end": values[-1],
+        "steady_mean": sum(steady) / len(steady),
+    }
+
+
+def _optional_series_summary(values: list[float | None]) -> dict[str, float] | None:
+    present = [value for value in values if value is not None]
+    if not present:
+        return None
+    return {
+        "min": min(present),
+        "max": max(present),
+        "mean": sum(present) / len(present),
+    }
+
+
+def _best_effort(callback):
+    try:
+        return callback()
+    except Exception:
+        return None
+
+
+def _command(*args: str) -> str | None:
+    try:
+        return subprocess.run(
+            args,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return None
+
+
+def _first_prefixed_line(path: str, prefix: str) -> str | None:
+    try:
+        for line in Path(path).read_text().splitlines():
+            if line.startswith(prefix):
+                return line.split(":", 1)[-1].strip()
+    except OSError:
+        return None
+    return None
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+__all__ = [
+    "ResourceMonitor",
+    "ResourceSample",
+    "collect_benchmark_provenance",
+    "summarize_resource_samples",
+]

--- a/docs/cookbook/qwen3_asr.md
+++ b/docs/cookbook/qwen3_asr.md
@@ -7,7 +7,15 @@
 Install `sglang-omni` by following [Installation](../get_started/installation.md), then download the model:
 
 ```bash
-hf download Qwen/Qwen3-ASR-1.7B
+MODEL_REVISION=7278e1e70fe206f11671096ffdd38061171dd6e5
+MODEL_PATH=$(hf download Qwen/Qwen3-ASR-1.7B --revision "${MODEL_REVISION}")
+```
+
+Source installations also need the system NUMA runtime used by `sglang-kernel`:
+
+```bash
+apt-get update
+apt-get install -y libnuma1
 ```
 
 ## Server Configuration
@@ -18,6 +26,32 @@ Qwen3-ASR runs a single ASR stage on one GPU.
 sgl-omni serve \
   --model-path Qwen/Qwen3-ASR-1.7B \
   --port 8000
+```
+
+### RTX 4090 (24 GB)
+
+The validated consumer profile uses BF16, at most 16 running requests, CUDA
+Graph batches through 16, `mem_fraction_static=0.65`, FlashInfer language-model
+attention, Triton multimodal attention, and no `torch.compile`.
+
+```bash
+CUDA_VISIBLE_DEVICES=0 sgl-omni serve \
+  --config examples/configs/qwen3_asr_rtx4090.yaml \
+  --model-path "${MODEL_PATH}" \
+  --model-name Qwen/Qwen3-ASR-1.7B \
+  --port 8000
+```
+
+The equivalent settings can be overridden explicitly:
+
+```bash
+sgl-omni serve \
+  --model-path "${MODEL_PATH}" \
+  --model-name Qwen/Qwen3-ASR-1.7B \
+  --port 8000 \
+  --mem-fraction-static 0.65 \
+  --max-running-requests 16 \
+  --cuda-graph-max-bs 16
 ```
 
 ## Transcribe Audio
@@ -58,11 +92,11 @@ print(resp.json()["text"])
 | `language` | string | `en` | Language hint; `zh`/`cn` select Chinese, other values use English prompting |
 | `response_format` | string | `json` | `json`, `verbose_json`, or `text` |
 | `temperature` | float | `0.01` effective | Sampling temperature; `0` is converted to near-greedy `0.01` |
+| `max_new_tokens` | integer | stage default | Maximum generated transcription tokens |
+| `stream` | boolean | `false` | Return transcript events over SSE |
 
 `verbose_json` is accepted, but currently returns the same minimal JSON shape as `json`:
 `{"text": "..."}`.
-
-`max_new_tokens` is supported inside the model request builder, but the public transcription endpoint does not currently expose it as a form field. The route uses the ASR stage default unless the pipeline is configured another way.
 
 ## Benchmarking
 
@@ -76,15 +110,123 @@ sgl-omni serve --model-path Qwen/Qwen3-ASR-1.7B --port 8000
 
 # Sweep the full SeedTTS EN set (1088 clips) at 1..64 concurrency, 3 repeats:
 python -m benchmarks.eval.benchmark_asr_seedtts \
-  --port 8000 --concurrencies 1,2,4,8,16,32,64 --repeats 3 --warmup
+  --port 8000 \
+  --dataset-revision 27f4c1adee83b5b29b7c4b375f6b976324bda308 \
+  --model-revision 7278e1e70fe206f11671096ffdd38061171dd6e5 \
+  --concurrencies 1,2,4,8,16,32 \
+  --repeats 3 --warmup \
+  --dtype bfloat16 \
+  --attention-backend flashinfer \
+  --mm-attention-backend triton_attn \
+  --cuda-graph --no-torch-compile \
+  --max-running-requests 16 \
+  --mem-fraction-static 0.65
+```
+
+The result JSON includes the fixed revisions and normalization, repository and
+dependency fingerprints, the launch configuration, complete sample counts,
+latency/RTF/throughput, CPU use, power, and peak/steady GPU memory.
+
+For functional paths and a mixed 30-minute soak:
+
+```bash
+python -m benchmarks.eval.benchmark_asr_stability \
+  --port 8000 \
+  --duration-s 1800 \
+  --concurrencies 1,4,8,16 \
+  --output asr_stability_results.json
 ```
 
 The ASR CI gate runs Fun-ASR-Nano on this same benchmark entry point
 (`tests/test_model/test_asr_ci_fun_asr.py`). Qwen3-ASR remains the
 transcriber for the TTS and talker WER stages.
 
+## RTX 4090 Validation Results
+
+Validated on Linux with one RTX 4090 (24,564 MiB, SM89), driver 580.159.04,
+CUDA 13.0, PyTorch 2.11.0, SGLang 0.5.12.post1, Transformers 5.6.0, and a
+450 W power limit. The validation worktree was based on commit
+`aa6f92c30e5279ed831776d0d6649344df3a94cb` with this change set applied.
+SeedTTS used revision
+`27f4c1adee83b5b29b7c4b375f6b976324bda308`; the model used revision
+`7278e1e70fe206f11671096ffdd38061171dd6e5`.
+
+Full SeedTTS EN (1088 clips, three measured repeats after one warmup):
+
+- Concurrency 1: 10.527 samples/s, 0.095 s mean latency, 0.119 s p95,
+  0.0205 mean RTF, worst corpus WER 0.0123.
+- Concurrency 4: 28.258 samples/s, 0.141 s mean latency, 0.181 s p95,
+  0.0306 mean RTF, worst corpus WER 0.0122.
+- Concurrency 8: 45.102 samples/s, 0.177 s mean latency, 0.233 s p95,
+  0.0382 mean RTF, worst corpus WER 0.0123.
+- Concurrency 16: 65.428 samples/s, 0.243 s mean latency, 0.321 s p95,
+  0.0526 mean RTF, worst corpus WER 0.0123.
+- Concurrency 32 (queueing stress above the 16-request admission limit):
+  65.747 samples/s, 0.482 s mean latency, 0.570 s p95, 0.1051 mean RTF,
+  worst corpus WER 0.0123.
+
+All EN runs evaluated 1088/1088 clips with no skips. The WER range
+(`0.0120`–`0.0123`) matches the published H100 BF16 reference (`0.0122`).
+
+Full SeedTTS ZH (2020 clips, three measured repeats after one warmup):
+
+- Concurrency 1: 11.671 samples/s, 0.086 s mean latency, 0.113 s p95,
+  0.0185 mean RTF, corpus CER 0.0062.
+- Concurrency 4: 34.622 samples/s, 0.115 s mean latency, 0.152 s p95,
+  0.0249 mean RTF, corpus CER 0.0062.
+- Concurrency 8: 55.214 samples/s, 0.145 s mean latency, 0.196 s p95,
+  0.0312 mean RTF, corpus CER 0.0062.
+- Concurrency 16: 79.532 samples/s, 0.201 s mean latency, 0.290 s p95,
+  0.0434 mean RTF, corpus CER 0.0062.
+- Concurrency 32 (queueing stress): 75.583 samples/s, 0.421 s mean latency,
+  0.518 s p95, 0.0910 mean RTF, corpus CER 0.0062.
+
+All ZH runs evaluated 2020/2020 clips with no skips. A matching Qwen3-ASR H100
+ZH reference was not available in the repository, so this is an absolute
+consumer result rather than a cross-hardware parity claim.
+
+Memory checkpoints for the 24 GB profile:
+
+- Before model load: 0.38 GiB process memory.
+- After weights and KV-cache allocation: 15.97 GiB process memory.
+- After CUDA Graph capture: 16.12 GiB process memory.
+- During the 30-minute mixed workload: 17,116 MiB at each stage boundary,
+  17,990 MiB sampled peak, and at least 6,574 MiB free.
+- The default FP16/graph-32 configuration used 18,458 MiB before the full
+  validation workload; the BF16/graph-16 profile preserves more headroom.
+
+Cold/warm behavior on this network-mounted source environment:
+
+- The initial default process took about 401 seconds from launch to `/health`;
+  the final profile took about 308 seconds with caches populated. Roughly
+  54 seconds of the final launch covered model/static allocation and graph
+  capture; Python imports dominated the remaining startup time.
+- The first uncached BF16 transcription took 35.8 seconds while Triton kernels
+  compiled. After warmup, the 20-clip concurrency-1 mean was 0.155 seconds.
+
+The 30-minute soak completed 78,418 successful transcriptions at concurrency
+1/4/8/16 with zero unexpected errors. It also passed 28 malformed-input checks
+and 28 stream-cancel/reconnect checks. Memory was 17,116 MiB before and after
+the soak and after cooldown, `/health` remained available, and SIGTERM stopped
+the worker and released GPU memory.
+
 ## Known Limitations
 
 - The endpoint accepts one uploaded file per request.
+- Audio duration is bounded by the configured context and requested
+  `max_new_tokens`, rather than a fixed 30-second window. Split audio or reduce
+  `max_new_tokens` if the request exceeds that token budget.
 - `prompt` is accepted by the HTTP endpoint for OpenAI compatibility, but Qwen3-ASR currently ignores it.
 - Audio is resampled to 16 kHz before transcription.
+- SSE transport, cancellation, and reconnect are validated, but this model
+  emitted only the terminal transcript event in the recorded run; no
+  low-latency partial-text claim is made.
+- `torch.compile` is disabled in the validated profile because CUDA Graphs
+  already provided higher throughput with only about 0.14 GiB capture memory.
+- `flash-attn-4` is still installed as a core dependency even though the SM89
+  validation selected FlashInfer and Triton. Making architecture-specific
+  kernels optional remains a repository-wide consumer-installation task.
+- Source installs can log optional Mooncake/NIXL relay warnings when RDMA
+  libraries are absent; those relays are not used by this single-GPU pipeline.
+- Consumer-GPU validation is manual and reproducible; there is no blocking
+  RTX 4090 CI gate.

--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -39,6 +39,9 @@ uv pip install -v -e .   # drop `-e` for a non-editable install
 
 Build the prerequisites first:
 
+- **libnuma runtime** — on Ubuntu/Debian, install it with
+  `apt-get install -y libnuma1`; `sglang-kernel` cannot load without
+  `libnuma.so.1`.
 - **UCX 1.20.x** with CUDA + verbs support — follow [upstream](https://github.com/openucx/ucx), or reuse the exact build flags in [`docker/Dockerfile`](../../docker/Dockerfile).
 - **flash-attn-4** — install `>=4.0.0b9,<4.0.0b16`, matching `torch==2.11.0` and SGLang's `nvidia-cutlass-dsl` pin.
 

--- a/examples/configs/qwen3_asr_rtx4090.yaml
+++ b/examples/configs/qwen3_asr_rtx4090.yaml
@@ -1,0 +1,15 @@
+# Conservative single-GPU profile validated on one RTX 4090 (SM89, 24 GB).
+config_cls: Qwen3ASRPipelineConfig
+name: qwen3-asr-rtx4090
+model_path: Qwen/Qwen3-ASR-1.7B
+
+runtime_overrides:
+  asr:
+    dtype: bfloat16
+    max_running_requests: 16
+
+stage_overrides:
+  asr:
+    runtime:
+      sglang_server_args:
+        mem_fraction_static: 0.65

--- a/sglang_omni/models/qwen3_asr/config.py
+++ b/sglang_omni/models/qwen3_asr/config.py
@@ -15,6 +15,14 @@ class Qwen3ASRPipelineConfig(PipelineConfig):
 
     architecture: ClassVar[str] = "Qwen3ASRForConditionalGeneration"
 
+    @classmethod
+    def mem_fraction_role_to_stage(cls) -> dict[str, str]:
+        return {"asr": "asr"}
+
+    @classmethod
+    def generation_sglang_role_to_stage(cls) -> dict[str, str]:
+        return {"generation": "asr"}
+
     model_path: str
     entry_stage: str = "asr"
     stages: list[StageConfig] = [

--- a/sglang_omni/models/qwen3_asr/request_builders.py
+++ b/sglang_omni/models/qwen3_asr/request_builders.py
@@ -142,7 +142,13 @@ def make_qwen3_asr_scheduler_adapters(
 
     def request_builder(payload: StagePayload) -> Qwen3ASRRequestData:
         params = payload.request.params or {}
-        audio = _load_audio(_audio_source_from_payload(payload))
+        try:
+            audio = _load_audio(_audio_source_from_payload(payload))
+        except Exception as exc:
+            raise ValueError(
+                "Qwen3-ASR could not decode the uploaded audio; provide a valid "
+                "audio file."
+            ) from exc
         audio_duration_s = float(len(audio) / _SAMPLE_RATE)
         fingerprint = audio_fingerprint(audio)
 
@@ -160,9 +166,9 @@ def make_qwen3_asr_scheduler_adapters(
             return_tensors="pt",
             return_attention_mask=True,
             padding="longest",
-            truncation=True,
+            truncation=False,
         )
-        features = extracted.input_features  # [128, true_frames] (<= 3000)
+        features = extracted.input_features  # [128, true_frames]
         feature_attention_mask = getattr(extracted, "attention_mask", None)
         if feature_attention_mask is None:
             # WhisperFeatureExtractor normally returns one; fall back to all-valid.

--- a/sglang_omni/models/qwen3_asr/stages.py
+++ b/sglang_omni/models/qwen3_asr/stages.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from sglang.srt.managers.mm_utils import init_mm_embedding_cache
@@ -25,6 +26,21 @@ from sglang_omni.scheduling.sglang_backend import (
     build_sglang_server_args,
 )
 from sglang_omni.utils.gpu_compat import get_visible_gpu_sm_version
+from sglang_omni.utils.gpu_memory import (
+    format_bytes_gib,
+    get_process_gpu_memory_bytes,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _log_memory_checkpoint(checkpoint: str, gpu_id: int) -> None:
+    logger.info(
+        "Qwen3-ASR memory checkpoint=%s gpu=%d process_gpu_memory=%s",
+        checkpoint,
+        gpu_id,
+        format_bytes_gib(get_process_gpu_memory_bytes(gpu_id)),
+    )
 
 
 def create_sglang_qwen3_asr_executor(
@@ -62,12 +78,15 @@ def create_sglang_qwen3_asr_executor(
         "sampling_backend": "pytorch",
         "dtype": dtype,
     }
+    sm_version = get_visible_gpu_sm_version(gpu_id)
+    mm_backend_reason = "explicit override"
     if mm_attention_backend is not None:
         defaults["mm_attention_backend"] = mm_attention_backend
     else:
-        sm_version = get_visible_gpu_sm_version(gpu_id)
-        if sm_version is not None and sm_version >= 100:
+        mm_backend_reason = "SGLang automatic selection"
+        if sm_version == 89 or (sm_version is not None and sm_version >= 100):
             defaults["mm_attention_backend"] = "triton_attn"
+            mm_backend_reason = f"validated capability policy for SM{sm_version}"
     overrides = build_generation_batch_overrides(
         max_running_requests=max_running_requests,
         server_args_overrides=server_args_overrides,
@@ -83,6 +102,23 @@ def create_sglang_qwen3_asr_executor(
         model_name="Qwen3-ASR",
         server_args=server_args,
     )
+    logger.info(
+        "Qwen3-ASR runtime profile: sm=%s dtype=%s attention_backend=%s "
+        "mm_attention_backend=%s mm_backend_reason=%s cuda_graph=%s "
+        "cuda_graph_bs=%s torch_compile=%s max_running_requests=%s "
+        "mem_fraction_static=%s",
+        sm_version,
+        server_args.dtype,
+        server_args.attention_backend,
+        server_args.mm_attention_backend,
+        mm_backend_reason,
+        not server_args.disable_cuda_graph,
+        server_args.cuda_graph_bs,
+        server_args.enable_torch_compile,
+        server_args.max_running_requests,
+        server_args.mem_fraction_static,
+    )
+    _log_memory_checkpoint("pre_model_load", gpu_id)
 
     want_cuda_graph, (
         model_worker,
@@ -97,9 +133,11 @@ def create_sglang_qwen3_asr_executor(
         gpu_id,
         model_arch_override="Qwen3ASRForConditionalGeneration",
     )
+    _log_memory_checkpoint("post_static_allocation", gpu_id)
 
     if want_cuda_graph:
         model_worker.model_runner.init_device_graphs()
+    _log_memory_checkpoint("post_cuda_graph_capture", gpu_id)
 
     init_mm_embedding_cache(mm_embedding_cache_size_bytes)
 

--- a/sglang_omni/serve/launcher.py
+++ b/sglang_omni/serve/launcher.py
@@ -28,9 +28,11 @@ import asyncio
 import json
 import logging
 import os
+import signal
 import socket
+import threading
 import time
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from typing import Any
 
 import uvicorn
@@ -53,6 +55,35 @@ from sglang_omni.utils.gpu_memory import (
 )
 
 logger = logging.getLogger(__name__)
+
+_HANDLED_SIGNALS = (signal.SIGINT, signal.SIGTERM)
+
+
+class _PipelineUvicornServer(uvicorn.Server):
+    """Keep Uvicorn's graceful handling without re-raising process signals.
+
+    Uvicorn re-raises a captured SIGTERM after HTTP shutdown. That terminates
+    the interpreter before ``_run_server`` can stop spawned pipeline workers.
+    The pipeline launcher owns child-process cleanup, so it restores the
+    original handlers but deliberately consumes the already-handled signal.
+    """
+
+    @contextmanager
+    def capture_signals(self):
+        if threading.current_thread() is not threading.main_thread():
+            yield
+            return
+
+        original_handlers = {
+            sig: signal.signal(sig, self.handle_exit) for sig in _HANDLED_SIGNALS
+        }
+        try:
+            yield
+        finally:
+            for sig, handler in original_handlers.items():
+                signal.signal(sig, handler)
+            self._captured_signals.clear()
+
 
 # ---------------------------------------------------------------------------
 # Built-in pipeline registry
@@ -402,7 +433,7 @@ async def _run_server(
             log_level=log_level,
             timeout_keep_alive=120,
         )
-        server = uvicorn.Server(config)
+        server = _PipelineUvicornServer(config)
         await _serve_with_failure_watch(server, [mp_runner.wait_failed()])
     finally:
         logger.info("Shutting down pipeline …")

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -126,6 +126,7 @@ _BAD_REQUEST_MARKERS = (
     "longer than the model's context length",
     "Requested token count exceeds the model's maximum context length",
     "accepts audio up to",
+    "could not decode the uploaded audio",
     "max_new_tokens must be",
 )
 
@@ -1382,7 +1383,9 @@ async def _speech_audio_response(
             if disconnect_task in done:
                 if not next_chunk_task.done():
                     await _cancel_task_bounded(next_chunk_task)
-                await _abort_and_close_speech_stream(client, request_id, chunk_stream)
+                await _abort_and_close_generation_stream(
+                    client, request_id, chunk_stream
+                )
                 stream_closed = True
                 raise asyncio.CancelledError
 
@@ -1408,11 +1411,11 @@ async def _speech_audio_response(
             raise RuntimeError("No audio output generated from the pipeline.")
     except asyncio.CancelledError:
         if not stream_closed:
-            await _abort_and_close_speech_stream(client, request_id, chunk_stream)
+            await _abort_and_close_generation_stream(client, request_id, chunk_stream)
         raise
     except Exception:
         if not stream_completed:
-            await _abort_and_close_speech_stream(client, request_id, chunk_stream)
+            await _abort_and_close_generation_stream(client, request_id, chunk_stream)
         else:
             await _close_async_iterator_if_supported(chunk_stream)
         raise
@@ -1448,7 +1451,9 @@ async def _speech_audio_response(
             active_request = False
         finally:
             if active_request:
-                await _abort_and_close_speech_stream(client, request_id, chunk_stream)
+                await _abort_and_close_generation_stream(
+                    client, request_id, chunk_stream
+                )
             else:
                 await _close_async_iterator_if_supported(chunk_stream)
 
@@ -1537,7 +1542,7 @@ async def _close_async_iterator_if_supported(stream: AsyncIterator[Any]) -> None
     await close()
 
 
-async def _abort_and_close_speech_stream(
+async def _abort_and_close_generation_stream(
     client: Client,
     request_id: str,
     stream: AsyncIterator[Any],
@@ -1678,8 +1683,11 @@ async def _transcription_stream(
     post-processed transcript.
     """
     final_text: str | None = None
+    stream = client.generate(gen_req, request_id=request_id)
+    stream_completed = False
+    stream_closed = False
     try:
-        async for chunk in client.generate(gen_req, request_id=request_id):
+        async for chunk in stream:
             if chunk.finish_reason is not None:
                 if isinstance(chunk.text, str) and chunk.text:
                     final_text = chunk.text
@@ -1687,11 +1695,23 @@ async def _transcription_stream(
             if chunk.modality == "text" and chunk.text:
                 event = TranscriptionTextDeltaEvent(delta=chunk.text)
                 yield f"data: {event.model_dump_json(exclude_none=True)}\n\n"
+        stream_completed = True
+    except asyncio.CancelledError:
+        await _abort_and_close_generation_stream(client, request_id, stream)
+        stream_closed = True
+        raise
     except Exception as exc:
+        await _abort_and_close_generation_stream(client, request_id, stream)
+        stream_closed = True
         logger.exception("Error streaming transcription for request %s", request_id)
         payload = {"type": "error", "error": {"message": str(exc)}}
         yield f"data: {json.dumps(payload)}\n\n"
         return
+    finally:
+        if stream_completed:
+            await _close_async_iterator_if_supported(stream)
+        elif not stream_closed:
+            await _abort_and_close_generation_stream(client, request_id, stream)
 
     text = adapter.postprocess_text(final_text or "")
     usage = (

--- a/tests/unit_test/benchmarks/test_dataset_regressions.py
+++ b/tests/unit_test/benchmarks/test_dataset_regressions.py
@@ -102,9 +102,10 @@ def test_load_seedtts_samples_stages_only_selected_rows(
     stage_dir = tmp_path / "seedtts_stage"
     stage_dir.mkdir()
 
-    def fake_load_dataset(repo_id: str, split: str):
+    def fake_load_dataset(repo_id: str, split: str, revision: str | None = None):
         assert repo_id == "zhaochenyang20/seed-tts-eval-arrow"
         assert split == "en"
+        assert revision == prepare.SEEDTTS_DATASET_REVISION
         return dataset
 
     monkeypatch.setitem(
@@ -122,6 +123,7 @@ def test_load_seedtts_samples_stages_only_selected_rows(
         "zhaochenyang20/seed-tts-eval-arrow",
         max_samples=2,
         split="en",
+        revision=prepare.SEEDTTS_DATASET_REVISION,
     )
 
     assert dataset.selected_indices == [0, 1]

--- a/tests/unit_test/benchmarks/test_runtime_metrics.py
+++ b/tests/unit_test/benchmarks/test_runtime_metrics.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from benchmarks.runtime_metrics import ResourceSample, summarize_resource_samples
+
+
+def test_summarize_resource_samples_reports_peak_and_steady_values() -> None:
+    samples = [
+        ResourceSample(
+            elapsed_s=0.0,
+            gpu_memory_used_mib=100.0,
+            gpu_memory_free_mib=900.0,
+            gpu_process_memory_mib=80.0,
+            gpu_util_percent=10.0,
+            power_w=20.0,
+            system_cpu_percent=5.0,
+            gpu_process_cpu_percent=25.0,
+            gpu_process_pids=(11,),
+        ),
+        ResourceSample(
+            elapsed_s=1.0,
+            gpu_memory_used_mib=200.0,
+            gpu_memory_free_mib=800.0,
+            gpu_process_memory_mib=180.0,
+            gpu_util_percent=90.0,
+            power_w=120.0,
+            system_cpu_percent=15.0,
+            gpu_process_cpu_percent=125.0,
+            gpu_process_pids=(11, 22),
+        ),
+    ]
+
+    result = summarize_resource_samples(samples, interval_s=1.0)
+
+    assert result["available"] is True
+    assert result["gpu_memory_used_mib"] == {
+        "min": 100.0,
+        "max": 200.0,
+        "end": 200.0,
+        "steady_mean": 150.0,
+    }
+    assert result["gpu_process_memory_mib"]["max"] == 180.0
+    assert result["power_w"]["max"] == 120.0
+    assert result["gpu_process_cpu_percent"]["max"] == 125.0
+    assert result["gpu_process_pids"] == [11, 22]
+
+
+def test_summarize_resource_samples_reports_unavailable_monitor() -> None:
+    result = summarize_resource_samples([], interval_s=0.2, error="NVML unavailable")
+
+    assert result == {
+        "available": False,
+        "sample_interval_s": 0.2,
+        "samples": 0,
+        "error": "NVML unavailable",
+    }

--- a/tests/unit_test/pipeline/test_ipc.py
+++ b/tests/unit_test/pipeline/test_ipc.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import signal
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -555,6 +556,22 @@ async def test_launcher_stops_runner_when_server_raises(
         )
 
     server_serve.assert_awaited_once()
+
+
+def test_pipeline_uvicorn_server_consumes_handled_sigterm() -> None:
+    from sglang_omni.serve import launcher
+
+    server = launcher._PipelineUvicornServer(
+        launcher.uvicorn.Config(FastAPI(), port=8000)
+    )
+    original_handler = signal.getsignal(signal.SIGTERM)
+
+    with server.capture_signals():
+        server.handle_exit(signal.SIGTERM, None)
+        assert server.should_exit
+
+    assert server._captured_signals == []
+    assert signal.getsignal(signal.SIGTERM) is original_handler
 
 
 @pytest.mark.asyncio

--- a/tests/unit_test/qwen3_asr/test_pipeline.py
+++ b/tests/unit_test/qwen3_asr/test_pipeline.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import inspect
+from pathlib import Path
 from types import SimpleNamespace
 
 import sglang_omni.models.qwen3_asr.stages as qwen3_asr_stages
+from sglang_omni.config.manager import ConfigManager
+from sglang_omni.config.runtime import resolve_stage_static_factory_args
 from sglang_omni.models.qwen3_asr.config import Qwen3ASRPipelineConfig
 from sglang_omni.models.qwen3_asr.stages import create_sglang_qwen3_asr_executor
 from sglang_omni.models.registry import PIPELINE_CONFIG_REGISTRY
@@ -24,6 +27,10 @@ def test_qwen3_asr_config_uses_batched_stage_with_32_running_requests() -> None:
     assert config.stages[0].factory_args["request_build_max_workers"] == 2
     assert config.stages[0].factory_args["request_build_max_pending"] == 16
     assert "request_build_max_backlog" not in config.stages[0].factory_args
+    assert Qwen3ASRPipelineConfig.mem_fraction_role_to_stage() == {"asr": "asr"}
+    assert Qwen3ASRPipelineConfig.generation_sglang_role_to_stage() == {
+        "generation": "asr"
+    }
     assert (
         PIPELINE_CONFIG_REGISTRY.get_config("Qwen3ASRForConditionalGeneration")
         is Qwen3ASRPipelineConfig
@@ -57,6 +64,20 @@ def test_qwen3_asr_stage_default_disables_torch_compile() -> None:
     assert signature.parameters["enable_torch_compile"].default is False
 
 
+def test_qwen3_asr_rtx4090_profile_is_bf16_and_bounded() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    config = ConfigManager.from_file(
+        str(repo_root / "examples/configs/qwen3_asr_rtx4090.yaml")
+    ).config
+    stage = config.stages[0]
+
+    factory_args = resolve_stage_static_factory_args(stage, config)
+
+    assert factory_args["dtype"] == "bfloat16"
+    assert factory_args["max_running_requests"] == 16
+    assert factory_args["server_args_overrides"]["mem_fraction_static"] == 0.65
+
+
 def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
     build_kwargs: dict[str, object] = {}
 
@@ -73,7 +94,12 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
     monkeypatch.setattr(
         qwen3_asr_stages,
         "get_visible_gpu_sm_version",
-        lambda gpu_id: None,
+        lambda gpu_id: 89,
+    )
+    monkeypatch.setattr(
+        qwen3_asr_stages,
+        "get_process_gpu_memory_bytes",
+        lambda gpu_id: 0,
     )
     monkeypatch.setattr(qwen3_asr_stages, "init_mm_embedding_cache", lambda size: None)
     monkeypatch.setattr(
@@ -99,7 +125,12 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
 
     def _fake_server_args_builder(model_path, context_length, **overrides):
         build_kwargs.update(overrides)
-        return SimpleNamespace(**overrides)
+        values = {
+            "attention_backend": "flashinfer",
+            "mm_attention_backend": None,
+        }
+        values.update(overrides)
+        return SimpleNamespace(**values)
 
     def _fake_create_infrastructure(server_args, gpu_id, **kwargs):
         model_worker = SimpleNamespace(model_runner=SimpleNamespace(model=object()))
@@ -128,3 +159,4 @@ def test_qwen3_asr_threads_explicit_cuda_graph_bs(monkeypatch) -> None:
 
     assert build_kwargs["cuda_graph_max_bs"] == 32
     assert build_kwargs["cuda_graph_bs"] == [1, 2, 4, 8, 12, 16, 24, 32]
+    assert build_kwargs["mm_attention_backend"] == "triton_attn"

--- a/tests/unit_test/qwen3_asr/test_request_builders.py
+++ b/tests/unit_test/qwen3_asr/test_request_builders.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 import torch
 
 import sglang_omni.models.qwen3_asr.request_builders as request_builders
@@ -115,6 +116,27 @@ def test_qwen3_asr_request_builder_records_inclusive_audio_offsets(monkeypatch) 
     assert data.prompt_token_ids[start : end + 1] == (
         [audio_item.pad_value] * num_audio_tokens
     )
+
+
+def test_qwen3_asr_request_builder_rejects_undecodable_audio(monkeypatch) -> None:
+    monkeypatch.setattr(
+        request_builders,
+        "_load_audio",
+        lambda source: (_ for _ in ()).throw(RuntimeError("decode failed")),
+    )
+    request_builder, _ = make_qwen3_asr_scheduler_adapters(
+        tokenizer=_FakeTokenizer(),
+        max_new_tokens=32,
+        feature_extractor=object(),
+    )
+    payload = StagePayload(
+        request_id="req-invalid",
+        request=OmniRequest(inputs={"audio_bytes": b"not-audio"}),
+        data={},
+    )
+
+    with pytest.raises(ValueError, match="could not decode the uploaded audio"):
+        request_builder(payload)
 
 
 def test_qwen3_asr_result_adapter_decodes_without_text_round_trip() -> None:

--- a/tests/unit_test/serve/test_openai_api.py
+++ b/tests/unit_test/serve/test_openai_api.py
@@ -25,6 +25,7 @@ from sglang_omni.serve.openai_api import (
     _build_chat_generate_request,
     _chat_stream,
     _speech_audio_response,
+    _transcription_stream,
     build_transcription_generate_request,
 )
 from sglang_omni.serve.protocol import ChatCompletionRequest, CreateSpeechRequest
@@ -267,6 +268,29 @@ class SuccessfulTranscriptionClient:
         del request_id, audio_format
         self.requests.append(request)
         return CompletionResult(request_id="transcription-1", text="hello world")
+
+
+class BlockingStreamingTranscriptionClient:
+    def __init__(self) -> None:
+        self.aborted: list[str] = []
+
+    async def generate(self, request: Any, request_id: str | None = None):
+        del request
+        yield GenerateChunk(
+            request_id=request_id or "transcription-1",
+            modality="text",
+            text="hello",
+            finish_reason=None,
+        )
+        await asyncio.Future()
+
+    async def abort(self, request_id: str) -> None:
+        self.aborted.append(request_id)
+
+
+class _IdentityTranscriptionAdapter:
+    def postprocess_text(self, text: str) -> str:
+        return text
 
 
 class AdminClient:
@@ -1016,6 +1040,34 @@ def test_transcription_endpoint_returns_text_json() -> None:
     assert request.model == "openai/whisper-large-v3"
     assert request.prompt["filename"] == "sample.wav"
     assert request.extra_params["language"] == "en"
+
+
+@pytest.mark.asyncio
+async def test_transcription_stream_aborts_when_consumer_closes() -> None:
+    transcription_client = BlockingStreamingTranscriptionClient()
+    request = build_transcription_generate_request(
+        audio_bytes=b"RIFF",
+        filename="sample.wav",
+        content_type="audio/wav",
+        model="Qwen/Qwen3-ASR-1.7B",
+        language="en",
+        prompt=None,
+        temperature=None,
+        stream=True,
+    )
+    stream = _transcription_stream(
+        transcription_client,
+        request,
+        request_id="transcription-disconnect",
+        adapter=_IdentityTranscriptionAdapter(),
+        duration_s=1.0,
+    )
+
+    first_event = await anext(stream)
+    assert "transcript.text.delta" in first_event
+    await stream.aclose()
+
+    assert transcription_client.aborted == ["transcription-disconnect"]
 
 
 def test_transcription_endpoint_maps_bad_request_error_to_400() -> None:


### PR DESCRIPTION
## Summary
- add the measured BF16/SM89 profile and runtime diagnostics used for the single-RTX-4090 validation
- add pinned, provenance-rich EN/ZH benchmarks and a 30-minute mixed stability harness
- preserve full audio beyond Whisper's former 30-second preprocessing boundary and report genuine context limits separately
- include lifecycle/input fixes, tests, documentation, and measured results

## Validation
- Full SeedTTS EN: 1088/1088 samples at each concurrency, WER 0.0120-0.0123
- Full SeedTTS ZH: 2020/2020 samples at each concurrency, CER 0.0062
- 30-minute c=1/4/8/16 soak: 78,418 successful requests, zero unexpected errors
- Original soak peak sampled GPU memory: 17,990 MiB on one RTX 4090
- Targeted post-#1176/#1193 RTX 4090 validation:
  - 31-second input: 3/3 HTTP 200, identical 80-word transcript
  - 60-second input: 3/3 HTTP 200, identical 146-word transcript
  - 124.91-second over-context input: 3/3 HTTP 400 before mel extraction (`1637 + 128 > 1636` tokens)
  - targeted-run peak GPU memory: 17,464 MiB; minimum free memory: 6,618 MiB

The full SeedTTS sweeps and 30-minute short-clip soak were not repeated. All corpus samples completed while the 30-second guard was active, and `truncation=False` is behaviorally unchanged for those inputs.

## Incremental review PRs
- #1153 — generic stream cancellation and SIGTERM lifecycle fixes
- #1154 — Qwen3-ASR SM89 profile, diagnostics, and malformed-input handling; blocked by #1176
- #1155 — pinned benchmark provenance, resource monitoring, stability harness, and results
- #1176 — correctness fix preserving audio beyond 30 seconds with `truncation=False`
- #1193 — proactive context-capacity validation and HTTP 400 error mapping

The incremental PRs are the intended review and merge path. This Draft preserves the complete validation diff in one place and should not be merged independently. It should be synchronized after #1176 and #1193 land.

## Test plan
- [x] `python -m pytest -q tests/unit_test/qwen3_asr tests/unit_test/benchmarks` — 50 passed
- [x] full SeedTTS EN and ZH, three measured repeats after warmup
- [x] 30-minute mixed-concurrency stability run
- [x] targeted 31-second, 60-second, and over-context RTX 4090 validation
- [x] SIGTERM worker/GPU cleanup

Resource measurements use `nvidia-smi`; `ncu` kernel profiling is unavailable in the Runpod container because admin-only profiling is enabled without `CAP_SYS_ADMIN`.

## Tracking
- Benchmark report: #1151
- Parent roadmap: #1120
- Raw original benchmark artifacts: https://gist.github.com/wirybeaver/ec331dad6e2caa2b32f1cd44f5a761e5