### PR TITLE
feat(qwen3-tts): add experimental RTX 4090 profile

### DIFF
--- a/docs/cookbook/qwen3_tts.md
+++ b/docs/cookbook/qwen3_tts.md
@@ -55,6 +55,29 @@ sgl-omni serve \
   --port 8000
 ```
 
+### Experimental RTX 4090 24 GB Profile
+
+The 0.6B Base checkpoint has a bounded single-GPU profile for a 24 GB RTX 4090:
+
+```bash
+sgl-omni serve \
+  --config examples/configs/qwen3_tts_0_6b_4090_24gb.yaml \
+  --port 8000
+```
+
+The profile limits admission and CUDA Graph capture to batch size 8, reserves
+75% of device memory for the SGLang engine, and disables `torch.compile`. The
+compile-off setting is intentional: the original [RTX 4090 smoke
+run](https://github.com/sgl-project/sglang-omni/pull/1156#issuecomment-5056169521)
+reduced graph-capture time from 101.37 seconds to 2.94 seconds and reduced the
+observed concurrency-8 peak from 20,241 MiB to 19,729 MiB.
+
+This is an experimental functional profile, not a general consumer-GPU or
+quality-validation claim. The source run covered short reference-audio requests
+at concurrency 1, 2, 4, and 8, but did not record a pinned checkpoint revision
+or complete the quality, long-form, and sustained-load gates in
+[the consumer-GPU roadmap](https://github.com/sgl-project/sglang-omni/issues/1120).
+
 ## Synthesizing Speech
 
 ### Text-only Requests

--- a/examples/configs/qwen3_tts_0_6b_4090_24gb.yaml
+++ b/examples/configs/qwen3_tts_0_6b_4090_24gb.yaml
@@ -12,6 +12,13 @@ runtime_overrides:
   tts_engine:
     server_args_overrides:
       max_running_requests: 8
-      mem_fraction_static: 0.75
       cuda_graph_bs: [1, 2, 4, 8]
       cuda_graph_max_bs: 8
+      disable_cuda_graph: false
+      enable_torch_compile: false
+
+stage_overrides:
+  tts_engine:
+    runtime:
+      sglang_server_args:
+        mem_fraction_static: 0.75

--- a/examples/configs/qwen3_tts_0_6b_4090_24gb.yaml
+++ b/examples/configs/qwen3_tts_0_6b_4090_24gb.yaml
@@ -1,0 +1,17 @@
+# Experimental single-RTX-4090 (24GB) profile for Qwen3-TTS 0.6B Base.
+#
+# This profile deliberately bounds the SGLang AR stage below the model-family
+# defaults. The values are a validation target, not a claim of general
+# consumer-GPU support; see #1120 for the roadmap context.
+
+config_cls: Qwen3TTSPipelineConfig
+name: qwen3-tts-0.6b-4090-24gb
+model_path: Qwen/Qwen3-TTS-12Hz-0.6B-Base
+
+runtime_overrides:
+  tts_engine:
+    server_args_overrides:
+      max_running_requests: 8
+      mem_fraction_static: 0.75
+      cuda_graph_bs: [1, 2, 4, 8]
+      cuda_graph_max_bs: 8

--- a/tests/README.md
+++ b/tests/README.md
@@ -473,6 +473,7 @@ that happened to contain an older version of the test.
 
 - `unit_test/qwen3_tts/`: Qwen3-TTS unit tests:
   - pipeline config and registry contracts
+  - bounded RTX 4090 profile parsing, including compile and CUDA Graph policy
   - OmniScheduler-backed AR stage factory wiring
   - request mapping for `ref_audio` / `ref_text` and `references`
   - model-owned default preservation for language and sampling parameters

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -7,6 +7,7 @@ import sys
 import threading
 import types
 from collections import deque
+from pathlib import Path
 from queue import Queue
 from types import SimpleNamespace
 
@@ -14,6 +15,8 @@ import numpy as np
 import pytest
 import torch
 
+from sglang_omni.config.manager import ConfigManager
+from sglang_omni.config.runtime import resolve_stage_static_factory_args
 from sglang_omni.models.qwen3_omni.pending_text_queue import PendingTextTensorQueue
 from sglang_omni.models.qwen3_tts import request_builders as qwen3_request_builders
 from sglang_omni.models.qwen3_tts.config import Qwen3TTSPipelineConfig
@@ -2253,6 +2256,26 @@ def test_qwen3_tts_engine_probes_runtime_before_checkpoint_resolution(
         )
 
     assert checkpoint_resolutions == []
+
+
+def test_qwen3_tts_rtx4090_profile_is_bf16_and_bounded() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    config = ConfigManager.from_file(
+        str(repo_root / "examples/configs/qwen3_tts_0_6b_4090_24gb.yaml")
+    ).config
+    tts_engine = next(stage for stage in config.stages if stage.name == "tts_engine")
+
+    factory_args = resolve_stage_static_factory_args(tts_engine, config)
+    server_args = factory_args["server_args_overrides"]
+
+    assert config.model_path == "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
+    assert factory_args["dtype"] == "bfloat16"
+    assert server_args["max_running_requests"] == 8
+    assert server_args["mem_fraction_static"] == 0.75
+    assert server_args["cuda_graph_bs"] == [1, 2, 4, 8]
+    assert server_args["cuda_graph_max_bs"] == 8
+    assert server_args["disable_cuda_graph"] is False
+    assert server_args["enable_torch_compile"] is False
 
 
 def test_qwen3_tts_mem_fraction_role_to_stage_targets_tts_engine() -> None:


### PR DESCRIPTION
## Summary

- add an experimental single-RTX-4090 (24 GB) profile for Qwen3-TTS 0.6B Base
- bound admission, static memory, and CUDA Graph capture to the hardware-tested limits
- pin `torch.compile` off because the measured compile-off path captured faster and used less peak memory
- document the exact scope and exercise the profile through the production config resolver

## Profile

- `max_running_requests: 8`
- `mem_fraction_static: 0.75` through the typed stage-runtime contract
- `cuda_graph_bs: [1, 2, 4, 8]`
- `cuda_graph_max_bs: 8`
- CUDA Graph enabled
- `torch.compile` disabled

Explicit CLI/runtime overrides still take precedence over these file defaults.

## Ownership and dependencies

This is the model-local Qwen3-TTS 0.6B profile slice of #1120. It is rebased onto current `main` and does not duplicate the shared architecture/dependency work in #1199 or the cross-model low-memory fallbacks in #1198. It can merge independently; no automatic GPU detection or shared framework policy is added.

## Hardware evidence

Original functional smoke on one RTX 4090 (24,564 MiB), driver 580.105.08:

- short Base reference-audio requests at concurrency 1/2/4/8 all returned HTTP 200 with valid 24 kHz mono WAV files
- compile off: 2.94-second CUDA Graph capture and 19,729 MiB peak at concurrency 8
- compile on: 101.37-second capture and 20,241 MiB peak at concurrency 8

The source run did not record a pinned model revision or complete quality, long-form, or sustained-load validation. This remains an experimental Functional profile, not a general consumer-GPU support claim.

## Validation

- `pytest tests/unit_test/qwen3_tts/test_pipeline.py -q -k 'rtx4090_profile or mem_fraction_role_to_stage or cli_mem_fraction_static or cli_talker_mem_fraction or cli_rejects_unsupported_thinker'` — 5 passed
- changed-file Black, isort, AST, and YAML hooks — passed
- architecture drift hook — no baseline update required

## Tracking

- #1120
