### PR TITLE
[Perf] Unify torch.compile lifecycle for speech pipeline stages

### DIFF
--- a/sglang_omni/models/fishaudio_s2_pro/stages.py
+++ b/sglang_omni/models/fishaudio_s2_pro/stages.py
@@ -27,6 +27,7 @@ from sglang_omni.scheduling.reference_encoder import (
     TensorReferenceEncodeHook,
 )
 from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoint
+from sglang_omni.utils.compiled_stage import CompiledStage
 
 logger = logging.getLogger(__name__)
 
@@ -69,8 +70,13 @@ def _compile_s2pro_codebook_decoder(model: Any, *, max_batch_size: int) -> None:
     )
     audio_decoder = model._audio_decoder
     compiled_forward_kvcached_layers = [
-        torch.compile(layer.forward_kvcached, mode=compile_mode)
-        for layer in audio_decoder.layers
+        CompiledStage(
+            f"fishaudio_s2_pro.codebook_decoder.layer_{index}",
+            layer.forward_kvcached,
+            compile_kwargs={"mode": compile_mode},
+            bucket_fn=lambda x, *args, **kwargs: int(x.shape[0]),
+        )
+        for index, layer in enumerate(audio_decoder.layers)
     ]
     audio_decoder.set_compiled_forward_kvcached_layers(
         compiled_forward_kvcached_layers,

--- a/sglang_omni/models/higgs_tts/config.py
+++ b/sglang_omni/models/higgs_tts/config.py
@@ -49,7 +49,7 @@ class HiggsTtsPipelineConfig(PipelineConfig):
             name="audio_encoder",
             process="pipeline",
             factory=f"{_PKG}.stages.create_audio_encoder_executor",
-            factory_args={"device": "cuda"},
+            factory_args={"device": "cuda", "compile_encoder": True},
             gpu=0,
             runtime=StageRuntimeConfig(
                 resources=StageResourceConfig(total_gpu_memory_fraction=0.03)

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -67,6 +67,7 @@ from sglang_omni.scheduling.speaker_cache import (
 )
 from sglang_omni.scheduling.stage_cache import StageOutputCache
 from sglang_omni.scheduling.threaded_simple_scheduler import ThreadedSimpleScheduler
+from sglang_omni.utils.compiled_stage import CompiledStage, CompileWarmupCase
 
 logger = logging.getLogger(__name__)
 
@@ -354,6 +355,7 @@ def create_audio_encoder_executor(
     device: str = "cuda:0",
     dtype: str = "bfloat16",
     num_codebooks: int = 8,
+    compile_encoder: bool = True,
 ):
     """GPU stage: codec-encode raw ref audio → delayed codes + prompt assembly.
 
@@ -367,12 +369,36 @@ def create_audio_encoder_executor(
     adapter = HiggsTokenizerAdapter(tokenizer)
 
     codec = get_or_load_codec(checkpoint_dir, device, dtype)
-    codec.model.acoustic_encoder = torch.compile(
-        codec.model.acoustic_encoder, mode="default", dynamic=True
+    acoustic_encoder = codec.model.acoustic_encoder
+    encoder_compile = CompiledStage(
+        "higgs_tts.audio_encoder",
+        acoustic_encoder.forward,
+        enabled=compile_encoder,
+        compile_kwargs={"mode": "default", "dynamic": True},
+        bucket_fn=lambda waveform, *args, **kwargs: tuple(waveform.shape),
     )
-    codec.encode_reference(
-        torch.zeros(codec.SAMPLE_RATE), sample_rate=codec.SAMPLE_RATE
+    acoustic_encoder.forward = encoder_compile
+    parameter = next(acoustic_encoder.parameters(), None)
+    warmup_device = parameter.device if parameter is not None else torch.device("cpu")
+    warmup_dtype = parameter.dtype if parameter is not None else torch.float32
+    encoder_compile.warmup(
+        [
+            CompileWarmupCase(
+                "one-second-reference",
+                args=(
+                    torch.zeros(
+                        1,
+                        1,
+                        codec.SAMPLE_RATE,
+                        device=warmup_device,
+                        dtype=warmup_dtype,
+                    ),
+                ),
+                bucket=(1, 1, codec.SAMPLE_RATE),
+            )
+        ]
     )
+    codec._compiled_audio_encoder = encoder_compile
     reference_service = ReferenceEncodeService(
         _HiggsReferenceEncodeHook(
             codec,
@@ -488,29 +514,37 @@ def create_vocoder_executor(
     codec = get_or_load_codec(checkpoint_dir, device, dtype)
     if compile_decode:
         eager_decode = codec.model.decode
-        try:
-            codec.model.decode = torch.compile(eager_decode, dynamic=True)
-            warm_codes_TN = torch.zeros(
-                (
-                    max(_VOCODER_COMPILE_WARMUP_FRAME_COUNTS),
-                    int(codec.model.config.num_quantizers),
-                ),
-                dtype=torch.long,
-                device="cpu",
-            )
-            # Note: (stephenkgli) match serving's contiguous [T, N] layout and
-            # warm the zero-one-specialized batch and frame-count classes.
-            for frame_count in _VOCODER_COMPILE_WARMUP_FRAME_COUNTS:
-                frame_codes_TN = warm_codes_TN[:frame_count]
-                codec.decode(frame_codes_TN)
-                codec.decode_batch([frame_codes_TN, frame_codes_TN])
-        except Exception:
-            logger.warning(
-                "torch.compile of the codec decode failed; falling back to the "
-                "eager vocoder decode",
-                exc_info=True,
-            )
-            codec.model.decode = eager_decode
+        decode_compile = CompiledStage(
+            "higgs_tts.vocoder_decode",
+            eager_decode,
+            compile_kwargs={"dynamic": True},
+            bucket_fn=lambda codes, *args, **kwargs: (
+                int(codes.shape[0]),
+                int(codes.shape[-1]),
+            ),
+        )
+        codec.model.decode = decode_compile
+        num_quantizers = int(codec.model.config.num_quantizers)
+        warmup_cases = []
+        for frame_count in _VOCODER_COMPILE_WARMUP_FRAME_COUNTS:
+            for batch_size in (1, 2):
+                warmup_cases.append(
+                    CompileWarmupCase(
+                        f"batch={batch_size},frames={frame_count}",
+                        args=(
+                            torch.zeros(
+                                batch_size,
+                                num_quantizers,
+                                frame_count,
+                                dtype=torch.long,
+                                device=codec.device,
+                            ),
+                        ),
+                        bucket=(batch_size, frame_count),
+                    )
+                )
+        decode_compile.warmup(warmup_cases)
+        codec._compiled_decode = decode_compile
 
     return HiggsStreamingVocoderScheduler(
         codec,

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -370,35 +370,37 @@ def create_audio_encoder_executor(
 
     codec = get_or_load_codec(checkpoint_dir, device, dtype)
     acoustic_encoder = codec.model.acoustic_encoder
-    encoder_compile = CompiledStage(
-        "higgs_tts.audio_encoder",
-        acoustic_encoder.forward,
-        enabled=compile_encoder,
-        compile_kwargs={"mode": "default", "dynamic": True},
-        bucket_fn=lambda waveform, *args, **kwargs: tuple(waveform.shape),
-    )
-    acoustic_encoder.forward = encoder_compile
-    parameter = next(acoustic_encoder.parameters(), None)
-    warmup_device = parameter.device if parameter is not None else torch.device("cpu")
-    warmup_dtype = parameter.dtype if parameter is not None else torch.float32
-    encoder_compile.warmup(
-        [
-            CompileWarmupCase(
-                "one-second-reference",
-                args=(
-                    torch.zeros(
-                        1,
-                        1,
-                        codec.SAMPLE_RATE,
-                        device=warmup_device,
-                        dtype=warmup_dtype,
+    if compile_encoder:
+        encoder_compile = CompiledStage(
+            "higgs_tts.audio_encoder",
+            acoustic_encoder.forward,
+            compile_kwargs={"mode": "default", "dynamic": True},
+            bucket_fn=lambda waveform, *args, **kwargs: tuple(waveform.shape),
+        )
+        acoustic_encoder.forward = encoder_compile
+        parameter = next(acoustic_encoder.parameters(), None)
+        warmup_device = (
+            parameter.device if parameter is not None else torch.device("cpu")
+        )
+        warmup_dtype = parameter.dtype if parameter is not None else torch.float32
+        encoder_compile.warmup(
+            [
+                CompileWarmupCase(
+                    "one-second-reference",
+                    args=(
+                        torch.zeros(
+                            1,
+                            1,
+                            codec.SAMPLE_RATE,
+                            device=warmup_device,
+                            dtype=warmup_dtype,
+                        ),
                     ),
-                ),
-                bucket=(1, 1, codec.SAMPLE_RATE),
-            )
-        ]
-    )
-    codec._compiled_audio_encoder = encoder_compile
+                    bucket=(1, 1, codec.SAMPLE_RATE),
+                )
+            ]
+        )
+        codec._compiled_audio_encoder = encoder_compile
     reference_service = ReferenceEncodeService(
         _HiggsReferenceEncodeHook(
             codec,

--- a/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
+++ b/sglang_omni/models/moss_transcribe_diarize/sglang_model.py
@@ -32,6 +32,7 @@ from sglang_omni.models.moss_transcribe_diarize.hf_config import (
     MossTranscribeDiarizeConfig,
 )
 from sglang_omni.scheduling.stage_cache import StageOutputCache
+from sglang_omni.utils.compiled_stage import CompiledStage, CompileWarmupCase
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +93,7 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
         self.pattern = MultiModalityDataPaddingPatternMultimodalTokens()
         self._encoder_cache: Optional[StageOutputCache] = None
         self._encoder_graph_runner = None
-        self._compiled_encoder = None
+        self._compiled_encoder: CompiledStage | None = None
         self._compiled_chunk_buckets: frozenset[int] = frozenset()
         self._compiled_input_feature_len = 0
 
@@ -150,30 +151,41 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
         if not buckets:
             return
         set_torch_compile_config()
-        self._compiled_encoder = torch.compile(self.whisper_encoder, dynamic=False)
         self._compiled_input_feature_len = int(input_feature_len)
         p = next(self.whisper_encoder.parameters())
         frames = int(input_feature_len)
         num_mel_bins = int(self.config.audio_config.num_mel_bins)
         pos = torch.arange((frames - 1) // 2 + 1, device=p.device, dtype=torch.long)
-        warmed: list[int] = []
+        self._compiled_encoder = CompiledStage(
+            "moss_transcribe_diarize.whisper_encoder",
+            self.whisper_encoder,
+            compile_kwargs={"dynamic": False},
+            bucket_fn=lambda feats, *args, **kwargs: (
+                int(feats.shape[0]),
+                int(feats.shape[-1]),
+            ),
+            restrict_to_warmed_buckets=True,
+        )
+        cases = [
+            CompileWarmupCase(
+                f"chunks={n}",
+                args=(
+                    torch.zeros(
+                        n, num_mel_bins, frames, device=p.device, dtype=p.dtype
+                    ),
+                    pos,
+                    None,
+                ),
+                bucket=(n, frames),
+                repeat=3,
+            )
+            for n in buckets
+        ]
         with torch.no_grad():
-            for n in buckets:
-                feats = torch.zeros(
-                    n, num_mel_bins, frames, device=p.device, dtype=p.dtype
-                )
-                try:
-                    for _ in range(3):
-                        self._compiled_encoder(feats, pos, None)
-                except Exception as exc:
-                    logger.warning(
-                        f"MOSS-TD encoder torch.compile warmup failed for "
-                        f"chunks={n}: {exc}; that chunk count will run eager"
-                    )
-                    continue
-                warmed.append(n)
-        self._compiled_chunk_buckets = frozenset(warmed)
-        logger.info(f"MOSS-TD encoder torch.compile warmed buckets={warmed}")
+            stats = self._compiled_encoder.warmup(cases)
+        self._compiled_chunk_buckets = frozenset(
+            int(bucket[0]) for bucket in stats.warmed_buckets
+        )
 
     def time_merge(self, features: torch.Tensor) -> torch.Tensor:
         batch_size, seq_len, hidden_size = features.shape
@@ -268,11 +280,7 @@ class MossTranscribeDiarizeForConditionalGeneration(nn.Module):
             encoder_position_ids = torch.arange(
                 encoder_len, device=device, dtype=torch.long
             )
-            if (
-                self._compiled_encoder is not None
-                and batched_features.shape[0] in self._compiled_chunk_buckets
-                and batched_features.shape[-1] == self._compiled_input_feature_len
-            ):
+            if self._compiled_encoder is not None:
                 features = self._compiled_encoder(
                     batched_features, encoder_position_ids, forward_batch
                 )

--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -37,7 +37,10 @@ def _stages(*, codec_device: str, colocated: bool) -> list[StageConfig]:
             mem_fraction_static=None if colocated else _AR_MEM_FRACTION_STATIC
         ),
     )
-    tts_engine_args: dict[str, Any] = {"dtype": "bfloat16"}
+    tts_engine_args: dict[str, Any] = {
+        "dtype": "bfloat16",
+        "compile_frame_sampler": True,
+    }
     if colocated:
         tts_engine_args["codec_mem_reserve"] = _COLOCATED_CODEC_MEM_RESERVE
 

--- a/sglang_omni/models/moss_tts_local/engine_builder.py
+++ b/sglang_omni/models/moss_tts_local/engine_builder.py
@@ -23,11 +23,13 @@ class MossTtsLocalEngineBuilder(TtsEngineBuilder):
         async_decode_min_batch_size: int,
         total_gpu_memory_fraction: float | None,
         codec_mem_reserve: float,
+        compile_frame_sampler: bool = True,
     ) -> None:
         self.enable_async_decode = enable_async_decode
         self.async_decode_min_batch_size = async_decode_min_batch_size
         self.total_gpu_memory_fraction = total_gpu_memory_fraction
         self.codec_mem_reserve = codec_mem_reserve
+        self.compile_frame_sampler = bool(compile_frame_sampler)
         self.memory_budget = moss_local_stages._ArMemoryBudget(
             effective_total_gpu_memory_fraction=None,
             applied_codec_mem_reserve=0.0,
@@ -113,7 +115,10 @@ class MossTtsLocalEngineBuilder(TtsEngineBuilder):
         # (1 + n_vq micro-steps and 13 seeded sampling passes per frame):
         # eager it is kernel-launch-bound at ~22 ms/frame independent of batch
         # size.
-        model.init_frame_decode_graphs(list(server_args.cuda_graph_bs))
+        model.init_frame_decode_graphs(
+            list(server_args.cuda_graph_bs),
+            compile_frame_sampler=self.compile_frame_sampler,
+        )
 
     def make_model_runner(self, model_worker: Any, output_proc: Any) -> Any:
         model_runner_mod = importlib.import_module(

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -38,6 +38,7 @@ from sglang_omni.models.moss_tts_local.payload_types import (
     moss_tts_local_special_token_defaults,
 )
 from sglang_omni.models.moss_tts_local.state_pool import MossTTSLocalDecodeStatePool
+from sglang_omni.utils.compiled_stage import CompiledStage
 
 logger = logging.getLogger(__name__)
 
@@ -368,18 +369,21 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         set_torch_compile_config()
         self._frame_compile_configured = True
 
-    def _ensure_frame_sampler_compile(self) -> None:
+    def _ensure_frame_sampler_compile(self, *, enabled: bool = True) -> None:
         if self._compiled_frame_sampler is None:
             compile_mode = os.environ.get(
                 "SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs"
             )
-            self._ensure_frame_compile_config()
-            self._compiled_frame_sampler = torch.compile(
+            if enabled:
+                self._ensure_frame_compile_config()
+            self._compiled_frame_sampler = CompiledStage(
+                "moss_tts_local.frame_sampler",
                 sample_seeded_branchless,
-                mode=compile_mode,
+                enabled=enabled,
+                compile_kwargs={"mode": compile_mode},
+                bucket_fn=lambda logits, *args, **kwargs: int(logits.shape[0]),
             )
             self._sample_seeded_branchless = self._compiled_frame_sampler
-            logger.info(f"Compiled MOSS-TTS Local frame sampler (mode={compile_mode})")
 
     @torch.no_grad()
     def _decode_frame_graphable(
@@ -448,7 +452,12 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         return stop_choice, torch.stack(codes, dim=-1), feedback
 
     @torch.no_grad()
-    def init_frame_decode_graphs(self, batch_sizes: list[int]) -> None:
+    def init_frame_decode_graphs(
+        self,
+        batch_sizes: list[int],
+        *,
+        compile_frame_sampler: bool = True,
+    ) -> None:
         """Capture the per-frame local decode (1 + n_vq micro-steps plus all
         13 seeded sampling passes) into one CUDA graph per batch-size bucket.
 
@@ -468,7 +477,7 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             max(max(buckets), max_eager_bs), device, self.dtype
         )
         self.local_transformer.freeze_kv_cache()
-        self._ensure_frame_sampler_compile()
+        self._ensure_frame_sampler_compile(enabled=compile_frame_sampler)
         frame_decode = self._decode_frame_graphable
         self._frame_graphs: dict[
             int,

--- a/sglang_omni/models/moss_tts_local/sglang_model.py
+++ b/sglang_omni/models/moss_tts_local/sglang_model.py
@@ -369,17 +369,15 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
         set_torch_compile_config()
         self._frame_compile_configured = True
 
-    def _ensure_frame_sampler_compile(self, *, enabled: bool = True) -> None:
+    def _ensure_frame_sampler_compile(self) -> None:
         if self._compiled_frame_sampler is None:
             compile_mode = os.environ.get(
                 "SGLANG_TORCH_COMPILE_MODE", "max-autotune-no-cudagraphs"
             )
-            if enabled:
-                self._ensure_frame_compile_config()
+            self._ensure_frame_compile_config()
             self._compiled_frame_sampler = CompiledStage(
                 "moss_tts_local.frame_sampler",
                 sample_seeded_branchless,
-                enabled=enabled,
                 compile_kwargs={"mode": compile_mode},
                 bucket_fn=lambda logits, *args, **kwargs: int(logits.shape[0]),
             )
@@ -477,7 +475,8 @@ class MossTTSLocalSGLangModel(torch.nn.Module):
             max(max(buckets), max_eager_bs), device, self.dtype
         )
         self.local_transformer.freeze_kv_cache()
-        self._ensure_frame_sampler_compile(enabled=compile_frame_sampler)
+        if compile_frame_sampler:
+            self._ensure_frame_sampler_compile()
         frame_decode = self._decode_frame_graphable
         self._frame_graphs: dict[
             int,

--- a/sglang_omni/models/moss_tts_local/stages.py
+++ b/sglang_omni/models/moss_tts_local/stages.py
@@ -548,6 +548,7 @@ def create_sglang_tts_engine_executor(
     async_decode_min_batch_size: int = 2,
     total_gpu_memory_fraction: float | None = None,
     codec_mem_reserve: float = 0.0,
+    compile_frame_sampler: bool = True,
 ) -> Any:
     from sglang_omni.models.moss_tts_local.engine_builder import (
         MossTtsLocalEngineBuilder,
@@ -558,6 +559,7 @@ def create_sglang_tts_engine_executor(
         async_decode_min_batch_size=async_decode_min_batch_size,
         total_gpu_memory_fraction=total_gpu_memory_fraction,
         codec_mem_reserve=codec_mem_reserve,
+        compile_frame_sampler=compile_frame_sampler,
     ).build(
         model_path,
         device=device,

--- a/sglang_omni/models/qwen3_tts/config.py
+++ b/sglang_omni/models/qwen3_tts/config.py
@@ -31,6 +31,10 @@ class Qwen3TTSPipelineConfig(PipelineConfig):
     def mem_fraction_role_to_stage(cls) -> dict[str, str]:
         return {"talker": "tts_engine"}
 
+    @classmethod
+    def talker_sglang_role_to_stage(cls) -> dict[str, str]:
+        return {"talker": "tts_engine"}
+
     model_path: str
     stages: list[StageConfig] = [
         StageConfig(

--- a/sglang_omni/models/qwen3_tts/stages.py
+++ b/sglang_omni/models/qwen3_tts/stages.py
@@ -25,6 +25,7 @@ from sglang_omni.scheduling.simple_scheduler import SimpleScheduler
 from sglang_omni.scheduling.vocoder_base import BatchVocoderBase
 from sglang_omni.utils.audio_payload import audio_waveform_payload
 from sglang_omni.utils.checkpoint import resolve_checkpoint as _resolve_checkpoint
+from sglang_omni.utils.compiled_stage import CompiledStage
 
 logger = logging.getLogger(__name__)
 
@@ -119,8 +120,25 @@ def _compile_qwen3_tts_backbone(model: Any) -> None:
         "max-autotune-no-cudagraphs",
     )
     text_model._compiled_decode_layers = [
-        torch.compile(layer, mode=compile_mode) for layer in layers
+        CompiledStage(
+            f"qwen3_tts.decode_backbone.layer_{index}",
+            layer,
+            compile_kwargs={"mode": compile_mode},
+            bucket_fn=lambda *args, **kwargs: _decode_layer_batch_bucket(args, kwargs),
+        )
+        for index, layer in enumerate(layers)
     ]
+
+
+def _decode_layer_batch_bucket(
+    args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> int | None:
+    hidden_states = kwargs.get("hidden_states")
+    if hidden_states is None and len(args) >= 2:
+        hidden_states = args[1]
+    if not isinstance(hidden_states, torch.Tensor) or hidden_states.ndim == 0:
+        return None
+    return int(hidden_states.shape[0])
 
 
 def create_preprocessing_executor(model_path: str) -> SimpleScheduler:

--- a/sglang_omni/utils/compiled_stage.py
+++ b/sglang_omni/utils/compiled_stage.py
@@ -1,0 +1,319 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared torch.compile lifecycle for host-bound pipeline stages."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable, Hashable, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CompileWarmupCase:
+    """One model-defined input used to compile and warm a shape bucket."""
+
+    label: str
+    args: tuple[Any, ...] = ()
+    kwargs: Mapping[str, Any] = field(default_factory=dict)
+    bucket: Hashable | None = None
+    repeat: int = 1
+
+    def __post_init__(self) -> None:
+        if self.repeat < 1:
+            raise ValueError("compile warmup repeat must be >= 1")
+
+
+@dataclass(frozen=True)
+class CompiledStageStats:
+    """Immutable snapshot of compile and fallback counters."""
+
+    enabled: bool
+    compilation_count: int
+    recompilation_count: int
+    compile_time_s: float
+    warmup_time_s: float
+    warmup_failures: int
+    runtime_fallbacks: int
+    warmed_buckets: frozenset[Hashable]
+    failed_buckets: frozenset[Hashable]
+
+
+class CompiledStage:
+    """Callable torch.compile wrapper with warmup and eager fallback.
+
+    ``torch.compile`` is lazy: most compile time is paid on the first call and
+    on later guard misses. This wrapper observes those calls, records graph
+    compilation events, and falls back to the original callable if setup,
+    warmup, or a serving-time compiled invocation fails.
+
+    When ``restrict_to_warmed_buckets`` is true, only successfully warmed
+    buckets use the compiled callable. Models with exact/static shapes should
+    enable it; dynamic-shape stages can leave it false and use warmup cases to
+    move known specializations before readiness without rejecting new shapes.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        eager: Callable[..., Any],
+        *,
+        enabled: bool = True,
+        compile_kwargs: Mapping[str, Any] | None = None,
+        bucket_fn: Callable[..., Hashable | None] | None = None,
+        restrict_to_warmed_buckets: bool = False,
+        compile_fn: Callable[..., Callable[..., Any]] | None = None,
+    ) -> None:
+        self.name = name
+        self.eager = eager
+        self.enabled = bool(enabled)
+        self.bucket_fn = bucket_fn
+        self.restrict_to_warmed_buckets = bool(restrict_to_warmed_buckets)
+        self._compiled: Callable[..., Any] | None = None
+        self._compile_kwargs = dict(compile_kwargs or {})
+        self._lock = threading.Lock()
+        self._compilation_count = 0
+        self._compile_trigger_count = 0
+        self._compile_time_s = 0.0
+        self._warmup_time_s = 0.0
+        self._warmup_failures = 0
+        self._runtime_fallbacks = 0
+        self._warmed_buckets: set[Hashable] = set()
+        self._failed_buckets: set[Hashable] = set()
+        self._failed_without_bucket = False
+        self._observed_buckets: set[Hashable] = set()
+        self._observed_without_bucket = False
+
+        if not self.enabled:
+            logger.info("Compiled stage %s is disabled; using eager execution", name)
+            return
+
+        compiler = compile_fn or torch.compile
+        try:
+            self._compiled = compiler(eager, **self._compile_kwargs)
+        except Exception:
+            self._failed_without_bucket = True
+            logger.warning(
+                "Compiled stage %s setup failed; using eager execution",
+                name,
+                exc_info=True,
+            )
+
+    @property
+    def compiled(self) -> Callable[..., Any] | None:
+        return self._compiled
+
+    def stats(self) -> CompiledStageStats:
+        with self._lock:
+            return CompiledStageStats(
+                enabled=self.enabled,
+                compilation_count=self._compilation_count,
+                recompilation_count=max(0, self._compile_trigger_count - 1),
+                compile_time_s=self._compile_time_s,
+                warmup_time_s=self._warmup_time_s,
+                warmup_failures=self._warmup_failures,
+                runtime_fallbacks=self._runtime_fallbacks,
+                warmed_buckets=frozenset(self._warmed_buckets),
+                failed_buckets=frozenset(self._failed_buckets),
+            )
+
+    def warmup(self, cases: Sequence[CompileWarmupCase]) -> CompiledStageStats:
+        """Run model-defined inputs before readiness and retain good buckets."""
+        if self._compiled is None:
+            return self.stats()
+
+        started = time.perf_counter()
+        for case in cases:
+            bucket = case.bucket
+            if bucket is None:
+                bucket = self._resolve_bucket(case.args, case.kwargs)
+            try:
+                for _ in range(case.repeat):
+                    self._call_compiled(
+                        case.args,
+                        case.kwargs,
+                        observe_compile=self._reserve_compile_observation(bucket),
+                    )
+            except Exception:
+                with self._lock:
+                    self._warmup_failures += 1
+                    self._mark_failed_locked(bucket)
+                logger.warning(
+                    "Compiled stage %s warmup failed for %s (bucket=%r); "
+                    "that bucket will run eager",
+                    self.name,
+                    case.label,
+                    bucket,
+                    exc_info=True,
+                )
+                continue
+            if bucket is not None:
+                with self._lock:
+                    self._warmed_buckets.add(bucket)
+
+        elapsed = time.perf_counter() - started
+        with self._lock:
+            self._warmup_time_s += elapsed
+            snapshot = self.stats_unlocked()
+        logger.info(
+            "Compiled stage %s warmup complete: buckets=%s failures=%d "
+            "compile_events=%d recompiles=%d compile_time=%.3fs warmup_time=%.3fs",
+            self.name,
+            sorted(snapshot.warmed_buckets, key=repr),
+            snapshot.warmup_failures,
+            snapshot.compilation_count,
+            snapshot.recompilation_count,
+            snapshot.compile_time_s,
+            snapshot.warmup_time_s,
+        )
+        return snapshot
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        bucket = self._resolve_bucket(args, kwargs)
+        if not self._should_use_compiled(bucket):
+            return self.eager(*args, **kwargs)
+
+        try:
+            return self._call_compiled(
+                args,
+                kwargs,
+                observe_compile=self._reserve_compile_observation(bucket),
+            )
+        except Exception:
+            with self._lock:
+                self._runtime_fallbacks += 1
+                self._mark_failed_locked(bucket)
+            logger.warning(
+                "Compiled stage %s failed at runtime for bucket=%r; "
+                "falling back to eager execution",
+                self.name,
+                bucket,
+                exc_info=True,
+            )
+            return self.eager(*args, **kwargs)
+
+    def stats_unlocked(self) -> CompiledStageStats:
+        return CompiledStageStats(
+            enabled=self.enabled,
+            compilation_count=self._compilation_count,
+            recompilation_count=max(0, self._compile_trigger_count - 1),
+            compile_time_s=self._compile_time_s,
+            warmup_time_s=self._warmup_time_s,
+            warmup_failures=self._warmup_failures,
+            runtime_fallbacks=self._runtime_fallbacks,
+            warmed_buckets=frozenset(self._warmed_buckets),
+            failed_buckets=frozenset(self._failed_buckets),
+        )
+
+    def _resolve_bucket(
+        self, args: tuple[Any, ...], kwargs: Mapping[str, Any]
+    ) -> Hashable | None:
+        if self.bucket_fn is None:
+            return None
+        return self.bucket_fn(*args, **kwargs)
+
+    def _should_use_compiled(self, bucket: Hashable | None) -> bool:
+        if self._compiled is None or self._failed_without_bucket:
+            return False
+        with self._lock:
+            if bucket is not None and bucket in self._failed_buckets:
+                return False
+            if self.restrict_to_warmed_buckets:
+                return bucket is not None and bucket in self._warmed_buckets
+        return True
+
+    def _mark_failed_locked(self, bucket: Hashable | None) -> None:
+        if bucket is None:
+            self._failed_without_bucket = True
+        else:
+            self._failed_buckets.add(bucket)
+            self._warmed_buckets.discard(bucket)
+
+    def _reserve_compile_observation(self, bucket: Hashable | None) -> bool:
+        """Observe only the first compiled call for each serving shape bucket."""
+        with self._lock:
+            if bucket is None:
+                if self._observed_without_bucket:
+                    return False
+                self._observed_without_bucket = True
+                return True
+            if bucket in self._observed_buckets:
+                return False
+            self._observed_buckets.add(bucket)
+            return True
+
+    def _call_compiled(
+        self,
+        args: tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+        *,
+        observe_compile: bool,
+    ) -> Any:
+        compiled = self._compiled
+        if compiled is None:
+            raise RuntimeError(f"Compiled stage {self.name} is unavailable")
+
+        if not observe_compile:
+            return compiled(*args, **kwargs)
+
+        events: list[float] = []
+        try:
+            with _observe_torch_compilations(events):
+                result = compiled(*args, **kwargs)
+        finally:
+            if events:
+                elapsed = sum(events)
+                with self._lock:
+                    self._compilation_count += len(events)
+                    self._compile_trigger_count += 1
+                    self._compile_time_s += elapsed
+                    count = self._compilation_count
+                    recompilations = max(0, self._compile_trigger_count - 1)
+                    total = self._compile_time_s
+                logger.info(
+                    "Compiled stage %s observed %d compile event(s): total=%d "
+                    "recompiles=%d compile_time=%.3fs",
+                    self.name,
+                    len(events),
+                    count,
+                    recompilations,
+                    total,
+                )
+        return result
+
+
+@contextmanager
+def _observe_torch_compilations(events: list[float]):
+    """Observe lazy Dynamo compile duration during one callable invocation."""
+    dynamo = getattr(torch, "_dynamo", None)
+    handler = getattr(dynamo, "callback_handler", None)
+    if handler is None:
+        yield
+        return
+
+    started: list[float] = []
+
+    def _on_start(_args: Any) -> None:
+        started.append(time.perf_counter())
+
+    def _on_end(_args: Any) -> None:
+        if started:
+            events.append(time.perf_counter() - started.pop())
+
+    handler.register_start_callback(_on_start)
+    handler.register_end_callback(_on_end)
+    try:
+        yield
+    finally:
+        handler.remove_start_callback(_on_start)
+        handler.remove_end_callback(_on_end)
+
+
+__all__ = ["CompileWarmupCase", "CompiledStage", "CompiledStageStats"]

--- a/sglang_omni/utils/compiled_stage.py
+++ b/sglang_omni/utils/compiled_stage.py
@@ -35,7 +35,6 @@ class CompileWarmupCase:
 class CompiledStageStats:
     """Immutable snapshot of compile and fallback counters."""
 
-    enabled: bool
     compilation_count: int
     recompilation_count: int
     compile_time_s: float
@@ -65,7 +64,6 @@ class CompiledStage:
         name: str,
         eager: Callable[..., Any],
         *,
-        enabled: bool = True,
         compile_kwargs: Mapping[str, Any] | None = None,
         bucket_fn: Callable[..., Hashable | None] | None = None,
         restrict_to_warmed_buckets: bool = False,
@@ -73,7 +71,6 @@ class CompiledStage:
     ) -> None:
         self.name = name
         self.eager = eager
-        self.enabled = bool(enabled)
         self.bucket_fn = bucket_fn
         self.restrict_to_warmed_buckets = bool(restrict_to_warmed_buckets)
         self._compiled: Callable[..., Any] | None = None
@@ -91,11 +88,7 @@ class CompiledStage:
         self._observed_buckets: set[Hashable] = set()
         self._observed_without_bucket = False
 
-        if not self.enabled:
-            logger.info("Compiled stage %s is disabled; using eager execution", name)
-            return
-
-        compiler = compile_fn or torch.compile
+        compiler = torch.compile if compile_fn is None else compile_fn
         try:
             self._compiled = compiler(eager, **self._compile_kwargs)
         except Exception:
@@ -113,7 +106,6 @@ class CompiledStage:
     def stats(self) -> CompiledStageStats:
         with self._lock:
             return CompiledStageStats(
-                enabled=self.enabled,
                 compilation_count=self._compilation_count,
                 recompilation_count=max(0, self._compile_trigger_count - 1),
                 compile_time_s=self._compile_time_s,
@@ -201,7 +193,6 @@ class CompiledStage:
 
     def stats_unlocked(self) -> CompiledStageStats:
         return CompiledStageStats(
-            enabled=self.enabled,
             compilation_count=self._compilation_count,
             recompilation_count=max(0, self._compile_trigger_count - 1),
             compile_time_s=self._compile_time_s,

--- a/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
+++ b/tests/unit_test/fishaudio_s2_pro/test_pipeline.py
@@ -582,7 +582,9 @@ def test_s2pro_compile_helper_targets_forward_kvcached(
     assert getattr(target, "__name__", "") == "forward_kvcached"
     assert mode == "reduce-overhead"
     assert kwargs == {}
-    assert audio_decoder._compiled_forward_kvcached_layers == ["compiled-1"]
+    assert [
+        stage.compiled for stage in audio_decoder._compiled_forward_kvcached_layers
+    ] == ["compiled-1"]
     assert audio_decoder._compiled_forward_kvcached_max_bs == 2
 
 

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -39,7 +39,27 @@ def test_higgs_streaming_pipeline_routes_chunks_to_vocoder() -> None:
 
     assert stages_by_name["tts_engine"].stream_to == ["vocoder"]
     assert "server_args_overrides" not in stages_by_name["tts_engine"].factory_args
+    assert stages_by_name["audio_encoder"].factory_args["compile_encoder"] is True
+    assert stages_by_name["vocoder"].factory_args["compile_decode"] is True
     assert stages_by_name["vocoder"].can_accept_stream_before_payload is True
+
+
+def test_higgs_compiled_stages_have_explicit_off_switches() -> None:
+    config = HiggsTtsPipelineConfig(
+        model_path="fake-model",
+        runtime_overrides={
+            "audio_encoder": {"compile_encoder": False},
+            "vocoder": {"compile_decode": False},
+        },
+    )
+    stages_by_name = {stage.name: stage for stage in config.stages}
+
+    encoder_args = resolve_stage_static_factory_args(
+        stages_by_name["audio_encoder"], config
+    )
+    vocoder_args = resolve_stage_static_factory_args(stages_by_name["vocoder"], config)
+    assert encoder_args["compile_encoder"] is False
+    assert vocoder_args["compile_decode"] is False
 
 
 def test_higgs_streaming_pipeline_shares_vocoder_stride_with_tts_engine() -> None:
@@ -413,6 +433,7 @@ def test_higgs_audio_encoder_uses_reference_code_cache(monkeypatch) -> None:
         "ckpt",
         device="cuda:0",
         num_codebooks=2,
+        compile_encoder=False,
     )
     # Ignore the construction-time codec warm-up call added by #612.
     fake_codec.calls = 0
@@ -490,6 +511,7 @@ def test_higgs_audio_encoder_uses_shared_cache_for_uploaded_voice(
         "ckpt",
         device="cuda:0",
         num_codebooks=2,
+        compile_encoder=False,
     )
     fake_codec.calls = 0
     encode = scheduler._fn

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -428,6 +428,13 @@ def test_higgs_audio_encoder_uses_reference_code_cache(monkeypatch) -> None:
     fake_codec = FakeCodec()
     monkeypatch.setattr(stages, "HiggsTokenizerAdapter", FakeAdapter)
     monkeypatch.setattr(stages, "get_or_load_codec", lambda *args, **kwargs: fake_codec)
+    monkeypatch.setattr(
+        stages,
+        "CompiledStage",
+        lambda *args, **kwargs: pytest.fail(
+            "compile-disabled encoder must keep the eager callable"
+        ),
+    )
 
     scheduler = stages.create_audio_encoder_executor(
         "ckpt",

--- a/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
+++ b/tests/unit_test/moss_transcribe_diarize/test_pipeline.py
@@ -75,7 +75,10 @@ def test_compile_encoder_sets_runner_and_warms_each_bucket(
         lambda: None,
     )
     warmups: list[tuple[int, ...]] = []
-    runner = lambda feats, pos, forward_batch: warmups.append(tuple(feats.shape))
+
+    def runner(feats, pos, forward_batch):
+        warmups.append(tuple(feats.shape))
+
     monkeypatch.setattr(torch, "compile", lambda module, **kwargs: runner)
 
     encoder = torch.nn.Linear(4, 4)
@@ -88,7 +91,7 @@ def test_compile_encoder_sets_runner_and_warms_each_bucket(
 
     Model.compile_encoder(model, [2, 1, 1], input_feature_len=6)
 
-    assert model._compiled_encoder is runner
+    assert model._compiled_encoder.compiled is runner
     assert model._compiled_chunk_buckets == frozenset({1, 2})
     assert model._compiled_input_feature_len == 6
     assert len(warmups) == 6

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -12,6 +12,7 @@ import torch
 
 from sglang_omni.client.audio import encode_audio, encode_wav
 from sglang_omni.config.placement import build_stage_placement_plan
+from sglang_omni.config.runtime import resolve_stage_static_factory_args
 from sglang_omni.models.moss_tts_local.audio_tokenizer import MossTTSLocalAudioTokenizer
 from sglang_omni.models.moss_tts_local.config import (
     MossTTSLocalColocatedPipelineConfig,
@@ -404,6 +405,7 @@ def test_pipeline_stage_wiring():
     assert tts_engine_runtime.resources.total_gpu_memory_fraction == pytest.approx(0.90)
     assert tts_engine_runtime.sglang_server_args.mem_fraction_static is None
     assert stages["tts_engine"].factory_args["codec_mem_reserve"] == pytest.approx(0.15)
+    assert stages["tts_engine"].factory_args["compile_frame_sampler"] is True
     assert stages["vocoder"].process == "pipeline"
     assert stages["vocoder"].gpu == 0
     assert stages["vocoder"].factory_args["device"] == "cuda:0"
@@ -432,6 +434,19 @@ def test_pipeline_stage_wiring():
     assert split_runtime.resources.total_gpu_memory_fraction is None
     assert split_runtime.sglang_server_args.mem_fraction_static == pytest.approx(0.85)
     assert split_stages["vocoder"].factory_args["device"] == "cuda:1"
+
+
+def test_moss_local_frame_sampler_compile_has_explicit_off_switch() -> None:
+    config = MossTTSLocalPipelineConfig(
+        model_path="OpenMOSS-Team/moss-local-test",
+        runtime_overrides={"tts_engine": {"compile_frame_sampler": False}},
+    )
+    stage = next(stage for stage in config.stages if stage.name == "tts_engine")
+
+    assert (
+        resolve_stage_static_factory_args(stage, config)["compile_frame_sampler"]
+        is False
+    )
 
 
 def test_pipeline_config_injects_reference_cache_factory_args():

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -1934,6 +1934,33 @@ def test_qwen3_tts_compile_backbone_requires_text_layers(
         _compile_qwen3_tts_backbone(SimpleNamespace())
 
 
+def test_qwen3_tts_declares_talker_stage_for_compile_cli() -> None:
+    from sglang_omni.cli.serve import apply_torch_compile_cli_overrides
+    from sglang_omni.models.qwen3_tts.config import Qwen3TTSPipelineConfig
+
+    assert Qwen3TTSPipelineConfig.talker_sglang_role_to_stage() == {
+        "talker": "tts_engine"
+    }
+    config = Qwen3TTSPipelineConfig(model_path="Qwen/Qwen3-TTS-12Hz-0.6B-Base")
+    updated = apply_torch_compile_cli_overrides(
+        config,
+        thinker_torch_compile="default",
+        talker_torch_compile="off",
+        thinker_torch_compile_max_bs=None,
+        talker_torch_compile_max_bs=None,
+    )
+    stage = next(stage for stage in updated.stages if stage.name == "tts_engine")
+    assert stage.factory_args["server_args_overrides"]["enable_torch_compile"] is False
+
+
+def test_qwen3_tts_compile_preserves_enabled_default() -> None:
+    from sglang_omni.models.qwen3_tts.engine_builder import Qwen3TtsEngineBuilder
+
+    defaults = Qwen3TtsEngineBuilder().generation_defaults(dtype="bfloat16")
+
+    assert defaults["enable_torch_compile"] is True
+
+
 def test_qwen3_tts_compile_backbone_compiles_every_layer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1963,7 +1990,7 @@ def test_qwen3_tts_compile_backbone_compiles_every_layer(
 
     assert set_config_calls == [True]
     assert compiled == [(layer, "max-autotune-no-cudagraphs") for layer in layers]
-    assert text_model._compiled_decode_layers == [
+    assert [stage.compiled for stage in text_model._compiled_decode_layers] == [
         "compiled-1",
         "compiled-2",
         "compiled-3",
@@ -2118,6 +2145,7 @@ def test_qwen3_tts_engine_applies_compat_overrides_and_reenables_cuda_graph(
         device="cuda:0",
         server_args_overrides={
             "cuda_graph_max_bs": 32,
+            "enable_torch_compile": True,
             "mem_fraction_static": 0.7,
             "max_running_requests": 2,
         },

--- a/tests/unit_test/utils/test_compiled_stage.py
+++ b/tests/unit_test/utils/test_compiled_stage.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang_omni.utils.compiled_stage import CompiledStage, CompileWarmupCase
+
+
+def test_disabled_compiled_stage_never_calls_compiler() -> None:
+    compiler_calls = []
+
+    stage = CompiledStage(
+        "disabled",
+        lambda value: value + 1,
+        enabled=False,
+        compile_fn=lambda fn, **kwargs: compiler_calls.append((fn, kwargs)),
+    )
+
+    assert stage(2) == 3
+    assert compiler_calls == []
+    assert stage.stats().enabled is False
+
+
+def test_compile_setup_failure_uses_eager(caplog) -> None:
+    def fail_compile(_fn, **_kwargs):
+        raise RuntimeError("compiler unavailable")
+
+    with caplog.at_level(logging.WARNING):
+        stage = CompiledStage(
+            "setup-failure",
+            lambda value: value * 2,
+            compile_fn=fail_compile,
+        )
+
+    assert stage(4) == 8
+    assert "setup failed" in caplog.text
+
+
+def test_warmup_failure_restricts_only_failed_bucket_to_eager() -> None:
+    eager_calls = []
+
+    def eager(value):
+        eager_calls.append(value)
+        return value + 10
+
+    def compile_fn(_fn, **_kwargs):
+        def compiled(value):
+            if value == 2:
+                raise RuntimeError("bad shape")
+            return value + 100
+
+        return compiled
+
+    stage = CompiledStage(
+        "bucketed",
+        eager,
+        compile_fn=compile_fn,
+        bucket_fn=lambda value: value,
+        restrict_to_warmed_buckets=True,
+    )
+    stats = stage.warmup(
+        [
+            CompileWarmupCase("one", args=(1,), bucket=1),
+            CompileWarmupCase("two", args=(2,), bucket=2),
+        ]
+    )
+
+    assert stats.warmed_buckets == frozenset({1})
+    assert stats.failed_buckets == frozenset({2})
+    assert stats.warmup_failures == 1
+    assert stage(1) == 101
+    assert stage(2) == 12
+    assert stage(3) == 13
+    assert eager_calls == [2, 3]
+
+
+def test_runtime_compile_failure_falls_back_and_sticks_per_bucket() -> None:
+    compiled_calls = []
+    eager_calls = []
+
+    def eager(value):
+        eager_calls.append(value)
+        return -value
+
+    def compiled(value):
+        compiled_calls.append(value)
+        if value == 7:
+            raise RuntimeError("inductor failure")
+        return value
+
+    stage = CompiledStage(
+        "runtime-failure",
+        eager,
+        compile_fn=lambda _fn, **_kwargs: compiled,
+        bucket_fn=lambda value: value,
+    )
+
+    assert stage(7) == -7
+    assert stage(7) == -7
+    assert stage(8) == 8
+    assert compiled_calls == [7, 8]
+    assert eager_calls == [7, 7]
+    assert stage.stats().runtime_fallbacks == 1
+
+
+def test_compile_kwargs_and_repeat_are_forwarded() -> None:
+    seen = {}
+    calls = []
+
+    def compile_fn(fn, **kwargs):
+        seen.update(kwargs)
+        return fn
+
+    stage = CompiledStage(
+        "kwargs",
+        lambda value, *, scale: calls.append(value) or value * scale,
+        compile_kwargs={"dynamic": True, "mode": "default"},
+        compile_fn=compile_fn,
+    )
+    stage.warmup(
+        [CompileWarmupCase("repeat", args=(3,), kwargs={"scale": 2}, repeat=3)]
+    )
+
+    assert seen == {"dynamic": True, "mode": "default"}
+    assert calls == [3, 3, 3]
+
+
+def test_warmup_case_rejects_non_positive_repeat() -> None:
+    with pytest.raises(ValueError, match="repeat"):
+        CompileWarmupCase("bad", repeat=0)
+
+
+def test_compile_events_track_time_and_recompilations(monkeypatch) -> None:
+    class FakeCallbackHandler:
+        def __init__(self) -> None:
+            self.starts = []
+            self.ends = []
+            self.start_registrations = 0
+            self.end_registrations = 0
+
+        def register_start_callback(self, callback) -> None:
+            self.start_registrations += 1
+            self.starts.append(callback)
+
+        def register_end_callback(self, callback) -> None:
+            self.end_registrations += 1
+            self.ends.append(callback)
+
+        def remove_start_callback(self, callback) -> None:
+            self.starts.remove(callback)
+
+        def remove_end_callback(self, callback) -> None:
+            self.ends.remove(callback)
+
+        def fire(self) -> None:
+            args = SimpleNamespace(compile_id="test", callback_trigger="dynamo")
+            for callback in list(self.starts):
+                callback(args)
+            for callback in list(self.ends):
+                callback(args)
+
+    handler = FakeCallbackHandler()
+    monkeypatch.setattr(torch._dynamo, "callback_handler", handler)
+
+    def compile_fn(fn, **_kwargs):
+        def compiled(value):
+            handler.fire()
+            return fn(value)
+
+        return compiled
+
+    stage = CompiledStage(
+        "stats",
+        lambda value: value + 1,
+        compile_fn=compile_fn,
+        bucket_fn=lambda value: value,
+    )
+
+    assert stage(1) == 2
+    assert stage(2) == 3
+    assert stage(2) == 3
+    stats = stage.stats()
+    assert stats.compilation_count == 2
+    assert stats.recompilation_count == 1
+    assert stats.compile_time_s >= 0.0
+    assert handler.start_registrations == 2
+    assert handler.end_registrations == 2

--- a/tests/unit_test/utils/test_compiled_stage.py
+++ b/tests/unit_test/utils/test_compiled_stage.py
@@ -11,21 +11,6 @@ import torch
 from sglang_omni.utils.compiled_stage import CompiledStage, CompileWarmupCase
 
 
-def test_disabled_compiled_stage_never_calls_compiler() -> None:
-    compiler_calls = []
-
-    stage = CompiledStage(
-        "disabled",
-        lambda value: value + 1,
-        enabled=False,
-        compile_fn=lambda fn, **kwargs: compiler_calls.append((fn, kwargs)),
-    )
-
-    assert stage(2) == 3
-    assert compiler_calls == []
-    assert stage.stats().enabled is False
-
-
 def test_compile_setup_failure_uses_eager(caplog) -> None:
     def fail_compile(_fn, **_kwargs):
         raise RuntimeError("compiler unavailable")


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

## Modifications

- Add `CompiledStage` and `CompileWarmupCase` as the shared lifecycle wrapper
  for model-owned `torch.compile` callables.
- Support explicit enable/disable behavior, compile options, model-defined
  shape buckets, pre-readiness warmup, compile/recompile timing, and per-bucket
  eager fallback.
- Limit Dynamo compile observation to the first call for each model-defined
  bucket so repeated serving calls stay on the direct compiled callable path.
- Migrate the FishAudio S2-Pro Fast-AR codebook decoder layers.
- Migrate the Qwen3-TTS decode backbone layers.
- Migrate the Higgs TTS acoustic encoder and codec decoder, preserving their
  existing dynamic-shape compilation and warmup behavior.
- Migrate the MOSS-Transcribe-Diarize Whisper encoder and restrict compiled
  execution to successfully warmed static chunk buckets.
- Migrate the MOSS-TTS-Local branchless frame sampler and propagate an explicit
  `compile_frame_sampler` configuration switch.
- Preserve the existing defaults: this PR does not enable compilation for a
  model that previously ran eager and does not switch an existing compiled
  model to eager.
- Add focused unit coverage for setup failure, warmup failure, runtime
  fallback, bucket isolation, disabled execution, compile options, lifecycle
  counters, configuration propagation, and each migrated model integration.

## Related Issues

Closes #1121.

## Accuracy Test

Accuracy and output parity were checked with fixed checkpoints, inputs, and
seeds on the same NVIDIA H20 host.

All five migrated model families were checked independently:

| Model | Accuracy or parity workload | Upstream `main` | Refactor | Result |
| --- | --- | --- | --- | --- |
| Qwen3-TTS | Official 50-sample English SeedTTS subset, transcribed with Qwen3-ASR-1.7B | 50/50 successful, 1.064% corpus WER | 50/50 successful, 1.064% corpus WER | Equal corpus WER; no failed or truncated samples |
| MOSS-Transcribe-Diarize | 80 fixed audio requests | Identical speaker labels, timestamps, and transcript | Identical speaker labels, timestamps, and transcript | All 80 responses byte-identical |
| Higgs TTS | 20 fixed-seed reference-audio requests | 20/20 valid WAV responses | 20/20 valid WAV responses | Identical token, frame, byte-count, format, and sample-rate invariants |
| MOSS-TTS-Local | Repeated fixed-seed steady-state synthesis | 32 completion tokens, 122,880 WAV frames | 32 completion tokens, 122,880 WAV frames | Steady-state WAV files byte-identical |
| FishAudio S2-Pro | Repeated fixed-seed reference-audio synthesis | 63 completion tokens, 129,024 WAV frames | 63 completion tokens, 129,024 WAV frames | Steady-state WAV files byte-identical |

### Benchmark methods

| Model | Workload and generation settings | Load and modes | Correctness / quality oracle |
| --- | --- | --- | --- |
| Qwen3-TTS | Performance: fixed text, reference audio/transcript, English, `seed=1234`. Quality: official 50-sample SeedTTS EN subset generated by Qwen3-TTS 0.6B and transcribed by Qwen3-ASR-1.7B. | Performance: 40 requests, c=4, 4 warmups, non-streaming. SeedTTS: 50 samples, c=16, 1 warmup. | Repository English normalizer + `jiwer` corpus/per-sample WER; success/truncation; 24 kHz mono PCM-16 validity; CUDA Graph and fallback logs. WAV hashes are not required because sampled token counts can differ. |
| FishAudio S2-Pro | Fixed text and reference audio/transcript; `temperature=0.8`, `top_p=0.8`, `top_k=30`, `repetition_penalty=1.1`, `max_new_tokens=64`, `seed=1234`. | 20 requests, c=4, 2 HTTP conditioning/warmup requests; WAV non-streaming and PCM streaming. | Post-conditioning WAVs byte-identical; completion tokens, frames, response bytes, channels, sample width/rate, and success count equal. Fresh-process request 1 is excluded because it is unstable even across repeated `main` launches. |
| Higgs TTS | Fixed text and reference audio/transcript; `temperature=0.8`, `top_k=50`, `max_new_tokens=128`, `seed=1234`. | 20 requests, c=4, 2 warmups; WAV non-streaming and PCM streaming. | Structural parity rather than WAV hash: completion tokens, frames, response bytes, channels, sample width/rate, and success count equal. Both runs produced 85 tokens, 74,880 frames, and 149,804-byte 24 kHz mono PCM-16 WAVs. |
| MOSS-TTS-Local | Fixed text without reference audio; `token_count=32`, `temperature=1.0`, `top_p=0.8`, `top_k=25`, `seed=1234`; local MOSS-Audio-Tokenizer-v2. | 40 requests, c=4, 2 HTTP conditioning/warmup requests; WAV non-streaming and PCM streaming. | Post-conditioning WAVs byte-identical; completion tokens, frames, response bytes, channels, sample width/rate, and success count equal. Fresh-process request 1 is excluded for the same upstream instability as FishAudio. |
| MOSS-Transcribe-Diarize | `tests/data/query_to_cars.wav`; encoder compile enabled with chunk buckets `[1, 2, 4, 8]`; `max_new_tokens=128`. | The fixed audio repeated 80 times, c=8, 2 warmups; non-streaming and SSE streaming. | Exact speaker labels, timestamps, and transcript; all outputs equal `[1.45][S01] How many cars are there in the picture?[4.41]`. Repeated input controls shape/parity and is not presented as mixed-corpus production QPS. |

<details>
<summary>Exact server and benchmark commands</summary>

### Command details

The commands below were run once from the upstream `main` worktree and once
from the refactor worktree. `<CHECKPOINT>` and `<PORT>` denote the same local
checkpoint and an otherwise unused port for each side. All performance runs
used the local closed-loop resource harness, which records every request plus
process-tree CPU and `nvidia-smi` utilization/VRAM samples:

```bash
python -m benchmarks.eval.benchmark_compiled_speech_stage \
  --base-url http://127.0.0.1:<PORT> \
  --payload <PAYLOAD.json> \
  --out <RESULT.json> \
  --label <LABEL> \
  --requests <N> --concurrency <C> --warmup 2 \
  --server-pid <SERVER_PID>
```

For a cold-start measurement, each server was launched through
`benchmarks/eval/launch_profiled_server.py` with a newly created empty
`TORCHINDUCTOR_CACHE_DIR`. The launcher sampled startup CPU, GPU utilization,
and VRAM until `/health` returned 200. Warm steady-state measurements were then
run in the same process after the complete request path had been exercised at
the measured concurrency.

FishAudio and Higgs used the synthesis text
`The compiled stage must preserve the original behavior.`, reference audio
`file:docs/_static/audio/male-voice.wav`, and reference transcript
`Hey, Adam here. Let us create something that feels real, sounds human, and connects every time.`
MOSS-TTS-Local used the same synthesis text without a reference-audio field.
The per-model payload parameters that differ are listed below.

#### Qwen3-TTS

The fixed-payload throughput run used the 0.6B Base checkpoint, the text
`SGLang Omni provides efficient and reliable speech generation.`, the checked
in `docs/_static/audio/male-voice.wav` reference and transcript, English,
`seed=1234`, 40 measured requests, and concurrency 4:

```bash
python -m sglang_omni.cli serve \
  --config examples/configs/qwen3_tts_0_6b.yaml \
  --model-path <QWEN3_TTS_0_6B_CHECKPOINT> \
  --host 127.0.0.1 --port <PORT> \
  --allowed-local-media-path docs/_static/audio \
  --max-running-requests 4 --cuda-graph-max-bs 4

python -m benchmarks.eval.benchmark_compiled_speech_stage \
  --base-url http://127.0.0.1:<PORT> \
  --payload benchmarks/compiled_stage/qwen3_tts_0_6b_payload.json \
  --out <QWEN_RESULT.json> --label <LABEL> \
  --requests 40 --concurrency 4 --warmup 4 \
  --server-pid <SERVER_PID>
```

Quality used the PR #527 two-phase SeedTTS workflow. One H20 generated the
official first 50 English samples at concurrency 16, persisted every WAV, and
then Qwen3-ASR-1.7B transcribed the saved files. `benchmark_tts_seedtts.py`
uses the repository English normalizer and `jiwer` for corpus/sample WER:

```bash
python -m benchmarks.eval.benchmark_tts_seedtts \
  --base-url http://127.0.0.1:<PORT> \
  --model Qwen/Qwen3-TTS-12Hz-0.6B-Base \
  --meta <SEEDTTS_EN_META> --lang en --max-samples 50 \
  --warmup 1 --concurrency 16 --seed 1234 \
  --output-dir <QWEN_SEEDTTS_OUTPUT> --generate-only

python -m benchmarks.eval.benchmark_tts_seedtts \
  --model Qwen/Qwen3-TTS-12Hz-0.6B-Base \
  --meta <SEEDTTS_EN_META> --lang en --max-samples 50 \
  --output-dir <QWEN_SEEDTTS_OUTPUT> \
  --asr-model-path <QWEN3_ASR_1_7B_CHECKPOINT> --transcribe-only
```

The parity oracle is corpus WER plus per-sample WER, request success, WAV
format, sample rate, truncation, and decode-log inspection. Generated WAV
bytes are not required to match because this workload produces different
sampled token counts even with the same request seed.

#### FishAudio S2-Pro

FishAudio used the S2-Pro checkpoint, the same fixed input and reference audio
on both sides, `temperature=0.8`, `top_p=0.8`, `top_k=30`,
`repetition_penalty=1.1`, `max_new_tokens=64`, and `seed=1234`. Twenty requests
were measured at concurrency 4:

```bash
python -m sglang_omni.cli serve \
  --config examples/configs/s2pro_tts.yaml \
  --model-path <FISHAUDIO_S2_PRO_CHECKPOINT> \
  --host 127.0.0.1 --port <PORT> \
  --allowed-local-media-path docs/_static/audio \
  --max-running-requests 4 --cuda-graph-max-bs 4

python -m benchmarks.eval.benchmark_compiled_speech_stage \
  --base-url http://127.0.0.1:<PORT> \
  --payload benchmarks/compiled_stage/fishaudio_s2_pro_payload.json \
  --out <FISH_RESULT.json> --label <LABEL> \
  --requests 20 --concurrency 4 --warmup 2 \
  --server-pid <SERVER_PID>

# Repeat with raw PCM streaming to measure time to first audio bytes.
python -m benchmarks.eval.benchmark_compiled_speech_stage \
  --base-url http://127.0.0.1:<PORT> \
  --payload benchmarks/compiled_stage/fishaudio_s2_pro_payload.json \
  --out <FISH_STREAM_RESULT.json> --label <LABEL> \
  --requests 20 --concurrency 4 --warmup 2 --stream \
  --server-pid <SERVER_PID>
```

The first fresh-process response is not a parity oracle because it is not
byte-stable even between repeated upstream `main` launches. After two
identical HTTP conditioning requests, the next fixed-seed WAVs were compared
byte-for-byte across `main` and the refactor. Completion-token count, WAV
frames, channels, sample width/rate, response bytes, and request success were
also checked.

#### Higgs TTS

Higgs used the same 4B checkpoint, fixed input, reference audio/transcript,
`temperature=0.8`, `top_k=50`, `max_new_tokens=128`, and `seed=1234`. Twenty
requests were measured at concurrency 4:

```bash
python -m sglang_omni.cli serve \
  --model-path <HIGGS_TTS_4B_CHECKPOINT> \
  --host 127.0.0.1 --port <PORT> \
  --allowed-local-media-path docs/_static/audio \
  --max-running-requests 4 --cuda-graph-max-bs 4

python -m benchmarks.eval.benchmark_compiled_speech_stage \
  --base-url http://127.0.0.1:<PORT> \
  --payload benchmarks/compiled_stage/higgs_tts_payload.json \
  --out <HIGGS_RESULT.json> --label <LABEL> \
  --requests 20 --concurrency 4 --warmup 2 \
  --server-pid <SERVER_PID>

python -m benchmarks.eval.benchmark_compiled_speech_stage \
  --base-url http://127.0.0.1:<PORT> \
  --payload benchmarks/compiled_stage/higgs_tts_payload.json \
  --out <HIGGS_STREAM_RESULT.json> --label <LABEL> \
  --requests 20 --concurrency 4 --warmup 2 --stream \
  --server-pid <SERVER_PID>
```

Higgs parity is structural rather than a waveform hash: both implementations
must return the same completion-token count, WAV frame count, response byte
count, channel count, sample width, and sample rate for every successful
request. The checked responses contained 85 completion tokens, 74,880 frames,
and 149,804 bytes of 24 kHz mono PCM-16 audio.

#### MOSS-TTS-Local

MOSS-TTS-Local used the v1.5 Transformer checkpoint, the fixed input text,
`token_count=32`, `temperature=1.0`, `top_p=0.8`, `top_k=25`, and `seed=1234`.
Forty requests were measured at concurrency 4. `HF_HOME` pointed at the local
cache containing MOSS-Audio-Tokenizer-v2:

```bash
HF_HOME=<HF_CACHE> HF_HUB_OFFLINE=1 \
python -m sglang_omni.cli serve \
  --config examples/configs/moss_tts_local.yaml \
  --model-path <MOSS_TTS_LOCAL_V1_5_CHECKPOINT> \
  --host 127.0.0.1 --port <PORT> \
  --allowed-local-media-path docs/_static/audio \
  --max-running-requests 4 --cuda-graph-max-bs 4

python -m benchmarks.eval.benchmark_compiled_speech_stage \
  --base-url http://127.0.0.1:<PORT> \
  --payload benchmarks/compiled_stage/moss_tts_local_payload.json \
  --out <MOSS_LOCAL_RESULT.json> --label <LABEL> \
  --requests 40 --concurrency 4 --warmup 2 \
  --server-pid <SERVER_PID>

python -m benchmarks.eval.benchmark_compiled_speech_stage \
  --base-url http://127.0.0.1:<PORT> \
  --payload benchmarks/compiled_stage/moss_tts_local_payload.json \
  --out <MOSS_LOCAL_STREAM_RESULT.json> --label <LABEL> \
  --requests 40 --concurrency 4 --warmup 2 --stream \
  --server-pid <SERVER_PID>
```

As with FishAudio, fresh-process first responses are not byte-stable even on
repeated `main` launches. After two identical HTTP conditioning requests, the
subsequent fixed-seed WAVs were byte-identical between `main` and the
refactor. Completion tokens, WAV frames, channels, sample width/rate, response
bytes, and request success were checked separately.

#### MOSS-Transcribe-Diarize

MOSS-TD explicitly enabled the opt-in Whisper encoder compile and warmed chunk
buckets `[1, 2, 4, 8]` on both sides. The benchmark repeated
`tests/data/query_to_cars.wav` 80 times at concurrency 8 with two warmup
requests and `max_new_tokens=128`. The benchmark-only config was:

```yaml
config_cls: MossTranscribeDiarizePipelineConfig
model_path: <MOSS_TD_CHECKPOINT>
runtime_overrides:
  asr:
    encoder_torch_compile: true
    encoder_chunk_buckets: [1, 2, 4, 8]
```

```bash
python -m sglang_omni.cli serve \
  --config <MOSS_TD_COMPILE_CONFIG.yaml> \
  --model-path <MOSS_TD_CHECKPOINT> \
  --host 127.0.0.1 --port <PORT> \
  --max-running-requests 8 --cuda-graph-max-bs 8 \
  --mem-fraction-static 0.80

python -m benchmarks.eval.benchmark_compiled_asr_stage \
  --base-url http://127.0.0.1:<PORT> \
  --model <MOSS_TD_CHECKPOINT> \
  --audio-file tests/data/query_to_cars.wav \
  --out <MOSS_TD_RESULT.json> --label <LABEL> \
  --requests 80 --concurrency 8 --warmup 2 \
  --max-new-tokens 128 --server-pid <SERVER_PID>

python -m benchmarks.eval.benchmark_compiled_asr_stage \
  --base-url http://127.0.0.1:<PORT> \
  --model <MOSS_TD_CHECKPOINT> \
  --audio-file tests/data/query_to_cars.wav \
  --out <MOSS_TD_STREAM_RESULT.json> --label <LABEL> \
  --requests 80 --concurrency 8 --warmup 2 --stream \
  --max-new-tokens 128 --server-pid <SERVER_PID>
```

Every response was compared exactly, including speaker labels, timestamps,
and transcript. Both sides returned
`[1.45][S01] How many cars are there in the picture?[4.41]`. Repeating one
audio file intentionally controls encoder shape and output parity; because it
also reuses the LLM radix prefix, its absolute QPS is not presented as a
mixed-corpus production benchmark.

</details>

### Cold start

| Model | Build | Ready time | CPU mean | GPU util mean | GPU active / idle | Peak / ready-idle VRAM |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| Qwen3-TTS | `main` | 83.64 s | 111.7% | 2.46% | 24.2 / 59.5 s | 83,697 / 83,697 MiB |
|  | Refactor | 87.31 s | 113.3% | 2.55% | 26.1 / 61.2 s | 83,697 / 83,697 MiB |
| FishAudio S2-Pro | `main` | 84.69 s | 138.0% | 4.24% | 31.8 / 52.9 s | 89,131 / 89,131 MiB |
|  | Refactor | 82.24 s | 138.7% | 4.13% | 34.3 / 47.9 s | 89,131 / 89,131 MiB |
| Higgs TTS | `main` | 65.50 s | 187.7% | 3.40% | 8.6 / 56.9 s | 83,225 / 83,225 MiB |
|  | Refactor | 65.33 s | 194.8% | 3.50% | 8.1 / 57.2 s | 83,225 / 83,225 MiB |
| MOSS-TTS-Local | `main` | 61.10 s | 118.2% | 11.96% | 22.8 / 38.3 s | 81,791 / 81,739 MiB |
|  | Refactor | 61.18 s | 118.5% | 11.82% | 22.5 / 38.7 s | 81,793 / 81,739 MiB |
| MOSS-Transcribe-Diarize | `main` | 126.63 s | 97.2% | 3.44% | 37.6 / 89.1 s | 78,601 / 78,601 MiB |
|  | Refactor | 123.74 s | 98.9% | 3.77% | 38.4 / 85.4 s | 78,601 / 78,601 MiB |

### Warm steady state

| Model / load | Build | Throughput | Mean / p95 latency | CPU mean | GPU util | GPU active / idle | Peak / idle VRAM |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Qwen3-TTS, 40 requests, c=4 | `main` | 1.546 req/s | 2.586 / 2.707 s | 101.7% | 17.45% | 25.87 / 0.00 s | 85,965 / 85,963 MiB |
|  | Refactor | 1.607 req/s | 2.488 / 2.563 s | 102.0% | 19.54% | 24.88 / 0.00 s | 85,951 / 85,947 MiB |
| FishAudio S2-Pro, 20 requests, c=4 | `main` | 3.836 req/s | 1.031 / 1.279 s | 111.1% | 60.37% | 5.21 / 0.00 s | 89,943 / 89,131 MiB |
|  | Refactor | 3.588 req/s | 1.102 / 1.327 s | 110.3% | 63.35% | 5.57 / 0.00 s | 89,943 / 89,131 MiB |
| Higgs TTS, 20 requests, c=4 | `main` | 9.154 req/s | 0.435 / 0.442 s | 139.0% | 75.38% | 2.18 / 0.00 s | 83,623 / 83,225 MiB |
|  | Refactor | 8.194 req/s | 0.486 / 0.715 s | 118.9% | 73.22% | 2.17 / 0.27 s | 83,683 / 83,225 MiB |
| MOSS-TTS-Local, 40 requests, c=4 | `main` | 6.807 req/s | 0.574 / 0.769 s | 161.1% | 72.00% | 5.60 / 0.28 s | 81,991 / 81,739 MiB |
|  | Refactor | 6.779 req/s | 0.578 / 0.751 s | 160.9% | 68.57% | 5.62 / 0.28 s | 81,991 / 81,739 MiB |
| MOSS-Transcribe-Diarize, 80 requests, c=8 | `main` | 33.504 req/s | 0.129 / 0.406 s | 107.3% | 21.11% | 1.89 / 0.50 s | 78,827 / 78,601 MiB |
|  | Refactor | 33.633 req/s | 0.127 / 0.382 s | 105.1% | 17.89% | 1.38 / 1.00 s | 78,827 / 78,601 MiB |

The complete cold-cache run shows no systematic throughput or latency claim:
Qwen3-TTS and MOSS-TD are slightly faster, MOSS-TTS-Local is effectively
unchanged, and the single short FishAudio and Higgs non-streaming runs favor
`main`. This PR therefore treats performance as validation of a
behavior-preserving refactor, not as an optimization result. The longer
50-sample Qwen quality run had equal 1.064% corpus WER; its work-normalized
audio and output-token throughput each changed by -0.4%.

### Streaming

TTFA is measured as time to the first PCM response bytes. MOSS-TD produces
text, so its corresponding metric is text TTFT. Qwen3-TTS reports N/A because
its model capability explicitly has `streaming_vocoder=false`.

| Model / load | Build | Throughput | Mean / p95 latency | TTFA/TTFT mean / p95 | CPU mean | GPU util | GPU active / idle | Peak / idle VRAM |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| FishAudio S2-Pro, 20 requests, c=4 | `main` | 3.359 req/s | 1.170 / 1.276 s | 0.617 / 0.711 s | 123.4% | 69.77% | 5.95 / 0.00 s | 89,943 / 89,943 MiB |
|  | Refactor | 3.242 req/s | 1.213 / 1.312 s | 0.649 / 0.748 s | 122.1% | 66.73% | 6.17 / 0.00 s | 89,943 / 89,943 MiB |
| Higgs TTS, 20 requests, c=4 | `main` | 9.015 req/s | 0.442 / 0.450 s | 0.092 / 0.099 s | 160.0% | 80.38% | 2.22 / 0.00 s | 83,623 / 83,623 MiB |
|  | Refactor | 9.052 req/s | 0.440 / 0.444 s | 0.090 / 0.093 s | 139.1% | 81.63% | 2.21 / 0.00 s | 83,683 / 83,683 MiB |
| MOSS-TTS-Local, 40 requests, c=4 | `main` | 4.469 req/s | 0.878 / 0.916 s | 0.185 / 0.307 s | 173.0% | 84.50% | 8.95 / 0.00 s | 82,763 / 81,991 MiB |
|  | Refactor | 4.434 req/s | 0.886 / 0.942 s | 0.183 / 0.302 s | 169.9% | 82.33% | 9.02 / 0.00 s | 82,763 / 81,991 MiB |
| MOSS-TD, 80 requests, c=8 | `main` | 66.400 req/s | 0.102 / 0.118 s | 0.055 / 0.072 s | 172.2% | 38.20% | 1.08 / 0.12 s | 78,827 / 78,827 MiB |
|  | Refactor | 67.025 req/s | 0.101 / 0.111 s | 0.056 / 0.067 s | 183.1% | 37.90% | 1.07 / 0.12 s | 78,827 / 78,827 MiB |
| Qwen3-TTS | Both | N/A | N/A | N/A | N/A | N/A | N/A | N/A |

Cold-start logs also validate the requested compile observability. The
refactor reported compile time and recompile count for every migrated region:
FishAudio (2 stages), Higgs (2 stages), MOSS-TTS-Local (1 stage), MOSS-TD (1
stage), and all 28 Qwen3-TTS decoder layers. MOSS-TD, for example, reported 4
compile events, 3 recompiles, and 35.924 s cumulative compile time while
warming buckets `[1, 2, 4, 8]`. Setup, warmup, and runtime fallback behavior is
covered by focused tests; no fallback was observed in the successful GPU runs.

Formatting and static checks completed successfully:

```text
black --check: passed
isort --check-only: passed
ruff check: passed
git diff --check: passed
```

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
