### PR TITLE
[Higgs-TTS] Isolate preprocessing and audio encoder from the AR engine

### DIFF
--- a/sglang_omni/models/higgs_tts/config.py
+++ b/sglang_omni/models/higgs_tts/config.py
@@ -24,6 +24,10 @@ class HiggsTtsPipelineConfig(PipelineConfig):
     drives the AR loop on the sglang backbone with the precomputed embed
     pasted at ``-100`` placeholder positions; vocoder reverses the delay
     pattern and decodes to waveform via the higgs-audio-v2-tokenizer codec.
+
+    Preprocessing and audio_encoder share a dedicated process so reference
+    waveforms stay on the local handoff while their host work is isolated from
+    the autoregressive engine.
     """
 
     architecture: ClassVar[str] = "HiggsMultimodalQwen3ForConditionalGeneration"
@@ -41,13 +45,13 @@ class HiggsTtsPipelineConfig(PipelineConfig):
     stages: list[StageConfig] = [
         StageConfig(
             name="preprocessing",
-            process="pipeline",
+            process="tts_frontend",
             factory=f"{_PKG}.stages.create_preprocessing_executor",
             next="audio_encoder",
         ),
         StageConfig(
             name="audio_encoder",
-            process="pipeline",
+            process="tts_frontend",
             factory=f"{_PKG}.stages.create_audio_encoder_executor",
             factory_args={"device": "cuda"},
             gpu=0,

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -7,8 +7,9 @@ Pipeline shape::
 
 - ``create_preprocessing_executor``: text tokenize + (if raw audio path)
   load waveform; fast path also delay-encodes client-supplied
-  ``reference_codes`` and builds the prompt. Returns a
-  :class:`ThreadedSimpleScheduler` for CPU-heavy work.
+  ``reference_codes`` and builds the prompt. Consumed reference media is
+  stripped from ``request.inputs`` before the payload leaves the stage.
+  Returns a :class:`ThreadedSimpleScheduler` for CPU-heavy work.
 - ``create_audio_encoder_executor``: GPU codec encode for the raw-audio
   path → delayed ref codes + prompt assembly. No-op on the fast path.
 - ``create_sglang_tts_engine_executor``: runs :class:`HiggsTTSModel` under
@@ -80,6 +81,14 @@ _REF_WAVEFORM_CACHE_MAX_ITEMS = 256
 _REF_WAVEFORM_CACHE_MAX_BYTES = 512 * 1024 * 1024
 _VOCODER_COMPILE_WARMUP_FRAME_COUNTS = (1, 8)
 
+# note (kaige li): preprocessing folds these into HiggsTtsState and nothing
+# downstream reads request.inputs again. Leaving them on the request re-pickles
+# the raw reference audio into the payload header on every cross-process hop
+# (audio_encoder -> tts_engine, tts_engine -> vocoder).
+_CONSUMED_REFERENCE_INPUT_KEYS = frozenset(
+    {"reference_audio", "references", "reference_codes"}
+)
+
 
 def _reference_audio_cache_key(reference_audio: Any) -> str | None:
     """Safe source key for preprocessing waveform-cache lookup."""
@@ -100,6 +109,17 @@ def _reference_audio_cache_key(reference_audio: Any) -> str | None:
         return None
     raw = base64.b64decode(encoded) if isinstance(encoded, str) else bytes(encoded)
     return hash_media_item(raw)
+
+
+def _without_consumed_reference_media(inputs: Any) -> Any:
+    """Return inputs with the reference media preprocessing already consumed."""
+    if not isinstance(inputs, dict):
+        return inputs
+    return {
+        key: value
+        for key, value in inputs.items()
+        if key not in _CONSUMED_REFERENCE_INPUT_KEYS
+    }
 
 
 def _reference_code_cache_key_from_waveform(
@@ -202,6 +222,10 @@ def create_preprocessing_executor(
     pre-encoded ``reference_codes``. When raw audio is supplied, defers
     codec encoding (and prompt assembly) to the audio_encoder stage —
     only the loaded waveform is shipped forward.
+
+    Reference media is dropped from ``request.inputs`` once folded into the
+    state, so downstream cross-process hops stop re-pickling the raw audio
+    into the payload header.
     """
     checkpoint_dir = resolve_checkpoint(model_path)
 
@@ -343,6 +367,9 @@ def create_preprocessing_executor(
             return_omni_rollout=bool(params.get("return_omni_rollout", False)),
         )
         payload.data = state.to_dict()
+        payload.request.inputs = _without_consumed_reference_media(
+            payload.request.inputs
+        )
         return payload
 
     return ThreadedSimpleScheduler(_preprocess, max_concurrency=max_concurrency)

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -2,6 +2,7 @@
 
 import base64
 import logging
+import pickle
 import queue
 from types import SimpleNamespace
 from typing import Any
@@ -650,6 +651,93 @@ def test_higgs_preprocessing_url_refs_use_decoded_content_key(monkeypatch) -> No
     assert first_state.reference_code_cache_key is not None
     assert first_state.reference_code_cache_key.startswith("waveform:")
     assert first_state.reference_code_cache_key == second_state.reference_code_cache_key
+
+
+def _stub_preprocessing_tokenizer(monkeypatch) -> None:
+    monkeypatch.setattr(stages, "resolve_checkpoint", lambda model_path: model_path)
+    monkeypatch.setattr(stages.Tokenizer, "from_file", lambda _path: object())
+    monkeypatch.setattr(
+        stages,
+        "PreTrainedTokenizerFast",
+        lambda tokenizer_object: object(),
+    )
+    monkeypatch.setattr(
+        stages,
+        "HiggsTokenizerAdapter",
+        lambda _tokenizer: SimpleNamespace(
+            build_prompt=lambda text, num_ref_tokens, reference_text: [1, 2, 3]
+        ),
+    )
+
+
+def test_higgs_preprocessing_drops_consumed_reference_audio(monkeypatch) -> None:
+    _stub_preprocessing_tokenizer(monkeypatch)
+    monkeypatch.setattr(
+        stages,
+        "load_audio_to_24k",
+        lambda reference_audio: (np.zeros(16, dtype=np.float32), 24000),
+    )
+
+    encoded = base64.b64encode(b"\x00\x11" * 4096).decode("ascii")
+    scheduler = stages.create_preprocessing_executor("ckpt", num_codebooks=2)
+    payload = scheduler._fn(
+        StagePayload(
+            request_id="raw-audio",
+            request=OmniRequest(
+                inputs={
+                    "text": "hello",
+                    "references": [{"media_type": "audio/wav", "data": encoded}],
+                },
+                params={"stream": True},
+            ),
+            data={},
+        )
+    )
+
+    assert payload.request.inputs == {"text": "hello"}
+    assert payload.request.params == {"stream": True}
+    assert HiggsTtsState.from_dict(payload.data).reference_waveform is not None
+    # write_payload pickles request into the data_ref header on every
+    # cross-process hop, so the reference audio must not survive preprocessing.
+    assert encoded.encode() not in pickle.dumps(payload.request)
+
+
+def test_higgs_preprocessing_drops_consumed_reference_codes(monkeypatch) -> None:
+    _stub_preprocessing_tokenizer(monkeypatch)
+
+    scheduler = stages.create_preprocessing_executor("ckpt", num_codebooks=2)
+    payload = scheduler._fn(
+        StagePayload(
+            request_id="ref-codes",
+            request=OmniRequest(
+                inputs={
+                    "text": "hello",
+                    "reference_text": "speaker",
+                    "reference_codes": [[1, 2], [3, 4]],
+                },
+                params={},
+            ),
+            data={},
+        )
+    )
+
+    assert payload.request.inputs == {"text": "hello", "reference_text": "speaker"}
+    assert HiggsTtsState.from_dict(payload.data).reference_codes_delayed is not None
+
+
+def test_higgs_preprocessing_keeps_plain_text_inputs(monkeypatch) -> None:
+    _stub_preprocessing_tokenizer(monkeypatch)
+
+    scheduler = stages.create_preprocessing_executor("ckpt", num_codebooks=2)
+    payload = scheduler._fn(
+        StagePayload(
+            request_id="text-only",
+            request=OmniRequest(inputs="hello", params={}),
+            data={},
+        )
+    )
+
+    assert payload.request.inputs == "hello"
 
 
 def test_higgs_model_runner_marks_sampler_finish() -> None:

--- a/tests/unit_test/higgs_tts/test_process_topology.py
+++ b/tests/unit_test/higgs_tts/test_process_topology.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from sglang_omni.config import build_process_topology_plan, build_stage_placement_plan
+from sglang_omni.models.higgs_tts.config import HiggsTtsPipelineConfig
+
+
+def test_higgs_preprocessing_and_audio_encoder_share_independent_process() -> None:
+    config = HiggsTtsPipelineConfig(model_path="fake-model")
+    placement_plan = build_stage_placement_plan(config)
+    process_plan = build_process_topology_plan(config, placement_plan)
+
+    assert process_plan.stage_to_process == {
+        "preprocessing": "audio_encoder",
+        "audio_encoder": "audio_encoder",
+        "tts_engine": "pipeline",
+        "vocoder": "vocoder",
+    }
+    assert [
+        (group.name, group.stage_names, group.gpu_id) for group in process_plan.groups
+    ] == [
+        ("audio_encoder", ("preprocessing", "audio_encoder"), 0),
+        ("pipeline", ("tts_engine",), 0),
+        ("vocoder", ("vocoder",), 0),
+    ]

--- a/tests/unit_test/higgs_tts/test_process_topology.py
+++ b/tests/unit_test/higgs_tts/test_process_topology.py
@@ -4,21 +4,21 @@ from sglang_omni.config import build_process_topology_plan, build_stage_placemen
 from sglang_omni.models.higgs_tts.config import HiggsTtsPipelineConfig
 
 
-def test_higgs_preprocessing_and_audio_encoder_share_independent_process() -> None:
+def test_higgs_preprocessing_and_audio_encoder_share_tts_frontend_process() -> None:
     config = HiggsTtsPipelineConfig(model_path="fake-model")
     placement_plan = build_stage_placement_plan(config)
     process_plan = build_process_topology_plan(config, placement_plan)
 
     assert process_plan.stage_to_process == {
-        "preprocessing": "audio_encoder",
-        "audio_encoder": "audio_encoder",
+        "preprocessing": "tts_frontend",
+        "audio_encoder": "tts_frontend",
         "tts_engine": "pipeline",
         "vocoder": "vocoder",
     }
     assert [
         (group.name, group.stage_names, group.gpu_id) for group in process_plan.groups
     ] == [
-        ("audio_encoder", ("preprocessing", "audio_encoder"), 0),
+        ("tts_frontend", ("preprocessing", "audio_encoder"), 0),
         ("pipeline", ("tts_engine",), 0),
         ("vocoder", ("vocoder",), 0),
     ]


### PR DESCRIPTION
## Motivation

The Higgs TTS pipeline currently places `preprocessing`, `audio_encoder`, and `tts_engine` in the same `pipeline` process. This couples reference-audio preparation to the autoregressive engine's Python process and makes the two paths share the same process-level runtime resources.

## Modifications

This change moves `preprocessing` and `audio_encoder` into one dedicated process. Keeping these two stages co-located preserves their local handoff, while isolating both stages from the autoregressive engine.

## Accuracy Test

Not related

## Benchmark & Profiling

- Dataset: SeedTTS
- 256 warmup requests per case
- Concurrency: 96
- `max_running_requests=96`
- `cuda_graph_max_bs=96`
- `prefill_coalesce_requests=32`
- `prefill_coalesce_wait_ms=300`
- Compiled vocoder decode enabled
- `max_new_tokens=2048`

| Metric | main | this PR | Change |
|---|---:|---:|---:|
| Throughput | 19.328 QPS | 28.894 QPS | **+49.50%** |
| Mean latency | 4.816 s | 3.254 s | **-32.44%** |
| P50 latency | 4.954 s | 3.214 s | **-35.12%** |
| P95 latency | 6.183 s | 4.531 s | **-26.71%** |
| P99 latency | 6.863 s | 5.196 s | **-24.28%** |

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.