### PR TITLE
[Qwen3-Omni Perf] Code2Wav: CUDA-graph shape hit-rate telemetry

### DIFF
--- a/docs/basic_usage/qwen3_omni.md
+++ b/docs/basic_usage/qwen3_omni.md
@@ -173,6 +173,26 @@ sgl-omni serve \
 
 Use `examples/configs/qwen3_omni_colocated_h200.yaml` on single-H200 workers.
 
+Exact-shape CUDA Graph replay is enabled by default for Qwen3-Omni Code2Wav.
+The default stage config supplies a 2% typed GPU memory budget; colocated
+example configs override it with their hardware-specific budget.
+
+To disable replay, add this runtime override to the YAML config:
+
+```yaml
+runtime_overrides:
+  code2wav:
+    enable_cuda_graph: false
+```
+
+When replay is enabled, a custom Code2Wav stage must define
+`runtime.resources.total_gpu_memory_fraction`; startup rejects a missing typed
+budget before loading the model.
+
+The feature captures only the current serial serving windows
+`B1/T{10,20,30,35}`. Unsupported shapes and final stream tails run eagerly.
+Capture-time incompatibilities also fall back to eager execution.
+
 For manual multi-GPU placement, use the example script:
 
 ```bash

--- a/docs/basic_usage/qwen3_omni.md
+++ b/docs/basic_usage/qwen3_omni.md
@@ -193,6 +193,19 @@ The feature captures only the current serial serving windows
 `B1/T{10,20,30,35}`. Unsupported shapes and final stream tails run eagerly.
 Capture-time incompatibilities also fall back to eager execution.
 
+To observe the graph hit rate under serving traffic, enable per-shape telemetry:
+
+```bash
+SGLANG_OMNI_TRACE_CODE2WAV_GRAPH=1 sgl-omni serve \
+  --model-path Qwen/Qwen3-Omni-30B-A3B-Instruct \
+  --config examples/configs/qwen3_omni_colocated_h20.yaml \
+  --colocate
+```
+
+The Code2Wav stage logs cumulative graph replays and eager fallbacks, grouped
+by batch size, frame count, and fallback reason. It reports every 2,000
+executions and once when the scheduler exits. Telemetry is disabled by default.
+
 For manual multi-GPU placement, use the example script:
 
 ```bash

--- a/sglang_omni/models/qwen3_omni/components/code2wav_cuda_graph.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_cuda_graph.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import gc
+import json
 import logging
 import math
 import os
@@ -16,6 +17,10 @@ from typing import Any
 import torch
 
 logger = logging.getLogger(__name__)
+
+_CODE2WAV_GRAPH_TRACE_ENV = "SGLANG_OMNI_TRACE_CODE2WAV_GRAPH"
+_CODE2WAV_GRAPH_TRACE_REPORT_INTERVAL = 2000
+_FALSE_ENV_VALUES = {"", "0", "false", "no", "off"}
 
 
 @dataclass(frozen=True, slots=True)
@@ -183,6 +188,15 @@ class Code2WavCudaGraphRunner:
         self._fallback_counts: Counter[str] = Counter()
         self._graph_replays = 0
         self._replay_failures = 0
+        trace_value = os.getenv(_CODE2WAV_GRAPH_TRACE_ENV, "")
+        self._shape_trace_enabled = trace_value.strip().lower() not in _FALSE_ENV_VALUES
+        self._shape_graph_counts: Counter[GraphKey] | None = (
+            Counter() if self._shape_trace_enabled else None
+        )
+        self._shape_fallback_counts: Counter[tuple[GraphKey, str]] | None = (
+            Counter() if self._shape_trace_enabled else None
+        )
+        self._shape_trace_executions = 0
 
     @classmethod
     def build(
@@ -442,6 +456,8 @@ class Code2WavCudaGraphRunner:
             self._disable_runtime(reason)
             raise
         self._graph_replays += 1
+        if self._shape_trace_enabled:
+            self._record_shape_execution(key=key, fallback_reason=None)
         return Code2WavRunResult(
             output=captured.static_output,
             execution_mode="cuda_graph",
@@ -473,6 +489,11 @@ class Code2WavCudaGraphRunner:
         self._fallback_counts[reason] += 1
         with torch.inference_mode():
             output = self._model(codes)
+        if self._shape_trace_enabled:
+            self._record_shape_execution(
+                key=self._shape_key_if_available(codes),
+                fallback_reason=reason,
+            )
         return Code2WavRunResult(
             output=output,
             execution_mode="eager",
@@ -497,8 +518,109 @@ class Code2WavCudaGraphRunner:
             )
         logger.exception("Code2Wav CUDA graph replay disabled the runner")
 
+    @staticmethod
+    def _shape_key_if_available(codes: torch.Tensor) -> GraphKey | None:
+        """Return the graph lookup shape without imposing graph validation."""
+
+        if codes.ndim != 3:
+            return None
+        return GraphKey(
+            batch_size=int(codes.shape[0]),
+            frames=int(codes.shape[2]),
+        )
+
+    def _record_shape_execution(
+        self,
+        *,
+        key: GraphKey | None,
+        fallback_reason: str | None,
+    ) -> None:
+        # Standard Code2Wav inputs are always [B, Q, T]. Avoid letting optional
+        # observability change eager behavior for an unexpected model input.
+        if key is None:
+            return
+        graph_counts = self._shape_graph_counts
+        fallback_counts = self._shape_fallback_counts
+        assert graph_counts is not None
+        assert fallback_counts is not None
+        if fallback_reason is None:
+            graph_counts[key] += 1
+        else:
+            fallback_counts[(key, fallback_reason)] += 1
+        self._shape_trace_executions += 1
+        if self._shape_trace_executions % _CODE2WAV_GRAPH_TRACE_REPORT_INTERVAL == 0:
+            self.log_shape_telemetry(trigger="periodic")
+
+    def _shape_telemetry_stats(self) -> dict[str, Any]:
+        graph_counts = self._shape_graph_counts
+        fallback_counts = self._shape_fallback_counts
+        assert graph_counts is not None
+        assert fallback_counts is not None
+
+        fallbacks_by_key: dict[GraphKey, dict[str, int]] = {}
+        for (key, reason), count in sorted(
+            fallback_counts.items(),
+            key=lambda item: (
+                item[0][0].batch_size,
+                item[0][0].frames,
+                item[0][1],
+            ),
+        ):
+            fallbacks_by_key.setdefault(key, {})[reason] = count
+
+        keys = set(graph_counts) | set(fallbacks_by_key)
+        shapes: list[dict[str, Any]] = []
+        for key in sorted(keys, key=lambda item: (item.batch_size, item.frames)):
+            graph_replays = graph_counts[key]
+            per_reason = fallbacks_by_key.get(key, {})
+            eager_fallbacks = sum(per_reason.values())
+            total = graph_replays + eager_fallbacks
+            shapes.append(
+                {
+                    "batch_size": key.batch_size,
+                    "frames": key.frames,
+                    "graph_replays": graph_replays,
+                    "eager_fallbacks": eager_fallbacks,
+                    "fallback_counts": per_reason,
+                    "hit_rate": graph_replays / total,
+                }
+            )
+
+        graph_replays = sum(graph_counts.values())
+        eager_fallbacks = sum(fallback_counts.values())
+        total = graph_replays + eager_fallbacks
+        return {
+            "total_executions": total,
+            "graph_replays": graph_replays,
+            "eager_fallbacks": eager_fallbacks,
+            "hit_rate": graph_replays / total if total else None,
+            "shapes": shapes,
+        }
+
+    def log_shape_telemetry(self, *, trigger: str) -> None:
+        """Log one cumulative per-shape snapshot when tracing is enabled."""
+
+        if not self._shape_trace_enabled:
+            return
+        stats = self._shape_telemetry_stats()
+        if not stats["total_executions"]:
+            return
+        logger.info(
+            "Code2Wav CUDA graph shape telemetry trigger=%s stats=%s",
+            trigger,
+            json.dumps(stats, sort_keys=True, separators=(",", ":")),
+        )
+
     def stats(self) -> dict[str, Any]:
         """Return a strict JSON-safe snapshot of build and runtime state."""
+
+        runtime: dict[str, Any] = {
+            "graph_replays": self._graph_replays,
+            "replay_failures": self._replay_failures,
+            "fallback_counts": dict(sorted(self._fallback_counts.items())),
+        }
+        if self._shape_trace_enabled:
+            runtime["shape_telemetry"] = self._shape_telemetry_stats()
 
         return {
             "enabled": self._enabled,
@@ -520,11 +642,7 @@ class Code2WavCudaGraphRunner:
             },
             "build": deepcopy(self._build_stats),
             "memory": deepcopy(self._memory_stats),
-            "runtime": {
-                "graph_replays": self._graph_replays,
-                "replay_failures": self._replay_failures,
-                "fallback_counts": dict(sorted(self._fallback_counts.items())),
-            },
+            "runtime": runtime,
         }
 
 

--- a/sglang_omni/models/qwen3_omni/components/code2wav_cuda_graph.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_cuda_graph.py
@@ -1,0 +1,536 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exact-shape CUDA graphs for the Qwen3-Omni Code2Wav component."""
+
+from __future__ import annotations
+
+import gc
+import logging
+import math
+import os
+from collections import Counter
+from contextlib import AbstractContextManager
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class GraphKey:
+    """One exact Code2Wav input shape, excluding fixed quantizer count."""
+
+    batch_size: int
+    frames: int
+
+
+CODE2WAV_GRAPH_KEYS = tuple(
+    GraphKey(batch_size=1, frames=frames) for frames in (10, 20, 30, 35)
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Code2WavRunResult:
+    """Result metadata for either an exact graph replay or eager fallback.
+
+    A ``cuda_graph`` output is a borrowed static buffer. The caller must finish
+    all reads, including trim and device-to-host transfer, before the next graph
+    replay. It must not retain the tensor or use it concurrently. The current
+    scheduler's outer ``_state_lock`` is intended to cover that whole lifetime;
+    this runner deliberately does not clone the output.
+    """
+
+    output: torch.Tensor
+    execution_mode: str
+    key: GraphKey | None
+    fallback_reason: str | None
+
+
+@dataclass(slots=True)
+class _CapturedGraph:
+    graph: Any
+    static_input: torch.Tensor
+    static_output: torch.Tensor
+
+
+class _BuildFailure(RuntimeError):
+    pass
+
+
+class _TorchCudaApi:
+    """Small injectable boundary around CUDA-only operations."""
+
+    def device_context(self, device: torch.device) -> AbstractContextManager[Any]:
+        return torch.cuda.device(device)
+
+    def memory_stats(self, device: torch.device) -> dict[str, int]:
+        free_bytes, total_bytes = torch.cuda.mem_get_info(device)
+        return {
+            "allocated_bytes": int(torch.cuda.memory_allocated(device)),
+            "reserved_bytes": int(torch.cuda.memory_reserved(device)),
+            "max_reserved_bytes": int(torch.cuda.max_memory_reserved(device)),
+            "free_bytes": int(free_bytes),
+            "total_bytes": int(total_bytes),
+        }
+
+    def empty_cache(self) -> None:
+        torch.cuda.empty_cache()
+
+    def new_static_input(
+        self, shape: tuple[int, int, int], *, device: torch.device
+    ) -> torch.Tensor:
+        return torch.zeros(shape, dtype=torch.long, device=device)
+
+    def new_stream(self, device: torch.device) -> torch.cuda.Stream:
+        return torch.cuda.Stream(device=device)
+
+    def warmup(
+        self,
+        model: Any,
+        static_input: torch.Tensor,
+        *,
+        iterations: int,
+        device: torch.device,
+        stream: torch.cuda.Stream,
+    ) -> None:
+        current_stream = torch.cuda.current_stream(device)
+        stream.wait_stream(current_stream)
+        with torch.cuda.stream(stream), torch.inference_mode():
+            for _ in range(iterations):
+                model(static_input)
+        current_stream.wait_stream(stream)
+
+    def graph_pool_handle(self) -> Any:
+        return torch.cuda.graph_pool_handle()
+
+    def capture(
+        self,
+        model: Any,
+        static_input: torch.Tensor,
+        *,
+        pool: Any,
+        stream: torch.cuda.Stream,
+    ) -> tuple[torch.cuda.CUDAGraph, torch.Tensor]:
+        current_stream = torch.cuda.current_stream(static_input.device)
+        stream.wait_stream(current_stream)
+        graph = torch.cuda.CUDAGraph()
+        try:
+            with torch.inference_mode():
+                with torch.cuda.graph(
+                    graph,
+                    pool=pool,
+                    stream=stream,
+                    capture_error_mode="thread_local",
+                ):
+                    static_output = model(static_input)
+        finally:
+            # torch.cuda.graph.__exit__ calls capture_end before restoring its
+            # stream context. If capture_end raises, restore explicitly using
+            # the original stream's device-aware identity.
+            torch.cuda.set_stream(current_stream)
+        current_stream.wait_stream(stream)
+        return graph, static_output
+
+    def synchronize(self, device: torch.device) -> None:
+        torch.cuda.synchronize(device)
+
+    def is_cuda_tensor(self, tensor: torch.Tensor) -> bool:
+        return tensor.is_cuda
+
+    def tensor_device_matches(self, tensor: torch.Tensor, device: torch.device) -> bool:
+        return tensor.device == device
+
+
+class Code2WavCudaGraphRunner:
+    """Atomic exact-shape CUDA graph runner for ``[B, Q, T]`` long codes.
+
+    One instance is permanently bound to one model, CUDA device, quantizer
+    count, ``torch.long`` input dtype, and owner process. Build failures disable
+    the complete runner and leave no partial graph matrix published.
+    """
+
+    _WARMUP_ITERATIONS = 3
+
+    def __init__(
+        self,
+        model: Any,
+        *,
+        device: str | torch.device,
+        num_quantizers: int,
+        cuda_api: Any,
+    ) -> None:
+        self._model = model
+        self._device = torch.device(device)
+        if self._device.type != "cuda" or self._device.index is None:
+            raise ValueError("Code2Wav CUDA graphs require a concrete CUDA device")
+        self._num_quantizers = int(num_quantizers)
+        if self._num_quantizers <= 0:
+            raise ValueError("Code2Wav CUDA graphs require a positive quantizer count")
+        self._owner_pid = os.getpid()
+        self._cuda = cuda_api
+        self._graphs: dict[GraphKey, _CapturedGraph] = {}
+        self._pool: Any | None = None
+        self._capture_stream: Any | None = None
+        self._enabled = False
+        self._disable_reason: str | None = None
+        self._build_stats: dict[str, Any] = {
+            "attempted_graph_count": 0,
+            "published_graph_count": 0,
+        }
+        self._memory_stats: dict[str, Any] = {"total_gpu_memory_fraction": None}
+        self._fallback_counts: Counter[str] = Counter()
+        self._graph_replays = 0
+        self._replay_failures = 0
+
+    @classmethod
+    def build(
+        cls,
+        model: Any,
+        *,
+        device: str | torch.device,
+        num_quantizers: int,
+        total_gpu_memory_fraction: float | None,
+        cuda_api: Any | None = None,
+    ) -> Code2WavCudaGraphRunner:
+        """Build the four serving-reachable serial graphs."""
+
+        runner = cls(
+            model,
+            device=device,
+            num_quantizers=num_quantizers,
+            cuda_api=_TorchCudaApi() if cuda_api is None else cuda_api,
+        )
+        runner._build(total_gpu_memory_fraction)
+        return runner
+
+    def _build(self, total_gpu_memory_fraction: float | None) -> None:
+        fraction = self._valid_fraction(total_gpu_memory_fraction)
+        if fraction is None:
+            self._disable_reason = "invalid_total_gpu_memory_fraction"
+            return
+        self._memory_stats["total_gpu_memory_fraction"] = fraction
+
+        temporary: dict[GraphKey, _CapturedGraph] = {}
+        pool: Any | None = None
+        capture_stream: Any | None = None
+        before: dict[str, int] | None = None
+        failure_reason: str | None = None
+        try:
+            with self._cuda.device_context(self._device):
+                before = self._cuda.memory_stats(self._device)
+                self._memory_stats["before"] = before
+                stage_budget = int(before["total_bytes"] * fraction)
+                loaded_model_footprint = before["allocated_bytes"]
+                graph_budget = max(0, stage_budget - loaded_model_footprint)
+                self._memory_stats.update(
+                    {
+                        "stage_budget_bytes": stage_budget,
+                        "loaded_model_footprint_bytes": loaded_model_footprint,
+                        "graph_budget_bytes": graph_budget,
+                    }
+                )
+
+                pool = self._cuda.graph_pool_handle()
+                capture_stream = self._cuda.new_stream(self._device)
+                for key in reversed(CODE2WAV_GRAPH_KEYS):
+                    self._build_stats["attempted_graph_count"] += 1
+                    temporary[key] = self._capture_graph(
+                        key,
+                        pool=pool,
+                        stream=capture_stream,
+                    )
+
+                # Capture, replay and equivalence checks enqueue CUDA work. Do
+                # not make the all-or-nothing graph matrix visible until every
+                # key has completed on the bound device.
+                self._cuda.synchronize(self._device)
+                gc.collect()
+                self._cuda.empty_cache()
+                after = self._cuda.memory_stats(self._device)
+                self._memory_stats["after"] = after
+                allocated_delta = max(
+                    0,
+                    after["allocated_bytes"] - before["allocated_bytes"],
+                )
+                reserved_delta = max(
+                    0,
+                    after["reserved_bytes"] - before["reserved_bytes"],
+                )
+                graph_footprint = max(allocated_delta, reserved_delta)
+                self._memory_stats["graph_footprint_bytes"] = graph_footprint
+                if graph_footprint > graph_budget:
+                    raise _BuildFailure(
+                        f"memory_budget_exceeded: graph footprint "
+                        f"{graph_footprint} exceeds budget "
+                        f"{graph_budget}",
+                    )
+
+        except Exception as exc:
+            failure_reason = (
+                str(exc)
+                if isinstance(exc, _BuildFailure)
+                else f"capture_failed: {type(exc).__name__}: {exc}"
+            )
+
+        if failure_reason is not None:
+            pool = None
+            capture_stream = None
+            self._rollback_build(
+                temporary=temporary,
+                reason=failure_reason,
+            )
+            return
+
+        self._pool = pool
+        self._capture_stream = capture_stream
+        self._graphs = {key: temporary[key] for key in CODE2WAV_GRAPH_KEYS}
+        self._build_stats["published_graph_count"] = len(self._graphs)
+        self._enabled = True
+        logger.info(
+            "Code2Wav CUDA graph runner published %d exact graphs on %s",
+            len(self._graphs),
+            self._device,
+        )
+
+    def _capture_graph(
+        self,
+        key: GraphKey,
+        *,
+        pool: Any,
+        stream: Any,
+    ) -> _CapturedGraph:
+        static_input = self._cuda.new_static_input(
+            (key.batch_size, self._num_quantizers, key.frames),
+            device=self._device,
+        )
+        self._cuda.warmup(
+            self._model,
+            static_input,
+            iterations=self._WARMUP_ITERATIONS,
+            device=self._device,
+            stream=stream,
+        )
+        graph, static_output = self._cuda.capture(
+            self._model,
+            static_input,
+            pool=pool,
+            stream=stream,
+        )
+        with torch.inference_mode():
+            eager_output = self._model(static_input).detach().clone()
+            graph.replay()
+        self._verify_equivalence(
+            key=key,
+            eager_output=eager_output,
+            graph_output=static_output,
+        )
+        return _CapturedGraph(graph, static_input, static_output)
+
+    @staticmethod
+    def _valid_fraction(value: float | None) -> float | None:
+        if value is None or isinstance(value, bool):
+            return None
+        try:
+            fraction = float(value)
+        except (TypeError, ValueError):
+            return None
+        if not math.isfinite(fraction) or not 0.0 < fraction <= 1.0:
+            return None
+        return fraction
+
+    @staticmethod
+    def _verify_equivalence(
+        *,
+        key: GraphKey,
+        eager_output: torch.Tensor,
+        graph_output: torch.Tensor,
+    ) -> None:
+        if not (
+            eager_output.shape == graph_output.shape
+            and bool(torch.isfinite(eager_output).all().item())
+            and bool(torch.isfinite(graph_output).all().item())
+            and torch.equal(eager_output, graph_output)
+        ):
+            raise _BuildFailure(
+                f"equivalence_failed: {key}: eager and graph outputs differ"
+            )
+
+    def _rollback_build(
+        self,
+        *,
+        temporary: dict[GraphKey, _CapturedGraph],
+        reason: str,
+    ) -> None:
+        if "after" not in self._memory_stats:
+            try:
+                self._cuda.synchronize(self._device)
+            except Exception as synchronize_exc:
+                logger.warning(
+                    "Code2Wav CUDA graph rollback synchronize failed: %s",
+                    synchronize_exc,
+                )
+            try:
+                self._memory_stats["after"] = self._cuda.memory_stats(self._device)
+            except Exception as snapshot_exc:
+                logger.warning(
+                    "Code2Wav CUDA graph rollback snapshot failed: %s",
+                    snapshot_exc,
+                )
+        self._graphs.clear()
+        temporary.clear()
+        self._pool = None
+        self._capture_stream = None
+        self._enabled = False
+        self._disable_reason = reason
+        gc.collect()
+        try:
+            with self._cuda.device_context(self._device):
+                self._cuda.empty_cache()
+                self._memory_stats["after_rollback"] = self._cuda.memory_stats(
+                    self._device
+                )
+        except Exception as cleanup_exc:
+            logger.warning(
+                "Code2Wav CUDA graph rollback cleanup failed: %s",
+                cleanup_exc,
+            )
+        logger.warning("Code2Wav CUDA graph runner disabled: %s", reason)
+
+    def run(
+        self,
+        codes: torch.Tensor,
+        *,
+        eligible: bool = True,
+    ) -> Code2WavRunResult:
+        """Replay an exact graph or eagerly execute with a stable reason.
+
+        Graph outputs are borrowed and valid only until the next graph replay;
+        callers must serialize replay through trim and D2H consumption.
+        """
+
+        current_pid = os.getpid()
+        if current_pid != self._owner_pid:
+            raise RuntimeError(
+                "Code2Wav CUDA graph runner/model belongs to PID "
+                f"{self._owner_pid}, but was used in PID {current_pid}; it must "
+                "be rebuilt in a spawned process before inference"
+            )
+        if not self._enabled:
+            return self._eager(codes, key=None, reason="disabled")
+        if not eligible:
+            return self._eager(codes, key=None, reason="ineligible")
+        self._validate_codes(codes)
+
+        key = GraphKey(
+            batch_size=int(codes.shape[0]),
+            frames=int(codes.shape[2]),
+        )
+        captured = self._graphs.get(key)
+        if captured is None:
+            return self._eager(codes, key=key, reason="key_miss")
+
+        try:
+            captured.static_input.copy_(codes)
+            captured.graph.replay()
+        except Exception as exc:
+            self._replay_failures += 1
+            reason = f"runtime_replay_failed: {type(exc).__name__}: {exc}"
+            # Drop the last local graph reference before cleanup releases its pool.
+            captured = None
+            self._disable_runtime(reason)
+            raise
+        self._graph_replays += 1
+        return Code2WavRunResult(
+            output=captured.static_output,
+            execution_mode="cuda_graph",
+            key=key,
+            fallback_reason=None,
+        )
+
+    def _validate_codes(self, codes: torch.Tensor) -> None:
+        if not self._cuda.is_cuda_tensor(codes):
+            raise TypeError("Code2Wav graph input must be a CUDA tensor")
+        if codes.dtype != torch.long:
+            raise TypeError("Code2Wav graph input must use torch.long")
+        if not self._cuda.tensor_device_matches(codes, self._device):
+            raise ValueError(f"Code2Wav graph input must be on {self._device}")
+        if codes.ndim != 3:
+            raise ValueError("Code2Wav graph input must have shape [B, Q, T]")
+        if int(codes.shape[1]) != self._num_quantizers:
+            raise ValueError(
+                f"Code2Wav graph input must contain {self._num_quantizers} quantizers"
+            )
+
+    def _eager(
+        self,
+        codes: torch.Tensor,
+        *,
+        key: GraphKey | None,
+        reason: str,
+    ) -> Code2WavRunResult:
+        self._fallback_counts[reason] += 1
+        with torch.inference_mode():
+            output = self._model(codes)
+        return Code2WavRunResult(
+            output=output,
+            execution_mode="eager",
+            key=key,
+            fallback_reason=reason,
+        )
+
+    def _disable_runtime(self, reason: str) -> None:
+        self._graphs.clear()
+        self._pool = None
+        self._capture_stream = None
+        self._enabled = False
+        self._disable_reason = reason
+        gc.collect()
+        try:
+            with self._cuda.device_context(self._device):
+                self._cuda.empty_cache()
+        except Exception as cleanup_exc:
+            logger.warning(
+                "Code2Wav CUDA graph runtime cleanup failed: %s",
+                cleanup_exc,
+            )
+        logger.exception("Code2Wav CUDA graph replay disabled the runner")
+
+    def stats(self) -> dict[str, Any]:
+        """Return a strict JSON-safe snapshot of build and runtime state."""
+
+        return {
+            "enabled": self._enabled,
+            "disable_reason": self._disable_reason,
+            "binding": {
+                "device": str(self._device),
+                "num_quantizers": self._num_quantizers,
+                "input_dtype": "torch.long",
+                "owner_pid": self._owner_pid,
+            },
+            "graph_contract": {
+                "keys": [
+                    {
+                        "batch_size": key.batch_size,
+                        "frames": key.frames,
+                    }
+                    for key in CODE2WAV_GRAPH_KEYS
+                ],
+            },
+            "build": deepcopy(self._build_stats),
+            "memory": deepcopy(self._memory_stats),
+            "runtime": {
+                "graph_replays": self._graph_replays,
+                "replay_failures": self._replay_failures,
+                "fallback_counts": dict(sorted(self._fallback_counts.items())),
+            },
+        }
+
+
+__all__ = [
+    "CODE2WAV_GRAPH_KEYS",
+    "Code2WavCudaGraphRunner",
+    "Code2WavRunResult",
+    "GraphKey",
+]

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -90,6 +90,13 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         super().__init__(compute_fn=None)
         self._payloads = self._stream_payloads
 
+    def start(self) -> None:
+        try:
+            super().start()
+        finally:
+            if self._cuda_graph_runner is not None:
+                self._cuda_graph_runner.log_shape_telemetry(trigger="shutdown")
+
     def is_streaming_payload(self, payload: StagePayload) -> bool:
         del payload
         return True

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -4,16 +4,23 @@
 Receives codec code chunks via inbox (stream_chunk), accumulates them,
 runs vocoder incrementally, outputs final audio via outbox.
 """
+
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
 import numpy as np
 import torch
 
+from sglang_omni.models.qwen3_omni.components.code2wav_cuda_graph import (
+    Code2WavCudaGraphRunner,
+    Code2WavRunResult,
+)
 from sglang_omni.pipeline.stage.stream_queue import StreamItem
 from sglang_omni.profiler.event_recorder import emit as _emit_event
+from sglang_omni.profiler.event_recorder import get_recorder as _get_event_recorder
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.streaming_simple_scheduler import StreamingSimpleScheduler
@@ -47,7 +54,7 @@ def load_code2wav_model(
         device=device,
         strict=False,
     )
-    return model
+    return model.eval()
 
 
 class Code2WavScheduler(StreamingSimpleScheduler):
@@ -61,6 +68,8 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         left_context_size: int = 25,
         sample_rate: int = 24000,
         codec_eos_token_id: int = 2150,
+        enable_cuda_graph: bool = False,
+        _cuda_graph_runner: Code2WavCudaGraphRunner | None = None,
     ):
         self._model = model
         self._device = torch.device(device)
@@ -69,6 +78,9 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         self._sample_rate = sample_rate
         self._codec_eos_token_id = codec_eos_token_id
         self._total_upsample = int(model.total_upsample)
+        self._cuda_graph_runner = (
+            _cuda_graph_runner if bool(enable_cuda_graph) else None
+        )
 
         # Per-request state
         self._code_chunks: dict[str, list[torch.Tensor]] = {}
@@ -150,7 +162,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         self._code_chunks[request_id].append(codes)
         ready = len(self._code_chunks[request_id]) - self._emitted[request_id]
         if ready >= self._stream_chunk_size:
-            return self._decode_and_emit(request_id)
+            return self._decode_and_emit(request_id, trigger="threshold")
         return []
 
     def on_stream_done(self, request_id: str) -> list[OutgoingMessage]:
@@ -159,7 +171,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         emitted = self._emitted[request_id]
         messages: list[OutgoingMessage] = []
         if chunks and emitted < len(chunks):
-            messages.extend(self._decode_and_emit(request_id))
+            messages.extend(self._decode_and_emit(request_id, trigger="stream_done"))
 
         # Build final output
         audio_parts = self._audio_chunks.get(request_id, [])
@@ -203,11 +215,19 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         )
         return messages
 
-    def _decode_and_emit(self, request_id: str) -> list[OutgoingMessage]:
+    def _decode_and_emit(
+        self, request_id: str, *, trigger: str
+    ) -> list[OutgoingMessage]:
         chunks = self._code_chunks[request_id]
         start = self._emitted[request_id]
         end = len(chunks)
-        audio = self._decode_incremental(request_id, chunks, start, end)
+        audio = self._decode_incremental(
+            request_id,
+            chunks,
+            start,
+            end,
+            trigger=trigger,
+        )
         self._emitted[request_id] = end
         messages: list[OutgoingMessage] = []
         if audio.size > 0:
@@ -233,21 +253,66 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         return messages
 
     def _decode_incremental(
-        self, request_id: str, code_chunks, start, end
+        self,
+        request_id: str,
+        code_chunks,
+        start,
+        end,
+        *,
+        trigger: str,
     ) -> np.ndarray:
         if start >= end:
             return np.zeros((0,), dtype=np.float32)
         context = min(self._left_context_size, start)
+        profile_metadata: dict[str, Any] | None = None
+        if _get_event_recorder().is_active():
+            threshold_ready_request_count = sum(
+                len(chunks) - self._emitted.get(ready_request_id, 0)
+                >= self._stream_chunk_size
+                for ready_request_id, chunks in self._code_chunks.items()
+            )
+            profile_metadata = {
+                "trigger": trigger,
+                "start_frame": start,
+                "end_frame": end,
+                "new_frames": end - start,
+                "context_frames": context,
+                "window_frames": end - start + context,
+                "active_request_count": len(self._code_chunks),
+                "threshold_ready_request_count": threshold_ready_request_count,
+                "inbox_depth": self.inbox.qsize(),
+                "pending_message_depth": len(self._pending_messages),
+            }
+            _emit_event(
+                request_id=request_id,
+                stage=None,
+                event_name="code2wav_decode_start",
+                metadata=profile_metadata,
+            )
         window = torch.stack(code_chunks[start - context : end], dim=0)
         codes = window.transpose(0, 1).unsqueeze(0)
-        with torch.no_grad():
-            if self._device.type == "cuda":
-                torch.cuda.set_device(self._device)
-            wav = self._model(codes)
+        wav, execution_metadata = self._forward_codes(
+            codes,
+            graph_eligible=trigger == "threshold",
+        )
+        # Base scheduler chunk/done wrappers hold ``_state_lock`` across this
+        # complete path. A borrowed graph output is therefore trimmed and
+        # copied to host-owned NumPy storage before another replay can start.
         trim = context * self._total_upsample
         if trim:
             wav = wav[..., trim:]
         audio = wav.reshape(-1).detach().cpu().float().numpy().copy()
+        if profile_metadata is not None:
+            _emit_event(
+                request_id=request_id,
+                stage=None,
+                event_name="code2wav_decode_end",
+                metadata={
+                    **profile_metadata,
+                    "audio_samples": int(audio.shape[0]),
+                    **execution_metadata,
+                },
+            )
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(
                 "Code2Wav decode window=%s start=%s end=%s trim=%s samples=%s",
@@ -258,6 +323,44 @@ class Code2WavScheduler(StreamingSimpleScheduler):
                 int(audio.shape[0]),
             )
         return audio
+
+    def _forward_codes(
+        self,
+        codes: torch.Tensor,
+        *,
+        graph_eligible: bool,
+    ) -> tuple[torch.Tensor, dict[str, Any]]:
+        """Run one serial model call and return strict JSON-safe metadata."""
+
+        with torch.no_grad():
+            if self._device.type == "cuda":
+                torch.cuda.set_device(self._device)
+            if self._cuda_graph_runner is None:
+                result = Code2WavRunResult(
+                    output=self._model(codes),
+                    execution_mode="eager",
+                    key=None,
+                    fallback_reason=None,
+                )
+            else:
+                result = self._cuda_graph_runner.run(
+                    codes,
+                    eligible=graph_eligible,
+                )
+
+        graph_key = None
+        if result.key is not None:
+            graph_key = {
+                "batch_size": int(result.key.batch_size),
+                "frames": int(result.key.frames),
+            }
+        return result.output, {
+            "execution_mode": str(result.execution_mode),
+            "graph_key": graph_key,
+            "fallback_reason": (
+                None if result.fallback_reason is None else str(result.fallback_reason)
+            ),
+        }
 
     def _build_audio_payload(self, audio: np.ndarray) -> dict[str, Any]:
         return audio_waveform_payload(
@@ -276,14 +379,43 @@ def create_code2wav_scheduler(
     gpu_id: int | None = None,
     stream_chunk_size: int = 10,
     left_context_size: int = 25,
+    enable_cuda_graph: bool = False,
+    total_gpu_memory_fraction: float | None = None,
 ):
     """Factory: returns Code2WavScheduler."""
+    if enable_cuda_graph and total_gpu_memory_fraction is None:
+        raise ValueError(
+            "Code2Wav CUDA graph requires "
+            "runtime.resources.total_gpu_memory_fraction"
+        )
     if gpu_id is not None:
         device = f"cuda:{gpu_id}"
+    concrete_device = torch.device(device)
+    if concrete_device.type == "cuda" and concrete_device.index is None:
+        concrete_device = torch.device("cuda", torch.cuda.current_device())
+    device = str(concrete_device)
     model = load_code2wav_model(model_path, device=device, dtype=dtype)
+    cuda_graph_runner = None
+    if enable_cuda_graph:
+        cuda_graph_runner = Code2WavCudaGraphRunner.build(
+            model,
+            device=concrete_device,
+            num_quantizers=int(model.config.num_quantizers),
+            total_gpu_memory_fraction=total_gpu_memory_fraction,
+        )
+        logger.info(
+            "Code2Wav CUDA graph startup stats=%s",
+            json.dumps(
+                cuda_graph_runner.stats(),
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        )
     return Code2WavScheduler(
         model,
         device=device,
         stream_chunk_size=stream_chunk_size,
         left_context_size=left_context_size,
+        enable_cuda_graph=enable_cuda_graph,
+        _cuda_graph_runner=cuda_graph_runner,
     )

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -7,7 +7,13 @@ from typing import ClassVar
 
 from pydantic import Field
 
-from sglang_omni.config import PipelineConfig, PlacementConfig, StageConfig
+from sglang_omni.config import (
+    PipelineConfig,
+    PlacementConfig,
+    StageConfig,
+    StageResourceConfig,
+    StageRuntimeConfig,
+)
 
 _PKG = "sglang_omni.models.qwen3_omni"
 _PLACEMENT_POLICY = f"{_PKG}.placement.Qwen3OmniPlacementPolicy"
@@ -202,8 +208,11 @@ def _code2wav_stage(*, gpu: int, process: str) -> StageConfig:
         name="code2wav",
         process=process,
         factory=f"{_PKG}.components.code2wav_scheduler.create_code2wav_scheduler",
-        factory_args={"device": "cuda"},
+        factory_args={"device": "cuda", "enable_cuda_graph": True},
         gpu=gpu,
+        runtime=StageRuntimeConfig(
+            resources=StageResourceConfig(total_gpu_memory_fraction=0.02)
+        ),
         terminal=True,
         can_accept_stream_before_payload=True,
     )

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,6 +52,7 @@ tests/
     ├── qwen3_omni/
     │   ├── test_cli.py
     │   ├── test_code2wav.py
+    │   ├── test_code2wav_cuda_graph.py
     │   ├── test_colocation_config.py
     │   ├── test_config_manager.py
     │   ├── test_fp8_backend_config.py
@@ -384,6 +385,15 @@ that happened to contain an older version of the test.
     tensor storage/slicing, decode feedback/text FIFO consumption, and replay
     of generated-token input embeds after decode retract
   - Code2Wav streaming/cleanup behavior
+  - Code2Wav CUDA Graph lifecycle, exact-shape replay, atomic rollback, memory
+    budget enforcement, eager fallbacks, replay failures, and JSON-safe stats;
+    the `gpu`-marked cases exercise real CUDA stream restoration and graph
+    capture/replay. Run them with:
+
+    ```bash
+    pytest tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py -m gpu -q
+    ```
+
   - logit-shaping helpers (e.g. repetition penalty) numerical equivalence with the original per-row scalar formulas.
 
 - `unit_test/ming_omni/` Ming-Omni unit tests:

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -2,14 +2,619 @@
 
 from __future__ import annotations
 
+import json
+import logging
+import threading
+from types import SimpleNamespace
+
 import numpy as np
+import pytest
 import torch
 
+from sglang_omni.models.qwen3_omni.components import code2wav_scheduler
+from sglang_omni.models.qwen3_omni.components.code2wav_cuda_graph import (
+    CODE2WAV_GRAPH_KEYS,
+    Code2WavRunResult,
+    GraphKey,
+)
 from sglang_omni.models.qwen3_omni.components.code2wav_scheduler import (
     Code2WavScheduler,
 )
 from sglang_omni.pipeline.stage.stream_queue import StreamItem
+from sglang_omni.scheduling.messages import IncomingMessage
 from tests.unit_test.fixtures.qwen_fakes import FakeCode2WavModel, make_qwen_payload
+
+
+class _FactoryModel(FakeCode2WavModel):
+    def __init__(self, *, num_quantizers: int = 16) -> None:
+        super().__init__()
+        self.config = SimpleNamespace(num_quantizers=num_quantizers)
+        self.eval_calls = 0
+
+    def eval(self):
+        self.eval_calls += 1
+        return self
+
+
+class _FakeCudaGraphRunner:
+    def __init__(self, model, *, replay_error: Exception | None = None) -> None:
+        self.model = model
+        self.replay_error = replay_error
+        self.calls: list[tuple[tuple[int, ...], bool]] = []
+
+    def run(self, codes: torch.Tensor, *, eligible: bool) -> Code2WavRunResult:
+        self.calls.append((tuple(codes.shape), eligible))
+        if self.replay_error is not None:
+            raise self.replay_error
+        output = self.model(codes)
+        key = GraphKey(batch_size=int(codes.shape[0]), frames=int(codes.shape[-1]))
+        if eligible and key in CODE2WAV_GRAPH_KEYS:
+            return Code2WavRunResult(output, "cuda_graph", key, None)
+        if eligible:
+            return Code2WavRunResult(output, "eager", key, "key_miss")
+        return Code2WavRunResult(output, "eager", None, "ineligible")
+
+
+def _activate_event_capture(monkeypatch) -> list[dict]:
+    events: list[dict] = []
+
+    class _ActiveRecorder:
+        @staticmethod
+        def is_active() -> bool:
+            return True
+
+    monkeypatch.setattr(
+        code2wav_scheduler, "_get_event_recorder", lambda: _ActiveRecorder()
+    )
+    monkeypatch.setattr(
+        code2wav_scheduler, "_emit_event", lambda **event: events.append(event)
+    )
+    return events
+
+
+def test_qwen_load_code2wav_model_returns_eval_model(monkeypatch) -> None:
+    from transformers import AutoConfig
+    from transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe import (
+        Qwen3OmniMoeCode2Wav,
+    )
+
+    from sglang_omni.models import weight_loader
+
+    model = _FactoryModel()
+    config = SimpleNamespace(code2wav_config=object())
+    monkeypatch.setattr(
+        AutoConfig,
+        "from_pretrained",
+        staticmethod(lambda *args, **kwargs: config),
+    )
+    monkeypatch.setattr(
+        Qwen3OmniMoeCode2Wav,
+        "_from_config",
+        staticmethod(lambda code2wav_config: model),
+    )
+    monkeypatch.setattr(weight_loader, "resolve_dtype", lambda dtype: torch.float32)
+    monkeypatch.setattr(
+        weight_loader,
+        "load_module",
+        lambda loaded_model, *args, **kwargs: loaded_model,
+    )
+
+    loaded = code2wav_scheduler.load_code2wav_model("dummy", device="cpu")
+
+    assert loaded is model
+    assert model.eval_calls == 1
+
+
+def test_qwen_code2wav_factory_default_does_not_build_cuda_graphs(monkeypatch) -> None:
+    model = _FactoryModel()
+    monkeypatch.setattr(
+        code2wav_scheduler, "load_code2wav_model", lambda *a, **k: model
+    )
+
+    def _unexpected_build(*args, **kwargs):
+        raise AssertionError("disabled default must not build CUDA graphs")
+
+    monkeypatch.setattr(
+        code2wav_scheduler.Code2WavCudaGraphRunner,
+        "build",
+        staticmethod(_unexpected_build),
+    )
+
+    scheduler = code2wav_scheduler.create_code2wav_scheduler(
+        "dummy",
+        device="cpu",
+    )
+
+    assert scheduler._cuda_graph_runner is None
+
+
+def test_qwen_code2wav_enabled_factory_rejects_missing_typed_budget_before_load(
+    monkeypatch,
+) -> None:
+    load_calls = 0
+
+    def _load(*args, **kwargs):
+        nonlocal load_calls
+        load_calls += 1
+        return _FactoryModel()
+
+    monkeypatch.setattr(code2wav_scheduler, "load_code2wav_model", _load)
+
+    with pytest.raises(ValueError, match="total_gpu_memory_fraction"):
+        code2wav_scheduler.create_code2wav_scheduler(
+            "dummy",
+            device="cuda:0",
+            enable_cuda_graph=True,
+        )
+
+    assert load_calls == 0
+
+
+def test_qwen_code2wav_enabled_factory_normalizes_device_once_and_uses_budget(
+    monkeypatch,
+    caplog,
+) -> None:
+    model = _FactoryModel(num_quantizers=12)
+    runner = SimpleNamespace(
+        stats=lambda: {
+            "enabled": True,
+            "disable_reason": None,
+            "graph_contract": {
+                "keys": [
+                    {"batch_size": key.batch_size, "frames": key.frames}
+                    for key in CODE2WAV_GRAPH_KEYS
+                ]
+            },
+            "build": {"published_graph_count": 4},
+        }
+    )
+    load_call: dict = {}
+    build_call: dict = {}
+    monkeypatch.setattr(
+        code2wav_scheduler.torch.cuda,
+        "current_device",
+        lambda: 3,
+    )
+
+    def _load(*args, **kwargs):
+        load_call.update(args=args, **kwargs)
+        return model.eval()
+
+    def _build(built_model, **kwargs):
+        build_call.update(model=built_model, **kwargs)
+        return runner
+
+    monkeypatch.setattr(code2wav_scheduler, "load_code2wav_model", _load)
+    monkeypatch.setattr(
+        code2wav_scheduler.Code2WavCudaGraphRunner,
+        "build",
+        staticmethod(_build),
+    )
+
+    with caplog.at_level(logging.INFO, logger=code2wav_scheduler.__name__):
+        scheduler = code2wav_scheduler.create_code2wav_scheduler(
+            "dummy",
+            enable_cuda_graph=True,
+            total_gpu_memory_fraction=0.02,
+        )
+
+    assert model.eval_calls == 1
+    assert load_call == {
+        "args": ("dummy",),
+        "device": "cuda:3",
+        "dtype": None,
+    }
+    assert build_call == {
+        "model": model,
+        "device": torch.device("cuda:3"),
+        "num_quantizers": 12,
+        "total_gpu_memory_fraction": 0.02,
+    }
+    assert scheduler._device == torch.device("cuda:3")
+    assert scheduler._cuda_graph_runner is runner
+    stats_record = next(
+        record
+        for record in caplog.records
+        if "CUDA graph startup stats=" in record.message
+    )
+    assert json.loads(stats_record.message.split("stats=", 1)[1]) == runner.stats()
+
+
+def test_qwen_code2wav_enabled_factory_logs_disabled_build_reason(
+    monkeypatch,
+    caplog,
+) -> None:
+    model = _FactoryModel(num_quantizers=12)
+    runner = SimpleNamespace(
+        stats=lambda: {
+            "enabled": False,
+            "disable_reason": "capture_failed: RuntimeError: capture failed",
+        }
+    )
+    monkeypatch.setattr(
+        code2wav_scheduler, "load_code2wav_model", lambda *a, **k: model.eval()
+    )
+    monkeypatch.setattr(
+        code2wav_scheduler.Code2WavCudaGraphRunner,
+        "build",
+        staticmethod(lambda *args, **kwargs: runner),
+    )
+
+    with caplog.at_level(logging.INFO, logger=code2wav_scheduler.__name__):
+        scheduler = code2wav_scheduler.create_code2wav_scheduler(
+            "dummy",
+            gpu_id=3,
+            enable_cuda_graph=True,
+            total_gpu_memory_fraction=0.02,
+        )
+
+    assert scheduler._cuda_graph_runner is runner
+    stats_record = next(
+        record
+        for record in caplog.records
+        if "CUDA graph startup stats=" in record.message
+    )
+    assert json.loads(stats_record.message.split("stats=", 1)[1]) == {
+        "disable_reason": "capture_failed: RuntimeError: capture failed",
+        "enabled": False,
+    }
+
+
+def test_qwen_code2wav_threshold_context_windows_hit_cuda_graph(monkeypatch) -> None:
+    model = FakeCode2WavModel(total_upsample=2)
+    runner = _FakeCudaGraphRunner(model)
+    scheduler = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=10,
+        left_context_size=25,
+        enable_cuda_graph=True,
+        _cuda_graph_runner=runner,
+    )
+    scheduler._payloads["req-1"] = make_qwen_payload(request_id="req-1")
+    scheduler._ensure_request_state("req-1")
+    events = _activate_event_capture(monkeypatch)
+
+    for chunk_id in range(40):
+        scheduler._on_chunk(
+            "req-1",
+            StreamItem(
+                chunk_id,
+                torch.tensor([chunk_id + 1, 10]),
+                "talker",
+                metadata={"stream": True},
+            ),
+        )
+
+    assert runner.calls == [
+        ((1, 2, 10), True),
+        ((1, 2, 20), True),
+        ((1, 2, 30), True),
+        ((1, 2, 35), True),
+    ]
+    decode_ends = [
+        event for event in events if event["event_name"] == "code2wav_decode_end"
+    ]
+    assert [event["metadata"]["execution_mode"] for event in decode_ends] == [
+        "cuda_graph"
+    ] * 4
+    assert [event["metadata"]["graph_key"]["frames"] for event in decode_ends] == [
+        10,
+        20,
+        30,
+        35,
+    ]
+
+
+def test_qwen_code2wav_stream_done_tail_is_eager_when_shape_matches_graph(
+    monkeypatch,
+) -> None:
+    model = FakeCode2WavModel(total_upsample=2)
+    runner = _FakeCudaGraphRunner(model)
+    scheduler = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=6,
+        left_context_size=5,
+        enable_cuda_graph=True,
+        _cuda_graph_runner=runner,
+    )
+    scheduler._payloads["req-1"] = make_qwen_payload(request_id="req-1")
+    scheduler._ensure_request_state("req-1")
+    events = _activate_event_capture(monkeypatch)
+
+    for chunk_id in range(11):
+        scheduler._on_chunk(
+            "req-1",
+            StreamItem(
+                chunk_id,
+                torch.tensor([chunk_id + 1, 10]),
+                "talker",
+                metadata={"stream": False},
+            ),
+        )
+    scheduler._on_done("req-1")
+
+    assert runner.calls == [((1, 2, 6), True), ((1, 2, 10), False)]
+    decode_ends = [
+        event for event in events if event["event_name"] == "code2wav_decode_end"
+    ]
+    tail_metadata = decode_ends[-1]["metadata"]
+    assert tail_metadata["trigger"] == "stream_done"
+    assert tail_metadata["window_frames"] == 10
+    assert tail_metadata["execution_mode"] == "eager"
+    assert tail_metadata["graph_key"] is None
+    assert tail_metadata["fallback_reason"] == "ineligible"
+
+
+def test_qwen_code2wav_request_events_are_symmetric_and_keep_start_metadata(
+    monkeypatch,
+) -> None:
+    model = FakeCode2WavModel(total_upsample=2)
+    scheduler = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=2,
+        left_context_size=1,
+        sample_rate=24000,
+    )
+    scheduler._payloads["req-1"] = make_qwen_payload(request_id="req-1")
+    scheduler._ensure_request_state("req-1")
+    events = _activate_event_capture(monkeypatch)
+
+    for chunk_id, codes in enumerate(([1, 10], [2, 20], [3, 30])):
+        scheduler._on_chunk(
+            "req-1",
+            StreamItem(
+                chunk_id,
+                torch.tensor(codes),
+                "talker",
+                metadata={"stream": False},
+            ),
+        )
+    scheduler._on_done("req-1")
+
+    decode_events = [
+        event for event in events if event["event_name"].startswith("code2wav_decode_")
+    ]
+    assert [event["event_name"] for event in decode_events] == [
+        "code2wav_decode_start",
+        "code2wav_decode_end",
+        "code2wav_decode_start",
+        "code2wav_decode_end",
+    ]
+    first = decode_events[0]["metadata"]
+    assert first == {
+        "trigger": "threshold",
+        "start_frame": 0,
+        "end_frame": 2,
+        "new_frames": 2,
+        "context_frames": 0,
+        "window_frames": 2,
+        "active_request_count": 1,
+        "threshold_ready_request_count": 1,
+        "inbox_depth": 0,
+        "pending_message_depth": 0,
+    }
+    assert decode_events[1]["metadata"] == {
+        **first,
+        "audio_samples": 4,
+        "execution_mode": "eager",
+        "graph_key": None,
+        "fallback_reason": None,
+    }
+    tail = decode_events[2]["metadata"]
+    assert tail["trigger"] == "stream_done"
+    assert tail["new_frames"] == 1
+    assert tail["context_frames"] == 1
+    assert tail["window_frames"] == 2
+    assert tail["threshold_ready_request_count"] == 0
+    assert decode_events[3]["metadata"] == {
+        **tail,
+        "audio_samples": 2,
+        "execution_mode": "eager",
+        "graph_key": None,
+        "fallback_reason": None,
+    }
+    assert any(event["event_name"] == "code2wav_first_audio" for event in events)
+
+
+def test_qwen_code2wav_eligible_key_miss_has_json_safe_fallback_metadata(
+    monkeypatch,
+) -> None:
+    model = FakeCode2WavModel(total_upsample=2)
+    runner = _FakeCudaGraphRunner(model)
+    scheduler = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=6,
+        left_context_size=0,
+        enable_cuda_graph=True,
+        _cuda_graph_runner=runner,
+    )
+    scheduler._payloads["req-1"] = make_qwen_payload(request_id="req-1")
+    scheduler._ensure_request_state("req-1")
+    events = _activate_event_capture(monkeypatch)
+
+    for chunk_id in range(6):
+        scheduler._on_chunk(
+            "req-1",
+            StreamItem(
+                chunk_id,
+                torch.tensor([chunk_id + 1, 10]),
+                "talker",
+                metadata={"stream": True},
+            ),
+        )
+
+    decode_start = next(
+        event for event in events if event["event_name"] == "code2wav_decode_start"
+    )
+    decode_end = next(
+        event for event in events if event["event_name"] == "code2wav_decode_end"
+    )
+    assert "execution_mode" not in decode_start["metadata"]
+    assert "graph_key" not in decode_start["metadata"]
+    assert "fallback_reason" not in decode_start["metadata"]
+    assert decode_end["metadata"]["execution_mode"] == "eager"
+    assert decode_end["metadata"]["graph_key"] == {
+        "batch_size": 1,
+        "frames": 6,
+    }
+    assert decode_end["metadata"]["fallback_reason"] == "key_miss"
+
+
+def _run_code2wav_stream(*, cuda_graph: bool) -> tuple[list[tuple], object]:
+    model = FakeCode2WavModel(total_upsample=2)
+    runner = _FakeCudaGraphRunner(model) if cuda_graph else None
+    scheduler = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=10,
+        left_context_size=1,
+        enable_cuda_graph=cuda_graph,
+        _cuda_graph_runner=runner,
+    )
+    scheduler._payloads["req-1"] = make_qwen_payload(request_id="req-1")
+    scheduler._ensure_request_state("req-1")
+    for chunk_id in range(11):
+        scheduler._on_chunk(
+            "req-1",
+            StreamItem(
+                chunk_id,
+                torch.tensor([chunk_id + 1, 10]),
+                "talker",
+                metadata={"stream": True},
+            ),
+        )
+    scheduler._on_done("req-1")
+
+    messages = [scheduler.outbox.get_nowait() for _ in range(scheduler.outbox.qsize())]
+    snapshot: list[tuple] = []
+    for message in messages:
+        if message.type == "stream":
+            snapshot.append(
+                (
+                    message.type,
+                    message.data["audio_waveform"],
+                    message.data["sample_rate"],
+                    message.metadata,
+                )
+            )
+        else:
+            snapshot.append((message.type, message.data.data))
+    return snapshot, runner
+
+
+def test_qwen_code2wav_graph_output_protocol_matches_eager_exactly() -> None:
+    eager_snapshot, _ = _run_code2wav_stream(cuda_graph=False)
+    graph_snapshot, runner = _run_code2wav_stream(cuda_graph=True)
+
+    assert graph_snapshot == eager_snapshot
+    assert [item[0] for item in graph_snapshot] == ["stream", "stream", "result"]
+    assert [
+        len(np.frombuffer(item[1], dtype=np.float32))
+        for item in graph_snapshot
+        if item[0] == "stream"
+    ] == [20, 2]
+    assert runner.calls == [((1, 2, 10), True), ((1, 2, 2), False)]
+
+
+def test_qwen_code2wav_consumes_borrowed_output_under_state_lock() -> None:
+    class _BorrowedOutputRunner:
+        def __init__(self) -> None:
+            self.scheduler = None
+            self.static_output = torch.zeros((1, 1, 2), dtype=torch.float32)
+            self.lock_was_held: list[bool] = []
+            self.replays = 0
+
+        def run(self, codes: torch.Tensor, *, eligible: bool) -> Code2WavRunResult:
+            assert eligible
+            self.lock_was_held.append(self.scheduler._state_lock._is_owned())
+            self.replays += 1
+            self.static_output.fill_(float(self.replays))
+            return Code2WavRunResult(
+                self.static_output,
+                "cuda_graph",
+                GraphKey(1, int(codes.shape[-1])),
+                None,
+            )
+
+    model = FakeCode2WavModel(total_upsample=2)
+    runner = _BorrowedOutputRunner()
+    scheduler = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=1,
+        left_context_size=0,
+        enable_cuda_graph=True,
+        _cuda_graph_runner=runner,
+    )
+    runner.scheduler = scheduler
+    scheduler._payloads["req-1"] = make_qwen_payload(request_id="req-1")
+    scheduler._ensure_request_state("req-1")
+
+    for chunk_id in range(2):
+        scheduler._on_chunk(
+            "req-1",
+            StreamItem(
+                chunk_id,
+                torch.tensor([chunk_id + 1, 10]),
+                "talker",
+                metadata={"stream": True},
+            ),
+        )
+
+    assert runner.lock_was_held == [True, True]
+    assert [chunk.tolist() for chunk in scheduler._audio_chunks["req-1"]] == [
+        [1.0, 1.0],
+        [2.0, 2.0],
+    ]
+
+
+def test_qwen_code2wav_replay_error_reaches_base_abort_without_eager_retry() -> None:
+    model = FakeCode2WavModel(total_upsample=2)
+    replay_error = RuntimeError("replay failed")
+    runner = _FakeCudaGraphRunner(model, replay_error=replay_error)
+    scheduler = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=1,
+        left_context_size=0,
+        enable_cuda_graph=True,
+        _cuda_graph_runner=runner,
+    )
+    scheduler._payloads["req-1"] = make_qwen_payload(request_id="req-1")
+    scheduler._ensure_request_state("req-1")
+    scheduler.inbox.put(
+        IncomingMessage(
+            request_id="req-1",
+            type="stream_chunk",
+            data=StreamItem(
+                0,
+                torch.tensor([1, 10]),
+                "talker",
+                metadata={"stream": True},
+            ),
+        )
+    )
+
+    worker = threading.Thread(target=scheduler.start)
+    worker.start()
+    try:
+        message = scheduler.outbox.get(timeout=2.0)
+    finally:
+        scheduler.stop()
+        worker.join(timeout=2.0)
+
+    assert not worker.is_alive()
+    assert runner.calls == [((1, 2, 1), True)]
+    assert model.calls == []
+    assert message.request_id == "req-1"
+    assert message.type == "error"
+    assert message.data is replay_error
+    assert scheduler._is_aborted("req-1")
+    assert "req-1" not in scheduler._code_chunks
 
 
 def test_qwen_code2wav_streams_incrementally_and_abort_clears_state() -> None:

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -41,6 +41,7 @@ class _FakeCudaGraphRunner:
         self.model = model
         self.replay_error = replay_error
         self.calls: list[tuple[tuple[int, ...], bool]] = []
+        self.telemetry_triggers: list[str] = []
 
     def run(self, codes: torch.Tensor, *, eligible: bool) -> Code2WavRunResult:
         self.calls.append((tuple(codes.shape), eligible))
@@ -53,6 +54,9 @@ class _FakeCudaGraphRunner:
         if eligible:
             return Code2WavRunResult(output, "eager", key, "key_miss")
         return Code2WavRunResult(output, "eager", None, "ineligible")
+
+    def log_shape_telemetry(self, *, trigger: str) -> None:
+        self.telemetry_triggers.append(trigger)
 
 
 def _activate_event_capture(monkeypatch) -> list[dict]:
@@ -609,6 +613,7 @@ def test_qwen_code2wav_replay_error_reaches_base_abort_without_eager_retry() -> 
 
     assert not worker.is_alive()
     assert runner.calls == [((1, 2, 1), True)]
+    assert runner.telemetry_triggers == ["shutdown"]
     assert model.calls == []
     assert message.request_id == "req-1"
     assert message.type == "error"

--- a/tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py
@@ -1,0 +1,658 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from contextlib import nullcontext
+from typing import Any
+
+import pytest
+import torch
+
+from sglang_omni.models.qwen3_omni.components import code2wav_cuda_graph
+from sglang_omni.models.qwen3_omni.components.code2wav_cuda_graph import (
+    CODE2WAV_GRAPH_KEYS,
+    Code2WavCudaGraphRunner,
+    GraphKey,
+)
+
+
+class _FakeModel:
+    def __init__(self) -> None:
+        self.calls: list[torch.Tensor] = []
+
+    def __call__(self, codes: torch.Tensor) -> torch.Tensor:
+        self.calls.append(codes.detach().clone())
+        samples = int(codes.shape[-1]) * 2
+        base = codes.float().sum(dim=(1, 2), keepdim=True)
+        ramp = torch.arange(samples, dtype=torch.float32).view(1, 1, samples)
+        return base + ramp
+
+
+class _FakeGraph:
+    def __init__(
+        self,
+        model: _FakeModel,
+        static_input: torch.Tensor,
+        static_output: torch.Tensor,
+        *,
+        corrupt: bool,
+    ) -> None:
+        self._model = model
+        self.static_input = static_input
+        self.static_output = static_output
+        self.corrupt = corrupt
+        self.fail_replay: Exception | None = None
+        self.replay_inputs: list[torch.Tensor] = []
+
+    def replay(self) -> None:
+        if self.fail_replay is not None:
+            raise self.fail_replay
+        self.replay_inputs.append(self.static_input.clone())
+        output = self._model(self.static_input)
+        if self.corrupt:
+            output = output + 1
+        self.static_output.copy_(output)
+
+
+class _FakeCudaBackend:
+    def __init__(
+        self,
+        *,
+        capture_error_at: int | None = None,
+        corrupt_at: int | None = None,
+        replay_error_at: int | None = None,
+        after_allocated: int = 160,
+        after_reserved: int = 200,
+    ) -> None:
+        self.capture_error_at = capture_error_at
+        self.corrupt_at = corrupt_at
+        self.replay_error_at = replay_error_at
+        self.capture_calls = 0
+        self.pool_calls = 0
+        self.capture_pools: list[Any] = []
+        self.new_stream_devices: list[torch.device] = []
+        self.warmup_streams: list[Any | None] = []
+        self.capture_streams: list[Any | None] = []
+        self.warmup_iterations: list[int] = []
+        self.synchronize_calls = 0
+        self.empty_cache_calls = 0
+        self.graphs: list[_FakeGraph] = []
+        self._tensor_devices: dict[int, torch.device] = {}
+        self._memory_snapshots = [
+            {
+                "allocated_bytes": 100,
+                "reserved_bytes": 120,
+                "max_reserved_bytes": 130,
+                "free_bytes": 900,
+                "total_bytes": 1000,
+            },
+            {
+                "allocated_bytes": after_allocated,
+                "reserved_bytes": after_reserved,
+                "max_reserved_bytes": 250,
+                "free_bytes": 820,
+                "total_bytes": 1000,
+            },
+            {
+                "allocated_bytes": 100,
+                "reserved_bytes": 120,
+                "max_reserved_bytes": 250,
+                "free_bytes": 900,
+                "total_bytes": 1000,
+            },
+        ]
+        self._memory_index = 0
+
+    def device_context(self, device: torch.device):
+        del device
+        return nullcontext()
+
+    def memory_stats(self, device: torch.device) -> dict[str, int]:
+        del device
+        index = min(self._memory_index, len(self._memory_snapshots) - 1)
+        self._memory_index += 1
+        return dict(self._memory_snapshots[index])
+
+    def empty_cache(self) -> None:
+        self.empty_cache_calls += 1
+
+    def new_static_input(
+        self, shape: tuple[int, int, int], *, device: torch.device
+    ) -> torch.Tensor:
+        tensor = torch.zeros(shape, dtype=torch.long)
+        self.mark_cuda(tensor, device=device)
+        return tensor
+
+    def warmup(
+        self,
+        model: _FakeModel,
+        static_input: torch.Tensor,
+        *,
+        iterations: int,
+        device: torch.device,
+        stream: object | None = None,
+    ) -> None:
+        del device
+        self.warmup_streams.append(stream)
+        self.warmup_iterations.append(iterations)
+        for _ in range(iterations):
+            model(static_input)
+
+    def graph_pool_handle(self) -> object:
+        self.pool_calls += 1
+        return object()
+
+    def new_stream(self, device: torch.device) -> object:
+        self.new_stream_devices.append(device)
+        return object()
+
+    def capture(
+        self,
+        model: _FakeModel,
+        static_input: torch.Tensor,
+        *,
+        pool: object,
+        stream: object | None = None,
+    ) -> tuple[_FakeGraph, torch.Tensor]:
+        call_index = self.capture_calls
+        self.capture_calls += 1
+        self.capture_pools.append(pool)
+        self.capture_streams.append(stream)
+        if call_index == self.capture_error_at:
+            raise torch.OutOfMemoryError("fake capture OOM")
+        static_output = model(static_input).detach().clone()
+        graph = _FakeGraph(
+            model,
+            static_input,
+            static_output,
+            corrupt=call_index == self.corrupt_at,
+        )
+        if call_index == self.replay_error_at:
+            graph.fail_replay = RuntimeError("fake build replay failed")
+        self.graphs.append(graph)
+        return graph, static_output
+
+    def synchronize(self, device: torch.device) -> None:
+        del device
+        self.synchronize_calls += 1
+
+    def is_cuda_tensor(self, tensor: torch.Tensor) -> bool:
+        return id(tensor) in self._tensor_devices
+
+    def tensor_device_matches(self, tensor: torch.Tensor, device: torch.device) -> bool:
+        return self._tensor_devices.get(id(tensor)) == device
+
+    def mark_cuda(
+        self, tensor: torch.Tensor, *, device: str | torch.device = "cuda:0"
+    ) -> torch.Tensor:
+        self._tensor_devices[id(tensor)] = torch.device(device)
+        return tensor
+
+
+def _build_runner(
+    *,
+    backend: _FakeCudaBackend | None = None,
+    model: _FakeModel | None = None,
+    total_gpu_memory_fraction: float | None = 0.5,
+) -> tuple[Code2WavCudaGraphRunner, _FakeCudaBackend, _FakeModel]:
+    backend = backend or _FakeCudaBackend()
+    model = model or _FakeModel()
+    runner = Code2WavCudaGraphRunner.build(
+        model,
+        device="cuda:0",
+        num_quantizers=16,
+        total_gpu_memory_fraction=total_gpu_memory_fraction,
+        cuda_api=backend,
+    )
+    return runner, backend, model
+
+
+def _codes(
+    backend: _FakeCudaBackend,
+    batch_size: int,
+    frames: int,
+    *,
+    num_quantizers: int = 16,
+    dtype: torch.dtype = torch.long,
+    device: str = "cuda:0",
+) -> torch.Tensor:
+    tensor = torch.arange(
+        batch_size * num_quantizers * frames,
+        dtype=dtype,
+    ).reshape(batch_size, num_quantizers, frames)
+    return backend.mark_cuda(tensor, device=device)
+
+
+def test_graph_keys_are_the_four_serial_serving_shapes() -> None:
+    assert CODE2WAV_GRAPH_KEYS == tuple(
+        GraphKey(batch_size=1, frames=frames) for frames in (10, 20, 30, 35)
+    )
+
+
+def test_build_uses_three_warmups_one_private_pool_and_atomic_publication() -> None:
+    runner, backend, _model = _build_runner()
+
+    assert backend.warmup_iterations == [3] * 4
+    assert [tuple(graph.static_input.shape) for graph in backend.graphs] == [
+        (1, 16, 35),
+        (1, 16, 30),
+        (1, 16, 20),
+        (1, 16, 10),
+    ]
+    assert backend.pool_calls == 1
+    assert len({id(pool) for pool in backend.capture_pools}) == 1
+    assert backend.synchronize_calls >= 1
+
+    stats = runner.stats()
+    assert stats["enabled"] is True
+    assert stats["graph_contract"]["keys"] == [
+        {"batch_size": key.batch_size, "frames": key.frames}
+        for key in CODE2WAV_GRAPH_KEYS
+    ]
+    assert stats["build"]["published_graph_count"] == 4
+    assert stats["memory"] == {
+        "total_gpu_memory_fraction": 0.5,
+        "stage_budget_bytes": 500,
+        "loaded_model_footprint_bytes": 100,
+        "graph_budget_bytes": 400,
+        "graph_footprint_bytes": 80,
+        "before": {
+            "allocated_bytes": 100,
+            "reserved_bytes": 120,
+            "max_reserved_bytes": 130,
+            "free_bytes": 900,
+            "total_bytes": 1000,
+        },
+        "after": {
+            "allocated_bytes": 160,
+            "reserved_bytes": 200,
+            "max_reserved_bytes": 250,
+            "free_bytes": 820,
+            "total_bytes": 1000,
+        },
+    }
+
+
+def test_build_reuses_one_private_stream_for_all_warmups_and_captures() -> None:
+    runner, backend, _model = _build_runner()
+
+    assert runner.stats()["enabled"] is True
+    assert backend.new_stream_devices == [torch.device("cuda:0")]
+    assert len(backend.warmup_streams) == 4
+    assert len(backend.capture_streams) == 4
+    private_stream = backend.warmup_streams[0]
+    assert private_stream is not None
+    assert all(stream is private_stream for stream in backend.warmup_streams)
+    assert all(stream is private_stream for stream in backend.capture_streams)
+
+
+def test_stats_report_only_operational_state() -> None:
+    runner, backend, _model = _build_runner()
+    runner.run(_codes(backend, 1, 10))
+
+    stats = runner.stats()
+    assert stats["binding"] == {
+        "device": "cuda:0",
+        "num_quantizers": 16,
+        "input_dtype": "torch.long",
+        "owner_pid": stats["binding"]["owner_pid"],
+    }
+    assert stats["build"] == {
+        "attempted_graph_count": 4,
+        "published_graph_count": 4,
+    }
+    assert stats["runtime"] == {
+        "graph_replays": 1,
+        "replay_failures": 0,
+        "fallback_counts": {},
+    }
+
+
+def test_all_serving_keys_hit_while_batch_two_misses() -> None:
+    runner, backend, model = _build_runner()
+
+    for key in CODE2WAV_GRAPH_KEYS:
+        result = runner.run(_codes(backend, key.batch_size, key.frames))
+        assert result.execution_mode == "cuda_graph"
+        assert result.key == key
+        assert result.fallback_reason is None
+
+    calls_before = len(model.calls)
+    missed = runner.run(_codes(backend, 2, 10))
+
+    assert missed.execution_mode == "eager"
+    assert missed.key == GraphKey(batch_size=2, frames=10)
+    assert missed.fallback_reason == "key_miss"
+    assert len(model.calls) == calls_before + 1
+    assert runner.stats()["runtime"] == {
+        "graph_replays": 4,
+        "replay_failures": 0,
+        "fallback_counts": {"key_miss": 1},
+    }
+
+
+def test_cuda_api_restores_original_stream_when_capture_exit_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_stream = object()
+    current = {"stream": original_stream}
+
+    class _SideStream:
+        def wait_stream(self, stream: object) -> None:
+            assert stream is original_stream
+
+    side_stream = _SideStream()
+
+    class _FailingCaptureContext:
+        def __enter__(self) -> None:
+            current["stream"] = side_stream
+
+        def __exit__(self, *_args: object) -> None:
+            raise RuntimeError("fake capture_end failed")
+
+    def graph_context(*_args: object, **kwargs: object) -> _FailingCaptureContext:
+        assert kwargs["stream"] is side_stream
+        return _FailingCaptureContext()
+
+    monkeypatch.setattr(
+        code2wav_cuda_graph.torch.cuda,
+        "current_stream",
+        lambda _device: current["stream"],
+    )
+    monkeypatch.setattr(
+        code2wav_cuda_graph.torch.cuda,
+        "set_stream",
+        lambda stream: current.update(stream=stream),
+    )
+    monkeypatch.setattr(
+        code2wav_cuda_graph.torch.cuda,
+        "CUDAGraph",
+        lambda: object(),
+    )
+    monkeypatch.setattr(code2wav_cuda_graph.torch.cuda, "graph", graph_context)
+
+    with pytest.raises(RuntimeError, match="fake capture_end failed"):
+        code2wav_cuda_graph._TorchCudaApi().capture(
+            _FakeModel(),
+            torch.zeros((1, 16, 10), dtype=torch.long),
+            pool=object(),
+            stream=side_stream,
+        )
+
+    assert current["stream"] is original_stream
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_real_cuda_invalid_capture_preserves_current_stream() -> None:
+    api = code2wav_cuda_graph._TorchCudaApi()
+    device = torch.device("cuda", torch.cuda.current_device())
+    original_stream = torch.cuda.current_stream(device)
+    side_stream = api.new_stream(device)
+    static_input = torch.zeros((1, 16, 10), dtype=torch.long, device=device)
+
+    def invalidate_capture(codes: torch.Tensor) -> torch.Tensor:
+        # Host synchronization is prohibited during graph capture. This marks
+        # the capture invalid so capture_end itself exercises the failure path
+        # that used to skip the graph context's normal stream restoration.
+        torch.cuda.synchronize(device)
+        return codes
+
+    current_after: torch.cuda.Stream | None = None
+    try:
+        with pytest.raises(RuntimeError, match="(?i)captur"):
+            api.capture(
+                invalidate_capture,
+                static_input,
+                pool=torch.cuda.graph_pool_handle(),
+                stream=side_stream,
+            )
+        current_after = torch.cuda.current_stream(device)
+    finally:
+        torch.cuda.set_stream(original_stream)
+
+    assert current_after == original_stream
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_real_cuda_build_and_replay_matches_eager() -> None:
+    class _TinyCode2WavModel(torch.nn.Module):
+        def forward(self, codes: torch.Tensor) -> torch.Tensor:
+            return (codes.float() * 2).sum(dim=1, keepdim=True)
+
+    device = torch.device("cuda", torch.cuda.current_device())
+    model = _TinyCode2WavModel().to(device).eval()
+    runner = Code2WavCudaGraphRunner.build(
+        model,
+        device=device,
+        num_quantizers=2,
+        total_gpu_memory_fraction=1.0,
+    )
+
+    stats = runner.stats()
+    assert stats["enabled"] is True
+    assert stats["build"]["published_graph_count"] == len(CODE2WAV_GRAPH_KEYS)
+
+    for key in CODE2WAV_GRAPH_KEYS:
+        codes = torch.arange(
+            key.batch_size * 2 * key.frames,
+            dtype=torch.long,
+            device=device,
+        ).reshape(key.batch_size, 2, key.frames)
+        with torch.inference_mode():
+            eager = model(codes).clone()
+        result = runner.run(codes)
+        graph_output = result.output.clone()
+
+        assert result.execution_mode == "cuda_graph"
+        assert result.key == key
+        assert torch.equal(graph_output, eager)
+
+
+def test_run_copies_live_input_replays_and_returns_borrowed_output_metadata() -> None:
+    runner, backend, _model = _build_runner()
+    graph = next(
+        graph
+        for graph in backend.graphs
+        if tuple(graph.static_input.shape) == (1, 16, 10)
+    )
+    first_codes = _codes(backend, 1, 10)
+
+    first = runner.run(first_codes)
+    first_snapshot = first.output.clone()
+
+    assert first.execution_mode == "cuda_graph"
+    assert first.key == GraphKey(batch_size=1, frames=10)
+    assert first.fallback_reason is None
+    assert first.output is graph.static_output
+    assert torch.equal(graph.replay_inputs[-1], first_codes)
+
+    second_codes = _codes(backend, 1, 10) + 7
+    backend.mark_cuda(second_codes)
+    second = runner.run(second_codes)
+
+    assert second.output is first.output
+    assert not torch.equal(first.output, first_snapshot)
+    assert torch.equal(graph.replay_inputs[-1], second_codes)
+    assert runner.stats()["runtime"]["graph_replays"] == 2
+
+
+@pytest.mark.parametrize(
+    ("runner_state", "eligible", "batch_size", "expected_reason"),
+    [
+        ("disabled", True, 1, "disabled"),
+        ("enabled", False, 1, "ineligible"),
+        ("enabled", True, 2, "key_miss"),
+    ],
+)
+def test_intentional_eager_fallbacks(
+    runner_state: str,
+    eligible: bool,
+    batch_size: int,
+    expected_reason: str,
+) -> None:
+    fraction = None if runner_state == "disabled" else 0.5
+    runner, backend, model = _build_runner(total_gpu_memory_fraction=fraction)
+    codes = _codes(backend, batch_size, 10)
+
+    calls_before = len(model.calls)
+    result = runner.run(codes, eligible=eligible)
+
+    assert result.execution_mode == "eager"
+    assert result.fallback_reason == expected_reason
+    assert len(model.calls) == calls_before + 1
+    assert runner.stats()["runtime"]["fallback_counts"] == {expected_reason: 1}
+    if expected_reason == "key_miss":
+        assert result.key == GraphKey(batch_size=batch_size, frames=10)
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_error", "message"),
+    [
+        ("non_cuda", TypeError, "CUDA tensor"),
+        ("wrong_dtype", TypeError, "torch.long"),
+        ("wrong_device", ValueError, "cuda:0"),
+        ("wrong_shape", ValueError, "shape"),
+        ("wrong_num_quantizers", ValueError, "16 quantizers"),
+    ],
+)
+def test_eligible_input_contract_violations_raise(
+    case: str,
+    expected_error: type[Exception],
+    message: str,
+) -> None:
+    runner, backend, model = _build_runner()
+    if case == "non_cuda":
+        codes = torch.zeros((1, 16, 10), dtype=torch.long)
+    elif case == "wrong_dtype":
+        codes = _codes(backend, 1, 10, dtype=torch.int32)
+    elif case == "wrong_device":
+        codes = _codes(backend, 1, 10, device="cuda:1")
+    elif case == "wrong_shape":
+        codes = backend.mark_cuda(torch.zeros((16, 10), dtype=torch.long))
+    else:
+        codes = _codes(backend, 1, 10, num_quantizers=15)
+    calls_before = len(model.calls)
+
+    with pytest.raises(expected_error, match=message):
+        runner.run(codes)
+
+    assert len(model.calls) == calls_before
+    assert runner.stats()["runtime"]["fallback_counts"] == {}
+
+
+@pytest.mark.parametrize(
+    ("runner_state", "eligible"),
+    [
+        ("enabled", True),
+        ("ineligible", False),
+        ("disabled", True),
+    ],
+)
+def test_pid_mismatch_fails_closed_before_any_eager_model_call(
+    runner_state: str,
+    eligible: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fraction = None if runner_state == "disabled" else 0.5
+    runner, backend, model = _build_runner(total_gpu_memory_fraction=fraction)
+    calls_before = len(model.calls)
+    monkeypatch.setattr(
+        code2wav_cuda_graph.os,
+        "getpid",
+        lambda: runner.stats()["binding"]["owner_pid"] + 1,
+    )
+
+    with pytest.raises(RuntimeError, match="must be rebuilt in a spawned process"):
+        runner.run(_codes(backend, 1, 10), eligible=eligible)
+
+    assert len(model.calls) == calls_before
+    runtime = runner.stats()["runtime"]
+    assert runtime["fallback_counts"] == {}
+    json.dumps(runner.stats(), allow_nan=False)
+
+
+@pytest.mark.parametrize(
+    ("backend_factory", "fraction", "reason_prefix"),
+    [
+        (lambda: _FakeCudaBackend(capture_error_at=3), 0.5, "capture_failed"),
+        (lambda: _FakeCudaBackend(replay_error_at=3), 0.5, "capture_failed"),
+        (lambda: _FakeCudaBackend(corrupt_at=3), 0.5, "equivalence_failed"),
+        (lambda: _FakeCudaBackend(), 0.15, "memory_budget_exceeded"),
+    ],
+)
+def test_any_build_failure_rolls_back_every_graph(
+    backend_factory: Callable[[], _FakeCudaBackend],
+    fraction: float,
+    reason_prefix: str,
+) -> None:
+    backend = backend_factory()
+    runner, backend, _model = _build_runner(
+        backend=backend,
+        total_gpu_memory_fraction=fraction,
+    )
+
+    stats = runner.stats()
+    assert stats["enabled"] is False
+    assert stats["build"]["published_graph_count"] == 0
+    assert stats["disable_reason"].startswith(reason_prefix)
+    assert backend.empty_cache_calls >= 1
+    memory = stats["memory"]
+    assert memory["after"]["allocated_bytes"] == 160
+    assert memory["after_rollback"]["allocated_bytes"] == 100
+
+
+@pytest.mark.parametrize("fraction", [None, 0.0, -0.1, 1.01, float("nan")])
+def test_memory_fraction_must_be_explicit_and_in_range(
+    fraction: float | None,
+) -> None:
+    runner, _backend, _model = _build_runner(
+        total_gpu_memory_fraction=fraction,
+    )
+
+    stats = runner.stats()
+    assert stats["enabled"] is False
+    assert stats["build"]["published_graph_count"] == 0
+    assert stats["disable_reason"] == "invalid_total_gpu_memory_fraction"
+
+
+def test_runtime_replay_failure_is_raised_and_disables_all_graphs() -> None:
+    runner, backend, _model = _build_runner()
+    build_stats = runner.stats()["build"]
+    graph = next(
+        graph
+        for graph in backend.graphs
+        if tuple(graph.static_input.shape) == (1, 16, 10)
+    )
+    graph.fail_replay = RuntimeError("replay exploded")
+
+    with pytest.raises(RuntimeError, match="replay exploded"):
+        runner.run(_codes(backend, 1, 10))
+
+    stats = runner.stats()
+    assert stats["enabled"] is False
+    assert stats["disable_reason"] == (
+        "runtime_replay_failed: RuntimeError: replay exploded"
+    )
+    assert stats["build"] == build_stats
+    assert stats["runtime"]["replay_failures"] == 1
+
+    calls_before = len(_model.calls)
+    fallback = runner.run(_codes(backend, 1, 10))
+    assert fallback.execution_mode == "eager"
+    assert fallback.fallback_reason == "disabled"
+    assert len(_model.calls) == calls_before + 1
+
+
+def test_stats_are_strictly_json_safe_after_success_and_failure() -> None:
+    successful, successful_backend, _model = _build_runner()
+    successful.run(_codes(successful_backend, 3, 10))
+    failed, _failed_backend, _model = _build_runner(
+        backend=_FakeCudaBackend(corrupt_at=0)
+    )
+
+    json.dumps(successful.stats(), allow_nan=False)
+    json.dumps(failed.stats(), allow_nan=False)

--- a/tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav_cuda_graph.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Callable
 from contextlib import nullcontext
 from typing import Any
@@ -225,6 +226,13 @@ def _codes(
     return backend.mark_cuda(tensor, device=device)
 
 
+@pytest.fixture(autouse=True)
+def _disable_shape_telemetry_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SGLANG_OMNI_TRACE_CODE2WAV_GRAPH", raising=False)
+
+
 def test_graph_keys_are_the_four_serial_serving_shapes() -> None:
     assert CODE2WAV_GRAPH_KEYS == tuple(
         GraphKey(batch_size=1, frames=frames) for frames in (10, 20, 30, 35)
@@ -308,6 +316,146 @@ def test_stats_report_only_operational_state() -> None:
         "replay_failures": 0,
         "fallback_counts": {},
     }
+
+
+@pytest.mark.parametrize("value", [None, "", "0", "false", "no", "off"])
+def test_shape_telemetry_false_values_leave_runtime_stats_unchanged(
+    value: str | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if value is None:
+        monkeypatch.delenv("SGLANG_OMNI_TRACE_CODE2WAV_GRAPH", raising=False)
+    else:
+        monkeypatch.setenv("SGLANG_OMNI_TRACE_CODE2WAV_GRAPH", value)
+    runner, backend, _model = _build_runner()
+
+    runner.run(_codes(backend, 1, 10))
+
+    assert runner._shape_graph_counts is None
+    assert runner._shape_fallback_counts is None
+    assert runner.stats()["runtime"] == {
+        "graph_replays": 1,
+        "replay_failures": 0,
+        "fallback_counts": {},
+    }
+
+
+def test_shape_telemetry_matches_known_hit_and_fallback_mix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_TRACE_CODE2WAV_GRAPH", "1")
+    runner, backend, _model = _build_runner()
+
+    runner.run(_codes(backend, 1, 10))
+    runner.run(_codes(backend, 1, 10))
+    runner.run(_codes(backend, 1, 20))
+    runner.run(_codes(backend, 2, 10))
+    runner.run(_codes(backend, 1, 35), eligible=False)
+
+    assert runner.stats()["runtime"]["shape_telemetry"] == {
+        "total_executions": 5,
+        "graph_replays": 3,
+        "eager_fallbacks": 2,
+        "hit_rate": 0.6,
+        "shapes": [
+            {
+                "batch_size": 1,
+                "frames": 10,
+                "graph_replays": 2,
+                "eager_fallbacks": 0,
+                "fallback_counts": {},
+                "hit_rate": 1.0,
+            },
+            {
+                "batch_size": 1,
+                "frames": 20,
+                "graph_replays": 1,
+                "eager_fallbacks": 0,
+                "fallback_counts": {},
+                "hit_rate": 1.0,
+            },
+            {
+                "batch_size": 1,
+                "frames": 35,
+                "graph_replays": 0,
+                "eager_fallbacks": 1,
+                "fallback_counts": {"ineligible": 1},
+                "hit_rate": 0.0,
+            },
+            {
+                "batch_size": 2,
+                "frames": 10,
+                "graph_replays": 0,
+                "eager_fallbacks": 1,
+                "fallback_counts": {"key_miss": 1},
+                "hit_rate": 0.0,
+            },
+        ],
+    }
+
+
+def test_shape_telemetry_logs_periodically_and_on_shutdown(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_TRACE_CODE2WAV_GRAPH", "yes")
+    monkeypatch.setattr(
+        code2wav_cuda_graph,
+        "_CODE2WAV_GRAPH_TRACE_REPORT_INTERVAL",
+        2,
+    )
+    runner, backend, _model = _build_runner()
+
+    with caplog.at_level(logging.INFO, logger=code2wav_cuda_graph.__name__):
+        runner.run(_codes(backend, 1, 10))
+        assert not [
+            record for record in caplog.records if "shape telemetry" in record.message
+        ]
+        runner.run(_codes(backend, 2, 10))
+        runner.log_shape_telemetry(trigger="shutdown")
+
+    records = [
+        record for record in caplog.records if "shape telemetry" in record.message
+    ]
+    assert [
+        record.message.split(" trigger=", 1)[1].split(" ", 1)[0] for record in records
+    ] == ["periodic", "shutdown"]
+    snapshots = [json.loads(record.message.split("stats=", 1)[1]) for record in records]
+    assert snapshots[0] == snapshots[1]
+    assert snapshots[0]["total_executions"] == 2
+    assert snapshots[0]["hit_rate"] == 0.5
+
+
+def test_shape_telemetry_tracks_disabled_fallback_after_replay_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SGLANG_OMNI_TRACE_CODE2WAV_GRAPH", "1")
+    runner, backend, _model = _build_runner()
+    graph = next(
+        graph
+        for graph in backend.graphs
+        if tuple(graph.static_input.shape) == (1, 16, 10)
+    )
+    graph.fail_replay = RuntimeError("replay exploded")
+
+    with pytest.raises(RuntimeError, match="replay exploded"):
+        runner.run(_codes(backend, 1, 10))
+    runner.run(_codes(backend, 1, 10))
+
+    telemetry = runner.stats()["runtime"]["shape_telemetry"]
+    assert telemetry["total_executions"] == 1
+    assert telemetry["graph_replays"] == 0
+    assert telemetry["eager_fallbacks"] == 1
+    assert telemetry["shapes"] == [
+        {
+            "batch_size": 1,
+            "frames": 10,
+            "graph_replays": 0,
+            "eager_fallbacks": 1,
+            "fallback_counts": {"disabled": 1},
+            "hit_rate": 0.0,
+        }
+    ]
 
 
 def test_all_serving_keys_hit_while_batch_two_misses() -> None:

--- a/tests/unit_test/qwen3_omni/test_colocation_config.py
+++ b/tests/unit_test/qwen3_omni/test_colocation_config.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 
 import pytest
 
-from sglang_omni.config import build_process_topology_plan, build_stage_placement_plan
+from sglang_omni.config import (
+    build_process_topology_plan,
+    build_stage_placement_plan,
+    resolve_stage_factory_args,
+)
 from sglang_omni.models.qwen3_omni.config import (
     Qwen3OmniSpeechColocatedPipelineConfig,
     Qwen3OmniSpeechPipelineConfig,
@@ -43,11 +47,15 @@ def _set_colocated_runtime(
 
 def test_default_speech_topology_stays_disaggregated() -> None:
     config = Qwen3OmniSpeechPipelineConfig(model_path="dummy")
+    code2wav = _stage(config, "code2wav")
+    code2wav_args = resolve_stage_factory_args(code2wav, config)
 
     assert len(config.stages) == 8
     assert _stage(config, "thinker").gpu == 0
     assert _stage(config, "talker_ar").gpu == 1
-    assert _stage(config, "code2wav").gpu == 1
+    assert code2wav.gpu == 1
+    assert code2wav_args["enable_cuda_graph"] is True
+    assert code2wav_args["total_gpu_memory_fraction"] == pytest.approx(0.02)
     assert _stage(config, "talker_ar").factory_args["enable_partial_start"] is True
     assert config.placement.require_memory_fraction_for_colocation is False
     assert {stage.name: stage.process for stage in config.stages} == {


### PR DESCRIPTION
 ## Motivation

  Qwen3-Omni Code2Wav CUDA graphs capture only the exact serving shapes
  `B1/T{10,20,30,35}`. If incoming shapes drift, execution silently falls back
  to eager mode, making it difficult to verify graph coverage under real traffic
  or determine which additional shapes should be captured. See more in https://github.com/sgl-project/sglang-omni/issues/1146 

  This PR adds opt-in per-shape telemetry so operators can observe CUDA-graph hit
  rates and eager fallback reasons.

  ## Modifications

  - Add the `SGLANG_OMNI_TRACE_CODE2WAV_GRAPH=1` environment variable.
  - Track CUDA-graph replays by `(batch_size, frames)`.
  - Track eager fallbacks by shape and reason:
    - `disabled`
    - `ineligible`
    - `key_miss`
  - Report cumulative totals, per-shape counts, and hit rates as JSON.
  - Log a summary every 2,000 Code2Wav decodes and when the scheduler exits.
    The interval follows the existing MOSS-TTS Local vocoder precedent.
  - Continue tracking `disabled` fallbacks after a runtime replay failure disables
    the graph runner.
  - Keep telemetry disabled by default. The disabled decode path only checks a
    cached boolean and does not allocate per-shape counters.
  - Add unit tests for known hit/miss mixtures, periodic and shutdown reporting,
    disabled environment values, and runtime graph disablement.
  - Document how to enable and interpret the telemetry.

  ## Related Issues

  Closes #1146.

  Part of #1022.

  Depends on #1101.

  ## Accuracy Test

  Not required. This is an observability-only change and does not alter CUDA-graph
  selection, eager fallback behavior, model execution, or audio output.

  The focused unit tests pass:

  ```text
  51 passed, 2 skipped

  The two skipped tests require CUDA hardware.

  ## Benchmark & Profiling

  Not required. Telemetry is disabled by default and this PR does not change
  inference behavior or make a performance claim.

  When enabled, telemetry uses host-side counters and emits one periodic log every
  2,000 Code2Wav decodes, plus a final summary when the scheduler exits.

  ## Checklist

  - [x] Format your code according with pre-commit.
  - [x] Add unit tests.
  - [x] Update documentation / docstrings / example tutorials as needed.
  - [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
  - [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

  ## CI

  CI runs on self-hosted GPU runners and requires a maintainer to add the
  run-ci label. Once labeled, every subsequent push re-triggers CI as
  long as the label remains. Use /tag-and-rerun-ci higgs or
  /tag-and-rerun-ci moss to select a TTS CI model. Draft PRs are skipped even
  if labeled.

