### PR TITLE
[Fix][TTS][MOSS] Fix request memory leak in MOSS-TTS Local Transformer v1.5

### DIFF
--- a/sglang_omni/scheduling/omni_scheduler.py
+++ b/sglang_omni/scheduling/omni_scheduler.py
@@ -54,6 +54,13 @@ _ABORTED_REQUEST_ID_LIMIT = 10000
 _ABORTED_REQUEST_ID_RETAINED = 5000
 
 
+def _break_request_data_cycle(req: Any) -> None:
+    """Detach completed Reqs while preserving data.req for async snapshots."""
+    data = getattr(req, "_omni_data", None)
+    if data is not None and getattr(data, "req", None) is req:
+        req._omni_data = None
+
+
 class _NoOpSender:
     """Stub for send_to_detokenizer — stream_output handles emission."""
 
@@ -714,7 +721,6 @@ class OmniScheduler:
             self._pending_stream_done.discard(req_id)
         self._deferred_request_payloads.pop(req_id, None)
         req = req_data.req
-        req._omni_data = req_data
         req_id = req.rid
         if bool(getattr(req_data, "enforce_request_limits", False)):
             error_msg = self._prepare_request_limits(req_data)
@@ -738,6 +744,7 @@ class OmniScheduler:
         def enqueue_if_live() -> None:
             if req_id in self._aborted_request_ids:
                 return
+            req._omni_data = req_data
             _emit_event(
                 request_id=req_id,
                 stage=None,
@@ -1026,6 +1033,7 @@ class OmniScheduler:
                         )
                 self._first_emit_done.discard(rid)
                 self._prefill_start_done.discard(rid)
+                _break_request_data_cycle(req)
                 continue
 
             # Build result payload from the Req
@@ -1051,6 +1059,7 @@ class OmniScheduler:
             finally:
                 data.prefill_input_embeds = None
                 data.decode_input_embeds = None
+                _break_request_data_cycle(req)
 
             self._first_emit_done.discard(rid)
             self._prefill_start_done.discard(rid)
@@ -1155,9 +1164,13 @@ class OmniScheduler:
                 ]
                 self._backlogged_request_build_payloads.clear()
                 self._backlogged_request_build_payloads.extend(retained)
-            self.waiting_queue = [
-                req for req in self.waiting_queue if req.rid != request_id
-            ]
+            waiting_queue = []
+            for req in self.waiting_queue:
+                if req.rid == request_id:
+                    _break_request_data_cycle(req)
+                else:
+                    waiting_queue.append(req)
+            self.waiting_queue = waiting_queue
         if self._abort_callback is not None and not running_abort:
             try:
                 self._abort_callback(request_id)
@@ -1987,6 +2000,9 @@ class OmniScheduler:
 def _remove_from_batch(batch: Any, request_id: str) -> None:
     if batch is None:
         return
+    for req in batch.reqs:
+        if req.rid == request_id:
+            _break_request_data_cycle(req)
     batch.reqs = [req for req in batch.reqs if req.rid != request_id]
     if not batch.reqs:
         batch.batch_is_full = False

--- a/tests/unit_test/pipeline/test_scheduler.py
+++ b/tests/unit_test/pipeline/test_scheduler.py
@@ -229,6 +229,9 @@ def test_omni_scheduler_run_batch_failure_emits_error_and_aborts(monkeypatch) ->
         is_prefill_only=True,
         is_extend_in_batch=False,
     )
+    failed_reqs = list(batch.reqs)
+    for req in failed_reqs:
+        req._omni_data.req = req
     scheduler.running_batch = batch
     scheduler.cur_batch = batch
     _init_sync_request_build_state(scheduler)
@@ -243,6 +246,7 @@ def test_omni_scheduler_run_batch_failure_emits_error_and_aborts(monkeypatch) ->
     assert all("cuda out of memory" in str(output.data) for output in outputs)
     assert scheduler._aborted_request_ids == {"req-1", "req-2"}
     assert batch.reqs == []
+    assert all(req._omni_data is None for req in failed_reqs)
     assert release_calls == [("req-1", tree_cache), ("req-2", tree_cache)]
     assert scheduler._pending_stream_chunks == {}
     assert scheduler._pending_stream_done == set()
@@ -506,6 +510,8 @@ def test_omni_scheduler_abort_cleans_queued_request_immediately() -> None:
     scheduler.inbox = Queue()
 
     req = SimpleNamespace(rid="req-wait")
+    request_data = SimpleNamespace(req=req)
+    req._omni_data = request_data
     scheduler.waiting_queue = [req]
     scheduler.running_batch = SimpleNamespace(reqs=[], batch_is_full=False)
     scheduler.cur_batch = None
@@ -516,6 +522,8 @@ def test_omni_scheduler_abort_cleans_queued_request_immediately() -> None:
 
     assert scheduler.waiting_queue == []
     assert cleaned == ["req-wait"]
+    assert req._omni_data is None
+    assert request_data.req is req
 
 
 def test_omni_scheduler_emit_stream_output_skips_aborted_requests() -> None:
@@ -596,6 +604,7 @@ def test_omni_scheduler_fish_abort_during_step_suppresses_chunk_and_result() -> 
         req_pool_idx=1,
         _omni_data=data,
     )
+    data.req = req
     batch = SimpleNamespace(reqs=[req], batch_is_full=True)
     scheduler.running_batch = batch
     scheduler.cur_batch = batch
@@ -623,6 +632,8 @@ def test_omni_scheduler_fish_abort_during_step_suppresses_chunk_and_result() -> 
     assert adapted == []
     assert cleaned == ["req-fish"]
     assert scheduler.outbox.empty()
+    assert req._omni_data is None
+    assert data.req is req
 
 
 def test_omni_scheduler_abort_caps_aborted_id_set() -> None:
@@ -943,10 +954,11 @@ def test_omni_scheduler_rejects_custom_request_over_context() -> None:
         sampling_params=SimpleNamespace(max_new_tokens=10),
         output_ids=[],
     )
-    scheduler._request_builder = lambda payload: SimpleNamespace(
+    request_data = SimpleNamespace(
         req=req,
         enforce_request_limits=True,
     )
+    scheduler._request_builder = lambda payload: request_data
 
     scheduler.process_input_requests([SimpleNamespace(request_id="req-long")])
 
@@ -956,6 +968,8 @@ def test_omni_scheduler_rejects_custom_request_over_context() -> None:
     assert isinstance(output.data, ValueError)
     assert "Input length (5 tokens) exceeds" in str(output.data)
     assert scheduler.waiting_queue == []
+    assert getattr(req, "_omni_data", None) is None
+    assert request_data.req is req
 
 
 def test_omni_scheduler_follower_rejections_do_not_emit_errors() -> None:
@@ -1078,6 +1092,7 @@ def test_omni_scheduler_result_adapter_failure_emits_error_without_raise() -> No
         finished=lambda: True,
         finished_reason=None,
     )
+    request_data.req = req
 
     scheduler.stream_output([req])
 
@@ -1089,3 +1104,5 @@ def test_omni_scheduler_result_adapter_failure_emits_error_without_raise() -> No
     assert scheduler._prefill_start_done == set()
     assert request_data.prefill_input_embeds is None
     assert request_data.decode_input_embeds is None
+    assert req._omni_data is None
+    assert request_data.req is req


### PR DESCRIPTION
## Motivation

### Observed problem

`OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5` voice-cloning requests caused request-correlated host-memory growth in a long-running SGLang-Omni server.

In a controlled workload at concurrency 16, worker RSS increased from about 6.41 GiB to 8.86 GiB over 320 successful requests. That is roughly 7.8 MiB of net RSS growth per request and makes the model unsafe to serve continuously under load.

During broader testing on the original 16 GiB host with no swap, the kernel OOM killer later terminated the main worker at about 13.1 GiB anonymous RSS. Retained completed requests were a confirmed contributor, although the available logs do not establish that they were the only contributor to that OOM.

Memray showed about 3.9 GiB of outstanding allocations originating in msgpack request deserialization. With the full 89.091-second voice-cloning reference, each retained request held roughly 12 MiB of scheduler data.

### Root cause

`OmniScheduler` creates this bidirectional reference for an active request:

```text
Req._omni_data -> request_data.req -> Req
```

Several completion, rejection, and abort paths removed the request from scheduler queues without breaking the cycle. The complete deserialized multimodal payload therefore remained retained until cyclic GC collected it.

## Modifications

Release terminal request state explicitly when the scheduler no longer owns the request:

- Attach `_omni_data` only after the request passes admission and is still live under the admission lock.
- Clear the `Req._omni_data` side when the request finishes, aborts, leaves the waiting queue, or is removed from a batch.
- Preserve `request_data.req`, because already-launched async lookahead snapshots hold `request_data` directly and still require that link.
- Extend scheduler regression coverage for rejected admission, queued and running aborts, adapter errors, and batch failures.

The leak was reproduced with MOSS-TTS Local Transformer v1.5 because its voice-cloning payload makes the retained memory especially visible. The cleanup belongs in `OmniScheduler`, however, because terminal request ownership is scheduler-wide rather than model-specific.

## Related Issues

None found.

## Accuracy Test

This does not modify model execution, sampling, or request data before terminal cleanup.

```text
29 passed, 21 warnings in 15.58s
```

Command:

```bash
pytest -q tests/unit_test/pipeline/test_scheduler.py
```

## Benchmark & Profiling

Measured on an RTX 6000 Ada 48 GB test server with 32 GB host RAM, `OpenMOSS-Team/MOSS-TTS-Local-Transformer-v1.5`, and the full 89.091-second voice-cloning reference:

- Memray showed about 3.9 GiB of outstanding allocations originating in msgpack request deserialization. Object inspection traced the retained payloads to the `Req._omni_data` / `request_data.req` cycle.
- Before the cleanup, worker RSS grew from about 6.41 GiB to 8.86 GiB over 320 requests at concurrency 16.
- With this cleanup, all 320 requests succeeded. After the initial CUDA/allocator warm-up, anonymous memory stayed within about 12 MiB for the remainder of the run, and VRAM also stabilized.

This change addresses host memory retained by terminal requests. It does not bound active generation length or change disconnected-client cancellation, and it is not expected to change model latency or throughput.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [x] Update documentation / docstrings / example tutorials as needed. (No user-facing change; the async-snapshot invariant is documented on the helper.)
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the `run-ci` label. Once labeled, every subsequent push re-triggers CI as long as the label remains. Use `/tag-and-rerun-ci higgs` or `/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even if labeled.
