### PR TITLE
Fix code2wav initial chunk size

### DIFF
--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -17,6 +17,7 @@ from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.streaming_simple_scheduler import StreamingSimpleScheduler
+from sglang_omni.scheduling.streaming_vocoder import resolve_initial_codec_chunk_frames
 from sglang_omni.utils.audio_payload import audio_waveform_payload
 
 logger = logging.getLogger(__name__)
@@ -59,6 +60,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         device: str,
         stream_chunk_size: int = 10,
         left_context_size: int = 25,
+        initial_codec_chunk_frames: int = 0,
         sample_rate: int = 24000,
         codec_eos_token_id: int = 2150,
     ):
@@ -66,6 +68,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         self._device = torch.device(device)
         self._stream_chunk_size = max(int(stream_chunk_size), 1)
         self._left_context_size = max(int(left_context_size), 0)
+        self._initial_codec_chunk_frames = max(int(initial_codec_chunk_frames), 0)
         self._sample_rate = sample_rate
         self._codec_eos_token_id = codec_eos_token_id
         self._total_upsample = int(model.total_upsample)
@@ -75,6 +78,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         self._emitted: dict[str, int] = {}
         self._audio_chunks: dict[str, list[np.ndarray]] = {}
         self._stream_enabled: dict[str, bool] = {}
+        self._initial_chunk_frames: dict[str, int] = {}
         super().__init__(compute_fn=None)
         self._payloads = self._stream_payloads
 
@@ -83,14 +87,20 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         return True
 
     def on_streaming_new_request(self, request_id: str, payload: StagePayload) -> None:
-        del payload
         self._ensure_request_state(request_id)
+        override = resolve_initial_codec_chunk_frames(
+            payload.request.params, steady_chunk_frames=self._stream_chunk_size
+        )
+        self._initial_chunk_frames[request_id] = (
+            override or self._initial_codec_chunk_frames
+        )
 
     def clear_stream_state(self, request_id: str) -> None:
         self._code_chunks.pop(request_id, None)
         self._emitted.pop(request_id, None)
         self._audio_chunks.pop(request_id, None)
         self._stream_enabled.pop(request_id, None)
+        self._initial_chunk_frames.pop(request_id, None)
 
     def _fail_request(self, request_id: str, error: Exception) -> None:
         self.outbox.put(
@@ -148,8 +158,14 @@ class Code2WavScheduler(StreamingSimpleScheduler):
                 )
             return []
         self._code_chunks[request_id].append(codes)
-        ready = len(self._code_chunks[request_id]) - self._emitted[request_id]
-        if ready >= self._stream_chunk_size:
+        emitted = self._emitted[request_id]
+        # Before payload arrives, fall back to stage default (not 0).
+        initial = self._initial_chunk_frames.get(
+            request_id, self._initial_codec_chunk_frames
+        )
+        threshold = initial if emitted == 0 and initial > 0 else self._stream_chunk_size
+        ready = len(self._code_chunks[request_id]) - emitted
+        if ready >= threshold:
             return self._decode_and_emit(request_id)
         return []
 
@@ -276,6 +292,7 @@ def create_code2wav_scheduler(
     gpu_id: int | None = None,
     stream_chunk_size: int = 10,
     left_context_size: int = 25,
+    initial_codec_chunk_frames: int = 0,
 ):
     """Factory: returns Code2WavScheduler."""
     if gpu_id is not None:
@@ -286,4 +303,5 @@ def create_code2wav_scheduler(
         device=device,
         stream_chunk_size=stream_chunk_size,
         left_context_size=left_context_size,
+        initial_codec_chunk_frames=initial_codec_chunk_frames,
     )

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -202,7 +202,12 @@ def _code2wav_stage(*, gpu: int, process: str) -> StageConfig:
         name="code2wav",
         process=process,
         factory=f"{_PKG}.components.code2wav_scheduler.create_code2wav_scheduler",
-        factory_args={"device": "cuda"},
+        factory_args={
+            "device": "cuda",
+            "stream_chunk_size": 10,
+            "left_context_size": 25,
+            "initial_codec_chunk_frames": 0,
+        },
         gpu=gpu,
         terminal=True,
         can_accept_stream_before_payload=True,

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -52,3 +52,95 @@ def test_qwen_code2wav_streams_incrementally_and_abort_clears_state() -> None:
     assert "req-2" not in scheduler._code_chunks
     assert "req-2" not in scheduler._payloads
     assert "req-2" not in scheduler._pending_done
+
+
+def _feed_chunks(scheduler: Code2WavScheduler, request_id: str, count: int) -> None:
+    chunk_meta = {"stream": False}
+    for i in range(count):
+        scheduler._on_chunk(
+            request_id,
+            StreamItem(i, torch.tensor([i, i * 10]), "talker", metadata=chunk_meta),
+        )
+
+
+def test_qwen_code2wav_initial_chunk_override_shrinks_first_flush() -> None:
+    """A request-level initial_codec_chunk_frames flushes chunk 0 early, and
+    chunk 1's decode window uses the whole first chunk as left context."""
+    model = FakeCode2WavModel(total_upsample=2)
+    scheduler = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=10,
+        left_context_size=25,
+        sample_rate=24000,
+    )
+    payload = make_qwen_payload(
+        request_id="req-1", params={"initial_codec_chunk_frames": 4}
+    )
+    scheduler._on_streaming_new_request("req-1", payload)
+
+    # First 4 chunks flush at the initial size, not the steady size of 10.
+    _feed_chunks(scheduler, "req-1", 4)
+    assert model.calls == [(1, 2, 4)]
+
+    # Next 10 chunks (steady size, counted from the initial offset) flush the
+    # second chunk. Its window covers all 14 frames seen so far, i.e. context
+    # == 4 == the entire first (initial) chunk, so the seam is continuous.
+    for i in range(4, 14):
+        scheduler._on_chunk(
+            "req-1",
+            StreamItem(
+                i, torch.tensor([i, i * 10]), "talker", metadata={"stream": False}
+            ),
+        )
+    assert model.calls == [(1, 2, 4), (1, 2, 14)]
+
+
+def test_qwen_code2wav_no_override_keeps_steady_size_for_first_flush() -> None:
+    """Without a request-level override, the first flush still uses the
+    configured steady stream_chunk_size (unchanged prior behavior)."""
+    model = FakeCode2WavModel(total_upsample=2)
+    scheduler = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=10,
+        left_context_size=25,
+        sample_rate=24000,
+    )
+    payload = make_qwen_payload(request_id="req-1", params={})
+    scheduler._on_streaming_new_request("req-1", payload)
+
+    _feed_chunks(scheduler, "req-1", 9)
+    assert model.calls == []  # not enough for a steady-size flush yet
+
+    scheduler._on_chunk(
+        "req-1",
+        StreamItem(9, torch.tensor([9, 90]), "talker", metadata={"stream": False}),
+    )
+    assert model.calls == [(1, 2, 10)]
+
+
+def test_qwen_code2wav_stage_default_applies_before_payload_arrives() -> None:
+    """code2wav has can_accept_stream_before_payload=True, so chunks can reach
+    on_stream_chunk before on_streaming_new_request resolves the per-request
+    override. The stage-configured default must still apply in that race,
+    not silently fall back to the steady size."""
+    model = FakeCode2WavModel(total_upsample=2)
+    scheduler = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=10,
+        left_context_size=25,
+        initial_codec_chunk_frames=4,
+        sample_rate=24000,
+    )
+
+    # Chunks arrive first; on_streaming_new_request has not run yet.
+    _feed_chunks(scheduler, "req-1", 4)
+    assert model.calls == [(1, 2, 4)]
+
+    # The payload arrives afterward with no per-request override; the
+    # already-applied stage default must not be disturbed.
+    payload = make_qwen_payload(request_id="req-1", params={})
+    scheduler._on_streaming_new_request("req-1", payload)
+    assert scheduler._initial_chunk_frames["req-1"] == 4


### PR DESCRIPTION
## Motivation
The Qwen3-Omni `code2wav` (vocoder) stage buffers a full `stream_chunk_size` (10 codec frames) before emitting any audio, so `time-to-first-audio` (TTFA) is gated by the steady-state chunk size. This PR lets the first flush use a smaller, separately configurable chunk size to lower TTFA, while keeping the steady-state chunk size for all subsequent flushes.

## Modifications

- code2wav_scheduler.py — Add initial_codec_chunk_frames to Code2WavScheduler and its factory. The first flush (emitted == 0) uses this smaller threshold (per-request override from payload.request.params, else stage default); later flushes use stream_chunk_size. Race fix: since the stage allows chunks before the payload, fall back to the stage default (not 0) when the override isn't resolved yet.
- config.py — code2wav factory_args now sets stream_chunk_size, left_context_size, and initial_codec_chunk_frames explicitly (was device-only).
- test_code2wav.py — Cover initial-override shrinks first flush, no-override keeps steady size, and before-payload default fallback.

## Related Issues
N/A

## Accuracy Test
- Targeted unit tests: test_code2wav.py, test_config_manager.py, test_pipeline.py — all pass.
- Full CI suite on a CUDA-13 H100 (pytest tests/ -v -m "not benchmark" -x): 2225 passed, 31 skipped.

## Benchmark & Profiling
TTFA/xRT sweep pending on GPU (initial ∈ {2, 4, 10} × steady ∈ {10, 25}, c1–c16). 

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

#1148 