### PR TITLE
[Fix][TTS][MOSS] Support all MOSS-TTS Local v1.5 languages

### DIFF
--- a/sglang_omni/models/moss_tts_local/config.py
+++ b/sglang_omni/models/moss_tts_local/config.py
@@ -81,6 +81,31 @@ class MossTTSLocalPipelineConfig(PipelineConfig):
         "MossTTSLocal",
         "MossTTSLocalForConditionalGeneration",
     )
+    additional_speech_languages: ClassVar[frozenset[str]] = frozenset(
+        {
+            "Cantonese",
+            "Arabic",
+            "Czech",
+            "Danish",
+            "Dutch",
+            "Finnish",
+            "Greek",
+            "Hebrew",
+            "Hindi",
+            "Hungarian",
+            "Macedonian",
+            "Malay",
+            "Persian (Farsi)",
+            "Polish",
+            "Romanian",
+            "Swahili",
+            "Swedish",
+            "Tagalog",
+            "Thai",
+            "Turkish",
+            "Vietnamese",
+        }
+    )
 
     @classmethod
     def mem_fraction_role_to_stage(cls) -> dict[str, str]:

--- a/sglang_omni/models/moss_tts_local/request_builders.py
+++ b/sglang_omni/models/moss_tts_local/request_builders.py
@@ -132,6 +132,8 @@ def build_moss_tts_local_state(payload: StagePayload) -> MossTTSLocalState:
     language = _resolve_optional_text(
         tts_params.get("language") or params.get("language")
     )
+    if language is not None and language.casefold() == "auto":
+        language = None
     instructions = _resolve_optional_text(
         tts_params.get("instructions")
         or tts_params.get("instruct")

--- a/tests/unit_test/moss_tts_local/test_pipeline.py
+++ b/tests/unit_test/moss_tts_local/test_pipeline.py
@@ -730,6 +730,9 @@ def test_build_state_token_count_and_language():
     assert state.text == "hello world"
     assert state.language == "English"
 
+    payload.request.params["language"] = "Auto"
+    assert build_moss_tts_local_state(payload).language is None
+
 
 # Preprocessing handoff + result adapter
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

MOSS-TTS-Local-Transformer-v1.5 supports 31 languages, but the shared Speech API language set only contains 10 of them. As a result, requests using the other 21 languages documented in the model card are rejected during Speech API validation before reaching the MOSS-TTS-Local processor.

The shared API also accepts `Auto`, while the Hugging Face processor does not special-case that value. It treats the supplied language as literal prompt text, so passing `Auto` through would render `Auto` in the `- Language:` field instead of using the processor's unspecified-language behavior.

## Modifications

- Add the 21 missing model-card languages to `MossTTSLocalPipelineConfig.additional_speech_languages`, completing the model's 31-language set without changing the shared Speech API language list.
- Normalize case-insensitive `Auto` to `None` in the MOSS-TTS-Local request builder before calling `processor.build_user_message(...)`.
- Add regression coverage verifying that `Auto` is converted to `None` while explicit language names continue to pass through unchanged.

The newly accepted languages are Arabic, Cantonese, Czech, Danish, Dutch, Finnish, Greek, Hebrew, Hindi, Hungarian, Macedonian, Malay, Persian (Farsi), Polish, Romanian, Swahili, Swedish, Tagalog, Thai, Turkish, and Vietnamese.

## Related Issues

N/A.

## Accuracy Test

N/A.

## Benchmark & Profiling

N/A. The change is limited to request validation metadata and one case-insensitive string check during request construction; it does not affect the model execution or serving hot path.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.

## CI

CI runs on self-hosted GPU runners and requires a maintainer to add the
`run-ci` label. Once labeled, every subsequent push re-triggers CI as
long as the label remains. Use `/tag-and-rerun-ci higgs` or
`/tag-and-rerun-ci moss` to select a TTS CI model. Draft PRs are skipped even
if labeled.
