### PR TITLE
optimizate  code2wav  default initial_codec_chunk_frames & stream_chunk_size & left_context_size

### DIFF
--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -120,16 +120,6 @@ class Code2WavScheduler(StreamingSimpleScheduler):
     def _latch_initial_chunk_frames(
         self, request_id: str, payload: StagePayload | None
     ) -> None:
-        """Resolve and cache the per-request first-chunk size.
-
-        A request may override the scheduler default via
-        ``params['initial_codec_chunk_frames']`` (0 opts out of a smaller
-        first chunk; values are clamped to ``stream_chunk_size``). Absent the
-        param, the scheduler-level ``initial_codec_chunk_frames`` default
-        applies. Called from ``on_streaming_new_request``; safe before or
-        after chunks arrive because the gate only consumes the value while
-        nothing has been emitted yet.
-        """
         if request_id in self._req_initial_chunk_frames:
             return
         params = None
@@ -148,10 +138,6 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         self._req_initial_chunk_frames[request_id] = resolved
 
     def _initial_chunk_frames_for(self, request_id: str) -> int:
-        """Per-request first-chunk size, falling back to the scheduler default
-        when the payload has not arrived yet (chunks may precede the payload
-        because ``can_accept_stream_before_payload`` is set). 0 means 'use the
-        steady chunk size for every chunk'."""
         resolved = self._req_initial_chunk_frames.get(request_id)
         if resolved is not None:
             return resolved

--- a/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
+++ b/sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py
@@ -17,6 +17,10 @@ from sglang_omni.profiler.event_recorder import emit as _emit_event
 from sglang_omni.proto import StagePayload
 from sglang_omni.scheduling.messages import OutgoingMessage
 from sglang_omni.scheduling.streaming_simple_scheduler import StreamingSimpleScheduler
+from sglang_omni.scheduling.streaming_vocoder import (
+    INITIAL_CODEC_CHUNK_FRAMES_PARAM,
+    resolve_initial_codec_chunk_frames,
+)
 from sglang_omni.utils.audio_payload import audio_waveform_payload
 
 logger = logging.getLogger(__name__)
@@ -59,6 +63,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         device: str,
         stream_chunk_size: int = 10,
         left_context_size: int = 25,
+        initial_codec_chunk_frames: int = 0,
         sample_rate: int = 24000,
         codec_eos_token_id: int = 2150,
     ):
@@ -66,6 +71,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         self._device = torch.device(device)
         self._stream_chunk_size = max(int(stream_chunk_size), 1)
         self._left_context_size = max(int(left_context_size), 0)
+        self._initial_codec_chunk_frames = max(int(initial_codec_chunk_frames), 0)
         self._sample_rate = sample_rate
         self._codec_eos_token_id = codec_eos_token_id
         self._total_upsample = int(model.total_upsample)
@@ -75,6 +81,7 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         self._emitted: dict[str, int] = {}
         self._audio_chunks: dict[str, list[np.ndarray]] = {}
         self._stream_enabled: dict[str, bool] = {}
+        self._req_initial_chunk_frames: dict[str, int] = {}
         super().__init__(compute_fn=None)
         self._payloads = self._stream_payloads
 
@@ -83,14 +90,15 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         return True
 
     def on_streaming_new_request(self, request_id: str, payload: StagePayload) -> None:
-        del payload
         self._ensure_request_state(request_id)
+        self._latch_initial_chunk_frames(request_id, payload)
 
     def clear_stream_state(self, request_id: str) -> None:
         self._code_chunks.pop(request_id, None)
         self._emitted.pop(request_id, None)
         self._audio_chunks.pop(request_id, None)
         self._stream_enabled.pop(request_id, None)
+        self._req_initial_chunk_frames.pop(request_id, None)
 
     def _fail_request(self, request_id: str, error: Exception) -> None:
         self.outbox.put(
@@ -108,6 +116,46 @@ class Code2WavScheduler(StreamingSimpleScheduler):
         self._code_chunks[request_id] = []
         self._emitted[request_id] = 0
         self._audio_chunks[request_id] = []
+
+    def _latch_initial_chunk_frames(
+        self, request_id: str, payload: StagePayload | None
+    ) -> None:
+        """Resolve and cache the per-request first-chunk size.
+
+        A request may override the scheduler default via
+        ``params['initial_codec_chunk_frames']`` (0 opts out of a smaller
+        first chunk; values are clamped to ``stream_chunk_size``). Absent the
+        param, the scheduler-level ``initial_codec_chunk_frames`` default
+        applies. Called from ``on_streaming_new_request``; safe before or
+        after chunks arrive because the gate only consumes the value while
+        nothing has been emitted yet.
+        """
+        if request_id in self._req_initial_chunk_frames:
+            return
+        params = None
+        if payload is not None:
+            req = getattr(payload, "request", None)
+            if req is not None:
+                raw_params = getattr(req, "params", None)
+                if isinstance(raw_params, dict):
+                    params = raw_params
+        if params is not None and params.get(INITIAL_CODEC_CHUNK_FRAMES_PARAM) is not None:
+            resolved = resolve_initial_codec_chunk_frames(
+                params, steady_chunk_frames=self._stream_chunk_size
+            )
+        else:
+            resolved = min(self._initial_codec_chunk_frames, self._stream_chunk_size)
+        self._req_initial_chunk_frames[request_id] = resolved
+
+    def _initial_chunk_frames_for(self, request_id: str) -> int:
+        """Per-request first-chunk size, falling back to the scheduler default
+        when the payload has not arrived yet (chunks may precede the payload
+        because ``can_accept_stream_before_payload`` is set). 0 means 'use the
+        steady chunk size for every chunk'."""
+        resolved = self._req_initial_chunk_frames.get(request_id)
+        if resolved is not None:
+            return resolved
+        return min(self._initial_codec_chunk_frames, self._stream_chunk_size)
 
     def on_stream_chunk(
         self, request_id: str, chunk: StreamItem
@@ -149,7 +197,12 @@ class Code2WavScheduler(StreamingSimpleScheduler):
             return []
         self._code_chunks[request_id].append(codes)
         ready = len(self._code_chunks[request_id]) - self._emitted[request_id]
-        if ready >= self._stream_chunk_size:
+        threshold = self._stream_chunk_size
+        if self._emitted[request_id] == 0:
+            initial = self._initial_chunk_frames_for(request_id)
+            if initial > 0:
+                threshold = initial
+        if ready >= threshold:
             return self._decode_and_emit(request_id)
         return []
 
@@ -276,6 +329,7 @@ def create_code2wav_scheduler(
     gpu_id: int | None = None,
     stream_chunk_size: int = 10,
     left_context_size: int = 25,
+    initial_codec_chunk_frames: int = 0,
 ):
     """Factory: returns Code2WavScheduler."""
     if gpu_id is not None:
@@ -286,4 +340,5 @@ def create_code2wav_scheduler(
         device=device,
         stream_chunk_size=stream_chunk_size,
         left_context_size=left_context_size,
+        initial_codec_chunk_frames=initial_codec_chunk_frames,
     )

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -186,7 +186,22 @@ def _code2wav_stage(*, gpu: int, process: str) -> StageConfig:
         name="code2wav",
         process=process,
         factory=f"{_PKG}.components.code2wav_scheduler.create_code2wav_scheduler",
-        factory_args={"device": "cuda"},
+        factory_args={
+            "device": "cuda",
+            # Steady streaming chunk (frames per decode window after the first).
+            # Larger than the legacy default of 10 to amortize vocoder calls
+            # during steady-state; paired with a small first chunk below.
+            "stream_chunk_size": 25,
+            # Left context (overlap frames) reused across adjacent windows.
+            # The trim in _decode_incremental removes the overlap so the seam
+            # is sample-accurate; chunk 1 naturally gets min(left, start)=0.
+            "left_context_size": 25,
+            # First-chunk size: a small initial decode window lowers first-audio
+            # latency. Per-request override via
+            # params['initial_codec_chunk_frames'] (0 opts out; clamped to
+            # stream_chunk_size). 0 here = 'use steady size for every chunk'.
+            "initial_codec_chunk_frames": 4,
+        },
         gpu=gpu,
         terminal=True,
         can_accept_stream_before_payload=True,

--- a/sglang_omni/models/qwen3_omni/config.py
+++ b/sglang_omni/models/qwen3_omni/config.py
@@ -188,19 +188,9 @@ def _code2wav_stage(*, gpu: int, process: str) -> StageConfig:
         factory=f"{_PKG}.components.code2wav_scheduler.create_code2wav_scheduler",
         factory_args={
             "device": "cuda",
-            # Steady streaming chunk (frames per decode window after the first).
-            # Larger than the legacy default of 10 to amortize vocoder calls
-            # during steady-state; paired with a small first chunk below.
             "stream_chunk_size": 25,
-            # Left context (overlap frames) reused across adjacent windows.
-            # The trim in _decode_incremental removes the overlap so the seam
-            # is sample-accurate; chunk 1 naturally gets min(left, start)=0.
             "left_context_size": 25,
-            # First-chunk size: a small initial decode window lowers first-audio
-            # latency. Per-request override via
-            # params['initial_codec_chunk_frames'] (0 opts out; clamped to
-            # stream_chunk_size). 0 here = 'use steady size for every chunk'.
-            "initial_codec_chunk_frames": 4,
+            "initial_codec_chunk_frames": 0,
         },
         gpu=gpu,
         terminal=True,

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -9,6 +9,10 @@ from sglang_omni.models.qwen3_omni.components.code2wav_scheduler import (
     Code2WavScheduler,
 )
 from sglang_omni.pipeline.stage.stream_queue import StreamItem
+from sglang_omni.proto import OmniRequest, StagePayload
+from sglang_omni.scheduling.streaming_vocoder import (
+    INITIAL_CODEC_CHUNK_FRAMES_PARAM,
+)
 from tests.unit_test.fixtures.qwen_fakes import FakeCode2WavModel, make_qwen_payload
 
 
@@ -52,3 +56,178 @@ def test_qwen_code2wav_streams_incrementally_and_abort_clears_state() -> None:
     assert "req-2" not in scheduler._code_chunks
     assert "req-2" not in scheduler._payloads
     assert "req-2" not in scheduler._pending_done
+
+
+# ---------------------------------------------------------------------------
+# Configurable initial / steady chunk sizes
+# ---------------------------------------------------------------------------
+
+
+def test_code2wav_config_stage_passes_chunk_size_args() -> None:
+    """_code2wav_stage must expose stream_chunk_size, left_context_size and
+    initial_codec_chunk_frames via factory_args so config controls both the
+    steady and the first-chunk sizes."""
+    from sglang_omni.models.qwen3_omni.config import _code2wav_stage
+
+    stage = _code2wav_stage(gpu=0, process="code2wav")
+    assert stage.factory_args["stream_chunk_size"] == 25
+    assert stage.factory_args["left_context_size"] == 25
+    assert stage.factory_args["initial_codec_chunk_frames"] == 4
+
+
+def _code_chunk(idx: int, *, stream: bool = True) -> StreamItem:
+    """One codec frame, two codebooks, non-EOS."""
+    return StreamItem(
+        chunk_id=idx,
+        data=torch.tensor([idx + 1, (idx + 1) * 10], dtype=torch.long),
+        from_stage="talker",
+        metadata={"stream": stream},
+    )
+
+
+def _drain_stream_audio(scheduler: Code2WavScheduler) -> list[np.ndarray]:
+    """Collect every emitted 'stream' message's PCM as a float32 array."""
+    parts: list[np.ndarray] = []
+    while not scheduler.outbox.empty():
+        msg = scheduler.outbox.get_nowait()
+        if msg.type == "stream":
+            parts.append(
+                np.frombuffer(msg.data["audio_waveform"], dtype=np.float32).copy()
+            )
+    return parts
+
+
+def test_code2wav_smaller_first_chunk_then_steady_with_seamless_overlap() -> None:
+    """First emit uses the small initial chunk; the second (steady) window
+    reuses the *entire* initial chunk as left context and trims the overlap,
+    so the size change across the seam is sample-accurate.
+
+    initial=2, steady=3, left=5, upsample=2:
+      - emit 1: window [0:2], context=min(5,0)=0, trim=0  -> 4 samples
+      - emit 2: window [0:5], context=min(5,2)=2, trim=4  -> 6 samples
+    The second window's 2-frame left context == the whole first chunk.
+    """
+    model = FakeCode2WavModel(total_upsample=2)
+    sched = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=3,
+        left_context_size=5,
+        initial_codec_chunk_frames=2,
+        sample_rate=24000,
+    )
+    sched._payloads["req-1"] = StagePayload(
+        request_id="req-1",
+        request=OmniRequest(inputs=[], params={"stream": True}),
+        data={},
+    )
+
+    # Frame 1: ready=1 < initial=2 -> no emit.
+    sched._on_chunk("req-1", _code_chunk(0))
+    assert model.calls == []
+    # Frame 2: ready=2 >= initial=2 -> first emit (2-frame window).
+    sched._on_chunk("req-1", _code_chunk(1))
+    assert model.calls == [(1, 2, 2)]
+    # Frames 3-4: steady threshold=3, not enough yet.
+    sched._on_chunk("req-1", _code_chunk(2))
+    sched._on_chunk("req-1", _code_chunk(3))
+    assert model.calls == [(1, 2, 2)]
+    # Frame 5: ready=3 >= steady=3 -> second emit (5-frame window = 2 left + 3 new).
+    sched._on_chunk("req-1", _code_chunk(4))
+    assert model.calls == [(1, 2, 2), (1, 2, 5)]
+
+    parts = _drain_stream_audio(sched)
+    assert len(parts) == 2
+    assert parts[0].shape == (4,), "first chunk: 2 frames * 2 upsample"
+    assert parts[1].shape == (6,), "second chunk: 5 frames * 2 - 4 trim"
+
+
+def test_code2wav_per_request_initial_chunk_overrides_config_default() -> None:
+    """params['initial_codec_chunk_frames'] overrides the scheduler default."""
+    model = FakeCode2WavModel(total_upsample=2)
+    sched = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=10,
+        left_context_size=0,
+        initial_codec_chunk_frames=4,  # config default
+        sample_rate=24000,
+    )
+    payload = StagePayload(
+        request_id="req-1",
+        request=OmniRequest(
+            inputs=[],
+            params={"stream": True, INITIAL_CODEC_CHUNK_FRAMES_PARAM: 2},
+        ),
+        data={},
+    )
+    # Realistic entry: stores payload + calls on_streaming_new_request (latch).
+    sched._handle_streaming_new_request("req-1", payload)
+    assert sched._req_initial_chunk_frames["req-1"] == 2
+
+    for i in range(2):
+        sched._on_chunk("req-1", _code_chunk(i))
+    # First emit at 2 (per-request override), not 4 (config) or 10 (steady).
+    assert model.calls == [(1, 2, 2)]
+
+
+def test_code2wav_per_request_initial_chunk_zero_opts_out() -> None:
+    """An explicit params['initial_codec_chunk_frames']=0 must opt out of the
+    smaller first chunk, falling back to the steady size even when the
+    scheduler config default is non-zero."""
+    model = FakeCode2WavModel(total_upsample=2)
+    sched = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=3,
+        left_context_size=0,
+        initial_codec_chunk_frames=2,  # config default
+        sample_rate=24000,
+    )
+    payload = StagePayload(
+        request_id="req-1",
+        request=OmniRequest(
+            inputs=[],
+            params={"stream": True, INITIAL_CODEC_CHUNK_FRAMES_PARAM: 0},
+        ),
+        data={},
+    )
+    sched._handle_streaming_new_request("req-1", payload)
+    assert sched._req_initial_chunk_frames["req-1"] == 0
+
+    # Feed 2 frames: config default would emit at 2, but opt-out means steady=3.
+    for i in range(2):
+        sched._on_chunk("req-1", _code_chunk(i))
+    assert model.calls == []
+    # Frame 3: steady threshold reached.
+    sched._on_chunk("req-1", _code_chunk(2))
+    assert model.calls == [(1, 2, 3)]
+
+
+def test_code2wav_initial_chunk_clamped_to_steady() -> None:
+    """A per-request initial chunk larger than steady is clamped to steady
+    (resolve_initial_codec_chunk_frames semantics), so it degrades gracefully
+    to the steady size rather than over-collecting."""
+    model = FakeCode2WavModel(total_upsample=2)
+    sched = Code2WavScheduler(
+        model,
+        device="cpu",
+        stream_chunk_size=3,
+        left_context_size=0,
+        sample_rate=24000,
+    )
+    payload = StagePayload(
+        request_id="req-1",
+        request=OmniRequest(
+            inputs=[],
+            params={"stream": True, INITIAL_CODEC_CHUNK_FRAMES_PARAM: 100},
+        ),
+        data={},
+    )
+    sched._handle_streaming_new_request("req-1", payload)
+    # Clamped to steady=3.
+    assert sched._req_initial_chunk_frames["req-1"] == 3
+
+    for i in range(3):
+        sched._on_chunk("req-1", _code_chunk(i))
+    assert model.calls == [(1, 2, 3)]

--- a/tests/unit_test/qwen3_omni/test_code2wav.py
+++ b/tests/unit_test/qwen3_omni/test_code2wav.py
@@ -72,7 +72,8 @@ def test_code2wav_config_stage_passes_chunk_size_args() -> None:
     stage = _code2wav_stage(gpu=0, process="code2wav")
     assert stage.factory_args["stream_chunk_size"] == 25
     assert stage.factory_args["left_context_size"] == 25
-    assert stage.factory_args["initial_codec_chunk_frames"] == 4
+    # 0 = off by default (backwards compatible); per-request opt-in still works.
+    assert stage.factory_args["initial_codec_chunk_frames"] == 0
 
 
 def _code_chunk(idx: int, *, stream: bool = True) -> StreamItem:


### PR DESCRIPTION
## Motivation

The Qwen3-Omni code2wav scheduler previously used a single hard-coded chunk size (`stream_chunk_size=10`) for every decode window, including the first, and never exposed this parameter through config. This means Time-To-First-Audio (TTFA) is bounded below by "wait for a full steady chunk." The balance between steady chunk size, left context size, and first-chunk size governs the trade-off between TTFA vs. steady-state throughput (xRT) vs. audio quality — there is no single "correct" value that fits all deployments.

- `initial_codec_chunk_frames` controls TTFA: a smaller first chunk means earlier first audio, but too small degrades audio quality due to the vocoder's receptive field requirements.
- `stream_chunk_size` controls steady xRT: larger chunks amortize vocoder calls but lengthen the gap between streamed audio segments.
- `left_context_size` controls seam quality: larger overlap = cleaner splice but more compute per window.


This PR makes all three configurable at the config level and overridable per request, so deployments can tune optimal values via TTFA/xRT sweeps (at c1/c8) for their hardware and latency budget without code changes.

## Modifications

**`sglang_omni/models/qwen3_omni/config.py`**
- `_code2wav_stage`: Added `stream_chunk_size=25`, `left_context_size=25`, `initial_codec_chunk_frames=0` to `factory_args`. The default `0` preserves legacy behavior (every chunk uses steady size); flipping to e.g. `4` enables a smaller first chunk for all requests.

**`sglang_omni/models/qwen3_omni/components/code2wav_scheduler.py`**
- `Code2WavScheduler.__init__`: Added `initial_codec_chunk_frames` parameter and per-request `_req_initial_chunk_frames` dict.
- `on_streaming_new_request`: Calls new `_latch_initial_chunk_frames` to resolve the per-request first-chunk size from `payload.request.params`, routed through the shared `resolve_initial_codec_chunk_frames` helper (the same primitive higgs_tts and moss_tts_local use), so clamp/validation semantics stay identical.
- `on_stream_chunk` accumulate gate: First emit (`emitted == 0`) uses the initial chunk size as threshold; subsequent emits use steady size, counted from the initial offset. The existing cursor `emitted` already computes `ready = len(chunks) - emitted` from the right position, so no new offset logic is needed.
- `clear_stream_state`: Cleans up the new `_req_initial_chunk_frames` entry.
- Added `_latch_initial_chunk_frames` / `_initial_chunk_frames_for` helpers. An explicit `0` is an opt-out ("use steady for every chunk"), distinguished from "unset" via `is not None` so a request's intent is never silently overridden.
- `create_code2wav_scheduler` factory: Added `initial_codec_chunk_frames` pass-through.
- `_decode_incremental` unchanged: the existing `context = min(left_context_size, start)` already lets chunk 1 use the full initial chunk as left context, keeping the seam seamless across the size change via overlap-trim.


## Related Issues

https://github.com/sgl-project/sglang-omni/issues/1148


## Accuracy Test

full unit suites 0 failures.

## Benchmark & Profiling

Expected to impact performance. Plan: sweep `initial_codec_chunk_frames ∈ {0, 2, 4, 6}` × `stream_chunk_size ∈ {10, 25}`, recording TTFA + steady xRT at concurrency 1 and 8. Target: lower TTFA than steady-only config with acceptable steady xRT degradation (≥1.0 xRT) at c8. Results to be appended once GPU access is available.

## Checklist

- [x] Format your code according with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as co-author when merging the PR.