### PR TITLE
[WIP][Higgs TTS] Keep codec handoffs tensor-native

### DIFF
--- a/sglang_omni/models/higgs_tts/model_runner.py
+++ b/sglang_omni/models/higgs_tts/model_runner.py
@@ -428,7 +428,7 @@ class HiggsTTSModelRunner(ModelRunner):
             data = sched_req.data
             end = offset + int(data.req.extend_range.length)
             codes_rows = data.reference_codes_delayed
-            if not codes_rows:
+            if codes_rows is None:
                 offset = end
                 continue
 
@@ -438,7 +438,6 @@ class HiggsTTSModelRunner(ModelRunner):
                 offset = end
                 continue
 
-            codes = torch.tensor(codes_rows, dtype=torch.long, device=device)
             # Radix reuse can begin this request's live extension after a
             # cached reference-audio prefix. Derive the code row from the
             # absolute prompt position instead of request-local progress.
@@ -446,14 +445,19 @@ class HiggsTTSModelRunner(ModelRunner):
                 token == AUDIO_PLACEHOLDER_ID
                 for token in data.req.origin_input_ids[: data.req.extend_range.start]
             )
-            if consumed + n_placeholders > len(codes_rows):
+            if consumed + n_placeholders > int(codes_rows.shape[0]):
                 raise RuntimeError(
                     "Higgs reference-code rows do not cover the live audio "
                     f"placeholders: consumed={consumed}, "
-                    f"live={n_placeholders}, available={len(codes_rows)}"
+                    f"live={n_placeholders}, available={codes_rows.shape[0]}"
                 )
+            # Slice on the host so only the rows this extend needs cross to device.
+            codes = codes_rows[consumed : consumed + n_placeholders].to(
+                device=device,
+                dtype=torch.long,
+            )
             with torch.no_grad():
-                embed = fused_embed(codes[consumed : consumed + n_placeholders])
+                embed = fused_embed(codes)
             mask_idx = full_mask.nonzero(as_tuple=True)[0] + offset
             text_embeds[mask_idx] = embed.to(text_embeds.dtype)
             offset = end

--- a/sglang_omni/models/higgs_tts/payload_types.py
+++ b/sglang_omni/models/higgs_tts/payload_types.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+import torch
+
 from sglang_omni.scheduling.pipeline_state import DeclarativeStateBase, wire
 
 
@@ -22,7 +24,9 @@ class HiggsTtsState(DeclarativeStateBase):
 
     # preprocessing / audio_encoder
     prompt_token_ids: list[int] = wire(default_factory=list, codec="list")
-    reference_codes_delayed: list[list[int]] | None = None
+    # Delayed code rows stay CPU tensors end to end: the relay lifts them out of
+    # the payload as raw bytes, while nested lists would ride the header pickle.
+    reference_codes_delayed: torch.Tensor | None = None
     target_text: str | None = None
     reference_text: str | None = None
     reference_waveform: Any | None = None  # mono 24 kHz [1, 1, L] torch.Tensor
@@ -45,7 +49,7 @@ class HiggsTtsState(DeclarativeStateBase):
     return_omni_rollout: bool = wire(False, emit="truthy", codec="bool")
 
     # tts_engine
-    output_codes_delayed: list[list[int]] | None = None
+    output_codes_delayed: torch.Tensor | None = None
     omni_rollout: dict[str, Any] | None = None
 
     # vocoder

--- a/sglang_omni/models/higgs_tts/request_builders.py
+++ b/sglang_omni/models/higgs_tts/request_builders.py
@@ -14,6 +14,7 @@ from sglang.srt.sampling.sampling_params import SamplingParams
 
 from sglang_omni.models.higgs_tts.payload_types import HiggsTtsState
 from sglang_omni.models.higgs_tts.rollout_trace import build_omni_rollout_trace
+from sglang_omni.models.higgs_tts.utils import to_cpu_code_rows
 from sglang_omni.models.higgs_tts.vocoder_scheduler import (
     DEFAULT_HIGGS_INITIAL_CHUNK_FRAMES,
     DEFAULT_HIGGS_STREAM_FOLLOWUP_STRIDE,
@@ -33,7 +34,7 @@ from sglang_omni.scheduling.streaming_vocoder import (
 class HiggsSGLangRequestData(SGLangARRequestData):
     """Per-request state for the Higgs TTS scheduler."""
 
-    reference_codes_delayed: list[list[int]] | None = None
+    reference_codes_delayed: torch.Tensor | None = None
     num_codebooks: int = 8
     codebook_size: int = 1026
     output_codes: list[torch.Tensor] = field(default_factory=list)
@@ -58,7 +59,29 @@ def _perf_counter() -> float:
     return time.perf_counter()
 
 
-def _ref_audio_fingerprint(codes: list[list[int]] | None) -> str | None:
+def _normalize_reference_codes(codes: Any) -> torch.Tensor | None:
+    """Validate the decoded payload's ref codes at the engine boundary.
+
+    Not detached-and-copied: the tensor rides the relay's transfer buffer and is
+    read many times over the request's prefill, so aliasing it is the point.
+    """
+    if codes is None:
+        return None
+    if not isinstance(codes, torch.Tensor):
+        raise TypeError(
+            f"Higgs reference codes must be a torch.Tensor, got {type(codes).__name__}"
+        )
+    tensor = codes.detach()
+    if tensor.numel() == 0:
+        return None
+    if tensor.ndim != 2:
+        raise ValueError(
+            f"Higgs reference codes must have shape [T, N], got {tuple(tensor.shape)}"
+        )
+    return tensor
+
+
+def _ref_audio_fingerprint(codes: torch.Tensor | None) -> str | None:
     """Stable hash of the full N-codebook ref-audio sequence.
 
     Returned as a short hex string used as ``Req.extra_key``. ``None`` for
@@ -66,15 +89,14 @@ def _ref_audio_fingerprint(codes: list[list[int]] | None) -> str | None:
     Each codec value packs into 2 bytes (range 0..1025) so the hash is
     sensitive to every codebook, not just cb0.
     """
-    if not codes:
+    if codes is None or codes.numel() == 0:
         return None
-    buf = bytearray(2 * sum(len(row) for row in codes))
+    buf = bytearray(2 * codes.numel())
     i = 0
-    for row in codes:
-        for c in row:
-            buf[i] = c & 0xFF
-            buf[i + 1] = (c >> 8) & 0xFF
-            i += 2
+    for c in codes.reshape(-1).tolist():
+        buf[i] = c & 0xFF
+        buf[i + 1] = (c >> 8) & 0xFF
+        i += 2
     return hashlib.blake2b(bytes(buf), digest_size=16).hexdigest()
 
 
@@ -83,6 +105,7 @@ def build_sglang_higgs_request(
 ) -> HiggsSGLangRequestData:
     input_ids_list = list(state.prompt_token_ids)
     input_ids = torch.tensor(input_ids_list, dtype=torch.long)
+    reference_codes = _normalize_reference_codes(state.reference_codes_delayed)
 
     sp_kwargs: dict[str, Any] = {
         "max_new_tokens": int(state.max_new_tokens),
@@ -109,7 +132,7 @@ def build_sglang_higgs_request(
         origin_input_ids=input_ids_list,
         sampling_params=sampling_params,
         vocab_size=151_936,
-        extra_key=_ref_audio_fingerprint(state.reference_codes_delayed),
+        extra_key=_ref_audio_fingerprint(reference_codes),
     )
     # V1's prefill manager probes these attrs; absence triggers AttributeError.
     req._codec_suppress_tokens = None
@@ -118,7 +141,7 @@ def build_sglang_higgs_request(
     return HiggsSGLangRequestData(
         input_ids=input_ids,
         req=req,
-        reference_codes_delayed=state.reference_codes_delayed,
+        reference_codes_delayed=reference_codes,
         num_codebooks=int(state.num_codebooks),
         codebook_size=int(state.codebook_size),
         max_new_tokens=int(state.max_new_tokens),
@@ -172,12 +195,13 @@ def build_higgs_stream_metadata(
 def apply_higgs_result(state: HiggsTtsState, data: HiggsSGLangRequestData) -> None:
     num_codebooks = int(data.num_codebooks)
     if data.output_code_buffer is not None and data.output_code_count > 0:
-        codes = data.output_code_buffer[: data.output_code_count].to(torch.long)
-        state.output_codes_delayed = codes.tolist()
+        # Owned copy: the engine reuses output_code_buffer for the next request.
+        codes = to_cpu_code_rows(data.output_code_buffer[: data.output_code_count])
+        state.output_codes_delayed = codes
         state.completion_tokens = int(codes.shape[0])
     elif data.output_codes:
-        codes = torch.stack(data.output_codes, dim=0).to(torch.long)
-        state.output_codes_delayed = codes.tolist()
+        codes = to_cpu_code_rows(torch.stack(data.output_codes, dim=0))
+        state.output_codes_delayed = codes
         state.completion_tokens = int(codes.shape[0])
     else:
         codes = torch.empty((0, num_codebooks), dtype=torch.long)

--- a/sglang_omni/models/higgs_tts/stages.py
+++ b/sglang_omni/models/higgs_tts/stages.py
@@ -41,6 +41,7 @@ from sglang_omni.models.higgs_tts.utils import (
     load_audio_to_24k,
     resolve_checkpoint,
     to_codes_TN,
+    to_cpu_code_rows,
 )
 from sglang_omni.models.higgs_tts.vocoder_scheduler import (
     DEFAULT_HIGGS_INITIAL_CHUNK_FRAMES,
@@ -331,7 +332,7 @@ def create_preprocessing_executor(
                 num_ref_tokens=delayed.shape[0],
                 reference_text=reference_text,
             )
-            ref_codes_delayed: list[list[int]] | None = delayed.tolist()
+            ref_codes_delayed: torch.Tensor | None = to_cpu_code_rows(delayed)
             target_text_for_encoder = None
             reference_text_for_encoder = None
         elif waveform_tensor is None:
@@ -430,21 +431,22 @@ def create_audio_encoder_executor(
             else None
         )
         if cached_delayed is not None:
-            delayed_rows = cached_delayed.tolist()
+            delayed_rows = to_cpu_code_rows(cached_delayed)
         else:
             delayed = reference_service.get_or_encode(
                 _HiggsReferenceInput(waveform, state.reference_code_cache_key),
                 desc=state.uploaded_voice_name or "ad-hoc reference",
             )
-            delayed_rows = delayed.tolist()
+            delayed_rows = to_cpu_code_rows(delayed)
             if speaker_code_cache_key is not None:
                 speaker_cache.put(
-                    speaker_code_cache_key, delayed.detach().to("cpu", torch.int32)
+                    speaker_code_cache_key,
+                    to_cpu_code_rows(delayed_rows, dtype=torch.int32),
                 )
         state.reference_codes_delayed = delayed_rows
         state.prompt_token_ids = adapter.build_prompt(
             state.target_text or "",
-            num_ref_tokens=len(delayed_rows),
+            num_ref_tokens=int(delayed_rows.shape[0]),
             reference_text=state.reference_text,
         )
         state.reference_waveform = None

--- a/sglang_omni/models/higgs_tts/utils.py
+++ b/sglang_omni/models/higgs_tts/utils.py
@@ -96,6 +96,13 @@ def get_or_load_codec(path: str, device: str, dtype: str) -> HiggsAudioCodec:
     return codec
 
 
+def to_cpu_code_rows(
+    codes: torch.Tensor, *, dtype: torch.dtype = torch.long
+) -> torch.Tensor:
+    """Materialize ``[T, N]`` codes as an owned, contiguous CPU tensor."""
+    return codes.detach().to(device="cpu", dtype=dtype, copy=True).contiguous()
+
+
 def to_codes_TN(raw: Any, num_codebooks: int) -> torch.Tensor | None:
     """Coerce client-supplied ``reference_codes`` to a ``[T, N]`` int64 tensor."""
     if raw is None:
@@ -153,5 +160,6 @@ __all__ = [
     "load_audio_to_24k",
     "resolve_checkpoint",
     "to_codes_TN",
+    "to_cpu_code_rows",
     "truncate_rope_to_bf16",
 ]

--- a/sglang_omni/models/higgs_tts/vocoder_scheduler.py
+++ b/sglang_omni/models/higgs_tts/vocoder_scheduler.py
@@ -27,6 +27,15 @@ DEFAULT_HIGGS_STREAM_FOLLOWUP_STRIDE = 75
 DEFAULT_HIGGS_INITIAL_CHUNK_FRAMES = 20
 
 
+def _delayed_rows_tensor(rows: torch.Tensor | list[torch.Tensor]) -> torch.Tensor:
+    """``[L, N]`` int64 view of delayed rows."""
+    if isinstance(rows, torch.Tensor):
+        return rows.to(dtype=torch.long)
+    if len(rows) == 0:
+        return torch.empty((0, 0), dtype=torch.long)
+    return torch.stack(rows, dim=0).to(torch.long)
+
+
 @dataclass
 class _HiggsStreamState:
     delayed_rows: list[torch.Tensor] = field(default_factory=list)
@@ -383,9 +392,11 @@ class HiggsStreamingVocoderScheduler(StreamingVocoderBase[_HiggsStreamState, Non
     ) -> tuple[HiggsTtsState, torch.Tensor | None]:
         state = HiggsTtsState.from_dict(payload.data)
         delayed_rows = state.output_codes_delayed
-        if not delayed_rows:
+        if delayed_rows is None:
             return state, None
-        delayed_LN = torch.tensor(delayed_rows, dtype=torch.long)
+        delayed_LN = _delayed_rows_tensor(delayed_rows)
+        if delayed_LN.numel() == 0:
+            return state, None
         if delayed_LN.shape[0] < state.num_codebooks:
             return state, None
         codes_TN = reverse_delay_pattern(delayed_LN)
@@ -416,30 +427,30 @@ class HiggsStreamingVocoderScheduler(StreamingVocoderBase[_HiggsStreamState, Non
 
     def _decode_state_to_audio(self, state: HiggsTtsState) -> torch.Tensor | None:
         delayed_rows = state.output_codes_delayed
-        if not delayed_rows:
+        if delayed_rows is None:
             return None
-        rows = [torch.tensor(row, dtype=torch.long) for row in delayed_rows]
-        if len(rows) < int(state.num_codebooks):
+        delayed_LN = _delayed_rows_tensor(delayed_rows)
+        if delayed_LN.numel() == 0 or delayed_LN.shape[0] < int(state.num_codebooks):
             return None
         return self._decode_delayed_rows(
-            rows,
+            delayed_LN,
             num_codebooks=int(state.num_codebooks),
             codebook_size=int(state.codebook_size),
         )
 
     def _decode_delayed_rows(
         self,
-        rows: list[torch.Tensor],
+        rows: torch.Tensor | list[torch.Tensor],
         *,
         num_codebooks: int,
         codebook_size: int,
     ) -> torch.Tensor:
-        if len(rows) < int(num_codebooks):
+        delayed_LN = _delayed_rows_tensor(rows)
+        if delayed_LN.shape[0] < int(num_codebooks):
             raise ValueError(
                 f"Higgs delayed rows must include at least {num_codebooks} rows, "
-                f"got {len(rows)}"
+                f"got {delayed_LN.shape[0]}"
             )
-        delayed_LN = torch.stack(rows, dim=0).to(torch.long)
         codes_TN = reverse_delay_pattern(delayed_LN)
         codec_vocab = int(codebook_size) - 2
         codes_TN = torch.where(

--- a/tests/unit_test/higgs_tts/test_pipeline.py
+++ b/tests/unit_test/higgs_tts/test_pipeline.py
@@ -157,7 +157,9 @@ def test_higgs_prefill_embeddings_follow_radix_prefix_position() -> None:
                 origin_input_ids=origin_input_ids,
                 extend_range=SimpleNamespace(start=2, length=2),
             ),
-            reference_codes_delayed=[[10, 11], [20, 21], [30, 31]],
+            reference_codes_delayed=torch.tensor(
+                [[10, 11], [20, 21], [30, 31]], dtype=torch.int32
+            ),
         )
     )
     forward_batch = SimpleNamespace(
@@ -793,9 +795,13 @@ def test_higgs_audio_encoder_uses_reference_code_cache(monkeypatch) -> None:
     second = encode(make_payload("second"))
 
     assert fake_codec.calls == 1
-    assert (
-        first.data["reference_codes_delayed"] == second.data["reference_codes_delayed"]
-    )
+    first_codes = first.data["reference_codes_delayed"]
+    second_codes = second.data["reference_codes_delayed"]
+    assert torch.equal(first_codes, second_codes)
+    assert first_codes.device.type == "cpu"
+    assert first_codes.dtype == torch.long
+    assert first_codes.is_contiguous()
+    assert first_codes.data_ptr() != second_codes.data_ptr()
     assert first.data["prompt_token_ids"] == [5, 3, 7]
     assert second.data["prompt_token_ids"] == [5, 3, 7]
     assert "reference_waveform" not in second.data
@@ -890,16 +896,62 @@ def test_higgs_audio_encoder_uses_shared_cache_for_uploaded_voice(
     )
 
     assert fake_codec.calls == 2
-    assert (
-        first.data["reference_codes_delayed"] == second.data["reference_codes_delayed"]
+    first_codes = first.data["reference_codes_delayed"]
+    assert torch.equal(first_codes, second.data["reference_codes_delayed"])
+    assert torch.equal(third.data["reference_codes_delayed"], first_codes)
+    assert not torch.equal(
+        reuploaded.data["reference_codes_delayed"],
+        first_codes,
     )
-    assert (
-        third.data["reference_codes_delayed"] == first.data["reference_codes_delayed"]
+
+
+def test_higgs_preprocessing_keeps_preencoded_codes_as_cpu_tensor(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(stages, "resolve_checkpoint", lambda model_path: model_path)
+    monkeypatch.setattr(stages.Tokenizer, "from_file", lambda _path: object())
+    monkeypatch.setattr(
+        stages,
+        "PreTrainedTokenizerFast",
+        lambda tokenizer_object: object(),
     )
-    assert (
-        reuploaded.data["reference_codes_delayed"]
-        != first.data["reference_codes_delayed"]
+
+    class FakeAdapter:
+        def __init__(self, _tokenizer) -> None:
+            pass
+
+        def build_prompt(
+            self, text: str, *, num_ref_tokens: int, reference_text: str | None
+        ) -> list[int]:
+            return [len(text), num_ref_tokens, len(reference_text or "")]
+
+    monkeypatch.setattr(stages, "HiggsTokenizerAdapter", FakeAdapter)
+    scheduler = stages.create_preprocessing_executor("ckpt", num_codebooks=2)
+    source_codes = torch.tensor([[1, 2], [3, 4]], dtype=torch.int32)
+    payload = StagePayload(
+        request_id="preencoded",
+        request=OmniRequest(
+            inputs={
+                "text": "hello",
+                "reference_text": "speaker",
+                "reference_codes": source_codes,
+            },
+            params={},
+        ),
+        data={},
     )
+
+    result = scheduler._fn(payload)
+    delayed_codes = result.data["reference_codes_delayed"]
+
+    assert torch.equal(
+        delayed_codes,
+        apply_delay_pattern(source_codes.to(torch.long)),
+    )
+    assert delayed_codes.device.type == "cpu"
+    assert delayed_codes.dtype == torch.long
+    assert delayed_codes.is_contiguous()
+    assert result.data["prompt_token_ids"] == [5, 3, 7]
 
 
 def test_higgs_preprocessing_uses_waveform_cache(monkeypatch, tmp_path) -> None:
@@ -1554,6 +1606,70 @@ def test_higgs_model_runner_skips_already_finished_eager_request() -> None:
     assert result.next_token_ids.tolist() == [0]
 
 
+class _CaptureEmbedding(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.dtypes: list[torch.dtype] = []
+
+    def forward(self, codes: torch.Tensor) -> torch.Tensor:
+        self.dtypes.append(codes.dtype)
+        return codes.to(torch.float32)
+
+
+def _make_prefill_runner(capture: _CaptureEmbedding) -> HiggsTTSModelRunner:
+    runner = object.__new__(HiggsTTSModelRunner)
+    runner.model = SimpleNamespace(
+        backbone=SimpleNamespace(
+            model=SimpleNamespace(embed_tokens=torch.nn.Embedding(16, 3))
+        ),
+        multimodal_embedding=SimpleNamespace(modality_embedding_0=capture),
+    )
+    return runner
+
+
+# Prompt with a leading text token so placeholder rows are not simply position:
+# row k belongs to the k-th -100, not to token index k.
+_PREFILL_PROMPT_IDS = torch.tensor([2, -100, -100, -100, -100], dtype=torch.long)
+_PREFILL_REF_CODES = torch.tensor(
+    [
+        [0, 1024, 1025],
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+    ],
+    dtype=torch.int32,
+)
+
+
+def test_higgs_model_runner_prefill_slices_tensor_reference_codes() -> None:
+    """Reference rows arrive as a CPU tensor. Only the slice this extend needs
+    crosses to the device, and the fused embedding always sees int64 rows
+    whatever dtype the frontend stored them in."""
+    capture = _CaptureEmbedding()
+    runner = _make_prefill_runner(capture)
+    data = SimpleNamespace(
+        req=SimpleNamespace(
+            origin_input_ids=_PREFILL_PROMPT_IDS.tolist(),
+            extend_range=SimpleNamespace(start=0, length=3),
+        ),
+        reference_codes_delayed=_PREFILL_REF_CODES,
+    )
+
+    first_embeds = runner._build_prefill_input_embeds(
+        SimpleNamespace(input_ids=_PREFILL_PROMPT_IDS[:3]),
+        [SimpleNamespace(data=data)],
+    )
+    data.req.extend_range = SimpleNamespace(start=3, length=2)
+    second_embeds = runner._build_prefill_input_embeds(
+        SimpleNamespace(input_ids=_PREFILL_PROMPT_IDS[3:]),
+        [SimpleNamespace(data=data)],
+    )
+
+    assert torch.equal(first_embeds[1:], _PREFILL_REF_CODES[:2].to(torch.float32))
+    assert torch.equal(second_embeds, _PREFILL_REF_CODES[2:].to(torch.float32))
+    assert capture.dtypes == [torch.long, torch.long]
+
+
 def _make_payload(request_id: str, state: HiggsTtsState) -> StagePayload:
     return StagePayload(
         request_id=request_id,
@@ -1616,7 +1732,9 @@ def test_higgs_tts_vocoder_batches_decode_requests(
     p1 = _make_payload(
         "r1",
         HiggsTtsState(
-            output_codes_delayed=[[i % 100] * 8 for i in range(10)],
+            output_codes_delayed=torch.tensor(
+                [[i % 100] * 8 for i in range(10)], dtype=torch.int32
+            ),
             prompt_tokens=5,
             completion_tokens=10,
             engine_time_s=0.5,
@@ -1625,7 +1743,9 @@ def test_higgs_tts_vocoder_batches_decode_requests(
     p2 = _make_payload(
         "r2",
         HiggsTtsState(
-            output_codes_delayed=[[i % 100] * 8 for i in range(12)],
+            output_codes_delayed=torch.tensor(
+                [[i % 100] * 8 for i in range(12)], dtype=torch.long
+            ),
         ),
     )
 
@@ -1650,14 +1770,23 @@ def test_higgs_tts_vocoder_batch_handles_empty_items(
     )
 
     payloads = [
-        _make_payload("r-empty", HiggsTtsState(output_codes_delayed=None)),
+        _make_payload(
+            "r-empty",
+            HiggsTtsState(output_codes_delayed=torch.empty((0, 8), dtype=torch.long)),
+        ),
         _make_payload(
             "r-short",
-            HiggsTtsState(output_codes_delayed=[[0] * 8 for _ in range(3)]),
+            HiggsTtsState(
+                output_codes_delayed=torch.zeros((3, 8), dtype=torch.long),
+            ),
         ),
         _make_payload(
             "r-valid",
-            HiggsTtsState(output_codes_delayed=[[i % 100] * 8 for i in range(10)]),
+            HiggsTtsState(
+                output_codes_delayed=torch.tensor(
+                    [[i % 100] * 8 for i in range(10)], dtype=torch.long
+                ),
+            ),
         ),
     ]
 
@@ -1723,7 +1852,7 @@ def _higgs_stream_payload(
     initial_codec_chunk_frames: int | None = None,
 ) -> StagePayload:
     state = HiggsTtsState(
-        output_codes_delayed=delayed_rows,
+        output_codes_delayed=torch.tensor(delayed_rows, dtype=torch.long),
         num_codebooks=num_codebooks,
         codebook_size=codebook_size,
         prompt_tokens=2,

--- a/tests/unit_test/higgs_tts/test_request_builders.py
+++ b/tests/unit_test/higgs_tts/test_request_builders.py
@@ -16,14 +16,14 @@ def test_higgs_reference_audio_namespaces_radix_cache() -> None:
     first = request_builders.build_sglang_higgs_request(
         HiggsTtsState(
             prompt_token_ids=prompt,
-            reference_codes_delayed=[[1, 2], [3, 4]],
+            reference_codes_delayed=torch.tensor([[1, 2], [3, 4]]),
         ),
         request_id="first",
     ).req
     second = request_builders.build_sglang_higgs_request(
         HiggsTtsState(
             prompt_token_ids=prompt,
-            reference_codes_delayed=[[5, 6], [7, 8]],
+            reference_codes_delayed=torch.tensor([[5, 6], [7, 8]]),
         ),
         request_id="second",
     ).req
@@ -64,6 +64,10 @@ def test_higgs_scheduler_adapters_clamp_cap_and_record_engine_time(
 
     assert data.max_new_tokens == 2048
     assert data.req.sampling_params.max_new_tokens == 2048
+    assert torch.equal(
+        result.data["output_codes_delayed"],
+        torch.tensor([[1, 2, 3]], dtype=torch.long),
+    )
     assert result.data["completion_tokens"] == 1
     assert result.data["engine_time_s"] == 2.5
 
@@ -85,12 +89,22 @@ def test_higgs_result_adapter_reads_output_code_buffer() -> None:
     )
     data.stage_payload = payload
     data.output_codes.append(torch.tensor([9, 9, 9], dtype=torch.long))
-    data.output_code_buffer = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.long)
+    output_code_buffer = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.long)
+    data.output_code_buffer = output_code_buffer
     data.output_code_count = 2
 
     result = result_adapter(data)
 
-    assert result.data["output_codes_delayed"] == [[1, 2, 3], [4, 5, 6]]
+    output_codes = result.data["output_codes_delayed"]
+    assert torch.equal(
+        output_codes,
+        torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.long),
+    )
+    assert output_codes.device.type == "cpu"
+    assert output_codes.is_contiguous()
+    assert output_codes.data_ptr() != output_code_buffer.data_ptr()
+    output_code_buffer.zero_()
+    assert output_codes.tolist() == [[1, 2, 3], [4, 5, 6]]
     assert result.data["completion_tokens"] == 2
 
 
@@ -120,3 +134,12 @@ def test_higgs_result_adapter_propagates_conversion_failure(
 
     with pytest.raises(RuntimeError, match="result conversion failed"):
         result_adapter(data)
+
+
+def test_higgs_request_builder_rejects_non_tensor_reference_codes() -> None:
+    """Delayed rows are tensor-only on the wire; a nested list means an upstream
+    stage regressed to the list handoff and must fail at the boundary."""
+    with pytest.raises(TypeError, match="must be a torch.Tensor"):
+        request_builders.build_sglang_higgs_request(
+            HiggsTtsState(reference_codes_delayed=[[1, 2], [3, 4]])
+        )

--- a/tests/unit_test/scheduling/test_pipeline_state.py
+++ b/tests/unit_test/scheduling/test_pipeline_state.py
@@ -253,7 +253,7 @@ def test_tts_pipeline_state_round_trips_preserve_payload_fields() -> None:
         (
             HiggsTtsState(
                 prompt_token_ids=[10, 11],
-                reference_codes_delayed=[[1, 2], [3, 4]],
+                reference_codes_delayed=torch.tensor([[1, 2], [3, 4]]),
                 target_text="target",
                 reference_text="reference",
                 reference_waveform=torch.tensor([[[0.1, 0.2]]]),
@@ -265,7 +265,7 @@ def test_tts_pipeline_state_round_trips_preserve_payload_fields() -> None:
                 seed=7,
                 return_logprob=True,
                 return_omni_rollout=True,
-                output_codes_delayed=[[5, 6], [7, 8]],
+                output_codes_delayed=torch.tensor([[5, 6], [7, 8]]),
                 omni_rollout={"tokens": [1, 2], "logprobs": [-0.1, -0.2]},
                 prompt_tokens=2,
                 completion_tokens=4,


### PR DESCRIPTION
## Motivation

After moving preprocessing and reference audio encoding into the dedicated `tts_frontend` process, profiling showed that host-side stage I/O was limiting throughput:

- the TTS scheduler was off-CPU for 31.71% of the profiling window;
- 97.09% of its off-CPU samples were blocked in futex waits;
- the pipeline main thread was the strongest GIL competitor;
- 47.82% of its self CPU time was spent recursively inspecting and restoring cross-process payload values.

The main source of overhead was the codec representation:

```python
list[list[int]]
```

Although the codec matrix is small in bytes, converting it into nested lists creates thousands of Python objects. Stage I/O then recursively visits those objects during tensor detection, device inspection, serialization, and restoration.

## Modifications

This PR keeps delayed reference and generated codec rows as contiguous CPU tensors across Higgs TTS stage boundaries, avoiding costly .tolist() conversions and recursive Python-object serialization. The TTS engine and vocoder consume these tensors directly while preserving the existing cache fingerprint, rollout schema, and external API.

## Accuracy Test

Not related

## Benchmark & Profiling

- Dataset: SeedTTS English split, 1,088 samples
- Warmup: 256 requests
- Random seed: 42
- Maximum new tokens: 2,048
- Server and clients were pinned to separate NUMA nodes
- QPS counts only successful requests completed within the measurement window(90 seconds)

### Results

| Implementation | Topology | Total Concurrency | QPS | P50 Latency | P95 Latency | Improvement over Baseline |
|---|---:|---:|---:|---:|---:|---:|
| Encoder split baseline #1159 | DP=1 | 96 | **30.433** | 3.034s | 4.309s | — |
| Stage I/O optimization, peak | DP=1 | 320 | **42.522** | 7.522s | 8.652s | +39.72% |
| Tuned MPS configuration | DP=2 | 768 | **74.944** | 9.532s | 13.532s | **+146.26%** |
| Tuned MPS configuration | DP=3 | 768 | **81.156** | 8.784s | 13.455s | **+166.67%** |

## Checklist

- [ ] Format your code according with pre-commit.
- [ ] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
