### PR TITLE
[Qwen3-Omni Perf] Use SDPA enable_gqa in predictor attention

### DIFF
--- a/sglang_omni/models/qwen3_omni/components/talker.py
+++ b/sglang_omni/models/qwen3_omni/components/talker.py
@@ -791,7 +791,6 @@ class Qwen3OmniMoeTalkerCodePredictor(nn.Module):
             1, 2
         )
 
-        # Use SDPA with native GQA (no materialized KV expansion)
         attn_output = torch.nn.functional.scaled_dot_product_attention(
             q,
             k,

--- a/sglang_omni/models/qwen3_omni/components/talker.py
+++ b/sglang_omni/models/qwen3_omni/components/talker.py
@@ -54,17 +54,6 @@ def _bind_default_weight_loaders(module: nn.Module) -> None:
             param.weight_loader = default_weight_loader
 
 
-def _repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
-    """Repeat KV heads to match the number of query heads."""
-    batch, num_kv_heads, seq_len, head_dim = hidden_states.shape
-    if n_rep == 1:
-        return hidden_states
-    hidden_states = hidden_states[:, :, None, :, :].expand(
-        batch, num_kv_heads, n_rep, seq_len, head_dim
-    )
-    return hidden_states.reshape(batch, num_kv_heads * n_rep, seq_len, head_dim)
-
-
 class _PredictorDecodeGraph:
     """CUDA graph for one Qwen3-Omni predictor single-token decode bucket."""
 
@@ -802,16 +791,13 @@ class Qwen3OmniMoeTalkerCodePredictor(nn.Module):
             1, 2
         )
 
-        num_kv_groups = attn.num_heads // attn.num_kv_heads
-        k = _repeat_kv(k, num_kv_groups)
-        v = _repeat_kv(v, num_kv_groups)
-
-        # Use SDPA to match HF's attention computation
+        # Use SDPA with native GQA (no materialized KV expansion)
         attn_output = torch.nn.functional.scaled_dot_product_attention(
             q,
             k,
             v,
             is_causal=True,
+            enable_gqa=(attn.num_heads != attn.num_kv_heads),
         )
         attn_output = attn_output.transpose(1, 2).reshape(
             batch_size * seq_len, attn.num_heads * attn.head_dim
@@ -1631,15 +1617,13 @@ class Qwen3OmniTalker(nn.Module):
 
         cached_k = layer_k_cache[:, :, : cache_len + 1, :]
         cached_v = layer_v_cache[:, :, : cache_len + 1, :]
-        num_kv_groups = attn.num_heads // attn.num_kv_heads
-        cached_k = _repeat_kv(cached_k, num_kv_groups)
-        cached_v = _repeat_kv(cached_v, num_kv_groups)
 
         attn_output = torch.nn.functional.scaled_dot_product_attention(
             q,
             cached_k,
             cached_v,
             is_causal=False,
+            enable_gqa=(attn.num_heads != attn.num_kv_heads),
         )
         attn_output = attn_output.transpose(1, 2).reshape(
             batch_size, attn.num_heads * attn.head_dim

--- a/tests/unit_test/qwen3_omni/test_talker.py
+++ b/tests/unit_test/qwen3_omni/test_talker.py
@@ -362,6 +362,36 @@ def test_qwen_code_predictor_keeps_4d_logits_token_shape() -> None:
     assert sampled.tolist() == [[2, 0]]
 
 
+def test_predictor_sdpa_enable_gqa_matches_materialized_kv_repeat() -> None:
+    """Native GQA SDPA matches explicit KV head expansion on a toy GQA shape."""
+    torch.manual_seed(0)
+    batch, seq_len, num_heads, num_kv_heads, head_dim = 2, 4, 16, 8, 8
+    n_rep = num_heads // num_kv_heads
+    q = torch.randn(batch, num_heads, seq_len, head_dim)
+    k = torch.randn(batch, num_kv_heads, seq_len, head_dim)
+    v = torch.randn(batch, num_kv_heads, seq_len, head_dim)
+
+    k_expanded = (
+        k[:, :, None, :, :]
+        .expand(batch, num_kv_heads, n_rep, seq_len, head_dim)
+        .reshape(batch, num_heads, seq_len, head_dim)
+    )
+    v_expanded = (
+        v[:, :, None, :, :]
+        .expand(batch, num_kv_heads, n_rep, seq_len, head_dim)
+        .reshape(batch, num_heads, seq_len, head_dim)
+    )
+
+    out_gqa = torch.nn.functional.scaled_dot_product_attention(
+        q, k, v, is_causal=True, enable_gqa=True
+    )
+    out_expanded = torch.nn.functional.scaled_dot_product_attention(
+        q, k_expanded, v_expanded, is_causal=True
+    )
+
+    assert torch.allclose(out_gqa, out_expanded, atol=1e-5, rtol=1e-5)
+
+
 def test_qwen_predictor_cuda_graph_capture_uses_thread_local_error_mode() -> None:
     """Keeps lazy predictor graph capture scoped to this thread."""
     source = (


### PR DESCRIPTION
## Motivation
The talker code predictor attention was materializing K/V head copies via `_repeat_kv` before SDPA. PyTorch SDPA already supports GQA natively with `enable_gqa=True`, which broadcasts KV inside the kernel and avoids those copies. Align qwen3_omni with the existing voxtral / qwen3_tts pattern and remove per-step KV expansion overhead from the predictor path.
## Modifications
- In `_direct_self_attention` and `_predictor_cached_self_attention`, drop `_repeat_kv` and pass `enable_gqa=(attn.num_heads != attn.num_kv_heads)` to SDPA.
- Delete unused `_repeat_kv`.
- Add a unit test asserting SDPA `enable_gqa` matches materialized KV expansion on a GQA-shaped toy config (16Q / 8KV).
## Related Issues
Closes #1145
Part of #1022

## Accuracy Test
Behavior-preserving change: SDPA math is unchanged; only KV layout handling differs. Added unit test confirms identical outputs vs explicit KV expansion on a fixed-seed GQA toy tensor.
## Benchmark & Profiling
Not measured in this PR. Issue #1145 expects a small single-digit percent drop in predictor replay wall time; 