### PR TITLE
ci: preserve benchmark result on cleanup timeout

### DIFF
--- a/.github/actions/omni-post-stage/action.yaml
+++ b/.github/actions/omni-post-stage/action.yaml
@@ -121,4 +121,16 @@ runs:
         # note (Yue Yin): post-stage runs after the test in an isolated --rm
         # container, so reap nvidia-invisible orphans (spawn workers) that would
         # otherwise hold VRAM and time out the cleanup wait. setup must NOT.
+        # Teardown must not override a completed stage's result when the runner
+        # reports residual memory but no killable process. Setup and retry
+        # cleanup stay strict; this post-stage hook records diagnostics and
+        # lets the next stage decide whether the runner is usable.
+        set +e
         bash .github/scripts/delete_gpu_process.sh --kill-orphans
+        cleanup_status=$?
+        set -e
+        if [ "${cleanup_status}" -eq 1 ]; then
+          echo "::warning::Post-stage GPU cleanup did not reach the memory threshold; diagnostics were printed above."
+        elif [ "${cleanup_status}" -ne 0 ]; then
+          exit "${cleanup_status}"
+        fi

--- a/.github/scripts/delete_gpu_process.sh
+++ b/.github/scripts/delete_gpu_process.sh
@@ -42,6 +42,33 @@ selected_gpu_ids() {
     return 1
 }
 
+_print_gpu_cleanup_diagnostics() {
+    local gpu_index query_output
+
+    echo "=== GPU cleanup diagnostics ==="
+    for gpu_index in "${_SELECTED_GPUS[@]}"; do
+        gpu_index=$(printf '%s' "$gpu_index" | ${_TR} -d ' ')
+        [ -n "${gpu_index}" ] || continue
+        echo "--- nvidia-smi summary for GPU ${gpu_index} ---"
+        nvidia-smi --id="${gpu_index}" || true
+        echo "--- compute apps for GPU ${gpu_index} ---"
+        query_output="$(nvidia-smi --query-compute-apps=pid,process_name,used_memory \
+            --format=csv,noheader --id="${gpu_index}" 2>/dev/null || true)"
+        if [ -n "${query_output}" ]; then
+            printf '%s\n' "${query_output}"
+        else
+            echo "(nvidia-smi reports no compute apps)"
+        fi
+        if command -v fuser >/dev/null 2>&1; then
+            echo "--- fuser /dev/nvidia${gpu_index} ---"
+            fuser -v "/dev/nvidia${gpu_index}" 2>&1 || true
+        fi
+    done
+    echo "--- all GPU processes visible to nvidia-smi ---"
+    nvidia-smi --query-compute-apps=gpu_uuid,pid,process_name,used_memory \
+        --format=csv,noheader 2>/dev/null || true
+}
+
 # note (Yue Yin): kill orphan processes that hold /dev/nvidia* fds but are
 # invisible to nvidia-smi (e.g. multiprocessing.spawn workers after a crash).
 _kill_orphan_gpu_processes() {
@@ -202,6 +229,7 @@ while true; do
     fi
 
     if [ "${SECONDS}" -ge "${deadline}" ]; then
+        _print_gpu_cleanup_diagnostics
         echo "::error::Timed out waiting for GPU memory.used < ${memory_threshold_mb} MiB; max memory.used=${max_used_mb} MiB."
         exit 1
     fi

--- a/tests/unit_test/test_tune_ci_thresholds.py
+++ b/tests/unit_test/test_tune_ci_thresholds.py
@@ -1,6 +1,9 @@
 import ast
 import importlib.util
+import subprocess
 from pathlib import Path
+
+import yaml
 
 TUNE_PATH = (
     Path(__file__).resolve().parents[2] / ".claude/skills/tune-ci-thresholds/tune.py"
@@ -57,6 +60,60 @@ def test_gpu_cleanup_is_scoped_to_explicit_targets(monkeypatch, tmp_path):
     cmd, kwargs = calls[0]
     assert cmd[-1] == "--kill-orphans"
     assert kwargs["env"]["CUDA_VISIBLE_DEVICES"] == "2,3"
+
+
+def test_post_stage_cleanup_only_downgrades_memory_timeout():
+    action_path = (
+        Path(__file__).resolve().parents[2]
+        / ".github/actions/omni-post-stage/action.yaml"
+    )
+    action = yaml.safe_load(action_path.read_text())
+    kill_step = next(
+        step for step in action["runs"]["steps"] if step["name"] == "Kill GPU processes"
+    )
+
+    run = kill_step["run"]
+    assert "cleanup_status=$?" in run
+    assert 'if [ "${cleanup_status}" -eq 1 ]; then' in run
+    assert "::warning::Post-stage GPU cleanup did not reach" in run
+    assert 'elif [ "${cleanup_status}" -ne 0 ]; then' in run
+    assert 'exit "${cleanup_status}"' in run
+
+
+def test_post_stage_cleanup_exit_status_policy():
+    action_path = (
+        Path(__file__).resolve().parents[2]
+        / ".github/actions/omni-post-stage/action.yaml"
+    )
+    action = yaml.safe_load(action_path.read_text())
+    run = next(
+        step["run"]
+        for step in action["runs"]["steps"]
+        if step["name"] == "Kill GPU processes"
+    )
+    cleanup_command = "bash .github/scripts/delete_gpu_process.sh --kill-orphans"
+
+    for cleanup_status, expected_status in ((0, 0), (1, 0), (2, 2)):
+        simulated_run = run.replace(cleanup_command, f"bash -c 'exit {cleanup_status}'")
+        result = subprocess.run(
+            ["bash", "-c", simulated_run], capture_output=True, text=True
+        )
+
+        assert result.returncode == expected_status
+        assert ("::warning::" in result.stdout) is (cleanup_status == 1)
+
+
+def test_gpu_cleanup_timeout_prints_diagnostics_before_failing():
+    script_path = (
+        Path(__file__).resolve().parents[2] / ".github/scripts/delete_gpu_process.sh"
+    )
+    script = script_path.read_text()
+
+    assert "_print_gpu_cleanup_diagnostics" in script
+    assert "Timed out waiting for GPU memory.used" in script
+    assert script.index("_print_gpu_cleanup_diagnostics") < script.rindex(
+        "Timed out waiting for GPU memory.used"
+    )
 
 
 def test_metric_statistics_retains_outlier_and_reports_dispersion():


### PR DESCRIPTION
## Summary
- print scoped `nvidia-smi` and `fuser` diagnostics when GPU memory cleanup times out
- keep a completed benchmark result from turning red solely because post-stage cleanup reports residual memory with no killable process
- downgrade only the timeout exit code (`1`); configuration and scope errors remain strict failures

This is the standalone `main`-targeted follow-up requested in the discussion on #1093 and supersedes the dependent, now-closed #1099.

## Verification
- `python3 -m pytest -q tests/unit_test/test_tune_ci_thresholds.py` (10 passed)
- dynamic post-stage policy coverage for cleanup exit codes 0, 1, and 2
- `pre-commit run --files .github/actions/omni-post-stage/action.yaml .github/scripts/delete_gpu_process.sh tests/unit_test/test_tune_ci_thresholds.py`
- `bash -n .github/scripts/delete_gpu_process.sh`
- `git diff --check`