### PR TITLE
fix(qwen3-tts): expose finish_reason on /v1/audio/speech

### DIFF
--- a/sglang_omni/client/client.py
+++ b/sglang_omni/client/client.py
@@ -255,6 +255,7 @@ class Client:
             format=actual_format,
             sample_rate=sample_rate,
             usage=last_chunk.usage if last_chunk else None,
+            finish_reason=last_chunk.finish_reason if last_chunk else None,
         )
 
     # ------------------------------------------------------------------

--- a/sglang_omni/client/types.py
+++ b/sglang_omni/client/types.py
@@ -229,6 +229,7 @@ class SpeechResult:
     format: str
     sample_rate: int | None = None
     usage: UsageInfo | None = None
+    finish_reason: str | None = None
 
 
 class ClientError(Exception):

--- a/sglang_omni/models/qwen3_tts/payload_types.py
+++ b/sglang_omni/models/qwen3_tts/payload_types.py
@@ -32,3 +32,4 @@ class Qwen3TTSState(DeclarativeStateBase):
     audio_codes: Any | None = wire(None, codec="tensor_list")
     ref_code_len: int = wire(0, emit="truthy", codec="int")
     audio_samples: Any | None = wire(None, codec="tensor_list")
+    finish_reason: str | None = None

--- a/sglang_omni/models/qwen3_tts/request_builders.py
+++ b/sglang_omni/models/qwen3_tts/request_builders.py
@@ -1059,18 +1059,54 @@ def apply_sglang_qwen3_tts_result(
     else:
         codes = torch.empty((0, 0), dtype=torch.long)
 
+    finish_reason = _resolve_qwen3_tts_finish_reason(data)
+
+    result_data: dict[str, Any] = {
+        "audio_codes": codes,
+        "ref_code_len": data.ref_code_len,
+        "prompt_tokens": data.ref_code_len,
+        "completion_tokens": len(data.output_codes),
+        "engine_time_s": time.perf_counter() - data.engine_start_s,
+        "sample_rate": 24000,
+    }
+    if finish_reason is not None:
+        result_data["finish_reason"] = finish_reason
+
     return StagePayload(
         request_id=payload.request_id,
         request=payload.request,
-        data={
-            "audio_codes": codes,
-            "ref_code_len": data.ref_code_len,
-            "prompt_tokens": data.ref_code_len,
-            "completion_tokens": len(data.output_codes),
-            "engine_time_s": time.perf_counter() - data.engine_start_s,
-            "sample_rate": 24000,
-        },
+        data=result_data,
     )
+
+
+def _resolve_qwen3_tts_finish_reason(
+    data: Qwen3TTSSGLangRequestData,
+) -> str | None:
+    """Normalize the generation termination reason ("stop"/"length"/"abort")."""
+    raw = getattr(data, "finish_reason", None)
+    if raw is None and getattr(data, "req", None) is not None:
+        req_reason = getattr(data.req, "finished_reason", None)
+        if req_reason is not None and hasattr(req_reason, "to_json"):
+            raw = req_reason.to_json().get("type")
+        elif req_reason is not None:
+            raw = str(req_reason)
+
+    normalized = str(raw).lower() if raw is not None else None
+    if normalized is not None:
+        if "length" in normalized:
+            return "length"
+        if "abort" in normalized:
+            return "abort"
+        if "error" in normalized:
+            return "error"
+        if "stop" in normalized:
+            return "stop"
+        return str(raw)
+
+    max_new_tokens = getattr(data, "max_new_tokens", None)
+    if max_new_tokens is not None and len(data.output_codes) >= int(max_new_tokens):
+        return "length"
+    return "stop"
 
 
 def make_qwen3_tts_scheduler_adapters(*, model: Any, wrapper: Any):

--- a/sglang_omni/serve/openai_api.py
+++ b/sglang_omni/serve/openai_api.py
@@ -1248,6 +1248,8 @@ def _register_speech(app: FastAPI) -> None:
         headers = {
             "Content-Disposition": f'attachment; filename="speech.{result.format}"',
         }
+        if result.finish_reason is not None:
+            headers["X-Finish-Reason"] = str(result.finish_reason)
         if result.usage is not None:
             if result.usage.prompt_tokens is not None:
                 headers["X-Prompt-Tokens"] = str(result.usage.prompt_tokens)

--- a/tests/unit_test/qwen3_tts/test_pipeline.py
+++ b/tests/unit_test/qwen3_tts/test_pipeline.py
@@ -1020,6 +1020,90 @@ def test_qwen3_tts_result_adapter_keeps_code_handoff_tensor_native() -> None:
     assert result.data["completion_tokens"] == 2
 
 
+def test_qwen3_tts_result_adapter_propagates_scheduler_finish_reason() -> None:
+    """The scheduler stores a normalized reason on data.finish_reason before the
+    result adapter runs; it must reach the result so /v1/audio/speech can tell a
+    budget-truncated response from one that ended on codec EOS."""
+    payload = make_payload(inputs="target")
+    data = Qwen3TTSSGLangRequestData(
+        req=SimpleNamespace(output_ids=[]),
+        output_codes=[torch.tensor([1, 2])],
+        stage_payload=payload,
+        finish_reason="length",
+    )
+
+    result = apply_sglang_qwen3_tts_result(payload, data)
+
+    assert result.data["finish_reason"] == "length"
+
+
+def test_qwen3_tts_result_adapter_reports_stop_reason() -> None:
+    payload = make_payload(inputs="target")
+    data = Qwen3TTSSGLangRequestData(
+        req=SimpleNamespace(output_ids=[]),
+        output_codes=[torch.tensor([1, 2])],
+        stage_payload=payload,
+        finish_reason="stop",
+    )
+
+    result = apply_sglang_qwen3_tts_result(payload, data)
+
+    assert result.data["finish_reason"] == "stop"
+
+
+def test_qwen3_tts_result_adapter_reads_finish_reason_from_req() -> None:
+    """Falls back to the SGLang Req's finished_reason.to_json()['type'] when the
+    scheduler-normalized field is absent (mirrors Ming-TTS)."""
+
+    class _FinishLength:
+        def to_json(self):
+            return {"type": "length", "length": 2048}
+
+    payload = make_payload(inputs="target")
+    data = Qwen3TTSSGLangRequestData(
+        req=SimpleNamespace(output_ids=[], finished_reason=_FinishLength()),
+        output_codes=[torch.tensor([1, 2])],
+        stage_payload=payload,
+        finish_reason=None,
+    )
+
+    result = apply_sglang_qwen3_tts_result(payload, data)
+
+    assert result.data["finish_reason"] == "length"
+
+
+def test_qwen3_tts_result_adapter_infers_length_at_budget() -> None:
+    """When no reason is available at all but generation hit the token budget,
+    infer 'length' so a truncated response is never reported as a clean stop."""
+    payload = make_payload(inputs="target")
+    data = Qwen3TTSSGLangRequestData(
+        req=SimpleNamespace(output_ids=[]),
+        output_codes=[torch.tensor([1]), torch.tensor([2]), torch.tensor([3])],
+        stage_payload=payload,
+        finish_reason=None,
+        max_new_tokens=3,
+    )
+
+    result = apply_sglang_qwen3_tts_result(payload, data)
+
+    assert result.data["finish_reason"] == "length"
+
+
+def test_qwen3_tts_result_adapter_defaults_to_stop_below_budget() -> None:
+    payload = make_payload(inputs="target")
+    data = Qwen3TTSSGLangRequestData(
+        req=SimpleNamespace(output_ids=[]),
+        output_codes=[torch.tensor([1])],
+        stage_payload=payload,
+        finish_reason=None,
+        max_new_tokens=2048,
+    )
+
+    result = apply_sglang_qwen3_tts_result(payload, data)
+
+    assert result.data["finish_reason"] == "stop"
+
+
 def test_qwen3_tts_request_data_keeps_decode_tensors_on_prepared_device(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit_test/scheduling/test_pipeline_state.py
+++ b/tests/unit_test/scheduling/test_pipeline_state.py
@@ -344,6 +344,7 @@ def test_tts_pipeline_state_round_trips_preserve_payload_fields() -> None:
                 audio_codes=torch.tensor([[1, 2], [3, 4]]),
                 ref_code_len=1,
                 audio_samples=torch.tensor([0.5, 0.6]),
+                finish_reason="length",
                 prompt_tokens=9,
                 completion_tokens=11,
                 engine_time_s=0.625,


### PR DESCRIPTION
## Motivation

A Qwen3-TTS response from `/v1/audio/speech` never reports how generation
terminated. A response cut short at the generation budget looks exactly like
one that ended on codec EOS: HTTP 200 with decodable audio in both cases, and
no signal to tell them apart.

The scheduler already records it (`{"type":"length"}` vs `{"type":"stop"}`) and
`OmniScheduler` normalizes it onto `data.finish_reason` before the result
adapter runs, but `apply_sglang_qwen3_tts_result` rebuilds the `StagePayload`
without it, so the reason never reaches the vocoder result, `SpeechResult`, or
the HTTP response. The `/v1/audio/speech/stream` WebSocket path already exposes
a per-chunk finish reason; only the HTTP path loses it.

The practical cost: in one benchmark run, 174 of 55,944 requests stopped at
exactly `max_new_tokens` but were indistinguishable from clean completions, and
only surfaced downstream as an out-of-memory failure while scoring the
abnormally long audio.

## Modifications

- `qwen3_tts/request_builders.py`: `apply_sglang_qwen3_tts_result` now threads
  the finish reason through the result. It reads the scheduler-normalized
  `data.finish_reason`, falls back to the SGLang `Req.finished_reason`, and
  infers `length` when the reason is absent but generation hit the token budget
  (mirrors `ming_tts/engine_io.py`).
- `qwen3_tts/payload_types.py`: add `finish_reason` to `Qwen3TTSState` so it
  survives the vocoder stage's `load_state`/`store_state` round-trip (this is
  how `MingTTSState` and `S2ProState` already carry it).
- `client/types.py` + `client/client.py`: carry `finish_reason` on
  `SpeechResult` (`Client.generate` already reads it from the terminal payload).
- `serve/openai_api.py`: emit `X-Finish-Reason` from `/v1/audio/speech`,
  alongside the existing `X-Prompt-Tokens` / `X-Completion-Tokens` headers.

A successful budget-truncated request stays HTTP 200 and now also reports
`finish_reason=length`, matching the typed reasons elsewhere in the repo
(`/v1/rollout/generate`, chat completions).

## Related Issues

Closes #1178

## Accuracy Test

No model-side / numerical changes; this only propagates an existing
scheduler-computed field to the HTTP response.

## Benchmark & Profiling

No performance impact (metadata plumbing only).

Manual end-to-end verification on a single A100 with
`Qwen/Qwen3-TTS-12Hz-0.6B-Base` (voice-cloning Base path):

| Input | `max_new_tokens` | `X-Completion-Tokens` | `X-Finish-Reason` |
|---|---:|---:|---|
| long sentence | 8 | 8 | `length` |
| short input | 2048 | 11 | `stop` |
| same long sentence | 2048 | 49 | `stop` |

Same input with a tiny budget reports `length` and with an ample budget stops
naturally at `stop`, so truncation is now distinguishable from completion.

## Checklist

- [x] Format your code according with pre-commit (ruff / black / isort clean).
- [x] Add unit tests (result-adapter reason resolution + state round-trip).
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
