### PR TITLE
[Perf][MOSS-TTS] Restrict MOSS-TTS Delay audio-state text sampling

### DIFF
--- a/sglang_omni/models/moss_tts/model_runner.py
+++ b/sglang_omni/models/moss_tts/model_runner.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import torch
 from sglang.srt.layers.sampler import multinomial_with_seed
+from sglang.srt.layers.utils.hash import murmur_hash32
 
 from sglang_omni.model_runner.base import ModelRunner
 from sglang_omni.models.moss_tts.request_builders import _INF_DELAY
@@ -16,6 +17,24 @@ _NEG_INF = float("-inf")
 _INT64_MAX = torch.iinfo(torch.int64).max
 _UINT64_MASK = (1 << 64) - 1
 _INT64_SEED_MASK = (1 << 63) - 1
+
+
+@torch.compile(dynamic=True)
+def _multinomial_with_seed_and_token_ids(
+    logprobs: torch.Tensor,
+    seed: torch.Tensor,
+    positions: torch.Tensor,
+    token_ids: torch.Tensor,
+) -> torch.Tensor:
+    """Seeded Gumbel-max using original vocabulary ids as RNG columns."""
+
+    seed = seed.to(torch.uint64)
+    hashed = murmur_hash32(seed, positions, token_ids)
+    noise = hashed.to(torch.float64) / torch.iinfo(torch.uint32).max
+    noise.log_().clamp_(min=torch.finfo(noise.dtype).min).neg_()
+    noise.log_().neg_()
+    noise.add_(logprobs.to(torch.float64))
+    return torch.argmax(noise, dim=1)
 
 
 class MossTTSModelRunner(ModelRunner):
@@ -147,15 +166,25 @@ class MossTTSModelRunner(ModelRunner):
         schedule_batch: Any,
         requests: list,
     ) -> None:
-        channel_logits = self._channel_logits_from_result(result, forward_batch)
+        datas = [sched_req.data for sched_req in requests]
+        is_audio = bool(datas) and all(data.is_audio for data in datas)
+        channel_logits = self._channel_logits_from_result(
+            result,
+            forward_batch,
+            is_audio=is_audio,
+        )
         n_vq = len(channel_logits) - 1
         if n_vq <= 0:
             raise RuntimeError("MOSS-TTS requires at least one audio codebook head")
         if not requests:
             return
 
-        datas = [sched_req.data for sched_req in requests]
-        rows = self._sample_rows(channel_logits, datas, n_vq=n_vq)
+        rows = self._sample_rows(
+            channel_logits,
+            datas,
+            n_vq=n_vq,
+            is_audio=is_audio,
+        )
 
         next_token_ids = rows[:, 0].contiguous()
         result.next_token_ids = next_token_ids
@@ -170,17 +199,30 @@ class MossTTSModelRunner(ModelRunner):
         self,
         result: Any,
         forward_batch: Any,
+        *,
+        is_audio: bool = False,
     ) -> list[torch.Tensor]:
         logits_output = result.logits_output
         customized = getattr(logits_output, "customized_info", None)
         if isinstance(customized, dict):
             values = customized.get("moss_tts_channel_logits")
             if isinstance(values, list) and values:
+                if is_audio:
+                    token_ids = self.model.text_control_token_ids.to(
+                        device=values[0].device
+                    )
+                    return [values[0].index_select(-1, token_ids), *values[1:]]
                 return values
         hidden_states = getattr(logits_output, "hidden_states", None)
         if isinstance(hidden_states, torch.Tensor):
             if hidden_states.ndim == 3:
                 hidden_states = hidden_states[:, -1, :]
+            if is_audio:
+                return self.model.compute_channel_logits(
+                    hidden_states,
+                    forward_batch,
+                    is_audio=True,
+                )
             return self.model.compute_channel_logits(hidden_states, forward_batch)
         raise RuntimeError("MOSS-TTS model output did not include channel logits")
 
@@ -199,7 +241,7 @@ class MossTTSModelRunner(ModelRunner):
                 [
                     int(getattr(data, "audio_length", 0)),
                     delayed,
-                    int(bool(getattr(data, "is_audio", False))),
+                    int(data.is_audio),
                 ],
                 dtype=torch.long,
                 device=device,
@@ -213,6 +255,7 @@ class MossTTSModelRunner(ModelRunner):
         datas: list,
         *,
         n_vq: int,
+        is_audio: bool = False,
     ) -> torch.Tensor:
         """One batched MOSS-TTS delay-pattern decode step over the whole batch.
 
@@ -236,7 +279,7 @@ class MossTTSModelRunner(ModelRunner):
         )
         audio_lengths = delay_state[:, 0]
         delayed = delay_state[:, 1]
-        is_audio = delay_state[:, 2].bool()
+        audio_mask = delay_state[:, 2].bool()
         gen_steps = torch.tensor(
             [int(d.generation_steps) for d in datas], dtype=torch.long, device=device
         )
@@ -273,48 +316,60 @@ class MossTTSModelRunner(ModelRunner):
         num_channels = n_vq + 1
 
         text_logits = channel_logits[0].to(torch.float32)
-        vocab = text_logits.shape[-1]
-
         next_text = torch.full(
             (batch_size,), pad_token_id, dtype=torch.long, device=device
         )
         next_text[delayed < n_vq] = delay_slot
         is_audio_eos = delayed == n_vq
         next_text[is_audio_eos] = audio_end
-        is_audio = is_audio & ~is_audio_eos
-        sampling_text_mask = delayed > n_vq
-
-        not_audio = ~is_audio
-        if bool(not_audio.any()):
-            exclude = torch.tensor(
-                [
-                    t
-                    for t in (pad_token_id, gen_slot, delay_slot, audio_end)
-                    if 0 <= t < vocab
-                ],
-                dtype=torch.long,
-                device=device,
+        audio_mask = audio_mask & ~is_audio_eos
+        text_candidate_token_ids: torch.Tensor | None = None
+        if is_audio:
+            if int(text_logits.shape[-1]) != 2:
+                raise RuntimeError(
+                    "MOSS-TTS control-only text logits must have two columns"
+                )
+            text_candidate_token_ids = self.model.text_control_token_ids.to(
+                device=device
             )
-            text_logits[not_audio] = text_logits[not_audio].index_fill(
-                -1, exclude, _NEG_INF
-            )
-        if bool(is_audio.any()):
-            allow_only = torch.ones(vocab, dtype=torch.bool, device=device)
-            for token_id in (gen_slot, delay_slot):
-                if 0 <= token_id < vocab:
-                    allow_only[token_id] = False
-            text_logits[is_audio] = text_logits[is_audio].masked_fill(
-                allow_only, _NEG_INF
-            )
-
-        if 0 <= delay_slot < vocab:
+            sampling_text_mask = audio_mask & (delayed > n_vq)
             step0 = gen_steps == 0
             if bool(step0.any()):
-                text_logits[step0, delay_slot] = _NEG_INF
-        if 0 <= im_end < vocab:
-            step_le_nvq = gen_steps <= n_vq
-            if bool(step_le_nvq.any()):
-                text_logits[step_le_nvq, im_end] = _NEG_INF
+                text_logits[step0, 1] = _NEG_INF
+        else:
+            vocab = text_logits.shape[-1]
+            sampling_text_mask = delayed > n_vq
+            not_audio = ~audio_mask
+            if bool(not_audio.any()):
+                exclude = torch.tensor(
+                    [
+                        t
+                        for t in (pad_token_id, gen_slot, delay_slot, audio_end)
+                        if 0 <= t < vocab
+                    ],
+                    dtype=torch.long,
+                    device=device,
+                )
+                text_logits[not_audio] = text_logits[not_audio].index_fill(
+                    -1, exclude, _NEG_INF
+                )
+            if bool(audio_mask.any()):
+                allow_only = torch.ones(vocab, dtype=torch.bool, device=device)
+                for token_id in (gen_slot, delay_slot):
+                    if 0 <= token_id < vocab:
+                        allow_only[token_id] = False
+                text_logits[audio_mask] = text_logits[audio_mask].masked_fill(
+                    allow_only, _NEG_INF
+                )
+
+            if 0 <= delay_slot < vocab:
+                step0 = gen_steps == 0
+                if bool(step0.any()):
+                    text_logits[step0, delay_slot] = _NEG_INF
+            if 0 <= im_end < vocab:
+                step_le_nvq = gen_steps <= n_vq
+                if bool(step_le_nvq.any()):
+                    text_logits[step_le_nvq, im_end] = _NEG_INF
 
         if bool(sampling_text_mask.any()):
             idx = sampling_text_mask.nonzero(as_tuple=False).squeeze(1)
@@ -325,9 +380,10 @@ class MossTTSModelRunner(ModelRunner):
                 top_k=text_top_k[idx],
                 seeds=sampling_seeds[idx],
                 positions=gen_steps[idx] * num_channels,
+                candidate_token_ids=text_candidate_token_ids,
             )
-        is_audio = is_audio | (next_text == audio_start)
-        is_audio = is_audio & (next_text != im_end)
+        audio_mask = audio_mask | (next_text == audio_start)
+        audio_mask = audio_mask & (next_text != im_end)
 
         next_audio = torch.full(
             (batch_size, n_vq), audio_pad_code, dtype=torch.long, device=device
@@ -372,7 +428,7 @@ class MossTTSModelRunner(ModelRunner):
         delayed[not_inf] = delayed[not_inf] + 1
         delayed[delayed > n_vq] = _INT64_MAX
 
-        next_state = torch.stack((audio_lengths, delayed, is_audio.long()), dim=1)
+        next_state = torch.stack((audio_lengths, delayed, audio_mask.long()), dim=1)
         for i, data in enumerate(datas):
             data.delay_state = next_state[i].detach()
             if device.type == "cpu":
@@ -409,22 +465,29 @@ class MossTTSModelRunner(ModelRunner):
         top_k: torch.Tensor | int,
         seeds: torch.Tensor,
         positions: torch.Tensor,
+        candidate_token_ids: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Per-row temperature / top-k / top-p sampling for ``[N, vocab]`` logits.
 
         ``temperature``/``top_p``/``top_k`` may be scalars or per-row tensors of
         length N and are applied entirely through vectorized tensor masks (no
         ``.tolist()`` or Python-side grouping, so each row keeps its own params).
-        Sampling uses ``multinomial_with_seed`` so each row draws from its own
-        ``seeds``/``positions`` and is reproducible regardless of batch
-        composition. Rows with temperature <= 0, or rows left fully masked, fall
-        back to greedy argmax; ``logits`` is float32 with disallowed tokens
-        already masked to ``-inf``.
+        When ``candidate_token_ids`` is provided, ``logits`` must contain exactly
+        those two candidates; sampling hashes their original vocabulary ids and
+        maps the local sampled column back to the original id. Rows with
+        temperature <= 0, or rows left fully masked, fall back to greedy argmax;
+        ``logits`` is float32 with disallowed tokens already masked to ``-inf``.
         """
-        num_rows = logits.shape[0]
+        num_rows = int(logits.shape[0])
         if num_rows == 0:
             return torch.empty(0, dtype=torch.long, device=logits.device)
         device = logits.device
+        if candidate_token_ids is not None:
+            candidate_token_ids = candidate_token_ids.to(device=device)
+            if tuple(logits.shape[1:]) != (2,) or int(candidate_token_ids.numel()) != 2:
+                raise ValueError(
+                    "MOSS-TTS compact candidate sampling requires exactly two tokens"
+                )
 
         temp = MossTTSModelRunner._as_row_tensor(
             temperature, num_rows, torch.float32, device
@@ -438,8 +501,16 @@ class MossTTSModelRunner(ModelRunner):
         do_sample = temp > 0
         safe_temp = torch.where(do_sample, temp, torch.ones_like(temp))
         scores = logits / safe_temp.unsqueeze(1)
-        scores = MossTTSModelRunner._apply_top_k(scores, top_k_row)
-        scores = MossTTSModelRunner._apply_top_p(scores, top_p_row)
+        if candidate_token_ids is not None:
+            scores = MossTTSModelRunner._apply_two_token_top_k(scores, top_k_row)
+            scores = MossTTSModelRunner._apply_top_p(
+                scores,
+                top_p_row,
+                skip_inactive_check=True,
+            )
+        else:
+            scores = MossTTSModelRunner._apply_top_k(scores, top_k_row)
+            scores = MossTTSModelRunner._apply_top_p(scores, top_p_row)
 
         probs = torch.softmax(scores, dim=-1)
         probs = torch.nan_to_num(probs, nan=0.0, posinf=0.0, neginf=0.0)
@@ -451,8 +522,25 @@ class MossTTSModelRunner(ModelRunner):
             positions, num_rows, torch.long, device
         )
         fallback = (~do_sample) | (probs.sum(dim=-1) <= 0)
-        sample_mask = ~fallback
         sampled = torch.argmax(logits, dim=-1)
+        if candidate_token_ids is not None:
+            if device.type == "cpu":
+                candidate_sampled = MossTTSModelRunner._multinomial_with_seed_cpu(
+                    probs,
+                    seeds_row,
+                    positions_row,
+                )
+            else:
+                candidate_sampled = _multinomial_with_seed_and_token_ids(
+                    scores,
+                    seeds_row,
+                    positions_row,
+                    candidate_token_ids,
+                )
+            sampled = torch.where(fallback, sampled, candidate_sampled)
+            return candidate_token_ids[sampled].to(torch.long)
+
+        sample_mask = ~fallback
         if bool(sample_mask.any()):
             if device.type == "cpu":
                 sampled[sample_mask] = MossTTSModelRunner._multinomial_with_seed_cpu(
@@ -470,6 +558,18 @@ class MossTTSModelRunner(ModelRunner):
                     positions_row[sample_mask],
                 ).view(-1)
         return sampled.to(torch.long)
+
+    @staticmethod
+    def _apply_two_token_top_k(
+        scores: torch.Tensor,
+        top_k_row: torch.Tensor,
+    ) -> torch.Tensor:
+        """Apply the only active compact top-k case without a host sync."""
+        top1 = top_k_row == 1
+        top1_threshold = scores.max(dim=-1, keepdim=True).values
+        return scores.masked_fill(
+            top1.unsqueeze(1) & (scores < top1_threshold), _NEG_INF
+        )
 
     @staticmethod
     def _multinomial_with_seed_cpu(
@@ -517,10 +617,20 @@ class MossTTSModelRunner(ModelRunner):
         return scores.masked_fill(scores < threshold, _NEG_INF)
 
     @staticmethod
-    def _apply_top_p(scores: torch.Tensor, top_p_row: torch.Tensor) -> torch.Tensor:
-        """Per-row nucleus mask; rows with p <= 0 or p >= 1 are left untouched."""
+    def _apply_top_p(
+        scores: torch.Tensor,
+        top_p_row: torch.Tensor,
+        *,
+        skip_inactive_check: bool = False,
+    ) -> torch.Tensor:
+        """Apply per-row nucleus masking.
+
+        ``skip_inactive_check`` keeps the compact hot path tensor-only instead
+        of synchronizing with the host just to discover that every row uses
+        ``top_p=1``.
+        """
         active = (top_p_row > 0.0) & (top_p_row < 1.0)
-        if not bool(active.any()):
+        if not skip_inactive_check and not bool(active.any()):
             return scores
         sorted_scores, sorted_indices = torch.sort(scores, descending=True, dim=-1)
         probs = torch.softmax(sorted_scores, dim=-1)
@@ -591,9 +701,18 @@ class MossTTSModelRunner(ModelRunner):
             return
 
         eos_id = int(self.model.config.im_end_token_id)
+        audio_start_id = int(self.model.config.audio_start_token_id)
+        audio_end_id = int(self.model.config.audio_end_token_id)
         for row_idx, sched_req in enumerate(scheduler_output.requests):
             req_output = outputs[sched_req.request_id]
-            if req_output.data is None or int(req_output.data) == eos_id:
+            if req_output.data is None:
+                continue
+            text_token_id = int(req_output.data)
+            if text_token_id == audio_start_id:
+                sched_req.data.is_audio = True
+            elif text_token_id == audio_end_id:
+                sched_req.data.is_audio = False
+            if text_token_id == eos_id:
                 continue
             sched_req.data.output_rows.append(rows[row_idx].detach().clone())
             sched_req.data.pending_feedback_queue.append(

--- a/sglang_omni/models/moss_tts/request_builders.py
+++ b/sglang_omni/models/moss_tts/request_builders.py
@@ -311,7 +311,7 @@ def build_generation_kwargs(
         )
 
     for source in (tts_params, params):
-        for field in (
+        for param_name in (
             "text_temperature",
             "text_top_p",
             "text_top_k",
@@ -320,10 +320,10 @@ def build_generation_kwargs(
             "audio_top_k",
             "audio_repetition_penalty",
         ):
-            if source.get(field) is not None:
-                value = source[field]
-                generation_kwargs[field] = (
-                    int(value) if field.endswith("top_k") else float(value)
+            if source.get(param_name) is not None:
+                value = source[param_name]
+                generation_kwargs[param_name] = (
+                    int(value) if param_name.endswith("top_k") else float(value)
                 )
 
     seed = tts_params.get("seed")
@@ -343,17 +343,21 @@ def _validate_moss_tts_generation_kwargs(kwargs: dict[str, Any]) -> None:
         raise ValueError(
             f"MOSS-TTS max_new_tokens must be > 0, got {kwargs['max_new_tokens']!r}"
         )
-    for field in ("text_temperature", "audio_temperature"):
-        if float(kwargs[field]) < 0:
-            raise ValueError(f"MOSS-TTS {field} must be >= 0, got {kwargs[field]!r}")
-    for field in ("text_top_p", "audio_top_p"):
-        if not 0.0 < float(kwargs[field]) <= 1.0:
+    for param_name in ("text_temperature", "audio_temperature"):
+        if float(kwargs[param_name]) < 0:
             raise ValueError(
-                f"MOSS-TTS {field} must be in (0, 1], got {kwargs[field]!r}"
+                f"MOSS-TTS {param_name} must be >= 0, got {kwargs[param_name]!r}"
             )
-    for field in ("text_top_k", "audio_top_k"):
-        if int(kwargs[field]) < -1:
-            raise ValueError(f"MOSS-TTS {field} must be >= -1, got {kwargs[field]!r}")
+    for param_name in ("text_top_p", "audio_top_p"):
+        if not 0.0 < float(kwargs[param_name]) <= 1.0:
+            raise ValueError(
+                f"MOSS-TTS {param_name} must be in (0, 1], got {kwargs[param_name]!r}"
+            )
+    for param_name in ("text_top_k", "audio_top_k"):
+        if int(kwargs[param_name]) < -1:
+            raise ValueError(
+                f"MOSS-TTS {param_name} must be >= -1, got {kwargs[param_name]!r}"
+            )
     if float(kwargs["audio_repetition_penalty"]) <= 0:
         raise ValueError(
             "MOSS-TTS audio_repetition_penalty must be > 0, got "

--- a/sglang_omni/models/moss_tts/sglang_model.py
+++ b/sglang_omni/models/moss_tts/sglang_model.py
@@ -120,6 +120,17 @@ class MossTTSDelaySGLangModel(torch.nn.Module):
             ]
         )
         self._pad_token_per_channel = self._compute_pad_token_per_channel()
+        self.register_buffer(
+            "_text_control_token_ids",
+            torch.tensor(
+                [
+                    int(self.config.audio_assistant_gen_slot_token_id),
+                    int(self.config.audio_assistant_delay_slot_token_id),
+                ],
+                dtype=torch.long,
+            ),
+            persistent=False,
+        )
 
         max_batch_size = getattr(getattr(self, "config", None), "max_batch_size", None)
         try:
@@ -320,25 +331,44 @@ class MossTTSDelaySGLangModel(torch.nn.Module):
         logits_metadata = LogitsMetadata.from_forward_batch(forward_batch)
         logits_metadata.next_token_logits_buffer = None
         logits_metadata.forward_mode = ForwardMode.DECODE
-        return [
+        outputs = [
+            self.logits_processors[0](
+                None,
+                hidden_states=hidden_states,
+                lm_head=self.lm_heads[0],
+                logits_metadata=logits_metadata,
+            )
+        ]
+        outputs.extend(
             processor(
                 None,
                 hidden_states=hidden_states,
                 lm_head=self.lm_heads[idx],
                 logits_metadata=logits_metadata,
             )
-            for idx, processor in enumerate(self.logits_processors)
-        ]
+            for idx, processor in enumerate(self.logits_processors[1:], start=1)
+        )
+        return outputs
 
     def compute_channel_logits(
         self,
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
+        *,
+        is_audio: bool = False,
     ) -> list[torch.Tensor]:
-        return [
+        logits = [
             output.next_token_logits
             for output in self.compute_channel_outputs(hidden_states, forward_batch)
         ]
+        if is_audio:
+            token_ids = self._text_control_token_ids.to(device=logits[0].device)
+            logits[0] = logits[0].index_select(-1, token_ids)
+        return logits
+
+    @property
+    def text_control_token_ids(self) -> torch.Tensor:
+        return self._text_control_token_ids
 
     @staticmethod
     def _select_sample_hidden_states(

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -677,6 +677,104 @@ def test_moss_delay_runner_samples_audio_and_appends_feedback() -> None:
     assert data.audio_length == 2
 
 
+def test_moss_delay_runner_restricts_text_only_while_audio_is_active() -> None:
+    from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+
+    cfg = SimpleNamespace(
+        pad_token_id=0,
+        audio_start_token_id=10,
+        audio_end_token_id=11,
+        audio_assistant_gen_slot_token_id=12,
+        audio_assistant_delay_slot_token_id=13,
+        audio_pad_code=4,
+        im_end_token_id=14,
+    )
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    runner.model = SimpleNamespace(
+        config=cfg,
+        text_control_token_ids=torch.tensor([12, 13], dtype=torch.long),
+    )
+    data = SimpleNamespace(
+        delay_state=torch.tensor([1, torch.iinfo(torch.int64).max, 1]),
+        generation_steps=1,
+        sampling_seed=0,
+        text_temperature=0.0,
+        text_top_p=1.0,
+        text_top_k=-1,
+        audio_temperature=0.0,
+        audio_top_p=1.0,
+        audio_top_k=-1,
+        audio_repetition_penalty=1.0,
+        prompt_rows=None,
+        output_rows=[],
+    )
+    control_logits = torch.tensor([[5.0, -5.0]])
+    audio0_logits = torch.tensor([[-1.0, 0.0, 5.0, 1.0, -100.0]])
+    audio1_logits = torch.tensor([[-1.0, 6.0, 0.0, 1.0, -100.0]])
+
+    rows = runner._sample_rows(
+        [control_logits, audio0_logits, audio1_logits],
+        [data],
+        n_vq=2,
+        is_audio=True,
+    )
+    assert int(rows[0, 0]) == cfg.audio_assistant_gen_slot_token_id
+
+    # Once the Delay tail reaches n_vq, audio_end is forced. The next step must
+    # return to the original full-vocabulary text path; it is not forced to EOS
+    # inside the two-token sampler.
+    data.delay_state = torch.tensor([1, 2, 1])
+    data.generation_steps = 3
+    rows = runner._sample_rows(
+        [control_logits, audio0_logits, audio1_logits],
+        [data],
+        n_vq=2,
+        is_audio=True,
+    )
+    assert int(rows[0, 0]) == cfg.audio_end_token_id
+
+
+def test_moss_collect_step_uses_full_text_path_outside_audio() -> None:
+    from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    runner.model = SimpleNamespace(
+        device=torch.device("cpu"),
+        _prepare_multi_modal_inputs=lambda rows: rows.to(torch.float32),
+    )
+    seen: dict[str, bool] = {}
+
+    def channel_logits(result, forward_batch, *, is_audio=False):
+        del result, forward_batch
+        seen["head"] = is_audio
+        return [torch.zeros(1, 20), torch.zeros(1, 5)]
+
+    def sample_rows(channel_logits, datas, *, n_vq, is_audio=False):
+        del channel_logits, datas, n_vq
+        seen["sampler"] = is_audio
+        return torch.tensor([[0, 4]], dtype=torch.long)
+
+    runner._channel_logits_from_result = channel_logits
+    runner._sample_rows = sample_rows
+    result = SimpleNamespace(next_token_ids=None)
+    schedule_batch = SimpleNamespace(output_ids=None)
+    request = SimpleNamespace(data=SimpleNamespace(is_audio=False))
+
+    runner._collect_moss_step(result, object(), schedule_batch, [request])
+
+    assert seen == {"head": False, "sampler": False}
+
+
+def test_moss_collect_step_requires_is_audio_state() -> None:
+    from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    request = SimpleNamespace(data=SimpleNamespace())
+
+    with pytest.raises(AttributeError, match="is_audio"):
+        runner._collect_moss_step(object(), object(), object(), [request])
+
+
 def test_moss_prefill_forward_uses_prompt_row_embeds() -> None:
     from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
 
@@ -866,11 +964,41 @@ def test_moss_channel_logits_use_decode_metadata(
     assert metadata.next_token_logits_buffer is None
 
 
+def test_moss_text_control_logits_select_from_full_processor_output() -> None:
+    from sglang_omni.models.moss_tts.sglang_model import MossTTSDelaySGLangModel
+
+    full_text_logits = torch.arange(20, dtype=torch.float32).view(1, 20)
+    audio_logits = torch.tensor([[1.0, 2.0, 3.0]])
+    model = SimpleNamespace(
+        _text_control_token_ids=torch.tensor([12, 13], dtype=torch.long),
+        compute_channel_outputs=lambda hidden_states, forward_batch: [
+            SimpleNamespace(next_token_logits=full_text_logits),
+            SimpleNamespace(next_token_logits=audio_logits),
+        ],
+    )
+
+    logits = MossTTSDelaySGLangModel.compute_channel_logits(
+        model,
+        hidden_states=torch.ones(1, 4),
+        forward_batch=object(),
+        is_audio=True,
+    )
+
+    assert torch.equal(logits[0], full_text_logits[:, [12, 13]])
+    assert logits[1] is audio_logits
+
+
 def test_moss_post_process_outputs_skips_im_end() -> None:
     from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
 
     runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
-    runner.model = SimpleNamespace(config=SimpleNamespace(im_end_token_id=14))
+    runner.model = SimpleNamespace(
+        config=SimpleNamespace(
+            im_end_token_id=14,
+            audio_start_token_id=10,
+            audio_end_token_id=11,
+        )
+    )
     runner._pending_rows = torch.tensor([[12, 2, 4], [14, 4, 4]], dtype=torch.long)
     runner._pending_embeds = torch.ones((2, 3))
     requests = [
@@ -897,6 +1025,36 @@ def test_moss_post_process_outputs_skips_im_end() -> None:
     assert len(requests[0].data.pending_feedback_queue) == 1
     assert requests[1].data.output_rows == []
     assert requests[1].data.pending_feedback_queue == []
+
+
+def test_moss_post_process_audio_end_restores_full_text_sampling() -> None:
+    from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    runner.model = SimpleNamespace(
+        config=SimpleNamespace(
+            im_end_token_id=14,
+            audio_start_token_id=10,
+            audio_end_token_id=11,
+        )
+    )
+    runner._pending_rows = torch.tensor([[11, 4, 4]], dtype=torch.long)
+    runner._pending_embeds = torch.ones((1, 3))
+    data = SimpleNamespace(
+        output_rows=[],
+        pending_feedback_queue=[],
+        is_audio=True,
+    )
+    request = SimpleNamespace(request_id="audio-end", data=data)
+
+    runner.post_process_outputs(
+        object(),
+        SimpleNamespace(requests=[request]),
+        {"audio-end": RequestOutput("audio-end", data=11)},
+    )
+
+    assert data.is_audio is False
+    assert [row.tolist() for row in data.output_rows] == [[11, 4, 4]]
 
 
 def test_moss_delay_codec_splits_non_pad_segments() -> None:
@@ -948,6 +1106,66 @@ def test_moss_sample_tokens_uses_per_row_top_k() -> None:
     assert row0_vals == {0}  # top_k=1 -> always the argmax
     assert row1_vals - {0}  # top_k=4 -> reaches beyond the argmax
     assert row1_vals <= {0, 1, 2, 3}  # never the -inf-masked token
+
+
+def test_moss_compact_candidate_sampler_maps_greedy_indices() -> None:
+    from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+
+    token_ids = torch.tensor([12, 13], dtype=torch.long)
+    sampled = MossTTSModelRunner._sample_tokens(
+        torch.tensor([[1.0, 3.0], [4.0, 2.0]]),
+        temperature=torch.zeros(2),
+        top_p=torch.ones(2),
+        top_k=torch.full((2,), 50, dtype=torch.long),
+        seeds=torch.tensor([100, 101]),
+        positions=torch.tensor([33, 66]),
+        candidate_token_ids=token_ids,
+    )
+
+    assert sampled.tolist() == [13, 12]
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA seeded sampler"
+)
+def test_moss_text_control_sampler_preserves_full_vocab_seed_columns() -> None:
+    from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+
+    device = torch.device("cuda")
+    rows = 16
+    vocab = 32
+    token_ids = torch.tensor([12, 13], dtype=torch.long, device=device)
+    torch.manual_seed(0)
+    selected_logits = torch.randn(rows, 2, device=device)
+    full_logits = torch.full(
+        (rows, vocab), float("-inf"), dtype=torch.float32, device=device
+    )
+    full_logits[:, token_ids] = selected_logits
+    temperature = torch.full((rows,), 1.5, device=device)
+    top_p = torch.tensor([1.0, 0.8] * (rows // 2), device=device)
+    top_k = torch.tensor([50, 1] * (rows // 2), dtype=torch.long, device=device)
+    seeds = torch.arange(rows, dtype=torch.long, device=device) + 100
+    positions = torch.arange(rows, dtype=torch.long, device=device) * 33
+
+    full = MossTTSModelRunner._sample_tokens(
+        full_logits,
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+        seeds=seeds,
+        positions=positions,
+    )
+    restricted = MossTTSModelRunner._sample_tokens(
+        selected_logits,
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+        seeds=seeds,
+        positions=positions,
+        candidate_token_ids=token_ids,
+    )
+
+    assert torch.equal(restricted, full)
 
 
 def test_moss_tts_rejects_invalid_token_count() -> None:

--- a/tests/unit_test/moss_tts/test_pipeline.py
+++ b/tests/unit_test/moss_tts/test_pipeline.py
@@ -765,6 +765,85 @@ def test_moss_collect_step_uses_full_text_path_outside_audio() -> None:
     assert seen == {"head": False, "sampler": False}
 
 
+def test_moss_collect_step_mixed_batch_uses_full_text_path() -> None:
+    from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+
+    cfg = SimpleNamespace(
+        pad_token_id=0,
+        audio_start_token_id=10,
+        audio_end_token_id=11,
+        audio_assistant_gen_slot_token_id=12,
+        audio_assistant_delay_slot_token_id=13,
+        audio_pad_code=4,
+        im_end_token_id=14,
+    )
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    runner.model = SimpleNamespace(
+        config=cfg,
+        device=torch.device("cpu"),
+        _prepare_multi_modal_inputs=lambda rows: rows.to(torch.float32),
+    )
+    seen: dict[str, bool] = {}
+    text_logits = torch.full((2, 20), -100.0)
+    text_logits[0, 5] = 100.0
+    text_logits[0, cfg.audio_assistant_gen_slot_token_id] = 10.0
+    text_logits[0, cfg.audio_assistant_delay_slot_token_id] = 9.0
+    text_logits[1, 5] = 10.0
+    text_logits[1, cfg.audio_assistant_gen_slot_token_id] = 100.0
+    audio_logits = torch.tensor(
+        [
+            [-1.0, 0.0, 5.0, 1.0, -100.0],
+            [-1.0, 0.0, 1.0, 5.0, -100.0],
+        ]
+    )
+
+    def channel_logits(result, forward_batch, *, is_audio=False):
+        del result, forward_batch
+        seen["head"] = is_audio
+        return [text_logits, audio_logits]
+
+    sample_rows = runner._sample_rows
+
+    def sample_rows_spy(channel_logits, datas, *, n_vq, is_audio=False):
+        seen["sampler"] = is_audio
+        return sample_rows(channel_logits, datas, n_vq=n_vq, is_audio=is_audio)
+
+    runner._channel_logits_from_result = channel_logits
+    runner._sample_rows = sample_rows_spy
+
+    def data(*, is_audio: bool) -> SimpleNamespace:
+        return SimpleNamespace(
+            delay_state=torch.tensor(
+                [int(is_audio), torch.iinfo(torch.int64).max, int(is_audio)]
+            ),
+            generation_steps=1,
+            sampling_seed=0,
+            text_temperature=0.0,
+            text_top_p=1.0,
+            text_top_k=-1,
+            audio_temperature=0.0,
+            audio_top_p=1.0,
+            audio_top_k=-1,
+            audio_repetition_penalty=1.0,
+            is_audio=is_audio,
+        )
+
+    requests = [
+        SimpleNamespace(data=data(is_audio=True)),
+        SimpleNamespace(data=data(is_audio=False)),
+    ]
+    result = SimpleNamespace(next_token_ids=None)
+    schedule_batch = SimpleNamespace(output_ids=None)
+
+    runner._collect_moss_step(result, object(), schedule_batch, requests)
+
+    assert seen == {"head": False, "sampler": False}
+    assert runner._pending_rows[:, 0].tolist() == [
+        cfg.audio_assistant_gen_slot_token_id,
+        5,
+    ]
+
+
 def test_moss_collect_step_requires_is_audio_state() -> None:
     from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
 
@@ -1055,6 +1134,79 @@ def test_moss_post_process_audio_end_restores_full_text_sampling() -> None:
 
     assert data.is_audio is False
     assert [row.tolist() for row in data.output_rows] == [[11, 4, 4]]
+
+
+def test_moss_audio_end_in_batch_uses_full_text_path_on_next_step() -> None:
+    from sglang_omni.models.moss_tts.model_runner import MossTTSModelRunner
+
+    cfg = SimpleNamespace(
+        im_end_token_id=14,
+        audio_start_token_id=10,
+        audio_end_token_id=11,
+    )
+    runner = MossTTSModelRunner.__new__(MossTTSModelRunner)
+    runner.model = SimpleNamespace(
+        config=cfg,
+        device=torch.device("cpu"),
+        _prepare_multi_modal_inputs=lambda rows: rows.to(torch.float32),
+    )
+    requests = [
+        SimpleNamespace(
+            request_id="audio-end",
+            data=SimpleNamespace(
+                is_audio=True,
+                output_rows=[],
+                pending_feedback_queue=[],
+            ),
+        ),
+        SimpleNamespace(
+            request_id="audio-active",
+            data=SimpleNamespace(
+                is_audio=True,
+                output_rows=[],
+                pending_feedback_queue=[],
+            ),
+        ),
+    ]
+    runner._pending_rows = torch.tensor([[11, 4], [12, 2]], dtype=torch.long)
+    runner._pending_embeds = torch.ones((2, 2))
+
+    runner.post_process_outputs(
+        object(),
+        SimpleNamespace(requests=requests),
+        {
+            "audio-end": RequestOutput("audio-end", data=11),
+            "audio-active": RequestOutput("audio-active", data=12),
+        },
+    )
+
+    assert requests[0].data.is_audio is False
+    assert requests[1].data.is_audio is True
+
+    seen: dict[str, bool] = {}
+
+    def channel_logits(result, forward_batch, *, is_audio=False):
+        del result, forward_batch
+        seen["head"] = is_audio
+        return [torch.zeros(2, 20), torch.zeros(2, 5)]
+
+    def sample_rows(channel_logits, datas, *, n_vq, is_audio=False):
+        del channel_logits, datas, n_vq
+        seen["sampler"] = is_audio
+        return torch.tensor([[5, 4], [12, 2]], dtype=torch.long)
+
+    runner._channel_logits_from_result = channel_logits
+    runner._sample_rows = sample_rows
+    result = SimpleNamespace(next_token_ids=None)
+
+    runner._collect_moss_step(
+        result,
+        object(),
+        SimpleNamespace(output_ids=None),
+        requests,
+    )
+
+    assert seen == {"head": False, "sampler": False}
 
 
 def test_moss_delay_codec_splits_non_pad_segments() -> None:


### PR DESCRIPTION
## Motivation

During MOSS-TTS Delay audio generation, the text channel can only choose between
the generation-slot and delay-slot control tokens. The existing path still
carried the full text vocabulary through masking, top-k/top-p processing, and
seeded sampling on every audio decode step.

This PR reduces that audio-state text-sampling work while preserving:

- the existing full `LogitsProcessor` projection;
- the 32 audio-codebook projection and batched sampling path;
- full-vocabulary sampling rules outside audio generation;
- per-request temperature, top-k, top-p, and seed behavior;
- seeded sampling results based on the original global vocabulary token IDs.

## Modifications

- Track whether scheduled MOSS-TTS requests are currently inside an audio span
  and enable the compact path only when the whole active batch is in the audio
  state. Mixed or non-audio batches retain the original full-vocabulary path.
- Register the generation-slot and delay-slot token IDs on the model. After the
  normal text `LogitsProcessor` runs, select only those two columns for
  audio-state text sampling.
- Add a two-candidate sampling path that:
  - preserves greedy, temperature, top-k, and top-p behavior;
  - hashes the original vocabulary IDs when performing CUDA seeded Gumbel-max;
  - maps the selected local column back to the original global token ID;
  - avoids the general top-k host synchronization for the two-token case.
- Update audio start/end state transitions so the runner returns to the full
  text path after the audio span ends.
- Add tests covering compact audio-state sampling, non-audio fallback, state
  transitions, control-logit selection, greedy token-ID mapping, and CUDA seeded
  equivalence with the original full-vocabulary sampler.
- Rename local generation-parameter loop variables in `request_builders.py`;
  this is a behavior-neutral cleanup.

## Related Issues

N/A.

## Accuracy Test

No model weights, audio-codebook candidate set, or non-audio text candidate set
is changed. The CUDA equivalence test verifies that compact control-token
sampling produces the same seeded result as full-vocabulary sampling with all
other text tokens masked.

```text
.venv/bin/pytest -q tests/unit_test/moss_tts/test_pipeline.py
37 passed, 20 warnings in 12.14s
```

The saved WAVs from the final performance repetitions 2, 3, 5, 6, and 7 were
then evaluated directly, without regenerating audio:

- ASR: `Qwen/Qwen3-ASR-1.7B`, concurrency 32;
- speaker similarity: WavLM large with the SeedTTS fine-tuned checkpoint;
- perceptual quality: `balacoon/utmos`, scores in `[1, 5]`;
- five full 1088-sample evaluations per side;
- every WER, similarity, and UTMOS run evaluated `1088/1088` samples with zero
  skips.

| Quality metric | Base mean +/- sample SD | Current mean +/- sample SD | Current - Base |
| --- | ---: | ---: | ---: |
| Qwen3-ASR corpus WER | 1.3514% +/- 0.0437 pp | 1.3782% +/- 0.0528 pp | +0.0268 pp |
| WER excluding >50% samples | 1.2852% +/- 0.0438 pp | 1.3120% +/- 0.0529 pp | +0.0268 pp |
| WavLM speaker similarity | 68.8941 +/- 0.0521 | 68.9143 +/- 0.0427 | +0.0202 |
| UTMOS | 3.9474 +/- 0.0031 | 3.9436 +/- 0.0060 | -0.0038 |

No material WER or speaker-similarity regression was observed. The WER shift
is smaller than the per-side run-to-run standard deviation, while mean speaker
similarity is slightly higher. The UTMOS shift is also smaller than the observed
run-to-run variation. No subjective listening evaluation was run.

## Benchmark & Profiling

End-to-end SeedTTS EN generation benchmark:

- model: `OpenMOSS-Team/MOSS-TTS-v1.5`;
- dataset: `zhaochenyang20/seed-tts-eval-arrow`, all 1088 EN samples;
- endpoint: non-streaming `/v1/audio/speech`;
- GPU: NVIDIA A800-SXM4-80GB;
- concurrency / max running requests / CUDA graph max batch size: `16 / 16 / 16`;
- one warm-up request, unlimited request rate, `max_new_tokens=2048`;
- fresh service and independent TorchInductor cache for every run;
- comparison: arithmetic mean of Current divided by arithmetic mean of Base,
  minus one. Per-pair relative deltas are not averaged into the primary result.

| Metric | Base mean | Current mean | Current vs. Base | Ratio-of-means 95% CI |
| --- | ---: | ---: | ---: | ---: |
| QPS | 2.9382 | 2.9858 | +1.620% | [+1.125%, +2.117%] |
| Mean latency | 5.4190 s | 5.3330 s | -1.587% | [-2.070%, -1.102%] |
| P95 latency | 6.5612 s | 6.4688 s | -1.408% | [-2.112%, -0.700%] |
| Mean RTF | 1.26898 | 1.24954 | -1.532% | [-2.042%, -1.020%] |
| Audio throughput | 13.1644 | 13.3784 | +1.626% | [+1.129%, +2.124%] |
| Output throughput | 261.52 tok/s | 265.76 tok/s | +1.621% | [+1.123%, +2.122%] |

No kernel-level profiler trace was collected; the table reports end-to-end
serving performance.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci moss` to select the MOSS-TTS
CI model. Draft PRs are skipped even if labeled.

GitHub CI has not been run yet.
